### PR TITLE
feat(healthz): adapter readiness-probe 名 typed funnel (Soft→Hard, close #805)

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -88,7 +88,8 @@ ref: `pkg/redaction/redaction.go`；archtest `SPAN-RECORD-ERROR-REDACT-01`（sib
 
 - Adapter readiness probe 使用 stable snake_case，并以后缀 `_ready` 表示依赖可用性，例如 `rabbitmq_ready`、`vault_transit_ready`。
 - 一个 adapter 只有单一外部依赖时，禁止同时暴露多个同义 ready probe；多角色 worker 可用 `component-role` 拆分不同失败域。
-- probe 名是运维契约；改名必须同步 dashboard / alert / 文档，并用 archtest 或单测锁定。
+- probe 名是运维契约；改名必须同步 dashboard / alert / 文档。
+- Adapter probe 名是 `kernel/healthz.ReadyProbeName` typed-string funnel：各 adapter 声明 typed const（如 `postgres.ProbeReady`），构造点（Checkers map key 走 `string(<const>)`、`adapterutil.HealthToCheckers` 首参收 typed）只能引用声明的 const，裸字面量在静态分析层不可表达。archtest `OPS-CONTRACT-STRING-FUNNEL-01` 双向锁（下游构造解析 + 上游声明站点锁）+ golden inventory；符号清单活在该 archtest 的 package godoc。框架 probe（`config_watcher` / `outbox_failopen_rate_<cell>`）走 `NewProbe` / `WithHealthChecker` 的裸 `string`，由 `READYZ-PROBE-NAMING-01` 守 hyphen；cell repo probe 由 cellgen `RegisterRepoReady` funnel。
 
 ### Cell 级别 Repo Readiness Probe
 

--- a/adapters/adapterutil/health.go
+++ b/adapters/adapterutil/health.go
@@ -3,6 +3,8 @@ package adapterutil
 import (
 	"context"
 	"time"
+
+	"github.com/ghbvf/gocell/kernel/healthz"
 )
 
 // DefaultProbeTimeout bounds a /readyz probe so a slow dependency does not
@@ -26,15 +28,24 @@ const DefaultProbeTimeout = 5 * time.Second
 // single-probe case. A multi-entry variant was considered but deferred
 // until a third multi-probe caller emerges (YAGNI).
 //
+// The name argument is a healthz.ReadyProbeName-typed const declared at the
+// caller's adapter (e.g. redis.ProbeReady); a bare string literal here fails
+// archtest OPS-CONTRACT-STRING-FUNNEL-01. The conversion to the bare-string
+// Checkers() map key happens here once, at the funnel boundary.
+//
 // ref: kubernetes/kubernetes pkg/util/healthz — named health checkers with
 // per-probe deadlines.
 // ref: uber-go/fx app.go StopTimeout — same shared-deadline pattern, dual side.
-func HealthToCheckers(name string, healthFn func(context.Context) error, timeout time.Duration) map[string]func(context.Context) error {
+func HealthToCheckers(
+	name healthz.ReadyProbeName,
+	healthFn func(context.Context) error,
+	timeout time.Duration,
+) map[string]func(context.Context) error {
 	if timeout <= 0 {
 		timeout = DefaultProbeTimeout
 	}
 	return map[string]func(context.Context) error{
-		name: func(ctx context.Context) error {
+		string(name): func(ctx context.Context) error {
 			probeCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 			return healthFn(probeCtx)

--- a/adapters/adapterutil/health_test.go
+++ b/adapters/adapterutil/health_test.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/adapters/adapterutil"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 func TestHealthToCheckers_ReturnsSingleNamedProbe(t *testing.T) {
 	t.Parallel()
 
-	probes := adapterutil.HealthToCheckers("foo_ready", func(context.Context) error {
+	probes := adapterutil.HealthToCheckers(healthz.ReadyProbeName("foo_ready"), func(context.Context) error {
 		return nil
 	}, testtime.D1s)
 	if len(probes) != 1 {
@@ -27,7 +28,7 @@ func TestHealthToCheckers_ReturnsSingleNamedProbe(t *testing.T) {
 func TestHealthToCheckers_HealthyDelegatesNil(t *testing.T) {
 	t.Parallel()
 
-	probes := adapterutil.HealthToCheckers("foo_ready", func(context.Context) error {
+	probes := adapterutil.HealthToCheckers(healthz.ReadyProbeName("foo_ready"), func(context.Context) error {
 		return nil
 	}, testtime.D1s)
 	if err := probes["foo_ready"](context.Background()); err != nil {
@@ -39,7 +40,7 @@ func TestHealthToCheckers_ErrorPropagated(t *testing.T) {
 	t.Parallel()
 
 	sentinel := errors.New("boom")
-	probes := adapterutil.HealthToCheckers("foo_ready", func(context.Context) error {
+	probes := adapterutil.HealthToCheckers(healthz.ReadyProbeName("foo_ready"), func(context.Context) error {
 		return sentinel
 	}, testtime.D1s)
 	if err := probes["foo_ready"](context.Background()); !errors.Is(err, sentinel) {
@@ -50,7 +51,7 @@ func TestHealthToCheckers_ErrorPropagated(t *testing.T) {
 func TestHealthToCheckers_InnerTimeoutBoundsProbe(t *testing.T) {
 	t.Parallel()
 
-	probes := adapterutil.HealthToCheckers("foo_ready", func(ctx context.Context) error {
+	probes := adapterutil.HealthToCheckers(healthz.ReadyProbeName("foo_ready"), func(ctx context.Context) error {
 		<-ctx.Done()
 		return ctx.Err()
 	}, testtime.D50ms)
@@ -74,7 +75,7 @@ func TestHealthToCheckers_DefaultTimeoutWhenZero(t *testing.T) {
 	if adapterutil.DefaultProbeTimeout != testtime.D5s {
 		t.Fatalf("DefaultProbeTimeout = %v, want %v", adapterutil.DefaultProbeTimeout, testtime.D5s)
 	}
-	probes := adapterutil.HealthToCheckers("foo_ready", func(context.Context) error {
+	probes := adapterutil.HealthToCheckers(healthz.ReadyProbeName("foo_ready"), func(context.Context) error {
 		return nil
 	}, 0)
 	if err := probes["foo_ready"](context.Background()); err != nil {
@@ -89,7 +90,7 @@ func TestHealthToCheckers_InheritsCallerDeadline(t *testing.T) {
 	// extend it — the probe still respects ctx cancellation.
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.D20ms)
 	defer cancel()
-	probes := adapterutil.HealthToCheckers("foo_ready", func(ctx context.Context) error {
+	probes := adapterutil.HealthToCheckers(healthz.ReadyProbeName("foo_ready"), func(ctx context.Context) error {
 		<-ctx.Done()
 		return ctx.Err()
 	}, testtime.D5s)

--- a/adapters/oidc/oidc.go
+++ b/adapters/oidc/oidc.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ghbvf/gocell/adapters/adapterutil"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -207,12 +208,16 @@ func (a *Adapter) Verifier(ctx context.Context) (*gooidc.IDTokenVerifier, error)
 	return p.Verifier(&gooidc.Config{ClientID: a.config.ClientID}), nil
 }
 
+// ProbeReady is the ops-contract name for the OIDC readiness probe.
+// healthz.ReadyProbeName-typed, funneled by OPS-CONTRACT-STRING-FUNNEL-01.
+const ProbeReady healthz.ReadyProbeName = "oidc_ready"
+
 // Checkers returns a readyz probe for the OIDC provider. The probe verifies
 // that the cached provider is populated without re-discovering.
 //
 // ref: kubernetes/kubernetes pkg/util/healthz — named health checkers.
 func (a *Adapter) Checkers() map[string]func(context.Context) error {
-	return adapterutil.HealthToCheckers("oidc_ready", a.healthProbe, adapterutil.DefaultProbeTimeout)
+	return adapterutil.HealthToCheckers(ProbeReady, a.healthProbe, adapterutil.DefaultProbeTimeout)
 }
 
 // Worker returns a worker.Worker that drives the periodic OIDC re-discovery

--- a/adapters/postgres/pool.go
+++ b/adapters/postgres/pool.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/ghbvf/gocell/adapters/adapterutil"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	kworker "github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -18,6 +19,15 @@ import (
 var (
 	_ lifecycle.ContextCloser   = (*Pool)(nil)
 	_ lifecycle.ManagedResource = (*Pool)(nil)
+)
+
+// Pool readiness-probe names. healthz.ReadyProbeName-typed consts funneled by
+// archtest OPS-CONTRACT-STRING-FUNNEL-01 (snake_case + _ready).
+const (
+	// ProbeReady probes basic pool liveness (Ping).
+	ProbeReady healthz.ReadyProbeName = "postgres_ready"
+	// ProbeIndexesValidReady probes that all expected indexes are valid.
+	ProbeIndexesValidReady healthz.ReadyProbeName = "postgres_indexes_valid_ready"
 )
 
 // Default pool configuration values.
@@ -188,12 +198,12 @@ func (p *Pool) Checkers() map[string]func(context.Context) error {
 		healthFn = p.Health
 	}
 	return map[string]func(context.Context) error{
-		"postgres_ready": func(ctx context.Context) error {
+		string(ProbeReady): func(ctx context.Context) error {
 			probeCtx, cancel := context.WithTimeout(ctx, adapterutil.DefaultProbeTimeout)
 			defer cancel()
 			return healthFn(probeCtx)
 		},
-		"postgres_indexes_valid_ready": func(ctx context.Context) error {
+		string(ProbeIndexesValidReady): func(ctx context.Context) error {
 			probeCtx, cancel := context.WithTimeout(ctx, adapterutil.DefaultProbeTimeout)
 			defer cancel()
 			return InvalidIndexCheck(probeCtx, p)

--- a/adapters/postgres/pool_test.go
+++ b/adapters/postgres/pool_test.go
@@ -310,7 +310,7 @@ func TestPool_CheckersReturnsBothProbes(t *testing.T) {
 	p := &Pool{} // stub: inner=nil; Checkers() must not dereference inner
 	checkers := p.Checkers()
 	require.Len(t, checkers, 2, "expected 2 checkers (postgres_ready + postgres_indexes_valid_ready)")
-	for _, name := range []string{"postgres_ready", "postgres_indexes_valid_ready"} {
+	for _, name := range []string{string(ProbeReady), string(ProbeIndexesValidReady)} {
 		fn, ok := checkers[name]
 		if !ok {
 			t.Errorf("expected checker named %q", name)
@@ -359,7 +359,7 @@ func TestPool_CheckerTimeout(t *testing.T) {
 	}
 
 	checkers := p.Checkers()
-	fn := checkers["postgres_ready"]
+	fn := checkers[string(ProbeReady)]
 	require.NotNil(t, fn, "postgres_ready checker must not be nil")
 
 	require.NoError(t, fn(context.Background()))

--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ghbvf/gocell/adapters/adapterutil"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/worker"
@@ -1195,6 +1196,10 @@ func connectionStateMessage(state ConnectionPhase) string {
 // — the "rabbitmq_ready" probe is exposed automatically.
 var _ lifecycle.ManagedResource = (*Connection)(nil)
 
+// ProbeReady is the ops-contract name for the RabbitMQ readiness probe.
+// healthz.ReadyProbeName-typed, funneled by OPS-CONTRACT-STRING-FUNNEL-01.
+const ProbeReady healthz.ReadyProbeName = "rabbitmq_ready"
+
 // Checkers returns the rabbitmq_ready probe for /readyz integration.
 //
 // The probe wraps Health(ctx) which honors ctx (early cancel) and reads the
@@ -1210,7 +1215,7 @@ var _ lifecycle.ManagedResource = (*Connection)(nil)
 // ref: adapters/vault/transit_provider.go::Checkers — sibling adapter pattern.
 func (c *Connection) Checkers() map[string]func(context.Context) error {
 	return map[string]func(context.Context) error{
-		"rabbitmq_ready": c.Health,
+		string(ProbeReady): c.Health,
 	}
 }
 

--- a/adapters/rabbitmq/connection_managed_resource_test.go
+++ b/adapters/rabbitmq/connection_managed_resource_test.go
@@ -23,7 +23,7 @@ func TestConnection_Checkers_HealthyConnected(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close(context.Background()) })
 
 	checkers := conn.Checkers()
-	probe, ok := checkers["rabbitmq_ready"]
+	probe, ok := checkers[string(ProbeReady)]
 	if !ok {
 		t.Fatalf("Checkers() missing 'rabbitmq_ready'; got keys: %v", keysOf(checkers))
 	}
@@ -39,7 +39,7 @@ func TestConnection_Checkers_HonorsCtxDeadline(t *testing.T) {
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	probe := conn.Checkers()["rabbitmq_ready"]
+	probe := conn.Checkers()[string(ProbeReady)]
 	start := time.Now()
 	err := probe(canceled)
 	elapsed := time.Since(start)
@@ -64,7 +64,7 @@ func TestConnection_Checkers_UnhealthyDisconnected(t *testing.T) {
 	conn.state = StateDisconnected
 	conn.mu.Unlock()
 
-	err := conn.Checkers()["rabbitmq_ready"](context.Background())
+	err := conn.Checkers()[string(ProbeReady)](context.Background())
 	if err == nil {
 		t.Fatal("rabbitmq_ready in StateDisconnected must return an error, got nil")
 	}
@@ -85,7 +85,7 @@ func TestConnection_Checkers_UnhealthyWhenPermanentRecorded(t *testing.T) {
 	conn.permanentErr = permanentErr
 	conn.mu.Unlock()
 
-	err := conn.Checkers()["rabbitmq_ready"](context.Background())
+	err := conn.Checkers()[string(ProbeReady)](context.Background())
 	if err == nil {
 		t.Fatal("rabbitmq_ready with permanentErr set must return that error, got nil")
 	}

--- a/adapters/redis/client.go
+++ b/adapters/redis/client.go
@@ -12,6 +12,7 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/ghbvf/gocell/adapters/adapterutil"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -673,13 +674,17 @@ func (c *Client) Health(ctx context.Context) error {
 	return nil
 }
 
+// ProbeReady is the ops-contract name for the Redis readiness probe.
+// healthz.ReadyProbeName-typed, funneled by OPS-CONTRACT-STRING-FUNNEL-01.
+const ProbeReady healthz.ReadyProbeName = "redis_ready"
+
 // Checkers returns the named health probe for /readyz. The single entry
-// "redis_ready" wraps Health with adapterutil.DefaultProbeTimeout so a slow
+// redis_ready wraps Health with adapterutil.DefaultProbeTimeout so a slow
 // ping does not hold the readyz response indefinitely.
 //
 // ref: kubernetes/kubernetes pkg/util/healthz — named health checkers.
 func (c *Client) Checkers() map[string]func(context.Context) error {
-	return adapterutil.HealthToCheckers("redis_ready", c.Health, adapterutil.DefaultProbeTimeout)
+	return adapterutil.HealthToCheckers(ProbeReady, c.Health, adapterutil.DefaultProbeTimeout)
 }
 
 // Worker returns nil — the Redis client has no background goroutine.

--- a/adapters/s3/s3.go
+++ b/adapters/s3/s3.go
@@ -16,6 +16,7 @@ import (
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -30,11 +31,11 @@ const (
 	// NO magic literal: this const is the single source of truth for the 30s default.
 	defaultS3HealthInterval = 30 * time.Second
 
-	// ReadyProbeName is the ops-contract name for the S3 readiness probe registered
-	// by Checkers(). Probe name follows the observability rule: snake_case + "_ready"
-	// suffix. Single-sourced here so production code and tests reference the same
-	// identifier without drift.
-	ReadyProbeName = "s3_ready"
+	// ProbeReady is the ops-contract name for the S3 readiness probe registered
+	// by Checkers(). It is a healthz.ReadyProbeName-typed const (snake_case +
+	// "_ready" suffix), funneled by archtest OPS-CONTRACT-STRING-FUNNEL-01 so
+	// production code and tests reference the same identifier without drift.
+	ProbeReady healthz.ReadyProbeName = "s3_ready"
 )
 
 // bucketHeader is the narrow interface used by the health state machine.
@@ -286,17 +287,17 @@ func (c *Client) Health(ctx context.Context) error {
 // ---------------------------------------------------------------------------
 
 // Checkers implements lifecycle.ManagedResource. It returns a single probe
-// keyed by ReadyProbeName ("s3_ready") that reads the latest health state
+// keyed by ProbeReady ("s3_ready") that reads the latest health state
 // without any network call.
 //
 // probe name follows the observability rule: snake_case + "_ready" suffix.
-// ReadyProbeName is the single source of truth; both this method and tests
+// ProbeReady is the single source of truth; both this method and tests
 // reference it so the name cannot drift.
 //
 // ref: runtime/websocket/hub.go Checkers — state-read probe pattern.
 func (c *Client) Checkers() map[string]func(context.Context) error {
 	return map[string]func(context.Context) error{
-		ReadyProbeName: func(_ context.Context) error {
+		string(ProbeReady): func(_ context.Context) error {
 			if errPtr := c.state.Load(); errPtr != nil {
 				return *errPtr
 			}

--- a/adapters/s3/s3_integration_test.go
+++ b/adapters/s3/s3_integration_test.go
@@ -102,9 +102,9 @@ func startWorkerWithTickProof(t *testing.T, ctx context.Context, client *Client,
 	client.state.Store(&sentinel)
 
 	checkers := client.Checkers()
-	require.Contains(t, checkers, ReadyProbeName)
+	require.Contains(t, checkers, string(ProbeReady))
 	testwait.External(t, "s3-worker-tick-executed", func() bool {
-		return checkers[ReadyProbeName](ctx) == nil
+		return checkers[string(ProbeReady)](ctx) == nil
 	}, timeout, testtime.SlowPoll,
 		"s3_ready should clear worker-tick-proof sentinel once worker probes healthy MinIO")
 }
@@ -151,8 +151,8 @@ func TestIntegration_S3_UploadHealthHappy(t *testing.T) {
 
 	// State-machine probe: reads atomic state, no network I/O.
 	checkers := client.Checkers()
-	require.Contains(t, checkers, ReadyProbeName)
-	assert.NoError(t, checkers[ReadyProbeName](ctx), "s3_ready checker should be nil")
+	require.Contains(t, checkers, string(ProbeReady))
+	assert.NoError(t, checkers[string(ProbeReady)](ctx), "s3_ready checker should be nil")
 }
 
 // TestIntegration_S3_RecoveryAfterContainerRestart verifies the stop/start
@@ -270,7 +270,7 @@ func TestIntegration_S3_WorkerTickStateTracksContainer(t *testing.T) {
 	require.NoError(t, ctr.Stop(ctx, &stopTimeout), "stop container for worker test")
 
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		return checkers[ReadyProbeName](ctx) != nil
+		return checkers[string(ProbeReady)](ctx) != nil
 	}, testtime.EventuallyExtraLong, testtime.SlowPoll,
 		"s3_ready should flip to non-nil error while container is stopped")
 

--- a/adapters/s3/s3_test.go
+++ b/adapters/s3/s3_test.go
@@ -373,8 +373,8 @@ func TestCheckers_ReadyWhenStateHealthy(t *testing.T) {
 	c := newTestClient(validConfig(), mock)
 	// state is nil (healthy by default after zero-value)
 	checkers := c.Checkers()
-	require.Contains(t, checkers, ReadyProbeName)
-	require.NoError(t, checkers[ReadyProbeName](context.Background()))
+	require.Contains(t, checkers, string(ProbeReady))
+	require.NoError(t, checkers[string(ProbeReady)](context.Background()))
 }
 
 func TestCheckers_UnhealthyWhenStateError(t *testing.T) {
@@ -386,8 +386,8 @@ func TestCheckers_UnhealthyWhenStateError(t *testing.T) {
 	c.state.Store(&sentinel)
 
 	checkers := c.Checkers()
-	require.Contains(t, checkers, ReadyProbeName)
-	err := checkers[ReadyProbeName](context.Background())
+	require.Contains(t, checkers, string(ProbeReady))
+	err := checkers[string(ProbeReady)](context.Background())
 	require.Error(t, err)
 	assert.Equal(t, sentinel, err)
 }
@@ -399,7 +399,7 @@ func TestCheckers_NoNetworkCall(t *testing.T) {
 	c := newTestClient(validConfig(), mock)
 	checkers := c.Checkers()
 
-	_ = checkers[ReadyProbeName](context.Background())
+	_ = checkers[string(ProbeReady)](context.Background())
 	assert.EqualValues(t, 0, mock.callCount.Load(), "Checkers probe must not call HeadBucket")
 }
 
@@ -461,7 +461,7 @@ func TestWorker_UpdatesStateOnError(t *testing.T) {
 	checkers := c.Checkers()
 	var lastErr error
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		lastErr = checkers[ReadyProbeName](context.Background())
+		lastErr = checkers[string(ProbeReady)](context.Background())
 		return lastErr != nil
 	}, testtime.D250ms, testtime.FastPoll)
 
@@ -502,7 +502,7 @@ func TestWorker_StateBecomesHealthyAfterRecovery(t *testing.T) {
 	checkers := c.Checkers()
 	var lastErr error
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		lastErr = checkers[ReadyProbeName](context.Background())
+		lastErr = checkers[string(ProbeReady)](context.Background())
 		return callN.Load() >= 2 && lastErr == nil
 	}, testtime.D300ms, testtime.FastPoll)
 
@@ -846,7 +846,7 @@ func TestWorker_Tick403_StateUnhealthyPermanent(t *testing.T) {
 	checkers := c.Checkers()
 	var stateErr error
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		stateErr = checkers[ReadyProbeName](context.Background())
+		stateErr = checkers[string(ProbeReady)](context.Background())
 		return stateErr != nil
 	}, testtime.D250ms, testtime.FastPoll, "state must become unhealthy after 403 tick")
 
@@ -883,7 +883,7 @@ func TestWorker_Tick5xx_StateUnhealthyTransient(t *testing.T) {
 	checkers := c.Checkers()
 	var stateErr error
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		stateErr = checkers[ReadyProbeName](context.Background())
+		stateErr = checkers[string(ProbeReady)](context.Background())
 		return stateErr != nil
 	}, testtime.D250ms, testtime.FastPoll, "state must become unhealthy after 503 tick")
 
@@ -927,7 +927,7 @@ func TestWorker_TickTimeoutThenRecovery(t *testing.T) {
 	// Phase 1: wait for state to become unhealthy with a transient error.
 	var stateErr error
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		stateErr = checkers[ReadyProbeName](context.Background())
+		stateErr = checkers[string(ProbeReady)](context.Background())
 		return stateErr != nil
 	}, testtime.D250ms, testtime.FastPoll, "state must become unhealthy after timeout ticks")
 	assert.True(t, errcode.IsTransient(stateErr), "timeout tick error must be transient")
@@ -935,7 +935,7 @@ func TestWorker_TickTimeoutThenRecovery(t *testing.T) {
 	// Phase 2: wait for state to recover to healthy (nil).
 	// Budget widened to D500ms to absorb CI scheduler jitter between ticks 2 and 3.
 	testwait.External(t, "s3-health-probe-ok", func() bool {
-		return checkers[ReadyProbeName](context.Background()) == nil
+		return checkers[string(ProbeReady)](context.Background()) == nil
 	}, testtime.D500ms, testtime.FastPoll, "state must recover to healthy after success ticks")
 
 	cancel()
@@ -979,18 +979,6 @@ func assertHealthRequestShape(t *testing.T, tr *recordingTransport) {
 		"HeadBucket path: /{bucket}")
 }
 
-// ---------------------------------------------------------------------------
-// F3 — Ops contract literal anchor
-// ---------------------------------------------------------------------------
-
-// TestReadyProbeName_LiteralAnchor locks the "s3_ready" string contract.
-// production Checkers + all tests reference ReadyProbeName; without this
-// anchor a const-value rename drifts silently.
-//
-// AI-robust rating: Soft (string convention).
-//
-// ref: .claude/rules/gocell/observability.md「Readyz Probe 命名」
-func TestReadyProbeName_LiteralAnchor(t *testing.T) {
-	assert.Equal(t, "s3_ready", ReadyProbeName,
-		"ReadyProbeName is an ops contract — dashboards/alerts depend on this literal")
-}
+// The "s3_ready" ops-contract literal is now funneled + frozen by archtest
+// OPS-CONTRACT-STRING-FUNNEL-01 (golden inventory adapters/s3.ProbeReady=s3_ready);
+// the prior Soft string-anchor unit test was removed (no parallel Soft+Hard).

--- a/adapters/vault/readiness_test.go
+++ b/adapters/vault/readiness_test.go
@@ -50,7 +50,7 @@ func TestTransitReadiness_Healthy(t *testing.T) {
 	checkers := p.Checkers()
 	require.NotNil(t, checkers, "Checkers must not return nil")
 
-	probe, ok := checkers["vault_transit_ready"]
+	probe, ok := checkers[string(vaultadapter.ProbeReady)]
 	require.True(t, ok, "Checkers must contain 'vault_transit_ready' key")
 	require.NotNil(t, probe, "vault_transit_ready probe must not be nil")
 
@@ -89,7 +89,7 @@ func TestTransitReadiness_MountDeleted(t *testing.T) {
 	require.NoError(t, err, "Unmount transit must succeed (dev root token has sys capability)")
 
 	checkers := p.Checkers()
-	probe := checkers["vault_transit_ready"]
+	probe := checkers[string(vaultadapter.ProbeReady)]
 	require.NotNil(t, probe)
 
 	probeErr := probe(context.Background())
@@ -161,7 +161,7 @@ func TestTransitReadiness_ContextTimeout(t *testing.T) {
 		err = rootClient.Sys().UnmountWithContext(context.Background(), "transit")
 		require.NoError(t, err, "Unmount transit must succeed")
 		checkers := p.Checkers()
-		probe := checkers["vault_transit_ready"]
+		probe := checkers[string(vaultadapter.ProbeReady)]
 		require.NotNil(t, probe)
 		probeErr := probe(context.Background())
 		require.Error(t, probeErr, "probe must return error after transit unmount")
@@ -173,7 +173,7 @@ func TestTransitReadiness_ContextTimeout(t *testing.T) {
 	}
 
 	checkers := pUnreachable.Checkers()
-	probe := checkers["vault_transit_ready"]
+	probe := checkers[string(vaultadapter.ProbeReady)]
 	require.NotNil(t, probe)
 
 	// The probe internally uses context.WithTimeout(3s), but since we also set
@@ -263,7 +263,7 @@ func TestTransitReadiness_RevokedToken(t *testing.T) {
 
 	// Verify the probe works before revocation (confirms the policy grants access).
 	checkers := p.Checkers()
-	probe := checkers["vault_transit_ready"]
+	probe := checkers[string(vaultadapter.ProbeReady)]
 	require.NotNil(t, probe)
 	require.NoError(t, probe(context.Background()), "probe must succeed with valid child token (policy grants transit read)")
 

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -1156,7 +1156,12 @@ func validVaultKeyVersion(version string) bool {
 var _ lifecycle.ManagedResource = (*TransitKeyProvider)(nil)
 
 // transitReadinessTimeout is the per-probe context deadline for vault_transit_ready.
-// 3 seconds is sufficient for LAN Vault deployments.
+// 3 seconds is sufficient for LAN Vault deployments. Intentionally tighter than
+// adapterutil.DefaultProbeTimeout (5s): a transit/keys/{name} metadata read is a
+// single fast round-trip, so a slow Vault should mark the probe down quickly
+// rather than hold /readyz near the aggregator deadline. This is why the Checkers
+// map is built directly here instead of via adapterutil.HealthToCheckers (which
+// would apply the 5s default).
 const transitReadinessTimeout = 3 * time.Second
 
 // ProbeReady is the ops-contract name for the Vault transit readiness probe.

--- a/adapters/vault/transit_provider.go
+++ b/adapters/vault/transit_provider.go
@@ -20,6 +20,7 @@ import (
 	promadapter "github.com/ghbvf/gocell/adapters/prometheus"
 	"github.com/ghbvf/gocell/kernel/clock"
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/aeadutil"
@@ -1158,6 +1159,10 @@ var _ lifecycle.ManagedResource = (*TransitKeyProvider)(nil)
 // 3 seconds is sufficient for LAN Vault deployments.
 const transitReadinessTimeout = 3 * time.Second
 
+// ProbeReady is the ops-contract name for the Vault transit readiness probe.
+// healthz.ReadyProbeName-typed, funneled by OPS-CONTRACT-STRING-FUNNEL-01.
+const ProbeReady healthz.ReadyProbeName = "vault_transit_ready"
+
 // Checkers returns a map of readiness probe functions for TransitKeyProvider.
 // The single probe "vault_transit_ready" reads transit/keys/{keyName} metadata
 // (the same path used by readLatestVersion) to verify that:
@@ -1178,7 +1183,7 @@ const transitReadinessTimeout = 3 * time.Second
 //	uses auth/token/lookup-self + business-path probe, not sys/health
 func (p *TransitKeyProvider) Checkers() map[string]func(context.Context) error {
 	return map[string]func(context.Context) error{
-		"vault_transit_ready": func(ctx context.Context) error {
+		string(ProbeReady): func(ctx context.Context) error {
 			probeCtx, cancel := context.WithTimeout(ctx, transitReadinessTimeout)
 			defer cancel()
 			_, err := p.readLatestVersion(probeCtx)

--- a/docs/architecture/202605241600-adr-ready-probe-name-typed-funnel.md
+++ b/docs/architecture/202605241600-adr-ready-probe-name-typed-funnel.md
@@ -1,0 +1,132 @@
+# ADR: Adapter readiness-probe 名 typed-string concept funnel（Soft → Hard）
+
+- Status: Accepted
+- Date: 2026-05-24
+- Tracks: gh issue #805 `OPS-CONTRACT-STRING-FUNNEL-01`
+- Builds on: ai-robust.md §"Hard 范本目录" string-typed concept funnel；`kernel/governance.RuleCode` + archtest `GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01`（精确镜像对象）
+- Implemented by: PR (worktree 500-ready-probe-name-funnel)
+
+## §1 背景
+
+Adapter dependency-availability readiness-probe 名（`postgres_ready` /
+`redis_ready` / `s3_ready` / `rabbitmq_ready` / `vault_transit_ready` /
+`oidc_ready` / `websocket_hub_ready` / `postgres_indexes_valid_ready`）此前以
+散落的 untyped string 形态存在三种构造面：
+
+1. `lifecycle.ManagedResource.Checkers() map[string]func(...)` 的 map 字面量 key
+   （postgres ×2 / rabbitmq / vault / websocket）；
+2. `adapterutil.HealthToCheckers(name string, …)` 首参（redis / oidc）；
+3. s3 的一个 untyped `const ReadyProbeName = "s3_ready"`。
+
+PR #538 为此引入的 enforcement 只到 **Soft**：
+
+- `adapters/s3/s3_test.go::TestReadyProbeName_LiteralAnchor`（自评 "AI-robust
+  rating: Soft (string convention)"）锁 `"s3_ready"` 字面量；
+- archtest `health_aggregation_test.go` 的 regex 扫描器
+  （`adapterCheckerNameViolationsFromPass` / `healthCheckerCallNameViolationsFromPass`）
+  + `managed_resource_contract_test.go` 的两个 `…UseReadySuffix` 测试，只校验
+  **值形状**（snake_case + `_ready`），不把值收口到单一声明集；
+- `READYZ-PROBE-NAMING-01` 自身在 godoc 里声明 "Blind spot #2"：adapter
+  Checkers / HealthToCheckers 面不被 `NewProbe` hyphen-check 覆盖。
+
+Soft 的后果：AI co-author 可随手写一个新的裸字面量 probe 名（typo / 漂移 /
+dashboard 全量重命名），regex 仍然 pass，drift 在最深处（运维 dashboard /
+alert 断链）才暴露。issue #805 的 trigger 正是"第 3 个 adapter readiness const
+漂移事故 / observability dashboard 全量重命名"。
+
+## §2 决策
+
+把 adapter probe 名升级为 **Hard 的 string-typed concept funnel**，机制与
+`kernel/governance.RuleCode` 同形：
+
+1. **类型**：`kernel/healthz.ReadyProbeName`（`type ReadyProbeName string`）。
+   仅覆盖 adapter dependency-availability `_ready` probe。
+2. **声明集**：各 adapter 在自己 package 声明 typed const（统一命名
+   `ProbeReady`，postgres 另有 `ProbeIndexesValidReady`）。
+3. **构造点收口**：
+   - `adapterutil.HealthToCheckers(name healthz.ReadyProbeName, …)` 首参收 typed，
+     内部一次 `string(name)` 转回 bare-string map key（funnel 边界）；
+   - 直接 map 字面量 adapter 用 `string(ProbeReady)` 作 key（`map[string]` 契约不变）。
+4. **archtest `OPS-CONTRACT-STRING-FUNNEL-01`**（`ops_contract_string_funnel_test.go`）：
+   - `construction_funnel`（下游）：每个 sanctioned package 的 Checkers map key
+     + HealthToCheckers 首参必须经 `info.Uses` 解析到声明的 `*types.Const`，
+     拒 `BasicLit` / `BinaryExpr` / `string(localVar)`；
+   - `declaration_site_lock`（上游）：`ReadyProbeName` typed const 只能声明在
+     sanctioned package 集（6 adapter + runtime/websocket）；
+   - `value_shape`：每个声明 const 值过 snake_case + `_ready` regex（每 const 一次）；
+   - `golden_inventory`：冻结全量 `(pkg.const → value)`，增删改名 = 显式 golden diff；
+   - 盲区自检 fixtures（bare literal / local var / decl bypass）+
+     `sanctioned_set_covers_all_checkers` meta-check。
+
+`ManagedResource.Checkers()` 接口签名 **不变**（保持 `map[string]func`）。
+
+### §2.1 AI-robust 双向锁评级（ai-robust.md §"Funnel 双向锁评级"）
+
+- **下游 Hard**：construction_funnel 用类型信息把构造实参解析到声明集，裸字面量
+  不可表达——与 `ruleCodeArgResolvesToConst` 同机制。
+- **上游 Hard**：declaration_site_lock + named type（裸 string 不能不经转换赋给
+  `ReadyProbeName` const）使唯一授权路径 = "在 sanctioned package 声明 typed const"。
+
+这是 archtest-bound Hard（非编译期 seal），与 RuleCode 同档——是 string-typed
+concept funnel 形状可达的最高档。
+
+## §3 被拒绝方案：把 `Checkers()` map key 改成 typed（Option A）
+
+考虑过把接口改成 `Checkers() map[healthz.ReadyProbeName]func(...)`，让构造点
+`{ProbeReady: fn}` 免去 `string(...)`。**拒绝**，理由：
+
+1. **优雅简洁反噬**：`ManagedResource` 有约 25 个实现，其中约 18 个返回 nil/空 map
+   或非 readiness 键（test fakes、`otel.poolMetricsResource`、
+   `postgres.PGSessionStore`、`corebundle.bootstrapLimiterResource`），它们与
+   ready-probe 无关，却被迫 import healthz + 改签名——ceremony 扇出到整个生态。
+2. **类型说谎反例**：`runtime/outbox.Relay.Checkers()` 的 key 是
+   `outbox-relay-poll` / `-reclaim` / `-cleanup`（连字符 budget checker，**非**
+   `_ready` readiness probe）。typed map 会逼它写
+   `healthz.ReadyProbeName("outbox-relay-poll")`——把一个非 readiness 概念强行
+   套上 readiness 类型，语义错误。
+3. **funnel 不依赖 map key 类型**：Hard 来自 archtest 把构造实参解析到声明集
+   （RuleCode 的 `Code` 字段是 typed，但拦截力来自 archtest，不是字段类型）。
+   typed map key 只改 call-site 工效，不增 Hard 强度。
+
+代价（5 处 `string(ProbeReady)` 直接 map key）是从 typed 域穿到共享 `map[string]`
+契约边界的诚实标记，可接受。该接口签名不变也意味着本变更**不触发 contract-fanout
+interface 规则**；唯一签名变更 `adapterutil.HealthToCheckers` 是 helper 签名
+（contract-fanout.md 明确不触发），仅 2 个 caller（redis / oidc）。
+
+## §4 无 runtime `Validate()`
+
+`ReadyProbeName` 不提供运行时校验方法。probe-name shape policy（snake_case +
+`_ready`）由 archtest 静态守，新增 runtime regex 会制造平行治理面（见
+`kernel/healthz/probe.go::Probe.Name` godoc 同款论证）。
+
+## §5 sanctioned-set 诚实 caveat + 补偿
+
+construction_funnel 只扫 sanctioned package 集；一个**未列入**该集的新 adapter
+若用裸 `_ready` 字面量授权 probe 会逃逸。补偿：`sanctioned_set_covers_all_checkers`
+meta-check 加载 production，发现任何 `Checkers()` 返回 `map[string]func` 且含
+`_ready` 形状字面量 key 的 package，断言其 ∈ sanctioned 集——新 bare-literal
+probe 作者会 fail loud，直到被纳入 funnel。
+
+## §6 影响 / 迁移
+
+- 删除（不与 Hard 并存）：`TestReadyProbeName_LiteralAnchor`、
+  `TestAdapterManagedResourceCheckerNamesUseReadySuffix`、
+  `TestRuntimeWebsocketCheckerNamesUseReadySuffix`、health_aggregation 的
+  `adapter*/healthChecker* / checkerNamesFromFuncPass / constStringValue` 扫描器。
+- `READYZ-PROBE-NAMING-01` Blind spot #2 关闭（godoc 改指向本 funnel）；该规则
+  保留 `NewProbe` hyphen-check 覆盖 framework / cellgen probe 名。
+- `bootstrap.WithHealthChecker` 命名扫描原本在 prod 无 callsite（vacuous），随
+  health_aggregation 扫描器一并删除；未来若 composition root 用它注册 adapter
+  probe，命名归 composition root 责任（已在删除点 godoc 标注）。
+
+## §7 状态对照（覆盖表逐行）
+
+| probe 面 | 旧 enforcement | 新 enforcement | 评级 |
+|---------|---------------|---------------|------|
+| adapter Checkers map key | regex 值形状（Soft） | OPS-CONTRACT-STRING-FUNNEL-01 construction_funnel | Hard |
+| HealthToCheckers 首参 | regex 值形状（Soft） | 同上 + typed 签名 | Hard |
+| s3 const 字面量 | TestReadyProbeName_LiteralAnchor（Soft） | golden_inventory | Hard |
+| probe const 声明位置 | 无 | declaration_site_lock | Hard |
+| 新 adapter 未纳入 funnel | 无 | sanctioned_set_covers meta-check | Hard（兜底） |
+| framework probe（config_watcher 等） | READYZ-PROBE-NAMING-01 hyphen | 不变 | 既有 |
+| cell repo probe | cellgen RegisterRepoReady | 不变 | 既有 Hard |

--- a/docs/architecture/202605241600-adr-ready-probe-name-typed-funnel.md
+++ b/docs/architecture/202605241600-adr-ready-probe-name-typed-funnel.md
@@ -102,10 +102,12 @@ interface 规则**；唯一签名变更 `adapterutil.HealthToCheckers` 是 helpe
 ## §5 sanctioned-set 诚实 caveat + 补偿
 
 construction_funnel 只扫 sanctioned package 集；一个**未列入**该集的新 adapter
-若用裸 `_ready` 字面量授权 probe 会逃逸。补偿：`sanctioned_set_covers_all_checkers`
+若用裸 `_ready` 字符串常量授权 probe 会逃逸。补偿：`sanctioned_set_covers_all_checkers`
 meta-check 加载 production，发现任何 `Checkers()` 返回 `map[string]func` 且含
-`_ready` 形状字面量 key 的 package，断言其 ∈ sanctioned 集——新 bare-literal
-probe 作者会 fail loud，直到被纳入 funnel。
+`_ready` 形状字符串常量 key（BasicLit / const ident / BinaryExpr concat，经
+`EvaluateConstString` 折叠）的 package，断言其 ∈ sanctioned 集——新 bare-constant
+probe 作者会 fail loud，直到被纳入 funnel。`HealthToCheckers` 首参分支 package-wide
+扫描（不限于 `Checkers()` 方法体），故从 helper 方法授权 probe 也不逃逸。
 
 ## §6 影响 / 迁移
 
@@ -118,6 +120,11 @@ probe 作者会 fail loud，直到被纳入 funnel。
 - `bootstrap.WithHealthChecker` 命名扫描原本在 prod 无 callsite（vacuous），随
   health_aggregation 扫描器一并删除；未来若 composition root 用它注册 adapter
   probe，命名归 composition root 责任（已在删除点 godoc 标注）。
+- **所有 8 个 probe 的字符串值完全不变**（`postgres_ready` / `postgres_indexes_valid_ready`
+  / `redis_ready` / `s3_ready` / `rabbitmq_ready` / `vault_transit_ready` /
+  `oidc_ready` / `websocket_hub_ready`）——本 PR 只改承载方式（untyped string →
+  typed const），`/readyz` verbose `dependencies` 键名与改前一致，**dashboard /
+  alert 无需更新**。
 
 ## §7 状态对照（覆盖表逐行）
 
@@ -130,3 +137,22 @@ probe 作者会 fail loud，直到被纳入 funnel。
 | 新 adapter 未纳入 funnel | 无 | sanctioned_set_covers meta-check | Hard（兜底） |
 | framework probe（config_watcher 等） | READYZ-PROBE-NAMING-01 hyphen | 不变 | 既有 |
 | cell repo probe | cellgen RegisterRepoReady | 不变 | 既有 Hard |
+
+## §8 新增 adapter readiness probe 操作步骤（三步）
+
+新增一个 adapter `_ready` probe（或纳入一个新 adapter 到 funnel）需要三处协同编辑，
+缺一则 archtest 红：
+
+1. **声明 typed const**：在 owning 包写
+   `const ProbeReady healthz.ReadyProbeName = "<name>_ready"`，构造点用
+   `string(ProbeReady)` 作 Checkers map key，或把 const 传给
+   `adapterutil.HealthToCheckers`。
+2. **加入 sanctioned 集**：把包的 module-relative path 加进
+   `tools/archtest/ops_contract_string_funnel_test.go` 的 `readyProbeSanctionedPkgs`
+   （否则 construction_funnel 不扫它，且 `sanctioned_set_covers` meta-check 红）。
+3. **更新 golden**：把 `<pkg>.<Const>=<value>` 加进同文件 `goldenReadyProbeNames()`
+   （否则 golden_inventory 红）。
+
+archtest 失败信息已指向以上动作（declaration-site / construction / sanctioned-set
+三处的 message + `readyProbeSanctionedPkgs` / `goldenReadyProbeNames` godoc 都列了
+该 checklist）。

--- a/docs/contributing/adapter-checklist.md
+++ b/docs/contributing/adapter-checklist.md
@@ -107,11 +107,23 @@ Common reference points for adapters:
 Every adapter that wraps a long-lived external connection or key provider must
 implement `kernel/lifecycle.ManagedResource`:
 
+The readiness-probe name is a typed ops contract: declare it as a
+`kernel/healthz.ReadyProbeName` const and reference that const at the
+construction site. Bare string literals are rejected by archtest
+OPS-CONTRACT-STRING-FUNNEL-01 (see its package godoc + ADR
+`docs/architecture/202605241600-adr-ready-probe-name-typed-funnel.md` §8 for the
+three-step new-probe checklist: declare const → add package to
+`readyProbeSanctionedPkgs` → add to `goldenReadyProbeNames()`).
+
 ```go
-func (p *MyAdapter) Checkers() map[string]func() error {
-    return map[string]func() error{
-        "my_adapter_ready": func() error {
-            ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+// ProbeReady is the snake_case + _ready ops-contract name, funneled by
+// OPS-CONTRACT-STRING-FUNNEL-01.
+const ProbeReady healthz.ReadyProbeName = "my_adapter_ready"
+
+func (p *MyAdapter) Checkers() map[string]func(context.Context) error {
+    return map[string]func(context.Context) error{
+        string(ProbeReady): func(ctx context.Context) error {
+            ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
             defer cancel()
             // Probe the actual business path (not sys/health or a ping endpoint).
             // A business-path probe covers auth, routing, and resource availability.
@@ -125,6 +137,15 @@ func (p *MyAdapter) Close(ctx context.Context) error { ... }
 
 // Compile-time assertion.
 var _ lifecycle.ManagedResource = (*MyAdapter)(nil)
+```
+
+For the common single-probe case, prefer the helper (it applies the inner
+deadline and the conversion at the funnel boundary):
+
+```go
+func (p *MyAdapter) Checkers() map[string]func(context.Context) error {
+    return adapterutil.HealthToCheckers(ProbeReady, p.Health, adapterutil.DefaultProbeTimeout)
+}
 ```
 
 Probe selection rule: use the minimum API call that verifies the adapter's

--- a/kernel/healthz/probe.go
+++ b/kernel/healthz/probe.go
@@ -11,13 +11,18 @@ import (
 //
 // Name returns a stable lower-case snake_case identifier ending in "_ready"
 // for dependency probes; framework probes use stable identifiers without the
-// "_ready" suffix. Name shape (snake_case + _ready suffix) is enforced
-// **statically** by archtest READYZ-PROBE-NAMING-01 (see
-// tools/archtest/readyz_probe_naming_test.go) rather than at runtime —
-// runtime Aggregator.Register only rejects empty and duplicate names. The
-// archtest is the single source of truth for naming policy; adding a runtime
-// regex check would create a parallel governance surface and is intentionally
-// avoided.
+// "_ready" suffix. Name shape is enforced **statically** by archtest, not at
+// runtime (runtime Aggregator.Register only rejects empty and duplicate names);
+// adding a runtime regex check would create a parallel governance surface and is
+// intentionally avoided. Two archtests split the surface by authoring site:
+//   - adapter dependency-availability probes authored via
+//     lifecycle.ManagedResource.Checkers() / adapterutil.HealthToCheckers —
+//     OPS-CONTRACT-STRING-FUNNEL-01 (must be a healthz.ReadyProbeName const;
+//     see kernel/healthz/readyprobename.go);
+//   - framework + cellgen probes constructed directly via NewProbe(name, fn)
+//     (config_watcher, outbox_failopen_rate_<cell>, <cell>_repo_ready) —
+//     READYZ-PROBE-NAMING-01 (no hyphens; see
+//     tools/archtest/readyz_probe_naming_test.go).
 //
 // Check is invoked by the Aggregator with a context carrying the probe
 // deadline. Returning nil indicates healthy; a non-nil error indicates

--- a/kernel/healthz/readyprobename.go
+++ b/kernel/healthz/readyprobename.go
@@ -1,0 +1,30 @@
+package healthz
+
+// ReadyProbeName is the named string type for adapter dependency-availability
+// readiness-probe names (postgres_ready, redis_ready, s3_ready, rabbitmq_ready,
+// vault_transit_ready, oidc_ready, websocket_hub_ready, …). Each owning adapter
+// declares its probe name as a ReadyProbeName-typed const at its own package
+// declaration site; the construction sites — a lifecycle.ManagedResource
+// Checkers() map key (via string(<const>)) and adapterutil.HealthToCheckers's
+// name argument — reference those consts rather than bare string literals.
+//
+// This makes probe-name drift unexpressible in static analysis: a bare literal
+// at a construction site, or a const declared outside the sanctioned package
+// set, fails archtest OPS-CONTRACT-STRING-FUNNEL-01 (the same string-typed
+// concept funnel mechanism as kernel/governance.RuleCode). The full symbol
+// inventory, double-lock rationale, and blind-spot self-checks live in that
+// archtest's package godoc — see tools/archtest/ops_contract_string_funnel_test.go.
+//
+// Scope: ReadyProbeName covers ONLY adapter dependency-availability "_ready"
+// probes. Framework probes registered through NewProbe / bootstrap.WithHealthChecker
+// (config_watcher, outbox_failopen_rate_<cell>, …) and runtime/outbox.Relay
+// budget keys (outbox-relay-poll/-reclaim/-cleanup) are intentionally NOT
+// ReadyProbeName and remain bare strings. Cell-level repo probes
+// (cells/*/healthz_gen.go) are funneled separately via the cellgen-generated
+// RegisterRepoReady helper.
+//
+// There is deliberately NO runtime Validate() method: probe-name shape policy
+// (snake_case + _ready suffix) is enforced statically by archtest, not at
+// runtime — adding a runtime regex check would create a parallel governance
+// surface (see Probe.Name godoc and .claude/rules/gocell/observability.md).
+type ReadyProbeName string

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/healthz"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -836,6 +837,10 @@ func (h *Hub) ConnCount() int {
 // lifecycle.ManagedResource implementation
 // ---------------------------------------------------------------------------
 
+// ProbeReady is the ops-contract name for the websocket hub readiness probe.
+// healthz.ReadyProbeName-typed, funneled by OPS-CONTRACT-STRING-FUNNEL-01.
+const ProbeReady healthz.ReadyProbeName = "websocket_hub_ready"
+
 // Checkers implements lifecycle.ManagedResource. It returns a single probe
 // "websocket_hub_ready" that reports nil (healthy) only when the Hub is in
 // the running state. Any other state (idle/stopping/stopped) returns
@@ -847,7 +852,7 @@ func (h *Hub) ConnCount() int {
 // ref: adapters/rabbitmq/connection.go Checkers — probe name + pre-allocated error pattern.
 func (h *Hub) Checkers() map[string]func(context.Context) error {
 	return map[string]func(context.Context) error{
-		"websocket_hub_ready": func(_ context.Context) error {
+		string(ProbeReady): func(_ context.Context) error {
 			if h.state.Load() == stateRunning {
 				return nil
 			}

--- a/runtime/websocket/hub_test.go
+++ b/runtime/websocket/hub_test.go
@@ -204,7 +204,7 @@ func TestHub_Checkers_StateMachine(t *testing.T) {
 			hub.state.Store(tt.state)
 			checkers := hub.Checkers()
 			require.NotEmpty(t, checkers, "Checkers must return a non-empty map")
-			fn, ok := checkers["websocket_hub_ready"]
+			fn, ok := checkers[string(ProbeReady)]
 			require.True(t, ok, "must have 'websocket_hub_ready' key")
 			err := fn(context.Background())
 			if tt.wantNil {
@@ -242,7 +242,7 @@ func TestHub_Checkers_StateMachine(t *testing.T) {
 
 		// Checkers must report non-nil while stopping.
 		checkers := hub.Checkers()
-		fn, ok := checkers["websocket_hub_ready"]
+		fn, ok := checkers[string(ProbeReady)]
 		require.True(t, ok)
 		assert.Error(t, fn(context.Background()), "Checkers must return error while hub is stopping")
 

--- a/tools/archtest/health_aggregation_test.go
+++ b/tools/archtest/health_aggregation_test.go
@@ -20,19 +20,13 @@ package archtest
 
 import (
 	"go/ast"
-	"go/constant"
-	"go/token"
 	"go/types"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // typeMethodSet collects every exported method (own + promoted) on every
@@ -227,83 +221,11 @@ func TestHealthAggregation_FixtureRegression(t *testing.T) {
 		"Bad declares only Checkers() — must remain flagged as missing Worker/Close")
 }
 
-var adapterReadyProbeNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:_[a-z0-9]+)*_ready$`)
-
-// adapterCheckerNameViolationsFromPass scans all files in a Pass for Checkers()
-// methods on exported receiver types and validates each probe name.
-func adapterCheckerNameViolationsFromPass(fset *token.FileSet, files []*ast.File, info *types.Info, rel string) []string {
-	var violations []string
-	for _, file := range files {
-		scanner.EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
-			if fn.Name.Name != "Checkers" || fn.Recv == nil || len(fn.Recv.List) == 0 {
-				return
-			}
-			recv := scanner.ReceiverTypeName(fn.Recv.List[0].Type)
-			if recv == "" || !ast.IsExported(recv) {
-				return
-			}
-			for _, name := range checkerNamesFromFuncPass(fset, info, fn) {
-				if !adapterReadyProbeNamePattern.MatchString(name) {
-					violations = append(violations, rel+"."+recv+" Checkers probe "+strconv.Quote(name)+" must be snake_case and end with _ready")
-				}
-			}
-		})
-	}
-	return violations
-}
-
-func checkerNamesFromFuncPass(_ *token.FileSet, info *types.Info, fn *ast.FuncDecl) []string {
-	var names []string
-	scanner.EachInSubtree[ast.KeyValueExpr](fn.Body, func(kv *ast.KeyValueExpr) {
-		tv, ok := info.Types[kv.Key]
-		if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
-			return
-		}
-		names = append(names, constant.StringVal(tv.Value))
-	})
-	scanner.EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "HealthToCheckers" || len(call.Args) == 0 {
-			return
-		}
-		obj, ok := info.Uses[sel.Sel].(*types.Func)
-		if !ok || !strings.HasSuffix(obj.Pkg().Path(), "adapters/adapterutil") {
-			return
-		}
-		name, ok := constStringValue(info, call.Args[0])
-		if !ok {
-			return
-		}
-		names = append(names, name)
-	})
-	return names
-}
-
-// healthCheckerCallNameViolationsFromPass scans all files in a Pass for
-// WithHealthChecker call sites and validates each probe name.
-func healthCheckerCallNameViolationsFromPass(_ *token.FileSet, files []*ast.File, info *types.Info, rel string) []string {
-	var violations []string
-	for _, file := range files {
-		scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-			if selectorName(call.Fun) != "WithHealthChecker" || len(call.Args) == 0 {
-				return
-			}
-			name, ok := constStringValue(info, call.Args[0])
-			if !ok {
-				return
-			}
-			if !adapterReadyProbeNamePattern.MatchString(name) {
-				violations = append(violations, rel+" bootstrap.WithHealthChecker probe "+strconv.Quote(name)+" must be snake_case and end with _ready")
-			}
-		})
-	}
-	return violations
-}
-
-func constStringValue(info *types.Info, expr ast.Expr) (string, bool) {
-	tv, ok := info.Types[expr]
-	if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
-		return "", false
-	}
-	return constant.StringVal(tv.Value), true
-}
+// Adapter/runtime ready-probe NAME validation (snake_case + _ready, single
+// source) moved to the Hard funnel OPS-CONTRACT-STRING-FUNNEL-01
+// (ops_contract_string_funnel_test.go). The Soft regex scanners that lived here
+// — adapterCheckerNameViolationsFromPass / checkerNamesFromFuncPass /
+// healthCheckerCallNameViolationsFromPass — were removed (no parallel
+// Soft+Hard). The bootstrap.WithHealthChecker scan had no production callsite
+// (vacuous); naming for any future composition-root WithHealthChecker call is
+// the composition root's responsibility.

--- a/tools/archtest/managed_resource_contract_test.go
+++ b/tools/archtest/managed_resource_contract_test.go
@@ -161,60 +161,9 @@ func TestAdaptersExportedTypesManagedResourceOrOptOut(t *testing.T) {
 	assert.Empty(t, violations, "A54 ManagedResource contract violations")
 }
 
-func TestAdapterManagedResourceCheckerNamesUseReadySuffix(t *testing.T) {
-	root := findModuleRoot(t)
-	modulePath := readModulePath(t, root)
-	adapterPrefix := modulePath + "/adapters/"
-	coreBundlePkg := modulePath + "/cmd/corebundle"
-
-	var violations []string
-	RunTypedProduction(t, TypedOpts{Tests: false},
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil || p.TypesInfo == nil {
-				return nil
-			}
-			pkgPath := p.Pkg.Path()
-
-			adapterPkg, ok := strings.CutPrefix(pkgPath, adapterPrefix)
-			if ok && !strings.Contains(adapterPkg, "/") {
-				violations = append(violations,
-					adapterCheckerNameViolationsFromPass(p.Fset, p.Files, p.TypesInfo, "adapters/"+adapterPkg)...)
-				return nil
-			}
-			if pkgPath == coreBundlePkg {
-				violations = append(violations,
-					healthCheckerCallNameViolationsFromPass(p.Fset, p.Files, p.TypesInfo, "cmd/corebundle")...)
-			}
-			return nil
-		})
-
-	sort.Strings(violations)
-	assert.Empty(t, violations, "adapter ManagedResource ready probes must use stable snake_case names ending in _ready")
-}
-
-// TestRuntimeWebsocketCheckerNamesUseReadySuffix enforces the
-// observability rule (Readyz Probe Naming) for runtime/websocket.Hub:
-// all Checkers() map keys must be snake_case and end with "_ready".
-//
-// This extends the adapter coverage from TestAdapterManagedResourceCheckerNamesUseReadySuffix
-// to the runtime/websocket package, which owns a ManagedResource
-// but lives in runtime/ rather than adapters/.
-func TestRuntimeWebsocketCheckerNamesUseReadySuffix(t *testing.T) {
-	root := findModuleRoot(t)
-	modulePath := readModulePath(t, root)
-	websocketPkg := modulePath + "/runtime/websocket"
-
-	var violations []string
-	RunTypedProduction(t, TypedOpts{Tests: false},
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != websocketPkg {
-				return nil
-			}
-			violations = append(violations,
-				adapterCheckerNameViolationsFromPass(p.Fset, p.Files, p.TypesInfo, "runtime/websocket")...)
-			return nil
-		})
-
-	sort.Strings(violations)
-	assert.Empty(t, violations, "runtime/websocket ManagedResource probe names must be snake_case and end with _ready")
-}
+// Adapter/runtime ready-probe NAME enforcement (snake_case + _ready + single
+// source) moved to the Hard OPS-CONTRACT-STRING-FUNNEL-01 funnel
+// (tools/archtest/ops_contract_string_funnel_test.go). The prior Soft regex
+// scanners (TestAdapterManagedResourceCheckerNamesUseReadySuffix /
+// TestRuntimeWebsocketCheckerNamesUseReadySuffix) were removed — no parallel
+// Soft+Hard. This file keeps only the ManagedResource COMPLETENESS contract.

--- a/tools/archtest/ops_contract_string_funnel_test.go
+++ b/tools/archtest/ops_contract_string_funnel_test.go
@@ -30,7 +30,7 @@
 // through healthz.NewProbe / bootstrap.WithHealthChecker (config_watcher,
 // outbox_failopen_rate_<cell>, …) and runtime/outbox.Relay budget keys
 // (outbox-relay-poll/-reclaim/-cleanup, hyphenated and non-_ready). Cell-level
-// repo probes (cells/*/healthz_gen.go ProbeRepoReady) are codegen-funnelled
+// repo probes (cells/*/healthz_gen.go ProbeRepoReady) are codegen-funneled
 // separately via RegisterRepoReady and are not touched here.
 //
 // Tool: RunTypedProduction (Pass-Driver) for production; RunTyped over testdata
@@ -54,7 +54,7 @@
 //     sanctioned_set_covers_all_checkers meta-check loads production, discovers
 //     every Checkers() returning a map[string]func with a _ready-shaped string
 //     LITERAL key, and asserts that package is in the sanctioned set — so a new
-//     bare-literal probe author fails loudly until it is funnelled.
+//     bare-literal probe author fails loudly until it is funneled.
 //  5. Shadowing the builtin `string` identifier inside a sanctioned Checkers
 //     (so string(x) is not the conversion). Non-fixturable; compensation:
 //     shadowing a predeclared identifier is independently caught by go vet /
@@ -127,7 +127,7 @@ func goldenReadyProbeNames() []string {
 func TestOpsContractStringFunnel(t *testing.T) {
 	root := findModuleRoot(t)
 	modPath := readModulePath(t, root)
-	healthzPkgPath := modPath + "/kernel/healthz"
+	// healthzPkgPath is the package const declared in readyz_probe_naming_test.go.
 
 	var goldenEntries []string
 
@@ -390,7 +390,7 @@ func testOpsContractSanctionedSetCoverage(t *testing.T, modPath string) {
 	})
 	sort.Strings(violations)
 	assert.Empty(t, violations,
-		"a new ready-probe author must be added to readyProbeSanctionedPkgs and funnelled through a ReadyProbeName const")
+		"a new ready-probe author must be added to readyProbeSanctionedPkgs and funneled through a ReadyProbeName const")
 }
 
 // testOpsContractBareLiteralKeyFixture proves construction_funnel flags

--- a/tools/archtest/ops_contract_string_funnel_test.go
+++ b/tools/archtest/ops_contract_string_funnel_test.go
@@ -1,0 +1,477 @@
+// INVARIANT: OPS-CONTRACT-STRING-FUNNEL-01
+//
+// ops_contract_string_funnel_test.go — OPS-CONTRACT-STRING-FUNNEL-01
+//
+// Rule: every adapter dependency-availability readiness-probe name
+// (postgres_ready, redis_ready, s3_ready, rabbitmq_ready, vault_transit_ready,
+// oidc_ready, websocket_hub_ready, postgres_indexes_valid_ready) must be
+// authored as a kernel/healthz.ReadyProbeName-typed const declared at the
+// owning adapter's own package, and referenced at the construction site
+// (Checkers() map[string]func key via string(<const>), or
+// adapterutil.HealthToCheckers first arg) by an identifier that resolves —
+// through go/types info.Uses — to one of those declared consts. A bare string
+// literal, a concat, a fmt.Sprintf, or a runtime variable at any of those
+// construction points fails. This upgrades the prior Soft regex/string-anchor
+// enforcement (PR #538) to a Hard "string-typed concept funnel" — the same
+// mechanism kernel/governance.RuleCode uses (see
+// governance_rules_invariants_test.go GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01).
+//
+// Funnel double-lock (ai-robust.md §"Funnel 双向锁评级"):
+//   - Downstream Hard (集合外不能进): construction_funnel resolves every probe-name
+//     key/arg to a declared *types.Const via info.Uses, rejecting BasicLit /
+//     BinaryExpr / CallExpr / *types.Var. Identical to ruleCodeArgResolvesToConst.
+//   - Upstream Hard (集合内必须经过): declaration_site_lock collects every real
+//     healthz.ReadyProbeName *types.Const in production and flags any declared
+//     outside the sanctioned package set; combined with the named type making a
+//     bare string non-assignable to a ReadyProbeName const, the only authoring
+//     path is "declare a typed const in a sanctioned package".
+//
+// Out of scope (NOT ReadyProbeName, intentionally bare string): framework probes
+// through healthz.NewProbe / bootstrap.WithHealthChecker (config_watcher,
+// outbox_failopen_rate_<cell>, …) and runtime/outbox.Relay budget keys
+// (outbox-relay-poll/-reclaim/-cleanup, hyphenated and non-_ready). Cell-level
+// repo probes (cells/*/healthz_gen.go ProbeRepoReady) are codegen-funnelled
+// separately via RegisterRepoReady and are not touched here.
+//
+// Tool: RunTypedProduction (Pass-Driver) for production; RunTyped over testdata
+// fixtures for the blind-spot self-checks. info.Uses / info.Types resolution +
+// the EachInSubtree/EachInChildren scanner façade.
+//
+// Declared blind spots + reverse self-checks (ai-robust.md §"工具选定后强制盲区自检"):
+//  1. Non-Ident key shapes — BasicLit "x_ready", BinaryExpr "x"+"_ready",
+//     CallExpr fmt.Sprintf. Covered by testdata/ops_contract_string_funnel_fixtures/
+//     bare_literal_key_red (asserts the construction scan flags them).
+//  2. Runtime variable key — string(localVar) where localVar is a
+//     healthz.ReadyProbeName *types.Var, not a const. info.Uses resolves to
+//     *types.Var → rejected. Covered by .../local_var_key_red.
+//  3. Declaration outside the sanctioned package set (a ReadyProbeName const
+//     declared in a non-adapter package). Covered by .../decl_bypass_red, which
+//     applies the sanctioned-package guard and asserts the const's package is
+//     flagged.
+//  4. A future adapter that authors probe names with BARE _ready string literals
+//     in a package NOT in the sanctioned set escapes construction_funnel (which
+//     only scans sanctioned packages). Compensation: the
+//     sanctioned_set_covers_all_checkers meta-check loads production, discovers
+//     every Checkers() returning a map[string]func with a _ready-shaped string
+//     LITERAL key, and asserts that package is in the sanctioned set — so a new
+//     bare-literal probe author fails loudly until it is funnelled.
+//  5. Shadowing the builtin `string` identifier inside a sanctioned Checkers
+//     (so string(x) is not the conversion). Non-fixturable; compensation:
+//     shadowing a predeclared identifier is independently caught by go vet /
+//     golangci and is absurd in production adapters.
+package archtest
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const opsContractStringFunnel01 = "OPS-CONTRACT-STRING-FUNNEL-01"
+
+// readyProbeNameTypeName is the kernel/healthz named-string type that funnels
+// adapter readiness-probe names.
+const readyProbeNameTypeName = "ReadyProbeName"
+
+// readyProbeValueShape is the snake_case + _ready ops-contract value shape
+// (migrated from the deleted health_aggregation Soft scanner). Applied once per
+// declared const rather than per construction site, since each value is now
+// single-sourced.
+var readyProbeValueShape = regexp.MustCompile(`^[a-z][a-z0-9]*(?:_[a-z0-9]+)*_ready$`)
+
+// readyProbeSanctionedPkgs is the module-relative set of packages allowed to
+// DECLARE healthz.ReadyProbeName consts and author probe-name constructions.
+// A const declared elsewhere is a declaration-site bypass; a Checkers() in a
+// package outside this set authoring _ready literals is caught by the
+// sanctioned_set_covers_all_checkers meta-check.
+var readyProbeSanctionedPkgs = map[string]struct{}{
+	"adapters/postgres": {},
+	"adapters/redis":    {},
+	"adapters/s3":       {},
+	"adapters/rabbitmq": {},
+	"adapters/vault":    {},
+	"adapters/oidc":     {},
+	"runtime/websocket": {},
+}
+
+// goldenReadyProbeNames freezes the full inventory of declared ReadyProbeName
+// consts as "<module-relative-pkg>.<ConstName>=<value>". Adding, removing, or
+// renaming any probe — including an observability dashboard mass rename — forces
+// a deliberate one-line diff here, mirroring goldenRuleIDs() for RuleCode.
+func goldenReadyProbeNames() []string {
+	return []string{
+		"adapters/oidc.ProbeReady=oidc_ready",
+		"adapters/postgres.ProbeIndexesValidReady=postgres_indexes_valid_ready",
+		"adapters/postgres.ProbeReady=postgres_ready",
+		"adapters/rabbitmq.ProbeReady=rabbitmq_ready",
+		"adapters/redis.ProbeReady=redis_ready",
+		"adapters/s3.ProbeReady=s3_ready",
+		"adapters/vault.ProbeReady=vault_transit_ready",
+		"runtime/websocket.ProbeReady=websocket_hub_ready",
+	}
+}
+
+// TestOpsContractStringFunnel is the OPS-CONTRACT-STRING-FUNNEL-01 entry point.
+// A single production load drives declaration-site, construction, and
+// value-shape checks plus the golden inventory; the testdata fixtures exercise
+// the blind-spot self-checks against the shared scan helpers.
+func TestOpsContractStringFunnel(t *testing.T) {
+	root := findModuleRoot(t)
+	modPath := readModulePath(t, root)
+	healthzPkgPath := modPath + "/kernel/healthz"
+
+	var goldenEntries []string
+
+	diags := RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		pkgRel := strings.TrimPrefix(p.Pkg.Path(), modPath+"/")
+		declared := collectReadyProbeNameConsts(p, healthzPkgPath)
+
+		var ds []Diagnostic
+		_, sanctioned := readyProbeSanctionedPkgs[pkgRel]
+
+		// declaration-site lock + value-shape + golden, per declared const.
+		for c := range declared {
+			pos := p.Fset.Position(c.Pos())
+			val, ok := readyProbeConstValue(c)
+			// declaration-site lock (upstream Hard).
+			if !sanctioned {
+				ds = append(ds, Diagnostic{
+					Rel:  pkgRel,
+					Line: pos.Line,
+					Message: readyProbeNameTypeName + " const " + strconv.Quote(c.Name()) +
+						" declared outside the sanctioned ready-probe package set",
+				})
+			}
+			// value-shape (once per declared const).
+			if !ok || !readyProbeValueShape.MatchString(val) {
+				ds = append(ds, Diagnostic{
+					Rel:  pkgRel,
+					Line: pos.Line,
+					Message: readyProbeNameTypeName + " const " + strconv.Quote(c.Name()) +
+						" value " + strconv.Quote(val) + " must be snake_case ending in _ready",
+				})
+			}
+			if ok {
+				goldenEntries = append(goldenEntries, pkgRel+"."+c.Name()+"="+val)
+			}
+		}
+
+		// construction funnel (downstream Hard) — runs for EVERY sanctioned
+		// package unconditionally: a bare-literal map key or HealthToCheckers
+		// arg fails even when no const is declared yet, so the funnel guards
+		// the authoring sites rather than merely the presence of consts.
+		if sanctioned {
+			for _, f := range p.Files {
+				ds = append(ds, scanReadyProbeConstructionViolations(f, p.Fset, p.TypesInfo, p.Rel(f), declared)...)
+			}
+		}
+		return ds
+	})
+
+	Report(t, opsContractStringFunnel01, diags)
+
+	t.Run("golden_inventory", func(t *testing.T) {
+		sort.Strings(goldenEntries)
+		assert.Equal(t, goldenReadyProbeNames(), goldenEntries,
+			"declared ReadyProbeName const inventory drifted from golden — update goldenReadyProbeNames() deliberately")
+	})
+
+	t.Run("sanctioned_set_covers_all_checkers", func(t *testing.T) {
+		testOpsContractSanctionedSetCoverage(t, modPath)
+	})
+
+	t.Run("blind_spot_bare_literal_key", testOpsContractBareLiteralKeyFixture)
+	t.Run("blind_spot_local_var_key", testOpsContractLocalVarKeyFixture)
+	t.Run("blind_spot_declaration_bypass", testOpsContractDeclBypassFixture)
+}
+
+// collectReadyProbeNameConsts returns the package-scope *types.Const objects in
+// p whose type is the real kernel/healthz.ReadyProbeName named type.
+func collectReadyProbeNameConsts(p *Pass, healthzPkgPath string) map[*types.Const]struct{} {
+	out := map[*types.Const]struct{}{}
+	scope := p.Pkg.Scope()
+	for _, name := range scope.Names() {
+		c, ok := scope.Lookup(name).(*types.Const)
+		if !ok {
+			continue
+		}
+		named, ok := c.Type().(*types.Named)
+		if !ok || named.Obj().Name() != readyProbeNameTypeName {
+			continue
+		}
+		if named.Obj().Pkg() == nil || named.Obj().Pkg().Path() != healthzPkgPath {
+			continue
+		}
+		out[c] = struct{}{}
+	}
+	return out
+}
+
+// readyProbeConstValue extracts the string value of a ReadyProbeName const.
+func readyProbeConstValue(c *types.Const) (string, bool) {
+	v := c.Val()
+	if v.Kind() != constant.String {
+		return "", false
+	}
+	return constant.StringVal(v), true
+}
+
+// scanReadyProbeConstructionViolations reports every Checkers() probe-name
+// construction in file that does not resolve to a const in declared. Shared
+// with the bare_literal_key_red / local_var_key_red fixtures so they exercise
+// the production path. info must come from the same load as file.
+func scanReadyProbeConstructionViolations(
+	file *ast.File,
+	fset *token.FileSet,
+	info *types.Info,
+	rel string,
+	declared map[*types.Const]struct{},
+) []Diagnostic {
+	var ds []Diagnostic
+	EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+		if fn.Name == nil || fn.Name.Name != "Checkers" || fn.Recv == nil || len(fn.Recv.List) == 0 || fn.Body == nil {
+			return
+		}
+		recv := ReceiverTypeName(fn.Recv.List[0].Type)
+		if recv == "" || !ast.IsExported(recv) {
+			return
+		}
+
+		// (A) direct map[string]func(context.Context) error literal keys.
+		EachInSubtree[ast.CompositeLit](fn.Body, func(cl *ast.CompositeLit) {
+			if !isReadyProbeCheckerMap(cl, info) {
+				return
+			}
+			EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
+				if probeNameExprResolves(kv.Key, info, declared) {
+					return
+				}
+				ds = append(ds, Diagnostic{
+					Rel:  rel,
+					Line: fset.Position(kv.Key.Pos()).Line,
+					Message: rel + "." + recv + " Checkers map key must be string(<" + readyProbeNameTypeName +
+						" const>) — got AST shape " + astShapeName(kv.Key),
+				})
+			})
+		})
+
+		// (B) adapterutil.HealthToCheckers(<const>, …) first arg.
+		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+			if !isHealthToCheckersCall(call, info) || len(call.Args) == 0 {
+				return
+			}
+			if probeNameExprResolves(call.Args[0], info, declared) {
+				return
+			}
+			ds = append(ds, Diagnostic{
+				Rel:  rel,
+				Line: fset.Position(call.Args[0].Pos()).Line,
+				Message: rel + "." + recv + " HealthToCheckers name arg must be a " + readyProbeNameTypeName +
+					" const — got AST shape " + astShapeName(call.Args[0]),
+			})
+		})
+	})
+	return ds
+}
+
+// probeNameExprResolves reports whether expr is <Ident> or string(<Ident>) and
+// the inner Ident resolves via info.Uses to a *types.Const in declared.
+// Fail-closed: nil info or any non-const resolution returns false.
+func probeNameExprResolves(expr ast.Expr, info *types.Info, declared map[*types.Const]struct{}) bool {
+	ident, ok := unwrapStringConversion(expr).(*ast.Ident)
+	if !ok || info == nil {
+		return false
+	}
+	obj, ok := info.Uses[ident]
+	if !ok {
+		return false
+	}
+	c, ok := obj.(*types.Const)
+	if !ok {
+		return false
+	}
+	_, found := declared[c]
+	return found
+}
+
+// unwrapStringConversion returns the inner expression of a string(x) conversion;
+// otherwise it returns expr unchanged. It only unwraps a CallExpr whose Fun is
+// the bare identifier "string" with exactly one argument.
+func unwrapStringConversion(expr ast.Expr) ast.Expr {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return expr
+	}
+	fun, ok := call.Fun.(*ast.Ident)
+	if !ok || fun.Name != "string" {
+		return expr
+	}
+	return call.Args[0]
+}
+
+// isReadyProbeCheckerMap reports whether cl is a map[string]func(...) composite
+// literal — the shape a Checkers() method returns.
+func isReadyProbeCheckerMap(cl *ast.CompositeLit, info *types.Info) bool {
+	if info == nil {
+		return false
+	}
+	tv, ok := info.Types[cl]
+	if !ok || tv.Type == nil {
+		return false
+	}
+	m, ok := tv.Type.Underlying().(*types.Map)
+	if !ok {
+		return false
+	}
+	if !types.Identical(m.Key(), types.Typ[types.String]) {
+		return false
+	}
+	_, isSig := m.Elem().Underlying().(*types.Signature)
+	return isSig
+}
+
+// isHealthToCheckersCall reports whether call invokes
+// adapters/adapterutil.HealthToCheckers.
+func isHealthToCheckersCall(call *ast.CallExpr, info *types.Info) bool {
+	pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+	return ok && name == "HealthToCheckers" && strings.HasSuffix(pkgPath, "adapters/adapterutil")
+}
+
+// testOpsContractSanctionedSetCoverage is the upstream-Hard compensation
+// (blind spot #4): any production Checkers() returning a map[string]func with a
+// _ready-shaped string LITERAL key must live in a sanctioned package.
+func testOpsContractSanctionedSetCoverage(t *testing.T, modPath string) {
+	var violations []string
+	RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		pkgRel := strings.TrimPrefix(p.Pkg.Path(), modPath+"/")
+		if _, ok := readyProbeSanctionedPkgs[pkgRel]; ok {
+			return nil
+		}
+		for _, f := range p.Files {
+			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+				if fn.Name == nil || fn.Name.Name != "Checkers" || fn.Body == nil {
+					return
+				}
+				EachInSubtree[ast.CompositeLit](fn.Body, func(cl *ast.CompositeLit) {
+					if !isReadyProbeCheckerMap(cl, p.TypesInfo) {
+						return
+					}
+					EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
+						lit, ok := kv.Key.(*ast.BasicLit)
+						if !ok {
+							return
+						}
+						val, ok := StringLitValue(lit)
+						if ok && readyProbeValueShape.MatchString(val) {
+							violations = append(violations,
+								pkgRel+" authors _ready probe "+strconv.Quote(val)+
+									" with a bare literal but is not in readyProbeSanctionedPkgs")
+						}
+					})
+				})
+			})
+		}
+		return nil
+	})
+	sort.Strings(violations)
+	assert.Empty(t, violations,
+		"a new ready-probe author must be added to readyProbeSanctionedPkgs and funnelled through a ReadyProbeName const")
+}
+
+// testOpsContractBareLiteralKeyFixture proves construction_funnel flags
+// BasicLit and BinaryExpr map keys (blind spot #1).
+func testOpsContractBareLiteralKeyFixture(t *testing.T) {
+	const pattern = "./tools/archtest/testdata/ops_contract_string_funnel_fixtures/bare_literal_key_red"
+	violations := runFixtureConstructionScan(t, pattern)
+	assert.GreaterOrEqual(t, len(violations), 2,
+		"bare literal + concat map keys must both be flagged, got: %v", violations)
+}
+
+// testOpsContractLocalVarKeyFixture proves construction_funnel flags a
+// string(localVar) key whose ident resolves to a *types.Var (blind spot #2).
+func testOpsContractLocalVarKeyFixture(t *testing.T) {
+	const pattern = "./tools/archtest/testdata/ops_contract_string_funnel_fixtures/local_var_key_red"
+	violations := runFixtureConstructionScan(t, pattern)
+	assert.GreaterOrEqual(t, len(violations), 1,
+		"string(localVar) key must be flagged (Var, not Const), got: %v", violations)
+}
+
+// runFixtureConstructionScan loads a single-package fixture, collects its local
+// ReadyProbeName-typed consts as the declared set, and runs the shared
+// construction scan over its files.
+func runFixtureConstructionScan(t *testing.T, pattern string) []Diagnostic {
+	var out []Diagnostic
+	RunTyped(t, TypedOpts{Tests: false}, []string{pattern}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		declared := collectLocalReadyProbeNameConsts(p)
+		for _, f := range p.Files {
+			out = append(out, scanReadyProbeConstructionViolations(f, p.Fset, p.TypesInfo, p.Rel(f), declared)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// collectLocalReadyProbeNameConsts collects consts of a type named
+// "ReadyProbeName" without the kernel/healthz package filter, for fixtures that
+// declare a local mirror type (mirrors the filename_bypass_red isolation).
+func collectLocalReadyProbeNameConsts(p *Pass) map[*types.Const]struct{} {
+	out := map[*types.Const]struct{}{}
+	scope := p.Pkg.Scope()
+	for _, name := range scope.Names() {
+		c, ok := scope.Lookup(name).(*types.Const)
+		if !ok {
+			continue
+		}
+		named, ok := c.Type().(*types.Named)
+		if !ok || named.Obj().Name() != readyProbeNameTypeName {
+			continue
+		}
+		out[c] = struct{}{}
+	}
+	return out
+}
+
+// testOpsContractDeclBypassFixture proves the declaration-site guard flags a
+// ReadyProbeName const declared in a package outside the sanctioned set
+// (blind spot #3). The fixture uses a local mirror type; the guard logic
+// (package ∉ sanctioned) is the production declaration_site_lock condition.
+func testOpsContractDeclBypassFixture(t *testing.T) {
+	const pattern = "./tools/archtest/testdata/ops_contract_string_funnel_fixtures/decl_bypass_red"
+	var flagged []string
+	RunTyped(t, TypedOpts{Tests: false}, []string{pattern}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		declared := collectLocalReadyProbeNameConsts(p)
+		require.NotEmpty(t, declared, "fixture must declare a ReadyProbeName const")
+		// The fixture package is, by construction, not in the sanctioned set.
+		pkgRel := p.Pkg.Path()
+		if _, ok := readyProbeSanctionedPkgs[pkgRel]; ok {
+			return nil
+		}
+		for c := range declared {
+			flagged = append(flagged, c.Name())
+		}
+		return nil
+	})
+	assert.NotEmpty(t, flagged,
+		"a ReadyProbeName const declared outside the sanctioned package set must be flagged by the declaration-site guard")
+}

--- a/tools/archtest/ops_contract_string_funnel_test.go
+++ b/tools/archtest/ops_contract_string_funnel_test.go
@@ -26,6 +26,12 @@
 //     bare string non-assignable to a ReadyProbeName const, the only authoring
 //     path is "declare a typed const in a sanctioned package".
 //
+// Both locks are archtest-bound Hard (CI-enforced), the same档 as
+// GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01. Go has no package-level const
+// visibility seal, so a compile-time upstream seal is not expressible for this
+// string-typed concept funnel shape — archtest-bound is the maximum achievable
+// and is not a Medium-upstream transitional form requiring a Hard-ization issue.
+//
 // Out of scope (NOT ReadyProbeName, intentionally bare string): framework probes
 // through healthz.NewProbe / bootstrap.WithHealthChecker (config_watcher,
 // outbox_failopen_rate_<cell>, …) and runtime/outbox.Relay budget keys
@@ -48,13 +54,16 @@
 //     declared in a non-adapter package). Covered by .../decl_bypass_red, which
 //     applies the sanctioned-package guard and asserts the const's package is
 //     flagged.
-//  4. A future adapter that authors probe names with BARE _ready string literals
-//     in a package NOT in the sanctioned set escapes construction_funnel (which
-//     only scans sanctioned packages). Compensation: the
+//  4. A future adapter that authors probe names with a bare _ready string
+//     CONSTANT in a package NOT in the sanctioned set escapes construction_funnel
+//     (which only scans sanctioned packages). Compensation: the
 //     sanctioned_set_covers_all_checkers meta-check loads production, discovers
 //     every Checkers() returning a map[string]func with a _ready-shaped string
-//     LITERAL key, and asserts that package is in the sanctioned set — so a new
-//     bare-literal probe author fails loudly until it is funneled.
+//     constant key (BasicLit / const ident / BinaryExpr concat, folded via
+//     EvaluateConstString), and asserts that package is in the sanctioned set —
+//     so a new bare-constant probe author fails loudly until it is funneled. The
+//     HealthToCheckers-arg branch is scanned package-wide (not only inside
+//     Checkers), so a probe authored from a helper method does not escape.
 //  5. Shadowing the builtin `string` identifier inside a sanctioned Checkers
 //     (so string(x) is not the conversion). Non-fixturable; compensation:
 //     shadowing a predeclared identifier is independently caught by go vet /
@@ -91,8 +100,15 @@ var readyProbeValueShape = regexp.MustCompile(`^[a-z][a-z0-9]*(?:_[a-z0-9]+)*_re
 // readyProbeSanctionedPkgs is the module-relative set of packages allowed to
 // DECLARE healthz.ReadyProbeName consts and author probe-name constructions.
 // A const declared elsewhere is a declaration-site bypass; a Checkers() in a
-// package outside this set authoring _ready literals is caught by the
+// package outside this set authoring _ready constants is caught by the
 // sanctioned_set_covers_all_checkers meta-check.
+//
+// Maintenance: a NEW adapter readiness probe requires three coordinated edits —
+// (1) declare a `const ProbeReady healthz.ReadyProbeName = "<name>_ready"` in the
+// owning package; (2) add that package here; (3) add its entry to
+// goldenReadyProbeNames(). adapters/adapterutil is intentionally NOT listed: it
+// is the funnel boundary (HealthToCheckers's body does the sole string(name)
+// conversion), not a probe-authoring site.
 var readyProbeSanctionedPkgs = map[string]struct{}{
 	"adapters/postgres": {},
 	"adapters/redis":    {},
@@ -106,7 +122,9 @@ var readyProbeSanctionedPkgs = map[string]struct{}{
 // goldenReadyProbeNames freezes the full inventory of declared ReadyProbeName
 // consts as "<module-relative-pkg>.<ConstName>=<value>". Adding, removing, or
 // renaming any probe — including an observability dashboard mass rename — forces
-// a deliberate one-line diff here, mirroring goldenRuleIDs() for RuleCode.
+// a deliberate one-line diff here, mirroring goldenRuleIDs() for RuleCode. Pair
+// any edit with the corresponding readyProbeSanctionedPkgs change (see its godoc
+// for the three-step new-probe checklist).
 func goldenReadyProbeNames() []string {
 	return []string{
 		"adapters/oidc.ProbeReady=oidc_ready",
@@ -125,6 +143,7 @@ func goldenReadyProbeNames() []string {
 // value-shape checks plus the golden inventory; the testdata fixtures exercise
 // the blind-spot self-checks against the shared scan helpers.
 func TestOpsContractStringFunnel(t *testing.T) {
+	t.Parallel()
 	root := findModuleRoot(t)
 	modPath := readModulePath(t, root)
 	// healthzPkgPath is the package const declared in readyz_probe_naming_test.go.
@@ -141,24 +160,18 @@ func TestOpsContractStringFunnel(t *testing.T) {
 		var ds []Diagnostic
 		_, sanctioned := readyProbeSanctionedPkgs[pkgRel]
 
-		// declaration-site lock + value-shape + golden, per declared const.
+		// declaration-site lock (upstream Hard) — shared with the
+		// decl_bypass_red fixture so that fixture is a real regression barrier
+		// on this guard rather than a tautology.
+		ds = append(ds, readyProbeDeclarationSiteViolations(pkgRel, declared, p.Fset)...)
+
+		// value-shape (once per declared const) + golden accumulation.
 		for c := range declared {
-			pos := p.Fset.Position(c.Pos())
 			val, ok := readyProbeConstValue(c)
-			// declaration-site lock (upstream Hard).
-			if !sanctioned {
-				ds = append(ds, Diagnostic{
-					Rel:  pkgRel,
-					Line: pos.Line,
-					Message: readyProbeNameTypeName + " const " + strconv.Quote(c.Name()) +
-						" declared outside the sanctioned ready-probe package set",
-				})
-			}
-			// value-shape (once per declared const).
 			if !ok || !readyProbeValueShape.MatchString(val) {
 				ds = append(ds, Diagnostic{
 					Rel:  pkgRel,
-					Line: pos.Line,
+					Line: p.Fset.Position(c.Pos()).Line,
 					Message: readyProbeNameTypeName + " const " + strconv.Quote(c.Name()) +
 						" value " + strconv.Quote(val) + " must be snake_case ending in _ready",
 				})
@@ -219,6 +232,29 @@ func collectReadyProbeNameConsts(p *Pass, healthzPkgPath string) map[*types.Cons
 	return out
 }
 
+// readyProbeDeclarationSiteViolations is the upstream-Hard declaration-site
+// lock: a ReadyProbeName const may only be declared in a sanctioned ready-probe
+// package. Returns one Diagnostic per declared const when pkgRel is NOT
+// sanctioned. Shared between the production scan and the decl_bypass_red fixture
+// so the fixture genuinely regresses this guard (delete the guard → fixture
+// fails), instead of re-implementing the condition inline.
+func readyProbeDeclarationSiteViolations(pkgRel string, declared map[*types.Const]struct{}, fset *token.FileSet) []Diagnostic {
+	if _, sanctioned := readyProbeSanctionedPkgs[pkgRel]; sanctioned {
+		return nil
+	}
+	var ds []Diagnostic
+	for c := range declared {
+		ds = append(ds, Diagnostic{
+			Rel:  pkgRel,
+			Line: fset.Position(c.Pos()).Line,
+			Message: readyProbeNameTypeName + " const " + strconv.Quote(c.Name()) +
+				" declared outside the sanctioned ready-probe package set; declare it in the" +
+				" owning adapter package and add that package to readyProbeSanctionedPkgs",
+		})
+	}
+	return ds
+}
+
 // readyProbeConstValue extracts the string value of a ReadyProbeName const.
 func readyProbeConstValue(c *types.Const) (string, bool) {
 	v := c.Val()
@@ -240,6 +276,9 @@ func scanReadyProbeConstructionViolations(
 	declared map[*types.Const]struct{},
 ) []Diagnostic {
 	var ds []Diagnostic
+
+	// (A) direct map[string]func(context.Context) error literal keys inside an
+	// exported-receiver Checkers() method.
 	EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
 		if fn.Name == nil || fn.Name.Name != "Checkers" || fn.Recv == nil || len(fn.Recv.List) == 0 || fn.Body == nil {
 			return
@@ -248,8 +287,6 @@ func scanReadyProbeConstructionViolations(
 		if recv == "" || !ast.IsExported(recv) {
 			return
 		}
-
-		// (A) direct map[string]func(context.Context) error literal keys.
 		EachInSubtree[ast.CompositeLit](fn.Body, func(cl *ast.CompositeLit) {
 			if !isReadyProbeCheckerMap(cl, info) {
 				return
@@ -261,26 +298,28 @@ func scanReadyProbeConstructionViolations(
 				ds = append(ds, Diagnostic{
 					Rel:  rel,
 					Line: fset.Position(kv.Key.Pos()).Line,
-					Message: rel + "." + recv + " Checkers map key must be string(<" + readyProbeNameTypeName +
-						" const>) — got AST shape " + astShapeName(kv.Key),
+					Message: rel + "." + recv + " Checkers map key must reference a " + readyProbeNameTypeName +
+						" const, e.g. string(ProbeReady) — got AST shape " + astShapeName(kv.Key),
 				})
 			})
 		})
+	})
 
-		// (B) adapterutil.HealthToCheckers(<const>, …) first arg.
-		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
-			if !isHealthToCheckersCall(call, info) || len(call.Args) == 0 {
-				return
-			}
-			if probeNameExprResolves(call.Args[0], info, declared) {
-				return
-			}
-			ds = append(ds, Diagnostic{
-				Rel:  rel,
-				Line: fset.Position(call.Args[0].Pos()).Line,
-				Message: rel + "." + recv + " HealthToCheckers name arg must be a " + readyProbeNameTypeName +
-					" const — got AST shape " + astShapeName(call.Args[0]),
-			})
+	// (B) adapterutil.HealthToCheckers(<const>, …) first arg — scanned
+	// package-wide (not only inside Checkers) so a probe name authored from a
+	// helper method cannot escape the funnel.
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !isHealthToCheckersCall(call, info) || len(call.Args) == 0 {
+			return
+		}
+		if probeNameExprResolves(call.Args[0], info, declared) {
+			return
+		}
+		ds = append(ds, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Args[0].Pos()).Line,
+			Message: rel + " HealthToCheckers name arg must be a " + readyProbeNameTypeName +
+				" const — got AST shape " + astShapeName(call.Args[0]),
 		})
 	})
 	return ds
@@ -351,7 +390,11 @@ func isHealthToCheckersCall(call *ast.CallExpr, info *types.Info) bool {
 
 // testOpsContractSanctionedSetCoverage is the upstream-Hard compensation
 // (blind spot #4): any production Checkers() returning a map[string]func with a
-// _ready-shaped string LITERAL key must live in a sanctioned package.
+// _ready-shaped string-CONSTANT key (BasicLit, const ident, or BinaryExpr
+// concat — folded via EvaluateConstString) must live in a sanctioned package,
+// so a new bare-literal probe author fails loud until funneled. A runtime
+// (non-constant) key folds to ("", false) and is left to the construction
+// funnel inside sanctioned packages.
 func testOpsContractSanctionedSetCoverage(t *testing.T, modPath string) {
 	var violations []string
 	RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
@@ -372,15 +415,14 @@ func testOpsContractSanctionedSetCoverage(t *testing.T, modPath string) {
 						return
 					}
 					EachInChildren[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
-						lit, ok := kv.Key.(*ast.BasicLit)
-						if !ok {
-							return
-						}
-						val, ok := StringLitValue(lit)
+						// Fold the key as a string constant: covers BasicLit,
+						// const ident, and BinaryExpr concat. A non-constant
+						// (runtime) key folds to ok=false and is ignored here.
+						val, ok := EvaluateConstString(p.TypesInfo, kv.Key)
 						if ok && readyProbeValueShape.MatchString(val) {
 							violations = append(violations,
 								pkgRel+" authors _ready probe "+strconv.Quote(val)+
-									" with a bare literal but is not in readyProbeSanctionedPkgs")
+									" with a bare string constant but is not in readyProbeSanctionedPkgs")
 						}
 					})
 				})
@@ -451,27 +493,24 @@ func collectLocalReadyProbeNameConsts(p *Pass) map[*types.Const]struct{} {
 
 // testOpsContractDeclBypassFixture proves the declaration-site guard flags a
 // ReadyProbeName const declared in a package outside the sanctioned set
-// (blind spot #3). The fixture uses a local mirror type; the guard logic
-// (package ∉ sanctioned) is the production declaration_site_lock condition.
+// (blind spot #3). It drives the SAME production helper
+// (readyProbeDeclarationSiteViolations) the main scan uses, so deleting that
+// guard makes this fixture fail — it is not a tautology. The fixture uses a
+// local mirror type; the guard logic (package ∉ sanctioned) is type-agnostic.
 func testOpsContractDeclBypassFixture(t *testing.T) {
 	const pattern = "./tools/archtest/testdata/ops_contract_string_funnel_fixtures/decl_bypass_red"
-	var flagged []string
+	var diags []Diagnostic
 	RunTyped(t, TypedOpts{Tests: false}, []string{pattern}, func(p *Pass) []Diagnostic {
 		if p.Pkg == nil {
 			return nil
 		}
 		declared := collectLocalReadyProbeNameConsts(p)
 		require.NotEmpty(t, declared, "fixture must declare a ReadyProbeName const")
-		// The fixture package is, by construction, not in the sanctioned set.
-		pkgRel := p.Pkg.Path()
-		if _, ok := readyProbeSanctionedPkgs[pkgRel]; ok {
-			return nil
-		}
-		for c := range declared {
-			flagged = append(flagged, c.Name())
-		}
+		// The fixture package path is, by construction, not in the sanctioned
+		// set, so the production guard must emit a violation.
+		diags = readyProbeDeclarationSiteViolations(p.Pkg.Path(), declared, p.Fset)
 		return nil
 	})
-	assert.NotEmpty(t, flagged,
-		"a ReadyProbeName const declared outside the sanctioned package set must be flagged by the declaration-site guard")
+	assert.NotEmpty(t, diags,
+		"readyProbeDeclarationSiteViolations must flag a ReadyProbeName const declared outside the sanctioned package set")
 }

--- a/tools/archtest/ops_contract_string_funnel_test.go
+++ b/tools/archtest/ops_contract_string_funnel_test.go
@@ -64,10 +64,13 @@
 //     so a new bare-constant probe author fails loudly until it is funneled. The
 //     HealthToCheckers-arg branch is scanned package-wide (not only inside
 //     Checkers), so a probe authored from a helper method does not escape.
-//  5. Shadowing the builtin `string` identifier inside a sanctioned Checkers
-//     (so string(x) is not the conversion). Non-fixturable; compensation:
-//     shadowing a predeclared identifier is independently caught by go vet /
-//     golangci and is absurd in production adapters.
+//  5. Shadowing the builtin `string` identifier so string(x) is a call, not a
+//     conversion. unwrapStringConversion type-verifies the conversion via
+//     info.Types[Fun].IsType()+Identical(string), so a shadowed `string`
+//     (a value, not a type) is rejected and the key is flagged — this does NOT
+//     depend on the predeclared linter. Doubly unexpressible in practice:
+//     shadowing `string` makes the map[string]func Checkers signature itself
+//     uncompilable, so no compilable fixture can exhibit it.
 package archtest
 
 import (
@@ -208,6 +211,7 @@ func TestOpsContractStringFunnel(t *testing.T) {
 	t.Run("blind_spot_bare_literal_key", testOpsContractBareLiteralKeyFixture)
 	t.Run("blind_spot_local_var_key", testOpsContractLocalVarKeyFixture)
 	t.Run("blind_spot_declaration_bypass", testOpsContractDeclBypassFixture)
+	t.Run("blind_spot_healthtocheckers_bypass", testOpsContractHealthToCheckersBypassFixture)
 }
 
 // collectReadyProbeNameConsts returns the package-scope *types.Const objects in
@@ -329,8 +333,11 @@ func scanReadyProbeConstructionViolations(
 // the inner Ident resolves via info.Uses to a *types.Const in declared.
 // Fail-closed: nil info or any non-const resolution returns false.
 func probeNameExprResolves(expr ast.Expr, info *types.Info, declared map[*types.Const]struct{}) bool {
-	ident, ok := unwrapStringConversion(expr).(*ast.Ident)
-	if !ok || info == nil {
+	if info == nil {
+		return false
+	}
+	ident, ok := unwrapStringConversion(expr, info).(*ast.Ident)
+	if !ok {
 		return false
 	}
 	obj, ok := info.Uses[ident]
@@ -345,16 +352,21 @@ func probeNameExprResolves(expr ast.Expr, info *types.Info, declared map[*types.
 	return found
 }
 
-// unwrapStringConversion returns the inner expression of a string(x) conversion;
-// otherwise it returns expr unchanged. It only unwraps a CallExpr whose Fun is
-// the bare identifier "string" with exactly one argument.
-func unwrapStringConversion(expr ast.Expr) ast.Expr {
+// unwrapStringConversion returns the inner expression of a genuine builtin
+// string(x) conversion; otherwise it returns expr unchanged. The conversion is
+// verified through go/types — info.Types[Fun].IsType() and the target type is
+// identical to the predeclared string — rather than by matching the bare
+// identifier name. A function or variable that shadows the predeclared `string`
+// identifier therefore is NOT treated as a conversion (its Fun is a value, not a
+// type), closing the name-only shadow gap without relying on the predeclared
+// linter being enabled.
+func unwrapStringConversion(expr ast.Expr, info *types.Info) ast.Expr {
 	call, ok := expr.(*ast.CallExpr)
-	if !ok || len(call.Args) != 1 {
+	if !ok || len(call.Args) != 1 || info == nil {
 		return expr
 	}
-	fun, ok := call.Fun.(*ast.Ident)
-	if !ok || fun.Name != "string" {
+	tv, ok := info.Types[call.Fun]
+	if !ok || !tv.IsType() || !types.Identical(tv.Type, types.Typ[types.String]) {
 		return expr
 	}
 	return call.Args[0]
@@ -388,13 +400,38 @@ func isHealthToCheckersCall(call *ast.CallExpr, info *types.Info) bool {
 	return ok && name == "HealthToCheckers" && strings.HasSuffix(pkgPath, "adapters/adapterutil")
 }
 
+// nonSanctionedHealthToCheckersViolations flags every adapterutil.HealthToCheckers
+// call in file: the helper always authors a probe name, so any caller must be a
+// sanctioned package (where the construction funnel resolves its arg to a
+// ReadyProbeName const). Callers are passed pkgRel only for the message; the
+// sanctioned-package gate is applied by the caller. Shared between the
+// sanctioned_set_covers meta-check and the healthtocheckers_bypass_red fixture.
+func nonSanctionedHealthToCheckersViolations(file *ast.File, info *types.Info, pkgRel string) []string {
+	var v []string
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !isHealthToCheckersCall(call, info) {
+			return
+		}
+		v = append(v, pkgRel+" calls adapterutil.HealthToCheckers but is not in"+
+			" readyProbeSanctionedPkgs; add the package so its probe name is funneled"+
+			" through a ReadyProbeName const")
+	})
+	return v
+}
+
 // testOpsContractSanctionedSetCoverage is the upstream-Hard compensation
-// (blind spot #4): any production Checkers() returning a map[string]func with a
-// _ready-shaped string-CONSTANT key (BasicLit, const ident, or BinaryExpr
-// concat — folded via EvaluateConstString) must live in a sanctioned package,
-// so a new bare-literal probe author fails loud until funneled. A runtime
-// (non-constant) key folds to ("", false) and is left to the construction
-// funnel inside sanctioned packages.
+// (blind spot #4): a non-sanctioned production package must not author a
+// readiness probe, via EITHER of the two construction surfaces —
+//   - a Checkers() map[string]func with a _ready-shaped string CONSTANT key
+//     (BasicLit, const ident, or BinaryExpr concat — folded via
+//     EvaluateConstString); or
+//   - any adapterutil.HealthToCheckers call (which always authors a probe and
+//     returns the map directly, so it leaves no composite-lit key to fold).
+//
+// Either form in a non-sanctioned package fails loud until that package is added
+// to readyProbeSanctionedPkgs (where the construction funnel then resolves the
+// name to a ReadyProbeName const). A runtime (non-constant) Checkers key folds
+// to ("", false) and is left to the construction funnel inside sanctioned pkgs.
 func testOpsContractSanctionedSetCoverage(t *testing.T, modPath string) {
 	var violations []string
 	RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
@@ -406,6 +443,11 @@ func testOpsContractSanctionedSetCoverage(t *testing.T, modPath string) {
 			return nil
 		}
 		for _, f := range p.Files {
+			// HealthToCheckers caller surface (closes the F1 bypass: a
+			// non-sanctioned Checkers returning HealthToCheckers(...) has no
+			// composite-lit key for the loop below to catch).
+			violations = append(violations, nonSanctionedHealthToCheckersViolations(f, p.TypesInfo, pkgRel)...)
+
 			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
 				if fn.Name == nil || fn.Name.Name != "Checkers" || fn.Body == nil {
 					return
@@ -513,4 +555,25 @@ func testOpsContractDeclBypassFixture(t *testing.T) {
 	})
 	assert.NotEmpty(t, diags,
 		"readyProbeDeclarationSiteViolations must flag a ReadyProbeName const declared outside the sanctioned package set")
+}
+
+// testOpsContractHealthToCheckersBypassFixture proves the meta-check flags a
+// non-sanctioned package that authors a probe via adapterutil.HealthToCheckers
+// (F1). It drives the same nonSanctionedHealthToCheckersViolations helper the
+// sanctioned_set_covers meta-check uses, so the F1 fix is a real regression
+// barrier.
+func testOpsContractHealthToCheckersBypassFixture(t *testing.T) {
+	const pattern = "./tools/archtest/testdata/ops_contract_string_funnel_fixtures/healthtocheckers_bypass_red"
+	var violations []string
+	RunTyped(t, TypedOpts{Tests: false}, []string{pattern}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		for _, f := range p.Files {
+			violations = append(violations, nonSanctionedHealthToCheckersViolations(f, p.TypesInfo, p.Pkg.Path())...)
+		}
+		return nil
+	})
+	assert.NotEmpty(t, violations,
+		"a non-sanctioned package calling adapterutil.HealthToCheckers must be flagged by the meta-check")
 }

--- a/tools/archtest/readyz_probe_naming_test.go
+++ b/tools/archtest/readyz_probe_naming_test.go
@@ -39,12 +39,12 @@
 //     a future one would escape this rule. Compensation: NewProbe is the single
 //     constructor, so any such site is grep-visible and reviewable.
 //  2. Adapter checker-name shapes that do NOT go through healthz.NewProbe —
-//     adapterutil.HealthToCheckers(name, …) arguments, map-literal keys
-//     ("postgres_ready": fn), and consts like ReadyProbeName="s3_ready". These
-//     are a separate naming surface; all current values are snake_case+_ready
-//     by inspection. Compensation: their names flow into the aggregator via
-//     WithHealthChecker and are reviewed at the adapter; a future widening to
-//     scan HealthToCheckers args is tracked if drift appears.
+//     adapterutil.HealthToCheckers(name, …) arguments and Checkers() map-literal
+//     keys — are now CLOSED by the Hard funnel OPS-CONTRACT-STRING-FUNNEL-01
+//     (ops_contract_string_funnel_test.go): every such name must resolve to a
+//     healthz.ReadyProbeName-typed const declared at a sanctioned adapter
+//     package, frozen by a golden inventory. This rule (READYZ-PROBE-NAMING-01)
+//     retains only the NewProbe hyphen-check for framework/cellgen probe names.
 //
 // Reverse self-check:
 //   - TestReadyzProbeNaming_RedHyphen — fixture package (build tag

--- a/tools/archtest/testdata/ops_contract_string_funnel_fixtures/bare_literal_key_red/violation.go
+++ b/tools/archtest/testdata/ops_contract_string_funnel_fixtures/bare_literal_key_red/violation.go
@@ -1,0 +1,29 @@
+// Package bare_literal_key_red is a testdata fixture for
+// OPS-CONTRACT-STRING-FUNNEL-01 blind spot #1: a Checkers() map[string]func
+// literal whose keys are a bare string literal and a string concat must both
+// be flagged by scanReadyProbeConstructionViolations, while the string(<const>)
+// key passes. Uses a local ReadyProbeName mirror type to isolate the
+// construction-scan logic (the production package filter is exercised
+// separately by the production load).
+package bare_literal_key_red
+
+import "context"
+
+// ReadyProbeName mirrors kernel/healthz.ReadyProbeName.
+type ReadyProbeName string
+
+// ProbeReady is the single sanctioned probe-name const for this fixture.
+const ProbeReady ReadyProbeName = "ok_ready"
+
+// Res implements a Checkers()-shaped method.
+type Res struct{}
+
+// Checkers returns three entries: two violations (BasicLit key, BinaryExpr
+// concat key) and one compliant string(<const>) key.
+func (Res) Checkers() map[string]func(context.Context) error {
+	return map[string]func(context.Context) error{
+		"bare_literal_ready":    func(context.Context) error { return nil },
+		"bad" + "_concat_ready": func(context.Context) error { return nil },
+		string(ProbeReady):      func(context.Context) error { return nil },
+	}
+}

--- a/tools/archtest/testdata/ops_contract_string_funnel_fixtures/decl_bypass_red/violation.go
+++ b/tools/archtest/testdata/ops_contract_string_funnel_fixtures/decl_bypass_red/violation.go
@@ -1,0 +1,15 @@
+// Package decl_bypass_red is a testdata fixture for
+// OPS-CONTRACT-STRING-FUNNEL-01 blind spot #3: a ReadyProbeName const declared
+// in a package outside the sanctioned ready-probe package set is a
+// declaration-site bypass. The declaration-site guard (package ∉
+// readyProbeSanctionedPkgs) must flag it. Uses a local ReadyProbeName mirror
+// type so the test isolates the sanctioned-package guard from the production
+// kernel/healthz type filter.
+package decl_bypass_red
+
+// ReadyProbeName mirrors kernel/healthz.ReadyProbeName.
+type ReadyProbeName string
+
+// probeBad is declared outside any sanctioned adapter/runtime package — the
+// guard must flag it.
+const probeBad ReadyProbeName = "bypass_ready"

--- a/tools/archtest/testdata/ops_contract_string_funnel_fixtures/healthtocheckers_bypass_red/violation.go
+++ b/tools/archtest/testdata/ops_contract_string_funnel_fixtures/healthtocheckers_bypass_red/violation.go
@@ -1,0 +1,21 @@
+// Package healthtocheckers_bypass_red is a testdata fixture for
+// OPS-CONTRACT-STRING-FUNNEL-01 F1: a package that authors a readiness probe via
+// adapterutil.HealthToCheckers but is NOT in readyProbeSanctionedPkgs. Such a
+// caller returns the map directly (no composite-lit key for the meta-check's
+// key-fold to catch), so it must be flagged by
+// nonSanctionedHealthToCheckersViolations. It imports the real adapterutil so
+// the type-resolved isHealthToCheckersCall matches; testdata is excluded from
+// RunTypedProduction, so this fixture never trips the production meta-check.
+package healthtocheckers_bypass_red
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/adapters/adapterutil"
+)
+
+// authorProbe smuggles a probe name past the funnel by calling HealthToCheckers
+// from a non-sanctioned package with a bare string literal.
+func authorProbe() map[string]func(context.Context) error {
+	return adapterutil.HealthToCheckers("bypass_ready", func(context.Context) error { return nil }, 0)
+}

--- a/tools/archtest/testdata/ops_contract_string_funnel_fixtures/local_var_key_red/violation.go
+++ b/tools/archtest/testdata/ops_contract_string_funnel_fixtures/local_var_key_red/violation.go
@@ -1,0 +1,25 @@
+// Package local_var_key_red is a testdata fixture for
+// OPS-CONTRACT-STRING-FUNNEL-01 blind spot #2: a string(localVar) map key whose
+// identifier resolves (via info.Uses) to a *types.Var — not a *types.Const —
+// must be flagged. Uses a local ReadyProbeName mirror type.
+package local_var_key_red
+
+import "context"
+
+// ReadyProbeName mirrors kernel/healthz.ReadyProbeName.
+type ReadyProbeName string
+
+// ProbeReady is a legitimate const; the violation is the runtime variable key.
+const ProbeReady ReadyProbeName = "ok_ready"
+
+// Res implements a Checkers()-shaped method.
+type Res struct{}
+
+// Checkers builds the map key from a local variable, which the funnel must
+// reject because info.Uses resolves the ident to a *types.Var.
+func (Res) Checkers() map[string]func(context.Context) error {
+	dynamic := ProbeReady
+	return map[string]func(context.Context) error{
+		string(dynamic): func(context.Context) error { return nil },
+	}
+}


### PR DESCRIPTION
## Summary

把 adapter dependency-availability readiness-probe 名（`postgres_ready` / `redis_ready` / `s3_ready` / `rabbitmq_ready` / `vault_transit_ready` / `oidc_ready` / `websocket_hub_ready` / `postgres_indexes_valid_ready`）从散落的 untyped string **Soft 约定**升级为 **Hard 的 string-typed concept funnel**，精确镜像 `kernel/governance.RuleCode` 的 `GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01`。

`Refs: OPS-CONTRACT-STRING-FUNNEL-01`

### 机制
- `kernel/healthz.ReadyProbeName`（`type … string`，无 runtime `Validate()`——命名策略归 archtest）
- 各 adapter 声明 typed const（`ProbeReady` / postgres 另有 `ProbeIndexesValidReady`）
- 构造点收口：`adapterutil.HealthToCheckers` 首参收 typed；直接 map key 走 `string(ProbeReady)`
- archtest `OPS-CONTRACT-STRING-FUNNEL-01`：construction_funnel（下游 Hard）+ declaration_site_lock（上游 Hard）+ value_shape + golden_inventory + 3 盲区自检 fixture + sanctioned-set meta-check

### 关键决策
- **`ManagedResource.Checkers()` 接口签名不变**（保持 `map[string]func`）。拒绝 Option A（typed map key）：会把类型强加给约 18 个返回 nil/budget-key 的无关实现，尤其 `outbox.Relay` 的连字符 budget key（`outbox-relay-poll`）会被套成语义错误的 `ReadyProbeName`。详见 ADR。
- **删 Soft 无并存**：`TestReadyProbeName_LiteralAnchor`（PR #538 引入，自评 Soft）、两个 `…UseReadySuffix` archtest、health_aggregation regex 扫描器全部删除。`READYZ-PROBE-NAMING-01` blind spot #2 关闭。`WithHealthChecker` 命名扫描 prod 零 callsite（vacuous）已删。

## AI-robust 评级（funnel 双向锁）
- **下游 Hard**：construction_funnel 用 `info.Uses` 把构造实参解析到声明的 `*types.Const`，拒 `BasicLit`/`BinaryExpr`/`string(localVar)`。
- **上游 Hard**：declaration_site_lock 限定 `ReadyProbeName` const 只能声明在 sanctioned package 集 + named type 使裸 string 不能不经转换赋值。
- archtest-bound Hard（与 RuleCode 同档）。

## Helper 签名变更（非 contract-fanout interface 触发）
```
adapterutil.HealthToCheckers(name string,…) → (name healthz.ReadyProbeName,…)
Callers: [x] adapters/redis  [x] adapters/oidc  （穷尽，2 处）
Repro: go test ./adapters/redis/... ./adapters/oidc/...
```
`ManagedResource.Checkers()` 接口未变，不触发 contract-fanout interface 规则。

ref: kubernetes/kubernetes pkg/util/healthz — named health checkers

## Test plan
- [x] `go build ./...`
- [x] `go test ./tools/archtest/ -run TestOpsContractStringFunnel`（含 golden + 3 盲区自检 + sanctioned-set meta-check，全 GREEN）
- [x] TDD 红→绿：Wave 1 RED commit（construction_funnel 命中 7 面 + golden 空）→ Wave 2 GREEN
- [x] 改动 9 个 adapter/runtime/healthz 包 + 3 个消费包（bootstrap / corebundle / outbox）单测全过
- [x] 删除的 Soft 替代后 `TestAdaptersExportedTypesManagedResourceOrOptOut` / `READYZ-PROBE-NAMING-01` 仍过
- [x] meta-archtest（coverage / inventory-anchor / shard-count）过——新 archtest 自动入集
- [x] `golangci-lint run` 0 issues

## ADR
`docs/architecture/202605241600-adr-ready-probe-name-typed-funnel.md` — 机制 / 双向锁评级 / Option A 反例（relay budget key）/ 无 runtime Validate 理由 / sanctioned-set caveat + 补偿 / §7 覆盖表逐行对照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)