### PR TITLE
feat(archtest): PG-REPO-AMBIENT-TX-01 双轴 Hard 化 (close #823)

### DIFF
--- a/adapters/postgres/pg_executor.go
+++ b/adapters/postgres/pg_executor.go
@@ -42,6 +42,14 @@ func (e pgExecutor) Query(ctx context.Context, sql string, args ...any) (pgx.Row
 	return e.pool.Query(ctx, sql, args...)
 }
 
+// ExecDirect bypasses the ambient transaction by executing directly on the
+// pool. Callers in *_repo.go / *_store.go MUST place a sibling
+// pgrepoapproved.ApprovedExecDirect("<kebab-case-reason>") marker call in the
+// same FuncDecl body; archtest PG-REPO-AMBIENT-TX-01 R3(b) enforces this.
+// pgExecutor's own methods are exempt.
+//
+// See pkg/pgrepoapproved and ADR
+// docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md.
 func (e pgExecutor) ExecDirect(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	return e.pool.Exec(ctx, sql, args...)
 }

--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/ctxutil"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/pgrepoapproved"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 )
@@ -587,6 +588,9 @@ func (s *PGRefreshStore) RevokeSessionDetached(ctx context.Context, sessionID st
 }
 
 func (s *PGRefreshStore) revokeSessionDetachedAt(ctx context.Context, sessionID string, revokedAt time.Time) error {
+	// ADR-approved ExecDirect callsite (PG-REPO-AMBIENT-TX-01 R3(b) marker).
+	// See ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md.
+	pgrepoapproved.ApprovedExecDirect("revoke-session-cascade")
 	// Detach from the caller's cancellation context: a security/compensation
 	// revoke MUST persist even when the HTTP request is canceled or times out.
 	// The detached context gets a bounded 5-second deadline so the write does
@@ -594,7 +598,6 @@ func (s *PGRefreshStore) revokeSessionDetachedAt(ctx context.Context, sessionID 
 	// path so the revoke commits on its own connection regardless of the outer
 	// RunInTx outcome.
 	// ref: golang/go context.WithoutCancel; hashicorp/vault token_store.go quitContext
-	// ref: ADR docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md
 	cascadeCtx, cancelCascade := ctxutil.WithDetachedTimeout(ctx, refresh.CascadeRevokeTimeout)
 	defer cancelCascade()
 	_, err := s.db.ExecDirect(cascadeCtx, revokeSessionSQL, revokedAt, sessionID)

--- a/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
+++ b/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
@@ -1,0 +1,157 @@
+# ADR 003 — PG-REPO-AMBIENT-TX-01 双轴 Hard 化（type-aware discovery + typed marker）
+
+## Status
+
+Accepted (2026-05-24)
+
+## Context
+
+**Issue #823 (F-A-002)** 跟踪 `PG-REPO-AMBIENT-TX-01` archtest 从"上游 Soft +
+下游 Hard"升级到闭环 Hard funnel（依 `.claude/rules/gocell/ai-robust.md`
+§"Funnel 双向锁评级"）。
+
+升级前的状态（`tools/archtest/pg_repo_ambient_tx_test.go`）：
+
+- **下游 R1/R2/R3 Hard** ✓：用 `*types.Info` 解析 `*pgxpool.Pool` /
+  `newPGExecutor` / `pgExecutor` 命名类型；无字符串锚点。
+- **上游 Soft**：`pgRepoPackagePatterns` 是 3 条人工维护列表（`adapters/postgres` /
+  accesscore 私有 / iotdevice 私有）。新增 cell 的 PG 适配包需开发者记得追加，
+  漏写 = coverage 静默清零。**PR #575 F-A-001 就是这个漂移**：iotdevice 模式
+  最初遗漏，导致该包所有 repo 文件逃过 R1/R2 检查。
+- **下游 R3(b) Soft**：`r3ExecDirectAllowlist map[string]struct{}` 单条字符串
+  锚点 entry `"adapters/postgres/refresh_store.go::revokeSessionDetachedAt"`。
+  改文件名 / 改函数名 / map key 写错 = 静默失效。
+
+**Soft → Hard 升级动机**：按 `ai-robust.md` "Soft 严禁立项 / 既有 Soft 优先升
+Hard"原则，两处 Soft 必须同 PR 升级。
+
+## Decision
+
+双轴升级：
+
+### 轴 A — 上游 type-aware 自动发现（Soft → Medium）
+
+**发现信号**：production package 在 archtest 扫描范围内 ⇔ 该包 scope 内
+声明了名为 `pgExecutor` 的类型。
+
+实现：`discoverPGAdapterPackages(t) []string` 用 `RunTyped` 遍历
+`prodscan.Patterns(root)` 加载的所有生产包，过滤
+`p.Pkg.Scope().Lookup(pgExecutorName) != nil` 的包返回其 import path 集合。
+`TestPGRepoAmbientTx` 用该集合代替原人工维护列表。
+
+理由：
+
+- 当前 3 个在册包都声明 `pgExecutor` 作为包局部 funnel；这本就是 R1/R2/R3
+  依赖的结构性不变量，把它升级为发现信号 = 让"funnel 入口"与"扫描范围"
+  共用同一类型符号，从根上消除"列表漏同步"失败模式。
+- 不声明 `pgExecutor` 的包无 funnel 符号可拦截，扫描无意义。
+- configcore (`Session` + `DBTX` 另一套 funnel) 被信号正确排除 — 这是另一种
+  funnel 模式，需独立 ADR + 独立 archtest，不在 PG-REPO-AMBIENT-TX-01 范围。
+- 新作者要么沿用 `pgExecutor` 范式（自动发现，R1/R2/R3 自动覆盖），要么发明新
+  funnel（需 ADR + 新 archtest）。
+
+**Coverage floor**：`TestPGRepoAmbientTx` 在调用 rule 前断言
+`len(discovered) ≥ 3`，防 discovery signal 被破坏的静默回归。
+`TestPGRepoAmbientTx_DiscoveryCoverage` 进一步断言发现集 == 当前 3 个已知包
+精确集合（diff-friendly 失败模式）。
+
+### 轴 B — 下游 R3 allowlist typed marker（Soft → Hard）
+
+**marker package**：新建 `pkg/pgrepoapproved`（sibling deployment of
+`pkg/panicregister`），含单一 no-op marker 函数：
+
+```go
+package pgrepoapproved
+
+func ApprovedExecDirect(reason string) {
+    _ = reason
+}
+```
+
+**callsite 形态**：合法 ExecDirect 调用必须在自身 FuncDecl body 内有 sibling
+marker 调用：
+
+```go
+func (s *PGRefreshStore) revokeSessionDetachedAt(...) error {
+    pgrepoapproved.ApprovedExecDirect("revoke-session-cascade")
+    // ...
+    _, err := s.db.ExecDirect(cascadeCtx, revokeSessionSQL, revokedAt, sessionID)
+    return err
+}
+```
+
+**archtest 形态**：R3(b) 删除 `r3ExecDirectAllowlist` map，改为同 body marker
+presence 检查 — `bodyHasApprovedExecDirectMarker(body, info)`。Marker 形态
+通过 (callee, arg) form-uniqueness 验证：
+
+1. callee 解析（via `*types.Info.Uses`）到 `*types.Func` 满足
+   `Name() == "ApprovedExecDirect"` AND `Pkg().Path() == "github.com/ghbvf/gocell/pkg/pgrepoapproved"`
+2. 第 1 参数的 `*types.Info.Types` TypeAndValue.Value 是
+   `constant.String`（const literal） — `fmt.Sprintf` / 字符串拼接 / 变量
+   均产生 non-constant 而被拒绝
+
+理由：与 `PANIC-REGISTERED-01` / `panic(panicregister.Approved)` 是相同 Hard
+范本 — "typed marker funnel for unbounded ops"。允许 = "存在 marker"，
+形态唯一性来自 callee 名 + 包路径 + arg 类型，无 "像但不是"的灰区。
+
+## Funnel 双向锁评级表
+
+| 维度 | 升级前 | 升级后 | 形态 |
+|------|--------|--------|------|
+| 上游（package discovery） | Soft（hand-maintained list） | **Medium** | archtest-bound type-aware：`Scope().Lookup("pgExecutor")` |
+| 下游 R1/R2（pool field / wrap funnel） | Hard | Hard | `*types.Info` 解析（不变） |
+| 下游 R3(a)（pool field access） | Hard | Hard | `*types.Info` 解析（不变） |
+| 下游 R3(b)（ExecDirect callsite） | Soft（hand-maintained map） | **Hard** | typed marker funnel：(callee, arg) form-uniqueness |
+
+**上游为何不是 Hard**：同 PANIC-REGISTERED-01 / SPAN-SETATTR-REDACT-01 上游
+package-internal 形态评级 — `pgExecutor` 当前是 package-private struct（包内
+sibling 可见），Go 编译器无法在包内阻止"非 pgExecutor struct 持 *pgxpool.Pool
+字段"。Hard terminal state 需 seal `pgExecutor` behind exported interface +
+私有构造，使包外不可表达跳过；工作量大（4 个 pgExecutor 实现 + 调用方 + R3
+type-resolution 逻辑改造），不在本 PR 范围。
+
+**跟踪 Hard terminal state**：同 PR 开 gh issue #916 (`PGEXECUTOR-SEAL-INTERFACE-01`)
+（依 ai-robust.md §"Funnel 双向锁评级"过渡形态要求），archtest godoc
+点名该 issue 号，让审查者能直接追到升级路径。
+
+## Out of scope
+
+- **`pgExecutor` sealed interface 改造**：见上文 Hard terminal state，gh
+  issue 跟踪。
+- **configcore `Session`/`DBTX` funnel formalization**：configcore 用结构性
+  不同的另一种 ambient-tx funnel（local `DBTX` interface + `*Session` 包装）。
+  其 `Session` struct 持有 `*pgxpool.Pool`，与 `pgExecutor` 角色对等但命名
+  不同。若需等价治理，需独立 ADR + 独立 archtest（命名建议
+  `PG-REPO-AMBIENT-TX-02`），不在 #823 ask 范围。本 PR 只 commit 到"该包不
+  在 PG-REPO-AMBIENT-TX-01 范围"这个事实，不强制迁移。
+
+## Threat Model
+
+| 威胁 | 缓解 |
+|------|------|
+| 新 PG 适配包沿用 `pgExecutor` 范式 | 自动被 `discoverPGAdapterPackages` 发现，R1/R2/R3 自动覆盖 ✓ |
+| 新 PG 适配包发明新 funnel（如 configcore Session） | 本 archtest 不覆盖；约定 + code-review + new-pattern-requires-ADR 兜底（不是回归 — 升级前也不覆盖） |
+| Refactor 把 pgExecutor 改名 / 移出包 scope | `TestPGRepoAmbientTx_DiscoveryCoverage` exact-set match 失败 + `TestPGRepoAmbientTx` 的 coverage floor (≥3) 兜底 ✓ |
+| 新 ExecDirect callsite 漏加 marker | R3(b) 同 body marker presence 检查失败 ✓ |
+| Marker reason 写成 `fmt.Sprintf` 隐藏审计串 | `bodyHasApprovedExecDirectMarker` 验证 `constant.String` 拒绝 non-constant arg ✓ |
+| 移到不相关 func body 放 marker 制造"看似 approved"的错觉 | BS-8 反向自检：marker 必须与同 body 的 `pgExecutor.ExecDirect` 调用共存 — 孤立 marker 失败 ✓ |
+| 拷贝 `pgrepoapproved` 包到其他位置绕过 funnel | callee 解析锁 `Pkg().Path()` 到精确字符串 `"github.com/ghbvf/gocell/pkg/pgrepoapproved"`，重定向 import 不改 package path ✓ |
+
+## Implementation matrix
+
+```
+Contract: PG-REPO-AMBIENT-TX-01 archtest（上游 Soft → Medium；下游 R3(b) Soft → Hard）
+Change: 引入 pkg/pgrepoapproved typed marker + 类型感知 discovery；删除 hand-maintained list + allowlist map
+Implementations: [x] adapters/postgres (refresh_store.go marker)  [x] cells/accesscore/internal/adapters/postgres（自动发现）  [x] examples/iotdevice/cells/devicecell/internal/adapters/postgres（自动发现）
+Conformance test: tools/archtest.TestPGRepoAmbientTx + TestPGRepoAmbientTx_RedFixtureDetected + TestPGRepoAmbientTx_SelfCheck + TestPGRepoAmbientTx_DiscoveryCoverage
+Repro: go test ./tools/archtest/... -run TestPGRepoAmbientTx
+Dependent contracts (governance scan): none
+```
+
+## References
+
+- `.claude/rules/gocell/ai-robust.md` §"Hard 范本目录" (#2 typed marker funnel for unbounded ops, #4 single sanctioned holder)
+- `.claude/rules/gocell/ai-robust.md` §"Funnel 双向锁评级"
+- `pkg/panicregister`（sibling typed marker funnel deployment）
+- ADR `docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md`（revokeSessionDetachedAt 的 ExecDirect bypass 起源）
+- ADR `docs/architecture/202605231400-002-required-dep-nil-guard-codegen-funnel.md`（最近一次 Soft → Hard 升级，同期参照）

--- a/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
+++ b/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
@@ -152,7 +152,7 @@ type-resolution 逻辑改造），不在本 PR 范围。
 | 新 PG 适配包发明新 funnel（如 configcore Session） | 本 archtest 不覆盖；约定 + code-review + new-pattern-requires-ADR 兜底（不是回归 — 升级前也不覆盖） |
 | Refactor 把 pgExecutor 改名 / 移出包 scope | `TestPGRepoAmbientTx_DiscoveryCoverage` exact-set match 失败 + `TestPGRepoAmbientTx` 的 coverage floor (≥3) 兜底 ✓ |
 | 新 ExecDirect callsite 漏加 marker | R3(b) 同 body marker presence 检查失败 ✓ |
-| Marker reason 写成 `fmt.Sprintf` 隐藏审计串 | `bodyHasApprovedExecDirectMarker` 验证 `constant.String` 拒绝 non-constant arg ✓ |
+| Marker reason 写成 `fmt.Sprintf` / 变量 / 函数返回值隐藏审计串 | `bodyHasApprovedExecDirectMarker` 要求 arg[0] 为 `*ast.BasicLit + token.STRING`；non-literal 表达式 AST 节点不是 BasicLit → 拒绝 ✓（与"const ident / 常量折叠"威胁同源，见下文专行）|
 | 移到不相关 func body 放 marker 制造"看似 approved"的错觉 | BS-8 反向自检：marker 必须与同 body 的 `pgExecutor.ExecDirect` 调用共存 — 孤立 marker 失败 ✓ |
 | 拷贝 `pgrepoapproved` 包到其他位置绕过 funnel | callee 解析锁 `Pkg().Path()` 到精确字符串 `"github.com/ghbvf/gocell/pkg/pgrepoapproved"`，重定向 import 不改 package path ✓ |
 | import 别名绕过 marker callee 识别 | callee 解析锁 `fn.Pkg().Path()`（via *types.Info.Uses），import alias 不改 package path ✓ |

--- a/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
+++ b/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
@@ -22,6 +22,16 @@ Accepted (2026-05-24)
   锚点 entry `"adapters/postgres/refresh_store.go::revokeSessionDetachedAt"`。
   改文件名 / 改函数名 / map key 写错 = 静默失效。
 
+> **2026-05-24 PR #917 round-2 修订**：本 ADR 第一版把 R3(b) 升级形态写为
+> "typed marker funnel：(callee, arg) form-uniqueness Hard"，但实施版本的 arg
+> 检查仅 `tv.Value.Kind() == constant.String`，仍接受 const ident /
+> 常量折叠 `"a"+"b"` / 空串 / 占位符 — 这只是 form-uniqueness 假象，落地评级
+> 实际仍 Soft（"像但不是 const literal"灰区）。同上， marker 检查通过
+> `EachInSubtree` 穿透 `*ast.FuncLit`，nested closure 内的 marker 可批准外层
+> ExecDirect（scope 漂移）。Round-2 修复（见下"轴 B 实现细节"）把 arg 校验改
+> 为 `*ast.BasicLit` + kebab regex + placeholder ban 5-门串行，marker 扫描收
+> 紧到 `inspectStopAtFuncLit` scope-bounded — R3(b) 才真正达到 Hard。
+
 **Soft → Hard 升级动机**：按 `ai-robust.md` "Soft 严禁立项 / 既有 Soft 优先升
 Hard"原则，两处 Soft 必须同 PR 升级。
 
@@ -80,19 +90,28 @@ func (s *PGRefreshStore) revokeSessionDetachedAt(...) error {
 }
 ```
 
-**archtest 形态**：R3(b) 删除 `r3ExecDirectAllowlist` map，改为同 body marker
-presence 检查 — `bodyHasApprovedExecDirectMarker(body, info)`。Marker 形态
-通过 (callee, arg) form-uniqueness 验证：
+**archtest 形态**：R3(b) 删除 `r3ExecDirectAllowlist` map，改为 same-scope
+marker presence 检查 — `bodyHasApprovedExecDirectMarker(body, info)` 用
+`inspectStopAtFuncLit` 把扫描限定到当前 FuncDecl/FuncLit body（不下降到
+nested closure）。`scanR3UsagePoints` 在 FuncDecl 之外递归进入每个 nested
+FuncLit body，treat each as its own approval scope。Marker 5-门 form-uniqueness
+（每门一个 reject 分支，对标 panicregister 6-rule chain）：
 
 1. callee 解析（via `*types.Info.Uses`）到 `*types.Func` 满足
-   `Name() == "ApprovedExecDirect"` AND `Pkg().Path() == "github.com/ghbvf/gocell/pkg/pgrepoapproved"`
-2. 第 1 参数的 `*types.Info.Types` TypeAndValue.Value 是
-   `constant.String`（const literal） — `fmt.Sprintf` / 字符串拼接 / 变量
-   均产生 non-constant 而被拒绝
+   `Name() == "ApprovedExecDirect"` AND
+   `Pkg().Path() == "github.com/ghbvf/gocell/pkg/pgrepoapproved"`
+2. `arg[0]` 必须是 `*ast.BasicLit` AND `Kind == token.STRING`（拒 const
+   identifier / 常量折叠 `"a" + "b"` BinaryExpr / 变量 / `fmt.Sprintf`）
+3. `strconv.Unquote(arg[0])` 必须 match `^[a-z][a-z0-9-]+$`（kebab-case，
+   长度 ≥ 2，首字符小写字母）
+4. 不在占位符集 `^(todo|fixme|tbd|xxx|placeholder|wip)(-|$)`
+5. scope 必须是当前 FuncDecl/FuncLit body — 通过 `inspectStopAtFuncLit` 强制
 
-理由：与 `PANIC-REGISTERED-01` / `panic(panicregister.Approved)` 是相同 Hard
-范本 — "typed marker funnel for unbounded ops"。允许 = "存在 marker"，
-形态唯一性来自 callee 名 + 包路径 + arg 类型，无 "像但不是"的灰区。
+理由：与 `PANIC-REGISTERED-01` 是相同 Hard 范本 — "typed marker funnel for
+unbounded ops"。允许 = "存在严格形态的 marker 在同 scope"，5-门串行消除"像但
+不是 const literal"灰区，scope-bounded 消除 nested-closure 走私 — 任何其他
+形态 archtest 即失败。BS-8 反向自检也升级为 scope-bounded，覆盖 spurious
+marker（marker 存在但同 scope 无 ExecDirect → audit-trail 退化）。
 
 ## Funnel 双向锁评级表
 
@@ -139,6 +158,8 @@ type-resolution 逻辑改造），不在本 PR 范围。
 | import 别名绕过 marker callee 识别 | callee 解析锁 `fn.Pkg().Path()`（via *types.Info.Uses），import alias 不改 package path ✓ |
 | build-tag 隔离的条件性 ExecDirect 调用 | RunTyped 用 default build context；如需覆盖须扩展 TypedOpts；当前 production 代码库无 build-tag 隔离 ExecDirect 先例；以 code review 兜底（accepted threat） |
 | ExecDirect 仅 adapters/postgres 当前持有 | accesscore / iotdevice 的 pgExecutor 当前不暴露 ExecDirect 方法；R3(b) 对其当前零 callsite 覆盖；新包加 ExecDirect 时第一次违规由 CI 抓 ✓ |
+| nested closure 走私 marker / ExecDirect（marker 在内层 closure 批准外层 ExecDirect，或反向） | `bodyHasApprovedExecDirectMarker` / `scanR3ExecDirect` 用 `inspectStopAtFuncLit` 把扫描限定到当前 FuncDecl/FuncLit body；`scanR3UsagePoints` 把每个 nested FuncLit body 视为独立 approval scope；RED fixture `badR3MarkerInNestedClosure` + `badR3MarkerOuterExecInNestedClosure` 守 ✓ |
+| marker reason 退化（const ident / `"a"+"b"` concat / 空串 / 占位符 todo/fixme/…） | arg[0] 必须 `*ast.BasicLit + token.STRING` + kebab regex + placeholder ban 5-门串行（落地对标 panicregister）；RED fixture `badR3ApprovedConstIdent` / `badR3ApprovedConcat` / `badR3ApprovedEmpty` / `badR3ApprovedPlaceholder` 4 个用例守 ✓ |
 
 ## Implementation matrix
 

--- a/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
+++ b/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
@@ -53,7 +53,7 @@ Hard"原则，两处 Soft 必须同 PR 升级。
 **Coverage floor**：`TestPGRepoAmbientTx` 在调用 rule 前断言
 `len(discovered) ≥ 3`，防 discovery signal 被破坏的静默回归。
 `TestPGRepoAmbientTx_DiscoveryCoverage` 进一步断言发现集 == 当前 3 个已知包
-精确集合（diff-friendly 失败模式）。
+精确集合（diff-friendly 失败模式）。`expectedPGAdapterPackageMin` 是固定下限（不随新包自动增大）。`TestPGRepoAmbientTx_DiscoveryCoverage` 的 exact-set match 才是主保护；floor 仅防 `prodscan.Patterns` 被破坏导致 discovery 静默返回空。新增 PG 包时需手动同时更新 `expected` slice 和 `expectedPGAdapterPackageMin`。
 
 ### 轴 B — 下游 R3 allowlist typed marker（Soft → Hard）
 
@@ -123,7 +123,7 @@ type-resolution 逻辑改造），不在本 PR 范围。
   其 `Session` struct 持有 `*pgxpool.Pool`，与 `pgExecutor` 角色对等但命名
   不同。若需等价治理，需独立 ADR + 独立 archtest（命名建议
   `PG-REPO-AMBIENT-TX-02`），不在 #823 ask 范围。本 PR 只 commit 到"该包不
-  在 PG-REPO-AMBIENT-TX-01 范围"这个事实，不强制迁移。
+  在 PG-REPO-AMBIENT-TX-01 范围"这个事实，不强制迁移。**重要：configcore 目前无等价 archtest 治理**；其 `Session`/`DBTX` 的 ambient-tx 安全边界依赖 code review。需要 archtest 覆盖时新开 gh issue 跟踪 `PG-REPO-AMBIENT-TX-02`。
 
 ## Threat Model
 
@@ -136,6 +136,9 @@ type-resolution 逻辑改造），不在本 PR 范围。
 | Marker reason 写成 `fmt.Sprintf` 隐藏审计串 | `bodyHasApprovedExecDirectMarker` 验证 `constant.String` 拒绝 non-constant arg ✓ |
 | 移到不相关 func body 放 marker 制造"看似 approved"的错觉 | BS-8 反向自检：marker 必须与同 body 的 `pgExecutor.ExecDirect` 调用共存 — 孤立 marker 失败 ✓ |
 | 拷贝 `pgrepoapproved` 包到其他位置绕过 funnel | callee 解析锁 `Pkg().Path()` 到精确字符串 `"github.com/ghbvf/gocell/pkg/pgrepoapproved"`，重定向 import 不改 package path ✓ |
+| import 别名绕过 marker callee 识别 | callee 解析锁 `fn.Pkg().Path()`（via *types.Info.Uses），import alias 不改 package path ✓ |
+| build-tag 隔离的条件性 ExecDirect 调用 | RunTyped 用 default build context；如需覆盖须扩展 TypedOpts；当前 production 代码库无 build-tag 隔离 ExecDirect 先例；以 code review 兜底（accepted threat） |
+| ExecDirect 仅 adapters/postgres 当前持有 | accesscore / iotdevice 的 pgExecutor 当前不暴露 ExecDirect 方法；R3(b) 对其当前零 callsite 覆盖；新包加 ExecDirect 时第一次违规由 CI 抓 ✓ |
 
 ## Implementation matrix
 

--- a/pkg/pgrepoapproved/pgrepoapproved.go
+++ b/pkg/pgrepoapproved/pgrepoapproved.go
@@ -19,12 +19,17 @@ package pgrepoapproved
 // bypassing the ambient transaction. archtest PG-REPO-AMBIENT-TX-01 R3(b)
 // rejects non-literal forms (fmt.Sprintf, concatenation, variables).
 //
+// It is not cross-checked against any catalog at build time; it serves as
+// source-level documentation. Reviewers verify the corresponding ADR
+// rationale exists.
+//
+// Note: an empty string "" satisfies the const-literal check but violates
+// review policy; reviewers must reject meaningless reasons.
+//
 // ApprovedExecDirect is purely a source-level marker (no-op at runtime).
 // The archtest enforces that every ExecDirect call from a non-pgExecutor
 // receiver has a sibling ApprovedExecDirect(literal) call in the same
-// FuncDecl body. Adding the marker without the corresponding ADR rationale
-// is a review violation; the marker's reason argument MUST cite an existing
-// ADR section.
+// FuncDecl body.
 //
 // Hard funnel rationale: this is the unique allowlist mechanism for
 // ExecDirect callsites in GoCell production code. The form-uniqueness

--- a/pkg/pgrepoapproved/pgrepoapproved.go
+++ b/pkg/pgrepoapproved/pgrepoapproved.go
@@ -1,41 +1,41 @@
 // Package pgrepoapproved provides the only approved way to call
 // pgExecutor.ExecDirect from a PG repo/store method. Every legitimate
 // ExecDirect callsite in a *_repo.go / *_store.go file MUST contain a
-// pgrepoapproved.ApprovedExecDirect(reason) marker in the same FuncDecl body
-// before invoking ExecDirect. This creates a typed funnel that archtest
-// PG-REPO-AMBIENT-TX-01 R3(b) statically verifies: any ExecDirect call
-// without a same-body marker, or with a non-literal reason, is rejected.
-// See .claude/rules/gocell/ai-robust.md "Hard 范本" (typed marker funnel
-// for unbounded ops) for the pattern; this is the sibling deployment of
-// pkg/panicregister applied to ExecDirect.
+// pgrepoapproved.ApprovedExecDirect(reason) marker in the SAME approval
+// scope (FuncDecl body OR enclosing FuncLit body — markers in nested
+// closures do NOT approve outer-scope ExecDirect calls and vice versa).
+// This creates a typed funnel that archtest PG-REPO-AMBIENT-TX-01 R3(b)
+// statically verifies. See .claude/rules/gocell/ai-robust.md "Hard 范本"
+// (typed marker funnel for unbounded ops); this is the sibling deployment
+// of pkg/panicregister applied to ExecDirect.
 package pgrepoapproved
 
-// ApprovedExecDirect tags the enclosing repo/store function as an
-// ADR-approved caller of pgExecutor.ExecDirect (which bypasses the ambient
-// transaction).
+// ApprovedExecDirect tags the enclosing repo/store function (or closure)
+// as an ADR-approved caller of pgExecutor.ExecDirect (which bypasses the
+// ambient transaction).
 //
-// reason MUST be a const string literal (kebab-case identifier like
-// "revoke-session-cascade") that documents the ADR-explicit rationale for
-// bypassing the ambient transaction. archtest PG-REPO-AMBIENT-TX-01 R3(b)
-// rejects non-literal forms (fmt.Sprintf, concatenation, variables).
-//
-// It is not cross-checked against any catalog at build time; it serves as
-// source-level documentation. Reviewers verify the corresponding ADR
-// rationale exists.
-//
-// Note: an empty string "" satisfies the const-literal check but violates
-// review policy; reviewers must reject meaningless reasons.
+// reason MUST be a *ast.BasicLit + token.STRING (a Go const string LITERAL
+// in source — not a const identifier, not "a" + "b" concatenation, not a
+// variable). The literal value must match the kebab-case regex
+// ^[a-z][a-z0-9-]+$ AND must not be a placeholder identifier (todo / fixme /
+// tbd / xxx / placeholder / wip). archtest PG-REPO-AMBIENT-TX-01 R3(b)
+// statically rejects every other form. The reason "is not cross-checked
+// against any catalog at build time; it serves as source-level documentation"
+// (sibling to pkg/panicregister.Approved); reviewers verify the corresponding
+// ADR rationale exists, and the placeholder/empty/non-kebab forms above are
+// rejected so the reason cannot be a meaningless audit-trail entry.
 //
 // ApprovedExecDirect is purely a source-level marker (no-op at runtime).
 // The archtest enforces that every ExecDirect call from a non-pgExecutor
 // receiver has a sibling ApprovedExecDirect(literal) call in the same
-// FuncDecl body.
+// approval scope.
 //
 // Hard funnel rationale: this is the unique allowlist mechanism for
 // ExecDirect callsites in GoCell production code. The form-uniqueness
-// (callee = pgrepoapproved.ApprovedExecDirect, arg[0] = const literal) plus
-// the same-body co-location check make any other shape — missing marker,
-// different callee, non-literal reason, marker in a different function —
+// (callee = pgrepoapproved.ApprovedExecDirect, arg[0] = kebab-case BasicLit,
+// non-placeholder) plus the same-scope co-location check make any other
+// shape — missing marker, different callee, non-literal reason, const ident /
+// concat / empty / placeholder reason, marker in a different func/closure —
 // fail archtest immediately. See .claude/rules/gocell/ai-robust.md
 // "Hard 范本目录" §"typed marker funnel for unbounded ops".
 func ApprovedExecDirect(reason string) {

--- a/pkg/pgrepoapproved/pgrepoapproved.go
+++ b/pkg/pgrepoapproved/pgrepoapproved.go
@@ -1,0 +1,38 @@
+// Package pgrepoapproved provides the only approved way to call
+// pgExecutor.ExecDirect from a PG repo/store method. Every legitimate
+// ExecDirect callsite in a *_repo.go / *_store.go file MUST contain a
+// pgrepoapproved.ApprovedExecDirect(reason) marker in the same FuncDecl body
+// before invoking ExecDirect. This creates a typed funnel that archtest
+// PG-REPO-AMBIENT-TX-01 R3(b) statically verifies: any ExecDirect call
+// without a same-body marker, or with a non-literal reason, is rejected.
+// See .claude/rules/gocell/ai-robust.md "Hard 范本" (typed marker funnel
+// for unbounded ops) for the pattern; this is the sibling deployment of
+// pkg/panicregister applied to ExecDirect.
+package pgrepoapproved
+
+// ApprovedExecDirect tags the enclosing repo/store function as an
+// ADR-approved caller of pgExecutor.ExecDirect (which bypasses the ambient
+// transaction).
+//
+// reason MUST be a const string literal (kebab-case identifier like
+// "revoke-session-cascade") that documents the ADR-explicit rationale for
+// bypassing the ambient transaction. archtest PG-REPO-AMBIENT-TX-01 R3(b)
+// rejects non-literal forms (fmt.Sprintf, concatenation, variables).
+//
+// ApprovedExecDirect is purely a source-level marker (no-op at runtime).
+// The archtest enforces that every ExecDirect call from a non-pgExecutor
+// receiver has a sibling ApprovedExecDirect(literal) call in the same
+// FuncDecl body. Adding the marker without the corresponding ADR rationale
+// is a review violation; the marker's reason argument MUST cite an existing
+// ADR section.
+//
+// Hard funnel rationale: this is the unique allowlist mechanism for
+// ExecDirect callsites in GoCell production code. The form-uniqueness
+// (callee = pgrepoapproved.ApprovedExecDirect, arg[0] = const literal) plus
+// the same-body co-location check make any other shape — missing marker,
+// different callee, non-literal reason, marker in a different function —
+// fail archtest immediately. See .claude/rules/gocell/ai-robust.md
+// "Hard 范本目录" §"typed marker funnel for unbounded ops".
+func ApprovedExecDirect(reason string) {
+	_ = reason
+}

--- a/pkg/pgrepoapproved/pgrepoapproved_test.go
+++ b/pkg/pgrepoapproved/pgrepoapproved_test.go
@@ -1,0 +1,30 @@
+package pgrepoapproved_test
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/pgrepoapproved"
+)
+
+// TestApprovedExecDirect_NoOp documents that the marker is a runtime no-op:
+// the function accepts any string reason and returns nothing. All meaningful
+// enforcement is performed statically by archtest PG-REPO-AMBIENT-TX-01 R3(b)
+// via *types.Info resolution — the marker's only runtime responsibility is to
+// be a valid call expression that compiles. This test exists to (1) document
+// the contract, (2) keep the package non-empty for coverage tooling, and
+// (3) catch a future regression where someone accidentally adds runtime
+// behavior (logging, side effects, panic) that would change call-site cost
+// expectations.
+func TestApprovedExecDirect_NoOp(t *testing.T) {
+	// All reasons are equally accepted — the function has no validation of
+	// reason content; that validation lives in the archtest (const-literal
+	// check via TypeAndValue).
+	cases := []string{
+		"revoke-session-cascade",
+		"some-other-future-reason",
+		"",
+	}
+	for _, reason := range cases {
+		pgrepoapproved.ApprovedExecDirect(reason)
+	}
+}

--- a/pkg/pgrepoapproved/pgrepoapproved_test.go
+++ b/pkg/pgrepoapproved/pgrepoapproved_test.go
@@ -16,15 +16,14 @@ import (
 // behavior (logging, side effects, panic) that would change call-site cost
 // expectations.
 func TestApprovedExecDirect_NoOp(t *testing.T) {
-	// All reasons are equally accepted — the function has no validation of
-	// reason content; that validation lives in the archtest (const-literal
-	// check via TypeAndValue).
+	// At runtime ApprovedExecDirect is a pure no-op — any string is accepted
+	// without inspection. The static reason constraints (BasicLit + kebab regex
+	// + placeholder ban) live in the archtest layer (PG-REPO-AMBIENT-TX-01 R3(b)),
+	// not here. The values below are all valid kebab-case literals so this test
+	// documents only the runtime no-op contract.
 	cases := []string{
 		"revoke-session-cascade",
 		"some-other-future-reason",
-		// "" satisfies archtest const-literal check, but violates review policy per godoc —
-		// included here to document runtime no-op semantics only
-		"",
 	}
 	for _, reason := range cases {
 		pgrepoapproved.ApprovedExecDirect(reason)

--- a/pkg/pgrepoapproved/pgrepoapproved_test.go
+++ b/pkg/pgrepoapproved/pgrepoapproved_test.go
@@ -22,6 +22,8 @@ func TestApprovedExecDirect_NoOp(t *testing.T) {
 	cases := []string{
 		"revoke-session-cascade",
 		"some-other-future-reason",
+		// "" satisfies archtest const-literal check, but violates review policy per godoc —
+		// included here to document runtime no-op semantics only
 		"",
 	}
 	for _, reason := range cases {

--- a/tools/archtest/internal/pgrepoambienttxfixture/fixture.go
+++ b/tools/archtest/internal/pgrepoambienttxfixture/fixture.go
@@ -27,22 +27,43 @@
 //
 // R3 — usage-point funnel: same-package repo/store methods must not access
 // pgExecutor's unexported pool field directly nor call pgExecutor.ExecDirect
-// outside the explicit callsite allowlist.
+// without a sibling pgrepoapproved.ApprovedExecDirect(<kebab-case-literal>)
+// marker in the SAME approval scope (FuncDecl/FuncLit body, not nested closure).
 //
 //   - badR3PoolDirect: a repo method that accesses r.db.pool directly.
 //     Must produce exactly one R3 diagnostic.
 //
-//   - badR3ExecDirect: a repo method that calls r.db.ExecDirect outside the
-//     allowlist. Must produce exactly one R3 diagnostic.
+//   - badR3ExecDirect: a repo method that calls r.db.ExecDirect without
+//     any marker. Must produce exactly one R3 diagnostic.
+//
+// F1 scope-bounded marker checks (PR #917 round-2):
+//
+//   - badR3MarkerInNestedClosure: marker in nested FuncLit cannot approve
+//     outer-scope ExecDirect. One R3 diagnostic at the outer call.
+//
+//   - badR3MarkerOuterExecInNestedClosure: outer-scope marker cannot approve
+//     ExecDirect inside a nested FuncLit. One R3 diagnostic at the inner call.
+//
+// F2 reason-form-uniqueness checks (PR #917 round-2):
+//
+//   - badR3ApprovedConstIdent: marker reason is a const identifier (rejected,
+//     must be *ast.BasicLit). One R3 diagnostic.
+//   - badR3ApprovedConcat: marker reason is "a" + "b" BinaryExpr (rejected).
+//     One R3 diagnostic.
+//   - badR3ApprovedEmpty: marker reason is "" (fails kebab regex). One R3.
+//   - badR3ApprovedPlaceholder: marker reason is "todo" (placeholder rejected).
+//     One R3 diagnostic.
 //
 // GREEN controls: NewGoodRepo takes *pgxpool.Pool and calls newPGExecutor,
 // goodExecMethod uses r.db.Exec (sanctioned), pgExecutor holds pool field.
 // goodApprovedSingleExecDirect holds a marker + 1 ExecDirect call (R3(b) GREEN).
 // goodApprovedMultiExecDirect holds 1 marker + 2 ExecDirect calls (R3(b) GREEN:
-// one marker covers all ExecDirect calls in the same body).
+// one marker covers all ExecDirect calls in the same scope).
 // Zero R1/R2/R3 diagnostics from all GREEN cases.
 //
-// Total expected diagnostics: 5 (one R1 + two R2 + two R3).
+// Total expected diagnostics: 11 (one R1 + two R2 + eight R3 — two for
+// pool-direct/ExecDirect-bare + two for F1 nested-closure + four for F2
+// reason form).
 package pgrepoambienttxfixture
 
 import (
@@ -143,4 +164,61 @@ func (r goodRepo) goodApprovedMultiExecDirect(ctx context.Context) {
 	pgrepoapproved.ApprovedExecDirect("fixture-green-multi")
 	r.db.ExecDirect(ctx, "SELECT 1")
 	r.db.ExecDirect(ctx, "SELECT 2")
+}
+
+// badR3MarkerInNestedClosure: marker placed inside a nested FuncLit cannot
+// approve an ExecDirect call in the outer FuncDecl scope. R3 must flag the
+// outer call (the outer scope has no marker after F1 scope-bounded fix).
+// (F1 in PR #917 round-2 review)
+func (r badR3Repo) badR3MarkerInNestedClosure(ctx context.Context) {
+	r.db.ExecDirect(ctx, "OUTER") // R3 violation: outer scope has no marker
+	_ = func() {
+		pgrepoapproved.ApprovedExecDirect("inner-marker-cannot-approve-outer")
+	}
+}
+
+// badR3MarkerOuterExecInNestedClosure: outer-scope marker cannot approve an
+// ExecDirect call inside a nested FuncLit scope. R3 must flag the inner call
+// (the nested closure is its own approval scope and has no marker).
+// (F1 in PR #917 round-2 review)
+func (r badR3Repo) badR3MarkerOuterExecInNestedClosure(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect("outer-marker-cannot-approve-inner")
+	_ = func() {
+		r.db.ExecDirect(ctx, "INNER") // R3 violation: closure scope has no marker
+	}
+}
+
+// badR3ApprovedConstIdent: marker reason is a const identifier (not a BasicLit).
+// F2 rule 2 requires *ast.BasicLit + token.STRING; an *ast.Ident is rejected.
+// (F2 in PR #917 round-2 review)
+const fixtureReasonConst = "kebab-from-const"
+
+func (r badR3Repo) badR3ApprovedConstIdent(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect(fixtureReasonConst) // F2: not a BasicLit
+	r.db.ExecDirect(ctx, "SELECT 1")                      // R3 violation: marker rejected
+}
+
+// badR3ApprovedConcat: marker reason is "a" + "b" — *ast.BinaryExpr at the AST
+// level, not *ast.BasicLit, so F2 rule 2 rejects it.
+// (F2 in PR #917 round-2 review)
+func (r badR3Repo) badR3ApprovedConcat(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect("ab-" + "cd-concat") // F2: BinaryExpr
+	r.db.ExecDirect(ctx, "SELECT 1")                       // R3 violation
+}
+
+// badR3ApprovedEmpty: empty-string reason fails the kebab-case regex (which
+// requires ^[a-z][a-z0-9-]+$ — length ≥ 2, leading lowercase letter).
+// (F2 in PR #917 round-2 review)
+func (r badR3Repo) badR3ApprovedEmpty(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect("") // F2: empty fails kebab regex
+	r.db.ExecDirect(ctx, "SELECT 1")      // R3 violation
+}
+
+// badR3ApprovedPlaceholder: placeholder identifier ("todo") is rejected by the
+// placeholder regex (todo/fixme/tbd/xxx/placeholder/wip) — meaningful reason
+// required for audit trail.
+// (F2 in PR #917 round-2 review)
+func (r badR3Repo) badR3ApprovedPlaceholder(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect("todo") // F2: placeholder rejected
+	r.db.ExecDirect(ctx, "SELECT 1")          // R3 violation
 }

--- a/tools/archtest/internal/pgrepoambienttxfixture/fixture.go
+++ b/tools/archtest/internal/pgrepoambienttxfixture/fixture.go
@@ -150,16 +150,17 @@ func (r badR3Repo) badR3ExecDirect(ctx context.Context) {
 }
 
 // goodApprovedSingleExecDirect is a GREEN R3(b) fixture: marker + single
-// ExecDirect in the same body. R3 must NOT flag this — marker presence covers
-// the call.
+// ExecDirect in the same approval scope (FuncDecl body, no nesting). R3
+// must NOT flag this — marker presence covers the call.
 func (r goodRepo) goodApprovedSingleExecDirect(ctx context.Context) {
 	pgrepoapproved.ApprovedExecDirect("fixture-green-single")
 	r.db.ExecDirect(ctx, "SELECT 1")
 }
 
 // goodApprovedMultiExecDirect is a GREEN R3(b) fixture: one marker covers
-// multiple ExecDirect calls in the same body. R3 must NOT flag either call —
-// a single marker suffices for all ExecDirect calls within the same FuncDecl.
+// multiple ExecDirect calls in the same approval scope. R3 must NOT flag
+// either call — a single marker suffices for all ExecDirect calls within
+// the same FuncDecl/FuncLit body.
 func (r goodRepo) goodApprovedMultiExecDirect(ctx context.Context) {
 	pgrepoapproved.ApprovedExecDirect("fixture-green-multi")
 	r.db.ExecDirect(ctx, "SELECT 1")

--- a/tools/archtest/internal/pgrepoambienttxfixture/fixture.go
+++ b/tools/archtest/internal/pgrepoambienttxfixture/fixture.go
@@ -35,9 +35,12 @@
 //   - badR3ExecDirect: a repo method that calls r.db.ExecDirect outside the
 //     allowlist. Must produce exactly one R3 diagnostic.
 //
-// GREEN control: NewGoodRepo takes *pgxpool.Pool and calls newPGExecutor,
+// GREEN controls: NewGoodRepo takes *pgxpool.Pool and calls newPGExecutor,
 // goodExecMethod uses r.db.Exec (sanctioned), pgExecutor holds pool field.
-// Zero R1/R2/R3 diagnostics from GREEN cases.
+// goodApprovedSingleExecDirect holds a marker + 1 ExecDirect call (R3(b) GREEN).
+// goodApprovedMultiExecDirect holds 1 marker + 2 ExecDirect calls (R3(b) GREEN:
+// one marker covers all ExecDirect calls in the same body).
+// Zero R1/R2/R3 diagnostics from all GREEN cases.
 //
 // Total expected diagnostics: 5 (one R1 + two R2 + two R3).
 package pgrepoambienttxfixture
@@ -46,6 +49,8 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ghbvf/gocell/pkg/pgrepoapproved"
 )
 
 // pgExecutor is the ONE sanctioned struct allowed to hold *pgxpool.Pool.
@@ -121,4 +126,21 @@ func (r badR3Repo) badR3PoolDirect(ctx context.Context) {
 // allowlist. R3 must flag this.
 func (r badR3Repo) badR3ExecDirect(ctx context.Context) {
 	r.db.ExecDirect(ctx, "SELECT 1") // R3 violation: ExecDirect outside allowlist
+}
+
+// goodApprovedSingleExecDirect is a GREEN R3(b) fixture: marker + single
+// ExecDirect in the same body. R3 must NOT flag this — marker presence covers
+// the call.
+func (r goodRepo) goodApprovedSingleExecDirect(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect("fixture-green-single")
+	r.db.ExecDirect(ctx, "SELECT 1")
+}
+
+// goodApprovedMultiExecDirect is a GREEN R3(b) fixture: one marker covers
+// multiple ExecDirect calls in the same body. R3 must NOT flag either call —
+// a single marker suffices for all ExecDirect calls within the same FuncDecl.
+func (r goodRepo) goodApprovedMultiExecDirect(ctx context.Context) {
+	pgrepoapproved.ApprovedExecDirect("fixture-green-multi")
+	r.db.ExecDirect(ctx, "SELECT 1")
+	r.db.ExecDirect(ctx, "SELECT 2")
 }

--- a/tools/archtest/pg_repo_ambient_tx_test.go
+++ b/tools/archtest/pg_repo_ambient_tx_test.go
@@ -180,11 +180,12 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
-	"go/constant"
 	"go/token"
 	"go/types"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -217,6 +218,36 @@ var (
 	pgAdapterPackagesCache []string
 )
 
+// pgrepoApprovedReasonFormat is the required format for the reason argument to
+// pgrepoapproved.ApprovedExecDirect: kebab-case identifier (lowercase letters,
+// digits, hyphens; starting with lowercase letter; length ≥ 2). Snake_case,
+// PascalCase, single-char, and leading-hyphen strings all fail. Aligned with
+// panicregister precedent (panic_invariants_test.go::panicRegisteredReasonFormat).
+var pgrepoApprovedReasonFormat = regexp.MustCompile(`^[a-z][a-z0-9-]+$`)
+
+// pgrepoApprovedReasonPlaceholder matches reason literals that are placeholder
+// identifiers (todo / fixme / tbd / xxx / placeholder / wip) optionally followed
+// by a hyphen and more text. Rejected because they provide no descriptive
+// information about the bypass site. Aligned with panicregister precedent.
+var pgrepoApprovedReasonPlaceholder = regexp.MustCompile(`^(todo|fixme|tbd|xxx|placeholder|wip)(-|$)`)
+
+// inspectStopAtFuncLit walks body's AST invoking visit on every non-FuncLit
+// node, but stops descending at *ast.FuncLit boundaries. R3 uses this to bound
+// the "approval scope" to a single FuncDecl/FuncLit body — markers and
+// ExecDirect calls must co-locate in the SAME scope, not the entire subtree.
+// Without this scope bound, a marker in a nested closure could batch-approve
+// outer-scope ExecDirect calls (and vice versa), defeating the audit-trail
+// intent. See F1 in PR #917 round-2 review.
+func inspectStopAtFuncLit(body ast.Node, visit func(ast.Node)) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		visit(n)
+		return true
+	})
+}
+
 // discoverPGAdapterPackages auto-discovers all production packages that
 // declare a package-local type named pgExecutor. The discovery signal replaces
 // the former hand-maintained pgRepoPackagePatterns list: a package is in
@@ -245,7 +276,22 @@ func discoverPGAdapterPackages(t *testing.T) []string {
 			if p.Pkg == nil || p.Pkg.Scope() == nil {
 				return nil
 			}
-			if p.Pkg.Scope().Lookup(pgExecutorName) == nil {
+			obj := p.Pkg.Scope().Lookup(pgExecutorName)
+			if obj == nil {
+				return nil
+			}
+			// F3 (PR #917 round-2): require obj to be a *types.TypeName whose
+			// type is a named struct. A var/const/func/alias named pgExecutor
+			// does not declare the funnel and must not put the package in scope.
+			tn, ok := obj.(*types.TypeName)
+			if !ok {
+				return nil
+			}
+			named, ok := tn.Type().(*types.Named)
+			if !ok {
+				return nil
+			}
+			if _, ok := named.Underlying().(*types.Struct); !ok {
 				return nil
 			}
 			paths = append(paths, p.Pkg.Path())
@@ -453,7 +499,9 @@ func scanR2PoolParams(fset *token.FileSet, file *ast.File, rel string, info *typ
 
 // scanR3UsagePoints implements R3: repo/store methods must not access
 // pgExecutor.pool directly nor call pgExecutor.ExecDirect without a sibling
-// pgrepoapproved.ApprovedExecDirect(literal) marker in the same FuncDecl body.
+// pgrepoapproved.ApprovedExecDirect(literal) marker in the SAME approval
+// scope (= same FuncDecl body OR same FuncLit body — nested closures are
+// independent scopes).
 //
 // pkgPath is the import path of the package being scanned and is used to verify
 // that the resolved pgExecutor type belongs to this same package (package-local
@@ -466,16 +514,17 @@ func scanR2PoolParams(fset *token.FileSet, file *ast.File, rel string, info *typ
 // (via *types.Info.Types) resolves to pgExecutor. Exempt: pgExecutor's own
 // methods (receiver type == pgExecutor); newPGExecutor.
 //
-// (b) ExecDirect call without same-body marker: any CallExpr
+// (b) ExecDirect call without same-scope marker: any CallExpr
 // `<x>.ExecDirect(...)` where <x> resolves to pgExecutor is rejected unless
-// the same FuncDecl body contains a CallExpr resolving to
-// pkg/pgrepoapproved.ApprovedExecDirect whose first argument is a const string
-// literal. The marker presence elevates the former hand-maintained string
-// allowlist to a Hard typed marker funnel — see ADR
-// docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md.
-// Exempt: pgExecutor's own methods.
+// the SAME approval scope contains a CallExpr resolving to
+// pkg/pgrepoapproved.ApprovedExecDirect whose first argument is a kebab-case
+// const string literal. See bodyHasApprovedExecDirectMarker godoc for the full
+// form-uniqueness chain. Exempt: pgExecutor's own methods.
 //
-// Cognitive complexity: split into two sub-helpers to stay ≤15.
+// Approval scope handling (F1 in PR #917 round-2 review): we visit each
+// FuncDecl body once, then recursively visit every nested *ast.FuncLit body
+// as its own independent scope. inspectStopAtFuncLit bounds each per-scope
+// scan so a marker in scope X cannot approve ExecDirect calls in scope Y.
 func scanR3UsagePoints(fset *token.FileSet, file *ast.File, rel string, info *types.Info, pkgPath string) []Diagnostic {
 	var diags []Diagnostic
 	EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
@@ -490,17 +539,35 @@ func scanR3UsagePoints(fset *token.FileSet, file *ast.File, rel string, info *ty
 		if fn.Body == nil {
 			return
 		}
+		// Scope 1: the FuncDecl body itself.
 		diags = append(diags, scanR3PoolAccess(fset, fn.Body, rel, info, pkgPath)...)
 		diags = append(diags, scanR3ExecDirect(fset, fn.Body, rel, info, pkgPath)...)
+		// Scope 2..N: every nested FuncLit body inside this FuncDecl is its
+		// own independent approval scope. Use EachInSubtree on the unmodified
+		// body to find FuncLits; the per-scope helpers themselves stop at
+		// FuncLit boundaries via inspectStopAtFuncLit, so they only see the
+		// scope-local AST of whichever body they are called on.
+		EachInSubtree[ast.FuncLit](fn.Body, func(fl *ast.FuncLit) {
+			if fl.Body == nil {
+				return
+			}
+			diags = append(diags, scanR3PoolAccess(fset, fl.Body, rel, info, pkgPath)...)
+			diags = append(diags, scanR3ExecDirect(fset, fl.Body, rel, info, pkgPath)...)
+		})
 	})
 	return diags
 }
 
 // scanR3PoolAccess flags SelectorExpr `<x>.pool` where <x> resolves to the
-// package-local pgExecutor type.
+// package-local pgExecutor type. Scope-bounded: walk stops at nested FuncLit
+// boundaries (each FuncLit is scanned separately by scanR3UsagePoints).
 func scanR3PoolAccess(fset *token.FileSet, body *ast.BlockStmt, rel string, info *types.Info, pkgPath string) []Diagnostic {
 	var diags []Diagnostic
-	EachInSubtree[ast.SelectorExpr](body, func(sel *ast.SelectorExpr) {
+	inspectStopAtFuncLit(body, func(n ast.Node) {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
 		if sel.Sel.Name != poolFieldName {
 			return
 		}
@@ -550,7 +617,11 @@ func scanR3ExecDirect(
 		return nil
 	}
 	var diags []Diagnostic
-	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+	inspectStopAtFuncLit(body, func(n ast.Node) {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return
+		}
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if !ok {
 			return
@@ -566,8 +637,9 @@ func scanR3ExecDirect(
 			Rel:  rel,
 			Line: line,
 			Message: "R3: pgExecutor.ExecDirect call requires sibling " +
-				"pgrepoapproved.ApprovedExecDirect(<const-literal>) marker in the same " +
-				"FuncDecl body to document the ADR-approved bypass of ambient tx; " +
+				"pgrepoapproved.ApprovedExecDirect(<kebab-case-literal>) marker in the same " +
+				"approval scope (FuncDecl/FuncLit body, not nested closure) to document the " +
+				"ADR-approved bypass of ambient tx; " +
 				"add 'pgrepoapproved.ApprovedExecDirect(\"your-adr-reason\")' before the " +
 				"ExecDirect call; see pkg/pgrepoapproved and ADR " +
 				"docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md",
@@ -578,22 +650,38 @@ func scanR3ExecDirect(
 
 // bodyHasApprovedExecDirectMarker reports whether body contains a CallExpr
 // whose callee resolves to pkg/pgrepoapproved.ApprovedExecDirect AND whose
-// first argument is a string-typed constant (const literal). Non-literal
-// reason arguments (fmt.Sprintf, concatenation, variable references) are
-// rejected so that the marker's audit-trail rationale cannot be hidden behind
-// runtime expressions.
+// first argument is a kebab-case const string literal. Form-uniqueness chain
+// (each rule a separate REJECT branch):
 //
-// Order is not enforced: marker may appear before, after, or between ExecDirect
-// calls — convention is before for readability, but archtest only checks
-// same-body co-location, not relative order.
+//  1. callee resolves via *types.Info.Uses to *types.Func with name
+//     "ApprovedExecDirect" AND Pkg().Path() == pkg/pgrepoapproved
+//  2. arg[0] is a *ast.BasicLit with Kind == token.STRING (rejects const
+//     identifiers, constant-folded "a"+"b" concatenation, variable references,
+//     fmt.Sprintf, and anything else that would erase the source-level reason)
+//  3. strconv.Unquote(arg[0]) matches pgrepoApprovedReasonFormat
+//     (^[a-z][a-z0-9-]+$ — kebab-case identifier, length ≥ 2)
+//  4. unquoted value is NOT a placeholder identifier (todo/fixme/tbd/xxx/
+//     placeholder/wip per pgrepoApprovedReasonPlaceholder)
 //
-// One marker covers all ExecDirect calls in the same body — multiple ExecDirect
-// calls do not require multiple markers. A single ApprovedExecDirect call
-// satisfies the check for all ExecDirect calls in that FuncDecl body.
+// Scope bound (F1 in PR #917 round-2 review): scan stops at *ast.FuncLit
+// boundaries via inspectStopAtFuncLit. A marker in a nested closure does NOT
+// approve outer-scope ExecDirect calls; conversely, an outer-scope marker does
+// NOT approve ExecDirect calls inside nested closures. Each FuncDecl /
+// FuncLit body is an independent approval scope (handled by scanR3UsagePoints
+// recursing into FuncLits with this same per-scope check).
+//
+// Order is not enforced: marker may appear before, after, or between
+// ExecDirect calls in the same scope — convention is before for readability.
+// One marker satisfies the check for all ExecDirect calls in the same scope;
+// multiple markers in one scope are allowed (harmless redundancy).
 func bodyHasApprovedExecDirectMarker(body *ast.BlockStmt, info *types.Info) bool {
 	found := false
-	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+	inspectStopAtFuncLit(body, func(n ast.Node) {
 		if found {
+			return
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
 			return
 		}
 		fn := resolveCalleeFunc(call.Fun, info)
@@ -606,8 +694,18 @@ func bodyHasApprovedExecDirectMarker(body *ast.BlockStmt, info *types.Info) bool
 		if len(call.Args) == 0 {
 			return
 		}
-		tv, ok := info.Types[call.Args[0]]
-		if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
+		// F2 rule 2: arg[0] must be a *ast.BasicLit + token.STRING.
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return
+		}
+		// F2 rule 3: kebab-case format.
+		val, err := strconv.Unquote(lit.Value)
+		if err != nil || !pgrepoApprovedReasonFormat.MatchString(val) {
+			return
+		}
+		// F2 rule 4: not a placeholder identifier.
+		if pgrepoApprovedReasonPlaceholder.MatchString(val) {
 			return
 		}
 		found = true
@@ -790,19 +888,33 @@ type fixtureViolation struct {
 // test because the set sizes must match AND every actual entry must be in the
 // expected set.
 var expectedFixtureViolations = []fixtureViolation{
-	// R1: badR1Repo — struct field pool *pgxpool.Pool type position at line 93 of fixture.go
-	{"R1:", 93},
-	// R2: badR2NonNew — non-New* func with *pgxpool.Pool param, func name at line 98
-	{"R2:", 98},
-	// R2: NewBadR2NoWrap — New* func without newPGExecutor call, func name at line 104
-	{"R2:", 104},
-	// R3: badR3PoolDirect — r.db.pool direct access selector at line 122
-	{"R3:", 122},
-	// R3: badR3ExecDirect — r.db.ExecDirect call without sibling marker at line 128
-	{"R3:", 128},
+	// R1: badR1Repo — struct field pool *pgxpool.Pool type position at line 114
+	{"R1:", 114},
+	// R2: badR2NonNew — non-New* func with *pgxpool.Pool param, func name at line 119
+	{"R2:", 119},
+	// R2: NewBadR2NoWrap — New* func without newPGExecutor call, func name at line 125
+	{"R2:", 125},
+	// R3: badR3PoolDirect — r.db.pool direct access selector at line 143
+	{"R3:", 143},
+	// R3: badR3ExecDirect — r.db.ExecDirect call without sibling marker at line 149
+	{"R3:", 149},
+	// F1 RED (PR #917 round-2):
+	// R3: badR3MarkerInNestedClosure — outer ExecDirect, marker in nested closure at line 174
+	{"R3:", 174},
+	// R3: badR3MarkerOuterExecInNestedClosure — inner ExecDirect, marker in outer scope at line 187
+	{"R3:", 187},
+	// F2 RED (PR #917 round-2):
+	// R3: badR3ApprovedConstIdent — marker reason is const ident (not BasicLit), at line 198
+	{"R3:", 198},
+	// R3: badR3ApprovedConcat — marker reason is "a"+"b" BinaryExpr at line 206
+	{"R3:", 206},
+	// R3: badR3ApprovedEmpty — marker reason is "" (fails kebab regex) at line 214
+	{"R3:", 214},
+	// R3: badR3ApprovedPlaceholder — marker reason is "todo" (placeholder) at line 223
+	{"R3:", 223},
 }
 
-// TestPGRepoAmbientTx_RedFixtureDetected asserts the rule catches all five
+// TestPGRepoAmbientTx_RedFixtureDetected asserts the rule catches all eleven
 // RED violations in internal/pgrepoambienttxfixture:
 //
 //   - 1 R1: badR1Repo holds *pgxpool.Pool (not named pgExecutor)
@@ -810,6 +922,18 @@ var expectedFixtureViolations = []fixtureViolation{
 //   - 1 R2: NewBadR2NoWrap is a New* function with *pgxpool.Pool param but no newPGExecutor call
 //   - 1 R3: badR3PoolDirect accesses r.db.pool directly
 //   - 1 R3: badR3ExecDirect calls r.db.ExecDirect without sibling pgrepoapproved.ApprovedExecDirect marker
+//
+// F1 scope-bounded marker checks (PR #917 round-2):
+//
+//   - 1 R3: badR3MarkerInNestedClosure — outer ExecDirect, marker in nested closure
+//   - 1 R3: badR3MarkerOuterExecInNestedClosure — outer marker, inner ExecDirect in closure
+//
+// F2 reason form-uniqueness checks (PR #917 round-2):
+//
+//   - 1 R3: badR3ApprovedConstIdent — marker reason is *ast.Ident, not BasicLit
+//   - 1 R3: badR3ApprovedConcat — marker reason is "a"+"b" *ast.BinaryExpr
+//   - 1 R3: badR3ApprovedEmpty — marker reason "" fails kebab regex (len ≥ 2)
+//   - 1 R3: badR3ApprovedPlaceholder — marker reason "todo" matches placeholder regex
 //
 // GREEN cases (pgExecutor field, goodNewFoo→newPGExecutor, goodExecMethod using
 // r.db.Exec, goodApprovedSingleExecDirect with marker+1 ExecDirect,
@@ -1149,38 +1273,56 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 				continue
 			}
 			rel := p.Rel(file)
-			EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
-				if fn.Body == nil {
+			// Visit every approval scope (FuncDecl body + every nested FuncLit
+			// body); for each scope holding a marker, require a same-scope
+			// pgExecutor.ExecDirect call. This mirrors the F1 scope-bound
+			// fix in scanR3UsagePoints — marker and ExecDirect must co-locate
+			// in the SAME approval scope, so spurious-marker detection must
+			// also be scope-bounded.
+			visitScope := func(body *ast.BlockStmt, label string, pos token.Pos) {
+				if body == nil {
 					return
 				}
-				if !bodyHasApprovedExecDirectMarker(fn.Body, p.TypesInfo) {
+				if !bodyHasApprovedExecDirectMarker(body, p.TypesInfo) {
 					return
 				}
-				if !bodyCallsPGExecutorExecDirect(fn.Body, p.TypesInfo, pkgPath) {
+				if !bodyCallsPGExecutorExecDirect(body, p.TypesInfo, pkgPath) {
 					bs8Violations = append(bs8Violations, fmt.Sprintf(
-						"%s:%d: func %s has pgrepoapproved.ApprovedExecDirect marker but "+
-							"no pgExecutor.ExecDirect call in same body — marker is a spurious "+
-							"audit-trail entry; remove it or add the corresponding ExecDirect call",
-						rel, p.Fset.Position(fn.Pos()).Line, fn.Name.Name,
+						"%s:%d: %s has pgrepoapproved.ApprovedExecDirect marker but "+
+							"no pgExecutor.ExecDirect call in same approval scope — marker is "+
+							"a spurious audit-trail entry; remove it or add the corresponding "+
+							"ExecDirect call",
+						rel, p.Fset.Position(pos).Line, label,
 					))
 				}
+			}
+			EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+				visitScope(fn.Body, "func "+fn.Name.Name, fn.Pos())
+				EachInSubtree[ast.FuncLit](fn.Body, func(fl *ast.FuncLit) {
+					visitScope(fl.Body, "nested closure in "+fn.Name.Name, fl.Pos())
+				})
 			})
 		}
 		return nil
 	})
 	assert.Empty(t, bs8Violations,
 		"BS-8 self-check: pgrepoapproved.ApprovedExecDirect marker must only co-locate with "+
-			"an actual pgExecutor.ExecDirect call in the same FuncDecl body")
+			"an actual pgExecutor.ExecDirect call in the SAME approval scope (FuncDecl/FuncLit body)")
 }
 
 // bodyCallsPGExecutorExecDirect reports whether body contains a CallExpr
 // `<x>.ExecDirect(...)` whose receiver `<x>` resolves via *types.Info.Types to
-// the package-local pgExecutor named type. Used by BS-8 to anchor marker
-// presence to a real ExecDirect callsite.
+// the package-local pgExecutor named type. Scope-bounded: walk stops at nested
+// FuncLit boundaries so the marker/ExecDirect co-location check mirrors the
+// per-scope approval semantics of scanR3ExecDirect.
 func bodyCallsPGExecutorExecDirect(body *ast.BlockStmt, info *types.Info, pkgPath string) bool {
 	found := false
-	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+	inspectStopAtFuncLit(body, func(n ast.Node) {
 		if found {
+			return
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
 			return
 		}
 		sel, ok := call.Fun.(*ast.SelectorExpr)
@@ -1234,20 +1376,32 @@ func TestPGRepoAmbientTx_DiscoveryCoverage(t *testing.T) {
 	for _, p := range got {
 		gotSet[p] = struct{}{}
 	}
+	// F4 (PR #917 round-2): collect both sides into sorted slices before
+	// reporting so CI output is deterministic across runs (Go map iteration
+	// is randomized).
+	var missing, extra []string
 	for p := range expectedSet {
 		if _, ok := gotSet[p]; !ok {
-			t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: expected package %q "+
-				"not discovered — was pgExecutor renamed/moved out of package scope?", p)
+			missing = append(missing, p)
 		}
 	}
 	for p := range gotSet {
 		if _, ok := expectedSet[p]; !ok {
-			t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: discovered new package %q "+
-				"not in expected set — if intentional, add it to expected; "+
-				"if accidental, this package declares pgExecutor unexpectedly; "+
-				"update the 'expected []string' slice in TestPGRepoAmbientTx_DiscoveryCoverage "+
-				"and bump expectedPGAdapterPackageMin to match", p)
+			extra = append(extra, p)
 		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	for _, p := range missing {
+		t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: expected package %q "+
+			"not discovered — was pgExecutor renamed/moved out of package scope?", p)
+	}
+	for _, p := range extra {
+		t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: discovered new package %q "+
+			"not in expected set — if intentional, add it to expected; "+
+			"if accidental, this package declares pgExecutor unexpectedly; "+
+			"update the 'expected []string' slice in TestPGRepoAmbientTx_DiscoveryCoverage "+
+			"and bump expectedPGAdapterPackageMin to match", p)
 	}
 }
 

--- a/tools/archtest/pg_repo_ambient_tx_test.go
+++ b/tools/archtest/pg_repo_ambient_tx_test.go
@@ -21,11 +21,26 @@
 //   - R3 (usage-point funnel): methods on repo/store structs that hold a
 //     pgExecutor field must NOT (a) access <x>.pool directly (where <x>
 //     resolves to pgExecutor type via *types.Info) nor (b) call
-//     <x>.ExecDirect(...) unless the callsite is on the static allowlist.
-//     The allowlist is keyed by (file, enclosing function name) and currently
-//     contains exactly one entry:
-//     "adapters/postgres/refresh_store.go::revokeSessionDetachedAt" — the
-//     intentional independent-commit cascade-revoke compensation path.
+//     <x>.ExecDirect(...) without a sibling pgrepoapproved.ApprovedExecDirect
+//     (const-literal-reason) marker call in the same FuncDecl body. The marker
+//     is a typed funnel from pkg/pgrepoapproved; (callee, arg) form-uniqueness
+//     plus same-body co-location pin the allowed bypass to its source location.
+//     Currently exactly one production callsite holds a marker:
+//     adapters/postgres/refresh_store.go::revokeSessionDetachedAt
+//     (the intentional independent-commit cascade-revoke compensation path).
+//
+// # Discovery
+//
+// The set of in-scope packages is auto-derived at test time by
+// discoverPGAdapterPackages: a production package is in scope iff its scope
+// declares a type named "pgExecutor". This replaces the former hand-maintained
+// pgRepoPackagePatterns list — a structural property the rule already relies
+// on becomes the discovery signal, so adding a new PG adapter package that
+// follows the pgExecutor convention is automatically covered, and renaming
+// pgExecutor out of scope is caught by TestPGRepoAmbientTx_DiscoveryCoverage.
+// Packages that use a different funnel pattern (e.g., configcore's
+// Session/DBTX) are correctly excluded; they require a separate archtest if
+// equivalent governance is desired.
 //
 // # AI-robust grading (Funnel 双向锁评级)
 //
@@ -37,12 +52,14 @@
 // compiler cannot block it. The ceiling is archtest-bound form-uniqueness (same
 // grade and precedent as PANIC-REGISTERED-01 / panic(panicregister.Approved)
 // per ai-robust.md §Hard 范本 #2 caveat). R1+R2 guard holding+construction;
-// R3 adds callsite caller-allowlist enforcement so that the only existing
-// legitimate bypass (revokeSessionDetachedAt) is statically pinned and any NEW
-// bypass immediately fails CI. This elevates upstream enforcement from doc-only
-// to archtest-enforced Medium (caller-allowlist form). Hard terminal state
-// remains: seal pgExecutor behind an exported interface + private construction
-// funnel making bypass unexpressible package-externally.
+// R3(a) pins pool field access; R3(b) elevates the former hand-maintained
+// string allowlist to a Hard typed marker funnel
+// (pkg/pgrepoapproved.ApprovedExecDirect — sibling deployment of
+// panicregister.Approved). Discovery itself moved from Soft hand-maintained
+// list to Medium type-aware auto-derivation in PR #502 (issue #823).
+// Hard terminal state for the upstream remains: seal pgExecutor behind an
+// exported interface + private construction funnel making bypass unexpressible
+// package-externally — tracked at gh issue #916 (PGEXECUTOR-SEAL-INTERFACE-01).
 //
 // 下游 Hard via form-uniqueness (archtest-bound), NOT compile-time:
 //
@@ -71,10 +88,13 @@
 //     (a) For pool access: any SelectorExpr `<x>.pool` where <x> resolves to
 //     pgExecutor and `.pool` is accessed from outside pgExecutor's own methods.
 //     (b) For ExecDirect calls: any CallExpr `<x>.ExecDirect(...)` where <x>
-//     resolves to pgExecutor, unless the enclosing function is on the static
-//     allowlist map[string]struct{} keyed by "file::funcname".
-//     Exempted: pgExecutor's own methods (they legitimately use e.pool /
-//     call ExecDirect on self); newPGExecutor constructor.
+//     resolves to pgExecutor, unless the same FuncDecl body contains a sibling
+//     CallExpr to pkg/pgrepoapproved.ApprovedExecDirect whose first argument is
+//     a string-typed constant (const literal). Callee identity and arg
+//     constness are both verified via *types.Info; no string anchors / no
+//     hand-maintained map. Exempted: pgExecutor's own methods (they
+//     legitimately use e.pool / call ExecDirect on self); newPGExecutor
+//     constructor.
 //
 // # RED fixtures
 //
@@ -122,11 +142,13 @@
 // in cells/accesscore/pg_bundle.go (package accesscore). NewPGBundle accepts
 // *pgxpool.Pool as a constructor parameter but the PGBundle struct does NOT
 // retain it — only derived primitives (userRepo / roleRepo / setupLock /
-// txRunner). cells/accesscore is intentionally excluded from
-// pgRepoPackagePatterns. Reverse self-check: TestPGRepoAmbientTx_SelfCheck
-// BS-5 now asserts no struct in cells/accesscore (outside pgExecutor and
-// internal/) carries *pgxpool.Pool as a field — function-signature usage in
-// NewPGBundle is permitted because it does not persist the pool.
+// txRunner). cells/accesscore is intentionally excluded from discovery: its
+// package scope does not declare pgExecutor, so discoverPGAdapterPackages
+// does not place it in scope. Reverse self-check:
+// TestPGRepoAmbientTx_SelfCheck BS-5 asserts no struct in cells/accesscore
+// (outside pgExecutor and internal/) carries *pgxpool.Pool as a field —
+// function-signature usage in NewPGBundle is permitted because it does not
+// persist the pool.
 //
 // BS-6 R3 method-value indirection: `var fn = s.db.ExecDirect; fn(ctx, sql)` —
 // R3's ExecDirect detection looks for a CallExpr whose Fun is a SelectorExpr with
@@ -145,11 +167,20 @@
 // Accepted: pool is an unexported field — the only way to capture it locally is
 // inside the same package; the repo has no such pattern. Covered by
 // TestPGRepoAmbientTx_SelfCheck BS-7 reverse self-check.
+//
+// BS-8 R3(b) spurious marker: pgrepoapproved.ApprovedExecDirect marker placed
+// in a FuncDecl body that does NOT actually call pgExecutor.ExecDirect — a
+// review hazard because it documents an ADR-approved bypass that never
+// happens, decaying the audit trail. R3(b) itself does not check this (it
+// only fires when ExecDirect is called without a marker). Covered by
+// TestPGRepoAmbientTx_SelfCheck BS-8: scans every production FuncDecl body
+// holding a marker and requires a co-located pgExecutor.ExecDirect call.
 package archtest
 
 import (
 	"fmt"
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"go/types"
 	"path/filepath"
@@ -158,72 +189,58 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 const (
-	pgxpoolImportPath = "github.com/jackc/pgx/v5/pgxpool"
-	pgxpoolTypeName   = "Pool"
-	pgExecutorName    = "pgExecutor"
-	newPGExecutorName = "newPGExecutor"
-	execDirectName    = "ExecDirect"
-	poolFieldName     = "pool"
+	pgxpoolImportPath           = "github.com/jackc/pgx/v5/pgxpool"
+	pgxpoolTypeName             = "Pool"
+	pgExecutorName              = "pgExecutor"
+	newPGExecutorName           = "newPGExecutor"
+	execDirectName              = "ExecDirect"
+	poolFieldName               = "pool"
+	approvedMarkerImportPath    = "github.com/ghbvf/gocell/pkg/pgrepoapproved"
+	approvedMarkerFuncName      = "ApprovedExecDirect"
+	expectedPGAdapterPackageMin = 3 // discovery coverage floor; see ADR §3.
 )
 
-// r3ExecDirectAllowlist is the static callsite allowlist for R3(b): the ONLY
-// production callsites permitted to call pgExecutor.ExecDirect from a
-// repo/store method. Keys are "relative-file::enclosing-func-name".
+// discoverPGAdapterPackages auto-discovers all production packages that
+// declare a package-local type named pgExecutor. The discovery signal replaces
+// the former hand-maintained pgRepoPackagePatterns list: a package is in
+// scope of PG-REPO-AMBIENT-TX-01 iff its package scope declares pgExecutor,
+// which is itself the structural funnel the rule already depends on.
 //
-// Current single allowlist entry:
+// Returned slice is the set of import paths (deduped, sorted) and is suitable
+// for direct use with RunTyped. Packages whose scope does not contain
+// pgExecutor (including configcore's Session/DBTX alternative funnel) are
+// intentionally excluded — they need a separate archtest if/when they want
+// equivalent governance.
 //
-//	adapters/postgres/refresh_store.go::revokeSessionDetachedAt
-//
-// This is the intentional independent-commit cascade-revoke compensation path
-// (security response that must commit independently of the ambient transaction).
-// See PGRefreshStore.revokeSessionDetachedAt godoc and ADR
-// docs/architecture/202605051800-adr-refresh-store-ambient-tx-and-idle-grace.md.
-//
-// Maintenance obligation: add a new entry ONLY when there is an ADR-explicit
-// rationale for bypassing the ambient transaction. Any new *_repo.go/*_store.go
-// method calling ExecDirect that is NOT here will fail CI immediately.
-var r3ExecDirectAllowlist = map[string]struct{}{
-	"adapters/postgres/refresh_store.go::revokeSessionDetachedAt": {},
-}
-
-// modulePathPrefix is the go.mod module path plus trailing slash. Trimming it
-// from a pgRepoPackagePatterns entry yields the module-relative package
-// directory, which is the form Pass.Rel() / Diagnostic.Rel use. Deriving the
-// production-scope predicate from this single source (see isProductionRepoPkg)
-// removes the former hand-maintained literal list that silently drifted out of
-// sync with pgRepoPackagePatterns (the iotdevice pattern was missing from it).
-const modulePathPrefix = "github.com/ghbvf/gocell/"
-
-// pgRepoPackagePatterns lists the import patterns whose production .go files
-// the archtest must parse with full TypesInfo. All three PG adapter packages
-// (adapters/postgres, the accesscore cell-private adapter, and the iotdevice
-// example cell-private adapter) are included since each declares a pgExecutor
-// and their repos are subject to the same funnel rule.
-//
-// Maintenance obligation: whenever a new PG adapter package is added to the
-// repo that declares its own pgExecutor struct and *_repo.go or *_store.go
-// files, this list MUST be extended to include that package. Omitting a package
-// silently zeroes R1/R2 coverage for all repos in that package — the companion
-// assertProductionCoverage guard only validates packages already listed here;
-// it cannot detect entirely missing packages.
-//
-// Note: cells/accesscore (the PGBundle host) is intentionally NOT in this
-// list — it is a composition-root bridge package, not a repo/store package.
-// NewPGBundle's *pgxpool.Pool function-signature usage is covered by the
-// BS-5 self-check, which asserts no struct in cells/accesscore (outside the
-// internal/ tree) carries *pgxpool.Pool as a field.
-var pgRepoPackagePatterns = []string{
-	"github.com/ghbvf/gocell/adapters/postgres",
-	"github.com/ghbvf/gocell/cells/accesscore/internal/adapters/postgres",
-	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/adapters/postgres",
+// See package godoc §Discovery and ADR
+// docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md.
+func discoverPGAdapterPackages(t *testing.T) []string {
+	t.Helper()
+	root := findModuleRoot(t)
+	var paths []string
+	_ = RunTyped(t, TypedOpts{Tests: false}, prodscan.Patterns(root), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Scope() == nil {
+			return nil
+		}
+		if p.Pkg.Scope().Lookup(pgExecutorName) == nil {
+			return nil
+		}
+		paths = append(paths, p.Pkg.Path())
+		return nil
+	})
+	sort.Strings(paths)
+	return paths
 }
 
 // TestPGRepoAmbientTx guards PG-REPO-AMBIENT-TX-01 against the production
-// packages. RED fixtures are exercised separately by
+// packages. Discovery is type-aware (see discoverPGAdapterPackages): the set
+// of in-scope packages is derived from "package scope declares pgExecutor",
+// not from a hand-maintained list. RED fixtures are exercised separately by
 // TestPGRepoAmbientTx_RedFixtureDetected. Blind-spot self-checks are in
 // TestPGRepoAmbientTx_SelfCheck.
 func TestPGRepoAmbientTx(t *testing.T) {
@@ -233,18 +250,20 @@ func TestPGRepoAmbientTx(t *testing.T) {
 			"(loads PG repo packages with TypesInfo, ~2-3s)")
 	}
 
-	diags := RunTyped(t, TypedOpts{}, pgRepoPackagePatterns, pgRepoAmbientTxRule)
+	packages := discoverPGAdapterPackages(t)
+	assert.GreaterOrEqual(t, len(packages), expectedPGAdapterPackageMin,
+		"PG-REPO-AMBIENT-TX-01 discovery coverage floor: expected at least %d packages "+
+			"declaring pgExecutor; got %d (%v). A refactor may have broken the discovery "+
+			"signal (e.g., renamed pgExecutor or moved its declaration out of package scope).",
+		expectedPGAdapterPackageMin, len(packages), packages)
+
+	diags := RunTyped(t, TypedOpts{}, packages, pgRepoAmbientTxRule)
 	sort.Slice(diags, func(i, j int) bool {
 		if diags[i].Rel != diags[j].Rel {
 			return diags[i].Rel < diags[j].Rel
 		}
 		return diags[i].Line < diags[j].Line
 	})
-
-	// Companion coverage guard: each package pattern must contribute at least
-	// one *_repo.go or *_store.go to the parsed set. A silent import-path drift
-	// would zero out the rule's coverage.
-	assertProductionCoverage(t)
 
 	for _, d := range diags {
 		t.Errorf("PG-REPO-AMBIENT-TX-01 %s:%d: %s", d.Rel, d.Line, d.Message)
@@ -255,29 +274,26 @@ func TestPGRepoAmbientTx(t *testing.T) {
 // Extracted so the same logic is exercised by both the production-package test
 // and the RED-fixture test.
 //
-// File scope: only *_repo.go and *_store.go files are checked. Infrastructure
+// File scope: in production packages (those whose package scope contains
+// pgExecutor), only *_repo.go and *_store.go files are checked. Infrastructure
 // files (pool.go, tx_manager.go, pg_executor.go, etc.) legitimately hold raw
-// *pgxpool.Pool fields and are intentionally out of scope. The fixture package
-// uses plain .go files without the _repo/_store suffix; the fixture filename
-// itself (fixture.go) is in scope for the fixture test by design — the rule
-// checks all files when no suffix filter applies to fixture packages. To keep
-// the production and fixture paths consistent, R1/R2 scans all files passed
-// via p.Files; the production test separately applies the filename-suffix
-// coverage guard via assertProductionCoverage.
+// *pgxpool.Pool fields and are intentionally out of scope. For fixture packages
+// (loaded under tools/archtest/internal/..., which prodscan.Patterns does not
+// reach), the rule checks all files so RED fixtures named fixture.go are still
+// detected — the production-vs-fixture distinction is structural: discovery
+// only ever hands production packages here, so the suffix filter is always
+// correct for them; fixture packages reach this function via RunTypedFixture
+// in a separate test path where no discovery filter applies.
 //
-// Infrastructure exemptions are applied via the isInfraFile predicate, which
-// excludes files that are NOT *_repo.go or *_store.go from the R1/R2 checks
-// in the production packages. For fixture packages (which don't follow the
-// _repo/_store naming), the rule applies to all files so the RED fixtures are
-// detected.
+// The production/fixture branch uses the same heuristic as discovery: a
+// production PG adapter package has its files under a directory whose go.mod
+// module-relative path is NOT below tools/archtest/internal/. We detect this
+// by looking at p.Rel(file) prefix: fixture rels start with "tools/archtest/"
+// while production rels start with cells/, adapters/, examples/, etc.
 func pgRepoAmbientTxRule(p *Pass) []Diagnostic {
 	if p.TypesInfo == nil || p.Fset == nil {
 		return nil
 	}
-	// pkgPath is the import path of the package being scanned. It is used by
-	// bodyCallsNewPGExecutorWith to assert that the resolved newPGExecutor callee
-	// belongs to this same package (package-local function), not a same-named
-	// function in a different package.
 	var pkgPath string
 	if p.Pkg != nil {
 		pkgPath = p.Pkg.Path()
@@ -286,14 +302,7 @@ func pgRepoAmbientTxRule(p *Pass) []Diagnostic {
 	for _, file := range p.Files {
 		rel := p.Rel(file)
 		base := filepath.Base(rel)
-		// In production packages, only check *_repo.go and *_store.go.
-		// Infrastructure files (pool.go, tx_manager.go, pg_executor.go, errors.go,
-		// etc.) legitimately need *pgxpool.Pool fields. Fixture files have no
-		// _repo/_store suffix but should still be checked for RED fixture coverage.
-		// The production-scope predicate is DERIVED from pgRepoPackagePatterns
-		// (single source) so adding a fourth PG adapter package cannot leave the
-		// suffix filter silently disabled for it.
-		if isProductionRepoPkg(rel) {
+		if !strings.HasPrefix(rel, "tools/archtest/") {
 			if !strings.HasSuffix(base, "_repo.go") && !strings.HasSuffix(base, "_store.go") {
 				continue
 			}
@@ -303,30 +312,6 @@ func pgRepoAmbientTxRule(p *Pass) []Diagnostic {
 		diags = append(diags, scanR3UsagePoints(p.Fset, file, rel, p.TypesInfo, pkgPath)...)
 	}
 	return diags
-}
-
-// isProductionRepoPkg reports whether the module-relative file path rel lives
-// in one of the production PG adapter packages listed in pgRepoPackagePatterns.
-// It is the single-source replacement for the former hand-maintained substring
-// disjunction; the iotdevice package pattern was absent from that literal list,
-// so its files escaped the *_repo.go/*_store.go suffix filter. Fixture packages
-// (loaded under a separate tools/archtest/internal/... pattern) are never under
-// these prefixes, so they correctly return false and remain fully scanned.
-//
-// rel is always a *.go file path (from Pass.Rel), never the package directory,
-// so only HasPrefix("<dir>/") matches — equality against a bare directory is
-// not a reachable case and intentionally not checked.
-func isProductionRepoPkg(rel string) bool {
-	for _, pattern := range pgRepoPackagePatterns {
-		relDir := strings.TrimPrefix(pattern, modulePathPrefix)
-		if relDir == pattern {
-			continue // not a module-local pattern; defensive, should not happen
-		}
-		if strings.HasPrefix(rel, relDir+"/") {
-			return true
-		}
-	}
-	return false
 }
 
 // scanR1PoolFields implements R1: every struct field whose type resolves to
@@ -437,7 +422,8 @@ func scanR2PoolParams(fset *token.FileSet, file *ast.File, rel string, info *typ
 }
 
 // scanR3UsagePoints implements R3: repo/store methods must not access
-// pgExecutor.pool directly nor call pgExecutor.ExecDirect outside the allowlist.
+// pgExecutor.pool directly nor call pgExecutor.ExecDirect without a sibling
+// pgrepoapproved.ApprovedExecDirect(literal) marker in the same FuncDecl body.
 //
 // pkgPath is the import path of the package being scanned and is used to verify
 // that the resolved pgExecutor type belongs to this same package (package-local
@@ -450,10 +436,14 @@ func scanR2PoolParams(fset *token.FileSet, file *ast.File, rel string, info *typ
 // (via *types.Info.Types) resolves to pgExecutor. Exempt: pgExecutor's own
 // methods (receiver type == pgExecutor); newPGExecutor.
 //
-// (b) ExecDirect call outside allowlist: any CallExpr `<x>.ExecDirect(...)` where
-// <x> resolves to pgExecutor, unless the enclosing FuncDecl's canonical key
-// "relative-file::func-name" is in r3ExecDirectAllowlist. Exempt: pgExecutor's
-// own methods.
+// (b) ExecDirect call without same-body marker: any CallExpr
+// `<x>.ExecDirect(...)` where <x> resolves to pgExecutor is rejected unless
+// the same FuncDecl body contains a CallExpr resolving to
+// pkg/pgrepoapproved.ApprovedExecDirect whose first argument is a const string
+// literal. The marker presence elevates the former hand-maintained string
+// allowlist to a Hard typed marker funnel — see ADR
+// docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md.
+// Exempt: pgExecutor's own methods.
 //
 // Cognitive complexity: split into two sub-helpers to stay ≤15.
 func scanR3UsagePoints(fset *token.FileSet, file *ast.File, rel string, info *types.Info, pkgPath string) []Diagnostic {
@@ -470,9 +460,8 @@ func scanR3UsagePoints(fset *token.FileSet, file *ast.File, rel string, info *ty
 		if fn.Body == nil {
 			return
 		}
-		enclosingKey := rel + "::" + fn.Name.Name
 		diags = append(diags, scanR3PoolAccess(fset, fn.Body, rel, info, pkgPath)...)
-		diags = append(diags, scanR3ExecDirect(fset, fn.Body, rel, info, pkgPath, enclosingKey)...)
+		diags = append(diags, scanR3ExecDirect(fset, fn.Body, rel, info, pkgPath)...)
 	})
 	return diags
 }
@@ -493,26 +482,39 @@ func scanR3PoolAccess(fset *token.FileSet, body *ast.BlockStmt, rel string, info
 			Rel:  rel,
 			Line: line,
 			Message: "R3: direct access to pgExecutor.pool field bypasses ambient-tx routing; " +
-				"use e.Exec/e.Query/e.QueryRow (or ExecDirect for allowlisted compensation paths)",
+				"use e.Exec/e.Query/e.QueryRow (or ExecDirect with sibling " +
+				"pgrepoapproved.ApprovedExecDirect marker for ADR-approved compensation paths)",
 		})
 	})
 	return diags
 }
 
 // scanR3ExecDirect flags CallExpr `<x>.ExecDirect(...)` where <x> resolves to
-// pgExecutor, unless enclosingKey is in r3ExecDirectAllowlist.
+// pgExecutor, unless the same FuncDecl body contains a sibling
+// pgrepoapproved.ApprovedExecDirect(literal) marker call. Marker form is
+// verified via (callee, arg) form-uniqueness:
+//
+//  1. callee resolves via *types.Info.Uses to the *types.Func for
+//     ApprovedExecDirect in pkg/pgrepoapproved (name + pkg path match);
+//  2. first argument's static type-and-value resolves via *types.Info.Types
+//     to a string constant (const literal) — fmt.Sprintf / concatenation /
+//     variables yield non-constant TypeAndValue and are rejected.
+//
+// The marker is checked once per FuncDecl body; the same marker covers every
+// ExecDirect call inside that body. Multiple markers in one body are not
+// rejected (they are harmless documentation), but archtest BS-8 reverse self-
+// check pins that only the sanctioned site holds a marker.
 func scanR3ExecDirect(
 	fset *token.FileSet,
 	body *ast.BlockStmt,
 	rel string,
 	info *types.Info,
 	pkgPath string,
-	enclosingKey string,
 ) []Diagnostic {
-	var diags []Diagnostic
-	if _, allowed := r3ExecDirectAllowlist[enclosingKey]; allowed {
+	if bodyHasApprovedExecDirectMarker(body, info) {
 		return nil
 	}
+	var diags []Diagnostic
 	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if !ok {
@@ -528,12 +530,44 @@ func scanR3ExecDirect(
 		diags = append(diags, Diagnostic{
 			Rel:  rel,
 			Line: line,
-			Message: "R3: pgExecutor.ExecDirect call outside the allowlist bypasses ambient-tx " +
-				"routing; only allowlisted compensation callsites may call ExecDirect " +
-				"(see r3ExecDirectAllowlist in pg_repo_ambient_tx_test.go)",
+			Message: "R3: pgExecutor.ExecDirect call requires sibling " +
+				"pgrepoapproved.ApprovedExecDirect(<const-literal>) marker in the same " +
+				"FuncDecl body to document the ADR-approved bypass of ambient tx; " +
+				"add the marker before the ExecDirect call (see pkg/pgrepoapproved)",
 		})
 	})
 	return diags
+}
+
+// bodyHasApprovedExecDirectMarker reports whether body contains a CallExpr
+// whose callee resolves to pkg/pgrepoapproved.ApprovedExecDirect AND whose
+// first argument is a string-typed constant (const literal). Non-literal
+// reason arguments (fmt.Sprintf, concatenation, variable references) are
+// rejected so that the marker's audit-trail rationale cannot be hidden behind
+// runtime expressions.
+func bodyHasApprovedExecDirectMarker(body *ast.BlockStmt, info *types.Info) bool {
+	found := false
+	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+		if found {
+			return
+		}
+		fn := resolveCalleeFunc(call.Fun, info)
+		if fn == nil || fn.Name() != approvedMarkerFuncName {
+			return
+		}
+		if fn.Pkg() == nil || fn.Pkg().Path() != approvedMarkerImportPath {
+			return
+		}
+		if len(call.Args) == 0 {
+			return
+		}
+		tv, ok := info.Types[call.Args[0]]
+		if !ok || tv.Value == nil || tv.Value.Kind() != constant.String {
+			return
+		}
+		found = true
+	})
+	return found
 }
 
 // isPgExecutorType reports whether expr's static type resolves to the
@@ -687,34 +721,6 @@ func isPgxPoolType(expr ast.Expr, info *types.Info) bool {
 	return obj.Pkg().Path() == pgxpoolImportPath && obj.Name() == pgxpoolTypeName
 }
 
-// assertProductionCoverage fails the test if any of the production package
-// patterns in pgRepoPackagePatterns did not yield at least one *_repo.go or
-// *_store.go file. This prevents a silent coverage zero-out caused by
-// import-path drift or package renaming.
-func assertProductionCoverage(t *testing.T) {
-	t.Helper()
-	if testing.Short() {
-		return
-	}
-	for _, pattern := range pgRepoPackagePatterns {
-		found := false
-		_ = RunTyped(t, TypedOpts{}, []string{pattern}, func(p *Pass) []Diagnostic {
-			for _, f := range p.Files {
-				base := filepath.Base(p.Rel(f))
-				if strings.HasSuffix(base, "_repo.go") || strings.HasSuffix(base, "_store.go") {
-					found = true
-				}
-			}
-			return nil
-		})
-		require.Truef(t, found,
-			"PG-REPO-AMBIENT-TX-01 coverage guard: no *_repo.go or *_store.go file found "+
-				"in package pattern %q — coverage zeroed out; "+
-				"check for package rename or import-path drift",
-			pattern)
-	}
-}
-
 // fixtureViolation is a (ruleID_prefix, line) pair identifying one expected
 // RED fixture diagnostic. The ruleID_prefix matches the start of Diagnostic.Message
 // ("R1:", "R2:", "R3:"). Line is the 1-based source line from the fixture file
@@ -747,7 +753,7 @@ var expectedFixtureViolations = []fixtureViolation{
 	{"R2:", 99},
 	// R3: badR3PoolDirect — r.db.pool direct access at line 117
 	{"R3:", 117},
-	// R3: badR3ExecDirect — r.db.ExecDirect outside allowlist at line 123
+	// R3: badR3ExecDirect — r.db.ExecDirect without sibling marker at line 123
 	{"R3:", 123},
 }
 
@@ -758,7 +764,7 @@ var expectedFixtureViolations = []fixtureViolation{
 //   - 1 R2: badR2NonNew is a non-New* function with *pgxpool.Pool param
 //   - 1 R2: NewBadR2NoWrap is a New* function with *pgxpool.Pool param but no newPGExecutor call
 //   - 1 R3: badR3PoolDirect accesses r.db.pool directly
-//   - 1 R3: badR3ExecDirect calls r.db.ExecDirect outside the allowlist
+//   - 1 R3: badR3ExecDirect calls r.db.ExecDirect without sibling pgrepoapproved.ApprovedExecDirect marker
 //
 // GREEN cases (pgExecutor field, goodNewFoo→newPGExecutor, goodExecMethod using
 // r.db.Exec) must produce zero diagnostics.
@@ -867,12 +873,14 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 		t.Skip("skipping SelfCheck in -short mode")
 	}
 
+	packages := discoverPGAdapterPackages(t)
+
 	// BS-1 reverse check: no embedded/anonymous struct field in any production
 	// package should transitively expose a *pgxpool.Pool outside pgExecutor.
 	// R1 only scans direct fields; this check verifies the accepted limitation
 	// does not silently hide a real violation in existing production code.
 	var bs1Violations []string
-	_ = RunTyped(t, TypedOpts{}, pgRepoPackagePatterns, func(p *Pass) []Diagnostic {
+	_ = RunTyped(t, TypedOpts{}, packages, func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
 		}
@@ -932,7 +940,7 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 	// This is strictly broader than the former AssignStmt-only scan and matches the
 	// godoc claim "asserts no function-value assignment from newPGExecutor".
 	var bs3Violations []string
-	_ = RunTyped(t, TypedOpts{}, pgRepoPackagePatterns, func(p *Pass) []Diagnostic {
+	_ = RunTyped(t, TypedOpts{}, packages, func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
 		}
@@ -956,7 +964,8 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 
 	// BS-5 reverse check: after Bundle funnel collapse (PR #595), no struct
 	// in cells/accesscore (outside the internal/ tree, intentionally NOT in
-	// pgRepoPackagePatterns) may carry *pgxpool.Pool as a field. NewPGBundle
+	// the discovered PG adapter set since cells/accesscore itself does not
+	// declare pgExecutor) may carry *pgxpool.Pool as a field. NewPGBundle
 	// accepts *pgxpool.Pool as a function parameter to derive repos/setupLock,
 	// but PGBundle itself stores only derived primitives — never the pool.
 	bs5Patterns := []string{"github.com/ghbvf/gocell/cells/accesscore"}
@@ -993,7 +1002,8 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 		"BS-5 self-check: no struct in cells/accesscore (outside the internal/ tree) "+
 			"may carry *pgxpool.Pool as a field — PGBundle must hold only derived "+
 			"primitives (userRepo/roleRepo/setupLock/txRunner). If a new struct "+
-			"legitimately needs to hold the pool, add it to pgRepoPackagePatterns instead.")
+			"legitimately needs to hold the pool, declare a package-local pgExecutor "+
+			"in that package so discovery auto-includes it.")
 
 	// BS-6 reverse check: ExecDirect must not appear as a method value (i.e., used
 	// as a value rather than directly called) in any production file. A method-value
@@ -1013,7 +1023,7 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 	// Check all files (not just _repo/_store) in the production packages to be
 	// conservative about the blind spot boundary.
 	var bs6Violations []string
-	_ = RunTyped(t, TypedOpts{}, pgRepoPackagePatterns, func(p *Pass) []Diagnostic {
+	_ = RunTyped(t, TypedOpts{}, packages, func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
 		}
@@ -1039,7 +1049,7 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 	// production repo/store file. An assignment like `p := s.db.pool` would let
 	// the caller bypass R3's pool-access detection on the subsequent p.Exec call.
 	var bs7Violations []string
-	_ = RunTyped(t, TypedOpts{}, pgRepoPackagePatterns, func(p *Pass) []Diagnostic {
+	_ = RunTyped(t, TypedOpts{}, packages, func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
 		}
@@ -1072,6 +1082,121 @@ func TestPGRepoAmbientTx_SelfCheck(t *testing.T) {
 	})
 	assert.Empty(t, bs7Violations,
 		"BS-7 self-check: pgExecutor.pool must not be assigned to a local variable in production")
+
+	// BS-8 reverse check: pgrepoapproved.ApprovedExecDirect markers must only
+	// appear in FuncDecl bodies that themselves contain a sibling
+	// pgExecutor.ExecDirect call. A spurious marker in any other body is a
+	// review violation — it documents an ADR-approved bypass that never
+	// happens, which decays the audit trail.
+	var bs8Violations []string
+	_ = RunTyped(t, TypedOpts{}, packages, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		pkgPath := ""
+		if p.Pkg != nil {
+			pkgPath = p.Pkg.Path()
+		}
+		for _, file := range p.Files {
+			if !p.IsFileInScope(file) {
+				continue
+			}
+			rel := p.Rel(file)
+			EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+				if fn.Body == nil {
+					return
+				}
+				if !bodyHasApprovedExecDirectMarker(fn.Body, p.TypesInfo) {
+					return
+				}
+				if !bodyCallsPGExecutorExecDirect(fn.Body, p.TypesInfo, pkgPath) {
+					bs8Violations = append(bs8Violations, fmt.Sprintf(
+						"%s:%d: func %s has pgrepoapproved.ApprovedExecDirect marker but "+
+							"no pgExecutor.ExecDirect call in same body — marker is a spurious "+
+							"audit-trail entry; remove it or add the corresponding ExecDirect call",
+						rel, p.Fset.Position(fn.Pos()).Line, fn.Name.Name,
+					))
+				}
+			})
+		}
+		return nil
+	})
+	assert.Empty(t, bs8Violations,
+		"BS-8 self-check: pgrepoapproved.ApprovedExecDirect marker must only co-locate with "+
+			"an actual pgExecutor.ExecDirect call in the same FuncDecl body")
+}
+
+// bodyCallsPGExecutorExecDirect reports whether body contains a CallExpr
+// `<x>.ExecDirect(...)` whose receiver `<x>` resolves via *types.Info.Types to
+// the package-local pgExecutor named type. Used by BS-8 to anchor marker
+// presence to a real ExecDirect callsite.
+func bodyCallsPGExecutorExecDirect(body *ast.BlockStmt, info *types.Info, pkgPath string) bool {
+	found := false
+	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+		if found {
+			return
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != execDirectName {
+			return
+		}
+		if isPgExecutorType(sel.X, info, pkgPath) {
+			found = true
+		}
+	})
+	return found
+}
+
+// TestPGRepoAmbientTx_DiscoveryCoverage asserts the auto-discovery returns the
+// expected set of PG adapter packages. Failure mode is a clear diff against
+// the named set, replacing the former silent zero-coverage failure mode where
+// a hand-maintained list could drop a package without any visible signal.
+//
+// The expected set is intentionally exhaustive (every currently-known PG
+// adapter package) so that:
+//   - removing pgExecutor from any existing package fails this test loudly
+//   - adding a new PG adapter package requires updating this expected set
+//     (the update is the same act as declaring the package in-scope, but in a
+//     visible diff rather than a silent omission)
+//
+// This is a Hard 范本 "single sanctioned holder" applied to discovery: the
+// discovery signal IS the funnel symbol (pgExecutor type declaration), so any
+// package that the rule must scan and any package whose scope contains
+// pgExecutor are the same set by construction.
+func TestPGRepoAmbientTx_DiscoveryCoverage(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based discovery coverage in -short mode")
+	}
+
+	expected := []string{
+		"github.com/ghbvf/gocell/adapters/postgres",
+		"github.com/ghbvf/gocell/cells/accesscore/internal/adapters/postgres",
+		"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/adapters/postgres",
+	}
+	got := discoverPGAdapterPackages(t)
+
+	expectedSet := make(map[string]struct{}, len(expected))
+	for _, p := range expected {
+		expectedSet[p] = struct{}{}
+	}
+	gotSet := make(map[string]struct{}, len(got))
+	for _, p := range got {
+		gotSet[p] = struct{}{}
+	}
+	for p := range expectedSet {
+		if _, ok := gotSet[p]; !ok {
+			t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: expected package %q "+
+				"not discovered — was pgExecutor renamed/moved out of package scope?", p)
+		}
+	}
+	for p := range gotSet {
+		if _, ok := expectedSet[p]; !ok {
+			t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: discovered new package %q "+
+				"not in expected set — if intentional, add it to expected; "+
+				"if accidental, this package declares pgExecutor unexpectedly", p)
+		}
+	}
 }
 
 // findNewPGExecutorValueUses returns violations for BS-3: any Ident in the file

--- a/tools/archtest/pg_repo_ambient_tx_test.go
+++ b/tools/archtest/pg_repo_ambient_tx_test.go
@@ -22,11 +22,13 @@
 //     pgExecutor field must NOT (a) access <x>.pool directly (where <x>
 //     resolves to pgExecutor type via *types.Info) nor (b) call
 //     <x>.ExecDirect(...) without a sibling pgrepoapproved.ApprovedExecDirect
-//     (const-literal-reason) marker call in the same FuncDecl body. The marker
-//     is a typed funnel from pkg/pgrepoapproved; (callee, arg) form-uniqueness
-//     plus same-body co-location pin the allowed bypass to its source location.
-//     Currently exactly one production callsite holds a marker:
-//     adapters/postgres/refresh_store.go::revokeSessionDetachedAt
+//     marker in the SAME approval scope (FuncDecl body OR nested FuncLit body
+//     — closures are independent scopes). The marker is a typed funnel from
+//     pkg/pgrepoapproved; 5-门 form-uniqueness (callee resolves to the funnel,
+//     arg[0] is *ast.BasicLit + token.STRING + kebab-case regex + non-
+//     placeholder) plus same-scope co-location pin the allowed bypass to its
+//     source location. Currently exactly one production callsite holds a
+//     marker: adapters/postgres/refresh_store.go::revokeSessionDetachedAt
 //     (the intentional independent-commit cascade-revoke compensation path).
 //
 // # Discovery
@@ -88,12 +90,15 @@
 //     (a) For pool access: any SelectorExpr `<x>.pool` where <x> resolves to
 //     pgExecutor and `.pool` is accessed from outside pgExecutor's own methods.
 //     (b) For ExecDirect calls: any CallExpr `<x>.ExecDirect(...)` where <x>
-//     resolves to pgExecutor, unless the same FuncDecl body contains a sibling
-//     CallExpr to pkg/pgrepoapproved.ApprovedExecDirect whose first argument is
-//     a string-typed constant (const literal). Callee identity and arg
-//     constness are both verified via *types.Info; no string anchors / no
-//     hand-maintained map. Exempted: pgExecutor's own methods (they
-//     legitimately use e.pool / call ExecDirect on self); newPGExecutor
+//     resolves to pgExecutor, unless the SAME approval scope (FuncDecl body
+//     OR enclosing FuncLit body — not nested closure) contains a sibling
+//     CallExpr to pkg/pgrepoapproved.ApprovedExecDirect whose first argument
+//     is a kebab-case BasicLit (regex ^[a-z][a-z0-9-]+$, not a placeholder
+//     identifier). Callee identity is verified via *types.Info.Uses; arg form
+//     is verified via *ast.BasicLit + token.STRING + strconv.Unquote + regex.
+//     No string anchors / no hand-maintained map. Exempted: pgExecutor's own
+//     methods (they legitimately use e.pool / call ExecDirect on self);
+//     newPGExecutor
 //     constructor.
 //
 // # RED fixtures
@@ -587,25 +592,24 @@ func scanR3PoolAccess(fset *token.FileSet, body *ast.BlockStmt, rel string, info
 }
 
 // scanR3ExecDirect flags CallExpr `<x>.ExecDirect(...)` where <x> resolves to
-// pgExecutor, unless the same FuncDecl body contains a sibling
-// pgrepoapproved.ApprovedExecDirect(literal) marker call. Marker form is
-// verified via (callee, arg) form-uniqueness:
+// pgExecutor, unless the SAME approval scope (the body argument — a FuncDecl
+// body OR a nested FuncLit body, depending on how scanR3UsagePoints invoked
+// this) contains a sibling pgrepoapproved.ApprovedExecDirect marker call.
+// Walk is scope-bounded via inspectStopAtFuncLit: nested FuncLit bodies are
+// NOT descended into here; scanR3UsagePoints visits each FuncLit body as its
+// own independent approval scope. See bodyHasApprovedExecDirectMarker for the
+// 5-门 marker form chain (callee identity + BasicLit + token.STRING +
+// kebab-case regex + non-placeholder).
 //
-//  1. callee resolves via *types.Info.Uses to the *types.Func for
-//     ApprovedExecDirect in pkg/pgrepoapproved (name + pkg path match);
-//  2. first argument's static type-and-value resolves via *types.Info.Types
-//     to a string constant (const literal) — fmt.Sprintf / concatenation /
-//     variables yield non-constant TypeAndValue and are rejected.
+// One marker satisfies the check for every ExecDirect call in the same scope.
+// Multiple markers in one scope are allowed (harmless redundancy); BS-8
+// reverse self-check separately pins that a marker only co-locates with an
+// actual ExecDirect call (spurious-marker detection).
 //
-// The marker is checked once per FuncDecl body; the same marker covers every
-// ExecDirect call inside that body. Multiple markers in one body are not
-// rejected (they are harmless documentation), but archtest BS-8 reverse self-
-// check pins that only the sanctioned site holds a marker.
-//
-// Marker order relative to ExecDirect calls is NOT enforced by this check —
-// co-location (same FuncDecl body) is the only structural requirement. By
-// convention the marker is placed before the ExecDirect call for readability,
-// but the archtest passes regardless of order.
+// Marker order relative to ExecDirect calls is NOT enforced — co-location
+// (same approval scope) is the only structural requirement. By convention
+// the marker is placed before the ExecDirect call for readability, but the
+// archtest passes regardless of order.
 func scanR3ExecDirect(
 	fset *token.FileSet,
 	body *ast.BlockStmt,
@@ -899,19 +903,19 @@ var expectedFixtureViolations = []fixtureViolation{
 	// R3: badR3ExecDirect — r.db.ExecDirect call without sibling marker at line 149
 	{"R3:", 149},
 	// F1 RED (PR #917 round-2):
-	// R3: badR3MarkerInNestedClosure — outer ExecDirect, marker in nested closure at line 174
-	{"R3:", 174},
-	// R3: badR3MarkerOuterExecInNestedClosure — inner ExecDirect, marker in outer scope at line 187
-	{"R3:", 187},
+	// R3: badR3MarkerInNestedClosure — outer ExecDirect, marker in nested closure at line 175
+	{"R3:", 175},
+	// R3: badR3MarkerOuterExecInNestedClosure — inner ExecDirect, marker in outer scope at line 188
+	{"R3:", 188},
 	// F2 RED (PR #917 round-2):
-	// R3: badR3ApprovedConstIdent — marker reason is const ident (not BasicLit), at line 198
-	{"R3:", 198},
-	// R3: badR3ApprovedConcat — marker reason is "a"+"b" BinaryExpr at line 206
-	{"R3:", 206},
-	// R3: badR3ApprovedEmpty — marker reason is "" (fails kebab regex) at line 214
-	{"R3:", 214},
-	// R3: badR3ApprovedPlaceholder — marker reason is "todo" (placeholder) at line 223
-	{"R3:", 223},
+	// R3: badR3ApprovedConstIdent — marker reason is const ident (not BasicLit), at line 199
+	{"R3:", 199},
+	// R3: badR3ApprovedConcat — marker reason is "a"+"b" BinaryExpr at line 207
+	{"R3:", 207},
+	// R3: badR3ApprovedEmpty — marker reason is "" (fails kebab regex) at line 215
+	{"R3:", 215},
+	// R3: badR3ApprovedPlaceholder — marker reason is "todo" (placeholder) at line 224
+	{"R3:", 224},
 }
 
 // TestPGRepoAmbientTx_RedFixtureDetected asserts the rule catches all eleven

--- a/tools/archtest/pg_repo_ambient_tx_test.go
+++ b/tools/archtest/pg_repo_ambient_tx_test.go
@@ -44,7 +44,7 @@
 //
 // # AI-robust grading (Funnel 双向锁评级)
 //
-// 下游 Hard / 上游 Medium (PG-REPO-AMBIENT-TX-UPSTREAM-HARD-01).
+// 下游 Hard / 上游 Medium (Hard terminal state tracked: gh issue #916 PGEXECUTOR-SEAL-INTERFACE-01).
 //
 // 上游 Medium: intra-package compile Hard is unreachable — adapters/postgres
 // repos share the package with pgExecutor; Go package-level visibility means a
@@ -186,6 +186,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -205,6 +206,17 @@ const (
 	expectedPGAdapterPackageMin = 3 // discovery coverage floor; see ADR §3.
 )
 
+// pgAdapterPackagesCache holds the once-computed result of
+// discoverPGAdapterPackages. Three parallel tests (TestPGRepoAmbientTx,
+// TestPGRepoAmbientTx_DiscoveryCoverage, TestPGRepoAmbientTx_SelfCheck) each
+// call discoverPGAdapterPackages; without caching each would execute a full
+// RunTyped/packages.Load sweep. The cached slice is a deduped sorted read-only
+// value — safe for concurrent readers once populated by sync.Once.
+var (
+	pgAdapterPackagesOnce  sync.Once
+	pgAdapterPackagesCache []string
+)
+
 // discoverPGAdapterPackages auto-discovers all production packages that
 // declare a package-local type named pgExecutor. The discovery signal replaces
 // the former hand-maintained pgRepoPackagePatterns list: a package is in
@@ -217,24 +229,32 @@ const (
 // intentionally excluded — they need a separate archtest if/when they want
 // equivalent governance.
 //
+// The result is computed once per test binary execution via sync.Once and
+// cached for concurrent reuse. The returned slice is read-only; callers must
+// not mutate it. Three parallel tests share this cache: TestPGRepoAmbientTx,
+// TestPGRepoAmbientTx_DiscoveryCoverage, and TestPGRepoAmbientTx_SelfCheck.
+//
 // See package godoc §Discovery and ADR
 // docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md.
 func discoverPGAdapterPackages(t *testing.T) []string {
 	t.Helper()
-	root := findModuleRoot(t)
-	var paths []string
-	_ = RunTyped(t, TypedOpts{Tests: false}, prodscan.Patterns(root), func(p *Pass) []Diagnostic {
-		if p.Pkg == nil || p.Pkg.Scope() == nil {
+	pgAdapterPackagesOnce.Do(func() {
+		root := findModuleRoot(t)
+		var paths []string
+		_ = RunTyped(t, TypedOpts{Tests: false}, prodscan.Patterns(root), func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Scope() == nil {
+				return nil
+			}
+			if p.Pkg.Scope().Lookup(pgExecutorName) == nil {
+				return nil
+			}
+			paths = append(paths, p.Pkg.Path())
 			return nil
-		}
-		if p.Pkg.Scope().Lookup(pgExecutorName) == nil {
-			return nil
-		}
-		paths = append(paths, p.Pkg.Path())
-		return nil
+		})
+		sort.Strings(paths)
+		pgAdapterPackagesCache = paths
 	})
-	sort.Strings(paths)
-	return paths
+	return pgAdapterPackagesCache
 }
 
 // TestPGRepoAmbientTx guards PG-REPO-AMBIENT-TX-01 against the production
@@ -302,6 +322,16 @@ func pgRepoAmbientTxRule(p *Pass) []Diagnostic {
 	for _, file := range p.Files {
 		rel := p.Rel(file)
 		base := filepath.Base(rel)
+		// Fixture packages reside under tools/archtest/internal/ and are loaded
+		// via RunTypedFixture (separate test path), never through production
+		// discovery. The tools/archtest/ prefix check is a Soft convention: fixture
+		// packages MUST be placed under tools/archtest/internal/ as documented by
+		// RunTypedFixture and the fixture naming convention; misplacing a fixture
+		// package outside that prefix would cause R1/R2/R3 to apply the
+		// _repo.go/_store.go suffix filter and miss the fixture's intentional
+		// violations. Production packages always start with cells/, adapters/,
+		// examples/, etc., so the prefix boundary is structurally stable but not
+		// mechanically enforced beyond this string check.
 		if !strings.HasPrefix(rel, "tools/archtest/") {
 			if !strings.HasSuffix(base, "_repo.go") && !strings.HasSuffix(base, "_store.go") {
 				continue
@@ -504,6 +534,11 @@ func scanR3PoolAccess(fset *token.FileSet, body *ast.BlockStmt, rel string, info
 // ExecDirect call inside that body. Multiple markers in one body are not
 // rejected (they are harmless documentation), but archtest BS-8 reverse self-
 // check pins that only the sanctioned site holds a marker.
+//
+// Marker order relative to ExecDirect calls is NOT enforced by this check —
+// co-location (same FuncDecl body) is the only structural requirement. By
+// convention the marker is placed before the ExecDirect call for readability,
+// but the archtest passes regardless of order.
 func scanR3ExecDirect(
 	fset *token.FileSet,
 	body *ast.BlockStmt,
@@ -533,7 +568,9 @@ func scanR3ExecDirect(
 			Message: "R3: pgExecutor.ExecDirect call requires sibling " +
 				"pgrepoapproved.ApprovedExecDirect(<const-literal>) marker in the same " +
 				"FuncDecl body to document the ADR-approved bypass of ambient tx; " +
-				"add the marker before the ExecDirect call (see pkg/pgrepoapproved)",
+				"add 'pgrepoapproved.ApprovedExecDirect(\"your-adr-reason\")' before the " +
+				"ExecDirect call; see pkg/pgrepoapproved and ADR " +
+				"docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md",
 		})
 	})
 	return diags
@@ -545,6 +582,14 @@ func scanR3ExecDirect(
 // reason arguments (fmt.Sprintf, concatenation, variable references) are
 // rejected so that the marker's audit-trail rationale cannot be hidden behind
 // runtime expressions.
+//
+// Order is not enforced: marker may appear before, after, or between ExecDirect
+// calls — convention is before for readability, but archtest only checks
+// same-body co-location, not relative order.
+//
+// One marker covers all ExecDirect calls in the same body — multiple ExecDirect
+// calls do not require multiple markers. A single ApprovedExecDirect call
+// satisfies the check for all ExecDirect calls in that FuncDecl body.
 func bodyHasApprovedExecDirectMarker(body *ast.BlockStmt, info *types.Info) bool {
 	found := false
 	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
@@ -745,16 +790,16 @@ type fixtureViolation struct {
 // test because the set sizes must match AND every actual entry must be in the
 // expected set.
 var expectedFixtureViolations = []fixtureViolation{
-	// R1: badR1Repo — struct field pool *pgxpool.Pool at line 88 of fixture.go
-	{"R1:", 88},
-	// R2: badR2NonNew — non-New* func with *pgxpool.Pool param, func name at line 93
-	{"R2:", 93},
-	// R2: NewBadR2NoWrap — New* func without newPGExecutor call, func name at line 99
-	{"R2:", 99},
-	// R3: badR3PoolDirect — r.db.pool direct access at line 117
-	{"R3:", 117},
-	// R3: badR3ExecDirect — r.db.ExecDirect without sibling marker at line 123
-	{"R3:", 123},
+	// R1: badR1Repo — struct field pool *pgxpool.Pool type position at line 93 of fixture.go
+	{"R1:", 93},
+	// R2: badR2NonNew — non-New* func with *pgxpool.Pool param, func name at line 98
+	{"R2:", 98},
+	// R2: NewBadR2NoWrap — New* func without newPGExecutor call, func name at line 104
+	{"R2:", 104},
+	// R3: badR3PoolDirect — r.db.pool direct access selector at line 122
+	{"R3:", 122},
+	// R3: badR3ExecDirect — r.db.ExecDirect call without sibling marker at line 128
+	{"R3:", 128},
 }
 
 // TestPGRepoAmbientTx_RedFixtureDetected asserts the rule catches all five
@@ -767,7 +812,9 @@ var expectedFixtureViolations = []fixtureViolation{
 //   - 1 R3: badR3ExecDirect calls r.db.ExecDirect without sibling pgrepoapproved.ApprovedExecDirect marker
 //
 // GREEN cases (pgExecutor field, goodNewFoo→newPGExecutor, goodExecMethod using
-// r.db.Exec) must produce zero diagnostics.
+// r.db.Exec, goodApprovedSingleExecDirect with marker+1 ExecDirect,
+// goodApprovedMultiExecDirect with 1 marker+2 ExecDirect calls) must produce
+// zero diagnostics.
 //
 // The assertion is an exact-set match on (ruleID_prefix, line) pairs from
 // expectedFixtureViolations. This prevents a masked substitution where losing
@@ -1174,6 +1221,9 @@ func TestPGRepoAmbientTx_DiscoveryCoverage(t *testing.T) {
 		"github.com/ghbvf/gocell/cells/accesscore/internal/adapters/postgres",
 		"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/adapters/postgres",
 	}
+	assert.Equal(t, expectedPGAdapterPackageMin, len(expected),
+		"expectedPGAdapterPackageMin floor constant must equal expected set size; "+
+			"update both if a package is added or removed")
 	got := discoverPGAdapterPackages(t)
 
 	expectedSet := make(map[string]struct{}, len(expected))
@@ -1194,7 +1244,9 @@ func TestPGRepoAmbientTx_DiscoveryCoverage(t *testing.T) {
 		if _, ok := expectedSet[p]; !ok {
 			t.Errorf("PG-REPO-AMBIENT-TX-01 DiscoveryCoverage: discovered new package %q "+
 				"not in expected set — if intentional, add it to expected; "+
-				"if accidental, this package declares pgExecutor unexpectedly", p)
+				"if accidental, this package declares pgExecutor unexpectedly; "+
+				"update the 'expected []string' slice in TestPGRepoAmbientTx_DiscoveryCoverage "+
+				"and bump expectedPGAdapterPackageMin to match", p)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`PG-REPO-AMBIENT-TX-01` archtest funnel 双轴升级，消除两处 Soft 闭环漂移失败模式：

- **上游** (`pgRepoPackagePatterns` 列表) **Soft → Medium**：改用 type-aware 自动发现 — 包 scope 内含 `pgExecutor` 命名类型即在扫描范围。新 PG 适配包只要沿用 `pgExecutor` 范式自动覆盖，无需手动列表更新；PR #575 F-A-001 漂移失败模式消除。
- **下游 R3(b)** (`r3ExecDirectAllowlist` 字符串 map) **Soft → Hard**：改用 typed marker funnel — 新建 `pkg/pgrepoapproved` (sibling deployment of `pkg/panicregister`)；合法 `pgExecutor.ExecDirect` callsite 必须在自身 FuncDecl body 内有 `pgrepoapproved.ApprovedExecDirect(<const-literal>)` marker；callee 身份 + arg const-literal 双锁，无 "像但不是" 灰区。

新增反向自检 BS-8 拒孤立 marker (marker 必须与同 body 的 ExecDirect 共存)；新增 `TestPGRepoAmbientTx_DiscoveryCoverage` exact-set match 防 discovery signal 被静默打断。

Closes #823.

## Funnel 双向锁评级 (升级前 → 升级后)

| 维度 | 升级前 | 升级后 |
|------|--------|--------|
| 上游 package discovery | Soft (hand-maintained list) | **Medium** (archtest-bound type-aware) |
| 下游 R1/R2/R3(a) | Hard | Hard (不变) |
| 下游 R3(b) ExecDirect callsite | Soft (hand-maintained map) | **Hard** (typed marker funnel) |

上游 Hard terminal state (seal `pgExecutor` behind exported interface + 私有构造) 工作量大，按 `ai-robust.md` §"Funnel 双向锁评级"过渡形态要求，同 PR 开 follow-up issue #916 跟踪。

## Implementation matrix

```
Contract: PG-REPO-AMBIENT-TX-01 archtest (上游 Soft→Medium; 下游 R3(b) Soft→Hard)
Change: type-aware discovery + typed marker funnel; 删除 hand-maintained list + allowlist map
Implementations: [x] adapters/postgres (refresh_store.go marker)  [x] cells/accesscore/internal/adapters/postgres (自动发现)  [x] examples/iotdevice/cells/devicecell/internal/adapters/postgres (自动发现)
Conformance test: tools/archtest.TestPGRepoAmbientTx + TestPGRepoAmbientTx_RedFixtureDetected + TestPGRepoAmbientTx_SelfCheck + TestPGRepoAmbientTx_DiscoveryCoverage
Repro: go test ./tools/archtest/... -run TestPGRepoAmbientTx
Dependent contracts (governance scan): none
```

ref: `pkg/panicregister` (typed marker funnel 范本)
ADR: `docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md`

## Test plan

- [x] `go build ./...` — clean
- [x] `go build -tags=integration ./...` — clean
- [x] `go test ./tools/archtest/... -run 'TestPGRepoAmbientTx'` — 4 tests pass (RED fixture 5/5, discovery 3/3, self-check BS-1~BS-8, main rule)
- [x] `go test ./pkg/pgrepoapproved/... ./adapters/postgres/... -run Refresh` — pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] 端到端: stash 后跑 develop baseline → fixture 仍输出 5/5 RED 诊断 (新 R3 marker 错误消息)
- [ ] CI 全绿（ship workflow 跟进）

## Pre-existing failures observed (out of scope, also fail on develop)

- `tools/archtest.TestDependabotCoversCIAndGolangCILint` — dependabot.yml schema mismatch
- `adapters/postgres.TestNewPool_ConnectTimeout_Blackhole` — network blackhole timeout flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)