### PR TITLE
fix(interface): ISP 消费者文档闭环 + ARCH-EVO 出口表面收口 (#836 Bundle 1+2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,6 @@ archtest CI 入口是 `.github/workflows/archtest-nightly.yml`（schedule cron +
 
 格式：`yyyyMMddHHmm-编号-实际功能或问题.md`
 示例：`202603281443-022-compliance-api-review.md`
+
+适用范围：`docs/architecture/` (ADR)、`docs/plans/` (实施计划)、`docs/reviews/` 等时间序载体。
+`docs/guides/` / `docs/ops/` 等长期参考文档按主题名命名（如 `cell-development-guide.md`），不需要时间戳前缀。

--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ func New() *MyCell {
 func (c *MyCell) initInternal(ctx context.Context, reg cell.Registrar) error {
     return nil
 }
+
+// Compile-time assertion: MyCell satisfies all four ISP sub-interfaces.
+// Forgetting a method pinpoints the missing sub-interface (e.g.,
+// "missing method Stop" surfaces as "does not implement CellLifecycle").
+// ref: docs/architecture/202605101800-adr-cell-interface-isp-split.md §D3
+var (
+    _ cell.CellIdentity  = (*MyCell)(nil)
+    _ cell.CellLifecycle = (*MyCell)(nil)
+    _ cell.CellStatus    = (*MyCell)(nil)
+    _ cell.CellInventory = (*MyCell)(nil)
+)
 ```
 
 The `+cell:listener` / `+slice:route` markers tell `cellgen` how to emit `cell_gen.go::Init`, which calls `BaseCell.Init`, then `c.initInternal`, then registers each route group + slice. Re-run `gocell generate cell --all` after changing markers.
@@ -298,6 +309,13 @@ go build ./cmd/myapp && ./myapp
 curl http://localhost:8080/api/v1/hello
 # {"message":"hello from mycell"}
 ```
+
+### Further Reading
+
+- [`docs/guides/cell-interface-isp.md`](docs/guides/cell-interface-isp.md) — 为什么拆四个子接口（CellIdentity / CellLifecycle / CellStatus / CellInventory）
+- [`docs/guides/why-sealed-marker.md`](docs/guides/why-sealed-marker.md) — outbox / persistence 注入：sealed marker 模式
+- [`docs/architecture/202605101800-adr-cell-interface-isp-split.md`](docs/architecture/202605101800-adr-cell-interface-isp-split.md) — ADR: Cell interface ISP split
+- [`docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md`](docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md) — ADR: Cell raw infra sealed marker
 
 ## Scaffold（K#09）
 

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -23,6 +23,7 @@ import (
 // SelfOr cannot be used here because "self" is determined by the actorId query
 // parameter, not a path parameter.
 // role-name literal will be migrated to permission-based authz when that work lands.
+// Deferred (S43, tracked by gh issue #914 — PERMISSION-BASED-AUTHZ-01)
 func auditQueryPolicy(r *http.Request) error {
 	ctx := r.Context()
 	p, ok := auth.FromContext(ctx)

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -23,7 +23,7 @@ import (
 // SelfOr cannot be used here because "self" is determined by the actorId query
 // parameter, not a path parameter.
 // role-name literal will be migrated to permission-based authz when that work lands.
-// Deferred (S43, tracked by gh issue #914 — PERMISSION-BASED-AUTHZ-01)
+// Deferred (S43, tracked by gh issue #914 — PERMISSION-BASED-AUTHZ-01).
 func auditQueryPolicy(r *http.Request) error {
 	ctx := r.Context()
 	p, ok := auth.FromContext(ctx)

--- a/docs/architecture/202604270030-architectural-panic-whitelist.md
+++ b/docs/architecture/202604270030-architectural-panic-whitelist.md
@@ -98,7 +98,6 @@ Examples by module:
 - `kernel/outbox/entry_id.go` — `outbox-entry-id-init`
 - `kernel/wrapper/{consumer,handler}.go` — `wrapper-consumer-init`, `wrapper-handler-init`
 - `pkg/errcode/errcode.go` — `errcode-redact-attr-self`, `errcode-redact-message-self`
-- `runtime/audit/ledger/mem_store.go` — `audit-mem-tamper-hash-out-of-range`, `audit-mem-tamper-prev-hash-out-of-range`
 - `runtime/auth/{keys,principal,provider,route}.go` — `auth-test-rsa-keypair`, `auth-test-keyset`, `auth-principal-context-missing`, `auth-test-hmac-keyring`, `auth-route-mount`
 - `runtime/distlock/locker.go` — `distlock-init`
 - `runtime/http/{health,middleware/cookie_session,middleware/circuit_breaker,router}` — `health-checker-register`, `cookie-session-init`, `circuit-breaker-init`, `router-init`

--- a/docs/architecture/202605101800-adr-audit-ledger-protocol.md
+++ b/docs/architecture/202605101800-adr-audit-ledger-protocol.md
@@ -58,7 +58,7 @@ hash = hex.EncodeToString(HMAC-SHA256(key, msg))
 **HMAC key 安全要求**：
 - key 必须 ≥ 32 bytes（hash output 大小；短 key 降低 HMAC 安全强度）
 - key 不得出现在错误消息或 slog 字段中
-- key 通过 `WithChainHMAC` 注入；`Protocol.HMACKey()` 返回 defensive copy
+- key 通过 `WithChainHMAC` 注入，完成后 caller 切片被 `clear(key)` 清零；Protocol 不暴露 raw key getter（A-08 删除，防止 key 材料从 export 表面泄漏）
 
 ref: google/trillian log/sequencer.go@master
 

--- a/docs/architecture/202605101800-adr-cell-interface-isp-split.md
+++ b/docs/architecture/202605101800-adr-cell-interface-isp-split.md
@@ -1,5 +1,7 @@
 # ADR: Cell Interface ISP Split + Raw-Infra Closure
 
+> 面向：framework 内部贡献者。框架使用者请先看 [`docs/guides/cell-interface-isp.md`](../guides/cell-interface-isp.md)。
+
 > Status: Accepted
 > Date: 2026-05-10
 > ref: docs/plans/202605011500-029-master-roadmap.md #13 PR-A22

--- a/docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md
+++ b/docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md
@@ -1,5 +1,7 @@
 # ADR: Cell Raw-Infra Sealed Marker（升级 CELL-RAW-DEPS-01 为 AI-HARD type-system 强制）
 
+> 面向：framework 内部贡献者。框架使用者请先看 [`docs/guides/why-sealed-marker.md`](../guides/why-sealed-marker.md)。
+
 > Status: Accepted
 > Date: 2026-05-10
 > Amends: docs/architecture/202605101800-adr-cell-interface-isp-split.md §D6

--- a/docs/architecture/202605171800-adr-kernel-mustctor-removal.md
+++ b/docs/architecture/202605171800-adr-kernel-mustctor-removal.md
@@ -289,8 +289,8 @@ system 表达"function name 必须有 receiver"。
 | `pkgErrcode` | `MustValidateDetailsKinds` | assertion guard | details kind 合法性，pkg-level var init |
 | `pkgAppender` | `MustNewSpec` | codegen funnel | sealed 白名单 funnel，pkg-level var init |
 | `pkgWebsocketHub` | `MustValidateHubConfig` | 内部 validator | `NewHub` 内部调用，不暴露为跨包 callee |
-| `runtime/audit/ledger` | `MustTamperEntryHash` | (c) test fixture method on MemStore | test-only method 暴露在 production package 供 storetest 合规测试（负向 Verify 用例）注入篡改；不能移到 `_test.go`，因为 `storetest` 子包在 suite runtime 消费该方法 |
-| `runtime/audit/ledger` | `MustTamperEntryPrevHash` | (c) test fixture method on MemStore | 同上，`MustTamperEntryHash` 的配套方法，用于篡改 prev_hash 构造 chain-break 测试向量 |
+| ~~`runtime/audit/ledger`~~ | ~~`MustTamperEntryHash`~~ | ~~(c) test fixture method on MemStore~~ | **REMOVED (A-05 refactor)**: relocated to `ledger/mem_store_tamper_test.go` as unexported `tamperEntryHash`; negative Verify tests moved from `storetest/suite.go` to same-package `_test.go`; carve-out entry deleted from archtest `allowedMustDecls`. |
+| ~~`runtime/audit/ledger`~~ | ~~`MustTamperEntryPrevHash`~~ | ~~(c) test fixture method on MemStore~~ | **REMOVED (A-05 refactor)**: same as above; unexported `tamperEntryPrevHash` in `_test.go`. |
 
 Test fixture 包路径前缀（`testFixturePkgPrefixes` slice，这些路径下不扫描）：
 

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -140,9 +140,10 @@ Raw infra 类型（`outbox.Publisher`、`outbox.Writer`、`persistence.TxRunner`
 package mycell
 
 import (
+    "github.com/ghbvf/gocell/kernel/cell"
     "github.com/ghbvf/gocell/kernel/outbox"
     "github.com/ghbvf/gocell/kernel/persistence"
-    "github.com/ghbvf/gocell/kernel/cell"
+    "github.com/ghbvf/gocell/pkg/validation"
 )
 
 type MyCell struct {
@@ -163,9 +164,12 @@ func WithOutboxDeps(p outbox.CellPublisher, w outbox.CellWriter) Option {
 
 // WithTxManager 注入 sealed tx 依赖。tx 必须通过 persistence.WrapForCell 在
 // composition root 构造。nil 静默忽略；最终 nil 校验由 validateRequired() 完成。
+// CellTxManager 是 sealed interface（不可作 struct literal 构造），用
+// pkg/validation.IsNilInterface 做 typed-nil 检测（kernel/runtime 单源 helper，
+// 详见 .claude/rules/gocell/runtime-api.md §Option 范式分层 — 累加式 builder option）。
 func WithTxManager(tx persistence.CellTxManager) Option {
     return func(c *MyCell) {
-        if tx == (persistence.CellTxManager{}) {
+        if validation.IsNilInterface(tx) {
             return
         }
         c.txMgr = tx
@@ -176,13 +180,15 @@ func WithTxManager(tx persistence.CellTxManager) Option {
 #### Composition root 对照例
 
 ```go
-// demo / 测试模式 — 用 noop 实现在 composition root 构造 sealed marker
+// demo / 测试模式 — 用 noop 实现在 composition root 构造 sealed marker。
+// DiscardPublisher 用 pointer receiver，故传 &outbox.DiscardPublisher{}；
+// NoopWriter / DemoTxRunner 用 value receiver，可直接传值。
 mycell.New(
     mycell.WithOutboxDeps(
-        outbox.WrapPublisherForCell(outbox.DiscardPublisher{}),
+        outbox.WrapPublisherForCell(&outbox.DiscardPublisher{}),
         outbox.WrapWriterForCell(outbox.NoopWriter{}),
     ),
-    mycell.WithTxManager(persistence.WrapForCell(persistence.DemoTxRunner{})),
+    mycell.WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})),
 )
 
 // production 模式 — 用真实 adapter 在 composition root 构造 sealed marker

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -213,6 +213,11 @@ ref: `docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md §D1`
 
 option 名称后缀对应 cell 能力的真实分布：`WithOutboxDeps` 表示同时持有 publisher 与 writer 的平台 cell，`WithOutboxWriter` 表示只写 outbox 不主动 publish 的 L2 cell，`WithDirectPublisher` 表示绕过 outbox 直接发布的 L4 cell。选错 option 形态会让能力边界在代码审查时不可见，增加 L2/L4 混淆风险。
 
+> 备注：上表按 **cell 能力维度**（哪些 outbox 路径有/无）描述 Option 形态。
+> 对应的 **sealed marker 类型维度**（哪种 raw infra 对应哪个 sealed marker / wrap 函数）
+> 见 `.claude/rules/gocell/cell-patterns.md` §"Sealed Marker Wrap Pattern"——两表互补：
+> 这里告诉你"该用哪种 Option"，那里告诉你"Option 的参数类型背后是哪个 wrap 函数"。
+
 ### 6. 注册 HTTP 路由（可选）
 
 通过 `reg.RouteGroup(...)` 在 `Init` 内声明每组路由所属的物理 listener，

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -85,7 +85,15 @@ import (
     "github.com/ghbvf/gocell/kernel/cell"
 )
 
-var _ cell.Cell = (*MyCell)(nil)
+// ISP split: cell.Cell is decomposed into four focused interfaces. Each assertion
+// independently verifies compliance at compile time.
+// ref: docs/architecture/202605101800-adr-cell-interface-isp-split.md §D3
+var (
+    _ cell.CellIdentity  = (*MyCell)(nil)
+    _ cell.CellLifecycle = (*MyCell)(nil)
+    _ cell.CellStatus    = (*MyCell)(nil)
+    _ cell.CellInventory = (*MyCell)(nil)
+)
 
 type MyCell struct {
     *cell.BaseCell
@@ -115,7 +123,97 @@ func (c *MyCell) initInternal(ctx context.Context, reg cell.Registrar) error {
 `cell.go` 中的 `// +cell:listener` / `// +slice:route` / `// +slice:subscribe` markers
 生成 RouteGroup/Subscribe 注册代码（参考 `cells/configcore/cell_gen.go`）。
 
-### 4. 注册 HTTP 路由（可选）
+### 4. Outbox 注入：sealed marker 模式
+
+Raw infra 类型（`outbox.Publisher`、`outbox.Writer`、`persistence.TxRunner`）**不能**直接出现在 `cell.go` 的 `With*` Option 签名中。原因：这些类型无法区分"production-wired"与"demo/test-wired"，调用方可以不过 composition root 直接传入任意实现，违背了 sealed marker 的设计意图（见 ADR `docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md §D1`）。
+
+框架提供三个 sealed marker 类型，仅可通过对应的 `Wrap*ForCell` / `WrapForCell` 构造函数获取：
+
+- `outbox.CellPublisher` — 封装 `outbox.Publisher`，通过 `outbox.WrapPublisherForCell(pub)` 构造
+- `outbox.CellWriter` — 封装 `outbox.Writer`，通过 `outbox.WrapWriterForCell(w)` 构造
+- `persistence.CellTxManager` — 封装 `persistence.TxRunner`，通过 `persistence.WrapForCell(txRunner)` 构造
+
+#### 最小 cell.go 示例
+
+```go
+// cell.go
+package mycell
+
+import (
+    "github.com/ghbvf/gocell/kernel/outbox"
+    "github.com/ghbvf/gocell/kernel/persistence"
+    "github.com/ghbvf/gocell/kernel/cell"
+)
+
+type MyCell struct {
+    cell.BaseCell
+    pendingPublisher outbox.CellPublisher
+    pendingWriter    outbox.CellWriter
+    txMgr            persistence.CellTxManager
+}
+
+// WithOutboxDeps 注入 sealed outbox 依赖。pub 和 w 必须通过
+// outbox.WrapPublisherForCell / outbox.WrapWriterForCell 在 composition root 构造。
+func WithOutboxDeps(p outbox.CellPublisher, w outbox.CellWriter) Option {
+    return func(c *MyCell) {
+        c.pendingPublisher = p
+        c.pendingWriter = w
+    }
+}
+
+// WithTxManager 注入 sealed tx 依赖。tx 必须通过 persistence.WrapForCell 在
+// composition root 构造。nil 静默忽略；最终 nil 校验由 validateRequired() 完成。
+func WithTxManager(tx persistence.CellTxManager) Option {
+    return func(c *MyCell) {
+        if tx == (persistence.CellTxManager{}) {
+            return
+        }
+        c.txMgr = tx
+    }
+}
+```
+
+#### Composition root 对照例
+
+```go
+// demo / 测试模式 — 用 noop 实现在 composition root 构造 sealed marker
+mycell.New(
+    mycell.WithOutboxDeps(
+        outbox.WrapPublisherForCell(outbox.DiscardPublisher{}),
+        outbox.WrapWriterForCell(outbox.NoopWriter{}),
+    ),
+    mycell.WithTxManager(persistence.WrapForCell(persistence.DemoTxRunner{})),
+)
+
+// production 模式 — 用真实 adapter 在 composition root 构造 sealed marker
+mycell.New(
+    mycell.WithOutboxDeps(
+        outbox.WrapPublisherForCell(rabbitPub),
+        outbox.WrapWriterForCell(pgWriter),
+    ),
+    mycell.WithTxManager(persistence.WrapForCell(pgTxRunner)),
+)
+```
+
+两种模式下 `cell.go` 代码完全一致；切换点仅在 `cmd/myapp/main.go`（或 `examples/.../main.go`）的 composition root。
+
+Cross-link: 常见问题与设计理由见 `docs/guides/why-sealed-marker.md`。
+
+ref: `docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md §D1`
+
+### 5. 按 cell 能力选 outbox option 形态
+
+不同 cell 能力对应不同的 Option 组合，选错会导致 option 名称与真实能力不匹配：
+
+| Cell 能力 | 一致性级别 | Option 形态 | 示例 |
+|----------|-----------|------------|------|
+| 平台 cell（pub + writer + tx） | L1/L2 | `WithOutboxDeps(pub, writer)` + `WithTxManager(tx)` | `cells/accesscore` `cells/configcore` `cells/auditcore` |
+| L2 outbox-only（仅 writer + tx） | L2 OutboxFact | `WithOutboxWriter(writer)` + `WithTxManager(tx)` | `examples/todoorder/cells/ordercell` |
+| L4 publish-only（仅 publisher） | L4 DeviceLatent | `WithDirectPublisher(pub)` | `examples/iotdevice/cells/devicecell` |
+
+option 名称后缀对应 cell 能力的真实分布：`WithOutboxDeps` 表示同时持有 publisher 与 writer 的平台 cell，`WithOutboxWriter` 表示只写 outbox 不主动 publish 的 L2 cell，`WithDirectPublisher` 表示绕过 outbox 直接发布的 L4 cell。选错 option 形态会让能力边界在代码审查时不可见，增加 L2/L4 混淆风险。
+
+### 6. 注册 HTTP 路由（可选）
 
 通过 `reg.RouteGroup(...)` 在 `Init` 内声明每组路由所属的物理 listener，
 并在 `Register` 闭包里使用 `auth.Mount` 声明鉴权语义（参见
@@ -194,7 +292,7 @@ func (c *MyCell) Init(ctx context.Context, reg cell.Registrar) error {
 - 禁止在 `Route` / `Group` / `With` 嵌套子作用域里再次进入 `/internal/v1/*`——会触发 `chiRouterAdapter.guardNestedInternalRegistration` panic（顶层 Router 是内外 mux 分流的唯一入口）。
 - `/healthz` / `/readyz` / `/metrics` 只在 health listener；未声明 health listener 时才 fallback 到 primary。
 
-### 5. 注册事件订阅（可选）
+### 7. 注册事件订阅（可选）
 
 通过 `reg.Subscribe(...)` 在 `Init` 内声明订阅意图——禁止手动启动 goroutine 或
 直接调 `Subscriber.Subscribe`，goroutine 生命周期、错误收敛、Setup/Ready 阶段
@@ -236,7 +334,7 @@ EventRouter 在所有 cell 注册完成后按四阶段生命周期启动：
    `bootstrap.WithEventRouterReadyTimeout` 可调），任何未就绪的订阅会出现在错误信息中
 4. **Block**：阻塞至 ctx cancel 或运行时错误
 
-### 6. 注册到 Assembly
+### 8. 注册到 Assembly
 
 ```go
 asm := assembly.New(assembly.Config{ID: "myapp", DurabilityMode: outbox.DurabilityDemo})

--- a/docs/guides/cell-interface-isp.md
+++ b/docs/guides/cell-interface-isp.md
@@ -1,0 +1,270 @@
+# Cell 接口 ISP 拆分：消费者指南
+
+> 本篇面向 Go 开发者（Cell 实现者 / Framework 组件作者）。  
+> 完整设计决策请阅读 ADR `docs/architecture/202605101800-adr-cell-interface-isp-split.md`。
+
+## 背景：4 个子接口
+
+`kernel/cell` 包中的 `Cell` 接口在 PR #441 之后重定义为 4 个子接口的复合体。
+
+```go
+// kernel/cell/interfaces.go
+type Cell interface {
+    CellIdentity
+    CellLifecycle
+    CellStatus
+    CellInventory
+}
+```
+
+4 个子接口各自封装一类正交职责：
+
+### CellIdentity — 静态身份
+
+```go
+type CellIdentity interface {
+    ID() string
+    Type() cellvocab.CellType
+    ConsistencyLevel() cellvocab.Level
+}
+```
+
+**消费者**：registry lookup（`kernel/cell.Assembly`）、metrics label
+（`runtime/http/middleware.Metrics` 的 `cell` label）、log correlation（slog 字段）、
+route attribution（`runtime/http/router.Router` 路由归属）。
+
+### CellLifecycle — 生命周期
+
+```go
+type CellLifecycle interface {
+    Init(ctx context.Context, reg Registrar) error
+    Start(ctx context.Context) error
+    Stop(ctx context.Context) error
+}
+```
+
+**消费者**：Assembly orchestrator（`kernel/cell.Assembly`）、bootstrap phases、
+lifecycle test harnesses。
+
+### CellStatus — 运行时探针
+
+```go
+type CellStatus interface {
+    Health() HealthStatus
+    Ready() bool
+}
+```
+
+**消费者**：`/healthz` 与 `/readyz` HTTP handler（`runtime/http/health.Handler`）、
+runtime supervision（`kernel/cell.Assembly`）。
+
+### CellInventory — 声明态读取
+
+```go
+type CellInventory interface {
+    Metadata() *metadata.CellMeta
+    OwnedSlices() []Slice
+    ProducedContracts() []Contract
+    ConsumedContracts() []Contract
+}
+```
+
+**消费者**：contract validators（`kernel/governance`）、metadata inspectors
+（`cmd/gocell validate`）、codegen（`tools/codegen/contractgen`）。
+
+这 4 个子接口在 `kernel/cell/interfaces.go` 中有完整的 godoc（含各自的 `Consumers:` 段），
+拿不准某个消费场景该用哪个子接口时直接查 godoc。
+
+## 为什么拆？
+
+### 1. ISP（Interface Segregation Principle）
+
+拆分前，`Cell` 是 12 方法的大接口。一个只需要读 `ID()` 的 metrics middleware
+在函数签名上却被迫接受完整的 `cell.Cell`，引入了不必要的耦合。
+
+拆分后：
+
+```go
+// runtime/http/middleware/metrics.go — 只读 cell ID，用 CellIdentity 即可
+func newMetricsCollector(cells []cell.CellIdentity) *Collector { ... }
+```
+
+framework 内部组件可以精确声明自己需要的那一部分，不再依赖 12 方法全集。
+
+### 2. 编译错误精度
+
+**拆分前**（单条 `_ Cell` 断言）：漏实现某个方法时，编译器报出全部 12 个缺失方法，
+开发者要在一大段错误里找到自己漏掉的那一个。
+
+**拆分后**（四段式断言，见下节）：错误精确定位到子接口。例如漏实现 `Stop` 时：
+
+```
+cannot use *MyCell as cell.CellLifecycle: missing method Stop
+```
+
+立刻知道要去实现 `CellLifecycle` 接口的 `Stop` 方法，不需要在 12 方法里查找。
+
+### 3. AI-Hard 治理
+
+子接口是 archtest 的稳固锚点。`CELL-IFACE-ISP-COMPOSITE-01` / `METHODSETS-01` /
+`BASECELL-CHECK-01` 等 archtest（Medium 评级，type-aware AST 扫描）守卫：
+
+- `Cell` 复合接口必须嵌入且仅嵌入这 4 个子接口
+- 每个子接口方法集与 ADR §D1 一致，不能增减
+- `BaseCell` 在 `base.go` 必须有四段式 compile-time check
+
+这些规则在 CI 中自动校验，AI 无法静默地把子接口改回单大接口或把方法移来移去。
+
+### 4. 零代码变更（对 cell 实现者）
+
+复合接口形态保留了 `Cell` 这个名字，且它等价于四子接口的全集。
+`kernel/assembly` 9 处 `cell.Cell` 引用、`runtime/bootstrap/*_test.go`、
+`cells/*/cell_gen.go` 全部无需修改——只要嵌了 `BaseCell`，满足四子接口 ≡ 满足 `Cell`。
+
+## 四段式 compile-time check
+
+cell 实现文件（通常是 `base.go` 或 `cell.go`）应使用四段式断言，而不是单条
+`var _ Cell = (*MyCell)(nil)`：
+
+```go
+// cells/mycell/cell.go 或 kernel/cell/base.go
+var (
+    _ cell.CellIdentity  = (*MyCell)(nil)
+    _ cell.CellLifecycle = (*MyCell)(nil)
+    _ cell.CellStatus    = (*MyCell)(nil)
+    _ cell.CellInventory = (*MyCell)(nil)
+)
+```
+
+**为什么这样写更好：**
+
+单条 `_ cell.Cell` 断言在漏方法时会同时报出所有缺失方法（最多 12 条），
+让人不知道从哪里入手。四段式断言将 12 方法按职责分组，每段 3~4 个方法，
+编译错误精确到子接口粒度：
+
+```
+# 漏实现 Ready() 时
+./cell.go:15:6: cannot use *MyCell as cell.CellStatus:
+    *MyCell does not implement cell.CellStatus (missing method Ready)
+```
+
+开发者一眼就知道要补 `CellStatus.Ready()`。
+
+**kernel/cell/base.go 的实际形态**（由 `BASECELL-CHECK-01` archtest 守卫）：
+
+```go
+var (
+    _ CellIdentity  = (*BaseCell)(nil)
+    _ CellLifecycle = (*BaseCell)(nil)
+    _ CellStatus    = (*BaseCell)(nil)
+    _ CellInventory = (*BaseCell)(nil)
+    _ Slice         = (*BaseSlice)(nil)
+    _ Contract      = (*BaseContract)(nil)
+)
+```
+
+`BaseCell` 实现了全部 12 方法，复合 `Cell` 接口由四子接口同时满足时自动满足，
+不需要额外写 `_ Cell = (*BaseCell)(nil)`。
+
+## 我什么时候只声明子接口依赖？
+
+### 99% 的情况：保持嵌 BaseCell，无需单独关注子接口
+
+如果你在开发一个新 Cell，直接嵌 `cell.BaseCell` 即可：
+
+```go
+type MyCell struct {
+    cell.BaseCell
+    // ... 字段
+}
+```
+
+`BaseCell` 已实现全部 12 方法（`ID()` / `Type()` / `ConsistencyLevel()` /
+`Init()` / `Start()` / `Stop()` / `Health()` / `Ready()` /
+`Metadata()` / `OwnedSlices()` / `ProducedContracts()` / `ConsumedContracts()`）。
+你只需要覆盖业务相关的方法（通常是 `Init`，以及 codegen 生成的 metadata accessor），
+不需要关心哪些方法属于哪个子接口。
+
+### 极少数情况：自定义 framework 组件，需按 ISP 声明最小依赖
+
+如果你在实现 framework 内部组件（如自定义 metrics collector、自定义 middleware、
+自定义 health aggregator），可以也应该按 ISP 只接受需要的子接口：
+
+```go
+// 只读 cell ID 用于 metric label — CellIdentity 已够用
+func newMetricsCollector(cells []cell.CellIdentity) *Collector {
+    // 不依赖 CellLifecycle / CellStatus / CellInventory
+}
+
+// 只驱动生命周期 — CellLifecycle 已够用
+func startAll(ctx context.Context, cells []cell.CellLifecycle) error {
+    for _, c := range cells {
+        if err := c.Start(ctx); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+// 只读健康状态 — CellStatus 已够用
+func aggregateHealth(cells []cell.CellStatus) map[string]bool {
+    result := make(map[string]bool)
+    for _, c := range cells {
+        // CellStatus 没有 ID()，这里需要 CellIdentity
+        // 两者都需要时用 Cell 或声明为 interface{ CellIdentity; CellStatus }
+    }
+    return result
+}
+```
+
+**不要"为了显得 ISP 而拆"**：如果你的函数实际上需要调用多个子接口的方法，
+直接用 `cell.Cell`（复合接口）即可，不需要把参数拆成 4 个子接口类型传入。
+
+**子接口组合**：当你需要某两个子接口时，可以用匿名复合或直接用 `Cell`：
+
+```go
+// 既需要 ID 又需要 Health 的场景
+type healthObserver interface {
+    cell.CellIdentity
+    cell.CellStatus
+}
+func watchHealth(cells []healthObserver) { ... }
+```
+
+## 零代码变更承诺范围澄清
+
+ADR `202605101800` 中的"零代码变更"有明确边界，避免在两条主线变更之间混淆：
+
+**承诺覆盖范围**：`kernel/cell.Cell` 接口的 **消费方**（`kernel/assembly` /
+`runtime/bootstrap` / `cells/*/cell_gen.go` 等）——这些代码继续用 `cell.Cell`
+类型，无需改动，因为复合接口的 method set 与拆分前完全相同。
+
+**不在承诺范围内**：**注入侧** raw infra 的变更。PR #441 同步改造了 cell Option
+函数的参数类型（raw infra → sealed marker）以及所有 composition root 和测试的
+调用点。这部分变更属于 ADR `202605101900`（sealed marker ADR）的范畴，与 ISP
+拆分是两条独立主线，但在同一 PR 内落地。
+
+| 变更类型 | 属于哪条主线 | 有无"零变更"承诺 |
+|---------|------------|----------------|
+| `kernel/assembly` 等消费 `cell.Cell` 的地方 | ISP 拆分 | 有（调用方不需改动） |
+| `cells/*/cell.go` 的 `WithTxManager` 参数类型 | sealed marker | 无（主动改造，注入侧破坏性变更） |
+| `cmd/*` 的 raw infra → `WrapForCell` 调用 | sealed marker | 无（主动改造，composition root 适配） |
+
+如果你看到 PR #441 中有 `cells/*` 的 `service.go` 参数类型从 `persistence.TxRunner`
+改为 `persistence.CellTxManager` 的变更，那是 sealed marker 主线的改动，
+不是 ISP 主线"打破了零变更承诺"。
+
+## 进阶阅读
+
+- **ADR** `docs/architecture/202605101800-adr-cell-interface-isp-split.md` —
+  完整设计决策，包含 ISP 拆分动机、`BaseCell` 四段式断言、Slice 接口默认不拆
+  的理由（§D4），以及 AI-robust 三档分级一览。
+
+- **接口定义** `kernel/cell/interfaces.go` — 4 个子接口的 godoc，每个接口末尾的
+  `Consumers:` 段说明了各子接口的实际消费者，是选择最小子接口依赖的权威参考。
+
+- **兄弟篇** `docs/guides/why-sealed-marker.md` — 讲解 sealed marker wrap pattern，
+  即 raw infra 为什么不能直接注入 cell、应如何用 `persistence.WrapForCell` /
+  `outbox.WrapPublisherForCell` / `outbox.WrapWriterForCell` 在 composition root
+  包装，以及 `persistence.CellTxManager` / `outbox.CellPublisher` /
+  `outbox.CellWriter` 三种 sealed marker 的使用场景。

--- a/docs/guides/cell-interface-isp.md
+++ b/docs/guides/cell-interface-isp.md
@@ -185,6 +185,8 @@ type MyCell struct {
 你只需要覆盖业务相关的方法（通常是 `Init`，以及 codegen 生成的 metadata accessor），
 不需要关心哪些方法属于哪个子接口。
 
+> 如果你不写 framework 内部组件（如自定义 middleware / metrics collector），跳过下一节即可——直接嵌 `BaseCell` 是 99% 场景的正解。
+
 ### 极少数情况：自定义 framework 组件，需按 ISP 声明最小依赖
 
 如果你在实现 framework 内部组件（如自定义 metrics collector、自定义 middleware、

--- a/docs/guides/codegen-new-endpoint.md
+++ b/docs/guides/codegen-new-endpoint.md
@@ -159,6 +159,35 @@ reg.RouteGroup(cell.RouteGroup{
 })
 ```
 
+### Composition root injection (cells that use outbox)
+
+When a cell depends on outbox or a transaction manager, the **composition root**
+(`cmd/myapp/main.go`) is responsible for wrapping raw infra types into the
+sealed marker types before passing them to the cell constructor. Cell-side
+`With*` Option signatures accept only sealed marker types — not raw infra —
+so passing raw values is a compile-time error.
+
+```go
+// cmd/myapp/main.go — wrap raw infra before passing to cell
+mycell.New(
+    mycell.WithOutboxDeps(
+        outbox.WrapPublisherForCell(eb),       // raw outbox.Publisher → CellPublisher
+        outbox.WrapWriterForCell(nw),          // raw outbox.Writer   → CellWriter
+    ),
+    mycell.WithTxManager(persistence.WrapForCell(tx)), // raw TxRunner → CellTxManager
+)
+```
+
+The sealed marker types (`outbox.CellPublisher`, `outbox.CellWriter`,
+`persistence.CellTxManager`) carry an unexported method that makes them
+unimplementable outside their defining package. This is the
+**AI-HARD type-system funnel** — constructing a fake value to satisfy the
+interface is a compile error, not a convention.
+
+ref: [`docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md`](../architecture/202605101900-adr-cell-raw-infra-sealed-marker.md)
+
+See also: [`docs/guides/why-sealed-marker.md`](why-sealed-marker.md)
+
 ## Step 5: Update slice.yaml
 
 Add the contract usage to `cells/myapp/slices/widgetcreate/slice.yaml`:
@@ -204,3 +233,4 @@ takes a standard `outbox.EntryHandler` — no custom interface to implement.
 | Wrong `contractUsages` role | `gocell validate` ADV-06 fail | Set `role: serve` for HTTP server, `role: subscribe` for event subscriber |
 | `return nil, err` for business 4xx | Generated handler falls through to `httputil.WriteError` 5xx path; business error loses its intended status code | Return typed struct: `return createg.Create404ErrorResponse{Body: *errcode.New(...)}, nil` |
 | Missing `responses:` block in contract.yaml | CH-06 governance silently passes (empty set × empty set = true), but the generated typed envelope contains only the success status struct — the adapter has no typed struct to express business errors | Any POST/PUT/DELETE endpoint must declare at least `400` and `500` in `responses:` |
+| 把 raw `outbox.Publisher` 传入 `WithOutboxDeps` | `cannot use ... as outbox.CellPublisher value ... missing method sealedCellPublisher` | composition root 调用 `outbox.WrapPublisherForCell(p)` 包装后再传 |

--- a/docs/guides/why-sealed-marker.md
+++ b/docs/guides/why-sealed-marker.md
@@ -1,0 +1,217 @@
+# 为什么必须 wrap raw infra：Sealed Marker 消费者指南
+
+> 本篇面向 Go 开发者（Cell 实现者 / Example 作者）。  
+> 框架内部贡献者视角请阅读 ADR `docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md`。
+
+## 为什么我必须 wrap raw infra？
+
+当你构建一个 Cell 时，注入依赖的 Option 函数接受的类型不是 raw infra：
+
+```go
+// cells/mycell/cell.go — 正确签名
+func WithTxManager(tx persistence.CellTxManager) Option  { ... }
+func WithOutboxDeps(pub outbox.CellPublisher, w outbox.CellWriter) Option { ... }
+```
+
+而不是：
+
+```go
+// 错误：不接受 raw infra
+func WithTxManager(tx persistence.TxRunner) Option      { ... } // 编译期 / archtest 拦截
+func WithOutboxDeps(pub outbox.Publisher, ...) Option    { ... } // 编译期 / archtest 拦截
+```
+
+**为什么这样设计？**
+
+GoCell 要求 raw infra 只能在 composition root（`cmd/*` / `examples/*/main.go` 等）
+被组装，不允许进入 cell 子树。原因有三：
+
+1. **Composition root 单源治理**：谁在哪里拿了哪个 DB 连接池、哪个 broker
+   publisher，必须在一个地方读清楚。raw infra 散入各 cell 会让这个"清单"消失。
+
+2. **Type-system Hard 防线**：sealed marker 携带 unexported method（`sealedCellTxManager()`
+   等），包外任何类型无法实现它，只能走 kernel 提供的 `Wrap*ForCell(...)` 工厂。
+   这使"往 cell 注入 raw infra"在编译期不可表达，而不是靠 lint 或代码 review 拦截。
+
+3. **AI-robust 设计原则**：GoCell 的主要实施者是 AI。字符串约定和注释可被 AI 复制
+   粘贴绕过；Go 类型系统不会。这是项目治理章程（`.claude/rules/gocell/ai-robust.md`）
+   要求"违反不可表达"的直接实践。
+
+**正确做法**：在 composition root 用以下三个工厂函数包装 raw infra：
+
+| Raw infra | Sealed marker | Wrap 函数 |
+|-----------|---------------|-----------|
+| `persistence.TxRunner` | `persistence.CellTxManager` | `persistence.WrapForCell(tx)` |
+| `outbox.Publisher` | `outbox.CellPublisher` | `outbox.WrapPublisherForCell(pub)` |
+| `outbox.Writer` | `outbox.CellWriter` | `outbox.WrapWriterForCell(w)` |
+
+## 如果我不 wrap，编译会怎样？
+
+尝试把 raw infra 直接传给 cell Option 时，Go 编译器输出类似：
+
+```
+cannot use myWriter (variable of type outbox.Writer) as outbox.CellWriter value
+in argument to ordercell.WithOutboxWriter:
+    outbox.Writer does not implement outbox.CellWriter
+    (missing method sealedCellWriter)
+```
+
+或：
+
+```
+cannot use pgTxRunner (variable of type *adapters/postgres.TxManager)
+as persistence.CellTxManager value in argument to mycell.WithTxManager:
+    *adapters/postgres.TxManager does not implement persistence.CellTxManager
+    (missing method sealedCellTxManager)
+```
+
+**如何解读这类错误：**
+
+- `sealedCellWriter` / `sealedCellPublisher` / `sealedCellTxManager` 是 unexported
+  marker method，**不要尝试在自己的类型上实现它**——这些 method 只属于 kernel
+  包内部的 wrapper struct，包外实现会导致编译失败（unexported，无法在包外声明）。
+- 正确修法：调用对应的 `Wrap*ForCell(...)` 工厂，它在 kernel 包内完成实现，
+  返回已满足 sealed interface 的值。
+
+同理，如果你看到：
+
+```
+cannot use myPublisher as outbox.CellPublisher (missing method sealedCellPublisher)
+```
+
+修法是 `outbox.WrapPublisherForCell(myPublisher)`，而不是给 `myPublisher` 加方法。
+
+如果 archtest `CELL-RAW-INFRA-PUBLIC-OPTION-PARAM-01` 在 CI 报红，说明某个 cell
+子树（`cells/<x>/**/*.go` 或 `examples/<demo>/cells/<x>/**/*.go`）有公开的 `With*`
+Option 签名直接接受了 `persistence.TxRunner` / `outbox.Publisher` / `outbox.Writer`
+类型（或其 inline interface embedding 形态）。修法是将该 Option 参数类型改为
+对应的 sealed marker 类型。
+
+## 三场景标准写法
+
+### Demo 模式（in-process，无 broker / 无 DB）
+
+开发时或单元测试中不想启动外部依赖，用内置的 noop / discard 实现：
+
+```go
+// examples/myapp/main.go 或 cmd/myserver/main.go（composition root）
+import (
+    "github.com/ghbvf/gocell/kernel/outbox"
+    "github.com/ghbvf/gocell/kernel/persistence"
+    "github.com/ghbvf/gocell/cells/mycell"
+)
+
+cell, err := mycell.New(
+    mycell.WithOutboxDeps(
+        outbox.WrapPublisherForCell(outbox.DiscardPublisher{}),
+        outbox.WrapWriterForCell(outbox.NoopWriter{}),
+    ),
+    mycell.WithTxManager(persistence.WrapForCell(persistence.DemoTxRunner{})),
+)
+```
+
+`outbox.DiscardPublisher{}` 丢弃所有发布调用（不报错）；`outbox.NoopWriter{}` 同理。
+`persistence.DemoTxRunner{}` 提供无 DB 的事务语义（调用成功但不持久化）。
+这三个类型均实现 `Noop() bool` 接口，`cell.CheckNotNoop` 在 `Init()` 时会记录
+warn 日志提示当前运行在 demo 模式——这是预期行为。
+
+### Production 模式（RabbitMQ + PostgreSQL）
+
+在 composition root 中拿到真实的 adapter 实例后 wrap：
+
+```go
+// cmd/corebundle/access_module.go（composition root）
+import (
+    "github.com/ghbvf/gocell/kernel/outbox"
+    "github.com/ghbvf/gocell/kernel/persistence"
+    "github.com/ghbvf/gocell/cells/mycell"
+    "github.com/ghbvf/gocell/adapters/postgres"
+    "github.com/ghbvf/gocell/adapters/rabbitmq"
+)
+
+// rabbitPub 是 *rabbitmq.Publisher（实现 outbox.Publisher）
+// pgWriter 是 *postgres.OutboxWriter（实现 outbox.Writer）
+// pgTxRunner 是 *postgres.TxManager（实现 persistence.TxRunner）
+
+cell, err := mycell.New(
+    mycell.WithOutboxDeps(
+        outbox.WrapPublisherForCell(rabbitPub),
+        outbox.WrapWriterForCell(pgWriter),
+    ),
+    mycell.WithTxManager(persistence.WrapForCell(pgTxRunner)),
+)
+```
+
+sealed wrapper 的 embed 设计让 cell 内部 service 方法体仍可透明调用 raw 方法
+（如 `s.txRunner.RunInTx(...)`），不需要任何额外适配——embed 保留了 raw method set。
+
+### Test 模式（构造 fake，在 `*_test.go` 任意位置）
+
+wrap 函数在测试文件中可以任意调用：
+
+```go
+// cells/mycell/cell_test.go 或 cells/mycell/slices/xxx/service_test.go
+import (
+    "github.com/ghbvf/gocell/kernel/outbox"
+    "github.com/ghbvf/gocell/kernel/persistence"
+    "github.com/ghbvf/gocell/cells/mycell"
+)
+
+func TestMyCell_Init(t *testing.T) {
+    fakePub := &outbox.FakePublisher{} // 或任意实现 outbox.Publisher 的 testdouble
+    fakeWriter := outbox.NoopWriter{}
+    fakeTx := persistence.DemoTxRunner{}
+
+    c, err := mycell.New(
+        mycell.WithOutboxDeps(
+            outbox.WrapPublisherForCell(fakePub),
+            outbox.WrapWriterForCell(fakeWriter),
+        ),
+        mycell.WithTxManager(persistence.WrapForCell(fakeTx)),
+    )
+    // ...
+}
+```
+
+`*_test.go` 文件不受 `CELL-RAW-INFRA-WRAPPER-LOCATION-01` archtest 的路径限制，
+可以在任意测试文件中调用 `Wrap*ForCell` 函数。
+
+## Wrap 函数允许出现的位置
+
+archtest `CELL-RAW-INFRA-WRAPPER-LOCATION-01` 静态守卫 wrap 函数
+（`persistence.WrapForCell` / `outbox.WrapPublisherForCell` / `outbox.WrapWriterForCell`）
+的调用方所在文件路径。只有以下位置允许调用：
+
+| 位置 | 说明 |
+|------|------|
+| `cmd/*` 任意文件 | composition root（corebundle / CLI 入口等） |
+| `examples/<demo>/main.go` | example 顶层入口 |
+| `examples/<demo>/app.go` | example 应用初始化文件 |
+| `examples/<demo>/run.go` | example 运行时启动文件 |
+| `*_test.go` 任意路径 | 测试文件，无路径限制 |
+| `kernel/persistence/cell_marker.go` | marker 定义本身（实现内部） |
+| `kernel/outbox/cell_marker.go` | marker 定义本身（实现内部） |
+| `kernel/outbox/demo_tx_runner.go` | `DemoCellTxManager()` 工厂（cells/* demo fallback 收敛点） |
+
+**cells/* 内部不允许出现任何 wrap 调用**（含 cell-package root / `internal/` /
+`slices/<y>/` / `postgres/` / `mem/` 等所有子目录）。cells/* 是 raw infra
+的"消费侧"，只能接受已 wrap 好的 sealed marker，不负责 wrap 逻辑本身。
+
+违反时 archtest 在 CI 报红，错误信息会指出违规的文件路径和调用形态（包括
+dot-import 形态 `import . "kernel/persistence"; WrapForCell(p)` 也会被拦截）。
+
+## 进阶阅读
+
+- **ADR** `docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md` —
+  框架内部贡献者视角，包含 sealed marker 的 type system Hard 防线 + archtest
+  Medium 双重防线的完整设计决策，以及 Amendment 2026-05-12 scope 扩展说明。
+
+- **AI 规则** `.claude/rules/gocell/cell-patterns.md` §"Sealed Marker Wrap Pattern" —
+  包含完整的 Raw infra / Sealed marker / Wrapper 对照表，以及各 cell 类型的
+  cell-specific Option 声明规范（`WithOutboxDeps` vs `WithOutboxWriter` vs
+  `WithDirectPublisher` 的适用场景）。
+
+- **兄弟篇** `docs/guides/cell-interface-isp.md` — 讲解 `cell.Cell` 接口 ISP
+  4 子接口拆分（`CellIdentity` / `CellLifecycle` / `CellStatus` / `CellInventory`）
+  以及四段式 compile-time check 写法，与本篇 sealed marker 防线并列构成
+  PR #441 的两条主线改动。

--- a/docs/guides/why-sealed-marker.md
+++ b/docs/guides/why-sealed-marker.md
@@ -87,6 +87,8 @@ Option 签名直接接受了 `persistence.TxRunner` / `outbox.Publisher` / `outb
 类型（或其 inline interface embedding 形态）。修法是将该 Option 参数类型改为
 对应的 sealed marker 类型。
 
+> 快速修复：见 [§三场景标准写法](#三场景标准写法)
+
 ## 三场景标准写法
 
 ### Demo 模式（in-process，无 broker / 无 DB）
@@ -106,12 +108,12 @@ cell, err := mycell.New(
         outbox.WrapPublisherForCell(outbox.DiscardPublisher{}),
         outbox.WrapWriterForCell(outbox.NoopWriter{}),
     ),
-    mycell.WithTxManager(persistence.WrapForCell(persistence.DemoTxRunner{})),
+    mycell.WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})),
 )
 ```
 
 `outbox.DiscardPublisher{}` 丢弃所有发布调用（不报错）；`outbox.NoopWriter{}` 同理。
-`persistence.DemoTxRunner{}` 提供无 DB 的事务语义（调用成功但不持久化）。
+`outbox.DemoTxRunner{}` 提供无 DB 的事务语义（调用成功但不持久化）。
 这三个类型均实现 `Noop() bool` 接口，`cell.CheckNotNoop` 在 `Init()` 时会记录
 warn 日志提示当前运行在 demo 模式——这是预期行为。
 
@@ -158,9 +160,11 @@ import (
 )
 
 func TestMyCell_Init(t *testing.T) {
-    fakePub := &outbox.FakePublisher{} // 或任意实现 outbox.Publisher 的 testdouble
+    // 测试可以用 outbox.DiscardPublisher{} / outbox.NoopWriter{} 作为最小 testdouble；
+    // 或者构造任意实现 outbox.Publisher / outbox.Writer 接口的私有类型。
+    fakePub := &outbox.DiscardPublisher{} // 实现 outbox.Publisher
     fakeWriter := outbox.NoopWriter{}
-    fakeTx := persistence.DemoTxRunner{}
+    fakeTx := outbox.DemoTxRunner{}
 
     c, err := mycell.New(
         mycell.WithOutboxDeps(

--- a/docs/guides/why-sealed-marker.md
+++ b/docs/guides/why-sealed-marker.md
@@ -105,7 +105,7 @@ import (
 
 cell, err := mycell.New(
     mycell.WithOutboxDeps(
-        outbox.WrapPublisherForCell(outbox.DiscardPublisher{}),
+        outbox.WrapPublisherForCell(&outbox.DiscardPublisher{}),
         outbox.WrapWriterForCell(outbox.NoopWriter{}),
     ),
     mycell.WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})),

--- a/runtime/audit/ledger/mem_store.go
+++ b/runtime/audit/ledger/mem_store.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -240,40 +239,6 @@ func (m *MemStore) Verify(_ context.Context, fromSeq, toSeq int64) (valid bool, 
 // kernel/healthz.RepoProber.
 func (m *MemStore) RepoReady(_ context.Context) error {
 	return nil
-}
-
-// MustTamperEntryHash directly modifies the Hash field of the stored entry at
-// the given seq_no (1-indexed). Used only by storetest for negative Verify cases.
-//
-// This method is intentionally exported from the test-only MemStore so that
-// storetest can construct tampered-chain scenarios without coupling the test
-// infrastructure to the concrete store type outside this package. The Must*
-// prefix follows PANIC-REGISTERED-01: panicking on an out-of-range seq_no is a
-// B-class assertion (programming error in the test caller).
-func (m *MemStore) MustTamperEntryHash(seq int64, newHash string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	idx := seq - 1
-	if int(idx) < 0 || int(idx) >= len(m.entries) {
-		panic(panicregister.Approved("audit-mem-tamper-hash-out-of-range",
-			errcode.Assertion("MustTamperEntryHash: seq %d out of range [1, %d]", seq, len(m.entries))))
-	}
-	m.entries[idx].Hash = newHash
-}
-
-// MustTamperEntryPrevHash directly modifies the PrevHash field of the stored
-// entry at the given seq_no (1-indexed). Used only by storetest for negative
-// Verify cases. The Must* prefix follows PANIC-REGISTERED-01: panicking on an
-// out-of-range seq_no is a B-class assertion (programming error in the test caller).
-func (m *MemStore) MustTamperEntryPrevHash(seq int64, newPrevHash string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	idx := seq - 1
-	if int(idx) < 0 || int(idx) >= len(m.entries) {
-		panic(panicregister.Approved("audit-mem-tamper-prev-hash-out-of-range",
-			errcode.Assertion("MustTamperEntryPrevHash: seq %d out of range [1, %d]", seq, len(m.entries))))
-	}
-	m.entries[idx].PrevHash = newPrevHash
 }
 
 // validatePayloadJSON checks that payload is a valid JSON object or null.

--- a/runtime/audit/ledger/mem_store_tamper_test.go
+++ b/runtime/audit/ledger/mem_store_tamper_test.go
@@ -1,0 +1,160 @@
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+)
+
+// tamperEntryHash directly modifies the Hash field of the stored entry at the
+// given seq (1-indexed). Test-only helper — physically isolated to _test.go so
+// it is excluded from the production binary.
+//
+// Panics with a plain fmt.Sprintf message on out-of-range seq. Test files are
+// excluded from PANIC-REGISTERED-01 enforcement (archtest skips _test.go), so
+// plain panic is acceptable here.
+func (m *MemStore) tamperEntryHash(seq int64, newHash string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	idx := seq - 1
+	if int(idx) < 0 || int(idx) >= len(m.entries) {
+		panic(fmt.Sprintf("tamperEntryHash: seq %d out of range [1, %d]", seq, len(m.entries)))
+	}
+	m.entries[idx].Hash = newHash
+}
+
+// tamperEntryPrevHash directly modifies the PrevHash field of the stored entry
+// at the given seq (1-indexed). Test-only helper — physically isolated to
+// _test.go so it is excluded from the production binary.
+func (m *MemStore) tamperEntryPrevHash(seq int64, newPrevHash string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	idx := seq - 1
+	if int(idx) < 0 || int(idx) >= len(m.entries) {
+		panic(fmt.Sprintf("tamperEntryPrevHash: seq %d out of range [1, %d]", seq, len(m.entries)))
+	}
+	m.entries[idx].PrevHash = newPrevHash
+}
+
+// newTestProtocolForTamper constructs a test Protocol; mirrors newTestProtocol
+// in mem_store_test.go but lives in the same-package test file to access
+// package-internal fields after tampering.
+func newTestProtocolForTamper(t *testing.T) *Protocol {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	ns, err := ParseNamespaceID("auditcore")
+	if err != nil {
+		t.Fatalf("ParseNamespaceID: %v", err)
+	}
+	p, err := NewProtocol(
+		WithChainHMAC(key),
+		WithNamespace(ns),
+		WithRestartRecovery(RestartRecoveryStrictTailVerify{}),
+		WithIdempotency(IdempotencyContentFingerprint{}),
+	)
+	if err != nil {
+		t.Fatalf("NewProtocol: %v", err)
+	}
+	return p
+}
+
+// TestMemStore_VerifyTamperedHash: a MemStore entry with a corrupted Hash field
+// must cause Verify to return valid=false at that seq_no.
+//
+// F5: negative Verify case; moved here from storetest.runVerifyTamperedHash
+// (A-05 refactor: MustTamperEntryHash removed from production export surface).
+func TestMemStore_VerifyTamperedHash(t *testing.T) {
+	t.Parallel()
+	fc := clockmock.New(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	p := newTestProtocolForTamper(t)
+
+	store, err := NewMemStore(p, fc)
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+
+	e := &Entry{
+		EventID:   "tamper-hash-evt",
+		EventType: "tamper.test",
+		ActorID:   "actor",
+		Timestamp: fc.Now(),
+		Payload:   []byte(`{}`),
+	}
+	if err := store.Append(context.Background(), e); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// Tamper the stored entry's Hash via the unexported test helper.
+	store.tamperEntryHash(1, "tampered-hash-value")
+
+	valid, firstInvalid, err := store.Verify(context.Background(), 1, 1)
+	if err != nil {
+		t.Fatalf("Verify: unexpected error: %v", err)
+	}
+	if valid {
+		t.Error("Verify: expected valid=false after Hash tampering")
+	}
+	if firstInvalid != 1 {
+		t.Errorf("Verify: firstInvalidSeq: got %d, want 1", firstInvalid)
+	}
+
+	// Confirm the stored hash no longer matches the recomputed hash.
+	entry, err := store.GetBySeq(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetBySeq: %v", err)
+	}
+	correctHash := p.ComputeHash(entry.PrevHash, entry)
+	if entry.Hash == correctHash {
+		t.Error("tampered hash unexpectedly matches recomputed hash")
+	}
+}
+
+// TestMemStore_VerifyTamperedPrevHash: a MemStore entry with a corrupted
+// PrevHash field must cause Verify to return valid=false at that seq_no.
+//
+// F5: negative Verify case; moved here from storetest.runVerifyTamperedPrevHash
+// (A-05 refactor: MustTamperEntryPrevHash removed from production export surface).
+func TestMemStore_VerifyTamperedPrevHash(t *testing.T) {
+	t.Parallel()
+	fc := clockmock.New(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	p := newTestProtocolForTamper(t)
+
+	store, err := NewMemStore(p, fc)
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+
+	// Append two entries so seq 2 has a meaningful PrevHash linkage.
+	for i, id := range []string{"prev-hash-evt-1", "prev-hash-evt-2"} {
+		e := &Entry{
+			EventID:   id,
+			EventType: "tamper.test",
+			ActorID:   "actor",
+			Timestamp: fc.Now(),
+			Payload:   []byte(`{}`),
+		}
+		if err := store.Append(context.Background(), e); err != nil {
+			t.Fatalf("Append %d: %v", i+1, err)
+		}
+	}
+
+	// Tamper the second entry's PrevHash — breaks the chain link between seq 1 and seq 2.
+	store.tamperEntryPrevHash(2, "tampered-prev-hash")
+
+	valid, firstInvalid, err := store.Verify(context.Background(), 1, 2)
+	if err != nil {
+		t.Fatalf("Verify: unexpected error: %v", err)
+	}
+	if valid {
+		t.Error("Verify: expected valid=false after PrevHash tampering")
+	}
+	if firstInvalid != 2 {
+		t.Errorf("Verify: firstInvalidSeq: got %d, want 2", firstInvalid)
+	}
+}

--- a/runtime/audit/ledger/mem_store_tamper_test.go
+++ b/runtime/audit/ledger/mem_store_tamper_test.go
@@ -1,3 +1,22 @@
+// Package ledger — in-package (white-box) test file.
+//
+// This file uses `package ledger` (not `package ledger_test`) so the test
+// helpers tamperEntryHash / tamperEntryPrevHash can access *MemStore's
+// unexported entries field. The sibling mem_store_test.go uses
+// `package ledger_test` (black-box, exercises only the public surface).
+//
+// Test-only physical exclusion (A-05, ADR docs/architecture/202605171800-
+// adr-kernel-mustctor-removal.md): defining the tamper helpers in this
+// _test.go file removes them from the production binary (Go `go build` does
+// not compile _test.go), making "any production caller of tamper" not just
+// banned but unrepresentable.
+//
+// Panic discipline: bare panic(fmt.Sprintf(...)) is used below for
+// out-of-range diagnostics because PANIC-REGISTERED-01 archtest skips
+// _test.go files. If future maintainers need a tamper helper in
+// production source (mem_store.go), the panic must be wrapped with
+// panicregister.Approved(...) per PANIC-REGISTERED-01.
+
 package ledger
 
 import (

--- a/runtime/audit/ledger/protocol.go
+++ b/runtime/audit/ledger/protocol.go
@@ -120,22 +120,12 @@ func ParseNamespaceID(s string) (NamespaceID, error) {
 // Protocol bundles the protocol decisions that govern an audit ledger.
 //
 // Fields are required (NewProtocol fail-fasts on missing values) and are
-// immutable after construction. Accessor methods return defensive copies
-// where applicable.
+// immutable after construction.
 type Protocol struct {
 	hmacKey         []byte
 	namespace       NamespaceID
 	restartRecovery RestartRecoveryMode
 	idempotency     IdempotencyMode
-}
-
-// HMACKey returns a defensive copy of the configured HMAC key.
-// The returned slice must not be used for logging or error messages —
-// HMAC key bytes are secret material.
-func (p *Protocol) HMACKey() []byte {
-	out := make([]byte, len(p.hmacKey))
-	copy(out, p.hmacKey)
-	return out
 }
 
 // Namespace returns the configured namespace identifier.

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -430,15 +430,18 @@ func TestNewProtocol_Error_OnMissingOptions(t *testing.T) {
 	}
 }
 
-// TestProtocol_HMACKeyDefensiveCopy: HMACKey() returns a defensive copy.
-func TestProtocol_HMACKeyDefensiveCopy(t *testing.T) {
+// TestWithChainHMAC_CallerSliceZeroedAfterCopy: WithChainHMAC zeroes the
+// caller's key slice after the defensive copy so that HMAC key material
+// does not linger in the caller's allocation. Verifies the clear(key) call
+// in WithChainHMAC body (A-08: HMACKey getter deleted from export surface).
+func TestWithChainHMAC_CallerSliceZeroedAfterCopy(t *testing.T) {
 	t.Parallel()
 	key := make([]byte, 32)
 	for i := range key {
 		key[i] = byte(i + 1)
 	}
 	ns, _ := ledger.ParseNamespaceID("auditcore")
-	p, err := ledger.NewProtocol(
+	_, err := ledger.NewProtocol(
 		ledger.WithChainHMAC(key),
 		ledger.WithNamespace(ns),
 		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
@@ -447,15 +450,10 @@ func TestProtocol_HMACKeyDefensiveCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProtocol: %v", err)
 	}
-	got := p.HMACKey()
-	if len(got) != len(key) {
-		t.Fatalf("HMACKey length: got %d, want %d", len(got), len(key))
-	}
-	// Mutate the returned copy.
-	got[0] = 0xFF
-	again := p.HMACKey()
-	if again[0] == 0xFF {
-		t.Error("HMACKey() must return a defensive copy; caller mutation leaked into protocol")
+	for i, b := range key {
+		if b != 0 {
+			t.Errorf("caller key byte %d not zeroed after WithChainHMAC: got %#x", i, b)
+		}
 	}
 }
 

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -246,30 +246,21 @@ func TestNewProtocol_WithNamespaceMissing_Rejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// A-06 RED: With* Option nil → immediate error (short-circuit), not sticky sentinel.
+// With* Option nil → immediate error (short-circuit, no sentinel sticky).
 //
-// Current implementation uses a sentinel flag (hmacKeyNil / restartRecoveryNil /
-// idempotencyNil) that is checked only at the end of NewProtocol. The target
-// semantics require the Option func itself to return an error immediately so that
-// NewProtocol short-circuits and does NOT execute subsequent options.
-//
-// We test this by inserting a side-effect "probe" option after the nil option:
-//   - RED (current): probe runs because nil option returns nil error
-//   - GREEN (after fix): probe does NOT run because nil option returns error → short-circuit
+// Each Option func returns a non-nil error on receiving an invalid input
+// (nil / empty / zero-value), causing NewProtocol to stop applying subsequent
+// options. The pattern below inserts an invalid option followed by a valid one
+// and asserts the immediate error wins — the second valid call cannot mask the
+// first invalid call.
 // ---------------------------------------------------------------------------
 
 // TestWithChainHMAC_NilReturnsError_Immediate verifies that WithChainHMAC(nil)
-// causes NewProtocol to short-circuit immediately, not execute subsequent options.
-//
-// A-06 RED: current WithChainHMAC(nil) returns nil error (sets hmacKeyNil sentinel).
-// The sentinel-sticky doctrine means the nil option returns nil, subsequent options
-// still run, and the error is only detected at the END of NewProtocol.
-//
-// After A-06 fix: the Option itself must return a non-nil error immediately,
-// making NewProtocol stop applying further options. The observable: passing
-// WithChainHMAC(nil) then WithChainHMAC(validKey) must still fail — and the
-// error message must indicate "nil/empty key" (immediate error), not the deferred
-// "HMAC key required (use WithChainHMAC)" sentinel message.
+// returns an error immediately so NewProtocol short-circuits and does not
+// execute subsequent options. The observable: passing WithChainHMAC(nil) then
+// WithChainHMAC(validKey) must still fail, and the error message must mention
+// "nil"/"empty" (immediate error from the Option func itself, not a deferred
+// "key required" message).
 func TestWithChainHMAC_NilReturnsError_Immediate(t *testing.T) {
 	t.Parallel()
 	ns, _ := ledger.ParseNamespaceID("auditcore")
@@ -286,22 +277,19 @@ func TestWithChainHMAC_NilReturnsError_Immediate(t *testing.T) {
 		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
 	)
 	if err == nil {
-		t.Fatal("A-06: WithChainHMAC(nil) followed by valid key must still return error")
+		t.Fatal("WithChainHMAC(nil) followed by valid key must still return error")
 	}
 	errStr := err.Error()
-	// RED assertion: current deferred sentinel message is "HMAC key required (use WithChainHMAC".
-	// GREEN: immediate error mentions "nil" or "empty" (not the deferred sentinel).
-	// This FAILS in RED state because the sentinel message does not contain "nil" or "empty".
+	// Immediate error must mention "nil" or "empty" — not a deferred "key required" sentinel.
 	if !containsAny(errStr, "nil", "empty", "missing key") {
-		t.Errorf("A-06 RED: WithChainHMAC(nil) should immediately return error "+
-			"mentioning 'nil' or 'empty', got deferred sentinel message: %q", errStr)
+		t.Errorf("WithChainHMAC(nil) should immediately return error "+
+			"mentioning 'nil' or 'empty', got %q", errStr)
 	}
 }
 
 // TestWithNamespace_EmptyReturnsError_Immediate verifies that WithNamespace("")
-// causes NewProtocol to short-circuit immediately.
-//
-// A-06 RED: current WithNamespace("") sets namespaceNil sentinel (deferred check).
+// returns an error immediately so NewProtocol short-circuits and does not
+// apply the subsequent valid namespace.
 func TestWithNamespace_EmptyReturnsError_Immediate(t *testing.T) {
 	t.Parallel()
 	validKey := make([]byte, 32)
@@ -310,9 +298,8 @@ func TestWithNamespace_EmptyReturnsError_Immediate(t *testing.T) {
 	}
 	validNS, _ := ledger.ParseNamespaceID("auditcore")
 
-	// Passing empty namespace then valid namespace: target semantics = short-circuit,
-	// valid NS option never runs → protocol is nil.
-	// Current semantics = sentinel-sticky → error at end even after valid NS is set.
+	// Passing empty namespace then valid namespace: short-circuit semantics =
+	// valid NS option never runs because the first call returns an error.
 	_, err := ledger.NewProtocol(
 		ledger.WithChainHMAC(validKey),
 		ledger.WithNamespace(""), // empty NamespaceID = typed zero value
@@ -321,21 +308,19 @@ func TestWithNamespace_EmptyReturnsError_Immediate(t *testing.T) {
 		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
 	)
 	if err == nil {
-		t.Fatal("A-06: WithNamespace(\"\") followed by valid namespace must still return error")
+		t.Fatal("WithNamespace(\"\") followed by valid namespace must still return error")
 	}
 	errStr := err.Error()
-	// A-06 RED: current error is the deferred "namespace required" sentinel message.
-	// GREEN: error is immediate and mentions "empty" or the zero-value namespace specifically.
+	// Immediate error must mention "empty" — not a deferred "namespace required" sentinel.
 	if !containsAny(errStr, "empty", "must not be empty", "namespace ID must not be empty") {
-		t.Errorf("A-06 RED: WithNamespace(\"\") should immediately return error "+
-			"mentioning empty namespace, got deferred sentinel: %q", errStr)
+		t.Errorf("WithNamespace(\"\") should immediately return error "+
+			"mentioning empty namespace, got %q", errStr)
 	}
 }
 
 // TestWithRestartRecovery_NilReturnsError_Immediate verifies that
-// WithRestartRecovery(nil) causes NewProtocol to short-circuit immediately.
-//
-// A-06 RED: current implementation sets restartRecoveryNil sentinel (deferred).
+// WithRestartRecovery(nil) returns an error immediately so NewProtocol
+// short-circuits and does not apply the subsequent valid mode.
 func TestWithRestartRecovery_NilReturnsError_Immediate(t *testing.T) {
 	t.Parallel()
 	validKey := make([]byte, 32)
@@ -345,7 +330,7 @@ func TestWithRestartRecovery_NilReturnsError_Immediate(t *testing.T) {
 	ns, _ := ledger.ParseNamespaceID("auditcore")
 	var nilRR ledger.RestartRecoveryMode // typed nil
 
-	// nil then valid: target = short-circuit; current = sentinel-sticky error at end.
+	// nil then valid: short-circuit means the valid mode never runs.
 	_, err := ledger.NewProtocol(
 		ledger.WithChainHMAC(validKey),
 		ledger.WithNamespace(ns),
@@ -354,22 +339,19 @@ func TestWithRestartRecovery_NilReturnsError_Immediate(t *testing.T) {
 		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
 	)
 	if err == nil {
-		t.Fatal("A-06: WithRestartRecovery(nil) followed by valid mode must still return error")
+		t.Fatal("WithRestartRecovery(nil) followed by valid mode must still return error")
 	}
 	errStr := err.Error()
-	// A-06 RED: current error is the deferred sentinel message.
-	// GREEN: error comes from WithRestartRecovery option immediately and mentions
-	// nil/invalid directly rather than "restart recovery mode required".
+	// Immediate error must mention nil/invalid — not a deferred "mode required" sentinel.
 	if !containsAny(errStr, "nil", "invalid", "must not be nil") {
-		t.Errorf("A-06 RED: WithRestartRecovery(nil) should immediately error "+
-			"mentioning nil/invalid, got deferred sentinel: %q", errStr)
+		t.Errorf("WithRestartRecovery(nil) should immediately error "+
+			"mentioning nil/invalid, got %q", errStr)
 	}
 }
 
 // TestWithIdempotency_NilReturnsError_Immediate verifies that
-// WithIdempotency(nil) causes NewProtocol to short-circuit immediately.
-//
-// A-06 RED: current implementation sets idempotencyNil sentinel (deferred).
+// WithIdempotency(nil) returns an error immediately so NewProtocol
+// short-circuits and does not apply the subsequent valid mode.
 func TestWithIdempotency_NilReturnsError_Immediate(t *testing.T) {
 	t.Parallel()
 	validKey := make([]byte, 32)
@@ -379,7 +361,7 @@ func TestWithIdempotency_NilReturnsError_Immediate(t *testing.T) {
 	ns, _ := ledger.ParseNamespaceID("auditcore")
 	var nilIM ledger.IdempotencyMode // typed nil
 
-	// nil then valid: target = short-circuit; current = sentinel-sticky error at end.
+	// nil then valid: short-circuit means the valid mode never runs.
 	_, err := ledger.NewProtocol(
 		ledger.WithChainHMAC(validKey),
 		ledger.WithNamespace(ns),
@@ -388,14 +370,13 @@ func TestWithIdempotency_NilReturnsError_Immediate(t *testing.T) {
 		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
 	)
 	if err == nil {
-		t.Fatal("A-06: WithIdempotency(nil) followed by valid mode must still return error")
+		t.Fatal("WithIdempotency(nil) followed by valid mode must still return error")
 	}
 	errStr := err.Error()
-	// A-06 RED: current error is the deferred sentinel message.
-	// GREEN: error comes from WithIdempotency option immediately and mentions nil.
+	// Immediate error must mention nil/invalid — not a deferred "mode required" sentinel.
 	if !containsAny(errStr, "nil", "invalid", "must not be nil") {
-		t.Errorf("A-06 RED: WithIdempotency(nil) should immediately error "+
-			"mentioning nil/invalid, got deferred sentinel: %q", errStr)
+		t.Errorf("WithIdempotency(nil) should immediately error "+
+			"mentioning nil/invalid, got %q", errStr)
 	}
 }
 

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -430,30 +430,71 @@ func TestNewProtocol_Error_OnMissingOptions(t *testing.T) {
 	}
 }
 
-// TestWithChainHMAC_CallerSliceZeroedAfterCopy: WithChainHMAC zeroes the
-// caller's key slice after the defensive copy so that HMAC key material
-// does not linger in the caller's allocation. Verifies the clear(key) call
-// in WithChainHMAC body (A-08: HMACKey getter deleted from export surface).
+// TestWithChainHMAC_CallerSliceZeroedAfterCopy verifies the security invariant
+// that WithChainHMAC zeroes the caller's key slice via clear(key) after copy.
+// Removing the clear(key) call in WithChainHMAC body causes the "happy" subtest
+// to fail: each key byte remains non-zero. Replaces TestProtocol_HMACKeyDefensiveCopy
+// (HMACKey getter removed per A-08).
+//
+// Boundary cases (nil / short key) verify the documented fail-fast behavior:
+// WithChainHMAC returns an error before clear() runs, and the caller slice is
+// left untouched — no crash, no silent data alteration.
 func TestWithChainHMAC_CallerSliceZeroedAfterCopy(t *testing.T) {
 	t.Parallel()
-	key := make([]byte, 32)
-	for i := range key {
-		key[i] = byte(i + 1)
-	}
 	ns, _ := ledger.ParseNamespaceID("auditcore")
-	_, err := ledger.NewProtocol(
-		ledger.WithChainHMAC(key),
-		ledger.WithNamespace(ns),
-		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
-		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
-	)
-	if err != nil {
-		t.Fatalf("NewProtocol: %v", err)
+
+	tests := []struct {
+		name       string
+		keyLen     int // -1 → nil key
+		wantErr    bool
+		wantZeroed bool // post-call caller slice all-zero check
+	}{
+		{"happy_32_byte", 32, false, true},
+		{"short_31_byte_rejected", 31, true, false}, // clear() never runs; caller slice untouched
+		{"nil_key_rejected", -1, true, false},       // nil-safe: clear(nil) is no-op
 	}
-	for i, b := range key {
-		if b != 0 {
-			t.Errorf("caller key byte %d not zeroed after WithChainHMAC: got %#x", i, b)
-		}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var key []byte
+			if tt.keyLen >= 0 {
+				key = make([]byte, tt.keyLen)
+				for i := range key {
+					key[i] = byte(i + 1)
+				}
+			}
+			_, err := ledger.NewProtocol(
+				ledger.WithChainHMAC(key),
+				ledger.WithNamespace(ns),
+				ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
+				ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
+			)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NewProtocol: expected error for %s, got nil", tt.name)
+				}
+				if tt.keyLen > 0 {
+					// Caller slice should be unchanged (no clear ran)
+					if key[0] == 0 {
+						t.Errorf("caller key unexpectedly zeroed on error path for %s; clear() must only run on success", tt.name)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewProtocol: %v", err)
+			}
+			if tt.wantZeroed {
+				for i, b := range key {
+					if b != 0 {
+						t.Errorf("caller key not zeroed: first non-zero byte at index %d = %#x (additional non-zero bytes suppressed)", i, b)
+						break // C.F2: surface first failure only
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -117,9 +117,11 @@ func NewEntryFixture(t *testing.T, eventID, eventType, actorID string, now time.
 // Run executes the Protocol-driven contract suite against factory. All backends
 // share NewTestProtocol to prove parity on the same protocol decisions.
 //
-// The protocol parameter must match the protocol passed to Factory; it is
-// validated non-nil to catch misconfigured callers at test setup time. The
-// Verify_Tampered* cases previously accepted via this parameter have been
+// The protocol parameter is the same instance the Factory uses internally; the
+// Protocol_HashParity subtest re-computes ComputeHash on appended entries to
+// prove the store's persisted hash matches the protocol's output byte-for-byte
+// (the core single-source contract between Store implementations and Protocol).
+// The Verify_Tampered* cases previously accepted via this parameter have been
 // relocated to mem_store_tamper_test.go (A-05 refactor).
 func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Helper()
@@ -147,6 +149,7 @@ func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Run("Query_ByFilters", func(t *testing.T) { runQueryByFilters(t, factory) })
 	t.Run("Append_MultiKey_Payload_RoundTrip", func(t *testing.T) { runAppendMultiKeyPayloadRoundTrip(t, factory) })
 	t.Run("Query_Ordering_TimestampDesc_IDAsc", func(t *testing.T) { runQueryOrderingTimestampDescIDAsc(t, factory) })
+	t.Run("Protocol_HashParity", func(t *testing.T) { runProtocolHashParity(t, factory, protocol) })
 }
 
 // runAppendTailRoundTrip: Append persists entry; Tail advances; GetBySeq returns entry.
@@ -558,6 +561,51 @@ func runQueryOrderingTimestampDescIDAsc(t *testing.T, factory Factory) {
 				"(F-05: both backends must sort timestamp DESC)",
 				i, gotEventID, wantEventID)
 		}
+	}
+}
+
+// runProtocolHashParity verifies that a Store's persisted entry.Hash matches
+// protocol.ComputeHash byte-for-byte. This is the single-source contract
+// between Store implementations and Protocol: both Mem and PG stores must
+// produce identical hashes for identical inputs, otherwise chain continuity
+// breaks when a payload migrates across backends or a Verify spans the cut.
+//
+// Two entries cover both prevHash branches:
+//   - seq 1: prevHash="" (chain root)
+//   - seq 2: prevHash=entry1.Hash (chain link)
+func runProtocolHashParity(t *testing.T, factory Factory, protocol *ledger.Protocol) {
+	store, fc, cleanup := factory(t)
+	defer cleanup()
+
+	e1 := NewEntryFixture(t, "parity-1", "parity.test", "actor-parity", fc.Now())
+	if err := store.Append(context.Background(), e1); err != nil {
+		t.Fatalf("Append seq 1: %v", err)
+	}
+	e2 := NewEntryFixture(t, "parity-2", "parity.test", "actor-parity", fc.Now())
+	if err := store.Append(context.Background(), e2); err != nil {
+		t.Fatalf("Append seq 2: %v", err)
+	}
+
+	got1, err := store.GetBySeq(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetBySeq 1: %v", err)
+	}
+	want1 := protocol.ComputeHash("", got1)
+	if got1.Hash != want1 {
+		t.Errorf("seq 1 hash parity broken: store=%s protocol=%s "+
+			"(Store implementation and Protocol must agree byte-for-byte)",
+			got1.Hash, want1)
+	}
+
+	got2, err := store.GetBySeq(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("GetBySeq 2: %v", err)
+	}
+	want2 := protocol.ComputeHash(got1.Hash, got2)
+	if got2.Hash != want2 {
+		t.Errorf("seq 2 hash parity broken: store=%s protocol=%s "+
+			"(chain link broken — Store does not use Protocol.ComputeHash for prevHash threading)",
+			got2.Hash, want2)
 	}
 }
 

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -117,8 +117,10 @@ func NewEntryFixture(t *testing.T, eventID, eventType, actorID string, now time.
 // Run executes the Protocol-driven contract suite against factory. All backends
 // share NewTestProtocol to prove parity on the same protocol decisions.
 //
-// The protocol parameter is used by the Verify_Tampered* cases to recompute
-// expected hashes for comparison. It must match the protocol passed to Factory.
+// The protocol parameter must match the protocol passed to Factory; it is
+// validated non-nil to catch misconfigured callers at test setup time. The
+// Verify_Tampered* cases previously accepted via this parameter have been
+// relocated to mem_store_tamper_test.go (A-05 refactor).
 func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Helper()
 	if factory == nil {
@@ -136,8 +138,6 @@ func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Run("Concurrent_Append_HashChainValid", func(t *testing.T) { runConcurrentAppendHashChainValid(t, factory) })
 	t.Run("StrictPayload_InvalidJSON", func(t *testing.T) { runStrictPayloadInvalidJSON(t, factory) })
 	t.Run("Verify_FullRange", func(t *testing.T) { runVerifyFullRange(t, factory) })
-	t.Run("Verify_TamperedHash", func(t *testing.T) { runVerifyTamperedHash(t, factory, protocol) })
-	t.Run("Verify_TamperedPrevHash", func(t *testing.T) { runVerifyTamperedPrevHash(t, factory, protocol) })
 	t.Run("GetBySeq_NotFound", func(t *testing.T) {
 		store, _, cleanup := factory(t)
 		defer cleanup()
@@ -420,89 +420,6 @@ func runVerifyFullRange(t *testing.T, factory Factory) {
 	if !valid {
 		t.Errorf("Verify: expected valid, first invalid at seq %d", firstInvalid)
 	}
-}
-
-// runVerifyTamperedHash: a MemStore entry with a corrupted Hash field must
-// cause Verify to return valid=false at that seq_no.
-//
-// F5: negative Verify case using protocol.ComputeHash for expected-hash reference.
-// This function uses a type-switch to access MemStore internals — only MemStore
-// (the test-only in-process backend) supports direct field tampering; PG store
-// tampered cases require external SQL manipulation and belong in integration tests.
-func runVerifyTamperedHash(t *testing.T, factory Factory, protocol *ledger.Protocol) {
-	store, fc, cleanup := factory(t)
-	defer cleanup()
-
-	e := NewEntryFixture(t, "tamper-hash-evt", "tamper.test", "actor", fc.Now())
-	if err := store.Append(context.Background(), e); err != nil {
-		t.Fatalf(msgAppend, err)
-	}
-
-	ms, ok := store.(*ledger.MemStore)
-	if !ok {
-		t.Skip("Verify_TamperedHash requires *ledger.MemStore; skipping for non-MemStore backends")
-	}
-
-	// Tamper the stored entry's Hash via MemStore test helper.
-	ms.MustTamperEntryHash(1, "tampered-hash-value")
-
-	valid, firstInvalid, err := store.Verify(context.Background(), 1, 1)
-	if err != nil {
-		t.Fatalf("Verify: unexpected error: %v", err)
-	}
-	if valid {
-		t.Error("Verify: expected valid=false after Hash tampering")
-	}
-	if firstInvalid != 1 {
-		t.Errorf("Verify: firstInvalidSeq: got %d, want 1", firstInvalid)
-	}
-
-	// Confirm protocol can still recompute the correct hash from stored data.
-	entry, err := store.GetBySeq(context.Background(), 1)
-	if err != nil {
-		t.Fatalf("GetBySeq: %v", err)
-	}
-	correctHash := protocol.ComputeHash(entry.PrevHash, entry)
-	if entry.Hash == correctHash {
-		t.Error("tampered hash unexpectedly matches recomputed hash")
-	}
-}
-
-// runVerifyTamperedPrevHash: a MemStore entry with a corrupted PrevHash field
-// must cause Verify to return valid=false at that seq_no.
-//
-// F5: negative Verify case; mirrors runVerifyTamperedHash but targets PrevHash linkage.
-func runVerifyTamperedPrevHash(t *testing.T, factory Factory, protocol *ledger.Protocol) {
-	store, fc, cleanup := factory(t)
-	defer cleanup()
-
-	// Append two entries so seq 2 has a meaningful PrevHash linkage.
-	for i, id := range []string{"prev-hash-evt-1", "prev-hash-evt-2"} {
-		e := NewEntryFixture(t, id, "tamper.test", "actor", fc.Now())
-		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf(msgAppendIdx, i+1, err)
-		}
-	}
-
-	ms, ok := store.(*ledger.MemStore)
-	if !ok {
-		t.Skip("Verify_TamperedPrevHash requires *ledger.MemStore; skipping for non-MemStore backends")
-	}
-
-	// Tamper the second entry's PrevHash — breaks the chain link between seq 1 and seq 2.
-	ms.MustTamperEntryPrevHash(2, "tampered-prev-hash")
-
-	valid, firstInvalid, err := store.Verify(context.Background(), 1, 2)
-	if err != nil {
-		t.Fatalf("Verify: unexpected error: %v", err)
-	}
-	if valid {
-		t.Error("Verify: expected valid=false after PrevHash tampering")
-	}
-	if firstInvalid != 2 {
-		t.Errorf("Verify: firstInvalidSeq: got %d, want 2", firstInvalid)
-	}
-	_ = protocol // used for documentation; hash recomputation is in runVerifyTamperedHash
 }
 
 // runQueryByFilters: Query returns only entries matching the filter.

--- a/tools/archtest/audit_ledger_composition_root_test.go
+++ b/tools/archtest/audit_ledger_composition_root_test.go
@@ -24,11 +24,6 @@
 //
 // Allowlist is enumerated, not prefix-based — adding a sibling sub-package
 // (e.g. `runtime/audit/ledger/dump/`) must be an explicit decision (K-04).
-//
-// Sentinel sticky doctrine: 4 wiring options (WithChainHMAC / WithNamespace /
-// WithRestartRecovery / WithIdempotency) each have a xxxNil bool sticky flag
-// that is set when a nil interface value is received and is never cleared by
-// a subsequent valid call — misconfiguration must not be silently masked.
 package archtest
 
 import (

--- a/tools/archtest/kernel_mustctor_production_decl_test.go
+++ b/tools/archtest/kernel_mustctor_production_decl_test.go
@@ -117,13 +117,6 @@ var allowedMustDecls = map[string]map[string]struct{}{
 	"runtime/websocket": {
 		"MustValidateHubConfig": {},
 	},
-	// (c) test fixture method on test-only MemStore — exposed for storetest
-	// conformance suite (negative Verify cases). Cannot move to _test.go
-	// because storetest sub-package consumes these methods at suite runtime.
-	"runtime/audit/ledger": {
-		"MustTamperEntryHash":     {},
-		"MustTamperEntryPrevHash": {},
-	},
 }
 
 // testFixturePkgPrefixes are package path prefixes (module-relative) that are


### PR DESCRIPTION
## Summary

闭环 PR #441/#450 review 留下的 interface 出口表面 + 消费者文档缺口，覆盖 #836 issue body 的 Bundle 1 (PR441-DOC) + Bundle 2 (S7-FU-ARCH-EVO 实际 3 条)。

### Bundle 1 — 消费者文档闭环（PR441-DOC，P1/Cx3）
- README §"30-Minute Tutorial" Step 4 — 改 4-段式 ISP 子接口断言 (`CellIdentity` / `CellLifecycle` / `CellStatus` / `CellInventory`) + 末尾 Further Reading 链 ADR/guides
- `docs/guides/cell-development-guide.md` — 4-段式断言改写 + §"Outbox 注入：sealed marker 模式" demo/production 对照例 + §"按 cell 能力选 outbox option 形态" decision table
- `docs/guides/codegen-new-endpoint.md` — composition root wrap 注入示例 + Common mistakes 新条目
- `docs/guides/why-sealed-marker.md` (NEW, 217 行) — 消费者视角 FAQ（为什么 wrap / 不 wrap 编译错误形态 / Demo/Production/Test 三场景）
- `docs/guides/cell-interface-isp.md` (NEW, 270 行) — 消费者视角 ISP 4 子接口拆分解释
- 2 ADR 顶部加 audience note 指向消费者面 guide

**消费者文档命中**：grep 验证 `CellIdentity|CellLifecycle|CellStatus|CellInventory|CellTxManager|CellPublisher|CellWriter|Wrap*ForCell` 在 README + 4 guides 命中 100+（原 0 命中）

### Bundle 2 — ARCH-EVO 出口表面收口
- **A-05** (P1/Cx2): `MemStore.MustTamperEntryHash` / `MustTamperEntryPrevHash` 移到 `mem_store_tamper_test.go` (`_test.go` file `go build` 不编译 → 生产二进制方法物理不存在) + 改 unexported `tamperEntryHash` / `tamperEntryPrevHash` + 测试 suite 从 storetest 移入 mem_store 同包 + 删除 archtest whitelist 2 条 + 同步 ADR `202605171800-adr-kernel-mustctor-removal.md` 标 REMOVED
- **A-08** (P2/Cx1): 删 `Protocol.HMACKey()` getter + 删 `TestProtocol_HMACKeyDefensiveCopy` (依赖物消失) + **新增** `TestWithChainHMAC_CallerSliceZeroedAfterCopy` 直接验证 `clear(key)` 安全不变量（修复 PR #450 落地时未覆盖的 caller heap key residue 测试空洞）
- **F-14** (P2/Cx1): backlog 注册 PERMISSION-BASED-AUTHZ-01 → gh issue #914 + handler.go 注释更新指向 #914

### 跳过项（issue body 同列但已 ship）
- F-04 (strictTailVerifyOnStartup 30s timeout): `cells/auditcore/cell.go:33,301` 已 ship + `TestStrictTailVerifyOnStartup_TimeoutCapped` 覆盖
- A-04 (LedgerStore.Probes() 删除): 已 by PR-REPO-READYZ

### 不在范围
- Bundle 3 (S7-FU-DOCS 14 条) — 按 implementation plan §6.3 hold，trigger=S7 接口/PG 演进窗口；本 PR `Refs #836`（不 Closes，父 bundle 待 Bundle 3 落地后关）

## 四原则自评

| 措施 | 彻底 | 不向后兼容 | 优雅简洁 | AI-Hard |
|------|------|-----------|---------|---------|
| A-05 tamper 移 _test.go + unexport | ✓ 根因解，非 patch | ✓ 无 deprecation | ✓ 无新 build tag/新 sealed 包 | **Hard** (生产二进制方法不存在) |
| A-08 删 HMACKey() | ✓ 删除 + 安全测试迁移 | ✓ pure 删除 | ✓ 净 -10/+15 | **Hard** (架构师原话「不可表达」) |
| F-14 backlog 注册 | ✓ issue body 仅要求注册 | N/A | ✓ 1 行注释 + 1 issue | N/A (bookkeeping) |
| Bundle 1 docs | ✓ 7 文件一次性闭环 | ✓ README 4-段式直替 | ✓ 2 separate guides 主题不同 | Soft (文档本质不可硬化，已显式声明边界) |

## Test plan

- [x] `go build ./...` (worktree) — passes
- [x] `go test ./...` (worktree) — passes (full suite green)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build -tags=integration ./...` — passes (改了 export 表面必跑)
- [x] `TestMemStore_VerifyTamperedHash` / `TestMemStore_VerifyTamperedPrevHash` — passes (新位置)
- [x] `TestWithChainHMAC_CallerSliceZeroedAfterCopy` — passes (替补 A-08 删除的 defensive copy 测试)
- [x] `TestKernelMustCtorProductionDecl` 等 archtest — passes (whitelist 删除后仍 green)
- [x] grep 验证 `MustTamperEntry` 全仓 0 live ref；`HMACKey()` 0 hit；docs 命中 100+

## Files

修改 (13): `README.md` + `docs/guides/cell-development-guide.md` + `docs/guides/codegen-new-endpoint.md` + 2 ADRs + `runtime/audit/ledger/{mem_store,protocol,protocol_test}.go` + `runtime/audit/ledger/storetest/suite.go` + `tools/archtest/kernel_mustctor_production_decl_test.go` + `cells/auditcore/slices/auditquery/handler.go` + ADR `202605171800-adr-kernel-mustctor-removal.md`
新增 (3): `docs/guides/why-sealed-marker.md` + `docs/guides/cell-interface-isp.md` + `runtime/audit/ledger/mem_store_tamper_test.go`
外部: gh issue #914

ref: PR #441 (ISP split + sealed marker) review `docs/reviews/202605110539-pr441-six-role/product-manager.md` PM-F2/F7
ref: PR #450 (audit ledger Protocol+Store) review `docs/reviews/PR-450/architect.md` A-05/A-08 + `reviewer.md` F-14
ref: Kubernetes apiserver healthz wire/log buffer separation pattern (HMAC key never in wire surface)
ref: hashicorp/vault `audit log_raw=false` 默认 fail-closed (HMACKey 出口收敛同源哲学)

Refs #836
Refs #914 (registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)