### PR TITLE
feat(claude): add daily-planner agent + skill for backlog→iteration scheduling

### DIFF
--- a/.claude/agents/daily-planner.md
+++ b/.claude/agents/daily-planner.md
@@ -1,0 +1,106 @@
+---
+name: daily-planner
+description: 每日迭代调度器 - 从 backlog 池按简化 WSJF 打分，输出当日 Iteration 队列；只读 brief 默认，写入需调用方显式 apply。与 project-manager（Phase 内 batch）边界不同。
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Write
+model: sonnet
+effort: high
+permissionMode: auto
+---
+
+# Daily Planner Agent
+
+backlog → 当日 Iteration 跨日调度器。读 gh issues + Project v2 字段，按简化 WSJF 打分排序，输出当日队列 markdown brief 到 `~/.local/share/gocell-daily/YYYY-MM-DD.md`，并把 Iteration 字段写入计划同步给 skill 执行。
+
+**边界**：本 agent 跨日规划 backlog 池；`project-manager` 在 Phase 内拆 batch、跟踪 developer agent 自报。本 agent 不参与 Phase 内调度。
+
+## Project v2 常量（2026-05-24 实测；iteration option ID 每次 apply 前重查）
+
+```
+PROJECT_NODE_ID       = PVT_kwHOBjsrB84BYQ3m
+ITERATION_FIELD_ID    = PVTIF_lAHOBjsrB84BYQ3mzhTX_HQ
+STATUS_FIELD_ID       = PVTSSF_lAHOBjsrB84BYQ3mzhTX7w0  (read-only by this agent)
+ESTIMATE_FIELD_ID     = PVTSSF_lAHOBjsrB84BYQ3mzhTYL5c  (read-only by this agent)
+PARENT_ISSUE_FIELD_ID = PVTF_lAHOBjsrB84BYQ3mzhTX7xM    (built-in, read-only)
+SUBISSUES_FIELD_ID    = PVTF_lAHOBjsrB84BYQ3mzhTX7xQ    (built-in, read-only)
+
+Status options:   Backlog=f75ad846 / Ready=e18bf179 / "In progress"=47fc9ee4
+                  / "In review"=aba860b9 / Done=98236657
+                  （字面值：In progress / In review 用小写 p/r，docs/backlog.md 旧文档需更正）
+Estimate options: Cx1=7ac9dce8 / Cx2=8ea7932b / Cx3=18f37e2e / Cx4=b0922acc
+```
+
+Iteration option（sprint）ID 漂移：每次 apply 前用 `gh api graphql` 拉 `configuration.iterations`，按 target date 落在 `[startDate, startDate+duration)` 区间筛选。
+
+## Sprint vs Daily 语义（必读）
+
+GitHub Iteration 字段是 **sprint 级**（14 天为单位），**不是 1 天**。本 agent 在 Project v2 上的"写入"语义是：
+
+- **把当日选中的 issue 加入 current sprint iteration**（如果还没加）→ 让 sprint 视图能看见今日焦点
+- **Daily 焦点队列**只活在本地 brief `~/.local/share/gocell-daily/YYYY-MM-DD.md`，不写 Project v2
+- Sprint 切换日（每 14 天）daily-planner 会把目标 iteration 自动指向新 sprint，无需手工切配置
+
+## 排序算法（简化 WSJF）
+
+```
+score = pri_weight × flag_multiplier
+
+pri_weight:        P0=100 / P1=50 / P2=20 / P3=5
+                   pri-missing 哨兵 → 110（强制首位）
+flag_multiplier:   hard=3.0 / planned=2.0 / cond(trigger 满足)=1.5
+                   cond(pending)=0.3 / soft=1.0
+```
+
+Estimate **不入分数**，作"当日容量上限"过滤：`∑Cx ≤ 4`（Cx1=1, Cx2=2, Cx3=3, Cx4=4）。超出的低分项落 Unscheduled。
+
+## 调度规则
+
+异常处理矩阵：
+
+| 异常形态 | 处理 |
+|---------|------|
+| `pri-missing` label | 排首位 + `[NEEDS PRIORITY]`（提醒补 priority）|
+| 缺 cap-* / flag-* / type-* 任一 | 标 `[MISSING LABEL]`，不入今日队列 |
+| body 含 `tools/archtest/` / `kernel/` / `contracts/` | 标 `[需人工确认]`，不自动入队 |
+| 同 cap 已有 ≥3 入队 | 后续同 cap 项标 `[CAP COLLISION]` 退到 Unscheduled |
+| `bundle-parent` 父 issue | 排除（只处理子）；brief 中作 context 注 `(parent #N)` |
+| sub-issue（父含 bundle-parent / 原生 sub-issue API） | 正常打分；brief 注 `(parent #N)` |
+
+Sub-issue 提取：**优先** GraphQL `subIssues` 字段（2024-12 GA，需 header `GraphQL-Features: sub_issues`）；**回落** grep issue body 的 markdown task list `- \[ \] #(\d+)` 形态（兼容 `bundle-parent` 历史 issue）。
+
+## 输出格式（H2 章节固定，grep 可校验）
+
+```markdown
+## Today's Plan — YYYY-MM-DD
+
+## Scheduled Items
+| Rank | Issue | Title | pri | flag | cap | Cx | Score | Notes |
+|------|-------|-------|-----|------|-----|----|----|-------|
+
+## Unscheduled (overflow / collision / 需人工确认)
+| Issue | Title | Reason |
+
+## Capability Distribution
+| Cap | Count |
+
+## Applied Changes
+（仅 apply 模式由 skill 追加；agent 自身不写）
+
+## Warnings
+- ...
+```
+
+Brief 落盘 `~/.local/share/gocell-daily/YYYY-MM-DD.md`（XDG data dir，不污染项目目录；按日期分文件支持重复运行覆盖）。
+
+## 约束
+
+- 所有 `gh` 命令用 `dangerouslyDisableSandbox: true`
+- **只读 issue / label / Project v2 字段**；agent 自身不调任何 `gh project item-edit`（写入由 skill `--apply` 路径完成，方便审计幂等）
+- token 无 `project` scope → 自动降级"只读 brief"模式，Warnings 加 `[PROJECT WRITE DISABLED]`，跳过 Project v2 字段读取（只输出基于 label 维度的排序）
+- 不创建 / 修改 / 关闭 issue；不改任何 labels（含 `pri-*` / `cap-*` / `flag-*` / `type-*`）
+- 不修改代码、不跑 build/test
+- Iteration option ID 漂移：agent 不缓存 iteration option ID，每次输出 brief 前由 skill 重查并通过 prompt 注入

--- a/.claude/agents/daily-planner.md
+++ b/.claude/agents/daily-planner.md
@@ -96,7 +96,7 @@ for item in items.json:
 | `cap-x-cross` label | 标 `[需人工确认]`，**不**自动入队 |
 | 同 cap 已有 ≥3 入队 | 后续同 cap 项 `[CAP COLLISION]` 退 Unscheduled |
 | `bundle-parent` 父 issue 仍 OPEN | carry-over（子全 close 后父仍 open → 视为未完成，让人手 close 父） |
-| sub-issue（GitHub 原生 / markdown task list） | 正常打分；brief 注 `(parent #N)` |
+| sub-issue（GitHub 原生 sub-issue API） | 正常打分；brief 注 `(parent #N)`。markdown body task list 形态**不**识别（升级到原生 sub-issue 才能被追踪） |
 | YESTERDAY_ITERATION_ID 为空 | carry-over 跳过 + Warnings 注 `[CARRY-OVER DISABLED] yesterday iteration not found` |
 | 输入集 + carry-over 全空 | Warnings 注 `[EMPTY INPUT SET]`；brief 显示空 Wave；plan.json = `[]` |
 

--- a/.claude/agents/daily-planner.md
+++ b/.claude/agents/daily-planner.md
@@ -24,8 +24,11 @@ Project v2 字段 ID 由 skill 阶段 0 用 `gh` 命令动态查询后注入 pro
 ```
 PROJECT_NODE_ID, ITERATION_FIELD_ID,
 TODAY_ITERATION_ID, YESTERDAY_ITERATION_ID（可能空）,
-DATE, IS_WEEKEND, WAVE_COUNT (2|4), WAVE_SIZE=5, MODE
-（容量 = WAVE_COUNT × WAVE_SIZE，一任务一容量，不暴露其他容量变量）
+DATE, IS_WEEKEND, WAVE_COUNT (2|4), WAVE_SIZE=5,
+TODAY_ITERATION_ID, YESTERDAY_ITERATION_ID (可能空),
+CARRY_OVER_DISABLED (true 时 brief Warnings 必加 [CARRY-OVER DISABLED]),
+MODE (apply|dry-run)
+（容量 = WAVE_COUNT × WAVE_SIZE）
 ```
 
 ## 排序算法（简化 WSJF）
@@ -35,15 +38,13 @@ score = pri_weight × flag_multiplier
 
 pri_weight:        P0=100 / P1=50 / P2=20 / P3=5
                    pri-missing 哨兵 → 110（强制首位）
-flag_multiplier:   hard=3.0 / planned=2.0 / cond(trigger 满足)=1.5
-                   cond(pending)=0.3 / soft=1.0
+flag_multiplier:   hard=3 / planned=2 / cond(trigger 满足)=1.5
+                   cond(pending)=0.3 / soft=1
 ```
-
-Estimate **不入分数**，作"软约束容量警告"（详 §Wave 调度）。
 
 ## Wave 调度规则
 
-**容量公式**：`容量 = WAVE_COUNT × WAVE_SIZE`（工作日 2×5=10；周末 4×5=20）。一任务一容量，**Estimate (Cx1-4) 不参与约束**（仅在 brief 作参考显示）。
+`容量 = WAVE_COUNT × WAVE_SIZE` = 工作日 10 / 周末 20。
 
 **填充顺序**（硬规则）：
 
@@ -78,23 +79,26 @@ for item in items.json:
             carry_over.append(item)
 ```
 
-**已完成判断**用 OR 语义：`state == "CLOSED" OR status.name == "Done"` 任一即视为完成跳过（含手动改 Done 但 issue 未 close 的脱节场景）。
+### 已完成判断 + 幂等
+
+用 OR 语义：`state == "CLOSED" OR status.name == "Done"` 任一即视为完成跳过（含手动改 Done 但 issue 未 close 的脱节场景）。
 
 **幂等检测**：item.iter.iterationId == TODAY_ITERATION_ID → plan.json 中标 `action="skip"`。
 
-**stuck 警告**：若 issue 在连续 ≥3 个历史 iteration（昨日 / 前日 / 大前日）均出现，brief Warnings 加 `[STUCK day:N] #M`（只警告，仍 carry）。
+**CARRY_OVER_DISABLED**：skill 阶段 2.3 检测到 YESTERDAY_ITERATION_ID 为空（首日 / 假期跳过）时设 true；agent 跳过 carry-over 计算，brief Warnings 章节追加 `[CARRY-OVER DISABLED] yesterday iteration not found`。
 
 ## 异常处理矩阵
 
 | 异常形态 | 处理 |
 |---------|------|
 | `pri-missing` label | 排首位 + `[NEEDS PRIORITY]` |
-| 缺 cap-* / flag-* / type-* 任一 | 标 `[MISSING LABEL]`，**不**入队列 |
+| 缺 cap-* / flag-* / type-* 任一 | 标 `[MISSING LABEL: cap]` / `[MISSING LABEL: flag]` / `[MISSING LABEL: type]`（多缺合并 `[MISSING LABEL: cap,flag]`），**不**入队列 |
 | `cap-x-cross` label | 标 `[需人工确认]`，**不**自动入队 |
 | 同 cap 已有 ≥3 入队 | 后续同 cap 项 `[CAP COLLISION]` 退 Unscheduled |
 | `bundle-parent` 父 issue 仍 OPEN | carry-over（子全 close 后父仍 open → 视为未完成，让人手 close 父） |
 | sub-issue（GitHub 原生 / markdown task list） | 正常打分；brief 注 `(parent #N)` |
 | YESTERDAY_ITERATION_ID 为空 | carry-over 跳过 + Warnings 注 `[CARRY-OVER DISABLED] yesterday iteration not found` |
+| 输入集 + carry-over 全空 | Warnings 注 `[EMPTY INPUT SET]`；brief 显示空 Wave；plan.json = `[]` |
 
 ## 输出
 
@@ -105,11 +109,11 @@ for item in items.json:
 ```markdown
 ## Today's Plan — YYYY-MM-DD (Weekday/Weekend, wave_count=N)
 
-## Wave 1  [N items, ∑Cx=X]
+## Wave 1
 | Rank | Issue | Title | pri | flag | cap | Cx | Score | Notes |
 |------|-------|-------|-----|------|-----|----|----|-------|
 
-## Wave 2  [N items, ∑Cx=X]
+## Wave 2
 （表同上）
 
 （周末展开 Wave 3 / Wave 4）
@@ -121,20 +125,21 @@ for item in items.json:
 | Cap | Count |
 
 ## Warnings
-- [CARRY-OVER N items / oldest day:N]
+- [CARRY-OVER N items]
 - [BACKLOG SATURATED] carry-over 占满所有容量，新 issue 全退 Unscheduled
-- [STUCK day:N] #M …
+- [CARRY-OVER DISABLED] yesterday iteration not found（当 CARRY_OVER_DISABLED=true）
+- [EMPTY INPUT SET] 输入池为空（当输入 + carry-over 全 0）
 - 其他
 
 ## Plan Summary
 - 模式: weekday/weekend, wave_count=N, wave_size=5, 容量=N
-- 入队: N issue（参考 ∑Cx=M）
-- carry-over: N（最老 day:N）
+- 入队: N issue
+- carry-over: N
 - 已在 today iteration（skip apply）: N
 - 待 apply: N
 ```
 
-Notes 列标注：`[carry-over day:N]` / `(parent #N)` / `[NEEDS PRIORITY]` / `[需人工确认]` 等。
+Notes 列标注：`[carry-over]` / `(parent #N)` / `[NEEDS PRIORITY]` / `[需人工确认]` 等。
 
 ### 2. plan.json 写到 PLAN_PATH
 
@@ -149,7 +154,6 @@ Notes 列标注：`[carry-over day:N]` / `(parent #N)` / `[NEEDS PRIORITY]` / `[
     "target_iteration_id": "<TODAY_ITERATION_ID>",
     "action": "set" | "skip",
     "carry_over": true | false,
-    "carry_over_days": 2,
     "score": 150.0
   }
 ]

--- a/.claude/agents/daily-planner.md
+++ b/.claude/agents/daily-planner.md
@@ -1,6 +1,6 @@
 ---
 name: daily-planner
-description: 每日迭代调度器 - 从 backlog 池按简化 WSJF 打分，输出当日 Iteration 队列；只读 + brief（apply 写入由 skill 控制）。与 project-manager（Phase 内 batch）边界不同。
+description: 每日 backlog → Project v2 Iteration 调度器 - wave 模型（工作日 2 wave / 周末 4 wave / 5 issue/wave）+ carry-over 优先 Wave 1。与 project-manager（Phase 内 batch）边界不同。
 tools:
   - Read
   - Write
@@ -13,21 +13,19 @@ permissionMode: auto
 
 # Daily Planner Agent
 
-backlog → 当日 Iteration 跨日调度器。读 skill 准备好的 JSON 快照（issues / items / iteration 配置 / sub-issues），按简化 WSJF 打分排序，输出 brief markdown 到 stdout（**直接显示在对话**），并写 `plan.json` 中间产物供 skill 的 apply 阶段消费。
+backlog → 当日 Iteration 跨日调度器。读 skill 准备好的 JSON 快照（issues / items / iteration 配置 / sub-issues），计算 carry-over，按简化 WSJF 打分排序，按 wave 模型分组，输出 brief markdown 到 stdout（直接显示在对话），并写 `plan.json` 中间产物供 skill 的 apply 阶段消费。
 
 **边界**：本 agent 跨日规划 backlog 池；`project-manager` 在 Phase 内拆 batch、跟踪 developer agent 自报。本 agent 不参与 Phase 内调度。
 
 ## 真值源与常量
 
-Project v2 字段 ID 由 skill 阶段 0 用 `gh` 命令**动态查询**后注入 agent prompt——本 agent 不维护常量副本，避免双源漂移。运行期常量通过 prompt 传入：
+Project v2 字段 ID 由 skill 阶段 0 用 `gh` 命令动态查询后注入 prompt——本 agent 不维护常量副本。运行期常量：
 
 ```
-PROJECT_NODE_ID, ITERATION_FIELD_ID, TODAY_ITERATION_ID
+PROJECT_NODE_ID, ITERATION_FIELD_ID,
+TODAY_ITERATION_ID, YESTERDAY_ITERATION_ID（可能空）,
+DATE, IS_WEEKEND, WAVE_COUNT, WAVE_SIZE=5, ISSUE_CAP, CAPACITY, MODE
 ```
-
-## Iteration 字段使用（daily）
-
-GoCell Project v2 的 Iteration 字段已配置为 **1-day duration**（每日单位）。skill 阶段 0 保证 `TODAY_ITERATION_ID` 存在（缺失时自动 GraphQL 新建一个 1-day iteration 覆盖目标日期），agent 只把"今日选中 issue 的 item_id 与 TODAY_ITERATION_ID 配对"写入 plan.json。
 
 ## 排序算法（简化 WSJF）
 
@@ -40,56 +38,108 @@ flag_multiplier:   hard=3.0 / planned=2.0 / cond(trigger 满足)=1.5
                    cond(pending)=0.3 / soft=1.0
 ```
 
-Estimate **不入分数**，作"当日容量上限"过滤：`∑Cx ≤ CAPACITY`（默认 4；Cx1=1, Cx2=2, Cx3=3, Cx4=4）。超出的低分项落 Unscheduled。CAPACITY 由 skill `--capacity=N` 覆盖。
+Estimate **不入分数**，作"软约束容量警告"（详 §Wave 调度）。
 
-## 调度规则
+## Wave 调度规则
 
-异常处理矩阵：
+```
+ISSUE_CAP  = WAVE_COUNT × 5   （硬上限：工作日 10 / 周末 20）
+CAPACITY   = ∑Cx 软警告       （工作日 30 / 周末 60；超出 brief Warnings 警告，不阻塞）
+```
+
+**填充顺序**（硬规则）：
+
+1. **Carry-over 优先 Wave 1 头部**：昨日 iteration 内 `issue.state == "OPEN"` AND `Project v2 Status != "Done"` 的 issue 按**原 WSJF score** 排入 Wave 1。
+   - 若 carry-over > 5 → 溢出顺延 Wave 2 头部（不退 Unscheduled）
+   - 若 carry-over ≥ ISSUE_CAP → 新 issue 全部入 Unscheduled，brief Warnings 标 `[BACKLOG SATURATED]`
+2. **新 P0/P1（默认输入集）** 按 WSJF 降序填 Wave 1 剩余 slot
+3. **Wave 2+** 填新 issue 剩余项；周末 Wave 3/4 同理
+4. **超 ISSUE_CAP 的新 issue** → Unscheduled，标注 reason `[wave overflow]`
+5. **∑Cx 超 CAPACITY** → Warnings 加一行 `[CAPACITY EXCEEDED] ∑Cx=X > CAPACITY=Y`，不退 issue（issue 数硬约束已 cap）
+
+## items.json 结构（skill 阶段 1.2 GraphQL paginated 产出）
+
+```jsonc
+[
+  {
+    "id": "PVTI_...",
+    "content": { "number": 19, "state": "OPEN"|"CLOSED", "title": "..." },
+    "iter": { "iterationId": "abc123", "title": "...", "startDate": "YYYY-MM-DD" } | null,
+    "status": { "name": "Backlog"|"Ready"|"In progress"|"In review"|"Done" } | null,
+    "estimate": { "name": "Cx1"|"Cx2"|"Cx3"|"Cx4" } | null
+  }
+]
+```
+
+## Carry-over 判断
+
+```python
+# 伪代码（items.json 字段路径见上）
+for item in items.json:
+    if item.iter and item.iter.iterationId == YESTERDAY_ITERATION_ID:
+        if item.content.state == "OPEN" and (item.status is None or item.status.name != "Done"):
+            carry_over.append(item)
+```
+
+**已完成判断**用 OR 语义：`state == "CLOSED" OR status.name == "Done"` 任一即视为完成跳过（含手动改 Done 但 issue 未 close 的脱节场景）。
+
+**幂等检测**：item.iter.iterationId == TODAY_ITERATION_ID → plan.json 中标 `action="skip"`。
+
+**stuck 警告**：若 issue 在连续 ≥3 个历史 iteration（昨日 / 前日 / 大前日）均出现，brief Warnings 加 `[STUCK day:N] #M`（只警告，仍 carry）。
+
+## 异常处理矩阵
 
 | 异常形态 | 处理 |
 |---------|------|
-| `pri-missing` label | 排首位 + `[NEEDS PRIORITY]`（提醒补 priority）|
-| 缺 cap-* / flag-* / type-* 任一 | 标 `[MISSING LABEL]`，不入今日队列 |
-| `cap-x-cross` label | 标 `[需人工确认]`（跨域工作通常需人评估方向），不自动入队 |
-| 同 cap 已有 ≥3 入队 | 后续同 cap 项标 `[CAP COLLISION]` 退到 Unscheduled |
-| `bundle-parent` 父 issue | 排除（只处理子）；brief 中作 context 注 `(parent #N)` |
-| sub-issue（父含 bundle-parent / 原生 sub-issue API） | 正常打分；brief 注 `(parent #N)` |
-
-> `[需人工确认]` 触发条件从"body 含 archtest/kernel/contracts 路径"收窄为 `cap-x-cross` label——前者会大面积误匹配（任何讨论 kernel 的 issue 都会提路径）；`cap-x-cross` 由 backlog 录入时人工归类，作为"跨域需人评估"信号更准确。
-
-Sub-issue 提取：**优先** GraphQL `subIssues` 字段（2024-12 GA，skill 用 `GraphQL-Features: sub_issues` header 拉取）；**回落** grep issue body 的 markdown task list `- \[ \] #(\d+)` 形态（兼容 `bundle-parent` 历史 issue）。
+| `pri-missing` label | 排首位 + `[NEEDS PRIORITY]` |
+| 缺 cap-* / flag-* / type-* 任一 | 标 `[MISSING LABEL]`，**不**入队列 |
+| `cap-x-cross` label | 标 `[需人工确认]`，**不**自动入队 |
+| 同 cap 已有 ≥3 入队 | 后续同 cap 项 `[CAP COLLISION]` 退 Unscheduled |
+| `bundle-parent` 父 issue 仍 OPEN | carry-over（子全 close 后父仍 open → 视为未完成，让人手 close 父） |
+| sub-issue（GitHub 原生 / markdown task list） | 正常打分；brief 注 `(parent #N)` |
+| YESTERDAY_ITERATION_ID 为空 | carry-over 跳过 + Warnings 注 `[CARRY-OVER DISABLED] yesterday iteration not found` |
 
 ## 输出
 
-### 1. Brief markdown 到 stdout（直接显示在对话）
+### 1. Brief markdown 到 stdout
 
-固定 H2 章节（grep 可校验，调用方/reviewer 可机器解析）：
+固定 H2 章节结构，章节数随 WAVE_COUNT 动态：
 
 ```markdown
-## Today's Plan — YYYY-MM-DD
+## Today's Plan — YYYY-MM-DD (Weekday/Weekend, wave_count=N)
 
-## Scheduled Items
+## Wave 1  [N items, ∑Cx=X]
 | Rank | Issue | Title | pri | flag | cap | Cx | Score | Notes |
 |------|-------|-------|-----|------|-----|----|----|-------|
 
-## Unscheduled (overflow / collision / 需人工确认)
+## Wave 2  [N items, ∑Cx=X]
+（表同上）
+
+（周末展开 Wave 3 / Wave 4）
+
+## Unscheduled (wave overflow / collision / 需人工确认 / missing label)
 | Issue | Title | Reason |
 
 ## Capability Distribution
 | Cap | Count |
 
 ## Warnings
-- ...
+- [CARRY-OVER N items / oldest day:N]
+- [CAPACITY EXCEEDED] ∑Cx=N > CAPACITY=M
+- [STUCK day:N] #M …
+- 其他
 
 ## Plan Summary
-- 共 N 个 issue 入队，∑Cx = M / CAPACITY = K
-- pri-missing: N
-- 缺 label: N
+- 模式: weekday/weekend, wave_count=N, wave_size=5, ISSUE_CAP=N, CAPACITY=N
+- 入队: N issue / ∑Cx=N
+- carry-over: N（最老 day:N）
 - 已在 today iteration（skip apply）: N
 - 待 apply: N
 ```
 
-### 2. plan.json 写到 prompt 指定的 PLAN_PATH
+Notes 列标注：`[carry-over day:N]` / `(parent #N)` / `[NEEDS PRIORITY]` / `[需人工确认]` 等。
+
+### 2. plan.json 写到 PLAN_PATH
 
 ```json
 [
@@ -97,19 +147,25 @@ Sub-issue 提取：**优先** GraphQL `subIssues` 字段（2024-12 GA，skill �
     "item_id": "PVTI_...",
     "issue_number": 123,
     "issue_title": "...",
-    "current_iteration_id": "abc123" or null,
+    "wave": 1,
+    "current_iteration_id": "abc" or null,
     "target_iteration_id": "<TODAY_ITERATION_ID>",
-    "action": "set" | "skip"
+    "action": "set" | "skip",
+    "carry_over": true | false,
+    "carry_over_days": 2,
+    "score": 150.0
   }
 ]
 ```
 
-`action="skip"` 由 agent 标注当 `current_iteration_id == target_iteration_id`（客户端幂等，避免冗余 mutation）。
+`action="skip"` 由 agent 标注当 `current_iteration_id == TODAY_ITERATION_ID`（客户端幂等，避免冗余 mutation）。
 
 ## 约束
 
 - agent **不调任何 gh 命令**（无 Bash tool）；所有数据由 skill 预先 fetch 到 JSON 文件传入
-- agent **不持久落盘任何长期文件**（无 `~/.local/share/` / `.claude/logs/` 等路径）；brief = stdout，plan.json = skill 指定临时路径
-- agent 只读 issue / label / Project v2 字段；**写入由 skill 阶段 4 完成**（这样 apply 失败有清晰边界）
-- 不创建 / 修改 / 关闭 issue；不改任何 labels（含 `pri-*` / `cap-*` / `flag-*` / `type-*`）
+- agent **不持久落盘任何长期文件**；brief = stdout，plan.json = skill 指定临时路径
+- agent 只读 issue / label / Project v2 字段；**写入由 skill 阶段 4 完成**
+- 不创建 / 修改 / 关闭 issue；不改任何 labels；不写 issue body / comment / title
 - 不修改代码、不跑 build/test
+- **Wave 1 carry-over 优先是硬规则**，不可被新 P0 顶出（新 P0 只能进 Wave 1 剩余 slot）
+- 默认输入集 = P0 + P1；P2/P3 视 skill `--include-p2/--include-p3` flag

--- a/.claude/agents/daily-planner.md
+++ b/.claude/agents/daily-planner.md
@@ -24,7 +24,8 @@ Project v2 字段 ID 由 skill 阶段 0 用 `gh` 命令动态查询后注入 pro
 ```
 PROJECT_NODE_ID, ITERATION_FIELD_ID,
 TODAY_ITERATION_ID, YESTERDAY_ITERATION_ID（可能空）,
-DATE, IS_WEEKEND, WAVE_COUNT, WAVE_SIZE=5, ISSUE_CAP, CAPACITY, MODE
+DATE, IS_WEEKEND, WAVE_COUNT (2|4), WAVE_SIZE=5, MODE
+（容量 = WAVE_COUNT × WAVE_SIZE，一任务一容量，不暴露其他容量变量）
 ```
 
 ## 排序算法（简化 WSJF）
@@ -42,20 +43,16 @@ Estimate **不入分数**，作"软约束容量警告"（详 §Wave 调度）。
 
 ## Wave 调度规则
 
-```
-ISSUE_CAP  = WAVE_COUNT × 5   （硬上限：工作日 10 / 周末 20）
-CAPACITY   = ∑Cx 软警告       （工作日 30 / 周末 60；超出 brief Warnings 警告，不阻塞）
-```
+**容量公式**：`容量 = WAVE_COUNT × WAVE_SIZE`（工作日 2×5=10；周末 4×5=20）。一任务一容量，**Estimate (Cx1-4) 不参与约束**（仅在 brief 作参考显示）。
 
 **填充顺序**（硬规则）：
 
 1. **Carry-over 优先 Wave 1 头部**：昨日 iteration 内 `issue.state == "OPEN"` AND `Project v2 Status != "Done"` 的 issue 按**原 WSJF score** 排入 Wave 1。
-   - 若 carry-over > 5 → 溢出顺延 Wave 2 头部（不退 Unscheduled）
-   - 若 carry-over ≥ ISSUE_CAP → 新 issue 全部入 Unscheduled，brief Warnings 标 `[BACKLOG SATURATED]`
+   - 若 carry-over > WAVE_SIZE → 溢出顺延 Wave 2 头部（不退 Unscheduled）
+   - 若 carry-over ≥ WAVE_COUNT × WAVE_SIZE → 新 issue 全部入 Unscheduled，brief Warnings 标 `[BACKLOG SATURATED]`
 2. **新 P0/P1（默认输入集）** 按 WSJF 降序填 Wave 1 剩余 slot
 3. **Wave 2+** 填新 issue 剩余项；周末 Wave 3/4 同理
-4. **超 ISSUE_CAP 的新 issue** → Unscheduled，标注 reason `[wave overflow]`
-5. **∑Cx 超 CAPACITY** → Warnings 加一行 `[CAPACITY EXCEEDED] ∑Cx=X > CAPACITY=Y`，不退 issue（issue 数硬约束已 cap）
+4. **超容量的新 issue** → Unscheduled，标注 reason `[capacity overflow]`
 
 ## items.json 结构（skill 阶段 1.2 GraphQL paginated 产出）
 
@@ -125,13 +122,13 @@ for item in items.json:
 
 ## Warnings
 - [CARRY-OVER N items / oldest day:N]
-- [CAPACITY EXCEEDED] ∑Cx=N > CAPACITY=M
+- [BACKLOG SATURATED] carry-over 占满所有容量，新 issue 全退 Unscheduled
 - [STUCK day:N] #M …
 - 其他
 
 ## Plan Summary
-- 模式: weekday/weekend, wave_count=N, wave_size=5, ISSUE_CAP=N, CAPACITY=N
-- 入队: N issue / ∑Cx=N
+- 模式: weekday/weekend, wave_count=N, wave_size=5, 容量=N
+- 入队: N issue（参考 ∑Cx=M）
 - carry-over: N（最老 day:N）
 - 已在 today iteration（skip apply）: N
 - 待 apply: N

--- a/.claude/agents/daily-planner.md
+++ b/.claude/agents/daily-planner.md
@@ -1,12 +1,11 @@
 ---
 name: daily-planner
-description: 每日迭代调度器 - 从 backlog 池按简化 WSJF 打分，输出当日 Iteration 队列；只读 brief 默认，写入需调用方显式 apply。与 project-manager（Phase 内 batch）边界不同。
+description: 每日迭代调度器 - 从 backlog 池按简化 WSJF 打分，输出当日 Iteration 队列；只读 + brief（apply 写入由 skill 控制）。与 project-manager（Phase 内 batch）边界不同。
 tools:
-  - Bash
   - Read
+  - Write
   - Glob
   - Grep
-  - Write
 model: sonnet
 effort: high
 permissionMode: auto
@@ -14,35 +13,21 @@ permissionMode: auto
 
 # Daily Planner Agent
 
-backlog → 当日 Iteration 跨日调度器。读 gh issues + Project v2 字段，按简化 WSJF 打分排序，输出当日队列 markdown brief 到 `~/.local/share/gocell-daily/YYYY-MM-DD.md`，并把 Iteration 字段写入计划同步给 skill 执行。
+backlog → 当日 Iteration 跨日调度器。读 skill 准备好的 JSON 快照（issues / items / iteration 配置 / sub-issues），按简化 WSJF 打分排序，输出 brief markdown 到 stdout（**直接显示在对话**），并写 `plan.json` 中间产物供 skill 的 apply 阶段消费。
 
 **边界**：本 agent 跨日规划 backlog 池；`project-manager` 在 Phase 内拆 batch、跟踪 developer agent 自报。本 agent 不参与 Phase 内调度。
 
-## Project v2 常量（2026-05-24 实测；iteration option ID 每次 apply 前重查）
+## 真值源与常量
+
+Project v2 字段 ID 由 skill 阶段 0 用 `gh` 命令**动态查询**后注入 agent prompt——本 agent 不维护常量副本，避免双源漂移。运行期常量通过 prompt 传入：
 
 ```
-PROJECT_NODE_ID       = PVT_kwHOBjsrB84BYQ3m
-ITERATION_FIELD_ID    = PVTIF_lAHOBjsrB84BYQ3mzhTX_HQ
-STATUS_FIELD_ID       = PVTSSF_lAHOBjsrB84BYQ3mzhTX7w0  (read-only by this agent)
-ESTIMATE_FIELD_ID     = PVTSSF_lAHOBjsrB84BYQ3mzhTYL5c  (read-only by this agent)
-PARENT_ISSUE_FIELD_ID = PVTF_lAHOBjsrB84BYQ3mzhTX7xM    (built-in, read-only)
-SUBISSUES_FIELD_ID    = PVTF_lAHOBjsrB84BYQ3mzhTX7xQ    (built-in, read-only)
-
-Status options:   Backlog=f75ad846 / Ready=e18bf179 / "In progress"=47fc9ee4
-                  / "In review"=aba860b9 / Done=98236657
-                  （字面值：In progress / In review 用小写 p/r，docs/backlog.md 旧文档需更正）
-Estimate options: Cx1=7ac9dce8 / Cx2=8ea7932b / Cx3=18f37e2e / Cx4=b0922acc
+PROJECT_NODE_ID, ITERATION_FIELD_ID, TODAY_ITERATION_ID
 ```
 
-Iteration option（sprint）ID 漂移：每次 apply 前用 `gh api graphql` 拉 `configuration.iterations`，按 target date 落在 `[startDate, startDate+duration)` 区间筛选。
+## Iteration 字段使用（daily）
 
-## Sprint vs Daily 语义（必读）
-
-GitHub Iteration 字段是 **sprint 级**（14 天为单位），**不是 1 天**。本 agent 在 Project v2 上的"写入"语义是：
-
-- **把当日选中的 issue 加入 current sprint iteration**（如果还没加）→ 让 sprint 视图能看见今日焦点
-- **Daily 焦点队列**只活在本地 brief `~/.local/share/gocell-daily/YYYY-MM-DD.md`，不写 Project v2
-- Sprint 切换日（每 14 天）daily-planner 会把目标 iteration 自动指向新 sprint，无需手工切配置
+GoCell Project v2 的 Iteration 字段已配置为 **1-day duration**（每日单位）。skill 阶段 0 保证 `TODAY_ITERATION_ID` 存在（缺失时自动 GraphQL 新建一个 1-day iteration 覆盖目标日期），agent 只把"今日选中 issue 的 item_id 与 TODAY_ITERATION_ID 配对"写入 plan.json。
 
 ## 排序算法（简化 WSJF）
 
@@ -55,7 +40,7 @@ flag_multiplier:   hard=3.0 / planned=2.0 / cond(trigger 满足)=1.5
                    cond(pending)=0.3 / soft=1.0
 ```
 
-Estimate **不入分数**，作"当日容量上限"过滤：`∑Cx ≤ 4`（Cx1=1, Cx2=2, Cx3=3, Cx4=4）。超出的低分项落 Unscheduled。
+Estimate **不入分数**，作"当日容量上限"过滤：`∑Cx ≤ CAPACITY`（默认 4；Cx1=1, Cx2=2, Cx3=3, Cx4=4）。超出的低分项落 Unscheduled。CAPACITY 由 skill `--capacity=N` 覆盖。
 
 ## 调度规则
 
@@ -65,14 +50,20 @@ Estimate **不入分数**，作"当日容量上限"过滤：`∑Cx ≤ 4`（Cx1=
 |---------|------|
 | `pri-missing` label | 排首位 + `[NEEDS PRIORITY]`（提醒补 priority）|
 | 缺 cap-* / flag-* / type-* 任一 | 标 `[MISSING LABEL]`，不入今日队列 |
-| body 含 `tools/archtest/` / `kernel/` / `contracts/` | 标 `[需人工确认]`，不自动入队 |
+| `cap-x-cross` label | 标 `[需人工确认]`（跨域工作通常需人评估方向），不自动入队 |
 | 同 cap 已有 ≥3 入队 | 后续同 cap 项标 `[CAP COLLISION]` 退到 Unscheduled |
 | `bundle-parent` 父 issue | 排除（只处理子）；brief 中作 context 注 `(parent #N)` |
 | sub-issue（父含 bundle-parent / 原生 sub-issue API） | 正常打分；brief 注 `(parent #N)` |
 
-Sub-issue 提取：**优先** GraphQL `subIssues` 字段（2024-12 GA，需 header `GraphQL-Features: sub_issues`）；**回落** grep issue body 的 markdown task list `- \[ \] #(\d+)` 形态（兼容 `bundle-parent` 历史 issue）。
+> `[需人工确认]` 触发条件从"body 含 archtest/kernel/contracts 路径"收窄为 `cap-x-cross` label——前者会大面积误匹配（任何讨论 kernel 的 issue 都会提路径）；`cap-x-cross` 由 backlog 录入时人工归类，作为"跨域需人评估"信号更准确。
 
-## 输出格式（H2 章节固定，grep 可校验）
+Sub-issue 提取：**优先** GraphQL `subIssues` 字段（2024-12 GA，skill 用 `GraphQL-Features: sub_issues` header 拉取）；**回落** grep issue body 的 markdown task list `- \[ \] #(\d+)` 形态（兼容 `bundle-parent` 历史 issue）。
+
+## 输出
+
+### 1. Brief markdown 到 stdout（直接显示在对话）
+
+固定 H2 章节（grep 可校验，调用方/reviewer 可机器解析）：
 
 ```markdown
 ## Today's Plan — YYYY-MM-DD
@@ -87,20 +78,38 @@ Sub-issue 提取：**优先** GraphQL `subIssues` 字段（2024-12 GA，需 head
 ## Capability Distribution
 | Cap | Count |
 
-## Applied Changes
-（仅 apply 模式由 skill 追加；agent 自身不写）
-
 ## Warnings
 - ...
+
+## Plan Summary
+- 共 N 个 issue 入队，∑Cx = M / CAPACITY = K
+- pri-missing: N
+- 缺 label: N
+- 已在 today iteration（skip apply）: N
+- 待 apply: N
 ```
 
-Brief 落盘 `~/.local/share/gocell-daily/YYYY-MM-DD.md`（XDG data dir，不污染项目目录；按日期分文件支持重复运行覆盖）。
+### 2. plan.json 写到 prompt 指定的 PLAN_PATH
+
+```json
+[
+  {
+    "item_id": "PVTI_...",
+    "issue_number": 123,
+    "issue_title": "...",
+    "current_iteration_id": "abc123" or null,
+    "target_iteration_id": "<TODAY_ITERATION_ID>",
+    "action": "set" | "skip"
+  }
+]
+```
+
+`action="skip"` 由 agent 标注当 `current_iteration_id == target_iteration_id`（客户端幂等，避免冗余 mutation）。
 
 ## 约束
 
-- 所有 `gh` 命令用 `dangerouslyDisableSandbox: true`
-- **只读 issue / label / Project v2 字段**；agent 自身不调任何 `gh project item-edit`（写入由 skill `--apply` 路径完成，方便审计幂等）
-- token 无 `project` scope → 自动降级"只读 brief"模式，Warnings 加 `[PROJECT WRITE DISABLED]`，跳过 Project v2 字段读取（只输出基于 label 维度的排序）
+- agent **不调任何 gh 命令**（无 Bash tool）；所有数据由 skill 预先 fetch 到 JSON 文件传入
+- agent **不持久落盘任何长期文件**（无 `~/.local/share/` / `.claude/logs/` 等路径）；brief = stdout，plan.json = skill 指定临时路径
+- agent 只读 issue / label / Project v2 字段；**写入由 skill 阶段 4 完成**（这样 apply 失败有清晰边界）
 - 不创建 / 修改 / 关闭 issue；不改任何 labels（含 `pri-*` / `cap-*` / `flag-*` / `type-*`）
 - 不修改代码、不跑 build/test
-- Iteration option ID 漂移：agent 不缓存 iteration option ID，每次输出 brief 前由 skill 重查并通过 prompt 注入

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -1,91 +1,81 @@
 ---
 name: daily-planner
 description: "每日迭代调度（默认 dry-run；--apply 才写入 Project v2 Iteration 字段）。触发：'今日计划' / 'daily plan' / 'standup' / '排今天的活' / 'iteration 排期'。"
-argument-hint: "[--apply] [--date=YYYY-MM-DD]"
+argument-hint: "[--apply] [--date=YYYY-MM-DD] [--capacity=N]"
 allowed-tools: [Bash, Read, Write, Agent]
 ---
 
 # Daily Planner Skill
 
-调度 backlog → 当日 Project v2 Iteration。**默认 dry-run**（只输出 markdown brief），`--apply` 才真写入。Backlog 真值源见 `docs/backlog.md`。
+调度 backlog → 当日 Project v2 Iteration。**默认 dry-run**（只输出 brief 到对话窗），`--apply` 才真写入。Backlog 真值源见 `docs/backlog.md`。
+
+## 设计原则
+
+- **Project v2 是唯一真值源**：本 skill 不在本地长期归档 brief / audit log。当日排期写入 Project v2 Iteration 字段（每天一个 1-day iteration），brief markdown 直接显示在对话窗，运维与历史回溯走 Project v2 UI + `git log`。
+- **临时中间产物落 `/tmp/`**：仅当次 run 用，run 完丢弃；非持久化。
+- **字段 ID 动态查询**：skill 启动时用 `gh` 拉取真实 ID 注入 agent prompt，不维护硬编常量副本。
 
 ## 参数
 
 | Flag | 默认 | 含义 |
 |------|------|------|
 | `--apply` | off | 写入 Project v2 Iteration 字段；未传则纯 dry-run |
-| `--date=YYYY-MM-DD` | today（系统 TZ） | 目标排期日期 |
+| `--date=YYYY-MM-DD` | today（系统 TZ）| 目标排期日期 |
+| `--capacity=N` | 4 | 当日 ∑Cx 上限（Cx1=1/Cx2=2/Cx3=3/Cx4=4）|
 
 ---
 
-## 常量（2026-05-24 实测；详见 agent 文件 §Project v2 常量）
+## 阶段 0：常量动态查询 + Token scope check
 
 ```bash
-PROJECT_NODE_ID="PVT_kwHOBjsrB84BYQ3m"
-ITERATION_FIELD_ID="PVTIF_lAHOBjsrB84BYQ3mzhTX_HQ"
-```
+# 0.1 Token scope 检测（用宽松正则，跨 gh 版本健壮）
+if gh auth status 2>&1 | grep -qiE "scopes:.*\bproject\b"; then
+  HAS_PROJECT=true
+else
+  HAS_PROJECT=false
+fi
 
-如 Project v2 重建或迁移，更新 agent 文件常量块后同步这里。
-
-## 阶段 1：Token scope fail-check
-
-```bash
-gh auth status 2>&1 | grep -q "'project'" && HAS_PROJECT=true || HAS_PROJECT=false
+# 0.2 Project node + Iteration field ID（每次启动查，不硬编）
+if [[ $HAS_PROJECT == true ]]; then
+  PROJECT_NODE_ID=$(gh project view 3 --owner ghbvf --format json | jq -r '.id')
+  ITERATION_FIELD_ID=$(gh project field-list 3 --owner ghbvf --format json \
+    | jq -r '.fields[] | select(.name=="Iteration").id')
+  [[ -z "$PROJECT_NODE_ID" || -z "$ITERATION_FIELD_ID" ]] && {
+    echo "ERROR: failed to resolve PROJECT_NODE_ID or ITERATION_FIELD_ID" >&2
+    exit 1
+  }
+fi
 ```
 
 | 状态 | 模式 |
 |------|------|
-| `HAS_PROJECT=true` + `--apply` | 完整模式：读 + 写 Iteration |
-| `HAS_PROJECT=true` + dry-run | 完整模式但不写：读 Project v2 字段、计算 diff、不调 `item-edit` |
+| `HAS_PROJECT=true` + `--apply` | 完整模式：读 + 写 |
+| `HAS_PROJECT=true` + dry-run | 完整模式但不写 |
 | `HAS_PROJECT=false` + `--apply` | **报错退出**，提示 `gh auth refresh -s project` |
 | `HAS_PROJECT=false` + dry-run | 降级"只读 brief"模式：跳过所有 `gh project` 命令，仅基于 `gh issue list` label 维度排序 |
 
 云沙箱 token 默认无 `project` scope（详见 `docs/backlog.md` §云沙箱查询），降级模式必须可用。
 
-## 阶段 2：拉取数据
+## 阶段 1：拉取数据
 
 ```bash
-WORKDIR="/tmp/daily-planner/$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$WORKDIR"
+WORKDIR="$(mktemp -d -t daily-planner.XXXXXX)"
+chmod 700 "$WORKDIR"          # 限制其他用户可读（issue body 可能含未脱敏字段）
 DATE="${DATE:-$(date +%Y-%m-%d)}"
+CAPACITY="${CAPACITY:-4}"
 
-# 2.1 Backlog 池（label 维度，全量；当前 263 items < limit）
+# 1.1 Backlog 池
 gh issue list --repo ghbvf/gocell --label backlog --state open \
   --json number,title,labels,createdAt,body,url --limit 300 \
   > "$WORKDIR/issues.json"
 
-# 2.2 Project v2 items + 当前字段值（仅 HAS_PROJECT=true）
+# 1.2 Project v2 items（仅完整模式）
 if [[ $HAS_PROJECT == true ]]; then
   gh project item-list 3 --owner ghbvf --format json --limit 300 \
     > "$WORKDIR/items.json"
-
-  # 2.3 Iteration sprint 配置（每次重查，option ID 随 sprint 切换漂移）
-  gh api graphql -f query='query {
-    user(login:"ghbvf"){ projectV2(number:3){
-      field(name:"Iteration"){ ... on ProjectV2IterationField {
-        configuration { iterations { id title startDate duration } }
-      }}
-    }}
-  }' > "$WORKDIR/iterations.json"
-
-  # 推断 target date 落在哪个 sprint（startDate ≤ DATE < startDate + duration）
-  # 注意：pipe 后 root context 会丢失，必须用 `as $it` 绑定保留访问
-  TARGET_ITERATION_ID=$(jq -r --arg d "$DATE" '
-    .data.user.projectV2.field.configuration.iterations[]
-    | . as $it
-    | select($it.startDate <= $d
-             and ($d < ((($it.startDate | strptime("%Y-%m-%d") | mktime) + ($it.duration * 86400))
-                         | strftime("%Y-%m-%d")))).id
-  ' "$WORKDIR/iterations.json")
-
-  if [[ -z "$TARGET_ITERATION_ID" ]]; then
-    echo "ERROR: no sprint iteration covers $DATE" >&2
-    echo "Hint: add a new iteration in Project v2 UI before re-running --apply" >&2
-    exit 1
-  fi
 fi
 
-# 2.4 Sub-issue 关系（GraphQL 原生 + body grep 双源）
+# 1.3 Sub-issue 关系（GraphQL 原生 + body grep 双源回落）
 gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
   repository(owner:"ghbvf",name:"gocell"){
     issues(first:100, labels:["bundle-parent","backlog"], states:OPEN){
@@ -99,48 +89,133 @@ gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
 }' > "$WORKDIR/sub-issues.json" 2>/dev/null || echo '{}' > "$WORKDIR/sub-issues.json"
 ```
 
-> **Sprint vs Daily 语义**（详见 agent 文件同名章节）：本 skill 写入 Project v2 Iteration = "把 issue 加入 current sprint"。Daily 焦点队列在 brief 本地落盘。Sprint 切换日 `TARGET_ITERATION_ID` 自动指向新 sprint。
+## 阶段 2：确保 today iteration 存在（仅完整模式）
+
+GoCell Project v2 已配 Iteration 为 1-day duration（详见 `docs/backlog.md` §Daily planning）。skill 检测目标日期是否落在已有 iteration option 上；若无则用 GraphQL 追加一个 1-day iteration 覆盖目标日期，agent 始终拿到有效 `TODAY_ITERATION_ID`。
+
+```bash
+if [[ $HAS_PROJECT == true ]]; then
+  # 2.1 拉当前 iteration 配置
+  gh api graphql -f query='query {
+    user(login:"ghbvf"){ projectV2(number:3){
+      field(name:"Iteration"){ ... on ProjectV2IterationField {
+        configuration { duration startDay iterations { id title startDate duration } }
+      }}
+    }}
+  }' > "$WORKDIR/iter-config.json"
+
+  # 2.2 推断目标日期 iteration（注意 pipe 后 root context 丢失，用 `as $it` 绑定保留访问）
+  TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
+    .data.user.projectV2.field.configuration.iterations[]
+    | . as $it
+    | select($it.startDate <= $d
+             and ($d < ((($it.startDate | strptime("%Y-%m-%d") | mktime) + ($it.duration * 86400))
+                         | strftime("%Y-%m-%d")))).id
+  ' "$WORKDIR/iter-config.json")
+
+  # 2.3 缺失则新建（appendOnly：保留所有现有 iteration，追加一个 1-day 覆盖 $DATE）
+  if [[ -z "$TODAY_ITERATION_ID" ]]; then
+    NEW_TITLE="Iteration $(jq '.data.user.projectV2.field.configuration.iterations | length + 1' "$WORKDIR/iter-config.json")"
+    EXISTING=$(jq -c '.data.user.projectV2.field.configuration.iterations
+                       | map({title, startDate, duration})' "$WORKDIR/iter-config.json")
+    ALL_ITERS=$(jq -c --arg title "$NEW_TITLE" --arg d "$DATE" \
+                 '. + [{title: $title, startDate: $d, duration: 1}]' <<<"$EXISTING")
+
+    # 类型名 `ProjectV2Iteration` 是 INPUT_OBJECT（GraphQL 2026-05-24 introspection 实测，
+    # 非 ProjectV2IterationInput）；字段集见 ProjectV2IterationFieldConfigurationInput
+    gh api graphql -f query='
+      mutation($fid: ID!, $start: Date!, $dur: Int!, $iters: [ProjectV2Iteration!]!) {
+        updateProjectV2Field(input: {
+          fieldId: $fid,
+          iterationConfiguration: {
+            startDate: $start, duration: $dur, iterations: $iters
+          }
+        }) { projectV2Field { ... on ProjectV2IterationField {
+          configuration { iterations { id title startDate duration } }
+        }}}
+      }' \
+      -f fid="$ITERATION_FIELD_ID" \
+      -f start="$(jq -r '.[0].startDate' <<<"$ALL_ITERS")" \
+      -F dur="$(jq -r '.[0].duration' <<<"$ALL_ITERS")" \
+      -f iters="$ALL_ITERS" \
+      > "$WORKDIR/iter-config-after.json"
+
+    TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
+      .data.updateProjectV2Field.projectV2Field.configuration.iterations[]
+      | . as $it | select($it.startDate == $d).id
+    ' "$WORKDIR/iter-config-after.json")
+
+    [[ -z "$TODAY_ITERATION_ID" ]] && {
+      echo "ERROR: failed to create iteration for $DATE; check rate limit + field permissions" >&2
+      exit 1
+    }
+    echo "INFO: created new daily iteration for $DATE -> $TODAY_ITERATION_ID" >&2
+  fi
+fi
+```
 
 ## 阶段 3：派发 daily-planner agent 评分排序
 
 ```
+PLAN_PATH="$WORKDIR/plan.json"
+
 Agent(
   description: "Score backlog and emit daily brief",
   subagent_type: "daily-planner",
-  prompt: """
-    Data files: $WORKDIR/{issues,items,fields,sub-issues}.json
-    Mode: ${APPLY:+apply}${APPLY:-dry-run}
-    Date: ${DATE:-$(date +%Y-%m-%d)}
-    Target iteration option ID: $TARGET_ITERATION_ID
-    HAS_PROJECT: $HAS_PROJECT
+  prompt: f"""
+    Constants (injected by skill):
+      PROJECT_NODE_ID = {PROJECT_NODE_ID}
+      ITERATION_FIELD_ID = {ITERATION_FIELD_ID}
+      TODAY_ITERATION_ID = {TODAY_ITERATION_ID}
+      DATE = {DATE}
+      CAPACITY = {CAPACITY}
+      HAS_PROJECT = {HAS_PROJECT}
+      MODE = {"apply" if APPLY else "dry-run"}
 
-    Read the 4 files, score & sort per WSJF 简化版，emit brief to
-    ~/.local/share/gocell-daily/${DATE}.md following 输出格式 章节。
-    Also emit machine-readable plan to $WORKDIR/plan.json
-    形如 [{item_id, issue, target_iteration_id, current_iteration_id, action}]，
-    供阶段 4 apply 消费。dry-run 模式只输出 brief 与 plan.json，不要建议任何写入。
+    Data files (Read these directly):
+      {WORKDIR}/issues.json        — backlog gh issue list output
+      {WORKDIR}/items.json         — Project v2 items (only if HAS_PROJECT)
+      {WORKDIR}/iter-config.json   — Iteration field configuration
+      {WORKDIR}/sub-issues.json    — GraphQL sub-issue relations
+
+    Tasks:
+      1. Read all 4 files
+      2. Score & sort per WSJF 简化版 (see your agent.md §排序算法)
+      3. Apply capacity filter ∑Cx <= CAPACITY
+      4. Emit brief markdown to STDOUT (use the §输出 章节 fixed format)
+      5. Write plan.json to {PLAN_PATH} (see schema in your agent.md §输出 #2)
+      6. dry-run mode: write plan.json but with all action="dry-run" (skill skips阶段 4)
   """
 )
 ```
 
+> 主 LLM 派发此 Agent 后会拿到 agent 的 stdout（brief markdown）+ plan.json 已落盘。brief 直接复述给用户在对话窗显示。
+
 ## 阶段 4：Apply 分支（仅 `--apply` + `HAS_PROJECT=true`）
 
 ```bash
-# 4.1 快照（apply 前防丢失，回滚依据）
-SNAPSHOT="$WORKDIR/snapshot-before.json"
-cp "$WORKDIR/items.json" "$SNAPSHOT"
+# 4.1 plan.json schema 校验（防 agent 漂移字段名）
+jq -e '
+  (type == "array") and
+  all(.[]; (.item_id | type == "string") and (.target_iteration_id | type == "string") and (.action | type == "string"))
+' "$WORKDIR/plan.json" > /dev/null || {
+  echo "ERROR: plan.json schema invalid (expect [{item_id,target_iteration_id,action,...}])" >&2
+  exit 1
+}
 
-# 4.2 逐项写入（客户端幂等：当前值 == 期望值 → skip）
-AUDIT=".claude/logs/daily-planner-$(date +%Y%m%d).jsonl"
-mkdir -p "$(dirname "$AUDIT")"
+# 4.2 逐项写入（agent 已用 action="skip" 标注幂等项）
+APPLIED=0
+SKIPPED=0
+FAILED_ITEMS=()
 
-jq -c '.[]' "$WORKDIR/plan.json" | while read -r row; do
+while read -r row; do
+  action=$(jq -r '.action' <<<"$row")
   item_id=$(jq -r '.item_id' <<<"$row")
-  cur_iter=$(jq -r '.current_iteration_id // empty' <<<"$row")
-  tgt_iter=$(jq -r '.target_iteration_id' <<<"$row")
+  tgt=$(jq -r '.target_iteration_id' <<<"$row")
+  cur=$(jq -r '.current_iteration_id // ""' <<<"$row")
 
-  if [[ "$cur_iter" == "$tgt_iter" ]]; then
-    echo "SKIP (no-op) $item_id" >&2
+  if [[ "$action" == "skip" || "$action" == "dry-run" ]]; then
+    SKIPPED=$((SKIPPED+1))
     continue
   fi
 
@@ -148,40 +223,36 @@ jq -c '.[]' "$WORKDIR/plan.json" | while read -r row; do
        --project-id "$PROJECT_NODE_ID" \
        --id "$item_id" \
        --field-id "$ITERATION_FIELD_ID" \
-       --iteration-id "$tgt_iter"; then
-    jq -nc --arg ts "$(date -u +%FT%TZ)" --arg item "$item_id" \
-       --arg old "$cur_iter" --arg new "$tgt_iter" --arg snap "$SNAPSHOT" \
-       '{ts:$ts, mode:"apply", item_id:$item, field:"Iteration",
-         old:$old, new:$new, snapshot:$snap}' >> "$AUDIT"
+       --iteration-id "$tgt" >/dev/null; then
+    APPLIED=$((APPLIED+1))
   else
-    # 失败：输出 rollback 命令清单到 stderr，不自动执行
-    echo "FAIL $item_id" >&2
-    echo "ROLLBACK: gh project item-edit --project-id $PROJECT_NODE_ID --id $item_id --field-id $ITERATION_FIELD_ID --iteration-id $cur_iter" >&2
-    jq -nc --arg ts "$(date -u +%FT%TZ)" --arg item "$item_id" \
-       --arg snap "$SNAPSHOT" \
-       '{ts:$ts, mode:"apply", item_id:$item, status:"failed",
-         snapshot:$snap, partial:true}' >> "$AUDIT"
+    FAILED_ITEMS+=("$item_id|$cur|$tgt")
   fi
-done
+done < <(jq -c '.[]' "$WORKDIR/plan.json")
 ```
 
 ## 阶段 5：报告
 
-输出给用户：
-- Brief 路径：`~/.local/share/gocell-daily/<DATE>.md`（点击可看）
-- Plan 路径：`$WORKDIR/plan.json`（机器可读）
-- 写入数 / 跳过数 / 失败数（仅 apply 模式）
-- Snapshot：`$SNAPSHOT`（仅 apply 模式）
-- Audit log：`$AUDIT`（仅 apply 模式）
-- 任何 `[NEEDS PRIORITY]` / `[MISSING LABEL]` / `[CAP COLLISION]` / `[需人工确认]` 警告
+主 LLM 把以下信息综合到对话回应：
+
+1. **Brief**（阶段 3 agent stdout 全文，固定 H2 章节）
+2. **Apply 摘要**（仅 apply 模式）：
+   - 写入 `$APPLIED` / 跳过 `$SKIPPED` / 失败 `${#FAILED_ITEMS[@]}`
+3. **失败回滚命令**（仅有失败项时；**逐条审查后再执行**，不要批量复制粘贴）：
+   ```
+   # 以下命令仅对失败项有效，请确认对应项确需回滚再逐条执行
+   gh project item-edit --project-id <PID> --id <ITEM> --field-id <FID> --iteration-id <OLD_ITER_ID>
+   ...
+   ```
+4. **WORKDIR 清理提示**：`rm -rf $WORKDIR`（含 issues.json 等含 body 副本的临时文件）
 
 ## 约束
 
 - 所有 `gh` 命令 `dangerouslyDisableSandbox: true`
-- **默认 dry-run；`--apply` 必须显式 opt-in**（首次使用一定先看 brief）
-- 只写 Project v2 Iteration 字段；**不动 Status / Estimate / labels**（这些是人控的进度语义）
+- **默认 dry-run**；`--apply` 必须显式 opt-in
+- 只写 Project v2 Iteration 字段 value + Iteration field configuration（追加 daily iteration option，append-only）；**不动 Status / Estimate / labels**
 - 不创建 / 修改 / 关闭 issue
 - 不修改代码、不跑 build/test
 - Apply 失败不自动回滚（输出回滚命令清单交人决策，避免二次破坏）
-- Iteration option ID 每次重查（sprint 切换漂移），不缓存到 agent 文件常量
-- Snapshot + audit log 落 `/tmp/daily-planner/` 与 `.claude/logs/`（已被 .gitignore）
+- **不在本地长期落盘**：brief = stdout，plan.json = `$WORKDIR/`（mktemp，run 完丢弃）
+- 字段 ID 每次启动从 `gh` 查询，不硬编（避免 Project v2 迁移后双源漂移）

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -306,10 +306,12 @@ Agent(
 
 # 4.1 plan.json 校验。两层 gate：
 #   (a) schema：类型 + action 取值集
-#   (b) membership：item_id ∈ items.json；target_iteration_id == TODAY_ITERATION_ID；
+#   (b) membership：item_id ∈ allowed set（本轮 input 集对应 item ∪ carry-over item）；
+#       target_iteration_id == TODAY_ITERATION_ID；
 #       current_iteration_id（若非空）∈ iter-config.json 的 iteration IDs
-# 校验失败 fail-closed：plan.json 是 agent (LLM) 生成的，必须当作未经信任的输入对待，
-# 防止"未在候选集中的 item / 非 TODAY 的 target iteration / 未知 action"被直接写真值。
+# 校验失败 fail-closed：plan.json 是 agent (LLM) 生成的，必须当作未经信任的输入对待。
+# allowed set 由 bash 独立从 items.json + issues.json + YESTERDAY_ITERATION_ID 算出，
+# 不复用 agent 的判定——防止 agent 把任意 Project item（不在本轮排期范围）写入 today。
 jq -e '
   (type == "array") and
   all(.[];
@@ -323,8 +325,25 @@ jq -e '
   exit 1
 }
 
-# 候选 item_id 集 (Project v2 已有 items)；候选 iteration_id 集 (field configuration)
-jq -r '.[].id' "$WORKDIR/items.json" | sort -u > "$WORKDIR/valid-item-ids.txt"
+# 候选 item_id 集 = (本轮 input 集对应的 Project item) ∪ (carry-over item)，
+# 由 bash 用 items.json + issues.json + YESTERDAY_ITERATION_ID 确定性算出，
+# **不**信任 agent 的取舍——agent 偏离时由 bash 收口 fail-closed。
+# 校验范围比"任意 Project item"窄，对齐 skill 的安全边界：
+# "LLM 排计划，bash 守真实 mutation"。
+jq -r --slurpfile issues "$WORKDIR/issues.json" --arg yid "${YESTERDAY_ITERATION_ID:-}" '
+  ($issues[0] | map(.number)) as $inputNums |
+  .[] | select(
+    # (a) Project item linked to an input backlog issue
+    (.content.number != null and ($inputNums | index(.content.number) != null))
+    or
+    # (b) carry-over: yesterday iter + OPEN + not Done
+    ($yid != "" and .iter.iterationId == $yid
+     and .content.state == "OPEN"
+     and (.status == null or .status.name != "Done"))
+  ) | .id
+' "$WORKDIR/items.json" | sort -u > "$WORKDIR/valid-item-ids.txt"
+
+# 候选 iteration_id 集 (field configuration)
 jq -r '.data.user.projectV2.field.configuration.iterations[].id' \
   "$WORKDIR/iter-config.json" | sort -u > "$WORKDIR/valid-iter-ids.txt"
 # 2.2 新建的 today iteration 也合法；merge 进去。
@@ -338,7 +357,7 @@ while read -r row; do
   cur=$(jq -r '.current_iteration_id // ""' <<<"$row")
 
   if ! grep -qxF "$item_id" "$WORKDIR/valid-item-ids.txt"; then
-    echo "ERROR: plan.json item_id not in Project v2 items: $item_id" >&2
+    echo "ERROR: plan.json item_id not in allowed set (input issues ∪ carry-over): $item_id" >&2
     VIOLATIONS=$((VIOLATIONS+1))
   fi
   if [[ "$tgt" != "$TODAY_ITERATION_ID" ]]; then
@@ -401,11 +420,11 @@ if [[ ${#FAILED_ITEMS[@]} -gt 0 ]]; then
   echo "" >&2
   echo "# --- partial apply detected: ${#APPLIED_ITEMS[@]} applied / ${#FAILED_ITEMS[@]} failed ---" >&2
   if [[ ${#APPLIED_ITEMS[@]} -gt 0 ]]; then
-    echo "# --- rollback commands for ALREADY-APPLIED items (REVIEW EACH BEFORE EXEC; prev_iter==\"\" 表示原本无 iteration) ---" >&2
+    echo "# --- rollback commands for ALREADY-APPLIED items (REVIEW EACH BEFORE EXEC; prev_iter==\"\" 表示原本无 iteration → --clear) ---" >&2
     for entry in "${APPLIED_ITEMS[@]}"; do
       IFS='|' read -r a_item a_prev _ <<<"$entry"
       if [[ -z "$a_prev" ]]; then
-        echo "# $a_item: original had no iteration; rollback = clear field value via UI (gh project item-edit lacks --clear-iteration)" >&2
+        echo "gh project item-edit --project-id $PROJECT_NODE_ID --id $a_item --field-id $ITERATION_FIELD_ID --clear" >&2
       else
         echo "gh project item-edit --project-id $PROJECT_NODE_ID --id $a_item --field-id $ITERATION_FIELD_ID --iteration-id $a_prev" >&2
       fi

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -332,9 +332,12 @@ jq -e '
 # "LLM 排计划，bash 守真实 mutation"。
 jq -r --slurpfile issues "$WORKDIR/issues.json" --arg yid "${YESTERDAY_ITERATION_ID:-}" '
   ($issues[0] | map(.number)) as $inputNums |
-  .[] | select(
-    # (a) Project item linked to an input backlog issue
-    (.content.number != null and ($inputNums | index(.content.number) != null))
+  .[] | .content.number as $cn | select(
+    # (a) Project item linked to an input backlog issue.
+    # NOTE: `index()` 内的 `.` 被解析为 index() 的输入（即 $inputNums 数组），
+    # 不是外层 item；必须先把 .content.number 绑到 $cn，否则 jq 会去做
+    # `$inputNums.content.number`，触发 "Cannot index array with string content"
+    ($cn != null and ($inputNums | index($cn)) != null)
     or
     # (b) carry-over: yesterday iter + OPEN + not Done
     ($yid != "" and .iter.iterationId == $yid

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -14,7 +14,7 @@ disable-model-invocation: true
 
 - **Project v2 是真值源**：当日排期写入 Iteration field value；不在本地长期归档 brief / audit log
 - **默认输入集 = P0 + P1**：单人项目 P3 大头不参与每日排期；`--include-p2` / `--include-p3` 可扩
-- **Wave 模型**：工作日 2 wave × 5 issue = 10 容量 / 周末 4 wave × 5 issue = 20 容量（一任务一容量；不引入 ∑Cx 加权）
+- **Wave 模型**：工作日 2 wave × 5 issue = 10 容量 / 周末 4 wave × 5 issue = 20 容量
 - **Carry-over 硬规则**：昨日 iteration 内 issue.state≠CLOSED 且 Status≠Done 的项**优先占 Wave 1 头部**
 - **字段 ID 动态查询**：每次启动从 `gh` 拉真实 ID，不维护硬编副本
 
@@ -28,13 +28,38 @@ disable-model-invocation: true
 | `--include-p2` | off | 加入 P2 issue 作输入 |
 | `--include-p3` | off | 加入 P3 issue（极少需要；P3 默认 nice-to-have） |
 
+`disable-model-invocation: true`（frontmatter）= 阻止 AI 在日常对话里"看到 today / standup 关键词"就主动调本 skill；仅用户显式 `/daily-planner` 触发。
+
+## Argument parsing convention
+
+宿主 LLM 收到用户 `/daily-planner <args>` 后，将 flag 解析为环境变量再执行下列 bash：
+
+| Flag | Env 设置 |
+|------|---------|
+| `--apply` | `APPLY=true` |
+| `--date=YYYY-MM-DD` | `DATE=YYYY-MM-DD` |
+| `--weekend` | `FORCE_WEEKEND=true` |
+| `--weekday` | `FORCE_WEEKDAY=true` |
+| `--include-p2` | `INCLUDE_P2=true` |
+| `--include-p3` | `INCLUDE_P3=true` |
+
+未设的 env 默认 unset（bash `${VAR:-}` 兜底）。
+
 ---
 
 ## 阶段 0：常量动态查询 + token scope fail-fast + 模式探测
 
 ```bash
-# 0.1 Token scope（无 project scope → 直接退出；删除原降级模式）
-if ! gh auth status 2>&1 | grep -qiE "scopes:.*\bproject\b"; then
+set -euo pipefail
+
+# 0.1 Token scope。先区分未登录 vs 缺 scope（gh auth status 失败 → 未登录；
+# 成功但 grep 不到 → 缺 scope）。grep 用宽松正则，跨 gh 版本健壮。
+if ! AUTH_STATUS=$(gh auth status 2>&1); then
+  echo "ERROR: gh auth status failed; run: gh auth login" >&2
+  echo "$AUTH_STATUS" >&2
+  exit 1
+fi
+if ! grep -qiE "scopes:.*\bproject\b" <<<"$AUTH_STATUS"; then
   echo "ERROR: token missing 'project' scope; run: gh auth refresh -s project" >&2
   exit 1
 fi
@@ -48,12 +73,17 @@ ITERATION_FIELD_ID=$(gh project field-list 3 --owner ghbvf --format json \
   exit 1
 }
 
-# 0.3 日期 + 模式（weekday/weekend）。用 python3 跨 macOS BSD / Linux GNU date 兼容
+# 0.3 日期 + 模式（weekday/weekend）。python3 用 sys.argv 传 $DATE 防 shell 注入
 DATE="${DATE:-$(date +%Y-%m-%d)}"
-DOW=$(python3 -c "from datetime import date; print(date.fromisoformat('$DATE').isoweekday())")
-# 自动判定，flag 覆盖
-if [[ "$FORCE_WEEKEND" == "true" ]]; then IS_WEEKEND=true
-elif [[ "$FORCE_WEEKDAY" == "true" ]]; then IS_WEEKEND=false
+DOW=$(python3 -c 'import sys,datetime; print(datetime.date.fromisoformat(sys.argv[1]).isoweekday())' "$DATE")
+
+# --weekend / --weekday 互斥（同传 fail-fast 不静默吞错）
+if [[ "${FORCE_WEEKEND:-}" == "true" && "${FORCE_WEEKDAY:-}" == "true" ]]; then
+  echo "ERROR: --weekend and --weekday are mutually exclusive" >&2
+  exit 1
+fi
+if [[ "${FORCE_WEEKEND:-}" == "true" ]]; then IS_WEEKEND=true
+elif [[ "${FORCE_WEEKDAY:-}" == "true" ]]; then IS_WEEKEND=false
 elif [[ "$DOW" -ge 6 ]]; then IS_WEEKEND=true
 else IS_WEEKEND=false
 fi
@@ -68,22 +98,21 @@ WAVE_COUNT=$([[ "$IS_WEEKEND" == "true" ]] && echo 4 || echo 2)
 WORKDIR="$(mktemp -d -t daily-planner.XXXXXX)"
 chmod 700 "$WORKDIR"
 
-# 1.1 输入集：P0 + P1 (默认) + 可选 P2/P3
-PRI_TERMS='label:pri-p0,label:pri-p1'
-[[ "$INCLUDE_P2" == "true" ]] && PRI_TERMS="$PRI_TERMS,label:pri-p2"
-[[ "$INCLUDE_P3" == "true" ]] && PRI_TERMS="$PRI_TERMS,label:pri-p3"
+# 1.1 输入集：P0 + P1 (默认) + 可选 P2/P3。GitHub label search 是 AND 语义，需逐 label 拉
+PRI_LABELS=(pri-p0 pri-p1)
+[[ "${INCLUDE_P2:-}" == "true" ]] && PRI_LABELS+=(pri-p2)
+[[ "${INCLUDE_P3:-}" == "true" ]] && PRI_LABELS+=(pri-p3)
 
-# 用多次 gh issue list 联合（GitHub label search 是 AND 语义，需逐 label 拉再合并）
 echo "[]" > "$WORKDIR/issues.json"
-for term in ${PRI_TERMS//,/ }; do
-  pri_label="${term#label:}"
+for pri_label in "${PRI_LABELS[@]}"; do
   gh issue list --repo ghbvf/gocell --label backlog --label "$pri_label" \
     --state open --json number,title,labels,createdAt,body,url --limit 200 \
     > "$WORKDIR/issues-$pri_label.json"
-  jq -s '.[0] + .[1]' "$WORKDIR/issues.json" "$WORKDIR/issues-$pri_label.json" \
+  jq -s '(.[0] + .[1]) | unique_by(.number)' \
+    "$WORKDIR/issues.json" "$WORKDIR/issues-$pri_label.json" \
     > "$WORKDIR/issues.tmp" && mv "$WORKDIR/issues.tmp" "$WORKDIR/issues.json"
 done
-echo "INFO: input set = $(jq 'length' "$WORKDIR/issues.json") issues (priority labels: $PRI_TERMS)"
+echo "INFO: input set = $(jq 'length' "$WORKDIR/issues.json") issues (priorities: ${PRI_LABELS[*]})" >&2
 
 # 1.2 Project v2 items（用 GraphQL paginated，因为 gh project item-list 不返回 iteration value 和 issue.state）
 # 输出 NDJSON 多页，jq -s 合并所有页的 nodes
@@ -108,7 +137,7 @@ query($endCursor: String) {
     }
   }}
 }' | jq -s '[.[].data.user.projectV2.items.nodes[]]' > "$WORKDIR/items.json"
-echo "INFO: $(jq 'length' "$WORKDIR/items.json") Project v2 items loaded"
+echo "INFO: $(jq 'length' "$WORKDIR/items.json") Project v2 items loaded" >&2
 
 # 1.3 Iteration 配置（拿当前所有 iteration option）
 gh api graphql -f query='query {
@@ -136,7 +165,9 @@ gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
 ## 阶段 2：确保 today iteration 存在
 
 ```bash
-# 2.1 推断 $DATE 对应的 iteration option（注意 pipe 后 root context 丢失，用 `as $it` 绑定保留）
+# 2.1 推断 $DATE 对应的 iteration option
+# jq 在 select() 内嵌套 pipe 后 . 会被覆盖为子表达式中间值；用 `as $it` 把当前
+# iteration 对象绑定为变量，确保算术子表达式仍能引用其 startDate / duration
 TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
   .data.user.projectV2.field.configuration.iterations[]
   | . as $it
@@ -148,11 +179,16 @@ TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
 # 2.2 缺失则用 GraphQL mutation append 一个 1-day iteration option 覆盖 $DATE
 if [[ -z "$TODAY_ITERATION_ID" ]]; then
   EXISTING=$(jq -c '.data.user.projectV2.field.configuration.iterations | map({title, startDate, duration})' "$WORKDIR/iter-config.json")
-  NEW_TITLE="Iteration $(jq 'length + 1' <<<"$EXISTING")"
+  NEW_TITLE="Iteration $(jq 'length + 1' <<<"$EXISTING")"  # 命名仅展示用，实际唯一 ID 由 GitHub 生成
   ALL_ITERS=$(jq -c --arg title "$NEW_TITLE" --arg d "$DATE" \
                '. + [{title: $title, startDate: $d, duration: 1}]' <<<"$EXISTING")
 
-  # 类型名 ProjectV2Iteration 是 INPUT_OBJECT（GraphQL 2026-05-24 introspection 实测）
+  # iterationConfiguration.startDate / .duration 是 field-level "cycle 起点 / 周期" 配置，
+  # iterations 数组每项 startDate / duration 才决定每个 option 的 daily 边界。
+  # 用 EXISTING 第一项的 startDate / duration 作 cycle 锚点（保持已有配置不变；
+  # 实际新增的 option 在 iterations 数组最后一项）。
+  # 类型名 ProjectV2Iteration 是 INPUT_OBJECT（GraphQL 2026-05-24 introspection 实测）。
+  # `-F` 大写才把 value 当 raw JSON/array 传入；`-f` 小写是 string 字面量（数组场景必 fail）。
   gh api graphql -f query='
     mutation($fid: ID!, $start: Date!, $dur: Int!, $iters: [ProjectV2Iteration!]!) {
       updateProjectV2Field(input: {
@@ -165,7 +201,7 @@ if [[ -z "$TODAY_ITERATION_ID" ]]; then
     -f fid="$ITERATION_FIELD_ID" \
     -f start="$(jq -r '.[0].startDate' <<<"$ALL_ITERS")" \
     -F dur="$(jq -r '.[0].duration' <<<"$ALL_ITERS")" \
-    -f iters="$ALL_ITERS" \
+    -F iters="$ALL_ITERS" \
     > "$WORKDIR/iter-config-after.json"
 
   TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
@@ -179,17 +215,25 @@ if [[ -z "$TODAY_ITERATION_ID" ]]; then
   echo "INFO: created new daily iteration for $DATE -> $TODAY_ITERATION_ID" >&2
 fi
 
-# 2.3 推断昨日 iteration ID（carry-over 源）
-YESTERDAY=$(python3 -c "from datetime import date,timedelta; print(date.fromisoformat('$DATE') - timedelta(days=1))")
+# 2.3 推断昨日 iteration ID（carry-over 源）。python3 用 sys.argv 传 $DATE 防注入
+YESTERDAY=$(python3 -c 'import sys,datetime; print(datetime.date.fromisoformat(sys.argv[1]) - datetime.timedelta(days=1))' "$DATE")
 YESTERDAY_ITERATION_ID=$(jq -r --arg d "$YESTERDAY" '
   .data.user.projectV2.field.configuration.iterations[]
   | . as $it
   | select($it.startDate == $d).id
 ' "$WORKDIR/iter-config.json")
-[[ -z "$YESTERDAY_ITERATION_ID" ]] && echo "WARN: yesterday iteration not found ($YESTERDAY); carry-over disabled" >&2
+CARRY_OVER_DISABLED=false
+if [[ -z "$YESTERDAY_ITERATION_ID" ]]; then
+  CARRY_OVER_DISABLED=true
+  echo "WARN: yesterday iteration not found ($YESTERDAY); carry-over disabled" >&2
+fi
 ```
 
 ## 阶段 3：派发 daily-planner agent 评分排序
+
+下面 `Agent(...)` 块是**宿主 LLM 伪代码模板**（不是 bash），由宿主 LLM 把
+`{VAR}` 占位符替换为上方 bash 阶段 0-2 设置的环境变量真实值后，调用 Agent
+tool。每个 `{VAR}` 都必须能在 bash 上下文中找到对应变量。
 
 ```
 PLAN_PATH="$WORKDIR/plan.json"
@@ -203,6 +247,7 @@ Agent(
       ITERATION_FIELD_ID = {ITERATION_FIELD_ID}
       TODAY_ITERATION_ID = {TODAY_ITERATION_ID}
       YESTERDAY_ITERATION_ID = {YESTERDAY_ITERATION_ID}  # 可能空（首日 / 假期跳过后）
+      CARRY_OVER_DISABLED = {CARRY_OVER_DISABLED}        # true 时 brief Warnings 必加 [CARRY-OVER DISABLED]
       DATE = {DATE}                                       # YYYY-MM-DD
       IS_WEEKEND = {IS_WEEKEND}                           # true|false
       WAVE_COUNT = {WAVE_COUNT}                           # 2|4
@@ -217,13 +262,15 @@ Agent(
 
     Tasks:
       1. Read all 4 files
-      2. Compute carry-over: items.json 中 iteration == YESTERDAY_ITERATION_ID 且
-         (issue.state == "OPEN") AND (status != "Done") 的 issue → 加入 carry-over 列表
+      2. Compute carry-over (if not CARRY_OVER_DISABLED): items.json 中
+         iter.iterationId == YESTERDAY_ITERATION_ID AND content.state == "OPEN"
+         AND (status==null OR status.name != "Done") 的 issue → 加入 carry-over 列表
       3. Score P0/P1 池 per WSJF 简化版（详 agent.md §排序算法）
       4. Wave 调度：
          - Wave 1 头部填 carry-over（按原 WSJF score 排序）
          - 剩余 Wave 1 / Wave 2+ 填 新 issue 按分数降序
-         - 容量 = WAVE_COUNT × WAVE_SIZE（一任务一容量；超出 → Unscheduled [capacity overflow]）
+         - 容量 = WAVE_COUNT × WAVE_SIZE；超出 → Unscheduled [capacity overflow]
+         - 空输入集（input + carry-over 均 0）→ brief Warnings [EMPTY INPUT SET]，plan=[]
       5. Emit brief markdown to STDOUT（详 agent.md §输出格式）
       6. Write plan.json to {PLAN_PATH}（详 agent.md §输出 #2）
   """
@@ -268,21 +315,36 @@ while read -r row; do
     FAILED_ITEMS+=("$item_id|$cur|$tgt")
   fi
 done < <(jq -c '.[]' "$WORKDIR/plan.json")
+
+# 4.3 生成回滚命令清单（实际值展开，避免占位符被 shell 误解析为重定向）
+if [[ ${#FAILED_ITEMS[@]} -gt 0 ]]; then
+  echo "" >&2
+  echo "# --- rollback commands (REVIEW EACH BEFORE EXEC; cur_iter==\"\" 表示失败项原本无 iteration) ---" >&2
+  for entry in "${FAILED_ITEMS[@]}"; do
+    IFS='|' read -r f_item f_cur _ <<<"$entry"
+    if [[ -z "$f_cur" ]]; then
+      echo "# $f_item: original had no iteration; rollback = clear field value (use gh project item-edit --clear iteration in UI)" >&2
+    else
+      echo "gh project item-edit --project-id $PROJECT_NODE_ID --id $f_item --field-id $ITERATION_FIELD_ID --iteration-id $f_cur" >&2
+    fi
+  done
+  echo "# --- end rollback ---" >&2
+fi
+
+# 4.4 Audit 行
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+MODE_STR=$([[ "$IS_WEEKEND" == "true" ]] && echo weekend || echo weekday)
+echo "[audit] $TS date=$DATE mode=$MODE_STR wave_count=$WAVE_COUNT applied=$APPLIED skipped=$SKIPPED failed=${#FAILED_ITEMS[@]}" >&2
 ```
 
 ## 阶段 5：报告
 
-主 LLM 把以下信息综合到对话回应：
+宿主 LLM 把以下信息综合到对话回应：
 
 1. **Brief**（阶段 3 agent stdout 全文，含 Wave N 章节）
-2. **Audit 行**（仅 apply 模式）：`[audit] $(date -u +%FT%TZ) date=$DATE mode=$([[ $IS_WEEKEND == true ]] && echo weekend || echo weekday) wave_count=$WAVE_COUNT applied=$APPLIED skipped=$SKIPPED failed=${#FAILED_ITEMS[@]}`
-3. **失败回滚命令**（仅有失败项时；**逐条审查后再执行**，不要批量复制粘贴）：
-   ```
-   # 以下命令仅对失败项有效，逐条确认对应项确需回滚再执行
-   gh project item-edit --project-id <PID> --id <ITEM> --field-id <FID> --iteration-id <OLD_ITER_ID>
-   ...
-   ```
-4. **WORKDIR 清理提示**：`rm -rf $WORKDIR`
+2. **Audit 行**（仅 apply 模式，由 4.4 写到 stderr）
+3. **失败回滚命令清单**（仅 apply 模式有失败项时，由 4.3 写到 stderr，已是真实可执行命令）
+4. **WORKDIR 清理提示**：`rm -rf $WORKDIR`（保留供 apply 失败后追溯；用户审查后手动清）
 
 ## 约束
 

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: daily-planner
+description: "每日迭代调度（默认 dry-run；--apply 才写入 Project v2 Iteration 字段）。触发：'今日计划' / 'daily plan' / 'standup' / '排今天的活' / 'iteration 排期'。"
+argument-hint: "[--apply] [--date=YYYY-MM-DD]"
+allowed-tools: [Bash, Read, Write, Agent]
+---
+
+# Daily Planner Skill
+
+调度 backlog → 当日 Project v2 Iteration。**默认 dry-run**（只输出 markdown brief），`--apply` 才真写入。Backlog 真值源见 `docs/backlog.md`。
+
+## 参数
+
+| Flag | 默认 | 含义 |
+|------|------|------|
+| `--apply` | off | 写入 Project v2 Iteration 字段；未传则纯 dry-run |
+| `--date=YYYY-MM-DD` | today（系统 TZ） | 目标排期日期 |
+
+---
+
+## 常量（2026-05-24 实测；详见 agent 文件 §Project v2 常量）
+
+```bash
+PROJECT_NODE_ID="PVT_kwHOBjsrB84BYQ3m"
+ITERATION_FIELD_ID="PVTIF_lAHOBjsrB84BYQ3mzhTX_HQ"
+```
+
+如 Project v2 重建或迁移，更新 agent 文件常量块后同步这里。
+
+## 阶段 1：Token scope fail-check
+
+```bash
+gh auth status 2>&1 | grep -q "'project'" && HAS_PROJECT=true || HAS_PROJECT=false
+```
+
+| 状态 | 模式 |
+|------|------|
+| `HAS_PROJECT=true` + `--apply` | 完整模式：读 + 写 Iteration |
+| `HAS_PROJECT=true` + dry-run | 完整模式但不写：读 Project v2 字段、计算 diff、不调 `item-edit` |
+| `HAS_PROJECT=false` + `--apply` | **报错退出**，提示 `gh auth refresh -s project` |
+| `HAS_PROJECT=false` + dry-run | 降级"只读 brief"模式：跳过所有 `gh project` 命令，仅基于 `gh issue list` label 维度排序 |
+
+云沙箱 token 默认无 `project` scope（详见 `docs/backlog.md` §云沙箱查询），降级模式必须可用。
+
+## 阶段 2：拉取数据
+
+```bash
+WORKDIR="/tmp/daily-planner/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$WORKDIR"
+DATE="${DATE:-$(date +%Y-%m-%d)}"
+
+# 2.1 Backlog 池（label 维度，全量；当前 263 items < limit）
+gh issue list --repo ghbvf/gocell --label backlog --state open \
+  --json number,title,labels,createdAt,body,url --limit 300 \
+  > "$WORKDIR/issues.json"
+
+# 2.2 Project v2 items + 当前字段值（仅 HAS_PROJECT=true）
+if [[ $HAS_PROJECT == true ]]; then
+  gh project item-list 3 --owner ghbvf --format json --limit 300 \
+    > "$WORKDIR/items.json"
+
+  # 2.3 Iteration sprint 配置（每次重查，option ID 随 sprint 切换漂移）
+  gh api graphql -f query='query {
+    user(login:"ghbvf"){ projectV2(number:3){
+      field(name:"Iteration"){ ... on ProjectV2IterationField {
+        configuration { iterations { id title startDate duration } }
+      }}
+    }}
+  }' > "$WORKDIR/iterations.json"
+
+  # 推断 target date 落在哪个 sprint（startDate ≤ DATE < startDate + duration）
+  # 注意：pipe 后 root context 会丢失，必须用 `as $it` 绑定保留访问
+  TARGET_ITERATION_ID=$(jq -r --arg d "$DATE" '
+    .data.user.projectV2.field.configuration.iterations[]
+    | . as $it
+    | select($it.startDate <= $d
+             and ($d < ((($it.startDate | strptime("%Y-%m-%d") | mktime) + ($it.duration * 86400))
+                         | strftime("%Y-%m-%d")))).id
+  ' "$WORKDIR/iterations.json")
+
+  if [[ -z "$TARGET_ITERATION_ID" ]]; then
+    echo "ERROR: no sprint iteration covers $DATE" >&2
+    echo "Hint: add a new iteration in Project v2 UI before re-running --apply" >&2
+    exit 1
+  fi
+fi
+
+# 2.4 Sub-issue 关系（GraphQL 原生 + body grep 双源）
+gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
+  repository(owner:"ghbvf",name:"gocell"){
+    issues(first:100, labels:["bundle-parent","backlog"], states:OPEN){
+      nodes {
+        number title
+        subIssuesSummary { total completed }
+        subIssues(first:50){ nodes { number title state } }
+      }
+    }
+  }
+}' > "$WORKDIR/sub-issues.json" 2>/dev/null || echo '{}' > "$WORKDIR/sub-issues.json"
+```
+
+> **Sprint vs Daily 语义**（详见 agent 文件同名章节）：本 skill 写入 Project v2 Iteration = "把 issue 加入 current sprint"。Daily 焦点队列在 brief 本地落盘。Sprint 切换日 `TARGET_ITERATION_ID` 自动指向新 sprint。
+
+## 阶段 3：派发 daily-planner agent 评分排序
+
+```
+Agent(
+  description: "Score backlog and emit daily brief",
+  subagent_type: "daily-planner",
+  prompt: """
+    Data files: $WORKDIR/{issues,items,fields,sub-issues}.json
+    Mode: ${APPLY:+apply}${APPLY:-dry-run}
+    Date: ${DATE:-$(date +%Y-%m-%d)}
+    Target iteration option ID: $TARGET_ITERATION_ID
+    HAS_PROJECT: $HAS_PROJECT
+
+    Read the 4 files, score & sort per WSJF 简化版，emit brief to
+    ~/.local/share/gocell-daily/${DATE}.md following 输出格式 章节。
+    Also emit machine-readable plan to $WORKDIR/plan.json
+    形如 [{item_id, issue, target_iteration_id, current_iteration_id, action}]，
+    供阶段 4 apply 消费。dry-run 模式只输出 brief 与 plan.json，不要建议任何写入。
+  """
+)
+```
+
+## 阶段 4：Apply 分支（仅 `--apply` + `HAS_PROJECT=true`）
+
+```bash
+# 4.1 快照（apply 前防丢失，回滚依据）
+SNAPSHOT="$WORKDIR/snapshot-before.json"
+cp "$WORKDIR/items.json" "$SNAPSHOT"
+
+# 4.2 逐项写入（客户端幂等：当前值 == 期望值 → skip）
+AUDIT=".claude/logs/daily-planner-$(date +%Y%m%d).jsonl"
+mkdir -p "$(dirname "$AUDIT")"
+
+jq -c '.[]' "$WORKDIR/plan.json" | while read -r row; do
+  item_id=$(jq -r '.item_id' <<<"$row")
+  cur_iter=$(jq -r '.current_iteration_id // empty' <<<"$row")
+  tgt_iter=$(jq -r '.target_iteration_id' <<<"$row")
+
+  if [[ "$cur_iter" == "$tgt_iter" ]]; then
+    echo "SKIP (no-op) $item_id" >&2
+    continue
+  fi
+
+  if gh project item-edit \
+       --project-id "$PROJECT_NODE_ID" \
+       --id "$item_id" \
+       --field-id "$ITERATION_FIELD_ID" \
+       --iteration-id "$tgt_iter"; then
+    jq -nc --arg ts "$(date -u +%FT%TZ)" --arg item "$item_id" \
+       --arg old "$cur_iter" --arg new "$tgt_iter" --arg snap "$SNAPSHOT" \
+       '{ts:$ts, mode:"apply", item_id:$item, field:"Iteration",
+         old:$old, new:$new, snapshot:$snap}' >> "$AUDIT"
+  else
+    # 失败：输出 rollback 命令清单到 stderr，不自动执行
+    echo "FAIL $item_id" >&2
+    echo "ROLLBACK: gh project item-edit --project-id $PROJECT_NODE_ID --id $item_id --field-id $ITERATION_FIELD_ID --iteration-id $cur_iter" >&2
+    jq -nc --arg ts "$(date -u +%FT%TZ)" --arg item "$item_id" \
+       --arg snap "$SNAPSHOT" \
+       '{ts:$ts, mode:"apply", item_id:$item, status:"failed",
+         snapshot:$snap, partial:true}' >> "$AUDIT"
+  fi
+done
+```
+
+## 阶段 5：报告
+
+输出给用户：
+- Brief 路径：`~/.local/share/gocell-daily/<DATE>.md`（点击可看）
+- Plan 路径：`$WORKDIR/plan.json`（机器可读）
+- 写入数 / 跳过数 / 失败数（仅 apply 模式）
+- Snapshot：`$SNAPSHOT`（仅 apply 模式）
+- Audit log：`$AUDIT`（仅 apply 模式）
+- 任何 `[NEEDS PRIORITY]` / `[MISSING LABEL]` / `[CAP COLLISION]` / `[需人工确认]` 警告
+
+## 约束
+
+- 所有 `gh` 命令 `dangerouslyDisableSandbox: true`
+- **默认 dry-run；`--apply` 必须显式 opt-in**（首次使用一定先看 brief）
+- 只写 Project v2 Iteration 字段；**不动 Status / Estimate / labels**（这些是人控的进度语义）
+- 不创建 / 修改 / 关闭 issue
+- 不修改代码、不跑 build/test
+- Apply 失败不自动回滚（输出回滚命令清单交人决策，避免二次破坏）
+- Iteration option ID 每次重查（sprint 切换漂移），不缓存到 agent 文件常量
+- Snapshot + audit log 落 `/tmp/daily-planner/` 与 `.claude/logs/`（已被 .gitignore）

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-planner
 description: "每日 backlog → Project v2 Iteration 调度（wave 模型 + carry-over + 周末自动识别）。默认 dry-run；--apply 才写入。仅用户显式 /daily-planner 触发，避免 AI 主动调用对真实 Project v2 写入。"
-argument-hint: "[--apply] [--date=YYYY-MM-DD] [--capacity=N] [--weekend|--weekday] [--include-p2] [--include-p3]"
+argument-hint: "[--apply] [--date=YYYY-MM-DD] [--weekend|--weekday] [--include-p2] [--include-p3]"
 allowed-tools: [Bash, Read, Write, Agent]
 disable-model-invocation: true
 ---
@@ -14,7 +14,7 @@ disable-model-invocation: true
 
 - **Project v2 是真值源**：当日排期写入 Iteration field value；不在本地长期归档 brief / audit log
 - **默认输入集 = P0 + P1**：单人项目 P3 大头不参与每日排期；`--include-p2` / `--include-p3` 可扩
-- **Wave 模型**：工作日 2 wave × 5 issue / 周末 4 wave × 5 issue；wave_count × 5 是硬上限，∑Cx ≤ capacity 是软警告
+- **Wave 模型**：工作日 2 wave × 5 issue = 10 容量 / 周末 4 wave × 5 issue = 20 容量（一任务一容量；不引入 ∑Cx 加权）
 - **Carry-over 硬规则**：昨日 iteration 内 issue.state≠CLOSED 且 Status≠Done 的项**优先占 Wave 1 头部**
 - **字段 ID 动态查询**：每次启动从 `gh` 拉真实 ID，不维护硬编副本
 
@@ -24,8 +24,7 @@ disable-model-invocation: true
 |------|------|------|
 | `--apply` | off | 写入 Project v2 Iteration 字段（含 carry-over move）；未传则纯 dry-run |
 | `--date=YYYY-MM-DD` | today | 目标排期日期 |
-| `--capacity=N` | 30 工作日 / 60 周末 | ∑Cx 软警告阈值（Cx1=1/Cx2=2/Cx3=3/Cx4=4） |
-| `--weekend` / `--weekday` | 自动 `date +%u` | 强制模式覆盖 |
+| `--weekend` / `--weekday` | 自动 `date +%u` | 强制模式覆盖（影响 wave 数 → 容量）|
 | `--include-p2` | off | 加入 P2 issue 作输入 |
 | `--include-p3` | off | 加入 P3 issue（极少需要；P3 默认 nice-to-have） |
 
@@ -59,16 +58,8 @@ elif [[ "$DOW" -ge 6 ]]; then IS_WEEKEND=true
 else IS_WEEKEND=false
 fi
 
-if [[ "$IS_WEEKEND" == "true" ]]; then
-  WAVE_COUNT=4
-  CAPACITY_DEFAULT=60
-else
-  WAVE_COUNT=2
-  CAPACITY_DEFAULT=30
-fi
-CAPACITY="${CAPACITY:-$CAPACITY_DEFAULT}"
 WAVE_SIZE=5  # 固定，Miller's Law
-ISSUE_CAP=$(( WAVE_COUNT * WAVE_SIZE ))
+WAVE_COUNT=$([[ "$IS_WEEKEND" == "true" ]] && echo 4 || echo 2)
 ```
 
 ## 阶段 1：拉取数据
@@ -215,9 +206,7 @@ Agent(
       DATE = {DATE}                                       # YYYY-MM-DD
       IS_WEEKEND = {IS_WEEKEND}                           # true|false
       WAVE_COUNT = {WAVE_COUNT}                           # 2|4
-      WAVE_SIZE = 5
-      ISSUE_CAP = {ISSUE_CAP}                             # WAVE_COUNT * 5
-      CAPACITY = {CAPACITY}                               # ∑Cx 软警告阈值
+      WAVE_SIZE = 5                                       # 容量 = WAVE_COUNT * WAVE_SIZE
       MODE = {"apply" if APPLY else "dry-run"}
 
     Data files (Read these):
@@ -234,8 +223,7 @@ Agent(
       4. Wave 调度：
          - Wave 1 头部填 carry-over（按原 WSJF score 排序）
          - 剩余 Wave 1 / Wave 2+ 填 新 issue 按分数降序
-         - 硬约束: 总 issue 数 ≤ ISSUE_CAP
-         - 软约束: ∑Cx 超 CAPACITY 时在 Warnings 标注，不阻塞
+         - 容量 = WAVE_COUNT × WAVE_SIZE（一任务一容量；超出 → Unscheduled [capacity overflow]）
       5. Emit brief markdown to STDOUT（详 agent.md §输出格式）
       6. Write plan.json to {PLAN_PATH}（详 agent.md §输出 #2）
   """
@@ -287,7 +275,7 @@ done < <(jq -c '.[]' "$WORKDIR/plan.json")
 主 LLM 把以下信息综合到对话回应：
 
 1. **Brief**（阶段 3 agent stdout 全文，含 Wave N 章节）
-2. **Audit 行**（仅 apply 模式）：`[audit] $(date -u +%FT%TZ) date=$DATE mode=$([[ $IS_WEEKEND == true ]] && echo weekend || echo weekday) wave_count=$WAVE_COUNT capacity=$CAPACITY applied=$APPLIED skipped=$SKIPPED failed=${#FAILED_ITEMS[@]}`
+2. **Audit 行**（仅 apply 模式）：`[audit] $(date -u +%FT%TZ) date=$DATE mode=$([[ $IS_WEEKEND == true ]] && echo weekend || echo weekday) wave_count=$WAVE_COUNT applied=$APPLIED skipped=$SKIPPED failed=${#FAILED_ITEMS[@]}`
 3. **失败回滚命令**（仅有失败项时；**逐条审查后再执行**，不要批量复制粘贴）：
    ```
    # 以下命令仅对失败项有效，逐条确认对应项确需回滚再执行

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -98,8 +98,11 @@ WAVE_COUNT=$([[ "$IS_WEEKEND" == "true" ]] && echo 4 || echo 2)
 WORKDIR="$(mktemp -d -t daily-planner.XXXXXX)"
 chmod 700 "$WORKDIR"
 
-# 1.1 输入集：P0 + P1 (默认) + 可选 P2/P3。GitHub label search 是 AND 语义，需逐 label 拉
-PRI_LABELS=(pri-p0 pri-p1)
+# 1.1 输入集：pri-missing 哨兵 + P0 + P1 (默认) + 可选 P2/P3。
+# pri-missing 是 backlog workflow 自动打的哨兵 (CLAUDE.md "新 backlog 条目")，
+# 漏标 priority 的 issue 不能被排期忽略；按 score 公式它有最高权重 (110)。
+# GitHub label search 是 AND 语义，需逐 label 拉。
+PRI_LABELS=(pri-missing pri-p0 pri-p1)
 [[ "${INCLUDE_P2:-}" == "true" ]] && PRI_LABELS+=(pri-p2)
 [[ "${INCLUDE_P3:-}" == "true" ]] && PRI_LABELS+=(pri-p3)
 
@@ -149,7 +152,9 @@ gh api graphql -f query='query {
 }' > "$WORKDIR/iter-config.json"
 
 # 1.4 Sub-issue 关系（GraphQL 原生）
-gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
+# GraphQL-Features header 是 preview API；账号 / repo 未启用时会返回 errors。
+# 失败显式 WARN，不静默吞错（保留降级 `{}`，让 agent 当作"无 sub-issue 数据"运行）。
+if ! gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
   repository(owner:"ghbvf",name:"gocell"){
     issues(first:100, labels:["bundle-parent"], states:OPEN){
       nodes {
@@ -159,7 +164,12 @@ gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
       }
     }
   }
-}' > "$WORKDIR/sub-issues.json" 2>/dev/null || echo '{}' > "$WORKDIR/sub-issues.json"
+}' > "$WORKDIR/sub-issues.json" 2>"$WORKDIR/sub-issues.err"; then
+  echo "WARN: sub-issue GraphQL query failed; sub-issue data unavailable for this run" >&2
+  echo "WARN: gh stderr:" >&2
+  sed 's/^/  /' "$WORKDIR/sub-issues.err" >&2
+  echo '{}' > "$WORKDIR/sub-issues.json"
+fi
 ```
 
 ## 阶段 2：确保 today iteration 存在
@@ -176,8 +186,17 @@ TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
                        | strftime("%Y-%m-%d")))).id
 ' "$WORKDIR/iter-config.json")
 
-# 2.2 缺失则用 GraphQL mutation append 一个 1-day iteration option 覆盖 $DATE
+# 2.2 缺失则用 GraphQL mutation append 一个 1-day iteration option 覆盖 $DATE。
+# **写入 Project v2 是 apply-only**——dry-run 不得执行 updateProjectV2Field（mutation
+# 会真实改 field configuration）；缺 iteration 时 dry-run 给出 would-create 摘要并退出。
 if [[ -z "$TODAY_ITERATION_ID" ]]; then
+  if [[ "${APPLY:-}" != "true" ]]; then
+    echo "INFO: [DRY-RUN] today iteration for $DATE missing; --apply would append a 1-day option to Iteration field." >&2
+    echo "INFO: [DRY-RUN] no Project v2 mutation executed; planning aborted (need TODAY_ITERATION_ID to score wave layout)." >&2
+    echo "INFO: re-run with --apply to create today's iteration option and proceed." >&2
+    exit 0
+  fi
+
   EXISTING=$(jq -c '.data.user.projectV2.field.configuration.iterations | map({title, startDate, duration})' "$WORKDIR/iter-config.json")
   NEW_TITLE="Iteration $(jq 'length + 1' <<<"$EXISTING")"  # 命名仅展示用，实际唯一 ID 由 GitHub 生成
   ALL_ITERS=$(jq -c --arg title "$NEW_TITLE" --arg d "$DATE" \
@@ -280,22 +299,77 @@ Agent(
 ## 阶段 4：Apply 分支（仅 `--apply`）
 
 ```bash
-[[ "$APPLY" != "true" ]] && {
+[[ "${APPLY:-}" != "true" ]] && {
   echo "INFO: dry-run 模式，跳过 Project v2 写入。加 --apply 真写。" >&2
   exit 0
 }
 
-# 4.1 plan.json schema 校验
+# 4.1 plan.json 校验。两层 gate：
+#   (a) schema：类型 + action 取值集
+#   (b) membership：item_id ∈ items.json；target_iteration_id == TODAY_ITERATION_ID；
+#       current_iteration_id（若非空）∈ iter-config.json 的 iteration IDs
+# 校验失败 fail-closed：plan.json 是 agent (LLM) 生成的，必须当作未经信任的输入对待，
+# 防止"未在候选集中的 item / 非 TODAY 的 target iteration / 未知 action"被直接写真值。
 jq -e '
   (type == "array") and
-  all(.[]; (.item_id | type == "string") and (.target_iteration_id | type == "string") and (.action | type == "string"))
+  all(.[];
+    (.item_id | type == "string") and
+    (.target_iteration_id | type == "string") and
+    (.action | type == "string") and
+    (.action == "set" or .action == "skip")
+  )
 ' "$WORKDIR/plan.json" > /dev/null || {
-  echo "ERROR: plan.json schema invalid" >&2
+  echo "ERROR: plan.json schema invalid (type / action enum)" >&2
   exit 1
 }
 
-# 4.2 逐项写入（agent 已用 action="skip" 标注幂等项）
-APPLIED=0; SKIPPED=0; FAILED_ITEMS=()
+# 候选 item_id 集 (Project v2 已有 items)；候选 iteration_id 集 (field configuration)
+jq -r '.[].id' "$WORKDIR/items.json" | sort -u > "$WORKDIR/valid-item-ids.txt"
+jq -r '.data.user.projectV2.field.configuration.iterations[].id' \
+  "$WORKDIR/iter-config.json" | sort -u > "$WORKDIR/valid-iter-ids.txt"
+# 2.2 新建的 today iteration 也合法；merge 进去。
+echo "$TODAY_ITERATION_ID" >> "$WORKDIR/valid-iter-ids.txt"
+sort -u "$WORKDIR/valid-iter-ids.txt" -o "$WORKDIR/valid-iter-ids.txt"
+
+VIOLATIONS=0
+while read -r row; do
+  item_id=$(jq -r '.item_id' <<<"$row")
+  tgt=$(jq -r '.target_iteration_id' <<<"$row")
+  cur=$(jq -r '.current_iteration_id // ""' <<<"$row")
+
+  if ! grep -qxF "$item_id" "$WORKDIR/valid-item-ids.txt"; then
+    echo "ERROR: plan.json item_id not in Project v2 items: $item_id" >&2
+    VIOLATIONS=$((VIOLATIONS+1))
+  fi
+  if [[ "$tgt" != "$TODAY_ITERATION_ID" ]]; then
+    echo "ERROR: plan.json target_iteration_id != TODAY_ITERATION_ID ($tgt vs $TODAY_ITERATION_ID) for item $item_id" >&2
+    VIOLATIONS=$((VIOLATIONS+1))
+  fi
+  if [[ -n "$cur" ]] && ! grep -qxF "$cur" "$WORKDIR/valid-iter-ids.txt"; then
+    echo "ERROR: plan.json current_iteration_id unknown: $cur (item $item_id)" >&2
+    VIOLATIONS=$((VIOLATIONS+1))
+  fi
+done < <(jq -c '.[]' "$WORKDIR/plan.json")
+[[ $VIOLATIONS -gt 0 ]] && {
+  echo "ERROR: $VIOLATIONS plan.json membership violation(s); refusing to apply" >&2
+  exit 1
+}
+
+# 4.2 逐项写入（agent 已用 action="skip" 标注幂等项）。
+# APPLIED_ITEMS 跟踪"实际写入成功"的项（item_id|prev_iter|new_iter），供 4.3 回滚清单使用——
+# partial apply 失败时，操作员真正需要回滚的是**已经写入**的项，而不是失败项（失败项未写）。
+# 同步把每条 action 落地为 NDJSON 一行（4.4 持久化 per-item audit），用于失败追溯
+# / 还原 old iteration / 重放 ——单行聚合 audit 信息不足以重建上下文。
+APPLIED=0; SKIPPED=0; APPLIED_ITEMS=(); FAILED_ITEMS=()
+AUDIT_NDJSON="$WORKDIR/audit.ndjson"
+: > "$AUDIT_NDJSON"
+audit_entry() {
+  # $1=action $2=item_id $3=prev_iter $4=target_iter $5=result
+  printf '{"ts":"%s","date":"%s","mode":"%s","action":"%s","item_id":"%s","prev_iteration_id":"%s","target_iteration_id":"%s","result":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$DATE" "$([[ "$IS_WEEKEND" == "true" ]] && echo weekend || echo weekday)" \
+    "$1" "$2" "$3" "$4" "$5" >> "$AUDIT_NDJSON"
+}
+
 while read -r row; do
   action=$(jq -r '.action' <<<"$row")
   item_id=$(jq -r '.item_id' <<<"$row")
@@ -304,6 +378,7 @@ while read -r row; do
 
   if [[ "$action" == "skip" ]]; then
     SKIPPED=$((SKIPPED+1))
+    audit_entry "$action" "$item_id" "$cur" "$tgt" "skipped"
     continue
   fi
 
@@ -311,30 +386,45 @@ while read -r row; do
        --project-id "$PROJECT_NODE_ID" --id "$item_id" \
        --field-id "$ITERATION_FIELD_ID" --iteration-id "$tgt" >/dev/null; then
     APPLIED=$((APPLIED+1))
+    APPLIED_ITEMS+=("$item_id|$cur|$tgt")
+    audit_entry "$action" "$item_id" "$cur" "$tgt" "applied"
   else
     FAILED_ITEMS+=("$item_id|$cur|$tgt")
+    audit_entry "$action" "$item_id" "$cur" "$tgt" "failed"
   fi
 done < <(jq -c '.[]' "$WORKDIR/plan.json")
 
-# 4.3 生成回滚命令清单（实际值展开，避免占位符被 shell 误解析为重定向）
+# 4.3 生成回滚命令清单（实际值展开，避免占位符被 shell 误解析为重定向）。
+# 范围 = APPLIED_ITEMS（partial apply 失败时已写入的项），不是 FAILED_ITEMS。
+# 失败项未写入 Project v2，不需要回滚；失败项另列在 retry section 供操作员决策重试。
 if [[ ${#FAILED_ITEMS[@]} -gt 0 ]]; then
   echo "" >&2
-  echo "# --- rollback commands (REVIEW EACH BEFORE EXEC; cur_iter==\"\" 表示失败项原本无 iteration) ---" >&2
+  echo "# --- partial apply detected: ${#APPLIED_ITEMS[@]} applied / ${#FAILED_ITEMS[@]} failed ---" >&2
+  if [[ ${#APPLIED_ITEMS[@]} -gt 0 ]]; then
+    echo "# --- rollback commands for ALREADY-APPLIED items (REVIEW EACH BEFORE EXEC; prev_iter==\"\" 表示原本无 iteration) ---" >&2
+    for entry in "${APPLIED_ITEMS[@]}"; do
+      IFS='|' read -r a_item a_prev _ <<<"$entry"
+      if [[ -z "$a_prev" ]]; then
+        echo "# $a_item: original had no iteration; rollback = clear field value via UI (gh project item-edit lacks --clear-iteration)" >&2
+      else
+        echo "gh project item-edit --project-id $PROJECT_NODE_ID --id $a_item --field-id $ITERATION_FIELD_ID --iteration-id $a_prev" >&2
+      fi
+    done
+    echo "# --- end rollback ---" >&2
+  fi
+  echo "# --- failed items (NOT written; safe to retry) ---" >&2
   for entry in "${FAILED_ITEMS[@]}"; do
-    IFS='|' read -r f_item f_cur _ <<<"$entry"
-    if [[ -z "$f_cur" ]]; then
-      echo "# $f_item: original had no iteration; rollback = clear field value (use gh project item-edit --clear iteration in UI)" >&2
-    else
-      echo "gh project item-edit --project-id $PROJECT_NODE_ID --id $f_item --field-id $ITERATION_FIELD_ID --iteration-id $f_cur" >&2
-    fi
+    IFS='|' read -r f_item _ f_tgt <<<"$entry"
+    echo "gh project item-edit --project-id $PROJECT_NODE_ID --id $f_item --field-id $ITERATION_FIELD_ID --iteration-id $f_tgt" >&2
   done
-  echo "# --- end rollback ---" >&2
+  echo "# --- end failed ---" >&2
 fi
 
-# 4.4 Audit 行
+# 4.4 Audit：聚合行 + per-item NDJSON 路径
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 MODE_STR=$([[ "$IS_WEEKEND" == "true" ]] && echo weekend || echo weekday)
 echo "[audit] $TS date=$DATE mode=$MODE_STR wave_count=$WAVE_COUNT applied=$APPLIED skipped=$SKIPPED failed=${#FAILED_ITEMS[@]}" >&2
+echo "[audit] per-item NDJSON: $AUDIT_NDJSON (one line per plan row with prev/target iteration + result)" >&2
 ```
 
 ## 阶段 5：报告
@@ -343,17 +433,19 @@ echo "[audit] $TS date=$DATE mode=$MODE_STR wave_count=$WAVE_COUNT applied=$APPL
 
 1. **Brief**（阶段 3 agent stdout 全文，含 Wave N 章节）
 2. **Audit 行**（仅 apply 模式，由 4.4 写到 stderr）
-3. **失败回滚命令清单**（仅 apply 模式有失败项时，由 4.3 写到 stderr，已是真实可执行命令）
-4. **WORKDIR 清理提示**：`rm -rf $WORKDIR`（保留供 apply 失败后追溯；用户审查后手动清）
+3. **Per-item NDJSON 路径**（仅 apply 模式，由 4.4 写到 stderr：`$WORKDIR/audit.ndjson`）——每行含 ts/date/mode/action/item_id/prev_iteration_id/target_iteration_id/result，是 partial apply / 还原 old iteration / 重放的真值源
+4. **失败回滚命令清单**（仅 apply 模式有失败项时，由 4.3 写到 stderr，已是真实可执行命令；回滚目标是**已写入**的项，不是失败项）
+5. **WORKDIR 清理提示**：`rm -rf $WORKDIR`（保留供 apply 失败后追溯 + per-item audit；用户审查后手动清）
 
 ## 约束
 
 - 所有 `gh` 命令 `dangerouslyDisableSandbox: true`
-- **默认 dry-run；`--apply` 必须显式 opt-in**
+- **默认 dry-run；`--apply` 必须显式 opt-in**——所有 Project v2 mutation（含 `updateProjectV2Field` field-configuration append、`gh project item-edit` field-value 写入）必须在 `APPLY=true` 分支内；dry-run 路径零 mutation
 - 只写 Project v2 Iteration field value + Iteration field configuration（append-only 追加 daily option）；**不动 Status / Estimate / labels / issue body / comment / title**
 - 不创建 / 修改 / 关闭 issue
 - 不修改代码、不跑 build/test
-- Apply 失败不自动回滚（输出回滚命令清单交人决策）
-- **不在本地长期落盘**：brief = stdout，plan.json = `$WORKDIR/` mktemp 临时
+- **Plan.json 来自 agent (LLM) → 当作未经信任的输入**：apply 前两层 gate（schema + membership：item_id ∈ Project items、target == TODAY_ITERATION_ID、action ∈ {set, skip}），任一违规整体 fail-closed
+- Apply 失败不自动回滚（输出回滚命令清单交人决策）；**回滚目标 = 已写入项**（partial apply 残留），失败项另列在 retry section
+- **不在本地长期落盘**：brief = stdout，plan.json / audit.ndjson = `$WORKDIR/` mktemp 临时；per-item NDJSON 提供 partial apply / 还原 / 重放所需的真值
 - 字段 ID 每次启动从 `gh` 查询，不硬编（避免 Project v2 迁移后双源漂移）
 - token 无 `project` scope → fail-fast 退出（无云沙箱降级）

--- a/.claude/skills/daily-planner/SKILL.md
+++ b/.claude/skills/daily-planner/SKILL.md
@@ -1,87 +1,140 @@
 ---
 name: daily-planner
-description: "每日迭代调度（默认 dry-run；--apply 才写入 Project v2 Iteration 字段）。触发：'今日计划' / 'daily plan' / 'standup' / '排今天的活' / 'iteration 排期'。"
-argument-hint: "[--apply] [--date=YYYY-MM-DD] [--capacity=N]"
+description: "每日 backlog → Project v2 Iteration 调度（wave 模型 + carry-over + 周末自动识别）。默认 dry-run；--apply 才写入。仅用户显式 /daily-planner 触发，避免 AI 主动调用对真实 Project v2 写入。"
+argument-hint: "[--apply] [--date=YYYY-MM-DD] [--capacity=N] [--weekend|--weekday] [--include-p2] [--include-p3]"
 allowed-tools: [Bash, Read, Write, Agent]
+disable-model-invocation: true
 ---
 
 # Daily Planner Skill
 
-调度 backlog → 当日 Project v2 Iteration。**默认 dry-run**（只输出 brief 到对话窗），`--apply` 才真写入。Backlog 真值源见 `docs/backlog.md`。
+调度 backlog → 当日 Project v2 Iteration（每日 1-day option）。**默认 dry-run**；`--apply` 才真写入。Backlog 真值源见 `docs/backlog.md`。
 
 ## 设计原则
 
-- **Project v2 是唯一真值源**：本 skill 不在本地长期归档 brief / audit log。当日排期写入 Project v2 Iteration 字段（每天一个 1-day iteration），brief markdown 直接显示在对话窗，运维与历史回溯走 Project v2 UI + `git log`。
-- **临时中间产物落 `/tmp/`**：仅当次 run 用，run 完丢弃；非持久化。
-- **字段 ID 动态查询**：skill 启动时用 `gh` 拉取真实 ID 注入 agent prompt，不维护硬编常量副本。
+- **Project v2 是真值源**：当日排期写入 Iteration field value；不在本地长期归档 brief / audit log
+- **默认输入集 = P0 + P1**：单人项目 P3 大头不参与每日排期；`--include-p2` / `--include-p3` 可扩
+- **Wave 模型**：工作日 2 wave × 5 issue / 周末 4 wave × 5 issue；wave_count × 5 是硬上限，∑Cx ≤ capacity 是软警告
+- **Carry-over 硬规则**：昨日 iteration 内 issue.state≠CLOSED 且 Status≠Done 的项**优先占 Wave 1 头部**
+- **字段 ID 动态查询**：每次启动从 `gh` 拉真实 ID，不维护硬编副本
 
 ## 参数
 
 | Flag | 默认 | 含义 |
 |------|------|------|
-| `--apply` | off | 写入 Project v2 Iteration 字段；未传则纯 dry-run |
-| `--date=YYYY-MM-DD` | today（系统 TZ）| 目标排期日期 |
-| `--capacity=N` | 4 | 当日 ∑Cx 上限（Cx1=1/Cx2=2/Cx3=3/Cx4=4）|
+| `--apply` | off | 写入 Project v2 Iteration 字段（含 carry-over move）；未传则纯 dry-run |
+| `--date=YYYY-MM-DD` | today | 目标排期日期 |
+| `--capacity=N` | 30 工作日 / 60 周末 | ∑Cx 软警告阈值（Cx1=1/Cx2=2/Cx3=3/Cx4=4） |
+| `--weekend` / `--weekday` | 自动 `date +%u` | 强制模式覆盖 |
+| `--include-p2` | off | 加入 P2 issue 作输入 |
+| `--include-p3` | off | 加入 P3 issue（极少需要；P3 默认 nice-to-have） |
 
 ---
 
-## 阶段 0：常量动态查询 + Token scope check
+## 阶段 0：常量动态查询 + token scope fail-fast + 模式探测
 
 ```bash
-# 0.1 Token scope 检测（用宽松正则，跨 gh 版本健壮）
-if gh auth status 2>&1 | grep -qiE "scopes:.*\bproject\b"; then
-  HAS_PROJECT=true
+# 0.1 Token scope（无 project scope → 直接退出；删除原降级模式）
+if ! gh auth status 2>&1 | grep -qiE "scopes:.*\bproject\b"; then
+  echo "ERROR: token missing 'project' scope; run: gh auth refresh -s project" >&2
+  exit 1
+fi
+
+# 0.2 Project node + Iteration field ID
+PROJECT_NODE_ID=$(gh project view 3 --owner ghbvf --format json | jq -r '.id')
+ITERATION_FIELD_ID=$(gh project field-list 3 --owner ghbvf --format json \
+  | jq -r '.fields[] | select(.name=="Iteration").id')
+[[ -z "$PROJECT_NODE_ID" || -z "$ITERATION_FIELD_ID" ]] && {
+  echo "ERROR: failed to resolve PROJECT_NODE_ID or ITERATION_FIELD_ID" >&2
+  exit 1
+}
+
+# 0.3 日期 + 模式（weekday/weekend）。用 python3 跨 macOS BSD / Linux GNU date 兼容
+DATE="${DATE:-$(date +%Y-%m-%d)}"
+DOW=$(python3 -c "from datetime import date; print(date.fromisoformat('$DATE').isoweekday())")
+# 自动判定，flag 覆盖
+if [[ "$FORCE_WEEKEND" == "true" ]]; then IS_WEEKEND=true
+elif [[ "$FORCE_WEEKDAY" == "true" ]]; then IS_WEEKEND=false
+elif [[ "$DOW" -ge 6 ]]; then IS_WEEKEND=true
+else IS_WEEKEND=false
+fi
+
+if [[ "$IS_WEEKEND" == "true" ]]; then
+  WAVE_COUNT=4
+  CAPACITY_DEFAULT=60
 else
-  HAS_PROJECT=false
+  WAVE_COUNT=2
+  CAPACITY_DEFAULT=30
 fi
-
-# 0.2 Project node + Iteration field ID（每次启动查，不硬编）
-if [[ $HAS_PROJECT == true ]]; then
-  PROJECT_NODE_ID=$(gh project view 3 --owner ghbvf --format json | jq -r '.id')
-  ITERATION_FIELD_ID=$(gh project field-list 3 --owner ghbvf --format json \
-    | jq -r '.fields[] | select(.name=="Iteration").id')
-  [[ -z "$PROJECT_NODE_ID" || -z "$ITERATION_FIELD_ID" ]] && {
-    echo "ERROR: failed to resolve PROJECT_NODE_ID or ITERATION_FIELD_ID" >&2
-    exit 1
-  }
-fi
+CAPACITY="${CAPACITY:-$CAPACITY_DEFAULT}"
+WAVE_SIZE=5  # 固定，Miller's Law
+ISSUE_CAP=$(( WAVE_COUNT * WAVE_SIZE ))
 ```
-
-| 状态 | 模式 |
-|------|------|
-| `HAS_PROJECT=true` + `--apply` | 完整模式：读 + 写 |
-| `HAS_PROJECT=true` + dry-run | 完整模式但不写 |
-| `HAS_PROJECT=false` + `--apply` | **报错退出**，提示 `gh auth refresh -s project` |
-| `HAS_PROJECT=false` + dry-run | 降级"只读 brief"模式：跳过所有 `gh project` 命令，仅基于 `gh issue list` label 维度排序 |
-
-云沙箱 token 默认无 `project` scope（详见 `docs/backlog.md` §云沙箱查询），降级模式必须可用。
 
 ## 阶段 1：拉取数据
 
 ```bash
 WORKDIR="$(mktemp -d -t daily-planner.XXXXXX)"
-chmod 700 "$WORKDIR"          # 限制其他用户可读（issue body 可能含未脱敏字段）
-DATE="${DATE:-$(date +%Y-%m-%d)}"
-CAPACITY="${CAPACITY:-4}"
+chmod 700 "$WORKDIR"
 
-# 1.1 Backlog 池
-gh issue list --repo ghbvf/gocell --label backlog --state open \
-  --json number,title,labels,createdAt,body,url --limit 300 \
-  > "$WORKDIR/issues.json"
+# 1.1 输入集：P0 + P1 (默认) + 可选 P2/P3
+PRI_TERMS='label:pri-p0,label:pri-p1'
+[[ "$INCLUDE_P2" == "true" ]] && PRI_TERMS="$PRI_TERMS,label:pri-p2"
+[[ "$INCLUDE_P3" == "true" ]] && PRI_TERMS="$PRI_TERMS,label:pri-p3"
 
-# 1.2 Project v2 items（仅完整模式）
-if [[ $HAS_PROJECT == true ]]; then
-  gh project item-list 3 --owner ghbvf --format json --limit 300 \
-    > "$WORKDIR/items.json"
-fi
+# 用多次 gh issue list 联合（GitHub label search 是 AND 语义，需逐 label 拉再合并）
+echo "[]" > "$WORKDIR/issues.json"
+for term in ${PRI_TERMS//,/ }; do
+  pri_label="${term#label:}"
+  gh issue list --repo ghbvf/gocell --label backlog --label "$pri_label" \
+    --state open --json number,title,labels,createdAt,body,url --limit 200 \
+    > "$WORKDIR/issues-$pri_label.json"
+  jq -s '.[0] + .[1]' "$WORKDIR/issues.json" "$WORKDIR/issues-$pri_label.json" \
+    > "$WORKDIR/issues.tmp" && mv "$WORKDIR/issues.tmp" "$WORKDIR/issues.json"
+done
+echo "INFO: input set = $(jq 'length' "$WORKDIR/issues.json") issues (priority labels: $PRI_TERMS)"
 
-# 1.3 Sub-issue 关系（GraphQL 原生 + body grep 双源回落）
+# 1.2 Project v2 items（用 GraphQL paginated，因为 gh project item-list 不返回 iteration value 和 issue.state）
+# 输出 NDJSON 多页，jq -s 合并所有页的 nodes
+gh api graphql --paginate -f query='
+query($endCursor: String) {
+  user(login:"ghbvf"){ projectV2(number:3){
+    items(first:100, after:$endCursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        content { ... on Issue { number state title } }
+        iter: fieldValueByName(name:"Iteration") {
+          ... on ProjectV2ItemFieldIterationValue { iterationId title startDate }
+        }
+        status: fieldValueByName(name:"Status") {
+          ... on ProjectV2ItemFieldSingleSelectValue { name }
+        }
+        estimate: fieldValueByName(name:"Estimate") {
+          ... on ProjectV2ItemFieldSingleSelectValue { name }
+        }
+      }
+    }
+  }}
+}' | jq -s '[.[].data.user.projectV2.items.nodes[]]' > "$WORKDIR/items.json"
+echo "INFO: $(jq 'length' "$WORKDIR/items.json") Project v2 items loaded"
+
+# 1.3 Iteration 配置（拿当前所有 iteration option）
+gh api graphql -f query='query {
+  user(login:"ghbvf"){ projectV2(number:3){
+    field(name:"Iteration"){ ... on ProjectV2IterationField {
+      configuration { duration startDay iterations { id title startDate duration } }
+    }}
+  }}
+}' > "$WORKDIR/iter-config.json"
+
+# 1.4 Sub-issue 关系（GraphQL 原生）
 gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
   repository(owner:"ghbvf",name:"gocell"){
-    issues(first:100, labels:["bundle-parent","backlog"], states:OPEN){
+    issues(first:100, labels:["bundle-parent"], states:OPEN){
       nodes {
-        number title
-        subIssuesSummary { total completed }
+        number title state
+        subIssuesSummary { total completed percentCompleted }
         subIssues(first:50){ nodes { number title state } }
       }
     }
@@ -89,69 +142,60 @@ gh api graphql -H "GraphQL-Features: sub_issues" -f query='query {
 }' > "$WORKDIR/sub-issues.json" 2>/dev/null || echo '{}' > "$WORKDIR/sub-issues.json"
 ```
 
-## 阶段 2：确保 today iteration 存在（仅完整模式）
-
-GoCell Project v2 已配 Iteration 为 1-day duration（详见 `docs/backlog.md` §Daily planning）。skill 检测目标日期是否落在已有 iteration option 上；若无则用 GraphQL 追加一个 1-day iteration 覆盖目标日期，agent 始终拿到有效 `TODAY_ITERATION_ID`。
+## 阶段 2：确保 today iteration 存在
 
 ```bash
-if [[ $HAS_PROJECT == true ]]; then
-  # 2.1 拉当前 iteration 配置
-  gh api graphql -f query='query {
-    user(login:"ghbvf"){ projectV2(number:3){
-      field(name:"Iteration"){ ... on ProjectV2IterationField {
-        configuration { duration startDay iterations { id title startDate duration } }
-      }}
-    }}
-  }' > "$WORKDIR/iter-config.json"
+# 2.1 推断 $DATE 对应的 iteration option（注意 pipe 后 root context 丢失，用 `as $it` 绑定保留）
+TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
+  .data.user.projectV2.field.configuration.iterations[]
+  | . as $it
+  | select($it.startDate <= $d
+           and ($d < ((($it.startDate | strptime("%Y-%m-%d") | mktime) + ($it.duration * 86400))
+                       | strftime("%Y-%m-%d")))).id
+' "$WORKDIR/iter-config.json")
 
-  # 2.2 推断目标日期 iteration（注意 pipe 后 root context 丢失，用 `as $it` 绑定保留访问）
+# 2.2 缺失则用 GraphQL mutation append 一个 1-day iteration option 覆盖 $DATE
+if [[ -z "$TODAY_ITERATION_ID" ]]; then
+  EXISTING=$(jq -c '.data.user.projectV2.field.configuration.iterations | map({title, startDate, duration})' "$WORKDIR/iter-config.json")
+  NEW_TITLE="Iteration $(jq 'length + 1' <<<"$EXISTING")"
+  ALL_ITERS=$(jq -c --arg title "$NEW_TITLE" --arg d "$DATE" \
+               '. + [{title: $title, startDate: $d, duration: 1}]' <<<"$EXISTING")
+
+  # 类型名 ProjectV2Iteration 是 INPUT_OBJECT（GraphQL 2026-05-24 introspection 实测）
+  gh api graphql -f query='
+    mutation($fid: ID!, $start: Date!, $dur: Int!, $iters: [ProjectV2Iteration!]!) {
+      updateProjectV2Field(input: {
+        fieldId: $fid,
+        iterationConfiguration: { startDate: $start, duration: $dur, iterations: $iters }
+      }) { projectV2Field { ... on ProjectV2IterationField {
+        configuration { iterations { id title startDate duration } }
+      }}}
+    }' \
+    -f fid="$ITERATION_FIELD_ID" \
+    -f start="$(jq -r '.[0].startDate' <<<"$ALL_ITERS")" \
+    -F dur="$(jq -r '.[0].duration' <<<"$ALL_ITERS")" \
+    -f iters="$ALL_ITERS" \
+    > "$WORKDIR/iter-config-after.json"
+
   TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
-    .data.user.projectV2.field.configuration.iterations[]
-    | . as $it
-    | select($it.startDate <= $d
-             and ($d < ((($it.startDate | strptime("%Y-%m-%d") | mktime) + ($it.duration * 86400))
-                         | strftime("%Y-%m-%d")))).id
-  ' "$WORKDIR/iter-config.json")
-
-  # 2.3 缺失则新建（appendOnly：保留所有现有 iteration，追加一个 1-day 覆盖 $DATE）
-  if [[ -z "$TODAY_ITERATION_ID" ]]; then
-    NEW_TITLE="Iteration $(jq '.data.user.projectV2.field.configuration.iterations | length + 1' "$WORKDIR/iter-config.json")"
-    EXISTING=$(jq -c '.data.user.projectV2.field.configuration.iterations
-                       | map({title, startDate, duration})' "$WORKDIR/iter-config.json")
-    ALL_ITERS=$(jq -c --arg title "$NEW_TITLE" --arg d "$DATE" \
-                 '. + [{title: $title, startDate: $d, duration: 1}]' <<<"$EXISTING")
-
-    # 类型名 `ProjectV2Iteration` 是 INPUT_OBJECT（GraphQL 2026-05-24 introspection 实测，
-    # 非 ProjectV2IterationInput）；字段集见 ProjectV2IterationFieldConfigurationInput
-    gh api graphql -f query='
-      mutation($fid: ID!, $start: Date!, $dur: Int!, $iters: [ProjectV2Iteration!]!) {
-        updateProjectV2Field(input: {
-          fieldId: $fid,
-          iterationConfiguration: {
-            startDate: $start, duration: $dur, iterations: $iters
-          }
-        }) { projectV2Field { ... on ProjectV2IterationField {
-          configuration { iterations { id title startDate duration } }
-        }}}
-      }' \
-      -f fid="$ITERATION_FIELD_ID" \
-      -f start="$(jq -r '.[0].startDate' <<<"$ALL_ITERS")" \
-      -F dur="$(jq -r '.[0].duration' <<<"$ALL_ITERS")" \
-      -f iters="$ALL_ITERS" \
-      > "$WORKDIR/iter-config-after.json"
-
-    TODAY_ITERATION_ID=$(jq -r --arg d "$DATE" '
-      .data.updateProjectV2Field.projectV2Field.configuration.iterations[]
-      | . as $it | select($it.startDate == $d).id
-    ' "$WORKDIR/iter-config-after.json")
-
-    [[ -z "$TODAY_ITERATION_ID" ]] && {
-      echo "ERROR: failed to create iteration for $DATE; check rate limit + field permissions" >&2
-      exit 1
-    }
-    echo "INFO: created new daily iteration for $DATE -> $TODAY_ITERATION_ID" >&2
-  fi
+    .data.updateProjectV2Field.projectV2Field.configuration.iterations[]
+    | . as $it | select($it.startDate == $d).id
+  ' "$WORKDIR/iter-config-after.json")
+  [[ -z "$TODAY_ITERATION_ID" ]] && {
+    echo "ERROR: failed to create iteration for $DATE" >&2
+    exit 1
+  }
+  echo "INFO: created new daily iteration for $DATE -> $TODAY_ITERATION_ID" >&2
 fi
+
+# 2.3 推断昨日 iteration ID（carry-over 源）
+YESTERDAY=$(python3 -c "from datetime import date,timedelta; print(date.fromisoformat('$DATE') - timedelta(days=1))")
+YESTERDAY_ITERATION_ID=$(jq -r --arg d "$YESTERDAY" '
+  .data.user.projectV2.field.configuration.iterations[]
+  | . as $it
+  | select($it.startDate == $d).id
+' "$WORKDIR/iter-config.json")
+[[ -z "$YESTERDAY_ITERATION_ID" ]] && echo "WARN: yesterday iteration not found ($YESTERDAY); carry-over disabled" >&2
 ```
 
 ## 阶段 3：派发 daily-planner agent 评分排序
@@ -160,70 +204,77 @@ fi
 PLAN_PATH="$WORKDIR/plan.json"
 
 Agent(
-  description: "Score backlog and emit daily brief",
+  description: "Score backlog + carry-over + wave grouping",
   subagent_type: "daily-planner",
   prompt: f"""
-    Constants (injected by skill):
+    Constants:
       PROJECT_NODE_ID = {PROJECT_NODE_ID}
       ITERATION_FIELD_ID = {ITERATION_FIELD_ID}
       TODAY_ITERATION_ID = {TODAY_ITERATION_ID}
-      DATE = {DATE}
-      CAPACITY = {CAPACITY}
-      HAS_PROJECT = {HAS_PROJECT}
+      YESTERDAY_ITERATION_ID = {YESTERDAY_ITERATION_ID}  # 可能空（首日 / 假期跳过后）
+      DATE = {DATE}                                       # YYYY-MM-DD
+      IS_WEEKEND = {IS_WEEKEND}                           # true|false
+      WAVE_COUNT = {WAVE_COUNT}                           # 2|4
+      WAVE_SIZE = 5
+      ISSUE_CAP = {ISSUE_CAP}                             # WAVE_COUNT * 5
+      CAPACITY = {CAPACITY}                               # ∑Cx 软警告阈值
       MODE = {"apply" if APPLY else "dry-run"}
 
-    Data files (Read these directly):
-      {WORKDIR}/issues.json        — backlog gh issue list output
-      {WORKDIR}/items.json         — Project v2 items (only if HAS_PROJECT)
-      {WORKDIR}/iter-config.json   — Iteration field configuration
-      {WORKDIR}/sub-issues.json    — GraphQL sub-issue relations
+    Data files (Read these):
+      {WORKDIR}/issues.json        — backlog 池 (P0/P1 默认；P2/P3 视 flag)
+      {WORKDIR}/items.json         — Project v2 items（含 iteration / status / state）
+      {WORKDIR}/iter-config.json   — Iteration 配置
+      {WORKDIR}/sub-issues.json    — sub-issue 关系（GraphQL 原生）
 
     Tasks:
       1. Read all 4 files
-      2. Score & sort per WSJF 简化版 (see your agent.md §排序算法)
-      3. Apply capacity filter ∑Cx <= CAPACITY
-      4. Emit brief markdown to STDOUT (use the §输出 章节 fixed format)
-      5. Write plan.json to {PLAN_PATH} (see schema in your agent.md §输出 #2)
-      6. dry-run mode: write plan.json but with all action="dry-run" (skill skips阶段 4)
+      2. Compute carry-over: items.json 中 iteration == YESTERDAY_ITERATION_ID 且
+         (issue.state == "OPEN") AND (status != "Done") 的 issue → 加入 carry-over 列表
+      3. Score P0/P1 池 per WSJF 简化版（详 agent.md §排序算法）
+      4. Wave 调度：
+         - Wave 1 头部填 carry-over（按原 WSJF score 排序）
+         - 剩余 Wave 1 / Wave 2+ 填 新 issue 按分数降序
+         - 硬约束: 总 issue 数 ≤ ISSUE_CAP
+         - 软约束: ∑Cx 超 CAPACITY 时在 Warnings 标注，不阻塞
+      5. Emit brief markdown to STDOUT（详 agent.md §输出格式）
+      6. Write plan.json to {PLAN_PATH}（详 agent.md §输出 #2）
   """
 )
 ```
 
-> 主 LLM 派发此 Agent 后会拿到 agent 的 stdout（brief markdown）+ plan.json 已落盘。brief 直接复述给用户在对话窗显示。
-
-## 阶段 4：Apply 分支（仅 `--apply` + `HAS_PROJECT=true`）
+## 阶段 4：Apply 分支（仅 `--apply`）
 
 ```bash
-# 4.1 plan.json schema 校验（防 agent 漂移字段名）
+[[ "$APPLY" != "true" ]] && {
+  echo "INFO: dry-run 模式，跳过 Project v2 写入。加 --apply 真写。" >&2
+  exit 0
+}
+
+# 4.1 plan.json schema 校验
 jq -e '
   (type == "array") and
   all(.[]; (.item_id | type == "string") and (.target_iteration_id | type == "string") and (.action | type == "string"))
 ' "$WORKDIR/plan.json" > /dev/null || {
-  echo "ERROR: plan.json schema invalid (expect [{item_id,target_iteration_id,action,...}])" >&2
+  echo "ERROR: plan.json schema invalid" >&2
   exit 1
 }
 
 # 4.2 逐项写入（agent 已用 action="skip" 标注幂等项）
-APPLIED=0
-SKIPPED=0
-FAILED_ITEMS=()
-
+APPLIED=0; SKIPPED=0; FAILED_ITEMS=()
 while read -r row; do
   action=$(jq -r '.action' <<<"$row")
   item_id=$(jq -r '.item_id' <<<"$row")
   tgt=$(jq -r '.target_iteration_id' <<<"$row")
   cur=$(jq -r '.current_iteration_id // ""' <<<"$row")
 
-  if [[ "$action" == "skip" || "$action" == "dry-run" ]]; then
+  if [[ "$action" == "skip" ]]; then
     SKIPPED=$((SKIPPED+1))
     continue
   fi
 
   if gh project item-edit \
-       --project-id "$PROJECT_NODE_ID" \
-       --id "$item_id" \
-       --field-id "$ITERATION_FIELD_ID" \
-       --iteration-id "$tgt" >/dev/null; then
+       --project-id "$PROJECT_NODE_ID" --id "$item_id" \
+       --field-id "$ITERATION_FIELD_ID" --iteration-id "$tgt" >/dev/null; then
     APPLIED=$((APPLIED+1))
   else
     FAILED_ITEMS+=("$item_id|$cur|$tgt")
@@ -235,24 +286,24 @@ done < <(jq -c '.[]' "$WORKDIR/plan.json")
 
 主 LLM 把以下信息综合到对话回应：
 
-1. **Brief**（阶段 3 agent stdout 全文，固定 H2 章节）
-2. **Apply 摘要**（仅 apply 模式）：
-   - 写入 `$APPLIED` / 跳过 `$SKIPPED` / 失败 `${#FAILED_ITEMS[@]}`
+1. **Brief**（阶段 3 agent stdout 全文，含 Wave N 章节）
+2. **Audit 行**（仅 apply 模式）：`[audit] $(date -u +%FT%TZ) date=$DATE mode=$([[ $IS_WEEKEND == true ]] && echo weekend || echo weekday) wave_count=$WAVE_COUNT capacity=$CAPACITY applied=$APPLIED skipped=$SKIPPED failed=${#FAILED_ITEMS[@]}`
 3. **失败回滚命令**（仅有失败项时；**逐条审查后再执行**，不要批量复制粘贴）：
    ```
-   # 以下命令仅对失败项有效，请确认对应项确需回滚再逐条执行
+   # 以下命令仅对失败项有效，逐条确认对应项确需回滚再执行
    gh project item-edit --project-id <PID> --id <ITEM> --field-id <FID> --iteration-id <OLD_ITER_ID>
    ...
    ```
-4. **WORKDIR 清理提示**：`rm -rf $WORKDIR`（含 issues.json 等含 body 副本的临时文件）
+4. **WORKDIR 清理提示**：`rm -rf $WORKDIR`
 
 ## 约束
 
 - 所有 `gh` 命令 `dangerouslyDisableSandbox: true`
-- **默认 dry-run**；`--apply` 必须显式 opt-in
-- 只写 Project v2 Iteration 字段 value + Iteration field configuration（追加 daily iteration option，append-only）；**不动 Status / Estimate / labels**
+- **默认 dry-run；`--apply` 必须显式 opt-in**
+- 只写 Project v2 Iteration field value + Iteration field configuration（append-only 追加 daily option）；**不动 Status / Estimate / labels / issue body / comment / title**
 - 不创建 / 修改 / 关闭 issue
 - 不修改代码、不跑 build/test
-- Apply 失败不自动回滚（输出回滚命令清单交人决策，避免二次破坏）
-- **不在本地长期落盘**：brief = stdout，plan.json = `$WORKDIR/`（mktemp，run 完丢弃）
+- Apply 失败不自动回滚（输出回滚命令清单交人决策）
+- **不在本地长期落盘**：brief = stdout，plan.json = `$WORKDIR/` mktemp 临时
 - 字段 ID 每次启动从 `gh` 查询，不硬编（避免 Project v2 迁移后双源漂移）
+- token 无 `project` scope → fail-fast 退出（无云沙箱降级）

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -65,7 +65,7 @@ CLI 路径**不解析** [`.github/ISSUE_TEMPLATE/backlog.yml`](../.github/ISSUE_
 |---|---|---|---|
 | Status | single-select | `Backlog` / `Ready` / `In progress` / `In review` / `Done` | 进度状态（人控，daily-planner 不写）|
 | Estimate | single-select | `Cx1` / `Cx2` / `Cx3` / `Cx4` | context 复杂度，rerating 时改 |
-| Iteration | iteration | 14-day sprint（详见 §"Daily planning"）| sprint planning，daily-planner 写入 |
+| Iteration | iteration | **1-day duration**（详见 §"Daily planning"）| 每日焦点队列，daily-planner 自动新建 + 写入 |
 | Parent issue | built-in | 自动派生（GitHub 原生 sub-issue API）| 大型任务父子关系展示 |
 | Sub-issues progress | built-in | 自动派生（子 issue close 比例）| 父 issue 完成度进度条 |
 
@@ -161,31 +161,34 @@ Project UI 仍可作为筛选/排序入口（按 label group），但写入面�
 
 backlog 池 → 每日工作焦点调度由 `/daily-planner` skill + `daily-planner` agent 承载。详见 `.claude/agents/daily-planner.md` 与 `.claude/skills/daily-planner/SKILL.md`。
 
+**真值源**：Project v2 Iteration 字段（每个 1-day option = 一天的焦点队列）+ 对话窗 brief markdown 输出。**不在本地长期归档**任何 daily brief 或 audit log。
+
 ### 用法
 
 ```bash
-# dry-run（默认）：输出 brief，不写 Project v2
+# dry-run（默认）：在对话窗输出 brief，不写 Project v2
 /daily-planner
 
-# apply：把当日选中 issue 写入 current sprint Iteration
+# apply：把当日选中 issue 写入 today iteration
 /daily-planner --apply
 
-# 指定日期（按 sprint 推断目标 iteration）
+# 指定日期（按 1-day iteration 推断目标 option，缺失则自动新建）
 /daily-planner --date=2026-05-25
 /daily-planner --apply --date=2026-05-25
+
+# 当日 ∑Cx 容量覆盖（默认 4）
+/daily-planner --apply --capacity=6
 ```
 
-输出：
-- Brief markdown 落盘 `~/.local/share/gocell-daily/YYYY-MM-DD.md`
-- Apply 模式额外写 audit log 到 `.claude/logs/daily-planner-YYYYMMDD.jsonl`（已被 .gitignore）
+### Daily Iteration 自动管理
 
-### Sprint vs Daily 语义
+Project v2 的 Iteration 字段配置为 **1-day duration**（duration=1, startDay=1，每个 option 覆盖 1 天）。daily-planner 自动管理 iteration option 集合：
 
-GitHub Project v2 的 Iteration 字段是 **14-day sprint**（不是 1 天）。daily-planner 写入语义：
+- 启动时检查 `$DATE` 是否落在已有 iteration option 上
+- 缺失则用 GraphQL `updateProjectV2Field.iterationConfiguration`（append-only）追加一个 1-day iteration option 覆盖 `$DATE`
+- 历史 iteration option 保留不动（form audit trail：哪天排了哪些 issue 永远可在 Project UI 回溯）
 
-- **当日 brief 中选中的 issue → 加入 current sprint Iteration**（如果还没加），让 sprint 视图反映"已被纳入近期焦点"
-- **每日焦点队列**只活在本地 brief（按日期分文件归档），不在 Project v2 上为每天单独建 iteration
-- Sprint 切换日（每 14 天）`TARGET_ITERATION_ID` 自动指向新 sprint，无需手工切配置；管理员需提前在 Project v2 UI 加好后续 iteration（当前已配 Iteration 1-5 覆盖至 2026-07-29）
+历史回溯：在 Project v2 UI 按 Iteration group by，每个 1-day iteration 列出当日纳入的 issue。daily brief 的文本本体不持久化（每次 `/daily-planner` 重生成），但 Project v2 的"哪些 issue 在哪天入队"是持久真值。
 
 ### 排序算法（简化 WSJF）
 
@@ -193,24 +196,28 @@ GitHub Project v2 的 Iteration 字段是 **14-day sprint**（不是 1 天）。
 score = pri_weight × flag_multiplier
   pri_weight:        P0=100 / P1=50 / P2=20 / P3=5 / pri-missing=110（强制首位）
   flag_multiplier:   hard=3 / planned=2 / cond(trigger 满足)=1.5 / cond(pending)=0.3 / soft=1
-  容量过滤:          当日 ∑Cx ≤ 4（Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4），超出落 Unscheduled
+  容量过滤:          当日 ∑Cx ≤ CAPACITY（默认 4；Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4），超出落 Unscheduled
+                    可通过 `--capacity=N` 覆盖默认值
 ```
 
-异常处理：`pri-missing` 强制首位 + `[NEEDS PRIORITY]`；缺 cap/flag/type 标 `[MISSING LABEL]`；body 含 `tools/archtest/` 或 `kernel/` 或 `contracts/` 标 `[需人工确认]`；同 cap 已 ≥3 入队 → 后续 `[CAP COLLISION]` 退到 Unscheduled；`bundle-parent` 父 issue 排除（仅处理子 issue）。
+异常处理：`pri-missing` 强制首位 + `[NEEDS PRIORITY]`；缺 cap/flag/type 任一 → `[MISSING LABEL]`；`cap-x-cross` label → `[需人工确认]`（跨域需人评估）；同 cap 已 ≥3 入队 → 后续 `[CAP COLLISION]` 退到 Unscheduled；`bundle-parent` 父 issue 排除（仅处理子 issue）。
 
-### 写入边界（agent 只动 Iteration）
+### 写入边界
 
 | 字段 | daily-planner |
 |------|---------------|
-| Iteration | **可写**（apply 模式）|
-| Status / Estimate / labels（含 pri/cap/flag/type） | 只读 |
+| Iteration field **value**（item 行的 iteration 设置）| **可写**（仅 apply 模式）|
+| Iteration field **configuration**（追加 1-day iteration option）| **可写**（append-only，缺失目标日期 option 时自动追加）|
+| Status / Estimate / labels（含 pri/cap/flag/type）| 只读 |
 | issue body / title / comment | 不动 |
 
-误写 Iteration 影响半径 = 当日 brief 噪音 + 当前 sprint 视图多出一条，**无数据丢失**——可手动在 Project UI 清字段恢复，或 skill 回滚命令清单（apply 失败时输出到 stderr，需人工执行避免二次破坏）。
+误写 Iteration value 影响半径 = 当日 brief 噪音 + Project v2 视图多出一条；apply 失败 skill 输出回滚命令清单（**逐条审查后执行**，不要批量复制粘贴，避免二次破坏）。Iteration configuration 是 append-only，不会删除历史 option，无数据丢失风险。
 
 ### Token scope
 
 | Scope | dry-run | --apply |
 |-------|---------|---------|
 | 仅 `repo`（云沙箱常见）| ✓ 降级"只读 brief"模式（只用 label 维度排序）| ✗ 报错退出，提示 `gh auth refresh -s project` |
-| `repo` + `project`（本地常见）| ✓ 完整模式（读 Project v2 字段，不写）| ✓ 完整模式（写 Iteration）|
+| `repo` + `project`（本地常见）| ✓ 完整模式（读 Project v2 字段，不写）| ✓ 完整模式（写 Iteration value + 必要时追加 option）|
+
+token scope 检测用宽松正则 `grep -qiE "scopes:.*\bproject\b"`，跨 gh 版本健壮（不依赖单引号风格）。

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -197,7 +197,7 @@ daily-planner 默认只把 `label:backlog AND (label:pri-p0 OR label:pri-p1)` �
 
 ### Wave 模型
 
-**容量公式**：`容量 = WAVE_COUNT × WAVE_SIZE`（一任务一容量，不引入 ∑Cx 加权）
+**容量公式**：`容量 = WAVE_COUNT × WAVE_SIZE`
 
 | 模式 | WAVE_COUNT | WAVE_SIZE | 容量 (issue 数) |
 |------|-----------|-----------|----------------|
@@ -206,7 +206,6 @@ daily-planner 默认只把 `label:backlog AND (label:pri-p0 OR label:pri-p1)` �
 
 - **WAVE_SIZE=5** 固定，对齐 Miller's Law 认知槽（5-7 chunk）
 - **超容量的 issue** → Unscheduled，标注 `[capacity overflow]`
-- **Estimate (Cx1-4)** 仅在 brief 表格作参考显示，**不参与容量约束**
 - **周末检测** `date +%u >= 6`（自动）；`--weekend` / `--weekday` flag 显式覆盖
 
 ### Carry-over（昨日未完成 → 今日）
@@ -214,7 +213,6 @@ daily-planner 默认只把 `label:backlog AND (label:pri-p0 OR label:pri-p1)` �
 skill 拉昨日 iteration 的 items；满足 `issue.state == OPEN AND Project Status != Done` 的 issue **优先占 Wave 1 头部**（按原 WSJF score 排序）：
 
 - carry-over > 5 → 顺延 Wave 2 头部（**不退** Unscheduled）
-- 连续 ≥3 天未完成 → Warnings 标 `[STUCK day:N]`（只警告仍 carry，由人决策是否拆分 / 降 priority）
 - 已完成判断用 OR 语义（覆盖手动改 Status=Done 但 issue 未 close 的脱节场景）
 - **不写 audit comment**（保持 agent 对 issue 完全只读；历史回溯靠对话窗 brief + git log + Project v2 activity feed）
 
@@ -232,8 +230,6 @@ score = pri_weight × flag_multiplier
   pri_weight:        P0=100 / P1=50 / P2=20 / P3=5 / pri-missing=110（强制首位）
   flag_multiplier:   hard=3 / planned=2 / cond(trigger 满足)=1.5 / cond(pending)=0.3 / soft=1
 ```
-
-Estimate **不入分数**，作 ∑Cx 软警告基准（Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4）。
 
 异常处理：`pri-missing` 强制首位 + `[NEEDS PRIORITY]`；缺 cap/flag/type 任一 → `[MISSING LABEL]` 不入队；`cap-x-cross` label → `[需人工确认]` 不入队；同 cap 已 ≥3 入队 → 后续 `[CAP COLLISION]` 退 Unscheduled；`bundle-parent` 父 issue（仍 OPEN）→ carry-over（子全 close 不自动闭父，让人手 close）。
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -59,15 +59,23 @@ CLI 路径**不解析** [`.github/ISSUE_TEMPLATE/backlog.yml`](../.github/ISSUE_
 
 > "单选"由 review 把关；GitHub label 不强制 enum。完成态用 issue closure 表达，不编码进 Flag。
 
-## Project v2 字段（仅模板原生）
+## Project v2 字段
 
-| Field | Type | Values |
-|---|---|---|
-| Status | single-select | `Backlog` / `Ready` / `In Progress` / `In Review` / `Done` |
-| Estimate | single-select | `Cx1` / `Cx2` / `Cx3` / `Cx4` |
-| Iteration | iteration | 可选，sprint 用，初期不开 |
+| Field | Type | Values | 用途 |
+|---|---|---|---|
+| Status | single-select | `Backlog` / `Ready` / `In progress` / `In review` / `Done` | 进度状态（人控，daily-planner 不写）|
+| Estimate | single-select | `Cx1` / `Cx2` / `Cx3` / `Cx4` | context 复杂度，rerating 时改 |
+| Iteration | iteration | 14-day sprint（详见 §"Daily planning"）| sprint planning，daily-planner 写入 |
+| Parent issue | built-in | 自动派生（GitHub 原生 sub-issue API）| 大型任务父子关系展示 |
+| Sub-issues progress | built-in | 自动派生（子 issue close 比例）| 父 issue 完成度进度条 |
 
+> Status 字面值是 `In progress` / `In review`（小写 p/r），不是首字母大写——2026-05-24 实测 option name 校准。
+>
 > Priority 原为 Project field，2026-05-22 单源降级为 `pri-pX` label（PR #861，详见 §"云沙箱查询"）。
+>
+> 还有一个老 `Size` 字段（XS/S/M/L/XL）是模板默认，**已被 Estimate (Cx1-4) 替代**，不再使用；保留只为不破坏历史 item，新条目不需要填。
+>
+> Parent issue + Sub-issues progress 是 GitHub 平台内建隐藏字段（2024-12 sub-issue API GA 后启用），**无需手工新增 custom field**——在 Project v2 Table View 右上角 `+` → Hidden fields 即可启用显示。
 
 ## 常用查询
 
@@ -90,15 +98,39 @@ gh issue list --repo ghbvf/gocell --state closed \
 | Flag | `--label flag-XX` | — |
 | Type | `--label type-XX` | — |
 | Priority | `--label pri-pX` | — |
-| Status | — | ✓（含中间态 Ready/In Progress/In Review）|
+| Status | — | ✓（含中间态 Ready/In progress/In review）|
 | Estimate | — | ✓ |
 | Iteration | — | ✓ |
 
 Token scope：日常查询 `repo` 足够；rerating 时如需在 Project UI 批改 Status/Estimate 才需要本地 `project` scope。Priority 自迁移后由 `pri-pX` label 单源承载，Rerating 流程改用 `gh issue edit --add-label --remove-label`（见 §"Rerating"）。
 
-## Bundle / sub-issue
+## Bundle / sub-issue（大型任务拆分与跟踪）
 
-父 issue 贴 `bundle-parent` label，body 用 GitHub 原生 sub-issue task list：
+大型任务（Cx3/Cx4 或跨 ≥2 capability）拆子 issue 处理。两种承载形态：
+
+### 形态 A：GitHub 原生 sub-issue（**推荐**，2024-12 GA）
+
+```bash
+# 建父子关系（父 issue 已存在 #230，新增子 issue #235 后挂载）
+gh api -X POST /repos/ghbvf/gocell/issues/230/sub_issues \
+  --field sub_issue_id=235
+
+# 列父 issue 的 sub-issues
+gh api -H "GraphQL-Features: sub_issues" graphql -f query='query {
+  repository(owner:"ghbvf",name:"gocell"){
+    issue(number:230){
+      subIssuesSummary { total completed percentCompleted }
+      subIssues(first:50){ nodes { number title state } }
+    }
+  }
+}'
+```
+
+父 issue 仍贴 `bundle-parent` label 作 backlog 检索锚点；子 issue 独立 cap/flag/type/pri label，独立 close。Project v2 自动派生：
+- **Parent issue** 字段 → 子 issue 行显示父 issue 链接
+- **Sub-issues progress** 字段 → 父 issue 行显示进度条（completed/total）
+
+### 形态 B：markdown task list（**legacy**，兼容 2024-12 前的存量）
 
 ```markdown
 ## Sub-items
@@ -106,7 +138,13 @@ Token scope：日常查询 `repo` 足够；rerating 时如需在 Project UI 批�
 - [ ] #235 子条 2 标题
 ```
 
-子 issue 独立 cap/flag/type labels，可独立 close。父 issue 进度自动渲染。
+存量父 issue 不强制迁移；新建大型任务优先用形态 A。`daily-planner` skill 同时识别两种形态（GraphQL `subIssues` 字段 + body grep 双源回落）。
+
+### 跟踪与排期
+
+- **子 issue 入当日 Iteration**（可操作单元），父 issue 常驻 Backlog status；不强制把父 issue 加进 Iteration。
+- **父 Status 不自动联动**：所有子 done 后人工把父改 Done。
+- daily-planner brief 中子 issue 用 `(parent #N)` 扁平标注，不做缩进树。
 
 ## Rerating
 
@@ -118,3 +156,61 @@ gh issue edit <N> --add-label pri-p0 --remove-label pri-p2   # 升级 P2 → P0
 ```
 
 Project UI 仍可作为筛选/排序入口（按 label group），但写入面只剩 label。Phase 决策叙事如需文档化新建 `docs/backlog/RERATING-LOG-<YYYY-qN>.md`，规则真值源 [`backlog/20260520/RERATING-RUBRIC.md`](backlog/20260520/RERATING-RUBRIC.md)。
+
+## Daily planning
+
+backlog 池 → 每日工作焦点调度由 `/daily-planner` skill + `daily-planner` agent 承载。详见 `.claude/agents/daily-planner.md` 与 `.claude/skills/daily-planner/SKILL.md`。
+
+### 用法
+
+```bash
+# dry-run（默认）：输出 brief，不写 Project v2
+/daily-planner
+
+# apply：把当日选中 issue 写入 current sprint Iteration
+/daily-planner --apply
+
+# 指定日期（按 sprint 推断目标 iteration）
+/daily-planner --date=2026-05-25
+/daily-planner --apply --date=2026-05-25
+```
+
+输出：
+- Brief markdown 落盘 `~/.local/share/gocell-daily/YYYY-MM-DD.md`
+- Apply 模式额外写 audit log 到 `.claude/logs/daily-planner-YYYYMMDD.jsonl`（已被 .gitignore）
+
+### Sprint vs Daily 语义
+
+GitHub Project v2 的 Iteration 字段是 **14-day sprint**（不是 1 天）。daily-planner 写入语义：
+
+- **当日 brief 中选中的 issue → 加入 current sprint Iteration**（如果还没加），让 sprint 视图反映"已被纳入近期焦点"
+- **每日焦点队列**只活在本地 brief（按日期分文件归档），不在 Project v2 上为每天单独建 iteration
+- Sprint 切换日（每 14 天）`TARGET_ITERATION_ID` 自动指向新 sprint，无需手工切配置；管理员需提前在 Project v2 UI 加好后续 iteration（当前已配 Iteration 1-5 覆盖至 2026-07-29）
+
+### 排序算法（简化 WSJF）
+
+```
+score = pri_weight × flag_multiplier
+  pri_weight:        P0=100 / P1=50 / P2=20 / P3=5 / pri-missing=110（强制首位）
+  flag_multiplier:   hard=3 / planned=2 / cond(trigger 满足)=1.5 / cond(pending)=0.3 / soft=1
+  容量过滤:          当日 ∑Cx ≤ 4（Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4），超出落 Unscheduled
+```
+
+异常处理：`pri-missing` 强制首位 + `[NEEDS PRIORITY]`；缺 cap/flag/type 标 `[MISSING LABEL]`；body 含 `tools/archtest/` 或 `kernel/` 或 `contracts/` 标 `[需人工确认]`；同 cap 已 ≥3 入队 → 后续 `[CAP COLLISION]` 退到 Unscheduled；`bundle-parent` 父 issue 排除（仅处理子 issue）。
+
+### 写入边界（agent 只动 Iteration）
+
+| 字段 | daily-planner |
+|------|---------------|
+| Iteration | **可写**（apply 模式）|
+| Status / Estimate / labels（含 pri/cap/flag/type） | 只读 |
+| issue body / title / comment | 不动 |
+
+误写 Iteration 影响半径 = 当日 brief 噪音 + 当前 sprint 视图多出一条，**无数据丢失**——可手动在 Project UI 清字段恢复，或 skill 回滚命令清单（apply 失败时输出到 stderr，需人工执行避免二次破坏）。
+
+### Token scope
+
+| Scope | dry-run | --apply |
+|-------|---------|---------|
+| 仅 `repo`（云沙箱常见）| ✓ 降级"只读 brief"模式（只用 label 维度排序）| ✗ 报错退出，提示 `gh auth refresh -s project` |
+| `repo` + `project`（本地常见）| ✓ 完整模式（读 Project v2 字段，不写）| ✓ 完整模式（写 Iteration）|

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -138,7 +138,7 @@ gh api -H "GraphQL-Features: sub_issues" graphql -f query='query {
 - [ ] #235 子条 2 标题
 ```
 
-存量父 issue 不强制迁移；新建大型任务优先用形态 A。`daily-planner` skill 同时识别两种形态（GraphQL `subIssues` 字段 + body grep 双源回落）。
+存量父 issue 不强制迁移，但只有形态 A（原生 sub-issue）能被 `daily-planner` skill 识别——skill 只查 GraphQL `subIssues` 字段，**不**解析 markdown body task list。形态 B 的子条目相当于 daily-planner 视角下的"未追踪"，需要时升级到形态 A。
 
 ### 跟踪与排期
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -169,26 +169,62 @@ backlog 池 → 每日工作焦点调度由 `/daily-planner` skill + `daily-plan
 # dry-run（默认）：在对话窗输出 brief，不写 Project v2
 /daily-planner
 
-# apply：把当日选中 issue 写入 today iteration
+# apply：把当日选中 issue（含昨日 carry-over）写入 today iteration
 /daily-planner --apply
 
-# 指定日期（按 1-day iteration 推断目标 option，缺失则自动新建）
-/daily-planner --date=2026-05-25
+# 指定日期（按 1-day iteration 推断；缺失自动新建）
 /daily-planner --apply --date=2026-05-25
 
-# 当日 ∑Cx 容量覆盖（默认 4）
-/daily-planner --apply --capacity=6
+# 容量覆盖（默认 30 工作日 / 60 周末）
+/daily-planner --apply --capacity=40
+
+# 强制周末模式（出差/补班等场景）
+/daily-planner --apply --weekend
+/daily-planner --apply --weekday
+
+# 扩输入集（默认仅 P0/P1；P2 是 follow-up / P3 是 nice-to-have，平时不进每日排期）
+/daily-planner --apply --include-p2
+/daily-planner --apply --include-p2 --include-p3
 ```
+
+### 输入集（默认 P0+P1）
+
+daily-planner 默认只把 `label:backlog AND (label:pri-p0 OR label:pri-p1)` 的 issue 纳入排期。理由：
+
+- P0 是 incident-driven 红线（详 `backlog/20260520/RERATING-RUBRIC.md`），有就必排
+- P1 是当季交付项，是日常 wave 的主力
+- P2 默认是 review follow-up / 技术债登记，不阻塞主线 → 通过 `--include-p2` 显式纳入
+- P3 是 nice-to-have / 长尾，平时不进每日排期 → 通过 `--include-p3` 显式纳入
+
+实测（2026-05-24）：P0=0 / P1=31 / P2=63 / P3=145；默认 31 个候选完全够支撑 10-20 个/天的 wave 调度。
+
+### Wave 模型
+
+| 模式 | wave_count | wave_size | 当日 issue 上限 | ∑Cx 软警告 |
+|------|------------|-----------|--------------|-----------|
+| 工作日 | 2 | 5 | 10 | 30 |
+| 周末 | 4 | 5 | 20 | 60 |
+
+- **wave_size=5** 对齐 Miller's Law 认知槽（5-7 chunk）
+- **wave_count × 5** 是硬上限；超出 → Unscheduled `[wave overflow]`
+- **∑Cx ≤ CAPACITY** 是软警告；超出 → brief Warnings `[CAPACITY EXCEEDED]`，不阻塞
+- **周末检测** `date +%u >= 6`（自动）；`--weekend` / `--weekday` flag 显式覆盖
+
+### Carry-over（昨日未完成 → 今日）
+
+skill 拉昨日 iteration 的 items；满足 `issue.state == OPEN AND Project Status != Done` 的 issue **优先占 Wave 1 头部**（按原 WSJF score 排序）：
+
+- carry-over > 5 → 顺延 Wave 2 头部（**不退** Unscheduled）
+- 连续 ≥3 天未完成 → Warnings 标 `[STUCK day:N]`（只警告仍 carry，由人决策是否拆分 / 降 priority）
+- 已完成判断用 OR 语义（覆盖手动改 Status=Done 但 issue 未 close 的脱节场景）
+- **不写 audit comment**（保持 agent 对 issue 完全只读；历史回溯靠对话窗 brief + git log + Project v2 activity feed）
 
 ### Daily Iteration 自动管理
 
-Project v2 的 Iteration 字段配置为 **1-day duration**（duration=1, startDay=1，每个 option 覆盖 1 天）。daily-planner 自动管理 iteration option 集合：
+Project v2 的 Iteration 字段配置为 **1-day duration**（duration=1, startDay=1）。daily-planner 自动管理 option 集合：
 
-- 启动时检查 `$DATE` 是否落在已有 iteration option 上
-- 缺失则用 GraphQL `updateProjectV2Field.iterationConfiguration`（append-only）追加一个 1-day iteration option 覆盖 `$DATE`
-- 历史 iteration option 保留不动（form audit trail：哪天排了哪些 issue 永远可在 Project UI 回溯）
-
-历史回溯：在 Project v2 UI 按 Iteration group by，每个 1-day iteration 列出当日纳入的 issue。daily brief 的文本本体不持久化（每次 `/daily-planner` 重生成），但 Project v2 的"哪些 issue 在哪天入队"是持久真值。
+- 启动检查 `$DATE` 是否落在已有 option；缺失则用 GraphQL `updateProjectV2Field.iterationConfiguration` append-only 追加 1-day option
+- 历史 option 保留不动；carry-over 的 move 语义（iteration field 是 single-select，写入今日时昨日视图自动失去 item）是 GitHub Iteration 字段固有行为
 
 ### 排序算法（简化 WSJF）
 
@@ -196,28 +232,23 @@ Project v2 的 Iteration 字段配置为 **1-day duration**（duration=1, startD
 score = pri_weight × flag_multiplier
   pri_weight:        P0=100 / P1=50 / P2=20 / P3=5 / pri-missing=110（强制首位）
   flag_multiplier:   hard=3 / planned=2 / cond(trigger 满足)=1.5 / cond(pending)=0.3 / soft=1
-  容量过滤:          当日 ∑Cx ≤ CAPACITY（默认 4；Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4），超出落 Unscheduled
-                    可通过 `--capacity=N` 覆盖默认值
 ```
 
-异常处理：`pri-missing` 强制首位 + `[NEEDS PRIORITY]`；缺 cap/flag/type 任一 → `[MISSING LABEL]`；`cap-x-cross` label → `[需人工确认]`（跨域需人评估）；同 cap 已 ≥3 入队 → 后续 `[CAP COLLISION]` 退到 Unscheduled；`bundle-parent` 父 issue 排除（仅处理子 issue）。
+Estimate **不入分数**，作 ∑Cx 软警告基准（Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4）。
+
+异常处理：`pri-missing` 强制首位 + `[NEEDS PRIORITY]`；缺 cap/flag/type 任一 → `[MISSING LABEL]` 不入队；`cap-x-cross` label → `[需人工确认]` 不入队；同 cap 已 ≥3 入队 → 后续 `[CAP COLLISION]` 退 Unscheduled；`bundle-parent` 父 issue（仍 OPEN）→ carry-over（子全 close 不自动闭父，让人手 close）。
 
 ### 写入边界
 
 | 字段 | daily-planner |
 |------|---------------|
-| Iteration field **value**（item 行的 iteration 设置）| **可写**（仅 apply 模式）|
+| Iteration field **value**（item 行的 iteration 设置）| **可写**（仅 apply 模式；carry-over move + 新入队 set）|
 | Iteration field **configuration**（追加 1-day iteration option）| **可写**（append-only，缺失目标日期 option 时自动追加）|
 | Status / Estimate / labels（含 pri/cap/flag/type）| 只读 |
-| issue body / title / comment | 不动 |
+| issue body / title / **comment** | **不动**（含 carry-over audit comment 也不写）|
 
-误写 Iteration value 影响半径 = 当日 brief 噪音 + Project v2 视图多出一条；apply 失败 skill 输出回滚命令清单（**逐条审查后执行**，不要批量复制粘贴，避免二次破坏）。Iteration configuration 是 append-only，不会删除历史 option，无数据丢失风险。
+误写 Iteration value 影响半径 = 当日 brief 噪音 + Project v2 视图多出一条；apply 失败 skill 输出回滚命令清单（**逐条审查后执行**，不要批量复制粘贴）。Iteration configuration 是 append-only，无数据丢失风险。
 
 ### Token scope
 
-| Scope | dry-run | --apply |
-|-------|---------|---------|
-| 仅 `repo`（云沙箱常见）| ✓ 降级"只读 brief"模式（只用 label 维度排序）| ✗ 报错退出，提示 `gh auth refresh -s project` |
-| `repo` + `project`（本地常见）| ✓ 完整模式（读 Project v2 字段，不写）| ✓ 完整模式（写 Iteration value + 必要时追加 option）|
-
-token scope 检测用宽松正则 `grep -qiE "scopes:.*\bproject\b"`，跨 gh 版本健壮（不依赖单引号风格）。
+token 必须有 `project` scope（detection: `grep -qiE "scopes:.*\bproject\b"`）。无则 fail-fast 退出（不再提供"仅 repo"降级模式——daily-planner 不在云沙箱跑）。本地缺则 `gh auth refresh -s project`。

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -175,10 +175,7 @@ backlog 池 → 每日工作焦点调度由 `/daily-planner` skill + `daily-plan
 # 指定日期（按 1-day iteration 推断；缺失自动新建）
 /daily-planner --apply --date=2026-05-25
 
-# 容量覆盖（默认 30 工作日 / 60 周末）
-/daily-planner --apply --capacity=40
-
-# 强制周末模式（出差/补班等场景）
+# 强制周末模式（出差/补班等场景；影响 wave 数 → 容量）
 /daily-planner --apply --weekend
 /daily-planner --apply --weekday
 
@@ -200,14 +197,16 @@ daily-planner 默认只把 `label:backlog AND (label:pri-p0 OR label:pri-p1)` �
 
 ### Wave 模型
 
-| 模式 | wave_count | wave_size | 当日 issue 上限 | ∑Cx 软警告 |
-|------|------------|-----------|--------------|-----------|
-| 工作日 | 2 | 5 | 10 | 30 |
-| 周末 | 4 | 5 | 20 | 60 |
+**容量公式**：`容量 = WAVE_COUNT × WAVE_SIZE`（一任务一容量，不引入 ∑Cx 加权）
 
-- **wave_size=5** 对齐 Miller's Law 认知槽（5-7 chunk）
-- **wave_count × 5** 是硬上限；超出 → Unscheduled `[wave overflow]`
-- **∑Cx ≤ CAPACITY** 是软警告；超出 → brief Warnings `[CAPACITY EXCEEDED]`，不阻塞
+| 模式 | WAVE_COUNT | WAVE_SIZE | 容量 (issue 数) |
+|------|-----------|-----------|----------------|
+| 工作日 | 2 | 5 | **10** |
+| 周末 | 4 | 5 | **20** |
+
+- **WAVE_SIZE=5** 固定，对齐 Miller's Law 认知槽（5-7 chunk）
+- **超容量的 issue** → Unscheduled，标注 `[capacity overflow]`
+- **Estimate (Cx1-4)** 仅在 brief 表格作参考显示，**不参与容量约束**
 - **周末检测** `date +%u >= 6`（自动）；`--weekend` / `--weekday` flag 显式覆盖
 
 ### Carry-over（昨日未完成 → 今日）


### PR DESCRIPTION
## Summary

新增每日 backlog → Project v2 Iteration 调度器，作为现有 `project-manager` agent（Phase 内 batch 协调）之外的另一层：跨日规划 backlog 池。

- **新 agent** `.claude/agents/daily-planner.md`：简化 WSJF 排序（pri × flag + 容量过滤 ∑Cx≤4）+ 异常处理矩阵
- **新 skill** `.claude/skills/daily-planner/SKILL.md`：默认 dry-run，`--apply` 显式 opt-in；token scope fail-check + 降级"只读 brief"模式（云沙箱友好）
- **docs/backlog.md**：加 §"Daily planning" + sub-issue API 现代化路径 + Status 字面值校准

## 设计要点

### Sprint vs Daily 语义校准

GitHub Project v2 的 Iteration 字段是 **14-day sprint**（不是 1 天）。本 agent 在 Project v2 上的写入语义：
- 当日选中的 issue → **加入 current sprint Iteration**（如果还没加）
- **Daily 焦点队列**只活在本地 brief `~/.local/share/gocell-daily/YYYY-MM-DD.md`，不为每天新建 iteration
- Sprint 切换日 `TARGET_ITERATION_ID` 自动指向新 sprint，无需手工切配置

### 字段权限边界

| 字段 | daily-planner |
|------|---------------|
| Iteration | 可写（apply 模式）|
| Status / Estimate / labels（含 pri/cap/flag/type）| **只读** |
| issue body / title / comment | 不动 |

只动 Iteration 的论证：Status 是人控的进度语义，agent 误写会丢失进度信息；误写 Iteration 仅影响"当日 brief 噪音 + sprint 视图多一条"，无数据丢失，可手动恢复。

### 排序公式（简化 WSJF）

```
score = pri_weight × flag_multiplier
  pri_weight:        P0=100 / P1=50 / P2=20 / P3=5 / pri-missing=110（强制首位）
  flag_multiplier:   hard=3 / planned=2 / cond(satisfied)=1.5 / cond(pending)=0.3 / soft=1
  容量过滤:          当日 ∑Cx ≤ 4（Cx1=1 / Cx2=2 / Cx3=3 / Cx4=4）
```

### Sub-issue（大型任务）双源支持

- **首选**：GitHub 原生 sub-issue API（2024-12 GA）+ Project v2 内置 Parent issue / Sub-issues progress 字段（已存在，无需新增 custom field）
- **回落**：现有 `bundle-parent` label + markdown task list 形态保持兼容，存量不强制迁移
- daily-planner brief 中子 issue 用 `(parent #N)` 扁平标注

## 实测数据（2026-05-24 dry-run）

| 检测项 | 结果 |
|--------|------|
| Token scope `project` | ✓ 可用 |
| Backlog 池拉取 | 244 issues ✓ |
| Project v2 items | 263 items ✓ |
| TARGET_ITERATION_ID 解析 | `381c7c80` (Iteration 1, 2026-05-20~06-03) ✓ |
| pri-missing 哨兵 | 0 |
| 缺 pri / cap / flag / type | 6 / 6 / 11 / 3（< 5%，符合 explorer 预估）|
| bundle-parent 父 issue | 0（当前无大型任务）|
| `gh project item-edit` 命令形态 | ✓ 4 个 ID（PROJECT/ITEM/FIELD/ITERATION）全部对齐 |

Brief 落盘路径：`~/.local/share/gocell-daily/YYYY-MM-DD.md`（XDG data dir，不污染项目）
Audit log：`.claude/logs/daily-planner-YYYYMMDD.jsonl`（已被 .gitignore）

## 已知决策点（请 review 关注）

1. **Sprint vs Daily 语义**：用户原需求是"每天当作一个迭代"，但 GitHub Iteration 字段是 14-day sprint。本 PR 务实方案 = 写入 = 加入 current sprint；每日焦点活在本地 brief。如果需要新增"Daily" custom field 表达更细粒度，需另开 PR。
2. **`Size` 字段**（XS/S/M/L/XL）已被 `Estimate` (Cx1-4) 替代，本 PR 仅文档标注 deprecated，不删字段（避免破坏历史 item）。
3. **agent 只动 Iteration** 是收敛后的最小写入面；如需把 daily-planner 扩展到 Status 自动联动（如自动改 Backlog → Ready），需再次 ADR 化决策。

## Test plan

- [x] dry-run 实跑：跑 SKILL.md 阶段 1+2 bash pipeline，验证数据流通顺
- [x] Iteration option ID 解析（jq 表达式 bug 已修复，需 `as $it` 绑定保留 root context）
- [x] Token scope `project` 检测
- [x] Item-edit 命令形态（4 个 GraphQL ID 对齐）
- [ ] Apply 模式实跑（避免污染 Project v2 真实数据，未在本 PR 执行；待用户主动 `/daily-planner --apply` 验证）
- [ ] 云沙箱降级模式（仅 `repo` scope）实跑（需要切 token，本 PR 未验证）
- [ ] GitHub 原生 sub-issue 提取（当前 repo 无 sub-issue，未端到端验证；GraphQL query 形态正确）

## ref

- WSJF (SAFe) — `score = (Business Value + Time Criticality) / Job Size` 启发的简化版
- Linear Cycles / Shape Up scopes — epic-issue 分层（父常驻、子入冲刺）
- GitHub Issues sub-issues REST API（2024-12 GA）— `POST /repos/.../issues/{n}/sub_issues`
- GitHub Projects v2 GraphQL `updateProjectV2ItemFieldValue` — Iteration 写入路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)