### PR TITLE
fix(archtest): drop strict decode from dependabot validator (close #925)

### DIFF
--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -1,4 +1,9 @@
-// INVARIANT: CI-PINNING-WORKFLOW-DIGEST-01: golangci-lint pinned to patch version; all external workflow uses pinned to SHA
+// INVARIANT:
+//   - CI-PINNING-WORKFLOW-DIGEST-01: golangci-lint pinned to patch version; all external workflow uses pinned to SHA
+//   - DEPENDABOT-COVERAGE-GOLANGCI-01: dependabot root github-actions block covers
+//     golangci/golangci-lint-action and a root gomod block is present; the decode is
+//     tolerant of unmodeled orchestration fields (a typo in an asserted field
+//     collapses to its zero value and still reds the guard)
 package archtest
 
 import (
@@ -281,8 +286,16 @@ updates:
 // the other validators in this file (validateGeneratedArtifactGates /
 // validateCodegenJobStructure). A strict KnownFields(true) decode here would
 // red on every new dependabot field while adding nothing to the assertion —
-// that fragility caused #925. This test prevents a "helpful" reintroduction
-// of strict decode.
+// that fragility caused #925 (trigger: #911 added `ignore:`). This test
+// prevents a "helpful" reintroduction of strict decode: with strict decode
+// re-added, the unmodeled fields below (open-pull-requests-limit / labels /
+// ignore + sub-fields) make the decode error and this NoError assertion red.
+//
+// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01.
+//
+// The fixture MUST retain those unmodeled fields — they are the regression
+// trip-wire; shrinking the fixture to only modeled fields would silently
+// turn this test into a tautology that no longer catches strict-decode reentry.
 func TestDependabotCoversCIAndGolangCILintToleratesUnmodeledFields(t *testing.T) {
 	body := []byte(`version: 2
 updates:
@@ -318,6 +331,31 @@ updates:
 	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
 }
 
+// TestDependabotCoversCIAndGolangCILintRejectsGroupsFieldTypo is the
+// blind-spot self-check for dropping strict decode (#925): a typo in an
+// *asserted* field must still red the guard. Here `groops:` (typo of
+// `groups:`) is tolerantly ignored, leaving Groups empty, so the root
+// github-actions block can no longer cover golangci/golangci-lint-action and
+// the guard reds. This proves tolerant decode stays fail-closed on the fields
+// the guard reads — the safety claim that justified removing KnownFields(true).
+//
+// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01.
+func TestDependabotCoversCIAndGolangCILintRejectsGroupsFieldTypo(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groops:
+      golangci-lint:
+        patterns:
+          - "golangci/golangci-lint-action"
+  - package-ecosystem: "gomod"
+    directory: "/"
+`)
+	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
+		"a typo in the asserted `groups` field must red the guard, not pass silently")
+}
+
 // dependabotConfig models only the fields validateDependabotCoversCIAndGolangCILint
 // asserts on. The decode is intentionally tolerant (no KnownFields(true)):
 // dependabot.yml legitimately grows orchestration fields (ignore /
@@ -337,6 +375,10 @@ type dependabotUpdate struct {
 	Groups           map[string]dependabotGroup `yaml:"groups"`
 }
 
+// dependabotGroup deliberately models only Patterns. The guard asks whether a
+// group's Patterns contains the required action, never what is excluded, so
+// exclude-patterns is left unmodeled and tolerantly ignored (see the
+// AllowsGroupExclusions fixture).
 type dependabotGroup struct {
 	Patterns []string `yaml:"patterns"`
 }

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -272,32 +272,78 @@ updates:
 	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
 }
 
+// TestDependabotCoversCIAndGolangCILintToleratesUnmodeledFields locks the
+// guard's tolerant-evolution contract: dependabot.yml legitimately carries
+// orchestration fields the guard does not assert on — ignore (with full
+// dependency-name/versions/update-types), open-pull-requests-limit, labels.
+// The validator must check only the coverage invariant (root github-actions
+// covers golangci + root gomod) and stay tolerant of schema growth, matching
+// the other validators in this file (validateGeneratedArtifactGates /
+// validateCodegenJobStructure). A strict KnownFields(true) decode here would
+// red on every new dependabot field while adding nothing to the assertion —
+// that fragility caused #925. This test prevents a "helpful" reintroduction
+// of strict decode.
+func TestDependabotCoversCIAndGolangCILintToleratesUnmodeledFields(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci/golangci-lint-action"
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "mvdan.cc/gofumpt"
+        versions:
+          - "0.10.0"
+        update-types:
+          - "version-update:semver-minor"
+    groups:
+      go-other:
+        patterns:
+          - "*"
+`)
+	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
+}
+
+// dependabotConfig models only the fields validateDependabotCoversCIAndGolangCILint
+// asserts on. The decode is intentionally tolerant (no KnownFields(true)):
+// dependabot.yml legitimately grows orchestration fields (ignore /
+// open-pull-requests-limit / labels / reviewers / …) that the coverage guard
+// does not care about, and strict decode would red on each one while adding
+// nothing to the assertion (a typo in a field the guard *does* read collapses
+// it to its zero value, so the pattern match fails and the guard reds anyway).
+// Matches the tolerant decode in validateGeneratedArtifactGates /
+// validateCodegenJobStructure. See #925.
 type dependabotConfig struct {
-	Version int                `yaml:"version"`
 	Updates []dependabotUpdate `yaml:"updates"`
 }
 
 type dependabotUpdate struct {
 	PackageEcosystem string                     `yaml:"package-ecosystem"`
 	Directory        string                     `yaml:"directory"`
-	Schedule         dependabotSchedule         `yaml:"schedule"`
 	Groups           map[string]dependabotGroup `yaml:"groups"`
 }
 
-type dependabotSchedule struct {
-	Interval string `yaml:"interval"`
-}
-
 type dependabotGroup struct {
-	Patterns        []string `yaml:"patterns"`
-	ExcludePatterns []string `yaml:"exclude-patterns"`
+	Patterns []string `yaml:"patterns"`
 }
 
 func validateDependabotCoversCIAndGolangCILint(body []byte) error {
 	var cfg dependabotConfig
-	dec := yaml.NewDecoder(bytes.NewReader(body))
-	dec.KnownFields(true)
-	if err := dec.Decode(&cfg); err != nil {
+	if err := yaml.Unmarshal(body, &cfg); err != nil {
 		return fmt.Errorf("parse dependabot.yml: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

`tools/archtest/ci_pinning_test.go::validateDependabotCoversCIAndGolangCILint` 用 `dec.KnownFields(true)`（strict decode），强制 archtest 全量建模 dependabot.yml schema。PR #911 给 `.github/dependabot.yml` 加 `ignore:`（锁 `mvdan.cc/gofumpt`）后，strict decode 因未建模字段报错，`TestDependabotCoversCIAndGolangCILint` 在 `make verify` / `archtest-nightly` 该 lane 红（PR-time CI 走 4-core-invariant 子集不含此 test，故 PR 未被阻塞，但污染信号）。

**根因是 strict decode，不是漏字段**：strict 对 guard 的覆盖断言无任何贡献（guard 关心的字段若 typo 会塌成零值 → pattern 匹配失败 → guard 照样红），却让 dependabot 每加一个合法编排字段（`ignore` / `open-pull-requests-limit` / `labels`…）就误伤。

## 改动（单文件）

- 删 `dec.KnownFields(true)`，改普通 `yaml.Unmarshal` —— 与同文件另两个 validator（`validateGeneratedArtifactGates` / `validateCodegenJobStructure`）的 tolerant 解码一致。
- 精简 struct 到 guard 真正断言的 3 字段路径（`PackageEcosystem` / `Directory` / `Groups[].Patterns`）；删 `Version` / `Schedule`(`dependabotSchedule`) / `ExcludePatterns` 等仅为过 strict 而存在的陪跑字段（`ExcludePatterns` 本身即上次同类 bug 的痕迹）。
- 新增 `TestDependabotCoversCIAndGolangCILintToleratesUnmodeledFields` 锁定 tolerant-evolution 契约，防止 strict decode 被"好心"恢复。

> 不是"补 `Ignore` 字段"的 Soft 补丁——那只堵这一次，根因脆性仍在，下次加字段复发。本 PR 消除根因。

## AI-robust

本改动是**消除一个会持续误伤、只能靠记忆约定维护的脆性机制**（非新增 enforcement），符合 ai-robust「既有 Soft 的补丁 → 优先消除根源」。新 test 把 tolerant 演化固化为行为契约。

## 契约扇出

放松 archtest 解析脆性，不改 dependabot.yml（真值源）本身，不涉及 interface/DB/errcode/contract.yaml。不触发 5 载体 implementation matrix。

## Test plan

- [x] `go test ./tools/archtest/ -run TestDependabot` 全绿（含新 test + 3 个既有 negative/positive fixture）
- [x] `go build ./...`
- [x] `golangci-lint run ./tools/archtest/...` → 0 issues
- [x] 改前确认 `TestDependabotCoversCIAndGolangCILint` + 新 test 均 RED，改后 GREEN

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)