### PR TITLE
test(rabbitmq): de-flake terminal-propagation test via FakeClock + faithful broker-close mock (#930)

### DIFF
--- a/adapters/rabbitmq/connection.go
+++ b/adapters/rabbitmq/connection.go
@@ -862,6 +862,12 @@ func (c *Connection) handleReconnectError(err error, attempt int) {
 // handling): on wake, callers re-read permanentErr under RLock and, finding
 // it non-nil, return it. permanentErr is cleared by markRecovered when a
 // later dial succeeds.
+//
+// INVARIANT: must close-and-replace the connected channel on EVERY permanent
+// dial cycle, not once-only. A WaitConnected caller that read the channel after
+// a prior swap is parked on a still-open channel and relies on this cycle's
+// close to be woken. Making it once-only would re-introduce a lost-wakeup; the
+// guard is TestWaitConnected_WokenAcrossPermanentChannelSwaps (see #930).
 func (c *Connection) markPermanent(cause error, sanitizedErr string) {
 	c.mu.Lock()
 	c.permanentErr = errcode.Wrap(errcode.KindInternal, ErrAdapterAMQPConnectPermanent,

--- a/adapters/rabbitmq/connection_channel_limit_test.go
+++ b/adapters/rabbitmq/connection_channel_limit_test.go
@@ -320,11 +320,7 @@ func TestReconnect_DrainPool_ReleasesInUseChannels(t *testing.T) {
 		return mocks[0].notifyCloseCh != nil
 	}, testtime.D2s, testtime.D10ms, "reconnectLoop must have registered NotifyClose")
 
-	mocks[0].mu.Lock()
-	notifyCh := mocks[0].notifyCloseCh
-	mocks[0].isClosed = true
-	mocks[0].mu.Unlock()
-	notifyCh <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	mocks[0].triggerBrokerClose()
 
 	// Wait for reconnect to complete (dial count reaches 2).
 	testwait.External(t, "amqp-reconnect-completed", func() bool {

--- a/adapters/rabbitmq/connection_runtime_terminal_test.go
+++ b/adapters/rabbitmq/connection_runtime_terminal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
@@ -524,6 +525,85 @@ func TestReconnectLoop_PermanentAndRecovery(t *testing.T) {
 	defer cancel()
 	assert.NoError(t, conn.WaitConnected(ctx),
 		"WaitConnected must return nil after self-heal")
+}
+
+// TestWaitConnected_WokenAcrossPermanentChannelSwaps guards the invariant that a
+// WaitConnected caller parked on the `connected` channel is woken even when it
+// must wait across a markPermanent channel swap.
+//
+// markPermanent runs on EVERY failed permanent dial (connection.go
+// reconnectWithBackoff's `continue` re-enters handleReconnectError each cycle),
+// creating a fresh `connected` channel and closing the previous one. A caller
+// that read the channel AFTER a swap (the fresh, still-open one) relies on the
+// NEXT cycle's markPermanent to close it. If markPermanent were ever changed to
+// fire once-only (skip the swap/close on subsequent permanent dials), such a
+// caller would park forever and this test would time out — converting a latent
+// production lost-wakeup into a hard RED.
+//
+// Deterministic via FakeClock: each reconnect backoff fires only on fc.Advance,
+// so the test drives the permanent cycles itself rather than racing wall-clock.
+func TestWaitConnected_WokenAcrossPermanentChannelSwaps(t *testing.T) {
+	originalMock := newMockConnection()
+
+	var phase atomic.Int32 // 0 = dial succeeds; 1 = ErrSASL (definitive permanent)
+	dialFunc := func(string) (AMQPConnection, error) {
+		if phase.Load() == 0 {
+			return originalMock, nil
+		}
+		return nil, amqp.ErrSASL
+	}
+
+	fc := clockmock.New(time.Time{})
+	conn, err := NewConnection(Config{
+		URL:                 testAMQPURL,
+		ChannelPoolSize:     2,
+		ReconnectBaseDelay:  testtime.D1ms,
+		ReconnectMaxBackoff: testtime.FastPoll,
+	}, WithDialFunc(dialFunc), WithConnectionClock(fc))
+	require.NoError(t, err)
+	defer func() {
+		if cErr := conn.Close(context.Background()); cErr != nil {
+			t.Logf("conn.Close: %v", cErr)
+		}
+	}()
+
+	testwait.External(t, "amqp-notify-close-registered", func() bool {
+		originalMock.mu.Lock()
+		defer originalMock.mu.Unlock()
+		return originalMock.notifyCloseCh != nil
+	}, testtime.D2s, testtime.D1ms)
+
+	phase.Store(1)
+	originalMock.triggerBrokerClose()
+
+	// Cycle 1: drive one backoff so the first permanent dial runs markPermanent
+	// (sets permErr, swaps the connected channel). Once Health reports the
+	// permanent error, c.connected is the fresh post-swap channel.
+	testwait.External(t, "amqp-permanent-channel-swapped", func() bool {
+		if fc.PendingTimers() > 0 {
+			fc.Advance(testtime.FastPoll)
+		}
+		var ecErr *errcode.Error
+		hErr := conn.Health(context.Background())
+		return hErr != nil && errors.As(hErr, &ecErr) && ecErr.Code == ErrAdapterAMQPConnectPermanent
+	}, testtime.EventuallyLong, testtime.D1ms,
+		"first permanent dial must set permErr and swap the connected channel")
+
+	// Park a WaitConnected caller on the post-swap (fresh, still-open) channel.
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyLong)
+	defer cancel()
+	waitErrCh := make(chan error, 1)
+	go func() { waitErrCh <- conn.WaitConnected(ctx) }()
+
+	// A subsequent markPermanent must close the post-swap channel and wake the
+	// parked caller. Drive fc until WaitConnected returns.
+	waitErr := advanceFakeReconnectUntil(t, fc, waitErrCh)
+	require.Error(t, waitErr, "WaitConnected parked on a post-swap channel must be woken, not hang")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(waitErr, &ecErr),
+		"WaitConnected error must wrap *errcode.Error; got %T: %v", waitErr, waitErr)
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code,
+		"WaitConnected must return ErrAdapterAMQPConnectPermanent")
 }
 
 // =============================================================================

--- a/adapters/rabbitmq/connection_runtime_terminal_test.go
+++ b/adapters/rabbitmq/connection_runtime_terminal_test.go
@@ -499,11 +499,7 @@ func TestReconnectLoop_PermanentAndRecovery(t *testing.T) {
 	}, testtime.D2s, testtime.D1ms)
 
 	phase.Store(1)
-	originalMock.mu.Lock()
-	closeNotifyCh := originalMock.notifyCloseCh
-	originalMock.isClosed = true
-	originalMock.mu.Unlock()
-	closeNotifyCh <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	originalMock.triggerBrokerClose()
 
 	// Permanent classification must surface — Health returns ErrAdapterAMQPConnectPermanent.
 	testwait.External(t, "amqp-permanent-err-set", func() bool {

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
@@ -123,6 +124,11 @@ type mockChannel struct {
 
 	consumeDeliveries chan amqp.Delivery
 	consumeErr        error
+	consumeCalled     bool
+	// deliveriesOnce guards closeDeliveries: a broker disconnect can reach the
+	// same channel through several paths (pool drain, multi-cycle reconnect,
+	// deferred Subscriber.Close), and double-closing consumeDeliveries would panic.
+	deliveriesOnce sync.Once
 
 	cancelCalled   bool
 	cancelCount    int64
@@ -193,10 +199,24 @@ func (m *mockChannel) PublishWithContext(_ context.Context, exchange, key string
 func (m *mockChannel) Consume(
 	queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table,
 ) (<-chan amqp.Delivery, error) {
+	m.mu.Lock()
 	if m.consumeErr != nil {
-		return nil, m.consumeErr
+		err := m.consumeErr
+		m.mu.Unlock()
+		return nil, err
 	}
+	m.consumeCalled = true
+	m.mu.Unlock()
 	return m.consumeDeliveries, nil
+}
+
+// closeDeliveries closes consumeDeliveries exactly once. Real amqp091-go closes a
+// consumer's delivery channel when the underlying connection drops; the mock must
+// model this so a blocked consumeLoop observes the close (errSubscriptionLost)
+// instead of parking forever. sync.Once makes it safe to call from every broker
+// disconnect path.
+func (m *mockChannel) closeDeliveries() {
+	m.deliveriesOnce.Do(func() { close(m.consumeDeliveries) })
 }
 
 func (m *mockChannel) Cancel(consumer string, noWait bool) error {
@@ -384,6 +404,78 @@ func (m *mockConnection) Close() error {
 	defer m.mu.Unlock()
 	m.isClosed = true
 	return m.closeErr
+}
+
+// brokerForcedClose is the canonical CONNECTION_FORCED error a RabbitMQ broker
+// delivers via NotifyClose when it forcibly drops a client connection (the close
+// behind rabbitmqctl close_all_connections). Recover=true marks it retryable, so
+// the reconnect loop re-dials.
+func brokerForcedClose() *amqp.Error {
+	return &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+}
+
+// triggerBrokerClose models a broker-forced connection loss: it marks the
+// connection closed and delivers the close error to the registered NotifyClose
+// receiver. It is the single canonical broker-disconnect path; tests MUST NOT
+// hand-roll the lock/isClosed/notify steps separately.
+//
+// NOTE (#930 RED): this intentionally does NOT yet close consumer delivery
+// channels. Real amqp091-go closes them on connection drop; omitting it is the
+// historical mock defect that let a blocked consumeLoop park forever — exactly
+// what TestSubscriber_Subscribe_PropagatesPermanentError must catch. The GREEN
+// commit adds the deliveries close. Precondition: NotifyClose already registered
+// (callers barrier on notifyCloseCh != nil first).
+func (m *mockConnection) triggerBrokerClose() {
+	m.mu.Lock()
+	m.isClosed = true
+	notify := m.notifyCloseCh
+	m.mu.Unlock()
+	notify <- brokerForcedClose()
+}
+
+// consumingStarted reports whether any issued channel has had Consume called —
+// i.e. a subscriber has passed subscribeOnce setup and is (about to be) parked in
+// consumeLoop on <-deliveries. Tests barrier on this before triggerBrokerClose so
+// they deterministically exercise the consumeLoop→errSubscriptionLost→
+// awaitReconnect→WaitConnected path rather than racing the AcquireChannel-setup
+// terminal path.
+func (m *mockConnection) consumingStarted() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, ch := range m.channels {
+		ch.mu.Lock()
+		started := ch.consumeCalled
+		ch.mu.Unlock()
+		if started {
+			return true
+		}
+	}
+	return false
+}
+
+// advanceFakeReconnectUntil steps fc through reconnect backoff cycles — gated on
+// PendingTimers so it never Advances into an unregistered timer (mirrors
+// runtime/distlock/manager_test.go::waitPendingTimers) — until resultCh produces a
+// value, then returns it. With the connection on a FakeClock the whole reconnect
+// path is deterministic; the EventuallyLong backstop never fires in practice.
+func advanceFakeReconnectUntil[T any](t *testing.T, fc *clockmock.FakeClock, resultCh <-chan T) T {
+	t.Helper()
+	var got T
+	have := false
+	testwait.External(t, "amqp-fake-reconnect-result", func() bool {
+		if fc.PendingTimers() > 0 {
+			fc.Advance(testtime.FastPoll) // ≥ ReconnectMaxBackoff cap: fires the jittered timer this step
+		}
+		select {
+		case got = <-resultCh:
+			have = true
+			return true
+		default:
+			return false
+		}
+	}, testtime.EventuallyLong, testtime.D1ms)
+	require.True(t, have, "fake reconnect did not produce a result within budget")
+	return got
 }
 
 // --- Mock Publisher (for DLQ) ---

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -414,20 +414,22 @@ func brokerForcedClose() *amqp.Error {
 	return &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 }
 
-// triggerBrokerClose models a broker-forced connection loss: it marks the
-// connection closed and delivers the close error to the registered NotifyClose
-// receiver. It is the single canonical broker-disconnect path; tests MUST NOT
-// hand-roll the lock/isClosed/notify steps separately.
-//
-// NOTE (#930 RED): this intentionally does NOT yet close consumer delivery
-// channels. Real amqp091-go closes them on connection drop; omitting it is the
-// historical mock defect that let a blocked consumeLoop park forever — exactly
-// what TestSubscriber_Subscribe_PropagatesPermanentError must catch. The GREEN
-// commit adds the deliveries close. Precondition: NotifyClose already registered
-// (callers barrier on notifyCloseCh != nil first).
+// triggerBrokerClose models a broker-forced connection loss as one faithful step:
+// mark the connection closed, close every issued channel's consumer delivery
+// channel (real amqp091-go closes consumer channels on connection drop, so a
+// blocked consumeLoop observes errSubscriptionLost → awaitReconnect →
+// WaitConnected), then deliver the close error to the registered NotifyClose
+// receiver (so the reconnect loop re-dials). It is the single canonical
+// broker-disconnect path; tests MUST NOT hand-roll the lock/isClosed/deliveries/
+// notify steps separately — omitting the deliveries close is exactly the #930
+// defect. Precondition: NotifyClose already registered (callers barrier on
+// notifyCloseCh != nil first).
 func (m *mockConnection) triggerBrokerClose() {
 	m.mu.Lock()
 	m.isClosed = true
+	for _, ch := range m.channels {
+		ch.closeDeliveries()
+	}
 	notify := m.notifyCloseCh
 	m.mu.Unlock()
 	notify <- brokerForcedClose()
@@ -993,12 +995,8 @@ func TestConnection_ReconnectLoop_DisconnectAndReconnect(t *testing.T) {
 		return mocks[0].notifyCloseCh != nil
 	}, testtime.D2s, testtime.D1ms, "reconnectLoop did not call NotifyClose")
 
-	// Now send on the channel that reconnectLoop is actually selecting on.
-	mocks[0].mu.Lock()
-	ch := mocks[0].notifyCloseCh
-	mocks[0].isClosed = true
-	mocks[0].mu.Unlock()
-	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	// Trigger the broker-forced close reconnectLoop is selecting on.
+	mocks[0].triggerBrokerClose()
 
 	// reconnectLoop should reconnect. Verify dial was called again.
 	testwait.External(t, "amqp-reconnect-completed", func() bool {
@@ -1056,11 +1054,7 @@ func TestConnection_ReconnectLoop_RetriesIndefinitelyUntilRecovery(t *testing.T)
 	}, testtime.D2s, testtime.D1ms, "reconnectLoop did not call NotifyClose")
 
 	// Trigger disconnect.
-	mocks[0].mu.Lock()
-	ch := mocks[0].notifyCloseCh
-	mocks[0].isClosed = true
-	mocks[0].mu.Unlock()
-	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	mocks[0].triggerBrokerClose()
 
 	// Wait for reconnection to succeed (dial count >= 4: 1 initial + 2 failed + 1 success).
 	testwait.External(t, "amqp-reconnect-completed", func() bool {
@@ -3884,11 +3878,7 @@ func TestConnection_Health_DuringReconnect(t *testing.T) {
 	}, testtime.D2s, testtime.D1ms)
 
 	// Trigger disconnect.
-	mock1.mu.Lock()
-	ch := mock1.notifyCloseCh
-	mock1.isClosed = true
-	mock1.mu.Unlock()
-	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	mock1.triggerBrokerClose()
 
 	// Wait until reconnect dial is blocked (dialCount == 2).
 	testwait.External(t, "amqp-reconnect-completed", func() bool {
@@ -4335,11 +4325,7 @@ func TestConnection_ReconnectLoop_StateTransitions(t *testing.T) {
 	}, testtime.D2s, testtime.D1ms)
 
 	// Trigger disconnect.
-	mock1.mu.Lock()
-	ch := mock1.notifyCloseCh
-	mock1.isClosed = true
-	mock1.mu.Unlock()
-	ch <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	mock1.triggerBrokerClose()
 
 	// Wait until reconnect dial is blocked — state should be Disconnected.
 	testwait.External(t, "amqp-reconnect-completed", func() bool {

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -213,8 +213,12 @@ func (m *mockChannel) Consume(
 // closeDeliveries closes consumeDeliveries exactly once. Real amqp091-go closes a
 // consumer's delivery channel when the underlying connection drops; the mock must
 // model this so a blocked consumeLoop observes the close (errSubscriptionLost)
-// instead of parking forever. sync.Once makes it safe to call from every broker
-// disconnect path.
+// instead of parking forever.
+//
+// Called by triggerBrokerClose (the broker-disconnect path) and directly by tests
+// that close a single channel's stream. sync.Once provides the concurrency
+// guarantee, so it is deliberately safe to call without holding ch.mu — e.g.
+// triggerBrokerClose invokes it while holding m.mu but not ch.mu.
 func (m *mockChannel) closeDeliveries() {
 	m.deliveriesOnce.Do(func() { close(m.consumeDeliveries) })
 }
@@ -406,14 +410,6 @@ func (m *mockConnection) Close() error {
 	return m.closeErr
 }
 
-// brokerForcedClose is the canonical CONNECTION_FORCED error a RabbitMQ broker
-// delivers via NotifyClose when it forcibly drops a client connection (the close
-// behind rabbitmqctl close_all_connections). Recover=true marks it retryable, so
-// the reconnect loop re-dials.
-func brokerForcedClose() *amqp.Error {
-	return &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
-}
-
 // triggerBrokerClose models a broker-forced connection loss as one faithful step:
 // mark the connection closed, close every issued channel's consumer delivery
 // channel (real amqp091-go closes consumer channels on connection drop, so a
@@ -422,8 +418,15 @@ func brokerForcedClose() *amqp.Error {
 // receiver (so the reconnect loop re-dials). It is the single canonical
 // broker-disconnect path; tests MUST NOT hand-roll the lock/isClosed/deliveries/
 // notify steps separately — omitting the deliveries close is exactly the #930
-// defect. Precondition: NotifyClose already registered (callers barrier on
-// notifyCloseCh != nil first).
+// defect.
+//
+// Precondition: NotifyClose is already registered. Callers barrier on it first:
+//
+//	testwait.External(t, "amqp-notify-close-registered", func() bool {
+//		m.mu.Lock(); defer m.mu.Unlock()
+//		return m.notifyCloseCh != nil
+//	}, testtime.D2s, testtime.D1ms)
+//	m.triggerBrokerClose()
 func (m *mockConnection) triggerBrokerClose() {
 	m.mu.Lock()
 	m.isClosed = true
@@ -432,15 +435,20 @@ func (m *mockConnection) triggerBrokerClose() {
 	}
 	notify := m.notifyCloseCh
 	m.mu.Unlock()
-	notify <- brokerForcedClose()
+	// Code 320 CONNECTION_FORCED, Recover=true: the canonical retryable
+	// broker-forced close, so the reconnect loop re-dials.
+	notify <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
 }
 
-// consumingStarted reports whether any issued channel has had Consume called —
-// i.e. a subscriber has passed subscribeOnce setup and is (about to be) parked in
-// consumeLoop on <-deliveries. Tests barrier on this before triggerBrokerClose so
-// they deterministically exercise the consumeLoop→errSubscriptionLost→
-// awaitReconnect→WaitConnected path rather than racing the AcquireChannel-setup
-// terminal path.
+// consumingStarted reports whether any issued channel has had Consume called.
+// At that point the subscriber has passed subscribeOnce's AcquireChannel/Qos/
+// declareTopology setup and is on the consumeLoop path — either in the brief
+// non-blocking tail (newSubscriptionRun/addRun/slog) or already parked on
+// <-deliveries. Either way it has left the AcquireChannel-setup terminal path,
+// which is what matters: tests barrier on this before triggerBrokerClose so the
+// delivery-channel close deterministically drives consumeLoop→
+// errSubscriptionLost→awaitReconnect→WaitConnected rather than racing the setup
+// path.
 func (m *mockConnection) consumingStarted() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -460,6 +468,15 @@ func (m *mockConnection) consumingStarted() bool {
 // runtime/distlock/manager_test.go::waitPendingTimers) — until resultCh produces a
 // value, then returns it. With the connection on a FakeClock the whole reconnect
 // path is deterministic; the EventuallyLong backstop never fires in practice.
+//
+// Each Advance is testtime.FastPoll, which fires the jittered backoff timer in one
+// step only while the connection's ReconnectMaxBackoff ≤ FastPoll (true for the
+// callers here). When PendingTimers()==0 — the reconnect goroutine has not yet
+// re-armed its timer — the loop simply yields on the D1ms wall-clock tick and
+// re-checks; the EventuallyLong backstop bounds the total wall time.
+//
+// T is generic so the helper serves any result channel (today <-chan error from
+// Subscribe/WaitConnected; future <-chan struct{} barriers) without duplication.
 func advanceFakeReconnectUntil[T any](t *testing.T, fc *clockmock.FakeClock, resultCh <-chan T) T {
 	t.Helper()
 	var got T
@@ -599,6 +616,10 @@ func TestNewConnection_RecoverableDialError(t *testing.T) {
 func TestConnection_Health_ConnRaceWindow(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
+	// NOTE: intentionally NOT triggerBrokerClose() — this models the
+	// IsClosed-but-connected race window (no NotifyClose, no reconnect), not a
+	// broker-forced disconnect. triggerBrokerClose would fire NotifyClose and
+	// close deliveries, changing the scenario.
 	mockConn.mu.Lock()
 	mockConn.isClosed = true
 	mockConn.mu.Unlock()
@@ -644,6 +665,10 @@ func TestConnection_AcquireChannel(t *testing.T) {
 func TestConnection_AcquireChannel_ConnRaceWindow(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
+	// NOTE: intentionally NOT triggerBrokerClose() — this models the
+	// IsClosed-but-connected race window (no NotifyClose, no reconnect), not a
+	// broker-forced disconnect. triggerBrokerClose would fire NotifyClose and
+	// close deliveries, changing the scenario.
 	mockConn.mu.Lock()
 	mockConn.isClosed = true
 	mockConn.mu.Unlock()

--- a/adapters/rabbitmq/subscriber_terminal_propagation_test.go
+++ b/adapters/rabbitmq/subscriber_terminal_propagation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
@@ -55,12 +56,17 @@ func TestSubscriber_Subscribe_PropagatesPermanentError(t *testing.T) {
 		return nil, amqp.ErrSASL
 	}
 
+	// FakeClock on the connection makes reconnect backoff deterministic: the
+	// backoff timer fires only when the test Advances fc, so propagation timing
+	// no longer races a real wall-clock deadline (the #930 flake).
+	fc := clockmock.New(time.Time{})
+
 	conn, err := NewConnection(Config{
 		URL:                 testAMQPURL,
 		ChannelPoolSize:     2,
 		ReconnectBaseDelay:  testtime.D1ms,
 		ReconnectMaxBackoff: testtime.FastPoll,
-	}, WithDialFunc(dialFunc), WithConnectionClock(clock.Real()))
+	}, WithDialFunc(dialFunc), WithConnectionClock(fc))
 	require.NoError(t, err, "initial dial must succeed (phase=0)")
 	defer func() {
 		if cErr := conn.Close(context.Background()); cErr != nil {
@@ -93,25 +99,30 @@ func TestSubscriber_Subscribe_PropagatesPermanentError(t *testing.T) {
 			}))
 	}()
 
-	// Phase 0 → 1: trigger broker-side close → reconnect dial returns ErrSASL
-	// → markPermanent → WaitConnected returns ErrAdapterAMQPConnectPermanent
-	// → awaitReconnect propagates it → Subscribe returns it.
-	phase.Store(1)
-	originalMock.mu.Lock()
-	closeNotifyCh := originalMock.notifyCloseCh
-	originalMock.isClosed = true
-	originalMock.mu.Unlock()
-	closeNotifyCh <- &amqp.Error{Code: 320, Reason: "CONNECTION_FORCED", Recover: true}
+	// Barrier: wait until the subscriber is consuming (parked in consumeLoop on
+	// <-deliveries). Without this, the broker close can land while subscribeOnce
+	// is still in setup, taking the AcquireChannel terminal path and never
+	// exercising the consumeLoop→awaitReconnect→WaitConnected contract this test
+	// guards (and the path that flaked under CI load).
+	testwait.External(t, "amqp-consumer-parked", func() bool {
+		return originalMock.consumingStarted()
+	}, testtime.D2s, testtime.D1ms)
 
-	select {
-	case subErr := <-subErrCh:
-		require.Error(t, subErr, "Subscribe must return permanent error, not nil")
-		var ecErr *errcode.Error
-		require.True(t, errors.As(subErr, &ecErr),
-			"Subscribe error must wrap *errcode.Error; got %T: %v", subErr, subErr)
-		assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code,
-			"Subscribe must propagate ErrAdapterAMQPConnectPermanent")
-	case <-time.After(testtime.EventuallyLong):
-		t.Fatal("Subscribe did not return within budget; propagation contract broken")
-	}
+	// Phase 0 → 1: trigger a broker-forced close. triggerBrokerClose closes the
+	// consumer delivery channel (so the parked consumeLoop returns
+	// errSubscriptionLost → awaitReconnect → WaitConnected) and fires NotifyClose
+	// (so the reconnect loop re-dials). The reconnect dial returns ErrSASL →
+	// markPermanent → WaitConnected returns ErrAdapterAMQPConnectPermanent →
+	// awaitReconnect propagates it → Subscribe returns it.
+	phase.Store(1)
+	originalMock.triggerBrokerClose()
+
+	// Drive the reconnect backoff deterministically via fc until Subscribe returns.
+	subErr := advanceFakeReconnectUntil(t, fc, subErrCh)
+	require.Error(t, subErr, "Subscribe must return permanent error, not nil")
+	var ecErr *errcode.Error
+	require.True(t, errors.As(subErr, &ecErr),
+		"Subscribe error must wrap *errcode.Error; got %T: %v", subErr, subErr)
+	assert.Equal(t, ErrAdapterAMQPConnectPermanent, ecErr.Code,
+		"Subscribe must propagate ErrAdapterAMQPConnectPermanent")
 }

--- a/adapters/rabbitmq/subscriber_terminal_propagation_test.go
+++ b/adapters/rabbitmq/subscriber_terminal_propagation_test.go
@@ -74,6 +74,10 @@ func TestSubscriber_Subscribe_PropagatesPermanentError(t *testing.T) {
 		}
 	}()
 
+	// Subscriber keeps a real clock: the FakeClock only needs to gate the
+	// connection-level reconnect backoff. The subscriber clock drives the
+	// graceful-drain timer, which this scenario never enters (the propagation
+	// path is consumeLoop→awaitReconnect→WaitConnected, no subscriber timer).
 	sub := NewSubscriber(conn, SubscriberConfig{
 		DLXExchange: "test.terminal.dlx",
 		Clock:       clock.Real(),


### PR DESCRIPTION
## Summary

`TestSubscriber_Subscribe_PropagatesPermanentError` occasionally hit its 5s deadline in CI (`build-test (others)` lane). 根因不是调度抖动，而是**测试 mock 缺陷**：真实 `amqp091-go` 在连接断开时会关闭 consumer 投递通道，使 `consumeLoop` 收到 channel-close → `errSubscriptionLost` → `awaitReconnect → WaitConnected`；但 `mockChannel.consumeDeliveries` 在 broker 关闭时**从不关闭**，于是 Subscribe goroutine 一旦 park 在 `consumeLoop` 就一直等到 5s ctx 超时返回 nil。旧测试只在赢得「`subscribeOnce` 仍在 setup」竞争时才通过，CI 负载下输掉竞争即红。

修复（纯测试改动，无 production 代码变更）：

1. **结构化 mock broker-close**：`mockConnection.triggerBrokerClose()` 单一忠实建模连接丢失——置 `isClosed` + 关闭所有 channel 的 `consumeDeliveries`（`sync.Once` 守护）+ 投递 `NotifyClose`。「触发 broker close 而不关投递通道」（#930 真因）不再能经该 canonical 路径表达。
2. **FakeClock 注入**：连接侧 `WithConnectionClock(clockmock)`，配 `advanceFakeReconnectUntil`（`PendingTimers` 门控 + `Advance`）驱动重连退避，功能路径零 wall-clock 依赖，`EventuallyLong` 退化为永不触发的兜底。
3. **consumeLoop park barrier**：`consumingStarted()` 确保测试在 broker close 前已 park 在 `consumeLoop`，确定性走 docstring 声称的传播路径（而非 setup 竞争路径）。
4. **统一全部 7 处手搓 broker-close 站点**到 `triggerBrokerClose()`（无混杂）：`connection_runtime_terminal_test.go`、`connection_channel_limit_test.go`、4 处 `rabbitmq_test.go` 重连测试。
5. **connection 层回归守卫** `TestWaitConnected_WokenAcrossPermanentChannelSwaps`：`markPermanent` 每个失败重连周期都重关 `connected` 通道，守住「parked WaitConnected 跨换通道窗口仍被唤醒」不变量；若未来改 `markPermanent` 为 once-only，该测试超时 RED。

## AI-robust 评级

错误夹具可表达性 **Soft → Medium**：单一忠实 `triggerBrokerClose` 路径，漏关投递通道不再是默认/简单选项。止于 Medium 而非 Hard——mock 在 `package rabbitmq` 同包，测试可直接 poke 小写字段，类型系统无法编译期禁止旁路；推 Hard 需 sealed 子包，与「同包 mock」约定冲突且对 test double 过度工程。

## 评估后刻意不改

- **集成测试 `TestIntegration_ConnectionRecovery`**：跑真实 broker（testcontainers + `rabbitmqctl close_all_connections`），真实重连本质 wall-clock 绑定，无法套 FakeClock；已用 `testwait.External` + 合理预算，测的是 happy 自愈路径（非 permanent 传播），#930 未归因于它。
- **~14 处 `close(ch.consumeDeliveries)`**：语义不同的独立 idiom（显式单通道关闭，非 broker close），保留。
- **`isClosed`-only 站点（无 NotifyClose）**：建模「连接已关」而非 broker-forced disconnect，保留。

## Test plan

- [x] `go test ./adapters/rabbitmq/ -run 'PropagatesPermanentError|WokenAcross' -race -count=50` → 2.5s 全绿（确定性）
- [x] 全包 `go test ./adapters/rabbitmq/... -race -count=5` → 35s 全绿
- [x] `go build ./...` 全仓库通过
- [x] `golangci-lint run ./adapters/rabbitmq/...` → 0 issues
- [x] archtest 自检：TEST-TIME-LITERAL-01 / TEST-SLEEP-DISCIPLINE-01 / TEST-POLLING-EXTERNAL-REASON-LITERAL-01 / CLOCK-INJECTION-* 全绿
- [x] RED 复现验证：未补投递关闭时 `PropagatesPermanentError` 确定性失败（consumeLoop park 至 5s ctx）

Refs: #930
ref: rabbitmq/amqp091-go Channel.NotifyClose / consumer delivery channel close-on-disconnect
ref: runtime/distlock/manager_test.go waitPendingTimers (PendingTimers + Advance barrier pattern)

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)