### PR TITLE
test(governance): L2-OUTBOX-ATOMICITY-COVERAGE-01 — L2 outbox 原子性测试覆盖 Hard 化 (#876)

### DIFF
--- a/.claude/rules/gocell/go-standards.md
+++ b/.claude/rules/gocell/go-standards.md
@@ -56,6 +56,8 @@ paths:
 | L3 | event replay 测试 + 投影重建测试 |
 | L4 | 状态机转换测试 + 超时/重试测试 + 延迟到达测试 |
 
+> L2 覆盖由 archtest `L2-OUTBOX-ATOMICITY-COVERAGE-01` Hard 强制（从 `consistencyLevel: L2` 枚举单元 + 按 Service 定义包名派生期望测试名 exact-name match，缺失即 CI 红）。subtype 分类（producer / hybrid / store-level）与各类测试位置/断言要求见 ADR `docs/architecture/202605241940-adr-l2-atomicity-subtypes.md`。
+
 ## 工程质量护栏
 
 - 函数认知复杂度上限 15，超过必须拆分

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ test-integration:
 		./cmd/corebundle/... \
 		./examples/ssobff/... \
 		./cells/accesscore/... \
+		./cells/configcore/... \
+		./cells/auditcore/... \
 		./runtime/bootstrap/... \
 		-count=1 -timeout 15m -v
 

--- a/adapters/postgres/audit_ledger_store_test.go
+++ b/adapters/postgres/audit_ledger_store_test.go
@@ -328,6 +328,18 @@ func TestL2Atomicity_auditcore_RollsBack(t *testing.T) {
 		Scan(&countAfter))
 	assert.Equal(t, countBefore, countAfter,
 		"store.Append must roll back atomically with outbox failure: no new row must persist")
+
+	// Negative control: a successful Append on the same store must persist a
+	// row, proving the rollback assertion above is not vacuous (i.e., Append
+	// genuinely writes a row on the happy path and the store is properly wired).
+	e2 := storetest.NewEntryFixture(t, "atomicity-control-evt", "atomicity.control", "actor", fc.Now())
+	require.NoError(t, store.Append(ctx, e2), "negative control: Append must succeed without outbox failure")
+	var countControl int
+	require.NoError(t, p.DB().QueryRow(ctx,
+		"SELECT count(*) FROM audit_entries WHERE namespace = $1", string(ns)).
+		Scan(&countControl))
+	assert.Equal(t, countAfter+1, countControl,
+		"negative control: successful Append must persist exactly one new audit_entries row")
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/postgres/audit_ledger_store_test.go
+++ b/adapters/postgres/audit_ledger_store_test.go
@@ -275,18 +275,22 @@ func TestAuditLedgerStore_AdvisoryLockSerializesAppend(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestAuditLedgerStore_OutboxAtomicityFailureProof (AUDITAPPEND-L2-FAILURE-PROOF-01)
+// TestL2Atomicity_auditcore_RollsBack (AUDITAPPEND-L2-FAILURE-PROOF-01 / L2-OUTBOX-ATOMICITY-COVERAGE-01)
 // ---------------------------------------------------------------------------
 
-// TestAuditLedgerStore_OutboxAtomicityFailureProof proves that when an outbox
-// write fails inside the same transaction as store.Append, the entire
-// transaction rolls back and no audit_entries row is written.
+// TestL2Atomicity_auditcore_RollsBack proves that when an outbox write fails
+// inside the same transaction as store.Append, the entire transaction rolls
+// back and no audit_entries row is written.
+//
+// This test satisfies L2-OUTBOX-ATOMICITY-COVERAGE-01 for the auditcore
+// cell-level L2 unit (cell-level test; shared appender package covers the
+// hybrid consumer path via TestL2Atomicity_appender_{RollsBack,ReplayIdempotent}).
 //
 // Design: the test injects a "fail-injecting outbox writer" that runs inside
 // the same txRunner.RunInTx block. store.Append succeeds within the tx, then
 // the outbox writer deliberately returns an error, causing RunInTx to rollback
 // the whole transaction. We then assert audit_entries has no new rows.
-func TestAuditLedgerStore_OutboxAtomicityFailureProof(t *testing.T) {
+func TestL2Atomicity_auditcore_RollsBack(t *testing.T) {
 	ctx := context.Background()
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	require.NoError(t, err)

--- a/cells/auditcore/internal/appender/service_integration_test.go
+++ b/cells/auditcore/internal/appender/service_integration_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package appender_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/cells/auditcore/internal/appender"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/runtime/audit/ledger"
+	"github.com/ghbvf/gocell/runtime/audit/ledger/storetest"
+)
+
+// errEmitFail is the sentinel returned by failingEmitter.Emit.
+var errEmitFail = errors.New("simulated outbox emit failure")
+
+// failingEmitter is a local outbox.Emitter that always returns errEmitFail.
+// Used to force RunInTx rollback in atomicity proof tests.
+type failingEmitter struct{}
+
+func (failingEmitter) Emit(_ context.Context, _ outbox.Entry) error { return errEmitFail }
+
+// passThroughEmitter accepts all Emit calls with no side effects.
+// Used as the "no outbox failure" emitter for idempotency proof.
+type passThroughEmitter struct{}
+
+func (passThroughEmitter) Emit(_ context.Context, _ outbox.Entry) error { return nil }
+
+// newIntegProtocol returns a ledger.Protocol for the "auditcore" namespace,
+// mirroring newTestLedgerProtocol in adapters/postgres/audit_ledger_store_test.go.
+func newIntegProtocol(t *testing.T) *ledger.Protocol {
+	t.Helper()
+	ns, err := ledger.ParseNamespaceID("auditcore")
+	require.NoError(t, err)
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	p, err := ledger.NewProtocol(
+		ledger.WithChainHMAC(key),
+		ledger.WithNamespace(ns),
+		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
+		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
+	)
+	require.NoError(t, err, "ledger.NewProtocol for auditcore namespace")
+	return p
+}
+
+// newValidEntry returns an outbox.Entry with a JSON payload that satisfies
+// ActorAcceptUserFallback (carries "actorId"). Caller may adjust ID for replay tests.
+func newValidEntry(id string) outbox.Entry {
+	return outbox.Entry{
+		ID:        id,
+		EventType: "event.user.created.v1",
+		Payload:   []byte(`{"actorId":"integ-actor-1","userId":"integ-user-1"}`),
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// countAuditRows returns the number of audit_entries rows for the auditcore namespace.
+func countAuditRows(t *testing.T, pool *adapterpg.Pool) int {
+	t.Helper()
+	var count int
+	err := pool.DB().QueryRow(context.Background(),
+		"SELECT count(*) FROM audit_entries WHERE namespace = $1", "auditcore").Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+// TestL2Atomicity_appender_RollsBack is the hybrid atomicity proof for the
+// shared appender.Service used by all four auditappend* slices.
+//
+// Contract (L2-OUTBOX-ATOMICITY-COVERAGE-01): if outbox.Emit fails inside
+// RunInTx, the transaction must roll back — no audit_entries row is persisted.
+// Negative control confirms the happy path commits exactly one row.
+func TestL2Atomicity_appender_RollsBack(t *testing.T) {
+	ctx := context.Background()
+	proto := newIntegProtocol(t)
+	fc := clockmock.New(storetest.EpochAnchor())
+	spec := appender.MustNewSpec("auditappenduser", appender.ActorAcceptUserFallback)
+
+	// --- Failure path: Emit fails → RunInTx rolls back → no audit_entries row ---
+	failPool := sharedPG.NewPerTestPool(t)
+	failTxm := adapterpg.NewTxManager(failPool)
+	failStore, err := adapterpg.NewLedgerStore(failPool.DB(), failTxm, proto, fc)
+	require.NoError(t, err)
+
+	failSvc, err := appender.NewService(
+		spec, failStore, proto, slog.Default(), fc,
+		appender.WithEmitter(failingEmitter{}),
+		appender.WithTxManager(persistence.WrapForCell(failTxm)),
+	)
+	require.NoError(t, err)
+
+	countBefore := countAuditRows(t, failPool)
+	res := failSvc.HandleEvent(ctx, newValidEntry("atomicity-evt-fail"))
+	assert.NotEqual(t, outbox.DispositionAck, res.Disposition,
+		"failing emitter must not produce Ack")
+	countAfter := countAuditRows(t, failPool)
+	assert.Equal(t, countBefore, countAfter,
+		"store.Append must roll back atomically with outbox Emit failure: no new row must persist")
+
+	// --- Positive control: pass-through emitter → Ack + exactly 1 row ---
+	okPool := sharedPG.NewPerTestPool(t)
+	okTxm := adapterpg.NewTxManager(okPool)
+	okStore, err := adapterpg.NewLedgerStore(okPool.DB(), okTxm, proto, fc)
+	require.NoError(t, err)
+
+	okSvc, err := appender.NewService(
+		spec, okStore, proto, slog.Default(), fc,
+		appender.WithEmitter(passThroughEmitter{}),
+		appender.WithTxManager(persistence.WrapForCell(okTxm)),
+	)
+	require.NoError(t, err)
+
+	okRes := okSvc.HandleEvent(ctx, newValidEntry("atomicity-evt-ok"))
+	assert.Equal(t, outbox.DispositionAck, okRes.Disposition,
+		"pass-through emitter must Ack")
+	assert.Equal(t, 1, countAuditRows(t, okPool),
+		"exactly one audit_entries row must be committed on success")
+}
+
+// TestL2Atomicity_appender_ReplayIdempotent is the consumer idempotency proof
+// for appender.Service (L2-OUTBOX-ATOMICITY-COVERAGE-01).
+//
+// Contract: delivering the same outbox.Entry twice (same entry.ID → same
+// EventID fingerprint) must Ack both times and produce exactly ONE
+// audit_entries row (ErrAuditLedgerAlreadyExists → Ack path).
+func TestL2Atomicity_appender_ReplayIdempotent(t *testing.T) {
+	ctx := context.Background()
+	proto := newIntegProtocol(t)
+	fc := clockmock.New(storetest.EpochAnchor())
+	spec := appender.MustNewSpec("auditappenduser", appender.ActorAcceptUserFallback)
+
+	pool := sharedPG.NewPerTestPool(t)
+	txm := adapterpg.NewTxManager(pool)
+	store, err := adapterpg.NewLedgerStore(pool.DB(), txm, proto, fc)
+	require.NoError(t, err)
+
+	svc, err := appender.NewService(
+		spec, store, proto, slog.Default(), fc,
+		appender.WithEmitter(passThroughEmitter{}),
+		appender.WithTxManager(persistence.WrapForCell(txm)),
+	)
+	require.NoError(t, err)
+
+	entry := newValidEntry("replay-idempotent-evt-1")
+
+	// First delivery — must Ack and commit one row.
+	first := svc.HandleEvent(ctx, entry)
+	require.Equal(t, outbox.DispositionAck, first.Disposition,
+		"first HandleEvent must Ack")
+	assert.Equal(t, 1, countAuditRows(t, pool),
+		"first delivery must produce exactly one audit_entries row")
+
+	// Second delivery of identical entry — ErrAuditLedgerAlreadyExists → Ack.
+	second := svc.HandleEvent(ctx, entry)
+	assert.Equal(t, outbox.DispositionAck, second.Disposition,
+		"idempotent replay must Ack, not Requeue/Reject")
+	assert.Equal(t, 1, countAuditRows(t, pool),
+		"idempotent replay must not add a second audit_entries row")
+}

--- a/cells/auditcore/internal/appender/testmain_integration_test.go
+++ b/cells/auditcore/internal/appender/testmain_integration_test.go
@@ -1,0 +1,25 @@
+//go:build integration
+
+package appender_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ghbvf/gocell/tests/testutil/pgshare"
+)
+
+// Package-shared PostgreSQL lifecycle: one container per test binary;
+// per-test isolation via CREATE DATABASE <test> TEMPLATE <pre-migrated>
+// clone. See tests/testutil/pgshare for the mechanics.
+//
+// The appender integration tests (TestL2Atomicity_appender_RollsBack and
+// TestL2Atomicity_appender_ReplayIdempotent) share this template, collapsing
+// two container cold starts onto one boot + two fast file clones.
+var sharedPG = pgshare.New("gocell_auditappender_test_template")
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	sharedPG.Shutdown()
+	os.Exit(code)
+}

--- a/cells/configcore/internal/testutil/testutil.go
+++ b/cells/configcore/internal/testutil/testutil.go
@@ -15,12 +15,17 @@ import (
 )
 
 // RecordingWriter records outbox entries written to it. Set Err to simulate failures.
+// Calls is incremented on every Write call, including calls that return Err,
+// so tests can assert the writer was actually invoked (not silently skipped due
+// to a wiring bug).
 type RecordingWriter struct {
 	Entries []outbox.Entry
 	Err     error
+	Calls   int
 }
 
 func (w *RecordingWriter) Write(_ context.Context, entry outbox.Entry) error {
+	w.Calls++
 	if w.Err != nil {
 		return w.Err
 	}

--- a/cells/configcore/internal/testutil/testutil.go
+++ b/cells/configcore/internal/testutil/testutil.go
@@ -15,17 +15,12 @@ import (
 )
 
 // RecordingWriter records outbox entries written to it. Set Err to simulate failures.
-// Calls is incremented on every Write call, including calls that return Err,
-// so tests can assert the writer was actually invoked (not silently skipped due
-// to a wiring bug).
 type RecordingWriter struct {
 	Entries []outbox.Entry
 	Err     error
-	Calls   int
 }
 
 func (w *RecordingWriter) Write(_ context.Context, entry outbox.Entry) error {
-	w.Calls++
 	if w.Err != nil {
 		return w.Err
 	}

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -241,7 +241,8 @@ func TestL2Atomicity_configpublish_RollsBack(t *testing.T) {
 
 	_, err = svcFail.Rollback(svcCtx, "rollback.failure.key", 1, versionBefore)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outbox")
+	assert.ErrorIs(t, err, failingWriter.err,
+		"Rollback error must wrap the injected outbox sentinel")
 
 	// config_entries version must NOT have changed (rolled back).
 	entryAfter, err := bundle.repo.GetByKey(ctx, "rollback.failure.key")
@@ -252,6 +253,25 @@ func TestL2Atomicity_configpublish_RollsBack(t *testing.T) {
 		"entry-upserted outbox row must roll back when the later rollback audit write fails")
 	assert.Equal(t, beforeAudit, countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigRollback),
 		"rollback audit outbox row must not be committed after writer failure")
+
+	// Negative control: pass-through Service on the same pool/txMgr must
+	// succeed and increment the version. This guards against a vacuous-pass
+	// where the prior version-unchanged assertion would hold even if Rollback
+	// were a no-op, by proving Rollback genuinely bumps the version when the
+	// outbox write succeeds.
+	passBundle := setupPublishBundle(t)
+	// Re-seed and publish on the pass-through bundle to get a valid Rollback target.
+	seedConfigEntry(t, passBundle, "rollback.failure.control.key", "control-value")
+	_, err = passBundle.svc.Publish(svcCtx, "rollback.failure.control.key")
+	require.NoError(t, err)
+	controlBefore, err := passBundle.repo.GetByKey(ctx, "rollback.failure.control.key")
+	require.NoError(t, err)
+	_, err = passBundle.svc.Rollback(svcCtx, "rollback.failure.control.key", 1, controlBefore.Version)
+	require.NoError(t, err, "negative control: Rollback must succeed with pass-through writer")
+	controlAfter, err := passBundle.repo.GetByKey(ctx, "rollback.failure.control.key")
+	require.NoError(t, err)
+	assert.Equal(t, controlBefore.Version+1, controlAfter.Version,
+		"negative control: Rollback must increment config_entries version on success")
 }
 
 // TestL2Atomicity_configpublish_RollsBack_Publish verifies that when the outbox
@@ -284,6 +304,8 @@ func TestL2Atomicity_configpublish_RollsBack_Publish(t *testing.T) {
 
 	_, err = svcFail.Publish(svcCtx, "rollback.publish.key")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, failingWriter.err,
+		"Publish error must wrap the injected outbox sentinel")
 
 	// Outbox-side: the version-published row must NOT exist (rolled back).
 	after := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigVersionPublished)
@@ -297,6 +319,19 @@ func TestL2Atomicity_configpublish_RollsBack_Publish(t *testing.T) {
 	_, verErr := bundle.repo.GetVersion(ctx, liveEntry.ID, 1)
 	require.Error(t, verErr,
 		"config_versions row must not exist when outbox write fails (atomic Publish rollback)")
+
+	// Negative control: pass-through Service on a fresh bundle must succeed
+	// and leave a config_versions row. This proves Publish genuinely persists
+	// the version on the happy path, making the rollback assertion non-vacuous.
+	passBundle := setupPublishBundle(t)
+	seedConfigEntry(t, passBundle, "rollback.publish.control.key", "control-value")
+	_, err = passBundle.svc.Publish(svcCtx, "rollback.publish.control.key")
+	require.NoError(t, err, "negative control: Publish must succeed with pass-through writer")
+	controlEntry, err := passBundle.repo.GetByKey(ctx, "rollback.publish.control.key")
+	require.NoError(t, err)
+	_, err = passBundle.repo.GetVersion(ctx, controlEntry.ID, 1)
+	require.NoError(t, err,
+		"negative control: config_versions row must exist after successful Publish")
 }
 
 type failOnWriteNumberWriter struct {

--- a/cells/configcore/slices/configpublish/service_integration_test.go
+++ b/cells/configcore/slices/configpublish/service_integration_test.go
@@ -204,10 +204,10 @@ func TestRollback_AtomicWithOutbox(t *testing.T) {
 		"Rollback must co-commit exactly one %s outbox row (L2 atomicity)", domain.TopicConfigRollback)
 }
 
-// TestRollback_AtomicWithOutbox_FailureRollsBackBoth verifies that when the outbox
-// write fails during Rollback, both the config_entries update and the outbox write
-// are rolled back (transaction atomicity).
-func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
+// TestL2Atomicity_configpublish_RollsBack verifies that when the outbox write
+// fails during Rollback, both the config_entries update and the outbox write
+// are rolled back (transaction atomicity — L2 canonical rollback proof).
+func TestL2Atomicity_configpublish_RollsBack(t *testing.T) {
 	bundle := setupPublishBundle(t)
 	ctx := context.Background()
 	svcCtx := adminIntegCtx()
@@ -252,6 +252,51 @@ func TestRollback_AtomicWithOutbox_FailureRollsBackBoth(t *testing.T) {
 		"entry-upserted outbox row must roll back when the later rollback audit write fails")
 	assert.Equal(t, beforeAudit, countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigRollback),
 		"rollback audit outbox row must not be committed after writer failure")
+}
+
+// TestL2Atomicity_configpublish_RollsBack_Publish verifies that when the outbox
+// write fails during Publish, both the config_versions row and the outbox write
+// are rolled back (transaction atomicity — per-mutation L2 rollback proof).
+func TestL2Atomicity_configpublish_RollsBack_Publish(t *testing.T) {
+	bundle := setupPublishBundle(t)
+	ctx := context.Background()
+	svcCtx := adminIntegCtx()
+
+	// Seed a config entry; the seed itself does not emit a version-published row.
+	seedConfigEntry(t, bundle, "rollback.publish.key", "publish-value")
+
+	// Baseline outbox count before the failing Publish.
+	before := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigVersionPublished)
+	require.Equal(t, 0, before, "baseline: no version-published rows before failing Publish")
+
+	// Inject a writer that always fails, sharing the bundle's repo/txMgr.
+	failingWriter := &failOnWriteNumberWriter{
+		delegate: adapterpg.NewOutboxWriter(clock.Real()),
+		failOn:   1, // fail on the very first Write (the version-published event)
+		err:      errors.New("outbox broker down"),
+	}
+	svcFail, err := NewService(
+		bundle.repo, slog.Default(), clock.Real(),
+		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
+		WithTxManager(persistence.WrapForCell(bundle.txMgr)),
+	)
+	require.NoError(t, err)
+
+	_, err = svcFail.Publish(svcCtx, "rollback.publish.key")
+	require.Error(t, err)
+
+	// Outbox-side: the version-published row must NOT exist (rolled back).
+	after := countOutboxRowsByEventType(t, bundle.pool, domain.TopicConfigVersionPublished)
+	assert.Equal(t, before, after,
+		"version-published outbox row must roll back when outbox write fails")
+
+	// Domain-side: no config_versions row must have been committed.
+	// GetVersion requires a configID; obtain it via the live entry.
+	liveEntry, getErr := bundle.repo.GetByKey(ctx, "rollback.publish.key")
+	require.NoError(t, getErr, "live config_entries row must still exist after rolled-back Publish")
+	_, verErr := bundle.repo.GetVersion(ctx, liveEntry.ID, 1)
+	require.Error(t, verErr,
+		"config_versions row must not exist when outbox write fails (atomic Publish rollback)")
 }
 
 type failOnWriteNumberWriter struct {

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -187,13 +187,11 @@ func TestL2Atomicity_configwrite_RollsBack(t *testing.T) {
 	_, err = svc.Create(adminIntegCtx(), CreateInput{Key: "rollback.test", Value: "v"})
 	require.Error(t, err)
 	// Exact-sentinel check: the error must wrap the injected sentinel, not a
-	// coincidental substring match from unrelated infrastructure.
+	// coincidental substring match from unrelated infrastructure. This also
+	// proves Write was actually invoked — the sentinel instance only exists
+	// inside the writer, so a wiring bug that skipped Write could not produce it.
 	assert.ErrorIs(t, err, failingWriter.Err,
-		"Create error must wrap the injected outbox sentinel")
-	// Write-was-invoked proof: Calls must be 1; a wiring bug that skips Write
-	// would still produce a rollback but would not exercise the L2 path at all.
-	assert.Equal(t, 1, failingWriter.Calls,
-		"writer.Write must be invoked exactly once before rollback")
+		"Create error must wrap the injected outbox sentinel (proves Write was invoked)")
 
 	// config_entries row must NOT exist (rolled back).
 	_, getErr := repo.GetByKey(ctx, "rollback.test")
@@ -263,9 +261,7 @@ func TestL2Atomicity_configwrite_RollsBack_Update(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, failingWriter.Err,
-		"Update error must wrap the injected outbox sentinel")
-	assert.Equal(t, 1, failingWriter.Calls,
-		"writer.Write must be invoked exactly once before Update rollback")
+		"Update error must wrap the injected outbox sentinel (proves Write was invoked)")
 
 	// config_entries must still be at version 1 (UPDATE rolled back).
 	afterEntry, getErr := repo.GetByKey(ctx, "rollback.update.key")
@@ -311,9 +307,7 @@ func TestL2Atomicity_configwrite_RollsBack_Delete(t *testing.T) {
 	deleteErr := failSvc.Delete(adminIntegCtx(), "rollback.delete.key", 1)
 	require.Error(t, deleteErr)
 	assert.ErrorIs(t, deleteErr, failingWriter.Err,
-		"Delete error must wrap the injected outbox sentinel")
-	assert.Equal(t, 1, failingWriter.Calls,
-		"writer.Write must be invoked exactly once before Delete rollback")
+		"Delete error must wrap the injected outbox sentinel (proves Write was invoked)")
 
 	// config_entries row must still exist (DELETE rolled back).
 	afterEntry, getErr := repo.GetByKey(ctx, "rollback.delete.key")

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -159,10 +159,10 @@ func TestDelete_AtomicWithOutbox(t *testing.T) {
 		"deleted entry must return ErrConfigRepoNotFound")
 }
 
-// TestCreate_RollbackOnOutboxFailure verifies that when the outbox write
-// returns a permanent error, the config_entries row is absent (transaction
-// rolled back atomically).
-func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
+// TestL2Atomicity_configwrite_RollsBack verifies that when the outbox write
+// returns a permanent error on Create, the config_entries row is absent
+// (transaction rolled back atomically — L2 canonical rollback proof).
+func TestL2Atomicity_configwrite_RollsBack(t *testing.T) {
 	ctx := context.Background()
 	pool := sharedPG.NewPerTestPool(t)
 
@@ -190,4 +190,97 @@ func TestCreate_RollbackOnOutboxFailure(t *testing.T) {
 	require.ErrorAs(t, getErr, &ec)
 	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code,
 		"config entry must not persist after outbox-failure rollback")
+}
+
+// TestL2Atomicity_configwrite_RollsBack_Update verifies that when the outbox
+// write fails during Update, the config_entries row stays at the pre-update
+// version (Update rolled back atomically — per-mutation L2 rollback proof).
+func TestL2Atomicity_configwrite_RollsBack_Update(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedPG.NewPerTestPool(t)
+	txMgr := adapterpg.NewTxManager(pool)
+
+	session := cellpg.NewSession(pool.DB())
+	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil, clock.Real())
+
+	// Phase 1: seed the entry with a pass-through writer so the Create commits.
+	passSvc, err := NewService(repo, slog.Default(), clock.Real(),
+		WithEmitter(testoutbox.MustEmitter(t, adapterpg.NewOutboxWriter(clock.Real()))),
+		WithTxManager(persistence.WrapForCell(txMgr)),
+	)
+	require.NoError(t, err)
+	_, err = passSvc.Create(adminIntegCtx(), CreateInput{Key: "rollback.update.key", Value: "initial"})
+	require.NoError(t, err)
+
+	// Verify the seed committed at version 1.
+	seedEntry, err := repo.GetByKey(ctx, "rollback.update.key")
+	require.NoError(t, err)
+	require.Equal(t, 1, seedEntry.Version, "seed must commit at version 1")
+
+	// Phase 2: construct a second Service against the SAME pool/txMgr but with
+	// a failing writer. Update must error and the row must stay at version 1.
+	failingWriter := &cctestutil.RecordingWriter{Err: errors.New("outbox broker down")}
+	failSvc, err := NewService(repo, slog.Default(), clock.Real(),
+		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
+		WithTxManager(persistence.WrapForCell(txMgr)),
+	)
+	require.NoError(t, err)
+
+	_, err = failSvc.Update(adminIntegCtx(), UpdateInput{
+		Key:             "rollback.update.key",
+		Value:           "should-not-persist",
+		ExpectedVersion: 1,
+	})
+	require.Error(t, err)
+
+	// config_entries must still be at version 1 (UPDATE rolled back).
+	afterEntry, getErr := repo.GetByKey(ctx, "rollback.update.key")
+	require.NoError(t, getErr)
+	assert.Equal(t, 1, afterEntry.Version,
+		"config_entries version must not change when outbox write fails (atomic Update rollback)")
+	assert.Equal(t, "initial", afterEntry.Value,
+		"config_entries value must not change when outbox write fails (atomic Update rollback)")
+}
+
+// TestL2Atomicity_configwrite_RollsBack_Delete verifies that when the outbox
+// write fails during Delete, the config_entries row is still present
+// (Delete rolled back atomically — per-mutation L2 rollback proof).
+func TestL2Atomicity_configwrite_RollsBack_Delete(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedPG.NewPerTestPool(t)
+	txMgr := adapterpg.NewTxManager(pool)
+
+	session := cellpg.NewSession(pool.DB())
+	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil, clock.Real())
+
+	// Phase 1: seed the entry with a pass-through writer so the Create commits.
+	passSvc, err := NewService(repo, slog.Default(), clock.Real(),
+		WithEmitter(testoutbox.MustEmitter(t, adapterpg.NewOutboxWriter(clock.Real()))),
+		WithTxManager(persistence.WrapForCell(txMgr)),
+	)
+	require.NoError(t, err)
+	_, err = passSvc.Create(adminIntegCtx(), CreateInput{Key: "rollback.delete.key", Value: "to-be-deleted"})
+	require.NoError(t, err)
+
+	// Verify the seed committed.
+	_, err = repo.GetByKey(ctx, "rollback.delete.key")
+	require.NoError(t, err, "seed entry must exist before the failing Delete")
+
+	// Phase 2: failing-writer Service — Delete must error and the row must survive.
+	failingWriter := &cctestutil.RecordingWriter{Err: errors.New("outbox broker down")}
+	failSvc, err := NewService(repo, slog.Default(), clock.Real(),
+		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
+		WithTxManager(persistence.WrapForCell(txMgr)),
+	)
+	require.NoError(t, err)
+
+	deleteErr := failSvc.Delete(adminIntegCtx(), "rollback.delete.key", 1)
+	require.Error(t, deleteErr)
+
+	// config_entries row must still exist (DELETE rolled back).
+	afterEntry, getErr := repo.GetByKey(ctx, "rollback.delete.key")
+	require.NoError(t, getErr,
+		"config_entries row must still exist when outbox write fails (atomic Delete rollback)")
+	assert.Equal(t, "to-be-deleted", afterEntry.Value,
+		"config_entries value must be unchanged when outbox write fails (atomic Delete rollback)")
 }

--- a/cells/configcore/slices/configwrite/service_integration_test.go
+++ b/cells/configcore/slices/configwrite/service_integration_test.go
@@ -162,17 +162,22 @@ func TestDelete_AtomicWithOutbox(t *testing.T) {
 // TestL2Atomicity_configwrite_RollsBack verifies that when the outbox write
 // returns a permanent error on Create, the config_entries row is absent
 // (transaction rolled back atomically — L2 canonical rollback proof).
+//
+// Negative control: after asserting the rollback, a second Service with a
+// pass-through writer performs the same Create and asserts the row persists.
+// This guards against a vacuous-pass scenario where the test setup itself is
+// broken (e.g., the key was never written in the first place).
 func TestL2Atomicity_configwrite_RollsBack(t *testing.T) {
 	ctx := context.Background()
 	pool := sharedPG.NewPerTestPool(t)
 
 	session := cellpg.NewSession(pool.DB())
 	repo := cellpg.NewConfigRepository(session, crypto.NoopTransformer{}, nil, clock.Real())
+	txMgr := adapterpg.NewTxManager(pool)
 
 	// Inject a writer that always fails — simulates outbox unavailable.
 	failingWriter := &cctestutil.RecordingWriter{Err: errors.New("outbox broker down")}
 
-	txMgr := adapterpg.NewTxManager(pool)
 	svc, err := NewService(repo, slog.Default(), clock.Real(),
 		WithEmitter(testoutbox.MustEmitter(t, failingWriter)),
 		WithTxManager(persistence.WrapForCell(txMgr)),
@@ -181,7 +186,14 @@ func TestL2Atomicity_configwrite_RollsBack(t *testing.T) {
 
 	_, err = svc.Create(adminIntegCtx(), CreateInput{Key: "rollback.test", Value: "v"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outbox")
+	// Exact-sentinel check: the error must wrap the injected sentinel, not a
+	// coincidental substring match from unrelated infrastructure.
+	assert.ErrorIs(t, err, failingWriter.Err,
+		"Create error must wrap the injected outbox sentinel")
+	// Write-was-invoked proof: Calls must be 1; a wiring bug that skips Write
+	// would still produce a rollback but would not exercise the L2 path at all.
+	assert.Equal(t, 1, failingWriter.Calls,
+		"writer.Write must be invoked exactly once before rollback")
 
 	// config_entries row must NOT exist (rolled back).
 	_, getErr := repo.GetByKey(ctx, "rollback.test")
@@ -190,6 +202,24 @@ func TestL2Atomicity_configwrite_RollsBack(t *testing.T) {
 	require.ErrorAs(t, getErr, &ec)
 	assert.Equal(t, errcode.ErrConfigRepoNotFound, ec.Code,
 		"config entry must not persist after outbox-failure rollback")
+
+	// Negative control: pass-through Service on the same pool/txMgr must
+	// succeed, proving the rollback assertion above is not vacuously trivial
+	// (i.e., Create genuinely writes a row on the happy path).
+	passSvc, err := NewService(repo, slog.Default(), clock.Real(),
+		WithEmitter(testoutbox.MustEmitter(t, adapterpg.NewOutboxWriter(clock.Real()))),
+		WithTxManager(persistence.WrapForCell(txMgr)),
+	)
+	require.NoError(t, err)
+	got, err := passSvc.Create(adminIntegCtx(), CreateInput{Key: "rollback.test", Value: "v"})
+	require.NoError(t, err, "negative control: Create must succeed with pass-through writer")
+	assert.Equal(t, "rollback.test", got.Key)
+	assert.Equal(t, "v", got.Value)
+
+	controlEntry, getErr := repo.GetByKey(ctx, "rollback.test")
+	require.NoError(t, getErr, "negative control: config_entries row must exist after successful Create")
+	assert.Equal(t, "v", controlEntry.Value,
+		"negative control: persisted value must match the Create input")
 }
 
 // TestL2Atomicity_configwrite_RollsBack_Update verifies that when the outbox
@@ -232,6 +262,10 @@ func TestL2Atomicity_configwrite_RollsBack_Update(t *testing.T) {
 		ExpectedVersion: 1,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, failingWriter.Err,
+		"Update error must wrap the injected outbox sentinel")
+	assert.Equal(t, 1, failingWriter.Calls,
+		"writer.Write must be invoked exactly once before Update rollback")
 
 	// config_entries must still be at version 1 (UPDATE rolled back).
 	afterEntry, getErr := repo.GetByKey(ctx, "rollback.update.key")
@@ -276,6 +310,10 @@ func TestL2Atomicity_configwrite_RollsBack_Delete(t *testing.T) {
 
 	deleteErr := failSvc.Delete(adminIntegCtx(), "rollback.delete.key", 1)
 	require.Error(t, deleteErr)
+	assert.ErrorIs(t, deleteErr, failingWriter.Err,
+		"Delete error must wrap the injected outbox sentinel")
+	assert.Equal(t, 1, failingWriter.Calls,
+		"writer.Write must be invoked exactly once before Delete rollback")
 
 	// config_entries row must still exist (DELETE rolled back).
 	afterEntry, getErr := repo.GetByKey(ctx, "rollback.delete.key")

--- a/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
+++ b/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
@@ -111,6 +111,12 @@ archtest 将期望名集合与实际 `go/ast` FuncDecl 精确名 match，任何�
 
 **Enforcement 运行位置（nightly，非 PR-time）**：`L2-OUTBOX-ATOMICITY-COVERAGE-01` 由 `archtest-nightly.yml`（16-shard）执行；**不**纳入 PR-time `hack/verify-archtest-invariants.sh`。后者由 ADR `202605120000` §Amendment 2026-05-23 §D8 冻结为 4 类核心运行时 invariant（clock / duration / testtime / panic），扩充该集合需另行 amend 该 ADR，不在本 PR 范围。本 coverage gate 选择 nightly 的理由：(1) 它守护的是 integration 测试的**存在性**，而被守护的测试本身 `//go:build integration` 依赖 Docker、只在 CI integration 分片实跑，PR-time 无法验证其真实通过；(2) `RunTypedProduction` 全量 typed-load 成本与 nightly 预算更匹配。新 L2 单元漏测试 → 当晚 nightly 红 + 本地 `make verify` 即时红。若未来需 PR-time 即时阻断，走 ADR `202605120000` §D8 amendment 把本 ID 加入冻结集（届时按 §"ADR amendment 落地必查"逐行重评威胁矩阵）。
 
+**Gate 粒度 = per-unit（非 per-mutation）**：本 archtest 对每个 L2 slice 强制**一个** canonical `TestL2Atomicity_<pkg>_RollsBack`（hybrid 另加 `_ReplayIdempotent`），对齐 issue #876 的明文粒度「按 `consistencyLevel: L2` 枚举所有 L2 单元」。同一 slice 的多条 outbox mutation 路径（如 configwrite 的 Create/Update/Delete、configpublish 的 Publish/Rollback）各自的 `*_RollsBack_<Mutation>` 测试是**有意保留的 defense-in-depth，不在本 gate 的 Hard 期望集内**——删除它们不会触发 archtest 红。这是**已知且文档化**的边界，不是隐式 false-green：
+
+- per-unit gate 已完整满足 #876 的 Hard 验收（每个 L2 单元必须有原子性证明）。
+- per-mutation Hard 强制是 #876 之上的增强；其唯一 AI-robust 正解是从 Service「调 `RunInTx` 的 exported emitting method」typed 派生期望名（避免手列 suffix 这一 Medium 倒退）。该派生对 identitymanage（6 个 emitting method）等多 mutation slice 会显著扩展 E2E 测试面，且 `sessionlogin.IssueForUser` 等非-HTTP internal 路径无法经 E2E harness 驱动——实为 Cx4，与本 PR 体量不成比例。
+- 故按 `feedback_pr_scope_carveouts_must_backlog` 登记为独立 backlog（cap-14 / type-test / pri-p2）跟踪 per-mutation typed 派生升级，不在本 PR 内做、也不以手列 suffix 临时打补丁。
+
 ---
 
 ## 威胁矩阵

--- a/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
+++ b/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
@@ -1,0 +1,161 @@
+# ADR — L2 原子性测试分类体系 + Hard enforcement（L2-OUTBOX-ATOMICITY-COVERAGE-01）
+
+## Status
+
+Accepted (2026-05-24)
+
+## Implementation
+
+PR 在分支 `062-l2-atomicity-coverage`（TBD）
+
+## Closes
+
+issue #876
+
+---
+
+## Context
+
+**L2（OutboxFact）一致性等级**要求"本地事务 + outbox 发布"原子提交：domain row 与 outbox row 必须在同一 `RunInTx` 块内落盘，任一侧失败则全部回滚。`.claude/rules/gocell/go-standards.md` §各级测试要求明确规定 L2 必须有"outbox 原子性测试 + consumer 幂等测试"。
+
+**升级前是 Soft enforcement**（人工记忆 + review）：
+
+- 12 个 L2 单元中，只有 rbacassign（E2E 通路，#873）和 auditcore store 层（`adapters/postgres/audit_ledger_store_test.go`）提供了原子性证明，其余 10 个静默漂移。
+- issue #655 即因漏报 L2 原子性证据而被标记；无机器护栏，AI 实施者随时可绕过。
+- issue #876 原文把 auditappend 族 4 个 slice（auditappendconfig / auditappendrole / auditappendsession / auditappenduser）称作"consumer-only"，暗示其不需要原子性测试。
+
+**本 ADR 核实并修正**：auditappend 族不是纯消费者。4 个 slice 通过 Go type alias 共享同一 `cells/auditcore/internal/appender/service.go::Service`：
+
+```go
+// cells/auditcore/slices/auditappendconfig/service.go
+type Service = appender.Service
+```
+
+`appender.Service.HandleEvent` 在同一 `RunInTx` 内执行 `store.Append + outbox.Emit`，并实现 ConsumerBase 幂等 replay 语义。因此它是 **hybrid**（消费域事件 **并** 发布 `event.audit.appended.v1`），同时需要原子性测试与 consumer 幂等测试。
+
+---
+
+## Decision
+
+### D1 — L2 subtype 三分类法
+
+| 子类型 | 定义 | 实例 | 适用规则 |
+|--------|------|------|---------|
+| **producer** | HTTP/command 触发 domain write + outbox publish 同 tx | sessionlogin / sessionlogout / identitymanage / setup / rbacassign / configpublish / configwrite | 原子性测试（必须）；无 consumer 幂等要求 |
+| **hybrid** | event ingest + ledger/projection write + outbox publish + 幂等 replay 同 tx | auditappendconfig / auditappendrole / auditappendsession / auditappenduser（折叠到 `appender`） | 原子性测试（必须）+ consumer 幂等测试（必须） |
+| **store-level** | cell 级 store 原子性，无 service 编排 | auditcore cell | 原子性测试（必须）；无 consumer 幂等要求 |
+
+**原子性测试断言要求（producer / hybrid / store-level 共同）**：
+
+1. 正向控制：outbox writer fail → domain row 不持久（事务整体回滚）。
+2. 负向控制：清除 outbox writer 注入 → domain row 正常持久（确认 row 本身是合法写入，而非测试副作用导致 0 行）。
+
+**consumer 幂等测试断言要求（hybrid 专属）**：
+
+1. 正常路径：相同 `EventID` 第二次 replay → `Ack` 且 `audit_entries` 行数不变（无重复 row）。
+
+### D2 — 期望测试名从代码 SoR 确定性派生（Hard）
+
+archtest `L2-OUTBOX-ATOMICITY-COVERAGE-01` 的期望测试名不靠手工维护的 map、命名公约或注释豁免，而是通过以下确定性派生链计算：
+
+**上游枚举**（枚举集 SoR）：从 `cells/*/cell.yaml` + `cells/*/slices/*/slice.yaml` 的 `consistencyLevel: L2` 字段提取 L2 单元集合。metadata 字段非空强制（`gocell validate` 的既有 MSL-01 规则兜底），任何 L2 声明无需人工维护即被自动纳入枚举。
+
+**定义包名派生**（期望名 SoR）：对每个 L2 slice，archtest 用 `go/types` 加载该 slice 的 Service 类型，调用 `types.Unalias` 解析别名后，取类型的**定义包名**（`Obj().Pkg().Name()`）作为 `<P>`。期望测试名规则：
+
+- slice 级 producer → `TestL2Atomicity_<P>_RollsBack`
+- slice 级 hybrid（Service 有 `HandleEvent(ctx context.Context, entry outbox.Entry) outbox.HandleResult` 方法签名）→ `TestL2Atomicity_<P>_RollsBack` + `TestL2Atomicity_<P>_ReplayIdempotent`
+- cell 级单元（无 slice Service，由 cell.yaml `consistencyLevel: L2` 直接声明）→ `TestL2Atomicity_<cellID>_RollsBack`
+
+archtest 将期望名集合与实际 `go/ast` FuncDecl 精确名 match，任何缺失即 CI 红。
+
+### D3 — shared-impl 折叠用 go/types alias 解析（Hard）
+
+4 个 auditappend slice 的 Service 字段类型是 `type Service = appender.Service`（Go type alias）。archtest 经 `types.Unalias` 解析后全部归结到定义包 `appender`，期望名统一为 `TestL2Atomicity_appender_RollsBack` 和 `TestL2Atomicity_appender_ReplayIdempotent`，天然折叠为 1 份测试，无需手工 allowlist。
+
+若未来有人去掉 alias（改为 4 个 slice 各自定义 Service 结构体），期望集自动扩展为 4 个独立包名的期望名集合，强制各 slice 提供独立测试，不会静默漏掉。反向自检测试 `_AliasFoldsToSinglePackage` 断言当前 4 个 slice 的 Unalias 结果均指向 `appender` 包。
+
+### D4 — 既有测试归一重命名（不向后兼容，单源）
+
+| 旧名 | 新名 |
+|------|------|
+| `TestAuditLedgerStore_OutboxAtomicityFailureProof` | `TestL2Atomicity_auditcore_RollsBack` |
+| `TestL2_RbacAssign_OutboxWriteFailure_RollsBack` | `TestL2Atomicity_rbacassign_RollsBack` |
+| configcore 各 slice 现有 rollback 测试 | 并入 canonical `TestL2Atomicity_<P>_RollsBack` |
+
+旧名不留别名。项目无外部消费方，不考虑向后兼容。
+
+---
+
+## AI-robust 评级
+
+| 维度 | 机制 | 评级 |
+|------|------|------|
+| 上游枚举（L2 单元发现） | `cells/*/cell.yaml` + `slice.yaml` `consistencyLevel: L2` 字段，`gocell validate` MSL-01 强制非空，元数据 SoR 不可绕过 | **Hard** |
+| typed 期望名派生 | `go/types` 加载 + `types.Unalias` 确定性解析，无启发式字符串锚点 | **Hard** |
+| alias 折叠 | `types.Unalias` 确定性，go/types 结果与 AST 字符串形态无关 | **Hard** |
+| 下游 exact-name AST match | FuncDecl 精确名匹配，无 string-comment 逃逸路径 | **Hard** |
+| `_BodyAssertsRollback` 自检 | 测试体是否断言了 rollback 语义是静态分析不可判定问题，非可升级 carve-out，仅尽力而为（见下文说明） | **Medium**（接受，不入 backlog） |
+
+**Funnel 双向锁评级**（依 `.claude/rules/gocell/ai-robust.md` §"Funnel 双向锁评级"）：
+
+| 方向 | 评级 |
+|------|------|
+| 上游（L2 单元枚举） | **Hard**（metadata SoR + gocell validate 强制） |
+| 下游（期望名 match） | **Hard**（FuncDecl 精确名 AST match） |
+
+双侧均 Hard，构成闭环 funnel。
+
+**`_BodyAssertsRollback` 为何不升 Hard**：判定"函数体是否真的断言了 rollback 语义"等价于判定函数语义等价性，属 Go 静态分析不可判定（undecidable）范围；不存在低成本且正确的 Hard 路径。该 Medium 项是实际语义边界，非技术债务，不开 backlog 追踪，文档注明即可。
+
+形态参照 `.claude/rules/gocell/ai-robust.md` §"Hard 范本目录"中的"codegen funnel + golden"（metadata-driven 枚举 + 代码 SoR 派生）与"string-typed concept funnel"（类型信息精确解析代替字符串启发式）的近亲组合。
+
+---
+
+## 威胁矩阵
+
+| 威胁 | 缓解 |
+|------|------|
+| 新增 L2 slice 漏写原子性测试 | 上游枚举自动从 slice.yaml `consistencyLevel: L2` 发现；下游期望名 match 失败 → CI 红 ✓ |
+| L2 降级为 L1/L0 逃逸检测 | `consistencyLevel` 变更触发 `gocell validate` MSL-01 + 其他治理规则 + code review；降级本身即语义变更，需显式决策 ✓ |
+| 测试函数改名绕过 match | exact-name FuncDecl 匹配，任何改名立即导致期望集 diff 失败 ✓ |
+| 空 body / `t.Skip` 假装测试存在 | `_BodyAssertsRollback` 自检（Medium，尽力而为）；full review gate 兜底 ⚠️（接受，见上文） |
+| auditappend 去 alias 绕过折叠 | `_AliasFoldsToSinglePackage` 反向自检：断言 4 个 slice 的 Unalias 均指向 `appender` 包，去 alias 后自检失败 ✓ |
+| 测试漏 `//go:build integration` tag | archtest 解析 build constraint，要求 producer/hybrid 的 `_RollsBack` / `_ReplayIdempotent` 测试携带 integration tag（否则无 PG 实例的 CI 会静默 skip，无原子性保护） ✓ |
+| L2 slice 的 Service 改名/删除致期望集静默缩水 | `_ServiceLookupTotal` 反向自检：断言 go/types 加载到的 L2 Service 总数 ≥ 已知下限，防 Service 符号消失导致枚举静默归零 ✓ |
+| 期望名派生公式依赖 go/types，但 go/types 加载失败静默跳过 | archtest 在 `RunTyped` 错误路径 `t.Fatal`，不静默跳过；`_ServiceLookupTotal` 额外守 ✓ |
+
+---
+
+## Implementation matrix
+
+```
+Contract: L2-OUTBOX-ATOMICITY-COVERAGE-01 archtest（Soft → Hard enforcement）
+Change: 引入三分类法 + metadata-driven 期望名派生 + alias 折叠；删除人工 map / 命名公约
+Implementations:
+  [x] accesscore L2 slices（sessionlogin / sessionlogout / identitymanage / setup / rbacassign）
+      → tests/integration/l2atomicity/ 下各 _RollsBack 函数归一命名
+  [x] configcore L2 slices（configpublish / configwrite）
+      → 各 slice service_integration_test.go 归一命名
+  [x] auditcore L2 hybrid（auditappend* 4 个 slice 折叠到 appender）
+      → cells/auditcore/internal/appender/service_integration_test.go
+         TestL2Atomicity_appender_RollsBack + TestL2Atomicity_appender_ReplayIdempotent
+  [x] auditcore store-level
+      → adapters/postgres/audit_ledger_store_test.go
+         TestL2Atomicity_auditcore_RollsBack（旧名: TestAuditLedgerStore_OutboxAtomicityFailureProof）
+Conformance test: tools/archtest.TestL2OutboxAtomicityCoverage
+Repro: go test ./tools/archtest/... -run TestL2OutboxAtomicityCoverage
+Dependent contracts (governance scan): none
+```
+
+---
+
+## 参考
+
+- `.claude/rules/gocell/go-standards.md` §各级测试要求
+- `.claude/rules/gocell/ai-robust.md` §"Hard 范本目录" / §"Funnel 双向锁评级"
+- `tools/archtest/seed_role_iface_test.go`（metadata-driven Hard 枚举范本）
+- `tools/archtest/l2_outbox_atomicity_coverage_test.go`（本 ADR 的 enforcement 载体）
+- issue #876（原始 ask：补齐 12 个 L2 单元原子性证明 + Machine enforcement）
+- PR #873（rbacassign L2 单点补齐，`TestL2_RbacAssign_OutboxWriteFailure_RollsBack` 先驱）
+- issue #655（Soft 漏报证据：L2 slice 无原子性测试且无拦截机制）
+- ADR `docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md`（同期 Soft→Hard 升级参照，metadata type-aware discovery 范本）

--- a/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
+++ b/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
@@ -6,7 +6,7 @@ Accepted (2026-05-24)
 
 ## Implementation
 
-PR 在分支 `062-l2-atomicity-coverage`（TBD）
+PR #950（分支 `062-l2-atomicity-coverage`）
 
 ## Closes
 
@@ -108,6 +108,8 @@ archtest 将期望名集合与实际 `go/ast` FuncDecl 精确名 match，任何�
 **`_BodyAssertsRollback` 为何不升 Hard**：判定"函数体是否真的断言了 rollback 语义"等价于判定函数语义等价性，属 Go 静态分析不可判定（undecidable）范围；不存在低成本且正确的 Hard 路径。该 Medium 项是实际语义边界，非技术债务，不开 backlog 追踪，文档注明即可。
 
 形态参照 `.claude/rules/gocell/ai-robust.md` §"Hard 范本目录"中的"codegen funnel + golden"（metadata-driven 枚举 + 代码 SoR 派生）与"string-typed concept funnel"（类型信息精确解析代替字符串启发式）的近亲组合。
+
+**Enforcement 运行位置（nightly，非 PR-time）**：`L2-OUTBOX-ATOMICITY-COVERAGE-01` 由 `archtest-nightly.yml`（16-shard）执行；**不**纳入 PR-time `hack/verify-archtest-invariants.sh`。后者由 ADR `202605120000` §Amendment 2026-05-23 §D8 冻结为 4 类核心运行时 invariant（clock / duration / testtime / panic），扩充该集合需另行 amend 该 ADR，不在本 PR 范围。本 coverage gate 选择 nightly 的理由：(1) 它守护的是 integration 测试的**存在性**，而被守护的测试本身 `//go:build integration` 依赖 Docker、只在 CI integration 分片实跑，PR-time 无法验证其真实通过；(2) `RunTypedProduction` 全量 typed-load 成本与 nightly 预算更匹配。新 L2 单元漏测试 → 当晚 nightly 红 + 本地 `make verify` 即时红。若未来需 PR-time 即时阻断，走 ADR `202605120000` §D8 amendment 把本 ID 加入冻结集（届时按 §"ADR amendment 落地必查"逐行重评威胁矩阵）。
 
 ---
 

--- a/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
+++ b/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
@@ -115,7 +115,7 @@ archtest 将期望名集合与实际 `go/ast` FuncDecl 精确名 match，任何�
 
 - per-unit gate 已完整满足 #876 的 Hard 验收（每个 L2 单元必须有原子性证明）。
 - per-mutation Hard 强制是 #876 之上的增强；其唯一 AI-robust 正解是从 Service「调 `RunInTx` 的 exported emitting method」typed 派生期望名（避免手列 suffix 这一 Medium 倒退）。该派生对 identitymanage（6 个 emitting method）等多 mutation slice 会显著扩展 E2E 测试面，且 `sessionlogin.IssueForUser` 等非-HTTP internal 路径无法经 E2E harness 驱动——实为 Cx4，与本 PR 体量不成比例。
-- 故按 `feedback_pr_scope_carveouts_must_backlog` 登记为独立 backlog（cap-14 / type-test / pri-p2）跟踪 per-mutation typed 派生升级，不在本 PR 内做、也不以手列 suffix 临时打补丁。
+- 故按 `feedback_pr_scope_carveouts_must_backlog` 登记为独立 backlog **#957**（cap-14 / type-test / pri-p2）跟踪 per-mutation typed 派生升级，不在本 PR 内做、也不以手列 suffix 临时打补丁。
 
 ---
 

--- a/tests/integration/l2atomicity/harness_test.go
+++ b/tests/integration/l2atomicity/harness_test.go
@@ -206,6 +206,27 @@ func newL2Harness(t *testing.T) *l2Harness {
 // composition root (SharedDeps + BuildApp + buildAssembly + bootstrap.New).
 func newL2HarnessWithWriter(t *testing.T, pgOutboxOverride outbox.Writer) *l2Harness {
 	t.Helper()
+	h := bootL2Assembly(t, pgOutboxOverride)
+	seedAdmin(t, h.base)
+	return h
+}
+
+// newL2HarnessNoSeed boots the full assembly but SKIPS seedAdmin. Use this
+// when the test itself drives POST /api/v1/access/setup/admin so that the
+// setup path is exercised under a controlled outbox writer (e.g. with a
+// selectiveFailWriter). Calling seedAdmin after boot would be non-idempotent
+// if the test already POSTed setup/admin.
+func newL2HarnessNoSeed(t *testing.T, pgOutboxOverride outbox.Writer) *l2Harness {
+	t.Helper()
+	return bootL2Assembly(t, pgOutboxOverride)
+}
+
+// bootL2Assembly constructs and starts the full PG-backed assembly (accesscore
+// + configcore + auditcore) and waits for /healthz to be ready. It does NOT
+// seed an admin — callers are responsible for calling seedAdmin or driving
+// setup/admin directly.
+func bootL2Assembly(t *testing.T, pgOutboxOverride outbox.Writer) *l2Harness {
+	t.Helper()
 
 	pg := buildPGStores(t)
 	authDeps := buildAuthLayer(t)
@@ -237,7 +258,6 @@ func newL2HarnessWithWriter(t *testing.T, pgOutboxOverride outbox.Writer) *l2Har
 	runBootstrap(t, asm, primaryLn, internalLn, eb, authDeps, relayWorker)
 	base := "http://" + primaryLn.Addr().String()
 	waitForHealthz(t, base)
-	seedAdmin(t, base)
 
 	return &l2Harness{
 		pool:         pg.pool,

--- a/tests/integration/l2atomicity/helpers_test.go
+++ b/tests/integration/l2atomicity/helpers_test.go
@@ -462,6 +462,54 @@ func countLiveRefreshTokensForSubject(t *testing.T, h *l2Harness, subjectID stri
 	return n
 }
 
+// userCountByUsername returns the count of users rows matching username.
+// Used by identitymanage atomicity tests to confirm the domain write did
+// not persist after an outbox-write failure rolls back the transaction.
+func userCountByUsername(t *testing.T, h *l2Harness, username string) int {
+	t.Helper()
+	var n int
+	err := h.pool.DB().QueryRow(context.Background(),
+		`SELECT count(*) FROM users WHERE username = $1`, username).Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
+// httpLogoutStatus calls DELETE /api/v1/access/sessions/{sessionID} with the
+// given bearer token and returns the HTTP status code. Unlike httpLogout it
+// does NOT assert the status, so failure-injection tests can call this when
+// the server is expected to return 500.
+func httpLogoutStatus(t *testing.T, base, accessToken, sessionID string) int {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodDelete, base+"/api/v1/access/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	return resp.StatusCode
+}
+
+// httpCreateUserStatus POSTs /api/v1/access/users with an admin bearer token
+// and returns the HTTP status code without asserting it. Unlike httpCreateUser
+// it tolerates non-201 responses, so failure-injection tests can call this
+// when the server is expected to return 500.
+func httpCreateUserStatus(t *testing.T, base, adminAccessToken, username, email, password string) int {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{
+		"username": username,
+		"email":    email,
+		"password": password,
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/api/v1/access/users", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminAccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	return resp.StatusCode
+}
+
 // assignRole calls POST /internal/v1/access/roles/assign with a service token
 // signed for the "accesscore" caller cell. The "accesscore" callerCell literal
 // is required by the SVCTOKEN-CALLER-CELL-REQUIRED-01 archtest: every

--- a/tests/integration/l2atomicity/identitymanage_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/identitymanage_atomicity_failureproof_e2e_test.go
@@ -61,7 +61,7 @@ func TestL2Atomicity_identitymanage_RollsBack(t *testing.T) {
 	// will fail when identitymanage.Service tries to emit event.user.created.v1
 	// inside the transaction, causing the txRunner to roll back the users INSERT.
 	status := httpCreateUserStatus(t, h.base, adminLogin.AccessToken,
-		newUsername, "identitymanage-atomicity@l2.local", "VictimPass!99")
+		newUsername, "identitymanage-atomicity@l2.local", victimPassword)
 	require.Equal(t, http.StatusInternalServerError, status,
 		"user creation must surface 500 when outbox writer fails")
 
@@ -80,7 +80,7 @@ func TestL2Atomicity_identitymanage_RollsBack(t *testing.T) {
 	// succeed and a user row must appear.
 	sw.failType.Store("")
 	httpCreateUser(t, h.base, adminLogin.AccessToken,
-		newUsername, "identitymanage-atomicity@l2.local", "VictimPass!99")
+		newUsername, "identitymanage-atomicity@l2.local", victimPassword)
 	assert.Equal(t, 1, userCountByUsername(t, h, newUsername),
 		"control: users row MUST persist on happy user creation")
 }

--- a/tests/integration/l2atomicity/identitymanage_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/identitymanage_atomicity_failureproof_e2e_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package l2atomicity
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/kernel/clock"
+)
+
+// Topic literals are kept inlined (not imported from
+// cells/accesscore/internal/dto) because the tests/integration/l2atomicity
+// package cannot import internal/. Same "expected duplication" rationale as
+// eventRoleAssignedV1 in rbacassign_atomicity_failureproof_e2e_test.go: if the
+// producer-side constant changes, this test must be updated in lockstep — and
+// will visibly fail in the inject-failure window when the new event type fails
+// to be intercepted. The negative-control path clears failType and is
+// topic-agnostic by design.
+const (
+	eventUserCreatedV1 = "event.user.created.v1"
+)
+
+// ---------------------------------------------------------------------------
+// TestL2Atomicity_identitymanage_RollsBack (L2-OUTBOX-ATOMICITY-COVERAGE-01)
+// ---------------------------------------------------------------------------
+
+// TestL2Atomicity_identitymanage_RollsBack proves that when the outbox writer
+// fails inside identitymanage.Service's transaction (user creation path), the
+// domain write (users INSERT) rolls back atomically and no user row persists.
+//
+// Setup phase uses a pass-through writer so admin login succeeds normally.
+// The failure window is opened only for event.user.created.v1 immediately
+// before the create-user-under-test call.
+//
+// ref: rbacassign_atomicity_failureproof_e2e_test.go (canonical pattern)
+// ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
+func TestL2Atomicity_identitymanage_RollsBack(t *testing.T) {
+	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
+	h := newL2HarnessWithWriter(t, sw)
+	ctx := context.Background()
+
+	// Setup phase: pass-through writer. Admin login passes through.
+	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
+
+	const newUsername = "l2-identitymanage-atomicity-user"
+	require.Equal(t, 0, userCountByUsername(t, h, newUsername),
+		"baseline: target username must not exist before create-under-test")
+
+	auditBefore := countAuditEntries(t, ctx, h, eventUserCreatedV1)
+
+	// Trigger window: only event.user.created.v1 will fail at the writer.
+	sw.failType.Store(eventUserCreatedV1)
+
+	// The create-user-under-test: admin creates a new user. The outbox writer
+	// will fail when identitymanage.Service tries to emit event.user.created.v1
+	// inside the transaction, causing the txRunner to roll back the users INSERT.
+	status := httpCreateUserStatus(t, h.base, adminLogin.AccessToken,
+		newUsername, "identitymanage-atomicity@l2.local", "VictimPass!99")
+	require.Equal(t, http.StatusInternalServerError, status,
+		"user creation must surface 500 when outbox writer fails")
+
+	require.Equal(t, int64(1), sw.failCount.Load(),
+		"writer.Write must have been invoked exactly once before transaction rollback")
+
+	// Rollback proof: users INSERT did NOT persist.
+	require.Equal(t, 0, userCountByUsername(t, h, newUsername),
+		"users row MUST NOT persist after outbox-write failure rollback")
+
+	// Audit-silence proof: no audit entry must appear for the aborted user creation.
+	require.Equal(t, auditBefore, countAuditEntries(t, ctx, h, eventUserCreatedV1),
+		"rollback: no audit entry must appear for aborted user creation")
+
+	// Negative control: with the trigger cleared, the same create path must
+	// succeed and a user row must appear.
+	sw.failType.Store("")
+	httpCreateUser(t, h.base, adminLogin.AccessToken,
+		newUsername, "identitymanage-atomicity@l2.local", "VictimPass!99")
+	assert.Equal(t, 1, userCountByUsername(t, h, newUsername),
+		"control: users row MUST persist on happy user creation")
+}

--- a/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
@@ -76,9 +76,9 @@ func newSelectiveFailWriter(inner outbox.Writer) *selectiveFailWriter {
 }
 
 // roleAssignmentCount returns the number of role_assignments rows for
-// (userID, roleID). Inlined rather than added to helpers_test.go so the
-// helper remains scoped to the only test that needs it; if a future test
-// adopts the same query, hoist then.
+// (userID, roleID). Inlined rather than added to helpers_test.go because
+// it is only used by the two atomicity tests in this file (Assign and Revoke);
+// if a test outside this file adopts the same query, hoist then.
 func roleAssignmentCount(t *testing.T, h *l2Harness, userID, roleID string) int {
 	t.Helper()
 	var n int
@@ -132,8 +132,8 @@ func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string)
 // write (role_assignments INSERT via PGRoleRepo.AssignToUser) rolls back
 // atomically and no row persists.
 //
-// Mirrors TestAuditLedgerStore_OutboxAtomicityFailureProof
-// (adapters/postgres/audit_ledger_store_test.go AUDITAPPEND-L2-FAILURE-PROOF-01)
+// Mirrors TestL2Atomicity_auditcore_RollsBack
+// (adapters/postgres/audit_ledger_store_test.go)
 // but injects failure at the writer layer (where issue #655 specifies — "故意
 // fail writer") rather than the txRunner closure. Drives the full HTTP →
 // service-token-auth → handler → service → persistChange → emitter →
@@ -187,10 +187,10 @@ func TestL2Atomicity_rbacassign_RollsBack(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestL2_RbacRevoke_OutboxWriteFailure_RollsBack (RBACASSIGN-L2-PG-ATOMICITY-01)
+// TestL2Atomicity_rbacassign_RollsBack_Revoke (L2-OUTBOX-ATOMICITY-COVERAGE-01)
 // ---------------------------------------------------------------------------
 
-// TestL2_RbacRevoke_OutboxWriteFailure_RollsBack proves the stronger L2
+// TestL2Atomicity_rbacassign_RollsBack_Revoke proves the stronger L2
 // invariant for the Revoke path: when the outbox writer fails, the
 // credentialinvalidate.Invalidator cascade
 // (BumpAuthzEpoch + RevokeForSubject + RevokeUser) rolls back atomically
@@ -201,7 +201,7 @@ func TestL2Atomicity_rbacassign_RollsBack(t *testing.T) {
 // login + session/refresh chain creation all succeed normally. The failure
 // window is opened only for event.role.revoked.v1 immediately before the
 // revoke call.
-func TestL2_RbacRevoke_OutboxWriteFailure_RollsBack(t *testing.T) {
+func TestL2Atomicity_rbacassign_RollsBack_Revoke(t *testing.T) {
 	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
 	h := newL2HarnessWithWriter(t, sw)
 	ctx := context.Background()

--- a/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
@@ -124,10 +124,10 @@ func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string)
 }
 
 // ---------------------------------------------------------------------------
-// TestL2_RbacAssign_OutboxWriteFailure_RollsBack (RBACASSIGN-L2-PG-ATOMICITY-01)
+// TestL2Atomicity_rbacassign_RollsBack (L2-OUTBOX-ATOMICITY-COVERAGE-01)
 // ---------------------------------------------------------------------------
 
-// TestL2_RbacAssign_OutboxWriteFailure_RollsBack proves that when the outbox
+// TestL2Atomicity_rbacassign_RollsBack proves that when the outbox
 // writer fails inside rbacassign.Service.Assign's transaction, the domain
 // write (role_assignments INSERT via PGRoleRepo.AssignToUser) rolls back
 // atomically and no row persists.
@@ -142,7 +142,7 @@ func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string)
 //
 // ref: adapters/postgres/audit_ledger_store_test.go:335-392
 // ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
-func TestL2_RbacAssign_OutboxWriteFailure_RollsBack(t *testing.T) {
+func TestL2Atomicity_rbacassign_RollsBack(t *testing.T) {
 	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
 	h := newL2HarnessWithWriter(t, sw)
 	ctx := context.Background()

--- a/tests/integration/l2atomicity/sessionlogin_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/sessionlogin_atomicity_failureproof_e2e_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+
+package l2atomicity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/kernel/clock"
+)
+
+// Topic literals are kept inlined (not imported from
+// cells/accesscore/internal/dto) because the tests/integration/l2atomicity
+// package cannot import internal/. Same "expected duplication" rationale as
+// eventRoleAssignedV1 in rbacassign_atomicity_failureproof_e2e_test.go: if the
+// producer-side constant changes, this test must be updated in lockstep — and
+// will visibly fail in the inject-failure window when the new event type fails
+// to be intercepted. The negative-control path clears failType and is
+// topic-agnostic by design.
+const (
+	eventSessionCreatedV1 = "event.session.created.v1"
+)
+
+// ---------------------------------------------------------------------------
+// TestL2Atomicity_sessionlogin_RollsBack (L2-OUTBOX-ATOMICITY-COVERAGE-01)
+// ---------------------------------------------------------------------------
+
+// TestL2Atomicity_sessionlogin_RollsBack proves that when the outbox writer
+// fails inside sessionlogin.Service's transaction, the domain write
+// (sessions INSERT) rolls back atomically and no session row persists.
+//
+// Pattern mirrors TestL2Atomicity_rbacassign_RollsBack: setup phase uses a
+// pass-through writer so admin login and victim user creation succeed normally;
+// the failure window is opened only for event.session.created.v1 immediately
+// before the login-under-test.
+//
+// ref: rbacassign_atomicity_failureproof_e2e_test.go (canonical pattern)
+// ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
+func TestL2Atomicity_sessionlogin_RollsBack(t *testing.T) {
+	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
+	h := newL2HarnessWithWriter(t, sw)
+	ctx := context.Background()
+
+	// Setup phase: pass-through writer. Admin login and victim user creation
+	// both pass through (failType is "").
+	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
+	const victimUsername = "l2-sessionlogin-atomicity-user"
+	const victimLoginPassword = "VictimPass!99"
+	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
+		victimUsername, "sessionlogin-atomicity@l2.local", victimLoginPassword)
+
+	require.Equal(t, 0, countLiveSessions(t, h, victimID),
+		"baseline: victim must have no live sessions before login-under-test")
+
+	auditBefore := countAuditEntries(t, ctx, h, eventSessionCreatedV1)
+
+	// Trigger window: only event.session.created.v1 will fail at the writer.
+	sw.failType.Store(eventSessionCreatedV1)
+
+	// The login-under-test: victim logs in. The outbox writer will fail when
+	// sessionlogin.Service tries to emit event.session.created.v1 inside the
+	// transaction, causing the txRunner to roll back the sessions INSERT.
+	loginBody, _ := json.Marshal(map[string]string{
+		"username": victimUsername,
+		"password": victimLoginPassword,
+	})
+	req, _ := http.NewRequest(http.MethodPost, h.base+"/api/v1/access/sessions/login",
+		bytes.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode,
+		"login must surface 500 when outbox writer fails")
+
+	require.Equal(t, int64(1), sw.failCount.Load(),
+		"writer.Write must have been invoked exactly once before transaction rollback")
+
+	// Rollback proof: sessions INSERT did NOT persist.
+	require.Equal(t, 0, countLiveSessions(t, h, victimID),
+		"sessions row MUST NOT persist after outbox-write failure rollback")
+
+	// Audit-silence proof: no audit entry must appear for the aborted login.
+	require.Equal(t, auditBefore, countAuditEntries(t, ctx, h, eventSessionCreatedV1),
+		"rollback: no audit entry must appear for aborted login")
+
+	// Negative control: with the trigger cleared, the same login path must
+	// succeed and a session row must appear.
+	sw.failType.Store("")
+	victimLogin := httpLogin(t, h.base, victimUsername, victimLoginPassword)
+	assert.Equal(t, 1, countLiveSessions(t, h, victimID),
+		"control: sessions row MUST persist on happy login")
+	assert.NotEmpty(t, victimLogin.SessionID, "control: sessionId must be present")
+}

--- a/tests/integration/l2atomicity/sessionlogin_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/sessionlogin_atomicity_failureproof_e2e_test.go
@@ -53,9 +53,8 @@ func TestL2Atomicity_sessionlogin_RollsBack(t *testing.T) {
 	// both pass through (failType is "").
 	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
 	const victimUsername = "l2-sessionlogin-atomicity-user"
-	const victimLoginPassword = "VictimPass!99"
 	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
-		victimUsername, "sessionlogin-atomicity@l2.local", victimLoginPassword)
+		victimUsername, "sessionlogin-atomicity@l2.local", victimPassword)
 
 	require.Equal(t, 0, countLiveSessions(t, h, victimID),
 		"baseline: victim must have no live sessions before login-under-test")
@@ -70,7 +69,7 @@ func TestL2Atomicity_sessionlogin_RollsBack(t *testing.T) {
 	// transaction, causing the txRunner to roll back the sessions INSERT.
 	loginBody, _ := json.Marshal(map[string]string{
 		"username": victimUsername,
-		"password": victimLoginPassword,
+		"password": victimPassword,
 	})
 	req, _ := http.NewRequest(http.MethodPost, h.base+"/api/v1/access/sessions/login",
 		bytes.NewReader(loginBody))
@@ -96,7 +95,7 @@ func TestL2Atomicity_sessionlogin_RollsBack(t *testing.T) {
 	// Negative control: with the trigger cleared, the same login path must
 	// succeed and a session row must appear.
 	sw.failType.Store("")
-	victimLogin := httpLogin(t, h.base, victimUsername, victimLoginPassword)
+	victimLogin := httpLogin(t, h.base, victimUsername, victimPassword)
 	assert.Equal(t, 1, countLiveSessions(t, h, victimID),
 		"control: sessions row MUST persist on happy login")
 	assert.NotEmpty(t, victimLogin.SessionID, "control: sessionId must be present")

--- a/tests/integration/l2atomicity/sessionlogout_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/sessionlogout_atomicity_failureproof_e2e_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package l2atomicity
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/kernel/clock"
+)
+
+// Topic literals are kept inlined (not imported from
+// cells/accesscore/internal/dto) because the tests/integration/l2atomicity
+// package cannot import internal/. Same "expected duplication" rationale as
+// eventRoleAssignedV1 in rbacassign_atomicity_failureproof_e2e_test.go: if the
+// producer-side constant changes, this test must be updated in lockstep — and
+// will visibly fail in the inject-failure window when the new event type fails
+// to be intercepted. The negative-control path clears failType and is
+// topic-agnostic by design.
+const (
+	eventSessionRevokedV1 = "event.session.revoked.v1"
+)
+
+// ---------------------------------------------------------------------------
+// TestL2Atomicity_sessionlogout_RollsBack (L2-OUTBOX-ATOMICITY-COVERAGE-01)
+// ---------------------------------------------------------------------------
+
+// TestL2Atomicity_sessionlogout_RollsBack proves that when the outbox writer
+// fails inside sessionlogout.Service's transaction, the domain write
+// (sessions revoked_at UPDATE) rolls back atomically and the session
+// remains live.
+//
+// Setup phase uses a pass-through writer so admin login, victim creation, and
+// victim's initial login all succeed normally. The failure window is opened
+// only for event.session.revoked.v1 immediately before the logout-under-test.
+//
+// ref: rbacassign_atomicity_failureproof_e2e_test.go (canonical pattern)
+// ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
+func TestL2Atomicity_sessionlogout_RollsBack(t *testing.T) {
+	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
+	h := newL2HarnessWithWriter(t, sw)
+	ctx := context.Background()
+
+	// Setup phase: pass-through writer. Admin login, victim user creation,
+	// and victim login all pass through (failType is "").
+	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
+	const victimUsername = "l2-sessionlogout-atomicity-user"
+	const victimLogoutPassword = "VictimPass!99"
+	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
+		victimUsername, "sessionlogout-atomicity@l2.local", victimLogoutPassword)
+
+	// Login the victim so there is a live session to revoke.
+	victimLogin := httpLogin(t, h.base, victimUsername, victimLogoutPassword)
+	require.NotEmpty(t, victimLogin.SessionID, "setup: victim must have a live session")
+
+	require.Equal(t, 1, countLiveSessions(t, h, victimID),
+		"setup: victim must have exactly 1 live session before logout-under-test")
+
+	auditBefore := countAuditEntries(t, ctx, h, eventSessionRevokedV1)
+
+	// Trigger window: only event.session.revoked.v1 will fail at the writer.
+	sw.failType.Store(eventSessionRevokedV1)
+
+	// The logout-under-test: victim logs out. The outbox writer will fail when
+	// sessionlogout.Service tries to emit event.session.revoked.v1 inside the
+	// transaction, causing the txRunner to roll back the revoked_at UPDATE.
+	status := httpLogoutStatus(t, h.base, victimLogin.AccessToken, victimLogin.SessionID)
+	require.Equal(t, http.StatusInternalServerError, status,
+		"logout must surface 500 when outbox writer fails")
+
+	require.Equal(t, int64(1), sw.failCount.Load(),
+		"writer.Write must have been invoked exactly once before transaction rollback")
+
+	// Rollback proof: session revoked_at UPDATE did NOT persist — session is
+	// still live.
+	require.Equal(t, 1, countLiveSessions(t, h, victimID),
+		"sessions row MUST remain live after outbox-write failure rollback")
+
+	// Audit-silence proof: no audit entry must appear for the aborted logout.
+	require.Equal(t, auditBefore, countAuditEntries(t, ctx, h, eventSessionRevokedV1),
+		"rollback: no audit entry must appear for aborted logout")
+
+	// Negative control: with the trigger cleared, the same logout path must
+	// succeed and the session must be revoked.
+	sw.failType.Store("")
+	httpLogout(t, h.base, victimLogin.AccessToken, victimLogin.SessionID)
+	assert.Equal(t, 0, countLiveSessions(t, h, victimID),
+		"control: session MUST be revoked on happy logout")
+}

--- a/tests/integration/l2atomicity/sessionlogout_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/sessionlogout_atomicity_failureproof_e2e_test.go
@@ -50,12 +50,11 @@ func TestL2Atomicity_sessionlogout_RollsBack(t *testing.T) {
 	// and victim login all pass through (failType is "").
 	adminLogin := httpLogin(t, h.base, adminUsername, adminPassword)
 	const victimUsername = "l2-sessionlogout-atomicity-user"
-	const victimLogoutPassword = "VictimPass!99"
 	victimID := httpCreateUser(t, h.base, adminLogin.AccessToken,
-		victimUsername, "sessionlogout-atomicity@l2.local", victimLogoutPassword)
+		victimUsername, "sessionlogout-atomicity@l2.local", victimPassword)
 
 	// Login the victim so there is a live session to revoke.
-	victimLogin := httpLogin(t, h.base, victimUsername, victimLogoutPassword)
+	victimLogin := httpLogin(t, h.base, victimUsername, victimPassword)
 	require.NotEmpty(t, victimLogin.SessionID, "setup: victim must have a live session")
 
 	require.Equal(t, 1, countLiveSessions(t, h, victimID),

--- a/tests/integration/l2atomicity/setup_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/setup_atomicity_failureproof_e2e_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package l2atomicity
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/kernel/clock"
+)
+
+// ---------------------------------------------------------------------------
+// TestL2Atomicity_setup_RollsBack (L2-OUTBOX-ATOMICITY-COVERAGE-01)
+// ---------------------------------------------------------------------------
+
+// TestL2Atomicity_setup_RollsBack proves that when the outbox writer fails
+// inside setup.Service's transaction (setup/admin POST), the domain write
+// (admin user INSERT) rolls back atomically and no admin user persists.
+//
+// The harness is created WITHOUT seeding an admin (newL2HarnessNoSeed) because
+// setup/admin is non-idempotent: a second POST after the first succeeds returns
+// 410 ERR_SETUP_ALREADY_INITIALIZED. The test itself drives POST
+// /api/v1/access/setup/admin directly, controlling the outbox failure window.
+//
+// event.user.created.v1 is the topic emitted by setup.Service when it creates
+// the initial admin user — the same topic as identitymanage creates for
+// ordinary users (shared identitymanage.Service path).
+//
+// ref: rbacassign_atomicity_failureproof_e2e_test.go (canonical pattern)
+// ref: Transactional Outbox Pattern (Microservices Patterns, Chris Richardson)
+func TestL2Atomicity_setup_RollsBack(t *testing.T) {
+	sw := newSelectiveFailWriter(adapterpg.NewOutboxWriter(clock.Real()))
+	// Boot without seeding admin — the test drives setup/admin directly.
+	h := newL2HarnessNoSeed(t, sw)
+
+	setupBody, _ := json.Marshal(map[string]string{
+		"username": adminUsername,
+		"email":    adminEmail,
+		"password": adminPassword,
+	})
+	newSetupBody := func() *bytes.Reader { return bytes.NewReader(setupBody) }
+
+	require.False(t, setupHasAdmin(t, h.base),
+		"baseline: no admin must exist before setup-under-test")
+
+	// Trigger window: event.user.created.v1 is the topic emitted by
+	// setup.Service when it creates the initial admin user.
+	sw.failType.Store(eventUserCreatedV1)
+
+	// The setup-under-test: POST /api/v1/access/setup/admin with bootstrap
+	// basic auth. The outbox writer fails when setup.Service tries to emit
+	// event.user.created.v1 inside the transaction, rolling back the INSERT.
+	resp, err := postSetupAdmin(h.base, newSetupBody())
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode,
+		"setup/admin must surface 500 when outbox writer fails")
+
+	require.Equal(t, int64(1), sw.failCount.Load(),
+		"writer.Write must have been invoked exactly once before transaction rollback")
+
+	// Rollback proof: no admin persisted — setup/admin can be retried.
+	require.False(t, setupHasAdmin(t, h.base),
+		"admin MUST NOT persist after outbox-write failure rollback")
+
+	// Negative control: with the trigger cleared, setup/admin must succeed
+	// and an admin must be present.
+	sw.failType.Store("")
+	resp2, err := postSetupAdmin(h.base, newSetupBody())
+	require.NoError(t, err)
+	_ = resp2.Body.Close()
+	require.Equal(t, http.StatusCreated, resp2.StatusCode,
+		"setup/admin must return 201 on happy path after rollback")
+	assert.True(t, setupHasAdmin(t, h.base),
+		"control: admin MUST exist after successful setup/admin")
+}

--- a/tools/archtest/l2_outbox_atomicity_coverage_test.go
+++ b/tools/archtest/l2_outbox_atomicity_coverage_test.go
@@ -1,0 +1,763 @@
+// INVARIANT: L2-OUTBOX-ATOMICITY-COVERAGE-01
+//
+// l2_outbox_atomicity_coverage_test.go — every L2 unit (cell-level or
+// slice-level) must have an atomicity test whose name is derived from the
+// unit's Service package (typed, via go/types + types.Unalias) and whose
+// file carries //go:build integration.
+//
+// # L2-OUTBOX-ATOMICITY-COVERAGE-01
+//
+// Invariant: for each L2 unit (a cell or slice whose consistencyLevel==L2),
+// a test named TestL2Atomicity_<P>_RollsBack MUST exist as a top-level
+// func TestXxx(*testing.T) in some *_test.go file across the module.
+// Hybrid L2 units (Service has HandleEvent(ctx context.Context, entry
+// outbox.Entry) outbox.HandleResult) additionally require
+// TestL2Atomicity_<P>_ReplayIdempotent.
+//
+// Derivation logic (three-phase):
+//
+//  1. YAML scan (upstream Hard, YAML-derived): scan cells/*/cell.yaml and
+//     cells/*/slices/*/slice.yaml to enumerate L2 units.
+//     Floor assert: >= 12 L2 units (fail-closed against broken scan).
+//
+//  2. Typed derivation (Hard, via go/types): RunTypedProduction loads every
+//     production package; for L2 slice packages the Service symbol is
+//     resolved via pass.Pkg.Scope().Lookup("Service") + types.Unalias to
+//     pierce aliases. Alias-to-appender folding: all 4 auditappend* slices
+//     resolve to package "appender" via `type Service = appender.Service`,
+//     so the expected set for those 4 collapses to a single pair
+//     TestL2Atomicity_appender_{RollsBack,ReplayIdempotent}.
+//     Hybrid detection: does the named type's method set include HandleEvent
+//     with signature (context.Context, outbox.Entry) outbox.HandleResult?
+//
+//  3. Downstream Hard — exact-name match: scan ALL *_test.go in the module
+//     (ModuleScope + IncludeTests). Collect top-level FuncDecl names.
+//     For each expected name: absent → Diagnostic. Found → assert
+//     //go:build integration constraint.
+//
+// Cell-level L2 units (auditcore): no Service symbol to derive from; use
+// the cell ID directly: TestL2Atomicity_auditcore_RollsBack.
+//
+// AI-robust grade:
+//   - Upstream (enumeration): Hard — YAML is the canonical SoR for
+//     consistencyLevel; scan is self-contained (no metadata.NewParser).
+//   - Typed derivation: Hard — types.Unalias + method-set walk; alias
+//     folding is correctness-by-construction (not a hand-maintained list).
+//   - Downstream (name match): Hard — exact FuncDecl name in AST.
+//
+// Tools used + blind spots:
+//
+//   - RunTypedProduction: does not see *_test.go files (Tests:false);
+//     guard: all expected test funcs live in test-only files, the
+//     downstream AST scan uses DirsScope+IncludeTests.
+//   - types.Unalias: Go 1.22+; must be applied before (*types.Named) assert.
+//   - Blind spot B1 (Medium): service.go Service type renamed away from
+//     "Service" → ServiceLookupTotal self-check catches this.
+//   - Blind spot B2 (Medium): auditappend* de-aliases (removes `type Service
+//     = appender.Service`) → AliasFoldsToSinglePackage self-check catches.
+//   - Blind spot B3 (Hard, via DetectsMissingName): matcher fails-open →
+//     synthetic non-existent name self-check proves it fails-closed.
+//   - Blind spot B4 (Medium, BodyAssertsRollback): body content is semantic
+//     best-effort; documented as inherent-Medium.
+//
+// ref: seed_role_iface_test.go (alias detection form precedent)
+// ref: assembly_invariants_test.go (YAML + typed multi-phase structure)
+// ref: ai-robust.md "string-typed concept funnel" + "single sanctioned holder"
+package archtest
+
+import (
+	"go/ast"
+	"go/build/constraint"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const ruleL2AtomicityCoverage = "L2-OUTBOX-ATOMICITY-COVERAGE-01"
+
+// outboxPkgImportPath is the canonical import path of kernel/outbox.
+const outboxPkgImportPath = "github.com/ghbvf/gocell/kernel/outbox"
+
+// l2MinUnits is the floor assertion: scan must find at least this many L2
+// units. Fail-closed against a broken YAML scan silently zeroing coverage.
+const l2MinUnits = 12
+
+// l2UnitKind distinguishes cell-level from slice-level L2 units.
+type l2UnitKind int
+
+const (
+	l2UnitCell  l2UnitKind = iota // whole cell declared L2
+	l2UnitSlice                   // slice declared L2
+)
+
+// l2Unit records one L2 unit as discovered from YAML metadata.
+type l2Unit struct {
+	kind     l2UnitKind
+	cellID   string // always set
+	sliceDir string // set only for l2UnitSlice
+}
+
+// l2SliceInfo records typed resolution for one L2 slice package.
+type l2SliceInfo struct {
+	defPkgName string // package name of the defining (Unalias'd) type
+	isHybrid   bool   // Service has HandleEvent method matching the L2 hybrid signature
+}
+
+// TestL2OutboxAtomicityCoverage is the primary enforcement test.
+// It fails (RED) until Wave 2 backfills the missing atomicity tests.
+func TestL2OutboxAtomicityCoverage(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	// Phase 1: enumerate L2 units from YAML.
+	units := l2EnumerateUnits(t, root)
+
+	// Phase 2: typed derivation — resolve Service defPkg + hybrid for slices.
+	sliceInfos := l2ResolveSliceInfos(t, root, units)
+
+	// Phase 3: build expected-name set.
+	expected := l2BuildExpectedNames(units, sliceInfos)
+
+	// Phase 4: collect all *_test.go top-level Test* FuncDecl names + files.
+	testFuncs := l2CollectTestFuncs(t, root)
+
+	// Phase 5: match + report.
+	var diags []Diagnostic
+	for name := range expected {
+		info, found := testFuncs[name]
+		if !found {
+			diags = append(diags, Diagnostic{
+				Rel: "cells/",
+				Message: "L2 unit missing atomicity test " + name +
+					"; add it with //go:build integration",
+			})
+			continue
+		}
+		if !info.hasIntegrationTag {
+			diags = append(diags, Diagnostic{
+				Rel:     info.file,
+				Message: name + " found but its file lacks //go:build integration constraint",
+			})
+		}
+	}
+	Report(t, ruleL2AtomicityCoverage, diags)
+}
+
+// l2TestFuncInfo holds info about a discovered test function.
+type l2TestFuncInfo struct {
+	file              string // module-relative slash path
+	hasIntegrationTag bool
+}
+
+// l2EnumerateUnits scans cells/*/cell.yaml and cells/*/slices/*/slice.yaml
+// to collect all L2 units. Uses raw YAML only (no metadata.NewParser) for
+// self-containment.
+func l2EnumerateUnits(t *testing.T, root string) []l2Unit {
+	t.Helper()
+	var units []l2Unit
+
+	// Scan cell.yaml files: cells/<id>/cell.yaml (depth-2 from cells/).
+	cellScope := DirsScope(root, []string{"cells"},
+		MatchRels(func(rel string) bool {
+			rel = filepath.ToSlash(rel)
+			return strings.HasPrefix(rel, "cells/") &&
+				strings.Count(rel, "/") == depth2SlashCount &&
+				filepath.Base(rel) == "cell.yaml"
+		}),
+	)
+
+	EachContentFile(t, cellScope, []string{".yaml"}, func(_ *testing.T, fc ContentContext) {
+		var doc struct {
+			ID               string `yaml:"id"`
+			ConsistencyLevel string `yaml:"consistencyLevel"`
+		}
+		require.NoError(t, yaml.Unmarshal(fc.Bytes, &doc),
+			"%s: parse %s", ruleL2AtomicityCoverage, fc.Rel)
+		if doc.ConsistencyLevel == "L2" {
+			units = append(units, l2Unit{kind: l2UnitCell, cellID: doc.ID})
+		}
+	})
+
+	// Scan slice.yaml files: cells/<cell-id>/slices/<slice-id>/slice.yaml.
+	// depth from cells/ is 4: cells/<cell>  /slices/<slice>/slice.yaml = 4 slashes.
+	const sliceDepthSlashCount = 4
+	sliceScope := DirsScope(root, []string{"cells"},
+		MatchRels(func(rel string) bool {
+			rel = filepath.ToSlash(rel)
+			return strings.HasPrefix(rel, "cells/") &&
+				strings.Count(rel, "/") == sliceDepthSlashCount &&
+				filepath.Base(rel) == "slice.yaml"
+		}),
+	)
+
+	EachContentFile(t, sliceScope, []string{".yaml"}, func(_ *testing.T, fc ContentContext) {
+		var doc struct {
+			ID               string `yaml:"id"`
+			BelongsToCell    string `yaml:"belongsToCell"`
+			ConsistencyLevel string `yaml:"consistencyLevel"`
+		}
+		require.NoError(t, yaml.Unmarshal(fc.Bytes, &doc),
+			"%s: parse %s", ruleL2AtomicityCoverage, fc.Rel)
+		if doc.ConsistencyLevel != "L2" {
+			return
+		}
+		// sliceDir is the directory name (e.g. "sessionlogin")
+		sliceDir := filepath.Base(filepath.Dir(filepath.FromSlash(fc.Rel)))
+		units = append(units, l2Unit{
+			kind:     l2UnitSlice,
+			cellID:   doc.BelongsToCell,
+			sliceDir: sliceDir,
+		})
+	})
+
+	require.GreaterOrEqual(t, len(units), l2MinUnits,
+		"%s: found only %d L2 units (want >= %d); YAML scan may be broken — fail-closed",
+		ruleL2AtomicityCoverage, len(units), l2MinUnits)
+
+	return units
+}
+
+// l2ResolveSliceInfos uses RunTypedProduction to resolve Service type + hybrid
+// flag for every L2 slice unit. Returns a map from sliceDir → l2SliceInfo.
+func l2ResolveSliceInfos(t *testing.T, root string, units []l2Unit) map[string]l2SliceInfo {
+	t.Helper()
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "%s: read module path", ruleL2AtomicityCoverage)
+
+	// Build set of L2 slice pkg import paths we care about.
+	// Each slice lives at cells/<cellID>/slices/<sliceDir>.
+	type wantEntry struct {
+		sliceDir  string
+		importPkg string
+	}
+	var wantSlices []wantEntry
+	for _, u := range units {
+		if u.kind != l2UnitSlice {
+			continue
+		}
+		importPath := modPath + "/cells/" + u.cellID + "/slices/" + u.sliceDir
+		wantSlices = append(wantSlices, wantEntry{
+			sliceDir:  u.sliceDir,
+			importPkg: importPath,
+		})
+	}
+	// Build lookup map: importPath → sliceDir
+	wantMap := make(map[string]string, len(wantSlices))
+	for _, w := range wantSlices {
+		wantMap[w.importPkg] = w.sliceDir
+	}
+
+	infos := make(map[string]l2SliceInfo, len(wantSlices))
+
+	_ = RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		sliceDir, ok := wantMap[p.Pkg.Path()]
+		if !ok {
+			return nil
+		}
+		info := l2ResolveServiceInfo(p.Pkg, modPath)
+		infos[sliceDir] = info
+		return nil
+	})
+
+	return infos
+}
+
+// l2ResolveServiceInfo resolves the Service symbol in pkg and returns its
+// defPkgName (after Unalias) and whether it is hybrid (has HandleEvent).
+func l2ResolveServiceInfo(pkg *types.Package, modPath string) l2SliceInfo {
+	obj := pkg.Scope().Lookup("Service")
+	if obj == nil {
+		// No Service symbol; fall back to the package's own name.
+		return l2SliceInfo{defPkgName: pkg.Name()}
+	}
+
+	// Pierce through alias chain to reach the defining Named type.
+	raw := types.Unalias(obj.Type())
+	named, ok := raw.(*types.Named)
+	if !ok {
+		return l2SliceInfo{defPkgName: pkg.Name()}
+	}
+	defPkg := named.Obj().Pkg()
+	if defPkg == nil {
+		return l2SliceInfo{defPkgName: pkg.Name()}
+	}
+
+	isHybrid := l2ServiceIsHybrid(named, modPath)
+	return l2SliceInfo{
+		defPkgName: defPkg.Name(),
+		isHybrid:   isHybrid,
+	}
+}
+
+// l2ServiceIsHybrid reports whether named (a *types.Named from Unalias) has a
+// method HandleEvent with signature (context.Context, outbox.Entry) outbox.HandleResult.
+func l2ServiceIsHybrid(named *types.Named, modPath string) bool {
+	outboxPath := outboxPkgImportPath
+
+	for i := range named.NumMethods() {
+		m := named.Method(i)
+		if m.Name() != "HandleEvent" {
+			continue
+		}
+		sig, ok := m.Type().(*types.Signature)
+		if !ok {
+			continue
+		}
+		params := sig.Params()
+		results := sig.Results()
+		if params.Len() != 2 || results.Len() != 1 {
+			continue
+		}
+		// param[0]: context.Context
+		if !l2IsContextContext(params.At(0).Type()) {
+			continue
+		}
+		// param[1]: outbox.Entry
+		if !l2IsNamedFrom(params.At(1).Type(), outboxPath, "Entry") {
+			continue
+		}
+		// result[0]: outbox.HandleResult
+		if !l2IsNamedFrom(results.At(0).Type(), outboxPath, "HandleResult") {
+			continue
+		}
+		_ = modPath // kept for future cross-package path checks
+		return true
+	}
+	return false
+}
+
+// l2IsContextContext reports whether t is context.Context (interface).
+func l2IsContextContext(t types.Type) bool {
+	t = types.Unalias(t)
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == "context" && obj.Name() == "Context"
+}
+
+// l2IsNamedFrom reports whether t (after Unalias) is a named type from pkgPath
+// with name typeName.
+func l2IsNamedFrom(t types.Type, pkgPath, typeName string) bool {
+	t = types.Unalias(t)
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == pkgPath && obj.Name() == typeName
+}
+
+// l2BuildExpectedNames constructs the complete deduplicated expected-name set.
+func l2BuildExpectedNames(units []l2Unit, sliceInfos map[string]l2SliceInfo) map[string]struct{} {
+	expected := make(map[string]struct{})
+
+	for _, u := range units {
+		switch u.kind {
+		case l2UnitCell:
+			// Cell-level: TestL2Atomicity_<cellID>_RollsBack.
+			expected["TestL2Atomicity_"+u.cellID+"_RollsBack"] = struct{}{}
+
+		case l2UnitSlice:
+			info, ok := sliceInfos[u.sliceDir]
+			if !ok {
+				// Typed resolution missed this slice; fall back to sliceDir.
+				expected["TestL2Atomicity_"+u.sliceDir+"_RollsBack"] = struct{}{}
+				continue
+			}
+			p := info.defPkgName
+			expected["TestL2Atomicity_"+p+"_RollsBack"] = struct{}{}
+			if info.isHybrid {
+				expected["TestL2Atomicity_"+p+"_ReplayIdempotent"] = struct{}{}
+			}
+		}
+	}
+	return expected
+}
+
+// l2CollectTestFuncs scans every *_test.go file in the module and returns a
+// map from Test* function name to l2TestFuncInfo.
+func l2CollectTestFuncs(t *testing.T, root string) map[string]l2TestFuncInfo {
+	t.Helper()
+	scope := ModuleScope(root, IncludeTests())
+	result := make(map[string]l2TestFuncInfo)
+
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			if !strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			hasTag := l2FileHasIntegrationTag(p.Abs(f))
+			EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+				if fd.Recv != nil {
+					return
+				}
+				if fd.Name == nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+					return
+				}
+				if !l2IsStandardTestFunc(fd.Type) {
+					return
+				}
+				result[fd.Name.Name] = l2TestFuncInfo{
+					file:              rel,
+					hasIntegrationTag: hasTag,
+				}
+			})
+		}
+		return nil
+	})
+	return result
+}
+
+// l2FileHasIntegrationTag reports whether the file at absPath carries a
+// //go:build integration constraint (or the legacy // +build integration form).
+func l2FileHasIntegrationTag(absPath string) bool {
+	if absPath == "" {
+		return false
+	}
+	expr, err := ParseBuildConstraint(absPath)
+	if err != nil || expr == nil {
+		return false
+	}
+	// Evaluate with "integration" as the only active tag.
+	return expr.Eval(func(tag string) bool { return tag == "integration" })
+}
+
+// l2IsStandardTestFunc reports whether ft matches func(*testing.T).
+func l2IsStandardTestFunc(ft *ast.FuncType) bool {
+	if ft == nil || ft.Params == nil || len(ft.Params.List) != 1 {
+		return false
+	}
+	field := ft.Params.List[0]
+	ptr, ok := field.Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := ptr.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name == "testing" && sel.Sel.Name == "T"
+}
+
+// l2MatchName reports whether name exists in testFuncs (for self-checks).
+func l2MatchName(name string, testFuncs map[string]l2TestFuncInfo) bool {
+	_, found := testFuncs[name]
+	return found
+}
+
+// ---- Self-check tests ----
+
+// TestL2OutboxAtomicityCoverage_ServiceLookupTotal verifies that every L2 slice
+// package successfully resolves a Service symbol via go/types. A refactor that
+// removes or renames the Service type would shrink the expected-name set
+// silently without this guard.
+//
+// AI-robust: Medium (archtest-bound; a rename makes it fail visibly).
+// Blind spot: Service present but of wrong kind (e.g. func) — rare, caught by
+// l2ResolveServiceInfo fallback and subsequent RED in the main test.
+func TestL2OutboxAtomicityCoverage_ServiceLookupTotal(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err)
+
+	units := l2EnumerateUnits(t, root)
+	infos := l2ResolveSliceInfos(t, root, units)
+
+	var missing []string
+	for _, u := range units {
+		if u.kind != l2UnitSlice {
+			continue
+		}
+		info, found := infos[u.sliceDir]
+		if !found || info.defPkgName == "" {
+			missing = append(missing, u.cellID+"/"+u.sliceDir)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%s ServiceLookupTotal: %d L2 slice(s) failed to resolve Service; "+
+			"check that each slice package exports a type named 'Service'. "+
+			"Missing: %v (module: %s)",
+			ruleL2AtomicityCoverage, len(missing), missing, modPath)
+	}
+}
+
+// TestL2OutboxAtomicityCoverage_AliasFoldsToSinglePackage verifies that all 4
+// auditappend* slices' Service types Unalias to package "appender". If someone
+// de-aliases them, the expected set would expand from 1 to 4 names, which
+// would violate the current folded contract.
+//
+// AI-robust: Medium (validates current alias structure; breaks loudly on change).
+func TestL2OutboxAtomicityCoverage_AliasFoldsToSinglePackage(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	units := l2EnumerateUnits(t, root)
+	infos := l2ResolveSliceInfos(t, root, units)
+
+	auditappendSlices := []string{
+		"auditappendconfig",
+		"auditappendrole",
+		"auditappendsession",
+		"auditappenduser",
+	}
+
+	for _, sliceDir := range auditappendSlices {
+		info, found := infos[sliceDir]
+		if !found {
+			t.Errorf("%s AliasFoldsToSinglePackage: slice %s not found in typed infos",
+				ruleL2AtomicityCoverage, sliceDir)
+			continue
+		}
+		assert.Equal(t, "appender", info.defPkgName,
+			"%s AliasFoldsToSinglePackage: slice %s should Unalias to package 'appender'; "+
+				"got %q. If the alias was removed, update the expected folding and open a "+
+				"backlog item for the naming impact.",
+			ruleL2AtomicityCoverage, sliceDir, info.defPkgName)
+		assert.True(t, info.isHybrid,
+			"%s AliasFoldsToSinglePackage: slice %s (appender.Service) should be detected "+
+				"as hybrid (has HandleEvent); check that HandleEvent signature matches "+
+				"(context.Context, outbox.Entry) outbox.HandleResult",
+			ruleL2AtomicityCoverage, sliceDir)
+	}
+}
+
+// TestL2OutboxAtomicityCoverage_DetectsMissingName verifies that the matcher
+// correctly reports a missing name (fails-closed, not silently passes).
+// Feeds a synthetic name that cannot exist in the real test suite.
+//
+// AI-robust: Hard — directly exercises l2MatchName with a known-absent name.
+func TestL2OutboxAtomicityCoverage_DetectsMissingName(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	testFuncs := l2CollectTestFuncs(t, root)
+
+	const syntheticName = "TestL2Atomicity_zzznonexistent_RollsBack"
+	if l2MatchName(syntheticName, testFuncs) {
+		t.Errorf("%s DetectsMissingName: matcher reported %q as found; "+
+			"that test must not exist in the module — remove it or choose a different synthetic name",
+			ruleL2AtomicityCoverage, syntheticName)
+	}
+}
+
+// TestL2OutboxAtomicityCoverage_BodyAssertsRollback verifies that each matched
+// producer/hybrid test FuncDecl body contains at least one assert/require
+// selector call AND some rollback-shaped expression (a reference to
+// rollback-related identifiers). This is a semantic best-effort guard.
+//
+// AI-robust: Medium (inherent blind spot — cannot reliably verify test
+// semantics from AST; documented as the one Medium gap in this archtest).
+// Passes vacuously when no expected names are found yet (RED phase).
+func TestL2OutboxAtomicityCoverage_BodyAssertsRollback(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	units := l2EnumerateUnits(t, root)
+	sliceInfos := l2ResolveSliceInfos(t, root, units)
+	expected := l2BuildExpectedNames(units, sliceInfos)
+
+	// Scan *_test.go files collecting FuncDecl AST nodes for matched names.
+	scope := ModuleScope(root, IncludeTests())
+	type funcEntry struct {
+		decl *ast.FuncDecl
+		file *ast.File
+		rel  string
+	}
+	matched := make(map[string]funcEntry)
+
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			if !strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+				if fd.Recv != nil || fd.Name == nil {
+					return
+				}
+				if _, want := expected[fd.Name.Name]; !want {
+					return
+				}
+				if !l2IsStandardTestFunc(fd.Type) {
+					return
+				}
+				matched[fd.Name.Name] = funcEntry{decl: fd, file: f, rel: rel}
+			})
+		}
+		return nil
+	})
+
+	// Vacuous pass when nothing is matched yet (RED phase: tests don't exist).
+	for name, entry := range matched {
+		l2AssertBodyHasAssertion(t, name, entry.decl, entry.rel)
+	}
+}
+
+// l2AssertBodyHasAssertion checks that a test function body contains at least
+// one assert/require call (best-effort semantic check).
+func l2AssertBodyHasAssertion(t *testing.T, name string, fd *ast.FuncDecl, rel string) {
+	t.Helper()
+	if fd.Body == nil {
+		return
+	}
+	hasAssertion := false
+	EachInSubtree[ast.SelectorExpr](fd.Body, func(sel *ast.SelectorExpr) {
+		if hasAssertion {
+			return
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return
+		}
+		if pkg.Name == "assert" || pkg.Name == "require" {
+			hasAssertion = true
+		}
+	})
+	// Check for rollback-shaped identifiers.
+	hasRollbackShape := false
+	EachInSubtree[ast.Ident](fd.Body, func(id *ast.Ident) {
+		if hasRollbackShape {
+			return
+		}
+		name := strings.ToLower(id.Name)
+		if strings.Contains(name, "rollback") || strings.Contains(name, "zero") ||
+			strings.Contains(name, "notexist") || strings.Contains(name, "notfound") ||
+			strings.Contains(name, "empty") || strings.Contains(name, "count") ||
+			strings.Contains(name, "equal") {
+			hasRollbackShape = true
+		}
+	})
+
+	if !hasAssertion {
+		t.Errorf("%s BodyAssertsRollback: %s:%s has no assert/require call (Medium — "+
+			"best-effort semantic check; may need manual inspection)",
+			ruleL2AtomicityCoverage, rel, name)
+	}
+	if !hasRollbackShape {
+		t.Errorf("%s BodyAssertsRollback: %s:%s has no rollback-shaped assertion "+
+			"(count/equal/notexist/rollback reference; Medium — best-effort)",
+			ruleL2AtomicityCoverage, rel, name)
+	}
+}
+
+// ---- Build-tag check helper (used in integration tag self-verification) ----
+
+// l2ParseIntegrationConstraint is a thin wrapper around the file scanner to
+// extract and evaluate a //go:build integration constraint from src content.
+// Used by inline tests; production path uses l2FileHasIntegrationTag.
+func l2ParseIntegrationConstraint(src string) bool {
+	for _, line := range strings.Split(src, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "//go:build") {
+			continue
+		}
+		expr, err := constraint.Parse(line)
+		if err != nil {
+			return false
+		}
+		return expr.Eval(func(tag string) bool { return tag == "integration" })
+	}
+	return false
+}
+
+// TestL2OutboxAtomicityCoverage_IntegrationTagParser verifies that the
+// integration tag parser correctly identifies //go:build integration files
+// and rejects unconstrained ones.
+func TestL2OutboxAtomicityCoverage_IntegrationTagParser(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "has integration tag",
+			src:  "//go:build integration\n\npackage foo\n",
+			want: true,
+		},
+		{
+			name: "no build tag",
+			src:  "package foo\n",
+			want: false,
+		},
+		{
+			name: "different tag",
+			src:  "//go:build e2e\n\npackage foo\n",
+			want: false,
+		},
+		{
+			name: "compound tag with integration",
+			src:  "//go:build integration && !race\n\npackage foo\n",
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := l2ParseIntegrationConstraint(tc.src)
+			assert.Equal(t, tc.want, got,
+				"l2ParseIntegrationConstraint(%q) = %v, want %v", tc.src, got, tc.want)
+		})
+	}
+}
+
+// ---- Inline fixture for AST-scan correctness ----
+
+// TestL2OutboxAtomicityCoverage_ASTScanCollectsTestFunc verifies that
+// l2CollectTestFuncs recognizes a standard Test*(*testing.T) declaration
+// and ignores helper functions with different signatures.
+func TestL2OutboxAtomicityCoverage_ASTScanCollectsTestFunc(t *testing.T) {
+	t.Parallel()
+
+	src := `package foo
+
+import "testing"
+
+func TestFoo(t *testing.T) {}
+func TestBar(t *testing.T, extra int) {}
+func helperFoo(t *testing.T) {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src, 0)
+	require.NoError(t, err)
+
+	var found []string
+	EachInSubtree[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+		if fd.Recv != nil || fd.Name == nil {
+			return
+		}
+		if !strings.HasPrefix(fd.Name.Name, "Test") {
+			return
+		}
+		if !l2IsStandardTestFunc(fd.Type) {
+			return
+		}
+		found = append(found, fd.Name.Name)
+	})
+
+	assert.Equal(t, []string{"TestFoo"}, found,
+		"AST scan should collect only TestFoo (standard signature)")
+}

--- a/tools/archtest/l2_outbox_atomicity_coverage_test.go
+++ b/tools/archtest/l2_outbox_atomicity_coverage_test.go
@@ -372,6 +372,14 @@ func l2IsNamedFrom(t types.Type, pkgPath, typeName string) bool {
 }
 
 // l2BuildExpectedNames constructs the complete deduplicated expected-name set.
+//
+// Granularity is per-UNIT: one canonical TestL2Atomicity_<pkg>_RollsBack per L2
+// slice (+ _ReplayIdempotent for hybrid), matching issue #876's stated scope.
+// A slice's individual outbox-mutation paths (e.g. configwrite Create/Update/
+// Delete) are NOT separately required here — their *_RollsBack_<Mutation> tests
+// are intentional defense-in-depth, documented in the ADR as outside this gate.
+// per-mutation Hard derivation (from RunInTx-emitting Service methods) is tracked
+// in backlog #957; do NOT hand-list mutation suffixes here (Medium regression).
 func l2BuildExpectedNames(units []l2Unit, sliceInfos map[string]l2SliceInfo) map[string]struct{} {
 	expected := make(map[string]struct{})
 

--- a/tools/archtest/l2_outbox_atomicity_coverage_test.go
+++ b/tools/archtest/l2_outbox_atomicity_coverage_test.go
@@ -234,48 +234,47 @@ func l2EnumerateUnits(t *testing.T, root string) []l2Unit {
 	return units
 }
 
+// l2SliceKey is the composite global identity for an L2 slice. Two cells can
+// declare a same-named slice dir (e.g. cells/a/slices/foo and cells/b/slices/foo),
+// so the bare basename is NOT a unique key — keying typed infos by it would let
+// one cell's slice silently overwrite the other's. cellID/sliceDir is unique
+// (mirrors K8s namespace/name identity; bare basename is never a global id).
+func l2SliceKey(cellID, sliceDir string) string {
+	return cellID + "/" + sliceDir
+}
+
 // l2ResolveSliceInfos uses RunTypedProduction to resolve Service type + hybrid
-// flag for every L2 slice unit. Returns a map from sliceDir → l2SliceInfo.
+// flag for every L2 slice unit. Returns a map from l2SliceKey(cellID,sliceDir)
+// → l2SliceInfo (composite key avoids cross-cell same-name collisions).
 func l2ResolveSliceInfos(t *testing.T, root string, units []l2Unit) map[string]l2SliceInfo {
 	t.Helper()
 	modPath, err := moduleImportPath(root)
 	require.NoError(t, err, "%s: read module path", ruleL2AtomicityCoverage)
 
-	// Build set of L2 slice pkg import paths we care about.
-	// Each slice lives at cells/<cellID>/slices/<sliceDir>.
-	type wantEntry struct {
-		sliceDir  string
-		importPkg string
-	}
-	var wantSlices []wantEntry
+	// wantMap maps each L2 slice's import path → its composite identity key.
+	// Each slice lives at cells/<cellID>/slices/<sliceDir>; the import path is
+	// globally unique, and we record results under the composite key so two
+	// cells with a same-named slice dir cannot collide.
+	wantMap := make(map[string]string)
 	for _, u := range units {
 		if u.kind != l2UnitSlice {
 			continue
 		}
 		importPath := modPath + "/cells/" + u.cellID + "/slices/" + u.sliceDir
-		wantSlices = append(wantSlices, wantEntry{
-			sliceDir:  u.sliceDir,
-			importPkg: importPath,
-		})
-	}
-	// Build lookup map: importPath → sliceDir
-	wantMap := make(map[string]string, len(wantSlices))
-	for _, w := range wantSlices {
-		wantMap[w.importPkg] = w.sliceDir
+		wantMap[importPath] = l2SliceKey(u.cellID, u.sliceDir)
 	}
 
-	infos := make(map[string]l2SliceInfo, len(wantSlices))
+	infos := make(map[string]l2SliceInfo, len(wantMap))
 
 	_ = RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
 		if p.Pkg == nil {
 			return nil
 		}
-		sliceDir, ok := wantMap[p.Pkg.Path()]
+		key, ok := wantMap[p.Pkg.Path()]
 		if !ok {
 			return nil
 		}
-		info := l2ResolveServiceInfo(p.Pkg, modPath)
-		infos[sliceDir] = info
+		infos[key] = l2ResolveServiceInfo(p.Pkg, modPath)
 		return nil
 	})
 
@@ -383,7 +382,7 @@ func l2BuildExpectedNames(units []l2Unit, sliceInfos map[string]l2SliceInfo) map
 			expected["TestL2Atomicity_"+u.cellID+"_RollsBack"] = struct{}{}
 
 		case l2UnitSlice:
-			info, ok := sliceInfos[u.sliceDir]
+			info, ok := sliceInfos[l2SliceKey(u.cellID, u.sliceDir)]
 			if !ok {
 				// Typed resolution missed this slice; fall back to sliceDir.
 				expected["TestL2Atomicity_"+u.sliceDir+"_RollsBack"] = struct{}{}
@@ -505,7 +504,7 @@ func TestL2OutboxAtomicityCoverage_ServiceLookupTotal(t *testing.T) {
 		if u.kind != l2UnitSlice {
 			continue
 		}
-		info, found := infos[u.sliceDir]
+		info, found := infos[l2SliceKey(u.cellID, u.sliceDir)]
 		if !found || !info.serviceFound {
 			missing = append(missing, u.cellID+"/"+u.sliceDir)
 		}
@@ -540,7 +539,8 @@ func TestL2OutboxAtomicityCoverage_AliasFoldsToSinglePackage(t *testing.T) {
 	}
 
 	for _, sliceDir := range auditappendSlices {
-		info, found := infos[sliceDir]
+		// All four auditappend* slices live under the auditcore cell.
+		info, found := infos[l2SliceKey("auditcore", sliceDir)]
 		if !found {
 			t.Errorf("%s AliasFoldsToSinglePackage: slice %s not found in typed infos",
 				ruleL2AtomicityCoverage, sliceDir)

--- a/tools/archtest/l2_outbox_atomicity_coverage_test.go
+++ b/tools/archtest/l2_outbox_atomicity_coverage_test.go
@@ -52,13 +52,22 @@
 //     downstream AST scan uses DirsScope+IncludeTests.
 //   - types.Unalias: Go 1.22+; must be applied before (*types.Named) assert.
 //   - Blind spot B1 (Medium): service.go Service type renamed away from
-//     "Service" → ServiceLookupTotal self-check catches this.
+//     "Service", OR Service present but non-Named / nil defining pkg → all
+//     such degraded resolutions set serviceFound=false and are caught by
+//     TestL2OutboxAtomicityCoverage_ServiceLookupTotal.
 //   - Blind spot B2 (Medium): auditappend* de-aliases (removes `type Service
-//     = appender.Service`) → AliasFoldsToSinglePackage self-check catches.
-//   - Blind spot B3 (Hard, via DetectsMissingName): matcher fails-open →
-//     synthetic non-existent name self-check proves it fails-closed.
-//   - Blind spot B4 (Medium, BodyAssertsRollback): body content is semantic
-//     best-effort; documented as inherent-Medium.
+//     = appender.Service`) → TestL2OutboxAtomicityCoverage_AliasFoldsToSinglePackage.
+//   - Blind spot B3 (Hard, via TestL2OutboxAtomicityCoverage_DetectsMissingName):
+//     matcher fails-open → synthetic non-existent name proves it fails-closed.
+//   - Blind spot B4 (Medium, TestL2OutboxAtomicityCoverage_BodyAssertsRollback):
+//     "does the body truly assert rollback" is semantic-equivalence (undecidable,
+//     Rice's theorem) — no sound low-cost Hard path exists, so this stays Medium
+//     by nature (NOT deferred tech debt; no backlog issue). Scans idents AND
+//     string-literal messages for rollback-specific vocabulary.
+//   - Blind spot B5 (Medium): if typed resolution misses a slice entirely
+//     (package load failure), l2BuildExpectedNames falls back to the sliceDir
+//     string for the expected name; ServiceLookupTotal surfaces the miss as a
+//     visible failure rather than silently degrading.
 //
 // ref: seed_role_iface_test.go (alias detection form precedent)
 // ref: assembly_invariants_test.go (YAML + typed multi-phase structure)
@@ -106,8 +115,9 @@ type l2Unit struct {
 
 // l2SliceInfo records typed resolution for one L2 slice package.
 type l2SliceInfo struct {
-	defPkgName string // package name of the defining (Unalias'd) type
-	isHybrid   bool   // Service has HandleEvent method matching the L2 hybrid signature
+	defPkgName   string // package name of the defining (Unalias'd) type
+	isHybrid     bool   // Service has HandleEvent method matching the L2 hybrid signature
+	serviceFound bool   // true ONLY when Service resolved fully (obj→Named→defPkg); false on any fallback
 }
 
 // TestL2OutboxAtomicityCoverage is the primary enforcement test.
@@ -294,8 +304,9 @@ func l2ResolveServiceInfo(pkg *types.Package, modPath string) l2SliceInfo {
 
 	isHybrid := l2ServiceIsHybrid(named, modPath)
 	return l2SliceInfo{
-		defPkgName: defPkg.Name(),
-		isHybrid:   isHybrid,
+		defPkgName:   defPkg.Name(),
+		isHybrid:     isHybrid,
+		serviceFound: true, // full resolution: obj → Named → defPkg all succeeded
 	}
 }
 
@@ -475,8 +486,11 @@ func l2MatchName(name string, testFuncs map[string]l2TestFuncInfo) bool {
 // silently without this guard.
 //
 // AI-robust: Medium (archtest-bound; a rename makes it fail visibly).
-// Blind spot: Service present but of wrong kind (e.g. func) — rare, caught by
-// l2ResolveServiceInfo fallback and subsequent RED in the main test.
+// Checks info.serviceFound (set true ONLY on the full obj→Named→defPkg path),
+// not defPkgName != "" — the fallback returns also set a non-empty pkg.Name(),
+// so a "Service present but non-Named / nil defPkg / absent" degradation would
+// pass a defPkgName check while silently bypassing the typed-derivation Hard
+// guarantee. serviceFound closes that blind spot.
 func TestL2OutboxAtomicityCoverage_ServiceLookupTotal(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
@@ -492,7 +506,7 @@ func TestL2OutboxAtomicityCoverage_ServiceLookupTotal(t *testing.T) {
 			continue
 		}
 		info, found := infos[u.sliceDir]
-		if !found || info.defPkgName == "" {
+		if !found || !info.serviceFound {
 			missing = append(missing, u.cellID+"/"+u.sliceDir)
 		}
 	}
@@ -637,17 +651,29 @@ func l2AssertBodyHasAssertion(t *testing.T, name string, fd *ast.FuncDecl, rel s
 			hasAssertion = true
 		}
 	})
-	// Check for rollback-shaped identifiers.
+	// Check for rollback-specific vocabulary in BOTH identifiers and
+	// string-literal assertion messages. The rollback intent in these tests
+	// lives predominantly in assert/require message strings ("MUST NOT persist",
+	// "rolled back") rather than identifiers, so scanning ast.BasicLit is what
+	// gives this check signal beyond hasAssertion. Generic tokens (equal/count)
+	// are deliberately excluded: nearly every test references assert.Equal or a
+	// count helper, so including them would collapse hasRollbackShape into
+	// hasAssertion (the trivially-true degenerate the reviewer flagged).
+	isRollbackToken := func(s string) bool {
+		s = strings.ToLower(s)
+		return strings.Contains(s, "rollback") || strings.Contains(s, "roll back") ||
+			strings.Contains(s, "persist") || strings.Contains(s, "unchanged") ||
+			strings.Contains(s, "notexist") || strings.Contains(s, "notfound") ||
+			strings.Contains(s, "must not")
+	}
 	hasRollbackShape := false
 	EachInSubtree[ast.Ident](fd.Body, func(id *ast.Ident) {
-		if hasRollbackShape {
-			return
+		if !hasRollbackShape && isRollbackToken(id.Name) {
+			hasRollbackShape = true
 		}
-		name := strings.ToLower(id.Name)
-		if strings.Contains(name, "rollback") || strings.Contains(name, "zero") ||
-			strings.Contains(name, "notexist") || strings.Contains(name, "notfound") ||
-			strings.Contains(name, "empty") || strings.Contains(name, "count") ||
-			strings.Contains(name, "equal") {
+	})
+	EachInSubtree[ast.BasicLit](fd.Body, func(lit *ast.BasicLit) {
+		if !hasRollbackShape && lit.Kind == token.STRING && isRollbackToken(lit.Value) {
 			hasRollbackShape = true
 		}
 	})
@@ -659,7 +685,8 @@ func l2AssertBodyHasAssertion(t *testing.T, name string, fd *ast.FuncDecl, rel s
 	}
 	if !hasRollbackShape {
 		t.Errorf("%s BodyAssertsRollback: %s:%s has no rollback-shaped assertion "+
-			"(count/equal/notexist/rollback reference; Medium — best-effort)",
+			"(rollback/persist/unchanged/must-not reference in ident or message; "+
+			"Medium — best-effort)",
 			ruleL2AtomicityCoverage, rel, name)
 	}
 }

--- a/tools/archtest/l2_outbox_atomicity_coverage_test.go
+++ b/tools/archtest/l2_outbox_atomicity_coverage_test.go
@@ -67,7 +67,6 @@ package archtest
 
 import (
 	"go/ast"
-	"go/build/constraint"
 	"go/parser"
 	"go/token"
 	"go/types"
@@ -424,18 +423,21 @@ func l2CollectTestFuncs(t *testing.T, root string) map[string]l2TestFuncInfo {
 	return result
 }
 
-// l2FileHasIntegrationTag reports whether the file at absPath carries a
-// //go:build integration constraint (or the legacy // +build integration form).
+// l2FileHasIntegrationTag reports whether the file at absPath is exclusively
+// gated on the integration build tag (builds with -tags=integration on top of
+// toolchain defaults, and NOT without it). Delegates to the package-canonical
+// fileHasExclusivelyTag so build-constraint evaluation flows through
+// BuildContextPredicate (TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01) and inherits
+// the drifting toolchain-default tag set rather than a hand-written predicate.
 func l2FileHasIntegrationTag(absPath string) bool {
 	if absPath == "" {
 		return false
 	}
-	expr, err := ParseBuildConstraint(absPath)
-	if err != nil || expr == nil {
+	has, err := fileHasExclusivelyTag(absPath, "integration")
+	if err != nil {
 		return false
 	}
-	// Evaluate with "integration" as the only active tag.
-	return expr.Eval(func(tag string) bool { return tag == "integration" })
+	return has
 }
 
 // l2IsStandardTestFunc reports whether ft matches func(*testing.T).
@@ -662,67 +664,11 @@ func l2AssertBodyHasAssertion(t *testing.T, name string, fd *ast.FuncDecl, rel s
 	}
 }
 
-// ---- Build-tag check helper (used in integration tag self-verification) ----
-
-// l2ParseIntegrationConstraint is a thin wrapper around the file scanner to
-// extract and evaluate a //go:build integration constraint from src content.
-// Used by inline tests; production path uses l2FileHasIntegrationTag.
-func l2ParseIntegrationConstraint(src string) bool {
-	for _, line := range strings.Split(src, "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "//go:build") {
-			continue
-		}
-		expr, err := constraint.Parse(line)
-		if err != nil {
-			return false
-		}
-		return expr.Eval(func(tag string) bool { return tag == "integration" })
-	}
-	return false
-}
-
-// TestL2OutboxAtomicityCoverage_IntegrationTagParser verifies that the
-// integration tag parser correctly identifies //go:build integration files
-// and rejects unconstrained ones.
-func TestL2OutboxAtomicityCoverage_IntegrationTagParser(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		src  string
-		want bool
-	}{
-		{
-			name: "has integration tag",
-			src:  "//go:build integration\n\npackage foo\n",
-			want: true,
-		},
-		{
-			name: "no build tag",
-			src:  "package foo\n",
-			want: false,
-		},
-		{
-			name: "different tag",
-			src:  "//go:build e2e\n\npackage foo\n",
-			want: false,
-		},
-		{
-			name: "compound tag with integration",
-			src:  "//go:build integration && !race\n\npackage foo\n",
-			want: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := l2ParseIntegrationConstraint(tc.src)
-			assert.Equal(t, tc.want, got,
-				"l2ParseIntegrationConstraint(%q) = %v, want %v", tc.src, got, tc.want)
-		})
-	}
-}
+// Build-tag detection is delegated to the package-canonical
+// fileHasExclusivelyTag (see l2FileHasIntegrationTag) so constraint evaluation
+// flows through BuildContextPredicate; that helper carries its own parser
+// self-checks in ci_integration_discovery_invariants_test.go, so no duplicate
+// parser/self-check is maintained here.
 
 // ---- Inline fixture for AST-scan correctness ----
 


### PR DESCRIPTION
## Summary

把 L2 (OutboxFact) 「outbox 原子性测试 + consumer 幂等测试」从 **Soft**（人工记忆 + review）升级为 **Hard** archtest 强制，并补齐缺失测试。升级前 12 个 L2 单元只 2 个有原子性证明。

### 新增 archtest `L2-OUTBOX-ATOMICITY-COVERAGE-01`（`tools/archtest/l2_outbox_atomicity_coverage_test.go`）
- **上游 Hard**：从 `cells/*/cell.yaml` + `cells/*/slices/*/slice.yaml` 的 `consistencyLevel: L2`（metadata SoR）枚举所有 L2 单元，floor 断言 ≥ 12。
- **typed 派生（Hard）**：用 `RunTypedProduction` + `types.Unalias` 解析每个 L2 slice 的 `Service` 定义包名 `<P>`，按 `HandleEvent(...) outbox.HandleResult` typed 信号判 producer/hybrid，派生期望测试名 `TestL2Atomicity_<P>_RollsBack`（hybrid 另加 `_ReplayIdempotent`，cell 级 `TestL2Atomicity_<cellID>_RollsBack`）。
- **下游 Hard**：全局 AST FuncDecl exact-name match + `//go:build integration` 约束校验（经 `BuildContextPredicate`，TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01）。
- **alias 折叠**：4 个 auditappend slice 的 `Service` 经 `types.Unalias` 全部解析到 `appender` → 期望名同一 → 天然折叠成 1 份测试，无手 allowlist、无 alias 启发式。
- 盲区自检：`_ServiceLookupTotal` / `_AliasFoldsToSinglePackage` / `_DetectsMissingName` / `_BodyAssertsRollback`(Medium，语义尽力而为)。

### subtype 分类法（ADR `docs/architecture/202605241940-adr-l2-atomicity-subtypes.md`）
修正 issue 原文 `auditappend* = consumer-only` → **hybrid**（消费域事件 **并** 在同一 `RunInTx` 内发布 `event.audit.appended.v1`）。

| subtype | 实例 | 测试位置 | 断言 |
|---------|------|---------|------|
| producer | sessionlogin/logout/identitymanage/setup/rbacassign/configpublish/configwrite | accesscore→`tests/integration/l2atomicity/`；configcore→slice 集成测试 | outbox fail → domain row 不持久 + 负向控制 |
| hybrid | auditappend{config,role,session,user}（折叠到 appender） | `cells/auditcore/internal/appender/` | emitter fail → ledger 不持久 + replay 幂等 |
| store-level | auditcore cell | `adapters/postgres/audit_ledger_store_test.go` | store.Append + tx fail → 行数不变 |

### 补齐测试（各 cell 自然归属，复用现有 PG 设施）
- **accesscore**（4 E2E，selectiveFailWriter + l2Harness，新增 `newL2HarnessNoSeed`）：sessionlogin / sessionlogout / identitymanage / setup。
- **configcore**：configwrite/configpublish canonical + 每条 mutation 路径 rollback 证明（Update/Delete/Publish-fail）。
- **auditcore**：1 份共享 appender hybrid 测试（真 PG ledger + failing emitter rollback + replay 幂等）。
- 既有 3 个测试归一重命名（rbacassign / auditcore store / config）到 `TestL2Atomicity_*` 命名，删旧名不留别名。
- `make test-integration` 接入 config/audit 包；`go-standards.md` L2 行加 ADR/archtest 指针。

## Test plan
- [x] `go test -run TestL2OutboxAtomicityCoverage ./tools/archtest/...` — **GREEN**（含 4 盲区自检）
- [x] `go build ./...`、5 个 touched 包 `go test -tags=integration,e2e -c` 编译通过
- [x] `golangci-lint run --new-from-merge-base=origin/develop` — **0 new issues**
- [x] meta-archtest `ARCHTEST-VERIFY-COVERAGE-01` / coverage 发现新文件
- [ ] 集成测试运行时行为（rollback/replay）：本地 Docker daemon 不可用，**由 CI 集成分片（testcontainers）实跑**；测试严格克隆已验证模板（rbacassign / 既有 config rollback / audit store），wiring by construction
## Notes

- 本地全量 `go test ./tools/archtest/...` 因 628+ test 超单进程 10min 默认 timeout（CLAUDE.md 已述，应走 `hack/verify-archtest.sh` 分片 / `make verify`）；本 PR 用定向 `-run` 验证个别 archtest。
- 早期排查时，孤立 `go test -run` 单个 typed archtest 曾出现 5 个无关 failure（SCANNER-FRAMEWORK-USAGE-01 等）——经 CI **`make verify` SUCCESS** 确认那是孤立运行缺少全套件 SharedResolver warmup 导致的 typed-info 假阳性，**develop 与本分支的完整 archtest 套件在 CI 全绿，无 pre-existing 失败**，无需另开 issue。
- 集成测试运行时行为（rollback / replay / 负向控制）由 CI 集成分片（testcontainers，含 race-postgres）实跑验证通过（本地 Docker daemon 不可用）。

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)