### PR TITLE
fix(accesscore): mem tx lock-ownership → sealed lock-witness (Hard) (#945)

### DIFF
--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -42,9 +42,9 @@ import (
 )
 
 // durableTxRunner is a test-only TxRunner that simulates a non-noop (real) tx
-// context. It injects the mem-tx token via mem.WithTxContext (holdsLock=false)
+// context. It injects the mem-tx token via mem.WithTxContext (zero witness)
 // so GetByUsernameForUpdate / GetByIDForUpdate take the in-tx code path on
-// mem.Store. holdsLock=false keeps per-call locking (race-safe, no
+// mem.Store. The zero witness keeps per-call locking (race-safe, no
 // cross-method atomicity) since PR fix/238 — ADR
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
 type durableTxRunner struct{}

--- a/cells/accesscore/cell_test.go
+++ b/cells/accesscore/cell_test.go
@@ -42,15 +42,14 @@ import (
 )
 
 // durableTxRunner is a test-only TxRunner that simulates a non-noop (real) tx
-// context. It injects the mem-tx token via mem.WithTxContext (zero witness)
-// so GetByUsernameForUpdate / GetByIDForUpdate take the in-tx code path on
-// mem.Store. The zero witness keeps per-call locking (race-safe, no
-// cross-method atomicity) since PR fix/238 — ADR
+// context. It does NOT hold mem.Store.mu, so it injects no lease: repo methods
+// take their per-call lock (race-safe, no cross-method atomicity). For
+// whole-closure atomicity wire mem.Store.TxRunner() instead. See ADR
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
 type durableTxRunner struct{}
 
 func (durableTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	return fn(mem.WithTxContext(ctx))
+	return fn(ctx)
 }
 
 var _ persistence.TxRunner = durableTxRunner{}

--- a/cells/accesscore/internal/mem/internal/txlock/txlock.go
+++ b/cells/accesscore/internal/mem/internal/txlock/txlock.go
@@ -1,0 +1,62 @@
+// Package txlock mints un-forgeable lock-ownership witnesses for the mem
+// accesscore store. It is the upstream+downstream Hard half of the mem tx
+// lock-ownership funnel (MEM-TX-LOCK-OWNERSHIP-01; ADR
+// docs/architecture/202605171846-adr-mem-tx-lock-ownership.md).
+//
+// The funnel exists to make the "sentinel present but no lock" flake
+// (PR #558 concurrent-map-write) compile-impossible rather than archtest-caught:
+// a tx-context token may authorize a repository method to skip its per-call
+// store.mu lock ONLY if the lock is genuinely held on the calling goroutine.
+//
+// Held is the proof. Its sole field (mu) is unexported, so:
+//
+//   - No package outside txlock can write txlock.Held{mu: …} — the
+//     composite-literal field is inaccessible. The empty literal txlock.Held{}
+//     and the zero value carry mu == nil and Holds reports false for any mutex.
+//   - The ONLY way to obtain a Held whose Holds(&store.mu) is true is to call
+//     Acquire(&store.mu), which actually Lock()s the mutex first.
+//
+// Therefore "in a tx context AND holding the lock" cannot be expressed without
+// having locked — not even inside package mem (mem can call Acquire, but Acquire
+// locks; mem cannot forge a held witness via a struct literal). The double
+// internal/ path (cells/accesscore/internal/mem/internal/txlock) additionally
+// restricts importers to the mem package tree.
+package txlock
+
+import "sync"
+
+// Held is an un-forgeable, read-only proof that Acquire locked a specific
+// *sync.Mutex. It has no Release method by design: a Held carried in a context
+// can prove the lock (Holds) but CANNOT unlock it, so a stray
+// `tok.held.Release()` mid-transaction is structurally impossible. The unlock
+// capability is a separate closure returned by Acquire and kept local to the
+// acquiring frame.
+//
+// The zero Held (and any txlock.Held{} built outside this package) holds no
+// lock: Holds reports false. Held is a value type carrying a *sync.Mutex
+// pointer, so copying it copies the pointer (no sync.Mutex value is copied;
+// go vet copylocks is satisfied).
+type Held struct {
+	mu *sync.Mutex
+}
+
+// Acquire locks mu and returns a Held proof plus the unlock function. It is the
+// sole constructor of a lock-holding Held. The caller keeps unlock local and
+// defers it (`held, unlock := Acquire(&mu); defer unlock()`), then carries held
+// in context for txHoldsLock to consult. Splitting proof from unlock means a
+// context-carried Held cannot release the lock. MEM-TX-LOCK-OWNERSHIP-01 W1
+// funnels all Acquire calls to the single sanctioned site so the lock/unlock
+// pairing is local and auditable. (Same proof-vs-capability split as
+// context.WithCancel returning a cancel func.)
+func Acquire(mu *sync.Mutex) (held Held, unlock func()) {
+	mu.Lock()
+	return Held{mu: mu}, mu.Unlock
+}
+
+// Holds reports whether h proves mu is held — pointer identity against the
+// mutex Acquire locked. A token minted for store A's mutex reports false for
+// store B's mutex (cross-store safety), and the zero Held reports false for any
+// mutex.
+func (h Held) Holds(mu *sync.Mutex) bool {
+	return h.mu != nil && h.mu == mu
+}

--- a/cells/accesscore/internal/mem/internal/txlock/txlock.go
+++ b/cells/accesscore/internal/mem/internal/txlock/txlock.go
@@ -1,62 +1,98 @@
-// Package txlock mints un-forgeable lock-ownership witnesses for the mem
-// accesscore store. It is the upstream+downstream Hard half of the mem tx
+// Package txlock mints un-forgeable, self-invalidating lock-ownership leases for
+// the mem accesscore store. It is the upstream+downstream Hard half of the mem tx
 // lock-ownership funnel (MEM-TX-LOCK-OWNERSHIP-01; ADR
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md).
 //
 // The funnel exists to make the "sentinel present but no lock" flake
 // (PR #558 concurrent-map-write) compile-impossible rather than archtest-caught:
-// a tx-context token may authorize a repository method to skip its per-call
-// store.mu lock ONLY if the lock is genuinely held on the calling goroutine.
+// a tx-context lease may authorize a repository method to skip its per-call
+// store.mu lock ONLY while the lock is genuinely held on the calling goroutine.
 //
-// Held is the proof. Its sole field (mu) is unexported, so:
+// Lease is the proof. Both fields are unexported, so:
 //
-//   - No package outside txlock can write txlock.Held{mu: …} — the
-//     composite-literal field is inaccessible. The empty literal txlock.Held{}
-//     and the zero value carry mu == nil and Holds reports false for any mutex.
-//   - The ONLY way to obtain a Held whose Holds(&store.mu) is true is to call
-//     Acquire(&store.mu), which actually Lock()s the mutex first.
+//   - No package outside txlock can write txlock.Lease{mu: …, live: …} — the
+//     composite-literal fields are inaccessible. The empty literal txlock.Lease{}
+//     and the zero value carry mu == nil / live == nil, and Live reports false for
+//     any mutex.
+//   - The ONLY way to obtain a Lease whose Live(&store.mu) is true is to call
+//     Acquire(&store.mu), which actually Lock()s the mutex AND arms the live flag.
 //
-// Therefore "in a tx context AND holding the lock" cannot be expressed without
-// having locked — not even inside package mem (mem can call Acquire, but Acquire
-// locks; mem cannot forge a held witness via a struct literal). The double
-// internal/ path (cells/accesscore/internal/mem/internal/txlock) additionally
-// restricts importers to the mem package tree.
+// # Forge axis (upstream Hard)
+//
+// "In a tx context AND holding the lock" cannot be expressed without having
+// locked — not even inside package mem (mem can call Acquire, but Acquire locks;
+// mem cannot forge a live lease via a struct literal because mu/live are
+// unexported).
+//
+// # Liveness axis (downstream Hard)
+//
+// The lease SELF-INVALIDATES. Acquire's unlock closure is the sole writer of the
+// live flag; it flips live=false (then Unlocks) when the transaction frame
+// returns. A lease carried in a context that escapes its RunInTx closure
+// therefore reports Live==false afterwards — the repository falls back to
+// per-call locking (fail-closed), so a stale ctx can no longer skip the lock with
+// no lock held. This mirrors database/sql's *Tx.done → ErrTxDone invalidation on
+// commit/rollback. Lease has no Release method and no way to write live from
+// outside the unlock closure, so a ctx-carried lease can neither unlock nor
+// re-arm itself.
+//
+// The double internal/ path (cells/accesscore/internal/mem/internal/txlock)
+// additionally restricts importers to the mem package tree.
 package txlock
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
-// Held is an un-forgeable, read-only proof that Acquire locked a specific
-// *sync.Mutex. It has no Release method by design: a Held carried in a context
-// can prove the lock (Holds) but CANNOT unlock it, so a stray
-// `tok.held.Release()` mid-transaction is structurally impossible. The unlock
-// capability is a separate closure returned by Acquire and kept local to the
-// acquiring frame.
+// Lease is an un-forgeable, self-invalidating proof that Acquire locked a
+// specific *sync.Mutex and that the lock is STILL held (live). It has no Release
+// method by design: a Lease carried in a context can prove the lock (Live) but
+// CANNOT unlock it, so a stray release mid-transaction is structurally
+// impossible. The unlock capability is a separate closure returned by Acquire and
+// kept local to the acquiring frame; that closure is also the sole writer of the
+// live flag.
 //
-// The zero Held (and any txlock.Held{} built outside this package) holds no
-// lock: Holds reports false. Held is a value type carrying a *sync.Mutex
-// pointer, so copying it copies the pointer (no sync.Mutex value is copied;
-// go vet copylocks is satisfied).
-type Held struct {
-	mu *sync.Mutex
+// The zero Lease (and any txlock.Lease{} built outside this package) holds no
+// lock: Live reports false (mu == nil, live == nil). Lease is a value type
+// carrying two pointers (*sync.Mutex and *atomic.Bool), so copying it copies the
+// pointers (no sync.Mutex or atomic value is copied; go vet copylocks is
+// satisfied). The *atomic.Bool MUST stay a pointer, not a value field: a value
+// atomic.Bool would (a) trip copylocks and (b) break visibility, since the unlock
+// closure and every context-carried copy of the Lease must observe the same flag.
+type Lease struct {
+	mu   *sync.Mutex
+	live *atomic.Bool
 }
 
-// Acquire locks mu and returns a Held proof plus the unlock function. It is the
-// sole constructor of a lock-holding Held. The caller keeps unlock local and
-// defers it (`held, unlock := Acquire(&mu); defer unlock()`), then carries held
-// in context for txHoldsLock to consult. Splitting proof from unlock means a
-// context-carried Held cannot release the lock. MEM-TX-LOCK-OWNERSHIP-01 W1
-// funnels all Acquire calls to the single sanctioned site so the lock/unlock
-// pairing is local and auditable. (Same proof-vs-capability split as
-// context.WithCancel returning a cancel func.)
-func Acquire(mu *sync.Mutex) (held Held, unlock func()) {
+// Acquire locks mu, arms a fresh live flag, and returns a Lease proof plus the
+// unlock function. It is the sole constructor of a live, lock-holding Lease. The
+// caller keeps unlock local and defers it (`lease, unlock := Acquire(&mu); defer
+// unlock()`), then carries lease in context for inLiveTx to consult. The unlock
+// closure flips the lease dead (live=false) BEFORE Unlocking, so any
+// context-carried copy that outlives the frame reports Live==false. Splitting the
+// proof from the unlock/invalidate capability means a context-carried Lease can
+// neither release the lock nor keep itself live. MEM-TX-LOCK-OWNERSHIP-01 W1
+// funnels all Acquire calls to the single sanctioned site so the
+// lock/unlock/invalidate triple is local and auditable. (Same proof-vs-capability
+// split as context.WithCancel returning a cancel func; same
+// self-invalidation-on-completion as database/sql *Tx.done → ErrTxDone.)
+func Acquire(mu *sync.Mutex) (lease Lease, unlock func()) {
 	mu.Lock()
-	return Held{mu: mu}, mu.Unlock
+	live := &atomic.Bool{}
+	live.Store(true)
+	return Lease{mu: mu, live: live}, func() {
+		live.Store(false)
+		mu.Unlock()
+	}
 }
 
-// Holds reports whether h proves mu is held — pointer identity against the
-// mutex Acquire locked. A token minted for store A's mutex reports false for
-// store B's mutex (cross-store safety), and the zero Held reports false for any
-// mutex.
-func (h Held) Holds(mu *sync.Mutex) bool {
-	return h.mu != nil && h.mu == mu
+// Live reports whether l proves mu is held RIGHT NOW: pointer identity against
+// the mutex Acquire locked AND the live flag still set. A lease minted for store
+// A's mutex reports false for store B's mutex (cross-store safety); the zero
+// Lease reports false for any mutex (live == nil); and a lease whose unlock has
+// run reports false (self-invalidation, #972). The mu != nil / live != nil guards
+// preceding the loads make the zero Lease and Live(nil) both safe (no nil deref).
+func (l Lease) Live(mu *sync.Mutex) bool {
+	return l.mu != nil && l.mu == mu && l.live != nil && l.live.Load()
 }

--- a/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
+++ b/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
@@ -55,6 +55,19 @@ func TestZeroHeldHoldsNothing(t *testing.T) {
 	}
 }
 
+// TestNonZeroHeldHoldsNil covers the `h.mu != nil && mu == nil` branch: a real
+// witness asked whether it holds the nil mutex must report false (no spurious
+// match, no nil deref).
+func TestNonZeroHeldHoldsNil(t *testing.T) {
+	var mu sync.Mutex
+	held, unlock := Acquire(&mu)
+	defer unlock()
+
+	if held.Holds(nil) {
+		t.Error("non-zero Held Holds(nil) = true, want false")
+	}
+}
+
 // TestHeldSealFrozen is the MEM-TX-LOCK-OWNERSHIP-01 W3 seal regression guard
 // (reflect field-set freeze, mirroring FixtureOpts in tools/archtest/pass_test.go).
 // The Hard property — no package can forge a lock-holding Held — rests on the

--- a/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
+++ b/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
@@ -1,0 +1,81 @@
+package txlock
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAcquireHoldsThenUnlock verifies the witness lifecycle: Acquire locks and
+// yields a Held proving that mutex; Holds is pointer-identity (true for the
+// locked mutex, false for a foreign one); the returned unlock releases so the
+// mutex can be re-acquired (proving Acquire really Lock()ed and unlock really
+// Unlock()ed).
+func TestAcquireHoldsThenUnlock(t *testing.T) {
+	var mu, other sync.Mutex
+
+	held, unlock := Acquire(&mu)
+	if !held.Holds(&mu) {
+		t.Fatal("Acquire(&mu) proof.Holds(&mu) = false, want true")
+	}
+	if held.Holds(&other) {
+		t.Error("Holds(&other) = true, want false (cross-mutex identity)")
+	}
+	unlock()
+
+	// If unlock truly released, a fresh Acquire must not block. Run it in a
+	// goroutine guarded by a channel so a regression (missing Unlock) is a test
+	// timeout rather than a hang.
+	done := make(chan struct{})
+	go func() {
+		_, u2 := Acquire(&mu)
+		u2()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-Acquire blocked: unlock did not Unlock the mutex")
+	}
+}
+
+// TestZeroHeldHoldsNothing verifies the un-forgeable property's runtime face:
+// the zero Held (what any txlock.Held{} built outside this package collapses to)
+// proves no mutex is held.
+func TestZeroHeldHoldsNothing(t *testing.T) {
+	var mu sync.Mutex
+	var zero Held
+
+	if zero.Holds(&mu) {
+		t.Error("zero Held Holds(&mu) = true, want false")
+	}
+	if zero.Holds(nil) {
+		t.Error("zero Held Holds(nil) = true, want false")
+	}
+}
+
+// TestHeldSealFrozen is the MEM-TX-LOCK-OWNERSHIP-01 W3 seal regression guard
+// (reflect field-set freeze, mirroring FixtureOpts in tools/archtest/pass_test.go).
+// The Hard property — no package can forge a lock-holding Held — rests on the
+// sole field being unexported and of pointer-to-mutex type. Exporting it, adding
+// a field, or changing the type would weaken the seal; this fails loudly then.
+func TestHeldSealFrozen(t *testing.T) {
+	rt := reflect.TypeOf(Held{})
+	if rt.NumField() != 1 {
+		t.Fatalf("Held has %d fields, want exactly 1 (mu *sync.Mutex); adding a "+
+			"field risks an exported forge path that defeats the witness seal",
+			rt.NumField())
+	}
+	f := rt.Field(0)
+	if f.Name != "mu" {
+		t.Errorf("Held field[0] name = %q, want %q", f.Name, "mu")
+	}
+	if f.PkgPath == "" {
+		t.Error("Held field[0] is exported; the witness field MUST stay unexported " +
+			"so txlock.Held{<field>: …} is inexpressible outside package txlock")
+	}
+	if f.Type != reflect.TypeOf((*sync.Mutex)(nil)) {
+		t.Errorf("Held field[0] type = %v, want *sync.Mutex", f.Type)
+	}
+}

--- a/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
+++ b/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
@@ -8,6 +8,11 @@ import (
 	"time"
 )
 
+// reAcquireTimeout bounds the re-Acquire-after-unlock check so a regression (an
+// unlock that fails to Unlock) surfaces as a clear test timeout, not a hang.
+// Package-level const per TEST-TIME-LITERAL-01 (no inline duration literals).
+const reAcquireTimeout = 2 * time.Second
+
 // TestAcquireLiveThenUnlock verifies the lease lifecycle: Acquire locks and
 // yields a Lease proving that mutex is held; Live is pointer-identity AND
 // liveness (true for the locked mutex while live, false for a foreign one); the
@@ -45,7 +50,7 @@ func TestAcquireLiveThenUnlock(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	case <-time.After(reAcquireTimeout):
 		t.Fatal("re-Acquire blocked: unlock did not Unlock the mutex")
 	}
 }

--- a/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
+++ b/cells/accesscore/internal/mem/internal/txlock/txlock_test.go
@@ -3,26 +3,36 @@ package txlock
 import (
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// TestAcquireHoldsThenUnlock verifies the witness lifecycle: Acquire locks and
-// yields a Held proving that mutex; Holds is pointer-identity (true for the
-// locked mutex, false for a foreign one); the returned unlock releases so the
-// mutex can be re-acquired (proving Acquire really Lock()ed and unlock really
-// Unlock()ed).
-func TestAcquireHoldsThenUnlock(t *testing.T) {
+// TestAcquireLiveThenUnlock verifies the lease lifecycle: Acquire locks and
+// yields a Lease proving that mutex is held; Live is pointer-identity AND
+// liveness (true for the locked mutex while live, false for a foreign one); the
+// returned unlock both releases the mutex AND invalidates the lease so Live
+// reports false afterwards — the self-invalidation that closes the
+// capability-escape (#972).
+func TestAcquireLiveThenUnlock(t *testing.T) {
 	var mu, other sync.Mutex
 
-	held, unlock := Acquire(&mu)
-	if !held.Holds(&mu) {
-		t.Fatal("Acquire(&mu) proof.Holds(&mu) = false, want true")
+	lease, unlock := Acquire(&mu)
+	if !lease.Live(&mu) {
+		t.Fatal("Acquire(&mu) lease.Live(&mu) = false, want true")
 	}
-	if held.Holds(&other) {
-		t.Error("Holds(&other) = true, want false (cross-mutex identity)")
+	if lease.Live(&other) {
+		t.Error("Live(&other) = true, want false (cross-mutex identity)")
 	}
 	unlock()
+
+	// Self-invalidation: after unlock, the lease is dead — Live(&mu) reports false
+	// even though the mutex pointer still matches. An inner ctx carrying this lease
+	// that escapes its RunInTx closure can therefore no longer authorize skipping
+	// the per-call lock.
+	if lease.Live(&mu) {
+		t.Fatal("after unlock, lease.Live(&mu) = true, want false (self-invalidating lease)")
+	}
 
 	// If unlock truly released, a fresh Acquire must not block. Run it in a
 	// goroutine guarded by a channel so a regression (missing Unlock) is a test
@@ -40,55 +50,69 @@ func TestAcquireHoldsThenUnlock(t *testing.T) {
 	}
 }
 
-// TestZeroHeldHoldsNothing verifies the un-forgeable property's runtime face:
-// the zero Held (what any txlock.Held{} built outside this package collapses to)
-// proves no mutex is held.
-func TestZeroHeldHoldsNothing(t *testing.T) {
+// TestZeroLeaseLiveNothing verifies the un-forgeable property's runtime face: the
+// zero Lease (what any txlock.Lease{} built outside this package collapses to,
+// and what the absence of a tx ctx value yields) proves no mutex is held.
+func TestZeroLeaseLiveNothing(t *testing.T) {
 	var mu sync.Mutex
-	var zero Held
+	var zero Lease
 
-	if zero.Holds(&mu) {
-		t.Error("zero Held Holds(&mu) = true, want false")
+	if zero.Live(&mu) {
+		t.Error("zero Lease Live(&mu) = true, want false")
 	}
-	if zero.Holds(nil) {
-		t.Error("zero Held Holds(nil) = true, want false")
+	if zero.Live(nil) {
+		t.Error("zero Lease Live(nil) = true, want false")
 	}
 }
 
-// TestNonZeroHeldHoldsNil covers the `h.mu != nil && mu == nil` branch: a real
-// witness asked whether it holds the nil mutex must report false (no spurious
+// TestNonZeroLeaseLiveNil covers the `l.mu != nil && mu == nil` branch: a real
+// live lease asked whether it holds the nil mutex must report false (no spurious
 // match, no nil deref).
-func TestNonZeroHeldHoldsNil(t *testing.T) {
+func TestNonZeroLeaseLiveNil(t *testing.T) {
 	var mu sync.Mutex
-	held, unlock := Acquire(&mu)
+	lease, unlock := Acquire(&mu)
 	defer unlock()
 
-	if held.Holds(nil) {
-		t.Error("non-zero Held Holds(nil) = true, want false")
+	if lease.Live(nil) {
+		t.Error("non-zero Lease Live(nil) = true, want false")
 	}
 }
 
-// TestHeldSealFrozen is the MEM-TX-LOCK-OWNERSHIP-01 W3 seal regression guard
+// TestLeaseSealFrozen is the MEM-TX-LOCK-OWNERSHIP-01 seal regression guard
 // (reflect field-set freeze, mirroring FixtureOpts in tools/archtest/pass_test.go).
-// The Hard property — no package can forge a lock-holding Held — rests on the
-// sole field being unexported and of pointer-to-mutex type. Exporting it, adding
-// a field, or changing the type would weaken the seal; this fails loudly then.
-func TestHeldSealFrozen(t *testing.T) {
-	rt := reflect.TypeOf(Held{})
-	if rt.NumField() != 1 {
-		t.Fatalf("Held has %d fields, want exactly 1 (mu *sync.Mutex); adding a "+
-			"field risks an exported forge path that defeats the witness seal",
+// The Hard property — no package can forge a live, lock-holding Lease — rests on
+// BOTH fields being unexported: mu (the locked mutex identity) and live (the
+// liveness flag, written only by Acquire's unlock closure). Exporting either,
+// adding a field, or changing a type would open a forge path; this fails loudly.
+func TestLeaseSealFrozen(t *testing.T) {
+	rt := reflect.TypeOf(Lease{})
+	if rt.NumField() != 2 {
+		t.Fatalf("Lease has %d fields, want exactly 2 (mu *sync.Mutex; live *atomic.Bool); "+
+			"adding or exporting a field risks a forge path that defeats the lease seal",
 			rt.NumField())
 	}
-	f := rt.Field(0)
-	if f.Name != "mu" {
-		t.Errorf("Held field[0] name = %q, want %q", f.Name, "mu")
+
+	mu := rt.Field(0)
+	if mu.Name != "mu" {
+		t.Errorf("Lease field[0] name = %q, want %q", mu.Name, "mu")
 	}
-	if f.PkgPath == "" {
-		t.Error("Held field[0] is exported; the witness field MUST stay unexported " +
-			"so txlock.Held{<field>: …} is inexpressible outside package txlock")
+	if mu.PkgPath == "" {
+		t.Error("Lease field[0] is exported; the mutex field MUST stay unexported " +
+			"so txlock.Lease{mu: …} is inexpressible outside package txlock")
 	}
-	if f.Type != reflect.TypeOf((*sync.Mutex)(nil)) {
-		t.Errorf("Held field[0] type = %v, want *sync.Mutex", f.Type)
+	if mu.Type != reflect.TypeOf((*sync.Mutex)(nil)) {
+		t.Errorf("Lease field[0] type = %v, want *sync.Mutex", mu.Type)
+	}
+
+	live := rt.Field(1)
+	if live.Name != "live" {
+		t.Errorf("Lease field[1] name = %q, want %q", live.Name, "live")
+	}
+	if live.PkgPath == "" {
+		t.Error("Lease field[1] is exported; the liveness flag MUST stay unexported " +
+			"so a live lease cannot be forged by setting it outside Acquire")
+	}
+	if live.Type != reflect.TypeOf((*atomic.Bool)(nil)) {
+		t.Errorf("Lease field[1] type = %v, want *atomic.Bool", live.Type)
 	}
 }

--- a/cells/accesscore/internal/mem/role_repo.go
+++ b/cells/accesscore/internal/mem/role_repo.go
@@ -40,7 +40,7 @@ func (r *RoleRepository) SeedRole(role *domain.Role) {
 // Safe to call both inside and outside a RunInTx closure; see the lock
 // contract on UserRepository (same rules apply here).
 func (r *RoleRepository) Create(ctx context.Context, role *domain.Role) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -54,7 +54,7 @@ func (r *RoleRepository) Create(ctx context.Context, role *domain.Role) error {
 // GetByID returns the Role with the given ID. Safe to call both inside and
 // outside a RunInTx closure; see the lock contract on UserRepository.
 func (r *RoleRepository) GetByID(ctx context.Context, id string) (*domain.Role, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -72,7 +72,7 @@ func (r *RoleRepository) GetByID(ctx context.Context, id string) (*domain.Role, 
 // GetByUserID returns all roles assigned to userID. Safe to call both inside
 // and outside a RunInTx closure; see the lock contract on UserRepository.
 func (r *RoleRepository) GetByUserID(ctx context.Context, userID string) ([]*domain.Role, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -95,7 +95,7 @@ func (r *RoleRepository) GetByUserID(ctx context.Context, userID string) ([]*dom
 // AssignToUser assigns roleID to userID. Safe to call both inside and outside
 // a RunInTx closure; see the lock contract on UserRepository.
 func (r *RoleRepository) AssignToUser(ctx context.Context, userID, roleID string) (bool, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -120,7 +120,7 @@ func (r *RoleRepository) AssignToUser(ctx context.Context, userID, roleID string
 // both inside and outside a RunInTx closure; see the lock contract on
 // UserRepository.
 func (r *RoleRepository) RemoveFromUser(ctx context.Context, userID, roleID string) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -155,7 +155,7 @@ func (r *RoleRepository) RemoveFromUser(ctx context.Context, userID, roleID stri
 // serialization. Safe to call both inside and outside a RunInTx closure; see
 // the lock contract on UserRepository.
 func (r *RoleRepository) RemoveFromUserIfNotLast(ctx context.Context, userID, roleID string) (bool, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -212,7 +212,7 @@ func (r *RoleRepository) ListByUserID(ctx context.Context, userID string, params
 }
 
 func (r *RoleRepository) rolesByUserSnapshot(ctx context.Context, userID string) []*domain.Role {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -261,7 +261,7 @@ func roleFieldValue(r *domain.Role, field string) any {
 // see CountEffectiveAdmins. Safe to call both inside and outside a RunInTx
 // closure; see the lock contract on UserRepository.
 func (r *RoleRepository) CountByRole(ctx context.Context, roleID string) (int, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -280,7 +280,7 @@ func (r *RoleRepository) CountByRole(ctx context.Context, roleID string) (int, e
 // call both inside and outside a RunInTx closure; see the lock contract on
 // UserRepository.
 func (r *RoleRepository) CountEffectiveAdmins(ctx context.Context) (int, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -308,7 +308,7 @@ func (r *RoleRepository) CountEffectiveAdmins(ctx context.Context) (int, error) 
 // for typical small user sets). Safe to call both inside and outside a
 // RunInTx closure; see the lock contract on UserRepository.
 func (r *RoleRepository) EffectiveAdminExists(ctx context.Context) (bool, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}

--- a/cells/accesscore/internal/mem/store.go
+++ b/cells/accesscore/internal/mem/store.go
@@ -16,7 +16,7 @@
 // NewStore to make the shared-state choice explicit and prevent accidental
 // dual-store wiring that would silently lose cross-repo atomicity.
 //
-// # Single-lock rule with sealed lock-ownership witness (PR fix/238, #945)
+// # Single-lock rule with a self-invalidating lock-ownership lease (#945, #972)
 //
 // store.mu is the sole synchronization primitive for all map state. There are
 // exactly two lock-acquisition sites:
@@ -29,37 +29,52 @@
 //  2. Individual repository methods called OUTSIDE a held lock — each acquires
 //     store.mu for its own read or write, then releases it before returning.
 //
-// The tx sentinel in ctx is a typed *memTxToken carrying an un-forgeable
-// txlock.Held witness (see internal/txlock), NOT a bool. Only runLocked — which
-// has just called txlock.Acquire(&store.mu) — injects a token whose witness
-// proves THIS store's mutex is held. Repository methods skip their per-call
-// lock acquisition ONLY when Store.txHoldsLock(ctx) proves the held witness
-// matches store.mu by pointer identity:
+// The ctx carries a txlock.Lease value (see internal/txlock), NOT a bool and NOT
+// a wrapper struct. Only runLocked — which has just called
+// txlock.Acquire(&store.mu) — injects a live lease. Repository methods skip their
+// per-call lock acquisition ONLY when Store.inLiveTx(ctx) reports the lease is
+// live AND bound to THIS store's mutex:
 //
-//   - tok.held.Holds(&s.mu) : runLocked holds store.mu for the whole closure →
-//     skip the per-call lock (sync.Mutex is not reentrant; re-acquiring would
-//     deadlock).
-//   - otherwise (no token / no-witness token / foreign store's mutex) : acquire
-//     store.mu per call.
+//   - inLiveTx true (lease live, lease.mu == &store.mu) : runLocked holds store.mu
+//     for the whole closure → skip the per-call lock (sync.Mutex is not reentrant;
+//     re-acquiring would deadlock).
+//   - otherwise (no lease / dead lease / foreign store's mutex) : acquire store.mu
+//     per call.
 //
-// Why a witness, not a bool: the original bool sentinel could not distinguish
-// "RunInTx holds the lock" from "WithTxContext injected the sentinel but holds
-// no lock". A non-locking TxRunner fake injecting the bool made repo methods
-// skip locking with no lock actually held → concurrent map writes under
-// multi-goroutine load (fatal error: concurrent map writes; the flake fixed by
-// PR fix/238). The witness closes this at the type system: txlock.Held's sole
-// field is unexported, so the ONLY way to obtain a Held whose Holds(&store.mu)
-// is true is txlock.Acquire(&store.mu), which actually Lock()s the mutex.
-// "In a tx context yet not holding the lock, so skip locking" is therefore
-// inexpressible — not even inside package mem (mem may call Acquire, but Acquire
-// locks; mem cannot forge a held witness through a struct literal). WithTxContext
-// mints no witness, so its callers always take the per-call lock and can never
-// race the maps — at the cost of no cross-method atomicity (single-goroutine
-// test helpers do not need it; real cross-method atomicity requires
-// Store.TxRunner()). This aligns with ent (*Tx in context), GORM (in-tx via
-// ConnPool type assertion) and Kratos (*queries.Queries in context): the context
-// carries a strongly-typed ownership object, never a bool. See ADR
+// Two AI-robust axes, both carried by the sealed txlock package (not archtest):
+//
+//   - Forge (upstream Hard): txlock.Lease's fields are unexported, so the ONLY
+//     way to obtain a lease whose Live(&store.mu) is true is
+//     txlock.Acquire(&store.mu), which actually Lock()s the mutex. "In a tx
+//     context yet not holding the lock, so skip locking" is inexpressible — not
+//     even inside package mem (mem may call Acquire, but Acquire locks; mem cannot
+//     forge a live lease through a struct literal).
+//   - Liveness (downstream Hard): the lease self-invalidates. Acquire's unlock
+//     closure (the sole writer of the live flag) flips it dead before store.mu is
+//     released. A ctx that escapes the runLocked closure — captured by a goroutine
+//     or an after-commit hook — therefore reports inLiveTx==false afterwards and
+//     falls back to per-call locking (fail-closed). This closes the
+//     capability-escape that the earlier pointer-only witness left open (#972): the
+//     witness proved the mutex was locked at SOME point, never that it is locked
+//     NOW. Mirrors database/sql *Tx.done → ErrTxDone invalidation on completion.
+//
+// History: the original bool sentinel (pre-#945) could not distinguish "RunInTx
+// holds the lock" from "a non-locking fake injected the sentinel"; a fake making
+// repo methods skip locking with no lock held caused concurrent map writes under
+// multi-goroutine load (fatal error: concurrent map writes; flake fixed by PR
+// fix/238 → #945 witness → #972 lease). The model aligns with ent (*Tx in
+// context), GORM (in-tx via ConnPool type assertion) and Kratos
+// (*queries.Queries in context): the context carries a strongly-typed,
+// resource-bound ownership object, never a bool. See ADR
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
+//
+// Concurrency boundary: the lease guards AFTER-RETURN escape, not
+// CONCURRENT-DURING-TX use. Two goroutines sharing one LIVE tx ctx (e.g. a
+// goroutine spawned inside the closure that touches the repo with the inner ctx
+// while the parent still holds the lock) both see inLiveTx==true and skip
+// locking → the non-holder races the maps. This is the database/sql "*Tx must not
+// be used concurrently by multiple goroutines" boundary and is out of scope for
+// the lease, exactly as ErrTxDone does not make *sql.Tx concurrency-safe.
 //
 // MEM-STORE-RWMUTEX-READ-CONCURRENCY: store.mu could become sync.RWMutex so
 // outside-tx read methods take RLock (cf. client-go ThreadSafeStore).
@@ -67,10 +82,10 @@
 //
 // ForUpdate variants (GetByIDForUpdate, GetByUsernameForUpdate) follow the
 // same rule: inside RunInTx they read under the held store.mu (full
-// FOR-UPDATE-until-commit serialization); under a foreign CellTxManager or
-// WithTxContext they take store.mu per call (functional fallback, no
-// cross-statement serialization). They never hard-fail on the TxRunner
-// pairing — see #501 (that broke corebundle/ssobff/demo logins).
+// FOR-UPDATE-until-commit serialization); under a foreign CellTxManager they take
+// store.mu per call (functional fallback, no cross-statement serialization). They
+// never hard-fail on the TxRunner pairing — see #501 (that broke
+// corebundle/ssobff/demo logins).
 package mem
 
 import (
@@ -83,32 +98,24 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 )
 
-// memTxKey is the context key carrying the *memTxToken injected by
-// memTxRunner.runLocked (with a held witness) or WithTxContext (no witness).
-// Repository methods consult it via Store.txHoldsLock to decide whether
-// store.mu is already held on the calling goroutine.
+// memTxKey is the context key carrying the txlock.Lease injected by
+// memTxRunner.runLocked. A LIVE lease authorizes repository methods to skip their
+// per-call store.mu lock (store.mu is held for the whole runLocked closure); the
+// zero Lease (absent key) means the method must take its own lock. Repository
+// methods consult it via Store.inLiveTx.
+//
+// The ctx carries the txlock.Lease value directly — no wrapper struct. The ONLY
+// way to obtain a Lease whose Live(&store.mu) is true is txlock.Acquire(&store.mu)
+// (which Lock()s the mutex and arms the live flag), and the sole sanctioned
+// Acquire site is runLocked. So "in a tx context AND holding the lock" is
+// inexpressible without genuinely holding the lock (upstream Hard), and the lease
+// self-invalidates when unlock runs so a ctx that escapes the closure fails
+// closed (downstream Hard) — see internal/txlock.
 type memTxKey struct{}
-
-// memTxToken is the typed tx-context value. It carries a txlock.Held witness
-// (see internal/txlock): the ONLY way to obtain a Held that proves store.mu is
-// locked is txlock.Acquire(&store.mu), which Lock()s the mutex. No code outside
-// package txlock can forge a held witness (Held's field is unexported), and the
-// only sanctioned Acquire site is runLocked. So "in a tx context AND holding the
-// lock" is inexpressible without genuinely holding the lock — the upstream and
-// downstream Hard halves of the AI-robust funnel (MEM-TX-LOCK-OWNERSHIP-01).
-// WithTxContext mints a zero-witness token (Holds reports false), which never
-// authorizes a lock skip. The witness's mutex identity also encodes which store
-// the lock belongs to, so a separate store field is unnecessary (cross-store
-// safety is the pointer comparison in Holds).
-type memTxToken struct {
-	// held witnesses that store.mu is locked on the calling goroutine for the
-	// lifetime of the ctx (the runLocked closure). The zero Held holds nothing.
-	held txlock.Held
-}
 
 // memTxRunner is a Store-bound TxRunner that acquires store.mu for the entire
 // transaction closure. All repository operations invoked from within the
-// closure run without additional locking (txHoldsLock proves the lock is
+// closure run without additional locking (inLiveTx proves the lock is
 // held), serializing them atomically — equivalent to PG SELECT FOR UPDATE
 // held until commit.
 //
@@ -118,15 +125,14 @@ type memTxToken struct {
 type memTxRunner struct{ s *Store }
 
 // RunInTx acquires store.mu (exclusive write lock) for the entire duration of
-// fn (via runLocked), injecting a *memTxToken whose txlock.Held witness proves
-// the lock so that repository methods skip their individual lock
-// acquisitions. This serializes
-// all concurrent mem writes for the lifetime of fn — equivalent to a PG
-// transaction WITH SELECT FOR UPDATE.
+// fn (via runLocked), injecting a live txlock.Lease so that repository methods
+// skip their individual lock acquisitions. This serializes all concurrent mem
+// writes for the lifetime of fn — equivalent to a PG transaction WITH SELECT FOR
+// UPDATE.
 //
 // Lock contract: store.mu is held from the start of fn until fn returns.
-// Repository methods called from fn must not acquire store.mu (txHoldsLock
-// returns true for this store, so they skip locking to avoid a deadlock).
+// Repository methods called from fn must not acquire store.mu (inLiveTx returns
+// true for this store, so they skip locking to avoid a deadlock).
 func (r memTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
 	ctx, drainAfterCommit := persistence.WithAfterCommitRegistry(ctx)
 	mark := persistence.AfterCommitMark(ctx)
@@ -135,24 +141,28 @@ func (r memTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error
 		return err
 	}
 	if drainAfterCommit {
-		// Drain AFTER releasing store.mu. store.mu is non-reentrant; the hook ctx
-		// no longer carries the witness token (it is the outer ctx), so a hook
-		// that legitimately touches the store would acquire store.mu fresh —
-		// under the lock that would deadlock. Mirrors PG firing hooks after the
-		// commit is durable.
+		// Drain AFTER releasing store.mu. store.mu is non-reentrant; the drain ctx
+		// is the outer ctx (no lease), so a hook that legitimately touches the
+		// store acquires store.mu fresh. Even a hook that captured the inner ctx
+		// is safe now: runLocked's defer unlock() flipped the lease dead before
+		// this point (#972), so inLiveTx reports false on the captured ctx and the
+		// hook takes the per-call lock instead of stale-skipping. Mirrors PG firing
+		// hooks after the commit is durable.
 		persistence.RunAfterCommitHooks(ctx)
 	}
 	return nil
 }
 
-// runLocked holds store.mu for the duration of fn, injecting a memTxToken whose
-// txlock.Held witness proves the lock. This is the sole sanctioned txlock.Acquire
-// site (MEM-TX-LOCK-OWNERSHIP-01 W1): the witness it mints is the only one that
-// makes txHoldsLock return true for this store.
+// runLocked holds store.mu for the duration of fn, injecting the txlock.Lease
+// that proves the lock. This is the sole sanctioned txlock.Acquire site
+// (MEM-TX-LOCK-OWNERSHIP-01 W1): the lease it mints is the only one that makes
+// inLiveTx return true for this store, and it self-invalidates when unlock runs,
+// so an inner ctx that escapes this frame reports inLiveTx==false afterwards and
+// falls back to per-call locking (#972).
 func (r memTxRunner) runLocked(ctx context.Context, fn func(context.Context) error) error {
-	held, unlock := txlock.Acquire(&r.s.mu)
+	lease, unlock := txlock.Acquire(&r.s.mu)
 	defer unlock()
-	return fn(context.WithValue(ctx, memTxKey{}, &memTxToken{held: held}))
+	return fn(context.WithValue(ctx, memTxKey{}, lease))
 }
 
 // Store is the shared backing for an in-memory accesscore deployment. The
@@ -177,18 +187,20 @@ type Store struct {
 	clock     clock.Clock
 }
 
-// txHoldsLock reports whether ctx carries a *memTxToken whose witness proves
-// THIS store's mu is already held on the calling goroutine (the runLocked
-// closure). Returns false for: no token, WithTxContext's zero-witness token, or
-// a token minted for a different *Store's mutex. A false result means the caller
-// MUST acquire store.mu for its own read/write.
+// inLiveTx reports whether ctx carries a LIVE txlock.Lease proving THIS store's
+// mu is held on the calling goroutine (inside the runLocked closure). Returns
+// false for: no lease (absent key → zero Lease), a lease minted for a different
+// *Store's mutex, or a lease whose tx already returned (unlock flipped it dead —
+// #972). A false result means the caller MUST acquire store.mu for its own
+// read/write.
 //
-// MEM-TX-LOCK-OWNERSHIP-01 W2 pins this exact form (`tok != nil &&
-// tok.held.Holds(&s.mu)`); dropping the Holds conjunct would revive the
-// "sentinel present but no lock" flake.
-func (s *Store) txHoldsLock(ctx context.Context) bool {
-	tok, _ := ctx.Value(memTxKey{}).(*memTxToken)
-	return tok != nil && tok.held.Holds(&s.mu)
+// MEM-TX-LOCK-OWNERSHIP-01 W2 pins this exact form (single return of
+// `l.Live(&s.mu)` where l is the type-asserted lease); the identity + liveness
+// logic lives in the sealed, reflect-frozen txlock.Lease.Live. The zero Lease
+// from a failed type assertion is safe (Live's mu/live nil-guards report false).
+func (s *Store) inLiveTx(ctx context.Context) bool {
+	l, _ := ctx.Value(memTxKey{}).(txlock.Lease)
+	return l.Live(&s.mu)
 }
 
 // NewStore constructs an empty shared Store. clk must be non-nil; mem
@@ -219,45 +231,21 @@ func (s *Store) RoleRepository() *RoleRepository {
 }
 
 // TxRunner returns a Store-bound persistence.TxRunner. It acquires store.mu
-// for the entire RunInTx closure and injects a token whose txlock.Held witness
-// proves the lock so that repository methods skip their individual lock
-// acquisitions.
+// for the entire RunInTx closure and injects a live txlock.Lease so that
+// repository methods skip their individual lock acquisitions.
 //
 // This is the only correct TxRunner to use with repos vended by this Store.
 // Composition roots and test helpers must call:
 //
 //	persistence.WrapForCell(store.TxRunner())
 //
-// Using any other TxRunner (including outbox.DemoTxRunner or a fake that injects
-// the sentinel without holding store.mu) does not break safety — repo methods
-// fall back to per-call locking — but it forfeits cross-method serialization.
+// Using any other TxRunner (including outbox.DemoTxRunner or a fake that does not
+// hold store.mu) does not break safety — repo methods fall back to per-call
+// locking (no live lease in ctx) — but it forfeits cross-method serialization.
 // As a visible consequence, ChangePassword may then return
 // ErrAuthOldPasswordIncorrect (if a concurrent write replaces the hash between
 // the read and the bcrypt comparison) in addition to ErrVersionConflict; the
 // Store-paired TxRunner's FOR-UPDATE-until-commit serialization prevents this.
 func (s *Store) TxRunner() persistence.TxRunner {
 	return memTxRunner{s: s}
-}
-
-// WithTxContext returns ctx carrying a zero-witness *memTxToken. Test helpers
-// that need GetByIDForUpdate / GetByUsernameForUpdate to take the in-tx code
-// path outside a full RunInTx (e.g. a single-goroutine test) use this. Unlike
-// RunInTx, it does NOT hold store.mu and does NOT authorize skipping the
-// per-call lock: every repo method invoked under this ctx still acquires
-// store.mu for its own read/write. It therefore provides no cross-method
-// atomicity — concurrent goroutines are each serialized per call but a
-// multi-statement read-modify-write is not atomic. For real cross-method
-// atomicity use Store.TxRunner().
-//
-// Token semantics: the injected token's held witness is the zero txlock.Held,
-// whose Holds reports false for any mutex (no nil dereference; the witness is a
-// value). It is structurally impossible for WithTxContext to mint a held
-// witness — txlock.Acquire is the only source and it would lock the mutex. The
-// use case is not limited to ForUpdate variants: any code that must enter the
-// in-tx branch (e.g. a fake TxRunner injecting transaction context without
-// holding the lock) can use this. Single-goroutine helpers are safe; for
-// multi-goroutine scenarios requiring cross-method atomicity, use
-// Store.TxRunner() instead.
-func WithTxContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, memTxKey{}, &memTxToken{})
 }

--- a/cells/accesscore/internal/mem/store.go
+++ b/cells/accesscore/internal/mem/store.go
@@ -136,6 +136,12 @@ type memTxRunner struct{ s *Store }
 // Lock contract: store.mu is held from the start of fn until fn returns.
 // Repository methods called from fn must not acquire store.mu (inLiveTx returns
 // true for this store, so they skip locking to avoid a deadlock).
+//
+// Nested RunInTx (e.g. inside an after-commit hook): WithAfterCommitRegistry
+// returns drainAfterCommit=false when a registry is already present in ctx, so
+// hooks registered by a RunInTx invoked from within a hook accumulate into the
+// outer registry and fire in the outer drain pass, not from the nested call.
+// (Upstream kernel/persistence semantics, unchanged by the lease rework.)
 func (r memTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
 	ctx, drainAfterCommit := persistence.WithAfterCommitRegistry(ctx)
 	mark := persistence.AfterCommitMark(ctx)

--- a/cells/accesscore/internal/mem/store.go
+++ b/cells/accesscore/internal/mem/store.go
@@ -16,46 +16,49 @@
 // NewStore to make the shared-state choice explicit and prevent accidental
 // dual-store wiring that would silently lose cross-repo atomicity.
 //
-// # Single-lock rule (R1) with lock-ownership truth (PR fix/238)
+// # Single-lock rule with sealed lock-ownership witness (PR fix/238, #945)
 //
 // store.mu is the sole synchronization primitive for all map state. There are
 // exactly two lock-acquisition sites:
 //
-//  1. memTxRunner.RunInTx — acquires store.mu for the entire transaction
-//     closure. This gives all tx-path operations serialized, atomic access
-//     equivalent to PG SELECT FOR UPDATE held until commit.
+//  1. memTxRunner.runLocked (the body of RunInTx) — acquires store.mu for the
+//     entire transaction closure via txlock.Acquire(&store.mu). This gives all
+//     tx-path operations serialized, atomic access equivalent to PG SELECT FOR
+//     UPDATE held until commit.
 //
 //  2. Individual repository methods called OUTSIDE a held lock — each acquires
 //     store.mu for its own read or write, then releases it before returning.
 //
-// The tx sentinel in ctx is a typed *memTxToken, NOT a bool. Only RunInTx —
-// which has *just called store.mu.Lock() — injects a token with
-// holdsLock=true bound to its own *Store. Repository methods skip their
-// per-call lock acquisition ONLY when Store.txHoldsLock(ctx) proves that THIS
-// store's mutex is genuinely held on the calling goroutine:
+// The tx sentinel in ctx is a typed *memTxToken carrying an un-forgeable
+// txlock.Held witness (see internal/txlock), NOT a bool. Only runLocked — which
+// has just called txlock.Acquire(&store.mu) — injects a token whose witness
+// proves THIS store's mutex is held. Repository methods skip their per-call
+// lock acquisition ONLY when Store.txHoldsLock(ctx) proves the held witness
+// matches store.mu by pointer identity:
 //
-//   - holdsLock==true && token.store==s : RunInTx holds store.mu for the
-//     whole closure → skip the per-call lock (sync.Mutex is not reentrant;
-//     re-acquiring would deadlock).
-//   - otherwise (no token / holdsLock==false / foreign store) : acquire
+//   - tok.held.Holds(&s.mu) : runLocked holds store.mu for the whole closure →
+//     skip the per-call lock (sync.Mutex is not reentrant; re-acquiring would
+//     deadlock).
+//   - otherwise (no token / no-witness token / foreign store's mutex) : acquire
 //     store.mu per call.
 //
-// Why a typed token, not a bool: the previous bool sentinel could not
-// distinguish "RunInTx holds the lock" from "WithTxContext injected the
-// sentinel but holds no lock". A non-locking TxRunner fake injecting the bool
-// made repo methods skip locking with no lock actually held → concurrent map
-// writes under multi-goroutine load (fatal error: concurrent map writes; the
-// flake fixed by PR fix/238). With holdsLock as an unexported field whose
-// only true-construction site is memTxRunner.RunInTx in this file (which
-// really holds the lock), "in a tx context yet not holding the lock, so skip
-// locking" is no longer expressible by any code outside package mem.
-// WithTxContext yields holdsLock=false, so its callers always take the
-// per-call lock and can never race the maps — at the cost of no cross-method
-// atomicity (single-goroutine test helpers do not need it; real cross-method
-// atomicity requires Store.TxRunner()). This aligns with ent (*Tx in
-// context), GORM (in-tx via ConnPool type assertion) and Kratos
-// (*queries.Queries in context): the context carries a strongly-typed
-// ownership object, never a bool. See ADR
+// Why a witness, not a bool: the original bool sentinel could not distinguish
+// "RunInTx holds the lock" from "WithTxContext injected the sentinel but holds
+// no lock". A non-locking TxRunner fake injecting the bool made repo methods
+// skip locking with no lock actually held → concurrent map writes under
+// multi-goroutine load (fatal error: concurrent map writes; the flake fixed by
+// PR fix/238). The witness closes this at the type system: txlock.Held's sole
+// field is unexported, so the ONLY way to obtain a Held whose Holds(&store.mu)
+// is true is txlock.Acquire(&store.mu), which actually Lock()s the mutex.
+// "In a tx context yet not holding the lock, so skip locking" is therefore
+// inexpressible — not even inside package mem (mem may call Acquire, but Acquire
+// locks; mem cannot forge a held witness through a struct literal). WithTxContext
+// mints no witness, so its callers always take the per-call lock and can never
+// race the maps — at the cost of no cross-method atomicity (single-goroutine
+// test helpers do not need it; real cross-method atomicity requires
+// Store.TxRunner()). This aligns with ent (*Tx in context), GORM (in-tx via
+// ConnPool type assertion) and Kratos (*queries.Queries in context): the context
+// carries a strongly-typed ownership object, never a bool. See ADR
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
 //
 // MEM-STORE-RWMUTEX-READ-CONCURRENCY: store.mu could become sync.RWMutex so
@@ -63,9 +66,9 @@
 // Deferred — orthogonal to the flake root fix and independently verifiable.
 //
 // ForUpdate variants (GetByIDForUpdate, GetByUsernameForUpdate) follow the
-// same rule: inside memTxRunner.RunInTx they read under the held store.mu
-// (full FOR-UPDATE-until-commit serialization); under a foreign CellTxManager
-// or WithTxContext they take store.mu per call (functional fallback, no
+// same rule: inside RunInTx they read under the held store.mu (full
+// FOR-UPDATE-until-commit serialization); under a foreign CellTxManager or
+// WithTxContext they take store.mu per call (functional fallback, no
 // cross-statement serialization). They never hard-fail on the TxRunner
 // pairing — see #501 (that broke corebundle/ssobff/demo logins).
 package mem
@@ -75,31 +78,32 @@ import (
 	"sync"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/cells/accesscore/internal/mem/internal/txlock"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
 )
 
 // memTxKey is the context key carrying the *memTxToken injected by
-// memTxRunner.RunInTx (holdsLock=true) or WithTxContext (holdsLock=false).
+// memTxRunner.runLocked (with a held witness) or WithTxContext (no witness).
 // Repository methods consult it via Store.txHoldsLock to decide whether
 // store.mu is already held on the calling goroutine.
 type memTxKey struct{}
 
-// memTxToken is the typed tx-context value. It is unexported and its fields
-// are unexported: the ONLY site that can construct a token with
-// holdsLock=true is memTxRunner.RunInTx in this file (which has just called
-// store.mu.Lock()). No code outside package mem — including test TxRunner
-// fakes — can express "in a tx context AND holding the lock"; the only
-// out-of-package entry, WithTxContext, hard-codes holdsLock=false. This is
-// the upstream half of the AI-robust Hard funnel (MEM-TX-LOCK-OWNERSHIP-01).
+// memTxToken is the typed tx-context value. It carries a txlock.Held witness
+// (see internal/txlock): the ONLY way to obtain a Held that proves store.mu is
+// locked is txlock.Acquire(&store.mu), which Lock()s the mutex. No code outside
+// package txlock can forge a held witness (Held's field is unexported), and the
+// only sanctioned Acquire site is runLocked. So "in a tx context AND holding the
+// lock" is inexpressible without genuinely holding the lock — the upstream and
+// downstream Hard halves of the AI-robust funnel (MEM-TX-LOCK-OWNERSHIP-01).
+// WithTxContext mints a zero-witness token (Holds reports false), which never
+// authorizes a lock skip. The witness's mutex identity also encodes which store
+// the lock belongs to, so a separate store field is unnecessary (cross-store
+// safety is the pointer comparison in Holds).
 type memTxToken struct {
-	// store identifies which *Store's mutex the holder claims to hold. A
-	// token minted for store A must not let store B's repo methods skip
-	// their lock (cross-store safety).
-	store *Store
-	// holdsLock is true iff the injector currently holds store.mu on the
-	// calling goroutine for the lifetime of the ctx (the RunInTx closure).
-	holdsLock bool
+	// held witnesses that store.mu is locked on the calling goroutine for the
+	// lifetime of the ctx (the runLocked closure). The zero Held holds nothing.
+	held txlock.Held
 }
 
 // memTxRunner is a Store-bound TxRunner that acquires store.mu for the entire
@@ -114,8 +118,9 @@ type memTxToken struct {
 type memTxRunner struct{ s *Store }
 
 // RunInTx acquires store.mu (exclusive write lock) for the entire duration of
-// fn, injecting a holdsLock=true *memTxToken bound to this store so that
-// repository methods skip their individual lock acquisitions. This serializes
+// fn (via runLocked), injecting a *memTxToken whose txlock.Held witness proves
+// the lock so that repository methods skip their individual lock
+// acquisitions. This serializes
 // all concurrent mem writes for the lifetime of fn — equivalent to a PG
 // transaction WITH SELECT FOR UPDATE.
 //
@@ -131,19 +136,23 @@ func (r memTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error
 	}
 	if drainAfterCommit {
 		// Drain AFTER releasing store.mu. store.mu is non-reentrant; the hook ctx
-		// no longer carries the holdsLock token, so a hook that legitimately
-		// touches the store would acquire store.mu fresh — under the lock that
-		// would deadlock. Mirrors PG firing hooks after the commit is durable.
+		// no longer carries the witness token (it is the outer ctx), so a hook
+		// that legitimately touches the store would acquire store.mu fresh —
+		// under the lock that would deadlock. Mirrors PG firing hooks after the
+		// commit is durable.
 		persistence.RunAfterCommitHooks(ctx)
 	}
 	return nil
 }
 
-// runLocked holds store.mu for the duration of fn, injecting the holdsLock token.
+// runLocked holds store.mu for the duration of fn, injecting a memTxToken whose
+// txlock.Held witness proves the lock. This is the sole sanctioned txlock.Acquire
+// site (MEM-TX-LOCK-OWNERSHIP-01 W1): the witness it mints is the only one that
+// makes txHoldsLock return true for this store.
 func (r memTxRunner) runLocked(ctx context.Context, fn func(context.Context) error) error {
-	r.s.mu.Lock()
-	defer r.s.mu.Unlock()
-	return fn(context.WithValue(ctx, memTxKey{}, &memTxToken{store: r.s, holdsLock: true}))
+	held, unlock := txlock.Acquire(&r.s.mu)
+	defer unlock()
+	return fn(context.WithValue(ctx, memTxKey{}, &memTxToken{held: held}))
 }
 
 // Store is the shared backing for an in-memory accesscore deployment. The
@@ -168,14 +177,18 @@ type Store struct {
 	clock     clock.Clock
 }
 
-// txHoldsLock reports whether ctx carries a *memTxToken proving that THIS
-// store's mu is already held on the calling goroutine (the RunInTx closure).
-// Returns false for: no token, WithTxContext's holdsLock=false token, or a
-// token minted for a different *Store. A false result means the caller MUST
-// acquire store.mu for its own read/write.
+// txHoldsLock reports whether ctx carries a *memTxToken whose witness proves
+// THIS store's mu is already held on the calling goroutine (the runLocked
+// closure). Returns false for: no token, WithTxContext's zero-witness token, or
+// a token minted for a different *Store's mutex. A false result means the caller
+// MUST acquire store.mu for its own read/write.
+//
+// MEM-TX-LOCK-OWNERSHIP-01 W2 pins this exact form (`tok != nil &&
+// tok.held.Holds(&s.mu)`); dropping the Holds conjunct would revive the
+// "sentinel present but no lock" flake.
 func (s *Store) txHoldsLock(ctx context.Context) bool {
 	tok, _ := ctx.Value(memTxKey{}).(*memTxToken)
-	return tok != nil && tok.holdsLock && tok.store == s
+	return tok != nil && tok.held.Holds(&s.mu)
 }
 
 // NewStore constructs an empty shared Store. clk must be non-nil; mem
@@ -206,8 +219,9 @@ func (s *Store) RoleRepository() *RoleRepository {
 }
 
 // TxRunner returns a Store-bound persistence.TxRunner. It acquires store.mu
-// for the entire RunInTx closure and injects a holdsLock=true token so that
-// repository methods skip their individual lock acquisitions.
+// for the entire RunInTx closure and injects a token whose txlock.Held witness
+// proves the lock so that repository methods skip their individual lock
+// acquisitions.
 //
 // This is the only correct TxRunner to use with repos vended by this Store.
 // Composition roots and test helpers must call:
@@ -225,25 +239,25 @@ func (s *Store) TxRunner() persistence.TxRunner {
 	return memTxRunner{s: s}
 }
 
-// WithTxContext returns ctx carrying a holdsLock=false *memTxToken. Test
-// helpers that need GetByIDForUpdate / GetByUsernameForUpdate to take the
-// in-tx code path outside a full RunInTx (e.g. a single-goroutine test) use
-// this. Unlike RunInTx, it does NOT hold store.mu and does NOT authorize
-// skipping the per-call lock: every repo method invoked under this ctx still
-// acquires store.mu for its own read/write. It therefore provides no
-// cross-method atomicity — concurrent goroutines are each serialized per
-// call but a multi-statement read-modify-write is not atomic. For real
-// cross-method atomicity use Store.TxRunner().
+// WithTxContext returns ctx carrying a zero-witness *memTxToken. Test helpers
+// that need GetByIDForUpdate / GetByUsernameForUpdate to take the in-tx code
+// path outside a full RunInTx (e.g. a single-goroutine test) use this. Unlike
+// RunInTx, it does NOT hold store.mu and does NOT authorize skipping the
+// per-call lock: every repo method invoked under this ctx still acquires
+// store.mu for its own read/write. It therefore provides no cross-method
+// atomicity — concurrent goroutines are each serialized per call but a
+// multi-statement read-modify-write is not atomic. For real cross-method
+// atomicity use Store.TxRunner().
 //
-// Token semantics: the injected token has store==nil and holdsLock==false.
-// txHoldsLock's tok.store == s is a pointer comparison, which is safe for a
-// nil tok.store in Go (no field access); the holdsLock==false short-circuit
-// additionally means that comparison is never reached. Either way, there is no
-// nil dereference. The use case is not limited to ForUpdate variants: any code
-// that must enter the in-tx branch (e.g. a fake TxRunner injecting transaction
-// context without holding the lock) can use this. Single-goroutine helpers are
-// safe; for multi-goroutine scenarios requiring cross-method atomicity, use
+// Token semantics: the injected token's held witness is the zero txlock.Held,
+// whose Holds reports false for any mutex (no nil dereference; the witness is a
+// value). It is structurally impossible for WithTxContext to mint a held
+// witness — txlock.Acquire is the only source and it would lock the mutex. The
+// use case is not limited to ForUpdate variants: any code that must enter the
+// in-tx branch (e.g. a fake TxRunner injecting transaction context without
+// holding the lock) can use this. Single-goroutine helpers are safe; for
+// multi-goroutine scenarios requiring cross-method atomicity, use
 // Store.TxRunner() instead.
 func WithTxContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, memTxKey{}, &memTxToken{holdsLock: false})
+	return context.WithValue(ctx, memTxKey{}, &memTxToken{})
 }

--- a/cells/accesscore/internal/mem/store.go
+++ b/cells/accesscore/internal/mem/store.go
@@ -75,6 +75,9 @@
 // locking → the non-holder races the maps. This is the database/sql "*Tx must not
 // be used concurrently by multiple goroutines" boundary and is out of scope for
 // the lease, exactly as ErrTxDone does not make *sql.Tx concurrency-safe.
+// Operational rule: a goroutine spawned inside the closure MUST NOT use the inner
+// ctx to call repository methods — pass context.Background() (or hand results back
+// over a channel) so the goroutine takes its own per-call lock.
 //
 // MEM-STORE-RWMUTEX-READ-CONCURRENCY: store.mu could become sync.RWMutex so
 // outside-tx read methods take RLock (cf. client-go ThreadSafeStore).

--- a/cells/accesscore/internal/mem/store_escape_test.go
+++ b/cells/accesscore/internal/mem/store_escape_test.go
@@ -4,29 +4,45 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/kernel/clock"
 )
 
 // TestLeaseInvalidatedAfterTxReturn is the escape regression for the
 // self-invalidating lease (#972). A repo method invoked with an inner ctx that
 // escaped its RunInTx closure must NOT skip its per-call store.mu lock: once the
-// tx returns and unlock() runs, the lease is dead, so the in-tx check reports
-// false and the method takes the per-call lock (fail-closed). Run under -race: a
-// stale-skip would be a concurrent map write on the unsynchronized maps.
+// tx returns and unlock() runs, the lease is dead, so inLiveTx reports false and
+// the method takes the per-call lock (fail-closed). Run under -race: with a
+// regression (lease still live after return), the concurrent WRITE goroutines
+// below would skip the lock and race the maps (concurrent map writes / DATA
+// RACE). Note the writes are essential — concurrent map READS are safe in Go, so
+// a read-only loop would not detect the stale-skip.
 //
-// Under the pre-#972 witness model this FAILS: the witness proof is pointer
-// identity that never expires, so the escaped ctx still reports "in tx" after the
-// lock is released — the capability-escape the lease closes.
+// Under the pre-#972 witness model this FAILS at the inLiveTx(escaped) assertion:
+// the witness proof is pointer identity that never expires.
 func TestLeaseInvalidatedAfterTxReturn(t *testing.T) {
 	store := NewStore(clock.Real())
 	runner, ok := store.TxRunner().(memTxRunner)
 	if !ok {
 		t.Fatal("Store.TxRunner() is not a memTxRunner")
 	}
+	repo := store.UserRepository()
+
+	// Seed a user so the escaped-ctx goroutines exercise the read-modify-write
+	// path (BumpAuthzEpoch rewrites usersByID/byName/byEmail) rather than a miss.
+	seed, err := domain.NewUser("escapee", "escapee@example.com", "$2a$12$hash", time.Now())
+	if err != nil {
+		t.Fatalf("NewUser: %v", err)
+	}
+	seed.ID = "usr-escape-001"
+	if err := repo.Create(context.Background(), seed); err != nil {
+		t.Fatalf("seed Create: %v", err)
+	}
 
 	var escaped context.Context
-	err := runner.RunInTx(context.Background(), func(inner context.Context) error {
+	err = runner.RunInTx(context.Background(), func(inner context.Context) error {
 		escaped = inner // capture the in-tx ctx (carries a live lease)
 		if !store.inLiveTx(inner) {
 			t.Fatal("in-tx check must be true inside RunInTx (lock genuinely held)")
@@ -44,16 +60,26 @@ func TestLeaseInvalidatedAfterTxReturn(t *testing.T) {
 			"sentinel-without-lock flake — the lock is no longer held")
 	}
 
-	// Concurrency proof: many goroutines hit the escaped ctx. Because the lease is
-	// dead, each takes per-call store.mu — no concurrent map write under -race.
-	repo := store.UserRepository()
+	// Concurrency proof (write path): many goroutines drive BumpAuthzEpoch — a
+	// read-modify-write on the shared maps — with the escaped (dead-lease) ctx.
+	// Because inLiveTx is false, each call takes per-call store.mu and the writes
+	// serialize: no concurrent map write under -race. A stale-skip regression
+	// would race the maps here.
+	errs := make(chan error, 8)
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = repo.GetByID(escaped, "missing")
+			_, e := repo.BumpAuthzEpoch(escaped, seed.ID)
+			errs <- e
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for e := range errs {
+		if e != nil {
+			t.Errorf("BumpAuthzEpoch on escaped ctx (per-call locked path): %v", e)
+		}
+	}
 }

--- a/cells/accesscore/internal/mem/store_escape_test.go
+++ b/cells/accesscore/internal/mem/store_escape_test.go
@@ -28,7 +28,7 @@ func TestLeaseInvalidatedAfterTxReturn(t *testing.T) {
 	var escaped context.Context
 	err := runner.RunInTx(context.Background(), func(inner context.Context) error {
 		escaped = inner // capture the in-tx ctx (carries a live lease)
-		if !store.txHoldsLock(inner) {
+		if !store.inLiveTx(inner) {
 			t.Fatal("in-tx check must be true inside RunInTx (lock genuinely held)")
 		}
 		return nil
@@ -38,7 +38,7 @@ func TestLeaseInvalidatedAfterTxReturn(t *testing.T) {
 	}
 
 	// After RunInTx returned, the lease must be dead for the escaped ctx.
-	if store.txHoldsLock(escaped) {
+	if store.inLiveTx(escaped) {
 		t.Fatal("in-tx check must be FALSE for an escaped inner ctx after the tx " +
 			"returned (self-invalidating lease); a true result re-arms the " +
 			"sentinel-without-lock flake — the lock is no longer held")

--- a/cells/accesscore/internal/mem/store_escape_test.go
+++ b/cells/accesscore/internal/mem/store_escape_test.go
@@ -1,0 +1,59 @@
+package mem
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+)
+
+// TestLeaseInvalidatedAfterTxReturn is the escape regression for the
+// self-invalidating lease (#972). A repo method invoked with an inner ctx that
+// escaped its RunInTx closure must NOT skip its per-call store.mu lock: once the
+// tx returns and unlock() runs, the lease is dead, so the in-tx check reports
+// false and the method takes the per-call lock (fail-closed). Run under -race: a
+// stale-skip would be a concurrent map write on the unsynchronized maps.
+//
+// Under the pre-#972 witness model this FAILS: the witness proof is pointer
+// identity that never expires, so the escaped ctx still reports "in tx" after the
+// lock is released — the capability-escape the lease closes.
+func TestLeaseInvalidatedAfterTxReturn(t *testing.T) {
+	store := NewStore(clock.Real())
+	runner, ok := store.TxRunner().(memTxRunner)
+	if !ok {
+		t.Fatal("Store.TxRunner() is not a memTxRunner")
+	}
+
+	var escaped context.Context
+	err := runner.RunInTx(context.Background(), func(inner context.Context) error {
+		escaped = inner // capture the in-tx ctx (carries a live lease)
+		if !store.txHoldsLock(inner) {
+			t.Fatal("in-tx check must be true inside RunInTx (lock genuinely held)")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunInTx: %v", err)
+	}
+
+	// After RunInTx returned, the lease must be dead for the escaped ctx.
+	if store.txHoldsLock(escaped) {
+		t.Fatal("in-tx check must be FALSE for an escaped inner ctx after the tx " +
+			"returned (self-invalidating lease); a true result re-arms the " +
+			"sentinel-without-lock flake — the lock is no longer held")
+	}
+
+	// Concurrency proof: many goroutines hit the escaped ctx. Because the lease is
+	// dead, each takes per-call store.mu — no concurrent map write under -race.
+	repo := store.UserRepository()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = repo.GetByID(escaped, "missing")
+		}()
+	}
+	wg.Wait()
+}

--- a/cells/accesscore/internal/mem/user_repo.go
+++ b/cells/accesscore/internal/mem/user_repo.go
@@ -28,12 +28,12 @@ const (
 // # Lock contract
 //
 // Methods on UserRepository follow the single-lock rule (see store.go package
-// godoc). Each method checks r.store.txHoldsLock(ctx):
+// godoc). Each method checks r.store.inLiveTx(ctx):
 //
-//   - txHoldsLock==true: store.mu is already held by memTxRunner.RunInTx on
-//     the calling goroutine — do NOT acquire store.mu (sync.Mutex is not
-//     reentrant; re-acquiring would deadlock).
-//   - txHoldsLock==false (no token / WithTxContext / foreign store): acquire
+//   - inLiveTx==true: store.mu is already held by memTxRunner.RunInTx on
+//     the calling goroutine (a live lease is in ctx) — do NOT acquire store.mu
+//     (sync.Mutex is not reentrant; re-acquiring would deadlock).
+//   - inLiveTx==false (no lease / dead lease / foreign store): acquire
 //     store.mu for the duration of this method call.
 //
 // ForUpdate variants (GetByIDForUpdate, GetByUsernameForUpdate) follow the same
@@ -50,7 +50,7 @@ type UserRepository struct {
 // Create persists a new User. Safe to call both inside and outside a RunInTx
 // closure; see UserRepository lock contract.
 func (r *UserRepository) Create(ctx context.Context, user *domain.User) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -74,7 +74,7 @@ func (r *UserRepository) Create(ctx context.Context, user *domain.User) error {
 // GetByID returns the User with the given ID. Safe to call both inside and
 // outside a RunInTx closure; see UserRepository lock contract.
 func (r *UserRepository) GetByID(ctx context.Context, id string) (*domain.User, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -91,7 +91,7 @@ func (r *UserRepository) GetByID(ctx context.Context, id string) (*domain.User, 
 // GetByUsername returns the User with the given username. Safe to call both
 // inside and outside a RunInTx closure; see UserRepository lock contract.
 func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -133,7 +133,7 @@ func (r *UserRepository) UpdateProfile(
 	name, email *domain.NonEmpty,
 	now time.Time,
 ) (*domain.User, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -213,7 +213,7 @@ func (r *UserRepository) UpdateLockState(
 	status domain.UserStatus,
 	now time.Time,
 ) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -286,7 +286,7 @@ func (r *UserRepository) UpdatePasswordResetFlag(
 	required bool,
 	now time.Time,
 ) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -415,7 +415,7 @@ func (r *UserRepository) UpdatePassword(
 	resetRequired bool,
 	expectedPV int64,
 ) (int64, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -462,7 +462,7 @@ func (r *UserRepository) UpdatePassword(
 //
 // Returns ErrAuthUserNotFound when no user matches userID.
 func (r *UserRepository) BumpAuthzEpoch(ctx context.Context, userID string) (int64, error) {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -514,7 +514,7 @@ func (r *UserRepository) BumpAuthzEpoch(ctx context.Context, userID string) (int
 // UpdateLockoutFields, then may call ApplyInTx(LockUser) which goes through
 // a separate Update path).
 func (r *UserRepository) UpdateLockoutFields(ctx context.Context, user *domain.User) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}
@@ -535,7 +535,7 @@ func (r *UserRepository) UpdateLockoutFields(ctx context.Context, user *domain.U
 // Delete removes the User with the given ID. Safe to call both inside and
 // outside a RunInTx closure; see UserRepository lock contract.
 func (r *UserRepository) Delete(ctx context.Context, id string) error {
-	if !r.store.txHoldsLock(ctx) {
+	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()
 	}

--- a/cells/accesscore/internal/mem/user_repo_test.go
+++ b/cells/accesscore/internal/mem/user_repo_test.go
@@ -298,9 +298,9 @@ func TestGetByUsernameForUpdate_InsideRunInTx(t *testing.T) {
 	assert.Equal(t, "usr-intx-un-001", got.ID)
 }
 
-// TestGetByIDForUpdate_WithTxContext verifies that mem.WithTxContext can be
-// used by custom TxRunners to inject the sentinel for GetByIDForUpdate.
-func TestGetByIDForUpdate_WithTxContext(t *testing.T) {
+// TestGetByIDForUpdate_Standalone verifies GetByIDForUpdate works on the
+// standalone (per-call lock) path, outside any RunInTx.
+func TestGetByIDForUpdate_Standalone(t *testing.T) {
 	store := NewStore(clock.Real())
 	repo := store.UserRepository()
 
@@ -309,9 +309,8 @@ func TestGetByIDForUpdate_WithTxContext(t *testing.T) {
 	user.ID = "usr-withctx-001"
 	require.NoError(t, repo.Create(context.Background(), user))
 
-	// WithTxContext must allow GetByIDForUpdate to succeed.
-	ctx := WithTxContext(context.Background())
-	got, err := repo.GetByIDForUpdate(ctx, "usr-withctx-001")
+	// GetByIDForUpdate must succeed on the standalone per-call lock path.
+	got, err := repo.GetByIDForUpdate(context.Background(), "usr-withctx-001")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "usr-withctx-001", got.ID)

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -133,9 +133,8 @@ func newE2EFixture() *e2eFixture {
 	// Shared stub TxRunner — both services fail-fast on nil after 029 #03
 	// ADR Decision 2 (persistence.NoopTxRunner deletion). The e2e flow has
 	// no DB, so a stub that just invokes fn(ctx) satisfies the L2 contract.
-	// stubTxRunner injects a zero witness (mem.WithTxContext), so each repo
-	// method takes a per-call lock: this e2e does NOT verify cross-method
-	// atomicity. Cross-method atomicity (store-bound TxRunner, held witness)
+	// stubTxRunner holds no lock, so each repo method takes its per-call lock:
+	// this e2e does NOT verify cross-method atomicity. Cross-method atomicity (store-bound TxRunner, held witness)
 	// is covered by identitymanage_credential_race_test.go
 	// TestIdentitymanageCredential_ConcurrentChangePassword_EpochPositive.
 	tx := &stubTxRunner{}

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -134,7 +134,7 @@ func newE2EFixture() *e2eFixture {
 	// ADR Decision 2 (persistence.NoopTxRunner deletion). The e2e flow has
 	// no DB, so a stub that just invokes fn(ctx) satisfies the L2 contract.
 	// stubTxRunner holds no lock, so each repo method takes its per-call lock:
-	// this e2e does NOT verify cross-method atomicity. Cross-method atomicity (store-bound TxRunner, held witness)
+	// this e2e does NOT verify cross-method atomicity. Cross-method atomicity (store-bound TxRunner, live lease)
 	// is covered by identitymanage_credential_race_test.go
 	// TestIdentitymanageCredential_ConcurrentChangePassword_EpochPositive.
 	tx := &stubTxRunner{}

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -133,9 +133,9 @@ func newE2EFixture() *e2eFixture {
 	// Shared stub TxRunner — both services fail-fast on nil after 029 #03
 	// ADR Decision 2 (persistence.NoopTxRunner deletion). The e2e flow has
 	// no DB, so a stub that just invokes fn(ctx) satisfies the L2 contract.
-	// stubTxRunner injects holdsLock=false (mem.WithTxContext), so each repo
+	// stubTxRunner injects a zero witness (mem.WithTxContext), so each repo
 	// method takes a per-call lock: this e2e does NOT verify cross-method
-	// atomicity. Cross-method atomicity (store-bound TxRunner, holdsLock=true)
+	// atomicity. Cross-method atomicity (store-bound TxRunner, held witness)
 	// is covered by identitymanage_credential_race_test.go
 	// TestIdentitymanageCredential_ConcurrentChangePassword_EpochPositive.
 	tx := &stubTxRunner{}

--- a/cells/accesscore/slices/identitymanage/contract_test.go
+++ b/cells/accesscore/slices/identitymanage/contract_test.go
@@ -81,7 +81,7 @@ func (w *contractRecordingWriter) Write(_ context.Context, e outbox.Entry) error
 type contractTxRunner struct{}
 
 func (contractTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	return fn(mem.WithTxContext(ctx))
+	return fn(ctx)
 }
 
 var _ persistence.TxRunner = contractTxRunner{}

--- a/cells/accesscore/slices/identitymanage/identitymanage_credential_race_test.go
+++ b/cells/accesscore/slices/identitymanage/identitymanage_credential_race_test.go
@@ -16,7 +16,7 @@ package identitymanage
 //
 // Design: 50 goroutines concurrently call ChangePassword and Lock on the same
 // user. The in-memory store uses sync.Mutex (per-call lock on all methods);
-// holdsLock=true token is only injectable by store-bound TxRunner (see
+// a held-witness token is only mintable by the store-bound TxRunner (see
 // ADR 202605171846-adr-mem-tx-lock-ownership.md). All operations are
 // race-safe. Post-run assertions verify:
 // (Future upgrade MEM-STORE-RWMUTEX-READ-CONCURRENCY: defer RWMutex hot-path.)
@@ -74,7 +74,7 @@ func TestIdentitymanageCredential_ConcurrentChangePasswordAndLock(t *testing.T) 
 	// Use the store-bound TxRunner so the whole ChangePassword closure runs
 	// under store.mu (cross-method atomicity), which this test's epoch /
 	// revocation terminal assertions require. Since PR fix/238 simpleTxRunner
-	// is itself race-SAFE (holdsLock=false → per-call lock; no more concurrent
+	// is itself race-SAFE (no witness → per-call lock; no more concurrent
 	// map writes) but only Store.TxRunner() gives cross-method atomicity. See
 	// ADR docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
 	svc, err := NewService(userRepo, inv, slog.Default(),
@@ -160,7 +160,7 @@ func TestIdentitymanageCredential_ConcurrentChangePasswordAndLock(t *testing.T) 
 // that after concurrent ChangePassword calls, authz_epoch is positive (each
 // successful ChangePassword increments by exactly 1 via the funnel).
 //
-// This test uses Store.TxRunner() (store-bound, holdsLock=true), which holds
+// This test uses Store.TxRunner() (store-bound, held witness), which holds
 // store.mu for the entire transaction closure and serializes cross-method
 // operations atomically. That whole-closure atomicity is required here because
 // the epoch-positive terminal assertion needs every increment to be fully

--- a/cells/accesscore/slices/identitymanage/identitymanage_credential_race_test.go
+++ b/cells/accesscore/slices/identitymanage/identitymanage_credential_race_test.go
@@ -16,7 +16,7 @@ package identitymanage
 //
 // Design: 50 goroutines concurrently call ChangePassword and Lock on the same
 // user. The in-memory store uses sync.Mutex (per-call lock on all methods);
-// a held-witness token is only mintable by the store-bound TxRunner (see
+// a live txlock.Lease is only mintable by the store-bound TxRunner (see
 // ADR 202605171846-adr-mem-tx-lock-ownership.md). All operations are
 // race-safe. Post-run assertions verify:
 // (Future upgrade MEM-STORE-RWMUTEX-READ-CONCURRENCY: defer RWMutex hot-path.)
@@ -74,7 +74,7 @@ func TestIdentitymanageCredential_ConcurrentChangePasswordAndLock(t *testing.T) 
 	// Use the store-bound TxRunner so the whole ChangePassword closure runs
 	// under store.mu (cross-method atomicity), which this test's epoch /
 	// revocation terminal assertions require. Since PR fix/238 simpleTxRunner
-	// is itself race-SAFE (no witness → per-call lock; no more concurrent
+	// is itself race-SAFE (no live lease → per-call lock; no more concurrent
 	// map writes) but only Store.TxRunner() gives cross-method atomicity. See
 	// ADR docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
 	svc, err := NewService(userRepo, inv, slog.Default(),
@@ -160,7 +160,7 @@ func TestIdentitymanageCredential_ConcurrentChangePasswordAndLock(t *testing.T) 
 // that after concurrent ChangePassword calls, authz_epoch is positive (each
 // successful ChangePassword increments by exactly 1 via the funnel).
 //
-// This test uses Store.TxRunner() (store-bound, held witness), which holds
+// This test uses Store.TxRunner() (store-bound, live lease), which holds
 // store.mu for the entire transaction closure and serializes cross-method
 // operations atomically. That whole-closure atomicity is required here because
 // the epoch-positive terminal assertion needs every increment to be fully

--- a/cells/accesscore/slices/identitymanage/outbox_test.go
+++ b/cells/accesscore/slices/identitymanage/outbox_test.go
@@ -43,7 +43,7 @@ type stubTxRunner struct{ calls int }
 
 func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
 	s.calls++
-	return fn(mem.WithTxContext(context.Background()))
+	return fn(context.Background())
 }
 
 // outboxStubIssuer is a minimal TokenIssuer stub used by outbox tests that do

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -829,7 +829,7 @@ func (s *Service) ChangePassword(ctx context.Context, input ChangePasswordInput)
 	// the hash computation next to the CAS write avoids a TOCTOU window where a
 	// concurrent change could replace the hash between hash computation and write.
 	//
-	// mem no-witness path (WithTxContext / foreign TxRunner): GetByID and
+	// mem path outside a live tx (foreign / non-locking TxRunner): GetByID and
 	// UpdatePassword each acquire store.mu independently (per-call), so bcrypt
 	// runs between the two locks rather than under a held lock. Cross-method
 	// atomicity is only guaranteed by the mem Store's own TxRunner (held witness)

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -832,7 +832,7 @@ func (s *Service) ChangePassword(ctx context.Context, input ChangePasswordInput)
 	// mem path outside a live tx (foreign / non-locking TxRunner): GetByID and
 	// UpdatePassword each acquire store.mu independently (per-call), so bcrypt
 	// runs between the two locks rather than under a held lock. Cross-method
-	// atomicity is only guaranteed by the mem Store's own TxRunner (held witness)
+	// atomicity is only guaranteed by the mem Store's own TxRunner (live lease)
 	// and by PG; the CAS version check still guards correctness on the mem path
 	// (ADR 202605171846).
 	var userID string

--- a/cells/accesscore/slices/identitymanage/service.go
+++ b/cells/accesscore/slices/identitymanage/service.go
@@ -829,10 +829,10 @@ func (s *Service) ChangePassword(ctx context.Context, input ChangePasswordInput)
 	// the hash computation next to the CAS write avoids a TOCTOU window where a
 	// concurrent change could replace the hash between hash computation and write.
 	//
-	// mem holdsLock=false path (WithTxContext / foreign TxRunner): GetByID and
+	// mem no-witness path (WithTxContext / foreign TxRunner): GetByID and
 	// UpdatePassword each acquire store.mu independently (per-call), so bcrypt
 	// runs between the two locks rather than under a held lock. Cross-method
-	// atomicity is only guaranteed by the mem Store's own TxRunner (holdsLock=true)
+	// atomicity is only guaranteed by the mem Store's own TxRunner (held witness)
 	// and by PG; the CAS version check still guards correctness on the mem path
 	// (ADR 202605171846).
 	var userID string

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -42,21 +42,16 @@ func adminCtxForService() context.Context {
 // care about the token pair content.
 var minimalStubIssuer TokenIssuer = &stubTokenIssuer{}
 
-// simpleTxRunner is a test-only pass-through TxRunner. It injects the mem-tx
-// token via mem.WithTxContext (zero witness) so GetByIDForUpdate /
-// GetByUsernameForUpdate take the in-tx code path on a mem.Store repository.
-//
-// Since PR fix/238 a zero witness does NOT bypass store.mu: every repo
-// method still takes its per-call lock, so this runner is race-safe even
-// under concurrent goroutines (no more "concurrent map writes"). It does
-// NOT provide cross-method atomicity (GetByID→…→UpdatePassword are
-// independently locked); tests needing a whole-closure atomic tx must wire
-// mem.Store.TxRunner() instead. See ADR
-// docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
+// simpleTxRunner is a test-only pass-through TxRunner. It holds no lock and
+// passes ctx through unchanged, so each repo method takes its own per-call
+// lock (race-safe under concurrent goroutines). It does NOT provide
+// cross-method atomicity (GetByID→…→UpdatePassword are independently locked);
+// tests needing a whole-closure atomic tx must wire mem.Store.TxRunner()
+// instead. See ADR docs/architecture/202605171846-adr-mem-tx-lock-ownership.md.
 type simpleTxRunner struct{}
 
 func (simpleTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	return fn(mem.WithTxContext(ctx))
+	return fn(ctx)
 }
 
 var _ persistence.TxRunner = simpleTxRunner{}
@@ -998,13 +993,12 @@ func TestChangePassword_StalePasswordVersion_ReturnsConflict(t *testing.T) {
 // MEM-TX-LOCK-OWNERSHIP-01; ADR
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md).
 //
-// It deliberately wires simpleTxRunner — a foreign TxRunner that injects
-// mem.WithTxContext (a zero witness), the exact shape that, under the old
-// bool sentinel, made repo methods skip locking with no lock held and
-// produced `fatal error: concurrent map writes` (the PR #552 CI flake). With
-// the sealed lock-witness, a zero witness forces every repo method onto its
-// per-call store.mu, so 8 goroutines mutating the same user can never race
-// the maps.
+// It deliberately wires simpleTxRunner — a pass-through runner that holds no
+// lock (the exact shape that, under the old bool sentinel, made repo methods
+// skip locking with no lock held and produced `fatal error: concurrent map
+// writes` (the PR #552 CI flake)). With the sealed lock-witness, a foreign
+// runner forces every repo method onto its per-call store.mu, so 8 goroutines
+// mutating the same user can never race the maps.
 //
 // What this test guards (race-safe invariants — NOT timing-dependent):
 //
@@ -1305,8 +1299,8 @@ func TestService_Create_PublishError_DoesNotFailCreate(t *testing.T) {
 // recordingTxRunner observes whether the wrapped repository call happened
 // inside RunInTx. inTx is true only between RunInTx invocation and the
 // closure's return. runs counts how many times RunInTx was invoked.
-// It injects the mem-tx sentinel so GetByIDForUpdate / GetByUsernameForUpdate
-// succeed when called through authzmutate paths that use a mem.Store repository.
+// It holds no lock, so repo methods take their per-call lock (race-safe,
+// no cross-method atomicity).
 type recordingTxRunner struct {
 	inTx bool
 	runs int
@@ -1316,7 +1310,7 @@ func (r *recordingTxRunner) RunInTx(ctx context.Context, fn func(context.Context
 	r.runs++
 	r.inTx = true
 	defer func() { r.inTx = false }()
-	return fn(mem.WithTxContext(ctx))
+	return fn(ctx)
 }
 
 // observingUserRepo snapshots `runner.inTx` at the moment GetByID / Update

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -43,10 +43,10 @@ func adminCtxForService() context.Context {
 var minimalStubIssuer TokenIssuer = &stubTokenIssuer{}
 
 // simpleTxRunner is a test-only pass-through TxRunner. It injects the mem-tx
-// token via mem.WithTxContext (holdsLock=false) so GetByIDForUpdate /
+// token via mem.WithTxContext (zero witness) so GetByIDForUpdate /
 // GetByUsernameForUpdate take the in-tx code path on a mem.Store repository.
 //
-// Since PR fix/238 holdsLock=false does NOT bypass store.mu: every repo
+// Since PR fix/238 a zero witness does NOT bypass store.mu: every repo
 // method still takes its per-call lock, so this runner is race-safe even
 // under concurrent goroutines (no more "concurrent map writes"). It does
 // NOT provide cross-method atomicity (GetByID→…→UpdatePassword are
@@ -999,10 +999,10 @@ func TestChangePassword_StalePasswordVersion_ReturnsConflict(t *testing.T) {
 // docs/architecture/202605171846-adr-mem-tx-lock-ownership.md).
 //
 // It deliberately wires simpleTxRunner — a foreign TxRunner that injects
-// mem.WithTxContext (holdsLock=false), the exact shape that, under the old
+// mem.WithTxContext (a zero witness), the exact shape that, under the old
 // bool sentinel, made repo methods skip locking with no lock held and
 // produced `fatal error: concurrent map writes` (the PR #552 CI flake). With
-// the typed *memTxToken, holdsLock=false forces every repo method onto its
+// the sealed lock-witness, a zero witness forces every repo method onto its
 // per-call store.mu, so 8 goroutines mutating the same user can never race
 // the maps.
 //

--- a/cells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/cells/accesscore/slices/sessionlogin/outbox_test.go
@@ -81,7 +81,7 @@ type stubTxRunner struct {
 
 func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error) error {
 	s.calls++
-	err := fn(mem.WithTxContext(context.Background()))
+	err := fn(context.Background())
 	s.committedCleanly = append(s.committedCleanly, err == nil)
 	return err
 }
@@ -89,11 +89,11 @@ func (s *stubTxRunner) RunInTx(_ context.Context, fn func(context.Context) error
 // noopTxRunner is a pass-through TxRunner that implements outbox.Nooper (Noop()==true),
 // signaling to the service that no real transaction is available (demo/test mode).
 // The service uses isNoopTx to decide whether to run explicit session cleanup on failure.
-// It injects the mem-tx sentinel so GetByUsernameForUpdate succeeds in the non-PG path.
+// It holds no lock, so repo methods take their per-call lock on the non-PG path.
 type noopTxRunner struct{}
 
 func (noopTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
-	return fn(mem.WithTxContext(ctx))
+	return fn(ctx)
 }
 
 func (noopTxRunner) Noop() bool { return true }

--- a/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
+++ b/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
@@ -196,13 +196,16 @@ ref: golang/go database/sql (explicit Tx ownership; non-reentrant Mutex rational
 | **包内** edit 在 runLocked 外 mint 持锁 token | ⚠️ 无防护 | ⚠️→Medium archtest（bool 仍可在包内赋值） | ✅✅ **编译不可表达** | `txlock.Held.mu` 不导出 + 无 Acquire 无 witness（下游 Hard 升级；W1/W2/R1 archtest 仅守纪律漂移） |
 | 构造 token 后 reflect/unsafe 改持锁字段 | ⚠️ — | ✅ 反向自检（mem 禁 reflect/unsafe） | ✅ 反向自检（扩至 txlock 包） | mem + txlock 两包禁 import reflect/unsafe（archtest） |
 | ctx 携带的 witness 被用来**解锁**（liveness） | n/a | ⚠️ token 含可解锁句柄（理论） | ✅ 不可表达 | `Held` 无 Release 方法；unlock 闭包留 runLocked 本地（type system） |
+| after-commit hook 闭包捕获 inner ctx（含 witness），在锁释放后调 repo → stale-skip 锁 | ⚠️ 同属性（bool 亦不随释放过期） | ⚠️ 同属性 | ⚠️ 同属性（**当前不可利用**） | accesscore 零 `RegisterAfterCommit`；框架用 outer ctx drain hooks；gh issue #972 跟踪 accesscore 引入 hook 时的静态守卫 |
 | 跨 store token 混用（A 的 token 让 B 跳锁） | ⚠️ bool 无 store 维度 | ✅ 拒绝（`tok.store == s`） | ✅ 拒绝（不变） | `Held.Holds(&s.mu)` mutex 指针身份（取代 store 字段比较） |
 | RunInTx 跨方法原子性丢失（PG FOR UPDATE 等价） | ✅ 持锁全程 | ✅ 不变 | ✅ 不变 | 持 witness 跳 per-call 锁，闭包持锁 |
 | 单 goroutine fake 测试退化 | ✅ | ✅ 不变 | ✅ 不变 | per-call 锁串行天然原子（无并发） |
 
-无格子从 ✅ 回退到 ⚠️/❌：#945 把第 3 行 ⚠️/Medium 升为 ✅✅（编译 Hard），并新增第 5
-行（witness 解锁 liveness 隐患）由「`Held` 无 Release」结构性消除——两处皆为 verdict
-改善，非回退。
+无格子从 ✅ 回退到 ⚠️/❌：#945 把第 3 行 ⚠️/Medium 升为 ✅✅（编译 Hard），第 5 行
+（witness 解锁 liveness）由「`Held` 无 Release」结构性消除。第 6 行（hook 闭包捕获 inner
+ctx）是 witness 与原 bool 共有的 proof-不随释放过期属性，**当前不可利用**（accesscore 无
+after-commit hook 调用，框架 drain 路径用无 witness 的 outer ctx），由 gh issue #972 跟踪
+未来 accesscore 引入 hook 时需补的静态守卫——属诚实登记的残留 ⚠️，非本 PR 引入的回退。
 
 ## contract-fanout 回灌（5 载体）
 

--- a/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
+++ b/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
@@ -4,6 +4,44 @@
 > Date: 2026-05-17
 > Implementation: 238-mem-tx-lock-ownership
 > Source plan: /Users/shengming/.claude/plans/https-github-com-ghbvf-gocell-actions-ru-smooth-pumpkin.md
+> Amendment: 2026-05-25 (#945) — sealed lock-witness (bool→token Medium funnel
+> upgraded to compile-impossible Hard). The Decisions, threat matrix, and Hard
+> 范本 below are rewritten to the witness model; the Context / L3 root cause
+> records the original bool flake unchanged (accurate history).
+
+## Amendment 2026-05-25 (#945): sealed lock-witness
+
+The 238 design (D1 below, as rewritten) replaced the bool sentinel with a typed
+`*memTxToken{store, holdsLock bool}`. That made *out-of-package* forgery
+compile-impossible (Hard) but left the **in-package** "mint a holdsLock=true
+token outside RunInTx" residue to a **Medium archtest** (old D3 R1/R2) — the
+`holdsLock` bool was still assignable by any code inside package mem.
+
+PR #558 review (issue #945) flagged that the old archtest only checked the
+token literal's *lexical scope*, not its field values, so a future
+`WithTxContext{holdsLock: true}` edit would pass. Rather than patch the Medium
+archtest to pin the bool value, #945 **deletes the bool** and encodes
+lock-ownership as an un-forgeable witness:
+
+- New package `cells/accesscore/internal/mem/internal/txlock` (double-`internal/`
+  → importable only by the mem tree). `txlock.Held` has a single unexported
+  `*sync.Mutex` field; `Acquire(mu) (Held, unlock func())` is the sole way to
+  obtain a Held whose `Holds(&mu)` is true, and it `Lock()`s mu first.
+- `memTxToken` drops `holdsLock bool` AND `store *Store` (the witness's mutex
+  identity subsumes store binding), carrying only `held txlock.Held`.
+- `runLocked` mints the witness (`held, unlock := txlock.Acquire(&r.s.mu)`);
+  `WithTxContext` mints a zero-witness token; `txHoldsLock` returns
+  `tok != nil && tok.held.Holds(&s.mu)`.
+
+Result: "in a tx context AND holding the lock" is **compile-impossible even
+inside package mem** — no code can construct a held witness without calling
+Acquire (which locks). The downstream half moves from runtime-AND-check to
+type-system-Hard. The archtest (`MEM-TX-LOCK-OWNERSHIP-01`, rewritten D3) is
+demoted to a Medium **regression layer** over that Hard core (W1 Acquire site /
+W2 txHoldsLock form / R1 token literal scope); the old R2b `.holdsLock` selector
+funnel is deleted (no bool field exists). `Held` additionally has **no Release
+method** (unlock is a separate closure kept local to runLocked), so a
+ctx-carried witness cannot release the lock either.
 
 ## Context
 
@@ -37,57 +75,78 @@ goroutine 测试即让 repo 方法误判跳锁、无锁并发写 map → fatal�
 
 ## Decisions
 
-### D1. ctx sentinel：bool → 私有 typed `*memTxToken`
+### D1. ctx sentinel：bool → 私有 typed `*memTxToken`（持 sealed witness，#945）
 
-`memTxKey{}` 的 value 类型由 `bool` 改为**包内私有** `*memTxToken`：
+`memTxKey{}` 的 value 类型由 `bool` 改为**包内私有** `*memTxToken`，token 持一个
+**不可伪造的 `txlock.Held` witness**（非 bool、非 store 指针）：
 
 ```go
+// cells/accesscore/internal/mem/internal/txlock（双 internal/，仅 mem 树可 import）
+type Held struct{ mu *sync.Mutex }                       // 唯一字段 unexported
+func Acquire(mu *sync.Mutex) (held Held, unlock func())  // 唯一铸造点，先 Lock()
+func (h Held) Holds(mu *sync.Mutex) bool                 // 指针身份比较（无 Release 方法）
+
+// cells/accesscore/internal/mem
 type memTxToken struct {
-    store     *Store // 哪个 Store 的锁；跨 store 不得跳锁
-    holdsLock bool   // 注入者当前是否在调用 goroutine 上持有 store.mu
+    held txlock.Held // 零值 holds nothing；mutex 身份即 store 绑定（不需 store 字段）
 }
 ```
 
-- `memTxRunner.RunInTx`：`mu.Lock()` 后注入 `&memTxToken{store: r.s, holdsLock: true}`。
-- `WithTxContext`：注入 `&memTxToken{holdsLock: false}`（签名不变）。
-- 删除 `isInMemTx`；新增 `func (s *Store) txHoldsLock(ctx) bool` =
-  `tok != nil && tok.holdsLock && tok.store == s`。
-- 18 处 repo guard（user_repo ×7 / role_repo ×11）
-  `if !isInMemTx(ctx)` → `if !r.store.txHoldsLock(ctx)`。
+- `memTxRunner.runLocked`（`RunInTx` 的 body）：`held, unlock := txlock.Acquire(&r.s.mu); defer unlock()`
+  后注入 `&memTxToken{held: held}`。
+- `WithTxContext`：注入 `&memTxToken{}`（零 witness，签名不变）。
+- `func (s *Store) txHoldsLock(ctx) bool` = `tok != nil && tok.held.Holds(&s.mu)`。
+- 18 处 repo guard 不变（`if !r.store.txHoldsLock(ctx)`；`txHoldsLock` 契约不变，
+  仅内部由 witness 判定取代 bool）。
 
-效果：`holdsLock=false`（WithTxContext / 6 fake）→ 任何 repo 方法走 per-call
-`store.mu.Lock()`，并发写 map **不可能**发生。`holdsLock=true`（仅 RunInTx，
-且 store 身份匹配）→ 跳 per-call 锁，整闭包持锁，跨方法原子性不变（等价 PG
-SELECT FOR UPDATE-until-commit）。`sync.Mutex` 不可重入约束不变。
+效果：零 witness（WithTxContext / fake）→ `Holds` 报 false → 任何 repo 方法走
+per-call `store.mu.Lock()`，并发写 map **不可能**。持 witness（仅 runLocked，且
+mutex 身份匹配）→ 跳 per-call 锁，整闭包持锁，跨方法原子性不变（等价 PG SELECT
+FOR UPDATE-until-commit）。跨 store 由 mutex 指针身份保证（A 的 witness `Holds(&B.mu)`
+为 false），故 `store *Store` 字段删除（冗余）。`sync.Mutex` 不可重入约束不变。
 
-### D2. AI-robust 评级：Hard（type system + 私有字段封装），funnel 双向锁
+### D2. AI-robust 评级：Hard（type system + sealed witness），funnel 双向锁
 
-- **上游 Hard**：`memTxToken` 与 `holdsLock` 均不导出。构造 `holdsLock=true`
-  token 的唯一 callsite 是包内 `memTxRunner.RunInTx`（私有 struct，刚
-  `mu.Lock()`）。`WithTxContext` 公开 API 硬编码 `holdsLock:false`。包外
-  任何代码（含测试 fake）**无 API 表面**可表达「在 tx 且持锁」——Go 编译器
-  即 gate。
-- **下游 Hard**：跳 per-call 锁的能力仅当 `txHoldsLock` 返回 true；该函数
-  AND 校验 `holdsLock && store==s`。
+- **上游 Hard**：`txlock.Held` 唯一字段 `mu` 不导出 → 包外（含 package mem）无法
+  `txlock.Held{mu:…}` 构造；持锁 witness 的唯一来源是 `txlock.Acquire`（真 Lock）。
+  `memTxToken` 与 `held` 字段亦不导出。包外任何代码无 API 表面可表达「在 tx 且
+  持锁」——Go 编译器即 gate。
+- **下游 Hard**（#945 由 runtime-AND-check 升级为 type-system）：跳 per-call 锁仅当
+  `tok.held.Holds(&s.mu)`，而能让 `Holds` 为 true 的 witness 编译期不可伪造——
+  即便在 package mem 内部，无 Acquire（真持锁）就拿不到。`Held` 无 `Release` 方法，
+  ctx 携带的 witness 连解锁都不能（unlock 闭包留在 runLocked 本地）。
 
-闭环成立（对照 ai-robust.md §Funnel 双向锁：下游 Hard + 上游 Hard）。
+闭环成立且**双侧 Hard 由类型系统承载**（对照 ai-robust.md §Funnel 双向锁）。
+原 238 设计下游靠 `txHoldsLock` 的 `holdsLock && store==s` runtime AND 校验
+（Hard 但 runtime）；#945 witness 使该校验退化为 mutex 身份比较，伪造在编译期即
+不可达。
 
-### D3. archtest `MEM-TX-LOCK-OWNERSHIP-01`（Medium 双重防线）
+### D3. archtest `MEM-TX-LOCK-OWNERSHIP-01`（Medium 回归层）
 
-type system 是 Hard 主线；archtest 闭包包内残留风险（未来包内 edit 在别处
-mint holdsLock=true）：R1 = `memTxToken` 复合字面量只许在
-`(memTxRunner).RunInTx` / `WithTxContext`；R2 = 禁 `new(memTxToken)` + 禁
-`.holdsLock` 赋值 LHS。盲区（reflect/unsafe 字段写）由反向自检测试关闭；
-companion-index 精度测试防 vacuous-pass。文件
-`tools/archtest/mem_tx_lock_ownership_test.go`。
+type system（D2 witness seal）是 Hard 主线；archtest 退为 **Medium 回归层**，
+守 witness funnel 的纪律漂移：
 
-R2b accessor 以「FuncDecl 名 `txHoldsLock` + receiver `*Store`」识别（`receiverTypeName`
-是字符串比对 helper，Soft 字符串锚点），并由反向自检
-`TestMemTxLockOwnership01_R2bFindsHoldsLockAccessor`（companion-index）防
-vacuous-pass。因此 R2b 评级为 **Medium**（非 Soft）：两部分字符串锚点匹配 +
-companion-index 防空集。威胁矩阵第 3 行「包内未来 edit 在 RunInTx 外 mint
-holdsLock=true ✅」维持成立——F-A（receiver 校验）与 F-B（反向自检）已在同
-PR 落地。
+- **W1**：`txlock.Acquire` 只许在 `(memTxRunner).runLocked` 内调用（witness 唯一
+  铸造点；按 func 名 `Acquire` + 包路径后缀 `/txlock` typed 解析）。
+- **W2**：`(*Store).txHoldsLock` return 形态 pin 为 `tok != nil && tok.held.Holds(&s.mu)`
+  （扁平化 `&&` 树，恰好 2 合取项：nil-guard + `tok.held.Holds(&<recv>.mu)`）。这把
+  下游 runtime 检查的形态钉死，防 silent regression（如丢 `.Holds` 合取项）。
+- **R1**：`memTxToken` 复合字面量（typed 匹配当前包 `*types.Named`）只许在
+  `runLocked` / `WithTxContext`。
+
+旧 R2b（`.holdsLock` selector funnel）**删除**——无 bool 字段。旧 R2a（禁
+`new(memTxToken)`）亦无必要：零 witness token 无害（`Holds` false），且 `held`
+不可被赋值为持锁 witness。`Held` 字段集冻结（恰好 1 个 unexported `*sync.Mutex`）
+由 `internal/txlock/txlock_test.go::TestHeldSealFrozen` reflect 守（tools/archtest
+不能 import 双 internal 的 txlock，故 seal freeze 活在 txlock 包自身，镜像
+`FixtureOpts` freeze 范式）。盲区（reflect/unsafe 写 `Held.mu`）由 mem + txlock
+两包禁 import reflect/unsafe 的反向自检关闭；vacuous-pass 由 companion-index
+`TestMemTxLockOwnership01_FindsSanctionedSites` + real-source 反向自检
+`TestMemTxLockOwnership01_FixturePattern`（`internal/memtxlockfixture`）防。
+
+const-fold note：#945 原提案拟用 go/types 常量折叠 pin `holdsLock` bool 值；witness
+删除该 bool，无值可折叠、无 bool-const 替换盲区，故 const-fold 取消（typed 模式仍
+用于解析 memTxToken 类型与 Acquire 包）。
 
 ### D4. 被删测试改为活体回归（不删除）
 
@@ -125,19 +184,25 @@ ref: kubernetes/client-go tools/cache/thread_safe_store.go (RWMutex, *Locked con
 ref: golang/go database/sql (explicit Tx ownership; non-reentrant Mutex rationale)
 ```
 
-## 威胁矩阵
+## 威胁矩阵（#945 witness 逐行重评）
 
-| 威胁 | 改造前 | 改造后 | 机制 |
-|------|--------|--------|------|
-| sentinel 在场 + 不持锁 → 并发写 map（本 flake） | ❌ fatal（偶发，调度运气） | ✅ 消除 | holdsLock=false → 强制 per-call 锁 |
-| 包外 fake 伪造「在 tx 且持锁」 | ❌ bool 任意可注入 | ✅ 不可表达 | memTxToken/holdsLock 不导出，编译器 gate（上游 Hard） |
-| 包内未来 edit 在 RunInTx 外 mint holdsLock=true | ⚠️ 无防护 | ✅ archtest 拦截 | MEM-TX-LOCK-OWNERSHIP-01 R1/R2（Medium） |
-| 构造 token 后 reflect/unsafe 改 holdsLock | ⚠️ — | ✅ 反向自检 | mem 包禁 import reflect/unsafe（archtest） |
-| 跨 store token 混用（A 的 token 让 B 跳锁） | ⚠️ bool 无 store 维度 | ✅ 拒绝 | txHoldsLock 校验 `tok.store == s` |
-| RunInTx 跨方法原子性丢失（PG FOR UPDATE 等价） | ✅ 持锁全程 | ✅ 不变 | holdsLock=true 跳 per-call 锁，闭包持锁 |
-| 单 goroutine fake 测试退化 | ✅ | ✅ 不变 | per-call 锁串行天然原子（无并发） |
+「改造后」= 238 token 设计；「#945 后」= sealed witness。三栏对照便于逐行验证
+无 verdict 回退。
 
-无格子从 ✅ 变 ⚠️/❌。
+| 威胁 | 改造前 | 改造后（238 token） | #945 后（witness） | 机制（#945） |
+|------|--------|--------------------|--------------------|------|
+| sentinel 在场 + 不持锁 → 并发写 map（本 flake） | ❌ fatal（偶发） | ✅ 消除（runtime） | ✅ 消除（不变） | 零 witness → `Holds` false → 强制 per-call 锁 |
+| 包外 fake 伪造「在 tx 且持锁」 | ❌ bool 任意可注入 | ✅ 不可表达 | ✅ 不可表达（不变） | `Held`/`memTxToken`/字段不导出，编译器 gate（上游 Hard） |
+| **包内** edit 在 runLocked 外 mint 持锁 token | ⚠️ 无防护 | ⚠️→Medium archtest（bool 仍可在包内赋值） | ✅✅ **编译不可表达** | `txlock.Held.mu` 不导出 + 无 Acquire 无 witness（下游 Hard 升级；W1/W2/R1 archtest 仅守纪律漂移） |
+| 构造 token 后 reflect/unsafe 改持锁字段 | ⚠️ — | ✅ 反向自检（mem 禁 reflect/unsafe） | ✅ 反向自检（扩至 txlock 包） | mem + txlock 两包禁 import reflect/unsafe（archtest） |
+| ctx 携带的 witness 被用来**解锁**（liveness） | n/a | ⚠️ token 含可解锁句柄（理论） | ✅ 不可表达 | `Held` 无 Release 方法；unlock 闭包留 runLocked 本地（type system） |
+| 跨 store token 混用（A 的 token 让 B 跳锁） | ⚠️ bool 无 store 维度 | ✅ 拒绝（`tok.store == s`） | ✅ 拒绝（不变） | `Held.Holds(&s.mu)` mutex 指针身份（取代 store 字段比较） |
+| RunInTx 跨方法原子性丢失（PG FOR UPDATE 等价） | ✅ 持锁全程 | ✅ 不变 | ✅ 不变 | 持 witness 跳 per-call 锁，闭包持锁 |
+| 单 goroutine fake 测试退化 | ✅ | ✅ 不变 | ✅ 不变 | per-call 锁串行天然原子（无并发） |
+
+无格子从 ✅ 回退到 ⚠️/❌：#945 把第 3 行 ⚠️/Medium 升为 ✅✅（编译 Hard），并新增第 5
+行（witness 解锁 liveness 隐患）由「`Held` 无 Release」结构性消除——两处皆为 verdict
+改善，非回退。
 
 ## contract-fanout 回灌（5 载体）
 
@@ -151,12 +216,15 @@ ref: golang/go database/sql (explicit Tx ownership; non-reentrant Mutex rational
 
 ## Rollback
 
-回退 store.go（token→bool）+ 18 处 guard + 删 archtest。flake 复现（已知
+回退 store.go（witness→token→bool）+ 删 txlock 包 + 删 archtest。flake 复现（已知
 `-race -count` 必现），不建议。
 
 ## Hard 范本登记
 
-「unexported typed token + unexported ownership 字段，唯一 true-构造点为
-持锁入口」——context-carried 资源所有权真值的 Hard funnel 范本（上游
-type-system Hard + 下游 txHoldsLock AND 校验 + Medium archtest 包内残留闭包）。
-对标 ent `*Tx` / GORM ConnPool type assertion。
+#945 后落入 ai-robust.md §Hard 范本「**sealed construction**」+「**single sanctioned
+holder**」：context-carried 锁所有权真值经 `internal/` 子包 + unexported 字段 + 私有
+构造（`Acquire` 真持锁）使「在 tx 且持锁」**编译不可表达，即便在 owning 包内**——比
+238 的「unexported typed token + runtime AND 校验」更强（下游从 runtime-Hard 升为
+type-system-Hard）。capability/proof 分离（`Held` 只证不解锁，unlock 闭包另返）对标
+`context.WithCancel`。范本本身已在 ai-robust.md 封闭集内，本条仅登记落地实例，不扩目录。
+对标 ent `*Tx` / GORM ConnPool type assertion / context.WithCancel。

--- a/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
+++ b/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
@@ -8,6 +8,7 @@
 > upgraded to compile-impossible Hard). The Decisions, threat matrix, and Hard
 > 范本 below are rewritten to the witness model; the Context / L3 root cause
 > records the original bool flake unchanged (accurate history).
+> Amendment: 2026-05-25 (#972) — self-invalidating lease（witness 的 liveness 残留闭环）
 
 ## Amendment 2026-05-25 (#945): sealed lock-witness
 
@@ -33,15 +34,58 @@ lock-ownership as an un-forgeable witness:
   `WithTxContext` mints a zero-witness token; `txHoldsLock` returns
   `tok != nil && tok.held.Holds(&s.mu)`.
 
-Result: "in a tx context AND holding the lock" is **compile-impossible even
-inside package mem** — no code can construct a held witness without calling
-Acquire (which locks). The downstream half moves from runtime-AND-check to
-type-system-Hard. The archtest (`MEM-TX-LOCK-OWNERSHIP-01`, rewritten D3) is
-demoted to a Medium **regression layer** over that Hard core (W1 Acquire site /
-W2 txHoldsLock form / R1 token literal scope); the old R2b `.holdsLock` selector
-funnel is deleted (no bool field exists). `Held` additionally has **no Release
-method** (unlock is a separate closure kept local to runLocked), so a
-ctx-carried witness cannot release the lock either.
+Result (**forge axis only** — see correction below): FORGING a held witness —
+expressing "in a tx context AND holding the lock" without calling Acquire — is
+**compile-impossible even inside package mem** (no code can construct a held
+witness through a struct literal; Acquire is the sole source and it locks). This
+moves the *forge* check from runtime-AND to type-system-Hard. The archtest
+(`MEM-TX-LOCK-OWNERSHIP-01`, rewritten D3) is demoted to a Medium **regression
+layer** over that Hard forge core; the old R2b `.holdsLock` selector funnel is
+deleted (no bool field exists). `Held` additionally has **no Release method**
+(unlock is a separate closure kept local to runLocked), so a ctx-carried witness
+cannot release the lock either.
+
+**Correction (#972, do not read the above as closing liveness):** #945 closed
+only the *forge* axis. It did NOT close the *liveness* axis — `Held.Holds` is
+pointer-identity only and **never expires**, so a witness that escapes its
+runLocked frame still reports held after `unlock()`. That residual (threat-matrix
+row 6) is closed by the #972 self-invalidating lease below. "Downstream Hard"
+without qualification was an over-claim; the accurate split is forge-Hard (#945)
++ liveness-Hard (#972).
+
+## Amendment 2026-05-25 (#972): self-invalidating lease
+
+#945 witness 使 forge（包外/包内均无法在不调 `Acquire` 的情况下构造持锁 proof）
+达到编译 Hard；但遗留了一个 liveness 残留：`Held.Holds` 只做 mutex 指针比较、
+**永不过期**。当 `runLocked` 返回、`unlock()` 执行后，凡先前通过 inner ctx 逃逸
+（如被 after-commit hook 闭包捕获）的 `Held` 仍让 `Holds` 返回 true——即
+stale-skip：持有逃逸 ctx 的调用方会跳过 per-call 加锁、无锁并发写 map。这正是
+威胁矩阵第 6 行 ⚠️ 的根源。
+
+#972 将 witness 演进为**自失效 lease**，结构性消除该残留：
+
+**结构变化**
+
+- `txlock.Held` → `txlock.Lease`，字段：`{mu *sync.Mutex; live *atomic.Bool}`（均不导出）。
+- `Acquire(mu *sync.Mutex) (Lease, unlock func())`：锁 mu 并 `live.Store(true)`，返回
+  的 unlock 闭包执行 `live.Store(false); mu.Unlock()`。`live` 的翻转**封在 Acquire
+  返回的 unlock 闭包内，外部不可绕过**（无 setter、无 Release 方法、字段不导出）。
+- `Holds(mu) bool` → `Live(mu *sync.Mutex) bool` = `l.mu != nil && l.mu == mu && l.live != nil && l.live.Load()`。
+
+**Ordering 保证**：`runLocked` 中 `defer unlock()` 在函数返回时触发，先于
+`RunInTx` drain after-commit hooks 执行。即便未来 accesscore 注册 after-commit hook
+并捕获 inner ctx，`inLiveTx`（原 `txHoldsLock`）也会因 lease 已失效返回 false，
+fail-closed 退化 per-call 加锁，并发写 map 不可能。
+
+**同步删除的死抽象**
+
+- `memTxToken` 包装器删除（单字段冗余包装，ctx 直接携带 `txlock.Lease`）。
+- `WithTxContext` 删除（注入零 lease，行为与不注入等价；无测试场景需要该 API）。
+- `txHoldsLock` → `inLiveTx`，调用 `l.Live(&s.mu)`，`l` 来自 ctx.Value 类型断言。
+
+对标 `database/sql` 的 `Tx.done`（`atomic.Bool`）→ `ErrTxDone`：commit/rollback 后
+资源自失效，后续操作 fail-closed。`txlock.Lease` 同形态：proof 绑定资源存活窗口
+而非永久 token，窗口结束由 seal 独占翻转，调用方不可续期、不可绕过。
 
 ## Context
 
@@ -75,83 +119,89 @@ goroutine 测试即让 repo 方法误判跳锁、无锁并发写 map → fatal�
 
 ## Decisions
 
-### D1. ctx sentinel：bool → 私有 typed `*memTxToken`（持 sealed witness，#945）
+### D1. ctx sentinel：bool → ctx 直接携带 `txlock.Lease`（#972）
 
-`memTxKey{}` 的 value 类型由 `bool` 改为**包内私有** `*memTxToken`，token 持一个
-**不可伪造的 `txlock.Held` witness**（非 bool、非 store 指针）：
+`memTxKey{}` 的 value 类型由 `bool` 改为**包内私有**的 `txlock.Lease`（值类型，
+非指针包装），持有**不可伪造且自失效**的锁所有权证明：
 
 ```go
 // cells/accesscore/internal/mem/internal/txlock（双 internal/，仅 mem 树可 import）
-type Held struct{ mu *sync.Mutex }                       // 唯一字段 unexported
-func Acquire(mu *sync.Mutex) (held Held, unlock func())  // 唯一铸造点，先 Lock()
-func (h Held) Holds(mu *sync.Mutex) bool                 // 指针身份比较（无 Release 方法）
+type Lease struct {
+    mu   *sync.Mutex  // 不导出
+    live *atomic.Bool // 不导出；翻转封在 unlock 闭包内，外部无 setter
+}
+func Acquire(mu *sync.Mutex) (lease Lease, unlock func())  // 唯一铸造点，先 Lock()，live.Store(true)
+func (l Lease) Live(mu *sync.Mutex) bool                   // mu 指针身份 + live.Load()（无 Release 方法）
 
 // cells/accesscore/internal/mem
-type memTxToken struct {
-    held txlock.Held // 零值 holds nothing；mutex 身份即 store 绑定（不需 store 字段）
-}
+// ctx 直接携带 txlock.Lease（不再有 memTxToken 包装器）
 ```
 
-- `memTxRunner.runLocked`（`RunInTx` 的 body）：`held, unlock := txlock.Acquire(&r.s.mu); defer unlock()`
-  后注入 `&memTxToken{held: held}`。
-- `WithTxContext`：注入 `&memTxToken{}`（零 witness，签名不变）。
-- `func (s *Store) txHoldsLock(ctx) bool` = `tok != nil && tok.held.Holds(&s.mu)`。
-- 18 处 repo guard 不变（`if !r.store.txHoldsLock(ctx)`；`txHoldsLock` 契约不变，
-  仅内部由 witness 判定取代 bool）。
+- `memTxRunner.runLocked`（`RunInTx` 的 body）：`lease, unlock := txlock.Acquire(&r.s.mu); defer unlock()`
+  后注入 `lease` 到 ctx。`defer unlock()` 在 `runLocked` 返回时执行：`live.Store(false); mu.Unlock()`。
+- `WithTxContext` 已删除（零 lease 行为与不注入等价）。
+- `func (s *Store) inLiveTx(ctx) bool`：从 ctx 取出 `txlock.Lease` 做类型断言，调用
+  `l.Live(&s.mu)`。
+- 18 处 repo guard 不变（`if !r.store.inLiveTx(ctx)`；契约不变，仅内部由
+  live-lease 判定取代 witness Holds 判定）。
 
-效果：零 witness（WithTxContext / fake）→ `Holds` 报 false → 任何 repo 方法走
-per-call `store.mu.Lock()`，并发写 map **不可能**。持 witness（仅 runLocked，且
-mutex 身份匹配）→ 跳 per-call 锁，整闭包持锁，跨方法原子性不变（等价 PG SELECT
-FOR UPDATE-until-commit）。跨 store 由 mutex 指针身份保证（A 的 witness `Holds(&B.mu)`
-为 false），故 `store *Store` 字段删除（冗余）。`sync.Mutex` 不可重入约束不变。
+效果：零 lease（ctx 无 lease）→ `Live` 报 false → 任何 repo 方法走 per-call
+`store.mu.Lock()`，并发写 map **不可能**。持 live lease（仅 `runLocked` 路径，且
+`runLocked` 未返回、mutex 身份匹配）→ 跳 per-call 锁，整闭包持锁，跨方法原子性
+不变（等价 PG SELECT FOR UPDATE-until-commit）。`runLocked` 返回后逃逸 inner ctx
+的 lease：`Live` 因 `live=false` 返回 false → fail-closed 强制 per-call 加锁。跨
+store 由 mutex 指针身份保证（A 的 lease `Live(&B.mu)` 为 false）。`sync.Mutex`
+不可重入约束不变。
 
-### D2. AI-robust 评级：Hard（type system + sealed witness），funnel 双向锁
+### D2. AI-robust 评级：forge=Hard + liveness=Hard（type system + sealed lease），funnel 双向锁
 
-- **上游 Hard**：`txlock.Held` 唯一字段 `mu` 不导出 → 包外（含 package mem）无法
-  `txlock.Held{mu:…}` 构造；持锁 witness 的唯一来源是 `txlock.Acquire`（真 Lock）。
-  `memTxToken` 与 `held` 字段亦不导出。包外任何代码无 API 表面可表达「在 tx 且
-  持锁」——Go 编译器即 gate。
-- **下游 Hard**（#945 由 runtime-AND-check 升级为 type-system）：跳 per-call 锁仅当
-  `tok.held.Holds(&s.mu)`，而能让 `Holds` 为 true 的 witness 编译期不可伪造——
-  即便在 package mem 内部，无 Acquire（真持锁）就拿不到。`Held` 无 `Release` 方法，
-  ctx 携带的 witness 连解锁都不能（unlock 闭包留在 runLocked 本地）。
+- **上游 Hard（forge）**：`txlock.Lease` 两字段均不导出 → 包外（含 package mem）无法
+  `txlock.Lease{mu:…, live:…}` 构造；持锁 + live lease 的唯一来源是
+  `txlock.Acquire`（真 Lock + `live.Store(true)`）。ctx value 亦不导出（私有 key 类型）。
+  包外任何代码无 API 表面可表达「在 tx 且持锁」——Go 编译器即 gate。
+- **下游 Hard（liveness，#972 新增）**：跳 per-call 锁仅当 `l.Live(&s.mu)`，而
+  `Live` 的 `live.Load()` 在 `unlock()` 执行后（`runLocked` 返回时 defer 触发）
+  永远返回 false。`live` 的翻转**封在 `Acquire` 返回的 unlock 闭包内，外部无
+  setter、无 Release 方法、字段不导出**——seal 独占翻转，调用方不可续期。
+  逃逸 inner ctx 的 lease 自动失效，fail-closed 退化 per-call 加锁。
 
-闭环成立且**双侧 Hard 由类型系统承载**（对照 ai-robust.md §Funnel 双向锁）。
-原 238 设计下游靠 `txHoldsLock` 的 `holdsLock && store==s` runtime AND 校验
-（Hard 但 runtime）；#945 witness 使该校验退化为 mutex 身份比较，伪造在编译期即
-不可达。
+闭环成立且**forge 与 liveness 均由 seal 承载（双侧 Hard）**（对照 ai-robust.md
+§Funnel 双向锁）。原 #945 witness 中，下游 liveness 是残留 ⚠️（proof 不随锁释放
+过期）；#972 lease 将其升为结构性 Hard，与 forge 侧对称。
 
 ### D3. archtest `MEM-TX-LOCK-OWNERSHIP-01`（Medium 回归层）
 
-type system（D2 witness seal）是 Hard 主线；archtest 退为 **Medium 回归层**，
-守 witness funnel 的纪律漂移：
+type system（D2 lease seal）是 Hard 主线；archtest 退为 **Medium 回归层**，
+守 lease funnel 的纪律漂移：
 
-- **W1**：`txlock.Acquire` 只许在 `(memTxRunner).runLocked` 内调用（witness 唯一
-  铸造点；按 func 名 `Acquire` + 包路径后缀 `/txlock` typed 解析）。
-- **W2**：`(*Store).txHoldsLock` return 形态 pin 为 `tok != nil && tok.held.Holds(&s.mu)`
-  （扁平化 `&&` 树，恰好 2 合取项：nil-guard + `tok.held.Holds(&<recv>.mu)`）。这把
-  下游 runtime 检查的形态钉死，防 silent regression（如丢 `.Holds` 合取项）。
-- **R1**：`memTxToken` 复合字面量（typed 匹配当前包 `*types.Named`）只许在
-  `runLocked` / `WithTxContext`。
+- **W1**：`txlock.Acquire` 只许在 `(memTxRunner).runLocked` 内调用（lease 唯一
+  铸造点；按 func 名 `Acquire` + 包路径后缀 `/txlock` typed 解析；实参须
+  `&r.s.mu`，拒嵌套 func-lit 内的调用形态）。
+- **W2**：`(*Store).inLiveTx` return 形态 pin 为单值 `return l.Live(&s.mu)`，其中
+  `l` 来自 ctx.Value 类型断言（扁平化单 return，无 `&&` 多合取项）。这把下游
+  runtime 检查的形态钉死，防 silent regression（如丢 `.Live` 调用或引入额外
+  条件）。
+- **R1 删除**：原 R1（`memTxToken` 复合字面量范围 pin）随 `memTxToken` 包装器
+  一并删除——ctx 直接携带 `txlock.Lease` 值类型，无复合字面量构造点。
 
-旧 R2b（`.holdsLock` selector funnel）**删除**——无 bool 字段。旧 R2a（禁
-`new(memTxToken)`）亦无必要：零 witness token 无害（`Holds` false），且 `held`
-不可被赋值为持锁 witness。`Held` 字段集冻结（恰好 1 个 unexported `*sync.Mutex`）
-由 `internal/txlock/txlock_test.go::TestHeldSealFrozen` reflect 守（tools/archtest
+旧 R2b（`.holdsLock` selector funnel）已在 #945 删除。`Lease` 字段集冻结（恰好
+2 个 unexported 字段：`*sync.Mutex` + `*atomic.Bool`）由
+`internal/txlock/txlock_test.go::TestLeaseSealFrozen` reflect 守（tools/archtest
 不能 import 双 internal 的 txlock，故 seal freeze 活在 txlock 包自身，镜像
-`FixtureOpts` freeze 范式）。盲区（reflect/unsafe 写 `Held.mu`）由 mem + txlock
-两包禁 import reflect/unsafe 的反向自检关闭；vacuous-pass 由 companion-index
-`TestMemTxLockOwnership01_FindsSanctionedSites` + real-source 反向自检
-`TestMemTxLockOwnership01_FixturePattern`（`internal/memtxlockfixture`）防。
+`FixtureOpts` freeze 范式）。盲区（reflect/unsafe 写 `Lease` 字段）由 mem +
+txlock 两包禁 import reflect/unsafe 的反向自检关闭；vacuous-pass 由
+companion-index `TestMemTxLockOwnership01_FindsSanctionedSites` + real-source
+反向自检 `TestMemTxLockOwnership01_FixturePattern`（`internal/memtxlockfixture`）
+防。
 
-const-fold note：#945 原提案拟用 go/types 常量折叠 pin `holdsLock` bool 值；witness
-删除该 bool，无值可折叠、无 bool-const 替换盲区，故 const-fold 取消（typed 模式仍
-用于解析 memTxToken 类型与 Acquire 包）。
+const-fold note：#945 原提案拟用 go/types 常量折叠 pin `holdsLock` bool 值；
+witness/lease 删除该 bool，无值可折叠、无 bool-const 替换盲区，故 const-fold
+取消（typed 模式仍用于解析 `Lease` 类型与 `Acquire` 包）。
 
 ### D4. 被删测试改为活体回归（不删除）
 
 `TestChangePassword_ConcurrentRequests_ExactlyOneSucceeds` 保留并接
-`simpleTxRunner`（holdsLock=false 路径），断言重构为竞争安全不变量：无 fatal/
+`simpleTxRunner`（零 lease 路径），断言重构为竞争安全不变量：无 fatal/
 race；`successes==1`；loser 是 `ErrVersionConflict` **或**
 `ErrAuthOldPasswordIncorrect`（per-call 锁无跨方法原子性，两者皆合法竞争结局；
 仅断言 ErrVersionConflict 本身就是 latent flake）；最终 version==1。强
@@ -170,11 +220,11 @@ store.go 包 godoc 点名（不 silent carryover）。
 
 | 框架 | 事实 | 结论 |
 |------|------|------|
-| ent/ent `ent.go` | ctx 存强类型 `*Tx` 指针非 bool；不持连接者无法伪造 | 与 `*memTxToken` 同构；`holdsLock` 字段是 GoCell 特有（ent 无"假 tx"场景）非反模式 |
+| ent/ent `ent.go` | ctx 存强类型 `*Tx` 指针非 bool；不持连接者无法伪造 | 与 `txlock.Lease` 同构；lease 自失效是 GoCell 特有（ent 无"假 tx"场景）非反模式 |
 | go-gorm/gorm `finisher_api.go` | in-tx 靠 `ConnPool.(TxCommitter)` type assertion 非 bool | "对象类型而非 bool 判断 in-tx"同构 |
 | go-kratos/examples `data.go` | ctx 存 `*queries.Queries` 非 bool | 同向背书 |
 | kubernetes/client-go `tools/cache/thread_safe_store.go` | 单 RWMutex 无条件加锁，无 sentinel-skip；无跨方法事务需求 | 纯 RWMutex-无条件锁方案被否（GoCell 需 RunInTx 跨方法原子性）；`*Locked` 内部约定 GoCell 已遵循 |
-| golang/go `database/sql` + Go 官方 | Mutex 故意不可重入；`*sql.Tx` 显式持有者 | "外持锁+内不重入"是唯一正确路径；bool-不持锁是设计哲学偏离点 |
+| golang/go `database/sql` + Go 官方 | Mutex 故意不可重入；`*sql.Tx` 显式持有者；`Tx.done atomic.Bool` + `ErrTxDone`：commit/rollback 后资源自失效（done 翻转封在 commit/rollback 内，调用方不可续期） | "外持锁+内不重入"是唯一正确路径；bool-不持锁是设计哲学偏离点；`Tx.done` self-invalidation 形态是 `txlock.Lease.live` 的直接对标 |
 
 ```
 ref: ent/ent examples/o2o2types/ent/ent.go (typed *Tx in context, no bool sentinel)
@@ -182,35 +232,43 @@ ref: go-gorm/gorm finisher_api.go (in-tx via type assertion)
 ref: go-kratos/examples transaction/sqlc/internal/data/data.go
 ref: kubernetes/client-go tools/cache/thread_safe_store.go (RWMutex, *Locked convention)
 ref: golang/go database/sql (explicit Tx ownership; non-reentrant Mutex rationale)
+ref: golang/go database/sql sql.go (Tx.done atomic.Bool + ErrTxDone, self-invalidation-on-completion)
 ```
 
-## 威胁矩阵（#945 witness 逐行重评）
+## 威胁矩阵（逐行重评，#972 lease 第 4 栏）
 
-「改造后」= 238 token 设计；「#945 后」= sealed witness。三栏对照便于逐行验证
-无 verdict 回退。
+「改造后」= 238 token 设计；「#945 后」= sealed witness；「#972 后」= self-invalidating lease。
+四栏对照便于逐行验证无 verdict 回退。
 
-| 威胁 | 改造前 | 改造后（238 token） | #945 后（witness） | 机制（#945） |
-|------|--------|--------------------|--------------------|------|
-| sentinel 在场 + 不持锁 → 并发写 map（本 flake） | ❌ fatal（偶发） | ✅ 消除（runtime） | ✅ 消除（不变） | 零 witness → `Holds` false → 强制 per-call 锁 |
-| 包外 fake 伪造「在 tx 且持锁」 | ❌ bool 任意可注入 | ✅ 不可表达 | ✅ 不可表达（不变） | `Held`/`memTxToken`/字段不导出，编译器 gate（上游 Hard） |
-| **包内** edit 在 runLocked 外 mint 持锁 token | ⚠️ 无防护 | ⚠️→Medium archtest（bool 仍可在包内赋值） | ✅✅ **编译不可表达** | `txlock.Held.mu` 不导出 + 无 Acquire 无 witness（下游 Hard 升级；W1/W2/R1 archtest 仅守纪律漂移） |
-| 构造 token 后 reflect/unsafe 改持锁字段 | ⚠️ — | ✅ 反向自检（mem 禁 reflect/unsafe） | ✅ 反向自检（扩至 txlock 包） | mem + txlock 两包禁 import reflect/unsafe（archtest） |
-| ctx 携带的 witness 被用来**解锁**（liveness） | n/a | ⚠️ token 含可解锁句柄（理论） | ✅ 不可表达 | `Held` 无 Release 方法；unlock 闭包留 runLocked 本地（type system） |
-| after-commit hook 闭包捕获 inner ctx（含 witness），在锁释放后调 repo → stale-skip 锁 | ⚠️ 同属性（bool 亦不随释放过期） | ⚠️ 同属性 | ⚠️ 同属性（**当前不可利用**） | accesscore 零 `RegisterAfterCommit`；框架用 outer ctx drain hooks；gh issue #972 跟踪 accesscore 引入 hook 时的静态守卫 |
-| 跨 store token 混用（A 的 token 让 B 跳锁） | ⚠️ bool 无 store 维度 | ✅ 拒绝（`tok.store == s`） | ✅ 拒绝（不变） | `Held.Holds(&s.mu)` mutex 指针身份（取代 store 字段比较） |
-| RunInTx 跨方法原子性丢失（PG FOR UPDATE 等价） | ✅ 持锁全程 | ✅ 不变 | ✅ 不变 | 持 witness 跳 per-call 锁，闭包持锁 |
-| 单 goroutine fake 测试退化 | ✅ | ✅ 不变 | ✅ 不变 | per-call 锁串行天然原子（无并发） |
+| 威胁 | 改造前 | 改造后（238 token） | #945 后（witness） | #972 后（lease） | 机制（#972） |
+|------|--------|--------------------|--------------------|-----------------|------|
+| sentinel 在场 + 不持锁 → 并发写 map（本 flake） | ❌ fatal（偶发） | ✅ 消除（runtime） | ✅ 消除（不变） | ✅ 消除（不变） | 零 lease → `Live` false → 强制 per-call 锁 |
+| 包外 fake 伪造「在 tx 且持锁」 | ❌ bool 任意可注入 | ✅ 不可表达 | ✅ 不可表达（不变） | ✅ 不可表达（不变） | `Lease` 字段不导出，编译器 gate（上游 Hard forge） |
+| **包内** edit 在 `runLocked` 外 mint 持锁 lease | ⚠️ 无防护 | ⚠️→Medium archtest（bool 仍可在包内赋值） | ✅✅ 编译不可表达 | ✅✅ 编译不可表达（不变） | `txlock.Lease` 字段不导出 + 无 `Acquire` 无 live lease（下游 Hard；W1/W2 archtest 仅守纪律漂移） |
+| 构造 lease 后 reflect/unsafe 改持锁字段 | ⚠️ — | ✅ 反向自检（mem 禁 reflect/unsafe） | ✅ 反向自检（扩至 txlock 包） | ✅ 反向自检（不变） | mem + txlock 两包禁 import reflect/unsafe（archtest） |
+| ctx 携带的 lease 被用来**解锁**（liveness 写路径） | n/a | ⚠️ token 含可解锁句柄（理论） | ✅ 不可表达 | ✅ 不可表达（不变，加固） | `Lease` 无 Release 方法；unlock 闭包留 `runLocked` 本地；`live` 亦不可在 unlock 闭包外写——liveness 双重结构性（无 Release + live seal 独占） |
+| after-commit hook 闭包捕获 inner ctx（含 lease），在锁释放后调 repo → stale-skip | ⚠️ 同属性（bool 不随释放过期） | ⚠️ 同属性 | ⚠️ 同属性（proof 永不过期） | ✅ **结构性消除** | `unlock()` 在 `runLocked` 返回时 defer 触发，先于 `RunInTx` drain hooks；`live.Store(false)` 封在 seal unlock 闭包内，调用方不可绕过 → 逃逸 inner ctx 的 `inLiveTx` 返回 false → fail-closed per-call 加锁 |
+| 跨 store lease 混用（A 的 lease 让 B 跳锁） | ⚠️ bool 无 store 维度 | ✅ 拒绝（`tok.store == s`） | ✅ 拒绝（不变） | ✅ 拒绝（不变） | `Lease.Live(&s.mu)` mutex 指针身份（删 store 字段后同等保证） |
+| RunInTx 跨方法原子性丢失（PG FOR UPDATE 等价） | ✅ 持锁全程 | ✅ 不变 | ✅ 不变 | ✅ 不变 | 持 live lease 跳 per-call 锁，闭包持锁；`runLocked` 返回前 live=true 全程成立 |
+| 单 goroutine fake 测试退化 | ✅ | ✅ 不变 | ✅ 不变 | ✅ 不变 | per-call 锁串行天然原子（无并发） |
 
 无格子从 ✅ 回退到 ⚠️/❌：#945 把第 3 行 ⚠️/Medium 升为 ✅✅（编译 Hard），第 5 行
-（witness 解锁 liveness）由「`Held` 无 Release」结构性消除。第 6 行（hook 闭包捕获 inner
-ctx）是 witness 与原 bool 共有的 proof-不随释放过期属性，**当前不可利用**（accesscore 无
-after-commit hook 调用，框架 drain 路径用无 witness 的 outer ctx），由 gh issue #972 跟踪
-未来 accesscore 引入 hook 时需补的静态守卫——属诚实登记的残留 ⚠️，非本 PR 引入的回退。
+（lease 解锁 liveness）保持 ✅，`live` 亦不可在 unlock 闭包外写，liveness 双重
+结构性（无 Release + live seal 独占）进一步加固。#972 把第 6 行
+（after-commit hook 闭包捕获 inner ctx → stale-skip）从 ⚠️ 改善为 ✅，结构性消除该残留
+（lease 自失效，`unlock()` 在 drain 前翻 `live=false`，逃逸 inner ctx fail-closed）。
+原文「gh issue #972 跟踪未来 accesscore 引入 hook 时需补的静态守卫……属诚实登记的残留
+⚠️」**已由 #972 结构性消除，非延迟**——任何时刻 accesscore 注册 after-commit hook 并
+捕获 inner ctx，`inLiveTx` 均因 lease 失效返回 false，无需额外静态守卫。
 
 ## contract-fanout 回灌（5 载体）
 
-- 接口/语义定义：store.go 包 godoc + WithTxContext godoc 重写（锁所有权真值）。
-- 全部实现：mem 单实现；user_repo/role_repo godoc lock contract 段同步。
+本次改动（#972）局限 `cells/accesscore/internal/mem` 内部实现，**不触发
+contract-fanout**：无 Go interface 方法签名变化、无 error sentinel 变化、无返回值
+metadata 变化、无 contract.yaml / DB schema 变化、无 errcode 新 Kind/Category/Sentinel。
+
+- 接口/语义定义：store.go 包 godoc + `inLiveTx` godoc 重写（锁所有权 + 自失效语义）。
+- 全部实现：mem 单实现；user_repo/role_repo godoc lock contract 段同步（`inLiveTx` 取代 `txHoldsLock`）。
 - 各层 test：并发回归（活体）+ 6 fake/4 包单 goroutine 回归 + archtest + PG integration。
 - 测试夹具：6 fake 注释订正；`identitymanage_credential_race_test.go` 两处
   「causes concurrent map writes under -race」**已失真**注释重写（store-bound
@@ -219,15 +277,25 @@ after-commit hook 调用，框架 drain 路径用无 witness 的 outer ctx），
 
 ## Rollback
 
-回退 store.go（witness→token→bool）+ 删 txlock 包 + 删 archtest。flake 复现（已知
+回退 store.go（lease→witness→token→bool）+ 删 txlock 包演进 + 删 archtest。flake 复现（已知
 `-race -count` 必现），不建议。
 
 ## Hard 范本登记
 
-#945 后落入 ai-robust.md §Hard 范本「**sealed construction**」+「**single sanctioned
+#972 后落入 ai-robust.md §Hard 范本「**sealed construction**」+「**single sanctioned
 holder**」：context-carried 锁所有权真值经 `internal/` 子包 + unexported 字段 + 私有
-构造（`Acquire` 真持锁）使「在 tx 且持锁」**编译不可表达，即便在 owning 包内**——比
-238 的「unexported typed token + runtime AND 校验」更强（下游从 runtime-Hard 升为
-type-system-Hard）。capability/proof 分离（`Held` 只证不解锁，unlock 闭包另返）对标
-`context.WithCancel`。范本本身已在 ai-robust.md 封闭集内，本条仅登记落地实例，不扩目录。
-对标 ent `*Tx` / GORM ConnPool type assertion / context.WithCancel。
+构造（`Acquire` 真持锁 + `live.Store(true)`）+ sealed unlock 闭包（唯一可翻 `live`
+的路径）使「在 tx 且持锁」与「proof 在锁持有期内有效」**双重编译不可表达，即便在
+owning 包内**。capability/proof 分离对标：
+
+- **`context.WithCancel`**：`cancel()` 闭包是 capability，`ctx.Done()` 是 proof；
+  proof（`Done`）只读取状态，cancel 能力与 proof 分离。`Lease` 同形态：`unlock()`
+  是 capability（改变 live 状态），`Live()` 是 proof（只读取）；调用方持 proof 但
+  不持 capability。
+- **`database/sql` `Tx.done` → `ErrTxDone`**：commit/rollback 后 `done` 翻转，后续
+  操作 fail-closed（`ErrTxDone`）；proof（"是否在活跃 tx 内"）与资源存活窗口绑定，
+  完成后自动失效。`txlock.Lease.live` 同形态：`unlock()` 翻 `live=false`，后续
+  `Live()` fail-closed，proof 绑定 `runLocked` 执行窗口而非永久 token。
+
+范本本身已在 ai-robust.md 封闭集内，本条仅登记落地实例，不扩目录。
+对标 ent `*Tx` / GORM ConnPool type assertion / context.WithCancel / database/sql Tx.done。

--- a/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
+++ b/docs/architecture/202605171846-adr-mem-tx-lock-ownership.md
@@ -12,6 +12,14 @@
 
 ## Amendment 2026-05-25 (#945): sealed lock-witness
 
+> **Superseded by #972 (next section).** The symbols described in this block —
+> `txlock.Held` / `Holds`, `memTxToken`, `WithTxContext`, `txHoldsLock` — were
+> replaced in #972 by `txlock.Lease` / `Live`, a directly ctx-carried lease (no
+> wrapper), and `inLiveTx`. This block records the #945 *forge-axis* step
+> (bool → un-forgeable witness); read it as history, not as the current design.
+> The live design is §"Amendment 2026-05-25 (#972)" + §Decisions (rewritten to
+> the lease model).
+
 The 238 design (D1 below, as rewritten) replaced the bool sentinel with a typed
 `*memTxToken{store, holdsLock bool}`. That made *out-of-package* forgery
 compile-impossible (Hard) but left the **in-package** "mint a holdsLock=true

--- a/tools/archtest/internal/memtxlockfixture/fixture.go
+++ b/tools/archtest/internal/memtxlockfixture/fixture.go
@@ -39,8 +39,8 @@ type memTxRunner struct{ s *Store }
 // runLocked is the sole sanctioned holds-lock site: Acquire here is CLEAN, and
 // the memTxToken literal carrying the witness is CLEAN.
 func (r memTxRunner) runLocked(ctx context.Context, fn func(context.Context) error) error {
-	held := txlock.Acquire(&r.s.mu) // CLEAN: Acquire inside runLocked
-	defer held.Release()
+	held, unlock := txlock.Acquire(&r.s.mu) // CLEAN: Acquire inside runLocked
+	defer unlock()
 	return fn(context.WithValue(ctx, memTxKey{}, &memTxToken{held: held})) // CLEAN literal
 }
 
@@ -57,8 +57,9 @@ func (s *Store) txHoldsLock(ctx context.Context) bool {
 }
 
 // leakAcquire RED (W1): mints a holds-lock witness outside runLocked.
-func leakAcquire(s *Store) txlock.Held {
-	return txlock.Acquire(&s.mu) // RED W1: Acquire outside runLocked
+func leakAcquire(s *Store) {
+	_, unlock := txlock.Acquire(&s.mu) // RED W1: Acquire outside runLocked
+	unlock()
 }
 
 // leakToken RED (R1): constructs a memTxToken outside the two sanctioned sites.

--- a/tools/archtest/internal/memtxlockfixture/fixture.go
+++ b/tools/archtest/internal/memtxlockfixture/fixture.go
@@ -1,22 +1,23 @@
 //go:build archtest_fixture
 
 // Package memtxlockfixture is the MEM-TX-LOCK-OWNERSHIP-01 reverse self-check
-// corpus for the sealed lock-witness funnel. It mirrors
-// cells/accesscore/internal/mem's witness model (memTxToken carries a
-// txlock.Held; runLocked is the only sanctioned Acquire site; WithTxContext
-// mints no witness; txHoldsLock proves the lock via Held.Holds). The detector
+// corpus for the sealed lock-lease funnel. It mirrors
+// cells/accesscore/internal/mem's lease model (ctx carries a txlock.Lease
+// directly — no wrapper struct; runLocked is the only sanctioned Acquire site;
+// inLiveTx delegates to the sealed txlock.Lease.Live). The detector
 // scanMemTxLockWitness, pointed at this package, MUST report exactly the three
-// RED sites below and MUST NOT flag the clean ones:
+// RED sites below and MUST NOT flag the clean one:
 //
-//   - runLocked      — CLEAN: Acquire + memTxToken literal inside the sanctioned site
-//   - WithTxContext  — CLEAN: memTxToken literal at the no-witness site
-//   - leakAcquire    — RED W1: txlock.Acquire called outside runLocked
-//   - txHoldsLock    — RED W2: return drops the `&& tok.held.Holds(&s.mu)` conjunct
-//   - leakToken      — RED R1: memTxToken composite literal outside the two sites
+//   - runLocked          — CLEAN: Acquire(&r.s.mu) in the direct body + Lease
+//     injected into ctx
+//   - leakAcquire        — RED W1: txlock.Acquire called outside runLocked
+//   - leakAcquireFuncLit — RED W1: txlock.Acquire wrapped in a closure (the
+//     file-wide scan must still descend into func literals)
+//   - inLiveTx           — RED W2: return drops the `l.Live(&s.mu)` delegation
 //
-// Bypassing the reverse self-check requires editing this real source (loaded
-// via packages.Load with the archtest_fixture build tag) — not a hand-crafted
-// AST string.
+// Bypassing the reverse self-check requires editing this real source (loaded via
+// packages.Load with the archtest_fixture build tag) — not a hand-crafted AST
+// string.
 package memtxlockfixture
 
 import (
@@ -31,46 +32,44 @@ type memTxKey struct{}
 // Store mirrors mem.Store's mutex-bearing shape.
 type Store struct{ mu sync.Mutex }
 
-// memTxToken mirrors the witness-bearing token (no holdsLock bool).
-type memTxToken struct{ held txlock.Held }
-
 type memTxRunner struct{ s *Store }
 
-// runLocked is the sole sanctioned holds-lock site: Acquire here is CLEAN, and
-// the memTxToken literal carrying the witness is CLEAN.
+// runLocked is the sole sanctioned mint site: Acquire(&r.s.mu) in the direct
+// body is CLEAN, and the lease injected into ctx is CLEAN.
 func (r memTxRunner) runLocked(ctx context.Context, fn func(context.Context) error) error {
-	held, unlock := txlock.Acquire(&r.s.mu) // CLEAN: Acquire inside runLocked
+	lease, unlock := txlock.Acquire(&r.s.mu) // CLEAN: Acquire(&r.s.mu) inside runLocked
 	defer unlock()
-	return fn(context.WithValue(ctx, memTxKey{}, &memTxToken{held: held})) // CLEAN literal
+	return fn(context.WithValue(ctx, memTxKey{}, lease))
 }
 
-// WithTxContext mints no witness — CLEAN memTxToken literal at the no-witness site.
-func WithTxContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, memTxKey{}, &memTxToken{}) // CLEAN literal
+// inLiveTx RED (W2): drops the `l.Live(&s.mu)` delegation, so a stale/zero lease
+// would falsely authorize a lock-skip.
+func (s *Store) inLiveTx(ctx context.Context) bool {
+	l, _ := ctx.Value(memTxKey{}).(txlock.Lease)
+	_ = l
+	return true // RED W2: missing return l.Live(&s.mu)
 }
 
-// txHoldsLock RED (W2): drops the `&& tok.held.Holds(&s.mu)` conjunct, so a
-// no-witness token would falsely authorize lock-skip.
-func (s *Store) txHoldsLock(ctx context.Context) bool {
-	tok, _ := ctx.Value(memTxKey{}).(*memTxToken)
-	return tok != nil // RED W2: missing && tok.held.Holds(&s.mu)
-}
-
-// leakAcquire RED (W1): mints a holds-lock witness outside runLocked.
+// leakAcquire RED (W1): mints a lease outside runLocked.
 func leakAcquire(s *Store) {
 	_, unlock := txlock.Acquire(&s.mu) // RED W1: Acquire outside runLocked
 	unlock()
 }
 
-// leakToken RED (R1): constructs a memTxToken outside the two sanctioned sites.
-func leakToken() *memTxToken {
-	return &memTxToken{} // RED R1: literal outside runLocked / WithTxContext
+// leakAcquireFuncLit RED (W1): hides Acquire in a closure. The file-wide scan
+// must descend into func literals and still flag it (it is not the sanctioned
+// runLocked direct-body call).
+func leakAcquireFuncLit(s *Store) {
+	f := func() {
+		_, unlock := txlock.Acquire(&s.mu) // RED W1: Acquire in a closure, outside runLocked
+		unlock()
+	}
+	f()
 }
 
 var (
-	_ = WithTxContext
 	_ = leakAcquire
-	_ = leakToken
-	_ = (*Store).txHoldsLock
+	_ = leakAcquireFuncLit
+	_ = (*Store).inLiveTx
 	_ = memTxRunner.runLocked
 )

--- a/tools/archtest/internal/memtxlockfixture/fixture.go
+++ b/tools/archtest/internal/memtxlockfixture/fixture.go
@@ -1,0 +1,75 @@
+//go:build archtest_fixture
+
+// Package memtxlockfixture is the MEM-TX-LOCK-OWNERSHIP-01 reverse self-check
+// corpus for the sealed lock-witness funnel. It mirrors
+// cells/accesscore/internal/mem's witness model (memTxToken carries a
+// txlock.Held; runLocked is the only sanctioned Acquire site; WithTxContext
+// mints no witness; txHoldsLock proves the lock via Held.Holds). The detector
+// scanMemTxLockWitness, pointed at this package, MUST report exactly the three
+// RED sites below and MUST NOT flag the clean ones:
+//
+//   - runLocked      — CLEAN: Acquire + memTxToken literal inside the sanctioned site
+//   - WithTxContext  — CLEAN: memTxToken literal at the no-witness site
+//   - leakAcquire    — RED W1: txlock.Acquire called outside runLocked
+//   - txHoldsLock    — RED W2: return drops the `&& tok.held.Holds(&s.mu)` conjunct
+//   - leakToken      — RED R1: memTxToken composite literal outside the two sites
+//
+// Bypassing the reverse self-check requires editing this real source (loaded
+// via packages.Load with the archtest_fixture build tag) — not a hand-crafted
+// AST string.
+package memtxlockfixture
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/memtxlockfixture/txlock"
+)
+
+type memTxKey struct{}
+
+// Store mirrors mem.Store's mutex-bearing shape.
+type Store struct{ mu sync.Mutex }
+
+// memTxToken mirrors the witness-bearing token (no holdsLock bool).
+type memTxToken struct{ held txlock.Held }
+
+type memTxRunner struct{ s *Store }
+
+// runLocked is the sole sanctioned holds-lock site: Acquire here is CLEAN, and
+// the memTxToken literal carrying the witness is CLEAN.
+func (r memTxRunner) runLocked(ctx context.Context, fn func(context.Context) error) error {
+	held := txlock.Acquire(&r.s.mu) // CLEAN: Acquire inside runLocked
+	defer held.Release()
+	return fn(context.WithValue(ctx, memTxKey{}, &memTxToken{held: held})) // CLEAN literal
+}
+
+// WithTxContext mints no witness — CLEAN memTxToken literal at the no-witness site.
+func WithTxContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, memTxKey{}, &memTxToken{}) // CLEAN literal
+}
+
+// txHoldsLock RED (W2): drops the `&& tok.held.Holds(&s.mu)` conjunct, so a
+// no-witness token would falsely authorize lock-skip.
+func (s *Store) txHoldsLock(ctx context.Context) bool {
+	tok, _ := ctx.Value(memTxKey{}).(*memTxToken)
+	return tok != nil // RED W2: missing && tok.held.Holds(&s.mu)
+}
+
+// leakAcquire RED (W1): mints a holds-lock witness outside runLocked.
+func leakAcquire(s *Store) txlock.Held {
+	return txlock.Acquire(&s.mu) // RED W1: Acquire outside runLocked
+}
+
+// leakToken RED (R1): constructs a memTxToken outside the two sanctioned sites.
+func leakToken() *memTxToken {
+	return &memTxToken{} // RED R1: literal outside runLocked / WithTxContext
+}
+
+var (
+	_ = WithTxContext
+	_ = leakAcquire
+	_ = leakToken
+	_ = (*Store).txHoldsLock
+	_ = memTxRunner.runLocked
+)

--- a/tools/archtest/internal/memtxlockfixture/txlock/txlock.go
+++ b/tools/archtest/internal/memtxlockfixture/txlock/txlock.go
@@ -1,27 +1,40 @@
 //go:build archtest_fixture
 
 // Package txlock mirrors the production
-// cells/accesscore/internal/mem/internal/txlock sealed lock-witness package so
-// the MEM-TX-LOCK-OWNERSHIP-01 reverse self-check can exercise the
-// witness-funnel detector (W1 Acquire-call-site, W2 txHoldsLock form) against a
-// real, build-tag-gated source corpus. Acquire is the sole witness mint; the
+// cells/accesscore/internal/mem/internal/txlock sealed lock-lease package so the
+// MEM-TX-LOCK-OWNERSHIP-01 reverse self-check can exercise the witness-funnel
+// detector (W1 Acquire-call-site + arg + nesting, W2 inLiveTx form) against a
+// real, build-tag-gated source corpus. Acquire is the sole lease mint; the
 // detector matches it by package name "txlock" + func name "Acquire", so this
 // fixture mirror and the production package are recognized identically.
 package txlock
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
-// Held mirrors the production read-only proof: a *sync.Mutex behind an
-// unexported field, un-forgeable outside this package, with no Release method.
-type Held struct{ mu *sync.Mutex }
-
-// Acquire is the witness mint (mirrors production: proof + unlock closure).
-func Acquire(mu *sync.Mutex) (held Held, unlock func()) {
-	mu.Lock()
-	return Held{mu: mu}, mu.Unlock
+// Lease mirrors the production self-invalidating lease: a *sync.Mutex + a live
+// *atomic.Bool behind unexported fields, un-forgeable outside this package, with
+// no Release method.
+type Lease struct {
+	mu   *sync.Mutex
+	live *atomic.Bool
 }
 
-// Holds reports whether h witnesses mu (pointer identity).
-func (h Held) Holds(mu *sync.Mutex) bool {
-	return h.mu != nil && h.mu == mu
+// Acquire is the lease mint (mirrors production: proof + unlock closure that
+// flips the lease dead before unlocking).
+func Acquire(mu *sync.Mutex) (lease Lease, unlock func()) {
+	mu.Lock()
+	live := &atomic.Bool{}
+	live.Store(true)
+	return Lease{mu: mu, live: live}, func() {
+		live.Store(false)
+		mu.Unlock()
+	}
+}
+
+// Live reports whether l proves mu is held right now (pointer identity + live).
+func (l Lease) Live(mu *sync.Mutex) bool {
+	return l.mu != nil && l.mu == mu && l.live != nil && l.live.Load()
 }

--- a/tools/archtest/internal/memtxlockfixture/txlock/txlock.go
+++ b/tools/archtest/internal/memtxlockfixture/txlock/txlock.go
@@ -11,21 +11,14 @@ package txlock
 
 import "sync"
 
-// Held mirrors the production Held: a *sync.Mutex behind an unexported field,
-// un-forgeable outside this package.
+// Held mirrors the production read-only proof: a *sync.Mutex behind an
+// unexported field, un-forgeable outside this package, with no Release method.
 type Held struct{ mu *sync.Mutex }
 
-// Acquire is the witness mint (mirrors production).
-func Acquire(mu *sync.Mutex) Held {
+// Acquire is the witness mint (mirrors production: proof + unlock closure).
+func Acquire(mu *sync.Mutex) (held Held, unlock func()) {
 	mu.Lock()
-	return Held{mu: mu}
-}
-
-// Release unlocks the witnessed mutex.
-func (h Held) Release() {
-	if h.mu != nil {
-		h.mu.Unlock()
-	}
+	return Held{mu: mu}, mu.Unlock
 }
 
 // Holds reports whether h witnesses mu (pointer identity).

--- a/tools/archtest/internal/memtxlockfixture/txlock/txlock.go
+++ b/tools/archtest/internal/memtxlockfixture/txlock/txlock.go
@@ -1,0 +1,34 @@
+//go:build archtest_fixture
+
+// Package txlock mirrors the production
+// cells/accesscore/internal/mem/internal/txlock sealed lock-witness package so
+// the MEM-TX-LOCK-OWNERSHIP-01 reverse self-check can exercise the
+// witness-funnel detector (W1 Acquire-call-site, W2 txHoldsLock form) against a
+// real, build-tag-gated source corpus. Acquire is the sole witness mint; the
+// detector matches it by package name "txlock" + func name "Acquire", so this
+// fixture mirror and the production package are recognized identically.
+package txlock
+
+import "sync"
+
+// Held mirrors the production Held: a *sync.Mutex behind an unexported field,
+// un-forgeable outside this package.
+type Held struct{ mu *sync.Mutex }
+
+// Acquire is the witness mint (mirrors production).
+func Acquire(mu *sync.Mutex) Held {
+	mu.Lock()
+	return Held{mu: mu}
+}
+
+// Release unlocks the witnessed mutex.
+func (h Held) Release() {
+	if h.mu != nil {
+		h.mu.Unlock()
+	}
+}
+
+// Holds reports whether h witnesses mu (pointer identity).
+func (h Held) Holds(mu *sync.Mutex) bool {
+	return h.mu != nil && h.mu == mu
+}

--- a/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
@@ -22,7 +22,6 @@ import (
 // false-negative drift (detector goes blind) and false-positive drift
 // (detector flags the sanctioned sites).
 func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
-	t.Parallel()
 	root := findModuleRoot(t)
 	modPath, err := moduleImportPath(root)
 	require.NoError(t, err, "read module path from go.mod")

--- a/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
@@ -10,17 +10,19 @@ import (
 // TestMemTxLockOwnership01_FixturePattern is the MEM-TX-LOCK-OWNERSHIP-01
 // reverse self-check (ai-robust.md §"工具选定后强制盲区自检"): a real,
 // build-tag-gated package (internal/memtxlockfixture) modeling the sealed
-// lock-witness funnel. The detector scanMemTxLockWitness MUST report exactly
-// the three RED sites and MUST NOT flag the clean ones:
+// lock-lease funnel. The detector scanMemTxLockWitness MUST report exactly the
+// three RED sites and MUST NOT flag the clean one:
 //
-//	W1 leakAcquire   — txlock.Acquire outside (memTxRunner).runLocked
-//	W2 txHoldsLock   — return drops `&& tok.held.Holds(&s.mu)`
-//	R1 leakToken     — memTxToken literal outside runLocked / WithTxContext
+//	W1 leakAcquire        — txlock.Acquire outside (memTxRunner).runLocked
+//	W1 leakAcquireFuncLit — txlock.Acquire hidden in a closure (scan must descend)
+//	W2 inLiveTx           — return drops the `l.Live(&s.mu)` delegation
 //
-// Clean (MUST NOT be flagged): runLocked's Acquire + memTxToken literal, and
-// WithTxContext's memTxToken literal. Asserting the exact count catches both
-// false-negative drift (detector goes blind) and false-positive drift
-// (detector flags the sanctioned sites).
+// Clean (MUST NOT be flagged): runLocked's Acquire(&r.s.mu) + the Lease injected
+// into ctx. Asserting the exact count catches both false-negative drift (detector
+// goes blind) and false-positive drift (detector flags the sanctioned site). The
+// former R1 (memTxToken literal scope) is gone: the ctx carries txlock.Lease
+// directly and a live Lease can only come from Acquire (W1), so seal + W1 subsume
+// it.
 func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
 	root := findModuleRoot(t)
 	modPath, err := moduleImportPath(root)
@@ -33,7 +35,7 @@ func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
 		[]string{fixturePattern},
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != fixturePkgPath {
-				return nil // skip the txlock sub-package; scan the witness consumer
+				return nil // skip the txlock sub-package; scan the lease consumer
 			}
 			return scanMemTxLockWitness(p)
 		})
@@ -43,21 +45,18 @@ func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
 	}
 	require.Len(t, diags, 3,
 		"%s reverse self-check: memtxlockfixture must yield exactly 3 RED sites "+
-			"(W1 leakAcquire + W2 txHoldsLock + R1 leakToken); the sanctioned "+
-			"runLocked / WithTxContext sites must not be flagged",
+			"(W1 leakAcquire + W1 leakAcquireFuncLit + W2 inLiveTx); the sanctioned "+
+			"runLocked site must not be flagged",
 		ruleMemTxLockOwnership01)
 
 	joined := ""
 	for _, d := range diags {
 		joined += d.Message + "\n"
 	}
-	// Each diagnostic names its enclosing function as "in <fn>"; assert the
-	// three RED sites are reported there and the sanctioned sites are not
-	// (the messages reference runLocked / WithTxContext as the *allowed* sites,
-	// so match on the "in <fn>" enclosing-function marker, not bare names).
+	// Each diagnostic names its enclosing function as "in <fn>"; assert the three
+	// RED sites are reported there and the sanctioned site is not.
 	assert.Contains(t, joined, "in leakAcquire", "W1: Acquire-outside-runLocked must be reported")
-	assert.Contains(t, joined, "in txHoldsLock", "W2: weakened txHoldsLock form must be reported")
-	assert.Contains(t, joined, "in leakToken", "R1: memTxToken literal outside sites must be reported")
-	assert.NotContains(t, joined, "in runLocked", "runLocked is the sanctioned Acquire + literal site")
-	assert.NotContains(t, joined, "in WithTxContext", "WithTxContext literal is sanctioned")
+	assert.Contains(t, joined, "in leakAcquireFuncLit", "W1: Acquire hidden in a closure must be reported")
+	assert.Contains(t, joined, "in inLiveTx", "W2: weakened inLiveTx form must be reported")
+	assert.NotContains(t, joined, "in runLocked", "runLocked is the sanctioned Acquire site")
 }

--- a/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
@@ -1,0 +1,60 @@
+package archtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMemTxLockOwnership01_FixturePattern is the MEM-TX-LOCK-OWNERSHIP-01
+// reverse self-check (ai-robust.md §"工具选定后强制盲区自检"): a real,
+// build-tag-gated package (internal/memtxlockfixture) modelling the sealed
+// lock-witness funnel. The detector scanMemTxLockWitness MUST report exactly
+// the three RED sites and MUST NOT flag the clean ones:
+//
+//	W1 leakAcquire   — txlock.Acquire outside (memTxRunner).runLocked
+//	W2 txHoldsLock   — return drops `&& tok.held.Holds(&s.mu)`
+//	R1 leakToken     — memTxToken literal outside runLocked / WithTxContext
+//
+// Clean (MUST NOT be flagged): runLocked's Acquire + memTxToken literal, and
+// WithTxContext's memTxToken literal. Asserting the exact count catches both
+// false-negative drift (detector goes blind) and false-positive drift
+// (detector flags the sanctioned sites).
+func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+
+	fixturePkgPath := modPath + "/tools/archtest/internal/memtxlockfixture"
+	fixturePattern := "./tools/archtest/internal/memtxlockfixture/..."
+
+	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
+		[]string{fixturePattern},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != fixturePkgPath {
+				return nil // skip the txlock sub-package; scan the witness consumer
+			}
+			return scanMemTxLockWitness(p)
+		})
+
+	for _, d := range diags {
+		t.Log(d.Message)
+	}
+	require.Len(t, diags, 3,
+		"%s reverse self-check: memtxlockfixture must yield exactly 3 RED sites "+
+			"(W1 leakAcquire + W2 txHoldsLock + R1 leakToken); the sanctioned "+
+			"runLocked / WithTxContext sites must not be flagged",
+		ruleMemTxLockOwnership01)
+
+	joined := ""
+	for _, d := range diags {
+		joined += d.Message + "\n"
+	}
+	assert.Contains(t, joined, "leakAcquire", "W1: Acquire-outside-runLocked must be reported")
+	assert.Contains(t, joined, "txHoldsLock", "W2: weakened txHoldsLock form must be reported")
+	assert.Contains(t, joined, "leakToken", "R1: memTxToken literal outside sites must be reported")
+	assert.NotContains(t, joined, "runLocked", "runLocked is the sanctioned Acquire + literal site")
+	assert.NotContains(t, joined, "WithTxContext", "WithTxContext literal is sanctioned")
+}

--- a/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestMemTxLockOwnership01_FixturePattern is the MEM-TX-LOCK-OWNERSHIP-01
 // reverse self-check (ai-robust.md §"工具选定后强制盲区自检"): a real,
-// build-tag-gated package (internal/memtxlockfixture) modelling the sealed
+// build-tag-gated package (internal/memtxlockfixture) modeling the sealed
 // lock-witness funnel. The detector scanMemTxLockWitness MUST report exactly
 // the three RED sites and MUST NOT flag the clean ones:
 //
@@ -52,9 +52,13 @@ func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
 	for _, d := range diags {
 		joined += d.Message + "\n"
 	}
-	assert.Contains(t, joined, "leakAcquire", "W1: Acquire-outside-runLocked must be reported")
-	assert.Contains(t, joined, "txHoldsLock", "W2: weakened txHoldsLock form must be reported")
-	assert.Contains(t, joined, "leakToken", "R1: memTxToken literal outside sites must be reported")
-	assert.NotContains(t, joined, "runLocked", "runLocked is the sanctioned Acquire + literal site")
-	assert.NotContains(t, joined, "WithTxContext", "WithTxContext literal is sanctioned")
+	// Each diagnostic names its enclosing function as "in <fn>"; assert the
+	// three RED sites are reported there and the sanctioned sites are not
+	// (the messages reference runLocked / WithTxContext as the *allowed* sites,
+	// so match on the "in <fn>" enclosing-function marker, not bare names).
+	assert.Contains(t, joined, "in leakAcquire", "W1: Acquire-outside-runLocked must be reported")
+	assert.Contains(t, joined, "in txHoldsLock", "W2: weakened txHoldsLock form must be reported")
+	assert.Contains(t, joined, "in leakToken", "R1: memTxToken literal outside sites must be reported")
+	assert.NotContains(t, joined, "in runLocked", "runLocked is the sanctioned Acquire + literal site")
+	assert.NotContains(t, joined, "in WithTxContext", "WithTxContext literal is sanctioned")
 }

--- a/tools/archtest/mem_tx_lock_ownership_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_test.go
@@ -81,6 +81,15 @@ package archtest
 //   - W2 field/method-name anchors ("inLiveTx", "Live", "memTxKey", "mu"): a
 //     rename breaks every call site to compile before archtest runs (build error),
 //     and the txlock.Lease seal is reflect-frozen by TestLeaseSealFrozen.
+//   - W2 type/source matchers are syntactic, not typed: isLeaseTypeExpr matches any
+//     `<pkg>.Lease` or bare `Lease` (NOT resolved to the txlock package via
+//     ResolvePackageRef), and isCtxValueMemTxKeyCall matches
+//     `<anyVar>.Value(memTxKey{})` (the receiver is not pinned to `ctx`). A foreign
+//     Lease type, or a non-ctx receiver calling `.Value(memTxKey{})`, would still
+//     satisfy bindsLeaseFromCtx. Accepted, not closed: package mem imports only
+//     txlock.Lease and has exactly one inLiveTx (canonical `ctx` receiver), and W2
+//     is a Medium regression anchor over the Hard seal — a syntactic match is
+//     sufficient here; tightening to ResolvePackageRef is optional future hardening.
 
 import (
 	"fmt"
@@ -471,7 +480,9 @@ type Store struct{ mu int }
 type memTxRunner struct{ s *Store }
 func (r memTxRunner) runLocked() {
 	direct(&r.s.mu)
-	go func() { nested(&r.s.mu) }()
+	go func() { nested(&r.s.mu) }()      // goroutine closure → excluded
+	g := func() { nestedLocal(&r.s.mu) } // local-assignment closure → excluded
+	g()
 }
 `
 	fset := token.NewFileSet()
@@ -489,11 +500,12 @@ func (r memTxRunner) runLocked() {
 	// Syntactic acquire predicate (no type info): exercises the traversal only.
 	synAcq := func(ce *ast.CallExpr) bool {
 		id, ok := ce.Fun.(*ast.Ident)
-		return ok && (id.Name == "direct" || id.Name == "nested")
+		return ok && (id.Name == "direct" || id.Name == "nested" || id.Name == "nestedLocal")
 	}
 	got := directBodyAcquireCalls(runLocked, synAcq)
 	require.Lenf(t, got, 1,
-		"directBodyAcquireCalls must exclude the nested-closure Acquire (got %d)", len(got))
+		"directBodyAcquireCalls must exclude BOTH the goroutine and local-assignment "+
+			"closure Acquires, keeping only the direct-body call (got %d)", len(got))
 	assert.True(t, isAcquireArgRecvStoreMu(got[0], "r"),
 		"the direct-body direct(&r.s.mu) must satisfy the &recv.s.mu arg pin")
 

--- a/tools/archtest/mem_tx_lock_ownership_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_test.go
@@ -2,68 +2,79 @@ package archtest
 
 // INVARIANT: MEM-TX-LOCK-OWNERSHIP-01
 //
-// mem_tx_lock_ownership_test.go is the Medium double-line defense for the mem
-// tx lock-ownership funnel (ADR
-// docs/architecture/202605171846-adr-mem-tx-lock-ownership.md). The Hard line
-// is the Go type system itself: cells/accesscore/internal/mem.memTxToken and
-// its holdsLock field are unexported, so no code outside package mem can
-// construct a holdsLock=true token (compiler-enforced — the upstream half of
-// the funnel). This archtest closes the in-package residue: a future edit
-// inside package mem must not mint a holdsLock=true token anywhere except
-// memTxRunner.RunInTx (which has just called store.mu.Lock()), nor mutate the
-// holdsLock field after construction, nor bypass the composite-literal form.
+// mem_tx_lock_ownership_test.go guards the regression surface of the mem tx
+// lock-ownership funnel after the sealed lock-witness rework (#945; ADR
+// docs/architecture/202605171846-adr-mem-tx-lock-ownership.md). The threat is
+// "sentinel present but no lock": a tx-context token authorizing a repository
+// method to skip its per-call store.mu lock when the lock is NOT held →
+// concurrent map writes (the PR #558 flake).
 //
-// Rule R1 — construction-site lock:
+// That threat is now compile-impossible — the Hard core lives in the type
+// system, not in this archtest:
 //
-//	every *ast.CompositeLit of type memTxToken in a non-test .go file under
-//	cells/accesscore/internal/mem MUST be lexically inside one of exactly two
-//	FuncDecls:
-//	  - func (memTxRunner) RunInTx   (the only holdsLock=true site)
-//	  - func WithTxContext           (the only holdsLock=false site)
-//	A memTxToken composite literal anywhere else (another method, a helper, a
-//	package-level var) is a violation.
+//   - Upstream Hard: cells/accesscore/internal/mem/internal/txlock.Held's sole
+//     field is unexported, so no package (not even mem) can write txlock.Held{…}
+//     with a real mutex. The only way to obtain a Held whose Holds(&store.mu) is
+//     true is txlock.Acquire(&store.mu), which Lock()s the mutex.
+//   - Downstream Hard: a memTxToken carries that Held; txHoldsLock authorizes a
+//     lock-skip only when tok.held.Holds(&s.mu). "In a tx context yet not holding
+//     the lock" is inexpressible without having locked. The Held also has NO
+//     Release method (Acquire returns a separate unlock closure kept local to
+//     runLocked), so a ctx-carried witness cannot even release the lock.
 //
-// Rule R2 — blind-spot closure (post-construction mutation / non-literal
-// construction):
+// This file is the Medium regression layer over that Hard core. It runs the
+// shared detector scanMemTxLockWitness over package mem (typed, via RunTyped)
+// and reports:
 //
-//	R2a: `new(memTxToken)` is banned (pointer-to-zero then field-set bypasses
-//	the composite-literal funnel).
-//	R2b: every `x.holdsLock` SelectorExpr (read OR write) must sit inside
-//	(*Store).txHoldsLock — the sole legitimate accessor. The two construction
-//	sites set holdsLock via composite-literal Ident keys (not SelectorExpr),
-//	so R2b does not touch them; R1 funnels construction. Combined, "build a
-//	token then flip holdsLock" / "read holdsLock to fork logic elsewhere" is
-//	inexpressible without tripping the rule.
+//	W1 — txlock.Acquire is called only inside (memTxRunner).runLocked, the sole
+//	     sanctioned witness-mint site (matched by func name "Acquire" + package
+//	     path suffix "/txlock", resolved typed via ResolvePackageRef).
+//	W2 — (*Store).txHoldsLock returns exactly `tok != nil && tok.held.Holds(&s.mu)`
+//	     (flatten the && tree; exactly two conjuncts: a nil-guard and the Holds
+//	     call on tok.held with arg &<recv>.mu). Dropping the Holds conjunct, adding
+//	     a third conjunct, or weakening the call shape fails — this pins the
+//	     downstream-Hard runtime check against silent regression.
+//	R1 — every memTxToken composite literal (typed match: *types.Named "memTxToken"
+//	     in the package under scan) sits inside runLocked or WithTxContext.
 //
-// Blind spots of the chosen tool (pure AST CompositeLit/CallExpr/AssignStmt
-// scan) and their handling — required by .claude/rules/gocell/ai-robust.md:
+// The seal itself (txlock.Held field-set: exactly one unexported *sync.Mutex
+// field) is frozen by reflect in the txlock package's own test
+// (TestHeldSealFrozen in internal/txlock/txlock_test.go) — tools/archtest cannot
+// import the double-internal txlock package, so the freeze lives where Held is
+// defined, mirroring the FixtureOpts freeze in pass_test.go.
 //
-//   - reflect-based field mutation (reflect.Value.SetBool on holdsLock):
-//     out of scope of an AST literal scan. Closed by
-//     TestMemTxLockOwnership01_NoReflectInMemPkg asserting package mem
-//     (non-test) does not import "reflect" at all (true today; a reverse
-//     self-check, not the primary rule).
-//   - unsafe pointer field write: same class; package mem does not import
-//     "unsafe" — asserted by the same reverse self-check
-//     (TestMemTxLockOwnership01_NoUnsafeInMemPkg).
-//   - vacuous-pass risk (matcher silently matching nothing): closed by
-//     TestMemTxLockOwnership01_FindsExactlyTheTwoSites companion-index
-//     precision test — it asserts the scan finds the two real construction
-//     sites by name, so a regression that stops detecting memTxToken literals
-//     fails loudly instead of passing empty.
-//   - R2b accessor identified by FuncDecl name "txHoldsLock" + receiver type
-//     name "Store" — both are Soft string anchors (receiverTypeName is a
-//     string-comparison helper). Mitigated by (a) receiver type check added in
-//     F-A (symmetric with allowedTokenFunc), and (b) the companion-index
-//     reverse self-check TestMemTxLockOwnership01_R2bFindsHoldsLockAccessor
-//     asserting the accessor FuncDecl is non-empty and contains at least one
-//     "holdsLock" SelectorExpr, preventing vacuous-pass when the function is
-//     renamed or its body is emptied. Rating: Medium (string-anchor, two-part
-//     match, companion-index guard).
+// Note on "const-fold": #945 originally proposed pinning a holdsLock bool field
+// value via go/types constant folding. The witness rework deletes that bool
+// (there is no value left to fold and no bool-const substitution blind spot);
+// R1 now pins only construction SITE, while W1/W2 + the type-system seal carry
+// the lock-ownership truth.
+//
+// AI-robust rating (modifies an enforcement mechanism + reworks runtime design):
+//   - Upstream Hard / Downstream Hard — type system (txlock.Held seal; Held has
+//     no Release). This archtest is NOT the primary defense.
+//   - This file (W1/W2/R1) = Medium regression layer: string anchors
+//     ("Acquire"/"txlock"/"runLocked"/"WithTxContext"/"txHoldsLock"/"held"/"mu")
+//     + AST form-uniqueness. No gh issue to "Hard-ify" — the funnel is already
+//     Hard via the seal; W1/W2/R1 only catch funnel-discipline drift.
+//
+// Tool blind spots (pure-AST/typed scan) + their reverse self-checks, per
+// ai-robust.md §"工具选定后强制盲区自检":
+//   - reflect.Value.Set / unsafe pointer write on txlock.Held.mu would forge a
+//     witness: closed by NoReflectInMemPkg / NoUnsafeInMemPkg asserting neither
+//     package mem nor package txlock imports "reflect"/"unsafe".
+//   - vacuous-pass (matcher silently matches nothing): closed by
+//     FindsSanctionedSites asserting the scan actually finds the runLocked
+//     Acquire site, both memTxToken literal sites, and the txHoldsLock accessor.
+//   - detector correctness (false-negative / false-positive drift): closed by
+//     the real-source reverse self-check TestMemTxLockOwnership01_FixturePattern
+//     (mem_tx_lock_ownership_red_fixture_test.go) asserting exactly the three RED
+//     sites are reported and the sanctioned sites are not.
 
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
+	"go/types"
 	"strings"
 	"testing"
 
@@ -75,255 +86,399 @@ const ruleMemTxLockOwnership01 = "MEM-TX-LOCK-OWNERSHIP-01"
 
 const memPkgRel = "cells/accesscore/internal/mem"
 
-// memTxTokenTypeName is the unexported struct whose construction this rule
-// funnels. Same-package AST ident match is sufficient (no cross-package type
-// resolution): the type is unexported, so the identifier memTxToken inside
-// package mem can only denote this type.
+// memTxTokenTypeName is the unexported witness-bearing token whose construction
+// site this rule funnels (R1).
 const memTxTokenTypeName = "memTxToken"
 
-// isMemTxTokenLit reports whether cl constructs a memTxToken value, covering
-// both `memTxToken{…}` and `&memTxToken{…}` (the unary & wraps the same
-// CompositeLit node, so only the lit's Type matters).
-func isMemTxTokenLit(cl *ast.CompositeLit) bool {
-	id, ok := cl.Type.(*ast.Ident)
-	return ok && id.Name == memTxTokenTypeName
+const (
+	// memTxSiteRunLocked is the holds-witness mint site: (memTxRunner).runLocked
+	// is the only function allowed to call txlock.Acquire (W1) and the holds-lock
+	// memTxToken construction site (R1).
+	memTxSiteRunLocked = "runLocked"
+	// memTxSiteWithTxContext is the no-witness site: WithTxContext constructs a
+	// zero-witness memTxToken (R1) and never calls Acquire.
+	memTxSiteWithTxContext = "WithTxContext"
+)
+
+// memTxTokenSiteKind reports whether fd is one of the two sanctioned memTxToken
+// construction sites: func (memTxRunner) runLocked, or func WithTxContext.
+func memTxTokenSiteKind(fd *ast.FuncDecl) (site string, ok bool) {
+	switch fd.Name.Name {
+	case memTxSiteRunLocked:
+		// must be a method on memTxRunner (value or pointer receiver).
+		if fd.Recv != nil && receiverTypeName(fd) == "memTxRunner" {
+			return memTxSiteRunLocked, true
+		}
+	case memTxSiteWithTxContext:
+		if fd.Recv == nil {
+			return memTxSiteWithTxContext, true
+		}
+	}
+	return "", false
 }
 
-// allowedTokenFunc reports whether fd is one of the two legitimate
-// construction sites: func (memTxRunner) RunInTx, or func WithTxContext.
-func allowedTokenFunc(fd *ast.FuncDecl) bool {
-	switch fd.Name.Name {
-	case "RunInTx":
-		// must be a method on memTxRunner (value or pointer receiver).
-		// receiverTypeName is the shared archtest helper (pg_repo_ambient_tx).
-		return fd.Recv != nil && receiverTypeName(fd) == "memTxRunner"
-	case "WithTxContext":
-		return fd.Recv == nil
-	default:
+// receiverVarName returns the receiver variable name of fd (the `s` in
+// `func (s *Store) …`), or "" when there is no named receiver.
+func receiverVarName(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 || len(fd.Recv.List[0].Names) == 0 {
+		return ""
+	}
+	return fd.Recv.List[0].Names[0].Name
+}
+
+// isMemTxTokenLitTyped reports whether cl constructs a memTxToken value declared
+// in the package under scan, covering both `memTxToken{…}` and `&memTxToken{…}`.
+// Typed match against *types.Named (immune to local shadowing); the package
+// identity check lets the same detector run over production mem and the
+// fixture's own memTxToken alike.
+func isMemTxTokenLitTyped(info *types.Info, pkg *types.Package, cl *ast.CompositeLit) bool {
+	if info == nil || pkg == nil || cl == nil || cl.Type == nil {
 		return false
 	}
+	t := info.TypeOf(cl.Type)
+	if t == nil {
+		return false
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == memTxTokenTypeName &&
+		obj.Pkg() != nil && obj.Pkg().Path() == pkg.Path()
 }
 
-// TestMemTxLockOwnership01 enforces R1 + R2 over the mem package.
+// isTxlockAcquireCall reports whether sel is a reference to func Acquire in a
+// package whose import path ends in "/txlock" (production
+// …/mem/internal/txlock or the fixture mirror …/memtxlockfixture/txlock).
+func isTxlockAcquireCall(info *types.Info, sel *ast.SelectorExpr) bool {
+	if sel.Sel == nil || sel.Sel.Name != "Acquire" {
+		return false
+	}
+	pkgPath, name, ok := ResolvePackageRef(info, sel)
+	return ok && name == "Acquire" && strings.HasSuffix(pkgPath, "/txlock")
+}
+
+// flattenLAND splits a left-associative `a && b && c` tree into its leaf
+// conjuncts. A non-&& expression returns itself as a single leaf.
+func flattenLAND(e ast.Expr) []ast.Expr {
+	be, ok := e.(*ast.BinaryExpr)
+	if !ok || be.Op != token.LAND {
+		return []ast.Expr{e}
+	}
+	return append(flattenLAND(be.X), flattenLAND(be.Y)...)
+}
+
+// nilGuardVar returns the non-nil operand identifier name of an `x != nil`
+// BinaryExpr (either order), or ("", false) for any other shape.
+func nilGuardVar(e ast.Expr) (name string, ok bool) {
+	be, ok := e.(*ast.BinaryExpr)
+	if !ok || be.Op != token.NEQ {
+		return "", false
+	}
+	x, xIsIdent := be.X.(*ast.Ident)
+	y, yIsIdent := be.Y.(*ast.Ident)
+	if !xIsIdent || !yIsIdent {
+		return "", false
+	}
+	switch {
+	case y.Name == "nil":
+		return x.Name, true
+	case x.Name == "nil":
+		return y.Name, true
+	default:
+		return "", false
+	}
+}
+
+// isHeldHoldsCall reports whether e is exactly `<tok>.held.Holds(&<recv>.mu)`.
+func isHeldHoldsCall(e ast.Expr, tok, recv string) bool {
+	ce, ok := e.(*ast.CallExpr)
+	if !ok || len(ce.Args) != 1 {
+		return false
+	}
+	holds, ok := ce.Fun.(*ast.SelectorExpr) // <…>.Holds
+	if !ok || holds.Sel.Name != "Holds" {
+		return false
+	}
+	heldSel, ok := holds.X.(*ast.SelectorExpr) // <tok>.held
+	if !ok || heldSel.Sel.Name != "held" {
+		return false
+	}
+	if id, ok := heldSel.X.(*ast.Ident); !ok || id.Name != tok {
+		return false
+	}
+	addr, ok := ce.Args[0].(*ast.UnaryExpr) // &<recv>.mu
+	if !ok || addr.Op != token.AND {
+		return false
+	}
+	muSel, ok := addr.X.(*ast.SelectorExpr)
+	if !ok || muSel.Sel.Name != "mu" {
+		return false
+	}
+	id, ok := muSel.X.(*ast.Ident)
+	return ok && id.Name == recv
+}
+
+// txHoldsLockFormOK pins the (*Store).txHoldsLock return to exactly
+// `tok != nil && tok.held.Holds(&s.mu)`: a single single-value return whose &&
+// tree flattens to exactly two conjuncts — a nil-guard on tok and the Holds call
+// on tok.held with arg &<recv>.mu. Order-independent; receiver/token names are
+// taken from the source, not hard-coded.
+func txHoldsLockFormOK(fd *ast.FuncDecl) (ok bool, why string) {
+	recv := receiverVarName(fd)
+	if recv == "" {
+		return false, "no named receiver"
+	}
+	var rets []*ast.ReturnStmt
+	EachInSubtree[ast.ReturnStmt](fd, func(rs *ast.ReturnStmt) {
+		if len(rs.Results) == 1 {
+			rets = append(rets, rs)
+		}
+	})
+	if len(rets) != 1 {
+		return false, fmt.Sprintf("expected exactly 1 single-value return, got %d", len(rets))
+	}
+	conj := flattenLAND(rets[0].Results[0])
+	if len(conj) != 2 {
+		return false, fmt.Sprintf("expected exactly 2 && conjuncts, got %d", len(conj))
+	}
+	var tok string
+	var sawNil bool
+	for _, c := range conj {
+		if v, ok := nilGuardVar(c); ok {
+			tok, sawNil = v, true
+		}
+	}
+	if !sawNil {
+		return false, "missing `tok != nil` nil-guard conjunct"
+	}
+	for _, c := range conj {
+		if isHeldHoldsCall(c, tok, recv) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("missing `%s.held.Holds(&%s.mu)` conjunct", tok, recv)
+}
+
+// scanMemTxLockWitness is the shared witness-funnel detector. It runs over a
+// single package Pass — production (cells/accesscore/internal/mem) and the
+// memtxlockfixture reverse self-check alike — and reports W1 / W2 / R1 (see the
+// file INVARIANT block). Requires a typed Pass; returns nil for a bare-AST Pass.
+func scanMemTxLockWitness(p *Pass) []Diagnostic {
+	if p.TypesInfo == nil || p.Pkg == nil {
+		return nil
+	}
+	var ds []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		report := func(node ast.Node, msg string) {
+			ds = append(ds, Diagnostic{
+				Rel:     rel,
+				Line:    p.Fset.Position(node.Pos()).Line,
+				Message: msg,
+			})
+		}
+
+		// Record sanctioned construction-site spans.
+		type span struct {
+			kind   string
+			lo, hi token.Pos
+		}
+		var sites []span
+		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
+				return
+			}
+			if kind, ok := memTxTokenSiteKind(fd); ok {
+				sites = append(sites, span{kind, fd.Pos(), fd.End()})
+			}
+		})
+		within := func(n ast.Node, kinds ...string) bool {
+			for _, s := range sites {
+				if n.Pos() < s.lo || n.End() > s.hi {
+					continue
+				}
+				for _, k := range kinds {
+					if s.kind == k {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		// W1: txlock.Acquire only inside (memTxRunner).runLocked.
+		EachInSubtree[ast.CallExpr](file, func(ce *ast.CallExpr) {
+			sel, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok || !isTxlockAcquireCall(p.TypesInfo, sel) {
+				return
+			}
+			if within(ce, memTxSiteRunLocked) {
+				return
+			}
+			report(ce, fmt.Sprintf(
+				"txlock.Acquire in %s, outside the sole sanctioned runLocked "+
+					"witness-mint site (%s W1)",
+				enclosingFuncName(file, ce.Pos()), ruleMemTxLockOwnership01))
+		})
+
+		// R1: memTxToken composite literal only inside a sanctioned site.
+		EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
+			if !isMemTxTokenLitTyped(p.TypesInfo, p.Pkg, cl) {
+				return
+			}
+			if within(cl, memTxSiteRunLocked, memTxSiteWithTxContext) {
+				return
+			}
+			report(cl, fmt.Sprintf(
+				"memTxToken composite literal in %s, outside runLocked / "+
+					"WithTxContext (%s R1)",
+				enclosingFuncName(file, cl.Pos()), ruleMemTxLockOwnership01))
+		})
+
+		// W2: (*Store).txHoldsLock return form.
+		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Body == nil || fd.Name.Name != "txHoldsLock" {
+				return
+			}
+			if fd.Recv == nil || receiverTypeName(fd) != "Store" {
+				return
+			}
+			if ok, why := txHoldsLockFormOK(fd); !ok {
+				report(fd, fmt.Sprintf(
+					"weakened (*Store).txHoldsLock in %s: %s — must be "+
+						"`tok != nil && tok.held.Holds(&s.mu)` (%s W2)",
+					enclosingFuncName(file, fd.Pos()), why, ruleMemTxLockOwnership01))
+			}
+		})
+	}
+	return ds
+}
+
+// memProductionScan runs scanMemTxLockWitness over the production mem package
+// only (skipping the txlock sub-package and any other loaded package).
+func memProductionScan(t *testing.T) []Diagnostic {
+	t.Helper()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+	memPkgPath := modPath + "/" + memPkgRel
+
+	var diags []Diagnostic
+	RunTyped(t, TypedOpts{Tests: false}, []string{"./" + memPkgRel + "/..."},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != memPkgPath {
+				return nil
+			}
+			diags = append(diags, scanMemTxLockWitness(p)...)
+			return nil
+		})
+	return diags
+}
+
+// TestMemTxLockOwnership01 enforces W1 + W2 + R1 over the production mem package.
 func TestMemTxLockOwnership01(t *testing.T) {
-	root := findModuleRoot(t)
-	scope := DirsScope(root, []string{memPkgRel})
+	diags := memProductionScan(t)
 
-	type violation struct {
-		file, detail string
-		line         int
+	var lines []string
+	for _, d := range diags {
+		lines = append(lines, fmt.Sprintf("  %s:%d  %s", d.Rel, d.Line, d.Message))
 	}
-	var violations []violation
-
-	// DirsScope without IncludeTests() excludes *_test.go.
-	Run(t, scope, func(p *Pass) []Diagnostic {
-		for _, file := range p.Files {
-			// Record the Pos/End spans of the two allowed funcs.
-			type span struct{ lo, hi ast.Node }
-			var allowed []span
-			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-				if fd.Body != nil && allowedTokenFunc(fd) {
-					allowed = append(allowed, span{fd, fd})
-				}
-			})
-			inAllowed := func(n ast.Node) bool {
-				for _, s := range allowed {
-					if n.Pos() >= s.lo.Pos() && n.End() <= s.hi.End() {
-						return true
-					}
-				}
-				return false
-			}
-
-			// R1: every memTxToken composite literal must sit inside an
-			// allowed func.
-			EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
-				if !isMemTxTokenLit(cl) {
-					return
-				}
-				if inAllowed(cl) {
-					return
-				}
-				pos := p.Fset.Position(cl.Pos())
-				violations = append(violations, violation{
-					file:   p.Rel(file),
-					line:   pos.Line,
-					detail: "memTxToken composite literal outside (memTxRunner).RunInTx / WithTxContext (R1)",
-				})
-			})
-
-			// R2a: ban new(memTxToken).
-			EachInSubtree[ast.CallExpr](file, func(ce *ast.CallExpr) {
-				id, ok := ce.Fun.(*ast.Ident)
-				if !ok || id.Name != "new" || len(ce.Args) != 1 {
-					return
-				}
-				arg, ok := ce.Args[0].(*ast.Ident)
-				if !ok || arg.Name != memTxTokenTypeName {
-					return
-				}
-				pos := p.Fset.Position(ce.Pos())
-				violations = append(violations, violation{
-					file:   p.Rel(file),
-					line:   pos.Line,
-					detail: "new(memTxToken) banned; construct via the composite-literal funnel (R2a)",
-				})
-			})
-
-			// R2b: every `x.holdsLock` selector (read OR write) must sit inside
-			// (*Store).txHoldsLock — the sole legitimate field accessor. The
-			// two construction sites use composite-literal Ident keys
-			// (KeyValueExpr.Key), NOT SelectorExpr, so they are not matched
-			// here; R1 already funnels construction. Funneling all selector
-			// access to txHoldsLock makes "build then flip / read elsewhere"
-			// uniformly catchable with a single-node walk (no []ast.Expr
-			// for-range — SCANNER-FRAMEWORK-USAGE-01 compliant).
-			//
-			// Receiver check: the accessor must have receiver *Store (value or
-			// pointer), symmetric with allowedTokenFunc's receiver check for
-			// RunInTx. This prevents a same-named function on a different type
-			// from being falsely accepted as the allowed accessor.
-			var accessor []ast.Node
-			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-				if fd.Body != nil && fd.Name.Name == "txHoldsLock" &&
-					fd.Recv != nil && receiverTypeName(fd) == "Store" {
-					accessor = append(accessor, fd)
-				}
-			})
-			inAccessor := func(n ast.Node) bool {
-				for _, a := range accessor {
-					if n.Pos() >= a.Pos() && n.End() <= a.End() {
-						return true
-					}
-				}
-				return false
-			}
-			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
-				if sel.Sel.Name != "holdsLock" || inAccessor(sel) {
-					return
-				}
-				pos := p.Fset.Position(sel.Pos())
-				violations = append(violations, violation{
-					file:   p.Rel(file),
-					line:   pos.Line,
-					detail: ".holdsLock accessed outside (*Store).txHoldsLock (R2b)",
-				})
-			})
-		}
-		return nil
-	})
-
-	var violationLines []string
-	for _, v := range violations {
-		violationLines = append(violationLines, fmt.Sprintf("  %s:%d  %s", v.file, v.line, v.detail))
-	}
-	assert.Empty(t, violationLines,
-		"%s: %d violation(s) — memTxToken (holdsLock truth token) may only be constructed in "+
-			"(memTxRunner).RunInTx / WithTxContext and never post-mutated; see ADR "+
+	assert.Empty(t, lines,
+		"%s: %d violation(s) — the witness funnel (txlock.Acquire only in "+
+			"runLocked; txHoldsLock pins tok.held.Holds; memTxToken only in "+
+			"runLocked/WithTxContext) is broken; see ADR "+
 			"202605171846-adr-mem-tx-lock-ownership.md:\n%s",
-		ruleMemTxLockOwnership01, len(violationLines), strings.Join(violationLines, "\n"))
+		ruleMemTxLockOwnership01, len(lines), strings.Join(lines, "\n"))
 }
 
-// TestMemTxLockOwnership01_FindsExactlyTheTwoSites is the companion-index
-// precision test (anti-vacuous-pass): it asserts the scan actually sees a
-// memTxToken composite literal inside BOTH RunInTx and WithTxContext. If a
-// refactor renames the type or moves construction such that the matcher stops
-// firing, this fails loudly instead of the primary rule passing empty.
-func TestMemTxLockOwnership01_FindsExactlyTheTwoSites(t *testing.T) {
+// TestMemTxLockOwnership01_FindsSanctionedSites is the companion-index
+// precision test (anti-vacuous-pass): it asserts the scan actually sees the
+// witness funnel's anchors in production — the runLocked txlock.Acquire site,
+// a memTxToken literal inside BOTH runLocked and WithTxContext, and the
+// (*Store).txHoldsLock accessor. If a refactor renames the type / functions or
+// moves construction so the matchers stop firing, this fails loudly instead of
+// the primary rule passing empty.
+func TestMemTxLockOwnership01_FindsSanctionedSites(t *testing.T) {
 	root := findModuleRoot(t)
-	scope := DirsScope(root, []string{memPkgRel})
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+	memPkgPath := modPath + "/" + memPkgRel
 
-	sites := map[string]bool{} // func name -> saw memTxToken lit inside
-	Run(t, scope, func(p *Pass) []Diagnostic {
-		for _, file := range p.Files {
-			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-				if fd.Body == nil || !allowedTokenFunc(fd) {
-					return
-				}
-				EachInSubtree[ast.CompositeLit](fd, func(cl *ast.CompositeLit) {
-					if isMemTxTokenLit(cl) {
-						sites[fd.Name.Name] = true
+	var acquireInRunLocked, txHoldsLockAccessors int
+	litSites := map[string]bool{} // site kind -> saw memTxToken literal inside
+
+	RunTyped(t, TypedOpts{Tests: false}, []string{"./" + memPkgRel + "/..."},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != memPkgPath {
+				return nil
+			}
+			for _, file := range p.Files {
+				EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+					if fd.Body == nil {
+						return
+					}
+					if fd.Name.Name == "txHoldsLock" && fd.Recv != nil &&
+						receiverTypeName(fd) == "Store" {
+						txHoldsLockAccessors++
+					}
+					kind, isSite := memTxTokenSiteKind(fd)
+					if !isSite {
+						return
+					}
+					EachInSubtree[ast.CompositeLit](fd, func(cl *ast.CompositeLit) {
+						if isMemTxTokenLitTyped(p.TypesInfo, p.Pkg, cl) {
+							litSites[kind] = true
+						}
+					})
+					if kind == memTxSiteRunLocked {
+						EachInSubtree[ast.CallExpr](fd, func(ce *ast.CallExpr) {
+							if sel, ok := ce.Fun.(*ast.SelectorExpr); ok &&
+								isTxlockAcquireCall(p.TypesInfo, sel) {
+								acquireInRunLocked++
+							}
+						})
 					}
 				})
-			})
-		}
-		return nil
-	})
+			}
+			return nil
+		})
 
-	require.Truef(t, sites["RunInTx"],
-		"%s precision: expected a memTxToken literal inside (memTxRunner).RunInTx; "+
+	require.Positivef(t, acquireInRunLocked,
+		"%s precision: expected a txlock.Acquire call inside (memTxRunner).runLocked; "+
 			"matcher may be stale", ruleMemTxLockOwnership01)
-	require.Truef(t, sites["WithTxContext"],
-		"%s precision: expected a memTxToken literal inside WithTxContext; "+
-			"matcher may be stale", ruleMemTxLockOwnership01)
-}
-
-// TestMemTxLockOwnership01_R2bFindsHoldsLockAccessor is the companion-index
-// reverse self-check for R2b: it asserts that the scan actually finds a
-// FuncDecl named "txHoldsLock" with receiver *Store in the mem package AND
-// that function body contains at least one "holdsLock" SelectorExpr. If the
-// accessor is renamed or its body emptied, this fails loudly instead of R2b
-// passing vacuously (no accessor found → everything outside the empty set
-// passes trivially).
-//
-// Medium rating: receiver identification uses string anchors
-// (receiverTypeName == "Store"), per ai-robust.md §"Funnel 双向锁评级"
-// this is an allowed Medium upstream.
-func TestMemTxLockOwnership01_R2bFindsHoldsLockAccessor(t *testing.T) {
-	root := findModuleRoot(t)
-	scope := DirsScope(root, []string{memPkgRel})
-
-	var accessorCount int
-	var holdsLockSelCount int
-
-	Run(t, scope, func(p *Pass) []Diagnostic {
-		for _, file := range p.Files {
-			EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-				if fd.Body == nil || fd.Name.Name != "txHoldsLock" {
-					return
-				}
-				if fd.Recv == nil || receiverTypeName(fd) != "Store" {
-					return
-				}
-				accessorCount++
-				EachInSubtree[ast.SelectorExpr](fd, func(sel *ast.SelectorExpr) {
-					if sel.Sel.Name == "holdsLock" {
-						holdsLockSelCount++
-					}
-				})
-			})
-		}
-		return nil
-	})
-
-	require.Equalf(t, 1, accessorCount,
-		"%s R2b companion-index: expected exactly 1 FuncDecl named txHoldsLock with "+
-			"receiver *Store in %s; got %d — matcher may be stale after rename or "+
-			"a second same-named accessor was added (false-negative risk)",
-		ruleMemTxLockOwnership01, memPkgRel, accessorCount)
-	require.Positivef(t, holdsLockSelCount,
-		"%s R2b companion-index: expected at least one .holdsLock SelectorExpr "+
-			"inside (*Store).txHoldsLock; body may be empty or renamed",
+	require.Truef(t, litSites[memTxSiteRunLocked],
+		"%s precision: expected a memTxToken literal inside (memTxRunner).runLocked",
 		ruleMemTxLockOwnership01)
+	require.Truef(t, litSites[memTxSiteWithTxContext],
+		"%s precision: expected a memTxToken literal inside WithTxContext",
+		ruleMemTxLockOwnership01)
+	require.Equalf(t, 1, txHoldsLockAccessors,
+		"%s precision: expected exactly 1 (*Store).txHoldsLock accessor in %s, got %d",
+		ruleMemTxLockOwnership01, memPkgRel, txHoldsLockAccessors)
 }
 
-// TestMemTxLockOwnership01_NoReflectInMemPkg closes the reflect blind spot:
-// an AST literal scan cannot see reflect.Value.SetBool mutation of holdsLock.
-// Package mem does not (and must not) import "reflect"; assert it absent.
+// TestMemTxLockOwnership01_NoReflectInMemPkg closes the reflect blind spot: an
+// AST/typed scan cannot see reflect-based mutation of txlock.Held.mu (which
+// would forge a witness). Neither package mem nor package txlock imports
+// "reflect"; assert it absent.
 func TestMemTxLockOwnership01_NoReflectInMemPkg(t *testing.T) {
-	assertMemPkgDoesNotImport(t, "reflect")
+	assertMemTreeDoesNotImport(t, "reflect")
 }
 
 // TestMemTxLockOwnership01_NoUnsafeInMemPkg closes the unsafe blind spot
-// (unsafe-pointer field write). Package mem must not import "unsafe".
+// (unsafe-pointer write to txlock.Held.mu). Neither package must import "unsafe".
 func TestMemTxLockOwnership01_NoUnsafeInMemPkg(t *testing.T) {
-	assertMemPkgDoesNotImport(t, "unsafe")
+	assertMemTreeDoesNotImport(t, "unsafe")
 }
 
-func assertMemPkgDoesNotImport(t *testing.T, pkg string) {
+// assertMemTreeDoesNotImport asserts that neither the mem package nor its
+// internal/txlock seal package imports pkg (a witness-forge channel).
+func assertMemTreeDoesNotImport(t *testing.T, pkg string) {
 	t.Helper()
 	root := findModuleRoot(t)
-	scope := DirsScope(root, []string{memPkgRel})
+	scope := DirsScope(root, []string{memPkgRel, memPkgRel + "/internal/txlock"})
 
 	var offenders []string
 	Run(t, scope, func(p *Pass) []Diagnostic {
@@ -337,25 +492,7 @@ func assertMemPkgDoesNotImport(t *testing.T, pkg string) {
 		return nil
 	})
 	assert.Emptyf(t, offenders,
-		"%s blind-spot guard: package %s must not import %q (would defeat the "+
-			"AST construction-site funnel); offenders: %v",
-		ruleMemTxLockOwnership01, memPkgRel, pkg, offenders)
-}
-
-// scanMemTxLockWitness is the shared witness-funnel detector (Wave 2 sealed
-// lock-witness model). It runs over a single package Pass — production
-// (cells/accesscore/internal/mem) and the memtxlockfixture reverse self-check
-// alike — and reports:
-//
-//	W1: txlock.Acquire called outside (memTxRunner).runLocked.
-//	W2: (*Store).txHoldsLock return not of the exact form
-//	    `tok != nil && tok.held.Holds(&s.mu)`.
-//	R1: memTxToken composite literal outside runLocked / WithTxContext.
-//
-// STUB (Wave 1 RED): returns nil so the reverse self-check
-// (TestMemTxLockOwnership01_FixturePattern) fails until Wave 2 implements the
-// scan. Wave 2 replaces this body and rewires TestMemTxLockOwnership01.
-func scanMemTxLockWitness(p *Pass) []Diagnostic {
-	_ = p
-	return nil
+		"%s blind-spot guard: mem tree must not import %q (would defeat the "+
+			"sealed-witness funnel by forging txlock.Held.mu); offenders: %v",
+		ruleMemTxLockOwnership01, pkg, offenders)
 }

--- a/tools/archtest/mem_tx_lock_ownership_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_test.go
@@ -81,15 +81,12 @@ package archtest
 //   - W2 field/method-name anchors ("inLiveTx", "Live", "memTxKey", "mu"): a
 //     rename breaks every call site to compile before archtest runs (build error),
 //     and the txlock.Lease seal is reflect-frozen by TestLeaseSealFrozen.
-//   - W2 type/source matchers are syntactic, not typed: isLeaseTypeExpr matches any
-//     `<pkg>.Lease` or bare `Lease` (NOT resolved to the txlock package via
-//     ResolvePackageRef), and isCtxValueMemTxKeyCall matches
-//     `<anyVar>.Value(memTxKey{})` (the receiver is not pinned to `ctx`). A foreign
-//     Lease type, or a non-ctx receiver calling `.Value(memTxKey{})`, would still
-//     satisfy bindsLeaseFromCtx. Accepted, not closed: package mem imports only
-//     txlock.Lease and has exactly one inLiveTx (canonical `ctx` receiver), and W2
-//     is a Medium regression anchor over the Hard seal — a syntactic match is
-//     sufficient here; tightening to ResolvePackageRef is optional future hardening.
+//   - W2 type/source matchers are TYPED (closed, not a blind spot): isTxlockLeaseType
+//     resolves the asserted type via go/types to a named Lease in a /txlock package
+//     (a foreign `<pkg>.Lease` is rejected), and isCtxValueMemTxKeyCall requires the
+//     `.Value(memTxKey{})` receiver to resolve to context.Context. No string-name
+//     latitude remains, so bindsLeaseFromCtx cannot be satisfied by a fabricated,
+//     freshly-Acquired, or foreign-typed lease source.
 
 import (
 	"fmt"
@@ -210,26 +207,48 @@ func leaseLiveCall(e ast.Expr, recv string) (leaseVar string, ok bool) {
 	return lid.Name, true
 }
 
-// isLeaseTypeExpr reports whether e names the Lease type (txlock.Lease or a bare
-// Lease alias).
-func isLeaseTypeExpr(e ast.Expr) bool {
-	switch t := e.(type) {
-	case *ast.SelectorExpr:
-		return t.Sel != nil && t.Sel.Name == "Lease"
-	case *ast.Ident:
-		return t.Name == "Lease"
+// isTxlockLeaseType reports whether the type expression e resolves (typed) to a
+// named "Lease" declared in a package whose import path ends in "/txlock"
+// (production …/mem/internal/txlock or the fixture mirror). Typed resolution via
+// info — not a bare Sel.Name=="Lease" string match — so a foreign package's Lease
+// type cannot satisfy the W2 lease-source check.
+func isTxlockLeaseType(info *types.Info, e ast.Expr) bool {
+	t := info.TypeOf(e)
+	if t == nil {
+		return false
 	}
-	return false
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == "Lease" &&
+		obj.Pkg() != nil && strings.HasSuffix(obj.Pkg().Path(), "/txlock")
 }
 
-// isCtxValueMemTxKeyCall reports whether e is `ctx.Value(memTxKey{})`.
-func isCtxValueMemTxKeyCall(e ast.Expr) bool {
+// isContextContextType reports whether t is the named interface context.Context.
+func isContextContextType(t types.Type) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == "Context" &&
+		obj.Pkg() != nil && obj.Pkg().Path() == "context"
+}
+
+// isCtxValueMemTxKeyCall reports whether e is `<ctx>.Value(memTxKey{})` where the
+// receiver is typed context.Context (typed — not any variable calling .Value).
+func isCtxValueMemTxKeyCall(info *types.Info, e ast.Expr) bool {
 	ce, ok := e.(*ast.CallExpr)
 	if !ok || len(ce.Args) != 1 {
 		return false
 	}
 	sel, ok := ce.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel == nil || sel.Sel.Name != "Value" {
+		return false
+	}
+	if rt := info.TypeOf(sel.X); rt == nil || !isContextContextType(rt) {
 		return false
 	}
 	cl, ok := ce.Args[0].(*ast.CompositeLit)
@@ -241,9 +260,11 @@ func isCtxValueMemTxKeyCall(e ast.Expr) bool {
 }
 
 // bindsLeaseFromCtx reports whether fd assigns leaseVar from
-// `ctx.Value(memTxKey{}).(txlock.Lease)`. Pins the W2 lease source so the
-// delegation cannot read a fabricated or freshly-Acquired lease.
-func bindsLeaseFromCtx(fd *ast.FuncDecl, leaseVar string) bool {
+// `<ctx>.Value(memTxKey{}).(txlock.Lease)` — typed: the asserted type resolves to
+// a /txlock-package Lease and the receiver is context.Context. Pins the W2 lease
+// source so the delegation cannot read a fabricated, freshly-Acquired, or
+// foreign-typed lease.
+func bindsLeaseFromCtx(info *types.Info, fd *ast.FuncDecl, leaseVar string) bool {
 	found := false
 	EachInSubtree[ast.AssignStmt](fd, func(as *ast.AssignStmt) {
 		if found || len(as.Lhs) == 0 || len(as.Rhs) != 1 {
@@ -254,10 +275,10 @@ func bindsLeaseFromCtx(fd *ast.FuncDecl, leaseVar string) bool {
 			return
 		}
 		ta, ok := as.Rhs[0].(*ast.TypeAssertExpr)
-		if !ok || ta.Type == nil || !isLeaseTypeExpr(ta.Type) {
+		if !ok || ta.Type == nil || !isTxlockLeaseType(info, ta.Type) {
 			return
 		}
-		if isCtxValueMemTxKeyCall(ta.X) {
+		if isCtxValueMemTxKeyCall(info, ta.X) {
 			found = true
 		}
 	})
@@ -274,7 +295,7 @@ func bindsLeaseFromCtx(fd *ast.FuncDecl, leaseVar string) bool {
 // is the canonical form; weakening it (dropping the Live delegation, comparing
 // l.mu directly to bypass the live flag, sourcing l elsewhere) must be a
 // deliberate edit that also updates this rule.
-func inLiveTxFormOK(fd *ast.FuncDecl) (ok bool, why string) {
+func inLiveTxFormOK(info *types.Info, fd *ast.FuncDecl) (ok bool, why string) {
 	recv := receiverVarName(fd)
 	if recv == "" {
 		return false, "no named receiver"
@@ -292,7 +313,7 @@ func inLiveTxFormOK(fd *ast.FuncDecl) (ok bool, why string) {
 	if !ok {
 		return false, fmt.Sprintf("return must be `<lease>.Live(&%s.mu)`", recv)
 	}
-	if !bindsLeaseFromCtx(fd, leaseVar) {
+	if !bindsLeaseFromCtx(info, fd, leaseVar) {
 		return false, fmt.Sprintf("`%s` must be bound from ctx.Value(memTxKey{}).(txlock.Lease)", leaseVar)
 	}
 	return true, ""
@@ -363,7 +384,7 @@ func scanMemTxLockWitness(p *Pass) []Diagnostic {
 			if fd.Recv == nil || receiverTypeName(fd) != "Store" {
 				return
 			}
-			if ok, why := inLiveTxFormOK(fd); !ok {
+			if ok, why := inLiveTxFormOK(p.TypesInfo, fd); !ok {
 				report(fd, fmt.Sprintf(
 					"weakened (*Store).inLiveTx in %s: %s — must be `return "+
 						"l.Live(&s.mu)` with l from ctx.Value(memTxKey{}).(txlock.Lease) "+

--- a/tools/archtest/mem_tx_lock_ownership_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_test.go
@@ -69,6 +69,12 @@ package archtest
 //     the real-source reverse self-check TestMemTxLockOwnership01_FixturePattern
 //     (mem_tx_lock_ownership_red_fixture_test.go) asserting exactly the three RED
 //     sites are reported and the sanctioned sites are not.
+//   - W2 field-name anchors ("held" on memTxToken, "mu" on Store): a rename of
+//     memTxToken.held would make isHeldHoldsCall silently miss (false-negative).
+//     Compiler-defended, no standalone self-check needed: every tok.held.Holds(…)
+//     call site in user_repo.go / role_repo.go (via txHoldsLock) breaks to compile
+//     on rename, so it is a build error before archtest runs. (txlock.Held.mu is
+//     additionally reflect-frozen by TestHeldSealFrozen.)
 
 import (
 	"fmt"
@@ -225,6 +231,13 @@ func isHeldHoldsCall(e ast.Expr, tok, recv string) bool {
 // tree flattens to exactly two conjuncts — a nil-guard on tok and the Holds call
 // on tok.held with arg &<recv>.mu. Order-independent; receiver/token names are
 // taken from the source, not hard-coded.
+//
+// Form, not semantics, is pinned (intentional, to block silent regression of a
+// security invariant): a refactor producing MORE than one single-value return —
+// e.g. an early-return guard `if tok == nil { return false }; return …` — trips
+// this check even though it is semantically equivalent. The one-liner is the
+// canonical form; weakening it (dropping the Holds conjunct, adding a third
+// conjunct) must be a deliberate edit that also updates this rule.
 func txHoldsLockFormOK(fd *ast.FuncDecl) (ok bool, why string) {
 	recv := receiverVarName(fd)
 	if recv == "" {
@@ -366,6 +379,9 @@ func memProductionScan(t *testing.T) []Diagnostic {
 	memPkgPath := modPath + "/" + memPkgRel
 
 	var diags []Diagnostic
+	// Load mem/... (not just mem) so the typed resolver has the txlock sub-package
+	// in the loaded set — isTxlockAcquireCall → ResolvePackageRef needs it. The
+	// p.Pkg.Path() filter then restricts the scan to the mem package itself.
 	RunTyped(t, TypedOpts{Tests: false}, []string{"./" + memPkgRel + "/..."},
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != memPkgPath {
@@ -445,9 +461,11 @@ func TestMemTxLockOwnership01_FindsSanctionedSites(t *testing.T) {
 			return nil
 		})
 
-	require.Positivef(t, acquireInRunLocked,
-		"%s precision: expected a txlock.Acquire call inside (memTxRunner).runLocked; "+
-			"matcher may be stale", ruleMemTxLockOwnership01)
+	require.Equalf(t, 1, acquireInRunLocked,
+		"%s precision: expected exactly 1 txlock.Acquire call inside (memTxRunner).runLocked, "+
+			"got %d — 0 means the matcher is stale; >1 means a second Acquire (a "+
+			"re-entrant double-lock deadlock bug) that W1 would not catch (it only flags "+
+			"Acquire OUTSIDE runLocked)", ruleMemTxLockOwnership01, acquireInRunLocked)
 	require.Truef(t, litSites[memTxSiteRunLocked],
 		"%s precision: expected a memTxToken literal inside (memTxRunner).runLocked",
 		ruleMemTxLockOwnership01)
@@ -481,6 +499,10 @@ func assertMemTreeDoesNotImport(t *testing.T, pkg string) {
 	scope := DirsScope(root, []string{memPkgRel, memPkgRel + "/internal/txlock"})
 
 	var offenders []string
+	// Bare Run (not RunTyped): a direct import-path string match suffices for
+	// stdlib "reflect"/"unsafe" — they have no alias form in ImportSpec.Path.Value
+	// and the threat is a direct import within mem/txlock, not a transitive one.
+	// RunTyped would load the full type graph for no benefit.
 	Run(t, scope, func(p *Pass) []Diagnostic {
 		for _, file := range p.Files {
 			for _, imp := range file.Imports {

--- a/tools/archtest/mem_tx_lock_ownership_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_test.go
@@ -3,82 +3,89 @@ package archtest
 // INVARIANT: MEM-TX-LOCK-OWNERSHIP-01
 //
 // mem_tx_lock_ownership_test.go guards the regression surface of the mem tx
-// lock-ownership funnel after the sealed lock-witness rework (#945; ADR
-// docs/architecture/202605171846-adr-mem-tx-lock-ownership.md). The threat is
-// "sentinel present but no lock": a tx-context token authorizing a repository
-// method to skip its per-call store.mu lock when the lock is NOT held →
-// concurrent map writes (the PR #558 flake).
+// lock-ownership funnel after the self-invalidating lease rework (#945 witness →
+// #972 lease; ADR docs/architecture/202605171846-adr-mem-tx-lock-ownership.md).
+// The threat is "sentinel present but no lock": a tx-context value authorizing a
+// repository method to skip its per-call store.mu lock when the lock is NOT held
+// → concurrent map writes (the PR #558 flake).
 //
-// That threat is now compile-impossible — the Hard core lives in the type
-// system, not in this archtest:
+// That threat is closed in the TYPE SYSTEM (the sealed txlock package), not in
+// this archtest:
 //
-//   - Upstream Hard: cells/accesscore/internal/mem/internal/txlock.Held's sole
-//     field is unexported, so no package (not even mem) can write txlock.Held{…}
-//     with a real mutex. The only way to obtain a Held whose Holds(&store.mu) is
-//     true is txlock.Acquire(&store.mu), which Lock()s the mutex.
-//   - Downstream Hard: a memTxToken carries that Held; txHoldsLock authorizes a
-//     lock-skip only when tok.held.Holds(&s.mu). "In a tx context yet not holding
-//     the lock" is inexpressible without having locked. The Held also has NO
-//     Release method (Acquire returns a separate unlock closure kept local to
-//     runLocked), so a ctx-carried witness cannot even release the lock.
+//   - Upstream Hard (forge): cells/accesscore/internal/mem/internal/txlock.Lease
+//     has only unexported fields (mu *sync.Mutex, live *atomic.Bool), so no
+//     package (not even mem) can write txlock.Lease{…} with a real mutex+live
+//     flag. The only way to obtain a Lease whose Live(&store.mu) is true is
+//     txlock.Acquire(&store.mu), which Lock()s the mutex and arms live.
+//   - Downstream Hard (liveness): the lease SELF-INVALIDATES. Acquire's unlock
+//     closure (the sole writer of live) flips it dead before releasing store.mu.
+//     A ctx carrying the lease that escapes the runLocked closure reports
+//     Live==false afterwards (fail-closed: per-call lock). Lease has no Release
+//     method and no way to write live from outside the unlock closure, so a
+//     ctx-carried lease can neither unlock nor re-arm itself. (database/sql
+//     *Tx.done → ErrTxDone analog.)
 //
 // This file is the Medium regression layer over that Hard core. It runs the
-// shared detector scanMemTxLockWitness over package mem (typed, via RunTyped)
-// and reports:
+// shared detector scanMemTxLockWitness over package mem (typed, via RunTyped) and
+// reports:
 //
-//	W1 — txlock.Acquire is called only inside (memTxRunner).runLocked, the sole
-//	     sanctioned witness-mint site (matched by func name "Acquire" + package
-//	     path suffix "/txlock", resolved typed via ResolvePackageRef).
-//	W2 — (*Store).txHoldsLock returns exactly `tok != nil && tok.held.Holds(&s.mu)`
-//	     (flatten the && tree; exactly two conjuncts: a nil-guard and the Holds
-//	     call on tok.held with arg &<recv>.mu). Dropping the Holds conjunct, adding
-//	     a third conjunct, or weakening the call shape fails — this pins the
-//	     downstream-Hard runtime check against silent regression.
-//	R1 — every memTxToken composite literal (typed match: *types.Named "memTxToken"
-//	     in the package under scan) sits inside runLocked or WithTxContext.
+//	W1 — txlock.Acquire is the single sanctioned mint: it appears ONLY as
+//	     `txlock.Acquire(&r.s.mu)` in the DIRECT body of (memTxRunner).runLocked.
+//	     Any Acquire elsewhere, with a foreign argument, or nested inside a
+//	     closure within runLocked is reported. (Tightened in #972: the earlier
+//	     rule pinned only the lexical site, not the &r.s.mu argument or the
+//	     direct-body / non-closure shape.)
+//	W2 — (*Store).inLiveTx returns exactly `l.Live(&s.mu)`, where l is the lease
+//	     bound from `ctx.Value(memTxKey{}).(txlock.Lease)`. Dropping the Live
+//	     delegation (e.g. `return true`), comparing the mutex directly (bypassing
+//	     the live flag), or sourcing the lease elsewhere fails — this pins the
+//	     downstream check against silent regression.
 //
-// The seal itself (txlock.Held field-set: exactly one unexported *sync.Mutex
-// field) is frozen by reflect in the txlock package's own test
-// (TestHeldSealFrozen in internal/txlock/txlock_test.go) — tools/archtest cannot
-// import the double-internal txlock package, so the freeze lives where Held is
-// defined, mirroring the FixtureOpts freeze in pass_test.go.
+// The ctx now carries the txlock.Lease value directly (no memTxToken wrapper) and
+// WithTxContext is gone, so the former R1 (memTxToken literal scope) is deleted:
+// a live Lease can ONLY originate in txlock.Acquire (W1 pins it to runLocked) and
+// a zero Lease is harmless (Live false). The seal + W1 subsume R1.
 //
-// Note on "const-fold": #945 originally proposed pinning a holdsLock bool field
-// value via go/types constant folding. The witness rework deletes that bool
-// (there is no value left to fold and no bool-const substitution blind spot);
-// R1 now pins only construction SITE, while W1/W2 + the type-system seal carry
-// the lock-ownership truth.
+// The seal itself (txlock.Lease field-set: exactly two unexported fields,
+// *sync.Mutex + *atomic.Bool) is frozen by reflect in the txlock package's own
+// test (TestLeaseSealFrozen in internal/txlock/txlock_test.go) — tools/archtest
+// cannot import the double-internal txlock package, so the freeze lives where
+// Lease is defined, mirroring the FixtureOpts freeze in pass_test.go. The live
+// flip lives only in Acquire's unlock closure inside that sealed package, so no
+// standalone archtest can (or needs to) guard it.
 //
 // AI-robust rating (modifies an enforcement mechanism + reworks runtime design):
-//   - Upstream Hard / Downstream Hard — type system (txlock.Held seal; Held has
-//     no Release). This archtest is NOT the primary defense.
-//   - This file (W1/W2/R1) = Medium regression layer: string anchors
-//     ("Acquire"/"txlock"/"runLocked"/"WithTxContext"/"txHoldsLock"/"held"/"mu")
-//     + AST form-uniqueness. No gh issue to "Hard-ify" — the funnel is already
-//     Hard via the seal; W1/W2/R1 only catch funnel-discipline drift.
+//   - Upstream Hard / Downstream Hard — type system (txlock.Lease seal; Lease has
+//     no Release; live writable only by Acquire's unlock closure). This archtest
+//     is NOT the primary defense.
+//   - This file (W1/W2) = Medium regression layer: string/AST anchors
+//     ("Acquire"/"txlock"/"runLocked"/"inLiveTx"/"Live"/"mu"/"memTxKey") + AST
+//     form-uniqueness. No gh issue to "Hard-ify" — the funnel is already Hard via
+//     the seal; W1/W2 only catch funnel-discipline drift.
 //
 // Tool blind spots (pure-AST/typed scan) + their reverse self-checks, per
 // ai-robust.md §"工具选定后强制盲区自检":
-//   - reflect.Value.Set / unsafe pointer write on txlock.Held.mu would forge a
-//     witness: closed by NoReflectInMemPkg / NoUnsafeInMemPkg asserting neither
-//     package mem nor package txlock imports "reflect"/"unsafe".
+//   - reflect.Value.Set / unsafe pointer write on txlock.Lease.{mu,live} would
+//     forge a lease: closed by NoReflectInMemPkg / NoUnsafeInMemPkg asserting
+//     neither package mem nor package txlock imports "reflect"/"unsafe".
 //   - vacuous-pass (matcher silently matches nothing): closed by
-//     FindsSanctionedSites asserting the scan actually finds the runLocked
-//     Acquire site, both memTxToken literal sites, and the txHoldsLock accessor.
-//   - detector correctness (false-negative / false-positive drift): closed by
-//     the real-source reverse self-check TestMemTxLockOwnership01_FixturePattern
+//     FindsSanctionedSites asserting the scan finds the runLocked Acquire(&r.s.mu)
+//     site and the inLiveTx accessor in production.
+//   - W1 arg-pin / nesting traversal correctness: closed by the AST unit test
+//     W1ArgAndNesting (isAcquireArgRecvStoreMu table + directBodyAcquireCalls
+//     excludes nested-closure calls).
+//   - detector correctness (false-negative / false-positive drift): closed by the
+//     real-source reverse self-check TestMemTxLockOwnership01_FixturePattern
 //     (mem_tx_lock_ownership_red_fixture_test.go) asserting exactly the three RED
-//     sites are reported and the sanctioned sites are not.
-//   - W2 field-name anchors ("held" on memTxToken, "mu" on Store): a rename of
-//     memTxToken.held would make isHeldHoldsCall silently miss (false-negative).
-//     Compiler-defended, no standalone self-check needed: every tok.held.Holds(…)
-//     call site in user_repo.go / role_repo.go (via txHoldsLock) breaks to compile
-//     on rename, so it is a build error before archtest runs. (txlock.Held.mu is
-//     additionally reflect-frozen by TestHeldSealFrozen.)
+//     sites are reported and the sanctioned site is not.
+//   - W2 field/method-name anchors ("inLiveTx", "Live", "memTxKey", "mu"): a
+//     rename breaks every call site to compile before archtest runs (build error),
+//     and the txlock.Lease seal is reflect-frozen by TestLeaseSealFrozen.
 
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"strings"
@@ -92,36 +99,10 @@ const ruleMemTxLockOwnership01 = "MEM-TX-LOCK-OWNERSHIP-01"
 
 const memPkgRel = "cells/accesscore/internal/mem"
 
-// memTxTokenTypeName is the unexported witness-bearing token whose construction
-// site this rule funnels (R1).
-const memTxTokenTypeName = "memTxToken"
-
-const (
-	// memTxSiteRunLocked is the holds-witness mint site: (memTxRunner).runLocked
-	// is the only function allowed to call txlock.Acquire (W1) and the holds-lock
-	// memTxToken construction site (R1).
-	memTxSiteRunLocked = "runLocked"
-	// memTxSiteWithTxContext is the no-witness site: WithTxContext constructs a
-	// zero-witness memTxToken (R1) and never calls Acquire.
-	memTxSiteWithTxContext = "WithTxContext"
-)
-
-// memTxTokenSiteKind reports whether fd is one of the two sanctioned memTxToken
-// construction sites: func (memTxRunner) runLocked, or func WithTxContext.
-func memTxTokenSiteKind(fd *ast.FuncDecl) (site string, ok bool) {
-	switch fd.Name.Name {
-	case memTxSiteRunLocked:
-		// must be a method on memTxRunner (value or pointer receiver).
-		if fd.Recv != nil && receiverTypeName(fd) == "memTxRunner" {
-			return memTxSiteRunLocked, true
-		}
-	case memTxSiteWithTxContext:
-		if fd.Recv == nil {
-			return memTxSiteWithTxContext, true
-		}
-	}
-	return "", false
-}
+// memTxSiteRunLocked is the sole sanctioned lease-mint site: (memTxRunner).runLocked
+// is the only function allowed to call txlock.Acquire, and only as the
+// direct-body `&r.s.mu` call (W1).
+const memTxSiteRunLocked = "runLocked"
 
 // receiverVarName returns the receiver variable name of fd (the `s` in
 // `func (s *Store) …`), or "" when there is no named receiver.
@@ -130,28 +111,6 @@ func receiverVarName(fd *ast.FuncDecl) string {
 		return ""
 	}
 	return fd.Recv.List[0].Names[0].Name
-}
-
-// isMemTxTokenLitTyped reports whether cl constructs a memTxToken value declared
-// in the package under scan, covering both `memTxToken{…}` and `&memTxToken{…}`.
-// Typed match against *types.Named (immune to local shadowing); the package
-// identity check lets the same detector run over production mem and the
-// fixture's own memTxToken alike.
-func isMemTxTokenLitTyped(info *types.Info, pkg *types.Package, cl *ast.CompositeLit) bool {
-	if info == nil || pkg == nil || cl == nil || cl.Type == nil {
-		return false
-	}
-	t := info.TypeOf(cl.Type)
-	if t == nil {
-		return false
-	}
-	named, ok := t.(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj != nil && obj.Name() == memTxTokenTypeName &&
-		obj.Pkg() != nil && obj.Pkg().Path() == pkg.Path()
 }
 
 // isTxlockAcquireCall reports whether sel is a reference to func Acquire in a
@@ -165,80 +124,148 @@ func isTxlockAcquireCall(info *types.Info, sel *ast.SelectorExpr) bool {
 	return ok && name == "Acquire" && strings.HasSuffix(pkgPath, "/txlock")
 }
 
-// flattenLAND splits a left-associative `a && b && c` tree into its leaf
-// conjuncts. A non-&& expression returns itself as a single leaf.
-func flattenLAND(e ast.Expr) []ast.Expr {
-	be, ok := e.(*ast.BinaryExpr)
-	if !ok || be.Op != token.LAND {
-		return []ast.Expr{e}
+// isAcquireArgRecvStoreMu reports whether ce's sole argument is exactly
+// `&<recv>.s.mu` — the store mutex owned by runLocked's receiver. This is the W1
+// argument pin (#972): it rejects `txlock.Acquire(&otherMu)`,
+// `txlock.Acquire(&r.s.someOtherField)`, and `txlock.Acquire(&x.mu)` even when
+// they sit inside runLocked, so the mint can only lock THIS store's mutex.
+func isAcquireArgRecvStoreMu(ce *ast.CallExpr, recv string) bool {
+	if len(ce.Args) != 1 {
+		return false
 	}
-	return append(flattenLAND(be.X), flattenLAND(be.Y)...)
+	addr, ok := ce.Args[0].(*ast.UnaryExpr) // &…
+	if !ok || addr.Op != token.AND {
+		return false
+	}
+	muSel, ok := addr.X.(*ast.SelectorExpr) // ….mu
+	if !ok || muSel.Sel.Name != "mu" {
+		return false
+	}
+	sSel, ok := muSel.X.(*ast.SelectorExpr) // r.s
+	if !ok || sSel.Sel.Name != "s" {
+		return false
+	}
+	id, ok := sSel.X.(*ast.Ident) // r
+	return ok && id.Name == recv
 }
 
-// nilGuardVar returns the non-nil operand identifier name of an `x != nil`
-// BinaryExpr (either order), or ("", false) for any other shape.
-func nilGuardVar(e ast.Expr) (name string, ok bool) {
-	be, ok := e.(*ast.BinaryExpr)
-	if !ok || be.Op != token.NEQ {
-		return "", false
-	}
-	x, xIsIdent := be.X.(*ast.Ident)
-	y, yIsIdent := be.Y.(*ast.Ident)
-	if !xIsIdent || !yIsIdent {
-		return "", false
-	}
-	switch {
-	case y.Name == "nil":
-		return x.Name, true
-	case x.Name == "nil":
-		return y.Name, true
-	default:
-		return "", false
-	}
+// directBodyAcquireCalls collects the Acquire calls (per isAcquire) reachable
+// from fd.Body WITHOUT descending into a nested func literal. An Acquire wrapped
+// in `go func(){ … }()` or any closure inside runLocked is therefore excluded
+// from the sanctioned set (W1 #972): the single synchronous mint must be a direct
+// statement of runLocked, not deferred to another stack frame / goroutine.
+func directBodyAcquireCalls(fd *ast.FuncDecl, isAcquire func(*ast.CallExpr) bool) []*ast.CallExpr {
+	var out []*ast.CallExpr
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false // do not descend into nested closures
+		}
+		if ce, ok := n.(*ast.CallExpr); ok && isAcquire(ce) {
+			out = append(out, ce)
+		}
+		return true
+	})
+	return out
 }
 
-// isHeldHoldsCall reports whether e is exactly `<tok>.held.Holds(&<recv>.mu)`.
-func isHeldHoldsCall(e ast.Expr, tok, recv string) bool {
+// leaseLiveCall reports whether e is exactly `<lease>.Live(&<recv>.mu)` and
+// returns the lease identifier name. Used to pin (*Store).inLiveTx's return (W2).
+func leaseLiveCall(e ast.Expr, recv string) (leaseVar string, ok bool) {
+	ce, ok := e.(*ast.CallExpr)
+	if !ok || len(ce.Args) != 1 {
+		return "", false
+	}
+	live, ok := ce.Fun.(*ast.SelectorExpr) // <lease>.Live
+	if !ok || live.Sel.Name != "Live" {
+		return "", false
+	}
+	lid, ok := live.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	addr, ok := ce.Args[0].(*ast.UnaryExpr) // &<recv>.mu
+	if !ok || addr.Op != token.AND {
+		return "", false
+	}
+	muSel, ok := addr.X.(*ast.SelectorExpr)
+	if !ok || muSel.Sel.Name != "mu" {
+		return "", false
+	}
+	rid, ok := muSel.X.(*ast.Ident)
+	if !ok || rid.Name != recv {
+		return "", false
+	}
+	return lid.Name, true
+}
+
+// isLeaseTypeExpr reports whether e names the Lease type (txlock.Lease or a bare
+// Lease alias).
+func isLeaseTypeExpr(e ast.Expr) bool {
+	switch t := e.(type) {
+	case *ast.SelectorExpr:
+		return t.Sel != nil && t.Sel.Name == "Lease"
+	case *ast.Ident:
+		return t.Name == "Lease"
+	}
+	return false
+}
+
+// isCtxValueMemTxKeyCall reports whether e is `ctx.Value(memTxKey{})`.
+func isCtxValueMemTxKeyCall(e ast.Expr) bool {
 	ce, ok := e.(*ast.CallExpr)
 	if !ok || len(ce.Args) != 1 {
 		return false
 	}
-	holds, ok := ce.Fun.(*ast.SelectorExpr) // <…>.Holds
-	if !ok || holds.Sel.Name != "Holds" {
+	sel, ok := ce.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "Value" {
 		return false
 	}
-	heldSel, ok := holds.X.(*ast.SelectorExpr) // <tok>.held
-	if !ok || heldSel.Sel.Name != "held" {
+	cl, ok := ce.Args[0].(*ast.CompositeLit)
+	if !ok {
 		return false
 	}
-	if id, ok := heldSel.X.(*ast.Ident); !ok || id.Name != tok {
-		return false
-	}
-	addr, ok := ce.Args[0].(*ast.UnaryExpr) // &<recv>.mu
-	if !ok || addr.Op != token.AND {
-		return false
-	}
-	muSel, ok := addr.X.(*ast.SelectorExpr)
-	if !ok || muSel.Sel.Name != "mu" {
-		return false
-	}
-	id, ok := muSel.X.(*ast.Ident)
-	return ok && id.Name == recv
+	id, ok := cl.Type.(*ast.Ident)
+	return ok && id.Name == "memTxKey"
 }
 
-// txHoldsLockFormOK pins the (*Store).txHoldsLock return to exactly
-// `tok != nil && tok.held.Holds(&s.mu)`: a single single-value return whose &&
-// tree flattens to exactly two conjuncts — a nil-guard on tok and the Holds call
-// on tok.held with arg &<recv>.mu. Order-independent; receiver/token names are
-// taken from the source, not hard-coded.
+// bindsLeaseFromCtx reports whether fd assigns leaseVar from
+// `ctx.Value(memTxKey{}).(txlock.Lease)`. Pins the W2 lease source so the
+// delegation cannot read a fabricated or freshly-Acquired lease.
+func bindsLeaseFromCtx(fd *ast.FuncDecl, leaseVar string) bool {
+	found := false
+	EachInSubtree[ast.AssignStmt](fd, func(as *ast.AssignStmt) {
+		if found || len(as.Lhs) == 0 || len(as.Rhs) != 1 {
+			return
+		}
+		id, ok := as.Lhs[0].(*ast.Ident)
+		if !ok || id.Name != leaseVar {
+			return
+		}
+		ta, ok := as.Rhs[0].(*ast.TypeAssertExpr)
+		if !ok || ta.Type == nil || !isLeaseTypeExpr(ta.Type) {
+			return
+		}
+		if isCtxValueMemTxKeyCall(ta.X) {
+			found = true
+		}
+	})
+	return found
+}
+
+// inLiveTxFormOK pins (*Store).inLiveTx to exactly `return l.Live(&s.mu)` where l
+// is bound from `ctx.Value(memTxKey{}).(txlock.Lease)`: a single single-value
+// return delegating to the sealed liveness check on the ctx-sourced lease.
 //
 // Form, not semantics, is pinned (intentional, to block silent regression of a
-// security invariant): a refactor producing MORE than one single-value return —
-// e.g. an early-return guard `if tok == nil { return false }; return …` — trips
-// this check even though it is semantically equivalent. The one-liner is the
-// canonical form; weakening it (dropping the Holds conjunct, adding a third
-// conjunct) must be a deliberate edit that also updates this rule.
-func txHoldsLockFormOK(fd *ast.FuncDecl) (ok bool, why string) {
+// security invariant): an early-return refactor producing MORE than one
+// single-value return trips this even when semantically equivalent. The one-liner
+// is the canonical form; weakening it (dropping the Live delegation, comparing
+// l.mu directly to bypass the live flag, sourcing l elsewhere) must be a
+// deliberate edit that also updates this rule.
+func inLiveTxFormOK(fd *ast.FuncDecl) (ok bool, why string) {
 	recv := receiverVarName(fd)
 	if recv == "" {
 		return false, "no named receiver"
@@ -252,36 +279,29 @@ func txHoldsLockFormOK(fd *ast.FuncDecl) (ok bool, why string) {
 	if len(rets) != 1 {
 		return false, fmt.Sprintf("expected exactly 1 single-value return, got %d", len(rets))
 	}
-	conj := flattenLAND(rets[0].Results[0])
-	if len(conj) != 2 {
-		return false, fmt.Sprintf("expected exactly 2 && conjuncts, got %d", len(conj))
+	leaseVar, ok := leaseLiveCall(rets[0].Results[0], recv)
+	if !ok {
+		return false, fmt.Sprintf("return must be `<lease>.Live(&%s.mu)`", recv)
 	}
-	var tok string
-	var sawNil bool
-	for _, c := range conj {
-		if v, ok := nilGuardVar(c); ok {
-			tok, sawNil = v, true
-		}
+	if !bindsLeaseFromCtx(fd, leaseVar) {
+		return false, fmt.Sprintf("`%s` must be bound from ctx.Value(memTxKey{}).(txlock.Lease)", leaseVar)
 	}
-	if !sawNil {
-		return false, "missing `tok != nil` nil-guard conjunct"
-	}
-	for _, c := range conj {
-		if isHeldHoldsCall(c, tok, recv) {
-			return true, ""
-		}
-	}
-	return false, fmt.Sprintf("missing `%s.held.Holds(&%s.mu)` conjunct", tok, recv)
+	return true, ""
 }
 
-// scanMemTxLockWitness is the shared witness-funnel detector. It runs over a
-// single package Pass — production (cells/accesscore/internal/mem) and the
-// memtxlockfixture reverse self-check alike — and reports W1 / W2 / R1 (see the
-// file INVARIANT block). Requires a typed Pass; returns nil for a bare-AST Pass.
+// scanMemTxLockWitness is the shared lease-funnel detector. It runs over a single
+// package Pass — production (cells/accesscore/internal/mem) and the
+// memtxlockfixture reverse self-check alike — and reports W1 / W2 (see the file
+// INVARIANT block). Requires a typed Pass; returns nil for a bare-AST Pass.
 func scanMemTxLockWitness(p *Pass) []Diagnostic {
 	if p.TypesInfo == nil || p.Pkg == nil {
 		return nil
 	}
+	isAcquire := func(ce *ast.CallExpr) bool {
+		sel, ok := ce.Fun.(*ast.SelectorExpr)
+		return ok && isTxlockAcquireCall(p.TypesInfo, sel)
+	}
+
 	var ds []Diagnostic
 	for _, file := range p.Files {
 		rel := p.Rel(file)
@@ -293,75 +313,52 @@ func scanMemTxLockWitness(p *Pass) []Diagnostic {
 			})
 		}
 
-		// Record sanctioned construction-site spans.
-		type span struct {
-			kind   string
-			lo, hi token.Pos
-		}
-		var sites []span
+		// Locate the sole sanctioned mint site: (memTxRunner).runLocked, and record
+		// the Acquire(&r.s.mu) calls in its direct body (excluding nested closures
+		// and foreign-arg calls) as sanctioned.
+		sanctioned := map[*ast.CallExpr]bool{}
 		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-			if fd.Body == nil {
+			if fd.Body == nil || fd.Name.Name != memTxSiteRunLocked {
 				return
 			}
-			if kind, ok := memTxTokenSiteKind(fd); ok {
-				sites = append(sites, span{kind, fd.Pos(), fd.End()})
+			if fd.Recv == nil || receiverTypeName(fd) != "memTxRunner" {
+				return
+			}
+			recv := receiverVarName(fd)
+			for _, ce := range directBodyAcquireCalls(fd, isAcquire) {
+				if isAcquireArgRecvStoreMu(ce, recv) {
+					sanctioned[ce] = true
+				}
 			}
 		})
-		within := func(n ast.Node, kinds ...string) bool {
-			for _, s := range sites {
-				if n.Pos() < s.lo || n.End() > s.hi {
-					continue
-				}
-				for _, k := range kinds {
-					if s.kind == k {
-						return true
-					}
-				}
-			}
-			return false
-		}
 
-		// W1: txlock.Acquire only inside (memTxRunner).runLocked.
+		// W1: every txlock.Acquire call must be the sanctioned direct-body &r.s.mu
+		// call in runLocked. EachInSubtree descends into closures, so a hidden
+		// nested Acquire is still seen here and (not being sanctioned) reported.
 		EachInSubtree[ast.CallExpr](file, func(ce *ast.CallExpr) {
-			sel, ok := ce.Fun.(*ast.SelectorExpr)
-			if !ok || !isTxlockAcquireCall(p.TypesInfo, sel) {
-				return
-			}
-			if within(ce, memTxSiteRunLocked) {
+			if !isAcquire(ce) || sanctioned[ce] {
 				return
 			}
 			report(ce, fmt.Sprintf(
-				"txlock.Acquire in %s, outside the sole sanctioned runLocked "+
-					"witness-mint site (%s W1)",
+				"txlock.Acquire in %s — the only sanctioned mint is the single "+
+					"`txlock.Acquire(&r.s.mu)` in (memTxRunner).runLocked's direct body "+
+					"(not a foreign mutex, not nested in a closure) (%s W1)",
 				enclosingFuncName(file, ce.Pos()), ruleMemTxLockOwnership01))
 		})
 
-		// R1: memTxToken composite literal only inside a sanctioned site.
-		EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
-			if !isMemTxTokenLitTyped(p.TypesInfo, p.Pkg, cl) {
-				return
-			}
-			if within(cl, memTxSiteRunLocked, memTxSiteWithTxContext) {
-				return
-			}
-			report(cl, fmt.Sprintf(
-				"memTxToken composite literal in %s, outside runLocked / "+
-					"WithTxContext (%s R1)",
-				enclosingFuncName(file, cl.Pos()), ruleMemTxLockOwnership01))
-		})
-
-		// W2: (*Store).txHoldsLock return form.
+		// W2: (*Store).inLiveTx return form.
 		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-			if fd.Body == nil || fd.Name.Name != "txHoldsLock" {
+			if fd.Body == nil || fd.Name.Name != "inLiveTx" {
 				return
 			}
 			if fd.Recv == nil || receiverTypeName(fd) != "Store" {
 				return
 			}
-			if ok, why := txHoldsLockFormOK(fd); !ok {
+			if ok, why := inLiveTxFormOK(fd); !ok {
 				report(fd, fmt.Sprintf(
-					"weakened (*Store).txHoldsLock in %s: %s — must be "+
-						"`tok != nil && tok.held.Holds(&s.mu)` (%s W2)",
+					"weakened (*Store).inLiveTx in %s: %s — must be `return "+
+						"l.Live(&s.mu)` with l from ctx.Value(memTxKey{}).(txlock.Lease) "+
+						"(%s W2)",
 					enclosingFuncName(file, fd.Pos()), why, ruleMemTxLockOwnership01))
 			}
 		})
@@ -393,7 +390,7 @@ func memProductionScan(t *testing.T) []Diagnostic {
 	return diags
 }
 
-// TestMemTxLockOwnership01 enforces W1 + W2 + R1 over the production mem package.
+// TestMemTxLockOwnership01 enforces W1 + W2 over the production mem package.
 func TestMemTxLockOwnership01(t *testing.T) {
 	diags := memProductionScan(t)
 
@@ -402,59 +399,52 @@ func TestMemTxLockOwnership01(t *testing.T) {
 		lines = append(lines, fmt.Sprintf("  %s:%d  %s", d.Rel, d.Line, d.Message))
 	}
 	assert.Empty(t, lines,
-		"%s: %d violation(s) — the witness funnel (txlock.Acquire only in "+
-			"runLocked; txHoldsLock pins tok.held.Holds; memTxToken only in "+
-			"runLocked/WithTxContext) is broken; see ADR "+
+		"%s: %d violation(s) — the lease funnel (txlock.Acquire only as &r.s.mu in "+
+			"runLocked; inLiveTx pins l.Live(&s.mu)) is broken; see ADR "+
 			"202605171846-adr-mem-tx-lock-ownership.md:\n%s",
 		ruleMemTxLockOwnership01, len(lines), strings.Join(lines, "\n"))
 }
 
-// TestMemTxLockOwnership01_FindsSanctionedSites is the companion-index
-// precision test (anti-vacuous-pass): it asserts the scan actually sees the
-// witness funnel's anchors in production — the runLocked txlock.Acquire site,
-// a memTxToken literal inside BOTH runLocked and WithTxContext, and the
-// (*Store).txHoldsLock accessor. If a refactor renames the type / functions or
-// moves construction so the matchers stop firing, this fails loudly instead of
-// the primary rule passing empty.
+// TestMemTxLockOwnership01_FindsSanctionedSites is the precision test
+// (anti-vacuous-pass): it asserts the scan actually sees the funnel's anchors in
+// production — exactly one txlock.Acquire(&r.s.mu) in (memTxRunner).runLocked's
+// direct body, and exactly one (*Store).inLiveTx accessor. If a refactor renames
+// the type / functions or moves the mint so the matchers stop firing, this fails
+// loudly instead of the primary rule passing empty.
 func TestMemTxLockOwnership01_FindsSanctionedSites(t *testing.T) {
 	root := findModuleRoot(t)
 	modPath, err := moduleImportPath(root)
 	require.NoError(t, err, "read module path from go.mod")
 	memPkgPath := modPath + "/" + memPkgRel
 
-	var acquireInRunLocked, txHoldsLockAccessors int
-	litSites := map[string]bool{} // site kind -> saw memTxToken literal inside
+	var acquireInRunLocked, inLiveTxAccessors int
 
 	RunTyped(t, TypedOpts{Tests: false}, []string{"./" + memPkgRel + "/..."},
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != memPkgPath {
 				return nil
 			}
+			isAcquire := func(ce *ast.CallExpr) bool {
+				sel, ok := ce.Fun.(*ast.SelectorExpr)
+				return ok && isTxlockAcquireCall(p.TypesInfo, sel)
+			}
 			for _, file := range p.Files {
 				EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
 					if fd.Body == nil {
 						return
 					}
-					if fd.Name.Name == "txHoldsLock" && fd.Recv != nil &&
+					if fd.Name.Name == "inLiveTx" && fd.Recv != nil &&
 						receiverTypeName(fd) == "Store" {
-						txHoldsLockAccessors++
+						inLiveTxAccessors++
 					}
-					kind, isSite := memTxTokenSiteKind(fd)
-					if !isSite {
-						return
-					}
-					EachInSubtree[ast.CompositeLit](fd, func(cl *ast.CompositeLit) {
-						if isMemTxTokenLitTyped(p.TypesInfo, p.Pkg, cl) {
-							litSites[kind] = true
-						}
-					})
-					if kind == memTxSiteRunLocked {
-						EachInSubtree[ast.CallExpr](fd, func(ce *ast.CallExpr) {
-							if sel, ok := ce.Fun.(*ast.SelectorExpr); ok &&
-								isTxlockAcquireCall(p.TypesInfo, sel) {
+					if fd.Name.Name == memTxSiteRunLocked && fd.Recv != nil &&
+						receiverTypeName(fd) == "memTxRunner" {
+						recv := receiverVarName(fd)
+						for _, ce := range directBodyAcquireCalls(fd, isAcquire) {
+							if isAcquireArgRecvStoreMu(ce, recv) {
 								acquireInRunLocked++
 							}
-						})
+						}
 					}
 				})
 			}
@@ -462,37 +452,90 @@ func TestMemTxLockOwnership01_FindsSanctionedSites(t *testing.T) {
 		})
 
 	require.Equalf(t, 1, acquireInRunLocked,
-		"%s precision: expected exactly 1 txlock.Acquire call inside (memTxRunner).runLocked, "+
-			"got %d — 0 means the matcher is stale; >1 means a second Acquire (a "+
-			"re-entrant double-lock deadlock bug) that W1 would not catch (it only flags "+
-			"Acquire OUTSIDE runLocked)", ruleMemTxLockOwnership01, acquireInRunLocked)
-	require.Truef(t, litSites[memTxSiteRunLocked],
-		"%s precision: expected a memTxToken literal inside (memTxRunner).runLocked",
-		ruleMemTxLockOwnership01)
-	require.Truef(t, litSites[memTxSiteWithTxContext],
-		"%s precision: expected a memTxToken literal inside WithTxContext",
-		ruleMemTxLockOwnership01)
-	require.Equalf(t, 1, txHoldsLockAccessors,
-		"%s precision: expected exactly 1 (*Store).txHoldsLock accessor in %s, got %d",
-		ruleMemTxLockOwnership01, memPkgRel, txHoldsLockAccessors)
+		"%s precision: expected exactly 1 txlock.Acquire(&r.s.mu) in (memTxRunner).runLocked's "+
+			"direct body, got %d — 0 means the matcher is stale (rename/arg drift); >1 means a "+
+			"second mint (a re-entrant double-lock deadlock bug)", ruleMemTxLockOwnership01, acquireInRunLocked)
+	require.Equalf(t, 1, inLiveTxAccessors,
+		"%s precision: expected exactly 1 (*Store).inLiveTx accessor in %s, got %d",
+		ruleMemTxLockOwnership01, memPkgRel, inLiveTxAccessors)
+}
+
+// TestMemTxLockOwnership01_W1ArgAndNesting closes the W1-tightening blind spot
+// (#972): the pure-AST helpers isAcquireArgRecvStoreMu (argument pin) and
+// directBodyAcquireCalls (nested-closure exclusion) are exercised on parsed
+// source, since the real-source fixture can host only one runLocked and cannot
+// model a foreign-arg / nested mint INSIDE the sanctioned site.
+func TestMemTxLockOwnership01_W1ArgAndNesting(t *testing.T) {
+	const src = `package p
+type Store struct{ mu int }
+type memTxRunner struct{ s *Store }
+func (r memTxRunner) runLocked() {
+	direct(&r.s.mu)
+	go func() { nested(&r.s.mu) }()
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "src.go", src, 0)
+	require.NoError(t, err)
+
+	var runLocked *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "runLocked" {
+			runLocked = fd
+		}
+	}
+	require.NotNil(t, runLocked)
+
+	// Syntactic acquire predicate (no type info): exercises the traversal only.
+	synAcq := func(ce *ast.CallExpr) bool {
+		id, ok := ce.Fun.(*ast.Ident)
+		return ok && (id.Name == "direct" || id.Name == "nested")
+	}
+	got := directBodyAcquireCalls(runLocked, synAcq)
+	require.Lenf(t, got, 1,
+		"directBodyAcquireCalls must exclude the nested-closure Acquire (got %d)", len(got))
+	assert.True(t, isAcquireArgRecvStoreMu(got[0], "r"),
+		"the direct-body direct(&r.s.mu) must satisfy the &recv.s.mu arg pin")
+
+	// Argument pin: positive and negative shapes.
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{"f(&r.s.mu)", true},
+		{"f(&r.s.other)", false},       // wrong field
+		{"f(&other)", false},           // not recv.s.mu
+		{"f(&x.mu)", false},            // wrong base (x.mu, not r.s.mu)
+		{"f(&r.s.mu, &r.s.mu)", false}, // wrong arity
+		{"f(r.s.mu)", false},           // missing address-of
+	}
+	for _, tc := range cases {
+		e, err := parser.ParseExpr(tc.expr)
+		require.NoErrorf(t, err, "parse %s", tc.expr)
+		ce, ok := e.(*ast.CallExpr)
+		require.Truef(t, ok, "%s is not a call", tc.expr)
+		assert.Equalf(t, tc.want, isAcquireArgRecvStoreMu(ce, "r"),
+			"isAcquireArgRecvStoreMu(%s, \"r\")", tc.expr)
+	}
 }
 
 // TestMemTxLockOwnership01_NoReflectInMemPkg closes the reflect blind spot: an
-// AST/typed scan cannot see reflect-based mutation of txlock.Held.mu (which
-// would forge a witness). Neither package mem nor package txlock imports
-// "reflect"; assert it absent.
+// AST/typed scan cannot see reflect-based mutation of txlock.Lease.{mu,live}
+// (which would forge a live lease). Neither package mem nor package txlock
+// imports "reflect"; assert it absent.
 func TestMemTxLockOwnership01_NoReflectInMemPkg(t *testing.T) {
 	assertMemTreeDoesNotImport(t, "reflect")
 }
 
 // TestMemTxLockOwnership01_NoUnsafeInMemPkg closes the unsafe blind spot
-// (unsafe-pointer write to txlock.Held.mu). Neither package must import "unsafe".
+// (unsafe-pointer write to txlock.Lease fields). Neither package must import
+// "unsafe".
 func TestMemTxLockOwnership01_NoUnsafeInMemPkg(t *testing.T) {
 	assertMemTreeDoesNotImport(t, "unsafe")
 }
 
 // assertMemTreeDoesNotImport asserts that neither the mem package nor its
-// internal/txlock seal package imports pkg (a witness-forge channel).
+// internal/txlock seal package imports pkg (a lease-forge channel).
 func assertMemTreeDoesNotImport(t *testing.T, pkg string) {
 	t.Helper()
 	root := findModuleRoot(t)
@@ -502,7 +545,6 @@ func assertMemTreeDoesNotImport(t *testing.T, pkg string) {
 	// Bare Run (not RunTyped): a direct import-path string match suffices for
 	// stdlib "reflect"/"unsafe" — they have no alias form in ImportSpec.Path.Value
 	// and the threat is a direct import within mem/txlock, not a transitive one.
-	// RunTyped would load the full type graph for no benefit.
 	Run(t, scope, func(p *Pass) []Diagnostic {
 		for _, file := range p.Files {
 			for _, imp := range file.Imports {
@@ -515,6 +557,6 @@ func assertMemTreeDoesNotImport(t *testing.T, pkg string) {
 	})
 	assert.Emptyf(t, offenders,
 		"%s blind-spot guard: mem tree must not import %q (would defeat the "+
-			"sealed-witness funnel by forging txlock.Held.mu); offenders: %v",
+			"sealed-lease funnel by forging txlock.Lease fields); offenders: %v",
 		ruleMemTxLockOwnership01, pkg, offenders)
 }

--- a/tools/archtest/mem_tx_lock_ownership_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_test.go
@@ -341,3 +341,21 @@ func assertMemPkgDoesNotImport(t *testing.T, pkg string) {
 			"AST construction-site funnel); offenders: %v",
 		ruleMemTxLockOwnership01, memPkgRel, pkg, offenders)
 }
+
+// scanMemTxLockWitness is the shared witness-funnel detector (Wave 2 sealed
+// lock-witness model). It runs over a single package Pass — production
+// (cells/accesscore/internal/mem) and the memtxlockfixture reverse self-check
+// alike — and reports:
+//
+//	W1: txlock.Acquire called outside (memTxRunner).runLocked.
+//	W2: (*Store).txHoldsLock return not of the exact form
+//	    `tok != nil && tok.held.Holds(&s.mu)`.
+//	R1: memTxToken composite literal outside runLocked / WithTxContext.
+//
+// STUB (Wave 1 RED): returns nil so the reverse self-check
+// (TestMemTxLockOwnership01_FixturePattern) fails until Wave 2 implements the
+// scan. Wave 2 replaces this body and rewires TestMemTxLockOwnership01.
+func scanMemTxLockWitness(p *Pass) []Diagnostic {
+	_ = p
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes #945 (PR #558 review High) and #972 (capability-escape residual).

Reworks accesscore mem store lock-ownership from a ctx-carried **witness**
(`txlock.Held`, pointer-proof that never expires) into a **self-invalidating
lease** (`txlock.Lease` with a `live *atomic.Bool` flipped dead by the unlock
closure). This closes the L3 root cause a multi-party review flagged on the
witness design: the witness proved the mutex was locked at *some* point, never
that it is locked *now*, so an inner ctx escaping its `RunInTx` closure
(captured by a goroutine / after-commit hook) still authorized a lock-skip after
release → the exact concurrent-map-write flake the work set out to eliminate.

Per the design discussion (frozen `persistence.TxRunner` kernel interface rules
out a closure-param scope without a 5+-cell blast radius), the realizable form
keeps the ctx-carried signal but makes it **escape-safe**: after `RunInTx`
returns, the lease is dead → `inLiveTx` reports false → repo falls back to
per-call locking (fail-closed). Aligns with `database/sql` `*Tx.done`→`ErrTxDone`
and kratos's ctx-carried resource (not a bool/proof).

## Design — self-invalidating lease (done-in-seal)

- `cells/accesscore/internal/mem/internal/txlock` (double-`internal/`, importable
  only by the mem tree): `Lease{mu *sync.Mutex; live *atomic.Bool}` — both fields
  unexported. `Acquire(mu) (Lease, unlock)` locks mu, arms `live`, and returns an
  unlock closure that flips `live=false` before Unlocking. `Live(mu)` =
  pointer-identity AND `live.Load()`. No `Release` method; `live` is writable only
  by Acquire's unlock closure.
- store: ctx carries the `txlock.Lease` value directly (the `memTxToken` wrapper
  is deleted — single-field redundancy); `txHoldsLock`→`inLiveTx` delegates to
  `Lease.Live`. ~20 repo guards are a pure rename (`if !r.store.inLiveTx(ctx)`).
- **Deleted dead abstraction** `WithTxContext`: it injected a zero lease →
  behaviorally equivalent to no injection since the witness era; ~8 test fakes
  become pass-through `fn(ctx)`.

## AI-robust rating (funnel double-lock)

| axis | rating | carrier |
|------|--------|---------|
| upstream (forge) | **Hard** | `Lease` fields unexported; only `Acquire` mints a live lease (and it locks) |
| downstream (liveness) | **Hard** | `live` flip sealed in Acquire's unlock closure; no Release; fields unexported → escape fails closed |
| archtest W1/W2 | Medium | regression layer over the Hard seal |

Lands in ai-robust §Hard 范本 「sealed construction + single sanctioned holder」 —
ai-robust.md unchanged; ADR registers the instance + adds the `database/sql`
done-invalidation analog.

## archtest (MEM-TX-LOCK-OWNERSHIP-01)

- **W1 tightened** (review C2): sole sanctioned mint pinned to
  `txlock.Acquire(&r.s.mu)` in `runLocked`'s **direct body** — rejects foreign-mutex
  args (`isAcquireArgRecvStoreMu`) and Acquire hidden in nested closures
  (`directBodyAcquireCalls` excludes func-lits). New `W1ArgAndNesting` AST unit test.
- **W2 reshaped**: `inLiveTx` pinned to `return l.Live(&s.mu)` with `l` from
  `ctx.Value(memTxKey{}).(txlock.Lease)`.
- **R1 deleted**: `memTxToken` gone; live Lease originates only in Acquire (W1) +
  zero Lease harmless → seal+W1 subsume the literal-scope rule.
- RED fixture mirrors the lease model; `FixturePattern` expects 3 RED sites
  (leakAcquire + leakAcquireFuncLit W1, inLiveTx W2). `TestLeaseSealFrozen` → 2 fields.

## Threat matrix (ADR, #972 column)

Row 6 (after-commit hook captures inner ctx → stale-skip): **⚠️ → ✅** — `unlock()`
flips `live=false` before `RunInTx` drains hooks, so an escaped inner ctx fails
closed. No ✅→⚠️ regressions. The #945 block's unqualified "compile-impossible
even in-package / downstream type-system-Hard" over-claim is corrected to
forge-axis-only (no two truth sources). **Boundary (documented, not closed):**
concurrent-during-tx use of one live ctx across goroutines is the `*sql.Tx`
"not concurrency-safe" boundary — out of scope, like `ErrTxDone`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cells/accesscore/...` — copylocks clean (Lease all-pointer fields)
- [x] `go test ./cells/accesscore/internal/mem/... -race -count=3` — incl. lease unit + escape regression
- [x] `go test ./cells/accesscore/slices/identitymanage/... -race -run ChangePassword_Concurrent`
- [x] `go test ./tools/archtest/ -run TestMemTxLockOwnership01 -v` — production + companions + W1ArgAndNesting + RED fixture (3 sites) all green
- [x] `golangci-lint run ./cells/accesscore/internal/mem/... ./tools/archtest/...` — 0 issues

Repro: `go test ./tools/archtest/ -run 'TestMemTxLockOwnership01' -v`

> Note: branch base is behind develop; rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
