### PR TITLE
feat(ssobff): route bootstrap auth-fail through audit funnel

### DIFF
--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/audit"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/auth/session"
@@ -61,19 +62,6 @@ const (
 // ssobffDatabaseURLEnv is the environment variable holding the PostgreSQL DSN.
 // Required: NewSSOBFFApp fails fast when absent.
 const ssobffDatabaseURLEnv = "DATABASE_URL"
-
-// ssobffBootstrapAuthFailLogger returns the onAuthFail observer wired into the
-// demo bootstrap middleware.
-//
-// This is the legacy slog-only shape; migrate to runtime/audit.NewBootstrapAuthFailObserver
-// when the audit chain wiring is complete.
-func ssobffBootstrapAuthFailLogger(logger *slog.Logger) auth.BootstrapAuthFailObserver {
-	return func(ctx context.Context, reason string) {
-		logger.ErrorContext(ctx, "bootstrap_auth_failed",
-			slog.String("event", "bootstrap_auth_failed"),
-			slog.String("reason", reason))
-	}
-}
 
 // SSOBFFApp is the shared ssobff composition root used by main and tests.
 //
@@ -237,6 +225,22 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 	// first admin). Bootstrap credentials are still mandatory — they protect
 	// the setup endpoint via Basic Auth (ADR §D2 operator credential via env). The demo uses the package-local ssobffBootstrap* constants;
 	// production deployments inject from K8s Secret / Vault.
+	// Build pgOutboxWriter + auditcore (and capture pgLedgerStore) BEFORE the
+	// bootstrap middleware: runtime/audit.NewBootstrapAuthFailObserver needs
+	// the same ledger.Store auditcore drains into HTTP queries, so bootstrap
+	// 401/429s land in the auditcore hash chain (not slog-only).
+	pgOutboxWriter := adapterpg.NewOutboxWriter(clock.Real())
+	auc, ledgerStore, err := buildSSOBFFAuditCore(cfg.logger, eb, pgOutboxWriter, pool, txMgr)
+	if err != nil {
+		_ = pool.Close(ctx)
+		return nil, err
+	}
+	authFailObserver, err := audit.NewBootstrapAuthFailObserver(cfg.logger, ledgerStore, clock.Real())
+	if err != nil {
+		_ = pool.Close(ctx)
+		return nil, fmt.Errorf("ssobff: audit.NewBootstrapAuthFailObserver: %w", err)
+	}
+
 	ssobffBootstrapCreds := auth.BootstrapCredentials{
 		Username: []byte(ssobffBootstrapUsername),
 		Password: []byte(ssobffBootstrapPassword),
@@ -248,7 +252,7 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 	bootstrapMW := auth.NewBootstrapMiddleware(
 		ssobffBootstrapCreds,
 		rlLimiter,
-		ssobffBootstrapAuthFailLogger(cfg.logger),
+		authFailObserver,
 	)
 	ssobffSessionProto, err := session.NewProtocol(
 		session.WithFingerprint(session.FingerprintJTIRef{}),
@@ -258,8 +262,6 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ssobff: session.NewProtocol: %w", err)
 	}
-
-	pgOutboxWriter := adapterpg.NewOutboxWriter(clock.Real())
 
 	// P1.5 fix (PR-CFG-L2-DIVERGENCE review): durable mode requires an outbox
 	// relay; without it events stay in outbox_entries pending and subscribers
@@ -276,6 +278,7 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 		pool: pool, txMgr: txMgr, eb: eb, pgOutboxWriter: pgOutboxWriter,
 		jwtIssuer: jwtIssuer, jwtVerifier: jwtVerifier,
 		bootstrapMW: bootstrapMW, sessionProto: ssobffSessionProto, logger: cfg.logger,
+		auc: auc,
 	})
 	if err != nil {
 		_ = pool.Close(ctx)
@@ -309,20 +312,25 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 // ledger.Protocol is owned by the composition root; cells never hold the raw
 // HMAC key. Mirrors cmd/corebundle/audit_module.go durable path but uses
 // in-source demo HMAC key (production deployments must inject from a secret manager).
+//
+// Returns the AuditCore cell alongside the pgLedgerStore it was wired with, so
+// the composition root can hand the same store to
+// runtime/audit.NewBootstrapAuthFailObserver — bootstrap auth failures land in
+// the same hash chain that auditcore drains into HTTP queries.
 func buildSSOBFFAuditCore(
 	logger *slog.Logger,
 	eb outbox.Publisher,
 	outboxWriter *adapterpg.OutboxWriter,
 	pool *adapterpg.Pool,
 	txMgr *adapterpg.TxManager,
-) (*auditcore.AuditCore, error) {
+) (*auditcore.AuditCore, ledger.Store, error) {
 	cursorCodec, err := query.NewCursorCodec([]byte("ssobff-audit-cursor-key-32bytes!"))
 	if err != nil {
-		return nil, fmt.Errorf("ssobff: create audit cursor codec: %w", err)
+		return nil, nil, fmt.Errorf("ssobff: create audit cursor codec: %w", err)
 	}
 	ns, err := ledger.ParseNamespaceID("auditcore")
 	if err != nil {
-		return nil, fmt.Errorf("ssobff: parse audit namespace: %w", err)
+		return nil, nil, fmt.Errorf("ssobff: parse audit namespace: %w", err)
 	}
 	// WARNING: demo key only. Production deployments must inject from a secret manager.
 	protocol, err := ledger.NewProtocol(
@@ -332,13 +340,13 @@ func buildSSOBFFAuditCore(
 		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("ssobff: build audit protocol: %w", err)
+		return nil, nil, fmt.Errorf("ssobff: build audit protocol: %w", err)
 	}
 	pgLedgerStore, err := adapterpg.NewLedgerStore(pool.DB(), txMgr, protocol, clock.Real())
 	if err != nil {
-		return nil, fmt.Errorf("ssobff: adapterpg.NewLedgerStore: %w", err)
+		return nil, nil, fmt.Errorf("ssobff: adapterpg.NewLedgerStore: %w", err)
 	}
-	return auditcore.NewAuditCore(
+	auc := auditcore.NewAuditCore(
 		auditcore.WithClock(clock.Real()),
 		auditcore.WithLedgerProtocol(protocol),
 		auditcore.WithLedgerStore(pgLedgerStore),
@@ -347,7 +355,8 @@ func buildSSOBFFAuditCore(
 		auditcore.WithCursorCodec(cursorCodec),
 		auditcore.WithLogger(logger),
 		auditcore.WithMetricsProvider(metrics.NopProvider{}),
-	), nil
+	)
+	return auc, pgLedgerStore, nil
 }
 
 // registerSSOBFFCells registers all three platform cells into the assembly.
@@ -373,6 +382,7 @@ type ssobffBuildParams struct {
 	bootstrapMW    func(http.Handler) http.Handler
 	sessionProto   *session.Protocol
 	logger         *slog.Logger
+	auc            *auditcore.AuditCore
 }
 
 // buildSSOBFFAssembly wires all three platform cells, registers them in a new
@@ -399,12 +409,10 @@ func buildSSOBFFAssembly(p ssobffBuildParams) (*assembly.CoreAssembly, *outbox.C
 		accesscore.WithMetricsProvider(metrics.NopProvider{}),
 	)...)
 
-	// Demo only: HMAC and cursor keys are public source constants. Production
-	// deployments must inject fresh secrets from a secret manager.
-	auc, err := buildSSOBFFAuditCore(p.logger, p.eb, p.pgOutboxWriter, p.pool, p.txMgr)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	// auditcore is built by NewSSOBFFApp so its ledger.Store can also feed
+	// runtime/audit.NewBootstrapAuthFailObserver before the bootstrap
+	// middleware constructs.
+	auc := p.auc
 
 	configStorageOpts, err := buildSSOBFFConfigCoreStorageOpts(p.pool)
 	if err != nil {

--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -559,6 +559,63 @@ func TestWalkthrough(t *testing.T) {
 		}
 	})
 
+	t.Run("bootstrap auth-fail writes audit chain entry", func(t *testing.T) {
+		// End-to-end regression for PR #1005 ssobff bootstrap-audit-observer
+		// wiring. Trigger a 401 against the bootstrap-protected endpoint by
+		// reusing the valid username with a wrong password. The funnel-built
+		// observer (runtime/audit.NewBootstrapAuthFailObserver) must append
+		// a bootstrap.auth.fail entry via audit.AppendBootstrapAuthFail with
+		// reason=wrong_credentials, queryable via /api/v1/audit/entries.
+		//
+		// Why this complements the archtest: archtest guarantees the wire is
+		// in place; this test proves the wire actually carries the signal end-
+		// to-end (request → observer → ledger → auditquery).
+		// ref: Kubernetes audit (https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
+		// — each request emits an audit event persisted by the backend; this is
+		// the runtime equivalent for bootstrap auth failures.
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			base+"/api/v1/access/setup/admin",
+			strings.NewReader(`{"username":"unused","email":"unused@local","password":"unused"}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.SetBasicAuth(ssobffBootstrapUsername, "wrong-password-walkthrough")
+		failResp := doWalkthroughRequest(t, req)
+		require.Equal(t, http.StatusUnauthorized, failResp.StatusCode,
+			"bootstrap middleware must reject wrong password with 401")
+		_ = failResp.Body.Close()
+
+		// Append goes directly to ledger.Store (no outbox roundtrip), but the
+		// ledger write + auditquery read both run through PG transactions, so
+		// a short visibility window may exist under contention. testwait.External
+		// mirrors the sibling outbox-route audit subtest's posture.
+		var entries []json.RawMessage
+		testwait.External(t, "ssobff-bootstrap-audit-fail-entry-available", func() bool {
+			data, ok := fetchAuditEntries(base+"/api/v1/audit/entries?eventType=bootstrap.auth.fail", adminToken)
+			if ok {
+				entries = data
+			}
+			return ok
+		}, testtime.D5s, testtime.MediumPoll, "expected bootstrap.auth.fail audit entry")
+
+		var entry struct {
+			EventType string          `json:"eventType"`
+			ActorID   string          `json:"actorId"`
+			Payload   json.RawMessage `json:"payload"`
+		}
+		require.NoError(t, json.Unmarshal(entries[0], &entry))
+		assert.Equal(t, "bootstrap.auth.fail", entry.EventType,
+			"funnel observer must persist runtime/audit.bootstrapAuthFailEventType")
+		assert.Equal(t, "system:bootstrap", entry.ActorID,
+			"funnel observer must record platform-level actor (no user principal at bootstrap auth)")
+
+		var payload struct {
+			Reason string `json:"reason"`
+		}
+		require.NoError(t, json.Unmarshal(entry.Payload, &payload))
+		assert.Equal(t, "wrong_credentials", payload.Reason,
+			"payload.reason must match runtime/audit.ReasonWrongCredentials for Basic-Auth password mismatch")
+	})
+
 	// Steps 8-11: configcore CRUD + feature flags.
 	// PR-CFG-C: ALL config + flags HTTP routes (read and write) require RoleAdmin —
 	// even GET endpoints, because key names + the sensitive flag are themselves a

--- a/tools/archtest/bootstrap_audit_observer_funnel_test.go
+++ b/tools/archtest/bootstrap_audit_observer_funnel_test.go
@@ -69,9 +69,9 @@
 // returns a custom impl): this is reachable only via Go-type-system upstream
 // Hard (sealing auth.BootstrapAuthFailObserver into a marker that only
 // runtime/audit can construct, which forces runtime/auth → runtime/audit,
-// breaking the documented non-dependency). Promotion to Hard is tracked as
-// This archtest defines the Medium ceiling reachable
-// without that refactor.
+// breaking the documented non-dependency). Until that refactor lands, this
+// archtest defines the Medium ceiling reachable without sealing the
+// observer interface.
 //
 // Scope:
 //   - cmd/corebundle/ (production, non-test): the platform composition root.
@@ -413,6 +413,12 @@ func TestBootstrapAuditObserverFunnelUpstreamMedium01(t *testing.T) {
 		corebundlePkgPath: true,
 		ssobffPkgPath:     true,
 	}
+	// Reverse self-check (ai-robust.md §"工具选定后强制盲区自检"): record
+	// which scope packages were actually visited so we fail loudly if a
+	// future RunTypedProduction loader config silently skips one (e.g. drops
+	// package main binaries under examples/). Without this guard a vacuous
+	// pass would let the demo regress to slog-only undetected.
+	visited := map[string]bool{}
 
 	var upstreamViolations []upstreamViolation
 
@@ -420,6 +426,7 @@ func TestBootstrapAuditObserverFunnelUpstreamMedium01(t *testing.T) {
 		if p.Pkg == nil || !scanPaths[p.Pkg.Path()] {
 			return nil
 		}
+		visited[p.Pkg.Path()] = true
 		for _, file := range p.Files {
 			rel := p.Rel(file)
 			if strings.HasSuffix(rel, "_test.go") {
@@ -462,6 +469,16 @@ func TestBootstrapAuditObserverFunnelUpstreamMedium01(t *testing.T) {
 		}
 		return nil
 	})
+
+	// Fail loudly if any scope package was not visited by the loader. A
+	// vacuous pass (no violations because nothing was scanned) would let
+	// the demo or platform composition root regress to slog-only undetected.
+	for path := range scanPaths {
+		require.Truef(t, visited[path],
+			"%s: RunTypedProduction did not visit %q — scope coverage gap, "+
+				"upstream Medium guard would pass vacuously without it",
+			ruleBootstrapAuditObserverFunnelUpstreamMedium01, path)
+	}
 
 	for _, v := range upstreamViolations {
 		t.Logf("%s: %s — %s", ruleBootstrapAuditObserverFunnelUpstreamMedium01, v.location, v.reason)

--- a/tools/archtest/bootstrap_audit_observer_funnel_test.go
+++ b/tools/archtest/bootstrap_audit_observer_funnel_test.go
@@ -73,12 +73,14 @@
 // This archtest defines the Medium ceiling reachable
 // without that refactor.
 //
-// Scope carve-out (must match the F2 plan decision):
-//   - examples/ssobff/app.go intentionally still wires the legacy
-//     slog-only observer; it will be moved through this funnel and widen the scope below.
-//   - cmd/corebundle/*_test.go invocations are mocks for rate-limit /
-//     bootstrap-credential paths and do not represent production wiring;
-//     RunTypedProduction(opts.Tests=false) keeps them out of the Pass set.
+// Scope:
+//   - cmd/corebundle/ (production, non-test): the platform composition root.
+//   - examples/ssobff/ (production, non-test): the in-repo demo composition
+//     root. Migrated through the funnel by ssobff bootstrap-audit-chain wiring;
+//     keeping it in scope guarantees the demo cannot regress to slog-only.
+//   - *_test.go invocations are mocks for rate-limit / bootstrap-credential
+//     paths and do not represent production wiring; RunTypedProduction(
+//     opts.Tests=false) keeps them out of the Pass set in both packages above.
 
 package archtest
 
@@ -101,6 +103,7 @@ const (
 	auditPkgSuffix          = "/runtime/audit"
 	authPkgSuffix           = "/runtime/auth"
 	corebundlePkgSuffix     = "/cmd/corebundle"
+	ssobffPkgSuffix         = "/examples/ssobff"
 	observerFnName          = "NewBootstrapAuthFailObserver"
 	appendFnName            = "AppendBootstrapAuthFail"
 	bootstrapMiddlewareName = "NewBootstrapMiddleware"
@@ -385,10 +388,12 @@ func exprStringForLog(c *ast.CallExpr) string {
 
 // TestBootstrapAuditObserverFunnelUpstreamMedium01 enforces the upstream
 // half: every production call to auth.NewBootstrapMiddleware in cmd/corebundle
-// must hand the funnel-built observer as its third positional argument. The
-// observer may be either the direct CallExpr to
+// or examples/ssobff must hand the funnel-built observer as its third
+// positional argument. The observer may be either the direct CallExpr to
 // audit.NewBootstrapAuthFailObserver or an identifier short-declared from it
-// in the same source file.
+// in the same source file. Both packages share the same upstream Medium
+// posture; the demo composition root is held to the production wiring rule
+// to keep an in-repo regression out of the funnel impossible.
 //
 // Why a small Medium gap exists: a function-level "X = func(ctx, reason){...}"
 // assignment with the same identifier as a legitimate funnel-built observer
@@ -403,11 +408,16 @@ func TestBootstrapAuditObserverFunnelUpstreamMedium01(t *testing.T) {
 	auditPkgPath := modPath + auditPkgSuffix
 	authPkgPath := modPath + authPkgSuffix
 	corebundlePkgPath := modPath + corebundlePkgSuffix
+	ssobffPkgPath := modPath + ssobffPkgSuffix
+	scanPaths := map[string]bool{
+		corebundlePkgPath: true,
+		ssobffPkgPath:     true,
+	}
 
 	var upstreamViolations []upstreamViolation
 
 	_ = RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
-		if p.Pkg == nil || p.Pkg.Path() != corebundlePkgPath {
+		if p.Pkg == nil || !scanPaths[p.Pkg.Path()] {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -457,8 +467,9 @@ func TestBootstrapAuditObserverFunnelUpstreamMedium01(t *testing.T) {
 		t.Logf("%s: %s — %s", ruleBootstrapAuditObserverFunnelUpstreamMedium01, v.location, v.reason)
 	}
 	assert.Empty(t, upstreamViolations,
-		"%s: cmd/corebundle production callers of auth.%s must route through audit.%s; "+
-			"recovering to slog-only observers (the pre-PR shape) is what this rule prevents",
+		"%s: cmd/corebundle and examples/ssobff production callers of auth.%s "+
+			"must route through audit.%s; recovering to slog-only observers "+
+			"(the pre-PR shape) is what this rule prevents",
 		ruleBootstrapAuditObserverFunnelUpstreamMedium01, bootstrapMiddlewareName, observerFnName)
 }
 


### PR DESCRIPTION
## Summary

- Migrates `examples/ssobff/app.go` from the slog-only `ssobffBootstrapAuthFailLogger` to `runtime/audit.NewBootstrapAuthFailObserver`, so bootstrap auth failures land in the same hash-chain auditcore drains into HTTP queries.
- Widens `BOOTSTRAP-AUDIT-OBSERVER-FUNNEL-UPSTREAM-MEDIUM-01` archtest scan scope from `cmd/corebundle/` alone to `{cmd/corebundle/, examples/ssobff/}`, retiring the F2 carve-out that intentionally kept ssobff out of the funnel.

Closes #700

## Refs

- archtest invariants: `BOOTSTRAP-AUDIT-OBSERVER-FUNNEL-DOWNSTREAM-HARD-01` (unchanged) + `BOOTSTRAP-AUDIT-OBSERVER-FUNNEL-UPSTREAM-MEDIUM-01` (scope widened)
- ADR/source: plan 039 W1-2 §F2 carve-out (ssobff was deliberately deferred until in-scope migration)
- ref: `cmd/corebundle audit_module.go` + `access_module.go` (canonical funnel pattern)

## Implementation

`buildSSOBFFAuditCore` now returns `(*auditcore.AuditCore, ledger.Store, error)`. `NewSSOBFFApp` reorders so that pgOutboxWriter + auditcore (capturing `ledgerStore`) are built **before** `auth.NewBootstrapMiddleware`, which now takes the funnel-built observer instead of the deleted slog-only helper. `buildSSOBFFAssembly` consumes the pre-built `*auditcore.AuditCore` via `ssobffBuildParams.auc`, keeping the assembly step ordering-free.

## Out-of-scope housekeeping (separate from this PR)

- `#715` (shutdown outcome label / metric name three-source drift) — verified already aligned on develop; closing as already-fixed (no PR).
- `#637` (AUTH-FAIL-CLOSED-DOC-CLEANUP-01) — nonce.go inline docs already document fail-closed; \`docs/archive/specs/201-wm2-key-rotation/\` is by-name historical; closing as won't-fix (no PR).

## Test plan

- [x] \`go -C worktrees/208 build ./...\` — clean
- [x] \`go -C worktrees/208 build -tags=integration ./...\` — clean
- [x] \`go -C worktrees/208 test ./examples/ssobff/...\` — pass
- [x] \`go -C worktrees/208 test ./tools/archtest/ -run TestBootstrapAuditObserverFunnel\` — pass (RED→GREEN over two commits)
- [x] \`golangci-lint run ./...\` — 0 new issues (pre-existing gocognit:17 in \`tools/codegen/cellgen/literal_printer.go:340\` is untouched by this PR)
- [ ] Note: 4 archtest failures on full suite (\`TestAssemblyMetaDTOCoverage\`, \`TestInventoryAnchorValidID\`, \`TestInventoryAnchorRequired\`, \`TestExternalReasonLiteral\`) are **pre-existing on develop** — confirmed by running the same tests on the develop base. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)