### PR TITLE
fix(devops): healthcheck-verify cleanup + correct wait-timeout flag (#19)

### DIFF
--- a/hack/verify-archtest-invariants.sh
+++ b/hack/verify-archtest-invariants.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# verify-archtest-invariants — single entry for the 4 PR-time archtest invariants
-# preserved by ADR 202605120000 §Amendment 2026-05-23 §D8 (4 类 PR-time archtest gate).
+# verify-archtest-invariants — PR-time archtest entry preserved by ADR
+# 202605120000 §Amendment 2026-05-23 §D8. Original scope: 4 typed-AST
+# invariants (clock-injection / duration-const / test-time-literal /
+# panic-registered). Issue #19 added a 5th, lightweight, string-anchor
+# invariant for `scripts/healthcheck-verify.sh` — it does no typed-AST
+# load (it reads the script bytes and tokenizes), runs in <1s, and
+# would otherwise wait for nightly to catch a regression.
 #
 # Why merged: each separate go test invocation cold-loads tools/archtest's
-# typed AST (~5s/process via typeseval.SharedResolver). Running 4 separate
-# processes wastes ~15s on redundant packages.Load. Single process shares
-# the SharedResolver cache key (root, false, nil, "./...") via testmain
-# warmup (tools/archtest/testmain_test.go).
+# typed AST (~5s/process via typeseval.SharedResolver). Running separate
+# processes wastes ~5s/each on redundant packages.Load. Single process
+# shares the SharedResolver cache key (root, false, nil, "./...") via
+# testmain warmup (tools/archtest/testmain_test.go).
 #
 # Why no -race: archtest is read-only static analysis. SharedResolver
 # concurrent-init race coverage is owned by test-race.yml::race-unit
@@ -16,5 +21,5 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go test ./tools/archtest \
-  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures)$' \
+  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestHealthcheckVerifyScriptInvariant01|TestHealthcheckVerifyScriptInvariantMeta01)$' \
   -count=1 -timeout 5m

--- a/hack/verify-archtest-invariants.sh
+++ b/hack/verify-archtest-invariants.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
-# verify-archtest-invariants — PR-time archtest entry preserved by ADR
-# 202605120000 §Amendment 2026-05-23 §D8. Original scope: 4 typed-AST
-# invariants (clock-injection / duration-const / test-time-literal /
-# panic-registered). Issue #19 added a 5th, lightweight, string-anchor
-# invariant for `scripts/healthcheck-verify.sh` — it does no typed-AST
-# load (it reads the script bytes and tokenizes), runs in <1s, and
-# would otherwise wait for nightly to catch a regression.
+# verify-archtest-invariants — single entry for the 4 PR-time archtest invariants
+# preserved by ADR 202605120000 §Amendment 2026-05-23 §D8 (4 类 PR-time archtest gate).
 #
 # Why merged: each separate go test invocation cold-loads tools/archtest's
-# typed AST (~5s/process via typeseval.SharedResolver). Running separate
-# processes wastes ~5s/each on redundant packages.Load. Single process
-# shares the SharedResolver cache key (root, false, nil, "./...") via
-# testmain warmup (tools/archtest/testmain_test.go).
+# typed AST (~5s/process via typeseval.SharedResolver). Running 4 separate
+# processes wastes ~15s on redundant packages.Load. Single process shares
+# the SharedResolver cache key (root, false, nil, "./...") via testmain
+# warmup (tools/archtest/testmain_test.go).
 #
 # Why no -race: archtest is read-only static analysis. SharedResolver
 # concurrent-init race coverage is owned by test-race.yml::race-unit
@@ -21,5 +16,5 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go test ./tools/archtest \
-  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestHealthcheckVerifyScriptInvariant01|TestHealthcheckVerifyScriptInvariantMeta01)$' \
+  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures)$' \
   -count=1 -timeout 5m

--- a/scripts/healthcheck-verify.sh
+++ b/scripts/healthcheck-verify.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
 # healthcheck-verify.sh
-# Boots all Docker Compose services, waits up to 30 s for every service to
-# pass its built-in health check, prints status, then tears down.
+# Boots all Docker Compose services, waits up to TIMEOUT seconds for every
+# service to pass its built-in health check, prints status, then tears down.
+#
+# INVARIANT (HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01, issue #19):
+#   - `trap ... EXIT` must be installed before the first `docker compose`
+#     call so cleanup runs on success, `set -e` early-exit, and SIGINT.
+#   - `docker compose up --wait` must be bounded by `--wait-timeout`,
+#     never bare `--timeout` (that's the stop-shutdown flag and is
+#     silently ignored as a wait bound).
+# Both are enforced by tools/archtest/healthcheck_verify_script_test.go.
+#
 # Exit 0 on success, non-zero if any service fails within the timeout.
 
 set -euo pipefail
 
 TIMEOUT=30
 
+trap 'docker compose down' EXIT
+
 echo "Starting Docker Compose services..."
-docker compose up -d --wait --timeout "${TIMEOUT}"
+docker compose up -d --wait --wait-timeout "${TIMEOUT}"
 
 echo ""
 echo "All services healthy."
@@ -17,5 +28,4 @@ echo ""
 docker compose ps
 
 echo ""
-docker compose down
 echo "Healthcheck verification complete."

--- a/scripts/healthcheck-verify.sh
+++ b/scripts/healthcheck-verify.sh
@@ -6,30 +6,41 @@
 # INVARIANT (HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01, issue #19):
 #   - `trap ... EXIT` must be installed before the first `docker compose`
 #     call so cleanup runs on success, `set -e` early-exit, and SIGINT.
+#   - the trap body must invoke `docker compose down` (not a noop) — the
+#     archtest cross-checks the body to rule out an empty cleanup.
+#   - cleanup must propagate its own failure: if the main flow succeeded
+#     but `docker compose down` failed, the script exits non-zero so the
+#     caller doesn't see "success + orphan containers". When the main
+#     flow already failed, the original failure code is preserved.
 #   - `docker compose up --wait` must be bounded by `--wait-timeout`,
 #     never bare `--timeout` (that's the stop-shutdown flag and is
 #     silently ignored as a wait bound).
-# Both are enforced by tools/archtest/healthcheck_verify_script_test.go.
+# All four are enforced by tools/archtest/healthcheck_verify_script_test.go.
 #
-# Exit 0 on success, non-zero if any service fails within the timeout.
+# Exit 0 on success, non-zero if any service fails within the timeout
+# OR if cleanup itself fails on an otherwise-clean run.
 
 set -euo pipefail
 
 TIMEOUT=30
 
-# Cleanup preserves the original exit code: bash's EXIT trap would
-# otherwise overwrite $? with the trap body's exit code, hiding the
-# real failure from callers (CI scripts, make targets). The explicit
-# `exit "$_rc"` at the end restores the caller-visible code while the
-# `|| ...` branch ensures a noisy `down` failure is logged, not
-# silenced (a silently-failed cleanup leaves orphan containers and
-# breaks the next run with port conflicts).
-#
-# shellcheck disable=SC2154
-# _rc is assigned inside the same trap body string before it is
-# referenced; shellcheck cannot follow sequence inside a single-quoted
-# trap argument.
-trap '_rc=$?; echo "[healthcheck-verify] tearing down containers..." >&2; docker compose down || echo "[healthcheck-verify] WARNING: docker compose down exited $? — orphan containers may remain" >&2; exit "$_rc"' EXIT
+_cleanup() {
+  local _rc=$?
+  echo "[healthcheck-verify] tearing down containers..." >&2
+  if ! docker compose down; then
+    local _down_rc=$?
+    echo "[healthcheck-verify] WARNING: docker compose down exited $_down_rc — orphan containers may remain" >&2
+    # If the main flow succeeded, surface the cleanup failure instead of
+    # masking it with exit 0 (orphan containers + exit 0 misleads CI).
+    # If the main flow already failed, keep the original failure code.
+    if [ "$_rc" -eq 0 ]; then
+      _rc=$_down_rc
+    fi
+  fi
+  exit "$_rc"
+}
+
+trap _cleanup EXIT
 
 echo "Starting Docker Compose services..."
 docker compose up -d --wait --wait-timeout "${TIMEOUT}"

--- a/scripts/healthcheck-verify.sh
+++ b/scripts/healthcheck-verify.sh
@@ -27,7 +27,14 @@ TIMEOUT=30
 _cleanup() {
   local _rc=$?
   echo "[healthcheck-verify] tearing down containers..." >&2
-  if ! docker compose down; then
+  # Note: do NOT use `if ! docker compose down; then ... fi` here. Inside
+  # the then-branch of `if ! cmd`, $? is the result of the `!` expression
+  # (always 0), not of cmd. The if-then-else form below preserves cmd's
+  # real exit code in the else-branch's $?. Pinned by archtest's runtime
+  # arm (TestHealthcheckVerifyRuntime01_CleanupFailurePropagates).
+  if docker compose down; then
+    :
+  else
     local _down_rc=$?
     echo "[healthcheck-verify] WARNING: docker compose down exited $_down_rc — orphan containers may remain" >&2
     # If the main flow succeeded, surface the cleanup failure instead of

--- a/scripts/healthcheck-verify.sh
+++ b/scripts/healthcheck-verify.sh
@@ -17,7 +17,19 @@ set -euo pipefail
 
 TIMEOUT=30
 
-trap 'docker compose down' EXIT
+# Cleanup preserves the original exit code: bash's EXIT trap would
+# otherwise overwrite $? with the trap body's exit code, hiding the
+# real failure from callers (CI scripts, make targets). The explicit
+# `exit "$_rc"` at the end restores the caller-visible code while the
+# `|| ...` branch ensures a noisy `down` failure is logged, not
+# silenced (a silently-failed cleanup leaves orphan containers and
+# breaks the next run with port conflicts).
+#
+# shellcheck disable=SC2154
+# _rc is assigned inside the same trap body string before it is
+# referenced; shellcheck cannot follow sequence inside a single-quoted
+# trap argument.
+trap '_rc=$?; echo "[healthcheck-verify] tearing down containers..." >&2; docker compose down || echo "[healthcheck-verify] WARNING: docker compose down exited $? — orphan containers may remain" >&2; exit "$_rc"' EXIT
 
 echo "Starting Docker Compose services..."
 docker compose up -d --wait --wait-timeout "${TIMEOUT}"

--- a/tools/archtest/healthcheck_verify_runtime_test.go
+++ b/tools/archtest/healthcheck_verify_runtime_test.go
@@ -1,0 +1,179 @@
+//go:build !windows
+
+package archtest
+
+// INVARIANT: HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01 (Invariant E,
+// runtime arm — exit-code propagation on cleanup failure)
+//
+// Static archtest (healthcheck_verify_script_test.go, Invariants A-D)
+// can prove the script shape but cannot prove bash semantics. PR #1011
+// round-2 review found this gap concretely: the cleanup function had
+//
+//	if ! docker compose down; then
+//	  local _down_rc=$?    # always 0 — `!` already inverted to success
+//	  ...
+//	fi
+//
+// Static checks (shape, presence of `docker compose down`, presence of
+// `if [ "$_rc" -eq 0 ]; then _rc=$_down_rc; fi`) all passed; the script
+// still exited 0 on the "main success + cleanup failure" path because
+// `$?` inside the `if ! cmd; then` branch is the result of the `!`
+// expression, not of cmd. Caller saw "success + orphan containers".
+//
+// This file pins the *behavior* by running the real script with a
+// fake `docker` on PATH that simulates the exact failure mode, then
+// asserting the script's exit code matches the expected propagation
+// semantics. AI-robust: Medium — bash semantics are not statically
+// expressible from Go, but a black-box runtime test executed in CI is
+// the closest practical guard.
+//
+// Build constraint: !windows. The test needs `bash` and a stub
+// shell script on PATH; Windows runners get t.Skip via constraint.
+// macOS / Linux runners (PR-time CI + nightly) cover it.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHealthcheckVerifyRuntime01 covers the two cleanup-failure
+// propagation paths as a black-box runtime test against the real
+// script. Subtests use a `docker` stub on PATH that simulates each
+// scenario.
+//
+// Subtest matrix:
+//
+//	main flow / cleanup / expected script exit
+//	  succeed  /  fail   /  non-zero (== cleanup exit code, currently 1)
+//	  fail(7)  /  fail   /  7 (original main-flow failure preserved,
+//	                        cleanup's exit code must NOT mask it)
+func TestHealthcheckVerifyRuntime01(t *testing.T) {
+	t.Parallel()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+	root := findModuleRoot(t)
+	scriptPath := filepath.Clean(filepath.Join(root, "scripts", "healthcheck-verify.sh"))
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script not found: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		// stub returns this exit code for `docker compose up ...`;
+		// `docker compose down` always exits 1; everything else 0.
+		upExit int
+		// wantExit==-1 means "non-zero, exact code does not matter"
+		// (used for the cleanup-only-fails path where the cleanup
+		// exit code is propagated but its exact value is bash's
+		// concern — only "non-zero" matters for the contract).
+		wantExit int
+		why      string
+	}{
+		{
+			name:     "cleanup-failure-propagates",
+			upExit:   0,
+			wantExit: -1,
+			why: "main success + cleanup failure must surface as " +
+				"non-zero exit so the caller doesn't see " +
+				"`success + orphan containers`",
+		},
+		{
+			name:     "original-failure-preserved",
+			upExit:   7,
+			wantExit: 7,
+			why: "main-flow failure code must propagate verbatim; " +
+				"the cleanup failure must NOT mask the original " +
+				"signal the caller cares about",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stubDir := t.TempDir()
+			stubPath := filepath.Join(stubDir, "docker")
+			stub := buildDockerStub(tc.upExit)
+			if err := os.WriteFile(stubPath, []byte(stub), 0o755); err != nil {
+				t.Fatalf("write stub: %v", err)
+			}
+			//nolint:gosec // bash from exec.LookPath; scriptPath from findModuleRoot; both trusted
+			cmd := exec.Command(bash, scriptPath)
+			cmd.Env = append(os.Environ(), "PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			out, _ := cmd.CombinedOutput()
+			got := cmd.ProcessState.ExitCode()
+
+			var ok bool
+			switch tc.wantExit {
+			case -1:
+				ok = got != 0
+			default:
+				ok = got == tc.wantExit
+			}
+			if !ok {
+				wantDesc := "non-zero"
+				if tc.wantExit != -1 {
+					wantDesc = itoa(tc.wantExit)
+				}
+				t.Fatalf("HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01 (E/%s): "+
+					"got exit %d, want %s.\nWhy: %s\nScript output:\n%s",
+					tc.name, got, wantDesc, tc.why, indent(string(out)))
+			}
+		})
+	}
+}
+
+// buildDockerStub returns a bash docker-stub that:
+//   - returns upExit for any `docker compose up ...` invocation
+//   - returns 1 for `docker compose down`
+//   - returns 0 for everything else (e.g. `docker compose ps`)
+//
+// Stub echoes its invocation to stderr so a test failure dump
+// shows what the script actually attempted.
+func buildDockerStub(upExit int) string {
+	return `#!/usr/bin/env bash
+# Test stub for docker — used by TestHealthcheckVerifyRuntime01.
+echo "[docker-stub] $*" >&2
+case "$2" in
+  up)   exit ` + itoa(upExit) + ` ;;
+  down) exit 1 ;;
+  *)    exit 0 ;;
+esac
+`
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func indent(s string) string {
+	if s == "" {
+		return "  <empty>"
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, l := range lines {
+		lines[i] = "  " + l
+	}
+	return strings.Join(lines, "\n")
+}

--- a/tools/archtest/healthcheck_verify_script_test.go
+++ b/tools/archtest/healthcheck_verify_script_test.go
@@ -20,18 +20,38 @@ package archtest
 //
 // AI-robust: Medium (string-anchor regression). Bash has no typed call
 // sites; the Hard upgrade path is to port the verifier to Go (os/exec +
-// testcontainers), which is unjustified by this single 22-line script's
-// footprint. The Medium guard locks the exact regression class — line
-// ordering of trap-vs-first-docker-compose and token-level inspection of
-// the `up` invocation — both of which are independently necessary and
-// jointly sufficient to prevent silent reintroduction.
+// testcontainers). For this 22-line script the upgrade cost outweighs the
+// residual risk after the Medium guard below, so no tracking issue is
+// opened — this is an explicit decision to remain at Medium, not an
+// oversight. Per `.claude/rules/gocell/ai-robust.md` Review checklist,
+// silent Medium carryover is forbidden; this paragraph is the explicit
+// declaration.
+//
+// Parser blind spots the Medium guard deliberately addresses:
+//
+//   - Token-form: `--timeout=N` (equals form) — Invariant B detects both
+//     space-separated `--timeout N` and equals-form `--timeout=N`.
+//   - Line-continuation: a backslash-continued multi-line `docker compose
+//     up` invocation would put `--wait` and `--timeout` on different lines
+//     and defeat per-line token scan. Invariant C bans line-continuation
+//     on the `docker compose up` logical command (the script is single-
+//     line by convention; the ban makes that convention machine-checked).
+//
+// Self-check (meta-regression): TestHealthcheckVerifyScriptInvariantMeta01
+// feeds known-broken script fixtures through the same checker the file-
+// reading test uses, asserting each fixture trips the expected diagnostic.
+// This closes the gap noted in `.claude/rules/gocell/ai-robust.md`
+// §"工具选定后强制盲区自检".
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+const ruleHealthcheckVerify01 = "HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01"
 
 func TestHealthcheckVerifyScriptInvariant01(t *testing.T) {
 	t.Parallel()
@@ -41,6 +61,135 @@ func TestHealthcheckVerifyScriptInvariant01(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read %s: %v", scriptPath, err)
 	}
+	for _, diag := range checkHealthcheckVerifyScript(data, scriptPath) {
+		t.Errorf("%s", diag)
+	}
+}
+
+// TestHealthcheckVerifyScriptInvariantMeta01 is the reverse self-check
+// required by `.claude/rules/gocell/ai-robust.md` §"工具选定后强制盲区
+// 自检". Each fixture below is a synthetic script that violates exactly
+// one invariant; the test asserts the checker emits a diagnostic naming
+// the expected sub-rule (A/B/C). Together with the prod test above this
+// closes the TDD FAIL→PASS demonstration into a permanent regression
+// guard.
+func TestHealthcheckVerifyScriptInvariantMeta01(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		script    string
+		wantSub   string
+		wantClean bool
+	}{
+		{
+			name: "A-no-trap",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+docker compose up -d --wait --wait-timeout 30
+docker compose down
+`,
+			wantSub: "(A)",
+		},
+		{
+			name: "A-trap-after-docker",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+docker compose up -d --wait --wait-timeout 30
+trap 'docker compose down' EXIT
+`,
+			wantSub: "(A)",
+		},
+		{
+			name: "B-space-form-timeout",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait --timeout 30
+`,
+			wantSub: "(B)",
+		},
+		{
+			name: "B-equals-form-timeout",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait --timeout=30
+`,
+			wantSub: "(B)",
+		},
+		{
+			name: "B-missing-wait-timeout-entirely",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait
+`,
+			wantSub: "(B)",
+		},
+		{
+			name: "C-line-continuation",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d \
+  --wait \
+  --wait-timeout 30
+`,
+			wantSub: "(C)",
+		},
+		{
+			name: "clean-canonical",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait --wait-timeout 30
+docker compose ps
+`,
+			wantClean: true,
+		},
+		{
+			name: "clean-equals-form-wait-timeout",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait --wait-timeout=30
+`,
+			wantClean: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diags := checkHealthcheckVerifyScript([]byte(tc.script), "<fixture>")
+			if tc.wantClean {
+				if len(diags) != 0 {
+					t.Errorf("expected clean fixture but got diagnostics: %v", diags)
+				}
+				return
+			}
+			if len(diags) == 0 {
+				t.Fatalf("expected diagnostic with substring %q, got none", tc.wantSub)
+			}
+			matched := false
+			for _, d := range diags {
+				if strings.Contains(d, tc.wantSub) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Errorf("expected diagnostic with substring %q, got %v", tc.wantSub, diags)
+			}
+		})
+	}
+}
+
+// checkHealthcheckVerifyScript runs the three string-anchor invariants
+// against script bytes and returns a slice of diagnostic messages. Empty
+// slice = healthy. Pure function over bytes so meta self-checks can drive
+// it with synthetic fixtures.
+func checkHealthcheckVerifyScript(data []byte, scriptDesc string) []string {
+	var diags []string
 	lines := strings.Split(string(data), "\n")
 
 	firstDockerComposeLine := -1
@@ -67,49 +216,68 @@ func TestHealthcheckVerifyScriptInvariant01(t *testing.T) {
 		}
 	}
 
-	const ruleID = "HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01"
-
 	// Invariant A: a `trap ... EXIT` must be installed before the first
 	// `docker compose` invocation so cleanup runs on every exit path.
 	switch {
 	case trapEXITLine < 0:
-		t.Errorf("%s (A): no `trap ... EXIT` line in %s; "+
-			"failure / SIGINT paths will leak containers",
-			ruleID, scriptPath)
+		diags = append(diags, fmt.Sprintf(
+			"%s (A): no `trap ... EXIT` line in %s; "+
+				"failure / SIGINT paths will leak containers",
+			ruleHealthcheckVerify01, scriptDesc))
 	case firstDockerComposeLine >= 0 && trapEXITLine > firstDockerComposeLine:
-		t.Errorf("%s (A): `trap ... EXIT` at line %d is AFTER "+
-			"first `docker compose` at line %d; install trap first",
-			ruleID, trapEXITLine+1, firstDockerComposeLine+1)
+		diags = append(diags, fmt.Sprintf(
+			"%s (A): `trap ... EXIT` at line %d is AFTER "+
+				"first `docker compose` at line %d; install trap first",
+			ruleHealthcheckVerify01, trapEXITLine+1, firstDockerComposeLine+1))
 	}
 
-	// Invariant B: `docker compose up` using `--wait` must bound it with
-	// `--wait-timeout`, never with bare `--timeout` (which is the
-	// stop-shutdown flag and is silently ignored as a wait bound).
+	// Invariant B / C: `docker compose up` must (B) bound `--wait` with
+	// `--wait-timeout` (never `--timeout` — that's the stop-shutdown
+	// flag), and (C) stay on a single logical line so per-line token
+	// scanning is reliable.
 	if upLineIdx >= 0 {
-		tokens := strings.Fields(upLine)
-		var hasWait, hasBareTimeout, hasWaitTimeout bool
-		for _, tok := range tokens {
-			switch tok {
-			case "--wait":
-				hasWait = true
-			case "--timeout":
-				hasBareTimeout = true
-			case "--wait-timeout":
-				hasWaitTimeout = true
+		if strings.HasSuffix(strings.TrimRight(upLine, " \t"), "\\") {
+			diags = append(diags, fmt.Sprintf(
+				"%s (C): line %d uses bash line-continuation; "+
+					"the `docker compose up` command must stay on one "+
+					"logical line so per-line token scanning is reliable",
+				ruleHealthcheckVerify01, upLineIdx+1))
+		} else {
+			tokens := strings.Fields(upLine)
+			var hasWait, hasBareTimeout, hasWaitTimeout bool
+			for _, tok := range tokens {
+				switch {
+				case tok == "--wait":
+					hasWait = true
+				case tok == "--wait-timeout" ||
+					strings.HasPrefix(tok, "--wait-timeout="):
+					hasWaitTimeout = true
+				case tok == "--timeout" ||
+					strings.HasPrefix(tok, "--timeout="):
+					hasBareTimeout = true
+				}
+			}
+			// Branches are mutually exclusive: when `--timeout` is
+			// present we report the precise diagnostic (stop-shutdown
+			// flag confusion); only when it is absent do we fall through
+			// to the generic missing-bound diagnostic. Avoids the
+			// duplicate-error issue from the first revision.
+			switch {
+			case hasWait && hasBareTimeout:
+				diags = append(diags, fmt.Sprintf(
+					"%s (B): line %d combines `--wait` with `--timeout`; "+
+						"`--timeout` is the stop-shutdown flag, "+
+						"use `--wait-timeout` to bound `--wait` polling",
+					ruleHealthcheckVerify01, upLineIdx+1))
+			case hasWait && !hasWaitTimeout:
+				diags = append(diags, fmt.Sprintf(
+					"%s (B): line %d uses `--wait` without `--wait-timeout`; "+
+						"health-check wait must be bounded explicitly",
+					ruleHealthcheckVerify01, upLineIdx+1))
 			}
 		}
-		if hasWait && hasBareTimeout {
-			t.Errorf("%s (B): line %d combines `--wait` with `--timeout`; "+
-				"`--timeout` is the stop-shutdown flag, "+
-				"use `--wait-timeout` to bound `--wait` polling",
-				ruleID, upLineIdx+1)
-		}
-		if hasWait && !hasWaitTimeout {
-			t.Errorf("%s (B): line %d uses `--wait` without `--wait-timeout`; "+
-				"health-check wait must be bounded explicitly",
-				ruleID, upLineIdx+1)
-		}
 	}
+	return diags
 }
 
 // hasToken reports whether word appears as a whitespace-separated token in s.

--- a/tools/archtest/healthcheck_verify_script_test.go
+++ b/tools/archtest/healthcheck_verify_script_test.go
@@ -2,27 +2,33 @@ package archtest
 
 // INVARIANT: HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01
 //
-// scripts/healthcheck-verify.sh — regression guard for two bugs surfaced in
-// PR #9 post-merge review (issue #19, backlog
+// scripts/healthcheck-verify.sh — regression guard for bugs surfaced in
+// PR #9 / PR #1011 post-merge review (issue #19, backlog
 // DEVOPS-INTEGRATION-CLEANUP-WAIT-TIMEOUT-01):
 //
 //  1. Bare `docker compose down` at the script tail does not run when
 //     `docker compose up --wait` fails, when `docker compose ps` fails, or
 //     on SIGINT (`set -euo pipefail` exits early). Must install a `trap`
 //     on EXIT before any `docker compose` invocation so cleanup is
-//     unconditional across success / failure / signal paths.
+//     unconditional across success / failure / signal paths (Invariant A).
 //
 //  2. `docker compose up --wait --timeout N` uses the stop-shutdown flag,
 //     not the wait bound. The flag that bounds `--wait` polling is
 //     `--wait-timeout`. The original bug was silent: the documented
 //     "wait up to TIMEOUT seconds" envelope was inert; `--wait` ran with
-//     compose's internal default.
+//     compose's internal default. Applies to every `docker compose up`
+//     in the script, not just the first (Invariant B; F3 round-2 fix).
+//
+//  3. EXIT-trap shape alone does not prove cleanup actually runs `down`:
+//     `trap 'echo noop' EXIT` would satisfy Invariant A but leak
+//     containers. The script must contain a literal `docker compose
+//     down` reachable from the trap (Invariant D; F2 round-2 fix).
 //
 // AI-robust: Medium (string-anchor regression). Bash has no typed call
 // sites; the Hard upgrade path is to port the verifier to Go (os/exec +
-// testcontainers). For this 22-line script the upgrade cost outweighs the
-// residual risk after the Medium guard below, so no tracking issue is
-// opened — this is an explicit decision to remain at Medium, not an
+// testcontainers). For this <50-line script the upgrade cost outweighs
+// the residual risk after the Medium guard below, so no tracking issue
+// is opened — this is an explicit decision to remain at Medium, not an
 // oversight. Per `.claude/rules/gocell/ai-robust.md` Review checklist,
 // silent Medium carryover is forbidden; this paragraph is the explicit
 // declaration.
@@ -36,6 +42,13 @@ package archtest
 //     and defeat per-line token scan. Invariant C bans line-continuation
 //     on the `docker compose up` logical command (the script is single-
 //     line by convention; the ban makes that convention machine-checked).
+//   - Multi-up: a script may call `docker compose up` more than once
+//     (e.g. once for healthchecks, once for a real boot). Invariant B/C
+//     iterate every `docker compose up` line, not only the first.
+//   - Trap-noop: an EXIT trap with a body that does not call `docker
+//     compose down` (e.g. `trap 'echo bye' EXIT`) would pass A. Invariant
+//     D asserts the script contains a literal `docker compose down`
+//     command, ensuring the trap has a real cleanup target to reach.
 //
 // Self-check (meta-regression): TestHealthcheckVerifyScriptInvariantMeta01
 // feeds known-broken script fixtures through the same checker the file-
@@ -68,11 +81,11 @@ func TestHealthcheckVerifyScriptInvariant01(t *testing.T) {
 
 // TestHealthcheckVerifyScriptInvariantMeta01 is the reverse self-check
 // required by `.claude/rules/gocell/ai-robust.md` §"工具选定后强制盲区
-// 自检". Each fixture below is a synthetic script that violates exactly
-// one invariant; the test asserts the checker emits a diagnostic naming
-// the expected sub-rule (A/B/C). Together with the prod test above this
-// closes the TDD FAIL→PASS demonstration into a permanent regression
-// guard.
+// 自检". Each fixture below is a synthetic script that either violates
+// exactly one invariant (the test asserts the checker emits the expected
+// sub-rule diagnostic) or is canonical-clean (the test asserts zero
+// diagnostics). Together with the prod test above this closes the TDD
+// FAIL→PASS demonstration into a permanent regression guard.
 func TestHealthcheckVerifyScriptInvariantMeta01(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -127,6 +140,16 @@ docker compose up -d --wait
 			wantSub: "(B)",
 		},
 		{
+			name: "B-second-up-broken",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait --wait-timeout 30
+docker compose up -d --wait --timeout 60
+`,
+			wantSub: "(B)",
+		},
+		{
 			name: "C-line-continuation",
 			script: `#!/usr/bin/env bash
 set -euo pipefail
@@ -136,6 +159,16 @@ docker compose up -d \
   --wait-timeout 30
 `,
 			wantSub: "(C)",
+		},
+		{
+			name: "D-trap-noop",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo noop' EXIT
+docker compose up -d --wait --wait-timeout 30
+docker compose ps
+`,
+			wantSub: "(D)",
 		},
 		{
 			name: "clean-canonical",
@@ -153,6 +186,28 @@ docker compose ps
 set -euo pipefail
 trap 'docker compose down' EXIT
 docker compose up -d --wait --wait-timeout=30
+`,
+			wantClean: true,
+		},
+		{
+			name: "clean-function-trap",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+_cleanup() {
+  docker compose down || true
+}
+trap _cleanup EXIT
+docker compose up -d --wait --wait-timeout 30
+`,
+			wantClean: true,
+		},
+		{
+			name: "clean-multi-up-both-correct",
+			script: `#!/usr/bin/env bash
+set -euo pipefail
+trap 'docker compose down' EXIT
+docker compose up -d --wait --wait-timeout 30
+docker compose up -d --wait --wait-timeout=60
 `,
 			wantClean: true,
 		},
@@ -184,24 +239,59 @@ docker compose up -d --wait --wait-timeout=30
 	}
 }
 
-// checkHealthcheckVerifyScript runs the three string-anchor invariants
-// against script bytes and returns a slice of diagnostic messages. Empty
-// slice = healthy. Pure function over bytes so meta self-checks can drive
-// it with synthetic fixtures.
+// checkHealthcheckVerifyScript runs the four string-anchor invariants
+// (A trap-before-docker, B/C per-up flag form, D cleanup-actually-runs-
+// down) against script bytes and returns a slice of diagnostic messages.
+// Empty slice = healthy. Pure function over bytes so meta self-checks
+// can drive it with synthetic fixtures.
+//
+// Function-body scoping: `docker compose` inside a bash function body
+// (e.g. inside `_cleanup() { ... }`) is a *definition*, not a *call*,
+// and must not count toward Invariant A's "first docker compose call".
+// Per-line scanning tracks a simple function-nesting depth: an opening
+// `name() {` increments depth, a closing `}` decrements it. Only lines
+// at depth 0 are considered for A/B/C; D scans every depth (the
+// `docker compose down` may live inside the trap's cleanup function,
+// which is precisely the recommended idiom).
 func checkHealthcheckVerifyScript(data []byte, scriptDesc string) []string {
 	var diags []string
 	lines := strings.Split(string(data), "\n")
 
 	firstDockerComposeLine := -1
 	trapEXITLine := -1
-	upLineIdx := -1
-	var upLine string
+	hasDockerComposeDown := false
+	var upLines []int // line indices of every top-level `docker compose up`
 
+	funcDepth := 0
 	for i, raw := range lines {
 		trimmed := strings.TrimSpace(raw)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
+
+		// Invariant D (any nesting depth): the script must contain at
+		// least one literal `docker compose down`. Comments stripped
+		// above, so a `# docker compose down` doc line never matches.
+		if strings.Contains(trimmed, "docker compose down") {
+			hasDockerComposeDown = true
+		}
+
+		// Function-body nesting: lines inside `name() { ... }` are
+		// definition, not execution. Increment on opening, decrement
+		// on closing brace; skip A/B/C accounting while nested.
+		if isBashFuncOpen(trimmed) {
+			funcDepth++
+			continue
+		}
+		if trimmed == "}" && funcDepth > 0 {
+			funcDepth--
+			continue
+		}
+		if funcDepth > 0 {
+			continue
+		}
+
+		// At top level from here on.
 		if strings.HasPrefix(trimmed, "trap ") && hasToken(trimmed, "EXIT") {
 			if trapEXITLine < 0 {
 				trapEXITLine = i
@@ -210,9 +300,8 @@ func checkHealthcheckVerifyScript(data []byte, scriptDesc string) []string {
 		if strings.Contains(trimmed, "docker compose") && firstDockerComposeLine < 0 {
 			firstDockerComposeLine = i
 		}
-		if strings.Contains(trimmed, "docker compose up") && upLineIdx < 0 {
-			upLineIdx = i
-			upLine = trimmed
+		if strings.Contains(trimmed, "docker compose up") {
+			upLines = append(upLines, i)
 		}
 	}
 
@@ -231,50 +320,64 @@ func checkHealthcheckVerifyScript(data []byte, scriptDesc string) []string {
 			ruleHealthcheckVerify01, trapEXITLine+1, firstDockerComposeLine+1))
 	}
 
-	// Invariant B / C: `docker compose up` must (B) bound `--wait` with
-	// `--wait-timeout` (never `--timeout` — that's the stop-shutdown
-	// flag), and (C) stay on a single logical line so per-line token
-	// scanning is reliable.
-	if upLineIdx >= 0 {
+	// Invariant D: the script must contain at least one literal
+	// `docker compose down` outside comments. Without this an EXIT
+	// trap whose body is `echo noop` (or similar) would silently
+	// satisfy A while leaking every container. Comments were stripped
+	// during the scan, so a `# docker compose down` doc string does
+	// not count.
+	if !hasDockerComposeDown {
+		diags = append(diags, fmt.Sprintf(
+			"%s (D): %s contains no `docker compose down` outside "+
+				"comments; the EXIT trap has no real cleanup target",
+			ruleHealthcheckVerify01, scriptDesc))
+	}
+
+	// Invariant B / C: each `docker compose up` must (B) bound `--wait`
+	// with `--wait-timeout` (never `--timeout` — that's the stop-
+	// shutdown flag), and (C) stay on a single logical line so per-
+	// line token scanning is reliable. Applied to every up line, not
+	// only the first, so a regression on a secondary up cannot hide.
+	for _, idx := range upLines {
+		upLine := strings.TrimSpace(lines[idx])
 		if strings.HasSuffix(strings.TrimRight(upLine, " \t"), "\\") {
 			diags = append(diags, fmt.Sprintf(
 				"%s (C): line %d uses bash line-continuation; "+
 					"the `docker compose up` command must stay on one "+
 					"logical line so per-line token scanning is reliable",
-				ruleHealthcheckVerify01, upLineIdx+1))
-		} else {
-			tokens := strings.Fields(upLine)
-			var hasWait, hasBareTimeout, hasWaitTimeout bool
-			for _, tok := range tokens {
-				switch {
-				case tok == "--wait":
-					hasWait = true
-				case tok == "--wait-timeout" ||
-					strings.HasPrefix(tok, "--wait-timeout="):
-					hasWaitTimeout = true
-				case tok == "--timeout" ||
-					strings.HasPrefix(tok, "--timeout="):
-					hasBareTimeout = true
-				}
-			}
-			// Branches are mutually exclusive: when `--timeout` is
-			// present we report the precise diagnostic (stop-shutdown
-			// flag confusion); only when it is absent do we fall through
-			// to the generic missing-bound diagnostic. Avoids the
-			// duplicate-error issue from the first revision.
+				ruleHealthcheckVerify01, idx+1))
+			continue
+		}
+		tokens := strings.Fields(upLine)
+		var hasWait, hasBareTimeout, hasWaitTimeout bool
+		for _, tok := range tokens {
 			switch {
-			case hasWait && hasBareTimeout:
-				diags = append(diags, fmt.Sprintf(
-					"%s (B): line %d combines `--wait` with `--timeout`; "+
-						"`--timeout` is the stop-shutdown flag, "+
-						"use `--wait-timeout` to bound `--wait` polling",
-					ruleHealthcheckVerify01, upLineIdx+1))
-			case hasWait && !hasWaitTimeout:
-				diags = append(diags, fmt.Sprintf(
-					"%s (B): line %d uses `--wait` without `--wait-timeout`; "+
-						"health-check wait must be bounded explicitly",
-					ruleHealthcheckVerify01, upLineIdx+1))
+			case tok == "--wait":
+				hasWait = true
+			case tok == "--wait-timeout" ||
+				strings.HasPrefix(tok, "--wait-timeout="):
+				hasWaitTimeout = true
+			case tok == "--timeout" ||
+				strings.HasPrefix(tok, "--timeout="):
+				hasBareTimeout = true
 			}
+		}
+		// Branches are mutually exclusive: when `--timeout` is
+		// present we report the precise diagnostic (stop-shutdown
+		// flag confusion); only when it is absent do we fall
+		// through to the generic missing-bound diagnostic.
+		switch {
+		case hasWait && hasBareTimeout:
+			diags = append(diags, fmt.Sprintf(
+				"%s (B): line %d combines `--wait` with `--timeout`; "+
+					"`--timeout` is the stop-shutdown flag, "+
+					"use `--wait-timeout` to bound `--wait` polling",
+				ruleHealthcheckVerify01, idx+1))
+		case hasWait && !hasWaitTimeout:
+			diags = append(diags, fmt.Sprintf(
+				"%s (B): line %d uses `--wait` without `--wait-timeout`; "+
+					"health-check wait must be bounded explicitly",
+				ruleHealthcheckVerify01, idx+1))
 		}
 	}
 	return diags
@@ -290,4 +393,45 @@ func hasToken(s, word string) bool {
 		}
 	}
 	return false
+}
+
+// isBashFuncOpen reports whether trimmed is the opening line of a bash
+// function definition. Accepts both common forms:
+//
+//	name() {
+//	name () {
+//	function name {
+//	function name() {
+//
+// The brace may sit on the next line in some styles; this helper only
+// matches the same-line form, which is the GoCell convention for
+// scripts/*.sh. A future style change would need to extend this
+// matcher in tandem.
+func isBashFuncOpen(trimmed string) bool {
+	if !strings.HasSuffix(trimmed, "{") {
+		return false
+	}
+	head := strings.TrimSpace(strings.TrimSuffix(trimmed, "{"))
+	// `function name` or `function name()`
+	if strings.HasPrefix(head, "function ") {
+		head = strings.TrimSpace(strings.TrimPrefix(head, "function "))
+	}
+	// Strip trailing `()` (with or without internal whitespace).
+	if idx := strings.Index(head, "("); idx >= 0 {
+		rest := strings.TrimSpace(head[idx:])
+		if rest != "()" && rest != "( )" {
+			return false
+		}
+		head = strings.TrimSpace(head[:idx])
+	}
+	if head == "" {
+		return false
+	}
+	for _, r := range head {
+		if r != '_' && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') &&
+			(r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
 }

--- a/tools/archtest/healthcheck_verify_script_test.go
+++ b/tools/archtest/healthcheck_verify_script_test.go
@@ -1,0 +1,125 @@
+package archtest
+
+// INVARIANT: HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01
+//
+// scripts/healthcheck-verify.sh — regression guard for two bugs surfaced in
+// PR #9 post-merge review (issue #19, backlog
+// DEVOPS-INTEGRATION-CLEANUP-WAIT-TIMEOUT-01):
+//
+//  1. Bare `docker compose down` at the script tail does not run when
+//     `docker compose up --wait` fails, when `docker compose ps` fails, or
+//     on SIGINT (`set -euo pipefail` exits early). Must install a `trap`
+//     on EXIT before any `docker compose` invocation so cleanup is
+//     unconditional across success / failure / signal paths.
+//
+//  2. `docker compose up --wait --timeout N` uses the stop-shutdown flag,
+//     not the wait bound. The flag that bounds `--wait` polling is
+//     `--wait-timeout`. The original bug was silent: the documented
+//     "wait up to TIMEOUT seconds" envelope was inert; `--wait` ran with
+//     compose's internal default.
+//
+// AI-robust: Medium (string-anchor regression). Bash has no typed call
+// sites; the Hard upgrade path is to port the verifier to Go (os/exec +
+// testcontainers), which is unjustified by this single 22-line script's
+// footprint. The Medium guard locks the exact regression class — line
+// ordering of trap-vs-first-docker-compose and token-level inspection of
+// the `up` invocation — both of which are independently necessary and
+// jointly sufficient to prevent silent reintroduction.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHealthcheckVerifyScriptInvariant01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	scriptPath := filepath.Clean(filepath.Join(root, "scripts", "healthcheck-verify.sh"))
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptPath, err)
+	}
+	lines := strings.Split(string(data), "\n")
+
+	firstDockerComposeLine := -1
+	trapEXITLine := -1
+	upLineIdx := -1
+	var upLine string
+
+	for i, raw := range lines {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "trap ") && hasToken(trimmed, "EXIT") {
+			if trapEXITLine < 0 {
+				trapEXITLine = i
+			}
+		}
+		if strings.Contains(trimmed, "docker compose") && firstDockerComposeLine < 0 {
+			firstDockerComposeLine = i
+		}
+		if strings.Contains(trimmed, "docker compose up") && upLineIdx < 0 {
+			upLineIdx = i
+			upLine = trimmed
+		}
+	}
+
+	const ruleID = "HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01"
+
+	// Invariant A: a `trap ... EXIT` must be installed before the first
+	// `docker compose` invocation so cleanup runs on every exit path.
+	switch {
+	case trapEXITLine < 0:
+		t.Errorf("%s (A): no `trap ... EXIT` line in %s; "+
+			"failure / SIGINT paths will leak containers",
+			ruleID, scriptPath)
+	case firstDockerComposeLine >= 0 && trapEXITLine > firstDockerComposeLine:
+		t.Errorf("%s (A): `trap ... EXIT` at line %d is AFTER "+
+			"first `docker compose` at line %d; install trap first",
+			ruleID, trapEXITLine+1, firstDockerComposeLine+1)
+	}
+
+	// Invariant B: `docker compose up` using `--wait` must bound it with
+	// `--wait-timeout`, never with bare `--timeout` (which is the
+	// stop-shutdown flag and is silently ignored as a wait bound).
+	if upLineIdx >= 0 {
+		tokens := strings.Fields(upLine)
+		var hasWait, hasBareTimeout, hasWaitTimeout bool
+		for _, tok := range tokens {
+			switch tok {
+			case "--wait":
+				hasWait = true
+			case "--timeout":
+				hasBareTimeout = true
+			case "--wait-timeout":
+				hasWaitTimeout = true
+			}
+		}
+		if hasWait && hasBareTimeout {
+			t.Errorf("%s (B): line %d combines `--wait` with `--timeout`; "+
+				"`--timeout` is the stop-shutdown flag, "+
+				"use `--wait-timeout` to bound `--wait` polling",
+				ruleID, upLineIdx+1)
+		}
+		if hasWait && !hasWaitTimeout {
+			t.Errorf("%s (B): line %d uses `--wait` without `--wait-timeout`; "+
+				"health-check wait must be bounded explicitly",
+				ruleID, upLineIdx+1)
+		}
+	}
+}
+
+// hasToken reports whether word appears as a whitespace-separated token in s.
+// Used to distinguish `EXIT` (a real signal name) from substrings inside
+// quoted commands or comments.
+func hasToken(s, word string) bool {
+	for _, tok := range strings.Fields(s) {
+		if tok == word {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

`scripts/healthcheck-verify.sh` (added in PR #9) had two bugs surfaced in post-merge review and tracked as `DEVOPS-INTEGRATION-CLEANUP-WAIT-TIMEOUT-01`:

1. **Container leak on failure / SIGINT** — bare `docker compose down` at the script tail did not run on `up --wait` failure, `ps` failure, or `^C` (`set -euo pipefail` exits early).
2. **Wrong wait-timeout flag** — `docker compose up --wait --timeout 30` used the stop-shutdown flag, not the wait bound. `--wait` ran with compose's internal default; the documented "wait up to 30 s" envelope was silently inert.

## Fix

- `trap 'docker compose down' EXIT` installed before any `docker compose` invocation — cleanup runs unconditionally across success / failure / signal paths.
- `--timeout` → `--wait-timeout` so the 30 s envelope is real.
- New regression archtest `HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01` (AI-robust **Medium**, string-anchor; bash has no typed call sites, Hard upgrade would require porting the verifier to Go — out of scope for a 22-line script) locks both invariants statically.

## Acceptance criteria (issue #19)

- [x] Containers torn down on both success and failure — `trap ... EXIT` fires on every exit path
- [x] Healthcheck timeout behaves as documented — `--wait-timeout 30` actually bounds the polling

## Test plan

- [x] `go test ./tools/archtest -run TestHealthcheckVerifyScriptInvariant01` — passes after fix (TDD-confirmed FAIL → PASS)
- [x] `bash hack/verify-archtest-invariants.sh` — PR-time invariant suite passes
- [x] `bash -n scripts/healthcheck-verify.sh` — syntax OK
- [x] `shellcheck scripts/healthcheck-verify.sh` — 0 issues
- [x] `go build ./...` and `go build -tags=integration ./...` — both clean
- [x] `golangci-lint run ./...` — 0 new issues (1 pre-existing gocognit in `tools/codegen/cellgen/literal_printer.go`, untouched)
- [ ] Local Docker smoke success path: `make healthcheck-verify` → exit 0, `docker ps` shows no leftover containers — *requires Docker daemon, not covered in CI; reviewer welcome to spot-check*
- [ ] Local Docker smoke failure path: point a service at invalid image tag, run `make healthcheck-verify` → non-zero exit, `docker ps` shows no leftover containers (trap fired) — same caveat

Closes #19
Refs: `DEVOPS-INTEGRATION-CLEANUP-WAIT-TIMEOUT-01`

ref: https://docs.docker.com/reference/cli/docker/compose/up/ (`--wait-timeout` semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)