### PR TITLE
test(rand-entropy): cover failure branch in 5 UUID/token generators

### DIFF
--- a/adapters/postgres/command_queue.go
+++ b/adapters/postgres/command_queue.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"slices"
 	"time"
@@ -599,10 +600,12 @@ func (q *PGCommandQueue) notFoundOrInvalidLease(ctx context.Context, commandID s
 
 // commandQueueNewID generates a random hex-encoded 16-byte ID for entries
 // that do not have one set by the caller.
-func commandQueueNewID() (string, error) {
+func commandQueueNewID() (string, error) { return commandQueueNewIDFrom(rand.Reader) }
+
+func commandQueueNewIDFrom(r io.Reader) (string, error) {
 	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("command_queue: generate ID: %w", err)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return "", fmt.Errorf("command_queue: read entropy: %w", err)
 	}
 	return hex.EncodeToString(b), nil
 }

--- a/adapters/postgres/command_queue.go
+++ b/adapters/postgres/command_queue.go
@@ -600,9 +600,9 @@ func (q *PGCommandQueue) notFoundOrInvalidLease(ctx context.Context, commandID s
 
 // commandQueueNewID generates a random hex-encoded 16-byte ID for entries
 // that do not have one set by the caller.
-func commandQueueNewID() (string, error) { return commandQueueNewIDFrom(rand.Reader) }
+func commandQueueNewID() (string, error) { return newCommandQueueID(rand.Reader) }
 
-func commandQueueNewIDFrom(r io.Reader) (string, error) {
+func newCommandQueueID(r io.Reader) (string, error) {
 	b := make([]byte, 16)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return "", fmt.Errorf("command_queue: read entropy: %w", err)

--- a/adapters/postgres/command_queue_internal_test.go
+++ b/adapters/postgres/command_queue_internal_test.go
@@ -17,7 +17,7 @@ func (failingCommandQueueReader) Read([]byte) (int, error) {
 }
 
 func TestCommandQueueNewID_RandFailure(t *testing.T) {
-	id, err := commandQueueNewIDFrom(failingCommandQueueReader{})
+	id, err := newCommandQueueID(failingCommandQueueReader{})
 	require.Error(t, err)
 	assert.Empty(t, id)
 	assert.ErrorIs(t, err, errCommandQueueEntropyFailedForTest)

--- a/adapters/postgres/command_queue_internal_test.go
+++ b/adapters/postgres/command_queue_internal_test.go
@@ -1,0 +1,25 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errCommandQueueEntropyFailedForTest = errors.New("postgres_test: command-queue entropy stub failure")
+
+type failingCommandQueueReader struct{}
+
+func (failingCommandQueueReader) Read([]byte) (int, error) {
+	return 0, errCommandQueueEntropyFailedForTest
+}
+
+func TestCommandQueueNewID_RandFailure(t *testing.T) {
+	id, err := commandQueueNewIDFrom(failingCommandQueueReader{})
+	require.Error(t, err)
+	assert.Empty(t, id)
+	assert.ErrorIs(t, err, errCommandQueueEntropyFailedForTest)
+	assert.ErrorContains(t, err, "command_queue: read entropy")
+}

--- a/adapters/redis/idempotency.go
+++ b/adapters/redis/idempotency.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -310,10 +311,12 @@ func (r *redisReceipt) Extend(ctx context.Context, ttl time.Duration) error {
 }
 
 // claimToken generates a 16-byte hex-encoded token for lease ownership.
-func claimToken() (string, error) {
+func claimToken() (string, error) { return claimTokenFrom(rand.Reader) }
+
+func claimTokenFrom(r io.Reader) (string, error) {
 	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
+	if _, err := io.ReadFull(r, b); err != nil {
+		return "", fmt.Errorf("redis: read entropy: %w", err)
 	}
 	return hex.EncodeToString(b), nil
 }

--- a/adapters/redis/idempotency.go
+++ b/adapters/redis/idempotency.go
@@ -311,9 +311,9 @@ func (r *redisReceipt) Extend(ctx context.Context, ttl time.Duration) error {
 }
 
 // claimToken generates a 16-byte hex-encoded token for lease ownership.
-func claimToken() (string, error) { return claimTokenFrom(rand.Reader) }
+func claimToken() (string, error) { return newClaimToken(rand.Reader) }
 
-func claimTokenFrom(r io.Reader) (string, error) {
+func newClaimToken(r io.Reader) (string, error) {
 	b := make([]byte, 16)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return "", fmt.Errorf("redis: read entropy: %w", err)

--- a/adapters/redis/idempotency_internal_test.go
+++ b/adapters/redis/idempotency_internal_test.go
@@ -12,10 +12,12 @@ var errClaimTokenEntropyFailedForTest = errors.New("redis_test: claim-token entr
 
 type failingClaimTokenReader struct{}
 
-func (failingClaimTokenReader) Read([]byte) (int, error) { return 0, errClaimTokenEntropyFailedForTest }
+func (failingClaimTokenReader) Read([]byte) (int, error) {
+	return 0, errClaimTokenEntropyFailedForTest
+}
 
 func TestClaimToken_RandFailure(t *testing.T) {
-	tok, err := claimTokenFrom(failingClaimTokenReader{})
+	tok, err := newClaimToken(failingClaimTokenReader{})
 	require.Error(t, err)
 	assert.Empty(t, tok)
 	assert.ErrorIs(t, err, errClaimTokenEntropyFailedForTest)

--- a/adapters/redis/idempotency_internal_test.go
+++ b/adapters/redis/idempotency_internal_test.go
@@ -1,0 +1,23 @@
+package redis
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errClaimTokenEntropyFailedForTest = errors.New("redis_test: claim-token entropy stub failure")
+
+type failingClaimTokenReader struct{}
+
+func (failingClaimTokenReader) Read([]byte) (int, error) { return 0, errClaimTokenEntropyFailedForTest }
+
+func TestClaimToken_RandFailure(t *testing.T) {
+	tok, err := claimTokenFrom(failingClaimTokenReader{})
+	require.Error(t, err)
+	assert.Empty(t, tok)
+	assert.ErrorIs(t, err, errClaimTokenEntropyFailedForTest)
+	assert.ErrorContains(t, err, "redis: read entropy")
+}

--- a/kernel/outbox/entry_id.go
+++ b/kernel/outbox/entry_id.go
@@ -36,10 +36,10 @@ func newEntryID(r io.Reader) (string, error) {
 	return EntryIDPrefix + hex.EncodeToString(b[:]), nil
 }
 
-// MustNewEntryID is the panic-on-error variant of NewEntryID. crypto/rand.Read
-// only fails on broken OS entropy, which is non-recoverable, so most call
-// sites use this Must variant; outbox writers that want to surface the error
-// to upstream tx callers should use NewEntryID directly.
+// MustNewEntryID is the panic-on-error variant of NewEntryID. The underlying
+// entropy read only fails on broken OS entropy, which is non-recoverable,
+// so most call sites use this Must variant; outbox writers that want to
+// surface the error to upstream tx callers should use NewEntryID directly.
 func MustNewEntryID() string {
 	id, err := NewEntryID()
 	if err != nil {

--- a/kernel/outbox/entry_id.go
+++ b/kernel/outbox/entry_id.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
@@ -21,12 +22,14 @@ const EntryIDPrefix = "evt-"
 // Uses crypto/rand directly (not github.com/google/uuid) because kernel/ may
 // only depend on the Go standard library per CLAUDE.md's layering rule.
 //
-// Returns the wrapped crypto/rand.Read error if the OS entropy source is
+// Returns the wrapped entropy read error if the OS entropy source is
 // broken; callers that prefer fail-fast wiring can use MustNewEntryID.
-func NewEntryID() (string, error) {
+func NewEntryID() (string, error) { return newEntryID(rand.Reader) }
+
+func newEntryID(r io.Reader) (string, error) {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", fmt.Errorf("outbox: crypto/rand.Read failed: %w", err)
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return "", fmt.Errorf("outbox: read entropy: %w", err)
 	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant RFC 4122

--- a/kernel/outbox/entry_id_test.go
+++ b/kernel/outbox/entry_id_test.go
@@ -1,13 +1,29 @@
 package outbox
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/idutil"
 )
+
+var errEntropyFailedForTest = errors.New("outbox_test: entropy stub failure")
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errEntropyFailedForTest }
+
+func TestNewEntryID_RandFailure(t *testing.T) {
+	id, err := newEntryID(failingReader{})
+	require.Error(t, err)
+	assert.Empty(t, id)
+	assert.ErrorIs(t, err, errEntropyFailedForTest)
+	assert.ErrorContains(t, err, "outbox: read entropy")
+}
 
 func TestNewEntryID_HasPrefix(t *testing.T) {
 	id := MustNewEntryID()

--- a/kernel/outbox/entry_id_test.go
+++ b/kernel/outbox/entry_id_test.go
@@ -11,17 +11,19 @@ import (
 	"github.com/ghbvf/gocell/pkg/idutil"
 )
 
-var errEntropyFailedForTest = errors.New("outbox_test: entropy stub failure")
+var errEntryIDEntropyFailedForTest = errors.New("outbox_test: entry-id entropy stub failure")
 
-type failingReader struct{}
+type failingEntryIDReader struct{}
 
-func (failingReader) Read([]byte) (int, error) { return 0, errEntropyFailedForTest }
+func (failingEntryIDReader) Read([]byte) (int, error) {
+	return 0, errEntryIDEntropyFailedForTest
+}
 
 func TestNewEntryID_RandFailure(t *testing.T) {
-	id, err := newEntryID(failingReader{})
+	id, err := newEntryID(failingEntryIDReader{})
 	require.Error(t, err)
 	assert.Empty(t, id)
-	assert.ErrorIs(t, err, errEntropyFailedForTest)
+	assert.ErrorIs(t, err, errEntryIDEntropyFailedForTest)
 	assert.ErrorContains(t, err, "outbox: read entropy")
 }
 

--- a/pkg/idutil/id.go
+++ b/pkg/idutil/id.go
@@ -8,6 +8,7 @@ package idutil
 import (
 	"crypto/rand"
 	"fmt"
+	"io"
 )
 
 const (
@@ -53,10 +54,12 @@ func IsSafeID(s string) bool {
 // crypto/rand.Read always succeeds in Go 1.24+; it calls runtime.fatal
 // on OS entropy failure rather than returning an error, but the error return
 // keeps callers honest if that contract changes.
-func NewUUID() (string, error) {
+func NewUUID() (string, error) { return newUUID(rand.Reader) }
+
+func newUUID(r io.Reader) (string, error) {
 	var buf [16]byte
-	if _, err := rand.Read(buf[:]); err != nil {
-		return "", fmt.Errorf("idutil: crypto/rand.Read: %w", err)
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return "", fmt.Errorf("idutil: read entropy: %w", err)
 	}
 	buf[6] = (buf[6] & 0x0f) | 0x40 // version 4
 	buf[8] = (buf[8] & 0x3f) | 0x80 // variant 10

--- a/pkg/idutil/id.go
+++ b/pkg/idutil/id.go
@@ -50,10 +50,11 @@ func IsSafeID(s string) bool {
 	return true
 }
 
-// NewUUID generates a UUID v4 string using crypto/rand.
-// crypto/rand.Read always succeeds in Go 1.24+; it calls runtime.fatal
-// on OS entropy failure rather than returning an error, but the error return
-// keeps callers honest if that contract changes.
+// NewUUID generates a UUID v4 string from crypto/rand.Reader via io.ReadFull.
+// In Go 1.24+ crypto/rand.Reader.Read calls runtime.fatal on OS entropy
+// failure rather than returning an error, so the error return is unreachable
+// for the production path; keeping it surfaces a future stdlib contract
+// change rather than swallowing it.
 func NewUUID() (string, error) { return newUUID(rand.Reader) }
 
 func newUUID(r io.Reader) (string, error) {

--- a/pkg/idutil/id_test.go
+++ b/pkg/idutil/id_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errEntropyFailedForTest = errors.New("idutil_test: entropy stub failure")
+var errUUIDEntropyFailedForTest = errors.New("idutil_test: uuid entropy stub failure")
 
-type failingReader struct{}
+type failingUUIDReader struct{}
 
-func (failingReader) Read([]byte) (int, error) { return 0, errEntropyFailedForTest }
+func (failingUUIDReader) Read([]byte) (int, error) { return 0, errUUIDEntropyFailedForTest }
 
 func TestNewUUID_RandFailure(t *testing.T) {
-	id, err := newUUID(failingReader{})
+	id, err := newUUID(failingUUIDReader{})
 	require.Error(t, err)
 	assert.Empty(t, id)
-	assert.ErrorIs(t, err, errEntropyFailedForTest)
+	assert.ErrorIs(t, err, errUUIDEntropyFailedForTest)
 	assert.ErrorContains(t, err, "idutil: read entropy")
 }
 

--- a/pkg/idutil/id_test.go
+++ b/pkg/idutil/id_test.go
@@ -1,12 +1,27 @@
 package idutil
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var errEntropyFailedForTest = errors.New("idutil_test: entropy stub failure")
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errEntropyFailedForTest }
+
+func TestNewUUID_RandFailure(t *testing.T) {
+	id, err := newUUID(failingReader{})
+	require.Error(t, err)
+	assert.Empty(t, id)
+	assert.ErrorIs(t, err, errEntropyFailedForTest)
+	assert.ErrorContains(t, err, "idutil: read entropy")
+}
 
 func TestIsSafeID(t *testing.T) {
 	tests := []struct {

--- a/runtime/distlock/token.go
+++ b/runtime/distlock/token.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 )
 
 // randomToken generates a cryptographically secure random hex string suitable
@@ -11,10 +12,12 @@ import (
 // so the token generation strategy is independent of the backend adapter.
 //
 // ref: adapters/redis/distlock.go randomToken — identical algorithm, hoisted up
-func randomToken() (string, error) {
+func randomToken() (string, error) { return randomTokenFrom(rand.Reader) }
+
+func randomTokenFrom(r io.Reader) (string, error) {
 	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("distlock: random token generation failed: %w", err)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return "", fmt.Errorf("distlock: read entropy: %w", err)
 	}
 	return hex.EncodeToString(b), nil
 }

--- a/runtime/distlock/token.go
+++ b/runtime/distlock/token.go
@@ -12,9 +12,9 @@ import (
 // so the token generation strategy is independent of the backend adapter.
 //
 // ref: adapters/redis/distlock.go randomToken — identical algorithm, hoisted up
-func randomToken() (string, error) { return randomTokenFrom(rand.Reader) }
+func randomToken() (string, error) { return newRandomToken(rand.Reader) }
 
-func randomTokenFrom(r io.Reader) (string, error) {
+func newRandomToken(r io.Reader) (string, error) {
 	b := make([]byte, 32)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return "", fmt.Errorf("distlock: read entropy: %w", err)

--- a/runtime/distlock/token_internal_test.go
+++ b/runtime/distlock/token_internal_test.go
@@ -8,16 +8,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errEntropyFailedForTest = errors.New("distlock_test: entropy stub failure")
+var errRandomTokenEntropyFailedForTest = errors.New("distlock_test: random-token entropy stub failure")
 
-type failingReader struct{}
+type failingRandomTokenReader struct{}
 
-func (failingReader) Read([]byte) (int, error) { return 0, errEntropyFailedForTest }
+func (failingRandomTokenReader) Read([]byte) (int, error) {
+	return 0, errRandomTokenEntropyFailedForTest
+}
 
 func TestRandomToken_RandFailure(t *testing.T) {
-	tok, err := randomTokenFrom(failingReader{})
+	tok, err := newRandomToken(failingRandomTokenReader{})
 	require.Error(t, err)
 	assert.Empty(t, tok)
-	assert.ErrorIs(t, err, errEntropyFailedForTest)
+	assert.ErrorIs(t, err, errRandomTokenEntropyFailedForTest)
 	assert.ErrorContains(t, err, "distlock: read entropy")
 }

--- a/runtime/distlock/token_internal_test.go
+++ b/runtime/distlock/token_internal_test.go
@@ -1,0 +1,23 @@
+package distlock
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errEntropyFailedForTest = errors.New("distlock_test: entropy stub failure")
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errEntropyFailedForTest }
+
+func TestRandomToken_RandFailure(t *testing.T) {
+	tok, err := randomTokenFrom(failingReader{})
+	require.Error(t, err)
+	assert.Empty(t, tok)
+	assert.ErrorIs(t, err, errEntropyFailedForTest)
+	assert.ErrorContains(t, err, "distlock: read entropy")
+}


### PR DESCRIPTION
## Summary

5 production functions wrapped `crypto/rand.Read` failures into error returns but no regression test exercised the failure branch. The wrap is unreachable under Go 1.24+ stdlib (entropy failure calls `runtime.fatal`) but is kept deliberately so callers stay honest if that contract changes. This PR makes the branch testable + adds the 5 tests.

Refactored each site to thread an unexported `io.Reader` via a helper; public signatures preserved.

| Site | Before | After |
|------|--------|-------|
| `pkg/idutil.NewUUID` | `rand.Read(buf)` | `newUUID(rand.Reader)` → `io.ReadFull(r, buf)` |
| `kernel/outbox.NewEntryID` | `rand.Read(b)` | `newEntryID(rand.Reader)` → `io.ReadFull(r, b)` |
| `runtime/distlock.randomToken` | `rand.Read(b)` | `randomTokenFrom(rand.Reader)` → `io.ReadFull(r, b)` |
| `adapters/redis.claimToken` | `rand.Read(b)` (bare err) | `claimTokenFrom(rand.Reader)` → wrap `redis: read entropy: %w` |
| `adapters/postgres.commandQueueNewID` | `rand.Read(b)` | `commandQueueNewIDFrom(rand.Reader)` → wrap `command_queue: read entropy: %w` |

Error wraps normalized to `"<pkg>: read entropy: %w"` (was `"crypto/rand.Read"` — lied once we went through `io.ReadFull`). `claimToken` now wraps where it previously returned bare error.

ref: `adapters/postgres/refresh_store.go` / `runtime/auth/refresh/memstore/store.go` (existing constructor-injected `io.Reader` pattern in this repo).

Closes #23, #720.

## Implementation matrix

```
Contract:        crypto/rand.Read failure branch in 5 production generators
Change:          thread io.Reader through unexported newXxx helper; uniform error wrap
Implementations: [x] pkg/idutil  [x] kernel/outbox  [x] runtime/distlock  [x] adapters/redis  [x] adapters/postgres
Conformance:     5 new tests, 1 per site (see below)
Repro:           go test -run 'RandFailure' ./pkg/idutil/... ./kernel/outbox/... ./runtime/distlock/... ./adapters/redis/... ./adapters/postgres/...
Dependent contracts: none
```

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags=integration ./...` clean
- [x] `go test ./pkg/idutil/... ./kernel/outbox/... ./runtime/distlock/... ./adapters/redis/... ./adapters/postgres/...` — all 5 new tests pass, no regression in existing tests
- [x] `golangci-lint run --new-from-rev=origin/develop ./...` — 0 issues
- [x] PR-time archtest gate (`hack/verify-archtest-invariants.sh`) — pass
- [x] Mutation check: deleting the `if err != nil { return ... }` block in any `newXxx` helper makes the corresponding `*_RandFailure` test fail (verified locally)

Note: 9 archtests fail on this branch — same 9 fail on `develop`, pre-existing nightly-only failures unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)