### PR TITLE
feat(metadata): cell.requires single-source → derive assembly capabilities (#855)

### DIFF
--- a/assemblies/corebundle/assembly.yaml
+++ b/assemblies/corebundle/assembly.yaml
@@ -6,6 +6,3 @@ cells:
 owner:
   team: platform-core
   role: maintainer
-capabilities:
-  - postgres
-  - redis

--- a/cells/accesscore/cell.yaml
+++ b/cells/accesscore/cell.yaml
@@ -12,3 +12,6 @@ verify:
     - smoke.accesscore.startup
 goStructName: AccessCore
 l0Dependencies: []
+requires:
+  - postgres
+  - redis

--- a/cells/accesscore/cell_gen.go
+++ b/cells/accesscore/cell_gen.go
@@ -32,6 +32,10 @@ var cellMeta = &metadata.CellMeta{
 		"smoke.accesscore.startup",
 	}},
 	GoStructName: metadata.MustNewGoIdentifier("AccessCore"),
+	Requires: []string{
+		"postgres",
+		"redis",
+	},
 }
 
 func loadCellMetadata() *metadata.CellMeta { return cellMeta.Clone() }

--- a/cells/auditcore/cell.yaml
+++ b/cells/auditcore/cell.yaml
@@ -12,3 +12,5 @@ verify:
     - smoke.auditcore.startup
 goStructName: AuditCore
 l0Dependencies: []
+requires:
+  - postgres

--- a/cells/auditcore/cell_gen.go
+++ b/cells/auditcore/cell_gen.go
@@ -41,6 +41,9 @@ var cellMeta = &metadata.CellMeta{
 		"smoke.auditcore.startup",
 	}},
 	GoStructName: metadata.MustNewGoIdentifier("AuditCore"),
+	Requires: []string{
+		"postgres",
+	},
 }
 
 func loadCellMetadata() *metadata.CellMeta { return cellMeta.Clone() }

--- a/cells/configcore/cell.yaml
+++ b/cells/configcore/cell.yaml
@@ -12,3 +12,5 @@ verify:
     - smoke.configcore.startup
 goStructName: ConfigCore
 l0Dependencies: []
+requires:
+  - postgres

--- a/cells/configcore/cell_gen.go
+++ b/cells/configcore/cell_gen.go
@@ -30,6 +30,9 @@ var cellMeta = &metadata.CellMeta{
 		"smoke.configcore.startup",
 	}},
 	GoStructName: metadata.MustNewGoIdentifier("ConfigCore"),
+	Requires: []string{
+		"postgres",
+	},
 }
 
 func loadCellMetadata() *metadata.CellMeta { return cellMeta.Clone() }

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -41,6 +41,12 @@ func pgxPoolFromProvider(pg capability.PGProvider) (*pgxpool.Pool, error) {
 // the providers are present (or fail-fast) before any module.Provide runs —
 // mirroring fx.New()'s resolve-before-start ordering (ref: uber-go/fx app.go).
 func provisionCapabilities(ctx context.Context, shared *SharedDeps) error {
+	// INVARIANT: generatedCapabilities() exists because the corebundle assembly's
+	// cells declare a non-empty `requires` union (auditcore/configcore require
+	// postgres). The codegen template emits generatedCapabilities() iff that union
+	// is non-empty — so this unconditional call is only safe while corebundle keeps
+	// provisioning ≥1 capability. A hypothetical zero-capability corebundle would
+	// not need a provisioner at all; this function would then be removed alongside.
 	for _, c := range generatedCapabilities() {
 		switch c {
 		case capability.Postgres:
@@ -50,10 +56,13 @@ func provisionCapabilities(ctx context.Context, shared *SharedDeps) error {
 		case capability.Redis:
 			provisionRedis(shared)
 		default:
-			// Unreachable: FMT-36 governance (cell.yaml requires ∈ CapabilityEnum) +
-			// the generator's capabilityConstNames guard reject unknown values, and
-			// generatedCapabilities() is codegen-derived from the validated set.
-			// Defense-in-depth only.
+			// Reached when a cell requires a capability that is a recognized enum
+			// member but has no provisioning path here — today only rabbitmq (it is
+			// in CapabilityEnum + capabilityConstNames, so it passes FMT-36 + codegen,
+			// but provisionCapabilities has no rabbitmq case). By-design fail-fast:
+			// a real provider must land its provisioning atomically. Truly unknown
+			// values are already rejected upstream by FMT-36 + the codegen guard.
+			// See runtime/capability.RabbitMQ.
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 				"corebundle: declared capability has no provisioning path",
 				errcode.WithInternal(fmt.Sprintf("capability=%q", string(c))))

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -30,7 +30,8 @@ func pgxPoolFromProvider(pg capability.PGProvider) (*pgxpool.Pool, error) {
 // downstream allowlist locks construction to this file.
 //
 // It iterates the codegen-declared generatedCapabilities() (single source:
-// assemblies/corebundle/assembly.yaml `capabilities`), and for each declared
+// the derived union of the assembly cells' cell.yaml `requires`, computed in
+// kernel/assembly.GenerateModulesGen), and for each declared
 // capability provisions the shared resource exactly once and wraps it into the
 // sealed runtime/capability provider stored on shared. Consuming cell modules receive
 // the injected provider (shared.PG / shared.Redis) and never construct adapter
@@ -49,9 +50,10 @@ func provisionCapabilities(ctx context.Context, shared *SharedDeps) error {
 		case capability.Redis:
 			provisionRedis(shared)
 		default:
-			// Unreachable: FMT-36 governance + assembly.schema.json enum reject
-			// unknown capabilities, and generatedCapabilities() is codegen-derived
-			// from the validated set. Defense-in-depth only.
+			// Unreachable: FMT-36 governance (cell.yaml requires ∈ CapabilityEnum) +
+			// the generator's capabilityConstNames guard reject unknown values, and
+			// generatedCapabilities() is codegen-derived from the validated set.
+			// Defense-in-depth only.
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 				"corebundle: declared capability has no provisioning path",
 				errcode.WithInternal(fmt.Sprintf("capability=%q", string(c))))

--- a/cmd/corebundle/modules_gen.go
+++ b/cmd/corebundle/modules_gen.go
@@ -15,7 +15,9 @@ func generatedCellModules() []CellModule {
 // generatedCapabilities lists the assembly-level shared infrastructure
 // capabilities — the sorted union of the assembly cells' cell.yaml `requires`.
 // The composition root provisions each once and injects the resulting
-// runtime/capability provider into consuming modules.
+// runtime/capability provider into consuming modules. Emitted iff the union is
+// non-empty: an assembly whose cells require nothing has no provisioner to call
+// it, so the function (and its capability import) are omitted to avoid dead code.
 func generatedCapabilities() []capability.Kind {
 	return []capability.Kind{
 		capability.Postgres,

--- a/cmd/corebundle/modules_gen.go
+++ b/cmd/corebundle/modules_gen.go
@@ -13,8 +13,9 @@ func generatedCellModules() []CellModule {
 }
 
 // generatedCapabilities lists the assembly-level shared infrastructure
-// capabilities declared in assembly.yaml. The composition root provisions each
-// once and injects the resulting runtime/capability provider into consuming modules.
+// capabilities — the sorted union of the assembly cells' cell.yaml `requires`.
+// The composition root provisions each once and injects the resulting
+// runtime/capability provider into consuming modules.
 func generatedCapabilities() []capability.Kind {
 	return []capability.Kind{
 		capability.Postgres,

--- a/cmd/gocell/app/codegen_assembly_cmd.go
+++ b/cmd/gocell/app/codegen_assembly_cmd.go
@@ -34,7 +34,7 @@ var assemblyCodegenSpec = codegenSpec[assemblyDriftResult]{
 	GenerateUsage:   "gocell generate assembly --id=<assemblyID> | --all",
 	AllFlagDesc:     "regenerate modules_gen.go for all assemblies (cells>0)",
 	PluralNoun:      "assembly modules_gen.go",
-	SourceArtifacts: "assembly.yaml / cell.yaml goStructName",
+	SourceArtifacts: "assembly.yaml / cell.yaml goStructName + requires",
 	Generate:        generateAssemblyModulesGen,
 }
 

--- a/cmd/gocell/app/verify.go
+++ b/cmd/gocell/app/verify.go
@@ -90,9 +90,10 @@ var verifySubcommands = []subcommand[func(ctx context.Context, args []string) er
 	{
 		name: "codegen-assembly",
 		help: []string{
-			"Verify cmd/*/modules_gen.go are in sync with assembly.yaml /",
-			"cell.yaml goStructName. Default --local in-place verify (fast).",
-			"CI: pass --local=false for git worktree sandbox.",
+			"Verify cmd/*/modules_gen.go are in sync with assembly.yaml +",
+			"cell.yaml goStructName/requires (generatedCapabilities() derives",
+			"from the union of cells' requires). Default --local in-place verify",
+			"(fast). CI: pass --local=false for git worktree sandbox.",
 		},
 		run: runVerifyCodegenAssembly,
 	},

--- a/docs/architecture/202605251500-adr-capability-provider-interface.md
+++ b/docs/architecture/202605251500-adr-capability-provider-interface.md
@@ -6,6 +6,36 @@
 - **来源路线**：`docs/plans/framework-capability-gaps/202605221303-006-spring-comparison-and-simplification-roadmap.md` §4 P0-1
 - **相关**：#855（P0-2，复用本接口）；ADR `202605201400-adr-relay-managedresource-isolation.md`（relay 归属不变）
 
+## Amendment 2026-05-26（#855 Design Y：capability 声明源翻转）
+
+#855 落地把 capability 的**声明源**从手写 `assembly.yaml capabilities` 翻转为 per-cell
+`cell.yaml requires`：assembly 的 provision 集是其 cells `requires` 的**排序去重 union**，由
+`kernel/assembly.GenerateModulesGen` 派生进 `modules_gen.go`。删 `AssemblyMeta.Capabilities`
++ `assembly.yaml capabilities` property + assembly#CapabilityEnum schema 测试；enum 镜像移到
+`cell.schema.json requires`。FMT-36 从校验 `assembly.capabilities` repurpose 为校验 per-cell
+`requires`（well-formedness：known + 无重复）。
+
+**与本 ADR §1「为什么不是 per-cell」的关系——不矛盾**：§1 拒绝的是 per-cell **provisioning**
+（每个 cell 自开 pool，破坏单池 + LIFO + 单 outbox/relay）。Design Y **不动 provisioning 模型**
+——`provisionCapabilities` 仍在 assembly 级把每个 capability provision 恰好一次（单池、LIFO 不变）。
+变的只是 capability **集合的声明源**：从「composition root 作者手写一份 assembly 列表」改为
+「每个 cell 声明自己消费什么，assembly 集由 union 派生」。声明源单源化消除了「cell 用 PG 但 assembly
+忘记声明」这一类 drift（漏声明 → 不入 union → 不 provision → cell nil-guard fail-fast），且兑现
+本 ADR §3 在 `runtime/capability/capability.go` 留下的 `requires` forward-reference。原 §1 末段
+「per-cell `requires:[postgres]` 让每个 cell 自开 pool」已就地改写以区分「声明源 per-cell」与
+「provisioning per-cell」。
+
+**Enforcement 矩阵逐行重评（无 ✅→⚠️/❌ 降级）**：
+
+| # | amendment 后 | 评级变化 |
+|---|------|---------|
+| 1 | FMT-36 校验对象 `assembly.capabilities` → **per-cell `cell.requires`**；schema 镜像移到 `cell.schema.json`；**新增** `TestCapabilityConstNamesMatchCapabilityEnum` 锁 `capabilityConstNames` key 集 == `CapabilityEnum`（补此前 codegen const-name 表与 enum 无守卫的盲区）| Medium 不变（守卫增强）|
+| 2 | golden 派生源 `assembly.yaml` → **∪cells.requires**；`gocell generate assembly` regenerate-and-diff 字节锁不变 | Hard 不变 |
+| 3 | sealed construction（provider 不可伪造）| Hard 不变，无关本 amendment |
+| 4 | CAPABILITY-PROVIDER-FUNNEL-01 caller-allowlist | Medium 不变，无关本 amendment |
+
+机制 3+4 的 Hard 上游 + Medium 下游过渡形态（gh #988 跟踪 Hard 化）不受本 amendment 影响。
+
 ## Context
 
 composition root（`cmd/corebundle/*_module.go`）的 infra wiring 全手写。三个平台 cell 在 postgres 模式各自从一个共享 pool 派生 `adapterpg.NewTxManager` / `NewOutboxWriter` / `pool.DB()`，pool 由 configcore 创建后经 `SharedDeps.SharedPGPool` publish-back 给 access/audit。这套耦合带来：
@@ -24,7 +54,7 @@ P0-1 目标：把 adapter 派生胶水收口到标准 capability provider，comp
 
 capability 是 **assembly 一次性 provision、注入消费 cell** 的共享资源，**不是** per-cell 构造。这对齐编译期 DI（Wire/Dagger）/ uber-fx `fx.Supply`——共享值 provision 一次，多 module 消费。pool 生命周期（open/close、ManagedResource、LIFO teardown）由 assembly composition root 持有。
 
-**为什么不是 per-cell**：per-cell `requires:[postgres]` 让每个 cell 自开 pool，破坏单 pool + LIFO shutdown，且与"一个 outbox 表 / 一个 relay"矛盾。共享资源天然是 assembly 级。
+**为什么 provisioning 不是 per-cell**：per-cell **provisioning**（每个 cell 自开 pool）破坏单 pool + LIFO shutdown，且与"一个 outbox 表 / 一个 relay"矛盾。共享资源天然是 assembly 级一次性 provision。（注：#855 Design Y 后 capability **声明源**是 per-cell `cell.yaml requires`，assembly 集由 union 派生——但 **provisioning 仍 assembly 级单次**，与此处结论一致；详见顶部 Amendment 2026-05-26。）
 
 ### 2. 接口 + sealed 构造（`runtime/capability/capability.go`，仅 import kernel/ + pkg/）
 
@@ -67,7 +97,7 @@ pg := capability.NewPGProvider(adapterpg.NewTxManager(pool), adapterpg.NewOutbox
 
 ### 3. SharedDeps：删 `SharedPGPool`，加 `PG`/`Redis` capability handle
 
-- `runCorebundle` 在 `LoadSharedDepsFromEnv` 之后、`BuildApp` 之前调用 `provisionCapabilities`（`cap_wiring.go`），遍历 codegen 派生的 `generatedCapabilities()`（单源 = `assembly.yaml capabilities:[]`）逐项 provision：postgres 模式下 open pool + `verifyPGPreconditions`（schema version / shape / invalid-index——用 bundle-global `adapterpg.MigrationsFS()`，本就是整 bundle 的共享迁移集，非 configcore 私有）+ 构造 `capability.PGProvider` 写 `SharedDeps.PG`；redis 包装 `buildSharedReplayDeps` 已建的 client 写 `SharedDeps.Redis`（client 本身仍在 `buildSharedReplayDeps` 构造，claimer/nonce 同源）。memory 模式 `SharedDeps.PG` 保持 nil，cell 走 in-memory 路径。
+- `runCorebundle` 在 `LoadSharedDepsFromEnv` 之后、`BuildApp` 之前调用 `provisionCapabilities`（`cap_wiring.go`），遍历 codegen 派生的 `generatedCapabilities()`（单源 = cells 的 `cell.yaml requires` union，#855 Design Y；见顶部 Amendment）逐项 provision：postgres 模式下 open pool + `verifyPGPreconditions`（schema version / shape / invalid-index——用 bundle-global `adapterpg.MigrationsFS()`，本就是整 bundle 的共享迁移集，非 configcore 私有）+ 构造 `capability.PGProvider` 写 `SharedDeps.PG`；redis 包装 `buildSharedReplayDeps` 已建的 client 写 `SharedDeps.Redis`（client 本身仍在 `buildSharedReplayDeps` 构造，claimer/nonce 同源）。memory 模式 `SharedDeps.PG` 保持 nil，cell 走 in-memory 路径。
 - **删** `SharedDeps.SharedPGPool *adapterpg.Pool`（+ `RedisClient` 公开字段，改 `Redis capability.RedisProvider` + unexported `redisClient`）。
 - pool 的 `ManagedResource`（`SharedDeps.poolMR`）由 `runtimeBaseOptions`（`defaultRuntimeOptions` 的一部分，先于 cellOpts append）注册 → LIFO 下 pool 最后 close（晚于所有 consumer）。`provisionCapabilities` 与 `bootstrap.Run` 之间的失败窗口由 `runCorebundle` 的 `handedToBootstrap` defer 守卫关池。
 - **删** `MODULE-ORDER-CONFIGCORE-FIRST-01`（`tools/archtest/module_order_test.go`）+ `main_test.go:65` 断言：前提（configcore 创建 pool）消失。
@@ -85,8 +115,8 @@ pg := capability.NewPGProvider(adapterpg.NewTxManager(pool), adapterpg.NewOutbox
 
 | # | 约束 | 载体 | 评级 |
 |---|------|------|------|
-| 1 | `assembly.yaml capabilities` ∈ 封闭集 `{postgres,redis,rabbitmq}`、无重复 | `gocell validate` governance rule **FMT-36** + 单源 `metadata.CapabilityEnum` + `IsKnownCapability`；schema enum 由 `TestSchemaConstantsMatchSchemaLiterals` 字节对齐 | **Medium**（governance rule + 测试守卫；3 值封闭集不值得引 codegen funnel——K8s 旧 enum 模式同构，校验落 admission 层而非 parser） |
-| 2 | `modules_gen.go`（含 `generatedCapabilities()`）= `assembly.yaml` 派生 | `gocell verify codegen-assembly` regenerate-and-diff 字节锁 | **Hard**（codegen funnel + golden；既有机制，现覆盖 capabilities 分支） |
+| 1 | per-cell `cell.requires` ∈ 封闭集 `{postgres,redis,rabbitmq}`、无重复（#855 Design Y；原 `assembly.capabilities`）| `gocell validate` governance rule **FMT-36** + 单源 `metadata.CapabilityEnum` + `IsKnownCapability`；schema enum（`cell.schema.json requires`）由 `TestSchemaConstantsMatchSchemaLiterals` 字节对齐；`capabilityConstNames` key 集由 `TestCapabilityConstNamesMatchCapabilityEnum` 锁到 enum | **Medium**（governance rule + 测试守卫；3 值封闭集不值得引 codegen funnel——K8s 旧 enum 模式同构，校验落 admission 层而非 parser） |
+| 2 | `modules_gen.go`（含 `generatedCapabilities()`）= **∪cells.requires** 派生（#855 Design Y）| `gocell generate assembly` regenerate-and-diff 字节锁 | **Hard**（codegen funnel + golden；既有机制，现覆盖派生 capabilities 分支） |
 | 3 | cell module 不能伪造 bypass provider | `capability.PGProvider`/`RedisProvider` sealed（unexported marker + 私有 impl + 唯一构造 `capability.NewPGProvider`/`NewRedisProvider`），包外不可表达 | **Hard**（sealed construction，type system） |
 | 4 | `cmd/<id>/*_module.go` 不直接构造**共享基建** | archtest **CAPABILITY-PROVIDER-FUNNEL-01**（`tools/archtest/capability_provider_funnel_test.go`）：ban `adapterpg.NewPool`/`NewTxManager`/`NewOutboxWriter` + `adapterredis.NewClient`，caller allowlist = `cmd/corebundle/cap_wiring.go` + `_test.go`；**不 ban** per-cell 派生（`NewSessionStore`/`NewCache`/`NewRedisDriver`/…，从注入 handle 构造，CLAUDE.md observability §per-cell 资源约定）；镜像 `CAS-PROTOCOL-COMPOSITION-ROOT-01` | **Medium**（type-aware caller-allowlist，非编译期） |
 

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -116,12 +116,14 @@ type modulesContext struct {
 	Capabilities []string
 }
 
-// capabilityConstNames maps assembly.yaml `capabilities` enum values to their
+// capabilityConstNames maps cell.yaml `requires` enum values to their
 // runtime/capability.Kind const identifiers. The enum is closed and mirrored by
-// assembly.schema.json + runtime/capability.Kind; an unknown value here means
-// the schema enum and this map drifted — GenerateModulesGen fails rather than
-// emit an undefined const (the FMT-36 validation in gocell validate is the
-// primary upstream gate).
+// metadata.CapabilityEnum + cell.schema.json + runtime/capability.Kind;
+// TestCapabilityConstNamesMatchCapabilityEnum locks this map's key set to
+// metadata.CapabilityEnum so adding a capability to the enum without a const
+// mapping (or vice versa) fails in CI. An unknown value reaching here means that
+// guard was bypassed — GenerateModulesGen fails rather than emit an undefined
+// const (the FMT-36 validation in gocell validate is the primary upstream gate).
 var capabilityConstNames = map[string]string{
 	"postgres": "Postgres",
 	"redis":    "Redis",
@@ -230,6 +232,11 @@ func (g *Generator) GenerateBoundary(assemblyID string) ([]byte, error) {
 // Each cell must have GoStructName set (cell.yaml schema extension consumed
 // by codegen). The generated factory references {GoStructName}Module by
 // convention; the *Module struct is hand-written in cmd/{assemblyID}/.
+//
+// generatedCapabilities() is the sorted, de-duplicated union of the assembly
+// cells' cell.yaml `requires` (Design Y, #855). Changing a cell's `requires`
+// therefore requires re-running `gocell generate assembly` to refresh
+// modules_gen.go; `--verify` catches stale output in CI.
 func (g *Generator) GenerateModulesGen(assemblyID string) ([]byte, error) {
 	asm := g.project.Assemblies[assemblyID]
 	if asm == nil {

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -109,10 +109,10 @@ type modulesContext struct {
 	SourcePath string   // path to the assembly.yaml that drove generation (asm.File)
 	Modules    []string // CellModule struct names, in cells.yaml order
 	// Capabilities are runtime/capability.Kind const names (e.g. "Postgres"),
-	// derived from assembly.yaml `capabilities`. When non-empty the template
-	// emits generatedCapabilities() + the capability import; empty leaves the
-	// file byte-identical to the pre-capabilities form so assemblies that declare
-	// no capabilities are unaffected.
+	// the sorted de-duplicated union of the assembly cells' cell.yaml `requires`
+	// (Design Y, #855). When non-empty the template emits generatedCapabilities()
+	// + the capability import; empty leaves the file byte-identical to the
+	// pre-capabilities form so assemblies whose cells require nothing are unaffected.
 	Capabilities []string
 }
 
@@ -239,6 +239,7 @@ func (g *Generator) GenerateModulesGen(assemblyID string) ([]byte, error) {
 	}
 
 	modules := make([]string, 0, len(asm.Cells))
+	capSet := make(map[string]struct{})
 	for _, cellID := range asm.Cells {
 		cm := g.cells.Get(cellID)
 		if cm == nil {
@@ -252,14 +253,26 @@ func (g *Generator) GenerateModulesGen(assemblyID string) ([]byte, error) {
 				errcode.WithInternal(fmt.Sprintf("assembly=%q cell=%q", assemblyID, cellID)))
 		}
 		modules = append(modules, cm.GoStructName.String()+"Module")
+		for _, c := range cm.Requires {
+			capSet[c] = struct{}{}
+		}
 	}
 
-	capConsts := make([]string, 0, len(asm.Capabilities))
-	for _, c := range asm.Capabilities {
+	// Design Y (#855): the assembly's provisioned capability set is the sorted,
+	// de-duplicated union of its cells' `requires` — the single source. Sorting
+	// makes generatedCapabilities() deterministic regardless of cell iteration
+	// or per-cell requires declaration order.
+	requiredCaps := make([]string, 0, len(capSet))
+	for c := range capSet {
+		requiredCaps = append(requiredCaps, c)
+	}
+	sort.Strings(requiredCaps)
+	capConsts := make([]string, 0, len(requiredCaps))
+	for _, c := range requiredCaps {
 		name, ok := capabilityConstNames[c]
 		if !ok {
 			return nil, errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
-				"assembly declares an unknown capability",
+				"cell declares an unknown capability in requires",
 				errcode.WithInternal(fmt.Sprintf("assembly=%q capability=%q", assemblyID, c)))
 		}
 		capConsts = append(capConsts, name)

--- a/kernel/assembly/generator_modulesgen_test.go
+++ b/kernel/assembly/generator_modulesgen_test.go
@@ -66,10 +66,11 @@ func TestGenerateModulesGen_Corebundle(t *testing.T) {
 	assert.Contains(t, content, "AccessCoreModule{}")
 	assert.Contains(t, content, "AuditCoreModule{}")
 	assert.Contains(t, content, "ConfigCoreModule{}")
-	// Empty-capabilities path is byte-inert: no capability import, no
-	// generatedCapabilities(). Locks the {{- if .Capabilities}} else-branch so
-	// assemblies that declare no capabilities stay identical to the
-	// pre-capabilities form.
+	// Empty union (no cell declares requires) is byte-inert: no capability import,
+	// no generatedCapabilities(). The function is emitted iff the union is
+	// non-empty — an assembly whose cells require nothing has no provisioner to
+	// call it, so emitting a dead generatedCapabilities() (+ unused-looking import)
+	// would only pollute non-provisioning assemblies (e.g. examples). #855 F2.
 	assert.NotContains(t, content, "runtime/capability")
 	assert.NotContains(t, content, "generatedCapabilities")
 }

--- a/kernel/assembly/generator_modulesgen_test.go
+++ b/kernel/assembly/generator_modulesgen_test.go
@@ -73,12 +73,18 @@ func TestGenerateModulesGen_Corebundle(t *testing.T) {
 	assert.NotContains(t, content, "generatedCapabilities")
 }
 
-// TestGenerateModulesGen_Capabilities exercises the non-empty capabilities
-// branch: the template must emit the capability import + generatedCapabilities()
-// with one capability.Kind const per declared capability, in declaration order.
-func TestGenerateModulesGen_Capabilities(t *testing.T) {
+// TestGenerateModulesGen_DerivesCapabilitiesFromCellRequires exercises the
+// non-empty branch under Design Y (#855): the assembly capability set is the
+// sorted, de-duplicated union of its cells' `requires`. Input order is
+// irrelevant (sorted output) and a capability required by multiple cells emits
+// exactly one const (dedup).
+func TestGenerateModulesGen_DerivesCapabilitiesFromCellRequires(t *testing.T) {
 	project := buildModulesTestProject()
-	project.Assemblies["corebundle"].Capabilities = []string{"postgres", "redis"}
+	// Unsorted input + cross-cell duplicate of postgres → output must be the
+	// sorted union {postgres, redis} with postgres emitted once.
+	project.Cells["accesscore"].Requires = []string{"redis", "postgres"}
+	project.Cells["auditcore"].Requires = []string{"postgres"}
+	project.Cells["configcore"].Requires = []string{"postgres"}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 
 	out, err := gen.GenerateModulesGen("corebundle")
@@ -89,21 +95,24 @@ func TestGenerateModulesGen_Capabilities(t *testing.T) {
 	assert.Contains(t, content, "func generatedCapabilities() []capability.Kind")
 	assert.Contains(t, content, "capability.Postgres")
 	assert.Contains(t, content, "capability.Redis")
-	// Declaration order is preserved (postgres before redis).
+	// Deterministic alphabetical order regardless of per-cell input order.
 	assert.Less(t,
 		indexOfStr(content, "capability.Postgres"),
 		indexOfStr(content, "capability.Redis"),
-		"capabilities must appear in assembly.yaml declaration order")
+		"derived capabilities must be sorted (postgres before redis)")
+	// Dedup: postgres required by all three cells must appear exactly once.
+	assert.Equal(t, 1, strings.Count(content, "capability.Postgres"),
+		"postgres required by multiple cells must emit a single const")
 }
 
 // TestGenerateModulesGen_UnknownCapability verifies the codegen-time guard:
-// a capability value absent from capabilityConstNames fails with
+// a cell `requires` value absent from capabilityConstNames fails with
 // ErrMetadataInvalid rather than emitting an undefined capability const. The
 // closed enum's validation-time enforcement is FMT-36 (gocell validate); this
 // test only locks the generator's own fail-rather-than-emit-garbage behavior.
 func TestGenerateModulesGen_UnknownCapability(t *testing.T) {
 	project := buildModulesTestProject()
-	project.Assemblies["corebundle"].Capabilities = []string{"bogus-capability"}
+	project.Cells["accesscore"].Requires = []string{"bogus-capability"}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 
 	_, err := gen.GenerateModulesGen("corebundle")

--- a/kernel/assembly/generator_modulesgen_test.go
+++ b/kernel/assembly/generator_modulesgen_test.go
@@ -2,6 +2,7 @@ package assembly
 
 import (
 	"errors"
+	"sort"
 	"strings"
 	"testing"
 
@@ -103,6 +104,47 @@ func TestGenerateModulesGen_DerivesCapabilitiesFromCellRequires(t *testing.T) {
 	// Dedup: postgres required by all three cells must appear exactly once.
 	assert.Equal(t, 1, strings.Count(content, "capability.Postgres"),
 		"postgres required by multiple cells must emit a single const")
+}
+
+// TestCapabilityConstNamesMatchCapabilityEnum locks the capabilityConstNames
+// map key set to metadata.CapabilityEnum (single source). Adding a capability to
+// the enum without a matching const-name entry (or vice versa) fails here in CI,
+// closing the gap between the codegen const-name table and the
+// governance/schema enum that TestSchemaConstantsMatchSchemaLiterals already
+// pins to cell.schema.json.
+func TestCapabilityConstNamesMatchCapabilityEnum(t *testing.T) {
+	keys := make([]string, 0, len(capabilityConstNames))
+	for k, v := range capabilityConstNames {
+		assert.NotEmpty(t, v, "capabilityConstNames[%q] must map to a non-empty const name", k)
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	want := append([]string(nil), metadata.CapabilityEnum...)
+	sort.Strings(want)
+	assert.Equal(t, want, keys,
+		"capabilityConstNames key set must equal metadata.CapabilityEnum (single source)")
+}
+
+// TestGenerateModulesGen_RabbitMQAndSingle covers the single-capability path
+// (sort/dedup with len 1) and the rabbitmq → capability.RabbitMQ const mapping
+// — the enum member with no provider yet, whose codegen path is otherwise
+// uncovered. The generated const must still emit (provisioning fails later at
+// provisionCapabilities' default branch, by design).
+func TestGenerateModulesGen_RabbitMQAndSingle(t *testing.T) {
+	project := buildModulesTestProject()
+	project.Cells["accesscore"].Requires = []string{"rabbitmq"}
+	// auditcore / configcore leave Requires nil — union is the single {rabbitmq}.
+	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
+
+	out, err := gen.GenerateModulesGen("corebundle")
+	require.NoError(t, err)
+
+	content := string(out)
+	assert.Contains(t, content, "func generatedCapabilities() []capability.Kind")
+	assert.Contains(t, content, "capability.RabbitMQ")
+	assert.Equal(t, 1, strings.Count(content, "capability.RabbitMQ"))
+	assert.NotContains(t, content, "capability.Postgres")
+	assert.NotContains(t, content, "capability.Redis")
 }
 
 // TestGenerateModulesGen_UnknownCapability verifies the codegen-time guard:

--- a/kernel/assembly/gentpl/modules_gen.go.tpl
+++ b/kernel/assembly/gentpl/modules_gen.go.tpl
@@ -16,8 +16,9 @@ func generatedCellModules() []CellModule {
 {{- if .Capabilities}}
 
 // generatedCapabilities lists the assembly-level shared infrastructure
-// capabilities declared in assembly.yaml. The composition root provisions each
-// once and injects the resulting runtime/capability provider into consuming modules.
+// capabilities — the sorted union of the assembly cells' cell.yaml `requires`.
+// The composition root provisions each once and injects the resulting
+// runtime/capability provider into consuming modules.
 func generatedCapabilities() []capability.Kind {
 	return []capability.Kind{
 {{- range .Capabilities}}

--- a/kernel/assembly/gentpl/modules_gen.go.tpl
+++ b/kernel/assembly/gentpl/modules_gen.go.tpl
@@ -18,7 +18,9 @@ func generatedCellModules() []CellModule {
 // generatedCapabilities lists the assembly-level shared infrastructure
 // capabilities — the sorted union of the assembly cells' cell.yaml `requires`.
 // The composition root provisions each once and injects the resulting
-// runtime/capability provider into consuming modules.
+// runtime/capability provider into consuming modules. Emitted iff the union is
+// non-empty: an assembly whose cells require nothing has no provisioner to call
+// it, so the function (and its capability import) are omitted to avoid dead code.
 func generatedCapabilities() []capability.Kind {
 	return []capability.Kind{
 {{- range .Capabilities}}

--- a/kernel/assembly/synthesize_field_guard_test.go
+++ b/kernel/assembly/synthesize_field_guard_test.go
@@ -17,14 +17,11 @@ import (
 // fields have a synthesizable spec source. Future additions that genuinely
 // cannot be derived from AssemblyScaffoldSpec should add an entry with a
 // reason before the new field reaches AssemblyMeta.
-var synthesisFieldExemptions = map[string]string{
-	// capabilities is an opt-in assembly-level declaration added to an existing
-	// assembly.yaml after scaffolding (the operator decides which shared infra
-	// the assembly provisions). A freshly scaffolded assembly declares none, so
-	// synthesizeAssemblyMeta intentionally leaves it nil — the empty-capabilities
-	// path renders modules_gen.go byte-identically to the pre-capabilities form.
-	"capabilities": "opt-in post-scaffold declaration; new assemblies have none",
-}
+// Empty under the current implementation: every yaml-bearing AssemblyMeta field
+// is synthesizable from AssemblyScaffoldSpec. (The former "capabilities" entry
+// was removed with the field itself — Design Y, #855: the assembly capability
+// set is now derived from cells' requires, not an assembly-level field.)
+var synthesisFieldExemptions = map[string]string{}
 
 // TestAssemblyMetaSynthesisFieldGuard uses reflection to assert that
 // synthesizeAssemblyMeta populates every yaml-bearing field on

--- a/kernel/governance/rule_inventory_test.go
+++ b/kernel/governance/rule_inventory_test.go
@@ -126,7 +126,7 @@ func goldenRuleIDs() []string {
 		// FMT-35: subscribe CU field placement (handler required for subscribe;
 		// handler/group/field forbidden for non-subscribe roles).
 		"FMT-35",
-		// FMT-36: assembly.capabilities ∈ closed enum {postgres,redis,rabbitmq}, no dups.
+		// FMT-36: cell.requires ∈ closed enum {postgres,redis,rabbitmq}, no dups (Design Y, #855).
 		"FMT-36",
 		"FMT-A1", "FMT-C1",
 

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -1563,50 +1563,54 @@ func (v *Validator) validateFMT34() []ValidationResult {
 	return results
 }
 
-// validateFMT36 enforces that every assembly's capabilities list contains only
-// values from metadata.CapabilityEnum (closed enum: postgres, redis, rabbitmq)
-// and that no value appears more than once (uniqueItems). The schema literal at
-// schemas/assembly.schema.json properties.capabilities.items.enum is kept
-// byte-equal to metadata.CapabilityEnum by TestSchemaConstantsMatchSchemaLiterals;
-// governance is the sole runtime gatekeeper that rejects out-of-enum and
-// duplicate values.
+// validateFMT36 enforces that every cell's `requires` list contains only values
+// from metadata.CapabilityEnum (closed enum: postgres, redis, rabbitmq) and that
+// no value appears more than once (uniqueItems). cell.requires is the
+// authoritative single source from which an assembly's provisioned capability
+// set is derived (Design Y, #855); the schema literal at
+// schemas/cell.schema.json properties.requires.items.enum is kept byte-equal to
+// metadata.CapabilityEnum by TestSchemaConstantsMatchSchemaLiterals; governance
+// is the sole runtime gatekeeper that rejects out-of-enum and duplicate values.
 //
 // Without this rule, schema-aware tooling rejects unknown/duplicate values but
 // `gocell validate` accepts them, leaving CLI users with a different contract
 // than the schema declares. Mirrors the pattern established by validateFMT30
 // for build.deployTemplate.
+//
+// A subset check (requires ⊆ assembly.capabilities) is intentionally absent:
+// the assembly set is the union of cell requires, so subset holds structurally.
 func (v *Validator) validateFMT36() []ValidationResult {
 	var results []ValidationResult
-	for _, asm := range v.project.Assemblies {
-		if asm == nil {
+	for _, c := range v.project.Cells {
+		if c == nil {
 			continue
 		}
-		seen := make(map[string]bool, len(asm.Capabilities))
-		for i, cap := range asm.Capabilities {
-			field := fmt.Sprintf("capabilities[%d]", i)
+		seen := make(map[string]bool, len(c.Requires))
+		for i, cap := range c.Requires {
+			field := fmt.Sprintf("requires[%d]", i)
 			if !metadata.IsKnownCapability(cap) {
 				results = append(results, v.newError(
 					codeFMT36, IssueInvalid,
-					assemblyFile(asm),
+					cellFile(c),
 					field,
 					fmt.Sprintf(
-						"assembly %q capabilities[%d]=%q is not one of %v",
-						asm.ID, i, cap, metadata.CapabilityEnum,
+						"cell %q requires[%d]=%q is not one of %v",
+						c.ID, i, cap, metadata.CapabilityEnum,
 					),
-					"set capabilities items to one of the allowed values: postgres, redis, rabbitmq",
+					"set requires items to one of the allowed values: postgres, redis, rabbitmq",
 				))
 				continue
 			}
 			if seen[cap] {
 				results = append(results, v.newError(
 					codeFMT36, IssueDuplicate,
-					assemblyFile(asm),
+					cellFile(c),
 					field,
 					fmt.Sprintf(
-						"assembly %q capabilities[%d]=%q is a duplicate; each capability may appear at most once",
-						asm.ID, i, cap,
+						"cell %q requires[%d]=%q is a duplicate; each capability may appear at most once",
+						c.ID, i, cap,
 					),
-					"remove the duplicate capability entry",
+					"remove the duplicate requires entry",
 				))
 				continue
 			}

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -1527,56 +1527,60 @@ func collectFMT34Fields(matches []ValidationResult) map[string]bool {
 	return out
 }
 
-// --- FMT-36: assembly.capabilities must be known enum values, no duplicates ---
+// --- FMT-36: cell.requires must be known capability enum values, no duplicates ---
+//
+// Design Y (#855): capability dependency is declared per-cell via cell.yaml
+// `requires`; the assembly's provisioned capability set is the derived union.
+// FMT-36 validates the per-cell declaration (well-formedness), not an
+// assembly-level list.
 
-// buildFMT36Project returns a minimal ProjectMeta with one assembly whose
-// capabilities field is set to the given slice.
-func buildFMT36Project(capabilities []string) *metadata.ProjectMeta {
+// buildFMT36Project returns a minimal ProjectMeta with one cell whose
+// requires field is set to the given slice.
+func buildFMT36Project(requires []string) *metadata.ProjectMeta {
 	return &metadata.ProjectMeta{
-		Cells:     map[string]*metadata.CellMeta{},
-		Slices:    map[string]*metadata.SliceMeta{},
-		Contracts: map[string]*metadata.ContractMeta{},
-		Journeys:  map[string]*metadata.JourneyMeta{},
-		Assemblies: map[string]*metadata.AssemblyMeta{
-			"testasm": {
-				ID:           "testasm",
-				Cells:        []string{},
-				Capabilities: capabilities,
-				Owner:        metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
-				Dir:          "testasm",
-				File:         "assemblies/testasm/assembly.yaml",
+		Cells: map[string]*metadata.CellMeta{
+			"testcell": {
+				ID:       "testcell",
+				Requires: requires,
+				Owner:    metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+				Dir:      "testcell",
+				File:     "cells/testcell/cell.yaml",
 			},
 		},
+		Slices:     map[string]*metadata.SliceMeta{},
+		Contracts:  map[string]*metadata.ContractMeta{},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
 	}
 }
 
-// TestFMT36_ValidCapabilities verifies that a known subset produces 0 findings.
-func TestFMT36_ValidCapabilities(t *testing.T) {
+// TestFMT36_ValidRequires verifies that a known subset produces 0 findings.
+func TestFMT36_ValidRequires(t *testing.T) {
 	project := buildFMT36Project([]string{"postgres", "redis"})
 	v := NewValidator(project, "", clock.Real())
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 0 {
-		t.Fatalf("FMT-36: expected 0 findings for valid capabilities, got: %v", matches)
+		t.Fatalf("FMT-36: expected 0 findings for valid requires, got: %v", matches)
 	}
 }
 
-// TestFMT36_EmptyCapabilities verifies that an empty capabilities list is accepted.
-func TestFMT36_EmptyCapabilities(t *testing.T) {
+// TestFMT36_EmptyRequires verifies that an empty requires list is accepted.
+func TestFMT36_EmptyRequires(t *testing.T) {
 	project := buildFMT36Project([]string{})
 	v := NewValidator(project, "", clock.Real())
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 0 {
-		t.Fatalf("FMT-36: expected 0 findings for empty capabilities, got: %v", matches)
+		t.Fatalf("FMT-36: expected 0 findings for empty requires, got: %v", matches)
 	}
 }
 
-// TestFMT36_NilCapabilities verifies that a nil capabilities field is accepted.
-func TestFMT36_NilCapabilities(t *testing.T) {
+// TestFMT36_NilRequires verifies that a nil requires field is accepted.
+func TestFMT36_NilRequires(t *testing.T) {
 	project := buildFMT36Project(nil)
 	v := NewValidator(project, "", clock.Real())
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 0 {
-		t.Fatalf("FMT-36: expected 0 findings for nil capabilities, got: %v", matches)
+		t.Fatalf("FMT-36: expected 0 findings for nil requires, got: %v", matches)
 	}
 }
 
@@ -1586,44 +1590,44 @@ func TestFMT36_AllThree(t *testing.T) {
 	v := NewValidator(project, "", clock.Real())
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 0 {
-		t.Fatalf("FMT-36: expected 0 findings for all three capabilities, got: %v", matches)
+		t.Fatalf("FMT-36: expected 0 findings for all three requires, got: %v", matches)
 	}
 }
 
-// TestFMT36_UnknownCapability verifies that a single unknown value produces
-// exactly 1 error finding on field "capabilities[0]".
-func TestFMT36_UnknownCapability(t *testing.T) {
+// TestFMT36_UnknownRequires verifies that a single unknown value produces
+// exactly 1 error finding on field "requires[0]".
+func TestFMT36_UnknownRequires(t *testing.T) {
 	project := buildFMT36Project([]string{"foobar"})
 	v := NewValidator(project, "", clock.Real())
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 1 {
-		t.Fatalf("FMT-36: expected 1 finding for unknown capability, got %d: %v", len(matches), matches)
+		t.Fatalf("FMT-36: expected 1 finding for unknown requires, got %d: %v", len(matches), matches)
 	}
 	if matches[0].Severity != SeverityError {
 		t.Errorf("FMT-36: expected SeverityError, got %v", matches[0].Severity)
 	}
-	if matches[0].Field != "capabilities[0]" {
-		t.Errorf("FMT-36: expected Field=capabilities[0], got %q", matches[0].Field)
+	if matches[0].Field != "requires[0]" {
+		t.Errorf("FMT-36: expected Field=requires[0], got %q", matches[0].Field)
 	}
 	if matches[0].Fix == "" {
 		t.Errorf("FMT-36: Fix field must be non-empty")
 	}
 }
 
-// TestFMT36_DuplicateCapability verifies that a duplicate value produces
-// exactly 1 error finding on field "capabilities[1]".
-func TestFMT36_DuplicateCapability(t *testing.T) {
+// TestFMT36_DuplicateRequires verifies that a duplicate value produces
+// exactly 1 error finding on field "requires[1]".
+func TestFMT36_DuplicateRequires(t *testing.T) {
 	project := buildFMT36Project([]string{"postgres", "postgres"})
 	v := NewValidator(project, "", clock.Real())
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 1 {
-		t.Fatalf("FMT-36: expected 1 finding for duplicate capability, got %d: %v", len(matches), matches)
+		t.Fatalf("FMT-36: expected 1 finding for duplicate requires, got %d: %v", len(matches), matches)
 	}
 	if matches[0].Severity != SeverityError {
 		t.Errorf("FMT-36: expected SeverityError, got %v", matches[0].Severity)
 	}
-	if matches[0].Field != "capabilities[1]" {
-		t.Errorf("FMT-36: expected Field=capabilities[1], got %q", matches[0].Field)
+	if matches[0].Field != "requires[1]" {
+		t.Errorf("FMT-36: expected Field=requires[1], got %q", matches[0].Field)
 	}
 	if matches[0].Fix == "" {
 		t.Errorf("FMT-36: Fix field must be non-empty")
@@ -1649,21 +1653,21 @@ func TestFMT36_MultipleErrors(t *testing.T) {
 	}
 }
 
-// TestFMT36_NilAssembly verifies that a nil assembly entry does not panic.
-func TestFMT36_NilAssembly(t *testing.T) {
+// TestFMT36_NilCell verifies that a nil cell entry does not panic.
+func TestFMT36_NilCell(t *testing.T) {
 	project := &metadata.ProjectMeta{
-		Cells:     map[string]*metadata.CellMeta{},
-		Slices:    map[string]*metadata.SliceMeta{},
-		Contracts: map[string]*metadata.ContractMeta{},
-		Journeys:  map[string]*metadata.JourneyMeta{},
-		Assemblies: map[string]*metadata.AssemblyMeta{
-			"nilasm": nil,
+		Cells: map[string]*metadata.CellMeta{
+			"nilcell": nil,
 		},
+		Slices:     map[string]*metadata.SliceMeta{},
+		Contracts:  map[string]*metadata.ContractMeta{},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
 	}
 	v := NewValidator(project, "", clock.Real())
-	// Must not panic; nil assembly guard mirrors validateFMT29/FMT30.
+	// Must not panic; nil cell guard mirrors validateFMT29/FMT30.
 	matches := findByCode(v.validateFMT36(), codeFMT36)
 	if len(matches) != 0 {
-		t.Fatalf("FMT-36: expected 0 findings for nil assembly, got: %v", matches)
+		t.Fatalf("FMT-36: expected 0 findings for nil cell, got: %v", matches)
 	}
 }

--- a/kernel/metadata/contract_constraints.go
+++ b/kernel/metadata/contract_constraints.go
@@ -50,12 +50,13 @@ const (
 // reorder without updating schemas/assembly.schema.json in lockstep.
 var DeployTemplateEnum = []string{"k8s", "compose", "binary"}
 
-// CapabilityEnum lists the canonical values accepted for
-// assembly.capabilities items. Order matches the schema enum order at
-// schemas/assembly.schema.json properties.capabilities.items.enum; do not
-// reorder without updating the schema in lockstep.
-// TestSchemaConstantsMatchSchemaLiterals (kernel/metadata/schemas) asserts
-// byte-level parity between this slice and the schema enum array.
+// CapabilityEnum lists the canonical values accepted for cell.requires items.
+// Order matches the schema enum order at schemas/cell.schema.json
+// properties.requires.items.enum; do not reorder without updating the schema
+// in lockstep. TestSchemaConstantsMatchSchemaLiterals (kernel/metadata/schemas)
+// asserts byte-level parity between this slice and the schema enum array. The
+// assembly's provisioned set is the derived union of its cells' requires
+// (Design Y, #855) — there is no assembly-level capabilities enum.
 var CapabilityEnum = []string{"postgres", "redis", "rabbitmq"}
 
 var goStructNameRe = regexp.MustCompile(GoStructNamePattern)

--- a/kernel/metadata/schemas/assembly.schema.json
+++ b/kernel/metadata/schemas/assembly.schema.json
@@ -36,15 +36,6 @@
         }
       }
     },
-    "capabilities": {
-      "type": "array",
-      "description": "Assembly-level shared infrastructure capabilities provisioned once by the composition root and injected into consuming cell modules (runtime/cap). Closed enum; mirrored by runtime/cap.Capability and rejected outside the set by the parser.",
-      "items": {
-        "type": "string",
-        "enum": ["postgres", "redis", "rabbitmq"]
-      },
-      "uniqueItems": true
-    },
     "build": {
       "type": "object",
       "description": "Build configuration for the assembly. All fields optional; defaults are derived.",

--- a/kernel/metadata/schemas/assembly_schema_test.go
+++ b/kernel/metadata/schemas/assembly_schema_test.go
@@ -83,35 +83,20 @@ func TestAssemblySchema_BuildOptional(t *testing.T) {
 	assert.NoError(t, schema.Validate(doc), "assembly with id/cells/owner only must pass")
 }
 
-// TestAssemblySchema_CapabilitiesEnum verifies that the capabilities array only
-// accepts the declared enum values (postgres/redis/rabbitmq) and rejects others
-// — the upstream-Hard half of CAPABILITY-PROVIDER-FUNNEL-01.
-func TestAssemblySchema_CapabilitiesEnum(t *testing.T) {
+// TestAssemblySchema_NoCapabilitiesProperty verifies that assembly.yaml no
+// longer accepts a `capabilities` property (Design Y, #855): the field moved to
+// cell.requires and additionalProperties:false now rejects it at the assembly
+// level. Coverage of the capability enum itself lives in cell_schema_test.go.
+func TestAssemblySchema_NoCapabilitiesProperty(t *testing.T) {
 	schema := compileAssemblySchema(t)
-
-	valid := parseAssemblyDoc(t, `{
+	doc := parseAssemblyDoc(t, `{
 		"id": "corebundle",
 		"cells": ["accesscore"],
 		"owner": {"team": "platform", "role": "cell-owner"},
 		"capabilities": ["postgres", "redis"]
 	}`)
-	assert.NoError(t, schema.Validate(valid), "capabilities with declared enum values must pass")
-
-	bogus := parseAssemblyDoc(t, `{
-		"id": "corebundle",
-		"cells": ["accesscore"],
-		"owner": {"team": "platform", "role": "cell-owner"},
-		"capabilities": ["postgres", "bogus"]
-	}`)
-	assert.Error(t, schema.Validate(bogus), "capabilities with a value outside the enum must fail")
-
-	dup := parseAssemblyDoc(t, `{
-		"id": "corebundle",
-		"cells": ["accesscore"],
-		"owner": {"team": "platform", "role": "cell-owner"},
-		"capabilities": ["postgres", "postgres"]
-	}`)
-	assert.Error(t, schema.Validate(dup), "duplicate capabilities must fail (uniqueItems)")
+	assert.Error(t, schema.Validate(doc),
+		"assembly capabilities property was removed; it must be rejected by additionalProperties:false")
 }
 
 // formatf is a helper that avoids importing fmt in a test-only file.

--- a/kernel/metadata/schemas/cell.schema.json
+++ b/kernel/metadata/schemas/cell.schema.json
@@ -94,6 +94,16 @@
       "type": "string",
       "description": "Go receiver type backing this cell (e.g. OrderCell). Required when codegen renders cell_gen.go for this cell. There is no automatic mapping from a lowercased id to its conventional CamelCase Go type.",
       "pattern": "^[A-Z][A-Za-z0-9]*$"
+    },
+    "requires": {
+      "type": "array",
+      "description": "Assembly-level shared infrastructure capabilities this cell consumes (postgres / redis / rabbitmq), including optional provision-if-available ones. Authoritative single source: the owning assembly's provisioned capability set is the derived union of its cells' requires. Closed enum mirrored by metadata.CapabilityEnum + runtime/capability.Kind; FMT-36 rejects unknown/duplicate values.",
+      "default": [],
+      "items": {
+        "type": "string",
+        "enum": ["postgres", "redis", "rabbitmq"]
+      },
+      "uniqueItems": true
     }
   }
 }

--- a/kernel/metadata/schemas/cell_schema_test.go
+++ b/kernel/metadata/schemas/cell_schema_test.go
@@ -1,0 +1,82 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cellSchemaURL = "https://gocell.dev/schemas/cell.schema.json"
+
+func compileCellSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	raw, err := FS.ReadFile("cell.schema.json")
+	require.NoError(t, err)
+
+	var schemaDoc any
+	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
+
+	compiler := jsonschema.NewCompiler()
+	require.NoError(t, compiler.AddResource(cellSchemaURL, schemaDoc))
+
+	schema, err := compiler.Compile(cellSchemaURL)
+	require.NoError(t, err)
+	return schema
+}
+
+// TestCellSchema_RequiresEnum verifies that the cell `requires` array only
+// accepts the declared enum values (postgres/redis/rabbitmq) and rejects
+// out-of-enum / duplicate values. cell.requires is the authoritative single
+// source for the assembly's derived capability set (Design Y, #855); this is
+// the schema-shape upstream-Hard half (the const-parity half lives in
+// schema_const_consistency_test.go).
+func TestCellSchema_RequiresEnum(t *testing.T) {
+	schema := compileCellSchema(t)
+
+	valid := parseAssemblyDoc(t, `{
+		"id": "accesscore",
+		"type": "core",
+		"consistencyLevel": "L3",
+		"owner": {"team": "platform", "role": "cell-owner"},
+		"verify": {"smoke": ["smoke.accesscore.startup"]},
+		"requires": ["postgres", "redis"]
+	}`)
+	assert.NoError(t, schema.Validate(valid), "requires with declared enum values must pass")
+
+	bogus := parseAssemblyDoc(t, `{
+		"id": "accesscore",
+		"type": "core",
+		"consistencyLevel": "L3",
+		"owner": {"team": "platform", "role": "cell-owner"},
+		"verify": {"smoke": ["smoke.accesscore.startup"]},
+		"requires": ["postgres", "bogus"]
+	}`)
+	assert.Error(t, schema.Validate(bogus), "requires with a value outside the enum must fail")
+
+	dup := parseAssemblyDoc(t, `{
+		"id": "accesscore",
+		"type": "core",
+		"consistencyLevel": "L3",
+		"owner": {"team": "platform", "role": "cell-owner"},
+		"verify": {"smoke": ["smoke.accesscore.startup"]},
+		"requires": ["postgres", "postgres"]
+	}`)
+	assert.Error(t, schema.Validate(dup), "duplicate requires must fail (uniqueItems)")
+}
+
+// TestCellSchema_RequiresOptional verifies a cell without a requires field
+// (most cells) still validates — requires is optional with a [] default.
+func TestCellSchema_RequiresOptional(t *testing.T) {
+	schema := compileCellSchema(t)
+	doc := parseAssemblyDoc(t, `{
+		"id": "ordercell",
+		"type": "core",
+		"consistencyLevel": "L2",
+		"owner": {"team": "platform", "role": "cell-owner"},
+		"verify": {"smoke": ["smoke.ordercell.startup"]}
+	}`)
+	assert.NoError(t, schema.Validate(doc), "cell without requires must pass (optional field)")
+}

--- a/kernel/metadata/schemas/schema_const_consistency_test.go
+++ b/kernel/metadata/schemas/schema_const_consistency_test.go
@@ -64,12 +64,16 @@ func TestSchemaConstantsMatchSchemaLiterals(t *testing.T) {
 			got, metadata.DeployTemplateEnum)
 	})
 
-	t.Run("assembly.schema.json#CapabilityEnum", func(t *testing.T) {
+	// CapabilityEnum now lives on cell.schema.json `requires` — the per-cell
+	// declaration is the authoritative single source from which the assembly's
+	// provisioned capability set is derived (Design Y, #855). assembly.schema.json
+	// no longer carries a `capabilities` property.
+	t.Run("cell.schema.json#requires.enum", func(t *testing.T) {
 		t.Parallel()
-		got := readSchemaStringSlice(t, "assembly.schema.json",
-			[]string{"properties", "capabilities", "items", "enum"})
+		got := readSchemaStringSlice(t, "cell.schema.json",
+			[]string{"properties", "requires", "items", "enum"})
 		require.True(t, reflect.DeepEqual(metadata.CapabilityEnum, got),
-			"schemas/assembly.schema.json capabilities.items.enum drifted from metadata.CapabilityEnum: schema=%v const=%v",
+			"schemas/cell.schema.json requires.items.enum drifted from metadata.CapabilityEnum: schema=%v const=%v",
 			got, metadata.CapabilityEnum)
 	})
 }

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -38,9 +38,13 @@ type CellMeta struct {
 	// cell.schema.json `requires` enum; unknown/duplicate values are rejected by
 	// `gocell validate` governance rule FMT-36 (validation-time, not by ParseFS —
 	// the parser stays lenient, matching Kubernetes admission-layer validation).
-	// "Requires" names what the cell consumes, including optional
-	// provision-if-available capabilities (e.g. accesscore's redis cache); the
-	// provisioner (provisionCapabilities) decides hard-vs-best-effort per kind.
+	// "Requires" names what the cell consumes; it declares intent, not a uniform
+	// hardness contract. Whether a listed capability is hard-required or
+	// best-effort is decided per kind by the provisioner (cmd/corebundle
+	// provisionCapabilities): postgres is hard-required in non-memory storage
+	// modes (absence fails fast at the cell's nil-guard); redis is
+	// provision-if-available (absence degrades gracefully — e.g. accesscore's
+	// AUTH-CACHE-01 session cache is skipped when no redis client is configured).
 	Requires []string `yaml:"requires,omitempty"`
 	Dir      string   `yaml:"-"` // directory segment under cells/, set by parser
 	File     string   `yaml:"-"` // parsed cell.yaml path relative to project root

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -30,8 +30,20 @@ type CellMeta struct {
 	// Go type (e.g. "ordercell" → "OrderCell"), which is why explicit
 	// declaration is required.
 	GoStructName GoIdentifier `yaml:"goStructName,omitempty"`
-	Dir          string       `yaml:"-"` // directory segment under cells/, set by parser
-	File         string       `yaml:"-"` // parsed cell.yaml path relative to project root
+	// Requires lists the assembly-level shared infrastructure capabilities this
+	// cell consumes (postgres / redis / rabbitmq). It is the authoritative single
+	// source: the owning assembly's provisioned capability set is the derived
+	// union of its cells' Requires (see kernel/assembly.GenerateModulesGen). The
+	// closed value set is mirrored by CapabilityEnum + runtime/capability.Kind +
+	// cell.schema.json `requires` enum; unknown/duplicate values are rejected by
+	// `gocell validate` governance rule FMT-36 (validation-time, not by ParseFS —
+	// the parser stays lenient, matching Kubernetes admission-layer validation).
+	// "Requires" names what the cell consumes, including optional
+	// provision-if-available capabilities (e.g. accesscore's redis cache); the
+	// provisioner (provisionCapabilities) decides hard-vs-best-effort per kind.
+	Requires []string `yaml:"requires,omitempty"`
+	Dir      string   `yaml:"-"` // directory segment under cells/, set by parser
+	File     string   `yaml:"-"` // parsed cell.yaml path relative to project root
 }
 
 // Clone returns a deep copy of c, independently owning every slice and
@@ -47,6 +59,7 @@ func (c *CellMeta) Clone() *CellMeta {
 	cp := *c
 	cp.L0Dependencies = append([]L0DepMeta(nil), c.L0Dependencies...)
 	cp.Verify.Smoke = append([]string(nil), c.Verify.Smoke...)
+	cp.Requires = append([]string(nil), c.Requires...)
 	return &cp
 }
 
@@ -278,14 +291,11 @@ type AssemblyMeta struct {
 	ID    string    `yaml:"id"`
 	Cells []string  `yaml:"cells"`
 	Owner OwnerMeta `yaml:"owner"`
-	// Capabilities lists assembly-level shared infrastructure capabilities
-	// (postgres / redis / rabbitmq) provisioned once by the composition root
-	// and injected into consuming cell modules via runtime/capability. The closed
-	// value set is mirrored by CapabilityEnum + runtime/capability.Kind +
-	// assembly.schema.json enum. Unknown or duplicate values are rejected by
-	// `gocell validate` governance rule FMT-36 (validation-time, not by ParseFS —
-	// the parser stays lenient, matching Kubernetes admission-layer validation).
-	Capabilities        []string  `yaml:"capabilities,omitempty"`
+	// The assembly's provisioned capability set is NOT declared here — it is the
+	// derived union of its cells' CellMeta.Requires (Design Y, #855). There is no
+	// hand-authored assembly-level `capabilities` field; the single source is
+	// per-cell. kernel/assembly.GenerateModulesGen computes the union when
+	// rendering generatedCapabilities() in modules_gen.go.
 	Build               BuildMeta `yaml:"build,omitempty"`
 	MaxConsistencyLevel string    `yaml:"-"` // derived; yaml occurrence rejected by KnownFields
 	Dir                 string    `yaml:"-"` // assembly directory name (parts[1]); set by parser from path, not YAML

--- a/kernel/metadata/types_test.go
+++ b/kernel/metadata/types_test.go
@@ -34,9 +34,27 @@ func TestCellMetaRoundTrip(t *testing.T) {
 		Schema:           SchemaMeta{Primary: "cell_access_core"},
 		Verify:           CellVerifyMeta{Smoke: []string{"smoke.accesscore.startup"}},
 		L0Dependencies:   []L0DepMeta{{Cell: "shared-crypto", Reason: "hashing"}},
+		Requires:         []string{"postgres", "redis"},
 	}
 	_, got := roundTrip(t, orig)
 	assert.Equal(t, orig, got)
+}
+
+// TestCellMeta_Clone_RequiresIndependence asserts that Clone deep-copies the
+// Requires slice (Design Y, #855): mutating the clone's Requires must not leak
+// into the original. Mirrors the L0Dependencies / Verify.Smoke deep-copy guard.
+func TestCellMeta_Clone_RequiresIndependence(t *testing.T) {
+	src := &CellMeta{
+		ID:       "accesscore",
+		Requires: []string{"postgres", "redis"},
+	}
+	clone := src.Clone()
+	require.Equal(t, src.Requires, clone.Requires)
+
+	clone.Requires[0] = "MUTATED"
+	clone.Requires = append(clone.Requires, "rabbitmq")
+	assert.Equal(t, []string{"postgres", "redis"}, src.Requires,
+		"mutating clone.Requires must not affect the original")
 }
 
 func TestCellMetaEmptyL0Dependencies(t *testing.T) {

--- a/runtime/capability/capability.go
+++ b/runtime/capability/capability.go
@@ -5,10 +5,11 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 )
 
-// Kind names an assembly-level shared infrastructure capability declared in
-// assembly.yaml `capabilities` and (in #855) consumed via cell.yaml `requires`.
-// The closed value set below is the single source mirrored by the
-// assembly.schema.json enum (kept in lockstep by kernel/metadata/schemas
+// Kind names an assembly-level shared infrastructure capability. Cells declare
+// what they consume via cell.yaml `requires`; the assembly's provisioned set is
+// the derived union of its cells' requires (Design Y, #855 — see
+// kernel/assembly.GenerateModulesGen). The closed value set below is mirrored by
+// the cell.schema.json `requires` enum (kept in lockstep by kernel/metadata/schemas
 // TestSchemaConstantsMatchSchemaLiterals). Unknown or duplicate values are
 // rejected by `gocell validate` governance rule FMT-36 at validation time — not
 // at parse time: ParseFS stays lenient, matching Kubernetes admission-layer enum
@@ -22,8 +23,8 @@ const (
 	Redis Kind = "redis"
 	// RabbitMQ is recognized by the enum but has NO provider / provisioning path
 	// yet: there is no RabbitMQProvider and cap_wiring's provisionCapabilities has
-	// no rabbitmq case, so declaring `capabilities: [rabbitmq]` passes FMT-36 +
-	// codegen but fails fast at provisionCapabilities' default branch. It stays in
+	// no rabbitmq case, so declaring `requires: [rabbitmq]` in a cell.yaml passes
+	// FMT-36 + codegen but fails fast at provisionCapabilities' default branch. It stays in
 	// the enum as recognized forward vocabulary; a real AMQP-shared-connection
 	// assembly must land the RabbitMQProvider + provisioning atomically.
 	RabbitMQ Kind = "rabbitmq"

--- a/runtime/devtools/catalog/build.go
+++ b/runtime/devtools/catalog/build.go
@@ -179,6 +179,7 @@ func buildCellEntity(c *metadata.CellMeta, inc IncludeOptions) Entity {
 		Schema:           CellSpecSchema{Primary: c.Schema.Primary},
 		VerifySmoke:      c.Verify.Smoke,
 		L0Dependencies:   l0Deps,
+		Requires:         c.Requires,
 	}
 
 	var rels []Relation

--- a/runtime/devtools/catalog/build_test.go
+++ b/runtime/devtools/catalog/build_test.go
@@ -135,6 +135,32 @@ func baseOpts() catalog.ExportOptions {
 	}
 }
 
+// ---- TestBuildDocument_CellRequiresProjected ----
+
+// TestBuildDocument_CellRequiresProjected asserts CellMeta.Requires flows into
+// CellSpec.Requires on the catalog wire surface (#855 F1). Without this mapping
+// `gocell export` silently drops the authoritative capability declaration; the
+// CELL-META-DTO-COVERAGE-01 archtest guards the field-set, this guards the value.
+func TestBuildDocument_CellRequiresProjected(t *testing.T) {
+	pm := minimalPM()
+	pm.Cells["accesscore"].Requires = []string{"postgres", "redis"}
+	doc, err := catalog.BuildDocument(pm, baseOpts())
+	require.NoError(t, err)
+
+	var found bool
+	for _, e := range doc.Entities {
+		if e.Kind != "Cell" || e.Metadata.Name != "accesscore" {
+			continue
+		}
+		spec, ok := e.Spec.(catalog.CellSpec)
+		require.True(t, ok, "Cell entity should have CellSpec, got %T", e.Spec)
+		assert.Equal(t, []string{"postgres", "redis"}, spec.Requires,
+			"CellMeta.Requires must project to CellSpec.Requires")
+		found = true
+	}
+	require.True(t, found, "accesscore Cell entity must be present")
+}
+
 // ---- TestBuildDocument_FullSnapshot ----
 
 func TestBuildDocument_FullSnapshot(t *testing.T) {

--- a/runtime/devtools/catalog/wire.go
+++ b/runtime/devtools/catalog/wire.go
@@ -180,7 +180,9 @@ type CellSpec struct {
 	Schema           CellSpecSchema  `json:"schema"           yaml:"schema"`
 	VerifySmoke      []string        `json:"verifySmoke,omitempty"    yaml:"verifySmoke,omitempty"`
 	L0Dependencies   []CellSpecL0Dep `json:"l0Dependencies,omitempty" yaml:"l0Dependencies,omitempty"`
-	Slices           []string        `json:"slices,omitempty"         yaml:"slices,omitempty"` // canonical "cell.slice" IDs
+	// Requires is the assembly capabilities this cell consumes (postgres/redis/rabbitmq).
+	Requires []string `json:"requires,omitempty" yaml:"requires,omitempty"`
+	Slices   []string `json:"slices,omitempty"   yaml:"slices,omitempty"` // canonical "cell.slice" IDs
 }
 
 // CellSpecOwner mirrors OwnerMeta on the wire (camelCase tags).

--- a/tools/archtest/cell_meta_dto_drift_test.go
+++ b/tools/archtest/cell_meta_dto_drift_test.go
@@ -1,0 +1,66 @@
+// INVARIANT: CELL-META-DTO-COVERAGE-01
+//
+// TestCellMetaDTOCoverage enforces that every top-level yaml-bearing exported
+// field on metadata.CellMeta is either:
+//
+//   - mapped onto runtime/devtools/catalog.CellSpec, or
+//   - listed in catalogExcludedCellFields with a documented reason.
+//
+// Sibling of ASSEMBLY-META-DTO-COVERAGE-01 (assembly_meta_dto_drift_test.go),
+// sharing its exportedYAMLNames / exportedJSONNames helpers. This guard was
+// MISSING when #855 added CellMeta.Requires: the field landed without a
+// corresponding CellSpec projection and nothing flagged the drift, so
+// `gocell export` silently dropped the new authoritative capability declaration
+// from the catalog/metadata wire surface. (The assembly side did have this
+// guard, which is exactly why #854's analogous AssemblyMeta.Capabilities gap
+// surfaced as a red test.) Adding a new top-level CellMeta field now triggers
+// this test, closing the cell-side leg of the "metadata extends but catalog
+// stays stale" drift class.
+//
+// One-level reflection (matching the assembly invariant): nested struct field
+// equality (metadata.OwnerMeta ↔ catalog.CellSpecOwner, etc.) stays outside
+// this gate and is covered by focused catalog round-trip tests.
+
+package archtest
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/runtime/devtools/catalog"
+)
+
+// catalogExcludedCellFields lists CellMeta exported yaml-bearing fields that are
+// intentionally not surfaced (by matching tag name) via CellSpec. Each entry
+// maps the yaml field name to a reason string.
+var catalogExcludedCellFields = map[string]string{
+	// id is the resource identifier; surfaced via Entity.Metadata.Name + UID
+	// (build.go buildCellEntity sets Name: c.ID), not inside Spec.
+	"id": "surfaced via EntityMetadata.Name, not Spec",
+	// verify is flattened: CellMeta.Verify.Smoke projects to CellSpec.VerifySmoke
+	// (json/yaml tag "verifySmoke"), so the top-level "verify" tag has no
+	// same-named Spec field by design.
+	"verify": "flattened to CellSpec.VerifySmoke",
+	// goStructName is a codegen-only extension (tools/codegen consumes it to
+	// render cell_gen.go); it is not part of the catalog resource shape.
+	"goStructName": "codegen-internal extension; not catalog Spec shape",
+}
+
+// TestCellMetaDTOCoverage is the CELL-META-DTO-COVERAGE-01 top-level field-set gate.
+func TestCellMetaDTOCoverage(t *testing.T) {
+	t.Parallel()
+	metaFields := exportedYAMLNames(reflect.TypeOf(metadata.CellMeta{}))
+	specFields := exportedJSONNames(reflect.TypeOf(catalog.CellSpec{}))
+
+	for fname := range metaFields {
+		if catalogExcludedCellFields[fname] != "" {
+			continue
+		}
+		if _, ok := specFields[fname]; !ok {
+			t.Errorf("metadata.CellMeta field %q has no CellSpec mapping; "+
+				"add it to CellSpec, update buildCellEntity, or list it in "+
+				"catalogExcludedCellFields with a reason", fname)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #855（Cell module.go 自动化 / K#10 收尾）。

**经三轮激进自审，#855 字面要求（codegen 生成 `{cell}_module.go`，预期降 70%）被否决**：实测三平台 cell module.go 仅 13–35% 机械、其余是深度交织的安全关键 wiring（`accessOpts` 127→194 行连续 mutate、audit 的 `defer clear(hmacKey)` 生命周期、bootstrap observer 必须先于 ratelimit），强行生成产出更差代码。逐子项剖析见末表。

本 PR 交付的是 #855 唯一有真实前提的部分 —— 兑现 #854（`runtime/capability`）在 `capability.go` 留下的 `requires` forward-reference，并按 **Design Y** 做成单源派生：

> **把 capability 依赖从手写 `assembly.yaml capabilities` 翻转为 per-cell `cell.yaml requires` 权威单源；assembly 的 provision 集由 `∪cells.requires` 派生。**

这给了 `requires` 一个活消费方（驱动 `provisionCapabilities` 真实 provision）+ 运行期准确性 enforcement（漏声明 → 不入 union → 不 provision → 现有 nil-guard 触发），摆脱了"纯字段只被 validate 读"的 Soft 核。

## Design

- `cell.yaml requires: [...]` = 本 cell 消费的 capability（含可选 provision-if-available，如 accesscore 的 redis 缓存）。
- `kernel/assembly.GenerateModulesGen` 遍历 `assembly.cells` → `∪ CellMeta.Requires` → 排序去重 → 渲染 `generatedCapabilities()`。
- 删 `AssemblyMeta.Capabilities` + `assembly.yaml capabilities` + assembly schema property → 第二真值源在结构上不可表达。
- `provisionCapabilities` 消费方不变；hard-vs-best-effort（redis best-effort）由 provisioner 决定。

**行为零变化**：派生 `∪ = [postgres, redis]`（排序后）== 今日 corebundle 手写值；`modules_gen.go` 仅注释变、capability 列表字节不变。

## AI-robust 评级

- **派生 / 单源 = Hard**：`gocell generate assembly` 把 `∪cells.requires` byte-locked 进 `modules_gen.go`（regenerate-and-diff）；手写源删除使第二源不可表达；schema enum ↔ `CapabilityEnum` 字节 parity（`TestSchemaConstantsMatchSchemaLiterals`，从 assembly#capabilities 重定位到 cell#requires）。
- **准确性 = Medium（inherent，同档现有 capability 模型）**：漏声明 → 不 provision → nil-guard。无 Soft、无 funnel 双向锁 gh issue 需求。

## Implementation matrix

```
Contract: cell.yaml schema (requires) + AssemblyMeta/CellMeta structs + cell_gen.go literal
Change: capability 源从 assembly.capabilities 翻转为 per-cell requires，assembly 集派生
Implementations: [x] CellMeta.Requires  [x] schema(cell +requires / assembly −capabilities)  [x] GenerateModulesGen 派生  [x] FMT-36 repurpose
Conformance test: kernel/assembly.TestGenerateModulesGen_DerivesCapabilitiesFromCellRequires
Repro: go test ./kernel/metadata/... ./kernel/governance/... ./kernel/assembly/... -count=1
Dependent contracts (governance scan): none（无 contract.yaml / DB schema / errcode 变化）
```

## Test plan

- [x] TDD：RED commit (`bc4389054`) 先于实施
- [x] `go build ./...` clean
- [x] `go test ./kernel/metadata/... ./kernel/governance/... ./kernel/assembly/... ./runtime/devtools/... ./cmd/corebundle/...` GREEN
- [x] `go run ./cmd/gocell generate cell --verify` 无 drift
- [x] `go run ./cmd/gocell validate` 0 error（2 个 unrelated 既有 journey 警告）
- [x] `golangci-lint run` 0 issues
- [x] 覆盖：schema parity / CellMeta round-trip + Clone deep-copy / generator 派生(sort+dedup) / FMT-36 per-cell(known+dup) / cell schema requires enum

## 顺带修复

删除 `AssemblyMeta.Capabilities` 修复了 #854 遗留的 **`ASSEMBLY-META-DTO-COVERAGE-01`** nightly archtest 失败（capabilities 字段加进了 AssemblyMeta 却从未映射进 `catalog.AssemblySpec` 也未 excluded；全 archtest 仅 nightly 跑故 PR CI 没拦住）。删字段后该 test 自动 GREEN。

## ⚠️ 两个既有 archtest 失败（非本 PR 引入）

全 archtest suite 另有 2 个失败，均在**本 PR 未触碰**的文件，属 develop 上既有 nightly breakage（同 DTO-coverage 一类）：
- `TestTypesutilImplementsFunnel01` → `tools/archtest/aftercommit_pure_transient_test.go:226,230`
- `TestExternalReasonLiteral` → `runtime/saga/integration_test.go:785`
二者是对未修改文件的静态扫描，与 capability/requires 无关。建议另开 issue 修。

## 被否决的 #855 范围（带论证，非 backlog）

| 项 | 否决论证 |
|----|---------|
| 生成 `{cell}_module.go` / overrides 拆分 | 前提假（13%/87% 实测）；产出更差、破坏 audit defer-clear 生命周期与 access accessOpts pipeline 不变量 |
| runtime guard dedup | FMT 后 nil-guard 在合法配置下结构上不可达；dedup 死代码无 Hard funnel |
| 纯 `requires` 字段（无派生） | 仅 validate 消费、准确性无 enforcement = Soft 核 → 由 Design Y 派生消费方解决 |
| `sliceWiring` hint | 无消费方；slice 已由 cellgen 单源 |
| examples module.go | examples 用 run.go 内联，无 CellModule 模式 |

> 均为"否决+论证"（写入此处防被重新尝试），无未来价值，不开 backlog。

🤖 Generated with [Claude Code](https://claude.com/claude-code)