### PR TITLE
ci(pr-check): cut critical path 5m→~4m10s via 3 shard-level optimizations

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -102,13 +102,15 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      # Static checks (Build, Vet, golangci-lint, validate/check commands, layering
-      # guard, kernel coverage gate) run only on the kernel shard. Running them on
-      # every shard would cost 4x runner minutes for no signal — each step is
-      # repo-global (no package scoping) and its verdict does not depend on which
-      # shard is executing. Hosting them on the kernel shard (the smallest test
-      # load at ~22k lines / 17.9%) also gives the fastest fail-fast path when a
-      # lint regression is introduced.
+      # Static checks (Build, golangci-lint, kernel coverage gate) run only
+      # on the kernel shard. Running them on every shard would cost 4x runner
+      # minutes for no signal — each step is repo-global (no package scoping)
+      # and its verdict does not depend on which shard is executing. Hosting
+      # them on the kernel shard (the smallest test load at ~22k lines /
+      # 17.9%) also gives the fastest fail-fast path when a lint regression
+      # is introduced. (Vet is intentionally not listed: govet is in
+      # golangci-lint v2's default linter set — see the absence-rationale
+      # comment between Build and golangci-lint below.)
       - name: Build
         if: matrix.static_checks
         run: go build ./...

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -75,8 +75,18 @@ jobs:
           - shard: cells
             pkgs: ./cells/...
             static_checks: false
-          - shard: others
-            pkgs: ./adapters/... ./cmd/... ./examples/... ./tests/... ./contracts/...
+          # `others` was a single 140s shard covering adapters + cmd +
+          # examples + tests + contracts. Splitting along compile cost:
+          # `others-heavy` carries ./adapters/... (external SDK dependency
+          # surface — postgres / redis / rabbitmq / vault / otel) and
+          # ./examples/... (links every layer end-to-end). `others-light`
+          # carries the remaining lightweight subtrees. The split brings the
+          # heavier leg below the kernel-shard critical path.
+          - shard: others-heavy
+            pkgs: ./adapters/... ./examples/...
+            static_checks: false
+          - shard: others-light
+            pkgs: ./cmd/... ./tests/... ./contracts/...
             static_checks: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -103,10 +113,12 @@ jobs:
         if: matrix.static_checks
         run: go build ./...
 
-      - name: Vet
-        if: matrix.static_checks
-        run: go vet ./...
-
+      # `go vet ./...` is intentionally absent here: golangci-lint v2 has
+      # `govet` in its default-enabled linter set (see .golangci.yml line 4
+      # comment), so a standalone vet step would re-walk the full repo AST
+      # for zero additional signal. Removing it cuts ~21s off the kernel
+      # shard wall time. Cross-tag vet (e.g. `-tags=e2e`) is still done
+      # explicitly below where the build tag changes the file set.
       - name: golangci-lint
         if: matrix.static_checks
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
@@ -245,38 +257,68 @@ jobs:
         if: matrix.static_checks
         run: go vet -tags=e2e ./tests/e2e/...
 
-      # NOTE: Kernel coverage gate re-runs `go test -cover ./kernel/...`
-      # deliberately — it is not a duplicate of the Test step. The gate requires
-      # in-package kernel coverage (each package's tests of itself), while the
-      # kernel-shard Test step produces a merged profile that does not split
-      # per-package. Running standalone avoids having to slice the profile.
+      # Kernel coverage gate — parses the per-shard coverage profile produced
+      # by the Test step (covermode=atomic, one statement-block per row) and
+      # computes statement-weighted per-package coverage. Mirrors the
+      # adapters/postgres coverage gate pattern below: no extra `go test`
+      # invocation, ~1s parse vs ~13s re-run. Atomic profile rows are
+      # `<import_path>/<file>.go:start.col,end.col stmts hits`, so import
+      # path is a clean per-package key — no need for `go test -cover` stdout.
+      #
+      # Helper-package exemption: packages whose final path segment ends in
+      # `test` (Go *test convention: authtest, celltest, commandtest,
+      # outboxtest, persistencetest, sagajournaltest, sagaregtest) carry
+      # fixtures / Must* wrappers, not production logic — exempt from the
+      # 90% floor. `[no statements]` packages don't appear in the profile
+      # at all, so they're naturally skipped (no FAIL triggered).
       - name: Kernel coverage gate
         if: matrix.static_checks
         run: |
-          go test -cover ./kernel/... 2>&1 | tee /tmp/kernel-cov.txt
-          awk '
-            /coverage: \[no statements\]/ { next }
-            # Test-support helper packages (Go *test convention: authtest,
-            # celltest, commandtest, outboxtest) carry fixtures / Must* wrappers,
-            # not production logic — exempt from the kernel 90% floor. Match the
-            # path segment generically (not a per-package enumeration) so that
-            # extracting a new *test helper never silently re-breaks this gate.
-            /\/[a-z]+test/ { next }
-            /coverage:/ {
-              cov = $0
-              sub(/^.*coverage: /, "", cov)
-              sub(/% of statements.*$/, "", cov)
-              if (cov == $0) {
-                print "FAIL: could not parse coverage line: " $0;
-                exit 1
+          set -euo pipefail
+          PROFILE="coverage-shard-${{ matrix.shard }}.out"
+          KERNEL_PREFIX='github.com/ghbvf/gocell/kernel/'
+
+          if [ ! -s "$PROFILE" ]; then
+            echo "FAIL: $PROFILE missing or empty"; exit 1
+          fi
+
+          fail=0
+          while IFS= read -r pkg; do
+            if echo "$pkg" | grep -qE '/[a-z]+test$'; then
+              continue
+            fi
+            pkg_pct=$(awk -v prefix="${pkg}/" '
+              $1 ~ "^"prefix"[^/]+\\.go:" {
+                total += $2
+                if ($3 > 0) hit += $2
               }
-              if (cov + 0 < 90) {
-                print "FAIL: " $2 " coverage " cov "% < 90%";
-                exit 1
+              END {
+                if (total > 0) printf "%.1f", hit/total*100
+                else print "no_stmts"
               }
+            ' "$PROFILE")
+            if [ "$pkg_pct" = "no_stmts" ]; then
+              continue
+            fi
+            result=$(awk -v p="$pkg_pct" -v pkg="$pkg" 'BEGIN {
+              if (p+0 < 90) { print "FAIL: " pkg " coverage " p "% < 90%"; exit 1 }
+              print "PASS: " pkg " " p "%"
+            }')
+            echo "$result"
+            echo "$result" | grep -q '^FAIL' && fail=1 || true
+          done < <(awk -v prefix="$KERNEL_PREFIX" '
+            $1 ~ "^"prefix {
+              path = $1
+              sub(/:[^:]*$/, "", path)
+              sub(/\/[^\/]+\.go$/, "", path)
+              print path
             }
-          ' /tmp/kernel-cov.txt
-          echo "PASS: kernel coverage >= 90%"
+          ' "$PROFILE" | sort -u)
+
+          if [ "$fail" -eq 1 ]; then
+            exit 1
+          fi
+          echo "PASS: all kernel packages >= 90%"
 
       - name: Upload coverage profile
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -321,13 +363,22 @@ jobs:
     # DISCOVERY-01 archtest still passes; no hardcoded `./<path>/...` globs
     # appear in the run block).
     #
-    # The OTel collector smoke + PG migrator race + Redis primitive race +
-    # Redis cluster vet + adapters/postgres coverage gate are scoped to the
-    # adapters shard exclusively (matrix.run_adapters_extras flag) — they
-    # all read from packages that fall under the adapters shard's filter so
-    # putting them anywhere else would either double-run containers (cells/
-    # tests/corebundle shards re-pulling postgres image) or break the
-    # `coverage-integration-<shard>.out` profile referenced by the gate.
+    # Step scoping uses two flags on matrix entries:
+    #   - `run_adapters_extras`: scopes Redis cluster compile gate +
+    #     adapters/postgres coverage gate to the `adapters` main leg
+    #     (which produces coverage-integration-adapters.out the gate reads).
+    #   - `run_adapters_race`: scopes the three race / OTel smoke steps to
+    #     the dedicated `adapters-race` leg. Splitting them off keeps the
+    #     adapters main leg's wall-time bounded by the main integration step
+    #     alone (~117s) instead of main + ~70s of serial race steps.
+    #
+    # `filter: ''` on the adapters-race leg disables the main `Integration
+    # tests (testcontainers)` step (guarded by `if: matrix.filter != ''`) —
+    # the race leg only runs the focused -run race steps, not the full
+    # adapter integration suite. Without this guard adapters-race would
+    # re-discover and re-run every postgres / redis / vault integration
+    # already exercised on the adapters main leg.
+    #
     # New integration test contributors: your package falls into a shard
     # automatically by import-path prefix — no yaml edit needed:
     #   adapters/...                          → adapters shard
@@ -340,23 +391,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # adapters shard owns the OTel smoke / PG + Redis race / Redis
-          # cluster vet / adapters/postgres coverage gate steps; each of
-          # those steps below MUST carry `if: ${{ matrix.run_adapters_extras }}`.
-          # When adding a new adapters-only integration step, add the same
-          # condition or it will run 4× across all shards.
+          # adapters main leg: full adapter integration suite + Redis cluster
+          # compile gate + adapters/postgres coverage gate. Each adapters-only
+          # post-integration step MUST carry `if: ${{ matrix.run_adapters_extras }}`.
           - shard: adapters
             filter: '^github.com/ghbvf/gocell/adapters/'
             run_adapters_extras: true
+            run_adapters_race: false
+          # adapters-race leg: OTel smoke + PG migrator race + Redis primitive
+          # race only. Empty filter disables the main integration step (see
+          # `if: matrix.filter != ''` guard below). Race steps re-spin small
+          # containers focused on -run patterns; no coverage profile is
+          # produced, so the upload step is guarded by the same filter check.
+          - shard: adapters-race
+            filter: ''
+            run_adapters_extras: false
+            run_adapters_race: true
           - shard: cells
             filter: '^github.com/ghbvf/gocell/cells/'
             run_adapters_extras: false
+            run_adapters_race: false
           - shard: corebundle
             filter: '^github.com/ghbvf/gocell/(cmd|examples)/'
             run_adapters_extras: false
+            run_adapters_race: false
           - shard: tests
             filter: '^github.com/ghbvf/gocell/(tests|kernel|runtime|tools)/'
             run_adapters_extras: false
+            run_adapters_race: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -366,6 +428,10 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Integration tests (testcontainers)
+        # Skip on adapters-race leg (filter==''); that leg only runs the
+        # focused race/OTel steps below, not the full adapter integration
+        # suite.
+        if: ${{ matrix.filter != '' }}
         env:
           GOCELL_TEST_DOCKER_REQUIRED: "1"
           SHARD_NAME: ${{ matrix.shard }}
@@ -433,7 +499,7 @@ jobs:
           go test -tags=integration -covermode=atomic -coverprofile=coverage-integration-${{ matrix.shard }}.out "${pkgs[@]}" -count=1 -timeout 15m
 
       - name: OTel collector smoke
-        if: ${{ matrix.run_adapters_extras }}
+        if: ${{ matrix.run_adapters_race }}
         env:
           GOCELL_TEST_DOCKER_REQUIRED: "1"
         # Keep the PR/push gate focused on the single real OTLP/gRPC collector
@@ -454,7 +520,7 @@ jobs:
           fi
 
       - name: Race coverage for PG migrator concurrent Up
-        if: ${{ matrix.run_adapters_extras }}
+        if: ${{ matrix.run_adapters_race }}
         env:
           GOCELL_TEST_DOCKER_REQUIRED: "1"
         # B4 GOOSE-SESSION-LOCKER regression guard. The main integration step
@@ -481,7 +547,7 @@ jobs:
           fi
 
       - name: Race coverage for Redis primitive contention
-        if: ${{ matrix.run_adapters_extras }}
+        if: ${{ matrix.run_adapters_race }}
         env:
           GOCELL_TEST_DOCKER_REQUIRED: "1"
         # B11 PR-V1-REDIS-KEYNS / B2-A-29: race stress for the four Redis
@@ -595,6 +661,10 @@ jobs:
           done
 
       - name: Upload integration coverage profile
+        # adapters-race leg has no main integration step, so no profile is
+        # produced — skip upload to keep upload-artifact from failing on a
+        # missing path. Same `matrix.filter != ''` guard as the main step.
+        if: ${{ matrix.filter != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-${{ matrix.shard }}
@@ -811,7 +881,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "mode: atomic" > coverage-merged.out
-          for f in coverage-shard-kernel.out coverage-shard-tools.out coverage-shard-runtime.out coverage-shard-cells.out coverage-shard-others.out \
+          # build-test produces unit profiles for: kernel, tools, runtime,
+          #   cells, others-heavy, others-light (others-* replaces the single
+          #   former `others` shard, see build-test matrix above).
+          # integration-test produces profiles for: adapters (main leg),
+          #   cells, corebundle, tests. The adapters-race leg produces no
+          #   coverage profile (focused race-only steps, no main integration
+          #   run — see matrix definition's filter-empty guard).
+          for f in coverage-shard-kernel.out coverage-shard-tools.out coverage-shard-runtime.out coverage-shard-cells.out \
+                   coverage-shard-others-heavy.out coverage-shard-others-light.out \
                    coverage-integration-adapters.out coverage-integration-cells.out coverage-integration-corebundle.out coverage-integration-tests.out; do
             if [ ! -f "$f" ]; then
               echo "FAIL: expected profile $f is missing" >&2

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -265,12 +265,30 @@ jobs:
       # `<import_path>/<file>.go:start.col,end.col stmts hits`, so import
       # path is a clean per-package key — no need for `go test -cover` stdout.
       #
+      # Equivalence with `go test -cover` stdout: `go test -cover` reports
+      # "X% of statements" per package = (covered_stmts / total_stmts) * 100,
+      # where a statement is "covered" iff its hit count is non-zero. Under
+      # `-covermode=atomic`, the hits column ($3) is an atomic accumulator
+      # of execution counts (≥0), so `if ($3 > 0)` is exactly the same
+      # binary "covered or not" judgment — the per-package percentages
+      # produced here match the legacy `go test -cover` stdout to the digit.
+      #
       # Helper-package exemption: packages whose final path segment ends in
       # `test` (Go *test convention: authtest, celltest, commandtest,
       # outboxtest, persistencetest, sagajournaltest, sagaregtest) carry
       # fixtures / Must* wrappers, not production logic — exempt from the
-      # 90% floor. `[no statements]` packages don't appear in the profile
-      # at all, so they're naturally skipped (no FAIL triggered).
+      # 90% floor. Regex `[a-z0-9_]+test$` covers future helper names with
+      # digits or underscores (e.g. `saga2test`); pure-lowercase is too
+      # tight a contract to enforce only here. `[no statements]` packages
+      # don't appear in the profile at all, so they're naturally skipped.
+      #
+      # FAIL aggregation: the inner awk always exits 0 (printing either
+      # PASS or FAIL line); the outer grep scans the captured string to
+      # update `fail`. Using `awk ... exit 1` for FAIL would interact with
+      # `set -e` on the `result=$(...)` assignment, terminating the loop
+      # on the first failing package before printing the FAIL line — the
+      # gate would still go red, but the operator would lose visibility
+      # into *every* failing package's percentage on the same run.
       - name: Kernel coverage gate
         if: matrix.static_checks
         run: |
@@ -284,7 +302,7 @@ jobs:
 
           fail=0
           while IFS= read -r pkg; do
-            if echo "$pkg" | grep -qE '/[a-z]+test$'; then
+            if echo "$pkg" | grep -qE '/[a-z0-9_]+test$'; then
               continue
             fi
             pkg_pct=$(awk -v prefix="${pkg}/" '
@@ -301,11 +319,13 @@ jobs:
               continue
             fi
             result=$(awk -v p="$pkg_pct" -v pkg="$pkg" 'BEGIN {
-              if (p+0 < 90) { print "FAIL: " pkg " coverage " p "% < 90%"; exit 1 }
-              print "PASS: " pkg " " p "%"
+              if (p+0 < 90) { print "FAIL: " pkg " coverage " p "% < 90%" }
+              else { print "PASS: " pkg " " p "%" }
             }')
             echo "$result"
-            echo "$result" | grep -q '^FAIL' && fail=1 || true
+            if echo "$result" | grep -q '^FAIL'; then
+              fail=1
+            fi
           done < <(awk -v prefix="$KERNEL_PREFIX" '
             $1 ~ "^"prefix {
               path = $1
@@ -363,21 +383,23 @@ jobs:
     # DISCOVERY-01 archtest still passes; no hardcoded `./<path>/...` globs
     # appear in the run block).
     #
-    # Step scoping uses two flags on matrix entries:
+    # Step scoping uses three flags on matrix entries (all booleans, no
+    # string sentinels — YAML null vs '' parsing differs across runners
+    # and is too easy to misread). Default each new shard to false explicitly:
+    #   - `run_main_integration`: enables the main `Integration tests
+    #     (testcontainers)` step + the coverage profile upload. Set false
+    #     on the adapters-race leg, which runs only focused race/-run
+    #     steps and produces no profile.
     #   - `run_adapters_extras`: scopes Redis cluster compile gate +
     #     adapters/postgres coverage gate to the `adapters` main leg
     #     (which produces coverage-integration-adapters.out the gate reads).
-    #   - `run_adapters_race`: scopes the three race / OTel smoke steps to
-    #     the dedicated `adapters-race` leg. Splitting them off keeps the
-    #     adapters main leg's wall-time bounded by the main integration step
-    #     alone (~117s) instead of main + ~70s of serial race steps.
+    #   - `run_adapters_race`: scopes the three race / OTel smoke steps
+    #     to the dedicated `adapters-race` leg. Splitting them off keeps
+    #     the adapters main leg's wall-time bounded by the main integration
+    #     step alone (~117s) instead of main + ~70s of serial race steps.
     #
-    # `filter: ''` on the adapters-race leg disables the main `Integration
-    # tests (testcontainers)` step (guarded by `if: matrix.filter != ''`) —
-    # the race leg only runs the focused -run race steps, not the full
-    # adapter integration suite. Without this guard adapters-race would
-    # re-discover and re-run every postgres / redis / vault integration
-    # already exercised on the adapters main leg.
+    # `filter` is still per-shard (passed via env to the discovery shell);
+    # it's an integration-test routing axis, not a step-enable toggle.
     #
     # New integration test contributors: your package falls into a shard
     # automatically by import-path prefix — no yaml edit needed:
@@ -396,27 +418,32 @@ jobs:
           # post-integration step MUST carry `if: ${{ matrix.run_adapters_extras }}`.
           - shard: adapters
             filter: '^github.com/ghbvf/gocell/adapters/'
+            run_main_integration: true
             run_adapters_extras: true
             run_adapters_race: false
           # adapters-race leg: OTel smoke + PG migrator race + Redis primitive
-          # race only. Empty filter disables the main integration step (see
-          # `if: matrix.filter != ''` guard below). Race steps re-spin small
+          # race only. `run_main_integration: false` disables the main
+          # integration step + coverage upload. Race steps re-spin small
           # containers focused on -run patterns; no coverage profile is
-          # produced, so the upload step is guarded by the same filter check.
+          # produced.
           - shard: adapters-race
             filter: ''
+            run_main_integration: false
             run_adapters_extras: false
             run_adapters_race: true
           - shard: cells
             filter: '^github.com/ghbvf/gocell/cells/'
+            run_main_integration: true
             run_adapters_extras: false
             run_adapters_race: false
           - shard: corebundle
             filter: '^github.com/ghbvf/gocell/(cmd|examples)/'
+            run_main_integration: true
             run_adapters_extras: false
             run_adapters_race: false
           - shard: tests
             filter: '^github.com/ghbvf/gocell/(tests|kernel|runtime|tools)/'
+            run_main_integration: true
             run_adapters_extras: false
             run_adapters_race: false
     steps:
@@ -428,10 +455,10 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Integration tests (testcontainers)
-        # Skip on adapters-race leg (filter==''); that leg only runs the
-        # focused race/OTel steps below, not the full adapter integration
-        # suite.
-        if: ${{ matrix.filter != '' }}
+        # Skipped on adapters-race leg (run_main_integration: false); that
+        # leg only runs the focused race/OTel steps below, not the full
+        # adapter integration suite.
+        if: ${{ matrix.run_main_integration }}
         env:
           GOCELL_TEST_DOCKER_REQUIRED: "1"
           SHARD_NAME: ${{ matrix.shard }}
@@ -663,8 +690,8 @@ jobs:
       - name: Upload integration coverage profile
         # adapters-race leg has no main integration step, so no profile is
         # produced — skip upload to keep upload-artifact from failing on a
-        # missing path. Same `matrix.filter != ''` guard as the main step.
-        if: ${{ matrix.filter != '' }}
+        # missing path. Same flag as the main integration step.
+        if: ${{ matrix.run_main_integration }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-${{ matrix.shard }}
@@ -878,16 +905,22 @@ jobs:
         # test matrix + every shard name in the integration-test matrix is
         # enumerated) so partial glob expansion cannot silently drop a
         # shard.
+        #
+        # SYNC-WITH-MATRIX: this file list must match the build-test +
+        # integration-test matrix `shard` values one-to-one (excluding any
+        # shard whose `run_main_integration: false`, which intentionally
+        # produces no profile — currently only adapters-race). When adding,
+        # renaming, or splitting a matrix shard, update this list in the
+        # same PR or sonarcloud will silently drop the missing shard's
+        # coverage signal.
         run: |
           set -euo pipefail
           echo "mode: atomic" > coverage-merged.out
-          # build-test produces unit profiles for: kernel, tools, runtime,
-          #   cells, others-heavy, others-light (others-* replaces the single
-          #   former `others` shard, see build-test matrix above).
-          # integration-test produces profiles for: adapters (main leg),
-          #   cells, corebundle, tests. The adapters-race leg produces no
-          #   coverage profile (focused race-only steps, no main integration
-          #   run — see matrix definition's filter-empty guard).
+          # build-test profiles: kernel, tools, runtime, cells, others-heavy,
+          #   others-light (others-* replaces the single former `others`
+          #   shard, see build-test matrix above).
+          # integration-test profiles: adapters (main leg), cells, corebundle,
+          #   tests. adapters-race has no profile (run_main_integration: false).
           for f in coverage-shard-kernel.out coverage-shard-tools.out coverage-shard-runtime.out coverage-shard-cells.out \
                    coverage-shard-others-heavy.out coverage-shard-others-light.out \
                    coverage-integration-adapters.out coverage-integration-cells.out coverage-integration-corebundle.out coverage-integration-tests.out; do

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -28,8 +28,10 @@
 #     extra local guard because the integration-tag build break is a
 #     repeatedly-forgotten failure mode (project memory: integration-tag
 #     build). The other three commands do mirror real CI steps
-#     (_build-lint.yml: go build ./... / go vet ./... / go vet -tags=e2e
-#     ./tests/e2e/...).
+#     (_build-lint.yml: go build ./... / go vet -tags=e2e ./tests/e2e/...;
+#     bare `go vet ./...` is intentionally absent from CI because govet
+#     is in golangci-lint v2's default linter set, but the hook still runs
+#     it as a fast standalone fail-fast independent of the lint step).
 #   - archtest is NOT run here. PR #887 first round wired
 #     `SHARD_COUNT=4 bash hack/verify-archtest.sh` as a PR-time
 #     replacement after ADR 202605120000 §Amendment 2026-05-23-pr-time-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,9 +14,10 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 # bus) under -tags=integration. The default build-test job only exercises it
 # via fakePubSub shims (see kernel/outbox/outboxtest/helpers_test.go), so
 # in-package line coverage does not reflect the package's real exercise
-# surface. The kernel coverage gate in .github/workflows/ci.yml already
-# skips outboxtest/celltest with the same rationale; mirror that here to
-# keep SonarCloud's new-code metric honest.
+# surface. The kernel coverage gate in .github/workflows/_build-lint.yml
+# already skips outboxtest/celltest (via the `/[a-z0-9_]+test$` helper
+# exemption regex) with the same rationale; mirror that here to keep
+# SonarCloud's new-code metric honest.
 #
 # runtime/outbox/outboxtest/ is the public in-memory Store + Store conformance
 # suite for runtime/outbox. FakeStore is exercised by unit tests (bootstrap,
@@ -46,8 +47,9 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 #
 # runtime/distlock/locktest/conformance.go borrows the same conformance-suite
 # exclusion principle but applies only to Sonar — the CI kernel coverage gate
-# at .github/workflows/_build-lint.yml runs `go test -cover ./kernel/...` and
-# never reaches runtime/distlock/, so there is no in-CI gate to mirror; the
+# at .github/workflows/_build-lint.yml parses coverage-shard-kernel.out
+# (awk over the per-shard atomic profile) and never reaches runtime/distlock/,
+# so there is no in-CI gate to mirror; the
 # Sonar exclusion stands alone. Rationale: RunDriverTTLConformance / conformC5
 # / conformC6 only run against real backends (adapters/redis integration
 # tests) because FakeDriver wired with FakeClock cannot exercise wall-clock


### PR DESCRIPTION
## Summary

Trims the SonarCloud-gated PR critical path from ~5m to ~4m10s by three shard-level optimizations in `_build-lint.yml`, no Go code changes, no test coverage holes.

| Shard | Before | After | Mechanism |
|---|---|---|---|
| build-test/kernel | 3m08s | ~2m37s | Delete redundant `go vet ./...` (-21s, govet already in golangci-lint default linter set per .golangci.yml line 4) + replace coverage gate's `go test -cover` rerun with awk parse of profile (-12s) |
| integration-test/adapters | 3m25s | ~2m17s | Split race/OTel smoke off to dedicated `adapters-race` matrix leg (~85s parallel vs ~70s serial); main leg keeps Redis cluster vet + adapters/postgres coverage gate |
| build-test/others | 2m20s | ~1m30s | Split into `others-heavy` (./adapters/... ./examples/...) + `others-light` (./cmd/... ./tests/... ./contracts/...) |

Expected critical path = max(all build-test legs, all integration-test legs) + sonarcloud 1m35s ≈ **~4m10s** (down from ~5m). Sonar still on the critical path via `needs: [build-test, integration-test]` — strictly < 4m requires also detaching sonar from `needs:`, deferred.

## Implementation notes

**Kernel coverage gate (awk profile)**: `coverage-shard-kernel.out` is `-covermode=atomic` so each row is `<import_path>/<file>.go:start.col,end.col stmts hits`. Statement-weighted per-package aggregation matches what `go test -cover` stdout prints. `*test`-suffix helper exemption preserved (path-end match, more precise than the old line-anywhere regex). `[no statements]` packages naturally absent from the profile, no special handling. Local verification: ran new awk against fresh profile, every package count matches old stdout exactly.

**adapters-race leg**: `matrix.filter == ''` disables the main integration step (race leg only runs focused -run race patterns, doesn't need full adapter suite re-discovery). Upload coverage step also guarded — no profile is produced, so no artifact missing-path failure.

**others-heavy/light split**: heavy carries the external-SDK-bound subtrees (./adapters/... pulls postgres/redis/rabbitmq/vault/otel SDKs; ./examples/... links every layer end-to-end). Light carries cmd/tests/contracts which compile fast.

**Sonarcloud merge step**: profile list updated to 6 unit shards + 4 integration shards (was 5 + 4). adapters-race produces no profile, so it's intentionally absent — sonar coverage view unchanged.

## ⚠️ Branch protection

This PR renames matrix legs visible in PR check UI:
- `build-test (others, ...)` → split into `build-test (others-heavy, ...)` + `build-test (others-light, ...)`
- New leg `integration-test (adapters-race, ...)`

If branch protection required-checks pins any of these names by exact string, the list needs manual update post-merge — otherwise PRs cannot merge.

## Test plan

- [x] actionlint `.github/workflows/_build-lint.yml` — 0 errors (2 pre-existing shellcheck info, unrelated)
- [x] Local awk equivalence: `go test -covermode=atomic -coverprofile=$TMPDIR/kernel.out ./kernel/...` + new awk → every per-package percentage matches `go test -cover` stdout
- [ ] CI run on this PR — verify critical path lands close to ~4m10s; verify all 18 checks green
- [ ] adapters-race leg actually executes the 3 race steps + reports green (no profile artifact uploaded)
- [ ] others-heavy / others-light each upload their coverage profile; sonarcloud merge step picks them up successfully

ref: kubernetes/kubernetes hack/make-rules/test-integration.sh
ref: grpc/grpc-go .github/workflows/testing.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)