### PR TITLE
fix(health): readyz 主诊断 slog 透传 request ctx + 四通道 ADR 安全文档纠正 (#942)

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -152,7 +152,7 @@ emitter health probe（`outbox_failopen_rate_<cell>`）的注册同理收口：c
 readyz 各字段归属：
 - wire body `dependencies[*]` (200 verbose) — 类型 `verboseDependencyEntry{Status, DurationMs}`，字段集冻结（`HEALTH-VERBOSE-WIRE-SHAPE-FROZEN-01`）。**wire 上不携带 error 文本**——对齐 Kubernetes apiserver healthz.go:274-275 wire/klog 双 buffer 分离。
 - slog `dependencies` — 用 `slog.Group("dependencies", slog.Any(name, entry)...)`，**不要**用 `slog.Any("dependencies", map)`（后者在 unexported 字段下被 JSON handler 输出成 `{}`，丢失诊断，PR #552 实测 bug）。`SlogDependencyEntry` 三字段全 unexported，唯一构造路径 `newRedactedErrorMsg → RedactString`、无 testing backdoor（上游 Hard），下游 `HEALTH-REDACTED-ERROR-MSG-FUNNEL-01` 锁 conversion callsite——funnel 细节见 archtest godoc + ADR。
-- `logDiagnostics` 经 `slog.Log(ctx, level, ...)` 透传 request ctx，readyz record 带 `request_id`/`trace_id`/`correlation_id`（contextHandler 注入，与 errcode `WithInternal` 同源；#942 R2）。slog 是 wire 删 error 文本后的主诊断通道，secret 泄漏面真值以 ADR §3 威胁矩阵为准（裸 JWT/PEM/UUID 仍会进 slog——已知盲区，wire 兜底）。
+- `logDiagnostics` 经 `slog.Log(ctx, level, ...)` 透传 request ctx，readyz record 带 `request_id` + `correlation_id`（RequestID middleware 注入，与 errcode `WithInternal` 同源；#942 R2）；`trace_id` 在 probe 端点**默认不出现**——`DefaultProbeFilter` 跳过 `/healthz /readyz /livez /metrics` 的 tracing span 创建。slog 是 wire 删 error 文本后的主诊断通道，secret 泄漏面真值以 ADR §3 威胁矩阵为准（裸 JWT/PEM/UUID 仍会进 slog——已知盲区，wire 兜底）。
 
 详见 ADR `docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md`。
 

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -147,11 +147,12 @@ emitter health probe（`outbox_failopen_rate_<cell>`）的注册同理收口：c
 | a. Message | `errcode.Message` const literal | ✓ | ✓ | 不需要 |
 | b. Details | `errcode.Details` `[]slog.Attr` | 4xx ✓ / 5xx strip | ✓ | runtime 字段为低敏感 |
 | c. Internal | `errcode.WithInternal` | ✗ | ✓ | server-only |
-| **d. Ops-Diagnostics** | handler-side `slog.Warn` typed payload | ✗ | ✓ | **typed funnel + archtest** |
+| **d. Ops-Diagnostics** | handler-side `slog.Log(ctx, level, ...)` typed payload（透传 request ctx 关联字段） | ✗ | ✓ | **typed funnel + archtest** |
 
 readyz 各字段归属：
 - wire body `dependencies[*]` (200 verbose) — 类型 `verboseDependencyEntry{Status, DurationMs}`，字段集冻结（`HEALTH-VERBOSE-WIRE-SHAPE-FROZEN-01`）。**wire 上不携带 error 文本**——对齐 Kubernetes apiserver healthz.go:274-275 wire/klog 双 buffer 分离。
 - slog `dependencies` — 用 `slog.Group("dependencies", slog.Any(name, entry)...)`，**不要**用 `slog.Any("dependencies", map)`（后者在 unexported 字段下被 JSON handler 输出成 `{}`，丢失诊断，PR #552 实测 bug）。`SlogDependencyEntry` 三字段全 unexported，唯一构造路径 `newRedactedErrorMsg → RedactString`、无 testing backdoor（上游 Hard），下游 `HEALTH-REDACTED-ERROR-MSG-FUNNEL-01` 锁 conversion callsite——funnel 细节见 archtest godoc + ADR。
+- `logDiagnostics` 经 `slog.Log(ctx, level, ...)` 透传 request ctx，readyz record 带 `request_id`/`trace_id`/`correlation_id`（contextHandler 注入，与 errcode `WithInternal` 同源；#942 R2）。slog 是 wire 删 error 文本后的主诊断通道，secret 泄漏面真值以 ADR §3 威胁矩阵为准（裸 JWT/PEM/UUID 仍会进 slog——已知盲区，wire 兜底）。
 
 详见 ADR `docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md`。
 

--- a/docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md
+++ b/docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md
@@ -268,6 +268,23 @@ ctx 仅承载关联值（非 secret），不引入新泄漏面——见 §4 威�
   不携带 probe error 文本，**不扩大 d 列暴露面**。
 - (P1)(P2) 两条前提仍由 guard ①④ 机器强制，未受本次 amendment 影响。
 
+§3 八行逐行对照（改动前 → 改动后，无 ✅→⚠️/❌ 回归）：
+
+| §3 行（Secret 形态） | 改动前 d 列 | 改动后 d 列 |
+|---|---|---|
+| `password=hunter2`（结构化） | ✓ masked | ✓ masked（不变） |
+| `Authorization: Bearer …` | ✓ masked | ✓ masked（不变） |
+| `Authorization: Basic …` | ✓ masked | ✓ masked（不变） |
+| 裸 JWT 子串（无 key 锚） | ⚠ 泄漏到 slog | ⚠ 泄漏到 slog（不变；§SIEM/ELK 改为与此一致） |
+| PEM 块（无 key 锚） | ⚠ 泄漏到 slog | ⚠ 泄漏到 slog（不变） |
+| 裸 UUID API key | ⚠ 泄漏到 slog | ⚠ 泄漏到 slog（不变） |
+| panic %v 含 secret | ✓ masked | ✓ masked（不变） |
+| `connection_string=…;Pwd=…` | ✓ masked | ✓ masked（不变） |
+
+a/b/c 列「✗ wire 不带文本」八行全不变。本次 amendment 仅删除 §SIEM/ELK 与 ⚠ 三行矛盾的
+绝对化断言（文档纠正）+ D8 新增非 secret 关联 ID 到 record（不进 d 列暴露面）；**无任一
+格子从 ✅ 退为 ⚠️/❌**，无需补偿措施。
+
 **slog 序列化路径**：见 §2 D6 — `slog.Group("dependencies", slog.Any(name, entry)...)` 是唯一让 LogValue 真生效的 slog idiom，所有 handler 输出一致 snake_case。**严禁退回 `slog.Any("dependencies", map)` 形态**——unexported 字段 + JSON handler 会输出 `{}`，所有诊断信息丢失（round-4 实测 bug）。
 
 ## §5 ADR amendment 验证矩阵（与 ADR `202605051730` 关系）

--- a/docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md
+++ b/docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md
@@ -74,7 +74,7 @@ typed `dependencies` 字段。
 | **a. Message** | `errcode.Message` (const literal) | 下发 | 下发 | 记录 | 不需要（const literal，无 runtime 数据） |
 | **b. Details** | `errcode.Details` (`[]slog.Attr`) | 下发 | strip | 记录 | runtime 字段为程序员选择的低敏感字段（ID / 枚举 / 计数），无 raw secret |
 | **c. Internal** | `errcode.WithInternal` | ❌ 不下发 | ❌ 不下发 | 记录 | runtime 调试信息（堆栈摘要、SQL 片段），仅服务端可见 |
-| **d. Ops-Diagnostics** | handler-side `slog.Warn` 内的 typed payload | ❌ | ❌ | 记录 | **必须**经 typed funnel（health 包：`newRedactedErrorMsg(err) → redactedErrorMsg` 强制 `pkg/redaction.RedactString`） |
+| **d. Ops-Diagnostics** | handler-side `slog.Log(ctx, level, ...)` 内的 typed payload（D8 起透传 request ctx 关联字段） | ❌ | ❌ | 记录 | **必须**经 typed funnel（health 包：`newRedactedErrorMsg(err) → redactedErrorMsg` 强制 `pkg/redaction.RedactString`） |
 
 a/b/c 三层延续 ADR `202605051730-adr-errcode-message-pii-safety.md`；d 通道是
 本 ADR 新增的形式化——handler 在 errcode envelope 之外独立向 slog 写出
@@ -151,8 +151,10 @@ JSON handler 输出 `"dependencies":{"db":{}}`——所有字段丢失，operato
 修复：`logDiagnostics` 改用 `slog.Group("dependencies", slog.Any(name, entry)...)`。
 Group 内每个 sub-attr 的 value 是 SlogDependencyEntry（LogValuer），handler 在 Resolve 阶段
 调 LogValue 返回 GroupValue，所有 handler（JSON / text / logfmt）一致输出 snake_case。
-text 输出形态：`dependencies.db.status=unhealthy dependencies.db.duration_ms=0 dependencies.db.error_msg=<REDACTED>`。
-JSON 输出形态：`"dependencies":{"db":{"status":"unhealthy","duration_ms":0,"error_msg":"<REDACTED>"}}`。
+text 输出形态（probe error `dial failed password=hunter2 host=mq` 脱敏后）：
+`dependencies.db.status=unhealthy dependencies.db.duration_ms=0 dependencies.db.error_msg="dial failed password=<REDACTED> host=mq"`
+（text handler 对含空格 / `=` 的值加引号；空 error_msg 输出 `error_msg=""`，单 token 无特殊字符如 `error_msg=timeout` 则不加引号）。
+JSON 输出形态：`"dependencies":{"db":{"status":"unhealthy","duration_ms":0,"error_msg":"dial failed password=<REDACTED> host=mq"}}`。
 
 healthtest 包内 `ReadyzUnhealthyDeps` + `HasReadyzDependencyStatus` + health 包本地
 `readyzUnhealthyDeps` helper 全部改用 `slog.Value.Group()` 遍历——而非旧的 type-assert
@@ -174,6 +176,22 @@ upstream Hard 现在没有任何 backdoor：SlogDependencyEntry 三个字段 une
 exported 构造函数 + redactedErrorMsg 是包私有 newtype——外部包构造该类型在 Go 编译器
 层完全不可表达。
 
+### D8 — `logDiagnostics` 透传 request ctx（#942 R2 修复）
+
+D5 把 `logUnhealthy` 改名 `logDiagnostics` 时，slog 调用仍是
+`slog.Log(context.Background(), level, msg, ...)`。wire 删 error 文本后（D1），slog 是
+**主诊断通道**——用 `context.Background()` 会丢框架 contextHandler
+（`runtime/observability/logging`）从 ctx 注入的 `request_id` / `trace_id` /
+`correlation_id`，使 503 / degraded 记录无法关联到触发它的请求（PR #552 review R2）。
+
+修复：`logDiagnostics` 加 `ctx context.Context` 首参，`writeTo`（持有 request ctx）的
+degraded / unhealthy 两条调用路径都传入，末行改 `slog.Log(ctx, level, msg, ...)`。关联
+字段来源与 errcode `WithInternal` 路径**同源**（同一 contextHandler）。同 readyz 路径的
+shutting-down / singleflight-error / panic-recover 三处包级 slog 调用一并改用
+`slog.InfoContext` / `slog.ErrorContext`，消除 readyz 路径全部 ctx 丢失点。
+
+ctx 仅承载关联值（非 secret），不引入新泄漏面——见 §4 威胁矩阵 #942 重评。
+
 ## §3 Threat Matrix
 
 | Secret 形态 | 通道 a/b/c 暴露面 | 通道 d 暴露面 | 备注 |
@@ -189,14 +207,34 @@ exported 构造函数 + redactedErrorMsg 是包私有 newtype——外部包构�
 
 ⚠ 项是"已知盲区"（regex 类 redaction 共有），不在本 ADR 范围内解决；通过通道 a/b 完全不下发文本兜底——即便 d 通道 mask 漏，wire 仍不携带任何文本。
 
-### SIEM/ELK fingerprint 风险
+### SIEM/ELK 转发：redactor 覆盖面 vs 真实泄漏面
 
-mask 后 `<REDACTED>` 是固定字面量，value 长度信息丢失。SIEM/ELK 转发场景下：
-- 原始 secret 文本不出现在日志流中（key 保留，value 被替换），不存在通过日志泄漏 secret 的路径。
-- `<REDACTED>` 字面量长度恒定，不能反推原始 value 长度，不构成旁信道。
-- 对 SIEM 告警规则而言，`error_msg` 含 `<REDACTED>` 是正常形态（表示 secret 已被 mask），不是告警信号。
+通道 d（slog）是 wire 删 error 文本（D1）之后的**主诊断通道**，因此必须诚实区分 redactor
+*覆盖到*的形态与 *覆盖不到*的真实泄漏面——二者不能混为一谈：
 
-综合结论：SIEM/ELK 转发场景下无额外 fingerprint 风险，属已知接受非威胁。
+- **覆盖面（已脱敏）**：结构化 `key=value` 形态的 secret——`password=` / `Authorization:` /
+  `connection_string=` / JSON quoted key（见 `pkg/redaction.sensitiveKeyPattern`）。这类
+  value 段被替换为 `<REDACTED>`，原始 secret 文本不出现在日志流（§3 矩阵前三行 + panic /
+  connection_string 行）。
+- **真实泄漏面（已知盲区，会进 slog）**：无 key 锚的裸 token——裸 JWT 子串、PEM 块、
+  裸 UUID API key（§3 威胁矩阵 ⚠ 三行）。regex redaction 必须有 key 锚才能命中，这类
+  token **会原样写入 slog**。这不是「无泄漏路径」，而是「泄漏面收敛到 server-side slog
+  单一通道，且 wire 结构性永不携带任何 error 文本兜底」。
+
+接受该盲区的依据是**纵深防御，非「已消除」**：
+
+1. **wire 兜底**：即便 d 通道 mask 漏，通道 a/b 在 wire 上结构性不下发任何 error 文本
+   （`verboseDependencyEntry` 字段集冻结无 error 字段）——公网客户端永远拿不到。
+2. **通道受限**：slog 落 SIEM / ELK / Datadog，是运维受限的内部诊断面，不对外暴露。
+3. **probe 作者纵深**：probe error message 应避免硬编码完整 secret / PEM / 裸 token
+   （§3 备注列的纵深指引）；后续可加针对裸 base64url JWT 的 pattern 进一步收窄盲区。
+
+`<REDACTED>` fingerprint：mask 后为固定字面量，长度恒定，不反推原始 value 长度，不构成
+旁信道；`error_msg` 含 `<REDACTED>` 是 secret 已 mask 的正常形态，非告警信号。
+
+> **纠正（#942 R3）**：本节早期版本曾断言「不存在通过日志泄漏 secret 的路径」，与 §3
+> 威胁矩阵 ⚠ 三行（裸 JWT / PEM / UUID 泄漏到 slog）直接矛盾——运维若以前者为准会误判
+> d 通道已 fail-closed。该绝对化断言已删除；secret 泄漏面的真值以 §3 威胁矩阵为准。
 
 ## §4 Enforcement Funnel Matrix
 
@@ -217,14 +255,28 @@ mask 后 `<REDACTED>` 是固定字面量，value 长度信息丢失。SIEM/ELK �
 
 **威胁矩阵（§3）重评**：#947→#996 是 enforcement **强化**，无 ✅→⚠️ 回归。§3 所有行依赖两条前提：(P1)「通道 d 的每个 error 文本值都由 `newRedactedErrorMsg` 创建」和 (P2)「`newRedactedErrorMsg` 真的调用 `RedactString` 脱敏」。**纠正先前版本的过度声明**：曾写「guard ②（字段类型）把该前提机器强制」——这是错的。guard ②（`errorMsg` 类型必为 `redactedErrorMsg`）只保证字段**类型**，既不保证创建点收口（P1）也不保证 body 脱敏（P2）。真正的机器强制是：**guard ①（创建点 funnel）强制 P1**（含 untyped-const 入流，非仅显式 conversion——#996 F1 补；先前"字段类型即足够"漏了包内 `SlogDependencyEntry{errorMsg:"raw"}` / `var x redactedErrorMsg="raw"` 入流），**guard ④（body-redaction form-lock）强制 P2**（#996 F2 补；先前无任何 guard 验证 body 调 RedactString，去掉它 ①②③ 全绿）。guard ②/③ 是 ① 的反 vacuous 支撑（字段退 string / funnel 消失则 ① 失守）。四锁齐备后 §3 各行所依赖的 funnel **应用性 + 脱敏性**才真正从「文档断言」升级为「archtest 强制」。
 
+**威胁矩阵（§3）重评 — #942 R2/R3 amendment**：本次 amendment 是「文档纠正（R3，重写
+§SIEM/ELK）+ slog ctx 透传（R2，D8）」，**逐行重评无 ✅→⚠️ 回归**：
+
+- §3 八行的 a/b/c 列「✗ wire 不带文本」全部不变（wire shape 未动，`verboseDependencyEntry`
+  字段集仍冻结）。
+- d 列三个 ⚠ 盲区行（裸 JWT / PEM / UUID）表述本就准确；本次仅把 §SIEM/ELK 与之**对齐**
+  ——删除矛盾的「无泄漏路径」绝对化断言，§SIEM/ELK 是被纠正方，§3 矩阵是真值源。无格子
+  从 ✅ 变 ⚠️。
+- D8 的 ctx 透传只新增 `request_id` / `trace_id` / `correlation_id` 关联字段到 slog
+  record。这些是关联 ID（非 secret，本就由 contextHandler 在全框架所有 slog record 注入），
+  不携带 probe error 文本，**不扩大 d 列暴露面**。
+- (P1)(P2) 两条前提仍由 guard ①④ 机器强制，未受本次 amendment 影响。
+
 **slog 序列化路径**：见 §2 D6 — `slog.Group("dependencies", slog.Any(name, entry)...)` 是唯一让 LogValue 真生效的 slog idiom，所有 handler 输出一致 snake_case。**严禁退回 `slog.Any("dependencies", map)` 形态**——unexported 字段 + JSON handler 会输出 `{}`，所有诊断信息丢失（round-4 实测 bug）。
 
 ## §5 ADR amendment 验证矩阵（与 ADR `202605051730` 关系）
 
 本 ADR **扩展**而非 amend 现有 errcode-PII ADR。errcode 三层模型保持不变；新增的
-ops-diagnostics 第 4 通道在 errcode 之外独立运作（handler 直接 `slog.Warn(...)`，
-不经 errcode envelope）。因此现有 `202605051730` ADR 不需要 §"威胁矩阵" / §D
-段重审；本 ADR §3 是 readyz 自身的新威胁矩阵，与之并列。
+ops-diagnostics 第 4 通道在 errcode 之外独立运作——handler 经
+`slog.Log(ctx, level, ...)`（D8 起透传 request ctx）写出 typed payload，不经 errcode
+envelope。因此现有 `202605051730` ADR 不需要 §"威胁矩阵" / §D 段重审；本 ADR §3 是
+readyz 自身的新威胁矩阵，与之并列。
 
 后续如有新 handler 引入"ops-diagnostics 通道"形态（典型场景：recovery middleware
 panic dump、outbox last_error sanitize、auditquery payload redaction），该 handler

--- a/docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md
+++ b/docs/architecture/202605171200-adr-readyz-verbose-four-channel-redaction.md
@@ -95,7 +95,7 @@ archtest 锁形态"双保险。
 | slog `dependencies` map (`map[name]slogDependencyEntry`) | d | `slog.Any` | **ErrorMsg 字段类型 = `redactedErrorMsg`，由 `newRedactedErrorMsg` funnel 强制 `pkg/redaction.RedactString`**；适用于 degraded（Info 级）和 unhealthy（Warn 级）两条路径 |
 | slog `adapters` map (`map[role]info`) | d | `slog.Any` | adapter info 是部署期声明（in-memory / postgres / redis 等），无 runtime secret |
 | wire body `dependencies[*]` (200 verbose) | a body fragment | `map[name]verboseDependencyEntry` | struct 字段集冻结无 error → wire 上**结构性**无 error 文本；适用于 degraded 和 healthy 200 响应 |
-| degraded 路径 slog level | d | `slog.LevelInfo` | `logDiagnostics(slog.LevelInfo, "readyz degraded")` — 操作员关注但不触发告警；unhealthy 路径用 `slog.LevelWarn` |
+| degraded 路径 slog level | d | `slog.LevelInfo` | `logDiagnostics(ctx, slog.LevelInfo, "readyz degraded")`（ctx 首参见 D8）— 操作员关注但不触发告警；unhealthy 路径用 `slog.LevelWarn` |
 
 ### D4 — RETRACTS：旧 `health.go:426` 设计
 
@@ -129,8 +129,9 @@ ErrorMsg 从未被 operator 看到（F3 / PR #552 review P1 finding）。
 
 修复：
 
-1. `logUnhealthy` 重命名为 `logDiagnostics(level slog.Level, msg string, extra ...slog.Attr)`，
-   level 参数区分 unhealthy（`slog.LevelWarn`）和 degraded（`slog.LevelInfo`）。
+1. `logUnhealthy` 重命名为 `logDiagnostics(ctx context.Context, level slog.Level, msg string, extra ...slog.Attr)`，
+   level 参数区分 unhealthy（`slog.LevelWarn`）和 degraded（`slog.LevelInfo`）。ctx 首参由
+   #942 R2 加入（见 D8），此处签名为当前形态。
 2. `writeTo` 在 "degraded" 路径也调用 `logDiagnostics`，确保 channel d 覆盖两种非健康状态。
 3. unhealthy 路径额外传 `slog.String("reason", reason)` attr，保持既有 reason 字段。
 
@@ -181,14 +182,28 @@ exported 构造函数 + redactedErrorMsg 是包私有 newtype——外部包构�
 D5 把 `logUnhealthy` 改名 `logDiagnostics` 时，slog 调用仍是
 `slog.Log(context.Background(), level, msg, ...)`。wire 删 error 文本后（D1），slog 是
 **主诊断通道**——用 `context.Background()` 会丢框架 contextHandler
-（`runtime/observability/logging`）从 ctx 注入的 `request_id` / `trace_id` /
-`correlation_id`，使 503 / degraded 记录无法关联到触发它的请求（PR #552 review R2）。
+（`runtime/observability/logging`）从 ctx 注入的关联字段，使 503 / degraded 记录无法关联
+到触发它的请求（PR #552 review R2）。
 
 修复：`logDiagnostics` 加 `ctx context.Context` 首参，`writeTo`（持有 request ctx）的
 degraded / unhealthy 两条调用路径都传入，末行改 `slog.Log(ctx, level, msg, ...)`。关联
 字段来源与 errcode `WithInternal` 路径**同源**（同一 contextHandler）。同 readyz 路径的
 shutting-down / singleflight-error / panic-recover 三处包级 slog 调用一并改用
 `slog.InfoContext` / `slog.ErrorContext`，消除 readyz 路径全部 ctx 丢失点。
+
+**关联字段在 probe 端点的实际可见性**（#942 R2 二轮复审纠正——先前误写「record 必带
+request_id / trace_id / correlation_id」）：
+
+- `request_id` + `correlation_id`：**出现**。`RequestID` middleware（`runtime/http/middleware`）
+  在 listener-root chain 且无 probe filter，对 `/readyz` 照常运行（同时把 request_id bridge
+  成 correlation_id）。
+- `trace_id`：**默认不出现**。`Tracing` middleware 带 `WithProbeFilter(DefaultProbeFilter)`，
+  跳过 `/healthz /readyz /livez /metrics` 的 span 创建（`TestBootstrap_TracingE2E_InfraEndpoints`
+  断言），故 `ctxkeys.TraceID` 未设。仅当部署移除 probe filter（不推荐——高频探针会吃 span
+  预算）且 ctx 携带 span 时才出现。
+
+故 R2 的实质收益是 probe 端点 record 重获 `request_id` + `correlation_id` 关联（此前被
+`context.Background()` 丢弃），不含 `trace_id`。
 
 ctx 仅承载关联值（非 secret），不引入新泄漏面——见 §4 威胁矩阵 #942 重评。
 
@@ -263,9 +278,10 @@ ctx 仅承载关联值（非 secret），不引入新泄漏面——见 §4 威�
 - d 列三个 ⚠ 盲区行（裸 JWT / PEM / UUID）表述本就准确；本次仅把 §SIEM/ELK 与之**对齐**
   ——删除矛盾的「无泄漏路径」绝对化断言，§SIEM/ELK 是被纠正方，§3 矩阵是真值源。无格子
   从 ✅ 变 ⚠️。
-- D8 的 ctx 透传只新增 `request_id` / `trace_id` / `correlation_id` 关联字段到 slog
-  record。这些是关联 ID（非 secret，本就由 contextHandler 在全框架所有 slog record 注入），
-  不携带 probe error 文本，**不扩大 d 列暴露面**。
+- D8 的 ctx 透传只新增非 secret 关联 ID（probe 端点实际为 `request_id` + `correlation_id`，
+  `trace_id` 被 DefaultProbeFilter 拦掉——见 D8 末段）到 slog record。这些是关联 ID（非 secret，
+  本就由 contextHandler 在全框架所有 slog record 注入），不携带 probe error 文本，**不扩大 d
+  列暴露面**。
 - (P1)(P2) 两条前提仍由 guard ①④ 机器强制，未受本次 amendment 影响。
 
 §3 八行逐行对照（改动前 → 改动后，无 ✅→⚠️/❌ 回归）：

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -33,25 +33,34 @@ All health responses use the project-wide JSON envelope
   never reaches public clients).
 
 The verbose breakdown (cells + dependencies + optional adapters) lives
-under `data.*` on 200 only. On 503 the wire body carries no breakdown; the
-same data is emitted to server-side `slog`
-(`logger.Warn("readyz unhealthy", status, reason, cells, dependencies, adapters)`)
-so on-call retains the diagnostic without leaking it to public 503
-consumers. ref: k8s.io/apiserver/pkg/server/healthz — failed checks do not
-surface in the 503 body; verbose breakdown is operator-only.
+under `data.*` on 200 (healthy **and** degraded) only. On 503 the wire body
+carries no breakdown; the same data is emitted to server-side `slog` via
+`slog.Log(ctx, level, "readyz <status>", ...)` — a `slog.Group("dependencies",
+...)` plus status / reason / cells / adapters attrs — so on-call retains the
+diagnostic without leaking it to public 503 consumers. Because `slog.Log`
+receives the **request context**, every readyz record also carries the
+framework correlation fields (`request_id` / `trace_id` / `correlation_id`)
+injected by the logging contextHandler — the same source as the errcode
+`WithInternal` path — so a 503/degraded record can be joined back to the
+request that produced it (#942). ref: k8s.io/apiserver/pkg/server/healthz —
+failed checks do not surface in the 503 body; verbose breakdown is
+operator-only.
 
 Public `/readyz` 503 reasons are intentionally low-cardinality. Operators
 read them from the structured `slog` record (the wire body carries an empty
 details array):
 
-| slog level | slog `status` | slog `reason` | Meaning |
-|------------|---------------|---------------|---------|
-| `Warn` (msg=`readyz unhealthy`) | `unhealthy` | `readiness_failed` | One or more cells/probes failed, or the readiness aggregator failed closed. Internal computation failures are logged server-side and do not create a separate public reason. |
-| `Info` (msg=`readyz: shutting down (graceful_shutdown)`) | `shutting_down` | `graceful_shutdown` | The process is draining and should be removed from load balancer traffic. |
+| slog level | slog `msg` | slog `status` | slog `reason` | Meaning |
+|------------|------------|---------------|---------------|---------|
+| `Warn` | `readyz unhealthy` | `unhealthy` | `readiness_failed` | One or more cells/probes failed (HTTP 503), or the readiness aggregator failed closed. Internal computation failures are logged server-side and do not create a separate public reason. |
+| `Info` | `readyz degraded` | `degraded` | — (no `reason` attr) | One or more cells/probes are degraded but serving (**HTTP 200**, fail-open). Emitted at Info so operators can observe degraded dependency `error_msg` without a Warn-level alert. |
+| `Info` | `readyz: shutting down (graceful_shutdown)` | `shutting_down` | `graceful_shutdown` | The process is draining and should be removed from load balancer traffic. |
 
 On-call dashboards / alert rules that filter by level alone will miss the
-`shutting_down` path; query both `level=Warn AND msg="readyz unhealthy"`
-and `level=Info AND status="shutting_down"` to capture every 503.
+`degraded` and `shutting_down` paths; query `level=Warn AND msg="readyz
+unhealthy"`, `level=Info AND msg="readyz degraded"`, and `level=Info AND
+status="shutting_down"` to capture every non-healthy outcome (degraded is a
+200, the other two are 503).
 
 ## Kubernetes probes — MUST NOT use `?verbose`
 
@@ -117,6 +126,33 @@ the `X-Readyz-Token` header.
 }
 ```
 
+200 (degraded — one or more cells/probes degraded but serving). A degraded
+service is **fail-open**: it returns HTTP 200 so it is NOT evicted from load
+balancer / kubelet rotation (ref: envoyproxy/envoy admin `/ready` — DEGRADED
+returns 200). The verbose wire body carries the per-dependency `{status,
+duration_ms}` exactly like the healthy case; `error_msg` is **never** on the
+wire (it rides the slog channel only):
+
+```json
+{
+  "data": {
+	    "status": "degraded",
+	    "cells":   { "accesscore": "healthy", "auditcore": "degraded" },
+	    "dependencies": {
+	      "postgres_ready": { "status": "healthy", "duration_ms": 3 },
+	      "rabbitmq_ready":  { "status": "degraded", "duration_ms": 8 }
+	    },
+	    "adapters": { "storage": "postgres", "eventbus": "rabbitmq" }
+	  }
+}
+```
+
+The degraded breakdown is additionally emitted to slog at **Info** level
+(`msg="readyz degraded"`), so operators see the degraded dependency
+`error_msg` without a Warn-level alert firing. The slog shape is identical to
+the unhealthy example below, only the level (`INFO`) and `msg`
+(`readyz degraded`) differ, and there is no `reason` attr.
+
 503 (one or more probes unhealthy):
 
 ```json
@@ -141,18 +177,22 @@ triggering request was verbose:
   `?verbose=true`): slog record additionally carries cells +
   dependencies + adapters maps.
 
-Verbose 503 slog example（text handler，`-log-format=text` 默认）：
+Verbose 503 slog example（text handler，`-log-format=text` 默认）。实际是单行
+key=value（这里按字段折行只为可读）。`request_id` / `trace_id` 等关联字段由 logging
+contextHandler 注入。**注意 `error_msg` 的引号规则**（text handler 的 logfmt 行为，决定
+下方 grep 怎么写）：含空格或 `=` 的值加引号、空值输出 `error_msg=""`、单 token 无特殊
+字符（如 `error_msg=timeout`）**不加引号**：
 
 ```
-level=WARN msg="readyz unhealthy"
-  status=unhealthy reason=readiness_failed
+time=2026-05-26T03:50:06Z level=WARN msg="readyz unhealthy"
+  request_id=7f3c… trace_id=a1b2… status=unhealthy reason=readiness_failed
   cells=map[accesscore:healthy auditcore:degraded]
   dependencies.postgres_ready.status=healthy
   dependencies.postgres_ready.duration_ms=3
   dependencies.postgres_ready.error_msg=""
   dependencies.rabbitmq_ready.status=unhealthy
   dependencies.rabbitmq_ready.duration_ms=12
-  dependencies.rabbitmq_ready.error_msg="<REDACTED>"
+  dependencies.rabbitmq_ready.error_msg="dial failed password=<REDACTED> host=mq"
   adapters=map[storage:postgres eventbus:rabbitmq]
 ```
 
@@ -162,16 +202,23 @@ Verbose 503 slog example（JSON handler，`-log-format=json`）：
 {
   "level": "WARN",
   "msg": "readyz unhealthy",
+  "request_id": "7f3c…",
+  "trace_id": "a1b2…",
   "status": "unhealthy",
   "reason": "readiness_failed",
   "cells": {"accesscore": "healthy", "auditcore": "degraded"},
   "dependencies": {
     "postgres_ready": {"status": "healthy", "duration_ms": 3, "error_msg": ""},
-    "rabbitmq_ready": {"status": "unhealthy", "duration_ms": 12, "error_msg": "<REDACTED>"}
+    "rabbitmq_ready": {"status": "unhealthy", "duration_ms": 12, "error_msg": "dial failed password=<REDACTED> host=mq"}
   },
   "adapters": {"storage": "postgres", "eventbus": "rabbitmq"}
 }
 ```
+
+The redacted `error_msg` retains the surrounding key context (`dial failed … host=mq`)
+and masks only the sensitive value (`password=<REDACTED>`); it is **not** truncated
+(slog has no wire-capacity constraint). A degraded 200 record is identical except
+`level=INFO`, `msg="readyz degraded"`, and no `reason` attr.
 
 `dependencies` 字段是 `slog.Group` 而非 `slog.Any(map)`——Group 内每个 sub-attr 的 value
 是 `health.SlogDependencyEntry`（LogValuer），handler 在 Resolve 阶段调
@@ -193,14 +240,20 @@ error 文本就无需截断）。Probe 实现仍应避免在 error message 中�
 
 ## 操作员诊断 cookbook
 
+> JSON 是推荐的诊断格式——嵌套对象路径可被 jq / LogQL 直接索引，且不受 text handler
+> 的引号歧义影响。需要按请求关联时，所有 readyz record 都带 `request_id` / `trace_id`。
+
 ### JSON handler（`-log-format=json`）
 
 ```bash
-# 过滤所有 readyz unhealthy 事件并展示 dependencies 字段
-kubectl logs <pod> | jq 'select(.msg == "readyz unhealthy") | .dependencies'
+# unhealthy(503) 与 degraded(200) 两类非健康记录都看（degraded 是 Info，别只过滤 unhealthy）
+kubectl logs <pod> | jq 'select(.msg == "readyz unhealthy" or .msg == "readyz degraded") | {msg, request_id, dependencies}'
 
-# 进一步定位某个 probe 的 error_msg
-kubectl logs <pod> | jq 'select(.msg == "readyz unhealthy") | .dependencies.rabbitmq_ready.error_msg'
+# 定位某个 probe 的 error_msg（healthy probe 为空字符串）
+kubectl logs <pod> | jq 'select(.msg|test("readyz (unhealthy|degraded)")) | .dependencies.rabbitmq_ready.error_msg'
+
+# 按 request_id 关联一次具体请求的所有日志（R2：readyz record 现带关联字段）
+kubectl logs <pod> | jq 'select(.request_id == "7f3c…")'
 
 # Grafana / Loki LogQL 查询示例（结构化字段索引）：
 # {app="myapp"} | json | msg = "readyz unhealthy" | dependencies_rabbitmq_ready_status = "unhealthy"
@@ -209,16 +262,19 @@ kubectl logs <pod> | jq 'select(.msg == "readyz unhealthy") | .dependencies.rabb
 ### Text handler（`-log-format=text`，默认）
 
 ```bash
-# 过滤 readyz unhealthy 行
-kubectl logs <pod> | grep "readyz unhealthy"
+# 过滤 unhealthy(503) 与 degraded(200) 两类记录
+kubectl logs <pod> | grep -E 'msg="readyz (unhealthy|degraded)"'
 
-# 提取某个 probe 的 error_msg（key=value 形态）
-kubectl logs <pod> | grep "readyz unhealthy" | grep -oE 'dependencies\.rabbitmq_ready\.error_msg="[^"]*"'
+# 提取某个 probe 的 error_msg。值可能加引号（含空格/=，如 "dial … <REDACTED>"）也可能
+# 不加引号（单 token，如 timeout）——两种都匹配，否则会漏掉 unquoted 值：
+kubectl logs <pod> | grep -E 'msg="readyz (unhealthy|degraded)"' \
+  | grep -oE 'dependencies\.rabbitmq_ready\.error_msg=("[^"]*"|[^ ]+)'
 ```
 
 text handler 输出形态是 `dependencies.<probe_name>.<field>=<value>` 而非嵌套 `{}` 块，
-Loki / Grafana 通过 key=value 解析直接索引。如需更结构化的查询能力（嵌套对象路径），
-切换到 JSON handler。
+Loki / Grafana 通过 key=value 解析直接索引。`error_msg` 的引号取决于值内容（含空格/`=`
+→ 加引号；空 → `""`；单 token → 不加引号），所以**只匹配 `error_msg="…"` 会漏掉 unquoted
+值**。如需稳定的结构化查询（不受引号规则影响），切换到 JSON handler。
 
 ### Waiving the verbose endpoint
 

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -38,11 +38,15 @@ carries no breakdown; the same data is emitted to server-side `slog` via
 `slog.Log(ctx, level, "readyz <status>", ...)` — a `slog.Group("dependencies",
 ...)` plus status / reason / cells / adapters attrs — so on-call retains the
 diagnostic without leaking it to public 503 consumers. Because `slog.Log`
-receives the **request context**, every readyz record also carries the
-framework correlation fields (`request_id` / `trace_id` / `correlation_id`)
-injected by the logging contextHandler — the same source as the errcode
-`WithInternal` path — so a 503/degraded record can be joined back to the
-request that produced it (#942). ref: k8s.io/apiserver/pkg/server/healthz —
+receives the **request context**, a readyz record carries the framework
+correlation fields the contextHandler injects from ctx — the same source as the
+errcode `WithInternal` path. On probe endpoints those are **`request_id` +
+`correlation_id`** (the RequestID middleware runs on `/readyz` and is not
+probe-filtered), so a 503/degraded record can be joined back to the request
+that produced it (#942). **`trace_id` is NOT emitted on probe endpoints by
+default** — the Tracing middleware's `DefaultProbeFilter` skips span creation
+for `/healthz`, `/readyz`, `/livez`, `/metrics`; it only appears if a
+deployment removes that filter. ref: k8s.io/apiserver/pkg/server/healthz —
 failed checks do not surface in the 503 body; verbose breakdown is
 operator-only.
 
@@ -178,14 +182,15 @@ triggering request was verbose:
   dependencies + adapters maps.
 
 Verbose 503 slog example（text handler，`-log-format=text` 默认）。实际是单行
-key=value（这里按字段折行只为可读）。`request_id` / `trace_id` 等关联字段由 logging
-contextHandler 注入。**注意 `error_msg` 的引号规则**（text handler 的 logfmt 行为，决定
-下方 grep 怎么写）：含空格或 `=` 的值加引号、空值输出 `error_msg=""`、单 token 无特殊
-字符（如 `error_msg=timeout`）**不加引号**：
+key=value（这里按字段折行只为可读）。`request_id` / `correlation_id` 由 RequestID
+middleware 经 contextHandler 注入（probe 端点有；`trace_id` 默认无——见上文 preamble）。
+**注意 `error_msg` 的引号规则**（text handler 的 logfmt 行为，决定下方 grep 怎么写）：含
+空格或 `=` 的值加引号、空值输出 `error_msg=""`、单 token 无特殊字符（如 `error_msg=timeout`）
+**不加引号**：
 
 ```
 time=2026-05-26T03:50:06Z level=WARN msg="readyz unhealthy"
-  request_id=7f3c… trace_id=a1b2… status=unhealthy reason=readiness_failed
+  request_id=7f3c… correlation_id=7f3c… status=unhealthy reason=readiness_failed
   cells=map[accesscore:healthy auditcore:degraded]
   dependencies.postgres_ready.status=healthy
   dependencies.postgres_ready.duration_ms=3
@@ -203,7 +208,7 @@ Verbose 503 slog example（JSON handler，`-log-format=json`）：
   "level": "WARN",
   "msg": "readyz unhealthy",
   "request_id": "7f3c…",
-  "trace_id": "a1b2…",
+  "correlation_id": "7f3c…",
   "status": "unhealthy",
   "reason": "readiness_failed",
   "cells": {"accesscore": "healthy", "auditcore": "degraded"},
@@ -241,7 +246,8 @@ error 文本就无需截断）。Probe 实现仍应避免在 error message 中�
 ## 操作员诊断 cookbook
 
 > JSON 是推荐的诊断格式——嵌套对象路径可被 jq / LogQL 直接索引，且不受 text handler
-> 的引号歧义影响。需要按请求关联时，所有 readyz record 都带 `request_id` / `trace_id`。
+> 的引号歧义影响。需要按请求关联时，readyz record 带 `request_id` / `correlation_id`
+> （`trace_id` 在 probe 端点默认无，见 preamble）。
 
 ### JSON handler（`-log-format=json`）
 

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -52,7 +52,7 @@ details array):
 
 | slog level | slog `msg` | slog `status` | slog `reason` | Meaning |
 |------------|------------|---------------|---------------|---------|
-| `Warn` | `readyz unhealthy` | `unhealthy` | `readiness_failed` | One or more cells/probes failed (HTTP 503), or the readiness aggregator failed closed. Internal computation failures are logged server-side and do not create a separate public reason. |
+| `Warn` | `readyz unhealthy` | `unhealthy` | `readiness_failed` | One or more cells/probes failed (HTTP 503), or the readiness aggregator failed closed. NOTE: an internal computation panic is recovered and logged under a **different** `msg="readyz: recovered panic during readiness computation"` (Error level, `internal_reason=readiness_computation_failed`) — filter that msg separately, it does not appear under `readyz unhealthy`. |
 | `Info` | `readyz degraded` | `degraded` | — (no `reason` attr) | One or more cells/probes are degraded but serving (**HTTP 200**, fail-open). Emitted at Info so operators can observe degraded dependency `error_msg` without a Warn-level alert. |
 | `Info` | `readyz: shutting down (graceful_shutdown)` | `shutting_down` | `graceful_shutdown` | The process is draining and should be removed from load balancer traffic. |
 
@@ -274,7 +274,10 @@ kubectl logs <pod> | grep -E 'msg="readyz (unhealthy|degraded)"' \
 text handler 输出形态是 `dependencies.<probe_name>.<field>=<value>` 而非嵌套 `{}` 块，
 Loki / Grafana 通过 key=value 解析直接索引。`error_msg` 的引号取决于值内容（含空格/`=`
 → 加引号；空 → `""`；单 token → 不加引号），所以**只匹配 `error_msg="…"` 会漏掉 unquoted
-值**。如需稳定的结构化查询（不受引号规则影响），切换到 JSON handler。
+值**。另：若 error message 本身含双引号，text handler 会转义为 `\"`，上面的 `"[^"]*"`
+分支会在转义引号处提前截断——这类带引号的 error 用 grep 难以稳健提取。**生产诊断推荐
+JSON handler**（`-log-format=json`）：嵌套对象路径不受引号规则与转义影响，jq / LogQL 可
+稳定索引。
 
 ### Waiving the verbose endpoint
 

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -495,11 +495,15 @@ func (r readyzResult) writeTo(ctx context.Context, w http.ResponseWriter) {
 //
 // ctx is the request context (threaded from ReadyzHandler via writeTo). Since
 // the wire body carries no error text post-ADR, slog is the *primary*
-// diagnostic channel — it MUST carry the request correlation fields
-// (request_id / trace_id / correlation_id) that the framework's contextHandler
-// (runtime/observability/logging) injects from ctx, same source as the errcode
-// WithInternal path. Passing context.Background() here silently drops them and
-// breaks the link between a 503/degraded record and its request (R2 / #942).
+// diagnostic channel — it must carry the request correlation fields that the
+// framework's contextHandler (runtime/observability/logging) injects from ctx,
+// same source as the errcode WithInternal path. On probe endpoints that means
+// request_id + correlation_id (RequestID middleware runs on /readyz; it is not
+// probe-filtered); trace_id is NOT present by default because the Tracing
+// middleware's DefaultProbeFilter skips span creation for /healthz, /readyz,
+// /livez, /metrics. Passing context.Background() here silently drops even
+// request_id/correlation_id and breaks the link between a 503/degraded record
+// and its request (R2 / #942).
 //
 // The slogDependencies map (not the wire dependencies) is what gets logged
 // — its typed SlogDependencyEntry.ErrorMsg field carries the redacted error

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -606,7 +606,7 @@ func (h *Handler) verboseDecision(r *http.Request) (verbose, denied bool) {
 	h.mu.RUnlock()
 	remoteAddr := logutil.SafeAddr(r.RemoteAddr)
 	if disabled {
-		slog.Debug("readyz: verbose requested but endpoint is disabled; serving plain aggregate",
+		slog.DebugContext(r.Context(), "readyz: verbose requested but endpoint is disabled; serving plain aggregate",
 			slog.String("remote_addr", remoteAddr))
 		return false, false
 	}
@@ -614,7 +614,7 @@ func (h *Handler) verboseDecision(r *http.Request) (verbose, denied bool) {
 	// configure a token or disable the verbose endpoint. Silently rendering
 	// verbose output when token="" leaks internal health details.
 	if token == "" {
-		slog.Warn("readyz: verbose requested but no token configured; denying",
+		slog.WarnContext(r.Context(), "readyz: verbose requested but no token configured; denying",
 			slog.String("reason", "token_unconfigured"),
 			slog.String("hint", "set GOCELL_READYZ_VERBOSE_TOKEN or GOCELL_READYZ_VERBOSE_DISABLED=1"),
 			slog.String("remote_addr", remoteAddr))
@@ -623,7 +623,7 @@ func (h *Handler) verboseDecision(r *http.Request) (verbose, denied bool) {
 	submitted := sha256.Sum256([]byte(r.Header.Get(VerboseAuthHeader)))
 	configured := sha256.Sum256([]byte(token))
 	if subtle.ConstantTimeCompare(submitted[:], configured[:]) != 1 {
-		slog.Warn("readyz: verbose token mismatch at handler layer; denying",
+		slog.WarnContext(r.Context(), "readyz: verbose token mismatch at handler layer; denying",
 			slog.String("reason", "token_mismatch"),
 			slog.String("remote_addr", remoteAddr))
 		return false, true

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -217,7 +217,7 @@ func (h *Handler) ReadyzHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if h.shuttingDown.Load() {
-			slog.Info("readyz: shutting down (graceful_shutdown)",
+			slog.InfoContext(ctx, "readyz: shutting down (graceful_shutdown)",
 				slog.String("status", readyzStatusShuttingDown),
 				slog.String("reason", readyzReasonGracefulShutdown))
 			writeReadyz503(ctx, w, readyzStatusShuttingDown, readyzReasonGracefulShutdown)
@@ -251,7 +251,7 @@ func (h *Handler) ReadyzHandler() http.HandlerFunc {
 		})
 		result, ok := shared.(readyzResult)
 		if !ok {
-			slog.Error("readyz: singleflight returned unexpected payload; failing closed",
+			slog.ErrorContext(ctx, "readyz: singleflight returned unexpected payload; failing closed",
 				slog.String("internal_reason", "readiness_computation_failed"),
 				slog.Any("value", shared))
 			writeReadyz503(ctx, w, "unhealthy", readyzReasonReadinessFailed)
@@ -275,7 +275,7 @@ func (h *Handler) ReadyzHandler() http.HandlerFunc {
 func (h *Handler) computeReadyzSafe(ctx context.Context, verbose bool) (result readyzResult) {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("readyz: recovered panic during readiness computation",
+			slog.ErrorContext(ctx, "readyz: recovered panic during readiness computation",
 				slog.String("internal_reason", "readiness_computation_failed"),
 				slog.Any("panic", redaction.RedactAny(r)))
 			result = readyzResult{overall: "unhealthy", reason: readyzReasonReadinessFailed}
@@ -477,14 +477,14 @@ func (r readyzResult) writeTo(ctx context.Context, w http.ResponseWriter) {
 		// ref: envoyproxy/envoy admin /ready — DEGRADED returns 200.
 		// Emit channel d ops-diagnostics at Info level so operators can observe
 		// degraded dependency ErrorMsg without triggering a warn-level alert.
-		r.logDiagnostics(slog.LevelInfo, "readyz degraded")
+		r.logDiagnostics(ctx, slog.LevelInfo, "readyz degraded")
 		writeJSON(w, http.StatusOK, envelopeData(body))
 	default: // "unhealthy"
 		reason := r.reason
 		if reason == "" {
 			reason = readyzReasonReadinessFailed
 		}
-		r.logDiagnostics(slog.LevelWarn, "readyz unhealthy", slog.String("reason", reason))
+		r.logDiagnostics(ctx, slog.LevelWarn, "readyz unhealthy", slog.String("reason", reason))
 		writeReadyz503(ctx, w, r.overall, reason)
 	}
 }
@@ -492,6 +492,14 @@ func (r readyzResult) writeTo(ctx context.Context, w http.ResponseWriter) {
 // logDiagnostics emits the channel d (ops-diagnostics) breakdown to slog so
 // operators retain the diagnostic data per ADR 202605171200 §3. Public
 // responses always carry no error text on wire (D1 decision).
+//
+// ctx is the request context (threaded from ReadyzHandler via writeTo). Since
+// the wire body carries no error text post-ADR, slog is the *primary*
+// diagnostic channel — it MUST carry the request correlation fields
+// (request_id / trace_id / correlation_id) that the framework's contextHandler
+// (runtime/observability/logging) injects from ctx, same source as the errcode
+// WithInternal path. Passing context.Background() here silently drops them and
+// breaks the link between a 503/degraded record and its request (R2 / #942).
 //
 // The slogDependencies map (not the wire dependencies) is what gets logged
 // — its typed SlogDependencyEntry.ErrorMsg field carries the redacted error
@@ -514,7 +522,7 @@ func (r readyzResult) writeTo(ctx context.Context, w http.ResponseWriter) {
 // Cells/dependencies/adapters maps are appended only on verbose probes so
 // that high-frequency k8s readiness probes (typically every 5s) don't spam
 // log backends with full breakdown when only status/reason are actionable.
-func (r readyzResult) logDiagnostics(level slog.Level, msg string, extra ...slog.Attr) {
+func (r readyzResult) logDiagnostics(ctx context.Context, level slog.Level, msg string, extra ...slog.Attr) {
 	attrs := []any{
 		slog.String("status", r.overall),
 	}
@@ -539,7 +547,7 @@ func (r readyzResult) logDiagnostics(level slog.Level, msg string, extra ...slog
 			slog.Any("adapters", r.adapters),
 		)
 	}
-	slog.Log(context.Background(), level, msg, attrs...)
+	slog.Log(ctx, level, msg, attrs...)
 }
 
 // writeReadyz503 emits the canonical errcode 503 envelope shared with all

--- a/runtime/http/health/health.go
+++ b/runtime/http/health/health.go
@@ -168,7 +168,7 @@ func (h *Handler) SetShuttingDown() {
 // infrastructure and business responses uniformly (PR-A35 alignment).
 func (h *Handler) LivezHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, envelopeData(map[string]any{
+		writeJSON(r.Context(), w, http.StatusOK, envelopeData(map[string]any{
 			"status": "healthy",
 		}))
 	}
@@ -471,14 +471,14 @@ func (r readyzResult) writeTo(ctx context.Context, w http.ResponseWriter) {
 	body["status"] = r.overall
 	switch r.overall {
 	case "healthy":
-		writeJSON(w, http.StatusOK, envelopeData(body))
+		writeJSON(ctx, w, http.StatusOK, envelopeData(body))
 	case "degraded":
 		// HTTP 200 — degraded does NOT trigger pod eviction (fail-open semantic).
 		// ref: envoyproxy/envoy admin /ready — DEGRADED returns 200.
 		// Emit channel d ops-diagnostics at Info level so operators can observe
 		// degraded dependency ErrorMsg without triggering a warn-level alert.
 		r.logDiagnostics(ctx, slog.LevelInfo, "readyz degraded")
-		writeJSON(w, http.StatusOK, envelopeData(body))
+		writeJSON(ctx, w, http.StatusOK, envelopeData(body))
 	default: // "unhealthy"
 		reason := r.reason
 		if reason == "" {
@@ -681,10 +681,10 @@ func statusFromRank(r int) string {
 	}
 }
 
-func writeJSON(w http.ResponseWriter, statusCode int, v any) {
+func writeJSON(ctx context.Context, w http.ResponseWriter, statusCode int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		slog.Error("health: failed to write response", slog.Any("error", err))
+		slog.ErrorContext(ctx, "health: failed to write response", slog.Any("error", err))
 	}
 }

--- a/runtime/http/health/health_test.go
+++ b/runtime/http/health/health_test.go
@@ -36,17 +36,22 @@ func newAggWithDeadline(clk clock.Clock, d time.Duration) khealthz.Aggregator {
 }
 
 // captureHandler records every slog event passed to it so tests can assert
-// on the verbose breakdown that K#08 5xx redaction keeps off the wire.
+// on the verbose breakdown that K#08 5xx redaction keeps off the wire. The
+// per-record ctx is captured in lockstep so tests can assert that the readyz
+// handler threads the request context (carrying request_id/trace_id/
+// correlation_id) into slog rather than context.Background() (R2 / #942).
 type captureHandler struct {
 	mu      sync.Mutex
 	records []slog.Record
+	ctxs    []context.Context
 }
 
 func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
-func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+func (h *captureHandler) Handle(ctx context.Context, r slog.Record) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.records = append(h.records, r.Clone())
+	h.ctxs = append(h.ctxs, ctx)
 	return nil
 }
 func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
@@ -59,6 +64,19 @@ func (h *captureHandler) snapshot() []slog.Record {
 	out := make([]slog.Record, len(h.records))
 	copy(out, h.records)
 	return out
+}
+
+// recordCtx returns the ctx captured for the first slog record whose Message
+// equals msg. The bool reports whether such a record was seen.
+func (h *captureHandler) recordCtx(msg string) (context.Context, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i, r := range h.records {
+		if r.Message == msg {
+			return h.ctxs[i], true
+		}
+	}
+	return nil, false
 }
 
 // withSlogCapture redirects slog.Default for the duration of the test and

--- a/runtime/http/health/verbose_shape.go
+++ b/runtime/http/health/verbose_shape.go
@@ -117,9 +117,9 @@ func (e SlogDependencyEntry) DurationMs() int64 { return e.durationMs }
 
 // ErrorMsg returns the redacted probe error text (already passed through
 // newRedactedErrorMsg → pkg/redaction.RedactString). Empty string when
-// ProbeResult.Err was nil — which, per the kernel ProbeResult.Err contract
-// ("nil iff Status == StatusUp"), means a healthy probe. Read-only accessor;
-// the underlying field is unexported.
+// ProbeResult.Err was nil — which, per the kernel/healthz.ProbeResult.Err
+// contract ("Err is nil iff Status == StatusUp"), means a healthy probe.
+// Read-only accessor; the underlying field is unexported.
 func (e SlogDependencyEntry) ErrorMsg() string { return string(e.errorMsg) }
 
 // LogValue implements slog.LogValuer. logDiagnostics passes each entry to

--- a/runtime/http/health/verbose_shape.go
+++ b/runtime/http/health/verbose_shape.go
@@ -116,8 +116,10 @@ func (e SlogDependencyEntry) Status() string { return e.status }
 func (e SlogDependencyEntry) DurationMs() int64 { return e.durationMs }
 
 // ErrorMsg returns the redacted probe error text (already passed through
-// newRedactedErrorMsg → pkg/redaction.RedactString). Empty string when the
-// probe was healthy. Read-only accessor; the underlying field is unexported.
+// newRedactedErrorMsg → pkg/redaction.RedactString). Empty string when
+// ProbeResult.Err was nil — which, per the kernel ProbeResult.Err contract
+// ("nil iff Status == StatusUp"), means a healthy probe. Read-only accessor;
+// the underlying field is unexported.
 func (e SlogDependencyEntry) ErrorMsg() string { return string(e.errorMsg) }
 
 // LogValue implements slog.LogValuer. logDiagnostics passes each entry to

--- a/runtime/http/health/verbose_shape_test.go
+++ b/runtime/http/health/verbose_shape_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/clock"
 	khealthz "github.com/ghbvf/gocell/kernel/healthz"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
 )
 
 // TestNewRedactedErrorMsg_NilReturnsEmpty verifies the nil-input sentinel path.
@@ -141,6 +142,11 @@ func TestSlogDependencyEntry_LogValue(t *testing.T) {
 // resolve. Pre-round-5 this would have emitted "dependencies":{"db":{}}
 // because slog.Any(map) bypassed LogValue and json.Marshal can't see
 // unexported fields.
+//
+// R5 (#942): assertions round-trip the handler output through json.Unmarshal
+// and navigate the nested object — not substring Contains — so the test proves
+// the *handler-serialized* shape (dependencies.db.{status,duration_ms,error_msg}),
+// not merely that the right attrs were injected.
 func TestLogDiagnostics_EmitsGroupWithSnakeCaseViaJSONHandler(t *testing.T) {
 	var buf bytes.Buffer
 	prev := slog.Default()
@@ -157,27 +163,223 @@ func TestLogDiagnostics_EmitsGroupWithSnakeCaseViaJSONHandler(t *testing.T) {
 	require.NoError(t, agg.Register(khealthz.NewProbe("db", func(_ context.Context) error {
 		return errors.New("connection refused")
 	})))
+	require.NoError(t, agg.Register(khealthz.NewProbe("cache", func(_ context.Context) error {
+		return nil // healthy — proves error_msg is "" not omitted
+	})))
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/readyz?verbose=true", nil)
 	req.Header.Set(VerboseAuthHeader, testVerboseToken)
 	h.ReadyzHandler().ServeHTTP(rec, req)
 
+	rec503 := findJSONRecord(t, buf.String(), "readyz unhealthy")
+
+	deps, ok := rec503["dependencies"].(map[string]any)
+	require.True(t, ok, "dependencies must round-trip to a JSON object (slog.Group), got %T", rec503["dependencies"])
+
+	db, ok := deps["db"].(map[string]any)
+	require.True(t, ok, "db dep must be a nested object (LogValue GroupValue), got %T", deps["db"])
+	assert.Equal(t, "unhealthy", db["status"])
+	_, hasDur := db["duration_ms"]
+	assert.True(t, hasDur, "db dep must carry duration_ms")
+	assert.Equal(t, "connection refused", db["error_msg"])
+
+	cache, ok := deps["cache"].(map[string]any)
+	require.True(t, ok, "cache dep must be a nested object")
+	assert.Equal(t, "healthy", cache["status"])
+	assert.Equal(t, "", cache["error_msg"], "healthy probe error_msg must be empty string, not omitted")
+
+	// Negative: round-4 bug shape (empty object) and the unexported-field
+	// fallback shape (CamelCase keys) must never appear.
 	out := buf.String()
-	// Locate the readyz unhealthy record (last one — preceded by other slog
-	// records from probe setup).
-	require.Contains(t, out, `"msg":"readyz unhealthy"`)
-	require.Contains(t, out, `"dependencies":{`, "dependencies must be a JSON object (slog.Group)")
-	require.Contains(t, out, `"db":{`, "db dep must be a sub-object (LogValue GroupValue)")
-	assert.Contains(t, out, `"status":"unhealthy"`)
-	assert.Contains(t, out, `"duration_ms":`)
-	assert.Contains(t, out, `"error_msg":"connection refused"`)
-	// Negative: must NOT emit empty objects (round-4 bug shape) or CamelCase
-	// fields (the unexported-field fallback shape).
 	assert.NotContains(t, out, `"db":{}`)
 	assert.NotContains(t, out, `"Status"`)
 	assert.NotContains(t, out, `"DurationMs"`)
 	assert.NotContains(t, out, `"ErrorMsg"`)
+}
+
+// TestLogDiagnostics_PropagatesRequestCtx is the R2 (#942) regression guard:
+// logDiagnostics must thread the request context — carrying request_id /
+// trace_id / correlation_id — into slog, not context.Background(). The
+// framework's contextHandler injects those correlation fields from ctx; with
+// context.Background() they are silently dropped and operators lose the link
+// between a 503/degraded diagnostic record and the request that triggered it.
+//
+// The capture handler records the ctx handed to Handle; we assert the injected
+// correlation values survive the writeTo → logDiagnostics → slog.Log hop.
+// Against the pre-fix code (slog.Log(context.Background(), ...)) the captured
+// ctx is Background and the *From lookups miss → RED.
+func TestLogDiagnostics_PropagatesRequestCtx(t *testing.T) {
+	asm := assembly.New(assembly.Config{ID: "test-ctx", DurabilityMode: outbox.DurabilityDemo, Clock: clock.Real()})
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	agg := newAgg(clock.Real())
+	h := New(asm, agg, clock.Real())
+	h.SetVerboseToken(testVerboseToken)
+	require.NoError(t, agg.Register(khealthz.NewProbe("db", func(_ context.Context) error {
+		return errors.New("connection refused")
+	})))
+
+	capture := withSlogCapture(t)
+
+	const (
+		wantReqID   = "req-abc-123"
+		wantTraceID = "trace-xyz-789"
+		wantCorrID  = "corr-456"
+	)
+	ctx := context.Background()
+	ctx = ctxkeys.WithRequestID(ctx, wantReqID)
+	ctx = ctxkeys.WithTraceID(ctx, wantTraceID)
+	ctx = ctxkeys.WithCorrelationID(ctx, wantCorrID)
+
+	rec := httptest.NewRecorder()
+	req := newVerboseRequest("/readyz?verbose=true").WithContext(ctx)
+	h.ReadyzHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	gotCtx, ok := capture.recordCtx("readyz unhealthy")
+	require.True(t, ok, "must capture a 'readyz unhealthy' slog record")
+
+	reqID, _ := ctxkeys.RequestIDFrom(gotCtx)
+	assert.Equal(t, wantReqID, reqID, "logDiagnostics must pass the request ctx (request_id) to slog, not context.Background()")
+	traceID, _ := ctxkeys.TraceIDFrom(gotCtx)
+	assert.Equal(t, wantTraceID, traceID, "trace_id must survive the slog hop")
+	corrID, _ := ctxkeys.CorrelationIDFrom(gotCtx)
+	assert.Equal(t, wantCorrID, corrID, "correlation_id must survive the slog hop")
+}
+
+// TestLogDiagnostics_TextHandlerRoundTrip is the R5 (#942) coverage lock for
+// the default text / logfmt handler — the prior contract test only exercised
+// the JSON handler. It round-trips the text-handler output through a logfmt
+// parser (not substring Contains) so the cross-handler snake_case contract
+// (slog.Group + LogValuer) is proven for the key=value format too.
+//
+// It also pins the exact quoting behaviour the docs/ops/readyz.md runbook
+// cookbook depends on: a redacted/space-containing error_msg is quoted, an
+// empty error_msg is "" — operators' grep patterns must match both.
+func TestLogDiagnostics_TextHandlerRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	asm := assembly.New(assembly.Config{ID: "test-text", DurabilityMode: outbox.DurabilityDemo, Clock: clock.Real()})
+	require.NoError(t, asm.Start(context.Background()))
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	agg := newAgg(clock.Real())
+	h := New(asm, agg, clock.Real())
+	h.SetVerboseToken(testVerboseToken)
+	require.NoError(t, agg.Register(khealthz.NewProbe("db", func(_ context.Context) error {
+		return errors.New("dial failed password=hunter2")
+	})))
+	require.NoError(t, agg.Register(khealthz.NewProbe("cache", func(_ context.Context) error {
+		return nil // healthy
+	})))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz?verbose=true", nil)
+	req.Header.Set(VerboseAuthHeader, testVerboseToken)
+	h.ReadyzHandler().ServeHTTP(rec, req)
+
+	line := findLogfmtLine(t, buf.String(), "readyz unhealthy")
+	kv := parseLogfmtLine(line)
+
+	assert.Equal(t, "unhealthy", kv["dependencies.db.status"], "text handler must emit snake_case dotted group keys")
+	_, hasDur := kv["dependencies.db.duration_ms"]
+	assert.True(t, hasDur, "db dep must carry duration_ms in text output")
+	assert.Contains(t, kv["dependencies.db.error_msg"], "<REDACTED>", "secret must be redacted in text output")
+	assert.NotContains(t, kv["dependencies.db.error_msg"], "hunter2", "raw secret must not appear")
+
+	assert.Equal(t, "healthy", kv["dependencies.cache.status"])
+	assert.Equal(t, "", kv["dependencies.cache.error_msg"], "healthy probe error_msg must round-trip to empty string")
+}
+
+// findJSONRecord scans newline-delimited slog JSON output for the first record
+// whose "msg" equals msg and returns it as a parsed map. Fails the test if no
+// such record is present.
+func findJSONRecord(t *testing.T, out, msg string) map[string]any {
+	t.Helper()
+	for _, ln := range strings.Split(strings.TrimSpace(out), "\n") {
+		if ln == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(ln), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	t.Fatalf("no JSON slog record with msg=%q in output:\n%s", msg, out)
+	return nil
+}
+
+// findLogfmtLine returns the first newline-delimited text-handler line whose
+// msg field equals msg. slog quotes msg values containing spaces, so we match
+// on the quoted form. Fails the test if absent.
+func findLogfmtLine(t *testing.T, out, msg string) string {
+	t.Helper()
+	want := `msg="` + msg + `"`
+	for _, ln := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.Contains(ln, want) {
+			return ln
+		}
+	}
+	t.Fatalf("no text slog line with %s in output:\n%s", want, out)
+	return ""
+}
+
+// parseLogfmtLine tokenizes a single slog text-handler (logfmt) line into a
+// key→value map, handling both bare values (key=value) and double-quoted
+// values (key="value with spaces"). Quoted values have their surrounding
+// quotes stripped and \" / \\ unescaped. This is a round-trip decoder: it
+// reverses what slog.NewTextHandler emitted, so assertions run against the
+// decoded values rather than raw substrings.
+func parseLogfmtLine(line string) map[string]string {
+	m := make(map[string]string)
+	i := 0
+	for i < len(line) {
+		for i < len(line) && line[i] == ' ' {
+			i++
+		}
+		if i >= len(line) {
+			break
+		}
+		start := i
+		for i < len(line) && line[i] != '=' && line[i] != ' ' {
+			i++
+		}
+		if i >= len(line) || line[i] != '=' {
+			continue // token without '=' — skip
+		}
+		key := line[start:i]
+		i++ // consume '='
+		var val string
+		if i < len(line) && line[i] == '"' {
+			i++
+			var sb strings.Builder
+			for i < len(line) && line[i] != '"' {
+				if line[i] == '\\' && i+1 < len(line) {
+					i++
+				}
+				sb.WriteByte(line[i])
+				i++
+			}
+			i++ // consume closing quote
+			val = sb.String()
+		} else {
+			vs := i
+			for i < len(line) && line[i] != ' ' {
+				i++
+			}
+			val = line[vs:i]
+		}
+		m[key] = val
+	}
+	return m
 }
 
 // TestVerboseDependencyEntry_JSONShape verifies the wire shape serializes

--- a/runtime/http/health/verbose_shape_test.go
+++ b/runtime/http/health/verbose_shape_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -132,6 +133,10 @@ func TestSlogDependencyEntry_LogValue(t *testing.T) {
 	}
 	assert.Equal(t, "degraded", got["status"])
 	assert.Equal(t, int64(42), got["duration_ms"])
+	// "drop ratio exceeded" is unchanged: LogValue does NOT redact — redaction
+	// happens upstream in the newRedactedErrorMsg funnel (exercised here, the
+	// input has no key=value secret to mask). This asserts the LogValue
+	// serialization shape, not the redaction contract.
 	assert.Equal(t, "drop ratio exceeded", got["error_msg"])
 }
 
@@ -209,44 +214,71 @@ func TestLogDiagnostics_EmitsGroupWithSnakeCaseViaJSONHandler(t *testing.T) {
 // correlation values survive the writeTo → logDiagnostics → slog.Log hop.
 // Against the pre-fix code (slog.Log(context.Background(), ...)) the captured
 // ctx is Background and the *From lookups miss → RED.
+//
+// Both writeTo branches are covered: unhealthy (Warn, 503, msg "readyz
+// unhealthy") and degraded (Info, 200, msg "readyz degraded") — each calls
+// logDiagnostics with the request ctx, so both must carry the correlation
+// fields.
 func TestLogDiagnostics_PropagatesRequestCtx(t *testing.T) {
-	asm := assembly.New(assembly.Config{ID: "test-ctx", DurabilityMode: outbox.DurabilityDemo, Clock: clock.Real()})
-	require.NoError(t, asm.Start(context.Background()))
-	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
-
-	agg := newAgg(clock.Real())
-	h := New(asm, agg, clock.Real())
-	h.SetVerboseToken(testVerboseToken)
-	require.NoError(t, agg.Register(khealthz.NewProbe("db", func(_ context.Context) error {
-		return errors.New("connection refused")
-	})))
-
-	capture := withSlogCapture(t)
-
 	const (
 		wantReqID   = "req-abc-123"
 		wantTraceID = "trace-xyz-789"
 		wantCorrID  = "corr-456"
 	)
-	ctx := context.Background()
-	ctx = ctxkeys.WithRequestID(ctx, wantReqID)
-	ctx = ctxkeys.WithTraceID(ctx, wantTraceID)
-	ctx = ctxkeys.WithCorrelationID(ctx, wantCorrID)
+	tests := []struct {
+		name     string
+		probeErr error
+		wantCode int
+		wantMsg  string
+	}{
+		{
+			name:     "unhealthy path (Warn/503)",
+			probeErr: errors.New("connection refused"),
+			wantCode: http.StatusServiceUnavailable,
+			wantMsg:  "readyz unhealthy",
+		},
+		{
+			name:     "degraded path (Info/200)",
+			probeErr: fmt.Errorf("soft degradation: %w", outbox.ErrDegraded),
+			wantCode: http.StatusOK,
+			wantMsg:  "readyz degraded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asm := assembly.New(assembly.Config{ID: "test-ctx", DurabilityMode: outbox.DurabilityDemo, Clock: clock.Real()})
+			require.NoError(t, asm.Start(context.Background()))
+			t.Cleanup(func() { _ = asm.Stop(context.Background()) })
 
-	rec := httptest.NewRecorder()
-	req := newVerboseRequest("/readyz?verbose=true").WithContext(ctx)
-	h.ReadyzHandler().ServeHTTP(rec, req)
-	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+			agg := newAgg(clock.Real())
+			h := New(asm, agg, clock.Real())
+			h.SetVerboseToken(testVerboseToken)
+			require.NoError(t, agg.Register(khealthz.NewProbe("db", func(_ context.Context) error {
+				return tt.probeErr
+			})))
 
-	gotCtx, ok := capture.recordCtx("readyz unhealthy")
-	require.True(t, ok, "must capture a 'readyz unhealthy' slog record")
+			capture := withSlogCapture(t)
 
-	reqID, _ := ctxkeys.RequestIDFrom(gotCtx)
-	assert.Equal(t, wantReqID, reqID, "logDiagnostics must pass the request ctx (request_id) to slog, not context.Background()")
-	traceID, _ := ctxkeys.TraceIDFrom(gotCtx)
-	assert.Equal(t, wantTraceID, traceID, "trace_id must survive the slog hop")
-	corrID, _ := ctxkeys.CorrelationIDFrom(gotCtx)
-	assert.Equal(t, wantCorrID, corrID, "correlation_id must survive the slog hop")
+			ctx := ctxkeys.WithRequestID(context.Background(), wantReqID)
+			ctx = ctxkeys.WithTraceID(ctx, wantTraceID)
+			ctx = ctxkeys.WithCorrelationID(ctx, wantCorrID)
+
+			rec := httptest.NewRecorder()
+			req := newVerboseRequest("/readyz?verbose=true").WithContext(ctx)
+			h.ReadyzHandler().ServeHTTP(rec, req)
+			require.Equal(t, tt.wantCode, rec.Code)
+
+			gotCtx, ok := capture.recordCtx(tt.wantMsg)
+			require.Truef(t, ok, "must capture a %q slog record", tt.wantMsg)
+
+			reqID, _ := ctxkeys.RequestIDFrom(gotCtx)
+			assert.Equal(t, wantReqID, reqID, "logDiagnostics must pass the request ctx (request_id) to slog, not context.Background()")
+			traceID, _ := ctxkeys.TraceIDFrom(gotCtx)
+			assert.Equal(t, wantTraceID, traceID, "trace_id must survive the slog hop")
+			corrID, _ := ctxkeys.CorrelationIDFrom(gotCtx)
+			assert.Equal(t, wantCorrID, corrID, "correlation_id must survive the slog hop")
+		})
+	}
 }
 
 // TestLogDiagnostics_TextHandlerRoundTrip is the R5 (#942) coverage lock for
@@ -335,9 +367,16 @@ func findLogfmtLine(t *testing.T, out, msg string) string {
 // parseLogfmtLine tokenizes a single slog text-handler (logfmt) line into a
 // key→value map, handling both bare values (key=value) and double-quoted
 // values (key="value with spaces"). Quoted values have their surrounding
-// quotes stripped and \" / \\ unescaped. This is a round-trip decoder: it
-// reverses what slog.NewTextHandler emitted, so assertions run against the
-// decoded values rather than raw substrings.
+// quotes stripped and \" / \\ unescaped. slog.TextHandler serializes a
+// slog.Group as flat dotted keys (group.sub=val) — a documented log/slog
+// convention, not an internal detail — so dependency fields decode as
+// dependencies.<probe>.<field>. This is a round-trip decoder: it reverses what
+// slog.NewTextHandler emitted, so assertions run against decoded values rather
+// than raw substrings.
+//
+// Known limits (sufficient for the single-line readyz record under test): one
+// line only (caller pre-selects the line); no \n inside values; first
+// occurrence wins on duplicate keys.
 func parseLogfmtLine(line string) map[string]string {
 	m := make(map[string]string)
 	i := 0

--- a/runtime/http/health/verbose_shape_test.go
+++ b/runtime/http/health/verbose_shape_test.go
@@ -255,7 +255,7 @@ func TestLogDiagnostics_PropagatesRequestCtx(t *testing.T) {
 // parser (not substring Contains) so the cross-handler snake_case contract
 // (slog.Group + LogValuer) is proven for the key=value format too.
 //
-// It also pins the exact quoting behaviour the docs/ops/readyz.md runbook
+// It also pins the exact quoting behavior the docs/ops/readyz.md runbook
 // cookbook depends on: a redacted/space-containing error_msg is quoted, an
 // empty error_msg is "" — operators' grep patterns must match both.
 func TestLogDiagnostics_TextHandlerRoundTrip(t *testing.T) {

--- a/runtime/http/health/verbose_shape_test.go
+++ b/runtime/http/health/verbose_shape_test.go
@@ -259,6 +259,12 @@ func TestLogDiagnostics_PropagatesRequestCtx(t *testing.T) {
 
 			capture := withSlogCapture(t)
 
+			// Inject all three correlation fields directly into the request ctx
+			// to prove the threading MECHANISM (whatever is in ctx reaches slog).
+			// trace_id is included only to exercise the mechanism — in production
+			// the probe endpoints do NOT carry trace_id (DefaultProbeFilter skips
+			// tracing for /readyz); request_id + correlation_id are the fields a
+			// real readyz record carries (RequestID middleware). See #942 R2.
 			ctx := ctxkeys.WithRequestID(context.Background(), wantReqID)
 			ctx = ctxkeys.WithTraceID(ctx, wantTraceID)
 			ctx = ctxkeys.WithCorrelationID(ctx, wantCorrID)


### PR DESCRIPTION
## Summary

PR #552 follow-up（`#942`，`flag-hard` / `pri-p1`，发布阻塞），收口 R2–R5 四项 review finding。

- **R2（必修，可观测性）**：`logDiagnostics` 用 `slog.Log(context.Background(), ...)` 写诊断，丢失 contextHandler 从 ctx 注入的 `request_id`/`trace_id`/`correlation_id`。wire 删 error 文本后 slog 是主诊断通道，丢关联字段使 503/degraded 记录无法关联触发请求。修复：`logDiagnostics` 加 `ctx` 首参 + `slog.Log(ctx,...)`；`writeTo` degraded/unhealthy 两路径传 ctx；同 readyz 路径另 3 处包级 slog（shutting-down / singleflight / panic-recover）一并改 `*Context(ctx,...)`。
- **R3（必修，安全文档误导）**：ADR `202605171200` §SIEM/ELK 断言「不存在通过日志泄漏 secret 的路径」，与 §3 威胁矩阵「裸 JWT/PEM/UUID 泄漏到 slog」互斥。**原地重写**矛盾段（redactor 覆盖面 vs 真实泄漏面）+ 扩写 §3 威胁矩阵逐行重评（无 ✅→⚠️ 回归）+ 新增 D8 + §D2/§5 校正。
- **R4（校准）**：`docs/ops/readyz.md` 补 degraded 200 响应体 + `readyz degraded`(Info) slog 行；text/JSON slog 示例改真实引号形态；grep cookbook 同时匹配 quoted/unquoted error_msg（旧 grep 漏单 token unquoted 值）；补 request_id 关联查询。
- **R5（校准）**：补 default text/logfmt round-trip 实测（logfmt 解码器，非 substring）；JSON 测试强化为 `json.Unmarshal` round-trip。

`Refs: PR #552 R2/R3/R4/R5`
`Closes #942`

## 关联载体扇出

| 载体 | 同步 |
|------|------|
| code | `runtime/http/health/health.go`（logDiagnostics ctx + 4 处 slog） |
| godoc | `verbose_shape.go::SlogDependencyEntry.ErrorMsg`（对齐 ProbeResult.Err「nil iff StatusUp」契约） |
| test | `verbose_shape_test.go` R2 ctx-propagation（RED→GREEN）+ R5 text/JSON round-trip；`health_test.go` captureHandler 记录 ctx |
| ADR | `202605171200`（§SIEM/ELK 重写 + 威胁矩阵重评 + D8 + §D2/§5） |
| runbook | `docs/ops/readyz.md`（degraded/引号/grep/关联字段） |
| rule | `.claude/rules/gocell/observability.md`（channel d descriptor 单源同步） |

## AI-robust 定性

R2 是 **bugfix**（AI-robust §适用范围明确排除「修 bug」），不立 archtest——回归守卫是 `TestLogDiagnostics_PropagatesRequestCtx` 行为单元测试。已核实 sloglint context 检查未启用且生产代码 233 处合法 bare slog，全仓 ctx-lint 有意不立（会误伤无 ctx 路径）。既有 `HEALTH-VERBOSE-WIRE-SHAPE-FROZEN-01` / `HEALTH-REDACTED-ERROR-MSG-FUNNEL-01` 两个 Hard funnel 不触碰、验证仍绿。

## Test plan

- [x] `go build ./...`
- [x] `go test ./runtime/http/health/... ./runtime/bootstrap/... ./cmd/corebundle/...` GREEN
- [x] `golangci-lint run ./runtime/http/health/...` 0 issues
- [x] 健康 archtest `TestHealthVerbose*` / `TestHealthRedacted*` GREEN（funnel/wire-shape 未受影响）
- [x] R2 测试先 RED（`context.Background()`）后 GREEN（TDD）
- [x] runbook / ADR 所有 slog 示例形态由 round-trip 测试实测验证

> ⚠️ 预存在失败（**非本 PR 引入**，已对 `origin/develop` 验证）：`tools/archtest` 的 `TestCellRepoReadyzProbe`（saga `PGJournal` 未入 conformance，PR #1004）/ `TestInventoryAnchorValidID|Required`（`ci_pinning`/`healthcheck_verify` 锚点）/ `TestTypesutilImplementsFunnel01`（`aftercommit`）/ `TestExternalReasonLiteral`（`runtime/saga`）。这些文件与本 PR 7 个改动文件零重叠；完整 archtest 由 nightly 兜底（PR CI 不跑），属 develop 既有状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)