### PR TITLE
feat(audit): keyset 游标下推到 store 层（去 500 内存 fetch cap）(#1000)

### DIFF
--- a/adapters/postgres/audit_ledger_store.go
+++ b/adapters/postgres/audit_ledger_store.go
@@ -418,6 +418,11 @@ FROM audit_entries WHERE namespace = `, ns)
 // / filters.To bindings above already do — but cannot encode a bare string for
 // a timestamptz parameter. Non-timestamp columns (id, a text column) are left
 // untouched. Returns params unchanged on the first page (no cursor).
+//
+// When ledger.QuerySort gains another non-text keyset column (e.g. another
+// timestamptz or a numeric column), add a matching conversion case here: pgx
+// cannot bind the RFC3339Nano/JSON string wire form to a non-text column.
+// Audit is currently the only non-text keyset consumer in the codebase.
 func bindTimestampCursor(params query.ListParams) (query.ListParams, error) {
 	if params.CursorValues == nil {
 		return params, nil

--- a/adapters/postgres/audit_ledger_store.go
+++ b/adapters/postgres/audit_ledger_store.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -18,6 +20,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/ctxcancel"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	pgquery "github.com/ghbvf/gocell/pkg/pgquery"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
@@ -362,11 +365,21 @@ func (s *LedgerStore) GetBySeq(ctx context.Context, seq int64) (*ledger.Entry, e
 	return &e, nil
 }
 
-// Query lists entries matching the supplied AuditFilters with simple
-// LIMIT/OFFSET pagination as documented in store.go for QueryListParams.
-// Returns an empty (non-nil) slice when no entries match.
-func (s *LedgerStore) Query(ctx context.Context, filters ledger.AuditFilters, params ledger.QueryListParams) ([]*ledger.Entry, error) {
+// Query lists entries matching the supplied AuditFilters using keyset cursor
+// pagination pushed into SQL via pgquery.AppendKeyset: params.Sort drives the
+// ORDER BY and the keyset WHERE predicate, and params.FetchLimit() (Limit+1) is
+// the LIMIT for N+1 hasMore detection. The idx_audit_namespace_ts_id composite
+// index covers the (timestamp DESC, id ASC) keyset, so this is an index scan.
+// params.Sort must be non-empty (callers pass ledger.QuerySort); AppendKeyset
+// returns ErrValidationFailed on empty Sort. Returns an empty (non-nil) slice
+// when no entries match.
+func (s *LedgerStore) Query(ctx context.Context, filters ledger.AuditFilters, params query.ListParams) ([]*ledger.Entry, error) {
 	ns := s.namespace()
+
+	params, err := bindTimestampCursor(params)
+	if err != nil {
+		return nil, err
+	}
 
 	b := pgquery.NewBuilder()
 	b.AppendParam(`SELECT id, seq_no, event_id, event_type, actor_id, timestamp, payload, prev_hash, hash
@@ -375,12 +388,8 @@ FROM audit_entries WHERE namespace = `, ns)
 	b.AppendIf(filters.ActorID != "", `AND actor_id = `, filters.ActorID)
 	b.AppendIf(!filters.From.IsZero(), `AND timestamp >= `, filters.From)
 	b.AppendIf(!filters.To.IsZero(), `AND timestamp <= `, filters.To)
-	b.Append(`ORDER BY timestamp DESC, id ASC`)
-	if params.Limit > 0 {
-		b.AppendParam(`LIMIT `, params.Limit)
-	}
-	if params.Offset > 0 {
-		b.AppendParam(`OFFSET `, params.Offset)
+	if ksErr := pgquery.AppendKeyset(b, params); ksErr != nil {
+		return nil, ksErr
 	}
 
 	sql, args := b.Build()
@@ -399,6 +408,39 @@ FROM audit_entries WHERE namespace = `, ns)
 		result = []*ledger.Entry{}
 	}
 	return result, nil
+}
+
+// bindTimestampCursor converts the cursor value for the "timestamp" sort column
+// from its RFC3339Nano string wire form back to time.Time. Cursor values arrive
+// as strings: the auditquery service Extract closure formats the timestamp as
+// RFC3339Nano, and the cursor codec round-trips values through JSON. pgx binds
+// time.Time into the timestamptz keyset predicate — exactly as the filters.From
+// / filters.To bindings above already do — but cannot encode a bare string for
+// a timestamptz parameter. Non-timestamp columns (id, a text column) are left
+// untouched. Returns params unchanged on the first page (no cursor).
+func bindTimestampCursor(params query.ListParams) (query.ListParams, error) {
+	if params.CursorValues == nil {
+		return params, nil
+	}
+	vals := slices.Clone(params.CursorValues)
+	for i, col := range params.Sort {
+		if col.Name != "timestamp" || i >= len(vals) {
+			continue
+		}
+		raw, ok := vals[i].(string)
+		if !ok {
+			continue
+		}
+		ts, parseErr := time.Parse(time.RFC3339Nano, raw)
+		if parseErr != nil {
+			return query.ListParams{}, errcode.New(errcode.KindInvalid, errcode.ErrCursorInvalid,
+				"invalid cursor; restart from first page (client should discard stored cursor)",
+				errcode.WithInternal(fmt.Sprintf("timestamp cursor parse: %v", parseErr)))
+		}
+		vals[i] = ts
+	}
+	params.CursorValues = vals
+	return params, nil
 }
 
 // scanEntries scans all rows from a pgx.Rows result into []*ledger.Entry.

--- a/adapters/postgres/audit_ledger_store.go
+++ b/adapters/postgres/audit_ledger_store.go
@@ -416,8 +416,9 @@ FROM audit_entries WHERE namespace = `, ns)
 // RFC3339Nano, and the cursor codec round-trips values through JSON. pgx binds
 // time.Time into the timestamptz keyset predicate — exactly as the filters.From
 // / filters.To bindings above already do — but cannot encode a bare string for
-// a timestamptz parameter. Non-timestamp columns (id, a text column) are left
-// untouched. Returns params unchanged on the first page (no cursor).
+// a timestamptz parameter. The id UUID tie-breaker already uses the cursor's
+// string form and is left untouched. Returns params unchanged on the first page
+// (no cursor).
 //
 // When ledger.QuerySort gains another non-text keyset column (e.g. another
 // timestamptz or a numeric column), add a matching conversion case here: pgx

--- a/adapters/postgres/audit_ledger_store_cursor_test.go
+++ b/adapters/postgres/audit_ledger_store_cursor_test.go
@@ -41,7 +41,7 @@ func TestBindTimestampCursor(t *testing.T) {
 		ts, ok := out.CursorValues[0].(time.Time)
 		require.True(t, ok, "timestamp cursor value must be converted to time.Time, got %T", out.CursorValues[0])
 		require.True(t, ts.Equal(wantTS), "converted timestamp mismatch: got %v want %v", ts, wantTS)
-		require.Equal(t, "id-7", out.CursorValues[1], "id (text column) must be left untouched")
+		require.Equal(t, "id-7", out.CursorValues[1], "id UUID tie-breaker must be left untouched")
 
 		// Caller's slice must not be mutated (slices.Clone defensiveness).
 		require.Equal(t, tsStr, in.CursorValues[0], "input CursorValues must not be mutated")

--- a/adapters/postgres/audit_ledger_store_cursor_test.go
+++ b/adapters/postgres/audit_ledger_store_cursor_test.go
@@ -1,0 +1,85 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
+	"github.com/ghbvf/gocell/runtime/audit/ledger"
+)
+
+// TestBindTimestampCursor exercises bindTimestampCursor in isolation — the
+// helper that converts the RFC3339Nano string timestamp cursor value back to
+// time.Time before the pgx timestamptz keyset bind. The conformance suite only
+// covers the happy path; this locks the nil / non-string / invalid-string /
+// length-guard branches that the SQL path never reaches. No DB required.
+func TestBindTimestampCursor(t *testing.T) {
+	const tsStr = "2025-01-02T03:04:05.123456789Z"
+	wantTS, err := time.Parse(time.RFC3339Nano, tsStr)
+	require.NoError(t, err)
+
+	t.Run("nil cursor returns params unchanged (first page)", func(t *testing.T) {
+		in := query.ListParams{Limit: 10, Sort: ledger.QuerySort()}
+		out, err := bindTimestampCursor(in)
+		require.NoError(t, err)
+		require.Nil(t, out.CursorValues)
+	})
+
+	t.Run("valid RFC3339Nano timestamp converted to time.Time, id untouched", func(t *testing.T) {
+		in := query.ListParams{
+			Limit:        10,
+			Sort:         ledger.QuerySort(),
+			CursorValues: []any{tsStr, "id-7"},
+		}
+		out, err := bindTimestampCursor(in)
+		require.NoError(t, err)
+
+		ts, ok := out.CursorValues[0].(time.Time)
+		require.True(t, ok, "timestamp cursor value must be converted to time.Time, got %T", out.CursorValues[0])
+		require.True(t, ts.Equal(wantTS), "converted timestamp mismatch: got %v want %v", ts, wantTS)
+		require.Equal(t, "id-7", out.CursorValues[1], "id (text column) must be left untouched")
+
+		// Caller's slice must not be mutated (slices.Clone defensiveness).
+		require.Equal(t, tsStr, in.CursorValues[0], "input CursorValues must not be mutated")
+	})
+
+	t.Run("invalid timestamp string returns ErrCursorInvalid", func(t *testing.T) {
+		in := query.ListParams{
+			Limit:        10,
+			Sort:         ledger.QuerySort(),
+			CursorValues: []any{"not-a-timestamp", "id-7"},
+		}
+		_, err := bindTimestampCursor(in)
+		var coded *errcode.Error
+		require.True(t, errors.As(err, &coded), "expected *errcode.Error, got %T: %v", err, err)
+		require.Equal(t, errcode.ErrCursorInvalid, coded.Code)
+	})
+
+	t.Run("non-string timestamp value left untouched", func(t *testing.T) {
+		// A time.Time already in place (defensive: should not be re-parsed).
+		in := query.ListParams{
+			Limit:        10,
+			Sort:         ledger.QuerySort(),
+			CursorValues: []any{wantTS, "id-7"},
+		}
+		out, err := bindTimestampCursor(in)
+		require.NoError(t, err)
+		require.Equal(t, wantTS, out.CursorValues[0])
+	})
+
+	t.Run("cursor shorter than sort does not panic", func(t *testing.T) {
+		in := query.ListParams{
+			Limit:        10,
+			Sort:         ledger.QuerySort(), // 2 columns
+			CursorValues: []any{tsStr},       // 1 value
+		}
+		out, err := bindTimestampCursor(in)
+		require.NoError(t, err)
+		_, ok := out.CursorValues[0].(time.Time)
+		require.True(t, ok)
+	})
+}

--- a/adapters/postgres/audit_ledger_store_test.go
+++ b/adapters/postgres/audit_ledger_store_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/audit/ledger/storetest"
 )
@@ -394,14 +395,14 @@ func TestAuditLedgerStore_NamespaceIsolation(t *testing.T) {
 	assert.Equal(t, int64(2), tailB.SeqNo, "namespace B SeqNo must be 2")
 
 	// Query storeA must not return storeB's entries.
-	aEntries, err := storeA.Query(ctx, ledger.AuditFilters{}, ledger.QueryListParams{Limit: 50})
+	aEntries, err := storeA.Query(ctx, ledger.AuditFilters{}, query.ListParams{Limit: 50, Sort: ledger.QuerySort})
 	require.NoError(t, err)
 	assert.Len(t, aEntries, 3, "namespace A Query must return exactly 3 entries")
 	for _, e := range aEntries {
 		assert.Equal(t, "actor-a", e.ActorID, "namespace A entry must have actor-a")
 	}
 
-	bEntries, err := storeB.Query(ctx, ledger.AuditFilters{}, ledger.QueryListParams{Limit: 50})
+	bEntries, err := storeB.Query(ctx, ledger.AuditFilters{}, query.ListParams{Limit: 50, Sort: ledger.QuerySort})
 	require.NoError(t, err)
 	assert.Len(t, bEntries, 2, "namespace B Query must return exactly 2 entries")
 	for _, e := range bEntries {

--- a/adapters/postgres/audit_ledger_store_test.go
+++ b/adapters/postgres/audit_ledger_store_test.go
@@ -395,14 +395,14 @@ func TestAuditLedgerStore_NamespaceIsolation(t *testing.T) {
 	assert.Equal(t, int64(2), tailB.SeqNo, "namespace B SeqNo must be 2")
 
 	// Query storeA must not return storeB's entries.
-	aEntries, err := storeA.Query(ctx, ledger.AuditFilters{}, query.ListParams{Limit: 50, Sort: ledger.QuerySort})
+	aEntries, err := storeA.Query(ctx, ledger.AuditFilters{}, query.ListParams{Limit: 50, Sort: ledger.QuerySort()})
 	require.NoError(t, err)
 	assert.Len(t, aEntries, 3, "namespace A Query must return exactly 3 entries")
 	for _, e := range aEntries {
 		assert.Equal(t, "actor-a", e.ActorID, "namespace A entry must have actor-a")
 	}
 
-	bEntries, err := storeB.Query(ctx, ledger.AuditFilters{}, query.ListParams{Limit: 50, Sort: ledger.QuerySort})
+	bEntries, err := storeB.Query(ctx, ledger.AuditFilters{}, query.ListParams{Limit: 50, Sort: ledger.QuerySort()})
 	require.NoError(t, err)
 	assert.Len(t, bEntries, 2, "namespace B Query must return exactly 2 entries")
 	for _, e := range bEntries {

--- a/cells/auditcore/slices/auditquery/service.go
+++ b/cells/auditcore/slices/auditquery/service.go
@@ -54,7 +54,7 @@ func (s *Service) Query(
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*ledger.Entry]{
 		Codec:      s.codec,
 		PageParams: pageReq,
-		Sort:       ledger.QuerySort,
+		Sort:       ledger.QuerySort(),
 		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*ledger.Entry, error) {
 			// Keyset pagination is pushed into the store (PG: SQL keyset via

--- a/cells/auditcore/slices/auditquery/service.go
+++ b/cells/auditcore/slices/auditquery/service.go
@@ -3,7 +3,6 @@
 package auditquery
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -12,21 +11,6 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
-
-// auditQueryFetchCap is the maximum number of entries fetched from the store in
-// a single Query call. It acts as a defensive ceiling to prevent unbounded
-// memory growth when the audit_entries table grows large and callers do not
-// narrow their filter predicates sufficiently.
-//
-// This is an application-level guard only — it does not replace real keyset
-// pagination pushed into the SQL layer.
-const auditQueryFetchCap = 500
-
-// auditSort defines the default sort for audit listings: newest first.
-var auditSort = []query.SortColumn{
-	{Name: "timestamp", Direction: query.SortDESC},
-	{Name: "id", Direction: query.SortASC},
-}
 
 // Service implements audit query business logic using ledger.Store.
 type Service struct {
@@ -70,30 +54,18 @@ func (s *Service) Query(
 	return query.ExecutePagedQuery(ctx, query.PagedQueryConfig[*ledger.Entry]{
 		Codec:      s.codec,
 		PageParams: pageReq,
-		Sort:       auditSort,
+		Sort:       ledger.QuerySort,
 		QueryCtx:   qctx,
 		Fetch: func(ctx context.Context, params query.ListParams) ([]*ledger.Entry, error) {
-			// Fetch up to auditQueryFetchCap entries, then apply in-memory cursor
-			// and sort. ledger.Store.Query supports only simple LIMIT; keyset
-			// semantics are provided here at the service layer for MemStore
-			// compatibility.
-			//
-			// auditQueryFetchCap (500) is a defensive ceiling against OOM when
-			// the audit_entries table grows large and filters are not narrow enough.
-			all, err := s.store.Query(ctx, filters, ledger.QueryListParams{Limit: auditQueryFetchCap})
+			// Keyset pagination is pushed into the store (PG: SQL keyset via
+			// pgquery.AppendKeyset over idx_audit_namespace_ts_id; MemStore:
+			// in-memory keyset). The store returns up to params.FetchLimit()
+			// (Limit+1) rows; BuildPageResult trims to Limit and detects hasMore.
+			entries, err := s.store.Query(ctx, filters, params)
 			if err != nil {
 				return nil, fmt.Errorf("audit-query: query: %w", err)
 			}
-			if len(all) >= auditQueryFetchCap {
-				s.logger.Warn(
-					"audit-query: fetch cap reached; results may be incomplete — narrow filters",
-					slog.Int("cap", auditQueryFetchCap),
-					slog.String("eventType", filters.EventType),
-					slog.String("actorId", filters.ActorID),
-				)
-			}
-			query.Sort(all, params.Sort, compareEntryField)
-			return query.ApplyCursor(all, params, entryFieldValue)
+			return entries, nil
 		},
 		Extract: func(e *ledger.Entry) []any {
 			return []any{e.Timestamp.Format(time.RFC3339Nano), e.ID}
@@ -101,28 +73,4 @@ func (s *Service) Query(
 		OnCursorErr: query.LogCursorError(s.logger, "auditquery"),
 		RunMode:     s.runMode,
 	})
-}
-
-// compareEntryField compares a single named field of two ledger entries.
-func compareEntryField(a, b *ledger.Entry, field string) int {
-	switch field {
-	case "timestamp":
-		return a.Timestamp.Compare(b.Timestamp)
-	case "id":
-		return cmp.Compare(a.ID, b.ID)
-	default:
-		return 0
-	}
-}
-
-// entryFieldValue extracts a cursor-comparable value from a ledger entry by field name.
-func entryFieldValue(e *ledger.Entry, field string) any {
-	switch field {
-	case "timestamp":
-		return e.Timestamp
-	case "id":
-		return e.ID
-	default:
-		return ""
-	}
 }

--- a/cells/auditcore/slices/auditquery/service_test.go
+++ b/cells/auditcore/slices/auditquery/service_test.go
@@ -378,61 +378,6 @@ func TestService_Query_SubsecondFilterContext(t *testing.T) {
 	require.NoError(t, err, "changing From between pages must not invalidate the cursor")
 }
 
-// TestQuery_FetchCap_500 asserts that auditQueryFetchCap equals 500.
-//
-// A-07/F-07 RED: current value is 5000. After the fix it must be 500 to
-// prevent unbounded in-memory loads before keyset pagination lands (S8).
-// This test verifies the constant value directly via a mock store that
-// returns exactly 501 entries and checks that the Warn log fires at that threshold.
-//
-// Note: auditQueryFetchCap is package-private; we probe it indirectly by
-// seeding 501 entries and checking the Warn fires. When the cap is 5000 (current)
-// no Warn is emitted → RED. When the cap is 500 (target) the Warn fires → GREEN.
-func TestQuery_FetchCap_500(t *testing.T) {
-	var buf strings.Builder
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
-	p, err := ledger.NewProtocol(
-		ledger.WithChainHMAC([]byte("test-hmac-key-32bytes-long!!!!!!!")),
-		ledger.WithNamespace(ledger.NamespaceID("auditcore")),
-		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
-		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
-	)
-	require.NoError(t, err)
-	store, err := ledger.NewMemStore(p, clock.Real())
-	require.NoError(t, err)
-
-	svc, err := NewService(store, testCodec(), logger, query.RunModeProd)
-	require.NoError(t, err)
-
-	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	// Seed 501 entries — above the target cap of 500, below the current cap of 5000.
-	// When cap == 500: Warn fires → GREEN; when cap == 5000: no Warn → RED.
-	const seedCount = 501
-	for i := range seedCount {
-		e := &ledger.Entry{
-			EventID:   fmt.Sprintf("cap500-evt-%d", i),
-			EventType: "cap.test",
-			ActorID:   "actor",
-			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
-			Payload:   []byte("{}"),
-		}
-		require.NoError(t, store.Append(context.Background(), e))
-	}
-
-	buf.Reset()
-	_, err = svc.Query(context.Background(), ledger.AuditFilters{}, query.PageParams{Limit: 10})
-	require.NoError(t, err)
-
-	// Cap warning must appear — only fires when cap ≤ 501.
-	// RED: current cap is 5000, so 501 entries does NOT trigger the warning.
-	if !strings.Contains(buf.String(), "fetch cap reached") {
-		t.Errorf("expected 'fetch cap reached' warning for 501 entries with cap=500; "+
-			"current cap is 5000 so this FAILS as expected (F-07 RED); log output: %q",
-			buf.String())
-	}
-}
-
 // TestQuery_ZeroTime_SkipsFromToFormat asserts that when filters.From and filters.To
 // are zero, the QueryContext attrs slice does NOT contain "from" or "to" keys.
 //
@@ -528,51 +473,5 @@ func TestQuery_ZeroTime_SkipsFromToFormat(t *testing.T) {
 		} else {
 			t.Errorf("unexpected error on page2 with non-zero From: %v", err2)
 		}
-	}
-}
-
-// TestAuditQuery_FetchCapEnforced verifies that when the store returns
-// auditQueryFetchCap or more entries the service logs a warning at Warn level.
-// The store is seeded with exactly cap entries so the warning fires, then a
-// second query with fewer entries confirms the happy path does not warn.
-func TestAuditQuery_FetchCapEnforced(t *testing.T) {
-	// Use a log handler that captures records.
-	var buf strings.Builder
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
-	p, err := ledger.NewProtocol(
-		ledger.WithChainHMAC([]byte("test-hmac-key-32bytes-long!!!!!!!")),
-		ledger.WithNamespace(ledger.NamespaceID("auditcore")),
-		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
-		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
-	)
-	require.NoError(t, err)
-	store, err := ledger.NewMemStore(p, clock.Real())
-	require.NoError(t, err)
-
-	svc, err := NewService(store, testCodec(), logger, query.RunModeProd)
-	require.NoError(t, err)
-
-	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-
-	// Seed exactly auditQueryFetchCap entries so the cap warning fires.
-	for i := range auditQueryFetchCap {
-		e := &ledger.Entry{
-			EventID:   fmt.Sprintf("cap-evt-%d", i),
-			EventType: "cap.test",
-			ActorID:   "actor",
-			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
-			Payload:   []byte("{}"),
-		}
-		require.NoError(t, store.Append(context.Background(), e))
-	}
-
-	buf.Reset()
-	_, err = svc.Query(context.Background(), ledger.AuditFilters{}, query.PageParams{Limit: 10})
-	require.NoError(t, err)
-
-	// Cap warning must appear in the log output.
-	if !strings.Contains(buf.String(), "fetch cap reached") {
-		t.Errorf("expected 'fetch cap reached' warning in log; got: %s", buf.String())
 	}
 }

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -229,7 +229,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 
 		entries, err := auditStore.Query(context.Background(),
 			ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-			query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+			query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(entries), 1, "401 missing-header path must write a bootstrap.auth.fail ledger entry")
 		var payloadStruct struct {
@@ -259,7 +259,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 
 		entries, err := auditStore.Query(context.Background(),
 			ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-			query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+			query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(entries), 2,
 			"wrong-credentials path must add a second bootstrap.auth.fail entry (missing_header from 2a is first)")
@@ -523,7 +523,7 @@ func TestSetupAdminBootstrap_RateLimited_Returns429AndWritesAuditChain(t *testin
 	// above, the ledger Append has already completed — no Eventually needed.
 	entries, qerr := auditStore.Query(context.Background(),
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 	require.NoError(t, qerr)
 	require.Len(t, entries, 1, "exactly one rate_limited entry expected")
 

--- a/cmd/corebundle/setup_integration_test.go
+++ b/cmd/corebundle/setup_integration_test.go
@@ -229,7 +229,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 
 		entries, err := auditStore.Query(context.Background(),
 			ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-			ledger.QueryListParams{Limit: 10})
+			query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(entries), 1, "401 missing-header path must write a bootstrap.auth.fail ledger entry")
 		var payloadStruct struct {
@@ -259,7 +259,7 @@ func TestSetupEndpoints_FirstRunFlow(t *testing.T) {
 
 		entries, err := auditStore.Query(context.Background(),
 			ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-			ledger.QueryListParams{Limit: 10})
+			query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(entries), 2,
 			"wrong-credentials path must add a second bootstrap.auth.fail entry (missing_header from 2a is first)")
@@ -523,7 +523,7 @@ func TestSetupAdminBootstrap_RateLimited_Returns429AndWritesAuditChain(t *testin
 	// above, the ledger Append has already completed — no Eventually needed.
 	entries, qerr := auditStore.Query(context.Background(),
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		ledger.QueryListParams{Limit: 10})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 	require.NoError(t, qerr)
 	require.Len(t, entries, 1, "exactly one rate_limited entry expected")
 

--- a/runtime/audit/bootstrap_append_test.go
+++ b/runtime/audit/bootstrap_append_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
@@ -69,7 +70,7 @@ func TestAppendBootstrapAuthFail_WritesEntryWithReasonAndClientIP(t *testing.T) 
 
 			entries, err := store.Query(context.Background(),
 				ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-				ledger.QueryListParams{Limit: 10})
+				query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 			require.NoError(t, err, "ledger query")
 			require.Len(t, entries, 1, "exactly one bootstrap.auth.fail entry expected")
 
@@ -142,7 +143,7 @@ func TestAppendBootstrapAuthFail_DuplicateFingerprintRejected(t *testing.T) {
 
 	entries, qerr := store.Query(ctx,
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		ledger.QueryListParams{Limit: 10})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 	require.NoError(t, qerr)
 	assert.Len(t, entries, 2, "both Appends should produce distinct ledger entries due to unique EventIDs")
 }

--- a/runtime/audit/bootstrap_append_test.go
+++ b/runtime/audit/bootstrap_append_test.go
@@ -70,7 +70,7 @@ func TestAppendBootstrapAuthFail_WritesEntryWithReasonAndClientIP(t *testing.T) 
 
 			entries, err := store.Query(context.Background(),
 				ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-				query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+				query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 			require.NoError(t, err, "ledger query")
 			require.Len(t, entries, 1, "exactly one bootstrap.auth.fail entry expected")
 
@@ -143,7 +143,7 @@ func TestAppendBootstrapAuthFail_DuplicateFingerprintRejected(t *testing.T) {
 
 	entries, qerr := store.Query(ctx,
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 	require.NoError(t, qerr)
 	assert.Len(t, entries, 2, "both Appends should produce distinct ledger entries due to unique EventIDs")
 }

--- a/runtime/audit/bootstrap_observer_test.go
+++ b/runtime/audit/bootstrap_observer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
@@ -63,7 +64,7 @@ func TestNewBootstrapAuthFailObserver_DoubleWriteSlogAndAudit(t *testing.T) {
 	// Audit channel: a hash-chained entry was written to the ledger.
 	entries, err := store.Query(context.Background(),
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		ledger.QueryListParams{Limit: 10})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 	require.NoError(t, err)
 	require.Len(t, entries, 1, "observer must write exactly one ledger entry per invocation")
 	var payload struct {
@@ -135,7 +136,7 @@ func TestNewBootstrapAuthFailObserver_DetachedCtxSurvivesCallerCancel(t *testing
 
 	entries, err := store.Query(context.Background(),
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		ledger.QueryListParams{Limit: 10})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 	require.NoError(t, err)
 	require.Len(t, entries, 1,
 		"detached ctx must let the ledger write complete even when the caller ctx is already canceled; "+

--- a/runtime/audit/bootstrap_observer_test.go
+++ b/runtime/audit/bootstrap_observer_test.go
@@ -64,7 +64,7 @@ func TestNewBootstrapAuthFailObserver_DoubleWriteSlogAndAudit(t *testing.T) {
 	// Audit channel: a hash-chained entry was written to the ledger.
 	entries, err := store.Query(context.Background(),
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 	require.NoError(t, err)
 	require.Len(t, entries, 1, "observer must write exactly one ledger entry per invocation")
 	var payload struct {
@@ -136,7 +136,7 @@ func TestNewBootstrapAuthFailObserver_DetachedCtxSurvivesCallerCancel(t *testing
 
 	entries, err := store.Query(context.Background(),
 		ledger.AuditFilters{EventType: "bootstrap.auth.fail"},
-		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 	require.NoError(t, err)
 	require.Len(t, entries, 1,
 		"detached ctx must let the ledger write complete even when the caller ctx is already canceled; "+

--- a/runtime/audit/ledger/mem_store.go
+++ b/runtime/audit/ledger/mem_store.go
@@ -2,17 +2,18 @@ package ledger
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sort"
 	"sync"
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -161,16 +162,26 @@ func (m *MemStore) GetBySeq(_ context.Context, seq int64) (*Entry, error) {
 	return copyEntry(m.entries[seq-1]), nil
 }
 
-// Query returns entries matching the supplied filters sorted by timestamp DESC,
-// with ID ASC as the tie-breaker for entries sharing the same timestamp.
-// This matches the PG store ORDER BY clause (ORDER BY timestamp DESC, id ASC).
-// Zero-value filter fields are treated as "no filter". Applies Limit if > 0.
-func (m *MemStore) Query(_ context.Context, filters AuditFilters, params QueryListParams) ([]*Entry, error) {
+// Query returns entries matching the supplied filters using keyset cursor
+// pagination: candidates are filtered, sorted by params.Sort, then ApplyCursor
+// skips past params.CursorValues and returns up to params.FetchLimit() (Limit+1)
+// rows for N+1 hasMore detection. Zero-value filter fields are treated as "no
+// filter".
+//
+// params.Sort must be non-empty (callers pass QuerySort). An empty Sort is a
+// programmer error and yields ErrValidationFailed — the same rejection the PG
+// keyset builder produces, so both backends reject it identically.
+func (m *MemStore) Query(_ context.Context, filters AuditFilters, params query.ListParams) ([]*Entry, error) {
+	if len(params.Sort) == 0 {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"audit ledger: query requires a non-empty sort")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Collect all matching entries first (before applying Limit) so that the
-	// sort sees the full candidate set and Limit is applied after ordering.
+	// Collect all matching entries first so the sort/keyset see the full
+	// candidate set; ApplyCursor then trims to FetchLimit after ordering.
 	var candidates []*Entry
 	for _, e := range m.entries {
 		if matchesFilters(e, filters) {
@@ -178,23 +189,43 @@ func (m *MemStore) Query(_ context.Context, filters AuditFilters, params QueryLi
 		}
 	}
 
-	// Sort: primary timestamp DESC, secondary ID ASC (mirrors PG ORDER BY).
-	sort.SliceStable(candidates, func(i, j int) bool {
-		if candidates[i].Timestamp.Equal(candidates[j].Timestamp) {
-			return candidates[i].ID < candidates[j].ID
-		}
-		return candidates[i].Timestamp.After(candidates[j].Timestamp)
-	})
-
-	// Apply Limit after sorting.
-	results := candidates
-	if params.Limit > 0 && len(results) > params.Limit {
-		results = results[:params.Limit]
+	query.Sort(candidates, params.Sort, compareEntryField)
+	results, err := query.ApplyCursor(candidates, params, entryFieldValue)
+	if err != nil {
+		return nil, err
 	}
 	if results == nil {
 		results = []*Entry{}
 	}
 	return results, nil
+}
+
+// compareEntryField compares a single named field of two ledger entries for
+// in-memory keyset sorting. Only QuerySort columns are recognized.
+func compareEntryField(a, b *Entry, field string) int {
+	switch field {
+	case "timestamp":
+		return a.Timestamp.Compare(b.Timestamp)
+	case "id":
+		return cmp.Compare(a.ID, b.ID)
+	default:
+		return 0
+	}
+}
+
+// entryFieldValue extracts a cursor-comparable value from a ledger entry. The
+// timestamp is returned as time.Time (not a formatted string) so that
+// query.CompareAny uses temporal comparison against the RFC3339Nano string
+// cursor value rather than lexical string comparison.
+func entryFieldValue(e *Entry, field string) any {
+	switch field {
+	case "timestamp":
+		return e.Timestamp
+	case "id":
+		return e.ID
+	default:
+		return ""
+	}
 }
 
 // Verify re-computes the HMAC-SHA256 hash for each entry in [fromSeq, toSeq]

--- a/runtime/audit/ledger/mem_store_test.go
+++ b/runtime/audit/ledger/mem_store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
 
@@ -567,7 +568,8 @@ func TestMemStore_Query_ByFilters(t *testing.T) {
 		}
 	}
 
-	results, err := store.Query(context.Background(), ledger.AuditFilters{EventType: "type.A"}, ledger.QueryListParams{Limit: 100})
+	results, err := store.Query(context.Background(), ledger.AuditFilters{EventType: "type.A"},
+		query.ListParams{Limit: 100, Sort: ledger.QuerySort})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}

--- a/runtime/audit/ledger/mem_store_test.go
+++ b/runtime/audit/ledger/mem_store_test.go
@@ -569,7 +569,7 @@ func TestMemStore_Query_ByFilters(t *testing.T) {
 	}
 
 	results, err := store.Query(context.Background(), ledger.AuditFilters{EventType: "type.A"},
-		query.ListParams{Limit: 100, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 100, Sort: ledger.QuerySort()})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}

--- a/runtime/audit/ledger/store.go
+++ b/runtime/audit/ledger/store.go
@@ -3,6 +3,8 @@ package ledger
 import (
 	"context"
 	"time"
+
+	"github.com/ghbvf/gocell/pkg/query"
 )
 
 // TailSnapshot holds a point-in-time snapshot of the ledger chain tail.
@@ -37,18 +39,14 @@ type AuditFilters struct {
 	To time.Time
 }
 
-// QueryListParams holds pagination parameters for Store.Query.
-// Intentionally simple (no cursor) for the MemStore implementation; the PG
-// store will extend this with keyset cursor support in S8+.
-type QueryListParams struct {
-	// Limit is the maximum number of entries to return. Zero or negative
-	// values are treated as "no limit" for the MemStore; PG store applies
-	// query.MaxPageSize capping.
-	Limit int
-
-	// Offset is a simple row offset for MemStore. PG store will replace this
-	// with keyset cursor semantics.
-	Offset int
+// QuerySort is the canonical ordering for audit ledger listings: newest first
+// (timestamp DESC) with the store-assigned id as a stable ASC tie-breaker. It
+// is the single source of truth shared by every Store.Query caller and matches
+// the idx_audit_namespace_ts_id composite index, so PG keyset pagination is an
+// index scan. Store.Query requires a non-empty Sort — callers pass this.
+var QuerySort = []query.SortColumn{
+	{Name: "timestamp", Direction: query.SortDESC},
+	{Name: "id", Direction: query.SortASC},
 }
 
 // Store persists audit entries in a tamper-evident hash chain. Implementations
@@ -72,7 +70,7 @@ type QueryListParams struct {
 //   - Tail: returns the current chain tail snapshot. Returns zero TailSnapshot
 //     for an empty store (not an error).
 //   - GetBySeq: fetch entry by sequence number. Missing → ErrAuditLedgerNotFound.
-//   - Query: list entries matching AuditFilters with simple pagination.
+//   - Query: list entries matching AuditFilters with keyset cursor pagination.
 //     Returns empty slice (not error) when no entries match.
 //   - Verify: re-compute HMAC for each entry in [fromSeq, toSeq] and check
 //     chain linkage. Returns valid=true and firstInvalidSeq=-1 when all
@@ -95,9 +93,13 @@ type Store interface {
 	// ErrAuditLedgerNotFound when the sequence number does not exist.
 	GetBySeq(ctx context.Context, seq int64) (*Entry, error)
 
-	// Query lists entries matching AuditFilters with simple pagination.
+	// Query lists entries matching AuditFilters using keyset cursor pagination
+	// defined by params (Limit + decoded CursorValues + Sort). It returns up to
+	// params.FetchLimit() (Limit+1) rows for N+1 hasMore detection, ordered by
+	// params.Sort. params.Sort must be non-empty (callers pass QuerySort);
+	// an empty Sort is a programmer error and yields ErrValidationFailed.
 	// Returns an empty (non-nil) slice when no entries match.
-	Query(ctx context.Context, filters AuditFilters, params QueryListParams) ([]*Entry, error)
+	Query(ctx context.Context, filters AuditFilters, params query.ListParams) ([]*Entry, error)
 
 	// Verify re-computes the HMAC for each entry in [fromSeq, toSeq] and checks
 	// chain linkage (PrevHash). Returns valid=true and firstInvalidSeq=-1 when

--- a/runtime/audit/ledger/store.go
+++ b/runtime/audit/ledger/store.go
@@ -39,14 +39,19 @@ type AuditFilters struct {
 	To time.Time
 }
 
-// QuerySort is the canonical ordering for audit ledger listings: newest first
-// (timestamp DESC) with the store-assigned id as a stable ASC tie-breaker. It
-// is the single source of truth shared by every Store.Query caller and matches
-// the idx_audit_namespace_ts_id composite index, so PG keyset pagination is an
-// index scan. Store.Query requires a non-empty Sort — callers pass this.
-var QuerySort = []query.SortColumn{
-	{Name: "timestamp", Direction: query.SortDESC},
-	{Name: "id", Direction: query.SortASC},
+// QuerySort returns the canonical ordering for audit ledger listings: newest
+// first (timestamp DESC) with the store-assigned id as a stable ASC tie-breaker.
+// It is the single source of truth shared by every Store.Query caller and
+// matches the idx_audit_namespace_ts_id composite index, so PG keyset pagination
+// is an index scan. Store.Query requires a non-empty Sort — callers pass this.
+//
+// A fresh slice is returned on each call so callers cannot mutate shared package
+// state (the exported value would otherwise be an aliasable mutable global).
+func QuerySort() []query.SortColumn {
+	return []query.SortColumn{
+		{Name: "timestamp", Direction: query.SortDESC},
+		{Name: "id", Direction: query.SortASC},
+	}
 }
 
 // Store persists audit entries in a tamper-evident hash chain. Implementations

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -151,6 +151,8 @@ func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Run("Append_MultiKey_Payload_RoundTrip", func(t *testing.T) { runAppendMultiKeyPayloadRoundTrip(t, factory) })
 	t.Run("Query_Ordering_TimestampDesc_IDAsc", func(t *testing.T) { runQueryOrderingTimestampDescIDAsc(t, factory) })
 	t.Run("Query_Keyset_Pagination", func(t *testing.T) { runQueryKeysetPagination(t, factory) })
+	t.Run("Query_EmptySort_Rejected", func(t *testing.T) { runQueryEmptySortRejected(t, factory) })
+	t.Run("Query_InvalidCursor_Rejected", func(t *testing.T) { runQueryInvalidCursorRejected(t, factory) })
 	t.Run("Protocol_HashParity", func(t *testing.T) { runProtocolHashParity(t, factory, protocol) })
 }
 
@@ -450,7 +452,7 @@ func runQueryByFilters(t *testing.T, factory Factory) {
 	}
 
 	results, err := store.Query(context.Background(), ledger.AuditFilters{EventType: "type.X"},
-		query.ListParams{Limit: 50, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 50, Sort: ledger.QuerySort()})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -547,7 +549,7 @@ func runQueryOrderingTimestampDescIDAsc(t *testing.T, factory Factory) {
 	}
 
 	results, err := store.Query(context.Background(), ledger.AuditFilters{},
-		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -635,13 +637,20 @@ func seedKeysetEntries(t *testing.T, store ledger.Store, base time.Time) {
 // []any{ts.Format(RFC3339Nano), id} — to reproduce the string-typed cursor that
 // exercises the PG timestamptz bind path. The loop is bounded by keysetSeedTotal
 // to guard against a non-terminating cursor.
+//
+// This drives the store-layer CursorValues API directly (raw []any), not an
+// opaque codec token — codec round-tripping is covered by the service tests.
+// last.ID differs by backend (EventID on MemStore, random UUID on PG) but is
+// always taken from the Query result, so the cross-backend contract asserted
+// here is "full traversal visits every entry once in order", not cursor-value
+// equality (the seed uses distinct timestamps so the id tie-break never fires).
 func collectKeysetPages(t *testing.T, store ledger.Store, limit int) []string {
 	t.Helper()
 	var collected []string
 	var cursorVals []any
 	for iter := 0; iter <= keysetSeedTotal+1; iter++ {
 		rows, err := store.Query(context.Background(), ledger.AuditFilters{},
-			query.ListParams{Limit: limit, Sort: ledger.QuerySort, CursorValues: cursorVals})
+			query.ListParams{Limit: limit, Sort: ledger.QuerySort(), CursorValues: cursorVals})
 		if err != nil {
 			t.Fatalf("Query iter %d: %v", iter, err)
 		}
@@ -661,6 +670,40 @@ func collectKeysetPages(t *testing.T, store ledger.Store, limit int) []string {
 	}
 	t.Fatal("keyset traversal did not terminate within bound")
 	return nil
+}
+
+// runQueryEmptySortRejected asserts both backends reject a Query with an empty
+// Sort with ErrValidationFailed. The keyset contract requires a non-empty sort
+// (MemStore guards explicitly; PG via pgquery.AppendKeyset) — this case locks
+// that both backends produce the same rejection.
+func runQueryEmptySortRejected(t *testing.T, factory Factory) {
+	store, _, cleanup := factory(t)
+	defer cleanup()
+
+	_, err := store.Query(context.Background(), ledger.AuditFilters{}, query.ListParams{Limit: 10})
+	assertErrCode(t, err, errcode.ErrValidationFailed)
+}
+
+// runQueryInvalidCursorRejected asserts both backends reject a cursor whose
+// timestamp value is not a valid RFC3339Nano string with ErrCursorInvalid.
+// The backends reach the rejection via different paths — MemStore through
+// query.CompareAny's parse, PG through bindTimestampCursor's time.Parse — so
+// this case locks cross-backend parity on the malformed-cursor error. At least
+// one entry is seeded so MemStore's ApplyCursor actually performs the compare.
+func runQueryInvalidCursorRejected(t *testing.T, factory Factory) {
+	store, fc, cleanup := factory(t)
+	defer cleanup()
+
+	for i := 1; i <= 2; i++ {
+		e := NewEntryFixture(t, fmt.Sprintf("badcur-%d", i), "badcur.test", "actor", fc.Now())
+		if err := store.Append(context.Background(), e); err != nil {
+			t.Fatalf(msgAppendIdx, i, err)
+		}
+	}
+
+	_, err := store.Query(context.Background(), ledger.AuditFilters{},
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort(), CursorValues: []any{"not-a-timestamp", "some-id"}})
+	assertErrCode(t, err, errcode.ErrCursorInvalid)
 }
 
 // runProtocolHashParity verifies that a Store's persisted entry.Hash matches

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest" // test funnel; storetest is testing-helper package, errcodetest import is intentional (not a test-only import in a non-_test.go file)
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
@@ -149,6 +150,7 @@ func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Run("Query_ByFilters", func(t *testing.T) { runQueryByFilters(t, factory) })
 	t.Run("Append_MultiKey_Payload_RoundTrip", func(t *testing.T) { runAppendMultiKeyPayloadRoundTrip(t, factory) })
 	t.Run("Query_Ordering_TimestampDesc_IDAsc", func(t *testing.T) { runQueryOrderingTimestampDescIDAsc(t, factory) })
+	t.Run("Query_Keyset_Pagination", func(t *testing.T) { runQueryKeysetPagination(t, factory) })
 	t.Run("Protocol_HashParity", func(t *testing.T) { runProtocolHashParity(t, factory, protocol) })
 }
 
@@ -447,7 +449,8 @@ func runQueryByFilters(t *testing.T, factory Factory) {
 		}
 	}
 
-	results, err := store.Query(context.Background(), ledger.AuditFilters{EventType: "type.X"}, ledger.QueryListParams{Limit: 50})
+	results, err := store.Query(context.Background(), ledger.AuditFilters{EventType: "type.X"},
+		query.ListParams{Limit: 50, Sort: ledger.QuerySort})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -543,7 +546,8 @@ func runQueryOrderingTimestampDescIDAsc(t *testing.T, factory Factory) {
 		}
 	}
 
-	results, err := store.Query(context.Background(), ledger.AuditFilters{}, ledger.QueryListParams{Limit: 10})
+	results, err := store.Query(context.Background(), ledger.AuditFilters{},
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort})
 	if err != nil {
 		t.Fatalf("Query: %v", err)
 	}
@@ -562,6 +566,101 @@ func runQueryOrderingTimestampDescIDAsc(t *testing.T, factory Factory) {
 				i, gotEventID, wantEventID)
 		}
 	}
+}
+
+// runQueryKeysetPagination verifies cross-backend keyset cursor pagination:
+// full traversal via the (timestamp DESC, id ASC) keyset yields every entry
+// exactly once, in timestamp-DESC order, with the final page detected by
+// len(rows) <= limit (no FetchLimit overflow row).
+//
+// Sub-second-distinct timestamps are deliberately used: the cursor value for
+// the timestamp column is an RFC3339Nano *string* (the wire form produced by
+// the service Extract closure after JSON round-trip). The PG store must convert
+// it back to time.Time before pushing it into the timestamptz keyset predicate;
+// millisecond-distinct timestamps prove that conversion preserves sub-second
+// ordering rather than truncating or lexically mis-comparing. MemStore exercises
+// the same string-typed cursor through query.CompareAny.
+//
+// The suite calls store.Query directly (raw CursorValues, not an opaque codec
+// token), so the next page's cursor is built by hand from the last visible
+// entry — mirroring the service Extract: []any{ts.Format(RFC3339Nano), id}.
+func runQueryKeysetPagination(t *testing.T, factory Factory) {
+	store, fc, cleanup := factory(t)
+	defer cleanup()
+
+	seedKeysetEntries(t, store, fc.Now())
+	collected := collectKeysetPages(t, store, 2)
+
+	// timestamp DESC → ks-6, ks-5, ..., ks-0 (no ties: every entry seen once).
+	want := []string{"ks-6", "ks-5", "ks-4", "ks-3", "ks-2", "ks-1", "ks-0"}
+	if len(collected) != len(want) {
+		t.Fatalf("keyset traversal: got %d entries %v, want %d %v",
+			len(collected), collected, len(want), want)
+	}
+	for i := range want {
+		if collected[i] != want[i] {
+			t.Errorf("keyset order[%d]: got %q, want %q (full list got=%v)",
+				i, collected[i], want[i], collected)
+		}
+	}
+}
+
+// keysetSeedTotal is the number of entries seeded by seedKeysetEntries and the
+// upper bound on collectKeysetPages iterations.
+const keysetSeedTotal = 7
+
+// seedKeysetEntries appends keysetSeedTotal entries (ks-0..ks-6) in shuffled
+// insertion order with millisecond-distinct timestamps, so a backend that
+// ignores the keyset (returns insertion order) is caught.
+func seedKeysetEntries(t *testing.T, store ledger.Store, base time.Time) {
+	t.Helper()
+	insertion := []int{3, 0, 5, 1, 6, 2, 4}
+	for _, n := range insertion {
+		e := &ledger.Entry{
+			EventID:   fmt.Sprintf("ks-%d", n),
+			EventType: "keyset.test",
+			ActorID:   "actor",
+			Timestamp: base.Add(time.Duration(n) * time.Millisecond),
+			Payload:   []byte(`{}`),
+		}
+		if err := store.Append(context.Background(), e); err != nil {
+			t.Fatalf("Append ks-%d: %v", n, err)
+		}
+	}
+}
+
+// collectKeysetPages traverses every page via the (timestamp DESC, id ASC)
+// keyset and returns the EventIDs in visit order. Each next-page cursor is
+// built by hand from the last visible entry — mirroring the service Extract:
+// []any{ts.Format(RFC3339Nano), id} — to reproduce the string-typed cursor that
+// exercises the PG timestamptz bind path. The loop is bounded by keysetSeedTotal
+// to guard against a non-terminating cursor.
+func collectKeysetPages(t *testing.T, store ledger.Store, limit int) []string {
+	t.Helper()
+	var collected []string
+	var cursorVals []any
+	for iter := 0; iter <= keysetSeedTotal+1; iter++ {
+		rows, err := store.Query(context.Background(), ledger.AuditFilters{},
+			query.ListParams{Limit: limit, Sort: ledger.QuerySort, CursorValues: cursorVals})
+		if err != nil {
+			t.Fatalf("Query iter %d: %v", iter, err)
+		}
+		page := rows
+		hasMore := len(rows) > limit
+		if hasMore {
+			page = rows[:limit]
+		}
+		for _, e := range page {
+			collected = append(collected, e.EventID)
+		}
+		if !hasMore {
+			return collected
+		}
+		last := page[len(page)-1]
+		cursorVals = []any{last.Timestamp.Format(time.RFC3339Nano), last.ID}
+	}
+	t.Fatal("keyset traversal did not terminate within bound")
+	return nil
 }
 
 // runProtocolHashParity verifies that a Store's persisted entry.Hash matches

--- a/tests/integration/l2atomicity/helpers_test.go
+++ b/tests/integration/l2atomicity/helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -425,7 +426,7 @@ func countLiveRefreshTokens(t *testing.T, h *l2Harness, sessionID string) int {
 // concurrent role.assigned / session.created delivery could satisfy).
 func countAuditEntries(t *testing.T, ctx context.Context, h *l2Harness, eventType string) int {
 	t.Helper()
-	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, ledger.QueryListParams{})
+	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, query.ListParams{Limit: 500, Sort: ledger.QuerySort})
 	require.NoError(t, err)
 	return len(entries)
 }
@@ -440,7 +441,7 @@ func countAuditEntries(t *testing.T, ctx context.Context, h *l2Harness, eventTyp
 // triggers multiple revokes on the same harness needs the correct semantic.
 func latestAuditEntry(t *testing.T, ctx context.Context, h *l2Harness, eventType string) *ledger.Entry {
 	t.Helper()
-	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, ledger.QueryListParams{})
+	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, query.ListParams{Limit: 500, Sort: ledger.QuerySort})
 	require.NoError(t, err)
 	require.NotEmpty(t, entries, "expected at least one audit entry for event %s", eventType)
 	return entries[0]

--- a/tests/integration/l2atomicity/helpers_test.go
+++ b/tests/integration/l2atomicity/helpers_test.go
@@ -426,7 +426,7 @@ func countLiveRefreshTokens(t *testing.T, h *l2Harness, sessionID string) int {
 // concurrent role.assigned / session.created delivery could satisfy).
 func countAuditEntries(t *testing.T, ctx context.Context, h *l2Harness, eventType string) int {
 	t.Helper()
-	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, query.ListParams{Limit: 500, Sort: ledger.QuerySort})
+	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, query.ListParams{Limit: 500, Sort: ledger.QuerySort()})
 	require.NoError(t, err)
 	return len(entries)
 }
@@ -441,7 +441,7 @@ func countAuditEntries(t *testing.T, ctx context.Context, h *l2Harness, eventTyp
 // triggers multiple revokes on the same harness needs the correct semantic.
 func latestAuditEntry(t *testing.T, ctx context.Context, h *l2Harness, eventType string) *ledger.Entry {
 	t.Helper()
-	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, query.ListParams{Limit: 500, Sort: ledger.QuerySort})
+	entries, err := h.auditStore.Query(ctx, ledger.AuditFilters{EventType: eventType}, query.ListParams{Limit: 500, Sort: ledger.QuerySort()})
 	require.NoError(t, err)
 	require.NotEmpty(t, entries, "expected at least one audit entry for event %s", eventType)
 	return entries[0]


### PR DESCRIPTION
## Summary

audit 查询（`GET /api/v1/audit/entries`）的 keyset 游标分页此前只在 **service 层假下推**：从 store 一次性捞最多 `auditQueryFetchCap=500` 行，再在内存里 `query.Sort` + `query.ApplyCursor`。数据量超 500 时翻页结果不完整。

本 PR 把 keyset **真正推进 store 层**，对标 `configcore` List 下推形态：
- **PG**：`pgquery.AppendKeyset` 经已存在的 `idx_audit_namespace_ts_id (namespace, timestamp DESC, id ASC)` 索引做 SQL keyset 扫描，每页只取 `LIMIT FetchLimit()`。
- **MemStore**：`query.Sort` + `query.ApplyCursor` 内存 keyset。
- 删除 `auditQueryFetchCap` 内存硬 limit。HTTP wire 契约与游标格式不变。

`Refs: S8-AUDIT-QUERY-KEYSET-PUSH-DOWN-01`
`ref: configcore internal/configreader/service.go + internal/adapters/postgres/config_repo.go`（keyset 下推范本）

Closes #1000

## 关键设计点

- **timestamptz 绑定**（load-bearing）：游标值经 cursor codec 的 JSON round-trip 后是 RFC3339Nano **字符串**；pgx 二进制协议无法把 string 绑到 `timestamptz`。新增 `bindTimestampCursor` 在 `AppendKeyset` 前把 timestamp 列游标值 `time.Parse` 回 `time.Time`（与现有 `filters.From` 的 time.Time 绑定同路径）。MemStore 无需转换（`query.CompareAny` 已支持 `time.Time ↔ RFC3339 string`）。**已由跨后端 conformance 的亚秒级 PG 用例证明正确**。
- **去 Sort 静默回填**（无向后兼容软点）：删 `ledger.QueryListParams`（含无人用的 `Offset`），`Store.Query` 改收 `query.ListParams`。canonical 序单源到 `ledger.QuerySort`，两后端**统一要求非空 Sort**，违反即 `ErrValidationFailed`（PG 由 `AppendKeyset` 强制，mem 加等价 guard）。无别名、无双路径。
- **OOM 上限不丢**：删 cap 后单页行数由 `PageParams.Normalize`（Limit 钳到 ≤`MaxPageSize=500`）+ 每页 `LIMIT FetchLimit()` 结构性保证。

## Contract-fanout 实现矩阵（Store 接口签名变更触发）

```
Contract: runtime/audit/ledger.Store.Query
Change: QueryListParams{Limit,Offset} → query.ListParams（keyset 语义）
Implementations: [x] MemStore  [x] PG  (无第三实现/decorator)
Conformance test: runtime/audit/ledger/storetest.runQueryKeysetPagination（跑 MemStore + PG）
Repro: go test -tags=integration ./adapters/postgres/... -run 'TestAuditLedgerStore_StoretestSuite/Query_Keyset_Pagination'
       go test ./runtime/audit/ledger/... -run 'Query_Keyset'
Dependent contracts (governance scan): none（HTTP contract.yaml 已声明 cursor/limit/hasMore，不变）
```

## AI-robust 边界说明

本 PR 是 feature 实现，不属 ai-robust 章程「约束 enforcement 机制」范畴。`bindTimestampCursor` 是当前唯一非文本列 keyset 消费者的局部解，正确性由跨后端 conformance（test）守；不预建「通用非文本列游标绑定」机制，不超前于代码，故无 archtest / backlog carve-out。

## Test plan

- [x] `go build ./...`
- [x] MemStore conformance（含新增 `Query_Keyset_Pagination`）：`go test ./runtime/audit/ledger/...`
- [x] **PG conformance（含 `Query_Keyset_Pagination` on real PG，timestamptz 绑定正确性兜底）**：`go test -tags=integration ./adapters/postgres/... -run TestAuditLedgerStore_StoretestSuite`
- [x] auditcore + auditquery 单元：`go test ./cells/auditcore/...`
- [x] l2atomicity 集成（`countAuditEntries`/`latestAuditEntry` 行为修复）：`go test -tags=integration ./tests/integration/l2atomicity/...`
- [x] `golangci-lint run`：0 issues
- [x] 全量 `go test ./...` 仅 `tools/archtest` 失败，经核对与 `origin/develop` (523e6d6c4) 完全一致（pre-existing，与本 diff 无关；完整 archtest 由 nightly 兜底）

🤖 Generated with [Claude Code](https://claude.com/claude-code)