### PR TITLE
refactor(observability): kernel metrics 接口 ctx-bearing funnel (METRICS-CTX-FUNNEL-01)

### DIFF
--- a/adapters/oidc/metrics.go
+++ b/adapters/oidc/metrics.go
@@ -1,6 +1,8 @@
 package oidc
 
 import (
+	"context"
+
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -15,7 +17,7 @@ type RefreshCollector interface {
 	// RecordRefresh increments the refresh counter.
 	// success=true means discovery succeeded and a.provider was updated;
 	// success=false means discovery failed (fail-open: old provider kept).
-	RecordRefresh(success bool)
+	RecordRefresh(ctx context.Context, success bool)
 }
 
 // NoopRefreshCollector is the default collector used when no observability is
@@ -24,7 +26,7 @@ type RefreshCollector interface {
 type NoopRefreshCollector struct{}
 
 // RecordRefresh is a no-op.
-func (NoopRefreshCollector) RecordRefresh(_ bool) { /* no-op: metrics disabled */ }
+func (NoopRefreshCollector) RecordRefresh(_ context.Context, _ bool) { /* no-op: metrics disabled */ }
 
 // Compile-time interface check.
 var _ RefreshCollector = NoopRefreshCollector{}
@@ -80,10 +82,10 @@ func NewProviderRefreshCollector(p metrics.Provider, cellID string) (RefreshColl
 }
 
 // RecordRefresh increments oidc_jwks_refresh_total{cell, result}.
-func (c *providerRefreshCollector) RecordRefresh(success bool) {
+func (c *providerRefreshCollector) RecordRefresh(ctx context.Context, success bool) {
 	result := "failure"
 	if success {
 		result = "success"
 	}
-	c.refresh.With(metrics.Labels{"cell": c.cellID, "result": result}).Inc()
+	c.refresh.With(metrics.Labels{"cell": c.cellID, "result": result}).Inc(ctx)
 }

--- a/adapters/oidc/metrics_test.go
+++ b/adapters/oidc/metrics_test.go
@@ -1,6 +1,7 @@
 package oidc
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -43,8 +44,8 @@ func TestNewProviderRefreshCollector_NopProviderNoPanic(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
-	assert.NotPanics(t, func() { c.RecordRefresh(true) })
-	assert.NotPanics(t, func() { c.RecordRefresh(false) })
+	assert.NotPanics(t, func() { c.RecordRefresh(context.Background(), true) })
+	assert.NotPanics(t, func() { c.RecordRefresh(context.Background(), false) })
 }
 
 // TestNewProviderRefreshCollector_RegistrationFailure verifies that a Provider
@@ -82,7 +83,7 @@ func TestProviderRefreshCollector_RecordRefresh_Labels(t *testing.T) {
 			col, err := NewProviderRefreshCollector(provider, "oidctest")
 			require.NoError(t, err)
 
-			col.RecordRefresh(tc.success)
+			col.RecordRefresh(context.Background(), tc.success)
 
 			ops := provider.ops()
 			require.Len(t, ops, 1, "exactly one counter Inc per RecordRefresh")
@@ -112,8 +113,8 @@ func TestProviderRefreshCollector_RegistersExpectedLabelNames(t *testing.T) {
 func TestNoopRefreshCollector_NoPanic(t *testing.T) {
 	t.Parallel()
 	var c NoopRefreshCollector
-	assert.NotPanics(t, func() { c.RecordRefresh(true) })
-	assert.NotPanics(t, func() { c.RecordRefresh(false) })
+	assert.NotPanics(t, func() { c.RecordRefresh(context.Background(), true) })
+	assert.NotPanics(t, func() { c.RecordRefresh(context.Background(), false) })
 }
 
 // ---------------------------------------------------------------------------
@@ -202,13 +203,13 @@ type refreshSpyCounter struct {
 	labels metrics.Labels
 }
 
-func (c *refreshSpyCounter) Inc() {
+func (c *refreshSpyCounter) Inc(_ context.Context) {
 	c.parent.records = append(c.parent.records, refreshSpyRecord{
 		name: c.name, op: "Inc", labels: c.labels, value: 1,
 	})
 }
 
-func (c *refreshSpyCounter) Add(d float64) {
+func (c *refreshSpyCounter) Add(_ context.Context, d float64) {
 	c.parent.records = append(c.parent.records, refreshSpyRecord{
 		name: c.name, op: "Add", labels: c.labels, value: d,
 	})

--- a/adapters/oidc/refresh_worker.go
+++ b/adapters/oidc/refresh_worker.go
@@ -121,7 +121,7 @@ func (a *Adapter) runRefreshLoop(ctx context.Context) {
 			_, err := a.Refresh(ctx)
 			if err != nil {
 				n := a.consecutiveFailures.Add(1)
-				a.refreshCollector.RecordRefresh(false)
+				a.refreshCollector.RecordRefresh(ctx, false)
 				slog.Warn(
 					"oidc: jwks refresh failed",
 					slog.String("issuer", a.config.IssuerURL),
@@ -130,7 +130,7 @@ func (a *Adapter) runRefreshLoop(ctx context.Context) {
 				)
 			} else {
 				prev := a.consecutiveFailures.Swap(0)
-				a.refreshCollector.RecordRefresh(true)
+				a.refreshCollector.RecordRefresh(ctx, true)
 				if prev > 0 {
 					slog.Info(
 						"oidc: jwks refresh recovered",

--- a/adapters/oidc/refresh_worker_test.go
+++ b/adapters/oidc/refresh_worker_test.go
@@ -27,7 +27,7 @@ type fakeRefreshCollector struct {
 	failureCount atomic.Int64
 }
 
-func (c *fakeRefreshCollector) RecordRefresh(success bool) {
+func (c *fakeRefreshCollector) RecordRefresh(_ context.Context, success bool) {
 	if success {
 		c.successCount.Add(1)
 	} else {

--- a/adapters/otel/metric_provider.go
+++ b/adapters/otel/metric_provider.go
@@ -269,18 +269,14 @@ type otelCounter struct {
 	attrs otelmetric.MeasurementOption
 }
 
-// Inc records 1. Uses context.Background() because the Counter interface
-// deliberately omits context (kernel modules emit from hot paths where
-// passing ctx everywhere would be noise). OTel tolerates Background.
-//
-// See METRICS-CTX-FUNNEL-01 — the ctx-bearing alignment to OTel
-// exemplar/baggage semantics is an open cross-layer refactor (kernel metrics
-// interface + adapters/{prometheus,otel} + all emission sites).
-// Background() here is bounded by the kernel interface shape, not by this adapter.
-func (c *otelCounter) Inc() { c.inner.Add(context.Background(), 1, c.attrs) }
+// Inc records 1. ctx is forwarded to the OTel instrument to support exemplar
+// and baggage correlation.
+func (c *otelCounter) Inc(ctx context.Context) { c.inner.Add(ctx, 1, c.attrs) }
 
-func (c *otelCounter) Add(delta float64) {
-	c.inner.Add(context.Background(), delta, c.attrs)
+// Add records delta. ctx is forwarded to the OTel instrument to support exemplar
+// and baggage correlation.
+func (c *otelCounter) Add(ctx context.Context, delta float64) {
+	c.inner.Add(ctx, delta, c.attrs)
 }
 
 type otelHistogram struct {
@@ -288,8 +284,10 @@ type otelHistogram struct {
 	attrs otelmetric.MeasurementOption
 }
 
-func (h *otelHistogram) Observe(v float64) {
-	h.inner.Record(context.Background(), v, h.attrs)
+// Observe records v. ctx is forwarded to the OTel instrument to support exemplar
+// and baggage correlation.
+func (h *otelHistogram) Observe(ctx context.Context, v float64) {
+	h.inner.Record(ctx, v, h.attrs)
 }
 
 // otelGaugeVec wraps Float64Gauge and provides per-label-set last-value
@@ -369,37 +367,40 @@ type otelGauge struct {
 }
 
 // Set records the gauge as absolute value v (Float64Gauge.Record semantics).
-//
-// See METRICS-CTX-FUNNEL-01 for the open work to propagate context through
-// the kernel metrics interface; until then context.Background() is the
-// correct placeholder here (mirrors Counter).
-func (g *otelGauge) Set(v float64) {
+// ctx is forwarded to the OTel instrument to support exemplar and baggage correlation.
+func (g *otelGauge) Set(ctx context.Context, v float64) {
 	g.mu.Lock()
 	g.last = v
 	g.mu.Unlock()
-	g.inner.Record(context.Background(), v, g.attrs)
+	g.inner.Record(ctx, v, g.attrs)
 }
 
-func (g *otelGauge) Inc() {
+// Inc increments the gauge by 1.
+// ctx is forwarded to the OTel instrument to support exemplar and baggage correlation.
+func (g *otelGauge) Inc(ctx context.Context) {
 	g.mu.Lock()
 	g.last++
 	v := g.last
 	g.mu.Unlock()
-	g.inner.Record(context.Background(), v, g.attrs)
+	g.inner.Record(ctx, v, g.attrs)
 }
 
-func (g *otelGauge) Dec() {
+// Dec decrements the gauge by 1.
+// ctx is forwarded to the OTel instrument to support exemplar and baggage correlation.
+func (g *otelGauge) Dec(ctx context.Context) {
 	g.mu.Lock()
 	g.last--
 	v := g.last
 	g.mu.Unlock()
-	g.inner.Record(context.Background(), v, g.attrs)
+	g.inner.Record(ctx, v, g.attrs)
 }
 
-func (g *otelGauge) Add(delta float64) {
+// Add adds delta to the gauge.
+// ctx is forwarded to the OTel instrument to support exemplar and baggage correlation.
+func (g *otelGauge) Add(ctx context.Context, delta float64) {
 	g.mu.Lock()
 	g.last += delta
 	v := g.last
 	g.mu.Unlock()
-	g.inner.Record(context.Background(), v, g.attrs)
+	g.inner.Record(ctx, v, g.attrs)
 }

--- a/adapters/otel/metric_provider_internal_test.go
+++ b/adapters/otel/metric_provider_internal_test.go
@@ -242,7 +242,7 @@ type fakeFloat64Counter struct {
 	gotDelta float64
 }
 
-func (f *fakeFloat64Counter) Add(ctx context.Context, incr float64, _ ...otelmetric.MeasurementOption) {
+func (f *fakeFloat64Counter) Add(ctx context.Context, incr float64, _ ...otelmetric.AddOption) {
 	f.gotCtx = ctx
 	f.gotDelta = incr
 }
@@ -254,7 +254,7 @@ type fakeFloat64Histogram struct {
 	gotValue float64
 }
 
-func (f *fakeFloat64Histogram) Record(ctx context.Context, value float64, _ ...otelmetric.MeasurementOption) {
+func (f *fakeFloat64Histogram) Record(ctx context.Context, value float64, _ ...otelmetric.RecordOption) {
 	f.gotCtx = ctx
 	f.gotValue = value
 }
@@ -266,7 +266,7 @@ type fakeFloat64Gauge struct {
 	gotValue float64
 }
 
-func (f *fakeFloat64Gauge) Record(ctx context.Context, value float64, _ ...otelmetric.MeasurementOption) {
+func (f *fakeFloat64Gauge) Record(ctx context.Context, value float64, _ ...otelmetric.RecordOption) {
 	f.gotCtx = ctx
 	f.gotValue = value
 }

--- a/adapters/otel/metric_provider_internal_test.go
+++ b/adapters/otel/metric_provider_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	otelmetric "go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
@@ -145,7 +146,7 @@ func TestMetricProvider_GaugeVec_OverflowGaugeSlotIsShared(t *testing.T) {
 
 	// Emit cap distinct label sets — all should land in gauges map.
 	for i := 0; i < cap; i++ {
-		gvIface.With(metrics.Labels{"k": strconv.Itoa(i)}).Set(1)
+		gvIface.With(metrics.Labels{"k": strconv.Itoa(i)}).Set(context.Background(), 1)
 	}
 	gv.gaugesMu.Lock()
 	sizeAtCap := len(gv.gauges)
@@ -154,7 +155,7 @@ func TestMetricProvider_GaugeVec_OverflowGaugeSlotIsShared(t *testing.T) {
 
 	// Emit 10 more distinct overflow label sets — gauges must not grow beyond cap.
 	for i := cap; i < cap+10; i++ {
-		gvIface.With(metrics.Labels{"k": strconv.Itoa(i)}).Set(float64(i))
+		gvIface.With(metrics.Labels{"k": strconv.Itoa(i)}).Set(context.Background(), float64(i))
 	}
 	gv.gaugesMu.Lock()
 	sizeAfterOverflow := len(gv.gauges)
@@ -193,7 +194,7 @@ func TestMetricProvider_OverflowDataPointEmitted(t *testing.T) {
 
 	// Emit 5 distinct values past cap=3 → 3 distinct cached + 2 overflow.
 	for i := 0; i < 5; i++ {
-		cv.With(metrics.Labels{"k": strconv.Itoa(i)}).Inc()
+		cv.With(metrics.Labels{"k": strconv.Itoa(i)}).Inc(context.Background())
 	}
 
 	var rm metricdata.ResourceMetrics
@@ -220,4 +221,150 @@ func TestMetricProvider_OverflowDataPointEmitted(t *testing.T) {
 		"a data point with otel.metric.overflow=true must appear past cap")
 	assert.LessOrEqual(t, totalDataPoints, 4,
 		"data points must collapse high-cardinality tail; got %d (cap=3 + 1 overflow expected)", totalDataPoints)
+}
+
+// ---------------------------------------------------------------------------
+// ctx-passthrough tests (METRICS-CTX-FUNNEL-01)
+//
+// These tests assert that every otelCounter / otelHistogram / otelGauge method
+// forwards the *caller-supplied* ctx to the underlying OTel instrument — not
+// context.Background(). Fake implementations of Float64Counter /
+// Float64Histogram / Float64Gauge capture the ctx argument so we can assert
+// sentinel value propagation.
+// ---------------------------------------------------------------------------
+
+type ctxSentinelKey struct{}
+
+// fakeFloat64Counter captures the ctx and delta from Add calls.
+type fakeFloat64Counter struct {
+	otelmetric.Float64Counter
+	gotCtx   context.Context
+	gotDelta float64
+}
+
+func (f *fakeFloat64Counter) Add(ctx context.Context, incr float64, _ ...otelmetric.MeasurementOption) {
+	f.gotCtx = ctx
+	f.gotDelta = incr
+}
+
+// fakeFloat64Histogram captures the ctx and value from Record calls.
+type fakeFloat64Histogram struct {
+	otelmetric.Float64Histogram
+	gotCtx   context.Context
+	gotValue float64
+}
+
+func (f *fakeFloat64Histogram) Record(ctx context.Context, value float64, _ ...otelmetric.MeasurementOption) {
+	f.gotCtx = ctx
+	f.gotValue = value
+}
+
+// fakeFloat64Gauge captures the ctx and value from Record calls.
+type fakeFloat64Gauge struct {
+	otelmetric.Float64Gauge
+	gotCtx   context.Context
+	gotValue float64
+}
+
+func (f *fakeFloat64Gauge) Record(ctx context.Context, value float64, _ ...otelmetric.MeasurementOption) {
+	f.gotCtx = ctx
+	f.gotValue = value
+}
+
+// sentinelCtx creates a context containing a sentinel value for identity checks.
+func sentinelCtx() context.Context {
+	return context.WithValue(context.Background(), ctxSentinelKey{}, "sentinel")
+}
+
+// assertCtxSentinel fails the test if ctx does not carry the sentinel value.
+func assertCtxSentinel(t *testing.T, ctx context.Context, method string) {
+	t.Helper()
+	if ctx == nil {
+		t.Errorf("%s: captured ctx is nil — method must forward ctx, not drop it", method)
+		return
+	}
+	if ctx.Value(ctxSentinelKey{}) != "sentinel" {
+		t.Errorf("%s: ctx does not carry sentinel — method forwarded context.Background() instead of caller ctx", method)
+	}
+}
+
+// TestOtelCounter_CtxPassthrough verifies Inc and Add forward the caller's ctx.
+// RED: if the body uses context.Background(), ctx.Value(ctxSentinelKey{}) == nil.
+// GREEN: when the body uses the ctx parameter, the sentinel value is present.
+func TestOtelCounter_CtxPassthrough(t *testing.T) {
+	fake := &fakeFloat64Counter{}
+	c := &otelCounter{inner: fake, attrs: overflowOpt}
+	ctx := sentinelCtx()
+
+	c.Inc(ctx)
+	assertCtxSentinel(t, fake.gotCtx, "otelCounter.Inc")
+	if fake.gotDelta != 1 {
+		t.Errorf("Inc: expected delta=1, got %v", fake.gotDelta)
+	}
+
+	c.Add(ctx, 7.5)
+	assertCtxSentinel(t, fake.gotCtx, "otelCounter.Add")
+	if fake.gotDelta != 7.5 {
+		t.Errorf("Add: expected delta=7.5, got %v", fake.gotDelta)
+	}
+}
+
+// TestOtelHistogram_CtxPassthrough verifies Observe forwards the caller's ctx.
+func TestOtelHistogram_CtxPassthrough(t *testing.T) {
+	fake := &fakeFloat64Histogram{}
+	h := &otelHistogram{inner: fake, attrs: overflowOpt}
+	ctx := sentinelCtx()
+
+	h.Observe(ctx, 3.14)
+	assertCtxSentinel(t, fake.gotCtx, "otelHistogram.Observe")
+	if fake.gotValue != 3.14 {
+		t.Errorf("Observe: expected value=3.14, got %v", fake.gotValue)
+	}
+}
+
+// TestOtelGauge_CtxPassthrough verifies Set, Inc, Dec, Add each forward the caller's ctx.
+func TestOtelGauge_CtxPassthrough(t *testing.T) {
+	ctx := sentinelCtx()
+
+	t.Run("Set", func(t *testing.T) {
+		fake := &fakeFloat64Gauge{}
+		g := &otelGauge{inner: fake, attrs: overflowOpt}
+		g.Set(ctx, 42.0)
+		assertCtxSentinel(t, fake.gotCtx, "otelGauge.Set")
+		if fake.gotValue != 42.0 {
+			t.Errorf("Set: expected value=42.0, got %v", fake.gotValue)
+		}
+	})
+
+	t.Run("Inc", func(t *testing.T) {
+		fake := &fakeFloat64Gauge{}
+		g := &otelGauge{inner: fake, attrs: overflowOpt}
+		g.Inc(ctx)
+		assertCtxSentinel(t, fake.gotCtx, "otelGauge.Inc")
+		if fake.gotValue != 1.0 {
+			t.Errorf("Inc: expected value=1.0, got %v", fake.gotValue)
+		}
+	})
+
+	t.Run("Dec", func(t *testing.T) {
+		fake := &fakeFloat64Gauge{}
+		g := &otelGauge{inner: fake, attrs: overflowOpt}
+		g.last = 5.0
+		g.Dec(ctx)
+		assertCtxSentinel(t, fake.gotCtx, "otelGauge.Dec")
+		if fake.gotValue != 4.0 {
+			t.Errorf("Dec: expected value=4.0, got %v", fake.gotValue)
+		}
+	})
+
+	t.Run("Add", func(t *testing.T) {
+		fake := &fakeFloat64Gauge{}
+		g := &otelGauge{inner: fake, attrs: overflowOpt}
+		g.last = 10.0
+		g.Add(ctx, 3.0)
+		assertCtxSentinel(t, fake.gotCtx, "otelGauge.Add")
+		if fake.gotValue != 13.0 {
+			t.Errorf("Add: expected value=13.0, got %v", fake.gotValue)
+		}
+	})
 }

--- a/adapters/otel/metric_provider_test.go
+++ b/adapters/otel/metric_provider_test.go
@@ -12,7 +12,48 @@ import (
 
 	gcotel "github.com/ghbvf/gocell/adapters/otel"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/kernel/observability/metrics/metricstest"
 )
+
+// TestOTelMetricProvider_CancelledCtxConformance enrolls otel.MetricProvider in
+// the no-skip-on-cancel conformance harness (METRICS-CANCEL-CTX-CONFORMANCE-01).
+// Readback reads measured values back through the ManualReader, proving the
+// cancelled-ctx writes landed (otelCounter/Histogram/Gauge forward ctx to the
+// SDK without an Err() gate).
+//
+// The provider is constructed concretely (not via newTestProvider, which widens
+// to metrics.Provider) so the archtest's per-impl enrollment scan can resolve
+// the argument to *otel.MetricProvider.
+func TestOTelMetricProvider_CancelledCtxConformance(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+	provider, err := gcotel.NewMetricProvider(mp.Meter("gocell.test"))
+	if err != nil {
+		t.Fatalf("NewMetricProvider: %v", err)
+	}
+	collect := func() metricdata.ResourceMetrics {
+		var rm metricdata.ResourceMetrics
+		if err := reader.Collect(context.Background(), &rm); err != nil {
+			t.Fatalf("reader.Collect: %v", err)
+		}
+		return rm
+	}
+	metricstest.RunCancelledCtxConformance(t, provider, metricstest.Readback{
+		Counter: func() float64 {
+			sum, _ := extractCounterSum(t, collect(), metricstest.CounterName)
+			return sum
+		},
+		Histogram: func() uint64 {
+			count, _ := extractHistogram(t, collect(), metricstest.HistogramName)
+			return count
+		},
+		Gauge: func() float64 {
+			val, _ := extractGauge(t, collect(), metricstest.GaugeName)
+			return val
+		},
+	})
+}
 
 // newTestProvider wires the SUT's NewMetricProvider to a fresh ManualReader.
 //

--- a/adapters/otel/metric_provider_test.go
+++ b/adapters/otel/metric_provider_test.go
@@ -15,16 +15,16 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics/metricstest"
 )
 
-// TestOTelMetricProvider_CancelledCtxConformance enrolls otel.MetricProvider in
+// TestOTelMetricProvider_CanceledCtxConformance enrolls otel.MetricProvider in
 // the no-skip-on-cancel conformance harness (METRICS-CANCEL-CTX-CONFORMANCE-01).
 // Readback reads measured values back through the ManualReader, proving the
-// cancelled-ctx writes landed (otelCounter/Histogram/Gauge forward ctx to the
+// canceled-ctx writes landed (otelCounter/Histogram/Gauge forward ctx to the
 // SDK without an Err() gate).
 //
 // The provider is constructed concretely (not via newTestProvider, which widens
 // to metrics.Provider) so the archtest's per-impl enrollment scan can resolve
 // the argument to *otel.MetricProvider.
-func TestOTelMetricProvider_CancelledCtxConformance(t *testing.T) {
+func TestOTelMetricProvider_CanceledCtxConformance(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
@@ -39,7 +39,7 @@ func TestOTelMetricProvider_CancelledCtxConformance(t *testing.T) {
 		}
 		return rm
 	}
-	metricstest.RunCancelledCtxConformance(t, provider, metricstest.Readback{
+	metricstest.RunCanceledCtxConformance(t, provider, metricstest.Readback{
 		Counter: func() float64 {
 			sum, _ := extractCounterSum(t, collect(), metricstest.CounterName)
 			return sum

--- a/adapters/otel/metric_provider_test.go
+++ b/adapters/otel/metric_provider_test.go
@@ -50,9 +50,9 @@ func TestOTelMetricProvider_CounterInc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CounterVec: %v", err)
 	}
-	cv.With(metrics.Labels{"outcome": "success"}).Inc()
-	cv.With(metrics.Labels{"outcome": "success"}).Inc()
-	cv.With(metrics.Labels{"outcome": "failure"}).Add(3)
+	cv.With(metrics.Labels{"outcome": "success"}).Inc(context.Background())
+	cv.With(metrics.Labels{"outcome": "success"}).Inc(context.Background())
+	cv.With(metrics.Labels{"outcome": "failure"}).Add(context.Background(), 3)
 
 	rm := collect()
 	sum, points := extractCounterSum(t, rm, "gocell_test_counter_total")
@@ -75,8 +75,8 @@ func TestOTelMetricProvider_HistogramObserve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HistogramVec: %v", err)
 	}
-	hv.With(metrics.Labels{"phase": "start"}).Observe(0.05)
-	hv.With(metrics.Labels{"phase": "start"}).Observe(2.5)
+	hv.With(metrics.Labels{"phase": "start"}).Observe(context.Background(), 0.05)
+	hv.With(metrics.Labels{"phase": "start"}).Observe(context.Background(), 2.5)
 
 	rm := collect()
 	count, sum := extractHistogram(t, rm, "gocell_test_hist_seconds")
@@ -130,7 +130,7 @@ func TestOTelMetricProvider_AttrCacheReuse(t *testing.T) {
 		t.Fatalf("CounterVec: %v", err)
 	}
 	for range 100 {
-		cv.With(metrics.Labels{"k": "v"}).Inc()
+		cv.With(metrics.Labels{"k": "v"}).Inc(context.Background())
 	}
 	_, points := extractCounterSum(t, collect(), "gocell_test_cache_total")
 	if points != 1 {
@@ -174,8 +174,8 @@ func TestMetricProvider_GaugeVec_RecordsViaFloat64Gauge(t *testing.T) {
 	}
 
 	g := gv.With(metrics.Labels{"instance": "a"})
-	g.Set(10)
-	g.Set(20) // absolute last-write-wins: current value = 20
+	g.Set(context.Background(), 10)
+	g.Set(context.Background(), 20) // absolute last-write-wins: current value = 20
 
 	rm := collect()
 	val, points := extractGauge(t, rm, "gocell_test_gauge_set")
@@ -201,8 +201,8 @@ func TestMetricProvider_GaugeVec_IncDec(t *testing.T) {
 	}
 
 	g := gv.With(metrics.Labels{"worker": "w1"})
-	g.Inc()
-	g.Dec()
+	g.Inc(context.Background())
+	g.Dec(context.Background())
 
 	rm := collect()
 	val, _ := extractGauge(t, rm, "gocell_test_gauge_incdec")
@@ -226,8 +226,8 @@ func TestMetricProvider_GaugeVec_Add_Positive_And_Negative(t *testing.T) {
 	}
 
 	g := gv.With(metrics.Labels{"queue": "main"})
-	g.Add(5)
-	g.Add(-3)
+	g.Add(context.Background(), 5)
+	g.Add(context.Background(), -3)
 
 	rm := collect()
 	val, _ := extractGauge(t, rm, "gocell_test_gauge_add")
@@ -267,7 +267,7 @@ func TestMetricProvider_GaugeVec_DistinctLabelSetsEmitted(t *testing.T) {
 
 	// Emit 3 distinct label sets; verify each produces a distinct data point.
 	for i := range 3 {
-		gv.With(metrics.Labels{"k": strconv.Itoa(i)}).Set(float64(i + 1))
+		gv.With(metrics.Labels{"k": strconv.Itoa(i)}).Set(context.Background(), float64(i+1))
 	}
 
 	var rm metricdata.ResourceMetrics
@@ -318,9 +318,9 @@ func TestMetricProvider_GaugeVec_SetAfterInc(t *testing.T) {
 	}
 
 	g := gv.With(metrics.Labels{"svc": "a"})
-	g.Set(5) // last=5, delta=+5, cum=5
-	g.Inc()  // last=6, delta=+1, cum=6
-	g.Set(3) // last=3, delta=-3, cum=3
+	g.Set(context.Background(), 5) // last=5, delta=+5, cum=5
+	g.Inc(context.Background())    // last=6, delta=+1, cum=6
+	g.Set(context.Background(), 3) // last=3, delta=-3, cum=3
 
 	val, _ := extractGauge(t, collect(), "set_after_inc_test")
 	if val != 3 {
@@ -355,13 +355,13 @@ func TestMetricProvider_ConcurrentGaugeVec_RaceDetector(t *testing.T) {
 			for i := range iters {
 				switch i % 4 {
 				case 0:
-					gauge.Set(float64(i))
+					gauge.Set(context.Background(), float64(i))
 				case 1:
-					gauge.Inc()
+					gauge.Inc(context.Background())
 				case 2:
-					gauge.Dec()
+					gauge.Dec(context.Background())
 				case 3:
-					gauge.Add(float64(i))
+					gauge.Add(context.Background(), float64(i))
 				}
 			}
 		}(g)

--- a/adapters/prometheus/exposition_test.go
+++ b/adapters/prometheus/exposition_test.go
@@ -71,8 +71,8 @@ func TestPrometheusExposition_HTTPCollector_FamiliesAndLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
-	c.RecordRequest("test-cell", "GET", "/api/v1/users", 200, 0.15)
-	c.RecordRequest("test-cell", "POST", "/api/v1/users", 201, 0.05)
+	c.RecordRequest(context.Background(), "test-cell", "GET", "/api/v1/users", 200, 0.15)
+	c.RecordRequest(context.Background(), "test-cell", "POST", "/api/v1/users", 201, 0.05)
 
 	body := expose(t, reg)
 
@@ -111,13 +111,13 @@ func TestPrometheusExposition_RelayCollector_FamiliesAndBuckets(t *testing.T) {
 		t.Fatalf("NewProviderRelayCollector: %v", err)
 	}
 
-	c.RecordPollCycle(outbox.PollCycleResult{
+	c.RecordPollCycle(context.Background(), outbox.PollCycleResult{
 		Published: 2, Retried: 0, Dead: 1, Skipped: 3,
 		ClaimDur: testtime.D10ms, PublishDur: testtime.MediumPoll, WriteBackDur: testtime.FastPoll,
 	})
-	c.RecordBatchSize(6)
-	c.RecordReclaim(4)
-	c.RecordCleanup(12, 2)
+	c.RecordBatchSize(context.Background(), 6)
+	c.RecordReclaim(context.Background(), 4)
+	c.RecordCleanup(context.Background(), 12, 2)
 
 	body := expose(t, reg)
 

--- a/adapters/prometheus/metric_provider.go
+++ b/adapters/prometheus/metric_provider.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -311,16 +312,16 @@ func join(ss []string) string {
 
 type promCounter struct{ inner prom.Counter }
 
-func (c promCounter) Inc()          { c.inner.Inc() }
-func (c promCounter) Add(d float64) { c.inner.Add(d) }
+func (c promCounter) Inc(_ context.Context)             { c.inner.Inc() }
+func (c promCounter) Add(_ context.Context, d float64)  { c.inner.Add(d) }
 
 type promHistogram struct{ inner prom.Observer }
 
-func (h promHistogram) Observe(v float64) { h.inner.Observe(v) }
+func (h promHistogram) Observe(_ context.Context, v float64) { h.inner.Observe(v) }
 
 type promGauge struct{ inner prom.Gauge }
 
-func (g promGauge) Set(value float64) { g.inner.Set(value) }
-func (g promGauge) Inc()              { g.inner.Inc() }
-func (g promGauge) Dec()              { g.inner.Dec() }
-func (g promGauge) Add(delta float64) { g.inner.Add(delta) }
+func (g promGauge) Set(_ context.Context, value float64) { g.inner.Set(value) }
+func (g promGauge) Inc(_ context.Context)                { g.inner.Inc() }
+func (g promGauge) Dec(_ context.Context)                { g.inner.Dec() }
+func (g promGauge) Add(_ context.Context, delta float64) { g.inner.Add(delta) }

--- a/adapters/prometheus/metric_provider.go
+++ b/adapters/prometheus/metric_provider.go
@@ -312,8 +312,8 @@ func join(ss []string) string {
 
 type promCounter struct{ inner prom.Counter }
 
-func (c promCounter) Inc(_ context.Context)             { c.inner.Inc() }
-func (c promCounter) Add(_ context.Context, d float64)  { c.inner.Add(d) }
+func (c promCounter) Inc(_ context.Context)            { c.inner.Inc() }
+func (c promCounter) Add(_ context.Context, d float64) { c.inner.Add(d) }
 
 type promHistogram struct{ inner prom.Observer }
 

--- a/adapters/prometheus/metric_provider.go
+++ b/adapters/prometheus/metric_provider.go
@@ -310,6 +310,12 @@ func join(ss []string) string {
 	return out.String() + "]"
 }
 
+// promCounter/promHistogram/promGauge adapt the prometheus/client_golang
+// instruments to the metrics interfaces. ctx is intentionally discarded (`_`):
+// prometheus client_golang's Inc/Add/Observe/Set do not accept a context, so
+// exemplar/baggage correlation is a no-op on this backend (it is realized by
+// the OTel adapter, adapters/otel/metric_provider.go). This is a deliberate
+// drop, not a missing implementation.
 type promCounter struct{ inner prom.Counter }
 
 func (c promCounter) Inc(_ context.Context)            { c.inner.Inc() }

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -1,6 +1,7 @@
 package prometheus_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -45,9 +46,9 @@ func TestMetricProvider_CounterInc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CounterVec: %v", err)
 	}
-	cv.With(metrics.Labels{"outcome": "success"}).Inc()
-	cv.With(metrics.Labels{"outcome": "success"}).Inc()
-	cv.With(metrics.Labels{"outcome": "failure"}).Add(3)
+	cv.With(metrics.Labels{"outcome": "success"}).Inc(context.Background())
+	cv.With(metrics.Labels{"outcome": "success"}).Inc(context.Background())
+	cv.With(metrics.Labels{"outcome": "failure"}).Add(context.Background(), 3)
 
 	got := testutil.CollectAndCount(reg, "gocelltest_events_total")
 	if got != 2 {
@@ -74,8 +75,8 @@ func TestMetricProvider_HistogramObserve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HistogramVec: %v", err)
 	}
-	hv.With(metrics.Labels{"phase": "start"}).Observe(0.05)
-	hv.With(metrics.Labels{"phase": "start"}).Observe(2.5)
+	hv.With(metrics.Labels{"phase": "start"}).Observe(context.Background(), 0.05)
+	hv.With(metrics.Labels{"phase": "start"}).Observe(context.Background(), 2.5)
 
 	count := testutil.CollectAndCount(reg, "gocelltest_hook_duration_seconds")
 	if count != 1 {
@@ -99,8 +100,8 @@ func TestMetricProvider_RegisterDuplicateReturnsExisting(t *testing.T) {
 		t.Fatalf("duplicate register must succeed (return existing), got error: %v", err)
 	}
 	// Both vecs must be functional and share the same underlying collector.
-	cv1.With(metrics.Labels{"a": "x"}).Inc()
-	cv2.With(metrics.Labels{"a": "x"}).Inc()
+	cv1.With(metrics.Labels{"a": "x"}).Inc(context.Background())
+	cv2.With(metrics.Labels{"a": "x"}).Inc(context.Background())
 	// The shared collector should report 2 increments.
 	if v := testutil.ToFloat64(collect(t, reg, "gocelltest_dup_total", prom.Labels{"a": "x"})); v != 2 {
 		t.Fatalf("shared counter = %v, want 2", v)
@@ -185,7 +186,7 @@ func TestMetricProvider_Unregister_RemovesAndAllowsReregister(t *testing.T) {
 
 	// Touch the new vec so Prometheus Gather emits a sample, then confirm
 	// exactly one family — the registry is in sync with no stale entries.
-	cv2.With(metrics.Labels{"label": "v"}).Inc()
+	cv2.With(metrics.Labels{"label": "v"}).Inc(context.Background())
 	families, err := reg.Gather()
 	if err != nil {
 		t.Fatalf("Gather: %v", err)
@@ -287,8 +288,8 @@ func TestMetricProvider_HistogramVec_DuplicateReturnsExisting(t *testing.T) {
 		t.Fatalf("duplicate HistogramVec must succeed (return existing), got error: %v", err)
 	}
 	// Both vecs must be functional and share the same underlying collector.
-	hv1.With(metrics.Labels{"phase": "start"}).Observe(0.05)
-	hv2.With(metrics.Labels{"phase": "start"}).Observe(0.50)
+	hv1.With(metrics.Labels{"phase": "start"}).Observe(context.Background(), 0.05)
+	hv2.With(metrics.Labels{"phase": "start"}).Observe(context.Background(), 0.50)
 	// Exactly 1 series since both writes go to the same underlying histogram.
 	if cnt := testutil.CollectAndCount(reg, "gocelltest_dup_hist_seconds"); cnt != 1 {
 		t.Fatalf("expected 1 series after shared histogram writes, got %d", cnt)
@@ -449,8 +450,8 @@ func TestMetricProvider_CounterVec_CrossProvider_ReuseWithoutLabelCheck(t *testi
 		t.Fatalf("p2.CounterVec (cross-provider reuse) must succeed, got: %v", err)
 	}
 	// Both vecs must share the same underlying collector.
-	cv1.With(metrics.Labels{"l": "v"}).Inc()
-	cv2.With(metrics.Labels{"l": "v"}).Inc()
+	cv1.With(metrics.Labels{"l": "v"}).Inc(context.Background())
+	cv2.With(metrics.Labels{"l": "v"}).Inc(context.Background())
 	if cnt := testutil.CollectAndCount(reg, "cross_shared_counter_total"); cnt != 1 {
 		t.Fatalf("expected 1 series, got %d", cnt)
 	}
@@ -478,8 +479,8 @@ func TestMetricProvider_HistogramVec_CrossProvider_ReuseWithoutLabelCheck(t *tes
 	if err != nil {
 		t.Fatalf("p2.HistogramVec (cross-provider reuse) must succeed, got: %v", err)
 	}
-	hv1.With(metrics.Labels{"l": "v"}).Observe(1.0)
-	hv2.With(metrics.Labels{"l": "v"}).Observe(2.0)
+	hv1.With(metrics.Labels{"l": "v"}).Observe(context.Background(), 1.0)
+	hv2.With(metrics.Labels{"l": "v"}).Observe(context.Background(), 2.0)
 	if cnt := testutil.CollectAndCount(reg, "crosshist_shared_hist_seconds"); cnt != 1 {
 		t.Fatalf("expected 1 series, got %d", cnt)
 	}
@@ -649,7 +650,7 @@ func TestMetricProvider_ConcurrentCounterVec_RaceDetector(t *testing.T) {
 				firstErr.CompareAndSwap(nil, err)
 				return
 			}
-			cv.With(metrics.Labels{"k": "v"}).Inc()
+			cv.With(metrics.Labels{"k": "v"}).Inc(context.Background())
 		}()
 	}
 	wg.Wait()
@@ -718,7 +719,7 @@ func TestMetricProvider_GaugeVec_Register(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second GaugeVec (reuse): %v", err)
 	}
-	gv.With(metrics.Labels{"queue": "main"}).Set(1)
+	gv.With(metrics.Labels{"queue": "main"}).Set(context.Background(), 1)
 	if n := testutil.CollectAndCount(reg, "gocelltest_queue_depth"); n != 1 {
 		t.Fatalf("expected 1 series after Set, got %d", n)
 	}
@@ -739,11 +740,11 @@ func TestMetricProvider_GaugeVec_SetInc(t *testing.T) {
 	}
 
 	g := gv.With(metrics.Labels{"pool": "default"})
-	g.Set(10) // 10
-	g.Inc()   // 11
-	g.Dec()   // 10
-	g.Add(5)  // 15
-	g.Add(-3) // 12
+	g.Set(context.Background(), 10) // 10
+	g.Inc(context.Background())     // 11
+	g.Dec(context.Background())     // 10
+	g.Add(context.Background(), 5)  // 15
+	g.Add(context.Background(), -3) // 12
 
 	if v := testutil.ToFloat64(collectGauge(t, reg, "gocelltest_workers_active", prom.Labels{"pool": "default"})); v != 12 {
 		t.Fatalf("gauge value = %v, want 12", v)
@@ -767,8 +768,8 @@ func TestMetricProvider_GaugeVec_AlreadyRegistered_Reuse(t *testing.T) {
 		t.Fatalf("duplicate GaugeVec must succeed (return existing), got error: %v", err)
 	}
 	// Both write to the same underlying series; last write wins (Set semantics).
-	gv1.With(metrics.Labels{"a": "x"}).Set(5)
-	gv2.With(metrics.Labels{"a": "x"}).Inc() // 6
+	gv1.With(metrics.Labels{"a": "x"}).Set(context.Background(), 5)
+	gv2.With(metrics.Labels{"a": "x"}).Inc(context.Background()) // 6
 	if v := testutil.ToFloat64(collectGauge(t, reg, "gocelltest_dup_gauge", prom.Labels{"a": "x"})); v != 6 {
 		t.Fatalf("shared gauge = %v, want 6", v)
 	}
@@ -828,7 +829,7 @@ func TestMetricProvider_GaugeVec_Unregister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-register after Unregister: %v", err)
 	}
-	gv2.With(metrics.Labels{"k": "v"}).Set(1)
+	gv2.With(metrics.Labels{"k": "v"}).Set(context.Background(), 1)
 	families, err := reg.Gather()
 	if err != nil {
 		t.Fatalf("Gather: %v", err)
@@ -870,7 +871,7 @@ func TestMetricProvider_ConcurrentGaugeVec_RaceDetector(t *testing.T) {
 				firstErr.CompareAndSwap(nil, err)
 				return
 			}
-			gv.With(metrics.Labels{"k": "v"}).Set(1)
+			gv.With(metrics.Labels{"k": "v"}).Set(context.Background(), 1)
 		}()
 	}
 	wg.Wait()
@@ -963,7 +964,7 @@ func TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector(t *testing.
 				firstErr.CompareAndSwap(nil, err)
 				return
 			}
-			cv.With(metrics.Labels{"k": "v"}).Inc()
+			cv.With(metrics.Labels{"k": "v"}).Inc(context.Background())
 			if err := p.Unregister(cv); err != nil {
 				firstErr.CompareAndSwap(nil, err)
 			}

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -22,15 +22,15 @@ import (
 // registered metric name is "<namespace>_<opts.Name>".
 const promNamespace = "gocelltest_"
 
-// TestMetricProvider_CancelledCtxConformance enrolls prometheus.MetricProvider
+// TestMetricProvider_CanceledCtxConformance enrolls prometheus.MetricProvider
 // in the no-skip-on-cancel conformance harness (METRICS-CANCEL-CTX-CONFORMANCE-01).
-// The Prometheus adapter discards ctx entirely, so a cancelled ctx can never
+// The Prometheus adapter discards ctx entirely, so a canceled ctx can never
 // suppress a write; the readback confirms the measured values regardless.
 //
 // The provider is constructed concretely (not via newTestProvider, which widens
 // to metrics.Provider) so the archtest's per-impl enrollment scan can resolve
 // the argument to *prometheus.MetricProvider.
-func TestMetricProvider_CancelledCtxConformance(t *testing.T) {
+func TestMetricProvider_CanceledCtxConformance(t *testing.T) {
 	reg := prom.NewRegistry()
 	provider, err := gcprom.NewMetricProvider(gcprom.MetricProviderConfig{
 		Registry:  reg,
@@ -40,7 +40,7 @@ func TestMetricProvider_CancelledCtxConformance(t *testing.T) {
 		t.Fatalf("NewMetricProvider: %v", err)
 	}
 	labels := prom.Labels(metricstest.Labels())
-	metricstest.RunCancelledCtxConformance(t, provider, metricstest.Readback{
+	metricstest.RunCanceledCtxConformance(t, provider, metricstest.Readback{
 		Counter: func() float64 {
 			return testutil.ToFloat64(collect(t, reg, promNamespace+metricstest.CounterName, labels))
 		},

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -15,7 +15,66 @@ import (
 
 	gcprom "github.com/ghbvf/gocell/adapters/prometheus"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/kernel/observability/metrics/metricstest"
 )
+
+// promNamespace mirrors newTestProvider's MetricProviderConfig.Namespace; the
+// registered metric name is "<namespace>_<opts.Name>".
+const promNamespace = "gocelltest_"
+
+// TestMetricProvider_CancelledCtxConformance enrolls prometheus.MetricProvider
+// in the no-skip-on-cancel conformance harness (METRICS-CANCEL-CTX-CONFORMANCE-01).
+// The Prometheus adapter discards ctx entirely, so a cancelled ctx can never
+// suppress a write; the readback confirms the measured values regardless.
+//
+// The provider is constructed concretely (not via newTestProvider, which widens
+// to metrics.Provider) so the archtest's per-impl enrollment scan can resolve
+// the argument to *prometheus.MetricProvider.
+func TestMetricProvider_CancelledCtxConformance(t *testing.T) {
+	reg := prom.NewRegistry()
+	provider, err := gcprom.NewMetricProvider(gcprom.MetricProviderConfig{
+		Registry:  reg,
+		Namespace: "gocelltest",
+	})
+	if err != nil {
+		t.Fatalf("NewMetricProvider: %v", err)
+	}
+	labels := prom.Labels(metricstest.Labels())
+	metricstest.RunCancelledCtxConformance(t, provider, metricstest.Readback{
+		Counter: func() float64 {
+			return testutil.ToFloat64(collect(t, reg, promNamespace+metricstest.CounterName, labels))
+		},
+		Histogram: func() uint64 {
+			return histogramSampleCount(t, reg, promNamespace+metricstest.HistogramName, labels)
+		},
+		Gauge: func() float64 {
+			return testutil.ToFloat64(collectGauge(t, reg, promNamespace+metricstest.GaugeName, labels))
+		},
+	})
+}
+
+// histogramSampleCount gathers reg and returns the observation count for the
+// histogram series matching name+labels. The shared collect helper only reads
+// counters, so the cancel-ctx conformance needs this histogram-specific reader.
+func histogramSampleCount(t *testing.T, reg *prom.Registry, name string, labels prom.Labels) uint64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if promLabelsMatch(labels, m.GetLabel()) {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	t.Fatalf("no histogram %s with labels %v", name, labels)
+	return 0
+}
 
 // raceConcurrency mirrors the constant in hook_observer_test (50). Kept as
 // a separate const here because the two test files live in different

--- a/adapters/rabbitmq/publisher.go
+++ b/adapters/rabbitmq/publisher.go
@@ -116,10 +116,10 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 		// Preserve terminal error code from Connection so callers can distinguish
 		// "permanent config failure" / "reconnect exhausted" from "transient publish failure".
 		if isTerminalConnectionError(err) {
-			p.collector.RecordPublishFailure(PublishFailureAcquireChannel)
+			p.collector.RecordPublishFailure(ctx, PublishFailureAcquireChannel)
 			return err
 		}
-		p.collector.RecordPublishFailure(PublishFailureAcquireChannel)
+		p.collector.RecordPublishFailure(ctx, PublishFailureAcquireChannel)
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterAMQPPublish, "rabbitmq: acquire channel for publish", err)
 	}
 	// Close the channel after use instead of returning it to the shared pool.
@@ -138,13 +138,13 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 
 	// Declare exchange idempotently.
 	if err := ch.ExchangeDeclare(topic, "fanout", true, false, false, false, nil); err != nil {
-		p.collector.RecordPublishFailure(PublishFailureDeclareExchange)
+		p.collector.RecordPublishFailure(ctx, PublishFailureDeclareExchange)
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterAMQPPublish, "rabbitmq: declare exchange", err)
 	}
 
 	// Enable confirm mode.
 	if err := ch.Confirm(false); err != nil {
-		p.collector.RecordPublishFailure(PublishFailureConfirmMode)
+		p.collector.RecordPublishFailure(ctx, PublishFailureConfirmMode)
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterAMQPPublish, "rabbitmq: enable confirm mode", err)
 	}
 
@@ -158,7 +158,7 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 	}
 
 	if err := ch.PublishWithContext(ctx, topic, "", false, false, msg); err != nil {
-		p.collector.RecordPublishFailure(PublishFailurePublishSend)
+		p.collector.RecordPublishFailure(ctx, PublishFailurePublishSend)
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterAMQPPublish, "rabbitmq: publish message", err)
 	}
 
@@ -170,14 +170,14 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 		if !ok {
 			slog.Warn("rabbitmq: confirm channel closed before broker confirmation",
 				slog.String("topic", topic))
-			p.collector.RecordPublishFailure(PublishFailureChanClosed)
+			p.collector.RecordPublishFailure(ctx, PublishFailureChanClosed)
 			return errcode.New(errcode.KindInternal, ErrAdapterAMQPConfirmTimeout, "rabbitmq: confirm channel closed")
 		}
 		if !confirm.Ack {
 			slog.Warn("rabbitmq: broker NACKed published message",
 				slog.String("topic", topic),
 				slog.Uint64("delivery_tag", confirm.DeliveryTag))
-			p.collector.RecordPublishFailure(PublishFailureNack)
+			p.collector.RecordPublishFailure(ctx, PublishFailureNack)
 			return errcode.New(errcode.KindInternal, ErrAdapterAMQPNack, "rabbitmq: broker nacked message")
 		}
 		slog.Debug("rabbitmq: message published and confirmed",
@@ -188,7 +188,7 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 		slog.Warn("rabbitmq: publish confirm timer fired before broker reply",
 			slog.String("topic", topic),
 			slog.Duration("budget", p.conn.config.ConfirmTimeout))
-		p.collector.RecordPublishFailure(PublishFailureTimeout)
+		p.collector.RecordPublishFailure(ctx, PublishFailureTimeout)
 		return errcode.New(errcode.KindInternal, ErrAdapterAMQPConfirmTimeout, "rabbitmq: publish confirm timed out")
 
 	case <-ctx.Done():

--- a/adapters/rabbitmq/publisher_metrics.go
+++ b/adapters/rabbitmq/publisher_metrics.go
@@ -1,6 +1,8 @@
 package rabbitmq
 
 import (
+	"context"
+
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
@@ -53,7 +55,7 @@ type PublisherCollector interface {
 	// RecordPublishFailure increments the failure counter for the given reason.
 	// Implementations MUST NOT panic on any reason value; the closed set is
 	// enforced by the call site, not the collector.
-	RecordPublishFailure(reason PublishFailureReason)
+	RecordPublishFailure(ctx context.Context, reason PublishFailureReason)
 }
 
 // NoopPublisherCollector is the default collector used when no observability
@@ -62,7 +64,7 @@ type PublisherCollector interface {
 type NoopPublisherCollector struct{}
 
 // RecordPublishFailure is a no-op.
-func (NoopPublisherCollector) RecordPublishFailure(_ PublishFailureReason) { /* no-op: metrics disabled */
+func (NoopPublisherCollector) RecordPublishFailure(_ context.Context, _ PublishFailureReason) { /* no-op: metrics disabled */
 }
 
 // Compile-time interface check.
@@ -122,6 +124,6 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 }
 
 // RecordPublishFailure increments rabbitmq_publish_failed_total{cell, reason}.
-func (c *providerPublisherCollector) RecordPublishFailure(reason PublishFailureReason) {
-	c.failed.With(metrics.Labels{"cell": c.cellID, "reason": string(reason)}).Inc()
+func (c *providerPublisherCollector) RecordPublishFailure(ctx context.Context, reason PublishFailureReason) {
+	c.failed.With(metrics.Labels{"cell": c.cellID, "reason": string(reason)}).Inc(ctx)
 }

--- a/adapters/rabbitmq/publisher_metrics_test.go
+++ b/adapters/rabbitmq/publisher_metrics_test.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestNewProviderPublisherCollector_NopProviderNoPanic(t *testing.T) {
 	require.NotNil(t, c)
 
 	for _, r := range allPublishFailureReasons() {
-		assert.NotPanics(t, func() { c.RecordPublishFailure(r) })
+		assert.NotPanics(t, func() { c.RecordPublishFailure(context.Background(), r) })
 	}
 }
 
@@ -79,7 +80,7 @@ func TestProviderPublisherCollector_RecordPublishFailure_AllReasons(t *testing.T
 			col, err := NewProviderPublisherCollector(provider, "rmqtest")
 			require.NoError(t, err)
 
-			col.RecordPublishFailure(reason)
+			col.RecordPublishFailure(context.Background(), reason)
 
 			ops := provider.ops()
 			require.Len(t, ops, 1, "exactly one counter Inc per RecordPublishFailure")
@@ -207,13 +208,13 @@ type publisherSpyCounter struct {
 	labels metrics.Labels
 }
 
-func (c *publisherSpyCounter) Inc() {
+func (c *publisherSpyCounter) Inc(_ context.Context) {
 	c.parent.records = append(c.parent.records, spyCounterRecord{
 		name: c.name, op: "Inc", labels: c.labels, value: 1,
 	})
 }
 
-func (c *publisherSpyCounter) Add(d float64) {
+func (c *publisherSpyCounter) Add(_ context.Context, d float64) {
 	c.parent.records = append(c.parent.records, spyCounterRecord{
 		name: c.name, op: "Add", labels: c.labels, value: d,
 	})

--- a/adapters/rabbitmq/publisher_test.go
+++ b/adapters/rabbitmq/publisher_test.go
@@ -253,7 +253,8 @@ func TestPublish_NackReturnsNackErrcodeAndRecords(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	col := &fakeCollector{}
-	pub := NewPublisher(conn,
+	pub := NewPublisher(
+		conn,
 		WithPublisherClock(clock.Real()),
 		WithPublisherCollector(col),
 	)
@@ -288,7 +289,8 @@ func TestPublish_TimeoutReturnsTimeoutAndRecords(t *testing.T) {
 	}()
 
 	col := &fakeCollector{}
-	pub := NewPublisher(conn,
+	pub := NewPublisher(
+		conn,
 		WithPublisherClock(clock.Real()),
 		WithPublisherCollector(col),
 	)
@@ -315,7 +317,8 @@ func TestPublish_ConfirmChanClosedReturnsTimeoutAndRecords(t *testing.T) {
 	mockConn.mu.Unlock()
 
 	col := &fakeCollector{}
-	pub := NewPublisher(conn,
+	pub := NewPublisher(
+		conn,
 		WithPublisherClock(clock.Real()),
 		WithPublisherCollector(col),
 	)

--- a/adapters/rabbitmq/publisher_test.go
+++ b/adapters/rabbitmq/publisher_test.go
@@ -227,7 +227,7 @@ type fakeCollector struct {
 	reasons []PublishFailureReason
 }
 
-func (f *fakeCollector) RecordPublishFailure(reason PublishFailureReason) {
+func (f *fakeCollector) RecordPublishFailure(_ context.Context, reason PublishFailureReason) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.reasons = append(f.reasons, reason)
@@ -343,7 +343,7 @@ func TestNoopPublisherCollector_DoesNotPanic(t *testing.T) {
 		PublishFailureConfirmMode,
 		PublishFailurePublishSend,
 	} {
-		assert.NotPanics(t, func() { noop.RecordPublishFailure(r) })
+		assert.NotPanics(t, func() { noop.RecordPublishFailure(context.Background(), r) })
 	}
 }
 

--- a/cells/accesscore/accesscoretest/builders_test.go
+++ b/cells/accesscore/accesscoretest/builders_test.go
@@ -168,7 +168,8 @@ func TestFakeConfigGetterCallsRecorded(t *testing.T) {
 func TestNewCredentialInvalidatorWithFixture(t *testing.T) {
 	t.Parallel()
 	f := accesscoretest.NewAccessFixture(t, clock.Real())
-	inv := accesscoretest.NewCredentialInvalidator(t,
+	inv := accesscoretest.NewCredentialInvalidator(
+		t,
 		accesscoretest.WithInvalidatorFixture(f),
 	)
 	require.NotNil(t, inv, "NewCredentialInvalidator must return non-nil *CredentialInvalidator")
@@ -224,7 +225,8 @@ func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 	fg := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
 		"jwt.ttl": accesscoretest.PresentStub("jwt.ttl", "3600", 1),
 	})
-	svc := accesscoretest.BuildConfigReceiveService(t,
+	svc := accesscoretest.BuildConfigReceiveService(
+		t,
 		accesscoretest.WithConfigReceiveConfigGetter(fg),
 	)
 
@@ -242,7 +244,8 @@ func TestBuildConfigReceiveServiceSmoke(t *testing.T) {
 	fgStale := accesscoretest.NewFakeConfigGetter(map[string]accesscoretest.ConfigGetterStub{
 		"gone.key": accesscoretest.NotFoundStub(),
 	})
-	svcStale := accesscoretest.BuildConfigReceiveService(t,
+	svcStale := accesscoretest.BuildConfigReceiveService(
+		t,
 		accesscoretest.WithConfigReceiveConfigGetter(fgStale),
 	)
 	staleEntry := makeConfigUpsertedEntry("gone.key", 1)
@@ -293,11 +296,13 @@ func TestBuildIdentityManageService_AllOptions(t *testing.T) {
 	customClock := clock.Real()
 	customLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	issuer := &recordingTokenIssuer{}
-	customInv := accesscoretest.NewCredentialInvalidator(t,
+	customInv := accesscoretest.NewCredentialInvalidator(
+		t,
 		accesscoretest.WithInvalidatorFixture(fix),
 	)
 
-	svc, _, rec := accesscoretest.BuildIdentityManageService(t,
+	svc, _, rec := accesscoretest.BuildIdentityManageService(
+		t,
 		accesscoretest.WithIdentityFixture(fix),
 		accesscoretest.WithIdentityClock(customClock),
 		accesscoretest.WithIdentityLogger(customLogger),
@@ -360,7 +365,8 @@ func TestBuildConfigReceiveService_WithCollectorAndLogger(t *testing.T) {
 	collector := &recordingCollector{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	svc := accesscoretest.BuildConfigReceiveService(t,
+	svc := accesscoretest.BuildConfigReceiveService(
+		t,
 		accesscoretest.WithConfigReceiveConfigGetter(fg),
 		accesscoretest.WithConfigReceiveLogger(logger),
 		accesscoretest.WithConfigReceiveCollector(collector),

--- a/cells/accesscore/accesscoretest/builders_test.go
+++ b/cells/accesscore/accesscoretest/builders_test.go
@@ -273,11 +273,11 @@ type recordingCollector struct {
 	processCount int
 }
 
-func (r *recordingCollector) RecordEventProcess(string, string, obmetrics.ConfigEventProcessReason) {
+func (r *recordingCollector) RecordEventProcess(_ context.Context, _, _ string, _ obmetrics.ConfigEventProcessReason) {
 	r.processCount++
 }
 
-func (recordingCollector) RecordEventSettlement(string, string, string, outbox.SettlementResult) {
+func (recordingCollector) RecordEventSettlement(_ context.Context, _, _, _ string, _ outbox.SettlementResult) {
 }
 
 // TestBuildIdentityManageService_AllOptions exercises every public With*

--- a/cells/accesscore/internal/accountlockout/service.go
+++ b/cells/accesscore/internal/accountlockout/service.go
@@ -40,7 +40,7 @@ type Service struct {
 // Reasons emitted: "threshold_locked" (auto-lock triggered) /
 // "lazy_unlocked" (TTL expired, user logged in).
 type MetricsRecorder interface {
-	IncAccountLockout(reason string)
+	IncAccountLockout(ctx context.Context, reason string)
 }
 
 // noopMetrics is the default no-op MetricsRecorder used when the caller does
@@ -50,7 +50,7 @@ type noopMetrics struct{}
 
 // IncAccountLockout is intentionally empty — noopMetrics discards all metric
 // increments. See noopMetrics godoc for when this is wired.
-func (noopMetrics) IncAccountLockout(string) {}
+func (noopMetrics) IncAccountLockout(context.Context, string) {}
 
 // Option configures the Service at construction time.
 type Option func(*Service)
@@ -156,7 +156,7 @@ func (s *Service) RecordFailure(ctx context.Context, txCtx context.Context, user
 	if err := s.publishLocked(txCtx, user.ID); err != nil {
 		return fmt.Errorf("accountlockout.RecordFailure: emit locked event: %w", err)
 	}
-	s.metrics.IncAccountLockout("threshold_locked")
+	s.metrics.IncAccountLockout(ctx, "threshold_locked")
 	s.logger.Warn("account auto-locked",
 		slog.String("user_id", user.ID),
 		slog.Int("failed_count", user.FailedLoginCount()),
@@ -232,7 +232,7 @@ func (s *Service) TryLazyUnlock(ctx context.Context, txCtx context.Context, user
 	if err := s.publishUnlocked(txCtx, user.ID); err != nil {
 		return false, fmt.Errorf("accountlockout.TryLazyUnlock: emit unlocked event: %w", err)
 	}
-	s.metrics.IncAccountLockout("lazy_unlocked")
+	s.metrics.IncAccountLockout(ctx, "lazy_unlocked")
 	s.logger.Info("account lazy-unlocked",
 		slog.String("user_id", user.ID),
 		slog.Time("locked_until", *until),

--- a/cells/accesscore/internal/accountlockout/service.go
+++ b/cells/accesscore/internal/accountlockout/service.go
@@ -130,7 +130,7 @@ func NewService(
 //  3. If shouldLock: authzmutator.ApplyInTx(LockUser{}) → SetStatus(Locked) +
 //     epoch bump + session/refresh revoke + repo.Update (status & epoch).
 //  4. If shouldLock: emit event.user.locked.v1 with ActorID=SystemActorID.
-//  5. If shouldLock: metrics.IncAccountLockout("threshold_locked").
+//  5. If shouldLock: metrics.IncAccountLockout(ctx, "threshold_locked").
 func (s *Service) RecordFailure(ctx context.Context, txCtx context.Context, user *domain.User) error {
 	if user == nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,

--- a/cells/accesscore/internal/accountlockout/service_test.go
+++ b/cells/accesscore/internal/accountlockout/service_test.go
@@ -56,7 +56,7 @@ type fakeMetrics struct {
 
 func newFakeMetrics() *fakeMetrics { return &fakeMetrics{byReason: map[string]int{}} }
 
-func (m *fakeMetrics) IncAccountLockout(reason string) {
+func (m *fakeMetrics) IncAccountLockout(_ context.Context, reason string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.byReason[reason]++
@@ -572,7 +572,7 @@ func TestWithMetrics_TypedNil_KeepsNoopDefault(t *testing.T) {
 	}
 	// Must not panic: noopMetrics swallows the call; a stored typed-nil would
 	// deref nil here.
-	s.metrics.IncAccountLockout("threshold_locked")
+	s.metrics.IncAccountLockout(context.Background(), "threshold_locked")
 }
 
 // Sanity: make sure fakeUserRepo conforms to the ports.UserRepository surface

--- a/cells/accesscore/slices/configreceive/service_test.go
+++ b/cells/accesscore/slices/configreceive/service_test.go
@@ -38,11 +38,11 @@ type configEventRecord struct {
 	reason obmetrics.ConfigEventProcessReason
 }
 
-func (c *recordingConfigEventCollector) RecordEventProcess(cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
+func (c *recordingConfigEventCollector) RecordEventProcess(_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
 	c.records = append(c.records, configEventRecord{cell: cellID, slice: sliceID, reason: reason})
 }
 
-func (c *recordingConfigEventCollector) RecordEventSettlement(string, string, string, outbox.SettlementResult) {
+func (c *recordingConfigEventCollector) RecordEventSettlement(_ context.Context, _, _, _ string, _ outbox.SettlementResult) {
 }
 
 // callWithConfigEventOwner runs handler through ConfigEventMiddleware and returns

--- a/cells/accesscore/slices/configreceive/service_test.go
+++ b/cells/accesscore/slices/configreceive/service_test.go
@@ -38,7 +38,9 @@ type configEventRecord struct {
 	reason obmetrics.ConfigEventProcessReason
 }
 
-func (c *recordingConfigEventCollector) RecordEventProcess(_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
+func (c *recordingConfigEventCollector) RecordEventProcess(
+	_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason,
+) {
 	c.records = append(c.records, configEventRecord{cell: cellID, slice: sliceID, reason: reason})
 }
 

--- a/cells/configcore/slices/configsubscribe/service.go
+++ b/cells/configcore/slices/configsubscribe/service.go
@@ -110,13 +110,13 @@ func (c *Cache) Len() int {
 // deletedAt exceeds tombstoneTTL. Active entries are never touched — the
 // monotonic-version guard for live keys is fully preserved. Each evicted
 // tombstone increments eventbus_cache_tombstone_evicted_total.
-func (c *Cache) sweepTombstones(now time.Time) {
+func (c *Cache) sweepTombstones(ctx context.Context, now time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for k, e := range c.entries {
 		if !e.present && now.Sub(e.deletedAt) > c.tombstoneTTL {
 			delete(c.entries, k)
-			c.cacheCollector.RecordTombstoneEvicted(cacheCellID, cacheSliceID)
+			c.cacheCollector.RecordTombstoneEvicted(ctx, cacheCellID, cacheSliceID)
 		}
 	}
 }
@@ -322,7 +322,7 @@ func (s *Service) runTombstoneGC(ctx context.Context, done chan struct{}) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C():
-			s.cache.sweepTombstones(s.clk.Now())
+			s.cache.sweepTombstones(ctx, s.clk.Now())
 		}
 	}
 }

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -90,7 +90,9 @@ type configEventRecord struct {
 	reason obmetrics.ConfigEventProcessReason
 }
 
-func (c *recordingConfigEventCollector) RecordEventProcess(_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
+func (c *recordingConfigEventCollector) RecordEventProcess(
+	_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason,
+) {
 	c.records = append(c.records, configEventRecord{cell: cellID, slice: sliceID, reason: reason})
 }
 

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -646,7 +646,8 @@ func (r *recordingEventbusCacheCollector) total() int64 { return r.count.Load() 
 func TestCache_SweepTombstones_RemovesExpiredOnly(t *testing.T) {
 	fc := clockmock.New(time.Unix(0, 0))
 	spy := &recordingEventbusCacheCollector{}
-	svc := mustNewService(t, slog.Default(),
+	svc := mustNewService(
+		t, slog.Default(),
 		WithClock(fc),
 		WithTombstoneTTL(testTTL),
 		WithEventbusCacheCollector(spy),
@@ -696,7 +697,8 @@ func TestCache_SweepTombstones_RemovesExpiredOnly(t *testing.T) {
 func TestCache_SweepTombstones_NeverTouchesActive(t *testing.T) {
 	fc := clockmock.New(time.Unix(0, 0))
 	spy := &recordingEventbusCacheCollector{}
-	svc := mustNewService(t, slog.Default(),
+	svc := mustNewService(
+		t, slog.Default(),
 		WithClock(fc),
 		WithTombstoneTTL(testTTL),
 		WithEventbusCacheCollector(spy),
@@ -730,7 +732,8 @@ func TestService_TombstoneGC_GoroutineLifecycle(t *testing.T) {
 
 	fc := clockmock.New(time.Unix(0, 0))
 	spy := &recordingEventbusCacheCollector{}
-	svc := mustNewService(t, slog.Default(),
+	svc := mustNewService(
+		t, slog.Default(),
 		WithClock(fc),
 		WithTombstoneTTL(testTTL),
 		WithEventbusCacheCollector(spy),
@@ -818,7 +821,8 @@ func TestNewService_TombstoneTTLDefaultAndWarn(t *testing.T) {
 // subsequent StopTombstoneGC(context.Background()) clears the state.
 func TestStopTombstoneGC_CtxTimeout(t *testing.T) {
 	fc := clockmock.New(time.Unix(0, 0))
-	svc := mustNewService(t, slog.Default(),
+	svc := mustNewService(
+		t, slog.Default(),
 		WithClock(fc),
 		WithTombstoneTTL(testTTL),
 	)
@@ -867,7 +871,8 @@ func TestTombstoneTTL_SubWindowClampedPreventsResurrection(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	svc := mustNewService(t, logger,
+	svc := mustNewService(
+		t, logger,
 		WithClock(fc),
 		WithTombstoneTTL(testSubWindowTTL), // 1h, below the 24h window → clamp
 	)
@@ -906,7 +911,8 @@ func TestTombstoneTTL_SubWindowClampedPreventsResurrection(t *testing.T) {
 // a subsequent Stop with a background ctx drains the original goroutine.
 func TestStopTombstoneGC_TimeoutThenNoRestartThenDrains(t *testing.T) {
 	fc := clockmock.New(time.Unix(0, 0))
-	svc := mustNewService(t, slog.Default(),
+	svc := mustNewService(
+		t, slog.Default(),
 		WithClock(fc),
 		WithTombstoneTTL(testTTL),
 	)

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -90,11 +90,11 @@ type configEventRecord struct {
 	reason obmetrics.ConfigEventProcessReason
 }
 
-func (c *recordingConfigEventCollector) RecordEventProcess(cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
+func (c *recordingConfigEventCollector) RecordEventProcess(_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
 	c.records = append(c.records, configEventRecord{cell: cellID, slice: sliceID, reason: reason})
 }
 
-func (c *recordingConfigEventCollector) RecordEventSettlement(string, string, string, outbox.SettlementResult) {
+func (c *recordingConfigEventCollector) RecordEventSettlement(_ context.Context, _, _, _ string, _ outbox.SettlementResult) {
 }
 
 func callWithConfigEventOwner(
@@ -627,7 +627,7 @@ type recordingEventbusCacheCollector struct {
 	mu    sync.Mutex
 }
 
-func (r *recordingEventbusCacheCollector) RecordTombstoneEvicted(cellID, sliceID string) {
+func (r *recordingEventbusCacheCollector) RecordTombstoneEvicted(_ context.Context, cellID, sliceID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.count.Add(1)
@@ -658,7 +658,7 @@ func TestCache_SweepTombstones_RemovesExpiredOnly(t *testing.T) {
 
 	// Advance only 12h — tombstone not yet expired.
 	fc.Advance(testHalfTTL)
-	svc.cache.sweepTombstones(fc.Now())
+	svc.cache.sweepTombstones(context.Background(), fc.Now())
 
 	// keyA still present as tombstone.
 	v, present := svc.Cache().GetVersion("keyA")
@@ -675,7 +675,7 @@ func TestCache_SweepTombstones_RemovesExpiredOnly(t *testing.T) {
 
 	// Advance 13h more (total 25h > 24h TTL) then sweep.
 	fc.Advance(testOverTTL)
-	svc.cache.sweepTombstones(fc.Now())
+	svc.cache.sweepTombstones(context.Background(), fc.Now())
 
 	// keyA is now gone.
 	v, present = svc.Cache().GetVersion("keyA")
@@ -706,7 +706,7 @@ func TestCache_SweepTombstones_NeverTouchesActive(t *testing.T) {
 
 	// Advance far beyond TTL.
 	fc.Advance(testFarFuture)
-	svc.cache.sweepTombstones(fc.Now())
+	svc.cache.sweepTombstones(context.Background(), fc.Now())
 
 	// keyB must still be present at v5.
 	v, present := svc.Cache().GetVersion("keyB")
@@ -889,7 +889,7 @@ func TestTombstoneTTL_SubWindowClampedPreventsResurrection(t *testing.T) {
 	fc.Advance(testSubWindowTTL + time.Second) // 1h+1s — would have expired if clamp hadn't fired
 
 	// Sweep: tombstone must still be present (not GC'd).
-	svc.cache.sweepTombstones(fc.Now())
+	svc.cache.sweepTombstones(context.Background(), fc.Now())
 	v, present := svc.Cache().GetVersion("k")
 	assert.False(t, present, "tombstone must survive past sub-window; clamped TTL holds")
 	assert.Equal(t, 5, v, "tombstone version must be preserved")

--- a/cmd/corebundle/config_event_metrics_wiring_test.go
+++ b/cmd/corebundle/config_event_metrics_wiring_test.go
@@ -145,6 +145,7 @@ type captureSubscriberHandler struct {
 }
 
 func (c *captureSubscriberHandler) Setup(_ context.Context, _ outbox.Subscription) error { return nil }
+
 func (c *captureSubscriberHandler) Ready(_ outbox.Subscription) <-chan struct{} {
 	ch := make(chan struct{})
 	close(ch)
@@ -177,11 +178,15 @@ type coreConfigEventSettlementRecord struct {
 	result      outbox.SettlementResult
 }
 
-func (c *recordingCoreConfigEventCollector) RecordEventProcess(cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
+func (c *recordingCoreConfigEventCollector) RecordEventProcess(
+	_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason,
+) {
 	c.processRecords = append(c.processRecords, coreConfigEventProcessRecord{cell: cellID, slice: sliceID, reason: reason})
 }
 
-func (c *recordingCoreConfigEventCollector) RecordEventSettlement(cellID, sliceID, disposition string, result outbox.SettlementResult) {
+func (c *recordingCoreConfigEventCollector) RecordEventSettlement(
+	_ context.Context, cellID, sliceID, disposition string, result outbox.SettlementResult,
+) {
 	rec := coreConfigEventSettlementRecord{
 		cell: cellID, slice: sliceID, disposition: disposition, result: result,
 	}

--- a/kernel/assembly/hook_dispatcher.go
+++ b/kernel/assembly/hook_dispatcher.go
@@ -264,7 +264,8 @@ func (d *hookDispatcher) dispatchOne(e cell.HookEvent) {
 		defer func() {
 			defer d.finishSink()
 			if r := recover(); r != nil {
-				d.dropped.With(metrics.Labels{"reason": DropReasonObserverPanic}).Inc()
+				// 后台 dispatch worker 从 channel 取事件、无请求 ctx，故用 Background（诚实，非占位）。
+				d.dropped.With(metrics.Labels{"reason": DropReasonObserverPanic}).Inc(context.Background())
 				slog.Error("lifecycle: hook observer panicked",
 					slog.String("cell", e.CellID),
 					slog.String("hook", string(e.Hook)),
@@ -286,7 +287,8 @@ func (d *hookDispatcher) dispatchOne(e cell.HookEvent) {
 		t.Stop()
 	case <-t.C():
 		t.Stop()
-		d.dropped.With(metrics.Labels{"reason": DropReasonSinkTimeout}).Inc()
+		// 后台 dispatch worker 从 channel 取事件、无请求 ctx，故用 Background（诚实，非占位）。
+		d.dropped.With(metrics.Labels{"reason": DropReasonSinkTimeout}).Inc(context.Background())
 		slog.Warn("lifecycle: hook observer exceeded sink timeout; abandoning",
 			slog.String("cell", e.CellID),
 			slog.String("hook", string(e.Hook)),
@@ -340,7 +342,8 @@ func (d *hookDispatcher) stop(ctx context.Context, drainTimeout time.Duration) {
 }
 
 func (d *hookDispatcher) dropQueueFull(e cell.HookEvent) {
-	d.dropped.With(metrics.Labels{"reason": DropReasonQueueFull}).Inc()
+	// 后台 dispatch worker 从 channel 取事件、无请求 ctx，故用 Background（诚实，非占位）。
+	d.dropped.With(metrics.Labels{"reason": DropReasonQueueFull}).Inc(context.Background())
 	d.queueWarn.Do(func() {
 		slog.Warn("assembly: hook dispatcher queue full; dropping hook event",
 			slog.String("reason", DropReasonQueueFull),

--- a/kernel/assembly/hook_dispatcher_test.go
+++ b/kernel/assembly/hook_dispatcher_test.go
@@ -68,8 +68,8 @@ type spyCounter struct {
 	reason string
 }
 
-func (c *spyCounter) Inc() { c.Add(1) }
-func (c *spyCounter) Add(d float64) {
+func (c *spyCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c *spyCounter) Add(_ context.Context, d float64) {
 	c.parent.mu.Lock()
 	c.parent.v[c.reason] += int(d)
 	c.parent.mu.Unlock()

--- a/kernel/observability/metrics/metrics.go
+++ b/kernel/observability/metrics/metrics.go
@@ -11,8 +11,11 @@
 // makes label-set drift a detectable error rather than a silent mismatch.
 //
 // Counter/Histogram/Gauge 方法都接受 context.Context 首参，对齐 OTel 原生
-// ctx-bearing 形态（exemplar/baggage 由 OTel adapter 透传；Prometheus adapter
-// 不消费 ctx）。
+// ctx-bearing 形态：OTel adapter 把 ctx 转发给底层 instrument 以支持 exemplar /
+// baggage 关联（需传请求级 ctx，含 active span 才有意义）；Prometheus adapter 不
+// 消费 ctx。约定两条：(1) 实现禁止因 ctx 已取消/超时而跳过记录——指标发射是
+// best-effort，ctx 取消不得导致数据丢失；(2) 无请求 ctx 的后台路径（如 hook
+// dispatcher worker）显式传 context.Background() 并就近注释说明。
 package metrics
 
 import (

--- a/kernel/observability/metrics/metrics.go
+++ b/kernel/observability/metrics/metrics.go
@@ -28,16 +28,17 @@ import (
 	"github.com/ghbvf/gocell/pkg/panicregister"
 )
 
-// Collector is a handle to a registered metric family (counter or histogram
-// vec). It is returned by CounterVec/HistogramVec and accepted by Unregister.
+// Collector is a handle to a registered metric family (counter, histogram, or
+// gauge vec). It is returned by CounterVec/HistogramVec/GaugeVec and accepted by
+// Unregister.
 //
 // Callers obtain Collector values only via Provider.CounterVec and
 // Provider.HistogramVec; passing other values to Unregister is undefined
 // behavior (implementations may silently no-op or return an error).
 //
-// Both CounterVec and HistogramVec embed Collector so that the return values
-// of CounterVec/HistogramVec can be passed directly to Unregister without
-// explicit type assertions.
+// CounterVec, HistogramVec, and GaugeVec all embed Collector so that the return
+// values of CounterVec/HistogramVec/GaugeVec can be passed directly to
+// Unregister without explicit type assertions.
 //
 // ref: prometheus/client_golang prometheus/collector.go — Collector is the
 // registration unit. GoCell's Collector is a thinner typed handle that keeps

--- a/kernel/observability/metrics/metrics.go
+++ b/kernel/observability/metrics/metrics.go
@@ -10,14 +10,13 @@
 // attribute.KeyValue because a map makes callers name their dimensions and
 // makes label-set drift a detectable error rather than a silent mismatch.
 //
-// The Prom-shape rationale covers label binding only. Counter.Inc / Add and
-// Histogram.Observe also deliberately omit context.Context — adapters/otel
-// emits with context.Background(). Aligning to OTel's ctx-bearing form
-// (which enables exemplar / baggage propagation) is open work; see
-// METRICS-CTX-FUNNEL-01.
+// Counter/Histogram/Gauge 方法都接受 context.Context 首参，对齐 OTel 原生
+// ctx-bearing 形态（exemplar/baggage 由 OTel adapter 透传；Prometheus adapter
+// 不消费 ctx）。
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -161,14 +160,14 @@ type GaugeVec interface {
 
 // Counter is a monotonically increasing counter, pre-bound to a label set.
 type Counter interface {
-	Inc()
-	Add(delta float64)
+	Inc(ctx context.Context)
+	Add(ctx context.Context, delta float64)
 }
 
 // Histogram records observations into predeclared buckets, pre-bound to a
 // label set.
 type Histogram interface {
-	Observe(value float64)
+	Observe(ctx context.Context, value float64)
 }
 
 // Gauge is an arbitrary-valued instrument that can move up or down,
@@ -180,10 +179,10 @@ type Histogram interface {
 //
 // ref: prometheus/client_golang prometheus/gauge.go — Gauge interface.
 type Gauge interface {
-	Set(value float64)
-	Inc()
-	Dec()
-	Add(delta float64)
+	Set(ctx context.Context, value float64)
+	Inc(ctx context.Context)
+	Dec(ctx context.Context)
+	Add(ctx context.Context, delta float64)
 }
 
 // ErrLabelMismatch is returned / panic-wrapped by ValidateLabels /

--- a/kernel/observability/metrics/metrics_test.go
+++ b/kernel/observability/metrics/metrics_test.go
@@ -162,7 +162,7 @@ func TestNopProvider_AcceptsEmptyLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CounterVec: %v", err)
 	}
-	cv.With(nil).Inc(context.Background())               // nil labels OK
+	cv.With(nil).Inc(context.Background())                 // nil labels OK
 	cv.With(metrics.Labels{}).Add(context.Background(), 1) // empty map OK
 }
 

--- a/kernel/observability/metrics/metrics_test.go
+++ b/kernel/observability/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -101,8 +102,8 @@ func TestNopProvider_CounterAndHistogram(t *testing.T) {
 		t.Fatalf("CounterVec: %v", err)
 	}
 	c := cv.With(metrics.Labels{"phase": "start"})
-	c.Inc()
-	c.Add(2.5) // must not panic
+	c.Inc(context.Background())
+	c.Add(context.Background(), 2.5) // must not panic
 
 	hv, err := p.HistogramVec(metrics.HistogramOpts{
 		Name:       "nop_hist_seconds",
@@ -114,7 +115,7 @@ func TestNopProvider_CounterAndHistogram(t *testing.T) {
 		t.Fatalf("HistogramVec: %v", err)
 	}
 	h := hv.With(metrics.Labels{"phase": "stop"})
-	h.Observe(0.5)
+	h.Observe(context.Background(), 0.5)
 }
 
 func TestNopProvider_PanicsOnLabelMismatch(t *testing.T) {
@@ -161,8 +162,8 @@ func TestNopProvider_AcceptsEmptyLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CounterVec: %v", err)
 	}
-	cv.With(nil).Inc()               // nil labels OK
-	cv.With(metrics.Labels{}).Add(1) // empty map OK
+	cv.With(nil).Inc(context.Background())               // nil labels OK
+	cv.With(metrics.Labels{}).Add(context.Background(), 1) // empty map OK
 }
 
 // TestNopProvider_Unregister_IdempotentReturnsNil verifies that
@@ -230,10 +231,10 @@ func TestNopProvider_Gauge(t *testing.T) {
 	}
 	g := gv.With(metrics.Labels{"cell": "outbox"})
 	// All four methods must not panic on the no-op gauge.
-	g.Set(42)
-	g.Inc()
-	g.Dec()
-	g.Add(-1.5)
+	g.Set(context.Background(), 42)
+	g.Inc(context.Background())
+	g.Dec(context.Background())
+	g.Add(context.Background(), -1.5)
 }
 
 func TestNopProvider_GaugeVec_PanicsOnLabelMismatch(t *testing.T) {
@@ -267,8 +268,8 @@ func TestNopProvider_GaugeVec_AcceptsEmptyLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GaugeVec: %v", err)
 	}
-	gv.With(nil).Set(0)
-	gv.With(metrics.Labels{}).Inc()
+	gv.With(nil).Set(context.Background(), 0)
+	gv.With(metrics.Labels{}).Inc(context.Background())
 }
 
 func TestNopGaugeVec_Registered_ReturnsTrue(t *testing.T) {

--- a/kernel/observability/metrics/metricstest/conformance.go
+++ b/kernel/observability/metrics/metricstest/conformance.go
@@ -1,0 +1,106 @@
+// Package metricstest provides the cross-implementation conformance harness for
+// the kernel metrics no-skip-on-cancel contract.
+//
+// kernel/observability/metrics/metrics.go §contract (1): "实现禁止因 ctx 已取消/
+// 超时而跳过记录——ctx 取消不得导致数据丢失". This harness drives a metrics.Provider's
+// Counter/Histogram/Gauge instruments with an already-cancelled context and
+// asserts — via an implementation-supplied Readback — that every measurement
+// still landed. Membership of every production Provider implementation is
+// enforced by archtest METRICS-CANCEL-CTX-CONFORMANCE-01.
+//
+// Stdlib testing asserts only: kernel/ depguard bans testify, so this harness
+// uses t.Fatalf/t.Errorf rather than require/assert.
+package metricstest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+)
+
+// Metric names the harness records under. Adapter-side Readback closures target
+// these (prefixed by the provider's namespace, if any).
+const (
+	CounterName   = "metricstest_cancelctx_counter_total"
+	HistogramName = "metricstest_cancelctx_hist_seconds"
+	GaugeName     = "metricstest_cancelctx_gauge"
+
+	labelKey = "k"
+	labelVal = "v"
+
+	// Expected recorded values after the cancelled-ctx drive sequence below.
+	wantCounter   = 3 // Add(2) + Inc
+	wantHistogram = 1 // one Observe
+	wantGauge     = 8 // Set(5) + Inc - Dec + Add(3)
+)
+
+// Labels is the single label set the harness binds for all three instruments.
+func Labels() metrics.Labels { return metrics.Labels{labelKey: labelVal} }
+
+// Readback supplies implementation-specific value extraction for the harness's
+// metrics under Labels(). Each closure returns the recorded value; the harness
+// asserts them against the expected post-drive totals.
+type Readback struct {
+	Counter   func() float64
+	Histogram func() uint64 // observation count
+	Gauge     func() float64
+}
+
+// RunCancelledCtxConformance asserts that p's instruments record measurements
+// even when the supplied context is already cancelled (metrics.go §contract (1)).
+// It drives Counter.Add/Inc, Histogram.Observe, and Gauge.Set/Inc/Dec/Add with an
+// already-cancelled ctx, then uses rb to assert each measurement landed. A
+// regression that gates recording on ctx.Err() makes a readback return the wrong
+// value and fails here — a no-op implementation cannot satisfy it.
+func RunCancelledCtxConformance(t *testing.T, p metrics.Provider, rb Readback) {
+	t.Helper()
+	if rb.Counter == nil || rb.Histogram == nil || rb.Gauge == nil {
+		t.Fatal("metricstest: Readback.Counter/Histogram/Gauge must all be supplied")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // every record call below observes ctx.Err() != nil
+
+	cv, err := p.CounterVec(metrics.CounterOpts{
+		Name: CounterName, Help: "cancel-ctx conformance counter", LabelNames: []string{labelKey},
+	})
+	if err != nil {
+		t.Fatalf("metricstest: CounterVec: %v", err)
+	}
+	cv.With(Labels()).Add(ctx, 2)
+	cv.With(Labels()).Inc(ctx)
+
+	hv, err := p.HistogramVec(metrics.HistogramOpts{
+		Name: HistogramName, Help: "cancel-ctx conformance histogram",
+		LabelNames: []string{labelKey}, Buckets: []float64{0.5, 1, 2},
+	})
+	if err != nil {
+		t.Fatalf("metricstest: HistogramVec: %v", err)
+	}
+	hv.With(Labels()).Observe(ctx, 1.0)
+
+	gv, err := p.GaugeVec(metrics.GaugeOpts{
+		Name: GaugeName, Help: "cancel-ctx conformance gauge", LabelNames: []string{labelKey},
+	})
+	if err != nil {
+		t.Fatalf("metricstest: GaugeVec: %v", err)
+	}
+	gv.With(Labels()).Set(ctx, 5)
+	gv.With(Labels()).Inc(ctx)
+	gv.With(Labels()).Dec(ctx)
+	gv.With(Labels()).Add(ctx, 3)
+
+	if got := rb.Counter(); got != wantCounter {
+		t.Errorf("metricstest: counter recorded %v under cancelled ctx, want %d "+
+			"(no-skip-on-cancel violated: Add/Inc must not gate on ctx.Err())", got, wantCounter)
+	}
+	if got := rb.Histogram(); got != wantHistogram {
+		t.Errorf("metricstest: histogram recorded count %d under cancelled ctx, want %d "+
+			"(no-skip-on-cancel violated: Observe must not gate on ctx.Err())", got, wantHistogram)
+	}
+	if got := rb.Gauge(); got != wantGauge {
+		t.Errorf("metricstest: gauge recorded %v under cancelled ctx, want %d "+
+			"(no-skip-on-cancel violated: Set/Inc/Dec/Add must not gate on ctx.Err())", got, wantGauge)
+	}
+}

--- a/kernel/observability/metrics/metricstest/conformance.go
+++ b/kernel/observability/metrics/metricstest/conformance.go
@@ -3,7 +3,7 @@
 //
 // kernel/observability/metrics/metrics.go §contract (1): "实现禁止因 ctx 已取消/
 // 超时而跳过记录——ctx 取消不得导致数据丢失". This harness drives a metrics.Provider's
-// Counter/Histogram/Gauge instruments with an already-cancelled context and
+// Counter/Histogram/Gauge instruments with an already-canceled context and
 // asserts — via an implementation-supplied Readback — that every measurement
 // still landed. Membership of every production Provider implementation is
 // enforced by archtest METRICS-CANCEL-CTX-CONFORMANCE-01.
@@ -29,7 +29,7 @@ const (
 	labelKey = "k"
 	labelVal = "v"
 
-	// Expected recorded values after the cancelled-ctx drive sequence below.
+	// Expected recorded values after the canceled-ctx drive sequence below.
 	wantCounter   = 3 // Add(2) + Inc
 	wantHistogram = 1 // one Observe
 	wantGauge     = 8 // Set(5) + Inc - Dec + Add(3)
@@ -47,13 +47,13 @@ type Readback struct {
 	Gauge     func() float64
 }
 
-// RunCancelledCtxConformance asserts that p's instruments record measurements
-// even when the supplied context is already cancelled (metrics.go §contract (1)).
+// RunCanceledCtxConformance asserts that p's instruments record measurements
+// even when the supplied context is already canceled (metrics.go §contract (1)).
 // It drives Counter.Add/Inc, Histogram.Observe, and Gauge.Set/Inc/Dec/Add with an
-// already-cancelled ctx, then uses rb to assert each measurement landed. A
+// already-canceled ctx, then uses rb to assert each measurement landed. A
 // regression that gates recording on ctx.Err() makes a readback return the wrong
 // value and fails here — a no-op implementation cannot satisfy it.
-func RunCancelledCtxConformance(t *testing.T, p metrics.Provider, rb Readback) {
+func RunCanceledCtxConformance(t *testing.T, p metrics.Provider, rb Readback) {
 	t.Helper()
 	if rb.Counter == nil || rb.Histogram == nil || rb.Gauge == nil {
 		t.Fatal("metricstest: Readback.Counter/Histogram/Gauge must all be supplied")
@@ -92,15 +92,15 @@ func RunCancelledCtxConformance(t *testing.T, p metrics.Provider, rb Readback) {
 	gv.With(Labels()).Add(ctx, 3)
 
 	if got := rb.Counter(); got != wantCounter {
-		t.Errorf("metricstest: counter recorded %v under cancelled ctx, want %d "+
+		t.Errorf("metricstest: counter recorded %v under canceled ctx, want %d "+
 			"(no-skip-on-cancel violated: Add/Inc must not gate on ctx.Err())", got, wantCounter)
 	}
 	if got := rb.Histogram(); got != wantHistogram {
-		t.Errorf("metricstest: histogram recorded count %d under cancelled ctx, want %d "+
+		t.Errorf("metricstest: histogram recorded count %d under canceled ctx, want %d "+
 			"(no-skip-on-cancel violated: Observe must not gate on ctx.Err())", got, wantHistogram)
 	}
 	if got := rb.Gauge(); got != wantGauge {
-		t.Errorf("metricstest: gauge recorded %v under cancelled ctx, want %d "+
+		t.Errorf("metricstest: gauge recorded %v under canceled ctx, want %d "+
 			"(no-skip-on-cancel violated: Set/Inc/Dec/Add must not gate on ctx.Err())", got, wantGauge)
 	}
 }

--- a/kernel/observability/metrics/nop.go
+++ b/kernel/observability/metrics/nop.go
@@ -60,8 +60,8 @@ func (v nopGaugeVec) With(l Labels) Gauge {
 
 type nopCounter struct{}
 
-func (nopCounter) Inc(_ context.Context)              {}
-func (nopCounter) Add(_ context.Context, _ float64)   {}
+func (nopCounter) Inc(_ context.Context)            {}
+func (nopCounter) Add(_ context.Context, _ float64) {}
 
 type nopHistogram struct{}
 

--- a/kernel/observability/metrics/nop.go
+++ b/kernel/observability/metrics/nop.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "context"
+
 // NopProvider is a no-op Provider used when no metrics backend is injected.
 // It validates label sets (so label-drift bugs surface in test) but records
 // nothing.
@@ -58,12 +60,12 @@ func (v nopGaugeVec) With(l Labels) Gauge {
 
 type nopCounter struct{}
 
-func (nopCounter) Inc()              {}
-func (nopCounter) Add(delta float64) {}
+func (nopCounter) Inc(_ context.Context)              {}
+func (nopCounter) Add(_ context.Context, _ float64)   {}
 
 type nopHistogram struct{}
 
-func (nopHistogram) Observe(value float64) {}
+func (nopHistogram) Observe(_ context.Context, _ float64) {}
 
 // nopGauge is the no-op Gauge returned by NopProvider. All mutating methods are
 // deliberate no-ops: NopProvider implements the Provider contract without
@@ -71,13 +73,13 @@ func (nopHistogram) Observe(value float64) {}
 type nopGauge struct{}
 
 // Set is a no-op; see nopGauge.
-func (nopGauge) Set(value float64) {}
+func (nopGauge) Set(_ context.Context, _ float64) {}
 
 // Inc is a no-op; see nopGauge.
-func (nopGauge) Inc() {}
+func (nopGauge) Inc(_ context.Context) {}
 
 // Dec is a no-op; see nopGauge.
-func (nopGauge) Dec() {}
+func (nopGauge) Dec(_ context.Context) {}
 
 // Add is a no-op; see nopGauge.
-func (nopGauge) Add(delta float64) {}
+func (nopGauge) Add(_ context.Context, _ float64) {}

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -600,7 +600,7 @@ func (cb *ConsumerBase) retryLoop(
 				slog.String("topic", topic),
 				slog.String("consumer_group", consumerGroup),
 			), func() {
-				cb.observer.ObserveReject(cellID, topic, consumerGroup, ConsumerRejectReasonHandlerReject)
+				cb.observer.ObserveReject(ctx, cellID, topic, consumerGroup, ConsumerRejectReasonHandlerReject)
 			})
 			return HandleResult{
 				Disposition:         DispositionReject,
@@ -641,7 +641,7 @@ func (cb *ConsumerBase) retryLoop(
 		slog.String("topic", topic),
 		slog.String("consumer_group", consumerGroup),
 	), func() {
-		cb.observer.ObserveReject(cellID, topic, consumerGroup, ConsumerRejectReasonRetryExhausted)
+		cb.observer.ObserveReject(ctx, cellID, topic, consumerGroup, ConsumerRejectReasonRetryExhausted)
 	})
 	return HandleResult{
 		Disposition:         DispositionReject,

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -1594,7 +1594,7 @@ func TestConsumerBase_ObserveReject_PanicingObserver_DoesNotEscape(t *testing.T)
 // used to verify panic isolation in ConsumerBase.Wrap.
 type panicingObserver struct{}
 
-func (p *panicingObserver) ObserveReject(_, _, _, _ string) {
+func (p *panicingObserver) ObserveReject(_ context.Context, _, _, _, _ string) {
 	panic("panicingObserver: intentional panic for isolation test")
 }
 

--- a/kernel/outbox/consumer_observer.go
+++ b/kernel/outbox/consumer_observer.go
@@ -1,6 +1,8 @@
 package outbox
 
 import (
+	"context"
+
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
@@ -30,7 +32,7 @@ import (
 // interface for the Relay path; same kernel-defined-runtime-implemented
 // pattern keeps adapter-backend imports out of kernel.
 type ConsumerObserver interface {
-	ObserveReject(cellID, topic, consumerGroup, reason string)
+	ObserveReject(ctx context.Context, cellID, topic, consumerGroup, reason string)
 }
 
 // ConsumerRejectReason* are the closed-set values passed to
@@ -63,7 +65,7 @@ type NopConsumerObserver struct{}
 // metrics collector is wired. Discarding the observation is deliberate — the
 // no-op exists so ConsumerBase can always call ObserveReject unconditionally
 // without a nil guard.
-func (NopConsumerObserver) ObserveReject(_, _, _, _ string) {
+func (NopConsumerObserver) ObserveReject(_ context.Context, _, _, _, _ string) {
 	// no-op: NopConsumerObserver is the default when no metrics collector is
 	// wired; discarding the observation is deliberate so ConsumerBase can call
 	// ObserveReject unconditionally without a nil guard.

--- a/kernel/outbox/consumer_observer_test.go
+++ b/kernel/outbox/consumer_observer_test.go
@@ -1,15 +1,17 @@
 package outbox
 
 import (
+	"context"
 	"testing"
 )
 
 func TestNopConsumerObserver_ObserveReject_DoesNotPanic(t *testing.T) {
 	var o ConsumerObserver = NopConsumerObserver{}
+	ctx := context.Background()
 	// All argument shapes must be safe; the Nop swallows them.
-	o.ObserveReject("accesscore", "topic.foo", "cg-accesscore-foo", ConsumerRejectReasonHandlerReject)
-	o.ObserveReject("", "", "", "")
-	o.ObserveReject("auditcore", "topic.bar", "cg-auditcore-bar", ConsumerRejectReasonRetryExhausted)
+	o.ObserveReject(ctx, "accesscore", "topic.foo", "cg-accesscore-foo", ConsumerRejectReasonHandlerReject)
+	o.ObserveReject(ctx, "", "", "", "")
+	o.ObserveReject(ctx, "auditcore", "topic.bar", "cg-auditcore-bar", ConsumerRejectReasonRetryExhausted)
 }
 
 func TestConsumerRejectReason_Constants(t *testing.T) {
@@ -63,6 +65,6 @@ type rejectCall struct {
 	reason        string
 }
 
-func (f *fakeObserver) ObserveReject(cellID, topic, consumerGroup, reason string) {
+func (f *fakeObserver) ObserveReject(_ context.Context, cellID, topic, consumerGroup, reason string) {
 	f.calls = append(f.calls, rejectCall{cellID, topic, consumerGroup, reason})
 }

--- a/kernel/outbox/emitter.go
+++ b/kernel/outbox/emitter.go
@@ -218,7 +218,7 @@ func (e *DirectEmitter) Emit(ctx context.Context, entry Entry) error {
 			e.failOpenDroppedCv.With(metrics.Labels{
 				"cell":  e.cellID,
 				"topic": topic,
-			}).Inc()
+			}).Inc(ctx)
 			e.failOpenTracker.RecordDrop()
 			return nil
 		}

--- a/kernel/outbox/emitter_test.go
+++ b/kernel/outbox/emitter_test.go
@@ -300,7 +300,7 @@ func TestNewDirectEmitter_NilClock(t *testing.T) {
 
 type spyCounter struct{ count int }
 
-func (c *spyCounter) Inc(_ context.Context)          { c.count++ }
+func (c *spyCounter) Inc(_ context.Context)            { c.count++ }
 func (c *spyCounter) Add(_ context.Context, d float64) { c.count += int(d) }
 
 type spyCounterVec struct {
@@ -337,9 +337,9 @@ func (v *spyGaugeVec) With(l metrics.Labels) metrics.Gauge {
 type spyGauge struct{}
 
 func (spyGauge) Set(_ context.Context, _ float64) {}
-func (spyGauge) Inc(_ context.Context)             {}
-func (spyGauge) Dec(_ context.Context)             {}
-func (spyGauge) Add(_ context.Context, _ float64)  {}
+func (spyGauge) Inc(_ context.Context)            {}
+func (spyGauge) Dec(_ context.Context)            {}
+func (spyGauge) Add(_ context.Context, _ float64) {}
 
 type spyMetricsProvider struct {
 	counter *spyCounter

--- a/kernel/outbox/emitter_test.go
+++ b/kernel/outbox/emitter_test.go
@@ -300,8 +300,8 @@ func TestNewDirectEmitter_NilClock(t *testing.T) {
 
 type spyCounter struct{ count int }
 
-func (c *spyCounter) Inc()          { c.count++ }
-func (c *spyCounter) Add(d float64) { c.count += int(d) }
+func (c *spyCounter) Inc(_ context.Context)          { c.count++ }
+func (c *spyCounter) Add(_ context.Context, d float64) { c.count += int(d) }
 
 type spyCounterVec struct {
 	counter *spyCounter
@@ -324,7 +324,7 @@ func (v *spyHistogramVec) With(l metrics.Labels) metrics.Histogram {
 
 type spyHistogram struct{}
 
-func (spyHistogram) Observe(_ float64) {}
+func (spyHistogram) Observe(_ context.Context, _ float64) {}
 
 type spyGaugeVec struct{ labels []string }
 
@@ -336,10 +336,10 @@ func (v *spyGaugeVec) With(l metrics.Labels) metrics.Gauge {
 
 type spyGauge struct{}
 
-func (spyGauge) Set(_ float64) {}
-func (spyGauge) Inc()          {}
-func (spyGauge) Dec()          {}
-func (spyGauge) Add(_ float64) {}
+func (spyGauge) Set(_ context.Context, _ float64) {}
+func (spyGauge) Inc(_ context.Context)             {}
+func (spyGauge) Dec(_ context.Context)             {}
+func (spyGauge) Add(_ context.Context, _ float64)  {}
 
 type spyMetricsProvider struct {
 	counter *spyCounter

--- a/kernel/outbox/relay_collector.go
+++ b/kernel/outbox/relay_collector.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -182,50 +183,50 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 // Zero-count outcomes are skipped to keep time-series cardinality clean:
 // a persistent zero counter fragment would otherwise appear in Grafana
 // topology for dead-lettered cells that never actually dead-letter anything.
-func (c *providerRelayCollector) RecordPollCycle(r PollCycleResult) {
+func (c *providerRelayCollector) RecordPollCycle(ctx context.Context, r PollCycleResult) {
 	if r.Published > 0 {
-		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "published"}).Add(float64(r.Published))
+		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "published"}).Add(ctx, float64(r.Published))
 	}
 	if r.Retried > 0 {
-		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "retried"}).Add(float64(r.Retried))
+		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "retried"}).Add(ctx, float64(r.Retried))
 	}
 	if r.Dead > 0 {
-		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "dead"}).Add(float64(r.Dead))
+		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "dead"}).Add(ctx, float64(r.Dead))
 	}
 	if r.Skipped > 0 {
-		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "skipped"}).Add(float64(r.Skipped))
+		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "skipped"}).Add(ctx, float64(r.Skipped))
 	}
 	if r.Lost > 0 {
-		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "lost"}).Add(float64(r.Lost))
+		c.relayed.With(metrics.Labels{"cell": c.cellID, "outcome": "lost"}).Add(ctx, float64(r.Lost))
 	}
 
-	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "claim"}).Observe(r.ClaimDur.Seconds())
-	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "publish"}).Observe(r.PublishDur.Seconds())
-	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "write_back"}).Observe(r.WriteBackDur.Seconds())
-	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "total"}).Observe((r.ClaimDur + r.PublishDur + r.WriteBackDur).Seconds())
+	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "claim"}).Observe(ctx, r.ClaimDur.Seconds())
+	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "publish"}).Observe(ctx, r.PublishDur.Seconds())
+	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "write_back"}).Observe(ctx, r.WriteBackDur.Seconds())
+	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "total"}).Observe(ctx, (r.ClaimDur+r.PublishDur+r.WriteBackDur).Seconds())
 }
 
 // RecordBatchSize observes the claim count of each poll, including zero to
 // capture idle cycles (useful for relay liveness panels).
-func (c *providerRelayCollector) RecordBatchSize(size int) {
-	c.batchSize.With(metrics.Labels{"cell": c.cellID}).Observe(float64(size))
+func (c *providerRelayCollector) RecordBatchSize(ctx context.Context, size int) {
+	c.batchSize.With(metrics.Labels{"cell": c.cellID}).Observe(ctx, float64(size))
 }
 
 // RecordReclaim emits only when count > 0; dropping zero avoids a noisy
 // counter increment every cleanup interval on a healthy relay.
-func (c *providerRelayCollector) RecordReclaim(count int64) {
+func (c *providerRelayCollector) RecordReclaim(ctx context.Context, count int64) {
 	if count > 0 {
-		c.reclaimed.With(metrics.Labels{"cell": c.cellID}).Add(float64(count))
+		c.reclaimed.With(metrics.Labels{"cell": c.cellID}).Add(ctx, float64(count))
 	}
 }
 
 // RecordCleanup splits increments by status so dashboards can track
 // published-vs-dead cleanup separately.
-func (c *providerRelayCollector) RecordCleanup(publishedDeleted, deadDeleted int64) {
+func (c *providerRelayCollector) RecordCleanup(ctx context.Context, publishedDeleted, deadDeleted int64) {
 	if publishedDeleted > 0 {
-		c.cleaned.With(metrics.Labels{"cell": c.cellID, "status": "published"}).Add(float64(publishedDeleted))
+		c.cleaned.With(metrics.Labels{"cell": c.cellID, "status": "published"}).Add(ctx, float64(publishedDeleted))
 	}
 	if deadDeleted > 0 {
-		c.cleaned.With(metrics.Labels{"cell": c.cellID, "status": "dead"}).Add(float64(deadDeleted))
+		c.cleaned.With(metrics.Labels{"cell": c.cellID, "status": "dead"}).Add(ctx, float64(deadDeleted))
 	}
 }

--- a/kernel/outbox/relay_collector.go
+++ b/kernel/outbox/relay_collector.go
@@ -203,7 +203,8 @@ func (c *providerRelayCollector) RecordPollCycle(ctx context.Context, r PollCycl
 	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "claim"}).Observe(ctx, r.ClaimDur.Seconds())
 	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "publish"}).Observe(ctx, r.PublishDur.Seconds())
 	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "write_back"}).Observe(ctx, r.WriteBackDur.Seconds())
-	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "total"}).Observe(ctx, (r.ClaimDur+r.PublishDur+r.WriteBackDur).Seconds())
+	total := (r.ClaimDur + r.PublishDur + r.WriteBackDur).Seconds()
+	c.pollDuration.With(metrics.Labels{"cell": c.cellID, "phase": "total"}).Observe(ctx, total)
 }
 
 // RecordBatchSize observes the claim count of each poll, including zero to

--- a/kernel/outbox/relay_collector_test.go
+++ b/kernel/outbox/relay_collector_test.go
@@ -1,6 +1,7 @@
 package outbox_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -26,7 +27,8 @@ func TestProviderRelayCollector_NopProviderNoPanic(t *testing.T) {
 		t.Fatalf("NewProviderRelayCollector: %v", err)
 	}
 
-	c.RecordPollCycle(outbox.PollCycleResult{
+	ctx := context.Background()
+	c.RecordPollCycle(ctx, outbox.PollCycleResult{
 		Published:    3,
 		Retried:      1,
 		Dead:         0,
@@ -35,14 +37,14 @@ func TestProviderRelayCollector_NopProviderNoPanic(t *testing.T) {
 		PublishDur:   testtime.MediumPoll,
 		WriteBackDur: testtime.FastPoll,
 	})
-	c.RecordBatchSize(6)
-	c.RecordReclaim(4)
-	c.RecordCleanup(10, 2)
+	c.RecordBatchSize(ctx, 6)
+	c.RecordReclaim(ctx, 4)
+	c.RecordCleanup(ctx, 10, 2)
 
 	// Zero counts must not panic; skipped counter increment for zero values.
-	c.RecordPollCycle(outbox.PollCycleResult{})
-	c.RecordReclaim(0)
-	c.RecordCleanup(0, 0)
+	c.RecordPollCycle(ctx, outbox.PollCycleResult{})
+	c.RecordReclaim(ctx, 0)
+	c.RecordCleanup(ctx, 0, 0)
 }
 
 // spyProvider records the last operation so tests can assert the collector
@@ -93,8 +95,8 @@ type spyCounter struct {
 	labels metrics.Labels
 }
 
-func (c spyCounter) Inc() { c.Add(1) }
-func (c spyCounter) Add(d float64) {
+func (c spyCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c spyCounter) Add(_ context.Context, d float64) {
 	c.parent.counterOps[c.name] = append(c.parent.counterOps[c.name], spyCounterOp{labels: c.labels, op: "add", value: d})
 }
 
@@ -116,7 +118,7 @@ type spyHistogram struct {
 	labels metrics.Labels
 }
 
-func (h spyHistogram) Observe(v float64) {
+func (h spyHistogram) Observe(_ context.Context, v float64) {
 	// Histogram observations are recorded as counter-like ops under the name
 	// "hist:{metric}" so the spy can remain a single map.
 	h.parent.counterOps["hist:"+h.name] = append(h.parent.counterOps["hist:"+h.name], spyCounterOp{labels: h.labels, op: "observe", value: v})
@@ -129,7 +131,7 @@ func TestProviderRelayCollector_PollCycleEmitsPerOutcome(t *testing.T) {
 		t.Fatalf("NewProviderRelayCollector: %v", err)
 	}
 
-	c.RecordPollCycle(outbox.PollCycleResult{
+	c.RecordPollCycle(context.Background(), outbox.PollCycleResult{
 		Published: 4, Retried: 1, Dead: 0, Skipped: 2,
 		ClaimDur: time.Millisecond, PublishDur: testtime.D2ms, WriteBackDur: testWriteBackDur500us,
 	})
@@ -152,8 +154,8 @@ func TestProviderRelayCollector_ZeroBatchSizeStillObserved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProviderRelayCollector: %v", err)
 	}
-	c.RecordBatchSize(0)
-	c.RecordBatchSize(5)
+	c.RecordBatchSize(context.Background(), 0)
+	c.RecordBatchSize(context.Background(), 5)
 	obs := p.counterOps["hist:outbox_batch_size"]
 	if len(obs) != 2 {
 		t.Fatalf("want 2 batch_size observations (including zero), got %d", len(obs))
@@ -236,10 +238,10 @@ func TestNewProviderRelayCollector_SuccessPath_AllFiveMetricsRegistered(t *testi
 		_ = totalVecs
 	}
 	// Exercise all recording paths to confirm all 5 vecs are live (no nil panic).
-	c.RecordPollCycle(outbox.PollCycleResult{Published: 1})
-	c.RecordBatchSize(1)
-	c.RecordReclaim(1)
-	c.RecordCleanup(1, 1)
+	c.RecordPollCycle(context.Background(), outbox.PollCycleResult{Published: 1})
+	c.RecordBatchSize(context.Background(), 1)
+	c.RecordReclaim(context.Background(), 1)
+	c.RecordCleanup(context.Background(), 1, 1)
 }
 
 // TestNewProviderRelayCollector_UnregisterLIFOOrder verifies that when
@@ -365,10 +367,10 @@ func (v *spyGaugeVec) With(l metrics.Labels) metrics.Gauge {
 
 type spyGauge struct{}
 
-func (spyGauge) Set(_ float64) {}
-func (spyGauge) Inc()          {}
-func (spyGauge) Dec()          {}
-func (spyGauge) Add(_ float64) {}
+func (spyGauge) Set(_ context.Context, _ float64) {}
+func (spyGauge) Inc(_ context.Context)             {}
+func (spyGauge) Dec(_ context.Context)             {}
+func (spyGauge) Add(_ context.Context, _ float64)  {}
 
 // MetricName exposes the name so collectorName can extract it in tests.
 func (v *spyCounterVec) MetricName() string   { return v.name }

--- a/kernel/outbox/relay_collector_test.go
+++ b/kernel/outbox/relay_collector_test.go
@@ -368,9 +368,9 @@ func (v *spyGaugeVec) With(l metrics.Labels) metrics.Gauge {
 type spyGauge struct{}
 
 func (spyGauge) Set(_ context.Context, _ float64) {}
-func (spyGauge) Inc(_ context.Context)             {}
-func (spyGauge) Dec(_ context.Context)             {}
-func (spyGauge) Add(_ context.Context, _ float64)  {}
+func (spyGauge) Inc(_ context.Context)            {}
+func (spyGauge) Dec(_ context.Context)            {}
+func (spyGauge) Add(_ context.Context, _ float64) {}
 
 // MetricName exposes the name so collectorName can extract it in tests.
 func (v *spyCounterVec) MetricName() string   { return v.name }

--- a/kernel/outbox/relay_metrics.go
+++ b/kernel/outbox/relay_metrics.go
@@ -1,6 +1,9 @@
 package outbox
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // PollCycleResult captures the outcome of a single relay poll cycle.
 // Used by RelayCollector.RecordPollCycle to avoid a long parameter list
@@ -31,11 +34,11 @@ type PollCycleResult struct {
 type RelayCollector interface {
 	// RecordPollCycle records a completed poll cycle with outcome counts and
 	// per-phase durations. Called once per pollOnce invocation after writeBack.
-	RecordPollCycle(result PollCycleResult)
+	RecordPollCycle(ctx context.Context, r PollCycleResult)
 
 	// RecordBatchSize records the number of entries claimed in a poll cycle.
 	// Called even when the batch is empty (size=0) to capture idle cycles.
-	RecordBatchSize(size int)
+	RecordBatchSize(ctx context.Context, size int)
 
 	// RecordReclaim records the number of stale entries reclaimed back to
 	// pending (or dead-lettered). Called once per reclaimStale tick **only
@@ -43,18 +46,26 @@ type RelayCollector interface {
 	// is a recovery counter, not a tick frequency gauge). This contrasts
 	// with RecordBatchSize which is also called on size==0 cycles so
 	// dashboards can detect a totally idle relay.
-	RecordReclaim(count int64)
+	RecordReclaim(ctx context.Context, count int64)
 
 	// RecordCleanup records the number of entries removed during periodic
 	// cleanup, split by original status (published vs dead-lettered).
-	RecordCleanup(publishedDeleted, deadDeleted int64)
+	RecordCleanup(ctx context.Context, publishedDeleted, deadDeleted int64)
 }
 
 // NoopRelayCollector is a no-op implementation of RelayCollector.
 // Used when metrics collection is disabled (nil Metrics in RelayConfig).
 type NoopRelayCollector struct{}
 
-func (NoopRelayCollector) RecordPollCycle(_ PollCycleResult) { /* no-op: metrics disabled */ }
-func (NoopRelayCollector) RecordBatchSize(_ int)             { /* no-op: metrics disabled */ }
-func (NoopRelayCollector) RecordReclaim(_ int64)             { /* no-op: metrics disabled */ }
-func (NoopRelayCollector) RecordCleanup(_, _ int64)          { /* no-op: metrics disabled */ }
+func (NoopRelayCollector) RecordPollCycle(_ context.Context, _ PollCycleResult) {
+	/* no-op: metrics disabled */
+}
+func (NoopRelayCollector) RecordBatchSize(_ context.Context, _ int) {
+	/* no-op: metrics disabled */
+}
+func (NoopRelayCollector) RecordReclaim(_ context.Context, _ int64) {
+	/* no-op: metrics disabled */
+}
+func (NoopRelayCollector) RecordCleanup(_ context.Context, _, _ int64) {
+	/* no-op: metrics disabled */
+}

--- a/kernel/outbox/relay_metrics.go
+++ b/kernel/outbox/relay_metrics.go
@@ -60,12 +60,15 @@ type NoopRelayCollector struct{}
 func (NoopRelayCollector) RecordPollCycle(_ context.Context, _ PollCycleResult) {
 	/* no-op: metrics disabled */
 }
+
 func (NoopRelayCollector) RecordBatchSize(_ context.Context, _ int) {
 	/* no-op: metrics disabled */
 }
+
 func (NoopRelayCollector) RecordReclaim(_ context.Context, _ int64) {
 	/* no-op: metrics disabled */
 }
+
 func (NoopRelayCollector) RecordCleanup(_ context.Context, _, _ int64) {
 	/* no-op: metrics disabled */
 }

--- a/kernel/outbox/relay_metrics_test.go
+++ b/kernel/outbox/relay_metrics_test.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -10,24 +11,26 @@ var _ RelayCollector = NoopRelayCollector{}
 
 func TestNoopRelayCollector_DoesNotPanic(t *testing.T) {
 	var c NoopRelayCollector
+	ctx := context.Background()
 	// All methods must be safe to call with any arguments.
-	c.RecordPollCycle(PollCycleResult{
+	c.RecordPollCycle(ctx, PollCycleResult{
 		Published: 1, Retried: 2, Dead: 3, Skipped: 4,
 		ClaimDur: time.Millisecond, PublishDur: time.Second, WriteBackDur: time.Microsecond,
 	})
-	c.RecordBatchSize(0)
-	c.RecordBatchSize(100)
-	c.RecordReclaim(0)
-	c.RecordReclaim(42)
-	c.RecordCleanup(0, 0)
-	c.RecordCleanup(100, 50)
+	c.RecordBatchSize(ctx, 0)
+	c.RecordBatchSize(ctx, 100)
+	c.RecordReclaim(ctx, 0)
+	c.RecordReclaim(ctx, 42)
+	c.RecordCleanup(ctx, 0, 0)
+	c.RecordCleanup(ctx, 100, 50)
 }
 
 func TestNoopRelayCollector_ZeroValue_Safe(t *testing.T) {
 	// Zero value must be usable without initialization.
 	var c NoopRelayCollector
-	c.RecordPollCycle(PollCycleResult{})
-	c.RecordBatchSize(0)
-	c.RecordReclaim(0)
-	c.RecordCleanup(0, 0)
+	ctx := context.Background()
+	c.RecordPollCycle(ctx, PollCycleResult{})
+	c.RecordBatchSize(ctx, 0)
+	c.RecordReclaim(ctx, 0)
+	c.RecordCleanup(ctx, 0, 0)
 }

--- a/runtime/auth/metrics.go
+++ b/runtime/auth/metrics.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -106,36 +107,36 @@ func NewAccountLockoutMetrics(p metrics.Provider) (*AccountLockoutMetrics, error
 // one of {"threshold_locked", "lazy_unlocked"}; arbitrary strings are
 // recorded as-is, but the accountlockout package only emits the two values
 // listed.
-func (m *AccountLockoutMetrics) IncAccountLockout(reason string) {
+func (m *AccountLockoutMetrics) IncAccountLockout(ctx context.Context, reason string) {
 	if m == nil {
 		return
 	}
-	m.total.With(metrics.Labels{"reason": reason}).Inc()
+	m.total.With(metrics.Labels{"reason": reason}).Inc(ctx)
 }
 
-func (m *AuthMetrics) recordTokenVerify(result, reason string, duration time.Duration) {
+func (m *AuthMetrics) recordTokenVerify(ctx context.Context, result, reason string, duration time.Duration) {
 	if m == nil {
 		return
 	}
-	m.tokenVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc()
-	m.tokenVerifyDuration.With(metrics.Labels{"result": result}).Observe(duration.Seconds())
+	m.tokenVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc(ctx)
+	m.tokenVerifyDuration.With(metrics.Labels{"result": result}).Observe(ctx, duration.Seconds())
 }
 
 // recordTokenVerifyCounter increments the token verify counter without recording
 // a duration. Used for early-exit paths (e.g. missing token) where no
 // verification work was performed and a 0 duration would pollute the histogram.
-func (m *AuthMetrics) recordTokenVerifyCounter(result, reason string) {
+func (m *AuthMetrics) recordTokenVerifyCounter(ctx context.Context, result, reason string) {
 	if m == nil {
 		return
 	}
-	m.tokenVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc()
+	m.tokenVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc(ctx)
 }
 
-func (m *AuthMetrics) recordServiceVerify(result, reason string) {
+func (m *AuthMetrics) recordServiceVerify(ctx context.Context, result, reason string) {
 	if m == nil {
 		return
 	}
-	m.serviceVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc()
+	m.serviceVerifyTotal.With(metrics.Labels{"result": result, "reason": reason}).Inc(ctx)
 }
 
 // classifyTokenError maps a token verification error to a short reason label.

--- a/runtime/auth/metrics_test.go
+++ b/runtime/auth/metrics_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -49,12 +50,12 @@ type lockoutSpyCounter struct {
 	reason string
 }
 
-func (c *lockoutSpyCounter) Inc() {
+func (c *lockoutSpyCounter) Inc(_ context.Context) {
 	c.vec.mu.Lock()
 	defer c.vec.mu.Unlock()
 	c.vec.byLabel[c.reason]++
 }
-func (c *lockoutSpyCounter) Add(_ float64) {}
+func (c *lockoutSpyCounter) Add(_ context.Context, _ float64) {}
 
 // lockoutSpyProvider wraps metrics.NopProvider but intercepts
 // auth_account_lockout_total registrations, returning the spy vec.
@@ -98,23 +99,26 @@ func TestNewAuthMetrics_NilProvider(t *testing.T) {
 func TestAuthMetrics_RecordTokenVerify_NoPanic(t *testing.T) {
 	am, err := NewAuthMetrics(metrics.NopProvider{})
 	require.NoError(t, err)
+	ctx := context.Background()
 	// Should not panic with valid labels.
-	am.recordTokenVerify("success", "ok", testtime.FastPoll)
-	am.recordTokenVerify("failure", "expired", testtime.D1ms)
+	am.recordTokenVerify(ctx, "success", "ok", testtime.FastPoll)
+	am.recordTokenVerify(ctx, "failure", "expired", testtime.D1ms)
 }
 
 func TestAuthMetrics_RecordServiceVerify_NoPanic(t *testing.T) {
 	am, err := NewAuthMetrics(metrics.NopProvider{})
 	require.NoError(t, err)
-	am.recordServiceVerify("success", "ok")
-	am.recordServiceVerify("failure", "expired")
+	ctx := context.Background()
+	am.recordServiceVerify(ctx, "success", "ok")
+	am.recordServiceVerify(ctx, "failure", "expired")
 }
 
 func TestAuthMetrics_NilSafe(t *testing.T) {
 	// nil AuthMetrics should not panic.
+	ctx := context.Background()
 	var am *AuthMetrics
-	am.recordTokenVerify("success", "ok", testtime.D1ms)
-	am.recordServiceVerify("success", "ok")
+	am.recordTokenVerify(ctx, "success", "ok", testtime.D1ms)
+	am.recordServiceVerify(ctx, "success", "ok")
 }
 
 // ─── AccountLockoutMetrics tests (F6) ────────────────────────────────────────
@@ -140,8 +144,9 @@ func TestNewAccountLockoutMetrics_NopProvider(t *testing.T) {
 // when the composition root omits metrics wiring (e.g., tests).
 func TestAccountLockoutMetrics_NilSafe(t *testing.T) {
 	var m *AccountLockoutMetrics
+	ctx := context.Background()
 	require.NotPanics(t, func() {
-		m.IncAccountLockout("threshold_locked")
+		m.IncAccountLockout(ctx, "threshold_locked")
 	}, "nil *AccountLockoutMetrics.IncAccountLockout must not panic")
 }
 
@@ -152,10 +157,11 @@ func TestAccountLockoutMetrics_IncAccountLockout_EmitsLabel(t *testing.T) {
 	spy := newLockoutSpyProvider()
 	m, err := NewAccountLockoutMetrics(spy)
 	require.NoError(t, err)
+	ctx := context.Background()
 
-	m.IncAccountLockout("threshold_locked")
-	m.IncAccountLockout("threshold_locked")
-	m.IncAccountLockout("lazy_unlocked")
+	m.IncAccountLockout(ctx, "threshold_locked")
+	m.IncAccountLockout(ctx, "threshold_locked")
+	m.IncAccountLockout(ctx, "lazy_unlocked")
 
 	assert.Equal(t, 2, spy.lockoutVec.count("threshold_locked"),
 		`IncAccountLockout("threshold_locked") must increment the "threshold_locked" label`)

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -82,13 +82,15 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 		// S43: expected 4xx (invalid/expired token, unauthorized) → Warn;
 		// infra errors (key load failure, verifier init error) → Error.
 		if errcode.IsExpected4xx(err) {
-			cfg.logger.Warn("token verification failed",
+			cfg.logger.Warn(
+				"token verification failed",
 				slog.Any("error", err),
 				slog.String("path", r.URL.Path),
 				slog.String("remote_addr", r.RemoteAddr),
 			)
 		} else {
-			cfg.logger.Error("token verification failed",
+			cfg.logger.Error(
+				"token verification failed",
 				slog.Any("error", err),
 				slog.String("path", r.URL.Path),
 				slog.String("remote_addr", r.RemoteAddr),
@@ -116,7 +118,8 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 	// their password and obtains a new token without the claim. If no matcher
 	// is wired, the gate rejects every request — fail-closed default.
 	if claims.PasswordResetRequired && !isPasswordResetExempt(cfg, r.Method, r.URL.Path) {
-		cfg.logger.Info("auth: password reset required gate blocked request",
+		cfg.logger.Info(
+			"auth: password reset required gate blocked request",
 			slog.String("subject", claims.Subject),
 			slog.String("path", r.URL.Path),
 			slog.String("method", r.Method),
@@ -245,7 +248,8 @@ func handleRequireRole(
 	if authorizer != nil {
 		allowed, err := checkAuthorizer(authorizer, r, p.Subject, roles)
 		if err != nil {
-			loggerFrom(r.Context()).Error("authorization check failed",
+			loggerFrom(r.Context()).Error(
+				"authorization check failed",
 				slog.Any("error", err),
 				slog.String("subject", p.Subject),
 			)
@@ -259,7 +263,8 @@ func handleRequireRole(
 		}
 	}
 
-	loggerFrom(r.Context()).Info("authorization role check failed",
+	loggerFrom(r.Context()).Info(
+		"authorization role check failed",
 		slog.String("subject", p.Subject),
 		slog.String("path", r.URL.Path),
 		slog.Any("required_roles", roles),

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -69,7 +69,7 @@ func AuthMiddleware(verifier IntentTokenVerifier, opts ...AuthOption) func(http.
 func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler, verifier IntentTokenVerifier, cfg authConfig) {
 	token, reason := extractBearerTokenWithReason(r)
 	if token == "" {
-		cfg.metrics.recordTokenVerifyCounter("failure", reason)
+		cfg.metrics.recordTokenVerifyCounter(r.Context(), "failure", reason)
 		httputil.WriteError(r.Context(), w,
 			errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "missing or invalid authorization header"))
 		return
@@ -78,7 +78,7 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 	start := cfg.clock.Now()
 	claims, err := verifier.VerifyIntent(r.Context(), token, TokenIntentAccess)
 	if err != nil {
-		cfg.metrics.recordTokenVerify("failure", classifyTokenError(err), cfg.clock.Since(start))
+		cfg.metrics.recordTokenVerify(r.Context(), "failure", classifyTokenError(err), cfg.clock.Since(start))
 		// S43: expected 4xx (invalid/expired token, unauthorized) → Warn;
 		// infra errors (key load failure, verifier init error) → Error.
 		if errcode.IsExpected4xx(err) {
@@ -107,7 +107,7 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 			errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "invalid token"))
 		return
 	}
-	cfg.metrics.recordTokenVerify("success", "ok", cfg.clock.Since(start))
+	cfg.metrics.recordTokenVerify(r.Context(), "success", "ok", cfg.clock.Since(start))
 
 	// Password-reset enforcement: when the token carries password_reset_required=true,
 	// only exempt endpoints (supplied by the composition root via

--- a/runtime/auth/refresh/metrics.go
+++ b/runtime/auth/refresh/metrics.go
@@ -72,12 +72,12 @@ func NewProviderGCCollector(p metrics.Provider) (*ProviderGCCollector, error) {
 	return &ProviderGCCollector{runs: runs, removed: removed, duration: duration}, nil
 }
 
-func (c *ProviderGCCollector) ObserveRefreshGC(_ context.Context, result string, removed int, duration time.Duration) {
+func (c *ProviderGCCollector) ObserveRefreshGC(ctx context.Context, result string, removed int, duration time.Duration) {
 	if c == nil {
 		return
 	}
 	labels := metrics.Labels{"result": result}
-	c.runs.With(labels).Inc()
-	c.removed.With(labels).Add(float64(removed))
-	c.duration.With(labels).Observe(duration.Seconds())
+	c.runs.With(labels).Inc(ctx)
+	c.removed.With(labels).Add(ctx, float64(removed))
+	c.duration.With(labels).Observe(ctx, duration.Seconds())
 }

--- a/runtime/auth/refresh/metrics_test.go
+++ b/runtime/auth/refresh/metrics_test.go
@@ -78,12 +78,12 @@ func (gcHistogramVec) With(metrics.Labels) metrics.Histogram { return gcHistogra
 
 type gcCounter struct{}
 
-func (gcCounter) Inc()              {}
-func (gcCounter) Add(delta float64) {}
+func (gcCounter) Inc(_ context.Context)              {}
+func (gcCounter) Add(_ context.Context, _ float64)   {}
 
 type gcHistogram struct{}
 
-func (gcHistogram) Observe(float64) {}
+func (gcHistogram) Observe(_ context.Context, _ float64) {}
 
 type gcGaugeVec struct {
 	name string
@@ -94,10 +94,10 @@ func (gcGaugeVec) With(metrics.Labels) metrics.Gauge { return gcGauge{} }
 
 type gcGauge struct{}
 
-func (gcGauge) Set(float64) {}
-func (gcGauge) Inc()        {}
-func (gcGauge) Dec()        {}
-func (gcGauge) Add(float64) {}
+func (gcGauge) Set(_ context.Context, _ float64) {}
+func (gcGauge) Inc(_ context.Context)            {}
+func (gcGauge) Dec(_ context.Context)            {}
+func (gcGauge) Add(_ context.Context, _ float64) {}
 
 func TestNewProviderGCCollector_CleansUpPartialRegistration(t *testing.T) {
 	p := newGCMetricProvider("auth_refresh_gc_removed_total")

--- a/runtime/auth/refresh/metrics_test.go
+++ b/runtime/auth/refresh/metrics_test.go
@@ -78,8 +78,8 @@ func (gcHistogramVec) With(metrics.Labels) metrics.Histogram { return gcHistogra
 
 type gcCounter struct{}
 
-func (gcCounter) Inc(_ context.Context)              {}
-func (gcCounter) Add(_ context.Context, _ float64)   {}
+func (gcCounter) Inc(_ context.Context)            {}
+func (gcCounter) Add(_ context.Context, _ float64) {}
 
 type gcHistogram struct{}
 

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -353,7 +353,8 @@ func writeServiceTokenError(cfg serviceTokenConfig, err error, callerCell string
 		// that operators must be able to attribute back to caller IP / path /
 		// request_id. Emit a structured Warn here so the alerting-rules.md
 		// triage step "grep slog code=ERR_AUTH_REPLAY_DETECTED" produces hits.
-		cfg.logger.WarnContext(r.Context(), "service token replay detected",
+		cfg.logger.WarnContext(
+			r.Context(), "service token replay detected",
 			slog.String("code", string(errcode.ErrAuthReplayDetected)),
 			slog.String("path", r.URL.Path),
 			slog.String("remote", r.RemoteAddr),
@@ -391,24 +392,28 @@ func writeServiceTokenError(cfg serviceTokenConfig, err error, callerCell string
 	reason := classifyServiceTokenVerifyError(err)
 	switch reason {
 	case "legacy_format":
-		cfg.logger.WarnContext(r.Context(), "legacy service token format rejected",
+		cfg.logger.WarnContext(
+			r.Context(), "legacy service token format rejected",
 			slog.String("path", r.URL.Path),
 			slog.String("format", "2-part"),
 		)
 	case "missing_caller_cell":
-		cfg.logger.WarnContext(r.Context(), "service token missing caller cell",
+		cfg.logger.WarnContext(
+			r.Context(), "service token missing caller cell",
 			slog.String("path", r.URL.Path),
 			slog.String("remote", r.RemoteAddr),
 			slog.String("caller_cell", callerCell),
 		)
 	case "invalid_caller_cell":
-		cfg.logger.WarnContext(r.Context(), "service token invalid caller cell",
+		cfg.logger.WarnContext(
+			r.Context(), "service token invalid caller cell",
 			slog.String("path", r.URL.Path),
 			slog.String("remote", r.RemoteAddr),
 			slog.String("caller_cell", callerCell),
 		)
 	case "invalid_format":
-		cfg.logger.WarnContext(r.Context(), "service token invalid format",
+		cfg.logger.WarnContext(
+			r.Context(), "service token invalid format",
 			slog.String("path", r.URL.Path),
 			slog.String("remote", r.RemoteAddr),
 			slog.String("caller_cell", callerCell),

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -280,7 +280,7 @@ func ServiceTokenMiddleware(ring kauth.HMACKeyring, clk clock.Clock, opts ...Ser
 func errorMiddlewareInternal(cfg serviceTokenConfig, reason string) func(http.Handler) http.Handler {
 	return func(_ http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			cfg.metrics.recordServiceVerify("failure", "internal")
+			cfg.metrics.recordServiceVerify(r.Context(), "failure", "internal")
 			cfg.logger.Error("service token middleware misconfigured",
 				slog.String("reason", reason),
 				slog.String("path", r.URL.Path))
@@ -299,7 +299,7 @@ func errorMiddlewareInternal(cfg serviceTokenConfig, reason string) func(http.Ha
 func handleServiceToken(cfg serviceTokenConfig, auth Authenticator, next http.Handler, w http.ResponseWriter, r *http.Request) {
 	token := extractServiceToken(r)
 	if token == "" {
-		cfg.metrics.recordServiceVerify("failure", "missing")
+		cfg.metrics.recordServiceVerify(r.Context(), "failure", "missing")
 		httputil.WriteError(r.Context(), w,
 			errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "missing service token"))
 		return
@@ -320,13 +320,13 @@ func handleServiceToken(cfg serviceTokenConfig, auth Authenticator, next http.Ha
 	if !ok {
 		// Absent: no ServiceToken header (already handled by extractServiceToken
 		// above, so this branch is a safety net for unexpected absent outcomes).
-		cfg.metrics.recordServiceVerify("failure", "missing")
+		cfg.metrics.recordServiceVerify(r.Context(), "failure", "missing")
 		httputil.WriteError(r.Context(), w,
 			errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "missing service token"))
 		return
 	}
 
-	cfg.metrics.recordServiceVerify("success", "ok")
+	cfg.metrics.recordServiceVerify(r.Context(), "success", "ok")
 	ctx := WithPrincipal(r.Context(), p)
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
@@ -348,7 +348,7 @@ func handleServiceToken(cfg serviceTokenConfig, auth Authenticator, next http.Ha
 func writeServiceTokenError(cfg serviceTokenConfig, err error, callerCell string, w http.ResponseWriter, r *http.Request) {
 	// errors.Is traverses the full chain, so ErrNonceReused in the Cause matches.
 	if errors.Is(err, ErrNonceReused) {
-		cfg.metrics.recordServiceVerify("failure", "replay")
+		cfg.metrics.recordServiceVerify(r.Context(), "failure", "replay")
 		// httputil.WriteError only logs at 5xx, but replay is a security signal
 		// that operators must be able to attribute back to caller IP / path /
 		// request_id. Emit a structured Warn here so the alerting-rules.md
@@ -367,7 +367,7 @@ func writeServiceTokenError(cfg serviceTokenConfig, err error, callerCell string
 	// ErrNonceStoreFull: store is at capacity with no expired entries to reclaim.
 	// Return 503 (transient; not a replay signal, not a permanent auth failure).
 	if errors.Is(err, ErrNonceStoreFull) {
-		cfg.metrics.recordServiceVerify("failure", "nonce_store_full")
+		cfg.metrics.recordServiceVerify(r.Context(), "failure", "nonce_store_full")
 		cfg.logger.Error("nonce store full; rejecting request",
 			slog.String("path", r.URL.Path))
 		httputil.WriteError(r.Context(), w,
@@ -380,7 +380,7 @@ func writeServiceTokenError(cfg serviceTokenConfig, err error, callerCell string
 	// infrastructure failure.
 	var ec *errcode.Error
 	if errors.As(err, &ec) && ec.Cause != nil {
-		cfg.metrics.recordServiceVerify("failure", "nonce_store_error")
+		cfg.metrics.recordServiceVerify(r.Context(), "failure", "nonce_store_error")
 		cfg.logger.Error("nonce store check failed", slog.Any("error", ec.Cause))
 		httputil.WriteError(r.Context(), w,
 			errcode.New(errcode.KindInternal, errcode.ErrInternal, msgInternalServerError))
@@ -414,7 +414,7 @@ func writeServiceTokenError(cfg serviceTokenConfig, err error, callerCell string
 			slog.String("caller_cell", callerCell),
 		)
 	}
-	cfg.metrics.recordServiceVerify("failure", reason)
+	cfg.metrics.recordServiceVerify(r.Context(), "failure", reason)
 	httputil.WriteError(r.Context(), w,
 		errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "invalid service token"))
 }

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -53,7 +53,8 @@ func mustTestRing(t *testing.T, current, previous string) *HMACKeyRing {
 
 func mustTestServiceHandler(t *testing.T, ring *HMACKeyRing, clk clock.Clock) http.Handler {
 	t.Helper()
-	return ServiceTokenMiddleware(ring, clk,
+	return ServiceTokenMiddleware(
+		ring, clk,
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +65,8 @@ func mustTestServiceHandler(t *testing.T, ring *HMACKeyRing, clk clock.Clock) ht
 
 func mustTestServiceHandlerFatal(t *testing.T, ring *HMACKeyRing, clk clock.Clock) http.Handler {
 	t.Helper()
-	return ServiceTokenMiddleware(ring, clk,
+	return ServiceTokenMiddleware(
+		ring, clk,
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -416,7 +418,8 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 
 func TestServiceTokenMiddleware_InvalidFormat_NoColon(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
-	handler := ServiceTokenMiddleware(ring, clock.Real(),
+	handler := ServiceTokenMiddleware(
+		ring, clock.Real(),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
@@ -490,7 +493,8 @@ func TestServiceTokenMiddleware_WithNonceStore_ReplayRejected(t *testing.T) {
 	now := time.Now()
 	store, err := NewInMemoryNonceStore(ServiceTokenNonceTTL, clock.Real())
 	require.NoError(t, err)
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(store),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -518,7 +522,8 @@ func TestServiceTokenMiddleware_WithNonceStore_UniqueTokensAccepted(t *testing.T
 	now := time.Now()
 	store, err := NewInMemoryNonceStore(ServiceTokenNonceTTL, clock.Real())
 	require.NoError(t, err)
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(store),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -569,7 +574,8 @@ func TestServiceTokenMiddleware_DefaultNoNonceStore_ReturnsErrorMiddleware(t *te
 func TestServiceTokenMiddleware_NoopNonceStoreSupplied_ReturnsErrorMiddleware(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(NewNoopNonceStore()),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("handler must not be called when NonceStore is Noop")
@@ -664,7 +670,8 @@ func TestServiceTokenMiddleware_LegacyTwoPartFormat_RealSignature_Rejected(t *te
 	// The 2-part format has no nonce, so this is a fully valid legacy credential.
 	legacyToken := legacyTwoPartToken(testHMACKey, method, path, now)
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: semantically valid 2-part token must be rejected")
@@ -692,7 +699,8 @@ func TestServiceTokenMiddleware_MalformedToken_TwoSegments_Rejected(t *testing.T
 	// Forged hex MAC — not a real HMAC output.
 	forgedMAC := "1700000000:aabbccdd1122334455667788990011223344556677889900112233445566778899"
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called: 2-part token must be rejected")
@@ -715,7 +723,8 @@ func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
 	now := time.Now()
 	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", now)
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -770,7 +779,8 @@ func TestServiceTokenMiddleware_InjectsServicePrincipal(t *testing.T) {
 	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
 
 	var gotPrincipal *Principal
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -885,7 +895,8 @@ func TestServiceToken_LegacyTwoPart_MetricLabel(t *testing.T) {
 
 	legacyToken := legacyTwoPartToken(testHMACKey, http.MethodGet, "/internal/v1/test", now)
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -917,7 +928,8 @@ func TestServiceTokenMiddleware_CallerCellPropagated(t *testing.T) {
 	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", now)
 
 	var gotPrincipal *Principal
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -957,7 +969,8 @@ func TestServiceTokenMiddleware_TamperedCallerCell_Rejected(t *testing.T) {
 	require.Len(t, parts, 4, "GenerateServiceToken must produce a 4-part token")
 	tamperedToken := parts[0] + ":" + parts[1] + ":configcore:" + parts[3]
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1077,7 +1090,8 @@ func TestServiceToken_EmptyCallerCell_MetricLabel(t *testing.T) {
 	ts := fmt.Sprintf("%d", now.Unix())
 	crafted := ts + ":somenonce16bytes::deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1108,7 +1122,8 @@ func TestServiceToken_InvalidCallerCellPattern_MetricLabel(t *testing.T) {
 	ts := fmt.Sprintf("%d", now.Unix())
 	crafted := ts + ":somenonce16bytes:Bad-Cell:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 		WithServiceTokenMetrics(am),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1141,7 +1156,8 @@ func TestServiceTokenMiddleware_LegacyThreePart_Rejected(t *testing.T) {
 	require.Len(t, oldThreePart, 2)
 	simulatedThreePart := oldThreePart[0] + ":aaabbbccc000111222333" + ":" + oldThreePart[1]
 
-	handler := ServiceTokenMiddleware(ring, clockmock.New(now),
+	handler := ServiceTokenMiddleware(
+		ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
 	)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -826,10 +827,10 @@ type spyCounter struct {
 	reason string
 }
 
-func (c *spyCounter) Inc() {
+func (c *spyCounter) Inc(_ context.Context) {
 	c.vec.recorded = append(c.vec.recorded, spyRecord{result: c.result, reason: c.reason})
 }
-func (c *spyCounter) Add(_ float64) {}
+func (c *spyCounter) Add(_ context.Context, _ float64) {}
 
 // spyProvider is a metrics.Provider that returns a spyCounterVec for the
 // service-token counter and no-ops for everything else.

--- a/runtime/bootstrap/metrics_wiring_test.go
+++ b/runtime/bootstrap/metrics_wiring_test.go
@@ -220,8 +220,8 @@ func TestAutoWire_CellLabel_FromCtxArg(t *testing.T) {
 
 	// Driving distinct cellIDs proves the collector does not cache one;
 	// each call emits the cellID it was given.
-	b.httpCollector.RecordRequest("accesscore", "GET", "/api/v1/users", 200, 0.05)
-	b.httpCollector.RecordRequest("_runtime", "GET", "/healthz", 200, 0.001)
+	b.httpCollector.RecordRequest(context.Background(), "accesscore", "GET", "/api/v1/users", 200, 0.05)
+	b.httpCollector.RecordRequest(context.Background(), "_runtime", "GET", "/healthz", 200, 0.001)
 
 	reqs := p.counter("http_requests_total")
 	require.NotNil(t, reqs, "http_requests_total must be registered")

--- a/runtime/bootstrap/phases_shutdown.go
+++ b/runtime/bootstrap/phases_shutdown.go
@@ -125,19 +125,19 @@ func (b *Bootstrap) phase10OrchestrateShutdown(s *phaseState, sig shutdownSignal
 	totalStart := b.clock.Now()
 
 	// --- stage 1: readiness flip ---
-	m.RecordPhaseEntry(metricsmiddleware.ShutdownPhaseReadinessFlip)
+	m.RecordPhaseEntry(drainCtx, metricsmiddleware.ShutdownPhaseReadinessFlip)
 	flipStart := b.clock.Now()
 	b.phase10ReadinessFlip(drainCtx, s)
-	m.ObservePhaseDuration(metricsmiddleware.ShutdownPhaseReadinessFlip, b.clock.Since(flipStart))
+	m.ObservePhaseDuration(drainCtx, metricsmiddleware.ShutdownPhaseReadinessFlip, b.clock.Since(flipStart))
 
 	// --- stage 2: HTTP drain (explicit; runs BEFORE LIFO teardown) ---
-	m.RecordPhaseEntry(metricsmiddleware.ShutdownPhaseHTTPDrain)
+	m.RecordPhaseEntry(drainCtx, metricsmiddleware.ShutdownPhaseHTTPDrain)
 	drainStart := b.clock.Now()
 	var httpDrainErr error
 	if s.httpDrain != nil {
 		httpDrainErr = s.httpDrain(drainCtx)
 	}
-	m.ObservePhaseDuration(metricsmiddleware.ShutdownPhaseHTTPDrain, b.clock.Since(drainStart))
+	m.ObservePhaseDuration(drainCtx, metricsmiddleware.ShutdownPhaseHTTPDrain, b.clock.Since(drainStart))
 
 	// --- stage 3: LIFO teardown — fresh tearCtx, independent of drainCtx ---
 	// A blocked HTTP drain cannot starve LIFO teardown of its budget; this
@@ -145,14 +145,14 @@ func (b *Bootstrap) phase10OrchestrateShutdown(s *phaseState, sig shutdownSignal
 	// TestPhase10_BudgetIsolation_LIFOTeardownGetsFreshCtx.
 	tearCtx, tearCancel := context.WithTimeout(context.Background(), b.shutdownTimeout)
 	defer tearCancel()
-	m.RecordPhaseEntry(metricsmiddleware.ShutdownPhaseLIFOTeardown)
+	m.RecordPhaseEntry(tearCtx, metricsmiddleware.ShutdownPhaseLIFOTeardown)
 	tearStart := b.clock.Now()
 	teardownErrs := b.phase10LIFOTeardown(tearCtx, s)
-	m.ObservePhaseDuration(metricsmiddleware.ShutdownPhaseLIFOTeardown, b.clock.Since(tearStart))
+	m.ObservePhaseDuration(tearCtx, metricsmiddleware.ShutdownPhaseLIFOTeardown, b.clock.Since(tearStart))
 
 	// --- stage 4: finalize ---
-	m.RecordPhaseEntry(metricsmiddleware.ShutdownPhaseClosed)
-	m.ObservePhaseDuration(metricsmiddleware.ShutdownPhaseTotal, b.clock.Since(totalStart))
+	m.RecordPhaseEntry(tearCtx, metricsmiddleware.ShutdownPhaseClosed)
+	m.ObservePhaseDuration(tearCtx, metricsmiddleware.ShutdownPhaseTotal, b.clock.Since(totalStart))
 
 	// Aggregate HTTP drain error with LIFO teardown errors. HTTP drain is
 	// best-effort just like LIFO: a failure here does not prevent backend
@@ -185,7 +185,7 @@ func (b *Bootstrap) phase10OrchestrateShutdown(s *phaseState, sig shutdownSignal
 	case sig.err != nil:
 		outcome = "signal_error"
 	}
-	m.CountOutcome(outcome)
+	m.CountOutcome(tearCtx, outcome)
 
 	// Safety net: cancel runCtx after all teardowns complete so any goroutine
 	// still holding runCtx eventually unblocks.

--- a/runtime/bootstrap/shutdown_metrics_test.go
+++ b/runtime/bootstrap/shutdown_metrics_test.go
@@ -62,8 +62,8 @@ type fakeCounter struct {
 	labels kernelmetrics.Labels
 }
 
-func (c *fakeCounter) Inc() { c.Add(1) }
-func (c *fakeCounter) Add(delta float64) {
+func (c *fakeCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c *fakeCounter) Add(_ context.Context, delta float64) {
 	c.vec.mu.Lock()
 	defer c.vec.mu.Unlock()
 	c.vec.records = append(c.vec.records, fakeCounterRecord{labels: c.labels, delta: delta})
@@ -104,7 +104,7 @@ type fakeHistogram struct {
 	labels kernelmetrics.Labels
 }
 
-func (h *fakeHistogram) Observe(value float64) {
+func (h *fakeHistogram) Observe(_ context.Context, value float64) {
 	h.vec.mu.Lock()
 	defer h.vec.mu.Unlock()
 	h.vec.records = append(h.vec.records, fakeHistogramRecord{labels: h.labels, value: value})

--- a/runtime/command/lifecycle.go
+++ b/runtime/command/lifecycle.go
@@ -310,7 +310,7 @@ func (l *SweeperLifecycle) runLoop(
 					slog.String("cell", l.cellID()),
 					slog.Any("error", err))
 				if l.SweepErrorCounter != nil {
-					l.SweepErrorCounter.With(kernelmetrics.Labels{"cell": l.cellID()}).Inc()
+					l.SweepErrorCounter.With(kernelmetrics.Labels{"cell": l.cellID()}).Inc(runCtx)
 				}
 			}
 		}

--- a/runtime/command/metricsspy_test.go
+++ b/runtime/command/metricsspy_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -97,8 +98,8 @@ type testCounter struct {
 	obs *atomic.Int64
 }
 
-func (c *testCounter) Inc()              { c.obs.Add(1) }
-func (c *testCounter) Add(delta float64) { c.obs.Add(int64(delta)) }
+func (c *testCounter) Inc(_ context.Context)                { c.obs.Add(1) }
+func (c *testCounter) Add(_ context.Context, delta float64) { c.obs.Add(int64(delta)) }
 
 // labelsKey produces a deterministic string key for a label set (sorted keys).
 func labelsKey(labels map[string]string) string {

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -373,7 +373,7 @@ func (r *Router) Run(ctx context.Context) error {
 			slog.String("topic", sf.topic),
 			slog.Any("error", sf.err))
 		observability.SafeObserve(slog.Default(), func() {
-			r.collector.RecordRuntimeError(sf.cellID, sf.topic, RuntimeErrorReasonRuntimeFault)
+			r.collector.RecordRuntimeError(runCtx, sf.cellID, sf.topic, RuntimeErrorReasonRuntimeFault)
 		})
 		cancel()
 		r.wg.Wait()
@@ -398,7 +398,7 @@ func (r *Router) runSetup(ctx context.Context, cancel context.CancelFunc, handle
 				slog.String("cell_id", sub.CellID),
 				slog.Any("error", err))
 			observability.SafeObserve(slog.Default(), func() {
-				r.collector.RecordSetupError(sub.CellID, sub.Topic, SetupErrorReasonSetupError)
+				r.collector.RecordSetupError(ctx, sub.CellID, sub.Topic, SetupErrorReasonSetupError)
 			})
 			cancel()
 			return wrapped
@@ -500,7 +500,7 @@ func (r *Router) runAwaitReady(
 			slog.String("reason", sf.reason),
 			slog.Any("error", sf.err))
 		observability.SafeObserve(slog.Default(), func() {
-			r.collector.RecordSetupError(sf.cellID, sf.topic, sf.reason)
+			r.collector.RecordSetupError(ctx, sf.cellID, sf.topic, sf.reason)
 		})
 		cancel()
 		r.wg.Wait()
@@ -516,7 +516,7 @@ func (r *Router) runAwaitReady(
 			notReady[i] = fmt.Sprintf("%s/%s/%s", h.cellID, h.consumerGroup, h.topic)
 			hCopy := h
 			observability.SafeObserve(slog.Default(), func() {
-				r.collector.RecordSetupError(hCopy.cellID, hCopy.topic, SetupErrorReasonReadyTimeout)
+				r.collector.RecordSetupError(ctx, hCopy.cellID, hCopy.topic, SetupErrorReasonReadyTimeout)
 			})
 		}
 		err := fmt.Errorf("eventrouter: %d/%d subscriptions not ready after %s: %v",
@@ -567,10 +567,10 @@ func (r *Router) awaitAllReady(ctx context.Context, handlers []handlerConfig) <-
 			case <-r.subscriber.Ready(sub):
 				elapsed := r.clock.Since(start)
 				observability.SafeObserve(slog.Default(), func() {
-					r.collector.ObserveReadyWait(sub.CellID, elapsed)
+					r.collector.ObserveReadyWait(ctx, sub.CellID, elapsed)
 				})
 				observability.SafeObserve(slog.Default(), func() {
-					r.collector.IncSubscriptionActive(sub.CellID)
+					r.collector.IncSubscriptionActive(ctx, sub.CellID)
 				})
 				r.activeMu.Lock()
 				r.activeCells = append(r.activeCells, sub.CellID)
@@ -727,7 +727,7 @@ func (r *Router) Close(ctx context.Context) error {
 	for _, cellID := range activeCells {
 		cid := cellID
 		observability.SafeObserve(slog.Default(), func() {
-			r.collector.DecSubscriptionActive(cid)
+			r.collector.DecSubscriptionActive(ctx, cid)
 		})
 	}
 

--- a/runtime/eventrouter/router_observability.go
+++ b/runtime/eventrouter/router_observability.go
@@ -1,6 +1,9 @@
 package eventrouter
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // RuntimeErrorReason is the type-safe closed-set for RecordRuntimeError's
 // reason argument. Using a named type prevents callers from passing arbitrary
@@ -15,17 +18,17 @@ type RuntimeErrorReason string
 // ref: ThreeDotsLabs/watermill router metrics middleware — subscription lifecycle
 // counters and gauges matching router_messages_processed_total / router_handler_active.
 type EventCollector interface {
-	IncSubscriptionActive(cellID string)
-	DecSubscriptionActive(cellID string)
-	RecordSetupError(cellID, topic, reason string)
-	ObserveReadyWait(cellID string, d time.Duration)
+	IncSubscriptionActive(ctx context.Context, cellID string)
+	DecSubscriptionActive(ctx context.Context, cellID string)
+	RecordSetupError(ctx context.Context, cellID, topic, reason string)
+	ObserveReadyWait(ctx context.Context, cellID string, d time.Duration)
 	// RecordRuntimeError records a runtime-phase fault for the given cell+topic.
 	// reason is a closed-set value drawn from RuntimeErrorReason* constants;
 	// the typed parameter prevents callers from drifting to free-form strings.
 	// Phase 4 owner — any failure detected after Running() closes is recorded
 	// here as runtime_fault. Phase 1–3 failures live on the setup metric via
 	// RecordSetupError (PR #593 review fix-up P2#3).
-	RecordRuntimeError(cellID, topic string, reason RuntimeErrorReason)
+	RecordRuntimeError(ctx context.Context, cellID, topic string, reason RuntimeErrorReason)
 }
 
 // SetupErrorReason* are the closed-set values passed to
@@ -81,26 +84,26 @@ const (
 type NopEventCollector struct{}
 
 // IncSubscriptionActive is a no-op for NopEventCollector (default when no metrics backend is wired).
-func (NopEventCollector) IncSubscriptionActive(string) {
+func (NopEventCollector) IncSubscriptionActive(_ context.Context, _ string) {
 	// intentional no-op: null-object pattern (Sonar S1186 — explicit body comment).
 }
 
 // DecSubscriptionActive is a no-op for NopEventCollector (default when no metrics backend is wired).
-func (NopEventCollector) DecSubscriptionActive(string) {
+func (NopEventCollector) DecSubscriptionActive(_ context.Context, _ string) {
 	// intentional no-op: null-object pattern (Sonar S1186 — explicit body comment).
 }
 
 // RecordSetupError is a no-op for NopEventCollector (default when no metrics backend is wired).
-func (NopEventCollector) RecordSetupError(string, string, string) {
+func (NopEventCollector) RecordSetupError(_ context.Context, _, _, _ string) {
 	// intentional no-op: null-object pattern (Sonar S1186 — explicit body comment).
 }
 
 // ObserveReadyWait is a no-op for NopEventCollector (default when no metrics backend is wired).
-func (NopEventCollector) ObserveReadyWait(string, time.Duration) {
+func (NopEventCollector) ObserveReadyWait(_ context.Context, _ string, _ time.Duration) {
 	// intentional no-op: null-object pattern (Sonar S1186 — explicit body comment).
 }
 
 // RecordRuntimeError is a no-op for NopEventCollector (default when no metrics backend is wired).
-func (NopEventCollector) RecordRuntimeError(string, string, RuntimeErrorReason) {
+func (NopEventCollector) RecordRuntimeError(_ context.Context, _, _ string, _ RuntimeErrorReason) {
 	// intentional no-op: null-object pattern (Sonar S1186 — explicit body comment).
 }

--- a/runtime/eventrouter/router_observability_test.go
+++ b/runtime/eventrouter/router_observability_test.go
@@ -43,31 +43,31 @@ type spyEventCollector struct {
 	readyWaits    []spyDuration
 }
 
-func (s *spyEventCollector) IncSubscriptionActive(cellID string) {
+func (s *spyEventCollector) IncSubscriptionActive(_ context.Context, cellID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.inc = append(s.inc, cellID)
 }
 
-func (s *spyEventCollector) DecSubscriptionActive(cellID string) {
+func (s *spyEventCollector) DecSubscriptionActive(_ context.Context, cellID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.dec = append(s.dec, cellID)
 }
 
-func (s *spyEventCollector) RecordSetupError(cellID, topic, reason string) {
+func (s *spyEventCollector) RecordSetupError(_ context.Context, cellID, topic, reason string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.setupErrors = append(s.setupErrors, spyEvent{cellID: cellID, topic: topic, reason: reason})
 }
 
-func (s *spyEventCollector) RecordRuntimeError(cellID, topic string, reason RuntimeErrorReason) {
+func (s *spyEventCollector) RecordRuntimeError(_ context.Context, cellID, topic string, reason RuntimeErrorReason) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.runtimeErrors = append(s.runtimeErrors, spyEvent{cellID: cellID, topic: topic, reason: string(reason)})
 }
 
-func (s *spyEventCollector) ObserveReadyWait(cellID string, d time.Duration) {
+func (s *spyEventCollector) ObserveReadyWait(_ context.Context, cellID string, d time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.readyWaits = append(s.readyWaits, spyDuration{cellID: cellID, duration: d})
@@ -431,23 +431,23 @@ func TestRouter_RecordRuntimeError_RuntimeFault(t *testing.T) {
 // panicEventCollector panics on every method call.
 type panicEventCollector struct{}
 
-func (panicEventCollector) IncSubscriptionActive(_ string) {
+func (panicEventCollector) IncSubscriptionActive(_ context.Context, _ string) {
 	panic("panicEventCollector: IncSubscriptionActive panics")
 }
 
-func (panicEventCollector) DecSubscriptionActive(_ string) {
+func (panicEventCollector) DecSubscriptionActive(_ context.Context, _ string) {
 	panic("panicEventCollector: DecSubscriptionActive panics")
 }
 
-func (panicEventCollector) RecordSetupError(_, _, _ string) {
+func (panicEventCollector) RecordSetupError(_ context.Context, _, _, _ string) {
 	panic("panicEventCollector: RecordSetupError panics")
 }
 
-func (panicEventCollector) ObserveReadyWait(_ string, _ time.Duration) {
+func (panicEventCollector) ObserveReadyWait(_ context.Context, _ string, _ time.Duration) {
 	panic("panicEventCollector: ObserveReadyWait panics")
 }
 
-func (panicEventCollector) RecordRuntimeError(_, _ string, _ RuntimeErrorReason) {
+func (panicEventCollector) RecordRuntimeError(_ context.Context, _, _ string, _ RuntimeErrorReason) {
 	panic("panicEventCollector: RecordRuntimeError panics")
 }
 

--- a/runtime/http/middleware/metrics.go
+++ b/runtime/http/middleware/metrics.go
@@ -54,7 +54,7 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Ha
 				if v, ok := ctxkeys.CellIDFrom(r.Context()); ok && v != "" {
 					cellID = v
 				}
-				collector.RecordRequest(cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
+				collector.RecordRequest(r.Context(), cellID, r.Method, route, state.Status(), clk.Since(start).Seconds())
 			})
 		})
 	}

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -7,6 +7,7 @@
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
@@ -29,7 +30,7 @@ type Collector interface {
 	// Use the owning cell ID for cell-owned RouteGroups, or "_runtime" for
 	// framework-owned paths (healthz/readyz/metrics, unmatched 404s, listeners
 	// with no business RouteGroup attached).
-	RecordRequest(cellID, method, route string, status int, durationSeconds float64)
+	RecordRequest(ctx context.Context, cellID, method, route string, status int, durationSeconds float64)
 }
 
 // RequestKey identifies one low-cardinality HTTP request metric series.
@@ -67,7 +68,7 @@ func metricKey(cellID, method, route string, status int) RequestKey {
 }
 
 // RecordRequest records a completed HTTP request.
-func (c *InMemoryCollector) RecordRequest(cellID, method, route string, status int, durationSeconds float64) {
+func (c *InMemoryCollector) RecordRequest(_ context.Context, cellID, method, route string, status int, durationSeconds float64) {
 	key := metricKey(cellID, method, route, status)
 
 	c.mu.RLock()

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -12,12 +13,13 @@ import (
 )
 
 func TestInMemoryCollector_Handler(t *testing.T) {
+	ctx := context.Background()
 	c := NewInMemoryCollector()
-	c.RecordRequest("auditcore", http.MethodPost, "/z", 500, 0.004)
-	c.RecordRequest("accesscore", http.MethodPost, "/api", 201, 0.1)
-	c.RecordRequest("accesscore", http.MethodGet, "/api", 200, 0.05)
-	c.RecordRequest("accesscore", http.MethodGet, "/api", 200, 0.03)
-	c.RecordRequest("accesscore", http.MethodGet, "/admin", 404, 0.002)
+	c.RecordRequest(ctx, "auditcore", http.MethodPost, "/z", 500, 0.004)
+	c.RecordRequest(ctx, "accesscore", http.MethodPost, "/api", 201, 0.1)
+	c.RecordRequest(ctx, "accesscore", http.MethodGet, "/api", 200, 0.05)
+	c.RecordRequest(ctx, "accesscore", http.MethodGet, "/api", 200, 0.03)
+	c.RecordRequest(ctx, "accesscore", http.MethodGet, "/admin", 404, 0.002)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -49,9 +51,10 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 }
 
 func TestInMemoryCollector_Snapshot(t *testing.T) {
+	ctx := context.Background()
 	c := NewInMemoryCollector()
-	c.RecordRequest("accesscore", "GET", "/a", 200, 0.001)
-	c.RecordRequest("accesscore", "GET", "/a", 200, 0.002)
+	c.RecordRequest(ctx, "accesscore", "GET", "/a", 200, 0.001)
+	c.RecordRequest(ctx, "accesscore", "GET", "/a", 200, 0.002)
 
 	snap := c.Snapshot()
 	key := RequestKey{Cell: "accesscore", Method: "GET", Route: "/a", Status: 200}
@@ -60,9 +63,10 @@ func TestInMemoryCollector_Snapshot(t *testing.T) {
 }
 
 func TestInMemoryCollector_PerCellSeparation(t *testing.T) {
+	ctx := context.Background()
 	c := NewInMemoryCollector()
-	c.RecordRequest("accesscore", "GET", "/api/v1/sessions", 200, 0.001)
-	c.RecordRequest("auditcore", "GET", "/api/v1/sessions", 200, 0.002)
+	c.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.001)
+	c.RecordRequest(ctx, "auditcore", "GET", "/api/v1/sessions", 200, 0.002)
 
 	snap := c.Snapshot()
 	assert.Equal(t, int64(1), snap.RequestCounts[RequestKey{

--- a/runtime/observability/metrics/config_event_collector.go
+++ b/runtime/observability/metrics/config_event_collector.go
@@ -22,19 +22,19 @@ const (
 
 // ConfigEventCollector records config event process and settlement metrics.
 type ConfigEventCollector interface {
-	RecordEventProcess(cellID, sliceID string, reason ConfigEventProcessReason)
-	RecordEventSettlement(cellID, sliceID, disposition string, result outbox.SettlementResult)
+	RecordEventProcess(ctx context.Context, cellID, sliceID string, reason ConfigEventProcessReason)
+	RecordEventSettlement(ctx context.Context, cellID, sliceID, disposition string, result outbox.SettlementResult)
 }
 
 // NoopConfigEventCollector drops config event observations.
 type NoopConfigEventCollector struct{}
 
-func (NoopConfigEventCollector) RecordEventProcess(string, string, ConfigEventProcessReason) {
+func (NoopConfigEventCollector) RecordEventProcess(_ context.Context, _, _ string, _ ConfigEventProcessReason) {
 	// Intentionally empty: callers can inject this collector when config-event
 	// metrics are disabled while keeping service code free of nil checks.
 }
 
-func (NoopConfigEventCollector) RecordEventSettlement(string, string, string, outbox.SettlementResult) {
+func (NoopConfigEventCollector) RecordEventSettlement(_ context.Context, _, _, _ string, _ outbox.SettlementResult) {
 	// Intentionally empty: callers can inject this collector when config-event
 	// metrics are disabled while keeping service code free of nil checks.
 }
@@ -72,7 +72,7 @@ func NewProviderConfigEventCollector(p kernelmetrics.Provider) (ConfigEventColle
 	return &providerConfigEventCollector{process: process, settlement: settlement}, nil
 }
 
-func (c *providerConfigEventCollector) RecordEventProcess(cellID, sliceID string, reason ConfigEventProcessReason) {
+func (c *providerConfigEventCollector) RecordEventProcess(ctx context.Context, cellID, sliceID string, reason ConfigEventProcessReason) {
 	if c == nil {
 		return
 	}
@@ -80,10 +80,12 @@ func (c *providerConfigEventCollector) RecordEventProcess(cellID, sliceID string
 		"cell":   cellID,
 		"slice":  sliceID,
 		"reason": string(reason),
-	}).Inc()
+	}).Inc(ctx)
 }
 
-func (c *providerConfigEventCollector) RecordEventSettlement(cellID, sliceID, disposition string, result outbox.SettlementResult) {
+func (c *providerConfigEventCollector) RecordEventSettlement(
+	ctx context.Context, cellID, sliceID, disposition string, result outbox.SettlementResult,
+) {
 	if c == nil {
 		return
 	}
@@ -92,7 +94,7 @@ func (c *providerConfigEventCollector) RecordEventSettlement(cellID, sliceID, di
 		"slice":       sliceID,
 		"disposition": disposition,
 		"result":      string(result),
-	}).Inc()
+	}).Inc(ctx)
 }
 
 type configEventOwner struct {
@@ -112,7 +114,7 @@ func RecordConfigEventProcess(ctx context.Context, collector ConfigEventCollecto
 	if !ok || owner.cellID == "" || owner.sliceID == "" {
 		return
 	}
-	collector.RecordEventProcess(owner.cellID, owner.sliceID, reason)
+	collector.RecordEventProcess(ctx, owner.cellID, owner.sliceID, reason)
 }
 
 // ConfigEventMiddleware installs config-event owner metadata for process
@@ -182,6 +184,6 @@ type configEventSettlementObserver struct {
 	owner     configEventOwner
 }
 
-func (o configEventSettlementObserver) ObserveSettlement(_ context.Context, obs outbox.SettlementObservation) {
-	o.collector.RecordEventSettlement(o.owner.cellID, o.owner.sliceID, obs.Disposition.String(), obs.Result)
+func (o configEventSettlementObserver) ObserveSettlement(ctx context.Context, obs outbox.SettlementObservation) {
+	o.collector.RecordEventSettlement(ctx, o.owner.cellID, o.owner.sliceID, obs.Disposition.String(), obs.Result)
 }

--- a/runtime/observability/metrics/config_event_collector_test.go
+++ b/runtime/observability/metrics/config_event_collector_test.go
@@ -20,11 +20,12 @@ func TestProviderConfigEventCollector_RejectsNilProvider(t *testing.T) {
 }
 
 func TestProviderConfigEventCollector_NopProviderNoPanic(t *testing.T) {
+	ctx := context.Background()
 	collector, err := obmetrics.NewProviderConfigEventCollector(kernelmetrics.NopProvider{})
 	require.NoError(t, err)
 
-	collector.RecordEventProcess("accesscore", "configreceive", obmetrics.ConfigEventProcessReasonAck)
-	collector.RecordEventSettlement("configcore", "configsubscribe", "requeue", outbox.SettlementResultCommitFailed)
+	collector.RecordEventProcess(ctx, "accesscore", "configreceive", obmetrics.ConfigEventProcessReasonAck)
+	collector.RecordEventSettlement(ctx, "configcore", "configsubscribe", "requeue", outbox.SettlementResultCommitFailed)
 }
 
 func TestProviderConfigEventCollector_ReturnsRegistrationError(t *testing.T) {
@@ -35,12 +36,13 @@ func TestProviderConfigEventCollector_ReturnsRegistrationError(t *testing.T) {
 }
 
 func TestProviderConfigEventCollector_EmitsExpectedMetricsAndLabels(t *testing.T) {
+	ctx := context.Background()
 	p := newSpyProvider()
 	collector, err := obmetrics.NewProviderConfigEventCollector(p)
 	require.NoError(t, err)
 
-	collector.RecordEventProcess("accesscore", "configreceive", obmetrics.ConfigEventProcessReasonStale)
-	collector.RecordEventSettlement("accesscore", "configreceive", "ack", outbox.SettlementResultSuccess)
+	collector.RecordEventProcess(ctx, "accesscore", "configreceive", obmetrics.ConfigEventProcessReasonStale)
+	collector.RecordEventSettlement(ctx, "accesscore", "configreceive", "ack", outbox.SettlementResultSuccess)
 
 	processOps := p.counterOps["config_event_process_total"]
 	require.Len(t, processOps, 1)
@@ -142,11 +144,15 @@ type configEventSettlementRecord struct {
 	result      outbox.SettlementResult
 }
 
-func (c *recordingConfigEventCollector) RecordEventProcess(cellID, sliceID string, reason obmetrics.ConfigEventProcessReason) {
+func (c *recordingConfigEventCollector) RecordEventProcess(
+	_ context.Context, cellID, sliceID string, reason obmetrics.ConfigEventProcessReason,
+) {
 	c.processRecords = append(c.processRecords, configEventProcessRecord{cell: cellID, slice: sliceID, reason: reason})
 }
 
-func (c *recordingConfigEventCollector) RecordEventSettlement(cellID, sliceID, disposition string, result outbox.SettlementResult) {
+func (c *recordingConfigEventCollector) RecordEventSettlement(
+	_ context.Context, cellID, sliceID, disposition string, result outbox.SettlementResult,
+) {
 	c.settlementRecords = append(c.settlementRecords,
 		configEventSettlementRecord{cell: cellID, slice: sliceID, disposition: disposition, result: result})
 }

--- a/runtime/observability/metrics/event.go
+++ b/runtime/observability/metrics/event.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -112,19 +113,19 @@ func NewEventRouterCollector(p kernelmetrics.Provider) (*EventRouterCollector, e
 }
 
 // IncSubscriptionActive increments the active subscription gauge for cellID.
-func (c *EventRouterCollector) IncSubscriptionActive(cellID string) {
+func (c *EventRouterCollector) IncSubscriptionActive(ctx context.Context, cellID string) {
 	if c == nil {
 		return
 	}
-	c.active.With(kernelmetrics.Labels{"cell": cellID}).Inc()
+	c.active.With(kernelmetrics.Labels{"cell": cellID}).Inc(ctx)
 }
 
 // DecSubscriptionActive decrements the active subscription gauge for cellID.
-func (c *EventRouterCollector) DecSubscriptionActive(cellID string) {
+func (c *EventRouterCollector) DecSubscriptionActive(ctx context.Context, cellID string) {
 	if c == nil {
 		return
 	}
-	c.active.With(kernelmetrics.Labels{"cell": cellID}).Dec()
+	c.active.With(kernelmetrics.Labels{"cell": cellID}).Dec(ctx)
 }
 
 // RecordSetupError increments the setup error counter for the given cell, topic
@@ -134,7 +135,7 @@ func (c *EventRouterCollector) DecSubscriptionActive(cellID string) {
 //   - eventrouter.SetupErrorReasonPanic ("panic"): subscription goroutine panicked (Phase 2)
 //   - eventrouter.SetupErrorReasonReadyTimeout ("ready_timeout"): Ready not signaled within timeout (Phase 3)
 //   - eventrouter.SetupErrorReasonSubscribeFailure ("subscribe_failure"): SubscribeEntry failed before Running() (Phase 3)
-func (c *EventRouterCollector) RecordSetupError(cellID, topic, reason string) {
+func (c *EventRouterCollector) RecordSetupError(ctx context.Context, cellID, topic, reason string) {
 	if c == nil {
 		return
 	}
@@ -142,22 +143,22 @@ func (c *EventRouterCollector) RecordSetupError(cellID, topic, reason string) {
 		"cell":   cellID,
 		"topic":  topic,
 		"reason": reason,
-	}).Inc()
+	}).Inc(ctx)
 }
 
 // ObserveReadyWait records the duration waited for the Ready signal on cellID.
-func (c *EventRouterCollector) ObserveReadyWait(cellID string, d time.Duration) {
+func (c *EventRouterCollector) ObserveReadyWait(ctx context.Context, cellID string, d time.Duration) {
 	if c == nil {
 		return
 	}
-	c.readyWait.With(kernelmetrics.Labels{"cell": cellID}).Observe(d.Seconds())
+	c.readyWait.With(kernelmetrics.Labels{"cell": cellID}).Observe(ctx, d.Seconds())
 }
 
 // RecordRuntimeError increments the runtime error counter for the given cell,
 // topic, and reason. The reason argument is drawn from the closed set defined
 // by the eventrouter package constants:
 //   - eventrouter.RuntimeErrorReasonRuntimeFault ("runtime_fault"): any fault detected in Phase 4
-func (c *EventRouterCollector) RecordRuntimeError(cellID, topic string, reason eventrouter.RuntimeErrorReason) {
+func (c *EventRouterCollector) RecordRuntimeError(ctx context.Context, cellID, topic string, reason eventrouter.RuntimeErrorReason) {
 	if c == nil {
 		return
 	}
@@ -165,5 +166,5 @@ func (c *EventRouterCollector) RecordRuntimeError(cellID, topic string, reason e
 		"cell":   cellID,
 		"topic":  topic,
 		"reason": string(reason),
-	}).Inc()
+	}).Inc(ctx)
 }

--- a/runtime/observability/metrics/event_test.go
+++ b/runtime/observability/metrics/event_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -42,7 +43,7 @@ func TestEventRouterCollector_IncSubscriptionActive_EmitsGaugeLabel(t *testing.T
 		t.Fatalf("NewEventRouterCollector: %v", err)
 	}
 
-	c.IncSubscriptionActive("accesscore")
+	c.IncSubscriptionActive(context.Background(), "accesscore")
 
 	ops := p.gaugeOps["event_router_subscriptions_active"]
 	if len(ops) != 1 {
@@ -60,7 +61,7 @@ func TestEventRouterCollector_DecSubscriptionActive_EmitsGaugeLabel(t *testing.T
 		t.Fatalf("NewEventRouterCollector: %v", err)
 	}
 
-	c.DecSubscriptionActive("configcore")
+	c.DecSubscriptionActive(context.Background(), "configcore")
 
 	ops := p.gaugeOps["event_router_subscriptions_active"]
 	if len(ops) != 1 {
@@ -78,7 +79,7 @@ func TestEventRouterCollector_RecordSetupError_EmitsCounterLabels(t *testing.T) 
 		t.Fatalf("NewEventRouterCollector: %v", err)
 	}
 
-	c.RecordSetupError("auditcore", "event.audit.appended.v1", "dial_timeout")
+	c.RecordSetupError(context.Background(), "auditcore", "event.audit.appended.v1", "dial_timeout")
 
 	ops := p.counterOps["event_router_setup_errors_total"]
 	if len(ops) != 1 {
@@ -103,7 +104,7 @@ func TestEventRouterCollector_ObserveReadyWait_EmitsHistogramLabel(t *testing.T)
 		t.Fatalf("NewEventRouterCollector: %v", err)
 	}
 
-	c.ObserveReadyWait("accesscore", testReadyWaitDuration)
+	c.ObserveReadyWait(context.Background(), "accesscore", testReadyWaitDuration)
 
 	ops := p.histogramOps["event_router_ready_wait_seconds"]
 	if len(ops) != 1 {
@@ -120,11 +121,12 @@ func TestEventRouterCollector_ObserveReadyWait_EmitsHistogramLabel(t *testing.T)
 }
 
 func TestEventRouterCollector_NilReceiverDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
 	var c *obmetrics.EventRouterCollector
-	c.IncSubscriptionActive("cell")
-	c.DecSubscriptionActive("cell")
-	c.RecordSetupError("cell", "topic", "reason")
-	c.ObserveReadyWait("cell", time.Second)
+	c.IncSubscriptionActive(ctx, "cell")
+	c.DecSubscriptionActive(ctx, "cell")
+	c.RecordSetupError(ctx, "cell", "topic", "reason")
+	c.ObserveReadyWait(ctx, "cell", time.Second)
 }
 
 func TestNewEventRouterCollector_RollbackOnPartialFailure(t *testing.T) {
@@ -233,8 +235,8 @@ type eventSpyCounter struct {
 	labels kernelmetrics.Labels
 }
 
-func (c *eventSpyCounter) Inc() { c.Add(1) }
-func (c *eventSpyCounter) Add(d float64) {
+func (c *eventSpyCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c *eventSpyCounter) Add(_ context.Context, d float64) {
 	c.parent.counterOps[c.name] = append(c.parent.counterOps[c.name], eventSpyRecord{labels: c.labels, value: d})
 }
 
@@ -244,7 +246,7 @@ type eventSpyHistogram struct {
 	labels kernelmetrics.Labels
 }
 
-func (h *eventSpyHistogram) Observe(v float64) {
+func (h *eventSpyHistogram) Observe(_ context.Context, v float64) {
 	h.parent.histogramOps[h.name] = append(h.parent.histogramOps[h.name], eventSpyRecord{labels: h.labels, value: v})
 }
 
@@ -254,12 +256,12 @@ type eventSpyGauge struct {
 	labels kernelmetrics.Labels
 }
 
-func (g *eventSpyGauge) Set(v float64) {
+func (g *eventSpyGauge) Set(_ context.Context, v float64) {
 	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], eventSpyRecord{labels: g.labels, value: v})
 }
-func (g *eventSpyGauge) Inc()          { g.Add(1) }
-func (g *eventSpyGauge) Dec()          { g.Add(-1) }
-func (g *eventSpyGauge) Add(d float64) { g.Set(d) }
+func (g *eventSpyGauge) Inc(ctx context.Context)            { g.Add(ctx, 1) }
+func (g *eventSpyGauge) Dec(ctx context.Context)            { g.Add(ctx, -1) }
+func (g *eventSpyGauge) Add(ctx context.Context, d float64) { g.Set(ctx, d) }
 
 // ---------------------------------------------------------------------------
 // eventPartialFailProvider: configurable partial failure for rollback tests.

--- a/runtime/observability/metrics/eventbus_cache.go
+++ b/runtime/observability/metrics/eventbus_cache.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -9,13 +10,13 @@ import (
 
 // EventbusCacheCollector records eventbus subscriber-cache lifecycle metrics.
 type EventbusCacheCollector interface {
-	RecordTombstoneEvicted(cellID, sliceID string)
+	RecordTombstoneEvicted(ctx context.Context, cellID, sliceID string)
 }
 
 // NoopEventbusCacheCollector drops eventbus cache observations.
 type NoopEventbusCacheCollector struct{}
 
-func (NoopEventbusCacheCollector) RecordTombstoneEvicted(string, string) {
+func (NoopEventbusCacheCollector) RecordTombstoneEvicted(_ context.Context, _, _ string) {
 	// Intentionally empty: callers can inject this collector when eventbus-cache
 	// metrics are disabled while keeping service code free of nil checks.
 }
@@ -44,9 +45,9 @@ func NewProviderEventbusCacheCollector(p kernelmetrics.Provider) (EventbusCacheC
 	return &providerEventbusCacheCollector{tombstoneEvicted: tombstoneEvicted}, nil
 }
 
-func (c *providerEventbusCacheCollector) RecordTombstoneEvicted(cellID, sliceID string) {
+func (c *providerEventbusCacheCollector) RecordTombstoneEvicted(ctx context.Context, cellID, sliceID string) {
 	if c == nil {
 		return
 	}
-	c.tombstoneEvicted.With(kernelmetrics.Labels{"cell": cellID, "slice": sliceID}).Inc()
+	c.tombstoneEvicted.With(kernelmetrics.Labels{"cell": cellID, "slice": sliceID}).Inc(ctx)
 }

--- a/runtime/observability/metrics/eventbus_cache_test.go
+++ b/runtime/observability/metrics/eventbus_cache_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,10 +18,11 @@ func TestProviderEventbusCacheCollector_RejectsNilProvider(t *testing.T) {
 }
 
 func TestProviderEventbusCacheCollector_NopProviderNoPanic(t *testing.T) {
+	ctx := context.Background()
 	collector, err := obmetrics.NewProviderEventbusCacheCollector(kernelmetrics.NopProvider{})
 	require.NoError(t, err)
 
-	collector.RecordTombstoneEvicted("configcore", "configsubscribe")
+	collector.RecordTombstoneEvicted(ctx, "configcore", "configsubscribe")
 }
 
 func TestProviderEventbusCacheCollector_ReturnsRegistrationError(t *testing.T) {
@@ -31,18 +33,19 @@ func TestProviderEventbusCacheCollector_ReturnsRegistrationError(t *testing.T) {
 }
 
 func TestProviderEventbusCacheCollector_EmitsExpectedMetricAndLabels(t *testing.T) {
+	ctx := context.Background()
 	p := newSpyProvider()
 	collector, err := obmetrics.NewProviderEventbusCacheCollector(p)
 	require.NoError(t, err)
 
-	collector.RecordTombstoneEvicted("configcore", "configsubscribe")
+	collector.RecordTombstoneEvicted(ctx, "configcore", "configsubscribe")
 
 	ops := p.counterOps["eventbus_cache_tombstone_evicted_total"]
 	require.Len(t, ops, 1)
 	assert.Equal(t, kernelmetrics.Labels{"cell": "configcore", "slice": "configsubscribe"}, ops[0].labels)
 	assert.Equal(t, 1.0, ops[0].value)
 
-	collector.RecordTombstoneEvicted("configcore", "configsubscribe")
+	collector.RecordTombstoneEvicted(ctx, "configcore", "configsubscribe")
 
 	ops = p.counterOps["eventbus_cache_tombstone_evicted_total"]
 	require.Len(t, ops, 2)
@@ -50,5 +53,5 @@ func TestProviderEventbusCacheCollector_EmitsExpectedMetricAndLabels(t *testing.
 }
 
 func TestNoopEventbusCacheCollector_NoPanic(t *testing.T) {
-	obmetrics.NoopEventbusCacheCollector{}.RecordTombstoneEvicted("a", "b")
+	obmetrics.NoopEventbusCacheCollector{}.RecordTombstoneEvicted(context.Background(), "a", "b")
 }

--- a/runtime/observability/metrics/outbox.go
+++ b/runtime/observability/metrics/outbox.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -59,7 +60,7 @@ func NewOutboxRejectCollector(p kernelmetrics.Provider) (*OutboxRejectCollector,
 //
 // Caller contract: topic MUST be a static contract identifier (ContractSpec.Topic).
 // Passing runtime-derived values (message IDs, tenant IDs) causes unbounded cardinality.
-func (c *OutboxRejectCollector) ObserveReject(cellID, topic, _ /* consumerGroup */, reason string) {
+func (c *OutboxRejectCollector) ObserveReject(ctx context.Context, cellID, topic, _ /* consumerGroup */, reason string) {
 	if c == nil {
 		return // nil-receiver safe: observability must never panic on startup
 	}
@@ -67,7 +68,7 @@ func (c *OutboxRejectCollector) ObserveReject(cellID, topic, _ /* consumerGroup 
 		"cell":   cellID,
 		"topic":  topic,
 		"reason": reason,
-	}).Inc()
+	}).Inc(ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -135,9 +136,9 @@ func NewOutboxPendingDepthCollector(p kernelmetrics.Provider, cellID string) (*O
 
 // ObservePendingDepth implements runtimeoutbox.PendingDepthObserver.
 // Records the current pending outbox depth for the owner cell.
-func (c *OutboxPendingDepthCollector) ObservePendingDepth(n int64) {
+func (c *OutboxPendingDepthCollector) ObservePendingDepth(ctx context.Context, n int64) {
 	if c == nil {
 		return
 	}
-	c.pending.With(kernelmetrics.Labels{"cell": c.cellID}).Set(float64(n))
+	c.pending.With(kernelmetrics.Labels{"cell": c.cellID}).Set(ctx, float64(n))
 }

--- a/runtime/observability/metrics/outbox_test.go
+++ b/runtime/observability/metrics/outbox_test.go
@@ -12,6 +12,7 @@ package metrics_test
 // with real implementations, these tests turn GREEN.
 
 import (
+	"context"
 	"testing"
 
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -86,7 +87,7 @@ func TestOutboxRejectCollector_ObserveReject_IncrementsCounterWithLabels(t *test
 		t.Fatalf("NewOutboxRejectCollector: %v", err)
 	}
 
-	c.ObserveReject("accesscore", "event.session.created.v1", "cg-accesscore-session", "handler_reject")
+	c.ObserveReject(context.Background(), "accesscore", "event.session.created.v1", "cg-accesscore-session", "handler_reject")
 
 	ops := p.counterOps["outbox_consumer_rejected_total"]
 	if len(ops) != 1 {
@@ -115,7 +116,7 @@ func TestOutboxRejectCollector_ObserveReject_IncrementsCounterWithLabels(t *test
 // TestOutboxRejectCollector_NilReceiver_DoesNotPanic verifies nil-safe call.
 func TestOutboxRejectCollector_NilReceiver_DoesNotPanic(t *testing.T) {
 	var c *obmetrics.OutboxRejectCollector
-	c.ObserveReject("cell", "topic", "cg", "handler_reject") // must not panic
+	c.ObserveReject(context.Background(), "cell", "topic", "cg", "handler_reject") // must not panic
 }
 
 // ---------------------------------------------------------------------------
@@ -184,7 +185,7 @@ func TestOutboxPendingDepthCollector_ObservePendingDepth_UsesConstructedCellID(t
 		t.Fatalf("NewOutboxPendingDepthCollector: %v", err)
 	}
 
-	c.ObservePendingDepth(42)
+	c.ObservePendingDepth(context.Background(), 42)
 
 	ops := p.gaugeOps["outbox_pending_depth"]
 	if len(ops) != 1 {
@@ -205,7 +206,7 @@ func TestOutboxPendingDepthCollector_ObservePendingDepth_UsesConstructedCellID(t
 // TestOutboxPendingDepthCollector_NilReceiver_DoesNotPanic verifies nil-safe call.
 func TestOutboxPendingDepthCollector_NilReceiver_DoesNotPanic(t *testing.T) {
 	var c *obmetrics.OutboxPendingDepthCollector
-	c.ObservePendingDepth(7) // must not panic
+	c.ObservePendingDepth(context.Background(), 7) // must not panic
 }
 
 // ---------------------------------------------------------------------------
@@ -280,8 +281,8 @@ type outboxSpyCounter struct {
 	labels kernelmetrics.Labels
 }
 
-func (c *outboxSpyCounter) Inc() { c.Add(1) }
-func (c *outboxSpyCounter) Add(d float64) {
+func (c *outboxSpyCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c *outboxSpyCounter) Add(_ context.Context, d float64) {
 	c.parent.counterOps[c.name] = append(c.parent.counterOps[c.name], outboxSpyRecord{labels: c.labels, value: d})
 }
 
@@ -291,9 +292,9 @@ type outboxSpyGauge struct {
 	labels kernelmetrics.Labels
 }
 
-func (g *outboxSpyGauge) Set(v float64) {
+func (g *outboxSpyGauge) Set(_ context.Context, v float64) {
 	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], outboxSpyRecord{labels: g.labels, value: v})
 }
-func (g *outboxSpyGauge) Inc()          { g.Add(1) }
-func (g *outboxSpyGauge) Dec()          { g.Add(-1) }
-func (g *outboxSpyGauge) Add(d float64) { g.Set(d) }
+func (g *outboxSpyGauge) Inc(ctx context.Context)            { g.Add(ctx, 1) }
+func (g *outboxSpyGauge) Dec(ctx context.Context)            { g.Add(ctx, -1) }
+func (g *outboxSpyGauge) Add(ctx context.Context, d float64) { g.Set(ctx, d) }

--- a/runtime/observability/metrics/provider_collector.go
+++ b/runtime/observability/metrics/provider_collector.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -75,13 +76,13 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 // http_request_duration_seconds, labeled identically. Status is stringified
 // once per call because Provider.CounterVec/HistogramVec expect string
 // labels uniformly (avoids adapter-specific type conversions).
-func (c *providerCollector) RecordRequest(cellID, method, route string, status int, durationSeconds float64) {
+func (c *providerCollector) RecordRequest(ctx context.Context, cellID, method, route string, status int, durationSeconds float64) {
 	labels := kernelmetrics.Labels{
 		"method": method,
 		"route":  route,
 		"status": strconv.Itoa(status),
 		"cell":   cellID,
 	}
-	c.requests.With(labels).Inc()
-	c.duration.With(labels).Observe(durationSeconds)
+	c.requests.With(labels).Inc(ctx)
+	c.duration.With(labels).Observe(ctx, durationSeconds)
 }

--- a/runtime/observability/metrics/provider_collector_test.go
+++ b/runtime/observability/metrics/provider_collector_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -20,8 +21,9 @@ func TestProviderCollector_NopProviderNoPanic(t *testing.T) {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
 	// Recording through the Nop provider must not panic.
-	c.RecordRequest("dev", "GET", "/api/v1/users", 200, 0.05)
-	c.RecordRequest("dev", "POST", "/api/v1/users", 201, 0.12)
+	ctx := context.Background()
+	c.RecordRequest(ctx, "dev", "GET", "/api/v1/users", 200, 0.05)
+	c.RecordRequest(ctx, "dev", "POST", "/api/v1/users", 201, 0.12)
 }
 
 func TestProviderCollector_EmitsCellLabelFromArg(t *testing.T) {
@@ -30,7 +32,7 @@ func TestProviderCollector_EmitsCellLabelFromArg(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
-	c.RecordRequest("accesscore", "GET", "/api/v1/sessions", 200, 0.01)
+	c.RecordRequest(context.Background(), "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
 
 	ops := p.counterOps["http_requests_total"]
 	if len(ops) != 1 {
@@ -58,9 +60,10 @@ func TestProviderCollector_PerCallCellLabel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProviderCollector: %v", err)
 	}
-	c.RecordRequest("accesscore", "GET", "/api/v1/sessions", 200, 0.01)
-	c.RecordRequest("auditcore", "GET", "/api/v1/audit", 200, 0.02)
-	c.RecordRequest("_runtime", "GET", "/healthz", 200, 0.001)
+	ctx := context.Background()
+	c.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
+	c.RecordRequest(ctx, "auditcore", "GET", "/api/v1/audit", 200, 0.02)
+	c.RecordRequest(ctx, "_runtime", "GET", "/healthz", 200, 0.001)
 
 	ops := p.counterOps["http_requests_total"]
 	if len(ops) != 3 {
@@ -144,8 +147,8 @@ type spyCounter struct {
 	labels kernelmetrics.Labels
 }
 
-func (c spyCounter) Inc() { c.Add(1) }
-func (c spyCounter) Add(d float64) {
+func (c spyCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c spyCounter) Add(_ context.Context, d float64) {
 	c.parent.counterOps[c.name] = append(c.parent.counterOps[c.name], spyOp{labels: c.labels, value: d})
 }
 
@@ -155,7 +158,7 @@ type spyHistogram struct {
 	labels kernelmetrics.Labels
 }
 
-func (h spyHistogram) Observe(v float64) {
+func (h spyHistogram) Observe(_ context.Context, v float64) {
 	h.parent.histogramOps[h.name] = append(h.parent.histogramOps[h.name], spyOp{labels: h.labels, value: v})
 }
 
@@ -177,12 +180,12 @@ type spyGauge struct {
 	labels kernelmetrics.Labels
 }
 
-func (g spyGauge) Set(v float64) {
+func (g spyGauge) Set(_ context.Context, v float64) {
 	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], spyOp{labels: g.labels, value: v})
 }
-func (g spyGauge) Inc() { g.Add(1) }
-func (g spyGauge) Dec() { g.Add(-1) }
-func (g spyGauge) Add(d float64) {
+func (g spyGauge) Inc(ctx context.Context) { g.Add(ctx, 1) }
+func (g spyGauge) Dec(ctx context.Context) { g.Add(ctx, -1) }
+func (g spyGauge) Add(ctx context.Context, d float64) {
 	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], spyOp{labels: g.labels, value: d})
 }
 

--- a/runtime/observability/metrics/provider_collector_test.go
+++ b/runtime/observability/metrics/provider_collector_test.go
@@ -52,6 +52,41 @@ func TestProviderCollector_EmitsCellLabelFromArg(t *testing.T) {
 	}
 }
 
+// ctxKey is a private type for the sentinel ctx value used to prove the middle
+// layer forwards the caller's ctx (not context.Background()) to the instruments.
+type ctxKey struct{}
+
+// TestProviderCollector_ForwardsCallerCtx asserts RecordRequest threads its ctx
+// argument into both the counter (Inc) and histogram (Observe) calls — F5: the
+// provider_collector middle layer must not substitute context.Background(),
+// otherwise OTel exemplar/baggage correlation is silently lost.
+func TestProviderCollector_ForwardsCallerCtx(t *testing.T) {
+	p := newSpyProvider()
+	c, err := metrics.NewProviderCollector(p, metrics.ProviderCollectorConfig{})
+	if err != nil {
+		t.Fatalf("NewProviderCollector: %v", err)
+	}
+
+	want := "sentinel-ctx-value"
+	ctx := context.WithValue(context.Background(), ctxKey{}, want)
+	c.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
+
+	assertForwardedCtx := func(label string, ops []spyOp) {
+		if len(ops) != 1 {
+			t.Fatalf("%s: want 1 op, got %d", label, len(ops))
+		}
+		if ops[0].ctx == nil {
+			t.Fatalf("%s: forwarded ctx is nil (middle layer dropped it)", label)
+		}
+		if got, _ := ops[0].ctx.Value(ctxKey{}).(string); got != want {
+			t.Errorf("%s: forwarded ctx value = %q, want %q "+
+				"(provider_collector substituted a different ctx — exemplar/baggage lost)", label, got, want)
+		}
+	}
+	assertForwardedCtx("http_requests_total", p.counterOps["http_requests_total"])
+	assertForwardedCtx("http_request_duration_seconds", p.histogramOps["http_request_duration_seconds"])
+}
+
 func TestProviderCollector_PerCallCellLabel(t *testing.T) {
 	// Two calls with different cellID values must yield two distinct label sets;
 	// no global / cached cellID can leak between calls.
@@ -93,6 +128,7 @@ type spyProvider struct {
 type spyOp struct {
 	labels kernelmetrics.Labels
 	value  float64
+	ctx    context.Context //nolint:containedctx // test spy captures the ctx the middle layer forwarded, to assert ctx passthrough (F5)
 }
 
 func newSpyProvider() *spyProvider {
@@ -148,8 +184,8 @@ type spyCounter struct {
 }
 
 func (c spyCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
-func (c spyCounter) Add(_ context.Context, d float64) {
-	c.parent.counterOps[c.name] = append(c.parent.counterOps[c.name], spyOp{labels: c.labels, value: d})
+func (c spyCounter) Add(ctx context.Context, d float64) {
+	c.parent.counterOps[c.name] = append(c.parent.counterOps[c.name], spyOp{labels: c.labels, value: d, ctx: ctx})
 }
 
 type spyHistogram struct {
@@ -158,8 +194,8 @@ type spyHistogram struct {
 	labels kernelmetrics.Labels
 }
 
-func (h spyHistogram) Observe(_ context.Context, v float64) {
-	h.parent.histogramOps[h.name] = append(h.parent.histogramOps[h.name], spyOp{labels: h.labels, value: v})
+func (h spyHistogram) Observe(ctx context.Context, v float64) {
+	h.parent.histogramOps[h.name] = append(h.parent.histogramOps[h.name], spyOp{labels: h.labels, value: v, ctx: ctx})
 }
 
 type spyGaugeVec struct {
@@ -180,13 +216,13 @@ type spyGauge struct {
 	labels kernelmetrics.Labels
 }
 
-func (g spyGauge) Set(_ context.Context, v float64) {
-	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], spyOp{labels: g.labels, value: v})
+func (g spyGauge) Set(ctx context.Context, v float64) {
+	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], spyOp{labels: g.labels, value: v, ctx: ctx})
 }
 func (g spyGauge) Inc(ctx context.Context) { g.Add(ctx, 1) }
 func (g spyGauge) Dec(ctx context.Context) { g.Add(ctx, -1) }
 func (g spyGauge) Add(ctx context.Context, d float64) {
-	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], spyOp{labels: g.labels, value: d})
+	g.parent.gaugeOps[g.name] = append(g.parent.gaugeOps[g.name], spyOp{labels: g.labels, value: d, ctx: ctx})
 }
 
 // silence unused import if toolchain introduces new helpers during refactors.

--- a/runtime/observability/metrics/shutdown.go
+++ b/runtime/observability/metrics/shutdown.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"time"
@@ -159,27 +160,27 @@ func NewShutdownCollector(p kernelmetrics.Provider) (*ShutdownCollector, error) 
 
 // RecordPhaseEntry increments the phase-entry counter for the given phase
 // label. No-op on nil receiver.
-func (m *ShutdownCollector) RecordPhaseEntry(phase string) {
+func (m *ShutdownCollector) RecordPhaseEntry(ctx context.Context, phase string) {
 	if m == nil || m.disabled {
 		return
 	}
-	m.phaseEntries.With(kernelmetrics.Labels{"phase": phase}).Inc()
+	m.phaseEntries.With(kernelmetrics.Labels{"phase": phase}).Inc(ctx)
 }
 
 // ObservePhaseDuration records the duration of a shutdown phase. No-op on
 // nil receiver.
-func (m *ShutdownCollector) ObservePhaseDuration(phase string, d time.Duration) {
+func (m *ShutdownCollector) ObservePhaseDuration(ctx context.Context, phase string, d time.Duration) {
 	if m == nil || m.disabled {
 		return
 	}
-	m.phaseDuration.With(kernelmetrics.Labels{"phase": phase}).Observe(d.Seconds())
+	m.phaseDuration.With(kernelmetrics.Labels{"phase": phase}).Observe(ctx, d.Seconds())
 }
 
 // CountOutcome increments the shutdown outcome counter. outcome must be one of
 // "success", "timeout", "teardown_error", or "signal_error". No-op on nil receiver.
-func (m *ShutdownCollector) CountOutcome(outcome string) {
+func (m *ShutdownCollector) CountOutcome(ctx context.Context, outcome string) {
 	if m == nil || m.disabled {
 		return
 	}
-	m.shutdownTotal.With(kernelmetrics.Labels{"outcome": outcome}).Inc()
+	m.shutdownTotal.With(kernelmetrics.Labels{"outcome": outcome}).Inc(ctx)
 }

--- a/runtime/observability/metrics/shutdown_test.go
+++ b/runtime/observability/metrics/shutdown_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -40,8 +41,8 @@ type shutdownFakeCounter struct {
 	labels kernelmetrics.Labels
 }
 
-func (c *shutdownFakeCounter) Inc() { c.Add(1) }
-func (c *shutdownFakeCounter) Add(delta float64) {
+func (c *shutdownFakeCounter) Inc(ctx context.Context) { c.Add(ctx, 1) }
+func (c *shutdownFakeCounter) Add(_ context.Context, delta float64) {
 	c.vec.mu.Lock()
 	defer c.vec.mu.Unlock()
 	c.vec.records = append(c.vec.records, shutdownFakeCounterRecord{labels: c.labels, delta: delta})
@@ -69,7 +70,7 @@ type shutdownFakeHistogram struct {
 	labels kernelmetrics.Labels
 }
 
-func (h *shutdownFakeHistogram) Observe(value float64) {
+func (h *shutdownFakeHistogram) Observe(_ context.Context, value float64) {
 	h.vec.mu.Lock()
 	defer h.vec.mu.Unlock()
 	h.vec.records = append(h.vec.records, shutdownFakeHistogramRecord{labels: h.labels, value: value})
@@ -119,11 +120,12 @@ var _ kernelmetrics.Provider = (*shutdownFakeProvider)(nil)
 // TestShutdownCollector_NilSafe verifies that all ShutdownCollector methods are
 // nil-safe and do not panic when called on a nil receiver.
 func TestShutdownCollector_NilSafe(t *testing.T) {
+	ctx := context.Background()
 	var m *ShutdownCollector
 	require.NotPanics(t, func() {
-		m.RecordPhaseEntry(ShutdownPhaseReadinessFlip)
-		m.ObservePhaseDuration("readiness_flip", testtime.D1ms)
-		m.CountOutcome("success")
+		m.RecordPhaseEntry(ctx, ShutdownPhaseReadinessFlip)
+		m.ObservePhaseDuration(ctx, "readiness_flip", testtime.D1ms)
+		m.CountOutcome(ctx, "success")
 	})
 }
 
@@ -150,6 +152,7 @@ func TestShutdownCollector_ConcurrentObserve(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m)
 
+	ctx := context.Background()
 	var wg sync.WaitGroup
 	var panicked atomic.Bool
 	for range 10 {
@@ -159,9 +162,9 @@ func TestShutdownCollector_ConcurrentObserve(t *testing.T) {
 					panicked.Store(true)
 				}
 			}()
-			m.RecordPhaseEntry(ShutdownPhaseReadinessFlip)
-			m.ObservePhaseDuration("readiness_flip", time.Millisecond)
-			m.CountOutcome("success")
+			m.RecordPhaseEntry(ctx, ShutdownPhaseReadinessFlip)
+			m.ObservePhaseDuration(ctx, "readiness_flip", time.Millisecond)
+			m.CountOutcome(ctx, "success")
 		})
 	}
 	wg.Wait()

--- a/runtime/outbox/metrics_safe.go
+++ b/runtime/outbox/metrics_safe.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"log/slog"
 
 	kout "github.com/ghbvf/gocell/kernel/outbox"
@@ -23,20 +24,20 @@ type safeRelayCollector struct {
 // Compile-time interface check.
 var _ kout.RelayCollector = (*safeRelayCollector)(nil)
 
-func (s *safeRelayCollector) RecordPollCycle(r kout.PollCycleResult) {
-	s.safeCall(func() { s.inner.RecordPollCycle(r) })
+func (s *safeRelayCollector) RecordPollCycle(ctx context.Context, r kout.PollCycleResult) {
+	s.safeCall(func() { s.inner.RecordPollCycle(ctx, r) })
 }
 
-func (s *safeRelayCollector) RecordBatchSize(size int) {
-	s.safeCall(func() { s.inner.RecordBatchSize(size) })
+func (s *safeRelayCollector) RecordBatchSize(ctx context.Context, size int) {
+	s.safeCall(func() { s.inner.RecordBatchSize(ctx, size) })
 }
 
-func (s *safeRelayCollector) RecordReclaim(count int64) {
-	s.safeCall(func() { s.inner.RecordReclaim(count) })
+func (s *safeRelayCollector) RecordReclaim(ctx context.Context, count int64) {
+	s.safeCall(func() { s.inner.RecordReclaim(ctx, count) })
 }
 
-func (s *safeRelayCollector) RecordCleanup(publishedDeleted, deadDeleted int64) {
-	s.safeCall(func() { s.inner.RecordCleanup(publishedDeleted, deadDeleted) })
+func (s *safeRelayCollector) RecordCleanup(ctx context.Context, publishedDeleted, deadDeleted int64) {
+	s.safeCall(func() { s.inner.RecordCleanup(ctx, publishedDeleted, deadDeleted) })
 }
 
 // safeCall runs fn and recovers from any panic, logging it instead of

--- a/runtime/outbox/metrics_safe_test.go
+++ b/runtime/outbox/metrics_safe_test.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,10 +13,13 @@ import (
 // panicRelayCollector is a test collector that panics on every call.
 type panicRelayCollector struct{}
 
-func (panicRelayCollector) RecordPollCycle(_ kout.PollCycleResult) { panic("boom: poll cycle") }
-func (panicRelayCollector) RecordBatchSize(_ int)                  { panic("boom: batch size") }
-func (panicRelayCollector) RecordReclaim(_ int64)                  { panic("boom: reclaim") }
-func (panicRelayCollector) RecordCleanup(_, _ int64)               { panic("boom: cleanup") }
+func (panicRelayCollector) RecordPollCycle(_ context.Context, _ kout.PollCycleResult) {
+	panic("boom: poll cycle")
+}
+
+func (panicRelayCollector) RecordBatchSize(_ context.Context, _ int)    { panic("boom: batch size") }
+func (panicRelayCollector) RecordReclaim(_ context.Context, _ int64)    { panic("boom: reclaim") }
+func (panicRelayCollector) RecordCleanup(_ context.Context, _, _ int64) { panic("boom: cleanup") }
 
 // mockCollector is a test collector that records calls without panicking.
 type mockCollector struct {
@@ -27,78 +31,90 @@ type mockCollector struct {
 
 type mockCleanupEntry struct{ publishedDeleted, deadDeleted int64 }
 
-func (m *mockCollector) RecordPollCycle(r kout.PollCycleResult) {
+func (m *mockCollector) RecordPollCycle(_ context.Context, r kout.PollCycleResult) {
 	m.pollCycles = append(m.pollCycles, r)
 }
-func (m *mockCollector) RecordBatchSize(size int) { m.batchSizes = append(m.batchSizes, size) }
-func (m *mockCollector) RecordReclaim(count int64) {
+
+func (m *mockCollector) RecordBatchSize(_ context.Context, size int) {
+	m.batchSizes = append(m.batchSizes, size)
+}
+
+func (m *mockCollector) RecordReclaim(_ context.Context, count int64) {
 	m.reclaimCounts = append(m.reclaimCounts, count)
 }
 
-func (m *mockCollector) RecordCleanup(p, d int64) {
+func (m *mockCollector) RecordCleanup(_ context.Context, p, d int64) {
 	m.cleanupCalls = append(m.cleanupCalls, mockCleanupEntry{p, d})
 }
 
 // typedNilCollector is a typed nil pointer for nil-dereference panic testing.
 type typedNilCollector struct{}
 
-func (t *typedNilCollector) RecordPollCycle(_ kout.PollCycleResult) { panic("nil method called") }
-func (t *typedNilCollector) RecordBatchSize(_ int)                  { panic("nil method called") }
-func (t *typedNilCollector) RecordReclaim(_ int64)                  { panic("nil method called") }
-func (t *typedNilCollector) RecordCleanup(_, _ int64)               { panic("nil method called") }
+func (t *typedNilCollector) RecordPollCycle(_ context.Context, _ kout.PollCycleResult) {
+	panic("nil method called")
+}
+
+func (t *typedNilCollector) RecordBatchSize(_ context.Context, _ int) { panic("nil method called") }
+
+func (t *typedNilCollector) RecordReclaim(_ context.Context, _ int64) { panic("nil method called") }
+
+func (t *typedNilCollector) RecordCleanup(_ context.Context, _, _ int64) { panic("nil method called") }
 
 func TestSafeRelayCollector_PanickingCollector_DoesNotCrash(t *testing.T) {
+	ctx := context.Background()
 	s := &safeRelayCollector{inner: panicRelayCollector{}}
 
 	assert.NotPanics(t, func() {
-		s.RecordPollCycle(kout.PollCycleResult{
+		s.RecordPollCycle(ctx, kout.PollCycleResult{
 			Published: 1, ClaimDur: time.Millisecond,
 			PublishDur: time.Millisecond, WriteBackDur: time.Millisecond,
 		})
 	}, "RecordPollCycle panic must be recovered")
 
 	assert.NotPanics(t, func() {
-		s.RecordBatchSize(10)
+		s.RecordBatchSize(ctx, 10)
 	}, "RecordBatchSize panic must be recovered")
 
 	assert.NotPanics(t, func() {
-		s.RecordReclaim(5)
+		s.RecordReclaim(ctx, 5)
 	}, "RecordReclaim panic must be recovered")
 
 	assert.NotPanics(t, func() {
-		s.RecordCleanup(10, 3)
+		s.RecordCleanup(ctx, 10, 3)
 	}, "RecordCleanup panic must be recovered")
 }
 
 func TestSafeRelayCollector_TypedNil_DoesNotCrash(t *testing.T) {
+	ctx := context.Background()
 	var nilCollector *typedNilCollector // typed nil
 	s := &safeRelayCollector{inner: nilCollector}
 
 	assert.NotPanics(t, func() {
-		s.RecordPollCycle(kout.PollCycleResult{Published: 1})
+		s.RecordPollCycle(ctx, kout.PollCycleResult{Published: 1})
 	}, "typed-nil collector must not crash")
 
 	assert.NotPanics(t, func() {
-		s.RecordBatchSize(5)
+		s.RecordBatchSize(ctx, 5)
 	}, "typed-nil collector must not crash")
 
 	assert.NotPanics(t, func() {
-		s.RecordReclaim(1)
+		s.RecordReclaim(ctx, 1)
 	}, "typed-nil collector must not crash")
 
 	assert.NotPanics(t, func() {
-		s.RecordCleanup(1, 0)
+		s.RecordCleanup(ctx, 1, 0)
 	}, "typed-nil collector must not crash")
 }
 
 func TestSafeRelayCollector_DelegatesCorrectly(t *testing.T) {
+	ctx := context.Background()
 	mc := &mockCollector{}
 	s := &safeRelayCollector{inner: mc}
 
-	s.RecordPollCycle(kout.PollCycleResult{Published: 3})
-	s.RecordBatchSize(42)
-	s.RecordReclaim(7)
-	s.RecordCleanup(10, 2)
+	s.RecordPollCycle(ctx, kout.PollCycleResult{Published: 3})
+	s.RecordBatchSize(ctx, 42)
+	s.RecordReclaim(ctx, 7)
+	s.RecordCleanup(ctx, 10, 2)
 
 	assert.Len(t, mc.pollCycles, 1)
 	assert.Equal(t, 3, mc.pollCycles[0].Published)

--- a/runtime/outbox/relay.go
+++ b/runtime/outbox/relay.go
@@ -86,7 +86,7 @@ type pollStats struct {
 // Intentionally defined here (not imported from runtime/observability/metrics)
 // to avoid coupling runtime/outbox to its sibling package.
 type PendingDepthObserver interface {
-	ObservePendingDepth(n int64)
+	ObservePendingDepth(ctx context.Context, n int64)
 }
 
 // Relay polls unpublished outbox entries via a Store interface and publishes
@@ -399,7 +399,7 @@ func (r *Relay) observePendingDepth(ctx context.Context) {
 			slog.Any("error", err))
 		return
 	}
-	observability.SafeObserve(slog.Default(), func() { r.pendingDepthObserver.ObservePendingDepth(n) })
+	observability.SafeObserve(slog.Default(), func() { r.pendingDepthObserver.ObservePendingDepth(ctx, n) })
 }
 
 // cleanupLoop runs cleanup data-driven: after each pass it asks the store for
@@ -510,7 +510,7 @@ func (r *Relay) pollOnce(ctx context.Context) error {
 	}
 
 	// Record batch size even for empty batches (captures idle cycles).
-	r.metrics.RecordBatchSize(len(entries))
+	r.metrics.RecordBatchSize(ctx, len(entries))
 
 	if len(entries) == 0 {
 		return nil
@@ -540,7 +540,7 @@ func (r *Relay) pollOnce(ctx context.Context) error {
 			slog.Duration("claim_dur", claimDur),
 			slog.Duration("publish_dur", pubDur),
 		)
-		r.metrics.RecordPollCycle(kout.PollCycleResult{
+		r.metrics.RecordPollCycle(ctx, kout.PollCycleResult{
 			Published:    stats.published,
 			Retried:      stats.retried,
 			Dead:         stats.dead,
@@ -708,7 +708,7 @@ func (r *Relay) reclaimStale(ctx context.Context) error {
 				"outbox relay: reclaimed stale entries",
 				slog.Int("count", total),
 			)
-			r.metrics.RecordReclaim(int64(total))
+			r.metrics.RecordReclaim(ctx, int64(total))
 		}
 	}()
 	for i := 0; i < reclaimMaxIterations; i++ {
@@ -787,7 +787,7 @@ func (r *Relay) cleanup(ctx context.Context) error {
 	}
 
 	if totalPublished > 0 || totalDead > 0 {
-		r.metrics.RecordCleanup(totalPublished, totalDead)
+		r.metrics.RecordCleanup(ctx, totalPublished, totalDead)
 	}
 	return nil
 }

--- a/runtime/outbox/relay_internal_test.go
+++ b/runtime/outbox/relay_internal_test.go
@@ -513,7 +513,7 @@ type reclaimRecordingCollector struct {
 	counts []int64
 }
 
-func (c *reclaimRecordingCollector) RecordReclaim(n int64) {
+func (c *reclaimRecordingCollector) RecordReclaim(_ context.Context, n int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.counts = append(c.counts, n)

--- a/runtime/outbox/relay_test.go
+++ b/runtime/outbox/relay_test.go
@@ -1086,7 +1086,7 @@ func newSpyDepthObserver() *spyDepthObserver {
 	return &spyDepthObserver{notify: make(chan struct{})}
 }
 
-func (s *spyDepthObserver) ObservePendingDepth(n int64) {
+func (s *spyDepthObserver) ObservePendingDepth(_ context.Context, n int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.values = append(s.values, n)
@@ -1243,17 +1243,17 @@ type testCollector struct {
 	batchSizes []int
 }
 
-func (c *testCollector) RecordPollCycle(r kout.PollCycleResult) {
+func (c *testCollector) RecordPollCycle(_ context.Context, r kout.PollCycleResult) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.pollCycles = append(c.pollCycles, r)
 }
 
-func (c *testCollector) RecordBatchSize(s int) {
+func (c *testCollector) RecordBatchSize(_ context.Context, s int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.batchSizes = append(c.batchSizes, s)
 }
 
-func (c *testCollector) RecordReclaim(_ int64)    {}
-func (c *testCollector) RecordCleanup(_, _ int64) {}
+func (c *testCollector) RecordReclaim(_ context.Context, _ int64)    {}
+func (c *testCollector) RecordCleanup(_ context.Context, _, _ int64) {}

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -56,10 +56,17 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 		}
 	})
 
+	// reqVarName is the *http.Request parameter of the handler funcLit (which
+	// encloses the SafeObserve closure that actually calls RecordRequest), bound
+	// to the formal param list so the arg0 check below asserts `<req>.Context()`
+	// rather than any-ident.Context() (ai-robust: bind to FuncDecl formal).
+	reqVarName := requestParamName(fn.Body)
+
 	var (
 		readsCtxCellID      bool
 		usesRuntimeSentinel bool
 		recordUsesCellIDArg bool
+		recordUsesReqCtxArg bool
 		ctxCellIDPos        token.Pos
 		runtimeSentinelPos  token.Pos
 		recordRequestPos    token.Pos
@@ -73,6 +80,9 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 			recordRequestPos = v.Pos()
 			// Arg 0 is the ctx (METRICS-CTX-FUNNEL-01 ctx-bearing signature);
 			// the ctx-derived cellID label is arg 1.
+			if len(v.Args) > 0 && isRequestContextCall(v.Args[0], reqVarName) {
+				recordUsesReqCtxArg = true
+			}
 			if len(v.Args) > 1 {
 				if id, ok := v.Args[1].(*ast.Ident); ok && id.Name == "cellID" {
 					recordUsesCellIDArg = true
@@ -96,6 +106,10 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 	assert.Truef(t, recordUsesCellIDArg,
 		"%s: %s — collector.RecordRequest must receive the ctx-derived cellID variable, not a constructor/config value",
 		rel, ruleHTTPMetricsLabelCtxSource01)
+	assert.Truef(t, recordUsesReqCtxArg,
+		"%s: %s — collector.RecordRequest arg0 must be the request ctx (%s.Context()), not "+
+			"context.Background()/TODO; the ctx-bearing funnel carries cell attribution + exemplar/baggage",
+		rel, ruleHTTPMetricsLabelCtxSource01, reqVarName)
 	assert.Truef(t, ctxCellIDPos.IsValid() && recordRequestPos.IsValid() && ctxCellIDPos < recordRequestPos,
 		"%s: %s — ctxkeys.CellIDFrom must feed the metrics path before collector.RecordRequest",
 		rel, ruleHTTPMetricsLabelCtxSource01)
@@ -105,6 +119,58 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 	assert.Falsef(t, callsOldState,
 		"%s: %s — old mutable cell helper is deleted; cell attribution must happen at router root",
 		rel, ruleHTTPMetricsLabelCtxSource01)
+}
+
+// requestParamName walks root for the handler funcLit whose param list includes
+// an `*http.Request`, returning that param's name (or "" if none). Matched by the
+// type expression `*http.Request` (no type info under parser.ParseFile), so the
+// arg0 check binds to the handler's actual request formal rather than any
+// identifier named "r". The RecordRequest call lives in a nested no-param
+// closure, so the request formal must be found in the enclosing handler funcLit.
+func requestParamName(root ast.Node) string {
+	var found string
+	scanner.EachInSubtree[ast.FuncLit](root, func(fl *ast.FuncLit) {
+		if found != "" || fl.Type == nil || fl.Type.Params == nil {
+			return
+		}
+		for _, field := range fl.Type.Params.List {
+			star, ok := field.Type.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			sel, ok := star.X.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "Request" {
+				continue
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "http" {
+				continue
+			}
+			if len(field.Names) > 0 {
+				found = field.Names[0].Name
+				return
+			}
+		}
+	})
+	return found
+}
+
+// isRequestContextCall reports whether expr is `<reqVar>.Context()` — a no-arg
+// method call on the request identifier. Returns false when reqVar is empty
+// (fail-closed: an unresolved request param must not silently pass).
+func isRequestContextCall(expr ast.Expr, reqVar string) bool {
+	if reqVar == "" {
+		return false
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "Context" {
+		return false
+	}
+	recv, ok := sel.X.(*ast.Ident)
+	return ok && recv.Name == reqVar
 }
 
 func TestHTTPMetricsLabelRouterAttribution01(t *testing.T) {

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -71,8 +71,10 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 		}
 		if isSelectorCall(v, "collector", "RecordRequest") {
 			recordRequestPos = v.Pos()
-			if len(v.Args) > 0 {
-				if id, ok := v.Args[0].(*ast.Ident); ok && id.Name == "cellID" {
+			// Arg 0 is the ctx (METRICS-CTX-FUNNEL-01 ctx-bearing signature);
+			// the ctx-derived cellID label is arg 1.
+			if len(v.Args) > 1 {
+				if id, ok := v.Args[1].(*ast.Ident); ok && id.Name == "cellID" {
 					recordUsesCellIDArg = true
 				}
 			}

--- a/tools/archtest/metrics_cancel_ctx_conformance_test.go
+++ b/tools/archtest/metrics_cancel_ctx_conformance_test.go
@@ -5,14 +5,14 @@
 // This archtest is a *test-existence backstop*: it enforces that every concrete
 // production kernel/observability/metrics.Provider implementation is exercised
 // by the no-skip-on-cancel behavioral conformance harness
-// (kernel/observability/metrics/metricstest.RunCancelledCtxConformance). It is
+// (kernel/observability/metrics/metricstest.RunCanceledCtxConformance). It is
 // the Medium membership layer that the Hard behavioral harness sits on.
 //
 //   - 实现扫描: types.Implements(*types.Interface) — type-aware, identifies every
 //     concrete named type (exported OR unexported) that satisfies
 //     kernel/observability/metrics.Provider (or *T), restricted to the
 //     enrollable production layer adapters/ (see scope below).
-//   - conformance 调用扫描: per *implementation*. Each RunCancelledCtxConformance
+//   - conformance 调用扫描: per *implementation*. Each RunCanceledCtxConformance
 //     call's Provider argument (args[1]) is resolved via *types.Info to its
 //     concrete type key, so a package with N Provider impls must
 //     conformance-test each of the N — enrolling one does not cover its
@@ -20,7 +20,7 @@
 //   - 综合: Medium is the **ceiling by construction** — Go cannot require a test
 //     to exist at compile time. This is the established shape of the sibling
 //     CELL-REPO-READYZ-PROBE-01. The behavioral correctness of the harness
-//     itself is Hard: RunCancelledCtxConformance records via an already-cancelled
+//     itself is Hard: RunCanceledCtxConformance records via an already-canceled
 //     ctx and asserts the measured values through an adapter-supplied readback,
 //     so a regression such as `if ctx.Err() != nil { return }` inside an
 //     adapter's Add/Observe/Set makes the readback return 0/wrong and the
@@ -28,7 +28,7 @@
 //
 // Enforces: every concrete type under adapters/ that implements
 // kernel/observability/metrics.Provider must be passed as the Provider argument
-// to at least one metricstest.RunCancelledCtxConformance call in a _test.go
+// to at least one metricstest.RunCanceledCtxConformance call in a _test.go
 // file. Impls with no such call are reported as violations.
 //
 // Contract source: kernel/observability/metrics/metrics.go §contract (1):
@@ -41,7 +41,7 @@
 //
 //   - In scope: package paths under adapters/. Both production Provider impls
 //     (otel.MetricProvider, prometheus.MetricProvider) live here and can hang a
-//     RunCancelledCtxConformance call off a _test.go in their own package.
+//     RunCanceledCtxConformance call off a _test.go in their own package.
 //
 //   - Excluded: kernel/. The kernel nop Provider (kernel/observability/metrics.nop*)
 //     records nothing — it has no observable failure domain and is structurally
@@ -83,13 +83,13 @@ const (
 	metricsProviderIfacePkg    = "github.com/ghbvf/gocell/kernel/observability/metrics"
 	metricsProviderIfaceName   = "Provider"
 	cancelCtxConformancePkg    = "github.com/ghbvf/gocell/kernel/observability/metrics/metricstest"
-	cancelCtxConformanceFunc   = "RunCancelledCtxConformance"
+	cancelCtxConformanceFunc   = "RunCanceledCtxConformance"
 	metricsProviderScopePrefix = "adapters/"
 )
 
 // TestMetricsCancelCtxConformance enforces METRICS-CANCEL-CTX-CONFORMANCE-01:
 // every concrete type under adapters/ implementing metrics.Provider must have a
-// metricstest.RunCancelledCtxConformance call in a _test.go file of its package.
+// metricstest.RunCanceledCtxConformance call in a _test.go file of its package.
 func TestMetricsCancelCtxConformance(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -143,7 +143,7 @@ func TestMetricsCancelCtxConformance(t *testing.T) {
 			"adapters/ — likely a type-universe regression (iface and impls must share one "+
 			"packages.Load). Expect otel.MetricProvider and prometheus.MetricProvider.")
 
-	// ─── Step 3: scan test corpus for RunCancelledCtxConformance call sites ───
+	// ─── Step 3: scan test corpus for RunCanceledCtxConformance call sites ───
 	enrolledImpls := make(map[string]bool) // "pkg/path.TypeName" → true
 	_ = RunTyped(t, TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, prodPatterns,
 		func(p *Pass) []Diagnostic {
@@ -271,8 +271,8 @@ func collectMetricsProviderImpls(pkg *types.Package, iface *types.Interface, imp
 }
 
 // collectEnrolledMetricsProviders records the concrete impl key of every
-// Provider argument (args[1]) passed to a metricstest.RunCancelledCtxConformance
-// call in file. Signature: RunCancelledCtxConformance(t, p, rb) — args[1] is
+// Provider argument (args[1]) passed to a metricstest.RunCanceledCtxConformance
+// call in file. Signature: RunCanceledCtxConformance(t, p, rb) — args[1] is
 // resolved to its concrete type so enrollment is per-implementation.
 func collectEnrolledMetricsProviders(file *ast.File, info *types.Info, enrolled map[string]bool) {
 	if info == nil {
@@ -309,9 +309,9 @@ func unenrolledMetricsProviders(implSet, enrolledImpls map[string]bool) []Diagno
 			Line: 0,
 			Message: fmt.Sprintf(
 				"archtest: metrics.Provider impl %q not enrolled in a "+
-					"metricstest.RunCancelledCtxConformance test call "+
+					"metricstest.RunCanceledCtxConformance test call "+
 					"(METRICS-CANCEL-CTX-CONFORMANCE-01). Add a _test.go in package %s that calls "+
-					"metricstest.RunCancelledCtxConformance(t, provider, readback) passing this "+
+					"metricstest.RunCanceledCtxConformance(t, provider, readback) passing this "+
 					"concrete Provider, asserting the no-skip-on-cancel contract "+
 					"(kernel/observability/metrics/metrics.go §contract (1)).",
 				implKey, pkgPath),

--- a/tools/archtest/metrics_cancel_ctx_conformance_test.go
+++ b/tools/archtest/metrics_cancel_ctx_conformance_test.go
@@ -1,0 +1,322 @@
+// INVARIANT: METRICS-CANCEL-CTX-CONFORMANCE-01
+//
+// AI-robust: Medium (test-existence backstop — NOT a funnel upstream lock).
+//
+// This archtest is a *test-existence backstop*: it enforces that every concrete
+// production kernel/observability/metrics.Provider implementation is exercised
+// by the no-skip-on-cancel behavioral conformance harness
+// (kernel/observability/metrics/metricstest.RunCancelledCtxConformance). It is
+// the Medium membership layer that the Hard behavioral harness sits on.
+//
+//   - 实现扫描: types.Implements(*types.Interface) — type-aware, identifies every
+//     concrete named type (exported OR unexported) that satisfies
+//     kernel/observability/metrics.Provider (or *T), restricted to the
+//     enrollable production layer adapters/ (see scope below).
+//   - conformance 调用扫描: per *implementation*. Each RunCancelledCtxConformance
+//     call's Provider argument (args[1]) is resolved via *types.Info to its
+//     concrete type key, so a package with N Provider impls must
+//     conformance-test each of the N — enrolling one does not cover its
+//     same-package siblings.
+//   - 综合: Medium is the **ceiling by construction** — Go cannot require a test
+//     to exist at compile time. This is the established shape of the sibling
+//     CELL-REPO-READYZ-PROBE-01. The behavioral correctness of the harness
+//     itself is Hard: RunCancelledCtxConformance records via an already-cancelled
+//     ctx and asserts the measured values through an adapter-supplied readback,
+//     so a regression such as `if ctx.Err() != nil { return }` inside an
+//     adapter's Add/Observe/Set makes the readback return 0/wrong and the
+//     conformance test fails — a no-op cannot satisfy it.
+//
+// Enforces: every concrete type under adapters/ that implements
+// kernel/observability/metrics.Provider must be passed as the Provider argument
+// to at least one metricstest.RunCancelledCtxConformance call in a _test.go
+// file. Impls with no such call are reported as violations.
+//
+// Contract source: kernel/observability/metrics/metrics.go §contract (1):
+// "实现禁止因 ctx 已取消/超时而跳过记录——ctx 取消不得导致数据丢失". Honored by
+// adapters/otel (forwards ctx to inner.Add/Record without an Err() gate) and
+// adapters/prometheus (discards ctx entirely). This archtest + the harness keep
+// both honoring it.
+//
+// # Scope (enrollable production layer only)
+//
+//   - In scope: package paths under adapters/. Both production Provider impls
+//     (otel.MetricProvider, prometheus.MetricProvider) live here and can hang a
+//     RunCancelledCtxConformance call off a _test.go in their own package.
+//
+//   - Excluded: kernel/. The kernel nop Provider (kernel/observability/metrics.nop*)
+//     records nothing — it has no observable failure domain and is structurally
+//     un-conformance-testable (no readback can assert a value a no-op never
+//     stored). This mirrors CELL-REPO-READYZ-PROBE-01's kernel exclusion: there
+//     is nothing to enroll and nothing to backlog. runtime/cells/examples define
+//     no metrics.Provider impl (providerCollector is a Collector, not a Provider;
+//     spyProvider lives in _test.go, excluded by the production load pass).
+//
+// # Blind-spot catalog (forms not reachable by *types.Info)
+//
+//   - B1. reflect-based implicit implementations: no production code uses this
+//     pattern; confirmed by TestMetricsCancelCtxConformance_ReverseBlindSpot,
+//     which scans for the interface name "Provider" string literal in adapters/
+//     non-test files as reflect bait.
+//   - B2. generated mock implementations in _test.go are excluded (Tests=false in
+//     the production impl scan); a mock in a production non-test file would be
+//     flagged — intentionally.
+//
+// ref: tools/archtest/cell_repo_readyz_probe_test.go (sibling backstop pattern)
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/internal/prodscan"
+	"github.com/ghbvf/gocell/tools/typesutil"
+)
+
+const (
+	metricsProviderIfacePkg    = "github.com/ghbvf/gocell/kernel/observability/metrics"
+	metricsProviderIfaceName   = "Provider"
+	cancelCtxConformancePkg    = "github.com/ghbvf/gocell/kernel/observability/metrics/metricstest"
+	cancelCtxConformanceFunc   = "RunCancelledCtxConformance"
+	metricsProviderScopePrefix = "adapters/"
+)
+
+// TestMetricsCancelCtxConformance enforces METRICS-CANCEL-CTX-CONFORMANCE-01:
+// every concrete type under adapters/ implementing metrics.Provider must have a
+// metricstest.RunCancelledCtxConformance call in a _test.go file of its package.
+func TestMetricsCancelCtxConformance(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	modPath := readModulePath(t, root)
+	prodPatterns := prodscan.Patterns(root)
+
+	// ─── Step 1: resolve metrics.Provider + collect adapters/ impl pkgs ───────
+	// The iface and the impl types MUST come from the same packages.Load so
+	// types.Implements uses pointer-identical *types.Named descriptors.
+	var providerIface *types.Interface
+	var implPkgs []*types.Package
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, prodPatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == metricsProviderIfacePkg {
+				if obj := p.Pkg.Scope().Lookup(metricsProviderIfaceName); obj != nil {
+					if named, ok := obj.Type().(*types.Named); ok {
+						if iface, ok := named.Underlying().(*types.Interface); ok {
+							providerIface = iface.Complete()
+						}
+					}
+				}
+				return nil
+			}
+			if inMetricsProviderScope(p.Pkg.Path(), modPath) {
+				implPkgs = append(implPkgs, p.Pkg)
+			}
+			return nil
+		})
+
+	require.NotNil(t, providerIface,
+		"METRICS-CANCEL-CTX-CONFORMANCE-01: failed to resolve metrics.Provider interface; "+
+			"check import path %s", metricsProviderIfacePkg)
+
+	// ─── Step 2: collect all concrete adapters/ implementations ───────────────
+	implSet := make(map[string]bool) // "pkg/path.TypeName" → true
+	for _, pkg := range implPkgs {
+		if pkg != nil {
+			collectMetricsProviderImpls(pkg, providerIface, implSet)
+		}
+	}
+	require.NotEmpty(t, implSet,
+		"METRICS-CANCEL-CTX-CONFORMANCE-01: zero metrics.Provider implementations collected under "+
+			"adapters/ — likely a type-universe regression (iface and impls must share one "+
+			"packages.Load). Expect otel.MetricProvider and prometheus.MetricProvider.")
+
+	// ─── Step 3: scan test corpus for RunCancelledCtxConformance call sites ───
+	enrolledImpls := make(map[string]bool) // "pkg/path.TypeName" → true
+	_ = RunTyped(t, TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, prodPatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				if !strings.HasSuffix(p.Rel(f), "_test.go") {
+					continue
+				}
+				collectEnrolledMetricsProviders(f, p.TypesInfo, enrolledImpls)
+			}
+			return nil
+		})
+
+	// ─── Step 4: flag unenrolled implementations ──────────────────────────────
+	diags := unenrolledMetricsProviders(implSet, enrolledImpls)
+	Report(t, "METRICS-CANCEL-CTX-CONFORMANCE-01", diags)
+}
+
+// TestMetricsCancelCtxConformance_REDFixture exercises the per-impl flag logic
+// (unenrolledMetricsProviders) with synthetic impl/enrollment sets — pure
+// function, no packages.Load. The same-package-partial case is the regression
+// guard against package-granularity enrollment.
+func TestMetricsCancelCtxConformance_REDFixture(t *testing.T) {
+	t.Parallel()
+
+	const (
+		otelPkg = "github.com/ghbvf/gocell/adapters/otel"
+		promPkg = "github.com/ghbvf/gocell/adapters/prometheus"
+		otelP   = otelPkg + ".MetricProvider"
+		promP   = promPkg + ".MetricProvider"
+	)
+	implSet := map[string]bool{otelP: true, promP: true}
+
+	flaggedKeys := func(diags []Diagnostic) map[string]bool {
+		out := make(map[string]bool, len(diags))
+		for _, d := range diags {
+			out[d.Rel] = true
+		}
+		return out
+	}
+
+	t.Run("missing-enrollment", func(t *testing.T) {
+		t.Parallel()
+		diags := unenrolledMetricsProviders(implSet, map[string]bool{otelP: true})
+		got := flaggedKeys(diags)
+		assert.True(t, got[promP], "prometheus.MetricProvider must be flagged when unenrolled")
+		assert.Len(t, diags, 1, "only the unenrolled impl should be flagged: %v", diags)
+	})
+
+	t.Run("all-enrolled-green", func(t *testing.T) {
+		t.Parallel()
+		diags := unenrolledMetricsProviders(implSet, implSet)
+		assert.Empty(t, diags, "fully enrolled implSet must produce zero violations")
+	})
+}
+
+// TestMetricsCancelCtxConformance_ReverseBlindSpot (blind spot B1) confirms no
+// adapters/ non-test file references the interface name "Provider" as a string
+// literal — which would hint at a reflect-based implicit implementation the
+// *types.Info impl scan cannot see.
+func TestMetricsCancelCtxConformance_ReverseBlindSpot(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping archtest in -short mode")
+	}
+	root := findModuleRoot(t)
+	scope := ModuleScope(root)
+
+	diags := Run(t, scope, func(p *Pass) []Diagnostic {
+		var out []Diagnostic
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			if strings.HasSuffix(rel, "_test.go") || !strings.HasPrefix(rel, metricsProviderScopePrefix) {
+				continue
+			}
+			EachInSubtree[ast.BasicLit](f, func(lit *ast.BasicLit) {
+				val, ok := StringLitValue(lit)
+				if !ok || val != metricsProviderIfaceName {
+					return
+				}
+				out = append(out, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(lit.Pos()).Line,
+					Message: "blind-spot B1: string literal \"Provider\" in adapters/ production code " +
+						"may indicate reflect-based impl (METRICS-CANCEL-CTX-CONFORMANCE-01)",
+				})
+			})
+		}
+		return out
+	})
+	assert.Empty(t, diags,
+		"B1 reverse: no adapters/ non-test file should contain the string literal %q as reflect bait",
+		metricsProviderIfaceName)
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// inMetricsProviderScope reports whether pkgPath is under adapters/.
+func inMetricsProviderScope(pkgPath, modPath string) bool {
+	rel := strings.TrimPrefix(pkgPath, modPath+"/")
+	if rel == pkgPath {
+		return false
+	}
+	return strings.HasPrefix(rel, metricsProviderScopePrefix)
+}
+
+// collectMetricsProviderImpls adds to implSet every concrete (non-interface)
+// named type in pkg that implements metrics.Provider (directly or via pointer).
+func collectMetricsProviderImpls(pkg *types.Package, iface *types.Interface, implSet map[string]bool) {
+	for _, name := range pkg.Scope().Names() {
+		obj, ok := pkg.Scope().Lookup(name).(*types.TypeName)
+		if !ok {
+			continue
+		}
+		tt := obj.Type()
+		if _, isIface := tt.Underlying().(*types.Interface); isIface {
+			continue
+		}
+		if typesutil.ImplementsInterface(tt, iface) {
+			implSet[pkg.Path()+"."+name] = true
+		}
+	}
+}
+
+// collectEnrolledMetricsProviders records the concrete impl key of every
+// Provider argument (args[1]) passed to a metricstest.RunCancelledCtxConformance
+// call in file. Signature: RunCancelledCtxConformance(t, p, rb) — args[1] is
+// resolved to its concrete type so enrollment is per-implementation.
+func collectEnrolledMetricsProviders(file *ast.File, info *types.Info, enrolled map[string]bool) {
+	if info == nil {
+		return
+	}
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != cancelCtxConformancePkg || name != cancelCtxConformanceFunc {
+			return
+		}
+		if len(call.Args) < 2 {
+			return
+		}
+		if key, ok := concreteImplKey(info, call.Args[1]); ok {
+			enrolled[key] = true
+		}
+	})
+}
+
+// unenrolledMetricsProviders returns a sorted Diagnostic for every impl in
+// implSet absent from enrolledImpls. Pure function — exercised by the REDFixture.
+func unenrolledMetricsProviders(implSet, enrolledImpls map[string]bool) []Diagnostic {
+	var diags []Diagnostic
+	for implKey := range implSet {
+		if enrolledImpls[implKey] {
+			continue
+		}
+		pkgPath := implKey
+		if dotIdx := strings.LastIndex(implKey, "."); dotIdx >= 0 {
+			pkgPath = implKey[:dotIdx]
+		}
+		diags = append(diags, Diagnostic{
+			Rel:  implKey,
+			Line: 0,
+			Message: fmt.Sprintf(
+				"archtest: metrics.Provider impl %q not enrolled in a "+
+					"metricstest.RunCancelledCtxConformance test call "+
+					"(METRICS-CANCEL-CTX-CONFORMANCE-01). Add a _test.go in package %s that calls "+
+					"metricstest.RunCancelledCtxConformance(t, provider, readback) passing this "+
+					"concrete Provider, asserting the no-skip-on-cancel contract "+
+					"(kernel/observability/metrics/metrics.go §contract (1)).",
+				implKey, pkgPath),
+		})
+	}
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	return diags
+}

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -338,7 +338,8 @@ func TestBuild_EmptyKnownWrapperBucketsUseDefaults(t *testing.T) {
 		require.NoError(t, err)
 		buckets, err := sp.configBuckets(
 			cfgExpr.(*ast.CompositeLit), "DurationBuckets",
-			runtimeMetricsPkg, "DefaultDurationBuckets", "fixture.go")
+			runtimeMetricsPkg, "DefaultDurationBuckets", "fixture.go",
+		)
 		require.NoError(t, err)
 		assert.Equal(t, []string{".005", ".01", ".025", ".05", ".1", ".25", ".5", "1", "2.5", "5", "10"}, buckets)
 	}
@@ -349,6 +350,7 @@ func TestCheckOBS01DetectsDirectLocalAndHelperParamClassifiers(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -357,16 +359,16 @@ import (
 )
 
 func direct(v metrics.CounterVec, err error) {
-	v.With(metrics.Labels{"reason": fmt.Sprint(ec.IsInfraError(err))}).Inc()
+	v.With(metrics.Labels{"reason": fmt.Sprint(ec.IsInfraError(err))}).Inc(context.Background())
 }
 
 func local(v metrics.CounterVec, err error) {
 	reason := fmt.Sprint(ec.IsInfraError(err))
-	v.With(metrics.Labels{"reason": reason}).Inc()
+	v.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func helper(v metrics.CounterVec, reason string) {
-	v.With(metrics.Labels{"reason": reason}).Inc()
+	v.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func viaHelper(v metrics.CounterVec, err error) {
@@ -375,7 +377,7 @@ func viaHelper(v metrics.CounterVec, err error) {
 
 func negative(v metrics.CounterVec, err error) {
 	if errors.Is(err, errors.ErrUnsupported) {
-		v.With(metrics.Labels{"reason": "unsupported"}).Inc()
+		v.With(metrics.Labels{"reason": "unsupported"}).Inc(context.Background())
 	}
 }
 `)
@@ -395,6 +397,7 @@ func TestCheckOBS01DetectsHelperReturnClassifiers(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -412,7 +415,7 @@ func classify(err error) string {
 }
 
 func direct(err error) {
-	counter.With(metrics.Labels{"reason": classify(err)}).Inc()
+	counter.With(metrics.Labels{"reason": classify(err)}).Inc(context.Background())
 }
 `)
 
@@ -429,6 +432,7 @@ func TestCheckOBS01DetectsNamedAndMultiReturnHelperClassifiers(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -451,22 +455,22 @@ func multi(err error) (bool, string) {
 }
 
 func useNamed(err error) {
-	counter.With(metrics.Labels{"reason": named(err)}).Inc()
+	counter.With(metrics.Labels{"reason": named(err)}).Inc(context.Background())
 }
 
 func useMulti(err error) {
 	_, reason := multi(err)
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func useVarMulti(err error) {
 	var _, reason = multi(err)
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func useMultiFlag(err error) {
 	flag, _ := multi(err)
-	counter.With(metrics.Labels{"reason": fmt.Sprint(flag)}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(flag)}).Inc(context.Background())
 }
 `)
 
@@ -480,6 +484,7 @@ func TestCheckOBS01DetectsExpandedMultiReturnHelperArgsByPosition(t *testing.T) 
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -497,11 +502,11 @@ func multi(err error) (bool, string) {
 }
 
 func helperReason(_ bool, reason string) {
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func helperFlag(flag bool, _ string) {
-	counter.With(metrics.Labels{"reason": fmt.Sprint(flag)}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(flag)}).Inc(context.Background())
 }
 
 func useReason(err error) {
@@ -525,6 +530,7 @@ func TestCheckOBS01DetectsBranchTaintBeforeSink(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -544,7 +550,7 @@ func branched(err error, safe bool) {
 	} else {
 		reason = fmt.Sprint(errcode.IsInfraError(err))
 	}
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 `)
 
@@ -560,6 +566,7 @@ func TestCheckOBS01DetectsCommaOKTupleExpressionTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -574,7 +581,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 
 func commaOK(err error) {
 	_, ok := map[string]string{}[fmt.Sprint(errcode.IsInfraError(err))]
-	counter.With(metrics.Labels{"reason": fmt.Sprint(ok)}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(ok)}).Inc(context.Background())
 }
 `)
 
@@ -590,6 +597,7 @@ func TestCheckOBS01DoesNotMergeTerminatedBranchTaintIntoLaterSink(t *testing.T) 
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -608,7 +616,7 @@ func terminated(err error, unsafe bool) {
 		reason = fmt.Sprint(errcode.IsInfraError(err))
 		return
 	}
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 `)
 
@@ -622,6 +630,7 @@ func TestCheckOBS01DetectsSwitchFallthroughTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -641,7 +650,7 @@ func fallthroughTaint(err error, code int) {
 		reason = fmt.Sprint(errcode.IsInfraError(err))
 		fallthrough
 	case 2:
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 `)
@@ -658,6 +667,7 @@ func TestCheckOBS01DetectsRangeValueTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -672,7 +682,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 
 func rangeValue(err error) {
 	for _, reason := range []string{fmt.Sprint(errcode.IsInfraError(err))} {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 `)
@@ -689,6 +699,7 @@ func TestCheckOBS01DetectsFuncLiteralLocalTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -704,7 +715,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func literal(err error) {
 	func() {
 		reason := fmt.Sprint(errcode.IsInfraError(err))
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}()
 }
 `)
@@ -720,7 +731,11 @@ func TestCheckOBS01DetectsGlobalTransitiveHelperSinkParams(t *testing.T) {
 	root := writeMetricsFixture(t)
 	writeFile(t, root, "shared/obs.go", `package shared
 
-import "github.com/ghbvf/gocell/kernel/observability/metrics"
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+)
 
 var provider = metrics.NopProvider{}
 var counter, _ = provider.CounterVec(metrics.CounterOpts{
@@ -729,7 +744,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 })
 
 func Record(reason string) {
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func Forward(reason string) {
@@ -774,6 +789,8 @@ func Reason(err error) string {
 	writeFile(t, root, "cmd/app/obs.go", `package main
 
 import (
+	"context"
+
 	"example.com/metricsfixture/pkg/obsreason"
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 )
@@ -785,7 +802,7 @@ var obsCounter, _ = obsProvider.CounterVec(metrics.CounterOpts{
 })
 
 func viaPkgHelper(err error) {
-	obsCounter.With(metrics.Labels{"reason": obsreason.Reason(err)}).Inc()
+	obsCounter.With(metrics.Labels{"reason": obsreason.Reason(err)}).Inc(context.Background())
 }
 `)
 
@@ -814,6 +831,7 @@ func TestCheckOBS01DetectsIIFEParamTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -828,7 +846,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 
 func iife(err error) {
 	func(reason string) {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}(fmt.Sprint(errcode.IsInfraError(err)))
 }
 `)
@@ -845,6 +863,7 @@ func TestCheckOBS01DoesNotScanUncalledFuncLiteral(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -860,7 +879,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func uncalled(err error) {
 	reason := fmt.Sprint(errcode.IsInfraError(err))
 	_ = func() {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 `)
@@ -875,6 +894,7 @@ func TestCheckOBS01DetectsCalledFuncLiteralVariable(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -890,7 +910,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func called(err error) {
 	reason := fmt.Sprint(errcode.IsInfraError(err))
 	f := func() {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 	f()
 }
@@ -908,6 +928,7 @@ func TestCheckOBS01DetectsCompoundAssignmentPreservesTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -923,7 +944,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func compound(err error) {
 	reason := fmt.Sprint(errcode.IsInfraError(err))
 	reason += ""
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 `)
 
@@ -939,6 +960,7 @@ func TestCheckOBS01DoesNotTaintRangeIndexFromSliceValue(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -953,7 +975,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 
 func rangeIndex(err error) {
 	for i := range []string{fmt.Sprint(errcode.IsInfraError(err))} {
-		counter.With(metrics.Labels{"reason": fmt.Sprint(i)}).Inc()
+		counter.With(metrics.Labels{"reason": fmt.Sprint(i)}).Inc(context.Background())
 	}
 }
 `)
@@ -968,6 +990,7 @@ func TestCheckOBS01DetectsMapLabelMutation(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -983,7 +1006,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func mapMutation(err error) {
 	labels := metrics.Labels{}
 	labels["reason"] = fmt.Sprint(errcode.IsInfraError(err))
-	counter.With(labels).Inc()
+	counter.With(labels).Inc(context.Background())
 }
 `)
 
@@ -1063,6 +1086,7 @@ func TestCheckOBS01DetectsBreakTaintAfterSwitch(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1082,7 +1106,7 @@ func breakTaint(err error, code int) {
 		reason = fmt.Sprint(errcode.IsInfraError(err))
 		break
 	}
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 `)
 
@@ -1098,6 +1122,7 @@ func TestCheckOBS01DoesNotCollectSinkParamsFromUncalledLiteral(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1112,7 +1137,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 
 func wrapper(reason string) {
 	_ = func() {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 
@@ -1131,6 +1156,7 @@ func TestCheckOBS01DetectsIIFEReturnTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1151,7 +1177,7 @@ func helper(err error) (reason string) {
 }
 
 func direct(err error) {
-	counter.With(metrics.Labels{"reason": helper(err)}).Inc()
+	counter.With(metrics.Labels{"reason": helper(err)}).Inc(context.Background())
 }
 `)
 
@@ -1195,6 +1221,7 @@ func TestCheckOBS01DetectsAssignedMapKeyRangeTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1210,7 +1237,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func rangeMapKey(err error) {
 	values := map[string]string{fmt.Sprint(errcode.IsInfraError(err)): "x"}
 	for reason := range values {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 `)
@@ -1227,6 +1254,7 @@ func TestCheckOBS01BranchClosureBindingsMerge(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1244,7 +1272,7 @@ func branchClosure(err error, safe bool) {
 	f := func() {}
 	if safe {
 		f = func() {
-			counter.With(metrics.Labels{"reason": reason}).Inc()
+			counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 		}
 	} else {
 		f = func() {}
@@ -1265,6 +1293,7 @@ func TestCheckOBS01ClosureCallCanClearCapturedTaint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1283,7 +1312,7 @@ func clearInClosure(err error) {
 		reason = "ok"
 	}
 	f()
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 `)
 
@@ -1358,6 +1387,7 @@ func TestCheckOBS01DoesNotTaintAssignedMapKeyFromValue(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1373,7 +1403,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func rangeMapValue(err error) {
 	values := map[string]string{"safe": fmt.Sprint(errcode.IsInfraError(err))}
 	for reason := range values {
-		counter.With(metrics.Labels{"reason": reason}).Inc()
+		counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 `)
@@ -1388,6 +1418,7 @@ func TestCheckOBS01DoesNotScanFunctionLiteralExpressionBody(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1404,7 +1435,7 @@ func literalValue(err error) {
 	f := func() string {
 		return fmt.Sprint(errcode.IsInfraError(err))
 	}
-	counter.With(metrics.Labels{"reason": fmt.Sprint(f)}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(f)}).Inc(context.Background())
 }
 `)
 
@@ -1418,6 +1449,7 @@ func TestCheckOBS01DetectsControlFlowAndMutationEdges(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1457,7 +1489,7 @@ func record(vals ...string) {
 func loopCarried(err error) {
 	reason := "ok"
 	for i := 0; i < 2; i++ {
-		loopCounter.With(metrics.Labels{"reason": reason}).Inc()
+		loopCounter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 		reason = fmt.Sprint(errcode.IsInfraError(err))
 	}
 }
@@ -1473,13 +1505,13 @@ func closureAlternatives(err error, clear bool) {
 		f = func() {}
 	}
 	f()
-	closureCounter.With(metrics.Labels{"reason": reason}).Inc()
+	closureCounter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func switchClosure(err error, mode int) {
 	reason := fmt.Sprint(errcode.IsInfraError(err))
 	f := func() {
-		switchCounter.With(metrics.Labels{"reason": reason}).Inc()
+		switchCounter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 	switch mode {
 	case 1:
@@ -1492,7 +1524,7 @@ func continuePost(err error) {
 	reason := "ok"
 	i := 0
 	for ; i < 2; reason = fmt.Sprint(errcode.IsInfraError(err)) {
-		continueCounter.With(metrics.Labels{"reason": reason}).Inc()
+		continueCounter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 		i++
 		continue
 	}
@@ -1506,7 +1538,7 @@ func mapKeyMutation(err error) {
 	values := map[string]string{}
 	values[fmt.Sprint(errcode.IsInfraError(err))] = "x"
 	for reason := range values {
-		mapCounter.With(metrics.Labels{"reason": reason}).Inc()
+		mapCounter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 	}
 }
 `)
@@ -1534,6 +1566,7 @@ func TestCheckOBS01DoesNotReportClearedTaintOrCategoryConstants(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1549,11 +1582,11 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 func cleared(err error) {
 	reason := fmt.Sprint(errcode.IsInfraError(err))
 	reason = "ok"
-	counter.With(metrics.Labels{"reason": reason}).Inc()
+	counter.With(metrics.Labels{"reason": reason}).Inc(context.Background())
 }
 
 func constantCategory() {
-	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.CategoryDomain)}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.CategoryDomain)}).Inc(context.Background())
 }
 `)
 
@@ -1594,6 +1627,7 @@ func TestCheckOBS01RequiresStrictAckFields(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1601,7 +1635,7 @@ import (
 )
 
 func direct(v metrics.CounterVec, err error) {
-	v.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc()
+	v.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
 }
 `)
 	writeFile(t, root, "docs/observability/metrics-migration-acks.yaml", `acknowledgements:
@@ -1620,6 +1654,7 @@ func TestCheckOBS01AckSuppressesMatchingFingerprint(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1633,7 +1668,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 })
 
 func direct(err error) {
-	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
 }
 `)
 
@@ -1671,6 +1706,7 @@ func TestCheckOBS01AckSuppressesMatchingFingerprintWithTrackedDashboard(t *testi
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1684,7 +1720,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 })
 
 func direct(err error) {
-	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
 }
 `)
 
@@ -1716,6 +1752,7 @@ func TestCheckOBS01AckMustMatchMetricAndLabel(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -1729,7 +1766,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 })
 
 func direct(err error) {
-	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc()
+	counter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
 }
 `)
 
@@ -1782,6 +1819,7 @@ func TestCheckOBS01AckCannotSuppressDynamicLabelKey(t *testing.T) {
 	writeFile(t, root, "reachable/obs.go", `package reachable
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -1797,7 +1835,7 @@ var counter, _ = provider.CounterVec(metrics.CounterOpts{
 
 func direct(err error) {
 	label := os.Getenv("LABEL")
-	counter.With(metrics.Labels{label: fmt.Sprint(errcode.IsInfraError(err))}).Inc()
+	counter.With(metrics.Labels{label: fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
 }
 `)
 


### PR DESCRIPTION
## Summary

将 kernel `metrics.Counter/Histogram/Gauge` 接口升级为 **ctx-bearing** 形态对齐 OTel 原生，ctx 沿 caller chain 透传到底，OTel adapter 用真实 ctx 替换 `context.Background()`，并清除三处孤儿 `METRICS-CTX-FUNNEL-01` open-work godoc 锚点。不向后兼容、直接替换（无 deprecation/别名/双路径）。

Closes #863

## 范围与价值

- **生产 adapter 是 Prometheus**（prom client 不消费 ctx，prom 侧形参 `_ context.Context`）。本次 ctx 的实际价值是**前瞻性**（OTel 后端 exemplar/baggage/trace 关联）+ 接口一致性 + 消化孤儿锚点——**不夸大运行时收益**。
- **OUT OF SCOPE**（非 kernel 接口，prom client 直连）：`adapters/vault/transit_metrics.go`（迁移由 #885 跟踪）、`adapters/prometheus/hook_observer.go`、otel pool/messaging 原生 collector。

## ctx 透传决策（优雅简洁：避免仪式形参）

每个发射方法收 ctx；「真 ctx vs Background」决策**上移到调用点**，adapter 不再硬编 Background。有真实 ctx 处透传真 ctx（HTTP `r.Context()`、relay `pollOnce(ctx)`、publish/refresh loop、consumer delivery、shutdown `drainCtx/tearCtx`、config-event `ObserveSettlement(ctx)`）。**唯一**确定无请求 ctx 的是 hook dispatcher 后台 worker（直调 `Inc()`、无中间 collector 方法）→ 调用点显式 `context.Background()` + 注释。

## AI-robust 定级

- 核心不变式「调用点必须传 ctx」= **Hard**（接口改签名后漏传即编译失败，type system 强制）。
- 残留「otel adapter 须用传入 ctx 而非 Background」无 Hard 载体（数据流）→ 由**覆盖全 7 方法的 fake-instrument RED 测试**（`adapters/otel/metric_provider_internal_test.go`）+ review 兜底；不立 Soft archtest（符合 §Soft 严禁立项）。

## Implementation matrix（contract-fanout）

```
Contract: kernel/observability/metrics {Counter,Histogram,Gauge} + 上层 collector 接口
Change: 全部方法加 leading ctx context.Context；adapter 用真实 ctx 替换 Background
Implementations: [x] nop  [x] prometheus(忽略 ctx)  [x] otel(透传)  [x] relay/oidc/rabbitmq/runtime collectors  [x] test spies
Conformance test: adapters/otel TestOtelCounter_CtxPassthrough / TestOtelHistogram_CtxPassthrough / TestOtelGauge_CtxPassthrough
Repro: go test ./adapters/otel/... -run CtxPassthrough
Dependent contracts (governance scan): RelayCollector / ConsumerObserver / runtime Collector / EventRouterCollector / ShutdownCollector / EventbusCacheCollector / ConfigEventCollector / pendingDepthObserver / oidc RefreshCollector / rabbitmq PublisherCollector — 全部同 PR 更新
Invariant inventory: n/a（无 DROP COLUMN / forbiddenColumns）
```

archtest `HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01` 已同步：cellID 校验位从 arg[0] 移到 arg[1]（arg[0] 现为 ctx），不变式不变。`tools/metricschema` OBS-01 checker fixture 同步加 ctx（prom `WithLabelValues` 链保留）。

ref: opentelemetry-go metric/meter.go — Add(ctx,...)/Record(ctx,...) 原生 ctx-bearing 形态

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 与 develop 比对**零新增 test 失败**（develop 既有 archtest 全套 raw-run flaky/pre-existing 失败：CI pinning / saga DAG / saga schema guard 等，本 PR 未触碰）
- [x] otel ctx-passthrough RED→GREEN（全 7 方法）
- [x] `golangci-lint run` 0 issues
- [x] `grep METRICS-CTX-FUNNEL-01 --include=*.go` 锚点清零（仅余 otel 测试的 label 注释）
- [x] PR-time archtest gate (`hack/verify-archtest-invariants.sh`) 绿
- [x] metrics 相关 archtest 隔离运行绿（GaugeVec funnel / OBS-01 ack / HTTP metrics label / span redact）

🤖 Generated with [Claude Code](https://claude.com/claude-code)