### PR TITLE
fix(archtest): REFLECT-STRING-ARG-SCANNER-01 — 单源 helper 收口 10 处 reflect string-arg 盲区 (#948)

### DIFF
--- a/cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red/usage.go
+++ b/cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red/usage.go
@@ -1,0 +1,87 @@
+// Package reflect_string_form_red is the shared RED fixture for
+// REFLECT-STRING-ARG-SCANNER-01 — the single-source reflect.Value
+// {Field,Method}ByName string-arg scanner used by every reflect blind-spot
+// reverse self-check (SESSION-REVOKED-FIELD-ACCESS-01,
+// CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01, DOMAIN-AUTHZ-*, etc.).
+//
+// It exercises the four extraction shapes that the incumbent
+// `call.Args[0].(*ast.BasicLit)` + `strings.Trim(…, "\"")` scan was blind to
+// (issue #948 / PR #542), plus the two boundaries the type-aware scanner must
+// NOT cross:
+//
+//	reflect.ValueOf(sess).FieldByName(`RevokedAt`)        // raw string   → detected
+//	reflect.ValueOf(sess).FieldByName(revokedAtField)     // const ident  → detected
+//	reflect.ValueOf(sess).FieldByName("Revoked" + "At")   // concat       → detected
+//	reflect.ValueOf(u).MethodByName(`CanAuthenticate`)    // raw string   → detected
+//	reflect.ValueOf(u).MethodByName(canAuthMethod)        // const ident  → detected
+//	reflect.ValueOf(u).MethodByName("CanAuth"+"enticate") // concat       → detected
+//	reflect.ValueOf(sess).FieldByName(runtimeName)        // runtime-value→ NOT detected (arg boundary)
+//	fakeReflect{}.FieldByName("RevokedAt")                // non-reflect  → NOT detected (receiver boundary)
+//
+// LOCATION RATIONALE: imports cells/accesscore/internal/domain, so Go's
+// internal-import rule requires this fixture to live under cells/accesscore/.
+// The testdata/ directory excludes the package from `go build ./...` and the
+// `./...` package pattern while archtest loads it via an explicit
+// packages.Load pattern (same convention as value_capture_red).
+package reflect_string_form_red
+
+import (
+	"reflect"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/runtime/auth/session"
+)
+
+// const-ident forms of the protected names.
+const (
+	revokedAtField = "RevokedAt"
+	canAuthMethod  = "CanAuthenticate"
+)
+
+// ── FieldByName("RevokedAt") — three const-expressible forms (must be detected) ──
+
+func badFieldRaw(sess session.Session) reflect.Value {
+	return reflect.ValueOf(sess).FieldByName(`RevokedAt`) // raw string literal
+}
+
+func badFieldConst(sess session.Session) reflect.Value {
+	return reflect.ValueOf(sess).FieldByName(revokedAtField) // const ident
+}
+
+func badFieldConcat(sess session.Session) reflect.Value {
+	return reflect.ValueOf(sess).FieldByName("Revoked" + "At") // string concatenation
+}
+
+// ── MethodByName("CanAuthenticate") — three const-expressible forms (must be detected) ──
+
+func badMethodRaw(u domain.User) reflect.Value {
+	return reflect.ValueOf(u).MethodByName(`CanAuthenticate`)
+}
+
+func badMethodConst(u domain.User) reflect.Value {
+	return reflect.ValueOf(u).MethodByName(canAuthMethod)
+}
+
+func badMethodConcat(u domain.User) reflect.Value {
+	return reflect.ValueOf(u).MethodByName("CanAuth" + "enticate")
+}
+
+// ── Boundary 1 (arg): runtime-value field name folds to no constant, so it is
+// structurally invisible to any static scan — the irreducible reflect caveat. ──
+
+func boundaryRuntimeArg(sess session.Session, runtimeName string) reflect.Value {
+	return reflect.ValueOf(sess).FieldByName(runtimeName)
+}
+
+// ── Boundary 2 (receiver): a non-reflect type that happens to expose a
+// FieldByName(string) method, called with a const banned name. The typed
+// receiver gate (reflect.Value only) must exclude it; the incumbent
+// BasicLit-only scan WOULD have falsely flagged it. ──
+
+type fakeReflect struct{}
+
+func (fakeReflect) FieldByName(name string) bool { return name == "" }
+
+func boundaryNonReflectReceiver() bool {
+	return fakeReflect{}.FieldByName("RevokedAt")
+}

--- a/cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red/usage.go
+++ b/cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red/usage.go
@@ -4,19 +4,23 @@
 // reverse self-check (SESSION-REVOKED-FIELD-ACCESS-01,
 // CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01, DOMAIN-AUTHZ-*, etc.).
 //
-// It exercises the four extraction shapes that the incumbent
-// `call.Args[0].(*ast.BasicLit)` + `strings.Trim(…, "\"")` scan was blind to
-// (issue #948 / PR #542), plus the two boundaries the type-aware scanner must
-// NOT cross:
+// It exercises every extraction shape the type-aware scanner must catch — the
+// const-foldable argument forms the incumbent `call.Args[0].(*ast.BasicLit)` +
+// `strings.Trim(…, "\"")` scan was blind to (issue #948 / PR #542), and the
+// method-EXPRESSION form whose argument offset the len(Args)!=1 scan missed —
+// plus every boundary the scanner must NOT cross:
 //
-//	reflect.ValueOf(sess).FieldByName(`RevokedAt`)        // raw string   → detected
-//	reflect.ValueOf(sess).FieldByName(revokedAtField)     // const ident  → detected
-//	reflect.ValueOf(sess).FieldByName("Revoked" + "At")   // concat       → detected
-//	reflect.ValueOf(u).MethodByName(`CanAuthenticate`)    // raw string   → detected
-//	reflect.ValueOf(u).MethodByName(canAuthMethod)        // const ident  → detected
-//	reflect.ValueOf(u).MethodByName("CanAuth"+"enticate") // concat       → detected
-//	reflect.ValueOf(sess).FieldByName(runtimeName)        // runtime-value→ NOT detected (arg boundary)
-//	fakeReflect{}.FieldByName("RevokedAt")                // non-reflect  → NOT detected (receiver boundary)
+//	reflect.ValueOf(sess).FieldByName(`RevokedAt`)             // raw string    → detected
+//	reflect.ValueOf(sess).FieldByName(revokedAtField)          // const ident   → detected
+//	reflect.ValueOf(sess).FieldByName("Revoked" + "At")        // concat        → detected
+//	reflect.Value.FieldByName(reflect.ValueOf(sess), "X")      // method expr   → detected (name at Args[1])
+//	reflect.ValueOf(u).MethodByName(`CanAuthenticate`)         // raw string    → detected
+//	reflect.ValueOf(u).MethodByName(canAuthMethod)             // const ident   → detected
+//	reflect.ValueOf(u).MethodByName("CanAuth"+"enticate")      // concat        → detected
+//	reflect.Value.MethodByName(reflect.ValueOf(u), "X")        // method expr   → detected (name at Args[1])
+//	reflect.ValueOf(sess).FieldByName(runtimeName)             // runtime-value → NOT detected (arg boundary)
+//	fakeReflect{}.FieldByName / .MethodByName("X")             // non-reflect   → NOT detected (receiver boundary)
+//	reflect.TypeOf(x).FieldByName / .MethodByName("X")         // reflect.Type  → NOT detected (Type, not Value)
 //
 // LOCATION RATIONALE: imports cells/accesscore/internal/domain, so Go's
 // internal-import rule requires this fixture to live under cells/accesscore/.
@@ -66,6 +70,19 @@ func badMethodConcat(u domain.User) reflect.Value {
 	return reflect.ValueOf(u).MethodByName("CanAuth" + "enticate") // string concatenation
 }
 
+// ── Method-expression forms — must be detected. Go spec §Method expressions:
+// the receiver becomes the explicit first argument, so the field/method NAME
+// shifts to Args[1] (and len(Args)==2). The incumbent len(Args)!=1 + Args[0]
+// scan was blind to these (issue #948 follow-up). ──
+
+func badFieldMethodExpr(sess session.Session) reflect.Value {
+	return reflect.Value.FieldByName(reflect.ValueOf(sess), "RevokedAt")
+}
+
+func badMethodMethodExpr(u domain.User) reflect.Value {
+	return reflect.Value.MethodByName(reflect.ValueOf(u), "CanAuthenticate")
+}
+
 // ── Boundary 1 (arg): runtime-value field name folds to no constant, so it is
 // structurally invisible to any static scan — the irreducible reflect caveat. ──
 
@@ -73,15 +90,34 @@ func boundaryRuntimeArg(sess session.Session, runtimeName string) reflect.Value 
 	return reflect.ValueOf(sess).FieldByName(runtimeName)
 }
 
-// ── Boundary 2 (receiver): a non-reflect type that happens to expose a
-// FieldByName(string) method, called with a const banned name. The typed
-// receiver gate (reflect.Value only) must exclude it; the incumbent
-// BasicLit-only scan WOULD have falsely flagged it. ──
+// ── Boundary 2 (receiver — non-reflect type): a non-reflect type that happens
+// to expose FieldByName/MethodByName(string) methods, called with const banned
+// names. The typed receiver gate (reflect.Value only) must exclude both; the
+// incumbent BasicLit-only scan WOULD have falsely flagged them. ──
 
 type fakeReflect struct{}
 
-func (fakeReflect) FieldByName(name string) bool { return name == "" }
+func (fakeReflect) FieldByName(name string) bool  { return name == "" }
+func (fakeReflect) MethodByName(name string) bool { return name == "" }
 
-func boundaryNonReflectReceiver() bool {
+func boundaryNonReflectFieldReceiver() bool {
 	return fakeReflect{}.FieldByName("RevokedAt")
+}
+
+func boundaryNonReflectMethodReceiver() bool {
+	return fakeReflect{}.MethodByName("CanAuthenticate")
+}
+
+// ── Boundary 3 (receiver — reflect.Type): reflect.Type.{Field,Method}ByName
+// returns StructField/Method METADATA, not the field/method VALUE, so it is not
+// a read-bypass vector. The typed receiver gate (reflect.Value, not reflect.Type)
+// must exclude it. ──
+
+func boundaryReflectTypeField(sess session.Session) reflect.StructField {
+	f, _ := reflect.TypeOf(sess).FieldByName("RevokedAt")
+	return f
+}
+
+func boundaryReflectTypeMethod(u domain.User) (reflect.Method, bool) {
+	return reflect.TypeOf(u).MethodByName("CanAuthenticate")
 }

--- a/cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red/usage.go
+++ b/cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red/usage.go
@@ -63,7 +63,7 @@ func badMethodConst(u domain.User) reflect.Value {
 }
 
 func badMethodConcat(u domain.User) reflect.Value {
-	return reflect.ValueOf(u).MethodByName("CanAuth" + "enticate")
+	return reflect.ValueOf(u).MethodByName("CanAuth" + "enticate") // string concatenation
 }
 
 // ── Boundary 1 (arg): runtime-value field name folds to no constant, so it is

--- a/tools/archtest/caching_session_revoke_delegate_only_test.go
+++ b/tools/archtest/caching_session_revoke_delegate_only_test.go
@@ -411,33 +411,22 @@ func TestCachingSessionRevokeDelegateOnly_BlindSpot_Reflect(t *testing.T) {
 
 	var violations []string
 	_ = RunTyped(t, TypedOpts{Tests: false}, []string{"./adapters/redis/..."}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Fset == nil {
+			return nil
+		}
 		for _, file := range p.Files {
 			rel := p.Rel(file)
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "MethodByName" {
-					return
-				}
-				if len(call.Args) != 1 {
-					return
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok {
-					return
-				}
-				name := strings.Trim(lit.Value, `"`)
-				if revokeTargetMethods[name] {
-					line := p.Fset.Position(call.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.MethodByName(%q) detected — "+
-							"archtest cannot see reflect-based invocations",
-						rel, line, name,
-					))
-				}
-			})
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+				func(n string) bool { return revokeTargetMethods[n] }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.MethodByName(%q) detected — "+
+						"archtest cannot see reflect-based invocations",
+					rel, hit.Line, hit.Name,
+				))
+			}
 		}
 		return nil
 	})

--- a/tools/archtest/caching_session_revoke_delegate_only_test.go
+++ b/tools/archtest/caching_session_revoke_delegate_only_test.go
@@ -422,8 +422,8 @@ func TestCachingSessionRevokeDelegateOnly_BlindSpot_Reflect(t *testing.T) {
 			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
 				func(n string) bool { return revokeTargetMethods[n] }) {
 				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.MethodByName(%q) detected — "+
-						"archtest cannot see reflect-based invocations",
+					"%s:%d: CACHING-SESSION-REVOKE-DELEGATE-ONLY-01: reflect.MethodByName(%q) "+
+						"detected — archtest cannot see reflect-based invocations",
 					rel, hit.Line, hit.Name,
 				))
 			}

--- a/tools/archtest/credential_authority_assert_funnel_test.go
+++ b/tools/archtest/credential_authority_assert_funnel_test.go
@@ -71,11 +71,15 @@ package archtest
 //
 //  2. reflect.Value.MethodByName("CanAuthenticate"): AST-invisible at the
 //     bytes that actually invoke the method. Captured by:
-//     TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName.
+//     TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName via the
+//     shared scanReflectStringArgCalls (REFLECT-STRING-ARG-SCANNER-01).
 //
 //  3. reflect.Value.FieldByName("PasswordVersion"): bypasses SelectorExpr
-//     resolution; field name is in a string literal. Captured by:
-//     TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectFieldByName.
+//     resolution; field name is a string argument. Captured by:
+//     TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectFieldByName via the
+//     shared scanReflectStringArgCalls — type-aware receiver gate +
+//     EvaluateConstString cover raw-string / const / concat forms (runtime-value
+//     names remain the irreducible reflect caveat).
 //     (RevokedAt blind-spot is handled by SESSION-REVOKED-FIELD-ACCESS-01.)
 //
 //  4. unsafe.Pointer offset read of a User field: bypasses Go field
@@ -448,6 +452,11 @@ func verifyDirectReadRedFixtureDetectedPerBucket(t *testing.T, pattern, label st
 // `fn := user.CanAuthenticate; fn()`) does NOT appear in non-allowlisted
 // production code. If it did, the upstream prong would miss the deferred
 // fn() CallExpr because Fun would be *ast.Ident, not *ast.SelectorExpr.
+//
+// Detection is typed (ResolveMethodCall + isFunnelMethod), not a name anchor:
+// only a selector that resolves to domain.(*User).CanAuthenticate is flagged,
+// so an unrelated type exposing a CanAuthenticate method does not false-positive
+// (Soft→Medium, issue #948 (b)).
 func TestCredentialAuthorityAssertFunnel_BlindSpot_MethodValueAssignment(t *testing.T) {
 	t.Parallel()
 
@@ -456,7 +465,7 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_MethodValueAssignment(t *test
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -470,14 +479,16 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_MethodValueAssignment(t *test
 				// the SelectorExpr nests inside a CallExpr child of the
 				// AssignStmt, which EachInChildren (depth=1) would miss.
 				EachInSubtree[ast.SelectorExpr](assign, func(sel *ast.SelectorExpr) {
-					if sel.Sel != nil && sel.Sel.Name == credCanAuthenticate {
-						line := p.Fset.Position(assign.Pos()).Line
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d: method-value assignment of CanAuthenticate "+
-								"blind spot detected — archtest would miss the deferred call",
-							rel, line,
-						))
+					fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+					if !ok || !isFunnelMethod(fn) {
+						return
 					}
+					line := p.Fset.Position(assign.Pos()).Line
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: method-value assignment of CanAuthenticate "+
+							"blind spot detected — archtest would miss the deferred call",
+						rel, line,
+					))
 				})
 			})
 		}
@@ -504,7 +515,7 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName(t *testin
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -512,28 +523,14 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName(t *testin
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
-					return
-				}
-				if len(call.Args) != 1 {
-					return
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok {
-					return
-				}
-				name := strings.Trim(lit.Value, `"`)
-				if name == credCanAuthenticate {
-					line := p.Fset.Position(call.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.MethodByName(%q) blind spot detected — "+
-							"archtest cannot see reflect-based invocations",
-						rel, line, name,
-					))
-				}
-			})
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+				func(n string) bool { return n == credCanAuthenticate }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.MethodByName(%q) blind spot detected — "+
+						"archtest cannot see reflect-based invocations",
+					rel, hit.Line, hit.Name,
+				))
+			}
 		}
 		return nil
 	})
@@ -555,16 +552,12 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName(t *testin
 func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectFieldByName(t *testing.T) {
 	t.Parallel()
 
-	bannedNames := map[string]bool{
-		credPasswordVersion: true,
-	}
-
 	var violations []string
 	_ = RunTyped(t, TypedOpts{}, []string{
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -572,28 +565,14 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectFieldByName(t *testing
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel == nil || sel.Sel.Name != "FieldByName" {
-					return
-				}
-				if len(call.Args) != 1 {
-					return
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok {
-					return
-				}
-				name := strings.Trim(lit.Value, `"`)
-				if bannedNames[name] {
-					line := p.Fset.Position(call.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
-							"archtest cannot see reflect-based field reads",
-						rel, line, name,
-					))
-				}
-			})
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectFieldByName,
+				func(n string) bool { return n == credPasswordVersion }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
+						"archtest cannot see reflect-based field reads",
+					rel, hit.Line, hit.Name,
+				))
+			}
 		}
 		return nil
 	})
@@ -674,8 +653,10 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_UnsafePointerRead(t *testing.
 // (SnapshotPasswordVersion, etc.), which controls field initialization.
 //
 // Hard rating: type identity is resolved through *types.Info; exported-name
-// detection is unicode.IsUpper on the first rune, identical to Go's own
-// export rule. Picking any exported name shape is a CI failure.
+// detection uses ast.IsExported (token.IsExported → unicode.IsUpper on the
+// first rune), identical to Go's own export rule — so a Unicode-uppercase
+// exported name (which the prior ASCII-only check missed) is still flagged.
+// Picking any exported name shape is a CI failure.
 func TestCredentialAuthorityAssertFunnel_UpstreamSealed_03(t *testing.T) {
 	t.Parallel()
 
@@ -724,7 +705,7 @@ func TestCredentialAuthorityAssertFunnel_UpstreamSealed_03(t *testing.T) {
 			if !typesutil.ImplementsInterface(named, checkIface) {
 				continue
 			}
-			if !isExportedName(name) {
+			if !ast.IsExported(name) {
 				continue
 			}
 			pos := p.Fset.Position(tn.Pos())
@@ -748,14 +729,6 @@ func TestCredentialAuthorityAssertFunnel_UpstreamSealed_03(t *testing.T) {
 			"concrete struct in credentialauthority/ that implements Check "+
 			"must be unexported, so package-external callers can only obtain "+
 			"a Check through the factory function.")
-}
-
-func isExportedName(s string) bool {
-	if s == "" {
-		return false
-	}
-	r := s[0]
-	return r >= 'A' && r <= 'Z'
 }
 
 // stripModuleRoot turns an absolute filename produced by p.Fset.Position
@@ -867,12 +840,36 @@ func TestCredentialAuthorityAssertFunnel_UpstreamCalleeReference_04(t *testing.T
 // type-assertion expr, type-conversion arg — all are non-CallExpr.Fun
 // positions and produce a violation. No syntactic-context enumeration.
 func scanFunnelCalleeReferences(p *Pass, file *ast.File, rel string) []string {
+	var out []string
+	for _, hit := range collectFunnelCalleeReferenceHits(p, file) {
+		out = append(out, fmt.Sprintf(
+			"%s:%d: CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01 (typed callee reference): "+
+				"%s referenced as value (not direct call) — bypasses "+
+				"caller allowlist via deferred invocation",
+			rel, hit.Line, hit.Callee,
+		))
+	}
+	return out
+}
+
+// funnelCalleeHit is one value-capture reference of a funnel-protected callee.
+type funnelCalleeHit struct {
+	Line   int
+	Callee string // funnelCalleeAssert or funnelCalleeCanAuth
+}
+
+// collectFunnelCalleeReferenceHits is the single-source scan behind both the
+// production assertion (scanFunnelCalleeReferences) and the per-callee RED
+// fixture self-check. Pass 1 collects every CallExpr.Fun node identity; pass 2
+// reports every SelectorExpr that typed-resolves to a funnel callee and is NOT
+// at a CallExpr.Fun position (value capture in any expression slot).
+func collectFunnelCalleeReferenceHits(p *Pass, file *ast.File) []funnelCalleeHit {
 	directCallFuns := map[ast.Expr]struct{}{}
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		directCallFuns[call.Fun] = struct{}{}
 	})
 
-	var out []string
+	var out []funnelCalleeHit
 	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
 		if _, isDirect := directCallFuns[sel]; isDirect {
 			return
@@ -881,13 +878,7 @@ func scanFunnelCalleeReferences(p *Pass, file *ast.File, rel string) []string {
 		if !ok {
 			return
 		}
-		line := p.Fset.Position(sel.Pos()).Line
-		out = append(out, fmt.Sprintf(
-			"%s:%d: CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01 (typed callee reference): "+
-				"%s referenced as value (not direct call) — bypasses "+
-				"caller allowlist via deferred invocation",
-			rel, line, callee,
-		))
+		out = append(out, funnelCalleeHit{Line: p.Fset.Position(sel.Pos()).Line, Callee: callee})
 	})
 	return out
 }
@@ -901,6 +892,15 @@ func scanFunnelCalleeReferences(p *Pass, file *ast.File, rel string) []string {
 //   - domain.(*User).CanAuthenticate — method selector, resolved via
 //     *types.Info.Selections[sel] (handles value or pointer receiver
 //     and embedded promotion uniformly).
+//
+// funnel callee labels — single source shared by resolveFunnelCallee (message
+// + bucket key) and verifyFunnelCalleeReferenceRedFixtureDetected (per-callee
+// assertion), so the two cannot drift.
+const (
+	funnelCalleeAssert  = "credentialauthority.Assert"
+	funnelCalleeCanAuth = "domain.(*User).CanAuthenticate"
+)
+
 func resolveFunnelCallee(info *types.Info, sel *ast.SelectorExpr) (string, bool) {
 	if sel.Sel == nil {
 		return "", false
@@ -909,7 +909,7 @@ func resolveFunnelCallee(info *types.Info, sel *ast.SelectorExpr) (string, bool)
 	if selection := info.Selections[sel]; selection != nil {
 		if fn, ok := selection.Obj().(*types.Func); ok {
 			if isFunnelMethod(fn) {
-				return "domain.(*User).CanAuthenticate", true
+				return funnelCalleeCanAuth, true
 			}
 		}
 	}
@@ -918,7 +918,7 @@ func resolveFunnelCallee(info *types.Info, sel *ast.SelectorExpr) (string, bool)
 	if obj := info.Uses[sel.Sel]; obj != nil {
 		if fn, ok := obj.(*types.Func); ok {
 			if isFunnelPackageFunc(fn) {
-				return "credentialauthority.Assert", true
+				return funnelCalleeAssert, true
 			}
 		}
 	}
@@ -951,27 +951,31 @@ func isFunnelMethod(fn *types.Func) bool {
 	return named.Obj().Name() == domainUserType
 }
 
-// verifyFunnelCalleeReferenceRedFixtureDetected asserts that the RED
-// fixture produces ≥ 1 violation. Per-bucket counting no longer applies:
-// typed-parent-check treats every non-CallExpr.Fun reference uniformly
-// regardless of syntactic context, so the meaningful self-check is
-// whether the detector fires at all, not per-syntactic-shape coverage.
+// verifyFunnelCalleeReferenceRedFixtureDetected asserts the RED fixture fires
+// ≥ 1 violation in EACH callee bucket. The two callees travel DIFFERENT typed
+// resolution paths — credentialauthority.Assert via *types.Info.Uses, and
+// domain.(*User).CanAuthenticate via *types.Info.Selections — so an aggregate
+// ≥ 1 count could silently pass while one resolution path is dead. Per-callee
+// counting proves both paths live (mirrors the Upstream_02 per-bucket rationale;
+// issue #948 (a)).
 func verifyFunnelCalleeReferenceRedFixtureDetected(t *testing.T, pattern, label string) {
 	t.Helper()
-	var found int
+	byCallee := map[string]int{}
 	_ = RunTyped(t, TypedOpts{}, []string{pattern}, func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
 		}
 		for _, file := range p.Files {
-			found += len(scanFunnelCalleeReferences(p, file, label))
+			for _, hit := range collectFunnelCalleeReferenceHits(p, file) {
+				byCallee[hit.Callee]++
+			}
 		}
 		return nil
 	})
-	assert.GreaterOrEqual(t, found, 1,
-		"RED fixture self-check FAILED: %s — expected ≥ 1 violation, got 0. "+
-			"Check that the fixture references credentialauthority.Assert or "+
-			"domain.(*User).CanAuthenticate as a function value (any non-call "+
-			"expression position).",
-		label)
+	assert.GreaterOrEqual(t, byCallee[funnelCalleeAssert], 1,
+		"RED fixture self-check FAILED (Assert via info.Uses): %s — expected ≥ 1 "+
+			"value-capture of credentialauthority.Assert, got 0.", label)
+	assert.GreaterOrEqual(t, byCallee[funnelCalleeCanAuth], 1,
+		"RED fixture self-check FAILED (CanAuthenticate via info.Selections): %s — "+
+			"expected ≥ 1 value-capture of domain.(*User).CanAuthenticate, got 0.", label)
 }

--- a/tools/archtest/credential_authority_assert_funnel_test.go
+++ b/tools/archtest/credential_authority_assert_funnel_test.go
@@ -401,19 +401,6 @@ func scanDirectFieldReads(p *Pass, file *ast.File, rel string) []string {
 	return out
 }
 
-// typeOwner unwraps a *T → T and returns the *types.TypeName for the owning
-// named type, or nil if the type isn't a *types.Named.
-func typeOwner(t types.Type) *types.TypeName {
-	if ptr, ok := t.(*types.Pointer); ok {
-		t = ptr.Elem()
-	}
-	named, ok := t.(*types.Named)
-	if !ok {
-		return nil
-	}
-	return named.Obj()
-}
-
 // verifyDirectReadRedFixtureDetectedPerBucket asserts that the fixture
 // produces ≥ 1 violation in EACH detector category (CanAuthenticate +
 // PasswordVersion). An aggregate ≥ 1 count would let a fixture cover only
@@ -526,8 +513,8 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName(t *testin
 			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
 				func(n string) bool { return n == credCanAuthenticate }) {
 				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.MethodByName(%q) blind spot detected — "+
-						"archtest cannot see reflect-based invocations",
+					"%s:%d: CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01: reflect.MethodByName(%q) blind "+
+						"spot detected — archtest cannot see reflect-based invocations",
 					rel, hit.Line, hit.Name,
 				))
 			}
@@ -568,8 +555,8 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectFieldByName(t *testing
 			for _, hit := range scanReflectStringArgCalls(p, file, reflectFieldByName,
 				func(n string) bool { return n == credPasswordVersion }) {
 				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
-						"archtest cannot see reflect-based field reads",
+					"%s:%d: CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01: reflect.FieldByName(%q) blind "+
+						"spot detected — archtest cannot see reflect-based field reads",
 					rel, hit.Line, hit.Name,
 				))
 			}

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -503,8 +503,9 @@ func TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment(t *testing.T) 
 // ("RevokeUser") does NOT appear in production code, confirming the reflect
 // blind spot is not exercised (which would be scanner-invisible).
 //
-// Scanner: AST-only search for ast.BasicLit STRING containing the banned names
-// as arguments to MethodByName calls.
+// Scanner: shared scanReflectStringArgCalls (REFLECT-STRING-ARG-SCANNER-01) —
+// typed reflect.Value receiver gate + EvaluateConstString arg folding (covers
+// raw-string / const / concat banned names passed to MethodByName).
 func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) {
 	t.Parallel()
 

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -518,7 +518,7 @@ func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) 
 	_ = RunTyped(t, TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/...", "./runtime/auth/...", "./adapters/...", "./cmd/..."},
 		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
+			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
 			}
 			for _, file := range p.Files {
@@ -526,28 +526,13 @@ func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) 
 				if strings.HasSuffix(rel, "_test.go") {
 					continue
 				}
-				EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-					sel, ok := call.Fun.(*ast.SelectorExpr)
-					if !ok || sel.Sel.Name != "MethodByName" {
-						return
-					}
-					if len(call.Args) != 1 {
-						return
-					}
-					lit, ok := call.Args[0].(*ast.BasicLit)
-					if !ok {
-						return
-					}
-					// Strip surrounding quotes from the string literal.
-					name := strings.Trim(lit.Value, `"`)
-					if bannedNames[name] {
-						line := p.Fset.Position(call.Pos()).Line
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d: reflect.MethodByName(%q) blind spot detected — archtest would miss this",
-							rel, line, name,
-						))
-					}
-				})
+				for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+					func(n string) bool { return bannedNames[n] }) {
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: reflect.MethodByName(%q) blind spot detected — archtest would miss this",
+						rel, hit.Line, hit.Name,
+					))
+				}
 			}
 			return nil
 		})

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -530,7 +530,8 @@ func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) 
 				for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
 					func(n string) bool { return bannedNames[n] }) {
 					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.MethodByName(%q) blind spot detected — archtest would miss this",
+						"%s:%d: CREDENTIAL-INVALIDATE-FUNNEL-01: reflect.MethodByName(%q) blind spot "+
+							"detected — archtest cannot see reflect-based invocations",
 						rel, hit.Line, hit.Name,
 					))
 				}

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -538,7 +538,7 @@ func TestDomainAuthzMutation_BlindSpot_ReflectMethodByName(t *testing.T) {
 	_ = RunTyped(t, TypedOpts{}, []string{
 		"./cells/accesscore/...", "./cmd/...",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -546,28 +546,14 @@ func TestDomainAuthzMutation_BlindSpot_ReflectMethodByName(t *testing.T) {
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "MethodByName" {
-					return
-				}
-				if len(call.Args) != 1 {
-					return
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok {
-					return
-				}
-				name := strings.Trim(lit.Value, `"`)
-				if bannedNames[name] {
-					line := p.Fset.Position(call.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.MethodByName(%q) blind spot detected — "+
-							"archtest cannot see reflect-based invocations of authz setters",
-						rel, line, name,
-					))
-				}
-			})
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+				func(n string) bool { return bannedNames[n] }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.MethodByName(%q) blind spot detected — "+
+						"archtest cannot see reflect-based invocations of authz setters",
+					rel, hit.Line, hit.Name,
+				))
+			}
 		}
 		return nil
 	})
@@ -656,7 +642,7 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 	_ = RunTyped(t, TypedOpts{}, []string{
 		"./cells/accesscore/...", "./cmd/...",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -664,28 +650,14 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "FieldByName" {
-					return
-				}
-				if len(call.Args) != 1 {
-					return
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok {
-					return
-				}
-				name := strings.Trim(lit.Value, `"`)
-				if bannedFieldNames[name] {
-					line := p.Fset.Position(call.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
-							"archtest cannot see reflect-based writes to domain.User authz fields",
-						rel, line, name,
-					))
-				}
-			})
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectFieldByName,
+				func(n string) bool { return bannedFieldNames[n] }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
+						"archtest cannot see reflect-based writes to domain.User authz fields",
+					rel, hit.Line, hit.Name,
+				))
+			}
 		}
 		return nil
 	})

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -472,7 +472,8 @@ func verifySetMutatorRedFixtureDetected(
 //
 // Scanner: EachInSubtree[ast.AssignStmt] + right-hand-side SelectorExpr name
 // matching. AST-only (no type info), but the method names are distinct enough
-// to avoid false positives.
+// to avoid false positives. Soft (name-only); typed-resolver upgrade tracked
+// in #1118 (method-value name-only detection across sites).
 func TestDomainAuthzMutation_BlindSpot_MethodValueAssignment(t *testing.T) {
 	t.Parallel()
 

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -550,8 +550,8 @@ func TestDomainAuthzMutation_BlindSpot_ReflectMethodByName(t *testing.T) {
 			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
 				func(n string) bool { return bannedNames[n] }) {
 				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.MethodByName(%q) blind spot detected — "+
-						"archtest cannot see reflect-based invocations of authz setters",
+					"%s:%d: DOMAIN-AUTHZ-FIELD-PRIVATE-01: reflect.MethodByName(%q) blind spot "+
+						"detected — archtest cannot see reflect-based invocations of authz setters",
 					rel, hit.Line, hit.Name,
 				))
 			}
@@ -654,8 +654,8 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 			for _, hit := range scanReflectStringArgCalls(p, file, reflectFieldByName,
 				func(n string) bool { return bannedFieldNames[n] }) {
 				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
-						"archtest cannot see reflect-based writes to domain.User authz fields",
+					"%s:%d: DOMAIN-AUTHZ-FIELD-PRIVATE-01: reflect.FieldByName(%q) blind spot "+
+						"detected — archtest cannot see reflect-based writes to domain.User authz fields",
 					rel, hit.Line, hit.Name,
 				))
 			}

--- a/tools/archtest/healthz_invariants_test.go
+++ b/tools/archtest/healthz_invariants_test.go
@@ -743,7 +743,7 @@ func TestHealthzInvariants_ReverseBlindSpot_NoReflectHealthz(t *testing.T) {
 	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./cells/..."},
 		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
+			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
 			}
 			for _, f := range p.Files {
@@ -751,25 +751,15 @@ func TestHealthzInvariants_ReverseBlindSpot_NoReflectHealthz(t *testing.T) {
 				if strings.HasSuffix(rel, "_test.go") {
 					continue
 				}
-				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-					sel, ok := call.Fun.(*ast.SelectorExpr)
-					if !ok || sel.Sel.Name != "MethodByName" || len(call.Args) != 1 {
-						return
-					}
-					lit, ok := call.Args[0].(*ast.BasicLit)
-					if !ok {
-						return
-					}
-					if strings.Trim(lit.Value, `"`) == "Healthz" {
-						line := p.Fset.Position(call.Pos()).Line
-						diags = append(diags, Diagnostic{
-							Rel:  rel,
-							Line: line,
-							Message: "reflect MethodByName(\"Healthz\") in cells/ bypasses " +
-								"HEALTHZ-TYPED-REGISTER-01 (blind spot B1)",
-						})
-					}
-				})
+				for _, hit := range scanReflectStringArgCalls(p, f, reflectMethodByName,
+					func(n string) bool { return n == "Healthz" }) {
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: hit.Line,
+						Message: "reflect MethodByName(\"Healthz\") in cells/ bypasses " +
+							"HEALTHZ-TYPED-REGISTER-01 (blind spot B1)",
+					})
+				}
 			}
 			return nil
 		})

--- a/tools/archtest/helpers_test.go
+++ b/tools/archtest/helpers_test.go
@@ -3,6 +3,7 @@
 package archtest
 
 import (
+	"go/types"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -11,6 +12,21 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
+
+// typeOwner unwraps a *T → T and returns the *types.TypeName for the owning
+// named type, or nil if the type isn't a *types.Named. Shared by the typed
+// field/method receiver checks across funnel and reflect blind-spot archtests
+// (credential_authority / session_revoked / reflect_string_arg).
+func typeOwner(t types.Type) *types.TypeName {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return nil
+	}
+	return named.Obj()
+}
 
 // findAllGoFilesInDir walks dir and returns all .go files (including _test.go).
 // Skips vendor, .git, generated, and testdata directories.

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1936,6 +1936,7 @@ func TestOutboxtestCloseViaBudget01_BlindSpot_NoMethodValue(t *testing.T) {
 
 				// Blind spot 1: SelectorExpr with Sel.Name == "Close" that is NOT
 				// in a CallExpr.Fun position — potential method-value assignment.
+				// Soft (name-only); typed-resolver upgrade tracked in #1118.
 				EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
 					if sel.Sel == nil || sel.Sel.Name != "Close" {
 						return

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1920,7 +1920,7 @@ func TestOutboxtestCloseViaBudget01_BlindSpot_NoMethodValue(t *testing.T) {
 	_ = RunTyped(t, TypedOpts{Tests: true},
 		[]string{outboxtestPattern},
 		func(p *Pass) []Diagnostic {
-			if p.Fset == nil {
+			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
 			}
 			for _, file := range p.Files {
@@ -1951,27 +1951,14 @@ func TestOutboxtestCloseViaBudget01_BlindSpot_NoMethodValue(t *testing.T) {
 				})
 
 				// Blind spot 2: reflect.MethodByName("Close")
-				EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-					sel, ok := call.Fun.(*ast.SelectorExpr)
-					if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
-						return
-					}
-					if len(call.Args) != 1 {
-						return
-					}
-					lit, ok := call.Args[0].(*ast.BasicLit)
-					if !ok {
-						return
-					}
-					name := strings.Trim(lit.Value, `"`)
-					if name == "Close" {
-						violations = append(violations, violation{
-							rel:  rel,
-							line: p.Fset.Position(call.Pos()).Line,
-							msg:  `reflect.MethodByName("Close") detected — OUTBOXTEST-CLOSE-VIA-BUDGET-01 cannot see reflect-based invocations`,
-						})
-					}
-				})
+				for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+					func(n string) bool { return n == "Close" }) {
+					violations = append(violations, violation{
+						rel:  rel,
+						line: hit.Line,
+						msg:  `reflect.MethodByName("Close") detected — OUTBOXTEST-CLOSE-VIA-BUDGET-01 cannot see reflect-based invocations`,
+					})
+				}
 			}
 			return nil
 		})

--- a/tools/archtest/reconstitute_user_caller_allowlist_test.go
+++ b/tools/archtest/reconstitute_user_caller_allowlist_test.go
@@ -240,7 +240,7 @@ func TestReconstituteUser_BlindSpot_NoMethodValueOrReflectInProd(t *testing.T) {
 	RunTyped(t, TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/...", "./cmd/..."},
 		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil || p.Fset == nil {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Fset == nil {
 				return nil
 			}
 			var diags []Diagnostic
@@ -253,7 +253,8 @@ func TestReconstituteUser_BlindSpot_NoMethodValueOrReflectInProd(t *testing.T) {
 				// Blind spot 1: SelectorExpr with Sel.Name == "ReconstituteUser" that is
 				// NOT in a CallExpr.Fun position. We collect all CallExpr.Fun selectors
 				// first, then flag any SelectorExpr with the target name that is absent
-				// from that set.
+				// from that set. Soft (name-only, not typed); typed-resolver upgrade
+				// tracked in #1118 (method-value name-only detection across sites).
 				callFunPositions := map[ast.Node]bool{}
 				EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 					if sel, ok := call.Fun.(*ast.SelectorExpr); ok {

--- a/tools/archtest/reconstitute_user_caller_allowlist_test.go
+++ b/tools/archtest/reconstitute_user_caller_allowlist_test.go
@@ -278,33 +278,19 @@ func TestReconstituteUser_BlindSpot_NoMethodValueOrReflectInProd(t *testing.T) {
 					})
 				})
 
-				// Blind spot 2: MethodByName("ReconstituteUser")
-				EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-					sel, ok := call.Fun.(*ast.SelectorExpr)
-					if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
-						return
-					}
-					if len(call.Args) != 1 {
-						return
-					}
-					lit, ok := call.Args[0].(*ast.BasicLit)
-					if !ok {
-						return
-					}
-					name := strings.Trim(lit.Value, `"`)
-					if name == reconstituteUserName {
-						line := p.Fset.Position(call.Pos()).Line
-						diags = append(diags, Diagnostic{
-							Rel:  rel,
-							Line: line,
-							Message: fmt.Sprintf(
-								"reflect.MethodByName(%q) detected — "+
-									"RECONSTITUTE-USER-CALLER-01 cannot see reflect-based invocations",
-								name,
-							),
-						})
-					}
-				})
+				// Blind spot 2: reflect.MethodByName("ReconstituteUser")
+				for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+					func(n string) bool { return n == reconstituteUserName }) {
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: hit.Line,
+						Message: fmt.Sprintf(
+							"reflect.MethodByName(%q) detected — "+
+								"RECONSTITUTE-USER-CALLER-01 cannot see reflect-based invocations",
+							hit.Name,
+						),
+					})
+				}
 			}
 			allDiags = append(allDiags, diags...)
 			return nil

--- a/tools/archtest/reflect_string_arg_test.go
+++ b/tools/archtest/reflect_string_arg_test.go
@@ -25,7 +25,7 @@ package archtest
 //	2. typed arg: EvaluateConstString folds the single argument (covers raw
 //	   string / const ident / concatenation / cross-package const), replacing
 //	   the incumbent *ast.BasicLit + strings.Trim that was blind to all but the
-//	   plain double-quoted literal.
+//	   plain double-quoted literal (issue #948 / PR #542).
 //
 // Why not Hard (upgrade path exhausted): reflect.Value.FieldByName(runtimeVar)
 // with a non-constant name cannot be folded → invisible to any static scan
@@ -50,7 +50,7 @@ package archtest
 
 import (
 	"go/ast"
-	"strings"
+	"go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +61,8 @@ import (
 const (
 	reflectFieldByName  = "FieldByName"
 	reflectMethodByName = "MethodByName"
+	reflectPkgPath      = "reflect"
+	reflectValueType    = "Value"
 )
 
 // reflectStringArgHit is one detected reflect.Value.{Field,Method}ByName call
@@ -73,12 +75,9 @@ type reflectStringArgHit struct {
 // scanReflectStringArgCalls walks file for calls to reflect.Value.<method>
 // (method ∈ {"FieldByName","MethodByName"}) whose single argument is a banned
 // constant string. See the package-level INVARIANT doc for the type-aware
-// two-gate design and grading.
-//
-// NOTE (Wave 1 RED stub): this body is the incumbent *ast.BasicLit-only
-// extraction, deliberately blind to raw-string / const / concat forms and to
-// the receiver type. TestReflectStringArgScanner_TypedReceiverAndConstArg fails
-// against it; Wave 2 replaces the body with the typed two-gate implementation.
+// two-gate design and grading. The sel.Sel.Name == method check is only a cheap
+// pre-filter; the real gate is isReflectValueMethod (typed receiver) +
+// EvaluateConstString (typed arg).
 func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned func(string) bool) []reflectStringArgHit {
 	var out []reflectStringArgHit
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
@@ -89,12 +88,11 @@ func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned fu
 		if len(call.Args) != 1 {
 			return
 		}
-		lit, ok := call.Args[0].(*ast.BasicLit)
-		if !ok {
+		if !isReflectValueMethod(p.TypesInfo, sel) {
 			return
 		}
-		name := strings.Trim(lit.Value, `"`)
-		if !banned(name) {
+		name, ok := EvaluateConstString(p.TypesInfo, call.Args[0])
+		if !ok || !banned(name) {
 			return
 		}
 		out = append(out, reflectStringArgHit{
@@ -103,6 +101,23 @@ func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned fu
 		})
 	})
 	return out
+}
+
+// isReflectValueMethod reports whether sel typed-resolves to a method of
+// reflect.Value (pkg "reflect", receiver named type "Value"). This is the typed
+// receiver gate that separates a genuine reflect bypass from a non-reflect type
+// exposing a same-named method and from reflect.Type.FieldByName metadata reads.
+func isReflectValueMethod(info *types.Info, sel *ast.SelectorExpr) bool {
+	fn, ok := ResolveMethodCall(info, sel)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != reflectPkgPath {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	owner := typeOwner(sig.Recv().Type())
+	return owner != nil && owner.Name() == reflectValueType
 }
 
 // TestReflectStringArgScanner_TypedReceiverAndConstArg is the reverse

--- a/tools/archtest/reflect_string_arg_test.go
+++ b/tools/archtest/reflect_string_arg_test.go
@@ -1,0 +1,141 @@
+package archtest
+
+// reflect_string_arg_test.go — single source for the reflect.Value
+// {Field,Method}ByName string-argument scanner shared by every reflect
+// blind-spot reverse self-check, plus its own reverse self-check fixture.
+//
+// INVARIANT: REFLECT-STRING-ARG-SCANNER-01
+//
+// Category (ai-robust.md §"工具选定后强制盲区自检"): the reflect/unsafe
+// blind-spot tests are the MANDATED reverse self-checks that supply the
+// prerequisite evidence for the Hard primary field-access funnels (typed
+// *types.Info.Selections resolution). They are not standalone Soft invariants
+// subject to the ≥Medium 立项 threshold; the charter REQUIRES them to exist.
+//
+// Grade — Medium (Soft→Medium upgrade, ai-robust.md "既有 Soft → 升级 Medium,
+// 不在 Soft 层打补丁"): scanReflectStringArgCalls identifies a violation through
+// TYPE information, not a string anchor —
+//
+//	1. typed receiver: ResolveMethodCall must resolve the call to a method of
+//	   reflect.Value (pkg=="reflect", receiver type=="Value"). This excludes
+//	   non-reflect types that happen to expose a FieldByName/MethodByName
+//	   method, and reflect.Type.FieldByName (which returns StructField metadata
+//	   and cannot read a field VALUE — not a bypass vector; see the legitimate
+//	   use in contract_subscribers_funnel_test.go).
+//	2. typed arg: EvaluateConstString folds the single argument (covers raw
+//	   string / const ident / concatenation / cross-package const), replacing
+//	   the incumbent *ast.BasicLit + strings.Trim that was blind to all but the
+//	   plain double-quoted literal.
+//
+// Why not Hard (upgrade path exhausted): reflect.Value.FieldByName(runtimeVar)
+// with a non-constant name cannot be folded → invisible to any static scan
+// (the irreducible reflect caveat, shared by all reflect scans). A blanket
+// reflect-import ban (the Hard form, mirroring the sibling unsafe-import ban)
+// is infeasible because the scanned scopes (cells/ + runtime/ + cmd/)
+// legitimately use reflect. Medium is the reachable ceiling.
+//
+// Blind-spot reverse self-check: TestReflectStringArgScanner_TypedReceiverAndConstArg
+// loads testdata/reflect_string_form_red and asserts the three const-form
+// FieldByName + three const-form MethodByName calls are detected, AND that the
+// two boundary calls (runtime-value arg; non-reflect receiver) are NOT — pinning
+// both Medium boundaries as tested facts.
+//
+// Residual gap (not Hard-closable, not a 立项-able Soft guard): a NEW blind-spot
+// test re-inlining BasicLit extraction instead of calling this helper. A clean
+// guard is infeasible (archtest itself has legitimate reflect.Type.FieldByName
+// uses, so distinguishing "blind-spot scan" from "legit reflection" needs
+// fragile semantic adjacency = Soft, which ai-robust.md forbids 立项). Mitigated
+// by single-sourcing here + this meta-test (guards the helper from regressing)
+// + review. Documented, not silently carried.
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// reflect method names + the receiver-type identity, hoisted to constants
+// because they recur across the ten reverse-self-check call sites.
+const (
+	reflectFieldByName  = "FieldByName"
+	reflectMethodByName = "MethodByName"
+)
+
+// reflectStringArgHit is one detected reflect.Value.{Field,Method}ByName call
+// whose constant-folded string argument is in the caller's banned set.
+type reflectStringArgHit struct {
+	Line int
+	Name string // the constant-folded argument value
+}
+
+// scanReflectStringArgCalls walks file for calls to reflect.Value.<method>
+// (method ∈ {"FieldByName","MethodByName"}) whose single argument is a banned
+// constant string. See the package-level INVARIANT doc for the type-aware
+// two-gate design and grading.
+//
+// NOTE (Wave 1 RED stub): this body is the incumbent *ast.BasicLit-only
+// extraction, deliberately blind to raw-string / const / concat forms and to
+// the receiver type. TestReflectStringArgScanner_TypedReceiverAndConstArg fails
+// against it; Wave 2 replaces the body with the typed two-gate implementation.
+func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned func(string) bool) []reflectStringArgHit {
+	var out []reflectStringArgHit
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != method {
+			return
+		}
+		if len(call.Args) != 1 {
+			return
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok {
+			return
+		}
+		name := strings.Trim(lit.Value, `"`)
+		if !banned(name) {
+			return
+		}
+		out = append(out, reflectStringArgHit{
+			Line: p.Fset.Position(call.Pos()).Line,
+			Name: name,
+		})
+	})
+	return out
+}
+
+// TestReflectStringArgScanner_TypedReceiverAndConstArg is the reverse
+// self-check for REFLECT-STRING-ARG-SCANNER-01. It loads the shared RED fixture
+// and asserts exact hit counts: each const-form is detected, and neither
+// boundary call (runtime-value arg, non-reflect receiver) is — an exact count
+// of 3 simultaneously proves the positive forms AND excludes both boundaries
+// (a leaking receiver gate would push FieldByName to 4 via the non-reflect
+// "RevokedAt" call).
+func TestReflectStringArgScanner_TypedReceiverAndConstArg(t *testing.T) {
+	t.Parallel()
+
+	const fixture = "./cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red"
+
+	var fieldHits, methodHits []reflectStringArgHit
+	_ = RunTyped(t, TypedOpts{}, []string{fixture}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Fset == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			fieldHits = append(fieldHits, scanReflectStringArgCalls(p, file, reflectFieldByName,
+				func(n string) bool { return n == credRevokedAt })...)
+			methodHits = append(methodHits, scanReflectStringArgCalls(p, file, reflectMethodByName,
+				func(n string) bool { return n == credCanAuthenticate })...)
+		}
+		return nil
+	})
+
+	assert.Len(t, fieldHits, 3,
+		"REFLECT-STRING-ARG-SCANNER-01: FieldByName(RevokedAt) must detect exactly the "+
+			"raw/const/concat forms (3) — not the runtime-value arg, not the non-reflect "+
+			"receiver. Got %d.", len(fieldHits))
+	assert.Len(t, methodHits, 3,
+		"REFLECT-STRING-ARG-SCANNER-01: MethodByName(CanAuthenticate) must detect exactly the "+
+			"raw/const/concat forms (3). Got %d.", len(methodHits))
+}

--- a/tools/archtest/reflect_string_arg_test.go
+++ b/tools/archtest/reflect_string_arg_test.go
@@ -16,13 +16,17 @@ package archtest
 // 不在 Soft 层打补丁"): scanReflectStringArgCalls identifies a violation through
 // TYPE information, not a string anchor —
 //
-//	1. typed receiver: ResolveMethodCall must resolve the call to a method of
+//	1. typed receiver: the call's *types.Selection.Obj() must be a method of
 //	   reflect.Value (pkg=="reflect", receiver type=="Value"). This excludes
 //	   non-reflect types that happen to expose a FieldByName/MethodByName
 //	   method, and reflect.Type.FieldByName (which returns StructField metadata
 //	   and cannot read a field VALUE — not a bypass vector; see the legitimate
 //	   use in contract_subscribers_funnel_test.go).
-//	2. typed arg: EvaluateConstString folds the single argument (covers raw
+//	2. selection kind → arg offset: types.MethodVal `v.FieldByName(name)` carries
+//	   the name at Args[0]; types.MethodExpr `reflect.Value.FieldByName(recv,
+//	   name)` shifts the receiver into Args[0] so the name is at Args[1] (Go spec
+//	   §Method expressions). Keying the offset on the kind covers both call forms.
+//	3. typed arg: EvaluateConstString folds the name argument (covers raw
 //	   string / const ident / concatenation / cross-package const), replacing
 //	   the incumbent *ast.BasicLit + strings.Trim that was blind to all but the
 //	   plain double-quoted literal (issue #948 / PR #542).
@@ -91,8 +95,9 @@ type reflectStringArgHit struct {
 // (method ∈ {"FieldByName","MethodByName"}) whose single argument is a banned
 // constant string. See the package-level INVARIANT doc for the type-aware
 // two-gate design and grading. The sel.Sel.Name == method check is only a cheap
-// pre-filter; the real gate is isReflectValueMethod (typed receiver) +
-// EvaluateConstString (typed arg).
+// pre-filter; the real gate is reflectValueMethodFunc (typed receiver) +
+// EvaluateConstString (typed arg), with the name-argument position chosen by
+// the selection kind.
 func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned func(string) bool) []reflectStringArgHit {
 	var out []reflectStringArgHit
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
@@ -100,13 +105,32 @@ func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned fu
 		if !ok || sel.Sel == nil || sel.Sel.Name != method {
 			return
 		}
-		if len(call.Args) != 1 {
+		selection := p.TypesInfo.Selections[sel]
+		if selection == nil {
 			return
 		}
-		if !isReflectValueMethod(p.TypesInfo, sel) {
+		fn, ok := selection.Obj().(*types.Func)
+		if !ok || !reflectValueMethodFunc(fn) {
 			return
 		}
-		name, ok := EvaluateConstString(p.TypesInfo, call.Args[0])
+		// The name-argument position depends on how the method is reached (Go
+		// spec §Method expressions): a method value `v.FieldByName(name)` carries
+		// the name at Args[0]; a method expression `reflect.Value.FieldByName(
+		// recv, name)` makes the receiver the explicit first arg, shifting the
+		// name to Args[1].
+		var nameIdx int
+		switch selection.Kind() {
+		case types.MethodVal:
+			nameIdx = 0
+		case types.MethodExpr:
+			nameIdx = 1
+		default:
+			return
+		}
+		if len(call.Args) != nameIdx+1 {
+			return
+		}
+		name, ok := EvaluateConstString(p.TypesInfo, call.Args[nameIdx])
 		if !ok || !banned(name) {
 			return
 		}
@@ -118,13 +142,14 @@ func scanReflectStringArgCalls(p *Pass, file *ast.File, method string, banned fu
 	return out
 }
 
-// isReflectValueMethod reports whether sel typed-resolves to a method of
-// reflect.Value (pkg "reflect", receiver named type "Value"). This is the typed
-// receiver gate that separates a genuine reflect bypass from a non-reflect type
-// exposing a same-named method and from reflect.Type.FieldByName metadata reads.
-func isReflectValueMethod(info *types.Info, sel *ast.SelectorExpr) bool {
-	fn, ok := ResolveMethodCall(info, sel)
-	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != reflectPkgPath {
+// reflectValueMethodFunc reports whether fn is a method of reflect.Value (pkg
+// "reflect", receiver named type "Value"). This is the typed receiver gate that
+// separates a genuine reflect value-read bypass from a non-reflect type exposing
+// a same-named method and from reflect.Type.{Field,Method}ByName metadata reads.
+// It inspects the method object's signature receiver, so it is identical for
+// both method-value and method-expression selections.
+func reflectValueMethodFunc(fn *types.Func) bool {
+	if fn == nil || fn.Pkg() == nil || fn.Pkg().Path() != reflectPkgPath {
 		return false
 	}
 	sig, ok := fn.Type().(*types.Signature)

--- a/tools/archtest/reflect_string_arg_test.go
+++ b/tools/archtest/reflect_string_arg_test.go
@@ -139,14 +139,20 @@ func isReflectValueMethod(info *types.Info, sel *ast.SelectorExpr) bool {
 
 // TestReflectStringArgScanner_TypedReceiverAndConstArg is the reverse
 // self-check for REFLECT-STRING-ARG-SCANNER-01. It loads the shared RED fixture
-// and asserts exact hit counts: each const-form is detected, and neither
-// boundary call is. The exact count of 3 simultaneously proves the positive
-// forms AND excludes both boundaries:
-//   - receiver boundary: a leaking receiver gate would push FieldByName to 4
-//     via the non-reflect fakeReflect{}.FieldByName("RevokedAt") plain literal.
-//   - arg boundary: the runtime-value call FieldByName(runtimeName) folds to no
+// and asserts exact hit counts of 4 (3 method-value const-forms — raw/const/
+// concat — plus 1 method-expression form), simultaneously proving the positive
+// forms AND excluding every boundary call (any boundary leaking in would push
+// the count to 5+):
+//   - method expression: reflect.Value.FieldByName(recv, "X") puts the name at
+//     Args[1] (Go spec §Method expressions); the incumbent len(Args)!=1 scan
+//     missed it. This is the count's 4th member.
+//   - receiver boundary (non-reflect): fakeReflect{}.FieldByName("RevokedAt") —
+//     excluded by the reflect.Value-only receiver gate.
+//   - receiver boundary (reflect.Type): reflect.TypeOf(x).FieldByName("X")
+//     returns metadata, not a value — excluded (Type, not Value).
+//   - arg boundary (runtime-value): FieldByName(runtimeName) folds to no
 //     constant (EvaluateConstString → false), so it never enters the banned
-//     check; a regression that mistook it for a constant would also push to 4.
+//     check.
 func TestReflectStringArgScanner_TypedReceiverAndConstArg(t *testing.T) {
 	t.Parallel()
 
@@ -172,11 +178,12 @@ func TestReflectStringArgScanner_TypedReceiverAndConstArg(t *testing.T) {
 		return nil
 	})
 
-	assert.Len(t, fieldHits, 3,
-		"REFLECT-STRING-ARG-SCANNER-01: FieldByName(RevokedAt) must detect exactly the "+
-			"raw/const/concat forms (3) — not the runtime-value arg, not the non-reflect "+
-			"receiver. Got %d.", len(fieldHits))
-	assert.Len(t, methodHits, 3,
-		"REFLECT-STRING-ARG-SCANNER-01: MethodByName(CanAuthenticate) must detect exactly the "+
-			"raw/const/concat forms (3). Got %d.", len(methodHits))
+	assert.Len(t, fieldHits, 4,
+		"REFLECT-STRING-ARG-SCANNER-01: FieldByName(RevokedAt) must detect exactly the 3 "+
+			"method-value forms (raw/const/concat) + 1 method-expression form — not the "+
+			"runtime-value arg, not the non-reflect receiver, not reflect.Type. Got %d.",
+		len(fieldHits))
+	assert.Len(t, methodHits, 4,
+		"REFLECT-STRING-ARG-SCANNER-01: MethodByName(CanAuthenticate) must detect exactly the 3 "+
+			"method-value forms + 1 method-expression form. Got %d.", len(methodHits))
 }

--- a/tools/archtest/reflect_string_arg_test.go
+++ b/tools/archtest/reflect_string_arg_test.go
@@ -34,6 +34,20 @@ package archtest
 // is infeasible because the scanned scopes (cells/ + runtime/ + cmd/)
 // legitimately use reflect. Medium is the reachable ceiling.
 //
+// This is a shared scanning helper, NOT a funnel (it neither restricts who may
+// call a method nor forces callers through a single path), so ai-robust.md
+// §"Funnel 双向锁评级" does not apply; each consuming archtest carries its own
+// funnel grading in its own godoc.
+//
+// Out-of-scope reflect read shapes (documented blind spots — this scanner keys
+// on the string ARGUMENT of FieldByName/MethodByName, so it cannot see):
+//   - reflect.Value.FieldByIndex([]int{…}) / .Field(i) — positional field read,
+//     no string name. Index→field-name resolution needs the struct type.
+//   - reflect.Value.Method(i) — positional method, same shape.
+// These are pre-existing gaps in all reflect blind-spot scans, not introduced
+// or widened here; closing them is a separate (harder) effort, not a 立项-able
+// Soft string-anchor.
+//
 // Blind-spot reverse self-check: TestReflectStringArgScanner_TypedReceiverAndConstArg
 // loads testdata/reflect_string_form_red and asserts the three const-form
 // FieldByName + three const-form MethodByName calls are detected, AND that the
@@ -116,6 +130,8 @@ func isReflectValueMethod(info *types.Info, sel *ast.SelectorExpr) bool {
 	if !ok || sig.Recv() == nil {
 		return false
 	}
+	// typeOwner unwraps *T→T to the owning *types.TypeName; it is a shared
+	// archtest helper defined in credential_authority_assert_funnel_test.go.
 	owner := typeOwner(sig.Recv().Type())
 	return owner != nil && owner.Name() == reflectValueType
 }
@@ -123,13 +139,20 @@ func isReflectValueMethod(info *types.Info, sel *ast.SelectorExpr) bool {
 // TestReflectStringArgScanner_TypedReceiverAndConstArg is the reverse
 // self-check for REFLECT-STRING-ARG-SCANNER-01. It loads the shared RED fixture
 // and asserts exact hit counts: each const-form is detected, and neither
-// boundary call (runtime-value arg, non-reflect receiver) is — an exact count
-// of 3 simultaneously proves the positive forms AND excludes both boundaries
-// (a leaking receiver gate would push FieldByName to 4 via the non-reflect
-// "RevokedAt" call).
+// boundary call is. The exact count of 3 simultaneously proves the positive
+// forms AND excludes both boundaries:
+//   - receiver boundary: a leaking receiver gate would push FieldByName to 4
+//     via the non-reflect fakeReflect{}.FieldByName("RevokedAt") plain literal.
+//   - arg boundary: the runtime-value call FieldByName(runtimeName) folds to no
+//     constant (EvaluateConstString → false), so it never enters the banned
+//     check; a regression that mistook it for a constant would also push to 4.
 func TestReflectStringArgScanner_TypedReceiverAndConstArg(t *testing.T) {
 	t.Parallel()
 
+	// RunTyped (not a fixture-tagged loader): reflect_string_form_red is a
+	// testdata/ subpackage of the main module — excluded from `go build ./...`
+	// and `./...` patterns, loaded only via this explicit path. It lives under
+	// cells/accesscore/ because it imports internal/domain (see fixture godoc).
 	const fixture = "./cells/accesscore/internal/credentialauthority/testdata/reflect_string_form_red"
 
 	var fieldHits, methodHits []reflectStringArgHit
@@ -137,6 +160,8 @@ func TestReflectStringArgScanner_TypedReceiverAndConstArg(t *testing.T) {
 		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
+		// No _test.go guard: TypedOpts{} defaults Tests:false, so p.Files holds
+		// only the fixture's non-test source.
 		for _, file := range p.Files {
 			fieldHits = append(fieldHits, scanReflectStringArgCalls(p, file, reflectFieldByName,
 				func(n string) bool { return n == credRevokedAt })...)

--- a/tools/archtest/reflect_string_arg_test.go
+++ b/tools/archtest/reflect_string_arg_test.go
@@ -41,12 +41,13 @@ package archtest
 //
 // Out-of-scope reflect read shapes (documented blind spots — this scanner keys
 // on the string ARGUMENT of FieldByName/MethodByName, so it cannot see):
-//   - reflect.Value.FieldByIndex([]int{…}) / .Field(i) — positional field read,
-//     no string name. Index→field-name resolution needs the struct type.
+//   - reflect.Value.FieldByIndex([]int{…}) / .FieldByIndexErr(…) / .Field(i) —
+//     positional field read, no string name. Index→field-name resolution needs
+//     the reflected struct type + numeric-const fold + (for non-inline) dataflow.
 //   - reflect.Value.Method(i) — positional method, same shape.
 // These are pre-existing gaps in all reflect blind-spot scans, not introduced
-// or widened here; closing them is a separate (harder) effort, not a 立项-able
-// Soft string-anchor.
+// or widened here; closing them is a separate (harder, false-positive-prone)
+// effort tracked in #1120 — NOT a 立项-able Soft string-anchor.
 //
 // Blind-spot reverse self-check: TestReflectStringArgScanner_TypedReceiverAndConstArg
 // loads testdata/reflect_string_form_red and asserts the three const-form
@@ -130,8 +131,8 @@ func isReflectValueMethod(info *types.Info, sel *ast.SelectorExpr) bool {
 	if !ok || sig.Recv() == nil {
 		return false
 	}
-	// typeOwner unwraps *T→T to the owning *types.TypeName; it is a shared
-	// archtest helper defined in credential_authority_assert_funnel_test.go.
+	// typeOwner (shared archtest helper in helpers_test.go) unwraps *T→T to the
+	// owning *types.TypeName.
 	owner := typeOwner(sig.Recv().Type())
 	return owner != nil && owner.Name() == reflectValueType
 }

--- a/tools/archtest/session_revoked_field_access_test.go
+++ b/tools/archtest/session_revoked_field_access_test.go
@@ -33,8 +33,12 @@ package archtest
 // Blind-spot self-checks (ai-robust.md §"工具选定后强制盲区自检"):
 //
 //  1. reflect.Value.FieldByName("RevokedAt"): bypasses SelectorExpr
-//     resolution; the field name is in a string literal. Captured by:
-//     TestSessionRevokedFieldAccess_BlindSpot_ReflectFieldByName.
+//     resolution; the field name is a string argument. Captured by:
+//     TestSessionRevokedFieldAccess_BlindSpot_ReflectFieldByName via the shared
+//     scanReflectStringArgCalls (REFLECT-STRING-ARG-SCANNER-01) — type-aware
+//     receiver gate + EvaluateConstString cover raw-string / const / concat
+//     forms. Irreducible caveat: a runtime-computed (non-constant) field name
+//     folds to no constant and is invisible to any static scan.
 //
 //  2. unsafe.Pointer offset read of Session / ValidateView.RevokedAt:
 //     bypasses Go field visibility entirely. Captured by:
@@ -212,7 +216,7 @@ func TestSessionRevokedFieldAccess_BlindSpot_ReflectFieldByName(t *testing.T) {
 		"./runtime/...",
 		"./cmd/...",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil || p.Fset == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -220,28 +224,14 @@ func TestSessionRevokedFieldAccess_BlindSpot_ReflectFieldByName(t *testing.T) {
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel == nil || sel.Sel.Name != "FieldByName" {
-					return
-				}
-				if len(call.Args) != 1 {
-					return
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok {
-					return
-				}
-				name := strings.Trim(lit.Value, `"`)
-				if name == credRevokedAt {
-					line := p.Fset.Position(call.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
-							"archtest cannot see reflect-based field reads",
-						rel, line, name,
-					))
-				}
-			})
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectFieldByName,
+				func(n string) bool { return n == credRevokedAt }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
+						"archtest cannot see reflect-based field reads",
+					rel, hit.Line, hit.Name,
+				))
+			}
 		}
 		return nil
 	})

--- a/tools/archtest/session_revoked_field_access_test.go
+++ b/tools/archtest/session_revoked_field_access_test.go
@@ -227,8 +227,8 @@ func TestSessionRevokedFieldAccess_BlindSpot_ReflectFieldByName(t *testing.T) {
 			for _, hit := range scanReflectStringArgCalls(p, file, reflectFieldByName,
 				func(n string) bool { return n == credRevokedAt }) {
 				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.FieldByName(%q) blind spot detected — "+
-						"archtest cannot see reflect-based field reads",
+					"%s:%d: SESSION-REVOKED-FIELD-ACCESS-01: reflect.FieldByName(%q) blind spot "+
+						"detected — archtest cannot see reflect-based field reads",
 					rel, hit.Line, hit.Name,
 				))
 			}


### PR DESCRIPTION
Closes #948

## Summary

`SESSION-REVOKED-FIELD-ACCESS-01` 等 reflect blind-spot 反向自检用 `call.Args[0].(*ast.BasicLit)` + `strings.Trim(…, "\"")` 提取 `reflect.Value.{Field,Method}ByName` 实参，盲于 **raw string / const ident / 拼接**（issue #948）。探查确认该盲区**系统性复制于 10 处 / 8 文件**。

本 PR 把 10 处内联提取收口到**单一 type-aware helper** `scanReflectStringArgCalls`，消灭这一类平行结构：

- **typed receiver 关**：`ResolveMethodCall` 解析到 `reflect.Value`（排除非 reflect 同名方法 + `reflect.Type.FieldByName` 元数据检视）
- **typed arg 关**：`EvaluateConstString` 折叠 raw/const/拼接/跨包 ident

reuse: `tools/archtest/resolve.go` `EvaluateConstString` / `ResolveMethodCall`；`go/ast` `IsExported`。

## AI-robust 评级（全部 ≥ Medium）

这些 reflect reverse-check 是 ai-robust.md §盲区自检 **mandated** 的 Hard 主防线（typed `Selections` 解析）举证材料，**非新 Soft 立项**。本 PR 是「既有 Soft → 升级 Medium」（章程指令），非 Soft 层打补丁：

| 改动 | 评级 |
|---|---|
| 共享 helper（typed receiver + typed const-fold arg） | **Soft→Medium** |
| `REFLECT-STRING-ARG-SCANNER-01` meta-test（real-source fixture + 双向反向自检） | Medium |
| (b) `BlindSpot_MethodValueAssignment` → `ResolveMethodCall`+`isFunnelMethod` | Soft→Medium |
| (c) `isExportedName`(ASCII) → `ast.IsExported`（闭合 Unicode 导出名绕过） | Medium |
| (a) `verifyFunnelCalleeReferenceRedFixtureDetected` 聚合 → 按 callee 分桶 | Medium |

**为何不能 Hard**：`reflect.FieldByName(runtimeVar)` 非常量名不可静态闭合；reflect import-ban 在合法使用 reflect 的 scope 不可行。Medium 是可达上限。残留固有缺口（runtime-value / 单源回归守卫脆弱不可立项 Soft）见 `reflect_string_arg_test.go` package godoc 显式记录。

## 收口的 10 处载体

session_revoked(×1) / credential_authority(×2) / domain_authz_mutation(×2) / reconstitute_user(×1) / caching_session_revoke(×1) / credential_invalidate(×1) / healthz_invariants(×1) / outbox_invariants(×1)。`aftercommit_pure_transient` 禁所有 MethodByName（不提取实参），无 string-arg 盲区，不在范围。

## TDD（严格 RED→GREEN）

- Wave 1 (7ee9e3101) RED：fixture + meta-test + helper incumbent BasicLit body → FieldByName 实得 1（仅误检非 reflect plain-literal）/期望 3、MethodByName 实得 0/期望 3。
- Wave 2 (706d21cd) GREEN：helper typed 两道关 + 10 站点收口 + (a)(b)(c) + godoc。

## Test plan

- [x] `go build ./...`
- [x] `go vet ./tools/archtest/`
- [x] `go test ./tools/archtest/ -run "TestReflectStringArgScanner_TypedReceiverAndConstArg"` — Wave1 FAIL → Wave2 PASS
- [x] 11 个受影响 blind-spot/funnel test `-v` 全部 RUN+PASS（无 SKIP）
- [x] `golangci-lint run ./tools/archtest/...` — 0 issues

## 范围外（显式 backlog）

method-value **name-only** 同类外溢（reconstitute/outbox/domain_authz blind spot 1，selector-by-name 非 reflect-by-name）→ #1118。

🤖 Generated with [Claude Code](https://claude.com/claude-code)