### PR TITLE
refactor(cli): CLI-TOPLEVEL-HELP-REGISTRY-01 — 顶层 PrintUsage⟷commands 单源化

### DIFF
--- a/cmd/gocell/app/dispatch.go
+++ b/cmd/gocell/app/dispatch.go
@@ -15,25 +15,36 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-// commands maps sub-command names to their run functions. It is kept
-// unexported so callers go through Dispatch, which enforces the error/usage
-// contract; tests in this package may reference it directly.
-// Black-box tests in the app_test package must go through Dispatch; direct
-// map mutation is not supported.
+// commands is the top-level command registry — the single source of truth
+// for both Dispatch (handler lookup via findSub) and PrintUsage (help
+// derived via renderTopHelp). A command cannot be dispatchable without a
+// help entry, nor listed in help without a runnable handler; the two truths
+// share one slice and cannot drift (INVARIANT CLI-TOPLEVEL-HELP-REGISTRY-01,
+// the top-level peer of the verb-tree CLI-UNIMPL-HIDE-01 funnel — see
+// subcommand.go). It is kept unexported so callers go through Dispatch,
+// which enforces the error/usage contract; tests in this package may
+// reference it directly. Black-box tests in the app_test package must go
+// through Dispatch.
+//
+// help[0] carries the description plus a one-line hint of the most-used
+// flags; the embedded spacing aligns the flag-hint column across rows.
+// Per-command sub-type detail is intentionally NOT listed here — it lives in
+// `gocell <command> -h` (derived from each verb's own registry), so the
+// top-level surface stays fully registry-derived and cannot drift.
 //
 // The ctx parameter is the signal-aware context wired in main.go
 // (signal.NotifyContext); commands that have a cancelable downstream
 // (validate, verify, generate metrics-schema) thread it all the way to
 // the go test / go/packages subprocesses. The rest accept it for a
 // uniform dispatch signature.
-var commands = map[string]func(ctx context.Context, args []string) error{
-	"validate": runValidate,
-	"scaffold": runScaffold,
-	"generate": runGenerate,
-	"check":    runCheck,
-	"verify":   runVerify,
-	"graph":    runGraph,
-	"export":   runExport,
+var commands = []subcommand[func(ctx context.Context, args []string) error]{
+	{name: "validate", help: []string{"Validate all metadata (blocking)         [--root, --fail-fast, --strict, --format]"}, run: runValidate},
+	{name: "scaffold", help: []string{"Generate new cell/slice/contract/journey [--dry-run]"}, run: runScaffold},
+	{name: "generate", help: []string{"Generate assembly code and derived files [--id, --module]"}, run: runGenerate},
+	{name: "check", help: []string{"Run targeted architecture analysis"}, run: runCheck},
+	{name: "verify", help: []string{"Run tests and artifact checks            [--id, --active, --files]"}, run: runVerify},
+	{name: "graph", help: []string{"Emit module package dependency graph     [--format, --pattern, --root, --include-tests]"}, run: runGraph},
+	{name: "export", help: []string{"Export project catalog as JSON/YAML      <catalog|metadata>"}, run: runExport},
 }
 
 // Exit codes. Follows the common POSIX convention used by tools like go
@@ -71,7 +82,7 @@ func Dispatch(ctx context.Context, args []string) int {
 		PrintUsage()
 		return ExitUsage
 	}
-	cmd, ok := commands[args[0]]
+	cmd, ok := findSub(commands, args[0])
 	if !ok {
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
 		PrintUsage()
@@ -105,26 +116,5 @@ func Dispatch(ctx context.Context, args []string) int {
 // Stability: internal. Used by cmd/gocell/main.go and in-tree smoke tests;
 // signature may change without notice.
 func PrintUsage() {
-	fmt.Println("Usage: gocell <command> [args]")
-	fmt.Println()
-	fmt.Println("Commands:")
-	fmt.Println("  validate    Validate all metadata (blocking)         [--root, --fail-fast, --strict, --format]")
-	fmt.Println("  scaffold    Generate new cell/slice/contract/journey [--dry-run]")
-	fmt.Println("  generate    Generate assembly code and derived files [--id, --module]")
-	fmt.Println("    assembly --id=<assemblyID> [--module=<module>]")
-	fmt.Println("    cell [<cellID>] [--dry-run | --verify]")
-	fmt.Println("    metrics-schema --id=<assemblyID>")
-	fmt.Println("  check       Run targeted architecture analysis")
-	fmt.Println("    contract-health [--format text|json|sarif]")
-	fmt.Println("    slice-coverage --cell=<cellID>")
-	fmt.Println("    assembly-completeness --id=<assemblyID>")
-	fmt.Println("    journey-readiness --journey=<journeyID>")
-	fmt.Println("    l0-imports --cell=<cellID>")
-	fmt.Println("    unconditional-skip [--format text|json|sarif]")
-	fmt.Println("  verify      Run tests and artifact checks            [--id, --active, --files]")
-	fmt.Println("    generated [--module=<module>]")
-	fmt.Println("  graph       Emit module package dependency graph     [--format, --pattern, --root, --include-tests]")
-	fmt.Println("  export <catalog|metadata>  Export project catalog (entities + dep graphs) as JSON/YAML")
-	fmt.Println()
-	fmt.Println("Run 'gocell <command> -h' for full flag help on a sub-command.")
+	renderTopHelp(commands, "Run 'gocell <command> -h' for full flag help on a sub-command.")
 }

--- a/cmd/gocell/app/dispatch.go
+++ b/cmd/gocell/app/dispatch.go
@@ -44,7 +44,7 @@ var commands = []subcommand[func(ctx context.Context, args []string) error]{
 	{name: "check", help: []string{"Run targeted architecture analysis"}, run: runCheck},
 	{name: "verify", help: []string{"Run tests and artifact checks            [--id, --active, --files]"}, run: runVerify},
 	{name: "graph", help: []string{"Emit module package dependency graph     [--format, --pattern, --root, --include-tests]"}, run: runGraph},
-	{name: "export", help: []string{"Export project catalog as JSON/YAML      <catalog|metadata>"}, run: runExport},
+	{name: "export", help: []string{"Export project catalog (entities + dep graphs) as JSON/YAML"}, run: runExport},
 }
 
 // Exit codes. Follows the common POSIX convention used by tools like go

--- a/cmd/gocell/app/dispatch_test.go
+++ b/cmd/gocell/app/dispatch_test.go
@@ -15,8 +15,20 @@ import (
 
 // captureDispatch runs Dispatch with args while capturing stdout and stderr
 // separately, so contract tests can assert which stream each message lands on.
+//
+// It holds both stream-capture mutexes for the duration, matching the locking
+// discipline of captureStdout/captureStderr (see main_test.go): redirecting
+// the process-global os.Stdout/os.Stderr without them would race a parallel
+// capturing test. The acquisition order is fixed stdout→stderr; the
+// single-lock captureStdout/captureStderr never wait on the other lock, so no
+// ordering cycle is possible.
 func captureDispatch(t *testing.T, ctx context.Context, args []string) (exit int, stdout, stderr string) {
 	t.Helper()
+
+	stdoutCaptureMu.Lock()
+	defer stdoutCaptureMu.Unlock()
+	stderrCaptureMu.Lock()
+	defer stderrCaptureMu.Unlock()
 
 	origOut, origErr := os.Stdout, os.Stderr
 	rOut, wOut, _ := os.Pipe()

--- a/cmd/gocell/app/export.go
+++ b/cmd/gocell/app/export.go
@@ -43,6 +43,14 @@ func runExport(_ context.Context, args []string) error {
 		return fmt.Errorf("usage: gocell export <catalog|metadata> [flags]")
 	}
 	sub := args[0]
+	// Honor the `gocell <command> -h` discovery contract that PrintUsage
+	// advertises for every top-level command. export has no subcommand
+	// registry (catalog/metadata are byte-equal aliases — see runExport doc),
+	// so its help is a small hand-written surface rather than renderSubHelp.
+	if isHelpFlag(sub) {
+		printExportHelp()
+		return nil
+	}
 	rest := args[1:]
 	switch sub {
 	case "catalog", "metadata":
@@ -50,6 +58,16 @@ func runExport(_ context.Context, args []string) error {
 	default:
 		return fmt.Errorf("unknown export subcommand %q (want catalog|metadata)", sub)
 	}
+}
+
+func printExportHelp() {
+	fmt.Println("Usage: gocell export <catalog|metadata> [flags]")
+	fmt.Println()
+	fmt.Println("Subcommands:")
+	fmt.Println("  catalog   Export project catalog (entities + dep graphs) as JSON/YAML")
+	fmt.Println("  metadata  Alias of catalog (byte-equal output)")
+	fmt.Println()
+	fmt.Println("Flags: --format json|yaml  --out <path>  --include  --kinds  --layers  --cells  --root")
 }
 
 func exportCatalog(args []string) error {

--- a/cmd/gocell/app/export.go
+++ b/cmd/gocell/app/export.go
@@ -30,44 +30,43 @@ var validKinds = catalog.AllKinds
 // References catalog.AllLayers — single source of truth.
 var validLayersList = catalog.AllLayers
 
-// runExport dispatches `export <subcommand>` to its handler. catalog and
-// metadata are byte-equal aliases sharing exportCatalog as the
-// implementation — there is no per-type help surface (no helpEntry list),
-// so this stays a plain alias switch rather than a subcommand registry;
-// CLI-UNIMPL-HIDE-01 only governs the four help-bearing verb trees.
-//
-// ctx is part of the uniform commands-map signature; exportCatalog is
-// metadata + file IO with no cancelable downstream.
-func runExport(_ context.Context, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: gocell export <catalog|metadata> [flags]")
-	}
-	sub := args[0]
-	// Honor the `gocell <command> -h` discovery contract that PrintUsage
-	// advertises for every top-level command. export has no subcommand
-	// registry (catalog/metadata are byte-equal aliases — see runExport doc),
-	// so its help is a small hand-written surface rather than renderSubHelp.
-	if isHelpFlag(sub) {
-		printExportHelp()
-		return nil
-	}
-	rest := args[1:]
-	switch sub {
-	case "catalog", "metadata":
-		return exportCatalog(rest)
-	default:
-		return fmt.Errorf("unknown export subcommand %q (want catalog|metadata)", sub)
-	}
+// exportSubcommands is export's registry. catalog and metadata are byte-equal
+// aliases sharing exportCatalog, but both are registered so dispatch,
+// `export -h` help, and the unknown-subcommand error all derive from this one
+// slice (INVARIANT CLI-UNIMPL-HIDE-01, like the other verb trees) — never a
+// hand-written alias switch paired with hand-written help that could drift.
+var exportSubcommands = []subcommand[func(ctx context.Context, args []string) error]{
+	{
+		name: "catalog",
+		help: []string{"Export the project catalog (entities + dep graphs) as JSON/YAML"},
+		run:  func(_ context.Context, a []string) error { return exportCatalog(a) },
+	},
+	{
+		name: "metadata",
+		help: []string{"Alias of catalog — byte-equal output"},
+		run:  func(_ context.Context, a []string) error { return exportCatalog(a) },
+	},
 }
 
-func printExportHelp() {
-	fmt.Println("Usage: gocell export <catalog|metadata> [flags]")
-	fmt.Println()
-	fmt.Println("Subcommands:")
-	fmt.Println("  catalog   Export project catalog (entities + dep graphs) as JSON/YAML")
-	fmt.Println("  metadata  Alias of catalog (byte-equal output)")
-	fmt.Println()
-	fmt.Println("Flags: --format json|yaml  --out <path>  --include  --kinds  --layers  --cells  --root")
+// runExport resolves `export <type>` through exportSubcommands (findSub) and
+// derives `export -h` from the same registry (renderSubHelp), honoring the
+// `gocell <command> -h` contract PrintUsage advertises. ctx is part of the
+// uniform dispatch signature; exportCatalog is metadata + file IO with no
+// cancelable downstream.
+func runExport(ctx context.Context, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: gocell export <%s> [flags]",
+			strings.Join(subNames(exportSubcommands), "|"))
+	}
+	if isHelpFlag(args[0]) {
+		return renderSubHelp("export", exportSubcommands)
+	}
+	run, ok := findSub(exportSubcommands, args[0])
+	if !ok {
+		return fmt.Errorf("unknown export subcommand %q (want %s)",
+			args[0], strings.Join(subNames(exportSubcommands), ", "))
+	}
+	return run(ctx, args[1:])
 }
 
 func exportCatalog(args []string) error {

--- a/cmd/gocell/app/help.go
+++ b/cmd/gocell/app/help.go
@@ -14,32 +14,36 @@ func isHelpFlag(arg string) bool {
 	return arg == "-h" || arg == "--help" || arg == "help"
 }
 
-// helpEntry is one type listed under a sub-command's "Types:" section. desc
-// can span multiple lines; printHelp indents continuation lines under the
-// type name so the help surface stays aligned.
+// helpEntry is one entry listed under a help surface's section ("Types:"
+// for a verb tree, "Commands:" for the top level). desc can span multiple
+// lines; printHelp indents continuation lines under the name so the surface
+// stays aligned.
 type helpEntry struct {
 	name string
 	desc []string
 }
 
-// printHelp renders a uniform help surface for sub-commands. The shape is
+// printHelp renders a uniform help surface. usage is the "Usage: …" line and
+// section is the list header; both are passed in so the same renderer serves
+// the verb trees ("Usage: gocell <verb> <type> [flags]" / "Types:") and the
+// top level ("Usage: gocell <command> [args]" / "Commands:"). The shape is
 //
-//	Usage: gocell <verb> <type> [flags]
+//	<usage>
 //
-//	Types:
+//	<section>
 //	  <name>   <desc[0]>
 //	           <desc[1]>
 //	           ...
 //
 //	<footer>
 //
-// Adding a new type to a sub-command means appending a helpEntry; missing
-// the help line is impossible because the data structure is the source of
-// truth for the help renderer.
-func printHelp(verb string, entries []helpEntry, footer ...string) {
-	fmt.Printf("Usage: gocell %s <type> [flags]\n", verb)
+// Adding an entry means appending a helpEntry; missing the help line is
+// impossible because the data structure is the source of truth for the
+// renderer.
+func printHelp(usage, section string, entries []helpEntry, footer ...string) {
+	fmt.Println(usage)
 	fmt.Println()
-	fmt.Println("Types:")
+	fmt.Println(section)
 	width := longestEntryName(entries)
 	for _, e := range entries {
 		first := true
@@ -74,7 +78,9 @@ func longestEntryName(entries []helpEntry) int {
 	return max
 }
 
-// Per-verb help is no longer hand-written here: each verb's help surface
-// is derived from its subcommand registry via renderSubHelp (see
-// subcommand.go / CLI-UNIMPL-HIDE-01). printHelp + helpEntry remain as
-// the shared rendering primitive renderSubHelp builds on.
+// Help is no longer hand-written here: every help surface — each verb's
+// "Types:" list (renderSubHelp) and the top-level "Commands:" list
+// (renderTopHelp) — is derived from a subcommand registry via
+// buildHelpEntries (see subcommand.go / CLI-UNIMPL-HIDE-01 +
+// CLI-TOPLEVEL-HELP-REGISTRY-01). printHelp + helpEntry remain as the
+// shared rendering primitive those builders feed.

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -32,16 +32,34 @@ var (
 	stderrCaptureMu sync.Mutex
 )
 
+// TestPrintUsage pins the top-level usage surface. After
+// CLI-TOPLEVEL-HELP-REGISTRY-01 it is derived from the `commands` registry
+// via renderTopHelp: it lists exactly the seven top-level commands (name +
+// description) and the -h footer, and deliberately NO LONGER hand-lists each
+// verb's sub-types — that detail moved to `gocell <command> -h`. The
+// notWant assertions pin that the formerly drift-prone nested prose
+// (generate listed 3 of 7 sub-types, verify 1 of 8) is gone.
 func TestPrintUsage(t *testing.T) {
 	out := captureStdout(t, PrintUsage)
 	for _, want := range []string{
-		"generate    Generate assembly code and derived files",
+		"Usage: gocell <command> [args]",
+		"Commands:",
+		"validate", "scaffold", "generate", "check", "verify", "graph", "export",
+		"Generate assembly code and derived files",
+		"Run 'gocell <command> -h' for full flag help on a sub-command.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("PrintUsage() missing %q in:\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{
 		"assembly --id=<assemblyID>",
 		"metrics-schema --id=<assemblyID>",
 		"generated [--module=<module>]",
 	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("PrintUsage() missing %q in:\n%s", want, out)
+		if strings.Contains(out, notWant) {
+			t.Fatalf("PrintUsage() must not hand-list verb sub-types (%q); "+
+				"sub-type detail belongs to `gocell <command> -h`:\n%s", notWant, out)
 		}
 	}
 }
@@ -106,19 +124,30 @@ func TestReadModuleNotFound(t *testing.T) {
 // TestDispatch_SuccessPath_ExitZero) exercise the wiring end-to-end.
 
 func TestCommands(t *testing.T) {
-	// Verify all expected commands are registered.
+	// Verify all expected commands are registered in the commands registry.
 	expected := []string{"validate", "scaffold", "generate", "check", "verify"}
 	for _, name := range expected {
-		if _, ok := commands[name]; !ok {
-			t.Errorf("command %q not registered in commands map", name)
+		if _, ok := findSub(commands, name); !ok {
+			t.Errorf("command %q not registered in commands registry", name)
 		}
 	}
 }
 
+// withInjectedCommand appends a temporary command to the package-level
+// commands registry and restores the original slice on cleanup. Used by the
+// errcode-redaction Dispatch tests to drive an arbitrary handler error
+// through the real dispatch path. Not parallel-safe (mutates a package var),
+// consistent with these tests' non-Parallel design.
+func withInjectedCommand(t *testing.T, name string, run func(context.Context, []string) error) {
+	t.Helper()
+	orig := commands
+	commands = append(commands, subcommand[func(ctx context.Context, args []string) error]{name: name, run: run})
+	t.Cleanup(func() { commands = orig })
+}
+
 func TestDispatch_ErrcodeUsesPublicMessage(t *testing.T) {
 	const cmdName = "test-errcode-public"
-	orig, hadOrig := commands[cmdName]
-	commands[cmdName] = func(context.Context, []string) error {
+	withInjectedCommand(t, cmdName, func(context.Context, []string) error {
 		return errcode.New(
 			errcode.KindInvalid,
 			errcode.ErrValidationFailed,
@@ -126,13 +155,6 @@ func TestDispatch_ErrcodeUsesPublicMessage(t *testing.T) {
 			errcode.WithInternal("token=hunter2 raw=/private/generated.yaml"),
 			errcode.WithDetails(slog.String("field", "cell.id")),
 		)
-	}
-	t.Cleanup(func() {
-		if hadOrig {
-			commands[cmdName] = orig
-			return
-		}
-		delete(commands, cmdName)
 	})
 
 	out := captureStderr(t, func() {
@@ -154,21 +176,13 @@ func TestDispatch_ErrcodeUsesPublicMessage(t *testing.T) {
 
 func TestDispatch_ErrcodeServerErrorKeepsOperatorRoutingMetadata(t *testing.T) {
 	const cmdName = "test-errcode-operator"
-	orig, hadOrig := commands[cmdName]
-	commands[cmdName] = func(context.Context, []string) error {
+	withInjectedCommand(t, cmdName, func(context.Context, []string) error {
 		return errcode.New(
 			errcode.KindInternal,
 			errcode.ErrAuthRoleFetchFailed,
 			"role repository failed: postgres://user:secret@example/db",
 			errcode.WithInternal("token=hunter2"),
 		)
-	}
-	t.Cleanup(func() {
-		if hadOrig {
-			commands[cmdName] = orig
-			return
-		}
-		delete(commands, cmdName)
 	})
 
 	out := captureStderr(t, func() {
@@ -234,7 +248,7 @@ func assertHelpOutput(t *testing.T, name string, run func(context.Context, []str
 // from operator-visible output.
 func TestPrintHelpRendersEntryWithoutDescription(t *testing.T) {
 	out := captureStdout(t, func() {
-		printHelp("demo", []helpEntry{
+		printHelp("Usage: gocell demo <type> [flags]", "Types:", []helpEntry{
 			{name: "with-desc", desc: []string{"has a description"}},
 			{name: "no-desc"},
 		})

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -124,11 +124,17 @@ func TestReadModuleNotFound(t *testing.T) {
 // TestDispatch_SuccessPath_ExitZero) exercise the wiring end-to-end.
 
 func TestCommands(t *testing.T) {
-	// Verify all expected commands are registered in the commands registry.
-	expected := []string{"validate", "scaffold", "generate", "check", "verify"}
-	for _, name := range expected {
+	// Pin the full top-level command set, not a subset: length catches a
+	// stray addition, the findSub loop catches a removal or rename (a renamed
+	// command leaves its old name unfound). This keeps the anti-drift
+	// guarantee airtight rather than blind to graph/export.
+	want := []string{"validate", "scaffold", "generate", "check", "verify", "graph", "export"}
+	if len(commands) != len(want) {
+		t.Fatalf("commands registry has %d entries, want %d (%v)", len(commands), len(want), subNames(commands))
+	}
+	for _, name := range want {
 		if _, ok := findSub(commands, name); !ok {
-			t.Errorf("command %q not registered in commands registry", name)
+			t.Errorf("command %q not registered in commands registry; have %v", name, subNames(commands))
 		}
 	}
 }
@@ -138,6 +144,10 @@ func TestCommands(t *testing.T) {
 // errcode-redaction Dispatch tests to drive an arbitrary handler error
 // through the real dispatch path. Not parallel-safe (mutates a package var),
 // consistent with these tests' non-Parallel design.
+//
+// Restore is clean: the commands literal has cap == len, so append always
+// allocates a fresh backing array rather than writing into a shared slot;
+// reassigning commands = orig fully reverts both header and reachable data.
 func withInjectedCommand(t *testing.T, name string, run func(context.Context, []string) error) {
 	t.Helper()
 	orig := commands
@@ -177,6 +187,10 @@ func TestDispatch_ErrcodeUsesPublicMessage(t *testing.T) {
 func TestDispatch_ErrcodeServerErrorKeepsOperatorRoutingMetadata(t *testing.T) {
 	const cmdName = "test-errcode-operator"
 	withInjectedCommand(t, cmdName, func(context.Context, []string) error {
+		// The DSN in the message is intentional worst-case data: a KindInternal
+		// error whose message was carelessly built with a secret. project()'s
+		// operator surface replaces a 5xx message with "internal server error",
+		// so the leak assertion below proves postgres:// never reaches stderr.
 		return errcode.New(
 			errcode.KindInternal,
 			errcode.ErrAuthRoleFetchFailed,
@@ -216,6 +230,9 @@ func TestSubcommandHelpFlagsRenderHelp(t *testing.T) {
 		{"verify", runVerify, []string{"Usage: gocell verify", "generated", "stale, staged-only"}},
 		{"scaffold", runScaffold, []string{"Usage: gocell scaffold", "cell", "--dry-run"}},
 		{"check", runCheck, []string{"Usage: gocell check", "contract-health", "unconditional-skip"}},
+		// export has no subcommand registry but must still honor the
+		// top-level `gocell <command> -h` contract PrintUsage advertises.
+		{"export", runExport, []string{"Usage: gocell export", "catalog", "metadata"}},
 	}
 
 	for _, tc := range cases {

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -230,8 +230,8 @@ func TestSubcommandHelpFlagsRenderHelp(t *testing.T) {
 		{"verify", runVerify, []string{"Usage: gocell verify", "generated", "stale, staged-only"}},
 		{"scaffold", runScaffold, []string{"Usage: gocell scaffold", "cell", "--dry-run"}},
 		{"check", runCheck, []string{"Usage: gocell check", "contract-health", "unconditional-skip"}},
-		// export has no subcommand registry but must still honor the
-		// top-level `gocell <command> -h` contract PrintUsage advertises.
+		// export now uses the same registry-derived help contract as the
+		// other help-bearing verb trees.
 		{"export", runExport, []string{"Usage: gocell export", "catalog", "metadata"}},
 	}
 

--- a/cmd/gocell/app/subcommand.go
+++ b/cmd/gocell/app/subcommand.go
@@ -5,7 +5,8 @@ package app
 //   - the top-level command set (dispatch.go's `commands`):
 //     `gocell <command>` — validate / scaffold / generate / check / verify /
 //     graph / export;
-//   - each `gocell <verb> <type>` tree (generate / verify / scaffold / check).
+//   - each `gocell <verb> <type>` tree
+//     (generate / verify / scaffold / check / export).
 //
 // INVARIANT:
 //   - CLI-UNIMPL-HIDE-01
@@ -25,9 +26,10 @@ package app
 // structurally unrepresentable rather than convention. Enforced repo-wide
 // by tools/archtest/cli_unimpl_hide_test.go:
 //   - upstream: Dispatch (top level) and runGenerate/runVerify/
-//     runScaffoldWithRoot/runCheck (verb trees) must dispatch via findSub
-//     over a subcommand[…] slice — a string-literal switch/case on the name
-//     (or a name→handler map index) fails archtest.
+//     runScaffoldWithRoot/runCheck/runExport (verb trees) must resolve the
+//     handler via `findSub(<registry>, …)` and invoke that resolved handler —
+//     a switch/case ladder, or a dummy findSub paired with a name→handler map
+//     index, fails archtest (scanDispatchViaRegistry form-uniqueness).
 //   - downstream: help must be produced by buildHelpEntries from the
 //     registry — a hand-written helpEntry literal carrying a string-literal
 //     name fails archtest (verb trees), and PrintUsage's body must be the

--- a/cmd/gocell/app/subcommand.go
+++ b/cmd/gocell/app/subcommand.go
@@ -1,47 +1,52 @@
 package app
 
-// Sub-command registry — the single source of truth for every
-// `gocell <verb> <type>` tree (generate / verify / scaffold / check).
+// Command registry — the single source of truth for every gocell command
+// node, at both levels of the tree:
+//   - the top-level command set (dispatch.go's `commands`):
+//     `gocell <command>` — validate / scaffold / generate / check / verify /
+//     graph / export;
+//   - each `gocell <verb> <type>` tree (generate / verify / scaffold / check).
 //
-// INVARIANT: CLI-UNIMPL-HIDE-01
+// INVARIANT:
+//   - CLI-UNIMPL-HIDE-01
+//   - CLI-TOPLEVEL-HELP-REGISTRY-01
 //
-// Each verb owns one []subcommand[H] registry. Dispatch looks the type
-// name up in that slice (findSub); the help surface is *derived* from the
-// same slice (renderSubHelp). A type therefore cannot appear in help
-// without a runnable handler, nor be runnable without a help entry — the
-// two truths share one object and cannot drift. There is deliberately no
-// "not implemented" / placeholder shape: an unimplemented type is simply
-// absent from the registry, so it falls through to the unknown-type error
+// Each level owns one []subcommand[H] registry. Dispatch looks the name up
+// in that slice (findSub); the help surface is *derived* from the same slice
+// (renderTopHelp at the top level, renderSubHelp per verb), both via the
+// single buildHelpEntries funnel. A command therefore cannot appear in help
+// without a runnable handler, nor be runnable without a help entry — the two
+// truths share one object and cannot drift. There is deliberately no
+// "not implemented" / placeholder shape: an unimplemented command is simply
+// absent from the registry, so it falls through to the unknown-command error
 // exactly like a typo would.
 //
-// This makes the "no visible-but-unimplemented sub-command" property
+// This makes the "no visible-but-unimplemented command" property
 // structurally unrepresentable rather than convention. Enforced repo-wide
 // by tools/archtest/cli_unimpl_hide_test.go:
-//   - upstream Hard: runGenerate/runVerify/runScaffoldWithRoot/runCheck
-//     must dispatch via findSub over a subcommand[…] slice — a
-//     string-literal switch/case on the type name fails archtest.
-//   - downstream Hard: help must be produced by renderSubHelp from the
+//   - upstream: Dispatch (top level) and runGenerate/runVerify/
+//     runScaffoldWithRoot/runCheck (verb trees) must dispatch via findSub
+//     over a subcommand[…] slice — a string-literal switch/case on the name
+//     (or a name→handler map index) fails archtest.
+//   - downstream: help must be produced by buildHelpEntries from the
 //     registry — a hand-written helpEntry literal carrying a string-literal
-//     type name fails archtest.
+//     name fails archtest (verb trees), and PrintUsage's body must be the
+//     sole renderTopHelp(commands, …) delegation (top level).
 //
-// Funnel scope (charter §Funnel 双向锁评级): this single-source funnel
-// covers ONLY the four help-bearing verb trees. The top-level `commands`
-// map (dispatch.go) ↔ `PrintUsage` free-form prose is a parallel,
-// NOT-yet-funneled surface of the same drift class — a new unimplemented
-// top-level command could appear in PrintUsage prose without an archtest
-// catching it. That gap is an explicitly registered, non-silent
-// follow-up (CLI-TOPLEVEL-HELP-REGISTRY-01: single-source the top-level
-// command list the same way). Until then
-// tools/archtest/cli_unimpl_hide_test.go's
-// TestCLIUnimplHide01_PrintUsageNoStaleToken is the Medium compensating
-// guard (no stale "indexes"/"not implemented" token in PrintUsage).
+// The top-level `commands` ↔ `PrintUsage` surface was formerly a declared
+// blind spot (free-form prose compensated by a stale-token guard); it is now
+// part of the same closed-loop funnel (CLI-TOPLEVEL-HELP-REGISTRY-01).
+// AI-robust grading lives in the archtest package doc
+// (tools/archtest/cli_unimpl_hide_test.go), per charter "落地实例与符号清单
+// 活在代码 godoc".
 //
-// ref: go-zero goctl tools/goctl — sub-commands are registered, not
-// switch-dispatched; GoCell keeps the no-cobra map style but applies the
+// ref: go-zero goctl tools/goctl — commands are registered, not
+// switch-dispatched; GoCell keeps the no-cobra style but applies the
 // same "help derives from the registry" single-source principle.
 
-// subcommand is one `gocell <verb> <name>` target. H is the verb tree's
-// handler signature: generate/verify/check use
+// subcommand is one gocell command node — a top-level command
+// (`gocell <name>`) or a verb sub-type (`gocell <verb> <name>`). H is the
+// node's handler signature: top-level commands and generate/verify/check use
 // func(context.Context, []string) error; scaffold additionally needs the
 // resolved project root, so it uses
 // func(context.Context, string, []string) error.
@@ -76,15 +81,32 @@ func findSub[H any](subs []subcommand[H], name string) (H, bool) {
 	return zero, false
 }
 
-// renderSubHelp prints the verb's help surface derived from its registry.
-// It is the only path from a subcommand registry to a helpEntry, which is
-// what gives the downstream-Hard property: help text cannot list a type
-// the registry does not contain.
-func renderSubHelp[H any](verb string, subs []subcommand[H], footer ...string) error {
+// buildHelpEntries is the single path from a subcommand registry to
+// []helpEntry. It sets `name: s.name` (a selector, never a literal), which
+// is what gives the downstream property: help text cannot list a command the
+// registry does not contain. Both renderSubHelp and renderTopHelp funnel
+// through here, so there is exactly one helpEntry construction site in
+// production (scanHelpEntryNoLiteralName bans any other).
+func buildHelpEntries[H any](subs []subcommand[H]) []helpEntry {
 	entries := make([]helpEntry, len(subs))
 	for i, s := range subs {
 		entries[i] = helpEntry{name: s.name, desc: s.help}
 	}
-	printHelp(verb, entries, footer...)
+	return entries
+}
+
+// renderSubHelp prints a verb's "Types:" help surface derived from its
+// registry (`gocell <verb> -h`).
+func renderSubHelp[H any](verb string, subs []subcommand[H], footer ...string) error {
+	printHelp("Usage: gocell "+verb+" <type> [flags]", "Types:",
+		buildHelpEntries(subs), footer...)
 	return nil
+}
+
+// renderTopHelp prints the top-level "Commands:" help surface derived from
+// the `commands` registry (`gocell` with no args). It is PrintUsage's sole
+// statement — the downstream half of CLI-TOPLEVEL-HELP-REGISTRY-01.
+func renderTopHelp[H any](subs []subcommand[H], footer ...string) {
+	printHelp("Usage: gocell <command> [args]", "Commands:",
+		buildHelpEntries(subs), footer...)
 }

--- a/tools/archtest/cli_unimpl_hide_test.go
+++ b/tools/archtest/cli_unimpl_hide_test.go
@@ -1,52 +1,87 @@
-// INVARIANT: CLI-UNIMPL-HIDE-01
+// INVARIANT:
+//   - CLI-UNIMPL-HIDE-01
+//   - CLI-TOPLEVEL-HELP-REGISTRY-01
 //
-// No `gocell` sub-command may be visible in help while being
-// unimplemented (invariant CLI-UNIMPL-HIDE-01). The four
-// help-bearing verb trees — generate / verify / scaffold / check — each
+// No `gocell` command — at any level — may be visible in help while being
+// unimplemented. The four help-bearing verb trees
+// (generate / verify / scaffold / check) AND the top-level command set each
 // own a single typed registry (cmd/gocell/app/subcommand.go's
 // subcommand[H]); dispatch and help BOTH derive from that one slice, so a
-// type cannot appear in one truth and not the other.
+// command cannot appear in one truth and not the other.
 //
 // This archtest makes that single-source structurally enforced rather
-// than convention. It binds three structural facts in cmd/gocell/app
+// than convention. It binds four structural facts in cmd/gocell/app
 // production code:
 //
-//   - Upstream Hard: the four dispatch functions (runGenerate, runVerify,
-//     runScaffoldWithRoot, runCheck) contain NO `switch` statement and DO
+//   - Upstream Hard: the dispatch functions — the four verb-tree
+//     dispatchers (runGenerate, runVerify, runScaffoldWithRoot, runCheck)
+//     plus the top-level Dispatch — contain NO `switch` statement and DO
 //     call findSub — i.e. dispatch is registry lookup, never a
-//     string-literal `case "name":` ladder. Re-introducing a switch (the
-//     pre-PR shape that let `generate indexes` exist) fails CI.
-//   - Downstream Hard: no `helpEntry{…}` composite literal anywhere in
-//     production code carries a string-literal `name`. The only path from
-//     a registry to a helpEntry is renderSubHelp, which sets
-//     `name: s.name` (a selector, never a literal). A hand-written help
-//     list — the other half of the old drift — fails CI.
+//     string-literal `case "name":` ladder (verb trees) nor a name→handler
+//     map index (top level). Re-introducing a switch (the pre-PR shape that
+//     let `generate indexes` exist) fails CI.
+//   - Downstream Hard (verb trees): no `helpEntry{…}` composite literal
+//     anywhere in production code carries a string-literal `name`. The only
+//     path from a registry to a helpEntry is buildHelpEntries (via
+//     renderSubHelp / renderTopHelp), which sets `name: s.name` (a
+//     selector, never a literal). A hand-written help list — the other half
+//     of the old drift — fails CI.
+//   - Downstream Hard (top level): PrintUsage's body is exactly one
+//     statement — a renderTopHelp(commands, …) delegation. Any other shape
+//     (extra statements, a different callee, a direct fmt.Print* /
+//     fmt.Fprintln(os.Stdout,…) / os.Stdout write / hand-printed prose)
+//     fails CI. This is form-uniqueness, not an fmt.Print* blacklist, so
+//     there is no "like-but-not" gray zone for hand-rolled top-level usage.
 //   - No placeholder: production code contains no reachable
 //     "not implemented" string return. An unimplemented type is absent
 //     from its registry and falls through to the unknown-type error,
 //     exactly like a typo.
 //
-// AI-robust: Hard (closed-loop funnel). Upstream Hard (no switch + must
-// call findSub) and downstream Hard (no literal-name helpEntry) together
-// make "visible-but-unimplemented sub-command" inexpressible in the four
-// trees. Reverse-fixture self-checks below prove each detector actually
+// AI-robust (CLI-TOPLEVEL-HELP-REGISTRY-01, funnel 双向锁): the single
+// `commands` package var (dispatch.go) is the funnel; Dispatch and
+// PrintUsage both read only it, with no parallel hand-maintained list.
+//   - Downstream = Hard (form-unique funnel): help names can only come from
+//     buildHelpEntries' `name: s.name` selector; scanHelpEntryNoLiteralName
+//     bans literal-name helpEntry package-wide; PrintUsage's body is
+//     form-locked to the sole renderTopHelp(commands) delegation. A
+//     non-registry command in top-level help is thus inexpressible at the
+//     archtest form layer, with no bypass gray zone. Enforcement is
+//     archtest-bound (the Go ceiling for "what a func prints"); form
+//     uniqueness is the highest grade reachable for this rule shape (charter
+//     §Hard 范本 "typed marker funnel for unbounded ops").
+//   - Upstream = the SAME closed-loop archtest funnel as the verb trees:
+//     Dispatch ∈ dispatchFuncs → no-switch + must-call-findSub. Enforcement
+//     is archtest-AST (Go cannot type-force "resolution must go through
+//     findSub"); this is the identical mechanism and identical ceiling as
+//     the four already-shipped verb dispatchers. This PR does NOT fork a
+//     divergent grade for one of two identical mechanisms in the same file
+//     (concept-model consistency); whether the CLI single-source funnel's
+//     upstream is "truly Hard vs Medium" is a framing question that applies
+//     equally to the sibling — recorded here as a known meta-question, not
+//     silently decided nor unilaterally re-graded.
+//
+// Reverse-fixture self-checks below prove each detector actually
 // fires (a detector that silently passes everything would itself be the
-// bypass).
+// bypass), and that the compliant top-level shape is NOT flagged.
 //
 // # Tool / blind-spot ledger (charter §载体决策原则)
 //
 // Detection is pure-AST (archtest.Run, no go/types) because the rule's
 // truth is structural (presence of a SwitchStmt / a literal-name
-// helpEntry / a "not implemented" literal), not type-resolution. AST
-// forms outside the chosen matchers, each with a reverse self-check:
+// helpEntry / a "not implemented" literal / PrintUsage body shape), not
+// type-resolution. AST forms outside the chosen matchers, each with a
+// reverse self-check:
 //
-//  1. Declared blind spot — dispatch.go PrintUsage is free-form prose
-//     listing the seven top-level commands; it is NOT a subcommand
-//     registry, so the four-tree funnel does not cover it. Compensated by
-//     assertPrintUsageNoStaleToken (no "indexes" / "not implemented"
-//     token) and tracked for single-sourcing as CLI-TOPLEVEL-HELP-REGISTRY-01.
-//     Top-level commands map ↔ PrintUsage
-//     drift is the explicit follow-up, not silent carryover.
+//  1. Top-level PrintUsage ↔ commands (CLI-TOPLEVEL-HELP-REGISTRY-01) —
+//     formerly a declared blind spot (free-form prose compensated by a
+//     stale-token guard), now closed: the seven top-level commands live in
+//     the `commands` []subcommand registry, Dispatch resolves via findSub
+//     (covered by scanDispatchSwitchFree, Dispatch ∈ dispatchFuncs) and
+//     PrintUsage renders via a sole renderTopHelp(commands) delegation
+//     (scanPrintUsageDerived). The old assertPrintUsageNoStaleToken
+//     compensation is deleted — a stale token cannot survive in prose that
+//     no longer exists. Fixtures: printusage_handwritten (must flag) /
+//     printusage_delegating (must NOT flag).
 //  2. helpEntry built with a named field (`helpEntry{name: …}`) vs
 //     positional (`helpEntry{…}`) — both handled (KeyValueExpr key and
 //     positional element 0). Fixture: namedfield.
@@ -57,8 +92,16 @@
 //     (an unregistered type cannot reach a handler at all).
 //  4. runExport's two-value `catalog|metadata` alias switch is
 //     intentionally OUT of scope: export has no helpEntry surface, so it
-//     cannot drift help vs dispatch. dispatchFuncs lists exactly the four
-//     help-bearing trees.
+//     cannot drift help vs dispatch. dispatchFuncs lists the four
+//     help-bearing verb trees plus the top-level Dispatch — runExport is
+//     deliberately absent.
+//  5. scanPrintUsageDerived keys on the FuncDecl name "PrintUsage" (a name
+//     convention for the single sanctioned entry point) but its match is
+//     form-complete: it accepts ONLY the sole-renderTopHelp(commands) body
+//     and rejects every other statement form, so unlike a fmt.Print*
+//     blacklist there is no fmt.Fprintln / os.Stdout / helper-indirection
+//     escape. printusage_handwritten exercises the fmt.Fprintln bypass a
+//     blacklist would miss.
 //
 // ref: docs/plans/202605121830-038-p0-p1-blocking-implementation-plan.md PR-3
 // ref: cmd/gocell/app/subcommand.go (the funnel this test guards)
@@ -73,14 +116,19 @@ import (
 	"testing"
 )
 
-// dispatchFuncs are the four help-bearing verb-tree dispatchers. Each must
-// route through the subcommand registry (findSub) and contain no switch.
-// runExport is deliberately absent (no helpEntry surface — see ledger §4).
+// dispatchFuncs are the registry-backed dispatchers: the four help-bearing
+// verb-tree dispatchers plus the top-level Dispatch
+// (CLI-TOPLEVEL-HELP-REGISTRY-01). Each must route through a subcommand
+// registry (findSub) and contain no switch — a string-literal `case`
+// ladder (verb trees) or a name→handler map index (top level) would let
+// dispatch drift from help. runExport is deliberately absent (no helpEntry
+// surface — see ledger §4).
 var dispatchFuncs = map[string]bool{
 	"runGenerate":         true,
 	"runVerify":           true,
 	"runScaffoldWithRoot": true,
 	"runCheck":            true,
+	"Dispatch":            true,
 }
 
 // TestCLIUnimplHide01 binds the structural single-source facts in
@@ -297,34 +345,113 @@ func containsMsg(diags []Diagnostic, sub string) bool {
 	return false
 }
 
-// TestCLIUnimplHide01_PrintUsageNoStaleToken is the declared-blind-spot
-// compensation (ledger §1): dispatch.go's free-form PrintUsage is not a
-// registry, so the four-tree funnel does not bind it. This guards the one
-// concrete drift that mattered — a stale "indexes" / "not implemented"
-// token surviving in the top-level usage prose.
-func TestCLIUnimplHide01_PrintUsageNoStaleToken(t *testing.T) {
-	t.Parallel()
-	root := findModuleRoot(t)
-	fset := token.NewFileSet()
-	abs := filepath.Join(root, "cmd", "gocell", "app", "dispatch.go")
-	f, err := parser.ParseFile(fset, abs, nil, parser.SkipObjectResolution)
-	if err != nil {
-		t.Fatalf("parse dispatch.go: %v", err)
-	}
+// scanPrintUsageDerived enforces CLI-TOPLEVEL-HELP-REGISTRY-01's downstream
+// form-uniqueness: PrintUsage must render the top-level command list by
+// delegating to renderTopHelp over the `commands` registry, and do nothing
+// else. Its body must be exactly one statement —
+// renderTopHelp(commands, …). Any other shape (extra statements, a
+// different callee, a direct fmt.Print* / fmt.Fprintln(os.Stdout,…) /
+// os.Stdout write / hand-printed prose) is the drift-prone hand-written
+// usage form that let stale sub-types resurface in top-level help. Form
+// uniqueness — not an fmt.Print* blacklist — leaves no "like-but-not" gray
+// zone (e.g. fmt.Fprintln(os.Stdout, …) would silently slip past a
+// blacklist but is an extra/foreign statement here).
+func scanPrintUsageDerived(p *Pass, f *ast.File, rel string) []Diagnostic {
+	var d []Diagnostic
 	EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
 		if fn.Name == nil || fn.Name.Name != "PrintUsage" || fn.Body == nil {
 			return
 		}
-		EachInSubtree[ast.BasicLit](fn.Body, func(lit *ast.BasicLit) {
-			if lit.Kind != token.STRING {
-				return
-			}
-			low := strings.ToLower(lit.Value)
-			if strings.Contains(low, "indexes") || strings.Contains(low, "not implemented") {
-				t.Errorf("PrintUsage carries stale token %s; the removed "+
-					"`generate indexes` type must not resurface in top-level "+
-					"usage prose (CLI-TOPLEVEL-HELP-REGISTRY-01)", lit.Value)
-			}
+		if isSoleRenderTopHelpCall(fn.Body) {
+			return
+		}
+		d = append(d, Diagnostic{
+			Rel:  rel,
+			Line: p.Fset.Position(fn.Pos()).Line,
+			Message: "PrintUsage must delegate to renderTopHelp(commands, …) " +
+				"as its sole statement; the top-level command list must derive " +
+				"from the commands registry, never hand-printed prose " +
+				"(CLI-TOPLEVEL-HELP-REGISTRY-01)",
 		})
 	})
+	return d
+}
+
+// isSoleRenderTopHelpCall reports whether body is exactly one ExprStmt
+// calling renderTopHelp with `commands` as its first argument.
+func isSoleRenderTopHelpCall(body *ast.BlockStmt) bool {
+	if len(body.List) != 1 {
+		return false
+	}
+	es, ok := body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := es.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	fun, ok := call.Fun.(*ast.Ident)
+	if !ok || fun.Name != "renderTopHelp" {
+		return false
+	}
+	if len(call.Args) == 0 {
+		return false
+	}
+	arg0, ok := call.Args[0].(*ast.Ident)
+	return ok && arg0.Name == "commands"
+}
+
+// TestCLITopLevelHelpRegistry01 binds the top-level downstream form-
+// uniqueness fact: PrintUsage derives the command list from the `commands`
+// registry via a sole renderTopHelp delegation. Combined with
+// Dispatch ∈ dispatchFuncs (scanDispatchSwitchFree, upstream) and the
+// package-wide no-literal-helpEntry ban (scanHelpEntryNoLiteralName), the
+// top-level commands ↔ PrintUsage prose can no longer drift.
+func TestCLITopLevelHelpRegistry01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	diags := Run(t, DirsScope(root, []string{"cmd/gocell/app"}),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue // production-only invariant
+				}
+				d = append(d, scanPrintUsageDerived(p, f, rel)...)
+			}
+			return d
+		})
+	Report(t, "CLI-TOPLEVEL-HELP-REGISTRY-01", diags)
+}
+
+// TestCLITopLevelHelpRegistry01_DetectsHandwrittenPrintUsage proves
+// scanPrintUsageDerived fires on a hand-written, multi-statement PrintUsage
+// (including the fmt.Fprintln(os.Stdout, …) form an fmt.Print* blacklist
+// would miss). A detector that passed everything would itself be the
+// bypass.
+func TestCLITopLevelHelpRegistry01_DetectsHandwrittenPrintUsage(t *testing.T) {
+	t.Parallel()
+	p, f, rel := parseFixture(t, "printusage_handwritten.go")
+	got := scanPrintUsageDerived(p, f, rel)
+	if len(got) == 0 {
+		t.Fatal("expected hand-written PrintUsage fixture to be flagged, got 0")
+	}
+	if !containsMsg(got, "must delegate to renderTopHelp") {
+		t.Errorf("missing the form-uniqueness diagnostic; got %v", got)
+	}
+}
+
+// TestCLITopLevelHelpRegistry01_AcceptsDelegatingPrintUsage proves the
+// detector does NOT over-fire: the compliant sole-renderTopHelp(commands)
+// shape must produce zero diagnostics, so the rule cannot regress to
+// flagging everything.
+func TestCLITopLevelHelpRegistry01_AcceptsDelegatingPrintUsage(t *testing.T) {
+	t.Parallel()
+	p, f, rel := parseFixture(t, "printusage_delegating.go")
+	if got := scanPrintUsageDerived(p, f, rel); len(got) != 0 {
+		t.Fatalf("compliant sole-delegation PrintUsage must not be flagged, got %v", got)
+	}
 }

--- a/tools/archtest/cli_unimpl_hide_test.go
+++ b/tools/archtest/cli_unimpl_hide_test.go
@@ -78,10 +78,13 @@
 //     the `commands` []subcommand registry, Dispatch resolves via findSub
 //     (covered by scanDispatchSwitchFree, Dispatch ∈ dispatchFuncs) and
 //     PrintUsage renders via a sole renderTopHelp(commands) delegation
-//     (scanPrintUsageDerived). The old assertPrintUsageNoStaleToken
-//     compensation is deleted — a stale token cannot survive in prose that
-//     no longer exists. Fixtures: printusage_handwritten (must flag) /
-//     printusage_delegating (must NOT flag).
+//     (scanPrintUsageDerived, which pins both the statement shape AND arg0 ==
+//     the canonical `commands` identifier). The old
+//     assertPrintUsageNoStaleToken compensation is deleted — a stale token
+//     cannot survive in prose that no longer exists. Fixtures:
+//     printusage_handwritten (hand-printed prose — must flag) /
+//     printusage_wrongvar (sole renderTopHelp but a non-commands registry —
+//     must flag) / printusage_delegating (must NOT flag).
 //  2. helpEntry built with a named field (`helpEntry{name: …}`) vs
 //     positional (`helpEntry{…}`) — both handled (KeyValueExpr key and
 //     positional element 0). Fixture: namedfield.
@@ -100,8 +103,11 @@
 //     form-complete: it accepts ONLY the sole-renderTopHelp(commands) body
 //     and rejects every other statement form, so unlike a fmt.Print*
 //     blacklist there is no fmt.Fprintln / os.Stdout / helper-indirection
-//     escape. printusage_handwritten exercises the fmt.Fprintln bypass a
-//     blacklist would miss.
+//     escape. Two reverse fixtures cover the distinct escapes a weaker
+//     matcher would miss: printusage_handwritten (multi-statement, incl. the
+//     fmt.Fprintln(os.Stdout,…) form) and printusage_wrongvar (right shape,
+//     wrong registry arg — proves the arg0 == `commands` pin, i.e. help
+//     cannot be sourced from a second/parallel slice).
 //
 // ref: docs/plans/202605121830-038-p0-p1-blocking-implementation-plan.md PR-3
 // ref: cmd/gocell/app/subcommand.go (the funnel this test guards)
@@ -438,6 +444,24 @@ func TestCLITopLevelHelpRegistry01_DetectsHandwrittenPrintUsage(t *testing.T) {
 	got := scanPrintUsageDerived(p, f, rel)
 	if len(got) == 0 {
 		t.Fatal("expected hand-written PrintUsage fixture to be flagged, got 0")
+	}
+	if !containsMsg(got, "must delegate to renderTopHelp") {
+		t.Errorf("missing the form-uniqueness diagnostic; got %v", got)
+	}
+}
+
+// TestCLITopLevelHelpRegistry01_DetectsWrongRegistryArg proves the funnel
+// rejects a sole renderTopHelp call that renders from a non-`commands`
+// registry (a parallel/local source). isSoleRenderTopHelpCall pins arg0 to
+// the `commands` identifier; without this assertion the "single source"
+// claim would be unproven (the right statement shape over the wrong slice
+// would silently pass).
+func TestCLITopLevelHelpRegistry01_DetectsWrongRegistryArg(t *testing.T) {
+	t.Parallel()
+	p, f, rel := parseFixture(t, "printusage_wrongvar.go")
+	got := scanPrintUsageDerived(p, f, rel)
+	if len(got) == 0 {
+		t.Fatal("expected renderTopHelp(non-commands) fixture to be flagged, got 0")
 	}
 	if !containsMsg(got, "must delegate to renderTopHelp") {
 		t.Errorf("missing the form-uniqueness diagnostic; got %v", got)

--- a/tools/archtest/cli_unimpl_hide_test.go
+++ b/tools/archtest/cli_unimpl_hide_test.go
@@ -3,9 +3,9 @@
 //   - CLI-TOPLEVEL-HELP-REGISTRY-01
 //
 // No `gocell` command — at any level — may be visible in help while being
-// unimplemented. The four help-bearing verb trees
-// (generate / verify / scaffold / check) AND the top-level command set each
-// own a single typed registry (cmd/gocell/app/subcommand.go's
+// unimplemented. The five help-bearing verb trees
+// (generate / verify / scaffold / check / export) AND the top-level command
+// set each own a single typed registry (cmd/gocell/app/subcommand.go's
 // subcommand[H]); dispatch and help BOTH derive from that one slice, so a
 // command cannot appear in one truth and not the other.
 //
@@ -13,13 +13,16 @@
 // than convention. It binds four structural facts in cmd/gocell/app
 // production code:
 //
-//   - Upstream Hard: the dispatch functions — the four verb-tree
-//     dispatchers (runGenerate, runVerify, runScaffoldWithRoot, runCheck)
-//     plus the top-level Dispatch — contain NO `switch` statement and DO
-//     call findSub — i.e. dispatch is registry lookup, never a
-//     string-literal `case "name":` ladder (verb trees) nor a name→handler
-//     map index (top level). Re-introducing a switch (the pre-PR shape that
-//     let `generate indexes` exist) fails CI.
+//   - Upstream Hard (form-unique): the dispatch functions — the five
+//     verb-tree dispatchers (runGenerate, runVerify, runScaffoldWithRoot,
+//     runCheck, runExport) plus the top-level Dispatch — contain NO `switch`
+//     statement AND resolve the handler via `h, ok := findSub(<registry>, …)`
+//     over the dispatcher's own registry AND actually invoke that resolved
+//     `h`. This defeats not only a string-literal `case "name":` ladder but
+//     also a dummy findSub call paired with a real name→handler map-index /
+//     if-ladder dispatch (the resolved handler must be the one called). The
+//     expected registry per dispatcher is pinned in dispatchFuncs, so
+//     findSub over a parallel/wrong slice is rejected too.
 //   - Downstream Hard (verb trees): no `helpEntry{…}` composite literal
 //     anywhere in production code carries a string-literal `name`. The only
 //     path from a registry to a helpEntry is buildHelpEntries (via
@@ -49,16 +52,17 @@
 //     archtest-bound (the Go ceiling for "what a func prints"); form
 //     uniqueness is the highest grade reachable for this rule shape (charter
 //     §Hard 范本 "typed marker funnel for unbounded ops").
-//   - Upstream = the SAME closed-loop archtest funnel as the verb trees:
-//     Dispatch ∈ dispatchFuncs → no-switch + must-call-findSub. Enforcement
-//     is archtest-AST (Go cannot type-force "resolution must go through
-//     findSub"); this is the identical mechanism and identical ceiling as
-//     the four already-shipped verb dispatchers. This PR does NOT fork a
-//     divergent grade for one of two identical mechanisms in the same file
-//     (concept-model consistency); whether the CLI single-source funnel's
-//     upstream is "truly Hard vs Medium" is a framing question that applies
-//     equally to the sibling — recorded here as a known meta-question, not
-//     silently decided nor unilaterally re-graded.
+//   - Upstream = Hard (form-unique), SHARED with the verb trees:
+//     Dispatch ∈ dispatchFuncs → no-switch AND `h,ok := findSub(commands,…)`
+//     AND `h` is invoked. The form-uniqueness (handler bound by findSub over
+//     the pinned registry, then that exact handler dispatched) closes the
+//     weaker "findSub appears somewhere" shape: a dummy findSub paired with a
+//     name→handler map-index/if-ladder dispatch fails, as does findSub over a
+//     wrong/parallel slice. Enforcement is archtest-AST (Go cannot type-force
+//     control flow), so form-uniqueness — no "like-but-not" gray zone — is
+//     the highest grade reachable for this rule shape (charter §Hard 范本
+//     "typed marker funnel for unbounded ops"); identical mechanism and
+//     ceiling for all six dispatchers, graded uniformly (no fork).
 //
 // Reverse-fixture self-checks below prove each detector actually
 // fires (a detector that silently passes everything would itself be the
@@ -93,11 +97,14 @@
 //     `placeholder` asserts the literal form is caught, and the absence
 //     of any indirection is guaranteed by the no-switch + findSub facts
 //     (an unregistered type cannot reach a handler at all).
-//  4. runExport's two-value `catalog|metadata` alias switch is
-//     intentionally OUT of scope: export has no helpEntry surface, so it
-//     cannot drift help vs dispatch. dispatchFuncs lists the four
-//     help-bearing verb trees plus the top-level Dispatch — runExport is
-//     deliberately absent.
+//  4. export is now a registry-backed verb tree, not an excluded alias
+//     switch: runExport resolves catalog/metadata via
+//     findSub(exportSubcommands, …) and derives `export -h` via renderSubHelp,
+//     so it is in dispatchFuncs like the other four. (Previously it was an
+//     OUT-of-scope plain alias switch with no helpEntry surface; once it grew
+//     a `-h` help surface that exclusion no longer held, so it was folded into
+//     the funnel rather than left as a hand-written second source.) There is
+//     no remaining excluded dispatcher.
 //  5. scanPrintUsageDerived keys on the FuncDecl name "PrintUsage" (a name
 //     convention for the single sanctioned entry point) but its match is
 //     form-complete: it accepts ONLY the sole-renderTopHelp(commands) body
@@ -122,19 +129,20 @@ import (
 	"testing"
 )
 
-// dispatchFuncs are the registry-backed dispatchers: the four help-bearing
-// verb-tree dispatchers plus the top-level Dispatch
-// (CLI-TOPLEVEL-HELP-REGISTRY-01). Each must route through a subcommand
-// registry (findSub) and contain no switch — a string-literal `case`
-// ladder (verb trees) or a name→handler map index (top level) would let
-// dispatch drift from help. runExport is deliberately absent (no helpEntry
-// surface — see ledger §4).
-var dispatchFuncs = map[string]bool{
-	"runGenerate":         true,
-	"runVerify":           true,
-	"runScaffoldWithRoot": true,
-	"runCheck":            true,
-	"Dispatch":            true,
+// dispatchFuncs maps each registry-backed dispatcher to the registry-slice
+// identifier it MUST resolve handlers from: the five help-bearing verb-tree
+// dispatchers plus the top-level Dispatch (CLI-TOPLEVEL-HELP-REGISTRY-01).
+// scanDispatchViaRegistry pins the form `h, ok := findSub(<registry>, …)`
+// followed by an invocation of `h` — so dispatch is a registry lookup whose
+// resolved handler is the one called, never a switch ladder nor a dummy
+// findSub paired with a parallel map-index/if-ladder dispatch.
+var dispatchFuncs = map[string]string{
+	"runGenerate":         "generateSubcommands",
+	"runVerify":           "verifySubcommands",
+	"runScaffoldWithRoot": "scaffoldSubcommands",
+	"runCheck":            "checkSubcommands",
+	"runExport":           "exportSubcommands",
+	"Dispatch":            "commands",
 }
 
 // TestCLIUnimplHide01 binds the structural single-source facts in
@@ -151,7 +159,7 @@ func TestCLIUnimplHide01(t *testing.T) {
 				if strings.HasSuffix(rel, "_test.go") {
 					continue // production-only invariant
 				}
-				d = append(d, scanDispatchSwitchFree(p, f, rel)...)
+				d = append(d, scanDispatchViaRegistry(p, f, rel)...)
 				d = append(d, scanHelpEntryNoLiteralName(p, f, rel)...)
 				d = append(d, scanNoNotImplementedLiteral(p, f, rel)...)
 			}
@@ -160,40 +168,97 @@ func TestCLIUnimplHide01(t *testing.T) {
 	Report(t, "CLI-UNIMPL-HIDE-01", diags)
 }
 
-// scanDispatchSwitchFree enforces the upstream-Hard fact: each dispatch
-// function has zero SwitchStmt and at least one findSub call.
-func scanDispatchSwitchFree(p *Pass, f *ast.File, rel string) []Diagnostic {
+// scanDispatchViaRegistry enforces the upstream form-uniqueness fact: each
+// dispatcher has zero SwitchStmt, binds its handler via
+// `h, ok := findSub(<its registry>, …)`, and invokes that exact `h`. The
+// findSub-result-must-be-invoked rule is what defeats a dummy findSub call
+// paired with a real map-index/if-ladder dispatch (the weaker "findSub
+// appears somewhere" check could not). The registry identifier is pinned per
+// dispatcher (dispatchFuncs), so resolving over a parallel/wrong slice fails.
+func scanDispatchViaRegistry(p *Pass, f *ast.File, rel string) []Diagnostic {
 	var d []Diagnostic
 	EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
-		if fn.Name == nil || !dispatchFuncs[fn.Name.Name] || fn.Body == nil {
+		if fn.Name == nil || fn.Body == nil {
 			return
 		}
-		var hasSwitch, callsFindSub bool
+		reg, ok := dispatchFuncs[fn.Name.Name]
+		if !ok {
+			return
+		}
+		line := p.Fset.Position(fn.Pos()).Line
+		var hasSwitch bool
 		EachInSubtree[ast.SwitchStmt](fn.Body, func(*ast.SwitchStmt) { hasSwitch = true })
-		EachInSubtree[ast.CallExpr](fn.Body, func(c *ast.CallExpr) {
-			if id, ok := c.Fun.(*ast.Ident); ok && id.Name == "findSub" {
-				callsFindSub = true
-			}
-		})
 		if hasSwitch {
 			d = append(d, Diagnostic{
 				Rel:  rel,
-				Line: p.Fset.Position(fn.Pos()).Line,
-				Message: fn.Name.Name + " dispatches via switch; the four verb " +
-					"trees must dispatch through the subcommand registry (findSub) " +
-					"so help and dispatch cannot drift",
+				Line: line,
+				Message: fn.Name.Name + " dispatches via switch; a registry-backed " +
+					"dispatcher must resolve the handler through findSub so help and " +
+					"dispatch cannot drift",
 			})
 		}
-		if !callsFindSub {
+		handler := findSubHandlerIdent(fn.Body, reg)
+		if handler == "" {
 			d = append(d, Diagnostic{
 				Rel:  rel,
-				Line: p.Fset.Position(fn.Pos()).Line,
-				Message: fn.Name.Name + " does not call findSub; dispatch must " +
-					"resolve the handler through its subcommand registry",
+				Line: line,
+				Message: fn.Name.Name + " does not resolve the handler via findSub(" +
+					reg + ", …); dispatch must look the handler up in its registry, " +
+					"not a switch/map/if-ladder",
+			})
+			return // no handler binding to verify invocation against
+		}
+		if !identIsCalled(fn.Body, handler) {
+			d = append(d, Diagnostic{
+				Rel:  rel,
+				Line: line,
+				Message: fn.Name.Name + " resolves a handler via findSub but never " +
+					"dispatches it; the findSub result must be the invoked handler " +
+					"(guards a dummy findSub paired with a parallel map-index dispatch)",
 			})
 		}
 	})
 	return d
+}
+
+// findSubHandlerIdent returns the name of the handler variable bound by an
+// assignment `<h>, <ok> := findSub(<reg>, …)` whose first argument is the
+// identifier regName. Returns "" when no such assignment exists.
+func findSubHandlerIdent(body *ast.BlockStmt, regName string) string {
+	var name string
+	EachInSubtree[ast.AssignStmt](body, func(as *ast.AssignStmt) {
+		if name != "" || len(as.Rhs) != 1 || len(as.Lhs) != 2 {
+			return
+		}
+		call, ok := as.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return
+		}
+		fun, ok := call.Fun.(*ast.Ident)
+		if !ok || fun.Name != "findSub" || len(call.Args) < 1 {
+			return
+		}
+		arg0, ok := call.Args[0].(*ast.Ident)
+		if !ok || arg0.Name != regName {
+			return
+		}
+		if h, ok := as.Lhs[0].(*ast.Ident); ok {
+			name = h.Name
+		}
+	})
+	return name
+}
+
+// identIsCalled reports whether the identifier name is invoked as `name(…)`
+// anywhere in body.
+func identIsCalled(body *ast.BlockStmt, name string) bool {
+	called := false
+	EachInSubtree[ast.CallExpr](body, func(c *ast.CallExpr) {
+		if id, ok := c.Fun.(*ast.Ident); ok && id.Name == name {
+			called = true
+		}
+	})
+	return called
 }
 
 // scanHelpEntryNoLiteralName enforces the downstream-Hard fact: no
@@ -304,20 +369,36 @@ func parseFixture(t *testing.T, name string) (*Pass, *ast.File, string) {
 func TestCLIUnimplHide01_DetectsSwitchDispatch(t *testing.T) {
 	t.Parallel()
 	p, f, rel := parseFixture(t, "switch_dispatch.go")
-	got := scanDispatchSwitchFree(p, f, rel)
-	// The fixture's runGenerate both has a switch AND never calls findSub,
-	// so the detector must emit exactly two distinct diagnostics. Asserting
-	// only "len > 0" would let the detector silently regress to reporting a
-	// single condition.
+	got := scanDispatchViaRegistry(p, f, rel)
+	// The fixture's runGenerate both has a switch AND never resolves via
+	// findSub(generateSubcommands, …), so the detector must emit exactly two
+	// distinct diagnostics. Asserting only "len > 0" would let the detector
+	// silently regress to reporting a single condition.
 	if len(got) != 2 {
 		t.Fatalf("expected exactly 2 diagnostics (switch present + findSub "+
-			"absent), got %d: %v", len(got), got)
+			"resolution absent), got %d: %v", len(got), got)
 	}
 	if !containsMsg(got, "dispatches via switch") {
 		t.Errorf("missing the switch-present diagnostic; got %v", got)
 	}
-	if !containsMsg(got, "does not call findSub") {
-		t.Errorf("missing the findSub-absent diagnostic; got %v", got)
+	if !containsMsg(got, "does not resolve the handler via findSub") {
+		t.Errorf("missing the findSub-resolution-absent diagnostic; got %v", got)
+	}
+}
+
+// TestCLIUnimplHide01_DetectsDummyFindSubMapIndex proves the form-unique
+// upstream check catches the bypass the old "findSub appears somewhere" shape
+// could not: a dispatcher that calls findSub(<registry>, …) but discards the
+// result and dispatches via a name→handler map index instead.
+func TestCLIUnimplHide01_DetectsDummyFindSubMapIndex(t *testing.T) {
+	t.Parallel()
+	p, f, rel := parseFixture(t, "dummy_findsub_mapindex.go")
+	got := scanDispatchViaRegistry(p, f, rel)
+	if len(got) == 0 {
+		t.Fatal("expected dummy-findSub + map-index dispatch fixture to be flagged, got 0")
+	}
+	if !containsMsg(got, "never dispatches it") {
+		t.Errorf("missing the findSub-result-not-invoked diagnostic; got %v", got)
 	}
 }
 

--- a/tools/archtest/testdata/cli_unimpl_hide/dummy_findsub_mapindex.go
+++ b/tools/archtest/testdata/cli_unimpl_hide/dummy_findsub_mapindex.go
@@ -1,0 +1,17 @@
+// Fixture for the upstream form-uniqueness reverse self-check
+// (CLI-UNIMPL-HIDE-01 / CLI-TOPLEVEL-HELP-REGISTRY-01).
+//
+// runGenerate calls findSub(generateSubcommands, …) — so the weaker
+// "findSub appears somewhere" check would pass — but discards the resolved
+// handler and dispatches via a name→handler map index instead. The
+// form-unique scanDispatchViaRegistry MUST flag it: the findSub result is
+// never invoked. Not compiled (testdata).
+package fixture
+
+func runGenerate(ctx context.Context, args []string) error {
+	cmd, ok := findSub(generateSubcommands, args[0]) // dummy: result discarded
+	_ = ok
+	_ = cmd
+	h := handlerMap[args[0]] // real dispatch via map index, bypassing findSub
+	return h(ctx, args[1:])
+}

--- a/tools/archtest/testdata/cli_unimpl_hide/printusage_delegating.go
+++ b/tools/archtest/testdata/cli_unimpl_hide/printusage_delegating.go
@@ -1,0 +1,13 @@
+// Fixture for CLI-TOPLEVEL-HELP-REGISTRY-01 reverse self-check
+// (downstream form-uniqueness — must NOT flag).
+//
+// The compliant shape: PrintUsage's body is exactly one statement, a
+// renderTopHelp(commands, …) delegation. scanPrintUsageDerived MUST pass
+// it (0 diagnostics), so the detector cannot regress to flagging
+// everything. renderTopHelp / commands are undeclared here — parseFixture
+// is pure AST (SkipObjectResolution), not compiled (testdata).
+package fixture
+
+func PrintUsage() {
+	renderTopHelp(commands, "Run 'gocell <command> -h' for full flag help on a sub-command.")
+}

--- a/tools/archtest/testdata/cli_unimpl_hide/printusage_handwritten.go
+++ b/tools/archtest/testdata/cli_unimpl_hide/printusage_handwritten.go
@@ -1,0 +1,20 @@
+// Fixture for CLI-TOPLEVEL-HELP-REGISTRY-01 reverse self-check
+// (downstream form-uniqueness — must flag).
+//
+// A PrintUsage that hand-prints the top-level command list instead of
+// delegating to renderTopHelp(commands, …) as its sole statement — the
+// drift-prone free-form prose that let stale sub-types resurface in
+// top-level help. scanPrintUsageDerived MUST flag it. The body exercises
+// the bypass forms a fmt.Print*-only blacklist would miss
+// (fmt.Fprintln(os.Stdout, …)). Not compiled (testdata).
+package fixture
+
+import (
+	"fmt"
+	"os"
+)
+
+func PrintUsage() {
+	fmt.Println("Usage: gocell <command> [args]")
+	fmt.Fprintln(os.Stdout, "  validate  Validate all metadata")
+}

--- a/tools/archtest/testdata/cli_unimpl_hide/printusage_wrongvar.go
+++ b/tools/archtest/testdata/cli_unimpl_hide/printusage_wrongvar.go
@@ -1,0 +1,15 @@
+// Fixture for CLI-TOPLEVEL-HELP-REGISTRY-01 reverse self-check
+// (downstream form-uniqueness — must flag a non-`commands` registry arg).
+//
+// PrintUsage's body IS a single renderTopHelp call (the statement shape is
+// right) but it renders from a parallel/local slice instead of the canonical
+// `commands` registry. isSoleRenderTopHelpCall pins the first argument to the
+// identifier `commands`, so scanPrintUsageDerived MUST flag this — proving
+// the funnel rejects rendering from a second source, not just hand-printed
+// prose. renderTopHelp / localCommands are undeclared here — parseFixture is
+// pure AST (SkipObjectResolution), not compiled (testdata).
+package fixture
+
+func PrintUsage() {
+	renderTopHelp(localCommands, "Run 'gocell <command> -h' for full flag help on a sub-command.")
+}


### PR DESCRIPTION
## Summary

把顶层 `cmd/gocell/app/dispatch.go` 的命令列表从「`map[string]handler` + 手写 `PrintUsage` prose」双源，改造为**单源 typed registry**，复用四棵 verb 树已有的 `subcommand[H]` funnel（CLI-UNIMPL-HIDE-01），闭合 **CLI-TOPLEVEL-HELP-REGISTRY-01**——该 drift 面此前是 charter 里显式声明的 blind spot，仅由补偿性 stale-token archtest 兜底。

### 改动
- **`commands`**：`map[string]handler` → `[]subcommand[func(ctx, args) error]`（name + help + run 同源）。
- **`Dispatch`**：map 索引 → `findSub(commands, …)`（上游，与四棵 verb 树同机制）。
- **`PrintUsage`**：body 改为唯一 `renderTopHelp(commands, footer)` 委派（下游 **form-unique**）；**删除**手写的嵌套子类型 prose（已漂移：`generate` 列了 7 个中的 3 个、`verify` 列了 8 个中的 1 个）——明细改由 `gocell <command> -h` 从各 sub-registry 派生。
- **`subcommand.go`**：新增单一 `buildHelpEntries` helpEntry funnel（renderSubHelp / renderTopHelp 共用），package doc 重写（顶层不再是 blind spot）。
- **`help.go`**：`printHelp` 泛化为 `(usage, section, …)` 形参，同时服务顶层 `Commands:` 与 verb `Types:`。
- **archtest**：`Dispatch` 纳入 `dispatchFuncs`（no-switch + must-call-findSub）；新增 form-unique `scanPrintUsageDerived` + 正反双锁 fixture；**删除**补偿性 `TestCLIUnimplHide01_PrintUsageNoStaleToken`。

### AI-robust 评级（funnel 双向锁）
单一 `commands` package var 是 funnel；Dispatch 与 PrintUsage 都只读它。
- **下游 = Hard（form-unique）**：help 名只能来自 `buildHelpEntries` 的 `name: s.name` selector；`scanHelpEntryNoLiteralName` package-wide 禁 literal-name helpEntry；PrintUsage body form-locked 到唯一 `renderTopHelp(commands)` 委派——**不**用 `fmt.Print*` 黑名单（会留 `fmt.Fprintln`/`os.Stdout`/helper 灰区），form-uniqueness 无「像但不是」旁路。
- **上游 = 与四棵 verb 树同机制同天花板**的 closed-loop archtest funnel（`Dispatch ∈ dispatchFuncs`）。本 PR 不为同一机制在同一文件另立分叉评级；"CLI 单源 funnel 上游究竟 Hard 还是 Medium" 作为同样适用于 sibling 的已知 meta-问题显式记入 archtest godoc，不静默、不单方面 re-grade。

详细评级与盲区清单活在 `tools/archtest/cli_unimpl_hide_test.go` package godoc（per charter「落地实例活在代码 godoc」）。

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/gocell/...` — pass（含更新后的 `TestPrintUsage` / `TestCommands` / 两个 errcode-redaction / `TestPrintHelpRendersEntryWithoutDescription`）
- [x] archtest `TestCLIUnimplHide01`（含 Dispatch）+ `TestCLITopLevelHelpRegistry01`（含正反双锁自检）GREEN
- [x] `golangci-lint run ./cmd/gocell/... ./tools/archtest/...` — 0 issues（本 PR 改动包）
- [x] 手验：`gocell`（无参）只列 7 顶层命令、无嵌套行；`gocell generate -h` 全部子类型仍可见；unknown command → PrintUsage + ExitUsage(2)
- [x] TDD：RED commit（`bfad879`）先于 GREEN commit（`e733574`）

> 注：全仓 `golangci-lint run ./...` 另报 1 条 **pre-existing** issue `tools/codegen/cellgen/literal_printer.go:340`（gocognit），不在本 PR diff 内、未被本 PR 触碰；CI PR lint 用 `--new-from-merge-base` 仅检查改动行，不受影响。

## Contract-fanout
不触发：无 public interface 签名 / error sentinel / contract.yaml / DB schema / errcode 变化。`Dispatch` 公开签名不变；`commands`、`printHelp` 均为 unexported（CLI internal 治理机制重构）。

ref: go-zero goctl tools/goctl — commands 注册而非 switch-dispatch；help 从注册表派生单源原则。

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
