### PR TITLE
test(archtest): CELL-TEST-NO-ADAPTER-IMPORT-01 — cell 单测禁 import 平台 adapters (#803)

### DIFF
--- a/.claude/rules/gocell/go-standards.md
+++ b/.claude/rules/gocell/go-standards.md
@@ -76,6 +76,7 @@ paths:
 - DB 字段 `snake_case`，JSON 字段 `camelCase`，Query/Path 参数 `camelCase`
 - 错误用 `errcode.New(code, message)`，包装上下文用 `fmt.Errorf("context: %w", err)`
 - mock 定义在测试文件中（`*_test.go` 同包）
+- cell 单测不 import 平台 `adapters/`，用 canonical in-mem fake（`session.MemStore` / `refresh/memstore` / `eventbus.InMemoryEventBus` / `outboxtest.Recorder` / `distlock/locktest` / `crypto.LocalAESKeyProvider` / `outbox.DemoTxRunner` / `cells/*/internal/mem`）；由 archtest `CELL-TEST-NO-ADAPTER-IMPORT-01` 守（清单与理由见其 package godoc），`//go:build integration` 门控的集成测试豁免
 
 ## 测试覆盖率
 

--- a/.claude/rules/gocell/go-standards.md
+++ b/.claude/rules/gocell/go-standards.md
@@ -76,7 +76,7 @@ paths:
 - DB 字段 `snake_case`，JSON 字段 `camelCase`，Query/Path 参数 `camelCase`
 - 错误用 `errcode.New(code, message)`，包装上下文用 `fmt.Errorf("context: %w", err)`
 - mock 定义在测试文件中（`*_test.go` 同包）
-- cell 单测不 import 平台 `adapters/`，用 canonical in-mem fake（`session.MemStore` / `refresh/memstore` / `eventbus.InMemoryEventBus` / `outboxtest.Recorder` / `distlock/locktest` / `crypto.LocalAESKeyProvider` / `outbox.DemoTxRunner` / `cells/*/internal/mem`）；由 archtest `CELL-TEST-NO-ADAPTER-IMPORT-01` 守（清单与理由见其 package godoc），`//go:build integration` 门控的集成测试豁免
+- cell 单测不 import 平台 `adapters/`，用 canonical in-mem fake；由 archtest `CELL-TEST-NO-ADAPTER-IMPORT-01` 守（fake 清单、豁免语义与理由见其 package godoc 单一真值源），build-tag 门控的集成测试豁免
 
 ## 测试覆盖率
 

--- a/cells/accesscore/bundle_options_test.go
+++ b/cells/accesscore/bundle_options_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	accessmem "github.com/ghbvf/gocell/cells/accesscore/mem"
 	accesspg "github.com/ghbvf/gocell/cells/accesscore/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
 // TestWithMemBundle_WiresFourPrimitives verifies that WithMemBundle copies the
@@ -40,7 +40,7 @@ func TestWithMemBundle_WiresFourPrimitives(t *testing.T) {
 // needed because inner constructors only store the references.
 func TestWithPGBundle_WiresFourPrimitives(t *testing.T) {
 	fakePool := new(pgxpool.Pool)
-	fakeTxm := new(adapterpg.TxManager)
+	fakeTxm := outbox.DemoTxRunner{}
 
 	b, err := accesspg.NewBundle(fakePool, fakeTxm, clock.Real())
 	require.NoError(t, err)

--- a/cells/accesscore/internal/adapters/postgres/role_repo_test.go
+++ b/cells/accesscore/internal/adapters/postgres/role_repo_test.go
@@ -8,18 +8,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // TestPGRoleRepo_Constructor_FailFast verifies that NewPGRoleRepo rejects nil
 // dependencies at construction time, without requiring a real PG connection.
-// Uses new(pgxpool.Pool) / new(adapterpg.TxManager) (non-nil zero values) to
-// reach the later guards — mirroring the session_store_uuid_test.go pattern.
+// Uses new(pgxpool.Pool) / outbox.DemoTxRunner{} (non-nil values) to reach the
+// later guards — outbox.DemoTxRunner is the canonical in-mem persistence.TxRunner
+// (no need to import the real adapters/postgres; CELL-TEST-NO-ADAPTER-IMPORT-01).
 func TestPGRoleRepo_Constructor_FailFast(t *testing.T) {
-	fakePool := new(pgxpool.Pool)       // non-nil zero value, no real PG needed
-	fakeTxm := new(adapterpg.TxManager) // non-nil zero value, reaches clock guard
+	fakePool := new(pgxpool.Pool)    // non-nil zero value, no real PG needed
+	fakeTxm := outbox.DemoTxRunner{} // non-nil TxRunner, reaches clock guard
 
 	assertValidationFailed := func(t *testing.T, err error) {
 		t.Helper()
@@ -35,7 +36,7 @@ func TestPGRoleRepo_Constructor_FailFast(t *testing.T) {
 	})
 
 	t.Run("nil_txRunner_typed_nil", func(t *testing.T) {
-		var nilTxm *adapterpg.TxManager // typed-nil caught by validation.IsNilInterface
+		var nilTxm *outbox.DemoTxRunner // typed-nil caught by validation.IsNilInterface
 		_, err := NewPGRoleRepo(fakePool, nilTxm, clock.Real())
 		assertValidationFailed(t, err)
 	})

--- a/cells/accesscore/postgres/bundle_test.go
+++ b/cells/accesscore/postgres/bundle_test.go
@@ -36,6 +36,9 @@ func TestNewBundle_FailFast(t *testing.T) {
 	})
 
 	t.Run("nil_txMgr_typed_nil", func(t *testing.T) {
+		// typed-nil caught by validation.IsNilInterface — behavior is identical
+		// for any concrete TxRunner type (DemoTxRunner here vs the real adapter
+		// in production), since IsNilInterface checks the interface's data pointer.
 		var nilTxm *outbox.DemoTxRunner
 		_, err := NewBundle(fakePool, nilTxm, clock.Real())
 		assertValidationFailed(t, err)

--- a/cells/accesscore/postgres/bundle_test.go
+++ b/cells/accesscore/postgres/bundle_test.go
@@ -8,18 +8,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // TestNewBundle_FailFast verifies the three nil-validation branches of
 // accesspg.NewBundle. Mirrors the internal/adapters/postgres role_repo_test.go
-// pattern: non-nil zero-value pool/txMgr reach the next guard without needing
-// a real PG connection.
+// pattern: non-nil zero-value pool + outbox.DemoTxRunner reach the next guard
+// without needing a real PG connection (outbox.DemoTxRunner is the canonical
+// in-mem persistence.TxRunner; CELL-TEST-NO-ADAPTER-IMPORT-01).
 func TestNewBundle_FailFast(t *testing.T) {
-	fakePool := new(pgxpool.Pool)       // non-nil zero value, no real PG needed
-	fakeTxm := new(adapterpg.TxManager) // non-nil zero value, reaches clock guard
+	fakePool := new(pgxpool.Pool)    // non-nil zero value, no real PG needed
+	fakeTxm := outbox.DemoTxRunner{} // non-nil TxRunner, reaches clock guard
 
 	assertValidationFailed := func(t *testing.T, err error) {
 		t.Helper()
@@ -35,7 +36,7 @@ func TestNewBundle_FailFast(t *testing.T) {
 	})
 
 	t.Run("nil_txMgr_typed_nil", func(t *testing.T) {
-		var nilTxm *adapterpg.TxManager
+		var nilTxm *outbox.DemoTxRunner
 		_, err := NewBundle(fakePool, nilTxm, clock.Real())
 		assertValidationFailed(t, err)
 	})
@@ -53,7 +54,7 @@ func TestNewBundle_FailFast(t *testing.T) {
 // methods return non-nil after a successful NewBundle call.
 func TestNewBundle_HappyPath(t *testing.T) {
 	fakePool := new(pgxpool.Pool)
-	fakeTxm := new(adapterpg.TxManager)
+	fakeTxm := outbox.DemoTxRunner{}
 
 	b, err := NewBundle(fakePool, fakeTxm, clock.Real())
 	require.NoError(t, err)

--- a/tools/archtest/cell_test_no_adapter_import_test.go
+++ b/tools/archtest/cell_test_no_adapter_import_test.go
@@ -1,0 +1,301 @@
+// INVARIANT: CELL-TEST-NO-ADAPTER-IMPORT-01: cell unit tests must not import
+// the platform adapters/ layer; they must use canonical in-mem fakes instead.
+//
+// # Why
+//
+// CLAUDE.md layering: cells/ depend on kernel/ + runtime/ but NOT adapters/
+// (decoupled via interfaces). Production cell code already obeys this via the
+// cells-isolation depguard rule. But every depguard isolation rule EXEMPTS
+// *_test.go files, so cell *unit* tests could import the real adapters/ package
+// (pulling in heavy SDKs like pgx and coupling tests to adapter internals)
+// instead of the framework's canonical in-mem implementations. This rule closes
+// that gap: it makes the "decoupling" benefit transfer from prod to test, which
+// the 2026-05-04 systems-layer review (§3) flagged but never enforced (#803).
+//
+// # Canonical in-mem fakes (use these, never the real adapter)
+//
+//   - session.Store         → runtime/auth/session.MemStore
+//   - refresh.Store         → runtime/auth/refresh/memstore
+//   - outbox publish/sub     → runtime/eventbus.InMemoryEventBus
+//   - outbox.Store / record  → runtime/outbox/outboxtest.{Recorder,FakeStore}
+//   - distlock.Driver        → runtime/distlock/locktest.FakeDriver
+//   - crypto.KeyProvider     → runtime/crypto.LocalAESKeyProvider
+//   - persistence.TxRunner   → kernel/outbox.DemoTxRunner
+//   - cell ports (repos)     → cells/<cell>/internal/mem, cells/accesscore/mem.Bundle
+//
+// Why NOT an adapters/<name>/<name>fake/ subpackage (the #803 literal ask):
+// (1) cells importing it would make cells/ → adapters/ — a layering violation;
+// (2) it duplicates the interface-layer in-mem impls above (parallel structure);
+// (3) s3/oidc/websocket/rabbitmq are not in any cell's injection surface — dead
+// code. OSS precedent agrees: the correct shape is in-mem at the interface layer
+// (Watermill pubsub/gochannel, go-micro registry/memory), not a sibling fake per
+// adapter (K8s client-go/fake works only because its interface+impl share a
+// package — a premise GoCell's layering does not have).
+//
+// # Exemption boundary = build tag, NOT filename
+//
+// Real integration/e2e tests legitimately use real adapters + testcontainers and
+// are gated behind //go:build integration (or e2e, etc.). The exemption is keyed
+// on the ACTUAL build constraint — a file is exempt iff it is NOT visible under
+// the default (no-extra-tags) build context. This is tag-name-agnostic (covers
+// integration / e2e / any future tag) and cannot be silently gamed by renaming a
+// file to *_integration_test.go (a filename-based exemption would be Soft: the
+// repo has integration tests named plainly with only the build tag, e.g.
+// cells/accesscore/slices/identitymanage/service_test.go, so filename is not a
+// reliable proxy and renaming would dodge the rule). To escape this rule an
+// author must add //go:build integration, which removes the test from the normal
+// unit run — a visible behavior change, not a silent bypass.
+//
+// # AI-robust grading
+//
+// downstream (the import ban): archtest Medium — "a test file must not import a
+// package" has no type-system Hard form (Go permits any import); archtest AST +
+// build-constraint eval (fail-closed in CI) is the ceiling for this rule shape.
+// The exemption boundary is build-tag-based (not renameable), which is strictly
+// more robust than a depguard filename exemption. depguard is deliberately NOT
+// used here: it matches paths only and cannot evaluate //go:build, so it cannot
+// express the correct (build-tag) exemption. Routed to archtest per ai-robust
+// "纯 AST 模式 → archtest.Run".
+//
+// # Blind spots (out of this rule's declared range) + reverse self-checks
+//
+//   - aliased import (adapterpg "...adapters/postgres"): COVERED — we match the
+//     import path literal, not the local name (fixture: aliased_import).
+//   - dot import (. "...adapters/s3"): COVERED — path literal still matches
+//     (fixture: dot_import).
+//   - cell-internal adapters (cells/<c>/internal/adapters/...): NOT a platform
+//     adapter; the prefix github.com/ghbvf/gocell/adapters/ does not match the
+//     cells/.../internal/adapters/ path (fixture: cell_internal_adapter).
+//   - transitive import (cell test imports a helper that imports adapters): OUT
+//     OF SCOPE — this rule bans direct imports only. A transitively-importing
+//     helper living under cells/ would itself be caught if it is a test file.
+//   - production cell .go importing adapters: OUT OF SCOPE here — governed by the
+//     cells-isolation depguard rule (fixture: production_file).
+//   - non-cell test files (runtime/, kernel/): OUT OF SCOPE — #803 is cells-only
+//     (fixture: non_cell_test).
+package archtest
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const platformAdapterImportPrefix = "github.com/ghbvf/gocell/adapters"
+
+// TestCellTestNoAdapterImport asserts no cell (or example-cell) unit test file
+// imports the platform adapters/ layer. Integration/e2e tests (build-tag gated)
+// are exempt.
+func TestCellTestNoAdapterImport(t *testing.T) {
+	root := findModuleRoot(t)
+	findings, err := cellTestAdapterImportFindings(root)
+	require.NoError(t, err)
+	assert.Empty(t, findings,
+		"cell unit tests must not import platform adapters/; use canonical in-mem "+
+			"fakes (session.MemStore / refresh memstore / eventbus.InMemoryEventBus / "+
+			"outboxtest.Recorder / distlock locktest / crypto.LocalAESKeyProvider / "+
+			"outbox.DemoTxRunner / cells/*/internal/mem). If this is a real integration "+
+			"test that needs a live adapter, gate it behind //go:build integration. "+
+			"See CELL-TEST-NO-ADAPTER-IMPORT-01 and issue #803.\nViolations:\n%s",
+		strings.Join(findings, "\n"))
+}
+
+// cellTestAdapterImportFindings walks every test file under cells/** and
+// examples/*/cells/** that is visible in the default build context (i.e. a real
+// unit test, not gated behind a build tag) and reports any direct import of the
+// platform adapters/ layer.
+func cellTestAdapterImportFindings(root string) ([]string, error) {
+	files, err := ModuleScope(root, IncludeTests()).Files()
+	if err != nil {
+		return nil, err
+	}
+
+	var findings []string
+	for _, path := range files {
+		if !strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		relSlash := filepath.ToSlash(rel)
+		if !isCellOrExampleCellPath(relSlash) {
+			continue
+		}
+
+		visible, vErr := fileDefaultVisible(path)
+		if vErr != nil {
+			return nil, vErr
+		}
+		if !visible {
+			continue // build-tag gated (integration/e2e/...) — legitimately uses real adapters
+		}
+
+		imports, iErr := fileImportPaths(path)
+		if iErr != nil {
+			return nil, iErr
+		}
+		for _, p := range imports {
+			if isPlatformAdapterImport(p) {
+				findings = append(findings, relSlash+": imports "+p)
+			}
+		}
+	}
+	return findings, nil
+}
+
+// isCellOrExampleCellPath reports whether a module-relative slash path is under
+// cells/ or examples/<x>/cells/.
+func isCellOrExampleCellPath(relSlash string) bool {
+	if strings.HasPrefix(relSlash, "cells/") {
+		return true
+	}
+	if !strings.HasPrefix(relSlash, "examples/") {
+		return false
+	}
+	// examples/<example>/cells/...
+	rest := strings.TrimPrefix(relSlash, "examples/")
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return false
+	}
+	return strings.HasPrefix(rest[slash+1:], "cells/")
+}
+
+// fileDefaultVisible reports whether the file is compiled under the default
+// (no-extra-tags) build context. A file with no //go:build directive is visible;
+// a file gated behind a tag (integration/e2e/...) that is false under defaults
+// is NOT visible and is exempt from this rule.
+func fileDefaultVisible(path string) (bool, error) {
+	expr, err := ParseBuildConstraint(path)
+	if err != nil {
+		return false, err
+	}
+	if expr == nil {
+		return true, nil
+	}
+	return expr.Eval(BuildContextPredicate()), nil
+}
+
+// fileImportPaths returns the import path literals of a Go file.
+func fileImportPaths(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, imp := range file.Imports {
+		if p := archStringLiteralValue(imp.Path); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// isPlatformAdapterImport reports whether an import path is the platform
+// adapters/ layer (github.com/ghbvf/gocell/adapters[/...]). It deliberately does
+// NOT match cell-internal adapters (github.com/ghbvf/gocell/cells/.../internal/adapters/...).
+func isPlatformAdapterImport(p string) bool {
+	return p == platformAdapterImportPrefix ||
+		strings.HasPrefix(p, platformAdapterImportPrefix+"/")
+}
+
+// TestCellTestNoAdapterImport_FixtureMetaTest verifies the walker classifies
+// synthetic files correctly across the blind spots documented in the package
+// godoc: aliased import, dot import, cell-internal adapter, build-tag exemption,
+// example-cell scope, non-cell out-of-scope, production-file out-of-scope.
+func TestCellTestNoAdapterImport_FixtureMetaTest(t *testing.T) {
+	t.Parallel()
+
+	fixtures := []struct {
+		name    string // also the subdir; reused in the relpath
+		rel     string // module-relative path of the file to write
+		content string
+		wantHit bool
+	}{
+		{
+			name:    "plain_cell_unit_import",
+			rel:     "cells/a/x_test.go",
+			content: "package a\nimport _ \"github.com/ghbvf/gocell/adapters/postgres\"\n",
+			wantHit: true,
+		},
+		{
+			name:    "integration_gated_exempt",
+			rel:     "cells/b/y_test.go",
+			content: "//go:build integration\n\npackage b\nimport _ \"github.com/ghbvf/gocell/adapters/postgres\"\n",
+			wantHit: false,
+		},
+		{
+			name:    "e2e_gated_exempt",
+			rel:     "cells/h/h_test.go",
+			content: "//go:build e2e\n\npackage h\nimport _ \"github.com/ghbvf/gocell/adapters/redis\"\n",
+			wantHit: false,
+		},
+		{
+			name:    "aliased_import",
+			rel:     "cells/c/z_test.go",
+			content: "package c\nimport pg \"github.com/ghbvf/gocell/adapters/redis\"\nvar _ = pg.Nil\n",
+			wantHit: true,
+		},
+		{
+			name:    "dot_import",
+			rel:     "cells/d/w_test.go",
+			content: "package d\nimport . \"github.com/ghbvf/gocell/adapters/s3\"\n",
+			wantHit: true,
+		},
+		{
+			name:    "cell_internal_adapter",
+			rel:     "cells/e/e_test.go",
+			content: "package e\nimport _ \"github.com/ghbvf/gocell/cells/e/internal/adapters/postgres\"\n",
+			wantHit: false,
+		},
+		{
+			name:    "example_cell_in_scope",
+			rel:     "examples/demo/cells/f/u_test.go",
+			content: "package f\nimport _ \"github.com/ghbvf/gocell/adapters/postgres\"\n",
+			wantHit: true,
+		},
+		{
+			name:    "non_cell_test_out_of_scope",
+			rel:     "runtime/g/r_test.go",
+			content: "package g\nimport _ \"github.com/ghbvf/gocell/adapters/postgres\"\n",
+			wantHit: false,
+		},
+		{
+			name:    "production_file_out_of_scope",
+			rel:     "cells/i/prod.go",
+			content: "package i\nimport _ \"github.com/ghbvf/gocell/adapters/postgres\"\n",
+			wantHit: false,
+		},
+	}
+
+	root := t.TempDir()
+	for _, fx := range fixtures {
+		full := filepath.Join(root, filepath.FromSlash(fx.rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(fx.content), 0o644))
+	}
+
+	findings, err := cellTestAdapterImportFindings(root)
+	require.NoError(t, err)
+
+	for _, fx := range fixtures {
+		relSlash := fx.rel
+		hit := false
+		for _, f := range findings {
+			if strings.HasPrefix(f, relSlash+":") {
+				hit = true
+				break
+			}
+		}
+		assert.Equal(t, fx.wantHit, hit, "fixture %s: import-detection result", fx.name)
+	}
+}

--- a/tools/archtest/cell_test_no_adapter_import_test.go
+++ b/tools/archtest/cell_test_no_adapter_import_test.go
@@ -20,7 +20,8 @@
 //   - outbox.Store / record  → runtime/outbox/outboxtest.{Recorder,FakeStore}
 //   - distlock.Driver        → runtime/distlock/locktest.FakeDriver
 //   - crypto.KeyProvider     → runtime/crypto.LocalAESKeyProvider
-//   - persistence.TxRunner   → kernel/outbox.DemoTxRunner
+//   - persistence.TxRunner       → kernel/outbox.DemoTxRunner{}        (bare runner, for constructors taking persistence.TxRunner)
+//   - persistence.CellTxManager  → kernel/outbox.DemoCellTxManager()   (sealed marker, for cell WithTxManager options)
 //   - cell ports (repos)     → cells/<cell>/internal/mem, cells/accesscore/mem.Bundle
 //
 // Why NOT an adapters/<name>/<name>fake/ subpackage (the #803 literal ask):
@@ -55,7 +56,17 @@
 // more robust than a depguard filename exemption. depguard is deliberately NOT
 // used here: it matches paths only and cannot evaluate //go:build, so it cannot
 // express the correct (build-tag) exemption. Routed to archtest per ai-robust
-// "纯 AST 模式 → archtest.Run".
+// "纯 AST 模式 → archtest.Run". The hand-written ModuleScope+ParseBuildConstraint
+// walker (vs an archtest.Run Rule closure) mirrors the sibling build-constraint
+// discovery rule ci_integration_discovery_invariants_test.go::discoverPackagesUnderTag,
+// uses only public archtest façade primitives (no internal/scanner import), and
+// passes SCANNER-FRAMEWORK-USAGE-01/02 + PASS-FUNNEL-* meta-archtests.
+//
+// This is a UNIDIRECTIONAL import ban, not a funnel — the ai-robust "下游/上游
+// 双向锁" grading does not apply. There is no upstream sealing: Go's type system
+// cannot prevent a test file from importing a package, so upstream is permanently
+// Soft (the same Go-language ceiling depguard hits). No gh issue is opened for an
+// upstream-Hard upgrade because none is reachable in Go.
 //
 // # Blind spots (out of this rule's declared range) + reverse self-checks
 //
@@ -76,6 +87,7 @@
 package archtest
 
 import (
+	"fmt"
 	"go/parser"
 	"go/token"
 	"os"
@@ -138,13 +150,13 @@ func cellTestAdapterImportFindings(root string) ([]string, error) {
 			continue // build-tag gated (integration/e2e/...) — legitimately uses real adapters
 		}
 
-		imports, iErr := fileImportPaths(path)
+		imports, iErr := fileImportRefs(path)
 		if iErr != nil {
 			return nil, iErr
 		}
-		for _, p := range imports {
-			if isPlatformAdapterImport(p) {
-				findings = append(findings, relSlash+": imports "+p)
+		for _, ir := range imports {
+			if isPlatformAdapterImport(ir.path) {
+				findings = append(findings, fmt.Sprintf("%s:%d: imports %s", relSlash, ir.line, ir.path))
 			}
 		}
 	}
@@ -184,17 +196,24 @@ func fileDefaultVisible(path string) (bool, error) {
 	return expr.Eval(BuildContextPredicate()), nil
 }
 
-// fileImportPaths returns the import path literals of a Go file.
-func fileImportPaths(path string) ([]string, error) {
+// importRef is an import path literal paired with its 1-based source line, so
+// findings can point CI at the exact line (not just the file).
+type importRef struct {
+	path string
+	line int
+}
+
+// fileImportRefs returns the import path literals of a Go file with line numbers.
+func fileImportRefs(path string) ([]importRef, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
 	if err != nil {
 		return nil, err
 	}
-	var out []string
+	var out []importRef
 	for _, imp := range file.Imports {
 		if p := archStringLiteralValue(imp.Path); p != "" {
-			out = append(out, p)
+			out = append(out, importRef{path: p, line: fset.Position(imp.Path.Pos()).Line})
 		}
 	}
 	return out, nil
@@ -211,7 +230,8 @@ func isPlatformAdapterImport(p string) bool {
 // TestCellTestNoAdapterImport_FixtureMetaTest verifies the walker classifies
 // synthetic files correctly across the blind spots documented in the package
 // godoc: aliased import, dot import, cell-internal adapter, build-tag exemption,
-// example-cell scope, non-cell out-of-scope, production-file out-of-scope.
+// example-cell scope, non-cell out-of-scope, production-file out-of-scope, and a
+// clean cell unit test (reverse self-check: no false positive).
 func TestCellTestNoAdapterImport_FixtureMetaTest(t *testing.T) {
 	t.Parallel()
 
@@ -273,6 +293,14 @@ func TestCellTestNoAdapterImport_FixtureMetaTest(t *testing.T) {
 			name:    "production_file_out_of_scope",
 			rel:     "cells/i/prod.go",
 			content: "package i\nimport _ \"github.com/ghbvf/gocell/adapters/postgres\"\n",
+			wantHit: false,
+		},
+		{
+			// Reverse self-check: a normal cell unit test importing only canonical
+			// in-mem fakes / kernel / stdlib must NOT be flagged (no false positive).
+			name:    "clean_cell_unit_test",
+			rel:     "cells/k/k_test.go",
+			content: "package k\nimport (\n\t\"testing\"\n\t_ \"github.com/ghbvf/gocell/kernel/outbox\"\n)\nfunc TestK(t *testing.T) {}\n",
 			wantHit: false,
 		},
 	}


### PR DESCRIPTION
## Summary

把 issue #803「Adapter fake export 一致性」**翻转**为它真正该交付的东西：用 build-tag-aware archtest 强制
**cell 单测不得 import 平台 `adapters/`、必须用 canonical in-mem fake**——而不是建 `adapters/<name>/<name>fake/` 子包。

### 为何否决 issue 字面方案（建 fake 子包）

1. **前提已被覆盖**：cell 注入的 adapter 接口全部已有可导入 in-mem 实现（`session.MemStore` / `refresh/memstore` /
   `eventbus.InMemoryEventBus` / `outboxtest.{Recorder,FakeStore}` / `distlock/locktest.FakeDriver` /
   `crypto.LocalAESKeyProvider` / `outbox.DemoTxRunner` / `cells/*/internal/mem`）。核实：当前 0 个 cell 单测手写过 adapter 接口 fake。
2. **死代码**：`s3/oidc/websocket/rabbitmq/NonceStore` 不在任何 cell 注入面 → fake 子包零消费方。
3. **平行结构 + 分层违规**：`adapters/<name>/<name>fake/` 供 cells import 会让 `cells/ → adapters/` 成立（违反 CLAUDE.md 分层），且与既有 interface-层 in-mem 重复。

### OSS 对标（WebFetch 取证）

- K8s `client-go/.../fake` 的 sibling-fake 成立前提是「接口与实现同包」，GoCell 不具备。
- 正确对标 = **Watermill `pubsub/gochannel`** / **go-micro `registry/memory`**（in-mem 在 interface 层），GoCell 既有布局已是此模式。
- depguard v2 `$test` 文件变量 + go-cleanarch 默认对 test 文件做层级检查 → 「约束 test 文件 import」有先例。

## 改动

- **新 archtest** `tools/archtest/cell_test_no_adapter_import_test.go`（INVARIANT `CELL-TEST-NO-ADAPTER-IMPORT-01`）：
  禁 `cells/**` 与 `examples/*/cells/**` 的 **default-visible**（非 build-tag 门控）测试文件 import 平台 `adapters/`；
  含 fixture 盲区自检（别名 import / dot import / cell-internal adapter / build-tag 豁免 / example-cell 范围 / 非-cell 越界 / production 文件越界）。
- **修 3 个既有违规单测**（`accesscore` bundle_options / postgres/bundle / internal/adapters/postgres/role_repo）：
  `new(adapterpg.TxManager)` 占位 → canonical `kernel/outbox.DemoTxRunner`，删平台 adapter import。测试三分支语义不变。
- **`go-standards.md` 命名规范 +1 行指针**（真值源在 archtest godoc，不复制）。

## 关键设计裁决：载体 = archtest 而非 depguard

仓库集成测试靠 `//go:build integration` 标记、**命名不一致**（有 build-tag 门控却命名普通 `*_test.go` 的集成测试）。
故 depguard 的文件名豁免会**误杀**合法集成测试、且可**改名静默绕过**（Soft）。depguard 看不到 build tag，**结构上无法表达**正确豁免边界。
改用 archtest 复用既有 `ParseBuildConstraint`/`BuildContextPredicate`/`ModuleScope`，豁免绑定**真实 build tag**（不可改名绕过）。

## AI-robust 评级（诚实）

- downstream（禁 import）= **archtest Medium**：「test 文件不得 import 某包」无 type-system Hard 形态（Go 允许任意 import），archtest AST + build-constraint eval 是该规则形状天花板。
- 豁免边界 = **build-tag-based（非 filename）**，严格优于 depguard filename 豁免（后者 Soft escape + 误杀）——这是 AI-robustness 核心，也是选 archtest 的决定性理由。
- 无低成本升 Hard 路径（type-system 不可表达），不挂 Hard 化 issue。

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./tools/archtest/ -run CellTestNoAdapterImport` → 0 finding + fixture meta-test pass（RED→GREEN 两 commit）
- [x] `go test ./cells/accesscore/...` 全通过（nil-guard / happy-path 三分支语义不变）
- [x] `golangci-lint run ./tools/archtest/... ./cells/accesscore/...` → 0 issues

> **关于完整 archtest suite**：本地全量跑出 4 个 FAIL（`SCANNER-FRAMEWORK-USAGE-01/02`、`CELL-REPO-READYZ-PROBE-01` saga.PGJournal、`TEST-POLLING-EXTERNAL-REASON-LITERAL-01` runtime/saga、`SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE-01` refresh_tokens）——**均为 develop baseline 既有 nightly 违规（已在 clean develop 上复现确认），与本 PR 5 文件 diff 无关**（saga / governance-scanner / schema-guard 子系统，本 PR 未触碰）。对齐 HEAD commit #1112「清 nightly 非-saga 违规」语境。

Closes #803

Refs: CELL-TEST-NO-ADAPTER-IMPORT-01; docs/reviews/20260504-systems-layer-03-adapters.md §1.5/§3
ref: ThreeDotsLabs/watermill pubsub/gochannel; go-micro.dev/v4 registry/memory; OpenPeeDeeP/depguard v2 $test; roblaszczak/go-cleanarch

🤖 Generated with [Claude Code](https://claude.com/claude-code)