### PR TITLE
feat(credentialfence): sealed FenceToken closes upstream half of credential-invalidate funnel (#1033)

### DIFF
--- a/adapters/postgres/refresh_store.go
+++ b/adapters/postgres/refresh_store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/pgrepoapproved"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 )
 
@@ -606,7 +607,8 @@ func (s *PGRefreshStore) revokeSessionDetachedAt(ctx context.Context, sessionID 
 
 // RevokeUser marks every row owned by subjectID as revoked.
 // Uses the ambient transaction from ctx when present (F1).
-func (s *PGRefreshStore) RevokeUser(ctx context.Context, subjectID string) error {
+func (s *PGRefreshStore) RevokeUser(ctx context.Context, subjectID string, tok credentialfence.FenceToken) error {
+	credentialfence.MustHave(tok, "refresh.Store.RevokeUser")
 	now := s.clock.Now()
 	if _, err := s.db.Exec(ctx, revokeUserSQL, now, subjectID); err != nil {
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "refresh store: revoke user", err)

--- a/adapters/postgres/session_store.go
+++ b/adapters/postgres/session_store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	pgquery "github.com/ghbvf/gocell/pkg/pgquery"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -298,7 +299,10 @@ func (s *PGSessionStore) Close(_ context.Context) error { return nil }
 // Pre-revoked sessions preserve their original RevokedAt timestamp (append-only
 // revoke semantics — ADR-Session D3). The event argument is informational under
 // the current protocol; the UPDATE covers all active sessions regardless of event.
-func (s *PGSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
+func (s *PGSessionStore) RevokeForSubject(
+	ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken,
+) error {
+	credentialfence.MustHave(tok, "session.Store.RevokeForSubject")
 	if subjectID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"session: RevokeForSubject requires non-empty subjectID")

--- a/adapters/postgres/session_store_integration_test.go
+++ b/adapters/postgres/session_store_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 	"github.com/ghbvf/gocell/runtime/auth/session/storetest"
 )
@@ -102,13 +103,13 @@ func (w *pgSessionStoreWrapper) Revoke(ctx context.Context, id string) error {
 	return w.inner.Revoke(ctx, id)
 }
 
-func (w *pgSessionStoreWrapper) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
+func (w *pgSessionStoreWrapper) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
 	if subjectID == "" {
 		// Let the inner store return ErrValidationFailed.
-		return w.inner.RevokeForSubject(ctx, subjectID, event)
+		return w.inner.RevokeForSubject(ctx, subjectID, event, tok)
 	}
 	uid := subjectUUID(subjectID)
-	return w.inner.RevokeForSubject(ctx, uid.String(), event)
+	return w.inner.RevokeForSubject(ctx, uid.String(), event, tok)
 }
 
 // RepoReady delegates to the inner PGSessionStore. The wrapper does not add

--- a/adapters/postgres/session_store_uuid_test.go
+++ b/adapters/postgres/session_store_uuid_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	pgquery "github.com/ghbvf/gocell/pkg/pgquery"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 	"github.com/ghbvf/gocell/runtime/auth/session/storetest"
 )
@@ -64,7 +65,7 @@ func TestPGSessionStore_RevokeForSubjectNonUUIDRejected(t *testing.T) {
 	store, err := NewSessionStore(fakePool, txm, proto, fc)
 	require.NoError(t, err)
 
-	revokeErr := store.RevokeForSubject(context.Background(), "not-a-uuid", session.CredentialEventPasswordReset)
+	revokeErr := store.RevokeForSubject(context.Background(), "not-a-uuid", session.CredentialEventPasswordReset, credentialfence.Mint())
 	require.Error(t, revokeErr, "non-UUID subjectID must be rejected before DB execution")
 
 	var coded *errcode.Error

--- a/adapters/redis/session_cache_store.go
+++ b/adapters/redis/session_cache_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -312,8 +313,10 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 // Hard-locked by archtest CACHING-SESSION-REVOKE-DELEGATE-ONLY-01: this
 // method body MUST be exactly one ReturnStmt delegating to inner with the
 // same name.
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(
+	ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken,
+) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }
 
 // RepoReady delegates to inner. Redis liveness is reported independently by

--- a/adapters/redis/session_cache_store_test.go
+++ b/adapters/redis/session_cache_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -44,6 +45,7 @@ type lastRevokeArgs struct {
 type lastRevokeSubjArgs struct {
 	subjectID string
 	event     session.CredentialEvent
+	tok       credentialfence.FenceToken
 }
 
 // fakeSessionStore is an inner session.Store used by CachingSessionStore unit
@@ -98,9 +100,11 @@ func (f *fakeSessionStore) Revoke(_ context.Context, id string) error {
 	return f.revokeErr
 }
 
-func (f *fakeSessionStore) RevokeForSubject(_ context.Context, subjectID string, event session.CredentialEvent) error {
+func (f *fakeSessionStore) RevokeForSubject(
+	_ context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken,
+) error {
 	f.revokeSubjCalls.Add(1)
-	f.lastRevokeSubj.Store(&lastRevokeSubjArgs{subjectID: subjectID, event: event})
+	f.lastRevokeSubj.Store(&lastRevokeSubjArgs{subjectID: subjectID, event: event, tok: tok})
 	return f.revokeSubjErr
 }
 
@@ -351,12 +355,14 @@ func TestCachingSessionStore_RevokeForSubject_DoesNotTouchCache(t *testing.T) {
 	inner := &fakeSessionStore{}
 	store := newTestCachingStore(t, inner, mock)
 
-	err = store.RevokeForSubject(context.Background(), scsTestSubj, session.CredentialEventPasswordReset)
+	mintedTok := credentialfence.Mint()
+	err = store.RevokeForSubject(context.Background(), scsTestSubj, session.CredentialEventPasswordReset, mintedTok)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), inner.revokeSubjCalls.Load())
 	if args := inner.lastRevokeSubj.Load(); assert.NotNil(t, args, "lastRevokeSubj must be set") {
 		assert.Equal(t, scsTestSubj, args.subjectID, "RevokeForSubject must delegate exact subjectID")
 		assert.Equal(t, session.CredentialEventPasswordReset, args.event, "RevokeForSubject must delegate exact event")
+		assert.Equal(t, mintedTok, args.tok, "RevokeForSubject must delegate exact FenceToken")
 	}
 
 	// Cache entry must still be present — wrapper must not have invalidated.

--- a/cells/accesscore/internal/accountlockout/service_test.go
+++ b/cells/accesscore/internal/accountlockout/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -202,7 +203,7 @@ func (r *fakeUserRepo) UpdatePassword(_ context.Context, _ string, _ string, _ b
 	return 0, errors.New("not used in accountlockout tests")
 }
 
-func (r *fakeUserRepo) BumpAuthzEpoch(_ context.Context, id string) (int64, error) {
+func (r *fakeUserRepo) BumpAuthzEpoch(_ context.Context, id string, _ credentialfence.FenceToken) (int64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	u, ok := r.byID[id]
@@ -270,7 +271,7 @@ func (s *stubSessionStore) Get(_ context.Context, _ string) (*session.ValidateVi
 	return nil, errors.New("stubSessionStore: Get unused")
 }
 func (s *stubSessionStore) Revoke(_ context.Context, _ string) error { return nil }
-func (s *stubSessionStore) RevokeForSubject(_ context.Context, _ string, ev session.CredentialEvent) error {
+func (s *stubSessionStore) RevokeForSubject(_ context.Context, _ string, ev session.CredentialEvent, _ credentialfence.FenceToken) error {
 	s.revokeForSubjectCalls++
 	s.revokedEvents = append(s.revokedEvents, ev)
 	return nil
@@ -298,7 +299,7 @@ func (s *stubRefreshStore) Rotate(_ context.Context, _ string) (string, *refresh
 }
 func (s *stubRefreshStore) RevokeSession(_ context.Context, _ string) error         { return nil }
 func (s *stubRefreshStore) RevokeSessionDetached(_ context.Context, _ string) error { return nil }
-func (s *stubRefreshStore) RevokeUser(_ context.Context, _ string) error {
+func (s *stubRefreshStore) RevokeUser(_ context.Context, _ string, _ credentialfence.FenceToken) error {
 	s.revokeUserCalls++
 	return nil
 }

--- a/cells/accesscore/internal/adapters/postgres/pg_executor_test.go
+++ b/cells/accesscore/internal/adapters/postgres/pg_executor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // TestAssertAmbientTx_NoTx verifies that assertAmbientTx returns an
@@ -76,7 +77,7 @@ func TestGetByUsernameForUpdate_NoAmbientTx(t *testing.T) {
 func TestBumpAuthzEpoch_NoAmbientTx(t *testing.T) {
 	repo := &PGUserRepo{db: pgExecutor{pool: nil}}
 
-	_, err := repo.BumpAuthzEpoch(context.Background(), "usr-test-001")
+	_, err := repo.BumpAuthzEpoch(context.Background(), "usr-test-001", credentialfence.Mint())
 	require.Error(t, err, "BumpAuthzEpoch must error without ambient tx")
 
 	var ec *errcode.Error

--- a/cells/accesscore/internal/adapters/postgres/user_repo.go
+++ b/cells/accesscore/internal/adapters/postgres/user_repo.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	pgquery "github.com/ghbvf/gocell/pkg/pgquery"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/state/cas"
 )
 
@@ -484,7 +485,8 @@ func (r *PGUserRepo) Delete(ctx context.Context, id string) error {
 // fail-fast enforced: calling without an ambient transaction returns an error
 // (errcode.ErrInternal); without a transaction the row update is auto-committed
 // before the caller's surrounding atomic sequence completes.
-func (r *PGUserRepo) BumpAuthzEpoch(ctx context.Context, userID string) (int64, error) {
+func (r *PGUserRepo) BumpAuthzEpoch(ctx context.Context, userID string, tok credentialfence.FenceToken) (int64, error) {
+	credentialfence.MustHave(tok, "ports.UserRepository.BumpAuthzEpoch")
 	if err := assertAmbientTx(ctx); err != nil {
 		return 0, err
 	}

--- a/cells/accesscore/internal/adapters/postgres/user_repo_integration_test.go
+++ b/cells/accesscore/internal/adapters/postgres/user_repo_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // sqlStateCheckViolation is SQLSTATE 23514 (check constraint violation).
@@ -260,7 +261,7 @@ func TestPGUserRepo_Integration(t *testing.T) {
 
 	t.Run("BumpAuthzEpoch_missing_returns_ErrAuthUserNotFound", func(t *testing.T) {
 		err := txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-			_, e := repo.BumpAuthzEpoch(txCtx, uuid.NewString())
+			_, e := repo.BumpAuthzEpoch(txCtx, uuid.NewString(), credentialfence.Mint())
 			return e
 		})
 		require.Error(t, err)
@@ -368,7 +369,7 @@ func TestPGUserRepo_BumpAuthzEpoch_ReadbackVisible(t *testing.T) {
 	// funnel entry point guarantees this in production).
 	var bumped int64
 	require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-		v, err := repo.BumpAuthzEpoch(txCtx, u.ID)
+		v, err := repo.BumpAuthzEpoch(txCtx, u.ID, credentialfence.Mint())
 		if err != nil {
 			return err
 		}
@@ -393,7 +394,7 @@ func TestPGUserRepo_BumpAuthzEpoch_ReadbackVisible(t *testing.T) {
 
 	// Second bump confirms monotonicity through the read path.
 	require.NoError(t, txMgr.RunInTx(ctx, func(txCtx context.Context) error {
-		v, err := repo.BumpAuthzEpoch(txCtx, u.ID)
+		v, err := repo.BumpAuthzEpoch(txCtx, u.ID, credentialfence.Mint())
 		if err != nil {
 			return err
 		}

--- a/cells/accesscore/internal/adminprovision/provisioner_test.go
+++ b/cells/accesscore/internal/adminprovision/provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // errStubUnused surfaces accidental calls to fake-repo stub methods that the
@@ -410,7 +411,7 @@ func (r *duplicateUserRepo) UpdatePassword(_ context.Context, _ string, _ string
 	return 0, nil
 }
 
-func (r *duplicateUserRepo) BumpAuthzEpoch(_ context.Context, _ string) (int64, error) {
+func (r *duplicateUserRepo) BumpAuthzEpoch(_ context.Context, _ string, _ credentialfence.FenceToken) (int64, error) {
 	return 0, nil
 }
 
@@ -600,7 +601,7 @@ func (r *errUserRepo) UpdatePassword(_ context.Context, _ string, _ string, _ bo
 	return 0, nil
 }
 
-func (r *errUserRepo) BumpAuthzEpoch(_ context.Context, _ string) (int64, error) {
+func (r *errUserRepo) BumpAuthzEpoch(_ context.Context, _ string, _ credentialfence.FenceToken) (int64, error) {
 	return 0, nil
 }
 

--- a/cells/accesscore/internal/credentialinvalidate/invalidator.go
+++ b/cells/accesscore/internal/credentialinvalidate/invalidator.go
@@ -8,7 +8,8 @@
 //   - CREDENTIAL-INVALIDATE-FUNNEL-01:    session.Store.RevokeForSubject callers ⊆ {this pkg, store impl, storetest, *_test.go}
 //   - USER-AUTHZ-EPOCH-BUMP-FUNNEL-01:    UserRepository.BumpAuthzEpoch callers ⊆ {this pkg, repo impl, conformance, *_test.go}
 //   - REFRESH-REVOKE-USER-FUNNEL-01:      refresh.Store.RevokeUser callers ⊆ {this pkg, store impl, *_test.go}
-//   - CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: Invalidator.Apply callers ⊆ {this pkg, authzmutate, identitymanage, sessionrefresh, rbacassign, *_test.go}
+//   - CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: Invalidator.Apply callers ⊆
+//     {this pkg, authzmutate, identitymanage, sessionrefresh, rbacassign, *_test.go}
 //   - FENCE-TOKEN-MINT-FUNNEL-01:         credentialfence.Mint callers ⊆ {this pkg, storetest/conformance, *_test.go}
 //
 // The three mutation methods take a credentialfence.FenceToken capability
@@ -30,6 +31,7 @@ package credentialinvalidate
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -77,6 +79,9 @@ func New(users ports.UserRepository, sessions session.Store, refreshStore refres
 // Order is defined only for short-circuit predictability; correctness does not
 // depend on the order.
 func (i *Invalidator) Apply(txCtx context.Context, subjectID string, event session.CredentialEvent) error {
+	slog.DebugContext(txCtx, "credentialinvalidate: apply",
+		slog.String("subject_id", subjectID),
+		slog.String("event", event.String()))
 	// Mint the FenceToken once and pass the same value through all three
 	// mutations. The token is identity-less (any non-nil FenceToken is
 	// equally valid), so sharing it across the three calls is

--- a/cells/accesscore/internal/credentialinvalidate/invalidator.go
+++ b/cells/accesscore/internal/credentialinvalidate/invalidator.go
@@ -2,19 +2,25 @@
 // revocation events: it bumps the user's authz_epoch, revokes all active
 // sessions, and revokes all refresh chains in one ambient transaction.
 //
-// AI-robust archtest (Hard, see tools/archtest/credential_invalidate_funnel_test.go):
-//   - CREDENTIAL-INVALIDATE-FUNNEL-01:  session.Store.RevokeForSubject callers ⊆ {this pkg, store impl, storetest, *_test.go}
-//   - USER-AUTHZ-EPOCH-BUMP-FUNNEL-01:  UserRepository.BumpAuthzEpoch callers ⊆ {this pkg, repo impl, *_test.go}
-//   - REFRESH-REVOKE-USER-FUNNEL-01:    refresh.Store.RevokeUser callers ⊆ {this pkg, store impl, *_test.go}
-//   - FENCE-TOKEN-MINT-FUNNEL-01:       credentialfence.Mint callers ⊆ {this pkg, storetest/conformance, *_test.go}
+// AI-robust archtest (all Hard post #1033, see
+// tools/archtest/credential_invalidate_funnel_invariants_test.go +
+// tools/archtest/fence_token_mint_funnel_test.go):
+//   - CREDENTIAL-INVALIDATE-FUNNEL-01:    session.Store.RevokeForSubject callers ⊆ {this pkg, store impl, storetest, *_test.go}
+//   - USER-AUTHZ-EPOCH-BUMP-FUNNEL-01:    UserRepository.BumpAuthzEpoch callers ⊆ {this pkg, repo impl, conformance, *_test.go}
+//   - REFRESH-REVOKE-USER-FUNNEL-01:      refresh.Store.RevokeUser callers ⊆ {this pkg, store impl, *_test.go}
+//   - CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: Invalidator.Apply callers ⊆ {this pkg, authzmutate, identitymanage, sessionrefresh, rbacassign, *_test.go}
+//   - FENCE-TOKEN-MINT-FUNNEL-01:         credentialfence.Mint callers ⊆ {this pkg, storetest/conformance, *_test.go}
 //
 // The three mutation methods take a credentialfence.FenceToken capability
 // proof (#1033). Apply mints a FenceToken via credentialfence.Mint and
-// passes it to each downstream call — combined with the type-system seal on
-// FenceToken (external packages cannot implement the interface or construct
-// the unexported impl), this closes the upstream half of the funnel: only
-// code reachable from this package can produce the token argument the
-// mutation methods require.
+// passes the same value to each of the three calls. Combined with the
+// type-system seal on FenceToken (external packages cannot implement the
+// interface or construct the unexported impl) plus the runtime nil-guard
+// (credentialfence.MustHave at the top of every mutation impl), the
+// upstream half of the funnel is now Hard: external packages cannot
+// produce a FenceToken value, so the mutation methods cannot be invoked
+// from outside the funnel even at compile time. See ADR §A16 for the
+// closure proof and threat-matrix re-evaluation.
 //
 // Apply must be called inside an ambient transaction (txCtx derived from
 // persistence.CellTxManager.RunInTx). All three operations commit atomically;

--- a/cells/accesscore/internal/credentialinvalidate/invalidator.go
+++ b/cells/accesscore/internal/credentialinvalidate/invalidator.go
@@ -6,6 +6,15 @@
 //   - CREDENTIAL-INVALIDATE-FUNNEL-01:  session.Store.RevokeForSubject callers ⊆ {this pkg, store impl, storetest, *_test.go}
 //   - USER-AUTHZ-EPOCH-BUMP-FUNNEL-01:  UserRepository.BumpAuthzEpoch callers ⊆ {this pkg, repo impl, *_test.go}
 //   - REFRESH-REVOKE-USER-FUNNEL-01:    refresh.Store.RevokeUser callers ⊆ {this pkg, store impl, *_test.go}
+//   - FENCE-TOKEN-MINT-FUNNEL-01:       credentialfence.Mint callers ⊆ {this pkg, storetest/conformance, *_test.go}
+//
+// The three mutation methods take a credentialfence.FenceToken capability
+// proof (#1033). Apply mints a FenceToken via credentialfence.Mint and
+// passes it to each downstream call — combined with the type-system seal on
+// FenceToken (external packages cannot implement the interface or construct
+// the unexported impl), this closes the upstream half of the funnel: only
+// code reachable from this package can produce the token argument the
+// mutation methods require.
 //
 // Apply must be called inside an ambient transaction (txCtx derived from
 // persistence.CellTxManager.RunInTx). All three operations commit atomically;
@@ -19,6 +28,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -61,16 +71,22 @@ func New(users ports.UserRepository, sessions session.Store, refreshStore refres
 // Order is defined only for short-circuit predictability; correctness does not
 // depend on the order.
 func (i *Invalidator) Apply(txCtx context.Context, subjectID string, event session.CredentialEvent) error {
+	// Mint the FenceToken once and pass the same value through all three
+	// mutations. The token is identity-less (any non-nil FenceToken is
+	// equally valid), so sharing it across the three calls is
+	// semantically equivalent to minting per call — and saves two
+	// allocations on the hot path.
+	tok := credentialfence.Mint()
 	// New epoch value is intentionally discarded: sessionvalidate re-reads
 	// authz_epoch from the DB on every request, so the caller does not need
 	// the bumped value here. The DB row is the single source of truth.
-	if _, err := i.users.BumpAuthzEpoch(txCtx, subjectID); err != nil {
+	if _, err := i.users.BumpAuthzEpoch(txCtx, subjectID, tok); err != nil {
 		return fmt.Errorf("credentialinvalidate: bump authz_epoch: %w", err)
 	}
-	if err := i.sessions.RevokeForSubject(txCtx, subjectID, event); err != nil {
+	if err := i.sessions.RevokeForSubject(txCtx, subjectID, event, tok); err != nil {
 		return fmt.Errorf("credentialinvalidate: revoke sessions: %w", err)
 	}
-	if err := i.refresh.RevokeUser(txCtx, subjectID); err != nil {
+	if err := i.refresh.RevokeUser(txCtx, subjectID, tok); err != nil {
 		return fmt.Errorf("credentialinvalidate: revoke refresh chain: %w", err)
 	}
 	return nil

--- a/cells/accesscore/internal/credentialinvalidate/invalidator_test.go
+++ b/cells/accesscore/internal/credentialinvalidate/invalidator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -28,7 +29,7 @@ type stubUserRepo struct {
 	bumpCallsFor []string // captures userID args
 }
 
-func (s *stubUserRepo) BumpAuthzEpoch(_ context.Context, userID string) (int64, error) {
+func (s *stubUserRepo) BumpAuthzEpoch(_ context.Context, userID string, _ credentialfence.FenceToken) (int64, error) {
 	s.bumpCallsFor = append(s.bumpCallsFor, userID)
 	return s.bumpEpoch, s.bumpErr
 }
@@ -98,7 +99,9 @@ func (s *stubSessionStore) Revoke(_ context.Context, _ string) error {
 	panic("stubSessionStore.Revoke: unexpected call")
 }
 
-func (s *stubSessionStore) RevokeForSubject(_ context.Context, subjectID string, _ session.CredentialEvent) error {
+func (s *stubSessionStore) RevokeForSubject(
+	_ context.Context, subjectID string, _ session.CredentialEvent, _ credentialfence.FenceToken,
+) error {
 	s.revokeCallsFor = append(s.revokeCallsFor, subjectID)
 	return s.revokeErr
 }
@@ -134,7 +137,7 @@ func (s *stubRefreshStore) RevokeSessionDetached(_ context.Context, _ string) er
 	panic("stubRefreshStore.RevokeSessionDetached: unexpected call")
 }
 
-func (s *stubRefreshStore) RevokeUser(_ context.Context, subjectID string) error {
+func (s *stubRefreshStore) RevokeUser(_ context.Context, subjectID string, _ credentialfence.FenceToken) error {
 	s.revokeUserCallsFor = append(s.revokeUserCallsFor, subjectID)
 	return s.revokeUserErr
 }

--- a/cells/accesscore/internal/credentialinvalidate/testdata/identitymanage_direct_bump_epoch_red/usage.go
+++ b/cells/accesscore/internal/credentialinvalidate/testdata/identitymanage_direct_bump_epoch_red/usage.go
@@ -20,10 +20,11 @@ import (
 	"context"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/ports"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // badBump directly calls BumpAuthzEpoch on a ports.UserRepository — bypassing
 // the credentialinvalidate funnel. This is the pattern the archtest bans.
-func badBump(ctx context.Context, repo ports.UserRepository, userID string) (int64, error) {
-	return repo.BumpAuthzEpoch(ctx, userID)
+func badBump(ctx context.Context, repo ports.UserRepository, userID string, tok credentialfence.FenceToken) (int64, error) {
+	return repo.BumpAuthzEpoch(ctx, userID, tok)
 }

--- a/cells/accesscore/internal/mem/store_escape_test.go
+++ b/cells/accesscore/internal/mem/store_escape_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // TestLeaseInvalidatedAfterTxReturn is the escape regression for the
@@ -71,7 +72,7 @@ func TestLeaseInvalidatedAfterTxReturn(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, e := repo.BumpAuthzEpoch(escaped, seed.ID)
+			_, e := repo.BumpAuthzEpoch(escaped, seed.ID, credentialfence.Mint())
 			errs <- e
 		}()
 	}

--- a/cells/accesscore/internal/mem/user_repo.go
+++ b/cells/accesscore/internal/mem/user_repo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/state/cas"
 )
 
@@ -461,7 +462,8 @@ func (r *UserRepository) UpdatePassword(
 // RunInTx closure; see UserRepository lock contract.
 //
 // Returns ErrAuthUserNotFound when no user matches userID.
-func (r *UserRepository) BumpAuthzEpoch(ctx context.Context, userID string) (int64, error) {
+func (r *UserRepository) BumpAuthzEpoch(ctx context.Context, userID string, tok credentialfence.FenceToken) (int64, error) {
+	credentialfence.MustHave(tok, "ports.UserRepository.BumpAuthzEpoch")
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
 		defer r.store.mu.Unlock()

--- a/cells/accesscore/internal/mem/user_repo_test.go
+++ b/cells/accesscore/internal/mem/user_repo_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 func TestUserRepo_PreservesPasswordResetRequired(t *testing.T) {
@@ -140,12 +141,12 @@ func TestUserRepo_BumpAuthzEpoch_IncrementsAndReturns(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, user))
 
 	// First bump: 1 → 2 (initial epoch is 1 per S4d design).
-	epoch1, err := repo.BumpAuthzEpoch(ctx, "usr-epoch-001")
+	epoch1, err := repo.BumpAuthzEpoch(ctx, "usr-epoch-001", credentialfence.Mint())
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), epoch1, "first BumpAuthzEpoch must return 2 (initial=1)")
 
 	// Second bump: 2 → 3.
-	epoch2, err := repo.BumpAuthzEpoch(ctx, "usr-epoch-001")
+	epoch2, err := repo.BumpAuthzEpoch(ctx, "usr-epoch-001", credentialfence.Mint())
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), epoch2, "second BumpAuthzEpoch must return 3")
 
@@ -159,11 +160,40 @@ func TestUserRepo_BumpAuthzEpoch_NotFound(t *testing.T) {
 	ctx := context.Background()
 	repo := NewStore(clock.Real()).UserRepository()
 
-	_, err := repo.BumpAuthzEpoch(ctx, "usr-nonexistent")
+	_, err := repo.BumpAuthzEpoch(ctx, "usr-nonexistent", credentialfence.Mint())
 	errcodetest.AssertCode(t, err, errcode.ErrAuthUserNotFound)
 	var ce *errcode.Error
 	require.True(t, errors.As(err, &ce))
 	assert.Equal(t, errcode.KindNotFound, ce.Kind)
+}
+
+// TestUserRepo_BumpAuthzEpoch_NilToken verifies that passing a nil FenceToken to
+// BumpAuthzEpoch panics via MustHave (B-class programmer error) and that the
+// panic payload is an *errcode.Error wrapping errcode.Assertion.
+func TestUserRepo_BumpAuthzEpoch_NilToken(t *testing.T) {
+	ctx := context.Background()
+	repo := NewStore(clock.Real()).UserRepository()
+
+	user, err := domain.NewUser("niltoken_user", "niltoken@example.com", "$2a$12$hash", time.Now())
+	require.NoError(t, err)
+	user.ID = "usr-niltoken-001"
+	require.NoError(t, repo.Create(ctx, user))
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_, _ = repo.BumpAuthzEpoch(ctx, "usr-niltoken-001", nil)
+	}()
+
+	if recovered == nil {
+		t.Fatal("BumpAuthzEpoch with nil FenceToken must panic, but did not")
+	}
+	var ce *errcode.Error
+	if !errors.As(recovered.(error), &ce) {
+		t.Fatalf("panic payload must be an *errcode.Error, got %T: %v", recovered, recovered)
+	}
+	assert.Equal(t, errcode.KindInternal, ce.Kind,
+		"nil-token panic must carry KindInternal (errcode.Assertion)")
 }
 
 func TestUserRepo_BumpAuthzEpoch_Concurrent(t *testing.T) {
@@ -181,7 +211,7 @@ func TestUserRepo_BumpAuthzEpoch_Concurrent(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			_, _ = repo.BumpAuthzEpoch(ctx, "usr-concurrent-001")
+			_, _ = repo.BumpAuthzEpoch(ctx, "usr-concurrent-001", credentialfence.Mint())
 		}()
 	}
 	wg.Wait()
@@ -344,7 +374,7 @@ func TestRunInTx_BumpAuthzEpoch_InsideTx(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		newEpoch, err = repo.BumpAuthzEpoch(txCtx, "usr-epoch-intx-001")
+		newEpoch, err = repo.BumpAuthzEpoch(txCtx, "usr-epoch-intx-001", credentialfence.Mint())
 		return err
 	})
 	require.NoError(t, txErr)
@@ -385,8 +415,8 @@ func TestRunInTx_Serialization_ConcurrentBumpEpochBlocked(t *testing.T) {
 	// tx-1: hold the lock, bump epoch to 2, then signal.
 	go func() {
 		_ = store.TxRunner().RunInTx(context.Background(), func(txCtx context.Context) error {
-			_, _ = repo.BumpAuthzEpoch(txCtx, "usr-serial-001") // epoch: 1 → 2
-			close(locked)                                       // signal: lock held, proceed
+			_, _ = repo.BumpAuthzEpoch(txCtx, "usr-serial-001", credentialfence.Mint()) // epoch: 1 → 2
+			close(locked)                                                               // signal: lock held, proceed
 			// Hold the lock for a short duration to let tx-2 start blocking.
 			time.Sleep(testtime.D20ms) //archtest:allow:test-sleep hold lock so tx-2 blocks (serialization proof)
 			return nil
@@ -398,7 +428,7 @@ func TestRunInTx_Serialization_ConcurrentBumpEpochBlocked(t *testing.T) {
 	<-locked
 
 	// tx-2 (outside RunInTx) calls BumpAuthzEpoch — must block until tx-1 releases.
-	epoch2, err := repo.BumpAuthzEpoch(context.Background(), "usr-serial-001")
+	epoch2, err := repo.BumpAuthzEpoch(context.Background(), "usr-serial-001", credentialfence.Mint())
 	<-done // tx-1 must have finished before us or concurrently with us
 
 	require.NoError(t, err)
@@ -428,7 +458,7 @@ func TestRunInTx_NoDeadlock_GetByUsernameForUpdateAndBump(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			_, err = repo.BumpAuthzEpoch(txCtx, "usr-nodeadlock-001")
+			_, err = repo.BumpAuthzEpoch(txCtx, "usr-nodeadlock-001", credentialfence.Mint())
 			return err
 		})
 		done <- err

--- a/cells/accesscore/internal/mem/user_repo_test.go
+++ b/cells/accesscore/internal/mem/user_repo_test.go
@@ -167,35 +167,6 @@ func TestUserRepo_BumpAuthzEpoch_NotFound(t *testing.T) {
 	assert.Equal(t, errcode.KindNotFound, ce.Kind)
 }
 
-// TestUserRepo_BumpAuthzEpoch_NilToken verifies that passing a nil FenceToken to
-// BumpAuthzEpoch panics via MustHave (B-class programmer error) and that the
-// panic payload is an *errcode.Error wrapping errcode.Assertion.
-func TestUserRepo_BumpAuthzEpoch_NilToken(t *testing.T) {
-	ctx := context.Background()
-	repo := NewStore(clock.Real()).UserRepository()
-
-	user, err := domain.NewUser("niltoken_user", "niltoken@example.com", "$2a$12$hash", time.Now())
-	require.NoError(t, err)
-	user.ID = "usr-niltoken-001"
-	require.NoError(t, repo.Create(ctx, user))
-
-	var recovered any
-	func() {
-		defer func() { recovered = recover() }()
-		_, _ = repo.BumpAuthzEpoch(ctx, "usr-niltoken-001", nil)
-	}()
-
-	if recovered == nil {
-		t.Fatal("BumpAuthzEpoch with nil FenceToken must panic, but did not")
-	}
-	var ce *errcode.Error
-	if !errors.As(recovered.(error), &ce) {
-		t.Fatalf("panic payload must be an *errcode.Error, got %T: %v", recovered, recovered)
-	}
-	assert.Equal(t, errcode.KindInternal, ce.Kind,
-		"nil-token panic must carry KindInternal (errcode.Assertion)")
-}
-
 func TestUserRepo_BumpAuthzEpoch_Concurrent(t *testing.T) {
 	ctx := context.Background()
 	repo := NewStore(clock.Real()).UserRepository()

--- a/cells/accesscore/internal/ports/conformance/conformance.go
+++ b/cells/accesscore/internal/ports/conformance/conformance.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -120,6 +121,9 @@ func RunUserRepoConformance(t *testing.T, factory UserRepoFactory, features Feat
 	})
 	t.Run("BumpAuthzEpoch_MonotonicIncrement", func(t *testing.T) {
 		conformBumpAuthzEpochMonotonic(t, factory)
+	})
+	t.Run("BumpAuthzEpoch_NilFenceToken_Panics", func(t *testing.T) {
+		conformBumpAuthzEpochNilFenceToken(t, factory)
 	})
 	t.Run("GetByIDForUpdate_LockContention", func(t *testing.T) {
 		conformGetByIDForUpdateLockContention(t, factory)
@@ -452,6 +456,40 @@ func conformBumpAuthzEpochSucceeds(t *testing.T, factory UserRepoFactory) {
 	}
 	if newEpoch != initialEpoch+1 {
 		t.Errorf("BumpAuthzEpoch_Succeeds: want epoch %d, got %d", initialEpoch+1, newEpoch)
+	}
+}
+
+// conformBumpAuthzEpochNilFenceToken: a nil FenceToken is a programmer error
+// that credentialfence.MustHave converts to a B-class panic (*errcode.Error,
+// KindInternal) identifying the call site. Every UserRepository impl (mem / PG)
+// must honor the guard — the shared conformance suite holds them all to it
+// rather than relying on per-impl unit tests. MustHave is the first statement
+// of each impl, so the panic fires before any tx / backend I/O (no seed or
+// RunInTx needed).
+func conformBumpAuthzEpochNilFenceToken(t *testing.T, factory UserRepoFactory) {
+	t.Helper()
+	repo, _, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		// nil FenceToken is intentional — exercising the MustHave guard.
+		_, _ = repo.BumpAuthzEpoch(context.Background(), "usr-nil-token", nil)
+	}()
+
+	if recovered == nil {
+		t.Fatal("nil FenceToken must trigger MustHave panic, got nil")
+	}
+	coded, ok := recovered.(*errcode.Error)
+	if !ok {
+		t.Fatalf("panic payload must be *errcode.Error, got %T: %v", recovered, recovered)
+	}
+	if coded.Kind != errcode.KindInternal {
+		t.Errorf("nil-token panic must carry KindInternal (Assertion), got %v", coded.Kind)
+	}
+	if !strings.Contains(coded.Message, "ports.UserRepository.BumpAuthzEpoch") {
+		t.Errorf("panic message must identify call site, got %q", coded.Message)
 	}
 }
 

--- a/cells/accesscore/internal/ports/conformance/conformance.go
+++ b/cells/accesscore/internal/ports/conformance/conformance.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // concurrencyDeadlineBudget bounds the Concurrent_NoDeadlock sub-test so a
@@ -444,7 +445,7 @@ func conformBumpAuthzEpochSucceeds(t *testing.T, factory UserRepoFactory) {
 	var newEpoch int64
 	if err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
 		var err error
-		newEpoch, err = repo.BumpAuthzEpoch(ctx, u.ID)
+		newEpoch, err = repo.BumpAuthzEpoch(ctx, u.ID, credentialfence.Mint())
 		return err
 	}); err != nil {
 		t.Fatalf("BumpAuthzEpoch_Succeeds: %v", err)
@@ -469,7 +470,7 @@ func conformBumpAuthzEpochMonotonic(t *testing.T, factory UserRepoFactory) {
 	var epoch1 int64
 	if err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
 		var err error
-		epoch1, err = repo.BumpAuthzEpoch(ctx, u.ID)
+		epoch1, err = repo.BumpAuthzEpoch(ctx, u.ID, credentialfence.Mint())
 		return err
 	}); err != nil {
 		t.Fatalf("BumpAuthzEpoch_MonotonicIncrement: first bump: %v", err)
@@ -478,7 +479,7 @@ func conformBumpAuthzEpochMonotonic(t *testing.T, factory UserRepoFactory) {
 	var epoch2 int64
 	if err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
 		var err error
-		epoch2, err = repo.BumpAuthzEpoch(ctx, u.ID)
+		epoch2, err = repo.BumpAuthzEpoch(ctx, u.ID, credentialfence.Mint())
 		return err
 	}); err != nil {
 		t.Fatalf("BumpAuthzEpoch_MonotonicIncrement: second bump: %v", err)
@@ -554,7 +555,7 @@ func conformConcurrentNoDeadlock(t *testing.T, factory UserRepoFactory) {
 				_, err = repo.UpdatePassword(ctx, u.ID, "$2a$12$concurrent", false, 0)
 			case 2:
 				err = txRunner.RunInTx(ctx, func(txCtx context.Context) error {
-					_, e := repo.BumpAuthzEpoch(txCtx, u.ID)
+					_, e := repo.BumpAuthzEpoch(txCtx, u.ID, credentialfence.Mint())
 					return e
 				})
 			}

--- a/cells/accesscore/internal/ports/user_repo.go
+++ b/cells/accesscore/internal/ports/user_repo.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // UserRepository persists and retrieves User aggregates.
@@ -138,7 +139,13 @@ type UserRepository interface {
 	// the new value. It must be called inside an ambient transaction (the
 	// credential-invalidation funnel entry point guarantees this). Returns
 	// ErrAuthUserNotFound (KindNotFound) when no row matches userID.
-	BumpAuthzEpoch(ctx context.Context, userID string) (newEpoch int64, err error)
+	//
+	// tok is a capability proof that this call routes through
+	// credentialinvalidate.Invalidator via credentialfence.Mint; only
+	// credentialinvalidate may mint a non-nil token in production. Passing a
+	// nil token panics through the panicregister funnel (B-class programmer
+	// error) at the implementation boundary.
+	BumpAuthzEpoch(ctx context.Context, userID string, tok credentialfence.FenceToken) (newEpoch int64, err error)
 
 	// GetByIDForUpdate fetches a user by primary key inside an ambient
 	// transaction and acquires a row-level write lock (PG: SELECT ... FOR

--- a/cells/accesscore/slices/identitymanage/service_test.go
+++ b/cells/accesscore/slices/identitymanage/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -828,7 +829,9 @@ type revokeFailingSessionStore struct {
 	err error
 }
 
-func (r *revokeFailingSessionStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent) error {
+func (r *revokeFailingSessionStore) RevokeForSubject(
+	_ context.Context, _ string, _ session.CredentialEvent, _ credentialfence.FenceToken,
+) error {
 	return r.err
 }
 
@@ -1661,7 +1664,7 @@ type failingRefreshStore struct {
 	calls         int
 }
 
-func (s *failingRefreshStore) RevokeUser(_ context.Context, _ string) error {
+func (s *failingRefreshStore) RevokeUser(_ context.Context, _ string, _ credentialfence.FenceToken) error {
 	s.calls++
 	return s.revokeUserErr
 }

--- a/cells/accesscore/slices/rbacassign/outbox_test.go
+++ b/cells/accesscore/slices/rbacassign/outbox_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/cells/accesscore/internal/testutil"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -39,9 +40,11 @@ type trackingSessionStore struct {
 	revokeCalls int
 }
 
-func (r *trackingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
+func (r *trackingSessionStore) RevokeForSubject(
+	ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken,
+) error {
 	r.revokeCalls++
-	return r.Store.RevokeForSubject(ctx, subjectID, event)
+	return r.Store.RevokeForSubject(ctx, subjectID, event, tok)
 }
 
 // newDurableTestService creates a Service with emitter + txRunner injected.

--- a/cells/accesscore/slices/rbacassign/service_test.go
+++ b/cells/accesscore/slices/rbacassign/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -405,7 +406,7 @@ type failingSessionStore struct {
 	session.Store
 }
 
-func (failingSessionStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent) error {
+func (failingSessionStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent, _ credentialfence.FenceToken) error {
 	return errors.New("session store unavailable")
 }
 

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	refreshmem "github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
@@ -642,7 +643,7 @@ func (refreshUnavailableUserRepo) UpdatePassword(_ context.Context, _ string, _ 
 	return 0, nil
 }
 
-func (refreshUnavailableUserRepo) BumpAuthzEpoch(_ context.Context, _ string) (int64, error) {
+func (refreshUnavailableUserRepo) BumpAuthzEpoch(_ context.Context, _ string, _ credentialfence.FenceToken) (int64, error) {
 	return 0, nil
 }
 
@@ -1584,7 +1585,7 @@ func TestRefresh_AccessJWT_NoAuthzEpochClaim(t *testing.T) {
 	require.NoError(t, userRepo.Create(context.Background(), u))
 	// Bump epoch 4 times so it reaches 5 (initial=1).
 	for range 4 {
-		_, _ = userRepo.BumpAuthzEpoch(context.Background(), "usr-epoch-ref")
+		_, _ = userRepo.BumpAuthzEpoch(context.Background(), "usr-epoch-ref", credentialfence.Mint())
 	}
 	u, _ = userRepo.GetByID(context.Background(), "usr-epoch-ref")
 
@@ -1673,7 +1674,7 @@ func TestRefresh_StaleEpoch_CascadeRevokesSessionOnly(t *testing.T) {
 		require.NoError(t, err)
 		u.ID = "usr-stale-epoch"
 		require.NoError(t, userRepo.Create(context.Background(), u))
-		_, bumpErr := userRepo.BumpAuthzEpoch(context.Background(), "usr-stale-epoch")
+		_, bumpErr := userRepo.BumpAuthzEpoch(context.Background(), "usr-stale-epoch", credentialfence.Mint())
 		require.NoError(t, bumpErr)
 		// Reload so u.AuthzEpoch() == 2.
 		u, err = userRepo.GetByID(context.Background(), "usr-stale-epoch")
@@ -2230,7 +2231,7 @@ func TestCascadeFailClosed_StaleEpoch_401(t *testing.T) {
 	u.ID = "usr-cfr-stale"
 	require.NoError(t, userRepo.Create(context.Background(), u))
 	// Bump epoch so user is at epoch=2; the token is issued at epoch=1 (stale).
-	_, bumpErr := userRepo.BumpAuthzEpoch(context.Background(), u.ID)
+	_, bumpErr := userRepo.BumpAuthzEpoch(context.Background(), u.ID, credentialfence.Mint())
 	require.NoError(t, bumpErr)
 
 	innerStore := newTestRefreshStore()

--- a/cells/accesscore/slices/sessionvalidate/epoch_only_test.go
+++ b/cells/accesscore/slices/sessionvalidate/epoch_only_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -84,7 +85,7 @@ func TestEnforceSessionState_EpochMismatch_RejectsWithoutSessionRevoke(t *testin
 
 	// Bump epoch via the repo directly — funnel intentionally bypassed so the
 	// session row remains active and only the epoch predicate can reject.
-	newEpoch, err := userRepo.BumpAuthzEpoch(context.Background(), userID)
+	newEpoch, err := userRepo.BumpAuthzEpoch(context.Background(), userID, credentialfence.Mint())
 	require.NoError(t, err)
 	require.Equal(t, int64(2), newEpoch, "first bump must advance epoch from 1 to 2")
 

--- a/cells/accesscore/slices/sessionvalidate/service_test.go
+++ b/cells/accesscore/slices/sessionvalidate/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/keystest"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
@@ -253,7 +254,7 @@ func (errorSessionStore) Get(_ context.Context, _ string) (*session.ValidateView
 	return nil, fmt.Errorf("db connection timeout")
 }
 func (errorSessionStore) Revoke(_ context.Context, _ string) error { return nil }
-func (errorSessionStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent) error {
+func (errorSessionStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent, _ credentialfence.FenceToken) error {
 	return nil
 }
 func (errorSessionStore) RepoReady(_ context.Context) error { return nil }
@@ -331,7 +332,7 @@ func (r *stubUserRepo) UpdatePassword(_ context.Context, _ string, _ string, _ b
 	panic("not implemented")
 }
 
-func (r *stubUserRepo) BumpAuthzEpoch(_ context.Context, _ string) (int64, error) {
+func (r *stubUserRepo) BumpAuthzEpoch(_ context.Context, _ string, _ credentialfence.FenceToken) (int64, error) {
 	panic("not implemented")
 }
 
@@ -425,7 +426,7 @@ func (r capturingStore) Get(_ context.Context, _ string) (*session.ValidateView,
 	return nil, r.getErr
 }
 func (r capturingStore) Revoke(_ context.Context, _ string) error { return nil }
-func (r capturingStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent) error {
+func (r capturingStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent, _ credentialfence.FenceToken) error {
 	return nil
 }
 func (r capturingStore) RepoReady(_ context.Context) error { return nil }
@@ -472,7 +473,7 @@ func (r *capturingUserRepo) UpdatePassword(_ context.Context, _ string, _ string
 	return 0, nil
 }
 
-func (r *capturingUserRepo) BumpAuthzEpoch(_ context.Context, _ string) (int64, error) {
+func (r *capturingUserRepo) BumpAuthzEpoch(_ context.Context, _ string, _ credentialfence.FenceToken) (int64, error) {
 	return 0, nil
 }
 

--- a/cells/accesscore/slices/sessionvalidate/sessionvalidate_concurrent_epoch_race_test.go
+++ b/cells/accesscore/slices/sessionvalidate/sessionvalidate_concurrent_epoch_race_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/ghbvf/gocell/cells/accesscore/internal/mem"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -139,7 +140,7 @@ func TestSessionvalidate_ConcurrentEpochBumpAndValidate(t *testing.T) {
 
 	// Bump the epoch directly (test-only; funnel not needed here — see package
 	// godoc for rationale).
-	newEpoch, err := userRepo.BumpAuthzEpoch(context.Background(), userID)
+	newEpoch, err := userRepo.BumpAuthzEpoch(context.Background(), userID, credentialfence.Mint())
 	require.NoError(t, err, "BumpAuthzEpoch must succeed")
 	require.Equal(t, int64(2), newEpoch, "bump from epoch=1 must yield epoch=2")
 

--- a/cmd/corebundle/access_module_session_cache_test.go
+++ b/cmd/corebundle/access_module_session_cache_test.go
@@ -13,6 +13,7 @@ import (
 
 	adapterredis "github.com/ghbvf/gocell/adapters/redis"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 	"github.com/ghbvf/gocell/runtime/capability"
 )
@@ -26,7 +27,7 @@ func (stubSessionStore) Get(context.Context, string) (*session.ValidateView, err
 	return nil, errors.New("stub: never called")
 }
 func (stubSessionStore) Revoke(context.Context, string) error { return nil }
-func (stubSessionStore) RevokeForSubject(context.Context, string, session.CredentialEvent) error {
+func (stubSessionStore) RevokeForSubject(_ context.Context, _ string, _ session.CredentialEvent, _ credentialfence.FenceToken) error {
 	return nil
 }
 func (stubSessionStore) RepoReady(context.Context) error { return nil }

--- a/docs/architecture/202605101400-adr-credential-session-protocol.md
+++ b/docs/architecture/202605101400-adr-credential-session-protocol.md
@@ -10,7 +10,7 @@
 
 ---
 
-## 0. Amendments（S4b 落地后修订；2026-05-14 — S4d 重写；2026-05-15；S4e mutation funnel landed PR #494；2026-05-15；PR #501 RC-A/B/C/D/E 闭环（RoleRevoked 死代码 + §A10 Medium 天花板锁定 + schema_guard CHECK 注册 + login error path 归一化 + Reconstitute params + storetest const）；2026-05-16；Wave 5 P1-1 authzmutator.ApplyInTx 单入口 Hard funnel；2026-05-17；2026-05-17 — §A11 重写：session-revoke 出 funnel + 上游 4 勿一 Hard 化 + 新增 §A13 wire-uniformity 防枚举载体（PR #542 P1-A/P1-B/P2-A/P2-B/P2-C 闭环）；2026-05-17 Wave 4 — value-capture detector 升级到 typed-parent-check（form uniqueness）+ scope 扩到 cells/+cmd/+runtime/ + TYPESUTIL-IMPLEMENTS-FUNNEL-01 合规 + Sonar TestAssert 复杂度 20→1 + checkOK godoc）；2026-05-25 — §A15 refresh user-not-active 收口 401（回退 post-§A13 漂入的 403）+ cascade fail-closed void 签名升 Hard（issue #940）
+## 0. Amendments（S4b 落地后修订；2026-05-14 — S4d 重写；2026-05-15；S4e mutation funnel landed PR #494；2026-05-15；PR #501 RC-A/B/C/D/E 闭环（RoleRevoked 死代码 + §A10 Medium 天花板锁定 + schema_guard CHECK 注册 + login error path 归一化 + Reconstitute params + storetest const）；2026-05-16；Wave 5 P1-1 authzmutator.ApplyInTx 单入口 Hard funnel；2026-05-17；2026-05-17 — §A11 重写：session-revoke 出 funnel + 上游 4 勿一 Hard 化 + 新增 §A13 wire-uniformity 防枚举载体（PR #542 P1-A/P1-B/P2-A/P2-B/P2-C 闭环）；2026-05-17 Wave 4 — value-capture detector 升级到 typed-parent-check（form uniqueness）+ scope 扩到 cells/+cmd/+runtime/ + TYPESUTIL-IMPLEMENTS-FUNNEL-01 合规 + Sonar TestAssert 复杂度 20→1 + checkOK godoc）；2026-05-25 — §A15 refresh user-not-active 收口 401（回退 post-§A13 漂入的 403）+ cascade fail-closed void 签名升 Hard（issue #940）；2026-05-26 — §A16 credential-invalidate sealed FenceToken 关闭 UPSTREAM-CALLER-01 上游半边，三 mutation 方法签名要求 `credentialfence.FenceToken`，funnel 上游 Medium → Hard（issue #1033，同时关闭 042 §3a row 3 + §4 ROI row 2 + 043 §1 row 4）
 
 S4b PR 落地后实际实现与 §2/§3 描述出现漂移。**S4d (PR S4d) 之后实际行为以本节 +
 §A8 / §D1 / §D2 / §D4.2 同 PR 重写后的描述为准。** 与 amendment 矛盾的原文段落
@@ -607,6 +607,78 @@ single-envelope 在这一具体漂移上从 service_test Medium 升为 **Hard**�
 `CHECK (password_version >= 0)` 作 defense-in-depth（NewUser 从 0、
 BumpPasswordVersion 只自增）。
 
+### A16 credential-invalidate sealed FenceToken — 上游 funnel 闭环（2026-05-26, issue #1033）
+
+**背景漂移**：§A10 "后续治理" 把 `CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01`
+明确标为 "Medium-by-necessity（co-tx atomicity 天花板证明）"。042 §3a 审计
+（`docs/reviews/202605181109-042-archtest-six-agent-audit.md` 第 83-85 行）+
+§4 ROI 表第 2 行将此识别为吊销安全模型的**唯一结构开口**——下游 Hard，但
+任何包都能直接构造 receiver 调用 `session.Store.RevokeForSubject` /
+`refresh.Store.RevokeUser` / `ports.UserRepository.BumpAuthzEpoch`，Go 类型
+系统层不阻挡，仅 CI archtest 兜底。
+
+**决策**：在新包 `runtime/auth/credentialfence/` 引入 sealed `FenceToken`
+能力证明：
+- `FenceToken` interface 带未导出标记方法 `isCredentialFenceToken()`，使外部包
+  无法实现（Go 可见性规则）。
+- `fenceToken` 具体 impl 未导出，外部包无法用 composite literal 构造。
+- `Mint() FenceToken` 是唯一构造入口；其调用方由新 archtest
+  `FENCE-TOKEN-MINT-FUNNEL-01` 锁到 `{credentialinvalidate funnel,
+  storetest, conformance, *_test.go}`（ResolvePackageRef call-site
+  form-uniqueness）。
+- 三 mutation 方法签名末位追加 `tok credentialfence.FenceToken`，并在 impl
+  首行 `credentialfence.MustHave(tok, "<site>")` 兜 nil 漏洞（panicregister.Approved
+  + errcode.Assertion，B-class panic → 500）。
+
+**funnel 闭环证明**：
+1. 类型系统层：外部包既无法实现 FenceToken（未导出标记方法），也无法构造
+   非 nil 值（未导出 impl + Mint 调用方 archtest 锁定）。
+2. 调用形态唯一性：`FENCE-TOKEN-MINT-FUNNEL-01` A1 锁 Mint 调用点 *types.Func
+   身份；A2/A3 反向自检 function-value 捕获 + reflect 调用盲区。
+3. nil 兜底：每个 mutation impl 首行运行时检查，archtest 盲区漏入的 nil
+   token 立即转 500。
+
+三者组合 = 上游 Hard。`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` godoc
+正式升 Medium → Hard。
+
+**与 §A10 co-tx atomicity 的关系**：§A10 的 Medium 天花板论证（"authzmutate
+接受外部 tx 上下文被 PR #501 以 Go 类型天花板拒绝"）已被本 amendment 绕开
+——不需要让 authzmutate 接外部 tx 才能 Hard，而是让 mutation 方法本身要求
+FenceToken。§A10 论证的前提"funnel 仅靠 caller allowlist"已不成立。
+
+**§3 威胁矩阵逐行重评**（按 ai-robust.md §"ADR amendment 落地必查"）：
+
+- line 893 "新增 user authz-affecting 字段漏调 invalidator"：原 ✅（S4e
+  AUTHZ-MUTATION-APPLY-FUNNEL-01 Hard）现 ✅✅ **强化**——`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01`
+  的 "Medium-by-necessity" 标注由 #1033 转 Hard。"漏调" 现在是 Go 编译期
+  错误（mutation 方法需要 FenceToken，外部包无法构造），不再依赖 archtest
+  CI 兜底。
+- 其他 ✅ 格子 **不退化**：本 amendment 只升级 1 个格子的支撑机制（Medium →
+  Hard），未改变任一格子的最终结论。
+- **无 ✅ → ⚠️/❌ 退化**。
+
+**与 §A11 / §A13 / §A15 正交**：本 amendment 仅触及"上游 funnel 类型系统
+闭环"——§A11（读侧 credential-authority funnel）、§A13（wire-uniformity
+防枚举）、§A15（refresh user-not-active 401 + cascade fail-closed void）
+均不受影响，各自机制保持原状。
+
+**042 + 043 关闭登记**：本 amendment 同时关闭 042 §3a 第 3 条（合规登记）
++ §4 ROI 第 2 行（sealed 范本落地）+ 043 §1 第 4 行（fenceToken 范本映射）；
+依 `.claude/rules/gocell/contract-fanout.md` 单一登记原则，三处合并关闭，
+避免重复跟踪。
+
+**协作 sub-funnel（独立维度，未合并）**：
+- #793 AUTH-CACHE-SUBJECT-REVERSE-INDEX-01（RevokeForSubject 反向索引性能；
+  读端缓存与写端 seal 正交）。
+- #948 SESSION-REVOKED-FIELD-ACCESS-01（reflect 盲区反向自检；读端字段访问
+  与写端 fence 正交）。
+
+ref: `tools/archtest/fence_token_mint_funnel_test.go` (FENCE-TOKEN-MINT-FUNNEL-01)。
+ref: `runtime/auth/credentialfence/doc.go`（包级 godoc 含开源对标 Vault audit
+broker / `crypto/tls.Config` sealed 字段）。
+ref: `.claude/rules/gocell/ai-robust.md` §Hard 范本目录 "typed marker funnel
+for unbounded ops"。
+
 ---
 
 ## 1. Context
@@ -890,7 +962,7 @@ sealed `FingerprintMode` 当前仅含 `FingerprintJTIRef` 单实现。未来 opa
 | Account delete → 残留 session 攻击面 | — | — | ✅ Delete event 同 tx 撤所有 | ✅ identitymanage.Delete 直调 inv.Apply（co-tx 必需，见 §A10） | ✅ 失效原子 |
 | 并发 login 与 role revoke (P1-#3) | — | ✅ login 持 user 行 FOR UPDATE 写锁，revoke 期 BumpAuthzEpoch 也持同行写锁 → PG read-committed + row lock 天然串行化 | — | — | ✅ 失效原子 |
 | stale refresh + epoch 不匹配（P2.b，S4e 修正）| — | ✅ row.epoch != user.epoch → `rejectIfStaleEpoch` → `cascadeRevoke("stale-epoch")`（session-scoped，非 user-wide） | ✅ session 失效原子（cascade revoke） | ✅ sessionrefresh 走 stale-epoch 路径（非 user-wide Invalidator.Apply） | ✅ 失效原子 |
-| 新增 user authz-affecting 字段漏调 invalidator（S4d → S4e 闭合）| — | — | — | ✅ S4e PR #494：domain.User authz 字段私有化（SetStatus/SetPasswordResetRequired caller-set ⊆ authzmutate）+ archtest `AUTHZ-MUTATION-APPLY-FUNNEL-01` Hard 闭合。RC-A：RoleRevoked 死代码删除，Mutation 目录精确到 5 个。`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` Medium-by-necessity（co-tx atomicity，§A10 天花板证明） | — |
+| 新增 user authz-affecting 字段漏调 invalidator（S4d → S4e → §A16 闭合）| — | — | — | ✅✅ S4e PR #494：domain.User authz 字段私有化 + archtest `AUTHZ-MUTATION-APPLY-FUNNEL-01` Hard。§A16 #1033：sealed `credentialfence.FenceToken` 关闭 `CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` 上游半边——mutation 方法签名要求 FenceToken；外部包既无法实现接口（未导出标记方法）也无法构造非 nil 值（Mint 调用方 archtest 锁定）。"漏调 invalidator" 现在是 Go 编译期错误，不再依赖 archtest CI 兜底 | — |
 | issue/validate authority predicate scatter（P1.1/P1.3 class）| — | — | — | ✅ Hard：read-side funnel `credentialauthority.Assert` 已落地（§A11），下游 caller allowlist + 上游 sealed-by-name + 上游 mandatory direct + 上游 value-capture 四勿一（Hard archtest `CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01`）；slice 通过 unexported concrete + 工厂函数（SnapshotPasswordVersion）永不直接读 `CanAuthenticate` / `PasswordVersion`。session-state（RevokedAt）由独立 Hard funnel `SESSION-REVOKED-FIELD-ACCESS-01` 接管 owner-package 字段访问 allowlist（§A11.2 + §A13）| — |
 | revoked session 后置导致 wire 漂移（PR #542 P1-A）| — | — | — | ✅ Hard：§A11 重写 — `SessionNotRevoked` 从 user-bound funnel 移出，session-state 检查 inline 跑在 `sessionStore.Get` 之后、`userRepo.GetByID` 之前；revoked + inactive 不再漂 403、revoked + repoErr 不再漂 503。wire 层 single-envelope 由 service_test 守护（Medium，升 Hard 路径 backlog `WIRE-UNIFORM-RESPONSE-ARCHTEST-01`）| — |
 | inactive/locked 账号密码匹配真值泄漏（PR #542 P2-C）| — | — | — | ✅ Hard：`sessionlogin/service.go` 删除 `bcrypt_ok=%v` slog Internal 字段。inactive 路径 slog 仅含 user_id + status，不再泄漏 "密码匹配" 真值，关闭账号枚举增强通道 | — |

--- a/docs/architecture/202605101400-adr-credential-session-protocol.md
+++ b/docs/architecture/202605101400-adr-credential-session-protocol.md
@@ -630,16 +630,26 @@ BumpPasswordVersion 只自增）。
   首行 `credentialfence.MustHave(tok, "<site>")` 兜 nil 漏洞（panicregister.Approved
   + errcode.Assertion，B-class panic → 500）。
 
-**funnel 闭环证明**：
-1. 类型系统层：外部包既无法实现 FenceToken（未导出标记方法），也无法构造
-   非 nil 值（未导出 impl + Mint 调用方 archtest 锁定）。
-2. 调用形态唯一性：`FENCE-TOKEN-MINT-FUNNEL-01` A1 锁 Mint 调用点 *types.Func
-   身份；A2/A3 反向自检 function-value 捕获 + reflect 调用盲区。
-3. nil 兜底：每个 mutation impl 首行运行时检查，archtest 盲区漏入的 nil
-   token 立即转 500。
+**funnel 闭环证明**（三机制，**分属不同 enforcement 层，不可混为一个 "Hard"**）：
 
-三者组合 = 上游 Hard。`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` godoc
-正式升 Medium → Hard。
+1. **构造封印（编译期 Hard，类型系统）**：外部包无法实现 FenceToken（未导出
+   标记方法），也无法构造 `fenceToken{}`（未导出 impl）。这是本 amendment **唯一**
+   的编译期保证——它强制任何外部吊销方必须从 `Mint` 取 token。
+2. **Mint 调用方 funnel（archtest form-uniqueness Hard，非编译期）**：
+   `FENCE-TOKEN-MINT-FUNNEL-01` 的扫描器是 **form-complete** 的——遍历所有
+   SelectorExpr 经 `ResolvePackageRef` 解析，flag **每一处** Mint 引用（直接调用 /
+   函数值捕获 var-decl/short-var / return / 传参 / reflect arg），不再靠逐形态盲区
+   自检。Go 无法表达 "只有包 X 能调 Mint"，故这是该规则形状可达的 Hard 天花板
+   （PANIC-REGISTERED-01 范本），**不是**编译期保证。下游三方法 funnel
+   （`CREDENTIAL-INVALIDATE-FUNNEL-01` 等）同样升级为 form-complete SelectorExpr
+   扫描，覆盖方法值捕获形态。
+3. **nil 运行时兜底（不计静态档）**：字面量 `nil` 实参可编译、对 (1)(2) 静态不可见；
+   每个 mutation impl 首行 `MustHave` 将其转 panic（500）。这是 defense-in-depth
+   backstop，**不抬升任何静态档**。
+
+上游 Hard 由 (1)+(2) 组合支撑（构造封印编译期 + Mint funnel form-complete
+archtest）；(3) 是运行时兜底，不属于静态 claim。`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01`
+godoc 正式升 Medium → Hard。
 
 **test-file Mint() caller 豁免**：`FENCE-TOKEN-MINT-FUNNEL-01` 的
 `isFenceTokenMintAllowlisted` helper 对所有 `*_test.go` 文件返回 true，使测试
@@ -658,9 +668,14 @@ FenceToken。§A10 论证的前提"funnel 仅靠 caller allowlist"已不成立�
 
 - line 893 "新增 user authz-affecting 字段漏调 invalidator"：原 ✅（S4e
   AUTHZ-MUTATION-APPLY-FUNNEL-01 Hard）现 ✅✅ **强化**——`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01`
-  的 "Medium-by-necessity" 标注由 #1033 转 Hard。"漏调" 现在是 Go 编译期
-  错误（mutation 方法需要 FenceToken，外部包无法构造），不再依赖 archtest
-  CI 兜底。
+  的 "Medium-by-necessity" 标注由 #1033 转 Hard。强化的精确含义（按上方三机制
+  分层，**不是**单一 "编译期错误"）：(a) 外部包**构造** FenceToken 是 Go 编译期
+  错误（构造封印），故新吊销方必须经 Mint；(b) Mint 调用方 + 三 mutation 方法
+  调用方由 **form-complete** archtest funnel 锁定（archtest-bound Hard，非编译期）；
+  (c) 漏传 `nil` 可编译，由运行时 `MustHave` 转 500 兜底。"漏调 invalidator"
+  之所以闭合，是因为新吊销方既无法构造 token，也无法在 funnel 外调用 Mint 取 token
+  （archtest 拦截），而非"方法签名需要 FenceToken"本身在编译期阻止漏调（传 nil
+  仍可编译）。
 - 其他 ✅ 格子 **不退化**：本 amendment 只升级 1 个格子的支撑机制（Medium →
   Hard），未改变任一格子的最终结论。
 - **无 ✅ → ⚠️/❌ 退化**。

--- a/docs/architecture/202605101400-adr-credential-session-protocol.md
+++ b/docs/architecture/202605101400-adr-credential-session-protocol.md
@@ -641,6 +641,14 @@ BumpPasswordVersion 只自增）。
 三者组合 = 上游 Hard。`CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` godoc
 正式升 Medium → Hard。
 
+**test-file Mint() caller 豁免**：`FENCE-TOKEN-MINT-FUNNEL-01` 的
+`isFenceTokenMintAllowlisted` helper 对所有 `*_test.go` 文件返回 true，使测试
+代码不受 allowlist 约束。这与 `credential_invalidate_funnel_invariants_test.go`
+的 `isAllowlisted` 惯例一致，也与 `PANIC-REGISTERED-01` 对 test-file 的豁免
+对称——测试用途必须能直接调用 Mint() 构造 FenceToken 来驱动存储层 conformance
+和单元测试；把测试路径加进 allowlist 会把 funnel 紧密度扩散到测试代码，得不偿失。
+此豁免是有意为之的 test ergonomics 决策，不是安全盲区。
+
 **与 §A10 co-tx atomicity 的关系**：§A10 的 Medium 天花板论证（"authzmutate
 接受外部 tx 上下文被 PR #501 以 Go 类型天花板拒绝"）已被本 amendment 绕开
 ——不需要让 authzmutate 接外部 tx 才能 Hard，而是让 mutation 方法本身要求

--- a/docs/plans/202605191100-043-archtest-audit-and-capability-gap-parallel-plan.md
+++ b/docs/plans/202605191100-043-archtest-audit-and-capability-gap-parallel-plan.md
@@ -20,7 +20,7 @@
 | §4#4 HandleResult unexport | sealed struct 字段全私有 + 包内 builder | **W0 envelope**：Entry.Headers 信封字段集 sealed + codegen 单源 |
 | §4#3 errcode sealed Public/Internal | sealed newtype 分公开/内部诊断 | W0 envelope 内 Principal/Correlation/Time 公开 vs 内部分层 |
 | §4#1 ProbeName sealed funnel | typed concept + 构造期 Validate + 注册面只收 typed | **[7] health dep**：cell.yaml 声明式依赖 + typed probe funnel |
-| §4#2 fenceToken 未导出 token | 上游封口 token，包外不可表达跳过 | W3 command bus / W4 in-proc 的 dispatch/transport 上游封口 |
+| §4#2 fenceToken 未导出 token ✅ **DONE 2026-05-26 #1033** — sealed `credentialfence.FenceToken` interface + FENCE-TOKEN-MINT-FUNNEL-01 archtest + runtime nil-guard；ADR §A16 关闭 | 上游封口 token，包外不可表达跳过 | W3 command bus / W4 in-proc 的 dispatch/transport 上游封口 |
 | §4#6 façade 单 Run + typeseval 跨文件 | 关系验证工具面 | **W5 schema registry** contract↔impl↔test 三方一致 / W0 字段集单源 archtest |
 | §2c 声明式 boundary（depguard） | 声明式单源替命令式 | W4 assembly 拓扑 transport bind |
 

--- a/docs/reviews/202605181109-042-archtest-six-agent-audit.md
+++ b/docs/reviews/202605181109-042-archtest-six-agent-audit.md
@@ -83,6 +83,11 @@
 - **credential-invalidate 三 funnel 的未封口上游**：`session.Store.RevokeForSubject` /
   `refresh.Store.RevokeUser` / `UserRepository.BumpAuthzEpoch` 下游 Hard、
   上游**完全无锁**且无配对 backlog —— 这是整个吊销安全模型唯一结构性开口。
+  > **CLOSED 2026-05-26** by issue #1033：sealed `credentialfence.FenceToken`
+  > 关闭上游半边；三 mutation 方法签名要求 FenceToken，外部包既无法实现接口
+  > 也无法构造非 nil 值。详见 ADR `docs/architecture/202605101400-adr-credential-session-protocol.md`
+  > §A16 + archtest `tools/archtest/fence_token_mint_funnel_test.go`
+  > (FENCE-TOKEN-MINT-FUNNEL-01)。
 
 ### 3b. Soft→Hard 通用范式（跨域复用 + 开源对标）
 
@@ -112,7 +117,7 @@
 | # | 收口动作 | 消灭 / 降级的规则 | 类别 |
 |---|---|---|---|
 | 1 | `reg.Health(string,fn)` → `RegisterReadiness(ProbeName, Prober)` | READYZ-PROBE-NAMING(Soft) 变编译错误；吸收 CELL-REPO-READYZ N1/N2 duck-type | 可观测最高 ROI |
-| 2 | credential-invalidate **sealed fenceToken**：三 mutation 方法收未导出 token，仅 `Invalidator` 可造 | 三 funnel 上游 Soft→闭环 Hard；堵住吊销模型唯一结构开口 | 安全最高 ROI |
+| 2 | credential-invalidate **sealed fenceToken**：三 mutation 方法收未导出 token，仅 `Invalidator` 可造 ✅ **DONE 2026-05-26 #1033** — sealed `credentialfence.FenceToken` interface + Mint funnel + runtime nil-guard 三层闭环；UPSTREAM-CALLER-01 Medium → Hard | 三 funnel 上游 Soft→闭环 Hard；堵住吊销模型唯一结构开口 | 安全最高 ROI |
 | 3 | `errcode.WithDetails/WithInternal` → sealed `PublicDetail/InternalDetail` newtype | DETAILS-SLOG-ATTR + MESSAGE-CONST 两 Medium → 一 Hard 类型 | 错误模型 |
 | 4 | `outbox.HandleResult` 字段全 unexport（kernel 内部 builder 分离） | OUTBOX-HANDLERESULT-FACTORY-PREFERRED + FIELDS-FROZEN 退役 | 事件总线 |
 | 5 | sink 侧脱敏（SafeSpan + slog middleware） | 删 4 条 call-site redaction Soft archtest | 可观测 |

--- a/hack/verify-archtest-invariants.sh
+++ b/hack/verify-archtest-invariants.sh
@@ -16,5 +16,5 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go test ./tools/archtest \
-  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestFenceTokenMintFunnel_AllowlistEnforced|TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment|TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation)$' \
+  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestFenceTokenMintFunnel_AllowlistEnforced)$' \
   -count=1 -timeout 5m

--- a/hack/verify-archtest-invariants.sh
+++ b/hack/verify-archtest-invariants.sh
@@ -16,5 +16,5 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go test ./tools/archtest \
-  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures)$' \
+  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestFenceTokenMintFunnel_AllowlistEnforced|TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment|TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation)$' \
   -count=1 -timeout 5m

--- a/runtime/auth/credentialfence/doc.go
+++ b/runtime/auth/credentialfence/doc.go
@@ -44,7 +44,7 @@
 //   - Implementation seal — Hard (Go type system; unimplementable outside
 //     this package due to unexported marker method)
 //   - Mint callsite seal — Hard via call-site form-uniqueness (archtest
-//     A1 ResolveMethodCall resolves the call to a unique *types.Func;
+//     A1 ResolvePackageRef resolves the SelectorExpr X to a *types.PkgName;
 //     A2/A3 blindspot self-checks reject function-value and reflect forms)
 //   - nil-FenceToken hole — closed via runtime guard in the three mutation
 //     methods (pkg/validation.IsNilInterface → errcode.Assertion through
@@ -69,7 +69,7 @@
 //     §4 ROI row 2
 //   - docs/plans/202605191100-043-archtest-audit-and-capability-gap-parallel-plan.md
 //     §1 row 4
-//   - docs/architecture/202605101400-adr-credential-session-protocol.md §A16
+//   - docs/architecture/202605101400-adr-credential-session-protocol.md §A16 (credential-invalidate sealed FenceToken — 上游 funnel 闭环)
 //
 // Open-source comparison: HashiCorp Vault audit broker sealed token,
 // crypto/tls.Config sealed fields.

--- a/runtime/auth/credentialfence/doc.go
+++ b/runtime/auth/credentialfence/doc.go
@@ -41,19 +41,34 @@
 //
 // # AI-robust evaluation
 //
-//   - Implementation seal — Hard (Go type system; unimplementable outside
-//     this package due to unexported marker method)
-//   - Mint callsite seal — Hard via call-site form-uniqueness (archtest
-//     A1 ResolvePackageRef resolves the SelectorExpr X to a *types.PkgName;
-//     A2/A3 blindspot self-checks reject function-value and reflect forms)
-//   - nil-FenceToken hole — closed via runtime guard in the three mutation
-//     methods (pkg/validation.IsNilInterface → errcode.Assertion through
-//     panicregister.Approved). Single-source completeness vs. archtest
-//     blindspots.
+// Three mechanisms with distinct enforcement layers — do not collapse them
+// into one "Hard":
 //
-// Combined grade: funnel upstream Hard, downstream Hard. See
-// .claude/rules/gocell/ai-robust.md §"Hard 范本目录" entry "typed marker
-// funnel for unbounded ops" and §"Funnel 双向锁评级".
+//   - Construction seal — Hard, compile-time (Go type system). FenceToken is
+//     unimplementable outside this package (unexported marker method) and the
+//     concrete [fenceToken] is unexported, so no external composite literal can
+//     build one. This is the only compile-time guarantee here; it forces every
+//     external would-be revoker to obtain a token from [Mint].
+//   - Mint callsite funnel — Hard via call-site form-uniqueness, archtest-bound
+//     (FENCE-TOKEN-MINT-FUNNEL-01), NOT compile-time. The scanner is
+//     form-complete: it flags every reference to Mint (direct call,
+//     function-value capture, return, pass-through arg, reflect arg) via a
+//     ResolvePackageRef SelectorExpr walk, so there is no per-form blindspot
+//     self-check to drift. Go cannot express "only package X may call Mint", so
+//     this is the Hard ceiling the rule's shape can reach (the
+//     PANIC-REGISTERED-01 precedent).
+//   - nil-FenceToken — runtime backstop, NOT a static grade. A literal nil
+//     argument compiles and is invisible to the two static mechanisms above;
+//     [MustHave] in each mutation impl converts it to an immediate panic
+//     (pkg/validation.IsNilInterface → errcode.Assertion via
+//     panicregister.Approved → 500). Defense-in-depth; it does not elevate any
+//     static grade.
+//
+// Combined grade: funnel upstream Hard, downstream Hard — resting on the
+// construction seal (compile-time) plus the two form-complete archtest funnels.
+// The nil guard is a runtime backstop, not part of the static claim. See
+// .claude/rules/gocell/ai-robust.md §"Hard 范本目录" entry "typed marker funnel
+// for unbounded ops" and §"Funnel 双向锁评级".
 //
 // # Reference precedent
 //

--- a/runtime/auth/credentialfence/doc.go
+++ b/runtime/auth/credentialfence/doc.go
@@ -1,0 +1,76 @@
+// Package credentialfence is the sealed source of the credential-invalidation
+// FenceToken — a capability proof that authorizes calls to the three credential
+// mutation methods (session.Store.RevokeForSubject /
+// refresh.Store.RevokeUser / ports.UserRepository.BumpAuthzEpoch).
+//
+// # Why
+//
+// Before #1033 the credential-invalidate funnel was half-closed:
+//
+//   - DOWNSTREAM Hard — the three mutation methods' caller allowlist is locked
+//     by archtests CREDENTIAL-INVALIDATE-FUNNEL-01 / USER-AUTHZ-EPOCH-BUMP-FUNNEL-01
+//     / REFRESH-REVOKE-USER-FUNNEL-01 (ResolveMethodCall form-uniqueness).
+//   - UPSTREAM Soft — any package could construct the receivers and call the
+//     methods directly. Only CI-time archtest catches it; Go's type system did
+//     not.
+//
+// 042 §3a row 3 and §4 ROI row 2 flagged this as the single remaining
+// structural opening in the revocation safety model. This package closes it:
+// the three mutation methods now require a [FenceToken] argument that only
+// [Mint] can produce.
+//
+// # How
+//
+// [FenceToken] is a sealed interface — the unexported isCredentialFenceToken
+// marker method makes external implementations impossible at compile time
+// (Go visibility rule: only types declared in this package can implement an
+// interface with an unexported method). The concrete impl [fenceToken] is
+// unexported, so [fenceToken{}] cannot be constructed from outside the
+// package either.
+//
+// [Mint] is the sole constructor. Its callers are restricted by archtest
+// FENCE-TOKEN-MINT-FUNNEL-01 to:
+//
+//   - cells/accesscore/internal/credentialinvalidate/ — the production funnel
+//   - runtime/auth/session/storetest/ + runtime/auth/refresh/storetest/ +
+//     cells/accesscore/internal/ports/conformance/ — conformance suites that
+//     must exercise the contract end-to-end
+//   - *_test.go files in any package — unit tests for impls and stubs
+//
+// Any other caller is detected as a form-uniqueness violation and fails CI.
+//
+// # AI-robust evaluation
+//
+//   - Implementation seal — Hard (Go type system; unimplementable outside
+//     this package due to unexported marker method)
+//   - Mint callsite seal — Hard via call-site form-uniqueness (archtest
+//     A1 ResolveMethodCall resolves the call to a unique *types.Func;
+//     A2/A3 blindspot self-checks reject function-value and reflect forms)
+//   - nil-FenceToken hole — closed via runtime guard in the three mutation
+//     methods (pkg/validation.IsNilInterface → errcode.Assertion through
+//     panicregister.Approved). Single-source completeness vs. archtest
+//     blindspots.
+//
+// Combined grade: funnel upstream Hard, downstream Hard. See
+// .claude/rules/gocell/ai-robust.md §"Hard 范本目录" entry "typed marker
+// funnel for unbounded ops" and §"Funnel 双向锁评级".
+//
+// # Reference precedent
+//
+//   - kernel/outbox/cell_marker.go (CellPublisher / CellEmitter sealed
+//     marker pattern)
+//   - kernel/persistence/cell_marker.go (CellTxManager sealed marker pattern)
+//   - pkg/panicregister/panicregister.go (typed marker funnel +
+//     PANIC-REGISTERED-01 archtest form-uniqueness)
+//
+// # Audit / plan references
+//
+//   - docs/reviews/202605181109-042-archtest-six-agent-audit.md §3a row 3,
+//     §4 ROI row 2
+//   - docs/plans/202605191100-043-archtest-audit-and-capability-gap-parallel-plan.md
+//     §1 row 4
+//   - docs/architecture/202605101400-adr-credential-session-protocol.md §A16
+//
+// Open-source comparison: HashiCorp Vault audit broker sealed token,
+// crypto/tls.Config sealed fields.
+package credentialfence

--- a/runtime/auth/credentialfence/fencetoken.go
+++ b/runtime/auth/credentialfence/fencetoken.go
@@ -1,0 +1,77 @@
+package credentialfence
+
+import (
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// FenceToken is a sealed capability proof for the credential-invalidation
+// trifecta. The unexported isCredentialFenceToken marker method makes this
+// interface unimplementable outside the credentialfence package, so external
+// packages cannot construct a non-nil FenceToken value.
+//
+// Allowed call site for [Mint] is enforced by archtest
+// FENCE-TOKEN-MINT-FUNNEL-01 (see package godoc).
+type FenceToken interface {
+	// MARKER: do not implement; this is the sealing marker — call
+	// credentialfence.Mint from cells/accesscore/internal/credentialinvalidate
+	// (or a *_test.go / conformance suite) instead.
+	isCredentialFenceToken()
+}
+
+// fenceToken is the unexported concrete impl. Outside this package the type
+// cannot be referenced, so fenceToken{} composite literals cannot be written.
+type fenceToken struct{}
+
+func (fenceToken) isCredentialFenceToken() {}
+
+// Mint returns a fresh FenceToken. It is the sole entry point for
+// constructing a non-nil FenceToken value.
+//
+// Allowed callers (enforced by archtest FENCE-TOKEN-MINT-FUNNEL-01):
+//   - cells/accesscore/internal/credentialinvalidate/ (the production funnel)
+//   - runtime/auth/session/storetest/, runtime/auth/refresh/storetest/,
+//     cells/accesscore/internal/ports/conformance/ (conformance suites)
+//   - any *_test.go file (unit / integration test bodies)
+//
+// Any other caller is rejected as a form-uniqueness violation.
+func Mint() FenceToken {
+	return fenceToken{}
+}
+
+// fenceTokenRequiredMessage is the const-literal format string passed to
+// errcode.Assertion. The %s slot carries the calling method's identifier
+// (e.g. "session.Store.RevokeForSubject"), supplied at the call site as a
+// runtime argument. Assertion is allowed to format runtime context into
+// Message per its documented exception (see pkg/errcode godoc).
+const fenceTokenRequiredMessage = "%s: FenceToken required; call must route through credentialinvalidate.Invalidator"
+
+// MustHave panics through the panic-taxonomy funnel
+// (panicregister.Approved + errcode.Assertion, B-class) when tok is nil or
+// a typed-nil interface, surfacing the programmer error as a 500 via the
+// kernel Recovery middleware rather than letting the bug slip past as a
+// silent failure deeper in the call chain.
+//
+// site identifies the offending method for the panic message — pass a
+// const string such as "session.Store.RevokeForSubject" so the operator
+// can pinpoint the bypass at a glance.
+//
+// The three credential-mutation methods (session.Store.RevokeForSubject,
+// refresh.Store.RevokeUser, ports.UserRepository.BumpAuthzEpoch) and their
+// implementations call MustHave as the first statement of their bodies.
+// This is the defense-in-depth complement to the type-system seal — even if
+// a future call form bypasses the upstream archtest blindspot checks
+// (function-value capture, reflect.MethodByName), a nil token would
+// still produce a hard failure here.
+//
+// MustHave is package-public because it is called from impl packages
+// (runtime/auth/session, runtime/auth/refresh, cells/accesscore/internal/mem,
+// adapters/postgres, adapters/redis); it does not weaken the seal because
+// it cannot construct a FenceToken — only Mint can.
+func MustHave(tok FenceToken, site string) {
+	if validation.IsNilInterface(tok) {
+		panic(panicregister.Approved("credential-fence-nil-token",
+			errcode.Assertion(fenceTokenRequiredMessage, site)))
+	}
+}

--- a/runtime/auth/credentialfence/fencetoken.go
+++ b/runtime/auth/credentialfence/fencetoken.go
@@ -45,7 +45,9 @@ func Mint() FenceToken {
 // (e.g. "session.Store.RevokeForSubject"), supplied at the call site as a
 // runtime argument. Assertion is allowed to format runtime context into
 // Message per its documented exception (see pkg/errcode godoc).
-const fenceTokenRequiredMessage = "%s: FenceToken required; call must route through credentialinvalidate.Invalidator"
+//
+//nolint:gosec // G101 false positive: format template, not a credential value
+const fenceTokenRequiredMessage = "%s: FenceToken required; must route through credentialinvalidate.Invalidator"
 
 // MustHave panics through the panic-taxonomy funnel
 // (panicregister.Approved + errcode.Assertion, B-class) when tok is nil or

--- a/runtime/auth/credentialfence/fencetoken_internal_test.go
+++ b/runtime/auth/credentialfence/fencetoken_internal_test.go
@@ -1,0 +1,34 @@
+package credentialfence
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// TestMustHave_TypedNilPanics constructs a typed-nil FenceToken
+// (var x *fenceToken = nil; var tok FenceToken = x) and verifies
+// MustHave panics through the panic-taxonomy funnel with an
+// *errcode.Error payload carrying KindInternal. This is the
+// internal complement to the external test, which can only
+// exercise bare-nil because the fenceToken impl is unexported.
+func TestMustHave_TypedNilPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("MustHave did not panic on typed-nil FenceToken")
+		}
+		err, ok := r.(*errcode.Error)
+		if !ok {
+			t.Fatalf("MustHave panic payload must be *errcode.Error; got %T", r)
+		}
+		if err.Kind != errcode.KindInternal {
+			t.Errorf("MustHave panic Kind must be KindInternal; got %v", err.Kind)
+		}
+	}()
+	var typed *fenceToken
+	var tok FenceToken = typed // typed-nil interface value
+	MustHave(tok, "credentialfence.internal_test.callsite")
+}

--- a/runtime/auth/credentialfence/fencetoken_test.go
+++ b/runtime/auth/credentialfence/fencetoken_test.go
@@ -121,16 +121,15 @@ func TestMustHave_NilPanics(t *testing.T) {
 	credentialfence.MustHave(nilTok, "test.callsite.nil")
 }
 
-// TestMustHave_TypedNilPanics asserts MustHave catches the typed-nil
-// interface form (var x credentialfence.FenceToken = (*someConcrete)(nil)).
-// IsNilInterface's whole purpose is to catch this case where bare-nil
-// comparison misses.
-//
-// Cannot construct a typed-nil FenceToken externally (FenceToken's only
-// impl is unexported), so this test uses a bare-nil var; the typed-nil
-// path is exercised transitively through validation.IsNilInterface, which
-// is unit-tested in pkg/validation.
-func TestMustHave_TypedNilPanics(t *testing.T) {
+// TestValidationIsNilInterface_TypedNilForFenceToken asserts the upstream
+// pkg/validation invariant that MustHave relies on: validation.IsNilInterface
+// must return true for a bare-nil FenceToken interface value. This test
+// exercises the external (package credentialfence_test) scope, where the
+// concrete fenceToken impl is unexported and a true typed-nil cannot be
+// constructed. The companion internal test (fencetoken_internal_test.go,
+// package credentialfence) constructs a true typed-nil and verifies
+// MustHave panics through the panic-taxonomy funnel.
+func TestValidationIsNilInterface_TypedNilForFenceToken(t *testing.T) {
 	t.Parallel()
 
 	// Sanity-check the upstream invariant we rely on.

--- a/runtime/auth/credentialfence/fencetoken_test.go
+++ b/runtime/auth/credentialfence/fencetoken_test.go
@@ -1,0 +1,141 @@
+package credentialfence_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
+)
+
+// TestMint_ReturnsNonNil asserts Mint produces a value that survives the
+// IsNilInterface guard the three mutation methods will apply at runtime.
+func TestMint_ReturnsNonNil(t *testing.T) {
+	t.Parallel()
+
+	tok := credentialfence.Mint()
+	if validation.IsNilInterface(tok) {
+		t.Fatal("Mint returned nil-interface; mutation methods would reject it at runtime")
+	}
+}
+
+// TestMint_AllValuesInterchangeable asserts every Mint return value is an
+// equally valid FenceToken — Mint conveys *authorization*, not identity, so
+// distinct values must be interchangeable.
+func TestMint_AllValuesInterchangeable(t *testing.T) {
+	t.Parallel()
+
+	a := credentialfence.Mint()
+	b := credentialfence.Mint()
+
+	if validation.IsNilInterface(a) || validation.IsNilInterface(b) {
+		t.Fatal("Mint returned nil-interface")
+	}
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		t.Fatalf("Mint values must share a concrete type; got %T vs %T", a, b)
+	}
+}
+
+// TestFenceToken_NotImplementableByExternalType is the runtime witness of
+// the type-system seal: the FenceToken interface has an unexported marker
+// method, so types declared outside this package cannot satisfy it.
+//
+// This test exercises the dual: an external type that is NOT a FenceToken
+// must NOT satisfy the interface assertion. If a future refactor exposed the
+// marker method (typo, accidental rename), an external struct would silently
+// satisfy FenceToken and this test would fail.
+func TestFenceToken_NotImplementableByExternalType(t *testing.T) {
+	t.Parallel()
+
+	type externalImpostor struct{}
+
+	if _, ok := any(externalImpostor{}).(credentialfence.FenceToken); ok {
+		t.Fatal("FenceToken seal broken: an empty external struct satisfies the interface — " +
+			"the marker method must remain unexported (lowercase isCredentialFenceToken)")
+	}
+}
+
+// TestFenceToken_MarkerMethodUnexported asserts that every method declared
+// on the FenceToken interface starts with a lowercase letter. The unexported
+// marker method (isCredentialFenceToken) is what gives FenceToken its seal:
+// types declared in any other package cannot implement an interface that
+// requires an unexported method from this package. A rename that
+// accidentally capitalizes the marker (e.g. to IsCredentialFenceToken) would
+// expose the method to external implementations and silently break the
+// seal. This test catches that regression.
+func TestFenceToken_MarkerMethodUnexported(t *testing.T) {
+	t.Parallel()
+
+	ifaceType := reflect.TypeOf((*credentialfence.FenceToken)(nil)).Elem()
+	for i := 0; i < ifaceType.NumMethod(); i++ {
+		m := ifaceType.Method(i)
+		// Interface method names are accessible via reflect, but exported-ness
+		// is reported separately. For sealed-marker safety every method must
+		// be PkgPath-bound (unexported).
+		if m.PkgPath == "" {
+			t.Fatalf("FenceToken seal broken: method %q is exported "+
+				"(PkgPath is empty); any package can declare a matching "+
+				"method and satisfy FenceToken. The marker method must "+
+				"stay unexported (lowercase first letter).", m.Name)
+		}
+	}
+}
+
+// TestMustHave_NonNil asserts MustHave is a noop when given a real Mint() value.
+// This is the happy-path branch every production callsite hits.
+func TestMustHave_NonNil(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("MustHave panicked on a real FenceToken: %v", r)
+		}
+	}()
+	credentialfence.MustHave(credentialfence.Mint(), "test.callsite")
+}
+
+// TestMustHave_NilPanics asserts MustHave panics with an *errcode.Error of
+// KindInternal when given a nil FenceToken. The panic is the surface area
+// for the programmer-error 500 surfaced by the kernel Recovery middleware.
+func TestMustHave_NilPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("MustHave did not panic on nil FenceToken")
+		}
+		err, ok := r.(*errcode.Error)
+		if !ok {
+			t.Fatalf("MustHave panic payload must be *errcode.Error; got %T (%v)", r, r)
+		}
+		if err.Kind != errcode.KindInternal {
+			t.Errorf("MustHave panic Kind must be KindInternal (assertion); got %v", err.Kind)
+		}
+		if err.Code != errcode.ErrInternal {
+			t.Errorf("MustHave panic must carry ErrInternal sentinel; got code=%v", err.Code)
+		}
+	}()
+	var nilTok credentialfence.FenceToken
+	credentialfence.MustHave(nilTok, "test.callsite.nil")
+}
+
+// TestMustHave_TypedNilPanics asserts MustHave catches the typed-nil
+// interface form (var x credentialfence.FenceToken = (*someConcrete)(nil)).
+// IsNilInterface's whole purpose is to catch this case where bare-nil
+// comparison misses.
+//
+// Cannot construct a typed-nil FenceToken externally (FenceToken's only
+// impl is unexported), so this test uses a bare-nil var; the typed-nil
+// path is exercised transitively through validation.IsNilInterface, which
+// is unit-tested in pkg/validation.
+func TestMustHave_TypedNilPanics(t *testing.T) {
+	t.Parallel()
+
+	// Sanity-check the upstream invariant we rely on.
+	var nilTok credentialfence.FenceToken
+	if !validation.IsNilInterface(nilTok) {
+		t.Fatal("validation.IsNilInterface(nil FenceToken) returned false — upstream invariant broken")
+	}
+}

--- a/runtime/auth/refresh/gc_worker_test.go
+++ b/runtime/auth/refresh/gc_worker_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 type staticClock struct {
@@ -71,7 +72,7 @@ func (s *gcStoreSpy) RevokeSessionDetached(context.Context, string) error {
 	return errors.New("not implemented")
 }
 
-func (s *gcStoreSpy) RevokeUser(context.Context, string) error {
+func (s *gcStoreSpy) RevokeUser(context.Context, string, credentialfence.FenceToken) error {
 	return errors.New("not implemented")
 }
 

--- a/runtime/auth/refresh/memstore/store.go
+++ b/runtime/auth/refresh/memstore/store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 )
 
@@ -299,7 +300,8 @@ func (s *store) RevokeSessionDetached(ctx context.Context, sessionID string) err
 }
 
 // RevokeUser marks every row owned by subjectID as revoked.
-func (s *store) RevokeUser(_ context.Context, subjectID string) error {
+func (s *store) RevokeUser(_ context.Context, subjectID string, tok credentialfence.FenceToken) error {
+	credentialfence.MustHave(tok, "refresh.Store.RevokeUser")
 	now := s.clock.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
@@ -173,4 +174,35 @@ func TestNewRejectsEmptyPolicy(t *testing.T) {
 	fakeClock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	_, err := memstore.New(refresh.Policy{}, fakeClock, nil)
 	require.Error(t, err, "New with empty Policy must return error")
+}
+
+// TestRevokeUserNilFenceTokenPanics verifies that passing a nil FenceToken to
+// RevokeUser triggers MustHave's B-class panic with errcode.Assertion payload.
+func TestRevokeUserNilFenceTokenPanics(t *testing.T) {
+	t.Parallel()
+	clk := storetest.NewFakeClock(baseTime)
+	store, err := memstore.New(
+		refresh.Policy{
+			ReuseInterval:  time.Second,
+			MaxAge:         time.Hour,
+			MaxIdle:        refresh.DefaultMaxIdle,
+			GraceMaxReuses: refresh.DefaultGraceMaxReuses,
+		},
+		clk,
+		nil,
+	)
+	require.NoError(t, err)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_ = store.RevokeUser(context.Background(), "subject-1", nil)
+	}()
+
+	require.NotNil(t, recovered, "nil FenceToken must cause MustHave to panic")
+	// The panic payload must be an errcode.Assertion (*errcode.Error).
+	errcodeErr, ok := recovered.(*errcode.Error)
+	require.True(t, ok, "panic payload must be *errcode.Error, got %T", recovered)
+	require.Equal(t, errcode.KindInternal, errcodeErr.Kind,
+		"assertion panic must carry KindInternal")
 }

--- a/runtime/auth/refresh/memstore/store_test.go
+++ b/runtime/auth/refresh/memstore/store_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
 	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
@@ -174,35 +173,4 @@ func TestNewRejectsEmptyPolicy(t *testing.T) {
 	fakeClock := storetest.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	_, err := memstore.New(refresh.Policy{}, fakeClock, nil)
 	require.Error(t, err, "New with empty Policy must return error")
-}
-
-// TestRevokeUserNilFenceTokenPanics verifies that passing a nil FenceToken to
-// RevokeUser triggers MustHave's B-class panic with errcode.Assertion payload.
-func TestRevokeUserNilFenceTokenPanics(t *testing.T) {
-	t.Parallel()
-	clk := storetest.NewFakeClock(baseTime)
-	store, err := memstore.New(
-		refresh.Policy{
-			ReuseInterval:  time.Second,
-			MaxAge:         time.Hour,
-			MaxIdle:        refresh.DefaultMaxIdle,
-			GraceMaxReuses: refresh.DefaultGraceMaxReuses,
-		},
-		clk,
-		nil,
-	)
-	require.NoError(t, err)
-
-	var recovered any
-	func() {
-		defer func() { recovered = recover() }()
-		_ = store.RevokeUser(context.Background(), "subject-1", nil)
-	}()
-
-	require.NotNil(t, recovered, "nil FenceToken must cause MustHave to panic")
-	// The panic payload must be an errcode.Assertion (*errcode.Error).
-	errcodeErr, ok := recovered.(*errcode.Error)
-	require.True(t, ok, "panic payload must be *errcode.Error, got %T", recovered)
-	require.Equal(t, errcode.KindInternal, errcodeErr.Kind,
-		"assertion panic must carry KindInternal")
 }

--- a/runtime/auth/refresh/store.go
+++ b/runtime/auth/refresh/store.go
@@ -3,6 +3,8 @@ package refresh
 import (
 	"context"
 	"time"
+
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // Store persists refresh token chains with CAS-protected Rotate and
@@ -124,8 +126,14 @@ type Store interface {
 	// level cascade revoke is split because it also serves security responses
 	// to token reuse and compensating cleanup.
 	//
+	// tok is a capability proof minted exclusively by
+	// credentialinvalidate.Invalidator via credentialfence.Mint. Passing a
+	// nil FenceToken triggers a MustHave panic (B-class programmer error)
+	// in every implementation; callers outside the Invalidator must not
+	// call this method directly.
+	//
 	// Consistency: L1 LocalTx — single UPDATE.
-	RevokeUser(ctx context.Context, subjectID string) error
+	RevokeUser(ctx context.Context, subjectID string, tok credentialfence.FenceToken) error
 
 	// GC removes rows whose effective expiry has passed olderThan. Effective
 	// expiry is the earlier of expires_at (hard cap) and idle_expires_at

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -124,6 +124,7 @@ func RunContractSuite(t *testing.T, factory Factory) {
 	t.Run("T16_Rotate_GraceInsideInterval_DistinctWire", func(t *testing.T) { t.Parallel(); runT16GraceInside(t, factory) })
 	t.Run("T17_Rotate_ParseFailure_Uniform", func(t *testing.T) { t.Parallel(); runT17ParseFailure(t, factory) })
 	t.Run("T18_RevokeUser_OnlyTargetSubject", func(t *testing.T) { t.Parallel(); runT18RevokeUser(t, factory) })
+	t.Run("T18b_RevokeUser_NilFenceToken_Panics", func(t *testing.T) { t.Parallel(); runT18bRevokeUserNilFenceToken(t, factory) })
 	t.Run("T19_Peek_DoesNotAdvanceLineage", func(t *testing.T) { t.Parallel(); runT19PeekDoesNotAdvance(t, factory) })
 	t.Run("T20_Peek_RejectionParityAndReuseCascade", func(t *testing.T) {
 		t.Parallel()
@@ -528,6 +529,28 @@ func runT18RevokeUser(t *testing.T, factory Factory) {
 
 	// Unknown subject is a no-op.
 	require.NoError(t, store.RevokeUser(ctx, "nobody", credentialfence.Mint()))
+}
+
+// runT18bRevokeUserNilFenceToken — Store contract: a nil FenceToken is a
+// programmer error that credentialfence.MustHave converts to a B-class panic
+// (*errcode.Error, KindInternal) identifying the call site. Every impl (mem /
+// PG) must honor the guard — the shared suite holds them all to it. MustHave is
+// the first statement, so the panic fires before any backend I/O.
+func runT18bRevokeUserNilFenceToken(t *testing.T, factory Factory) {
+	store, _ := factory(t, defaultPolicy)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		// nil FenceToken is intentional — exercising the MustHave guard.
+		_ = store.RevokeUser(context.Background(), "subject-nil-token", nil)
+	}()
+
+	require.NotNil(t, recovered, "nil FenceToken must trigger MustHave panic")
+	coded, ok := recovered.(*errcode.Error)
+	require.True(t, ok, "panic payload must be *errcode.Error, got %T", recovered)
+	require.Equal(t, errcode.KindInternal, coded.Kind, "nil-token panic must carry KindInternal")
+	require.Contains(t, coded.Message, "refresh.Store.RevokeUser", "panic message must identify call site")
 }
 
 func runT19PeekDoesNotAdvance(t *testing.T, factory Factory) {

--- a/runtime/auth/refresh/storetest/suite.go
+++ b/runtime/auth/refresh/storetest/suite.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 )
 
@@ -445,7 +446,7 @@ func runT15AfterRevokeUser(t *testing.T, factory Factory) {
 	userAWire2, _ := mustIssue(t, store, "sess-a2", t15TargetSubject)
 	userBWire, _ := mustIssue(t, store, "sess-b1", t15OtherSubject)
 
-	require.NoError(t, store.RevokeUser(ctx, t15TargetSubject))
+	require.NoError(t, store.RevokeUser(ctx, t15TargetSubject, credentialfence.Mint()))
 
 	_, _, err := store.Rotate(ctx, userAWire1)
 	assert.ErrorIs(t, err, refresh.ErrRejected)
@@ -516,8 +517,8 @@ func runT18RevokeUser(t *testing.T, factory Factory) {
 	aWire, _ := mustIssue(t, store, "sess-18a", t18TargetSubject)
 	bWire, _ := mustIssue(t, store, "sess-18b", t18OtherSubject)
 
-	require.NoError(t, store.RevokeUser(ctx, t18TargetSubject))
-	require.NoError(t, store.RevokeUser(ctx, t18TargetSubject)) // idempotent
+	require.NoError(t, store.RevokeUser(ctx, t18TargetSubject, credentialfence.Mint()))
+	require.NoError(t, store.RevokeUser(ctx, t18TargetSubject, credentialfence.Mint())) // idempotent
 
 	_, _, err := store.Rotate(ctx, aWire)
 	assert.ErrorIs(t, err, refresh.ErrRejected)
@@ -526,7 +527,7 @@ func runT18RevokeUser(t *testing.T, factory Factory) {
 	assert.NoError(t, err, "user-18B chain must survive RevokeUser(user-18A)")
 
 	// Unknown subject is a no-op.
-	require.NoError(t, store.RevokeUser(ctx, "nobody"))
+	require.NoError(t, store.RevokeUser(ctx, "nobody", credentialfence.Mint()))
 }
 
 func runT19PeekDoesNotAdvance(t *testing.T, factory Factory) {

--- a/runtime/auth/session/mem_store.go
+++ b/runtime/auth/session/mem_store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // MemStore is an in-memory Store implementation for dev and tests. It is
@@ -142,7 +143,8 @@ func (m *MemStore) Revoke(_ context.Context, id string) error {
 // (D3 fail-closed by default — every event triggers identical revoke
 // scoping); future protocols may scope per-event when sealed alternatives
 // are added. Missing subjects yield no error (always succeeds).
-func (m *MemStore) RevokeForSubject(_ context.Context, subjectID string, event CredentialEvent) error {
+func (m *MemStore) RevokeForSubject(_ context.Context, subjectID string, event CredentialEvent, tok credentialfence.FenceToken) error {
+	credentialfence.MustHave(tok, "session.Store.RevokeForSubject")
 	if subjectID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"session: RevokeForSubject requires non-empty subjectID")

--- a/runtime/auth/session/mem_store_test.go
+++ b/runtime/auth/session/mem_store_test.go
@@ -1,6 +1,7 @@
 package session_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -144,4 +145,41 @@ func TestMemStore_RepoReadinessConformance(t *testing.T) {
 		t.Fatalf("NewMemStore: %v", err)
 	}
 	celltest.RunRepoReadinessConformance(t, "session-mem", store, nil)
+}
+
+// TestMemStore_RevokeForSubject_NilFenceToken_Panics verifies that passing a
+// nil FenceToken to MemStore.RevokeForSubject triggers the MustHave guard
+// (B-class programmer error) with an *errcode.Error payload and a message that
+// identifies the call site.
+//
+// panicregister.Approved returns the payload unchanged, so recover() sees the
+// raw *errcode.Error from errcode.Assertion.
+func TestMemStore_RevokeForSubject_NilFenceToken_Panics(t *testing.T) {
+	t.Parallel()
+	fc := clockmock.New(storetest.EpochAnchor())
+	store, err := session.NewMemStore(storetest.NewTestProtocol(t), fc)
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		// nil FenceToken is intentional — we are testing the guard.
+		_ = store.RevokeForSubject(context.Background(), "subject-A", session.CredentialEventPasswordReset, nil)
+	}()
+
+	if recovered == nil {
+		t.Fatal("expected panic from nil FenceToken, got nil")
+	}
+	coded, ok := recovered.(*errcode.Error)
+	if !ok {
+		t.Fatalf("expected panic value *errcode.Error, got %T: %v", recovered, recovered)
+	}
+	if coded.Code != errcode.ErrInternal {
+		t.Errorf("expected ErrInternal (Assertion), got %s", coded.Code)
+	}
+	if !strings.Contains(coded.Message, "session.Store.RevokeForSubject") {
+		t.Errorf("expected panic message to identify call site, got %q", coded.Message)
+	}
 }

--- a/runtime/auth/session/mem_store_test.go
+++ b/runtime/auth/session/mem_store_test.go
@@ -1,7 +1,6 @@
 package session_test
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -145,41 +144,4 @@ func TestMemStore_RepoReadinessConformance(t *testing.T) {
 		t.Fatalf("NewMemStore: %v", err)
 	}
 	celltest.RunRepoReadinessConformance(t, "session-mem", store, nil)
-}
-
-// TestMemStore_RevokeForSubject_NilFenceToken_Panics verifies that passing a
-// nil FenceToken to MemStore.RevokeForSubject triggers the MustHave guard
-// (B-class programmer error) with an *errcode.Error payload and a message that
-// identifies the call site.
-//
-// panicregister.Approved returns the payload unchanged, so recover() sees the
-// raw *errcode.Error from errcode.Assertion.
-func TestMemStore_RevokeForSubject_NilFenceToken_Panics(t *testing.T) {
-	t.Parallel()
-	fc := clockmock.New(storetest.EpochAnchor())
-	store, err := session.NewMemStore(storetest.NewTestProtocol(t), fc)
-	if err != nil {
-		t.Fatalf("NewMemStore: %v", err)
-	}
-
-	var recovered any
-	func() {
-		defer func() { recovered = recover() }()
-		// nil FenceToken is intentional — we are testing the guard.
-		_ = store.RevokeForSubject(context.Background(), "subject-A", session.CredentialEventPasswordReset, nil)
-	}()
-
-	if recovered == nil {
-		t.Fatal("expected panic from nil FenceToken, got nil")
-	}
-	coded, ok := recovered.(*errcode.Error)
-	if !ok {
-		t.Fatalf("expected panic value *errcode.Error, got %T: %v", recovered, recovered)
-	}
-	if coded.Code != errcode.ErrInternal {
-		t.Errorf("expected ErrInternal (Assertion), got %s", coded.Code)
-	}
-	if !strings.Contains(coded.Message, "session.Store.RevokeForSubject") {
-		t.Errorf("expected panic message to identify call site, got %q", coded.Message)
-	}
 }

--- a/runtime/auth/session/store.go
+++ b/runtime/auth/session/store.go
@@ -3,6 +3,8 @@ package session
 import (
 	"context"
 	"time"
+
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
 // Session is the canonical server-side session record exchanged between
@@ -122,7 +124,10 @@ type ValidateView struct {
 //   - Revoke: mark a single session dead. Idempotent: already-revoked or
 //     missing IDs are no-ops returning nil (防枚举 — must not leak existence).
 //     RevokedAt is set exactly once; subsequent Revoke calls do not re-stamp.
-//   - RevokeForSubject: mark every active session for SubjectID dead. Empty
+//   - RevokeForSubject: mark every active session for SubjectID dead. tok is
+//     a credentialfence.FenceToken — a sealed capability proof minted only by
+//     credentialinvalidate.Invalidator via credentialfence.Mint; passing nil
+//     panics via MustHave (B-class programmer error, surfaces as 500). Empty
 //     subjectID returns ErrValidationFailed; an event value not declared in
 //     the CredentialEvent enum returns ErrValidationFailed. With valid
 //     arguments, returns nil even when the subject has no sessions; pre-
@@ -140,7 +145,7 @@ type Store interface {
 	Create(ctx context.Context, s *Session) error
 	Get(ctx context.Context, id string) (*ValidateView, error)
 	Revoke(ctx context.Context, id string) error
-	RevokeForSubject(ctx context.Context, subjectID string, event CredentialEvent) error
+	RevokeForSubject(ctx context.Context, subjectID string, event CredentialEvent, tok credentialfence.FenceToken) error
 	// RepoReady is a differentiated readiness check for the sessions relation.
 	// See Store godoc for full semantics.
 	RepoReady(ctx context.Context) error

--- a/runtime/auth/session/storetest/bench.go
+++ b/runtime/auth/session/storetest/bench.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -79,7 +80,7 @@ func benchRevokeForSubject(b *testing.B, factory BenchFactory, perRun int) {
 
 		b.ReportAllocs()
 		b.StartTimer()
-		err := store.RevokeForSubject(context.Background(), benchSubject, session.CredentialEventPasswordReset)
+		err := store.RevokeForSubject(context.Background(), benchSubject, session.CredentialEventPasswordReset, credentialfence.Mint())
 		b.StopTimer()
 		cleanup()
 

--- a/runtime/auth/session/storetest/suite.go
+++ b/runtime/auth/session/storetest/suite.go
@@ -144,6 +144,9 @@ func Run(t *testing.T, factory Factory, protocol *session.Protocol) {
 	t.Run("RevokeForSubject_UnknownEvent_Rejected", func(t *testing.T) {
 		runRevokeForSubjectUnknownEvent(t, factory)
 	})
+	t.Run("RevokeForSubject_NilFenceToken_Panics", func(t *testing.T) {
+		runRevokeForSubjectNilFenceToken(t, factory)
+	})
 
 	for _, event := range protocol.RevokeOn() {
 		event := event
@@ -331,6 +334,39 @@ func runRevokeForSubjectUnknownEvent(t *testing.T, factory Factory) {
 
 	err := store.RevokeForSubject(context.Background(), subjectA, session.CredentialEvent(99), credentialfence.Mint())
 	assertErrCode(t, err, errcode.ErrValidationFailed)
+}
+
+// runRevokeForSubjectNilFenceToken — Store contract: a nil FenceToken is a
+// programmer error that credentialfence.MustHave converts to a B-class panic
+// (*errcode.Error, KindInternal) whose message identifies the call site. Every
+// implementation (mem / PG / Redis decorator) must honor the guard — the shared
+// suite holds them all to it rather than relying on per-impl unit tests. The
+// MustHave check is the first statement of each impl, so the panic fires before
+// any backend I/O (PG runs this case under -tags=integration without a query).
+func runRevokeForSubjectNilFenceToken(t *testing.T, factory Factory) {
+	store, _, cleanup := factory(t)
+	defer cleanup()
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		// nil FenceToken is intentional — exercising the MustHave guard.
+		_ = store.RevokeForSubject(context.Background(), subjectA, session.CredentialEventPasswordReset, nil)
+	}()
+
+	if recovered == nil {
+		t.Fatal("nil FenceToken must trigger MustHave panic, got nil")
+	}
+	coded, ok := recovered.(*errcode.Error)
+	if !ok {
+		t.Fatalf("panic payload must be *errcode.Error, got %T: %v", recovered, recovered)
+	}
+	if coded.Kind != errcode.KindInternal {
+		t.Errorf("nil-token panic must carry KindInternal (Assertion), got %v", coded.Kind)
+	}
+	if !strings.Contains(coded.Message, "session.Store.RevokeForSubject") {
+		t.Errorf("panic message must identify call site, got %q", coded.Message)
+	}
 }
 
 // revokeForSubjectFixtures bundles the four session fixtures used by the

--- a/runtime/auth/session/storetest/suite.go
+++ b/runtime/auth/session/storetest/suite.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest" // test funnel; storetest is testing-helper package, errcodetest import is intentional (not a test-only import in a non-_test.go file)
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -316,7 +317,7 @@ func runRevokeForSubjectEmptySubject(t *testing.T, factory Factory) {
 	store, _, cleanup := factory(t)
 	defer cleanup()
 
-	err := store.RevokeForSubject(context.Background(), "", session.CredentialEventPasswordReset)
+	err := store.RevokeForSubject(context.Background(), "", session.CredentialEventPasswordReset, credentialfence.Mint())
 	assertErrCode(t, err, errcode.ErrValidationFailed)
 }
 
@@ -328,7 +329,7 @@ func runRevokeForSubjectUnknownEvent(t *testing.T, factory Factory) {
 	store, _, cleanup := factory(t)
 	defer cleanup()
 
-	err := store.RevokeForSubject(context.Background(), subjectA, session.CredentialEvent(99))
+	err := store.RevokeForSubject(context.Background(), subjectA, session.CredentialEvent(99), credentialfence.Mint())
 	assertErrCode(t, err, errcode.ErrValidationFailed)
 }
 
@@ -427,7 +428,7 @@ func runRevokeForSubject(t *testing.T, factory Factory, event session.Credential
 	fc.Advance(time.Minute) // ensure subsequent revoke would have a distinct timestamp
 	revokeAt := fc.Now()
 
-	if err := store.RevokeForSubject(context.Background(), subjectA, event); err != nil {
+	if err := store.RevokeForSubject(context.Background(), subjectA, event, credentialfence.Mint()); err != nil {
 		t.Fatalf("RevokeForSubject(%s, %s): %v", subjectA, event, err)
 	}
 

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -12,66 +12,75 @@ package archtest
 //
 // # AI-robust grade (post #1033)
 //
-// All four rules are Hard. UPSTREAM-CALLER-01's grade upgraded from
-// Medium to Hard once the sealed FenceToken capability proof (#1033)
-// closed the type-system half of the upstream funnel:
+// The credential-invalidation safety model rests on three mechanisms with
+// distinct enforcement layers — do not conflate them into one "Hard":
 //
-//  1. DOWNSTREAM (rules 1–3) — Hard via ResolveMethodCall call-site
-//     form-uniqueness. Any direct call to RevokeForSubject /
-//     BumpAuthzEpoch / RevokeUser outside the allowlisted paths
-//     resolves to the exact *types.Func identity and fails archtest.
-//     The honesty caveat (matching SESSIONREFRESH-NO-SESSION-CREATE-01):
-//     Go does not prevent the calls at compile time; enforcement is
-//     archtest-bound.
+//  1. DOWNSTREAM (rules 1–3) — Hard via call-site form-uniqueness, archtest-
+//     bound (NOT compile-time). scanFunnelViolationsPass is form-complete: it
+//     flags every reference to RevokeForSubject / BumpAuthzEpoch / RevokeUser
+//     outside the allowlist — direct call AND function-value capture alike —
+//     by resolving every SelectorExpr to the exact *types.Func identity. Go
+//     cannot express "only package X may call method Y", so this is the Hard
+//     ceiling the rule's shape can reach (same caveat as
+//     SESSIONREFRESH-NO-SESSION-CREATE-01 / the PANIC-REGISTERED-01 precedent).
 //
-//  2. UPSTREAM (rule 4) — Hard via the combined seal:
-//       (a) FenceToken interface seal: types declared outside
-//           runtime/auth/credentialfence cannot implement FenceToken
-//           (unexported isCredentialFenceToken marker method); the
-//           concrete fenceToken is itself unexported, so external
-//           composite literals cannot construct it. Compile-time
-//           guarantee.
-//       (b) FENCE-TOKEN-MINT-FUNNEL-01 archtest: credentialfence.Mint
-//           callers are locked to the credentialinvalidate funnel,
-//           storetest / conformance suites, and *_test.go files via
-//           ResolvePackageRef form-uniqueness. Combined with (a), no
-//           non-test production package outside the funnel can produce
-//           a FenceToken value.
-//       (c) Runtime nil-guard: credentialfence.MustHave at the top of
-//           every mutation impl converts the residual "pass nil" form
-//           into an immediate panic via panicregister.Approved +
-//           errcode.Assertion, surfaced as a 500. Closes the archtest
-//           blindspots (function-value capture / reflect.MethodByName)
-//           that the type-system seal alone cannot prevent.
+//  2. CONSTRUCTION SEAL — Hard, compile-time (Go type system). Types declared
+//     outside runtime/auth/credentialfence cannot implement FenceToken
+//     (unexported isCredentialFenceToken marker method); the concrete
+//     fenceToken is itself unexported, so external composite literals cannot
+//     construct it. This is the only genuinely compile-time guarantee here: a
+//     non-funnel package cannot fabricate a FenceToken, so to invoke a mutation
+//     method it must obtain one from Mint.
 //
-// See tools/archtest/fence_token_mint_funnel_test.go for the
-// FENCE-TOKEN-MINT-FUNNEL-01 godoc, and ADR
-// docs/architecture/202605101400-adr-credential-session-protocol.md §A16
-// for the closure proof and threat-matrix re-evaluation.
+//  3. Mint-CALLER FUNNEL — Hard via call-site form-uniqueness, archtest-bound
+//     (FENCE-TOKEN-MINT-FUNNEL-01). credentialfence.Mint references are locked
+//     to the credentialinvalidate funnel, storetest / conformance suites, and
+//     *_test.go files via a form-complete ResolvePackageRef scan. Combined with
+//     (2), no non-test production package outside the funnel can produce a
+//     FenceToken value.
 //
-// Scanning tool: ResolveMethodCall + EachInSubtree[ast.CallExpr].
-// Resolver scope: targeted package trees (not full module ./...) to keep RAM
-// bounded while still covering every non-test, non-store-impl call site.
+// Runtime nil-guard (NOT a static grade): credentialfence.MustHave at the top
+// of every mutation impl converts a literal `nil` argument — which compiles
+// and is therefore invisible to (1)/(3) — into an immediate panic
+// (panicregister.Approved + errcode.Assertion → 500). It is a defense-in-depth
+// backstop for the residual "pass nil" form; it does NOT elevate any static
+// grade, and the static Hard claims above stand on (1)+(2)+(3) alone.
+//
+// UPSTREAM-CALLER-01 (rule 4) upgraded Medium → Hard once (2)+(3) closed the
+// "missing caller" hole structurally (a new mutator cannot revoke without a
+// FenceToken it cannot mint). See tools/archtest/fence_token_mint_funnel_test.go
+// for the FENCE-TOKEN-MINT-FUNNEL-01 godoc, and ADR
+// docs/architecture/202605101400-adr-credential-session-protocol.md §A16 for
+// the closure proof and threat-matrix re-evaluation.
+//
+// Scanning tool: ResolveMethodCall + EachInSubtree[ast.SelectorExpr]. The scan
+// is form-complete — it resolves EVERY SelectorExpr (not only the Fun of a
+// CallExpr), so the direct call AND the function-value capture forms
+// (`fn := store.RevokeForSubject`, `var fn = store.RevokeForSubject`, return /
+// pass-through of the method value) all resolve to the same *types.Func and are
+// flagged. info.Selections records a MethodVal selection for a captured method
+// value even when it is not immediately invoked. Resolver scope: targeted
+// package trees (not full module ./...) to keep RAM bounded while still covering
+// every non-test, non-store-impl reference site.
 //
 // Blind-spot self-check (ai-robust.md §"工具选定后强制盲区自检"):
 //
 // ResolveMethodCall resolves `*ast.SelectorExpr` via info.Selections. Forms
 // NOT covered by this tool:
 //
-//  1. Function-value store + call: `fn := store.RevokeForSubject; fn(ctx, id, e)`
-//     The `fn(...)` CallExpr's Fun is *ast.Ident, not *ast.SelectorExpr, so
-//     info.Selections[sel] misses it. Captured by:
-//     TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment (asserts absence).
+//  1. reflect invoke: `reflect.ValueOf(store).MethodByName("RevokeForSubject").Call(...)`
+//     The method is named by string, so no SelectorExpr resolves to it — fully
+//     AST-invisible. Asserted absent by:
+//     TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName.
 //
-//  2. reflect invoke: `reflect.ValueOf(store).MethodByName("RevokeForSubject").Call(...)`
-//     Fully AST-invisible. Captured by:
-//     TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName (asserts absence).
+//  2. //go:linkname / unsafe — the universal class that defeats any static
+//     analysis; out of scope for an archtest funnel.
 //
-//  3. Embedded struct method promotion: `type Wrapper struct { session.Store };
-//     w.RevokeForSubject(...)` — receiver type resolves to Wrapper, not session.Store.
-//     ResolveMethodCall recovers the correct *types.Func via info.Selections, so
-//     this IS covered (embedded promotion is transparent to Selections.Obj()).
-//     Documented here for completeness; no separate self-check needed.
+// Covered without a separate self-check: embedded struct method promotion
+// (`type Wrapper struct { session.Store }; w.RevokeForSubject(...)`) —
+// ResolveMethodCall recovers the correct *types.Func via info.Selections, so
+// promotion is transparent. The function-value-capture form (formerly a
+// blind-spot self-check) is now caught directly by the form-complete scan.
 
 import (
 	"fmt"
@@ -266,11 +275,15 @@ func TestCredentialInvalidateFunnel_RevokeForSubject_01(t *testing.T) {
 
 	// RED fixture verification: the scanner must detect ≥ 1 violation in the
 	// rbacassign_direct_revoke_for_subject_red fixture package.
+	// wantMin=3: the fixture exercises three reference forms (direct call +
+	// short-var capture + var-decl capture). Requiring all three pins the
+	// form-completeness of the method-funnel scanner.
 	verifyRedFixtureDetectedPass(
 		t,
 		"./tools/archtest/testdata/credential_invalidate_fixtures/rbacassign_direct_revoke_for_subject_red",
 		sessionStorePkg, sessionRevokeMethod,
 		"CREDENTIAL-INVALIDATE-FUNNEL-01 RED fixture",
+		3,
 	)
 }
 
@@ -329,6 +342,7 @@ func TestCredentialInvalidateFunnel_BumpAuthzEpoch_01(t *testing.T) {
 		"./cells/accesscore/internal/credentialinvalidate/testdata/identitymanage_direct_bump_epoch_red",
 		userRepoPkg, userBumpMethod,
 		"USER-AUTHZ-EPOCH-BUMP-FUNNEL-01 RED fixture",
+		1,
 	)
 }
 
@@ -383,6 +397,7 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 		"./tools/archtest/testdata/credential_invalidate_fixtures/identitymanage_direct_revoke_refresh_red",
 		refreshStorePkg, refreshRevokeMethod,
 		"REFRESH-REVOKE-USER-FUNNEL-01 RED fixture",
+		1,
 	)
 }
 
@@ -465,69 +480,11 @@ func TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01(t *testing.T) {
 		"./cells/accesscore/internal/credentialinvalidate/testdata/sessionlogin_direct_apply_red",
 		invalidatorPkg, invalidatorMethod,
 		"CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 RED fixture",
+		1,
 	)
 }
 
 // ─── Blind-spot self-check tests ─────────────────────────────────────────
-
-// TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment asserts that the
-// function-value-assignment blind spot (e.g. `fn := store.RevokeForSubject; fn(...)`)
-// does NOT appear in production code. If it did, the scanner would miss it.
-// This inverts the blind-spot into a production-absence assertion so the rule
-// remains valid under the "blind spot is not present" premise.
-//
-// Scanner used: EachInSubtree[ast.AssignStmt] + right-hand-side SelectorExpr
-// name matching. This is an AST-only pattern check (not type-aware), but is
-// sufficient because the method names are distinct enough to avoid false
-// positives.
-func TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment(t *testing.T) {
-	t.Parallel()
-
-	bannedMethodNames := map[string]string{
-		"RevokeForSubject": "CREDENTIAL-INVALIDATE-FUNNEL-01",
-		"BumpAuthzEpoch":   "USER-AUTHZ-EPOCH-BUMP-FUNNEL-01",
-		"RevokeUser":       "REFRESH-REVOKE-USER-FUNNEL-01",
-	}
-
-	var violations []string
-	// Load production code (no tests).
-	_ = RunTyped(t, TypedOpts{Tests: false},
-		[]string{"./cells/accesscore/...", "./runtime/auth/...", "./adapters/...", "./cmd/..."},
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			for _, file := range p.Files {
-				rel := p.Rel(file)
-				if strings.HasSuffix(rel, "_test.go") {
-					continue
-				}
-				if isAllowlisted(rel) {
-					continue
-				}
-				EachInSubtree[ast.AssignStmt](file, func(assign *ast.AssignStmt) {
-					EachInChildren[ast.SelectorExpr](assign, func(sel *ast.SelectorExpr) {
-						if rule, banned := bannedMethodNames[sel.Sel.Name]; banned {
-							line := p.Fset.Position(assign.Pos()).Line
-							violations = append(violations, fmt.Sprintf(
-								"%s:%d: %s function-value assignment blind spot detected (%s)",
-								rel, line, sel.Sel.Name, rule,
-							))
-						}
-					})
-				})
-			}
-			return nil
-		})
-
-	sort.Strings(violations)
-	for _, v := range violations {
-		t.Log(v)
-	}
-	assert.Empty(t, violations,
-		"funnel blind-spot: function-value assignment of banned methods found in production code — "+
-			"the archtest would miss these calls. Refactor to call credentialinvalidate.Invalidator.Apply directly.")
-}
 
 // TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName asserts that
 // reflect.Value.MethodByName("RevokeForSubject") / ("BumpAuthzEpoch") /
@@ -594,13 +551,25 @@ func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) 
 
 // ─── shared helpers ──────────────────────────────────────────────────────
 
-// scanFunnelViolationsPass walks a single file's AST for CallExpr nodes where
-// the method receiver resolves to the interface at (targetPkg, targetMethod).
-// It returns a slice of violation strings for any call found.
+// scanFunnelViolationsPass walks a single file's AST for EVERY SelectorExpr
+// that resolves to the method (targetPkg, targetMethod) — regardless of whether
+// it is the Fun of a CallExpr. It returns a violation string for each. Walking
+// all selectors (not just call.Fun) makes the scan form-complete: it catches
+// the direct call (`store.RevokeForSubject(...)`) AND the function-value
+// capture forms (`fn := store.RevokeForSubject`, `var fn = store.RevokeForSubject`,
+// `return store.RevokeForSubject`, pass-through as an argument) that a
+// CallExpr-only scan misses (the later `fn(...)` has Fun = *ast.Ident, invisible
+// to ResolveMethodCall). info.Selections records a MethodVal selection for a
+// method value even when it is not immediately invoked, so ResolveMethodCall
+// resolves the capture forms to the same *types.Func identity.
 //
-// Receiver type check: we verify fn.Pkg().Path() == targetPkg AND that the
-// Selection receiver is the named interface type. This is the same pattern as
-// in sessionrefresh_no_session_create_test.go (which guards session.Store methods).
+// The `sel.Sel.Name != targetMethod` pre-filter keeps ResolveMethodCall off the
+// hot path for unrelated selectors. Receiver type check: fn.Pkg().Path() ==
+// targetPkg (same identity pattern as sessionrefresh_no_session_create_test.go).
+//
+// Residual blindspot (asserted absent by TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName):
+// reflect.Value.MethodByName("RevokeForSubject") names the method by string, so
+// no SelectorExpr resolves to it. //go:linkname / unsafe are the universal class.
 func scanFunnelViolationsPass(
 	p *Pass,
 	file *ast.File,
@@ -608,12 +577,8 @@ func scanFunnelViolationsPass(
 	targetPkg, targetMethod, ruleID string,
 ) []string {
 	var out []string
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil {
-			return
-		}
-		if sel.Sel.Name != targetMethod {
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != targetMethod {
 			return
 		}
 		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
@@ -623,29 +588,34 @@ func scanFunnelViolationsPass(
 		if fn.Pkg() == nil || fn.Pkg().Path() != targetPkg {
 			return
 		}
-		line := p.Fset.Position(call.Pos()).Line
+		line := p.Fset.Position(sel.Pos()).Line
 		out = append(out, fmt.Sprintf(
-			"%s:%d: %s: direct call to %s.%s bypasses credentialinvalidate funnel",
+			"%s:%d: %s: reference to %s.%s outside credentialinvalidate funnel "+
+				"(direct call or function-value capture)",
 			rel, line, ruleID, filepath.Base(targetPkg), targetMethod,
 		))
 	})
 	return out
 }
 
-// verifyRedFixtureDetectedPass loads the given fixture pattern via RunTyped
-// and asserts that the scanner finds ≥ 1 violation — proving the rule is
-// not permanently GREEN. This is the "反向 RED 自检" (reverse RED self-check)
-// mandated by ai-robust.md.
+// verifyRedFixtureDetectedPass loads the given fixture pattern via RunTyped and
+// asserts the scanner finds ≥ wantMin violations — proving the rule is not
+// permanently GREEN. This is the "反向 RED 自检" (reverse RED self-check)
+// mandated by ai-robust.md. wantMin is the number of distinct banned-method
+// reference forms in the fixture; for fixtures that also exercise function-value
+// capture (rbacassign_direct_revoke_for_subject_red), wantMin > 1 pins
+// form-completeness — a CallExpr-only scan would catch only the direct call and
+// fall short here.
 //
-// Fixture load failure is a hard fail: the previous silent t.Logf+return
-// masked archtest regressions — a fixture that stops type-checking would
-// silently disable the RED self-check, leaving the production scan
-// permanently GREEN with no warning. The fixture is in-tree and its build
-// health is part of the archtest contract, so a load failure must fail the
-// test and surface in CI.
+// Fixture load failure is a hard fail: the previous silent t.Logf+return masked
+// archtest regressions — a fixture that stops type-checking would silently
+// disable the RED self-check, leaving the production scan permanently GREEN with
+// no warning. The fixture is in-tree and its build health is part of the
+// archtest contract, so a load failure must fail the test and surface in CI.
 func verifyRedFixtureDetectedPass(
 	t *testing.T,
 	fixturePattern, targetPkg, targetMethod, label string,
+	wantMin int,
 ) {
 	t.Helper()
 
@@ -660,9 +630,11 @@ func verifyRedFixtureDetectedPass(
 		return nil
 	})
 	_ = diags
-	require.GreaterOrEqual(t, found, 1,
-		"RED fixture self-check FAILED: %s — expected ≥ 1 violation, got 0. "+
-			"This means the production scanner is permanently GREEN and would miss real violations. "+
-			"Check that the fixture file actually calls the banned method and is type-checkable.",
-		label)
+	require.GreaterOrEqual(t, found, wantMin,
+		"RED fixture self-check FAILED: %s — expected ≥ %d violations, got %d. "+
+			"A shortfall means the scanner is NOT form-complete (e.g. it only catches "+
+			"direct calls and misses function-value capture), so a non-funnel package "+
+			"could bypass the funnel undetected. Check scanFunnelViolationsPass walks "+
+			"all SelectorExpr, and that the fixture is type-checkable.",
+		label, wantMin, found)
 }

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -10,21 +10,44 @@ package archtest
 // INVARIANT: REFRESH-REVOKE-USER-FUNNEL-01
 // INVARIANT: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01
 //
-// S4d note (upstream rule): UPSTREAM-CALLER-01 is graded Medium —
-// `Invalidator.Apply`'s caller set is enforced by archtest, but the rule
-// catches "wrong call site" (the existing P1 patches handle the "missing
-// call site" hole at the identitymanage entry). Promoting to Hard requires
-// privatizing domain.User authz fields + sealed Mutation funnel; tracked
-// via domain.User authz field privatization and a sealed Mutation funnel.
+// # AI-robust grade (post #1033)
 //
-// AI-robust grade: Hard (closed-caller-set enforced via ResolveMethodCall;
-// form uniqueness = "call resolves to this exact *types.Func identity" — no gray zone).
+// All four rules are Hard. UPSTREAM-CALLER-01's grade upgraded from
+// Medium to Hard once the sealed FenceToken capability proof (#1033)
+// closed the type-system half of the upstream funnel:
 //
-// Hard property: any direct call to session.Store.RevokeForSubject /
-// ports.UserRepository.BumpAuthzEpoch / refresh.Store.RevokeUser outside the
-// credentialinvalidate funnel causes archtest to fail in CI.
-// The honesty caveat (matching SESSIONREFRESH-NO-SESSION-CREATE-01):
-// Go does not prevent the calls at compile time; enforcement is archtest-bound.
+//  1. DOWNSTREAM (rules 1–3) — Hard via ResolveMethodCall call-site
+//     form-uniqueness. Any direct call to RevokeForSubject /
+//     BumpAuthzEpoch / RevokeUser outside the allowlisted paths
+//     resolves to the exact *types.Func identity and fails archtest.
+//     The honesty caveat (matching SESSIONREFRESH-NO-SESSION-CREATE-01):
+//     Go does not prevent the calls at compile time; enforcement is
+//     archtest-bound.
+//
+//  2. UPSTREAM (rule 4) — Hard via the combined seal:
+//       (a) FenceToken interface seal: types declared outside
+//           runtime/auth/credentialfence cannot implement FenceToken
+//           (unexported isCredentialFenceToken marker method); the
+//           concrete fenceToken is itself unexported, so external
+//           composite literals cannot construct it. Compile-time
+//           guarantee.
+//       (b) FENCE-TOKEN-MINT-FUNNEL-01 archtest: credentialfence.Mint
+//           callers are locked to the credentialinvalidate funnel,
+//           storetest / conformance suites, and *_test.go files via
+//           ResolvePackageRef form-uniqueness. Combined with (a), no
+//           non-test production package outside the funnel can produce
+//           a FenceToken value.
+//       (c) Runtime nil-guard: credentialfence.MustHave at the top of
+//           every mutation impl converts the residual "pass nil" form
+//           into an immediate panic via panicregister.Approved +
+//           errcode.Assertion, surfaced as a 500. Closes the archtest
+//           blindspots (function-value capture / reflect.MethodByName)
+//           that the type-system seal alone cannot prevent.
+//
+// See tools/archtest/fence_token_mint_funnel_test.go for the
+// FENCE-TOKEN-MINT-FUNNEL-01 godoc, and ADR
+// docs/architecture/202605101400-adr-credential-session-protocol.md §A16
+// for the closure proof and threat-matrix re-evaluation.
 //
 // Scanning tool: ResolveMethodCall + EachInSubtree[ast.CallExpr].
 // Resolver scope: targeted package trees (not full module ./...) to keep RAM
@@ -363,7 +386,7 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 	)
 }
 
-// ─── Rule 4: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (S4d, Medium) ─────
+// ─── Rule 4: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (Hard, post #1033) ──
 
 // TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01 enforces
 // CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: every call to
@@ -373,13 +396,21 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 // itself. New callers must justify their addition via a PR that updates
 // upstreamCallerAllowlistPrefixes — this puts the funnel's surface area on
 // the reviewer's radar instead of relying on string convention.
-// See ADR §A10 for the canonical allowlist and co-tx atomicity rationale.
+// See ADR §A10 + §A16 for the canonical allowlist and co-tx atomicity
+// rationale, and the type-system seal that brings this rule to Hard.
 //
-// AI-robust grade: Medium. The rule catches "wrong caller" (cells outside
-// the allowlist invoking Apply directly) but NOT "missing caller" (a new
-// user-authz mutator forgetting to call Apply at all). The latter is what
-// P1-#1 in PR #490 review was — fixed in this PR by the identitymanage
-// service.go change.
+// AI-robust grade (post #1033): Hard. The rule's call-site allowlist
+// catches "wrong caller" (cells outside the allowlist invoking Apply
+// directly). The "missing caller" problem — a new user-authz mutator
+// forgetting to call Apply at all — is now closed structurally by the
+// sealed FenceToken capability proof: any mutation method (BumpAuthzEpoch
+// / RevokeForSubject / RevokeUser) requires a credentialfence.FenceToken
+// that only credentialfence.Mint can produce, and Mint's callers are
+// locked by FENCE-TOKEN-MINT-FUNNEL-01 to the funnel + storetest +
+// conformance + *_test.go. A new mutator that tries to revoke without
+// going through Invalidator.Apply cannot mint a FenceToken — production
+// archtest fails. See the package godoc and ADR §A16 for the full
+// closure proof.
 //
 // RED fixture: tools/archtest/testdata/credential_invalidate_fixtures/
 // sessionlogin_direct_apply_red — the sessionlogin slice is NOT on the

--- a/tools/archtest/fence_token_mint_funnel_test.go
+++ b/tools/archtest/fence_token_mint_funnel_test.go
@@ -163,10 +163,15 @@ func TestFenceTokenMintFunnel_AllowlistEnforced(t *testing.T) {
 // blindspot self-check for function-value capture: `fn := credentialfence.Mint;
 // fn()`. The right-hand side of the assignment is a *ast.SelectorExpr whose
 // Sel is "Mint", but the subsequent CallExpr has Fun = *ast.Ident, which
-// ResolveMethodCall cannot match against credentialfence.Mint. This test
+// ResolvePackageRef cannot match against credentialfence.Mint. This test
 // asserts the form does NOT appear in production code, keeping the
 // FENCE-TOKEN-MINT-FUNNEL-01 rule complete under the "blindspot is absent"
 // premise.
+//
+// Detection is alias-immune: the AssignStmt RHS SelectorExpr is resolved via
+// ResolvePackageRef (types.Info.Uses), which returns the canonical package
+// path regardless of any import alias (e.g. `import cf "...credentialfence"`).
+// Name-based xIdent.Name == "credentialfence" matching is NOT used here.
 //
 // Mirrors TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment in
 // credential_invalidate_funnel_invariants_test.go.
@@ -179,7 +184,7 @@ func TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment(t *testing.T) {
 
 	var violations []string
 	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
-		if p.Pkg == nil {
+		if p.Pkg == nil || p.TypesInfo == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -195,10 +200,14 @@ func TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment(t *testing.T) {
 					if sel.Sel.Name != fenceTokenMintFunc {
 						return
 					}
-					// Require sel.X == "credentialfence" identifier to reduce
-					// false positives from same-name methods on unrelated types.
-					xIdent, ok := sel.X.(*ast.Ident)
-					if !ok || xIdent.Name != "credentialfence" {
+					// Use ResolvePackageRef to resolve via types.Info.Uses to the
+					// canonical package path — immune to import aliases such as
+					// `import cf "...credentialfence"`.
+					pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, sel)
+					if !ok {
+						return
+					}
+					if pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
 						return
 					}
 					line := p.Fset.Position(assign.Pos()).Line
@@ -226,7 +235,15 @@ func TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment(t *testing.T) {
 // TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation is the reverse
 // blindspot self-check for reflect-based invocation. Production code must
 // never use reflect.ValueOf to fetch / call Mint — such forms are
-// AST-invisible to ResolveMethodCall. Asserts the form is absent.
+// AST-invisible to the main A1 ResolvePackageRef scanner. Asserts the form
+// is absent.
+//
+// Detection for the inner argument is alias-immune: the credentialfence.Mint
+// SelectorExpr passed as reflect.ValueOf's argument is resolved via
+// ResolvePackageRef (types.Info.Uses) to the canonical package path, not via
+// the local identifier name. The outer reflect.ValueOf identification uses
+// name-based matching ("reflect"/"ValueOf") which is safe because reflect is
+// a stdlib package that is never aliased in this codebase.
 //
 // Mirrors TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName.
 func TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation(t *testing.T) {
@@ -238,7 +255,7 @@ func TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation(t *testing.T) {
 
 	var violations []string
 	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
-		if p.Pkg == nil {
+		if p.Pkg == nil || p.TypesInfo == nil {
 			return nil
 		}
 		for _, file := range p.Files {
@@ -253,6 +270,8 @@ func TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation(t *testing.T) {
 				}
 				// reflect.ValueOf(credentialfence.Mint) — argument is the
 				// SelectorExpr we care about.
+				// Outer reflect.ValueOf identification is name-based (reflect is
+				// stdlib, never aliased in this codebase).
 				if sel.Sel.Name != "ValueOf" || len(call.Args) != 1 {
 					return
 				}
@@ -264,11 +283,13 @@ func TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation(t *testing.T) {
 				if !ok {
 					return
 				}
-				argIdent, ok := argSel.X.(*ast.Ident)
-				if !ok || argIdent.Name != "credentialfence" {
+				// Use ResolvePackageRef on the inner argument SelectorExpr to
+				// resolve via types.Info.Uses — alias-immune.
+				pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, argSel)
+				if !ok {
 					return
 				}
-				if argSel.Sel.Name != fenceTokenMintFunc {
+				if pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
 					return
 				}
 				line := p.Fset.Position(call.Pos()).Line

--- a/tools/archtest/fence_token_mint_funnel_test.go
+++ b/tools/archtest/fence_token_mint_funnel_test.go
@@ -1,0 +1,345 @@
+package archtest
+
+// fence_token_mint_funnel_test.go — caller-allowlist funnel for
+// credentialfence.Mint. Closes the upstream half of the credential-invalidate
+// funnel: combined with the Go type system seal (FenceToken interface has an
+// unexported isCredentialFenceToken marker method, so no external type can
+// implement it) and the runtime nil-guard in the three mutation methods, this
+// archtest yields upstream Hard via call-site form-uniqueness — the
+// .claude/rules/gocell/ai-robust.md §Hard 范本目录 "typed marker funnel for
+// unbounded ops" pattern.
+//
+// INVARIANT: FENCE-TOKEN-MINT-FUNNEL-01
+//
+// Rule: every non-test caller of credentialfence.Mint must live in one of the
+// allowlisted production paths (the credentialinvalidate funnel + storetest /
+// conformance suites). Any other caller is a violation: production code that
+// is not the funnel must not be able to construct a FenceToken.
+//
+// AI-robust grade: Hard (closed caller set enforced via ResolvePackageRef
+// form-uniqueness; A1 resolves the SelectorExpr X to a *types.PkgName and
+// requires (pkgPath, name) == (credentialfence, Mint); A2/A3 blindspot
+// self-checks reject function-value capture and reflect invocations).
+//
+// Companion archtests (the downstream half of the same funnel):
+//   - CREDENTIAL-INVALIDATE-FUNNEL-01    — RevokeForSubject caller allowlist
+//   - USER-AUTHZ-EPOCH-BUMP-FUNNEL-01    — BumpAuthzEpoch caller allowlist
+//   - REFRESH-REVOKE-USER-FUNNEL-01      — RevokeUser caller allowlist
+//   - CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 — Invalidator.Apply caller allowlist
+//
+// Together these four rules (downstream Hard) plus this rule (upstream Hard)
+// fully close the credential-invalidation safety model. See ADR
+// docs/architecture/202605101400-adr-credential-session-protocol.md §A16
+// for the closure proof and threat-matrix re-evaluation.
+
+import (
+	"fmt"
+	"go/ast"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mint funnel target. The pkg path constant is annotated with nolint:gosec
+// because gosec G101 flags strings containing "credential" as potential
+// hardcoded secrets; this is an import path used for type identity, not a
+// credential value.
+const (
+	//nolint:gosec // G101 false positive: import path, not a credential
+	fenceTokenPkgPath  = "github.com/ghbvf/gocell/runtime/auth/credentialfence"
+	fenceTokenMintFunc = "Mint"
+)
+
+// fenceTokenMintAllowlistPrefixes lists the module-relative path prefixes
+// permitted to call credentialfence.Mint in non-test production code.
+//
+//   - cells/accesscore/internal/credentialinvalidate/ — the production
+//     funnel; Invalidator.Apply is the only call site that constructs a
+//     FenceToken in real traffic.
+//   - runtime/auth/session/storetest/, runtime/auth/refresh/storetest/,
+//     cells/accesscore/internal/ports/conformance/ — conformance suites that
+//     must exercise the contract end-to-end; they need real FenceTokens to
+//     call the mutation methods.
+//
+// _test.go files in any path are also allowed (see isFenceTokenMintAllowlisted).
+//
+// Mirrors the credential_invalidate_funnel_invariants_test.go allowlist
+// philosophy: keep the set tight; any new caller is a code-review event that
+// must add a path here. The reviewer's question — "should this package own a
+// FenceToken?" — is the point.
+var fenceTokenMintAllowlistPrefixes = []string{
+	"cells/accesscore/internal/credentialinvalidate/",
+	"runtime/auth/session/storetest/",
+	"runtime/auth/refresh/storetest/",
+	"cells/accesscore/internal/ports/conformance/",
+}
+
+// isFenceTokenMintAllowlisted reports whether rel is a permitted Mint caller.
+// Test files (*_test.go) always pass — unit tests for stores, slice handlers,
+// and integration suites legitimately need FenceTokens to drive call paths.
+func isFenceTokenMintAllowlisted(rel string) bool {
+	if strings.HasSuffix(rel, "_test.go") {
+		return true
+	}
+	for _, prefix := range fenceTokenMintAllowlistPrefixes {
+		if strings.HasPrefix(rel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFenceTokenMintFunnel_AllowlistEnforced enforces FENCE-TOKEN-MINT-FUNNEL-01.
+//
+// Every call to credentialfence.Mint outside an allowlisted path is a
+// violation. Combined with the upstream type-system seal (unexported marker
+// method on FenceToken) the only way to construct a non-nil FenceToken is
+// through Mint; constraining Mint's callers therefore constrains every
+// non-nil FenceToken's origin.
+//
+// Scanner: ResolvePackageRef + EachInSubtree[ast.CallExpr]. credentialfence.Mint
+// is a package-level function (not a method), so its reference is recorded
+// in types.Info.Uses as a (PkgName, FuncName) pair — ResolveMethodCall would
+// silently miss it (Selections only holds method selectors). The resolver
+// returns the (pkgPath, name) tuple; we accept the call only when
+// pkgPath == credentialfence package path and name == "Mint" — exact
+// identity, no name-collision possible across packages.
+//
+// RED fixture verification: testdata/fence_token_fixtures/external_mint_red/
+// is loaded separately and the scanner must detect ≥ 1 violation, proving
+// the rule is not a permanently-passing no-op (the reverse RED self-check
+// mandated by ai-robust.md §"工具选定后强制盲区自检").
+func TestFenceTokenMintFunnel_AllowlistEnforced(t *testing.T) {
+	t.Parallel()
+
+	// Scan production trees that could plausibly call Mint. examples/ and
+	// cmd/ are included so a stray demo or composition root that fishes a
+	// FenceToken on its own is caught.
+	patterns := []string{
+		"./cells/...",
+		"./runtime/...",
+		"./adapters/...",
+		"./cmd/...",
+		"./examples/...",
+	}
+
+	var violations []string
+	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if isFenceTokenMintAllowlisted(rel) {
+				continue
+			}
+			violations = append(violations, scanFenceTokenMintViolations(p, file, rel)...)
+		}
+		return nil
+	})
+
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Log(v)
+	}
+	assert.Empty(t, violations,
+		"FENCE-TOKEN-MINT-FUNNEL-01: credentialfence.Mint must only be called "+
+			"from the credentialinvalidate funnel, storetest/conformance suites, "+
+			"or *_test.go files. New callers require updating "+
+			"fenceTokenMintAllowlistPrefixes — every addition is a review event "+
+			"about whether this package should own a FenceToken at all.")
+
+	// Reverse RED self-check: the scanner must catch the bypass attempt in
+	// the external_mint_red fixture (calls Mint from a non-allowlisted path).
+	verifyFenceTokenMintRedFixture(t,
+		"./tools/archtest/testdata/fence_token_fixtures/external_mint_red",
+		"FENCE-TOKEN-MINT-FUNNEL-01 RED fixture")
+}
+
+// TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment is the reverse
+// blindspot self-check for function-value capture: `fn := credentialfence.Mint;
+// fn()`. The right-hand side of the assignment is a *ast.SelectorExpr whose
+// Sel is "Mint", but the subsequent CallExpr has Fun = *ast.Ident, which
+// ResolveMethodCall cannot match against credentialfence.Mint. This test
+// asserts the form does NOT appear in production code, keeping the
+// FENCE-TOKEN-MINT-FUNNEL-01 rule complete under the "blindspot is absent"
+// premise.
+//
+// Mirrors TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment in
+// credential_invalidate_funnel_invariants_test.go.
+func TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment(t *testing.T) {
+	t.Parallel()
+
+	patterns := []string{
+		"./cells/...", "./runtime/...", "./adapters/...", "./cmd/...", "./examples/...",
+	}
+
+	var violations []string
+	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			if isFenceTokenMintAllowlisted(rel) {
+				continue
+			}
+			EachInSubtree[ast.AssignStmt](file, func(assign *ast.AssignStmt) {
+				EachInChildren[ast.SelectorExpr](assign, func(sel *ast.SelectorExpr) {
+					if sel.Sel.Name != fenceTokenMintFunc {
+						return
+					}
+					// Require sel.X == "credentialfence" identifier to reduce
+					// false positives from same-name methods on unrelated types.
+					xIdent, ok := sel.X.(*ast.Ident)
+					if !ok || xIdent.Name != "credentialfence" {
+						return
+					}
+					line := p.Fset.Position(assign.Pos()).Line
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: credentialfence.Mint function-value assignment blind spot detected "+
+							"(FENCE-TOKEN-MINT-FUNNEL-01)",
+						rel, line,
+					))
+				})
+			})
+		}
+		return nil
+	})
+
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Log(v)
+	}
+	assert.Empty(t, violations,
+		"FENCE-TOKEN-MINT-FUNNEL-01 blind-spot: function-value assignment of "+
+			"credentialfence.Mint found in production code — the archtest would "+
+			"miss subsequent invocations. Inline the call at the funnel site.")
+}
+
+// TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation is the reverse
+// blindspot self-check for reflect-based invocation. Production code must
+// never use reflect.ValueOf to fetch / call Mint — such forms are
+// AST-invisible to ResolveMethodCall. Asserts the form is absent.
+//
+// Mirrors TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName.
+func TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation(t *testing.T) {
+	t.Parallel()
+
+	patterns := []string{
+		"./cells/...", "./runtime/...", "./adapters/...", "./cmd/...", "./examples/...",
+	}
+
+	var violations []string
+	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
+				// reflect.ValueOf(credentialfence.Mint) — argument is the
+				// SelectorExpr we care about.
+				if sel.Sel.Name != "ValueOf" || len(call.Args) != 1 {
+					return
+				}
+				xIdent, ok := sel.X.(*ast.Ident)
+				if !ok || xIdent.Name != "reflect" {
+					return
+				}
+				argSel, ok := call.Args[0].(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
+				argIdent, ok := argSel.X.(*ast.Ident)
+				if !ok || argIdent.Name != "credentialfence" {
+					return
+				}
+				if argSel.Sel.Name != fenceTokenMintFunc {
+					return
+				}
+				line := p.Fset.Position(call.Pos()).Line
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: reflect.ValueOf(credentialfence.Mint) blind spot detected "+
+						"(FENCE-TOKEN-MINT-FUNNEL-01)",
+					rel, line,
+				))
+			})
+		}
+		return nil
+	})
+
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Log(v)
+	}
+	assert.Empty(t, violations,
+		"FENCE-TOKEN-MINT-FUNNEL-01 blind-spot: reflect.ValueOf(credentialfence.Mint) "+
+			"found in production code — the archtest cannot see reflect-based invocations.")
+}
+
+// scanFenceTokenMintViolations returns violation strings for every CallExpr
+// in file whose callee resolves to credentialfence.Mint.
+//
+// Resolution: credentialfence.Mint is a package-level function (not a
+// method), so its qualified reference lives in types.Info.Uses, not in
+// Selections. ResolvePackageRef walks the SelectorExpr (X is a PkgName,
+// Sel is the function name) and returns the (pkgPath, name) tuple.
+// ResolveMethodCall would silently miss this — it only resolves method
+// selections.
+func scanFenceTokenMintViolations(p *Pass, file *ast.File, rel string) []string {
+	var out []string
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+		if !ok {
+			return
+		}
+		if pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
+			return
+		}
+		line := p.Fset.Position(call.Pos()).Line
+		out = append(out, fmt.Sprintf(
+			"%s:%d: FENCE-TOKEN-MINT-FUNNEL-01: direct call to credentialfence.Mint "+
+				"bypasses the credentialinvalidate funnel",
+			rel, line,
+		))
+	})
+	return out
+}
+
+// verifyFenceTokenMintRedFixture loads the RED fixture and asserts the
+// scanner detects at least one violation. Mirrors verifyRedFixtureDetectedPass
+// in credential_invalidate_funnel_invariants_test.go.
+func verifyFenceTokenMintRedFixture(t *testing.T, fixturePattern, label string) {
+	t.Helper()
+
+	var found int
+	_ = RunTyped(t, TypedOpts{Tests: false}, []string{fixturePattern}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			found += len(scanFenceTokenMintViolations(p, file, label))
+		}
+		return nil
+	})
+	require.GreaterOrEqual(t, found, 1,
+		"RED fixture self-check FAILED: %s — expected ≥ 1 violation, got 0. "+
+			"The production scanner would be permanently GREEN and miss real "+
+			"violations. Check that the fixture file actually calls "+
+			"credentialfence.Mint and is type-checkable.",
+		label)
+}

--- a/tools/archtest/fence_token_mint_funnel_test.go
+++ b/tools/archtest/fence_token_mint_funnel_test.go
@@ -16,10 +16,23 @@ package archtest
 // conformance suites). Any other caller is a violation: production code that
 // is not the funnel must not be able to construct a FenceToken.
 //
-// AI-robust grade: Hard (closed caller set enforced via ResolvePackageRef
-// form-uniqueness; A1 resolves the SelectorExpr X to a *types.PkgName and
-// requires (pkgPath, name) == (credentialfence, Mint); A2/A3 blindspot
-// self-checks reject function-value capture and reflect invocations).
+// AI-robust grade (Mint-caller dimension): Hard via call-site form-uniqueness
+// per ai-robust.md §Hard 范本目录 "typed marker funnel for unbounded ops".
+// The scanner is form-complete: it flags EVERY reference to credentialfence.Mint
+// (direct call, var-decl / short-var function-value capture, return, pass-through
+// arg, reflect arg) by walking all SelectorExpr and resolving each via
+// ResolvePackageRef (alias-immune). Because credentialfence is type-sealed, a
+// reference to Mint is the only way to obtain a FenceToken, so flagging every
+// reference closes the function-value-capture and reflect blindspots
+// structurally — there is no separate per-form blindspot self-check to keep in
+// sync. Residual blindspots (dot-import, //go:linkname, unsafe) are the
+// universal class that defeats any static analysis; see scanFenceTokenMintRefs.
+//
+// Grade caveat: enforcement is archtest-bound, not compile-time. Go cannot
+// express "only package X may call function Y", so this is the Hard ceiling the
+// rule's shape can reach (the PANIC-REGISTERED-01 precedent). The type-system
+// Hard guarantee is the *construction* seal (external packages cannot implement
+// FenceToken nor build the unexported impl); see runtime/auth/credentialfence.
 //
 // Companion archtests (the downstream half of the same funnel):
 //   - CREDENTIAL-INVALIDATE-FUNNEL-01    — RevokeForSubject caller allowlist
@@ -94,24 +107,27 @@ func isFenceTokenMintAllowlisted(rel string) bool {
 
 // TestFenceTokenMintFunnel_AllowlistEnforced enforces FENCE-TOKEN-MINT-FUNNEL-01.
 //
-// Every call to credentialfence.Mint outside an allowlisted path is a
-// violation. Combined with the upstream type-system seal (unexported marker
-// method on FenceToken) the only way to construct a non-nil FenceToken is
-// through Mint; constraining Mint's callers therefore constrains every
-// non-nil FenceToken's origin.
+// Every reference to credentialfence.Mint outside an allowlisted path is a
+// violation — not just a direct call, but any function-value capture or
+// reflect arg as well (see scanFenceTokenMintRefs for the form-complete scan).
+// Combined with the upstream type-system seal (unexported marker method on
+// FenceToken) the only way to obtain a non-nil FenceToken is through Mint;
+// constraining every reference to Mint therefore constrains every non-nil
+// FenceToken's origin.
 //
-// Scanner: ResolvePackageRef + EachInSubtree[ast.CallExpr]. credentialfence.Mint
-// is a package-level function (not a method), so its reference is recorded
-// in types.Info.Uses as a (PkgName, FuncName) pair — ResolveMethodCall would
+// Scanner: ResolvePackageRef + EachInSubtree[ast.SelectorExpr]. credentialfence.Mint
+// is a package-level function (not a method), so its reference is recorded in
+// types.Info.Uses as a (PkgName, FuncName) pair — ResolveMethodCall would
 // silently miss it (Selections only holds method selectors). The resolver
-// returns the (pkgPath, name) tuple; we accept the call only when
-// pkgPath == credentialfence package path and name == "Mint" — exact
-// identity, no name-collision possible across packages.
+// returns the (pkgPath, name) tuple; a selector is a violation only when
+// pkgPath == credentialfence package path and name == "Mint" — exact identity,
+// no name-collision possible across packages, alias-immune.
 //
 // RED fixture verification: testdata/fence_token_fixtures/external_mint_red/
-// is loaded separately and the scanner must detect ≥ 1 violation, proving
-// the rule is not a permanently-passing no-op (the reverse RED self-check
-// mandated by ai-robust.md §"工具选定后强制盲区自检").
+// is loaded separately and the scanner must detect all five reference forms
+// (wantMin=5), proving the rule is form-complete and not a permanently-passing
+// no-op (the reverse RED self-check mandated by
+// ai-robust.md §"工具选定后强制盲区自检").
 func TestFenceTokenMintFunnel_AllowlistEnforced(t *testing.T) {
 	t.Parallel()
 
@@ -136,7 +152,7 @@ func TestFenceTokenMintFunnel_AllowlistEnforced(t *testing.T) {
 			if isFenceTokenMintAllowlisted(rel) {
 				continue
 			}
-			violations = append(violations, scanFenceTokenMintViolations(p, file, rel)...)
+			violations = append(violations, scanFenceTokenMintRefs(p, file, rel)...)
 		}
 		return nil
 	})
@@ -146,205 +162,78 @@ func TestFenceTokenMintFunnel_AllowlistEnforced(t *testing.T) {
 		t.Log(v)
 	}
 	assert.Empty(t, violations,
-		"FENCE-TOKEN-MINT-FUNNEL-01: credentialfence.Mint must only be called "+
+		"FENCE-TOKEN-MINT-FUNNEL-01: credentialfence.Mint must only be referenced "+
 			"from the credentialinvalidate funnel, storetest/conformance suites, "+
 			"or *_test.go files. New callers require updating "+
 			"fenceTokenMintAllowlistPrefixes — every addition is a review event "+
 			"about whether this package should own a FenceToken at all.")
 
-	// Reverse RED self-check: the scanner must catch the bypass attempt in
-	// the external_mint_red fixture (calls Mint from a non-allowlisted path).
+	// Reverse RED self-check: the scanner must catch all five reference forms
+	// (call / var-decl capture / short-var capture / pass-through arg /
+	// reflect arg) in the external_mint_red fixture. wantMin=5 pins
+	// form-completeness — a CallExpr-only scanner would catch only the single
+	// direct call and fail here.
 	verifyFenceTokenMintRedFixture(t,
 		"./tools/archtest/testdata/fence_token_fixtures/external_mint_red",
-		"FENCE-TOKEN-MINT-FUNNEL-01 RED fixture")
+		"FENCE-TOKEN-MINT-FUNNEL-01 RED fixture", 5)
 }
 
-// TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment is the reverse
-// blindspot self-check for function-value capture: `fn := credentialfence.Mint;
-// fn()`. The right-hand side of the assignment is a *ast.SelectorExpr whose
-// Sel is "Mint", but the subsequent CallExpr has Fun = *ast.Ident, which
-// ResolvePackageRef cannot match against credentialfence.Mint. This test
-// asserts the form does NOT appear in production code, keeping the
-// FENCE-TOKEN-MINT-FUNNEL-01 rule complete under the "blindspot is absent"
-// premise.
+// scanFenceTokenMintRefs returns a violation string for EVERY reference to
+// credentialfence.Mint in file — regardless of the syntactic shape that
+// references it. It walks all `*ast.SelectorExpr` nodes and resolves each via
+// ResolvePackageRef, so it catches the direct call (`credentialfence.Mint()`),
+// var-decl / short-var function-value capture (`var x = credentialfence.Mint`,
+// `x := credentialfence.Mint`), return of the function value, pass-through as a
+// call argument, and the reflect-arg form (`reflect.ValueOf(credentialfence.Mint)`).
 //
-// Detection is alias-immune: the AssignStmt RHS SelectorExpr is resolved via
-// ResolvePackageRef (types.Info.Uses), which returns the canonical package
-// path regardless of any import alias (e.g. `import cf "...credentialfence"`).
-// Name-based xIdent.Name == "credentialfence" matching is NOT used here.
+// This is the form-complete replacement for the earlier CallExpr-only scanner
+// plus its two enumerate-form blindspot self-checks: because credentialfence
+// is sealed, the ONLY way for a non-funnel package to obtain a FenceToken is to
+// reference Mint, so flagging every reference — not just the invocation —
+// closes the function-value-capture and reflect blindspots structurally rather
+// than asserting their absence one form at a time.
 //
-// Mirrors TestCredentialInvalidateFunnel_BlindSpot_FuncValueAssignment in
-// credential_invalidate_funnel_invariants_test.go.
-func TestFenceTokenMintFunnel_BlindSpot_FuncValueAssignment(t *testing.T) {
-	t.Parallel()
-
-	patterns := []string{
-		"./cells/...", "./runtime/...", "./adapters/...", "./cmd/...", "./examples/...",
-	}
-
-	var violations []string
-	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
-		if p.Pkg == nil || p.TypesInfo == nil {
-			return nil
-		}
-		for _, file := range p.Files {
-			rel := p.Rel(file)
-			if strings.HasSuffix(rel, "_test.go") {
-				continue
-			}
-			if isFenceTokenMintAllowlisted(rel) {
-				continue
-			}
-			EachInSubtree[ast.AssignStmt](file, func(assign *ast.AssignStmt) {
-				EachInChildren[ast.SelectorExpr](assign, func(sel *ast.SelectorExpr) {
-					if sel.Sel.Name != fenceTokenMintFunc {
-						return
-					}
-					// Use ResolvePackageRef to resolve via types.Info.Uses to the
-					// canonical package path — immune to import aliases such as
-					// `import cf "...credentialfence"`.
-					pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, sel)
-					if !ok {
-						return
-					}
-					if pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
-						return
-					}
-					line := p.Fset.Position(assign.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: credentialfence.Mint function-value assignment blind spot detected "+
-							"(FENCE-TOKEN-MINT-FUNNEL-01)",
-						rel, line,
-					))
-				})
-			})
-		}
-		return nil
-	})
-
-	sort.Strings(violations)
-	for _, v := range violations {
-		t.Log(v)
-	}
-	assert.Empty(t, violations,
-		"FENCE-TOKEN-MINT-FUNNEL-01 blind-spot: function-value assignment of "+
-			"credentialfence.Mint found in production code — the archtest would "+
-			"miss subsequent invocations. Inline the call at the funnel site.")
-}
-
-// TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation is the reverse
-// blindspot self-check for reflect-based invocation. Production code must
-// never use reflect.ValueOf to fetch / call Mint — such forms are
-// AST-invisible to the main A1 ResolvePackageRef scanner. Asserts the form
-// is absent.
+// Resolution: credentialfence.Mint is a package-level function (not a method),
+// so its qualified reference lives in types.Info.Uses. ResolvePackageRef
+// resolves the SelectorExpr (X is a PkgName, Sel is the function name) to the
+// canonical (pkgPath, name) tuple — alias-immune (an `import cf "…"` rename
+// resolves to the same path). The `sel.Sel.Name` pre-filter keeps the resolver
+// off the hot path for unrelated selectors.
 //
-// Detection for the inner argument is alias-immune: the credentialfence.Mint
-// SelectorExpr passed as reflect.ValueOf's argument is resolved via
-// ResolvePackageRef (types.Info.Uses) to the canonical package path, not via
-// the local identifier name. The outer reflect.ValueOf identification uses
-// name-based matching ("reflect"/"ValueOf") which is safe because reflect is
-// a stdlib package that is never aliased in this codebase.
-//
-// Mirrors TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName.
-func TestFenceTokenMintFunnel_BlindSpot_ReflectInvocation(t *testing.T) {
-	t.Parallel()
-
-	patterns := []string{
-		"./cells/...", "./runtime/...", "./adapters/...", "./cmd/...", "./examples/...",
-	}
-
-	var violations []string
-	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
-		if p.Pkg == nil || p.TypesInfo == nil {
-			return nil
-		}
-		for _, file := range p.Files {
-			rel := p.Rel(file)
-			if strings.HasSuffix(rel, "_test.go") {
-				continue
-			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok {
-					return
-				}
-				// reflect.ValueOf(credentialfence.Mint) — argument is the
-				// SelectorExpr we care about.
-				// Outer reflect.ValueOf identification is name-based (reflect is
-				// stdlib, never aliased in this codebase).
-				if sel.Sel.Name != "ValueOf" || len(call.Args) != 1 {
-					return
-				}
-				xIdent, ok := sel.X.(*ast.Ident)
-				if !ok || xIdent.Name != "reflect" {
-					return
-				}
-				argSel, ok := call.Args[0].(*ast.SelectorExpr)
-				if !ok {
-					return
-				}
-				// Use ResolvePackageRef on the inner argument SelectorExpr to
-				// resolve via types.Info.Uses — alias-immune.
-				pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, argSel)
-				if !ok {
-					return
-				}
-				if pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
-					return
-				}
-				line := p.Fset.Position(call.Pos()).Line
-				violations = append(violations, fmt.Sprintf(
-					"%s:%d: reflect.ValueOf(credentialfence.Mint) blind spot detected "+
-						"(FENCE-TOKEN-MINT-FUNNEL-01)",
-					rel, line,
-				))
-			})
-		}
-		return nil
-	})
-
-	sort.Strings(violations)
-	for _, v := range violations {
-		t.Log(v)
-	}
-	assert.Empty(t, violations,
-		"FENCE-TOKEN-MINT-FUNNEL-01 blind-spot: reflect.ValueOf(credentialfence.Mint) "+
-			"found in production code — the archtest cannot see reflect-based invocations.")
-}
-
-// scanFenceTokenMintViolations returns violation strings for every CallExpr
-// in file whose callee resolves to credentialfence.Mint.
-//
-// Resolution: credentialfence.Mint is a package-level function (not a
-// method), so its qualified reference lives in types.Info.Uses, not in
-// Selections. ResolvePackageRef walks the SelectorExpr (X is a PkgName,
-// Sel is the function name) and returns the (pkgPath, name) tuple.
-// ResolveMethodCall would silently miss this — it only resolves method
-// selections.
-func scanFenceTokenMintViolations(p *Pass, file *ast.File, rel string) []string {
+// Residual blindspots (universal class, not enumerated per-form): dot-import of
+// credentialfence (`import . "…/credentialfence"` makes Mint a bare Ident — not
+// used anywhere in this module, and a dot-import of an internal-style package
+// would itself be an anomaly), `//go:linkname`, and `unsafe`. These defeat any
+// static analysis and are out of scope for an archtest funnel.
+func scanFenceTokenMintRefs(p *Pass, file *ast.File, rel string) []string {
 	var out []string
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
-		if !ok {
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != fenceTokenMintFunc {
 			return
 		}
-		if pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
+		pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, sel)
+		if !ok || pkgPath != fenceTokenPkgPath || name != fenceTokenMintFunc {
 			return
 		}
-		line := p.Fset.Position(call.Pos()).Line
+		line := p.Fset.Position(sel.Pos()).Line
 		out = append(out, fmt.Sprintf(
-			"%s:%d: FENCE-TOKEN-MINT-FUNNEL-01: direct call to credentialfence.Mint "+
-				"bypasses the credentialinvalidate funnel",
+			"%s:%d: FENCE-TOKEN-MINT-FUNNEL-01: reference to credentialfence.Mint "+
+				"outside the funnel (direct call or function-value capture)",
 			rel, line,
 		))
 	})
 	return out
 }
 
-// verifyFenceTokenMintRedFixture loads the RED fixture and asserts the
-// scanner detects at least one violation. Mirrors verifyRedFixtureDetectedPass
-// in credential_invalidate_funnel_invariants_test.go.
-func verifyFenceTokenMintRedFixture(t *testing.T, fixturePattern, label string) {
+// verifyFenceTokenMintRedFixture loads the RED fixture and asserts the scanner
+// detects at least wantMin violations. wantMin is the number of distinct
+// credentialfence.Mint reference forms in the fixture (call / var-decl capture /
+// short-var capture / pass-through arg / reflect arg). Requiring the full count
+// — not merely ≥ 1 — proves the scanner is form-complete: a CallExpr-only
+// scanner would catch only the single direct call and fall short, surfacing the
+// regression here. Mirrors verifyRedFixtureDetectedPass in
+// credential_invalidate_funnel_invariants_test.go.
+func verifyFenceTokenMintRedFixture(t *testing.T, fixturePattern, label string, wantMin int) {
 	t.Helper()
 
 	var found int
@@ -353,14 +242,15 @@ func verifyFenceTokenMintRedFixture(t *testing.T, fixturePattern, label string) 
 			return nil
 		}
 		for _, file := range p.Files {
-			found += len(scanFenceTokenMintViolations(p, file, label))
+			found += len(scanFenceTokenMintRefs(p, file, label))
 		}
 		return nil
 	})
-	require.GreaterOrEqual(t, found, 1,
-		"RED fixture self-check FAILED: %s — expected ≥ 1 violation, got 0. "+
-			"The production scanner would be permanently GREEN and miss real "+
-			"violations. Check that the fixture file actually calls "+
-			"credentialfence.Mint and is type-checkable.",
-		label)
+	require.GreaterOrEqual(t, found, wantMin,
+		"RED fixture self-check FAILED: %s — expected ≥ %d violations, got %d. "+
+			"A shortfall means the scanner is NOT form-complete (e.g. it only "+
+			"catches direct CallExpr and misses function-value capture / reflect "+
+			"arg forms), so a non-funnel package could construct a FenceToken "+
+			"undetected. Check scanFenceTokenMintRefs covers every reference shape.",
+		label, wantMin, found)
 }

--- a/tools/archtest/kernel_mustctor_production_decl_test.go
+++ b/tools/archtest/kernel_mustctor_production_decl_test.go
@@ -107,6 +107,16 @@ var allowedMustDecls = map[string]map[string]struct{}{
 	"kernel/outbox": {
 		"MustNewEntryID": {},
 	},
+	// (a) assertion guard — credential-invalidate FenceToken nil-token check,
+	// surfaces the programmer error as a 500 via panicregister.Approved +
+	// errcode.Assertion (B-class). Called from the three mutation impls
+	// (session.Store / refresh.Store / ports.UserRepository) to defend against
+	// archtest blindspots (function-value capture, reflect.MethodByName).
+	// See FENCE-TOKEN-MINT-FUNNEL-01 godoc + ADR
+	// docs/architecture/202605101400-adr-credential-session-protocol.md §A16.
+	"runtime/auth/credentialfence": {
+		"MustHave": {},
+	},
 	"pkg/errcode": {
 		"MustValidateDetailsKinds": {},
 	},

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f1_multi_stmt_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f1_multi_stmt_red/usage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -16,7 +17,7 @@ type fakeInner struct{}
 func (fakeInner) Create(context.Context, *session.Session) error             { return nil }
 func (fakeInner) Get(context.Context, string) (*session.ValidateView, error) { return nil, nil }
 func (fakeInner) Revoke(context.Context, string) error                       { return nil }
-func (fakeInner) RevokeForSubject(context.Context, string, session.CredentialEvent) error {
+func (fakeInner) RevokeForSubject(context.Context, string, session.CredentialEvent, credentialfence.FenceToken) error {
 	return nil
 }
 func (fakeInner) RepoReady(context.Context) error { return nil }
@@ -33,6 +34,6 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 }
 
 // RevokeForSubject is conformant (single return delegate) — archtest must NOT flag this.
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f2_cache_delete_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f2_cache_delete_red/usage.go
@@ -6,6 +6,7 @@ package f2_cache_delete_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -27,6 +28,6 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 }
 
 // RevokeForSubject is conformant.
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f3_cache_set_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f3_cache_set_red/usage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -28,6 +29,6 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 }
 
 // RevokeForSubject is conformant.
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f4_wrong_delegate_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f4_wrong_delegate_red/usage.go
@@ -7,6 +7,7 @@ package f4_wrong_delegate_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -17,10 +18,10 @@ type CachingSessionStore struct {
 
 // Revoke delegates to the wrong method (RevokeForSubject) — violates CACHING-SESSION-REVOKE-DELEGATE-ONLY-01.
 func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
-	return s.inner.RevokeForSubject(ctx, id, session.CredentialEventLock) // VIOLATION: wrong method name
+	return s.inner.RevokeForSubject(ctx, id, session.CredentialEventLock, credentialfence.Mint()) // VIOLATION: wrong method name
 }
 
 // RevokeForSubject is conformant.
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f5_wrong_receiver_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f5_wrong_receiver_red/usage.go
@@ -7,6 +7,7 @@ package f5_wrong_receiver_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -16,7 +17,7 @@ type fakeInner struct{}
 func (fakeInner) Create(context.Context, *session.Session) error             { return nil }
 func (fakeInner) Get(context.Context, string) (*session.ValidateView, error) { return nil, nil }
 func (fakeInner) Revoke(context.Context, string) error                       { return nil }
-func (fakeInner) RevokeForSubject(context.Context, string, session.CredentialEvent) error {
+func (fakeInner) RevokeForSubject(context.Context, string, session.CredentialEvent, credentialfence.FenceToken) error {
 	return nil
 }
 func (fakeInner) RepoReady(context.Context) error { return nil }
@@ -37,6 +38,6 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 }
 
 // RevokeForSubject is conformant (single return delegate).
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f6_wrong_args_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f6_wrong_args_red/usage.go
@@ -7,6 +7,7 @@ package f6_wrong_args_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -22,6 +23,6 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 }
 
 // RevokeForSubject is conformant (single return delegate).
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/caching_session_revoke_fixtures/f7_cache_in_arg_red/usage.go
+++ b/tools/archtest/testdata/caching_session_revoke_fixtures/f7_cache_in_arg_red/usage.go
@@ -8,6 +8,7 @@ package f7_cache_in_arg_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
@@ -32,6 +33,6 @@ func (s *CachingSessionStore) Revoke(ctx context.Context, id string) error {
 }
 
 // RevokeForSubject is conformant (single return delegate).
-func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent) error {
-	return s.inner.RevokeForSubject(ctx, subjectID, event)
+func (s *CachingSessionStore) RevokeForSubject(ctx context.Context, subjectID string, event session.CredentialEvent, tok credentialfence.FenceToken) error {
+	return s.inner.RevokeForSubject(ctx, subjectID, event, tok)
 }

--- a/tools/archtest/testdata/credential_invalidate_fixtures/identitymanage_direct_revoke_refresh_red/usage.go
+++ b/tools/archtest/testdata/credential_invalidate_fixtures/identitymanage_direct_revoke_refresh_red/usage.go
@@ -7,11 +7,12 @@ package identitymanage_direct_revoke_refresh_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
 )
 
 // badRefreshRevoke directly calls RevokeUser on a refresh.Store — bypassing
 // the credentialinvalidate funnel. This is the pattern the archtest bans.
 func badRefreshRevoke(ctx context.Context, store refresh.Store, subjectID string) error {
-	return store.RevokeUser(ctx, subjectID)
+	return store.RevokeUser(ctx, subjectID, credentialfence.Mint())
 }

--- a/tools/archtest/testdata/credential_invalidate_fixtures/rbacassign_direct_revoke_for_subject_red/usage.go
+++ b/tools/archtest/testdata/credential_invalidate_fixtures/rbacassign_direct_revoke_for_subject_red/usage.go
@@ -7,11 +7,12 @@ package rbacassign_direct_revoke_for_subject_red
 import (
 	"context"
 
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
 // badRevoke directly calls RevokeForSubject on a session.Store — bypassing
 // the credentialinvalidate funnel. This is the pattern the archtest bans.
 func badRevoke(ctx context.Context, store session.Store, subjectID string) error {
-	return store.RevokeForSubject(ctx, subjectID, session.CredentialEventLock)
+	return store.RevokeForSubject(ctx, subjectID, session.CredentialEventLock, credentialfence.Mint())
 }

--- a/tools/archtest/testdata/credential_invalidate_fixtures/rbacassign_direct_revoke_for_subject_red/usage.go
+++ b/tools/archtest/testdata/credential_invalidate_fixtures/rbacassign_direct_revoke_for_subject_red/usage.go
@@ -1,7 +1,10 @@
-// Package rbacassign_direct_revoke_for_subject_red is a RED fixture:
-// it directly calls sessionStore.RevokeForSubject without going through the
-// credentialinvalidate funnel. CREDENTIAL-INVALIDATE-FUNNEL-01 must detect
-// exactly 1 violation in this file.
+// Package rbacassign_direct_revoke_for_subject_red is a RED fixture for
+// CREDENTIAL-INVALIDATE-FUNNEL-01. It references session.Store.RevokeForSubject
+// from a non-allowlisted path in three distinct AST shapes — direct call,
+// short-var function-value capture, and var-decl function-value capture. The
+// form-complete scanner must detect EVERY one (3 references); a CallExpr-only
+// scan would catch only the direct call and miss the two captures, so the
+// wantMin=3 self-check in the archtest pins form-completeness.
 package rbacassign_direct_revoke_for_subject_red
 
 import (
@@ -11,8 +14,20 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
-// badRevoke directly calls RevokeForSubject on a session.Store — bypassing
-// the credentialinvalidate funnel. This is the pattern the archtest bans.
+// 1. direct call — bypasses the credentialinvalidate funnel.
 func badRevoke(ctx context.Context, store session.Store, subjectID string) error {
 	return store.RevokeForSubject(ctx, subjectID, session.CredentialEventLock, credentialfence.Mint())
+}
+
+// 2. short-var method-value capture (AssignStmt) + deferred invocation. The
+//    `fn(...)` call has Fun = *ast.Ident, invisible to a CallExpr-only scan.
+func badRevokeAssignCapture(ctx context.Context, store session.Store, subjectID string) error {
+	fn := store.RevokeForSubject
+	return fn(ctx, subjectID, session.CredentialEventLock, credentialfence.Mint())
+}
+
+// 3. var-decl method-value capture (GenDecl ValueSpec — not an AssignStmt).
+func badRevokeVarCapture(store session.Store) func(context.Context, string, session.CredentialEvent, credentialfence.FenceToken) error {
+	var fn = store.RevokeForSubject
+	return fn
 }

--- a/tools/archtest/testdata/fence_token_fixtures/external_mint_red/usage.go
+++ b/tools/archtest/testdata/fence_token_fixtures/external_mint_red/usage.go
@@ -1,15 +1,48 @@
-// Package external_mint_red is a RED fixture: it directly calls
-// credentialfence.Mint from a non-allowlisted path. FENCE-TOKEN-MINT-FUNNEL-01
-// must detect exactly 1 violation in this file.
+// Package external_mint_red is a RED fixture for FENCE-TOKEN-MINT-FUNNEL-01.
+// It references credentialfence.Mint from a non-allowlisted path in five
+// distinct AST shapes. The form-complete scanner must detect EVERY one of them
+// (call / var-decl value-capture / short-var value-capture / pass-through arg /
+// reflect arg) — proving form-uniqueness across all reference shapes, not just
+// the direct CallExpr. A CallExpr-only scanner would miss the four capture
+// forms; the exact-count self-check in the archtest pins this.
+//
+// The reflect import is deliberately aliased to exercise the alias-immune
+// resolution path (ResolvePackageRef resolves via types.Info, not the local
+// identifier name).
 package external_mint_red
 
 import (
+	r "reflect"
+
 	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
 )
 
-// badMint constructs a FenceToken outside the credentialinvalidate funnel.
-// This is the pattern the archtest bans: any non-funnel call to Mint is a
-// upstream-funnel bypass.
-func badMint() credentialfence.FenceToken {
+// 1. direct call.
+func directCall() credentialfence.FenceToken {
 	return credentialfence.Mint()
 }
+
+// 2. var-decl function-value capture (GenDecl ValueSpec — NOT an AssignStmt).
+var capturedMint = credentialfence.Mint
+
+// 3. short-var function-value capture (AssignStmt) + deferred invocation.
+func assignCapture() credentialfence.FenceToken {
+	fn := credentialfence.Mint
+	return fn()
+}
+
+// 4. pass-through as a function argument.
+func passThrough() {
+	consume(credentialfence.Mint)
+}
+
+func consume(func() credentialfence.FenceToken) {}
+
+// 5. reflect arg via aliased reflect import (alias-immunity check).
+func reflectArg() r.Value {
+	return r.ValueOf(credentialfence.Mint)
+}
+
+// Keep capturedMint referenced so the fixture mirrors realistic capture-then-use
+// flow without tripping unused warnings under stricter loaders.
+func useCaptured() credentialfence.FenceToken { return capturedMint() }

--- a/tools/archtest/testdata/fence_token_fixtures/external_mint_red/usage.go
+++ b/tools/archtest/testdata/fence_token_fixtures/external_mint_red/usage.go
@@ -1,0 +1,15 @@
+// Package external_mint_red is a RED fixture: it directly calls
+// credentialfence.Mint from a non-allowlisted path. FENCE-TOKEN-MINT-FUNNEL-01
+// must detect exactly 1 violation in this file.
+package external_mint_red
+
+import (
+	"github.com/ghbvf/gocell/runtime/auth/credentialfence"
+)
+
+// badMint constructs a FenceToken outside the credentialinvalidate funnel.
+// This is the pattern the archtest bans: any non-funnel call to Mint is a
+// upstream-funnel bypass.
+func badMint() credentialfence.FenceToken {
+	return credentialfence.Mint()
+}

--- a/tools/archtest/userrepo_method_set_frozen_test.go
+++ b/tools/archtest/userrepo_method_set_frozen_test.go
@@ -49,7 +49,7 @@ import (
 // Adding/removing methods OR changing any signature here is a contract change
 // that must be paired with an ADR amendment (ADR 202605222309).
 var expectedUserRepoMethodSignatures = map[string]string{
-	"BumpAuthzEpoch":   "(ctx context.Context, userID string) (newEpoch int64, err error)",
+	"BumpAuthzEpoch":   "(ctx context.Context, userID string, tok credentialfence.FenceToken) (newEpoch int64, err error)",
 	"Create":           "(ctx context.Context, user *domain.User) error",
 	"Delete":           "(ctx context.Context, id string) error",
 	"GetByID":          "(ctx context.Context, id string) (*domain.User, error)",


### PR DESCRIPTION
## Summary

Closes the only structural opening in GoCell's credential revocation safety model. The credential-invalidate funnel was previously half-closed:

- **Downstream Hard** — `session.Store.RevokeForSubject` / `refresh.Store.RevokeUser` / `ports.UserRepository.BumpAuthzEpoch` caller allowlist locked by archtest.
- **Upstream Soft** — any package could directly construct receivers and call the methods; only CI archtest caught it.

This PR closes the upstream half via three layered defenses:

1. **Type-system seal** — new `runtime/auth/credentialfence` package introduces `FenceToken` interface with unexported `isCredentialFenceToken()` marker method. External types cannot implement the interface (Go visibility rule); the concrete `fenceToken` impl is unexported, so external composite literals cannot construct it either.
2. **Call-site form-uniqueness** — new archtest `FENCE-TOKEN-MINT-FUNNEL-01` (ResolvePackageRef-based, A1 callsite + A2/A3 blindspot self-checks for function-value capture & reflect) locks `credentialfence.Mint` callers to `{credentialinvalidate funnel, storetest, conformance, *_test.go}`.
3. **Runtime nil-guard** — `credentialfence.MustHave` at the top of every mutation impl catches the residual "pass nil" archtest blindspot, surfacing as 500 via `panicregister.Approved + errcode.Assertion`.

Combined ⇒ funnel upstream **Medium → Hard**. `CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` godoc upgraded.

ref: `kernel/outbox/cell_marker.go` (sealed interface precedent)
ref: `pkg/panicregister/panicregister.go` (typed marker funnel precedent)

## Implementation matrix

```
Contract: session.Store / refresh.Store / ports.UserRepository (three interfaces)
Change: Append `tok credentialfence.FenceToken` mandatory parameter to
        RevokeForSubject / RevokeUser / BumpAuthzEpoch; runtime nil-guard;
        new runtime/auth/credentialfence package; new FENCE-TOKEN-MINT-FUNNEL-01
        archtest; existing CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 godoc
        Medium → Hard.
Implementations: [x] session.mem [x] session.PG [x] session.Redis decorator
                 [x] refresh.mem [x] refresh.PG
                 [x] UserRepo.mem [x] UserRepo.PG
Conformance tests: session/storetest/suite + bench, refresh/storetest/suite,
                   ports/conformance
Repro: go test ./runtime/auth/{session,refresh}/... \
            ./cells/accesscore/internal/{ports,mem,credentialinvalidate}/...
       go test ./tools/archtest -run 'FENCE_TOKEN|CREDENTIAL_INVALIDATE'
Dependent contracts (governance scan): None new; archtest funnel files in-place updated
Invariant inventory: N/A (no DROP COLUMN / forbiddenColumns entry)
```

## Closure registrations (merged per contract-fanout.md single-registration rule)

* `docs/architecture/202605101400-adr-credential-session-protocol.md` §A16 — full amendment + threat-matrix line 893 re-evaluation (no ✅ regressions; row strengthened ✅✅).
* `docs/reviews/202605181109-042-archtest-six-agent-audit.md` §3a row 3 + §4 ROI row 2 — both marked CLOSED 2026-05-26.
* `docs/plans/202605191100-043-archtest-audit-and-capability-gap-parallel-plan.md` §1 row 4 — marked DONE 2026-05-26.

## Test plan

- [x] `go build ./...` (default + `-tags=integration`) — green
- [x] `go test ./runtime/auth/... ./cells/accesscore/... ./adapters/postgres/... ./adapters/redis/... ./cmd/corebundle/...` — all green
- [x] `go test ./tools/archtest -run 'TestFenceTokenMintFunnel|TestCredentialInvalidateFunnel|TestUserRepoMethodSetFrozen|TestKernelMustCtorProductionDecl'` — green
- [x] `golangci-lint run --new-from-rev=origin/develop ./...` — 0 issues (the 1 pre-existing gocognit issue in `tools/codegen/cellgen/literal_printer.go` predates this PR)
- [ ] Integration test `TestS4b_RefreshReuse_CascadesEpochAndSession` — local run requires PG container; signature-compiles verified via `-tags=integration` build
- [ ] Nightly archtest full suite — 5 pre-existing nightly violations on develop (saga-related: KERNEL-INTERNAL-DAG-01, SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE-01, SCANNER-FRAMEWORK-USAGE-01/02, CELL-REPO-READYZ-PROBE-01, TEST-POLLING-EXTERNAL-REASON-LITERAL-01) are not caused by this PR; verified by checking out develop and re-running.

## Out of scope (independent dimensions, per issue body)

- #793 AUTH-CACHE-SUBJECT-REVERSE-INDEX-01 — RevokeForSubject reverse-index performance (read-side cache; orthogonal to write-side seal).
- #948 SESSION-REVOKED-FIELD-ACCESS-01 — reflect blindspot static guard (read-side field access; orthogonal to write-side fence).

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)