### PR TITLE
refactor(quality): resolve 10 SonarCloud S1192/S1186 findings

### DIFF
--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -300,6 +300,10 @@ type expectedCheck struct {
 // Extracted to satisfy go:S1192 (used in 16 expectedColumns entries).
 const pgTypeTSTZ = "timestamp with time zone"
 
+// queryErrFmt is the WithInternal detail format for failed schema-dimension
+// SQL probes. Extracted to satisfy go:S1192 (used in 4 dimension probes).
+const queryErrFmt = "query: %v"
+
 // ---------------------------------------------------------------------------
 // Expected shape registries (hardcoded per ADR-credential §5.1.3)
 // ---------------------------------------------------------------------------
@@ -605,7 +609,7 @@ func verifyColumns(ctx context.Context, pool *Pool) error {
 					slog.String("table", ec.Table),
 					slog.String("column", ec.Column),
 				),
-				errcode.WithInternal(fmt.Sprintf("query: %v", err)),
+				errcode.WithInternal(fmt.Sprintf(queryErrFmt, err)),
 			)
 		}
 		if gotType != ec.Type {
@@ -756,7 +760,7 @@ func verifyIndexes(ctx context.Context, pool *Pool) error {
 					slog.String("table", idx.Table),
 					slog.String("index", idx.Name),
 				),
-				errcode.WithInternal(fmt.Sprintf("query: %v", err)),
+				errcode.WithInternal(fmt.Sprintf(queryErrFmt, err)),
 			)
 		}
 		if gotUnique != idx.Unique {
@@ -827,7 +831,7 @@ func verifyOneForeignKey(ctx context.Context, pool *Pool, fk expectedFK, fkQ str
 				slog.String("table", fk.Table),
 				slog.String("constraint", fk.Constraint),
 			),
-			errcode.WithInternal(fmt.Sprintf("query: %v", err)),
+			errcode.WithInternal(fmt.Sprintf(queryErrFmt, err)),
 		)
 	}
 	if gotRefTable != fk.RefTable {
@@ -928,7 +932,7 @@ func verifyTriggers(ctx context.Context, pool *Pool) error {
 					slog.String("table", tr.Table),
 					slog.String("trigger", tr.Name),
 				),
-				errcode.WithInternal(fmt.Sprintf("query: %v", err)),
+				errcode.WithInternal(fmt.Sprintf(queryErrFmt, err)),
 			)
 		}
 		isEnabled := gotEnabled == "O"

--- a/cells/accesscore/internal/accountlockout/service.go
+++ b/cells/accesscore/internal/accountlockout/service.go
@@ -50,7 +50,9 @@ type noopMetrics struct{}
 
 // IncAccountLockout is intentionally empty — noopMetrics discards all metric
 // increments. See noopMetrics godoc for when this is wired.
-func (noopMetrics) IncAccountLockout(context.Context, string) {}
+func (noopMetrics) IncAccountLockout(context.Context, string) {
+	// Intentional no-op: noopMetrics discards all metric increments.
+}
 
 // Option configures the Service at construction time.
 type Option func(*Service)

--- a/cells/accesscore/internal/credential/hasher.go
+++ b/cells/accesscore/internal/credential/hasher.go
@@ -67,7 +67,9 @@ func NewProductionHasher() Hasher { return bcryptHasher{cost: ProductionCost} }
 // test code.
 func NewTestHasher(cost int) Hasher { return bcryptHasher{cost: cost} }
 
-func (bcryptHasher) isCredentialHasher() {}
+func (bcryptHasher) isCredentialHasher() {
+	// Sealed-interface marker: no behavior; blocks external Hasher impls.
+}
 
 func (h bcryptHasher) Hash(password []byte) (string, error) {
 	b, err := bcrypt.GenerateFromPassword(password, h.cost)

--- a/cmd/gocell/app/generate.go
+++ b/cmd/gocell/app/generate.go
@@ -14,6 +14,10 @@ import (
 	"github.com/ghbvf/gocell/tools/metricschema"
 )
 
+// verifyDryRunHelpLine is the shared --verify/--dry-run help line reused
+// across codegen subcommands. Extracted to satisfy go:S1192.
+const verifyDryRunHelpLine = "--verify reports drift without writing; --dry-run prints"
+
 // generateSubcommands is the single source of truth for `gocell generate`
 // (see subcommand.go / CLI-UNIMPL-HIDE-01). assembly/catalog/cell/contract
 // have no cancelable downstream (codegen is metadata + file IO), so their
@@ -60,7 +64,7 @@ var generateSubcommands = []subcommand[func(ctx context.Context, args []string) 
 			"Render cell_gen.go and slice_gen.go from cell.yaml /",
 			"slice.yaml. Default: all opted-in cells (goStructName set).",
 			"Optional: [<cellID>] scopes to a single cell.",
-			"--verify reports drift without writing; --dry-run prints",
+			verifyDryRunHelpLine,
 			"would-write file paths without writing.",
 			"CI: commit cell_gen.go and run with --verify to detect stale artifacts.",
 		},
@@ -71,7 +75,7 @@ var generateSubcommands = []subcommand[func(ctx context.Context, args []string) 
 		help: []string{
 			"Render generated/contracts/**/*_gen.go from contract.yaml",
 			"+ JSON schemas. <contractID> | --all [--dry-run | --verify].",
-			"--verify reports drift without writing; --dry-run prints",
+			verifyDryRunHelpLine,
 			"would-write paths without writing.",
 			"Default: codegen on; set codegen: false to opt out.",
 			"CI: commit *_gen.go files and run with --verify.",
@@ -84,7 +88,7 @@ var generateSubcommands = []subcommand[func(ctx context.Context, args []string) 
 			"Generate service_required_gen.go for each slice that has",
 			"gocell:\"required\" struct field tags on its Service struct.",
 			"[<slicePath>] | --all [--dry-run | --verify].",
-			"--verify reports drift without writing; --dry-run prints",
+			verifyDryRunHelpLine,
 			"would-write paths without writing.",
 			"CI: commit service_required_gen.go and run with --verify.",
 		},

--- a/cmd/gocell/app/generate_required_deps.go
+++ b/cmd/gocell/app/generate_required_deps.go
@@ -14,6 +14,10 @@ import (
 
 const requiredDepsGenFileName = "service_required_gen.go"
 
+// requiredDepsKind is the codegen "kind" token for this command, passed to
+// writeDriftFixHint / driftErrorTemplate. Extracted to satisfy go:S1192.
+const requiredDepsKind = "required-deps"
+
 // generateRequiredDeps implements `gocell generate required-deps`.
 //
 // Modes:
@@ -113,8 +117,8 @@ func runRequiredDepsAll(root string, dryRun, verify bool) error {
 	}
 
 	if verify && len(drifted) > 0 {
-		writeDriftFixHint("required-deps")
-		return fmt.Errorf(driftErrorTemplate, len(drifted), "required-deps")
+		writeDriftFixHint(requiredDepsKind)
+		return fmt.Errorf(driftErrorTemplate, len(drifted), requiredDepsKind)
 	}
 	return nil
 }
@@ -138,8 +142,8 @@ func writeRequiredDepsFile(root, outPath string, content []byte, dryRun, verify 
 		fmt.Printf("Would write: %s\n", outPath)
 	case codegen.ActionDrifted:
 		fmt.Fprintf(os.Stderr, "drift: %s\n", outPath)
-		writeDriftFixHint("required-deps")
-		return fmt.Errorf(driftErrorTemplate, 1, "required-deps")
+		writeDriftFixHint(requiredDepsKind)
+		return fmt.Errorf(driftErrorTemplate, 1, requiredDepsKind)
 	}
 	return nil
 }

--- a/kernel/command/commandtest/inmem.go
+++ b/kernel/command/commandtest/inmem.go
@@ -26,6 +26,10 @@ import (
 // constant carries no runtime data (MESSAGE-CONST-LITERAL-01 compliant).
 const msgCommandAlreadyExists = "commandtest: command already exists"
 
+// commandIDInternalPrefix is the WithInternal detail prefix carrying the
+// runtime command ID. Extracted to satisfy go:S1192 (used in 5 lookups).
+const commandIDInternalPrefix = "commandID="
+
 // msgCommandNotFound is the static message for not-found errors. The runtime
 // command ID is attached via WithInternal so the message itself is a const
 // literal (go:S1192 / MESSAGE-CONST-LITERAL-01 compliant).
@@ -203,7 +207,7 @@ func (q *InMemQueue) Report(_ context.Context, commandID string, now time.Time) 
 	e, ok := q.entries[commandID]
 	if !ok {
 		return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound, msgCommandNotFound,
-			errcode.WithInternal("commandID="+commandID))
+			errcode.WithInternal(commandIDInternalPrefix+commandID))
 	}
 	if e.Status == command.StatusDelivered {
 		return nil // idempotent
@@ -237,7 +241,7 @@ func (q *InMemQueue) Ack(_ context.Context, commandID string, reason command.Ack
 	e, ok := q.entries[commandID]
 	if !ok {
 		return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound, msgCommandNotFound,
-			errcode.WithInternal("commandID="+commandID))
+			errcode.WithInternal(commandIDInternalPrefix+commandID))
 	}
 
 	target := reason.TargetStatus()
@@ -266,7 +270,7 @@ func (q *InMemQueue) ExtendLease(_ context.Context, commandID string, extension 
 
 	if _, ok := q.entries[commandID]; !ok {
 		return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound, msgCommandNotFound,
-			errcode.WithInternal("commandID="+commandID))
+			errcode.WithInternal(commandIDInternalPrefix+commandID))
 	}
 
 	expiry, hasLease := q.leases[commandID]
@@ -286,7 +290,7 @@ func (q *InMemQueue) Cancel(_ context.Context, commandID string, now time.Time) 
 	e, ok := q.entries[commandID]
 	if !ok {
 		return errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound, msgCommandNotFound,
-			errcode.WithInternal("commandID="+commandID))
+			errcode.WithInternal(commandIDInternalPrefix+commandID))
 	}
 	if err := command.AdvanceCommand(e, command.StatusCanceled, now); err != nil {
 		return fmt.Errorf("commandtest: cancel: %w", err)
@@ -364,7 +368,7 @@ func (q *InMemQueue) GetCommand(_ context.Context, id string) (*command.Entry, e
 	e, ok := q.entries[id]
 	if !ok {
 		return nil, errcode.New(errcode.KindNotFound, errcode.ErrCommandNotFound, msgCommandNotFound,
-			errcode.WithInternal("commandID="+id))
+			errcode.WithInternal(commandIDInternalPrefix+id))
 	}
 	cp := stripInternalMetaKeys(*e)
 	return &cp, nil

--- a/kernel/saga/sagajournaltest/conformance.go
+++ b/kernel/saga/sagajournaltest/conformance.go
@@ -32,11 +32,12 @@ type Factory func(t *testing.T) (j journal.Journal, clk *clockmock.FakeClock, cl
 
 // Package-level string constants extracted per SonarQube duplication rules.
 const (
-	stepOne         = "step-one"
-	anyLease        = "any-lease"
-	neverEnqueuedID = "never-enqueued-id"
-	fmtLoadErr      = "Load: %v"
-	fmtClaimErr     = "ClaimPending: err=%v len=%d"
+	stepOne          = "step-one"
+	anyLease         = "any-lease"
+	neverEnqueuedID  = "never-enqueued-id"
+	fmtLoadErr       = "Load: %v"
+	fmtClaimErr      = "ClaimPending: err=%v len=%d"
+	fmtAppendCompErr = "Append(KindCompensationStarted): %v"
 )
 
 // RunConformanceSuite runs the full Journal conformance suite against the
@@ -1046,7 +1047,7 @@ func conformCompensationPath(t *testing.T, factory Factory) {
 		Kind: journal.KindCompensationStarted, // Running → Compensating (no StepName needed)
 	})
 	if err != nil {
-		t.Fatalf("Append(KindCompensationStarted): %v", err)
+		t.Fatalf(fmtAppendCompErr, err)
 	}
 	appendStep(t, j, ci.Instance.ID, ci.LeaseID, journal.KindStepCompensated) // legal while Compensating
 
@@ -1547,7 +1548,7 @@ func driveToCompensating(t *testing.T, j journal.Journal, clk *clockmock.FakeClo
 		Kind: journal.KindCompensationStarted, // Running → Compensating
 	})
 	if err != nil {
-		t.Fatalf("Append(KindCompensationStarted): %v", err)
+		t.Fatalf(fmtAppendCompErr, err)
 	}
 	return ci
 }
@@ -1607,7 +1608,7 @@ func conformMarkTerminalCompensatingToSucceededIllegal(t *testing.T, factory Fac
 		Kind: journal.KindCompensationStarted, // Running → Compensating
 	})
 	if err != nil {
-		t.Fatalf("Append(KindCompensationStarted): %v", err)
+		t.Fatalf(fmtAppendCompErr, err)
 	}
 
 	_, err = j.MarkTerminal(context.Background(), ci.Instance.ID, ci.LeaseID, saga.StatusSucceeded)
@@ -1719,7 +1720,7 @@ func conformAppendForwardStepWhileCompensatingRejected(t *testing.T, factory Fac
 		Kind: journal.KindCompensationStarted, // Running → Compensating
 	})
 	if err != nil {
-		t.Fatalf("Append(KindCompensationStarted): %v", err)
+		t.Fatalf(fmtAppendCompErr, err)
 	}
 
 	// Now in Compensating — a forward step must be rejected.
@@ -1760,7 +1761,7 @@ func conformLeaderHandoffReadsCompensatingPhase(t *testing.T, factory Factory) {
 		Kind: journal.KindCompensationStarted, // Running → Compensating
 	})
 	if err != nil {
-		t.Fatalf("Append(KindCompensationStarted): %v", err)
+		t.Fatalf(fmtAppendCompErr, err)
 	}
 
 	// A's lease expires.

--- a/runtime/bootstrap/lifecycle.go
+++ b/runtime/bootstrap/lifecycle.go
@@ -483,7 +483,7 @@ func hookIdentityAttrs(h Hook) []slog.Attr {
 // The returned cancel func must always be called by the caller.
 func (lc *lifecycle) applyTimeout(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
 	if d < 0 {
-		return parent, func() {} // no-op cancel: negative timeout means no deadline applied
+		return parent, func() { /* no-op cancel: negative timeout means no deadline applied */ }
 	}
 	return context.WithTimeout(parent, d)
 }

--- a/runtime/capability/capability.go
+++ b/runtime/capability/capability.go
@@ -64,7 +64,9 @@ type pgProvider struct {
 func (p pgProvider) TxManager() persistence.TxRunner { return p.tx }
 func (p pgProvider) OutboxWriter() outbox.Writer     { return p.writer }
 func (p pgProvider) DB() any                         { return p.db }
-func (pgProvider) isPGProvider()                     {}
+func (pgProvider) isPGProvider() {
+	// Sealed-interface marker: no behavior; blocks external PGProvider impls.
+}
 
 // NewPGProvider wraps the composition-root-constructed postgres primitives into
 // the sealed PGProvider. tx and writer are kernel-typed; db is the raw
@@ -78,8 +80,10 @@ type redisProvider struct {
 	client any
 }
 
-func (p redisProvider) Client() any    { return p.client }
-func (redisProvider) isRedisProvider() {}
+func (p redisProvider) Client() any { return p.client }
+func (redisProvider) isRedisProvider() {
+	// Sealed-interface marker: no behavior; blocks external RedisProvider impls.
+}
 
 // NewRedisProvider wraps the composition-root-constructed redis client into the
 // sealed RedisProvider. client is the raw *adapterredis.Client passed as any.

--- a/runtime/http/middleware/circuit_breaker.go
+++ b/runtime/http/middleware/circuit_breaker.go
@@ -92,7 +92,7 @@ func circuitBreakerServe(cb Allower, next http.Handler, w http.ResponseWriter, r
 	// and log an Error so the operator can detect the broken implementation.
 	if done == nil {
 		slog.ErrorContext(r.Context(), "circuitbreaker: Allow returned nil done, contract violation; failing open")
-		done = func(error) {} // no-op: fail open — breaker contract violation, request served without reporting
+		done = func(error) { /* no-op: fail open — breaker contract violation, request served without reporting */ }
 	}
 
 	state, w, r := ensureRecorder(w, r)

--- a/runtime/saga/leader_elect.go
+++ b/runtime/saga/leader_elect.go
@@ -93,7 +93,7 @@ func leaderElectLockKey(definitionID, instanceID idutil.SafeID) string {
 // is false.
 func (c *Coordinator) acquireLead(ctx context.Context, ci journal.ClaimedInstance) (release func(), lead bool) {
 	if c.locker == nil {
-		return func() {}, true
+		return func() { /* no-op release: no distributed locker configured, single-coordinator mode */ }, true
 	}
 	key := leaderElectLockKey(ci.Instance.DefinitionID, ci.Instance.ID)
 	lock, err := c.locker.Acquire(ctx, key, c.cfg.LeaseDuration)

--- a/runtime/saga/leader_elect_test.go
+++ b/runtime/saga/leader_elect_test.go
@@ -759,7 +759,7 @@ func TestStop_ReleasesInflightLockOnShutdown(t *testing.T) {
 	case <-time.After(testtime.D2s):
 		t.Fatal("wedged step did not start")
 	}
-	if got := len(fd.Snapshot()); got != 1 {
+	if len(fd.Snapshot()) != 1 {
 		t.Fatalf("distlock not held while drive in-flight; snapshot=%v", fd.Snapshot())
 	}
 
@@ -770,7 +770,7 @@ func TestStop_ReleasesInflightLockOnShutdown(t *testing.T) {
 	defer stopCancel()
 	_ = c.Stop(stopCtx)
 
-	if got := len(fd.Snapshot()); got != 0 {
+	if len(fd.Snapshot()) != 0 {
 		t.Errorf("distlock still held after Stop with a wedged step; F1: Stop must release in-flight locks. snapshot=%v", fd.Snapshot())
 	}
 

--- a/runtime/websocket/hub.go
+++ b/runtime/websocket/hub.go
@@ -245,7 +245,8 @@ func NewHub(cfg HubConfig, handler MessageHandler) *Hub {
 		cfg.ConcurrentCloseLimit = defaultConcurrentCloseLimit
 	}
 	if handler == nil {
-		handler = func(context.Context, string, []byte) {} // no-op default: silently discard messages when no handler is configured
+		handler = func(context.Context, string, []byte) { /* no-op default: silently discard messages when no handler is configured */
+		}
 	}
 
 	return &Hub{

--- a/tests/integration/l2atomicity/harness_test.go
+++ b/tests/integration/l2atomicity/harness_test.go
@@ -256,7 +256,7 @@ func bootL2Assembly(t *testing.T, pgOutboxOverride outbox.Writer) *l2Harness {
 	require.NoError(t, asm.Register(cc))
 	require.NoError(t, asm.Register(auc))
 
-	runBootstrap(t, asm, primaryLn, internalLn, healthLn, eb, authDeps, relayWorker)
+	runBootstrap(t, asm, listenerSet{primary: primaryLn, internal: internalLn, health: healthLn}, eb, authDeps, relayWorker)
 	base := "http://" + primaryLn.Addr().String()
 	healthBase := "http://" + healthLn.Addr().String()
 	waitForHealthz(t, healthBase, base)
@@ -434,13 +434,21 @@ func buildCells(
 	return ac, cc, auc, auditStore
 }
 
+// listenerSet bundles the three bootstrap listeners so runBootstrap stays
+// within the 7-parameter limit (go:S107).
+type listenerSet struct {
+	primary  net.Listener
+	internal net.Listener
+	health   net.Listener
+}
+
 // runBootstrap launches bootstrap.App on the supplied listeners and registers
 // the LIFO cleanup that drains it gracefully. The relay is registered as a
 // ManagedResource so bootstrap drives its Start/Close lifecycle.
 func runBootstrap(
 	t *testing.T,
 	asm *assembly.CoreAssembly,
-	primaryLn, internalLn, healthLn net.Listener,
+	lns listenerSet,
 	eb *eventbus.InMemoryEventBus,
 	a *authLayer,
 	relayWorker *outboxruntime.Relay,
@@ -449,15 +457,15 @@ func runBootstrap(
 	app := bootstrap.New(
 		bootstrap.WithClock(clock.Real()),
 		bootstrap.WithAssembly(asm),
-		bootstrap.WithListener(cell.PrimaryListener, primaryLn.Addr().String(),
+		bootstrap.WithListener(cell.PrimaryListener, lns.primary.Addr().String(),
 			[]kauth.ListenerAuth{authtest.MustAuthJWTFromAssembly(asm)},
-			bootstrap.WithListenerNet(primaryLn)),
-		bootstrap.WithListener(cell.InternalListener, internalLn.Addr().String(),
+			bootstrap.WithListenerNet(lns.primary)),
+		bootstrap.WithListener(cell.InternalListener, lns.internal.Addr().String(),
 			[]kauth.ListenerAuth{authtest.MustAuthServiceToken(a.nonceStore, a.ring)},
-			bootstrap.WithListenerNet(internalLn)),
-		bootstrap.WithListener(cell.HealthListener, healthLn.Addr().String(),
+			bootstrap.WithListenerNet(lns.internal)),
+		bootstrap.WithListener(cell.HealthListener, lns.health.Addr().String(),
 			[]kauth.ListenerAuth{kauth.AuthNone{}},
-			bootstrap.WithListenerNet(healthLn)),
+			bootstrap.WithListenerNet(lns.health)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithConsumerBase(newTestConsumerBase(t, clock.Real())),
 		bootstrap.WithRelay(relayWorker),


### PR DESCRIPTION
## Summary

清理 develop 上 16 条 SonarCloud actionable findings（两个 commit，纯重构，零行为变更）。配套 11 条误报/领域命名已在 SonarCloud 直接标 falsepositive/wontfix。

### Commit 1 — 初始 10 条
**S1192**（重复字面量 ≥3 抽常量，对齐 `go-standards.md`，沿用仓库既有 `pgTypeTSTZ`/`msgCommandNotFound` 模式）：
- schema_guard.go `"query: %v"`×4 → `queryErrFmt`
- generate.go `--verify/--dry-run` help ×3 → `verifyDryRunHelpLine`
- generate_required_deps.go `"required-deps"`×4 → `requiredDepsKind`
- commandtest/inmem.go `"commandID="`×5 → `commandIDInternalPrefix`
- sagajournaltest/conformance.go `"Append(KindCompensationStarted): %v"`×5 → `fmtAppendCompErr`

**S1186**（空函数 body 内补注释）：accountlockout/service.go · credential/hasher.go · bootstrap/lifecycle.go · circuit_breaker.go · websocket/hub.go

### Commit 2 — 后续扫描浮现的 6 条（同 develop 基线）
- **S1186** capability.go（isPGProvider/isRedisProvider sealed marker）· saga/leader_elect.go（无 locker 时 no-op release）
- **go-idiom** leader_elect_test.go L762/L773：`if got:=len(...); got!=N` → `if len(...)!=N`（got 仅条件用）
- **go:S107** l2atomicity/harness_test.go：3 个 listener 收进 `listenerSet` struct（8→6 参数）

## SonarCloud 配套处置（无代码变更）
- **S1135/S1134 ×7** → FALSE_POSITIVE：`"todo"` 是 journey board 状态机枚举值，`pgrepoapproved.go` 的 todo/fixme 是 godoc 列举的禁用占位符 token，均非真实标记（全仓真实 TODO/FIXME 数=0）
- **S8196 ×4** → ACCEPTED：`CellModule`/`fakeTx`/`named` 领域/test-local 命名，改 -er 违背语义

依据 `cell-patterns.md`：误报/架构性命中标 issue-level won't-fix，不 contort code、不加 sonar 豁免规则。

## 留在 SKIPPED（不动，保持可见）
- validate.go:105 `runCtx context.Context`（S8242，godoc 已记载 VERIFY-06 ctx-bound 规则读它）
- verbose_shape_test.go / leader_elect_test.go 的 S3776（测试文件认知复杂度）

## Test plan
- [x] `go build ./...`
- [x] `go vet`（含 `-tags=integration` harness）— clean
- [x] `go test` 受影响包（cmd/gocell/app · kernel/command · kernel/saga · accesscore · runtime/{bootstrap,capability,saga,http/middleware,websocket} · adapters/postgres unit）— all ok
- [x] `golangci-lint` 受影响默认构建包 — 0 issues
- [x] merges cleanly into current develop（0 conflict；develop 推进未触碰本 PR 任何文件）
- 无行为变更，无新增测试（纯字面量抽取 + 注释 + 参数 struct 化，现有测试保持绿）

ref: SonarCloud project ghbvf_gocell；`go-standards.md` 工程质量护栏；`cell-patterns.md` SonarCloud 处置约定

🤖 Generated with [Claude Code](https://claude.com/claude-code)