### PR TITLE
refactor(archtest+ci): 清 develop archtest 套件 + funlen 阻塞

### DIFF
--- a/cells/accesscore/internal/ports/conformance/conformance.go
+++ b/cells/accesscore/internal/ports/conformance/conformance.go
@@ -145,11 +145,16 @@ func RunUserRepoConformance(t *testing.T, factory UserRepoFactory, features Feat
 		// must be inline at the test site (archtest does not follow helpers).
 		errcodetest.AssertCode(t, err, errcode.ErrAuthUserNotFound)
 	})
-	// USERREPO-METHOD-SET-FROZEN-01 narrow-write surface (issue #828):
-	// generic Update(*User) is removed. Each narrow method touches a disjoint
-	// column set; the conformance sub-tests below pin column isolation in mem
-	// + PG so a regression that re-introduces field bleed surfaces here, not
-	// in production.
+	runNarrowWriteSurfaceConformance(t, factory)
+}
+
+// runNarrowWriteSurfaceConformance covers USERREPO-METHOD-SET-FROZEN-01
+// (issue #828): generic Update(*User) is removed. Each narrow method touches
+// a disjoint column set; the sub-tests below pin column isolation in mem + PG
+// so a regression that re-introduces field bleed surfaces here, not in
+// production.
+func runNarrowWriteSurfaceConformance(t *testing.T, factory UserRepoFactory) {
+	t.Helper()
 	t.Run("UpdateProfile_Succeeds", func(t *testing.T) {
 		conformUpdateProfileSucceeds(t, factory)
 	})

--- a/tools/archtest/cli_unimpl_hide_test.go
+++ b/tools/archtest/cli_unimpl_hide_test.go
@@ -1,6 +1,5 @@
-// INVARIANT:
-//   - CLI-UNIMPL-HIDE-01
-//   - CLI-TOPLEVEL-HELP-REGISTRY-01
+// INVARIANT: CLI-UNIMPL-HIDE-01
+//   - INVARIANT: CLI-TOPLEVEL-HELP-REGISTRY-01
 //
 // No `gocell` command — at any level — may be visible in help while being
 // unimplemented. The five help-bearing verb trees

--- a/tools/archtest/internal/scanner/content_test.go
+++ b/tools/archtest/internal/scanner/content_test.go
@@ -80,6 +80,7 @@ func TestEachContentFile_HonorsDefaultSkipDirs(t *testing.T) {
 	writeFile(t, tmp, "vendor/skip.yaml", "skip")
 	writeFile(t, tmp, "generated/skip.yaml", "skip")
 	writeFile(t, tmp, ".git/skip.yaml", "skip")
+	writeFile(t, tmp, ".venv/skip.yaml", "skip")
 
 	scope := DirsScope(tmp, []string{"."})
 	var got []string

--- a/tools/archtest/internal/scanner/scope.go
+++ b/tools/archtest/internal/scanner/scope.go
@@ -24,12 +24,17 @@ func (e *DirsScopeEscapeError) Error() string {
 }
 
 // defaultSkipDirs is the set of directory base-names that are never walked.
+// `.venv` covers Python virtualenv directories that developers may create at
+// the repo root for tooling (e.g. spec-kit scripts); the dir is gitignored,
+// absent on CI, and contains symlinks that the walker would otherwise refuse
+// via walk.go's errSymlink fail-closed contract.
 var defaultSkipDirs = map[string]struct{}{
 	"vendor":       {},
 	"testdata":     {},
 	"worktrees":    {},
 	"generated":    {},
 	".git":         {},
+	".venv":        {},
 	"node_modules": {},
 }
 

--- a/tools/archtest/internal/scanner/scope.go
+++ b/tools/archtest/internal/scanner/scope.go
@@ -147,7 +147,7 @@ type Scope struct {
 
 // ModuleScope creates a Scope rooted at modRoot that walks the entire module,
 // skipping the default directory set: vendor, testdata, worktrees, generated,
-// .git, node_modules.
+// .git, .venv, node_modules.
 func ModuleScope(modRoot string, opts ...Option) Scope {
 	cfg := applyOptions(opts)
 	return newScope(modRoot, []string{modRoot}, cfg)
@@ -216,7 +216,7 @@ func newScope(modRoot string, roots []string, cfg scopeConfig) Scope {
 // buildSkipDirs returns the directory-name skip set for this scope. When
 // IncludeTestdata is set, "testdata" is removed from the default set; when
 // IncludeGenerated is set, "generated" is removed. Other entries
-// (vendor / worktrees / .git / node_modules) are never opt-in-able.
+// (vendor / worktrees / .git / .venv / node_modules) are never opt-in-able.
 func buildSkipDirs(cfg scopeConfig) map[string]struct{} {
 	if !cfg.includeTestdata && !cfg.includeGenerated {
 		return defaultSkipDirs

--- a/tools/archtest/saga_compensate_pure_test.go
+++ b/tools/archtest/saga_compensate_pure_test.go
@@ -88,6 +88,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 const (
@@ -191,53 +193,48 @@ func collectCompensateAssignments(p *Pass, file *ast.File) []compensateFuncAssig
 	info := p.TypesInfo
 	var out []compensateFuncAssignment
 
-	ast.Inspect(file, func(n ast.Node) bool {
-		switch node := n.(type) {
-		case *ast.ValueSpec:
-			// var c saga.CompensateFunc = <expr>
-			typ := info.TypeOf(node.Type)
-			if typ == nil || !isCompensateFuncType(typ) {
-				return true
-			}
-			for _, val := range node.Values {
-				out = append(out, classifyExpr(val))
-			}
-
-		case *ast.AssignStmt:
-			// c = <expr> — match each LHS/RHS pair
-			for i, lhs := range node.Lhs {
-				if i >= len(node.Rhs) {
-					break
-				}
-				lhsType := info.TypeOf(lhs)
-				if lhsType == nil || !isCompensateFuncType(lhsType) {
-					continue
-				}
-				out = append(out, classifyExpr(node.Rhs[i]))
-			}
-
-		case *ast.CompositeLit:
-			// saga.Step{Compensate: <expr>}
-			for _, elt := range node.Elts {
-				kv, ok := elt.(*ast.KeyValueExpr)
-				if !ok {
-					continue
-				}
-				key, ok := kv.Key.(*ast.Ident)
-				if !ok || key.Name != sagaCompensateFieldName {
-					continue
-				}
-				// Verify the field's declared type is CompensateFunc via struct
-				// field lookup (TypeOf on a CompositeLit KV value may return the
-				// underlying func signature, not the named alias).
-				if !compensateKVFieldIsCompensateFunc(info, node) {
-					continue
-				}
-				out = append(out, classifyExpr(kv.Value))
-			}
+	// var c saga.CompensateFunc = <expr>
+	scanner.EachInSubtree[ast.ValueSpec](file, func(node *ast.ValueSpec) {
+		typ := info.TypeOf(node.Type)
+		if typ == nil || !isCompensateFuncType(typ) {
+			return
 		}
-		return true
+		for _, val := range node.Values {
+			out = append(out, classifyExpr(val))
+		}
 	})
+
+	// c = <expr> where c is CompensateFunc
+	scanner.EachInSubtree[ast.AssignStmt](file, func(node *ast.AssignStmt) {
+		for i, lhs := range node.Lhs {
+			if i >= len(node.Rhs) {
+				break
+			}
+			lhsType := info.TypeOf(lhs)
+			if lhsType == nil || !isCompensateFuncType(lhsType) {
+				continue
+			}
+			out = append(out, classifyExpr(node.Rhs[i]))
+		}
+	})
+
+	// saga.Step{Compensate: <expr>}
+	scanner.EachInSubtree[ast.CompositeLit](file, func(node *ast.CompositeLit) {
+		scanner.EachInChildren[ast.KeyValueExpr](node, func(kv *ast.KeyValueExpr) {
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != sagaCompensateFieldName {
+				return
+			}
+			// Verify the field's declared type is CompensateFunc via struct
+			// field lookup (TypeOf on a CompositeLit KV value may return the
+			// underlying func signature, not the named alias).
+			if !compensateKVFieldIsCompensateFunc(info, node) {
+				return
+			}
+			out = append(out, classifyExpr(kv.Value))
+		})
+	})
+
 	return out
 }
 
@@ -291,17 +288,16 @@ func classifyExpr(expr ast.Expr) compensateFuncAssignment {
 func sagaFuncDeclsByObject(p *Pass) map[*types.Func]*ast.FuncDecl {
 	out := make(map[*types.Func]*ast.FuncDecl)
 	for _, f := range p.Files {
-		for _, decl := range f.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Body == nil {
-				continue
+		scanner.EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
+				return
 			}
 			obj, ok := p.TypesInfo.Defs[fd.Name].(*types.Func)
 			if !ok {
-				continue
+				return
 			}
 			out[obj] = fd
-		}
+		})
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

清掉 develop 现状下的 4 个仓库卫生类问题（archtest 完整跑通 + CI funlen 阻塞）：

1. **CI funlen 阻塞** (`cells/accesscore/internal/ports/conformance/conformance.go`)
   `RunUserRepoConformance` 82 行 > funlen 80 阈值，把 USERREPO-METHOD-SET-FROZEN-01 narrow-write surface 抽出为 `runNarrowWriteSurfaceConformance` helper，主函数降至 49 行。
2. **`SCANNER-FRAMEWORK-USAGE-01` 违反** (`tools/archtest/saga_compensate_pure_test.go`)
   W6 saga executor 合入留下 3 处盲点：line 194 `ast.Inspect` → 3 个 `scanner.EachInSubtree`；line 222 `for-range over Elts` → `scanner.EachInChildren[ast.KeyValueExpr]`；line 295 `for-range over f.Decls` → `scanner.EachInChildren[ast.FuncDecl]`。检测语义不变。
3. **`INVENTORY-ANCHOR-{REQUIRED,VALID-ID}-01` 违反** (`tools/archtest/cli_unimpl_hide_test.go`)
   文件头多 ID 续行漏 `INVARIANT:` 前缀，按 `.claude/rules/gocell/ai-robust.md` §archtest 文件命名 修正成第一行 `// INVARIANT: ID1` + 续行 `//   - INVARIANT: ID2`。
4. **`.venv` 本地开发体验** (`tools/archtest/internal/scanner/scope.go`)
   `defaultSkipDirs` 加 `.venv` entry（gitignored，CI 不存在；本地开发者带 Python venv 时 `.venv/bin/python` 符号链接之前 fail-closed 把 ~40 个 archtest 整体打挂），同步扩 `TestEachContentFile_HonorsDefaultSkipDirs` 锁该 entry。

## Test plan

- [x] `golangci-lint run ./...` → `0 issues`（CI funlen kernel job 通过）
- [x] `SHARD_COUNT=4 bash hack/verify-archtest.sh` → 4 shards × 184 tests = 736 PASS
- [x] `go test ./tools/archtest/internal/scanner/...` → 验 .venv skip entry 生效
- [x] `go build ./...` 全树编译

🤖 Generated with [Claude Code](https://claude.com/claude-code)