### PR TITLE
refactor(archtest): seal RunTypedProduction upstream funnel — delete per-file generated/ façades

### DIFF
--- a/docs/architecture/202605141519-adr-archtest-pass-funnel.md
+++ b/docs/architecture/202605141519-adr-archtest-pass-funnel.md
@@ -173,6 +173,30 @@ Additionally, **`FixtureBuildTag` is unexported → `fixtureBuildTag`** (type-sy
 
 **Conclusion**: #944 strictly tightens defense #4 — one vector graduates archtest→type-system Hard (Form D via unexport), two previously-open vectors close (FlatNonDefaultTags union, runTypedWithRoot), one Blind spot closes (same-file var-binding), and the coverage self-test's by-name skip is path-bound (Medium) so item 1's `repoSkipTagAllowlist` recognition cannot itself reopen a fail-open hole for production files. The two residual ⚠️ rows (cross-func escape; loader-set maintenance) are unchanged accepted Blind spots at the same grade as the sibling rules (`diagsLoadPackages` / taggroup BS-4/BS-5), tracked for inter-procedural Hard upgrade via gh issue #973. No previously-clean row regresses. `passFunnelPermanentExempt` size unchanged.
 
+### #722 amendment — RunTypedProduction upstream Hard seal (2026-05-27)
+
+The original Stage 1.7 commit shipped `RunTypedProduction` with **upstream Medium**: a rule author could still write `RunTyped(t, opts, []string{"./..."}, rule) + per-file pass.IsGenerated(f) skip` to opt into production-only scope without the driver-level filter. `pass.go::RunTypedProduction` godoc documented this gap explicitly as "Upstream Medium (honest caveat)" and tagged it for upgrade tracking. #722 closes the gap by **sealed construction**: delete the two per-file generated/ predicate façades so the bypass form becomes a Go compile error.
+
+1. **`(*archtest.Pass).IsGenerated` method removed** (`tools/archtest/pass.go`). Any business test calling `pass.IsGenerated(file)` becomes a compile error — there is no method by that name on `*archtest.Pass`.
+2. **`archtest.IsGeneratedRelPath` package-level re-export removed** (`tools/archtest/resolve.go`). The parallel "bare path string check via package façade" path becomes a compile error symmetrically.
+3. The one production caller (`http_contract_visibility_type_segregation_01_test.go:192`) is migrated: the `pass.IsGenerated(file)` call was dead code given the existing package-level filter at line 164 (`strings.Contains(pkgPath, "/generated/")`) which already excludes generated packages at Pass entry. Removed.
+4. The Wave 3 anchor `TestOutboxHandleResultFactoryPreferred_GeneratedLoadAnchor_Wave3` (`outbox_invariants_test.go`) — a meta-probe documenting that `RunTyped("./...")` loads generated/ files — switches from `IsGeneratedRelPath(rel)` to inline `strings.HasPrefix(rel, "generated/")`. This is semantically identical (`typeseval.IsGeneratedRelPath` body is literally this prefix check); the anchor probes loader output, not a production rule's filtering discipline.
+5. The two unit tests of the deleted symbols (`TestPass_IsGenerated`, `TestIsGeneratedRelPathReExported`) and one redundant safety-net call in `TestRunTypedProduction_excludesGeneratedPackages` (line 1230's `strings.HasPrefix` already asserts the same property) are deleted.
+
+**Threat matrix re-evaluation (per ai-robust.md §ADR amendment 落地必查):**
+
+| Vector | Before #722 | After #722 | Status change |
+|--------|-------------|------------|---------------|
+| `RunTyped("./...") + pass.IsGenerated(f)` per-file skip (façade-method form) | **Latently legal** (documented "upstream Medium honest caveat"; archtest-undetected) | **Compile error** — method does not exist on `*archtest.Pass` | ✅ Upgraded archtest-Medium → type-system Hard |
+| `RunTyped("./...") + archtest.IsGeneratedRelPath(rel)` per-file skip (façade-function form) | Latently legal (parallel path; same Medium) | **Compile error** — function does not exist in `archtest` package | ✅ Upgraded archtest-Medium → type-system Hard |
+| `RunTyped("./...") + typeseval.IsGeneratedRelPath(rel)` direct call to the typeseval oracle | Banned by `PASS-FUNNEL-RESOLVE-01` (Medium archtest, type-aware) | Banned by `PASS-FUNNEL-RESOLVE-01` (unchanged; symbol kept in banned set) | ⚠️ Unchanged (Medium archtest — same grade as sibling typeseval helpers, AST type-aware ceiling for symbol-reference bans in Go) |
+| `RunTyped("./...") + strings.HasPrefix(rel, "generated/")` hand-rolled per-file skip | Unguarded | Unguarded — but a deliberate visible deviation from the framework filter, surfaces in code review (no archtest façade to "casually" reach for) | ⚠️ Residual escape (accepted) — Go is Turing-complete, banning literal prefix checks is not expressible at any grade; raises friction by removing the convenience path |
+| `Pass.IsGenerated` / `archtest.IsGeneratedRelPath` future re-introduction (alias / re-shape) | N/A | Symbol absence + this amendment row documents the seal intent; closely paired with `RunTypedProduction` godoc's `Ref: sealed construction` line | ⚠️ Review-bound (Medium — same grade as the sibling `fixtureTagLoaderSet` enumeration maintenance row above) |
+
+**Conclusion**: #722 strictly tightens defense #4 (well-known-typeseval-helper façade discipline) by removing the two per-file generated/ façades that the documented upstream bypass relied upon. Two latently-legal vectors graduate archtest-Medium → type-system Hard (façade-method and façade-function forms); the existing oracle ban (PASS-FUNNEL-RESOLVE-01) is unchanged. The residual escape (hand-rolled `strings.HasPrefix`) is unavoidable in Go without banning the entire `strings.HasPrefix` API and is downgraded to "visible code-review deviation" since there is no longer a low-friction framework path. The new review-bound row (future re-introduction of the deleted façades) sits at the same Medium grade as sibling enumeration-maintenance rows. No previously-clean row regresses. `passFunnelPermanentExempt` size unchanged. `pass.go::RunTypedProduction` godoc updated to claim **upstream Hard (type-system seal)**.
+
+ref: ai-robust.md §Hard 范本 "sealed construction"; closes #722.
+
 ## Industry precedent
 
 | Project | Pass shape | INV-1 defense |

--- a/tools/archtest/http_contract_visibility_type_segregation_01_test.go
+++ b/tools/archtest/http_contract_visibility_type_segregation_01_test.go
@@ -188,8 +188,10 @@ func checkPassForVisibilityViolations(pass *Pass, ifaceSet *contractServiceIface
 	var out []httpVisibilityViolation
 	for _, file := range pass.Files {
 		rel := pass.Rel(file)
-		// Skip test files and generated files.
-		if strings.HasSuffix(rel, "_test.go") || pass.IsGenerated(file) {
+		// Skip test files. Generated packages are already filtered at the Pass
+		// level above (pkgPath contains "/generated/"), so no per-file
+		// generated check is needed.
+		if strings.HasSuffix(rel, "_test.go") {
 			continue
 		}
 

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1711,17 +1711,13 @@ func TestOutboxHandleResultFactoryPreferred(t *testing.T) {
 //
 // Anchor (informational, not a TDD RED): documents that
 // `typeseval.SharedResolver(root, false, nil, "./...")` DOES include
-// generated/ packages, contradicting the comment block above
-// TestOutboxHandleResultFactoryPreferred which claims `go list ./...`
-// default-skips generated/. Wave 3 introduces typeseval.IsGeneratedRelPath
-// + applies it before scanForHandleResultLiterals so the rule no longer
-// scans generated/ paths even though they ARE loaded. The Wave 3 commit
-// also adds a fixture-driven sub-test that exercises the skip with a
-// synthetic generated/-rel path containing a HandleResult literal.
+// generated/ packages, so the rule's choice of RunTypedProduction (which
+// pre-filters generated/ at the driver) is load-bearing — switching to
+// RunTyped("./...") would silently scan generated/ output.
 //
 // This test pins the load behavior so a future packages.Load default
 // change (or a `cfg.BuildFlags=["-tags=nogen"]` style filter at the
-// loader layer) doesn't silently mask the need for IsGeneratedRelPath.
+// loader layer) doesn't silently mask the need for RunTypedProduction.
 func TestOutboxHandleResultFactoryPreferred_GeneratedLoadAnchor_Wave3(t *testing.T) {
 	t.Parallel()
 
@@ -1732,7 +1728,7 @@ func TestOutboxHandleResultFactoryPreferred_GeneratedLoadAnchor_Wave3(t *testing
 		}
 		for _, file := range p.Files {
 			rel := p.Rel(file)
-			if IsGeneratedRelPath(rel) {
+			if strings.HasPrefix(rel, "generated/") {
 				generatedFiles = append(generatedFiles, rel)
 			}
 		}
@@ -1741,11 +1737,11 @@ func TestOutboxHandleResultFactoryPreferred_GeneratedLoadAnchor_Wave3(t *testing
 
 	if len(generatedFiles) == 0 {
 		t.Fatalf("anchor invalidated: RunTyped(./...) loaded 0 generated/ files; " +
-			"the rule's outdated comment claiming `go list ./...` default-skips generated/ " +
-			"may now be accurate, but verify by running `go list ./... | grep ^github.com/ghbvf/gocell/generated/` " +
-			"before removing the IsGeneratedRelPath skip")
+			"the rule's documented contrast against RunTypedProduction is vacuous. " +
+			"Verify by running `go list ./... | grep ^github.com/ghbvf/gocell/generated/` " +
+			"before relaxing the RunTypedProduction requirement.")
 	}
-	t.Logf("anchor: RunTyped(./...) loaded %d generated/ files — Wave 3's IsGeneratedRelPath must skip these", len(generatedFiles))
+	t.Logf("anchor: RunTyped(./...) loaded %d generated/ files — RunTypedProduction must continue to filter these", len(generatedFiles))
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/archtest/pass.go
+++ b/tools/archtest/pass.go
@@ -273,10 +273,12 @@ func RunTypedDir(t testing.TB, dir string, opts TypedOpts, patterns []string, ru
 // observe codegen output (false-positive risk + duplicated declarations).
 // It is the Pass-model successor of typeseval.LoadProductionPackages /
 // ProductionResolver: the generated/ filter is applied by the driver, NOT by
-// a per-callsite `if pass.IsGenerated(f) { continue }` discipline (which an
-// author can forget — a Hard→Soft regression).
+// a per-callsite generated-path skip discipline (which an author can forget —
+// a Hard→Soft regression). The corresponding per-file façades
+// ((*Pass).IsGenerated and archtest.IsGeneratedRelPath) were removed by #722
+// to seal the upstream funnel.
 //
-// AI-robust: downstream Hard / upstream Medium.
+// AI-robust: downstream Hard / upstream Hard (type-system seal).
 //
 //   - Downstream Hard: scanning generated/ output is NOT EXPRESSIBLE through
 //     this entry — a Pass it yields never contains a generated/ file. The
@@ -289,13 +291,17 @@ func RunTypedDir(t testing.TB, dir string, opts TypedOpts, patterns []string, ru
 //     / SharedResolver calls in business *_test.go; RunTypedProduction is the
 //     only legitimate production-load funnel (funnel widened, not bypassed).
 //
-//   - Upstream Medium (honest caveat): a rule author can still write
-//     RunTyped(t, opts, []string{"./..."}, rule) + manual pass.IsGenerated(f)
-//     skip per file. That form compiles and runs; generated/ files are present
-//     in the Pass but skipped per-file. It is not enforced to route through
-//     RunTypedProduction. The Hard "upstream" property (violation unrepresentable
-//     at the call site) is not achievable without sealing the RunTyped API,
-//     which would break fixture-module and partial-scan rules.
+//   - Upstream Hard (type-system seal): the bypass form
+//     RunTyped(t, opts, []string{"./..."}, rule) + per-file pass.IsGenerated(f)
+//     skip is no longer expressible. (*Pass).IsGenerated method and the
+//     archtest.IsGeneratedRelPath package-level re-export have been removed,
+//     so the per-file generated/ predicate has no archtest façade. The
+//     underlying oracle typeseval.IsGeneratedRelPath is banned by
+//     PASS-FUNNEL-RESOLVE-01 in business *_test.go (Medium archtest). The
+//     residual escape — hand-rolling strings.HasPrefix(rel, "generated/") —
+//     is a deliberate visible deviation from the framework filter, not a
+//     silent miss; it surfaces in code review. Closes #722.
+//     Ref: sealed construction (.claude/rules/gocell/ai-robust.md §Hard 范本).
 //
 // Failure modes (module-root not found, go.mod unreadable, load error)
 // fail-loud via t.Fatalf. For the full set including generated/, use
@@ -499,17 +505,4 @@ func (p *Pass) IsFileInScope(f *ast.File) bool {
 		return true
 	}
 	return expr.Eval(typeseval.BuildContextPredicate())
-}
-
-// IsGenerated reports whether f is a codegen output file under the repo's
-// generated/ tree. It delegates to typeseval.IsGeneratedRelPath on pass.Rel(f).
-//
-// Returns true when the file's module-relative path begins with "generated/".
-// Returns false (non-generated, conservative) when [Pass.Rel](f) yields the
-// absolute fallback path — i.e. when the file is outside the module root and
-// filepath.Rel returns the absolute path unchanged; IsGeneratedRelPath will
-// not match a "generated/" prefix on an absolute path.
-// f must come from pass.Files; behavior is undefined for files from other Passes.
-func (p *Pass) IsGenerated(f *ast.File) bool {
-	return typeseval.IsGeneratedRelPath(p.Rel(f))
 }

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -11,11 +11,14 @@ package archtest
 // The first four rules forbid archtest tools/archtest/<file>_test.go from
 // reaching the legacy entry points directly. Authors must use archtest.Run
 // (AST-only) / archtest.RunTyped (typed) / archtest.RunTypedFixture (fixture
-// packages) / archtest.RunTypedProduction (production-only) via the
-// Pass-Driver paradigm, and must call the façade helper functions in
-// archtest.ResolvePackageRef / ResolveMethodCall / EvaluateConstString /
-// FlatNonDefaultTags / KnownNonDefaultTags / Pass.IsFileInScope /
-// Pass.IsGenerated instead of importing internal/typeseval directly.
+// packages) / archtest.RunTypedProduction (production-only — driver-level
+// generated/ filter) via the Pass-Driver paradigm, and must call the façade
+// helper functions archtest.ResolvePackageRef / ResolveMethodCall /
+// EvaluateConstString / FlatNonDefaultTags / KnownNonDefaultTags /
+// Pass.IsFileInScope instead of importing internal/typeseval directly. The
+// per-file generated/ predicate has no façade by design — production-scope
+// rules MUST take generated/ filtering at the driver level via
+// archtest.RunTypedProduction (#722 sealed construction).
 //
 // PASS-FUNNEL-FIXTURE-TAG-01 closes the façade-bypass leg of the
 // archtest_fixture funnel: RunTypedFixture's outward Hard (FixtureOpts has

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -343,7 +343,8 @@ func diagsPackagesImport(tgt passFunnelTarget) []scanner.Diagnostic {
 // scannerImportBanCount from 3 to 2, failing the assertion.
 func diagsResolveHelpers(tgt passFunnelTarget) []scanner.Diagnostic {
 	const replacement = "archtest.{ResolvePackageRef,ResolveMethodCall,EvaluateConstString," +
-		"FlatNonDefaultTags,KnownNonDefaultTags} / Pass.{IsFileInScope,IsGenerated} / archtest.ImportBan"
+		"FlatNonDefaultTags,KnownNonDefaultTags} / Pass.{IsFileInScope} / archtest.ImportBan" +
+		" / archtest.RunTypedProduction (driver-level generated/ filter; no per-file façade)"
 	return scanForForbiddenCallees(
 		tgt,
 		map[string]map[string]bool{
@@ -717,7 +718,9 @@ func collectFixtureTagBoundObjects(info *types.Info, file *ast.File) map[types.O
 //   - typeseval helpers → archtest.ResolvePackageRef / .ResolveMethodCall /
 //     .EvaluateConstString / .FlatNonDefaultTags / .KnownNonDefaultTags
 //   - ParseBuildConstraint+BuildContextPredicate → pass.IsFileInScope(f)
-//   - IsGeneratedRelPath → pass.IsGenerated(f)
+//   - IsGeneratedRelPath → use archtest.RunTypedProduction (driver-level
+//     filter); the per-file Pass.IsGenerated / archtest.IsGeneratedRelPath
+//     façades were removed by #722 to seal the upstream funnel.
 //   - scanner.ImportBan → archtest.ImportBan (type alias, same struct API)
 //
 // Detection: SelectorExpr / bare Ident walk + typeseval.ResolvePackageRef

--- a/tools/archtest/pass_test.go
+++ b/tools/archtest/pass_test.go
@@ -4,7 +4,7 @@
 // driver surface: archtest.Run / archtest.RunTyped / archtest.RunTypedDir
 // plus the unexported helpers buildTypedPass / newPackageRel /
 // isPackageWithTestFiles. Also covers the Stage 1.5 additions: Pass.Abs,
-// Pass.IsFileInScope, Pass.IsGenerated, the façade helpers (ResolvePackageRef,
+// Pass.IsFileInScope, the façade helpers (ResolvePackageRef,
 // ResolveMethodCall, EvaluateConstString, FlatNonDefaultTags,
 // KnownNonDefaultTags), and the ImportBan re-export. Stage 1.6 additions:
 // RunTypedDir (fixture-module driver) and runTypedWithRoot delegation.
@@ -506,46 +506,6 @@ func TestPass_IsFileInScope(t *testing.T) {
 	Run(t, ModuleScope(root, IncludeTests()), rule)
 }
 
-// TestPass_IsGenerated verifies Pass.IsGenerated delegates correctly to
-// typeseval.IsGeneratedRelPath. Files under generated/ return true; others false.
-// RED until (*Pass).IsGenerated is added.
-//
-// Oracle comparison: typeseval.IsGeneratedRelPath called on pass.Rel(f).
-// The import of typeseval here is legal (pass_test.go is permanently exempt).
-func TestPass_IsGenerated(t *testing.T) {
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "go.mod"),
-		[]byte("module example.com/gen\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile go.mod: %v", err)
-	}
-	genDir := filepath.Join(root, "generated")
-	if err := os.Mkdir(genDir, 0o700); err != nil {
-		t.Fatalf("Mkdir generated: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(genDir, "code.go"),
-		[]byte("package generated\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile generated/code.go: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "normal.go"),
-		[]byte("package gen\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile normal.go: %v", err)
-	}
-
-	rule := func(p *Pass) []Diagnostic {
-		for _, f := range p.Files {
-			rel := p.Rel(f)
-			oracle := typeseval.IsGeneratedRelPath(rel)
-			got := p.IsGenerated(f)
-			if got != oracle {
-				t.Errorf("Pass.IsGenerated(%s) = %v, oracle typeseval.IsGeneratedRelPath = %v",
-					rel, got, oracle)
-			}
-		}
-		return nil
-	}
-	Run(t, ModuleScope(root, IncludeGenerated()), rule)
-}
-
 // TestImportBanReExport verifies that archtest.ImportBan is a type alias for
 // scanner.ImportBan, and that a trivial Run via the façade alias works.
 // RED until resolve.go adds `type ImportBan = scanner.ImportBan`.
@@ -993,41 +953,6 @@ func TestParseBuildConstraintReExported(t *testing.T) {
 	}
 }
 
-// TestIsGeneratedRelPathReExported verifies that archtest.IsGeneratedRelPath
-// is a thin delegate to typeseval.IsGeneratedRelPath: the returned bool must
-// agree with the oracle for generated/ and non-generated paths.
-//
-// RED proof: if IsGeneratedRelPath were removed from resolve.go (or not yet
-// added), this test would fail to compile.
-//
-// pass_test.go is permanently exempt from PASS-FUNNEL-RESOLVE-01 so the
-// direct typeseval oracle call here is legal.
-func TestIsGeneratedRelPathReExported(t *testing.T) {
-	cases := []struct {
-		rel  string
-		want bool
-	}{
-		{"generated/contracts/foo/v1/handler.go", true},
-		{"generated/foo.go", true},
-		// NOT generated: paths that don't start with "generated/"
-		{"cells/accesscore/slices/sessionlogin/handler.go", false},
-		{"kernel/outbox/result.go", false},
-		// Sub-directory named "generated" inside a hand-written package is not matched.
-		{"cells/foo/generated/bar.go", false},
-	}
-
-	for _, tc := range cases {
-		facade := IsGeneratedRelPath(tc.rel)
-		oracle := typeseval.IsGeneratedRelPath(tc.rel)
-		if facade != oracle {
-			t.Errorf("IsGeneratedRelPath(%q): façade=%v oracle=%v", tc.rel, facade, oracle)
-		}
-		if facade != tc.want {
-			t.Errorf("IsGeneratedRelPath(%q) = %v, want %v", tc.rel, facade, tc.want)
-		}
-	}
-}
-
 // ── Stage 1.6 additions ────────────────────────────────────────────────────
 
 // tbFatalSpy is a minimal testing.TB substitute that captures Fatalf/FailNow
@@ -1230,9 +1155,6 @@ func TestRunTypedProduction_excludesGeneratedPackages(t *testing.T) {
 			if strings.HasPrefix(rel, "generated/") {
 				t.Errorf("RunTypedProduction yielded generated/ file %q — "+
 					"generated packages must be unreachable under this entry", rel)
-			}
-			if p.IsGenerated(f) {
-				t.Errorf("RunTypedProduction yielded IsGenerated file %q", p.Rel(f))
 			}
 		}
 		if p.Pkg != nil && strings.Contains(p.Pkg.Path(), "/generated/") {

--- a/tools/archtest/resolve.go
+++ b/tools/archtest/resolve.go
@@ -26,8 +26,14 @@
 //   - enumerate build-tag groups for multi-tag SharedResolver loops —
 //     FlatNonDefaultTags / KnownNonDefaultTags;
 //   - extract a file's build constraint expression for 3-way evaluation under
-//     custom tag sets — ParseBuildConstraint;
-//   - test whether a module-relative path is under generated/ — IsGeneratedRelPath.
+//     custom tag sets — ParseBuildConstraint.
+//
+// Deliberately NOT re-exported: any per-file "is this generated?" predicate.
+// Production-scope rules must take generated/ filtering at the driver level
+// via archtest.RunTypedProduction. The per-file Pass.IsGenerated method and
+// archtest.IsGeneratedRelPath package-level re-export were removed by #722 to
+// seal the upstream funnel (sealed construction; see pass.go::RunTypedProduction
+// godoc and .claude/rules/gocell/ai-robust.md §Hard 范本).
 //
 // Hand-rolling these patterns via raw go/types in each rule is error-prone
 // (missed dot-import bare-Ident path, missed alias form, missed untyped const
@@ -171,24 +177,4 @@ func BuildContextPredicate(extraTags ...string) func(string) bool {
 // absolute OS-native path (pass.Abs(f) is a suitable source).
 func ParseBuildConstraint(filePath string) (constraint.Expr, error) {
 	return typeseval.ParseBuildConstraint(filePath)
-}
-
-// IsGeneratedRelPath reports whether rel is a codegen output path under the
-// repo's generated/ tree. rel must be a module-relative slash path (as
-// returned by pass.Rel(f) or pkgFileRel).
-//
-// Returns true when rel begins with "generated/" (top-level only). The repo
-// reserves exactly one generated/ directory at module root; a "generated/"
-// prefix inside a hand-written package would be a layout violation and is
-// intentionally not matched.
-//
-// Use [Pass.IsGenerated] when the path is derived from a *ast.File in
-// pass.Files — it calls pass.Rel(f) automatically. Use this function when
-// the module-relative path string is already available (e.g. iterating a
-// resolver's packages outside a Pass-Driver rule, as in the loader anchor
-// test TestOutboxHandleResultFactoryPreferred_GeneratedLoadAnchor_Wave3).
-//
-// Thin delegation to [typeseval.IsGeneratedRelPath].
-func IsGeneratedRelPath(rel string) bool {
-	return typeseval.IsGeneratedRelPath(rel)
 }


### PR DESCRIPTION
## Summary

Seals the `RunTypedProduction` upstream funnel by deleting the per-file generated/ façades, making the documented bypass form a **compile error** instead of an archtest detection. Upgrades upstream rating from **Medium → Hard (type-system seal)**.

- **Delete `(*Pass).IsGenerated`** (`tools/archtest/pass.go`)
- **Delete `archtest.IsGeneratedRelPath`** package-level re-export (`tools/archtest/resolve.go`)
- Migrate the 1 production caller (`http_contract_visibility_type_segregation_01_test.go`): the per-file `IsGenerated` skip was dead code given the package-level filter at line 164.
- Migrate the anchor caller (`outbox_invariants_test.go`): switch `IsGeneratedRelPath(rel)` → `strings.HasPrefix(rel, "generated/")` (anchor probes loader output, not a production-rule filter).
- Delete redundant `p.IsGenerated(f)` safety-net in `TestRunTypedProduction_excludesGeneratedPackages` (line 1230 `strings.HasPrefix` already covers).
- Delete the two unit tests (`TestPass_IsGenerated` / `TestIsGeneratedRelPathReExported`) — subjects of test no longer exist.
- Update godoc + replacement messages in `pass.go` and `pass_funnel_test.go`.

Net: **+43 / -141 (-98 lines)**.

## Funnel rating

| Path | Before | After |
|------|--------|-------|
| Downstream (`typeseval.LoadProductionPackages` etc) | Hard (PASS-FUNNEL-LOADPACKAGES-01) | unchanged |
| Downstream (`typeseval.IsGeneratedRelPath` direct call) | Medium (PASS-FUNNEL-RESOLVE-01) | unchanged |
| Upstream (`Pass.IsGenerated` per-file skip) | Medium (documented bypass) | **Hard — method removed, compile error** |
| Upstream (`archtest.IsGeneratedRelPath` per-file skip) | Medium (façade) | **Hard — function removed, compile error** |
| Upstream (`strings.HasPrefix` hand-rolled) | unguarded | unguarded — visible code-review deviation |

Pattern: `.claude/rules/gocell/ai-robust.md` §Hard 范本 **"sealed construction"** (let package-external call become Go-visibility compile error).

## Open-source benchmark (per CLAUDE.md §参考框架)

| Framework | Model | Type-system seal on "production-only scope" |
|-----------|-------|---------|
| `golang.org/x/tools/go/analysis` | single `Analyzer.Run` + per-file `ast.IsGenerated` | No |
| `golangci-lint` | single runner + `Issues.ExcludeGenerated` runtime flag | No |
| `buf` lint | typed `RuleType` (AST node level, not generation provenance) | No |

GoCell goes further by **deleting** the per-file generated/ façade so fail-open is unrepresentable.

`ref: golangci-lint pkg/config/issues.go` (filter-at-driver pattern, closest structural precedent)

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags=integration ./...` clean
- [x] `go test ./...` — impacted tests pass (`TestPassFunnel*` / `TestPass_*` / `TestRunTypedProduction_*` / `TestHTTPContractVisibilityTypeSegregation01_*` / `TestOutboxHandleResultFactoryPreferred*`)
- [x] `golangci-lint run ./...` — 0 issues (gofmt issue introduced by edits was caught and fixed)
- [x] Reverse self-check: anchor test reports 214 generated/ files loaded under `RunTyped("./...")` — non-vacuous; `RunTypedProduction` filter remains load-bearing.

### Pre-existing failures on `origin/develop` (NOT introduced by this PR — verified on clean checkout)

- `TestScannerFrameworkUsage01` — flags pre-existing patterns in `saga_compensate_pure_test.go:194,222,295` (introduced by PR #1179 saga executor)
- `TestInventoryAnchorRequired` — flags `cli_unimpl_hide_test.go:1` missing `// INVARIANT:` anchor
- `TestInventoryAnchorValidID` — same file, malformed anchor

These exist on `origin/develop` independently of this PR.

## AI-robust grading

This PR modifies an enforcement mechanism (per CLAUDE.md §AI-robust 治理章程 / ai-robust.md §适用范围):

- **Hard 范本 match**: `sealed construction` — package-external call is Go-visibility compile error
- **Funnel 双向锁评级**: downstream Hard (unchanged) + upstream **Hard** (type-system seal) = full closed-loop funnel
- **Residual escape**: hand-rolled `strings.HasPrefix(rel, "generated/")` — accepted as visible code-review deviation (Go is Turing-complete; cannot exclude hand-rolled detection)

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)