### PR TITLE
refactor(archtest): funnel allowlist file→callsite Hard 升级 — #732

### DIFF
--- a/cells/accesscore/internal/credentialinvalidate/invalidator.go
+++ b/cells/accesscore/internal/credentialinvalidate/invalidator.go
@@ -41,6 +41,24 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth/session"
 )
 
+// Applier is the credential-invalidation funnel surface used by callers that
+// need substitutability for testing (e.g. sessionrefresh injects a spy in
+// unit tests). The sole production implementation is *Invalidator.
+//
+// AI-robust archtest dependency: this interface MUST live in the
+// credentialinvalidate package — not in any caller package — so
+// info.Selections resolves Apply via this package, making call-sites
+// detectable by CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01. A caller-package
+// local interface (the pre-#1196 sessionrefresh.invalidatorApplier form)
+// would resolve Apply via the caller package, hiding the callsite from the
+// callsite-level scan and creating a Soft channel. Keep the interface here.
+type Applier interface {
+	Apply(ctx context.Context, subjectID string, event session.CredentialEvent) error
+}
+
+// Compile-time check: *Invalidator implements Applier.
+var _ Applier = (*Invalidator)(nil)
+
 // Invalidator is the single entry point for the credential-revocation trifecta:
 // bump user authz_epoch + revoke sessions + revoke refresh chain.
 // All callers must go through Apply; direct calls to the underlying stores

--- a/cells/accesscore/internal/domain/testdata/value_capture_setstatus_red/usage.go
+++ b/cells/accesscore/internal/domain/testdata/value_capture_setstatus_red/usage.go
@@ -1,0 +1,42 @@
+// Package value_capture_setstatus_red is a RED fixture for the
+// AUTHZ-MUTATION-APPLY-FUNNEL-01 form-completeness invariant (PR #1196
+// round-2): non-allowlisted code captures domain.User.SetStatus as a
+// function value WITHOUT immediately invoking it. The scanner must detect
+// this regression — function-value capture is the bypass form a
+// CallExpr.Fun-only walk would miss.
+//
+// LOCATION RATIONALE: imports cells/accesscore/internal/domain so Go's
+// internal-import rule requires this fixture to live under cells/accesscore/;
+// `testdata/` excludes the package from `go build ./...` while archtest
+// loads it via an explicit packages.Load pattern.
+package value_capture_setstatus_red
+
+import (
+	"time"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+)
+
+// badValueCapture stores domain.User.SetStatus as a function value. The
+// stored value is NOT invoked inside badValueCapture itself — the deferred
+// call would happen at the call site of fn. A CallExpr.Fun-only scanner
+// would miss this; the form-complete SelectorExpr scanner catches it
+// because info.Selections records a MethodVal selection for the bare
+// `u.SetStatus` SelectorExpr.
+func badValueCapture(u *domain.User) func(domain.UserStatus, time.Time) {
+	fn := u.SetStatus
+	return fn
+}
+
+// badReturnDirect returns the method value directly (no intermediate var)
+// — same SelectorExpr resolution, different surrounding statement.
+func badReturnDirect(u *domain.User) func(bool, time.Time) {
+	return u.SetPasswordResetRequired
+}
+
+// badArgPass passes the method value as an argument to another function.
+func badArgPass(u *domain.User) {
+	consume(u.SetStatus)
+}
+
+func consume(_ func(domain.UserStatus, time.Time)) {}

--- a/cells/accesscore/internal/domain/testdata/var_init_setstatus_red/usage.go
+++ b/cells/accesscore/internal/domain/testdata/var_init_setstatus_red/usage.go
@@ -1,0 +1,32 @@
+// Package var_init_setstatus_red is a RED fixture for the
+// AUTHZ-MUTATION-APPLY-FUNNEL-01 archtest blind-spot §6 (package-level
+// var init bypass).
+//
+// It invokes domain.User.SetStatus from a package-level var-init expression
+// — a node that has NO enclosing FuncDecl. The scanner must treat
+// ResolveEnclosingFunc → (nil, false) as an automatic violation with the
+// "outside any FuncDecl" substring, proving the var-init bypass form is
+// covered.
+//
+// LOCATION RATIONALE: imports cells/accesscore/internal/domain so Go's
+// internal-import rule requires this fixture to live under cells/accesscore/;
+// `testdata/` excludes the package from `go build ./...` while archtest
+// loads it via an explicit packages.Load pattern.
+package var_init_setstatus_red
+
+import (
+	"time"
+
+	"github.com/ghbvf/gocell/cells/accesscore/internal/domain"
+)
+
+// callSetStatusAtInit returns 0 after invoking the banned setter at
+// package-init time. The actual call site is the FuncLit invocation `()`,
+// which lives in a var-init expression — no enclosing FuncDecl.
+//
+//nolint:gochecknoglobals // RED fixture: package-level call is the regression form being asserted
+var _ = func() int {
+	u := &domain.User{}
+	u.SetStatus(domain.StatusLocked, time.Now())
+	return 0
+}()

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -51,24 +51,22 @@ func WithTxManager(tx persistence.CellTxManager) Option {
 	}
 }
 
-// invalidatorApplier is the minimal interface sessionrefresh needs from the
-// credential-invalidation funnel. Using an interface (rather than a concrete
-// *credentialinvalidate.Invalidator field) keeps the slice unit-testable with a
-// spy and decouples it from the concrete invalidator package at the type level.
-// Production code injects *credentialinvalidate.Invalidator which satisfies
-// this interface by method set.
-type invalidatorApplier interface {
-	Apply(ctx context.Context, subjectID string, event session.CredentialEvent) error
-}
-
 // WithInvalidator injects the credential-invalidation funnel used to
 // cascade epoch bump + session revoke + refresh chain revoke on refresh-token
 // reuse detection. Required — NewService fails fast when nil.
 // Nil is silently ignored to keep the option idempotent; final nil
 // enforcement is in NewService.
-func WithInvalidator(inv *credentialinvalidate.Invalidator) Option {
+//
+// Type rationale: the parameter is credentialinvalidate.Applier (the exported
+// funnel interface), not *credentialinvalidate.Invalidator. The interface
+// must live in credentialinvalidate so the callsite-level archtest
+// (CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01) can resolve s.invalidator.Apply
+// via info.Selections to a *types.Func with Pkg=credentialinvalidate.
+// Production wiring still passes a *Invalidator (which satisfies Applier);
+// unit tests inject a spy.
+func WithInvalidator(inv credentialinvalidate.Applier) Option {
 	return func(s *Service) {
-		if inv != nil {
+		if !validation.IsNilInterface(inv) {
 			s.invalidator = inv
 		}
 	}
@@ -85,8 +83,8 @@ type Service struct {
 	// fails fast when nil. On refresh-token reuse detection, Apply is called
 	// inside the outer transaction to atomically bump authz_epoch, revoke all
 	// sessions, and revoke all refresh chains for the subject.
-	invalidator invalidatorApplier `gocell:"required" gocellErr:"sessionrefresh: Invalidator required; use WithInvalidator"` //nolint:lll // R2-approved: struct tag for required-dep funnel cannot be split
-	issuer      *auth.JWTIssuer    `gocell:"required"`
+	invalidator credentialinvalidate.Applier `gocell:"required" gocellErr:"sessionrefresh: Invalidator required; use WithInvalidator"` //nolint:lll // R2-approved: struct tag for required-dep funnel cannot be split
+	issuer      *auth.JWTIssuer              `gocell:"required"`
 	logger      *slog.Logger
 	clock       clock.Clock
 }

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -166,13 +166,13 @@ type invalidatorServiceDeps struct {
 	refreshStore refresh.Store
 	issuer       *auth.JWTIssuer
 	logger       *slog.Logger
-	inv          invalidatorApplier
+	inv          credentialinvalidate.Applier
 }
 
 // mustNewServiceWithInvalidator constructs a Service with an explicit spy
-// invalidator (for tests that exercise the reuse-cascade path). Since the
-// invalidatorApplier interface is unexported but tests are in the same package,
-// the spy is directly assigned to the service's invalidator field.
+// invalidator (for tests that exercise the reuse-cascade path). The spy
+// implements credentialinvalidate.Applier (exported) so the same field type
+// the archtest funnel resolves against is used here.
 func mustNewServiceWithInvalidator(
 	deps invalidatorServiceDeps,
 	opts ...Option,

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -76,11 +76,44 @@ package archtest
 //  2. //go:linkname / unsafe — the universal class that defeats any static
 //     analysis; out of scope for an archtest funnel.
 //
+//  3. Interface-indirection routing (Rule 4 specific). When a slice injects
+//     the funnel via a locally-defined interface (e.g.
+//     sessionrefresh.invalidatorApplier in service.go) for unit-testability
+//     with a spy, info.Selections resolves the call to that local interface's
+//     Apply method — NOT to credentialinvalidate.(*Invalidator).Apply. The
+//     fn.Pkg().Path() check rejects it as out-of-scope, so the callsite is
+//     scanner-invisible. Documented trade-off: sessionrefresh.handleReuseDetected
+//     is a legitimate Apply caller but cannot appear in
+//     upstreamCallerCallsiteAllowlist (the meta-invariant test would then
+//     flag it as stale). Future analogous interface-routed callers will also
+//     be scanner-invisible; this is a known limit of info.Selections-based
+//     resolution. The reverse RED fixture (sessionlogin_direct_apply_red)
+//     uses the concrete *credentialinvalidate.Invalidator type, so all
+//     direct-typed paths remain locked.
+//
 // Covered without a separate self-check: embedded struct method promotion
 // (`type Wrapper struct { session.Store }; w.RevokeForSubject(...)`) —
 // ResolveMethodCall recovers the correct *types.Func via info.Selections, so
 // promotion is transparent. The function-value-capture form (formerly a
 // blind-spot self-check) is now caught directly by the form-complete scan.
+//
+// Rule 4 also has callsite-level identity invariants beyond the targetPkg
+// filter:
+//
+//  4. Package-level var init bypass: a setter call at package scope has no
+//     enclosing FuncDecl. ResolveEnclosingFunc returns (nil, false) and the
+//     scan emits an "outside any FuncDecl" violation automatically — handled
+//     in scanUpstreamCallerViolationsPass, no separate self-check needed
+//     (the var-init blind spot for similar funnels is documented at
+//     domain_authz_mutation_funnel_invariants_test.go §6).
+//
+//  5. FuncLit-inside-FuncDecl semantic choice (NOT a blind spot):
+//     ResolveEnclosingFunc collapses a nested FuncLit's identity to its
+//     outermost FuncDecl. Rationale: FuncLit author = FuncDecl author.
+//     Affected callers: identitymanage.deleteUserAndRevokeTokens (Apply
+//     inside RunInTx closure) — the closure's outer FuncDecl is correctly
+//     resolved to deleteUserAndRevokeTokens. Same pattern for all other
+//     allowlisted callers.
 
 import (
 	"fmt"
@@ -114,51 +147,70 @@ const (
 	invalidatorMethod = "Apply"
 )
 
-// upstreamCallerAllowlistPrefixes lists module-relative path prefixes whose
-// production code is permitted to invoke credentialinvalidate.Invalidator.Apply
-// directly. Every other caller is a violation: new authz-affecting state
-// transitions must route through one of these entry points.
+// upstreamCallerCallsiteAllowlist enumerates the exact production callsites
+// (enclosing FuncDecl identities) permitted to invoke or capture
+// credentialinvalidate.(*Invalidator).Apply. Keys are *types.Func.FullName()
+// values (canonical Go reflection form); values document the rationale.
 //
-// As of S4e (PR #494):
-//   - authzmutate/ owns all live-aggregate authz mutations (status demotion,
-//     RequirePasswordReset, role-revoke) via Mutator.Apply → inv.Apply.
-//   - identitymanage/ calls inv.Apply directly for two co-tx atomic operations:
-//     (a) Delete: user-row delete + revoke must be one transaction.
-//     (b) changePasswordInTx: password write + revoke must be one transaction.
-//     Routing through authzmutate would split these transactions; direct call is
-//     the intentional exception. Documented in service.go with
-//     "Routed through funnel (CREDENTIAL-INVALIDATE-FUNNEL-01)" comment.
-//   - sessionrefresh/ owns the reuse / stale-epoch cascade entry point.
-//   - rbacassign/ calls inv.Apply for role-revoke co-tx with the role-row write.
-//     Same atomicity reason as identitymanage.
-//   - The funnel package itself is always allowed (Apply is defined here).
+// Issue #732 upgrade (this file, 2026-05-27): replaces the prior file-level
+// upstreamCallerAllowlistPrefixes []string. callsite-level keying eliminates
+// the "same file / different function" slip path — any new function in an
+// already-allowed slice MUST explicitly add a callsite entry.
 //
-// S4e note: setup/ and adminprovision/ were removed from this list. Neither
-// package calls credentialinvalidate.Invalidator.Apply in production code
-// (verified by grep; provisioner.go only calls SetPasswordResetRequired on a
-// freshly constructed aggregate at creation time). Removing them tightens the
-// rule. The canonical allowlist is documented in ADR §A10 and is now in sync
-// with this set.
-var upstreamCallerAllowlistPrefixes = []string{
-	"cells/accesscore/internal/credentialinvalidate/",
-	"cells/accesscore/internal/authzmutate/",
-	"cells/accesscore/slices/identitymanage/",
-	"cells/accesscore/slices/sessionrefresh/",
-	"cells/accesscore/slices/rbacassign/",
-}
-
-// isUpstreamCallerAllowlisted reports whether a module-relative path is in
-// the upstream caller allowlist. Test files (*_test.go) always pass.
-func isUpstreamCallerAllowlisted(rel string) bool {
-	if strings.HasSuffix(rel, "_test.go") {
-		return true
-	}
-	for _, prefix := range upstreamCallerAllowlistPrefixes {
-		if strings.HasPrefix(rel, prefix) {
-			return true
-		}
-	}
-	return false
+// As of S4e (PR #494), the legitimate callers are:
+//
+//   - authzmutate/ — Mutator.ApplyInTx routes all live-aggregate authz
+//     mutations through Invalidator.Apply.
+//   - identitymanage/ — Delete + changePasswordInTx call Invalidator.Apply
+//     directly for co-tx atomicity (user-row delete and revoke, or password
+//     write and revoke, must be one transaction). Routing through authzmutate
+//     would split these transactions.
+//   - sessionrefresh/ — handleReuseDetected owns the reuse / stale-epoch
+//     cascade entry point.
+//   - rbacassign/ — persistChange calls Invalidator.Apply co-tx with the
+//     role-row write. Same atomicity reason as identitymanage.
+//
+// The funnel package itself (credentialinvalidate/) contains only the Apply
+// implementation — no internal call site exists today, so no entry is
+// needed. If a future helper inside the funnel calls Apply on a sibling
+// receiver, an entry must be added explicitly (no silent package allowance).
+//
+// S4e note: setup/ and adminprovision/ are NOT in this list. Neither calls
+// Invalidator.Apply in production code (provisioner.go only calls
+// SetPasswordResetRequired on a freshly constructed aggregate at creation
+// time). The canonical allowlist is documented in ADR §A10.
+//
+// Test files (*_test.go) bypass this check unconditionally. Removing the last
+// production caller of an entry triggers
+// TestCredentialInvalidateFunnel_AllowlistEntriesAreLive (meta-invariant),
+// forcing same-PR cleanup.
+// NOTE: sessionrefresh.handleReuseDetected is a LEGITIMATE production caller
+// of Invalidator.Apply, but it is NOT listed here — and cannot be listed —
+// because sessionrefresh injects the funnel via a locally-defined
+// `invalidatorApplier` interface (see slices/sessionrefresh/service.go:60)
+// for unit-testability with a spy. info.Selections resolves the call
+// `s.invalidator.Apply(...)` to (sessionrefresh.invalidatorApplier).Apply, NOT
+// to (credentialinvalidate.Invalidator).Apply, so the scanner cannot match
+// the (targetPkg, targetMethod) filter and never reaches the callsite check.
+// This is a structural blind spot of info.Selections-based method resolution
+// when business code intentionally routes through an interface contract.
+// Trade-off accepted: sessionrefresh's testability requires the interface
+// (the spy implements invalidatorApplier without depending on credentialinvalidate);
+// any future caller that introduces an analogous interface field would also be
+// scanner-invisible. The reverse RED fixture (sessionlogin_direct_apply_red)
+// uses the concrete *credentialinvalidate.Invalidator type, so direct-typed
+// callsites remain locked.
+// Allowlist keys are types.Func.FullName() values; split via string concat
+// to keep lines under the lll limit while preserving the literal key.
+var upstreamCallerCallsiteAllowlist = map[string]string{
+	"(*github.com/ghbvf/gocell/cells/accesscore/internal/authzmutate.Mutator).ApplyInTx": "" +
+		"primary funnel — routes all live-aggregate authz mutations",
+	"(*github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage.Service).deleteUserAndRevokeTokens": "" +
+		"co-tx atomicity: user-row delete + revoke in one transaction",
+	"(*github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage.Service).changePasswordInTx": "" +
+		"co-tx atomicity: password write + revoke in one transaction",
+	"(*github.com/ghbvf/gocell/cells/accesscore/slices/rbacassign.Service).persistChange": "" +
+		"co-tx atomicity: role-row write + revoke in one transaction",
 }
 
 // funnelAllowlistPathPrefixes lists the module-relative path prefixes that
@@ -404,30 +456,25 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 // ─── Rule 4: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (Hard, post #1033) ──
 
 // TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01 enforces
-// CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: every call to
-// credentialinvalidate.(*Invalidator).Apply in production code must come
-// from one of the allowlisted upstream entry points (authzmutate,
-// identitymanage, sessionrefresh, rbacassign) or the funnel package
-// itself. New callers must justify their addition via a PR that updates
-// upstreamCallerAllowlistPrefixes — this puts the funnel's surface area on
-// the reviewer's radar instead of relying on string convention.
-// See ADR §A10 + §A16 for the canonical allowlist and co-tx atomicity
-// rationale, and the type-system seal that brings this rule to Hard.
+// CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: every reference (call or
+// function-value capture) to credentialinvalidate.(*Invalidator).Apply in
+// production code must originate from an enclosing FuncDecl whose canonical
+// identity is listed in upstreamCallerCallsiteAllowlist.
 //
-// AI-robust grade (post #1033): Hard. The rule's call-site allowlist
-// catches "wrong caller" (cells outside the allowlist invoking Apply
-// directly). The "missing caller" problem — a new user-authz mutator
-// forgetting to call Apply at all — is now closed structurally by the
-// sealed FenceToken capability proof: any mutation method (BumpAuthzEpoch
-// / RevokeForSubject / RevokeUser) requires a credentialfence.FenceToken
-// that only credentialfence.Mint can produce, and Mint's callers are
-// locked by FENCE-TOKEN-MINT-FUNNEL-01 to the funnel + storetest +
-// conformance + *_test.go. A new mutator that tries to revoke without
-// going through Invalidator.Apply cannot mint a FenceToken — production
-// archtest fails. See the package godoc and ADR §A16 for the full
-// closure proof.
+// callsite-level keying (issue #732): the prior file-level allowlist admitted
+// any new function in an already-allowed slice silently. callsite identity =
+// outermost FuncDecl's *types.Func.FullName() rejects that slip path: a new
+// caller MUST add an explicit allowlist entry, putting the funnel surface
+// directly on the reviewer's diff.
 //
-// RED fixture: tools/archtest/testdata/credential_invalidate_fixtures/
+// AI-robust grade (post #1033 + #732): Hard. The callsite-level allowlist
+// catches "wrong caller" with type-resolved (callee, caller) form-uniqueness.
+// The "missing caller" problem is closed structurally by the sealed
+// FenceToken capability proof (see package godoc + ADR §A16) — a new
+// mutator that tries to revoke without going through Invalidator.Apply
+// cannot mint a FenceToken.
+//
+// RED fixture: cells/accesscore/internal/credentialinvalidate/testdata/
 // sessionlogin_direct_apply_red — the sessionlogin slice is NOT on the
 // allowlist; calling invalidator.Apply from there must be detected.
 func TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01(t *testing.T) {
@@ -450,10 +497,10 @@ func TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01(t *testing.T) {
 		}
 		for _, file := range p.Files {
 			rel := p.Rel(file)
-			if isUpstreamCallerAllowlisted(rel) {
+			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			violations = append(violations, scanFunnelViolationsPass(
+			violations = append(violations, scanUpstreamCallerViolationsPass(
 				p, file, rel,
 				invalidatorPkg, invalidatorMethod,
 				"CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01",
@@ -467,12 +514,11 @@ func TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01(t *testing.T) {
 		t.Log(v)
 	}
 	assert.Empty(t, violations,
-		"CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: credentialinvalidate.Invalidator.Apply "+
-			"must only be called from the allowlisted upstream entry points "+
-			"(authzmutate, identitymanage, sessionrefresh, rbacassign) "+
-			"or the funnel package itself. Adding a new caller requires updating "+
-			"upstreamCallerAllowlistPrefixes; this puts the funnel surface on the "+
-			"reviewer's radar instead of relying on string convention. "+
+		"CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (callsite-level): "+
+			"credentialinvalidate.Invalidator.Apply must only be called from enclosing "+
+			"functions explicitly listed in upstreamCallerCallsiteAllowlist. "+
+			"Adding a new caller requires adding a callsite entry; "+
+			"this puts the funnel surface on the reviewer's diff. "+
 			"See ADR docs/architecture/202605101400-adr-credential-session-protocol.md §A10.")
 
 	verifyRedFixtureDetectedPass(
@@ -482,6 +528,124 @@ func TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01(t *testing.T) {
 		"CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 RED fixture",
 		1,
 	)
+}
+
+// scanUpstreamCallerViolationsPass walks file's AST for every SelectorExpr
+// resolving to (targetPkg, targetMethod) and emits a violation when the
+// SelectorExpr's enclosing FuncDecl identity is NOT in
+// upstreamCallerCallsiteAllowlist. Catches direct call AND function-value
+// capture forms (same form-completeness as scanFunnelViolationsPass — see
+// that function's godoc).
+//
+// A SelectorExpr located outside any FuncDecl (package-level var/const init)
+// is an automatic violation: it has no allowlistable identity. Test files
+// must be skipped by the caller (this function operates per-file but does
+// not filter *_test.go itself).
+func scanUpstreamCallerViolationsPass(
+	p *Pass,
+	file *ast.File,
+	rel string,
+	targetPkg, targetMethod, ruleID string,
+) []string {
+	var out []string
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != targetMethod {
+			return
+		}
+		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+		if !ok {
+			return
+		}
+		if fn.Pkg() == nil || fn.Pkg().Path() != targetPkg {
+			return
+		}
+		line := p.Fset.Position(sel.Pos()).Line
+		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, sel)
+		if !ok {
+			out = append(out, fmt.Sprintf(
+				"%s:%d: %s: reference to %s.%s outside any FuncDecl "+
+					"(package-level init or similar) — cannot be allowlisted",
+				rel, line, ruleID, filepath.Base(targetPkg), targetMethod,
+			))
+			return
+		}
+		callerID := caller.FullName()
+		if _, allowed := upstreamCallerCallsiteAllowlist[callerID]; allowed {
+			return
+		}
+		out = append(out, fmt.Sprintf(
+			"%s:%d: %s: reference to %s.%s from caller %q not in "+
+				"upstreamCallerCallsiteAllowlist (direct call or function-value capture)",
+			rel, line, ruleID, filepath.Base(targetPkg), targetMethod, callerID,
+		))
+	})
+	return out
+}
+
+// TestCredentialInvalidateFunnel_AllowlistEntriesAreLive enforces that every
+// entry in upstreamCallerCallsiteAllowlist corresponds to ≥ 1 actual
+// production reference (call or capture). Deleting the last caller of an
+// allowlisted function makes the entry stale; this test fails to force
+// same-PR cleanup.
+//
+// Test files are excluded — adding _test.go callers does NOT keep an entry
+// alive. The allowlist tracks production callers only.
+func TestCredentialInvalidateFunnel_AllowlistEntriesAreLive(t *testing.T) {
+	t.Parallel()
+
+	hits := map[string]int{}
+	_ = RunTyped(t, TypedOpts{Tests: false}, []string{
+		"./cells/accesscore/...",
+		"./cmd/...",
+	}, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			countUpstreamAllowlistHits(p, file, hits)
+		}
+		return nil
+	})
+
+	var stale []string
+	for callerID := range upstreamCallerCallsiteAllowlist {
+		if hits[callerID] == 0 {
+			stale = append(stale, callerID)
+		}
+	}
+	sort.Strings(stale)
+	for _, s := range stale {
+		t.Errorf("CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 meta: allowlist entry %q "+
+			"has 0 production references — last caller removed; delete the entry in "+
+			"the same PR", s)
+	}
+}
+
+// countUpstreamAllowlistHits increments hits[callerID] for each production
+// SelectorExpr in file that resolves to credentialinvalidate.Invalidator.Apply
+// AND has a resolvable enclosing FuncDecl matching the allowlist.
+func countUpstreamAllowlistHits(p *Pass, file *ast.File, hits map[string]int) {
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != invalidatorMethod {
+			return
+		}
+		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+		if !ok || fn.Pkg() == nil || fn.Pkg().Path() != invalidatorPkg {
+			return
+		}
+		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, sel)
+		if !ok {
+			return
+		}
+		callerID := caller.FullName()
+		if _, allowed := upstreamCallerCallsiteAllowlist[callerID]; allowed {
+			hits[callerID]++
+		}
+	})
 }
 
 // ─── Blind-spot self-check tests ─────────────────────────────────────────

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -1,16 +1,19 @@
 package archtest
 
-// credential_invalidate_funnel_invariants_test.go — four closed-caller-set
+// credential_invalidate_funnel_invariants_test.go — five closed-caller-set
 // funnel rules covering both ends of the S4b/S4d credential-invalidation
 // pipeline. The first three guard the DOWNSTREAM (store implementations);
-// the fourth guards the UPSTREAM (the funnel's Apply entry point).
+// the fourth guards the UPSTREAM (the funnel's Apply entry point); the
+// fifth keeps the Applier interface canonical (declared only in the
+// credentialinvalidate package) so callsite-level scanning stays uniform.
 //
 // INVARIANT: CREDENTIAL-INVALIDATE-FUNNEL-01
 // INVARIANT: USER-AUTHZ-EPOCH-BUMP-FUNNEL-01
 // INVARIANT: REFRESH-REVOKE-USER-FUNNEL-01
 // INVARIANT: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01
+// INVARIANT: CREDENTIAL-INVALIDATE-APPLIER-INTERFACE-CANONICAL-01
 //
-// # AI-robust grade (post #1033)
+// # AI-robust grade (post #1033 + #732)
 //
 // The credential-invalidation safety model rests on three mechanisms with
 // distinct enforcement layers — do not conflate them into one "Hard":
@@ -46,36 +49,27 @@ package archtest
 // backstop for the residual "pass nil" form; it does NOT elevate any static
 // grade, and the static Hard claims above stand on (1)+(2)+(3) alone.
 //
-// UPSTREAM-CALLER-01 (rule 4) is mixed-grade post #1033 + #732 — split per
-// caller channel (direct-typed vs interface-routed):
+// UPSTREAM-CALLER-01 (rule 4) is Hard post #1033 + #732. Five known
+// production callers (authzmutate ApplyInTx, identitymanage Delete +
+// changePasswordInTx, rbacassign persistChange, sessionrefresh
+// handleReuseDetected) are all callsite-level allowlisted; the FenceToken
+// seal (2)+(3) closes the "missing caller" hole structurally — a new
+// mutator cannot revoke without a FenceToken it cannot mint.
 //
-//   - Direct-typed callers (4 of 5 known production sites: identitymanage
-//     Delete + changePasswordInTx, rbacassign persistChange, authzmutate
-//     ApplyInTx) hold `*credentialinvalidate.Invalidator` as a concrete
-//     field. The callsite-level allowlist + FenceToken seal (2)+(3) close
-//     these as **Hard**: a new mutator cannot revoke without a FenceToken
-//     it cannot mint, and any direct-typed reference (call or capture) outside
-//     the allowlist fails archtest. ADR §A16 closure proof applies here.
-//
-//   - Interface-routed callers (1 of 5: sessionrefresh.handleReuseDetected
-//     via the local invalidatorApplier interface, chosen for unit-test spy
-//     injection) — info.Selections resolves the call to the local interface
-//     method, NOT to credentialinvalidate.(*Invalidator).Apply, so the
-//     scanner cannot match the (targetPkg, targetMethod) filter. This
-//     channel is **Soft for archtest** (no machine verification of the
-//     enclosing FuncDecl identity), tracked by gh issue #1198
-//     (ARCHTEST-FUNNEL-INTERFACE-INDIRECTION-HARD) for Hard-ification.
-//     ADR §A16 closure proof does NOT apply here — a FenceToken is still
-//     required at runtime, but archtest cannot statically verify the caller
-//     identity. Until #1198 lands, the Soft channel is documented and the
-//     RED fixture (sessionlogin_direct_apply_red) uses a concrete
-//     *Invalidator type so all direct-typed paths remain locked.
+// PR #1196 (#732) closes the prior sessionrefresh "interface-routed Soft
+// channel": its invalidator field was typed as a local
+// sessionrefresh.invalidatorApplier interface, which made info.Selections
+// resolve Apply outside the credentialinvalidate package and hid the
+// callsite from the scanner. The fix is structural — Applier is now an
+// exported interface in credentialinvalidate, so info.Selections resolves
+// Apply with Pkg=credentialinvalidate for all five callers uniformly, and
+// the callsite-level allowlist reaches every production reference (direct
+// call or function-value capture).
 //
 // See tools/archtest/fence_token_mint_funnel_test.go for the
 // FENCE-TOKEN-MINT-FUNNEL-01 godoc, and ADR
 // docs/architecture/202605101400-adr-credential-session-protocol.md §A16
-// for the closure proof and threat-matrix re-evaluation (note: §A16
-// covers direct-typed channel only).
+// for the closure proof and threat-matrix re-evaluation.
 //
 // Scanning tool: ResolveMethodCall + EachInSubtree[ast.SelectorExpr]. The scan
 // is form-complete — it resolves EVERY SelectorExpr (not only the Fun of a
@@ -100,20 +94,16 @@ package archtest
 //  2. //go:linkname / unsafe — the universal class that defeats any static
 //     analysis; out of scope for an archtest funnel.
 //
-//  3. Interface-indirection routing (Rule 4 specific). When a slice injects
-//     the funnel via a locally-defined interface (e.g.
-//     sessionrefresh.invalidatorApplier in service.go) for unit-testability
-//     with a spy, info.Selections resolves the call to that local interface's
-//     Apply method — NOT to credentialinvalidate.(*Invalidator).Apply. The
-//     fn.Pkg().Path() check rejects it as out-of-scope, so the callsite is
-//     scanner-invisible. Documented trade-off: sessionrefresh.handleReuseDetected
-//     is a legitimate Apply caller but cannot appear in
-//     upstreamCallerCallsiteAllowlist (the meta-invariant test would then
-//     flag it as stale). Future analogous interface-routed callers will also
-//     be scanner-invisible; this is a known limit of info.Selections-based
-//     resolution. The reverse RED fixture (sessionlogin_direct_apply_red)
-//     uses the concrete *credentialinvalidate.Invalidator type, so all
-//     direct-typed paths remain locked.
+// Interface-routed Apply via caller-package local interfaces is NOT a blind
+// spot: archtest CREDENTIAL-INVALIDATE-APPLIER-INTERFACE-CANONICAL-01 forces
+// the Applier interface to live in the credentialinvalidate package (not in
+// any caller package), so info.Selections always resolves Apply with
+// Pkg=credentialinvalidate. Pre-#1196 the sessionrefresh package defined a
+// local invalidatorApplier interface that defeated this resolution; the fix
+// is structural (Applier moved to credentialinvalidate). A regression
+// reintroducing a caller-package local interface with method signature
+// Apply(ctx, string, session.CredentialEvent) error would be caught by the
+// canonical-interface archtest (see below).
 //
 // Covered without a separate self-check: embedded struct method promotion
 // (`type Wrapper struct { session.Store }; w.RevokeForSubject(...)`) —
@@ -142,6 +132,8 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
+	"go/types"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -208,22 +200,6 @@ const (
 // production caller of an entry triggers
 // TestCredentialInvalidateFunnel_AllowlistEntriesAreLive (meta-invariant),
 // forcing same-PR cleanup.
-// NOTE: sessionrefresh.handleReuseDetected is a LEGITIMATE production caller
-// of Invalidator.Apply, but it is NOT listed here — and cannot be listed —
-// because sessionrefresh injects the funnel via a locally-defined
-// `invalidatorApplier` interface (see slices/sessionrefresh/service.go:60)
-// for unit-testability with a spy. info.Selections resolves the call
-// `s.invalidator.Apply(...)` to (sessionrefresh.invalidatorApplier).Apply, NOT
-// to (credentialinvalidate.Invalidator).Apply, so the scanner cannot match
-// the (targetPkg, targetMethod) filter and never reaches the callsite check.
-// This is a structural blind spot of info.Selections-based method resolution
-// when business code intentionally routes through an interface contract.
-// Trade-off accepted: sessionrefresh's testability requires the interface
-// (the spy implements invalidatorApplier without depending on credentialinvalidate);
-// any future caller that introduces an analogous interface field would also be
-// scanner-invisible. The reverse RED fixture (sessionlogin_direct_apply_red)
-// uses the concrete *credentialinvalidate.Invalidator type, so direct-typed
-// callsites remain locked.
 // Allowlist keys are types.Func.FullName() values; split via string concat
 // to keep lines under the lll limit while preserving the literal key.
 //
@@ -231,6 +207,15 @@ const (
 // `reference to credentialinvalidate.Apply from caller "<KEY>" not in
 // upstreamCallerCallsiteAllowlist`. Paste the quoted "<KEY>" verbatim into
 // this map.
+//
+// All five production callers are now scanner-detectable. The pre-#1196
+// sessionrefresh blind spot (local invalidatorApplier interface in the
+// caller package made info.Selections resolve Apply outside
+// credentialinvalidate) is closed structurally by moving the interface to
+// credentialinvalidate.Applier; sessionrefresh.Service.invalidator now has
+// type credentialinvalidate.Applier, so info.Selections resolves Apply with
+// fn.Pkg().Path() == credentialinvalidate and the scanner reaches the
+// callsite check uniformly.
 var upstreamCallerCallsiteAllowlist = map[string]string{
 	"(*github.com/ghbvf/gocell/cells/accesscore/internal/authzmutate.Mutator).ApplyInTx": "" +
 		"primary funnel — routes all live-aggregate authz mutations",
@@ -240,6 +225,8 @@ var upstreamCallerCallsiteAllowlist = map[string]string{
 		"co-tx atomicity: password write + revoke in one transaction",
 	"(*github.com/ghbvf/gocell/cells/accesscore/slices/rbacassign.Service).persistChange": "" +
 		"co-tx atomicity: role-row write + revoke in one transaction",
+	"(*github.com/ghbvf/gocell/cells/accesscore/slices/sessionrefresh.Service).handleReuseDetected": "" +
+		"reuse / stale-epoch cascade entry point (interface routing via credentialinvalidate.Applier)",
 }
 
 // funnelAllowlistPathPrefixes lists the module-relative path prefixes that
@@ -482,7 +469,7 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 	)
 }
 
-// ─── Rule 4: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (Hard, post #1033) ──
+// ─── Rule 4: CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (Hard, post #1033 + #732) ──
 
 // TestCredentialInvalidateFunnel_ApplyUpstreamCaller_01 enforces
 // CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01: every reference (call or
@@ -497,36 +484,22 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 // directly on the reviewer's diff.
 //
 // AI-robust grade (post #1033 + #732), per ai-robust.md §"Funnel 双向锁评级":
+// **Hard** uniformly across all five known production callers.
 //
-//   - Direct-typed callsites (caller holds `*credentialinvalidate.Invalidator`
-//     as a concrete field type) — **Hard**: callsite identity is type-resolved
-//     via (ResolveMethodCall callee identity) + (ResolveEnclosingFunc caller
-//     identity); form-uniqueness applies. 4 of 5 known production callers fall
-//     into this category and ARE in upstreamCallerCallsiteAllowlist.
-//
-//   - Interface-indirection callsites (caller holds a locally-defined
-//     interface like sessionrefresh.invalidatorApplier as the field type) —
-//     **Soft for that channel**: info.Selections resolves the call to the
-//     local interface's method, NOT to credentialinvalidate.(*Invalidator).Apply,
-//     so the scanner cannot match the (targetPkg, targetMethod) filter. The
-//     only known instance is sessionrefresh.handleReuseDetected (see the
-//     comment above upstreamCallerCallsiteAllowlist for the architectural
-//     justification: testability via spy substitution).
-//
-// Per ai-robust.md the Hard-upstream / Soft-channel mix is a transitional
-// posture and requires a tracking issue for Hard-ification — gh issue #1198
-// (ARCHTEST-FUNNEL-INTERFACE-INDIRECTION-HARD). Proposed resolution:
-// introduce a `WithConcreteInvalidator(*Invalidator)` option alongside the
-// current `WithInvalidator(invalidatorApplier)`, then archtest against the
-// concrete field type. Until that lands, the Soft channel is documented and
-// the RED fixture (sessionlogin_direct_apply_red) covers all direct-typed
-// paths.
+// Callsite identity is type-resolved via (ResolveMethodCall callee identity)
+// + (ResolveEnclosingFunc caller identity); form-uniqueness applies. The
+// "interface-routed channel" Soft residual from PR #1196 round-1/2 (where
+// sessionrefresh held a local invalidatorApplier interface that made
+// info.Selections resolve Apply outside credentialinvalidate) is closed
+// structurally in round-3: Applier is an exported interface in the
+// credentialinvalidate package, sessionrefresh.Service.invalidator has
+// type credentialinvalidate.Applier, so all five callers' Apply references
+// resolve with Pkg=credentialinvalidate uniformly.
 //
 // The "missing caller" problem (a new mutator forgetting to call Apply at
 // all) is closed structurally by the sealed FenceToken capability proof
 // (see package godoc + ADR §A16) — a new mutator that tries to revoke
-// without going through Invalidator.Apply cannot mint a FenceToken,
-// independent of the interface-indirection blind spot.
+// without going through Invalidator.Apply cannot mint a FenceToken.
 //
 // RED fixture: cells/accesscore/internal/credentialinvalidate/testdata/
 // sessionlogin_direct_apply_red — the sessionlogin slice is NOT on the
@@ -753,6 +726,165 @@ func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) 
 	assert.Empty(t, violations,
 		"funnel blind-spot: reflect.MethodByName of banned method names found in production code — "+
 			"the archtest cannot see reflect-based invocations. Refactor to use direct calls.")
+}
+
+// ─── Rule 5: CREDENTIAL-INVALIDATE-APPLIER-INTERFACE-CANONICAL-01 ──────
+
+// TestCredentialInvalidateApplierInterfaceCanonical_01 enforces that the
+// `Apply(ctx context.Context, subjectID string, event session.CredentialEvent)
+// error` method signature appears in EXACTLY ONE production interface:
+// credentialinvalidate.Applier. A caller package redeclaring an interface
+// with the same signature would re-create the pre-#1196 sessionrefresh
+// "interface-routed Soft channel" — info.Selections would resolve Apply to
+// the caller-package interface, hiding the callsite from the
+// CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 scan.
+//
+// Mechanism: load credentialinvalidate.Applier.Apply's *types.Func via the
+// package scope; scan caller production packages (./cells/... ./runtime/...
+// ./cmd/...) for any *types.TypeName whose underlying type is an interface
+// that explicitly declares a method Apply whose *types.Signature is
+// types.Identical to the canonical one. Skip the credentialinvalidate
+// package itself; skip *_test.go (Tests:false).
+//
+// AI-robust grade: Medium (archtest-bound; type-resolved via go/types
+// identity comparison — no string anchor, no name pattern). Hard upstream
+// would require a sealed Applier (unexported marker method) but that
+// breaks the spy-injection testability pattern; this archtest is the
+// pragmatic backstop. Form-uniqueness: types.Identical on the method
+// signature object — any other shape (same name + different signature, or
+// same signature on a renamed method) does not match and is not the
+// regression vector this rule guards.
+//
+// RED fixture: tools/archtest/testdata/credential_invalidate_fixtures/
+// noncanonical_applier_interface_red declares
+// `type LocalApplier interface { Apply(ctx, string, event) error }` in a
+// non-credentialinvalidate package; the scanner must flag it.
+func TestCredentialInvalidateApplierInterfaceCanonical_01(t *testing.T) {
+	t.Parallel()
+
+	// Production scan: load credentialinvalidate (canonical home) + caller
+	// trees in ONE RunTyped, so types.Identical sees matching stdlib
+	// *types.Named instances. The canonical *types.Type is captured during
+	// the same pass that records candidate interfaces; comparison runs
+	// AFTER RunTyped returns (every package has been visited and canonical
+	// is set).
+	prodViolations := scanApplierInterfaceCanonical(t, []string{
+		"./cells/accesscore/internal/credentialinvalidate",
+		"./cells/...",
+		"./runtime/...",
+		"./cmd/...",
+	})
+
+	sort.Strings(prodViolations)
+	for _, v := range prodViolations {
+		t.Log(v)
+	}
+	assert.Empty(t, prodViolations,
+		"CREDENTIAL-INVALIDATE-APPLIER-INTERFACE-CANONICAL-01: non-canonical "+
+			"interface redeclares credentialinvalidate.Applier's Apply signature — "+
+			"info.Selections would resolve Apply outside credentialinvalidate, "+
+			"hiding the callsite from CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 scan. "+
+			"Move the interface to the credentialinvalidate package "+
+			"(or rename/reshape the method if the use case is unrelated).")
+
+	// RED fixture: same single-Load pattern (canonical + fixture together).
+	redViolations := scanApplierInterfaceCanonical(t, []string{
+		"./cells/accesscore/internal/credentialinvalidate",
+		"./tools/archtest/testdata/credential_invalidate_fixtures/noncanonical_applier_interface_red",
+	})
+	assert.GreaterOrEqual(t, len(redViolations), 1,
+		"RED fixture self-check FAILED: noncanonical_applier_interface_red — "+
+			"expected ≥ 1 violation, got %d. Check that the fixture declares an "+
+			"interface with method Apply(ctx, string, session.CredentialEvent) error "+
+			"and that ./cells/accesscore/internal/credentialinvalidate is in the same Load.",
+		len(redViolations))
+}
+
+// applierInterfaceCandidate records a *types.TypeName whose underlying type
+// is an interface with an explicitly declared Apply method, captured during
+// a single RunTyped pass. methodType is the *types.Signature of that Apply
+// method, comparable via types.Identical against the canonical signature
+// loaded by the same pass.
+type applierInterfaceCandidate struct {
+	pkgPath    string
+	typeName   string
+	methodType types.Type
+	pos        token.Position
+}
+
+// scanApplierInterfaceCanonical loads the canonical credentialinvalidate
+// package together with the scan-target patterns in a SINGLE RunTyped call,
+// then compares each candidate interface's Apply signature against the
+// canonical via types.Identical.
+//
+// Single-Load constraint: types.Identical requires matching *types.Named
+// instances for embedded stdlib types (e.g. context.Context). Separate
+// packages.Load invocations produce distinct *types.Named for the same
+// import path, defeating the comparison. Always pass the
+// credentialinvalidate package together with scan targets in the same
+// patterns slice.
+func scanApplierInterfaceCanonical(t *testing.T, patterns []string) []string {
+	t.Helper()
+	var canonical types.Type
+	var candidates []applierInterfaceCandidate
+	_ = RunTyped(t, TypedOpts{Tests: false}, patterns, func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		if p.Pkg.Path() == invalidatorPkg {
+			applier := p.Pkg.Scope().Lookup("Applier")
+			if applier == nil {
+				return nil
+			}
+			iface, ok := applier.Type().Underlying().(*types.Interface)
+			if !ok || iface.NumExplicitMethods() != 1 {
+				return nil
+			}
+			canonical = iface.ExplicitMethod(0).Type()
+			return nil
+		}
+		scope := p.Pkg.Scope()
+		for _, name := range scope.Names() {
+			obj := scope.Lookup(name)
+			tn, ok := obj.(*types.TypeName)
+			if !ok || tn.IsAlias() {
+				continue
+			}
+			iface, ok := tn.Type().Underlying().(*types.Interface)
+			if !ok {
+				continue
+			}
+			for i := 0; i < iface.NumExplicitMethods(); i++ {
+				m := iface.ExplicitMethod(i)
+				if m.Name() != "Apply" {
+					continue
+				}
+				candidates = append(candidates, applierInterfaceCandidate{
+					pkgPath:    p.Pkg.Path(),
+					typeName:   tn.Name(),
+					methodType: m.Type(),
+					pos:        p.Fset.Position(tn.Pos()),
+				})
+			}
+		}
+		return nil
+	})
+	require.NotNil(t, canonical,
+		"credentialinvalidate.Applier signature not captured — ensure "+
+			"./cells/accesscore/internal/credentialinvalidate is in the patterns slice")
+
+	var violations []string
+	for _, c := range candidates {
+		if types.Identical(c.methodType, canonical) {
+			violations = append(violations, fmt.Sprintf(
+				"%s: interface %s.%s declares Apply with the same signature "+
+					"as credentialinvalidate.Applier — interface must live in "+
+					"credentialinvalidate package",
+				c.pos, c.pkgPath, c.typeName,
+			))
+		}
+	}
+	return violations
 }
 
 // ─── shared helpers ──────────────────────────────────────────────────────

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -46,12 +46,36 @@ package archtest
 // backstop for the residual "pass nil" form; it does NOT elevate any static
 // grade, and the static Hard claims above stand on (1)+(2)+(3) alone.
 //
-// UPSTREAM-CALLER-01 (rule 4) upgraded Medium → Hard once (2)+(3) closed the
-// "missing caller" hole structurally (a new mutator cannot revoke without a
-// FenceToken it cannot mint). See tools/archtest/fence_token_mint_funnel_test.go
-// for the FENCE-TOKEN-MINT-FUNNEL-01 godoc, and ADR
-// docs/architecture/202605101400-adr-credential-session-protocol.md §A16 for
-// the closure proof and threat-matrix re-evaluation.
+// UPSTREAM-CALLER-01 (rule 4) is mixed-grade post #1033 + #732 — split per
+// caller channel (direct-typed vs interface-routed):
+//
+//   - Direct-typed callers (4 of 5 known production sites: identitymanage
+//     Delete + changePasswordInTx, rbacassign persistChange, authzmutate
+//     ApplyInTx) hold `*credentialinvalidate.Invalidator` as a concrete
+//     field. The callsite-level allowlist + FenceToken seal (2)+(3) close
+//     these as **Hard**: a new mutator cannot revoke without a FenceToken
+//     it cannot mint, and any direct-typed reference (call or capture) outside
+//     the allowlist fails archtest. ADR §A16 closure proof applies here.
+//
+//   - Interface-routed callers (1 of 5: sessionrefresh.handleReuseDetected
+//     via the local invalidatorApplier interface, chosen for unit-test spy
+//     injection) — info.Selections resolves the call to the local interface
+//     method, NOT to credentialinvalidate.(*Invalidator).Apply, so the
+//     scanner cannot match the (targetPkg, targetMethod) filter. This
+//     channel is **Soft for archtest** (no machine verification of the
+//     enclosing FuncDecl identity), tracked by gh issue #1198
+//     (ARCHTEST-FUNNEL-INTERFACE-INDIRECTION-HARD) for Hard-ification.
+//     ADR §A16 closure proof does NOT apply here — a FenceToken is still
+//     required at runtime, but archtest cannot statically verify the caller
+//     identity. Until #1198 lands, the Soft channel is documented and the
+//     RED fixture (sessionlogin_direct_apply_red) uses a concrete
+//     *Invalidator type so all direct-typed paths remain locked.
+//
+// See tools/archtest/fence_token_mint_funnel_test.go for the
+// FENCE-TOKEN-MINT-FUNNEL-01 godoc, and ADR
+// docs/architecture/202605101400-adr-credential-session-protocol.md §A16
+// for the closure proof and threat-matrix re-evaluation (note: §A16
+// covers direct-typed channel only).
 //
 // Scanning tool: ResolveMethodCall + EachInSubtree[ast.SelectorExpr]. The scan
 // is form-complete — it resolves EVERY SelectorExpr (not only the Fun of a

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -202,6 +202,11 @@ const (
 // callsites remain locked.
 // Allowlist keys are types.Func.FullName() values; split via string concat
 // to keep lines under the lll limit while preserving the literal key.
+//
+// CI failure messages print the exact key to copy: look for
+// `reference to credentialinvalidate.Apply from caller "<KEY>" not in
+// upstreamCallerCallsiteAllowlist`. Paste the quoted "<KEY>" verbatim into
+// this map.
 var upstreamCallerCallsiteAllowlist = map[string]string{
 	"(*github.com/ghbvf/gocell/cells/accesscore/internal/authzmutate.Mutator).ApplyInTx": "" +
 		"primary funnel — routes all live-aggregate authz mutations",
@@ -467,12 +472,37 @@ func TestCredentialInvalidateFunnel_RevokeUser_01(t *testing.T) {
 // caller MUST add an explicit allowlist entry, putting the funnel surface
 // directly on the reviewer's diff.
 //
-// AI-robust grade (post #1033 + #732): Hard. The callsite-level allowlist
-// catches "wrong caller" with type-resolved (callee, caller) form-uniqueness.
-// The "missing caller" problem is closed structurally by the sealed
-// FenceToken capability proof (see package godoc + ADR §A16) — a new
-// mutator that tries to revoke without going through Invalidator.Apply
-// cannot mint a FenceToken.
+// AI-robust grade (post #1033 + #732), per ai-robust.md §"Funnel 双向锁评级":
+//
+//   - Direct-typed callsites (caller holds `*credentialinvalidate.Invalidator`
+//     as a concrete field type) — **Hard**: callsite identity is type-resolved
+//     via (ResolveMethodCall callee identity) + (ResolveEnclosingFunc caller
+//     identity); form-uniqueness applies. 4 of 5 known production callers fall
+//     into this category and ARE in upstreamCallerCallsiteAllowlist.
+//
+//   - Interface-indirection callsites (caller holds a locally-defined
+//     interface like sessionrefresh.invalidatorApplier as the field type) —
+//     **Soft for that channel**: info.Selections resolves the call to the
+//     local interface's method, NOT to credentialinvalidate.(*Invalidator).Apply,
+//     so the scanner cannot match the (targetPkg, targetMethod) filter. The
+//     only known instance is sessionrefresh.handleReuseDetected (see the
+//     comment above upstreamCallerCallsiteAllowlist for the architectural
+//     justification: testability via spy substitution).
+//
+// Per ai-robust.md the Hard-upstream / Soft-channel mix is a transitional
+// posture and requires a tracking issue for Hard-ification — gh issue #1198
+// (ARCHTEST-FUNNEL-INTERFACE-INDIRECTION-HARD). Proposed resolution:
+// introduce a `WithConcreteInvalidator(*Invalidator)` option alongside the
+// current `WithInvalidator(invalidatorApplier)`, then archtest against the
+// concrete field type. Until that lands, the Soft channel is documented and
+// the RED fixture (sessionlogin_direct_apply_red) covers all direct-typed
+// paths.
+//
+// The "missing caller" problem (a new mutator forgetting to call Apply at
+// all) is closed structurally by the sealed FenceToken capability proof
+// (see package godoc + ADR §A16) — a new mutator that tries to revoke
+// without going through Invalidator.Apply cannot mint a FenceToken,
+// independent of the interface-indirection blind spot.
 //
 // RED fixture: cells/accesscore/internal/credentialinvalidate/testdata/
 // sessionlogin_direct_apply_red — the sessionlogin slice is NOT on the
@@ -575,7 +605,8 @@ func scanUpstreamCallerViolationsPass(
 		}
 		out = append(out, fmt.Sprintf(
 			"%s:%d: %s: reference to %s.%s from caller %q not in "+
-				"upstreamCallerCallsiteAllowlist (direct call or function-value capture)",
+				"upstreamCallerCallsiteAllowlist (direct call or function-value capture) "+
+				"(copy the quoted key verbatim into the map to allow)",
 			rel, line, ruleID, filepath.Base(targetPkg), targetMethod, callerID,
 		))
 	})

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -18,26 +18,37 @@ package archtest
 //
 //   Downstream Hard (AUTHZ-MUTATION-APPLY-FUNNEL-01, Rule a — SetStatus /
 //   SetPasswordResetRequired caller set):
-//     "Form uniqueness" = (typeseval.ResolveMethodCall resolves callee to this
-//     exact *types.Func identity) AND (typeseval.ResolveEnclosingFunc resolves
-//     caller to this exact *types.Func identity). Both ends are type-resolved;
-//     "string anchor" / "file path" / "package prefix" — none participate in
-//     the comparison. Any call site whose enclosing FuncDecl is outside the
-//     narrow callsite allowlist fails archtest in CI with no gray zone.
-//     Honest caveat: Go does not prevent the calls at compile time (the
-//     methods are exported); enforcement is archtest-bound. This is the
-//     highest Hard grade reachable in Go for exported-method caller
-//     restriction.
+//     "Form uniqueness" requires three axes, all type-resolved (no string
+//     anchors, no file paths, no package prefixes):
+//       1. callee identity via typeseval.ResolveMethodCall → exact *types.Func
+//       2. caller identity via typeseval.ResolveEnclosingFunc → exact *types.Func
+//          for the enclosing FuncDecl
+//       3. form completeness — EachInSubtree[ast.SelectorExpr] visits EVERY
+//          selector resolving to the banned method (direct call AND
+//          function-value capture: `fn := u.SetStatus`, `return u.SetStatus`,
+//          `pass(u.SetStatus)`). info.Selections records a MethodVal
+//          selection even when the method value is not immediately invoked.
+//     Any reference whose enclosing FuncDecl is outside the narrow callsite
+//     allowlist fails archtest in CI with no gray zone. Honest caveat: Go
+//     does not prevent the calls at compile time (the methods are exported);
+//     enforcement is archtest-bound. This is the highest Hard grade
+//     reachable in Go for exported-method caller restriction.
 //
 //     Issue #732 hardening (this file, 2026-05-27): the prior file-level
 //     allowlist (setMutatorAllowlist []string) admitted any new function in
 //     adminprovision/provisioner.go or identitymanage/service.go to call the
 //     setters silently. callsite-level keying eliminates this "same file /
-//     different function" slip path. Defensive package-prefix carve-outs for
-//     authzmutate/ and domain/ removed: production AST has zero CallExprs
-//     to these setters in those packages today; if a new helper needs the
-//     setter, the author must add a callsite entry (explicit acknowledgement,
-//     not silent reuse of a stale package allowance).
+//     different function" slip path. PR #1196 round-2 upgrade: scanner walks
+//     all SelectorExpr (not only CallExpr.Fun), closing the previously
+//     expressible "method-value capture" bypass that round-1 had documented
+//     as a blind spot — now caught directly by form-complete resolution
+//     (mirrors credential_invalidate sibling scanners).
+//
+//     Defensive package-prefix carve-outs for authzmutate/ and domain/
+//     removed: production AST has zero references to these setters in those
+//     packages today; if a new helper needs the setter, the author must add
+//     a callsite entry (explicit acknowledgement, not silent reuse of a
+//     stale package allowance).
 //
 //   Upstream Medium-by-necessity (caller-set upper-bound):
 //     The upstream guarantee — that all live-aggregate authz mutations MUST go
@@ -72,60 +83,63 @@ package archtest
 //
 // Scanning tool: typeseval.SharedResolver + archtest.ResolveMethodCall (callee
 // type-resolved) + archtest.ResolveEnclosingFunc (caller type-resolved) +
-// scanner.EachInSubtree[ast.CallExpr] for Rule (a); go/types struct field and
-// method set inspection for DOMAIN-AUTHZ-FIELD-PRIVATE-01.
+// scanner.EachInSubtree[ast.SelectorExpr] (form-complete, walks every
+// SelectorExpr — not only CallExpr.Fun) for Rule (a); go/types struct field
+// and method set inspection for DOMAIN-AUTHZ-FIELD-PRIVATE-01.
 //
 // Blind-spot self-check (ai-robust.md §"工具选定后强制盲区自检"):
 //
 // For AUTHZ-MUTATION-APPLY-FUNNEL-01 — ResolveMethodCall resolves via
 // info.Selections; ResolveEnclosingFunc walks file.Decls for *ast.FuncDecl
-// containing the call's position. AST forms NOT covered:
+// containing the reference's position. AST forms NOT covered:
 //
-//  1. Method-value store + call: `fn := u.SetStatus; fn(domain.StatusLocked, t)`
-//     The second `fn(...)` CallExpr's Fun is *ast.Ident, not *ast.SelectorExpr,
-//     so info.Selections is not consulted. Captured by:
-//     TestDomainAuthzMutation_BlindSpot_MethodValueAssignment (asserts absence
-//     in production code — if this pattern appeared, the scanner would miss it).
-//
-//  2. Method expression (qualified): `(*domain.User).SetStatus(u, s, t)`
+//  1. Method expression (qualified): `(*domain.User).SetStatus(u, s, t)`
 //     Fun is *ast.SelectorExpr resolving via info.Selections as MethodExpr.
 //     ResolveMethodCall explicitly accepts types.MethodExpr — this IS covered.
 //     Documented for completeness; no self-check needed.
 //
-//  3. reflect.Value.MethodByName("SetStatus").Call(...): fully AST-invisible.
+//  2. reflect.Value.MethodByName("SetStatus").Call(...): fully AST-invisible.
 //     Captured by:
 //     TestDomainAuthzMutation_BlindSpot_ReflectMethodByName (asserts absence).
 //
-//  4. Dot-import: `import . "...domain"` followed by a bare call. SetStatus is
+//  3. Dot-import: `import . "...domain"` followed by a bare call. SetStatus is
 //     a method, not a package-level function, so dot-import does not affect
 //     method calls on a receiver. Not applicable; no self-check needed.
 //
-//  5. Embedded promotion: `type W struct { *domain.User }; w.SetStatus(...)`
+//  4. Embedded promotion: `type W struct { *domain.User }; w.SetStatus(...)`
 //     resolves via info.Selections to the same *types.Func (promoted method
 //     Obj() is the original). This IS covered. Documented for completeness.
 //
-//  6. Package-level var init / const init bypass: `var _ = func() {
+//  5. Package-level var init / const init bypass: `var _ = func() {
 //     u.SetStatus(...); return 0 }()`. ResolveEnclosingFunc returns
 //     (nil, false) for any node outside a FuncDecl body. The scan loop treats
 //     (nil, false) as an AUTOMATIC violation — package-level init has no
 //     allowlistable identity. Captured (positively, i.e. confirming the rule
 //     fires) by: TestDomainAuthzMutation_BlindSpot_VarInitCall.
 //
-//  7. FuncLit-inside-FuncDecl semantic choice (NOT a blind spot):
+//  6. FuncLit-inside-FuncDecl semantic choice (NOT a blind spot):
 //     ResolveEnclosingFunc collapses a nested FuncLit's identity to its
 //     outermost FuncDecl. Rationale: FuncLit author = FuncDecl author;
 //     allowlisting the outer FuncDecl implicitly trusts any FuncLit inside.
 //     Documented for completeness; no reverse self-check needed.
 //
+// Function-value capture forms (`fn := u.SetStatus`, `return u.SetStatus`,
+// `pass(u.SetStatus)`) are COVERED — they are SelectorExpr nodes resolving
+// to the same *types.Func via info.Selections (MethodVal selection records
+// even when not immediately invoked). PR #1196 round-2 upgraded the scanner
+// to walk all SelectorExpr; the formerly separate
+// TestDomainAuthzMutation_BlindSpot_MethodValueAssignment self-check
+// retired (form-complete scan absorbs its assertion).
+//
 // For DOMAIN-AUTHZ-FIELD-PRIVATE-01 — go/types struct/method inspection.
 // AST forms NOT covered by the type definition check:
 //
-//  8. unsafe.Pointer offset write bypasses Go field visibility:
+//  7. unsafe.Pointer offset write bypasses Go field visibility:
 //     (*domain.UserStatus)(unsafe.Pointer(uintptr(unsafe.Pointer(u)) + offset))
 //     Captured by:
 //     TestDomainAuthzMutation_BlindSpot_UnsafePointerWrite (asserts absence).
 //
-//  9. reflect.ValueOf(u).Elem().FieldByName("status").Set(...):
+//  8. reflect.ValueOf(u).Elem().FieldByName("status").Set(...):
 //     Call-site reflection bypasses type checking. Captured by:
 //     TestDomainAuthzMutation_BlindSpot_ReflectFieldByName (asserts absence).
 
@@ -395,15 +409,20 @@ func TestAuthzMutationApplyFunnel_SetStatus_01(t *testing.T) {
 	)
 }
 
-// scanSetMutatorViolationsPass walks a single file's AST for CallExpr nodes where
-// the method receiver resolves to domain.User.SetStatus or
-// domain.User.SetPasswordResetRequired, then resolves the enclosing FuncDecl
-// and checks its canonical identity against setMutatorCallsiteAllowlist.
+// scanSetMutatorViolationsPass walks a single file's AST for EVERY SelectorExpr
+// resolving to (domainUserPkg, targetMethod) — direct call AND function-value
+// capture alike. Each violation is keyed by the enclosing FuncDecl's canonical
+// *types.Func.FullName(); references outside any FuncDecl (package-level var
+// init) are automatic violations.
 //
-// Returns a slice of violation strings (callsite identity + line). A call
-// outside any FuncDecl (package-level var init) is an automatic violation —
-// ResolveEnclosingFunc returns (nil, false) for such positions and the
-// allowlist cannot match.
+// Form-completeness rationale: ResolveMethodCall via info.Selections resolves a
+// SelectorExpr to the same *types.Func regardless of whether it sits in
+// CallExpr.Fun (direct call) or elsewhere (`fn := u.SetStatus`,
+// `return u.SetStatus`, `someFunc(u.SetStatus)`). Walking only CallExpr.Fun
+// would leave method-value capture as an AST-expressible bypass — failing the
+// AI-robust §"Hard 范本目录" form-uniqueness requirement. Mirrors
+// scanFunnelViolationsPass / scanUpstreamCallerViolationsPass in
+// credential_invalidate_funnel_invariants_test.go.
 func scanSetMutatorViolationsPass(
 	p *Pass,
 	file *ast.File,
@@ -411,12 +430,8 @@ func scanSetMutatorViolationsPass(
 	targetMethod string,
 ) []string {
 	var out []string
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil {
-			return
-		}
-		if sel.Sel.Name != targetMethod {
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != targetMethod {
 			return
 		}
 		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
@@ -426,11 +441,11 @@ func scanSetMutatorViolationsPass(
 		if fn.Pkg() == nil || fn.Pkg().Path() != domainUserPkg {
 			return
 		}
-		line := p.Fset.Position(call.Pos()).Line
-		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, call)
+		line := p.Fset.Position(sel.Pos()).Line
+		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, sel)
 		if !ok {
 			out = append(out, fmt.Sprintf(
-				"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: direct call to domain.User.%s "+
+				"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: reference to domain.User.%s "+
 					"outside any FuncDecl (package-level init or similar) — cannot be allowlisted",
 				rel, line, targetMethod,
 			))
@@ -441,9 +456,9 @@ func scanSetMutatorViolationsPass(
 			return
 		}
 		out = append(out, fmt.Sprintf(
-			"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: direct call to domain.User.%s "+
+			"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: reference to domain.User.%s "+
 				"from caller %q not in setMutatorCallsiteAllowlist "+
-				"(copy the quoted key verbatim into the map to allow)",
+				"(direct call or function-value capture; copy the quoted key verbatim into the map to allow)",
 			rel, line, targetMethod, callerID,
 		))
 	})
@@ -521,32 +536,31 @@ func TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive(t *testing.T) {
 	}
 }
 
-// countAllowlistHits increments hits[callerID] for each production CallExpr
-// in file that resolves to a domain.User setter AND has a resolvable
-// enclosing FuncDecl matching the allowlist. Calls outside any FuncDecl, or
-// inside non-allowlisted callers, are ignored — this counter is only used by
-// the meta-invariant to detect stale entries.
+// countAllowlistHits increments hits[callerID] for each production SelectorExpr
+// in file that resolves to a domain.User setter AND has a resolvable enclosing
+// FuncDecl matching the allowlist. Mirrors scanSetMutatorViolationsPass'
+// form-complete SelectorExpr walk (direct call + function-value capture both
+// count). References outside any FuncDecl, or inside non-allowlisted callers,
+// are ignored — this counter is only used by the meta-invariant to detect
+// stale entries.
 //
-// Note: hits[callerID] accumulates across all callsites within a single
-// FuncDecl — if `Service.Create` calls SetStatus twice, hits["…Service.Create"]
-// is 2. The meta-invariant only asserts ≥1, so an entry is considered stale
-// only when ALL callsites in its FuncDecl are removed. This is intentional:
-// the allowlist tracks "this function is a legitimate caller", not "exactly N
-// callsites within this function".
+// Note: hits[callerID] accumulates across all references within a single
+// FuncDecl — if `Service.Create` calls SetStatus twice, or captures it once
+// and calls it once, hits["…Service.Create"] is 2. The meta-invariant only
+// asserts ≥1, so an entry is considered stale only when ALL references in
+// its FuncDecl are removed. This is intentional: the allowlist tracks "this
+// function is a legitimate caller", not "exactly N references within this
+// function".
 func countAllowlistHits(p *Pass, file *ast.File, targetMethod string, hits map[string]int) {
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil {
-			return
-		}
-		if sel.Sel.Name != targetMethod {
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != targetMethod {
 			return
 		}
 		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
 		if !ok || fn.Pkg() == nil || fn.Pkg().Path() != domainUserPkg {
 			return
 		}
-		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, call)
+		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, sel)
 		if !ok {
 			return
 		}
@@ -557,74 +571,54 @@ func countAllowlistHits(p *Pass, file *ast.File, targetMethod string, hits map[s
 	})
 }
 
-// ─── Blind-spot self-check tests ─────────────────────────────────────────
+// ─── Form-completeness positive self-check ──────────────────────────────
 
-// TestDomainAuthzMutation_BlindSpot_MethodValueAssignment asserts that the
-// method-value-assignment blind spot (e.g. `fn := u.SetStatus; fn(...)`) does
-// NOT appear in production code outside the callsite allowlist. If it did, the
-// scanner would miss the second CallExpr because fn(...) has Fun=*ast.Ident,
-// not *ast.SelectorExpr.
+// TestDomainAuthzMutation_ValueCapture_Detected positively asserts that the
+// form-complete SelectorExpr scanner catches function-value capture of
+// domain.User.SetStatus / SetPasswordResetRequired — the bypass form a
+// CallExpr.Fun-only scanner would miss. Loads value_capture_setstatus_red,
+// which captures the methods as values (var/return/arg-pass) without an
+// immediate invocation; the scanner must emit ≥ 1 violation per form.
 //
-// Scanner: EachInSubtree[ast.AssignStmt] + right-hand-side SelectorExpr name
-// matching + ResolveEnclosingFunc-based allowlist check. AST-only for the name
-// match (no type info on the inner SelectorExpr), but the caller-identity
-// allowlist check is type-resolved. Soft (name-only); typed-resolver upgrade
-// tracked in #1118 (method-value name-only detection across sites).
-func TestDomainAuthzMutation_BlindSpot_MethodValueAssignment(t *testing.T) {
+// This is the positive complement to TestAuthzMutationApplyFunnel_SetStatus_01
+// (which asserts NO violations in production code): a form-uniqueness
+// guarantee requires both "absent from production" AND "present in a fixture
+// that exercises every covered form" so the scan is provably form-complete,
+// not silently empty.
+func TestDomainAuthzMutation_ValueCapture_Detected(t *testing.T) {
 	t.Parallel()
 
-	bannedNames := map[string]bool{
-		domainSetStatusMethod:                true,
-		domainSetPasswordResetRequiredMethod: true,
-	}
-
-	var violations []string
+	var found []string
 	_ = RunTyped(t, TypedOpts{}, []string{
-		"./cells/accesscore/...", "./cmd/...",
+		"./cells/accesscore/internal/domain/testdata/value_capture_setstatus_red",
 	}, func(p *Pass) []Diagnostic {
-		if p.Fset == nil {
+		if p.TypesInfo == nil {
 			return nil
 		}
 		for _, file := range p.Files {
 			rel := p.Rel(file)
-			if strings.HasSuffix(rel, "_test.go") {
-				continue
-			}
-			EachInSubtree[ast.AssignStmt](file, func(assign *ast.AssignStmt) {
-				EachInChildren[ast.SelectorExpr](assign, func(sel *ast.SelectorExpr) {
-					if !bannedNames[sel.Sel.Name] {
-						return
-					}
-					// Caller-identity check: if the AssignStmt is inside an
-					// allowlisted FuncDecl, the method-value assignment is
-					// permitted (defensive — no production code does this today).
-					caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, assign)
-					if ok {
-						if _, allowed := setMutatorCallsiteAllowlist[caller.FullName()]; allowed {
-							return
-						}
-					}
-					line := p.Fset.Position(assign.Pos()).Line
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: method-value assignment of %s blind spot detected — "+
-							"archtest would miss the second call site",
-						rel, line, sel.Sel.Name,
-					))
-				})
-			})
+			found = append(found,
+				scanSetMutatorViolationsPass(p, file, rel, domainSetStatusMethod)...)
+			found = append(found,
+				scanSetMutatorViolationsPass(p, file, rel, domainSetPasswordResetRequiredMethod)...)
 		}
 		return nil
 	})
 
-	sort.Strings(violations)
-	for _, v := range violations {
+	sort.Strings(found)
+	for _, v := range found {
 		t.Log(v)
 	}
-	assert.Empty(t, violations,
-		"authz-mutation blind-spot: method-value assignment of SetStatus / "+
-			"SetPasswordResetRequired found in non-allowlisted production code — "+
-			"the archtest would miss the deferred call. Refactor to call authzmutate.Mutator.Apply.")
+	// Three banned references in the fixture: badValueCapture (SetStatus
+	// assigned to var), badReturnDirect (SetPasswordResetRequired returned),
+	// badArgPass (SetStatus passed as arg). Each must produce ≥ 1 violation.
+	assert.GreaterOrEqual(t, len(found), 3,
+		"form-completeness RED fixture must catch ≥ 3 value-capture references "+
+			"(badValueCapture / badReturnDirect / badArgPass) — a CallExpr.Fun-only "+
+			"scanner would miss all three. Got %d violation(s).", len(found))
 }
+
+// ─── Blind-spot self-check tests ─────────────────────────────────────────
 
 // TestDomainAuthzMutation_BlindSpot_ReflectMethodByName asserts that
 // reflect.Value.MethodByName("SetStatus") / ("SetPasswordResetRequired") does
@@ -780,7 +774,7 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 // scanSetMutatorViolationsPass fires when a setter call is inside a
 // package-level var-init expression (no enclosing FuncDecl).
 //
-// This is the §6 blind-spot entry in the package godoc. Implementation: load
+// This is the §5 blind-spot entry in the package godoc. Implementation: load
 // the RED fixture `var_init_setstatus_red` whose package-level var init
 // invokes domain.User.SetStatus from outside any FuncDecl. The scanner must
 // emit a violation containing "outside any FuncDecl" — proving

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -18,12 +18,26 @@ package archtest
 //
 //   Downstream Hard (AUTHZ-MUTATION-APPLY-FUNNEL-01, Rule a — SetStatus /
 //   SetPasswordResetRequired caller set):
-//     "Form uniqueness" = "call resolves to this exact *types.Func identity via
-//     typeseval.ResolveMethodCall". Any call site outside the narrowed file-level
-//     allowlist fails archtest in CI with no gray zone. Honest caveat: Go does
-//     not prevent the calls at compile time (the methods are exported); enforcement
-//     is archtest-bound. This is the highest Hard grade reachable in Go for
-//     exported-method caller restriction.
+//     "Form uniqueness" = (typeseval.ResolveMethodCall resolves callee to this
+//     exact *types.Func identity) AND (typeseval.ResolveEnclosingFunc resolves
+//     caller to this exact *types.Func identity). Both ends are type-resolved;
+//     "string anchor" / "file path" / "package prefix" — none participate in
+//     the comparison. Any call site whose enclosing FuncDecl is outside the
+//     narrow callsite allowlist fails archtest in CI with no gray zone.
+//     Honest caveat: Go does not prevent the calls at compile time (the
+//     methods are exported); enforcement is archtest-bound. This is the
+//     highest Hard grade reachable in Go for exported-method caller
+//     restriction.
+//
+//     Issue #732 hardening (this file, 2026-05-27): the prior file-level
+//     allowlist (setMutatorAllowlist []string) admitted any new function in
+//     adminprovision/provisioner.go or identitymanage/service.go to call the
+//     setters silently. callsite-level keying eliminates this "same file /
+//     different function" slip path. Defensive package-prefix carve-outs for
+//     authzmutate/ and domain/ removed: production AST has zero CallExprs
+//     to these setters in those packages today; if a new helper needs the
+//     setter, the author must add a callsite entry (explicit acknowledgement,
+//     not silent reuse of a stale package allowance).
 //
 //   Upstream Medium-by-necessity (caller-set upper-bound):
 //     The upstream guarantee — that all live-aggregate authz mutations MUST go
@@ -33,17 +47,19 @@ package archtest
 //     routing through authzmutate would be semantically wrong.
 //     (b) sealed interfaces or codegen cannot express "creation-time-only" as a
 //     compile-time invariant without redesigning the domain model.
-//     The Medium ceiling is an accepted architectural trade-off; the file-level
-//     allowlist (not package-level) is the tightest achievable restriction:
-//     only the exact files that contain creation-time calls are allowlisted.
+//     The Medium ceiling is an accepted architectural trade-off independent of
+//     the archtest allowlist granularity; callsite-level keying within Rule (a)
+//     is orthogonal — it tightens the archtest tier without changing the
+//     architectural ceiling.
 //
 // Relationship to CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 (Rule b):
 //   The Hard closure of the P1.2 / P1-#1 regression class is Rule (a) above —
 //   field privatization + SetStatus/SetPasswordResetRequired funnel. Narrowing
 //   the credentialinvalidate.Invalidator.Apply caller set (Rule b) is a
-//   secondary tightening implemented in-file by modifying upstreamCallerAllowlistPrefixes
-//   in credential_invalidate_funnel_invariants_test.go (setup/ and adminprovision/
-//   removed — they do not call Apply in production code).
+//   secondary tightening implemented in-file by modifying
+//   upstreamCallerCallsiteAllowlist in
+//   credential_invalidate_funnel_invariants_test.go (also upgraded to
+//   callsite-level in this PR).
 //
 //   The ADR §A10 idealization "{authzmutate, sessionrefresh}" is NOT achievable:
 //   Delete and changePasswordInTx in identitymanage need Invalidator.Apply co-tx
@@ -54,22 +70,16 @@ package archtest
 //   Wave 3 ADR author: the P1 regression class is closed at Rule (a), not at
 //   Rule (b). §A10 should be updated to reflect the actual caller set.
 //
-// Allowlist precision (D1 RC-D hardening):
-//   The allowlist was narrowed from package-level prefixes to file-level paths
-//   for the two creation-time call sites (identitymanage/service.go and
-//   adminprovision/provisioner.go). Any new file in those packages that adds a
-//   direct setter call will fail the archtest immediately, without requiring a
-//   separate allowlist entry. This is the tightest achievable restriction given
-//   the Medium upstream ceiling.
-//
-// Scanning tool: typeseval.SharedResolver + typeseval.ResolveMethodCall +
-// scanner.EachInSubtree[ast.CallExpr] for Rule (a);
-// go/types struct field and method set inspection for DOMAIN-AUTHZ-FIELD-PRIVATE-01.
+// Scanning tool: typeseval.SharedResolver + archtest.ResolveMethodCall (callee
+// type-resolved) + archtest.ResolveEnclosingFunc (caller type-resolved) +
+// scanner.EachInSubtree[ast.CallExpr] for Rule (a); go/types struct field and
+// method set inspection for DOMAIN-AUTHZ-FIELD-PRIVATE-01.
 //
 // Blind-spot self-check (ai-robust.md §"工具选定后强制盲区自检"):
 //
 // For AUTHZ-MUTATION-APPLY-FUNNEL-01 — ResolveMethodCall resolves via
-// info.Selections. AST forms NOT covered:
+// info.Selections; ResolveEnclosingFunc walks file.Decls for *ast.FuncDecl
+// containing the call's position. AST forms NOT covered:
 //
 //  1. Method-value store + call: `fn := u.SetStatus; fn(domain.StatusLocked, t)`
 //     The second `fn(...)` CallExpr's Fun is *ast.Ident, not *ast.SelectorExpr,
@@ -94,15 +104,28 @@ package archtest
 //     resolves via info.Selections to the same *types.Func (promoted method
 //     Obj() is the original). This IS covered. Documented for completeness.
 //
+//  6. Package-level var init / const init bypass: `var _ = func() {
+//     u.SetStatus(...); return 0 }()`. ResolveEnclosingFunc returns
+//     (nil, false) for any node outside a FuncDecl body. The scan loop treats
+//     (nil, false) as an AUTOMATIC violation — package-level init has no
+//     allowlistable identity. Captured (positively, i.e. confirming the rule
+//     fires) by: TestDomainAuthzMutation_BlindSpot_VarInitCall.
+//
+//  7. FuncLit-inside-FuncDecl semantic choice (NOT a blind spot):
+//     ResolveEnclosingFunc collapses a nested FuncLit's identity to its
+//     outermost FuncDecl. Rationale: FuncLit author = FuncDecl author;
+//     allowlisting the outer FuncDecl implicitly trusts any FuncLit inside.
+//     Documented for completeness; no reverse self-check needed.
+//
 // For DOMAIN-AUTHZ-FIELD-PRIVATE-01 — go/types struct/method inspection.
 // AST forms NOT covered by the type definition check:
 //
-//  6. unsafe.Pointer offset write bypasses Go field visibility:
+//  8. unsafe.Pointer offset write bypasses Go field visibility:
 //     (*domain.UserStatus)(unsafe.Pointer(uintptr(unsafe.Pointer(u)) + offset))
 //     Captured by:
 //     TestDomainAuthzMutation_BlindSpot_UnsafePointerWrite (asserts absence).
 //
-//  7. reflect.ValueOf(u).Elem().FieldByName("status").Set(...):
+//  9. reflect.ValueOf(u).Elem().FieldByName("status").Set(...):
 //     Call-site reflection bypasses type checking. Captured by:
 //     TestDomainAuthzMutation_BlindSpot_ReflectFieldByName (asserts absence).
 
@@ -149,64 +172,28 @@ var sanctionedSetters = map[string]bool{
 // sanctionedSetters are flagged.
 var authzSetterPrefixes = []string{"Set", "Mark", "Clear", "Lock", "Unlock"}
 
-// setMutatorAllowlist lists the module-relative paths whose production code is
-// permitted to call domain.User.SetStatus or
-// domain.User.SetPasswordResetRequired directly.
+// setMutatorCallsiteAllowlist enumerates the exact production callsites that
+// may invoke domain.User.SetStatus or domain.User.SetPasswordResetRequired
+// directly. Keys are *types.Func.FullName() values (canonical Go reflection
+// form for the enclosing FuncDecl); values document the rationale per entry.
 //
-// Entries ending in "/" are package-level prefixes (all files in the package).
-// Entries ending in ".go" are exact file paths (only that file).
+// Adding an entry requires explicit reviewer acknowledgement: a new entry
+// means a function is bypassing authzmutate.Mutator.Apply, which is legitimate
+// only at creation time (no live sessions exist). Any other case must route
+// through Mutator.Apply.
 //
-// Allowlist rationale:
-//   - cells/accesscore/internal/authzmutate/ — the primary funnel (package
-//     prefix). All live-aggregate authz mutations route through Mutator.Apply
-//     which calls mutation.apply() → SetStatus / SetPasswordResetRequired.
-//     The entire package is allowlisted because any future mutation type
-//     added here is legitimate funnel code.
-//   - cells/accesscore/internal/adminprovision/provisioner.go — creation-time
-//     only (exact file). No live sessions exist for a brand-new user (epoch=1).
-//     SetPasswordResetRequired is called on a freshly constructed aggregate
-//     before any session exists. authzmutate.Apply is for mutating existing
-//     principals, not initial construction. Any NEW file in adminprovision/
-//     that adds a direct setter call MUST be reviewed and explicitly added here.
-//   - cells/accesscore/internal/domain/ — the methods' own package (package
-//     prefix). SetStatus and SetPasswordResetRequired are defined here.
-//   - cells/accesscore/slices/identitymanage/service.go — creation-time only
-//     (exact file). service.go calls SetPasswordResetRequired on a freshly
-//     constructed user aggregate (identitymanage create path). Any NEW file in
-//     identitymanage/ that adds a direct setter call MUST be reviewed and
-//     explicitly added here.
+// Removing the last code-level caller of an entry triggers
+// TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive (meta-invariant),
+// forcing the entry to be deleted in the same PR — no stale allowance.
 //
-// _test.go files are always allowed.
-var setMutatorAllowlist = []string{
-	"cells/accesscore/internal/authzmutate/",
-	"cells/accesscore/internal/adminprovision/provisioner.go",
-	"cells/accesscore/internal/domain/",
-	"cells/accesscore/slices/identitymanage/service.go",
-}
-
-// isSetMutatorAllowlisted reports whether a module-relative path is in the
-// set-mutator allowlist. Test files (*_test.go) always pass.
-//
-// Entries ending in "/" match any file under that directory prefix.
-// Entries ending in ".go" match only that exact file.
-func isSetMutatorAllowlisted(rel string) bool {
-	if strings.HasSuffix(rel, "_test.go") {
-		return true
-	}
-	for _, entry := range setMutatorAllowlist {
-		if strings.HasSuffix(entry, "/") {
-			// Package-level prefix: match any file under this directory.
-			if strings.HasPrefix(rel, entry) {
-				return true
-			}
-		} else {
-			// Exact file path.
-			if rel == entry {
-				return true
-			}
-		}
-	}
-	return false
+// Test files (*_test.go) bypass this check unconditionally.
+var setMutatorCallsiteAllowlist = map[string]string{
+	"(*github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision.Provisioner).createAdminUser": "" +
+		"creation-time: brand-new user (epoch=1), no live sessions exist; " +
+		"authzmutate.Apply is for mutating existing principals",
+	"(*github.com/ghbvf/gocell/cells/accesscore/slices/identitymanage.Service).Create": "" +
+		"creation-time: brand-new user (epoch=1), no live sessions exist; " +
+		"same rationale as adminprovision",
 }
 
 // ─── Rule 1: DOMAIN-AUTHZ-FIELD-PRIVATE-01 ─────────────────────────────
@@ -344,13 +331,12 @@ func verifyDomainFieldRedFixtureDetected(t *testing.T, root, fixturePattern, lab
 // TestAuthzMutationApplyFunnel_SetStatus_01 enforces Rule (a) of
 // AUTHZ-MUTATION-APPLY-FUNNEL-01: every call to domain.User.SetStatus or
 // domain.User.SetPasswordResetRequired in non-test production code must
-// originate from an entry in setMutatorAllowlist.
+// originate from an enclosing FuncDecl whose canonical identity
+// (types.Func.FullName) is listed in setMutatorCallsiteAllowlist.
 //
-// Allowlist (see setMutatorAllowlist for rationale):
-//   - cells/accesscore/internal/authzmutate/ — primary funnel (package prefix)
-//   - cells/accesscore/internal/adminprovision/provisioner.go — creation-time only (exact file)
-//   - cells/accesscore/internal/domain/ — methods' own package (package prefix)
-//   - cells/accesscore/slices/identitymanage/service.go — creation-time only (exact file)
+// callsite-level keying (issue #732): replaces the prior file-level allowlist.
+// Any new function in an already-allowed file is NOT silently permitted; the
+// reviewer must explicitly add a callsite entry.
 //
 // RED fixture: cells/accesscore/internal/domain/testdata/rbacassign_direct_setstatus_red
 // simulates an rbacassign caller invoking SetStatus directly — must detect ≥ 1.
@@ -367,7 +353,7 @@ func TestAuthzMutationApplyFunnel_SetStatus_01(t *testing.T) {
 		}
 		for _, file := range p.Files {
 			rel := p.Rel(file)
-			if isSetMutatorAllowlisted(rel) {
+			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
 			violations = append(violations,
@@ -383,10 +369,10 @@ func TestAuthzMutationApplyFunnel_SetStatus_01(t *testing.T) {
 		t.Log(v)
 	}
 	assert.Empty(t, violations,
-		"AUTHZ-MUTATION-APPLY-FUNNEL-01 (Rule a): domain.User.SetStatus and "+
-			"domain.User.SetPasswordResetRequired must only be called from the allowlisted "+
-			"packages (authzmutate/, adminprovision/, domain/, identitymanage/). "+
-			"Route new live-aggregate mutations through authzmutate.Mutator.Apply.")
+		"AUTHZ-MUTATION-APPLY-FUNNEL-01 (Rule a, callsite-level): domain.User.SetStatus "+
+			"and domain.User.SetPasswordResetRequired must only be called from enclosing "+
+			"functions explicitly listed in setMutatorCallsiteAllowlist. Route new "+
+			"live-aggregate mutations through authzmutate.Mutator.Apply.")
 
 	// RED fixture: rbacassign caller directly invoking SetStatus.
 	// LOCATION: cells/accesscore/internal/domain/testdata/ because domain is an
@@ -402,11 +388,13 @@ func TestAuthzMutationApplyFunnel_SetStatus_01(t *testing.T) {
 
 // scanSetMutatorViolationsPass walks a single file's AST for CallExpr nodes where
 // the method receiver resolves to domain.User.SetStatus or
-// domain.User.SetPasswordResetRequired. It returns a slice of violation strings.
+// domain.User.SetPasswordResetRequired, then resolves the enclosing FuncDecl
+// and checks its canonical identity against setMutatorCallsiteAllowlist.
 //
-// This reuses the same ResolveMethodCall + EachInSubtree[ast.CallExpr] pattern
-// as scanFunnelViolations in credential_invalidate_funnel_invariants_test.go,
-// but targets domain.User methods rather than store interface methods.
+// Returns a slice of violation strings (callsite identity + line). A call
+// outside any FuncDecl (package-level var init) is an automatic violation —
+// ResolveEnclosingFunc returns (nil, false) for such positions and the
+// allowlist cannot match.
 func scanSetMutatorViolationsPass(
 	p *Pass,
 	file *ast.File,
@@ -430,10 +418,23 @@ func scanSetMutatorViolationsPass(
 			return
 		}
 		line := p.Fset.Position(call.Pos()).Line
+		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, call)
+		if !ok {
+			out = append(out, fmt.Sprintf(
+				"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: direct call to domain.User.%s "+
+					"outside any FuncDecl (package-level init or similar) — cannot be allowlisted",
+				rel, line, targetMethod,
+			))
+			return
+		}
+		callerID := caller.FullName()
+		if _, allowed := setMutatorCallsiteAllowlist[callerID]; allowed {
+			return
+		}
 		out = append(out, fmt.Sprintf(
 			"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: direct call to domain.User.%s "+
-				"outside allowed funnel packages",
-			rel, line, targetMethod,
+				"from caller %q not in setMutatorCallsiteAllowlist",
+			rel, line, targetMethod, callerID,
 		))
 	})
 	return out
@@ -462,18 +463,96 @@ func verifySetMutatorRedFixtureDetected(
 		label)
 }
 
+// ─── Rule 2 meta-invariant: stale-entry detection ──────────────────────
+
+// TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive enforces that every
+// entry in setMutatorCallsiteAllowlist corresponds to ≥ 1 actual production
+// callsite. Deleting the last caller of an allowlisted function makes the
+// entry stale; this test fails to force same-PR cleanup.
+//
+// Mechanism: scan the same production tree as Rule (a), bucket each detected
+// callsite by its caller identity (types.Func.FullName), and assert every
+// allowlist key appears at least once.
+//
+// Test files are excluded — adding _test.go file caller of a setter does NOT
+// keep an allowlist entry alive. The allowlist is for production callers only.
+func TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive(t *testing.T) {
+	t.Parallel()
+
+	hits := map[string]int{}
+	_ = RunTyped(t, TypedOpts{}, []string{
+		"./cells/accesscore/...",
+		"./cmd/...",
+	}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			countAllowlistHits(p, file, domainSetStatusMethod, hits)
+			countAllowlistHits(p, file, domainSetPasswordResetRequiredMethod, hits)
+		}
+		return nil
+	})
+
+	var stale []string
+	for callerID := range setMutatorCallsiteAllowlist {
+		if hits[callerID] == 0 {
+			stale = append(stale, callerID)
+		}
+	}
+	sort.Strings(stale)
+	for _, s := range stale {
+		t.Errorf("AUTHZ-MUTATION-APPLY-FUNNEL-01 meta: allowlist entry %q has 0 production "+
+			"callsites — last caller removed; delete the entry in the same PR", s)
+	}
+}
+
+// countAllowlistHits increments hits[callerID] for each production CallExpr
+// in file that resolves to a domain.User setter AND has a resolvable
+// enclosing FuncDecl matching the allowlist. Calls outside any FuncDecl, or
+// inside non-allowlisted callers, are ignored — this counter is only used by
+// the meta-invariant to detect stale entries.
+func countAllowlistHits(p *Pass, file *ast.File, targetMethod string, hits map[string]int) {
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil {
+			return
+		}
+		if sel.Sel.Name != targetMethod {
+			return
+		}
+		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+		if !ok || fn.Pkg() == nil || fn.Pkg().Path() != domainUserPkg {
+			return
+		}
+		caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, call)
+		if !ok {
+			return
+		}
+		callerID := caller.FullName()
+		if _, allowed := setMutatorCallsiteAllowlist[callerID]; allowed {
+			hits[callerID]++
+		}
+	})
+}
+
 // ─── Blind-spot self-check tests ─────────────────────────────────────────
 
 // TestDomainAuthzMutation_BlindSpot_MethodValueAssignment asserts that the
 // method-value-assignment blind spot (e.g. `fn := u.SetStatus; fn(...)`) does
-// NOT appear in production code outside the allowlist. If it did, the scanner
-// would miss the second CallExpr because fn(...)  has Fun=*ast.Ident, not
-// *ast.SelectorExpr.
+// NOT appear in production code outside the callsite allowlist. If it did, the
+// scanner would miss the second CallExpr because fn(...) has Fun=*ast.Ident,
+// not *ast.SelectorExpr.
 //
 // Scanner: EachInSubtree[ast.AssignStmt] + right-hand-side SelectorExpr name
-// matching. AST-only (no type info), but the method names are distinct enough
-// to avoid false positives. Soft (name-only); typed-resolver upgrade tracked
-// in #1118 (method-value name-only detection across sites).
+// matching + ResolveEnclosingFunc-based allowlist check. AST-only for the name
+// match (no type info on the inner SelectorExpr), but the caller-identity
+// allowlist check is type-resolved. Soft (name-only); typed-resolver upgrade
+// tracked in #1118 (method-value name-only detection across sites).
 func TestDomainAuthzMutation_BlindSpot_MethodValueAssignment(t *testing.T) {
 	t.Parallel()
 
@@ -494,19 +573,26 @@ func TestDomainAuthzMutation_BlindSpot_MethodValueAssignment(t *testing.T) {
 			if strings.HasSuffix(rel, "_test.go") {
 				continue
 			}
-			if isSetMutatorAllowlisted(rel) {
-				continue
-			}
 			EachInSubtree[ast.AssignStmt](file, func(assign *ast.AssignStmt) {
 				EachInChildren[ast.SelectorExpr](assign, func(sel *ast.SelectorExpr) {
-					if bannedNames[sel.Sel.Name] {
-						line := p.Fset.Position(assign.Pos()).Line
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d: method-value assignment of %s blind spot detected — "+
-								"archtest would miss the second call site",
-							rel, line, sel.Sel.Name,
-						))
+					if !bannedNames[sel.Sel.Name] {
+						return
 					}
+					// Caller-identity check: if the AssignStmt is inside an
+					// allowlisted FuncDecl, the method-value assignment is
+					// permitted (defensive — no production code does this today).
+					caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, assign)
+					if ok {
+						if _, allowed := setMutatorCallsiteAllowlist[caller.FullName()]; allowed {
+							return
+						}
+					}
+					line := p.Fset.Position(assign.Pos()).Line
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: method-value assignment of %s blind spot detected — "+
+							"archtest would miss the second call site",
+						rel, line, sel.Sel.Name,
+					))
 				})
 			})
 		}
@@ -671,4 +757,44 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 		"authz-mutation blind-spot: reflect.FieldByName of authz field names found "+
 			"in production code — the archtest cannot see reflect-based field writes. "+
 			"Refactor to use authzmutate.Mutator.Apply.")
+}
+
+// TestDomainAuthzMutation_BlindSpot_VarInitCall asserts (positively) that
+// scanSetMutatorViolationsPass fires when a setter call is inside a
+// package-level var-init expression (no enclosing FuncDecl). The RED fixture
+// for this blind-spot does NOT need to exist in the production tree — what
+// must be confirmed is the scanner's response: ResolveEnclosingFunc returns
+// (nil, false) → automatic violation, "outside any FuncDecl".
+//
+// Implementation: synthesize a *types.Info + *ast.File via the same fixture
+// helper used by typeseval tests, then run scanSetMutatorViolationsPass and
+// assert ≥ 1 violation with the "outside any FuncDecl" substring.
+//
+// This is the §6 blind-spot entry in the package godoc.
+func TestDomainAuthzMutation_BlindSpot_VarInitCall(t *testing.T) {
+	t.Parallel()
+
+	// Reuse the existing rbacassign RED fixture which has a top-level
+	// FuncDecl calling SetStatus — that confirms the standard violation
+	// path. The var-init bypass form is asserted by the AST shape contract
+	// of ResolveEnclosingFunc (covered in typeseval/enclosing_func_test.go
+	// TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse), which
+	// guarantees (nil, false) for any node outside FuncDecl. The scan loop
+	// in scanSetMutatorViolationsPass treats (nil, false) as an automatic
+	// "outside any FuncDecl" violation.
+	//
+	// Coverage chain (reverse self-check):
+	//   typeseval.ResolveEnclosingFunc returns (nil, false) for var-init
+	//     ← guaranteed by TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse
+	//   AND
+	//   scanSetMutatorViolationsPass treats (nil, false) as a violation
+	//     ← guaranteed by the conditional `if !ok { out = append(..., "outside any FuncDecl"); return }`
+	//   ⟹ a var-init setter call WOULD be flagged in production AST today
+	//
+	// This test docs the chain; the production-AST assertion is the
+	// allowlist-meta + Rule(a) tests above (zero hits today = invariant holds).
+	t.Log("var-init blind-spot is covered by ResolveEnclosingFunc (nil,false) → " +
+		"scanSetMutatorViolationsPass 'outside any FuncDecl' branch. " +
+		"See typeseval enclosing_func_test.go TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse " +
+		"for the AST-shape guarantee.")
 }

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -186,6 +186,15 @@ var authzSetterPrefixes = []string{"Set", "Mark", "Clear", "Lock", "Unlock"}
 // TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive (meta-invariant),
 // forcing the entry to be deleted in the same PR — no stale allowance.
 //
+// CI failure messages print the exact key to copy: look for
+// `direct call to domain.User.X from caller "<KEY>" not in setMutatorCallsiteAllowlist`.
+// Paste the quoted "<KEY>" verbatim into this map.
+//
+// Verified zero production CallExprs to these setters in authzmutate/ and
+// domain/ packages (PR #1196 issue #732 verification); package-level carve-outs
+// removed in this PR. The two creation-time entries are the only legitimate
+// callsites outside the authzmutate funnel.
+//
 // Test files (*_test.go) bypass this check unconditionally.
 var setMutatorCallsiteAllowlist = map[string]string{
 	"(*github.com/ghbvf/gocell/cells/accesscore/internal/adminprovision.Provisioner).createAdminUser": "" +
@@ -433,7 +442,8 @@ func scanSetMutatorViolationsPass(
 		}
 		out = append(out, fmt.Sprintf(
 			"%s:%d: AUTHZ-MUTATION-APPLY-FUNNEL-01: direct call to domain.User.%s "+
-				"from caller %q not in setMutatorCallsiteAllowlist",
+				"from caller %q not in setMutatorCallsiteAllowlist "+
+				"(copy the quoted key verbatim into the map to allow)",
 			rel, line, targetMethod, callerID,
 		))
 	})
@@ -516,6 +526,13 @@ func TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive(t *testing.T) {
 // enclosing FuncDecl matching the allowlist. Calls outside any FuncDecl, or
 // inside non-allowlisted callers, are ignored — this counter is only used by
 // the meta-invariant to detect stale entries.
+//
+// Note: hits[callerID] accumulates across all callsites within a single
+// FuncDecl — if `Service.Create` calls SetStatus twice, hits["…Service.Create"]
+// is 2. The meta-invariant only asserts ≥1, so an entry is considered stale
+// only when ALL callsites in its FuncDecl are removed. This is intentional:
+// the allowlist tracks "this function is a legitimate caller", not "exactly N
+// callsites within this function".
 func countAllowlistHits(p *Pass, file *ast.File, targetMethod string, hits map[string]int) {
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		sel, ok := call.Fun.(*ast.SelectorExpr)
@@ -761,40 +778,42 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 
 // TestDomainAuthzMutation_BlindSpot_VarInitCall asserts (positively) that
 // scanSetMutatorViolationsPass fires when a setter call is inside a
-// package-level var-init expression (no enclosing FuncDecl). The RED fixture
-// for this blind-spot does NOT need to exist in the production tree — what
-// must be confirmed is the scanner's response: ResolveEnclosingFunc returns
-// (nil, false) → automatic violation, "outside any FuncDecl".
+// package-level var-init expression (no enclosing FuncDecl).
 //
-// Implementation: synthesize a *types.Info + *ast.File via the same fixture
-// helper used by typeseval tests, then run scanSetMutatorViolationsPass and
-// assert ≥ 1 violation with the "outside any FuncDecl" substring.
-//
-// This is the §6 blind-spot entry in the package godoc.
+// This is the §6 blind-spot entry in the package godoc. Implementation: load
+// the RED fixture `var_init_setstatus_red` whose package-level var init
+// invokes domain.User.SetStatus from outside any FuncDecl. The scanner must
+// emit a violation containing "outside any FuncDecl" — proving
+// ResolveEnclosingFunc → (nil, false) → automatic violation works end-to-end.
 func TestDomainAuthzMutation_BlindSpot_VarInitCall(t *testing.T) {
 	t.Parallel()
 
-	// Reuse the existing rbacassign RED fixture which has a top-level
-	// FuncDecl calling SetStatus — that confirms the standard violation
-	// path. The var-init bypass form is asserted by the AST shape contract
-	// of ResolveEnclosingFunc (covered in typeseval/enclosing_func_test.go
-	// TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse), which
-	// guarantees (nil, false) for any node outside FuncDecl. The scan loop
-	// in scanSetMutatorViolationsPass treats (nil, false) as an automatic
-	// "outside any FuncDecl" violation.
-	//
-	// Coverage chain (reverse self-check):
-	//   typeseval.ResolveEnclosingFunc returns (nil, false) for var-init
-	//     ← guaranteed by TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse
-	//   AND
-	//   scanSetMutatorViolationsPass treats (nil, false) as a violation
-	//     ← guaranteed by the conditional `if !ok { out = append(..., "outside any FuncDecl"); return }`
-	//   ⟹ a var-init setter call WOULD be flagged in production AST today
-	//
-	// This test docs the chain; the production-AST assertion is the
-	// allowlist-meta + Rule(a) tests above (zero hits today = invariant holds).
-	t.Log("var-init blind-spot is covered by ResolveEnclosingFunc (nil,false) → " +
-		"scanSetMutatorViolationsPass 'outside any FuncDecl' branch. " +
-		"See typeseval enclosing_func_test.go TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse " +
-		"for the AST-shape guarantee.")
+	var found []string
+	_ = RunTyped(t, TypedOpts{}, []string{
+		"./cells/accesscore/internal/domain/testdata/var_init_setstatus_red",
+	}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			found = append(found,
+				scanSetMutatorViolationsPass(p, file, rel, domainSetStatusMethod)...)
+		}
+		return nil
+	})
+
+	var hasOutsideFuncDecl bool
+	for _, v := range found {
+		t.Log(v)
+		if strings.Contains(v, "outside any FuncDecl") {
+			hasOutsideFuncDecl = true
+		}
+	}
+	assert.True(t, hasOutsideFuncDecl,
+		"var-init blind-spot RED fixture must produce ≥ 1 violation containing "+
+			"'outside any FuncDecl' — proves the scanner treats package-level "+
+			"setter calls as automatic violations when ResolveEnclosingFunc "+
+			"returns (nil, false). Got %d violation(s) without the expected substring.",
+		len(found))
 }

--- a/tools/archtest/internal/passfunnelfixture/redfixture.go
+++ b/tools/archtest/internal/passfunnelfixture/redfixture.go
@@ -100,6 +100,10 @@ var (
 	_ = typeseval.ResolveMethodCall // qualified
 	_ = te.ResolveMethodCall        // alias-import
 
+	// ResolveEnclosingFunc
+	_ = typeseval.ResolveEnclosingFunc // qualified
+	_ = te.ResolveEnclosingFunc        // alias-import
+
 	// EvaluateConstString
 	_ = typeseval.EvaluateConstString // qualified
 	_ = te.EvaluateConstString        // alias-import

--- a/tools/archtest/internal/passfunnelfixture/redfixture.go
+++ b/tools/archtest/internal/passfunnelfixture/redfixture.go
@@ -36,7 +36,7 @@
 //
 // Plus a direct packages-import violation for PASS-FUNNEL-PACKAGES-IMPORT-01.
 //
-// PASS-FUNNEL-RESOLVE-01 violations are added below for the 8 typeseval
+// PASS-FUNNEL-RESOLVE-01 violations are added below for the 9 typeseval
 // helpers and scanner.ImportBan, exercising the same three import forms.
 package passfunnelfixture
 
@@ -83,7 +83,7 @@ var (
 	_ packages.Config
 
 	// ── PASS-FUNNEL-RESOLVE-01 violations ─────────────────────────────────
-	// typeseval helper symbols banned from business *_test.go (8 symbols).
+	// typeseval helper symbols banned from business *_test.go (9 symbols).
 	// Three import forms each (qualified / alias / dot-import where applicable).
 
 	// ResolvePackageRef

--- a/tools/archtest/internal/typeseval/enclosing_func.go
+++ b/tools/archtest/internal/typeseval/enclosing_func.go
@@ -7,11 +7,13 @@ import (
 
 // ResolveEnclosingFunc returns the OUTERMOST top-level *ast.FuncDecl that
 // encloses node in file, mapped to its *types.Func identity via typesInfo.Defs.
-// The identity form (callers usually call fn.FullName()):
+// The identity form (callers usually call fn.FullName(), which is the go/types
+// canonical form — parentheses around the receiver type for both pointer and
+// value methods):
 //
 //   - Top-level function:   "pkg/path.FuncName"             (e.g. "fixture.DoThing")
 //   - Pointer method:       "(*pkg/path.Recv).MethodName"   (e.g. "(*fixture.Service).Run")
-//   - Value method:         "pkg/path.Recv.MethodName"      (e.g. "fixture.Counter.Inc")
+//   - Value method:         "(pkg/path.Recv).MethodName"    (e.g. "(fixture.Counter).Inc")
 //   - init() function:      "pkg/path.init"                 (Go reflection form)
 //
 // Returns (nil, false) when node is NOT inside any top-level FuncDecl:

--- a/tools/archtest/internal/typeseval/enclosing_func.go
+++ b/tools/archtest/internal/typeseval/enclosing_func.go
@@ -1,0 +1,69 @@
+package typeseval
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+// ResolveEnclosingFunc returns the OUTERMOST top-level *ast.FuncDecl that
+// encloses node in file, mapped to its *types.Func identity via typesInfo.Defs.
+// The identity form (callers usually call fn.FullName()):
+//
+//   - Top-level function:   "pkg/path.FuncName"             (e.g. "fixture.DoThing")
+//   - Pointer method:       "(*pkg/path.Recv).MethodName"   (e.g. "(*fixture.Service).Run")
+//   - Value method:         "pkg/path.Recv.MethodName"      (e.g. "fixture.Counter.Inc")
+//   - init() function:      "pkg/path.init"                 (Go reflection form)
+//
+// Returns (nil, false) when node is NOT inside any top-level FuncDecl:
+//
+//   - Package-level var / const init expression (e.g. `var X = helper()`)
+//   - Package-level var = FuncLit() invocation (e.g. `var _ = func(){...}()`)
+//   - Import block / file-level CommentGroup
+//   - nil typesInfo, nil file, or nil node
+//
+// Callers funneling callsite-level allowlists treat (nil, false) as an
+// automatic violation: a setter call at package scope has no enclosing
+// FuncDecl to allowlist and would otherwise slip through.
+//
+// FuncLit semantics (deliberate): a nested *ast.FuncLit inside a FuncDecl is
+// NOT a distinct callsite — its identity is the OUTERMOST containing FuncDecl.
+// Rationale: the FuncLit and the FuncDecl share the same author; allowlisting
+// the outer FuncDecl implicitly trusts any FuncLit inside it. Multi-level
+// FuncLit nesting collapses to the same outer FuncDecl.
+//
+// Implementation: iterate file.Decls for *ast.FuncDecl whose Pos ≤ node.Pos()
+// < End, then resolve fd.Name to *types.Func via typesInfo.Defs. O(F) lookup
+// where F = FuncDecl count per file. No binary search: F is small (tens at
+// most) and the scan is dominated by typesInfo.Defs map lookup.
+//
+// ref: golang/tools go/types: Info.Defs[*ast.FuncDecl.Name] is the canonical
+// way to obtain *types.Func for a FuncDecl. fn.FullName() returns the same
+// canonical form Go reflection uses for method names.
+func ResolveEnclosingFunc(typesInfo *types.Info, file *ast.File, node ast.Node) (*types.Func, bool) {
+	if typesInfo == nil || file == nil || node == nil {
+		return nil, false
+	}
+	pos := node.Pos()
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Body == nil {
+			// External / forward-declared func with no body: cannot enclose a CallExpr.
+			continue
+		}
+		if pos < fd.Pos() || pos >= fd.End() {
+			continue
+		}
+		// Resolve fd.Name to *types.Func via Defs. Generic methods produce a
+		// *types.Func with a non-nil Pkg(); shouldn't fail in practice.
+		obj := typesInfo.Defs[fd.Name]
+		fn, ok := obj.(*types.Func)
+		if !ok || fn == nil {
+			return nil, false
+		}
+		return fn, true
+	}
+	return nil, false
+}

--- a/tools/archtest/internal/typeseval/enclosing_func_test.go
+++ b/tools/archtest/internal/typeseval/enclosing_func_test.go
@@ -193,6 +193,42 @@ func (c *Container[T]) Show() { fmt.Println(c.v) }
 	assert.Equal(t, "Show", fn.Name())
 }
 
+func TestResolveEnclosingFunc_FuncLitInStructLiteral_ReturnsOuter(t *testing.T) {
+	// A FuncLit nested inside a struct literal (e.g. http.HandlerFunc(func() {...})
+	// assigned to a struct field) is the same lexical-containment case as a
+	// FuncLit assigned to a local variable: position is inside the outer
+	// FuncDecl, identity collapses to the outer FuncDecl.
+	src := `package fixture
+import "fmt"
+type Handler struct{ Fn func() }
+func MountHandler() {
+	_ = Handler{Fn: func() { fmt.Println("inside struct literal funclit") }}
+}
+`
+	pkg, file := buildFakePkg(t, src)
+	var target *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if target != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Println" {
+			target = call
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, target)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, target)
+	require.True(t, ok, "FuncLit inside struct literal must resolve to outer FuncDecl")
+	assert.Equal(t, "MountHandler", fn.Name(),
+		"identity must be outer FuncDecl, not the anonymous FuncLit nested in the struct literal")
+}
+
 func TestResolveEnclosingFunc_NestedFuncLits_ReturnsOutermost(t *testing.T) {
 	// Two levels of FuncLit nesting → identity is the outermost FuncDecl.
 	src := `package fixture

--- a/tools/archtest/internal/typeseval/enclosing_func_test.go
+++ b/tools/archtest/internal/typeseval/enclosing_func_test.go
@@ -1,0 +1,271 @@
+package typeseval
+
+import (
+	"go/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findFirstCall returns the first ast.CallExpr in file. Used as the "node"
+// argument for ResolveEnclosingFunc lookups in test fixtures.
+func findFirstCall(t *testing.T, file *ast.File) *ast.CallExpr {
+	t.Helper()
+	var found *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		if call, ok := n.(*ast.CallExpr); ok {
+			found = call
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, found, "no CallExpr found in fixture")
+	return found
+}
+
+func TestResolveEnclosingFunc_TopLevelFunc(t *testing.T) {
+	src := `package fixture
+import "fmt"
+func DoThing() { fmt.Println("hi") }
+`
+	pkg, file := buildFakePkg(t, src)
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, call)
+	require.True(t, ok, "top-level func enclosing must resolve")
+	assert.Equal(t, "DoThing", fn.Name())
+	assert.Equal(t, "fixture", fn.Pkg().Path())
+	assert.Equal(t, "fixture.DoThing", fn.FullName())
+}
+
+func TestResolveEnclosingFunc_PointerMethod(t *testing.T) {
+	src := `package fixture
+import "fmt"
+type Service struct{}
+func (s *Service) Run() { fmt.Println("run") }
+`
+	pkg, file := buildFakePkg(t, src)
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, call)
+	require.True(t, ok, "pointer-receiver method enclosing must resolve")
+	assert.Equal(t, "Run", fn.Name())
+	assert.Equal(t, "(*fixture.Service).Run", fn.FullName(),
+		"go/types canonical FullName form for pointer receiver")
+}
+
+func TestResolveEnclosingFunc_ValueMethod(t *testing.T) {
+	src := `package fixture
+import "fmt"
+type Counter struct{}
+func (c Counter) Inc() { fmt.Println("inc") }
+`
+	pkg, file := buildFakePkg(t, src)
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, call)
+	require.True(t, ok, "value-receiver method enclosing must resolve")
+	assert.Equal(t, "Inc", fn.Name())
+	assert.Equal(t, "(fixture.Counter).Inc", fn.FullName(),
+		"go/types canonical FullName form for value receiver")
+}
+
+func TestResolveEnclosingFunc_FuncLitInsideFuncDecl_ReturnsOuter(t *testing.T) {
+	// Deliberate semantic choice: nested FuncLit inherits outer FuncDecl
+	// identity. Allowlisting the outer FuncDecl implicitly trusts any FuncLit
+	// inside it (FuncLit author = FuncDecl author).
+	src := `package fixture
+import "fmt"
+func OuterHandler() {
+	fn := func() { fmt.Println("inside literal") }
+	fn()
+}
+`
+	pkg, file := buildFakePkg(t, src)
+	// We want the Println call (inside the FuncLit), not the fn() call.
+	var target *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if target != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Println" {
+			target = call
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, target, "could not find Println call in fixture")
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, target)
+	require.True(t, ok, "FuncLit-nested call must resolve to outer FuncDecl")
+	assert.Equal(t, "OuterHandler", fn.Name(),
+		"identity must be outer FuncDecl, not anonymous FuncLit")
+}
+
+func TestResolveEnclosingFunc_PackageLevelVarInit_ReturnsFalse(t *testing.T) {
+	// var-init with FuncLit at package scope has no enclosing FuncDecl.
+	// Callers treat (nil, false) as an automatic violation — see archtest
+	// godoc for the var-init blind-spot reverse self-check.
+	src := `package fixture
+import "fmt"
+var _ = func() int { fmt.Println("init-time"); return 0 }()
+`
+	pkg, file := buildFakePkg(t, src)
+	// Find the Println call (not the outer FuncLit invocation, which is also a CallExpr).
+	var target *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if target != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Println" {
+			target = call
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, target, "could not find Println call in fixture")
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, target)
+	assert.False(t, ok, "package-level var init must not resolve to a FuncDecl")
+	assert.Nil(t, fn)
+}
+
+func TestResolveEnclosingFunc_PackageLevelConstInit_ReturnsFalse(t *testing.T) {
+	// Package-level const init with a call inside an expression — same
+	// blind-spot category as var-init. Returns (nil, false).
+	src := `package fixture
+func helper() int { return 7 }
+var X = helper()
+`
+	pkg, file := buildFakePkg(t, src)
+	// First call in source order is helper() — but it's inside var X init,
+	// not inside any FuncDecl.
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, call)
+	assert.False(t, ok, "var X = helper() at package scope must not resolve to a FuncDecl")
+	assert.Nil(t, fn)
+}
+
+func TestResolveEnclosingFunc_InitFunc(t *testing.T) {
+	// Go's init() is a FuncDecl (named "init"); it must resolve like any
+	// other FuncDecl. Multiple init() per file are distinct FuncDecls — each
+	// resolves to its own *types.Func identity (Go assigns synthetic numeric
+	// suffixes internally for collision tracking, but the FuncDecl.Name.Name
+	// is always "init").
+	src := `package fixture
+import "fmt"
+func init() { fmt.Println("init") }
+`
+	pkg, file := buildFakePkg(t, src)
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, call)
+	require.True(t, ok, "init() FuncDecl must resolve")
+	assert.Equal(t, "init", fn.Name())
+}
+
+func TestResolveEnclosingFunc_GenericReceiverMethod(t *testing.T) {
+	// Generic receivers resolve normally; FullName encodes type parameters
+	// per go/types canonical form.
+	src := `package fixture
+import "fmt"
+type Container[T any] struct{ v T }
+func (c *Container[T]) Show() { fmt.Println(c.v) }
+`
+	pkg, file := buildFakePkg(t, src)
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, call)
+	require.True(t, ok, "generic-receiver method must resolve")
+	assert.Equal(t, "Show", fn.Name())
+}
+
+func TestResolveEnclosingFunc_NestedFuncLits_ReturnsOutermost(t *testing.T) {
+	// Two levels of FuncLit nesting → identity is the outermost FuncDecl.
+	src := `package fixture
+import "fmt"
+func Outermost() {
+	a := func() {
+		b := func() { fmt.Println("deep") }
+		b()
+	}
+	a()
+}
+`
+	pkg, file := buildFakePkg(t, src)
+	var target *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if target != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Println" {
+			target = call
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, target)
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, target)
+	require.True(t, ok)
+	assert.Equal(t, "Outermost", fn.Name(),
+		"identity must collapse to the OUTERMOST FuncDecl, not intermediate FuncLits")
+}
+
+func TestResolveEnclosingFunc_NilTypesInfo(t *testing.T) {
+	src := `package fixture
+import "fmt"
+func F() { fmt.Println("x") }
+`
+	_, file := buildFakePkg(t, src)
+	call := findFirstCall(t, file)
+
+	fn, ok := ResolveEnclosingFunc(nil, file, call)
+	assert.False(t, ok, "nil typesInfo must not panic and must return false")
+	assert.Nil(t, fn)
+}
+
+func TestResolveEnclosingFunc_NilFile(t *testing.T) {
+	src := `package fixture
+import "fmt"
+func F() { fmt.Println("x") }
+`
+	pkg, _ := buildFakePkg(t, src)
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, nil, nil)
+	assert.False(t, ok)
+	assert.Nil(t, fn)
+}
+
+func TestResolveEnclosingFunc_NodeOutsideFile(t *testing.T) {
+	// node.Pos() falling between two FuncDecls (e.g. in a CommentGroup or
+	// import block) → (nil, false). We synthesize this by giving a node
+	// whose Pos() points to the file's import declaration.
+	src := `package fixture
+import "fmt"
+func F() { fmt.Println("x") }
+`
+	pkg, file := buildFakePkg(t, src)
+	require.NotEmpty(t, file.Imports)
+	importNode := file.Imports[0]
+
+	fn, ok := ResolveEnclosingFunc(pkg.TypesInfo, file, importNode)
+	assert.False(t, ok, "node in import block has no enclosing FuncDecl")
+	assert.Nil(t, fn)
+}

--- a/tools/archtest/internal/typeseval/typeseval.go
+++ b/tools/archtest/internal/typeseval/typeseval.go
@@ -4,7 +4,7 @@
 // kernel/governance enforces stdlib-only and runtime/cells/adapters have no
 // reason to evaluate AST constants.
 //
-// The helpers cover two patterns:
+// The helpers cover three patterns:
 //
 //  1. EvaluateConstString — collapse BasicLit / Ident / SelectorExpr / BinaryExpr
 //     to their compile-time string constant value via go/types' built-in
@@ -14,6 +14,12 @@
 //     packages.Package. Both accept a `tests` flag (true loads test variant
 //     packages, including *_test.go files) and a `tags` slice (joined into
 //     -tags=a,b,c BuildFlags).
+//  3. ResolveMethodCall / ResolvePackageRef / ResolveEnclosingFunc — given a
+//     SelectorExpr / Expr / Node, return the canonical *types.Func or
+//     (pkg, symbol) identity for callee-side and caller-side checks.
+//     ResolveEnclosingFunc is the caller-side helper: walk a file's top-level
+//     FuncDecls and return the one that lexically contains the node, mapped to
+//     its *types.Func (used as callsite identity for funnel allowlists).
 //
 // ref: golang.org/x/tools/go/packages — NeedTypesInfo + constant folding
 // ref: go/types TypesInfo.Types — maps ast.Expr to TypeAndValue (incl. const)

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -316,7 +316,7 @@ func diagsPackagesImport(tgt passFunnelTarget) []scanner.Diagnostic {
 //
 // # Per-form fixture coverage
 //
-// The 8 typeseval helper symbols are fixtured in two import forms (qualified +
+// The 9 typeseval helper symbols are fixtured in two import forms (qualified +
 // alias) only. A typeseval dot-import fixture is not present: conflicting imports
 // (a file can only dot-import a given package path once, but the package is
 // already imported under both a qualified and alias form in redfixture.go) make
@@ -342,14 +342,15 @@ func diagsPackagesImport(tgt passFunnelTarget) []scanner.Diagnostic {
 // level. Reverting the *types.TypeName fix in call_target.go drops
 // scannerImportBanCount from 3 to 2, failing the assertion.
 func diagsResolveHelpers(tgt passFunnelTarget) []scanner.Diagnostic {
-	const replacement = "archtest.{ResolvePackageRef,ResolveMethodCall,EvaluateConstString," +
-		"FlatNonDefaultTags,KnownNonDefaultTags} / Pass.{IsFileInScope,IsGenerated} / archtest.ImportBan"
+	const replacement = "archtest.{ResolvePackageRef,ResolveMethodCall,ResolveEnclosingFunc," +
+		"EvaluateConstString,FlatNonDefaultTags,KnownNonDefaultTags} / Pass.{IsFileInScope,IsGenerated} / archtest.ImportBan"
 	return scanForForbiddenCallees(
 		tgt,
 		map[string]map[string]bool{
 			typesevalPkgPath: {
 				"ResolvePackageRef":     true,
 				"ResolveMethodCall":     true,
+				"ResolveEnclosingFunc":  true,
 				"EvaluateConstString":   true,
 				"FlatNonDefaultTags":    true,
 				"KnownNonDefaultTags":   true,
@@ -709,7 +710,7 @@ func collectFixtureTagBoundObjects(info *types.Info, file *ast.File) map[types.O
 
 // TestPassFunnelResolve01 — PASS-FUNNEL-RESOLVE-01.
 //
-// Archtest tools/archtest/<file>_test.go must NOT call the 8 typeseval helper
+// Archtest tools/archtest/<file>_test.go must NOT call the 9 typeseval helper
 // symbols (ResolvePackageRef, ResolveMethodCall, EvaluateConstString,
 // FlatNonDefaultTags, KnownNonDefaultTags, ParseBuildConstraint,
 // IsGeneratedRelPath, BuildContextPredicate) or scanner.ImportBan directly.
@@ -977,7 +978,7 @@ func loadPackagesImporters(t *testing.T) map[string]bool {
 // escape — the typed initial assignment still trips the rule, so wrapping
 // in a variable is a no-op disguise rather than a true bypass.
 //
-// For PASS-FUNNEL-RESOLVE-01 specifically: the 8 typeseval helpers are
+// For PASS-FUNNEL-RESOLVE-01 specifically: the 9 typeseval helpers are
 // fixtured in qualified + alias form only (2 forms). A typeseval dot-import
 // form is infeasible in redfixture.go (conflicting imports — the package is
 // already imported under qualified + alias; Go allows only one dot-import
@@ -1097,11 +1098,12 @@ func TestPassFunnel_FixtureCoverage(t *testing.T) {
 	for _, tgt := range fixtureTargets {
 		resolveDiags = append(resolveDiags, diagsResolveHelpers(tgt)...)
 	}
-	// Per-symbol ≥1 assertion for the 8 typeseval helpers.
+	// Per-symbol ≥1 assertion for the 9 typeseval helpers.
 	// Diagnostic messages have the form "use X instead of <typesevalPkgPath>.<SymbolName>".
 	typesevalHelpers := []string{
 		"ResolvePackageRef",
 		"ResolveMethodCall",
+		"ResolveEnclosingFunc",
 		"EvaluateConstString",
 		"FlatNonDefaultTags",
 		"KnownNonDefaultTags",

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -711,9 +711,10 @@ func collectFixtureTagBoundObjects(info *types.Info, file *ast.File) map[types.O
 // TestPassFunnelResolve01 — PASS-FUNNEL-RESOLVE-01.
 //
 // Archtest tools/archtest/<file>_test.go must NOT call the 9 typeseval helper
-// symbols (ResolvePackageRef, ResolveMethodCall, EvaluateConstString,
-// FlatNonDefaultTags, KnownNonDefaultTags, ParseBuildConstraint,
-// IsGeneratedRelPath, BuildContextPredicate) or scanner.ImportBan directly.
+// symbols (ResolvePackageRef, ResolveMethodCall, ResolveEnclosingFunc,
+// EvaluateConstString, FlatNonDefaultTags, KnownNonDefaultTags,
+// ParseBuildConstraint, IsGeneratedRelPath, BuildContextPredicate) or
+// scanner.ImportBan directly.
 // Use the archtest façade instead:
 //   - typeseval helpers → archtest.ResolvePackageRef / .ResolveMethodCall /
 //     .EvaluateConstString / .FlatNonDefaultTags / .KnownNonDefaultTags

--- a/tools/archtest/resolve.go
+++ b/tools/archtest/resolve.go
@@ -38,7 +38,7 @@
 // # PASS-FUNNEL-RESOLVE-01 (enforcement)
 //
 // The meta-archtest PASS-FUNNEL-RESOLVE-01 in pass_funnel_test.go bans
-// business *_test.go files from calling the eight typeseval helpers or
+// business *_test.go files from calling the nine typeseval helpers or
 // scanner.ImportBan directly. Files in passFunnelPermanentExempt (3 framework
 // files) are permanently exempt; LegacyAllowlist deleted in Stage 4.
 package archtest
@@ -84,6 +84,24 @@ func ResolvePackageRef(info *types.Info, expr ast.Expr) (pkgPath, name string, o
 // info must come from the same packages.Load result that produced sel.
 func ResolveMethodCall(info *types.Info, sel *ast.SelectorExpr) (*types.Func, bool) {
 	return typeseval.ResolveMethodCall(info, sel)
+}
+
+// ResolveEnclosingFunc returns the OUTERMOST top-level *ast.FuncDecl enclosing
+// node in file, mapped to its *types.Func identity (use fn.FullName() to obtain
+// the canonical caller-side identity, e.g. "pkg.Func" or "(*pkg.Recv).Method").
+//
+// Thin delegation to [typeseval.ResolveEnclosingFunc]. Returns (nil, false) for
+// package-level var / const init, import blocks, or any other location outside
+// a FuncDecl body — callers funneling callsite-level allowlists treat that as
+// an automatic violation.
+//
+// Nested *ast.FuncLit inherits the outer FuncDecl identity by design (FuncLit
+// author = FuncDecl author; allowlisting the outer FuncDecl implicitly trusts
+// any FuncLit inside it).
+//
+// info must come from the same packages.Load result that produced file.
+func ResolveEnclosingFunc(info *types.Info, file *ast.File, node ast.Node) (*types.Func, bool) {
+	return typeseval.ResolveEnclosingFunc(info, file, node)
 }
 
 // EvaluateConstString returns the compile-time string constant value of expr,

--- a/tools/archtest/resolve.go
+++ b/tools/archtest/resolve.go
@@ -99,6 +99,12 @@ func ResolveMethodCall(info *types.Info, sel *ast.SelectorExpr) (*types.Func, bo
 // author = FuncDecl author; allowlisting the outer FuncDecl implicitly trusts
 // any FuncLit inside it).
 //
+// The signature is asymmetric to [ResolveMethodCall] / [ResolvePackageRef]
+// (which take only info + expression): the lookup iterates `file.Decls` for
+// *ast.FuncDecl, because typesInfo.Defs has no file-scope index from which to
+// recover the enclosing FuncDecl by position alone. Pass the same *ast.File
+// from `pass.Files` that produced node.
+//
 // info must come from the same packages.Load result that produced file.
 func ResolveEnclosingFunc(info *types.Info, file *ast.File, node ast.Node) (*types.Func, bool) {
 	return typeseval.ResolveEnclosingFunc(info, file, node)

--- a/tools/archtest/testdata/credential_invalidate_fixtures/noncanonical_applier_interface_red/usage.go
+++ b/tools/archtest/testdata/credential_invalidate_fixtures/noncanonical_applier_interface_red/usage.go
@@ -1,0 +1,23 @@
+// Package noncanonical_applier_interface_red is a RED fixture for
+// CREDENTIAL-INVALIDATE-APPLIER-INTERFACE-CANONICAL-01: it declares a
+// LocalApplier interface whose Apply method has the same signature as
+// credentialinvalidate.Applier.Apply but lives outside the
+// credentialinvalidate package. The scanner must detect this regression —
+// allowing such a re-declaration would re-create the pre-#1196
+// sessionrefresh "interface-routed Soft channel" (info.Selections would
+// resolve s.inv.Apply to the local interface, hiding the callsite from
+// CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01).
+package noncanonical_applier_interface_red
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/runtime/auth/session"
+)
+
+// LocalApplier is the regression pattern: identical signature to
+// credentialinvalidate.Applier.Apply, declared in a non-canonical package.
+// The archtest must flag it.
+type LocalApplier interface {
+	Apply(ctx context.Context, subjectID string, event session.CredentialEvent) error
+}


### PR DESCRIPTION
## Summary

把两个 funnel 的 caller allowlist 从文件/包前缀级升级到 **callsite-level**，消除"同文件 / 不同函数漏过"路径：

- **AUTHZ-MUTATION-APPLY-FUNNEL-01 Rule (a)** (`tools/archtest/domain_authz_mutation_funnel_invariants_test.go`)
  - `setMutatorAllowlist []string`（4 entry 混合 file/package 前缀）→ `setMutatorCallsiteAllowlist map[string]string`（2 entry，types.Func.FullName）
- **CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01** (`tools/archtest/credential_invalidate_funnel_invariants_test.go`)
  - `upstreamCallerAllowlistPrefixes []string`（5 entry package 前缀）→ `upstreamCallerCallsiteAllowlist map[string]string`（4 entry，types.Func.FullName）
- 新增 `typeseval.ResolveEnclosingFunc(info, file, node) → (*types.Func, bool)` helper（OUTERMOST top-level FuncDecl identity；FuncLit 归属外层；var/const init 返回 false → 自动 violation）
- 两个 funnel 各加 `*_AllowlistEntriesAreLive` meta-invariant 防 stale entry：删除最后一个合规 caller 自动失败
- 同步：`archtest.ResolveEnclosingFunc` 薄转发 + `PASS-FUNNEL-RESOLVE-01` banned set + redfixture 三处

## Funnel 双向锁评级 (after)

| 方向 | 形态 | 评级 |
|------|------|------|
| 上游 `DOMAIN-AUTHZ-FIELD-PRIVATE-01` | Go field private + sanctioned setter set | **Hard**（compile-time） |
| 下游 `AUTHZ-MUTATION-APPLY-FUNNEL-01 Rule (a)` | ResolveMethodCall 锁 callee + ResolveEnclosingFunc 锁 caller，form-uniqueness 全部 type-resolved | **Hard**（archtest 上限） |
| 上游 `CREDENTIAL-INVALIDATE-FUNNEL-01` (Apply 入口架构层) | adminprovision/identitymanage 是合法 bypass | Medium-by-necessity |
| 下游 `CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01` | 同 Rule (a) | **Hard**（archtest 上限） |

落入 ai-robust §"Hard 范本目录" 的 **string-typed concept funnel**（callerID = types.Func.FullName，与 Go reflection canonical 同源）+ form-uniqueness。

## Documented blind-spot

`sessionrefresh.handleReuseDetected` 通过 local interface `invalidatorApplier` 注入 Invalidator（为单元测试可替换），`info.Selections` 解析到 sessionrefresh.invalidatorApplier.Apply 而非 credentialinvalidate.(*Invalidator).Apply → scanner 不可见。

这是 **pre-existing** 的 interface-indirection scanner blind spot，原 file-prefix allowlist（含 `sessionrefresh/`）同样无法检测该调用——file-level prefix 是"看不见的合规"而非"真正的合规"。callsite-level 不能继承不存在的检测能力，故 sessionrefresh 不进 allowlist，文件头 godoc + allowlist 注释三处显式登记。

direct-typed 路径（identitymanage / rbacassign / authzmutate / adminprovision）全部覆盖；RED fixture `sessionlogin_direct_apply_red` 使用 concrete 类型，direct-typed lockdown 不变。

## Test plan

- [x] `go build ./...` 通过
- [x] `go test ./tools/archtest/internal/typeseval/ -run TestResolveEnclosingFunc` 通过（11 cases：top-level func / pointer/value method / FuncLit / nested FuncLit / package-var init / const init / init() / generic / nil-guard）
- [x] `go test ./tools/archtest/ -run TestAuthzMutationApplyFunnel|TestDomainAuthzMutation|TestDomainAuthzFieldPrivate` 通过（含 RED fixture + 5 blind-spot self-check + 新增 AllowlistEntriesAreLive meta + VarInitCall doc test）
- [x] `go test ./tools/archtest/ -run TestCredentialInvalidate` 通过（4 rules + 新增 AllowlistEntriesAreLive meta + reflect blind-spot）
- [x] `go test ./tools/archtest/ -run TestPassFunnel` 通过（PASS-FUNNEL-RESOLVE-01 含新 ResolveEnclosingFunc 符号）
- [x] `go build -tags=integration ./...` 通过
- [x] `bash hack/verify-archtest-invariants.sh` 通过（PR-time 4 类 invariant）
- [x] `golangci-lint run ./...` 0 issues

## Files

新建：
- `tools/archtest/internal/typeseval/enclosing_func.go`
- `tools/archtest/internal/typeseval/enclosing_func_test.go`

修改：
- `tools/archtest/resolve.go`（+`ResolveEnclosingFunc` 薄转发）
- `tools/archtest/pass_funnel_test.go`（PASS-FUNNEL-RESOLVE-01 banned set + 9-helper symbol lock）
- `tools/archtest/internal/passfunnelfixture/redfixture.go`（+`ResolveEnclosingFunc` 红夹具 2 form）
- `tools/archtest/domain_authz_mutation_funnel_invariants_test.go`（callsite map + meta + godoc + blind-spot #6/#7）
- `tools/archtest/credential_invalidate_funnel_invariants_test.go`（callsite map + meta + godoc + blind-spot #3/#4/#5）

ref: `tools/archtest/healthz_invariants_test.go` (HEALTHZ-WRITE-01/A2 callsite allowlist 范本)
ref: `tools/archtest/aftercommit_pure_transient_test.go` (AFTERCOMMIT-HOOK-PURE-TRANSIENT-01/A3 范本)
ref: `tools/archtest/internal/typeseval/receiver_type.go` (ResolveMethodCall — sibling helper)

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)