### PR TITLE
refactor(archtest): drop two redundant Pass.IsGenerated checks

### DIFF
--- a/tools/archtest/http_contract_visibility_type_segregation_01_test.go
+++ b/tools/archtest/http_contract_visibility_type_segregation_01_test.go
@@ -188,8 +188,9 @@ func checkPassForVisibilityViolations(pass *Pass, ifaceSet *contractServiceIface
 	var out []httpVisibilityViolation
 	for _, file := range pass.Files {
 		rel := pass.Rel(file)
-		// Skip test files. Generated packages are already filtered above at
-		// pkgPath level (line ~164: strings.Contains(pkgPath, "/generated/")),
+		// Skip test files. Generated packages were already filtered at
+		// function entry by the pkgPath check above
+		// (strings.Contains(pkgPath, "/generated/") → return nil),
 		// so the per-file IsGenerated check is dead code.
 		if strings.HasSuffix(rel, "_test.go") {
 			continue

--- a/tools/archtest/http_contract_visibility_type_segregation_01_test.go
+++ b/tools/archtest/http_contract_visibility_type_segregation_01_test.go
@@ -188,8 +188,10 @@ func checkPassForVisibilityViolations(pass *Pass, ifaceSet *contractServiceIface
 	var out []httpVisibilityViolation
 	for _, file := range pass.Files {
 		rel := pass.Rel(file)
-		// Skip test files and generated files.
-		if strings.HasSuffix(rel, "_test.go") || pass.IsGenerated(file) {
+		// Skip test files. Generated packages are already filtered above at
+		// pkgPath level (line ~164: strings.Contains(pkgPath, "/generated/")),
+		// so the per-file IsGenerated check is dead code.
+		if strings.HasSuffix(rel, "_test.go") {
 			continue
 		}
 

--- a/tools/archtest/pass_test.go
+++ b/tools/archtest/pass_test.go
@@ -1231,9 +1231,6 @@ func TestRunTypedProduction_excludesGeneratedPackages(t *testing.T) {
 				t.Errorf("RunTypedProduction yielded generated/ file %q — "+
 					"generated packages must be unreachable under this entry", rel)
 			}
-			if p.IsGenerated(f) {
-				t.Errorf("RunTypedProduction yielded IsGenerated file %q", p.Rel(f))
-			}
 		}
 		if p.Pkg != nil && strings.Contains(p.Pkg.Path(), "/generated/") {
 			t.Errorf("RunTypedProduction yielded generated package %q", p.Pkg.Path())


### PR DESCRIPTION
## Summary

Two dead-code IsGenerated calls identified during #722 analysis (closed as won't-do — see #1195 thread for full reasoning).

The `Pass.IsGenerated` method itself is kept (still used by other rules); only the redundant call sites are removed.

1. **`tools/archtest/pass_test.go:1234`** — `if p.IsGenerated(f)` inside `TestRunTypedProduction_excludesGeneratedPackages` is redundant; the preceding line `if strings.HasPrefix(rel, "generated/")` already asserts the same property (`Pass.IsGenerated` is a thin delegate to `typeseval.IsGeneratedRelPath` which is itself `strings.HasPrefix(rel, "generated/")`).
2. **`tools/archtest/http_contract_visibility_type_segregation_01_test.go:192`** — `|| pass.IsGenerated(file)` branch is unreachable; line 164's package-path filter `strings.Contains(pkgPath, "/generated/")` already excludes generated packages at Pass entry, so no Pass containing a generated/ file ever reaches the inner loop.

Net: +4 / -5.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./tools/archtest/ -run 'TestRunTypedProduction_excludesGeneratedPackages|TestHTTPContractVisibilityTypeSegregation01' -count=1` passes
- [x] `golangci-lint run ./...` — 0 new issues (2 pre-existing dupl findings in `cells/accesscore/.../user_repo.go` unrelated)

Refs: #722 (closed won't-do), #1195 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)