### PR TITLE
feat(metadata): M1 — Locator funnel for external-repo Cell development (#1082)

### DIFF
--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -123,6 +123,7 @@ func checkContractHealth(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("check contract-health", flag.ContinueOnError)
 	format := fs.String("format", string(printers.FormatText),
 		"output format: text (non-stable, default) | json | sarif")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -132,7 +133,12 @@ func checkContractHealth(ctx context.Context, args []string) error {
 		return fmt.Errorf(errCannotFindRoot, err)
 	}
 
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return err
+	}
+
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf(errMetadataParse, err)
@@ -259,6 +265,7 @@ func checkSliceCoverage(args []string) error {
 	fs := flag.NewFlagSet(flagSetCheckPrefix+cmdSliceCoverage, flag.ContinueOnError)
 	cellID := fs.String("cell", "", "restrict check to this cell ID (empty = all cells)")
 	format := fs.String("format", string(printers.FormatText), flagFormatDescription)
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -268,7 +275,12 @@ func checkSliceCoverage(args []string) error {
 		return fmt.Errorf(errCannotFindRoot, err)
 	}
 
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return err
+	}
+
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf(errMetadataParse, err)
@@ -412,6 +424,7 @@ func checkAssemblyCompleteness(args []string) error {
 	fs := flag.NewFlagSet("check assembly-completeness", flag.ContinueOnError)
 	id := fs.String("id", "", "assembly ID (required)")
 	format := fs.String("format", string(printers.FormatText), flagFormatDescription)
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -424,7 +437,12 @@ func checkAssemblyCompleteness(args []string) error {
 		return fmt.Errorf(errCannotFindRoot, err)
 	}
 
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return err
+	}
+
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf(errMetadataParse, err)
@@ -475,6 +493,7 @@ func checkJourneyReadiness(args []string) error {
 	fs := flag.NewFlagSet(flagSetCheckPrefix+cmdJourneyReadiness, flag.ContinueOnError)
 	journeyID := fs.String("journey", "", "restrict check to this journey ID (empty = all)")
 	format := fs.String("format", string(printers.FormatText), flagFormatDescription)
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -484,7 +503,12 @@ func checkJourneyReadiness(args []string) error {
 		return fmt.Errorf(errCannotFindRoot, err)
 	}
 
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return err
+	}
+
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf(errMetadataParse, err)
@@ -610,6 +634,7 @@ func checkL0Imports(args []string) error {
 	fs := flag.NewFlagSet(flagSetCheckPrefix+cmdL0Imports, flag.ContinueOnError)
 	cellID := fs.String("cell", "", "restrict check to this cell ID (empty = all L0 cells)")
 	format := fs.String("format", string(printers.FormatText), flagFormatDescription)
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -619,7 +644,12 @@ func checkL0Imports(args []string) error {
 		return fmt.Errorf(errCannotFindRoot, err)
 	}
 
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return err
+	}
+
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf(errMetadataParse, err)

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -327,15 +327,28 @@ func checkSliceCoverage(args []string) error {
 func sliceCoverageForCell(root string, project *metadata.ProjectMeta, cid string) []governance.ValidationResult {
 	var results []governance.ValidationResult
 
-	results = append(results, sliceDirCheck(root, cid)...)
+	cell := project.Cells[cid]
+	results = append(results, sliceDirCheck(root, cid, cell)...)
 	results = append(results, sliceMetaCheck(project, cid)...)
 	return results
 }
 
-// sliceDirCheck verifies every subdir under cells/<cid>/slices/ has a slice.yaml.
-func sliceDirCheck(root, cid string) []governance.ValidationResult {
+// sliceDirCheck verifies every subdir under <cellDir>/slices/ has a slice.yaml.
+// The slices directory is derived from cell.File (the path to cell.yaml relative
+// to the project root), which satisfies LOCATOR-DISCOVERY-FUNNEL-01.A5 by
+// avoiding the hardcoded "cells" layout token. cid is used only for human-readable
+// messages; cell must be non-nil.
+func sliceDirCheck(root, cid string, cell *metadata.CellMeta) []governance.ValidationResult {
+	// Derive the slices directory from the cell's file path:
+	//   cell.File = "cells/accesscore/cell.yaml"
+	//   cellDir   = "cells/accesscore"
+	//   slicesDir = "<root>/cells/accesscore/slices"
+	// This works uniformly for conventional and Manifest layouts.
+	cellDir := filepath.Dir(filepath.FromSlash(cell.File))
+	slicesRelDir := filepath.ToSlash(filepath.Join(cellDir, "slices"))
+	slicesDir := filepath.Join(root, cellDir, "slices")
+
 	var results []governance.ValidationResult
-	slicesDir := filepath.Join(root, "cells", cid, "slices")
 	entries, err := os.ReadDir(slicesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -345,9 +358,9 @@ func sliceDirCheck(root, cid string) []governance.ValidationResult {
 			Code:      governance.RuleCode("CHECK-SLICE-DIR-READ-ERROR"),
 			Severity:  governance.SeverityError,
 			IssueType: governance.IssueInvalid,
-			File:      filepath.ToSlash(filepath.Join("cells", cid, "slices")),
+			File:      slicesRelDir,
 			Message:   fmt.Sprintf("cannot read slices dir for cell %q: %v", cid, err),
-			Fix:       "ensure the cells/<cellID>/slices/ directory exists and is readable",
+			Fix:       "ensure the slices/ directory exists and is readable",
 		}}
 	}
 	for _, e := range entries {
@@ -362,8 +375,8 @@ func sliceDirCheck(root, cid string) []governance.ValidationResult {
 				IssueType: governance.IssueRequired,
 				Scope:     cmdSliceCoverage,
 				Message:   fmt.Sprintf("cell %q: slices/%s has no slice.yaml", cid, e.Name()),
-				Fix: fmt.Sprintf("add a slice.yaml to cells/%s/slices/%s/ declaring the slice id, "+
-					"belongsToCell, contractUsages, and verify fields", cid, e.Name()),
+				Fix: fmt.Sprintf("add a slice.yaml to %s/slices/%s/ declaring the slice id, "+
+					"belongsToCell, contractUsages, and verify fields", cellDir, e.Name()),
 			})
 		}
 	}

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -576,7 +576,7 @@ func journeyReadinessFor(
 // readiness tracking. Same posture as validateADV01 (rules_misc_advisory.go)
 // and CONTRACT-CONSISTENCY-EMIT-01.
 func journeyStatusCheck(jm *metadata.JourneyMeta, statusCount map[string]int) []governance.ValidationResult {
-	if strings.HasPrefix(jm.File, "examples/") {
+	if metadata.IsInExamplesSubtree(jm.File) {
 		return nil
 	}
 	count := statusCount[jm.ID]

--- a/cmd/gocell/app/check_test.go
+++ b/cmd/gocell/app/check_test.go
@@ -833,3 +833,50 @@ func TestHTTPTransportColumns(t *testing.T) {
 		})
 	}
 }
+
+// TestJourneyStatusCheck_ExamplesExemption verifies that journeys whose file
+// path is under examples/ are exempt from the platform status-board requirement.
+// This test also exercises the metadata.IsInExamplesSubtree funnel path (T2).
+func TestJourneyStatusCheck_ExamplesExemption(t *testing.T) {
+	cases := []struct {
+		name        string
+		file        string
+		statusCount map[string]int
+		wantNil     bool // expect nil (no findings)
+	}{
+		{
+			name:        "examples journey with 0 status entries → exempt, no findings",
+			file:        "examples/foo/journeys/J-onboard.yaml",
+			statusCount: map[string]int{},
+			wantNil:     true,
+		},
+		{
+			name:        "platform journey with 0 status entries → finding",
+			file:        "journeys/J-onboard.yaml",
+			statusCount: map[string]int{},
+			wantNil:     false,
+		},
+		{
+			name:        "platform journey with exactly 1 entry → no finding",
+			file:        "journeys/J-onboard.yaml",
+			statusCount: map[string]int{"J-onboard": 1},
+			wantNil:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			jm := &metadata.JourneyMeta{
+				ID:   "J-onboard",
+				File: tc.file,
+			}
+			results := journeyStatusCheck(jm, tc.statusCount)
+			if tc.wantNil && len(results) != 0 {
+				t.Errorf("expected nil results for file %q, got %d: %v", tc.file, len(results), results)
+			}
+			if !tc.wantNil && len(results) == 0 {
+				t.Errorf("expected non-nil results for file %q, got nil", tc.file)
+			}
+		})
+	}
+}

--- a/cmd/gocell/app/codegen_cmd.go
+++ b/cmd/gocell/app/codegen_cmd.go
@@ -42,8 +42,8 @@ type CodegenResult interface {
 // wrap used by every codegen sub-command (`metadata parse: %w`).
 // Centralized so the wrap message stays consistent across dispatchers and
 // is the single place to extend (e.g. with structured logging) later.
-func parseProject(root string) (*metadata.ProjectMeta, error) {
-	project, err := metadata.NewParser(root).Parse()
+func parseProject(root string, opts ...metadata.LocatorOption) (*metadata.ProjectMeta, error) {
+	project, err := metadata.NewParser(root, opts...).Parse()
 	if err != nil {
 		return nil, fmt.Errorf("metadata parse: %w", err)
 	}
@@ -80,7 +80,7 @@ type codegenSpec[R CodegenResult] struct {
 //   - --all=false without positional id: error
 //   - --dry-run + --verify: mutually exclusive
 func runCodegenGenerate[R CodegenResult](spec codegenSpec[R], args []string) error {
-	dryRun, verify, only, err := parseCodegenFlags(spec, args)
+	dryRun, verify, only, locatorOpts, err := parseCodegenFlags(spec, args)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func runCodegenGenerate[R CodegenResult](spec codegenSpec[R], args []string) err
 	if err != nil {
 		return fmt.Errorf("cannot find project root: %w", err)
 	}
-	project, err := parseProject(root)
+	project, err := parseProject(root, locatorOpts...)
 	if err != nil {
 		return err
 	}
@@ -110,41 +110,50 @@ func runCodegenGenerate[R CodegenResult](spec codegenSpec[R], args []string) err
 	return nil
 }
 
-// parseCodegenFlags is the common --all/--dry-run/--verify/<id> parser.
+// parseCodegenFlags is the common --all/--dry-run/--verify/<id>/--layout/--manifest parser.
 //
 // Default behavior (K#05 W2 DX defaults):
 //   - --all defaults to true: `gocell generate cell` runs all cells
 //   - positional <id> wins over --all default: `gocell generate cell ordercell`
 //     scopes to ordercell only (--all is implicitly cleared)
 //   - explicit --all=false without a positional id is an error
-func parseCodegenFlags[R CodegenResult](spec codegenSpec[R], args []string) (dryRun, verify bool, only string, err error) {
+func parseCodegenFlags[R CodegenResult](
+	spec codegenSpec[R], args []string,
+) (dryRun, verify bool, only string, locatorOpts []metadata.LocatorOption, err error) {
 	fs := flag.NewFlagSet("generate "+spec.Kind, flag.ContinueOnError)
 	all := fs.Bool("all", true, spec.AllFlagDesc)
 	dr := fs.Bool("dry-run", false, "print would-write file paths without writing")
 	ver := fs.Bool("verify", false, "diff against disk, exit non-zero on drift, no write")
+	layout, manifestPath := addLocatorFlags(fs)
 	if perr := fs.Parse(args); perr != nil {
-		return false, false, "", perr
+		return false, false, "", nil, perr
 	}
+	const dryVerMutexMsg = "--dry-run (stdout preview) and --verify " +
+		"(CI drift check, no write) are mutually exclusive; pick one"
 	if *dr && *ver {
-		return false, false, "", errors.New("--dry-run (stdout preview) and --verify (CI drift check, no write) are mutually exclusive; pick one")
+		return false, false, "", nil, errors.New(dryVerMutexMsg)
+	}
+	opts, lerr := buildLocatorOptions(*layout, *manifestPath)
+	if lerr != nil {
+		return false, false, "", nil, fmt.Errorf("generate %s: %w", spec.Kind, lerr)
 	}
 	pos := fs.Args()
 	// Reject more than one positional id to avoid silent arg-drop surprises.
 	if len(pos) > 1 {
-		return false, false, "", fmt.Errorf("only one %s id allowed; got: %v", spec.Kind, pos)
+		return false, false, "", nil, fmt.Errorf("only one %s id allowed; got: %v", spec.Kind, pos)
 	}
 	// Positional id takes priority over --all (including the default true).
 	if len(pos) == 1 {
-		return *dr, *ver, pos[0], nil
+		return *dr, *ver, pos[0], opts, nil
 	}
 	// No positional id: honor --all flag value.
 	if !*all {
 		if *dr || *ver {
-			return false, false, "", fmt.Errorf("specify a %s id or --all when using --dry-run/--verify", spec.Kind)
+			return false, false, "", nil, fmt.Errorf("specify a %s id or --all when using --dry-run/--verify", spec.Kind)
 		}
-		return false, false, "", fmt.Errorf("usage: %s", spec.GenerateUsage)
+		return false, false, "", nil, fmt.Errorf("usage: %s", spec.GenerateUsage)
 	}
-	return *dr, *ver, "", nil
+	return *dr, *ver, "", opts, nil
 }
 
 // runCodegenVerify implements `gocell verify codegen-<kind>` (sandbox + --local).
@@ -157,21 +166,26 @@ func runCodegenVerify[R CodegenResult](spec codegenSpec[R], args []string) error
 	local := fs.Bool("local", true,
 		"skip git worktree sandbox; verify in-place against current working tree "+
 			"(default true; CI should pass --local=false for sandbox mode)")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("verify codegen-%s: %w", spec.Kind, err)
 	}
 	root, err := findRoot()
 	if err != nil {
 		return fmt.Errorf("cannot find project root: %w", err)
 	}
 	if *local {
-		return runCodegenVerifyInPlace(spec, root)
+		return runCodegenVerifyInPlace(spec, root, locatorOpts...)
 	}
 	return runCodegenVerifySandbox(spec, root)
 }
 
-func runCodegenVerifyInPlace[R CodegenResult](spec codegenSpec[R], root string) error {
-	project, err := parseProject(root)
+func runCodegenVerifyInPlace[R CodegenResult](spec codegenSpec[R], root string, locatorOpts ...metadata.LocatorOption) error {
+	project, err := parseProject(root, locatorOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/gocell/app/codegen_cmd_test.go
+++ b/cmd/gocell/app/codegen_cmd_test.go
@@ -28,7 +28,7 @@ var stubSpec = codegenSpec[cellgen.Result]{
 // cognitive complexity budget (< 15).
 func runParseCodegenFlagCase(t *testing.T, args []string, wantDry, wantVer bool, wantOnly, wantErrIn string) {
 	t.Helper()
-	dryRun, verify, only, err := parseCodegenFlags(stubSpec, args)
+	dryRun, verify, only, _, err := parseCodegenFlags(stubSpec, args)
 	if wantErrIn != "" {
 		if err == nil || !strings.Contains(err.Error(), wantErrIn) {
 			t.Fatalf("expected error containing %q, got %v", wantErrIn, err)

--- a/cmd/gocell/app/export.go
+++ b/cmd/gocell/app/export.go
@@ -78,6 +78,7 @@ func exportCatalog(args []string) error {
 	layers := fs.String("layers", "", "comma-separated layers; empty = all")
 	cellsArg := fs.String("cells", "", "comma-separated cell IDs to focus on (with first-order neighbors); empty = all")
 	root := fs.String("root", "", "project root directory; empty triggers go.mod auto-detection (walks up from cwd to find nearest go.mod)")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -91,7 +92,11 @@ func exportCatalog(args []string) error {
 		return err
 	}
 
-	pm, err := loadProjectMeta(rootDir)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("export catalog: %w", err)
+	}
+	pm, err := loadProjectMeta(rootDir, locatorOpts...)
 	if err != nil {
 		return err
 	}
@@ -200,8 +205,8 @@ func resolveRoot(arg string) (string, error) {
 }
 
 // loadProjectMeta parses the GoCell metadata under root.
-func loadProjectMeta(root string) (*metadata.ProjectMeta, error) {
-	pm, err := metadata.NewParser(root).Parse()
+func loadProjectMeta(root string, opts ...metadata.LocatorOption) (*metadata.ProjectMeta, error) {
+	pm, err := metadata.NewParser(root, opts...).Parse()
 	if err != nil {
 		return nil, fmt.Errorf("metadata parse: %w", err)
 	}

--- a/cmd/gocell/app/generate.go
+++ b/cmd/gocell/app/generate.go
@@ -134,6 +134,7 @@ func generateAssembly(args []string) error {
 	id := fs.String("id", "", "assembly ID (mutually exclusive with --all)")
 	all := fs.Bool("all", false, "generate for every assembly")
 	module := fs.String("module", "", "Go module path (default: read from go.mod)")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -152,7 +153,11 @@ func generateAssembly(args []string) error {
 	if err != nil {
 		return err
 	}
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("generate assembly: %w", err)
+	}
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf("metadata parse: %w", err)
@@ -261,6 +266,7 @@ func generateMetricsSchema(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("generate metrics-schema", flag.ContinueOnError)
 	id := fs.String("id", "", "assembly ID (mutually exclusive with --all)")
 	all := fs.Bool("all", false, "generate for every assembly")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -276,7 +282,11 @@ func generateMetricsSchema(ctx context.Context, args []string) error {
 		return fmt.Errorf("cannot find project root: %w", err)
 	}
 
-	parser := metadata.NewParser(root)
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("generate metrics-schema: %w", err)
+	}
+	parser := metadata.NewParser(root, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf("metadata parse: %w", err)

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -64,7 +64,7 @@ func readModule(root string) (string, error) {
 //
 // CLI flag wiring is currently restricted to `gocell validate` and `gocell check`
 // (M1 #1082 scope). Other subcommands (generate / verify / export / scaffold /
-// codegen) inherit auto-detect behaviour transparently: if .gocell/manifest.yaml
+// codegen) inherit auto-detect behavior transparently: if .gocell/manifest.yaml
 // exists at root, manifest mode kicks in without a flag.
 func buildLocatorOptions(layout, manifest string) ([]metadata.LocatorOption, error) {
 	var opts []metadata.LocatorOption

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
 // findRoot walks up from the current working directory to find the directory
@@ -53,4 +56,40 @@ func readModule(root string) (string, error) {
 	}
 
 	return "", fmt.Errorf("module directive not found in go.mod")
+}
+
+// buildLocatorOptions translates the validate/check --layout and --manifest
+// flags into LocatorOption values for kernel/metadata.NewParser. Empty flag
+// values mean "use defaults" (auto-detect mode + .gocell/manifest.yaml path).
+//
+// CLI flag wiring is currently restricted to `gocell validate` and `gocell check`
+// (M1 #1082 scope). Other subcommands (generate / verify / export / scaffold /
+// codegen) inherit auto-detect behaviour transparently: if .gocell/manifest.yaml
+// exists at root, manifest mode kicks in without a flag.
+func buildLocatorOptions(layout, manifest string) ([]metadata.LocatorOption, error) {
+	var opts []metadata.LocatorOption
+	mode, err := metadata.ParseLocatorMode(layout)
+	if err != nil {
+		return nil, err
+	}
+	if mode != metadata.LocatorAuto {
+		opts = append(opts, metadata.WithLocatorMode(mode))
+	}
+	if manifest != "" {
+		opts = append(opts, metadata.WithManifestPath(manifest))
+	}
+	return opts, nil
+}
+
+// addLocatorFlags registers --layout and --manifest on fs and returns
+// pointers to their string values. Used by `gocell validate` and the five
+// `gocell check ...` subcommands to share a single flag schema (M1 #1082).
+func addLocatorFlags(fs *flag.FlagSet) (layout, manifestPath *string) {
+	layout = fs.String("layout", "",
+		"locator mode: empty=auto (default) | conventional | manifest. "+
+			"auto detects .gocell/manifest.yaml at root.")
+	manifestPath = fs.String("manifest", "",
+		"explicit manifest path (default: <root>/.gocell/manifest.yaml). "+
+			"Only consulted when manifest mode applies.")
+	return layout, manifestPath
 }

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -12,24 +12,57 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
-// findRoot walks up from the current working directory to find the directory
-// containing go.mod, which is treated as the project root.
+// findRoot walks up from the current working directory to find the nearest
+// directory that contains a project root marker.
+//
+// Project root markers (any one is sufficient):
+//   - go.mod — standard Go module root
+//   - go.work — Go workspace root
+//   - .gocell/manifest.yaml — GoCell manifest-layout workspace root
+//
+// The search uses nearest-first semantics: a nested go.mod is returned before
+// an ancestor go.work, preserving correct behavior for sub-modules within a
+// workspace. If multiple markers are present in the same directory any one
+// suffices.
+//
+// When the intended root is ambiguous (e.g. both a go.mod sub-module and a
+// go.work workspace are in scope), use --root to specify the root explicitly.
 func findRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("getwd: %w", err)
 	}
+	return findRootFrom(dir)
+}
 
+// findRootFrom is the testable core of findRoot. It walks up from dir until it
+// finds a directory containing go.mod, go.work, or .gocell/manifest.yaml.
+func findRootFrom(dir string) (string, error) {
 	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+		if hasRootMarker(dir) {
 			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", fmt.Errorf("go.mod not found in any parent directory")
+			return "", fmt.Errorf("no project root marker (go.mod, go.work, or .gocell/manifest.yaml) found in any parent directory")
 		}
 		dir = parent
 	}
+}
+
+// hasRootMarker reports whether dir contains at least one project root marker.
+func hasRootMarker(dir string) bool {
+	markers := []string{
+		"go.mod",
+		"go.work",
+		filepath.Join(".gocell", "manifest.yaml"),
+	}
+	for _, m := range markers {
+		if _, err := os.Stat(filepath.Join(dir, m)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // readModule reads the module path from go.mod in the given root directory.
@@ -62,6 +95,11 @@ func readModule(root string) (string, error) {
 // LocatorOption values for kernel/metadata.NewParser. Empty flag values mean
 // "use defaults" (auto-detect mode + .gocell/manifest.yaml path).
 //
+// --layout=conventional and a non-empty --manifest are mutually exclusive:
+// conventional mode never reads a manifest file, so the flag would be silently
+// ignored. Pass --layout=manifest (or --layout=auto) to use a custom manifest
+// path, or omit --manifest when --layout=conventional.
+//
 // Used by every subcommand that calls metadata.NewParser: validate, check,
 // scaffold assembly, generate (assembly / metrics-schema / catalog), verify
 // (all codegen variants), and export catalog.
@@ -70,6 +108,9 @@ func buildLocatorOptions(layout, manifest string) ([]metadata.LocatorOption, err
 	mode, err := metadata.ParseLocatorMode(layout)
 	if err != nil {
 		return nil, err
+	}
+	if mode == metadata.LocatorConventional && manifest != "" {
+		return nil, fmt.Errorf("--manifest has no effect with --layout=conventional; remove --manifest or use --layout=manifest|auto")
 	}
 	if mode != metadata.LocatorAuto {
 		opts = append(opts, metadata.WithLocatorMode(mode))

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -58,14 +58,13 @@ func readModule(root string) (string, error) {
 	return "", fmt.Errorf("module directive not found in go.mod")
 }
 
-// buildLocatorOptions translates the validate/check --layout and --manifest
-// flags into LocatorOption values for kernel/metadata.NewParser. Empty flag
-// values mean "use defaults" (auto-detect mode + .gocell/manifest.yaml path).
+// buildLocatorOptions translates the --layout and --manifest flags into
+// LocatorOption values for kernel/metadata.NewParser. Empty flag values mean
+// "use defaults" (auto-detect mode + .gocell/manifest.yaml path).
 //
-// CLI flag wiring is currently restricted to `gocell validate` and `gocell check`
-// (M1 #1082 scope). Other subcommands (generate / verify / export / scaffold /
-// codegen) inherit auto-detect behavior transparently: if .gocell/manifest.yaml
-// exists at root, manifest mode kicks in without a flag.
+// Used by every subcommand that calls metadata.NewParser: validate, check,
+// scaffold assembly, generate (assembly / metrics-schema / catalog), verify
+// (all codegen variants), and export catalog.
 func buildLocatorOptions(layout, manifest string) ([]metadata.LocatorOption, error) {
 	var opts []metadata.LocatorOption
 	mode, err := metadata.ParseLocatorMode(layout)
@@ -82,15 +81,17 @@ func buildLocatorOptions(layout, manifest string) ([]metadata.LocatorOption, err
 }
 
 // addLocatorFlags registers --layout and --manifest on fs and returns
-// pointers to their string values. Used by `gocell validate` and the five
-// `gocell check ...` subcommands to share a single flag schema (M1 #1082).
+// pointers to their string values. Shared by all subcommands that call
+// metadata.NewParser: validate, check (all variants), scaffold assembly,
+// generate (assembly / metrics-schema / catalog), verify (codegen variants),
+// and export catalog.
 func addLocatorFlags(fs *flag.FlagSet) (layout, manifestPath *string) {
 	layout = fs.String("layout", "",
 		"locator mode: auto (default; empty also resolves to auto) | conventional | manifest. "+
 			"auto probes <root>/.gocell/manifest.yaml; manifest forces the manifest path.")
 	manifestPath = fs.String("manifest", "",
 		"explicit manifest file path (default: <root>/.gocell/manifest.yaml). "+
-			"Honored under --layout=manifest and under --layout=auto when the manifest file is detected; "+
-			"silently ignored under --layout=conventional.")
+			"Only used when --layout=manifest or when auto-detect selects manifest mode (.gocell/manifest.yaml present); "+
+			"has no effect otherwise.")
 	return layout, manifestPath
 }

--- a/cmd/gocell/app/helpers.go
+++ b/cmd/gocell/app/helpers.go
@@ -86,10 +86,11 @@ func buildLocatorOptions(layout, manifest string) ([]metadata.LocatorOption, err
 // `gocell check ...` subcommands to share a single flag schema (M1 #1082).
 func addLocatorFlags(fs *flag.FlagSet) (layout, manifestPath *string) {
 	layout = fs.String("layout", "",
-		"locator mode: empty=auto (default) | conventional | manifest. "+
-			"auto detects .gocell/manifest.yaml at root.")
+		"locator mode: auto (default; empty also resolves to auto) | conventional | manifest. "+
+			"auto probes <root>/.gocell/manifest.yaml; manifest forces the manifest path.")
 	manifestPath = fs.String("manifest", "",
-		"explicit manifest path (default: <root>/.gocell/manifest.yaml). "+
-			"Only consulted when manifest mode applies.")
+		"explicit manifest file path (default: <root>/.gocell/manifest.yaml). "+
+			"Honored under --layout=manifest and under --layout=auto when the manifest file is detected; "+
+			"silently ignored under --layout=conventional.")
 	return layout, manifestPath
 }

--- a/cmd/gocell/app/helpers_test.go
+++ b/cmd/gocell/app/helpers_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -51,10 +53,10 @@ func TestBuildLocatorOptions(t *testing.T) {
 			wantOptCount: 2,
 		},
 		{
-			name:         "conventional + manifest path → 2 opts",
-			layout:       "conventional",
-			manifest:     "some/manifest.yaml",
-			wantOptCount: 2,
+			name:     "conventional + manifest path → error (manifest has no effect)",
+			layout:   "conventional",
+			manifest: "some/manifest.yaml",
+			wantErr:  "--manifest has no effect with --layout=conventional",
 		},
 		{
 			name:    "invalid layout → error",
@@ -231,4 +233,154 @@ func TestAddLocatorFlags(t *testing.T) {
 			t.Errorf("error %q does not contain %q", err.Error(), want)
 		}
 	})
+}
+
+// TestFindRootFrom verifies that findRootFrom walks up from a starting directory
+// and recognizes go.mod, go.work, and .gocell/manifest.yaml as project root markers.
+func TestFindRootFrom(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(base string) string // returns starting dir
+		wantRel string                   // expected root relative to base; "" means base itself
+		wantErr string                   // non-empty → expect error containing this substring
+	}{
+		{
+			name: "only go.mod → root found",
+			setup: func(base string) string {
+				if err := os.WriteFile(filepath.Join(base, "go.mod"), []byte("module example.com/m\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile go.mod: %v", err)
+				}
+				return base
+			},
+			wantRel: ".",
+		},
+		{
+			name: "only go.work → root found",
+			setup: func(base string) string {
+				if err := os.WriteFile(filepath.Join(base, "go.work"), []byte("go 1.22\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile go.work: %v", err)
+				}
+				return base
+			},
+			wantRel: ".",
+		},
+		{
+			name: "only .gocell/manifest.yaml → root found",
+			setup: func(base string) string {
+				if err := os.MkdirAll(filepath.Join(base, ".gocell"), 0o750); err != nil {
+					t.Fatalf("MkdirAll .gocell: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(base, ".gocell", "manifest.yaml"), []byte("version: v1\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile manifest.yaml: %v", err)
+				}
+				return base
+			},
+			wantRel: ".",
+		},
+		{
+			name: "nested: lower go.mod found before upper go.work",
+			setup: func(base string) string {
+				// base/  has go.work
+				// base/sub/ has go.mod  ← nearest wins
+				if err := os.WriteFile(filepath.Join(base, "go.work"), []byte("go 1.22\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile go.work: %v", err)
+				}
+				sub := filepath.Join(base, "sub")
+				if err := os.MkdirAll(sub, 0o750); err != nil {
+					t.Fatalf("MkdirAll sub: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(sub, "go.mod"), []byte("module example.com/sub\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile sub/go.mod: %v", err)
+				}
+				return sub
+			},
+			wantRel: "sub",
+		},
+		{
+			name: "no marker anywhere → error with new message",
+			setup: func(base string) string {
+				return base
+			},
+			wantErr: "no project root marker",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			startDir := tc.setup(base)
+
+			got, err := findRootFrom(startDir)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			wantAbs := filepath.Join(base, tc.wantRel)
+			if tc.wantRel == "." {
+				wantAbs = base
+			}
+			if got != wantAbs {
+				t.Errorf("findRootFrom(%q) = %q, want %q", startDir, got, wantAbs)
+			}
+		})
+	}
+}
+
+// TestBuildLocatorOptions_ConventionalPlusManifest verifies that combining
+// --layout=conventional with a non-empty --manifest is rejected.
+func TestBuildLocatorOptions_ConventionalPlusManifest(t *testing.T) {
+	cases := []struct {
+		name     string
+		layout   string
+		manifest string
+		wantErr  string
+	}{
+		{
+			name:     "conventional + manifest path → error",
+			layout:   "conventional",
+			manifest: "some/manifest.yaml",
+			wantErr:  "--manifest has no effect with --layout=conventional",
+		},
+		{
+			name:     "auto + manifest → no error",
+			layout:   "auto",
+			manifest: "some/manifest.yaml",
+		},
+		{
+			name:     "manifest + manifest → no error",
+			layout:   "manifest",
+			manifest: "some/manifest.yaml",
+		},
+		{
+			name:     "conventional + empty manifest → no error",
+			layout:   "conventional",
+			manifest: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildLocatorOptions(tc.layout, tc.manifest)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }

--- a/cmd/gocell/app/helpers_test.go
+++ b/cmd/gocell/app/helpers_test.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"flag"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// TestBuildLocatorOptions covers the flag → LocatorOption translation.
+// buildLocatorOptions is called by `gocell validate` and `gocell check`
+// after parsing the --layout and --manifest flag values.
+func TestBuildLocatorOptions(t *testing.T) {
+	cases := []struct {
+		name         string
+		layout       string
+		manifest     string
+		wantErr      string // non-empty → expect error containing this substring
+		wantOptCount int    // expected number of LocatorOptions returned
+	}{
+		{
+			name:         "empty layout and manifest → auto (0 opts)",
+			layout:       "",
+			manifest:     "",
+			wantOptCount: 0,
+		},
+		{
+			name:         "auto explicit → still 0 opts (auto is the nil default)",
+			layout:       "auto",
+			manifest:     "",
+			wantOptCount: 0,
+		},
+		{
+			name:         "conventional → 1 opt (WithLocatorMode)",
+			layout:       "conventional",
+			manifest:     "",
+			wantOptCount: 1,
+		},
+		{
+			name:         "manifest layout only → 1 opt (WithLocatorMode)",
+			layout:       "manifest",
+			manifest:     "",
+			wantOptCount: 1,
+		},
+		{
+			name:         "manifest layout + custom path → 2 opts",
+			layout:       "manifest",
+			manifest:     "path/to/manifest.yaml",
+			wantOptCount: 2,
+		},
+		{
+			name:         "conventional + manifest path → 2 opts",
+			layout:       "conventional",
+			manifest:     "some/manifest.yaml",
+			wantOptCount: 2,
+		},
+		{
+			name:    "invalid layout → error",
+			layout:  "invalid-layout",
+			wantErr: "unknown locator mode",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := buildLocatorOptions(tc.layout, tc.manifest)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(opts) != tc.wantOptCount {
+				t.Errorf("option count = %d, want %d", len(opts), tc.wantOptCount)
+			}
+		})
+	}
+}
+
+// TestBuildLocatorOptions_ModeApplied verifies that the LocatorOptions
+// returned by buildLocatorOptions actually drive the correct resolved mode
+// when applied to NewLocatorFS.
+func TestBuildLocatorOptions_ModeApplied(t *testing.T) {
+	manifestContent := []byte("version: v1\nmodules:\n  - path: .\n")
+
+	t.Run("conventional overrides manifest file auto-detect", func(t *testing.T) {
+		opts, err := buildLocatorOptions("conventional", "")
+		if err != nil {
+			t.Fatalf("buildLocatorOptions: %v", err)
+		}
+		// fsys has .gocell/manifest.yaml — auto would pick Manifest;
+		// WithLocatorMode(Conventional) must override that.
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
+		}
+		loc, err := metadata.NewLocatorFS(fsys, opts...)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		if loc.Mode() != metadata.LocatorConventional {
+			t.Errorf("mode = %v, want LocatorConventional", loc.Mode())
+		}
+	})
+
+	t.Run("manifest forces manifest mode", func(t *testing.T) {
+		opts, err := buildLocatorOptions("manifest", "")
+		if err != nil {
+			t.Fatalf("buildLocatorOptions: %v", err)
+		}
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
+		}
+		loc, err := metadata.NewLocatorFS(fsys, opts...)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		if loc.Mode() != metadata.LocatorManifest {
+			t.Errorf("mode = %v, want LocatorManifest", loc.Mode())
+		}
+	})
+
+	t.Run("auto without manifest → conventional", func(t *testing.T) {
+		opts, err := buildLocatorOptions("", "")
+		if err != nil {
+			t.Fatalf("buildLocatorOptions: %v", err)
+		}
+		// No .gocell/manifest.yaml → auto-detect falls back to conventional.
+		fsys := fstest.MapFS{}
+		loc, err := metadata.NewLocatorFS(fsys, opts...)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		if loc.Mode() != metadata.LocatorConventional {
+			t.Errorf("mode = %v, want LocatorConventional", loc.Mode())
+		}
+	})
+
+	t.Run("auto with manifest → manifest mode", func(t *testing.T) {
+		opts, err := buildLocatorOptions("auto", "")
+		if err != nil {
+			t.Fatalf("buildLocatorOptions: %v", err)
+		}
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
+		}
+		loc, err := metadata.NewLocatorFS(fsys, opts...)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		if loc.Mode() != metadata.LocatorManifest {
+			t.Errorf("mode = %v, want LocatorManifest", loc.Mode())
+		}
+	})
+}
+
+// TestAddLocatorFlags verifies that addLocatorFlags registers --layout and
+// --manifest with the expected default values and that values update after
+// Parse.
+func TestAddLocatorFlags(t *testing.T) {
+	t.Run("defaults are empty strings", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		layout, manifestPath := addLocatorFlags(fs)
+
+		if layout == nil {
+			t.Fatal("layout pointer is nil")
+		}
+		if manifestPath == nil {
+			t.Fatal("manifestPath pointer is nil")
+		}
+		if *layout != "" {
+			t.Errorf("default layout = %q, want empty string", *layout)
+		}
+		if *manifestPath != "" {
+			t.Errorf("default manifestPath = %q, want empty string", *manifestPath)
+		}
+	})
+
+	t.Run("flags parse correctly", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		layout, manifestPath := addLocatorFlags(fs)
+
+		if err := fs.Parse([]string{"--layout=manifest", "--manifest=custom/manifest.yaml"}); err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if *layout != "manifest" {
+			t.Errorf("layout = %q after parse, want %q", *layout, "manifest")
+		}
+		if *manifestPath != "custom/manifest.yaml" {
+			t.Errorf("manifestPath = %q after parse, want %q", *manifestPath, "custom/manifest.yaml")
+		}
+	})
+
+	t.Run("conventional layout parses", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		layout, _ := addLocatorFlags(fs)
+		if err := fs.Parse([]string{"--layout=conventional"}); err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if *layout != "conventional" {
+			t.Errorf("layout = %q, want conventional", *layout)
+		}
+	})
+}

--- a/cmd/gocell/app/helpers_test.go
+++ b/cmd/gocell/app/helpers_test.go
@@ -207,4 +207,28 @@ func TestAddLocatorFlags(t *testing.T) {
 			t.Errorf("layout = %q, want conventional", *layout)
 		}
 	})
+
+	// Two-phase validation contract: flag.FlagSet accepts any string value for
+	// --layout (phase 1 — the FlagSet is value-agnostic for string flags), but
+	// buildLocatorOptions rejects unknown mode values (phase 2 — semantic
+	// validation). This test documents the explicit split so callers do not
+	// assume FlagSet.Parse is the sole gatekeeper.
+	t.Run("invalid layout value: Parse accepts, buildLocatorOptions rejects", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		layout, manifestPath := addLocatorFlags(fs)
+
+		// Phase 1: FlagSet accepts any string — no error expected here.
+		if err := fs.Parse([]string{"--layout=bogus"}); err != nil {
+			t.Fatalf("FlagSet.Parse unexpected error for unknown layout string: %v", err)
+		}
+
+		// Phase 2: semantic validation rejects the unknown mode.
+		_, err := buildLocatorOptions(*layout, *manifestPath)
+		if err == nil {
+			t.Fatal("buildLocatorOptions: expected error for layout=bogus, got nil")
+		}
+		if want := "unknown locator mode"; !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err.Error(), want)
+		}
+	})
 }

--- a/cmd/gocell/app/scaffold_assembly.go
+++ b/cmd/gocell/app/scaffold_assembly.go
@@ -39,6 +39,7 @@ func scaffoldAssembly(root string, args []string) error {
 	deploy := fs.String("deploy", "k8s", "deployment template: one of [k8s compose binary]")
 	dryRun := fs.Bool(dryRunFlag, false, dryRunUsage)
 	skipGenerate := fs.Bool(skipGenerateFlag, false, skipGenerateAssemblyUsage)
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -48,12 +49,17 @@ func scaffoldAssembly(root string, args []string) error {
 		return err
 	}
 
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("scaffold assembly: %w", err)
+	}
+
 	mod, err := readModule(root)
 	if err != nil {
 		return fmt.Errorf("scaffold assembly: read module path: %w", err)
 	}
 
-	project, err := metadata.NewParser(root).Parse()
+	project, err := metadata.NewParser(root, locatorOpts...).Parse()
 	if err != nil {
 		return fmt.Errorf("scaffold assembly: parse project: %w", err)
 	}

--- a/cmd/gocell/app/validate.go
+++ b/cmd/gocell/app/validate.go
@@ -34,6 +34,7 @@ func runValidate(ctx context.Context, args []string) error {
 	strict := fs.Bool("strict", false, strictFlagUsage())
 	format := fs.String("format", string(printers.FormatText),
 		"output format: text (non-stable, default) | json | sarif")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -52,8 +53,13 @@ func runValidate(ctx context.Context, args []string) error {
 		return err
 	}
 
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return err
+	}
+
 	// Parse all metadata.
-	parser := metadata.NewParser(rootDir)
+	parser := metadata.NewParser(rootDir, locatorOpts...)
 	project, err := parser.Parse()
 	if err != nil {
 		return fmt.Errorf("metadata parse: %w", err)

--- a/cmd/gocell/app/verify.go
+++ b/cmd/gocell/app/verify.go
@@ -146,6 +146,7 @@ func runVerifyResultCmd(ctx context.Context, args []string, spec verifyResultExe
 	id := fs.String(spec.flag, "", "<required>")
 	format := fs.String("format", "text",
 		"output format: "+strings.Join(printers.SupportedVerifyFormats(), " | "))
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -162,7 +163,11 @@ func runVerifyResultCmd(ctx context.Context, args []string, spec verifyResultExe
 		return err
 	}
 
-	root, project, err := parseProjectMeta()
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("verify %s: %w", spec.name, err)
+	}
+	root, project, err := parseProjectMeta(locatorOpts...)
 	if err != nil {
 		return err
 	}
@@ -211,13 +216,12 @@ func verifyJourney(ctx context.Context, args []string) error {
 	active := fs.Bool("active", false, "run all active journeys")
 	format := fs.String("format", "text",
 		"output format: "+strings.Join(printers.SupportedVerifyFormats(), " | "))
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *id == "" && !*active {
-		return fmt.Errorf("exactly one of --id or --active is required")
-	}
-	if *id != "" && *active {
+	// Exactly one of --id or --active must be set (XOR).
+	if (*id == "") == !*active {
 		return fmt.Errorf("exactly one of --id or --active is required")
 	}
 
@@ -225,7 +229,11 @@ func verifyJourney(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	root, project, err := parseProjectMeta()
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("verify journey: %w", err)
+	}
+	root, project, err := parseProjectMeta(locatorOpts...)
 	if err != nil {
 		return err
 	}
@@ -262,6 +270,7 @@ func verifyJourney(ctx context.Context, args []string) error {
 func verifyTargets(_ context.Context, args []string) error {
 	fs := flag.NewFlagSet("verify targets", flag.ContinueOnError)
 	files := fs.String("files", "", "comma-separated file paths (required)")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -270,7 +279,11 @@ func verifyTargets(_ context.Context, args []string) error {
 		return fmt.Errorf("--files is required")
 	}
 
-	_, project, err := parseProjectMeta()
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("verify targets: %w", err)
+	}
+	_, project, err := parseProjectMeta(locatorOpts...)
 	if err != nil {
 		return err
 	}
@@ -300,11 +313,16 @@ func verifyTargets(_ context.Context, args []string) error {
 func verifyGenerated(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("verify generated", flag.ContinueOnError)
 	module := fs.String("module", "", "Go module path (default: read from go.mod)")
+	layout, manifestPath := addLocatorFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	root, project, err := parseProjectMeta()
+	locatorOpts, err := buildLocatorOptions(*layout, *manifestPath)
+	if err != nil {
+		return fmt.Errorf("verify generated: %w", err)
+	}
+	root, project, err := parseProjectMeta(locatorOpts...)
 	if err != nil {
 		return err
 	}
@@ -354,13 +372,13 @@ func ctxInterrupted(ctx context.Context, label string) error {
 }
 
 // parseProjectMeta finds the project root, parses metadata, and returns both.
-func parseProjectMeta() (root string, project *metadata.ProjectMeta, err error) {
+func parseProjectMeta(opts ...metadata.LocatorOption) (root string, project *metadata.ProjectMeta, err error) {
 	root, err = findRoot()
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot find project root: %w", err)
 	}
 
-	parser := metadata.NewParser(root)
+	parser := metadata.NewParser(root, opts...)
 	project, err = parser.Parse()
 	if err != nil {
 		return "", nil, fmt.Errorf("metadata parse: %w", err)

--- a/docs/architecture/202605281200-adr-cell-development-external-repo.md
+++ b/docs/architecture/202605281200-adr-cell-development-external-repo.md
@@ -1,0 +1,409 @@
+# ADR: Operator-SDK + Workspace 双模式 Cell 开发
+
+- Status: Accepted
+- Date: 2026-05-28
+- Tracks: gh issue #1081 (umbrella: Operator-SDK + Workspace 双模式 Cell 开发)
+- M1 child: gh issue #1082 (metadata locator 抽象化)
+- Implemented by: worktrees/073-metadata-locator (M1), 后续子 worktree 跟进 M2-M12
+
+本 ADR merge 后，#1081 子 issue (M1-M12) 可进入 daily-planner wave。
+
+---
+
+## 背景 / Context
+
+GoCell 当前只支持 monorepo 内 Cell 开发。三条贯穿性架构假设（A/B/C，见下节）使得
+外部仓库或多仓库 Workspace 场景在工具链层面无法直接跑通。
+
+### 现状问题清单
+
+**R1 — archtest 不可外部 import**
+`tools/archtest/` 为 `package archtest`，置于 `tools/` 目录下。外部 Cell
+仓库无法 `go get github.com/ghbvf/gocell/tools/archtest` 并在自有测试中运行
+等价的约束验证。
+
+**R2 — codegen module path 硬编码**
+`pathx.ContractIDToPackagePath`（`cmd/gocell/pathx/`）将 contract ID
+映射到 `github.com/ghbvf/gocell/generated/contracts/...`，写死了 module
+路径。外部 module 的 generated 包路径不同，codegen 生成产物路径错误。
+
+**R3 — migration namespace 全局共享**
+`adapters/postgres` 下的 migration runner 默认以单一全局 schema 版本命名空间
+追踪已执行的 migration。多个外部 Cell module 各自带 migration 时会发生序号
+冲突或相互覆盖。
+
+**R4 — metadata parser 路径模式硬编码**
+`kernel/metadata/parser.go` 内多个 path match 函数（`cellDirFromPath` /
+`sliceDirsFromPath` / `contractDirFromPath` / `journeyIDFromPath` /
+`matchAssemblyYAML`）以 `cells/` / `cells/*/slices/` / `contracts/` /
+`journeys/` / `assemblies/` 五种固定前缀识别元数据文件。外部仓库可能使用不同
+layout（比如 `src/cells/` 或多模块嵌套路径），parser 无法识别。
+
+**R5 — governance targets 路径推导硬编码**
+`kernel/governance/targets.go` 用 `strings.HasPrefix(f, "cells/")` /
+`strings.HasPrefix(f, "contracts/")` 等路径前缀将文件路径反推为 contract ID
+和 governance 目标。与 R4 同源，外部 layout 无法通过此推导。
+
+**R6 — assembly.yaml 无 module: 字段**
+`assemblies/*/assembly.yaml` 当前不支持声明 Cell 来自外部 module。装配器
+无法将外部 Cell 纳入同一 assembly 进行物理打包。
+
+**R7 — Composition Root 私有化在 cmd/**
+`cmd/corebundle/` 是唯一可用的 wiring 入口；`CellModule` 接口与
+`SharedDeps` 在 `cmd/` 包内，Go 包可见性规则下外部仓库不可 import。外部
+Cell 没有合法路径注入到 corebundle 装配流程。
+
+**R8 — Registry.Subscribe cellID 由 cellgen 注入**
+当前 cellgen 从本地 cell.yaml 读取 cellID 并注入 `reg.Subscribe` 的第四位
+置参数。外部仓库使用同一 cellgen 时，cellID 解析路径是否正确需要额外验证。
+
+**R9 — gocell CLI 无 SemVer release**
+外部 Cell 仓库通过 `go get github.com/ghbvf/gocell` 引入工具链，但 CLI
+当前没有版本化发布约定，外部仓库无法 pin 到稳定版本。
+
+**R10 — contract publisher / consumer 无跨 module 注册表**
+当前 `EMIT-DECL-COVER-01` / `DEAD-CONTRACT-01` 等 invariant 只扫描本 repo
+内的 cell 与 contract。跨 module 的 publisher / consumer 对齐靠人工维护。
+
+**R11 — errcode 前缀无注册表**
+`ERR_*` 前缀没有全局注册表。多个外部 Cell module 各自定义错误码时可能
+前缀冲突，线上日志无法区分来源。
+
+**R12 — 无外部 Cell 开发 onboarding 路径**
+无 starter repo 模板，无独立仓库开发指南，外部团队入门成本高。
+
+---
+
+## 三条贯穿性架构假设
+
+### A. 单一 module / 单一 go.mod
+
+**证据：**
+- `tools/archtest/module_root.go` 用 `go/build.Default.GOPATH` + 向父目录回溯
+  找最近 `go.mod` 即停，假设只有一个 module root。
+- `pathx.ContractIDToPackagePath` 将 contract ID 拼接为
+  `github.com/ghbvf/gocell/generated/contracts/<id>` 路径，
+  写死了 module 路径前缀。
+- archtest suite 整体以 `go test ./tools/archtest/...` 启动，不支持在
+  `go.work` 聚合场景下跨 module 扫描。
+
+### B. filesystem topology = governance topology
+
+**证据：**
+- `kernel/metadata/parser.go:131-195`：`cellDirFromPath` /
+  `sliceDirsFromPath` / `contractDirFromPath` / `journeyIDFromPath` /
+  `matchAssemblyYAML` 五个函数以固定路径 segment 位置（`parts[0] == "cells"`
+  等）识别元数据文件。
+- `kernel/governance/targets.go:145-320`：`strings.HasPrefix(f, "cells/")` /
+  `strings.HasPrefix(f, "contracts/")` / `strings.HasPrefix(f, "journeys/")` /
+  `strings.HasPrefix(f, "assemblies/")` 等前缀判断直接从文件路径派生 governance
+  目标与 contract ID。
+- 两处均无 "layout 配置" 注入点，只有对路径字面量的 split-then-index-compare。
+
+### C. Composition Root 私有化在 cmd/
+
+**证据：**
+- `cmd/corebundle/` 是唯一完整 wiring 入口，包含 `SharedDeps`（包含
+  `clock.Real()` / postgres / redis / rabbitmq 等所有基建）和
+  `CellModule` interface（cell 向 corebundle 暴露自身的协议）。
+- 两者均在 `cmd/` 包，Go 规则下包外不可直接 import `cmd/` 的 unexported
+  symbol；即便 exported，`cmd/corebundle` 位于 main-adjacent 包，外部
+  module import 会引入传递依赖冲突。
+- 没有 plugin discovery 机制（无 `plugin.Open` / gRPC-plugin / `fx.Module`
+  外部注册），外部 Cell 无法在运行时注入。
+
+---
+
+## 决议 / Decision
+
+GoCell 同时支持三种 Cell 开发模式，**不破坏当前 monorepo 工作流**：
+
+### 模式一：Monorepo 模式（gocell 自身）
+
+conventional layout（`cells/` / `contracts/` / `journeys/` / `assemblies/`）。
+**无 manifest 文件**，所有工具链走现有路径推导逻辑（不变）。
+
+### 模式二：Operator-SDK 模式
+
+外部仓库自有 `go.mod`，通过 `go get github.com/ghbvf/gocell` 引入 gocell
+作为库依赖。仓库根放 `.gocell/manifest.yaml` 声明 layout。独立 CI / release
+pipeline，可 pin 到 gocell 版本标签（M7 提供）。
+
+典型场景：`acme/payment-cell` 独立仓库，团队自维护 CI 并发布自己的版本。
+
+### 模式三：Workspace 模式
+
+`go.work` 聚合 gocell + 多个外部 Cell module，开发期联调。Workspace 根放
+`.gocell/manifest.yaml`，通过 `modules:` 列表声明每个子模块路径。
+
+典型场景：平台团队在本地同时开发 gocell 本体和 `acme/payment-cell`，
+需要联调 contract 边界。
+
+---
+
+## M1 Locator 设计
+
+> 本节是 M1（#1082）的完整设计。其余 M2-M12 只列规划，不在本 ADR 展开设计细节。
+
+### 设计原则：单策略 struct，非 pluggable interface
+
+参照 buf v2 `buf.yaml` modules schema、kubebuilder PROJECT config
+`pkg/config/v3/config.go`、kustomize `api/types/kustomization.go`：
+上述工具均使用 **单策略 + 文件探测** 而非 strategy interface。引入
+`LocatorStrategy interface` 会把"选择哪种 layout"的决策点分散到调用方，
+产生跨 CLI surface 的配置漂移风险。
+
+`kernel/metadata.Locator` 是单一 struct，持有一个 `LocatorMode` 枚举字段，
+不对外暴露 strategy 接口。
+
+### LocatorMode 枚举
+
+```go
+// kernel/metadata/locator.go
+
+// LocatorMode 表示 metadata 文件的发现模式。
+type LocatorMode int
+
+const (
+    // LocatorConventional 使用 GoCell monorepo 约定的 5 种路径模式，
+    // 无需 manifest 文件。
+    LocatorConventional LocatorMode = iota
+
+    // LocatorManifest 从 .gocell/manifest.yaml 读取 layout 配置，
+    // 支持自定义路径模式与多模块 workspace。
+    LocatorManifest
+)
+```
+
+### 自动探测规则
+
+`Locator.Detect(root fs.FS)` 按以下顺序确定模式：
+
+1. 若 `<root>/.gocell/manifest.yaml` 存在 → `LocatorManifest`
+2. 否则 → `LocatorConventional`
+
+### CLI override hatch
+
+`gocell validate` 与 `gocell check` 命令首批接入 `--layout=conventional|manifest`
+flag，显式 override 自动探测结果。其余 12 个 CLI surface（scaffold / generate /
+verify 等）通过 `Locator.Detect` 自动工作，`--layout` flag 在后续 PR 跟
+backlog issue 补齐。
+
+### manifest.yaml schema
+
+位置：`<repo-root>/.gocell/manifest.yaml`（Operator-SDK 模式）或
+`<go.work-dir>/.gocell/manifest.yaml`（Workspace 模式）。
+
+```yaml
+version: v1
+modules:
+  - path: .                          # required，相对于 manifest 文件所在目录
+    includes:                        # optional；省略时使用 conventional 5 种模式
+      cells: ["cells/*/cell.yaml"]
+      slices: ["cells/*/slices/*/slice.yaml"]
+      contracts: ["contracts/**/contract.yaml"]
+      journeys: ["journeys/J-*.yaml"]
+      assemblies: ["assemblies/*/assembly.yaml"]
+      actors: "actors.yaml"          # workspace-level singleton
+      statusBoard: "journeys/status-board.yaml"  # workspace-level singleton
+    excludes: ["generated/**", "vendor/**"]
+  - path: ./acme-payment-cell        # Workspace 模式：第二个 module
+```
+
+**单模块外部 repo**：`modules` 仅一项 `path: .`，省略 `includes` 时使用 conventional
+5 种模式，`excludes` 默认含 `generated/**`。
+
+**Workspace 多模块**：每项 `path` 指向 `go.work` 中 `use` 的子目录之一。
+
+**`actors` / `statusBoard` 是 workspace-level singleton**：manifest 中多个
+module 条目均填写时，`Locator` 在解析阶段 fail-fast，返回
+`ErrDuplicateWorkspaceSingleton`。
+
+### path.Match glob 语义
+
+`includes` 字段使用 `fs.Glob` 语义（`path.Match` 规则）：
+
+- `*` 匹配单段
+- `**` 匹配零或多段（由 `Locator.discoverManifest` 走 `fs.WalkDir` 实现，
+  不依赖 `filepath.Glob` 对 `**` 的未定义行为）
+- `excludes` 在 `WalkDir` 回调中逐路径 check，命中则 skip
+
+### Locator struct 主要 API
+
+```go
+// kernel/metadata/locator.go
+
+// Locator 发现元数据文件路径，屏蔽 conventional / manifest 两种 layout 差异。
+// 零值无效；通过 NewLocator 或 DetectLocator 构造。
+type Locator struct {
+    mode     LocatorMode
+    manifest *manifestConfig  // non-nil iff mode == LocatorManifest
+    root     fs.FS
+}
+
+// DetectLocator 从 root 自动探测模式，可被 --layout flag override。
+// override 为空字符串时走自动探测。
+func DetectLocator(root fs.FS, override string) (*Locator, error)
+
+// Paths 返回指定类型的所有元数据文件相对路径列表。
+// kind 取值：KindCell / KindSlice / KindContract / KindJourney /
+//           KindAssembly / KindActors / KindStatusBoard
+func (l *Locator) Paths(kind MetadataKind) ([]string, error)
+
+// RootDir 返回用于将相对路径转换为绝对路径的根目录。
+func (l *Locator) RootDir() string
+```
+
+`Paths` 的实现路径：
+
+- `LocatorConventional` → `l.discoverConventional(kind)` — 复用现有 5 种
+  路径模式（硬编码在 locator.go 内，parser.go 中的 path match 函数迁移至此）
+- `LocatorManifest` → `l.discoverManifest(kind)` — 按 manifest.yaml 中各
+  module 的 `includes`/`excludes` 走 `fs.WalkDir`
+
+### parser.go 迁移策略
+
+现有 `kernel/metadata/parser.go` 中的 `cellDirFromPath` /
+`sliceDirsFromPath` / `contractDirFromPath` / `journeyIDFromPath` /
+`matchAssemblyYAML` 五个函数**保留原签名不变**，由 `Locator.discoverConventional`
+内部复用（不删除，不暴露为 public API）。M1 PR 的变更范围：
+
+1. 新增 `kernel/metadata/locator.go`（Locator struct + DetectLocator）
+2. 新增 `kernel/metadata/manifest.go`（manifestConfig 解析）
+3. parser.go 顶层入口 `ParseDir` 接受可选 `*Locator` 参数：`nil` 时走
+   现有逻辑（向后兼容 monorepo 调用方），非 `nil` 时委托 `Locator.Paths`。
+4. CLI `validate` / `check` 命令接入 `--layout` flag 并构造 `Locator`。
+
+---
+
+## M1-M12 工作路线
+
+依赖顺序如下；括号内为 gh issue 号。
+
+### Phase 1 基线 — 解锁 Operator-SDK 跑通 validate/build/test
+
+| 里程碑 | issue | 解决问题 | 前置 |
+|--------|-------|---------|------|
+| M1 | #1082 | metadata locator 抽象化 | 解 R4 + R5 | — |
+| M2 | #1083 | codegen module path 注入 | 解 R2 | — |
+| M3 | #1084 | archtest 提升为可被外部 import 的 library | 解 R1 | — |
+| M4 | #1085 | CellModule 接口公开化到 runtime/composition/ | 解 R7 | — |
+
+M1-M4 无相互依赖，可并行推进。
+
+### Phase 2 装配 — 外部 Cell 可被 corebundle 装配并运行
+
+| 里程碑 | issue | 解决问题 | 前置 |
+|--------|-------|---------|------|
+| M5 | #1086 | assembly.yaml 增加 module: 字段 | 解 R6 | M1 + M2 |
+| M6 | #1087 | Registry.Subscribe cellID builder API | 解 R8 | M4 |
+| M12 | #1093 | bootstrap cell ID closed set 校验 | 解 R11 部分 | M5 |
+
+### Phase 3 政策 — 可对外发布、可独立升级、有 onboarding 路径
+
+| 里程碑 | issue | 解决问题 | 前置 |
+|--------|-------|---------|------|
+| M7 | #1088 | gocell CLI versioned release + SemVer 承诺 | 解 R9 | — |
+| M8 | #1089 | migration namespace per module | 解 R3 | — |
+| M11 | #1092 | starter repo + 独立仓库开发指南 | 解 R12 | M1-M6 |
+
+### Phase 4 闭环 — 跨仓库治理
+
+| 里程碑 | issue | 解决问题 | 前置 |
+|--------|-------|---------|------|
+| M9 | #1090 | contract publisher / consumer registry | 解 R10 | M2 + M5 |
+| M10 | #1091 | errcode 前缀注册表 | 解 R11 partial | — |
+
+---
+
+## AI-robust 评级（locator funnel）
+
+locator funnel 的两个方向分别评级，对齐 `.claude/rules/gocell/ai-robust.md`
+§"Funnel 双向锁评级"。
+
+### 下游 Hard
+
+archtest `METADATA-LOCATOR-PATH-COMPARE-01`，扫描范围
+`kernel/metadata/**` + `kernel/governance/**`：
+
+- **A2 form-uniqueness**：`HasPrefix(path, "<literal>")` / `Split-then-index-compare`
+  / `path.Dir-compare` / `regex anchor` 等路径前缀比较形态的 callsite 必须
+  ⊆ `kernel/metadata/locator*.go`。其他文件出现等价的路径比较形态即 CI 红。
+- **盲区**：`strings.Contains` 形态未被 HasPrefix 形态锁覆盖 → 反向自检测试断言
+  `strings.Contains(path, "cells/")` 等形态在 `kernel/governance/targets.go`
+  不出现。
+
+### 上游 Medium
+
+archtest `METADATA-LOCATOR-PATH-COMPARE-01`，A1 caller-allowlist：
+
+- `fs.WalkDir` / `filepath.Walk` / `fs.ReadDir` 的调用方 ⊆
+  `{Locator.discoverConventional, Locator.discoverManifest}`（kernel/metadata/
+  内部可见）。
+
+**为何不开升级 issue**：上游 Hard 的唯一可行路径是 cross-package sealed interface
++ private constructor，在 Go 语言下对于"谁可以调用 fs.WalkDir"这一问题无法表达——
+`fs.WalkDir` 是标准库 public function，任何包均可调用，不存在 Go 类型系统层面的封堵。
+这是与 `SPAN-SETATTR-HOLDER-SEAL-01` (#851) 同范式的 Go 结构性不可达情形。开升级
+issue 等于承诺 Go 不可能完成的任务，故不开（对比 ai-robust.md §Funnel 双向锁评级：
+"Medium 上游 + Hard 下游的过渡形态，**必须同步开 gh issue 跟踪显式 Hard 化任务**"
+的条件是存在低成本 Hard 化路径——此处不满足）。
+
+此（Medium 上游 + Hard 下游）是 ai-robust §"Funnel 双向锁评级" 明文允许的合法
+final 形态，不构成降级。
+
+---
+
+## 威胁矩阵 / 边界条件
+
+| 场景 | 风险 | 处置 |
+|------|------|------|
+| Monorepo 误植 `.gocell/manifest.yaml` | 切到 manifest 模式，可能解析错误路径 | `--layout=conventional` flag 显式 override；governance 检查双模式声明冲突 |
+| manifest `path` 含 `../` 越界 | 路径逃逸至 repo 边界外 | `Locator` 在解析期拒绝绝对路径与含 `..` 段的相对路径，fail-fast，返回 `ErrUnsafePath` |
+| manifest 漏写 `excludes: ["generated/**"]` | `generated/` 下的 contract YAML 被重复解析，parser 报重复 ID | `excludes` 默认含 `generated/**`；用户显式写空时 warn |
+| symlink 跨 module 引入循环 | `fs.WalkDir` 死循环 | `Locator.discoverManifest` 走 `os.DirFS`，`fs.WalkDir` 不追踪 symlinked dir（标准库行为：`DirEntry.Type()&ModeSymlink != 0` 时 skip） |
+| Workspace 多模块 cell ID 冲突 | 同名 cell 被装配两次 | `parser.go` 现有 `duplicate cell ID` 校验保持不变，locator 不旁路此检查 |
+| manifest `modules[*].path` 指向不存在目录 | WalkDir 报 `*PathError` | `DetectLocator` 在构造阶段对每个 `path` 调用 `fs.Stat` fail-fast，而非推迟到 `Paths()` 调用时 |
+| go.work 中 use 的 module 不在 manifest modules 列表中 | manifest 遗漏子 module，相关 cell 不被扫描 | 本 ADR 不强制 go.work 与 manifest 对齐；M2 codegen module path 注入会在 codegen 阶段捕获不一致；long-term M11 指南补充手动校验步骤 |
+| Workspace 多模块均声明 `actors` 字段 | workspace-level singleton 重复声明 | `Locator` 解析 manifest 时 fail-fast，返回 `ErrDuplicateWorkspaceSingleton`，明确指出重复的模块路径 |
+
+---
+
+## 测试 / 验证
+
+**M1 PR 必须提供以下测试，缺失则 PR 阻塞：**
+
+1. `kernel/metadata/locator_test.go`：`fstest.MapFS` 三组 fixture
+   - `TestLocatorConventional`：monorepo 标准 layout，`DetectLocator` 返回
+     `LocatorConventional`，`Paths(KindCell)` 与现有 parser 结果一致
+   - `TestLocatorManifestSingle`：单模块外部 repo（`.gocell/manifest.yaml`
+     存在），`Paths` 返回 manifest 配置路径下的文件
+   - `TestLocatorManifestWorkspace`：两个 module path 的 workspace，
+     `Paths(KindCell)` 返回两个模块合并后的 cell 列表
+
+2. `kernel/metadata/parser_manifest_test.go`：manifest 模式下 `ParseDir`
+   结果与同等 conventional layout 下结果等价（cell ID 集合相同）
+
+3. `cmd/gocell/app/validate_test.go`：`--layout=conventional` flag 覆盖
+   manifest 自动探测的用例（fake fs 注入）
+
+4. **手测 e2e**（PR description 列出步骤）：在 `examples/ssobff` 根目录临时
+   写入 `.gocell/manifest.yaml`（单模块），跑 `gocell validate`，确认输出
+   与不带 manifest 时等价。
+
+---
+
+## 参考 / References
+
+- bufbuild/buf `buf.yaml` v2 modules schema:
+  https://buf.build/docs/configuration/v2/buf-yaml/
+- kubernetes-sigs/kubebuilder PROJECT external resources:
+  `pkg/config/v3/config.go`
+- kubernetes-sigs/kustomize Resources field:
+  `api/types/kustomization.go`
+- golang/go workspace `use` directive:
+  `cmd/vendor/golang.org/x/mod/modfile/work.go`
+- 关联 ADR（Hard funnel 双向锁参考范式）:
+  `docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md` §8
+- 关联 ADR（Medium 上游 + Hard 下游过渡形态论证范式）:
+  `docs/architecture/202605271100-adr-probename-sealed-funnel.md` §AI-robust 评级

--- a/docs/architecture/202605281200-adr-cell-development-external-repo.md
+++ b/docs/architecture/202605281200-adr-cell-development-external-repo.md
@@ -364,6 +364,8 @@ locator funnel 的两个方向分别评级，对齐 `.claude/rules/gocell/ai-rob
 （`tools/archtest/locator_discovery_funnel_test.go`），含 A1/A2a/A2b/A5 四条子规则；
 符号清单活在该 archtest 的 package godoc，不在本 ADR 复制。
 
+> 外部仓库在 M3 (#1084 archtest library-isation) 落地前不受 `LOCATOR-DISCOVERY-FUNNEL-01` archtest 守护，依赖文档约定。
+
 ### ENTERING funnel（path-prefix 比较，A1/A2 轴）
 
 | 方向 | 形态 | 评级 |
@@ -401,7 +403,7 @@ Locator 输出派生路径，不得通过 `filepath.Join("cells", id)` 等形式
 | 场景 | 风险 | 处置 |
 |------|------|------|
 | Monorepo 误植 `.gocell/manifest.yaml` | 切到 manifest 模式，可能解析错误路径 | `--layout=conventional` flag 显式 override；governance 检查双模式声明冲突 |
-| manifest `path` 含 `../` 越界 | 路径逃逸至 repo 边界外 | `Locator` 在解析期拒绝绝对路径与含 `..` 段的相对路径，fail-fast，返回 `ErrUnsafePath` |
+| manifest `path` 含 `../` 越界 | 路径逃逸至 repo 边界外 | `Locator` 在解析期拒绝绝对路径与含 `..` 段的相对路径，fail-fast，返回 wrapped `fmt.Errorf` 包含 `"path escape not allowed"` 或 `"absolute path not allowed"` 提示，无独立 sentinel |
 | manifest 漏写 `excludes: ["generated/**"]` | `generated/` 下的 contract YAML 被重复解析，parser 报重复 ID | `excludes` 默认含 `generated/**`；用户显式写空时 warn |
 | symlink 跨 module 引入循环 | `fs.WalkDir` 死循环 | `Locator.discoverManifest` 走 `os.DirFS`，`fs.WalkDir` 不追踪 symlinked dir（标准库行为：`DirEntry.Type()&ModeSymlink != 0` 时 skip） |
 | Workspace 多模块 cell ID 冲突 | 同名 cell 被装配两次 | `parser.go` 现有 `duplicate cell ID` 校验保持不变，locator 不旁路此检查 |
@@ -416,11 +418,11 @@ Locator 输出派生路径，不得通过 `filepath.Join("cells", id)` 等形式
 **M1 PR 提供以下测试（落地状态）：**
 
 1. `kernel/metadata/locator_test.go`：`fstest.MapFS` 三组 fixture
-   - `TestLocatorConventional`：monorepo 标准 layout，`NewLocatorFS` 返回
+   - `TestLocator_ConventionalDiscover`：monorepo 标准 layout，`NewLocatorFS` 返回
      `LocatorConventional`，`Discover()` 中 `SourceCell` 条目与现有 parser 结果一致
-   - `TestLocatorManifestSingle`：单模块外部 repo（`.gocell/manifest.yaml`
+   - `TestLocator_ManifestSingleModuleDefaults`：单模块外部 repo（`.gocell/manifest.yaml`
      存在），`Discover()` 返回 manifest 配置路径下的 MetadataSource 列表
-   - `TestLocatorManifestWorkspace`：两个 module path 的 workspace，
+   - `TestLocator_ManifestWorkspaceMultiModule`：两个 module path 的 workspace，
      `Discover()` 返回两个模块合并后的 SourceCell 列表
 
 2. `kernel/metadata/locator_manifest_e2e_test.go`（Batch 4 补充）：os.TempDir

--- a/docs/architecture/202605281200-adr-cell-development-external-repo.md
+++ b/docs/architecture/202605281200-adr-cell-development-external-repo.md
@@ -165,9 +165,14 @@ pipeline，可 pin 到 gocell 版本标签（M7 提供）。
 type LocatorMode int
 
 const (
+    // LocatorAuto selects Conventional unless .gocell/manifest.yaml exists at
+    // root, in which case Manifest mode is used. This is the default when
+    // NewLocator/NewLocatorFS is called without WithLocatorMode.
+    LocatorAuto LocatorMode = iota
+
     // LocatorConventional 使用 GoCell monorepo 约定的 5 种路径模式，
     // 无需 manifest 文件。
-    LocatorConventional LocatorMode = iota
+    LocatorConventional
 
     // LocatorManifest 从 .gocell/manifest.yaml 读取 layout 配置，
     // 支持自定义路径模式与多模块 workspace。
@@ -177,17 +182,20 @@ const (
 
 ### 自动探测规则
 
-`Locator.Detect(root fs.FS)` 按以下顺序确定模式：
+`NewLocator(root, opts...)` / `NewLocatorFS(fsys, opts...)` 在 `LocatorAuto` 模式下按以下顺序确定模式：
 
 1. 若 `<root>/.gocell/manifest.yaml` 存在 → `LocatorManifest`
 2. 否则 → `LocatorConventional`
 
+`ParseLocatorMode(s string) (LocatorMode, error)` 将 CLI 字符串（`"auto"` / `"conventional"` / `"manifest"`）转换为 `LocatorMode`。
+
 ### CLI override hatch
 
-`gocell validate` 与 `gocell check` 命令首批接入 `--layout=conventional|manifest`
-flag，显式 override 自动探测结果。其余 12 个 CLI surface（scaffold / generate /
-verify 等）通过 `Locator.Detect` 自动工作，`--layout` flag 在后续 PR 跟
-backlog issue 补齐。
+`gocell validate` 与 `gocell check` 命令首批接入 `--layout=auto|conventional|manifest`
+flag（默认空字符串等价于 `auto`），通过 `WithLocatorMode(mode)` 传入 `NewLocator`。
+其余 CLI surface（scaffold / generate / verify 等）继承 `LocatorAuto` 行为——若
+`.gocell/manifest.yaml` 存在则切 manifest 模式，否则走 conventional，
+无需额外 `--layout` flag（`--layout` flag 在后续 PR 补齐）。
 
 ### manifest.yaml schema
 
@@ -228,51 +236,84 @@ module 条目均填写时，`Locator` 在解析阶段 fail-fast，返回
   不依赖 `filepath.Glob` 对 `**` 的未定义行为）
 - `excludes` 在 `WalkDir` 回调中逐路径 check，命中则 skip
 
-### Locator struct 主要 API
+### Locator struct 主要 API（落地形态）
 
 ```go
 // kernel/metadata/locator.go
 
-// Locator 发现元数据文件路径，屏蔽 conventional / manifest 两种 layout 差异。
-// 零值无效；通过 NewLocator 或 DetectLocator 构造。
-type Locator struct {
-    mode     LocatorMode
-    manifest *manifestConfig  // non-nil iff mode == LocatorManifest
-    root     fs.FS
+// MetadataSource is one YAML file discovered by Locator.
+// Path is forward-slash relative to the locator root.
+// Kind classifies the bucket (SourceCell / SourceSlice / SourceContract /
+//   SourceJourney / SourceAssembly / SourceActors / SourceStatusBoard).
+// CellID is populated for SourceCell / SourceSlice when the locator can derive
+//   it from layout. In manifest mode with non-conventional layout, CellID
+//   stays empty — parser requires slice.yaml to declare belongsToCell.
+type MetadataSource struct {
+    Path   string
+    Kind   SourceKind
+    CellID string
 }
 
-// DetectLocator 从 root 自动探测模式，可被 --layout flag override。
-// override 为空字符串时走自动探测。
-func DetectLocator(root fs.FS, override string) (*Locator, error)
+// SourceKind constants:
+//   SourceUnknown / SourceCell / SourceSlice / SourceContract /
+//   SourceJourney / SourceAssembly / SourceActors / SourceStatusBoard
 
-// Paths 返回指定类型的所有元数据文件相对路径列表。
-// kind 取值：KindCell / KindSlice / KindContract / KindJourney /
-//           KindAssembly / KindActors / KindStatusBoard
-func (l *Locator) Paths(kind MetadataKind) ([]string, error)
+// NewLocator 从 on-disk root 构造 Locator（auto-detect mode by default）。
+func NewLocator(root string, opts ...LocatorOption) (*Locator, error)
 
-// RootDir 返回用于将相对路径转换为绝对路径的根目录。
-func (l *Locator) RootDir() string
+// NewLocatorFS 从任意 fs.FS 构造 Locator（测试 / embed.FS 场景）。
+func NewLocatorFS(fsys fs.FS, opts ...LocatorOption) (*Locator, error)
+
+// Discover 遍历 locator root，返回所有 MetadataSource，按 Path 排序。
+func (l *Locator) Discover() ([]MetadataSource, error)
+
+// Mode 返回解析后的 LocatorMode（auto-detect 后）。
+func (l *Locator) Mode() LocatorMode
+
+// Root 返回绑定的 on-disk root（NewLocatorFS 构造时为空串）。
+func (l *Locator) Root() string
+
+// FS 返回底层 fs.FS，供 parser 共享同一文件句柄。
+func (l *Locator) FS() fs.FS
 ```
 
-`Paths` 的实现路径：
+`Discover` 的实现路径：
 
-- `LocatorConventional` → `l.discoverConventional(kind)` — 复用现有 5 种
-  路径模式（硬编码在 locator.go 内，parser.go 中的 path match 函数迁移至此）
-- `LocatorManifest` → `l.discoverManifest(kind)` — 按 manifest.yaml 中各
+- `LocatorConventional` → `l.discoverConventional()` — 5 种固定路径模式
+  （硬编码在 `locator_conventional.go`，原 parser.go 中的 path match 函数迁移至此）
+- `LocatorManifest` → `l.discoverManifest()` — 按 manifest.yaml 中各
   module 的 `includes`/`excludes` 走 `fs.WalkDir`
 
-### parser.go 迁移策略
+LocatorOption 函数：
 
-现有 `kernel/metadata/parser.go` 中的 `cellDirFromPath` /
-`sliceDirsFromPath` / `contractDirFromPath` / `journeyIDFromPath` /
-`matchAssemblyYAML` 五个函数**保留原签名不变**，由 `Locator.discoverConventional`
-内部复用（不删除，不暴露为 public API）。M1 PR 的变更范围：
+- `WithLocatorMode(m LocatorMode)` — 覆盖自动探测，CI 用 `WithLocatorMode(LocatorConventional)` 锁定。
+- `WithManifestPath(p string)` — 覆盖默认 manifest 路径（`.gocell/manifest.yaml`）。
 
-1. 新增 `kernel/metadata/locator.go`（Locator struct + DetectLocator）
-2. 新增 `kernel/metadata/manifest.go`（manifestConfig 解析）
-3. parser.go 顶层入口 `ParseDir` 接受可选 `*Locator` 参数：`nil` 时走
-   现有逻辑（向后兼容 monorepo 调用方），非 `nil` 时委托 `Locator.Paths`。
-4. CLI `validate` / `check` 命令接入 `--layout` flag 并构造 `Locator`。
+### parser.go 迁移策略（落地形态）
+
+`kernel/metadata.Parser` 是消费 Locator 的唯一入口：
+
+```go
+// NewParser 创建从给定根目录读取的 Parser。
+// 可传 LocatorOption 覆盖自动探测（如 WithLocatorMode(LocatorManifest)）。
+func NewParser(root string, opts ...LocatorOption) *Parser
+
+// Parse 通过 NewLocator 构造 Locator，再 Discover + 逐 MetadataSource 解析。
+func (p *Parser) Parse() (*ProjectMeta, error)
+
+// ParseFS 从 fs.FS 解析（测试 / fstest.MapFS 场景）。
+func (p *Parser) ParseFS(fsys fs.FS) (*ProjectMeta, error)
+```
+
+Parser 内部调用 `loc.Discover()` 获得 `[]MetadataSource`，再按 `MetadataSource.Kind` dispatch 到对应的 `parseCell` / `parseSlice` / `parseContract` 等方法。Parser 不直接调用 `fs.WalkDir` / `filepath.Walk`（由 LOCATOR-DISCOVERY-FUNNEL-01 守）。
+
+M1 PR 的实际变更范围：
+
+1. 新增 `kernel/metadata/locator.go`（Locator struct + LocatorMode + SourceKind + MetadataSource）
+2. 新增 `kernel/metadata/locator_conventional.go`（discoverConventional）
+3. 新增 `kernel/metadata/locator_manifest.go`（ManifestSpec + discoverManifest）
+4. `kernel/metadata/parser.go` 重构为消费 `Locator.Discover()` 输出（不再直接走 fs）
+5. CLI `validate` / `check` 命令接入 `--layout` / `--manifest` flag。
 
 ---
 
@@ -319,38 +360,39 @@ M1-M4 无相互依赖，可并行推进。
 ## AI-robust 评级（locator funnel）
 
 locator funnel 的两个方向分别评级，对齐 `.claude/rules/gocell/ai-robust.md`
-§"Funnel 双向锁评级"。
+§"Funnel 双向锁评级"。落地 archtest 是 `LOCATOR-DISCOVERY-FUNNEL-01`
+（`tools/archtest/locator_discovery_funnel_test.go`），含 A1/A2a/A2b/A5 四条子规则；
+符号清单活在该 archtest 的 package godoc，不在本 ADR 复制。
 
-### 下游 Hard
+### ENTERING funnel（path-prefix 比较，A1/A2 轴）
 
-archtest `METADATA-LOCATOR-PATH-COMPARE-01`，扫描范围
-`kernel/metadata/**` + `kernel/governance/**`：
+| 方向 | 形态 | 评级 |
+|------|------|------|
+| 下游 Hard | A2a/A2b form-uniqueness：`strings.HasPrefix(_, "cells/")` 和 `x == "cells"` 等路径比较形态的 callsite 必须 ⊆ `kernel/metadata/locator*.go`，EvaluateConstString 解析 const 引用，盲区负向自检 | **Hard** |
+| 上游 Medium | A1 caller-allowlist：`fs.WalkDir` / `filepath.Walk` / `fs.ReadDir` 的调用方 ⊆ `{discoverConventional, discoverManifest}`（archtest allowlist 守，Go 类型系统无法封堵标准库 public function 调用） | **Medium（Go 结构性上限）** |
 
-- **A2 form-uniqueness**：`HasPrefix(path, "<literal>")` / `Split-then-index-compare`
-  / `path.Dir-compare` / `regex anchor` 等路径前缀比较形态的 callsite 必须
-  ⊆ `kernel/metadata/locator*.go`。其他文件出现等价的路径比较形态即 CI 红。
-- **盲区**：`strings.Contains` 形态未被 HasPrefix 形态锁覆盖 → 反向自检测试断言
-  `strings.Contains(path, "cells/")` 等形态在 `kernel/governance/targets.go`
-  不出现。
+**ENTERING 上游为何不开升级 issue**：上游 Hard 的唯一可行路径是 cross-package sealed
+interface + private constructor，在 Go 语言下对于"谁可以调用 `fs.WalkDir`"无法用类型系统
+表达——`fs.WalkDir` 是标准库 public function。这是与 `SPAN-SETATTR-HOLDER-SEAL-01`
+(#851) 同范式的 Go 结构性不可达情形，不满足 ai-robust.md §"Funnel 双向锁评级"
+"存在低成本 Hard 化路径"的开 issue 前提，故 **不开升级 issue**，Medium 是该形态的永久上限。
 
-### 上游 Medium
+### EXITING funnel（consumer-path 重建，A5 轴）
 
-archtest `METADATA-LOCATOR-PATH-COMPARE-01`，A1 caller-allowlist：
+| 方向 | 形态 | 评级 |
+|------|------|------|
+| 下游 Hard | A5 form-uniqueness：EvaluateConstString 解析 `filepath.Join` 每个 arg，命中 banned token ("cells", "cmd") 即 CI 红；consumer scope = kernel/governance + cmd/gocell + kernel/metadata（funnel 文件外） | **Hard** |
+| 上游 Medium | archtest caller-allowlist：Go 类型系统无法阻止包内代码任意调用 `filepath.Join`；A5 盲区负向自检补充 | **Medium（过渡形态）** |
 
-- `fs.WalkDir` / `filepath.Walk` / `fs.ReadDir` 的调用方 ⊆
-  `{Locator.discoverConventional, Locator.discoverManifest}`（kernel/metadata/
-  内部可见）。
+**EXITING 上游升级路径**：Locator sealed envelope（unexported result 类型 + 私有构造函数）/
+typed pathx 包 / 接受 Medium 上限（同 ENTERING）三条路径，
+由 **gh issue #1235** 跟踪显式 Hard 化任务。根据 ai-robust.md §"Funnel 双向锁评级"，
+Medium 上游 + Hard 下游是合法过渡形态；issue #1235 是该条款要求的必开跟踪 issue。
 
-**为何不开升级 issue**：上游 Hard 的唯一可行路径是 cross-package sealed interface
-+ private constructor，在 Go 语言下对于"谁可以调用 fs.WalkDir"这一问题无法表达——
-`fs.WalkDir` 是标准库 public function，任何包均可调用，不存在 Go 类型系统层面的封堵。
-这是与 `SPAN-SETATTR-HOLDER-SEAL-01` (#851) 同范式的 Go 结构性不可达情形。开升级
-issue 等于承诺 Go 不可能完成的任务，故不开（对比 ai-robust.md §Funnel 双向锁评级：
-"Medium 上游 + Hard 下游的过渡形态，**必须同步开 gh issue 跟踪显式 Hard 化任务**"
-的条件是存在低成本 Hard 化路径——此处不满足）。
-
-此（Medium 上游 + Hard 下游）是 ai-robust §"Funnel 双向锁评级" 明文允许的合法
-final 形态，不构成降级。
+**path 单一真值源**：A5 funnel 的语义边界是 `MetadataSource.Path`（`Locator.Discover()` 输出）——
+governance / CLI 代码必须从 `MetadataSource.Path` / `CellMeta.File` / `SliceMeta.File` 等
+Locator 输出派生路径，不得通过 `filepath.Join("cells", id)` 等形式重建。这是 funnel
+"EXITING 侧"的约束语义。
 
 ---
 
@@ -363,7 +405,7 @@ final 形态，不构成降级。
 | manifest 漏写 `excludes: ["generated/**"]` | `generated/` 下的 contract YAML 被重复解析，parser 报重复 ID | `excludes` 默认含 `generated/**`；用户显式写空时 warn |
 | symlink 跨 module 引入循环 | `fs.WalkDir` 死循环 | `Locator.discoverManifest` 走 `os.DirFS`，`fs.WalkDir` 不追踪 symlinked dir（标准库行为：`DirEntry.Type()&ModeSymlink != 0` 时 skip） |
 | Workspace 多模块 cell ID 冲突 | 同名 cell 被装配两次 | `parser.go` 现有 `duplicate cell ID` 校验保持不变，locator 不旁路此检查 |
-| manifest `modules[*].path` 指向不存在目录 | WalkDir 报 `*PathError` | `DetectLocator` 在构造阶段对每个 `path` 调用 `fs.Stat` fail-fast，而非推迟到 `Paths()` 调用时 |
+| manifest `modules[*].path` 指向不存在目录 | WalkDir 报 `*PathError` | `NewLocator` / `NewLocatorFS` 在构造阶段对每个 `path` 调用 `fs.Stat` fail-fast，而非推迟到 `Discover()` 调用时 |
 | go.work 中 use 的 module 不在 manifest modules 列表中 | manifest 遗漏子 module，相关 cell 不被扫描 | 本 ADR 不强制 go.work 与 manifest 对齐；M2 codegen module path 注入会在 codegen 阶段捕获不一致；long-term M11 指南补充手动校验步骤 |
 | Workspace 多模块均声明 `actors` 字段 | workspace-level singleton 重复声明 | `Locator` 解析 manifest 时 fail-fast，返回 `ErrDuplicateWorkspaceSingleton`，明确指出重复的模块路径 |
 
@@ -371,23 +413,27 @@ final 形态，不构成降级。
 
 ## 测试 / 验证
 
-**M1 PR 必须提供以下测试，缺失则 PR 阻塞：**
+**M1 PR 提供以下测试（落地状态）：**
 
 1. `kernel/metadata/locator_test.go`：`fstest.MapFS` 三组 fixture
-   - `TestLocatorConventional`：monorepo 标准 layout，`DetectLocator` 返回
-     `LocatorConventional`，`Paths(KindCell)` 与现有 parser 结果一致
+   - `TestLocatorConventional`：monorepo 标准 layout，`NewLocatorFS` 返回
+     `LocatorConventional`，`Discover()` 中 `SourceCell` 条目与现有 parser 结果一致
    - `TestLocatorManifestSingle`：单模块外部 repo（`.gocell/manifest.yaml`
-     存在），`Paths` 返回 manifest 配置路径下的文件
+     存在），`Discover()` 返回 manifest 配置路径下的 MetadataSource 列表
    - `TestLocatorManifestWorkspace`：两个 module path 的 workspace，
-     `Paths(KindCell)` 返回两个模块合并后的 cell 列表
+     `Discover()` 返回两个模块合并后的 SourceCell 列表
 
-2. `kernel/metadata/parser_manifest_test.go`：manifest 模式下 `ParseDir`
-   结果与同等 conventional layout 下结果等价（cell ID 集合相同）
+2. `kernel/metadata/locator_manifest_e2e_test.go`（Batch 4 补充）：os.TempDir
+   manifest 模式 E2E；`NewLocator(root, WithLocatorMode(LocatorManifest)).Discover()`
+   + `NewParser(root, WithLocatorMode(LocatorManifest)).Parse()` 整链验证
 
-3. `cmd/gocell/app/validate_test.go`：`--layout=conventional` flag 覆盖
+3. `cmd/gocell/app/helpers_test.go`（Batch 4 补充）：`buildLocatorOptions` 三种
+   入参组合（空值/conventional/manifest/auto/invalid）+ `addLocatorFlags` 默认值解析
+
+4. `cmd/gocell/app/validate_test.go`：`--layout=conventional` flag 覆盖
    manifest 自动探测的用例（fake fs 注入）
 
-4. **手测 e2e**（PR description 列出步骤）：在 `examples/ssobff` 根目录临时
+5. **手测 e2e**（PR description 列出步骤）：在 `examples/ssobff` 根目录临时
    写入 `.gocell/manifest.yaml`（单模块），跑 `gocell validate`，确认输出
    与不带 manifest 时等价。
 

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -620,3 +620,91 @@ assembly.yaml 必填仅 `id` + `cells` + `owner`，其余从 cell 元数据派�
 | `maxConsistencyLevel` | `max(cells[].consistencyLevel)` | ✗ 派生只读，yaml 出现该 key 即拒（KnownFields + schema additionalProperties:false 双层守） |
 
 详见 ADR `docs/architecture/202605061800-adr-assembly-yaml-minimal-derivation.md`。
+
+## External Repository 模式（M1 of #1082）
+
+GoCell 支持三种 Cell 开发模式：
+
+| 模式 | 仓库形态 | 配置方式 |
+|------|---------|---------|
+| **Monorepo**（gocell 自身） | 同一 `go.mod` 内 | 默认 conventional layout（无 `.gocell/manifest.yaml`） |
+| **Operator-SDK** | 外部仓库 `go get github.com/ghbvf/gocell` | 仓库根放 `.gocell/manifest.yaml`，1 个 module 条目 |
+| **Workspace** | `go.work` 聚合 gocell + 多 cell module | workspace 根放 `.gocell/manifest.yaml`，多 module 条目 |
+
+### Conventional Layout（默认）
+
+无 `.gocell/manifest.yaml` 时，Locator 走 conventional 5-pattern 探测：
+
+```
+<root>/
+├── cells/<cellID>/cell.yaml
+├── cells/<cellID>/slices/<sliceID>/slice.yaml
+├── contracts/<kind>/.../v<N>/contract.yaml
+├── journeys/J-<id>.yaml
+├── assemblies/<id>/assembly.yaml
+├── journeys/status-board.yaml     # workspace-level singleton
+└── actors.yaml                    # workspace-level singleton
+```
+
+### Manifest Layout
+
+放置 `<root>/.gocell/manifest.yaml`：
+
+```yaml
+version: v1
+modules:
+  - path: .                            # required, relative to manifest dir
+    # includes: 省略 = 使用默认 5-pattern
+    excludes: ["generated/**", "vendor/**"]
+```
+
+#### Workspace 多模块
+
+```yaml
+version: v1
+modules:
+  - path: .                            # workspace 根，承载 actors / status-board singleton
+    includes:
+      cells: ["cells/*/cell.yaml"]
+      slices: ["cells/*/slices/*/slice.yaml"]
+      contracts: ["contracts/**/contract.yaml"]
+      journeys: ["journeys/J-*.yaml"]
+      assemblies: ["assemblies/*/assembly.yaml"]
+      actors: "actors.yaml"
+      statusBoard: "journeys/status-board.yaml"
+  - path: ./vendor-cells/payment       # 子 module，由 go.work `use ./vendor-cells/payment` 聚合
+    # includes 同上结构；actors / statusBoard 留空（singleton 仅 modules[0] 可声明）
+```
+
+`actors.yaml` 与 `journeys/status-board.yaml` 是 workspace-level singleton：**只能在 modules[0] 声明**，多 module 重复填写会被 Locator 拒绝（fail-fast）。
+
+### CLI Flag
+
+`gocell validate` 与 `gocell check ...` 支持显式 layout override：
+
+```bash
+# auto-detect (默认)
+gocell validate
+
+# 强制 manifest 模式
+gocell validate --layout=manifest
+
+# 显式 manifest 路径
+gocell validate --layout=manifest --manifest=./config/.gocell/manifest.yaml
+
+# 强制 conventional (CI 防止 manifest 误植)
+gocell validate --layout=conventional
+```
+
+其他 12 个 CLI 子命令（`generate / verify / export / scaffold-assembly / codegen / graph` 等）通过 auto-detect 自动工作——`<root>/.gocell/manifest.yaml` 存在即用，无需显式 flag。
+
+### Manifest 模式下的 slice belongsToCell
+
+Conventional layout 下，`slice.yaml::belongsToCell` 可省略，由路径 `cells/<X>/slices/<Y>/slice.yaml` 中的 `<X>` 自动派生。Manifest 模式下，如果 slice 包含的 includes pattern 不遵循 `cells/<X>/slices/<Y>/` 结构，**Locator 无法派生 cellID，slice.yaml 必须显式声明 `belongsToCell`**，否则 parse 失败。
+
+### 限制（M1 范围）
+
+- M2 (#1083) 之前，archtest / codegen 的 module path 仍硬编码 `github.com/ghbvf/gocell/...`——外部仓库需要 M2 完工后才能跑完整 archtest。
+- M11 (#1092) 之前没有 starter repo template。当前 quickstart 见 `docs/guides/cell-external-repo-quickstart.md`。
+
+详见 ADR `docs/architecture/202605281200-adr-cell-development-external-repo.md`。

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -696,7 +696,9 @@ gocell validate --layout=manifest --manifest=./config/.gocell/manifest.yaml
 gocell validate --layout=conventional
 ```
 
-其他 12 个 CLI 子命令（`generate / verify / export / scaffold-assembly / codegen / graph` 等）通过 auto-detect 自动工作——`<root>/.gocell/manifest.yaml` 存在即用，无需显式 flag。
+其他 11 个 CLI 子命令（`generate / verify / export / scaffold-assembly / codegen / graph` 等）通过 auto-detect 自动工作——`<root>/.gocell/manifest.yaml` 存在即用，无需显式 flag。
+
+> **例外**：`gocell check unconditional-skip` 不走 metadata.Locator（它直接通过 `go/packages` 扫描 Go 代码做静态分析），其行为完全由 Go 包路径决定，manifest 配置不影响其扫描范围。
 
 ### Manifest 模式下的 slice belongsToCell
 

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -1,0 +1,138 @@
+# External Repository Quickstart (Operator-SDK 模式)
+
+> **范围**：本文档展示在**自己的 Go module 内**开发 Cell 的最小步骤。完整 starter repo + 真实业务样板属于 M11 (#1092) 范围；本 quickstart 只覆盖 M1 落地后已经跑得通的最小闭环：让 `gocell validate` / `gocell check` 在外部仓库识别你的 cell.yaml / slice.yaml / contract.yaml。
+>
+> 完整的双模式产品方向背景见 ADR `docs/architecture/202605281200-adr-cell-development-external-repo.md`。
+
+## 前置
+
+- Go 1.22+
+- `go install github.com/ghbvf/gocell/cmd/gocell@latest`（M7 #1088 之前用 `go install ...@develop`）
+
+## 步骤
+
+### 1. 初始化 module
+
+```bash
+mkdir -p ~/work/acme-payment-cell && cd ~/work/acme-payment-cell
+go mod init github.com/acme/payment-cell
+go get github.com/ghbvf/gocell@develop
+```
+
+### 2. 放 manifest 文件
+
+```bash
+mkdir -p .gocell
+cat > .gocell/manifest.yaml <<'EOF'
+version: v1
+modules:
+  - path: .
+    excludes:
+      - "generated/**"
+      - "vendor/**"
+EOF
+```
+
+Locator 探测到 `.gocell/manifest.yaml` 即自动切到 manifest 模式（auto-detect）。
+
+### 3. 声明 cell + slice + contract
+
+```bash
+mkdir -p cells/payment/slices/charge
+mkdir -p contracts/http/payment/charge/v1
+```
+
+`cells/payment/cell.yaml`:
+
+```yaml
+id: payment
+type: core
+consistencyLevel: L2
+lifecycle: experimental
+owner:
+  team: acme-platform
+  role: payment-cell-owner
+schema:
+  primary: payments
+verify:
+  smoke:
+    - payment/smoke
+```
+
+`cells/payment/slices/charge/slice.yaml`:
+
+```yaml
+id: charge
+belongsToCell: payment        # 必填（manifest 模式无路径自动派生）
+consistencyLevel: L2
+contractUsages:
+  - contract: http.payment.charge.v1
+    role: serve
+verify:
+  unit:
+    - payment/charge/unit
+  contract:
+    - contract.http.payment.charge.v1.serve
+```
+
+`contracts/http/payment/charge/v1/contract.yaml`:
+
+```yaml
+id: http.payment.charge.v1
+kind: http
+lifecycle: experimental
+endpoints:
+  http:
+    method: POST
+    path: /api/v1/payment/charge
+```
+
+### 4. 跑 gocell validate
+
+```bash
+gocell validate
+```
+
+预期输出：metadata 解析通过，governance rules 在 conventional-mode-specific 规则上 skip（因 examples/ 不存在），其余按 cell.yaml / slice.yaml / contract.yaml 内容评估。
+
+需要显式 override 时：
+
+```bash
+gocell validate --layout=manifest
+gocell validate --layout=manifest --manifest=./config/manifest.yaml
+```
+
+### 5. Workspace 模式
+
+如需同时联调 gocell 自身 + 业务 cell module，用 Go workspace：
+
+```bash
+mkdir -p ~/work/platform-workspace && cd ~/work/platform-workspace
+go work init ../gocell ../acme-payment-cell
+```
+
+workspace 根放 `.gocell/manifest.yaml`：
+
+```yaml
+version: v1
+modules:
+  - path: ../gocell                  # workspace root 持 actors / status-board singleton
+  - path: ../acme-payment-cell       # 外部业务 module
+```
+
+`gocell validate --root=.` 会聚合两个 module 的 cell/slice/contract。
+
+## 已知限制（M1 范围）
+
+| 限制 | 影响 | 解锁条件 |
+|------|------|---------|
+| Codegen 的 module path 仍硬编码 `github.com/ghbvf/gocell/...` | `gocell generate` 在外部 repo 生成的 import 路径不对 | M2 #1083 |
+| archtest 不能 import 进外部仓库做 nightly 守卫 | 外部仓库自定 invariant 需自己写 | M3 #1084 |
+| `CellModule` 接口在 `cmd/` 包内私有 | 外部仓库无法 wire 进 corebundle | M4 #1085 |
+| 没有 starter repo template | 上面步骤全手抄 | M11 #1092 |
+
+详细路线见 #1081 与 ADR `docs/architecture/202605281200-adr-cell-development-external-repo.md`。
+
+## 反馈
+
+外部仓库开发遇到的卡点请直接对 [#1081](https://github.com/ghbvf/gocell/issues/1081) 评论，或为具体 M2-M12 子 issue 提 PR。

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -48,6 +48,7 @@ mkdir -p contracts/http/payment/charge/v1
 id: payment
 type: core
 consistencyLevel: L2
+durabilityMode: demo
 lifecycle: experimental
 owner:
   team: acme-platform
@@ -56,7 +57,7 @@ schema:
   primary: payments
 verify:
   smoke:
-    - payment/smoke
+    - smoke.payment.charge
 ```
 
 `cells/payment/slices/charge/slice.yaml`:
@@ -65,14 +66,20 @@ verify:
 id: charge
 belongsToCell: payment        # 必填（manifest 模式无路径自动派生）
 consistencyLevel: L2
+allowedFiles:
+  - "cells/payment/slices/charge/**"
 contractUsages:
   - contract: http.payment.charge.v1
     role: serve
 verify:
   unit:
-    - payment/charge/unit
-  contract:
-    - contract.http.payment.charge.v1.serve
+    - unit.payment.charge
+  contract: []
+  waivers:
+    - contract: http.payment.charge.v1
+      owner: acme-platform
+      reason: "contract still in draft lifecycle; no executable contract test yet"
+      expiresAt: "2026-12-31"
 ```
 
 `contracts/http/payment/charge/v1/contract.yaml`:
@@ -80,20 +87,28 @@ verify:
 ```yaml
 id: http.payment.charge.v1
 kind: http
-lifecycle: experimental
+lifecycle: draft
+ownerCell: payment
+consistencyLevel: L1
 endpoints:
+  server: payment
   http:
     method: POST
     path: /api/v1/payment/charge
+    successStatus: 204
+    noContent: true
 ```
 
 ### 4. 跑 gocell validate
 
 ```bash
+# 必须在 module root（go.mod / .gocell/manifest.yaml 所在目录）运行；或用 --root=/path/to/repo 显式指定
 gocell validate
 ```
 
-预期：退出码 0，stderr/stdout 中出现 `INFO metadata: locator mode resolved mode=manifest`，stdout 输出 `PASS: no errors` 或仅 advisory warnings；governance rules 在 conventional-mode-specific 规则上自动 skip（因 `examples/` 子树在外部 repo 不存在）。
+预期：退出码 0，stderr/stdout 中出现 `INFO metadata: locator mode resolved mode=manifest`，stdout 输出 `No issues found.` 或仅 advisory warnings；governance rules 在 conventional-mode-specific 规则上自动 skip（因 `examples/` 子树在外部 repo 不存在）。
+
+> **说明**：外部仓库无 `examples/` 子树，conventional-layout-specific 规则（如 ADV-04 examples 反向覆盖）在 manifest 模式下自动 skip；详见 ADR § AI-robust 评级。
 
 需要显式 override 时：
 
@@ -101,6 +116,8 @@ gocell validate
 gocell validate --layout=manifest
 gocell validate --layout=manifest --manifest=./config/manifest.yaml
 ```
+
+> 跑通上方 `gocell validate` 即表示 M1 (#1082) acceptance criteria 已达到，后续能力见下方已知限制表。
 
 ### 5. Workspace 模式
 
@@ -123,7 +140,9 @@ modules:
   - path: acme-payment-cell          # 第二个 module
 ```
 
-`gocell validate --root=.` 会聚合两个 module 的 cell/slice/contract。预期退出码 0，输出末尾包含 `PASS: no errors` 或仅 advisory warnings。
+> manifest 的 `path:` 字段不需要 `./` 前缀；`path: gocell` 等价于 `./gocell`，Locator 内部 `path.Clean` 会规范化。
+
+`gocell validate --root=.` 会聚合两个 module 的 cell/slice/contract。预期退出码 0，输出末尾包含 `No issues found.` 或仅 advisory warnings。
 
 ## 已知限制（M1 范围）
 

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -93,7 +93,7 @@ endpoints:
 gocell validate
 ```
 
-预期输出：metadata 解析通过，governance rules 在 conventional-mode-specific 规则上 skip（因 examples/ 不存在），其余按 cell.yaml / slice.yaml / contract.yaml 内容评估。
+预期：退出码 0，stderr/stdout 中出现 `INFO metadata: locator mode resolved mode=manifest`，stdout 输出 `PASS: no errors` 或仅 advisory warnings；governance rules 在 conventional-mode-specific 规则上自动 skip（因 `examples/` 子树在外部 repo 不存在）。
 
 需要显式 override 时：
 
@@ -104,11 +104,14 @@ gocell validate --layout=manifest --manifest=./config/manifest.yaml
 
 ### 5. Workspace 模式
 
-如需同时联调 gocell 自身 + 业务 cell module，用 Go workspace：
+如需同时联调 gocell 自身 + 业务 cell module，用 Go workspace。Workspace 根目录是包含 `go.work` + `.gocell/manifest.yaml` 的目录；所有 `modules[].path` 必须**相对该目录** 且不含 `..`（Locator 会拒绝 `../foo` 形式的 module path，逃逸保护）。
 
 ```bash
 mkdir -p ~/work/platform-workspace && cd ~/work/platform-workspace
-go work init ../gocell ../acme-payment-cell
+# Clone or symlink dependencies inside the workspace root (NOT siblings)
+git clone https://github.com/ghbvf/gocell.git ./gocell
+git clone https://github.com/acme/payment-cell.git ./acme-payment-cell
+go work init ./gocell ./acme-payment-cell
 ```
 
 workspace 根放 `.gocell/manifest.yaml`：
@@ -116,11 +119,11 @@ workspace 根放 `.gocell/manifest.yaml`：
 ```yaml
 version: v1
 modules:
-  - path: ../gocell                  # workspace root 持 actors / status-board singleton
-  - path: ../acme-payment-cell       # 外部业务 module
+  - path: gocell                     # workspace 根的子目录，持 actors / status-board singleton
+  - path: acme-payment-cell          # 第二个 module
 ```
 
-`gocell validate --root=.` 会聚合两个 module 的 cell/slice/contract。
+`gocell validate --root=.` 会聚合两个 module 的 cell/slice/contract。预期退出码 0，输出末尾包含 `PASS: no errors` 或仅 advisory warnings。
 
 ## 已知限制（M1 范围）
 

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -477,6 +477,13 @@ func synthesizeAssemblyMeta(spec AssemblyScaffoldSpec) *metadata.AssemblyMeta {
 			Binary:         spec.ID.String(),
 			DeployTemplate: deployTemplate,
 		},
+		// File is set so that metadata.AssemblyGeneratedDir derives
+		// path.Dir(File)+"/generated" => "assemblies/<id>/generated".
+		// Before M1's Locator funnel, AssemblyGeneratedDir had an internal
+		// "if no examples/ prefix then assemblies/<id>" fallback that masked
+		// missing-File; the fallback was removed so synthesized meta must
+		// declare File explicitly.
+		File: "assemblies/" + spec.ID.String() + "/assembly.yaml",
 	}
 }
 

--- a/kernel/governance/helpers.go
+++ b/kernel/governance/helpers.go
@@ -192,6 +192,10 @@ func repositoryRoot(root string) string {
 //
 // Exported so cmd/gocell and other callers share a single implementation
 // rather than carrying a duplicate with a hand-maintained `// SYNC:` note.
+//
+// kernel/metadata.isWithinRoot is a forced duplicate (layering forbids
+// kernel/metadata importing kernel/governance); keep both in sync until the
+// shared-helper extraction tracked in #1255 lands.
 func IsWithinRoot(root, target string) bool {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {

--- a/kernel/governance/locator_manifest_e2e_test.go
+++ b/kernel/governance/locator_manifest_e2e_test.go
@@ -1,0 +1,129 @@
+// locator_manifest_e2e_test.go exercises the full
+// NewParser → Parse() → governance.NewValidator → ValidateStrict() chain in
+// manifest mode against a real on-disk temp directory.
+//
+// This is the T1 governance-validator third-layer E2E test from PR #1226
+// review round-7.  It complements:
+//   - kernel/metadata/locator_manifest_e2e_test.go — parser-layer tests
+//   - kernel/governance/*_test.go — unit tests for individual rules
+//
+// The test lives in kernel/governance/ (not kernel/metadata/) because
+// kernel/governance imports kernel/metadata; importing governance from
+// metadata/test would create an import cycle.
+package governance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// governanceCellYAML returns a minimal valid cell.yaml for T1 E2E fixtures.
+// All required fields (id/type/consistencyLevel/owner/schema.primary/verify.smoke)
+// are present so governance rules that validate presence of mandatory fields
+// do not fire.
+//
+// verify.smoke uses dot-separated format with ≥3 segments (VERIFY-05 rule).
+func governanceCellYAML(id, team, primarySchema string) string {
+	return "id: " + id + "\n" +
+		"type: core\n" +
+		"consistencyLevel: L1\n" +
+		"owner:\n" +
+		"  team: " + team + "\n" +
+		"  role: cell-owner\n" +
+		"schema:\n" +
+		"  primary: " + primarySchema + "\n" +
+		"verify:\n" +
+		"  smoke:\n" +
+		"    - smoke." + id + ".startup\n"
+}
+
+// governanceSliceYAML returns a minimal valid slice.yaml for T1 E2E fixtures.
+//
+// verify.unit uses dot-separated format with ≥3 segments (VERIFY-05 rule).
+// allowedFiles is populated with the conventional slice path (FMT-14 rule).
+func governanceSliceYAML(id, belongsToCell string) string {
+	return "id: " + id + "\n" +
+		"belongsToCell: " + belongsToCell + "\n" +
+		"consistencyLevel: L1\n" +
+		"contractUsages: []\n" +
+		"verify:\n" +
+		"  unit:\n" +
+		"    - unit." + belongsToCell + "." + id + "\n" +
+		"  contract: []\n" +
+		"allowedFiles:\n" +
+		"  - \"cells/" + belongsToCell + "/slices/" + id + "/**\"\n"
+}
+
+// governanceWriteFile writes content to path, creating parent dirs as needed.
+func governanceWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+// TestLocatorManifest_E2E_GovernanceValidate verifies the full three-layer chain:
+//
+//  1. metadata.NewParser(root, metadata.WithLocatorMode(metadata.LocatorManifest)).Parse()
+//     discovers and parses a manifest-mode project.
+//  2. governance.NewValidator(pm, root, clock.Real()).ValidateStrict(ctx, false, false)
+//     runs base + dep governance rules.
+//  3. The results contain no SeverityError entries for a well-formed minimal project.
+//     Warnings are permitted (e.g. ADV-05 dead-event warnings on event contracts
+//     without subscribers, which do not appear in this fixture).
+func TestLocatorManifest_E2E_GovernanceValidate(t *testing.T) {
+	root := t.TempDir()
+
+	// manifest.yaml: root module, no custom includes (uses conventional walk).
+	governanceWriteFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
+		"version: v1\nmodules:\n  - path: .\n")
+
+	// Minimal cell with all required YAML fields.
+	governanceWriteFile(t,
+		filepath.Join(root, "cells", "billing", "cell.yaml"),
+		governanceCellYAML("billing", "finance", "billing_records"))
+
+	// Minimal slice with all required YAML fields.
+	governanceWriteFile(t,
+		filepath.Join(root, "cells", "billing", "slices", "query", "slice.yaml"),
+		governanceSliceYAML("query", "billing"))
+
+	// Parse in manifest mode.
+	pm, err := metadata.NewParser(root, metadata.WithLocatorMode(metadata.LocatorManifest)).Parse()
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if _, ok := pm.Cells["billing"]; !ok {
+		t.Fatalf("Cells[\"billing\"] missing after Parse")
+	}
+
+	// Run governance validation (base + dep phases; not strict).
+	v := NewValidator(pm, root, clock.Real())
+	results, err := v.ValidateStrict(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("ValidateStrict: %v", err)
+	}
+
+	// Assert: no SeverityError results for a well-formed minimal project.
+	var errs []ValidationResult
+	for _, r := range results {
+		if r.Severity == SeverityError {
+			errs = append(errs, r)
+		}
+	}
+	if len(errs) > 0 {
+		t.Errorf("governance ValidateStrict returned %d error(s) for a minimal manifest-mode project:", len(errs))
+		for _, e := range errs {
+			t.Errorf("  [%s] %s: %s (fix: %s)", e.Code, e.File, e.Message, e.Fix)
+		}
+	}
+}

--- a/kernel/governance/rules_journey.go
+++ b/kernel/governance/rules_journey.go
@@ -32,6 +32,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
 // validBoardLifecycleMatrix maps board.state → set of allowed J-*.yaml
@@ -72,7 +74,7 @@ func (v *Validator) validateJOURNEYCONTRACTEXISTENCE01() []ValidationResult {
 		if c.Lifecycle != "active" {
 			continue
 		}
-		if strings.HasPrefix(c.File, "examples/") {
+		if metadata.IsExamplePath(c.File) {
 			continue
 		}
 		if referenced[c.ID] {

--- a/kernel/governance/rules_journey.go
+++ b/kernel/governance/rules_journey.go
@@ -74,7 +74,7 @@ func (v *Validator) validateJOURNEYCONTRACTEXISTENCE01() []ValidationResult {
 		if c.Lifecycle != "active" {
 			continue
 		}
-		if metadata.IsExamplePath(c.File) {
+		if metadata.IsInExamplesSubtree(c.File) {
 			continue
 		}
 		if referenced[c.ID] {

--- a/kernel/governance/rules_misc_advisory.go
+++ b/kernel/governance/rules_misc_advisory.go
@@ -55,7 +55,7 @@ func (v *Validator) validateADV01() []ValidationResult {
 	}
 
 	for _, j := range v.project.Journeys {
-		if strings.HasPrefix(journeyFile(j), "examples/") {
+		if metadata.IsExamplePath(journeyFile(j)) {
 			continue
 		}
 		if !sbJourneys[j.ID] {

--- a/kernel/governance/rules_misc_advisory.go
+++ b/kernel/governance/rules_misc_advisory.go
@@ -55,7 +55,7 @@ func (v *Validator) validateADV01() []ValidationResult {
 	}
 
 	for _, j := range v.project.Journeys {
-		if metadata.IsExamplePath(journeyFile(j)) {
+		if metadata.IsInExamplesSubtree(journeyFile(j)) {
 			continue
 		}
 		if !sbJourneys[j.ID] {

--- a/kernel/governance/rules_misc_consistency.go
+++ b/kernel/governance/rules_misc_consistency.go
@@ -361,9 +361,22 @@ func (v *Validator) checkReverseEmits(
 	return results
 }
 
+// newSliceRef note: when s.File is empty (e.g. the slice was constructed
+// without a Locator-populated path), ref.dir will be "". Callers of
+// scanSliceEmitTopics must skip such refs — passing dir="" would cause
+// path.Dir(path.Dir("")) to return "." and filepath.Join(root, ".") to
+// scan the entire project root.
 func scanSliceEmitTopics(root string, ref sliceRef, fileForError string) (map[string]struct{}, []ValidationResult) {
 	topics := map[string]struct{}{}
 	var results []ValidationResult
+
+	// Guard: an empty dir means the slice has no resolvable filesystem path
+	// (manifest mode with non-conventional layout, or a test-fixture slice
+	// whose File field was not populated). Scanning would fall back to the
+	// project root; skip silently instead.
+	if ref.dir == "" {
+		return topics, results
+	}
 
 	// Derive cellDir from the slice's directory (ref.dir is slash-separated,
 	// e.g. "cells/accesscore/slices/sessionlogin"). The cell directory is two

--- a/kernel/governance/rules_misc_consistency.go
+++ b/kernel/governance/rules_misc_consistency.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"maps"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -364,7 +365,12 @@ func scanSliceEmitTopics(root string, ref sliceRef, fileForError string) (map[st
 	topics := map[string]struct{}{}
 	var results []ValidationResult
 
-	cellDir := filepath.Join(root, "cells", ref.cellID)
+	// Derive cellDir from the slice's directory (ref.dir is slash-separated,
+	// e.g. "cells/accesscore/slices/sessionlogin"). The cell directory is two
+	// levels up from the slice directory. Using path.Dir twice avoids
+	// hardcoding the "cells" layout token, satisfying
+	// LOCATOR-DISCOVERY-FUNNEL-01.A5.
+	cellDir := filepath.Join(root, filepath.FromSlash(path.Dir(path.Dir(ref.dir))))
 	pkgConsts, constResults := buildPkgConsts(cellDir, fileForError)
 	results = append(results, constResults...)
 	sliceDir := filepath.Join(root, filepath.FromSlash(ref.dir))

--- a/kernel/governance/rules_misc_consistency.go
+++ b/kernel/governance/rules_misc_consistency.go
@@ -221,9 +221,11 @@ func (v *Validator) runPerContractPhase(
 	return results
 }
 
-// isExamplePath returns true if the path is under an examples/ subtree.
+// isExamplePath reports whether p is under the examples/ subtree. Delegates
+// to metadata.IsExamplePath so the conventional-layout literal "examples/"
+// stays inside the Locator funnel (LOCATOR-DISCOVERY-FUNNEL-01).
 func isExamplePath(p string) bool {
-	return strings.HasPrefix(p, "examples/")
+	return metadata.IsExamplePath(p)
 }
 
 // checkConsistencyConstraints12 validates constraints 1 and 2 for a contract.

--- a/kernel/governance/rules_misc_consistency.go
+++ b/kernel/governance/rules_misc_consistency.go
@@ -114,15 +114,13 @@ func newSliceRef(key string, s *metadata.SliceMeta) sliceRef {
 			}
 		}
 	}
-	cellDir := s.CellDir
-	if cellDir == "" {
-		cellDir = cellID
-	}
-	sliceDir := s.Dir
-	if sliceDir == "" {
-		sliceDir = sliceID
-	}
-	dir := filepath.ToSlash(filepath.Join("cells", cellDir, "slices", sliceDir))
+	// Post-M1 (#1082): slice.File is authoritative (populated by Locator).
+	// The dir is derived from File directly. The legacy
+	// filepath.Join("cells", cellDir, "slices", sliceDir) fallback was
+	// removed when the Locator funnel made File mandatory — keeping the
+	// fallback would re-leak the conventional layout "cells" literal into
+	// governance, violating LOCATOR-DISCOVERY-FUNNEL-01.
+	dir := ""
 	if s.File != "" {
 		dir = filepath.ToSlash(filepath.Dir(s.File))
 	}

--- a/kernel/governance/rules_misc_consistency.go
+++ b/kernel/governance/rules_misc_consistency.go
@@ -221,10 +221,10 @@ func (v *Validator) runPerContractPhase(
 }
 
 // isExamplePath reports whether p is under the examples/ subtree. Delegates
-// to metadata.IsExamplePath so the conventional-layout literal "examples/"
+// to metadata.IsInExamplesSubtree so the conventional-layout literal "examples/"
 // stays inside the Locator funnel (LOCATOR-DISCOVERY-FUNNEL-01).
 func isExamplePath(p string) bool {
-	return metadata.IsExamplePath(p)
+	return metadata.IsInExamplesSubtree(p)
 }
 
 // checkConsistencyConstraints12 validates constraints 1 and 2 for a contract.

--- a/kernel/governance/targets.go
+++ b/kernel/governance/targets.go
@@ -106,11 +106,16 @@ func (ts *TargetSelector) SelectFromSlice(sliceKey string) *AffectedTargets {
 	return ts.expandFromSlices(sliceSet)
 }
 
-// matchSliceFromCellsPath handles paths under parsed cell directories
-// (cells/* and examples/*/cells/*).
-// Returns true if the path was consumed (matched a known cell path).
-// fileCellSet tracks which cells are directly hit by file paths
-// (used for L0 dependency propagation).
+// matchSliceFromCellsPath handles paths that live under any parsed slice
+// or cell directory. After M1 (#1082)'s Locator funnel, this is the SOLE
+// matcher for cell/slice file changes — the prior matchLegacyCellsPath
+// fallback (which hardcoded HasPrefix("cells/")) was removed because
+// Locator already provides authoritative .File values for every cell and
+// slice, and the manifest-mode layout may not start with "cells/".
+//
+// Returns true if the path was consumed (matched a known cell or slice
+// directory). fileCellSet tracks cells directly hit by file paths so that
+// expandL0Dependents can propagate to slices depending on those L0 cells.
 func (ts *TargetSelector) matchSliceFromCellsPath(f string, sliceSet, fileCellSet map[string]struct{}) bool {
 	for key, s := range ts.project.Slices {
 		if s.File == "" {
@@ -138,41 +143,18 @@ func (ts *TargetSelector) matchSliceFromCellsPath(f string, sliceSet, fileCellSe
 		}
 		return true
 	}
-	return ts.matchLegacyCellsPath(f, sliceSet, fileCellSet)
+	return false
 }
 
-func (ts *TargetSelector) matchLegacyCellsPath(f string, sliceSet, fileCellSet map[string]struct{}) bool {
-	if !strings.HasPrefix(f, "cells/") {
-		return false
-	}
-	parts := strings.Split(f, "/")
-	if len(parts) < 2 {
-		return true
-	}
-	cellID := parts[1]
-	if _, ok := ts.project.Cells[cellID]; !ok {
-		return true
-	}
-	fileCellSet[cellID] = struct{}{}
-	if len(parts) >= 4 && parts[2] == "slices" {
-		key := cellID + "/" + parts[3]
-		if _, ok := ts.project.Slices[key]; ok {
-			sliceSet[key] = struct{}{}
-		}
-		return true
-	}
-	for key, s := range ts.project.Slices {
-		if s.BelongsToCell == cellID {
-			sliceSet[key] = struct{}{}
-		}
-	}
-	return true
-}
-
-// matchSlicesFromContractPath handles paths under contracts/.
-// It derives the contract ID from the directory path and finds all slices
-// that reference that contract via contractUsages.
-// Returns true if the path was consumed (matched contracts/ prefix).
+// matchSlicesFromContractPath handles paths that live inside a parsed
+// contract directory (or one of its schemaRefs). After M1 (#1082)'s
+// Locator funnel, this is the SOLE matcher for contract file changes —
+// the prior HasPrefix("contracts/") + contractIDFromPath fallback was
+// removed because Locator already provides authoritative .File and .Dir
+// values for every contract, and the manifest-mode layout may not start
+// with "contracts/".
+//
+// Returns true if the path was consumed (matched a known contract).
 func (ts *TargetSelector) matchSlicesFromContractPath(f string, sliceSet map[string]struct{}) bool {
 	matched := false
 	for contractID, c := range ts.project.Contracts {
@@ -181,29 +163,7 @@ func (ts *TargetSelector) matchSlicesFromContractPath(f string, sliceSet map[str
 			matched = true
 		}
 	}
-	if matched {
-		return true
-	}
-
-	if !strings.HasPrefix(f, "contracts/") {
-		return false
-	}
-
-	// Contract directory: contracts/{kind}/{domain...}/{version}/
-	// Contract ID: {kind}.{domain...}.{version}
-	// Example: contracts/http/auth/login/v1/contract.yaml -> http.auth.login.v1
-	contractID := ts.contractIDFromPath(f)
-	if contractID == "" {
-		return true
-	}
-
-	// Check that contract exists.
-	if _, ok := ts.project.Contracts[contractID]; !ok {
-		return true
-	}
-
-	ts.addSlicesForContract(contractID, sliceSet)
-	return true
+	return matched
 }
 
 func contractPathMatches(c *metadata.ContractMeta, f string) bool {
@@ -237,10 +197,12 @@ func (ts *TargetSelector) addSlicesForContract(contractID string, sliceSet map[s
 	}
 }
 
-// matchFromJourneyPath handles paths under journeys/.
-// Only J-*.yaml files are treated as journey files; other files (e.g.
-// status-board.yaml) are ignored.
-// Returns true if the path was consumed (matched journeys/ prefix).
+// matchFromJourneyPath handles paths under a parsed journey file. After
+// M1 (#1082)'s Locator funnel, the prior HasPrefix("journeys/") + filename
+// derivation fallback was removed because Locator already provides
+// authoritative JourneyMeta.File for every journey.
+//
+// Returns true if the path matched a known journey file.
 func (ts *TargetSelector) matchFromJourneyPath(f string, cellSet map[string]struct{}, contractSet map[string]struct{}) bool {
 	for _, journey := range ts.project.Journeys {
 		if journey.File == "" || f != journey.File {
@@ -249,29 +211,7 @@ func (ts *TargetSelector) matchFromJourneyPath(f string, cellSet map[string]stru
 		ts.addJourneyTargets(journey, cellSet, contractSet)
 		return true
 	}
-
-	if !strings.HasPrefix(f, "journeys/") {
-		return false
-	}
-
-	// Extract filename: journeys/J-ssologin.yaml -> J-ssologin.yaml
-	base := path.Base(f)
-
-	// Only J-*.yaml files are journey definitions.
-	if !strings.HasPrefix(base, "J-") || !strings.HasSuffix(base, ".yaml") {
-		return true
-	}
-
-	// Journey ID is the filename without the .yaml extension.
-	journeyID := strings.TrimSuffix(base, ".yaml")
-
-	journey, ok := ts.project.Journeys[journeyID]
-	if !ok {
-		return true
-	}
-
-	ts.addJourneyTargets(journey, cellSet, contractSet)
-	return true
+	return false
 }
 
 func (ts *TargetSelector) addJourneyTargets(journey *metadata.JourneyMeta, cellSet map[string]struct{}, contractSet map[string]struct{}) {
@@ -283,53 +223,27 @@ func (ts *TargetSelector) addJourneyTargets(journey *metadata.JourneyMeta, cellS
 	}
 }
 
-// matchFromAssemblyPath handles paths under assemblies/ or examples/.
-// Expects: assemblies/{id}/assembly.yaml or examples/{id}/assembly.yaml
-// Returns true if the path was consumed (matched assemblies/ or examples/ prefix).
+// matchFromAssemblyPath handles paths that live inside a parsed assembly
+// directory. After M1 (#1082)'s Locator funnel, the prior
+// HasPrefix("assemblies/") + HasPrefix("examples/") + position-based ID
+// derivation fallback was removed because Locator already provides
+// authoritative AssemblyMeta.File for every assembly.
+//
+// Returns true if the path was inside (or equal to) a known assembly
+// directory.
 func (ts *TargetSelector) matchFromAssemblyPath(f string, cellSet map[string]struct{}) bool {
-	if !strings.HasPrefix(f, "assemblies/") && !strings.HasPrefix(f, "examples/") {
-		return false
+	for _, asm := range ts.project.Assemblies {
+		if asm == nil || asm.File == "" {
+			continue
+		}
+		if pathWithin(f, path.Dir(asm.File)) {
+			for _, cellID := range asm.Cells {
+				cellSet[cellID] = struct{}{}
+			}
+			return true
+		}
 	}
-
-	parts := strings.Split(f, "/")
-	// parts[0] = "assemblies" or "examples", parts[1] = assemblyID, ...
-	if len(parts) < 2 {
-		return true
-	}
-	assemblyID := parts[1]
-
-	asm, ok := ts.project.Assemblies[assemblyID]
-	if !ok {
-		return true
-	}
-
-	// Add assembly's cells to the cell set.
-	for _, cellID := range asm.Cells {
-		cellSet[cellID] = struct{}{}
-	}
-
-	return true
-}
-
-// contractIDFromPath extracts a contract ID from a file path under contracts/.
-// It takes everything between "contracts/" and the filename, strips the trailing
-// slash, and joins with dots.
-// Example: "contracts/http/auth/login/v1/contract.yaml" -> "http.auth.login.v1".
-func (ts *TargetSelector) contractIDFromPath(f string) string {
-	// Remove the "contracts/" prefix.
-	rest := strings.TrimPrefix(f, "contracts/")
-	if rest == "" || rest == f {
-		return ""
-	}
-
-	// Get the directory part (remove the filename).
-	dir := path.Dir(rest)
-	if dir == "." || dir == "" {
-		return ""
-	}
-
-	// Replace slashes with dots to form the contract ID.
-	return strings.ReplaceAll(dir, "/", ".")
+	return false
 }
 
 func pathWithin(file, dir string) bool {

--- a/kernel/governance/targets_test.go
+++ b/kernel/governance/targets_test.go
@@ -12,6 +12,11 @@ import (
 // targetsProject returns a ProjectMeta for impact-analysis tests.
 // 2 cells, 3 slices (some with contractUsages), 2 contracts, 2 journeys, 1 assembly.
 func targetsProject() *metadata.ProjectMeta {
+	// File fields are populated so targets.matchSliceFromCellsPath /
+	// matchFromJourneyPath / matchFromAssemblyPath / contractPathMatches
+	// can resolve changed file paths against parsed metadata. After M1
+	// (#1082)'s Locator funnel, TargetSelector no longer falls back to
+	// path-prefix derivation when File is empty.
 	return &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{
 			metadatatest.CellIDAccessCore: {
@@ -19,12 +24,14 @@ func targetsProject() *metadata.ProjectMeta {
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+				File:             "cells/" + metadatatest.CellIDAccessCore + "/cell.yaml",
 			},
 			metadatatest.CellIDAuditCore: {
 				ID:               metadatatest.CellIDAuditCore,
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				Owner:            metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+				File:             "cells/" + metadatatest.CellIDAuditCore + "/cell.yaml",
 			},
 		},
 		Slices: map[string]*metadata.SliceMeta{
@@ -35,6 +42,7 @@ func targetsProject() *metadata.ProjectMeta {
 					{Contract: "http.auth.login.v1", Role: "serve"},
 					{Contract: "event.session.created.v1", Role: "publish"},
 				},
+				File: "cells/" + metadatatest.CellIDAccessCore + "/slices/session-login/slice.yaml",
 			},
 			"accesscore/session-refresh": {
 				ID:            "session-refresh",
@@ -42,6 +50,7 @@ func targetsProject() *metadata.ProjectMeta {
 				ContractUsages: []metadata.ContractUsage{
 					{Contract: "http.auth.login.v1", Role: "call"},
 				},
+				File: "cells/" + metadatatest.CellIDAccessCore + "/slices/session-refresh/slice.yaml",
 			},
 			"auditcore/audit-write": {
 				ID:            "audit-write",
@@ -49,6 +58,7 @@ func targetsProject() *metadata.ProjectMeta {
 				ContractUsages: []metadata.ContractUsage{
 					{Contract: "event.session.created.v1", Role: "subscribe"},
 				},
+				File: "cells/" + metadatatest.CellIDAuditCore + "/slices/audit-write/slice.yaml",
 			},
 		},
 		Contracts: map[string]*metadata.ContractMeta{
@@ -57,12 +67,16 @@ func targetsProject() *metadata.ProjectMeta {
 				Kind:      "http",
 				OwnerCell: metadatatest.CellIDAccessCore,
 				Lifecycle: "active",
+				Dir:       "contracts/http/auth/login/v1",
+				File:      "contracts/http/auth/login/v1/contract.yaml",
 			},
 			"event.session.created.v1": {
 				ID:        "event.session.created.v1",
 				Kind:      "event",
 				OwnerCell: metadatatest.CellIDAccessCore,
 				Lifecycle: "active",
+				Dir:       "contracts/event/session/created/v1",
+				File:      "contracts/event/session/created/v1/contract.yaml",
 			},
 		},
 		Journeys: map[string]*metadata.JourneyMeta{
@@ -71,11 +85,13 @@ func targetsProject() *metadata.ProjectMeta {
 				Goal:      "SSO login flow",
 				Cells:     []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore},
 				Contracts: []string{"http.auth.login.v1", "event.session.created.v1"},
+				File:      "journeys/J-ssologin.yaml",
 			},
 			"J-audit-trail": {
 				ID:    "J-audit-trail",
 				Goal:  "Audit trail for login",
 				Cells: []string{metadatatest.CellIDAuditCore},
+				File:  "journeys/J-audit-trail.yaml",
 			},
 		},
 		Assemblies: map[string]*metadata.AssemblyMeta{
@@ -86,6 +102,7 @@ func targetsProject() *metadata.ProjectMeta {
 					Entrypoint: "cmd/corebundle/main.go",
 					Binary:     "corebundle",
 				},
+				File: "assemblies/corebundle/assembly.yaml",
 			},
 		},
 	}
@@ -175,10 +192,17 @@ func TestSelectFromFiles_UnknownSlice(t *testing.T) {
 		"cells/accesscore/slices/nonexistent-slice/handler.go",
 	})
 
-	assert.Nil(t, result.Slices)
-	assert.Nil(t, result.Cells)
-	assert.Nil(t, result.Journeys)
-	assert.Nil(t, result.Contracts)
+	// After M1 (#1082)'s Locator funnel, TargetSelector no longer tries to
+	// resolve a slice ID from path segments — it uses parsed
+	// SliceMeta.File / CellMeta.File directly. A file inside the accesscore
+	// cell directory therefore propagates impact to all of that cell's
+	// known slices (the safe over-selection direction), even when the
+	// specific slice path doesn't match any parsed slice. The prior fallback
+	// silently dropped the file change, which under-selected.
+	assert.Equal(t, []string{"accesscore/session-login", "accesscore/session-refresh"}, result.Slices)
+	assert.Equal(t, []string{"accesscore"}, result.Cells)
+	assert.Equal(t, []string{"J-ssologin"}, result.Journeys)
+	assert.Equal(t, []string{"event.session.created.v1", "http.auth.login.v1"}, result.Contracts)
 }
 
 func TestSelectFromFiles_UnknownContract(t *testing.T) {
@@ -333,18 +357,24 @@ func TestSelectFromFiles_NonexistentJourney(t *testing.T) {
 // l0Project returns a ProjectMeta with L0 cells (with and without slices)
 // and dependent cells, plus a journey referencing the L0 cell.
 func l0Project() *metadata.ProjectMeta {
+	// File fields are populated so targets.matchSliceFromCellsPath can
+	// match changed file paths against parsed cell/slice/journey metadata
+	// — after M1 (#1082)'s Locator funnel, TargetSelector relies on parsed
+	// .File values rather than HasPrefix("cells/")-style path derivation.
 	return &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{
 			metadatatest.CellIDSharedCrypto: {
 				ID:               metadatatest.CellIDSharedCrypto,
 				Type:             "support",
 				ConsistencyLevel: "L0",
+				File:             "cells/" + metadatatest.CellIDSharedCrypto + "/cell.yaml",
 			},
 			metadatatest.CellIDSharedValidate: {
 				ID:               metadatatest.CellIDSharedValidate,
 				Type:             "support",
 				ConsistencyLevel: "L0",
 				// L0 cell with NO slices — tests propagation for slice-less cells.
+				File: "cells/" + metadatatest.CellIDSharedValidate + "/cell.yaml",
 			},
 			metadatatest.CellIDAccessCore: {
 				ID:               metadatatest.CellIDAccessCore,
@@ -354,12 +384,14 @@ func l0Project() *metadata.ProjectMeta {
 					{Cell: metadatatest.CellIDSharedCrypto, Reason: "hashing"},
 					{Cell: metadatatest.CellIDSharedValidate, Reason: "input validation"},
 				},
+				File: "cells/" + metadatatest.CellIDAccessCore + "/cell.yaml",
 			},
 			metadatatest.CellIDAuditCore: {
 				ID:               metadatatest.CellIDAuditCore,
 				Type:             "core",
 				ConsistencyLevel: "L2",
 				// no L0 dependencies
+				File: "cells/" + metadatatest.CellIDAuditCore + "/cell.yaml",
 			},
 			metadatatest.CellIDBillingCore: {
 				ID:               metadatatest.CellIDBillingCore,
@@ -370,12 +402,14 @@ func l0Project() *metadata.ProjectMeta {
 				},
 				// NOT referenced by J-l0-test journey — used to test
 				// that journey changes don't trigger L0 propagation.
+				File: "cells/" + metadatatest.CellIDBillingCore + "/cell.yaml",
 			},
 		},
 		Slices: map[string]*metadata.SliceMeta{
 			"sharedcrypto/hasher": {
 				ID:            "hasher",
 				BelongsToCell: metadatatest.CellIDSharedCrypto,
+				File:          "cells/" + metadatatest.CellIDSharedCrypto + "/slices/hasher/slice.yaml",
 			},
 			// sharedvalidate has NO slices (intentional).
 			"accesscore/session-login": {
@@ -384,26 +418,32 @@ func l0Project() *metadata.ProjectMeta {
 				ContractUsages: []metadata.ContractUsage{
 					{Contract: "http.auth.login.v1", Role: "serve"},
 				},
+				File: "cells/" + metadatatest.CellIDAccessCore + "/slices/session-login/slice.yaml",
 			},
 			"auditcore/audit-write": {
 				ID:            "audit-write",
 				BelongsToCell: metadatatest.CellIDAuditCore,
+				File:          "cells/" + metadatatest.CellIDAuditCore + "/slices/audit-write/slice.yaml",
 			},
 			"billingcore/payment": {
 				ID:            "payment",
 				BelongsToCell: metadatatest.CellIDBillingCore,
+				File:          "cells/" + metadatatest.CellIDBillingCore + "/slices/payment/slice.yaml",
 			},
 		},
 		Contracts: map[string]*metadata.ContractMeta{
 			"http.auth.login.v1": {
 				ID:   "http.auth.login.v1",
 				Kind: "http",
+				Dir:  "contracts/http/auth/login/v1",
+				File: "contracts/http/auth/login/v1/contract.yaml",
 			},
 		},
 		Journeys: map[string]*metadata.JourneyMeta{
 			"J-l0-test": {
 				ID:    "J-l0-test",
 				Cells: []string{metadatatest.CellIDSharedCrypto, metadatatest.CellIDAccessCore},
+				File:  "journeys/J-l0-test.yaml",
 			},
 		},
 		Assemblies: map[string]*metadata.AssemblyMeta{},

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -4153,6 +4153,12 @@ func TestREF16(t *testing.T) {
 				Entrypoint: "cmd/evil/main.go",
 				Binary:     "evil",
 			},
+			// File is set so REF-16's defense-in-depth IsWithinRoot check
+			// sees a traversal-bearing path. Post-M1 (#1082), Locator rejects
+			// ".." in manifest module paths at parse time, so this attack
+			// vector cannot reach REF-16 in production — the test directly
+			// injects the meta to verify REF-16 still catches it.
+			File: "assemblies/../../etc/assembly.yaml",
 		}
 
 		val := NewValidator(pm, srcDir, clock.Real())

--- a/kernel/metadata/assembly_derive.go
+++ b/kernel/metadata/assembly_derive.go
@@ -9,17 +9,17 @@ package metadata
 
 import (
 	"log/slog"
+	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/ghbvf/gocell/kernel/cellvocab"
 )
 
 // AssemblyGeneratedDir returns the project-relative path of the generated/
-// directory for an assembly. For assemblies whose source file lives under
-// examples/ (e.g. examples/todoorder/assembly.yaml) the generated directory
-// follows the same prefix: examples/{id}/generated/. All other assemblies
-// use assemblies/{id}/generated/.
+// directory for an assembly. It is derived uniformly as
+// path.Dir(asm.File) + "/generated", which works for the conventional
+// assemblies/<id>/ layout, the examples/<id>/ subtree, and arbitrary paths
+// emitted by Locator manifest mode.
 //
 // This is the single source of truth shared by:
 //   - kernel/assembly Generator.appendGeneratedFiles (boundary.yaml write path)
@@ -28,12 +28,12 @@ import (
 //   - kernel/governance validateREF16 (boundary.yaml existence check)
 //
 // asm.File is the path as loaded by the parser — relative to the project
-// root, using the OS path separator. ToSlash normalises for the prefix check.
+// root, with forward slashes (parser already normalised via filepath.ToSlash).
 func AssemblyGeneratedDir(asm *AssemblyMeta) string {
-	if strings.HasPrefix(filepath.ToSlash(asm.File), "examples/") {
-		return filepath.ToSlash(filepath.Join("examples", asm.ID, "generated"))
+	if asm == nil || asm.File == "" {
+		return ""
 	}
-	return filepath.ToSlash(filepath.Join("assemblies", asm.ID, "generated"))
+	return path.Join(path.Dir(filepath.ToSlash(asm.File)), "generated")
 }
 
 // applyAssemblyDerivations fills derived AssemblyMeta fields after parsing.
@@ -62,7 +62,9 @@ func deriveAssembly(pm *ProjectMeta, asm *AssemblyMeta) {
 		// examples/{id}/main.go to match the "identity by location" principle
 		// (helm/helm pkg/chartutil/create.go, kustomize-sigs pkg/types/kustomization.go).
 		// All other assemblies default to cmd/{id}/main.go.
-		if strings.HasPrefix(filepath.ToSlash(asm.File), "examples/") {
+		// IsExamplePath funnels the "examples/" literal through locator.go
+		// (LOCATOR-DISCOVERY-FUNNEL-01).
+		if IsExamplePath(asm.File) {
 			asm.Build.Entrypoint = filepath.ToSlash(filepath.Join("examples", asm.ID, "main.go"))
 		} else {
 			asm.Build.Entrypoint = filepath.ToSlash(filepath.Join("cmd", asm.ID, "main.go"))

--- a/kernel/metadata/assembly_derive.go
+++ b/kernel/metadata/assembly_derive.go
@@ -58,14 +58,18 @@ func applyAssemblyDerivations(pm *ProjectMeta) {
 
 func deriveAssembly(pm *ProjectMeta, asm *AssemblyMeta) {
 	if asm.Build.Entrypoint == "" {
-		// Assemblies under examples/ derive their entrypoint as
-		// examples/{id}/main.go to match the "identity by location" principle
-		// (helm/helm pkg/chartutil/create.go, kustomize-sigs pkg/types/kustomization.go).
-		// All other assemblies default to cmd/{id}/main.go.
-		// IsExamplePath funnels the "examples/" literal through locator.go
-		// (LOCATOR-DISCOVERY-FUNNEL-01).
+		// Assemblies under examples/ derive their entrypoint adjacent to
+		// the assembly.yaml file ({assembly_dir}/main.go) — preserves the
+		// "identity by location" principle without re-naming the
+		// "examples" path literal outside the Locator funnel
+		// (LOCATOR-DISCOVERY-FUNNEL-01). IsExamplePath funnels the
+		// classification decision through locator.go. All other assemblies
+		// default to cmd/{id}/main.go.
+		//
+		// ref: helm/helm pkg/chartutil/create.go, kustomize-sigs
+		// pkg/types/kustomization.go — identity by location.
 		if IsExamplePath(asm.File) {
-			asm.Build.Entrypoint = filepath.ToSlash(filepath.Join("examples", asm.ID, "main.go"))
+			asm.Build.Entrypoint = path.Join(path.Dir(filepath.ToSlash(asm.File)), "main.go")
 		} else {
 			asm.Build.Entrypoint = filepath.ToSlash(filepath.Join("cmd", asm.ID, "main.go"))
 		}

--- a/kernel/metadata/assembly_derive.go
+++ b/kernel/metadata/assembly_derive.go
@@ -58,19 +58,27 @@ func applyAssemblyDerivations(pm *ProjectMeta) {
 
 func deriveAssembly(pm *ProjectMeta, asm *AssemblyMeta) {
 	if asm.Build.Entrypoint == "" {
-		// Assemblies under examples/ derive their entrypoint adjacent to
-		// the assembly.yaml file ({assembly_dir}/main.go) — preserves the
-		// "identity by location" principle without re-naming the
-		// "examples" path literal outside the Locator funnel
-		// (LOCATOR-DISCOVERY-FUNNEL-01). IsExamplePath funnels the
-		// classification decision through locator.go. All other assemblies
-		// default to cmd/{id}/main.go.
+		// Entrypoint derivation follows "identity by location" for assemblies
+		// whose file lives outside the conventional assemblies/<id>/ directory
+		// (examples subtree, Manifest-mode custom layout). For those, the
+		// entrypoint is the main.go adjacent to the assembly.yaml.
+		//
+		// Conventional assemblies (assemblies/<id>/assembly.yaml) keep the
+		// historical cmd/<id>/main.go entrypoint so that the conventional
+		// starter layout is not silently broken — "cmd" is a conventional layout
+		// token and is allowlisted in LOCATOR-DISCOVERY-FUNNEL-01.A5 for this
+		// file only (see tools/archtest/locator_discovery_funnel_test.go godoc).
 		//
 		// ref: helm/helm pkg/chartutil/create.go, kustomize-sigs
 		// pkg/types/kustomization.go — identity by location.
-		if IsExamplePath(asm.File) {
+		if asm.File != "" && !IsConventionalAssemblyPath(asm.File) {
+			// Non-conventional layout (examples/, Manifest-mode custom path):
+			// use identity-by-location derivation.
 			asm.Build.Entrypoint = path.Join(path.Dir(filepath.ToSlash(asm.File)), "main.go")
 		} else {
+			// Conventional layout (assemblies/<id>/) or unset File: preserve
+			// the historical cmd/<id>/main.go entrypoint so the conventional
+			// starter layout is not silently broken.
 			asm.Build.Entrypoint = filepath.ToSlash(filepath.Join("cmd", asm.ID, "main.go"))
 		}
 		slog.Debug("metadata: assembly entrypoint derived",

--- a/kernel/metadata/assembly_derive_test.go
+++ b/kernel/metadata/assembly_derive_test.go
@@ -168,10 +168,16 @@ func TestAssemblyGeneratedDir(t *testing.T) {
 			wantPath: "assemblies/corebundle/generated",
 		},
 		{
-			name:     "empty_file_defaults_to_assemblies",
+			// Post-M1 (#1082) Locator funnel: empty File is a parsing-contract
+			// violation, not a recoverable fallback condition. AssemblyGeneratedDir
+			// returns "" so callers detect the missing-meta condition rather than
+			// silently producing a derived path that could collide with real
+			// output. Scaffold (kernel/assembly.synthesizeAssemblyMeta) now sets
+			// File explicitly to "assemblies/<id>/assembly.yaml".
+			name:     "empty_file_returns_empty",
 			asmID:    "newasm",
 			file:     "",
-			wantPath: "assemblies/newasm/generated",
+			wantPath: "",
 		},
 	}
 	for _, tc := range cases {

--- a/kernel/metadata/assembly_derive_test.go
+++ b/kernel/metadata/assembly_derive_test.go
@@ -193,6 +193,69 @@ func TestAssemblyGeneratedDir(t *testing.T) {
 	}
 }
 
+// TestApplyAssemblyDerivations_ConventionalAssemblyEntrypoint verifies that an
+// assembly under assemblies/<id>/ derives the conventional cmd/<id>/main.go
+// entrypoint (not identity-by-location assemblies/<id>/main.go), so the
+// conventional starter layout is preserved.
+func TestApplyAssemblyDerivations_ConventionalAssemblyEntrypoint(t *testing.T) {
+	t.Parallel()
+	asm := &metadata.AssemblyMeta{
+		ID:    "corebundle",
+		File:  "assemblies/corebundle/assembly.yaml",
+		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+	}
+	pm := buildAssemblyProject(map[string]string{}, []string{}, asm)
+
+	metadata.ExportedApplyAssemblyDerivations(pm)
+
+	if asm.Build.Entrypoint != "cmd/corebundle/main.go" {
+		t.Errorf("entrypoint: want %q, got %q", "cmd/corebundle/main.go", asm.Build.Entrypoint)
+	}
+}
+
+// TestApplyAssemblyDerivations_ManifestCustomEntrypoint verifies that an
+// assembly in a Manifest-mode custom path (not assemblies/ or examples/)
+// derives the identity-by-location entrypoint (path.Dir(file)/main.go).
+func TestApplyAssemblyDerivations_ManifestCustomEntrypoint(t *testing.T) {
+	t.Parallel()
+	asm := &metadata.AssemblyMeta{
+		ID:    "payment",
+		File:  "services/payment/assembly.yaml",
+		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
+	}
+	pm := buildAssemblyProject(map[string]string{}, []string{}, asm)
+
+	metadata.ExportedApplyAssemblyDerivations(pm)
+
+	if asm.Build.Entrypoint != "services/payment/main.go" {
+		t.Errorf("entrypoint: want %q, got %q", "services/payment/main.go", asm.Build.Entrypoint)
+	}
+}
+
+// TestIsConventionalAssemblyPath exercises all branches of the
+// IsConventionalAssemblyPath classification funnel.
+func TestIsConventionalAssemblyPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"assemblies/corebundle/assembly.yaml", true},
+		{"assemblies/corebundle/", true},
+		{"assemblies/", true},
+		{"examples/todoorder/assembly.yaml", false},
+		{"services/payment/assembly.yaml", false},
+		{"", false},
+		{"cmd/corebundle/main.go", false},
+	}
+	for _, tc := range cases {
+		got := metadata.IsConventionalAssemblyPath(tc.path)
+		if got != tc.want {
+			t.Errorf("IsConventionalAssemblyPath(%q): want %v, got %v", tc.path, tc.want, got)
+		}
+	}
+}
+
 func TestApplyAssemblyDerivations_InvalidLevelSkipsMaxLevel(t *testing.T) {
 	asm := &metadata.AssemblyMeta{
 		ID:    "badlvlbundle",

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -1,0 +1,306 @@
+// Package metadata: Locator abstracts metadata YAML discovery from parser
+// internals. It is the single funnel through which all path-prefix knowledge
+// about GoCell's filesystem topology must flow.
+//
+// Two modes:
+//   - Conventional — walks the hardcoded 5-pattern layout
+//     (cells/*/cell.yaml, cells/*/slices/*/slice.yaml,
+//     contracts/{kind}/.../contract.yaml, journeys/J-*.yaml,
+//     assemblies/*/assembly.yaml, plus the two singletons
+//     actors.yaml and journeys/status-board.yaml). examples/ subtree
+//     follows the same patterns with one extra prefix.
+//   - Manifest — reads .gocell/manifest.yaml and walks the modules:
+//     entries it declares. Single-module entry covers Operator-SDK external
+//     repo; multi-module entries cover Workspace mode aggregation.
+//
+// Auto-detection: NewLocator without WithLocatorMode probes the root for
+// .gocell/manifest.yaml; presence selects Manifest mode, absence selects
+// Conventional. Override with WithLocatorMode(LocatorConventional) for CI
+// determinism.
+//
+// ref: bufbuild/buf buf.yaml v2 modules: schema — single manifest expressing
+// both single-module and workspace-aggregate forms.
+// ref: kubernetes-sigs/kubebuilder PROJECT — manifest-driven resource
+// registration.
+// ref: kubernetes-sigs/kustomize kustomization.yaml resources: field.
+//
+// Funnel: LOCATOR-DISCOVERY-FUNNEL-01 (Hard downstream, Medium upstream).
+// All path-prefix string comparisons against {cells/, contracts/, journeys/,
+// assemblies/, examples/} must live inside locator_conventional.go or
+// locator_manifest.go. fs.WalkDir / filepath.Walk / fs.ReadDir callsites in
+// kernel/metadata/** must reside inside Locator.discoverConventional or
+// Locator.discoverManifest. The upstream Medium ceiling is the Go language
+// limit: cross-package sealed-interface-with-private-constructor is
+// structurally unreachable — see SPAN-SETATTR-HOLDER-SEAL-01 (#851) won't-do
+// for the precedent.
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SourceKind classifies a metadata YAML file by its semantic bucket.
+type SourceKind int
+
+const (
+	// SourceUnknown is the zero value; never emitted by Locator.
+	SourceUnknown SourceKind = iota
+	// SourceCell marks a cell.yaml file.
+	SourceCell
+	// SourceSlice marks a slice.yaml file.
+	SourceSlice
+	// SourceContract marks a contract.yaml file.
+	SourceContract
+	// SourceJourney marks a journeys/J-*.yaml file.
+	SourceJourney
+	// SourceAssembly marks an assembly.yaml file.
+	SourceAssembly
+	// SourceActors marks the workspace-level actors.yaml singleton.
+	SourceActors
+	// SourceStatusBoard marks the workspace-level journeys/status-board.yaml
+	// singleton.
+	SourceStatusBoard
+)
+
+// String returns the kebab-case name of the SourceKind, used in errors and
+// diagnostics.
+func (k SourceKind) String() string {
+	switch k {
+	case SourceCell:
+		return "cell"
+	case SourceSlice:
+		return "slice"
+	case SourceContract:
+		return "contract"
+	case SourceJourney:
+		return "journey"
+	case SourceAssembly:
+		return "assembly"
+	case SourceActors:
+		return "actors"
+	case SourceStatusBoard:
+		return "status-board"
+	default:
+		return "unknown"
+	}
+}
+
+// MetadataSource is one YAML file discovered by Locator.
+//
+// Path is forward-slash relative to the locator root.
+//
+// CellID is populated for SourceCell / SourceSlice when the locator can derive
+// it from layout (conventional walk path parts, or manifest includes that
+// happen to follow conventional layout). When the locator cannot derive
+// CellID (manifest with non-conventional layout), CellID stays empty —
+// parser will then require slice.yaml to declare belongsToCell explicitly.
+type MetadataSource struct {
+	Path   string
+	Kind   SourceKind
+	CellID string
+}
+
+// LocatorMode selects how Locator discovers metadata.
+type LocatorMode int
+
+const (
+	// LocatorAuto selects Conventional unless .gocell/manifest.yaml exists at
+	// root, in which case Manifest mode is used.
+	LocatorAuto LocatorMode = iota
+	// LocatorConventional walks the hardcoded 5-pattern layout. Used when no
+	// manifest file is present, or explicitly via WithLocatorMode.
+	LocatorConventional
+	// LocatorManifest reads .gocell/manifest.yaml and walks the modules:
+	// list it declares.
+	LocatorManifest
+)
+
+// String returns the kebab-case name of LocatorMode.
+func (m LocatorMode) String() string {
+	switch m {
+	case LocatorAuto:
+		return "auto"
+	case LocatorConventional:
+		return "conventional"
+	case LocatorManifest:
+		return "manifest"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseLocatorMode converts a CLI flag value to a LocatorMode. Empty string
+// resolves to LocatorAuto. Unknown values return an error.
+func ParseLocatorMode(s string) (LocatorMode, error) {
+	switch s {
+	case "", "auto":
+		return LocatorAuto, nil
+	case "conventional":
+		return LocatorConventional, nil
+	case "manifest":
+		return LocatorManifest, nil
+	default:
+		return 0, fmt.Errorf("metadata: unknown locator mode %q (want: auto|conventional|manifest)", s)
+	}
+}
+
+// DefaultManifestPath is the forward-slash path Locator probes during auto
+// mode and reads during Manifest mode unless WithManifestPath overrides it.
+const DefaultManifestPath = ".gocell/manifest.yaml"
+
+// LocatorOption configures NewLocator / NewLocatorFS.
+type LocatorOption func(*Locator)
+
+// WithLocatorMode overrides the auto-detected mode. Use this in CI to lock
+// the locator behaviour against accidental manifest detection.
+func WithLocatorMode(m LocatorMode) LocatorOption {
+	return func(l *Locator) { l.requestedMode = m }
+}
+
+// WithManifestPath sets an explicit manifest path. Defaults to
+// .gocell/manifest.yaml.
+func WithManifestPath(p string) LocatorOption {
+	return func(l *Locator) {
+		if p != "" {
+			l.manifestPath = p
+		}
+	}
+}
+
+// Locator discovers metadata YAML files from a filesystem root and emits one
+// MetadataSource per file, sorted by path for deterministic test fixtures.
+type Locator struct {
+	fsys          fs.FS
+	root          string // on-disk root for diagnostics; "" for in-memory fsys
+	requestedMode LocatorMode
+	resolvedMode  LocatorMode
+	manifestPath  string
+	manifestSpec  *ManifestSpec // nil when resolved mode is Conventional
+}
+
+// NewLocator constructs a Locator backed by the on-disk root directory.
+func NewLocator(root string, opts ...LocatorOption) (*Locator, error) {
+	if root == "" {
+		return nil, errors.New("metadata: NewLocator requires non-empty root")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("metadata: NewLocator resolve abs root: %w", err)
+	}
+	l := &Locator{
+		fsys:         os.DirFS(abs),
+		root:         abs,
+		manifestPath: DefaultManifestPath,
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	if err := l.resolveMode(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// NewLocatorFS constructs a Locator backed by an arbitrary fs.FS. Used by
+// tests to feed fstest.MapFS fixtures and by callers that already hold an
+// fs.FS handle (e.g., embed.FS, virtual FS).
+func NewLocatorFS(fsys fs.FS, opts ...LocatorOption) (*Locator, error) {
+	if fsys == nil {
+		return nil, errors.New("metadata: NewLocatorFS requires non-nil fsys")
+	}
+	l := &Locator{
+		fsys:         fsys,
+		manifestPath: DefaultManifestPath,
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	if err := l.resolveMode(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// Mode returns the resolved locator mode (after auto-detection).
+func (l *Locator) Mode() LocatorMode { return l.resolvedMode }
+
+// FS returns the underlying fs.FS so callers that need to read file contents
+// (parser unmarshalFile) can share the same handle.
+func (l *Locator) FS() fs.FS { return l.fsys }
+
+// Root returns the absolute disk root used by the locator, or empty string
+// when the locator was constructed via NewLocatorFS.
+func (l *Locator) Root() string { return l.root }
+
+// IsExamplePath reports whether p is a YAML / Go file under the GoCell
+// monorepo's examples/ subtree. This is a conventional-layout query
+// exposed here (rather than open-coded in governance rules) so that the
+// path-prefix literal "examples/" stays inside the Locator funnel —
+// see LOCATOR-DISCOVERY-FUNNEL-01. External-repo callers that follow
+// Manifest mode without an examples/ subtree get false uniformly,
+// which is the desired behaviour for skip-style rules that key off the
+// gocell self-repo's examples/ scope.
+func IsExamplePath(p string) bool {
+	return strings.HasPrefix(filepath.ToSlash(p), "examples/")
+}
+
+// resolveMode applies the requested mode (or auto-detection) and pre-loads
+// the manifest if Manifest mode is selected.
+func (l *Locator) resolveMode() error {
+	switch l.requestedMode {
+	case LocatorConventional:
+		l.resolvedMode = LocatorConventional
+		return nil
+	case LocatorManifest:
+		spec, err := loadManifest(l.fsys, l.manifestPath)
+		if err != nil {
+			return fmt.Errorf("metadata: locator: explicit manifest mode but manifest load failed: %w", err)
+		}
+		l.manifestSpec = spec
+		l.resolvedMode = LocatorManifest
+		return nil
+	case LocatorAuto:
+		// Probe for manifest presence.
+		if _, err := fs.Stat(l.fsys, l.manifestPath); err == nil {
+			spec, lerr := loadManifest(l.fsys, l.manifestPath)
+			if lerr != nil {
+				return fmt.Errorf("metadata: locator: manifest %s detected but load failed: %w", l.manifestPath, lerr)
+			}
+			l.manifestSpec = spec
+			l.resolvedMode = LocatorManifest
+			return nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("metadata: locator: probe manifest %s: %w", l.manifestPath, err)
+		}
+		l.resolvedMode = LocatorConventional
+		return nil
+	default:
+		return fmt.Errorf("metadata: locator: invalid mode %d", l.requestedMode)
+	}
+}
+
+// Discover walks the locator root and emits one MetadataSource per metadata
+// YAML file found, sorted by Path for deterministic output.
+func (l *Locator) Discover() ([]MetadataSource, error) {
+	var sources []MetadataSource
+	var err error
+	switch l.resolvedMode {
+	case LocatorConventional:
+		sources, err = l.discoverConventional()
+	case LocatorManifest:
+		sources, err = l.discoverManifest()
+	default:
+		return nil, fmt.Errorf("metadata: locator: unresolved mode %d", l.resolvedMode)
+	}
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(sources, func(i, j int) bool { return sources[i].Path < sources[j].Path })
+	return sources, nil
+}

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -202,6 +202,9 @@ func NewLocator(root string, opts ...LocatorOption) (*Locator, error) {
 	for _, opt := range opts {
 		opt(l)
 	}
+	if err := validateManifestRelativePath(l.manifestPath); err != nil {
+		return nil, fmt.Errorf("metadata: NewLocator manifest path: %w", err)
+	}
 	if err := l.resolveMode(); err != nil {
 		return nil, err
 	}
@@ -222,10 +225,28 @@ func NewLocatorFS(fsys fs.FS, opts ...LocatorOption) (*Locator, error) {
 	for _, opt := range opts {
 		opt(l)
 	}
+	if err := validateManifestRelativePath(l.manifestPath); err != nil {
+		return nil, fmt.Errorf("metadata: NewLocatorFS manifest path: %w", err)
+	}
 	if err := l.resolveMode(); err != nil {
 		return nil, err
 	}
 	return l, nil
+}
+
+// validateManifestRelativePath rejects absolute paths and paths with ".."
+// segments. It uses the same rules as validateManifestModulePath in
+// locator_manifest.go so the two share the same security boundary.
+func validateManifestRelativePath(p string) error {
+	if filepath.IsAbs(p) {
+		return fmt.Errorf("absolute path not allowed: %s", p)
+	}
+	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
+		if seg == ".." {
+			return fmt.Errorf("path escape not allowed: %s contains parent reference", p)
+		}
+	}
+	return nil
 }
 
 // Mode returns the resolved locator mode (after auto-detection).

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -3,11 +3,11 @@
 // about GoCell's filesystem topology must flow.
 //
 // Two modes:
-//   - Conventional — walks the hardcoded 5-pattern layout
+//   - Conventional — walks the hardcoded 5-pattern layout plus 2
+//     workspace-level singletons (actors.yaml, journeys/status-board.yaml)
 //     (cells/*/cell.yaml, cells/*/slices/*/slice.yaml,
 //     contracts/{kind}/.../contract.yaml, journeys/J-*.yaml,
-//     assemblies/*/assembly.yaml, plus the two singletons
-//     actors.yaml and journeys/status-board.yaml). examples/ subtree
+//     assemblies/*/assembly.yaml). examples/ subtree
 //     follows the same patterns with one extra prefix.
 //   - Manifest — reads .gocell/manifest.yaml and walks the modules:
 //     entries it declares. Single-module entry covers Operator-SDK external
@@ -174,6 +174,10 @@ func WithLocatorMode(m LocatorMode) LocatorOption {
 
 // WithManifestPath sets an explicit manifest path. Defaults to
 // .gocell/manifest.yaml.
+//
+// Passing an empty string is a no-op (default path unchanged).
+// Non-empty paths containing ".." segments or absolute paths cause
+// NewLocator / NewLocatorFS to return an error.
 func WithManifestPath(p string) LocatorOption {
 	return func(l *Locator) {
 		if p != "" {
@@ -272,10 +276,9 @@ func (l *Locator) Root() string { return l.root }
 // monorepo's examples/ subtree. This is a conventional-layout query
 // exposed here (rather than open-coded in governance rules) so that the
 // path-prefix literal "examples/" stays inside the Locator funnel —
-// see LOCATOR-DISCOVERY-FUNNEL-01. External-repo callers that follow
-// Manifest mode without an examples/ subtree get false uniformly,
-// which is the desired behavior for skip-style rules that key off the
-// gocell self-repo's examples/ scope.
+// see LOCATOR-DISCOVERY-FUNNEL-01. External-repo callers under Manifest
+// mode without an examples/ subtree always get false; this function is
+// intended for gocell-self-repo skip-style rules.
 func IsInExamplesSubtree(p string) bool {
 	return strings.HasPrefix(filepath.ToSlash(p), "examples/")
 }
@@ -289,6 +292,10 @@ func IsInExamplesSubtree(p string) bool {
 // Returns false for examples/, Manifest-mode custom paths, and an empty
 // string. Callers (e.g. deriveAssembly) check for empty file before calling
 // and apply convention-default behavior for that case.
+//
+// Intended for internal derivation logic only (deriveAssembly entrypoint
+// heuristic); governance rules should consume AssemblyMeta.File via
+// path.Dir instead of calling this directly.
 func IsConventionalAssemblyPath(p string) bool {
 	return strings.HasPrefix(filepath.ToSlash(p), "assemblies/")
 }
@@ -311,7 +318,7 @@ func (l *Locator) resolveMode() error {
 			slog.Error("metadata: locator manifest load failed",
 				slog.String("manifest_path", l.manifestPath),
 				slog.String("requested_mode", l.requestedMode.String()),
-				slog.String("err", err.Error()))
+				slog.Any("err", err))
 			return fmt.Errorf("metadata: locator: explicit manifest mode but manifest load failed: %w", err)
 		}
 		l.manifestSpec = spec
@@ -326,7 +333,7 @@ func (l *Locator) resolveMode() error {
 				slog.Error("metadata: locator manifest load failed (auto-detected)",
 					slog.String("manifest_path", l.manifestPath),
 					slog.String("requested_mode", l.requestedMode.String()),
-					slog.String("err", lerr.Error()))
+					slog.Any("err", lerr))
 				return fmt.Errorf("metadata: locator: manifest %s detected but load failed: %w", l.manifestPath, lerr)
 			}
 			l.manifestSpec = spec
@@ -334,6 +341,10 @@ func (l *Locator) resolveMode() error {
 			l.logResolved()
 			return nil
 		} else if !errors.Is(err, fs.ErrNotExist) {
+			slog.Error("metadata: locator manifest probe failed",
+				slog.String("manifest_path", l.manifestPath),
+				slog.String("requested_mode", l.requestedMode.String()),
+				slog.Any("err", err))
 			return fmt.Errorf("metadata: locator: probe manifest %s: %w", l.manifestPath, err)
 		}
 		l.resolvedMode = LocatorConventional
@@ -355,6 +366,7 @@ func (l *Locator) logResolved() {
 	}
 	slog.Info("metadata: locator mode resolved",
 		slog.String("mode", l.resolvedMode.String()),
+		slog.String("root", l.root),
 		slog.String("manifest_path", l.manifestPath),
 		slog.Int("manifest_modules", modules),
 		slog.String("requested_mode", l.requestedMode.String()))

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -120,7 +120,10 @@ type LocatorMode int
 
 const (
 	// LocatorAuto selects Conventional unless .gocell/manifest.yaml exists at
-	// root, in which case Manifest mode is used.
+	// root, in which case Manifest mode is used. If the manifest file is found
+	// but fails to parse, Locator returns an error and does NOT fall back to
+	// Conventional mode. Use WithLocatorMode(LocatorConventional) to bypass
+	// manifest detection explicitly.
 	LocatorAuto LocatorMode = iota
 	// LocatorConventional walks the hardcoded 5-pattern layout. Used when no
 	// manifest file is present, or explicitly via WithLocatorMode.

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -101,6 +101,14 @@ func (k SourceKind) String() string {
 // happen to follow conventional layout). When the locator cannot derive
 // CellID (manifest with non-conventional layout), CellID stays empty —
 // parser will then require slice.yaml to declare belongsToCell explicitly.
+//
+// To avoid empty CellID in manifest mode, callers have two options:
+//
+//	(a) Read the `id` field from the corresponding cell.yaml (already parsed
+//	    into ProjectMeta.Cells by Parser — use ProjectMeta.CellForSlice to
+//	    derive it after a full parse pass).
+//	(b) Declare `belongsToCell` explicitly in each slice.yaml; Parser will
+//	    propagate that value and governance rules will validate consistency.
 type MetadataSource struct {
 	Path   string
 	Kind   SourceKind
@@ -260,7 +268,7 @@ func (l *Locator) FS() fs.FS { return l.fsys }
 // when the locator was constructed via NewLocatorFS.
 func (l *Locator) Root() string { return l.root }
 
-// IsExamplePath reports whether p is a YAML / Go file under the GoCell
+// IsInExamplesSubtree reports whether p is a YAML / Go file under the GoCell
 // monorepo's examples/ subtree. This is a conventional-layout query
 // exposed here (rather than open-coded in governance rules) so that the
 // path-prefix literal "examples/" stays inside the Locator funnel —
@@ -268,7 +276,7 @@ func (l *Locator) Root() string { return l.root }
 // Manifest mode without an examples/ subtree get false uniformly,
 // which is the desired behavior for skip-style rules that key off the
 // gocell self-repo's examples/ scope.
-func IsExamplePath(p string) bool {
+func IsInExamplesSubtree(p string) bool {
 	return strings.HasPrefix(filepath.ToSlash(p), "examples/")
 }
 

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -158,7 +158,7 @@ const DefaultManifestPath = ".gocell/manifest.yaml"
 type LocatorOption func(*Locator)
 
 // WithLocatorMode overrides the auto-detected mode. Use this in CI to lock
-// the locator behaviour against accidental manifest detection.
+// the locator behavior against accidental manifest detection.
 func WithLocatorMode(m LocatorMode) LocatorOption {
 	return func(l *Locator) { l.requestedMode = m }
 }
@@ -244,7 +244,7 @@ func (l *Locator) Root() string { return l.root }
 // path-prefix literal "examples/" stays inside the Locator funnel —
 // see LOCATOR-DISCOVERY-FUNNEL-01. External-repo callers that follow
 // Manifest mode without an examples/ subtree get false uniformly,
-// which is the desired behaviour for skip-style rules that key off the
+// which is the desired behavior for skip-style rules that key off the
 // gocell self-repo's examples/ scope.
 func IsExamplePath(p string) bool {
 	return strings.HasPrefix(filepath.ToSlash(p), "examples/")

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -272,6 +272,19 @@ func IsExamplePath(p string) bool {
 	return strings.HasPrefix(filepath.ToSlash(p), "examples/")
 }
 
+// IsConventionalAssemblyPath reports whether p is an assembly YAML file under
+// the conventional assemblies/<id>/ directory (e.g.
+// "assemblies/corebundle/assembly.yaml"). Exposed here so the "assemblies/"
+// path-prefix literal stays inside the Locator funnel —
+// see LOCATOR-DISCOVERY-FUNNEL-01.A2a.
+//
+// Returns false for examples/, Manifest-mode custom paths, and an empty
+// string. Callers (e.g. deriveAssembly) check for empty file before calling
+// and apply convention-default behavior for that case.
+func IsConventionalAssemblyPath(p string) bool {
+	return strings.HasPrefix(filepath.ToSlash(p), "assemblies/")
+}
+
 // resolveMode applies the requested mode (or auto-detection) and pre-loads
 // the manifest if Manifest mode is selected. Emits a structured slog.Info
 // once the mode is decided so CI logs make the active layout explicit (CI

--- a/kernel/metadata/locator.go
+++ b/kernel/metadata/locator.go
@@ -39,6 +39,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -251,38 +252,70 @@ func IsExamplePath(p string) bool {
 }
 
 // resolveMode applies the requested mode (or auto-detection) and pre-loads
-// the manifest if Manifest mode is selected.
+// the manifest if Manifest mode is selected. Emits a structured slog.Info
+// once the mode is decided so CI logs make the active layout explicit (CI
+// debugging value when external-repo runs silently switch into manifest
+// mode); emits slog.Error before returning a manifest-load failure so
+// operators get a structured record alongside the wrapped error.
 func (l *Locator) resolveMode() error {
 	switch l.requestedMode {
 	case LocatorConventional:
 		l.resolvedMode = LocatorConventional
+		l.logResolved()
 		return nil
 	case LocatorManifest:
 		spec, err := loadManifest(l.fsys, l.manifestPath)
 		if err != nil {
+			slog.Error("metadata: locator manifest load failed",
+				slog.String("manifest_path", l.manifestPath),
+				slog.String("requested_mode", l.requestedMode.String()),
+				slog.String("err", err.Error()))
 			return fmt.Errorf("metadata: locator: explicit manifest mode but manifest load failed: %w", err)
 		}
 		l.manifestSpec = spec
 		l.resolvedMode = LocatorManifest
+		l.logResolved()
 		return nil
 	case LocatorAuto:
 		// Probe for manifest presence.
 		if _, err := fs.Stat(l.fsys, l.manifestPath); err == nil {
 			spec, lerr := loadManifest(l.fsys, l.manifestPath)
 			if lerr != nil {
+				slog.Error("metadata: locator manifest load failed (auto-detected)",
+					slog.String("manifest_path", l.manifestPath),
+					slog.String("requested_mode", l.requestedMode.String()),
+					slog.String("err", lerr.Error()))
 				return fmt.Errorf("metadata: locator: manifest %s detected but load failed: %w", l.manifestPath, lerr)
 			}
 			l.manifestSpec = spec
 			l.resolvedMode = LocatorManifest
+			l.logResolved()
 			return nil
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("metadata: locator: probe manifest %s: %w", l.manifestPath, err)
 		}
 		l.resolvedMode = LocatorConventional
+		l.logResolved()
 		return nil
 	default:
 		return fmt.Errorf("metadata: locator: invalid mode %d", l.requestedMode)
 	}
+}
+
+// logResolved emits a single structured slog.Info noting the active
+// locator mode. Aligns with the observability rule "Info: 生命周期" —
+// surfaces the layout decision in CI logs so external-repo operators
+// can confirm whether manifest detection succeeded.
+func (l *Locator) logResolved() {
+	modules := 0
+	if l.manifestSpec != nil {
+		modules = len(l.manifestSpec.Modules)
+	}
+	slog.Info("metadata: locator mode resolved",
+		slog.String("mode", l.resolvedMode.String()),
+		slog.String("manifest_path", l.manifestPath),
+		slog.Int("manifest_modules", modules),
+		slog.String("requested_mode", l.requestedMode.String()))
 }
 
 // Discover walks the locator root and emits one MetadataSource per metadata

--- a/kernel/metadata/locator_conventional.go
+++ b/kernel/metadata/locator_conventional.go
@@ -58,7 +58,7 @@ func classifyConventionalPath(path string) (MetadataSource, bool) {
 	if cellID, ok := matchCellPath(path); ok {
 		return MetadataSource{Path: path, Kind: SourceCell, CellID: cellID}, true
 	}
-	if cellID, _, ok := matchSlicePath(path); ok {
+	if cellID, ok := matchSlicePath(path); ok {
 		return MetadataSource{Path: path, Kind: SourceSlice, CellID: cellID}, true
 	}
 	if _, ok := matchContractPath(path); ok {
@@ -93,16 +93,19 @@ func matchCellPath(path string) (string, bool) {
 }
 
 // matchSlicePath matches cells/*/slices/*/slice.yaml and
-// examples/*/cells/*/slices/*/slice.yaml. Returns (cellID, sliceID).
-func matchSlicePath(path string) (cellDir, sliceDir string, ok bool) {
+// examples/*/cells/*/slices/*/slice.yaml. Returns the cellID (== parent
+// cell directory name) when matched. sliceID is intentionally not returned
+// — parser derives the slice directory directly via path.Base(path.Dir())
+// since slice.ID is the YAML-declared id, not a path-derived identity.
+func matchSlicePath(path string) (cellDir string, ok bool) {
 	parts := splitConventionalPath(path)
 	if len(parts) == 5 && parts[0] == "cells" && parts[2] == "slices" && parts[4] == "slice.yaml" {
-		return parts[1], parts[3], true
+		return parts[1], true
 	}
 	if len(parts) == 7 && parts[0] == "examples" && parts[2] == "cells" && parts[4] == "slices" && parts[6] == "slice.yaml" {
-		return parts[3], parts[5], true
+		return parts[3], true
 	}
-	return "", "", false
+	return "", false
 }
 
 // matchContractPath matches contracts/{kind}/{...}/contract.yaml and

--- a/kernel/metadata/locator_conventional.go
+++ b/kernel/metadata/locator_conventional.go
@@ -31,6 +31,13 @@ func (l *Locator) discoverConventional() ([]MetadataSource, error) {
 		if walkErr != nil {
 			return walkErr
 		}
+		// Explicitly skip symlinks regardless of whether the underlying fs.FS
+		// follows them. This avoids traversal through unexpected filesystem
+		// topology (e.g. symlink loops) that os.DirFS does not prevent.
+		// Mirrors the same guard in manifestGlobWalkFn.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
 		if d.IsDir() {
 			return nil
 		}

--- a/kernel/metadata/locator_conventional.go
+++ b/kernel/metadata/locator_conventional.go
@@ -1,0 +1,157 @@
+// locator_conventional.go — Conventional layout walker for Locator.
+//
+// This file is the funnel target for LOCATOR-DISCOVERY-FUNNEL-01 archtest:
+//   - A1 (caller allowlist on fs.WalkDir): the only fs.WalkDir call in
+//     kernel/metadata/** outside locator_manifest.go must reside here, inside
+//     Locator.discoverConventional.
+//   - A2 (form-uniqueness on path-prefix comparison): hardcoded path tokens
+//     {cells, contracts, journeys, assemblies, examples} appear only inside
+//     this file (and locator_manifest.go for default include patterns).
+//
+// The 5 path-pattern matchers were extracted verbatim from the original
+// kernel/metadata/parser.go (matchCellYAML / matchSliceYAML / matchContractYAML
+// / matchJourneyYAML / matchAssemblyYAML and their *FromPath siblings) when
+// the locator funnel was introduced (M1 of the Operator-SDK + Workspace dual
+// mode work — see ADR 202605281200).
+
+package metadata
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// discoverConventional walks the on-disk root applying the hardcoded 5-pattern
+// match. examples/ subtree is included via the same patterns with an extra
+// "examples/<id>/" prefix per pattern.
+func (l *Locator) discoverConventional() ([]MetadataSource, error) {
+	var out []MetadataSource
+	walkErr := fs.WalkDir(l.fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		clean := filepath.ToSlash(p)
+		if src, ok := classifyConventionalPath(clean); ok {
+			out = append(out, src)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return out, nil
+}
+
+// classifyConventionalPath inspects a forward-slash path against the 5
+// conventional patterns plus the 2 singletons. Returns the matching
+// MetadataSource and true when the path is a recognized metadata file;
+// returns the zero value and false otherwise.
+//
+// LOCATOR-DISCOVERY-FUNNEL-01 A2 allowlist: the path-token literals
+// {cells, contracts, journeys, assemblies, examples} appear only inside
+// the match*Path helpers below and inside this function's singleton checks.
+func classifyConventionalPath(path string) (MetadataSource, bool) {
+	if cellID, ok := matchCellPath(path); ok {
+		return MetadataSource{Path: path, Kind: SourceCell, CellID: cellID}, true
+	}
+	if cellID, _, ok := matchSlicePath(path); ok {
+		return MetadataSource{Path: path, Kind: SourceSlice, CellID: cellID}, true
+	}
+	if _, ok := matchContractPath(path); ok {
+		return MetadataSource{Path: path, Kind: SourceContract}, true
+	}
+	if _, ok := matchJourneyPath(path); ok {
+		return MetadataSource{Path: path, Kind: SourceJourney}, true
+	}
+	if matchAssemblyPath(path) {
+		return MetadataSource{Path: path, Kind: SourceAssembly}, true
+	}
+	if path == "actors.yaml" {
+		return MetadataSource{Path: path, Kind: SourceActors}, true
+	}
+	if path == "journeys/status-board.yaml" {
+		return MetadataSource{Path: path, Kind: SourceStatusBoard}, true
+	}
+	return MetadataSource{}, false
+}
+
+// matchCellPath matches cells/*/cell.yaml and examples/*/cells/*/cell.yaml.
+// Returns the cell directory name (== conventional cell ID) when matched.
+func matchCellPath(path string) (string, bool) {
+	parts := splitConventionalPath(path)
+	if len(parts) == 3 && parts[0] == "cells" && parts[2] == "cell.yaml" {
+		return parts[1], true
+	}
+	if len(parts) == 5 && parts[0] == "examples" && parts[2] == "cells" && parts[4] == "cell.yaml" {
+		return parts[3], true
+	}
+	return "", false
+}
+
+// matchSlicePath matches cells/*/slices/*/slice.yaml and
+// examples/*/cells/*/slices/*/slice.yaml. Returns (cellID, sliceID).
+func matchSlicePath(path string) (cellDir, sliceDir string, ok bool) {
+	parts := splitConventionalPath(path)
+	if len(parts) == 5 && parts[0] == "cells" && parts[2] == "slices" && parts[4] == "slice.yaml" {
+		return parts[1], parts[3], true
+	}
+	if len(parts) == 7 && parts[0] == "examples" && parts[2] == "cells" && parts[4] == "slices" && parts[6] == "slice.yaml" {
+		return parts[3], parts[5], true
+	}
+	return "", "", false
+}
+
+// matchContractPath matches contracts/{kind}/{...}/contract.yaml and
+// examples/*/contracts/{kind}/{...}/contract.yaml. Returns the contract
+// directory (forward-slash, no trailing slash, no contract.yaml suffix).
+func matchContractPath(path string) (string, bool) {
+	parts := splitConventionalPath(path)
+	if len(parts) >= 5 && parts[0] == "contracts" && parts[len(parts)-1] == "contract.yaml" {
+		return strings.Join(parts[:len(parts)-1], "/"), true
+	}
+	if len(parts) >= 7 && parts[0] == "examples" && parts[2] == "contracts" && parts[len(parts)-1] == "contract.yaml" {
+		return strings.Join(parts[:len(parts)-1], "/"), true
+	}
+	return "", false
+}
+
+// matchJourneyPath matches journeys/J-*.yaml and examples/*/journeys/J-*.yaml.
+// Returns the journey ID (filename minus the .yaml extension).
+func matchJourneyPath(path string) (string, bool) {
+	parts := splitConventionalPath(path)
+	var name string
+	switch {
+	case len(parts) == 2 && parts[0] == "journeys":
+		name = parts[1]
+	case len(parts) == 4 && parts[0] == "examples" && parts[2] == "journeys":
+		name = parts[3]
+	default:
+		return "", false
+	}
+	if !strings.HasPrefix(name, "J-") || !strings.HasSuffix(name, ".yaml") {
+		return "", false
+	}
+	return strings.TrimSuffix(name, ".yaml"), true
+}
+
+// matchAssemblyPath matches assemblies/*/assembly.yaml and
+// examples/*/assembly.yaml.
+func matchAssemblyPath(path string) bool {
+	parts := splitConventionalPath(path)
+	if len(parts) == 3 && parts[0] == "assemblies" && parts[2] == "assembly.yaml" {
+		return true
+	}
+	return len(parts) == 3 && parts[0] == "examples" && parts[2] == "assembly.yaml"
+}
+
+// splitConventionalPath splits a forward-slash-separated path into its
+// segments after normalising slashes. Used by the conventional matchers
+// only.
+func splitConventionalPath(path string) []string {
+	clean := filepath.ToSlash(path)
+	return strings.Split(clean, "/")
+}

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -102,7 +102,7 @@ func loadManifest(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := validateManifestSpec(manifestPath, spec); err != nil {
+	if err := validateManifestSpec(fsys, manifestPath, spec); err != nil {
 		return nil, err
 	}
 	return spec, nil
@@ -134,7 +134,7 @@ func readManifestSpec(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
 // validateManifestSpec applies the schema-version + module-path + singleton
 // invariants. Split out from loadManifest to keep cognitive complexity below
 // the kernel/-layer 15 budget.
-func validateManifestSpec(manifestPath string, spec *ManifestSpec) error {
+func validateManifestSpec(fsys fs.FS, manifestPath string, spec *ManifestSpec) error {
 	if spec.Version != manifestSchemaVersion {
 		return fmt.Errorf("manifest %s: unsupported version %q (want %q)",
 			manifestPath, spec.Version, manifestSchemaVersion)
@@ -145,11 +145,12 @@ func validateManifestSpec(manifestPath string, spec *ManifestSpec) error {
 	if len(spec.Modules) > maxManifestModules {
 		return fmt.Errorf(
 			"manifest %s: too many modules (count=%d limit=%d) — risk WalkDir amplification",
-			manifestPath, len(spec.Modules), maxManifestModules)
+			manifestPath, len(spec.Modules), maxManifestModules,
+		)
 	}
 	seenPaths := make(map[string]int)
 	for i, m := range spec.Modules {
-		if err := validateManifestModuleEntry(manifestPath, i, m, seenPaths); err != nil {
+		if err := validateManifestModuleEntry(fsys, manifestPath, i, m, seenPaths); err != nil {
 			return err
 		}
 	}
@@ -157,9 +158,9 @@ func validateManifestSpec(manifestPath string, spec *ManifestSpec) error {
 }
 
 // validateManifestModuleEntry applies all per-module invariants: path
-// safety (no absolute / no parent escape), duplicate detection, singleton
-// uniqueness, and exclude/include glob safety.
-func validateManifestModuleEntry(manifestPath string, i int, m ManifestModule, seenPaths map[string]int) error {
+// safety (no absolute / no parent escape), directory existence, duplicate
+// detection, singleton uniqueness, and exclude/include glob safety.
+func validateManifestModuleEntry(fsys fs.FS, manifestPath string, i int, m ManifestModule, seenPaths map[string]int) error {
 	if err := validateManifestModulePath(m.Path); err != nil {
 		return fmt.Errorf("manifest %s: modules[%d].path: %w", manifestPath, i, err)
 	}
@@ -169,10 +170,35 @@ func validateManifestModuleEntry(manifestPath string, i int, m ManifestModule, s
 			manifestPath, i, m.Path, dup)
 	}
 	seenPaths[normPath] = i
+	if err := validateManifestModuleDir(fsys, manifestPath, i, normPath); err != nil {
+		return err
+	}
 	if err := validateManifestSingleton(manifestPath, i, m); err != nil {
 		return err
 	}
 	return validateManifestGlobs(manifestPath, i, m)
+}
+
+// validateManifestModuleDir checks that the module path exists as a directory
+// in fsys. The special path "." (workspace root) is always considered valid
+// because fs.FS roots do not expose themselves as a nameable directory entry.
+func validateManifestModuleDir(fsys fs.FS, manifestPath string, i int, normPath string) error {
+	if normPath == "." {
+		return nil
+	}
+	info, err := fs.Stat(fsys, normPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("manifest %s: modules[%d].path %q does not exist (or is not a directory)",
+				manifestPath, i, normPath)
+		}
+		return fmt.Errorf("manifest %s: modules[%d].path %q stat: %w", manifestPath, i, normPath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("manifest %s: modules[%d].path %q does not exist (or is not a directory)",
+			manifestPath, i, normPath)
+	}
+	return nil
 }
 
 // validateManifestGlobs rejects glob patterns in includes/excludes that
@@ -278,10 +304,15 @@ func (l *Locator) discoverManifest() ([]MetadataSource, error) {
 
 // manifestEmission groups one set of glob patterns by destination
 // SourceKind plus an optional cell-ID derivation strategy.
+//
+// userDeclared is true when the patterns came from the manifest's explicit
+// includes: field. When false (defaults apply), a zero-match is only a
+// slog.Warn; when true, a zero-match is a hard error (typo guard — F2).
 type manifestEmission struct {
-	patterns   []string
-	kind       SourceKind
-	deriveCell func(p string) string
+	patterns     []string
+	kind         SourceKind
+	deriveCell   func(p string) string
+	userDeclared bool // true when patterns came from explicit includes:
 }
 
 // manifestModulePlan packages the per-emission plan + the singleton paths +
@@ -317,39 +348,44 @@ func (l *Locator) discoverManifestModule(mod ManifestModule, allowSingletons boo
 // produces the per-emission plan executed by discoverManifestPlanEmissions /
 // discoverManifestPlanSingletons.
 //
-// When the module does not declare any excludes, the ADR-promised
-// "generated/**" exclude is applied so codegen output never silently
-// re-enters the metadata scan. Users who genuinely want generated/ in
-// scope must declare a non-empty Excludes list (the default does not fire).
+// "generated/**" is always appended to the effective exclude list (additive,
+// not replacing). This ensures codegen output never silently re-enters the
+// metadata scan regardless of whether the user declared explicit excludes.
+// Users who explicitly declare excludes: ["fixtures/**"] end up with an
+// effective set of {"fixtures/**", "generated/**"}.
 func buildManifestModulePlan(mod ManifestModule, allowSingletons bool) manifestModulePlan {
+	userHasIncludes := !manifestIncludesEmpty(mod.Includes)
 	includes := mod.Includes
-	if manifestIncludesEmpty(includes) {
+	if !userHasIncludes {
 		includes = defaultManifestIncludes()
 	}
 	base := path.Clean(mod.Path)
 	if base == "." {
 		base = ""
 	}
-	excludes := mod.Excludes
-	if len(excludes) == 0 {
-		excludes = []string{"generated/**"}
-	}
+	excludes := appendGeneratedExclude(mod.Excludes)
 	plan := manifestModulePlan{
 		base:            base,
 		excludes:        compileManifestExcludes(base, excludes),
 		allowSingletons: allowSingletons,
 		emissions: []manifestEmission{
-			{patterns: includes.Cells, kind: SourceCell, deriveCell: func(p string) string {
-				id, _ := matchCellPath(stripBase(p, base))
-				return id
-			}},
-			{patterns: includes.Slices, kind: SourceSlice, deriveCell: func(p string) string {
-				cellID, _ := matchSlicePath(stripBase(p, base))
-				return cellID
-			}},
-			{patterns: includes.Contracts, kind: SourceContract},
-			{patterns: includes.Journeys, kind: SourceJourney},
-			{patterns: includes.Assemblies, kind: SourceAssembly},
+			{
+				patterns: includes.Cells, kind: SourceCell, userDeclared: userHasIncludes,
+				deriveCell: func(p string) string {
+					id, _ := matchCellPath(stripBase(p, base))
+					return id
+				},
+			},
+			{
+				patterns: includes.Slices, kind: SourceSlice, userDeclared: userHasIncludes,
+				deriveCell: func(p string) string {
+					cellID, _ := matchSlicePath(stripBase(p, base))
+					return cellID
+				},
+			},
+			{patterns: includes.Contracts, kind: SourceContract, userDeclared: userHasIncludes},
+			{patterns: includes.Journeys, kind: SourceJourney, userDeclared: userHasIncludes},
+			{patterns: includes.Assemblies, kind: SourceAssembly, userDeclared: userHasIncludes},
 		},
 	}
 	if allowSingletons {
@@ -361,6 +397,22 @@ func buildManifestModulePlan(mod ManifestModule, allowSingletons bool) manifestM
 		}
 	}
 	return plan
+}
+
+// appendGeneratedExclude returns a new slice with "generated/**" appended if
+// it is not already present. This is always additive — existing user-declared
+// excludes are preserved (F13).
+func appendGeneratedExclude(excludes []string) []string {
+	const genExclude = "generated/**"
+	for _, e := range excludes {
+		if e == genExclude {
+			return excludes
+		}
+	}
+	result := make([]string, len(excludes)+1)
+	copy(result, excludes)
+	result[len(excludes)] = genExclude
+	return result
 }
 
 // discoverManifestPlanEmissions runs each emission's glob expansion and
@@ -383,35 +435,60 @@ func (l *Locator) discoverManifestPlanEmissions(plan manifestModulePlan) ([]Meta
 // applicable. Split out so discoverManifestPlanEmissions itself stays a
 // straight three-line walk under the kernel/-layer 15-complexity budget.
 //
-// A glob pattern that matches zero files emits a structured slog.Warn —
-// zero matches is almost always a manifest typo (e.g. `cell.yml` instead
-// of `cell.yaml`) and silent skipping would hide the misconfiguration
-// behind a "PASS, but 0 cells found" outcome.
+// For user-declared patterns (em.userDeclared == true): zero matches returns
+// a hard error — this is almost always a manifest typo (e.g. "cell.yml"
+// instead of "cell.yaml") and silent skipping would hide misconfiguration
+// behind a "PASS, but 0 cells found" outcome (F2 fail-closed).
+//
+// For default patterns (em.userDeclared == false): zero matches emits only
+// a structured slog.Warn for workspaces that legitimately omit certain source
+// kinds.
 func (l *Locator) discoverEmission(base string, excludes *manifestExcludeSet, em manifestEmission) ([]MetadataSource, error) {
 	var out []MetadataSource
 	for _, g := range em.patterns {
-		matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g))
+		emitted, err := l.discoverEmissionPattern(base, g, excludes, em)
 		if err != nil {
-			return nil, fmt.Errorf("glob %s: %w", g, err)
+			return nil, err
 		}
-		emitted := 0
-		for _, m := range matches {
-			if excludes.match(m) {
-				continue
-			}
-			src := MetadataSource{Path: m, Kind: em.kind}
-			if em.deriveCell != nil {
-				src.CellID = em.deriveCell(m)
-			}
-			out = append(out, src)
-			emitted++
+		out = append(out, emitted...)
+	}
+	return out, nil
+}
+
+// discoverEmissionPattern handles a single glob pattern within an emission,
+// split from discoverEmission to keep cognitive complexity within budget.
+func (l *Locator) discoverEmissionPattern(
+	base, g string,
+	excludes *manifestExcludeSet,
+	em manifestEmission,
+) ([]MetadataSource, error) {
+	matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g))
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", g, err)
+	}
+	var out []MetadataSource
+	for _, m := range matches {
+		if excludes.match(m) {
+			continue
 		}
-		if emitted == 0 {
-			slog.Warn("metadata: locator manifest include pattern matched zero files",
-				slog.String("pattern", g),
-				slog.String("kind", em.kind.String()),
-				slog.String("module_base", base))
+		src := MetadataSource{Path: m, Kind: em.kind}
+		if em.deriveCell != nil {
+			src.CellID = em.deriveCell(m)
 		}
+		out = append(out, src)
+	}
+	if len(out) == 0 {
+		if em.userDeclared {
+			return nil, fmt.Errorf(
+				"manifest module %q include pattern %q (kind=%s) matched zero files"+
+					" — likely a typo (e.g. cell.yml vs cell.yaml)",
+				base, g, em.kind.String(),
+			)
+		}
+		slog.Warn("metadata: locator manifest include pattern matched zero files",
+			slog.String("pattern", g),
+			slog.String("kind", em.kind.String()),
+			slog.String("module_base", base))
 	}
 	return out, nil
 }
@@ -530,9 +607,26 @@ func (es *manifestExcludeSet) match(filePath string) bool {
 
 // matchManifestGlob expands a glob pattern against fsys via WalkDir. Returns
 // sorted matches.
+//
+// To avoid O(modules × total_files) WalkDir amplification, the walk is
+// started from the longest fixed prefix before the first wildcard segment
+// ("*" or "**"). For example, "cells/*/cell.yaml" starts from "cells/", so
+// only the cells/ subtree is scanned. Patterns that begin with a wildcard
+// (e.g. "**/cell.yaml" or "*/cell.yaml") fall back to walking from ".".
+// When the computed prefix does not exist in fsys, an empty match list is
+// returned without error.
 func matchManifestGlob(fsys fs.FS, pattern string) ([]string, error) {
+	root := manifestGlobFixedPrefix(pattern)
+	if root != "." {
+		if _, err := fs.Stat(fsys, root); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, err
+		}
+	}
 	var matches []string
-	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+	err := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -549,6 +643,55 @@ func matchManifestGlob(fsys fs.FS, pattern string) ([]string, error) {
 	}
 	sort.Strings(matches)
 	return matches, nil
+}
+
+// manifestGlobFixedPrefix extracts the longest fixed (non-wildcard) path
+// prefix from a glob pattern. It returns "." when the pattern begins with
+// a wildcard segment or when there is no fixed directory prefix.
+//
+// Examples:
+//
+//	"cells/*/cell.yaml"          → "cells"
+//	"contracts/**/contract.yaml" → "contracts"
+//	"**/cell.yaml"               → "."
+//	"*/cell.yaml"                → "."
+//	"actors.yaml"                → "." (single-segment file at root, no dir prefix)
+//	"cells/foo/bar/cell.yaml"    → "cells/foo/bar"
+func manifestGlobFixedPrefix(pattern string) string {
+	segs := strings.Split(pattern, "/")
+	var fixed []string
+	for _, seg := range segs {
+		if strings.ContainsAny(seg, "*?[") {
+			break
+		}
+		fixed = append(fixed, seg)
+	}
+	// No fixed directory prefix (pattern starts with wildcard, or the only
+	// fixed segment is the final filename at the root like "actors.yaml").
+	// In the latter case, fixed equals all segments (no wildcard at all) —
+	// we must not use the last segment as a directory root because it is a
+	// file, not a directory. Drop the last segment if it looks like a file.
+	//
+	// Heuristic: if the last fixed segment contains "." it is likely a
+	// filename; drop it. The remaining prefix is what to walk from.
+	//
+	// When no wildcards: walk from the parent of the literal file path so we
+	// don't need a separate Stat-and-match path.
+	hasWild := false
+	for _, seg := range segs {
+		if strings.ContainsAny(seg, "*?[") {
+			hasWild = true
+			break
+		}
+	}
+	if !hasWild && len(fixed) > 0 {
+		// Literal path (no wildcards) — walk parent directory.
+		fixed = fixed[:len(fixed)-1]
+	}
+	if len(fixed) == 0 {
+		return "."
+	}
+	return strings.Join(fixed, "/")
 }
 
 // matchManifestPattern matches a glob with "*" (single-segment wildcard) and

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -778,6 +778,17 @@ func (es *manifestExcludeSet) matchDir(dir string) bool {
 // The number of matches is capped at maxManifestMatchesPerGlob to prevent
 // unbounded WalkDir amplification; exceeding the cap aborts with an error.
 func matchManifestGlob(fsys fs.FS, pattern string, excludes *manifestExcludeSet) ([]string, error) {
+	return matchManifestGlobCapped(fsys, pattern, excludes, maxManifestMatchesPerGlob)
+}
+
+// matchManifestGlobCapped is matchManifestGlob with an injectable match cap.
+// Production always passes maxManifestMatchesPerGlob via matchManifestGlob;
+// the parameter exists so tests can exercise the cap-exceeded path with a
+// small value instead of materializing 50 000 files in a MapFS (which would
+// blow the per-test slowgate budget).
+func matchManifestGlobCapped(
+	fsys fs.FS, pattern string, excludes *manifestExcludeSet, maxMatches int,
+) ([]string, error) {
 	if pattern == "" {
 		return nil, nil
 	}
@@ -790,7 +801,7 @@ func matchManifestGlob(fsys fs.FS, pattern string, excludes *manifestExcludeSet)
 	}
 	var matches []string
 	count := 0
-	if err := fs.WalkDir(fsys, root, manifestGlobWalkFn(pattern, excludes, &matches, &count)); err != nil {
+	if err := fs.WalkDir(fsys, root, manifestGlobWalkFn(pattern, excludes, &matches, &count, maxMatches)); err != nil {
 		return nil, err
 	}
 	sort.Strings(matches)
@@ -823,8 +834,9 @@ func manifestGlobWalkRoot(fsys fs.FS, pattern string) (string, bool, error) {
 // (collectEmissionPattern) does a post-walk file-level check.
 //
 // count is incremented for each appended match; when it would exceed
-// maxManifestMatchesPerGlob the walk is aborted with a descriptive error.
-func manifestGlobWalkFn(pattern string, excludes *manifestExcludeSet, matches *[]string, count *int) fs.WalkDirFunc {
+// maxMatches the walk is aborted with a descriptive error. Production passes
+// maxManifestMatchesPerGlob (via matchManifestGlob); tests inject a small cap.
+func manifestGlobWalkFn(pattern string, excludes *manifestExcludeSet, matches *[]string, count *int, maxMatches int) fs.WalkDirFunc {
 	return func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -845,11 +857,11 @@ func manifestGlobWalkFn(pattern string, excludes *manifestExcludeSet, matches *[
 		}
 		if matchManifestPattern(pattern, p) {
 			*count++
-			if *count > maxManifestMatchesPerGlob {
+			if *count > maxMatches {
 				return fmt.Errorf(
 					"metadata: glob %q exceeded match cap (limit=%d)"+
 						" — workspace may be too large or pattern too broad",
-					pattern, maxManifestMatchesPerGlob,
+					pattern, maxMatches,
 				)
 			}
 			*matches = append(*matches, p)

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -1,0 +1,373 @@
+// locator_manifest.go — Manifest-driven layout walker for Locator.
+//
+// Reads .gocell/manifest.yaml (buf v2 style), expands include globs against
+// each module path, and emits MetadataSources. The same manifest expresses
+// both single-module (Operator-SDK external repo) and multi-module
+// (Workspace aggregation) layouts.
+//
+// ref: bufbuild/buf v2 buf.yaml modules: schema.
+//
+// This file is part of the LOCATOR-DISCOVERY-FUNNEL-01 allowlist (see
+// locator_conventional.go header). Path-prefix literals and fs.WalkDir
+// callsites are permitted here because Locator's funnel boundary is
+// kernel/metadata/locator*.go.
+
+package metadata
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ManifestSpec is the parsed .gocell/manifest.yaml file.
+type ManifestSpec struct {
+	Version string           `yaml:"version"`
+	Modules []ManifestModule `yaml:"modules"`
+}
+
+// ManifestModule is a single module entry inside ManifestSpec.Modules.
+//
+// Path is required, must be relative, and must not escape outside the
+// manifest directory (no ".." segments, no absolute paths).
+//
+// Includes carries glob patterns per metadata source kind. Empty Includes
+// falls back to the conventional 5-pattern defaults.
+//
+// Excludes are applied across all source kinds within this module.
+type ManifestModule struct {
+	Path     string           `yaml:"path"`
+	Includes ManifestIncludes `yaml:"includes"`
+	Excludes []string         `yaml:"excludes"`
+}
+
+// ManifestIncludes maps each metadata source kind to one or more glob
+// patterns. Globs are resolved relative to the owning ManifestModule.Path.
+// Patterns support "*" (single segment) and "**" (any number of segments).
+//
+// Actors and StatusBoard are workspace-level singletons and may only be
+// declared on Modules[0] (validated by loadManifest).
+type ManifestIncludes struct {
+	Cells       []string `yaml:"cells"`
+	Slices      []string `yaml:"slices"`
+	Contracts   []string `yaml:"contracts"`
+	Journeys    []string `yaml:"journeys"`
+	Assemblies  []string `yaml:"assemblies"`
+	Actors      string   `yaml:"actors"`
+	StatusBoard string   `yaml:"statusBoard"`
+}
+
+// defaultManifestIncludes mirrors the conventional 5-pattern layout. Used
+// when a module omits the includes: field.
+func defaultManifestIncludes() ManifestIncludes {
+	return ManifestIncludes{
+		Cells:       []string{"cells/*/cell.yaml"},
+		Slices:      []string{"cells/*/slices/*/slice.yaml"},
+		Contracts:   []string{"contracts/**/contract.yaml"},
+		Journeys:    []string{"journeys/J-*.yaml"},
+		Assemblies:  []string{"assemblies/*/assembly.yaml"},
+		Actors:      "actors.yaml",
+		StatusBoard: "journeys/status-board.yaml",
+	}
+}
+
+const manifestSchemaVersion = "v1"
+
+// loadManifest reads and decodes the manifest at manifestPath from fsys,
+// validating the schema version, module path safety, and singleton
+// uniqueness invariants.
+func loadManifest(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
+	data, err := fs.ReadFile(fsys, manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", manifestPath, err)
+	}
+	var spec ManifestSpec
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&spec); err != nil {
+		return nil, fmt.Errorf("decode manifest %s: %w", manifestPath, err)
+	}
+	if spec.Version != manifestSchemaVersion {
+		return nil, fmt.Errorf("manifest %s: unsupported version %q (want %q)",
+			manifestPath, spec.Version, manifestSchemaVersion)
+	}
+	if len(spec.Modules) == 0 {
+		return nil, fmt.Errorf("manifest %s: at least one module entry required", manifestPath)
+	}
+	seenPaths := make(map[string]int)
+	for i, m := range spec.Modules {
+		if err := validateManifestModulePath(m.Path); err != nil {
+			return nil, fmt.Errorf("manifest %s: modules[%d].path: %w", manifestPath, i, err)
+		}
+		normPath := path.Clean(m.Path)
+		if dup, ok := seenPaths[normPath]; ok {
+			return nil, fmt.Errorf("manifest %s: modules[%d].path %q duplicates modules[%d]",
+				manifestPath, i, m.Path, dup)
+		}
+		seenPaths[normPath] = i
+		if i > 0 {
+			if m.Includes.Actors != "" {
+				return nil, fmt.Errorf("manifest %s: modules[%d].includes.actors set; "+
+					"actors.yaml is a workspace-level singleton and may only be declared on modules[0]",
+					manifestPath, i)
+			}
+			if m.Includes.StatusBoard != "" {
+				return nil, fmt.Errorf("manifest %s: modules[%d].includes.statusBoard set; "+
+					"status-board.yaml is a workspace-level singleton and may only be declared on modules[0]",
+					manifestPath, i)
+			}
+		}
+	}
+	return &spec, nil
+}
+
+// validateManifestModulePath rejects absolute paths and any path containing
+// ".." segments. "." is allowed and means the manifest directory itself.
+// This is the security boundary against escape outside the workspace root.
+func validateManifestModulePath(p string) error {
+	if p == "" {
+		return errors.New("path is required")
+	}
+	if path.IsAbs(p) {
+		return fmt.Errorf("absolute path not allowed: %s", p)
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return fmt.Errorf("path escape not allowed: %s contains ..", p)
+		}
+	}
+	return nil
+}
+
+// discoverManifest walks each module declared in the manifest, expanding the
+// include globs (or defaults) and merging the result into a deduplicated set
+// of MetadataSources. allowSingletons is restricted to modules[0] so only the
+// workspace root contributes actors.yaml and status-board.yaml.
+func (l *Locator) discoverManifest() ([]MetadataSource, error) {
+	if l.manifestSpec == nil {
+		return nil, errors.New("metadata: locator: manifest mode but spec nil")
+	}
+	var out []MetadataSource
+	seen := make(map[string]struct{})
+	for i, mod := range l.manifestSpec.Modules {
+		modSources, err := l.discoverManifestModule(mod, i == 0)
+		if err != nil {
+			return nil, fmt.Errorf("module[%d] %s: %w", i, mod.Path, err)
+		}
+		for _, src := range modSources {
+			if _, dup := seen[src.Path]; dup {
+				continue
+			}
+			seen[src.Path] = struct{}{}
+			out = append(out, src)
+		}
+	}
+	return out, nil
+}
+
+// discoverManifestModule walks one manifest module: expands each include
+// pattern, classifies matching files, and applies excludes. allowSingletons
+// gates actors / status-board emission to the first module (workspace root).
+func (l *Locator) discoverManifestModule(mod ManifestModule, allowSingletons bool) ([]MetadataSource, error) {
+	includes := mod.Includes
+	if manifestIncludesEmpty(includes) {
+		includes = defaultManifestIncludes()
+	}
+	base := path.Clean(mod.Path)
+	if base == "." {
+		base = ""
+	}
+	excludes := compileManifestExcludes(base, mod.Excludes)
+	type emission struct {
+		patterns   []string
+		kind       SourceKind
+		deriveCell func(p string) string
+	}
+	plan := []emission{
+		{patterns: includes.Cells, kind: SourceCell, deriveCell: func(p string) string {
+			rel := stripBase(p, base)
+			id, _ := matchCellPath(rel)
+			return id
+		}},
+		{patterns: includes.Slices, kind: SourceSlice, deriveCell: func(p string) string {
+			rel := stripBase(p, base)
+			cellID, _, _ := matchSlicePath(rel)
+			return cellID
+		}},
+		{patterns: includes.Contracts, kind: SourceContract},
+		{patterns: includes.Journeys, kind: SourceJourney},
+		{patterns: includes.Assemblies, kind: SourceAssembly},
+	}
+	var out []MetadataSource
+	for _, em := range plan {
+		for _, g := range em.patterns {
+			matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g))
+			if err != nil {
+				return nil, fmt.Errorf("glob %s: %w", g, err)
+			}
+			for _, m := range matches {
+				if excludes.match(m) {
+					continue
+				}
+				src := MetadataSource{Path: m, Kind: em.kind}
+				if em.deriveCell != nil {
+					src.CellID = em.deriveCell(m)
+				}
+				out = append(out, src)
+			}
+		}
+	}
+	if allowSingletons {
+		if includes.Actors != "" {
+			full := joinManifestPath(base, includes.Actors)
+			if exists, err := fileExists(l.fsys, full); err != nil {
+				return nil, fmt.Errorf("stat actors %s: %w", full, err)
+			} else if exists && !excludes.match(full) {
+				out = append(out, MetadataSource{Path: full, Kind: SourceActors})
+			}
+		}
+		if includes.StatusBoard != "" {
+			full := joinManifestPath(base, includes.StatusBoard)
+			if exists, err := fileExists(l.fsys, full); err != nil {
+				return nil, fmt.Errorf("stat statusBoard %s: %w", full, err)
+			} else if exists && !excludes.match(full) {
+				out = append(out, MetadataSource{Path: full, Kind: SourceStatusBoard})
+			}
+		}
+	}
+	return out, nil
+}
+
+// manifestIncludesEmpty reports whether all include fields are unset.
+func manifestIncludesEmpty(inc ManifestIncludes) bool {
+	return len(inc.Cells) == 0 && len(inc.Slices) == 0 && len(inc.Contracts) == 0 &&
+		len(inc.Journeys) == 0 && len(inc.Assemblies) == 0 &&
+		inc.Actors == "" && inc.StatusBoard == ""
+}
+
+// joinManifestPath joins a module base path with a relative glob/file path,
+// keeping forward-slash separators. Returns just the rel argument when base
+// is empty (the workspace root case).
+func joinManifestPath(base, rel string) string {
+	if base == "" {
+		return path.Clean(rel)
+	}
+	return path.Clean(base + "/" + rel)
+}
+
+// stripBase removes the module base prefix from a discovered path so the
+// classifier helpers (matchCellPath, matchSlicePath) can derive cell IDs
+// using their original layout assumptions. When base is empty, the path is
+// returned as-is.
+func stripBase(p, base string) string {
+	if base == "" {
+		return p
+	}
+	prefix := base + "/"
+	if strings.HasPrefix(p, prefix) {
+		return strings.TrimPrefix(p, prefix)
+	}
+	return p
+}
+
+// fileExists reports whether p exists as a regular file in fsys.
+func fileExists(fsys fs.FS, p string) (bool, error) {
+	info, err := fs.Stat(fsys, p)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return !info.IsDir(), nil
+}
+
+// manifestExcludeSet holds compiled exclude patterns for one module.
+type manifestExcludeSet struct {
+	patterns []string
+}
+
+func compileManifestExcludes(base string, patterns []string) *manifestExcludeSet {
+	es := &manifestExcludeSet{}
+	for _, p := range patterns {
+		es.patterns = append(es.patterns, joinManifestPath(base, p))
+	}
+	return es
+}
+
+func (es *manifestExcludeSet) match(filePath string) bool {
+	for _, pat := range es.patterns {
+		if matchManifestPattern(pat, filePath) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchManifestGlob expands a glob pattern against fsys via WalkDir. Returns
+// sorted matches.
+func matchManifestGlob(fsys fs.FS, pattern string) ([]string, error) {
+	var matches []string
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if matchManifestPattern(pattern, p) {
+			matches = append(matches, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// matchManifestPattern matches a glob with "*" (single-segment wildcard) and
+// "**" (multi-segment wildcard) against a forward-slash path.
+func matchManifestPattern(pattern, name string) bool {
+	patSegs := strings.Split(pattern, "/")
+	nameSegs := strings.Split(name, "/")
+	return matchManifestSegments(patSegs, nameSegs)
+}
+
+// matchManifestSegments performs the recursive glob match. Supports "**" as
+// a multi-segment wildcard and falls back to path.Match for single segments.
+func matchManifestSegments(pat, name []string) bool {
+	for {
+		if len(pat) == 0 {
+			return len(name) == 0
+		}
+		if pat[0] == "**" {
+			rest := pat[1:]
+			if len(rest) == 0 {
+				return true
+			}
+			for i := 0; i <= len(name); i++ {
+				if matchManifestSegments(rest, name[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(name) == 0 {
+			return false
+		}
+		matched, err := path.Match(pat[0], name[0])
+		if err != nil || !matched {
+			return false
+		}
+		pat = pat[1:]
+		name = name[1:]
+	}
+}

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -57,9 +57,10 @@ type ManifestSpec struct {
 // discovery.
 //
 // Excludes applies path-prefix filters across all source kinds in this module.
-// Defaults effectively include "generated/**" and "vendor/**". Specifying
-// an explicit excludes: list overrides the defaults; to keep the defaults
-// while adding more, repeat them explicitly.
+// "generated/**" is always appended to the effective excludes list (additive).
+// "vendor/**" is NOT added automatically — declare it explicitly if needed.
+// Specifying an explicit excludes: list does not replace the generated/** guard;
+// both the user-declared patterns and "generated/**" are applied.
 type ManifestModule struct {
 	Path     string           `yaml:"path"`
 	Includes ManifestIncludes `yaml:"includes"`
@@ -79,13 +80,20 @@ type ManifestModule struct {
 // in Modules[0] (validated by loadManifest). Declaring them in more than one
 // module entry causes loadManifest to return ErrDuplicateWorkspaceSingleton.
 type ManifestIncludes struct {
-	Cells       []string `yaml:"cells"`
-	Slices      []string `yaml:"slices"`
-	Contracts   []string `yaml:"contracts"`
-	Journeys    []string `yaml:"journeys"`
-	Assemblies  []string `yaml:"assemblies"`
-	Actors      string   `yaml:"actors"`
-	StatusBoard string   `yaml:"statusBoard"`
+	// Cells corresponds to the "cells:" YAML key.
+	Cells []string `yaml:"cells"`
+	// Slices corresponds to the "slices:" YAML key.
+	Slices []string `yaml:"slices"`
+	// Contracts corresponds to the "contracts:" YAML key.
+	Contracts []string `yaml:"contracts"`
+	// Journeys corresponds to the "journeys:" YAML key.
+	Journeys []string `yaml:"journeys"`
+	// Assemblies corresponds to the "assemblies:" YAML key.
+	Assemblies []string `yaml:"assemblies"`
+	// Actors corresponds to the "actors:" YAML key (singular string, not a list).
+	Actors string `yaml:"actors"`
+	// StatusBoard corresponds to the "statusBoard:" YAML key (camelCase, not kebab-case).
+	StatusBoard string `yaml:"statusBoard"`
 }
 
 // defaultManifestIncludes mirrors the conventional 5-pattern layout. Used
@@ -116,6 +124,13 @@ const (
 	// above any realistic workspace size and below the threshold where
 	// glob expansion becomes a DoS vector.
 	maxManifestModules = 256
+
+	// maxManifestIncludePatternsPerKind caps the number of include patterns
+	// per kind (cells/slices/contracts/journeys/assemblies) per module at 128.
+	// Actors and StatusBoard are single-string fields and are not subject to
+	// this cap. The limit prevents O(patterns × files) WalkDir amplification
+	// from a manifest with thousands of explicit include globs.
+	maxManifestIncludePatternsPerKind = 128
 )
 
 // loadManifest reads and decodes the manifest at manifestPath from fsys,
@@ -213,51 +228,91 @@ func validateManifestModuleDir(fsys fs.FS, manifestPath string, i int, normPath 
 	info, err := fs.Stat(fsys, normPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("manifest %s: modules[%d].path %q does not exist (or is not a directory)",
+			return fmt.Errorf("manifest %s: modules[%d].path %q does not exist",
 				manifestPath, i, normPath)
 		}
 		return fmt.Errorf("manifest %s: modules[%d].path %q stat: %w", manifestPath, i, normPath, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("manifest %s: modules[%d].path %q does not exist (or is not a directory)",
+		return fmt.Errorf("manifest %s: modules[%d].path %q exists but is not a directory",
 			manifestPath, i, normPath)
 	}
 	return nil
 }
 
 // validateManifestGlobs rejects glob patterns in includes/excludes that
-// contain parent-escape ("..") segments. Without this guard, an exclude
-// like "../../other-module/cells/**" could suppress entries from a
-// sibling module in Workspace mode, breaking cell-scan isolation, while
-// includes leaking outside the module root would silently match nothing
-// (WalkDir doesn't surface "..") and confuse the user.
+// contain parent-escape ("..") segments, contain empty strings, or exceed
+// the per-kind pattern count cap. Without the path-escape guard, an exclude
+// like "../../other-module/cells/**" could suppress entries from a sibling
+// module in Workspace mode. Empty patterns are rejected to surface manifest
+// typos early. The per-kind cap (maxManifestIncludePatternsPerKind) prevents
+// O(patterns × files) WalkDir amplification.
 func validateManifestGlobs(manifestPath string, i int, m ManifestModule) error {
-	for _, p := range m.Excludes {
+	if err := validateManifestExcludeGlobs(manifestPath, i, m.Excludes); err != nil {
+		return err
+	}
+	return validateManifestIncludeGlobs(manifestPath, i, m.Includes)
+}
+
+// validateManifestExcludeGlobs validates the excludes list for a module entry.
+func validateManifestExcludeGlobs(manifestPath string, i int, excludes []string) error {
+	for _, p := range excludes {
 		if err := validateManifestModulePath(p); err != nil {
 			return fmt.Errorf("manifest %s: modules[%d].excludes %q: %w", manifestPath, i, p, err)
 		}
 	}
-	includeBuckets := [][]string{
-		m.Includes.Cells, m.Includes.Slices, m.Includes.Contracts,
-		m.Includes.Journeys, m.Includes.Assemblies,
+	return nil
+}
+
+// validateManifestIncludeGlobs validates the includes struct for a module entry:
+// checks per-kind count cap, rejects empty patterns, and validates path safety.
+func validateManifestIncludeGlobs(manifestPath string, i int, inc ManifestIncludes) error {
+	type namedBucket struct {
+		name     string
+		patterns []string
 	}
-	for _, bucket := range includeBuckets {
-		for _, p := range bucket {
-			if err := validateManifestModulePath(p); err != nil {
-				return fmt.Errorf("manifest %s: modules[%d].includes %q: %w", manifestPath, i, p, err)
-			}
+	buckets := []namedBucket{
+		{"cells", inc.Cells},
+		{"slices", inc.Slices},
+		{"contracts", inc.Contracts},
+		{"journeys", inc.Journeys},
+		{"assemblies", inc.Assemblies},
+	}
+	for _, nb := range buckets {
+		if err := validateIncludeBucket(manifestPath, i, nb.name, nb.patterns); err != nil {
+			return err
 		}
 	}
-	if m.Includes.Actors != "" {
-		if err := validateManifestModulePath(m.Includes.Actors); err != nil {
+	if inc.Actors != "" {
+		if err := validateManifestModulePath(inc.Actors); err != nil {
 			return fmt.Errorf("manifest %s: modules[%d].includes.actors %q: %w",
-				manifestPath, i, m.Includes.Actors, err)
+				manifestPath, i, inc.Actors, err)
 		}
 	}
-	if m.Includes.StatusBoard != "" {
-		if err := validateManifestModulePath(m.Includes.StatusBoard); err != nil {
+	if inc.StatusBoard != "" {
+		if err := validateManifestModulePath(inc.StatusBoard); err != nil {
 			return fmt.Errorf("manifest %s: modules[%d].includes.statusBoard %q: %w",
-				manifestPath, i, m.Includes.StatusBoard, err)
+				manifestPath, i, inc.StatusBoard, err)
+		}
+	}
+	return nil
+}
+
+// validateIncludeBucket validates a single named include pattern bucket.
+func validateIncludeBucket(manifestPath string, i int, name string, patterns []string) error {
+	if len(patterns) > maxManifestIncludePatternsPerKind {
+		return fmt.Errorf(
+			"manifest %s: modules[%d].includes.%s: too many patterns (count=%d limit=%d)",
+			manifestPath, i, name, len(patterns), maxManifestIncludePatternsPerKind,
+		)
+	}
+	for _, p := range patterns {
+		if p == "" {
+			return fmt.Errorf("manifest %s: modules[%d].includes.%s: empty pattern not allowed",
+				manifestPath, i, name)
+		}
+		if err := validateManifestModulePath(p); err != nil {
+			return fmt.Errorf("manifest %s: modules[%d].includes %q: %w", manifestPath, i, p, err)
 		}
 	}
 	return nil
@@ -388,28 +443,37 @@ func buildManifestModulePlan(mod ManifestModule, allowSingletons bool) manifestM
 		base = ""
 	}
 	excludes := appendGeneratedExclude(mod.Excludes)
+	// userDeclared is true for a specific kind's emission only when the user
+	// explicitly provided patterns for that kind. When the user declares ANY
+	// includes but omits a specific kind, that kind's patterns come from
+	// defaults (or are empty) and should not trigger fail-closed on zero match.
+	cellsDeclared := userHasIncludes && len(mod.Includes.Cells) > 0
+	slicesDeclared := userHasIncludes && len(mod.Includes.Slices) > 0
+	contractsDeclared := userHasIncludes && len(mod.Includes.Contracts) > 0
+	journeysDeclared := userHasIncludes && len(mod.Includes.Journeys) > 0
+	assembliesDeclared := userHasIncludes && len(mod.Includes.Assemblies) > 0
 	plan := manifestModulePlan{
 		base:            base,
 		excludes:        compileManifestExcludes(base, excludes),
 		allowSingletons: allowSingletons,
 		emissions: []manifestEmission{
 			{
-				patterns: includes.Cells, kind: SourceCell, userDeclared: userHasIncludes,
+				patterns: includes.Cells, kind: SourceCell, userDeclared: cellsDeclared,
 				deriveCell: func(p string) string {
 					id, _ := matchCellPath(stripBase(p, base))
 					return id
 				},
 			},
 			{
-				patterns: includes.Slices, kind: SourceSlice, userDeclared: userHasIncludes,
+				patterns: includes.Slices, kind: SourceSlice, userDeclared: slicesDeclared,
 				deriveCell: func(p string) string {
 					cellID, _ := matchSlicePath(stripBase(p, base))
 					return cellID
 				},
 			},
-			{patterns: includes.Contracts, kind: SourceContract, userDeclared: userHasIncludes},
-			{patterns: includes.Journeys, kind: SourceJourney, userDeclared: userHasIncludes},
-			{patterns: includes.Assemblies, kind: SourceAssembly, userDeclared: userHasIncludes},
+			{patterns: includes.Contracts, kind: SourceContract, userDeclared: contractsDeclared},
+			{patterns: includes.Journeys, kind: SourceJourney, userDeclared: journeysDeclared},
+			{patterns: includes.Assemblies, kind: SourceAssembly, userDeclared: assembliesDeclared},
 		},
 	}
 	if allowSingletons {
@@ -459,29 +523,67 @@ func (l *Locator) discoverManifestPlanEmissions(plan manifestModulePlan) ([]Meta
 // applicable. Split out so discoverManifestPlanEmissions itself stays a
 // straight three-line walk under the kernel/-layer 15-complexity budget.
 //
-// For user-declared patterns (em.userDeclared == true): zero matches returns
-// a hard error — this is almost always a manifest typo (e.g. "cell.yml"
-// instead of "cell.yaml") and silent skipping would hide misconfiguration
-// behind a "PASS, but 0 cells found" outcome (F2 fail-closed).
+// Fail-closed at emission granularity (all patterns combined); per-pattern
+// zero-match emits slog.Warn for typo diagnostics.
 //
-// For default patterns (em.userDeclared == false): zero matches emits only
-// a structured slog.Warn for workspaces that legitimately omit certain source
-// kinds.
+// For user-declared patterns (em.userDeclared == true): if all patterns
+// combined produce zero matches, a hard error is returned — this is almost
+// always a manifest typo and silent skipping would hide misconfiguration
+// behind a "PASS, but 0 cells found" outcome (F2 fail-closed). Individual
+// patterns that match zero files within a multi-pattern emission emit a
+// slog.Warn; the emission as a whole succeeds as long as at least one
+// pattern matches (multi-pattern fallback is legitimate).
+//
+// For default patterns (em.userDeclared == false): zero matches across the
+// entire emission emits only a structured slog.Warn for workspaces that
+// legitimately omit certain source kinds.
 func (l *Locator) discoverEmission(base string, excludes *manifestExcludeSet, em manifestEmission) ([]MetadataSource, error) {
 	var out []MetadataSource
 	for _, g := range em.patterns {
-		emitted, err := l.discoverEmissionPattern(base, g, excludes, em)
+		emitted, err := l.collectEmissionPattern(base, g, excludes, em)
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, emitted...)
 	}
+	if len(out) == 0 {
+		return l.handleEmissionZeroMatch(base, em)
+	}
 	return out, nil
 }
 
-// discoverEmissionPattern handles a single glob pattern within an emission,
+// handleEmissionZeroMatch is called when all patterns in an emission produced
+// zero results after excludes filtering. For user-declared emissions it returns
+// a hard error (fail-closed); for default emissions it emits a slog.Warn.
+func (l *Locator) handleEmissionZeroMatch(base string, em manifestEmission) ([]MetadataSource, error) {
+	displayBase := base
+	if displayBase == "" {
+		displayBase = "."
+	}
+	if em.userDeclared {
+		err := fmt.Errorf(
+			"manifest module %q include patterns for kind=%s matched zero files"+
+				" — check extension: .yaml not .yml; check path separator: forward slash;"+
+				" verify glob pattern matches expected layout",
+			displayBase, em.kind.String(),
+		)
+		slog.Error("metadata: locator manifest emission zero-match — fail-closed",
+			slog.String("kind", em.kind.String()),
+			slog.String("module_base", displayBase),
+			slog.Any("err", err))
+		return nil, err
+	}
+	slog.Warn("metadata: locator manifest emission matched zero files (default patterns)",
+		slog.String("kind", em.kind.String()),
+		slog.String("module_base", displayBase))
+	return nil, nil
+}
+
+// collectEmissionPattern handles a single glob pattern within an emission,
 // split from discoverEmission to keep cognitive complexity within budget.
-func (l *Locator) discoverEmissionPattern(
+// Per-pattern zero matches emit a slog.Warn for typo diagnostics; the
+// emission-level fail-closed check is in discoverEmission.
+func (l *Locator) collectEmissionPattern(
 	base, g string,
 	excludes *manifestExcludeSet,
 	em manifestEmission,
@@ -501,18 +603,15 @@ func (l *Locator) discoverEmissionPattern(
 		}
 		out = append(out, src)
 	}
-	if len(out) == 0 {
-		if em.userDeclared {
-			return nil, fmt.Errorf(
-				"manifest module %q include pattern %q (kind=%s) matched zero files"+
-					" — likely a typo (e.g. cell.yml vs cell.yaml)",
-				base, g, em.kind.String(),
-			)
+	if len(out) == 0 && em.userDeclared {
+		displayBase := base
+		if displayBase == "" {
+			displayBase = "."
 		}
 		slog.Warn("metadata: locator manifest include pattern matched zero files",
 			slog.String("pattern", g),
 			slog.String("kind", em.kind.String()),
-			slog.String("module_base", base))
+			slog.String("module_base", displayBase))
 	}
 	return out, nil
 }
@@ -630,7 +729,8 @@ func (es *manifestExcludeSet) match(filePath string) bool {
 }
 
 // matchManifestGlob expands a glob pattern against fsys via WalkDir. Returns
-// sorted matches.
+// sorted matches. Symlinks are explicitly skipped to avoid traversal through
+// unexpected filesystem topology that os.DirFS might not prevent.
 //
 // To avoid O(modules × total_files) WalkDir amplification, the walk is
 // started from the longest fixed prefix before the first wildcard segment
@@ -638,35 +738,64 @@ func (es *manifestExcludeSet) match(filePath string) bool {
 // only the cells/ subtree is scanned. Patterns that begin with a wildcard
 // (e.g. "**/cell.yaml" or "*/cell.yaml") fall back to walking from ".".
 // When the computed prefix does not exist in fsys, an empty match list is
-// returned without error.
+// returned without error. Passing an empty pattern returns (nil, nil).
 func matchManifestGlob(fsys fs.FS, pattern string) ([]string, error) {
-	root := manifestGlobFixedPrefix(pattern)
-	if root != "." {
-		if _, err := fs.Stat(fsys, root); err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil, nil
-			}
-			return nil, err
-		}
+	if pattern == "" {
+		return nil, nil
+	}
+	root, ok, err := manifestGlobWalkRoot(fsys, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
 	}
 	var matches []string
-	err := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, walkErr error) error {
+	if err := fs.WalkDir(fsys, root, manifestGlobWalkFn(pattern, &matches)); err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// manifestGlobWalkRoot resolves the WalkDir start directory for a glob pattern.
+// Returns (root, true, nil) when the root exists, ("", false, nil) when the
+// computed root does not exist in fsys, or ("", false, err) for other stat errors.
+func manifestGlobWalkRoot(fsys fs.FS, pattern string) (string, bool, error) {
+	root := manifestGlobFixedPrefix(pattern)
+	if root == "." {
+		return root, true, nil
+	}
+	if _, err := fs.Stat(fsys, root); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return root, true, nil
+}
+
+// manifestGlobWalkFn returns a WalkDir callback that appends matching paths to
+// matches. Symlinks are skipped to avoid traversal through unexpected topology.
+func manifestGlobWalkFn(pattern string, matches *[]string) fs.WalkDirFunc {
+	return func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		// Explicitly skip symlinks regardless of whether the underlying fs.FS
+		// follows them. This avoids traversal through unexpected filesystem
+		// topology (e.g. symlink loops) that os.DirFS does not prevent.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
 		}
 		if d.IsDir() {
 			return nil
 		}
 		if matchManifestPattern(pattern, p) {
-			matches = append(matches, p)
+			*matches = append(*matches, p)
 		}
 		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
-	sort.Strings(matches)
-	return matches, nil
 }
 
 // manifestGlobFixedPrefix extracts the longest fixed (non-wildcard) path

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -83,6 +83,20 @@ const manifestSchemaVersion = "v1"
 // validating the schema version, module path safety, and singleton
 // uniqueness invariants.
 func loadManifest(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
+	spec, err := readManifestSpec(fsys, manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateManifestSpec(manifestPath, spec); err != nil {
+		return nil, err
+	}
+	return spec, nil
+}
+
+// readManifestSpec performs only the file IO + YAML decode steps for
+// loadManifest, keeping validation in validateManifestSpec to satisfy the
+// kernel/-layer 15-complexity budget.
+func readManifestSpec(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
 	data, err := fs.ReadFile(fsys, manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("read manifest %s: %w", manifestPath, err)
@@ -93,38 +107,55 @@ func loadManifest(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
 	if err := dec.Decode(&spec); err != nil {
 		return nil, fmt.Errorf("decode manifest %s: %w", manifestPath, err)
 	}
+	return &spec, nil
+}
+
+// validateManifestSpec applies the schema-version + module-path + singleton
+// invariants. Split out from loadManifest to keep cognitive complexity below
+// the kernel/-layer 15 budget.
+func validateManifestSpec(manifestPath string, spec *ManifestSpec) error {
 	if spec.Version != manifestSchemaVersion {
-		return nil, fmt.Errorf("manifest %s: unsupported version %q (want %q)",
+		return fmt.Errorf("manifest %s: unsupported version %q (want %q)",
 			manifestPath, spec.Version, manifestSchemaVersion)
 	}
 	if len(spec.Modules) == 0 {
-		return nil, fmt.Errorf("manifest %s: at least one module entry required", manifestPath)
+		return fmt.Errorf("manifest %s: at least one module entry required", manifestPath)
 	}
 	seenPaths := make(map[string]int)
 	for i, m := range spec.Modules {
 		if err := validateManifestModulePath(m.Path); err != nil {
-			return nil, fmt.Errorf("manifest %s: modules[%d].path: %w", manifestPath, i, err)
+			return fmt.Errorf("manifest %s: modules[%d].path: %w", manifestPath, i, err)
 		}
 		normPath := path.Clean(m.Path)
 		if dup, ok := seenPaths[normPath]; ok {
-			return nil, fmt.Errorf("manifest %s: modules[%d].path %q duplicates modules[%d]",
+			return fmt.Errorf("manifest %s: modules[%d].path %q duplicates modules[%d]",
 				manifestPath, i, m.Path, dup)
 		}
 		seenPaths[normPath] = i
-		if i > 0 {
-			if m.Includes.Actors != "" {
-				return nil, fmt.Errorf("manifest %s: modules[%d].includes.actors set; "+
-					"actors.yaml is a workspace-level singleton and may only be declared on modules[0]",
-					manifestPath, i)
-			}
-			if m.Includes.StatusBoard != "" {
-				return nil, fmt.Errorf("manifest %s: modules[%d].includes.statusBoard set; "+
-					"status-board.yaml is a workspace-level singleton and may only be declared on modules[0]",
-					manifestPath, i)
-			}
+		if err := validateManifestSingleton(manifestPath, i, m); err != nil {
+			return err
 		}
 	}
-	return &spec, nil
+	return nil
+}
+
+// validateManifestSingleton rejects actors / statusBoard declarations on
+// modules other than modules[0] (the workspace root).
+func validateManifestSingleton(manifestPath string, i int, m ManifestModule) error {
+	if i == 0 {
+		return nil
+	}
+	if m.Includes.Actors != "" {
+		return fmt.Errorf("manifest %s: modules[%d].includes.actors set; "+
+			"actors.yaml is a workspace-level singleton and may only be declared on modules[0]",
+			manifestPath, i)
+	}
+	if m.Includes.StatusBoard != "" {
+		return fmt.Errorf("manifest %s: modules[%d].includes.statusBoard set; "+
+			"status-board.yaml is a workspace-level singleton and may only be declared on modules[0]",
+			manifestPath, i)
+	}
+	return nil
 }
 
 // validateManifestModulePath rejects absolute paths and any path containing
@@ -139,7 +170,7 @@ func validateManifestModulePath(p string) error {
 	}
 	for _, seg := range strings.Split(p, "/") {
 		if seg == ".." {
-			return fmt.Errorf("path escape not allowed: %s contains ..", p)
+			return fmt.Errorf("path escape not allowed: %s contains parent reference", p)
 		}
 	}
 	return nil
@@ -171,10 +202,47 @@ func (l *Locator) discoverManifest() ([]MetadataSource, error) {
 	return out, nil
 }
 
+// manifestEmission groups one set of glob patterns by destination
+// SourceKind plus an optional cell-ID derivation strategy.
+type manifestEmission struct {
+	patterns   []string
+	kind       SourceKind
+	deriveCell func(p string) string
+}
+
+// manifestModulePlan packages the per-emission plan + the singleton paths +
+// the compiled exclude set + the (already-normalised) module base path.
+// Building the plan in one place keeps discoverManifestModule itself a
+// straight three-line walk over the plan.
+type manifestModulePlan struct {
+	base            string
+	excludes        *manifestExcludeSet
+	emissions       []manifestEmission
+	actorsPath      string
+	statusBoardPath string
+	allowSingletons bool
+}
+
 // discoverManifestModule walks one manifest module: expands each include
 // pattern, classifies matching files, and applies excludes. allowSingletons
 // gates actors / status-board emission to the first module (workspace root).
 func (l *Locator) discoverManifestModule(mod ManifestModule, allowSingletons bool) ([]MetadataSource, error) {
+	plan := buildManifestModulePlan(mod, allowSingletons)
+	out, err := l.discoverManifestPlanEmissions(plan)
+	if err != nil {
+		return nil, err
+	}
+	singletons, err := l.discoverManifestPlanSingletons(plan)
+	if err != nil {
+		return nil, err
+	}
+	return append(out, singletons...), nil
+}
+
+// buildManifestModulePlan normalises the include defaults + base path and
+// produces the per-emission plan executed by discoverManifestPlanEmissions /
+// discoverManifestPlanSingletons.
+func buildManifestModulePlan(mod ManifestModule, allowSingletons bool) manifestModulePlan {
 	includes := mod.Includes
 	if manifestIncludesEmpty(includes) {
 		includes = defaultManifestIncludes()
@@ -183,65 +251,119 @@ func (l *Locator) discoverManifestModule(mod ManifestModule, allowSingletons boo
 	if base == "." {
 		base = ""
 	}
-	excludes := compileManifestExcludes(base, mod.Excludes)
-	type emission struct {
-		patterns   []string
-		kind       SourceKind
-		deriveCell func(p string) string
-	}
-	plan := []emission{
-		{patterns: includes.Cells, kind: SourceCell, deriveCell: func(p string) string {
-			rel := stripBase(p, base)
-			id, _ := matchCellPath(rel)
-			return id
-		}},
-		{patterns: includes.Slices, kind: SourceSlice, deriveCell: func(p string) string {
-			rel := stripBase(p, base)
-			cellID, _, _ := matchSlicePath(rel)
-			return cellID
-		}},
-		{patterns: includes.Contracts, kind: SourceContract},
-		{patterns: includes.Journeys, kind: SourceJourney},
-		{patterns: includes.Assemblies, kind: SourceAssembly},
-	}
-	var out []MetadataSource
-	for _, em := range plan {
-		for _, g := range em.patterns {
-			matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g))
-			if err != nil {
-				return nil, fmt.Errorf("glob %s: %w", g, err)
-			}
-			for _, m := range matches {
-				if excludes.match(m) {
-					continue
-				}
-				src := MetadataSource{Path: m, Kind: em.kind}
-				if em.deriveCell != nil {
-					src.CellID = em.deriveCell(m)
-				}
-				out = append(out, src)
-			}
-		}
+	plan := manifestModulePlan{
+		base:            base,
+		excludes:        compileManifestExcludes(base, mod.Excludes),
+		allowSingletons: allowSingletons,
+		emissions: []manifestEmission{
+			{patterns: includes.Cells, kind: SourceCell, deriveCell: func(p string) string {
+				id, _ := matchCellPath(stripBase(p, base))
+				return id
+			}},
+			{patterns: includes.Slices, kind: SourceSlice, deriveCell: func(p string) string {
+				cellID, _ := matchSlicePath(stripBase(p, base))
+				return cellID
+			}},
+			{patterns: includes.Contracts, kind: SourceContract},
+			{patterns: includes.Journeys, kind: SourceJourney},
+			{patterns: includes.Assemblies, kind: SourceAssembly},
+		},
 	}
 	if allowSingletons {
 		if includes.Actors != "" {
-			full := joinManifestPath(base, includes.Actors)
-			if exists, err := fileExists(l.fsys, full); err != nil {
-				return nil, fmt.Errorf("stat actors %s: %w", full, err)
-			} else if exists && !excludes.match(full) {
-				out = append(out, MetadataSource{Path: full, Kind: SourceActors})
-			}
+			plan.actorsPath = joinManifestPath(base, includes.Actors)
 		}
 		if includes.StatusBoard != "" {
-			full := joinManifestPath(base, includes.StatusBoard)
-			if exists, err := fileExists(l.fsys, full); err != nil {
-				return nil, fmt.Errorf("stat statusBoard %s: %w", full, err)
-			} else if exists && !excludes.match(full) {
-				out = append(out, MetadataSource{Path: full, Kind: SourceStatusBoard})
+			plan.statusBoardPath = joinManifestPath(base, includes.StatusBoard)
+		}
+	}
+	return plan
+}
+
+// discoverManifestPlanEmissions runs each emission's glob expansion and
+// excludes filter, producing MetadataSources for cells / slices / contracts
+// / journeys / assemblies.
+func (l *Locator) discoverManifestPlanEmissions(plan manifestModulePlan) ([]MetadataSource, error) {
+	var out []MetadataSource
+	for _, em := range plan.emissions {
+		emitted, err := l.discoverEmission(plan.base, plan.excludes, em)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, emitted...)
+	}
+	return out, nil
+}
+
+// discoverEmission expands one emission's glob patterns against l.fsys,
+// filters excludes, and emits MetadataSources with derived CellID where
+// applicable. Split out so discoverManifestPlanEmissions itself stays a
+// straight three-line walk under the kernel/-layer 15-complexity budget.
+func (l *Locator) discoverEmission(base string, excludes *manifestExcludeSet, em manifestEmission) ([]MetadataSource, error) {
+	var out []MetadataSource
+	for _, g := range em.patterns {
+		matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g))
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", g, err)
+		}
+		for _, m := range matches {
+			if excludes.match(m) {
+				continue
 			}
+			src := MetadataSource{Path: m, Kind: em.kind}
+			if em.deriveCell != nil {
+				src.CellID = em.deriveCell(m)
+			}
+			out = append(out, src)
 		}
 	}
 	return out, nil
+}
+
+// discoverManifestPlanSingletons emits actors.yaml + status-board.yaml when
+// allowSingletons was set and the files exist; absent files are skipped
+// silently, errors other than not-exist surface up.
+func (l *Locator) discoverManifestPlanSingletons(plan manifestModulePlan) ([]MetadataSource, error) {
+	if !plan.allowSingletons {
+		return nil, nil
+	}
+	var out []MetadataSource
+	actors, ok, err := l.maybeManifestSingleton(plan.actorsPath, SourceActors, plan.excludes, "actors")
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		out = append(out, actors)
+	}
+	sb, ok, err := l.maybeManifestSingleton(plan.statusBoardPath, SourceStatusBoard, plan.excludes, "statusBoard")
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		out = append(out, sb)
+	}
+	return out, nil
+}
+
+// maybeManifestSingleton returns (MetadataSource, true, nil) when the
+// singleton path exists and is not excluded; (zero, false, nil) when the
+// path is empty, file is missing, or excluded; (zero, false, err) only for
+// unexpected stat errors. The triple return avoids the (nil, nil) nilnil
+// linter complaint.
+func (l *Locator) maybeManifestSingleton(
+	p string, kind SourceKind, excludes *manifestExcludeSet, label string,
+) (MetadataSource, bool, error) {
+	if p == "" {
+		return MetadataSource{}, false, nil
+	}
+	exists, err := fileExists(l.fsys, p)
+	if err != nil {
+		return MetadataSource{}, false, fmt.Errorf("stat %s %s: %w", label, p, err)
+	}
+	if !exists || excludes.match(p) {
+		return MetadataSource{}, false, nil
+	}
+	return MetadataSource{Path: p, Kind: kind}, true, nil
 }
 
 // manifestIncludesEmpty reports whether all include fields are unset.
@@ -344,30 +466,44 @@ func matchManifestPattern(pattern, name string) bool {
 // matchManifestSegments performs the recursive glob match. Supports "**" as
 // a multi-segment wildcard and falls back to path.Match for single segments.
 func matchManifestSegments(pat, name []string) bool {
-	for {
-		if len(pat) == 0 {
-			return len(name) == 0
-		}
+	for len(pat) > 0 {
 		if pat[0] == "**" {
-			rest := pat[1:]
-			if len(rest) == 0 {
-				return true
-			}
-			for i := 0; i <= len(name); i++ {
-				if matchManifestSegments(rest, name[i:]) {
-					return true
-				}
-			}
+			return matchDoubleStarTail(pat[1:], name)
+		}
+		if !consumeSingleSegment(&pat, &name) {
 			return false
 		}
-		if len(name) == 0 {
-			return false
-		}
-		matched, err := path.Match(pat[0], name[0])
-		if err != nil || !matched {
-			return false
-		}
-		pat = pat[1:]
-		name = name[1:]
 	}
+	return len(name) == 0
+}
+
+// matchDoubleStarTail handles the "**" wildcard: try matching the remaining
+// pattern against every suffix of name, including the empty suffix when
+// "**" appears at the end of the pattern.
+func matchDoubleStarTail(rest, name []string) bool {
+	if len(rest) == 0 {
+		return true
+	}
+	for i := 0; i <= len(name); i++ {
+		if matchManifestSegments(rest, name[i:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// consumeSingleSegment advances pat and name one segment when the leading
+// segments match path.Match. Returns false (and leaves pat / name
+// unchanged) when there is no match or name is exhausted.
+func consumeSingleSegment(pat, name *[]string) bool {
+	if len(*name) == 0 {
+		return false
+	}
+	matched, err := path.Match((*pat)[0], (*name)[0])
+	if err != nil || !matched {
+		return false
+	}
+	*pat = (*pat)[1:]
+	*name = (*name)[1:]
+	return true
 }

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -28,6 +28,16 @@ import (
 )
 
 // ManifestSpec is the parsed .gocell/manifest.yaml file.
+//
+// Corresponds to the top-level buf v2 buf.yaml modules: schema:
+//
+//	version: v1
+//	modules:
+//	  - path: .
+//	    includes: { cells: ["cells/*/cell.yaml"], ... }
+//	    excludes: ["generated/**", "vendor/**"]
+//
+// Version must be "v1". Modules must have at least one entry.
 type ManifestSpec struct {
 	Version string           `yaml:"version"`
 	Modules []ManifestModule `yaml:"modules"`
@@ -35,13 +45,21 @@ type ManifestSpec struct {
 
 // ManifestModule is a single module entry inside ManifestSpec.Modules.
 //
-// Path is required, must be relative, and must not escape outside the
-// manifest directory (no ".." segments, no absolute paths).
+// Path is required, must be a non-empty relative path, and must not escape
+// outside the manifest directory (no ".." segments, no absolute paths).
+// Use "." for the module that lives at the same level as manifest.yaml.
 //
-// Includes carries glob patterns per metadata source kind. Empty Includes
-// falls back to the conventional 5-pattern defaults.
+// Includes carries per-kind glob patterns. When empty, the conventional
+// 5-pattern defaults are used (cells/*/cell.yaml, cells/*/slices/*/slice.yaml,
+// contracts/**/contract.yaml, journeys/J-*.yaml, assemblies/*/assembly.yaml,
+// plus actors.yaml and journeys/status-board.yaml singletons). This lets
+// Operator-SDK modules omit includes: entirely and still get conventional
+// discovery.
 //
-// Excludes are applied across all source kinds within this module.
+// Excludes applies path-prefix filters across all source kinds in this module.
+// Defaults effectively include "generated/**" and "vendor/**". Specifying
+// an explicit excludes: list overrides the defaults; to keep the defaults
+// while adding more, repeat them explicitly.
 type ManifestModule struct {
 	Path     string           `yaml:"path"`
 	Includes ManifestIncludes `yaml:"includes"`
@@ -50,10 +68,16 @@ type ManifestModule struct {
 
 // ManifestIncludes maps each metadata source kind to one or more glob
 // patterns. Globs are resolved relative to the owning ManifestModule.Path.
-// Patterns support "*" (single segment) and "**" (any number of segments).
+// Patterns support "*" (single segment) and "**" (zero or more segments,
+// implemented via fs.WalkDir — not filepath.Glob which has undefined "**"
+// semantics). Ref: bufbuild/buf v2 buf.yaml includes field.
 //
-// Actors and StatusBoard are workspace-level singletons and may only be
-// declared on Modules[0] (validated by loadManifest).
+// Cells / Slices / Contracts / Journeys / Assemblies accept multiple patterns
+// (slice of strings); Actors and StatusBoard are singletons (single string).
+//
+// Actors and StatusBoard are workspace-level singletons: they may only appear
+// in Modules[0] (validated by loadManifest). Declaring them in more than one
+// module entry causes loadManifest to return ErrDuplicateWorkspaceSingleton.
 type ManifestIncludes struct {
 	Cells       []string `yaml:"cells"`
 	Slices      []string `yaml:"slices"`

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"path"
 	"sort"
 	"strings"
@@ -77,7 +78,21 @@ func defaultManifestIncludes() ManifestIncludes {
 	}
 }
 
-const manifestSchemaVersion = "v1"
+const (
+	manifestSchemaVersion = "v1"
+
+	// maxManifestFileSize caps the .gocell/manifest.yaml file at 64 KiB.
+	// Real manifests are well under 1 KiB (a handful of module entries);
+	// 64 KiB leaves headroom for very large workspaces while preventing
+	// memory exhaustion from an adversarial multi-MB manifest.
+	maxManifestFileSize = 64 << 10 // 64 KiB
+
+	// maxManifestModules caps the number of module entries to prevent
+	// O(modules × glob_patterns) WalkDir amplification. 256 is well
+	// above any realistic workspace size and below the threshold where
+	// glob expansion becomes a DoS vector.
+	maxManifestModules = 256
+)
 
 // loadManifest reads and decodes the manifest at manifestPath from fsys,
 // validating the schema version, module path safety, and singleton
@@ -95,11 +110,17 @@ func loadManifest(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
 
 // readManifestSpec performs only the file IO + YAML decode steps for
 // loadManifest, keeping validation in validateManifestSpec to satisfy the
-// kernel/-layer 15-complexity budget.
+// kernel/-layer 15-complexity budget. The 64 KiB size cap prevents a
+// huge-manifest DoS at the wire boundary, mirroring unmarshalFile's
+// maxMetadataFileSize policy for cell/slice/contract YAML.
 func readManifestSpec(fsys fs.FS, manifestPath string) (*ManifestSpec, error) {
 	data, err := fs.ReadFile(fsys, manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("read manifest %s: %w", manifestPath, err)
+	}
+	if len(data) > maxManifestFileSize {
+		return nil, fmt.Errorf("manifest %s: exceeds size limit (size=%d limit=%d)",
+			manifestPath, len(data), maxManifestFileSize)
 	}
 	var spec ManifestSpec
 	dec := yaml.NewDecoder(bytes.NewReader(data))
@@ -121,19 +142,72 @@ func validateManifestSpec(manifestPath string, spec *ManifestSpec) error {
 	if len(spec.Modules) == 0 {
 		return fmt.Errorf("manifest %s: at least one module entry required", manifestPath)
 	}
+	if len(spec.Modules) > maxManifestModules {
+		return fmt.Errorf(
+			"manifest %s: too many modules (count=%d limit=%d) — risk WalkDir amplification",
+			manifestPath, len(spec.Modules), maxManifestModules)
+	}
 	seenPaths := make(map[string]int)
 	for i, m := range spec.Modules {
-		if err := validateManifestModulePath(m.Path); err != nil {
-			return fmt.Errorf("manifest %s: modules[%d].path: %w", manifestPath, i, err)
-		}
-		normPath := path.Clean(m.Path)
-		if dup, ok := seenPaths[normPath]; ok {
-			return fmt.Errorf("manifest %s: modules[%d].path %q duplicates modules[%d]",
-				manifestPath, i, m.Path, dup)
-		}
-		seenPaths[normPath] = i
-		if err := validateManifestSingleton(manifestPath, i, m); err != nil {
+		if err := validateManifestModuleEntry(manifestPath, i, m, seenPaths); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateManifestModuleEntry applies all per-module invariants: path
+// safety (no absolute / no parent escape), duplicate detection, singleton
+// uniqueness, and exclude/include glob safety.
+func validateManifestModuleEntry(manifestPath string, i int, m ManifestModule, seenPaths map[string]int) error {
+	if err := validateManifestModulePath(m.Path); err != nil {
+		return fmt.Errorf("manifest %s: modules[%d].path: %w", manifestPath, i, err)
+	}
+	normPath := path.Clean(m.Path)
+	if dup, ok := seenPaths[normPath]; ok {
+		return fmt.Errorf("manifest %s: modules[%d].path %q duplicates modules[%d]",
+			manifestPath, i, m.Path, dup)
+	}
+	seenPaths[normPath] = i
+	if err := validateManifestSingleton(manifestPath, i, m); err != nil {
+		return err
+	}
+	return validateManifestGlobs(manifestPath, i, m)
+}
+
+// validateManifestGlobs rejects glob patterns in includes/excludes that
+// contain parent-escape ("..") segments. Without this guard, an exclude
+// like "../../other-module/cells/**" could suppress entries from a
+// sibling module in Workspace mode, breaking cell-scan isolation, while
+// includes leaking outside the module root would silently match nothing
+// (WalkDir doesn't surface "..") and confuse the user.
+func validateManifestGlobs(manifestPath string, i int, m ManifestModule) error {
+	for _, p := range m.Excludes {
+		if err := validateManifestModulePath(p); err != nil {
+			return fmt.Errorf("manifest %s: modules[%d].excludes %q: %w", manifestPath, i, p, err)
+		}
+	}
+	includeBuckets := [][]string{
+		m.Includes.Cells, m.Includes.Slices, m.Includes.Contracts,
+		m.Includes.Journeys, m.Includes.Assemblies,
+	}
+	for _, bucket := range includeBuckets {
+		for _, p := range bucket {
+			if err := validateManifestModulePath(p); err != nil {
+				return fmt.Errorf("manifest %s: modules[%d].includes %q: %w", manifestPath, i, p, err)
+			}
+		}
+	}
+	if m.Includes.Actors != "" {
+		if err := validateManifestModulePath(m.Includes.Actors); err != nil {
+			return fmt.Errorf("manifest %s: modules[%d].includes.actors %q: %w",
+				manifestPath, i, m.Includes.Actors, err)
+		}
+	}
+	if m.Includes.StatusBoard != "" {
+		if err := validateManifestModulePath(m.Includes.StatusBoard); err != nil {
+			return fmt.Errorf("manifest %s: modules[%d].includes.statusBoard %q: %w",
+				manifestPath, i, m.Includes.StatusBoard, err)
 		}
 	}
 	return nil
@@ -242,6 +316,11 @@ func (l *Locator) discoverManifestModule(mod ManifestModule, allowSingletons boo
 // buildManifestModulePlan normalises the include defaults + base path and
 // produces the per-emission plan executed by discoverManifestPlanEmissions /
 // discoverManifestPlanSingletons.
+//
+// When the module does not declare any excludes, the ADR-promised
+// "generated/**" exclude is applied so codegen output never silently
+// re-enters the metadata scan. Users who genuinely want generated/ in
+// scope must declare a non-empty Excludes list (the default does not fire).
 func buildManifestModulePlan(mod ManifestModule, allowSingletons bool) manifestModulePlan {
 	includes := mod.Includes
 	if manifestIncludesEmpty(includes) {
@@ -251,9 +330,13 @@ func buildManifestModulePlan(mod ManifestModule, allowSingletons bool) manifestM
 	if base == "." {
 		base = ""
 	}
+	excludes := mod.Excludes
+	if len(excludes) == 0 {
+		excludes = []string{"generated/**"}
+	}
 	plan := manifestModulePlan{
 		base:            base,
-		excludes:        compileManifestExcludes(base, mod.Excludes),
+		excludes:        compileManifestExcludes(base, excludes),
 		allowSingletons: allowSingletons,
 		emissions: []manifestEmission{
 			{patterns: includes.Cells, kind: SourceCell, deriveCell: func(p string) string {
@@ -299,6 +382,11 @@ func (l *Locator) discoverManifestPlanEmissions(plan manifestModulePlan) ([]Meta
 // filters excludes, and emits MetadataSources with derived CellID where
 // applicable. Split out so discoverManifestPlanEmissions itself stays a
 // straight three-line walk under the kernel/-layer 15-complexity budget.
+//
+// A glob pattern that matches zero files emits a structured slog.Warn —
+// zero matches is almost always a manifest typo (e.g. `cell.yml` instead
+// of `cell.yaml`) and silent skipping would hide the misconfiguration
+// behind a "PASS, but 0 cells found" outcome.
 func (l *Locator) discoverEmission(base string, excludes *manifestExcludeSet, em manifestEmission) ([]MetadataSource, error) {
 	var out []MetadataSource
 	for _, g := range em.patterns {
@@ -306,6 +394,7 @@ func (l *Locator) discoverEmission(base string, excludes *manifestExcludeSet, em
 		if err != nil {
 			return nil, fmt.Errorf("glob %s: %w", g, err)
 		}
+		emitted := 0
 		for _, m := range matches {
 			if excludes.match(m) {
 				continue
@@ -315,6 +404,13 @@ func (l *Locator) discoverEmission(base string, excludes *manifestExcludeSet, em
 				src.CellID = em.deriveCell(m)
 			}
 			out = append(out, src)
+			emitted++
+		}
+		if emitted == 0 {
+			slog.Warn("metadata: locator manifest include pattern matched zero files",
+				slog.String("pattern", g),
+				slog.String("kind", em.kind.String()),
+				slog.String("module_base", base))
 		}
 	}
 	return out, nil

--- a/kernel/metadata/locator_manifest.go
+++ b/kernel/metadata/locator_manifest.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -78,7 +79,7 @@ type ManifestModule struct {
 //
 // Actors and StatusBoard are workspace-level singletons: they may only appear
 // in Modules[0] (validated by loadManifest). Declaring them in more than one
-// module entry causes loadManifest to return ErrDuplicateWorkspaceSingleton.
+// module entry causes loadManifest to return a validation error.
 type ManifestIncludes struct {
 	// Cells corresponds to the "cells:" YAML key.
 	Cells []string `yaml:"cells"`
@@ -131,6 +132,13 @@ const (
 	// this cap. The limit prevents O(patterns × files) WalkDir amplification
 	// from a manifest with thousands of explicit include globs.
 	maxManifestIncludePatternsPerKind = 128
+
+	// maxManifestMatchesPerGlob caps the number of files a single glob pattern
+	// may match per WalkDir invocation. 50 000 is well above any realistic
+	// workspace size (GoCell itself has ~50 metadata files). Exceeding the cap
+	// aborts the walk with an error rather than silently returning a truncated
+	// result set — no silent truncation.
+	maxManifestMatchesPerGlob = 50_000
 )
 
 // loadManifest reads and decodes the manifest at manifestPath from fsys,
@@ -340,11 +348,15 @@ func validateManifestSingleton(manifestPath string, i int, m ManifestModule) err
 // validateManifestModulePath rejects absolute paths and any path containing
 // ".." segments. "." is allowed and means the manifest directory itself.
 // This is the security boundary against escape outside the workspace root.
+//
+// Uses filepath.IsAbs(filepath.FromSlash(p)) — consistent with
+// validateManifestRelativePath in locator.go — so that Windows-style absolute
+// paths (e.g. "C:\foo") that path.IsAbs would not recognize are also caught.
 func validateManifestModulePath(p string) error {
 	if p == "" {
 		return errors.New("path is required")
 	}
-	if path.IsAbs(p) {
+	if filepath.IsAbs(filepath.FromSlash(p)) {
 		return fmt.Errorf("absolute path not allowed: %s", p)
 	}
 	for _, seg := range strings.Split(p, "/") {
@@ -588,7 +600,7 @@ func (l *Locator) collectEmissionPattern(
 	excludes *manifestExcludeSet,
 	em manifestEmission,
 ) ([]MetadataSource, error) {
-	matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g))
+	matches, err := matchManifestGlob(l.fsys, joinManifestPath(base, g), excludes)
 	if err != nil {
 		return nil, fmt.Errorf("glob %s: %w", g, err)
 	}
@@ -728,6 +740,23 @@ func (es *manifestExcludeSet) match(filePath string) bool {
 	return false
 }
 
+// matchDir reports whether dir's entire subtree is excluded by a
+// "<prefix>/**" pattern, so WalkDir can SkipDir-prune it. Non-"/**" patterns
+// (e.g. a literal file path) never prune a directory — the directory may
+// still contain non-excluded files and must be walked.
+func (es *manifestExcludeSet) matchDir(dir string) bool {
+	for _, pat := range es.patterns {
+		prefix, ok := strings.CutSuffix(pat, "/**")
+		if !ok {
+			continue
+		}
+		if dir == prefix || strings.HasPrefix(dir, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // matchManifestGlob expands a glob pattern against fsys via WalkDir. Returns
 // sorted matches. Symlinks are explicitly skipped to avoid traversal through
 // unexpected filesystem topology that os.DirFS might not prevent.
@@ -739,7 +768,16 @@ func (es *manifestExcludeSet) match(filePath string) bool {
 // (e.g. "**/cell.yaml" or "*/cell.yaml") fall back to walking from ".".
 // When the computed prefix does not exist in fsys, an empty match list is
 // returned without error. Passing an empty pattern returns (nil, nil).
-func matchManifestGlob(fsys fs.FS, pattern string) ([]string, error) {
+//
+// excludes may be nil (no directory pruning). When non-nil, directories whose
+// entire subtree is excluded by a "<prefix>/**" pattern are pruned via
+// fs.SkipDir, avoiding needless traversal of large excluded subtrees such as
+// vendor/ or generated/. File-level exclude filtering is NOT performed here —
+// that remains in collectEmissionPattern to cover non-"/**" patterns.
+//
+// The number of matches is capped at maxManifestMatchesPerGlob to prevent
+// unbounded WalkDir amplification; exceeding the cap aborts with an error.
+func matchManifestGlob(fsys fs.FS, pattern string, excludes *manifestExcludeSet) ([]string, error) {
 	if pattern == "" {
 		return nil, nil
 	}
@@ -751,7 +789,8 @@ func matchManifestGlob(fsys fs.FS, pattern string) ([]string, error) {
 		return nil, nil
 	}
 	var matches []string
-	if err := fs.WalkDir(fsys, root, manifestGlobWalkFn(pattern, &matches)); err != nil {
+	count := 0
+	if err := fs.WalkDir(fsys, root, manifestGlobWalkFn(pattern, excludes, &matches, &count)); err != nil {
 		return nil, err
 	}
 	sort.Strings(matches)
@@ -777,7 +816,15 @@ func manifestGlobWalkRoot(fsys fs.FS, pattern string) (string, bool, error) {
 
 // manifestGlobWalkFn returns a WalkDir callback that appends matching paths to
 // matches. Symlinks are skipped to avoid traversal through unexpected topology.
-func manifestGlobWalkFn(pattern string, matches *[]string) fs.WalkDirFunc {
+//
+// When excludes is non-nil, directories whose subtree is entirely covered by a
+// "<prefix>/**" exclude pattern are pruned with fs.SkipDir. File-level
+// excludes (non-"/**" patterns) are NOT filtered here — the caller
+// (collectEmissionPattern) does a post-walk file-level check.
+//
+// count is incremented for each appended match; when it would exceed
+// maxManifestMatchesPerGlob the walk is aborted with a descriptive error.
+func manifestGlobWalkFn(pattern string, excludes *manifestExcludeSet, matches *[]string, count *int) fs.WalkDirFunc {
 	return func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -789,9 +836,22 @@ func manifestGlobWalkFn(pattern string, matches *[]string) fs.WalkDirFunc {
 			return nil
 		}
 		if d.IsDir() {
+			// SkipDir-prune directories whose entire subtree is excluded by a
+			// "<prefix>/**" pattern. Non-"/**" excludes are left to the caller.
+			if excludes != nil && excludes.matchDir(p) {
+				return fs.SkipDir
+			}
 			return nil
 		}
 		if matchManifestPattern(pattern, p) {
+			*count++
+			if *count > maxManifestMatchesPerGlob {
+				return fmt.Errorf(
+					"metadata: glob %q exceeded match cap (limit=%d)"+
+						" — workspace may be too large or pattern too broad",
+					pattern, maxManifestMatchesPerGlob,
+				)
+			}
 			*matches = append(*matches, p)
 		}
 		return nil
@@ -819,24 +879,12 @@ func manifestGlobFixedPrefix(pattern string) string {
 		}
 		fixed = append(fixed, seg)
 	}
-	// No fixed directory prefix (pattern starts with wildcard, or the only
-	// fixed segment is the final filename at the root like "actors.yaml").
-	// In the latter case, fixed equals all segments (no wildcard at all) —
-	// we must not use the last segment as a directory root because it is a
-	// file, not a directory. Drop the last segment if it looks like a file.
-	//
-	// Heuristic: if the last fixed segment contains "." it is likely a
-	// filename; drop it. The remaining prefix is what to walk from.
-	//
-	// When no wildcards: walk from the parent of the literal file path so we
-	// don't need a separate Stat-and-match path.
-	hasWild := false
-	for _, seg := range segs {
-		if strings.ContainsAny(seg, "*?[") {
-			hasWild = true
-			break
-		}
-	}
+	// fixed is shorter than segs when the loop broke early on a wildcard
+	// segment. When fixed == segs, the pattern is a pure literal path with
+	// no wildcards; in that case drop the last segment (the filename) so we
+	// walk from its parent directory instead of needing a separate
+	// Stat-and-match path.
+	hasWild := len(fixed) < len(segs)
 	if !hasWild && len(fixed) > 0 {
 		// Literal path (no wildcards) — walk parent directory.
 		fixed = fixed[:len(fixed)-1]

--- a/kernel/metadata/locator_manifest_e2e_test.go
+++ b/kernel/metadata/locator_manifest_e2e_test.go
@@ -1,0 +1,235 @@
+// locator_manifest_e2e_test.go exercises the manifest-mode Locator/Parser
+// chain against a real on-disk temp directory.  This complements the
+// fstest.MapFS-based unit tests in locator_test.go by exercising the
+// NewLocator (on-disk) path and the Parser.Parse() → Locator.Discover()
+// full chain.
+//
+// Test coverage:
+//   - TestLocatorManifest_E2E_DiscoverConsistency — Discover() SourceCell
+//     paths match the cell.yaml files written in the temp dir.
+//   - TestLocatorManifest_E2E_ParserParse — Parser.Parse() returns a
+//     ProjectMeta whose Cells map contains the expected cell IDs.
+//   - TestLocatorManifest_E2E_CellIDDerivation — Manifest mode with
+//     conventional-layout includes derives CellID from path; manifest
+//     mode with non-conventional layout leaves CellID empty (action path
+//     per MetadataSource.CellID godoc: slice.yaml must declare
+//     belongsToCell explicitly).
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cellYAML returns a minimal valid cell.yaml body for the given id, team, and
+// primarySchema.  Split out to avoid repeated long inline strings.
+func cellYAML(id, team, primarySchema string) string {
+	return "id: " + id + "\n" +
+		"type: core\n" +
+		"consistencyLevel: L1\n" +
+		"owner:\n" +
+		"  team: " + team + "\n" +
+		"  role: cell-owner\n" +
+		"schema:\n" +
+		"  primary: " + primarySchema + "\n" +
+		"verify:\n" +
+		"  smoke:\n" +
+		"    - " + id + "/smoke.startup\n"
+}
+
+// sliceYAML returns a minimal valid slice.yaml body.
+func sliceYAML(id, belongsToCell string) string {
+	return "id: " + id + "\n" +
+		"belongsToCell: " + belongsToCell + "\n" +
+		"consistencyLevel: L1\n" +
+		"contractUsages: []\n" +
+		"verify:\n" +
+		"  unit:\n" +
+		"    - " + belongsToCell + "/" + id + "/unit\n" +
+		"  contract: []\n" +
+		"allowedFiles: []\n"
+}
+
+// writeFile writes content to path, creating parent directories as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+// TestLocatorManifest_E2E_DiscoverConsistency creates a temp dir with a
+// manifest.yaml and conventional-layout cell/slice/contract files, then
+// verifies Discover() returns SourceCell entries with matching paths.
+func TestLocatorManifest_E2E_DiscoverConsistency(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
+		"version: v1\nmodules:\n  - path: .\n    excludes:\n"+
+			"      - \"generated/**\"\n      - \"vendor/**\"\n")
+	writeFile(t, filepath.Join(root, "cells", "charge", "cell.yaml"),
+		cellYAML("charge", "payments", "charges"))
+	writeFile(t, filepath.Join(root, "cells", "charge", "slices", "api", "slice.yaml"),
+		sliceYAML("api", "charge"))
+	writeFile(t, filepath.Join(root, "contracts", "http", "charge", "create", "v1", "contract.yaml"),
+		"id: http.charge.create.v1\nkind: http\nlifecycle: experimental\n"+
+			"endpoints:\n  http:\n    method: POST\n    path: /api/v1/charge\n")
+
+	loc, err := NewLocator(root, WithLocatorMode(LocatorManifest))
+	if err != nil {
+		t.Fatalf("NewLocator: %v", err)
+	}
+	if loc.Mode() != LocatorManifest {
+		t.Fatalf("mode = %v, want LocatorManifest", loc.Mode())
+	}
+
+	sources, err := loc.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	// (a) SourceCell path must match the file we wrote.
+	var cellSrcs []MetadataSource
+	for _, s := range sources {
+		if s.Kind == SourceCell {
+			cellSrcs = append(cellSrcs, s)
+		}
+	}
+	if len(cellSrcs) != 1 {
+		t.Fatalf("want 1 SourceCell, got %d: %v", len(cellSrcs), cellSrcs)
+	}
+	wantCellPath := "cells/charge/cell.yaml"
+	if cellSrcs[0].Path != wantCellPath {
+		t.Errorf("cell path = %q, want %q", cellSrcs[0].Path, wantCellPath)
+	}
+
+	// (b) CellID derivation: conventional-layout path → derived CellID.
+	if cellSrcs[0].CellID != "charge" {
+		t.Errorf("cell CellID = %q, want %q", cellSrcs[0].CellID, "charge")
+	}
+
+	// (c) SourceContract present.
+	var contractCount int
+	for _, s := range sources {
+		if s.Kind == SourceContract {
+			contractCount++
+		}
+	}
+	if contractCount != 1 {
+		t.Errorf("want 1 SourceContract, got %d", contractCount)
+	}
+}
+
+// TestLocatorManifest_E2E_ParserParse verifies that the full
+// NewParser → Parse() chain in manifest mode returns a ProjectMeta
+// whose Cells map contains the cell IDs from cell.yaml.
+func TestLocatorManifest_E2E_ParserParse(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
+		"version: v1\nmodules:\n  - path: .\n")
+	writeFile(t, filepath.Join(root, "cells", "invoice", "cell.yaml"),
+		cellYAML("invoice", "billing", "invoices"))
+	writeFile(t, filepath.Join(root, "cells", "invoice", "slices", "query", "slice.yaml"),
+		"id: query\nbelongsToCell: invoice\nconsistencyLevel: L0\n"+
+			"contractUsages: []\nverify:\n  unit:\n    - invoice/query/unit\n"+
+			"  contract: []\nallowedFiles: []\n")
+
+	pm, err := NewParser(root, WithLocatorMode(LocatorManifest)).Parse()
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	// (a) ProjectMeta.Cells contains the expected cell.
+	if _, ok := pm.Cells["invoice"]; !ok {
+		t.Errorf("Cells[\"invoice\"] missing; got keys: %v", cellKeys(pm))
+	}
+
+	// (b) Slices resolved with correct belongsToCell.
+	for _, sl := range pm.Slices {
+		if sl.BelongsToCell != "invoice" {
+			t.Errorf("slice %q belongsToCell = %q, want \"invoice\"",
+				sl.ID, sl.BelongsToCell)
+		}
+	}
+}
+
+// TestLocatorManifest_E2E_CellIDDerivation checks the CellID derivation
+// strategy documented in MetadataSource.CellID godoc:
+//   - conventional includes path → CellID derived from path segments
+//   - non-conventional layout (custom module path) → CellID empty,
+//     slice must declare belongsToCell explicitly.
+func TestLocatorManifest_E2E_CellIDDerivation(t *testing.T) {
+	t.Run("conventional includes derive CellID", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
+			"version: v1\nmodules:\n  - path: .\n")
+		writeFile(t, filepath.Join(root, "cells", "wallet", "cell.yaml"),
+			cellYAML("wallet", "fin", "wallets"))
+
+		loc, err := NewLocator(root, WithLocatorMode(LocatorManifest))
+		if err != nil {
+			t.Fatalf("NewLocator: %v", err)
+		}
+		sources, err := loc.Discover()
+		if err != nil {
+			t.Fatalf("Discover: %v", err)
+		}
+		for _, s := range sources {
+			if s.Kind == SourceCell && s.Path == "cells/wallet/cell.yaml" {
+				if s.CellID != "wallet" {
+					t.Errorf("CellID = %q, want %q", s.CellID, "wallet")
+				}
+				return
+			}
+		}
+		t.Fatal("SourceCell for wallet not found")
+	})
+
+	t.Run("non-conventional layout SourceCell is discoverable", func(t *testing.T) {
+		root := t.TempDir()
+		// Custom layout: services/payments/cells/charge/cell.yaml
+		// The manifest includes pattern matches, but the path segments
+		// do not follow cells/<id>/cell.yaml (extra prefix directory).
+		writeFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
+			"version: v1\nmodules:\n  - path: .\n    includes:\n"+
+				"      cells:\n        - \"services/*/cells/*/cell.yaml\"\n")
+		writeFile(t,
+			filepath.Join(root, "services", "payments", "cells", "charge", "cell.yaml"),
+			cellYAML("charge", "pay", "charges"))
+
+		loc, err := NewLocator(root, WithLocatorMode(LocatorManifest))
+		if err != nil {
+			t.Fatalf("NewLocator: %v", err)
+		}
+		sources, err := loc.Discover()
+		if err != nil {
+			t.Fatalf("Discover: %v", err)
+		}
+		for _, s := range sources {
+			if s.Kind == SourceCell {
+				// CellID may be empty when the locator cannot derive it
+				// from a non-conventional path. Callers should read the
+				// cell.yaml `id` field or require slice.yaml to declare
+				// belongsToCell explicitly (per MetadataSource.CellID godoc).
+				t.Logf("SourceCell found at %q CellID=%q (non-conventional layout)",
+					s.Path, s.CellID)
+				return
+			}
+		}
+		t.Fatal("SourceCell not found for non-conventional layout fixture")
+	})
+}
+
+// cellKeys returns sorted cell IDs from a ProjectMeta, used in error messages.
+func cellKeys(pm *ProjectMeta) []string {
+	keys := make([]string, 0, len(pm.Cells))
+	for k := range pm.Cells {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/kernel/metadata/locator_manifest_e2e_test.go
+++ b/kernel/metadata/locator_manifest_e2e_test.go
@@ -149,11 +149,21 @@ func TestLocatorManifest_E2E_ParserParse(t *testing.T) {
 		t.Errorf("Cells[\"invoice\"] missing; got keys: %v", cellKeys(pm))
 	}
 
-	// (b) Slices resolved with correct belongsToCell.
+	// (b) Slices resolved with correct belongsToCell and populated path fields.
 	for _, sl := range pm.Slices {
 		if sl.BelongsToCell != "invoice" {
 			t.Errorf("slice %q belongsToCell = %q, want \"invoice\"",
 				sl.ID, sl.BelongsToCell)
+		}
+		// T6: verify path fields are populated by the Locator-backed parser.
+		if sl.File == "" {
+			t.Errorf("slice %q File is empty; parser must set File from MetadataSource.Path", sl.ID)
+		}
+		if sl.Dir == "" {
+			t.Errorf("slice %q Dir is empty; parser must set Dir from path.Base(path.Dir(src.Path))", sl.ID)
+		}
+		if sl.CellDir != "invoice" {
+			t.Errorf("slice %q CellDir = %q, want \"invoice\"", sl.ID, sl.CellDir)
 		}
 	}
 }
@@ -212,12 +222,15 @@ func TestLocatorManifest_E2E_CellIDDerivation(t *testing.T) {
 		}
 		for _, s := range sources {
 			if s.Kind == SourceCell {
-				// CellID may be empty when the locator cannot derive it
-				// from a non-conventional path. Callers should read the
-				// cell.yaml `id` field or require slice.yaml to declare
+				// Non-conventional layout: the Locator cannot derive CellID
+				// from a path that does not match cells/<id>/cell.yaml.
+				// MetadataSource.CellID must be empty; callers must read
+				// the cell.yaml `id` field or require slice.yaml to declare
 				// belongsToCell explicitly (per MetadataSource.CellID godoc).
-				t.Logf("SourceCell found at %q CellID=%q (non-conventional layout)",
-					s.Path, s.CellID)
+				if s.CellID != "" {
+					t.Errorf("non-conventional layout source CellID = %q, want empty"+
+						" (only conventional walk can derive it)", s.CellID)
+				}
 				return
 			}
 		}

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -302,8 +302,8 @@ modules:
 
 // TestLocator_ManifestGlobNoMatch verifies that a custom include glob
 // that explicitly declares a pattern but matches zero files returns an
-// error (F2: fail-closed for explicit patterns — typo guard).
-// Nil/empty patterns are not affected.
+// error (F2/S1: fail-closed at emission granularity for explicit patterns —
+// typo guard). The error must mention "matched zero files" and the kind.
 func TestLocator_ManifestGlobNoMatch(t *testing.T) {
 	manifest := `version: v1
 modules:
@@ -327,8 +327,9 @@ modules:
 	if !strings.Contains(err.Error(), "matched zero files") {
 		t.Errorf("error %q does not contain %q", err.Error(), "matched zero files")
 	}
-	if !strings.Contains(err.Error(), "cells/bar/cell.yaml") {
-		t.Errorf("error %q does not contain pattern %q", err.Error(), "cells/bar/cell.yaml")
+	// S1 redesign: error is at emission (kind) level, not per-pattern.
+	if !strings.Contains(err.Error(), "cell") {
+		t.Errorf("error %q should mention kind 'cell'", err.Error())
 	}
 }
 
@@ -392,7 +393,7 @@ func TestParseLocatorMode(t *testing.T) {
 
 // TestLocator_ManifestModulePathExistence verifies that a manifest module.path
 // that does not exist as a directory in fsys returns an error (F1: fail-closed
-// existence + IsDir check).
+// existence + IsDir check). O3: ErrNotExist and file-not-dir are distinct messages.
 func TestLocator_ManifestModulePathExistence(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -406,7 +407,7 @@ func TestLocator_ManifestModulePathExistence(t *testing.T) {
 			fsys: fstest.MapFS{
 				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: nonexistent\n")},
 			},
-			wantSub: `does not exist (or is not a directory)`,
+			wantSub: `does not exist`,
 		},
 		{
 			name:     "module path is a file not a directory",
@@ -415,7 +416,7 @@ func TestLocator_ManifestModulePathExistence(t *testing.T) {
 				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: iam-a-file\n")},
 				"iam-a-file":            &fstest.MapFile{Data: []byte("not a dir\n")},
 			},
-			wantSub: `does not exist (or is not a directory)`,
+			wantSub: `is not a directory`,
 		},
 		{
 			name: "dot path (workspace root) always valid",
@@ -591,6 +592,198 @@ modules:
 	if got := summariseSources(sources); !reflect.DeepEqual(got, want) {
 		t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
 	}
+}
+
+// TestLocator_ManifestEmissionPerEmissionFailClosed verifies S1: zero matches
+// are fail-closed at the emission (kind) level, not the per-pattern level.
+// A manifest with two patterns for the same kind where the first matches and
+// the second doesn't should succeed (multi-pattern fallback).
+// A manifest with two patterns where neither matches should fail.
+func TestLocator_ManifestEmissionPerEmissionFailClosed(t *testing.T) {
+	t.Run("first pattern matches second empty — should succeed", func(t *testing.T) {
+		manifest := `version: v1
+modules:
+  - path: .
+    includes:
+      cells:
+        - "cells/*/cell.yaml"
+        - "alt/*/cell.yaml"
+`
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
+			"cells/foo/cell.yaml":   &fstest.MapFile{Data: []byte("id: foo\n")},
+			// alt/ does not exist — second pattern matches zero files, but
+			// the emission (cells kind) as a whole matched at least one file.
+		}
+		l, err := NewLocatorFS(fsys)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		sources, err := l.Discover()
+		if err != nil {
+			t.Fatalf("Discover unexpected error (multi-pattern fallback must succeed): %v", err)
+		}
+		got := summariseSources(sources)
+		want := []string{"cell:cells/foo/cell.yaml:foo"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("all patterns match zero — should fail-closed", func(t *testing.T) {
+		manifest := `version: v1
+modules:
+  - path: .
+    includes:
+      cells:
+        - "cells/bar/cell.yaml"
+        - "alt/bar/cell.yaml"
+`
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
+			"cells/foo/cell.yaml":   &fstest.MapFile{Data: []byte("id: foo\n")},
+		}
+		l, err := NewLocatorFS(fsys)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		_, err = l.Discover()
+		if err == nil {
+			t.Fatal("expected fail-closed error when all patterns for an emission match zero files")
+		}
+		if !strings.Contains(err.Error(), "matched zero files") {
+			t.Errorf("error %q does not contain %q", err.Error(), "matched zero files")
+		}
+		// S1: error message must mention both patterns or at least the kind.
+		if !strings.Contains(err.Error(), "cell") {
+			t.Errorf("error %q should mention kind 'cell'", err.Error())
+		}
+	})
+
+	t.Run("per-pattern warn not error when default patterns", func(t *testing.T) {
+		// Default-patterns emission that produces zero for journeys/assemblies is OK
+		// (e.g. a repo with only cells, no journeys). No error expected.
+		manifest := "version: v1\nmodules:\n  - path: .\n"
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
+			"cells/foo/cell.yaml":   &fstest.MapFile{Data: []byte("id: foo\n")},
+			// no journeys, no assemblies, no contracts, no slices
+		}
+		l, err := NewLocatorFS(fsys)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		_, err = l.Discover()
+		if err != nil {
+			t.Errorf("expected no error for default-pattern zero-match, got: %v", err)
+		}
+	})
+}
+
+// TestManifestGlobFixedPrefix exercises manifestGlobFixedPrefix with the
+// examples from the godoc plus edge cases.
+func TestManifestGlobFixedPrefix(t *testing.T) {
+	cases := []struct {
+		pattern string
+		want    string
+	}{
+		// godoc examples
+		{"cells/*/cell.yaml", "cells"},
+		{"contracts/**/contract.yaml", "contracts"},
+		{"**/cell.yaml", "."},
+		{"*/cell.yaml", "."},
+		{"actors.yaml", "."},
+		{"cells/foo/bar/cell.yaml", "cells/foo/bar"},
+		// additional edge cases
+		{"journeys/J-*.yaml", "journeys"},
+		{"assemblies/*/assembly.yaml", "assemblies"},
+		{"journeys/status-board.yaml", "journeys"},
+		// wildcard at root
+		{"**", "."},
+		{"*", "."},
+		// no wildcard, single file at root
+		{"cell.yaml", "."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			got := manifestGlobFixedPrefix(tc.pattern)
+			if got != tc.want {
+				t.Errorf("manifestGlobFixedPrefix(%q) = %q, want %q", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatchManifestPattern exercises matchManifestPattern with various
+// wildcard forms.
+func TestMatchManifestPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		name    string
+		want    bool
+	}{
+		// "*" matches a single path segment only
+		{"cells/*/cell.yaml", "cells/foo/cell.yaml", true},
+		{"cells/*/cell.yaml", "cells/foo/bar/cell.yaml", false},
+		{"cells/*/cell.yaml", "cells/cell.yaml", false},
+		// "**" matches zero or more segments
+		{"contracts/**/contract.yaml", "contracts/http/auth/login/v1/contract.yaml", true},
+		{"contracts/**/contract.yaml", "contracts/contract.yaml", true}, // zero segments
+		{"contracts/**/contract.yaml", "other/contract.yaml", false},
+		// "**" in middle
+		{"a/**/b/c.yaml", "a/x/y/b/c.yaml", true},
+		{"a/**/b/c.yaml", "a/b/c.yaml", true}, // ** matches zero
+		{"a/**/b/c.yaml", "a/c.yaml", false},
+		// literal file — exact match
+		{"actors.yaml", "actors.yaml", true},
+		{"actors.yaml", "other.yaml", false},
+		{"actors.yaml", "sub/actors.yaml", false},
+		// literal mismatch
+		{"cells/foo/cell.yaml", "cells/bar/cell.yaml", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pattern+"~"+tc.name, func(t *testing.T) {
+			got := matchManifestPattern(tc.pattern, tc.name)
+			if got != tc.want {
+				t.Errorf("matchManifestPattern(%q, %q) = %v, want %v",
+					tc.pattern, tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppendGeneratedExclude verifies idempotency (already-present entry is
+// not duplicated) and additive behavior (entry is appended when absent).
+func TestAppendGeneratedExclude(t *testing.T) {
+	t.Run("appends when absent", func(t *testing.T) {
+		in := []string{"fixtures/**"}
+		got := appendGeneratedExclude(in)
+		want := []string{"fixtures/**", "generated/**"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("idempotent when already present", func(t *testing.T) {
+		in := []string{"fixtures/**", "generated/**"}
+		got := appendGeneratedExclude(in)
+		if !reflect.DeepEqual(got, in) {
+			t.Errorf("got %v, want %v (idempotent)", got, in)
+		}
+	})
+	t.Run("nil input appends generated", func(t *testing.T) {
+		got := appendGeneratedExclude(nil)
+		want := []string{"generated/**"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("generated in middle — still idempotent", func(t *testing.T) {
+		in := []string{"generated/**", "other/**"}
+		got := appendGeneratedExclude(in)
+		if !reflect.DeepEqual(got, in) {
+			t.Errorf("got %v, want %v (idempotent)", got, in)
+		}
+	})
 }
 
 // TestLocator_AutoDetectStatErrorPropagates ensures probe failures other than

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -177,6 +177,7 @@ func TestLocator_ManifestRejectsBadPaths(t *testing.T) {
 	cases := []struct {
 		name     string
 		manifest string
+		extraFS  fstest.MapFS // optional extra files beyond .gocell/manifest.yaml
 		wantSub  string
 	}{
 		{
@@ -195,15 +196,25 @@ func TestLocator_ManifestRejectsBadPaths(t *testing.T) {
 			wantSub:  "duplicates modules[0]",
 		},
 		{
+			// secondary singleton: "sub" dir must exist so dir-existence check
+			// (F1) passes and the singleton check fires as expected.
 			name: "secondary singleton actors",
 			manifest: "version: v1\nmodules:\n  - path: .\n  - path: sub\n" +
 				"    includes:\n      actors: actors.yaml\n",
+			extraFS: fstest.MapFS{
+				"sub/.keep": &fstest.MapFile{Data: []byte("")},
+			},
 			wantSub: "actors.yaml is a workspace-level singleton",
 		},
 		{
+			// secondary singleton: "sub" dir must exist so dir-existence check
+			// (F1) passes and the singleton check fires as expected.
 			name: "secondary singleton statusBoard",
 			manifest: "version: v1\nmodules:\n  - path: .\n  - path: sub\n" +
 				"    includes:\n      statusBoard: journeys/status-board.yaml\n",
+			extraFS: fstest.MapFS{
+				"sub/.keep": &fstest.MapFile{Data: []byte("")},
+			},
 			wantSub: "status-board.yaml is a workspace-level singleton",
 		},
 		{
@@ -244,6 +255,9 @@ func TestLocator_ManifestRejectsBadPaths(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fsys := fstest.MapFS{
 				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(tc.manifest)},
+			}
+			for k, v := range tc.extraFS {
+				fsys[k] = v
 			}
 			_, err := NewLocatorFS(fsys, WithLocatorMode(LocatorManifest))
 			if err == nil {
@@ -287,9 +301,9 @@ modules:
 }
 
 // TestLocator_ManifestGlobNoMatch verifies that a custom include glob
-// that matches zero files is not an error and produces an empty result
-// (the slog.Warn surface is the operator-facing signal, not a hard
-// failure — gocell validate succeeds with zero discovered cells).
+// that explicitly declares a pattern but matches zero files returns an
+// error (F2: fail-closed for explicit patterns — typo guard).
+// Nil/empty patterns are not affected.
 func TestLocator_ManifestGlobNoMatch(t *testing.T) {
 	manifest := `version: v1
 modules:
@@ -306,12 +320,15 @@ modules:
 	if err != nil {
 		t.Fatalf("NewLocatorFS: %v", err)
 	}
-	sources, err := l.Discover()
-	if err != nil {
-		t.Fatalf("Discover: %v", err)
+	_, err = l.Discover()
+	if err == nil {
+		t.Fatal("expected error for zero-match explicit pattern, got nil")
 	}
-	if len(sources) != 0 {
-		t.Errorf("Discover with non-matching glob produced %d sources, want 0", len(sources))
+	if !strings.Contains(err.Error(), "matched zero files") {
+		t.Errorf("error %q does not contain %q", err.Error(), "matched zero files")
+	}
+	if !strings.Contains(err.Error(), "cells/bar/cell.yaml") {
+		t.Errorf("error %q does not contain pattern %q", err.Error(), "cells/bar/cell.yaml")
 	}
 }
 
@@ -373,6 +390,209 @@ func TestParseLocatorMode(t *testing.T) {
 	}
 }
 
+// TestLocator_ManifestModulePathExistence verifies that a manifest module.path
+// that does not exist as a directory in fsys returns an error (F1: fail-closed
+// existence + IsDir check).
+func TestLocator_ManifestModulePathExistence(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		fsys     fstest.MapFS
+		wantSub  string
+	}{
+		{
+			name:     "module path does not exist",
+			manifest: "version: v1\nmodules:\n  - path: nonexistent\n",
+			fsys: fstest.MapFS{
+				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: nonexistent\n")},
+			},
+			wantSub: `does not exist (or is not a directory)`,
+		},
+		{
+			name:     "module path is a file not a directory",
+			manifest: "version: v1\nmodules:\n  - path: iam-a-file\n",
+			fsys: fstest.MapFS{
+				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: iam-a-file\n")},
+				"iam-a-file":            &fstest.MapFile{Data: []byte("not a dir\n")},
+			},
+			wantSub: `does not exist (or is not a directory)`,
+		},
+		{
+			name: "dot path (workspace root) always valid",
+			fsys: fstest.MapFS{
+				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: .\n")},
+			},
+			wantSub: "", // no error expected
+		},
+		{
+			name: "valid subdirectory path exists",
+			fsys: fstest.MapFS{
+				".gocell/manifest.yaml":  &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: modules/core\n")},
+				"modules/core/cell.yaml": &fstest.MapFile{Data: []byte("id: core\n")},
+			},
+			wantSub: "", // no error expected
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewLocatorFS(tc.fsys, WithLocatorMode(LocatorManifest))
+			if tc.wantSub == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestLocator_ManifestGlobWalkPrefix verifies that matchManifestGlob starts
+// the WalkDir from the fixed prefix before the first wildcard, not from root.
+// This is F3: ReadDir should not be called on "." or "other" when the
+// pattern prefix is "cells".
+func TestLocator_ManifestGlobWalkPrefix(t *testing.T) {
+	// Build a filesystem with files in two top-level dirs.
+	fsys := fstest.MapFS{
+		"cells/foo/cell.yaml": &fstest.MapFile{Data: []byte("id: foo\n")},
+		"other/bar/file.txt":  &fstest.MapFile{Data: []byte("other\n")},
+	}
+	var readDirCalls []string
+	traceFS := &walkTraceFS{MapFS: fsys, visited: &readDirCalls}
+
+	matches, err := matchManifestGlob(traceFS, "cells/*/cell.yaml")
+	if err != nil {
+		t.Fatalf("matchManifestGlob: %v", err)
+	}
+	if len(matches) != 1 || matches[0] != "cells/foo/cell.yaml" {
+		t.Errorf("matches = %v, want [cells/foo/cell.yaml]", matches)
+	}
+	// ReadDir should not be called on "other" or any path under "other/".
+	for _, dir := range readDirCalls {
+		if dir == "other" || strings.HasPrefix(dir, "other/") {
+			t.Errorf("ReadDir called on %q — should not scan outside prefix", dir)
+		}
+	}
+	// ReadDir should not be called on "." (the root) when prefix is "cells".
+	for _, dir := range readDirCalls {
+		if dir == "." {
+			t.Errorf("ReadDir called on root '.' — expected prefix-scoped walk starting from 'cells'")
+		}
+	}
+	// ReadDir should have been called on "cells" (the walk root).
+	found := false
+	for _, dir := range readDirCalls {
+		if dir == "cells" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ReadDir was never called on 'cells' — prefix walk did not start from expected root; got: %v", readDirCalls)
+	}
+}
+
+// TestLocator_ManifestGlobWalkPrefixDoubleStarFromRoot verifies that a pattern
+// starting with "**" still walks from root (no prefix optimization possible).
+func TestLocator_ManifestGlobWalkPrefixDoubleStarFromRoot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"cells/foo/cell.yaml": &fstest.MapFile{Data: []byte("id: foo\n")},
+	}
+	var readDirCalls []string
+	traceFS := &walkTraceFS{MapFS: fsys, visited: &readDirCalls}
+	_, err := matchManifestGlob(traceFS, "**/cell.yaml")
+	if err != nil {
+		t.Fatalf("matchManifestGlob: %v", err)
+	}
+	// Root "." should be visited when pattern starts with **.
+	found := false
+	for _, dir := range readDirCalls {
+		if dir == "." {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ReadDir was never called on '.' for **-pattern; got: %v", readDirCalls)
+	}
+}
+
+// TestLocator_WithManifestPathRejectsUnsafe verifies that WithManifestPath
+// with an absolute path or parent-escape path is rejected at construction
+// (F12: fail-fast in NewLocatorFS/NewLocator).
+func TestLocator_WithManifestPathRejectsUnsafe(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		wantSub string
+	}{
+		{
+			name:    "absolute path",
+			path:    "/etc/manifest.yaml",
+			wantSub: "absolute path not allowed",
+		},
+		{
+			name:    "parent escape",
+			path:    "../outside/manifest.yaml",
+			wantSub: "path escape not allowed",
+		},
+		{
+			name:    "double parent escape",
+			path:    "../../manifest.yaml",
+			wantSub: "path escape not allowed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys := fstest.MapFS{
+				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: .\n")},
+			}
+			_, err := NewLocatorFS(fsys, WithManifestPath(tc.path), WithLocatorMode(LocatorConventional))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestLocator_GeneratedExcludeAdditive verifies that a manifest module with
+// explicit excludes still gets "generated/**" appended (F13: additive, not
+// replacing). The user-declared excludes must also be honored.
+func TestLocator_GeneratedExcludeAdditive(t *testing.T) {
+	manifest := `version: v1
+modules:
+  - path: .
+    excludes:
+      - "fixtures/**"
+`
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml":             &fstest.MapFile{Data: []byte(manifest)},
+		"cells/real/cell.yaml":              &fstest.MapFile{Data: []byte("id: real\n")},
+		"fixtures/cell.yaml":                &fstest.MapFile{Data: []byte("id: fixture\n")},
+		"generated/contracts/foo/cell.yaml": &fstest.MapFile{Data: []byte("id: gen\n")},
+		"generated/cells/bar/cell.yaml":     &fstest.MapFile{Data: []byte("id: gen2\n")},
+	}
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	// Only "real" should appear; fixtures/** and generated/** both excluded.
+	want := []string{"cell:cells/real/cell.yaml:real"}
+	if got := summariseSources(sources); !reflect.DeepEqual(got, want) {
+		t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
 // TestLocator_AutoDetectStatErrorPropagates ensures probe failures other than
 // fs.ErrNotExist surface up rather than being mis-treated as "manifest absent".
 func TestLocator_AutoDetectStatErrorPropagates(t *testing.T) {
@@ -427,3 +647,27 @@ type errFS struct{ err error }
 
 func (e errFS) Open(name string) (fs.File, error)     { return nil, e.err }
 func (e errFS) Stat(name string) (fs.FileInfo, error) { return nil, e.err }
+
+// walkTraceFS wraps a MapFS and records every directory path for which ReadDir
+// is called by fs.WalkDir, so tests can assert which subtrees were scanned.
+// fstest.MapFS implements ReadDirFS, so fs.WalkDir uses ReadDir (not Open) for
+// directory listing. We intercept ReadDir to capture the walked roots.
+type walkTraceFS struct {
+	MapFS   fstest.MapFS
+	visited *[]string
+}
+
+func (w *walkTraceFS) Open(name string) (fs.File, error) {
+	return w.MapFS.Open(name)
+}
+
+// ReadDir is the primary interception point: fs.WalkDir calls ReadDir on each
+// directory it descends into (including the walk root itself).
+func (w *walkTraceFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	*w.visited = append(*w.visited, name)
+	return w.MapFS.ReadDir(name)
+}
+
+func (w *walkTraceFS) Stat(name string) (fs.FileInfo, error) {
+	return fs.Stat(w.MapFS, name)
+}

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -466,7 +466,7 @@ func TestLocator_ManifestGlobWalkPrefix(t *testing.T) {
 	var readDirCalls []string
 	traceFS := &walkTraceFS{MapFS: fsys, visited: &readDirCalls}
 
-	matches, err := matchManifestGlob(traceFS, "cells/*/cell.yaml")
+	matches, err := matchManifestGlob(traceFS, "cells/*/cell.yaml", nil)
 	if err != nil {
 		t.Fatalf("matchManifestGlob: %v", err)
 	}
@@ -505,7 +505,7 @@ func TestLocator_ManifestGlobWalkPrefixDoubleStarFromRoot(t *testing.T) {
 	}
 	var readDirCalls []string
 	traceFS := &walkTraceFS{MapFS: fsys, visited: &readDirCalls}
-	_, err := matchManifestGlob(traceFS, "**/cell.yaml")
+	_, err := matchManifestGlob(traceFS, "**/cell.yaml", nil)
 	if err != nil {
 		t.Fatalf("matchManifestGlob: %v", err)
 	}

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -43,22 +43,22 @@ func TestLocator_AutoDetect(t *testing.T) {
 // are emitted for a conventional layout.
 func TestLocator_ConventionalDiscover(t *testing.T) {
 	fsys := fstest.MapFS{
-		"cells/accesscore/cell.yaml":                                       &fstest.MapFile{Data: []byte("id: accesscore\n")},
-		"cells/accesscore/slices/login/slice.yaml":                         &fstest.MapFile{Data: []byte("id: login\n")},
-		"cells/auditcore/cell.yaml":                                        &fstest.MapFile{Data: []byte("id: auditcore\n")},
-		"contracts/http/auth/login/v1/contract.yaml":                       &fstest.MapFile{Data: []byte("id: http.auth.login.v1\n")},
-		"contracts/event/session/created/v1/contract.yaml":                 &fstest.MapFile{Data: []byte("id: event.session.created.v1\n")},
-		"journeys/J-ssologin.yaml":                                         &fstest.MapFile{Data: []byte("id: J-ssologin\n")},
-		"journeys/status-board.yaml":                                       &fstest.MapFile{Data: []byte("- journey: J-ssologin\n")},
-		"assemblies/platform/assembly.yaml":                                &fstest.MapFile{Data: []byte("id: platform\n")},
-		"actors.yaml":                                                      &fstest.MapFile{Data: []byte("- id: external\n")},
-		"examples/ssobff/cells/foo/cell.yaml":                              &fstest.MapFile{Data: []byte("id: foo\n")},
-		"examples/ssobff/cells/foo/slices/bar/slice.yaml":                  &fstest.MapFile{Data: []byte("id: bar\n")},
-		"examples/ssobff/contracts/http/x/y/v1/contract.yaml":              &fstest.MapFile{Data: []byte("id: http.x.y.v1\n")},
-		"examples/ssobff/journeys/J-flow.yaml":                             &fstest.MapFile{Data: []byte("id: J-flow\n")},
-		"examples/ssobff/assembly.yaml":                                    &fstest.MapFile{Data: []byte("id: ssobff\n")},
-		"README.md":                                                        &fstest.MapFile{Data: []byte("ignored\n")},
-		"cells/accesscore/slices/login/handler.go":                         &fstest.MapFile{Data: []byte("// ignored\n")},
+		"cells/accesscore/cell.yaml":                          &fstest.MapFile{Data: []byte("id: accesscore\n")},
+		"cells/accesscore/slices/login/slice.yaml":            &fstest.MapFile{Data: []byte("id: login\n")},
+		"cells/auditcore/cell.yaml":                           &fstest.MapFile{Data: []byte("id: auditcore\n")},
+		"contracts/http/auth/login/v1/contract.yaml":          &fstest.MapFile{Data: []byte("id: http.auth.login.v1\n")},
+		"contracts/event/session/created/v1/contract.yaml":    &fstest.MapFile{Data: []byte("id: event.session.created.v1\n")},
+		"journeys/J-ssologin.yaml":                            &fstest.MapFile{Data: []byte("id: J-ssologin\n")},
+		"journeys/status-board.yaml":                          &fstest.MapFile{Data: []byte("- journey: J-ssologin\n")},
+		"assemblies/platform/assembly.yaml":                   &fstest.MapFile{Data: []byte("id: platform\n")},
+		"actors.yaml":                                         &fstest.MapFile{Data: []byte("- id: external\n")},
+		"examples/ssobff/cells/foo/cell.yaml":                 &fstest.MapFile{Data: []byte("id: foo\n")},
+		"examples/ssobff/cells/foo/slices/bar/slice.yaml":     &fstest.MapFile{Data: []byte("id: bar\n")},
+		"examples/ssobff/contracts/http/x/y/v1/contract.yaml": &fstest.MapFile{Data: []byte("id: http.x.y.v1\n")},
+		"examples/ssobff/journeys/J-flow.yaml":                &fstest.MapFile{Data: []byte("id: J-flow\n")},
+		"examples/ssobff/assembly.yaml":                       &fstest.MapFile{Data: []byte("id: ssobff\n")},
+		"README.md":                                           &fstest.MapFile{Data: []byte("ignored\n")},
+		"cells/accesscore/slices/login/handler.go":            &fstest.MapFile{Data: []byte("// ignored\n")},
 	}
 	l, err := NewLocatorFS(fsys, WithLocatorMode(LocatorConventional))
 	if err != nil {
@@ -98,14 +98,14 @@ modules:
   - path: .
 `
 	fsys := fstest.MapFS{
-		".gocell/manifest.yaml":                    &fstest.MapFile{Data: []byte(manifest)},
-		"cells/payment/cell.yaml":                  &fstest.MapFile{Data: []byte("id: payment\n")},
-		"cells/payment/slices/charge/slice.yaml":   &fstest.MapFile{Data: []byte("id: charge\n")},
+		".gocell/manifest.yaml":                          &fstest.MapFile{Data: []byte(manifest)},
+		"cells/payment/cell.yaml":                        &fstest.MapFile{Data: []byte("id: payment\n")},
+		"cells/payment/slices/charge/slice.yaml":         &fstest.MapFile{Data: []byte("id: charge\n")},
 		"contracts/http/payment/charge/v1/contract.yaml": &fstest.MapFile{Data: []byte("id: http.payment.charge.v1\n")},
-		"journeys/J-payment.yaml":                  &fstest.MapFile{Data: []byte("id: J-payment\n")},
-		"assemblies/payment-svc/assembly.yaml":     &fstest.MapFile{Data: []byte("id: payment-svc\n")},
-		"actors.yaml":                              &fstest.MapFile{Data: []byte("- id: bank\n")},
-		"journeys/status-board.yaml":               &fstest.MapFile{Data: []byte("- journey: J-payment\n")},
+		"journeys/J-payment.yaml":                        &fstest.MapFile{Data: []byte("id: J-payment\n")},
+		"assemblies/payment-svc/assembly.yaml":           &fstest.MapFile{Data: []byte("id: payment-svc\n")},
+		"actors.yaml":                                    &fstest.MapFile{Data: []byte("- id: bank\n")},
+		"journeys/status-board.yaml":                     &fstest.MapFile{Data: []byte("- journey: J-payment\n")},
 	}
 	l, err := NewLocatorFS(fsys)
 	if err != nil {
@@ -200,9 +200,9 @@ func TestLocator_ManifestRejectsBadPaths(t *testing.T) {
 			wantSub: "actors.yaml is a workspace-level singleton",
 		},
 		{
-			name: "unsupported version",
+			name:     "unsupported version",
 			manifest: "version: v2\nmodules:\n  - path: .\n",
-			wantSub: "unsupported version",
+			wantSub:  "unsupported version",
 		},
 		{
 			name:     "empty modules",
@@ -239,9 +239,9 @@ modules:
       - "cells/skip/**"
 `
 	fsys := fstest.MapFS{
-		".gocell/manifest.yaml":    &fstest.MapFile{Data: []byte(manifest)},
-		"cells/keep/cell.yaml":     &fstest.MapFile{Data: []byte("id: keep\n")},
-		"cells/skip/cell.yaml":     &fstest.MapFile{Data: []byte("id: skip\n")},
+		".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
+		"cells/keep/cell.yaml":  &fstest.MapFile{Data: []byte("id: keep\n")},
+		"cells/skip/cell.yaml":  &fstest.MapFile{Data: []byte("id: skip\n")},
 	}
 	l, err := NewLocatorFS(fsys)
 	if err != nil {
@@ -316,5 +316,5 @@ func summariseSources(sources []MetadataSource) []string {
 // path, used to verify Locator propagates probe failures.
 type errFS struct{ err error }
 
-func (e errFS) Open(name string) (fs.File, error)    { return nil, e.err }
+func (e errFS) Open(name string) (fs.File, error)     { return nil, e.err }
 func (e errFS) Stat(name string) (fs.FileInfo, error) { return nil, e.err }

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"reflect"
 	"sort"
@@ -200,6 +201,35 @@ func TestLocator_ManifestRejectsBadPaths(t *testing.T) {
 			wantSub: "actors.yaml is a workspace-level singleton",
 		},
 		{
+			name: "secondary singleton statusBoard",
+			manifest: "version: v1\nmodules:\n  - path: .\n  - path: sub\n" +
+				"    includes:\n      statusBoard: journeys/status-board.yaml\n",
+			wantSub: "status-board.yaml is a workspace-level singleton",
+		},
+		{
+			name: "excludes with parent escape",
+			manifest: "version: v1\nmodules:\n  - path: .\n" +
+				"    excludes:\n      - ../../secret/**\n",
+			wantSub: "path escape not allowed",
+		},
+		{
+			name: "include glob with parent escape",
+			manifest: "version: v1\nmodules:\n  - path: .\n" +
+				"    includes:\n      cells:\n        - ../../secret/cell.yaml\n",
+			wantSub: "path escape not allowed",
+		},
+		{
+			name: "manifest too large rejected",
+			// Repeat a valid module line until the YAML exceeds the 64 KiB cap.
+			manifest: largeManifestExceedingSizeLimit(),
+			wantSub:  "exceeds size limit",
+		},
+		{
+			name:     "too many modules rejected",
+			manifest: tooManyModulesManifest(),
+			wantSub:  "too many modules",
+		},
+		{
 			name:     "unsupported version",
 			manifest: "version: v2\nmodules:\n  - path: .\n",
 			wantSub:  "unsupported version",
@@ -256,6 +286,61 @@ modules:
 	}
 }
 
+// TestLocator_ManifestGlobNoMatch verifies that a custom include glob
+// that matches zero files is not an error and produces an empty result
+// (the slog.Warn surface is the operator-facing signal, not a hard
+// failure — gocell validate succeeds with zero discovered cells).
+func TestLocator_ManifestGlobNoMatch(t *testing.T) {
+	manifest := `version: v1
+modules:
+  - path: .
+    includes:
+      cells:
+        - "cells/bar/cell.yaml"
+`
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
+		"cells/foo/cell.yaml":   &fstest.MapFile{Data: []byte("id: foo\n")},
+	}
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(sources) != 0 {
+		t.Errorf("Discover with non-matching glob produced %d sources, want 0", len(sources))
+	}
+}
+
+// TestLocator_GeneratedExcludeDefault verifies that a manifest module
+// without an explicit excludes list still excludes generated/** so
+// codegen output doesn't re-enter the metadata scan (ADR threat
+// matrix promise).
+func TestLocator_GeneratedExcludeDefault(t *testing.T) {
+	manifest := "version: v1\nmodules:\n  - path: .\n"
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml":             &fstest.MapFile{Data: []byte(manifest)},
+		"cells/real/cell.yaml":              &fstest.MapFile{Data: []byte("id: real\n")},
+		"generated/contracts/foo/cell.yaml": &fstest.MapFile{Data: []byte("id: shouldnotappear\n")},
+		"generated/cells/foo/cell.yaml":     &fstest.MapFile{Data: []byte("id: shouldnotappear\n")},
+	}
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	want := []string{"cell:cells/real/cell.yaml:real"}
+	if got := summariseSources(sources); !reflect.DeepEqual(got, want) {
+		t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
 // TestParseLocatorMode covers the CLI flag string round trip.
 func TestParseLocatorMode(t *testing.T) {
 	cases := []struct {
@@ -299,6 +384,30 @@ func TestLocator_AutoDetectStatErrorPropagates(t *testing.T) {
 	if !strings.Contains(err.Error(), "probe manifest") {
 		t.Errorf("error does not mention probe: %v", err)
 	}
+}
+
+// largeManifestExceedingSizeLimit builds a manifest whose size exceeds the
+// 64 KiB cap by repeating a comment line.
+func largeManifestExceedingSizeLimit() string {
+	var b strings.Builder
+	b.WriteString("version: v1\nmodules:\n  - path: .\n")
+	// Filler comment lines until we exceed the cap.
+	filler := "# " + strings.Repeat("x", 200) + "\n"
+	for b.Len() < (65 << 10) {
+		b.WriteString(filler)
+	}
+	return b.String()
+}
+
+// tooManyModulesManifest builds a manifest with more than maxManifestModules
+// module entries to exercise the WalkDir-amplification guard.
+func tooManyModulesManifest() string {
+	var b strings.Builder
+	b.WriteString("version: v1\nmodules:\n")
+	for i := 0; i < 300; i++ {
+		fmt.Fprintf(&b, "  - path: m%d\n", i)
+	}
+	return b.String()
 }
 
 // summariseSources renders a deterministic sorted "kind:path:cellID" view of

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -1,0 +1,320 @@
+package metadata
+
+import (
+	"errors"
+	"io/fs"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// TestLocator_AutoDetect verifies that a fresh root without .gocell/manifest.yaml
+// resolves to Conventional, while a root with the manifest resolves to Manifest.
+func TestLocator_AutoDetect(t *testing.T) {
+	t.Run("conventional when no manifest", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"cells/foo/cell.yaml": &fstest.MapFile{Data: []byte("id: foo\n")},
+		}
+		l, err := NewLocatorFS(fsys)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		if got := l.Mode(); got != LocatorConventional {
+			t.Errorf("Mode = %v, want %v", got, LocatorConventional)
+		}
+	})
+	t.Run("manifest when present", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			".gocell/manifest.yaml": &fstest.MapFile{Data: []byte("version: v1\nmodules:\n  - path: .\n")},
+		}
+		l, err := NewLocatorFS(fsys)
+		if err != nil {
+			t.Fatalf("NewLocatorFS: %v", err)
+		}
+		if got := l.Mode(); got != LocatorManifest {
+			t.Errorf("Mode = %v, want %v", got, LocatorManifest)
+		}
+	})
+}
+
+// TestLocator_ConventionalDiscover validates that all 5 patterns + 2 singletons
+// are emitted for a conventional layout.
+func TestLocator_ConventionalDiscover(t *testing.T) {
+	fsys := fstest.MapFS{
+		"cells/accesscore/cell.yaml":                                       &fstest.MapFile{Data: []byte("id: accesscore\n")},
+		"cells/accesscore/slices/login/slice.yaml":                         &fstest.MapFile{Data: []byte("id: login\n")},
+		"cells/auditcore/cell.yaml":                                        &fstest.MapFile{Data: []byte("id: auditcore\n")},
+		"contracts/http/auth/login/v1/contract.yaml":                       &fstest.MapFile{Data: []byte("id: http.auth.login.v1\n")},
+		"contracts/event/session/created/v1/contract.yaml":                 &fstest.MapFile{Data: []byte("id: event.session.created.v1\n")},
+		"journeys/J-ssologin.yaml":                                         &fstest.MapFile{Data: []byte("id: J-ssologin\n")},
+		"journeys/status-board.yaml":                                       &fstest.MapFile{Data: []byte("- journey: J-ssologin\n")},
+		"assemblies/platform/assembly.yaml":                                &fstest.MapFile{Data: []byte("id: platform\n")},
+		"actors.yaml":                                                      &fstest.MapFile{Data: []byte("- id: external\n")},
+		"examples/ssobff/cells/foo/cell.yaml":                              &fstest.MapFile{Data: []byte("id: foo\n")},
+		"examples/ssobff/cells/foo/slices/bar/slice.yaml":                  &fstest.MapFile{Data: []byte("id: bar\n")},
+		"examples/ssobff/contracts/http/x/y/v1/contract.yaml":              &fstest.MapFile{Data: []byte("id: http.x.y.v1\n")},
+		"examples/ssobff/journeys/J-flow.yaml":                             &fstest.MapFile{Data: []byte("id: J-flow\n")},
+		"examples/ssobff/assembly.yaml":                                    &fstest.MapFile{Data: []byte("id: ssobff\n")},
+		"README.md":                                                        &fstest.MapFile{Data: []byte("ignored\n")},
+		"cells/accesscore/slices/login/handler.go":                         &fstest.MapFile{Data: []byte("// ignored\n")},
+	}
+	l, err := NewLocatorFS(fsys, WithLocatorMode(LocatorConventional))
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	got := summariseSources(sources)
+	want := []string{
+		"actors:actors.yaml:",
+		"assembly:assemblies/platform/assembly.yaml:",
+		"assembly:examples/ssobff/assembly.yaml:",
+		"cell:cells/accesscore/cell.yaml:accesscore",
+		"cell:cells/auditcore/cell.yaml:auditcore",
+		"cell:examples/ssobff/cells/foo/cell.yaml:foo",
+		"contract:contracts/event/session/created/v1/contract.yaml:",
+		"contract:contracts/http/auth/login/v1/contract.yaml:",
+		"contract:examples/ssobff/contracts/http/x/y/v1/contract.yaml:",
+		"journey:examples/ssobff/journeys/J-flow.yaml:",
+		"journey:journeys/J-ssologin.yaml:",
+		"slice:cells/accesscore/slices/login/slice.yaml:accesscore",
+		"slice:examples/ssobff/cells/foo/slices/bar/slice.yaml:foo",
+		"status-board:journeys/status-board.yaml:",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+// TestLocator_ManifestSingleModuleDefaults exercises the Operator-SDK case:
+// a single-module manifest with no includes: omits — defaults apply.
+func TestLocator_ManifestSingleModuleDefaults(t *testing.T) {
+	manifest := `version: v1
+modules:
+  - path: .
+`
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml":                    &fstest.MapFile{Data: []byte(manifest)},
+		"cells/payment/cell.yaml":                  &fstest.MapFile{Data: []byte("id: payment\n")},
+		"cells/payment/slices/charge/slice.yaml":   &fstest.MapFile{Data: []byte("id: charge\n")},
+		"contracts/http/payment/charge/v1/contract.yaml": &fstest.MapFile{Data: []byte("id: http.payment.charge.v1\n")},
+		"journeys/J-payment.yaml":                  &fstest.MapFile{Data: []byte("id: J-payment\n")},
+		"assemblies/payment-svc/assembly.yaml":     &fstest.MapFile{Data: []byte("id: payment-svc\n")},
+		"actors.yaml":                              &fstest.MapFile{Data: []byte("- id: bank\n")},
+		"journeys/status-board.yaml":               &fstest.MapFile{Data: []byte("- journey: J-payment\n")},
+	}
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	if l.Mode() != LocatorManifest {
+		t.Fatalf("auto-detect failed: got %v want %v", l.Mode(), LocatorManifest)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	got := summariseSources(sources)
+	want := []string{
+		"actors:actors.yaml:",
+		"assembly:assemblies/payment-svc/assembly.yaml:",
+		"cell:cells/payment/cell.yaml:payment",
+		"contract:contracts/http/payment/charge/v1/contract.yaml:",
+		"journey:journeys/J-payment.yaml:",
+		"slice:cells/payment/slices/charge/slice.yaml:payment",
+		"status-board:journeys/status-board.yaml:",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+// TestLocator_ManifestWorkspaceMultiModule exercises the Workspace case:
+// two modules, second module aggregates a subdirectory. actors.yaml and
+// status-board.yaml are workspace-level singletons attached to modules[0].
+func TestLocator_ManifestWorkspaceMultiModule(t *testing.T) {
+	manifest := `version: v1
+modules:
+  - path: .
+  - path: vendor-cells/payment
+`
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml":                                  &fstest.MapFile{Data: []byte(manifest)},
+		"cells/platform/cell.yaml":                               &fstest.MapFile{Data: []byte("id: platform\n")},
+		"actors.yaml":                                            &fstest.MapFile{Data: []byte("- id: bank\n")},
+		"vendor-cells/payment/cells/payment/cell.yaml":           &fstest.MapFile{Data: []byte("id: payment\n")},
+		"vendor-cells/payment/cells/payment/slices/c/slice.yaml": &fstest.MapFile{Data: []byte("id: c\n")},
+	}
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	got := summariseSources(sources)
+	want := []string{
+		"actors:actors.yaml:",
+		"cell:cells/platform/cell.yaml:platform",
+		"cell:vendor-cells/payment/cells/payment/cell.yaml:payment",
+		"slice:vendor-cells/payment/cells/payment/slices/c/slice.yaml:payment",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Discover output mismatch.\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+// TestLocator_ManifestRejectsBadPaths verifies the path safety boundary:
+// absolute paths and ".." segments are refused; duplicate module paths are
+// refused; singleton declarations on modules[i>0] are refused.
+func TestLocator_ManifestRejectsBadPaths(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		wantSub  string
+	}{
+		{
+			name:     "absolute path",
+			manifest: "version: v1\nmodules:\n  - path: /etc\n",
+			wantSub:  "absolute path not allowed",
+		},
+		{
+			name:     "parent escape",
+			manifest: "version: v1\nmodules:\n  - path: ../outside\n",
+			wantSub:  "path escape not allowed",
+		},
+		{
+			name:     "duplicate path",
+			manifest: "version: v1\nmodules:\n  - path: .\n  - path: .\n",
+			wantSub:  "duplicates modules[0]",
+		},
+		{
+			name: "secondary singleton actors",
+			manifest: "version: v1\nmodules:\n  - path: .\n  - path: sub\n" +
+				"    includes:\n      actors: actors.yaml\n",
+			wantSub: "actors.yaml is a workspace-level singleton",
+		},
+		{
+			name: "unsupported version",
+			manifest: "version: v2\nmodules:\n  - path: .\n",
+			wantSub: "unsupported version",
+		},
+		{
+			name:     "empty modules",
+			manifest: "version: v1\nmodules: []\n",
+			wantSub:  "at least one module entry required",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys := fstest.MapFS{
+				".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(tc.manifest)},
+			}
+			_, err := NewLocatorFS(fsys, WithLocatorMode(LocatorManifest))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestLocator_ManifestExcludes verifies that exclude patterns filter out
+// matched paths even when an include matched them.
+func TestLocator_ManifestExcludes(t *testing.T) {
+	manifest := `version: v1
+modules:
+  - path: .
+    includes:
+      cells:
+        - "cells/*/cell.yaml"
+    excludes:
+      - "cells/skip/**"
+`
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml":    &fstest.MapFile{Data: []byte(manifest)},
+		"cells/keep/cell.yaml":     &fstest.MapFile{Data: []byte("id: keep\n")},
+		"cells/skip/cell.yaml":     &fstest.MapFile{Data: []byte("id: skip\n")},
+	}
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if got := summariseSources(sources); !reflect.DeepEqual(got, []string{"cell:cells/keep/cell.yaml:keep"}) {
+		t.Errorf("Discover output mismatch: %v", got)
+	}
+}
+
+// TestParseLocatorMode covers the CLI flag string round trip.
+func TestParseLocatorMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want LocatorMode
+		err  bool
+	}{
+		{"", LocatorAuto, false},
+		{"auto", LocatorAuto, false},
+		{"conventional", LocatorConventional, false},
+		{"manifest", LocatorManifest, false},
+		{"bogus", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseLocatorMode(tc.in)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseLocatorMode(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseLocatorMode(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLocator_AutoDetectStatErrorPropagates ensures probe failures other than
+// fs.ErrNotExist surface up rather than being mis-treated as "manifest absent".
+func TestLocator_AutoDetectStatErrorPropagates(t *testing.T) {
+	fsys := errFS{err: errors.New("synthetic stat failure")}
+	_, err := NewLocatorFS(fsys)
+	if err == nil {
+		t.Fatalf("expected propagated stat error, got nil")
+	}
+	if !strings.Contains(err.Error(), "probe manifest") {
+		t.Errorf("error does not mention probe: %v", err)
+	}
+}
+
+// summariseSources renders a deterministic sorted "kind:path:cellID" view of
+// the discovered sources for table-driven comparison.
+func summariseSources(sources []MetadataSource) []string {
+	out := make([]string, 0, len(sources))
+	for _, s := range sources {
+		out = append(out, s.Kind.String()+":"+s.Path+":"+s.CellID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// errFS is a minimal fs.FS that returns a synthetic stat error for every
+// path, used to verify Locator propagates probe failures.
+type errFS struct{ err error }
+
+func (e errFS) Open(name string) (fs.File, error)    { return nil, e.err }
+func (e errFS) Stat(name string) (fs.FileInfo, error) { return nil, e.err }

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -35,6 +35,11 @@ const (
 // internals. ParserOption and LocatorOption are interchangeable — you can
 // pass a LocatorOption directly or construct one via WithLocatorMode /
 // WithManifestPath.
+//
+// e.g.: metadata.NewParser(root, metadata.WithLocatorMode(metadata.LocatorManifest))
+//
+// Don't declare ParserOption-typed variables separately; use the LocatorOption
+// constructors (WithLocatorMode, WithManifestPath) directly.
 type ParserOption = LocatorOption
 
 // Parser loads and parses all YAML metadata from a project root via a Locator.

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -30,6 +30,13 @@ const (
 	internalIDPathQuotedFmt = "id=%q path=%s"
 )
 
+// ParserOption is an alias for LocatorOption. NewParser accepts ParserOption
+// values so call sites are semantically named without exposing Locator
+// internals. ParserOption and LocatorOption are interchangeable — you can
+// pass a LocatorOption directly or construct one via WithLocatorMode /
+// WithManifestPath.
+type ParserOption = LocatorOption
+
 // Parser loads and parses all YAML metadata from a project root via a Locator.
 //
 // The Locator funnel is the single source of truth for filesystem topology
@@ -43,9 +50,9 @@ type Parser struct {
 
 // NewParser creates a Parser that reads from the given filesystem root. The
 // root should point to the project root directory (containing go.mod). Pass
-// LocatorOption to override the auto-detected layout (e.g.,
-// WithLocatorMode(LocatorManifest) for CI override).
-func NewParser(root string, opts ...LocatorOption) *Parser {
+// ParserOption (alias for LocatorOption) to override the auto-detected layout
+// (e.g., WithLocatorMode(LocatorManifest) for CI override).
+func NewParser(root string, opts ...ParserOption) *Parser {
 	return &Parser{root: root, locatorOpts: opts}
 }
 

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -16,10 +16,9 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
+	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -31,25 +30,49 @@ const (
 	internalIDPathQuotedFmt = "id=%q path=%s"
 )
 
-// Parser loads and parses all YAML metadata from a project root.
+// Parser loads and parses all YAML metadata from a project root via a Locator.
+//
+// The Locator funnel is the single source of truth for filesystem topology
+// — see kernel/metadata/locator.go. Parser does NOT walk the filesystem
+// directly; it consumes []MetadataSource from Locator and dispatches each
+// entry to the matching parseXxx method by SourceKind.
 type Parser struct {
-	root string
+	root        string
+	locatorOpts []LocatorOption
 }
 
-// NewParser creates a Parser that reads from the given filesystem root.
-// The root should point to the project root directory (containing go.mod).
-func NewParser(root string) *Parser {
-	return &Parser{root: root}
+// NewParser creates a Parser that reads from the given filesystem root. The
+// root should point to the project root directory (containing go.mod). Pass
+// LocatorOption to override the auto-detected layout (e.g.,
+// WithLocatorMode(LocatorManifest) for CI override).
+func NewParser(root string, opts ...LocatorOption) *Parser {
+	return &Parser{root: root, locatorOpts: opts}
 }
 
-// Parse walks the real file system and loads all metadata YAML files.
-// Returns a fully populated ProjectMeta.
+// Parse walks the real file system via Locator and loads all metadata YAML
+// files. Returns a fully populated ProjectMeta.
 func (p *Parser) Parse() (*ProjectMeta, error) {
-	return p.ParseFS(os.DirFS(p.root))
+	loc, err := NewLocator(p.root, p.locatorOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return p.parseWith(loc)
 }
 
-// ParseFS parses from an fs.FS (for testing with fstest.MapFS).
+// ParseFS parses from an fs.FS (for testing with fstest.MapFS or any caller
+// that already has an fs.FS handle).
 func (p *Parser) ParseFS(fsys fs.FS) (*ProjectMeta, error) {
+	loc, err := NewLocatorFS(fsys, p.locatorOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return p.parseWith(loc)
+}
+
+// parseWith drains the Locator into a fully populated ProjectMeta. The
+// Locator funnels all filesystem walking + path-prefix classification; this
+// method only dispatches by SourceKind and runs derivation passes.
+func (p *Parser) parseWith(loc *Locator) (*ProjectMeta, error) {
 	pm := &ProjectMeta{
 		Cells:      make(map[string]*CellMeta),
 		Slices:     make(map[string]*SliceMeta),
@@ -58,203 +81,119 @@ func (p *Parser) ParseFS(fsys fs.FS) (*ProjectMeta, error) {
 		Assemblies: make(map[string]*AssemblyMeta),
 		fileNodes:  make(map[string]*yaml.Node),
 	}
-
-	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-
-		switch {
-		case matchCellYAML(path):
-			return p.parseCell(fsys, path, pm)
-		case matchSliceYAML(path):
-			return p.parseSlice(fsys, path, pm)
-		case matchContractYAML(path):
-			return p.parseContract(fsys, path, pm)
-		case matchJourneyYAML(path):
-			return p.parseJourney(fsys, path, pm)
-		case matchAssemblyYAML(path):
-			return p.parseAssembly(fsys, path, pm)
-		case path == "journeys/status-board.yaml":
-			return p.parseStatusBoard(fsys, path, pm)
-		case path == "actors.yaml":
-			return p.parseActors(fsys, path, pm)
-		}
-		return nil
-	}); err != nil {
+	sources, err := loc.Discover()
+	if err != nil {
 		return nil, err
 	}
-
+	fsys := loc.FS()
+	for _, src := range sources {
+		if err := p.dispatchSource(fsys, src, pm); err != nil {
+			return nil, err
+		}
+	}
 	applyAssemblyDerivations(pm)
 	deriveEventSubscribers(pm)
-
 	return pm, nil
 }
 
-// matchCellYAML matches cells/*/cell.yaml and examples/*/cells/*/cell.yaml.
-func matchCellYAML(path string) bool {
-	_, ok := cellDirFromPath(path)
-	return ok
-}
-
-// matchSliceYAML matches cells/*/slices/*/slice.yaml and
-// examples/*/cells/*/slices/*/slice.yaml.
-func matchSliceYAML(path string) bool {
-	_, _, ok := sliceDirsFromPath(path)
-	return ok
-}
-
-// matchContractYAML matches paths like contracts/{kind}/{...}/{version}/contract.yaml
-// and examples/*/contracts/{kind}/{...}/{version}/contract.yaml.
-// The path must start with "contracts/" and end with "contract.yaml", with at least
-// 4 segments between (kind + at least one domain segment + version).
-func matchContractYAML(path string) bool {
-	_, ok := contractDirFromPath(path)
-	return ok
-}
-
-// matchJourneyYAML matches journeys/J-*.yaml and examples/*/journeys/J-*.yaml.
-func matchJourneyYAML(path string) bool {
-	_, ok := journeyIDFromPath(path)
-	return ok
-}
-
-// matchAssemblyYAML matches paths like assemblies/*/assembly.yaml (3 segments)
-// and examples/*/assembly.yaml (3 segments under examples/ root — symmetric
-// with matchCellYAML / matchSliceYAML / matchContractYAML / matchJourneyYAML).
-//
-// ref: helm/helm pkg/chartutil/create.go — identity by location (any dir with
-// Chart.yaml is a chart); kustomize-sigs pkg/types/kustomization.go — per-dir metadata.
-func matchAssemblyYAML(path string) bool {
-	parts := splitPath(path)
-	if len(parts) == 3 && parts[0] == "assemblies" && parts[2] == "assembly.yaml" {
-		return true
-	}
-	return len(parts) == 3 && parts[0] == "examples" && parts[2] == "assembly.yaml"
-}
-
-// splitPath splits a forward-slash-separated path into its segments.
-func splitPath(path string) []string {
-	// Normalise to forward slashes for consistent matching.
-	clean := filepath.ToSlash(path)
-	return strings.Split(clean, "/")
-}
-
-func cellDirFromPath(path string) (string, bool) {
-	parts := splitPath(path)
-	if len(parts) == 3 && parts[0] == "cells" && parts[2] == "cell.yaml" {
-		return parts[1], true
-	}
-	if len(parts) == 5 && parts[0] == "examples" && parts[2] == "cells" && parts[4] == "cell.yaml" {
-		return parts[3], true
-	}
-	return "", false
-}
-
-func sliceDirsFromPath(path string) (cellDir, sliceDir string, ok bool) {
-	parts := splitPath(path)
-	if len(parts) == 5 && parts[0] == "cells" && parts[2] == "slices" && parts[4] == "slice.yaml" {
-		return parts[1], parts[3], true
-	}
-	if len(parts) == 7 && parts[0] == "examples" && parts[2] == "cells" && parts[4] == "slices" && parts[6] == "slice.yaml" {
-		return parts[3], parts[5], true
-	}
-	return "", "", false
-}
-
-func contractDirFromPath(path string) (string, bool) {
-	parts := splitPath(path)
-	if len(parts) >= 5 && parts[0] == "contracts" && parts[len(parts)-1] == "contract.yaml" {
-		return strings.Join(parts[:len(parts)-1], "/"), true
-	}
-	if len(parts) >= 7 && parts[0] == "examples" && parts[2] == "contracts" && parts[len(parts)-1] == "contract.yaml" {
-		return strings.Join(parts[:len(parts)-1], "/"), true
-	}
-	return "", false
-}
-
-func journeyIDFromPath(path string) (string, bool) {
-	parts := splitPath(path)
-	var name string
-	switch {
-	case len(parts) == 2 && parts[0] == "journeys":
-		name = parts[1]
-	case len(parts) == 4 && parts[0] == "examples" && parts[2] == "journeys":
-		name = parts[3]
+// dispatchSource routes a discovered MetadataSource to its parse method.
+func (p *Parser) dispatchSource(fsys fs.FS, src MetadataSource, pm *ProjectMeta) error {
+	switch src.Kind {
+	case SourceCell:
+		return p.parseCell(fsys, src, pm)
+	case SourceSlice:
+		return p.parseSlice(fsys, src, pm)
+	case SourceContract:
+		return p.parseContract(fsys, src, pm)
+	case SourceJourney:
+		return p.parseJourney(fsys, src, pm)
+	case SourceAssembly:
+		return p.parseAssembly(fsys, src, pm)
+	case SourceStatusBoard:
+		return p.parseStatusBoard(fsys, src.Path, pm)
+	case SourceActors:
+		return p.parseActors(fsys, src.Path, pm)
 	default:
-		return "", false
+		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
+			"unknown metadata source kind",
+			errcode.WithInternal(errcode.InternalAttr("_",
+				fmt.Sprintf("kind=%s path=%s", src.Kind, src.Path))))
 	}
-	if !strings.HasPrefix(name, "J-") || !strings.HasSuffix(name, ".yaml") {
-		return "", false
-	}
-	return strings.TrimSuffix(name, ".yaml"), true
 }
 
 // --- individual parsers ---
 
-func (p *Parser) parseCell(fsys fs.FS, path string, pm *ProjectMeta) error {
+func (p *Parser) parseCell(fsys fs.FS, src MetadataSource, pm *ProjectMeta) error {
 	var m CellMeta
-	node, err := unmarshalFile(fsys, path, &m)
+	node, err := unmarshalFile(fsys, src.Path, &m)
 	if err != nil {
 		return err
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[src.Path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"cell id is empty",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, src.Path))))
 	}
 	// Record the real filesystem directory so strict rules (REF-04) can
 	// compare it against m.ID instead of self-comparing against the map key.
-	// Use ToSlash so that on Windows (where os.DirFS produces backslash paths)
-	// all metadata file paths are normalised to forward slashes — making
-	// validation error messages cross-platform consistent.
-	cellDir, _ := cellDirFromPath(path)
-	m.Dir = cellDir
-	m.File = filepath.ToSlash(path)
+	// CellID from Locator is the directory name in conventional mode; in
+	// manifest mode the locator may emit an empty CellID, in which case we
+	// derive the directory name from the file path.
+	if src.CellID != "" {
+		m.Dir = src.CellID
+	} else {
+		m.Dir = path.Base(path.Dir(src.Path))
+	}
+	m.File = filepath.ToSlash(src.Path)
 	if _, exists := pm.Cells[m.ID]; exists {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"duplicate cell ID",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, src.Path))))
 	}
 	pm.Cells[m.ID] = &m
 	return nil
 }
 
 // parseSlice parses a slice.yaml and applies G-7 auto-derivation:
-// if belongsToCell is omitted, it is inferred from the file path
-// (cells/{cellID}/slices/{sliceID}/slice.yaml → belongsToCell = cellID).
-// If an explicit value is provided but mismatches the path, an error is returned.
-func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
+// if belongsToCell is omitted, it is inferred from MetadataSource.CellID
+// (which Locator derives from conventional layout). When the locator cannot
+// derive CellID (manifest mode with non-conventional layout), slice.yaml
+// MUST declare belongsToCell explicitly.
+func (p *Parser) parseSlice(fsys fs.FS, src MetadataSource, pm *ProjectMeta) error {
 	var m SliceMeta
-	node, err := unmarshalFile(fsys, path, &m)
+	node, err := unmarshalFile(fsys, src.Path, &m)
 	if err != nil {
 		return err
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[src.Path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"slice id is empty",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, src.Path))))
 	}
 
-	// G-7: auto-derive belongsToCell from path.
-	cellID, sliceDir, _ := sliceDirsFromPath(path)
-
+	// G-7: prefer Locator-derived CellID, fall back to explicit field. When
+	// neither is set, reject the slice — manifest mode without layout
+	// derivation REQUIRES explicit belongsToCell.
+	derivedCellID := src.CellID
 	if m.BelongsToCell == "" {
-		m.BelongsToCell = cellID
-	} else if m.BelongsToCell != cellID {
+		if derivedCellID == "" {
+			return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
+				"slice belongsToCell is required (no layout derivation available)",
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("slice=%q path=%s",
+					m.ID, src.Path))))
+		}
+		m.BelongsToCell = derivedCellID
+	} else if derivedCellID != "" && m.BelongsToCell != derivedCellID {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"slice belongsToCell does not match directory cell",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("slice=%q belongs_to=%q dir_cell=%q path=%s",
-				m.ID, m.BelongsToCell, cellID, path))))
+				m.ID, m.BelongsToCell, derivedCellID, src.Path))))
 	}
 
 	// Record filesystem truth separately from the yaml id. Strict rules
@@ -262,15 +201,19 @@ func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
 	// (kebab dir paired with no-dash id, or vice versa) cannot escape the
 	// governance gate. ToSlash normalises Windows backslashes so error
 	// messages are cross-platform consistent.
-	m.Dir = sliceDir
-	m.CellDir = cellID
-	m.File = filepath.ToSlash(path)
+	m.Dir = path.Base(path.Dir(src.Path))
+	if derivedCellID != "" {
+		m.CellDir = derivedCellID
+	} else {
+		m.CellDir = m.BelongsToCell
+	}
+	m.File = filepath.ToSlash(src.Path)
 
-	key := cellID + "/" + m.ID
+	key := m.BelongsToCell + "/" + m.ID
 	if _, exists := pm.Slices[key]; exists {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"duplicate slice ID",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, key, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, key, src.Path))))
 	}
 	// slice.yaml is the single source of truth for slice consistency level
 	// (codegen funnel projects it into slice_gen.go.sliceMeta). The prior
@@ -280,7 +223,7 @@ func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if m.ConsistencyLevel == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"slice consistencyLevel is empty: declare consistencyLevel: L0|L1|L2|L3|L4",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("slice=%q path=%s", m.ID, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("slice=%q path=%s", m.ID, src.Path))))
 	}
 	pm.Slices[key] = &m
 	return nil
@@ -296,9 +239,9 @@ func (p *Parser) parseSlice(fsys fs.FS, path string, pm *ProjectMeta) error {
 // omits the `codegen:` key. The yaml.Node AST is inspected before the struct
 // decode is finalized so an absent key (vs. an explicit `codegen: false`) is
 // distinguishable. Explicit `codegen: false` is the only way to opt out.
-func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
+func (p *Parser) parseContract(fsys fs.FS, src MetadataSource, pm *ProjectMeta) error {
 	var m ContractMeta
-	node, err := unmarshalFile(fsys, path, &m)
+	node, err := unmarshalFile(fsys, src.Path, &m)
 	if err != nil {
 		return err
 	}
@@ -306,19 +249,21 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 		m.Codegen = true
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[src.Path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"contract id is empty",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, src.Path))))
 	}
 	// G-7: auto-derive ownerCell from provider endpoint if omitted (per contract.schema.json).
 	if m.OwnerCell == "" {
 		m.OwnerCell = m.ProviderEndpoint()
 	}
-	m.Dir, _ = contractDirFromPath(path)
-	m.File = filepath.ToSlash(path)
+	// Contract directory is derived uniformly from the source path (works
+	// for both conventional layout and manifest mode with arbitrary layout).
+	m.Dir = path.Dir(filepath.ToSlash(src.Path))
+	m.File = filepath.ToSlash(src.Path)
 
 	if err := resolveParamRefs(fsys, &m); err != nil {
 		return err
@@ -327,88 +272,86 @@ func (p *Parser) parseContract(fsys fs.FS, path string, pm *ProjectMeta) error {
 	if _, exists := pm.Contracts[m.ID]; exists {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"duplicate contract ID",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, src.Path))))
 	}
 	pm.Contracts[m.ID] = &m
 	return nil
 }
 
-func (p *Parser) parseJourney(fsys fs.FS, path string, pm *ProjectMeta) error {
+func (p *Parser) parseJourney(fsys fs.FS, src MetadataSource, pm *ProjectMeta) error {
 	var m JourneyMeta
-	node, err := unmarshalFile(fsys, path, &m)
+	node, err := unmarshalFile(fsys, src.Path, &m)
 	if err != nil {
 		return err
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[src.Path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"journey id is empty",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, src.Path))))
 	}
-	m.File = filepath.ToSlash(path)
+	m.File = filepath.ToSlash(src.Path)
 	if _, exists := pm.Journeys[m.ID]; exists {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"duplicate journey ID",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, src.Path))))
 	}
 	pm.Journeys[m.ID] = &m
 	return nil
 }
 
-func (p *Parser) parseAssembly(fsys fs.FS, path string, pm *ProjectMeta) error {
+func (p *Parser) parseAssembly(fsys fs.FS, src MetadataSource, pm *ProjectMeta) error {
 	var m AssemblyMeta
-	node, err := unmarshalFile(fsys, path, &m)
+	node, err := unmarshalFile(fsys, src.Path, &m)
 	if err != nil {
 		return err
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[src.Path] = node
 	}
 	if m.ID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"assembly id is empty",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalPathFmt, src.Path))))
 	}
-	// Record filesystem truth so strict rules (FMT-16) can compare the directory
-	// segment against m.ID. matchAssemblyYAML guarantees len(parts)==3 and
-	// parts[2]=="assembly.yaml". parts[0] is "assemblies" for platform assemblies
-	// or "examples" for example assemblies; parts[1] is the assembly directory
-	// in both cases.
-	parts := splitPath(path)
-	m.Dir = parts[1]
-	m.File = filepath.ToSlash(path)
+	// Record filesystem truth so strict rules (FMT-16) can compare the
+	// directory segment against m.ID. The directory name is the parent of
+	// the assembly.yaml file (works uniformly for assemblies/<id>/ and
+	// examples/<id>/ paths).
+	m.Dir = path.Base(path.Dir(filepath.ToSlash(src.Path)))
+	m.File = filepath.ToSlash(src.Path)
 	if _, exists := pm.Assemblies[m.ID]; exists {
 		return errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 			"duplicate assembly ID",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, path))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalIDPathQuotedFmt, m.ID, src.Path))))
 	}
 	pm.Assemblies[m.ID] = &m
 	return nil
 }
 
-func (p *Parser) parseStatusBoard(fsys fs.FS, path string, pm *ProjectMeta) error {
+func (p *Parser) parseStatusBoard(fsys fs.FS, srcPath string, pm *ProjectMeta) error {
 	var entries []StatusBoardEntry
-	node, err := unmarshalFile(fsys, path, &entries)
+	node, err := unmarshalFile(fsys, srcPath, &entries)
 	if err != nil {
 		return err
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[srcPath] = node
 	}
 	pm.StatusBoard = entries
 	return nil
 }
 
-func (p *Parser) parseActors(fsys fs.FS, path string, pm *ProjectMeta) error {
+func (p *Parser) parseActors(fsys fs.FS, srcPath string, pm *ProjectMeta) error {
 	var actors []ActorMeta
-	node, err := unmarshalFile(fsys, path, &actors)
+	node, err := unmarshalFile(fsys, srcPath, &actors)
 	if err != nil {
 		return err
 	}
 	if shouldCacheFileNode(node) {
-		pm.fileNodes[path] = node
+		pm.fileNodes[srcPath] = node
 	}
 	pm.Actors = actors
 	return nil

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -41,6 +41,10 @@ const (
 //
 // Don't declare ParserOption-typed variables separately; use the LocatorOption
 // constructors (WithLocatorMode, WithManifestPath) directly.
+//
+// AI-robust: the line above is a Soft godoc convention (no type-system /
+// archtest guard). Upgrade-or-remove is tracked in #1253 — likely resolution
+// is dropping the alias so NewParser takes ...LocatorOption directly.
 type ParserOption = LocatorOption
 
 // Parser loads and parses all YAML metadata from a project root via a Locator.

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"path"
 	"path/filepath"
 	"sort"
@@ -96,6 +97,14 @@ func (p *Parser) parseWith(loc *Locator) (*ProjectMeta, error) {
 	sources, err := loc.Discover()
 	if err != nil {
 		return nil, err
+	}
+	if len(sources) == 0 {
+		// Warn so operators can distinguish a legitimately empty project from
+		// a misconfigured root path or manifest that scanned nothing. Behavior
+		// is unchanged: return an empty ProjectMeta with nil error.
+		slog.Warn("metadata: parser discovered zero sources — verify root path and locator mode",
+			slog.String("root", p.root),
+		)
 	}
 	fsys := loc.FS()
 	for _, src := range sources {

--- a/kernel/metadata/review_findings_test.go
+++ b/kernel/metadata/review_findings_test.go
@@ -1,0 +1,399 @@
+// review_findings_test.go — TDD tests for PR #1226 review round-8 findings.
+//
+// Findings covered:
+//   - T1: discoverConventional symlink skip (real-fs, os.DirFS)
+//   - T2: validateManifestModulePath uses filepath.IsAbs+filepath.FromSlash not path.IsAbs
+//   - T3: parseWith warns when Discover returns zero sources
+//   - T4: godoc only (no runtime test needed — comment-only fix)
+//   - T5: manifestGlobFixedPrefix dead-comment + hasWild simplification (existing tests cover)
+//   - T6: LocatorAuto godoc (comment-only)
+//   - T7: excludes SkipDir pruning + match cap
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// ── T1: discoverConventional symlink skip ──────────────────────────────────
+
+// TestDiscoverConventional_SkipsSymlink verifies that discoverConventional
+// skips symlinks and does not classify them as metadata sources. Uses a real
+// temp directory because fstest.MapFS cannot represent symlinks.
+func TestDiscoverConventional_SkipsSymlink(t *testing.T) {
+	root := t.TempDir()
+
+	// Write a real cell.yaml so we know conventional discovery works.
+	cellDir := filepath.Join(root, "cells", "realcell")
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cellDir, "cell.yaml"), []byte("id: realcell\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Create a symlink inside cells/ pointing to an external file.
+	external := filepath.Join(t.TempDir(), "external_cell.yaml")
+	if err := os.WriteFile(external, []byte("id: shouldnotappear\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+	symlinkPath := filepath.Join(root, "cells", "symlinked.yaml")
+	if err := os.Symlink(external, symlinkPath); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	l, err := NewLocator(root, WithLocatorMode(LocatorConventional))
+	if err != nil {
+		t.Fatalf("NewLocator: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, s := range sources {
+		if strings.Contains(s.Path, "symlinked") {
+			t.Errorf("symlink was classified as a MetadataSource: %+v", s)
+		}
+	}
+	// Confirm the real cell was still found.
+	var found bool
+	for _, s := range sources {
+		if s.Kind == SourceCell && s.CellID == "realcell" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("real cell 'realcell' not discovered; sources = %v", sources)
+	}
+}
+
+// TestDiscoverConventional_SkipsSymlinkDir verifies that a symlink pointing
+// to a directory inside cells/ does not cause discoverConventional to follow
+// it and classify files inside.
+func TestDiscoverConventional_SkipsSymlinkDir(t *testing.T) {
+	root := t.TempDir()
+
+	// Build the real cell directory.
+	cellDir := filepath.Join(root, "cells", "realcell")
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll realcell: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cellDir, "cell.yaml"), []byte("id: realcell\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile realcell: %v", err)
+	}
+
+	// Build an external directory with a cell.yaml that must NOT appear.
+	extDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extDir, "cell.yaml"), []byte("id: escapedcell\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+
+	// Create a directory symlink inside cells/.
+	symlinkDir := filepath.Join(root, "cells", "linked")
+	if err := os.Symlink(extDir, symlinkDir); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	l, err := NewLocator(root, WithLocatorMode(LocatorConventional))
+	if err != nil {
+		t.Fatalf("NewLocator: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, s := range sources {
+		if strings.Contains(s.Path, "linked") || strings.Contains(s.Path, "escapedcell") {
+			t.Errorf("symlink dir was traversed and classified: %+v", s)
+		}
+	}
+}
+
+// ── T2: validateManifestModulePath filepath.IsAbs ─────────────────────────
+
+// TestValidateManifestModulePath_FilepathIsAbs verifies that path patterns
+// containing backslash-style absolute paths (e.g. C:\foo) are not silently
+// allowed. On UNIX filepath.IsAbs("C:\\foo") returns false, so the test
+// mainly validates the intent/documentation and non-regression of UNIX paths.
+func TestValidateManifestModulePath_FilepathIsAbs(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		// Existing cases that must still pass.
+		{"relative dot", ".", false},
+		{"simple relative", "cells/foo", false},
+		{"relative with wildcard", "cells/*/cell.yaml", false},
+		// Absolute paths must be rejected.
+		{"unix absolute", "/etc/cells", true},
+		{"root slash only", "/", true},
+		// Parent escape must be rejected.
+		{"parent escape", "../outside", true},
+		{"embedded parent", "cells/../secret", true},
+		// Empty path must be rejected.
+		{"empty", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateManifestModulePath(tc.path)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateManifestModulePath(%q) = nil, want error", tc.path)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateManifestModulePath(%q) = %v, want nil", tc.path, err)
+			}
+		})
+	}
+}
+
+// TestValidateManifestModulePath_ConsistentWithRelativePath verifies that
+// validateManifestModulePath and validateManifestRelativePath (locator.go)
+// agree on which inputs are invalid (both reject the same unsafe patterns).
+func TestValidateManifestModulePath_ConsistentWithRelativePath(t *testing.T) {
+	cases := []struct {
+		path string
+	}{
+		{"/etc/foo"},
+		{"../escape"},
+		{"a/../../b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			errModule := validateManifestModulePath(tc.path)
+			errRelative := validateManifestRelativePath(tc.path)
+			if (errModule == nil) != (errRelative == nil) {
+				t.Errorf(
+					"validateManifestModulePath(%q)=%v vs validateManifestRelativePath(%q)=%v — should agree",
+					tc.path, errModule, tc.path, errRelative,
+				)
+			}
+		})
+	}
+}
+
+// ── T3: parseWith warns on zero sources ───────────────────────────────────
+
+// captureSlogWarn installs a temporary slog handler that collects Warn-level
+// messages. Returns a cleanup function and a pointer to the collected slice.
+// The cleanup restores the default handler.
+func captureSlogWarn(t *testing.T) (cleanup func(), msgs *[]string) {
+	t.Helper()
+	var captured []string
+	msgs = &captured
+	old := slog.Default()
+	h := &warnCapture{msgs: &captured}
+	slog.SetDefault(slog.New(h))
+	cleanup = func() { slog.SetDefault(old) }
+	return cleanup, msgs
+}
+
+// warnCapture is a minimal slog.Handler that captures Warn messages.
+type warnCapture struct {
+	msgs *[]string
+}
+
+func (h *warnCapture) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *warnCapture) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		*h.msgs = append(*h.msgs, r.Message)
+	}
+	return nil
+}
+func (h *warnCapture) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *warnCapture) WithGroup(_ string) slog.Handler      { return h }
+
+// TestParseWith_ZeroSourcesWarn verifies that parseWith emits a slog.Warn
+// when the Locator returns zero sources, returns an empty ProjectMeta, and
+// returns nil error (behavior preserved).
+func TestParseWith_ZeroSourcesWarn(t *testing.T) {
+	// Empty fstest.MapFS → Conventional locator → Discover returns [].
+	fsys := fstest.MapFS{}
+	p := NewParser("")
+	loc, err := NewLocatorFS(fsys, WithLocatorMode(LocatorConventional))
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+
+	cleanup, msgs := captureSlogWarn(t)
+	defer cleanup()
+
+	pm, err := p.parseWith(loc)
+	if err != nil {
+		t.Fatalf("parseWith returned unexpected error: %v", err)
+	}
+	if pm == nil {
+		t.Fatal("parseWith returned nil ProjectMeta")
+	}
+	if len(pm.Cells) != 0 || len(pm.Slices) != 0 || len(pm.Contracts) != 0 {
+		t.Errorf("expected empty ProjectMeta, got cells=%d slices=%d contracts=%d",
+			len(pm.Cells), len(pm.Slices), len(pm.Contracts))
+	}
+	// At least one Warn must have been emitted mentioning "zero sources" or similar.
+	found := false
+	for _, m := range *msgs {
+		if strings.Contains(m, "zero sources") || strings.Contains(m, "no sources") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected slog.Warn about zero sources, got messages: %v", *msgs)
+	}
+}
+
+// ── T7: excludes SkipDir pruning + match cap ──────────────────────────────
+
+// TestManifestExcludeSet_MatchDir verifies the matchDir helper: only
+// "<prefix>/**" patterns prune directories.
+func TestManifestExcludeSet_MatchDir(t *testing.T) {
+	es := &manifestExcludeSet{
+		patterns: []string{"vendor/**", "generated/**", "cells/skip.yaml"},
+	}
+	cases := []struct {
+		dir  string
+		want bool
+	}{
+		{"vendor", true},
+		{"vendor/foo", true},
+		{"vendor/foo/bar", true},
+		{"generated", true},
+		{"generated/contracts", true},
+		// "cells/skip.yaml" is not a "/**" pattern — must NOT prune directories.
+		{"cells", false},
+		{"other", false},
+		{".", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dir, func(t *testing.T) {
+			got := es.matchDir(tc.dir)
+			if got != tc.want {
+				t.Errorf("matchDir(%q) = %v, want %v", tc.dir, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestManifestGlobWalkFn_SkipDirOnExclude verifies that the WalkDir callback
+// returns fs.SkipDir for directories that match a "<prefix>/**" exclude pattern,
+// preventing traversal into excluded subtrees.
+func TestManifestGlobWalkFn_SkipDirOnExclude(t *testing.T) {
+	fsys := fstest.MapFS{
+		"vendor/foo/cell.yaml": &fstest.MapFile{Data: []byte("id: vendor-cell\n")},
+		"cells/real/cell.yaml": &fstest.MapFile{Data: []byte("id: real\n")},
+		"cells/skip/cell.yaml": &fstest.MapFile{Data: []byte("id: skip\n")},
+	}
+
+	// Provide manifest with vendor/** exclude so vendor subtree is pruned.
+	manifest := `version: v1
+modules:
+  - path: .
+    includes:
+      cells:
+        - "cells/*/cell.yaml"
+        - "vendor/*/cell.yaml"
+    excludes:
+      - "vendor/**"
+`
+	fsys[".gocell/manifest.yaml"] = &fstest.MapFile{Data: []byte(manifest)}
+	l, err := NewLocatorFS(fsys, WithLocatorMode(LocatorManifest))
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, s := range sources {
+		if strings.Contains(s.Path, "vendor") {
+			t.Errorf("vendor path included despite exclude: %v", s)
+		}
+	}
+	// Confirm "cells/real/cell.yaml" is still present.
+	var found bool
+	for _, s := range sources {
+		if s.Path == "cells/real/cell.yaml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("cells/real/cell.yaml missing from sources: %v", sources)
+	}
+}
+
+// TestManifestGlobWalkFn_CapExceeded verifies that matching more than
+// maxManifestMatchesPerGlob files per glob returns an error.
+func TestManifestGlobWalkFn_CapExceeded(t *testing.T) {
+	// Build a filesystem with maxManifestMatchesPerGlob+1 matching files.
+	fsys := fstest.MapFS{}
+	cap := maxManifestMatchesPerGlob
+	for i := 0; i <= cap; i++ {
+		path := fmt.Sprintf("cells/c%d/cell.yaml", i)
+		fsys[path] = &fstest.MapFile{Data: []byte(fmt.Sprintf("id: c%d\n", i))}
+	}
+	_, err := matchManifestGlob(fsys, "cells/*/cell.yaml", nil)
+	if err == nil {
+		t.Fatalf("expected error when cap exceeded, got nil")
+	}
+	if !strings.Contains(err.Error(), "cap") && !strings.Contains(err.Error(), "limit") {
+		t.Errorf("error %q should mention cap or limit", err.Error())
+	}
+}
+
+// TestManifestGlobWalkFn_CapNotExceeded verifies that exactly
+// maxManifestMatchesPerGlob matches does not return an error.
+func TestManifestGlobWalkFn_CapNotExceeded(t *testing.T) {
+	fsys := fstest.MapFS{}
+	cap := maxManifestMatchesPerGlob
+	for i := 0; i < cap; i++ {
+		path := fmt.Sprintf("cells/c%d/cell.yaml", i)
+		fsys[path] = &fstest.MapFile{Data: []byte(fmt.Sprintf("id: c%d\n", i))}
+	}
+	matches, err := matchManifestGlob(fsys, "cells/*/cell.yaml", nil)
+	if err != nil {
+		t.Fatalf("unexpected error at exactly cap matches: %v", err)
+	}
+	if len(matches) != cap {
+		t.Errorf("got %d matches, want %d", len(matches), cap)
+	}
+}
+
+// TestManifestGlobWalkFn_SkipDirDoesNotAffectFileExcludes verifies that
+// file-level excludes (non-"/**" patterns) are still applied even when
+// SkipDir pruning is not triggered for that directory.
+func TestManifestGlobWalkFn_SkipDirDoesNotAffectFileExcludes(t *testing.T) {
+	// "cells/skip.yaml" is not a /**-pattern; cells/skip/cell.yaml file
+	// should still be filtered by the post-walk file-level exclude check.
+	manifest := `version: v1
+modules:
+  - path: .
+    includes:
+      cells:
+        - "cells/*/cell.yaml"
+    excludes:
+      - "cells/skip/cell.yaml"
+`
+	fsys := fstest.MapFS{
+		".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
+		"cells/keep/cell.yaml":  &fstest.MapFile{Data: []byte("id: keep\n")},
+		"cells/skip/cell.yaml":  &fstest.MapFile{Data: []byte("id: skip\n")},
+	}
+	l, err := NewLocatorFS(fsys, WithLocatorMode(LocatorManifest))
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	sources, err := l.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, s := range sources {
+		if strings.Contains(s.Path, "skip") {
+			t.Errorf("file-level exclude not applied: %v", s)
+		}
+	}
+}

--- a/kernel/metadata/review_findings_test.go
+++ b/kernel/metadata/review_findings_test.go
@@ -326,17 +326,20 @@ modules:
 	}
 }
 
-// TestManifestGlobWalkFn_CapExceeded verifies that matching more than
-// maxManifestMatchesPerGlob files per glob returns an error.
+// TestManifestGlobWalkFn_CapExceeded verifies that matching more than the
+// per-glob match cap returns an error. The cap is injected via
+// matchManifestGlobCapped so the test exercises the abort path with a tiny
+// value (testCap+1 files) instead of materializing 50 000 files in a MapFS —
+// which would blow the per-test slowgate budget. matchManifestGlob delegates
+// to matchManifestGlobCapped with maxManifestMatchesPerGlob in production.
 func TestManifestGlobWalkFn_CapExceeded(t *testing.T) {
-	// Build a filesystem with maxManifestMatchesPerGlob+1 matching files.
+	const testCap = 3
 	fsys := fstest.MapFS{}
-	cap := maxManifestMatchesPerGlob
-	for i := 0; i <= cap; i++ {
+	for i := 0; i <= testCap; i++ { // testCap+1 matching files
 		path := fmt.Sprintf("cells/c%d/cell.yaml", i)
 		fsys[path] = &fstest.MapFile{Data: []byte(fmt.Sprintf("id: c%d\n", i))}
 	}
-	_, err := matchManifestGlob(fsys, "cells/*/cell.yaml", nil)
+	_, err := matchManifestGlobCapped(fsys, "cells/*/cell.yaml", nil, testCap)
 	if err == nil {
 		t.Fatalf("expected error when cap exceeded, got nil")
 	}
@@ -345,21 +348,21 @@ func TestManifestGlobWalkFn_CapExceeded(t *testing.T) {
 	}
 }
 
-// TestManifestGlobWalkFn_CapNotExceeded verifies that exactly
-// maxManifestMatchesPerGlob matches does not return an error.
+// TestManifestGlobWalkFn_CapNotExceeded verifies that exactly testCap matches
+// does not return an error (boundary: count > cap aborts, count == cap is ok).
 func TestManifestGlobWalkFn_CapNotExceeded(t *testing.T) {
+	const testCap = 3
 	fsys := fstest.MapFS{}
-	cap := maxManifestMatchesPerGlob
-	for i := 0; i < cap; i++ {
+	for i := 0; i < testCap; i++ {
 		path := fmt.Sprintf("cells/c%d/cell.yaml", i)
 		fsys[path] = &fstest.MapFile{Data: []byte(fmt.Sprintf("id: c%d\n", i))}
 	}
-	matches, err := matchManifestGlob(fsys, "cells/*/cell.yaml", nil)
+	matches, err := matchManifestGlobCapped(fsys, "cells/*/cell.yaml", nil, testCap)
 	if err != nil {
 		t.Fatalf("unexpected error at exactly cap matches: %v", err)
 	}
-	if len(matches) != cap {
-		t.Errorf("got %d matches, want %d", len(matches), cap)
+	if len(matches) != testCap {
+		t.Errorf("got %d matches, want %d", len(matches), testCap)
 	}
 }
 

--- a/kernel/metadata/schema_refs.go
+++ b/kernel/metadata/schema_refs.go
@@ -34,6 +34,10 @@ type ResolvedSchemaRef struct {
 }
 
 // SchemaRefError reports a schema ref resolution failure.
+//
+// Kind is a free-form descriptive string used only in Error(); no caller
+// compares it. If a caller ever needs to switch on it, type it via the
+// string-typed concept funnel pattern — tracked in #1254.
 type SchemaRefError struct {
 	Field string
 	Ref   string
@@ -163,6 +167,9 @@ func sortedStringKeys(m map[string]string) []string {
 	return keys
 }
 
+// isWithinRoot mirrors kernel/governance.IsWithinRoot. The duplication is
+// forced by layering (kernel/metadata cannot import kernel/governance); keep
+// the two in sync. Extracting a shared helper is tracked in #1255.
 func isWithinRoot(root, target string) bool {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {

--- a/kernel/metadata/schema_refs.go
+++ b/kernel/metadata/schema_refs.go
@@ -44,21 +44,19 @@ func (e *SchemaRefError) Error() string {
 	return fmt.Sprintf("%s %q: %s", e.Field, e.Ref, e.Kind)
 }
 
-// ContractDirFromMeta returns the contract directory relative to the project root.
+// ContractDirFromMeta returns the contract directory relative to the project
+// root. Returns "" when c is nil or c.Dir is unset. c.Dir is populated by the
+// Locator funnel during ParseFS — callers that hit "" should treat it as a
+// parsed-meta-missing condition, not as an opportunity to derive a default
+// path from the ID. The prior ContractDirFromID-based fallback was removed
+// when M1 (#1082) made layout discovery go through Locator: a derived
+// "contracts/<id>" path is wrong in manifest mode and was masking real bugs
+// when c.Dir was unexpectedly empty.
 func ContractDirFromMeta(c *ContractMeta) string {
 	if c == nil {
 		return ""
 	}
-	if c.Dir != "" {
-		return filepath.ToSlash(c.Dir)
-	}
-	return ContractDirFromID(c.ID)
-}
-
-// ContractDirFromID converts a contract ID to its default directory path.
-func ContractDirFromID(id string) string {
-	segments := strings.Split(id, ".")
-	return filepath.ToSlash(filepath.Join("contracts", filepath.Join(segments...)))
+	return filepath.ToSlash(c.Dir)
 }
 
 // ContractSchemaRefs returns every schema reference declared by c in deterministic

--- a/kernel/metadata/schema_refs_test.go
+++ b/kernel/metadata/schema_refs_test.go
@@ -15,10 +15,12 @@ func TestContractDirFromMeta(t *testing.T) {
 		ID:  "http.auth.login.v1",
 		Dir: "examples/demo/contracts/http/auth/login/v1",
 	}))
-	assert.Equal(t, "contracts/http/auth/login/v1", ContractDirFromMeta(&ContractMeta{
+	// c.Dir empty returns "" — no derive-from-ID fallback after M1 (#1082).
+	// The Locator funnel guarantees c.Dir is set during ParseFS; callers
+	// observing "" should treat it as a missing-meta condition.
+	assert.Empty(t, ContractDirFromMeta(&ContractMeta{
 		ID: "http.auth.login.v1",
 	}))
-	assert.Equal(t, "contracts/http/auth/login/v1", ContractDirFromID("http.auth.login.v1"))
 }
 
 func TestContractSchemaRefsDeterministicOrder(t *testing.T) {

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -1,6 +1,5 @@
 // invariants asserted in this file:
 //   - INVARIANT: LOCATOR-DISCOVERY-FUNNEL-01
-//   - INVARIANT: LOCATOR-DISCOVERY-FUNNEL-01.A5
 //
 // LOCATOR-DISCOVERY-FUNNEL-01 (M1 of #1082) keeps kernel/metadata.Locator the
 // sole place in the codebase that knows how the filesystem topology maps to
@@ -35,13 +34,14 @@
 //      output (MetadataSource.File / CellMeta.File / etc.).
 //      AI-robust grading: upstream Medium (archtest caller allowlist) +
 //      downstream Hard (form uniqueness via const-eval arg scanning).
-//      TODO(LOCATOR-FUNNEL-A5-UPSTREAM-HARD): gh issue #?? — Batch 4 will
-//      fill the upstream Hard tracking issue number once opened.
+//      Funnel EXITING upstream is Medium (archtest caller-allowlist + blind-spot
+//      self-check); upstream Hard 升级路径 (Locator sealed envelope /
+//      typed pathx package / accept Medium 上限) is tracked by gh issue #1235.
 //
 // AI-robust grading: Medium upstream + Hard downstream is a final form per
 // ai-robust §"Funnel 双向锁评级". No follow-up issue is opened for A1/A2; the
 // upstream ceiling is a Go-language limit, not a deferred TODO. See ADR
-// 202605281200. A5 upstream tracking: see TODO comment above.
+// 202605281200. A5 upstream Hard tracking: gh issue #1235.
 
 package archtest
 
@@ -609,10 +609,14 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 					if bin.Op != token.EQL && bin.Op != token.NEQ {
 						return
 					}
-					for _, operand := range []ast.Expr{bin.X, bin.Y} {
-						if _, isLit := operand.(*ast.BasicLit); isLit {
-							return // already covered by A2b
-						}
+					// Skip when either operand is a BasicLit — that form is
+					// already covered by A2b; this blind-spot catches Ident
+					// operands (cross-package const refs) specifically.
+					if _, isLit := bin.X.(*ast.BasicLit); isLit {
+						return
+					}
+					if _, isLit := bin.Y.(*ast.BasicLit); isLit {
+						return
 					}
 					var lit string
 					var ok bool
@@ -654,11 +658,9 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 // AI-robust grading:
 //   - Upstream: Medium (archtest caller allowlist; Go type system cannot
 //     prevent package-internal code from calling filepath.Join freely).
+//     Upstream Hard upgrade path tracked by gh issue #1235.
 //   - Downstream: Hard (form-uniqueness: EvaluateConstString resolves every
 //     filepath.Join argument; any arg that evaluates to a banned token fails).
-//
-// TODO(LOCATOR-FUNNEL-A5-UPSTREAM-HARD): gh issue #?? — Batch 4 will fill
-// the tracking issue number once opened.
 //
 // Blind spots enforced by TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots.
 //
@@ -810,20 +812,19 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots(t *testing.T) {
 					if !locatorIsFilepathJoin(call) {
 						return
 					}
-					for _, arg := range call.Args {
-						bin, ok := arg.(*ast.BinaryExpr)
-						if !ok || bin.Op != token.ADD {
-							continue
+					EachInChildren[ast.BinaryExpr](call, func(bin *ast.BinaryExpr) {
+						if bin.Op != token.ADD {
+							return
 						}
 						// Only flag if both operands are basic literals (split literal concat).
 						_, lhsIsLit := bin.X.(*ast.BasicLit)
 						_, rhsIsLit := bin.Y.(*ast.BasicLit)
 						if !lhsIsLit || !rhsIsLit {
-							continue
+							return
 						}
-						lit, ok := EvaluateConstString(p.TypesInfo, arg)
+						lit, ok := EvaluateConstString(p.TypesInfo, bin)
 						if !ok {
-							continue
+							return
 						}
 						for _, banned := range locatorConsumerPathTokens {
 							if lit == banned {
@@ -837,7 +838,7 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots(t *testing.T) {
 								return
 							}
 						}
-					}
+					})
 				})
 			}
 			return d

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -1,5 +1,6 @@
 // invariants asserted in this file:
 //   - INVARIANT: LOCATOR-DISCOVERY-FUNNEL-01
+//   - INVARIANT: LOCATOR-DISCOVERY-FUNNEL-01.A5
 //
 // LOCATOR-DISCOVERY-FUNNEL-01 (M1 of #1082) keeps kernel/metadata.Locator the
 // sole place in the codebase that knows how the filesystem topology maps to
@@ -19,12 +20,28 @@
 //      assemblies/, examples/} are restricted to the locator's own files in
 //      kernel/metadata/locator*.go (plus two governance helper files for
 //      conventional-mode strict rules). The form catalog locks two AST
-//      shapes today and a reverse blind-spot self-check rejects two
-//      additional shapes via negative tests.
+//      shapes today (HasPrefix + == ) and uses EvaluateConstString (go/types
+//      constant folding) so that cross-package const references (e.g.
+//      const cellsPrefix = "cells/") cannot bypass the check.
+//      A reverse blind-spot self-check rejects const-eval bypass forms via
+//      negative tests.
+//
+//   A5 (downstream Hard — consumer-path reverse funnel): filepath.Join calls
+//      whose arguments evaluate to conventional layout tokens ("cells", "cmd")
+//      are banned from kernel/governance/**, cmd/gocell/**, and
+//      kernel/metadata/** (outside the Locator funnel files). This closes
+//      the EXITING side: governance and CLI code must not reconstruct
+//      conventional paths; they must instead consume paths from the Locator
+//      output (MetadataSource.File / CellMeta.File / etc.).
+//      AI-robust grading: upstream Medium (archtest caller allowlist) +
+//      downstream Hard (form uniqueness via const-eval arg scanning).
+//      TODO(LOCATOR-FUNNEL-A5-UPSTREAM-HARD): gh issue #?? — Batch 4 will
+//      fill the upstream Hard tracking issue number once opened.
 //
 // AI-robust grading: Medium upstream + Hard downstream is a final form per
-// ai-robust §"Funnel 双向锁评级". No follow-up issue is opened; the upstream
-// ceiling is a Go-language limit, not a deferred TODO. See ADR 202605281200.
+// ai-robust §"Funnel 双向锁评级". No follow-up issue is opened for A1/A2; the
+// upstream ceiling is a Go-language limit, not a deferred TODO. See ADR
+// 202605281200. A5 upstream tracking: see TODO comment above.
 
 package archtest
 
@@ -99,7 +116,20 @@ var locatorAllowedWalkCallers = map[string]bool{
 var locatorGovernanceConventionalFiles = map[string]bool{
 	"helpers.go":           true,
 	"rules_misc_strict.go": true,
-	"locator.go":           true,
+	// ctmCheckExamplesArrow uses strings.HasPrefix(_, "examples/") for conventional-layout
+	// enforcement — intrinsically conventional, would be incorrect under Manifest mode.
+	"rules_contract_test_mapping.go": true,
+	"locator.go":                     true,
+}
+
+// locatorConsumerPathTokens are the conventional layout tokens whose presence
+// as a literal argument to filepath.Join in consumer code (kernel/governance,
+// cmd/gocell, kernel/metadata outside Locator funnel files) indicates a
+// hardcoded path reconstruction that should instead consume the path from the
+// Locator's output (e.g. CellMeta.File, SliceMeta.File).
+var locatorConsumerPathTokens = []string{
+	"cells",
+	"cmd",
 }
 
 // locatorScanDirs returns the directories whose Go files are scanned by
@@ -110,6 +140,17 @@ func locatorScanDirs() []string {
 	return []string{
 		"kernel/metadata",
 		"kernel/governance",
+	}
+}
+
+// locatorConsumerScanPatterns returns the Go package patterns for A5 (consumer-
+// path reverse funnel). These are the packages outside the Locator core that
+// must not reconstruct conventional layout paths via filepath.Join.
+func locatorConsumerScanPatterns() []string {
+	return []string{
+		"./kernel/governance/...",
+		"./cmd/gocell/...",
+		"./kernel/metadata/...",
 	}
 }
 
@@ -156,10 +197,23 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist(t *testing.T) {
 // strings.HasPrefix(_, lit) call shapes with a conventional-layout-prefix
 // literal as the second argument may only appear in the Locator's own
 // files inside kernel/metadata/** and kernel/governance/**.
+//
+// Uses EvaluateConstString (go/types constant folding) to resolve the second
+// argument so that cross-package const references such as:
+//
+//	const cellsPrefix = "cells/"
+//	strings.HasPrefix(p, cellsPrefix)
+//
+// are caught, not just bare BasicLit forms.
+//
+// Blind spots documented in TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory
+// and A2_ConstEvalBypassBlindSpots.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
-	root := findModuleRoot(t)
-	diags := Run(t, DirsScope(root, locatorScanDirs()),
+	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./kernel/metadata/...", "./kernel/governance/..."},
 		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
 			var d []Diagnostic
 			for _, f := range p.Files {
 				rel := p.Rel(f)
@@ -170,7 +224,7 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
 					if !locatorIsCalleeStringsHasPrefix(call) || len(call.Args) < 2 {
 						return
 					}
-					lit, ok := locatorStringLiteral(call.Args[1])
+					lit, ok := EvaluateConstString(p.TypesInfo, call.Args[1])
 					if !ok {
 						return
 					}
@@ -197,10 +251,23 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
 // conventional-layout token) inside kernel/metadata/** or
 // kernel/governance/** must live in the Locator's own files. This is the
 // shape used by path-segment matchers (`parts[N] == "cells"`).
+//
+// Uses EvaluateConstString (go/types constant folding) to resolve operands so
+// that cross-package const references such as:
+//
+//	const cellsTok = "cells"
+//	parts[0] == cellsTok
+//
+// are caught, not just bare BasicLit operands.
+//
+// Blind spots documented in TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory
+// and A2_ConstEvalBypassBlindSpots.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *testing.T) {
-	root := findModuleRoot(t)
-	diags := Run(t, DirsScope(root, locatorScanDirs()),
+	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./kernel/metadata/...", "./kernel/governance/..."},
 		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
 			var d []Diagnostic
 			for _, f := range p.Files {
 				rel := p.Rel(f)
@@ -211,9 +278,9 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *tes
 					if bin.Op != token.EQL && bin.Op != token.NEQ {
 						return
 					}
-					lit, ok := locatorStringLiteral(bin.Y)
+					lit, ok := EvaluateConstString(p.TypesInfo, bin.Y)
 					if !ok {
-						lit, ok = locatorStringLiteral(bin.X)
+						lit, ok = EvaluateConstString(p.TypesInfo, bin.X)
 						if !ok {
 							return
 						}
@@ -432,6 +499,325 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
 	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.CONTAINS", containsDiags)
 }
 
+// TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots asserts that
+// the two forms that would bypass a BasicLit-only A2 check are absent from
+// production code in kernel/metadata/** and kernel/governance/**:
+//
+//  1. Cross-package const used as HasPrefix argument:
+//     const cellsPrefix = "cells/"
+//     strings.HasPrefix(p, cellsPrefix)
+//     → EvaluateConstString resolves cellsPrefix to "cells/" and catches it;
+//     this test asserts it does NOT appear so A2a keeps its PASS status.
+//
+//  2. Cross-package const used as equality operand:
+//     const cellsTok = "cells"
+//     parts[0] == cellsTok
+//     → EvaluateConstString resolves cellsTok to "cells" and catches it;
+//     this test asserts it does NOT appear so A2b keeps its PASS status.
+//
+// These negative tests are required by ai-robust §"工具选定后强制盲区自检".
+// The tests are vacuously true today (production AST has no such forms), which
+// confirms that upgrading A2a/A2b from BasicLit to EvaluateConstString does not
+// introduce false positives.
+func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) {
+	// Blind-spot BS-A: const Ident as strings.HasPrefix second arg evaluating to
+	// a banned prefix. EvaluateConstString resolves it; a production occurrence
+	// would mean A2a already catches it and a developer should not be able to
+	// bypass the funnel this way.
+	hasPrefixConstDiags := RunTyped(t, TypedOpts{Tests: false},
+		[]string{"./kernel/metadata/...", "./kernel/governance/..."},
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if !locatorIsCalleeStringsHasPrefix(call) || len(call.Args) < 2 {
+						return
+					}
+					// Only flag non-BasicLit second args that const-eval to a banned prefix.
+					// BasicLit forms are already caught by A2a; this catches the bypass
+					// where an Ident (cross-package const) is used instead.
+					if _, isLit := call.Args[1].(*ast.BasicLit); isLit {
+						return // already covered by A2a
+					}
+					lit, ok := EvaluateConstString(p.TypesInfo, call.Args[1])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutPrefixes {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "A2-BS-A (const-eval bypass): strings.HasPrefix(_, <const>=" +
+									strconv.Quote(lit) + ") outside Locator funnel — " +
+									"A2a now catches this; presence indicates a regression in bypass coverage",
+							})
+							break
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A2.BLINDSPOT.CONST-HASPFIX", hasPrefixConstDiags)
+
+	// Blind-spot BS-B: const Ident as equality operand evaluating to a banned token.
+	equalityConstDiags := RunTyped(t, TypedOpts{Tests: false},
+		[]string{"./kernel/metadata/...", "./kernel/governance/..."},
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.BinaryExpr](f, func(bin *ast.BinaryExpr) {
+					if bin.Op != token.EQL && bin.Op != token.NEQ {
+						return
+					}
+					for _, operand := range []ast.Expr{bin.X, bin.Y} {
+						if _, isLit := operand.(*ast.BasicLit); isLit {
+							return // already covered by A2b
+						}
+					}
+					var lit string
+					var ok bool
+					lit, ok = EvaluateConstString(p.TypesInfo, bin.Y)
+					if !ok {
+						lit, ok = EvaluateConstString(p.TypesInfo, bin.X)
+					}
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutTokens {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(bin.Pos()).Line,
+								Message: "A2-BS-B (const-eval bypass): <expr> ==/!= <const>=" +
+									strconv.Quote(lit) + " outside Locator funnel — " +
+									"A2b now catches this; presence indicates a regression in bypass coverage",
+							})
+							break
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A2.BLINDSPOT.CONST-EQ", equalityConstDiags)
+}
+
+// TestLOCATOR_DISCOVERY_FUNNEL_01_A5_ConsumerPathFunnel enforces that
+// filepath.Join callsites in the consumer packages (kernel/governance,
+// cmd/gocell, kernel/metadata outside Locator funnel files) do not reconstruct
+// conventional layout paths by passing literal "cells" or "cmd" as arguments.
+//
+// Consumer code must derive paths from Locator output (CellMeta.File,
+// SliceMeta.File, AssemblyMeta.File, etc.) rather than hardcoding the
+// conventional layout topology.
+//
+// AI-robust grading:
+//   - Upstream: Medium (archtest caller allowlist; Go type system cannot
+//     prevent package-internal code from calling filepath.Join freely).
+//   - Downstream: Hard (form-uniqueness: EvaluateConstString resolves every
+//     filepath.Join argument; any arg that evaluates to a banned token fails).
+//
+// TODO(LOCATOR-FUNNEL-A5-UPSTREAM-HARD): gh issue #?? — Batch 4 will fill
+// the tracking issue number once opened.
+//
+// Blind spots enforced by TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots.
+//
+// NOTE: This test is expected to FAIL until Batch 3 fixes the following
+// known violations (each will become a PASS after Batch 3):
+//   - kernel/governance/rules_misc_consistency.go:367
+//     filepath.Join(root, "cells", ref.cellID)
+//   - cmd/gocell/app/check.go:338
+//     filepath.Join(root, "cells", cid, "slices")
+//   - kernel/metadata/assembly_derive.go:74
+//     filepath.Join("cmd", asm.ID, "main.go")
+//
+// Additional violations in cmd/gocell/app/scaffold.go (scaffold.go:492,
+// scaffold.go:598, scaffold.go:612, scaffold.go:640) are also captured and
+// must be fixed by Batch 3.
+func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_ConsumerPathFunnel(t *testing.T) {
+	diags := RunTyped(t, TypedOpts{Tests: false}, locatorConsumerScanPatterns(),
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				// Skip test files.
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				// Skip Locator funnel files (they legitimately hold layout tokens).
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if !locatorIsFilepathJoin(call) || len(call.Args) == 0 {
+						return
+					}
+					for _, arg := range call.Args {
+						lit, ok := EvaluateConstString(p.TypesInfo, arg)
+						if !ok {
+							continue
+						}
+						for _, banned := range locatorConsumerPathTokens {
+							if lit == banned {
+								d = append(d, Diagnostic{
+									Rel:  rel,
+									Line: p.Fset.Position(call.Pos()).Line,
+									Message: "A5 (Hard downstream): filepath.Join arg " +
+										strconv.Quote(lit) +
+										" reconstructs a conventional layout path; " +
+										"use Locator output (e.g. CellMeta.File) instead",
+								})
+								return // one diagnostic per callsite
+							}
+						}
+					}
+				})
+			}
+			return d
+		})
+	// A5 is intentionally expected to FAIL until Batch 3 fixes the violations
+	// listed in the function godoc. We use Report which marks the test as failed
+	// when diagnostics are non-empty — this is the desired TDD "RED" state.
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A5", diags)
+}
+
+// TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots asserts that the two A5 blind
+// spots are absent from the consumer-path scan scope:
+//
+//  1. path.Join (not filepath.Join) with a banned token — different callee, same
+//     semantic violation.
+//
+//  2. String concatenation that rebuilds a banned token ("ce"+"lls") — the
+//     EvaluateConstString constant folding via go/types handles BinaryExpr ADD,
+//     but hand-split literals are unusual in production; this negative test
+//     ensures they never appear.
+//
+// Both are required reverse negative tests per ai-robust §"工具选定后强制盲区自检".
+func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots(t *testing.T) {
+	// Blind-spot A5-BS1: path.Join (not filepath.Join) with banned token.
+	pathJoinDiags := RunTyped(t, TypedOpts{Tests: false}, locatorConsumerScanPatterns(),
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok || sel.Sel == nil || sel.Sel.Name != "Join" {
+						return
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != "path" {
+						return
+					}
+					for _, arg := range call.Args {
+						lit, ok := EvaluateConstString(p.TypesInfo, arg)
+						if !ok {
+							continue
+						}
+						for _, banned := range locatorConsumerPathTokens {
+							if lit == banned {
+								d = append(d, Diagnostic{
+									Rel:  rel,
+									Line: p.Fset.Position(call.Pos()).Line,
+									Message: "A5-BS1 (path.Join blind spot): path.Join arg " +
+										strconv.Quote(lit) +
+										" reconstructs a conventional layout path — A5 only scans filepath.Join",
+								})
+								return
+							}
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A5.BLINDSPOT.PATHJOIN", pathJoinDiags)
+
+	// Blind-spot A5-BS2: string concatenation rebuilding a banned token in
+	// filepath.Join args. EvaluateConstString handles BinaryExpr ADD via
+	// go/types constant folding, so "ce"+"lls" would be resolved to "cells"
+	// and caught by A5. This negative test confirms no such form exists.
+	concatDiags := RunTyped(t, TypedOpts{Tests: false}, locatorConsumerScanPatterns(),
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if !locatorIsFilepathJoin(call) {
+						return
+					}
+					for _, arg := range call.Args {
+						bin, ok := arg.(*ast.BinaryExpr)
+						if !ok || bin.Op != token.ADD {
+							continue
+						}
+						// Only flag if both operands are basic literals (split literal concat).
+						_, lhsIsLit := bin.X.(*ast.BasicLit)
+						_, rhsIsLit := bin.Y.(*ast.BasicLit)
+						if !lhsIsLit || !rhsIsLit {
+							continue
+						}
+						lit, ok := EvaluateConstString(p.TypesInfo, arg)
+						if !ok {
+							continue
+						}
+						for _, banned := range locatorConsumerPathTokens {
+							if lit == banned {
+								d = append(d, Diagnostic{
+									Rel:  rel,
+									Line: p.Fset.Position(call.Pos()).Line,
+									Message: "A5-BS2 (concat blind spot): filepath.Join arg " +
+										strconv.Quote(lit) +
+										" from literal concat — present despite A5 catching it via const-eval",
+								})
+								return
+							}
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A5.BLINDSPOT.CONCAT", concatDiags)
+}
+
 // --- internal helpers ---
 
 // locatorWalkCalleeName returns the name (e.g. "fs.WalkDir") of a call
@@ -481,6 +867,19 @@ func locatorStringLiteral(expr ast.Expr) (string, bool) {
 		return "", false
 	}
 	return unq, true
+}
+
+// locatorIsFilepathJoin reports whether the call expression is filepath.Join(...).
+func locatorIsFilepathJoin(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "filepath" && sel.Sel.Name == "Join"
 }
 
 // locatorIsAllowedFile reports whether the module-relative path is one of

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -30,17 +30,12 @@ package archtest
 
 import (
 	"go/ast"
-	"go/parser"
 	"go/token"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 // locatorLayoutTokens are the path-token literals whose presence in
@@ -95,16 +90,16 @@ var locatorAllowedWalkCallers = map[string]bool{
 // Extending this allowlist must come with a written rationale in code
 // review — the inclusion criterion is "the rule is intrinsically about
 // conventional layout and would be incorrect under Manifest mode".
+//
+// governance/locator.go holds canonicalCellID / canonicalSliceKey /
+// canonicalContractID / canonicalJourneyID / canonicalAssemblyID —
+// conventional-layout-specific reverse mappers (path → canonical ID) used
+// by governance ValidationResult dedup. Same rationale; the parse-side
+// mapping is in kernel/metadata.Locator, this is its dual for governance.
 var locatorGovernanceConventionalFiles = map[string]bool{
 	"helpers.go":           true,
 	"rules_misc_strict.go": true,
-	// locator.go holds canonicalCellID / canonicalSliceKey /
-	// canonicalContractID / canonicalJourneyID / canonicalAssemblyID
-	// — conventional-layout-specific reverse mappers (path → canonical
-	// ID) used by governance ValidationResult dedup. Same rationale as
-	// the conventional-mode helpers above; the parse-side mapping is in
-	// kernel/metadata.Locator, this is its dual for governance.
-	"locator.go": true,
+	"locator.go":           true,
 }
 
 // locatorScanDirs returns the directories whose Go files are scanned by
@@ -120,27 +115,41 @@ func locatorScanDirs() []string {
 
 // TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist enforces that
 // fs.WalkDir / filepath.Walk / fs.ReadDir are only called from within the
-// Locator's discover{Conventional,Manifest} bodies inside
+// Locator's discover{Conventional,Manifest} bodies (and the manifest glob
+// expansion helpers that are themselves part of the funnel) inside
 // kernel/metadata/**.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist(t *testing.T) {
-	t.Parallel()
-	scope := scanner.DirsScope(findModuleRoot(t), []string{"kernel/metadata"})
-	var hits []string
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		scanner.EachInSubtree[ast.FuncDecl](fc.File, func(fn *ast.FuncDecl) {
-			if fn.Body == nil || locatorAllowedWalkCallers[fn.Name.Name] {
-				return
-			}
-			scanner.EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
-				if name, ok := locatorWalkCalleeName(call); ok {
-					hits = append(hits, locatorFunnelViolation(fc.Rel, fn.Name.Name, name))
+	root := findModuleRoot(t)
+	diags := Run(t, DirsScope(root, []string{"kernel/metadata"}),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
 				}
-			})
+				EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+					if fn.Body == nil || locatorAllowedWalkCallers[fn.Name.Name] {
+						return
+					}
+					EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+						name, ok := locatorWalkCalleeName(call)
+						if !ok {
+							return
+						}
+						d = append(d, Diagnostic{
+							Rel:  rel,
+							Line: p.Fset.Position(call.Pos()).Line,
+							Message: "A1 (Medium upstream): " + name +
+								" is only allowed inside " + locatorJoinKeys(locatorAllowedWalkCallers) +
+								" (callsite in " + fn.Name.Name + ")",
+						})
+					})
+				})
+			}
+			return d
 		})
-	})
-	assert.Empty(t, hits,
-		"LOCATOR-DISCOVERY-FUNNEL-01 A1: fs.WalkDir / filepath.Walk / fs.ReadDir "+
-			"is only allowed inside %v in kernel/metadata/**", locatorSortedKeys(locatorAllowedWalkCallers))
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A1", diags)
 }
 
 // TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness enforces that
@@ -148,34 +157,39 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist(t *testing.T) {
 // literal as the second argument may only appear in the Locator's own
 // files inside kernel/metadata/** and kernel/governance/**.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
-	t.Parallel()
-	hits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
-		if locatorIsAllowedFile(fc.Rel) {
-			return nil
-		}
-		var out []string
-		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
-			if !locatorIsCalleeStringsHasPrefix(call) || len(call.Args) < 2 {
-				return
-			}
-			lit, ok := locatorStringLiteral(call.Args[1])
-			if !ok {
-				return
-			}
-			for _, banned := range locatorLayoutPrefixes {
-				if lit == banned {
-					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
-						"strings.HasPrefix(_, "+strconv.Quote(lit)+")"))
-					break
+	root := findModuleRoot(t)
+	diags := Run(t, DirsScope(root, locatorScanDirs()),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
 				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if !locatorIsCalleeStringsHasPrefix(call) || len(call.Args) < 2 {
+						return
+					}
+					lit, ok := locatorStringLiteral(call.Args[1])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutPrefixes {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "A2a (Hard downstream): strings.HasPrefix(_, " +
+									strconv.Quote(lit) + ") may only appear inside the Locator funnel files",
+							})
+							break
+						}
+					}
+				})
 			}
+			return d
 		})
-		return out
-	})
-	assert.Empty(t, hits,
-		"LOCATOR-DISCOVERY-FUNNEL-01 A2a (HasPrefix + literal): conventional-layout "+
-			"prefix literals %v may only appear inside the Locator funnel files (%v)",
-		locatorLayoutPrefixes, locatorSortedKeys(locatorFunnelFiles))
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A2a", diags)
 }
 
 // TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness
@@ -184,37 +198,43 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
 // kernel/governance/** must live in the Locator's own files. This is the
 // shape used by path-segment matchers (`parts[N] == "cells"`).
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *testing.T) {
-	t.Parallel()
-	hits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
-		if locatorIsAllowedFile(fc.Rel) {
-			return nil
-		}
-		var out []string
-		scanner.EachInSubtree[ast.BinaryExpr](fc.File, func(bin *ast.BinaryExpr) {
-			if bin.Op != token.EQL && bin.Op != token.NEQ {
-				return
-			}
-			lit, ok := locatorStringLiteral(bin.Y)
-			if !ok {
-				lit, ok = locatorStringLiteral(bin.X)
-				if !ok {
-					return
+	root := findModuleRoot(t)
+	diags := Run(t, DirsScope(root, locatorScanDirs()),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
 				}
+				EachInSubtree[ast.BinaryExpr](f, func(bin *ast.BinaryExpr) {
+					if bin.Op != token.EQL && bin.Op != token.NEQ {
+						return
+					}
+					lit, ok := locatorStringLiteral(bin.Y)
+					if !ok {
+						lit, ok = locatorStringLiteral(bin.X)
+						if !ok {
+							return
+						}
+					}
+					for _, banned := range locatorLayoutTokens {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(bin.Pos()).Line,
+								Message: "A2b (Hard downstream): <expr> ==/!= " +
+									strconv.Quote(lit) +
+									" may only appear inside the Locator funnel files",
+							})
+							break
+						}
+					}
+				})
 			}
-			for _, banned := range locatorLayoutTokens {
-				if lit == banned {
-					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
-						"<expr> ==/!= "+strconv.Quote(lit)))
-					break
-				}
-			}
+			return d
 		})
-		return out
-	})
-	assert.Empty(t, hits,
-		"LOCATOR-DISCOVERY-FUNNEL-01 A2b (== / != with literal): conventional-layout "+
-			"tokens %v may only appear inside the Locator funnel files (%v)",
-		locatorLayoutTokens, locatorSortedKeys(locatorFunnelFiles))
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A2b", diags)
 }
 
 // TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory documents the AST
@@ -231,88 +251,88 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *tes
 //     "cell" + "s/")
 //   - Regex anchors (regexp.MustCompile(`^cells/`))
 func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
-	t.Parallel()
-
-	concatHits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
-		if locatorIsAllowedFile(fc.Rel) {
-			return nil
-		}
-		var out []string
-		scanner.EachInSubtree[ast.BinaryExpr](fc.File, func(bin *ast.BinaryExpr) {
-			if bin.Op != token.ADD {
-				return
-			}
-			lhs, lok := locatorStringLiteral(bin.X)
-			rhs, rok := locatorStringLiteral(bin.Y)
-			if !lok || !rok {
-				return
-			}
-			joined := lhs + rhs
-			for _, banned := range locatorLayoutPrefixes {
-				if joined == banned {
-					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
-						"<literal>+<literal> rebuilds "+strconv.Quote(banned)))
-					break
+	root := findModuleRoot(t)
+	concatDiags := Run(t, DirsScope(root, locatorScanDirs()),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
 				}
+				EachInSubtree[ast.BinaryExpr](f, func(bin *ast.BinaryExpr) {
+					if bin.Op != token.ADD {
+						return
+					}
+					lhs, lok := locatorStringLiteral(bin.X)
+					rhs, rok := locatorStringLiteral(bin.Y)
+					if !lok || !rok {
+						return
+					}
+					joined := lhs + rhs
+					for _, banned := range locatorLayoutPrefixes {
+						if joined == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(bin.Pos()).Line,
+								Message: "blind-spot #1 (concat): <literal>+<literal> rebuilds " +
+									strconv.Quote(banned),
+							})
+							break
+						}
+					}
+				})
 			}
+			return d
 		})
-		return out
-	})
-	assert.Empty(t, concatHits,
-		"blind-spot #1: literal concatenation reconstructing a conventional-layout prefix")
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.CONCAT", concatDiags)
 
-	regexHits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
-		if locatorIsAllowedFile(fc.Rel) {
-			return nil
-		}
-		var out []string
-		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
-			if len(call.Args) < 1 {
-				return
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return
-			}
-			ident, ok := sel.X.(*ast.Ident)
-			if !ok || ident.Name != "regexp" {
-				return
-			}
-			if sel.Sel.Name != "MustCompile" && sel.Sel.Name != "Compile" {
-				return
-			}
-			lit, ok := locatorStringLiteral(call.Args[0])
-			if !ok {
-				return
-			}
-			for _, banned := range locatorLayoutPrefixes {
-				if strings.HasPrefix(lit, "^"+banned) {
-					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
-						"regexp.MustCompile(`^"+banned+"...`)"))
-					break
+	regexDiags := Run(t, DirsScope(root, locatorScanDirs()),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
 				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if len(call.Args) < 1 {
+						return
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != "regexp" {
+						return
+					}
+					if sel.Sel.Name != "MustCompile" && sel.Sel.Name != "Compile" {
+						return
+					}
+					lit, ok := locatorStringLiteral(call.Args[0])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutPrefixes {
+						if strings.HasPrefix(lit, "^"+banned) {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "blind-spot #2 (regex): regexp.MustCompile(`^" +
+									banned + "...`)",
+							})
+							break
+						}
+					}
+				})
 			}
+			return d
 		})
-		return out
-	})
-	assert.Empty(t, regexHits,
-		"blind-spot #2: regex literal anchored on a conventional-layout prefix")
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.REGEX", regexDiags)
 }
 
 // --- internal helpers ---
-
-// locatorScanForViolations is the shared driver that wraps scanner.DirsScope
-// + scanner.EachFile across kernel/metadata/** and kernel/governance/**,
-// applying inspect to each parsed file and concatenating the results.
-func locatorScanForViolations(t *testing.T, inspect func(scanner.FileContext) []string) []string {
-	t.Helper()
-	var hits []string
-	scope := scanner.DirsScope(findModuleRoot(t), locatorScanDirs())
-	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
-		hits = append(hits, inspect(fc)...)
-	})
-	return hits
-}
 
 // locatorWalkCalleeName returns the name (e.g. "fs.WalkDir") of a call
 // expression when the call matches one of the walk-style fs helpers tracked
@@ -372,12 +392,6 @@ func locatorIsAllowedFile(rel string) bool {
 		return true
 	}
 	base := filepath.Base(rel)
-	if strings.Contains(rel, "/kernel/metadata/") && locatorFunnelFiles[base] {
-		return true
-	}
-	if strings.Contains(rel, "kernel/metadata/") && locatorFunnelFiles[base] {
-		return true
-	}
 	if strings.HasPrefix(rel, "kernel/metadata/") && locatorFunnelFiles[base] {
 		return true
 	}
@@ -387,15 +401,11 @@ func locatorIsAllowedFile(rel string) bool {
 	return false
 }
 
-func locatorFunnelViolation(file, function, expr string) string {
-	return file + ":" + function + ": " + expr
-}
-
-func locatorSortedKeys(m map[string]bool) []string {
+func locatorJoinKeys(m map[string]bool) string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	return keys
+	return strings.Join(keys, ", ")
 }

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -100,10 +100,10 @@ var locatorFunnelFiles = map[string]bool{
 // filepath.Walk / fs.ReadDir may appear inside kernel/metadata/**. Anything
 // else trips A1.
 var locatorAllowedWalkCallers = map[string]bool{
-	"discoverConventional":   true,
-	"discoverManifest":       true,
-	"discoverManifestModule": true,
-	"matchManifestGlob":      true,
+	"discoverConventional":    true,
+	"discoverManifest":        true,
+	"discoverManifestModule":  true,
+	"matchManifestGlobCapped": true, // holds the WalkDir; matchManifestGlob delegates here
 }
 
 // locatorGovernanceConventionalFiles names governance files allowed to hold

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -246,10 +246,18 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *tes
 //   - A2a: strings.HasPrefix(_, "<token>/")
 //   - A2b: x == "<token>" or x != "<token>"
 //
-// Not directly locked (blind spots), enforced as negative invariants:
+// Not directly locked (blind spots), enforced as negative invariants
+// in this test function:
 //   - String concatenation rebuilding a forbidden literal (e.g.
 //     "cell" + "s/")
 //   - Regex anchors (regexp.MustCompile(`^cells/`))
+//   - filepath.Join("<token>", ...) reconstructing a layout path
+//   - strings.Contains(_, "<token>/") substring scanning
+//
+// Upstream Hard is a Go-language won't-do (sealed cross-package
+// interface with private constructor is structurally unreachable in
+// Go) — see SPAN-SETATTR-HOLDER-SEAL-01 #851 same precedent; no
+// tracking issue is opened for the Medium upstream ceiling.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
 	root := findModuleRoot(t)
 	concatDiags := Run(t, DirsScope(root, locatorScanDirs()),
@@ -330,6 +338,98 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
 			return d
 		})
 	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.REGEX", regexDiags)
+
+	// Blind-spot #3: filepath.Join("<token>", ...) — reconstructs a
+	// conventional-layout path without any HasPrefix or ==/!= shape.
+	// Originally caught a `filepath.Join("cells", ...)` leak in
+	// kernel/governance/rules_misc_consistency.go after the M1 refactor.
+	joinDiags := Run(t, DirsScope(root, locatorScanDirs()),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if len(call.Args) < 1 {
+						return
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok {
+						return
+					}
+					if (ident.Name != "filepath" && ident.Name != "path") || sel.Sel.Name != "Join" {
+						return
+					}
+					lit, ok := locatorStringLiteral(call.Args[0])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutTokens {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "blind-spot #3 (filepath.Join): " + ident.Name + ".Join(" +
+									strconv.Quote(lit) + ", ...) reconstructs a conventional-layout path",
+							})
+							break
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.JOIN", joinDiags)
+
+	// Blind-spot #4: strings.Contains(_, "<token>/") — substring scan for
+	// a conventional-layout prefix. Not caught by A2a (HasPrefix) because
+	// the callee differs.
+	containsDiags := Run(t, DirsScope(root, locatorScanDirs()),
+		func(p *Pass) []Diagnostic {
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if len(call.Args) < 2 {
+						return
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != "strings" || sel.Sel.Name != "Contains" {
+						return
+					}
+					lit, ok := locatorStringLiteral(call.Args[1])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutPrefixes {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "blind-spot #4 (strings.Contains): strings.Contains(_, " +
+									strconv.Quote(lit) + ") substring-scans a conventional-layout prefix",
+							})
+							break
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.CONTAINS", containsDiags)
 }
 
 // --- internal helpers ---

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -18,9 +18,13 @@
 //      against the conventional layout tokens {cells/, contracts/, journeys/,
 //      assemblies/, examples/} are restricted to the locator's own files in
 //      kernel/metadata/locator*.go (plus two governance helper files for
-//      conventional-mode strict rules). The form catalog locks two AST
-//      shapes today (HasPrefix + == ) and uses EvaluateConstString (go/types
-//      constant folding) so that cross-package const references (e.g.
+//      conventional-mode strict rules). The scan scope is kernel/metadata/**,
+//      kernel/governance/**, AND cmd/gocell/** — the last added so the literal
+//      cannot escape into CLI consumer code (the gap that previously let
+//      journeyStatusCheck hold a bare strings.HasPrefix(_, "examples/") rather
+//      than route through metadata.IsInExamplesSubtree). The form catalog locks
+//      two AST shapes today (HasPrefix + == ) and uses EvaluateConstString
+//      (go/types constant folding) so that cross-package const references (e.g.
 //      const cellsPrefix = "cells/") cannot bypass the check.
 //      A reverse blind-spot self-check rejects const-eval bypass forms via
 //      negative tests.
@@ -248,7 +252,7 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist(t *testing.T) {
 // TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness enforces that
 // strings.HasPrefix(_, lit) call shapes with a conventional-layout-prefix
 // literal as the second argument may only appear in the Locator's own
-// files inside kernel/metadata/** and kernel/governance/**.
+// files inside kernel/metadata/**, kernel/governance/**, and cmd/gocell/**.
 //
 // Uses EvaluateConstString (go/types constant folding) to resolve the second
 // argument so that cross-package const references such as:
@@ -261,7 +265,7 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist(t *testing.T) {
 // Blind spots documented in TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory
 // and A2_ConstEvalBypassBlindSpots.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
-	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./kernel/metadata/...", "./kernel/governance/..."},
+	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./kernel/metadata/...", "./kernel/governance/...", "./cmd/gocell/..."},
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -315,7 +319,7 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
 // Blind spots documented in TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory
 // and A2_ConstEvalBypassBlindSpots.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *testing.T) {
-	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./kernel/metadata/...", "./kernel/governance/..."},
+	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./kernel/metadata/...", "./kernel/governance/...", "./cmd/gocell/..."},
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -1,0 +1,401 @@
+// invariants asserted in this file:
+//   - INVARIANT: LOCATOR-DISCOVERY-FUNNEL-01
+//
+// LOCATOR-DISCOVERY-FUNNEL-01 (M1 of #1082) keeps kernel/metadata.Locator the
+// sole place in the codebase that knows how the filesystem topology maps to
+// metadata YAML buckets. It is a two-direction funnel:
+//
+//   A1 (upstream Medium — Go-language final ceiling): all fs.WalkDir /
+//      filepath.Walk / fs.ReadDir callsites under kernel/metadata/** must
+//      live inside Locator.discoverConventional / discoverManifest (and the
+//      manifest glob expansion helpers that are themselves part of the
+//      funnel). The package-internal bypass is bounded only by this
+//      archtest's caller-allowlist; sealed cross-package interface is
+//      structurally unreachable in Go (SPAN-SETATTR-HOLDER-SEAL-01 #851
+//      same precedent).
+//
+//   A2 (downstream Hard — form-uniqueness): path-prefix string comparisons
+//      against the conventional layout tokens {cells/, contracts/, journeys/,
+//      assemblies/, examples/} are restricted to the locator's own files in
+//      kernel/metadata/locator*.go (plus two governance helper files for
+//      conventional-mode strict rules). The form catalog locks two AST
+//      shapes today and a reverse blind-spot self-check rejects two
+//      additional shapes via negative tests.
+//
+// AI-robust grading: Medium upstream + Hard downstream is a final form per
+// ai-robust §"Funnel 双向锁评级". No follow-up issue is opened; the upstream
+// ceiling is a Go-language limit, not a deferred TODO. See ADR 202605281200.
+
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// locatorLayoutTokens are the path-token literals whose presence in
+// kernel/metadata/** or kernel/governance/** code (outside the locator
+// files) indicates a leak of filesystem topology knowledge from Locator
+// into downstream code.
+var locatorLayoutTokens = []string{
+	"cells",
+	"contracts",
+	"journeys",
+	"assemblies",
+	"examples",
+}
+
+// locatorLayoutPrefixes are the same tokens with a trailing slash, matched
+// by strings.HasPrefix-style call shapes.
+var locatorLayoutPrefixes = []string{
+	"cells/",
+	"contracts/",
+	"journeys/",
+	"assemblies/",
+	"examples/",
+}
+
+// locatorFunnelFiles names the metadata files that are allowed to hold
+// path-prefix literals and fs.WalkDir callsites. Any file outside this set
+// in kernel/metadata/** or kernel/governance/** that contains a flagged
+// shape fails the archtest.
+var locatorFunnelFiles = map[string]bool{
+	"locator.go":              true,
+	"locator_conventional.go": true,
+	"locator_manifest.go":     true,
+	"locator_test.go":         true,
+}
+
+// locatorAllowedWalkCallers names the function bodies in which fs.WalkDir /
+// filepath.Walk / fs.ReadDir may appear inside kernel/metadata/**. Anything
+// else trips A1.
+var locatorAllowedWalkCallers = map[string]bool{
+	"discoverConventional":   true,
+	"discoverManifest":       true,
+	"discoverManifestModule": true,
+	"matchManifestGlob":      true,
+}
+
+// locatorGovernanceConventionalFiles names governance files allowed to hold
+// path-prefix literals because they implement conventional-layout-specific
+// governance rules (e.g., FMT-21 validates that contract.Dir matches the
+// derived "contracts/<id-as-path>" form). These are governance invariants
+// for conventional-mode projects, not part of the Locator funnel boundary.
+//
+// Extending this allowlist must come with a written rationale in code
+// review — the inclusion criterion is "the rule is intrinsically about
+// conventional layout and would be incorrect under Manifest mode".
+var locatorGovernanceConventionalFiles = map[string]bool{
+	"helpers.go":           true,
+	"rules_misc_strict.go": true,
+	// locator.go holds canonicalCellID / canonicalSliceKey /
+	// canonicalContractID / canonicalJourneyID / canonicalAssemblyID
+	// — conventional-layout-specific reverse mappers (path → canonical
+	// ID) used by governance ValidationResult dedup. Same rationale as
+	// the conventional-mode helpers above; the parse-side mapping is in
+	// kernel/metadata.Locator, this is its dual for governance.
+	"locator.go": true,
+}
+
+// locatorScanDirs returns the directories whose Go files are scanned by
+// the LOCATOR-DISCOVERY-FUNNEL-01 invariants. kernel/metadata houses the
+// Locator funnel; kernel/governance houses TargetSelector and the
+// conventional-layout strict rules.
+func locatorScanDirs() []string {
+	return []string{
+		"kernel/metadata",
+		"kernel/governance",
+	}
+}
+
+// TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist enforces that
+// fs.WalkDir / filepath.Walk / fs.ReadDir are only called from within the
+// Locator's discover{Conventional,Manifest} bodies inside
+// kernel/metadata/**.
+func TestLOCATOR_DISCOVERY_FUNNEL_01_A1_WalkdirCallerAllowlist(t *testing.T) {
+	t.Parallel()
+	scope := scanner.DirsScope(findModuleRoot(t), []string{"kernel/metadata"})
+	var hits []string
+	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
+		scanner.EachInSubtree[ast.FuncDecl](fc.File, func(fn *ast.FuncDecl) {
+			if fn.Body == nil || locatorAllowedWalkCallers[fn.Name.Name] {
+				return
+			}
+			scanner.EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+				if name, ok := locatorWalkCalleeName(call); ok {
+					hits = append(hits, locatorFunnelViolation(fc.Rel, fn.Name.Name, name))
+				}
+			})
+		})
+	})
+	assert.Empty(t, hits,
+		"LOCATOR-DISCOVERY-FUNNEL-01 A1: fs.WalkDir / filepath.Walk / fs.ReadDir "+
+			"is only allowed inside %v in kernel/metadata/**", locatorSortedKeys(locatorAllowedWalkCallers))
+}
+
+// TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness enforces that
+// strings.HasPrefix(_, lit) call shapes with a conventional-layout-prefix
+// literal as the second argument may only appear in the Locator's own
+// files inside kernel/metadata/** and kernel/governance/**.
+func TestLOCATOR_DISCOVERY_FUNNEL_01_A2a_HasPrefixFormUniqueness(t *testing.T) {
+	t.Parallel()
+	hits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
+		if locatorIsAllowedFile(fc.Rel) {
+			return nil
+		}
+		var out []string
+		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
+			if !locatorIsCalleeStringsHasPrefix(call) || len(call.Args) < 2 {
+				return
+			}
+			lit, ok := locatorStringLiteral(call.Args[1])
+			if !ok {
+				return
+			}
+			for _, banned := range locatorLayoutPrefixes {
+				if lit == banned {
+					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
+						"strings.HasPrefix(_, "+strconv.Quote(lit)+")"))
+					break
+				}
+			}
+		})
+		return out
+	})
+	assert.Empty(t, hits,
+		"LOCATOR-DISCOVERY-FUNNEL-01 A2a (HasPrefix + literal): conventional-layout "+
+			"prefix literals %v may only appear inside the Locator funnel files (%v)",
+		locatorLayoutPrefixes, locatorSortedKeys(locatorFunnelFiles))
+}
+
+// TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness
+// enforces the A2b form: a binary expression `x == "cells"` (or any other
+// conventional-layout token) inside kernel/metadata/** or
+// kernel/governance/** must live in the Locator's own files. This is the
+// shape used by path-segment matchers (`parts[N] == "cells"`).
+func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *testing.T) {
+	t.Parallel()
+	hits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
+		if locatorIsAllowedFile(fc.Rel) {
+			return nil
+		}
+		var out []string
+		scanner.EachInSubtree[ast.BinaryExpr](fc.File, func(bin *ast.BinaryExpr) {
+			if bin.Op != token.EQL && bin.Op != token.NEQ {
+				return
+			}
+			lit, ok := locatorStringLiteral(bin.Y)
+			if !ok {
+				lit, ok = locatorStringLiteral(bin.X)
+				if !ok {
+					return
+				}
+			}
+			for _, banned := range locatorLayoutTokens {
+				if lit == banned {
+					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
+						"<expr> ==/!= "+strconv.Quote(lit)))
+					break
+				}
+			}
+		})
+		return out
+	})
+	assert.Empty(t, hits,
+		"LOCATOR-DISCOVERY-FUNNEL-01 A2b (== / != with literal): conventional-layout "+
+			"tokens %v may only appear inside the Locator funnel files (%v)",
+		locatorLayoutTokens, locatorSortedKeys(locatorFunnelFiles))
+}
+
+// TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory documents the AST
+// shapes that the A2 form catalog does NOT explicitly lock and asserts
+// they remain absent in production code (reverse blind-spot self-check
+// required by ai-robust §"工具选定后强制盲区自检").
+//
+// Today the catalog covers:
+//   - A2a: strings.HasPrefix(_, "<token>/")
+//   - A2b: x == "<token>" or x != "<token>"
+//
+// Not directly locked (blind spots), enforced as negative invariants:
+//   - String concatenation rebuilding a forbidden literal (e.g.
+//     "cell" + "s/")
+//   - Regex anchors (regexp.MustCompile(`^cells/`))
+func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
+	t.Parallel()
+
+	concatHits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
+		if locatorIsAllowedFile(fc.Rel) {
+			return nil
+		}
+		var out []string
+		scanner.EachInSubtree[ast.BinaryExpr](fc.File, func(bin *ast.BinaryExpr) {
+			if bin.Op != token.ADD {
+				return
+			}
+			lhs, lok := locatorStringLiteral(bin.X)
+			rhs, rok := locatorStringLiteral(bin.Y)
+			if !lok || !rok {
+				return
+			}
+			joined := lhs + rhs
+			for _, banned := range locatorLayoutPrefixes {
+				if joined == banned {
+					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
+						"<literal>+<literal> rebuilds "+strconv.Quote(banned)))
+					break
+				}
+			}
+		})
+		return out
+	})
+	assert.Empty(t, concatHits,
+		"blind-spot #1: literal concatenation reconstructing a conventional-layout prefix")
+
+	regexHits := locatorScanForViolations(t, func(fc scanner.FileContext) []string {
+		if locatorIsAllowedFile(fc.Rel) {
+			return nil
+		}
+		var out []string
+		scanner.EachInSubtree[ast.CallExpr](fc.File, func(call *ast.CallExpr) {
+			if len(call.Args) < 1 {
+				return
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != "regexp" {
+				return
+			}
+			if sel.Sel.Name != "MustCompile" && sel.Sel.Name != "Compile" {
+				return
+			}
+			lit, ok := locatorStringLiteral(call.Args[0])
+			if !ok {
+				return
+			}
+			for _, banned := range locatorLayoutPrefixes {
+				if strings.HasPrefix(lit, "^"+banned) {
+					out = append(out, locatorFunnelViolation(fc.Rel, "(file scope)",
+						"regexp.MustCompile(`^"+banned+"...`)"))
+					break
+				}
+			}
+		})
+		return out
+	})
+	assert.Empty(t, regexHits,
+		"blind-spot #2: regex literal anchored on a conventional-layout prefix")
+}
+
+// --- internal helpers ---
+
+// locatorScanForViolations is the shared driver that wraps scanner.DirsScope
+// + scanner.EachFile across kernel/metadata/** and kernel/governance/**,
+// applying inspect to each parsed file and concatenating the results.
+func locatorScanForViolations(t *testing.T, inspect func(scanner.FileContext) []string) []string {
+	t.Helper()
+	var hits []string
+	scope := scanner.DirsScope(findModuleRoot(t), locatorScanDirs())
+	scanner.EachFile(t, scope, parser.SkipObjectResolution, func(t *testing.T, fc scanner.FileContext) {
+		hits = append(hits, inspect(fc)...)
+	})
+	return hits
+}
+
+// locatorWalkCalleeName returns the name (e.g. "fs.WalkDir") of a call
+// expression when the call matches one of the walk-style fs helpers tracked
+// by A1.
+func locatorWalkCalleeName(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	switch {
+	case pkgIdent.Name == "fs" && (sel.Sel.Name == "WalkDir" || sel.Sel.Name == "ReadDir"):
+		return "fs." + sel.Sel.Name, true
+	case pkgIdent.Name == "filepath" && (sel.Sel.Name == "Walk" || sel.Sel.Name == "WalkDir"):
+		return "filepath." + sel.Sel.Name, true
+	}
+	return "", false
+}
+
+// locatorIsCalleeStringsHasPrefix reports whether the call expression is
+// strings.HasPrefix(...).
+func locatorIsCalleeStringsHasPrefix(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "strings" && sel.Sel.Name == "HasPrefix"
+}
+
+// locatorStringLiteral returns the unquoted value of expr if it is a basic
+// string literal; returns ("", false) otherwise.
+func locatorStringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	unq, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return unq, true
+}
+
+// locatorIsAllowedFile reports whether the module-relative path is one of
+// the Locator funnel's allowed files (locator*.go in kernel/metadata/, or
+// the two governance conventional-mode helper files), or a _test.go file.
+func locatorIsAllowedFile(rel string) bool {
+	rel = filepath.ToSlash(rel)
+	if strings.HasSuffix(rel, "_test.go") {
+		return true
+	}
+	base := filepath.Base(rel)
+	if strings.Contains(rel, "/kernel/metadata/") && locatorFunnelFiles[base] {
+		return true
+	}
+	if strings.Contains(rel, "kernel/metadata/") && locatorFunnelFiles[base] {
+		return true
+	}
+	if strings.HasPrefix(rel, "kernel/metadata/") && locatorFunnelFiles[base] {
+		return true
+	}
+	if strings.HasPrefix(rel, "kernel/governance/") && locatorGovernanceConventionalFiles[base] {
+		return true
+	}
+	return false
+}
+
+func locatorFunnelViolation(file, function, expr string) string {
+	return file + ":" + function + ": " + expr
+}
+
+func locatorSortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -81,6 +81,10 @@ var locatorLayoutPrefixes = []string{
 // path-prefix literals and fs.WalkDir callsites. Any file outside this set
 // in kernel/metadata/** or kernel/governance/** that contains a flagged
 // shape fails the archtest.
+//
+// kernel/metadata/locator.go also exports path-classification helpers
+// (IsConventionalAssemblyPath, IsInExamplesSubtree) as legitimate funnel
+// exit points — these are intentionally inside the funnel allowlist.
 var locatorFunnelFiles = map[string]bool{
 	"locator.go":              true,
 	"locator_conventional.go": true,
@@ -134,7 +138,14 @@ var locatorConsumerPathTokens = []string{
 
 // locatorA5AllowedFiles names the module-relative source files that are
 // permanently allowlisted from the A5 consumer-path check. Each entry must
-// have a written rationale:
+// have a written rationale.
+//
+// Scope/allowlist principle: allowlist entries are **explicit exemptions**
+// for write-paths (layout generators) or IsConventional*-guarded paths
+// (files that emit layout tokens but are themselves guarded by a
+// conventional-mode predicate). Files outside the A5 scan scope (e.g.
+// testdata/, tools/) are simply not in the funnel's EXITING responsibility
+// domain; they are not added here. The two categories must not be mixed.
 //
 //   - cmd/gocell/app/scaffold.go: `gocell scaffold cell|slice` is a
 //     **write** path that intentionally produces the conventional
@@ -151,9 +162,18 @@ var locatorConsumerPathTokens = []string{
 //     isConventionalAssemblyPath guard so that Manifest-mode assemblies
 //     (assemblies/<id>/ absent) use path.Dir(asm.File)/main.go instead.
 //     See deriveAssembly comment for the full rationale.
+//
+//   - kernel/assembly/generator.go: the Generator is a **write** path that
+//     produces the conventional assembly scaffold output — both
+//     assemblies/<id>/assembly.yaml and cmd/<id>/run.go,main.go,app.go.
+//     "assemblies" and "cmd" here are the physical output directory names
+//     of the conventional scaffold layout, not discovery tokens consumed
+//     from Locator/MetadataSource output. Same rationale as scaffold.go
+//     (layout generator by definition, not a read/discovery consumer).
 var locatorA5AllowedFiles = map[string]bool{
 	"cmd/gocell/app/scaffold.go":         true,
 	"kernel/metadata/assembly_derive.go": true,
+	"kernel/assembly/generator.go":       true,
 }
 
 // locatorScanDirs returns the directories whose Go files are scanned by
@@ -170,11 +190,19 @@ func locatorScanDirs() []string {
 // locatorConsumerScanPatterns returns the Go package patterns for A5 (consumer-
 // path reverse funnel). These are the packages outside the Locator core that
 // must not reconstruct conventional layout paths via filepath.Join.
+//
+// kernel/assembly/ is included because the Generator writes output to
+// conventional layout paths (assemblies/<id>/ and cmd/<id>/). Write-path
+// files are allowlisted in locatorA5AllowedFiles (generator.go) with a
+// written rationale; any other file in kernel/assembly/ that uses a banned
+// token would indicate an unexpected read-path reconstruction and should
+// fail A5.
 func locatorConsumerScanPatterns() []string {
 	return []string{
 		"./kernel/governance/...",
 		"./cmd/gocell/...",
 		"./kernel/metadata/...",
+		"./kernel/assembly/...",
 	}
 }
 
@@ -344,6 +372,9 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2b_EqualityComparisonFormUniqueness(t *tes
 //   - Regex anchors (regexp.MustCompile(`^cells/`))
 //   - filepath.Join("<token>", ...) reconstructing a layout path
 //   - strings.Contains(_, "<token>/") substring scanning
+//   - strings.Replace / strings.ReplaceAll with a layout-token literal
+//     (e.g. strings.Replace(p, "cells/", "", 1))
+//   - strings.TrimPrefix(_, "<token>/") stripping a layout-token prefix
 //
 // Upstream Hard is a Go-language won't-do (sealed cross-package
 // interface with private constructor is structurally unreachable in
@@ -521,6 +552,111 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
 			return d
 		})
 	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.CONTAINS", containsDiags)
+
+	// Blind-spot #5: strings.Replace(_, "<token>/", ...) and
+	// strings.ReplaceAll(_, "<token>/", ...) — structural string mutation
+	// using a conventional-layout prefix as the old-value argument. Not
+	// caught by A2a (HasPrefix), A2b (==/!=), or blind-spots #1–#4.
+	// Uses EvaluateConstString to resolve the second argument.
+	replaceDiags := RunTyped(t, TypedOpts{Tests: false},
+		[]string{"./kernel/metadata/...", "./kernel/governance/..."},
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != "strings" {
+						return
+					}
+					if sel.Sel.Name != "Replace" && sel.Sel.Name != "ReplaceAll" {
+						return
+					}
+					// Replace: strings.Replace(s, old, new, n) — old is arg[1].
+					// ReplaceAll: strings.ReplaceAll(s, old, new) — old is arg[1].
+					if len(call.Args) < 2 {
+						return
+					}
+					lit, ok := EvaluateConstString(p.TypesInfo, call.Args[1])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutPrefixes {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "blind-spot #5 (strings.Replace/ReplaceAll): " +
+									sel.Sel.Name + "(_, " + strconv.Quote(lit) + ", ...) " +
+									"mutates a conventional-layout prefix outside the Locator funnel",
+							})
+							break
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.REPLACE", replaceDiags)
+
+	// Blind-spot #6: strings.TrimPrefix(_, "<token>/") — strips a
+	// conventional-layout prefix literal. Not caught by A2a (HasPrefix).
+	// Uses EvaluateConstString to resolve the second argument.
+	trimPrefixDiags := RunTyped(t, TypedOpts{Tests: false},
+		[]string{"./kernel/metadata/...", "./kernel/governance/..."},
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != "strings" || sel.Sel.Name != "TrimPrefix" {
+						return
+					}
+					if len(call.Args) < 2 {
+						return
+					}
+					lit, ok := EvaluateConstString(p.TypesInfo, call.Args[1])
+					if !ok {
+						return
+					}
+					for _, banned := range locatorLayoutPrefixes {
+						if lit == banned {
+							d = append(d, Diagnostic{
+								Rel:  rel,
+								Line: p.Fset.Position(call.Pos()).Line,
+								Message: "blind-spot #6 (strings.TrimPrefix): " +
+									"strings.TrimPrefix(_, " + strconv.Quote(lit) + ") " +
+									"strips a conventional-layout prefix outside the Locator funnel",
+							})
+							break
+						}
+					}
+				})
+			}
+			return d
+		})
+	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.BLINDSPOT.TRIMPREFIX", trimPrefixDiags)
 }
 
 // TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots asserts that

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -132,6 +132,30 @@ var locatorConsumerPathTokens = []string{
 	"cmd",
 }
 
+// locatorA5AllowedFiles names the module-relative source files that are
+// permanently allowlisted from the A5 consumer-path check. Each entry must
+// have a written rationale:
+//
+//   - cmd/gocell/app/scaffold.go: `gocell scaffold cell|slice` is a
+//     **write** path that intentionally produces the conventional
+//     cells/<id>/cell.yaml layout. Manifest-mode users do not call scaffold
+//     (manifest mode means "I own my layout"). A5 guards **read** paths
+//     (governance / check / assembly_derive) where consuming layout tokens
+//     indicates hardcoded discovery; scaffold is a layout generator by
+//     definition.
+//
+//   - kernel/metadata/assembly_derive.go: the conventional assembly
+//     entrypoint is cmd/<id>/main.go — "cmd" here is the physical output
+//     directory name of the conventional layout, not a discovery token
+//     derived from CellMeta/SliceMeta. The file contains an
+//     isConventionalAssemblyPath guard so that Manifest-mode assemblies
+//     (assemblies/<id>/ absent) use path.Dir(asm.File)/main.go instead.
+//     See deriveAssembly comment for the full rationale.
+var locatorA5AllowedFiles = map[string]bool{
+	"cmd/gocell/app/scaffold.go":         true,
+	"kernel/metadata/assembly_derive.go": true,
+}
+
 // locatorScanDirs returns the directories whose Go files are scanned by
 // the LOCATOR-DISCOVERY-FUNNEL-01 invariants. kernel/metadata houses the
 // Locator funnel; kernel/governance houses TargetSelector and the
@@ -638,18 +662,13 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 //
 // Blind spots enforced by TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots.
 //
-// NOTE: This test is expected to FAIL until Batch 3 fixes the following
-// known violations (each will become a PASS after Batch 3):
-//   - kernel/governance/rules_misc_consistency.go:367
-//     filepath.Join(root, "cells", ref.cellID)
-//   - cmd/gocell/app/check.go:338
-//     filepath.Join(root, "cells", cid, "slices")
-//   - kernel/metadata/assembly_derive.go:74
-//     filepath.Join("cmd", asm.ID, "main.go")
-//
-// Additional violations in cmd/gocell/app/scaffold.go (scaffold.go:492,
-// scaffold.go:598, scaffold.go:612, scaffold.go:640) are also captured and
-// must be fixed by Batch 3.
+// Two files are permanently allowlisted via locatorA5AllowedFiles:
+//   - cmd/gocell/app/scaffold.go: write path (layout generator); does not
+//     consume discovery paths, produces them.
+//   - kernel/metadata/assembly_derive.go: "cmd" is the conventional output
+//     directory name for the cmd/<id>/main.go entrypoint, guarded by
+//     isConventionalAssemblyPath so Manifest-mode assemblies use
+//     path.Dir(asm.File)/main.go instead.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_ConsumerPathFunnel(t *testing.T) {
 	diags := RunTyped(t, TypedOpts{Tests: false}, locatorConsumerScanPatterns(),
 		func(p *Pass) []Diagnostic {
@@ -665,6 +684,11 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_ConsumerPathFunnel(t *testing.T) {
 				}
 				// Skip Locator funnel files (they legitimately hold layout tokens).
 				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				// Skip A5-specific allowlisted files (write paths / layout
+				// generators / conventional-token sites with explicit guards).
+				if locatorA5AllowedFiles[filepath.ToSlash(rel)] {
 					continue
 				}
 				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
@@ -694,9 +718,6 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_ConsumerPathFunnel(t *testing.T) {
 			}
 			return d
 		})
-	// A5 is intentionally expected to FAIL until Batch 3 fixes the violations
-	// listed in the function godoc. We use Report which marks the test as failed
-	// when diagnostics are non-empty — this is the desired TDD "RED" state.
 	Report(t, "LOCATOR-DISCOVERY-FUNNEL-01.A5", diags)
 }
 
@@ -726,6 +747,9 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots(t *testing.T) {
 					continue
 				}
 				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				if locatorA5AllowedFiles[filepath.ToSlash(rel)] {
 					continue
 				}
 				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
@@ -777,6 +801,9 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots(t *testing.T) {
 					continue
 				}
 				if locatorIsAllowedFile(rel) {
+					continue
+				}
+				if locatorA5AllowedFiles[filepath.ToSlash(rel)] {
 					continue
 				}
 				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {

--- a/tools/archtest/parser_matcher_examples_symmetry_test.go
+++ b/tools/archtest/parser_matcher_examples_symmetry_test.go
@@ -1,6 +1,6 @@
 // INVARIANT: PARSER-MATCHER-EXAMPLES-SYMMETRY-01
 //
-// Every match{Kind}YAML function in kernel/metadata/parser.go must accept both
+// Every match{Kind}YAML function in kernel/metadata/locator_conventional.go must accept both
 // the root form (<root>/<kind>/...) and the examples form
 // (examples/*/<kind>/...). The archtest uses typed AST const evaluation to walk
 // each matcher body (and its directly-called package-private helper functions
@@ -74,17 +74,25 @@ import (
 	"testing"
 )
 
-// matcherRootSegment maps each match*YAML function name to the expected root
-// segment literal for the non-examples form. E.g. matchAssemblyYAML → "assemblies".
+// matcherRootSegment maps each match*Path function name (in
+// kernel/metadata/locator_conventional.go, post-M1 Locator funnel) to the
+// expected root segment literal for the non-examples form. E.g.
+// matchAssemblyPath → "assemblies". Before M1 these matchers lived in
+// kernel/metadata/locator_conventional.go as match*YAML; the rename + file move
+// accompanied the LOCATOR-DISCOVERY-FUNNEL-01 refactor (#1082).
 var matcherRootSegment = map[string]string{
-	"matchCellYAML":     "cells",
-	"matchSliceYAML":    "cells",
-	"matchContractYAML": "contracts",
-	"matchJourneyYAML":  "journeys",
-	"matchAssemblyYAML": "assemblies",
+	"matchCellPath":     "cells",
+	"matchSlicePath":    "cells",
+	"matchContractPath": "contracts",
+	"matchJourneyPath":  "journeys",
+	"matchAssemblyPath": "assemblies",
 }
 
-var matchYAMLFuncRE = regexp.MustCompile(`^match.+YAML$`)
+var matchYAMLFuncRE = regexp.MustCompile(`^match.+Path$`)
+
+// matcherFile is the path of the file inside kernel/metadata that hosts
+// the match*Path matchers after the M1 Locator funnel refactor.
+const matcherFile = "kernel/metadata/locator_conventional.go"
 
 // matcherAndCalleeBodies returns the function body block-statements that should
 // be inspected for blind-spot probes — the matcher itself plus its direct
@@ -121,7 +129,7 @@ func matcherAndCalleeBodies(file *ast.File, matcher *ast.FuncDecl) []*ast.BlockS
 }
 
 // TestParserMatcherExamplesSymmetry01 asserts that every match*YAML function in
-// kernel/metadata/parser.go includes both "examples" AND its kind root segment
+// kernel/metadata/locator_conventional.go includes both "examples" AND its kind root segment
 // (e.g. "assemblies") in the parts[0] comparison set — either directly in the
 // matcher body or in the package-private helper functions called directly from it.
 //
@@ -147,7 +155,7 @@ func TestParserMatcherExamplesSymmetry01(t *testing.T) {
 		// We need this to look up helper bodies when a matcher delegates to one.
 		parserFuncs := make(map[string]*ast.FuncDecl)
 		for _, f := range p.Files {
-			if p.Rel(f) != "kernel/metadata/parser.go" {
+			if p.Rel(f) != "kernel/metadata/locator_conventional.go" {
 				continue
 			}
 			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
@@ -201,7 +209,7 @@ func TestParserMatcherExamplesSymmetry01(t *testing.T) {
 		}
 
 		for _, f := range p.Files {
-			if p.Rel(f) != "kernel/metadata/parser.go" {
+			if p.Rel(f) != "kernel/metadata/locator_conventional.go" {
 				continue
 			}
 			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
@@ -243,7 +251,7 @@ func TestParserMatcherExamplesSymmetry01(t *testing.T) {
 		r, found := results[funcName]
 		if !found {
 			t.Errorf("INVARIANT PARSER-MATCHER-EXAMPLES-SYMMETRY-01 violated: "+
-				"matcher %s not found in kernel/metadata/parser.go", funcName)
+				"matcher %s not found in kernel/metadata/locator_conventional.go", funcName)
 			continue
 		}
 		if !r.foundRoot {
@@ -268,7 +276,7 @@ func TestParserMatcherExamplesSymmetry01(t *testing.T) {
 			return nil
 		}
 		for _, f := range p.Files {
-			if p.Rel(f) != "kernel/metadata/parser.go" {
+			if p.Rel(f) != "kernel/metadata/locator_conventional.go" {
 				continue
 			}
 			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
@@ -314,7 +322,7 @@ func TestParserMatcherSymmetry_BlindSpot_VariableIndex(t *testing.T) {
 			return nil
 		}
 		for _, f := range p.Files {
-			if p.Rel(f) != "kernel/metadata/parser.go" {
+			if p.Rel(f) != "kernel/metadata/locator_conventional.go" {
 				continue
 			}
 			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
@@ -387,7 +395,7 @@ func TestParserMatcherSymmetry_BlindSpot_SwitchStmt(t *testing.T) {
 			return nil
 		}
 		for _, f := range p.Files {
-			if p.Rel(f) != "kernel/metadata/parser.go" {
+			if p.Rel(f) != "kernel/metadata/locator_conventional.go" {
 				continue
 			}
 			EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {

--- a/tools/archtest/parser_matcher_examples_symmetry_test.go
+++ b/tools/archtest/parser_matcher_examples_symmetry_test.go
@@ -90,10 +90,6 @@ var matcherRootSegment = map[string]string{
 
 var matchYAMLFuncRE = regexp.MustCompile(`^match.+Path$`)
 
-// matcherFile is the path of the file inside kernel/metadata that hosts
-// the match*Path matchers after the M1 Locator funnel refactor.
-const matcherFile = "kernel/metadata/locator_conventional.go"
-
 // matcherAndCalleeBodies returns the function body block-statements that should
 // be inspected for blind-spot probes — the matcher itself plus its direct
 // callees within the same file. This mirrors the scope used by the main check

--- a/tools/generatedverify/generatedverify_test.go
+++ b/tools/generatedverify/generatedverify_test.go
@@ -398,6 +398,9 @@ func (PlaceholderModule) ID() string { return "placeholder" }
 			Entrypoint: "cmd/fixture/main.go",
 			Binary:     "bin/fixture",
 		},
+		// File mirrors the post-M1 (#1082) Locator-emitted path so
+		// AssemblyGeneratedDir resolves "assemblies/fixture/generated".
+		File: "assemblies/fixture/assembly.yaml",
 	}
 	return root, project
 }
@@ -537,6 +540,12 @@ func runFixture(context.Context, string, []string) error {
 			Entrypoint: "cmd/fixture/main.go",
 			Binary:     "bin/fixture",
 		},
+		// File is set so metadata.AssemblyGeneratedDir derives
+		// "assemblies/fixture/generated" (path.Dir(File)+"/generated").
+		// Before M1 (#1082), the helper had an internal fallback that
+		// defaulted to this path when File was empty; the fallback was
+		// removed when the Locator funnel made File authoritative.
+		File: "assemblies/fixture/assembly.yaml",
 	}
 	return root, project
 }


### PR DESCRIPTION
## Summary

- 抽象 `kernel/metadata` 中 5 段硬编码的文件系统拓扑探测到 `metadata.Locator`，外部仓库通过 `.gocell/manifest.yaml` 声明 layout（buf v2 风格 `modules: [{path, includes, excludes}]`，单条目 = Operator-SDK 外部 repo，多条目 = Workspace 聚合）。
- `parser.go` / `governance/targets.go` 不再以路径前缀派生 contract / cell ID；统一消费 Locator 输出与 parsed `.File` 元数据。
- 删除 `metadata.ContractDirFromID` 软回退（不向后兼容落地），删除 `governance/targets.go::matchLegacyCellsPath` / `contractIDFromPath`，重写 `AssemblyGeneratedDir` 为 `path.Dir(File)+"/generated"`。
- 同 PR 落地伞 ADR `docs/architecture/202605281200-adr-cell-development-external-repo.md`（Operator-SDK + Workspace 双模式产品方向），满足 issue #1081 trigger。

Closes #1082

## Round-5 fix (latest 4 commits)

Round-5 处理第 7 轮 6-reviewer 14 finding（4 cluster + 7 NIT Cx1），按用户 feedback "PR findings 默认 in-scope" 全部纳入本 PR：

- **archtest 升级**（`7280241bc`）：A2 用 `EvaluateConstString` 替代 BasicLit-only（const 中转绕过修复，F8）；新增 `A5_ConsumerPathFunnel` 反向守卫：kernel/governance + cmd/gocell 不得硬编 `filepath.Join(_, "cells"/"cmd", ...)`。A5 funnel EXITING 下游 Hard + 上游 Medium 过渡形态，Hard 化路径由 #1235 跟踪。
- **manifest fail-closed**（`fdf004c88`）：F1 path 存在性校验；F2 零匹配 slog.Warn → error；F3 WalkDir 加 SkipDir 剪枝；F12 WithManifestPath 拒绝绝对路径 + parent escape；F13 generated/** 默认 exclude 改 additive。
- **conventional path 硬编消除**（`66d9c5805`）：F4 findRoot 增 manifest probe；F5/F6 governance/check 走 `path.Dir(cell.File)` 派生 cellDir/slicesDir；F7 assembly_derive non-example 分支按 `IsConventionalAssemblyPath` 分流。scaffold.go 与 assembly_derive.go 在 A5 archtest 中 allowlist（write-path / conventional-output 语义保留）。
- **E2E + Cx1 NIT + ADR**（`9c3dd37e6`）：F9 manifest E2E 端到端测试；F10 CLI flag 回归 test；F11 quickstart contract 示例修复；F14 ADR API 漂移修复；Cx1 NIT 七项（ParserOption alias、MetadataSource.CellID godoc、IsExamplePath → IsInExamplesSubtree、ManifestSpec godoc、ADR amendment、issue #1082 comment）。

## Implementation matrix

```
Contract: kernel/metadata.Locator (new funnel) + ManifestSpec (.gocell/manifest.yaml v1)
Change: filesystem topology discovery → Locator funnel; manifest mode for external repos
Implementations: [x] Locator (Conventional + Manifest)  [x] parser  [x] governance/targets  [x] CLI (validate/check)
Conformance test: kernel/metadata.TestLocator_* + TestLocatorManifest_E2E_* + cmd/gocell/app.TestBuildLocatorOptions
Repro: go test ./kernel/metadata/... ./kernel/governance/... ./cmd/gocell/...
Dependent contracts (governance scan): none (no contract.yaml change)
```

## AI-robust Funnel

新增/升级 archtest `LOCATOR-DISCOVERY-FUNNEL-01`：

| Sub-rule | 方向 | 形态 | 评级 |
|----------|-----|------|------|
| A1 | 上游 | `fs.WalkDir` / `filepath.Walk` / `fs.ReadDir` caller-allowlist in `kernel/metadata/**` | **Medium**（Go cross-package sealed-interface 不可达，参 #851 precedent）|
| A2a/A2b | 下游 | `strings.HasPrefix(_, "<token>/")` + `==/!=` 比较 with EvaluateConstString | **Hard**（form-uniqueness on shape catalog）|
| A2-ConstEval blind spots | 反向自检 | const-Ident 形态在 production AST 不出现 | **Hard** |
| **A5** (新增) | 下游 | governance/cmd 不得 `filepath.Join(_, "cells"/"cmd", ...)` literal | **Hard** |
| A5 upstream | 上游 | archtest caller-allowlist + 盲区 negative test | **Medium 过渡**，升 Hard 路径由 #1235 跟踪 |

## Test plan

- [x] `go test ./kernel/metadata/... ./kernel/governance/... ./cmd/gocell/... ./tools/archtest/...` PASS
- [x] `go build -tags=integration ./...` PASS
- [x] `golangci-lint run --new-from-rev=origin/develop ./...` 0 issues
- [x] `LOCATOR-DISCOVERY-FUNNEL-01` A1 + A2a + A2b + A2-ConstEval-BlindSpots + A5 + A5-BlindSpots PASS
- [x] Manifest E2E (TestLocatorManifest_E2E_*) PASS
- [x] CLI flag (TestBuildLocatorOptions + TestAddLocatorFlags) PASS

## Out of scope (later milestones)

- M2 #1083 — codegen module path injection
- M3 #1084 — archtest library-isation
- M4 #1085 — `CellModule` interface publicisation
- M11 #1092 — starter repo template + onboarding
- #1235 — A5 funnel EXITING upstream Hard 化（Locator sealed envelope / typed pathx package）

ref: bufbuild/buf v2 `buf.yaml` modules: schema
ref: kubernetes-sigs/kubebuilder PROJECT external resource registration
ref: kubernetes-sigs/kustomize kustomization.yaml resources field
ref: golang/go go.work use directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)