### PR TITLE
feat(mqtt): Publisher + CI Integration 基础 [V11-4 PR-2]

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,6 +95,13 @@ linters:
       # Project codebase + comments use US English; misspell flags British
       # variants as errors (no auto-fix unless `golangci-lint run --fix` invoked).
       locale: US
+      extra-words:
+        # "Mosquitto" is the Eclipse Mosquitto MQTT broker product name.
+        # The misspell linter incorrectly flags it as "mosquito".
+        - typo: "mosquitto"
+          correction: "mosquitto"
+        - typo: "Mosquitto"
+          correction: "Mosquitto"
 
     godot:
       scope: declarations

--- a/adapters/mqtt/config.go
+++ b/adapters/mqtt/config.go
@@ -2,10 +2,12 @@ package mqtt
 
 import (
 	"crypto/tls"
+	"log/slog"
 	"net/url"
 	"time"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/redaction"
 	"github.com/ghbvf/gocell/pkg/secutil"
 )
 
@@ -69,6 +71,22 @@ const (
 type AuthConfig struct {
 	Username string
 	Password []byte // autopaho ConnectPassword is []byte
+}
+
+// LogValue implements slog.LogValuer so the broker password is never emitted in
+// structured logs. Any slog call that resolves an AuthConfig (directly, or as a
+// nested Attr) sees the username and a redacted password placeholder instead of
+// the raw bytes. Defensive: AuthConfig is not logged on any current path, but
+// this seals the credential against future logging wiring.
+func (a AuthConfig) LogValue() slog.Value {
+	pw := ""
+	if len(a.Password) > 0 {
+		pw = redaction.Mask
+	}
+	return slog.GroupValue(
+		slog.String("username", a.Username),
+		slog.String("password", pw),
+	)
 }
 
 // BackoffConfig controls reconnect back-off behavior.

--- a/adapters/mqtt/config.go
+++ b/adapters/mqtt/config.go
@@ -53,6 +53,7 @@ const (
 	msgConfigSessionExpiryBelowSecond = "mqtt: SessionExpiry > 0 must be >= 1s (uint32 seconds wire field truncates sub-second values to 0)"
 	msgConfigSessionExpiryRange       = "mqtt: SessionExpiry must be >= 0 and <= uint32 max seconds"
 	msgConfigBackoffInvalid           = "mqtt: Backoff.BaseDelay must be > 0 and MaxDelay >= BaseDelay"
+	msgConfigPublishTimeoutNegative   = "mqtt: PublishTimeout must be >= 0"
 
 	// PublicDetail key constants — extracted per go-standards.md
 	// "同义字符串重复 ≥ 3 次抽常量". keepAlive / sessionExpiry / broker
@@ -94,6 +95,11 @@ type Config struct {
 	MaximumPacketSize uint32        // 0 = broker default; non-zero is wired into the CONNECT packet
 	ConnectTimeout    time.Duration // per-attempt; must be > 0
 	KeepAlive         time.Duration // > 0, <= 65535s (uint16 wire field)
+	// PublishTimeout caps the wall-clock time for a single Publish call (per-
+	// publish; the publisher's WithTimeout child ctx fires after this duration).
+	// 0 = no adapter-imposed timeout — Publisher uses the caller-provided ctx's
+	// deadline as-is. < 0 rejected by Validate.
+	PublishTimeout time.Duration
 }
 
 // Validate checks all fields for internal consistency and returns the first
@@ -116,7 +122,10 @@ func (c Config) Validate() error {
 	if err := c.validateTimings(); err != nil {
 		return err
 	}
-	return c.validateBackoff()
+	if err := c.validateBackoff(); err != nil {
+		return err
+	}
+	return c.validatePublishTimeout()
 }
 
 // validateBrokers checks the Brokers slice and each individual broker URL.
@@ -213,6 +222,19 @@ func (c Config) validateBackoff() error {
 				errcode.PublicDuration("baseDelay", c.Backoff.BaseDelay),
 				errcode.PublicDuration("maxDelay", c.Backoff.MaxDelay),
 			))
+	}
+	return nil
+}
+
+// validatePublishTimeout checks that PublishTimeout is non-negative.
+// 0 is accepted — it means the Publisher uses the caller-provided ctx deadline
+// as-is with no additional adapter-imposed timeout. Negative values are always
+// rejected because they would immediately cancel any publish ctx.
+func (c Config) validatePublishTimeout() error {
+	if c.PublishTimeout < 0 {
+		return errcode.New(errcode.KindInvalid, ErrAdapterMQTTInvalidConfig,
+			msgConfigPublishTimeoutNegative,
+			errcode.WithDetails(errcode.PublicDuration("publishTimeout", c.PublishTimeout)))
 	}
 	return nil
 }

--- a/adapters/mqtt/config.go
+++ b/adapters/mqtt/config.go
@@ -86,13 +86,20 @@ type BackoffConfig struct {
 // typed errcode details so callers can surface them in structured logs without
 // PII leaking into messages (MESSAGE-CONST-LITERAL-01).
 type Config struct {
-	ClientID          ClientID      // sealed type from clientid.go; zero value invalid
-	Brokers           []string      // e.g. "tcp://127.0.0.1:1883", "tls://broker.example.com:8883"
-	TLS               *tls.Config   // optional; required when any broker uses tls/ssl/mqtts/wss scheme
-	SessionExpiry     time.Duration // 0 = clean session
-	Auth              AuthConfig
-	Backoff           BackoffConfig
-	MaximumPacketSize uint32        // 0 = broker default; non-zero is wired into the CONNECT packet
+	ClientID      ClientID      // sealed type from clientid.go; zero value invalid
+	Brokers       []string      // e.g. "tcp://127.0.0.1:1883", "tls://broker.example.com:8883"
+	TLS           *tls.Config   // optional; required when any broker uses tls/ssl/mqtts/wss scheme
+	SessionExpiry time.Duration // 0 = clean session
+	Auth          AuthConfig
+	Backoff       BackoffConfig
+	// MaximumPacketSize controls both the INBOUND limit advertised to the broker
+	// (via CONNECT packet Properties) AND the OUTBOUND client-side guard in
+	// Publisher.Publish (payloads exceeding this size return
+	// ErrAdapterMQTTPayloadTooLarge immediately without network round-trip).
+	//
+	// 0 = no client-declared limit (broker default applies) AND no outbound
+	// guard in Publisher.
+	MaximumPacketSize uint32
 	ConnectTimeout    time.Duration // per-attempt; must be > 0
 	KeepAlive         time.Duration // > 0, <= 65535s (uint16 wire field)
 	// PublishTimeout caps the wall-clock time for a single Publish call (per-

--- a/adapters/mqtt/config.go
+++ b/adapters/mqtt/config.go
@@ -47,6 +47,7 @@ const (
 	msgConfigNoBrokers                = "mqtt: config requires at least one broker"
 	msgConfigBadBrokerURL             = "mqtt: broker URL is invalid or uses an unsupported scheme"
 	msgConfigTLSRequired              = "mqtt: TLS config required for tls broker"
+	msgConfigTLSInsecureSkipVerify    = "mqtt: TLS InsecureSkipVerify is forbidden (certificate verification must not be disabled)"
 	msgConfigPlaintextRemote          = "mqtt: plaintext broker scheme requires loopback host"
 	msgConfigConnectTimeout           = "mqtt: ConnectTimeout must be > 0"
 	msgConfigKeepAlive                = "mqtt: KeepAlive must be > 0"
@@ -184,6 +185,13 @@ func (c Config) validateBrokers() error {
 	}
 	if needsTLS && c.TLS == nil {
 		return errcode.New(errcode.KindInvalid, ErrAdapterMQTTInvalidConfig, msgConfigTLSRequired)
+	}
+	// Fail-closed: a TLS config that disables certificate verification is never
+	// acceptable, regardless of scheme. InsecureSkipVerify would let a MITM
+	// present any certificate; reject it at construction rather than shipping a
+	// silently-insecure broker connection.
+	if c.TLS != nil && c.TLS.InsecureSkipVerify {
+		return errcode.New(errcode.KindInvalid, ErrAdapterMQTTInvalidConfig, msgConfigTLSInsecureSkipVerify)
 	}
 	return nil
 }

--- a/adapters/mqtt/config_test.go
+++ b/adapters/mqtt/config_test.go
@@ -432,3 +432,35 @@ func TestConfig_Validate_MaximumPacketSize_Accepted(t *testing.T) {
 	cfg.MaximumPacketSize = 1024 * 1024
 	require.NoError(t, cfg.Validate())
 }
+
+// TestConfig_Validate_PublishTimeout_Negative verifies that a negative
+// PublishTimeout is rejected by Validate.
+func TestConfig_Validate_PublishTimeout_Negative(t *testing.T) {
+	t.Parallel()
+	cfg := validConfig(t)
+	cfg.PublishTimeout = -1 * time.Second
+	err := cfg.Validate()
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTInvalidConfig, ec.Code)
+	assert.Contains(t, ec.Message, "PublishTimeout")
+}
+
+// TestConfig_Validate_PublishTimeout_Zero verifies that PublishTimeout == 0
+// is accepted (means no adapter-imposed timeout; caller ctx deadline applies).
+func TestConfig_Validate_PublishTimeout_Zero(t *testing.T) {
+	t.Parallel()
+	cfg := validConfig(t)
+	cfg.PublishTimeout = 0
+	require.NoError(t, cfg.Validate())
+}
+
+// TestConfig_Validate_PublishTimeout_Positive verifies that a positive
+// PublishTimeout is accepted.
+func TestConfig_Validate_PublishTimeout_Positive(t *testing.T) {
+	t.Parallel()
+	cfg := validConfig(t)
+	cfg.PublishTimeout = 5 * time.Second
+	require.NoError(t, cfg.Validate())
+}

--- a/adapters/mqtt/config_test.go
+++ b/adapters/mqtt/config_test.go
@@ -164,13 +164,27 @@ func TestConfig_Validate_TLSSchemeWithoutTLSConfig(t *testing.T) {
 }
 
 // TestConfig_Validate_TLSSchemeWithTLSConfig verifies that tls brokers succeed
-// when a TLS config is provided.
+// when a verifying TLS config is provided.
 func TestConfig_Validate_TLSSchemeWithTLSConfig(t *testing.T) {
 	t.Parallel()
 	cfg := validConfig(t)
 	cfg.Brokers = []string{"tls://broker.example.com:8883"}
-	cfg.TLS = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test only
+	cfg.TLS = &tls.Config{MinVersion: tls.VersionTLS12} // verifying config (no InsecureSkipVerify)
 	require.NoError(t, cfg.Validate())
+}
+
+// TestConfig_Validate_TLSInsecureSkipVerify_Rejected verifies that a TLS config
+// with InsecureSkipVerify=true is rejected fail-closed, regardless of scheme.
+func TestConfig_Validate_TLSInsecureSkipVerify_Rejected(t *testing.T) {
+	t.Parallel()
+	cfg := validConfig(t)
+	cfg.Brokers = []string{"tls://broker.example.com:8883"}
+	cfg.TLS = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // negative test: asserts this is rejected
+	err := cfg.Validate()
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTInvalidConfig, ec.Code)
 }
 
 // TestConfig_Validate_AllValidSchemes verifies all plaintext scheme variants

--- a/adapters/mqtt/config_test.go
+++ b/adapters/mqtt/config_test.go
@@ -438,7 +438,7 @@ func TestConfig_Validate_MaximumPacketSize_Accepted(t *testing.T) {
 func TestConfig_Validate_PublishTimeout_Negative(t *testing.T) {
 	t.Parallel()
 	cfg := validConfig(t)
-	cfg.PublishTimeout = -1 * time.Second
+	cfg.PublishTimeout = testtime.DNeg1s
 	err := cfg.Validate()
 	require.Error(t, err)
 	var ec *errcode.Error
@@ -461,6 +461,6 @@ func TestConfig_Validate_PublishTimeout_Zero(t *testing.T) {
 func TestConfig_Validate_PublishTimeout_Positive(t *testing.T) {
 	t.Parallel()
 	cfg := validConfig(t)
-	cfg.PublishTimeout = 5 * time.Second
+	cfg.PublishTimeout = testtime.D5s
 	require.NoError(t, cfg.Validate())
 }

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -427,6 +427,7 @@ type publishOpts struct {
 // Returns:
 //   - (*paho.PublishResponse, nil) on broker Ack (QoS 1).
 //   - (nil, ErrAdapterMQTTClosed) if Close has been called.
+//   - (nil, ErrAdapterMQTTPublishCanceled) if ctx is already canceled.
 //   - (nil, errcode-wrapped error) on transport-level failure from autopaho.
 //
 // The caller is responsible for setting any per-publish timeout via the ctx
@@ -438,6 +439,10 @@ func (c *Connection) Publish(ctx context.Context, t publishableTopic, payload []
 	if closed {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
 			"mqtt: connection is closed")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishCanceled,
+			"mqtt: publish canceled by caller context", err)
 	}
 	return c.cm.Publish(ctx, &paho.Publish{
 		Topic:   t.topic,

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -349,19 +349,43 @@ func (c *Connection) recordPermanentLocked(permErr error) {
 	c.mu.Unlock()
 }
 
+// isAuthRelatedConnackCode reports whether a CONNACK reason code is
+// auth-related (bad credentials or unauthorized). For these codes, the
+// human-readable reason name is moved to the Internal channel so it does
+// not help an attacker enumerate "credentials wrong vs authz missing".
+func isAuthRelatedConnackCode(code byte) bool {
+	return code == 0x86 || code == 0x87 || code == 0x8C
+}
+
 // buildConnackError wraps a CONNACK rejection into an errcode.Error with
-// public reasonCode/reasonName details so operators get structured diagnostics
-// (C5 F9 — reason code/name visibility). The cause is preserved via WithCause
-// for errors.Is/As chains; redaction happens at logging boundaries (slog), not
-// here (errcode WithCause does not redact).
+// structured diagnostics (C5 F9 — reason code/name visibility). For auth-related
+// reason codes (0x86/0x87/0x8C) the reason name is moved to the Internal channel
+// so it does not aid attacker enumeration of "credentials wrong vs authz missing";
+// only the numeric reasonCode is kept on wire. For all other codes, reasonName
+// stays in Public details for operator diagnostics.
+// The cause is preserved via WithCause for errors.Is/As chains; redaction
+// happens at logging boundaries (slog), not here.
 func buildConnackError(code errcode.Code, cause error, message string) error {
 	opts := []errcode.Option{}
 	var connackErr *autopaho.ConnackError
 	if errors.As(cause, &connackErr) {
-		opts = append(opts, errcode.WithDetails(
-			errcode.PublicInt("reasonCode", int(connackErr.ReasonCode)),
-			errcode.PublicString("reasonName", connackReasonName(connackErr.ReasonCode)),
-		))
+		if isAuthRelatedConnackCode(connackErr.ReasonCode) {
+			// Auth-related: keep only numeric code on wire; move name to Internal.
+			opts = append(opts,
+				errcode.WithDetails(
+					errcode.PublicInt("reasonCode", int(connackErr.ReasonCode)),
+				),
+				errcode.WithInternal(
+					errcode.InternalAttr("reasonName", connackReasonName(connackErr.ReasonCode)),
+				),
+			)
+		} else {
+			// Non-auth: both code and name are safe for operator diagnostics on wire.
+			opts = append(opts, errcode.WithDetails(
+				errcode.PublicInt("reasonCode", int(connackErr.ReasonCode)),
+				errcode.PublicString("reasonName", connackReasonName(connackErr.ReasonCode)),
+			))
+		}
 	}
 	if cause != nil {
 		opts = append(opts, errcode.WithInternal(

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -285,7 +285,9 @@ func (c *Connection) onConnectionDown() bool {
 	c.mu.Unlock()
 
 	if closed {
-		slog.Debug("mqtt: connection down after close; stopping retry",
+		// Graceful-shutdown lifecycle event — Info per observability.md (not Debug,
+		// which is off in production and would hide the orderly-stop confirmation).
+		slog.Info("mqtt: connection down after close; stopping retry",
 			slog.String("client_id", c.cfg.ClientID.String()))
 		return false
 	}
@@ -396,10 +398,14 @@ func buildConnackError(code errcode.Code, cause error, message string) error {
 }
 
 // onServerDisconnect records a server-initiated DISCONNECT for diagnostics.
+// reason_name is decoded via disconnectReasonName (MQTT v5 §3.14.2.1) — the
+// DISCONNECT reason-code table, NOT the CONNACK table, which shares numeric
+// codes with different meanings.
 func (c *Connection) onServerDisconnect(d *paho.Disconnect) {
 	slog.Warn("mqtt: server requested disconnect",
 		slog.String("client_id", c.cfg.ClientID.String()),
-		slog.Int("reason_code", int(d.ReasonCode)))
+		slog.Int("reason_code", int(d.ReasonCode)),
+		slog.String("reason_name", disconnectReasonName(d.ReasonCode)))
 }
 
 // publishOpts captures per-Publish options that are not part of the

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -378,13 +378,44 @@ func (c *Connection) onServerDisconnect(d *paho.Disconnect) {
 		slog.Int("reason_code", int(d.ReasonCode)))
 }
 
-// R4 round-2: Client() raw accessor removed entirely from PR-1. PR-2
-// (Publisher) and PR-3 (Subscriber) will add typed Publish / Subscribe
-// methods on *Connection that route topic arguments through
-// TopicNamespace.PublishOK / SubscribeOK before calling cm.Publish /
-// cm.Subscribe, and the callsite funnel archtest (gh #1225) will lock the
-// routing. Internal callers reach the manager via c.cm directly within the
-// package; no external access is needed.
+// publishOpts captures per-Publish options that are not part of the
+// (ns, topic, payload) triple. Future MQTT v5 PUBLISH fields (MessageExpiry,
+// UserProperties, ContentType, etc.) should be added here without breaking
+// Connection.Publish's signature.
+type publishOpts struct {
+	QoS    byte
+	Retain bool
+}
+
+// Publish sends a single MQTT PUBLISH packet via the underlying autopaho
+// ConnectionManager. The publishableTopic argument carries a topic that has
+// already been validated against the caller's TopicNamespace (constructor:
+// TopicNamespace.Mint). Internally this method calls c.cm.Publish — the
+// MQTT-PUBLISH-CALLSITE-FUNNEL-01 archtest locks this as the only callsite of
+// (*autopaho.ConnectionManager).Publish in the adapters/mqtt package.
+//
+// Returns:
+//   - (*paho.PublishResponse, nil) on broker Ack (QoS 1).
+//   - (nil, ErrAdapterMQTTClosed) if Close has been called.
+//   - (nil, errcode-wrapped error) on transport-level failure from autopaho.
+//
+// The caller is responsible for setting any per-publish timeout via the ctx
+// (the Publisher derives a child ctx from Config.PublishTimeout).
+func (c *Connection) Publish(ctx context.Context, t publishableTopic, payload []byte, opts publishOpts) (*paho.PublishResponse, error) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
+			"mqtt: connection is closed")
+	}
+	return c.cm.Publish(ctx, &paho.Publish{
+		Topic:   t.topic,
+		QoS:     opts.QoS,
+		Retain:  opts.Retain,
+		Payload: payload,
+	})
+}
 
 // Health returns the current readiness of the connection:
 //   - nil         — phaseConnected and no permanent error

--- a/adapters/mqtt/connection_publish_test.go
+++ b/adapters/mqtt/connection_publish_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 
 	mqttserver "github.com/mochi-mqtt/server/v2"
@@ -19,34 +20,84 @@ import (
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
-// startInternalBroker starts an in-process mochi MQTT broker on a random port
-// and returns the address plus a stop function. Internal variant (package mqtt)
-// mirrors startEmbeddedBroker from connection_test.go but is scoped here so
-// that internal tests (package mqtt) can access unexported types.
+// ---------------------------------------------------------------------------
+// Shared in-process broker (eliminates TOCTOU port-reuse race)
+// ---------------------------------------------------------------------------
+
+// sharedInternalBroker is a package-level shared mochi broker for all
+// publisher/connection unit tests in this file. Using sync.Once with a
+// pre-allocated random port (obtained via net.Listen then reused immediately
+// via listeners.NewTCP) avoids the TOCTOU window of the previous
+// ln.Close() + re-bind pattern. The broker is started once per test binary
+// run and all parallel tests share it safely.
+var (
+	sharedInternalBrokerOnce sync.Once
+	sharedInternalBrokerAddr string
+	sharedInternalBrokerStop func()
+)
+
+// initSharedInternalBroker starts the shared in-process mochi broker exactly
+// once. It allocates a random port via net.Listen, passes the open listener
+// directly to mochi's TCP listener (eliminating the TOCTOU close-then-rebind
+// window), and waits until the broker is ready.
+//
+// Note: mochi's listeners.NewTCP accepts an address string; the OS may assign
+// a different port if we close before passing, but here we pass the already-
+// bound address string immediately—the listener was closed after extracting the
+// port so we can re-bind before any other goroutine takes it. The window is
+// tiny and test-binary-scoped (no external competition).
+func initSharedInternalBroker(t *testing.T) {
+	t.Helper()
+	sharedInternalBrokerOnce.Do(func() {
+		srv := mqttserver.New(&mqttserver.Options{InlineClient: false})
+		if err := srv.AddHook(new(auth.AllowHook), nil); err != nil {
+			t.Errorf("shared broker: AddHook: %v", err)
+			return
+		}
+
+		// Allocate a free port.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Errorf("shared broker: listen: %v", err)
+			return
+		}
+		sharedInternalBrokerAddr = ln.Addr().String()
+		// Close immediately so mochi can re-bind. The window is safe within
+		// a single test binary (no external process competition).
+		_ = ln.Close()
+
+		tcp := listeners.NewTCP(listeners.Config{
+			ID:      "allow-tcp-shared",
+			Address: sharedInternalBrokerAddr,
+		})
+		if err := srv.AddListener(tcp); err != nil {
+			t.Errorf("shared broker: AddListener: %v", err)
+			return
+		}
+		go func() { _ = srv.Serve() }()
+
+		// Wait until the broker port is accepting connections.
+		testwait.External(t, "shared-broker-ready", func() bool {
+			c, dialErr := net.Dial("tcp", sharedInternalBrokerAddr)
+			if dialErr != nil {
+				return false
+			}
+			_ = c.Close()
+			return true
+		}, testtime.D2s, testtime.D10ms)
+
+		sharedInternalBrokerStop = func() { _ = srv.Close() }
+	})
+}
+
+// startInternalBroker returns the shared in-process broker address and a
+// no-op stop function. All tests sharing this broker must be parallel-safe
+// (no state mutation on the broker itself). The broker lifecycle is managed
+// by initSharedInternalBroker / TestMain (not by individual tests).
 func startInternalBroker(t *testing.T) (addr string, stop func()) {
 	t.Helper()
-	srv := mqttserver.New(&mqttserver.Options{InlineClient: false})
-	require.NoError(t, srv.AddHook(new(auth.AllowHook), nil), "add allow hook")
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "listen random port")
-	addr = ln.Addr().String()
-	require.NoError(t, ln.Close())
-
-	tcp := listeners.NewTCP(listeners.Config{ID: "allow-tcp-internal", Address: addr})
-	require.NoError(t, srv.AddListener(tcp), "add listener")
-	go func() { _ = srv.Serve() }()
-
-	testwait.External(t, "internal-broker-ready", func() bool {
-		c, err := net.Dial("tcp", addr)
-		if err != nil {
-			return false
-		}
-		_ = c.Close()
-		return true
-	}, testtime.D2s, testtime.D10ms)
-
-	return addr, func() { _ = srv.Close() }
+	initSharedInternalBroker(t)
+	return sharedInternalBrokerAddr, func() {} // stop is a no-op; shared broker outlives individual tests
 }
 
 // newInternalConfig returns a minimal valid Config pointing at addr.
@@ -67,6 +118,7 @@ func newInternalConfig(addr string) Config {
 // TestConnection_Publish_AfterClose verifies that Publish on a closed connection
 // returns ErrAdapterMQTTClosed before any broker interaction.
 func TestConnection_Publish_AfterClose(t *testing.T) {
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -99,6 +151,7 @@ func TestConnection_Publish_AfterClose(t *testing.T) {
 // TestConnection_Publish_QoS1Success verifies that a QoS-1 publish against an
 // accepting mochi broker returns a non-nil response with ReasonCode == 0x00.
 func TestConnection_Publish_QoS1Success(t *testing.T) {
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -126,6 +179,7 @@ func TestConnection_Publish_QoS1Success(t *testing.T) {
 // TestConnection_Publish_ContextCanceled verifies that passing an already-
 // canceled context causes Publish to return a non-nil error.
 func TestConnection_Publish_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 

--- a/adapters/mqtt/connection_publish_test.go
+++ b/adapters/mqtt/connection_publish_test.go
@@ -1,0 +1,152 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	mqttserver "github.com/mochi-mqtt/server/v2"
+	"github.com/mochi-mqtt/server/v2/hooks/auth"
+	"github.com/mochi-mqtt/server/v2/listeners"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
+)
+
+// startInternalBroker starts an in-process mochi MQTT broker on a random port
+// and returns the address plus a stop function. Internal variant (package mqtt)
+// mirrors startEmbeddedBroker from connection_test.go but is scoped here so
+// that internal tests (package mqtt) can access unexported types.
+func startInternalBroker(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	srv := mqttserver.New(&mqttserver.Options{InlineClient: false})
+	require.NoError(t, srv.AddHook(new(auth.AllowHook), nil), "add allow hook")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "listen random port")
+	addr = ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	tcp := listeners.NewTCP(listeners.Config{ID: "allow-tcp-internal", Address: addr})
+	require.NoError(t, srv.AddListener(tcp), "add listener")
+	go func() { _ = srv.Serve() }()
+
+	testwait.External(t, "internal-broker-ready", func() bool {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, testtime.D2s, testtime.D10ms)
+
+	return addr, func() { _ = srv.Close() }
+}
+
+// newInternalConfig returns a minimal valid Config pointing at addr.
+func newInternalConfig(addr string) Config {
+	id, _ := ParseEphemeralClientID("testcell", "internal")
+	return Config{
+		ClientID:       id,
+		Brokers:        []string{fmt.Sprintf("tcp://%s", addr)},
+		ConnectTimeout: testtime.D5s,
+		KeepAlive:      testtime.D30s,
+		Backoff: BackoffConfig{
+			BaseDelay: testtime.D100ms,
+			MaxDelay:  testtime.D2s,
+		},
+	}
+}
+
+// TestConnection_Publish_AfterClose verifies that Publish on a closed connection
+// returns ErrAdapterMQTTClosed before any broker interaction.
+func TestConnection_Publish_AfterClose(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+
+	// Close the connection first.
+	require.NoError(t, conn.Close(ctx))
+
+	// Mint a topic — topic validation is independent of connection state.
+	ns, nsErr := ParseTopicNamespace("test")
+	require.NoError(t, nsErr)
+	pt, mintErr := ns.Mint("test/x")
+	require.NoError(t, mintErr)
+
+	_, pubErr := conn.Publish(ctx, pt, []byte("payload"), publishOpts{})
+	require.Error(t, pubErr)
+
+	var ec *errcode.Error
+	require.True(t, errors.As(pubErr, &ec), "expected *errcode.Error, got %T: %v", pubErr, pubErr)
+	assert.Equal(t, ErrAdapterMQTTClosed, ec.Code, "expected ErrAdapterMQTTClosed")
+}
+
+// TestConnection_Publish_QoS1Success verifies that a QoS-1 publish against an
+// accepting mochi broker returns a non-nil response with ReasonCode == 0x00.
+func TestConnection_Publish_QoS1Success(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+	pt, err := ns.Mint("test/hello")
+	require.NoError(t, err)
+
+	resp, pubErr := conn.Publish(ctx, pt, []byte("hello world"), publishOpts{QoS: 1})
+	require.NoError(t, pubErr)
+	require.NotNil(t, resp, "expected non-nil response on QoS1 publish")
+	assert.Equal(t, byte(0x00), resp.ReasonCode, "expected PUBACK reason code 0x00 (Success)")
+}
+
+// TestConnection_Publish_ContextCanceled verifies that passing an already-
+// canceled context causes Publish to return a non-nil error.
+func TestConnection_Publish_ContextCanceled(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+	pt, err := ns.Mint("test/cancel")
+	require.NoError(t, err)
+
+	canceledCtx, cancelFn := context.WithCancel(context.Background())
+	cancelFn() // cancel immediately
+
+	_, pubErr := conn.Publish(canceledCtx, pt, []byte("payload"), publishOpts{QoS: 1})
+	require.Error(t, pubErr, "expected error with canceled context")
+}

--- a/adapters/mqtt/connection_publish_test.go
+++ b/adapters/mqtt/connection_publish_test.go
@@ -25,11 +25,10 @@ import (
 // ---------------------------------------------------------------------------
 
 // sharedInternalBroker is a package-level shared mochi broker for all
-// publisher/connection unit tests in this file. Using sync.Once with a
-// pre-allocated random port (obtained via net.Listen then reused immediately
-// via listeners.NewTCP) avoids the TOCTOU window of the previous
-// ln.Close() + re-bind pattern. The broker is started once per test binary
-// run and all parallel tests share it safely.
+// publisher/connection unit tests in this file. It is started once per test
+// binary run (sync.Once) and shared by all parallel tests. Sharing one broker
+// (rather than one per test) is what minimizes port churn — NOT a claim of
+// TOCTOU-freedom: see initSharedInternalBroker for the close-then-rebind window.
 var (
 	sharedInternalBrokerOnce sync.Once
 	sharedInternalBrokerAddr string
@@ -37,15 +36,16 @@ var (
 )
 
 // initSharedInternalBroker starts the shared in-process mochi broker exactly
-// once. It allocates a random port via net.Listen, passes the open listener
-// directly to mochi's TCP listener (eliminating the TOCTOU close-then-rebind
-// window), and waits until the broker is ready.
+// once and waits until it is ready.
 //
-// Note: mochi's listeners.NewTCP accepts an address string; the OS may assign
-// a different port if we close before passing, but here we pass the already-
-// bound address string immediately—the listener was closed after extracting the
-// port so we can re-bind before any other goroutine takes it. The window is
-// tiny and test-binary-scoped (no external competition).
+// Port allocation uses the standard probe-then-rebind idiom: net.Listen(":0")
+// to obtain a free port, Close it, then hand the address string to mochi's
+// listeners.NewTCP. This leaves a genuine — but small and test-binary-scoped —
+// TOCTOU window between Close and rebind. It is acceptable here because no other
+// process competes for the loopback ephemeral port within a single `go test`
+// run; mochi v2 does not accept a pre-bound net.Listener, so the window cannot
+// be fully eliminated without a different broker. Do NOT describe this as
+// TOCTOU-free.
 func initSharedInternalBroker(t *testing.T) {
 	t.Helper()
 	sharedInternalBrokerOnce.Do(func() {
@@ -62,8 +62,9 @@ func initSharedInternalBroker(t *testing.T) {
 			return
 		}
 		sharedInternalBrokerAddr = ln.Addr().String()
-		// Close immediately so mochi can re-bind. The window is safe within
-		// a single test binary (no external process competition).
+		// Close so mochi can rebind the same address. This is the close-then-
+		// rebind TOCTOU window documented on initSharedInternalBroker — small and
+		// test-binary-scoped, not eliminated.
 		_ = ln.Close()
 
 		tcp := listeners.NewTCP(listeners.Config{
@@ -98,6 +99,16 @@ func startInternalBroker(t *testing.T) (addr string, stop func()) {
 	t.Helper()
 	initSharedInternalBroker(t)
 	return sharedInternalBrokerAddr, func() {} // stop is a no-op; shared broker outlives individual tests
+}
+
+// stopSharedInternalBroker stops the shared in-process mochi broker if it was
+// started. Nil-safe and idempotent (srv.Close tolerates repeat calls), so both
+// the unit and integration TestMain can call it. Called once after m.Run() so
+// the broker goroutine + listener are released instead of leaking to exit.
+func stopSharedInternalBroker() {
+	if sharedInternalBrokerStop != nil {
+		sharedInternalBrokerStop()
+	}
 }
 
 // newInternalConfig returns a minimal valid Config pointing at addr.

--- a/adapters/mqtt/connection_publish_test.go
+++ b/adapters/mqtt/connection_publish_test.go
@@ -214,4 +214,7 @@ func TestConnection_Publish_ContextCanceled(t *testing.T) {
 
 	_, pubErr := conn.Publish(canceledCtx, pt, []byte("payload"), publishOpts{QoS: 1})
 	require.Error(t, pubErr, "expected error with canceled context")
+	var ec *errcode.Error
+	require.True(t, errors.As(pubErr, &ec), "expected *errcode.Error, got %T: %v", pubErr, pubErr)
+	assert.Equal(t, ErrAdapterMQTTPublishCanceled, ec.Code)
 }

--- a/adapters/mqtt/connection_test.go
+++ b/adapters/mqtt/connection_test.go
@@ -248,13 +248,14 @@ func assertErrCode(t *testing.T, err error, want errcode.Code) {
 
 // TestConnection_ReconnectMetric_Counted verifies that RecordReconnect is
 // called when a second connection event fires (first up does NOT count), and
-// increments to ≥1 after a reconnection.
+// increments to >=1 after a reconnection.
 //
-// Strategy: start a restartable broker on a fixed random port, connect, stop
-// the broker (triggers autopaho reconnect loop), restart on the same port, and
-// poll until the collector count reaches ≥1.
+// Strategy: start a live broker, connect, ask the broker to disconnect that
+// client, and poll until autopaho reconnects to the same broker. Keeping the
+// broker alive avoids racing mochi Server.Close with an in-flight client
+// disconnect, which can deadlock inside mochi's Clients lock.
 func TestConnection_ReconnectMetric_Counted(t *testing.T) {
-	addr, srv := startRestartableBroker(t)
+	addr, srv := startControlledBroker(t)
 
 	clk := clock.Real()
 	cfg := newValidConfig(addr)
@@ -267,38 +268,35 @@ func TestConnection_ReconnectMetric_Counted(t *testing.T) {
 	collector := &fakeCollector{}
 	conn, err := mqtt.Open(ctx, clk, cfg, mqtt.WithConnectionCollector(collector))
 	require.NoError(t, err)
-	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup; error not relevant
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), testtime.D2s)
+		defer closeCancel()
+		require.NoError(t, conn.Close(closeCtx), "connection cleanup")
+		testwait.External(t, "mqtt-reconnect-broker-client-drained", func() bool {
+			return srv.Clients.Len() == 0
+		}, testtime.D2s, testtime.D10ms)
+		require.NoError(t, srv.Close(), "broker cleanup")
+	}()
 
 	// Initial connection must not count as a reconnect.
 	assert.Equal(t, int64(0), collector.count.Load(),
 		"first connection must not increment reconnect counter")
 
-	// Stop the broker to trigger a disconnect in autopaho.
-	require.NoError(t, srv.Close(), "broker close")
+	var client *mqttserver.Client
+	testwait.External(t, "mqtt-broker-observes-client", func() bool {
+		var ok bool
+		client, ok = srv.Clients.Get(cfg.ClientID.String())
+		return ok && !client.Closed()
+	}, testtime.D2s, testtime.D10ms)
+
+	require.NoError(t, srv.DisconnectClient(client, packets.CodeDisconnect),
+		"server-initiated disconnect")
 
 	// Wait until autopaho detects the TCP close and enters the reconnect loop.
 	// We poll until onConnectionDown has fired (conn.Health returns non-nil).
 	testwait.External(t, "autopaho-detects-disconnect", func() bool {
 		return conn.Health(context.Background()) != nil
 	}, testtime.D5s, testtime.D20ms)
-
-	// Restart the broker on the same address so autopaho can reconnect.
-	srv2 := mqttserver.New(&mqttserver.Options{InlineClient: false})
-	require.NoError(t, srv2.AddHook(new(auth.AllowHook), nil))
-	tcp2 := listeners.NewTCP(listeners.Config{ID: "allow-tcp-restart", Address: addr})
-	require.NoError(t, srv2.AddListener(tcp2))
-	go func() { _ = srv2.Serve() }()
-	t.Cleanup(func() { _ = srv2.Close() })
-
-	// Wait until the restarted broker accepts TCP connections.
-	testwait.External(t, "mqtt-broker-restarted", func() bool {
-		c, err := net.Dial("tcp", addr)
-		if err != nil {
-			return false
-		}
-		_ = c.Close()
-		return true
-	}, testtime.D5s, testtime.D50ms)
 
 	// Poll until RecordReconnect is called (count >= 1) or timeout.
 	testwait.External(t, "reconnect-metric-fires", func() bool {
@@ -309,11 +307,10 @@ func TestConnection_ReconnectMetric_Counted(t *testing.T) {
 		"reconnect counter must increment after reconnection")
 }
 
-// startRestartableBroker starts a mochi broker on a random port and returns
-// the address and the server handle so it can be stopped and restarted in tests.
-// The caller is responsible for closing the returned server; no t.Cleanup is
-// registered so the caller can explicitly stop and restart without double-close.
-func startRestartableBroker(t *testing.T) (addr string, srv *mqttserver.Server) {
+// startControlledBroker starts a mochi broker on a random port and returns
+// the address and server handle so tests can drive server-side client actions.
+// The caller is responsible for closing the returned server.
+func startControlledBroker(t *testing.T) (addr string, srv *mqttserver.Server) {
 	t.Helper()
 	srv = mqttserver.New(&mqttserver.Options{InlineClient: false})
 	require.NoError(t, srv.AddHook(new(auth.AllowHook), nil))
@@ -324,11 +321,11 @@ func startRestartableBroker(t *testing.T) (addr string, srv *mqttserver.Server) 
 	addr = ln.Addr().String()
 	require.NoError(t, ln.Close())
 
-	tcp := listeners.NewTCP(listeners.Config{ID: "allow-tcp-restartable", Address: addr})
+	tcp := listeners.NewTCP(listeners.Config{ID: "allow-tcp-controlled", Address: addr})
 	require.NoError(t, srv.AddListener(tcp))
 	go func() { _ = srv.Serve() }()
 
-	testwait.External(t, "mqtt-broker-accepts-connections", func() bool {
+	testwait.External(t, "mqtt-controlled-broker-accepts-connections", func() bool {
 		c, derr := net.Dial("tcp", addr)
 		if derr != nil {
 			return false

--- a/adapters/mqtt/doc.go
+++ b/adapters/mqtt/doc.go
@@ -5,11 +5,15 @@
 //
 // # What ships in each PR
 //
-// PR-1 (this PR): connection infrastructure, sealed-struct identity funnels
+// PR-1 (merged): connection infrastructure, sealed-struct identity funnels
 // (ClientID, TopicNamespace), Config, metrics skeleton, pkg/redaction wiring,
 // and the archtest funnels that lock the sealed-struct shapes.
 //
-// PR-2: Publisher (outbox.Publisher).
+// PR-2 (this PR): Publisher (outbox.Publisher), QoS-1 PUBACK error classification
+// (classifyPubackReason), publisher metrics (mqtt_publish_failed_total closed-set
+// reason labels), and the MQTT-PUBLISH-CALLSITE-FUNNEL-01 callsite archtest that
+// locks all cm.Publish calls inside (*Connection).Publish.
+//
 // PR-3: Subscriber (outbox.Subscriber) + ConsumerBase integration.
 // PR-4: DLT routing ($dead/<topic>), outbox conformance suite.
 // PR-5: examples/iotdevice MQTT demo path.
@@ -21,10 +25,12 @@
 // Two types carry the "illegal state unrepresentable" guarantee:
 //
 // ClientID is a sealed struct with a single unexported field `value string`.
-// The only way to obtain a non-zero ClientID is ParseClientID, which validates
-// the "{cellID}-{role}-{uuid}" format before constructing. Callers who receive
-// a ClientID are guaranteed it passed validation. Go's visibility rules make
-// outside-package struct-literal construction a compile error.
+// The only way to obtain a non-zero ClientID is ParseEphemeralClientID or
+// ParseStableClientID, which validate the "{cellID}-{role}-{uuid}" format before
+// constructing. ParseEphemeralClientID generates the uuid internally (clean-session
+// use); ParseStableClientID accepts a caller-supplied instanceID (persistent-session
+// use). Callers who receive a ClientID are guaranteed it passed validation. Go's
+// visibility rules make outside-package struct-literal construction a compile error.
 //
 //	// INVARIANT: MQTT-CLIENT-ID-NAMESPACE-01
 //	// tools/archtest/mqtt_funnel_test.go locks the field shape (A1), the
@@ -39,9 +45,10 @@
 //	// INVARIANT: MQTT-TOPIC-NAMESPACE-01
 //	// tools/archtest/mqtt_funnel_test.go locks the field shape (A1), the
 //	// construction allowlist inside adapters/mqtt (A2), and the absence of
-//	// type aliases (A3). Downstream callsite enforcement (publish/subscribe
-//	// args must route through PublishOK/SubscribeOK) is deferred to PR-2/3
-//	// and tracked by gh issue #1225.
+//	// type aliases (A3). Downstream callsite enforcement (all cm.Publish calls
+//	// must route through (*Connection).Publish, which gates on PublishOK) is
+//	// implemented in PR-2 and locked by MQTT-PUBLISH-CALLSITE-FUNNEL-01
+//	// (tools/archtest/mqtt_callsite_funnel_test.go).
 //
 // # Readiness probe
 //
@@ -55,7 +62,8 @@
 //   - ClientID upstream Hard (package-external): Go compile error.
 //   - ClientID upstream Medium (package-internal): archtest A2 AST scan.
 //   - TopicNamespace: same grading as ClientID.
-//   - Downstream callsite funnel: deferred to PR-2/3 (#1225).
+//   - Downstream callsite funnel: MQTT-PUBLISH-CALLSITE-FUNNEL-01 landed in PR-2
+//     (tools/archtest/mqtt_callsite_funnel_test.go A1–A4). gh issue #1225 closed.
 //
 // # Reference
 //

--- a/adapters/mqtt/errors.go
+++ b/adapters/mqtt/errors.go
@@ -99,6 +99,22 @@ const (
 	// rate-limited or its message quota is exhausted. Callers should back off
 	// and retry after a delay.
 	ErrAdapterMQTTPublishRateLimited errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_RATE_LIMITED"
+
+	// ErrAdapterMQTTPublishCanceled signals that a publish call was canceled
+	// because the caller's context was canceled before the broker responded.
+	ErrAdapterMQTTPublishCanceled errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_CANCELED"
+
+	// ErrAdapterMQTTPublishFailed signals a transport-level publish failure (the
+	// underlying autopaho returned a non-context error and not a PUBACK reason
+	// code). Distinct from ErrAdapterMQTTConnect which is connection-side, and
+	// from ErrAdapterMQTTPubAckTimeout / PublishRejected which are PUBACK-side.
+	ErrAdapterMQTTPublishFailed errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_FAILED"
+
+	// ErrAdapterMQTTPublisherCloseTimeout signals that Publisher.Close exceeded
+	// its drain budget waiting for in-flight publishes to complete. Distinct from
+	// ErrAdapterMQTTPubAckTimeout (single-publish PUBACK timeout) — Close timeout
+	// indicates one or more goroutines are stuck.
+	ErrAdapterMQTTPublisherCloseTimeout errcode.Code = "ERR_ADAPTER_MQTT_PUBLISHER_CLOSE_TIMEOUT"
 )
 
 // connackClass classifies an OnConnectError into one of three categories.
@@ -214,11 +230,11 @@ func connackReasonName(code byte) string {
 //
 // Reason-code → (code, kind) mapping (ref: MQTT v5.0 spec §3.4.2.1):
 //
-//	0x00 Success                  → ("", KindInternal)               — Ack path, unused by error handler
+//	0x00 Success                  → ("", KindInternal)               — Ack path; caller MUST guard ReasonCode != 0x00 before calling
 //	0x10 NoMatchingSubscribers    → (ErrAdapterMQTTPublishNoSubscribers, KindUnavailable)
 //	0x80 UnspecifiedError         → (ErrAdapterMQTTPublishRejected,     KindInternal)
 //	0x83 ImplementationSpecific   → (ErrAdapterMQTTPublishRejected,     KindInternal)
-//	0x87 NotAuthorized            → (ErrAdapterMQTTPublishRejected,     KindInternal)
+//	0x87 NotAuthorized            → (ErrAdapterMQTTPublishRejected,     KindUnavailable) — retryable; operator fixes ACL
 //	0x90 TopicNameInvalid         → (ErrAdapterMQTTPublishRejected,     KindInvalid)
 //	0x97 QuotaExceeded            → (ErrAdapterMQTTPublishRateLimited,  KindUnavailable)
 //	0x99 PayloadFormatInvalid     → (ErrAdapterMQTTPayloadTooLarge,     KindInvalid)
@@ -227,7 +243,7 @@ func connackReasonName(code byte) string {
 // ref: MQTT v5.0 spec §3.4.2.1 PUBACK Reason Code table
 func classifyPubackReason(code byte) (errcode.Code, errcode.Kind) {
 	switch code {
-	case 0x00: // Success
+	case 0x00: // Success — Ack path; caller MUST guard ReasonCode != 0x00 before calling
 		return "", errcode.KindInternal
 	case 0x10: // No Matching Subscribers
 		return ErrAdapterMQTTPublishNoSubscribers, errcode.KindUnavailable
@@ -235,8 +251,8 @@ func classifyPubackReason(code byte) (errcode.Code, errcode.Kind) {
 		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
 	case 0x83: // Implementation Specific Error
 		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
-	case 0x87: // Not Authorized
-		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
+	case 0x87: // Not Authorized — retryable after operator fixes ACL (aligned with CONNACK 0x87 classPermanentRetain)
+		return ErrAdapterMQTTPublishRejected, errcode.KindUnavailable
 	case 0x90: // Topic Name Invalid
 		return ErrAdapterMQTTPublishRejected, errcode.KindInvalid
 	case 0x97: // Quota Exceeded

--- a/adapters/mqtt/errors.go
+++ b/adapters/mqtt/errors.go
@@ -88,10 +88,12 @@ const (
 	ErrAdapterMQTTPublishNoSubscribers errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_NO_SUBSCRIBERS"
 
 	// ErrAdapterMQTTPublishRejected signals that the broker returned a PUBACK
-	// reason code indicating the message was rejected: unspecified error (0x80),
-	// implementation-specific error (0x83), not authorized (0x87), or topic name
-	// invalid (0x90). These conditions typically require operator intervention or
-	// a client-side fix before retrying.
+	// reason code indicating the message was permanently rejected: unspecified
+	// error (0x80), implementation-specific error (0x83), or topic name invalid
+	// (0x90). These conditions require a client-side fix before retrying.
+	// Not-authorized (0x87) is NOT covered here — it is retryable-after-operator-
+	// ACL-fix and carries its own ErrAdapterMQTTPublishNotAuthorized code (below);
+	// payload-format-invalid (0x99) carries ErrAdapterMQTTPublishPayloadFormatInvalid.
 	ErrAdapterMQTTPublishRejected errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_REJECTED"
 
 	// ErrAdapterMQTTPublishRateLimited signals that the broker returned PUBACK
@@ -99,6 +101,25 @@ const (
 	// rate-limited or its message quota is exhausted. Callers should back off
 	// and retry after a delay.
 	ErrAdapterMQTTPublishRateLimited errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_RATE_LIMITED"
+
+	// ErrAdapterMQTTPublishNotAuthorized signals that the broker returned PUBACK
+	// reason code 0x87 (Not Authorized): the publisher's ACL does not permit
+	// publishing to the topic. Classified KindUnavailable (retryable) — aligned
+	// with CONNACK 0x87 classPermanentRetain semantics: the condition persists
+	// until an operator fixes the broker-side ACL, after which retries succeed.
+	// The outbox relay should keep retrying (bounded by its retry budget, then
+	// DLX) rather than treating it as a permanent client error. Decision recorded
+	// in ADR docs/architecture/202605281200-048-adr-mqtt-adapter.md §错误映射表.
+	ErrAdapterMQTTPublishNotAuthorized errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_NOT_AUTHORIZED"
+
+	// ErrAdapterMQTTPublishPayloadFormatInvalid signals that the broker returned
+	// PUBACK reason code 0x99 (Payload Format Invalid): the payload does not
+	// conform to the declared Payload Format Indicator / Content Type (e.g. a
+	// UTF-8 declaration carrying non-UTF-8 bytes). Classified KindInvalid —
+	// semantically distinct from ErrAdapterMQTTPayloadTooLarge (size), which it
+	// previously and incorrectly shared. A client-side payload-encoding fix is
+	// required.
+	ErrAdapterMQTTPublishPayloadFormatInvalid errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_PAYLOAD_FORMAT_INVALID"
 
 	// ErrAdapterMQTTPublishCanceled signals that a publish call was canceled
 	// because the caller's context was canceled before the broker responded.
@@ -232,13 +253,13 @@ func connackReasonName(code byte) string {
 //
 //	0x00 Success                  → ("", KindInternal)               — Ack path; caller MUST guard ReasonCode != 0x00 before calling
 //	0x10 NoMatchingSubscribers    → (ErrAdapterMQTTPublishNoSubscribers, KindUnavailable)
-//	0x80 UnspecifiedError         → (ErrAdapterMQTTPublishRejected,     KindInternal)
-//	0x83 ImplementationSpecific   → (ErrAdapterMQTTPublishRejected,     KindInternal)
-//	0x87 NotAuthorized            → (ErrAdapterMQTTPublishRejected,     KindUnavailable) — retryable; operator fixes ACL
-//	0x90 TopicNameInvalid         → (ErrAdapterMQTTPublishRejected,     KindInvalid)
-//	0x97 QuotaExceeded            → (ErrAdapterMQTTPublishRateLimited,  KindUnavailable)
-//	0x99 PayloadFormatInvalid     → (ErrAdapterMQTTPayloadTooLarge,     KindInvalid)
-//	default                       → (ErrAdapterMQTTPublishRejected,     KindInternal)
+//	0x80 UnspecifiedError         → (ErrAdapterMQTTPublishRejected,            KindInternal)
+//	0x83 ImplementationSpecific   → (ErrAdapterMQTTPublishRejected,            KindInternal)
+//	0x87 NotAuthorized            → (ErrAdapterMQTTPublishNotAuthorized,       KindUnavailable) — retryable; operator fixes ACL
+//	0x90 TopicNameInvalid         → (ErrAdapterMQTTPublishRejected,            KindInvalid)
+//	0x97 QuotaExceeded            → (ErrAdapterMQTTPublishRateLimited,         KindUnavailable)
+//	0x99 PayloadFormatInvalid     → (ErrAdapterMQTTPublishPayloadFormatInvalid, KindInvalid)
+//	default                       → (ErrAdapterMQTTPublishRejected,            KindInternal)
 //
 // ref: MQTT v5.0 spec §3.4.2.1 PUBACK Reason Code table
 func classifyPubackReason(code byte) (errcode.Code, errcode.Kind) {
@@ -252,13 +273,13 @@ func classifyPubackReason(code byte) (errcode.Code, errcode.Kind) {
 	case 0x83: // Implementation Specific Error
 		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
 	case 0x87: // Not Authorized — retryable after operator fixes ACL (aligned with CONNACK 0x87 classPermanentRetain)
-		return ErrAdapterMQTTPublishRejected, errcode.KindUnavailable
+		return ErrAdapterMQTTPublishNotAuthorized, errcode.KindUnavailable
 	case 0x90: // Topic Name Invalid
 		return ErrAdapterMQTTPublishRejected, errcode.KindInvalid
 	case 0x97: // Quota Exceeded
 		return ErrAdapterMQTTPublishRateLimited, errcode.KindUnavailable
-	case 0x99: // Payload Format Invalid
-		return ErrAdapterMQTTPayloadTooLarge, errcode.KindInvalid
+	case 0x99: // Payload Format Invalid — distinct from PayloadTooLarge (size)
+		return ErrAdapterMQTTPublishPayloadFormatInvalid, errcode.KindInvalid
 	default:
 		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
 	}
@@ -285,6 +306,50 @@ var pubackReasonNames = map[byte]string{
 // reasonCode field in structured logs.
 func pubackReasonName(code byte) string {
 	if name, ok := pubackReasonNames[code]; ok {
+		return name
+	}
+	return "Unknown"
+}
+
+// disconnectReasonNames is the single source of MQTT v5 DISCONNECT reason code →
+// spec-defined name mapping (MQTT v5.0 §3.14.2.1 Disconnect Reason Code table).
+// This is a DISTINCT table from connackReasonNames (§3.2.2.2) and
+// pubackReasonNames (§3.4.2.1): the three packets share some numeric codes with
+// different meanings, so a server-initiated DISCONNECT must be decoded with this
+// table, not the CONNACK one. Only the server-initiated subset is enumerated;
+// unrecognized codes fall back to "Unknown".
+var disconnectReasonNames = map[byte]string{
+	0x00: "NormalDisconnection",
+	0x04: "DisconnectWithWillMessage",
+	0x80: "UnspecifiedError",
+	0x81: "MalformedPacket",
+	0x82: "ProtocolError",
+	0x83: "ImplementationSpecificError",
+	0x87: "NotAuthorized",
+	0x89: "ServerBusy",
+	0x8B: "ServerShuttingDown",
+	0x8D: "KeepAliveTimeout",
+	0x8E: "SessionTakenOver",
+	0x8F: "TopicFilterInvalid",
+	0x90: "TopicNameInvalid",
+	0x93: "ReceiveMaximumExceeded",
+	0x94: "TopicAliasInvalid",
+	0x95: "PacketTooLarge",
+	0x96: "MessageRateTooHigh",
+	0x97: "QuotaExceeded",
+	0x98: "AdministrativeAction",
+	0x99: "PayloadFormatInvalid",
+	0x9C: "UseAnotherServer",
+	0x9D: "ServerMoved",
+	0x9F: "ConnectionRateExceeded",
+	0xA0: "MaximumConnectTime",
+}
+
+// disconnectReasonName returns the spec name for an MQTT v5 DISCONNECT reason
+// code. Unknown codes return "Unknown" so operators can still match the numeric
+// reasonCode field in structured logs.
+func disconnectReasonName(code byte) string {
+	if name, ok := disconnectReasonNames[code]; ok {
 		return name
 	}
 	return "Unknown"

--- a/adapters/mqtt/errors.go
+++ b/adapters/mqtt/errors.go
@@ -73,6 +73,32 @@ const (
 	// itself is malformed, and ErrAdapterMQTTTopicOutsideNamespace which means
 	// the filter's non-wildcard head falls outside the declared namespace.
 	ErrAdapterMQTTInvalidSubscribeFilter errcode.Code = "ERR_ADAPTER_MQTT_INVALID_SUBSCRIBE_FILTER"
+
+	// ErrAdapterMQTTPubAckTimeout signals that no PUBACK was received within
+	// the configured PublishTimeout budget. The broker may have received the
+	// message but the acknowledgement was lost; callers should treat this as a
+	// retryable transient failure and apply idempotency controls before retrying.
+	ErrAdapterMQTTPubAckTimeout errcode.Code = "ERR_ADAPTER_MQTT_PUBACK_TIMEOUT"
+
+	// ErrAdapterMQTTPublishNoSubscribers signals that the broker returned
+	// PUBACK reason code 0x10 (No Matching Subscribers): the message was
+	// accepted but no active subscriber matched the topic filter. This is an
+	// informational condition for QoS 1; the publisher may log a warning and
+	// continue rather than treating it as a hard error.
+	ErrAdapterMQTTPublishNoSubscribers errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_NO_SUBSCRIBERS"
+
+	// ErrAdapterMQTTPublishRejected signals that the broker returned a PUBACK
+	// reason code indicating the message was rejected: unspecified error (0x80),
+	// implementation-specific error (0x83), not authorized (0x87), or topic name
+	// invalid (0x90). These conditions typically require operator intervention or
+	// a client-side fix before retrying.
+	ErrAdapterMQTTPublishRejected errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_REJECTED"
+
+	// ErrAdapterMQTTPublishRateLimited signals that the broker returned PUBACK
+	// reason code 0x97 (Quota Exceeded), indicating the publisher has been
+	// rate-limited or its message quota is exhausted. Callers should back off
+	// and retry after a delay.
+	ErrAdapterMQTTPublishRateLimited errcode.Code = "ERR_ADAPTER_MQTT_PUBLISH_RATE_LIMITED"
 )
 
 // connackClass classifies an OnConnectError into one of three categories.
@@ -178,6 +204,71 @@ var connackReasonNames = map[byte]string{
 // numeric reasonCode field.
 func connackReasonName(code byte) string {
 	if name, ok := connackReasonNames[code]; ok {
+		return name
+	}
+	return "Unknown"
+}
+
+// classifyPubackReason maps an MQTT v5 PUBACK reason code (byte) to the
+// corresponding errcode.Code and errcode.Kind.
+//
+// Reason-code → (code, kind) mapping (ref: MQTT v5.0 spec §3.4.2.1):
+//
+//	0x00 Success                  → ("", KindInternal)               — Ack path, unused by error handler
+//	0x10 NoMatchingSubscribers    → (ErrAdapterMQTTPublishNoSubscribers, KindUnavailable)
+//	0x80 UnspecifiedError         → (ErrAdapterMQTTPublishRejected,     KindInternal)
+//	0x83 ImplementationSpecific   → (ErrAdapterMQTTPublishRejected,     KindInternal)
+//	0x87 NotAuthorized            → (ErrAdapterMQTTPublishRejected,     KindInternal)
+//	0x90 TopicNameInvalid         → (ErrAdapterMQTTPublishRejected,     KindInvalid)
+//	0x97 QuotaExceeded            → (ErrAdapterMQTTPublishRateLimited,  KindUnavailable)
+//	0x99 PayloadFormatInvalid     → (ErrAdapterMQTTPayloadTooLarge,     KindInvalid)
+//	default                       → (ErrAdapterMQTTPublishRejected,     KindInternal)
+//
+// ref: MQTT v5.0 spec §3.4.2.1 PUBACK Reason Code table
+func classifyPubackReason(code byte) (errcode.Code, errcode.Kind) {
+	switch code {
+	case 0x00: // Success
+		return "", errcode.KindInternal
+	case 0x10: // No Matching Subscribers
+		return ErrAdapterMQTTPublishNoSubscribers, errcode.KindUnavailable
+	case 0x80: // Unspecified Error
+		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
+	case 0x83: // Implementation Specific Error
+		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
+	case 0x87: // Not Authorized
+		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
+	case 0x90: // Topic Name Invalid
+		return ErrAdapterMQTTPublishRejected, errcode.KindInvalid
+	case 0x97: // Quota Exceeded
+		return ErrAdapterMQTTPublishRateLimited, errcode.KindUnavailable
+	case 0x99: // Payload Format Invalid
+		return ErrAdapterMQTTPayloadTooLarge, errcode.KindInvalid
+	default:
+		return ErrAdapterMQTTPublishRejected, errcode.KindInternal
+	}
+}
+
+// pubackReasonNames is the single source of MQTT v5 PUBACK reason code →
+// spec-defined name mapping (MQTT v5.0 §3.4.2.1 PUBACK Reason Code table).
+// Distinct from connackReasonNames — the two tables are different despite
+// some overlapping codes (CONNACK §3.2.2.2 vs PUBACK §3.4.2.1).
+var pubackReasonNames = map[byte]string{
+	0x00: "Success",
+	0x10: "NoMatchingSubscribers",
+	0x80: "UnspecifiedError",
+	0x83: "ImplementationSpecificError",
+	0x87: "NotAuthorized",
+	0x90: "TopicNameInvalid",
+	0x91: "PacketIdentifierInUse",
+	0x97: "QuotaExceeded",
+	0x99: "PayloadFormatInvalid",
+}
+
+// pubackReasonName returns the spec name for an MQTT v5 PUBACK reason code.
+// Unknown codes return "Unknown" so operators can still match the numeric
+// reasonCode field in structured logs.
+func pubackReasonName(code byte) string {
+	if name, ok := pubackReasonNames[code]; ok {
 		return name
 	}
 	return "Unknown"

--- a/adapters/mqtt/errors.go
+++ b/adapters/mqtt/errors.go
@@ -39,6 +39,13 @@ const (
 	// topic/filter does not fall within the declared TopicNamespace.
 	ErrAdapterMQTTTopicOutsideNamespace errcode.Code = "ERR_ADAPTER_MQTT_TOPIC_OUTSIDE_NAMESPACE"
 
+	// ErrAdapterMQTTInvalidPublishTopic signals that a publish topic is malformed
+	// under MQTT v5 rules: empty topic name, or a topic containing +/# wildcards.
+	// Subscribe filters use ErrAdapterMQTTInvalidSubscribeFilter because wildcard
+	// placement is legal-but-constrained there; publish topics are a distinct
+	// failure domain and must never reuse the subscribe-filter code.
+	ErrAdapterMQTTInvalidPublishTopic errcode.Code = "ERR_ADAPTER_MQTT_INVALID_PUBLISH_TOPIC"
+
 	// ErrAdapterMQTTConnect signals a transient connection failure (network
 	// timeout, server unavailable, quota exceeded). autopaho will retry.
 	ErrAdapterMQTTConnect errcode.Code = "ERR_ADAPTER_MQTT_CONNECT"

--- a/adapters/mqtt/errors_test.go
+++ b/adapters/mqtt/errors_test.go
@@ -140,6 +140,11 @@ func TestErrorCodes_DeclaredAsErrcodeCodes(t *testing.T) {
 		ErrAdapterMQTTClosed,
 		ErrAdapterMQTTPayloadTooLarge,
 		ErrAdapterMQTTInvalidSubscribeFilter,
+		// PR-2 additions
+		ErrAdapterMQTTPubAckTimeout,
+		ErrAdapterMQTTPublishNoSubscribers,
+		ErrAdapterMQTTPublishRejected,
+		ErrAdapterMQTTPublishRateLimited,
 	}
 	for _, c := range codes {
 		if c == "" {
@@ -148,5 +153,79 @@ func TestErrorCodes_DeclaredAsErrcodeCodes(t *testing.T) {
 		if string(c)[:len("ERR_ADAPTER_MQTT_")] != "ERR_ADAPTER_MQTT_" {
 			t.Errorf("code %q does not have ERR_ADAPTER_MQTT_ prefix", c)
 		}
+	}
+}
+
+func TestClassifyPubackReason(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		code     byte
+		wantCode errcode.Code
+		wantKind errcode.Kind
+	}{
+		// 0x00 Success — Ack path, empty sentinel + KindInternal (unused by caller)
+		{"success-0x00", 0x00, "", errcode.KindInternal},
+		// 0x10 No matching subscribers
+		{"no-matching-subscribers-0x10", 0x10, ErrAdapterMQTTPublishNoSubscribers, errcode.KindUnavailable},
+		// 0x80 Unspecified error
+		{"unspecified-error-0x80", 0x80, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
+		// 0x83 Implementation specific error
+		{"implementation-specific-0x83", 0x83, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
+		// 0x87 Not authorized
+		{"not-authorized-0x87", 0x87, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
+		// 0x90 Topic Name invalid
+		{"topic-name-invalid-0x90", 0x90, ErrAdapterMQTTPublishRejected, errcode.KindInvalid},
+		// 0x97 Quota exceeded / rate limited
+		{"quota-exceeded-0x97", 0x97, ErrAdapterMQTTPublishRateLimited, errcode.KindUnavailable},
+		// 0x99 Payload format invalid — reuse ErrAdapterMQTTPayloadTooLarge
+		{"payload-format-invalid-0x99", 0x99, ErrAdapterMQTTPayloadTooLarge, errcode.KindInvalid},
+		// default — unknown code
+		{"unknown-code-0x7f", 0x7F, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotCode, gotKind := classifyPubackReason(tc.code)
+			if gotCode != tc.wantCode {
+				t.Errorf("classifyPubackReason(0x%02x) code = %q, want %q", tc.code, gotCode, tc.wantCode)
+			}
+			if gotKind != tc.wantKind {
+				t.Errorf("classifyPubackReason(0x%02x) kind = %v, want %v", tc.code, gotKind, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestPubackReasonName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		code byte
+		want string
+	}{
+		{0x00, "Success"},
+		{0x10, "NoMatchingSubscribers"},
+		{0x80, "UnspecifiedError"},
+		{0x83, "ImplementationSpecificError"},
+		{0x87, "NotAuthorized"},
+		{0x90, "TopicNameInvalid"},
+		{0x91, "PacketIdentifierInUse"},
+		{0x97, "QuotaExceeded"},
+		{0x99, "PayloadFormatInvalid"},
+		{0x7F, "Unknown"}, // unrecognized code
+		{0xFE, "Unknown"}, // another unrecognized code
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("0x%02x", tc.code), func(t *testing.T) {
+			t.Parallel()
+			got := pubackReasonName(tc.code)
+			if got != tc.want {
+				t.Errorf("pubackReasonName(0x%02x) = %q, want %q", tc.code, got, tc.want)
+			}
+		})
 	}
 }

--- a/adapters/mqtt/errors_test.go
+++ b/adapters/mqtt/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/eclipse/paho.golang/autopaho"
@@ -145,6 +146,8 @@ func TestErrorCodes_DeclaredAsErrcodeCodes(t *testing.T) {
 		ErrAdapterMQTTPublishNoSubscribers,
 		ErrAdapterMQTTPublishRejected,
 		ErrAdapterMQTTPublishRateLimited,
+		ErrAdapterMQTTPublishNotAuthorized,
+		ErrAdapterMQTTPublishPayloadFormatInvalid,
 		ErrAdapterMQTTPublishCanceled,
 		ErrAdapterMQTTPublishFailed,
 		ErrAdapterMQTTPublisherCloseTimeout,
@@ -153,7 +156,10 @@ func TestErrorCodes_DeclaredAsErrcodeCodes(t *testing.T) {
 		if c == "" {
 			t.Errorf("error code is empty string: %v", c)
 		}
-		if string(c)[:len("ERR_ADAPTER_MQTT_")] != "ERR_ADAPTER_MQTT_" {
+		// strings.HasPrefix is bounds-safe for codes shorter than the prefix;
+		// a slice index ([:len(prefix)]) would panic on a short code instead of
+		// reporting a clean test failure.
+		if !strings.HasPrefix(string(c), "ERR_ADAPTER_MQTT_") {
 			t.Errorf("code %q does not have ERR_ADAPTER_MQTT_ prefix", c)
 		}
 	}
@@ -175,14 +181,15 @@ func TestClassifyPubackReason(t *testing.T) {
 		{"unspecified-error-0x80", 0x80, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
 		// 0x83 Implementation specific error
 		{"implementation-specific-0x83", 0x83, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
-		// 0x87 Not authorized — retryable (KindUnavailable, aligned with CONNACK 0x87 classPermanentRetain)
-		{"not-authorized-0x87", 0x87, ErrAdapterMQTTPublishRejected, errcode.KindUnavailable},
+		// 0x87 Not authorized — retryable (KindUnavailable, aligned with CONNACK 0x87 classPermanentRetain),
+		// dedicated code (not the permanent ErrAdapterMQTTPublishRejected)
+		{"not-authorized-0x87", 0x87, ErrAdapterMQTTPublishNotAuthorized, errcode.KindUnavailable},
 		// 0x90 Topic Name invalid
 		{"topic-name-invalid-0x90", 0x90, ErrAdapterMQTTPublishRejected, errcode.KindInvalid},
 		// 0x97 Quota exceeded / rate limited
 		{"quota-exceeded-0x97", 0x97, ErrAdapterMQTTPublishRateLimited, errcode.KindUnavailable},
-		// 0x99 Payload format invalid — reuse ErrAdapterMQTTPayloadTooLarge
-		{"payload-format-invalid-0x99", 0x99, ErrAdapterMQTTPayloadTooLarge, errcode.KindInvalid},
+		// 0x99 Payload format invalid — dedicated code, distinct from PayloadTooLarge (size)
+		{"payload-format-invalid-0x99", 0x99, ErrAdapterMQTTPublishPayloadFormatInvalid, errcode.KindInvalid},
 		// default — unknown code
 		{"unknown-code-0x7f", 0x7F, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
 	}

--- a/adapters/mqtt/errors_test.go
+++ b/adapters/mqtt/errors_test.go
@@ -134,6 +134,7 @@ func TestErrorCodes_DeclaredAsErrcodeCodes(t *testing.T) {
 		ErrAdapterMQTTInvalidClientID,
 		ErrAdapterMQTTInvalidTopicNamespace,
 		ErrAdapterMQTTTopicOutsideNamespace,
+		ErrAdapterMQTTInvalidPublishTopic,
 		ErrAdapterMQTTConnect,
 		ErrAdapterMQTTConnectTimeout,
 		ErrAdapterMQTTConnectPermanent,

--- a/adapters/mqtt/errors_test.go
+++ b/adapters/mqtt/errors_test.go
@@ -145,6 +145,9 @@ func TestErrorCodes_DeclaredAsErrcodeCodes(t *testing.T) {
 		ErrAdapterMQTTPublishNoSubscribers,
 		ErrAdapterMQTTPublishRejected,
 		ErrAdapterMQTTPublishRateLimited,
+		ErrAdapterMQTTPublishCanceled,
+		ErrAdapterMQTTPublishFailed,
+		ErrAdapterMQTTPublisherCloseTimeout,
 	}
 	for _, c := range codes {
 		if c == "" {
@@ -172,8 +175,8 @@ func TestClassifyPubackReason(t *testing.T) {
 		{"unspecified-error-0x80", 0x80, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
 		// 0x83 Implementation specific error
 		{"implementation-specific-0x83", 0x83, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
-		// 0x87 Not authorized
-		{"not-authorized-0x87", 0x87, ErrAdapterMQTTPublishRejected, errcode.KindInternal},
+		// 0x87 Not authorized — retryable (KindUnavailable, aligned with CONNACK 0x87 classPermanentRetain)
+		{"not-authorized-0x87", 0x87, ErrAdapterMQTTPublishRejected, errcode.KindUnavailable},
 		// 0x90 Topic Name invalid
 		{"topic-name-invalid-0x90", 0x90, ErrAdapterMQTTPublishRejected, errcode.KindInvalid},
 		// 0x97 Quota exceeded / rate limited

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -4,13 +4,14 @@ package mqtt
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -167,11 +168,13 @@ func TestIntegration_PublisherPubAckTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Publish succeeded; expected ErrAdapterMQTTPubAckTimeout")
 	}
-	// wrapPublishErr maps context.DeadlineExceeded → ErrAdapterMQTTPubAckTimeout
-	// with message "mqtt: PUBACK timeout". Accept any timeout-related text to be
-	// resilient to minor message wording changes.
-	msg := err.Error()
-	if !strings.Contains(msg, "PUBACK") && !strings.Contains(msg, "puback") && !strings.Contains(msg, "timeout") {
-		t.Fatalf("Publish err = %v; want PUBACK timeout-related", err)
+	// wrapPublishErr maps context.DeadlineExceeded → ErrAdapterMQTTPubAckTimeout.
+	// Assert via typed errcode check rather than fragile string matching.
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("Publish err is not *errcode.Error: %v", err)
+	}
+	if ec.Code != ErrAdapterMQTTPubAckTimeout {
+		t.Fatalf("Publish err code = %v, want %v", ec.Code, ErrAdapterMQTTPubAckTimeout)
 	}
 }

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -5,13 +5,17 @@ package mqtt
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -30,13 +34,13 @@ func newTestConfig(t *testing.T, role string) Config {
 	return Config{
 		ClientID:       cid,
 		Brokers:        []string{brokerURL},
-		ConnectTimeout: 5 * time.Second,
-		KeepAlive:      10 * time.Second,
+		ConnectTimeout: testtime.D5s,
+		KeepAlive:      testtime.D10s,
 		Backoff: BackoffConfig{
-			BaseDelay: 100 * time.Millisecond,
-			MaxDelay:  2 * time.Second,
+			BaseDelay: testtime.D100ms,
+			MaxDelay:  testtime.D2s,
 		},
-		PublishTimeout: 5 * time.Second,
+		PublishTimeout: testtime.D5s,
 	}
 }
 
@@ -44,7 +48,7 @@ func newTestConfig(t *testing.T, role string) Config {
 // Mosquitto broker: open connection, construct Publisher, publish a small
 // payload to a valid topic, assert no error returned (broker PUBACK 0x00).
 func TestIntegration_PublisherQoS1(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D20s)
 	defer cancel()
 
 	cfg := newTestConfig(t, "publish-qos1")
@@ -53,7 +57,7 @@ func TestIntegration_PublisherQoS1(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
 		defer c()
 		_ = conn.Close(cleanupCtx)
 	})
@@ -67,7 +71,7 @@ func TestIntegration_PublisherQoS1(t *testing.T) {
 		t.Fatalf("NewPublisher: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
 		defer c()
 		_ = pub.Close(cleanupCtx)
 	})
@@ -84,18 +88,18 @@ func TestIntegration_PublisherQoS1(t *testing.T) {
 // the keep-alive ping path — the test confirms the connection survives the
 // heartbeat exchange transparently.
 func TestIntegration_PublisherReconnect(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D30s)
 	defer cancel()
 
 	cfg := newTestConfig(t, "publish-reconnect")
-	cfg.KeepAlive = 2 * time.Second // tighter keep-alive for quick failure detection
+	cfg.KeepAlive = testtime.D2s // tighter keep-alive for quick failure detection
 
 	conn, err := Open(ctx, clock.Real(), cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
 		defer c()
 		_ = conn.Close(cleanupCtx)
 	})
@@ -109,7 +113,7 @@ func TestIntegration_PublisherReconnect(t *testing.T) {
 		t.Fatalf("NewPublisher: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
 		defer c()
 		_ = pub.Close(cleanupCtx)
 	})
@@ -120,7 +124,9 @@ func TestIntegration_PublisherReconnect(t *testing.T) {
 	}
 
 	// Sleep > KeepAlive interval — exercises keep-alive ping path.
-	time.Sleep(3 * time.Second)
+	// Wall-clock time must pass so the KeepAlive timer fires and exercises
+	// the broker heartbeat path; polling does not accelerate KeepAlive.
+	time.Sleep(testtime.D3s) //archtest:allow:test-sleep keep-alive-heartbeat-traversal: wall-clock must elapse for KeepAlive timer to fire
 
 	if err := pub.Publish(ctx, topic, []byte(`{"seq":2}`)); err != nil {
 		t.Fatalf("Publish seq=2 (post keep-alive): %v", err)
@@ -133,7 +139,7 @@ func TestIntegration_PublisherReconnect(t *testing.T) {
 // expect the context deadline to fire immediately, surfacing as
 // ErrAdapterMQTTPubAckTimeout per publisher.go's wrapPublishErr.
 func TestIntegration_PublisherPubAckTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
 	defer cancel()
 
 	cfg := newTestConfig(t, "publish-timeout")
@@ -144,7 +150,7 @@ func TestIntegration_PublisherPubAckTimeout(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
 		defer c()
 		_ = conn.Close(cleanupCtx)
 	})
@@ -158,7 +164,7 @@ func TestIntegration_PublisherPubAckTimeout(t *testing.T) {
 		t.Fatalf("NewPublisher: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
 		defer c()
 		_ = pub.Close(cleanupCtx)
 	})
@@ -177,4 +183,134 @@ func TestIntegration_PublisherPubAckTimeout(t *testing.T) {
 	if ec.Code != ErrAdapterMQTTPubAckTimeout {
 		t.Fatalf("Publish err code = %v, want %v", ec.Code, ErrAdapterMQTTPubAckTimeout)
 	}
+}
+
+// TestIntegration_PublisherTrueReconnect verifies that the autopaho connection
+// fully reconnects after a broker restart: it publishes, stops the broker
+// container, waits for WaitConnected to return after the container restarts,
+// then publishes again successfully.
+func TestIntegration_PublisherTrueReconnect(t *testing.T) {
+	testutil.RequireDocker(t)
+
+	// Bring up a dedicated broker — NOT the shared one — so we can stop/start it.
+	dedicatedURL, container, err := startDedicatedMosquittoContainer(t)
+	if err != nil {
+		t.Fatalf("start dedicated broker: %v", err)
+	}
+	t.Cleanup(func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+		defer cancel()
+		_ = container.Terminate(termCtx)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D60s)
+	defer cancel()
+
+	cid, err := ParseEphemeralClientID("itest", "true-reconnect")
+	if err != nil {
+		t.Fatalf("ParseEphemeralClientID: %v", err)
+	}
+	cfg := Config{
+		ClientID: cid,
+		Brokers:  []string{testutil.LoopbackIPEndpoint(dedicatedURL)},
+		ConnectTimeout: testtime.D5s,
+		KeepAlive:      testtime.D10s,
+		Backoff: BackoffConfig{
+			BaseDelay: testtime.D100ms,
+			MaxDelay:  testtime.D2s,
+		},
+		PublishTimeout: testtime.D5s,
+	}
+
+	conn, err := Open(ctx, clock.Real(), cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
+		defer c()
+		_ = conn.Close(cleanupCtx)
+	})
+
+	ns, err := ParseTopicNamespace("itest")
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	pub, err := NewPublisher(clock.Real(), conn, ns)
+	if err != nil {
+		t.Fatalf("NewPublisher: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), testtime.D5s)
+		defer c()
+		_ = pub.Close(cleanupCtx)
+	})
+
+	topic := "itest/true-reconnect/" + uuid.NewString()
+
+	// seq=1: initial publish — must succeed with broker up.
+	if err := pub.Publish(ctx, topic, []byte(`{"seq":1}`)); err != nil {
+		t.Fatalf("Publish seq=1: %v", err)
+	}
+
+	// Stop the broker — triggers disconnection.
+	stopTimeout := testtime.D10s
+	if err := container.Stop(ctx, &stopTimeout); err != nil {
+		t.Fatalf("container.Stop: %v", err)
+	}
+
+	// Restart the broker container.
+	if err := container.Start(ctx); err != nil {
+		t.Fatalf("container.Start: %v", err)
+	}
+
+	// Wait for autopaho to reconnect.
+	reconnectCtx, reconnectCancel := context.WithTimeout(ctx, testtime.D30s)
+	defer reconnectCancel()
+	if err := conn.WaitConnected(reconnectCtx); err != nil {
+		t.Fatalf("WaitConnected after restart: %v", err)
+	}
+
+	// seq=2: publish after full reconnect — must succeed.
+	if err := pub.Publish(ctx, topic, []byte(`{"seq":2}`)); err != nil {
+		t.Fatalf("Publish seq=2 (post restart): %v", err)
+	}
+}
+
+// startDedicatedMosquittoContainer starts an eclipse-mosquitto container for
+// exclusive use by TestIntegration_PublisherTrueReconnect (stop/start lifecycle).
+func startDedicatedMosquittoContainer(t *testing.T) (string, testcontainers.Container, error) {
+	t.Helper()
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        testutil.MosquittoImage,
+			ExposedPorts: []string{"1883/tcp"},
+			Files: []testcontainers.ContainerFile{
+				{
+					Reader:            strings.NewReader(mosquittoConf),
+					ContainerFilePath: "/mosquitto/config/mosquitto.conf",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForListeningPort("1883/tcp").
+				WithStartupTimeout(testtime.D30s),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return "", nil, err
+	}
+	port, err := container.MappedPort(ctx, "1883/tcp")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return "", nil, err
+	}
+	url := "tcp://" + host + ":" + port.Port()
+	return url, container, nil
 }

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+package mqtt
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/tests/testutil"
+)
+
+// newTestConfig returns a Config valid for connecting to the shared Mosquitto
+// container. The broker URL is normalized via testutil.LoopbackIPEndpoint so
+// that "localhost"-form URLs pass the loopback-IP-literal validator in
+// Config.validateBrokers (secutil.ValidateTLSEndpoint rejects DNS names for
+// plaintext plaintext schemes).
+func newTestConfig(t *testing.T, role string) Config {
+	t.Helper()
+	cid, err := ParseEphemeralClientID("itest", role)
+	if err != nil {
+		t.Fatalf("ParseEphemeralClientID: %v", err)
+	}
+	brokerURL := testutil.LoopbackIPEndpoint(sharedBrokerURL(t))
+	return Config{
+		ClientID:       cid,
+		Brokers:        []string{brokerURL},
+		ConnectTimeout: 5 * time.Second,
+		KeepAlive:      10 * time.Second,
+		Backoff: BackoffConfig{
+			BaseDelay: 100 * time.Millisecond,
+			MaxDelay:  2 * time.Second,
+		},
+		PublishTimeout: 5 * time.Second,
+	}
+}
+
+// TestIntegration_PublisherQoS1 verifies end-to-end publish against a real
+// Mosquitto broker: open connection, construct Publisher, publish a small
+// payload to a valid topic, assert no error returned (broker PUBACK 0x00).
+func TestIntegration_PublisherQoS1(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	cfg := newTestConfig(t, "publish-qos1")
+	conn, err := Open(ctx, clock.Real(), cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = conn.Close(cleanupCtx)
+	})
+
+	ns, err := ParseTopicNamespace("itest")
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	pub, err := NewPublisher(clock.Real(), conn, ns)
+	if err != nil {
+		t.Fatalf("NewPublisher: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = pub.Close(cleanupCtx)
+	})
+
+	topic := "itest/qos1/" + uuid.NewString()
+	if err := pub.Publish(ctx, topic, []byte(`{"hello":"world"}`)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+}
+
+// TestIntegration_PublisherReconnect verifies that after a keep-alive interval
+// passes, the autopaho connection remains healthy and subsequent publishes
+// succeed. We use a short KeepAlive (2s) and sleep > that interval to exercise
+// the keep-alive ping path — the test confirms the connection survives the
+// heartbeat exchange transparently.
+func TestIntegration_PublisherReconnect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg := newTestConfig(t, "publish-reconnect")
+	cfg.KeepAlive = 2 * time.Second // tighter keep-alive for quick failure detection
+
+	conn, err := Open(ctx, clock.Real(), cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = conn.Close(cleanupCtx)
+	})
+
+	ns, err := ParseTopicNamespace("itest")
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	pub, err := NewPublisher(clock.Real(), conn, ns)
+	if err != nil {
+		t.Fatalf("NewPublisher: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = pub.Close(cleanupCtx)
+	})
+
+	topic := "itest/reconnect/" + uuid.NewString()
+	if err := pub.Publish(ctx, topic, []byte(`{"seq":1}`)); err != nil {
+		t.Fatalf("Publish seq=1: %v", err)
+	}
+
+	// Sleep > KeepAlive interval — exercises keep-alive ping path.
+	time.Sleep(3 * time.Second)
+
+	if err := pub.Publish(ctx, topic, []byte(`{"seq":2}`)); err != nil {
+		t.Fatalf("Publish seq=2 (post keep-alive): %v", err)
+	}
+}
+
+// TestIntegration_PublisherPubAckTimeout verifies that when PublishTimeout
+// fires before the broker can respond, the error is classified as PUBACK
+// timeout. We provoke this by setting a very short PublishTimeout (1ns) and
+// expect the context deadline to fire immediately, surfacing as
+// ErrAdapterMQTTPubAckTimeout per publisher.go's wrapPublishErr.
+func TestIntegration_PublisherPubAckTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cfg := newTestConfig(t, "publish-timeout")
+	cfg.PublishTimeout = time.Nanosecond // intentionally fires immediately
+
+	conn, err := Open(ctx, clock.Real(), cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = conn.Close(cleanupCtx)
+	})
+
+	ns, err := ParseTopicNamespace("itest")
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	pub, err := NewPublisher(clock.Real(), conn, ns)
+	if err != nil {
+		t.Fatalf("NewPublisher: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = pub.Close(cleanupCtx)
+	})
+
+	topic := "itest/timeout/" + uuid.NewString()
+	err = pub.Publish(ctx, topic, []byte(`{"x":1}`))
+	if err == nil {
+		t.Fatalf("Publish succeeded; expected ErrAdapterMQTTPubAckTimeout")
+	}
+	// wrapPublishErr maps context.DeadlineExceeded → ErrAdapterMQTTPubAckTimeout
+	// with message "mqtt: PUBACK timeout". Accept any timeout-related text to be
+	// resilient to minor message wording changes.
+	msg := err.Error()
+	if !strings.Contains(msg, "PUBACK") && !strings.Contains(msg, "puback") && !strings.Contains(msg, "timeout") {
+		t.Fatalf("Publish err = %v; want PUBACK timeout-related", err)
+	}
+}

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -5,11 +5,15 @@ package mqtt
 import (
 	"context"
 	"errors"
+	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	dockercontainer "github.com/moby/moby/api/types/container"
+	dockernet "github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -211,8 +215,8 @@ func TestIntegration_PublisherTrueReconnect(t *testing.T) {
 		t.Fatalf("ParseEphemeralClientID: %v", err)
 	}
 	cfg := Config{
-		ClientID: cid,
-		Brokers:  []string{testutil.LoopbackIPEndpoint(dedicatedURL)},
+		ClientID:       cid,
+		Brokers:        []string{testutil.LoopbackIPEndpoint(dedicatedURL)},
 		ConnectTimeout: testtime.D5s,
 		KeepAlive:      testtime.D10s,
 		Backoff: BackoffConfig{
@@ -279,9 +283,24 @@ func TestIntegration_PublisherTrueReconnect(t *testing.T) {
 
 // startDedicatedMosquittoContainer starts an eclipse-mosquitto container for
 // exclusive use by TestIntegration_PublisherTrueReconnect (stop/start lifecycle).
+//
+// The 1883 container port is bound to a FIXED host port via PortBindings rather
+// than the default random ephemeral mapping. This is essential for the reconnect
+// test: a Stop()/Start() restart re-publishes the container's ports, and with a
+// random mapping Docker assigns a NEW host port on restart — leaving the broker
+// URL captured here stale, so autopaho keeps dialing the dead old port and
+// WaitConnected times out. Pinning the host port keeps the endpoint stable
+// across restart so reconnection can actually succeed.
 func startDedicatedMosquittoContainer(t *testing.T) (string, testcontainers.Container, error) {
 	t.Helper()
 	ctx := context.Background()
+
+	hostPort, err := freeLoopbackTCPPort()
+	if err != nil {
+		return "", nil, err
+	}
+	hostPortStr := strconv.Itoa(hostPort)
+
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        testutil.MosquittoImage,
@@ -293,6 +312,13 @@ func startDedicatedMosquittoContainer(t *testing.T) (string, testcontainers.Cont
 					FileMode:          0o644,
 				},
 			},
+			HostConfigModifier: func(hc *dockercontainer.HostConfig) {
+				hc.PortBindings = dockernet.PortMap{
+					dockernet.MustParsePort("1883/tcp"): []dockernet.PortBinding{
+						{HostPort: hostPortStr},
+					},
+				}
+			},
 			WaitingFor: wait.ForListeningPort("1883/tcp").
 				WithStartupTimeout(testtime.D30s),
 		},
@@ -301,16 +327,24 @@ func startDedicatedMosquittoContainer(t *testing.T) (string, testcontainers.Cont
 	if err != nil {
 		return "", nil, err
 	}
-	host, err := container.Host(ctx)
-	if err != nil {
-		_ = container.Terminate(ctx)
-		return "", nil, err
-	}
-	port, err := container.MappedPort(ctx, "1883/tcp")
-	if err != nil {
-		_ = container.Terminate(ctx)
-		return "", nil, err
-	}
-	url := "tcp://" + host + ":" + port.Port()
+	// Endpoint is the pinned host port, stable across Stop()/Start().
+	url := "tcp://127.0.0.1:" + hostPortStr
 	return url, container, nil
+}
+
+// freeLoopbackTCPPort allocates and immediately releases a loopback TCP port,
+// returning its number for use as a fixed container host-port binding. The
+// close-then-rebind window is small and test-binary-scoped (no external
+// competitor for a loopback ephemeral port within one `go test` run) — the same
+// idiom the in-process mochi broker tests use.
+func freeLoopbackTCPPort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if cerr := ln.Close(); cerr != nil {
+		return 0, cerr
+	}
+	return port, nil
 }

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -68,29 +68,42 @@ type PublishFailureReason string
 
 const (
 	// PublishFailurePayloadTooLarge means the message payload exceeded the
-	// broker's or adapter's configured maximum size.
+	// adapter's configured MaximumPacketSize (client-side guard, pre-network).
 	PublishFailurePayloadTooLarge PublishFailureReason = "payload_too_large"
-	// PublishFailureNeverConnected means Publish() was called before the
-	// adapter established its first successful connection.
-	PublishFailureNeverConnected PublishFailureReason = "never_connected"
 	// PublishFailureClosed means Publish() was called after the adapter was
 	// shut down (Close() already called).
 	PublishFailureClosed PublishFailureReason = "closed"
 	// PublishFailurePubAckTimeout means the broker did not send a PUBACK
-	// within the configured deadline (QoS 1 / QoS 2 flows).
+	// within the configured deadline (QoS 1 / QoS 2 flows). A publish issued
+	// before the connection is established surfaces here (or as
+	// context_canceled): autopaho queues the publish until connected, so the
+	// caller observes a deadline, not a distinct "never connected" reason.
 	PublishFailurePubAckTimeout PublishFailureReason = "puback_timeout"
 	// PublishFailureContextCanceled means the caller's context was canceled
 	// or its deadline exceeded before the publish completed.
 	PublishFailureContextCanceled PublishFailureReason = "context_canceled"
-	// PublishFailurePublishError means the underlying MQTT client returned
-	// an error from the publish wire call.
+	// PublishFailurePublishError means the underlying MQTT client returned a
+	// transport-level error from the publish wire call (not a broker PUBACK
+	// reason code).
 	PublishFailurePublishError PublishFailureReason = "publish_error"
 	// PublishFailureTopicOutsideNamespace means the topic was rejected because
 	// it falls outside the adapter's allowed topic namespace.
 	PublishFailureTopicOutsideNamespace PublishFailureReason = "topic_outside_namespace"
-	// PublishFailureRateLimited means the publish attempt was rejected by the
-	// adapter's rate limiter before the message reached the broker.
+	// PublishFailureRateLimited means the broker returned PUBACK 0x97 (Quota
+	// Exceeded) — the publisher is rate-limited.
 	PublishFailureRateLimited PublishFailureReason = "rate_limited"
+	// PublishFailureNotAuthorized means the broker returned PUBACK 0x87 (Not
+	// Authorized) — the publisher's ACL forbids the topic. Retryable after an
+	// operator fixes the broker ACL.
+	PublishFailureNotAuthorized PublishFailureReason = "not_authorized"
+	// PublishFailurePayloadFormatInvalid means the broker returned PUBACK 0x99
+	// (Payload Format Invalid) — the payload violates its declared format/
+	// content-type. Distinct from payload_too_large (size).
+	PublishFailurePayloadFormatInvalid PublishFailureReason = "payload_format_invalid"
+	// PublishFailureRejected means the broker returned a permanent-reject PUBACK
+	// reason code (0x80 Unspecified / 0x83 ImplementationSpecific / 0x90
+	// TopicNameInvalid) — a client-side fix is required before retrying.
+	PublishFailureRejected PublishFailureReason = "rejected"
 )
 
 // PublisherCollector observes publisher-side metrics. Construction-time cellID
@@ -181,9 +194,9 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 	publishFailed, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_publish_failed_total",
 		Help: "Total number of MQTT publish attempts that failed, classified by reason. " +
-			"reason ∈ {payload_too_large, never_connected, closed, puback_timeout, context_canceled, " +
-			"publish_error, topic_outside_namespace, rate_limited} — closed set; alerting rules can rely " +
-			"on the literals. Label: cell = construction-time cell identifier.",
+			"reason ∈ {payload_too_large, closed, puback_timeout, context_canceled, publish_error, " +
+			"topic_outside_namespace, rate_limited, not_authorized, payload_format_invalid, rejected} — " +
+			"closed set; alerting rules can rely on the literals. Label: cell = construction-time cell identifier.",
 		LabelNames: []string{"cell", "reason"},
 	})
 	if err != nil {

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -180,6 +180,17 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 			"mqtt: cellID is required for provider publisher collector")
 	}
 
+	// Register the three metrics with all-or-nothing semantics: if a later
+	// registration fails (e.g. a duplicate metric name), roll back the ones
+	// already registered so the provider is not left holding a partial set.
+	var registered []metrics.Collector
+	rollback := func(wrapErr error) error {
+		for _, c := range registered {
+			_ = p.Unregister(c)
+		}
+		return wrapErr
+	}
+
 	publishTotal, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_publish_total",
 		Help: "Total number of MQTT publish attempts that completed successfully (broker PUBACK received). " +
@@ -187,9 +198,10 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		LabelNames: []string{"cell"},
 	})
 	if err != nil {
-		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register publish total counter", err)
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish total counter", err))
 	}
+	registered = append(registered, publishTotal)
 
 	publishFailed, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_publish_failed_total",
@@ -200,9 +212,10 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		LabelNames: []string{"cell", "reason"},
 	})
 	if err != nil {
-		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register publish failed counter", err)
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish failed counter", err))
 	}
+	registered = append(registered, publishFailed)
 
 	ackDuration, err := p.HistogramVec(metrics.HistogramOpts{
 		Name: "mqtt_publish_ack_duration_seconds",
@@ -213,9 +226,11 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		Buckets:    ackDurationBuckets,
 	})
 	if err != nil {
-		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register publish ack duration histogram", err)
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish ack duration histogram", err))
 	}
+	// ackDuration is the last registration — nothing after it can fail, so it
+	// need not be appended to the rollback set.
 
 	return &providerPublisherCollector{
 		cellID:        cellID,

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -97,6 +97,10 @@ const (
 // becomes the "cell" label value (registration-time enumerated set, NOT derived
 // from request context — per observability.md HTTP metrics cell-label convention).
 //
+// Implementations MUST bind the "cell" label at construction time, NOT
+// from request ctx — per observability.md §HTTP Metrics cell Label
+// (cell = registration-time enumerated owner dimension).
+//
 // Implementations must be safe for concurrent use.
 type PublisherCollector interface {
 	// RecordPublishSuccess increments the success counter and observes the

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"context"
+	"time"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -58,4 +59,164 @@ func NewProviderConnectionCollector(p metrics.Provider, cellID string) (Connecti
 // RecordReconnect increments mqtt_reconnect_total{cell=c.cellID}.
 func (c *providerConnectionCollector) RecordReconnect(ctx context.Context) {
 	c.reconnect.With(metrics.Labels{"cell": c.cellID}).Inc(ctx)
+}
+
+// PublishFailureReason classifies why a Publish() call failed. The set is
+// closed; callers (alerting rules, log queries) can rely on the literals being
+// stable across releases.
+type PublishFailureReason string
+
+const (
+	// PublishFailurePayloadTooLarge means the message payload exceeded the
+	// broker's or adapter's configured maximum size.
+	PublishFailurePayloadTooLarge PublishFailureReason = "payload_too_large"
+	// PublishFailureNeverConnected means Publish() was called before the
+	// adapter established its first successful connection.
+	PublishFailureNeverConnected PublishFailureReason = "never_connected"
+	// PublishFailureClosed means Publish() was called after the adapter was
+	// shut down (Close() already called).
+	PublishFailureClosed PublishFailureReason = "closed"
+	// PublishFailurePubAckTimeout means the broker did not send a PUBACK
+	// within the configured deadline (QoS 1 / QoS 2 flows).
+	PublishFailurePubAckTimeout PublishFailureReason = "puback_timeout"
+	// PublishFailureContextCanceled means the caller's context was canceled
+	// or its deadline exceeded before the publish completed.
+	PublishFailureContextCanceled PublishFailureReason = "context_canceled"
+	// PublishFailurePublishError means the underlying MQTT client returned
+	// an error from the publish wire call.
+	PublishFailurePublishError PublishFailureReason = "publish_error"
+	// PublishFailureTopicOutsideNamespace means the topic was rejected because
+	// it falls outside the adapter's allowed topic namespace.
+	PublishFailureTopicOutsideNamespace PublishFailureReason = "topic_outside_namespace"
+	// PublishFailureRateLimited means the publish attempt was rejected by the
+	// adapter's rate limiter before the message reached the broker.
+	PublishFailureRateLimited PublishFailureReason = "rate_limited"
+)
+
+// PublisherCollector observes publisher-side metrics. Construction-time cellID
+// becomes the "cell" label value (registration-time enumerated set, NOT derived
+// from request context — per observability.md HTTP metrics cell-label convention).
+//
+// Implementations must be safe for concurrent use.
+type PublisherCollector interface {
+	// RecordPublishSuccess increments the success counter and observes the
+	// end-to-end ack round-trip duration for a completed publish.
+	RecordPublishSuccess(ctx context.Context, ackDuration time.Duration)
+	// RecordPublishFailure increments the failure counter for the given reason.
+	// Implementations MUST NOT panic on any reason value; the closed set is
+	// enforced by the call site, not the collector.
+	RecordPublishFailure(ctx context.Context, reason PublishFailureReason)
+}
+
+// NoopPublisherCollector is the default collector used when no observability
+// is wired. Method bodies intentionally empty — registration cost is zero and
+// metric absence is documented behavior, not a fault.
+type NoopPublisherCollector struct{}
+
+// RecordPublishSuccess is a no-op.
+func (NoopPublisherCollector) RecordPublishSuccess(_ context.Context, _ time.Duration) { /* no-op */ }
+
+// RecordPublishFailure is a no-op.
+func (NoopPublisherCollector) RecordPublishFailure(_ context.Context, _ PublishFailureReason) { /* no-op */
+}
+
+// Compile-time interface checks.
+var _ PublisherCollector = NoopPublisherCollector{}
+
+// providerPublisherCollector implements PublisherCollector via a provider-
+// neutral metrics.Provider. Wired at the composition root.
+//
+// Metrics (subsystem=mqtt):
+//
+//	mqtt_publish_total                 (counter,   labels: cell)
+//	mqtt_publish_failed_total          (counter,   labels: cell, reason)
+//	mqtt_publish_ack_duration_seconds  (histogram, labels: cell; buckets 1ms–10s)
+//
+// ref: adapters/rabbitmq/publisher_metrics.go — same inject-at-construction
+// pattern, extended with success counter and ack duration histogram (AC-8).
+type providerPublisherCollector struct {
+	cellID        string
+	publishTotal  metrics.CounterVec
+	publishFailed metrics.CounterVec
+	ackDuration   metrics.HistogramVec
+}
+
+var _ PublisherCollector = (*providerPublisherCollector)(nil)
+
+// ackDurationBuckets covers MQTT publish ack round-trip times from 1 ms to
+// 10 s, matching a standard Prometheus default-ish bucket set oriented to
+// network-latency distributions.
+var ackDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// NewProviderPublisherCollector registers 3 metrics on p and returns a
+// PublisherCollector bound to cellID. cellID becomes the "cell" label value.
+//
+// Returns an error when p is nil, cellID is empty, or the Provider reports a
+// registration failure (e.g. duplicate metric names).
+func NewProviderPublisherCollector(p metrics.Provider, cellID string) (PublisherCollector, error) {
+	if p == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: metrics.Provider is required")
+	}
+	if cellID == "" {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: cellID is required for provider publisher collector")
+	}
+
+	publishTotal, err := p.CounterVec(metrics.CounterOpts{
+		Name: "mqtt_publish_total",
+		Help: "Total number of MQTT publish attempts that completed successfully (broker PUBACK received). " +
+			"Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).",
+		LabelNames: []string{"cell"},
+	})
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish total counter", err)
+	}
+
+	publishFailed, err := p.CounterVec(metrics.CounterOpts{
+		Name: "mqtt_publish_failed_total",
+		Help: "Total number of MQTT publish attempts that failed, classified by reason. " +
+			"reason ∈ {payload_too_large, never_connected, closed, puback_timeout, context_canceled, " +
+			"publish_error, topic_outside_namespace, rate_limited} — closed set; alerting rules can rely " +
+			"on the literals. Label: cell = construction-time cell identifier.",
+		LabelNames: []string{"cell", "reason"},
+	})
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish failed counter", err)
+	}
+
+	ackDuration, err := p.HistogramVec(metrics.HistogramOpts{
+		Name: "mqtt_publish_ack_duration_seconds",
+		Help: "End-to-end MQTT publish ack round-trip duration in seconds, from Publish() call to broker PUBACK. " +
+			"Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. " +
+			"Label: cell = construction-time cell identifier.",
+		LabelNames: []string{"cell"},
+		Buckets:    ackDurationBuckets,
+	})
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish ack duration histogram", err)
+	}
+
+	return &providerPublisherCollector{
+		cellID:        cellID,
+		publishTotal:  publishTotal,
+		publishFailed: publishFailed,
+		ackDuration:   ackDuration,
+	}, nil
+}
+
+// RecordPublishSuccess increments mqtt_publish_total{cell} and observes
+// mqtt_publish_ack_duration_seconds{cell} = ackDuration.Seconds().
+func (c *providerPublisherCollector) RecordPublishSuccess(ctx context.Context, ackDuration time.Duration) {
+	c.publishTotal.With(metrics.Labels{"cell": c.cellID}).Inc(ctx)
+	c.ackDuration.With(metrics.Labels{"cell": c.cellID}).Observe(ctx, ackDuration.Seconds())
+}
+
+// RecordPublishFailure increments mqtt_publish_failed_total{cell, reason}.
+// mqtt_publish_total is NOT incremented — failure is not counted as success.
+func (c *providerPublisherCollector) RecordPublishFailure(ctx context.Context, reason PublishFailureReason) {
+	c.publishFailed.With(metrics.Labels{"cell": c.cellID, "reason": string(reason)}).Inc(ctx)
 }

--- a/adapters/mqtt/metrics_test.go
+++ b/adapters/mqtt/metrics_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 // TestNewProviderConnectionCollector_RejectsNilProvider verifies nil provider is
@@ -225,7 +225,7 @@ func TestProviderPublisherCollector_RecordPublishSuccess(t *testing.T) {
 	col, err := NewProviderPublisherCollector(spy, "testcell")
 	require.NoError(t, err)
 
-	col.RecordPublishSuccess(context.Background(), 25*time.Millisecond)
+	col.RecordPublishSuccess(context.Background(), testtime.D25ms)
 
 	ops := spy.ops()
 	// Expect: one Inc on publish_total and one Observe on ack_duration
@@ -288,7 +288,7 @@ func TestNoopPublisherCollector_Methods(t *testing.T) {
 	t.Parallel()
 	col := NoopPublisherCollector{}
 	assert.NotPanics(t, func() {
-		col.RecordPublishSuccess(context.Background(), 10*time.Millisecond)
+		col.RecordPublishSuccess(context.Background(), testtime.D10ms)
 		col.RecordPublishFailure(context.Background(), PublishFailureClosed)
 	})
 }

--- a/adapters/mqtt/metrics_test.go
+++ b/adapters/mqtt/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,5 +175,217 @@ func (c *connSpyCounter) Inc(_ context.Context) {
 func (c *connSpyCounter) Add(_ context.Context, d float64) {
 	c.parent.records = append(c.parent.records, connSpyRecord{
 		name: c.name, op: "Add", labels: c.labels, value: d,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Publisher metrics tests
+// ---------------------------------------------------------------------------
+
+// Compile-time interface check — kept here so the file fails to build if the
+// interface shape diverges.
+var _ PublisherCollector = (*providerPublisherCollector)(nil)
+
+// TestNewProviderPublisherCollector_NilProvider verifies nil provider returns
+// an errcode.Error (KindInternal).
+func TestNewProviderPublisherCollector_NilProvider(t *testing.T) {
+	t.Parallel()
+	_, err := NewProviderPublisherCollector(nil, "testcell")
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, errcode.KindInternal, ec.Kind)
+}
+
+// TestNewProviderPublisherCollector_EmptyCellID verifies empty cellID returns
+// an errcode.Error (KindInternal).
+func TestNewProviderPublisherCollector_EmptyCellID(t *testing.T) {
+	t.Parallel()
+	_, err := NewProviderPublisherCollector(metrics.NopProvider{}, "")
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, errcode.KindInternal, ec.Kind)
+}
+
+// TestNewProviderPublisherCollector_Registration verifies happy-path returns
+// non-nil collector with no error.
+func TestNewProviderPublisherCollector_Registration(t *testing.T) {
+	t.Parallel()
+	col, err := NewProviderPublisherCollector(metrics.NopProvider{}, "testcell")
+	require.NoError(t, err)
+	require.NotNil(t, col)
+}
+
+// TestProviderPublisherCollector_RecordPublishSuccess verifies that a success
+// call increments mqtt_publish_total and observes mqtt_publish_ack_duration_seconds.
+func TestProviderPublisherCollector_RecordPublishSuccess(t *testing.T) {
+	t.Parallel()
+	spy := newPubSpyProvider()
+	col, err := NewProviderPublisherCollector(spy, "testcell")
+	require.NoError(t, err)
+
+	col.RecordPublishSuccess(context.Background(), 25*time.Millisecond)
+
+	ops := spy.ops()
+	// Expect: one Inc on publish_total and one Observe on ack_duration
+	var foundTotal, foundDuration bool
+	for _, op := range ops {
+		switch {
+		case op.name == "mqtt_publish_total" && op.op == "Inc":
+			assert.Equal(t, "testcell", op.labels["cell"])
+			foundTotal = true
+		case op.name == "mqtt_publish_ack_duration_seconds" && op.op == "Observe":
+			assert.Equal(t, "testcell", op.labels["cell"])
+			assert.InDelta(t, 0.025, op.value, 1e-9)
+			foundDuration = true
+		}
+	}
+	assert.True(t, foundTotal, "mqtt_publish_total Inc not found in spy ops")
+	assert.True(t, foundDuration, "mqtt_publish_ack_duration_seconds Observe not found in spy ops")
+}
+
+// TestProviderPublisherCollector_RecordPublishFailure verifies all 8 reason
+// consts increment mqtt_publish_failed_total with the correct reason label.
+func TestProviderPublisherCollector_RecordPublishFailure(t *testing.T) {
+	t.Parallel()
+	allReasons := []PublishFailureReason{
+		PublishFailurePayloadTooLarge,
+		PublishFailureNeverConnected,
+		PublishFailureClosed,
+		PublishFailurePubAckTimeout,
+		PublishFailureContextCanceled,
+		PublishFailurePublishError,
+		PublishFailureTopicOutsideNamespace,
+		PublishFailureRateLimited,
+	}
+	for _, reason := range allReasons {
+		reason := reason
+		t.Run(string(reason), func(t *testing.T) {
+			t.Parallel()
+			spy := newPubSpyProvider()
+			col, err := NewProviderPublisherCollector(spy, "testcell")
+			require.NoError(t, err)
+
+			col.RecordPublishFailure(context.Background(), reason)
+
+			ops := spy.ops()
+			var found bool
+			for _, op := range ops {
+				if op.name == "mqtt_publish_failed_total" && op.op == "Inc" {
+					assert.Equal(t, "testcell", op.labels["cell"])
+					assert.Equal(t, string(reason), op.labels["reason"])
+					found = true
+				}
+			}
+			assert.True(t, found, "mqtt_publish_failed_total Inc not found for reason %s", reason)
+		})
+	}
+}
+
+// TestNoopPublisherCollector_Methods verifies NoopPublisherCollector does not panic.
+func TestNoopPublisherCollector_Methods(t *testing.T) {
+	t.Parallel()
+	col := NoopPublisherCollector{}
+	assert.NotPanics(t, func() {
+		col.RecordPublishSuccess(context.Background(), 10*time.Millisecond)
+		col.RecordPublishFailure(context.Background(), PublishFailureClosed)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Publisher test doubles
+// ---------------------------------------------------------------------------
+
+type pubSpyRecord struct {
+	name   string
+	op     string
+	labels metrics.Labels
+	value  float64
+}
+
+type pubSpyProvider struct {
+	counterRegs   []metrics.CounterOpts
+	histogramRegs []metrics.HistogramOpts
+	records       []pubSpyRecord
+}
+
+func newPubSpyProvider() *pubSpyProvider { return &pubSpyProvider{} }
+
+func (p *pubSpyProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
+	p.counterRegs = append(p.counterRegs, opts)
+	return &pubSpyCounterVec{parent: p, name: opts.Name, labelNames: opts.LabelNames}, nil
+}
+
+func (p *pubSpyProvider) HistogramVec(opts metrics.HistogramOpts) (metrics.HistogramVec, error) {
+	p.histogramRegs = append(p.histogramRegs, opts)
+	return &pubSpyHistogramVec{parent: p, name: opts.Name, labelNames: opts.LabelNames}, nil
+}
+
+func (p *pubSpyProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
+	return metrics.NopProvider{}.GaugeVec(metrics.GaugeOpts{})
+}
+
+func (p *pubSpyProvider) Unregister(_ metrics.Collector) error { return nil }
+
+func (p *pubSpyProvider) ops() []pubSpyRecord {
+	out := make([]pubSpyRecord, len(p.records))
+	copy(out, p.records)
+	return out
+}
+
+type pubSpyCounterVec struct {
+	parent     *pubSpyProvider
+	name       string
+	labelNames []string
+}
+
+func (v *pubSpyCounterVec) Registered() bool { return true }
+
+func (v *pubSpyCounterVec) With(l metrics.Labels) metrics.Counter {
+	metrics.MustValidateLabels(v.labelNames, l)
+	return &pubSpyCounter{parent: v.parent, name: v.name, labels: l}
+}
+
+type pubSpyCounter struct {
+	parent *pubSpyProvider
+	name   string
+	labels metrics.Labels
+}
+
+func (c *pubSpyCounter) Inc(_ context.Context) {
+	c.parent.records = append(c.parent.records, pubSpyRecord{
+		name: c.name, op: "Inc", labels: c.labels, value: 1,
+	})
+}
+
+func (c *pubSpyCounter) Add(_ context.Context, d float64) {
+	c.parent.records = append(c.parent.records, pubSpyRecord{
+		name: c.name, op: "Add", labels: c.labels, value: d,
+	})
+}
+
+type pubSpyHistogramVec struct {
+	parent     *pubSpyProvider
+	name       string
+	labelNames []string
+}
+
+func (v *pubSpyHistogramVec) Registered() bool { return true }
+
+func (v *pubSpyHistogramVec) With(l metrics.Labels) metrics.Histogram {
+	metrics.MustValidateLabels(v.labelNames, l)
+	return &pubSpyHistogram{parent: v.parent, name: v.name, labels: l}
+}
+
+type pubSpyHistogram struct {
+	parent *pubSpyProvider
+	name   string
+	labels metrics.Labels
+}
+
+func (h *pubSpyHistogram) Observe(_ context.Context, val float64) {
+	h.parent.records = append(h.parent.records, pubSpyRecord{
+		name: h.name, op: "Observe", labels: h.labels, value: val,
 	})
 }

--- a/adapters/mqtt/metrics_test.go
+++ b/adapters/mqtt/metrics_test.go
@@ -245,19 +245,21 @@ func TestProviderPublisherCollector_RecordPublishSuccess(t *testing.T) {
 	assert.True(t, foundDuration, "mqtt_publish_ack_duration_seconds Observe not found in spy ops")
 }
 
-// TestProviderPublisherCollector_RecordPublishFailure verifies all 8 reason
+// TestProviderPublisherCollector_RecordPublishFailure verifies all 10 reason
 // consts increment mqtt_publish_failed_total with the correct reason label.
 func TestProviderPublisherCollector_RecordPublishFailure(t *testing.T) {
 	t.Parallel()
 	allReasons := []PublishFailureReason{
 		PublishFailurePayloadTooLarge,
-		PublishFailureNeverConnected,
 		PublishFailureClosed,
 		PublishFailurePubAckTimeout,
 		PublishFailureContextCanceled,
 		PublishFailurePublishError,
 		PublishFailureTopicOutsideNamespace,
 		PublishFailureRateLimited,
+		PublishFailureNotAuthorized,
+		PublishFailurePayloadFormatInvalid,
+		PublishFailureRejected,
 	}
 	for _, reason := range allReasons {
 		reason := reason

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/eclipse/paho.golang/paho"
+
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -150,43 +152,62 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 	start := p.clk.Now()
 	resp, err := p.conn.Publish(publishCtx, t, payload, publishOpts{QoS: 1, Retain: false})
 	if err != nil {
-		reason := classifyPublishErr(publishCtx, err)
-		p.collector.RecordPublishFailure(ctx, reason)
-		return wrapPublishErr(err)
+		return p.handlePublishError(ctx, publishCtx, resp, err)
 	}
 
-	// Inspect PUBACK reason code. The outer guard (ReasonCode != 0x00) means
-	// classifyPubackReason never returns the empty Success code here, so no
-	// `code != ""` check is needed — only 0x10 NoMatchingSubscribers is the
-	// non-error case to skip.
-	if resp != nil && resp.ReasonCode != 0x00 {
-		code, kind := classifyPubackReason(resp.ReasonCode)
-		if code != ErrAdapterMQTTPublishNoSubscribers {
-			// Rejected / RateLimited / NotAuthorized / PayloadFormatInvalid path —
-			// record failure + return wrapped error.
-			reason := pubackReasonToMetric(code)
-			p.collector.RecordPublishFailure(ctx, reason)
-			return errcode.New(kind, code,
-				"mqtt: broker returned non-success PUBACK reason code",
-				errcode.WithDetails(
-					errcode.PublicInt("reasonCode", int(resp.ReasonCode)),
-					errcode.PublicString("reasonName", pubackReasonName(resp.ReasonCode)),
-				))
-		}
-		// 0x10 NoMatchingSubscribers is informational: count as success, but warn
-		// for operator visibility (device-not-yet-online scenario). topic is the
-		// operator's actionable field here; it may carry device/tenant identifiers
-		// in IoT deployments — configure slog handler redaction if that is a
-		// concern for the target sink.
-		if resp.ReasonCode == 0x10 {
-			slog.Warn("mqtt: publish succeeded with no matching subscribers",
-				slog.String("client_id", p.conn.cfg.ClientID.String()),
-				slog.String("topic", t.String()))
-		}
+	// Success path. paho returns a nil error ONLY for PUBACK reason codes < 0x80
+	// (paho/client.go:923): 0x00 Success and 0x10 NoMatchingSubscribers. Reason
+	// codes >= 0x80 (rejected / not-authorized / quota / payload-format) arrive
+	// via the error branch above — handlePublishError classifies them. 0x10 is
+	// informational: counted as success with an operator warning.
+	//
+	// topic is the operator's actionable field here; it may carry device/tenant
+	// identifiers in IoT deployments — configure slog handler redaction if that
+	// is a concern for the target sink.
+	if resp != nil && resp.ReasonCode == 0x10 {
+		slog.Warn("mqtt: publish succeeded with no matching subscribers",
+			slog.String("client_id", p.conn.cfg.ClientID.String()),
+			slog.String("topic", t.String()))
 	}
-
 	p.collector.RecordPublishSuccess(ctx, p.clk.Since(start))
 	return nil
+}
+
+// handlePublishError classifies the non-nil error returned by Connection.Publish.
+// paho multiplexes three distinct failure shapes through this single error, and
+// each must map to a different errcode/metric:
+//
+//  1. Broker-rejected PUBACK (reason >= 0x80): paho returns BOTH a non-nil resp
+//     (with resp.ReasonCode set) AND a non-nil error (paho/client.go:923). This
+//     is the ONLY path on which the broker's reason code reaches us — it is NOT
+//     surfaced via a nil-error resp — so classifyPubackReason MUST be driven from
+//     here, not from the success branch.
+//  2. Adapter-closed (resp == nil, err is ErrAdapterMQTTClosed): preserve the
+//     closed semantics rather than flattening to a generic publish failure.
+//  3. Deadline / cancel / transport (resp == nil): classifyPublishErr +
+//     wrapPublishErr distinguish caller-ctx cancel, adapter PublishTimeout, and
+//     generic transport errors.
+func (p *Publisher) handlePublishError(ctx, publishCtx context.Context, resp *paho.PublishResponse, err error) error {
+	// (1) Broker-rejected PUBACK reason code (>= 0x80).
+	if resp != nil && resp.ReasonCode >= 0x80 {
+		code, kind := classifyPubackReason(resp.ReasonCode)
+		p.collector.RecordPublishFailure(ctx, pubackReasonToMetric(code))
+		return errcode.New(kind, code,
+			"mqtt: broker returned non-success PUBACK reason code",
+			errcode.WithDetails(
+				errcode.PublicInt("reasonCode", int(resp.ReasonCode)),
+				errcode.PublicString("reasonName", pubackReasonName(resp.ReasonCode)),
+			))
+	}
+	// (2) Adapter closed — preserve the closed errcode rather than wrapping it.
+	var ec *errcode.Error
+	if errors.As(err, &ec) && ec.Code == ErrAdapterMQTTClosed {
+		p.collector.RecordPublishFailure(ctx, PublishFailureClosed)
+		return err
+	}
+	// (3) Deadline / cancel / transport.
+	p.collector.RecordPublishFailure(ctx, classifyPublishErr(ctx, publishCtx, err))
+	return wrapPublishErr(ctx, publishCtx, err)
 }
 
 // Close drains in-flight publishes and marks the publisher closed. It does NOT
@@ -214,9 +235,21 @@ func (p *Publisher) Close(ctx context.Context) error {
 	}
 }
 
-// classifyPublishErr maps a transport-level error from autopaho into a
-// PublishFailureReason metric label.
-func classifyPublishErr(publishCtx context.Context, err error) PublishFailureReason {
+// classifyPublishErr maps a non-PUBACK error into a PublishFailureReason metric
+// label, distinguishing the caller's own context from the adapter-derived
+// PublishTimeout child context:
+//
+//   - callerCtx already done (deadline or cancel) → context_canceled: the caller
+//     drove the abort, not the adapter's budget.
+//   - only the adapter PublishTimeout child fired (callerCtx alive) → puback_timeout.
+//   - neither ctx involved → publish_error (transport).
+//
+// When Config.PublishTimeout == 0, publishCtx == callerCtx, so the first branch
+// owns every deadline/cancel and puback_timeout is never (mis)reported.
+func classifyPublishErr(callerCtx, publishCtx context.Context, err error) PublishFailureReason {
+	if callerCtx.Err() != nil {
+		return PublishFailureContextCanceled
+	}
 	if publishCtx.Err() == context.DeadlineExceeded {
 		return PublishFailurePubAckTimeout
 	}
@@ -226,16 +259,21 @@ func classifyPublishErr(publishCtx context.Context, err error) PublishFailureRea
 	return PublishFailurePublishError
 }
 
-// wrapPublishErr wraps an autopaho transport error into an errcode.
-// Distinguishes PUBACK timeout, context-cancel, and generic publish failure.
-func wrapPublishErr(err error) error {
-	if errors.Is(err, context.DeadlineExceeded) {
-		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPubAckTimeout,
-			"mqtt: PUBACK timeout", err)
-	}
-	if errors.Is(err, context.Canceled) {
+// wrapPublishErr wraps a non-PUBACK error into an errcode, mirroring
+// classifyPublishErr's caller-vs-adapter-timeout distinction so the returned
+// errcode and the recorded metric reason always agree:
+//
+//   - caller ctx canceled/expired → ErrAdapterMQTTPublishCanceled
+//   - adapter PublishTimeout budget exhausted → ErrAdapterMQTTPubAckTimeout
+//   - generic transport failure → ErrAdapterMQTTPublishFailed
+func wrapPublishErr(callerCtx, publishCtx context.Context, err error) error {
+	if callerCtx.Err() != nil {
 		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishCanceled,
-			"mqtt: publish context canceled", err)
+			"mqtt: publish canceled by caller context", err)
+	}
+	if publishCtx.Err() == context.DeadlineExceeded {
+		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPubAckTimeout,
+			"mqtt: PUBACK timeout (adapter PublishTimeout budget exceeded)", err)
 	}
 	return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishFailed,
 		"mqtt: publish failed", err)

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -276,7 +276,7 @@ func wrapPublishErr(callerCtx, publishCtx context.Context, err error) error {
 			"mqtt: PUBACK timeout (adapter PublishTimeout budget exceeded)", err)
 	}
 	return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishFailed,
-		"mqtt: publish failed", err)
+		"mqtt: publish failed", redactErr(err))
 }
 
 // pubackReasonToMetric maps an errcode.Code (from classifyPubackReason) to a

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -61,6 +61,13 @@ func WithPublisherCollector(c PublisherCollector) PublisherOption {
 //
 // Returns error if conn is nil or ns is the zero-value namespace (which would
 // fail every Mint).
+//
+// Signature note: unlike adapters/rabbitmq.NewPublisher (which returns *Publisher
+// and panics via clock.MustHaveClock on a nil clock), this constructor returns
+// (*Publisher, error). The difference is deliberate: a nil clock is a programmer
+// error (panic, same as rabbitmq), but a nil Connection / zero TopicNamespace are
+// caller-supplied runtime values validated into a returned error so the bootstrap
+// wiring path can surface them as structured diagnostics rather than crashing.
 func NewPublisher(clk clock.Clock, conn *Connection, ns TopicNamespace, opts ...PublisherOption) (*Publisher, error) {
 	clock.MustHaveClock(clk, "mqtt.NewPublisher")
 	if conn == nil {
@@ -148,11 +155,15 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 		return wrapPublishErr(err)
 	}
 
-	// Inspect PUBACK reason code.
+	// Inspect PUBACK reason code. The outer guard (ReasonCode != 0x00) means
+	// classifyPubackReason never returns the empty Success code here, so no
+	// `code != ""` check is needed — only 0x10 NoMatchingSubscribers is the
+	// non-error case to skip.
 	if resp != nil && resp.ReasonCode != 0x00 {
 		code, kind := classifyPubackReason(resp.ReasonCode)
-		if code != "" && code != ErrAdapterMQTTPublishNoSubscribers {
-			// Rejected / RateLimited path — record failure + return wrapped error.
+		if code != ErrAdapterMQTTPublishNoSubscribers {
+			// Rejected / RateLimited / NotAuthorized / PayloadFormatInvalid path —
+			// record failure + return wrapped error.
 			reason := pubackReasonToMetric(code)
 			p.collector.RecordPublishFailure(ctx, reason)
 			return errcode.New(kind, code,
@@ -163,9 +174,13 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 				))
 		}
 		// 0x10 NoMatchingSubscribers is informational: count as success, but warn
-		// for operator visibility (device-not-yet-online scenario).
+		// for operator visibility (device-not-yet-online scenario). topic is the
+		// operator's actionable field here; it may carry device/tenant identifiers
+		// in IoT deployments — configure slog handler redaction if that is a
+		// concern for the target sink.
 		if resp.ReasonCode == 0x10 {
 			slog.Warn("mqtt: publish succeeded with no matching subscribers",
+				slog.String("client_id", p.conn.cfg.ClientID.String()),
 				slog.String("topic", t.String()))
 		}
 	}
@@ -227,7 +242,8 @@ func wrapPublishErr(err error) error {
 }
 
 // pubackReasonToMetric maps an errcode.Code (from classifyPubackReason) to a
-// PublishFailureReason metric label.
+// PublishFailureReason metric label, keeping the errcode↔metric mapping coherent
+// (each distinct PUBACK errcode → a distinct, actionable metric reason).
 //
 // Caller MUST pre-filter ErrAdapterMQTTPublishNoSubscribers — that code is
 // treated as success path (0x10 NoMatchingSubscribers) and never reaches this
@@ -236,8 +252,12 @@ func pubackReasonToMetric(code errcode.Code) PublishFailureReason {
 	switch code {
 	case ErrAdapterMQTTPublishRateLimited:
 		return PublishFailureRateLimited
-	case ErrAdapterMQTTPayloadTooLarge:
-		return PublishFailurePayloadTooLarge
+	case ErrAdapterMQTTPublishNotAuthorized:
+		return PublishFailureNotAuthorized
+	case ErrAdapterMQTTPublishPayloadFormatInvalid:
+		return PublishFailurePayloadFormatInvalid
+	case ErrAdapterMQTTPublishRejected:
+		return PublishFailureRejected
 	default:
 		return PublishFailurePublishError
 	}

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -1,0 +1,225 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// Compile-time interface assertion.
+var _ outbox.Publisher = (*Publisher)(nil)
+
+// Publisher implements kernel/outbox.Publisher for MQTT v5 brokers.
+//
+// Each Publisher is bound to one TopicNamespace and one Connection; Publish
+// calls Mint(topic) → conn.Publish, classifies the PUBACK reason code, and
+// reports metrics through the injected PublisherCollector.
+//
+// Concurrency: Publish is safe to call concurrently. Close drains in-flight
+// publishes via a WaitGroup but does NOT close the Connection — the
+// Connection lifecycle is owned by bootstrap and may be shared across multiple
+// publishers in future PRs (e.g., DLT publisher in PR-4).
+//
+// ref: adapters/rabbitmq/publisher.go closed-guard pattern (Mutex + atomic.Bool + WaitGroup).
+type Publisher struct {
+	clk       clock.Clock
+	conn      *Connection
+	ns        TopicNamespace
+	collector PublisherCollector
+
+	publishTimeout time.Duration
+
+	mu     sync.Mutex
+	closed atomic.Bool
+	wg     sync.WaitGroup
+}
+
+// PublisherOption configures optional behavior of a Publisher.
+type PublisherOption func(*Publisher)
+
+// WithPublisherCollector injects a PublisherCollector that records publish-side
+// metrics. Default is NoopPublisherCollector.
+func WithPublisherCollector(c PublisherCollector) PublisherOption {
+	return func(p *Publisher) {
+		if c != nil {
+			p.collector = c
+		}
+	}
+}
+
+// NewPublisher constructs a Publisher bound to conn and ns. clk is a required
+// positional parameter (CLOCK-POSITIONAL-INJECTION-01). The publish-timeout
+// budget comes from conn.cfg.PublishTimeout — 0 means no adapter timeout (the
+// caller-provided ctx deadline is honored as-is).
+//
+// Returns error if conn is nil or ns is the zero-value namespace (which would
+// fail every Mint).
+func NewPublisher(clk clock.Clock, conn *Connection, ns TopicNamespace, opts ...PublisherOption) (*Publisher, error) {
+	clock.MustHaveClock(clk, "mqtt.NewPublisher")
+	if conn == nil {
+		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTInvalidConfig,
+			"mqtt: NewPublisher requires non-nil Connection")
+	}
+	if ns.String() == "" {
+		return nil, errcode.New(errcode.KindInvalid, ErrAdapterMQTTInvalidTopicNamespace,
+			"mqtt: NewPublisher requires non-zero TopicNamespace")
+	}
+	p := &Publisher{
+		clk:            clk,
+		conn:           conn,
+		ns:             ns,
+		collector:      NoopPublisherCollector{},
+		publishTimeout: conn.cfg.PublishTimeout,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p, nil
+}
+
+// Publish satisfies outbox.Publisher. It validates topic against the publisher's
+// TopicNamespace via Mint, derives a child ctx with PublishTimeout if non-zero,
+// calls Connection.Publish (QoS 1 by default), and classifies the response.
+//
+// Records:
+//   - PublishFailure{reason} on every failure path
+//   - PublishSuccess(ackDuration) on successful PUBACK
+func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) error {
+	p.mu.Lock()
+	if p.closed.Load() {
+		p.mu.Unlock()
+		p.collector.RecordPublishFailure(ctx, PublishFailureClosed)
+		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
+			"mqtt: publisher is closed")
+	}
+	p.wg.Add(1)
+	p.mu.Unlock()
+	defer p.wg.Done()
+
+	// Type funnel: Mint enforces PublishOK precedence.
+	t, err := p.ns.Mint(topic)
+	if err != nil {
+		p.collector.RecordPublishFailure(ctx, PublishFailureTopicOutsideNamespace)
+		return err
+	}
+
+	// Payload size enforcement (per Config.MaximumPacketSize when non-zero).
+	// Compare as int64 to avoid G115 integer overflow: len(payload) fits int64,
+	// and MaximumPacketSize is uint32 (max 2^32-1), both representable in int64.
+	if max := p.conn.cfg.MaximumPacketSize; max > 0 && int64(len(payload)) > int64(max) {
+		p.collector.RecordPublishFailure(ctx, PublishFailurePayloadTooLarge)
+		return errcode.New(errcode.KindInvalid, ErrAdapterMQTTPayloadTooLarge,
+			"mqtt: payload exceeds maximum packet size",
+			errcode.WithDetails(
+				errcode.PublicInt("size", len(payload)),
+				errcode.PublicInt("max", int(max)),
+			))
+	}
+
+	// Derive per-publish timeout if configured.
+	publishCtx := ctx
+	if p.publishTimeout > 0 {
+		var cancel context.CancelFunc
+		publishCtx, cancel = context.WithTimeout(ctx, p.publishTimeout)
+		defer cancel()
+	}
+
+	start := p.clk.Now()
+	resp, err := p.conn.Publish(publishCtx, t, payload, publishOpts{QoS: 1, Retain: false})
+	if err != nil {
+		reason := classifyPublishErr(publishCtx, err)
+		p.collector.RecordPublishFailure(ctx, reason)
+		return wrapPublishErr(err)
+	}
+
+	// Inspect PUBACK reason code.
+	if resp != nil && resp.ReasonCode != 0x00 {
+		code, kind := classifyPubackReason(resp.ReasonCode)
+		if code != "" && code != ErrAdapterMQTTPublishNoSubscribers {
+			// Rejected / RateLimited path — record failure + return wrapped error.
+			reason := pubackReasonToMetric(code)
+			p.collector.RecordPublishFailure(ctx, reason)
+			return errcode.New(kind, code,
+				"mqtt: broker returned non-success PUBACK reason code",
+				errcode.WithDetails(
+					errcode.PublicInt("reasonCode", int(resp.ReasonCode)),
+					errcode.PublicString("reasonName", pubackReasonName(resp.ReasonCode)),
+				))
+		}
+		// 0x10 NoMatchingSubscribers is informational: count as success.
+	}
+
+	p.collector.RecordPublishSuccess(ctx, p.clk.Since(start))
+	return nil
+}
+
+// Close drains in-flight publishes and marks the publisher closed. It does NOT
+// close the underlying Connection (lifecycle owned by bootstrap). Idempotent.
+func (p *Publisher) Close(ctx context.Context) error {
+	p.mu.Lock()
+	if p.closed.Load() {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed.Store(true)
+	p.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPubAckTimeout,
+			"mqtt: publisher Close timed out waiting for in-flight publishes", ctx.Err())
+	}
+}
+
+// classifyPublishErr maps a transport-level error from autopaho into a
+// PublishFailureReason metric label.
+func classifyPublishErr(publishCtx context.Context, err error) PublishFailureReason {
+	if publishCtx.Err() == context.DeadlineExceeded {
+		return PublishFailurePubAckTimeout
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return PublishFailureContextCanceled
+	}
+	return PublishFailurePublishError
+}
+
+// wrapPublishErr wraps an autopaho transport error into an errcode.
+// Distinguishes context-cancel/timeout from generic publish failure.
+func wrapPublishErr(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPubAckTimeout,
+			"mqtt: PUBACK timeout", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTConnect,
+			"mqtt: publish context canceled", err)
+	}
+	return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTConnect,
+		"mqtt: publish failed", err)
+}
+
+// pubackReasonToMetric maps an errcode.Code (from classifyPubackReason) to a
+// PublishFailureReason metric label.
+func pubackReasonToMetric(code errcode.Code) PublishFailureReason {
+	switch code {
+	case ErrAdapterMQTTPublishRateLimited:
+		return PublishFailureRateLimited
+	case ErrAdapterMQTTPayloadTooLarge:
+		return PublishFailurePayloadTooLarge
+	default:
+		return PublishFailurePublishError
+	}
+}

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -85,11 +86,20 @@ func NewPublisher(clk clock.Clock, conn *Connection, ns TopicNamespace, opts ...
 
 // Publish satisfies outbox.Publisher. It validates topic against the publisher's
 // TopicNamespace via Mint, derives a child ctx with PublishTimeout if non-zero,
-// calls Connection.Publish (QoS 1 by default), and classifies the response.
+// calls Connection.Publish, and classifies the response.
+//
+// QoS 1 is used for every publish (caller cannot override).
+//
+// PublishTimeout: when Config.PublishTimeout > 0, a child ctx with that deadline
+// is derived; when 0, the caller-provided ctx is honored as-is.
+//
+// PUBACK 0x10 (NoMatchingSubscribers) is treated as success — counted in
+// mqtt_publish_total and ack_duration, with an additional slog.Warn for operator
+// visibility. No error is returned.
 //
 // Records:
 //   - PublishFailure{reason} on every failure path
-//   - PublishSuccess(ackDuration) on successful PUBACK
+//   - PublishSuccess(ackDuration) on successful PUBACK (including 0x10)
 func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) error {
 	p.mu.Lock()
 	if p.closed.Load() {
@@ -152,7 +162,12 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 					errcode.PublicString("reasonName", pubackReasonName(resp.ReasonCode)),
 				))
 		}
-		// 0x10 NoMatchingSubscribers is informational: count as success.
+		// 0x10 NoMatchingSubscribers is informational: count as success, but warn
+		// for operator visibility (device-not-yet-online scenario).
+		if resp.ReasonCode == 0x10 {
+			slog.Warn("mqtt: publish succeeded with no matching subscribers",
+				slog.String("topic", t.String()))
+		}
 	}
 
 	p.collector.RecordPublishSuccess(ctx, p.clk.Since(start))
@@ -179,7 +194,7 @@ func (p *Publisher) Close(ctx context.Context) error {
 	case <-done:
 		return nil
 	case <-ctx.Done():
-		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPubAckTimeout,
+		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublisherCloseTimeout,
 			"mqtt: publisher Close timed out waiting for in-flight publishes", ctx.Err())
 	}
 }
@@ -197,22 +212,26 @@ func classifyPublishErr(publishCtx context.Context, err error) PublishFailureRea
 }
 
 // wrapPublishErr wraps an autopaho transport error into an errcode.
-// Distinguishes context-cancel/timeout from generic publish failure.
+// Distinguishes PUBACK timeout, context-cancel, and generic publish failure.
 func wrapPublishErr(err error) error {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPubAckTimeout,
 			"mqtt: PUBACK timeout", err)
 	}
 	if errors.Is(err, context.Canceled) {
-		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTConnect,
+		return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishCanceled,
 			"mqtt: publish context canceled", err)
 	}
-	return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTConnect,
+	return errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishFailed,
 		"mqtt: publish failed", err)
 }
 
 // pubackReasonToMetric maps an errcode.Code (from classifyPubackReason) to a
 // PublishFailureReason metric label.
+//
+// Caller MUST pre-filter ErrAdapterMQTTPublishNoSubscribers — that code is
+// treated as success path (0x10 NoMatchingSubscribers) and never reaches this
+// mapping. The default branch covers any future drift.
 func pubackReasonToMetric(code errcode.Code) PublishFailureReason {
 	switch code {
 	case ErrAdapterMQTTPublishRateLimited:

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -498,6 +498,22 @@ func TestWrapPublishErr(t *testing.T) {
 	}
 }
 
+func TestWrapPublishErr_GenericTransportRedactsCause(t *testing.T) {
+	t.Parallel()
+
+	raw := errors.New("mqtt write failed: password=hunter2 token=abc123 host=broker")
+	err := wrapPublishErr(context.Background(), context.Background(), raw)
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTPublishFailed, ec.Code)
+	assert.NotContains(t, err.Error(), "hunter2")
+	assert.NotContains(t, err.Error(), "abc123")
+	assert.Contains(t, err.Error(), "<REDACTED>")
+	assert.False(t, errors.Is(err, raw),
+		"redacted generic transport errors intentionally break the raw cause chain")
+}
+
 // ---------------------------------------------------------------------------
 // Concurrent safety
 // ---------------------------------------------------------------------------

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -239,10 +240,16 @@ func TestPublisher_Publish_ContextCanceled(t *testing.T) {
 
 	err = pub.Publish(canceledCtx, "test/cancel", []byte("payload"))
 	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTPublishCanceled, ec.Code,
+		"canceled ctx must wrap ErrAdapterMQTTPublishCanceled")
 
 	spy.mu.Lock()
 	defer spy.mu.Unlock()
 	assert.Equal(t, 1, spy.failureCount, "RecordPublishFailure should be called on context cancel")
+	assert.Equal(t, PublishFailureContextCanceled, spy.lastFailureReason,
+		"canceled ctx must record the context_canceled metric reason")
 }
 
 // ---------------------------------------------------------------------------
@@ -339,6 +346,142 @@ func TestPublisher_Close_DrainsInFlight(t *testing.T) {
 	assert.NoError(t, closeErr, "Close should succeed after draining in-flight publishes")
 
 	wg.Wait()
+	// NOTE: this test cannot deterministically pin the publish to the "mid-flight
+	// at conn.Publish" window (scheduler-dependent). The deterministic mid-flight
+	// case — where the broker withholds PUBACK so the WaitGroup is provably held
+	// across Close — is covered by TestPublisher_Close_TimesOutOnStuckPublish.
+}
+
+// TestPublisher_Close_TimesOutOnStuckPublish deterministically exercises the
+// Close drain-timeout path (publisher.go select on ctx.Done): a broker hook
+// withholds the QoS-1 PUBACK so a publish is provably in-flight (WaitGroup
+// held), then Close is invoked with an already-canceled ctx. Close must return
+// ErrAdapterMQTTPublisherCloseTimeout, and — crucially — the in-flight publish
+// goroutine must NOT be killed: releasing the hook lets it complete, proving
+// Close-timeout is a bounded wait, not a cancellation.
+func TestPublisher_Close_TimesOutOnStuckPublish(t *testing.T) {
+	t.Parallel()
+	hook := &blockingPubAckHook{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	addr, stop := startBrokerWithHook(t, hook)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	cfg.PublishTimeout = 0 // no adapter timeout — publish blocks on the withheld PUBACK
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D15s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+
+	// Launch a publish the broker will not PUBACK until we release the hook.
+	pubDone := make(chan error, 1)
+	go func() { pubDone <- pub.Publish(ctx, "test/stuck", []byte("x")) }()
+
+	// Barrier: the broker received the PUBLISH (PUBACK now withheld), so the
+	// publisher's WaitGroup is held and Close must drain-wait.
+	select {
+	case <-hook.entered:
+	case <-ctx.Done():
+		t.Fatal("publish never reached broker hook")
+	}
+
+	// Close with an already-canceled ctx: drain cannot complete → timeout.
+	canceledCtx, cancelFn := context.WithCancel(context.Background())
+	cancelFn()
+	closeErr := pub.Close(canceledCtx)
+	require.Error(t, closeErr)
+	var ec *errcode.Error
+	require.True(t, errors.As(closeErr, &ec))
+	assert.Equal(t, ErrAdapterMQTTPublisherCloseTimeout, ec.Code,
+		"Close with canceled ctx and an in-flight publish must time out")
+
+	// Release the broker: the in-flight goroutine must still complete (Close
+	// timeout did not cancel it).
+	close(hook.release)
+	select {
+	case perr := <-pubDone:
+		assert.NoError(t, perr, "released in-flight publish should complete successfully")
+	case <-ctx.Done():
+		t.Fatal("in-flight publish goroutine did not complete after broker release")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// classifyPublishErr / wrapPublishErr — pure-function table-driven coverage
+// (no broker; exercises every branch including the generic-error path that the
+// broker-backed tests do not reach).
+// ---------------------------------------------------------------------------
+
+func TestClassifyPublishErr(t *testing.T) {
+	t.Parallel()
+
+	// deadline-exceeded publishCtx: the first branch keys off publishCtx.Err().
+	deadlineCtx, dcancel := context.WithTimeout(context.Background(), 0)
+	defer dcancel()
+	<-deadlineCtx.Done() // ensure Err() == DeadlineExceeded
+
+	canceledCtx, ccancel := context.WithCancel(context.Background())
+	ccancel()
+	<-canceledCtx.Done()
+
+	bg := context.Background()
+	wrapCanceled := fmt.Errorf("wrap: %w", context.Canceled)
+	wrapDeadline := fmt.Errorf("wrap: %w", context.DeadlineExceeded)
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want PublishFailureReason
+	}{
+		{"deadline-ctx-maps-puback-timeout", deadlineCtx, errors.New("transport"), PublishFailurePubAckTimeout},
+		{"canceled-err-maps-context-canceled", canceledCtx, wrapCanceled, PublishFailureContextCanceled},
+		{"deadline-err-without-deadline-ctx", bg, wrapDeadline, PublishFailureContextCanceled},
+		{"generic-transport-err", bg, errors.New("connection reset"), PublishFailurePublishError},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyPublishErr(tc.ctx, tc.err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWrapPublishErr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		err      error
+		wantCode errcode.Code
+	}{
+		{"deadline-exceeded", fmt.Errorf("wrap: %w", context.DeadlineExceeded), ErrAdapterMQTTPubAckTimeout},
+		{"canceled", fmt.Errorf("wrap: %w", context.Canceled), ErrAdapterMQTTPublishCanceled},
+		{"generic", errors.New("connection reset by peer"), ErrAdapterMQTTPublishFailed},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := wrapPublishErr(tc.err)
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec))
+			assert.Equal(t, tc.wantCode, ec.Code)
+			assert.Equal(t, errcode.KindUnavailable, ec.Kind)
+			assert.ErrorIs(t, err, tc.err, "wrapPublishErr must preserve the cause chain")
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -399,8 +542,9 @@ func TestPubackReasonToMetric(t *testing.T) {
 		reason PublishFailureReason
 	}{
 		{ErrAdapterMQTTPublishRateLimited, PublishFailureRateLimited},
-		{ErrAdapterMQTTPublishRejected, PublishFailurePublishError},
-		{ErrAdapterMQTTPayloadTooLarge, PublishFailurePayloadTooLarge},
+		{ErrAdapterMQTTPublishNotAuthorized, PublishFailureNotAuthorized},
+		{ErrAdapterMQTTPublishPayloadFormatInvalid, PublishFailurePayloadFormatInvalid},
+		{ErrAdapterMQTTPublishRejected, PublishFailureRejected},
 		{"UNKNOWN_CODE", PublishFailurePublishError},
 	}
 	for _, tc := range tests {
@@ -436,6 +580,60 @@ func (h *noMatchingSubscribersHook) OnPublish(_ *mqttserver.Client, pk mqttpacke
 		return pk, mqttpackets.CodeNoMatchingSubscribers
 	}
 	return pk, nil
+}
+
+// blockingPubAckHook withholds the QoS-1 PUBACK: mochi invokes OnPublish
+// synchronously before writing the PUBACK (server.go processPublish), so
+// blocking here provably holds a publish in-flight on the client side. `entered`
+// is signaled once when the first QoS>0 PUBLISH arrives; OnPublish then blocks
+// until `release` is closed. Used by TestPublisher_Close_TimesOutOnStuckPublish.
+type blockingPubAckHook struct {
+	mqttserver.HookBase
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (h *blockingPubAckHook) ID() string           { return "blocking-puback" }
+func (h *blockingPubAckHook) Provides(b byte) bool { return b == mqttserver.OnPublish }
+
+func (h *blockingPubAckHook) OnPublish(_ *mqttserver.Client, pk mqttpackets.Packet) (mqttpackets.Packet, error) {
+	if pk.FixedHeader.Qos > 0 {
+		h.once.Do(func() { close(h.entered) })
+		<-h.release
+	}
+	return pk, nil
+}
+
+// startBrokerWithHook starts a dedicated in-process mochi broker with the given
+// hook (plus AllowHook), on a fresh random port. Mirrors
+// startBrokerWithNoSubscribersHook but parameterized over the hook so callers
+// can inject custom PUBACK behavior.
+func startBrokerWithHook(t *testing.T, h mqttserver.Hook) (addr string, stop func()) {
+	t.Helper()
+	srv := mqttserver.New(&mqttserver.Options{InlineClient: false})
+	require.NoError(t, srv.AddHook(new(auth.AllowHook), nil), "add allow hook")
+	require.NoError(t, srv.AddHook(h, nil), "add custom hook")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "listen random port")
+	addr = ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	tcp := listeners.NewTCP(listeners.Config{ID: "hook-tcp", Address: addr})
+	require.NoError(t, srv.AddListener(tcp), "add listener")
+	go func() { _ = srv.Serve() }()
+
+	testwait.External(t, "hook-broker-ready", func() bool {
+		c, derr := net.Dial("tcp", addr)
+		if derr != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, testtime.D2s, testtime.D10ms)
+
+	return addr, func() { _ = srv.Close() }
 }
 
 // startBrokerWithNoSubscribersHook starts a broker that always returns PUBACK

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -1,0 +1,422 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+)
+
+// ---------------------------------------------------------------------------
+// TestPublisher_ImplementsOutboxPublisher — compile-time interface assertion
+// ---------------------------------------------------------------------------
+
+// The var-level assertion in publisher.go already covers this; this test
+// provides explicit runtime documentation.
+func TestPublisher_ImplementsOutboxPublisher(t *testing.T) {
+	t.Parallel()
+	var _ outbox.Publisher = (*Publisher)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// NewPublisher construction tests
+// ---------------------------------------------------------------------------
+
+func TestNewPublisher_NilConnection(t *testing.T) {
+	t.Parallel()
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	_, err = NewPublisher(clock.Real(), nil, ns)
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTInvalidConfig, ec.Code)
+}
+
+func TestNewPublisher_ZeroNamespace(t *testing.T) {
+	t.Parallel()
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	_, err = NewPublisher(clock.Real(), conn, TopicNamespace{})
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTInvalidTopicNamespace, ec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Publish tests
+// ---------------------------------------------------------------------------
+
+func TestPublisher_Publish_Success(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	spy := &spyCollector{}
+	pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	err = pub.Publish(ctx, "test/hello", []byte("payload"))
+	require.NoError(t, err)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Equal(t, 1, spy.successCount, "RecordPublishSuccess should be called once")
+	assert.Equal(t, 0, spy.failureCount, "RecordPublishFailure should not be called on success")
+}
+
+func TestPublisher_Publish_TopicOutsideNamespace(t *testing.T) {
+	t.Parallel()
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("ns1")
+	require.NoError(t, err)
+
+	spy := &spyCollector{}
+	pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	err = pub.Publish(ctx, "ns2/x", []byte("payload"))
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTTopicOutsideNamespace, ec.Code)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Equal(t, 0, spy.successCount)
+	assert.Equal(t, 1, spy.failureCount)
+	assert.Equal(t, PublishFailureTopicOutsideNamespace, spy.lastFailureReason)
+}
+
+func TestPublisher_Publish_PayloadTooLarge(t *testing.T) {
+	t.Parallel()
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	cfg.MaximumPacketSize = 10
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	spy := &spyCollector{}
+	pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	// 20-byte payload exceeds MaximumPacketSize=10.
+	err = pub.Publish(ctx, "test/large", make([]byte, 20))
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTPayloadTooLarge, ec.Code)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Equal(t, 1, spy.failureCount)
+	assert.Equal(t, PublishFailurePayloadTooLarge, spy.lastFailureReason)
+}
+
+func TestPublisher_Publish_AfterClose(t *testing.T) {
+	t.Parallel()
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	spy := &spyCollector{}
+	pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+	require.NoError(t, err)
+
+	// Close publisher first.
+	require.NoError(t, pub.Close(ctx))
+
+	err = pub.Publish(ctx, "test/x", []byte("payload"))
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, ErrAdapterMQTTClosed, ec.Code)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Equal(t, 1, spy.failureCount)
+	assert.Equal(t, PublishFailureClosed, spy.lastFailureReason)
+}
+
+func TestPublisher_Publish_ContextCanceled(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	spy := &spyCollector{}
+	pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	canceledCtx, cancelFn := context.WithCancel(context.Background())
+	cancelFn()
+
+	err = pub.Publish(canceledCtx, "test/cancel", []byte("payload"))
+	require.Error(t, err)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Equal(t, 1, spy.failureCount, "RecordPublishFailure should be called on context cancel")
+}
+
+// ---------------------------------------------------------------------------
+// Close tests
+// ---------------------------------------------------------------------------
+
+func TestPublisher_Close_Idempotent(t *testing.T) {
+	t.Parallel()
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+
+	assert.NoError(t, pub.Close(ctx), "first Close should succeed")
+	assert.NoError(t, pub.Close(ctx), "second Close should be idempotent")
+}
+
+func TestPublisher_Close_DoesNotCloseConnection(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+
+	require.NoError(t, pub.Close(ctx))
+
+	// Connection should still be healthy after publisher is closed.
+	assert.NoError(t, conn.Health(ctx), "conn.Health should still be nil after publisher Close")
+}
+
+func TestPublisher_Close_DrainsInFlight(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D15s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+
+	// Fire a publish in the background.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = pub.Publish(ctx, "test/drain", make([]byte, 5))
+	}()
+
+	// Allow the goroutine to start before closing.
+	time.Sleep(testtime.D10ms)
+
+	// Close should drain the in-flight publish before returning.
+	closeErr := pub.Close(ctx)
+	assert.NoError(t, closeErr, "Close should succeed after draining in-flight publishes")
+
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent safety
+// ---------------------------------------------------------------------------
+
+func TestPublisher_Publish_ConcurrentSafe(t *testing.T) {
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D15s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	const n = 20
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = pub.Publish(ctx, "test/concurrent", []byte("payload"))
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d publish error", i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pubackReasonToMetric table test
+// ---------------------------------------------------------------------------
+
+func TestPubackReasonToMetric(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		code   errcode.Code
+		reason PublishFailureReason
+	}{
+		{ErrAdapterMQTTPublishRateLimited, PublishFailureRateLimited},
+		{ErrAdapterMQTTPublishRejected, PublishFailurePublishError},
+		{ErrAdapterMQTTPayloadTooLarge, PublishFailurePayloadTooLarge},
+		{ErrAdapterMQTTPublishNoSubscribers, PublishFailurePublishError},
+		{"UNKNOWN_CODE", PublishFailurePublishError},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(string(tc.code), func(t *testing.T) {
+			t.Parallel()
+			got := pubackReasonToMetric(tc.code)
+			assert.Equal(t, tc.reason, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+// spyCollector is a PublisherCollector that records calls for assertions.
+type spyCollector struct {
+	mu                sync.Mutex
+	successCount      int
+	failureCount      int
+	lastFailureReason PublishFailureReason
+	lastAckDuration   time.Duration
+}
+
+func (s *spyCollector) RecordPublishSuccess(_ context.Context, d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.successCount++
+	s.lastAckDuration = d
+}
+
+func (s *spyCollector) RecordPublishFailure(_ context.Context, r PublishFailureReason) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failureCount++
+	s.lastFailureReason = r
+}

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -75,9 +75,7 @@ func TestNewPublisher_ZeroNamespace(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPublisher_Publish_Success(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker has a TOCTOU port-reuse window
-	// (ln.Close() then re-bind) that causes flaky port conflicts under parallel
-	// test execution. Deferred until broker helper is fixed.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -215,7 +213,7 @@ func TestPublisher_Publish_AfterClose(t *testing.T) {
 }
 
 func TestPublisher_Publish_ContextCanceled(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -276,7 +274,7 @@ func TestPublisher_Close_Idempotent(t *testing.T) {
 }
 
 func TestPublisher_Close_DoesNotCloseConnection(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -302,9 +300,7 @@ func TestPublisher_Close_DoesNotCloseConnection(t *testing.T) {
 }
 
 func TestPublisher_Close_DrainsInFlight(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker has a TOCTOU port-reuse window
-	// (ln.Close() then re-bind) that causes flaky port conflicts under parallel
-	// test execution. Deferred until broker helper is fixed.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -324,9 +320,10 @@ func TestPublisher_Close_DrainsInFlight(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fire a publish in the background with a channel barrier to signal when
-	// the goroutine is about to enter Publish, replacing the previous pure-sleep
-	// synchronization. A small additional sleep gives the goroutine time to
-	// reach the Publish mutex lock before Close marks the publisher closed.
+	// the goroutine is about to enter Publish. The channel barrier guarantees
+	// the goroutine has started; any in-flight work will have entered Publish
+	// (or will have exited via the closed-path check) by the time Close runs.
+	// Both outcomes are valid drain semantics.
 	started := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -336,9 +333,8 @@ func TestPublisher_Close_DrainsInFlight(t *testing.T) {
 		_ = pub.Publish(ctx, "test/drain", make([]byte, 5))
 	}()
 	<-started
-	time.Sleep(time.Millisecond) // let goroutine reach Publish mutex
 
-	// Close should drain the in-flight publish before returning.
+	// Close should drain any in-flight publish before returning.
 	closeErr := pub.Close(ctx)
 	assert.NoError(t, closeErr, "Close should succeed after draining in-flight publishes")
 
@@ -350,7 +346,7 @@ func TestPublisher_Close_DrainsInFlight(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPublisher_Publish_ConcurrentSafe(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -475,7 +471,7 @@ func startBrokerWithNoSubscribersHook(t *testing.T) (addr string, stop func()) {
 // (NoMatchingSubscribers) is treated as success: Publisher.Publish returns nil,
 // RecordPublishSuccess is called once, and RecordPublishFailure is not called.
 func TestPublisher_Publish_NoMatchingSubscribers_Success(t *testing.T) {
-	// t.Parallel disabled: startBrokerWithNoSubscribersHook has TOCTOU port-reuse.
+	t.Parallel()
 	addr, stop := startBrokerWithNoSubscribersHook(t)
 	defer stop()
 
@@ -513,7 +509,7 @@ func TestPublisher_Publish_NoMatchingSubscribers_Success(t *testing.T) {
 // len(nil) == 0, so the MaximumPacketSize guard passes and the broker accepts
 // an empty payload.
 func TestPublisher_Publish_NilPayload(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -543,7 +539,7 @@ func TestPublisher_Publish_NilPayload(t *testing.T) {
 // deadline is honored as-is. The test publishes with a generous ctx deadline and
 // confirms the call succeeds (demonstrating no internal timeout was imposed).
 func TestPublisher_Publish_NoAdapterTimeout(t *testing.T) {
-	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	t.Parallel()
 	addr, stop := startInternalBroker(t)
 	defer stop()
 

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -3,10 +3,15 @@ package mqtt
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 	"time"
 
+	mqttserver "github.com/mochi-mqtt/server/v2"
+	"github.com/mochi-mqtt/server/v2/hooks/auth"
+	"github.com/mochi-mqtt/server/v2/listeners"
+	mqttpackets "github.com/mochi-mqtt/server/v2/packets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
 // ---------------------------------------------------------------------------
@@ -69,6 +75,9 @@ func TestNewPublisher_ZeroNamespace(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPublisher_Publish_Success(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker has a TOCTOU port-reuse window
+	// (ln.Close() then re-bind) that causes flaky port conflicts under parallel
+	// test execution. Deferred until broker helper is fixed.
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -206,6 +215,7 @@ func TestPublisher_Publish_AfterClose(t *testing.T) {
 }
 
 func TestPublisher_Publish_ContextCanceled(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -266,6 +276,7 @@ func TestPublisher_Close_Idempotent(t *testing.T) {
 }
 
 func TestPublisher_Close_DoesNotCloseConnection(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -291,6 +302,9 @@ func TestPublisher_Close_DoesNotCloseConnection(t *testing.T) {
 }
 
 func TestPublisher_Close_DrainsInFlight(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker has a TOCTOU port-reuse window
+	// (ln.Close() then re-bind) that causes flaky port conflicts under parallel
+	// test execution. Deferred until broker helper is fixed.
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -309,16 +323,20 @@ func TestPublisher_Close_DrainsInFlight(t *testing.T) {
 	pub, err := NewPublisher(clk, conn, ns)
 	require.NoError(t, err)
 
-	// Fire a publish in the background.
+	// Fire a publish in the background with a channel barrier to signal when
+	// the goroutine is about to enter Publish, replacing the previous pure-sleep
+	// synchronization. A small additional sleep gives the goroutine time to
+	// reach the Publish mutex lock before Close marks the publisher closed.
+	started := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		close(started) // signal "about to enter Publish"
 		_ = pub.Publish(ctx, "test/drain", make([]byte, 5))
 	}()
-
-	// Allow the goroutine to start before closing.
-	time.Sleep(testtime.D10ms)
+	<-started
+	time.Sleep(time.Millisecond) // let goroutine reach Publish mutex
 
 	// Close should drain the in-flight publish before returning.
 	closeErr := pub.Close(ctx)
@@ -332,6 +350,7 @@ func TestPublisher_Close_DrainsInFlight(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPublisher_Publish_ConcurrentSafe(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
 	addr, stop := startInternalBroker(t)
 	defer stop()
 
@@ -374,6 +393,11 @@ func TestPublisher_Publish_ConcurrentSafe(t *testing.T) {
 
 func TestPubackReasonToMetric(t *testing.T) {
 	t.Parallel()
+	// ErrAdapterMQTTPublishNoSubscribers (0x10) is intentionally excluded:
+	// the Publish path guards `code != ErrAdapterMQTTPublishNoSubscribers` before
+	// calling pubackReasonToMetric, so that code never reaches this mapping.
+	// The default branch already covers any future drift. See also
+	// pubackReasonToMetric godoc "Caller MUST pre-filter" note.
 	tests := []struct {
 		code   errcode.Code
 		reason PublishFailureReason
@@ -381,7 +405,6 @@ func TestPubackReasonToMetric(t *testing.T) {
 		{ErrAdapterMQTTPublishRateLimited, PublishFailureRateLimited},
 		{ErrAdapterMQTTPublishRejected, PublishFailurePublishError},
 		{ErrAdapterMQTTPayloadTooLarge, PublishFailurePayloadTooLarge},
-		{ErrAdapterMQTTPublishNoSubscribers, PublishFailurePublishError},
 		{"UNKNOWN_CODE", PublishFailurePublishError},
 	}
 	for _, tc := range tests {
@@ -392,6 +415,163 @@ func TestPubackReasonToMetric(t *testing.T) {
 			assert.Equal(t, tc.reason, got)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// 7c: 0x10 NoMatchingSubscribers success path
+// ---------------------------------------------------------------------------
+
+// noMatchingSubscribersHook is a mochi hook that returns
+// packets.CodeNoMatchingSubscribers for every QoS 1 PUBLISH, causing the
+// broker to send PUBACK with ReasonCode 0x10.
+type noMatchingSubscribersHook struct {
+	mqttserver.HookBase
+}
+
+func (h *noMatchingSubscribersHook) ID() string { return "no-matching-subscribers" }
+func (h *noMatchingSubscribersHook) Provides(b byte) bool {
+	return b == mqttserver.OnPublish
+}
+
+func (h *noMatchingSubscribersHook) OnPublish(_ *mqttserver.Client, pk mqttpackets.Packet) (mqttpackets.Packet, error) {
+	if pk.FixedHeader.Qos > 0 {
+		// Return CodeNoMatchingSubscribers as the error; mochi will build a
+		// PUBACK with ReasonCode 0x10 for MQTT v5 QoS 1 clients.
+		return pk, mqttpackets.CodeNoMatchingSubscribers
+	}
+	return pk, nil
+}
+
+// startBrokerWithNoSubscribersHook starts a broker that always returns PUBACK
+// 0x10 for QoS 1 publishes, simulating a topic with no active subscribers.
+func startBrokerWithNoSubscribersHook(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	srv := mqttserver.New(&mqttserver.Options{InlineClient: false})
+	require.NoError(t, srv.AddHook(new(auth.AllowHook), nil), "add allow hook")
+	require.NoError(t, srv.AddHook(new(noMatchingSubscribersHook), nil), "add no-subscribers hook")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "listen random port")
+	addr = ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	tcp := listeners.NewTCP(listeners.Config{ID: "no-sub-tcp", Address: addr})
+	require.NoError(t, srv.AddListener(tcp), "add listener")
+	go func() { _ = srv.Serve() }()
+
+	testwait.External(t, "no-sub-broker-ready", func() bool {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, testtime.D2s, testtime.D10ms)
+
+	return addr, func() { _ = srv.Close() }
+}
+
+// TestPublisher_Publish_NoMatchingSubscribers_Success verifies that PUBACK 0x10
+// (NoMatchingSubscribers) is treated as success: Publisher.Publish returns nil,
+// RecordPublishSuccess is called once, and RecordPublishFailure is not called.
+func TestPublisher_Publish_NoMatchingSubscribers_Success(t *testing.T) {
+	// t.Parallel disabled: startBrokerWithNoSubscribersHook has TOCTOU port-reuse.
+	addr, stop := startBrokerWithNoSubscribersHook(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	spy := &spyCollector{}
+	pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	err = pub.Publish(ctx, "test/nosub", []byte("payload"))
+	require.NoError(t, err, "PUBACK 0x10 must be treated as success (no error returned)")
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	assert.Equal(t, 1, spy.successCount, "RecordPublishSuccess must be called once for PUBACK 0x10")
+	assert.Equal(t, 0, spy.failureCount, "RecordPublishFailure must NOT be called for PUBACK 0x10")
+}
+
+// ---------------------------------------------------------------------------
+// 7d: nil payload + PublishTimeout=0 tests
+// ---------------------------------------------------------------------------
+
+// TestPublisher_Publish_NilPayload verifies that nil payload is accepted:
+// len(nil) == 0, so the MaximumPacketSize guard passes and the broker accepts
+// an empty payload.
+func TestPublisher_Publish_NilPayload(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	// nil payload: len(nil) == 0, must not trigger payload-too-large guard.
+	err = pub.Publish(ctx, "test/nil-payload", nil)
+	require.NoError(t, err, "nil payload must be accepted (len(nil)==0)")
+}
+
+// TestPublisher_Publish_NoAdapterTimeout verifies that when Config.PublishTimeout
+// is 0, the publisher does NOT derive a child ctx and the caller-provided ctx
+// deadline is honored as-is. The test publishes with a generous ctx deadline and
+// confirms the call succeeds (demonstrating no internal timeout was imposed).
+func TestPublisher_Publish_NoAdapterTimeout(t *testing.T) {
+	// t.Parallel disabled: startInternalBroker TOCTOU port-reuse issue.
+	addr, stop := startInternalBroker(t)
+	defer stop()
+
+	clk := clock.Real()
+	cfg := newInternalConfig(addr)
+	// PublishTimeout = 0: no adapter-imposed timeout; caller ctx governs.
+	cfg.PublishTimeout = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+	defer cancel()
+
+	conn, err := Open(ctx, clk, cfg)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	ns, err := ParseTopicNamespace("test")
+	require.NoError(t, err)
+
+	pub, err := NewPublisher(clk, conn, ns)
+	require.NoError(t, err)
+	defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+	// Publish with a caller-provided ctx deadline (not overridden by publisher).
+	pubCtx, pubCancel := context.WithTimeout(ctx, testtime.D5s)
+	defer pubCancel()
+
+	err = pub.Publish(pubCtx, "test/no-timeout", []byte("payload"))
+	require.NoError(t, err, "publish with PublishTimeout=0 must honor caller ctx and succeed")
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -438,22 +438,25 @@ func TestClassifyPublishErr(t *testing.T) {
 	wrapCanceled := fmt.Errorf("wrap: %w", context.Canceled)
 	wrapDeadline := fmt.Errorf("wrap: %w", context.DeadlineExceeded)
 
+	// Cases distinguish the caller's own ctx from the adapter PublishTimeout child:
+	// caller-driven abort → context_canceled; only-adapter-timeout → puback_timeout.
 	tests := []struct {
-		name string
-		ctx  context.Context
-		err  error
-		want PublishFailureReason
+		name       string
+		callerCtx  context.Context
+		publishCtx context.Context
+		err        error
+		want       PublishFailureReason
 	}{
-		{"deadline-ctx-maps-puback-timeout", deadlineCtx, errors.New("transport"), PublishFailurePubAckTimeout},
-		{"canceled-err-maps-context-canceled", canceledCtx, wrapCanceled, PublishFailureContextCanceled},
-		{"deadline-err-without-deadline-ctx", bg, wrapDeadline, PublishFailureContextCanceled},
-		{"generic-transport-err", bg, errors.New("connection reset"), PublishFailurePublishError},
+		{"adapter-timeout-only", bg, deadlineCtx, errors.New("transport"), PublishFailurePubAckTimeout},
+		{"caller-canceled", canceledCtx, canceledCtx, wrapCanceled, PublishFailureContextCanceled},
+		{"caller-deadline", deadlineCtx, deadlineCtx, wrapDeadline, PublishFailureContextCanceled},
+		{"generic-transport-err", bg, bg, errors.New("connection reset"), PublishFailurePublishError},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := classifyPublishErr(tc.ctx, tc.err)
+			got := classifyPublishErr(tc.callerCtx, tc.publishCtx, tc.err)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -461,20 +464,31 @@ func TestClassifyPublishErr(t *testing.T) {
 
 func TestWrapPublishErr(t *testing.T) {
 	t.Parallel()
+
+	deadlineCtx, dcancel := context.WithTimeout(context.Background(), 0)
+	defer dcancel()
+	<-deadlineCtx.Done()
+	canceledCtx, ccancel := context.WithCancel(context.Background())
+	ccancel()
+	<-canceledCtx.Done()
+	bg := context.Background()
+
 	tests := []struct {
-		name     string
-		err      error
-		wantCode errcode.Code
+		name       string
+		callerCtx  context.Context
+		publishCtx context.Context
+		err        error
+		wantCode   errcode.Code
 	}{
-		{"deadline-exceeded", fmt.Errorf("wrap: %w", context.DeadlineExceeded), ErrAdapterMQTTPubAckTimeout},
-		{"canceled", fmt.Errorf("wrap: %w", context.Canceled), ErrAdapterMQTTPublishCanceled},
-		{"generic", errors.New("connection reset by peer"), ErrAdapterMQTTPublishFailed},
+		{"caller-canceled", canceledCtx, canceledCtx, fmt.Errorf("wrap: %w", context.Canceled), ErrAdapterMQTTPublishCanceled},
+		{"adapter-timeout-only", bg, deadlineCtx, errors.New("transport"), ErrAdapterMQTTPubAckTimeout},
+		{"generic", bg, bg, errors.New("connection reset by peer"), ErrAdapterMQTTPublishFailed},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := wrapPublishErr(tc.err)
+			err := wrapPublishErr(tc.callerCtx, tc.publishCtx, tc.err)
 			var ec *errcode.Error
 			require.True(t, errors.As(err, &ec))
 			assert.Equal(t, tc.wantCode, ec.Code)
@@ -634,6 +648,87 @@ func startBrokerWithHook(t *testing.T, h mqttserver.Hook) (addr string, stop fun
 	}, testtime.D2s, testtime.D10ms)
 
 	return addr, func() { _ = srv.Close() }
+}
+
+// rejectingPubAckHook returns a broker-rejection PUBACK reason code (>= 0x80)
+// for every QoS-1 PUBLISH. mochi builds a PUBACK carrying that code, which paho
+// surfaces via the ERROR return of Publish (paho/client.go:923) — NOT via a
+// nil-error response. This is the real path on which broker reason codes reach
+// the adapter; the test below uses it to prove Publisher.Publish routes those
+// errors through classifyPubackReason rather than collapsing them to a generic
+// publish failure.
+type rejectingPubAckHook struct {
+	mqttserver.HookBase
+	code byte
+}
+
+func (h *rejectingPubAckHook) ID() string           { return "rejecting-puback" }
+func (h *rejectingPubAckHook) Provides(b byte) bool { return b == mqttserver.OnPublish }
+
+func (h *rejectingPubAckHook) OnPublish(_ *mqttserver.Client, pk mqttpackets.Packet) (mqttpackets.Packet, error) {
+	if pk.FixedHeader.Qos > 0 {
+		return pk, mqttpackets.Code{Code: h.code, Reason: "rejected by test hook"}
+	}
+	return pk, nil
+}
+
+// TestPublisher_Publish_BrokerRejectedPUBACK_RealPath is the recurrence guard for
+// the dead-classifyPubackReason bug: paho returns reason codes >= 0x80 via the
+// error channel, so a naive `if err != nil { wrapPublishErr }` would collapse
+// every broker rejection into ErrAdapterMQTTPublishFailed and never reach
+// classifyPubackReason. This test drives a real broker that returns each
+// rejection reason and asserts the DEDICATED errcode + metric reason surface —
+// exercising the integrated paho path, not classifyPubackReason in isolation.
+func TestPublisher_Publish_BrokerRejectedPUBACK_RealPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		code       byte
+		wantCode   errcode.Code
+		wantReason PublishFailureReason
+	}{
+		{"not-authorized-0x87", 0x87, ErrAdapterMQTTPublishNotAuthorized, PublishFailureNotAuthorized},
+		{"quota-exceeded-0x97", 0x97, ErrAdapterMQTTPublishRateLimited, PublishFailureRateLimited},
+		{"payload-format-invalid-0x99", 0x99, ErrAdapterMQTTPublishPayloadFormatInvalid, PublishFailurePayloadFormatInvalid},
+		{"unspecified-0x80", 0x80, ErrAdapterMQTTPublishRejected, PublishFailureRejected},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			addr, stop := startBrokerWithHook(t, &rejectingPubAckHook{code: tc.code})
+			defer stop()
+
+			clk := clock.Real()
+			cfg := newInternalConfig(addr)
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
+			defer cancel()
+
+			conn, err := Open(ctx, clk, cfg)
+			require.NoError(t, err)
+			defer conn.Close(context.Background()) //nolint:errcheck // test cleanup
+
+			ns, err := ParseTopicNamespace("test")
+			require.NoError(t, err)
+			spy := &spyCollector{}
+			pub, err := NewPublisher(clk, conn, ns, WithPublisherCollector(spy))
+			require.NoError(t, err)
+			defer pub.Close(context.Background()) //nolint:errcheck // test cleanup
+
+			err = pub.Publish(ctx, "test/rejected", []byte("payload"))
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec))
+			assert.Equal(t, tc.wantCode, ec.Code,
+				"broker PUBACK 0x%02x must surface its dedicated errcode via classifyPubackReason, not generic", tc.code)
+
+			spy.mu.Lock()
+			defer spy.mu.Unlock()
+			assert.Equal(t, 1, spy.failureCount)
+			assert.Equal(t, tc.wantReason, spy.lastFailureReason)
+			assert.Equal(t, 0, spy.successCount)
+		})
+	}
 }
 
 // startBrokerWithNoSubscribersHook starts a broker that always returns PUBACK

--- a/adapters/mqtt/testmain_integration_test.go
+++ b/adapters/mqtt/testmain_integration_test.go
@@ -41,7 +41,7 @@ func sharedBrokerURL(t *testing.T) string {
 	t.Helper()
 	testutil.RequireDocker(t)
 	sharedBrokerOnce.Do(func() {
-		sharedBrokerURLValue, sharedBrokerShutdown, sharedBrokerStartErr = startBrokerContainer()
+		sharedBrokerURLValue, sharedBrokerShutdown, sharedBrokerStartErr = startMosquittoContainer()
 	})
 	if sharedBrokerStartErr != nil {
 		t.Fatalf("mqtt: shared broker start: %v", sharedBrokerStartErr)
@@ -49,12 +49,12 @@ func sharedBrokerURL(t *testing.T) string {
 	return sharedBrokerURLValue
 }
 
-// startBrokerContainer brings up an eclipse-mosquitto v2.0 MQTT broker with
+// startMosquittoContainer brings up an eclipse-mosquitto v2.0 MQTT broker with
 // anonymous auth. The conf file is mounted in-memory via ContainerFile so no
 // host filesystem access is required.
 //
 // ref: adapters/otel/integration_test.go (GenericContainer + ContainerFile pattern)
-func startBrokerContainer() (string, func(), error) {
+func startMosquittoContainer() (string, func(), error) {
 	ctx := context.Background()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
@@ -97,9 +97,16 @@ func startBrokerContainer() (string, func(), error) {
 // TestMain runs all tests in this package and then tears down the shared
 // broker. Mirrors adapters/rabbitmq/testmain_integration_test.go.
 func TestMain(m *testing.M) {
-	code := m.Run()
-	if sharedBrokerShutdown != nil {
-		sharedBrokerShutdown()
-	}
-	os.Exit(code)
+	os.Exit(runTestsWithShutdown(m))
+}
+
+// runTestsWithShutdown runs m.Run() and defers broker shutdown so the
+// container is torn down even if m.Run() panics before returning.
+func runTestsWithShutdown(m *testing.M) int {
+	defer func() {
+		if sharedBrokerShutdown != nil {
+			sharedBrokerShutdown()
+		}
+	}()
+	return m.Run()
 }

--- a/adapters/mqtt/testmain_integration_test.go
+++ b/adapters/mqtt/testmain_integration_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -68,7 +68,7 @@ func startMosquittoContainer() (string, func(), error) {
 				},
 			},
 			WaitingFor: wait.ForListeningPort("1883/tcp").
-				WithStartupTimeout(30 * time.Second),
+				WithStartupTimeout(testtime.D30s),
 		},
 		Started: true,
 	})
@@ -87,7 +87,7 @@ func startMosquittoContainer() (string, func(), error) {
 	}
 	url := fmt.Sprintf("tcp://%s:%s", host, port.Port())
 	shutdown := func() {
-		termCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		termCtx, cancel := context.WithTimeout(context.Background(), testtime.D10s)
 		defer cancel()
 		_ = container.Terminate(termCtx)
 	}

--- a/adapters/mqtt/testmain_integration_test.go
+++ b/adapters/mqtt/testmain_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package mqtt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/ghbvf/gocell/tests/testutil"
+)
+
+// mosquittoConf is the in-memory broker configuration mounted into the
+// eclipse-mosquitto container. Anonymous auth + listener on 0.0.0.0:1883.
+const mosquittoConf = `listener 1883 0.0.0.0
+allow_anonymous true
+`
+
+var (
+	sharedBrokerOnce     sync.Once
+	sharedBrokerURLValue string
+	sharedBrokerShutdown func()
+	sharedBrokerStartErr error
+)
+
+// sharedBrokerURL returns the URL of a shared Mosquitto MQTT container started
+// lazily on first call. Subsequent tests in the same package share the broker —
+// fast and avoids per-test container startup cost. Cleanup happens in TestMain
+// after all tests in the package finish.
+//
+// RequireDocker is called here so individual tests that call sharedBrokerURL
+// get the correct skip/fatal behavior when Docker is absent.
+func sharedBrokerURL(t *testing.T) string {
+	t.Helper()
+	testutil.RequireDocker(t)
+	sharedBrokerOnce.Do(func() {
+		sharedBrokerURLValue, sharedBrokerShutdown, sharedBrokerStartErr = startBrokerContainer()
+	})
+	if sharedBrokerStartErr != nil {
+		t.Fatalf("mqtt: shared broker start: %v", sharedBrokerStartErr)
+	}
+	return sharedBrokerURLValue
+}
+
+// startBrokerContainer brings up an eclipse-mosquitto v2.0 MQTT broker with
+// anonymous auth. The conf file is mounted in-memory via ContainerFile so no
+// host filesystem access is required.
+//
+// ref: adapters/otel/integration_test.go (GenericContainer + ContainerFile pattern)
+func startBrokerContainer() (string, func(), error) {
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        testutil.MosquittoImage,
+			ExposedPorts: []string{"1883/tcp"},
+			Files: []testcontainers.ContainerFile{
+				{
+					Reader:            strings.NewReader(mosquittoConf),
+					ContainerFilePath: "/mosquitto/config/mosquitto.conf",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForListeningPort("1883/tcp").
+				WithStartupTimeout(30 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("mqtt broker container start: %w", err)
+	}
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return "", nil, fmt.Errorf("mqtt broker host: %w", err)
+	}
+	port, err := container.MappedPort(ctx, "1883/tcp")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return "", nil, fmt.Errorf("mqtt broker mapped port: %w", err)
+	}
+	url := fmt.Sprintf("tcp://%s:%s", host, port.Port())
+	shutdown := func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = container.Terminate(termCtx)
+	}
+	return url, shutdown, nil
+}
+
+// TestMain runs all tests in this package and then tears down the shared
+// broker. Mirrors adapters/rabbitmq/testmain_integration_test.go.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedBrokerShutdown != nil {
+		sharedBrokerShutdown()
+	}
+	os.Exit(code)
+}

--- a/adapters/mqtt/testmain_integration_test.go
+++ b/adapters/mqtt/testmain_integration_test.go
@@ -101,12 +101,15 @@ func TestMain(m *testing.M) {
 }
 
 // runTestsWithShutdown runs m.Run() and defers broker shutdown so the
-// container is torn down even if m.Run() panics before returning.
+// container is torn down even if m.Run() panics before returning. It also stops
+// the shared in-process mochi broker: the untagged unit tests (which start it)
+// are compiled into the integration binary too, so it would otherwise leak here.
 func runTestsWithShutdown(m *testing.M) int {
 	defer func() {
 		if sharedBrokerShutdown != nil {
 			sharedBrokerShutdown()
 		}
+		stopSharedInternalBroker()
 	}()
 	return m.Run()
 }

--- a/adapters/mqtt/testmain_unit_test.go
+++ b/adapters/mqtt/testmain_unit_test.go
@@ -1,0 +1,23 @@
+//go:build !integration
+
+package mqtt
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain (unit build) runs the package tests and then stops the shared
+// in-process mochi broker that initSharedInternalBroker starts lazily, so the
+// broker goroutine and its listener socket are released rather than leaked to
+// process exit.
+//
+// The integration build supplies its own TestMain (testmain_integration_test.go,
+// //go:build integration) for the Mosquitto container; the mutually-exclusive
+// build tags (!integration here, integration there) guarantee exactly one
+// TestMain per build configuration — Go forbids two.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	stopSharedInternalBroker()
+	os.Exit(code)
+}

--- a/adapters/mqtt/topicns.go
+++ b/adapters/mqtt/topicns.go
@@ -98,8 +98,8 @@ func (n TopicNamespace) String() string { return n.value }
 // namespace if it equals the prefix exactly or starts with prefix + "/".
 //
 // Returns ErrAdapterMQTTInvalidTopicNamespace for the zero-value receiver,
-// ErrAdapterMQTTInvalidSubscribeFilter for wildcard/empty topic violations,
-// and ErrAdapterMQTTTopicOutsideNamespace for boundary violations.
+// ErrAdapterMQTTInvalidPublishTopic for wildcard/empty topic violations, and
+// ErrAdapterMQTTTopicOutsideNamespace for boundary violations.
 func (n TopicNamespace) PublishOK(topic string) error {
 	if n.value == "" {
 		return errcode.New(
@@ -110,14 +110,14 @@ func (n TopicNamespace) PublishOK(topic string) error {
 	}
 	if topic == "" {
 		return errcode.New(
-			errcode.KindInvalid, ErrAdapterMQTTInvalidSubscribeFilter,
+			errcode.KindInvalid, ErrAdapterMQTTInvalidPublishTopic,
 			msgEmptyTopic,
 			errcode.WithDetails(errcode.PublicString(detailKeyNamespace, n.value)),
 		)
 	}
 	if strings.ContainsAny(topic, "+#") {
 		return errcode.New(
-			errcode.KindInvalid, ErrAdapterMQTTInvalidSubscribeFilter,
+			errcode.KindInvalid, ErrAdapterMQTTInvalidPublishTopic,
 			msgPublishTopicWildcard,
 			errcode.WithDetails(
 				errcode.PublicString(detailKeyNamespace, n.value),

--- a/adapters/mqtt/topicns.go
+++ b/adapters/mqtt/topicns.go
@@ -105,7 +105,7 @@ func (n TopicNamespace) PublishOK(topic string) error {
 		return errcode.New(
 			errcode.KindInvalid, ErrAdapterMQTTInvalidTopicNamespace,
 			msgZeroNamespaceReceiver,
-			errcode.WithDetails(errcode.PublicString(detailKeyTopic, topic)),
+			errcode.WithInternal(errcode.InternalAttr(detailKeyTopic, topic)),
 		)
 	}
 	if topic == "" {
@@ -121,8 +121,8 @@ func (n TopicNamespace) PublishOK(topic string) error {
 			msgPublishTopicWildcard,
 			errcode.WithDetails(
 				errcode.PublicString(detailKeyNamespace, n.value),
-				errcode.PublicString(detailKeyTopic, topic),
 			),
+			errcode.WithInternal(errcode.InternalAttr(detailKeyTopic, topic)),
 		)
 	}
 	if topic == n.value {
@@ -136,8 +136,8 @@ func (n TopicNamespace) PublishOK(topic string) error {
 		msgTopicOutsideNamespace,
 		errcode.WithDetails(
 			errcode.PublicString(detailKeyNamespace, n.value),
-			errcode.PublicString(detailKeyTopic, topic),
 		),
+		errcode.WithInternal(errcode.InternalAttr(detailKeyTopic, topic)),
 	)
 }
 
@@ -156,7 +156,7 @@ func (n TopicNamespace) SubscribeOK(filter string) error {
 		return errcode.New(
 			errcode.KindInvalid, ErrAdapterMQTTInvalidTopicNamespace,
 			msgZeroNamespaceReceiver,
-			errcode.WithDetails(errcode.PublicString(detailKeyFilter, filter)),
+			errcode.WithInternal(errcode.InternalAttr(detailKeyFilter, filter)),
 		)
 	}
 	if filter == "" {
@@ -175,7 +175,7 @@ func (n TopicNamespace) SubscribeOK(filter string) error {
 				return errcode.New(
 					errcode.KindInvalid, ErrAdapterMQTTInvalidSubscribeFilter,
 					msgInvalidWildcardPlacement,
-					errcode.WithDetails(errcode.PublicString(detailKeyFilter, filter)),
+					errcode.WithInternal(errcode.InternalAttr(detailKeyFilter, filter)),
 				)
 			}
 			continue
@@ -188,7 +188,7 @@ func (n TopicNamespace) SubscribeOK(filter string) error {
 			return errcode.New(
 				errcode.KindInvalid, ErrAdapterMQTTInvalidSubscribeFilter,
 				msgInvalidWildcardPlacement,
-				errcode.WithDetails(errcode.PublicString(detailKeyFilter, filter)),
+				errcode.WithInternal(errcode.InternalAttr(detailKeyFilter, filter)),
 			)
 		}
 	}
@@ -206,8 +206,8 @@ func (n TopicNamespace) SubscribeOK(filter string) error {
 		msgSubscribeOutsideNS,
 		errcode.WithDetails(
 			errcode.PublicString(detailKeyNamespace, n.value),
-			errcode.PublicString(detailKeyFilter, filter),
 		),
+		errcode.WithInternal(errcode.InternalAttr(detailKeyFilter, filter)),
 	)
 }
 

--- a/adapters/mqtt/topicns.go
+++ b/adapters/mqtt/topicns.go
@@ -243,3 +243,35 @@ func isValidNSLevel(lvl string) bool {
 	}
 	return true
 }
+
+// publishableTopic carries a topic string that has been validated against a
+// TopicNamespace via PublishOK. Package-unexported and constructed exclusively
+// by TopicNamespace.Mint — the only way to obtain a publishableTopic is to
+// call Mint, which internally calls PublishOK. This encodes "PublishOK
+// precedence" as a type-system invariant: any callsite that accepts a
+// publishableTopic is guaranteed (at compile time) that the topic has passed
+// namespace validation.
+//
+// The Connection.Publish method (mqtt internal funnel) accepts only
+// publishableTopic, so no other package can drive a publish without minting
+// a topic through PublishOK. The single sanctioned holder + sealed
+// construction Hard funnel pattern. See archtest MQTT-PUBLISH-CALLSITE-FUNNEL-01.
+type publishableTopic struct {
+	topic string
+}
+
+// Mint validates topic against this namespace via PublishOK and returns a
+// publishableTopic on success. Caller passes the result to Connection.Publish
+// (or to any future publish helper) — the type system guarantees PublishOK
+// has been called.
+func (n TopicNamespace) Mint(topic string) (publishableTopic, error) {
+	if err := n.PublishOK(topic); err != nil {
+		return publishableTopic{}, err
+	}
+	return publishableTopic{topic: topic}, nil
+}
+
+// String returns the validated topic string. Provided for slog logging and
+// for the internal Publish path to read the topic when constructing the
+// paho.Publish packet.
+func (t publishableTopic) String() string { return t.topic }

--- a/adapters/mqtt/topicns_test.go
+++ b/adapters/mqtt/topicns_test.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -245,5 +246,149 @@ func TestTopicNamespace_SubscribeOK_WildcardErrorCodes(t *testing.T) {
 				t.Errorf("SubscribeOK(%q) code = %v, want %v", tc.filter, ec.Code, tc.wantCode)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// publishableTopic / TopicNamespace.Mint tests (B3a)
+// ---------------------------------------------------------------------------
+
+// TestTopicNamespace_Mint_Success verifies that Mint returns a non-zero
+// publishableTopic with String() == the input topic when the topic passes
+// PublishOK validation.
+func TestTopicNamespace_Mint_Success(t *testing.T) {
+	t.Parallel()
+	ns, err := ParseTopicNamespace("ns")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	pt, err := ns.Mint("ns/foo")
+	if err != nil {
+		t.Fatalf("Mint(%q) unexpected error: %v", "ns/foo", err)
+	}
+	if pt.String() != "ns/foo" {
+		t.Errorf("publishableTopic.String() = %q, want %q", pt.String(), "ns/foo")
+	}
+	// Also verify exact-topic (prefix == topic) succeeds.
+	pt2, err := ns.Mint("ns")
+	if err != nil {
+		t.Fatalf("Mint(%q) unexpected error: %v", "ns", err)
+	}
+	if pt2.String() != "ns" {
+		t.Errorf("publishableTopic.String() = %q, want %q", pt2.String(), "ns")
+	}
+}
+
+// TestTopicNamespace_Mint_PublishOKFailure verifies that Mint of an
+// out-of-namespace topic returns the zero publishableTopic and a non-nil error
+// with code ErrAdapterMQTTTopicOutsideNamespace.
+func TestTopicNamespace_Mint_PublishOKFailure(t *testing.T) {
+	t.Parallel()
+	ns, err := ParseTopicNamespace("ns1")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	pt, err := ns.Mint("ns2/x")
+	if err == nil {
+		t.Fatalf("Mint(out-of-namespace) expected error, got nil")
+	}
+	if pt != (publishableTopic{}) {
+		t.Errorf("Mint(out-of-namespace) returned non-zero publishableTopic: %v", pt)
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != ErrAdapterMQTTTopicOutsideNamespace {
+		t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTTopicOutsideNamespace)
+	}
+}
+
+// TestTopicNamespace_Mint_Empty verifies that Mint of an empty string returns
+// an error with code ErrAdapterMQTTInvalidSubscribeFilter (per PublishOK rule
+// for empty topics).
+func TestTopicNamespace_Mint_Empty(t *testing.T) {
+	t.Parallel()
+	ns, err := ParseTopicNamespace("ns")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	_, err = ns.Mint("")
+	if err == nil {
+		t.Fatal("Mint(empty) expected error, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != ErrAdapterMQTTInvalidSubscribeFilter {
+		t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidSubscribeFilter)
+	}
+}
+
+// TestTopicNamespace_Mint_Wildcard verifies that Mint of a wildcard topic
+// returns an error with code ErrAdapterMQTTInvalidSubscribeFilter.
+func TestTopicNamespace_Mint_Wildcard(t *testing.T) {
+	t.Parallel()
+	ns, err := ParseTopicNamespace("ns")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	for _, wc := range []string{"ns/+", "ns/#", "ns/a/+"} {
+		wc := wc
+		t.Run(wc, func(t *testing.T) {
+			t.Parallel()
+			_, err := ns.Mint(wc)
+			if err == nil {
+				t.Fatalf("Mint(%q) expected error, got nil", wc)
+			}
+			var ec *errcode.Error
+			if !errors.As(err, &ec) {
+				t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+			}
+			if ec.Code != ErrAdapterMQTTInvalidSubscribeFilter {
+				t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidSubscribeFilter)
+			}
+		})
+	}
+}
+
+// TestTopicNamespace_Mint_ZeroNS verifies that calling Mint on a zero-value
+// TopicNamespace returns an error with code ErrAdapterMQTTInvalidTopicNamespace.
+func TestTopicNamespace_Mint_ZeroNS(t *testing.T) {
+	t.Parallel()
+	var ns TopicNamespace
+	_, err := ns.Mint("x")
+	if err == nil {
+		t.Fatal("Mint on zero-value namespace expected error, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != ErrAdapterMQTTInvalidTopicNamespace {
+		t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidTopicNamespace)
+	}
+}
+
+// TestPublishableTopic_FieldFreeze locks the publishableTopic struct shape:
+// exactly one field named "topic" of type string, unexported. Any accidental
+// drift (rename, type change, export, new field) fails this test before it
+// could silently break the sealed-construction invariant.
+func TestPublishableTopic_FieldFreeze(t *testing.T) {
+	t.Parallel()
+	rt := reflect.TypeOf(publishableTopic{})
+	if rt.NumField() != 1 {
+		t.Errorf("publishableTopic NumField = %d, want 1", rt.NumField())
+	}
+	f := rt.Field(0)
+	if f.Name != "topic" {
+		t.Errorf("field[0].Name = %q, want %q", f.Name, "topic")
+	}
+	if f.Type.Kind() != reflect.String {
+		t.Errorf("field[0].Type = %v, want string", f.Type.Kind())
+	}
+	if f.IsExported() {
+		t.Error("field[0] is exported; want unexported")
 	}
 }

--- a/adapters/mqtt/topicns_test.go
+++ b/adapters/mqtt/topicns_test.go
@@ -93,6 +93,32 @@ func TestTopicNamespace_PublishOK(t *testing.T) {
 	}
 }
 
+func TestTopicNamespace_PublishOK_InvalidPublishTopicCode(t *testing.T) {
+	t.Parallel()
+	ns, err := ParseTopicNamespace("ns")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	for _, topic := range []string{"", "ns/+", "ns/#", "ns/a/+"} {
+		topic := topic
+		t.Run(topic, func(t *testing.T) {
+			t.Parallel()
+			err := ns.PublishOK(topic)
+			if err == nil {
+				t.Fatalf("PublishOK(%q) expected error, got nil", topic)
+			}
+			var ec *errcode.Error
+			if !errors.As(err, &ec) {
+				t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+			}
+			if ec.Code != ErrAdapterMQTTInvalidPublishTopic {
+				t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidPublishTopic)
+			}
+		})
+	}
+}
+
 func TestTopicNamespace_SubscribeOK(t *testing.T) {
 	ns, err := ParseTopicNamespace("ns")
 	if err != nil {
@@ -305,8 +331,8 @@ func TestTopicNamespace_Mint_PublishOKFailure(t *testing.T) {
 }
 
 // TestTopicNamespace_Mint_Empty verifies that Mint of an empty string returns
-// an error with code ErrAdapterMQTTInvalidSubscribeFilter (per PublishOK rule
-// for empty topics).
+// an error with code ErrAdapterMQTTInvalidPublishTopic (per PublishOK rule for
+// empty topics).
 func TestTopicNamespace_Mint_Empty(t *testing.T) {
 	t.Parallel()
 	ns, err := ParseTopicNamespace("ns")
@@ -321,13 +347,13 @@ func TestTopicNamespace_Mint_Empty(t *testing.T) {
 	if !errors.As(err, &ec) {
 		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
 	}
-	if ec.Code != ErrAdapterMQTTInvalidSubscribeFilter {
-		t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidSubscribeFilter)
+	if ec.Code != ErrAdapterMQTTInvalidPublishTopic {
+		t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidPublishTopic)
 	}
 }
 
 // TestTopicNamespace_Mint_Wildcard verifies that Mint of a wildcard topic
-// returns an error with code ErrAdapterMQTTInvalidSubscribeFilter.
+// returns an error with code ErrAdapterMQTTInvalidPublishTopic.
 func TestTopicNamespace_Mint_Wildcard(t *testing.T) {
 	t.Parallel()
 	ns, err := ParseTopicNamespace("ns")
@@ -346,8 +372,8 @@ func TestTopicNamespace_Mint_Wildcard(t *testing.T) {
 			if !errors.As(err, &ec) {
 				t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
 			}
-			if ec.Code != ErrAdapterMQTTInvalidSubscribeFilter {
-				t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidSubscribeFilter)
+			if ec.Code != ErrAdapterMQTTInvalidPublishTopic {
+				t.Errorf("code = %s, want %s", ec.Code, ErrAdapterMQTTInvalidPublishTopic)
 			}
 		})
 	}

--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -5,7 +5,7 @@
 | ADR ID | 048 |
 | 状态 | Accepted |
 | 日期 | 2026-05-28 |
-| 实施 PR 系列 | PR-1 (`073-mqtt-adapter-pr1`) … PR-5 |
+| 实施 PR 系列 | PR-1 (`073-mqtt-adapter-pr1`, merged) … PR-5 |
 | 关联 Epic | gh issue #1138 |
 | 关联 Spec | `docs/plans/specs/202605262101-047-mqtt-adapter/spec.md` |
 | 关联 Plan | `docs/plans/specs/202605262101-047-mqtt-adapter/plan.md` |
@@ -93,6 +93,60 @@ sealed struct 的上游 Hard 来自 Go 可见性规则：包外无法构造 unex
 - adapters/rabbitmq 原有 `rabbitmq/backoff.go` 与本 adapter 需要的逻辑完全相同。
 - 单源治理（DRY），避免 backoff 参数语义在两个 adapter 间悄悄漂移。
 
+### 2.7 PUBACK 错误映射（PR-2 落地）
+
+**决策**：`classifyPubackReason` 将 MQTT v5 PUBACK reason code 映射到独立的 `errcode.Code` + `errcode.Kind`，以及 `PublishFailureReason` metric label，三者保持 1:1 对应。
+
+**完整映射表**（ref: MQTT v5.0 spec §3.4.2.1）：
+
+| PUBACK 0x__ | 规范名称 | errcode.Code | errcode.Kind | Disposition 语义 | metric reason |
+|-------------|---------|--------------|--------------|----------------|---------------|
+| 0x00 | Success | — (Ack path) | — | outbox.Ack | — (success path) |
+| 0x10 | NoMatchingSubscribers | `ErrAdapterMQTTPublishNoSubscribers` | `KindUnavailable` | Ack + slog.Warn（broker 接受但无 subscriber，视为成功）| — (success path) |
+| 0x80 | UnspecifiedError | `ErrAdapterMQTTPublishRejected` | `KindInternal` | outbox.Reject | `rejected` |
+| 0x83 | ImplementationSpecificError | `ErrAdapterMQTTPublishRejected` | `KindInternal` | outbox.Reject | `rejected` |
+| 0x87 | NotAuthorized | `ErrAdapterMQTTPublishNotAuthorized` | **`KindUnavailable`** | **outbox.Requeue** | `not_authorized` |
+| 0x90 | TopicNameInvalid | `ErrAdapterMQTTPublishRejected` | `KindInvalid` | outbox.Reject | `rejected` |
+| 0x97 | QuotaExceeded | `ErrAdapterMQTTPublishRateLimited` | `KindUnavailable` | outbox.Requeue | `rate_limited` |
+| 0x99 | PayloadFormatInvalid | `ErrAdapterMQTTPublishPayloadFormatInvalid` | **`KindInvalid`** | outbox.Reject | `payload_format_invalid` |
+| default | (未知代码) | `ErrAdapterMQTTPublishRejected` | `KindInternal` | outbox.Reject | `rejected` |
+
+**关键决策理由**：
+
+**0x87 NotAuthorized → KindUnavailable（retryable）**：PUBACK 0x87 与 CONNACK 0x87 对齐——CONNACK 侧已归为 `classPermanentRetain`（readyz 503 + autopaho 继续重连等待 operator 修复）。PUBACK 侧同理：ACL 配置错误是 operator 可修复的运维问题，条件在 operator 修复 broker ACL 后自然消失。将其设为 retryable 使 outbox relay 在修复期间持续重试（受 retry budget 约束，耗尽后走 DLX），而非当作永久客户端错误直接丢弃消息。此语义与 `ErrAdapterMQTTPublishRejected`（KindInternal，永久）的区别在于：Rejected 代表消息本身不可接受（格式/路由错误），NotAuthorized 代表操作权限不足（外部条件）。
+
+**0x99 PayloadFormatInvalid → 独立错误码 `ErrAdapterMQTTPublishPayloadFormatInvalid`（KindInvalid）**：payload 格式问题与 payload 尺寸问题（`ErrAdapterMQTTPayloadTooLarge`，0x95 broker 侧拒绝）是不同失败域：format 是内容编码错误，size 是物理限制。复用同一错误码会混淆告警维度（format invalid 应检查 payload 编码逻辑；too large 应检查 MaximumPacketSize 配置），故引入独立码。两者均为 KindInvalid + Reject，语义一致。
+
+**`never_connected` reason 从 metric 删除**：`mqtt_publish_failed_total` 的 `reason` label 原计划含 `never_connected`，但 `Connection.Publish` 不做 phase 检查——pre-connect 阶段的 publish 调用经 autopaho 内部排队，等连接建立后发送，不会被 publisher 侧以 `NeverConnected` 错误拒绝；失败表现为 `puback_timeout` 或 `context_canceled`。该 label 在 publisher 路径结构上永不 emit，故删除以保持闭集完整性。`ErrAdapterMQTTNeverConnected` 错误码保留供 Health probe / WaitConnected 超时路径使用。
+
+**metric `reason` 闭集**（PR-2 落地后完整集合，共 10 个）：
+`payload_too_large`, `closed`, `puback_timeout`, `context_canceled`, `publish_error`, `topic_outside_namespace`, `rate_limited`, `not_authorized`, `payload_format_invalid`, `rejected`
+
+### 2.8 NewPublisher 构造函数签名：`(*Publisher, error)` vs `*Publisher` + panic
+
+**决策**：`NewPublisher` 返回 `(*Publisher, error)`，而非 `*Publisher` + 内部 panic（不对齐 `adapters/rabbitmq.NewPublisher`）。
+
+**参数分类与处理方式**：
+
+| 参数 | 分类 | 错误处理 |
+|------|------|---------|
+| `clk clock.Clock` | 程序员错误（编译期忘传，位置参）| `clock.MustHaveClock(clk, ...)` panic（B 类，同 rabbitmq） |
+| `conn *Connection` | 运行时值（依赖注入，可为 nil）| 返回 `error`（结构化诊断）|
+| `ns TopicNamespace` | 运行时值（依赖注入，可为零值）| 返回 `error`（结构化诊断）|
+
+**理由**：
+- `nil clock` 是 programmer error：调用方在编译期已知类型，漏传是代码缺陷；panic 与 `clock.MustHaveClock` 统一语义（CLOCK-POSITIONAL-INJECTION-01），与 rabbitmq 一致。
+- `nil Connection` / 零值 `TopicNamespace` 是 caller 在 runtime 传入的依赖值（来自 DI 容器、配置解析、环境变量），失败原因是 wiring 配置错误，不是 programmer error。bootstrap wiring 路径需要结构化错误（errcode.Error with Details）来产生可观测的诊断日志，而 panic 会阻断 wiring 流程并产生不友好的 stack trace。
+- 此决策使 `NewPublisher` 与 GoCell 中 `NewService` 系列构造函数的模式一致（required dep → validateRequired() → returned error），只是 clock 参数因其 programmer-error 语义保留 panic。
+
+ref: `adapters/rabbitmq/publisher.go` — `NewPublisher(*Publisher)` + `clock.MustHaveClock`；对比见 PR-2 `adapters/mqtt/publisher.go` 签名注释。
+
+### 2.9 onServerDisconnect 使用 disconnectReasonName（PR-2 落地）
+
+**决策**：`onServerDisconnect` callback 调用 `disconnectReasonName`（MQTT v5 §3.14.2.1 DISCONNECT reason code 表），而非 `connackReasonName`（§3.2.2.2 CONNACK 表）。
+
+**理由**：CONNACK 与 DISCONNECT 两个包虽有若干数值重叠，但每个 code 在不同包类型下的含义不同（例如 0x87 在 CONNACK 表示"连接未授权"，在 DISCONNECT 表示"会话被踢"，语义相关但上下文不同）。统一用一张表会产生 slog 日志中的 reason_name 字段与 broker 实际语义不符的问题，导致运维混淆。三张独立表（connackReasonNames / pubackReasonNames / disconnectReasonNames）分别锁定各自 spec 章节，互不复用。
+
 ---
 
 ## 3. 威胁矩阵 / Threat Model
@@ -100,7 +154,7 @@ sealed struct 的上游 Hard 来自 Go 可见性规则：包外无法构造 unex
 | 威胁 | 缓解 | 状态 |
 |------|------|------|
 | connect URL 中的 credentials 泄漏到 slog/span | `redact.go::redactConnectURL` 走 `pkg/redaction.RedactString` | ✅ PR-1 |
-| payload PII 泄漏到 slog/span | publish/subscribe 路径 payload 走 `pkg/redaction.RedactPayload`；span attribute 走 `safeStringAttr`（`SPAN-SETATTR-REDACT-01` 覆盖） | ✅ PR-2/3 实施 |
+| payload PII 泄漏到 slog/span | publish 路径 payload 走 `pkg/redaction.RedactPayload`；span attribute 走 `safeStringAttr`（`SPAN-SETATTR-REDACT-01` 覆盖）；subscribe 路径 PR-3 实施 | ✅ PR-2（publish）/ ⏳ PR-3（subscribe） |
 | CONNACK 0x81/0x82 (protocol/identifier error) | bootstrap fail-fast：onConnectError → classBootstrapFatal → bootstrapErrCh → Open 返回错误 | ✅ PR-1 |
 | CONNACK 0x84/0x85/0x8A (unsupported protocol version / invalid client ID / banned) | bootstrap fail-fast（protocol/identity 配置错误不可自愈） | ✅ PR-1 |
 | CONNACK 0x87/0x86/0x8C (operator-fixable not-authorized / bad-creds / bad-auth-method) | classPermanentRetain：readyz 503，autopaho 继续重连等待 operator 修复；首次失败也经 outcomeCh 透传给 Open，errcode Details 含 reasonCode + reasonName | ✅ PR-1 round-1 |
@@ -115,14 +169,17 @@ sealed struct 的上游 Hard 来自 Go 可见性规则：包外无法构造 unex
 | publish 空 topic（MQTT v5 §4.7.3 禁止）/ subscribe 空 filter | PublishOK / SubscribeOK 在 wildcard 检查之前先拒空字符串 | ✅ PR-1 round-2 |
 | 零值 TopicNamespace receiver 静默通过（包内 `var ns TopicNamespace` programmer error） | PublishOK / SubscribeOK 顶部 `if n.value == ""` 拒绝 → ErrAdapterMQTTInvalidTopicNamespace | ✅ PR-1 round-2 |
 | KeepAlive / SessionExpiry < 1s floor-truncation 到 wire 0 (uint16/uint32 截断) | validateTimings 下界 `cfg.KeepAlive < time.Second` 拒；`SessionExpiry > 0 && < 1s` 拒 | ✅ PR-1 round-2 |
-| raw `Client() *autopaho.ConnectionManager` 暴露为业务 publish/subscribe 永久绕过 TopicNamespace funnel | round-2 删除 `Client()` accessor；PR-2/3 typed Publish/Subscribe 与 #1225 callsite funnel 同期落地 | ✅ PR-1 round-2 |
+| raw `Client() *autopaho.ConnectionManager` 暴露为业务 publish/subscribe 永久绕过 TopicNamespace funnel | round-2 删除 `Client()` accessor；PR-2 typed Publish + `MQTT-PUBLISH-CALLSITE-FUNNEL-01` callsite funnel 已落地 | ✅ PR-1 round-2 + PR-2 |
 | connect URL query/fragment 中的 secret（redactConnectURL userinfo-only 早返回） | `redactConnectURL` 始终 compose `url.URL.Redacted()` 与 `pkg/redaction.RedactString` 两层 | ✅ PR-1 round-1 |
 | TLS handshake fail (x509: certificate signed by unknown authority) | bootstrap fail-fast：classifyConnackReason x509 err → classBootstrapFatal | ✅ PR-1 |
 | 网络瞬断 / broker 重启 | classTransient → autopaho 内置重连 + ExponentialBackoffWithJitter | ✅ PR-1 |
 | MQTT clientId 碰撞（broker 踢旧连接） | ParseEphemeralClientID 嵌入 uuid 保证跨实例唯一；ParseStableClientID 由 caller 控制 instanceID 服务持久会话 | ✅ PR-1 round-1 |
-| publish 到 cell namespace 外的 topic | TopicNamespace.PublishOK 在 Publisher 调用前拦截 | ⏳ PR-2 (#1225) |
-| subscribe 到 cell namespace 外的 filter | TopicNamespace.SubscribeOK 在 Subscriber 调用前拦截 | ⏳ PR-3 (#1225) |
-| QoS 1 PUBACK 超时（broker 慢） | publisher retry backoff (Requeue)；超时后 errcode.KindUnavailable | ⏳ PR-2 |
+| publish 到 cell namespace 外的 topic | `(*Connection).Publish` 调用 `ns.PublishOK` 拦截；`MQTT-PUBLISH-CALLSITE-FUNNEL-01` A1/A2/A3/A4 锁定所有 cm.Publish 调用点 | ✅ PR-2 |
+| PUBACK 0x87 NotAuthorized 被当永久错误导致消息丢弃 | classifyPubackReason → KindUnavailable + Requeue；operator 修复 ACL 后 retry 自然成功；retry budget 耗尽走 DLX（见 §2.7）| ✅ PR-2 |
+| PUBACK 0x99 PayloadFormatInvalid 被误判为 size 问题 | 独立错误码 ErrAdapterMQTTPublishPayloadFormatInvalid（KindInvalid）+ metric reason `payload_format_invalid`，与 PayloadTooLarge 失败域分离（见 §2.7）| ✅ PR-2 |
+| QoS 1 PUBACK 超时（broker 慢） | Publisher 构造时注入 `cfg.PublishTimeout`；超时 → ErrAdapterMQTTPubAckTimeout（KindUnavailable）→ outbox Requeue | ✅ PR-2 |
+| onServerDisconnect 使用错误的 reason code 表导致日志混淆 | `disconnectReasonName` 使用 §3.14.2.1 DISCONNECT 表，不复用 connackReasonName（§3.2.2.2）（见 §2.9）| ✅ PR-2 |
+| subscribe 到 cell namespace 外的 filter | TopicNamespace.SubscribeOK 在 Subscriber 调用前拦截 | ⏳ PR-3 |
 | Reject 消息堆积在 DLT topic | `$dead/<topic>` 独立 subscriber + metric dlx_total 可观测 | ⏳ PR-4 |
 | mTLS 证书过期 | bootstrap fail-fast（x509 handshake fail）；cert rotation 通过 Vault PKI（nightly TLS test） | ⏳ PR-4 nightly |
 
@@ -133,22 +190,22 @@ sealed struct 的上游 Hard 来自 Go 可见性规则：包外无法构造 unex
 | Archtest ID | 文件 | 评级 | 说明 |
 |-------------|------|------|------|
 | `MQTT-CLIENT-ID-NAMESPACE-01` | `tools/archtest/mqtt_funnel_test.go` | Hard 上游（包外 compile gate）+ Medium 上游（包内 archtest A2）| sealed-struct field freeze (A1) + construction allowlist (A2, allowedFuncs = {assembleClientID}) + no alias (A3) + A2 scanner red-fixture self-check (round-1) |
-| `MQTT-TOPIC-NAMESPACE-01` | `tools/archtest/mqtt_funnel_test.go` | 同上 | 同上，下游 callsite funnel 延迟 PR-2/3 (#1225) |
+| `MQTT-TOPIC-NAMESPACE-01` | `tools/archtest/mqtt_funnel_test.go` | 同上 | 同上，下游 callsite funnel 由 MQTT-PUBLISH-CALLSITE-FUNNEL-01 在 PR-2 落地 |
 | `MQTT-CONFIG-VALIDATE-FIRST-01` (round-1) | `tools/archtest/mqtt_config_validate_first_test.go` | Medium 下游（form-lock）| Open 函数体 cfg.Validate 必须在 autopaho.NewConnection 之前调用；Hard 升级（sealed Config + NewConfig 唯一构造）追踪 #1231 |
+| `MQTT-PUBLISH-CALLSITE-FUNNEL-01` (PR-2) | `tools/archtest/mqtt_callsite_funnel_test.go` | Hard 下游（A1/A2/A4: callsite allowlist）+ Medium 下游（A3: type-aware）| A1: 所有 cm.Publish 调用必须在 `(*Connection).Publish` 体内；A2: publishableTopic struct literal 只能在 Mint 体内构造；A3: TopicNamespace.PublishOK 返回类型 publishableTopic 守 type-level；A4: cm.Publish 不得用作 method-value |
 | `PROBENAME-SEALED-FUNNEL-01` (既有，扩 inventory) | `tools/archtest/probename_sealed_funnel_test.go` | Hard downstream (A2) + Medium upstream (A1) | `mqtt_ready` 加入 probeNameSanctionedPkgs + adapterSanctionedPkgs + goldenProbeNames() |
 
-ClientID Funnel 评级表（round-1 amended）：
+ClientID / TopicNamespace Funnel 评级表（PR-2 updated）：
 
-| Funnel | 上游构造 | 下游 callsite | PR-1 round-1 状态 |
-|--------|---------|--------------|-------------------|
+| Funnel | 上游构造 | 下游 callsite | 状态 |
+|--------|---------|--------------|------|
 | `ClientID` typed function choice | Hard 包外（sealed struct）+ Medium 包内（A2 + red-fixture self-check）| Hard `Config.ClientID` 类型化 | ✅ {ParseEphemeralClientID, ParseStableClientID} → assembleClientID 单 callsite |
 | `TopicNamespace` 类型 | 同上 | — | ✅ 类型/构造 seal |
-| `TopicNamespace` publish/subscribe callsite | — | Hard 延迟 PR-2/3 (#1225) | ⏳ |
+| `TopicNamespace` publish callsite | — | Hard（MQTT-PUBLISH-CALLSITE-FUNNEL-01 A1–A4，PR-2）| ✅ gh issue #1225 closed |
+| `TopicNamespace` subscribe callsite | — | Hard 延迟 PR-3 | ⏳ |
 | ConnectionManager 包外可达性 (raw `Client()` 出口) | round-2 删除；包外仅可见 typed surface | Hard（type system 包外不可达）| ✅ round-2 |
 | `TopicNamespace` receiver guards (zero-value + 空 topic/filter) | sealed-struct + ParseTopicNamespace | Cx1 受方法侧拒绝守护 | ✅ round-2 |
 | `Config` validate-first | — | Medium archtest form-lock | ✅ 升 Hard 追踪 #1231 |
-
-下游 callsite funnel（publish/subscribe topic 参数必须经 PublishOK/SubscribeOK）：gh issue #1225 跟踪，PR-2/3 实施，现在写是 vacuous-pass。
 
 延续 Soft 模式同步登记的升级 backlog（round-1）：
 

--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -97,6 +97,8 @@ sealed struct 的上游 Hard 来自 Go 可见性规则：包外无法构造 unex
 
 **决策**：`classifyPubackReason` 将 MQTT v5 PUBACK reason code 映射到独立的 `errcode.Code` + `errcode.Kind`，以及 `PublishFailureReason` metric label，三者保持 1:1 对应。
 
+**控制流（关键）**：paho 对 PUBACK **reason code ≥ 0x80** 走 **error 通道**返回 `(resp, err)`（`resp.ReasonCode` 已设，`err` 非 nil；见 `paho/client.go:923`），**不是**经 nil-error 的 `resp` 返回。因此 `< 0x80`（0x00 / 0x10）走 `Publisher.Publish` 成功分支，`≥ 0x80` 走 `err != nil` 分支由 `handlePublishError` 处理——后者**必须**先用 `resp.ReasonCode` 驱动 `classifyPubackReason`，再回落到 transport/ctx 兜底。早期实现把 `err != nil` 直接 `wrapPublishErr`，导致下表 0x80/0x83/0x87/0x90/0x97/0x99 全部塌缩成 generic `ErrAdapterMQTTPublishFailed`——`classifyPubackReason` 对这些 code 实为死代码。该路径由 `TestPublisher_Publish_BrokerRejectedPUBACK_RealPath`（真实 broker 返回 ≥0x80 reason，断言专属 errcode）守护防复发。
+
 **完整映射表**（ref: MQTT v5.0 spec §3.4.2.1）：
 
 | PUBACK 0x__ | 规范名称 | errcode.Code | errcode.Kind | Disposition 语义 | metric reason |

--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -167,8 +167,8 @@ ref: `adapters/rabbitmq/publisher.go` — `NewPublisher(*Publisher)` + `clock.Mu
 | MaximumPacketSize 死字段（Config 暴露但 wire 不下发） | `connectPacketBuilder` 把 cfg.MaximumPacketSize 注入 paho.Connect.Properties | ✅ PR-1 round-1 |
 | bootstrap-fatal CONNACK 信号被 select race 吞掉 | outcomeCh 单 channel 表达 connected/permErr，删 connectedCh+bootstrapErrCh 双轨设计 | ✅ PR-1 round-1 |
 | WaitConnected 在 Close 后悄悄阻塞 ctx | 循环顶部检查 `c.closed` 返回 ErrAdapterMQTTClosed；ctx 取消走 errcode.WrapInfra(ErrAdapterMQTTConnectTimeout, …) | ✅ PR-1 round-1 |
-| publish 到 topic 含 `+/#` wildcard（MQTT v5 §3.3.2.1 禁止） | TopicNamespace.PublishOK 顶部 `strings.ContainsAny(topic, "+#")` 拒绝 → ErrAdapterMQTTInvalidSubscribeFilter | ✅ PR-1 round-1 |
-| publish 空 topic（MQTT v5 §4.7.3 禁止）/ subscribe 空 filter | PublishOK / SubscribeOK 在 wildcard 检查之前先拒空字符串 | ✅ PR-1 round-2 |
+| publish 到 topic 含 `+/#` wildcard（MQTT v5 §3.3.2.1 禁止） | TopicNamespace.PublishOK 顶部 `strings.ContainsAny(topic, "+#")` 拒绝 → ErrAdapterMQTTInvalidPublishTopic | ✅ PR-1 round-1 / PR-2 review hardening |
+| publish 空 topic（MQTT v5 §4.7.3 禁止）/ subscribe 空 filter | PublishOK 用 ErrAdapterMQTTInvalidPublishTopic；SubscribeOK 用 ErrAdapterMQTTInvalidSubscribeFilter；二者在 wildcard 检查之前先拒空字符串 | ✅ PR-1 round-2 / PR-2 review hardening |
 | 零值 TopicNamespace receiver 静默通过（包内 `var ns TopicNamespace` programmer error） | PublishOK / SubscribeOK 顶部 `if n.value == ""` 拒绝 → ErrAdapterMQTTInvalidTopicNamespace | ✅ PR-1 round-2 |
 | KeepAlive / SessionExpiry < 1s floor-truncation 到 wire 0 (uint16/uint32 截断) | validateTimings 下界 `cfg.KeepAlive < time.Second` 拒；`SessionExpiry > 0 && < 1s` 拒 | ✅ PR-1 round-2 |
 | raw `Client() *autopaho.ConnectionManager` 暴露为业务 publish/subscribe 永久绕过 TopicNamespace funnel | round-2 删除 `Client()` accessor；PR-2 typed Publish + `MQTT-PUBLISH-CALLSITE-FUNNEL-01` callsite funnel 已落地 | ✅ PR-1 round-2 + PR-2 |

--- a/docs/plans/specs/202605262101-047-mqtt-adapter/plan.md
+++ b/docs/plans/specs/202605262101-047-mqtt-adapter/plan.md
@@ -37,7 +37,7 @@
 |------|---------|------|
 | `doc.go` | 80 | package godoc + INVARIANT 锚点（archtest 入口） |
 | `config.go` | 250 | `Config{ClientID, Brokers, TLS, SessionExpiry, Auth, Backoff, ...}` + `Validate()` |
-| `clientid.go` | 100 | `type ClientID struct{value string}` (sealed struct) + `ParseClientID(cellID, role string) (ClientID, error)` |
+| `clientid.go` | 100 | `type ClientID struct{value string}` (sealed struct) + `ParseEphemeralClientID(cellID, role string) (ClientID, error)` + `ParseStableClientID(cellID, role, instanceID string) (ClientID, error)` |
 | `topicns.go` | 130 | `type TopicNamespace struct{value string}` (sealed struct) + `ParseTopicNamespace(ns string) (TopicNamespace, error)` + `PublishOK` / `SubscribeOK` funnel |
 | `connection.go` | 550 | autopaho wrap + reconnect 循环 + `Health() error` + `Close(ctx)` + permanentErr 状态机 |
 | `publisher.go` | 220 | `Publisher` 实现：`Publish(ctx, topic, payload) error`，QoS 1 + WaitConnected + 超时 |
@@ -89,7 +89,7 @@
 
 | 文件 | 估算行数 | 内容 |
 |------|---------|------|
-| `.github/workflows/_build-lint.yml` | +30 | integration-test job 加 mosquitto service container |
+| `.github/workflows/_build-lint.yml` | +30 | integration-test job 通过 testcontainers 自动发现新增的 `adapters/mqtt` integration 包（CI-INTEGRATION-DISCOVERY-01 自动接入，无需静态 service container 配置） |
 | `go.mod` / `go.sum` | +30 | autopaho v0.12 + mochi v2.7 + paho.golang/paho v0.21 |
 
 ### 2.6 iotdevice demo
@@ -138,11 +138,11 @@
 |------|------|
 | Publisher 实现 | `adapters/mqtt/publisher.go` |
 | Publisher 单测 | `publisher_test.go`（in-process mochi） |
-| 集成测试基础 | `testmain_integration_test.go`（Mosquitto GenericContainer + wait strategy） |
+| 集成测试基础 | `testmain_integration_test.go`（`testcontainers.GenericContainer` 起 `eclipse-mosquitto:2.0`，in-memory conf mount + wait.ForLog strategy；非 docker-compose static service container） |
 | 集成测试 publisher | `integration_test.go` PR-2 部分（仅 publisher 场景：QoS1 / broker 断连重连 / publish timeout） |
-| CI | `.github/workflows/_build-lint.yml` 加 mqtt mosquitto service container |
+| CI | `.github/workflows/_build-lint.yml` 通过 testcontainers auto-discovery（`CI-INTEGRATION-DISCOVERY-01`）接入，无需手动添加 mqtt service 配置 |
 
-**验收**：unit + integration（mosquitto container）publisher 路径全过；adapters shard CI 实测时长 +<60s。
+**验收**：unit + integration（testcontainers eclipse-mosquitto:2.0）publisher 路径全过；adapters shard CI 实测时长 +<60s（待 CI 实测回填；计划估算基于 rabbitmq integration 同类参考值）。
 
 ### PR-3 / 047-pr3: Subscriber + ConsumerBase 接入
 

--- a/tests/testutil/images.go
+++ b/tests/testutil/images.go
@@ -22,9 +22,10 @@ const (
 	// the @sha256 digest is the immutable content reference and authoritative pin.
 	MinIOImage = "minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
 
-	// MosquittoImage is the eclipse-mosquitto v2.0 MQTT broker image pinned by digest.
+	// MosquittoImage is the eclipse-mosquitto v2.0.22 MQTT broker image pinned by digest.
 	// Used by adapters/mqtt integration tests.
-	MosquittoImage = "eclipse-mosquitto:2.0@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268"
+	// Patch version confirmed via `docker image inspect eclipse-mosquitto:2.0 .Config.Labels["org.opencontainers.image.version"]`.
+	MosquittoImage = "eclipse-mosquitto:2.0.22@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268"
 )
 
 // RedisClusterTestAddrsEnv is the discovery env consumed by

--- a/tests/testutil/images.go
+++ b/tests/testutil/images.go
@@ -21,6 +21,10 @@ const (
 	// (verified from image labels: release="RELEASE.2025-09-07T16-13-09Z") and
 	// the @sha256 digest is the immutable content reference and authoritative pin.
 	MinIOImage = "minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+
+	// MosquittoImage is the eclipse-mosquitto v2.0 MQTT broker image pinned by digest.
+	// Used by adapters/mqtt integration tests.
+	MosquittoImage = "eclipse-mosquitto:2.0@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268"
 )
 
 // RedisClusterTestAddrsEnv is the discovery env consumed by

--- a/tools/archtest/mqtt_callsite_funnel_test.go
+++ b/tools/archtest/mqtt_callsite_funnel_test.go
@@ -39,9 +39,9 @@
 //     Mint body + zero-value error return. publishableTopic field-shape reflect lock.
 //     Permanent Go-language ceiling (same as SPAN-SETATTR-REDACT-01 /
 //     PROBENAME-SEALED-FUNNEL-01 package-internal side).
-//     Tracked for potential Hard upgrade — open follow-up gh issue per
-//     ai-robust.md §Funnel 双向锁评级 ("必须同步开 gh issue 跟踪显式 Hard
-//     化任务"). Sibling: SPAN-SETATTR-REDACT-01 tracks gh #851 for the same
+//     Tracked for potential Hard upgrade — gh #1247 per ai-robust.md §Funnel
+//     双向锁评级 ("必须同步开 gh issue 跟踪显式 Hard 化任务").
+//     Sibling: SPAN-SETATTR-REDACT-01 tracks gh #851 for the same
 //     package-internal seal-upgrade question.
 //
 // # Sub-rules

--- a/tools/archtest/mqtt_callsite_funnel_test.go
+++ b/tools/archtest/mqtt_callsite_funnel_test.go
@@ -88,6 +88,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -422,13 +423,14 @@ func TestMQTTPublishCallsiteFunnel_A3_PublishableTopicFieldFreeze(t *testing.T) 
 // publishableTopic (which is unexported and inaccessible from here).
 func TestMQTTPublishCallsiteFunnel_A3_ExportedTypesShape(t *testing.T) {
 	t.Parallel()
-	// Confirm that the sealed-struct pattern is consistent across the package:
-	// TopicNamespace and ClientID still have their single unexported "value" field.
-	// (publishableTopic's shape is checked via go/types in A3 above.)
-	import_mqtt_pkg := mqtt.TopicNamespace{}
-	_ = import_mqtt_pkg // force import
-	// Intentionally no reflect on publishableTopic — it is unexported.
-	// The A3 go/types check above covers it.
+	// Real reflect assertions (not a no-op): the exported sibling sealed structs
+	// must each keep exactly one unexported "value string" field. assertMQTT-
+	// SealedSingleValueField (mqtt_funnel_test.go, same package) fails the test
+	// on any drift (field export, rename, type change, extra field, or reversion
+	// to a string newtype). publishableTopic itself is unexported and checked via
+	// go/types in TestMQTTPublishCallsiteFunnel_A3_PublishableTopicFieldFreeze.
+	assertMQTTSealedSingleValueField(t, "TopicNamespace", reflect.TypeOf(mqtt.TopicNamespace{}))
+	assertMQTTSealedSingleValueField(t, "ClientID", reflect.TypeOf(mqtt.ClientID{}))
 }
 
 // ─── A4: method-value blind-spot reverse self-check ──────────────────────────
@@ -631,7 +633,7 @@ func TestMQTTPublishCallsiteFunnel_A6_BlindSpot_NoReflectMethodByName(t *testing
 					continue
 				}
 				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-					if !isMethodByNamePublishCall(call) {
+					if !isMethodByNamePublishCall(p.TypesInfo, call) {
 						return
 					}
 					pos := p.Fset.Position(call.Pos())
@@ -944,13 +946,41 @@ func f(v reflect.Value) { v.MethodByName("Publish") }
 	f := mqttParseSnippet(t, src)
 	var fired bool
 	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-		if isMethodByNamePublishCall(call) {
+		if isMethodByNamePublishCall(nil, call) { // nil info → literal fallback path
 			fired = true
 		}
 	})
 	assert.True(t, fired,
 		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A6: isMethodByNamePublishCall did not fire on a "+
-			"known MethodByName(\"Publish\") call — the detector is broken (A6 would pass vacuously)")
+			"known MethodByName(\"Publish\") literal call — the detector is broken (A6 would pass vacuously)")
+}
+
+// TestMQTTPublishCallsiteFunnel_A6_ScannerNonVacuous_ConstFolded proves the
+// const-eval path: a `const m = "Publish"; v.MethodByName(m)` form (which a
+// literal-only scanner would MISS) is detected once type info resolves the
+// const. This is the exact blind spot the A6 upgrade closes.
+func TestMQTTPublishCallsiteFunnel_A6_ScannerNonVacuous_ConstFolded(t *testing.T) {
+	t.Parallel()
+	const src = `package x
+const pubMethod = "Publish"
+type hasMethod interface{ MethodByName(string) any }
+func f(v hasMethod) { v.MethodByName(pubMethod) }
+`
+	f, info := mqttTypeCheckSnippet(t, src)
+	var firedConst, firedLiteralOnly bool
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		if isMethodByNamePublishCall(info, call) {
+			firedConst = true
+		}
+		if isMethodByNamePublishCall(nil, call) { // literal-only path must NOT fire on a const arg
+			firedLiteralOnly = true
+		}
+	})
+	assert.True(t, firedConst,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A6: const-folded MethodByName(const) not detected with type info — "+
+			"the EvaluateConstString upgrade is broken")
+	assert.False(t, firedLiteralOnly,
+		"sanity: the literal-only fallback must NOT match a const Ident arg (proves the const path is what catches it)")
 }
 
 // TestMQTTPublishCallsiteFunnel_A7_ScannerNonVacuous proves the alias-form
@@ -998,15 +1028,23 @@ func f(t struct{ topic string }) { t.topic = "y" }
 // ─── Shared predicates / helpers for the blind-spot scanners ──────────────────
 
 // isMethodByNamePublishCall reports whether call is `_.MethodByName("Publish")`.
-// Pure AST (conservative over-approximation: any MethodByName("Publish")).
-// Shared by A6 and its non-vacuous self-check so both exercise one predicate.
-func isMethodByNamePublishCall(call *ast.CallExpr) bool {
+// The first argument is resolved via EvaluateConstString when type info is
+// available, so a const-folded form (`const m = "Publish"; v.MethodByName(m)`)
+// is caught too — not just a bare string literal. When info is nil (the
+// pure-AST non-vacuous snippet path), it falls back to a literal check.
+// Shared by A6 and its non-vacuous self-checks so all exercise one predicate.
+func isMethodByNamePublishCall(info *types.Info, call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
 		return false
 	}
 	if len(call.Args) < 1 {
 		return false
+	}
+	if info != nil {
+		if val, ok := EvaluateConstString(info, call.Args[0]); ok {
+			return val == publishMethodName
+		}
 	}
 	lit, isLit := call.Args[0].(*ast.BasicLit)
 	if !isLit {
@@ -1047,6 +1085,25 @@ func mqttParseSnippet(t *testing.T, src string) *ast.File {
 	f, err := parser.ParseFile(token.NewFileSet(), "snippet.go", src, 0)
 	require.NoError(t, err, "parse in-memory snippet for non-vacuous self-check")
 	return f
+}
+
+// mqttTypeCheckSnippet parses + type-checks an in-memory Go source string and
+// returns the file plus populated *types.Info, for const-eval based non-vacuity
+// proofs. The snippet MUST NOT import any package (no Importer is configured).
+func mqttTypeCheckSnippet(t *testing.T, src string) (*ast.File, *types.Info) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "snippet.go", src, 0)
+	require.NoError(t, err, "parse in-memory snippet for type-checked self-check")
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{},
+		Defs:  map[*ast.Ident]types.Object{},
+		Uses:  map[*ast.Ident]types.Object{},
+	}
+	conf := types.Config{} // no Importer — snippet must be import-free
+	_, err = conf.Check("x", fset, []*ast.File{f}, info)
+	require.NoError(t, err, "type-check in-memory snippet (must have no external imports)")
+	return f, info
 }
 
 // ─── Compile-time import guard ────────────────────────────────────────────────

--- a/tools/archtest/mqtt_callsite_funnel_test.go
+++ b/tools/archtest/mqtt_callsite_funnel_test.go
@@ -50,6 +50,10 @@
 //     callees in adapters/mqtt production files ⊆ {(*Connection).Publish body}.
 //   - A2 Mint construction allowlist (Medium): `publishableTopic{...}` composite
 //     literal in adapters/mqtt production files ⊆ {TopicNamespace.Mint body}.
+//   - A2b field-assignment blind-spot (Medium): no assignment to a
+//     publishableTopic `topic` field (`t.topic = …`) outside the Mint body — the
+//     in-package construction form A2's composite-literal scan does not cover.
+//     gh #1247 tracks the package-internal Hard-upgrade question.
 //   - A3 publishableTopic field freeze (Medium): reflect lock asserting
 //     NumField()==1, field name "topic", type string, unexported.
 //   - A4 method-value blind-spot (Hard reverse self-check): no `cm.Publish` as
@@ -81,6 +85,7 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"strings"
@@ -626,19 +631,7 @@ func TestMQTTPublishCallsiteFunnel_A6_BlindSpot_NoReflectMethodByName(t *testing
 					continue
 				}
 				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-					sel, ok := call.Fun.(*ast.SelectorExpr)
-					if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
-						return
-					}
-					if len(call.Args) < 1 {
-						return
-					}
-					lit, isLit := call.Args[0].(*ast.BasicLit)
-					if !isLit {
-						return
-					}
-					val, ok := StringLitValue(lit)
-					if !ok || val != publishMethodName {
+					if !isMethodByNamePublishCall(call) {
 						return
 					}
 					pos := p.Fset.Position(call.Pos())
@@ -800,6 +793,260 @@ func isCMSelectorExpr(expr ast.Expr) bool {
 		return false
 	}
 	return sel.Sel != nil && sel.Sel.Name == connectionManagerTypeName
+}
+
+// ─── A2b: publishableTopic field-assignment blind-spot (Medium) ───────────────
+
+// TestMQTTPublishCallsiteFunnel_A2b_NoFieldAssignmentBypass closes the A2
+// package-internal blind spot: A2 locks `publishableTopic{...}` composite-literal
+// construction to Mint, but a same-package caller could obtain a zero value
+// (`var t publishableTopic`) and then mutate the field directly
+// (`t.topic = "evil"`), driving Connection.Publish with a topic that never went
+// through PublishOK. This scanner bans any assignment to a publishableTopic
+// `topic` field outside the Mint body.
+//
+// AI-robust: Medium (package-internal upstream ceiling — Go cannot forbid
+// same-package field assignment at compile time; gh #1247 tracks the Hard
+// upgrade question). This is a REQUIRED blind-spot reverse self-check per
+// ai-robust.md §载体决策原则, NOT optional hardening: without it the A2 Medium
+// rating covers only one of the two in-package construction forms.
+func TestMQTTPublishCallsiteFunnel_A2b_NoFieldAssignmentBypass(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A2b"
+
+	var diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.AssignStmt](f, func(assign *ast.AssignStmt) {
+					for _, lhs := range assign.Lhs {
+						sel, ok := lhs.(*ast.SelectorExpr)
+						if !ok || sel.Sel == nil || sel.Sel.Name != "topic" {
+							continue
+						}
+						// Gate on receiver type == publishableTopic (same go/types
+						// path A2/A3 exercise) so unrelated `.topic` fields are ignored.
+						if !mqttIsPublishableTopicTyped(p.TypesInfo, sel.X) {
+							continue
+						}
+						if mqttEnclosingFuncName(f, assign.Pos()) == "Mint" {
+							continue
+						}
+						pos := p.Fset.Position(sel.Pos())
+						diags = append(diags, Diagnostic{
+							Rel:  rel,
+							Line: pos.Line,
+							Message: fmt.Sprintf(
+								"%s: assignment to publishableTopic.topic at %s:%d outside Mint — "+
+									"field-assignment bypasses PublishOK validation; construct via Mint only",
+								ruleID, rel, pos.Line,
+							),
+						})
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.Empty(t, diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A2b: publishableTopic.topic field assignment outside Mint detected")
+}
+
+// ─── Non-vacuous self-checks for the blind-spot scanners (F14) ────────────────
+//
+// A4–A7 (and A2b) are absence-checks: by design the forbidden form does NOT
+// exist in production, so `assert.Empty` alone could pass vacuously if the
+// detector silently broke. ai-robust.md §载体决策原则 requires each blind-spot
+// self-check to also prove the detector FIRES on a positive example. The
+// AST-mechanism detectors are proven against in-memory positive snippets; the
+// go/types-gated detectors (A4 receiver-type) are proven against the real
+// production cm.Publish receiver (the same path A1/A2 exercise).
+
+// TestMQTTPublishCallsiteFunnel_A4_ScannerNonVacuous proves isCMReceiver resolves
+// the receiver type of the real production `c.cm.Publish(...)` call inside
+// (*Connection).Publish to *autopaho.ConnectionManager. If this returns 0, the
+// types path A4 depends on is silently broken and A4 would vacuously pass.
+func TestMQTTPublishCallsiteFunnel_A4_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var cmReceiverHits int
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				if strings.HasSuffix(p.Rel(f), "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.SelectorExpr](f, func(sel *ast.SelectorExpr) {
+					if sel.Sel == nil || sel.Sel.Name != publishMethodName {
+						return
+					}
+					if isCMReceiver(p.TypesInfo, sel.X) {
+						cmReceiverHits++
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, cmReceiverHits, 1,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A4: isCMReceiver found 0 *autopaho.ConnectionManager "+
+			"receivers of a Publish selector — the go/types receiver-resolution path may be broken")
+}
+
+// TestMQTTPublishCallsiteFunnel_A5_ScannerNonVacuous proves
+// isMethodExpressionPublishCall fires on a synthetic method-expression call.
+func TestMQTTPublishCallsiteFunnel_A5_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	const src = `package x
+import "github.com/eclipse/paho.golang/autopaho"
+func f(cm *autopaho.ConnectionManager) { (*autopaho.ConnectionManager).Publish(cm, nil) }
+`
+	f := mqttParseSnippet(t, src)
+	var fired bool
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		if isMethodExpressionPublishCall(call) {
+			fired = true
+		}
+	})
+	assert.True(t, fired,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A5: isMethodExpressionPublishCall did not fire on a "+
+			"known method-expression call — the detector is broken (A5 would pass vacuously)")
+}
+
+// TestMQTTPublishCallsiteFunnel_A6_ScannerNonVacuous proves
+// isMethodByNamePublishCall fires on a synthetic reflect MethodByName("Publish").
+func TestMQTTPublishCallsiteFunnel_A6_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	const src = `package x
+import "reflect"
+func f(v reflect.Value) { v.MethodByName("Publish") }
+`
+	f := mqttParseSnippet(t, src)
+	var fired bool
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		if isMethodByNamePublishCall(call) {
+			fired = true
+		}
+	})
+	assert.True(t, fired,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A6: isMethodByNamePublishCall did not fire on a "+
+			"known MethodByName(\"Publish\") call — the detector is broken (A6 would pass vacuously)")
+}
+
+// TestMQTTPublishCallsiteFunnel_A7_ScannerNonVacuous proves the alias-form
+// detection (TypeSpec with Assign != token.NoPos) fires on a synthetic alias.
+// The autopaho-type RHS match is gated by the same go/types path A1/A2 prove
+// non-vacuous; this guards the AST traversal half from silently breaking.
+func TestMQTTPublishCallsiteFunnel_A7_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	const src = `package x
+type CM = int
+`
+	f := mqttParseSnippet(t, src)
+	var aliasForms int
+	EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Assign != token.NoPos {
+			aliasForms++
+		}
+	})
+	assert.GreaterOrEqual(t, aliasForms, 1,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A7: alias-form detection (TypeSpec.Assign != NoPos) found 0 "+
+			"aliases in a snippet that declares one — the AST traversal is broken (A7 would pass vacuously)")
+}
+
+// TestMQTTPublishCallsiteFunnel_A2b_ScannerNonVacuous proves the field-assignment
+// detection (LHS SelectorExpr with Sel "topic") fires on a synthetic snippet.
+func TestMQTTPublishCallsiteFunnel_A2b_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	const src = `package x
+func f(t struct{ topic string }) { t.topic = "y" }
+`
+	f := mqttParseSnippet(t, src)
+	var fired bool
+	EachInSubtree[ast.AssignStmt](f, func(assign *ast.AssignStmt) {
+		for _, lhs := range assign.Lhs {
+			if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel != nil && sel.Sel.Name == "topic" {
+				fired = true
+			}
+		}
+	})
+	assert.True(t, fired,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A2b: topic-field-assignment detection did not fire on a "+
+			"known `t.topic = ...` snippet — the AST traversal is broken (A2b would pass vacuously)")
+}
+
+// ─── Shared predicates / helpers for the blind-spot scanners ──────────────────
+
+// isMethodByNamePublishCall reports whether call is `_.MethodByName("Publish")`.
+// Pure AST (conservative over-approximation: any MethodByName("Publish")).
+// Shared by A6 and its non-vacuous self-check so both exercise one predicate.
+func isMethodByNamePublishCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
+		return false
+	}
+	if len(call.Args) < 1 {
+		return false
+	}
+	lit, isLit := call.Args[0].(*ast.BasicLit)
+	if !isLit {
+		return false
+	}
+	val, ok := StringLitValue(lit)
+	return ok && val == publishMethodName
+}
+
+// mqttIsPublishableTopicTyped reports whether expr has type publishableTopic
+// (value or pointer) declared in adapters/mqtt. Used by A2b.
+func mqttIsPublishableTopicTyped(info *types.Info, expr ast.Expr) bool {
+	if info == nil || expr == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	if !ok {
+		return false
+	}
+	typ := tv.Type
+	if ptr, isPtr := typ.(*types.Pointer); isPtr {
+		typ = ptr.Elem()
+	}
+	named, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+	tobj := named.Obj()
+	return tobj.Pkg() != nil &&
+		tobj.Pkg().Path() == mqttPkgPath &&
+		tobj.Name() == "publishableTopic"
+}
+
+// mqttParseSnippet parses an in-memory Go source string into an *ast.File for
+// pure-AST detector non-vacuity proofs (no type checking).
+func mqttParseSnippet(t *testing.T, src string) *ast.File {
+	t.Helper()
+	f, err := parser.ParseFile(token.NewFileSet(), "snippet.go", src, 0)
+	require.NoError(t, err, "parse in-memory snippet for non-vacuous self-check")
+	return f
 }
 
 // ─── Compile-time import guard ────────────────────────────────────────────────

--- a/tools/archtest/mqtt_callsite_funnel_test.go
+++ b/tools/archtest/mqtt_callsite_funnel_test.go
@@ -39,6 +39,10 @@
 //     Mint body + zero-value error return. publishableTopic field-shape reflect lock.
 //     Permanent Go-language ceiling (same as SPAN-SETATTR-REDACT-01 /
 //     PROBENAME-SEALED-FUNNEL-01 package-internal side).
+//     Tracked for potential Hard upgrade — open follow-up gh issue per
+//     ai-robust.md §Funnel 双向锁评级 ("必须同步开 gh issue 跟踪显式 Hard
+//     化任务"). Sibling: SPAN-SETATTR-REDACT-01 tracks gh #851 for the same
+//     package-internal seal-upgrade question.
 //
 // # Sub-rules
 //

--- a/tools/archtest/mqtt_callsite_funnel_test.go
+++ b/tools/archtest/mqtt_callsite_funnel_test.go
@@ -1,0 +1,814 @@
+// INVARIANT: MQTT-PUBLISH-CALLSITE-FUNNEL-01
+//
+// mqtt_callsite_funnel_test.go — downstream callsite funnel for
+// (*autopaho.ConnectionManager).Publish + upstream package-internal backstop
+// for publishableTopic / Connection.Publish.
+//
+// This file closes the gh #1225 deferred enforcement from PR-1.
+//
+// # Funnel architecture (per plan §2.5 + ai-robust.md Hard 范本目录)
+//
+// The PR-2 funnel is a "string-typed concept funnel" + "single sanctioned holder"
+// composite:
+//
+//   - publishableTopic: package-unexported struct with single `topic string`
+//     field. Its only constructor is TopicNamespace.Mint, which internally
+//     calls PublishOK. So any code holding a publishableTopic is guaranteed (at
+//     compile time, package-external) that the topic was validated against
+//     the namespace.
+//   - Connection.Publish: the ONLY method in adapters/mqtt that calls
+//     (*autopaho.ConnectionManager).Publish. Its first non-receiver parameter
+//     after ctx is publishableTopic — so the type system gates any external
+//     publish path through the namespace check.
+//
+// # AI-robust grading
+//
+// Per .claude/rules/gocell/ai-robust.md §Funnel 双向锁评级:
+//
+//   - Downstream Hard: A1 + A4-A7 blind-spot reverse self-checks — typed CallExpr
+//     resolution locks (*autopaho.ConnectionManager).Publish callsites ⊆
+//     {(*Connection).Publish.Body}. No method-value / method-expression / reflect /
+//     alias escape (each is a separate reverse self-check).
+//   - Upstream cross-package Hard: publishableTopic unexported + Mint sole
+//     constructor + Connection.Publish parameter type — package-external code
+//     cannot construct publishableTopic, so cannot call Connection.Publish, so
+//     cannot reach cm.Publish. Type-system gate, no archtest needed for the
+//     cross-package side.
+//   - Upstream package-internal Medium (A2 + A3 archtest backstop): publishableTopic{}
+//     composite-literal construction inside adapters/mqtt is restricted to the
+//     Mint body + zero-value error return. publishableTopic field-shape reflect lock.
+//     Permanent Go-language ceiling (same as SPAN-SETATTR-REDACT-01 /
+//     PROBENAME-SEALED-FUNNEL-01 package-internal side).
+//
+// # Sub-rules
+//
+//   - A1 downstream callsite (Hard): typed CallExpr scan; `(*autopaho.ConnectionManager).Publish`
+//     callees in adapters/mqtt production files ⊆ {(*Connection).Publish body}.
+//   - A2 Mint construction allowlist (Medium): `publishableTopic{...}` composite
+//     literal in adapters/mqtt production files ⊆ {TopicNamespace.Mint body}.
+//   - A3 publishableTopic field freeze (Medium): reflect lock asserting
+//     NumField()==1, field name "topic", type string, unexported.
+//   - A4 method-value blind-spot (Hard reverse self-check): no `cm.Publish` as
+//     non-call SelectorExpr in production AST (e.g., `f := cm.Publish` is forbidden).
+//   - A5 method-expression blind-spot (Hard reverse self-check): no
+//     `(*autopaho.ConnectionManager).Publish(receiver, args...)` form outside
+//     {(*Connection).Publish body}.
+//   - A6 reflect blind-spot (Hard reverse self-check): no `reflect.Value.MethodByName`
+//     in adapters/mqtt production AST with argument literal "Publish".
+//   - A7 alias blind-spot (Hard reverse self-check): no `type CM = *autopaho.ConnectionManager`
+//     or `type CM = autopaho.ConnectionManager` alias in adapters/mqtt.
+//
+// # Blind-spot inventory rationale (per ai-robust.md §载体决策原则)
+//
+// The downstream Hard rating requires explicit reverse self-checks for AST forms
+// outside the declared coverage of typed CallExpr resolution. The four blind
+// spots above (method-value, method-expression, reflect, alias) are precisely
+// the forms that would let cm.Publish be invoked without appearing as a direct
+// CallExpr `cm.Publish(...)`. Each gets a sub-test that walks production AST and
+// asserts the form does not appear. Together they close the funnel.
+//
+// ref: gh #1225 — PR-1 deferred enforcement
+// ref: ADR docs/architecture/202605281200-048-adr-mqtt-adapter.md
+// ref: ai-robust.md §Hard 范本目录 "single sanctioned holder" + "string-typed concept funnel"
+// ref: ai-robust.md §Funnel 双向锁评级
+// ref: SPAN-SETATTR-REDACT-01 (sibling Hard funnel pattern)
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/adapters/mqtt"
+)
+
+// autophoPkgPath is the import path of the autopaho package that owns ConnectionManager.
+const autophoPkgPath = "github.com/eclipse/paho.golang/autopaho"
+
+// connectionManagerTypeName is the type whose Publish method we funnel.
+const connectionManagerTypeName = "ConnectionManager"
+
+// publishMethodName is the callee method name we funnel.
+const publishMethodName = "Publish"
+
+// cmPublishFullName is the *types.Func.FullName() of the target callee.
+// This is the canonical key used by ResolveMethodCall-based checks.
+const cmPublishFullName = "(*github.com/eclipse/paho.golang/autopaho.ConnectionManager).Publish"
+
+// connectionPublishEnclosingFuncKey is the FullName() of the sole allowed
+// enclosing function for cm.Publish callsites.
+// (*mqtt.Connection).Publish — resolved via ResolveEnclosingFunc.
+const connectionPublishEnclosingFuncKey = "(*github.com/ghbvf/gocell/adapters/mqtt.Connection).Publish"
+
+// ─── A1: downstream cm.Publish callsite Hard ─────────────────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A1_DownstreamCMPublishCallsite enforces that
+// every call to (*autopaho.ConnectionManager).Publish in production files under
+// adapters/mqtt is enclosed by (*Connection).Publish and no other function.
+//
+// Detection: for each *ast.CallExpr whose Fun is *ast.SelectorExpr, resolve the
+// callee via ResolveMethodCall. If it matches cmPublishFullName, resolve the
+// enclosing top-level FuncDecl via ResolveEnclosingFunc. The enclosing func must
+// have FullName() == connectionPublishEnclosingFuncKey.
+func TestMQTTPublishCallsiteFunnel_A1_DownstreamCMPublishCallsite(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A1"
+
+	var diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+					if !ok || fn == nil {
+						return
+					}
+					if fn.FullName() != cmPublishFullName {
+						return
+					}
+					// Found a cm.Publish call. Verify the enclosing function.
+					enclosing, encOK := ResolveEnclosingFunc(p.TypesInfo, f, call)
+					if !encOK || enclosing == nil {
+						pos := p.Fset.Position(call.Pos())
+						diags = append(diags, Diagnostic{
+							Rel:  rel,
+							Line: pos.Line,
+							Message: fmt.Sprintf(
+								"%s: (*autopaho.ConnectionManager).Publish at %s:%d is outside any FuncDecl — "+
+									"only (*Connection).Publish may call cm.Publish",
+								ruleID, rel, pos.Line,
+							),
+						})
+						return
+					}
+					if enclosing.FullName() != connectionPublishEnclosingFuncKey {
+						pos := p.Fset.Position(call.Pos())
+						diags = append(diags, Diagnostic{
+							Rel:  rel,
+							Line: pos.Line,
+							Message: fmt.Sprintf(
+								"%s: (*autopaho.ConnectionManager).Publish at %s:%d is called from %q — "+
+									"only %q may call cm.Publish",
+								ruleID, rel, pos.Line, enclosing.FullName(), connectionPublishEnclosingFuncKey,
+							),
+						})
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.Empty(t, diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A1: cm.Publish callsites outside (*Connection).Publish detected")
+}
+
+// ─── A1 scanner non-vacuousness self-check ───────────────────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A1_ScannerNonVacuous asserts that the A1
+// scanner finds ≥1 cm.Publish callsite in adapters/mqtt production code (inside
+// (*Connection).Publish). If zero are found, the scanner is silently broken and
+// A1 vacuously passes.
+func TestMQTTPublishCallsiteFunnel_A1_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var foundCount int
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return
+					}
+					fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+					if !ok || fn == nil {
+						return
+					}
+					if fn.FullName() == cmPublishFullName {
+						foundCount++
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, foundCount, 1,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A1: scanner found 0 cm.Publish callsites in production files — "+
+			"the go/types resolution path may be silently broken, or Connection.Publish no longer calls cm.Publish")
+}
+
+// ─── A2: publishableTopic construction allowlist Medium ──────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A2_PublishableTopicConstructionAllowlist
+// enforces that non-zero publishableTopic composite literals in adapters/mqtt
+// production files are only inside TopicNamespace.Mint.
+//
+// Zero-value literals (no elements) are permitted anywhere — they appear in
+// error return paths like `return publishableTopic{}, err`.
+func TestMQTTPublishCallsiteFunnel_A2_PublishableTopicConstructionAllowlist(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A2"
+
+	var a2Diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a2Diags = append(a2Diags, scanMQTTCompositeLitConstruction(
+					p.Fset, f, rel, p.TypesInfo,
+					"publishableTopic",
+					[]string{"Mint"},
+					ruleID,
+				)...)
+			}
+			return nil
+		})
+
+	assert.Empty(t, a2Diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A2: publishableTopic composite literals outside Mint body detected")
+}
+
+// TestMQTTPublishCallsiteFunnel_A2_ScannerNonVacuous asserts that the A2
+// scanner finds ≥1 publishableTopic composite literal inside Mint (i.e. the
+// type-resolution path works). If zero are found inside Mint, the scanner is
+// silently broken.
+func TestMQTTPublishCallsiteFunnel_A2_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var insideCount int
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.CompositeLit](f, func(lit *ast.CompositeLit) {
+					if lit.Type == nil || len(lit.Elts) == 0 {
+						return
+					}
+					tv, ok := p.TypesInfo.Types[lit.Type]
+					if !ok {
+						return
+					}
+					named, ok := tv.Type.(*types.Named)
+					if !ok {
+						return
+					}
+					tobj := named.Obj()
+					if tobj.Pkg() == nil || tobj.Pkg().Path() != mqttPkgPath {
+						return
+					}
+					if tobj.Name() != "publishableTopic" {
+						return
+					}
+					fn := mqttEnclosingFuncName(f, lit.Pos())
+					if fn == "Mint" {
+						insideCount++
+					}
+					_ = rel // used for rel-relative path in outer closure
+				})
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, insideCount, 1,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A2: scanner found 0 publishableTopic literals inside Mint — "+
+			"the go/types resolution path may be silently broken")
+}
+
+// ─── A3: publishableTopic field freeze Medium ─────────────────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A3_PublishableTopicFieldFreeze locks the shape
+// of publishableTopic via go/types scope lookup: NumFields==1, field name
+// "topic", type string, unexported. Detects reversion to `type publishableTopic string`
+// (wrong Kind), field export, field rename, or addition of extra fields.
+//
+// publishableTopic is package-unexported, so we cannot use reflect.TypeOf on it
+// from outside adapters/mqtt. We use go/types scope lookup instead.
+func TestMQTTPublishCallsiteFunnel_A3_PublishableTopicFieldFreeze(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A3"
+
+	var checked bool
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			obj := p.Pkg.Scope().Lookup("publishableTopic")
+			if obj == nil {
+				return nil
+			}
+			checked = true
+			tn, ok := obj.(*types.TypeName)
+			if !ok {
+				t.Errorf("%s: publishableTopic scope object is not *types.TypeName", ruleID)
+				return nil
+			}
+			underlying := tn.Type().Underlying()
+			st, ok := underlying.(*types.Struct)
+			if !ok {
+				t.Errorf("%s: publishableTopic underlying type is %T, want *types.Struct — "+
+					"type may have been changed to a string newtype or alias", ruleID, underlying)
+				return nil
+			}
+			if st.NumFields() != 1 {
+				t.Errorf("%s: publishableTopic NumFields = %d, want 1 — "+
+					"adding a field re-opens sealed-construction invariant", ruleID, st.NumFields())
+			}
+			if st.NumFields() >= 1 {
+				f0 := st.Field(0)
+				if f0.Name() != "topic" {
+					t.Errorf("%s: publishableTopic field[0] name = %q, want %q — "+
+						"renaming the field breaks the sealed-topic-string contract",
+						ruleID, f0.Name(), "topic")
+				}
+				if f0.Exported() {
+					t.Errorf("%s: publishableTopic.topic is exported — "+
+						"package-external literal construction would become possible; unexport it",
+						ruleID)
+				}
+				basic, isBasic := f0.Type().(*types.Basic)
+				if !isBasic || basic.Kind() != types.String {
+					t.Errorf("%s: publishableTopic.topic type is %v, want string", ruleID, f0.Type())
+				}
+			}
+			return nil
+		})
+
+	require.True(t, checked,
+		"%s: publishableTopic not found in adapters/mqtt scope — "+
+			"type may have been renamed or deleted; rule must be updated", ruleID)
+}
+
+// ─── A3 reflect sanity: exported types still have the right shape ─────────────
+
+// TestMQTTPublishCallsiteFunnel_A3_ExportedTypesShape is a complement to A3
+// using reflect on the exported mqtt types (TopicNamespace, ClientID) that
+// follow the same {value string} sealed-struct pattern. It confirms the
+// checkMQTTSealedSingleValueField helper used in mqtt_funnel_test.go also holds
+// for our sibling pattern. This test is purposely NOT using reflect on
+// publishableTopic (which is unexported and inaccessible from here).
+func TestMQTTPublishCallsiteFunnel_A3_ExportedTypesShape(t *testing.T) {
+	t.Parallel()
+	// Confirm that the sealed-struct pattern is consistent across the package:
+	// TopicNamespace and ClientID still have their single unexported "value" field.
+	// (publishableTopic's shape is checked via go/types in A3 above.)
+	import_mqtt_pkg := mqtt.TopicNamespace{}
+	_ = import_mqtt_pkg // force import
+	// Intentionally no reflect on publishableTopic — it is unexported.
+	// The A3 go/types check above covers it.
+}
+
+// ─── A4: method-value blind-spot reverse self-check ──────────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A4_BlindSpot_NoMethodValue (Hard reverse
+// self-check) asserts that no production file in adapters/mqtt uses
+// (*autopaho.ConnectionManager).Publish as a non-call SelectorExpr (i.e.,
+// `f := cm.Publish` method-value extraction). Such a form would allow invoking
+// cm.Publish indirectly without appearing as a direct CallExpr — bypassing A1.
+//
+// Implementation: walk all SelectorExpr nodes in production AST whose receiver
+// type is *autopaho.ConnectionManager and Sel is "Publish". Check whether the
+// parent node is a CallExpr (i.e., this SelectorExpr is the Fun of a call).
+// If not, it is a method-value usage — violation.
+//
+// Parent tracking uses ast.Inspect with a parent stack.
+func TestMQTTPublishCallsiteFunnel_A4_BlindSpot_NoMethodValue(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A4"
+
+	var diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				// Walk with parent tracking.
+				var parentStack []ast.Node
+				ast.Inspect(f, func(n ast.Node) bool {
+					if n == nil {
+						if len(parentStack) > 0 {
+							parentStack = parentStack[:len(parentStack)-1]
+						}
+						return false
+					}
+					defer func() {
+						parentStack = append(parentStack, n)
+					}()
+
+					sel, ok := n.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					if sel.Sel == nil || sel.Sel.Name != publishMethodName {
+						return true
+					}
+					// Check whether the receiver is *autopaho.ConnectionManager.
+					if !isCMReceiver(p.TypesInfo, sel.X) {
+						return true
+					}
+					// Found a cm.Publish selector. Check parent.
+					if len(parentStack) == 0 {
+						// At root — unexpected but treat as violation.
+						pos := p.Fset.Position(sel.Pos())
+						diags = append(diags, Diagnostic{
+							Rel:  rel,
+							Line: pos.Line,
+							Message: fmt.Sprintf(
+								"%s: cm.Publish SelectorExpr at %s:%d has no parent — "+
+									"method-value usage suspected",
+								ruleID, rel, pos.Line,
+							),
+						})
+						return true
+					}
+					parent := parentStack[len(parentStack)-1]
+					if call, isCall := parent.(*ast.CallExpr); isCall && call.Fun == sel {
+						// Direct call — allowed.
+						return true
+					}
+					pos := p.Fset.Position(sel.Pos())
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"%s: cm.Publish at %s:%d is used as a method-value (not a direct call) — "+
+								"forbidden: all cm.Publish invocations must go through (*Connection).Publish",
+							ruleID, rel, pos.Line,
+						),
+					})
+					return true
+				})
+			}
+			return nil
+		})
+
+	assert.Empty(t, diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A4: cm.Publish used as method-value in adapters/mqtt production code")
+}
+
+// ─── A5: method-expression blind-spot reverse self-check ─────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A5_BlindSpot_NoMethodExpression (Hard reverse
+// self-check) asserts that the method-expression form
+// `(*autopaho.ConnectionManager).Publish(receiver, args...)` does not appear in
+// adapters/mqtt production files outside (*Connection).Publish.
+//
+// In the method-expression form, the Fun of the CallExpr is a SelectorExpr
+// whose X is a ParenExpr wrapping a StarExpr. A1's typed ResolveMethodCall
+// resolves both method-value and direct-call forms via info.Selections, so this
+// form may already be caught by A1. However, the explicit reverse self-check
+// closes the blind-spot inventory per ai-robust.md §载体决策原则.
+//
+// Detection: walk CallExpr where Fun is a SelectorExpr with Sel == "Publish"
+// AND X is a ParenExpr with a StarExpr inside referencing ConnectionManager.
+func TestMQTTPublishCallsiteFunnel_A5_BlindSpot_NoMethodExpression(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A5"
+
+	var diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					if !isMethodExpressionPublishCall(call) {
+						return
+					}
+					// Verify the enclosing function — if it's inside (*Connection).Publish
+					// body, it is the legitimate callsite already covered by A1.
+					enclosing, encOK := ResolveEnclosingFunc(p.TypesInfo, f, call)
+					if encOK && enclosing != nil && enclosing.FullName() == connectionPublishEnclosingFuncKey {
+						// Inside allowed caller — OK.
+						return
+					}
+					pos := p.Fset.Position(call.Pos())
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"%s: method-expression (*autopaho.ConnectionManager).Publish call at %s:%d "+
+								"outside (*Connection).Publish — forbidden",
+							ruleID, rel, pos.Line,
+						),
+					})
+				})
+			}
+			return nil
+		})
+
+	assert.Empty(t, diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A5: method-expression (*autopaho.ConnectionManager).Publish "+
+			"detected outside (*Connection).Publish in adapters/mqtt production code")
+}
+
+// ─── A6: reflect blind-spot reverse self-check ───────────────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A6_BlindSpot_NoReflectMethodByName (Hard reverse
+// self-check) asserts that no production file in adapters/mqtt calls
+// reflect.Value.MethodByName with a string literal "Publish". Such a call would
+// allow invoking ConnectionManager.Publish via reflection, bypassing A1.
+//
+// We scan for any CallExpr where Fun is a SelectorExpr with Sel == "MethodByName"
+// and whose first argument is a string literal "Publish". We intentionally do
+// NOT require the receiver to be typed as reflect.Value (which would require
+// extra resolution) — the conservative check bans any MethodByName("Publish")
+// in the mqtt package, which is a safe over-approximation.
+func TestMQTTPublishCallsiteFunnel_A6_BlindSpot_NoReflectMethodByName(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A6"
+
+	var diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
+						return
+					}
+					if len(call.Args) < 1 {
+						return
+					}
+					lit, isLit := call.Args[0].(*ast.BasicLit)
+					if !isLit {
+						return
+					}
+					val, ok := StringLitValue(lit)
+					if !ok || val != publishMethodName {
+						return
+					}
+					pos := p.Fset.Position(call.Pos())
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"%s: MethodByName(%q) at %s:%d in adapters/mqtt production code — "+
+								"reflect-based invocation of cm.Publish is forbidden",
+							ruleID, publishMethodName, rel, pos.Line,
+						),
+					})
+				})
+			}
+			return nil
+		})
+
+	assert.Empty(t, diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A6: reflect.MethodByName(\"Publish\") detected in adapters/mqtt production code")
+}
+
+// ─── A7: alias blind-spot reverse self-check ─────────────────────────────────
+
+// TestMQTTPublishCallsiteFunnel_A7_BlindSpot_NoConnectionManagerAlias (Hard
+// reverse self-check) asserts that no production file in adapters/mqtt declares
+// a type alias for *autopaho.ConnectionManager or autopaho.ConnectionManager.
+// Such an alias would let code drive cm.Publish through a different identifier
+// name, potentially confusing future A1 analyses.
+//
+// Detection: walk TypeSpec where Assign != token.NoPos (alias form). Resolve
+// the RHS via types.Info. If the underlying type resolves to
+// *autopaho.ConnectionManager or autopaho.ConnectionManager, report a violation.
+func TestMQTTPublishCallsiteFunnel_A7_BlindSpot_NoConnectionManagerAlias(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const ruleID = "MQTT-PUBLISH-CALLSITE-FUNNEL-01/A7"
+
+	var diags []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+					if ts.Assign == token.NoPos {
+						// Not an alias declaration.
+						return
+					}
+					// It's a type alias. Check if the RHS resolves to
+					// *ConnectionManager or ConnectionManager from autopaho.
+					tv, ok := p.TypesInfo.Types[ts.Type]
+					if !ok {
+						return
+					}
+					typ := tv.Type
+					// Strip pointer if present.
+					if ptr, isPtr := typ.(*types.Pointer); isPtr {
+						typ = ptr.Elem()
+					}
+					named, ok := typ.(*types.Named)
+					if !ok {
+						return
+					}
+					tobj := named.Obj()
+					if tobj.Pkg() == nil || tobj.Pkg().Path() != autophoPkgPath {
+						return
+					}
+					if tobj.Name() != connectionManagerTypeName {
+						return
+					}
+					pos := p.Fset.Position(ts.Pos())
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"%s: type alias `type %s = autopaho.ConnectionManager` (or pointer) at %s:%d "+
+								"in adapters/mqtt is forbidden — aliases of ConnectionManager obscure the publish funnel",
+							ruleID, ts.Name.Name, rel, pos.Line,
+						),
+					})
+				})
+			}
+			return nil
+		})
+
+	assert.Empty(t, diags,
+		"MQTT-PUBLISH-CALLSITE-FUNNEL-01/A7: autopaho.ConnectionManager alias detected in adapters/mqtt production code")
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// isCMReceiver reports whether expr has type *autopaho.ConnectionManager or
+// autopaho.ConnectionManager in the given types.Info. Used by A4.
+func isCMReceiver(info *types.Info, expr ast.Expr) bool {
+	if info == nil || expr == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	if !ok {
+		return false
+	}
+	typ := tv.Type
+	// Strip pointer.
+	if ptr, isPtr := typ.(*types.Pointer); isPtr {
+		typ = ptr.Elem()
+	}
+	named, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+	tobj := named.Obj()
+	return tobj.Pkg() != nil &&
+		tobj.Pkg().Path() == autophoPkgPath &&
+		tobj.Name() == connectionManagerTypeName
+}
+
+// isMethodExpressionPublishCall reports whether call has the method-expression
+// form `(*autopaho.ConnectionManager).Publish(receiver, args...)`. This form
+// has Fun as a SelectorExpr where X is a ParenExpr wrapping a StarExpr of a
+// SelectorExpr resolving to autopaho.ConnectionManager, and Sel == "Publish".
+// Pure AST check — does not require type resolution (conservative over-approx).
+func isMethodExpressionPublishCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != publishMethodName {
+		return false
+	}
+	// X must be a ParenExpr wrapping a StarExpr or a plain SelectorExpr
+	// referencing ConnectionManager.
+	x := sel.X
+	// Unwrap ParenExpr.
+	paren, isParen := x.(*ast.ParenExpr)
+	if isParen {
+		x = paren.X
+	}
+	// Check StarExpr (pointer method expression form: (*T).Method).
+	if star, isStar := x.(*ast.StarExpr); isStar {
+		return isCMSelectorExpr(star.X)
+	}
+	// Also handle non-pointer form (T).Method, though Publish has pointer recv.
+	return isCMSelectorExpr(x)
+}
+
+// isCMSelectorExpr reports whether expr is a SelectorExpr pkg.ConnectionManager
+// where pkg is an identifier imported from autophoPkgPath. Pure AST check by
+// selector name — conservative.
+func isCMSelectorExpr(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel != nil && sel.Sel.Name == connectionManagerTypeName
+}
+
+// ─── Compile-time import guard ────────────────────────────────────────────────
+
+// Ensure the mqtt package is imported (for the reflect check in
+// TestMQTTPublishCallsiteFunnel_A3_ExportedTypesShape and to keep the import
+// live). The blank assignment is a conventional Go pattern for compile-time
+// import verification.
+var _ = mqtt.TopicNamespace{}
+
+// Ensure assert/require are used (they are, but this keeps the linter happy if
+// future sub-tests are conditionally compiled away).
+var (
+	_ = assert.Empty
+	_ = require.True
+)

--- a/tools/archtest/outbox_publisher_conformance_enrollment_test.go
+++ b/tools/archtest/outbox_publisher_conformance_enrollment_test.go
@@ -1,0 +1,361 @@
+// INVARIANT: OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01
+//
+// AI-robust: Medium
+//
+//   - 实现扫描: typesutil.ImplementsInterface — type-aware; identifies every
+//     concrete named type (T or *T) in the production tree that satisfies
+//     kernel/outbox.Publisher.
+//   - conformance 调用扫描: ResolvePackageRef + _test.go path filter — type-aware
+//     callee resolution via *types.Info; identifies every package with an
+//     outboxtest.TestPubSub / RunBatch* call site.
+//   - 综合: Medium 天花板 — Go cannot require a test to exist at compile time;
+//     the enforcement is archtest-bound (CI fails), not compile-time.
+//
+// Enforces: every concrete production type implementing kernel/outbox.Publisher
+// must EITHER have an outboxtest.TestPubSub (or RunBatch*) conformance call in a
+// _test.go of its package, OR appear in outboxPublisherEnrollmentWaivers with a
+// documented reason. This is the machine guard for contract-fanout.md 载体#2
+// ("archtest 守新增实现自动接入 conformance") for the outbox.Publisher contract:
+// a new adapter that forgets to enroll fails CI rather than silently shipping
+// unverified.
+//
+// Why a waiver list instead of silent deferral: adapters/mqtt.Publisher landed
+// (PR-2) before adapters/mqtt.Subscriber (PR-3). outboxtest.TestPubSub is a
+// pub→sub roundtrip and cannot be constructed without the Subscriber, so mqtt
+// is waived WITH a tracked reason (not a silent carryover). When the Subscriber
+// lands, the stale-waiver guard below forces the waiver to be removed once the
+// real TestPubSub call appears.
+//
+// # Blind-spot catalog (forms not reachable by *types.Info)
+//
+//   - B1. reflect-based implicit implementations: no production code constructs
+//     a Publisher via reflect.MethodByName; confirmed by
+//     TestOutboxPublisherEnrollment_ReverseBlindSpot_NoReflectImpl.
+//   - B2. test-file impls (mocks/fakes in _test.go) are excluded by the
+//     Tests=false production load pass — intentional; only non-test concrete
+//     types must enroll. Test-double publishers that live in non-test .go files
+//     (e.g. cells/configcore/internal/testutil) are explicitly waived below.
+//
+// ref: tools/archtest/user_repo_conformance_enrollment_test.go (template)
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/internal/prodscan"
+	"github.com/ghbvf/gocell/tools/typesutil"
+)
+
+// INVARIANT: OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01
+
+const (
+	outboxPublisherIfacePkg  = "github.com/ghbvf/gocell/kernel/outbox"
+	outboxPublisherIfaceName = "Publisher"
+	outboxtestPkg            = "github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+)
+
+// outboxPublisherEnrollmentWaivers maps a production package path → the reason
+// its outbox.Publisher impl is exempt from the conformance-enrollment rule.
+// Each entry is auditable and principled; a flagged impl whose package is NOT
+// here fails CI, forcing a conscious decision (no silent additions).
+var outboxPublisherEnrollmentWaivers = map[string]string{
+	"github.com/ghbvf/gocell/kernel/outbox": "kernel noop sink outbox.DiscardPublisher (Noop()==true, rejected by cell.CheckNotNoop " +
+		"in durable mode) — it discards rather than delivers, so a pub→sub roundtrip " +
+		"(outboxtest.TestPubSub) is N/A by design.",
+	"github.com/ghbvf/gocell/cells/configcore/internal/testutil": "test-double publishers " +
+		"(StubPublisher / FailingPublisher) — not a real transport; outboxtest.TestPubSub " +
+		"roundtrip is N/A for in-memory stubs.",
+	"github.com/ghbvf/gocell/adapters/mqtt": "PR-3 waiver (V11-4 series, parent gh #1138): adapters/mqtt.Subscriber is not yet " +
+		"implemented (lands in PR-3); outboxtest.TestPubSub requires a pub→sub roundtrip. " +
+		"Remove this waiver and add adapters/mqtt/conformance_test.go calling " +
+		"outboxtest.TestPubSub when the Subscriber lands — the stale-waiver guard below " +
+		"will fail CI if the waiver is left in place after enrollment.",
+}
+
+// TestOutboxPublisherConformanceEnrollment enforces
+// OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01.
+func TestOutboxPublisherConformanceEnrollment(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+
+	// ─── Step 1: resolve kernel/outbox.Publisher + collect candidate impls ───
+	//
+	// The iface and the impl types MUST come from the same packages.Load
+	// invocation so types.Implements uses pointer-identical *types.Named
+	// descriptors (cross-load comparisons are always false).
+	prodPatterns := prodscan.Patterns(root)
+	ifacePatterns := append([]string{"./kernel/outbox/..."}, prodPatterns...)
+
+	var pubIface *types.Interface
+	var implPkgs []*types.Package
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == outboxPublisherIfacePkg {
+				if obj := p.Pkg.Scope().Lookup(outboxPublisherIfaceName); obj != nil {
+					if named, ok := obj.Type().(*types.Named); ok {
+						if iface, ok := named.Underlying().(*types.Interface); ok {
+							pubIface = iface.Complete()
+						}
+					}
+				}
+			}
+			implPkgs = append(implPkgs, p.Pkg)
+			return nil
+		})
+
+	require.NotNil(t, pubIface,
+		"OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01: failed to resolve kernel/outbox.Publisher; "+
+			"check import path %s", outboxPublisherIfacePkg)
+
+	// ─── Step 2: collect concrete implementations ───────────────────────────
+	implSet := make(map[string]bool)    // "pkg/path.TypeName" → true
+	implPkgSet := make(map[string]bool) // "pkg/path" → true
+	for _, pkg := range implPkgs {
+		if pkg != nil {
+			collectPublisherImpls(pkg, pubIface, implSet, implPkgSet)
+		}
+	}
+	require.NotEmpty(t, implSet,
+		"OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01: zero outbox.Publisher implementations collected — "+
+			"likely a type-universe regression (iface and impls must share one packages.Load). "+
+			"Expect at least adapters/rabbitmq.Publisher and adapters/mqtt.Publisher.")
+
+	// ─── Step 3: scan test corpus for outboxtest conformance call sites ──────
+	enrolledPkgs := make(map[string]bool)
+	testPatterns := prodscan.Patterns(root)
+	_ = RunTyped(t, TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, testPatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if !strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				if hasOutboxConformanceCall(f, p.TypesInfo) {
+					enrolledPkgs[canonicalPkgPath(p.Pkg.Path())] = true
+				}
+			}
+			return nil
+		})
+
+	// ─── Step 4: flag unenrolled, unwaived impls + stale waivers ─────────────
+	var diags []Diagnostic
+	for implKey := range implSet {
+		dotIdx := strings.LastIndex(implKey, ".")
+		if dotIdx < 0 {
+			continue
+		}
+		pkgPath := implKey[:dotIdx]
+		if enrolledPkgs[pkgPath] {
+			continue
+		}
+		if _, waived := outboxPublisherEnrollmentWaivers[pkgPath]; waived {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Rel:  implKey,
+			Line: 0,
+			Message: fmt.Sprintf(
+				"archtest: kernel/outbox.Publisher impl %q is not enrolled in an "+
+					"outboxtest.TestPubSub conformance test and is not in "+
+					"outboxPublisherEnrollmentWaivers (OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01). "+
+					"Add a _test.go in package %s that calls outboxtest.TestPubSub(t, features, ctor), "+
+					"or add a documented waiver entry.",
+				implKey, pkgPath),
+		})
+	}
+
+	// Stale-waiver guard: a waived package that IS now enrolled must drop its
+	// waiver (keeps the list honest; forces PR-3 to remove the mqtt waiver once
+	// the real TestPubSub call lands).
+	for pkgPath := range outboxPublisherEnrollmentWaivers {
+		if enrolledPkgs[pkgPath] {
+			diags = append(diags, Diagnostic{
+				Rel:  pkgPath,
+				Line: 0,
+				Message: fmt.Sprintf(
+					"archtest: package %s is in outboxPublisherEnrollmentWaivers but now HAS an "+
+						"outboxtest.TestPubSub call — remove the stale waiver entry "+
+						"(OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01).", pkgPath),
+			})
+		}
+	}
+
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	Report(t, "OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01", diags)
+}
+
+// TestOutboxPublisherEnrollment_REDFixture verifies the flagging logic reports a
+// violation when an impl's owning package is neither enrolled nor waived.
+// Strategy: collect the real implSet, then simulate a "missing enrollment" for
+// one non-waived impl and assert it is flagged.
+func TestOutboxPublisherEnrollment_REDFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based fixture test in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	prodPatterns := prodscan.Patterns(root)
+	ifacePatterns := append([]string{"./kernel/outbox/..."}, prodPatterns...)
+
+	var pubIface *types.Interface
+	var implPkgs []*types.Package
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == outboxPublisherIfacePkg {
+				if obj := p.Pkg.Scope().Lookup(outboxPublisherIfaceName); obj != nil {
+					if named, ok := obj.Type().(*types.Named); ok {
+						if iface, ok := named.Underlying().(*types.Interface); ok {
+							pubIface = iface.Complete()
+						}
+					}
+				}
+			}
+			implPkgs = append(implPkgs, p.Pkg)
+			return nil
+		})
+	require.NotNil(t, pubIface, "REDFixture: could not resolve outbox.Publisher interface")
+
+	implSet := make(map[string]bool)
+	implPkgSet := make(map[string]bool)
+	for _, pkg := range implPkgs {
+		if pkg != nil {
+			collectPublisherImpls(pkg, pubIface, implSet, implPkgSet)
+		}
+	}
+	require.NotEmpty(t, implSet, "REDFixture: implSet must not be empty")
+
+	// Pick any impl and derive its pkg path; simulate it being neither enrolled
+	// nor waived by running the flag loop with empty enrolled+waiver sets.
+	var target string
+	for k := range implSet {
+		target = k
+		break
+	}
+	dotIdx := strings.LastIndex(target, ".")
+	require.Greater(t, dotIdx, 0, "REDFixture: malformed impl key %q", target)
+
+	emptyEnrolled := map[string]bool{}
+	emptyWaivers := map[string]string{}
+	var diags []Diagnostic
+	for implKey := range implSet {
+		di := strings.LastIndex(implKey, ".")
+		if di < 0 {
+			continue
+		}
+		pkgPath := implKey[:di]
+		if emptyEnrolled[pkgPath] {
+			continue
+		}
+		if _, w := emptyWaivers[pkgPath]; w {
+			continue
+		}
+		diags = append(diags, Diagnostic{Rel: implKey, Message: implKey + " not enrolled"})
+	}
+	assert.GreaterOrEqual(t, len(diags), 1,
+		"REDFixture: with empty enrolled+waiver sets, every impl must be flagged (got 0)")
+}
+
+// TestOutboxPublisherEnrollment_ReverseBlindSpot_NoReflectImpl (blind spot B1)
+// confirms no production non-test file uses the string literal "Publisher" as
+// reflect bait to construct an implicit impl the type scan would miss.
+func TestOutboxPublisherEnrollment_ReverseBlindSpot_NoReflectImpl(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping archtest in -short mode")
+	}
+	root := findModuleRoot(t)
+	scope := ModuleScope(root)
+	diags := Run(t, scope, func(p *Pass) []Diagnostic {
+		var out []Diagnostic
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
+					return
+				}
+				out = append(out, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(call.Pos()).Line,
+					Message: "blind-spot B1: reflect MethodByName in production code may indicate a " +
+						"reflect-built outbox.Publisher the type scan misses " +
+						"(OUTBOX-PUBLISHER-CONFORMANCE-ENROLLMENT-01)",
+				})
+			})
+		}
+		return out
+	})
+	assert.Empty(t, diags,
+		"B1 reverse: no production non-test file should construct a Publisher via reflect.MethodByName")
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// collectPublisherImpls adds to implSet all exported concrete types in pkg that
+// implement outbox.Publisher (directly or via pointer). Interface types are
+// skipped. implPkgSet receives the package path for each collected impl.
+func collectPublisherImpls(pkg *types.Package, iface *types.Interface, implSet, implPkgSet map[string]bool) {
+	for _, name := range pkg.Scope().Names() {
+		obj, ok := pkg.Scope().Lookup(name).(*types.TypeName)
+		if !ok || !obj.Exported() {
+			continue
+		}
+		tt := obj.Type()
+		if _, isIface := tt.Underlying().(*types.Interface); isIface {
+			continue
+		}
+		if typesutil.ImplementsInterface(tt, iface) {
+			implSet[pkg.Path()+"."+name] = true
+			implPkgSet[pkg.Path()] = true
+		}
+	}
+}
+
+// hasOutboxConformanceCall returns true when file contains a call to
+// outboxtest.TestPubSub or any outboxtest.RunBatch* conformance entrypoint,
+// resolved via TypesInfo.
+func hasOutboxConformanceCall(file *ast.File, info *types.Info) bool {
+	if info == nil {
+		return false
+	}
+	found := false
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if found {
+			return
+		}
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != outboxtestPkg {
+			return
+		}
+		if name == "TestPubSub" || strings.HasPrefix(name, "RunBatch") {
+			found = true
+		}
+	})
+	return found
+}


### PR DESCRIPTION
## Summary

PR-2 of the V11-4 MQTT adapter series (parent #1138, spec/plan in `docs/plans/specs/202605262101-047-mqtt-adapter/`). Builds on PR-1 (commit 5a604ed9d) by adding the Publisher implementation, callsite funnel archtest, and Mosquitto-based integration tests.

- `outbox.Publisher` implementation (`adapters/mqtt.Publisher`) — QoS 1 + `Config.PublishTimeout` budget + PUBACK reason-code classification (8 codes via `classifyPubackReason`) + 3 metrics (`mqtt_publish_total` / `mqtt_publish_failed_total` / `mqtt_publish_ack_duration_seconds`)
- **Type-system funnel** for PublishOK precedence: `publishableTopic` unexported struct + `TopicNamespace.Mint` sole constructor → `Connection.Publish` only accepts `publishableTopic`. Cross-package Hard upstream (compile-gate), package-internal Medium backstop via archtest A2/A3, downstream Hard via archtest A1+A4-A7 blind-spot inventory
- `MQTT-PUBLISH-CALLSITE-FUNNEL-01` archtest in `tools/archtest/mqtt_callsite_funnel_test.go` (closes gh #1225 deferred enforcement)
- Integration tests against `eclipse-mosquitto:2.0` via testcontainers (3 scenarios: QoS1 / Reconnect / PubAckTimeout)
- PR-3 (Subscriber) / PR-4 (DLT + conformance + TLS) / PR-5 (iotdevice demo) are NOT in scope

Closes #1140

## Test plan

- [x] `go build ./...` clean
- [x] `go build -tags=integration ./...` clean
- [x] `go test ./adapters/mqtt/... -short` — all pass (101 unit cases including B1-B5 additions)
- [x] `go test -tags=integration -covermode=atomic ./adapters/mqtt/... -count=1 -timeout 5m` — 3/3 pass (90.0% coverage)
- [x] `go test ./tools/archtest/ -run 'MQTTPublishCallsiteFunnel' -count=1` — 10 sub-tests pass (A1+A2+A3+A4+A5+A6+A7 + 3 non-vacuous scanner checks)
- [x] `golangci-lint run ./adapters/mqtt/...` — 0 issues
- [x] `golangci-lint run ./tools/archtest/...` — 0 issues

## Refs

- `ref: eclipse/paho.golang/autopaho@v0.23.0` (`ConnectionManager.Publish(ctx, *paho.Publish) (*paho.PublishResponse, error)`)
- `ref: adapters/rabbitmq/publisher.go` (closed-guard `Mutex + atomic.Bool + WaitGroup` pattern; collector inject-at-construction)
- `ref: adapters/rabbitmq/publisher_metrics.go` (extended per AC-8 to add success counter + ack-duration histogram)
- `ref: adapters/rabbitmq/testmain_integration_test.go` (`sharedBrokerURL(t)` via `sync.Once` + TestMain teardown)
- `ref: adapters/otel/integration_test.go` (`testcontainers.GenericContainer` + `ContainerFile` in-memory conf mount)
- `ref: MQTT v5.0 §3.4.2.1` (PUBACK Reason Code table → `classifyPubackReason` matrix)

## Implementation matrix

```
Contract: kernel/outbox.Publisher interface
Change: add adapters/mqtt.Publisher implementation (no interface signature change)
Implementations: [x] memory (PR-1 ConnectionMock variants in connection_test.go)  [x] rabbitmq (existing)  [x] mqtt (this PR)
Conformance test: deferred to PR-4 (adapters/mqtt/conformance_test.go will call kernel/outbox/outboxtest.TestPubSub)
Repro: `go test -tags=integration -count=1 -timeout 5m ./adapters/mqtt/...`
Dependent contracts (governance scan): none — outbox.Publisher signature unchanged; this PR adds a new implementation of an existing stable interface
```

## AI-robust evaluation

Per `.claude/rules/gocell/ai-robust.md` review checklist for new enforcement mechanisms:

| Mechanism | Rating | Rationale |
|-----------|--------|-----------|
| `MQTT-PUBLISH-CALLSITE-FUNNEL-01` downstream | **Hard** | Typed CallExpr resolution + A4-A7 blind-spot reverse self-checks (method-value / method-expression / reflect / alias). Closed inventory. |
| `MQTT-PUBLISH-CALLSITE-FUNNEL-01` upstream cross-package | **Hard** | `publishableTopic` unexported + `TopicNamespace.Mint` sole constructor + `Connection.Publish` takes `publishableTopic` — Go type system compile-gate (string-typed concept funnel + sealed construction composite, per ai-robust.md §Hard 范本目录) |
| `MQTT-PUBLISH-CALLSITE-FUNNEL-01` upstream package-internal | **Medium** | A2 (Mint construction allowlist) + A3 (publishableTopic field freeze via go/types). Permanent Go ceiling (same as `SPAN-SETATTR-REDACT-01` / `PROBENAME-SEALED-FUNNEL-01` package-internal side); **no Hard upgrade gh issue needed** |

No new Soft archtest introduced. Closes the gh #1225 deferred funnel from PR-1.

## Diff size note

Net diff (insertions + deletions vs base commit `5a604ed9d`): ~2728 lines (issue body budget 2000). The overshoot is concentrated in the archtest file (814 lines for `mqtt_callsite_funnel_test.go`), which is in line with PR-1's `mqtt_funnel_test.go` (908 lines) and `probename_sealed_funnel_test.go` (1431 lines) — Hard funnel archtests with blind-spot inventories run 600-1000 lines in this codebase. Trimming would require cutting the blind-spot reverse self-checks, which are required by ai-robust.md §载体决策原则 for Hard ratings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)