### PR TITLE
feat(projection): CQRS projection harness ADR + kernel/projection skeleton [W10 PR-00] (#1172)

### DIFF
--- a/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+++ b/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
@@ -36,7 +36,7 @@ Hard funnel; hand-writing it N times is what the AI-robust charter forbids.
 | replay source | reuse the existing outbox journal / event store; this epic defines the cursor read contract |
 | **checkpoint / offset** | **new** — framework-owned offset table, committed in the same `CellTx` as business apply (exactly-once; does not touch business schema) |
 | **rebuild orchestration** | **new** — harness shell (Stop → Reset → Replay → Catch-up state machine) + business hook |
-| **observability metrics** | **new** — `projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_event_log_length` (covers #961) |
+| **observability metrics** | **new** — `projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_pending_events` (covers #961) |
 | **PROJECTION-CONSISTENCY-01 → Hard** | **new** — parser load-time `jsonschema.Validate` (covers #960) |
 | **examples L3 reference** | orderprojection rewritten onto the harness (covers #834) |
 

--- a/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+++ b/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
@@ -1,0 +1,336 @@
+# ADR: CQRS Projection lifecycle harness — design convergence (Q1–Q5) + kernel/projection skeleton
+
+- Status: Accepted
+- Date: 2026-05-26
+- Epic: #1100 (CQRS Projection lifecycle harness)
+- Implemented by (this PR — PR-00): #1172 [W10 PR-00] — ADR + `kernel/projection` skeleton (types/marker/phase, no implementation)
+- Sub-issues converged by the epic: #1079 (Projection/Replay runtime), #834 (L3 example projection), #960 (PROJECTION-CONSISTENCY-01 → Hard), #961 (L3 projection observability)
+- Spec / Plan / Tasks: `docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md` (+ `-implementation-plan.md`, `-tasks.md`)
+- Builds on ADRs: `202605051600-adr-pg-outbox-fencing.md` (fencing token), `202605101900-adr-cell-raw-infra-sealed-marker.md` (sealed marker), `202605161030-adr-cell-repo-readyz-probe.md` (readyz funnel), `202605241940-adr-l2-atomicity-subtypes.md` (L3 ⊥ L2)
+
+## 1. Context and scope
+
+GoCell's L3 projection scenario is hand-rolled today. The single instance —
+`examples/todoorder/cells/ordercell/internal/orderprojection` — mixes the
+framework-mechanical parts (sequence counter, in-memory append-only log, replay,
+rebuild) with the business parts (the event→state apply logic) in one
+hand-written `store`. Subscription wiring is already funneled through cellgen
+(`reg.Subscribe`), but **checkpoint / replay / rebuild / metrics are entirely
+business-implemented**: no persisted checkpoint (demo `nextSeq` is in-memory),
+rebuild is a bare in-memory log replay with no event-store replay protocol, and
+there is zero replay-lag / rebuild-duration / event-log-length observability.
+
+Two roadmap-committed consumers (winmdm `unified_device_id` / unified view,
+zerotrust `trustscore` / `eventcorrelation`) are about to ship streaming
+aggregation read-models across ~19 cells. Letting AI hand-write the projection
+loop (sequence / replay / checkpoint) in each is a textbook AI-robust Soft
+proliferation — a literal convention that **will** drift. Harnessing it once is a
+Hard funnel; hand-writing it N times is what the AI-robust charter forbids.
+
+### In scope (this epic)
+
+| Projection part | Owner |
+|---|---|
+| subscription wiring | harness (existing cellgen `reg.Subscribe`); this epic adds the `kind: projection` derivation path |
+| idempotent consume | harness (existing `ConsumerBase`); unchanged |
+| replay source | reuse the existing outbox journal / event store; this epic defines the cursor read contract |
+| **checkpoint / offset** | **new** — framework-owned offset table, committed in the same `CellTx` as business apply (exactly-once; does not touch business schema) |
+| **rebuild orchestration** | **new** — harness shell (Stop → Reset → Replay → Catch-up state machine) + business hook |
+| **observability metrics** | **new** — `projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_event_log_length` (covers #961) |
+| **PROJECTION-CONSISTENCY-01 → Hard** | **new** — parser load-time `jsonschema.Validate` (covers #960) |
+| **examples L3 reference** | orderprojection rewritten onto the harness (covers #834) |
+
+### Out of scope (GAP-8 sealed — see §4)
+
+The event→state apply **function body** and the read-model **schema** stay
+business-owned. The harness does not define a framework-level CQRS read-model
+table. v1 also defers snapshot / partial replay (§Q4), multi-projection
+concurrent rebuild, and cross-cell projection.
+
+### This PR (PR-00) delivers only
+
+The ADR (this document) plus the `kernel/projection` skeleton — interface
+declarations with no consume logic:
+
+- `doc.go` (package contract + ADR pointer), `phase.go` (the frozen 5-member
+  `Phase` enum), `types.go` (`Apply`, `CheckpointStore`, `Option`),
+  `cell_marker.go` (`CellCheckpointStore` sealed marker + `WrapCheckpointStoreForCell`).
+- `contract_test.go` — an *implementability proof*: a fake `CheckpointStore`, a
+  sample `Apply`, and assertions that the sealed marker + `Phase` work. This is
+  how PR-00 verifies the ADR's decisions are expressible **now** rather than
+  prose: `go build` proves the ambient-tx signatures typecheck against the real
+  `outbox.Entry` / `persistence` types; the test proves the contracts are
+  implementable and the marker actually seals. Behavioral correctness
+  (exactly-once / crash recovery) is verified by PR-01..PR-06 (see §6 threat
+  matrix → discharge column).
+- `tools/archtest/projection_state_phase_frozen_test.go` — PROJECTION-STATE-PHASE-FROZEN-01,
+  green from this PR (locks the `Phase` membership; §7).
+
+The Coordinator, mem/PG checkpoint stores, rebuild state machine, metrics,
+readyz, and cellgen derivation land in PR-01..PR-06 per the implementation plan.
+
+## 2. Open-source benchmarks (对标)
+
+Per CLAUDE.md every new module is benchmarked against open-source frameworks
+first. This is the deeper version of the spec §0 table.
+
+| Framework | apply hook shape | checkpoint store | rebuild orchestration | exactly-once | read during replay |
+|---|---|---|---|---|---|
+| **Axon** (Java — primary) | `@EventHandler void(MyEvent)` + business fetches repo | `token_entry` (processor_name, segment, token, **owner**) | 4-phase: Stop → Reset (`@ResetHandler`) → Replay → Catch-up | token committed in the **same tx** as the read-model | not blocked (stale) |
+| **Marten** Async (.NET) | `Apply(IDocumentOperations ops, Event e)` | `mt_event_progression` | `daemon.RebuildProjectionAsync<T>` | separate tx, idempotent upsert | not blocked (stale) |
+| **eventhorizon** (Go) | `Project(ctx, event, entity) (entity, error)` | **no built-in checkpoint** | no rebuild API | entity optimistic lock | business self-manages |
+| **Commanded** (Elixir) | `project %Event{}, meta, do: Ecto.Multi.x(...)` | EventStore `subscriptions` | clear table + restart subscriber | separate tx | not blocked (stale) |
+| **Watermill CQRS** (Go) | `Handle(ctx, event) error` | broker-side offset | no rebuild | broker-guaranteed | not blocked (stale) |
+
+`ref:` (deep citations used in the decisions below):
+
+- **Axon** — `org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore` (token-in-tx), `TrackingEventProcessor` lifecycle (Stop/Reset/Replay/Catch-up), `@ResetHandler`, `token_entry.owner` (distributed claim), `axon-micrometer` metrics (`eventProcessor.latency`).
+- **Marten** — `Marten.Events.Daemon` async-daemon, `IProjection.ApplyAsync` / `IDocumentOperations`, `mt_event_progression`.
+- **eventhorizon** — `github.com/looplab/eventhorizon/eventhandler/projector` (`Project(ctx, event, entity)`); **explicitly rejected** below.
+- **Commanded** — `Commanded.Projections.Ecto` read-model-projections (`Ecto.Multi`).
+- **Watermill** — `github.com/ThreeDotsLabs/watermill/components/cqrs` `EventProcessor` (GoCell's outbox + ConsumerBase already aligns with this; this epic is the projection extension on top).
+
+Key takeaways driving the decisions:
+
+1. eventhorizon's single-entity read-modify-write (its `Project` shape) **does
+   not fit GoCell** — GoCell projections routinely write across tables; a single
+   entity model locks the business. Explicitly rejected (Q2).
+2. Axon's `token_entry` + same-tx commit is the most rigorous exactly-once model
+   and maps exactly onto GoCell's `persistence.TxRunner.RunInTx` (Q1).
+3. Axon rebuild is **4-phase** (Stop → Reset → Replay → Catch-up); the original
+   spec's "3-phase" is superseded (§Q4-supplement / §3 Phase decision).
+4. Industry consensus: **rebuild does not block reads** (Axon / Marten /
+   Commanded / Watermill agree); stale read is a business concern. The spec §4
+   Scenario C "read returns 503" line is superseded (§5).
+5. Axon's `owner` column implements distributed claim; this introduces Q5
+   (multi-pod concurrency for a single projection).
+6. Snapshot is unnecessary for v1: Axon introduces snapshots because its event
+   log is globally shared with replay volumes ≥ millions; GoCell's outbox is a
+   per-cell local event stream, far smaller (Q4).
+
+## 3. Decisions (Q1–Q5)
+
+> Terminology: the Q-table option letters (A/B/C/D) are GoCell-local and do NOT
+> correspond to the open-source A/B/C in §2's table. Each decision names its
+> benchmark anchor explicitly.
+
+### Q1 — checkpoint exactly-once protocol → **A** (caller-provided tx, harness-internal SaveOffset)
+
+- **Options.** A: harness takes the caller's ambient tx and calls `SaveOffset`
+  internally (ref: Axon JdbcTokenStore). B: harness exposes
+  `RegisterCheckpoint(tx, offset)` for the business to commit. C: after-commit
+  hook writes the offset asynchronously (not exactly-once; ref: Marten Async /
+  Commanded).
+- **Argument.** A matches the existing `outbox.Writer.Write(ctx, entry)` pattern
+  exactly: the caller wraps in `RunInTx`, the implementation joins via
+  `persistence.TxFromContext(ctx)`. The Coordinator runs `apply` + `SaveOffset`
+  in one `RunInTx`, so the read-model mutation and the offset advance commit or
+  roll back together — the strictest exactly-once model, and it is the same
+  ambient-tx idiom every GoCell repository already uses (enforced by
+  `PG-REPO-AMBIENT-TX-01`). B leaks the offset mechanism into business code; C is
+  not exactly-once.
+- **Decision.** A. The `CheckpointStore` interface (PR-00 `types.go`) is
+  ambient-tx: `SaveOffset(ctx, cellID, projectionID, offset)` — no explicit tx
+  parameter.
+- **Correction of the plan sketch.** The implementation-plan and spec sketched
+  `apply(ctx, event, txHandle)` / `SaveOffset(ctx, tx, ...)` with a
+  `persistence.TxHandle` parameter. **No such type exists**, and an explicit
+  tx-handle parameter contradicts `PG-REPO-AMBIENT-TX-01` (landed 2026-05-29,
+  PR #1224), which seals repository tx access behind the ambient
+  `persistence.TxFromContext` + `internal/pgexec` funnel. This ADR freezes the
+  ambient-tx shape; the sketch is superseded.
+- **Risk.** If a future cross-cell projection needs two independent
+  transactions, ambient single-tx is insufficient. **Rollback condition:** ADR
+  amend + PR-01 Coordinator rework. (Cross-cell projection is already out of
+  scope for v1, §1.)
+- **ref:** Axon JdbcTokenStore (same-tx commit); GoCell `kernel/outbox/outbox.go::Writer`.
+
+### Q2 — business apply hook signature → **A** (`apply(ctx, event) error`, ambient tx)
+
+- **Options.** A: `apply(ctx, event) error` with the tx ambient in ctx (ref:
+  Marten Async `IDocumentOperations`). B: `apply(ctx, event, entity) (entity,
+  error)` + harness read-modify-write (ref: eventhorizon — rejected). C:
+  `apply(ctx, event) error` + business self-manages tx (ref: Watermill). D:
+  annotation-driven (ref: Axon `@EventHandler`; not idiomatic in Go).
+- **Argument.** A is the minimal dependency: the hook receives the event and
+  obtains the tx ambiently — it does not bind the read-model schema or an entity
+  type. This is the Marten `IDocumentOperations` shape adapted to GoCell's
+  ambient-tx convention. B (eventhorizon) locks the business into single-entity
+  read-modify-write — GoCell projections write across tables; rejected. C makes
+  exactly-once the business's problem; rejected.
+- **Decision.** A. PR-00 `types.go`:
+  `type Apply func(ctx context.Context, event outbox.Entry) error`.
+- **Risk.** Ambient tx is implicit — a business author might forget the apply
+  runs in a tx and open their own connection. Mitigated by
+  `PROJECTION-CHECKPOINT-TX-BOUND-01` (PR-02) + the doc.go contract + the
+  cellgen-derived wiring being the only Subscribe callsite
+  (`PROJECTION-APPLY-HOOK-FUNNEL-01`, PR-04). **Rollback condition:** if review
+  finds the ambient model error-prone in practice, switch to an explicit
+  ops-handle parameter — but this is an ADR-amend + epic-wide signature change,
+  not a silent patch.
+- **ref:** Marten async-daemon `IDocumentOperations`; eventhorizon `projector.Project` (rejected).
+
+### Q3 — kind:projection codegen funnel shape → **A** (single slice → single projection)
+
+- **Options.** A: one slice declares one projection (its subscribe set is that
+  projection's input stream). B: multiple slices share one projection (needs a
+  new metadata node).
+- **Argument.** A covers both roadmap-committed scenarios (winmdm
+  `unified_device_id`, zerotrust `trustscore`). B is a v1.1 extension point;
+  building the multi-slice metadata node now is speculative generality.
+- **Decision.** A. cellgen derives the projection wiring from a single slice's
+  `contractUsages[role=subscribe]` (PR-04).
+- **Risk.** A projection that genuinely needs to fan in from multiple event
+  streams must, in v1, route them through one slice's subscribe set. **Rollback
+  condition:** v1.1 adds a multi-slice projection metadata node; no v1 data
+  migration needed (the checkpoint key is `(cell_id, projection_id)`, agnostic
+  to slice count).
+- **ref:** Axon processor-to-event-handler grouping.
+
+### Q4 — snapshot / partial replay in v1 → **A** (not in v1; full rebuild)
+
+- **Options.** A: v1 does not do snapshots (rebuild is full). B: v1 leaves a
+  hook but no PG store. C: v1 full support.
+- **Argument.** A snapshot PG-table abstraction would cross the GAP-8 seal
+  boundary (it would impose a framework read-model-ish table). The
+  full-replay-only choice is well-supported by the benchmark: Axon introduces
+  snapshots because its event log is globally shared with replay volumes ≥
+  millions; GoCell's outbox is a per-cell local stream, far smaller.
+- **Decision.** A. No snapshot store in v1; deliberately blank.
+- **Risk.** If winmdm Stage 1 measures full rebuild ≥ 30 min, snapshot becomes a
+  v1.1 emergency. **This trigger condition is documented here, not filed as a
+  silent backlog** (per the no-lazy-deferral rule): *winmdm Stage 1 full-rebuild
+  wall-clock ≥ 30 min ⇒ open a v1.1 snapshot-store epic.* **Rollback
+  condition:** same trigger.
+- **ref:** Axon snapshot design motivation (shared-log replay volume) vs GoCell per-cell stream scale.
+
+### Q5 — multi-pod concurrency for one projection → **A** (v1 single-pod; reserve `owner` column)
+
+- **Options.** A: v1 single-pod (leader election handled by the upper layer
+  `cmd/corebundle`); the schema reserves an `owner TEXT` column but never reads
+  or writes it. B: v1 built-in pessimistic claim (owner column + advisory lock).
+- **Argument.** A is the lowest-complexity safe v1. The PG checkpoint schema
+  (PR-02) includes `owner TEXT NOT NULL DEFAULT ''` (ref: Axon
+  `token_entry.owner`), but v1 INSERT/UPDATE paths **must not touch it** (guarded
+  by `PROJECTION-CHECKPOINT-OWNER-COLUMN-V1-RESERVED-01`, PR-02). Multi-pod
+  safety in v1 is the responsibility of upper-layer leader election. v1.1
+  implements pessimistic claim on the existing `owner` column — zero migration
+  cost.
+- **Decision.** A. **Explicit v1 boundary:** v1 runs single-pod; running two
+  pods consuming the same projection without external leader election is
+  **unsafe in v1** (both would advance the same checkpoint). This is a documented
+  v1 limitation, surfaced in the threat matrix row 7.
+- **Risk.** An operator deploys 2+ replicas of a projection cell without leader
+  election → double-apply / checkpoint races. Mitigation: documented boundary +
+  the `owner` column is pre-provisioned so v1.1 claim needs no schema change.
+  **Rollback condition:** none needed — v1.1 is a forward extension, not a
+  rollback.
+- **ref:** Axon `token_entry.owner` distributed-claim column.
+
+### Phase enum (settled alongside Q-decisions)
+
+The `Phase` enum (PR-00 `phase.go`) is frozen to **five** members:
+`PhaseLive`, `PhaseStopped`, `PhaseReset`, `PhaseReplay`, `PhaseCatchup`. The
+four rebuild phases mirror Axon's processor lifecycle; `PhaseLive` is the
+steady-state value outside a rebuild, needed because `Phase()` is also the value
+a business read path inspects for its read-503 opt-in (§5).
+
+**Supersession (per ai-robust.md "原文与 amendment 矛盾段落同 PR 内重写").** The
+spec §5.1 "three-phase (reset/replay/catch-up)" and §4 Scenario C "business read
+returns 503 (blocking)" predate the Axon benchmark and are **superseded by this
+ADR**: rebuild is 4-phase (Stop added) and reads are not blocked (§5). The spec
+text is the historical input; this ADR is the authority.
+
+## 4. GAP-8 seal re-review record
+
+GAP-8 (the six-seat sealed boundary: "the framework does not prescribe CQRS
+read-model tables") was reviewed against this harness. **Finding:** the
+CellTx-offset design keeps the harness clear of the seal. The harness owns only
+its own `projection_checkpoints` offset table; it does **not** define, require,
+or constrain any business read-model table schema, and the event→state apply
+function body stays business-written. Therefore the harness is **not** within
+GAP-8's sealing rationale ("do not bind the business's table-design freedom").
+
+**Seal narrowed (recorded for the upcoming winmdm Stage 1 six-seat re-review):**
+the GAP-8 seal is read here as covering exactly two things — *(a)* the apply
+function body, and *(b)* the read-model table schema. Lifecycle mechanics
+(checkpoint / replay / rebuild / metrics) are explicitly outside the seal. This
+record is the input to feed the winmdm Stage 1 six-seat meeting; the seal itself
+is unchanged, only its scope is documented.
+
+## 5. Q4-supplement — reads are not blocked during rebuild; `Phase()` is the opt-in
+
+Industry consensus (Axon / Marten / Commanded / Watermill, §2 row "read during
+replay") is that **rebuild does not block business reads**; a stale read during
+rebuild is the business's responsibility. The harness follows this:
+
+- The harness **never** forces a 503 on business read paths.
+- The Coordinator exposes `Phase() Phase`. `PhaseLive` ⇒ the read-model is fresh
+  and serving; any other phase ⇒ a rebuild is in progress. A business read path
+  **may** consult `Phase()` and return 503 of its own accord, but the harness
+  does not impose it.
+
+This supersedes spec §4 Scenario C "business read returns 503" and §5.2
+"rebuild 期间业务 read endpoint 必须 503": the contract is **non-blocking +
+`Phase()` opt-in**, recorded here as the single source of truth.
+
+## 6. Threat matrix
+
+Each row names the threat, the v1 mechanism, and **which PR discharges it**
+(PR-00 freezes the contracts; behavior is proven downstream — answering "can an
+ADR-only PR be verified": the type-level decisions are verified now, behavior is
+verified by the listed PR).
+
+| # | Threat | v1 mechanism | Discharged by |
+|---|---|---|---|
+| 1 | **exactly-once** (apply runs once per offset) | apply + `SaveOffset` in one `CellTx` (Q1); offset ≤ checkpoint ⇒ skip apply | PR-01 Coordinator cold-start/out-of-order unit tests |
+| 2 | **crash recovery** (no replay window after restart) | checkpoint persisted in the apply tx; restart loads checkpoint, resumes at offset+1 | PR-01 crash-recovery unit test; PR-06 real-PG integration (kill → restart) |
+| 3 | **rebuild-period read consistency** | non-blocking by design (§5); `Phase()` lets business opt into 503; stale read is a business concern | PR-03 `Phase()` + readyz; ADR §5 contract |
+| 4 | **out-of-order replay** (broker redelivery during catch-up) | offset monotonic; offset ≤ checkpoint ⇒ apply NOT called (exactly-once delivery to apply) | PR-01 out-of-order unit test |
+| 5 | **fail-closed** (checkpoint store failure) | `SaveOffset` failure rolls back the whole `CellTx` (apply not committed); Coordinator requeues; never advances offset past an un-applied event | PR-01 fail-closed unit test |
+| 6 | **GAP-8 boundary** (harness must not prescribe read-model schema) | CellTx-offset design touches only the framework offset table; apply body + read-model schema stay business-owned (§4) | This PR (§4 record) + PR-02 schema review |
+| 7 | **multi-pod concurrency (v1 boundary)** | v1 single-pod (Q5); `owner` column reserved but unread/unwritten; multi-pod safety = upper-layer leader election; **2+ replicas without leader election is unsafe in v1** | PR-02 `owner`-reserved archtest; documented v1 limitation (Q5) |
+
+## 7. AI-robust ratings
+
+The epic introduces five enforcement mechanisms. Ratings follow
+`.claude/rules/gocell/ai-robust.md`; symbol inventories live in each archtest's
+package godoc (not duplicated here).
+
+| ID | PR (stub → green) | Funnel direction / rating | Hard-template (§"Hard 范本目录") |
+|---|---|---|---|
+| **PROJECTION-STATE-PHASE-FROZEN-01** | PR-00 (green now) | n/a (membership freeze) — **Medium** (AST const-set + String-arm lock; Go enums are not reflectable as a set, so an AST/golden lock is the ceiling — same shape as `OUTBOX-STATE-TRANSITION-COMPLETENESS-01`). The orthogonal "zero value invalid" guarantee is Hard via `iota+1` + `Phase.Valid()` (type system). | enum-set golden lock |
+| **PROJECTION-APPLY-HOOK-FUNNEL-01** | PR-01 stub → PR-04 green | 下游 **Hard** (Subscribe callable only from generated files + kernel self + `_test.go`) / 上游 **Medium** (caller allowlist; same shape as `HEALTHZ-WRITE-01` A2). Transitional Medium-upstream → gh issue tracked at PR-04. | single sanctioned holder / caller-identity allowlist |
+| **PROJECTION-CHECKPOINT-TX-BOUND-01** | PR-01 stub → PR-02 green | **Medium** (`SaveOffset` impl must obtain tx via `persistence.TxFromContext`; raw `db.Exec` / `*sql.Tx` form fails). Rides the existing `PG-REPO-AMBIENT-TX-01` Hard funnel for the PG adapter. | typed-param / ambient-tx form |
+| **PROJECTION-CHECKPOINT-OWNER-COLUMN-V1-RESERVED-01** | PR-02 | **Medium** (SQL-literal scan rejects `owner` in INSERT/UPDATE write paths; v1 scope — removed in the same PR that enables v1.1 claim). | input-struct field exclusion (SQL-write variant) |
+| **PROJECTION-CONSISTENCY-PARSE-TIME-01** | PR-05 | 下游 **Hard** (parser load path must call `jsonschema.Validate`; callsite identity locked) — upgrades #960 from Medium governance rule to Hard parse-time gate. | codegen/parse funnel + callsite identity |
+
+Sealed-marker note: `CellCheckpointStore` (PR-00 `cell_marker.go`) is the
+sealed-marker Hard at the field/assignment layer (external code cannot express
+`internalCellCheckpointStore`), mirroring `outbox.CellPublisher`. It auto-enrolls
+in `SEALED-MARKER-NOOP-TRANSPARENCY-01` (every kernel `internalCell*` must
+forward `Noop()`); this PR bumps that archtest's floor guard 4 → 5.
+
+## 8. Consequences
+
+**Positive.** One Hard funnel replaces N hand-written projection loops across
+winmdm/zerotrust. Checkpoint exactly-once is the same ambient-tx idiom as
+outbox.Writer (no new mental model). The skeleton makes the ADR's signature
+decisions compile-verifiable from day one.
+
+**Negative / accepted costs.** Ambient tx is implicit (mitigated by archtests +
+doc contract, Q2 risk). v1 is single-pod (Q5 boundary). No snapshot in v1 (Q4
+trigger documented). The `Phase` enum freeze means adding a phase is a
+deliberate golden update (intended).
+
+## 9. Alternatives rejected
+
+- **Explicit `persistence.TxHandle` parameter** (the plan sketch): rejected —
+  contradicts `PG-REPO-AMBIENT-TX-01` and `outbox.Writer`; would invent and seal
+  a new type for no benefit over the established ambient idiom (§Q1 correction).
+- **eventhorizon single-entity `Project(ctx, event, entity)`**: rejected —
+  GoCell projections write across tables (§Q2).
+- **After-commit async offset write** (Marten/Commanded separate-tx): rejected —
+  not exactly-once (§Q1 option C).
+- **Snapshot store in v1**: rejected — crosses GAP-8, unsupported by replay-scale
+  benchmark; deferred with a documented trigger (§Q4).

--- a/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+++ b/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
@@ -300,6 +300,31 @@ projection). It is constructed via `kernel/healthz.NewProbeName(...)` — there 
 PR-03's constructor returns `(ProbeName, error)` and fails fast at construction
 when the budget is exceeded, rather than silently dropping the probe.
 
+### Rebuild control-plane endpoint (PR-03 forward contract)
+
+The rebuild trigger is an internal HTTP endpoint. Its `contract.yaml` + handler
+land in **PR-03 (T-03-3)**; this section freezes the forward contract so PR-03
+does not drift and `/internal/v1/` declaration requirements
+(`.claude/rules/gocell/go-standards.md` §安全检查点) are satisfied at design time:
+
+- **Endpoint**: `POST /internal/v1/<cellID>/projection/<projectionID>/rebuild`.
+- **Caller / auth**: service-token authentication + caller-cell allowlist (the
+  caller's cell ID must be in the contract's `clients` allowlist). No public
+  access. Same shape as other `/internal/v1/` control-plane endpoints.
+- **Network boundary**: internal-only — never mounted on a public listener.
+- **HTTP semantics**: `202 Accepted` (rebuild is async — the state machine runs
+  in the background; the response acknowledges acceptance, not completion) /
+  `409 Conflict` (a rebuild is already in progress for this projection;
+  `Phase() != PhaseLive`) / `404 Not Found` (unknown cell/projection).
+- **Response envelope**: the unified `{"data": {...}}` shape
+  (`.claude/rules/gocell/error-handling.md`); the `data` object carries the
+  current `{phase, replayLagSeconds, pendingEvents}` snapshot. Errors use the
+  shared error envelope.
+
+The full `contract.yaml` (request/response schema, `clients` allowlist) is
+authored in PR-03; PR-00 freezes only the auth model + network boundary + status
+semantics above.
+
 ## 6. Threat matrix
 
 Each row names the threat, the v1 mechanism, and **which PR discharges it**

--- a/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+++ b/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
@@ -181,7 +181,10 @@ Key takeaways driving the decisions:
 - **Decision.** A. cellgen derives the projection wiring from a single slice's
   `contractUsages[role=subscribe]` (PR-04).
 - **Risk.** A projection that genuinely needs to fan in from multiple event
-  streams must, in v1, route them through one slice's subscribe set. **Rollback
+  streams must, in v1, route them through one slice's subscribe set — a single
+  slice may list multiple `contractUsages[role=subscribe]` entries (the existing
+  cellgen Subscribe loop already handles N contracts per slice), so v1 fan-in is
+  expressible without the multi-slice node. **Rollback
   condition:** v1.1 adds a multi-slice projection metadata node; no v1 data
   migration needed (the checkpoint key is `(cell_id, projection_id)`, agnostic
   to slice count).
@@ -211,8 +214,12 @@ Key takeaways driving the decisions:
   or writes it. B: v1 built-in pessimistic claim (owner column + advisory lock).
 - **Argument.** A is the lowest-complexity safe v1. The PG checkpoint schema
   (PR-02) includes `owner TEXT NOT NULL DEFAULT ''` (ref: Axon
-  `token_entry.owner`), but v1 INSERT/UPDATE paths **must not touch it** (guarded
-  by `PROJECTION-CHECKPOINT-OWNER-COLUMN-V1-RESERVED-01`, PR-02). Multi-pod
+  `token_entry.owner`), but v1 INSERT/UPDATE paths **must not touch it** — this
+  is **to be** statically guarded by `PROJECTION-CHECKPOINT-OWNER-COLUMN-V1-RESERVED-01`,
+  landing in **PR-02 together with the PG adapter that introduces the column**.
+  Until PR-02 merges there is no checkpoint write path at all (this PR is the
+  skeleton), so the constraint has nothing to guard yet; the row-7 boundary rests
+  on the documented limitation + PR-02 review until the archtest exists. Multi-pod
   safety in v1 is the responsibility of upper-layer leader election. v1.1
   implements pessimistic claim on the existing `owner` column — zero migration
   cost.
@@ -269,10 +276,29 @@ rebuild is the business's responsibility. The harness follows this:
   and serving; any other phase ⇒ a rebuild is in progress. A business read path
   **may** consult `Phase()` and return 503 of its own accord, but the harness
   does not impose it.
+- `Phase()` is a **best-effort point-in-time snapshot, not a freshness lock**: a
+  read path that observes `PhaseLive` and then queries the read-model has no
+  atomic ordering against a rebuild that may begin between the two calls.
+  Business code requiring strict freshness must maintain its own read quiescence;
+  the harness deliberately does not provide a happens-before guarantee here.
 
 This supersedes spec §4 Scenario C "business read returns 503" and §5.2
 "rebuild 期间业务 read endpoint 必须 503": the contract is **non-blocking +
 `Phase()` opt-in**, recorded here as the single source of truth.
+
+### Readyz probe name (PR-03 forward contract)
+
+The projection readiness probe name is frozen here as the operational contract
+(it becomes a dashboard/alert dependency once PR-03 lands):
+`<cell>_projection_<name>_ready` (supersedes the spec §3 `<cell>_projection_ready`
+form, which omitted the projection name — a cell may host more than one
+projection). It is constructed via `kernel/healthz.NewProbeName(...)` — there is
+**no `ReadyProbeName` type** and **no bare `healthz.ProbeName(string)` cast**
+(that would bypass `PROBENAME-SEALED-FUNNEL-01`). **Length budget:**
+`NewProbeName` caps names at 64 chars; the fixed segments cost 18
+(`_projection_` = 12, `_ready` = 6), so `len(cellID) + len(projectionID) ≤ 46`.
+PR-03's constructor returns `(ProbeName, error)` and fails fast at construction
+when the budget is exceeded, rather than silently dropping the probe.
 
 ## 6. Threat matrix
 
@@ -283,10 +309,10 @@ verified by the listed PR).
 
 | # | Threat | v1 mechanism | Discharged by |
 |---|---|---|---|
-| 1 | **exactly-once** (apply runs once per offset) | apply + `SaveOffset` in one `CellTx` (Q1); offset ≤ checkpoint ⇒ skip apply | PR-01 Coordinator cold-start/out-of-order unit tests |
+| 1 | **exactly-once** (apply runs once per offset) | apply + `SaveOffset` in one `CellTx` (Q1); the harness compares each replayed event's stream position (from the PR-01 replay cursor — not an `outbox.Entry` field) against the stored checkpoint and skips when ≤ checkpoint | PR-01 Coordinator cold-start/out-of-order unit tests |
 | 2 | **crash recovery** (no replay window after restart) | checkpoint persisted in the apply tx; restart loads checkpoint, resumes at offset+1 | PR-01 crash-recovery unit test; PR-06 real-PG integration (kill → restart) |
 | 3 | **rebuild-period read consistency** | non-blocking by design (§5); `Phase()` lets business opt into 503; stale read is a business concern | PR-03 `Phase()` + readyz; ADR §5 contract |
-| 4 | **out-of-order replay** (broker redelivery during catch-up) | offset monotonic; offset ≤ checkpoint ⇒ apply NOT called (exactly-once delivery to apply) | PR-01 out-of-order unit test |
+| 4 | **out-of-order replay** (broker redelivery during catch-up) | checkpoint is monotonic; a redelivered event whose replay-cursor position ≤ checkpoint does NOT invoke apply (exactly-once delivery to apply); ConsumerBase's Claimer idempotency layer sits above the Coordinator as defense-in-depth | PR-01 out-of-order unit test |
 | 5 | **fail-closed** (checkpoint store failure) | `SaveOffset` failure rolls back the whole `CellTx` (apply not committed); Coordinator requeues; never advances offset past an un-applied event | PR-01 fail-closed unit test |
 | 6 | **GAP-8 boundary** (harness must not prescribe read-model schema) | CellTx-offset design touches only the framework offset table; apply body + read-model schema stay business-owned (§4) | This PR (§4 record) + PR-02 schema review |
 | 7 | **multi-pod concurrency (v1 boundary)** | v1 single-pod (Q5); `owner` column reserved but unread/unwritten; multi-pod safety = upper-layer leader election; **2+ replicas without leader election is unsafe in v1** | PR-02 `owner`-reserved archtest; documented v1 limitation (Q5) |

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
@@ -101,19 +101,23 @@ Dependent contracts (governance scan): kind:projection contract.yaml schema (PR-
 
 ### 关键设计点（落 ADR §决议）
 
+> **以 ADR `202605261620` §3 为权威。** 本节早期草稿写的 `persistence.TxHandle`
+> 显式参数已被 PR-00 ADR Q1/Q2 收敛为 **ambient-tx**（该类型不存在，且与
+> `PG-REPO-AMBIENT-TX-01` 冲突）。下面是已对齐 PR-00 冻结签名的形态。
+
 ```go
-// kernel/projection/types.go (declared in PR-00, implemented in PR-01)
-type Apply func(ctx context.Context, event outbox.Entry, tx persistence.TxHandle) error
+// kernel/projection/types.go (declared in PR-00, Coordinator implemented in PR-01)
+type Apply func(ctx context.Context, event outbox.Entry) error
 
 type CheckpointStore interface {
-    LoadOffset(ctx context.Context, projectionID string) (int64, error)
-    SaveOffset(ctx context.Context, tx persistence.TxHandle, projectionID string, offset int64) error
+    LoadOffset(ctx context.Context, cellID, projectionID string) (int64, error)
+    SaveOffset(ctx context.Context, cellID, projectionID string, offset int64) error
 }
 
-// Sealed marker (cells/* 持有，composition root wrap)
+// Sealed marker (cells/* 持有，composition root wrap) — mirrors outbox.CellPublisher
 type CellCheckpointStore interface {
-    checkpointStoreOK()  // sealed marker method
     CheckpointStore
+    sealedCellCheckpointStore()  // sealed marker method
 }
 
 // Coordinator entry point (called by cellgen-derived wiring, NOT business code)
@@ -126,23 +130,23 @@ func (c *Coordinator) Subscribe(
 ) error
 ```
 
-**内部消费 handler 实现**（CellTx 包裹 apply + SaveOffset 同源 commit）：
+**内部消费 handler 实现**（CellTx 包裹 apply + SaveOffset 同源 commit；tx 为 ambient）：
 
 ```go
-// 伪码
-func (c *Coordinator) buildHandler(projectionID string, apply Apply) outbox.EntryHandler {
+// 伪码 — tx 不作显式参数，apply/SaveOffset 经 ctx 内 persistence.TxFromContext 取
+func (c *Coordinator) buildHandler(cellID, projectionID string, apply Apply) outbox.EntryHandler {
     return func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
         err := c.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
-            tx := persistence.TxFromContext(txCtx)
-            current, err := c.store.LoadOffset(txCtx, projectionID)
+            current, err := c.store.LoadOffset(txCtx, cellID, projectionID)
             if err != nil { return err }
-            if entry.Seq <= current {
+            pos := c.cursor.Position(entry)   // 由 PR-01 replay 源提供（outbox.Entry 无 Seq 字段）
+            if pos <= current {
                 return nil  // exactly-once: 已应用过，skip
             }
-            if err := apply(txCtx, entry, tx); err != nil { return err }
-            return c.store.SaveOffset(txCtx, tx, projectionID, entry.Seq)
+            if err := apply(txCtx, entry); err != nil { return err }
+            return c.store.SaveOffset(txCtx, cellID, projectionID, pos)
         })
-        // 错误分类 → Disposition
+        // 错误分类 → Disposition（permanent error 经 outbox.NewPermanentError 包裹）
         if err == nil { return outbox.Ack() }
         if isPermanent(err) { return outbox.Reject(err) }
         return outbox.Requeue(err)
@@ -155,8 +159,8 @@ func (c *Coordinator) buildHandler(projectionID string, apply Apply) outbox.Entr
 | ID | 评级 | 范式 |
 |----|------|------|
 | PROJECTION-APPLY-HOOK-FUNNEL-01 | Hard 下游 / Medium 上游 | `Coordinator.Subscribe` 仅允许在 generated 文件 + `kernel/projection/coordinator.go` 自身 + `_test.go` 调用；business 包内的手写 callsite fail（与 `HEALTHZ-WRITE-01` 同范式） |
-| PROJECTION-CHECKPOINT-TX-BOUND-01 | Medium | `CheckpointStore.SaveOffset` 必接 `persistence.TxHandle` typed 参数；any raw `*sql.Tx` / `db.Exec` 形态 fail |
-| PROJECTION-STATE-PHASE-FROZEN-01 | Hard | reflect 锁 `Phase` enum 字段集（与 `SUBSCRIBERS-DERIVED-FIELD-FROZEN-01` 同范式）—— v1 仅 `{cold, replay, catchup}`，新增需 PR 加 const + 更新 golden |
+| PROJECTION-CHECKPOINT-TX-BOUND-01 | Medium | `CheckpointStore.SaveOffset` 实现必须经 `persistence.TxFromContext(ctx)` 取 ambient tx；裸 `*sql.Tx` 参数 / `db.Exec` 形态 fail（与 outbox.Writer 同范式） |
+| PROJECTION-STATE-PHASE-FROZEN-01 | Medium | AST 锁 `Phase` enum const 集 + String arms —— v1 为 5 成员 `{PhaseLive, PhaseStopped, PhaseReset, PhaseReplay, PhaseCatchup}`，新增需 PR 加 const + 更新 golden（PR-00 已 green） |
 
 ### Done definition
 
@@ -268,15 +272,18 @@ projection_event_log_length{cell, projection}             gauge
 
 `cell` label 直接对齐 [observability.md HTTP Metrics cell Label 段](.claude/rules/gocell/observability.md) 既有约定。
 
-### ReadyProbeName typed funnel
+### Readyz probe name typed funnel
+
+> 经 `kernel/healthz.NewProbeName(...)` 构造，**无 `ReadyProbeName` 类型、无裸
+> `healthz.ProbeName(string)` cast**（裸 cast 绕过 `PROBENAME-SEALED-FUNNEL-01`）。
+> 名 `<cell>_projection_<name>_ready`，长度预算 `len(cellID)+len(projectionID) ≤ 46`
+> （cap 64 − 固定段 18）。详见 ADR §5「Readyz probe name」。
 
 ```go
 // kernel/projection/probe.go
-const probeReadySuffix healthz.ReadyProbeName = "_projection_ready"
-
-func ProbeName(cellID, projectionID string) healthz.ReadyProbeName {
-    // typed funnel — 与 postgres.ProbeReady 同范式
-    return healthz.ReadyProbeName(cellID + "_projection_" + projectionID + "_ready")
+func ProjectionReadyProbeName(cellID, projectionID string) (healthz.ProbeName, error) {
+    // typed funnel — 唯一构造入口 healthz.NewProbeName（含长度/字符校验，fail-fast）
+    return healthz.NewProbeName(cellID + "_projection_" + projectionID + "_ready")
 }
 ```
 

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
@@ -265,10 +265,15 @@ Invariant inventory (DROP COLUMN 不适用)
 ### Metric 命名（registered 一次，多 projection 共享）
 
 ```
-projection_event_replay_lag_seconds{cell, projection}    gauge
+projection_event_replay_lag_seconds{cell, projection}    gauge   # 时间维度：read-model 落后多久
 projection_rebuild_duration_seconds{cell, projection}     histogram
-projection_event_log_length{cell, projection}             gauge
+projection_pending_events{cell, projection}              gauge   # 记录维度：未应用事件数（source head − applied checkpoint）
 ```
+
+> `projection_pending_events` 语义 = **未处理事件数 = replay 源 head 位置 − 已提交
+> checkpoint**（积压深度，record 维度，replay_lag_seconds 的记录数版本）。原名
+> `projection_event_log_length`（"日志长度"）易误读为日志总量，已按 Scenario F
+> 「确认积压来源」语义 rename。
 
 `cell` label 直接对齐 [observability.md HTTP Metrics cell Label 段](.claude/rules/gocell/observability.md) 既有约定。
 

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
@@ -491,8 +491,8 @@ Dependent contracts (governance scan): 全部 kind:projection contract.yaml (ord
 | ID | PR | 评级 | 形态 |
 |----|----|------|------|
 | PROJECTION-APPLY-HOOK-FUNNEL-01 | PR-01 stub / PR-04 green | Hard 下游 + Medium 上游 | callsite 唯一性 |
-| PROJECTION-CHECKPOINT-TX-BOUND-01 | PR-01 stub / PR-02 green | Medium | typed-param 形态 |
-| PROJECTION-STATE-PHASE-FROZEN-01 | PR-00 stub / PR-03 green | Hard | reflect 字段冻结（4 相 enum） |
+| PROJECTION-CHECKPOINT-TX-BOUND-01 | PR-01 stub / PR-02 green | Medium | ambient-tx 形态（SaveOffset 经 TxFromContext，禁裸 db.Exec） |
+| PROJECTION-STATE-PHASE-FROZEN-01 | **PR-00 green** | **Medium** | AST const-set + String-arm 锁（5 成员 enum；Go enum 不可 reflect 成集，AST/golden 锁是天花板） |
 | PROJECTION-CONSISTENCY-PARSE-TIME-01 | PR-05 | Hard 下游 | parser callsite identity |
 | **PROJECTION-CHECKPOINT-OWNER-COLUMN-V1-RESERVED-01** | **PR-02** | **Medium** | **SQL 字面量扫 reject owner 写入**（v1 范围；v1.1 启用 claim 时同 PR 删除） |
 

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-implementation-plan.md
@@ -33,7 +33,7 @@ PR-00 ADR + skeleton ─┬─> PR-01 Coordinator + mem store ────> PR-0
 | `kernel/projection/doc.go` + 包 godoc | `kernel/projection/` | ~80 |
 | `kernel/projection/types.go`（Apply / CheckpointStore / Coordinator interface 声明，**无实现**） | `kernel/projection/` | ~120 |
 | `kernel/projection/cell_marker.go`（sealed CellCheckpointStore marker，对齐 outbox.CellPublisher 范式） | `kernel/projection/` | ~60 |
-| `kernel/projection/phase.go`（rebuild state machine **4 相**枚举（Stop / Reset / Replay / Catchup，对标 Axon）+ frozen reflect 测试 placeholder） | `kernel/projection/` | ~90 |
+| `kernel/projection/phase.go`（**5 成员** Phase enum：PhaseLive + rebuild **4 相** Stop/Reset/Replay/Catchup，对标 Axon）+ PROJECTION-STATE-PHASE-FROZEN-01 AST const-set 锁（PR-00 即 green） | `kernel/projection/` | ~90 |
 | spec / plan 文档 | `docs/plans/` | 已落 |
 | backlog 登记 (#1100 评论) | gh | — |
 | **预算总计** | | ~700 行 + ADR |
@@ -43,7 +43,7 @@ PR-00 ADR + skeleton ─┬─> PR-01 Coordinator + mem store ────> PR-0
 逐项**列出选项 + 论证 + 预填决议 + 风险 + 回滚条件 + 对标框架引用**：
 
 - Q1 → A（caller-provided tx + harness 内部 SaveOffset，与 outbox.Writer 同范式；`ref:` Axon JdbcTokenStore §同 tx 提交模型）
-- Q2 → A（`apply(ctx, event, txHandle) error` —— tx handle minimum dep；`ref:` Marten Async `IDocumentOperations` 形态；明确否决 eventhorizon `Project(ctx, evt, entity) (entity, error)` 形态）
+- Q2 → A（`apply(ctx, event) error` —— **ambient tx 经 ctx，无显式 tx handle 参数**（`persistence.TxHandle` 不存在、与 `PG-REPO-AMBIENT-TX-01` 冲突，见 ADR §3 Q2 Correction）；`ref:` Marten Async `IDocumentOperations` 形态；明确否决 eventhorizon `Project(ctx, evt, entity) (entity, error)` 形态）
 - Q3 → A（单 slice 单 projection，v1 scope）
 - Q4 → A（snapshot 不入 v1；触发条件：winmdm Stage 1 rebuild 全量实测 ≥ 30min；`ref:` Axon snapshot 设计动机 vs GoCell 单 cell event 流量级差异）
 - **Q5 → A**（v1 单 pod 模式；schema 预留 `owner TEXT` 列；多 pod 并发安全由上层 leader election 保证；`ref:` Axon `token_entry.owner` 字段，v1.1 在此列上实现 pessimistic claim）
@@ -73,7 +73,7 @@ Dependent contracts (governance scan): kind:projection contract.yaml schema (PR-
 
 - [ ] ADR 文件评 owner approval（review by architect agent）
 - [ ] `go build ./...` 通过
-- [ ] meta-archtest `PROJECTION-STATE-PHASE-FROZEN-01` 预先登记 placeholder 测试（fail-pending → 等 PR-03 实现 phase struct 后转 green）
+- [ ] meta-archtest `PROJECTION-STATE-PHASE-FROZEN-01`（AST const-set + String-arm 锁，5 成员 enum）—— PR-00 即 **green**（仓库无 fail-pending 约定；enum 已在本 PR 声明，无需等 PR-03）
 - [ ] backlog #1100 评论同步 ADR 文件路径
 
 ### 风险
@@ -257,7 +257,7 @@ Invariant inventory (DROP COLUMN 不适用)
 | `runtime/projection/rebuild_handler.go`（internal HTTP endpoint `POST /internal/v1/<cell>/projection/<name>/rebuild`） | `runtime/projection/` | ~150 |
 | `runtime/projection/rebuild_handler_test.go` | `runtime/projection/` | ~200 |
 | `contracts/http/projection/rebuild/v1/`（contract.yaml + payload schema） | `contracts/` | ~80 |
-| metrics 字段冻结 archtest（PROJECTION-STATE-PHASE-FROZEN-01 转 green） | `tools/archtest/` | ~100 |
+| PROJECTION-STATE-PHASE-FROZEN-01 保持 green（PR-00 已锁 5 成员 enum；PR-03 加 rebuild transition table 不改 enum 集，无新 archtest） | `tools/archtest/` | ~0 |
 | metrics label 入 `kernel/observability/metrics.MustValidateLabels` 注册 | `kernel/observability/...` | ~50 |
 | ops doc 更新 `docs/ops/`（projection_event_replay_lag_seconds alert example） | `docs/ops/` | ~80 |
 | **预算总计** | | ~1800 行 |
@@ -299,7 +299,7 @@ func ProjectionReadyProbeName(cellID, projectionID string) (healthz.ProbeName, e
 - [ ] `POST /internal/v1/<cell>/projection/<name>/rebuild` contract test
 - [ ] metrics 三件套 fired in 集成测试
 - [ ] readyz probe 在 lag > threshold 时返回 unhealthy
-- [ ] PROJECTION-STATE-PHASE-FROZEN-01 archtest 转 green（reflect 锁 4 相 enum）
+- [ ] PROJECTION-STATE-PHASE-FROZEN-01 保持 green（PR-00 已 AST 锁 5 成员 enum；PR-03 加 rebuild transition table 不改 enum 集）
 - [ ] **rebuild 期 business read 不阻塞**——对标 Axon / Marten / Commanded 业界共识；harness 仅暴露 `Phase()` 让业务自定决策（默认不返回 503），契约文档明示
 - [ ] Stop 相 graceful 退出验证：consumer 循环退出 + checkpoint claim 释放 + 新 event Requeue 至下一启动周期
 
@@ -346,7 +346,7 @@ func (s *Service) Subscribe(ctx context.Context, coord *projection.Coordinator) 
 }
 
 // hand-written hook in service.go:
-//   func (s *Service) applyOrderCreated(ctx context.Context, evt outbox.Entry, tx persistence.TxHandle) error { ... }
+//   func (s *Service) applyOrderCreated(ctx context.Context, evt outbox.Entry) error { ... }  // tx ambient via ctx
 ```
 
 ### contractUsages slice.yaml 新字段

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md
@@ -54,7 +54,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 | replay 源 | 复用既有 outbox journal / event store，本 epic 定义 Cursor 读契约 |
 | **checkpoint / offset** | **新**：框架自有 offset 表，与业务 apply 走同一 `CellTx` 提交（exactly-once，不碰业务表 schema） |
 | **rebuild 编排** | **新**：harness 壳（reset → replay → catch-up state machine）+ business hook |
-| **可观测 metrics** | **新**：`projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_event_log_length`（covers #961） |
+| **可观测 metrics** | **新**：`projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_pending_events`（covers #961） |
 | **PROJECTION-CONSISTENCY-01 升 Hard** | **新**：parser load-time `jsonschema.Validate`（covers #960） |
 | **examples L3 reference** | orderprojection 改造为 harness 官方 reference（covers #834） |
 
@@ -131,7 +131,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 
 1. consumer 处理速度 < producer 速度，`projection_event_replay_lag_seconds` 持续升高
 2. operator dashboard 触发告警（lag > 5min for 10min）
-3. operator 查 `projection_event_log_length` 确认积压来源（vs broker 卡死）
+3. operator 查 `projection_pending_events` 确认积压来源（vs broker 卡死）
 
 ## 5. Acceptance Criteria
 
@@ -143,7 +143,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 - [ ] rebuild state machine **4 相**（Stop / Reset / Replay / Catchup，对标 Axon；见 ADR §3 Phase enum），状态对外可读（HTTP endpoint 返回 phase + lag）
 - [ ] cellgen 派生：`kind: projection` slice 自动生成 harness wiring（订阅 + Subscribe 调用 + apply 字段桥接），业务只填 apply 函数体
 - [ ] `PROJECTION-CONSISTENCY-01` 由 Medium 升 Hard：parser load-time `jsonschema.Validate` 拒绝 L0/L1/L2
-- [ ] 三个 metrics：`projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` (histogram) / `projection_event_log_length` (gauge)
+- [ ] 三个 metrics：`projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` (histogram) / `projection_pending_events` (gauge)
 - [ ] `<cell>_projection_<name>_ready` readyz probe：lag < threshold && state != reset/replay 时 ready
 - [ ] examples/todoorder/orderprojection 改造为 harness 形态，作为 L3 reference
 

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md
@@ -81,7 +81,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 | **business cell（projection consumer）** | 实现 `apply(ctx, event) error` hook（tx ambient，经 ctx；见 ADR §3 Q2），声明 `cell.yaml kind: projection` + slice contractUsages[subscribe] |
 | **harness（kernel/projection）** | 托管订阅循环 / checkpoint / rebuild 编排 / metrics |
 | **composition root (`cmd/*`)** | 通过 `WithProjectionCheckpointStore(...)` 注入 checkpoint adapter（mem / PG） |
-| **operator** | 通过 internal HTTP endpoint（`/internal/v1/.../projection/rebuild`）触发 rebuild；通过 readyz `<cell>_projection_<name>_ready` probe 监控 lag |
+| **operator** | 通过 internal HTTP endpoint（`POST /internal/v1/<cell>/projection/<name>/rebuild`，service-token + caller-cell allowlist，internal-only；契约见 ADR §5「Rebuild control-plane endpoint」）触发 rebuild；通过 readyz `<cell>_projection_<name>_ready` probe 监控 lag |
 | **AI co-author** | 写 slice handler apply 函数体；其余生命周期 wiring 由 codegen 派生 |
 
 ## 4. User Scenarios（验收场景）
@@ -140,7 +140,8 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 - [ ] `kernel/projection.Coordinator` 提供 `Subscribe(ctx, spec, projectionID, apply, opts...) error` API；apply 签名为 `func(ctx context.Context, event outbox.Entry) error`（tx ambient，经 ctx；见 ADR §3 Q1/Q2 —— 原 `persistence.TxHandle` 显式参数已被收敛，该类型不存在）
 - [ ] checkpoint store 抽象 `CheckpointStore` interface；提供 `mem` + `postgres` 两个 adapter
 - [ ] postgres adapter 的 `LoadOffset` / `SaveOffset` 在 caller-provided CellTx 内执行（exactly-once 与 business apply 同 commit）
-- [ ] rebuild state machine **4 相**（Stop / Reset / Replay / Catchup，对标 Axon；见 ADR §3 Phase enum），状态对外可读（HTTP endpoint 返回 phase + lag）
+- [ ] rebuild state machine **4 相**（Stop / Reset / Replay / Catchup，对标 Axon；见 ADR §3 Phase enum），状态对外可读（HTTP endpoint 返回 `{phase, replayLagSeconds, pendingEvents}`）
+- [ ] rebuild control-plane endpoint `POST /internal/v1/<cell>/projection/<name>/rebuild` 的安全 + HTTP 契约（service-token + caller-cell allowlist / internal-only / 202 async·409 已在 rebuild·404 未知 / `{"data":...}` envelope）—— forward contract 见 **ADR §5「Rebuild control-plane endpoint」**；完整 contract.yaml 在 PR-03（T-03-3）落地
 - [ ] cellgen 派生：`kind: projection` slice 自动生成 harness wiring（订阅 + Subscribe 调用 + apply 字段桥接），业务只填 apply 函数体
 - [ ] `PROJECTION-CONSISTENCY-01` 由 Medium 升 Hard：parser load-time `jsonschema.Validate` 拒绝 L0/L1/L2
 - [ ] 三个 metrics：`projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` (histogram) / `projection_pending_events` (gauge)
@@ -196,7 +197,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 | ID | 张力 | 选项 |
 |----|------|------|
 | Q1 | **checkpoint exactly-once 协议** | A: harness 拿 caller-provided tx 在内部 SaveOffset（**对标 Axon JdbcTokenStore**）/ B: harness 暴露 `RegisterCheckpoint(tx, offset)` 让 business 主动提交 / C: after-commit hook 异步写 offset（非 exactly-once；对标 Marten Async / Commanded） |
-| Q2 | **business apply hook 签名** | A: `apply(ctx, event, txHandle) error`（**对标 Marten Async `Apply(IDocumentOperations, e)`**）/ B: `apply(ctx, event, entity) (entity, error)` + harness read-modify-write（**对标 eventhorizon**——已明确否决）/ C: `apply(ctx, event) error` + business 自管 tx（**对标 Watermill**）/ D: 注解驱动（对标 Axon `@EventHandler`，Go 不适用） |
+| Q2 | **business apply hook 签名** | A: ~~`apply(ctx, event, txHandle) error`~~ **→ 已收敛冻结为 `apply(ctx, event) error`（ambient tx 经 ctx；`txHandle` 类型不存在、与 `PG-REPO-AMBIENT-TX-01` 冲突，见 ADR §3 Q2 Correction）**（对标 Marten Async `Apply(IDocumentOperations, e)`）/ B: `apply(ctx, event, entity) (entity, error)` + harness read-modify-write（**对标 eventhorizon**——已明确否决）/ C: `apply(ctx, event) error` + business 自管 tx（**对标 Watermill**）/ D: 注解驱动（对标 Axon `@EventHandler`，Go 不适用） |
 | Q3 | **kind:projection codegen funnel 接法** | A: 单 slice 单 projection（subscribe 集合 = 单 projection 输入流）/ B: 多 slice 共享 projection（需新 metadata 节点） |
 | Q4 | **snapshot / 部分 replay 是否 v1** | A: v1 不做（rebuild 全量）/ B: v1 留 hook 但无 PG store / C: v1 完整支持 |
 | **Q5** | **多 pod 并发同一 projection 是否支持**（对标 Axon `token_entry.owner` 列） | A: v1 单 pod（leader election 走上层 `cmd/corebundle`，schema 预留 `owner` 列但不写）/ B: v1 内置 pessimistic claim（owner 列 + advisory lock） |
@@ -204,7 +205,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 **预填倾向**（待 ADR 论证后定）：Q1=A、Q2=A、Q3=A、Q4=A、**Q5=A**。理由（对标增强）：
 
 - **Q1=A**：与 outbox `Writer.Write` 同 pattern（caller 用 RunInTx 包，writer 内部用 TxFromContext join），AI-robust 形态一致；**对标 Axon JdbcTokenStore + 同 tx 提交模式**——业界最严谨的 exactly-once 实现。
-- **Q2=A**：tx handle 是最小依赖，不绑死读模型 schema / entity 类型；**直接对标 Marten Async `IDocumentOperations` 形态**。eventhorizon 的 entity read-modify-write（形态 B）已明确否决——GoCell L3 投影常需跨表写，单 entity 模型锁死业务。
+- **Q2=A**：ambient ctx-tx 是最小依赖（**无显式 tx handle 参数**——与 `outbox.Writer.Write` 同范式，hook 内经 `persistence.TxFromContext` 取 tx），不绑死读模型 schema / entity 类型；**对标 Marten Async `IDocumentOperations` 形态**。eventhorizon 的 entity read-modify-write（形态 B）已明确否决——GoCell L3 投影常需跨表写，单 entity 模型锁死业务。
 - **Q3=A**：单输入流单 projection 覆盖 winmdm `unified_device_id` / zerotrust `trustscore` 二条 roadmap-committed 场景；多 slice 多入是 v1.1 扩展点。
 - **Q4=A**：snapshot 的 PG 表抽象会越过 GAP-8 封存边界；v1 故意留白；**对标论证更扎实**——Axon 引入 snapshot 是因为 event log 全局共享 + replay 量级 ≥ 数百万条，GoCell outbox 是单 cell 局部事件流，全量重放量级远小于此。触发条件：winmdm Stage 1 实测 rebuild 全量 ≥ 30min 时新 epic 紧急加。
 - **Q5=A**：v1 单 pod 模式 complexity 最低；schema 预留 `owner TEXT` 列（对标 Axon `token_entry.owner`），v1 不写不读；多 pod 安全由上层 leader election 保证（`cmd/corebundle` 责任）；v1.1 在 owner 列上实现 pessimistic claim 即可。
@@ -223,6 +224,6 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 | #1079 [H2/W10] Projection / Replay runtime | PR-00 + PR-01 + PR-02 + PR-04（主体） |
 | #834 [L3-EXAMPLE-PROJECTION-01] | PR-06（orderprojection 改造为 reference） |
 | #960 PROJECTION-CONSISTENCY-01 升 Hard | PR-05（独立先行候选） |
-| #961 L3 投影可观测 metrics | PR-04（与 rebuild 编排同包） |
+| #961 L3 投影可观测 metrics | PR-03（rebuild + metrics + readyz 三件套同包） |
 
 Q&A、风险、PR 切分细节见 [implementation plan](./202605261600-1100-cqrs-projection-harness-implementation-plan.md)。

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-spec.md
@@ -78,10 +78,10 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 
 | Actor | 角色 |
 |-------|------|
-| **business cell（projection consumer）** | 实现 `apply(ctx, event, txHandle) error` hook，声明 `cell.yaml kind: projection` + slice contractUsages[subscribe] |
+| **business cell（projection consumer）** | 实现 `apply(ctx, event) error` hook（tx ambient，经 ctx；见 ADR §3 Q2），声明 `cell.yaml kind: projection` + slice contractUsages[subscribe] |
 | **harness（kernel/projection）** | 托管订阅循环 / checkpoint / rebuild 编排 / metrics |
 | **composition root (`cmd/*`)** | 通过 `WithProjectionCheckpointStore(...)` 注入 checkpoint adapter（mem / PG） |
-| **operator** | 通过 internal HTTP endpoint（`/internal/v1/.../projection/rebuild`）触发 rebuild；通过 readyz `<cell>_projection_ready` probe 监控 lag |
+| **operator** | 通过 internal HTTP endpoint（`/internal/v1/.../projection/rebuild`）触发 rebuild；通过 readyz `<cell>_projection_<name>_ready` probe 监控 lag |
 | **AI co-author** | 写 slice handler apply 函数体；其余生命周期 wiring 由 codegen 派生 |
 
 ## 4. User Scenarios（验收场景）
@@ -92,10 +92,10 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 2. cellgen 派生 harness wiring：订阅、checkpoint 读取、apply hook 调用
 3. 启动时 checkpoint 表无该 projection 行 → harness 视作 offset = 0
 4. 从 offset = 0 开始消费事件流，每条事件在一个 CellTx 内：
-   - 调用 business `apply(ctx, event, txHandle)`
-   - harness 更新 checkpoint 行 `offset = event.seq`
+   - 调用 business `apply(ctx, event)`（tx ambient，经 ctx）
+   - harness 更新 checkpoint 行（offset = replay-cursor 位置；outbox.Entry 无 seq 字段）
    - tx commit / rollback 决定 apply + checkpoint 是否同时生效
-5. 启动 60s 内 lag 收敛到 0，`<cell>_projection_ready` probe 转 ready
+5. 启动 60s 内 lag 收敛到 0，`<cell>_projection_<name>_ready` probe 转 ready
 
 ### Scenario B — Crash recovery
 
@@ -109,7 +109,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 2. operator 调用 `POST /internal/v1/<cell>/projection/<name>/rebuild`
 3. harness 执行 state machine（**对标 Axon 4 相**）：
    - **Stop**：停止消费循环，释放 checkpoint claim（防止并发写 checkpoint 表）
-   - **Reset**：调用 business `OnReset(ctx, txHandle)` hook（对标 Axon `@ResetHandler`；业务 TRUNCATE/DROP 自己的 read-model 表）+ harness 重置 checkpoint 行 offset = 0（同一 CellTx）
+   - **Reset**：调用 business `OnReset(ctx) error` hook（tx ambient，经 ctx；对标 Axon `@ResetHandler`；业务 TRUNCATE/DROP 自己的 read-model 表）+ harness 重置 checkpoint 行 offset = 0（同一 CellTx）
    - **Replay**：从 offset = 0 起遍历事件流，每条事件一个 CellTx（apply + checkpoint），可观测 `projection_rebuild_duration_seconds`
    - **Catch-up**：replay 追上"开始 rebuild 时的 head offset"后 transition 到 catch-up 模式，继续消费新事件
 4. **rebuild 期业务 read 不阻塞**（对标 Axon / Marten / Commanded 业界共识）—— stale read 是业务侧责任；业务可显式在 read 路径检查 `harness.Phase()` 返回 503 但 harness 不强加；
@@ -137,10 +137,10 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 
 ### 5.1 Functional
 
-- [ ] `kernel/projection.Coordinator` 提供 `Subscribe(ctx, spec, apply, opts...) error` API；apply 签名为 `func(ctx context.Context, event outbox.Entry, tx persistence.TxHandle) error`
+- [ ] `kernel/projection.Coordinator` 提供 `Subscribe(ctx, spec, projectionID, apply, opts...) error` API；apply 签名为 `func(ctx context.Context, event outbox.Entry) error`（tx ambient，经 ctx；见 ADR §3 Q1/Q2 —— 原 `persistence.TxHandle` 显式参数已被收敛，该类型不存在）
 - [ ] checkpoint store 抽象 `CheckpointStore` interface；提供 `mem` + `postgres` 两个 adapter
 - [ ] postgres adapter 的 `LoadOffset` / `SaveOffset` 在 caller-provided CellTx 内执行（exactly-once 与 business apply 同 commit）
-- [ ] rebuild state machine 三相（reset / replay / catch-up），状态对外可读（HTTP endpoint 返回 phase + lag）
+- [ ] rebuild state machine **4 相**（Stop / Reset / Replay / Catchup，对标 Axon；见 ADR §3 Phase enum），状态对外可读（HTTP endpoint 返回 phase + lag）
 - [ ] cellgen 派生：`kind: projection` slice 自动生成 harness wiring（订阅 + Subscribe 调用 + apply 字段桥接），业务只填 apply 函数体
 - [ ] `PROJECTION-CONSISTENCY-01` 由 Medium 升 Hard：parser load-time `jsonschema.Validate` 拒绝 L0/L1/L2
 - [ ] 三个 metrics：`projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` (histogram) / `projection_event_log_length` (gauge)
@@ -151,7 +151,7 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 
 - [ ] 单 cell 单 projection cold-start 60s 内 lag 收敛到 0（10k events / s 假设）
 - [ ] crash recovery 启动后第一个 tx 即从 checkpoint 恢复，无重放窗口
-- [ ] rebuild 期间业务 read endpoint 必须 503，不返回部分数据
+- [ ] rebuild 期间业务 read endpoint **不被 harness 强制 503**（非阻塞设计，业界共识；见 ADR §5）；业务可自查 `Phase()` 自行返回 503
 - [ ] kernel/projection ≥ 90% test coverage（kernel 层标准）
 
 ### 5.3 Governance / archtest
@@ -159,8 +159,8 @@ GoCell L3 投影场景当前**手撕**（`examples/todoorder/cells/ordercell/int
 - [ ] `PROJECTION-CONSISTENCY-01` 升 Hard 的 archtest 守卫（schema enum 在 parse 路径强制）
 - [ ] **新增 archtest funnel（≥ Medium，AI-robust 章程要求）**：
   - **PROJECTION-APPLY-HOOK-FUNNEL-01**：cellgen 派生的 harness wiring 是 business apply 函数唯一注册路径；手写 `Coordinator.Subscribe(..., apply, ...)` callsite 仅允许在 generated 文件
-  - **PROJECTION-CHECKPOINT-TX-BOUND-01**：`SaveOffset` 必须在 caller-provided `persistence.TxHandle` 内调用；裸 `db.Exec` 形态 fail
-  - **PROJECTION-STATE-PHASE-FROZEN-01**：rebuild state machine 三相枚举 reflect 字段冻结
+  - **PROJECTION-CHECKPOINT-TX-BOUND-01**：`SaveOffset` 实现必须经 `persistence.TxFromContext(ctx)` 取 ambient tx；裸 `*sql.Tx` 参数 / `db.Exec` 形态 fail（与 outbox.Writer 同范式）
+  - **PROJECTION-STATE-PHASE-FROZEN-01**：Phase enum const 集冻结（5 成员 PhaseLive/Stopped/Reset/Replay/Catchup，AST 锁；PR-00 已 green）
 - [ ] cellgen scaffold golden 更新（新增 `kind: projection` 派生模板）
 - [ ] L2-OUTBOX-ATOMICITY-COVERAGE-01 不变（projection 仍是 L3 consumer，与 L2 producer 测试体系正交）
 

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-tasks.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-tasks.md
@@ -255,7 +255,7 @@
 - **依赖**：T-06-1
 - **验收**：
   - [ ] crash recovery：杀进程 → 重启 → 第一个 tx 即从 checkpoint 恢复
-  - [ ] rebuild：POST /internal endpoint 触发 → 业务 read 503 → catch-up 完成后恢复
+  - [ ] rebuild：POST /internal endpoint 触发 → 业务 read **不阻塞**（harness 不强制 503，对标 Axon / Marten；业务可自查 `Phase()` 自行返回 503）→ catch-up 完成后继续消费（见 ADR §5）
 - **行数**：~400
 
 ### T-06-3 closeout + backlog 关闭

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-tasks.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-tasks.md
@@ -134,7 +134,7 @@
 
 ### T-03-2 Metrics 三件套
 
-- **what**：`metrics.go` 注册 `projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_event_log_length`
+- **what**：`metrics.go` 注册 `projection_event_replay_lag_seconds` / `projection_rebuild_duration_seconds` / `projection_pending_events`
 - **ship**：L2
 - **依赖**：T-03-1
 - **验收**：

--- a/docs/plans/specs/202605261600-1100-cqrs-projection-harness-tasks.md
+++ b/docs/plans/specs/202605261600-1100-cqrs-projection-harness-tasks.md
@@ -38,7 +38,7 @@
 - **验收**：
   - [ ] `go build ./kernel/projection/...` 通过
   - [ ] 包 godoc 引用 ADR 文件路径
-  - [ ] PROJECTION-STATE-PHASE-FROZEN-01 archtest stub 登记（pending，等 PR-03 phase struct 实现）
+  - [ ] PROJECTION-STATE-PHASE-FROZEN-01 archtest 登记并 **green**（AST const-set + String-arm 锁，5 成员 Phase enum；enum 在本 PR 声明，PR-00 即 green，非 pending）
 - **行数**：~340
 - **关键命令**：`make verify` 跑 archtest 全集（pending test 跳过）
 
@@ -127,7 +127,7 @@
 - **依赖**：PR-01 merged
 - **验收**：
   - [ ] **4 相 + 10+ transitions** 完整测试（含错误回退 / Stop 阶段 graceful 退出 / claim 释放）
-  - [ ] PROJECTION-STATE-PHASE-FROZEN-01 archtest 转 green（reflect 锁 4 相 phase enum 字段集）
+  - [ ] PROJECTION-STATE-PHASE-FROZEN-01 保持 green（PR-00 已 AST 锁 5 成员 Phase enum const 集；PR-03 加 rebuild transition table 不改 enum 集）
   - [ ] **harness 默认不阻塞 business read**（对标 Axon / Marten 业界共识）；暴露 `Phase() Phase` 方法供业务自选 503
   - [ ] `OnReset` hook 签名通过 ADR §对标 Axon `@ResetHandler` 论证
 - **行数**：~720

--- a/kernel/projection/cell_marker.go
+++ b/kernel/projection/cell_marker.go
@@ -1,0 +1,68 @@
+package projection
+
+import "github.com/ghbvf/gocell/pkg/validation"
+
+// CellCheckpointStore is the only CheckpointStore-shaped type that a cell's
+// public With* Options may accept. The unexported sealedCellCheckpointStore()
+// method makes it unimplementable outside kernel/projection — this package is
+// the sole entry point via WrapCheckpointStoreForCell, which composition roots
+// (cmd/*) call. This mirrors outbox.CellPublisher / persistence.CellTxManager.
+//
+// AI-robust 评级：
+//   - 字段/赋值层：Hard（sealed marker，外部不可表达 internalCellCheckpointStore 字面量）
+//   - 公开 With* Option 签名层：Medium（CELL-RAW-INFRA-PUBLIC-OPTION-PARAM-01 在
+//     PR-04 cell 接入投影时按需扩 rawPublicOptionForbidden；PR-00 无 cell option）
+//
+// CellCheckpointStore embeds CheckpointStore so cells can pass the wrapped value
+// directly wherever a CheckpointStore is expected — the embedded interface
+// satisfies those sites transparently, so internal harness API does not change.
+//
+// ref: docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md §D1
+// ref: kernel/outbox/cell_marker.go (CellPublisher precedent).
+type CellCheckpointStore interface {
+	CheckpointStore
+	// MARKER: do not implement; this is the sealing marker — call
+	// projection.WrapCheckpointStoreForCell(...) from your composition root instead.
+	sealedCellCheckpointStore()
+}
+
+// internalCellCheckpointStore is the only implementation of CellCheckpointStore.
+type internalCellCheckpointStore struct {
+	CheckpointStore
+}
+
+func (internalCellCheckpointStore) sealedCellCheckpointStore() {}
+
+// Noop transparently delegates to the wrapped CheckpointStore's Nooper interface
+// when present. Required by SEALED-MARKER-NOOP-TRANSPARENCY-01 (every kernel
+// internalCell* sealed marker must forward Noop) so a demo/in-memory checkpoint
+// store's noop signal is not hidden from durable-mode rejection. The interface
+// is matched structurally — kernel/projection does not import kernel/cell.
+func (i internalCellCheckpointStore) Noop() bool {
+	type nooper interface{ Noop() bool }
+	if n, ok := i.CheckpointStore.(nooper); ok {
+		return n.Noop()
+	}
+	return false
+}
+
+// WrapCheckpointStoreForCell is the sole authorized path for handing a
+// CheckpointStore to a cell's With* Option. Returns nil when s is bare-nil OR a
+// typed-nil interface (e.g. `var s *postgres.ProjectionCheckpointStore`) so
+// caller-side typed-nil detection in builder options keeps working — without
+// IsNilInterface the wrapper would emit a non-nil sealed value hiding the inner
+// nil, silently bypassing Init() fail-fast guards. Mirror of
+// outbox.WrapPublisherForCell.
+//
+// Allowed callers (enforced by archtest CELL-RAW-INFRA-WRAPPER-LOCATION-01 once
+// PR-02/PR-04 wire real callers):
+//   - cmd/* composition roots
+//   - examples/<demo>/main.go, examples/<demo>/app.go, examples/<demo>/run.go
+//   - *_test.go in any layer
+//   - kernel/projection/cell_marker.go (this file)
+func WrapCheckpointStoreForCell(s CheckpointStore) CellCheckpointStore {
+	if validation.IsNilInterface(s) {
+		return nil
+	}
+	return internalCellCheckpointStore{CheckpointStore: s}
+}

--- a/kernel/projection/contract_test.go
+++ b/kernel/projection/contract_test.go
@@ -1,0 +1,171 @@
+package projection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// This file is the PR-00 "implementability proof" for the projection lifecycle
+// harness ADR (docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md).
+//
+// PR-00 ships interface declarations only — the Coordinator + behavioral
+// guarantees (exactly-once / crash recovery) land in PR-01..PR-06. To prove the
+// ADR's frozen contracts are not vapor, this test:
+//
+//   - implements CheckpointStore with a fake (proves the interface is
+//     implementable against the ambient-tx signature),
+//   - binds a function to Apply (proves the hook shape is usable),
+//   - wraps the fake through WrapCheckpointStoreForCell and asserts the sealed
+//     marker behaves (non-nil + typed-nil rejection + Noop pass-through),
+//   - exercises Phase.String()/Valid() across the full enum.
+
+// fakeCheckpointStore proves CheckpointStore is implementable with the
+// ambient-tx signature (ctx-only; a real adapter pulls the tx via
+// persistence.TxFromContext inside Save/Load — same shape as outbox.Writer).
+type fakeCheckpointStore struct {
+	offsets map[string]int64
+	noop    bool
+}
+
+func newFakeCheckpointStore() *fakeCheckpointStore {
+	return &fakeCheckpointStore{offsets: map[string]int64{}}
+}
+
+func key(cellID, projectionID string) string { return cellID + "/" + projectionID }
+
+func (f *fakeCheckpointStore) LoadOffset(_ context.Context, cellID, projectionID string) (int64, error) {
+	return f.offsets[key(cellID, projectionID)], nil
+}
+
+func (f *fakeCheckpointStore) SaveOffset(_ context.Context, cellID, projectionID string, offset int64) error {
+	f.offsets[key(cellID, projectionID)] = offset
+	return nil
+}
+
+func (f *fakeCheckpointStore) Noop() bool { return f.noop }
+
+// Compile-time proof the fake satisfies the interface.
+var _ CheckpointStore = (*fakeCheckpointStore)(nil)
+
+// sampleApply proves the Apply function type is usable for a real hook shape.
+func sampleApply(_ context.Context, _ outbox.Entry) error { return nil }
+
+var _ Apply = sampleApply
+
+// Option must be expressible as a functional option closure.
+var _ Option = func(*subscribeOptions) {}
+
+func TestCheckpointStoreImplementable(t *testing.T) {
+	t.Parallel()
+	var s CheckpointStore = newFakeCheckpointStore()
+	ctx := context.Background()
+	if err := s.SaveOffset(ctx, "ordercell", "ordersummary", 7); err != nil {
+		t.Fatalf("SaveOffset: %v", err)
+	}
+	got, err := s.LoadOffset(ctx, "ordercell", "ordersummary")
+	if err != nil {
+		t.Fatalf("LoadOffset: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("LoadOffset = %d, want 7", got)
+	}
+}
+
+func TestWrapCheckpointStoreForCell_Seals(t *testing.T) {
+	t.Parallel()
+	inner := newFakeCheckpointStore()
+	wrapped := WrapCheckpointStoreForCell(inner)
+	if wrapped == nil {
+		t.Fatal("WrapCheckpointStoreForCell returned nil for a real store")
+	}
+	// The sealed marker still satisfies the base interface transparently.
+	var _ CheckpointStore = wrapped
+	if err := wrapped.SaveOffset(context.Background(), "c", "p", 1); err != nil {
+		t.Fatalf("wrapped SaveOffset: %v", err)
+	}
+}
+
+func TestWrapCheckpointStoreForCell_NilInputs(t *testing.T) {
+	t.Parallel()
+	// bare-nil interface
+	if got := WrapCheckpointStoreForCell(nil); got != nil {
+		t.Errorf("WrapCheckpointStoreForCell(nil) = %v, want nil", got)
+	}
+	// typed-nil interface (e.g. var s *fakeCheckpointStore) must also map to nil
+	var typedNil *fakeCheckpointStore
+	if got := WrapCheckpointStoreForCell(typedNil); got != nil {
+		t.Errorf("WrapCheckpointStoreForCell(typed-nil) = %v, want nil "+
+			"(typed-nil detection keeps Init() fail-fast guards working)", got)
+	}
+}
+
+func TestWrapCheckpointStoreForCell_NoopPassThrough(t *testing.T) {
+	t.Parallel()
+	// Inner reports noop=true → wrapper must forward it (durable-mode rejection
+	// depends on this; mirror of kernel/outbox cell_marker_test).
+	nooper := &fakeCheckpointStore{offsets: map[string]int64{}, noop: true}
+	wrapped := WrapCheckpointStoreForCell(nooper)
+	n, ok := wrapped.(interface{ Noop() bool })
+	if !ok {
+		t.Fatal("sealed CellCheckpointStore does not expose Noop() bool")
+	}
+	if !n.Noop() {
+		t.Error("Noop() = false, want true (pass-through from inner)")
+	}
+}
+
+func TestWrapCheckpointStoreForCell_NonNooperReturnsFalse(t *testing.T) {
+	t.Parallel()
+	// A store that does not implement Nooper → wrapper reports false.
+	wrapped := WrapCheckpointStoreForCell(nonNooperStore{})
+	n, ok := wrapped.(interface{ Noop() bool })
+	if !ok {
+		t.Fatal("sealed CellCheckpointStore does not expose Noop() bool")
+	}
+	if n.Noop() {
+		t.Error("Noop() = true, want false (inner is not a Nooper)")
+	}
+}
+
+// nonNooperStore implements CheckpointStore but NOT Nooper.
+type nonNooperStore struct{}
+
+func (nonNooperStore) LoadOffset(context.Context, string, string) (int64, error) { return 0, nil }
+func (nonNooperStore) SaveOffset(context.Context, string, string, int64) error   { return nil }
+
+func TestPhaseStringAndValid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		p     Phase
+		str   string
+		valid bool
+	}{
+		{PhaseLive, "live", true},
+		{PhaseStopped, "stopped", true},
+		{PhaseReset, "reset", true},
+		{PhaseReplay, "replay", true},
+		{PhaseCatchup, "catchup", true},
+		{Phase(0), "invalid", false},
+		{Phase(99), "phase(99)", false},
+	}
+	for _, c := range cases {
+		if got := c.p.String(); got != c.str {
+			t.Errorf("Phase(%d).String() = %q, want %q", c.p, got, c.str)
+		}
+		if got := c.p.Valid(); got != c.valid {
+			t.Errorf("Phase(%d).Valid() = %v, want %v", c.p, got, c.valid)
+		}
+	}
+}
+
+func TestPhaseZeroValueIsInvalid(t *testing.T) {
+	t.Parallel()
+	// iota+1 ensures the zero value is never a valid phase, so an
+	// uninitialised Phase cannot masquerade as PhaseLive.
+	var zero Phase
+	if zero.Valid() {
+		t.Error("zero-value Phase reported Valid() = true; iota+1 must make 0 invalid")
+	}
+}

--- a/kernel/projection/contract_test.go
+++ b/kernel/projection/contract_test.go
@@ -61,6 +61,11 @@ func TestCheckpointStoreImplementable(t *testing.T) {
 	t.Parallel()
 	var s CheckpointStore = newFakeCheckpointStore()
 	ctx := context.Background()
+	// Cold start: an unknown (cellID, projectionID) pair must load offset 0 with
+	// no error — the base case the harness relies on (ADR §6 threat row 1).
+	if got, err := s.LoadOffset(ctx, "ordercell", "never-seen"); err != nil || got != 0 {
+		t.Fatalf("cold-start LoadOffset = (%d, %v), want (0, nil)", got, err)
+	}
 	if err := s.SaveOffset(ctx, "ordercell", "ordersummary", 7); err != nil {
 		t.Fatalf("SaveOffset: %v", err)
 	}

--- a/kernel/projection/doc.go
+++ b/kernel/projection/doc.go
@@ -44,6 +44,16 @@
 // checkpoint SaveOffset commit in one transaction (exactly-once). Decided in
 // ADR §3 Q1/Q2 against an explicit tx-handle parameter.
 //
+// # v1 operational boundaries
+//
+//   - Single-pod only. v1 has no distributed claim: running two pods that
+//     consume the same projection without external leader election is UNSAFE —
+//     both advance the same checkpoint and double-apply. Multi-pod safety is the
+//     upper layer's responsibility (cmd/* leader election). The PG checkpoint
+//     schema reserves an `owner` column (ref: Axon token_entry.owner) for a v1.1
+//     pessimistic claim, but v1 never reads or writes it. See ADR §3 Q5.
+//   - Full rebuild only — no snapshot / partial replay in v1 (ADR §3 Q4).
+//
 // # Governance (lands across the epic; see each archtest godoc for ratings)
 //
 //   - PROJECTION-STATE-PHASE-FROZEN-01 — freezes the Phase enum membership

--- a/kernel/projection/doc.go
+++ b/kernel/projection/doc.go
@@ -1,0 +1,60 @@
+// Package projection declares the kernel-level contracts for the CQRS
+// projection lifecycle harness: the business event→state Apply hook, the
+// CheckpointStore offset abstraction, the CellCheckpointStore sealed marker,
+// the functional Option seam, and the rebuild-lifecycle Phase enum.
+//
+// # Scope
+//
+// L3 (WorkflowEventual): a projection consumes a cell's event stream and
+// maintains a derived read-model. The harness owns the mechanical parts —
+// checkpoint/offset persistence, exactly-once delivery to Apply, rebuild
+// orchestration, metrics, readyz — so business cells only write the Apply
+// function body and (optionally) an OnReset hook. The read-model schema and the
+// Apply body itself stay business-owned (GAP-8 seal; see ADR §4).
+//
+// # PR-00 boundary (this package, today)
+//
+// This package currently declares contracts only — there is NO Coordinator
+// implementation or consume loop here yet. The decisions these declarations
+// freeze are the subject of the ADR; the implementations land across the epic:
+//
+//   - PR-01: Coordinator + Subscribe + consume loop + checkpoint write
+//     (kernel/projection/coordinator.go); mem CheckpointStore + conformance.
+//   - PR-02: postgres CheckpointStore adapter (adapters/postgres).
+//   - PR-03: rebuild state machine (consumes Phase) + metrics + readyz.
+//   - PR-04: cellgen kind:projection derivation (the only sanctioned Subscribe
+//     callsite).
+//
+// Subscribe's frozen forward signature (implemented in PR-01):
+//
+//	func (c *Coordinator) Subscribe(
+//		ctx context.Context,
+//		spec contractspec.ContractSpec,
+//		projectionID string,
+//		apply Apply,
+//		opts ...Option,
+//	) error
+//
+// # Ambient transaction model
+//
+// Apply and CheckpointStore take ctx only and obtain the transaction ambiently
+// via persistence.TxFromContext — the established GoCell idiom (mirrors
+// outbox.Writer.Write and is enforced by PG-REPO-AMBIENT-TX-01). The Coordinator
+// wraps each event in persistence.TxRunner.RunInTx so the Apply mutation and the
+// checkpoint SaveOffset commit in one transaction (exactly-once). Decided in
+// ADR §3 Q1/Q2 against an explicit tx-handle parameter.
+//
+// # Governance (lands across the epic; see each archtest godoc for ratings)
+//
+//   - PROJECTION-STATE-PHASE-FROZEN-01 — freezes the Phase enum membership
+//     (green from PR-00).
+//   - PROJECTION-APPLY-HOOK-FUNNEL-01 — Subscribe is callable only from
+//     cellgen-derived wiring (PR-01 stub → PR-04 green).
+//   - PROJECTION-CHECKPOINT-TX-BOUND-01 — SaveOffset must use the ambient tx,
+//     no raw db handle (PR-01 stub → PR-02 green).
+//
+// ref: docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+// ref: AxonFramework TokenStore / @ResetHandler — checkpoint-in-tx + 4-phase rebuild.
+// ref: JasperFx/marten async-daemon — IDocumentOperations apply shape.
+// ref: ThreeDotsLabs/watermill components/cqrs — EventProcessor baseline.
+package projection

--- a/kernel/projection/phase.go
+++ b/kernel/projection/phase.go
@@ -16,6 +16,11 @@ import "fmt"
 // it. PhaseLive means the read-model is fresh and serving; any other phase means
 // a rebuild is in progress. See ADR §5.
 //
+// Phase() is a best-effort point-in-time snapshot, not a freshness lock: a read
+// path that observes PhaseLive and then queries the read-model has no atomic
+// ordering against a rebuild starting between the two calls. Business code
+// requiring strict freshness must maintain its own read quiescence.
+//
 // # Frozen membership
 //
 // The const set is frozen by archtest PROJECTION-STATE-PHASE-FROZEN-01 (the

--- a/kernel/projection/phase.go
+++ b/kernel/projection/phase.go
@@ -1,0 +1,76 @@
+package projection
+
+import "fmt"
+
+// Phase is the lifecycle state of a projection, exposed by the Coordinator
+// (PR-03) so operators (readyz / metrics) and business read paths can observe
+// where a projection is. The four rebuild phases mirror Axon's processor
+// lifecycle (Stop → Reset → Replay → Catch-up); PhaseLive is the steady-state
+// value outside a rebuild.
+//
+// # Business read-503 opt-in
+//
+// rebuild does NOT block business reads by default — stale reads during rebuild
+// are the industry consensus (Axon / Marten / Commanded). A business read path
+// MAY consult Phase() and return 503 of its own accord; the harness never forces
+// it. PhaseLive means the read-model is fresh and serving; any other phase means
+// a rebuild is in progress. See ADR §5.
+//
+// # Frozen membership
+//
+// The const set is frozen by archtest PROJECTION-STATE-PHASE-FROZEN-01 (the
+// operational contract for readyz/metrics/503 must not drift silently). The
+// rebuild state machine + transition table that drive these phases land in
+// PR-03.
+//
+// ref: kernel/outbox/state.go (enum + String pattern).
+// ref: AxonFramework EventProcessor lifecycle (Stop/Reset/Replay/Catch-up).
+type Phase uint8
+
+const (
+	// PhaseLive: steady-state consuming, read-model fresh and serving.
+	//
+	// IMPORTANT: iota+1 makes the zero value (0) an invalid Phase, so a
+	// forgotten/uninitialised Phase cannot silently appear as PhaseLive.
+	PhaseLive Phase = iota + 1 // = 1
+	// PhaseStopped: rebuild step 1 — consume loop halted, checkpoint claim
+	// released so the reset/replay can rewrite the offset row safely.
+	PhaseStopped
+	// PhaseReset: rebuild step 2 — business OnReset hook (TRUNCATE/DROP its
+	// read-model) + harness resets the checkpoint offset to 0, one CellTx.
+	PhaseReset
+	// PhaseReplay: rebuild step 3 — replaying the event stream from offset 0,
+	// each event in its own CellTx (Apply + checkpoint).
+	PhaseReplay
+	// PhaseCatchup: rebuild step 4 — replay reached the head offset captured at
+	// rebuild start; now consuming newly arriving events until caught up, then
+	// transition back to PhaseLive.
+	PhaseCatchup
+)
+
+// Valid reports whether p is a recognized Phase value.
+func (p Phase) Valid() bool {
+	return p >= PhaseLive && p <= PhaseCatchup
+}
+
+// String returns the canonical wire/log label for p. This is the sole producer
+// of the phase label used in metrics/readyz; the literals are frozen by
+// PROJECTION-STATE-PHASE-FROZEN-01.
+func (p Phase) String() string {
+	switch p {
+	case 0:
+		return "invalid"
+	case PhaseLive:
+		return "live"
+	case PhaseStopped:
+		return "stopped"
+	case PhaseReset:
+		return "reset"
+	case PhaseReplay:
+		return "replay"
+	case PhaseCatchup:
+		return "catchup"
+	default:
+		return fmt.Sprintf("phase(%d)", uint8(p))
+	}
+}

--- a/kernel/projection/types.go
+++ b/kernel/projection/types.go
@@ -14,9 +14,11 @@ import (
 // delivery; the harness never calls Apply twice for the same offset).
 //
 // Apply MUST NOT open its own transaction or connection. A transient failure
-// returns a plain error (the Coordinator requeues); a permanent failure returns
-// an errcode permanent error (the Coordinator rejects to the DLX). Decided in
-// ADR §3 Q2 against the eventhorizon read-modify-write entity shape and the
+// returns a plain error (the Coordinator requeues). A permanent failure returns
+// an error wrapping outbox.NewPermanentError(err); the Coordinator classifies it
+// as DispositionReject and routes to the DLX — the same vocabulary as the
+// ConsumerBase handler convention (see .claude/rules/gocell/eventbus.md). Decided
+// in ADR §3 Q2 against the eventhorizon read-modify-write entity shape and the
 // explicit tx-handle parameter.
 //
 // ref: JasperFx/marten async-daemon IDocumentOperations apply shape.
@@ -26,11 +28,17 @@ type Apply func(ctx context.Context, event outbox.Entry) error
 // own offset table — it does NOT touch any business read-model schema (the
 // CellTx-offset design keeps the harness clear of the GAP-8 seal; ADR §4).
 //
+// The offset is an opaque, monotonically increasing cursor over the projection's
+// input stream. Its concrete mapping to a stream position is owned by the replay
+// source defined in PR-01 (the harness compares a replayed event's position
+// against the stored checkpoint to skip already-applied events) — it is NOT an
+// outbox.Entry field (Entry carries no sequence number today). LoadOffset returns
+// 0 for an unknown (cellID, projectionID) pair (cold start = offset 0).
+//
 // Both methods are ambient-tx: SaveOffset participates in the caller's
 // transaction via persistence.TxFromContext(ctx) (no raw db handle — enforced by
 // PROJECTION-CHECKPOINT-TX-BOUND-01), so the offset advance commits together
-// with the Apply mutation. LoadOffset returns 0 for an unknown
-// (cellID, projectionID) pair (cold start = offset 0).
+// with the Apply mutation.
 //
 // Implementations: mem (PR-01) + postgres (PR-02); both verified by the shared
 // projectiontest.RunCheckpointConformance template (PR-01). Decided in ADR §3
@@ -50,6 +58,9 @@ type CheckpointStore interface {
 // (e.g. starting offset, fail-open policy) are added alongside the Coordinator.
 // Declared here so the Subscribe API surface is fixed by the ADR rather than
 // drifting when the implementation lands.
+//
+// In v1 no option constructors exist yet — passing no opts (an empty or nil
+// slice) is valid and is the expected call form for the initial release.
 type Option func(*subscribeOptions)
 
 // subscribeOptions holds the resolved Subscribe configuration. It is the target

--- a/kernel/projection/types.go
+++ b/kernel/projection/types.go
@@ -1,0 +1,57 @@
+package projection
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// Apply is the business event→state projection hook: given a consumed event,
+// mutate the read-model. The transaction is ambient — Apply obtains it via
+// persistence.TxFromContext(ctx) exactly like outbox.Writer.Write, because the
+// Coordinator (PR-01) invokes Apply inside persistence.TxRunner.RunInTx so the
+// read-model mutation and the checkpoint advance commit atomically (exactly-once
+// delivery; the harness never calls Apply twice for the same offset).
+//
+// Apply MUST NOT open its own transaction or connection. A transient failure
+// returns a plain error (the Coordinator requeues); a permanent failure returns
+// an errcode permanent error (the Coordinator rejects to the DLX). Decided in
+// ADR §3 Q2 against the eventhorizon read-modify-write entity shape and the
+// explicit tx-handle parameter.
+//
+// ref: JasperFx/marten async-daemon IDocumentOperations apply shape.
+type Apply func(ctx context.Context, event outbox.Entry) error
+
+// CheckpointStore persists a projection's consumed offset. It is the framework's
+// own offset table — it does NOT touch any business read-model schema (the
+// CellTx-offset design keeps the harness clear of the GAP-8 seal; ADR §4).
+//
+// Both methods are ambient-tx: SaveOffset participates in the caller's
+// transaction via persistence.TxFromContext(ctx) (no raw db handle — enforced by
+// PROJECTION-CHECKPOINT-TX-BOUND-01), so the offset advance commits together
+// with the Apply mutation. LoadOffset returns 0 for an unknown
+// (cellID, projectionID) pair (cold start = offset 0).
+//
+// Implementations: mem (PR-01) + postgres (PR-02); both verified by the shared
+// projectiontest.RunCheckpointConformance template (PR-01). Decided in ADR §3
+// Q1 (caller-provided tx + harness-internal SaveOffset, mirroring outbox.Writer
+// and Axon's JdbcTokenStore same-tx commit).
+type CheckpointStore interface {
+	// LoadOffset returns the last committed offset for the projection, or 0 if
+	// none has been recorded yet (cold start).
+	LoadOffset(ctx context.Context, cellID, projectionID string) (int64, error)
+	// SaveOffset advances the projection's committed offset within the ambient
+	// transaction carried by ctx.
+	SaveOffset(ctx context.Context, cellID, projectionID string, offset int64) error
+}
+
+// Option configures a projection subscription. It is the frozen functional-option
+// seam consumed by Coordinator.Subscribe (PR-01); concrete option constructors
+// (e.g. starting offset, fail-open policy) are added alongside the Coordinator.
+// Declared here so the Subscribe API surface is fixed by the ADR rather than
+// drifting when the implementation lands.
+type Option func(*subscribeOptions)
+
+// subscribeOptions holds the resolved Subscribe configuration. It is the target
+// of Option closures; fields are introduced with the Coordinator in PR-01.
+type subscribeOptions struct{}

--- a/tools/archtest/internal/wrapfixture/violation/violation.go
+++ b/tools/archtest/internal/wrapfixture/violation/violation.go
@@ -19,6 +19,7 @@ package violation
 import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/kernel/projection"
 )
 
 // CallWrapForCell deliberately calls persistence.WrapForCell from a
@@ -46,4 +47,12 @@ func CallWrapWriterForCell(w outbox.Writer) outbox.CellWriter {
 // the outbox.WrapEmitterForCell function leg of the wrapper-location invariant.
 func CallWrapEmitterForCell(e outbox.Emitter) outbox.CellEmitter {
 	return outbox.WrapEmitterForCell(e)
+}
+
+// CallWrapCheckpointStoreForCell mirrors CallWrapForCell for the projection
+// checkpoint-store wrapper (epic #1100 PR-00). Gives the scanner-detection test
+// a negative case for the projection.WrapCheckpointStoreForCell function leg of
+// the wrapper-location invariant.
+func CallWrapCheckpointStoreForCell(s projection.CheckpointStore) projection.CellCheckpointStore {
+	return projection.WrapCheckpointStoreForCell(s)
 }

--- a/tools/archtest/projection_state_phase_frozen_test.go
+++ b/tools/archtest/projection_state_phase_frozen_test.go
@@ -30,11 +30,13 @@
 //   - The const-block locator keys on the member name "PhaseLive". Renaming
 //     PhaseLive itself surfaces as a "block not found" Fatal (visible), not a
 //     silent pass — asserted by the reverse self-check below.
-//   - The String-arm extractor only reads `case PhaseX: return "literal"` arms.
-//     A String() rewritten to compute the literal dynamically (e.g. via a map
-//     or fmt) would yield an empty arm map and fail the per-member assertion —
-//     visible, not silent. Documented blind spot: none in-tree (phase.go uses
-//     the switch form, mirroring kernel/outbox/state.go).
+//   - The String-arm extractor only reads `case PhaseX: return "literal"` arms
+//     (const-Ident cases). A String() rewritten to compute the literal
+//     dynamically (e.g. via a map or fmt) yields an empty arm map and fails the
+//     per-member assertion — visible, not silent; exercised by reverse
+//     self-check case (4). The `case 0: return "invalid"` arm is keyed by an
+//     integer literal (BasicLit), not a const Ident, so it is locked separately
+//     via phaseZeroLiteralArm (reverse self-check case (5)).
 //   - Pointer-receiver String(): the locator accepts both `Phase` and `*Phase`
 //     receivers; value receiver is the established convention.
 //
@@ -97,6 +99,14 @@ func TestProjectionStatePhaseFrozen01(t *testing.T) {
 		t.Errorf("PROJECTION-STATE-PHASE-FROZEN-01: Phase String() arms = %v, want %v "+
 			"(String() literals are the wire/log contract — update wantPhaseStrings if intentional)",
 			arms, wantPhaseStrings)
+	}
+
+	// The zero-value arm (`case 0: return "invalid"`) is also a wire/log
+	// contract value; lock it explicitly since it is a BasicLit case, not an
+	// Ident case (and thus excluded from the const-keyed arm map above).
+	if zero := phaseZeroLiteralArm(parseFileOrFatal(t, src)); zero != "invalid" {
+		t.Errorf("PROJECTION-STATE-PHASE-FROZEN-01: Phase String() `case 0:` returns %q, want %q",
+			zero, "invalid")
 	}
 }
 
@@ -167,6 +177,45 @@ func (p Phase) String() string { return "x" }
 `)
 	if _, _, err := parsePhaseEnum(noBlock); err == nil {
 		t.Error("reverse self-check: parser did not error when the PhaseLive const block is absent")
+	}
+
+	// (4) A map-based (dynamic) String() has no case arms, so the arm map comes
+	// back empty and the main per-member assertion fails visibly rather than
+	// passing silently — exercising the documented dynamic-String blind spot.
+	dynamicString := []byte(`package projection
+type Phase uint8
+const (
+	PhaseLive Phase = iota + 1
+	PhaseStopped
+	PhaseReset
+	PhaseReplay
+	PhaseCatchup
+)
+var names = map[Phase]string{PhaseLive: "live"}
+func (p Phase) String() string { return names[p] }
+`)
+	_, dynArms, err := parsePhaseEnum(dynamicString)
+	if err != nil {
+		t.Fatalf("reverse self-check (dynamic String): parse: %v", err)
+	}
+	if len(dynArms) != 0 {
+		t.Errorf("reverse self-check: parser found case arms in a map-based String(); got %v", dynArms)
+	}
+
+	// (5) The zero-value arm extractor finds `case 0:` and ignores a renamed
+	// literal — proving a change away from "invalid" is observable.
+	if got := phaseZeroLiteralArm(parseFileOrFatal(t, []byte(`package projection
+type Phase uint8
+const PhaseLive Phase = iota + 1
+func (p Phase) String() string {
+	switch p {
+	case 0:
+		return "unknown"
+	}
+	return "x"
+}
+`))); got != "unknown" {
+		t.Errorf("reverse self-check: phaseZeroLiteralArm = %q, want %q (must observe the real literal)", got, "unknown")
 	}
 }
 
@@ -251,6 +300,45 @@ func phaseStringArms(f *ast.File) map[string]string {
 		})
 	}
 	return arms
+}
+
+func parseFileOrFatal(t *testing.T, src []byte) *ast.File {
+	t.Helper()
+	f, err := parser.ParseFile(token.NewFileSet(), "phase.go", src, 0)
+	if err != nil {
+		t.Fatalf("PROJECTION-STATE-PHASE-FROZEN-01: parse: %v", err)
+	}
+	return f
+}
+
+// phaseZeroLiteralArm returns the string literal of the `case 0:` arm in
+// Phase.String(), or "" if absent. This is the only arm keyed by an integer
+// literal (BasicLit), so phaseStringArms (which keys on const Idents) excludes
+// it; it is locked separately because "invalid" is also a wire/log contract.
+func phaseZeroLiteralArm(f *ast.File) string {
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "String" || fn.Recv == nil || !isPhaseReceiver(fn.Recv) {
+			continue
+		}
+		var lit string
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			cc, ok := n.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, e := range cc.List {
+				if bl, ok := e.(*ast.BasicLit); ok && bl.Kind == token.INT && bl.Value == "0" {
+					lit = firstReturnedStringLit(cc.Body)
+				}
+			}
+			return true
+		})
+		if lit != "" {
+			return lit
+		}
+	}
+	return ""
 }
 
 func isPhaseReceiver(recv *ast.FieldList) bool {

--- a/tools/archtest/projection_state_phase_frozen_test.go
+++ b/tools/archtest/projection_state_phase_frozen_test.go
@@ -1,0 +1,287 @@
+// INVARIANT: PROJECTION-STATE-PHASE-FROZEN-01
+//
+// PROJECTION-STATE-PHASE-FROZEN-01 — the rebuild-lifecycle Phase enum declared
+// in kernel/projection/phase.go is frozen to exactly five members
+// {PhaseLive, PhaseStopped, PhaseReset, PhaseReplay, PhaseCatchup} with the
+// canonical wire/log String() mapping. The set is the operational contract for
+// readyz / metrics / the business read-503 opt-in (Phase()); silently adding,
+// removing, or renaming a phase, or changing a String() literal, drifts the
+// contract. This lock fires on any such drift so the change is a deliberate,
+// reviewed golden update (bump the expected set below in the same PR).
+//
+// The enum is declared in PR-00 (#1172, ADR
+// docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md); the
+// rebuild state machine + transition table that consume it land in PR-03. This
+// archtest is green from PR-00 onward — it locks membership, not behavior.
+//
+// AI-robust 评级：Medium (AST const-set + String-arm lock).
+//   - This is stronger than a bare string-anchor: it parses the const block
+//     structurally and the String() switch arms, so it is not fooled by the
+//     word "Phase" appearing elsewhere. It is NOT Hard: discovery keys on the
+//     literal name "PhaseLive" to locate the const block, and Go enums are not
+//     reflectable as a set (unlike struct fields under
+//     SUBSCRIBERS-DERIVED-FIELD-FROZEN-01), so a golden/AST lock is the ceiling
+//     for an enum membership freeze. The type system already carries the
+//     orthogonal "zero value is invalid" guarantee via iota+1 + Phase.Valid().
+//   - Sibling precedent: OUTBOX-STATE-TRANSITION-COMPLETENESS-01 locks an enum
+//     transition map's key set; this locks the const set + String arms.
+//
+// 盲区自检（所选工具 go/parser AST walk 的声明范围外形态）:
+//   - The const-block locator keys on the member name "PhaseLive". Renaming
+//     PhaseLive itself surfaces as a "block not found" Fatal (visible), not a
+//     silent pass — asserted by the reverse self-check below.
+//   - The String-arm extractor only reads `case PhaseX: return "literal"` arms.
+//     A String() rewritten to compute the literal dynamically (e.g. via a map
+//     or fmt) would yield an empty arm map and fail the per-member assertion —
+//     visible, not silent. Documented blind spot: none in-tree (phase.go uses
+//     the switch form, mirroring kernel/outbox/state.go).
+//   - Pointer-receiver String(): the locator accepts both `Phase` and `*Phase`
+//     receivers; value receiver is the established convention.
+//
+// ref: kernel/outbox/state.go (enum + String + transition-table pattern).
+// ref: tools/archtest/contract_subscribers_funnel_test.go (frozen-field precedent).
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// wantPhaseConsts is the frozen, ordered membership of the Phase enum.
+// Changing this requires a same-PR review (golden update).
+var wantPhaseConsts = []string{
+	"PhaseLive",
+	"PhaseStopped",
+	"PhaseReset",
+	"PhaseReplay",
+	"PhaseCatchup",
+}
+
+// wantPhaseStrings is the frozen const→wire/log string mapping from String().
+var wantPhaseStrings = map[string]string{
+	"PhaseLive":    "live",
+	"PhaseStopped": "stopped",
+	"PhaseReset":   "reset",
+	"PhaseReplay":  "replay",
+	"PhaseCatchup": "catchup",
+}
+
+// TestProjectionStatePhaseFrozen01 locks the Phase enum membership + String arms.
+func TestProjectionStatePhaseFrozen01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	phasePath := filepath.Clean(filepath.Join(root, "kernel", "projection", "phase.go"))
+	src, err := os.ReadFile(phasePath)
+	if err != nil {
+		t.Fatalf("PROJECTION-STATE-PHASE-FROZEN-01: read phase.go: %v", err)
+	}
+
+	names, arms, err := parsePhaseEnum(src)
+	if err != nil {
+		t.Fatalf("PROJECTION-STATE-PHASE-FROZEN-01: parse phase.go: %v", err)
+	}
+
+	if !reflect.DeepEqual(names, wantPhaseConsts) {
+		t.Errorf("PROJECTION-STATE-PHASE-FROZEN-01: Phase const set = %v, want %v "+
+			"(adding/removing/renaming/reordering a phase changes the operational "+
+			"contract — update wantPhaseConsts in the same PR if intentional)", names, wantPhaseConsts)
+	}
+
+	if !reflect.DeepEqual(arms, wantPhaseStrings) {
+		t.Errorf("PROJECTION-STATE-PHASE-FROZEN-01: Phase String() arms = %v, want %v "+
+			"(String() literals are the wire/log contract — update wantPhaseStrings if intentional)",
+			arms, wantPhaseStrings)
+	}
+}
+
+// TestProjectionStatePhaseFrozen01_ReverseSelfCheck proves the parser has teeth:
+// it detects an added member, a removed member, and a missing String arm, and it
+// Fatals (not silently passes) when the locator name is absent.
+func TestProjectionStatePhaseFrozen01_ReverseSelfCheck(t *testing.T) {
+	t.Parallel()
+
+	// (1) An added member must be observed (6 names, not 5).
+	added := []byte(`package projection
+type Phase uint8
+const (
+	PhaseLive Phase = iota + 1
+	PhaseStopped
+	PhaseReset
+	PhaseReplay
+	PhaseCatchup
+	PhaseExtra
+)
+func (p Phase) String() string {
+	switch p {
+	case PhaseLive:
+		return "live"
+	}
+	return "x"
+}
+`)
+	names, _, err := parsePhaseEnum(added)
+	if err != nil {
+		t.Fatalf("reverse self-check (added): parse: %v", err)
+	}
+	if len(names) != 6 || names[5] != "PhaseExtra" {
+		t.Errorf("reverse self-check: parser did not observe an added const; got %v", names)
+	}
+
+	// (2) A missing String arm must be observed (no "PhaseReset" key).
+	missingArm := []byte(`package projection
+type Phase uint8
+const (
+	PhaseLive Phase = iota + 1
+	PhaseReset
+)
+func (p Phase) String() string {
+	switch p {
+	case PhaseLive:
+		return "live"
+	}
+	return "x"
+}
+`)
+	_, arms, err := parsePhaseEnum(missingArm)
+	if err != nil {
+		t.Fatalf("reverse self-check (missing arm): parse: %v", err)
+	}
+	if _, present := arms["PhaseReset"]; present {
+		t.Error("reverse self-check: parser invented a String arm for PhaseReset that does not exist")
+	}
+	if arms["PhaseLive"] != "live" {
+		t.Errorf("reverse self-check: parser dropped a real arm; got %v", arms)
+	}
+
+	// (3) Absent locator name → block-not-found error (visible, not silent pass).
+	noBlock := []byte(`package projection
+type Phase uint8
+const Renamed Phase = 1
+func (p Phase) String() string { return "x" }
+`)
+	if _, _, err := parsePhaseEnum(noBlock); err == nil {
+		t.Error("reverse self-check: parser did not error when the PhaseLive const block is absent")
+	}
+}
+
+// parsePhaseEnum extracts the ordered Phase const names (from the const block
+// that declares "PhaseLive") and the const→string map from the String() method's
+// `case PhaseX: return "literal"` arms. Returns an error if the const block is
+// not found (locator name renamed / removed).
+func parsePhaseEnum(src []byte) (names []string, arms map[string]string, err error) {
+	fset := token.NewFileSet()
+	f, perr := parser.ParseFile(fset, "phase.go", src, 0)
+	if perr != nil {
+		return nil, nil, perr
+	}
+
+	names = phaseConstNames(f)
+	if names == nil {
+		return nil, nil, errPhaseBlockNotFound
+	}
+	arms = phaseStringArms(f)
+	return names, arms, nil
+}
+
+var errPhaseBlockNotFound = phaseErr("PhaseLive const block not found")
+
+type phaseErr string
+
+func (e phaseErr) Error() string { return string(e) }
+
+// phaseConstNames returns the ordered const names in the GenDecl that declares
+// PhaseLive, or nil if no such block exists.
+func phaseConstNames(f *ast.File) []string {
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		var block []string
+		hasLocator := false
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				block = append(block, n.Name)
+				if n.Name == "PhaseLive" {
+					hasLocator = true
+				}
+			}
+		}
+		if hasLocator {
+			return block
+		}
+	}
+	return nil
+}
+
+// phaseStringArms maps each `case <Ident>: return "<literal>"` arm in the
+// Phase.String() method to its string literal.
+func phaseStringArms(f *ast.File) map[string]string {
+	arms := map[string]string{}
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "String" || fn.Recv == nil || !isPhaseReceiver(fn.Recv) {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			cc, ok := n.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			lit := firstReturnedStringLit(cc.Body)
+			if lit == "" {
+				return true
+			}
+			for _, e := range cc.List {
+				if id, ok := e.(*ast.Ident); ok {
+					arms[id.Name] = lit
+				}
+			}
+			return true
+		})
+	}
+	return arms
+}
+
+func isPhaseReceiver(recv *ast.FieldList) bool {
+	if len(recv.List) != 1 {
+		return false
+	}
+	switch t := recv.List[0].Type.(type) {
+	case *ast.Ident:
+		return t.Name == "Phase"
+	case *ast.StarExpr:
+		id, ok := t.X.(*ast.Ident)
+		return ok && id.Name == "Phase"
+	}
+	return false
+}
+
+func firstReturnedStringLit(body []ast.Stmt) string {
+	for _, s := range body {
+		ret, ok := s.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			continue
+		}
+		lit, ok := ret.Results[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			continue
+		}
+		v, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			continue
+		}
+		return v
+	}
+	return ""
+}

--- a/tools/archtest/sealed_marker_noop_transparency_test.go
+++ b/tools/archtest/sealed_marker_noop_transparency_test.go
@@ -95,12 +95,13 @@ func TestSealedMarkerNoopTransparency01(t *testing.T) {
 	// Floor guard against a silent discovery break (RunTyped scope resolving
 	// nothing, prefix typo, etc.): the known sealed markers are
 	// internalCellTxManager (kernel/persistence) + internalCellPublisher /
-	// internalCellWriter / internalCellEmitter (kernel/outbox) = 4. Assert we
-	// found at least those so a load regression cannot make this archtest
-	// vacuously pass. Bump this floor whenever a sealed marker is added.
-	if found < 4 {
+	// internalCellWriter / internalCellEmitter (kernel/outbox) +
+	// internalCellCheckpointStore (kernel/projection) = 5. Assert we found at
+	// least those so a load regression cannot make this archtest vacuously
+	// pass. Bump this floor whenever a sealed marker is added.
+	if found < 5 {
 		t.Fatalf("SEALED-MARKER-NOOP-TRANSPARENCY-01: discovered only %d internalCell* struct types under "+
-			"kernel/...; expected ≥4 (auto-discovery likely broken)", found)
+			"kernel/...; expected ≥5 (auto-discovery likely broken)", found)
 	}
 }
 

--- a/tools/archtest/wrapper_location_test.go
+++ b/tools/archtest/wrapper_location_test.go
@@ -3,8 +3,8 @@
 //
 // CELL-RAW-INFRA-WRAPPER-LOCATION-01 — persistence.WrapForCell /
 // outbox.WrapPublisherForCell / outbox.WrapWriterForCell /
-// outbox.WrapEmitterForCell are the sole authorized paths for handing raw
-// infra types into a cell's With* Option. They MUST be called only from
+// outbox.WrapEmitterForCell / projection.WrapCheckpointStoreForCell are the
+// sole authorized paths for handing raw infra types into a cell's With* Option. They MUST be called only from
 // composition roots (cmd/* + examples/<demo>/main.go + examples/<demo>/app.go
 // + examples/<demo>/run.go) or *_test.go, plus the kernel-internal resolution
 // funnel kernel/outbox/mode_resolver.go (ResolveCellEmitter wraps the
@@ -43,10 +43,11 @@ import (
 // new wrapper requires updating this set AND wrapperLocationAllowlistDoc
 // (godoc above) so the rule's surface stays trivially auditable.
 var wrapperFunctionsCanonical = map[string]bool{
-	"github.com/ghbvf/gocell/kernel/persistence.WrapForCell":     true,
-	"github.com/ghbvf/gocell/kernel/outbox.WrapPublisherForCell": true,
-	"github.com/ghbvf/gocell/kernel/outbox.WrapWriterForCell":    true,
-	"github.com/ghbvf/gocell/kernel/outbox.WrapEmitterForCell":   true,
+	"github.com/ghbvf/gocell/kernel/persistence.WrapForCell":               true,
+	"github.com/ghbvf/gocell/kernel/outbox.WrapPublisherForCell":           true,
+	"github.com/ghbvf/gocell/kernel/outbox.WrapWriterForCell":              true,
+	"github.com/ghbvf/gocell/kernel/outbox.WrapEmitterForCell":             true,
+	"github.com/ghbvf/gocell/kernel/projection.WrapCheckpointStoreForCell": true,
 }
 
 type wrapperViolation struct {
@@ -65,8 +66,8 @@ type wrapperViolation struct {
 //     examples/<demo>/run.go (composition root; run.go is the K#10-aligned
 //     hand-written runtime half when the example declares assembly.yaml and
 //     delegates main.go to the codegen entrypoint)
-//   - kernel/persistence/cell_marker.go and kernel/outbox/cell_marker.go
-//     (the wrapper definitions themselves)
+//   - kernel/persistence/cell_marker.go, kernel/outbox/cell_marker.go, and
+//     kernel/projection/cell_marker.go (the wrapper definitions themselves)
 //   - kernel/outbox/demo_tx_runner.go (DemoCellTxManager factory; the only
 //     kernel-internal helper that wraps a known noop fallback for cells —
 //     keeps cells/* free of any wrap call site)
@@ -96,6 +97,7 @@ func isWrapperCallerAllowed(rel string) bool {
 	switch rel {
 	case "kernel/persistence/cell_marker.go",
 		"kernel/outbox/cell_marker.go",
+		"kernel/projection/cell_marker.go",
 		"kernel/outbox/demo_tx_runner.go",
 		"kernel/outbox/mode_resolver.go",
 		"kernel/outbox/outboxtest/recorder.go",
@@ -181,7 +183,7 @@ func scanWrapperViolationsFromPass(p *Pass) []wrapperViolation {
 // impossible.
 func allowlistDescription() string {
 	return "cmd/* | examples/<demo>/main.go | examples/<demo>/app.go | examples/<demo>/run.go | *_test.go | " +
-		"kernel/{persistence,outbox}/cell_marker.go | kernel/outbox/demo_tx_runner.go | " +
+		"kernel/{persistence,outbox,projection}/cell_marker.go | kernel/outbox/demo_tx_runner.go | " +
 		"kernel/outbox/mode_resolver.go | kernel/outbox/outboxtest/recorder.go | " +
 		"cells/accesscore/{mem,postgres}/bundle.go"
 }

--- a/tools/archtest/wrapper_location_test.go
+++ b/tools/archtest/wrapper_location_test.go
@@ -265,6 +265,8 @@ func TestCellRawInfraWrapperLocation01_ScannerDetectsViolation(t *testing.T) {
 		"fixture must trigger outbox.WrapWriterForCell detection")
 	assert.NotEmpty(t, got["github.com/ghbvf/gocell/kernel/outbox.WrapEmitterForCell"],
 		"fixture must trigger outbox.WrapEmitterForCell detection")
+	assert.NotEmpty(t, got["github.com/ghbvf/gocell/kernel/projection.WrapCheckpointStoreForCell"],
+		"fixture must trigger projection.WrapCheckpointStoreForCell detection")
 
 	// dotimport.go uses `import . "kernel/outbox"` and writes the wrap
 	// calls without a package selector — call.Fun is *ast.Ident, not


### PR DESCRIPTION
## Summary

Epic #1100 PR-00 — the design-convergence + skeleton PR. Lands the ADR that
resolves the 5 open design tensions (Q1–Q5) and the `kernel/projection`
interface skeleton (declarations only, no consume logic). Every downstream PR
(PR-01..PR-06) builds on the signatures this PR freezes.

`Refs: #1100` · `Closes #1172`

### Key decisions (ADR §3)

- **Q1=A / Q2=A — ambient-tx model.** `Apply func(ctx, event) error` +
  `CheckpointStore.SaveOffset(ctx, cellID, projID, offset)`; the tx is ambient
  (`persistence.TxFromContext`), the Coordinator wraps each event in `RunInTx`
  so apply + checkpoint commit atomically (exactly-once). **This corrects the
  plan/spec's `persistence.TxHandle` parameter — that type does not exist and
  contradicts `PG-REPO-AMBIENT-TX-01` (landed today). The spec's own "与
  outbox.Writer 同范式" is the ambient pattern.**
- **Q3=A** single slice → single projection · **Q4=A** no snapshot in v1
  (trigger condition documented, not a silent backlog) · **Q5=A** single-pod v1
  with `owner` column reserved (multi-pod = upper-layer leader election;
  documented v1 boundary).
- **Phase enum frozen to 5 members** (`PhaseLive` + Axon's 4-phase rebuild
  Stop/Reset/Replay/Catchup). Supersedes the spec's "3-phase" + "read 503
  blocking" (rebuild reads are non-blocking per industry consensus; `Phase()` is
  the business 503 opt-in).

### Verifiability (answering "can an ADR-only PR be verified?")

PR-00 verifies the ADR's **type-level** decisions now; **behavior** is
discharged downstream (ADR §6 threat matrix names the PR per row):
- `go build ./kernel/projection/...` → ambient-tx signatures typecheck against
  real `outbox.Entry` / `persistence` types.
- `kernel/projection/contract_test.go` → contracts are implementable (fake
  store + sample apply), the `CellCheckpointStore` marker actually seals + Noop
  pass-through, `Phase.String()/Valid()` across the full enum.
- `PROJECTION-STATE-PHASE-FROZEN-01` (green now) → Phase membership is lockable.

### Contract fanout (implementation matrix)

```
Contract: kernel/projection.{Apply, CheckpointStore, CellCheckpointStore, Phase}
Change: introduce lifecycle harness interface skeleton (no implementation)
Implementations: [ ] memstore (PR-01)  [ ] PG (PR-02)  [x] fake (this PR, contract_test.go)
Conformance test: kernel/projection/projectiontest.RunCheckpointConformance (PR-01)
Repro: go build ./kernel/projection/... && go test ./kernel/projection/...
Dependent contracts (governance scan): kind:projection contract.yaml schema (PR-05 → Hard)
Invariant inventory (DROP COLUMN / forbiddenColumns): N/A — new table only, no DROP
```

### AI-robust

- `PROJECTION-STATE-PHASE-FROZEN-01` — **Medium** (AST const-set + String-arm
  lock; Go enums aren't reflectable as a set → AST/golden lock is the ceiling,
  same shape as `OUTBOX-STATE-TRANSITION-COMPLETENESS-01`). Reverse self-check +
  blind-spot list in the archtest godoc.
- `CellCheckpointStore` sealed marker — **Hard** at the field/assignment layer
  (mirrors `outbox.CellPublisher`); auto-enrolls in
  `SEALED-MARKER-NOOP-TRANSPARENCY-01` (floor bumped 4→5).
- Downstream funnel ratings (APPLY-HOOK / CHECKPOINT-TX-BOUND / OWNER-RESERVED /
  CONSISTENCY-PARSE-TIME) documented in ADR §7 for PR-01..PR-05.

### Test plan

- [x] `go build ./...`
- [x] `go test ./kernel/projection/...` (implementability proof)
- [x] `go test ./tools/archtest/ -run 'ProjectionStatePhaseFrozen|SealedMarkerNoopTransparency'`
- [x] `golangci-lint run ./kernel/projection/... ./tools/archtest/...` → 0 issues
- [x] `bash hack/verify-archtest-invariants.sh` (PR-time governance gate)

`ref: AxonFramework JdbcTokenStore / @ResetHandler / token_entry.owner`
`ref: JasperFx/marten async-daemon IDocumentOperations`
`ref: ThreeDotsLabs/watermill components/cqrs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)