### PR TITLE
feat(mtls): server-side *tls.Config builder + peer-identity ctx hook [WM-32]

### DIFF
--- a/.claude/rules/gocell/runtime-api.md
+++ b/.claude/rules/gocell/runtime-api.md
@@ -141,7 +141,7 @@ bootstrap.New(
 | `auth.NewAuthJWT(v) (AuthJWT, error)` | JWT 验证（直接注入 IntentTokenVerifier）。error-first；`Must*` 变体已删除（B2-K-02，ADR `202605171800`）。 | PrimaryListener |
 | `auth.NewAuthJWTFromAssembly(asm) (..., error)` | JWT 验证（phase4 自动从 authProvider Cell 发现 verifier） | PrimaryListener |
 | `auth.NewAuthServiceToken(...) (..., error)` | HMAC-SHA256 service token | InternalListener |
-| `auth.AuthMTLS{}` | mTLS — 仅断言存在 peer cert；链验证由 `tls.Config.ClientAuth=RequireAndVerifyClientCert` 在握手层完成（必须配置 WithListenerTLS） | InternalListener（高安全场景） |
+| `auth.AuthMTLS{}` | mTLS — 链验证由 `tls.Config.ClientAuth=RequireAndVerifyClientCert` 在握手层完成（必须配置 WithListenerTLS）；中间件 `runtime/http/middleware.MTLS()` 守 peer cert presence + 把 curated `PeerIdentity{Subject,DNSNames,URIs}` 写入 ctx（`pkg/ctxkeys.PeerIdentityFrom`）；server-side `*tls.Config` 用 `runtime/http/tlsutil.NewServerMTLSConfig(certPEM, keyPEM, clientCAs)` 构造 | InternalListener（高安全场景） |
 | `auth.AuthNone{}` | 显式无验证（HealthListener loopback 隔离场景；nil 已被 phase0 拒绝） | HealthListener（loopback 隔离） |
 
 **多 plan chain 示例**：

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -717,7 +717,7 @@ linters:
         linters:
           - gosec
         text: "G706"
-      - path: ^runtime/http/middleware/(recovery|csrf|mtls)\.go
+      - path: ^runtime/http/middleware/(recovery|csrf)\.go
         linters:
           - gosec
         text: "G706"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -717,7 +717,7 @@ linters:
         linters:
           - gosec
         text: "G706"
-      - path: ^runtime/http/middleware/(recovery|csrf)\.go
+      - path: ^runtime/http/middleware/(recovery|csrf|mtls)\.go
         linters:
           - gosec
         text: "G706"

--- a/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
+++ b/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
@@ -88,7 +88,7 @@ WM-32 trade-off 明文：**大规模 mTLS 卸载在 K8s/Service Mesh 解决，�
 
 > **sole-producer 有意不在 Hard 清单**：`runtime/http/middleware.MTLS` 是 `WithPeerIdentity` 今日唯一生产者，但这是约定、非 enforcement——跨包 `context.WithValue` setter 在 Go 无法 seal，caller-allowlist archtest 至多 Medium，且威胁模型显示 handler 伪造自身 ctx 身份无收益（不承重）。故**有意不立** sole-producer 守卫，也不声明其为 Hard（这正是修正前 Row 6 "single sanctioned holder = 结构上 Hard" 的错标，本版已移除）。
 
-本表唯一 Soft 是 Row 5 的 post-return-mutation 分量（Go 技术上限，符合 ai-robust §"Soft 严禁立项"之豁免条件）；其余形态均为 Hard，含 Row 6 经 `PEER-IDENTITY-FIELDS-FROZEN-01` 实证落地。
+本表唯一 Soft 是 Row 5 的 post-return-mutation 分量：它不是新增 enforcement 立项，而是 stdlib `*tls.Config` 可变 API 带来的 residual risk；本 PR 不把该 post-return surface 声明为 Hard，也不新增 Soft enforcement。其余形态均为 Hard，含 Row 6 经 `PEER-IDENTITY-FIELDS-FROZEN-01` 实证落地。
 
 ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — MTLSServerConfig（curated 字段）
 ref: kubernetes/apiserver pkg/server/secure_serving.go — server cert plumbing

--- a/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
+++ b/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
@@ -1,0 +1,87 @@
+# ADR 049 — mTLS server builder + peer-identity ctx hook
+
+Date: 2026-05-29
+Status: Accepted
+Related: WM-32 (#631) — backlog_later §7
+
+## Context
+
+GoCell 之前的 mTLS 支撑只到 "presence-only guard"：`kernel/auth.AuthMTLS{}`
+是 sealed marker；`runtime/bootstrap.WithListenerTLS(*tls.Config)` verbatim
+注入；phase0 `validateMTLSTLSConfig` 校验 `ClientAuth >= VerifyClientCertIfGiven`
++ `ClientCAs != nil`；`mtlsMiddleware` 仅 `r.TLS == nil ||
+len(r.TLS.PeerCertificates) == 0 → 401`。
+
+业务侧（cells/、examples/）0 个 peer cert 消费者：即使握手成功，handler 也拿
+不到对端证书身份，使 AuthMTLS 实际只是"是 mutual 握手"的 binary 标志，丢失
+mTLS 最重要的应用层属性 peer identity。
+
+WM-32 trade-off 明文：**大规模 mTLS 卸载在 K8s/Service Mesh 解决，框架仅提
+供构建器**。本 ADR 锁定 "framework enabling minimum"，避免后续 reviewer 把
+"该不该做 X" 重复评估为 WM-32 范围。
+
+## Decision
+
+1. **PEM-bytes 输入**：新 `runtime/http/tlsutil.NewServerMTLSConfig(certPEM,
+   keyPEM []byte, clientCAs *x509.CertPool) (*tls.Config, error)` 接 PEM 字节
+   不接 file path——runtime/ 层不引入 FS 依赖，callers 自己 `os.ReadFile`。
+2. **MinVersion = TLS 1.3**：builder 出厂 config 硬编 `cfg.MinVersion =
+   tls.VersionTLS13`。fail-closed 默认；与 spiffe/go-spiffe `spiffetls.
+   MTLSServerConfig` 一致；V1.1 启动期无 legacy client 包袱。
+3. **ClientAuth = RequireAndVerifyClientCert + 必填 ClientCAs**：builder
+   出厂 config 同样硬编；nil pool 返回 error。
+4. **PeerIdentity 字段集 curated**：`pkg/ctxkeys.PeerIdentity{Subject pkix.
+   Name, DNSNames []string, URIs []*url.URL}`——3 字段。**不暴露 raw
+   `*x509.Certificate`**，下游耦合 x509 内部"在 type system 不可表达"。字段
+   集 curation 仅 godoc 约定，不立 archtest enforcement（Cx2 scope；若将
+   来需 Hard 守卫，按 ai-robust §适用范围单独评级）。
+5. **PeerIdentity 放 `pkg/ctxkeys/`**：与 `request_id` / `real_ip` / `trace_id`
+   同族 request-scope；让 cells/ 与 runtime/ 共同消费时无 import 环。
+6. **不引入 spiffe/go-spiffe 依赖**：URIs 保留 raw `*url.URL`，业务侧若需
+   SPIFFE typed-ID 自行调 `spiffeid.FromURI`。
+7. **不做动态证书 reload / OCSP / `GetCertificate` callback / 出站 client
+   builder**：K8s/mesh 领域 + 当前 0 消费者。
+
+## Consequences
+
+- 业务 handler `ctxkeys.PeerIdentityFrom(ctx)` 一行拿身份；无 *x509 依赖
+- 不向后兼容：`runtime/bootstrap/auth_plan_apply.go` 内 `mtlsMiddleware()`
+  函数体 + section header + history comment 删除，等价覆盖迁移到
+  `runtime/http/middleware/mtls.go`，老 test `TestMtlsMiddleware_PeerCertPresence`
+  同 PR 删除并改写为 `mtls_test.go` + 集成 sub-test
+- `runtime/bootstrap/auth_plan_describe.go::chainContainsInternalGuard` godoc
+  同步更新："mTLS alone 不建立 caller_cell allowlist mapping（service-token
+  仍是 sole producer）"——保留正确语义、消除 "mTLS 不产生任何 identity"
+  的误读
+- 未来若需 SPIFFE helper，应放 cells/ 或新 `runtime/spiffe/`，不污染
+  pkg/ctxkeys
+
+## Alternatives rejected
+
+- **PEM file-path 入参**——runtime/ 引入 FS 依赖，testability 差
+- **暴露 raw `*x509.Certificate`**——下游耦合 x509 内部，PeerIdentity 字段
+  演化困难；k8s `UserConversionFunc`、SPIFFE `Authorizer` 都用 curated 视图
+- **bootstrap.WithListenerMTLS(...) 便捷 option**——caller 两行可达
+  (`tlsutil.NewServerMTLSConfig + WithListenerTLS + auth.AuthMTLS{}`)，YAGNI
+- **k8s `UserConversionFunc` 可插拔 identity extractor**——Cx2 scope 过重，
+  framework 不应预设 multi-tenant 认证模型
+- **MinVersion = TLS 1.2**（与 k8s apiserver 默认一致）——为了兼容老 client，
+  但 V1.1 启动期无该约束，TLS 1.3 fail-closed 更稳
+
+## AI HARD 形态分级（implementation 层面）
+
+| 约束 | 形态 | 等级 |
+|------|------|------|
+| `runtime/http/middleware/mtls.go` 不构造 `kauth.AuthMTLS{}` | 既有 AUTH-PLAN-04 archtest | Hard |
+| 错误信息不含裸 `"mtls"` 小写字面量 | 既有 AUTH-PLAN-01 archtest | Hard |
+| `MTLS()` 函数与 kernel/auth 包零交互 | 函数签名零 auth 类型参 + body 只依赖 stdlib+pkg/* | Hard (type-system) |
+| `runtime/http/tlsutil/` 只接 PEM bytes | 函数签名 `[]byte` 类型 | Hard (type-system) |
+| `NewServerMTLSConfig` 出厂 TLS1.3 + RequireAndVerify | builder body 硬编字段写入 | Hard (type-system) |
+| PeerIdentity 字段集 curated（不含 `Raw *x509.Certificate`） | pkg/ctxkeys 包边界 = single sanctioned holder | 结构上 Hard |
+| `applyListenerAuthChain` `case AuthMTLS:` 唯一 caller | sealed `ListenerAuth` interface + type-switch | Hard (type-system) |
+
+无 Soft enforcement 立项，符合 ai-robust §"Soft 严禁立项"。
+
+ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — MTLSServerConfig（curated 字段）
+ref: kubernetes/apiserver pkg/server/secure_serving.go — server cert plumbing
+ref: kubernetes/apiserver pkg/authentication/request/x509/x509.go — CN/SAN→user 提取

--- a/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
+++ b/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
@@ -32,9 +32,13 @@ WM-32 trade-off 明文：**大规模 mTLS 卸载在 K8s/Service Mesh 解决，�
    出厂 config 同样硬编；nil pool 返回 error。
 4. **PeerIdentity 字段集 curated**：`pkg/ctxkeys.PeerIdentity{Subject pkix.
    Name, DNSNames []string, URIs []*url.URL}`——3 字段。**不暴露 raw
-   `*x509.Certificate`**，下游耦合 x509 内部"在 type system 不可表达"。字段
-   集 curation 仅 godoc 约定，不立 archtest enforcement（Cx2 scope；若将
-   来需 Hard 守卫，按 ai-robust §适用范围单独评级）。
+   `*x509.Certificate`**：给定当前字段集，handler 无法从 PeerIdentity 读到
+   不存在的字段，下游对 x509 内部表示的耦合不可达。字段集本身由 reflect 字段
+   冻结 archtest `PEER-IDENTITY-FIELDS-FROZEN-01` 守卫（Hard：锁字段名/类型/
+   可见性，禁 embedding、禁 raw-cert 字段，附非空 reverse self-check）——
+   加/删字段或改类型即 CI 红。middleware 侧 `ownedPeerIdentity` 对 9 个
+   pkix.Name 切片 + 每个 `*url.URL` + DNSNames 做防御性深拷贝，使 ctx 中的
+   身份与连接缓存的证书完全隔离（见 `mtls.go`）。
 5. **PeerIdentity 放 `pkg/ctxkeys/`**：与 `request_id` / `real_ip` / `trace_id`
    同族 request-scope；让 cells/ 与 runtime/ 共同消费时无 import 环。
 6. **不引入 spiffe/go-spiffe 依赖**：URIs 保留 raw `*url.URL`，业务侧若需
@@ -76,13 +80,15 @@ WM-32 trade-off 明文：**大规模 mTLS 卸载在 K8s/Service Mesh 解决，�
 | 错误信息不含裸 `"mtls"` 小写字面量 | 既有 AUTH-PLAN-01 archtest | Hard |
 | `MTLS()` 函数与 kernel/auth 包零交互 | 函数签名零 auth 类型参 + body 只依赖 stdlib+pkg/* | Hard (type-system) |
 | `runtime/http/tlsutil/` 只接 PEM bytes | 函数签名 `[]byte` 类型 | Hard (type-system) |
-| `NewServerMTLSConfig` 出厂 TLS1.3 + RequireAndVerify | builder body 硬编字段写入；返回 stdlib `*tls.Config` 可变结构 | Soft (godoc 约定) — 升 Hard 不可行（`crypto/tls.Server` 接 `*tls.Config`，无 opaque wrapper 通道） |
-| PeerIdentity 字段集 curated（不含 `Raw *x509.Certificate`） | pkg/ctxkeys 包边界 = single sanctioned holder | 结构上 Hard |
+| `NewServerMTLSConfig` 出厂 TLS1.3 + RequireAndVerify | emit 形态：builder 唯一成功路径无条件硬编字段（无参数/分支可产出弱 config）；post-return：返回 stdlib `*tls.Config` 可变结构 | emit-time **Hard**（type-system：唯一成功路径硬编）+ post-return-mutation **Soft**（`crypto/tls.Server` 接 `*tls.Config`，无 opaque wrapper 通道，升 Hard 不可行） |
+| PeerIdentity 字段集 curated（不含 `Raw *x509.Certificate`） | reflect 字段冻结 archtest `PEER-IDENTITY-FIELDS-FROZEN-01`（锁字段名/类型/可见性，禁 embedding/raw-cert 字段，附非空 reverse self-check） | **Hard** |
 | `applyListenerAuthChain` `case AuthMTLS:` 唯一 caller | sealed `ListenerAuth` interface + type-switch | Hard (type-system) |
 
-> Row 5 Soft 的天花板限制：Go 生态约束。`crypto/tls.Server`/`http.ServeTLS` 强制接收 `*tls.Config` 标准类型；自定义 opaque wrapper 无法注入握手层。godoc 警告（见 `server.go::NewServerMTLSConfig`）是该 surface 唯一可行 enforcement。
+> **Row 5 的 post-return-mutation Soft 天花板**：Go 生态约束。`crypto/tls.Server`/`http.ServeTLS` 强制接收 `*tls.Config` 标准类型；自定义 opaque wrapper 无法注入握手层，故 builder 返回后调用方仍可改写 `cfg.MinVersion`。godoc 警告（见 `server.go::NewServerMTLSConfig`）是该 post-return surface 唯一可行 enforcement。emit-time（builder 出厂即 TLS1.3 + RequireAndVerify）则是 type-system Hard——唯一成功路径无条件写入，无分支可产出弱 config。
 
-Row 5 Soft 属 Go 生态技术上限（`crypto/tls.Server` 接受 `*tls.Config` 标准类型，无 opaque wrapper 通道），物理不可行升 Hard，符合 ai-robust §"Soft 严禁立项"之豁免条件。其余行均为 Hard。
+> **sole-producer 有意不在 Hard 清单**：`runtime/http/middleware.MTLS` 是 `WithPeerIdentity` 今日唯一生产者，但这是约定、非 enforcement——跨包 `context.WithValue` setter 在 Go 无法 seal，caller-allowlist archtest 至多 Medium，且威胁模型显示 handler 伪造自身 ctx 身份无收益（不承重）。故**有意不立** sole-producer 守卫，也不声明其为 Hard（这正是修正前 Row 6 "single sanctioned holder = 结构上 Hard" 的错标，本版已移除）。
+
+本表唯一 Soft 是 Row 5 的 post-return-mutation 分量（Go 技术上限，符合 ai-robust §"Soft 严禁立项"之豁免条件）；其余形态均为 Hard，含 Row 6 经 `PEER-IDENTITY-FIELDS-FROZEN-01` 实证落地。
 
 ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — MTLSServerConfig（curated 字段）
 ref: kubernetes/apiserver pkg/server/secure_serving.go — server cert plumbing

--- a/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
+++ b/docs/architecture/202605290130-049-adr-mtls-server-builder-and-identity-hook.md
@@ -76,11 +76,13 @@ WM-32 trade-off 明文：**大规模 mTLS 卸载在 K8s/Service Mesh 解决，�
 | 错误信息不含裸 `"mtls"` 小写字面量 | 既有 AUTH-PLAN-01 archtest | Hard |
 | `MTLS()` 函数与 kernel/auth 包零交互 | 函数签名零 auth 类型参 + body 只依赖 stdlib+pkg/* | Hard (type-system) |
 | `runtime/http/tlsutil/` 只接 PEM bytes | 函数签名 `[]byte` 类型 | Hard (type-system) |
-| `NewServerMTLSConfig` 出厂 TLS1.3 + RequireAndVerify | builder body 硬编字段写入 | Hard (type-system) |
+| `NewServerMTLSConfig` 出厂 TLS1.3 + RequireAndVerify | builder body 硬编字段写入；返回 stdlib `*tls.Config` 可变结构 | Soft (godoc 约定) — 升 Hard 不可行（`crypto/tls.Server` 接 `*tls.Config`，无 opaque wrapper 通道） |
 | PeerIdentity 字段集 curated（不含 `Raw *x509.Certificate`） | pkg/ctxkeys 包边界 = single sanctioned holder | 结构上 Hard |
 | `applyListenerAuthChain` `case AuthMTLS:` 唯一 caller | sealed `ListenerAuth` interface + type-switch | Hard (type-system) |
 
-无 Soft enforcement 立项，符合 ai-robust §"Soft 严禁立项"。
+> Row 5 Soft 的天花板限制：Go 生态约束。`crypto/tls.Server`/`http.ServeTLS` 强制接收 `*tls.Config` 标准类型；自定义 opaque wrapper 无法注入握手层。godoc 警告（见 `server.go::NewServerMTLSConfig`）是该 surface 唯一可行 enforcement。
+
+Row 5 Soft 属 Go 生态技术上限（`crypto/tls.Server` 接受 `*tls.Config` 标准类型，无 opaque wrapper 通道），物理不可行升 Hard，符合 ai-robust §"Soft 严禁立项"之豁免条件。其余行均为 Hard。
 
 ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — MTLSServerConfig（curated 字段）
 ref: kubernetes/apiserver pkg/server/secure_serving.go — server cert plumbing

--- a/pkg/ctxkeys/peer_identity.go
+++ b/pkg/ctxkeys/peer_identity.go
@@ -15,7 +15,9 @@ const peerIdentity ctxKey = "peer_identity"
 // OU / ...), DNS SANs, and URI SANs (including raw SPIFFE spiffe:// entries
 // that callers parse with their own helper). Raw *x509.Certificate is
 // deliberately not exposed, so handlers do not depend on the x509 internal
-// representation. Adding a field requires a focused review of this file.
+// representation. This field set is frozen by archtest
+// PEER-IDENTITY-FIELDS-FROZEN-01 (reflect lock: names, types, visibility, no
+// embedding, no raw-cert field) — adding/removing/retyping a field fails CI.
 //
 // SECURITY NOTE: Subject is the stdlib pkix.Name. Beyond CN/O/OU it carries
 // Names []pkix.AttributeTypeAndValue and ExtraNames []pkix.AttributeTypeAndValue
@@ -31,7 +33,15 @@ type PeerIdentity struct {
 }
 
 // WithPeerIdentity returns a new context carrying the given peer identity.
-// runtime/http/middleware.MTLS is the sole producer.
+//
+// runtime/http/middleware.MTLS is the sole producer in practice, but this is a
+// CONVENTION, not a statically enforced guarantee: WithPeerIdentity is exported
+// (a cross-package context setter cannot be sealed in Go), so any package could
+// call it. There is deliberately no caller-allowlist archtest — a handler
+// injecting a forged identity into its own request context gains nothing it
+// could not already do, so the sole-producer property is not security-load-
+// bearing. What IS enforced (Hard) is the curated field set: see PeerIdentity's
+// doc and archtest PEER-IDENTITY-FIELDS-FROZEN-01.
 func WithPeerIdentity(ctx context.Context, id PeerIdentity) context.Context {
 	return context.WithValue(ctx, peerIdentity, id)
 }

--- a/pkg/ctxkeys/peer_identity.go
+++ b/pkg/ctxkeys/peer_identity.go
@@ -1,0 +1,36 @@
+package ctxkeys
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"net/url"
+)
+
+const peerIdentity ctxKey = "peer_identity"
+
+// PeerIdentity is the curated subset of a verified leaf X.509 client
+// certificate surfaced to request-scope handlers.
+//
+// The field set is intentionally narrow: callers consume Subject (CN / O /
+// OU / ...), DNS SANs, and URI SANs (including raw SPIFFE spiffe:// entries
+// that callers parse with their own helper). Raw *x509.Certificate is
+// deliberately not exposed, so handlers do not depend on the x509 internal
+// representation. Adding a field requires a focused review of this file.
+type PeerIdentity struct {
+	Subject  pkix.Name
+	DNSNames []string
+	URIs     []*url.URL
+}
+
+// WithPeerIdentity returns a new context carrying the given peer identity.
+// runtime/http/middleware.MTLS is the sole producer.
+func WithPeerIdentity(ctx context.Context, id PeerIdentity) context.Context {
+	return context.WithValue(ctx, peerIdentity, id)
+}
+
+// PeerIdentityFrom extracts the peer identity from ctx. The boolean reports
+// whether the key was present; absent → zero-value PeerIdentity{} + false.
+func PeerIdentityFrom(ctx context.Context) (PeerIdentity, bool) {
+	v, ok := ctx.Value(peerIdentity).(PeerIdentity)
+	return v, ok
+}

--- a/pkg/ctxkeys/peer_identity.go
+++ b/pkg/ctxkeys/peer_identity.go
@@ -16,6 +16,14 @@ const peerIdentity ctxKey = "peer_identity"
 // that callers parse with their own helper). Raw *x509.Certificate is
 // deliberately not exposed, so handlers do not depend on the x509 internal
 // representation. Adding a field requires a focused review of this file.
+//
+// SECURITY NOTE: Subject is the stdlib pkix.Name. Beyond CN/O/OU it carries
+// Names []pkix.AttributeTypeAndValue and ExtraNames []pkix.AttributeTypeAndValue
+// which can hold arbitrary OID-value pairs (e.g. emailAddress, serialNumber).
+// Callers that serialize Subject wholesale into slog or access logs may leak
+// PII. Read only the named fields you need (Subject.CommonName,
+// Subject.Organization, etc.) and never marshal Subject directly into wire
+// or log payloads.
 type PeerIdentity struct {
 	Subject  pkix.Name
 	DNSNames []string
@@ -30,6 +38,13 @@ func WithPeerIdentity(ctx context.Context, id PeerIdentity) context.Context {
 
 // PeerIdentityFrom extracts the peer identity from ctx. The boolean reports
 // whether the key was present; absent → zero-value PeerIdentity{} + false.
+//
+// CALLERS MUST CHECK ok BEFORE USING THE IDENTITY. Absent means the request
+// did not pass through runtime/http/middleware.MTLS (e.g. mTLS not on this
+// listener, or the request hit a non-mTLS auth chain). Using the zero-value
+// PeerIdentity{} as if it were a real identity is a silent bug — it has an
+// empty CN, nil DNSNames, and nil URIs that would compare equal to other
+// zero values.
 func PeerIdentityFrom(ctx context.Context) (PeerIdentity, bool) {
 	v, ok := ctx.Value(peerIdentity).(PeerIdentity)
 	return v, ok

--- a/pkg/ctxkeys/peer_identity_test.go
+++ b/pkg/ctxkeys/peer_identity_test.go
@@ -1,0 +1,66 @@
+package ctxkeys
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestPeerIdentityRoundTrip(t *testing.T) {
+	want := PeerIdentity{
+		Subject: pkix.Name{
+			CommonName:   "device-01",
+			Organization: []string{"acme"},
+		},
+		DNSNames: []string{"device-01.example.com", "alt.example.com"},
+		URIs: []*url.URL{
+			mustParseURL(t, "spiffe://example.org/ns/edge/sa/device-01"),
+			mustParseURL(t, "urn:device:01"),
+		},
+	}
+
+	ctx := WithPeerIdentity(context.Background(), want)
+	got, ok := PeerIdentityFrom(ctx)
+	require.True(t, ok)
+	assert.Equal(t, want.Subject.CommonName, got.Subject.CommonName)
+	assert.Equal(t, want.Subject.Organization, got.Subject.Organization)
+	assert.Equal(t, want.DNSNames, got.DNSNames)
+	assert.Equal(t, want.URIs, got.URIs)
+}
+
+func TestPeerIdentityFrom_MissingKey(t *testing.T) {
+	got, ok := PeerIdentityFrom(context.Background())
+	assert.False(t, ok)
+	assert.Equal(t, PeerIdentity{}, got)
+}
+
+func TestPeerIdentity_CoexistsWithRequestScopeKeys(t *testing.T) {
+	id := PeerIdentity{Subject: pkix.Name{CommonName: "device-02"}}
+	ctx := context.Background()
+	ctx = WithRequestID(ctx, "req-001")
+	ctx = WithRealIP(ctx, "10.0.0.1")
+	ctx = WithPeerIdentity(ctx, id)
+
+	reqID, ok := RequestIDFrom(ctx)
+	require.True(t, ok)
+	assert.Equal(t, "req-001", reqID)
+
+	ip, ok := RealIPFrom(ctx)
+	require.True(t, ok)
+	assert.Equal(t, "10.0.0.1", ip)
+
+	got, ok := PeerIdentityFrom(ctx)
+	require.True(t, ok)
+	assert.Equal(t, "device-02", got.Subject.CommonName)
+}

--- a/runtime/bootstrap/auth_plan_apply.go
+++ b/runtime/bootstrap/auth_plan_apply.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/http/middleware"
 	"github.com/ghbvf/gocell/runtime/http/router"
 )
 
@@ -70,7 +70,7 @@ func (b *Bootstrap) applyListenerAuthChain(
 			routerOpts = append(routerOpts, authOpts...)
 
 		case kauth.AuthMTLS:
-			mws = append(mws, mtlsMiddleware())
+			mws = append(mws, middleware.MTLS())
 
 		case kauth.AuthServiceToken:
 			mws = append(mws, auth.ServiceTokenMiddleware(
@@ -166,27 +166,6 @@ func discoverAuthVerifierFromAssembly(asm kauth.AssemblyRef) (kauth.IntentTokenV
 				"or wire the verifier explicitly via kauth.NewAuthJWT(verifier)")
 	}
 	return found, nil
-}
-
-// ─── Middleware factories ─────────────────────────────────────────────────────
-
-// mtlsMiddleware returns the peer-cert-presence guard. The handshake layer
-// has already done the chain check (see auth_plan_validate.go phase0), so
-// the middleware only asserts that the connection terminated as TLS with at
-// least one peer cert.
-//
-// Moved from policy_mtls.go.
-func mtlsMiddleware() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
-				httputil.WriteError(r.Context(), w,
-					errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "mTLS client certificate required"))
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
 }
 
 // sortedListenerRefs returns listener refs in deterministic string order.

--- a/runtime/bootstrap/auth_plan_apply_test.go
+++ b/runtime/bootstrap/auth_plan_apply_test.go
@@ -6,8 +6,6 @@ package bootstrap
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -208,46 +206,6 @@ func TestApplyListenerAuthChain_EachKind(t *testing.T) {
 				"auth middleware installation")
 		})
 	}
-}
-
-// ─── TestMtlsMiddleware_PeerCertPresence ──────────────────────────────────────
-
-func TestMtlsMiddleware_PeerCertPresence(t *testing.T) {
-	t.Parallel()
-
-	mw := mtlsMiddleware()
-	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	t.Run("no_TLS_state_returns_401", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		// req.TLS is nil by default
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
-	})
-
-	t.Run("TLS_with_no_peer_certs_returns_401", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.TLS = &tls.ConnectionState{} // empty, no peer certs
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
-	})
-
-	t.Run("TLS_with_peer_cert_returns_200", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.TLS = &tls.ConnectionState{
-			PeerCertificates: []*x509.Certificate{{}}, // presence is enough
-		}
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-	})
 }
 
 // ─── TestVerboseTokenMiddleware_QueryParamBoundary ────────────────────────────

--- a/runtime/bootstrap/auth_plan_describe.go
+++ b/runtime/bootstrap/auth_plan_describe.go
@@ -73,8 +73,11 @@ func chainContainsAuthMTLS(chain []auth.ListenerAuth) bool {
 // chainContainsInternalGuard reports whether the listener chain has the
 // service-token guard required for /internal/v1/* routes. JWT is intentionally
 // excluded: internal routes use caller_cell allowlist via contract.clients
-// (enforced by auth.RequireCallerCell). AuthMTLS may be layered with
-// service-token, but mTLS alone does not currently establish caller identity.
+// (enforced by auth.RequireCallerCell). AuthMTLS surfaces peer identity
+// (Subject/DNS/URIs) into request ctx via runtime/http/middleware.MTLS, but
+// mTLS alone does not establish the caller_cell allowlist mapping that
+// /internal/v1/* requires; service-token remains the sole producer of
+// caller_cell.
 func chainContainsInternalGuard(chain []auth.ListenerAuth) bool {
 	for _, p := range chain {
 		if _, ok := p.(auth.AuthServiceToken); ok {

--- a/runtime/http/middleware/mtls.go
+++ b/runtime/http/middleware/mtls.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
@@ -27,12 +28,28 @@ import (
 // http.Request.TLS only, takes no auth-plan parameter, and depends only on
 // stdlib + pkg/* — keeping the AUTH-PLAN archtest boundary clean.
 //
+// To enable mTLS on a listener, three pieces must be wired together:
+// (1) build the *tls.Config with runtime/http/tlsutil.NewServerMTLSConfig;
+// (2) hand it to bootstrap.WithListenerTLS as the listener's TLS config;
+// (3) include kernel/auth.AuthMTLS{} in the listener's auth chain.
+// This middleware only covers the application-layer presence check and
+// identity extraction; without (1) and (2) the handshake layer will not
+// enforce peer cert validation.
+//
 // ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — Authorizer model
 // (typed peer-identity surface vs raw *x509.Certificate).
 func MTLS() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+				attrs := []any{
+					slog.String("method", r.Method),
+					slog.String("path", r.URL.Path),
+				}
+				if rid, ok := ctxkeys.RequestIDFrom(r.Context()); ok {
+					attrs = append(attrs, slog.String("request_id", rid))
+				}
+				slog.Warn("mtls rejected: no peer certificate", attrs...)
 				httputil.WriteError(r.Context(), w,
 					errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
 						"mTLS client certificate required"))

--- a/runtime/http/middleware/mtls.go
+++ b/runtime/http/middleware/mtls.go
@@ -1,12 +1,17 @@
 package middleware
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"slices"
 
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/logutil"
 )
 
 // MTLS returns the application-layer guard installed on listeners whose
@@ -16,9 +21,11 @@ import (
 //  1. Rejects requests that did not terminate as TLS or that present no peer
 //     certificate, returning a 401 envelope with code ERR_AUTH_UNAUTHORIZED.
 //  2. Extracts the leaf peer certificate's Subject, DNS SANs, and URI SANs
-//     into a curated PeerIdentity and stores it on the request context via
-//     pkg/ctxkeys.WithPeerIdentity. Downstream handlers read it with
-//     pkg/ctxkeys.PeerIdentityFrom — they never see *x509.Certificate.
+//     into a curated, fully-owned PeerIdentity (every slice/pointer is copied,
+//     so it never aliases the connection-cached *x509.Certificate) and stores
+//     it on the request context via pkg/ctxkeys.WithPeerIdentity. Downstream
+//     handlers read it with pkg/ctxkeys.PeerIdentityFrom — they never see
+//     *x509.Certificate.
 //
 // Chain validation (peer cert ↔ trust pool) is performed at handshake time
 // by the TLS layer (tls.Config.ClientAuth=RequireAndVerifyClientCert +
@@ -43,26 +50,85 @@ func MTLS() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 				attrs := []any{
-					slog.String("method", r.Method),
-					slog.String("path", r.URL.Path),
+					slog.String("method", logutil.Sanitize(r.Method)),
+					slog.String("path", logutil.Sanitize(r.URL.Path)),
 				}
 				if rid, ok := ctxkeys.RequestIDFrom(r.Context()); ok {
 					attrs = append(attrs, slog.String("request_id", rid))
 				}
-				slog.Warn("mtls rejected: no peer certificate", attrs...)
+				// r.Method / r.URL.Path are gosec-tainted net/http inputs. They are
+				// routed through logutil.Sanitize (strips control chars / newlines)
+				// and emitted as slog STRUCTURED attributes — slog quotes attr values,
+				// so there is no format-string interpolation / log-injection sink.
+				// gosec G706 taint analysis cannot clear the taint through a sanitize
+				// helper, so suppress at this single call site rather than re-adding a
+				// file-level exemption that would also blind future log sites.
+				slog.Warn("mtls rejected: no peer certificate", attrs...) //nolint:gosec // G706: see note above (sanitized + structured slog)
 				httputil.WriteError(r.Context(), w,
 					errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
 						"mTLS client certificate required"))
 				return
 			}
 			leaf := r.TLS.PeerCertificates[0]
-			id := ctxkeys.PeerIdentity{
-				Subject:  leaf.Subject,
-				DNSNames: leaf.DNSNames,
-				URIs:     leaf.URIs,
-			}
-			ctx := ctxkeys.WithPeerIdentity(r.Context(), id)
+			ctx := ctxkeys.WithPeerIdentity(r.Context(), ownedPeerIdentity(leaf))
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// ownedPeerIdentity projects the verified leaf certificate into a PeerIdentity
+// whose every slice and pointer is OWNED by the returned value, sharing no
+// backing storage with the *x509.Certificate. net/http caches the parsed peer
+// certificate on the TLS connection and reuses it across keep-alive requests
+// (crypto/tls: "the contents should not be modified"); without this copy a
+// downstream handler that mutated id.DNSNames / id.URIs / id.Subject.* would
+// corrupt the certificate for every subsequent request on that connection.
+//
+// ref: kubernetes/apiserver pkg/authentication/request/x509 — converts the
+// verified chain into an owned user.Info rather than aliasing the cert.
+func ownedPeerIdentity(leaf *x509.Certificate) ctxkeys.PeerIdentity {
+	return ctxkeys.PeerIdentity{
+		Subject:  clonePKIXName(leaf.Subject),
+		DNSNames: slices.Clone(leaf.DNSNames),
+		URIs:     cloneURLs(leaf.URIs),
+	}
+}
+
+// clonePKIXName deep-copies every slice-typed field of a pkix.Name so the
+// result shares no backing array with the source. The two scalar fields
+// (SerialNumber, CommonName) ride along on the struct assignment. Within
+// Names / ExtraNames, the per-element Value (an any holding immutable strings)
+// and Type (an OID identifier) are read-only by contract and not separately
+// cloned — doing so would be over-engineering.
+func clonePKIXName(in pkix.Name) pkix.Name {
+	out := in // copies scalars; slice headers are re-pointed below
+	out.Country = slices.Clone(in.Country)
+	out.Organization = slices.Clone(in.Organization)
+	out.OrganizationalUnit = slices.Clone(in.OrganizationalUnit)
+	out.Locality = slices.Clone(in.Locality)
+	out.Province = slices.Clone(in.Province)
+	out.StreetAddress = slices.Clone(in.StreetAddress)
+	out.PostalCode = slices.Clone(in.PostalCode)
+	out.Names = slices.Clone(in.Names)
+	out.ExtraNames = slices.Clone(in.ExtraNames)
+	return out
+}
+
+// cloneURLs copies the slice and each *url.URL element. Cloning only the slice
+// header would still share each *url.URL, letting a handler mutate the cert's
+// SAN URLs in place; url.URL's only pointer field (User *url.Userinfo) is
+// immutable, so a shallow per-element struct copy fully isolates each URL.
+func cloneURLs(in []*url.URL) []*url.URL {
+	if in == nil {
+		return nil
+	}
+	out := make([]*url.URL, len(in))
+	for i, u := range in {
+		if u == nil {
+			continue
+		}
+		cp := *u
+		out[i] = &cp
+	}
+	return out
 }

--- a/runtime/http/middleware/mtls.go
+++ b/runtime/http/middleware/mtls.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/httputil"
+)
+
+// MTLS returns the application-layer guard installed on listeners whose
+// auth chain contains kernel/auth.AuthMTLS. It does two things and only
+// those two:
+//
+//  1. Rejects requests that did not terminate as TLS or that present no peer
+//     certificate, returning a 401 envelope with code ERR_AUTH_UNAUTHORIZED.
+//  2. Extracts the leaf peer certificate's Subject, DNS SANs, and URI SANs
+//     into a curated PeerIdentity and stores it on the request context via
+//     pkg/ctxkeys.WithPeerIdentity. Downstream handlers read it with
+//     pkg/ctxkeys.PeerIdentityFrom — they never see *x509.Certificate.
+//
+// Chain validation (peer cert ↔ trust pool) is performed at handshake time
+// by the TLS layer (tls.Config.ClientAuth=RequireAndVerifyClientCert +
+// ClientCAs); the middleware is not a re-check.
+//
+// This middleware is deliberately decoupled from kernel/auth: it inspects
+// http.Request.TLS only, takes no auth-plan parameter, and depends only on
+// stdlib + pkg/* — keeping the AUTH-PLAN archtest boundary clean.
+//
+// ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — Authorizer model
+// (typed peer-identity surface vs raw *x509.Certificate).
+func MTLS() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+				httputil.WriteError(r.Context(), w,
+					errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
+						"mTLS client certificate required"))
+				return
+			}
+			leaf := r.TLS.PeerCertificates[0]
+			id := ctxkeys.PeerIdentity{
+				Subject:  leaf.Subject,
+				DNSNames: leaf.DNSNames,
+				URIs:     leaf.URIs,
+			}
+			ctx := ctxkeys.WithPeerIdentity(r.Context(), id)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/runtime/http/middleware/mtls_test.go
+++ b/runtime/http/middleware/mtls_test.go
@@ -1,0 +1,304 @@
+package middleware
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/http/tlsutil"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestMTLS_NoTLSStateReturns401(t *testing.T) {
+	t.Parallel()
+	handler := MTLS()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// req.TLS is nil by default
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMTLS_EmptyPeerChainReturns401(t *testing.T) {
+	t.Parallel()
+	handler := MTLS()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.TLS = &tls.ConnectionState{}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMTLS_401EnvelopeShape(t *testing.T) {
+	t.Parallel()
+	handler := MTLS()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ERR_AUTH_UNAUTHORIZED", errObj["code"])
+	assert.Equal(t, "mTLS client certificate required", errObj["message"])
+	assert.Equal(t, []any{}, errObj["details"])
+}
+
+func TestMTLS_PeerIdentityFieldsInjected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cert *x509.Certificate
+		want ctxkeys.PeerIdentity
+	}{
+		{
+			name: "cn_only",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{CommonName: "device-01"},
+			},
+			want: ctxkeys.PeerIdentity{
+				Subject: pkix.Name{CommonName: "device-01"},
+			},
+		},
+		{
+			name: "subject_with_org_ou",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName:         "device-02",
+					Organization:       []string{"acme"},
+					OrganizationalUnit: []string{"edge"},
+				},
+			},
+			want: ctxkeys.PeerIdentity{
+				Subject: pkix.Name{
+					CommonName:         "device-02",
+					Organization:       []string{"acme"},
+					OrganizationalUnit: []string{"edge"},
+				},
+			},
+		},
+		{
+			name: "dns_san",
+			cert: &x509.Certificate{
+				Subject:  pkix.Name{CommonName: "host-1"},
+				DNSNames: []string{"host-1.example.com", "alt.example.com"},
+			},
+			want: ctxkeys.PeerIdentity{
+				Subject:  pkix.Name{CommonName: "host-1"},
+				DNSNames: []string{"host-1.example.com", "alt.example.com"},
+			},
+		},
+		{
+			name: "uri_san_with_spiffe",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{CommonName: "wl-1"},
+				URIs: []*url.URL{
+					mustURL(t, "spiffe://example.org/ns/edge/sa/wl-1"),
+					mustURL(t, "urn:device:1"),
+				},
+			},
+			want: ctxkeys.PeerIdentity{
+				Subject: pkix.Name{CommonName: "wl-1"},
+				URIs: []*url.URL{
+					mustURL(t, "spiffe://example.org/ns/edge/sa/wl-1"),
+					mustURL(t, "urn:device:1"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got ctxkeys.PeerIdentity
+			var found bool
+			handler := MTLS()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got, found = ctxkeys.PeerIdentityFrom(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{tc.cert}}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.True(t, found)
+			assert.Equal(t, tc.want.Subject.CommonName, got.Subject.CommonName)
+			assert.Equal(t, tc.want.Subject.Organization, got.Subject.Organization)
+			assert.Equal(t, tc.want.Subject.OrganizationalUnit, got.Subject.OrganizationalUnit)
+			assert.Equal(t, tc.want.DNSNames, got.DNSNames)
+			assert.Equal(t, tc.want.URIs, got.URIs)
+		})
+	}
+}
+
+// ─── Integration: end-to-end handshake via httptest.NewUnstartedServer ───────
+
+// integTestChain holds server + client materials for a full mTLS round-trip.
+type integTestChain struct {
+	rootCertPEM   []byte
+	serverCertPEM []byte
+	serverKeyPEM  []byte
+	clientCert    tls.Certificate
+	clientLeaf    *x509.Certificate
+}
+
+func genIntegChain(t *testing.T) integTestChain {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "integ-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	rootCert, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+	rootCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+
+	// Server leaf — must include 127.0.0.1 / localhost in SAN for httptest.
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "integ-server"},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+
+	// Client leaf — CN + DNS SAN + URI SAN so the test asserts a non-trivial PeerIdentity.
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	spiffeURI, err := url.Parse("spiffe://example.org/ns/edge/sa/integ-client")
+	require.NoError(t, err)
+	clientTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject: pkix.Name{
+			CommonName:   "integ-client",
+			Organization: []string{"acme"},
+		},
+		DNSNames:    []string{"integ-client.example.com"},
+		URIs:        []*url.URL{spiffeURI},
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, rootCert, &clientKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	clientLeaf, err := x509.ParseCertificate(clientDER)
+	require.NoError(t, err)
+
+	return integTestChain{
+		rootCertPEM:   rootCertPEM,
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+		clientCert: tls.Certificate{
+			Certificate: [][]byte{clientDER},
+			PrivateKey:  clientKey,
+			Leaf:        clientLeaf,
+		},
+		clientLeaf: clientLeaf,
+	}
+}
+
+func TestMTLS_IntegrationRoundTripViaHTTPTestServer(t *testing.T) {
+	chain := genIntegChain(t)
+
+	caPool, err := tlsutil.NewClientCAPool(chain.rootCertPEM)
+	require.NoError(t, err)
+	serverCfg, err := tlsutil.NewServerMTLSConfig(chain.serverCertPEM, chain.serverKeyPEM, caPool)
+	require.NoError(t, err)
+
+	var seenIdentity ctxkeys.PeerIdentity
+	var seenOK bool
+	handler := MTLS()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenIdentity, seenOK = ctxkeys.PeerIdentityFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = serverCfg
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	clientCAs := x509.NewCertPool()
+	require.True(t, clientCAs.AppendCertsFromPEM(chain.rootCertPEM))
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      clientCAs,
+				Certificates: []tls.Certificate{chain.clientCert},
+				MinVersion:   tls.VersionTLS13,
+			},
+		},
+	}
+
+	resp, err := client.Get(srv.URL + "/")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, seenOK)
+	assert.Equal(t, "integ-client", seenIdentity.Subject.CommonName)
+	assert.Equal(t, []string{"acme"}, seenIdentity.Subject.Organization)
+	assert.Equal(t, []string{"integ-client.example.com"}, seenIdentity.DNSNames)
+	require.Len(t, seenIdentity.URIs, 1)
+	assert.Equal(t, "spiffe://example.org/ns/edge/sa/integ-client", seenIdentity.URIs[0].String())
+}

--- a/runtime/http/middleware/mtls_test.go
+++ b/runtime/http/middleware/mtls_test.go
@@ -170,6 +170,68 @@ func TestMTLS_PeerIdentityFieldsInjected(t *testing.T) {
 	}
 }
 
+// TestMTLS_PeerIdentityIsolatedFromCert locks F1 (cluster C1): the PeerIdentity
+// handed to handlers must own all of its slices/pointers, so a handler mutating
+// it cannot corrupt the connection-cached *x509.Certificate (which net/http
+// reuses across keep-alive requests). The handler below mutates every mutable
+// field of the identity; afterwards the source cert must be byte-for-byte
+// unchanged.
+func TestMTLS_PeerIdentityIsolatedFromCert(t *testing.T) {
+	t.Parallel()
+
+	cert := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "wl-1",
+			Organization:       []string{"acme"},
+			OrganizationalUnit: []string{"edge"},
+			Country:            []string{"US"},
+			Locality:           []string{"sf"},
+			Province:           []string{"ca"},
+			StreetAddress:      []string{"1 main"},
+			PostalCode:         []string{"94105"},
+		},
+		DNSNames: []string{"host-1.example.com", "alt.example.com"},
+		URIs: []*url.URL{
+			mustURL(t, "spiffe://example.org/ns/edge/sa/wl-1"),
+		},
+	}
+
+	// Snapshot the cert's mutable state before the request.
+	wantDNS := append([]string(nil), cert.DNSNames...)
+	wantOrg := append([]string(nil), cert.Subject.Organization...)
+	wantOU := append([]string(nil), cert.Subject.OrganizationalUnit...)
+	wantCountry := append([]string(nil), cert.Subject.Country...)
+	wantURIHost := cert.URIs[0].Host
+	wantURIPath := cert.URIs[0].Path
+
+	handler := MTLS()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := ctxkeys.PeerIdentityFrom(r.Context())
+		require.True(t, ok)
+		// Hostile handler: mutate every slice/pointer field in place.
+		id.DNSNames[0] = "evil.example.com"
+		id.Subject.Organization[0] = "evil-org"
+		id.Subject.OrganizationalUnit[0] = "evil-ou"
+		id.Subject.Country[0] = "ZZ"
+		id.URIs[0].Host = "evil.example.org"
+		id.URIs[0].Path = "/evil"
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// The source certificate must be untouched by the handler's mutations.
+	assert.Equal(t, wantDNS, cert.DNSNames, "cert.DNSNames must not alias the identity")
+	assert.Equal(t, wantOrg, cert.Subject.Organization, "cert.Subject.Organization must not alias")
+	assert.Equal(t, wantOU, cert.Subject.OrganizationalUnit, "cert.Subject.OrganizationalUnit must not alias")
+	assert.Equal(t, wantCountry, cert.Subject.Country, "cert.Subject.Country must not alias")
+	assert.Equal(t, wantURIHost, cert.URIs[0].Host, "cert.URIs[0] must not alias the identity URL")
+	assert.Equal(t, wantURIPath, cert.URIs[0].Path, "cert.URIs[0] must not alias the identity URL")
+}
+
 // ─── Integration: end-to-end handshake via httptest.NewUnstartedServer ───────
 
 // integTestChain holds server + client materials for a full mTLS round-trip.

--- a/runtime/http/tlsutil/server.go
+++ b/runtime/http/tlsutil/server.go
@@ -1,0 +1,87 @@
+// Package tlsutil builds server-side TLS configurations for GoCell HTTP
+// listeners.
+//
+// Scope: enabling helpers, not a substitute for a TLS-terminating proxy. Large
+// scale mTLS termination (rotation, OCSP stapling, dynamic SNI) is delegated to
+// the K8s/Service Mesh layer; this package only covers the "I have PEM bytes,
+// give me a correct *tls.Config" path used during framework wiring.
+//
+// ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — MTLSServerConfig field set.
+// ref: kubernetes/apiserver pkg/server/secure_serving.go — server cert plumbing.
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// NewServerMTLSConfig builds a *tls.Config suitable for server-side mutual
+// TLS. The returned config:
+//
+//   - pins MinVersion to TLS 1.3 (fail-closed; no negotiation down to weaker
+//     suites; matches spiffetls.MTLSServerConfig and modern Go TLS defaults);
+//   - sets ClientAuth = tls.RequireAndVerifyClientCert so the handshake layer
+//     rejects clients that present no certificate or one not chained to
+//     clientCAs;
+//   - installs clientCAs as the verification pool;
+//   - parses certPEMBlock + keyPEMBlock via tls.X509KeyPair as the server
+//     identity.
+//
+// Returns an error on PEM parse failure, cert/key mismatch, or nil clientCAs.
+// Callers should usually feed the result to bootstrap.WithListenerTLS.
+func NewServerMTLSConfig(certPEMBlock, keyPEMBlock []byte, clientCAs *x509.CertPool) (*tls.Config, error) {
+	if len(certPEMBlock) == 0 {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"tlsutil: certPEMBlock is empty")
+	}
+	if len(keyPEMBlock) == 0 {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"tlsutil: keyPEMBlock is empty")
+	}
+	if clientCAs == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"tlsutil: clientCAs is nil; build a pool with NewClientCAPool")
+	}
+	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"tlsutil: parse server cert/key PEM", err)
+	}
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}
+
+// NewClientCAPool parses one or more PEM-encoded CA bundles into an
+// x509.CertPool used to verify incoming peer certificates. Multiple
+// bundles are appended into the same pool; intra-bundle concatenation
+// (`cat ca1.pem ca2.pem > bundle.pem`) is also supported.
+//
+// Returns an error when no input is supplied or none of the supplied bytes
+// parse to at least one certificate.
+func NewClientCAPool(caPEMBlocks ...[]byte) (*x509.CertPool, error) {
+	if len(caPEMBlocks) == 0 {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"tlsutil: no CA PEM bundles supplied")
+	}
+	pool := x509.NewCertPool()
+	any := false
+	for _, b := range caPEMBlocks {
+		if len(b) == 0 {
+			continue
+		}
+		if pool.AppendCertsFromPEM(b) {
+			any = true
+		}
+	}
+	if !any {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"tlsutil: no valid CA certificates parsed from supplied PEM bundles")
+	}
+	return pool, nil
+}

--- a/runtime/http/tlsutil/server.go
+++ b/runtime/http/tlsutil/server.go
@@ -31,14 +31,22 @@ import (
 //
 // Returns an error on PEM parse failure, cert/key mismatch, or nil clientCAs.
 // Callers should usually feed the result to bootstrap.WithListenerTLS.
+//
+// CALLERS MUST NOT MUTATE the returned *tls.Config's MinVersion, ClientAuth,
+// or ClientCAs fields. The builder pins these to fail-closed defaults; mutating
+// them post-return downgrades the security posture without compiler/runtime
+// signal. If you need different values, re-call this builder with the desired
+// inputs; do not edit the returned config in place. (This is a Go ecosystem
+// limitation — crypto/tls.Server accepts only *tls.Config, so a sealed
+// opaque wrapper is not feasible here.)
 func NewServerMTLSConfig(certPEMBlock, keyPEMBlock []byte, clientCAs *x509.CertPool) (*tls.Config, error) {
 	if len(certPEMBlock) == 0 {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
-			"tlsutil: certPEMBlock is empty")
+			"tlsutil: certPEMBlock is empty; pass the PEM-encoded server certificate (see os.ReadFile)")
 	}
 	if len(keyPEMBlock) == 0 {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
-			"tlsutil: keyPEMBlock is empty")
+			"tlsutil: keyPEMBlock is empty; pass the PEM-encoded server private key (see os.ReadFile)")
 	}
 	if clientCAs == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,

--- a/runtime/http/tlsutil/server.go
+++ b/runtime/http/tlsutil/server.go
@@ -70,26 +70,30 @@ func NewServerMTLSConfig(certPEMBlock, keyPEMBlock []byte, clientCAs *x509.CertP
 // bundles are appended into the same pool; intra-bundle concatenation
 // (`cat ca1.pem ca2.pem > bundle.pem`) is also supported.
 //
-// Returns an error when no input is supplied or none of the supplied bytes
-// parse to at least one certificate.
+// Fail-closed: every supplied bundle MUST contribute at least one parseable
+// certificate. An empty or unparseable bundle returns an error identifying
+// its positional index (server-side detail) — silently dropping a bundle
+// would shrink the trust-anchor set without operator awareness, a fail-open
+// misconfiguration for a verification pool. Returns an error when no input
+// is supplied at all.
+//
+// Note on AppendCertsFromPEM semantics: the stdlib helper reports whether ANY
+// certificate was parsed; PEM blocks that are not CERTIFICATE (CRLs, keys) are
+// ignored. A bundle of only such blocks therefore yields zero certs and is
+// rejected here — correct for a CA verification pool, whose every input is
+// meant to contribute trust anchors.
 func NewClientCAPool(caPEMBlocks ...[]byte) (*x509.CertPool, error) {
 	if len(caPEMBlocks) == 0 {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			"tlsutil: no CA PEM bundles supplied")
 	}
 	pool := x509.NewCertPool()
-	any := false
-	for _, b := range caPEMBlocks {
-		if len(b) == 0 {
-			continue
+	for i, b := range caPEMBlocks {
+		if !pool.AppendCertsFromPEM(b) {
+			return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+				"tlsutil: CA PEM bundle contained no parseable certificate",
+				errcode.WithInternal(errcode.InternalAttr("bundleIndex", i)))
 		}
-		if pool.AppendCertsFromPEM(b) {
-			any = true
-		}
-	}
-	if !any {
-		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
-			"tlsutil: no valid CA certificates parsed from supplied PEM bundles")
 	}
 	return pool, nil
 }

--- a/runtime/http/tlsutil/server_test.go
+++ b/runtime/http/tlsutil/server_test.go
@@ -1,0 +1,175 @@
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testChain holds PEM-encoded materials produced by genTestChain.
+type testChain struct {
+	rootCertPEM   []byte
+	serverCertPEM []byte
+	serverKeyPEM  []byte
+}
+
+// genTestChain produces a self-signed root CA + a server leaf signed by the
+// root, all in PEM form. Uses ECDSA P-256 (fast, ~1ms total). The test only
+// needs material that tls.X509KeyPair will accept and x509.AppendCertsFromPEM
+// will parse — no real handshake is performed at the tlsutil package level.
+func genTestChain(t *testing.T) testChain {
+	t.Helper()
+
+	// Root CA.
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	rootCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+
+	// Server leaf.
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-server"},
+		DNSNames:     []string{"localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	rootCert, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+
+	return testChain{
+		rootCertPEM:   rootCertPEM,
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+	}
+}
+
+func TestNewServerMTLSConfig_ValidSetsTLS13RequireAndCAs(t *testing.T) {
+	chain := genTestChain(t)
+	pool, err := NewClientCAPool(chain.rootCertPEM)
+	require.NoError(t, err)
+
+	cfg, err := NewServerMTLSConfig(chain.serverCertPEM, chain.serverKeyPEM, pool)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+	assert.Same(t, pool, cfg.ClientCAs)
+	require.Len(t, cfg.Certificates, 1)
+}
+
+func TestNewServerMTLSConfig_ErrorPaths(t *testing.T) {
+	chain := genTestChain(t)
+	pool, err := NewClientCAPool(chain.rootCertPEM)
+	require.NoError(t, err)
+
+	t.Run("empty_cert_PEM_returns_error", func(t *testing.T) {
+		cfg, err := NewServerMTLSConfig(nil, chain.serverKeyPEM, pool)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("empty_key_PEM_returns_error", func(t *testing.T) {
+		cfg, err := NewServerMTLSConfig(chain.serverCertPEM, nil, pool)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("malformed_cert_PEM_returns_error", func(t *testing.T) {
+		cfg, err := NewServerMTLSConfig([]byte("not a pem"), chain.serverKeyPEM, pool)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("mismatched_cert_key_returns_error", func(t *testing.T) {
+		other := genTestChain(t)
+		cfg, err := NewServerMTLSConfig(chain.serverCertPEM, other.serverKeyPEM, pool)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("nil_ClientCAs_returns_error", func(t *testing.T) {
+		cfg, err := NewServerMTLSConfig(chain.serverCertPEM, chain.serverKeyPEM, nil)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+}
+
+func TestNewClientCAPool_SingleAndMultipleBundles(t *testing.T) {
+	a := genTestChain(t)
+	b := genTestChain(t)
+
+	t.Run("single_PEM_block", func(t *testing.T) {
+		pool, err := NewClientCAPool(a.rootCertPEM)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.Subjects(), 1) //nolint:staticcheck // Subjects() simplest count; alternatives require typed-cert reflection
+	})
+
+	t.Run("multiple_PEM_blocks_merged", func(t *testing.T) {
+		pool, err := NewClientCAPool(a.rootCertPEM, b.rootCertPEM)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.Subjects(), 2) //nolint:staticcheck // Subjects() simplest count; alternatives require typed-cert reflection
+	})
+
+	t.Run("concatenated_PEM_blocks_merged", func(t *testing.T) {
+		joined := append([]byte{}, a.rootCertPEM...)
+		joined = append(joined, b.rootCertPEM...)
+		pool, err := NewClientCAPool(joined)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		assert.Len(t, pool.Subjects(), 2) //nolint:staticcheck // Subjects() simplest count; alternatives require typed-cert reflection
+	})
+}
+
+func TestNewClientCAPool_NoValidCertReturnsError(t *testing.T) {
+	t.Run("no_input", func(t *testing.T) {
+		pool, err := NewClientCAPool()
+		assert.Error(t, err)
+		assert.Nil(t, pool)
+	})
+
+	t.Run("garbage_input", func(t *testing.T) {
+		pool, err := NewClientCAPool([]byte("not a cert"))
+		assert.Error(t, err)
+		assert.Nil(t, pool)
+	})
+
+	t.Run("empty_bytes", func(t *testing.T) {
+		pool, err := NewClientCAPool([]byte{})
+		assert.Error(t, err)
+		assert.Nil(t, pool)
+	})
+}

--- a/runtime/http/tlsutil/server_test.go
+++ b/runtime/http/tlsutil/server_test.go
@@ -173,3 +173,30 @@ func TestNewClientCAPool_NoValidCertReturnsError(t *testing.T) {
 		assert.Nil(t, pool)
 	})
 }
+
+// TestNewClientCAPool_FailsClosedOnBadBundleInMix locks the fail-closed
+// contract (F4 / cluster C2): a non-contributing bundle anywhere in the
+// variadic input fails the whole construction, regardless of position, even
+// when another bundle is valid. The pre-fix code returned a pool that
+// silently omitted the bad bundle's intended anchors.
+func TestNewClientCAPool_FailsClosedOnBadBundleInMix(t *testing.T) {
+	valid := genTestChain(t)
+
+	t.Run("valid_then_garbage_returns_error", func(t *testing.T) {
+		pool, err := NewClientCAPool(valid.rootCertPEM, []byte("not a cert"))
+		assert.Error(t, err)
+		assert.Nil(t, pool)
+	})
+
+	t.Run("valid_then_empty_returns_error", func(t *testing.T) {
+		pool, err := NewClientCAPool(valid.rootCertPEM, []byte{})
+		assert.Error(t, err)
+		assert.Nil(t, pool)
+	})
+
+	t.Run("garbage_then_valid_returns_error", func(t *testing.T) {
+		pool, err := NewClientCAPool([]byte("not a cert"), valid.rootCertPEM)
+		assert.Error(t, err)
+		assert.Nil(t, pool)
+	})
+}

--- a/tools/archtest/peer_identity_fields_frozen_test.go
+++ b/tools/archtest/peer_identity_fields_frozen_test.go
@@ -1,0 +1,164 @@
+package archtest
+
+// peer_identity_fields_frozen_test.go locks the curated field set of
+// pkg/ctxkeys.PeerIdentity.
+//
+// INVARIANT: PEER-IDENTITY-FIELDS-FROZEN-01
+//
+// ctxkeys.PeerIdentity is the curated request-scope view of a verified leaf
+// X.509 client certificate (WM-32, ADR docs/architecture/
+// 202605290130-049-adr-mtls-server-builder-and-identity-hook.md §Decision-4).
+// The ADR's design promise is that the type surfaces exactly
+// {Subject pkix.Name, DNSNames []string, URIs []*url.URL} and DELIBERATELY
+// never exposes the raw *x509.Certificate, so downstream handlers cannot
+// couple to the x509 internal representation.
+//
+// This reflect lock is what makes that promise genuinely Hard rather than a
+// godoc convention: adding any field (most dangerously `Raw *x509.Certificate`),
+// removing one, embedding a struct, unexporting a field, or changing a field's
+// type all trip an exact-set assertion in CI. Before this archtest, the
+// "no raw cert / curated field set" claim was enforced by nothing but a
+// comment in peer_identity.go — see ADR §Decision-4 (which this archtest
+// upgrades from "godoc 约定" to archtest-enforced) and the F1–F3 review of
+// PR #1250.
+//
+// AI-robust rating (.claude/rules/gocell/ai-robust.md §Hard 范本目录,
+// "codegen funnel + golden" sibling = reflect field-freeze; see
+// DETAILS-SEALED-FIELD-FROZEN-01 / SUBSCRIBERS-DERIVED-FIELD-FROZEN-01 /
+// OUTBOX-HANDLERESULT-FIELDS-FROZEN-01): Hard. A field-set drift is
+// inexpressible without a CI-visible failure. NOTE the scope boundary — this
+// freezes the FIELD SET (the "no raw cert" surface). It does NOT enforce that
+// runtime/http/middleware.MTLS is the SOLE producer of PeerIdentity values;
+// that sole-producer property is an unenforced convention (a cross-package
+// context.WithValue setter cannot be sealed in Go — caller-allowlist would be
+// at most Medium), and is intentionally NOT claimed as Hard in the ADR.
+//
+// Blind spots of a reflect field-freeze, each covered below or by the reverse
+// self-check (TestPeerIdentityFieldsFrozen01_ReverseBlindSpot):
+//   - Embedding: an anonymous field would smuggle a whole struct's surface
+//     past a name-keyed check → guarded explicitly (f.Anonymous → violation).
+//   - Type alias re-shape (`type PeerIdentity = otherStruct`): reflect resolves
+//     to the underlying struct, so the exact field-set check still fires.
+//   - Wrong field type / unexported field / extra / missing field: covered by
+//     the exact name→type map + NumField check.
+// The reverse self-check proves the detector is non-vacuous by running it
+// against deliberately-malformed local structs.
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+)
+
+// peerIdentityWantFields is the frozen curated field set: name → reflect type
+// string. Changing this set is a wire/contract surface change that must be made
+// together with ADR 202605290130-049 Row 6.
+var peerIdentityWantFields = map[string]string{
+	"Subject":  "pkix.Name",
+	"DNSNames": "[]string",
+	"URIs":     "[]*url.URL",
+}
+
+// checkPeerIdentityShape returns a list of violation messages for dt against
+// the frozen PeerIdentity field set; an empty result means dt conforms. It is
+// extracted from the test body so the reverse self-check can prove the detector
+// flags malformed shapes (non-vacuous Hard guard).
+func checkPeerIdentityShape(dt reflect.Type) []string {
+	if dt.Kind() != reflect.Struct {
+		return []string{fmt.Sprintf("Kind = %s, want struct", dt.Kind())}
+	}
+	var violations []string
+	if dt.NumField() != len(peerIdentityWantFields) {
+		violations = append(violations, fmt.Sprintf(
+			"NumField = %d, want exactly %d", dt.NumField(), len(peerIdentityWantFields)))
+	}
+	for i := 0; i < dt.NumField(); i++ {
+		f := dt.Field(i)
+		if f.Anonymous {
+			violations = append(violations, fmt.Sprintf(
+				"field %q is embedded (embedding re-opens the cert-internal surface)", f.Name))
+			continue
+		}
+		if !f.IsExported() {
+			violations = append(violations, fmt.Sprintf(
+				"field %q is unexported (curated fields are the handler read surface)", f.Name))
+		}
+		ts := f.Type.String()
+		if ts == "x509.Certificate" || ts == "*x509.Certificate" {
+			violations = append(violations, fmt.Sprintf(
+				"field %q exposes raw %s (the curated type never surfaces the raw certificate)", f.Name, ts))
+		}
+		wantType, ok := peerIdentityWantFields[f.Name]
+		if !ok {
+			violations = append(violations, fmt.Sprintf("unexpected field %q (%s)", f.Name, ts))
+			continue
+		}
+		if ts != wantType {
+			violations = append(violations, fmt.Sprintf(
+				"field %q type = %q, want %q", f.Name, ts, wantType))
+		}
+	}
+	return violations
+}
+
+func TestPeerIdentityFieldsFrozen01(t *testing.T) {
+	t.Parallel()
+	violations := checkPeerIdentityShape(reflect.TypeOf(ctxkeys.PeerIdentity{}))
+	for _, v := range violations {
+		t.Errorf("PEER-IDENTITY-FIELDS-FROZEN-01: %s. The curated set is %v; if this change is "+
+			"intentional, update ADR 202605290130-049 Row 6 + §Decision-4 and this golden in the same PR.",
+			v, peerIdentityWantFields)
+	}
+}
+
+// TestPeerIdentityFieldsFrozen01_ReverseBlindSpot proves checkPeerIdentityShape
+// is not vacuous: a conforming shape yields zero violations, and each
+// deliberately-malformed shape (raw-cert field, embedding, wrong type) yields
+// at least one. If this regresses, the freeze above could silently pass on a
+// drifted PeerIdentity.
+func TestPeerIdentityFieldsFrozen01_ReverseBlindSpot(t *testing.T) {
+	t.Parallel()
+
+	type good struct {
+		Subject  pkix.Name
+		DNSNames []string
+		URIs     []*url.URL
+	}
+	if v := checkPeerIdentityShape(reflect.TypeOf(good{})); len(v) != 0 {
+		t.Errorf("PEER-IDENTITY-FIELDS-FROZEN-01 self-test: detector flagged a conforming shape "+
+			"(vacuous-pass risk): %v", v)
+	}
+
+	type withRawCert struct {
+		Subject  pkix.Name
+		DNSNames []string
+		URIs     []*url.URL
+		Raw      *x509.Certificate
+	}
+	type embedded struct {
+		pkix.Name
+		DNSNames []string
+		URIs     []*url.URL
+	}
+	type wrongType struct {
+		Subject  string // was pkix.Name
+		DNSNames []string
+		URIs     []*url.URL
+	}
+	bad := map[string]reflect.Type{
+		"extra-raw-cert-field": reflect.TypeOf(withRawCert{}),
+		"embedded-field":       reflect.TypeOf(embedded{}),
+		"wrong-field-type":     reflect.TypeOf(wrongType{}),
+	}
+	for name, dt := range bad {
+		if v := checkPeerIdentityShape(dt); len(v) == 0 {
+			t.Errorf("PEER-IDENTITY-FIELDS-FROZEN-01 self-test: detector passed malformed shape %q "+
+				"(blind spot): expected at least one violation", name)
+		}
+	}
+}

--- a/tools/archtest/pkg_ctxkeys_no_cell_model_test.go
+++ b/tools/archtest/pkg_ctxkeys_no_cell_model_test.go
@@ -128,6 +128,7 @@ var allowedPkgCtxkeysValueDeclNames = map[string]struct{}{
 	"traceParent":   {},
 	"requestID":     {},
 	"realIP":        {},
+	"peerIdentity":  {}, // WM-32: mTLS peer X.509 identity (networking, not cell-model)
 }
 
 // allowedPkgCtxkeysFuncNames is the golden allowlist of function declaration
@@ -143,13 +144,16 @@ var allowedPkgCtxkeysFuncNames = map[string]struct{}{
 	"WithSpanID": {}, "SpanIDFrom": {},
 	"WithRequestID": {}, "RequestIDFrom": {},
 	"WithRealIP": {}, "RealIPFrom": {},
+	// WM-32: mTLS peer X.509 identity injected by runtime/http/middleware.MTLS.
+	"WithPeerIdentity": {}, "PeerIdentityFrom": {},
 }
 
 // allowedPkgCtxkeysTypeNames is the golden allowlist of top-level type
 // declarations in pkg/ctxkeys/ production .go files. Only the unexported
 // ctxKey alias is permitted.
 var allowedPkgCtxkeysTypeNames = map[string]struct{}{
-	"ctxKey": {},
+	"ctxKey":       {},
+	"PeerIdentity": {}, // WM-32: curated mTLS peer X.509 subset (Subject/DNSNames/URIs)
 }
 
 // allowedPkgCtxkeysKeyStringValues is the golden allowlist of string-literal
@@ -163,6 +167,7 @@ var allowedPkgCtxkeysKeyStringValues = map[string]struct{}{
 	"traceparent":    {},
 	"request_id":     {},
 	"real_ip":        {},
+	"peer_identity":  {}, // WM-32: mTLS peer X.509 identity (networking, not cell-model)
 }
 
 // goldenSelfFile is the module-relative slash path of this file; used as the


### PR DESCRIPTION
## Summary

Adds the framework-enabling minimum for mTLS that issue #631 requested. Trade-off (from the issue body) honored: framework only ships a builder + identity hook; large-scale mTLS termination stays K8s / Service Mesh territory.

- **TLS builder** — `runtime/http/tlsutil.NewServerMTLSConfig(certPEM, keyPEM, clientCAs)`: pins MinVersion = TLS 1.3, ClientAuth = RequireAndVerifyClientCert; PEM-bytes in (no FS dep). Companion: `NewClientCAPool(...)` for multi-bundle pools.
- **Middleware + peer-identity hook** — `runtime/http/middleware.MTLS()`: presence guard (401 on no peer cert) + extracts curated `PeerIdentity{Subject, DNSNames, URIs}` into request ctx. Handlers read it via `pkg/ctxkeys.PeerIdentityFrom(ctx)`. Raw `*x509.Certificate` deliberately not surfaced.
- **Bootstrap rewire** — `runtime/bootstrap/auth_plan_apply.go` switches `case kauth.AuthMTLS:` to call `middleware.MTLS()`. Inline `mtlsMiddleware()` + section header + history comment + `TestMtlsMiddleware_PeerCertPresence` deleted; equivalent coverage lives in the new `mtls_test.go` (plus a `httptest.NewUnstartedServer`-driven round-trip).
- **Doc sync** — `runtime-api.md` AuthMTLS row + `auth_plan_describe.go` godoc updated. ADR 202605290130-049 captures the design.
- **archtest allowlist** — `PKG-CTXKEYS-NO-CELL-MODEL-01` golden lists `peerIdentity` / `PeerIdentity` / `WithPeerIdentity` / `PeerIdentityFrom` / `peer_identity` per the archtest's own escape valve (networking key, not cell-model).

Refs: WM-32 (backlog_later §7)
ref: spiffe/go-spiffe v2/spiffetls/tlsconfig — MTLSServerConfig
ref: kubernetes/apiserver pkg/server/secure_serving.go

Closes #631

## AI HARD form inventory

| Constraint | Form | Tier |
|---|---|---|
| `middleware/mtls.go` doesn't construct `AuthMTLS{}` | AUTH-PLAN-04 archtest (existing) | Hard |
| Error message never carries bare `"mtls"` literal | AUTH-PLAN-01 archtest (existing) | Hard |
| `MTLS()` zero interaction with kernel/auth | Signature takes no auth type; body deps = stdlib + pkg/* | Hard (type-system) |
| `tlsutil` only takes PEM `[]byte` | Signature | Hard (type-system) |
| Builder always emits TLS 1.3 + RequireAndVerify | emit-time: sole success path hardcodes fields (no branch yields a weak config); post-return: mutable stdlib *tls.Config | emit-time Hard (type-system) + post-return-mutation Soft (crypto/tls.Server takes *tls.Config; no opaque wrapper — ADR 049 Row 5) |
| PeerIdentity field set curated (no `Raw *x509.Certificate`) | reflect field-freeze archtest `PEER-IDENTITY-FIELDS-FROZEN-01` (+ non-vacuous reverse self-check) | Hard |
| `case AuthMTLS:` is the only entry-point | Sealed `ListenerAuth` interface + type-switch | Hard (type-system) |

The only Soft form is the builder's **post-return mutation** surface (Go ecosystem ceiling: `crypto/tls.Server` takes `*tls.Config`, no opaque wrapper — ADR 049 Row 5). `WithPeerIdentity`'s sole-producer property is an **explicitly-unenforced convention** (a cross-package `context.WithValue` setter cannot be sealed in Go and is not security-load-bearing) — documented as such in godoc + ADR, deliberately not claimed as Hard.

## Post-review hardening (F1–F5, commit 1889021bf)

Review of this PR surfaced five findings; all fixed in-branch (no follow-up issues):

- **F1 (P2·Cx1):** `runtime/http/middleware/mtls.go` now deep-clones the peer identity (`ownedPeerIdentity`: DNSNames + each `*url.URL` + all 9 `pkix.Name` slices) so the ctx identity never aliases the connection-cached `*x509.Certificate` (net/http reuses it across keep-alive requests); + mutation-isolation regression test.
- **F2 (P3·Cx1):** sole-producer overclaim removed; documented as an unenforced convention (see above).
- **F3 (P2·Cx1):** ADR 049 §Decision-4 / Row 5 / Row 6 / closing reconciled — the "single sanctioned holder = Structurally Hard" contradiction is gone; this inventory updated to match.
- **F4 (P2·Cx1):** `runtime/http/tlsutil.NewClientCAPool` is now fail-closed — every supplied bundle must contribute ≥1 parseable cert, else error with the bundle index (was: silently dropped a bad bundle when another was valid).
- **F5 (P2·Cx1):** mtls reject-log routes method/path through `logutil.Sanitize` + a line-level `gosec G706` nolint; the file-level G706 exemption added by this PR is reverted (narrower blind spot — Sanitize alone does not clear gosec's taint).

New Hard guard: `PEER-IDENTITY-FIELDS-FROZEN-01` (reflect field-freeze, `tools/archtest/peer_identity_fields_frozen_test.go`).

## Out of scope (explicit, with blockers — no follow-up issues required)

| Item | Blocker |
|---|---|
| `NewClientMTLSConfig` (outbound) | 0 outbound mTLS consumers in cells/ + adapters/ today |
| Dynamic cert reload / `GetCertificate` callback | Trade-off: K8s/mesh territory |
| OCSP stapling / CRL | Same trade-off |
| SPIFFE typed-ID parsing | URIs already raw `*url.URL`; framework should not pre-bind spiffe/go-spiffe |
| `VerifyPeerCertificate` callback hook | Handshake-layer already validates chain; business hook = over-engineer |
| `bootstrap.WithListenerMTLS(...)` convenience option | YAGNI; caller two lines reach the same wiring |

## Test plan

- [x] `go test ./pkg/ctxkeys/... ./runtime/http/tlsutil/... ./runtime/http/middleware/... ./runtime/bootstrap/...` — all green
- [x] Coverage: tlsutil 100%, pkg/ctxkeys 100%, middleware (whole package incl. MTLS) 92%
- [x] `go test ./...` — 0 new failures; 3 pre-existing develop-baseline archtest reds on `adapters/mqtt/*` (TestAdaptersExportedTypesManagedResourceOrOptOut + TestErrcodeMessageConstLiteral + an unrelated mqtt rule) are reproducible on `origin/develop` without this branch
- [x] `golangci-lint run --new-from-merge-base=origin/develop ./...` — 0 issues
- [x] `go build -tags=integration ./...` — clean
- [x] `bash hack/verify-archtest-invariants.sh` — PR-time invariants green
- [x] Integration sub-test `TestMTLS_IntegrationRoundTripViaHTTPTestServer` exercises real `httptest.NewUnstartedServer` + TLS 1.3 + client cert handshake and asserts `PeerIdentity{CN, DNSNames, URIs}` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
