### PR TITLE
feat(webhook): kernel/webhook foundation — HMAC signer/verifier/source + errcode + redaction [KERNEL-WEBHOOK-01 PR-1]

### DIFF
--- a/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+++ b/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
@@ -1,0 +1,105 @@
+# ADR: Webhook signing algorithm — HMAC-SHA256 only, sealed funnel
+
+- Status: Accepted
+- Date: 2026-05-29
+- Context: KERNEL-WEBHOOK-01 PR-1 (#1156)
+- Supersedes / amends: none (greenfield)
+
+## Context
+
+`kernel/webhook` is the pure-computation core for GoCell's bidirectional
+webhook capability (inbound receiver verification + outbound dispatcher
+signing). The signing algorithm and the wire signature format are decided here,
+in the same PR that implements them, rather than deferred — the signer/verifier
+code IS the decision, and a dangling forward reference to a later PR's ADR would
+leave the security-critical choice undocumented at the point of implementation.
+
+## Decision
+
+1. **HMAC-SHA256 is the only legal signing algorithm.** `webhook.Algorithm` has
+   exactly one valid value, `AlgorithmHMACSHA256`; `Algorithm.Validate` rejects
+   every other value (including any SHA-1 form) with
+   `errcode.ErrWebhookAlgorithmUnsupported`. There is no algorithm-negotiation
+   path and no downgrade path.
+
+2. **Signed content is Svix-aligned:** the byte concatenation
+   `"{deliveryID}.{unixTimestamp}.{body}"`, MAC'd with HMAC-SHA256 over the
+   source secret. The signature header value is `"v1,<base64(mac)>"`. A
+   space-separated list of such tokens is accepted on verify so a sender can
+   rotate secrets without a flag day; the receiver accepts the delivery if any
+   presented token's decoded MAC matches the recomputed MAC.
+
+3. **Constant-time comparison is mandatory.** Verification compares the raw MAC
+   bytes with `crypto/hmac.Equal`. `bytes.Equal` / `==` over signature bytes is
+   forbidden.
+
+4. **Replay defense via a bidirectional timestamp window.** The verifier rejects
+   a delivery whose signed timestamp is more than the tolerance (default ±5min)
+   from the verifier's clock, in either direction, with
+   `errcode.ErrWebhookTimestampExpired`.
+
+5. **Secrets never reach logs/spans.** `webhook.Source` stores the secret in an
+   unexported field with no getter; `Source.LogValue` redacts it; and
+   `pkg/redaction` masks the webhook signature/secret key set. See the
+   secret-leak defense section below.
+
+## Rationale / alternatives considered
+
+- **HMAC-SHA256 vs Ed25519 / KMS signing.** HMAC-SHA256 is the de-facto industry
+  standard for webhook signing (Stripe, GitHub, Svix, Slack). Asymmetric (Ed25519)
+  and KMS-backed signing (Vault Transit) are deferred follow-ups — they cross the
+  `adapters/` layer boundary and are not needed for the receiver/dispatcher MVP.
+- **Why a fixed `v1` scheme prefix, not an algorithm name in the header.** The
+  scheme tag is a version, not an algorithm selector. Keeping algorithm choice
+  out of the wire prevents downgrade negotiation. A future `v2` scheme would be a
+  deliberate, code-level change, not a per-request choice.
+- **Why ±5min default tolerance.** Matches Stripe/Svix defaults; large enough to
+  absorb normal clock skew, small enough to bound the replay window.
+
+## AI-robust enforcement: WEBHOOK-HMAC-FUNNEL-01
+
+Carrier: `tools/archtest/webhook_hmac_funnel_test.go`. Symbol inventory and
+blind-spot list live in that test's package godoc (per ai-robust.md "落地实例与
+符号清单活在代码 godoc"); this ADR records only the ratings.
+
+| Sub-rule | Guards | Rating |
+|----------|--------|--------|
+| A1 | `crypto/hmac.New` has a single callsite (`computeMAC` in signer.go) | downstream **Hard** |
+| A2 | signature comparison uses only `hmac.Equal`/`subtle.ConstantTimeCompare` | downstream **Hard** |
+| A3 | `Signer`/`Verifier` sealed via unexported `sealed()` marker | upstream **Hard** (external) / **Medium** (package-internal) |
+
+A1 also closes the package-internal upstream blind spot: any new in-package
+struct that wants to sign MUST call `hmac.New`, which is allowlisted to
+signer.go, so an unsealed internal holder cannot produce signatures undetected.
+
+Per ai-robust.md §Funnel 双向锁评级, the A3 package-internal Medium axis has a
+tracking issue for explicit Hard-ization (unexported method-set interface +
+private construction, following the SPAN-SETATTR-HOLDER-SEAL #851 precedent):
+**gh #1243**. The funnel godoc names this issue.
+
+## Threat model
+
+| Threat | Mitigation | Status |
+|--------|-----------|--------|
+| Forged payload (no secret) | HMAC over full signed content; `hmac.Equal` | ✅ |
+| Algorithm downgrade (SHA-1) | single legal `Algorithm`; `Validate` rejects others | ✅ |
+| Replay of a captured valid delivery | bidirectional timestamp tolerance window | ✅ (bounded to ±tolerance; full idempotency dedupe is the receiver's Claimer, PR-3/PR-6) |
+| Timing side-channel on signature compare | `hmac.Equal` constant-time; A2 AST lock | ✅ |
+| Secret leak via logs/spans/error text | unexported secret + no getter + `Source.LogValue` mask + redaction key set + archtest B6 | ✅ |
+| Secret mutation after construction | `NewSource` defensive copy | ✅ |
+| Body-shifting between signed-content fields | MAC covers the whole string; fields never parsed back | ✅ (no forgery without the secret) |
+
+## Consequences
+
+- The receiver (PR-3) and dispatcher (PR-5) consume `Verifier`/`Signer` as the
+  only signing surface; they cannot introduce a second algorithm.
+- Secret rotation is supported on the verify side (multi-token header); persistent
+  multi-secret sources are a follow-up.
+
+## References
+
+- Svix manual verification: https://docs.svix.com/receiving/verifying-payloads/how-manual
+- Stripe webhook signatures: https://github.com/stripe/stripe-go/blob/master/webhook/client.go
+- ADR `202605051730-adr-errcode-message-pii-safety.md` (Message/Details/Internal redaction)
+- ADR `202604242030-adr-kernel-wrapper-contract-observability.md` §8 (span/error redaction)
+- ai-robust.md §Funnel 双向锁评级; gh #1243 (upstream Hard-ization), #851 (precedent)

--- a/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+++ b/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
@@ -83,7 +83,7 @@ private construction, following the SPAN-SETATTR-HOLDER-SEAL #851 precedent):
 |--------|-----------|--------|
 | Forged payload (no secret) | HMAC over full signed content; `hmac.Equal` | ✅ |
 | Algorithm downgrade (SHA-1) | single legal `Algorithm`; `Validate` rejects others | ✅ |
-| Replay of a captured valid delivery | bidirectional timestamp tolerance window | ✅ (bounded to ±tolerance; full idempotency dedupe is the receiver's Claimer, PR-3/PR-6) |
+| Replay of a captured valid delivery | bidirectional timestamp tolerance window | ⚠️ partial (bounded to ±tolerance; full idempotency dedupe is the receiver's Claimer, PR-3/PR-6) |
 | Timing side-channel on signature compare | `hmac.Equal` constant-time; A2 AST lock | ✅ |
 | Secret leak via logs/spans/error text | unexported secret + no getter + `Source.LogValue` mask + redaction key set + archtest B6 | ✅ |
 | Secret mutation after construction | `NewSource` defensive copy | ✅ |

--- a/kernel/webhook/doc.go
+++ b/kernel/webhook/doc.go
@@ -1,0 +1,77 @@
+// Package webhook is the kernel-level pure-computation core for GoCell's
+// bidirectional webhook capability (KERNEL-WEBHOOK-01): inbound receiver
+// verification and outbound dispatcher signing. It depends only on the
+// standard library + pkg/errcode + pkg/redaction + pkg/panicregister +
+// kernel/clock (kernel/ layering rule — no runtime/ adapters/ cells/).
+//
+// Scope: L0 (signature compute + verify are pure functions of input bytes).
+// The HTTP receiver middleware and the outbox dispatcher consumer that wire
+// these primitives into request/delivery flows live in runtime/webhook
+// (PR-3 / PR-5).
+//
+// # Core surface
+//
+//   - [Algorithm] — signing algorithm marker; the only legal value is
+//     [AlgorithmHMACSHA256]. [Algorithm.Validate] rejects everything else with
+//     [errcode.ErrWebhookAlgorithmUnsupported].
+//   - [SourceID] / [DeliveryID] — typed string newtypes with [NewSourceID] /
+//     [NewDeliveryID] validators (+ Must variants). Mirror the
+//     kernel/healthz.ProbeName funnel shape.
+//   - [Source] — an opaque (id, secret) pair. Its secret field is unexported
+//     with no getter, and [Source.LogValue] redacts it, so a webhook secret
+//     can never reach slog/spans by accident — see the secret-leak defenses
+//     below.
+//   - [Headers] — the wire signature headers (delivery id, timestamp,
+//     signature) produced by a [Signer] and consumed by a [Verifier].
+//   - [Signer] / [Verifier] — sealed interfaces (unexported sealed() marker)
+//     so package-external implementations are a compile error. The sole
+//     in-package implementations are the HMAC-SHA256 signer/verifier built by
+//     [NewHMACSigner] / [NewHMACVerifier].
+//   - [SourceStore] / [SourceRegistry] — secret lookup interface + in-memory
+//     implementation (externally replaceable; persistent stores are a
+//     follow-up).
+//
+// # Signing scheme (Svix-aligned)
+//
+// The signed content is the byte concatenation
+// "{deliveryID}.{unixTimestamp}.{body}", MAC'd with HMAC-SHA256 over the
+// source secret. The signature header value is "v1,<base64(mac)>"; a
+// space-separated list of such tokens is accepted on verify so a sender can
+// rotate secrets without a flag day. Verification recomputes the MAC and uses
+// crypto/hmac.Equal (constant time) against each presented token, after a
+// bidirectional timestamp-tolerance window check (default ±5min).
+//
+// ref: svix/svix-webhooks go/webhook.go@main
+// ref: stripe/stripe-go webhook/client.go@master
+//
+// # AI-robust funnel: WEBHOOK-HMAC-FUNNEL-01
+//
+// Enforced by tools/archtest/webhook_hmac_funnel_test.go. Ratings:
+//
+//   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite —
+//     computeMAC in signer.go. Any other hmac.New in this package fails CI.
+//     This also closes the package-internal upstream blind spot: any new struct
+//     that wants to sign MUST call hmac.New, which is allowlisted to signer.go.
+//   - A2 (downstream Hard): signature comparison may only use crypto/hmac.Equal
+//     or crypto/subtle.ConstantTimeCompare; bytes.Equal / == over signature
+//     bytes fails CI (constant-time invariant as an AST lock, not a flaky
+//     timing test).
+//   - A3 (upstream Hard external / Medium internal): [Signer] / [Verifier]
+//     carry an unexported sealed() marker, so external implementations are a
+//     compile error (Hard). Package-internal new holders are not blocked by
+//     sealing (Medium) — covered transitively by A1. The explicit Hard-ization
+//     of the internal axis (unexported method-set interface + private
+//     construction, per the SPAN-SETATTR-HOLDER-SEAL precedent) is tracked in
+//     gh issue #1243; this godoc names it per ai-robust.md §Funnel 双向锁评级.
+//
+// # Secret-leak defenses (Source.Secret)
+//
+// pkg/redaction masks the new key set webhook_secret / x_signature /
+// x_hub_signature / x_webhook_signature / svix_signature / hmac_key, but that
+// only covers string-key paths. [Source]'s secret is raw bytes, so a
+// slog.Any("source", src) would otherwise leak it. Two lines of defense:
+// (1) [Source.LogValue] renders the secret as redaction.Mask (type-system
+// level — every slog of a Source is auto-redacted); (2) archtest blind-spot
+// self-check TestWebhookFunnel_NoRawSecretSlog bans slog of a raw Source /
+// Source secret in this package.
+package webhook

--- a/kernel/webhook/signer.go
+++ b/kernel/webhook/signer.go
@@ -1,0 +1,79 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strconv"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+const (
+	// signatureSchemeV1 is the signature version token. The wire form is
+	// "v1,<base64(mac)>".
+	signatureSchemeV1 = "v1"
+	// signatureSchemeSep separates the scheme from the encoded MAC.
+	signatureSchemeSep = ","
+	// signedContentSep joins the delivery id, timestamp, and body in the
+	// MAC'd content "{deliveryID}.{timestamp}.{body}".
+	signedContentSep = "."
+)
+
+// Signer produces signature [Headers] for an outbound webhook delivery. The
+// interface is sealed (unexported sealed() marker): the sole implementation is
+// the HMAC-SHA256 signer from [NewHMACSigner], so package-external types cannot
+// satisfy Signer (WEBHOOK-HMAC-FUNNEL-01/A3 upstream).
+type Signer interface {
+	// Sign computes the signature headers for payload at time ts under
+	// deliveryID. ts is supplied by the caller (the dispatcher passes its
+	// clock's Now) so the signer holds no clock.
+	Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (Headers, error)
+	sealed()
+}
+
+type hmacSigner struct {
+	source Source
+}
+
+// NewHMACSigner returns an HMAC-SHA256 [Signer] bound to source. It fails if
+// the source has no secret (a zero-value Source from outside the package).
+func NewHMACSigner(source Source) (Signer, error) {
+	if len(source.secret) == 0 {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: signer requires a source with a non-empty secret")
+	}
+	return &hmacSigner{source: source}, nil
+}
+
+func (*hmacSigner) sealed() {}
+
+func (s *hmacSigner) Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (Headers, error) {
+	if err := deliveryID.Validate(); err != nil {
+		return Headers{}, err
+	}
+	timestamp := strconv.FormatInt(ts.Unix(), 10)
+	mac := computeMAC(s.source.secret, deliveryID, timestamp, payload)
+	signature := signatureSchemeV1 + signatureSchemeSep + base64.StdEncoding.EncodeToString(mac)
+	return Headers{
+		DeliveryID: deliveryID,
+		Timestamp:  timestamp,
+		Signature:  signature,
+	}, nil
+}
+
+// computeMAC is the SINGLE crypto/hmac.New callsite in this package
+// (WEBHOOK-HMAC-FUNNEL-01/A1). It MACs the signed content
+// "{deliveryID}.{timestamp}.{body}" with HMAC-SHA256 over secret and returns
+// the raw MAC bytes. Signing base64-encodes the result; verification compares
+// raw bytes via crypto/hmac.Equal.
+func computeMAC(secret []byte, deliveryID DeliveryID, timestamp string, payload []byte) []byte {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(deliveryID))
+	mac.Write([]byte(signedContentSep))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte(signedContentSep))
+	mac.Write(payload)
+	return mac.Sum(nil)
+}

--- a/kernel/webhook/signer.go
+++ b/kernel/webhook/signer.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -37,6 +38,10 @@ type hmacSigner struct {
 	source Source
 }
 
+// Compile-time assertion: *hmacSigner implements slog.LogValuer so callers
+// using slog.Any("signer", s) never leak the embedded source secret.
+var _ slog.LogValuer = (*hmacSigner)(nil)
+
 // NewHMACSigner returns an HMAC-SHA256 [Signer] bound to source. It fails if
 // the source has no secret (a zero-value Source from outside the package).
 func NewHMACSigner(source Source) (Signer, error) {
@@ -48,6 +53,12 @@ func NewHMACSigner(source Source) (Signer, error) {
 }
 
 func (*hmacSigner) sealed() {}
+
+// LogValue implements slog.LogValuer so logging a *hmacSigner never leaks the
+// source secret (defense-in-depth alongside Source.LogValue).
+func (s *hmacSigner) LogValue() slog.Value {
+	return slog.GroupValue(slog.Any("source", s.source))
+}
 
 func (s *hmacSigner) Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (Headers, error) {
 	if err := deliveryID.Validate(); err != nil {

--- a/kernel/webhook/signer_test.go
+++ b/kernel/webhook/signer_test.go
@@ -1,0 +1,82 @@
+package webhook
+
+import (
+	"encoding/base64"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// Compile-time assertion: the only Signer/Verifier implementations are the
+// in-package HMAC types. The unexported sealed() marker makes any
+// package-external implementation a compile error (WEBHOOK-HMAC-FUNNEL-01/A3).
+var (
+	_ Signer   = (*hmacSigner)(nil)
+	_ Verifier = (*hmacVerifier)(nil)
+)
+
+func TestNewHMACSigner_RejectsEmptySecret(t *testing.T) {
+	t.Parallel()
+	// A zero-value Source (constructible from outside the package) has no secret.
+	_, err := NewHMACSigner(Source{})
+	requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+}
+
+func TestSigner_RejectsBadDeliveryID(t *testing.T) {
+	t.Parallel()
+	src, err := NewSource(MustSourceID("s"), minSecret())
+	require.NoError(t, err)
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+	_, err = signer.Sign([]byte("b"), time.Unix(1700000000, 0), DeliveryID("bad id"))
+	requireErrCode(t, err, errcode.ErrWebhookInvalidHeader, errcode.KindInvalid)
+}
+
+// TestSign_MatchesSvixGoldenVector signs the canonical Svix vector and asserts
+// byte-for-byte agreement with the reference implementation.
+func TestSign_MatchesSvixGoldenVector(t *testing.T) {
+	t.Parallel()
+	v := loadVector(t, "svix_official_basic")
+	src, err := NewSource(MustSourceID(v.SourceID), v.secretBytes(t))
+	require.NoError(t, err)
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+
+	tsInt, err := strconv.ParseInt(v.Timestamp, 10, 64)
+	require.NoError(t, err)
+	headers, err := signer.Sign([]byte(v.Payload), time.Unix(tsInt, 0), MustDeliveryID(v.DeliveryID))
+	require.NoError(t, err)
+
+	assert.Equal(t, v.Signature, headers.Signature)
+	assert.Equal(t, v.Timestamp, headers.Timestamp)
+	assert.Equal(t, DeliveryID(v.DeliveryID), headers.DeliveryID)
+}
+
+// TestSign_SignerVerifierRoundTrip signs then verifies with the same source.
+func TestSign_SignerVerifierRoundTrip(t *testing.T) {
+	t.Parallel()
+	src, err := NewSource(MustSourceID("roundtrip"), minSecret())
+	require.NoError(t, err)
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+
+	ts := time.Unix(1700000000, 0)
+	body := []byte(`{"hello":"world"}`)
+	headers, err := signer.Sign(body, ts, MustDeliveryID("evt_rt"))
+	require.NoError(t, err)
+
+	// Signature must be a well-formed v1 token decoding to 32 MAC bytes.
+	require.True(t, len(headers.Signature) > 3 && headers.Signature[:3] == "v1,")
+	raw, err := base64.StdEncoding.DecodeString(headers.Signature[3:])
+	require.NoError(t, err)
+	assert.Len(t, raw, 32)
+
+	verifier, err := NewHMACVerifier(clockmockAt(ts))
+	require.NoError(t, err)
+	assert.NoError(t, verifier.Verify(body, headers, src))
+}

--- a/kernel/webhook/source.go
+++ b/kernel/webhook/source.go
@@ -28,9 +28,10 @@ func NewSourceRegistry() *SourceRegistry {
 	return &SourceRegistry{sources: make(map[SourceID]Source)}
 }
 
-// Register adds or replaces the source registered under src.ID(). It fails if
-// src is a zero-value Source (no secret), which cannot occur for a Source built
-// via [NewSource].
+// Register adds or replaces the source registered under src.ID(). It fails with
+// [errcode.ErrWebhookConfigInvalid] when src has an empty secret — a zero-value
+// Source{} built without [NewSource]. [NewSource] always yields a valid Source,
+// so this guard only catches accidental zero-value passing.
 func (r *SourceRegistry) Register(src Source) error {
 	if len(src.secret) == 0 {
 		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,

--- a/kernel/webhook/source.go
+++ b/kernel/webhook/source.go
@@ -1,0 +1,54 @@
+package webhook
+
+import (
+	"sync"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// SourceStore resolves a [SourceID] to its registered [Source]. The receiver
+// looks up the secret for an inbound delivery through this interface, so a
+// persistent / encrypted backing store (configcore, Vault) can replace the
+// in-memory default without touching the verification path.
+type SourceStore interface {
+	// Lookup returns the source registered under id and true, or the zero
+	// Source and false when id is unknown.
+	Lookup(id SourceID) (Source, bool)
+}
+
+// SourceRegistry is an in-memory [SourceStore]. It is safe for concurrent use
+// and is the default for single-process deployments, tests, and demos.
+type SourceRegistry struct {
+	mu      sync.RWMutex
+	sources map[SourceID]Source
+}
+
+// NewSourceRegistry returns an empty in-memory registry.
+func NewSourceRegistry() *SourceRegistry {
+	return &SourceRegistry{sources: make(map[SourceID]Source)}
+}
+
+// Register adds or replaces the source registered under src.ID(). It fails if
+// src is a zero-value Source (no secret), which cannot occur for a Source built
+// via [NewSource].
+func (r *SourceRegistry) Register(src Source) error {
+	if len(src.secret) == 0 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: cannot register a source with an empty secret")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sources[src.id] = src
+	return nil
+}
+
+// Lookup implements [SourceStore].
+func (r *SourceRegistry) Lookup(id SourceID) (Source, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	src, ok := r.sources[id]
+	return src, ok
+}
+
+// compile-time assertion that the in-memory registry satisfies SourceStore.
+var _ SourceStore = (*SourceRegistry)(nil)

--- a/kernel/webhook/source_test.go
+++ b/kernel/webhook/source_test.go
@@ -1,6 +1,8 @@
 package webhook
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +40,31 @@ func TestSourceRegistry_RejectsEmptySecret(t *testing.T) {
 	reg := NewSourceRegistry()
 	err := reg.Register(Source{})
 	requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+}
+
+// TestSourceRegistry_ConcurrentAccess surfaces data races under -race by
+// running concurrent Register and Lookup calls on a shared registry.
+func TestSourceRegistry_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	reg := NewSourceRegistry()
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			id := fmt.Sprintf("src-%d", i)
+			src, err := NewSource(MustSourceID(id), minSecret())
+			if err != nil {
+				return
+			}
+			if i%2 == 0 {
+				_ = reg.Register(src)
+			} else {
+				_, _ = reg.Lookup(MustSourceID(fmt.Sprintf("src-%d", i-1)))
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/kernel/webhook/source_test.go
+++ b/kernel/webhook/source_test.go
@@ -1,0 +1,41 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+func TestSourceRegistry(t *testing.T) {
+	t.Parallel()
+	reg := NewSourceRegistry()
+
+	_, ok := reg.Lookup(MustSourceID("absent"))
+	assert.False(t, ok, "empty registry has no sources")
+
+	src, err := NewSource(MustSourceID("stripe"), minSecret())
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(src))
+
+	got, ok := reg.Lookup(MustSourceID("stripe"))
+	require.True(t, ok)
+	assert.Equal(t, SourceID("stripe"), got.ID())
+
+	// Re-register replaces.
+	src2, err := NewSource(MustSourceID("stripe"), append(minSecret(), 'z'))
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(src2))
+	got2, ok := reg.Lookup(MustSourceID("stripe"))
+	require.True(t, ok)
+	assert.Equal(t, SourceID("stripe"), got2.ID())
+}
+
+func TestSourceRegistry_RejectsEmptySecret(t *testing.T) {
+	t.Parallel()
+	reg := NewSourceRegistry()
+	err := reg.Register(Source{})
+	requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+}

--- a/kernel/webhook/testdata/webhook-hmac-vectors.yaml
+++ b/kernel/webhook/testdata/webhook-hmac-vectors.yaml
@@ -1,0 +1,72 @@
+# HMAC-SHA256 webhook signature test vectors (KERNEL-WEBHOOK-01 PR-1).
+#
+# Each vector exercises kernel/webhook signer + verifier round-trips. The signed
+# content is "{deliveryId}.{timestamp}.{payload}" (Svix-aligned). secretBase64
+# is the base64 of the RAW HMAC key bytes (decoded by the test into a
+# webhook.Source secret); it is NOT a Svix "whsec_"-prefixed string.
+#
+# `signature` values are golden (computed independently with Python hmac), so a
+# regression in computeMAC is caught as a value mismatch, not a self-consistent
+# pass.
+#
+#   - svix_official_basic: the canonical vector published at
+#     https://docs.svix.com/receiving/verifying-payloads/how-manual — proves
+#     byte-for-byte agreement with the reference implementation.
+#   - the remaining vectors use a self-constructed key and cover empty body,
+#     tampered body, a bogus signature, and multi-signature rotation.
+vectors:
+  - name: svix_official_basic
+    sourceId: svix-demo
+    secretBase64: "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+    deliveryId: "msg_p5jXN8AQM9LWM0D4loKWxJek"
+    timestamp: "1614265330"
+    payload: '{"test": 2432232314}'
+    signature: "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="
+    valid: true
+
+  - name: empty_payload
+    sourceId: self-source
+    secretBase64: "c3VwZXJzZWNyZXRrZXktMDEyMzQ1Njc4OQ=="
+    deliveryId: "evt_empty_001"
+    timestamp: "1700000000"
+    payload: ""
+    signature: "v1,/PLGNECH9y5aabNVERytMyuKm70+9GBab321aIZvr/k="
+    valid: true
+
+  - name: simple_object
+    sourceId: self-source
+    secretBase64: "c3VwZXJzZWNyZXRrZXktMDEyMzQ1Njc4OQ=="
+    deliveryId: "evt_simple_002"
+    timestamp: "1700000100"
+    payload: '{"order":42}'
+    signature: "v1,jvo2tkmfTaIYx1PAg3CcatRmyg5BV4dZlwI+fEca7uc="
+    valid: true
+
+  - name: tampered_payload
+    sourceId: self-source
+    secretBase64: "c3VwZXJzZWNyZXRrZXktMDEyMzQ1Njc4OQ=="
+    deliveryId: "evt_simple_002"
+    timestamp: "1700000100"
+    payload: '{"order":43}'
+    signature: "v1,jvo2tkmfTaIYx1PAg3CcatRmyg5BV4dZlwI+fEca7uc="
+    valid: false
+
+  - name: bogus_signature
+    sourceId: self-source
+    secretBase64: "c3VwZXJzZWNyZXRrZXktMDEyMzQ1Njc4OQ=="
+    deliveryId: "evt_simple_002"
+    timestamp: "1700000100"
+    payload: '{"order":42}'
+    signature: "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    valid: false
+
+  - name: multi_signature_rotation
+    sourceId: self-source
+    secretBase64: "c3VwZXJzZWNyZXRrZXktMDEyMzQ1Njc4OQ=="
+    deliveryId: "evt_rotate_003"
+    timestamp: "1700000200"
+    payload: '{"a":1}'
+    # First token is bogus, second is the valid signature — verify accepts when
+    # any space-separated token matches.
+    signature: "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= v1,lgk0U1f4d1VQlNIUEiLrl0brTuq8/eMyzq+Zx1PPnXY="
+    valid: true

--- a/kernel/webhook/vectors_test.go
+++ b/kernel/webhook/vectors_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -36,11 +37,8 @@ func (v vector) secretBytes(t *testing.T) []byte {
 // unixTime returns the vector timestamp as a time.Time.
 func (v vector) unixTime(t *testing.T) time.Time {
 	t.Helper()
-	var sec int64
-	for _, r := range v.Timestamp {
-		require.True(t, r >= '0' && r <= '9', "vector %s: non-numeric timestamp", v.Name)
-		sec = sec*10 + int64(r-'0')
-	}
+	sec, err := strconv.ParseInt(v.Timestamp, 10, 64)
+	require.NoError(t, err, "vector %s: non-numeric timestamp", v.Name)
 	return time.Unix(sec, 0)
 }
 

--- a/kernel/webhook/vectors_test.go
+++ b/kernel/webhook/vectors_test.go
@@ -1,0 +1,72 @@
+package webhook
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+)
+
+// vector is one HMAC test vector from testdata/webhook-hmac-vectors.yaml.
+type vector struct {
+	Name         string `yaml:"name"`
+	SourceID     string `yaml:"sourceId"`
+	SecretBase64 string `yaml:"secretBase64"`
+	DeliveryID   string `yaml:"deliveryId"`
+	Timestamp    string `yaml:"timestamp"`
+	Payload      string `yaml:"payload"`
+	Signature    string `yaml:"signature"`
+	Valid        bool   `yaml:"valid"`
+}
+
+func (v vector) secretBytes(t *testing.T) []byte {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(v.SecretBase64)
+	require.NoError(t, err, "vector %s: bad secretBase64", v.Name)
+	return raw
+}
+
+// unixTime returns the vector timestamp as a time.Time.
+func (v vector) unixTime(t *testing.T) time.Time {
+	t.Helper()
+	var sec int64
+	for _, r := range v.Timestamp {
+		require.True(t, r >= '0' && r <= '9', "vector %s: non-numeric timestamp", v.Name)
+		sec = sec*10 + int64(r-'0')
+	}
+	return time.Unix(sec, 0)
+}
+
+func loadVectors(t *testing.T) []vector {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "webhook-hmac-vectors.yaml"))
+	require.NoError(t, err)
+	var doc struct {
+		Vectors []vector `yaml:"vectors"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &doc))
+	require.NotEmpty(t, doc.Vectors)
+	return doc.Vectors
+}
+
+func loadVector(t *testing.T, name string) vector {
+	t.Helper()
+	for _, v := range loadVectors(t) {
+		if v.Name == name {
+			return v
+		}
+	}
+	t.Fatalf("vector %q not found", name)
+	return vector{}
+}
+
+// clockmockAt returns a clock pinned to ts (skew zero against a vector signed
+// at ts).
+func clockmockAt(ts time.Time) clock.Clock { return clockmock.New(ts) }

--- a/kernel/webhook/verifier.go
+++ b/kernel/webhook/verifier.go
@@ -75,9 +75,12 @@ func (v *hmacVerifier) Verify(rawBody []byte, headers Headers, source Source) er
 	}
 	expected := computeMAC(source.secret, headers.DeliveryID, headers.Timestamp, rawBody)
 	if !matchAnySignature(headers.Signature, expected) {
+		// sourceId goes to Internal (server-side slog), not Details: the wire
+		// 401 must be uniform with the unknown-source case so the receive path
+		// is not a source-ID enumeration oracle (WEBHOOK-HMAC-FUNNEL-01 F8/F9).
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
 			"webhook: no presented signature matches the computed digest",
-			errcode.WithDetails(errcode.PublicString("sourceId", string(source.id))))
+			errcode.WithInternal(errcode.InternalAttr("sourceId", string(source.id))))
 	}
 	return nil
 }

--- a/kernel/webhook/verifier.go
+++ b/kernel/webhook/verifier.go
@@ -33,7 +33,7 @@ type hmacVerifier struct {
 	tolerance time.Duration
 }
 
-// VerifierOption configures a [hmacVerifier].
+// VerifierOption configures [NewHMACVerifier]; use [WithTolerance] to override defaults.
 type VerifierOption func(*hmacVerifier)
 
 // WithTolerance overrides the default ±5min timestamp window. A non-positive
@@ -70,7 +70,7 @@ func (v *hmacVerifier) Verify(rawBody []byte, headers Headers, source Source) er
 	if err := headers.DeliveryID.Validate(); err != nil {
 		return err
 	}
-	if err := v.checkTimestamp(headers.Timestamp); err != nil {
+	if err := v.validateTimestamp(headers.Timestamp); err != nil {
 		return err
 	}
 	expected := computeMAC(source.secret, headers.DeliveryID, headers.Timestamp, rawBody)
@@ -82,14 +82,14 @@ func (v *hmacVerifier) Verify(rawBody []byte, headers Headers, source Source) er
 	return nil
 }
 
-// checkTimestamp parses the unix-seconds timestamp header and enforces the
+// validateTimestamp parses the unix-seconds timestamp header and enforces the
 // bidirectional tolerance window.
-func (v *hmacVerifier) checkTimestamp(timestamp string) error {
+func (v *hmacVerifier) validateTimestamp(timestamp string) error {
 	tsInt, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
 			"webhook: timestamp header is not a unix-seconds integer",
-			errcode.WithDetails(errcode.PublicString("timestamp", timestamp)))
+			errcode.WithInternal(errcode.InternalAttr("rawTimestamp", timestamp)))
 	}
 	skew := v.clk.Now().Sub(time.Unix(tsInt, 0))
 	if skew < 0 {

--- a/kernel/webhook/verifier.go
+++ b/kernel/webhook/verifier.go
@@ -1,0 +1,128 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"encoding/base64"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// defaultTolerance is the bidirectional timestamp window within which a signed
+// delivery is accepted (replay defense). ±5min matches Stripe / Svix defaults.
+const defaultTolerance = 5 * time.Minute
+
+// Verifier checks the signature [Headers] of an inbound webhook against a
+// [Source]'s secret. The interface is sealed (unexported sealed() marker): the
+// sole implementation is the HMAC-SHA256 verifier from [NewHMACVerifier]
+// (WEBHOOK-HMAC-FUNNEL-01/A3 upstream).
+type Verifier interface {
+	// Verify returns nil when rawBody, headers, and source produce a matching
+	// HMAC within the tolerance window; otherwise it returns a typed
+	// *errcode.Error sentinel (ErrWebhookInvalidHeader / TimestampExpired /
+	// InvalidSignature / ConfigInvalid).
+	Verify(rawBody []byte, headers Headers, source Source) error
+	sealed()
+}
+
+type hmacVerifier struct {
+	clk       clock.Clock
+	tolerance time.Duration
+}
+
+// VerifierOption configures a [hmacVerifier].
+type VerifierOption func(*hmacVerifier)
+
+// WithTolerance overrides the default ±5min timestamp window. A non-positive
+// value is rejected at construction.
+func WithTolerance(d time.Duration) VerifierOption {
+	return func(v *hmacVerifier) { v.tolerance = d }
+}
+
+// NewHMACVerifier returns an HMAC-SHA256 [Verifier]. clk is the mandatory
+// positional clock used for the timestamp-tolerance window
+// (CLOCK-POSITIONAL-INJECTION-01).
+func NewHMACVerifier(clk clock.Clock, opts ...VerifierOption) (Verifier, error) {
+	clock.MustHaveClock(clk, "webhook.NewHMACVerifier")
+	v := &hmacVerifier{clk: clk, tolerance: defaultTolerance}
+	for _, o := range opts {
+		if o != nil {
+			o(v)
+		}
+	}
+	if v.tolerance <= 0 {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: verifier tolerance must be positive")
+	}
+	return v, nil
+}
+
+func (*hmacVerifier) sealed() {}
+
+func (v *hmacVerifier) Verify(rawBody []byte, headers Headers, source Source) error {
+	if len(source.secret) == 0 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: verify requires a source with a non-empty secret")
+	}
+	if err := headers.DeliveryID.Validate(); err != nil {
+		return err
+	}
+	if err := v.checkTimestamp(headers.Timestamp); err != nil {
+		return err
+	}
+	expected := computeMAC(source.secret, headers.DeliveryID, headers.Timestamp, rawBody)
+	if !matchAnySignature(headers.Signature, expected) {
+		return errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
+			"webhook: no presented signature matches the computed digest",
+			errcode.WithDetails(errcode.PublicString("sourceId", string(source.id))))
+	}
+	return nil
+}
+
+// checkTimestamp parses the unix-seconds timestamp header and enforces the
+// bidirectional tolerance window.
+func (v *hmacVerifier) checkTimestamp(timestamp string) error {
+	tsInt, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
+			"webhook: timestamp header is not a unix-seconds integer",
+			errcode.WithDetails(errcode.PublicString("timestamp", timestamp)))
+	}
+	skew := v.clk.Now().Sub(time.Unix(tsInt, 0))
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > v.tolerance {
+		return errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookTimestampExpired,
+			"webhook: signature timestamp is outside the tolerance window",
+			errcode.WithDetails(
+				errcode.PublicInt("skewSeconds", int64(skew/time.Second)),
+				errcode.PublicInt("toleranceSeconds", int64(v.tolerance/time.Second)),
+			))
+	}
+	return nil
+}
+
+// matchAnySignature reports whether any space-separated "v1,<base64>" token in
+// header decodes to a MAC equal to expected. Comparison uses crypto/hmac.Equal
+// (constant time) — WEBHOOK-HMAC-FUNNEL-01/A2. Multiple tokens support a
+// sender rotating secrets without a flag day.
+func matchAnySignature(header string, expected []byte) bool {
+	for _, token := range strings.Fields(header) {
+		scheme, encoded, ok := strings.Cut(token, signatureSchemeSep)
+		if !ok || scheme != signatureSchemeV1 {
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			continue
+		}
+		if hmac.Equal(expected, raw) {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/webhook/verifier_test.go
+++ b/kernel/webhook/verifier_test.go
@@ -13,8 +13,10 @@ import (
 
 // Test-time durations extracted to package-level consts (TEST-TIME-LITERAL-01).
 const (
-	tenMinutes       = 10 * time.Minute
-	oneHourTolerance = time.Hour
+	tenMinutes        = 10 * time.Minute
+	oneHourTolerance  = time.Hour
+	fiveMinutes       = 5 * time.Minute
+	justOverTolerance = 5*time.Minute + time.Second
 )
 
 // TestVerify_Vectors drives every golden vector through the verifier with the
@@ -52,6 +54,12 @@ func TestNewHMACVerifier_Options(t *testing.T) {
 	t.Run("nil_clock_panics", func(t *testing.T) {
 		t.Parallel()
 		assert.Panics(t, func() { _, _ = NewHMACVerifier(nil) })
+	})
+
+	t.Run("nil_option_ignored", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewHMACVerifier(fixedClock(t), nil)
+		require.NoError(t, err)
 	})
 
 	t.Run("non_positive_tolerance_rejected", func(t *testing.T) {
@@ -168,6 +176,24 @@ func TestVerify_Errors(t *testing.T) {
 			wantCode: errcode.ErrWebhookInvalidSignature,
 			wantKind: errcode.KindUnauthenticated,
 		},
+		{
+			name:     "empty_signature",
+			headers:  Headers{DeliveryID: good.DeliveryID, Timestamp: good.Timestamp, Signature: ""},
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookInvalidSignature,
+			wantKind: errcode.KindUnauthenticated,
+		},
+		{
+			name:     "timestamp_one_second_past_tolerance",
+			headers:  good,
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base.Add(justOverTolerance),
+			wantCode: errcode.ErrWebhookTimestampExpired,
+			wantKind: errcode.KindUnauthenticated,
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -182,4 +208,22 @@ func TestVerify_Errors(t *testing.T) {
 			assert.Equal(t, tc.wantKind, ec.Kind)
 		})
 	}
+}
+
+// TestVerify_AcceptsAtExactTolerance checks that skew == tolerance is accepted
+// (the check is strict `>`, so skew equal to tolerance must pass).
+func TestVerify_AcceptsAtExactTolerance(t *testing.T) {
+	t.Parallel()
+	base := time.Unix(1700000000, 0)
+	src, err := NewSource(MustSourceID("s"), minSecret())
+	require.NoError(t, err)
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+	good, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
+	require.NoError(t, err)
+
+	// Clock is exactly fiveMinutes after signing — skew == tolerance, must pass.
+	verifier, err := NewHMACVerifier(clockmockAt(base.Add(fiveMinutes)))
+	require.NoError(t, err)
+	assert.NoError(t, verifier.Verify([]byte("body"), good, src))
 }

--- a/kernel/webhook/verifier_test.go
+++ b/kernel/webhook/verifier_test.go
@@ -1,0 +1,185 @@
+package webhook
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// Test-time durations extracted to package-level consts (TEST-TIME-LITERAL-01).
+const (
+	tenMinutes       = 10 * time.Minute
+	oneHourTolerance = time.Hour
+)
+
+// TestVerify_Vectors drives every golden vector through the verifier with the
+// clock pinned to the vector's own timestamp (so the window check passes for
+// valid vectors and only the signature determines the outcome).
+func TestVerify_Vectors(t *testing.T) {
+	t.Parallel()
+	for _, v := range loadVectors(t) {
+		v := v
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+			src, err := NewSource(MustSourceID(v.SourceID), v.secretBytes(t))
+			require.NoError(t, err)
+			verifier, err := NewHMACVerifier(clockmockAt(v.unixTime(t)))
+			require.NoError(t, err)
+
+			err = verifier.Verify([]byte(v.Payload), Headers{
+				DeliveryID: MustDeliveryID(v.DeliveryID),
+				Timestamp:  v.Timestamp,
+				Signature:  v.Signature,
+			}, src)
+
+			if v.Valid {
+				assert.NoError(t, err)
+				return
+			}
+			requireErrCode(t, err, errcode.ErrWebhookInvalidSignature, errcode.KindUnauthenticated)
+		})
+	}
+}
+
+func TestNewHMACVerifier_Options(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_clock_panics", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { _, _ = NewHMACVerifier(nil) })
+	})
+
+	t.Run("non_positive_tolerance_rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewHMACVerifier(fixedClock(t), WithTolerance(0))
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+
+	t.Run("custom_tolerance_applies", func(t *testing.T) {
+		t.Parallel()
+		// Sign at T, verify at T+10min with a 1h tolerance → accepted.
+		base := time.Unix(1700000000, 0)
+		src, err := NewSource(MustSourceID("s"), minSecret())
+		require.NoError(t, err)
+		signer, err := NewHMACSigner(src)
+		require.NoError(t, err)
+		headers, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
+		require.NoError(t, err)
+
+		verifier, err := NewHMACVerifier(clockmockAt(base.Add(tenMinutes)), WithTolerance(oneHourTolerance))
+		require.NoError(t, err)
+		assert.NoError(t, verifier.Verify([]byte("body"), headers, src))
+	})
+}
+
+func TestVerify_Errors(t *testing.T) {
+	t.Parallel()
+	base := time.Unix(1700000000, 0)
+	src, err := NewSource(MustSourceID("s"), minSecret())
+	require.NoError(t, err)
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+	good, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		headers  Headers
+		body     []byte
+		source   Source
+		clockAt  time.Time
+		wantCode errcode.Code
+		wantKind errcode.Kind
+	}{
+		{
+			name:     "empty_secret_source",
+			headers:  good,
+			body:     []byte("body"),
+			source:   Source{},
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookConfigInvalid,
+			wantKind: errcode.KindInvalid,
+		},
+		{
+			name:     "bad_delivery_id",
+			headers:  Headers{DeliveryID: DeliveryID("bad id"), Timestamp: good.Timestamp, Signature: good.Signature},
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookInvalidHeader,
+			wantKind: errcode.KindInvalid,
+		},
+		{
+			name:     "non_numeric_timestamp",
+			headers:  Headers{DeliveryID: good.DeliveryID, Timestamp: "not-a-number", Signature: good.Signature},
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookInvalidHeader,
+			wantKind: errcode.KindInvalid,
+		},
+		{
+			name:     "timestamp_outside_window",
+			headers:  good,
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base.Add(tenMinutes), // > default 5min
+			wantCode: errcode.ErrWebhookTimestampExpired,
+			wantKind: errcode.KindUnauthenticated,
+		},
+		{
+			name:     "timestamp_outside_window_past",
+			headers:  good,
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base.Add(-tenMinutes), // bidirectional
+			wantCode: errcode.ErrWebhookTimestampExpired,
+			wantKind: errcode.KindUnauthenticated,
+		},
+		{
+			name:     "tampered_body",
+			headers:  good,
+			body:     []byte("tampered"),
+			source:   src,
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookInvalidSignature,
+			wantKind: errcode.KindUnauthenticated,
+		},
+		{
+			name:     "no_valid_signature_token",
+			headers:  Headers{DeliveryID: good.DeliveryID, Timestamp: good.Timestamp, Signature: "v2,abc malformed"},
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookInvalidSignature,
+			wantKind: errcode.KindUnauthenticated,
+		},
+		{
+			name:     "malformed_base64_token",
+			headers:  Headers{DeliveryID: good.DeliveryID, Timestamp: good.Timestamp, Signature: "v1,@@@not-base64@@@"},
+			body:     []byte("body"),
+			source:   src,
+			clockAt:  base,
+			wantCode: errcode.ErrWebhookInvalidSignature,
+			wantKind: errcode.KindUnauthenticated,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			verifier, verr := NewHMACVerifier(clockmockAt(tc.clockAt))
+			require.NoError(t, verr)
+			err := verifier.Verify(tc.body, tc.headers, tc.source)
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec), "want *errcode.Error, got %v", err)
+			assert.Equal(t, tc.wantCode, ec.Code)
+			assert.Equal(t, tc.wantKind, ec.Kind)
+		})
+	}
+}

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -1,0 +1,208 @@
+package webhook
+
+import (
+	"log/slog"
+	"regexp"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// Algorithm is the webhook signing algorithm marker. HMAC-SHA256 is the only
+// legal value (see ADR webhook-signing-algorithm); SHA-1 and other downgrades
+// are rejected by [Algorithm.Validate].
+type Algorithm string
+
+// AlgorithmHMACSHA256 is the sole supported signing algorithm.
+const AlgorithmHMACSHA256 Algorithm = "hmac-sha256"
+
+// String returns the algorithm name as a plain string.
+func (a Algorithm) String() string { return string(a) }
+
+// Validate reports whether a is a supported algorithm.
+func (a Algorithm) Validate() error {
+	if a != AlgorithmHMACSHA256 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookAlgorithmUnsupported,
+			"webhook: unsupported signing algorithm",
+			errcode.WithDetails(errcode.PublicString("algorithm", string(a))))
+	}
+	return nil
+}
+
+// SourceID is the typed identifier for a webhook source — the secret-isolation
+// key under which a [Source] is registered. Construct via [NewSourceID] /
+// [MustSourceID]; the validator mirrors kernel/healthz.ProbeName (snake/kebab
+// lowercase identifier).
+type SourceID string
+
+// String returns the source ID as a plain string.
+func (id SourceID) String() string { return string(id) }
+
+const sourceIDMaxLen = 64
+
+var sourceIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+
+// Validate reports whether id is a well-formed source ID.
+func (id SourceID) Validate() error {
+	if id == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: source ID must not be empty")
+	}
+	if len(id) > sourceIDMaxLen {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: source ID exceeds length budget",
+			errcode.WithDetails(
+				errcode.PublicInt("max", sourceIDMaxLen),
+				errcode.PublicInt("got", len(id)),
+			))
+	}
+	if !sourceIDPattern.MatchString(string(id)) {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: source ID must match [a-z][a-z0-9_-]* regex",
+			errcode.WithDetails(errcode.PublicString("sourceId", string(id))))
+	}
+	return nil
+}
+
+// NewSourceID validates s and returns a typed [SourceID]. It is the runtime
+// entry point; tests and init use [MustSourceID].
+func NewSourceID(s string) (SourceID, error) {
+	id := SourceID(s)
+	if err := id.Validate(); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// MustSourceID is the panic variant of [NewSourceID] for test fixtures and
+// package init where an invalid ID is a programmer error.
+func MustSourceID(s string) SourceID {
+	id, err := NewSourceID(s)
+	if err != nil {
+		panic(panicregister.Approved("webhook-source-id-invalid",
+			errcode.Assertion("webhook.MustSourceID(%q): %v", s, err)))
+	}
+	return id
+}
+
+// DeliveryID is the typed per-delivery identifier. It doubles as the
+// idempotency key on the receiver side and is part of the signed content, so
+// it must not contain whitespace. Construct via [NewDeliveryID] /
+// [MustDeliveryID].
+type DeliveryID string
+
+// String returns the delivery ID as a plain string.
+func (id DeliveryID) String() string { return string(id) }
+
+const deliveryIDMaxLen = 128
+
+// deliveryIDPattern permits the identifier shapes real providers emit (UUIDs,
+// "msg_…", "evt_…", colon/dot-segmented IDs) while forbidding whitespace — the
+// signed content concatenation relies on the absence of whitespace, and the
+// MAC covers the whole string so segment separators never enable forgery.
+var deliveryIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:-]*$`)
+
+// Validate reports whether id is a well-formed delivery ID. A malformed value
+// in an inbound header is a client error, so it maps to
+// [errcode.ErrWebhookInvalidHeader].
+func (id DeliveryID) Validate() error {
+	if id == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
+			"webhook: delivery ID must not be empty")
+	}
+	if len(id) > deliveryIDMaxLen {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
+			"webhook: delivery ID exceeds length budget",
+			errcode.WithDetails(
+				errcode.PublicInt("max", deliveryIDMaxLen),
+				errcode.PublicInt("got", len(id)),
+			))
+	}
+	if !deliveryIDPattern.MatchString(string(id)) {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
+			"webhook: delivery ID contains forbidden characters",
+			errcode.WithDetails(errcode.PublicString("deliveryId", string(id))))
+	}
+	return nil
+}
+
+// NewDeliveryID validates s and returns a typed [DeliveryID].
+func NewDeliveryID(s string) (DeliveryID, error) {
+	id := DeliveryID(s)
+	if err := id.Validate(); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// MustDeliveryID is the panic variant of [NewDeliveryID] for test fixtures.
+func MustDeliveryID(s string) DeliveryID {
+	id, err := NewDeliveryID(s)
+	if err != nil {
+		panic(panicregister.Approved("webhook-delivery-id-invalid",
+			errcode.Assertion("webhook.MustDeliveryID(%q): %v", s, err)))
+	}
+	return id
+}
+
+// minSecretLen is the floor for an HMAC secret. 16 bytes (128 bits) is the
+// minimum recommended for HMAC-SHA256 keying material.
+const minSecretLen = 16
+
+// Source is an opaque webhook source: an identifier plus the shared secret
+// used to sign/verify its deliveries. The secret is an unexported field with
+// no getter — in-package signer/verifier read it directly, package-external
+// callers can only construct a Source via [NewSource] and never read the
+// secret back. [Source.LogValue] redacts the secret so slog of a Source is
+// always safe.
+type Source struct {
+	id     SourceID
+	secret []byte
+}
+
+// NewSource validates id and secret and returns a [Source]. The secret must be
+// at least minSecretLen bytes.
+func NewSource(id SourceID, secret []byte) (Source, error) {
+	if err := id.Validate(); err != nil {
+		return Source{}, err
+	}
+	if len(secret) < minSecretLen {
+		return Source{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: source secret is shorter than the minimum length",
+			errcode.WithDetails(
+				errcode.PublicInt("min", minSecretLen),
+				errcode.PublicInt("got", len(secret)),
+			))
+	}
+	// Defensive copy so the caller cannot mutate the secret after construction.
+	cp := make([]byte, len(secret))
+	copy(cp, secret)
+	return Source{id: id, secret: cp}, nil
+}
+
+// ID returns the source identifier. The secret is intentionally not exposed.
+func (s Source) ID() SourceID { return s.id }
+
+// LogValue implements slog.LogValuer so that logging a Source never leaks the
+// secret: the secret field is rendered as redaction.Mask.
+func (s Source) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("id", string(s.id)),
+		slog.String("secret", redaction.Mask),
+	)
+}
+
+// Compile-time guarantee that Source redacts itself when logged — the
+// type-system half of the secret-leak defense (WEBHOOK-HMAC-FUNNEL-01 B6).
+// slog.Any honors slog.LogValuer, so even slog.Any("source", src) is safe.
+var _ slog.LogValuer = Source{}
+
+// Headers is the set of signature headers a [Signer] produces and a [Verifier]
+// consumes. Timestamp is unix seconds as a decimal string; Signature is one or
+// more space-separated "v1,<base64>" tokens.
+type Headers struct {
+	DeliveryID DeliveryID
+	Timestamp  string
+	Signature  string
+}

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -162,7 +162,7 @@ type Source struct {
 }
 
 // NewSource validates id and secret and returns a [Source]. The secret must be
-// at least minSecretLen bytes.
+// at least 16 bytes (128-bit minimum for HMAC-SHA256 keying material).
 func NewSource(id SourceID, secret []byte) (Source, error) {
 	if err := id.Validate(); err != nil {
 		return Source{}, err

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -146,9 +146,12 @@ func MustDeliveryID(s string) DeliveryID {
 	return id
 }
 
-// minSecretLen is the floor for an HMAC secret. 16 bytes (128 bits) is the
-// minimum recommended for HMAC-SHA256 keying material.
-const minSecretLen = 16
+// minSecretLen is the floor for an HMAC secret: 24 bytes (192 bits). This sits
+// well above the NIST SP800-107 floor of L/2 = 128 bits for HMAC-SHA256 while
+// staying compatible with real provider secrets — Svix issues 24-byte keys, so
+// a higher floor (e.g. 32) would reject genuine Svix/provider secrets and break
+// inbound verification. Outbound (dispatcher) secrets should prefer 32+ bytes.
+const minSecretLen = 24
 
 // Source is an opaque webhook source: an identifier plus the shared secret
 // used to sign/verify its deliveries. The secret is an unexported field with
@@ -162,7 +165,8 @@ type Source struct {
 }
 
 // NewSource validates id and secret and returns a [Source]. The secret must be
-// at least 16 bytes (128-bit minimum for HMAC-SHA256 keying material).
+// at least 24 bytes (192-bit floor; above NIST's 128-bit HMAC-SHA256 minimum
+// and compatible with provider keys such as Svix's 24-byte secrets).
 func NewSource(id SourceID, secret []byte) (Source, error) {
 	if err := id.Validate(); err != nil {
 		return Source{}, err

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"fmt"
 	"log/slog"
 	"regexp"
 
@@ -197,10 +198,29 @@ func (s Source) LogValue() slog.Value {
 	)
 }
 
-// Compile-time guarantee that Source redacts itself when logged — the
-// type-system half of the secret-leak defense (WEBHOOK-HMAC-FUNNEL-01 B6).
-// slog.Any honors slog.LogValuer, so even slog.Any("source", src) is safe.
-var _ slog.LogValuer = Source{}
+// String implements fmt.Stringer so fmt.Sprintf("%v", src), fmt.Errorf("… %v",
+// src), and log.Print(src) never leak the secret. fmt invokes String for %v,
+// %s, %q, and %+v — covering every non-#v verb. slog.LogValuer only covers the
+// slog package, so this closes the fmt/log/panic path (WEBHOOK-HMAC-FUNNEL-01
+// secret-leak defense).
+func (s Source) String() string {
+	return "Source(id=" + string(s.id) + ", secret=" + redaction.Mask + ")"
+}
+
+// GoString implements fmt.GoStringer so fmt.Sprintf("%#v", src) is also safe.
+func (s Source) GoString() string {
+	return "webhook.Source{id:" + string(s.id) + ", secret:" + redaction.Mask + "}"
+}
+
+// Compile-time guarantee that Source redacts itself across every formatting
+// path — the type-system half of the secret-leak defense
+// (WEBHOOK-HMAC-FUNNEL-01 B6). slog.Any honors slog.LogValuer; fmt honors
+// Stringer (%v/%s/%q/%+v) and GoStringer (%#v).
+var (
+	_ slog.LogValuer = Source{}
+	_ fmt.Stringer   = Source{}
+	_ fmt.GoStringer = Source{}
+)
 
 // Headers is the set of signature headers a [Signer] produces and a [Verifier]
 // consumes. Timestamp is unix seconds as a decimal string; Signature is one or

--- a/kernel/webhook/webhook_test.go
+++ b/kernel/webhook/webhook_test.go
@@ -1,0 +1,272 @@
+package webhook
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// redactionMask is the literal a redacted secret renders as (pkg/redaction.Mask).
+const redactionMask = "<REDACTED>"
+
+// fixedClock returns a clock pinned to a deterministic instant for tests that
+// do not depend on a specific vector timestamp.
+func fixedClock(t *testing.T) clock.Clock {
+	t.Helper()
+	return clockmock.New(time.Unix(1700000000, 0))
+}
+
+func nowUnixString(clk clock.Clock) string {
+	return strconv.FormatInt(clk.Now().Unix(), 10)
+}
+
+func minSecret() []byte { return bytes.Repeat([]byte("k"), minSecretLen) }
+
+func TestAlgorithmValidate(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, AlgorithmHMACSHA256.Validate())
+	assert.Equal(t, "hmac-sha256", AlgorithmHMACSHA256.String())
+
+	err := Algorithm("hmac-sha1").Validate()
+	requireErrCode(t, err, errcode.ErrWebhookAlgorithmUnsupported, errcode.KindInvalid)
+}
+
+func TestSourceIDValidate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"valid", "stripe", false},
+		{"valid_with_sep", "shopify-orders_v1", false},
+		{"empty", "", true},
+		{"uppercase", "Stripe", true},
+		{"leading_digit", "1stripe", true},
+		{"too_long", strings.Repeat("a", sourceIDMaxLen+1), true},
+		{"dot_forbidden", "stripe.payments", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := NewSourceID(tc.in)
+			if tc.wantErr {
+				requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+				assert.Equal(t, SourceID(""), id)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, SourceID(tc.in), id)
+		})
+	}
+}
+
+func TestMustSourceID(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, SourceID("stripe"), MustSourceID("stripe"))
+	assert.Panics(t, func() { MustSourceID("Bad-ID") })
+}
+
+func TestNewtypeString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "stripe", SourceID("stripe").String())
+	assert.Equal(t, "evt_1", DeliveryID("evt_1").String())
+}
+
+func TestDeliveryIDValidate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"uuid_like", "msg_p5jXN8AQM9LWM0D4loKWxJek", false},
+		{"colon_dot_segments", "evt:1.2-3_x", false},
+		{"empty", "", true},
+		{"whitespace", "evt 001", true},
+		{"too_long", strings.Repeat("a", deliveryIDMaxLen+1), true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := NewDeliveryID(tc.in)
+			if tc.wantErr {
+				requireErrCode(t, err, errcode.ErrWebhookInvalidHeader, errcode.KindInvalid)
+				assert.Equal(t, DeliveryID(""), id)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, DeliveryID(tc.in), id)
+		})
+	}
+}
+
+func TestMustDeliveryID(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, DeliveryID("evt_1"), MustDeliveryID("evt_1"))
+	assert.Panics(t, func() { MustDeliveryID("evt 1") })
+}
+
+func TestNewSource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		src, err := NewSource(MustSourceID("stripe"), minSecret())
+		require.NoError(t, err)
+		assert.Equal(t, SourceID("stripe"), src.ID())
+	})
+
+	t.Run("secret_too_short", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewSource(MustSourceID("stripe"), []byte("short"))
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+
+	t.Run("bad_source_id", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewSource(SourceID("Bad"), minSecret())
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+
+	t.Run("defensive_copy", func(t *testing.T) {
+		t.Parallel()
+		secret := minSecret()
+		src, err := NewSource(MustSourceID("stripe"), secret)
+		require.NoError(t, err)
+		signer, err := NewHMACSigner(src)
+		require.NoError(t, err)
+		ts := time.Unix(1700000000, 0)
+		before, err := signer.Sign([]byte("body"), ts, MustDeliveryID("d1"))
+		require.NoError(t, err)
+
+		// Mutating the caller's slice must not change the source's secret.
+		for i := range secret {
+			secret[i] = 'x'
+		}
+		after, err := signer.Sign([]byte("body"), ts, MustDeliveryID("d1"))
+		require.NoError(t, err)
+		assert.Equal(t, before.Signature, after.Signature)
+	})
+}
+
+// TestSourceLogValueRedactsSecret asserts the slog.LogValuer implementation
+// never emits the raw secret — the type-system half of the Source-leak defense.
+func TestSourceLogValueRedactsSecret(t *testing.T) {
+	t.Parallel()
+	rawSecret := []byte("topsecret-hmac-key-material")
+	src, err := NewSource(MustSourceID("stripe"), rawSecret)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("verifying", slog.Any("source", src))
+
+	out := buf.String()
+	assert.Contains(t, out, redactionMask, "secret must render as the mask")
+	assert.NotContains(t, out, string(rawSecret), "raw secret must never reach the log")
+	assert.Contains(t, out, "stripe", "non-secret id is still observable")
+
+	// Assert the structured value directly too.
+	v := src.LogValue()
+	require.Equal(t, slog.KindGroup, v.Kind())
+	var secretAttr string
+	for _, a := range v.Group() {
+		if a.Key == "secret" {
+			secretAttr = a.Value.String()
+		}
+	}
+	assert.Equal(t, redactionMask, secretAttr)
+}
+
+// TestSentinelKindMappingAtConstructionSites verifies that the webhook
+// sentinels reachable in PR-1 are constructed with the intended Kind, so the
+// Kind→HTTP-status contract holds at the real construction points (errcode_test
+// only freezes the code strings).
+func TestSentinelKindMappingAtConstructionSites(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		trigger    func() error
+		wantCode   errcode.Code
+		wantStatus int
+	}{
+		{
+			name:       "algorithm_unsupported_400",
+			trigger:    func() error { return Algorithm("sha1").Validate() },
+			wantCode:   errcode.ErrWebhookAlgorithmUnsupported,
+			wantStatus: 400,
+		},
+		{
+			name:       "config_invalid_400",
+			trigger:    func() error { return SourceID("").Validate() },
+			wantCode:   errcode.ErrWebhookConfigInvalid,
+			wantStatus: 400,
+		},
+		{
+			name:       "invalid_header_400",
+			trigger:    func() error { return DeliveryID("").Validate() },
+			wantCode:   errcode.ErrWebhookInvalidHeader,
+			wantStatus: 400,
+		},
+		{
+			name: "timestamp_expired_401",
+			trigger: func() error {
+				v, _ := NewHMACVerifier(fixedClock(t))
+				src, _ := NewSource(MustSourceID("s"), minSecret())
+				return v.Verify([]byte("b"),
+					Headers{DeliveryID: "d1", Timestamp: "1", Signature: "v1,AA=="}, src)
+			},
+			wantCode:   errcode.ErrWebhookTimestampExpired,
+			wantStatus: 401,
+		},
+		{
+			name: "invalid_signature_401",
+			trigger: func() error {
+				clk := fixedClock(t)
+				v, _ := NewHMACVerifier(clk)
+				src, _ := NewSource(MustSourceID("s"), minSecret())
+				return v.Verify([]byte("b"), Headers{
+					DeliveryID: "d1",
+					Timestamp:  nowUnixString(clk),
+					Signature:  "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+				}, src)
+			},
+			wantCode:   errcode.ErrWebhookInvalidSignature,
+			wantStatus: 401,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.trigger()
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec), "want *errcode.Error, got %v", err)
+			assert.Equal(t, tc.wantCode, ec.Code)
+			assert.Equal(t, tc.wantStatus, ec.Kind.Status())
+		})
+	}
+}
+
+// requireErrCode asserts err is an *errcode.Error with the given code and kind.
+func requireErrCode(t *testing.T, err error, code errcode.Code, kind errcode.Kind) {
+	t.Helper()
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec), "want *errcode.Error, got %v", err)
+	assert.Equal(t, code, ec.Code)
+	assert.Equal(t, kind, ec.Kind)
+}

--- a/kernel/webhook/webhook_test.go
+++ b/kernel/webhook/webhook_test.go
@@ -56,6 +56,7 @@ func TestSourceIDValidate(t *testing.T) {
 		{"leading_digit", "1stripe", true},
 		{"too_long", strings.Repeat("a", sourceIDMaxLen+1), true},
 		{"dot_forbidden", "stripe.payments", true},
+		{"max_len_valid", strings.Repeat("a", sourceIDMaxLen), false},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -97,6 +98,7 @@ func TestDeliveryIDValidate(t *testing.T) {
 		{"empty", "", true},
 		{"whitespace", "evt 001", true},
 		{"too_long", strings.Repeat("a", deliveryIDMaxLen+1), true},
+		{"max_len_valid", strings.Repeat("a", deliveryIDMaxLen), false},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/kernel/webhook/webhook_test.go
+++ b/kernel/webhook/webhook_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -192,6 +193,27 @@ func TestSourceLogValueRedactsSecret(t *testing.T) {
 		}
 	}
 	assert.Equal(t, redactionMask, secretAttr)
+}
+
+// TestSourceFmtRedactsSecret asserts the fmt-path defense (F1): String and
+// GoString keep the secret out of every fmt/log verb, since slog.LogValuer does
+// not cover fmt/log/panic.
+func TestSourceFmtRedactsSecret(t *testing.T) {
+	t.Parallel()
+	rawSecret := []byte("topsecret-hmac-key-material")
+	src, err := NewSource(MustSourceID("stripe"), rawSecret)
+	require.NoError(t, err)
+
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s", "%q"} {
+		out := fmt.Sprintf(verb, src)
+		assert.NotContains(t, out, string(rawSecret), "verb %s must not leak the raw secret", verb)
+		assert.Contains(t, out, redactionMask, "verb %s must render the mask", verb)
+		assert.Contains(t, out, "stripe", "verb %s keeps the non-secret id observable", verb)
+	}
+
+	// A Source embedded in an error wrapped with %v must also stay redacted.
+	wrapped := fmt.Errorf("processing %v: boom", src)
+	assert.NotContains(t, wrapped.Error(), string(rawSecret))
 }
 
 // TestSentinelKindMappingAtConstructionSites verifies that the webhook

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -712,6 +712,55 @@ const (
 	// ErrConflict so operator dashboards can route saga producer-side races
 	// separately from cell-wide conflict signals.
 	ErrSagaDuplicateInstance Code = "ERR_SAGA_DUPLICATE_INSTANCE"
+
+	// Webhook signing / verification / delivery codes (KERNEL-WEBHOOK-01).
+	// Each comment notes the intended Kind the construction site passes to
+	// errcode.New — the sentinel itself carries no Kind (Kind is framework-owned
+	// per status.go and set per call). kernel/webhook constructs these as
+	// *errcode.Error so handlers/consumers can errors.As + map to HTTP.
+
+	// ErrWebhookInvalidSignature signals HMAC signature verification failed —
+	// the recomputed digest does not match any presented signature header.
+	// Constructed with KindUnauthenticated → HTTP 401.
+	ErrWebhookInvalidSignature Code = "ERR_WEBHOOK_INVALID_SIGNATURE"
+	// ErrWebhookTimestampExpired signals the signed timestamp falls outside the
+	// allowed replay window (default ±5min). Constructed with
+	// KindUnauthenticated → HTTP 401.
+	ErrWebhookTimestampExpired Code = "ERR_WEBHOOK_TIMESTAMP_EXPIRED"
+	// ErrWebhookDuplicateDelivery signals a delivery ID was already processed
+	// (idempotent replay). Constructed with KindConflict → HTTP 409.
+	ErrWebhookDuplicateDelivery Code = "ERR_WEBHOOK_DUPLICATE_DELIVERY"
+	// ErrWebhookInvalidHeader signals a required signature header is missing or
+	// malformed (bad scheme, unparseable timestamp). Constructed with
+	// KindInvalid → HTTP 400.
+	ErrWebhookInvalidHeader Code = "ERR_WEBHOOK_INVALID_HEADER"
+	// ErrWebhookAlgorithmUnsupported signals an unrecognized / disallowed signing
+	// algorithm (only HMAC-SHA256 is legal). Constructed with KindInvalid →
+	// HTTP 400.
+	ErrWebhookAlgorithmUnsupported Code = "ERR_WEBHOOK_ALGORITHM_UNSUPPORTED"
+	// ErrWebhookSourceNotFound signals the source ID has no registered secret.
+	// Constructed with KindNotFound → HTTP 404.
+	ErrWebhookSourceNotFound Code = "ERR_WEBHOOK_SOURCE_NOT_FOUND"
+	// ErrWebhookSSRFBlocked signals an outbound dispatch target resolved to a
+	// blocked address (SSRF defense). Constructed with KindPermissionDenied →
+	// HTTP 403.
+	ErrWebhookSSRFBlocked Code = "ERR_WEBHOOK_SSRF_BLOCKED"
+	// ErrWebhookDeliveryFailed signals a transient delivery failure (connection
+	// refused, 5xx from target). Constructed with KindUnavailable → HTTP 503.
+	ErrWebhookDeliveryFailed Code = "ERR_WEBHOOK_DELIVERY_FAILED"
+	// ErrWebhookDeliveryTimeout signals delivery exceeded its deadline.
+	// Constructed with KindDeadlineExceeded → HTTP 504.
+	ErrWebhookDeliveryTimeout Code = "ERR_WEBHOOK_DELIVERY_TIMEOUT"
+	// ErrWebhookPermanentFailure signals a non-retryable delivery failure
+	// (retry budget exhausted, endpoint disabled). Constructed with KindInternal
+	// → HTTP 500.
+	ErrWebhookPermanentFailure Code = "ERR_WEBHOOK_PERMANENT_FAILURE"
+	// ErrWebhookBodyTooLarge signals the inbound webhook body exceeded the size
+	// limit. Constructed with KindPayloadTooLarge → HTTP 413.
+	ErrWebhookBodyTooLarge Code = "ERR_WEBHOOK_BODY_TOO_LARGE"
+	// ErrWebhookConfigInvalid signals invalid webhook configuration (bad source
+	// ID / delivery ID / empty secret). Constructed with KindInvalid → HTTP 400.
+	ErrWebhookConfigInvalid Code = "ERR_WEBHOOK_CONFIG_INVALID"
 )
 
 // PublicError is the structured projection shared by HTTP responses, CLI text

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -742,8 +742,13 @@ const (
 	// HTTP 400.
 	ErrWebhookAlgorithmUnsupported Code = "ERR_WEBHOOK_ALGORITHM_UNSUPPORTED"
 	// ErrWebhookSourceNotFound signals the source ID has no registered secret.
-	// Constructed with KindNotFound → HTTP 404. First constructed in PR-3
-	// (receiver runtime).
+	// KindNotFound → HTTP 404 is ONLY for management/config lookups
+	// (list/get source). On the inbound receive/verify path this sentinel MUST
+	// NOT be used — the receiver must return ErrWebhookInvalidSignature
+	// (KindUnauthenticated → 401) for any source-lookup failure, so the response
+	// is byte-identical to a bad-signature failure and cannot be used to
+	// enumerate which source IDs exist (via either HTTP status or wire error
+	// code). First constructed in PR-3 (receiver runtime).
 	ErrWebhookSourceNotFound Code = "ERR_WEBHOOK_SOURCE_NOT_FOUND"
 	// ErrWebhookSSRFBlocked signals an outbound dispatch target resolved to a
 	// blocked address (SSRF defense). Constructed with KindPermissionDenied →

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -728,7 +728,10 @@ const (
 	// KindUnauthenticated → HTTP 401.
 	ErrWebhookTimestampExpired Code = "ERR_WEBHOOK_TIMESTAMP_EXPIRED"
 	// ErrWebhookDuplicateDelivery signals a delivery ID was already processed
-	// (idempotent replay). Constructed with KindConflict → HTTP 409.
+	// (idempotent replay). Receiver maps idempotent replay to HTTP 200; this
+	// sentinel classifies the replay for logging. The wire status (200
+	// idempotent vs 409) is decided in PR-3 (receiver runtime). First
+	// constructed in PR-3 (receiver runtime).
 	ErrWebhookDuplicateDelivery Code = "ERR_WEBHOOK_DUPLICATE_DELIVERY"
 	// ErrWebhookInvalidHeader signals a required signature header is missing or
 	// malformed (bad scheme, unparseable timestamp). Constructed with
@@ -739,24 +742,28 @@ const (
 	// HTTP 400.
 	ErrWebhookAlgorithmUnsupported Code = "ERR_WEBHOOK_ALGORITHM_UNSUPPORTED"
 	// ErrWebhookSourceNotFound signals the source ID has no registered secret.
-	// Constructed with KindNotFound → HTTP 404.
+	// Constructed with KindNotFound → HTTP 404. First constructed in PR-3
+	// (receiver runtime).
 	ErrWebhookSourceNotFound Code = "ERR_WEBHOOK_SOURCE_NOT_FOUND"
 	// ErrWebhookSSRFBlocked signals an outbound dispatch target resolved to a
 	// blocked address (SSRF defense). Constructed with KindPermissionDenied →
-	// HTTP 403.
+	// HTTP 403. First constructed in PR-4 (SSRF guard).
 	ErrWebhookSSRFBlocked Code = "ERR_WEBHOOK_SSRF_BLOCKED"
 	// ErrWebhookDeliveryFailed signals a transient delivery failure (connection
 	// refused, 5xx from target). Constructed with KindUnavailable → HTTP 503.
+	// First constructed in PR-5 (dispatcher).
 	ErrWebhookDeliveryFailed Code = "ERR_WEBHOOK_DELIVERY_FAILED"
 	// ErrWebhookDeliveryTimeout signals delivery exceeded its deadline.
-	// Constructed with KindDeadlineExceeded → HTTP 504.
+	// Constructed with KindDeadlineExceeded → HTTP 504. First constructed in
+	// PR-5 (dispatcher).
 	ErrWebhookDeliveryTimeout Code = "ERR_WEBHOOK_DELIVERY_TIMEOUT"
 	// ErrWebhookPermanentFailure signals a non-retryable delivery failure
 	// (retry budget exhausted, endpoint disabled). Constructed with KindInternal
-	// → HTTP 500.
+	// → HTTP 500. First constructed in PR-5 (dispatcher).
 	ErrWebhookPermanentFailure Code = "ERR_WEBHOOK_PERMANENT_FAILURE"
 	// ErrWebhookBodyTooLarge signals the inbound webhook body exceeded the size
-	// limit. Constructed with KindPayloadTooLarge → HTTP 413.
+	// limit. Constructed with KindPayloadTooLarge → HTTP 413. First constructed
+	// in PR-3 (receiver runtime).
 	ErrWebhookBodyTooLarge Code = "ERR_WEBHOOK_BODY_TOO_LARGE"
 	// ErrWebhookConfigInvalid signals invalid webhook configuration (bad source
 	// ID / delivery ID / empty secret). Constructed with KindInvalid → HTTP 400.

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -36,6 +36,7 @@ func (e errcodeAsError) As(target any) bool {
 // strings so renames are caught. The intended Kind→HTTP mapping is verified at
 // the real construction points in kernel/webhook/webhook_test.go.
 func TestWebhookSentinelCodes(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		code Code
 		want string
@@ -57,7 +58,9 @@ func TestWebhookSentinelCodes(t *testing.T) {
 		t.Fatalf("expected 12 webhook sentinels, got %d", len(cases))
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tc.want, string(tc.code))
 		})
 	}

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -30,6 +30,39 @@ func (e errcodeAsError) As(target any) bool {
 	return true
 }
 
+// TestWebhookSentinelCodes locks the wire code string of every webhook sentinel
+// (KERNEL-WEBHOOK-01). Sentinels carry no intrinsic Kind — Kind is set at the
+// construction site (see kernel/webhook); this test only freezes the code
+// strings so renames are caught. The intended Kind→HTTP mapping is verified at
+// the real construction points in kernel/webhook/webhook_test.go.
+func TestWebhookSentinelCodes(t *testing.T) {
+	cases := []struct {
+		code Code
+		want string
+	}{
+		{ErrWebhookInvalidSignature, "ERR_WEBHOOK_INVALID_SIGNATURE"},
+		{ErrWebhookTimestampExpired, "ERR_WEBHOOK_TIMESTAMP_EXPIRED"},
+		{ErrWebhookDuplicateDelivery, "ERR_WEBHOOK_DUPLICATE_DELIVERY"},
+		{ErrWebhookInvalidHeader, "ERR_WEBHOOK_INVALID_HEADER"},
+		{ErrWebhookAlgorithmUnsupported, "ERR_WEBHOOK_ALGORITHM_UNSUPPORTED"},
+		{ErrWebhookSourceNotFound, "ERR_WEBHOOK_SOURCE_NOT_FOUND"},
+		{ErrWebhookSSRFBlocked, "ERR_WEBHOOK_SSRF_BLOCKED"},
+		{ErrWebhookDeliveryFailed, "ERR_WEBHOOK_DELIVERY_FAILED"},
+		{ErrWebhookDeliveryTimeout, "ERR_WEBHOOK_DELIVERY_TIMEOUT"},
+		{ErrWebhookPermanentFailure, "ERR_WEBHOOK_PERMANENT_FAILURE"},
+		{ErrWebhookBodyTooLarge, "ERR_WEBHOOK_BODY_TOO_LARGE"},
+		{ErrWebhookConfigInvalid, "ERR_WEBHOOK_CONFIG_INVALID"},
+	}
+	if len(cases) != 12 {
+		t.Fatalf("expected 12 webhook sentinels, got %d", len(cases))
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, string(tc.code))
+		})
+	}
+}
+
 func TestNewWrapAndOptions(t *testing.T) {
 	cause := errors.New("pool exhausted")
 	err := Wrap(

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -59,7 +59,8 @@ const sensitiveKeyPattern = `password|passwd|pwd|secret|` +
 	`private[_-]?key|signing[_-]?key|dsn|` +
 	// Webhook signing surface (KERNEL-WEBHOOK-01): inbound/outbound HMAC
 	// secrets + signature headers in Svix/Stripe/GitHub naming variants.
-	`webhook[_-]?secret|x[_-]?signature|x[_-]?hub[_-]?signature|` +
+	`webhook[_-]?secret|stripe[_-]?signature|x[_-]?signature|` +
+	`x[_-]?hub[_-]?signature(?:[_-](?:256|1))?|` +
 	`x[_-]?webhook[_-]?signature|svix[_-]?signature|hmac[_-]?key`
 
 // defaultPattern matches single-token `key=value` / `key: value` forms.

--- a/pkg/redaction/redaction.go
+++ b/pkg/redaction/redaction.go
@@ -56,7 +56,11 @@ var connectionStringPattern = regexp.MustCompile(
 const sensitiveKeyPattern = `password|passwd|pwd|secret|` +
 	`access[_-]?token|refresh[_-]?token|id[_-]?token|token|` +
 	`authorization|connection[_ ]?string|api[_-]?key|bearer|` +
-	`private[_-]?key|signing[_-]?key|dsn`
+	`private[_-]?key|signing[_-]?key|dsn|` +
+	// Webhook signing surface (KERNEL-WEBHOOK-01): inbound/outbound HMAC
+	// secrets + signature headers in Svix/Stripe/GitHub naming variants.
+	`webhook[_-]?secret|x[_-]?signature|x[_-]?hub[_-]?signature|` +
+	`x[_-]?webhook[_-]?signature|svix[_-]?signature|hmac[_-]?key`
 
 // defaultPattern matches single-token `key=value` / `key: value` forms.
 //

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -275,6 +275,21 @@ func TestRedactString(t *testing.T) {
 			want: "signer init: hmac_key=<REDACTED> done",
 		},
 		{
+			name: "stripe_sig_kv",
+			in:   "stripe_signature=abc next=ok",
+			want: "stripe_signature=<REDACTED> next=ok",
+		},
+		{
+			name: "x_hub_signature_256_kv",
+			in:   "x_hub_signature_256=abc trailing",
+			want: "x_hub_signature_256=<REDACTED> trailing",
+		},
+		{
+			name: "x_hub_signature_1_kv",
+			in:   "x-hub-signature-1=abc trailing",
+			want: "x-hub-signature-1=<REDACTED> trailing",
+		},
+		{
 			name: "empty",
 			in:   "",
 			want: "",
@@ -489,6 +504,12 @@ func TestIsSensitiveKey(t *testing.T) {
 		{"svix-signature", true},
 		{"hmac_key", true},
 		{"hmac-key", true},
+		// stripe + x-hub-signature-256/-1 variants (SEC-02/SEC-03)
+		{"stripe_signature", true},
+		{"stripe-signature", true},
+		{"x_hub_signature_256", true},
+		{"x-hub-signature-256", true},
+		{"x-hub-signature-1", true},
 		// case insensitivity
 		{"PASSWORD", true},
 		{"API_KEY", true},

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -255,6 +255,26 @@ func TestRedactString(t *testing.T) {
 			want: "plain validation error: field foo missing",
 		},
 		{
+			name: "webhook_secret_keyEqValue",
+			in:   "config rejected: webhook_secret=whsec_abc123 source=stripe",
+			want: "config rejected: webhook_secret=<REDACTED> source=stripe",
+		},
+		{
+			name: "x_signature_json",
+			in:   `{"x-signature":"v1,abc==","deliveryId":"d-1"}`,
+			want: `{"x-signature":"<REDACTED>","deliveryId":"d-1"}`,
+		},
+		{
+			name: "svix_signature_keyColon",
+			in:   "verify failed: svix_signature: v1,deadbeef",
+			want: "verify failed: svix_signature: <REDACTED>",
+		},
+		{
+			name: "hmac_key_keyEqValue",
+			in:   "signer init: hmac_key=supersecret done",
+			want: "signer init: hmac_key=<REDACTED> done",
+		},
+		{
 			name: "empty",
 			in:   "",
 			want: "",
@@ -454,6 +474,21 @@ func TestIsSensitiveKey(t *testing.T) {
 		{"private_key", true},
 		{"signing_key", true},
 		{"dsn", true},
+		// webhook signing surface (KERNEL-WEBHOOK-01)
+		{"webhook_secret", true},
+		{"webhook-secret", true},
+		{"webhooksecret", true},
+		{"webhookSecret", true},
+		{"x_signature", true},
+		{"x-signature", true},
+		{"x_hub_signature", true},
+		{"x-hub-signature", true},
+		{"x_webhook_signature", true},
+		{"x-webhook-signature", true},
+		{"svix_signature", true},
+		{"svix-signature", true},
+		{"hmac_key", true},
+		{"hmac-key", true},
 		// case insensitivity
 		{"PASSWORD", true},
 		{"API_KEY", true},

--- a/tools/archtest/testdata/webhook_hmac_violate/go.mod
+++ b/tools/archtest/testdata/webhook_hmac_violate/go.mod
@@ -1,0 +1,7 @@
+module fixturetest/webhook_hmac_violate
+
+go 1.25.10
+
+replace github.com/ghbvf/gocell => ../../../..
+
+require github.com/ghbvf/gocell v0.0.0

--- a/tools/archtest/testdata/webhook_hmac_violate/signer.go
+++ b/tools/archtest/testdata/webhook_hmac_violate/signer.go
@@ -1,0 +1,20 @@
+// This fixture file is named signer.go to exercise WEBHOOK-HMAC-FUNNEL-01/A1's
+// FUNCTION-level check: crypto/hmac.New here is inside signer.go but NOT inside
+// computeMAC, so scanWebhookHMACNew must still flag it (file-level allowlisting
+// would wrongly pass this).
+//
+// DO NOT use this package in production code.
+package webhook_hmac_violate
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+)
+
+// notComputeMAC sits in signer.go but is not computeMAC — the A1 function-level
+// check must fire on this hmac.New.
+func notComputeMAC(secret, payload []byte) []byte {
+	mac := hmac.New(sha256.New, secret) // VIOLATION A1 (signer.go, non-computeMAC func)
+	mac.Write(payload)
+	return mac.Sum(nil)
+}

--- a/tools/archtest/testdata/webhook_hmac_violate/violations.go
+++ b/tools/archtest/testdata/webhook_hmac_violate/violations.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"log/slog"
 )
 
 // ── A1 violation: crypto/hmac.New outside kernel/webhook/signer.go ───────────
@@ -26,3 +27,9 @@ func forgeMAC(secret, payload []byte) []byte {
 func compareSig(a, b []byte) bool {
 	return bytes.Equal(a, b) // VIOLATION A2
 }
+
+// ── B6 violation: slog call referencing a raw .secret field ──────────────────
+// scanWebhookSecretSlog must detect this call.
+type leakyHolder struct{ secret []byte }
+
+func (h leakyHolder) logIt() { slog.Info("dump", slog.Any("secret", h.secret)) } // VIOLATION B6

--- a/tools/archtest/testdata/webhook_hmac_violate/violations.go
+++ b/tools/archtest/testdata/webhook_hmac_violate/violations.go
@@ -11,25 +11,34 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"log/slog"
+	"reflect"
+	"slices"
 )
 
-// ── A1 violation: crypto/hmac.New outside kernel/webhook/signer.go ───────────
+// ── A1 violation (file-level): crypto/hmac.New outside signer.go ─────────────
 // scanWebhookHMACNew must detect this call (the file is violations.go, not
-// signer.go).
+// signer.go). The in-signer.go-but-outside-computeMAC form lives in signer.go.
 func forgeMAC(secret, payload []byte) []byte {
-	mac := hmac.New(sha256.New, secret) // VIOLATION A1
+	mac := hmac.New(sha256.New, secret) // VIOLATION A1 (outside signer.go)
 	mac.Write(payload)
 	return mac.Sum(nil)
 }
 
-// ── A2 violation: signature comparison via bytes.Equal instead of hmac.Equal ─
-// scanWebhookBytesEqual must detect this call.
+// ── A2 violations: non-constant-time comparison callees ──────────────────────
+// scanWebhookBytesEqual must detect each of these.
 func compareSig(a, b []byte) bool {
-	return bytes.Equal(a, b) // VIOLATION A2
+	return bytes.Equal(a, b) || // VIOLATION A2 (bytes.Equal)
+		bytes.Compare(a, b) == 0 || // VIOLATION A2 (bytes.Compare)
+		slices.Equal(a, b) || // VIOLATION A2 (slices.Equal)
+		reflect.DeepEqual(a, b) // VIOLATION A2 (reflect.DeepEqual)
 }
 
-// ── B6 violation: slog call referencing a raw .secret field ──────────────────
-// scanWebhookSecretSlog must detect this call.
+// ── B6 violations: slog calls referencing a raw .secret field ────────────────
+// scanWebhookSecretSlog must detect BOTH the package-function form and the
+// *slog.Logger method form.
 type leakyHolder struct{ secret []byte }
 
-func (h leakyHolder) logIt() { slog.Info("dump", slog.Any("secret", h.secret)) } // VIOLATION B6
+var fixtureLogger *slog.Logger
+
+func (h leakyHolder) logIt()       { slog.Info("dump", slog.Any("secret", h.secret)) }          // VIOLATION B6 (pkg func)
+func (h leakyHolder) logItMethod() { fixtureLogger.Info("dump", slog.Any("secret", h.secret)) } // VIOLATION B6 (method)

--- a/tools/archtest/testdata/webhook_hmac_violate/violations.go
+++ b/tools/archtest/testdata/webhook_hmac_violate/violations.go
@@ -1,0 +1,28 @@
+// Package webhook_hmac_violate is a synthetic violation fixture for the
+// WEBHOOK-HMAC-FUNNEL-01 archtest rule. Each violation form is exercised once
+// so the reverse self-test (TestWebhookHMACFunnel_ReverseFixture) can assert
+// the corresponding rule fires.
+//
+// DO NOT use this package in production code.
+package webhook_hmac_violate
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+)
+
+// ── A1 violation: crypto/hmac.New outside kernel/webhook/signer.go ───────────
+// scanWebhookHMACNew must detect this call (the file is violations.go, not
+// signer.go).
+func forgeMAC(secret, payload []byte) []byte {
+	mac := hmac.New(sha256.New, secret) // VIOLATION A1
+	mac.Write(payload)
+	return mac.Sum(nil)
+}
+
+// ── A2 violation: signature comparison via bytes.Equal instead of hmac.Equal ─
+// scanWebhookBytesEqual must detect this call.
+func compareSig(a, b []byte) bool {
+	return bytes.Equal(a, b) // VIOLATION A2
+}

--- a/tools/archtest/webhook_hmac_funnel_test.go
+++ b/tools/archtest/webhook_hmac_funnel_test.go
@@ -3,17 +3,18 @@
 // WEBHOOK-HMAC-FUNNEL-01 — kernel/webhook HMAC signing funnel (KERNEL-WEBHOOK-01).
 //
 //   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite in the
-//     kernel/webhook package — computeMAC in signer.go. Any other hmac.New call
-//     in the package fails. This also closes the package-internal upstream blind
-//     spot: any new struct that wants to sign MUST call hmac.New, which is
-//     allowlisted to signer.go, so an unsealed internal holder cannot produce a
+//     kernel/webhook package — the computeMAC function in signer.go. The check is
+//     FUNCTION-level, not file-level: an hmac.New in any other function (even
+//     inside signer.go) fails. This also closes the package-internal upstream
+//     blind spot: any new struct that wants to sign MUST call hmac.New, which is
+//     allowlisted to computeMAC, so an unsealed internal holder cannot produce a
 //     signature undetected. Detection: ResolvePackageRef(callee) == crypto/hmac.New
-//     AND enclosing file != signer.go.
+//     AND (file basename != signer.go OR enclosing func != computeMAC).
 //   - A2 (downstream Hard): signature comparison must use crypto/hmac.Equal or
-//     crypto/subtle.ConstantTimeCompare. bytes.Equal is banned in the package
-//     (it is not constant-time). This makes the constant-time invariant an AST
-//     lock rather than a flaky timing test. Detection:
-//     ResolvePackageRef(callee) == bytes.Equal in the package.
+//     crypto/subtle.ConstantTimeCompare. The non-constant-time comparison callees
+//     bytes.Equal / bytes.Compare / slices.Equal / reflect.DeepEqual are banned in
+//     the package. This makes the constant-time invariant an AST lock rather than
+//     a flaky timing test. Detection: ResolvePackageRef(callee) ∈ the banned set.
 //   - A3 (upstream Hard external / Medium internal): the Signer and Verifier
 //     interfaces each carry an unexported sealed() marker method, so
 //     package-external implementations are a compile error (Hard). Package-internal
@@ -26,12 +27,23 @@
 // Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
 //
 //	B-A1/A2 — rule-logic regression: a reverse fixture module
-//	  (testdata/webhook_hmac_violate) calls hmac.New outside signer.go and
-//	  bytes.Equal, and TestWebhookHMACFunnel_ReverseFixture asserts A1/A2 fire.
+//	  (testdata/webhook_hmac_violate) calls hmac.New outside computeMAC (both
+//	  outside signer.go and inside signer.go in a non-computeMAC func) and the
+//	  banned comparison callees; TestWebhookHMACFunnel_ReverseFixture asserts A1/A2
+//	  fire on each form.
 //	B6 — Source.Secret leak: slog of the raw unexported secret field would leak
 //	  it (Source.LogValue + slog.LogValuer covers slog.Any of a whole Source, but
-//	  not slog of src.secret directly). TestWebhookFunnel_NoRawSecretSlog asserts
-//	  no slog.* call in the package references a `.secret` selector.
+//	  not slog of src.secret directly). scanWebhookSecretSlog covers BOTH the
+//	  package-function form (slog.Info(...)) and the method form
+//	  (logger.Info(...)). TestWebhookFunnel_NoRawSecretSlog asserts no such call in
+//	  the package references a `.secret` selector.
+//	B7 — non-AST-detectable constant-time bypass: comparing the base64 signature
+//	  STRINGS with `==` (e.g. expectedB64 == presentedB64) is non-constant-time but
+//	  is a plain *ast.BinaryExpr with no resolvable callee, so the A2 callee scan
+//	  cannot see it. Detecting it would need type-level data-flow analysis. Bounded
+//	  response: production matchAnySignature compares raw MAC bytes via hmac.Equal
+//	  (A2-clean), and this blind spot is documented here so a future reviewer knows
+//	  the AST scan does not cover string-`==`.
 //
 // ref: docs/architecture/202605291200-adr-webhook-signing-algorithm.md
 // ref: tools/archtest/healthz_invariants_test.go (callsite-allowlist template)
@@ -50,65 +62,95 @@ import (
 )
 
 const (
-	webhookPkgPattern   = "./kernel/webhook/..."
-	webhookSignerSuffix = "kernel/webhook/signer.go"
-	hmacPkgPath         = "crypto/hmac"
-	slogPkgPath         = "log/slog"
+	webhookPkgPattern  = "./kernel/webhook/..."
+	signerFileBasename = "signer.go"
+	computeMACFuncName = "computeMAC"
+	hmacPkgPath        = "crypto/hmac"
+	slogPkgPath        = "log/slog"
 )
 
 // webhookSealedInterfaces are the interface type names in kernel/webhook that
 // must carry an unexported sealed() marker (A3).
 var webhookSealedInterfaces = map[string]bool{"Signer": true, "Verifier": true}
 
-// scanWebhookHMACNew implements A1: crypto/hmac.New callsites must live in
-// signer.go.
+// nonConstTimeCompareCallees is the A2 banned set: package-qualified callees
+// that compare bytes/values in non-constant time. Signature comparison must use
+// crypto/hmac.Equal or crypto/subtle.ConstantTimeCompare instead.
+var nonConstTimeCompareCallees = map[[2]string]bool{
+	{"bytes", "Equal"}:       true,
+	{"bytes", "Compare"}:     true,
+	{"slices", "Equal"}:      true,
+	{"reflect", "DeepEqual"}: true,
+}
+
+// scanWebhookHMACNew implements A1: crypto/hmac.New may be called only inside the
+// computeMAC function of signer.go (function-level, not merely file-level).
 func scanWebhookHMACNew(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
-	allowed := strings.HasSuffix(filepath.ToSlash(rel), webhookSignerSuffix)
+	inSignerFile := filepath.Base(filepath.ToSlash(rel)) == signerFileBasename
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
 		if !ok || pkgPath != hmacPkgPath || name != "New" {
 			return
 		}
-		if allowed {
-			return
+		if inSignerFile {
+			if fn, ok := ResolveEnclosingFunc(info, file, call); ok && fn != nil && fn.Name() == computeMACFuncName {
+				return
+			}
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
 			Line: fset.Position(call.Pos()).Line,
-			Message: "crypto/hmac.New called outside kernel/webhook/signer.go; " +
+			Message: "crypto/hmac.New called outside computeMAC (signer.go); " +
 				"all HMAC computation must funnel through computeMAC (WEBHOOK-HMAC-FUNNEL-01/A1)",
 		})
 	})
 	return out
 }
 
-// scanWebhookBytesEqual implements A2: bytes.Equal is banned in the package
-// (signature comparison must use hmac.Equal / subtle.ConstantTimeCompare).
+// scanWebhookBytesEqual implements A2: non-constant-time comparison callees are
+// banned in the package (signature comparison must use hmac.Equal /
+// subtle.ConstantTimeCompare). See nonConstTimeCompareCallees for the set; the
+// string-`==` form is the documented blind spot B7.
 func scanWebhookBytesEqual(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
-		if !ok || pkgPath != "bytes" || name != "Equal" {
+		if !ok || !nonConstTimeCompareCallees[[2]string{pkgPath, name}] {
 			return
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
 			Line: fset.Position(call.Pos()).Line,
-			Message: "bytes.Equal called in kernel/webhook; signature comparison must use " +
+			Message: pkgPath + "." + name + " called in kernel/webhook; signature comparison must use " +
 				"crypto/hmac.Equal or crypto/subtle.ConstantTimeCompare (WEBHOOK-HMAC-FUNNEL-01/A2)",
 		})
 	})
 	return out
 }
 
-// scanWebhookSecretSlog implements B6: no slog.* call may pass a `.secret`
-// selector (the raw unexported secret field).
+// isSlogCall reports whether call is a log/slog call in either form: a
+// package-function call (slog.Info(...)) or a method call on a *slog.Logger
+// (logger.Info(...)).
+func isSlogCall(call *ast.CallExpr, info *types.Info) bool {
+	if pkgPath, _, ok := ResolvePackageRef(info, call.Fun); ok && pkgPath == slogPkgPath {
+		return true
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	fn, ok := ResolveMethodCall(info, sel)
+	return ok && fn != nil && fn.Pkg() != nil && fn.Pkg().Path() == slogPkgPath
+}
+
+// scanWebhookSecretSlog implements B6: no slog call (package-function OR
+// *slog.Logger method form) may pass a `.secret` selector (the raw unexported
+// secret field).
 func scanWebhookSecretSlog(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, _, ok := ResolvePackageRef(info, call.Fun)
-		if !ok || pkgPath != slogPkgPath {
+		if !isSlogCall(call, info) {
 			return
 		}
 		for _, arg := range call.Args {
@@ -226,9 +268,16 @@ func TestWebhookHMACFunnel_ReverseFixture(t *testing.T) {
 			return nil
 		})
 
-	assert.NotEmpty(t, a1, "A1 reverse fixture: expected ≥1 diagnostic for hmac.New outside signer.go")
-	assert.NotEmpty(t, a2, "A2 reverse fixture: expected ≥1 diagnostic for bytes.Equal")
-	assert.NotEmpty(t, b6, "B6 reverse fixture: expected ≥1 diagnostic for slog of .secret")
+	// A1: both forms must fire — hmac.New outside signer.go (violations.go) AND
+	// hmac.New inside signer.go but outside computeMAC (signer.go fixture file).
+	assert.GreaterOrEqual(t, len(a1), 2,
+		"A1 reverse fixture: expected ≥2 diagnostics (hmac.New outside signer.go + inside signer.go non-computeMAC)")
+	// A2: every banned comparison callee must fire (Equal/Compare/slices.Equal/reflect.DeepEqual).
+	assert.GreaterOrEqual(t, len(a2), 4,
+		"A2 reverse fixture: expected ≥4 diagnostics (bytes.Equal/bytes.Compare/slices.Equal/reflect.DeepEqual)")
+	// B6: both the package-function form and the *slog.Logger method form must fire.
+	assert.GreaterOrEqual(t, len(b6), 2,
+		"B6 reverse fixture: expected ≥2 diagnostics (slog.Info package form + logger.Info method form)")
 }
 
 // TestWebhookFunnel_NoRawSecretSlog is the B6 blind-spot self-check: production

--- a/tools/archtest/webhook_hmac_funnel_test.go
+++ b/tools/archtest/webhook_hmac_funnel_test.go
@@ -208,7 +208,7 @@ func TestWebhookHMACFunnel_ReverseFixture(t *testing.T) {
 	root := findModuleRoot(t)
 	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_hmac_violate")
 
-	var a1, a2 []Diagnostic
+	var a1, a2, b6 []Diagnostic
 	_ = RunTypedDir(t, fixtureDir, TypedOpts{Tests: false}, []string{"./..."},
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
@@ -221,12 +221,14 @@ func TestWebhookHMACFunnel_ReverseFixture(t *testing.T) {
 				}
 				a1 = append(a1, scanWebhookHMACNew(p.Fset, f, rel, p.TypesInfo)...)
 				a2 = append(a2, scanWebhookBytesEqual(p.Fset, f, rel, p.TypesInfo)...)
+				b6 = append(b6, scanWebhookSecretSlog(p.Fset, f, rel, p.TypesInfo)...)
 			}
 			return nil
 		})
 
 	assert.NotEmpty(t, a1, "A1 reverse fixture: expected ≥1 diagnostic for hmac.New outside signer.go")
 	assert.NotEmpty(t, a2, "A2 reverse fixture: expected ≥1 diagnostic for bytes.Equal")
+	assert.NotEmpty(t, b6, "B6 reverse fixture: expected ≥1 diagnostic for slog of .secret")
 }
 
 // TestWebhookFunnel_NoRawSecretSlog is the B6 blind-spot self-check: production

--- a/tools/archtest/webhook_hmac_funnel_test.go
+++ b/tools/archtest/webhook_hmac_funnel_test.go
@@ -1,0 +1,256 @@
+// INVARIANT: WEBHOOK-HMAC-FUNNEL-01
+//
+// WEBHOOK-HMAC-FUNNEL-01 — kernel/webhook HMAC signing funnel (KERNEL-WEBHOOK-01).
+//
+//   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite in the
+//     kernel/webhook package — computeMAC in signer.go. Any other hmac.New call
+//     in the package fails. This also closes the package-internal upstream blind
+//     spot: any new struct that wants to sign MUST call hmac.New, which is
+//     allowlisted to signer.go, so an unsealed internal holder cannot produce a
+//     signature undetected. Detection: ResolvePackageRef(callee) == crypto/hmac.New
+//     AND enclosing file != signer.go.
+//   - A2 (downstream Hard): signature comparison must use crypto/hmac.Equal or
+//     crypto/subtle.ConstantTimeCompare. bytes.Equal is banned in the package
+//     (it is not constant-time). This makes the constant-time invariant an AST
+//     lock rather than a flaky timing test. Detection:
+//     ResolvePackageRef(callee) == bytes.Equal in the package.
+//   - A3 (upstream Hard external / Medium internal): the Signer and Verifier
+//     interfaces each carry an unexported sealed() marker method, so
+//     package-external implementations are a compile error (Hard). Package-internal
+//     new holders are not blocked by sealing (Medium) — covered transitively by
+//     A1. Explicit Hard-ization of the internal axis (unexported method-set
+//     interface + private construction, per the SPAN-SETATTR-HOLDER-SEAL #851
+//     precedent) is tracked in gh #1243. Detection: the Signer/Verifier interface
+//     type decls must contain an unexported method.
+//
+// Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
+//
+//	B-A1/A2 — rule-logic regression: a reverse fixture module
+//	  (testdata/webhook_hmac_violate) calls hmac.New outside signer.go and
+//	  bytes.Equal, and TestWebhookHMACFunnel_ReverseFixture asserts A1/A2 fire.
+//	B6 — Source.Secret leak: slog of the raw unexported secret field would leak
+//	  it (Source.LogValue + slog.LogValuer covers slog.Any of a whole Source, but
+//	  not slog of src.secret directly). TestWebhookFunnel_NoRawSecretSlog asserts
+//	  no slog.* call in the package references a `.secret` selector.
+//
+// ref: docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+// ref: tools/archtest/healthz_invariants_test.go (callsite-allowlist template)
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	webhookPkgPattern   = "./kernel/webhook/..."
+	webhookSignerSuffix = "kernel/webhook/signer.go"
+	hmacPkgPath         = "crypto/hmac"
+	slogPkgPath         = "log/slog"
+)
+
+// webhookSealedInterfaces are the interface type names in kernel/webhook that
+// must carry an unexported sealed() marker (A3).
+var webhookSealedInterfaces = map[string]bool{"Signer": true, "Verifier": true}
+
+// scanWebhookHMACNew implements A1: crypto/hmac.New callsites must live in
+// signer.go.
+func scanWebhookHMACNew(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	allowed := strings.HasSuffix(filepath.ToSlash(rel), webhookSignerSuffix)
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != hmacPkgPath || name != "New" {
+			return
+		}
+		if allowed {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "crypto/hmac.New called outside kernel/webhook/signer.go; " +
+				"all HMAC computation must funnel through computeMAC (WEBHOOK-HMAC-FUNNEL-01/A1)",
+		})
+	})
+	return out
+}
+
+// scanWebhookBytesEqual implements A2: bytes.Equal is banned in the package
+// (signature comparison must use hmac.Equal / subtle.ConstantTimeCompare).
+func scanWebhookBytesEqual(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != "bytes" || name != "Equal" {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "bytes.Equal called in kernel/webhook; signature comparison must use " +
+				"crypto/hmac.Equal or crypto/subtle.ConstantTimeCompare (WEBHOOK-HMAC-FUNNEL-01/A2)",
+		})
+	})
+	return out
+}
+
+// scanWebhookSecretSlog implements B6: no slog.* call may pass a `.secret`
+// selector (the raw unexported secret field).
+func scanWebhookSecretSlog(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, _, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != slogPkgPath {
+			return
+		}
+		for _, arg := range call.Args {
+			EachInSubtree[ast.SelectorExpr](arg, func(sel *ast.SelectorExpr) {
+				if sel.Sel.Name == "secret" {
+					out = append(out, Diagnostic{
+						Rel:  rel,
+						Line: fset.Position(call.Pos()).Line,
+						Message: "slog call references a raw .secret field in kernel/webhook; " +
+							"log a redacted Source instead (WEBHOOK-HMAC-FUNNEL-01 B6)",
+					})
+				}
+			})
+		}
+	})
+	return out
+}
+
+// interfaceSealed reports the unexported-marker status of the named sealed
+// interfaces declared in file. Returns a map name→hasUnexportedMethod for any
+// of webhookSealedInterfaces found.
+func collectWebhookSealedMarkers(file *ast.File) map[string]bool {
+	found := map[string]bool{}
+	EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+		if !webhookSealedInterfaces[ts.Name.Name] {
+			return
+		}
+		iface, ok := ts.Type.(*ast.InterfaceType)
+		if !ok {
+			return
+		}
+		hasUnexported := false
+		for _, m := range iface.Methods.List {
+			for _, n := range m.Names {
+				if !n.IsExported() {
+					hasUnexported = true
+				}
+			}
+		}
+		found[ts.Name.Name] = hasUnexported
+	})
+	return found
+}
+
+func TestWebhookHMACFunnel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var a1, a2, b6 []Diagnostic
+	sealed := map[string]bool{}
+
+	_ = RunTyped(t, TypedOpts{Tests: false}, []string{webhookPkgPattern},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != "github.com/ghbvf/gocell/kernel/webhook" {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanWebhookHMACNew(p.Fset, f, rel, p.TypesInfo)...)
+				a2 = append(a2, scanWebhookBytesEqual(p.Fset, f, rel, p.TypesInfo)...)
+				b6 = append(b6, scanWebhookSecretSlog(p.Fset, f, rel, p.TypesInfo)...)
+				for name, ok := range collectWebhookSealedMarkers(f) {
+					sealed[name] = ok
+				}
+			}
+			return nil
+		})
+
+	Report(t, "WEBHOOK-HMAC-FUNNEL-01/A1", a1)
+	Report(t, "WEBHOOK-HMAC-FUNNEL-01/A2", a2)
+	Report(t, "WEBHOOK-HMAC-FUNNEL-01/B6", b6)
+
+	// A3: both interfaces must exist and carry an unexported sealed() marker.
+	for name := range webhookSealedInterfaces {
+		hasUnexported, found := sealed[name]
+		assert.True(t, found, "WEBHOOK-HMAC-FUNNEL-01/A3: interface %s not found in kernel/webhook", name)
+		assert.True(t, hasUnexported,
+			"WEBHOOK-HMAC-FUNNEL-01/A3: interface %s must carry an unexported sealed() marker "+
+				"so package-external implementations are a compile error", name)
+	}
+}
+
+// TestWebhookHMACFunnel_ReverseFixture loads the synthetic violation fixture and
+// asserts A1 (hmac.New outside signer.go) and A2 (bytes.Equal) fire — guards
+// against the rule logic silently regressing to a vacuous pass.
+func TestWebhookHMACFunnel_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_hmac_violate")
+
+	var a1, a2 []Diagnostic
+	_ = RunTypedDir(t, fixtureDir, TypedOpts{Tests: false}, []string{"./..."},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanWebhookHMACNew(p.Fset, f, rel, p.TypesInfo)...)
+				a2 = append(a2, scanWebhookBytesEqual(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+
+	assert.NotEmpty(t, a1, "A1 reverse fixture: expected ≥1 diagnostic for hmac.New outside signer.go")
+	assert.NotEmpty(t, a2, "A2 reverse fixture: expected ≥1 diagnostic for bytes.Equal")
+}
+
+// TestWebhookFunnel_NoRawSecretSlog is the B6 blind-spot self-check: production
+// kernel/webhook must contain no slog call referencing a raw .secret field.
+func TestWebhookFunnel_NoRawSecretSlog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var b6 []Diagnostic
+	_ = RunTyped(t, TypedOpts{Tests: false}, []string{webhookPkgPattern},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != "github.com/ghbvf/gocell/kernel/webhook" {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				b6 = append(b6, scanWebhookSecretSlog(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+	require.Empty(t, b6, "B6 self-check: no slog call may reference a raw .secret field")
+}


### PR DESCRIPTION
## Summary

PR-1 (Foundation) of the 6-PR `KERNEL-WEBHOOK-01` plan
(`docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md` §3).
Pure-computation kernel core for GoCell's bidirectional webhook capability; no
runtime integration / contract schema / SSRF / dispatcher yet (PR-2..PR-6).

- **kernel/webhook**: `Algorithm` (HMAC-SHA256 only) · typed `SourceID`/`DeliveryID`
  newtypes + validators · `Source` (unexported secret, `slog.LogValuer` redaction,
  defensive copy) · `Headers` · sealed `Signer`/`Verifier` interfaces
  (`hmacSigner`/`hmacVerifier`) · `SourceStore` + in-mem `SourceRegistry`.
  Svix-aligned signed content `{deliveryID}.{ts}.{body}`, constant-time compare
  via `hmac.Equal`, ±5min bidirectional replay window, multi-signature header for
  sender-side rotation. **100% statement coverage.**
- **pkg/errcode**: 12 `ERR_WEBHOOK_*` sentinels (intended-Kind documented at decl).
- **pkg/redaction**: 6 webhook signature/secret keys added to the single-source
  `sensitiveKeyPattern`.
- **ADR** `202605291200-adr-webhook-signing-algorithm.md`: pulled into PR-1 (the
  algorithm/sealing decision is made here, not forward-referenced to PR-3).

## AI-robust — WEBHOOK-HMAC-FUNNEL-01

| Sub-rule | Guard | Rating |
|---|---|---|
| A1 | `crypto/hmac.New` ⊆ `signer.go::computeMAC` | downstream **Hard** |
| A2 | signature compare uses only `hmac.Equal`/`subtle.ConstantTimeCompare`; `bytes.Equal` banned | downstream **Hard** |
| A3 | `Signer`/`Verifier` sealed `sealed()` marker | upstream **Hard** (external) / **Medium** (internal) |

A1 transitively closes the package-internal upstream blind spot. Per ai-robust.md
§Funnel 双向锁评级, the A3 internal-axis Medium has a tracking issue for explicit
Hard-ization: **#1243** (named in `webhook_hmac_funnel_test.go` godoc + ADR).
Reverse fixture (`testdata/webhook_hmac_violate`) proves A1/A2 fire; B6 self-check
(`TestWebhookFunnel_NoRawSecretSlog`) + `Source.LogValue` cover the secret-leak
blind spot.

## Implementation Matrix

```
Contract: kernel/webhook Signer / Verifier / Source + 12 ERR_WEBHOOK_* sentinels + 6 redaction keys
Change: greenfield foundation (PR-1 of 6)
Implementations: [x] hmacSigner  [x] hmacVerifier  [x] in-mem SourceRegistry
Conformance test: kernel/webhook TestVerify_Vectors (golden Svix vectors) + TestSign_MatchesSvixGoldenVector
Repro: go test ./kernel/webhook/... ./pkg/errcode/... ./pkg/redaction/... ./tools/archtest/ -run Webhook -count=1
Dependent contracts (governance scan): none (greenfield; cross-impl conformance suite lands PR-3)
Invariant inventory: N/A (greenfield, no DROP COLUMN)
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./kernel/webhook/... -cover` → **100.0%** (kernel ≥ 90%)
- [x] `go test ./pkg/errcode/... ./pkg/redaction/... -count=1`
- [x] `go test ./tools/archtest/ -run Webhook` (production clean + reverse fixture fires)
- [x] `golangci-lint run` on changed packages → 0 issues
- [x] `bash hack/verify-archtest-invariants.sh` → exit 0

ref: svix/svix-webhooks go/webhook.go@main
ref: stripe/stripe-go webhook/client.go@master

Closes #1156
Refs: KERNEL-WEBHOOK-01

> Note: a pre-existing `MESSAGE-CONST-LITERAL-01` violation at
> `adapters/mqtt/connection.go:371` exists on `develop` (not in this diff; caught
> only by nightly full archtest, not the PR-time core gate). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)