### PR TITLE
refactor(saga): split journal.Journal into JournalCore + Heartbeater — seal SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 upstream to Hard (#1209)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -206,6 +206,30 @@ linters:
                 implicitly denied by strict mode; explicit deny makes the constraint
                 self-documenting and prevents accidental re-allowance. Ref: DX4 PR #578
                 A4 reciprocal guard.
+        saga-executor-no-journal-import:
+          # SAGA-JOURNAL-HOLDER-SEAL-01 / #1209 companion. runtime/saga/executor
+          # declares its OWN narrow Heartbeater interface (heartbeat.go) precisely
+          # so it never imports kernel/saga/journal — kernel/ cannot be a runtime/
+          # dependency direction it inverts, and importing journal would let the
+          # executor reference journal.Journal / journal.Heartbeater directly,
+          # eroding the decoupling the structural-duplication relies on (the
+          # executor subpackage is the sanctioned Heartbeat caller, excluded from
+          # SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01's A1 callsite scan). This deny is
+          # the Hard (path-level import ban) enforcement of the // INVARIANT:
+          # branded in heartbeat.go / executor.go. Ref: ai-robust.md §"路径级
+          # import ban → depguard". Layered on top of runtime-isolation (which
+          # allows kernel/* broadly); this rule subtracts just this one package.
+          files:
+            - "**/runtime/saga/executor/**"
+            - "!**/runtime/saga/executor/**/*_test.go"
+          deny:
+            - pkg: github.com/ghbvf/gocell/kernel/saga/journal
+              desc: |
+                runtime/saga/executor must never import kernel/saga/journal; it
+                declares its own narrow Heartbeater interface (heartbeat.go) that
+                journal implementations satisfy structurally. Keeps the executor a
+                generic per-step engine decoupled from the saga journal package
+                (SAGA-JOURNAL-HOLDER-SEAL-01 / #1209).
         adapters-isolation:
           # LAYER-04: adapters/ depend on kernel/ + runtime/ + pkg/ + SDKs.
           # Cell-internal `cells/*/internal/adapters/**` is owned by the cell

--- a/adapters/postgres/saga/journal_store.go
+++ b/adapters/postgres/saga/journal_store.go
@@ -36,8 +36,13 @@ type PGJournal struct {
 	clock clock.Clock
 }
 
-// Compile-time assertion.
-var _ journal.Journal = (*PGJournal)(nil)
+// Compile-time assertions: PGJournal satisfies the full Journal and, hence,
+// both halves of the JournalCore + Heartbeater split (#1209).
+var (
+	_ journal.Journal     = (*PGJournal)(nil)
+	_ journal.JournalCore = (*PGJournal)(nil)
+	_ journal.Heartbeater = (*PGJournal)(nil)
+)
 
 // NewJournal constructs a PGJournal backed by pool. clk is required; a nil or
 // typed-nil Clock panics via clock.MustHaveClock (programmer error, matching

--- a/kernel/saga/journal/interface.go
+++ b/kernel/saga/journal/interface.go
@@ -90,6 +90,9 @@ type Journal interface {
 // so a centralized heartbeat loop cannot be built on a stored JournalCore field
 // (the call would not type-check). See the "Interface split" section on
 // [Journal] and archtest SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01.
+//
+// Only runtime/saga.Coordinator may hold a JournalCore field, enforced by the
+// SAGA-JOURNAL-HOLDER-SEAL-01 archtest.
 type JournalCore interface {
 	// Enqueue enrolls a new saga instance for orchestration. The instance MUST
 	// pass saga.Instance.ValidateNew (Pending, CurrentStep 0, no timestamps

--- a/kernel/saga/journal/interface.go
+++ b/kernel/saga/journal/interface.go
@@ -36,6 +36,21 @@ type ClaimedInstance struct {
 // exact same contract and the same conformance suite (see
 // kernel/saga/sagajournaltest).
 //
+// # Interface split: JournalCore + Heartbeater (#1209)
+//
+// Journal is the union of two narrower interfaces:
+//
+//   - [JournalCore] — enrollment, the append-only log, claim/projection, and
+//     terminal commit: everything a coordinator needs EXCEPT lease renewal.
+//   - [Heartbeater] — the single Heartbeat lease-renewal method.
+//
+// runtime/saga.Coordinator holds only JournalCore, so a centralized heartbeat
+// loop becomes a compile error — the persisted field cannot express Heartbeat.
+// Per-step lease renewal is funneled through runtime/saga/executor, which
+// receives the full Journal value transiently at construction (NewExecutor). See
+// archtests SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 and SAGA-JOURNAL-HOLDER-SEAL-01.
+// PG and in-memory implementations satisfy the full Journal, hence both halves.
+//
 // # Time
 //
 // Unlike the pure saga state machine (saga.AdvanceSaga takes an explicit now),
@@ -58,12 +73,24 @@ type ClaimedInstance struct {
 //
 // # Single sanctioned holder
 //
-// Only runtime/saga.Coordinator is intended to hold a Journal field (the
-// SAGA-JOURNAL-HOLDER-SEAL-01 archtest in PR-08 enforces this once the
-// Coordinator exists; tracked in gh issue #956). Enqueue is the producer-facing
-// entry point; the possibility of splitting a narrower producer interface is
-// deferred until the Coordinator and a real producer exist (PR-03).
+// Only runtime/saga.Coordinator is intended to hold a JournalCore field; no
+// struct in runtime/saga may persist the Heartbeat-bearing full Journal (or a
+// bare Heartbeater) as a field. Both rules are enforced by the
+// SAGA-JOURNAL-HOLDER-SEAL-01 archtest. Enqueue is the producer-facing entry
+// point; a narrower producer interface may be split out if a real producer ever
+// needs less than JournalCore.
 type Journal interface {
+	JournalCore
+	Heartbeater
+}
+
+// JournalCore is the Heartbeat-free core of [Journal]: enrollment, the
+// append-only event log, claim/projection, and terminal commit. It is the
+// interface runtime/saga.Coordinator persists — deliberately WITHOUT Heartbeat,
+// so a centralized heartbeat loop cannot be built on a stored JournalCore field
+// (the call would not type-check). See the "Interface split" section on
+// [Journal] and archtest SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01.
+type JournalCore interface {
 	// Enqueue enrolls a new saga instance for orchestration. The instance MUST
 	// pass saga.Instance.ValidateNew (Pending, CurrentStep 0, no timestamps
 	// beyond StartedAt). Enqueue is lease-free: it writes the projection with
@@ -142,14 +169,6 @@ type Journal interface {
 	// directly while still folding Load for the exact step cursor.
 	ClaimPending(ctx context.Context, batchSize int, leaseDuration time.Duration) (claimed []ClaimedInstance, leaseID idutil.SafeID, err error)
 
-	// Heartbeat extends the lease on a single claimed instance to
-	// now+leaseDuration. leaseDuration MUST be > 0; a non-positive value returns a
-	// KindInvalid error. It is lease-fenced: ok is false (with a nil error) when
-	// leaseID no longer owns the instance, signaling the holder to stop driving
-	// it. A never-enqueued instance also returns ok=false (nil error); callers
-	// cannot distinguish it from a stale lease.
-	Heartbeat(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (ok bool, err error)
-
 	// MarkTerminal transitions the instance projection to finalStatus and appends
 	// the matching terminal event atomically, so the log alone replays which
 	// terminal state was reached. Terminal event kinds per finalStatus:
@@ -176,4 +195,23 @@ type Journal interface {
 	// Coordinator cell that holds the Journal (PR-03); a Journal implementation
 	// only provides the RepoProber method and does not self-register.
 	RepoReady(ctx context.Context) error
+}
+
+// Heartbeater is the single lease-renewal method split out of [Journal] (#1209).
+//
+// runtime/saga/executor owns the only sanctioned Heartbeat caller (the per-step
+// heartbeat goroutine) and declares its OWN structurally-identical Heartbeater
+// interface rather than importing this one: kernel/ cannot depend on runtime/,
+// and the executor must never import kernel/saga/journal
+// (SAGA-JOURNAL-HOLDER-SEAL-01). This kernel-side Heartbeater exists solely to
+// compose the full [Journal] so that the PG / in-memory implementations satisfy
+// it via interface embedding.
+type Heartbeater interface {
+	// Heartbeat extends the lease on a single claimed instance to
+	// now+leaseDuration. leaseDuration MUST be > 0; a non-positive value returns a
+	// KindInvalid error. It is lease-fenced: ok is false (with a nil error) when
+	// leaseID no longer owns the instance, signaling the holder to stop driving
+	// it. A never-enqueued instance also returns ok=false (nil error); callers
+	// cannot distinguish it from a stale lease.
+	Heartbeat(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (ok bool, err error)
 }

--- a/kernel/saga/journal/interface_test.go
+++ b/kernel/saga/journal/interface_test.go
@@ -14,10 +14,13 @@ import (
 	"github.com/ghbvf/gocell/kernel/saga/journal"
 )
 
-// Compile-time assertions: MemJournal must satisfy both Journal and
-// healthz.RepoProber. These lines cause a compile error until MemJournal
-// exists — that is the intended RED state.
+// Compile-time assertions: MemJournal must satisfy the full Journal (hence both
+// halves of the JournalCore + Heartbeater split, #1209) and healthz.RepoProber.
+// These lines cause a compile error until MemJournal exists — that is the
+// intended RED state.
 var (
-	_ journal.Journal    = (*journal.MemJournal)(nil)
-	_ healthz.RepoProber = (*journal.MemJournal)(nil)
+	_ journal.Journal     = (*journal.MemJournal)(nil)
+	_ journal.JournalCore = (*journal.MemJournal)(nil)
+	_ journal.Heartbeater = (*journal.MemJournal)(nil)
+	_ healthz.RepoProber  = (*journal.MemJournal)(nil)
 )

--- a/kernel/saga/journal/interface_test.go
+++ b/kernel/saga/journal/interface_test.go
@@ -1,12 +1,13 @@
-// Package journal_test is the RED-phase contract pin for kernel/saga/journal.
+// Package journal_test holds the compile-time contract pins for
+// kernel/saga/journal.
 //
-// This file intentionally does NOT compile until MemJournal is introduced in
-// the GREEN batch (PR-02). The compile-time interface assertions below are the
-// canonical source of what MemJournal MUST implement; any deviation will be
-// caught the moment the GREEN implementation is attempted.
-//
-// Do not add build tags or conditional compilation to silence the error —
-// the broken build IS the test.
+// The var _ assertions below are the canonical source of what every journal
+// implementation MUST satisfy: the full Journal, both halves of the
+// JournalCore + Heartbeater split (#1209), and healthz.RepoProber. They are
+// ongoing regression guards — adding a method to one of the interfaces, or a
+// drifting implementation, breaks this build. Do not add build tags or
+// conditional compilation to silence such an error: the broken build IS the
+// test.
 package journal_test
 
 import (

--- a/runtime/saga/coordinator.go
+++ b/runtime/saga/coordinator.go
@@ -153,11 +153,16 @@ func (c Config) Validate() error {
 //
 // # Single sanctioned journal holder
 //
-// Coordinator is the only struct in this package that holds a journal.Journal
-// field. Locked by SAGA-JOURNAL-HOLDER-SEAL-01 archtest (PR-08).
+// Coordinator is the only struct in this package that holds a
+// journal.JournalCore field — the Heartbeat-free core of journal.Journal. The
+// narrow type makes a centralized heartbeat loop a compile error
+// (c.journal.Heartbeat is undefined); per-step lease renewal is funneled through
+// the internal executor. Locked by SAGA-JOURNAL-HOLDER-SEAL-01 (only Coordinator
+// may hold JournalCore; no struct may persist the Heartbeat-bearing full Journal)
+// and SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 (#1209).
 type Coordinator struct {
 	// required deps — set by NewCoordinator, validated non-nil before opts loop
-	journal    journal.Journal
+	journal    journal.JournalCore
 	txRunner   persistence.TxRunner
 	outboxEmit koutbox.Emitter
 	registry   ksaga.Resolver
@@ -172,7 +177,8 @@ type Coordinator struct {
 	// optional leader election (PR-05). nil locker → single-process unsafe
 	// mode. leaderElectNil records a nil locker passed to WithLeaderElect so
 	// NewCoordinator can fail-fast (strong-dependency wiring option). Held here
-	// (NOT a journal.Journal field) so SAGA-JOURNAL-HOLDER-SEAL-01 is unaffected.
+	// (NOT a journal.JournalCore / journal.Journal field) so
+	// SAGA-JOURNAL-HOLDER-SEAL-01 is unaffected.
 	locker         distlock.Locker
 	leaderElectNil bool
 
@@ -181,9 +187,11 @@ type Coordinator struct {
 	// #1181 F5: previously injected via WithExecutor — that path allowed a
 	// caller to inject an Executor with a different journal / lease config,
 	// breaking the "claim and heartbeat are same-source" invariant. The
-	// invariant is now enforced by construction (Executor's Heartbeater = the
-	// Coordinator's journal). observer / tracer are caller-configurable via
-	// WithObserver / WithTracer and forwarded into the internal Executor.
+	// invariant is now enforced by construction: NewCoordinator passes the full
+	// journal.Journal value it receives to executor.NewExecutor (it satisfies
+	// executor.Heartbeater), then stores only the JournalCore facet in c.journal.
+	// observer / tracer are caller-configurable via WithObserver / WithTracer and
+	// forwarded into the internal Executor.
 	executor *executor.Executor
 	observer executor.Observer // default NopObserver{}, fan-out via WithObserver
 

--- a/runtime/saga/coordinator.go
+++ b/runtime/saga/coordinator.go
@@ -270,10 +270,12 @@ func NewCoordinator(
 	if err := c.cfg.Validate(); err != nil {
 		return nil, err
 	}
-	// Construct the internal Executor with c.journal as its Heartbeater so
-	// claim and heartbeat are guaranteed same-source by type-system
-	// construction (#1181 F5). observer / tracer flow from Coordinator-level
-	// options into Executor — single tracing root, single observer fan-out.
+	// Construct the internal Executor with the full journal.Journal value j as
+	// its Heartbeater so claim and heartbeat are guaranteed same-source by
+	// type-system construction (#1181 F5). j (the parameter) carries Heartbeat;
+	// c.journal stores only the JournalCore facet — see the struct doc. observer
+	// / tracer flow from Coordinator-level options into Executor — single tracing
+	// root, single observer fan-out.
 	exec, err := executor.NewExecutor(j, clk,
 		executor.WithHeartbeatInterval(c.cfg.HeartbeatInterval),
 		executor.WithLeaseDuration(c.cfg.LeaseDuration),

--- a/runtime/saga/doc.go
+++ b/runtime/saga/doc.go
@@ -106,10 +106,14 @@
 // code never executes with a database transaction held open. This invariant is
 // locked by the SAGA-STEP-RUN-OUTSIDE-TX-01 archtest.
 //
-// # Coordinator is the single sanctioned Journal holder
+// # Coordinator is the single sanctioned JournalCore holder
 //
-// Coordinator is the only struct in this package that holds a journal.Journal
-// field. Locked by SAGA-JOURNAL-HOLDER-SEAL-01 archtest.
+// Coordinator is the only struct in this package that holds a
+// journal.JournalCore field — the Heartbeat-free core of journal.Journal, so a
+// centralized heartbeat loop is a compile error (#1209). No struct in this
+// package may persist the Heartbeat-bearing full journal.Journal (or a bare
+// journal.Heartbeater) as a field. Locked by SAGA-JOURNAL-HOLDER-SEAL-01 and
+// SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 archtests.
 //
 // ref: dtm dtmsvr/cron.go (CronTransOnce structure)
 // ref: temporalio sdk-go internal_task_pollers.go

--- a/runtime/saga/executor/heartbeat.go
+++ b/runtime/saga/executor/heartbeat.go
@@ -10,11 +10,21 @@ import (
 )
 
 // Heartbeater extends a saga instance's lease by calling Heartbeat periodically.
-// The interface matches the journal.Journal.Heartbeat signature exactly so that
-// journal implementations satisfy it without importing this package.
+// The interface matches kernel/saga/journal.Heartbeater (and the Heartbeat
+// method on the full journal.Journal) exactly, so any journal implementation
+// satisfies it structurally without this package importing journal.
+//
+// This is deliberately a SEPARATE declaration from journal.Heartbeater, not an
+// alias or re-use: kernel/ cannot depend on runtime/, and this package must
+// never import kernel/saga/journal (below), so the two structurally-identical
+// interfaces are an intentional layering artifact. journal.Heartbeater exists
+// only to compose the full journal.Journal; this one is the executor's own
+// dependency surface.
 //
 // INVARIANT: executor never imports kernel/saga/journal — it uses this narrow
-// interface instead (SAGA-JOURNAL-HOLDER-SEAL-01).
+// interface instead. Enforced by the saga-executor-no-journal-import depguard
+// rule in .golangci.yml (path-level import ban) and complemented by
+// SAGA-JOURNAL-HOLDER-SEAL-01 (no journal.* field may be persisted here either).
 //
 // Caller contract: the Executor stops the heartbeat loop when ok=false is
 // returned; implementations should guarantee that ok=false is idempotent

--- a/runtime/saga/leader_elect.go
+++ b/runtime/saga/leader_elect.go
@@ -2,10 +2,11 @@ package saga
 
 // leader_elect.go — distlock-based leader election for the Coordinator (PR-05,
 // #964). The gate is injected into the existing tick loop (tickOnce) rather
-// than a wrapper struct: SAGA-JOURNAL-HOLDER-SEAL-01 forbids any struct other
-// than Coordinator from holding a journal.Journal, and journal access must stay
-// inside Coordinator. The only new state is an optional distlock.Locker field;
-// all gate logic lives here.
+// than a wrapper struct: post-#1209 SAGA-JOURNAL-HOLDER-SEAL-01 lets only the
+// Coordinator hold the journal.JournalCore field and bans the Heartbeat-bearing
+// journal.Journal / journal.Heartbeater as a field anywhere in runtime/saga, so
+// journal access must stay inside Coordinator. The only new state is an optional
+// distlock.Locker field; all gate logic lives here.
 
 import (
 	"context"

--- a/tools/archtest/saga_coordinator_no_heartbeat_test.go
+++ b/tools/archtest/saga_coordinator_no_heartbeat_test.go
@@ -23,25 +23,14 @@
 //
 // # Funnel shape (AI-robust §funnel 双向锁)
 //
-// Downstream (callsite ban — this archtest): Medium. AST + typed analysis
-// locates every method call to journal.Journal.Heartbeat in
-// runtime/saga (the Coordinator's package — recursive scope intentionally
-// includes only `./runtime/saga/.` not `.../...`, because the executor
-// subpackage is the sanctioned caller). The check is "set must be empty"
-// — any new call site fails CI.
-//
-// Upstream (type-system seal): MEDIUM (gh issue tracked). The
-// kernel/saga/journal.Journal interface still declares Heartbeat as a
-// method. As long as the Coordinator's `journal` field carries this
-// interface type, the type system permits a Heartbeat call at the source
-// level (it would be caught here, not at compile time). Hard upgrade
-// path = split Journal into JournalCore + Heartbeater so the Coordinator
-// field type lacks Heartbeat entirely — requires changing 22 conformance
-// case + multi-impl signatures, out of scope for #1181.
-//
-// Follow-up issue: gh issue #1209 (split Journal interface into
-// JournalCore + Heartbeater so the Coordinator field type lacks Heartbeat
-// entirely, upgrading this archtest's upstream from Medium to Hard).
+// Upstream HARD + downstream Medium (full rating in the "Funnel 双向锁评级"
+// section below). In short: #1209 split journal.Journal into JournalCore +
+// Heartbeater and narrowed Coordinator.journal to journal.JournalCore, which has
+// no Heartbeat method — so a centralized heartbeat loop (a long-lived
+// Heartbeat-bearing field re-Heartbeat-ing leases) is compile-time
+// inexpressible. A1 (this archtest) is retained to ban any .Heartbeat callsite
+// over the one transient full-Journal value: the NewCoordinator parameter handed
+// to the executor funnel.
 //
 // # Blind-spot self-test
 //
@@ -60,47 +49,47 @@
 //     here (it's a function call, not a SelectorExpr) — but it is
 //     unreachable without the method-value selector, which IS caught.
 //
-// Blind spot B1: a type alias `type X = journal.Journal` in runtime/saga
-// would let the package reference `journal.Journal.Heartbeat` indirectly
-// as `X.Heartbeat`. Mitigated by inheriting the alias ban from
-// SAGA-JOURNAL-HOLDER-SEAL-01's B1 reverse self-test, which forbids
-// `type X = journal.Journal` in runtime/saga.
+// Blind spot B1: a type alias `type X = journal.Journal` (or
+// `journal.Heartbeater`) in runtime/saga would let the package reference
+// `.Heartbeat` indirectly as `X.Heartbeat`. Mitigated by inheriting the alias
+// ban from SAGA-JOURNAL-HOLDER-SEAL-01's B1 reverse self-test, which forbids
+// `type X = journal.{Journal,JournalCore,Heartbeater}` in runtime/saga.
 //
 // # Funnel 双向锁评级
 //
-// Downstream (Medium): A1 archtest locks the set of runtime/saga (main package,
-// not executor subpackage) .Heartbeat callsites to the empty set. The scan
-// uses go/types structural signature matching so typed aliases and local
-// interface duplicates are covered. Scope boundary — excluding
-// runtime/saga/executor/ — is the B1 reverse self-check's purpose (below).
+// Upstream (type-system seal): HARD (landed in #1209). Coordinator.journal is
+// journal.JournalCore, which declares no Heartbeat method, so the centralized
+// heartbeat loop this invariant forbids — a long-lived Heartbeat-bearing field
+// re-Heartbeat-ing leases in a goroutine — cannot be expressed: c.journal.Heartbeat
+// is a compile error. SAGA-JOURNAL-HOLDER-SEAL-01 complements the seal by
+// forbidding any runtime/saga struct from persisting the full journal.Journal or
+// a bare journal.Heartbeater as a field. The loop is therefore compile-time
+// unbuildable, not merely archtest-banned.
 //
-// Upstream (Medium): journal.Journal still declares Heartbeat as a method.
-// The Coordinator's journal field carries that interface type, so the type
-// system permits a .Heartbeat call at the source level — it is caught by A1
-// at archtest time, not at compile time. Hard upstream requires splitting
-// journal.Journal into JournalCore + Heartbeater so the Coordinator field
-// type physically lacks Heartbeat. That change touches 22+ conformance cases
-// and multiple PG/mem implementations — out of scope for #1181.
+// Downstream (callsite ban — this archtest, A1): retained, honestly Medium. The
+// field seal closes the LOOP, but one transient Heartbeat-bearing value remains:
+// the NewCoordinator(j journal.Journal, ...) parameter, which must carry Heartbeat
+// to construct the executor (executor.NewExecutor(j, ...); the executor is the
+// sanctioned per-step heartbeat funnel and owns the only Heartbeat caller). That
+// parameter is irreducible — the Coordinator must own executor construction
+// (#1181 F5: claim and heartbeat same-source), so SOME runtime/saga value holds
+// Heartbeat at construction time. A1 bans any actual .Heartbeat() callsite over
+// that window via go/types structural signature matching (typed aliases and local
+// shape-duplicates are covered too; scope excludes runtime/saga/executor/, the
+// sanctioned caller — see B1 below). Handing j to the executor constructor is a
+// value pass, not a .Heartbeat selector, and stays green.
 //
-// Current rating: Medium downstream + Medium upstream.
+// Current rating: Hard upstream (loop compile-time inexpressible) + Medium
+// downstream (A1 guards the irreducible constructor pass-through window).
 //
-// This combination is NOT within the "Medium upstream + Hard downstream"
-// transition form that ai-robust.md §"Funnel 双向锁评级" explicitly permits.
-// It is the Go type-system ceiling for the current interface shape:
-//
-//   - Downstream Hard is not reachable without upstream Hard first: as long as
-//     Coordinator.journal exposes .Heartbeat, any archtest that only bans the
-//     call has an inherent bypass (rewrite, rename, extract) that the type
-//     system does not reject. A1's typed-signature match raises the bar from
-//     Soft to Medium; it cannot reach Hard without a compile-time gate.
-//
-//   - Upstream Hard (= Coordinator field type lacks Heartbeat) is tracked in
-//     gh issue #1209 ("split journal.Journal into JournalCore + Heartbeater").
-//     Once #1209 lands, a .Heartbeat call in runtime/saga becomes a compile
-//     error, upgrading both upstream and downstream to Hard simultaneously.
-//
-// This archtest is intentionally retained at Medium + Medium until #1209 lands.
-// The two-Medium rating is the correct honest assessment, not a Soft carryover.
+// This is NOT a blanket double-Hard, and the earlier godoc framing that "#1209
+// upgrades BOTH upstream and downstream to Hard" was aspirational. The
+// constructor parameter cannot be compile-sealed without forcing callers to pass
+// the journal twice (a worse API for zero real gain — a centralized loop needs a
+// PERSISTED Heartbeat field, which is now impossible). A1 therefore remains the
+// honest mechanism for that narrow, low-risk residual. Per ai-robust.md §"Funnel
+// 双向锁评级", a Hard-upstream funnel needs no gh-tracked upgrade path; the Medium
+// downstream here is a deliberate residual, not a Soft carryover.
 package archtest
 
 import (

--- a/tools/archtest/saga_coordinator_no_heartbeat_test.go
+++ b/tools/archtest/saga_coordinator_no_heartbeat_test.go
@@ -23,14 +23,17 @@
 //
 // # Funnel shape (AI-robust §funnel 双向锁)
 //
-// Upstream HARD + downstream Medium (full rating in the "Funnel 双向锁评级"
-// section below). In short: #1209 split journal.Journal into JournalCore +
+// Upstream is Hard for the journal-INTERFACE-field loop + Medium for the
+// func-value-field loop; downstream Medium (full rating in the "Funnel 双向锁
+// 评级" section below). In short: #1209 split journal.Journal into JournalCore +
 // Heartbeater and narrowed Coordinator.journal to journal.JournalCore, which has
-// no Heartbeat method — so a centralized heartbeat loop (a long-lived
-// Heartbeat-bearing field re-Heartbeat-ing leases) is compile-time
-// inexpressible. A1 (this archtest) is retained to ban any .Heartbeat callsite
-// over the one transient full-Journal value: the NewCoordinator parameter handed
-// to the executor funnel.
+// no Heartbeat method — so a centralized heartbeat loop built on a persisted
+// Heartbeat-bearing INTERFACE field is compile-time inexpressible. The
+// func-value variant (a heartbeat-shaped func field fed from a .Heartbeat
+// selector OUTSIDE runtime/saga) is NOT compile-sealed; it is archtest-banned by
+// SAGA-JOURNAL-HOLDER-SEAL-01 rule 3 (Medium). A1 (this archtest) is retained to
+// ban any .Heartbeat callsite over the one transient full-Journal value: the
+// NewCoordinator parameter handed to the executor funnel.
 //
 // # Blind-spot self-test
 //
@@ -57,14 +60,21 @@
 //
 // # Funnel 双向锁评级
 //
-// Upstream (type-system seal): HARD (landed in #1209). Coordinator.journal is
-// journal.JournalCore, which declares no Heartbeat method, so the centralized
-// heartbeat loop this invariant forbids — a long-lived Heartbeat-bearing field
-// re-Heartbeat-ing leases in a goroutine — cannot be expressed: c.journal.Heartbeat
-// is a compile error. SAGA-JOURNAL-HOLDER-SEAL-01 complements the seal by
-// forbidding any runtime/saga struct from persisting the full journal.Journal or
-// a bare journal.Heartbeater as a field. The loop is therefore compile-time
-// unbuildable, not merely archtest-banned.
+// Upstream (type-system seal): HARD for the INTERFACE-field loop (landed in
+// #1209). Coordinator.journal is journal.JournalCore, which declares no Heartbeat
+// method, so the centralized heartbeat loop this invariant forbids — a long-lived
+// Heartbeat-bearing field re-Heartbeat-ing leases in a goroutine — cannot be
+// expressed via a journal interface field: c.journal.Heartbeat is a compile
+// error. BUT the loop is ALSO expressible via a heartbeat-SHAPED func field
+// (`beat func(ctx, idutil.SafeID, idutil.SafeID, time.Duration) (bool, error)`)
+// populated from a `.Heartbeat` selector OUTSIDE runtime/saga — a path that is
+// NOT compile-sealed. SAGA-JOURNAL-HOLDER-SEAL-01 closes it at archtest time:
+// rule 1 forbids persisting the full journal.Journal / bare journal.Heartbeater
+// as a field, rule 3 forbids persisting a Heartbeater-shaped func field (Medium).
+// So the interface-field loop is compile-unbuildable (Hard) and the func-field
+// loop is archtest-banned (Medium); the only irreducible residual is a
+// constructor closure that captures the NewCoordinator heartbeat param WITHOUT
+// persisting it (same class as the downstream pass-through window below).
 //
 // Downstream (callsite ban — this archtest, A1): retained, honestly Medium. The
 // field seal closes the LOOP, but one transient Heartbeat-bearing value remains:
@@ -79,17 +89,21 @@
 // sanctioned caller — see B1 below). Handing j to the executor constructor is a
 // value pass, not a .Heartbeat selector, and stays green.
 //
-// Current rating: Hard upstream (loop compile-time inexpressible) + Medium
-// downstream (A1 guards the irreducible constructor pass-through window).
+// Current rating: upstream Hard for the interface-field loop (compile-time
+// inexpressible) + Medium for the func-field loop (SAGA-JOURNAL-HOLDER-SEAL-01
+// rule 3 archtest); downstream Medium (A1 guards the irreducible constructor
+// pass-through window).
 //
-// This is NOT a blanket double-Hard, and the earlier godoc framing that "#1209
-// upgrades BOTH upstream and downstream to Hard" was aspirational. The
-// constructor parameter cannot be compile-sealed without forcing callers to pass
-// the journal twice (a worse API for zero real gain — a centralized loop needs a
-// PERSISTED Heartbeat field, which is now impossible). A1 therefore remains the
-// honest mechanism for that narrow, low-risk residual. Per ai-robust.md §"Funnel
-// 双向锁评级", a Hard-upstream funnel needs no gh-tracked upgrade path; the Medium
-// downstream here is a deliberate residual, not a Soft carryover.
+// The earlier blanket "Hard upstream / loop compile-time inexpressible" framing
+// was overstated: a PERSISTED heartbeat callable need not be a journal interface
+// — a func-typed field of the heartbeat shape works too, and func fields are not
+// type-system-sealable here. That path is now archtest-banned (Medium) rather
+// than left open. The single irreducible residual is a constructor closure
+// capturing the NewCoordinator heartbeat param (not persisted in any field) —
+// same low-risk class as the downstream window; compile-sealing it would force
+// callers to pass the journal twice (worse API, zero real gain). Per ai-robust.md
+// §"Funnel 双向锁评级", the Hard interface-field seal needs no gh-tracked upgrade;
+// the Medium func-field + downstream residuals are deliberate, not Soft carryovers.
 package archtest
 
 import (
@@ -211,11 +225,26 @@ func methodIsHeartbeaterShape(fn *types.Func) bool {
 		return false
 	}
 	sig, ok := fn.Type().(*types.Signature)
-	if !ok {
-		return false
+	if !ok || sig.Recv() == nil {
+		return false // nil signature, or not a method
 	}
-	if sig.Recv() == nil {
-		return false // not a method
+	return signatureMatchesHeartbeaterShape(sig)
+}
+
+// signatureMatchesHeartbeaterShape reports whether sig has the parameter and
+// result types of journal.Heartbeater.Heartbeat, independent of whether sig is
+// a method (has a receiver) or a bare func type:
+//
+//	(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (bool, error)
+//
+// It backs two scans in this package: the .Heartbeat method-call scan
+// (SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 A1, via methodIsHeartbeaterShape) and
+// the heartbeat-shaped func-FIELD scan (SAGA-JOURNAL-HOLDER-SEAL-01, where a
+// persisted func value of this shape is the func-value equivalent of holding a
+// journal.Heartbeater field).
+func signatureMatchesHeartbeaterShape(sig *types.Signature) bool {
+	if sig == nil {
+		return false
 	}
 	params := sig.Params()
 	if params.Len() != 4 {

--- a/tools/archtest/saga_journal_holder_seal_test.go
+++ b/tools/archtest/saga_journal_holder_seal_test.go
@@ -2,39 +2,76 @@
 //
 // INVARIANT: SAGA-JOURNAL-HOLDER-SEAL-01
 //
-// Only runtime/saga.Coordinator may hold a kernel/saga/journal.Journal field.
-// Any other struct in runtime/saga declaring a field of that interface type is
-// a violation.
+// Two field-shape rules over runtime/saga production structs:
 //
-// # Why this lives in PR-03 (not PR-08 per plan)
+//  1. No struct may hold a Heartbeat-bearing journal interface as a persisted
+//     field — i.e. neither kernel/saga/journal.Journal (the full interface) nor
+//     kernel/saga/journal.Heartbeater. A persisted Heartbeat-capable field is
+//     exactly what a centralized heartbeat loop needs (the #1181 anti-pattern);
+//     it is forbidden everywhere, Coordinator included.
+//  2. kernel/saga/journal.JournalCore (the Heartbeat-free core) may be held only
+//     by runtime/saga.Coordinator. Any other holder is a violation.
 //
-// As soon as the type exists, the invariant is statically lockable. Earlier
-// locking catches PR-04/05/06 regressions immediately. AI-robust evaluation:
-// upstream Medium (archtest A1 typed-aware scan locks holder-struct identity
-// within package), downstream N/A (field-shape invariant, not a callsite
-// invariant — no caller allowlist needed). Upstream Hard upgrade path (seal
-// journal.Journal so non-Coordinator struct field is compile-time
-// inexpressible) tracked in gh issue #981.
+// The full journal.Journal still exists transiently as the NewCoordinator
+// parameter handed straight to executor.NewExecutor (the sanctioned per-step
+// heartbeat funnel); that is a parameter, not a field, so it never trips rule 1.
 //
-// # Blind-spot reverse self-test
+// # Relationship to the JournalCore split (#1209)
 //
-//   - B1: production code MUST NOT introduce a `type X = journal.Journal` alias
-//     in runtime/saga (would let a new struct hold `X` while still being the
-//     same interface — A1 would miss it because the AST alias TypeSpec has an
-//     Assign token and the alias RHS selector is the escape path).
+// Before #1209 this seal tracked the flat journal.Journal interface, and
+// Coordinator held journal.Journal directly. #1209 split journal.Journal into
+// JournalCore (6 methods) + Heartbeater (Heartbeat) and narrowed
+// Coordinator.journal to JournalCore so c.journal.Heartbeat(...) is a compile
+// error — that is what upgrades SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01's upstream
+// to Hard (see that archtest). This seal is the field-shape complement: it keeps
+// the narrow type single-held and bans any re-introduction of a Heartbeat-bearing
+// field.
 //
-// # Coverage notes (blind spots of A1 + B1)
+// # AI-robust rating
 //
-//   - A1 detects fields whose resolved type is the named interface
-//     kernel/saga/journal.Journal. A type alias `type J = journal.Journal` in a
-//     *different* package (outside runtime/saga) that is then imported and used
-//     as a field type in runtime/saga is not covered by B1 (B1 only scans
-//     runtime/saga itself). This is an accepted residual blind spot: cross-package
-//     aliases in Go are rare and the types resolution in A1 chases through aliases
-//     at the types.Type level (Named.Obj().Pkg() and Name() are canonical after
-//     type-checking, even through aliases in other packages).
-//   - B1 only scans non-test files in runtime/saga; test files may alias the
-//     type freely.
+// Upstream Medium: a typed-aware go/types scan locks holder-struct identity
+// within the package; a new non-Coordinator JournalCore field (or any
+// Heartbeat-bearing field) is rejected at archtest time, not by the compiler.
+// Downstream N/A: this is a field-shape invariant, not a callsite invariant —
+// there is no caller allowlist.
+//
+// The JournalCore split does NOT make THIS seal Hard: a non-Coordinator struct
+// declaring a JournalCore field is still source-expressible (the archtest, not
+// the type system, rejects it). The upstream-Hard path for the holder seal
+// (envelope / sealed-construction so a non-Coordinator field is compile-time
+// inexpressible) is tracked in gh issue #982; post-#1209 #982 tracks JournalCore
+// rather than the full Journal. (Historic note: this godoc previously cited
+// #981, which is an unrelated rule — SAGA-STEP-COMPENSATE-PURE-01.)
+//
+// # Blind-spot self-test (AI-robust §"工具选定后强制盲区自检")
+//
+// A1 uses go/types field-type resolution; B1 is an AST-only alias-declaration
+// scan. Forms outside those tools' reach:
+//
+//   - B1 (reverse self-test): a `type X = journal.{Journal,JournalCore,Heartbeater}`
+//     alias in runtime/saga would let a struct hold `X` evading a pure-AST name
+//     match. A1's go/types resolution already chases through aliases, but B1
+//     catches the alias declaration itself before any struct uses it. Covered.
+//   - Embedded (anonymous) field `struct { journal.Heartbeater }`: ast.StructType
+//     Fields.List includes embedded fields (Names empty, Type set), so A1
+//     classifies it. Covered.
+//   - Pointer field `*journal.JournalCore`: classifyResolvedJournalType unwraps
+//     one pointer level. Covered. Double pointer `**journal.JournalCore` is a
+//     degenerate, non-idiomatic form — accepted residual blind spot.
+//   - Cross-package alias `type J = journal.JournalCore` declared OUTSIDE
+//     runtime/saga then imported and used as a field type inside runtime/saga:
+//     A1 still classifies it correctly (Named.Obj().Pkg()/Name() are canonical
+//     after type-checking), but B1 (which only scans runtime/saga) does not flag
+//     the foreign declaration. Accepted residual blind spot — cross-package
+//     interface aliases are rare and A1 resolves the field type regardless.
+//   - Local interface that re-declares the Heartbeat shape, e.g.
+//     `type beat interface { Heartbeat(...) }` held as a field: a new named type,
+//     NOT journal.*, so this seal does not classify it. Accepted residual —
+//     composed with SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01, whose A1 callsite scan
+//     is signature-shape (not name) based and flags any actual .Heartbeat(...)
+//     call in runtime/saga regardless of the holder type. Holding without calling
+//     is inert; calling is caught there.
+//   - B1 only scans non-test files in runtime/saga; test files may alias freely.
 package archtest
 
 import (
@@ -47,78 +84,127 @@ import (
 )
 
 // journalInterfacePkgPath is the canonical import path of the package that
-// declares the Journal interface. Hardcoded rather than derived from go.mod
-// because it is load-bearing: a rename of this package path would be a
-// contract break requiring a deliberate update here.
+// declares the Journal / JournalCore / Heartbeater interfaces. Hardcoded rather
+// than derived from go.mod because it is load-bearing: a rename of this package
+// path would be a contract break requiring a deliberate update here.
 const journalInterfacePkgPath = "github.com/ghbvf/gocell/kernel/saga/journal"
 
-// journalInterfaceTypeName is the type name of the interface within the package.
-const journalInterfaceTypeName = "Journal"
+// journalInterfaceTypeName / heartbeaterInterfaceTypeName name the two
+// Heartbeat-bearing interfaces that may not be persisted as a field anywhere in
+// runtime/saga production code (rule 1).
+const (
+	journalInterfaceTypeName     = "Journal"
+	heartbeaterInterfaceTypeName = "Heartbeater"
+)
+
+// journalCoreInterfaceTypeName names the Heartbeat-free core interface that only
+// the Coordinator may hold as a field (rule 2).
+const journalCoreInterfaceTypeName = "JournalCore"
 
 // allowedSagaJournalHolder is the single struct in runtime/saga permitted to
-// hold a journal.Journal field.
+// hold a journal.JournalCore field.
 const allowedSagaJournalHolder = "Coordinator"
 
 // sagaJournalHolderSealRule is the rule ID prefixed to every diagnostic message.
 const sagaJournalHolderSealRule = "SAGA-JOURNAL-HOLDER-SEAL-01"
 
-// fieldTypeIsJournal reports whether the field's resolved type (via go/types)
-// is kernel/saga/journal.Journal. It handles:
-//   - direct field type `journal.Journal` (SelectorExpr in AST)
-//   - pointer to interface `*journal.Journal` (unusual but possible)
-//   - type aliases that resolve to journal.Journal (types resolve through aliases
-//     at the types.Type level, so Named.Obj().Pkg().Path() is canonical)
-//
-// Returns false if TypesInfo is nil or the expression cannot be resolved.
-func fieldTypeIsJournal(info *types.Info, expr ast.Expr) bool {
+// journalFieldKind classifies a struct field's resolved type against the three
+// journal-package interfaces this seal cares about.
+type journalFieldKind int
+
+const (
+	journalFieldNone        journalFieldKind = iota // not a journal-package interface
+	journalFieldFull                                // journal.Journal (Heartbeat-bearing)
+	journalFieldHeartbeater                         // journal.Heartbeater (Heartbeat-bearing)
+	journalFieldCore                                // journal.JournalCore (Heartbeat-free)
+)
+
+// classifyJournalFieldType resolves the field expression via go/types and
+// classifies it. Returns journalFieldNone when TypesInfo is nil or the type is
+// not one of the three journal-package interfaces.
+func classifyJournalFieldType(info *types.Info, expr ast.Expr) journalFieldKind {
 	if info == nil {
-		return false
+		return journalFieldNone
 	}
 	tv, ok := info.Types[expr]
 	if !ok {
-		return false
+		return journalFieldNone
 	}
-	return resolvedTypeIsJournal(tv.Type)
+	return classifyResolvedJournalType(tv.Type)
 }
 
-// resolvedTypeIsJournal checks whether t (possibly wrapped in a pointer or
-// alias) resolves to the kernel/saga/journal.Journal named interface.
-func resolvedTypeIsJournal(t types.Type) bool {
+// classifyResolvedJournalType checks whether t (possibly wrapped in one pointer
+// or resolved through an alias) is journal.Journal, journal.Heartbeater, or
+// journal.JournalCore. Aliases resolve at the types.Type level, so
+// Named.Obj().Pkg().Path() and Name() are canonical after type-checking.
+func classifyResolvedJournalType(t types.Type) journalFieldKind {
 	if t == nil {
-		return false
+		return journalFieldNone
 	}
-	// Unwrap a pointer: *journal.Journal is not idiomatic but we cover it.
+	// Unwrap a pointer: *journal.JournalCore is not idiomatic but we cover it.
 	if ptr, ok := t.(*types.Pointer); ok {
 		t = ptr.Elem()
 	}
-	// After un-aliasing at the types level, we expect a *types.Named.
-	// types.Unalias is available in Go 1.22+; fallback: walk through Named.
 	named, ok := t.(*types.Named)
 	if !ok {
-		return false
+		return journalFieldNone
 	}
 	obj := named.Obj()
-	if obj == nil {
-		return false
+	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != journalInterfacePkgPath {
+		return journalFieldNone
 	}
-	if obj.Name() != journalInterfaceTypeName {
-		return false
+	switch obj.Name() {
+	case journalInterfaceTypeName:
+		return journalFieldFull
+	case heartbeaterInterfaceTypeName:
+		return journalFieldHeartbeater
+	case journalCoreInterfaceTypeName:
+		return journalFieldCore
 	}
-	pkg := obj.Pkg()
-	if pkg == nil {
-		return false
-	}
-	return pkg.Path() == journalInterfacePkgPath
+	return journalFieldNone
 }
 
-// TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal scans the
-// runtime/saga production source for any struct declaring a field whose
-// resolved type is kernel/saga/journal.Journal. Asserts that the owning
-// TypeSpec.Name == "Coordinator".
+// journalFieldSealDiag applies the two seal rules to a single struct field and
+// returns a diagnostic when violated.
+func journalFieldSealDiag(p *Pass, rel, holderName string, field *ast.Field) (Diagnostic, bool) {
+	kind := classifyJournalFieldType(p.TypesInfo, field.Type)
+	if kind == journalFieldNone {
+		return Diagnostic{}, false
+	}
+	// Rule 2: JournalCore is allowed, but only on the Coordinator.
+	if kind == journalFieldCore && holderName == allowedSagaJournalHolder {
+		return Diagnostic{}, false
+	}
+	pos := p.Fset.Position(field.Pos())
+	return Diagnostic{Rel: rel, Line: pos.Line, Message: journalFieldSealMessage(kind, holderName)}, true
+}
+
+// journalFieldSealMessage renders the diagnostic text for a violating field.
+func journalFieldSealMessage(kind journalFieldKind, holderName string) string {
+	if kind == journalFieldCore {
+		return fmt.Sprintf(
+			"%s: struct %q holds a journal.JournalCore field; only %q may hold it",
+			sagaJournalHolderSealRule, holderName, allowedSagaJournalHolder)
+	}
+	// journalFieldFull / journalFieldHeartbeater — a Heartbeat-bearing field.
+	return fmt.Sprintf(
+		"%s: struct %q holds a Heartbeat-bearing journal interface field "+
+			"(journal.Journal or journal.Heartbeater); no struct in runtime/saga may "+
+			"persist a Heartbeat-capable field — hold journal.JournalCore instead. The "+
+			"full Journal exists transiently only as the NewCoordinator parameter handed "+
+			"to executor.NewExecutor (the sanctioned per-step heartbeat funnel).",
+		sagaJournalHolderSealRule, holderName)
+}
+
+// TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal scans runtime/saga
+// production source for struct fields whose resolved type is a journal-package
+// interface, applying both seal rules (see package godoc):
+//   - journal.Journal / journal.Heartbeater field anywhere → violation
+//   - journal.JournalCore field outside Coordinator → violation
 //
-// Uses RunTyped (not Run) so that go/types can resolve field types across
-// package boundaries — a pure AST scan cannot distinguish `journal.Journal`
-// from any other selector expression named "Journal" without type information.
+// Uses RunTyped (not Run) so go/types can resolve field types across package
+// boundaries — a pure AST scan cannot distinguish `journal.JournalCore` from any
+// other selector named "JournalCore" without type information.
 func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 	t.Parallel()
 
@@ -143,20 +229,9 @@ func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 				}
 				holderName := ts.Name.Name
 				for _, field := range st.Fields.List {
-					if !fieldTypeIsJournal(p.TypesInfo, field.Type) {
-						continue
+					if d, ok := journalFieldSealDiag(p, rel, holderName, field); ok {
+						out = append(out, d)
 					}
-					if holderName == allowedSagaJournalHolder {
-						continue
-					}
-					pos := p.Fset.Position(field.Pos())
-					out = append(out, Diagnostic{
-						Rel:  rel,
-						Line: pos.Line,
-						Message: fmt.Sprintf(
-							"%s: struct %q holds a journal.Journal field; only %q may hold this interface type",
-							sagaJournalHolderSealRule, holderName, allowedSagaJournalHolder),
-					})
 				}
 			})
 		}
@@ -166,19 +241,41 @@ func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 	Report(t, sagaJournalHolderSealRule+"-A1", diags)
 }
 
-// TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga ensures that
-// production non-test files in runtime/saga do not introduce a type alias of
-// the form `type X = journal.Journal`. Such an alias would let a new struct
-// declare a field of type X — which is structurally identical to journal.Journal
-// — while evading A1's exact-name check (if A1 were implemented as a pure AST
-// string match rather than a types-resolved check). Although A1 uses go/types
-// resolution (which chases through aliases), B1 is retained as defense-in-depth:
+// journalInterfaceAliasName reports the journal interface name aliased by ts if
+// ts is `type X = journal.{Journal,JournalCore,Heartbeater}`, else ("", false).
+func journalInterfaceAliasName(ts *ast.TypeSpec) (string, bool) {
+	// An alias has a valid Assign token.
+	if !ts.Assign.IsValid() {
+		return "", false
+	}
+	sel, ok := ts.Type.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != "journal" {
+		return "", false
+	}
+	switch sel.Sel.Name {
+	case journalInterfaceTypeName, journalCoreInterfaceTypeName, heartbeaterInterfaceTypeName:
+		return sel.Sel.Name, true
+	}
+	return "", false
+}
+
+// TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga ensures production
+// non-test files in runtime/saga do not introduce a type alias of the form
+// `type X = journal.Journal` / `journal.JournalCore` / `journal.Heartbeater`.
+// Such an alias would let a new struct declare a field of type X — structurally
+// identical to the aliased interface — while evading A1's exact-name check (if A1
+// were a pure AST string match rather than a types-resolved check). A1 uses
+// go/types resolution (which chases through aliases), so B1 is defense-in-depth:
 // it catches the alias declaration itself before any struct can use it.
 //
-// B1 uses Run (AST-only) because detecting `type X = journal.Journal` is a
-// pure syntactic check: an alias TypeSpec has a valid ts.Assign token, and the
-// RHS is a SelectorExpr whose X.Name == "journal" and Sel.Name == "Journal".
-// No cross-package resolution is needed for the alias declaration site itself.
+// B1 uses Run (AST-only) because detecting the alias is a pure syntactic check:
+// an alias TypeSpec has a valid ts.Assign token and the RHS is a SelectorExpr
+// whose X.Name == "journal". No cross-package resolution is needed at the alias
+// declaration site itself.
 func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 	t.Parallel()
 
@@ -197,21 +294,8 @@ func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 			}
 
 			EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
-				// An alias has a valid Assign token.
-				if !ts.Assign.IsValid() {
-					return
-				}
-				// Check whether the aliased type is journal.Journal via the
-				// selector expression `journal.Journal`.
-				sel, ok := ts.Type.(*ast.SelectorExpr)
+				aliased, ok := journalInterfaceAliasName(ts)
 				if !ok {
-					return
-				}
-				id, ok := sel.X.(*ast.Ident)
-				if !ok {
-					return
-				}
-				if id.Name != "journal" || sel.Sel.Name != journalInterfaceTypeName {
 					return
 				}
 				pos := p.Fset.Position(ts.Pos())
@@ -219,10 +303,10 @@ func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 					Rel:  rel,
 					Line: pos.Line,
 					Message: fmt.Sprintf(
-						"%s-B1: type alias %q = journal.Journal in runtime/saga; "+
-							"remove the alias and reference journal.Journal directly — "+
-							"aliases create an evasion path for the single-holder invariant",
-						sagaJournalHolderSealRule, ts.Name.Name),
+						"%s-B1: type alias %q = journal.%s in runtime/saga; remove the alias "+
+							"and reference the journal interface directly — aliases create an "+
+							"evasion path for the holder-seal invariant",
+						sagaJournalHolderSealRule, ts.Name.Name, aliased),
 				})
 			})
 		}

--- a/tools/archtest/saga_journal_holder_seal_test.go
+++ b/tools/archtest/saga_journal_holder_seal_test.go
@@ -77,6 +77,8 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
+	"go/token"
 	"go/types"
 	"path/filepath"
 	"strings"
@@ -314,4 +316,83 @@ func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 	})
 
 	Report(t, sagaJournalHolderSealRule+"-B1", diags)
+}
+
+// TestSagaJournalHolderSeal_BlindSpot_B1_MatcherNonVacuous proves the B1
+// alias-matcher is wired and non-vacuous. B1's production scan reports zero
+// violations today (by design), so — unlike NO-HEARTBEAT-LOOP's B1, which can
+// assert "executor has >=1 callsite" — it cannot demonstrate non-vacuity from
+// production source. Instead this exercises journalInterfaceAliasName against a
+// synthetic AST covering every form: the three sealed alias names must match,
+// and non-aliases / wrong package / non-selector / definition (non-alias) forms
+// must NOT. If the matcher silently stopped firing, B1 would pass vacuously and
+// this test catches it.
+func TestSagaJournalHolderSeal_BlindSpot_B1_MatcherNonVacuous(t *testing.T) {
+	t.Parallel()
+
+	const src = `package x
+type A = journal.Journal
+type B = journal.JournalCore
+type C = journal.Heartbeater
+type D = journal.Other
+type E = other.Journal
+type F journal.Journal
+type G = SomethingElse
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "synthetic.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse synthetic source: %v", err)
+	}
+
+	// typeName -> expected aliased journal interface name ("" = must NOT match).
+	want := map[string]string{
+		"A": journalInterfaceTypeName,     // type X = journal.Journal
+		"B": journalCoreInterfaceTypeName, // type X = journal.JournalCore
+		"C": heartbeaterInterfaceTypeName, // type X = journal.Heartbeater
+		"D": "",                           // journal.Other — not a sealed name
+		"E": "",                           // other.Journal — wrong package ident
+		"F": "",                           // definition, not an alias (no '=')
+		"G": "",                           // not a selector expression
+	}
+
+	seen := map[string]bool{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			exp, tracked := want[ts.Name.Name]
+			if !tracked {
+				continue
+			}
+			seen[ts.Name.Name] = true
+			aliased, matched := journalInterfaceAliasName(ts)
+			if exp == "" {
+				if matched {
+					t.Errorf("journalInterfaceAliasName(%s) = (%q, true); want no match",
+						ts.Name.Name, aliased)
+				}
+				continue
+			}
+			if !matched || aliased != exp {
+				t.Errorf("journalInterfaceAliasName(%s) = (%q, %v); want (%q, true)",
+					ts.Name.Name, aliased, matched, exp)
+			}
+		}
+	}
+
+	// Non-vacuity: the three positive cases must have been exercised — otherwise
+	// the fixture or the parse silently skipped them.
+	for _, name := range []string{"A", "B", "C"} {
+		if !seen[name] {
+			t.Errorf("synthetic fixture did not exercise positive case %q — "+
+				"B1 matcher self-test is vacuous", name)
+		}
+	}
 }

--- a/tools/archtest/saga_journal_holder_seal_test.go
+++ b/tools/archtest/saga_journal_holder_seal_test.go
@@ -2,7 +2,7 @@
 //
 // INVARIANT: SAGA-JOURNAL-HOLDER-SEAL-01
 //
-// Two field-shape rules over runtime/saga production structs:
+// Three field-shape rules over runtime/saga production structs:
 //
 //  1. No struct may hold a Heartbeat-bearing journal interface as a persisted
 //     field — i.e. neither kernel/saga/journal.Journal (the full interface) nor
@@ -11,6 +11,13 @@
 //     it is forbidden everywhere, Coordinator included.
 //  2. kernel/saga/journal.JournalCore (the Heartbeat-free core) may be held only
 //     by runtime/saga.Coordinator. Any other holder is a violation.
+//  3. No struct may persist a Heartbeater-SHAPED func value as a field
+//     (func(context.Context, idutil.SafeID, idutil.SafeID, time.Duration)
+//     (bool, error)). A persisted heartbeat func is the func-value equivalent of
+//     a journal.Heartbeater field: it lets a centralized loop be reconstructed
+//     from a heartbeat func handed in from OUTSIDE runtime/saga (where the
+//     `.Heartbeat` selector is beyond SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 A1's
+//     scope). Forbidden everywhere, Coordinator included. (rule 3 / F3)
 //
 // The full journal.Journal still exists transiently as the NewCoordinator
 // parameter handed straight to executor.NewExecutor (the sanctioned per-step
@@ -30,8 +37,9 @@
 // # AI-robust rating
 //
 // Upstream Medium: a typed-aware go/types scan locks holder-struct identity
-// within the package; a new non-Coordinator JournalCore field (or any
-// Heartbeat-bearing field) is rejected at archtest time, not by the compiler.
+// within the package; a new non-Coordinator JournalCore field, any
+// Heartbeat-bearing journal interface field, or any Heartbeater-shaped func
+// field (rule 3) is rejected at archtest time, not by the compiler.
 // Downstream N/A: this is a field-shape invariant, not a callsite invariant —
 // there is no caller allowlist.
 //
@@ -50,8 +58,9 @@
 //
 //   - B1 (reverse self-test): a `type X = journal.{Journal,JournalCore,Heartbeater}`
 //     alias in runtime/saga would let a struct hold `X` evading a pure-AST name
-//     match. A1's go/types resolution already chases through aliases, but B1
-//     catches the alias declaration itself before any struct uses it. Covered.
+//     match. A1's go/types resolution chases through aliases via types.Unalias
+//     (mandatory on Go 1.23+ where an alias is *types.Alias), but B1 catches the
+//     alias declaration itself before any struct uses it. Covered.
 //   - Embedded (anonymous) field `struct { journal.Heartbeater }`: ast.StructType
 //     Fields.List includes embedded fields (Names empty, Type set), so A1
 //     classifies it. Covered.
@@ -60,10 +69,11 @@
 //     degenerate, non-idiomatic form — accepted residual blind spot.
 //   - Cross-package alias `type J = journal.JournalCore` declared OUTSIDE
 //     runtime/saga then imported and used as a field type inside runtime/saga:
-//     A1 still classifies it correctly (Named.Obj().Pkg()/Name() are canonical
-//     after type-checking), but B1 (which only scans runtime/saga) does not flag
-//     the foreign declaration. Accepted residual blind spot — cross-package
-//     interface aliases are rare and A1 resolves the field type regardless.
+//     A1 classifies it correctly because classifyResolvedJournalType calls
+//     types.Unalias (required on Go 1.23+ where an alias is *types.Alias, not
+//     *types.Named). B1 (which only scans runtime/saga) does not flag the foreign
+//     declaration, but A1 resolves the field type regardless. Accepted residual
+//     for B1; A1-covered.
 //   - Local interface that re-declares the Heartbeat shape, e.g.
 //     `type beat interface { Heartbeat(...) }` held as a field: a new named type,
 //     NOT journal.*, so this seal does not classify it. Accepted residual —
@@ -71,7 +81,13 @@
 //     is signature-shape (not name) based and flags any actual .Heartbeat(...)
 //     call in runtime/saga regardless of the holder type. Holding without calling
 //     is inert; calling is caught there.
-//   - B1 only scans non-test files in runtime/saga; test files may alias freely.
+//   - B1 resolves the journal package's local binding from each file's imports
+//     (journalPackageLocalNames), so an import alias `import sagajournal "…/journal"`
+//     is covered (F2 fix). A dot-import `import . "…/journal"` would make the
+//     alias RHS a bare Ident (`type X = JournalCore`, no SelectorExpr) — not
+//     matched by B1; accepted residual (dot-imports are non-idiomatic and A1
+//     still resolves any field that actually uses such an alias). B1 only scans
+//     non-test files in runtime/saga; test files may alias freely.
 package archtest
 
 import (
@@ -80,7 +96,9 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -136,16 +154,27 @@ func classifyJournalFieldType(info *types.Info, expr ast.Expr) journalFieldKind 
 }
 
 // classifyResolvedJournalType checks whether t (possibly wrapped in one pointer
-// or resolved through an alias) is journal.Journal, journal.Heartbeater, or
-// journal.JournalCore. Aliases resolve at the types.Type level, so
-// Named.Obj().Pkg().Path() and Name() are canonical after type-checking.
+// or resolved through a type alias) is journal.Journal, journal.Heartbeater, or
+// journal.JournalCore.
+//
+// On Go 1.23+ (gotypesalias=1, the default — this module is on go 1.25), a type
+// alias materializes as *types.Alias, NOT transparently as the aliased
+// *types.Named. A bare t.(*types.Named) assertion therefore MISSES alias-typed
+// fields (a field of `type J = journal.JournalCore` resolves to *types.Alias and
+// the assertion fails). types.Unalias collapses an alias to its underlying type
+// so the Obj().Pkg().Path()/Name() check below is canonical regardless of how
+// many alias / pointer layers wrap the field type (go/types.Unalias expands a
+// type to the one it denotes after resolving package-level aliases).
 func classifyResolvedJournalType(t types.Type) journalFieldKind {
 	if t == nil {
 		return journalFieldNone
 	}
-	// Unwrap a pointer: *journal.JournalCore is not idiomatic but we cover it.
+	// Collapse a top-level alias (`type J = journal.JournalCore`) before the
+	// pointer probe, then again after unwrapping a pointer (`*J`, or
+	// `type J = *journal.JournalCore`), so every alias⇄pointer ordering resolves.
+	t = types.Unalias(t)
 	if ptr, ok := t.(*types.Pointer); ok {
-		t = ptr.Elem()
+		t = types.Unalias(ptr.Elem())
 	}
 	named, ok := t.(*types.Named)
 	if !ok {
@@ -198,6 +227,51 @@ func journalFieldSealMessage(kind journalFieldKind, holderName string) string {
 		sagaJournalHolderSealRule, holderName)
 }
 
+// heartbeatFuncFieldDiag (rule 3) flags a struct field whose type is a func —
+// anonymous, named, aliased, or pointer-to-func — matching the Heartbeater
+// signature shape. Persisting such a callable is the func-value equivalent of
+// holding a journal.Heartbeater field: a centralized heartbeat loop can be
+// reconstructed from a heartbeat func passed into the constructor from OUTSIDE
+// runtime/saga, where the `.Heartbeat` selector is beyond
+// SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 A1's scope. Closing the field-
+// persistence path here blocks the loop (a loop needs a persisted callable; a
+// bare constructor closure capturing the param is the irreducible residual, same
+// class as that archtest's NewCoordinator pass-through window). No struct in
+// runtime/saga — Coordinator included — may persist a heartbeat-shaped func.
+func heartbeatFuncFieldDiag(p *Pass, rel, holderName string, field *ast.Field) (Diagnostic, bool) {
+	if p.TypesInfo == nil {
+		return Diagnostic{}, false
+	}
+	tv, ok := p.TypesInfo.Types[field.Type]
+	if !ok {
+		return Diagnostic{}, false
+	}
+	// Collapse alias + one pointer level (mirrors classifyResolvedJournalType),
+	// then require the underlying type to be a func signature of the heartbeat
+	// shape. Interface fields (Underlying = *types.Interface) never match here —
+	// they are journal-package interfaces handled by classifyJournalFieldType.
+	t := types.Unalias(tv.Type)
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(ptr.Elem())
+	}
+	sig, ok := t.Underlying().(*types.Signature)
+	if !ok || !signatureMatchesHeartbeaterShape(sig) {
+		return Diagnostic{}, false
+	}
+	pos := p.Fset.Position(field.Pos())
+	return Diagnostic{
+		Rel:  rel,
+		Line: pos.Line,
+		Message: fmt.Sprintf(
+			"%s: struct %q holds a Heartbeater-shaped func field "+
+				"(func(context.Context, idutil.SafeID, idutil.SafeID, time.Duration) (bool, error)); "+
+				"no struct in runtime/saga may persist a Heartbeat-capable callable (interface OR func) "+
+				"— a persisted heartbeat func reconstructs the centralized-loop anti-pattern from a value "+
+				"passed in from outside runtime/saga. Funnel per-step heartbeat through executor.",
+			sagaJournalHolderSealRule, holderName),
+	}, true
+}
+
 // TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal scans runtime/saga
 // production source for struct fields whose resolved type is a journal-package
 // interface, applying both seal rules (see package godoc):
@@ -233,6 +307,10 @@ func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 				for _, field := range st.Fields.List {
 					if d, ok := journalFieldSealDiag(p, rel, holderName, field); ok {
 						out = append(out, d)
+						continue
+					}
+					if d, ok := heartbeatFuncFieldDiag(p, rel, holderName, field); ok {
+						out = append(out, d)
 					}
 				}
 			})
@@ -243,9 +321,39 @@ func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 	Report(t, sagaJournalHolderSealRule+"-A1", diags)
 }
 
+// journalPackageLocalNames returns the set of local identifiers in file bound
+// to the journal interface package (journalInterfacePkgPath): the default
+// package name for a plain import, plus any explicit import alias
+// (`import sagajournal "…/journal"`). Blank (`_`) and dot (`.`) imports are not
+// usable as a `pkg.Type` selector base and are excluded — a dot-imported
+// `type X = JournalCore` is a bare-Ident form (no SelectorExpr) noted as a
+// residual in the package godoc.
+func journalPackageLocalNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range file.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || p != journalInterfacePkgPath {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			names[path.Base(journalInterfacePkgPath)] = true // default name: "journal"
+		case imp.Name.Name == "_" || imp.Name.Name == ".":
+			// not usable as a selector base; skip
+		default:
+			names[imp.Name.Name] = true
+		}
+	}
+	return names
+}
+
 // journalInterfaceAliasName reports the journal interface name aliased by ts if
-// ts is `type X = journal.{Journal,JournalCore,Heartbeater}`, else ("", false).
-func journalInterfaceAliasName(ts *ast.TypeSpec) (string, bool) {
+// ts is `type X = <localName>.{Journal,JournalCore,Heartbeater}` where localName
+// is any local binding of the journal package (journalLocalNames), else
+// ("", false). Resolving via journalLocalNames rather than a hardcoded "journal"
+// closes the import-alias evasion: `import sagajournal "…/journal"` followed by
+// `type X = sagajournal.JournalCore` is now flagged.
+func journalInterfaceAliasName(ts *ast.TypeSpec, journalLocalNames map[string]bool) (string, bool) {
 	// An alias has a valid Assign token.
 	if !ts.Assign.IsValid() {
 		return "", false
@@ -255,7 +363,7 @@ func journalInterfaceAliasName(ts *ast.TypeSpec) (string, bool) {
 		return "", false
 	}
 	id, ok := sel.X.(*ast.Ident)
-	if !ok || id.Name != "journal" {
+	if !ok || !journalLocalNames[id.Name] {
 		return "", false
 	}
 	switch sel.Sel.Name {
@@ -276,8 +384,10 @@ func journalInterfaceAliasName(ts *ast.TypeSpec) (string, bool) {
 //
 // B1 uses Run (AST-only) because detecting the alias is a pure syntactic check:
 // an alias TypeSpec has a valid ts.Assign token and the RHS is a SelectorExpr
-// whose X.Name == "journal". No cross-package resolution is needed at the alias
-// declaration site itself.
+// whose X.Name binds to the journal package. The binding is resolved from the
+// file's own import specs (journalPackageLocalNames), so an import alias
+// (`import sagajournal "…/journal"`) is covered without cross-package type
+// resolution at the declaration site.
 func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 	t.Parallel()
 
@@ -294,9 +404,13 @@ func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 			if !strings.HasPrefix(rel, "runtime/saga/") {
 				continue
 			}
+			journalNames := journalPackageLocalNames(file)
+			if len(journalNames) == 0 {
+				continue // file does not import the journal package
+			}
 
 			EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
-				aliased, ok := journalInterfaceAliasName(ts)
+				aliased, ok := journalInterfaceAliasName(ts, journalNames)
 				if !ok {
 					return
 				}
@@ -327,6 +441,10 @@ func TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga(t *testing.T) {
 // and non-aliases / wrong package / non-selector / definition (non-alias) forms
 // must NOT. If the matcher silently stopped firing, B1 would pass vacuously and
 // this test catches it.
+//
+// Case H (`sagajournal.JournalCore`) locks the F2 fix: the journal package
+// imported under a non-default local name must still match, while case E
+// (`other.Journal`, a name NOT bound to the journal package) must not.
 func TestSagaJournalHolderSeal_BlindSpot_B1_MatcherNonVacuous(t *testing.T) {
 	t.Parallel()
 
@@ -338,6 +456,7 @@ type D = journal.Other
 type E = other.Journal
 type F journal.Journal
 type G = SomethingElse
+type H = sagajournal.JournalCore
 `
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "synthetic.go", src, 0)
@@ -345,15 +464,21 @@ type G = SomethingElse
 		t.Fatalf("parse synthetic source: %v", err)
 	}
 
+	// journalNames models a file that imports the journal package both plainly
+	// (local name "journal") and under an alias (`import sagajournal "…/journal"`).
+	// "other" is deliberately absent — it is NOT a binding of the journal pkg.
+	journalNames := map[string]bool{"journal": true, "sagajournal": true}
+
 	// typeName -> expected aliased journal interface name ("" = must NOT match).
 	want := map[string]string{
 		"A": journalInterfaceTypeName,     // type X = journal.Journal
 		"B": journalCoreInterfaceTypeName, // type X = journal.JournalCore
 		"C": heartbeaterInterfaceTypeName, // type X = journal.Heartbeater
 		"D": "",                           // journal.Other — not a sealed name
-		"E": "",                           // other.Journal — wrong package ident
+		"E": "",                           // other.Journal — name not bound to journal pkg
 		"F": "",                           // definition, not an alias (no '=')
 		"G": "",                           // not a selector expression
+		"H": journalCoreInterfaceTypeName, // type X = sagajournal.JournalCore (import alias)
 	}
 
 	seen := map[string]bool{}
@@ -372,7 +497,7 @@ type G = SomethingElse
 				continue
 			}
 			seen[ts.Name.Name] = true
-			aliased, matched := journalInterfaceAliasName(ts)
+			aliased, matched := journalInterfaceAliasName(ts, journalNames)
 			if exp == "" {
 				if matched {
 					t.Errorf("journalInterfaceAliasName(%s) = (%q, true); want no match",
@@ -387,12 +512,133 @@ type G = SomethingElse
 		}
 	}
 
-	// Non-vacuity: the three positive cases must have been exercised — otherwise
-	// the fixture or the parse silently skipped them.
-	for _, name := range []string{"A", "B", "C"} {
+	// Non-vacuity: every positive case (incl. the import-aliased H) must have
+	// been exercised — otherwise the fixture or the parse silently skipped them.
+	for _, name := range []string{"A", "B", "C", "H"} {
 		if !seen[name] {
 			t.Errorf("synthetic fixture did not exercise positive case %q — "+
 				"B1 matcher self-test is vacuous", name)
 		}
+	}
+}
+
+// TestSagaJournalHolderSeal_A1_AliasFieldResolvedViaUnalias is the F1 regression:
+// classifyResolvedJournalType must resolve a struct field whose type is a
+// package-level alias to journal.JournalCore. On Go 1.23+ (gotypesalias=1, this
+// module is on go 1.25) the field type is *types.Alias; without types.Unalias
+// the *types.Named assertion fails and the alias-typed holder silently evades
+// the seal — defeating the holder seal with a one-line alias.
+//
+// The fixture (testdata/saga_journal_alias_fixtures/aliasholder) has two
+// non-Coordinator holders — one direct, one via alias — and BOTH must be flagged.
+// Pre-fix the alias holder is missed (this test fails); post-fix both surface.
+func TestSagaJournalHolderSeal_A1_AliasFieldResolvedViaUnalias(t *testing.T) {
+	t.Parallel()
+
+	diags := RunTypedFixture(t, FixtureOpts{},
+		[]string{"./tools/archtest/testdata/saga_journal_holder_seal_fixtures/aliasholder"},
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var out []Diagnostic
+			for _, file := range p.Files {
+				rel := filepath.ToSlash(p.Rel(file))
+				EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+					st, ok := ts.Type.(*ast.StructType)
+					if !ok || st.Fields == nil {
+						return
+					}
+					// holderName is never "Coordinator" for fixture structs, so
+					// the rule-2 JournalCore allowance never applies — every
+					// JournalCore field (direct or aliased) must surface.
+					for _, field := range st.Fields.List {
+						if d, ok := journalFieldSealDiag(p, rel, ts.Name.Name, field); ok {
+							out = append(out, d)
+						}
+					}
+				})
+			}
+			return out
+		})
+
+	var directFlagged, aliasFlagged bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "HolderDirect") {
+			directFlagged = true
+		}
+		if strings.Contains(d.Message, "HolderViaAlias") {
+			aliasFlagged = true
+		}
+	}
+	if !directFlagged {
+		t.Errorf("%s-A1: fixture HolderDirect (journal.JournalCore field) not flagged — "+
+			"the holder-seal classifier is broken (fixture wiring or scan logic)",
+			sagaJournalHolderSealRule)
+	}
+	if !aliasFlagged {
+		t.Errorf("%s-A1: fixture HolderViaAlias (alias to journal.JournalCore) not flagged — "+
+			"classifyResolvedJournalType is not calling types.Unalias; on Go 1.23+ an alias "+
+			"is *types.Alias, so the alias-typed field evades the seal (F1 regression)",
+			sagaJournalHolderSealRule)
+	}
+}
+
+// TestSagaJournalHolderSeal_A1_HeartbeatFuncFieldFlagged is the F3 regression
+// (rule 3): a struct persisting a Heartbeater-shaped func value as a field — the
+// func-value equivalent of a journal.Heartbeater field — must be flagged, while
+// a non-heartbeat func field must NOT (shape-specific, not "any func"). This
+// closes the path where a heartbeat func handed in from outside runtime/saga is
+// stashed in a field to drive a centralized loop, which neither the interface
+// holder seal nor the name-filtered NO-HEARTBEAT-LOOP A1 catches.
+func TestSagaJournalHolderSeal_A1_HeartbeatFuncFieldFlagged(t *testing.T) {
+	t.Parallel()
+
+	diags := RunTypedFixture(t, FixtureOpts{},
+		[]string{"./tools/archtest/testdata/saga_journal_holder_seal_fixtures/funcfieldholder"},
+		func(p *Pass) []Diagnostic {
+			if p.TypesInfo == nil {
+				return nil
+			}
+			var out []Diagnostic
+			for _, file := range p.Files {
+				rel := filepath.ToSlash(p.Rel(file))
+				EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+					st, ok := ts.Type.(*ast.StructType)
+					if !ok || st.Fields == nil {
+						return
+					}
+					for _, field := range st.Fields.List {
+						if d, ok := heartbeatFuncFieldDiag(p, rel, ts.Name.Name, field); ok {
+							out = append(out, d)
+						}
+					}
+				})
+			}
+			return out
+		})
+
+	var anonFlagged, namedFlagged, plainFlagged bool
+	for _, d := range diags {
+		switch {
+		case strings.Contains(d.Message, "HeartbeatFuncHolder"):
+			anonFlagged = true
+		case strings.Contains(d.Message, "NamedFuncHolder"):
+			namedFlagged = true
+		case strings.Contains(d.Message, "PlainFuncHolder"):
+			plainFlagged = true
+		}
+	}
+	if !anonFlagged {
+		t.Errorf("%s-A1: HeartbeatFuncHolder (anonymous heartbeat-shaped func field) not flagged — "+
+			"the func-value evasion path is open (F3 regression)", sagaJournalHolderSealRule)
+	}
+	if !namedFlagged {
+		t.Errorf("%s-A1: NamedFuncHolder (named heartbeat-shaped func type field) not flagged — "+
+			"heartbeatFuncFieldDiag must resolve the named type's underlying signature", sagaJournalHolderSealRule)
+	}
+	if plainFlagged {
+		t.Errorf("%s-A1: PlainFuncHolder (non-heartbeat func field) wrongly flagged — "+
+			"the shape match is too loose (would false-positive on ordinary func fields)", sagaJournalHolderSealRule)
 	}
 }

--- a/tools/archtest/testdata/saga_journal_holder_seal_fixtures/aliasholder/fixture.go
+++ b/tools/archtest/testdata/saga_journal_holder_seal_fixtures/aliasholder/fixture.go
@@ -1,0 +1,27 @@
+//go:build archtest_fixture
+
+// Package aliasholder is a RED fixture for SAGA-JOURNAL-HOLDER-SEAL-01 (F1):
+// a non-Coordinator struct holds journal.JournalCore both directly and through
+// a package-level type alias. The alias-typed field exercises
+// classifyResolvedJournalType's types.Unalias path — on Go 1.23+ (gotypesalias=1)
+// the alias materializes as *types.Alias, so without types.Unalias the seal's
+// *types.Named assertion fails and the alias holder silently evades the rule.
+// Loaded only via RunTypedFixture.
+package aliasholder
+
+import "github.com/ghbvf/gocell/kernel/saga/journal"
+
+// aliasedCore is a package-level alias to the Heartbeat-free core interface.
+type aliasedCore = journal.JournalCore
+
+// HolderDirect holds journal.JournalCore directly — flagged with or without the
+// Unalias fix (control case proving the fixture wiring is live).
+type HolderDirect struct {
+	j journal.JournalCore
+}
+
+// HolderViaAlias holds the core through an alias. classifyResolvedJournalType
+// must call types.Unalias to resolve it; otherwise this struct evades the seal.
+type HolderViaAlias struct {
+	j aliasedCore
+}

--- a/tools/archtest/testdata/saga_journal_holder_seal_fixtures/funcfieldholder/fixture.go
+++ b/tools/archtest/testdata/saga_journal_holder_seal_fixtures/funcfieldholder/fixture.go
@@ -1,0 +1,37 @@
+//go:build archtest_fixture
+
+// Package funcfieldholder is a RED fixture for SAGA-JOURNAL-HOLDER-SEAL-01
+// rule 3 (F3): a struct persists a Heartbeater-shaped func value as a field.
+// Holding such a callable is the func-value equivalent of a journal.Heartbeater
+// field — it lets a centralized heartbeat loop be reconstructed from a heartbeat
+// func handed in from outside runtime/saga — and must be flagged. A non-
+// heartbeat func field is the negative control. Loaded only via RunTypedFixture.
+package funcfieldholder
+
+import (
+	"context"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/idutil"
+)
+
+// HeartbeatFuncHolder persists a heartbeat-shaped func — the func-value path the
+// holder seal (rule 3) must close.
+type HeartbeatFuncHolder struct {
+	beat func(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (bool, error)
+}
+
+// namedHeartbeatFunc is a named func type of the heartbeat shape; a field of
+// this type must also be flagged (Unalias/Underlying resolution).
+type namedHeartbeatFunc func(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (bool, error)
+
+// NamedFuncHolder persists the named heartbeat-shaped func type.
+type NamedFuncHolder struct {
+	beat namedHeartbeatFunc
+}
+
+// PlainFuncHolder holds a non-heartbeat func — must NOT be flagged (negative
+// control proving the shape match is specific, not "any func field").
+type PlainFuncHolder struct {
+	cb func(ctx context.Context) error
+}


### PR DESCRIPTION
## Summary

Splits `kernel/saga/journal.Journal` (flat 7-method interface) into **`JournalCore`** (6 methods) + **`Heartbeater`** (the `Heartbeat` method), with `Journal = JournalCore + Heartbeater` as an embedding union (public surface unchanged).

`runtime/saga.Coordinator.journal` is narrowed to **`journal.JournalCore`**, so `c.journal.Heartbeat(...)` is now a **compile error** — a centralized heartbeat loop built on a persisted Heartbeat-bearing **interface** field is type-system inexpressible (**Hard**). The func-value variant — a heartbeat-**shaped** `func(...)` field fed from a `.Heartbeat` selector outside `runtime/saga` — is not compile-sealable, so it is archtest-banned by `SAGA-JOURNAL-HOLDER-SEAL-01` **rule 3** (**Medium**). Net upstream for `SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01`: Hard (interface-field) + Medium (func-field); see the corrected ratings below.

Key design: only the **field facet** narrows. `NewCoordinator(j journal.Journal, ...)` keeps the full-interface parameter (it must, to wire the internal executor via `executor.NewExecutor(j, ...)`, which needs `executor.Heartbeater`). Because `Journal` stays the union, the conformance suite, PG/mem implementations, and every caller are untouched.

`Refs: PR #1181 / #982 / #1213`

## Changes

- **`kernel/saga/journal/interface.go`** — `JournalCore` + `Heartbeater` + `Journal` union; method godoc moved verbatim; kernel-vs-`executor.Heartbeater` layering note (kernel can't import runtime; executor must not import journal).
- **`runtime/saga/coordinator.go`** — `journal journal.JournalCore` field; godoc/comments updated for accuracy (executor receives the full `j` param; field stores the JournalCore facet).
- **`tools/archtest/saga_coordinator_no_heartbeat_test.go`** — rating rewritten: upstream **Hard (interface-field loop)** + **Medium (func-field loop, via holder-seal rule 3)**; **honest Medium downstream** (A1 retained for the irreducible `NewCoordinator` pass-through window). `methodIsHeartbeaterShape` refactored to share `signatureMatchesHeartbeaterShape` with the new func-field scan.
- **`tools/archtest/saga_journal_holder_seal_test.go`** — **complete seal** (3 rules): (1) forbid full `journal.Journal` / bare `journal.Heartbeater` as a field anywhere in `runtime/saga`; (2) allow `journal.JournalCore` only on `Coordinator`; (3) forbid a Heartbeater-**shaped func field** anywhere (F3). `classifyResolvedJournalType` now calls `types.Unalias` (F1 — required on Go 1.23+ where an alias is `*types.Alias`); B1 resolves import aliases from each file's imports (F2); AI-robust **blind-spot self-test** godoc; fixed wrong issue ref **#981 → #982**.
- **PG + mem** — added `var _ journal.JournalCore` / `var _ journal.Heartbeater` compile assertions alongside the existing `journal.Journal` one.

## Implementation matrix (contract-fanout)

```
Contract: kernel/saga/journal.Journal interface
Change: split into JournalCore (6 methods) + Heartbeater (Heartbeat); Journal = union
Implementations: [x] memstore (MemJournal)  [x] PG (PGJournal)  [ ] fake (n/a)
Conformance test: sagajournaltest.RunConformanceSuite (unchanged — Factory returns journal.Journal, exercises Heartbeat)
Repro:
  go test ./kernel/saga/... ./runtime/saga/...
  go test ./tools/archtest/ -run 'TestSagaJournalHolderSeal|TestSagaCoordinatorNoHeartbeatLoop'
  go test -tags=integration ./adapters/postgres/saga/... ./tests/integration/sagaleader/...
Dependent contracts (governance scan): none (internal kernel interface; no contract.yaml / wire / DB schema)
```

## AI-robust ratings

| Archtest | Upstream | Downstream |
|----------|----------|------------|
| SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 | **Hard (interface-field loop)** — `Coordinator.journal` is `JournalCore`, no `Heartbeat` method → compile error — **+ Medium (func-field loop)**: a heartbeat-shaped `func` field is not compile-sealable; banned by holder-seal rule 3. Irreducible residual: a constructor closure capturing the `NewCoordinator` param without persisting it. | **Medium** (A1 guards the irreducible NewCoordinator pass-through window; cannot compile-seal without forcing callers to pass the journal twice) |
| SAGA-JOURNAL-HOLDER-SEAL-01 | Medium (typed go/types field scan: interface fields rules 1–2 + Heartbeater-shaped func field rule 3; `types.Unalias`-correct) | N/A (field-shape invariant) — Hard path (envelope) tracked in #982, now targeting JournalCore |

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] `go test ./kernel/saga/... ./runtime/saga/...`
- [x] saga archtests: holder-seal A1/B1 + no-heartbeat A1/B1 (RED→GREEN verified: holder-seal flagged `coordinator.go:160` before the split, passes after)
- [x] broader saga/journal archtests (conformance enrollment, reverse coverage)
- [x] `golangci-lint run` on touched packages → 0 issues
- [x] PG saga conformance integration (real PG via testcontainers — exercises Heartbeat)
- [x] sagaleader PG integration (coordinator + leader-elect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-review hardening (F1–F4)

Review of this PR surfaced four findings in the archtest enforcement; all fixed in-branch (no follow-up issues):

- **F1 (P1·Cx1):** `classifyResolvedJournalType` now calls `types.Unalias`. On Go 1.23+ (`gotypesalias=1`, this module is on go 1.25) an alias field is `*types.Alias`, so the old `t.(*types.Named)` assertion silently missed a `type J = journal.JournalCore` field — defeating the holder seal with a one-line alias. + RunTypedFixture reverse test (`aliasholder`).
- **F2 (P2·Cx1):** B1 alias matcher resolves the journal package's local binding from each file's imports instead of hardcoding `id.Name == "journal"`, closing the `import sagajournal "…/journal"` evasion. + synthetic import-aliased case.
- **F3 (P1·Cx1):** new holder-seal **rule 3** bans a Heartbeater-shaped `func` field anywhere in `runtime/saga` (the func-value equivalent of a `journal.Heartbeater` field, fed from a `.Heartbeat` selector outside the package). The PR's blanket "Hard upstream / type-system inexpressible" claim is corrected to **Hard interface-field + Medium func-field + irreducible constructor-closure residual**. + reverse fixture test (`funcfieldholder`, positive anon/named + negative plain-func control).
- **F4 (P2·Cx1):** `runtime/saga/leader_elect.go` comment updated to the post-#1209 JournalCore truth source.
