### PR TITLE
refactor(metadata): drop ParserOption alias — NewParser takes ...LocatorOption directly

### DIFF
--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -31,22 +31,6 @@ const (
 	internalIDPathQuotedFmt = "id=%q path=%s"
 )
 
-// ParserOption is an alias for LocatorOption. NewParser accepts ParserOption
-// values so call sites are semantically named without exposing Locator
-// internals. ParserOption and LocatorOption are interchangeable — you can
-// pass a LocatorOption directly or construct one via WithLocatorMode /
-// WithManifestPath.
-//
-// e.g.: metadata.NewParser(root, metadata.WithLocatorMode(metadata.LocatorManifest))
-//
-// Don't declare ParserOption-typed variables separately; use the LocatorOption
-// constructors (WithLocatorMode, WithManifestPath) directly.
-//
-// AI-robust: the line above is a Soft godoc convention (no type-system /
-// archtest guard). Upgrade-or-remove is tracked in #1253 — likely resolution
-// is dropping the alias so NewParser takes ...LocatorOption directly.
-type ParserOption = LocatorOption
-
 // Parser loads and parses all YAML metadata from a project root via a Locator.
 //
 // The Locator funnel is the single source of truth for filesystem topology
@@ -60,9 +44,9 @@ type Parser struct {
 
 // NewParser creates a Parser that reads from the given filesystem root. The
 // root should point to the project root directory (containing go.mod). Pass
-// ParserOption (alias for LocatorOption) to override the auto-detected layout
-// (e.g., WithLocatorMode(LocatorManifest) for CI override).
-func NewParser(root string, opts ...ParserOption) *Parser {
+// LocatorOption to override the auto-detected layout (e.g.,
+// WithLocatorMode(LocatorManifest) for CI override).
+func NewParser(root string, opts ...LocatorOption) *Parser {
 	return &Parser{root: root, locatorOpts: opts}
 }
 

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -44,8 +44,9 @@ type Parser struct {
 
 // NewParser creates a Parser that reads from the given filesystem root. The
 // root should point to the project root directory (containing go.mod). Pass
-// LocatorOption to override the auto-detected layout (e.g.,
-// WithLocatorMode(LocatorManifest) for CI override).
+// LocatorOption to override the auto-detected layout — e.g.,
+// WithLocatorMode(LocatorConventional) to lock CI against accidental manifest
+// detection, or WithLocatorMode(LocatorManifest) for an external-repo layout.
 func NewParser(root string, opts ...LocatorOption) *Parser {
 	return &Parser{root: root, locatorOpts: opts}
 }


### PR DESCRIPTION
## Summary

移除 `kernel/metadata/parser.go` 中的纯类型别名 `type ParserOption = LocatorOption`，`NewParser` 直接收 `...LocatorOption`。

PR #1226 引入该别名时其 godoc 携带一条 **Soft 约定**（"别单独声明 ParserOption 类型变量，直接用 LocatorOption 构造器"）。按 `.claude/rules/gocell/ai-robust.md` §Review checklist，既有 Soft 约定应升级到 ≥ Medium 或移除。本 PR 选择**移除**（issue 推荐方向 1）。

## 为什么移除而非升级（AI-robust 自审）

- **彻底**：别名 + godoc Soft 约定 + `#1253` 追踪注释整块删除，无 TODO / follow-up。
- **不向后兼容**：直接删别名，不留 deprecation 别名 / 兼容 shim / 双路径。
- **优雅简洁**：单文件 +3/−19 行，不加新抽象 / 新文件 / 新 archtest。
- **AI-HARD**：本变更是**消除一条 Soft 字面约定**，非新增 enforcement 机制（ai-robust §适用范围排除日常 refactor）。从精神看移除是**最 Hard 解**——`ParserOption` 标识符不复存在，"误用它"在 type system 上即编译错误（违反不可表达）。候选 2（保留别名 + type marker + archtest）反而是用 Medium 机器守一个冗余的人为类型切分（parser 直通 locator，二者非独立概念）。

## 安全无碍

- 别名是 `=`（pure alias），与 `LocatorOption` 同一类型，全仓 56 处 `NewParser` 调用传的均已是 `LocatorOption` 值 → **零调用方改动，编译不变**。
- 无任何 test / archtest 引用 `ParserOption` 标识符（`runtime/auth/jwt.go` 内同名注释是 golang-jwt 无关类型）。
- ADR `202605281200-adr-cell-development-external-repo.md:299` 已记载目标形态 `NewParser(root string, opts ...LocatorOption) *Parser` — 删别名是**回归 ADR**，无需更新文档。

## Test plan

- [x] `go build ./...`
- [x] `go build -tags=integration ./...`（改了导出签名）
- [x] `go test ./kernel/metadata/...` — all pass
- [x] `go test ./...` — 全部 pass，仅 `tools/archtest` 3 项失败（`adapters/mqtt` / `kernel/webhook` / `auditledger` 的 pre-existing develop 失败，均不在本 diff、不在 PR-time archtest gate，nightly 兜底）
- [x] `golangci-lint run ./...` — 0 issues

Closes #1253
Refs: #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)