### PR TITLE
refactor(saga): plumb leaseID into all per-instance saga logs for lease_id correlation

### DIFF
--- a/runtime/saga/coordinator.go
+++ b/runtime/saga/coordinator.go
@@ -615,6 +615,7 @@ func (c *Coordinator) driveOne(ctx context.Context, ci journal.ClaimedInstance) 
 		c.logger.WarnContext(ctx, "saga: fold failed, marking terminal",
 			slog.String("instance_id", string(ci.Instance.ID)),
 			slog.String("definition_id", string(ci.Instance.DefinitionID)),
+			slog.String("lease_id", string(ci.LeaseID)),
 			slog.Any("error", foldErr))
 		return c.markTerminal(ctx, ci.Instance.ID, ci.LeaseID, ksaga.StatusFailed)
 	}
@@ -836,7 +837,8 @@ func (c *Coordinator) reverseWalkCompensate(
 		if !found {
 			c.logger.WarnContext(hbCtx, "saga: compensation: unknown committed step name, skipping",
 				slog.String("instance_id", string(ci.Instance.ID)),
-				slog.String("step_name", string(cs.name)))
+				slog.String("step_name", string(cs.name)),
+				slog.String("lease_id", string(ci.LeaseID)))
 			continue
 		}
 		if compensateErr := c.compensateOneStep(hbCtx, ci, step, cs.payload); compensateErr != nil {
@@ -948,12 +950,13 @@ func (c *Coordinator) compensateOneStep(
 	if step.Compensate == nil {
 		return nil
 	}
-	compensateErr := c.executor.Compensate(ctx, &ci.Instance, step, committedPayload)
+	compensateErr := c.executor.Compensate(ctx, &ci.Instance, ci.LeaseID, step, committedPayload)
 	if compensateErr != nil {
 		c.logger.WarnContext(ctx, "saga: compensation: step compensate failed, continuing",
 			slog.String("instance_id", string(ci.Instance.ID)),
 			slog.String("definition_id", string(ci.Instance.DefinitionID)),
 			slog.String("step_name", string(step.Name)),
+			slog.String("lease_id", string(ci.LeaseID)),
 			slog.Any("error", redaction.RedactAny(compensateErr)))
 		if txErr := c.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
 			_, aErr := c.journal.Append(txCtx, ci.Instance.ID, ci.LeaseID, journal.Event{
@@ -967,6 +970,7 @@ func (c *Coordinator) compensateOneStep(
 				slog.String("instance_id", string(ci.Instance.ID)),
 				slog.String("definition_id", string(ci.Instance.DefinitionID)),
 				slog.String("step_name", string(step.Name)),
+				slog.String("lease_id", string(ci.LeaseID)),
 				slog.Any("error", txErr))
 		}
 		return compensateErr
@@ -986,6 +990,7 @@ func (c *Coordinator) compensateOneStep(
 			slog.String("instance_id", string(ci.Instance.ID)),
 			slog.String("definition_id", string(ci.Instance.DefinitionID)),
 			slog.String("step_name", string(step.Name)),
+			slog.String("lease_id", string(ci.LeaseID)),
 			slog.Any("error", txErr))
 	}
 	return nil

--- a/runtime/saga/coordinator_test.go
+++ b/runtime/saga/coordinator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/idutil"
 	"github.com/ghbvf/gocell/pkg/redaction"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
@@ -1913,7 +1914,11 @@ func TestRunCompensation_StepFails_ContinuesReverseFinalStatusCompensationFailed
 	if err != nil {
 		t.Fatalf("NewInMemoryRegistry: %v", err)
 	}
-	c, err := NewCoordinator(j, newSafeFakeTxRunner(), newSafeFakeEmitter(), reg, clk)
+	// Capture logs so we can assert the compensation-failure log carries lease_id
+	// (#1211): an operator must be able to correlate the entry to the claim cycle.
+	var logBuf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	c, err := NewCoordinator(j, newSafeFakeTxRunner(), newSafeFakeEmitter(), reg, clk, WithLogger(logger))
 	if err != nil {
 		t.Fatalf("NewCoordinator: %v", err)
 	}
@@ -1926,6 +1931,9 @@ func TestRunCompensation_StepFails_ContinuesReverseFinalStatusCompensationFailed
 	// Drive step1 → step2 → step3 (step3 fails, triggers compensation walk).
 	// After each non-terminal step completes, the journal lease remains active for
 	// LeaseDuration (60s). Advance past it so the next ClaimPending can re-claim.
+	// compLeaseID holds the lease of the last (compensation) round so we can
+	// assert the compensation-failed log carries it.
+	var compLeaseID idutil.SafeID
 	for i := 0; i < 3; i++ {
 		// Expire any previous lease before claiming.
 		clk.Advance(testtime.D60s + testtime.D1ms)
@@ -1936,6 +1944,7 @@ func TestRunCompensation_StepFails_ContinuesReverseFinalStatusCompensationFailed
 		if len(claimed) == 0 {
 			break // instance terminal
 		}
+		compLeaseID = claimed[0].LeaseID
 		if err := c.driveOne(context.Background(), claimed[0]); err != nil {
 			t.Fatalf("driveOne round %d: %v", i, err)
 		}
@@ -1962,6 +1971,79 @@ func TestRunCompensation_StepFails_ContinuesReverseFinalStatusCompensationFailed
 	wantOrder := []string{"step2-fail", "step1"}
 	if !reflect.DeepEqual(got, wantOrder) {
 		t.Errorf("compensation order = %v, want %v", got, wantOrder)
+	}
+
+	// #1211: the "step compensate failed, continuing" Warn must carry lease_id.
+	entry := sloghelper.FindLogEntry(logBuf.String(), "step compensate failed, continuing")
+	if entry == nil {
+		t.Fatal("expected WARN log: step compensate failed, continuing")
+	}
+	if entry["lease_id"] != string(compLeaseID) {
+		t.Errorf("compensate-failed log lease_id = %v, want %q", entry["lease_id"], string(compLeaseID))
+	}
+}
+
+// foldFailJournal wraps MemJournal and injects a KindStepFailed event into Load
+// results, forcing foldEvents to return errFoldEventMismatch so driveOne
+// exercises the defensive "fold failed, marking terminal" branch. ClaimPending
+// is unaffected (the real projection stays non-terminal), so the instance is
+// still claimable — this isolates an otherwise-unreachable defensive path (the
+// real journal marks an instance terminal on a KindStepFailed append).
+type foldFailJournal struct {
+	*journal.MemJournal
+}
+
+func (f *foldFailJournal) Load(ctx context.Context, instanceID idutil.SafeID) ([]journal.Event, error) {
+	evs, err := f.MemJournal.Load(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	return append(evs, journal.Event{Kind: journal.KindStepFailed, StepName: "phantom"}), nil
+}
+
+// TestDriveOne_FoldFailed_LeaseIDLogged asserts the defensive "fold failed,
+// marking terminal" log carries lease_id (#1211). foldFailJournal injects a
+// KindStepFailed into Load so foldEvents returns an error during driveOne.
+func TestDriveOne_FoldFailed_LeaseIDLogged(t *testing.T) {
+	const defID idutil.SafeID = "foldfaillog"
+
+	def := &ksaga.Definition{
+		ID:    defID,
+		Steps: []ksaga.Step{{Name: "step1", Run: noopStep}},
+	}
+
+	clk := newFakeClock()
+	j := &foldFailJournal{MemJournal: newMemJournal(clk)}
+	reg, err := ksaga.NewInMemoryRegistry(def)
+	if err != nil {
+		t.Fatalf("NewInMemoryRegistry: %v", err)
+	}
+	var logBuf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	c, err := NewCoordinator(j, newSafeFakeTxRunner(), newSafeFakeEmitter(), reg, clk, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+
+	inst := ksaga.NewInstance(mustNewUUID(t), defID, clk.Now())
+	if err := j.Enqueue(context.Background(), inst); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, _, claimErr := j.ClaimPending(context.Background(), 1, testtime.D60s)
+	if claimErr != nil || len(claimed) != 1 {
+		t.Fatalf("ClaimPending: %v / %d", claimErr, len(claimed))
+	}
+
+	if err := c.driveOne(context.Background(), claimed[0]); err != nil {
+		t.Fatalf("driveOne: %v", err)
+	}
+
+	entry := sloghelper.FindLogEntry(logBuf.String(), "fold failed, marking terminal")
+	if entry == nil {
+		t.Fatal("expected WARN log: fold failed, marking terminal")
+	}
+	if entry["lease_id"] != string(claimed[0].LeaseID) {
+		t.Errorf("fold-failed log lease_id = %v, want %q", entry["lease_id"], string(claimed[0].LeaseID))
 	}
 }
 

--- a/runtime/saga/coordinator_test.go
+++ b/runtime/saga/coordinator_test.go
@@ -2047,6 +2047,49 @@ func TestDriveOne_FoldFailed_LeaseIDLogged(t *testing.T) {
 	}
 }
 
+// TestReverseWalkCompensate_UnknownStep_LeaseIDLogged asserts the "unknown
+// committed step name, skipping" Warn carries lease_id (#1211). White-box: a
+// committed entry whose name is absent from stepByName forces the unknown-step
+// branch directly, without needing a definition-drift fake journal — this is a
+// defensive branch (a committed step name not present in the current
+// definition) that the normal drive path does not reach.
+func TestReverseWalkCompensate_UnknownStep_LeaseIDLogged(t *testing.T) {
+	const leaseID = idutil.SafeID("lease-unknown-step")
+	var logBuf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	clk := newFakeClock()
+	j := newMemJournal(clk)
+	reg, err := ksaga.NewInMemoryRegistry(&ksaga.Definition{
+		ID:    "unknownstepdef",
+		Steps: []ksaga.Step{{Name: "step1", Run: noopStep}},
+	})
+	if err != nil {
+		t.Fatalf("NewInMemoryRegistry: %v", err)
+	}
+	c, err := NewCoordinator(j, newSafeFakeTxRunner(), newSafeFakeEmitter(), reg, clk, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+
+	ci := journal.ClaimedInstance{
+		Instance: ksaga.NewInstance(mustNewUUID(t), "unknownstepdef", clk.Now()),
+		LeaseID:  leaseID,
+	}
+	// committed step whose name is NOT in stepByName → unknown-step branch.
+	committed := []committedStepEntry{{name: "phantom-step", payload: nil}}
+	stepByName := map[idutil.SafeID]ksaga.Step{}
+	var compensateErrors []error
+	c.reverseWalkCompensate(context.Background(), ci, committed, stepByName, &compensateErrors)
+
+	entry := sloghelper.FindLogEntry(logBuf.String(), "unknown committed step name, skipping")
+	if entry == nil {
+		t.Fatal("expected WARN log: unknown committed step name, skipping")
+	}
+	if entry["lease_id"] != string(leaseID) {
+		t.Errorf("unknown-step log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
+	}
+}
+
 // mustNewUUID is a test helper that creates a UUID or fatals.
 func mustNewUUID(t *testing.T) idutil.SafeID {
 	t.Helper()

--- a/runtime/saga/executor/executor.go
+++ b/runtime/saga/executor/executor.go
@@ -165,19 +165,19 @@ func (e *Executor) safeObserveOutcome(
 	outcome Outcome,
 	attempts int,
 ) {
-	e.callObserverBounded(ctx, "ObserveOutcome", func() {
+	e.callObserverBounded(ctx, instanceID, leaseID, "ObserveOutcome", func() {
 		e.observer.ObserveOutcome(ctx, instanceID, leaseID, defID, stepName, outcome, attempts)
 	})
 }
 
 func (e *Executor) safeObserveRetry(ctx context.Context, instanceID, leaseID idutil.SafeID, defID, stepName string) {
-	e.callObserverBounded(ctx, "ObserveRetry", func() {
+	e.callObserverBounded(ctx, instanceID, leaseID, "ObserveRetry", func() {
 		e.observer.ObserveRetry(ctx, instanceID, leaseID, defID, stepName)
 	})
 }
 
 func (e *Executor) safeObserveHeartbeatFailure(ctx context.Context, instanceID, leaseID idutil.SafeID, reason HeartbeatFailureReason) {
-	e.callObserverBounded(ctx, "ObserveHeartbeatFailure", func() {
+	e.callObserverBounded(ctx, instanceID, leaseID, "ObserveHeartbeatFailure", func() {
 		e.observer.ObserveHeartbeatFailure(ctx, instanceID, leaseID, reason)
 	})
 }
@@ -188,11 +188,17 @@ func (e *Executor) safeObserveHeartbeatFailure(ctx context.Context, instanceID, 
 // observer call from outside). Used by all three safeObserve* helpers so the
 // Observer "MUST NOT block" contract is enforced at the boundary rather than
 // trusted on faith.
-func (e *Executor) callObserverBounded(ctx context.Context, method string, call func()) {
+//
+// instanceID/leaseID are carried only into the timeout/panic log lines so an
+// operator can correlate an observer-boundary failure back to the specific
+// instance and ClaimPending cycle it occurred under (every per-instance saga
+// log carries lease_id; the observer boundary is no exception). The three
+// safeObserve* callers all hold both, so plumbing them here is uniform.
+func (e *Executor) callObserverBounded(ctx context.Context, instanceID, leaseID idutil.SafeID, method string, call func()) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		defer e.recoverObserverPanic(ctx, method)
+		defer e.recoverObserverPanic(ctx, instanceID, leaseID, method)
 		call()
 	}()
 	timer := e.clk.NewTimerAt(e.clk.Now().Add(e.observerCallDeadline))
@@ -201,6 +207,8 @@ func (e *Executor) callObserverBounded(ctx context.Context, method string, call 
 	case <-done:
 	case <-timer.C():
 		e.logger.WarnContext(ctx, "saga executor: observer call exceeded deadline; continuing",
+			slog.String("instance_id", string(instanceID)),
+			slog.String("lease_id", string(leaseID)),
 			slog.String("method", method),
 			slog.Duration("deadline", e.observerCallDeadline),
 		)
@@ -212,9 +220,14 @@ func (e *Executor) callObserverBounded(ctx context.Context, method string, call 
 // reaching slog so a panic value carrying user data (sensitive headers, JWT
 // fragments) does not leak into operator logs (#1181 F10, mirrors
 // .claude/rules/gocell/observability.md §Span Error Redaction).
-func (e *Executor) recoverObserverPanic(ctx context.Context, method string) {
+//
+// instanceID/leaseID are logged for the same claim-cycle correlation as the
+// timeout branch in callObserverBounded.
+func (e *Executor) recoverObserverPanic(ctx context.Context, instanceID, leaseID idutil.SafeID, method string) {
 	if r := recover(); r != nil {
 		e.logger.WarnContext(ctx, "saga executor: observer call panicked, ignoring",
+			slog.String("instance_id", string(instanceID)),
+			slog.String("lease_id", string(leaseID)),
 			slog.String("method", method),
 			slog.Any("panic", redaction.RedactAny(r)),
 		)
@@ -578,6 +591,12 @@ func (e *Executor) RunWithHeartbeat(
 // a parent/lease cancellation propagates down and fires stepCtx too. We MUST
 // check context.Cause(runCtx) BEFORE the per-step timeout, otherwise a lease
 // loss or parent cancel could be misreported as a step-timeout Expired.
+//
+// leaseID is the fence token identifying the current coordinator's claim. Like
+// Compensate it is NOT forwarded to any Heartbeat call here (the heartbeat
+// goroutine owns lease renewal); it is carried only into the "retry budget
+// exhausted" log line so an operator can correlate that terminal-failure entry
+// back to the ClaimPending cycle that drove it.
 func (e *Executor) runAttempt(
 	runCtx context.Context,
 	inst *ksaga.Instance,

--- a/runtime/saga/executor/executor.go
+++ b/runtime/saga/executor/executor.go
@@ -444,7 +444,7 @@ func (e *Executor) executeInner(
 	stopAndJoin := func() { stopHB(); hbWG.Wait() }
 
 	for attempt := 1; ; attempt++ {
-		result, done := e.runAttempt(runCtx, inst, step, policy, prevState, attempt)
+		result, done := e.runAttempt(runCtx, inst, leaseID, step, policy, prevState, attempt)
 		if done {
 			stopAndJoin()
 			return result
@@ -581,6 +581,7 @@ func (e *Executor) RunWithHeartbeat(
 func (e *Executor) runAttempt(
 	runCtx context.Context,
 	inst *ksaga.Instance,
+	leaseID idutil.SafeID,
 	step ksaga.Step,
 	policy resolvedPolicy,
 	prevState []byte,
@@ -610,6 +611,7 @@ func (e *Executor) runAttempt(
 		e.logger.WarnContext(runCtx, "saga executor: retry budget exhausted",
 			slog.String("instance_id", string(inst.ID)),
 			slog.String("step_name", string(step.Name)),
+			slog.String("lease_id", string(leaseID)),
 			slog.Int("attempts", attempt),
 			slog.String("outcome", OutcomeFailed.String()),
 			slog.Any("error", runErr),
@@ -669,9 +671,15 @@ func (e *Executor) buildStepCtx(runCtx context.Context, step ksaga.Step) (contex
 // by step.Timeout (deliberate, mirrors Temporal's lack of CompensateTimeout).
 // The only bound is the saga-level ctx (parent deadline) plus the heartbeat
 // goroutine's lease-loss cancel (~heartbeatInterval granularity).
+//
+// leaseID is the fence token identifying the current coordinator's claim. Unlike
+// Execute it is NOT forwarded to any Heartbeat call (Compensate runs no
+// heartbeat); it is carried only into the compensation log lines so an operator
+// can correlate a compensation entry back to the ClaimPending cycle that drove it.
 func (e *Executor) Compensate(
 	ctx context.Context,
 	inst *ksaga.Instance,
+	leaseID idutil.SafeID,
 	step ksaga.Step,
 	committedState []byte,
 ) error {
@@ -690,11 +698,13 @@ func (e *Executor) Compensate(
 	e.logger.InfoContext(ctx, "saga executor: compensating step",
 		slog.String("instance_id", string(inst.ID)),
 		slog.String("step_name", string(step.Name)),
+		slog.String("lease_id", string(leaseID)),
 	)
 	if err := safeRunCompensate(ctx, step.Compensate, inst, committedState); err != nil {
 		e.logger.WarnContext(ctx, "saga executor: compensate failed",
 			slog.String("instance_id", string(inst.ID)),
 			slog.String("step_name", string(step.Name)),
+			slog.String("lease_id", string(leaseID)),
 			slog.Any("error", err),
 		)
 		// Redact before recording — see ObserveOutcome rationale above.

--- a/runtime/saga/executor/executor_test.go
+++ b/runtime/saga/executor/executor_test.go
@@ -364,6 +364,9 @@ func TestExecute_RetryExhausted_WarnLogged(t *testing.T) {
 	if _, ok := entry["error"]; !ok {
 		t.Error("log entry missing structured error field")
 	}
+	if entry["lease_id"] != "lease-warn" {
+		t.Errorf("log lease_id = %v, want %q", entry["lease_id"], "lease-warn")
+	}
 }
 
 // --- Execute per-step timeout → Expired (clock-driven, C3/F3) ---
@@ -732,7 +735,7 @@ func TestCompensate_Success(t *testing.T) {
 		},
 	}
 
-	err = exec.Compensate(context.Background(), newTestInstance(), step, []byte(`{"state":1}`))
+	err = exec.Compensate(context.Background(), newTestInstance(), "lease-comp-success", step, []byte(`{"state":1}`))
 	if err != nil {
 		t.Errorf("Compensate returned error: %v", err)
 	}
@@ -759,7 +762,7 @@ func TestCompensate_Failure(t *testing.T) {
 		},
 	}
 
-	err = exec.Compensate(context.Background(), newTestInstance(), step, nil)
+	err = exec.Compensate(context.Background(), newTestInstance(), "lease-comp-fail", step, nil)
 	if !errors.Is(err, wantErr) {
 		t.Errorf("Compensate = %v, want %v", err, wantErr)
 	}
@@ -780,7 +783,7 @@ func TestCompensate_NilCompensate_ReturnsNil(t *testing.T) {
 		Compensate: nil,
 	}
 
-	err = exec.Compensate(context.Background(), newTestInstance(), step, nil)
+	err = exec.Compensate(context.Background(), newTestInstance(), "lease-comp-nil", step, nil)
 	if err != nil {
 		t.Errorf("Compensate with nil func = %v, want nil", err)
 	}
@@ -803,7 +806,7 @@ func TestCompensate_Panic_ConvertedToError(t *testing.T) {
 		},
 	}
 
-	err = exec.Compensate(context.Background(), newTestInstance(), step, nil)
+	err = exec.Compensate(context.Background(), newTestInstance(), "lease-comp-panic", step, nil)
 	if err == nil {
 		t.Error("expected error from panic in Compensate, got nil")
 	}
@@ -836,7 +839,7 @@ func TestCompensate_IgnoresStepTimeout(t *testing.T) {
 		},
 	}
 
-	err = exec.Compensate(context.Background(), newTestInstance(), step, nil)
+	err = exec.Compensate(context.Background(), newTestInstance(), "lease-comp-timeout", step, nil)
 	if err != nil {
 		t.Errorf("Compensate with small step timeout returned error: %v", err)
 	}
@@ -845,6 +848,71 @@ func TestCompensate_IgnoresStepTimeout(t *testing.T) {
 	default:
 		t.Error("Compensate func not reached")
 	}
+}
+
+// TestCompensate_LeaseIDLogged asserts both compensation log lines carry the
+// lease_id field (the coordinator's fencing token), so an operator can
+// correlate a compensation log entry back to the ClaimPending cycle that drove
+// it. Mirrors TestExecute_RetryExhausted_WarnLogged's slog-capture pattern.
+// Covers issue #1211 acceptance: Info "compensating step" + Warn "compensate
+// failed" must both include slog.String("lease_id", string(leaseID)).
+func TestCompensate_LeaseIDLogged(t *testing.T) {
+	t.Parallel()
+	const leaseID = idutil.SafeID("lease-comp-logged")
+
+	t.Run("success logs lease_id on Info", func(t *testing.T) {
+		t.Parallel()
+		fc := clockmock.New(time.Now())
+		hb := &alwaysOKHeartbeater{}
+		buf := sloghelper.NewSyncBuffer()
+		logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		exec, err := NewExecutor(hb, fc, WithLogger(logger))
+		if err != nil {
+			t.Fatal(err)
+		}
+		step := ksaga.Step{
+			Name:       "step-log-success",
+			Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return nil, nil },
+			Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return nil },
+		}
+		if err := exec.Compensate(context.Background(), newTestInstance(), leaseID, step, nil); err != nil {
+			t.Fatalf("Compensate returned error: %v", err)
+		}
+		entry := sloghelper.FindLogEntry(buf.String(), "compensating step")
+		if entry == nil {
+			t.Fatal("expected an INFO log about compensating step")
+		}
+		if entry["lease_id"] != string(leaseID) {
+			t.Errorf("log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
+		}
+	})
+
+	t.Run("failure logs lease_id on Warn", func(t *testing.T) {
+		t.Parallel()
+		fc := clockmock.New(time.Now())
+		hb := &alwaysOKHeartbeater{}
+		buf := sloghelper.NewSyncBuffer()
+		logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		exec, err := NewExecutor(hb, fc, WithLogger(logger))
+		if err != nil {
+			t.Fatal(err)
+		}
+		step := ksaga.Step{
+			Name:       "step-log-fail",
+			Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return nil, nil },
+			Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return errors.New("boom") },
+		}
+		if err := exec.Compensate(context.Background(), newTestInstance(), leaseID, step, nil); err == nil {
+			t.Fatal("expected Compensate to return the compensate error")
+		}
+		entry := sloghelper.FindLogEntry(buf.String(), "compensate failed")
+		if entry == nil {
+			t.Fatal("expected a WARN log about compensate failed")
+		}
+		if entry["lease_id"] != string(leaseID) {
+			t.Errorf("log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
+		}
+	})
 }
 
 // TestSafeRun_PanicValueRedactedInInternalAttr asserts that a panic value

--- a/runtime/saga/executor/observer_test.go
+++ b/runtime/saga/executor/observer_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/rand/v2"
 	"sync"
 	"sync/atomic"
@@ -12,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	ksaga "github.com/ghbvf/gocell/kernel/saga"
 	"github.com/ghbvf/gocell/pkg/idutil"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
@@ -575,5 +577,107 @@ func TestNewExecutor_NilObserver_DefaultsToNop(t *testing.T) {
 	}
 	if _, ok := exec.observer.(NopObserver); !ok {
 		t.Errorf("observer = %T, want NopObserver after WithObserver(nil)", exec.observer)
+	}
+}
+
+// panicObserver is an out-of-contract Observer that panics in every callback.
+// Used to exercise recoverObserverPanic's correlation-logging path (F1).
+type panicObserver struct{}
+
+func (panicObserver) ObserveOutcome(_ context.Context, _, _ idutil.SafeID, _, _ string, _ Outcome, _ int) {
+	panic("observe outcome boom")
+}
+
+func (panicObserver) ObserveRetry(_ context.Context, _, _ idutil.SafeID, _, _ string) {
+	panic("observe retry boom")
+}
+
+func (panicObserver) ObserveHeartbeatFailure(_ context.Context, _, _ idutil.SafeID, _ HeartbeatFailureReason) {
+	panic("observe hb boom")
+}
+
+// TestObserverCall_Timeout_LogsCorrelation asserts the bounded-wait timeout log
+// (callObserverBounded) carries instance_id + lease_id + method so an operator
+// can correlate an observer-deadline breach back to the instance / ClaimPending
+// cycle it occurred under. F1: observer-boundary logs previously carried only
+// method, breaking the "all per-instance saga logs carry lease_id" invariant.
+func TestObserverCall_Timeout_LogsCorrelation(t *testing.T) {
+	t.Parallel()
+	fc := clockmock.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	hb := &staleHeartbeater{} // preflight returns ok=false → blocks on observer
+	obs := newBlockingObserver()
+	defer close(obs.release) // unblock the leaked observer goroutine on test exit
+	buf := sloghelper.NewSyncBuffer()
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	exec, err := NewExecutor(hb, fc,
+		WithLogger(logger),
+		WithHeartbeatInterval(testtime.D5s),
+		WithLeaseDuration(testtime.D30s),
+		WithObserver(obs),
+		WithObserverCallDeadline(testtime.D20ms),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- exec.RunWithHeartbeat(context.Background(), newTestInstance(), "lease-timeout-log",
+			func(_ context.Context) error { return nil })
+	}()
+
+	// Wait for the observer call to enter so the bounded timer exists, then
+	// advance past its deadline to fire the timeout branch.
+	testwait.Deterministic(t, obs.hbEntered, testtime.EventuallyShort, "observer-call-entered")
+	fc.Advance(testtime.D50ms)
+	_ = testwait.Deterministic(t, errCh, testtime.EventuallyShort, "RunWithHeartbeat must return")
+
+	entry := sloghelper.FindLogEntry(buf.String(), "observer call exceeded deadline")
+	if entry == nil {
+		t.Fatalf("expected an observer-deadline WARN log; logs=%s", buf.String())
+	}
+	if entry["instance_id"] != "test-instance-id" {
+		t.Errorf("timeout log instance_id = %v, want test-instance-id", entry["instance_id"])
+	}
+	if entry["lease_id"] != "lease-timeout-log" {
+		t.Errorf("timeout log lease_id = %v, want lease-timeout-log", entry["lease_id"])
+	}
+	if entry["method"] != "ObserveHeartbeatFailure" {
+		t.Errorf("timeout log method = %v, want ObserveHeartbeatFailure", entry["method"])
+	}
+}
+
+// TestObserverCall_Panic_LogsCorrelation asserts the recoverObserverPanic log
+// carries instance_id + lease_id + method (F1, panic branch). Uses a direct
+// safeObserveOutcome call with a panicking observer — recovery is synchronous,
+// so no clock dance is needed: callObserverBounded returns via <-done only
+// after recoverObserverPanic (deferred LIFO before close(done)) has logged.
+func TestObserverCall_Panic_LogsCorrelation(t *testing.T) {
+	t.Parallel()
+	fc := clockmock.New(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	hb := &alwaysOKHeartbeater{}
+	buf := sloghelper.NewSyncBuffer()
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	exec, err := NewExecutor(hb, fc, WithLogger(logger), WithObserver(panicObserver{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exec.safeObserveOutcome(context.Background(), "test-instance-id", "lease-panic-log",
+		"test-def-id", "step-x", OutcomeSucceeded, 1)
+
+	entry := sloghelper.FindLogEntry(buf.String(), "observer call panicked")
+	if entry == nil {
+		t.Fatalf("expected an observer-panic WARN log; logs=%s", buf.String())
+	}
+	if entry["instance_id"] != "test-instance-id" {
+		t.Errorf("panic log instance_id = %v, want test-instance-id", entry["instance_id"])
+	}
+	if entry["lease_id"] != "lease-panic-log" {
+		t.Errorf("panic log lease_id = %v, want lease-panic-log", entry["lease_id"])
+	}
+	if entry["method"] != "ObserveOutcome" {
+		t.Errorf("panic log method = %v, want ObserveOutcome", entry["method"])
 	}
 }

--- a/runtime/saga/leader_elect.go
+++ b/runtime/saga/leader_elect.go
@@ -103,10 +103,16 @@ func (c *Coordinator) acquireLead(ctx context.Context, ci journal.ClaimedInstanc
 	}
 	return func() {
 		if rerr := lock.Release(); rerr != nil {
+			// lock_key names the distlock efficiency lock; lease_id is the journal
+			// fencing token (ci.LeaseID) of the ClaimPending cycle this drive ran
+			// under. They are distinct leases (see package doc) — lease_id is logged
+			// purely for claim-cycle correlation, consistent with every other
+			// per-instance saga log, not because the distlock is fenced by it.
 			c.logger.WarnContext(ctx, "saga: distlock release failed",
 				slog.String("instance_id", string(ci.Instance.ID)),
 				slog.String("definition_id", string(ci.Instance.DefinitionID)),
 				slog.String("lock_key", key),
+				slog.String("lease_id", string(ci.LeaseID)),
 				slog.Any("error", rerr))
 		}
 	}, true
@@ -125,9 +131,13 @@ func (c *Coordinator) logLeaderSkip(ctx context.Context, ci journal.ClaimedInsta
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		level = slog.LevelDebug
 	}
+	// lease_id is the journal fencing token (ci.LeaseID); lock_key is the
+	// distlock identity — distinct leases (see package doc / acquireLead). lease_id
+	// is logged for claim-cycle correlation, uniform with all per-instance logs.
 	c.logger.Log(ctx, level, "saga: leader-elect skip (lock not acquired)",
 		slog.String("instance_id", string(ci.Instance.ID)),
 		slog.String("definition_id", string(ci.Instance.DefinitionID)),
 		slog.String("lock_key", key),
+		slog.String("lease_id", string(ci.LeaseID)),
 		slog.Any("error", err))
 }

--- a/runtime/saga/leader_elect_test.go
+++ b/runtime/saga/leader_elect_test.go
@@ -498,6 +498,11 @@ func TestLogLeaderSkip_Levels(t *testing.T) {
 			if !strings.Contains(logs, "leader-elect skip") {
 				t.Errorf("missing skip message; logs=%s", logs)
 			}
+			// lease_id (journal fencing token) correlates the skip back to the
+			// ClaimPending cycle; claimedFixture sets LeaseID="lease-inst1".
+			if !strings.Contains(logs, `"lease_id":"lease-inst1"`) {
+				t.Errorf("skip log missing lease_id; logs=%s", logs)
+			}
 		})
 	}
 }
@@ -531,6 +536,11 @@ func TestAcquireLead_ReleaseFail_LogsWarn(t *testing.T) {
 	}
 	if !strings.Contains(logs, `"definition_id":"def1"`) {
 		t.Errorf("release-failed log missing definition_id; logs=%s", logs)
+	}
+	// lease_id (journal fencing token) correlates the release failure back to the
+	// ClaimPending cycle; claimedFixture sets LeaseID="lease-inst1".
+	if !strings.Contains(logs, `"lease_id":"lease-inst1"`) {
+		t.Errorf("release-failed log missing lease_id; logs=%s", logs)
 	}
 }
 


### PR DESCRIPTION
## Summary

让 `runtime/saga` **全部 12 条 per-instance 日志**携带 `lease_id`(coordinator claim 的 fencing token),运维可把任意 per-instance 日志关联回驱动它的 `ClaimPending` 周期。

issue #1211 仅要求修 `executor.Compensate` 的 2 条补偿日志,并假设 "coordinator 补偿日志已带 lease_id"。**穷举核对 `runtime/saga` 全部 logger 调用发现这是事实错误**——coordinator 自己的补偿日志同样缺 lease_id,且 driveOne fold-failed / executor retry-exhausted 也缺。本 PR 一并补齐(用户确认扩大范围),彻底闭合 issue 标题的 "compensation logs carry lease_id" 目标。

**Round-2(PR review F1/F2)**:首轮声称 "all per-instance logs" 但全树普查发现还有 4 个 per-instance-context 站点缺关联字段——observer bounded-call 的 timeout/panic 日志、leader-elect 的 distlock release-fail/skip 日志。两处的 instance/lease 都在调用作用域内,仅未 plumb。本轮补齐,使 "all" 字面成真(8 → 12)。

### 12 条日志(全部加 `lease_id`,observer 两条另加 instance_id)

| # | 位置 | 日志 | leaseID 来源 |
|---|------|------|-------------|
| 1 | `executor.go` Compensate | Info "compensating step" | 签名新增 `leaseID` 参 |
| 2 | `executor.go` Compensate | Warn "compensate failed" | 同上 |
| 3 | `executor.go` runAttempt | Warn "retry budget exhausted" | `runAttempt` 透传 leaseID(executeInner 调用点) |
| 4 | `coordinator.go` driveOne | Warn "fold failed, marking terminal" | `ci.LeaseID` |
| 5 | `coordinator.go` reverseWalkCompensate | Warn "unknown committed step name, skipping" | `ci.LeaseID` |
| 6 | `coordinator.go` compensateOneStep | Warn "step compensate failed, continuing" | `ci.LeaseID` |
| 7 | `coordinator.go` compensateOneStep | Warn "failed to append KindStepCompensationFailed" | `ci.LeaseID` |
| 8 | `coordinator.go` compensateOneStep | Warn "failed to append KindStepCompensated" | `ci.LeaseID` |
| 9 | `executor.go` callObserverBounded | Warn "observer call exceeded deadline" | `callObserverBounded` 新增 instanceID+leaseID 参(3 个 safeObserve* caller 透传) |
| 10 | `executor.go` recoverObserverPanic | Warn "observer call panicked, ignoring" | 同上 |
| 11 | `leader_elect.go` acquireLead(release) | Warn "distlock release failed" | `ci.LeaseID` |
| 12 | `leader_elect.go` logLeaderSkip | Debug/Warn "leader-elect skip (lock not acquired)" | `ci.LeaseID` |

> **F2 语义注**:#11/#12 是 distlock 域日志。`lock_key`(distlock 效率锁身份) 与 `lease_id`(journal 围栏令牌) 是**两个不同的 lease**(见 leader_elect.go 包文档)。`lease_id` 仅作 claim 周期关联记录,**不代表** distlock 被它围栏——注释已在两个站点点明,避免误读。

**不动 trace span**:`saga.executor.step.compensate` span 与 `Execute` 的 run span 一致(都不放 lease_id;父 driveOne span 已带,子 span 通过 trace 树继承)。改 span 需 run+compensate 两个 span 同步改,超出本 issue(日志关联)目标。

**明确不动(实测有界,非 silent)**:`tickOnce`/`markTerminal`/executor heartbeat/preflight/heartbeat.go 已带 lease_id;`coordinator.go` 的生命周期日志(start `:317` / stop `:429`)与 tick-level `:510` "tick failed" 无 per-instance lease(发生在 ClaimPending 之外或之上,作用域内无 ci/leaseID)。

**P1-2 + 完整性 → backlog #1266**:reviewer 的 P1-2(`coordinator.go:683` "lease lost"、`:1066` "MarkTerminal stale")两行本就带 `lease_id` 但缺回归断言。全树普查发现这类 **pre-existing per-instance log 共 11 条**未断言(reviewer 仅抓到 2)。给它们补 per-site 断言是锁本不变式的正当 test-debt(**非 scope creep**——PR body 把它们列为 "已带 lease_id" 的 prose 声明应有断言兜底),但属 11 站点 + 多处故障注入(stale-MarkTerminal / hb-recover-panic / preflight infra-error)的系统性 sweep,过大不宜塞进本 PR。已开 backlog **#1266** 全量跟踪。本 PR 交付实际缺字段的修复(上表 12 条 + F1/F2 observer/leader-elect)。

## Implementation matrix (contract-fanout)

- **Contract**: `executor.Compensate` 方法签名(`inst` 后新增 `leaseID idutil.SafeID`)+ `runAttempt`/`callObserverBounded`/`recoverObserverPanic` 内部(unexported)签名
- **Change**: plumb leaseID(observer 两条另加 instanceID)into 12 per-instance log lines
- **Implementations**: Coordinator `compensateOneStep`/`acquireLead`/`logLeaderSkip` caller 透传 `ci.LeaseID`;`executeInner` 透传给 `runAttempt`;3 个 `safeObserve*` 透传给 `callObserverBounded`
- **Conformance test**: `executor_test.go::TestCompensate_LeaseIDLogged` / `TestExecute_RetryExhausted_WarnLogged` / `TestObserverCall_Timeout_LogsCorrelation` / `TestObserverCall_Panic_LogsCorrelation`;`leader_elect_test.go::TestLogLeaderSkip_Levels` / `TestAcquireLead_ReleaseFail_LogsWarn`;`coordinator_test.go::TestRunCompensation_StepFails_...` / `TestDriveOne_FoldFailed_LeaseIDLogged`
- **Repro**: `go test -race ./runtime/saga/...`
- **Dependent contracts (governance scan)**: none — `Compensate` 不在任何 funnel(详见下方 archtest 分析);observer/leader-elect 改动均为 unexported helper / 日志字段,无 contract 影响

## archtest 影响:无

`SAGA-STEP-COMPENSATE-PURE-01` 守的是 `kernel/saga.CompensateFunc`(用户补偿**函数体**的纯度),**不是** `Executor.Compensate` 方法签名。observer bounded-call 与 leader-elect 改动是日志字段 + unexported helper 签名,不触任何 funnel。回归已验证 green。

AI-robust:本 PR 是 refactor,不新增/修改 enforcement 机制(不在评级范围)。leaseID 位置必填参由**编译器 Hard** 保证 caller 不可漏传;**不**为"日志须含 lease_id"立 Soft archtest(字符串锚点=Soft=严禁立项)。

## Test plan

- [x] `go build -tags=integration ./runtime/saga/...` 通过
- [x] `go test -race ./runtime/saga/...` 全绿(executor 1.4s + coordinator 35.9s)
- [x] `golangci-lint run ./runtime/saga/...` **0 issues**
- [x] 新增/扩展日志字段断言:observer timeout/panic(instance_id+lease_id+method)、leader-elect skip/release-fail(lease_id="lease-inst1")
- [x] archtest `SAGA-STEP-COMPENSATE-PURE-01` 回归 green

Closes #1211
Refs: PR #1210 (DX/Observability F3), #1181; round-2 PR review F1/F2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
