### PR TITLE
docs(reconcile): ADR kernel/reconcile L4 收敛控制环设计 [#661 PR-A1]

### DIFF
--- a/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+++ b/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
@@ -1,0 +1,427 @@
+# ADR 661 — kernel/reconcile L4 desired-state 收敛控制环设计
+
+| 字段 | 值 |
+|------|---|
+| ADR ID | 661 |
+| 状态 | **Accepted（设计冻结）；实施 A1–A3 ahead-of-trigger 验证落地，A4–A10 PARKED-ON-TRIGGER（详见 §6）** |
+| 日期 | 2026-05-29 |
+| Issue | [#661](https://github.com/ghbvf/gocell/issues/661)（父）/ [#1162](https://github.com/ghbvf/gocell/issues/1162)（PR-A1） |
+| Spec | `docs/plans/specs/202605262359-661-kernel-reconcile-{spec,plan,tasks}.md` |
+| 一致性级别 | **L4 DeviceLatent**（issue 第一性原理重评结论） |
+
+> 本 ADR 是 `kernel/reconcile` 的设计权威源。本 PR（PR-A1）随附 PR-A2/A3 的可运行实现
+> （3 件套最小核 + Loop 调度骨架）一起落地，因此本文档记录的是**经代码验证的设计**，
+> 而非纯前瞻推演——`§2 ≥80% reuse`、`§3 接口形态`、`§7 panic 隔离`等论断均有 PR-A2/A3
+> 的编译 + 测试（`go test -race ./kernel/reconcile/`，coverage 90.8%）背书。
+> 设计与实现产生分歧时以本 ADR 为准，并在同 PR 内修正实现或修订本 ADR。
+
+---
+
+## §0 决策摘要
+
+**3 件套最小核**（PR-A2 已落地，archtest frozen）：
+
+| 件 | 形态 | 对标 controller-runtime |
+|----|------|------------------------|
+| `Reconciler` | `interface { Reconcile(ctx, Request) (Result, error) }` | `reconcile.Reconciler`（采纳） |
+| `Result.RequeueAfter` | `struct { RequeueAfter time.Duration }` | `reconcile.Result`（**削到单字段**） |
+| `PermanentError` / `IsPermanent` | sealed marker（不重试，进死信 metric） | `reconcile.TerminalError`（采纳语义，独立实现） |
+
+**删除的 K8s 控制平面专属抽象**（GoCell 无对应需求，详见 §2）：
+
+- `Informer` / CRD watch / `Source.Informer`（GoCell 不依赖 K8s 控制平面，无 watch 源）
+- `Predicate`（事件过滤；GoCell level-triggered 全量扫描）
+- `Manager`（K8s 多控制器编排；GoCell 由 cell registrar lifecycle 托管）
+- `Builder.For` / `Builder.Owns` / `Builder.Watches`（绑定 K8s informer 源）
+- `Result.Requeue bool`（用 `RequeueAfter==0` 表达，冗余字段删除）
+- `Result.Priority *int`（K8s 调度器优先队列特性；GoCell 无需求）
+
+简化倍率（SC-001）：`kernel/reconcile` 公开类型表面 `Reconciler`+`Request`+`Result`+
+`PermanentError`/`IsPermanent` ≈ 30 LoC（`reconciler.go` 45 + `result.go` 类型部分）；
+controller-runtime `pkg/reconcile`+`pkg/builder` 公开面 ≥800 LoC，简化 ≥4x。
+
+**落地状态**：PR-A1（本 ADR）+ PR-A2（接口 + 3 frozen archtest）+ PR-A3（Loop 调度骨架 +
+4 metrics + clock carve-out）已实现并验证；PR-A4–A10（Trigger / Backoff / LeaderElector /
+Builder / 迁移 / 文档）受 §6 trigger gate 封存。
+
+---
+
+## §1 问题陈述
+
+### 1.1 kernel/command Sweeper 域绑定
+
+现状 L4 控制环唯一实例是 `kernel/command.Sweeper` + `runtime/command.SweeperLifecycle`：
+
+- `kernel/command.Sweeper.SweepTick(ctx, now)` 是**命令实体专属**的批量扫描器——内部
+  `scanner.ScanActive` → `SweepOnce`（计算过期）→ `queue.Ack(AckTimeout)`，签名与命令
+  domain 强耦合（`ActiveScanner` / `Queue` / `ExpiryTransition`）。
+- `runtime/command.SweeperLifecycle`（446 LoC）是通用的**调度骨架**：control-plane ticker /
+  startup probe / owner-ctx 派生 / graceful stop / 错误计数——这部分与命令域无关。
+
+骨架可复用，但被命令域签名（`SweepTick`/`SweepTicker`/`SweepErrorCounter`）绑死，无法被
+其他 L4 消费方直接复用。
+
+### 1.2 四个真消费方需要泛化
+
+issue #661 第一性原理重评列出 ≥4 个 roadmap-committed 的 L4 desired-state 消费方
+（详见 §6 trigger 表）：`pkicell.rotation`（证书续期）、`mdmcell.command`（命令超时重发）、
+`devicelifecycle.cronsweep`（设备墓碑状态机）、`zerotrust.trustscore`（信任分周期重评）。
+四者都需要「周期观察非终态实体 → 逐个驱动至期望态 → 按结果重排」的相同控制环，仅
+Reconcile 逻辑不同。把 Sweeper 骨架泛化为 `kernel/reconcile.Loop` + `Reconciler` 接口，
+四者只写 Reconcile 本体。
+
+### 1.3 权限模型澄清（防与 ADR-041 §3.3 矛盾）
+
+ADR `202605041430-adr-architecture-optimization-via-engineering-thinking.md` §3.3 论证：
+**GoCell 框架自身的自收敛必须落在编译期/CI 期**，因为「运行时框架是被嵌入宿主应用的库，
+对宿主应用无修改权限」。本 ADR 不与该结论矛盾——它管辖的是**另一个收敛域**：
+
+| 收敛域 | 主体 | 时间维度 | 权限来源 | 归属 |
+|--------|------|---------|---------|------|
+| **框架自收敛** | GoCell 对**自己的仓库元数据** | 编译期 / CI 期 | 对自己仓库有 PR/commit 权限 | ADR-041 §3.3（**不在本 ADR**） |
+| **宿主 cell 业务 L4 收敛** | 宿主 cell 对**自己拥有的持久实体**（device commands / cert rows / trust scores） | 运行时 | cell 对自己的 PG/Redis 表有读写权限 | **本 ADR** |
+
+关键区分：`kernel/reconcile` 不让框架去改宿主应用——它只提供 `Loop` harness；**收敛权限
+属于消费 cell**（它对自己的实体表行使写权限，在 `Reconcile` 内）。框架不代行宿主权限，
+故 ADR-041 §3.3「框架无运行时权限」约束不适用于「cell 用框架提供的环来收敛自己的实体」。
+
+---
+
+## §2 对标 controller-runtime（快照 @ main，2026-05-29）
+
+对标快照固定在以下 5 个上游源；后续 PR commit message 引用对应 `ref:` 行。
+
+### 2.1 `pkg/reconcile/reconcile.go` — Reconciler / Request / Result
+
+ref: `kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go`
+（https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/main/pkg/reconcile/reconcile.go）
+
+```go
+type TypedReconciler[request comparable] interface {
+	Reconcile(context.Context, request) (Result, error)
+}
+type Request struct { types.NamespacedName }
+type Result struct {
+	Requeue      bool          // deprecated
+	RequeueAfter time.Duration // if >0, requeue the key after Duration
+	Priority     *int          // priority on re-enqueue
+}
+func TerminalError(wrapped error) error // prevents retry, still logs + metrics
+```
+
+**GoCell 适配**：
+
+| 上游 | GoCell | 决策 |
+|------|--------|------|
+| `Reconcile(ctx, request) (Result, error)` | 同形态，`request` 固定为 `Request` | **采纳** |
+| `Request{types.NamespacedName}` | `Request{EntityID string}` | **削**——cell-local 实体表无 namespace 维度，单 opaque ID 足够 |
+| `Result.RequeueAfter` | `Result.RequeueAfter` | **采纳**（核心调度提示） |
+| `Result.Requeue bool` | 删 | **删**——`RequeueAfter==0` 即「按 default tick 重入」，bool 冗余 |
+| `Result.Priority *int` | 删 | **删**——优先队列是 K8s 调度器特性，无需求 |
+| `TerminalError` | `PermanentError`/`IsPermanent` | **采纳语义、独立实现**——见 §3.3 |
+
+> GoCell 语义偏离一处：上游 `Result{}`（无 requeue）= 「done，等 watch/resync 再触发」；
+> GoCell `Result{}`（`RequeueAfter==0`）= 「按 default tick interval 重入」。因为 GoCell 是
+> level-triggered 周期扫描模型（承自 Sweeper），无 watch 源，需周期性重观察。
+
+### 2.2 `pkg/internal/controller/controller.go` — worker loop
+
+ref: `kubernetes-sigs/controller-runtime pkg/internal/controller/controller.go`
+
+```go
+wg.Add(c.MaxConcurrentReconciles)
+for i := 0; i < c.MaxConcurrentReconciles; i++ {
+	go func() { defer wg.Done(); for c.processNextWorkItem(ctx) {} }()
+}
+```
+
+- `MaxConcurrentReconciles` worker goroutines 从 workqueue 取 item；
+- 结果处理：`RequeueAfter`→`Queue.AddWithOpts{After}`；非 terminal error→`AddWithOpts{RateLimited}`；
+  success→`Queue.Forget`；terminal error→记 metric 不重排；
+- `RecoverPanic`（默认开）：`Reconcile` 内 panic 被 recover → 转 `fmt.Errorf("panic: %v")`。
+
+**GoCell 适配（PR-A3 已落地）**：`Loop` 起 `MaxConcurrentReconciles` 个 worker（默认 1）从
+内部 queue 取 `Request`；`process()` 做同 ID 串行（`sync.Map` inflight，level-triggered
+下重复触发安全丢弃 = `resultSkipped`）+ panic recovery（`safeReconcile`，单实体 panic 不杀
+worker，转 transient）+ 按 `Result`/error 重排。**未采纳 workqueue 的 dirty/processing 去重 +
+rate-limited delaying queue**：A3 用「skip-if-busy（丢重复，level-triggered 安全）+ per-requeue
+goroutine（受 runCtx 取消、WaitGroup 跟踪、无泄漏）」，比上游 workqueue 简（见 §7 威胁矩阵
+T-LEAK）；指数退避 rate limiter 是 PR-A5 的事（上游 default `5ms..1000s`，见 §2.4）。
+
+### 2.3 `pkg/builder/controller.go` — Builder DSL
+
+ref: `kubernetes-sigs/controller-runtime pkg/builder/controller.go`
+
+```go
+func (b *TypedBuilder[request]) For(object client.Object, opts ...ForOption) *TypedBuilder[request]
+func (b *TypedBuilder[request]) Owns(object client.Object, opts ...OwnsOption) *TypedBuilder[request]
+func (b *TypedBuilder[request]) Watches(object client.Object, h ..., opts ...) *TypedBuilder[request]
+func (b *TypedBuilder[request]) Complete(r reconcile.TypedReconciler[request]) error
+```
+
+`For`/`Owns`/`Watches` 绑定 K8s informer 源——**全删**（GoCell 无 informer）。GoCell Builder
+（PR-A7）= `New(reconciler).WithTrigger(...).WithLeader(...).WithConcurrency(...).Build()`，
+唯一公开构造入口（`Loop` 构造私有化，funnel 上游 Hard），不绑定任何 K8s 资源。
+
+### 2.4 `client-go util/workqueue/default_rate_limiters.go` — 退避默认值
+
+ref: `kubernetes/client-go util/workqueue/default_rate_limiters.go`
+
+```go
+NewTypedItemExponentialFailureRateLimiter[T](5*time.Millisecond, 1000*time.Second)
+```
+
+GoCell `Backoff`（PR-A5）采纳 `baseDelay=5ms / maxDelay=1000s`（FR-008）。
+
+### 2.5 `client-go tools/leaderelection/leaderelection.go` — lease 模型
+
+ref: `kubernetes/client-go tools/leaderelection/leaderelection.go`
+
+`LeaseDuration`（默认 15s，非 leader 强制接管前的观察窗）/ `RenewDeadline`（10s，leader 放弃前
+续约重试窗）/ `RetryPeriod`（2s，轮询间隔）；`LeaderElectionRecord{HolderIdentity,
+LeaseDurationSeconds, AcquireTime, RenewTime}`。GoCell `LeaderElector`（PR-A6）采纳 lease/renew
+模型，见 §4。
+
+### 2.6 ≥80% reuse 论证（SC-002，经实现验证）
+
+`runtime/command/lifecycle.go` 的 import 全部是 stdlib + `kernel/{cell,clock,observability/metrics}`
++ `pkg/{redaction,validation}`，**零 runtime-only 依赖**（已核验），可平移进 `kernel/reconcile`
+不违反分层（kernel/ 只依赖 stdlib+pkg+kernel）。
+
+实测（PR-A3，`loop.go` 392 LoC vs `lifecycle.go` 446 LoC）：
+
+| 部分 | 来源 | 形态 |
+|------|------|------|
+| **调度骨架**（`controlPlaneClock` seal / `Start` fast-return / `awaitProbe` / `Stop` graceful / owner-ctx 派生 / metrics preflight / helpers） | `SweeperLifecycle` 1:1 平移（仅改名 `Sweep*`→`Reconcile*`、删 `BusinessClock`） | ~270 LoC |
+| **per-entity 派发**（`pump` / `runWorker` / `process` / `safeReconcile` / `scheduleRequeue` + inflight 串行 + concurrency 信号量） | 新写（Sweeper 是单次批量 `SweepTick`，无 per-entity 派发层） | ~120 LoC |
+
+**口径**：SC-002「≥80%」指**调度骨架层**——它高保真平移（仅改名 + 删 `BusinessClock`，因
+`Reconcile(ctx, Request)` 不收 `now`，reconciler 自带时钟）。整包 `loop.go` reuse ≈ 270/392 ≈
+**69%**，低于 80% 的差额来自 Sweeper 没有的「per-entity worker 派发层」——这是把「单次批量
+扫描」泛化为「per-entity reconcile」的本质新增，不是平移损耗。**这是实现对 spec 假设的修正**：
+spec SC-002 原文「451 中迁移 ≥360」按「整体平移」估算，实测揭示需新增 per-entity 层，故口径
+收敛到「调度骨架层 ≥80% 平移 + per-entity 层新写」。
+
+---
+
+## §3 接口设计
+
+### 3.1 Reconciler / Request / Result（PR-A2 已落地，frozen）
+
+```go
+// INVARIANT: RECONCILE-INTERFACE-FROZEN-01
+type Reconciler interface { Reconcile(ctx context.Context, req Request) (Result, error) }
+// INVARIANT: RECONCILE-REQUEST-FIELDS-FROZEN-01
+type Request struct { EntityID string }
+// INVARIANT: RECONCILE-RESULT-FIELDS-FROZEN-01
+type Result struct { RequeueAfter time.Duration }
+```
+
+字段集由 reflect golden archtest 冻结（`tools/archtest/reconcile_invariants_test.go`），
+`RECONCILE-RESULT-FIELDS-FROZEN-01` 显式拒绝 `Requeue bool` / `Priority int` 残留 + 含反向
+盲区自检。`RequeueAfter` 语义：`>0` N 后重入；`==0` 按 default tick 重入；error≠nil 时忽略
+（走退避）；负值 clamp 到 0（`normalizedRequeueAfter`，PR-A2 测试）。
+
+### 3.2 Trigger（PR-A4 设计）
+
+```go
+type Trigger interface { Start(ctx context.Context, queue chan<- Request) error }
+func TickerTrigger(interval time.Duration) Trigger   // 周期全量重观察（替代 controller-runtime resync Source）
+func ChannelTrigger(in <-chan Request) Trigger       // outbox 事件唤醒
+```
+
+替代 controller-runtime `Source`，最小 2 实现。PR-A3 的 `Loop.Source <-chan Request` 是 Trigger
+产出的原始 channel 接缝（A3 测试直接注入 channel，A4 由 Trigger 产出）。Loop 控制面时钟走
+`controlPlaneClock` carve-out（见 §7 T-CLOCK）。
+
+### 3.3 PermanentError 来源裁决（PR-A2 已落地）
+
+```go
+type permanentError struct{ err error }       // unexported sealed marker
+func PermanentError(err error) error          // 唯一构造（nil→nil）
+func IsPermanent(err error) bool              // 唯一分类（errors.As，穿透 %w）
+```
+
+**裁决：新建 reconcile-local sealed marker，不复用 `kernel/outbox.PermanentError`。**
+
+- 现状：无 `errcode.IsPermanent`；唯一既有 marker 是 `kernel/outbox.PermanentError`（exported
+  struct，broker disposition 语义）。
+- Rejected alternative：import `kernel/outbox.PermanentError`——会让 `kernel/reconcile` 跨域
+  耦合 outbox 的 broker 语义（reconcile 与 outbox 是正交关注点），违反「优雅简洁/不引入
+  无关依赖」。
+- 采用：unexported `permanentError`（sealed construction 范本）——包外只能经 `PermanentError()`
+  构造、`IsPermanent()` 分类，「未经 `PermanentError` 的 permanent error」在包外不可表达。
+  语义等价上游 `reconcile.TerminalError`。
+
+### 3.4 LeaderElector（PR-A6 设计）
+
+```go
+type LeaderElector interface {
+	AcquireLease(ctx context.Context, reconcilerID string) (LeaseToken, error)
+	ReleaseLease(ctx context.Context, token LeaseToken) error
+	RenewLease(ctx context.Context, token LeaseToken) error
+}
+type LeaseToken struct {
+	ReconcilerID string
+	HolderID     string
+	AcquiredAt   time.Time
+	ExpiresAt    time.Time
+}
+```
+
+接口在 kernel 声明、实现在 adapter（对齐 `outbox.Emitter` / `persistence.CellTxManager`
+kernel-driven adapter-implements 模式，满足分层）。`LeaseToken` 字段对标 §2.5
+`LeaderElectionRecord`，但用中立形态（不绑 K8s `coordination.k8s.io/Lease`），扩 etcd 等
+adapter 不改 kernel。
+
+### 3.5 Builder（PR-A7 设计）
+
+```go
+func New(reconciler Reconciler) *Builder
+func (*Builder) WithTrigger(Trigger) *Builder
+func (*Builder) WithLeader(LeaderElector) *Builder
+func (*Builder) WithConcurrency(int) *Builder
+func (*Builder) WithBackoff(...) *Builder
+func (*Builder) WithMetrics(Metrics) *Builder
+func (*Builder) Build() (*Loop, error)   // Loop 构造私有化：Builder 是唯一公开入口
+```
+
+funnel：`Loop` 公开构造私有化（PR-A7 把 A3 的 exported `Loop{}` 字面量构造收口到 Builder），
+`RECONCILE-BUILDER-FUNNEL-01` 锁「消费方构造 Loop 必经 Builder」（funnel 上游 Hard = 构造函数
+私有化；下游 Hard = callsite allowlist）。**注**：PR-A3 阶段 `Loop` 字段 exported（支持
+struct 字面量构造，供测试 + kernel/command 迁移过渡）；A7 收口为私有 + Builder。
+
+### 3.6 Metrics（PR-A3 已落地）
+
+`RegisterMetrics(p Provider) (Metrics, error)` 单源注册 4 件：`reconcile_total{reconciler,result}`
+（result ∈ success/transient/permanent/skipped）/ `reconcile_duration_seconds{reconciler}` /
+`reconcile_in_flight{reconciler}` / `reconcile_leader{reconciler}`。注入式 pre-bound vec +
+`preflight`（recover 包裹 label 校验，misconfig → fail-fast Start，对齐
+`runtime/command.preflightSweepErrorCounter`）。
+
+> result 标签集冻结为 {success/transient/permanent/skipped}（FR-010）；recovered panic 归为
+> transient（可重试）。**spec 内部矛盾备案**：tasks.md T18 提到 `result="panic"` 第 5 标签，
+> 与 FR-010 四标签集冲突；本 ADR 采 FR-010 四标签，panic→transient；若 A5 需独立 panic
+> disposition，由 A5 同 PR 修订 FR-010 + 本 §3.6。
+
+---
+
+## §4 leader-elect 设计
+
+多副本部署时，`Loop` 必须保证**单实例扫描**（否则 mdmcell 会向设备重复发命令）。
+
+### 4.1 两 adapter
+
+| adapter | 机制 | 续约 | 失败语义 |
+|---------|------|------|---------|
+| `adapters/redis` | `SET key holderID NX PX leaseMs`（SETNX + TTL） | 周期 `PEXPIRE`（< LeaseDuration） | TTL 到期自动释放，follower SETNX 接管 |
+| `adapters/postgres` | `pg_try_advisory_lock(hash(reconcilerID))` | session-scoped lock + heartbeat goroutine | session 断 → lock 自动释放 |
+
+复用 `adapters/redis` Cache 的 cell-namespaced key 约定（lease key 带 namespace 前缀）。
+
+### 4.2 lease/token 模型 + RTO
+
+- `AcquireLease` 成功返回 `LeaseToken{ExpiresAt = now + LeaseDuration}`；`Loop` 仅在持 lease
+  时调 `Reconcile`，follower 在 `awaitProbe` 等待。
+- RTO（SC-004）：leader 崩溃 → follower 接管 P99 ≤ `LeaseDuration + 1s`（默认 LeaseDuration=15s，
+  对标 §2.5）；graceful shutdown（`ReleaseLease`）→ follower 接管 P99 ≤ 1s。
+- `reconcile_leader{reconciler}` gauge：持 lease=1，否则=0（A3 单进程恒置 1，A6 接真实选举）。
+
+---
+
+## §5 与 saga (#969) / projection harness (#1079) 边界
+
+三者正交，互不重叠：
+
+| 机制 | 触发 | 形态 | 一致性 | 对标 |
+|------|------|------|--------|------|
+| **reconcile**（本 ADR） | level-triggered（周期扫描非终态） | desired↔actual 无限收敛环 | **L4** DeviceLatent | controller-runtime |
+| **saga**（#969） | edge-triggered（事件） | 有限步骤前向编排 + 补偿（跑完即终态） | **L3** WorkflowEventual | Temporal |
+| **projection**（#1079） | edge-triggered（outbox 事件） | event → 读模型投影 | **L3**（CQRS 读侧） | Watermill |
+
+判别器：**能否信任事件驱动收敛？** L3 在系统内部走可靠 outbox（L2 保证投递），边沿触发吃满
+→ saga/projection；L4 跨不可靠设备边界，不能等事件，必须周期扫描主动驱动 → reconcile。
+reconcile **仅用于 cell 治理 / 设备收敛，不做业务编排**（业务编排是 saga 的活，
+controller-runtime 也明确二者正交）。
+
+---
+
+## §6 trigger 满足条件 + 激活流程
+
+### 6.1 Trigger Gate（A4–A10 实施前必须满足）
+
+| # | 触发条件 | 预计 |
+|---|---------|------|
+| T1 | `pkicell.rotation`（证书续期 L4 环） | winmdm Stage 1, 2027 Q1 |
+| T2 | `mdmcell.command`（命令超时重发） | winmdm Stage 2, 2027 Q2-Q3 |
+| T3 | `devicelifecycle.cronsweep`（设备墓碑状态机） | winmdm Stage 4, 2027 Q4 |
+| T4 | `zerotrust.trustscore`（信任分周期重评） | zt Phase 5, 2029 Q1 |
+
+**满足判定**：T1/T2/T3 至少 **2 个生产 cell** 落地（不含 `examples/iotdevice`），或 T1/T2/T3
+任一 + T4。
+
+### 6.2 A1–A3 ahead-of-trigger 例外（本 PR）
+
+trigger gate 的原始约束（spec.md §Trigger Gate）是「trigger 满足前合并任何
+`kernel/reconcile/*.go` **代码**均视为违章」，目的是禁止为 2027+ 消费方**预建**未验证的设计。
+本 PR 系列（A1–A3）经**显式决策 un-park**，理由：
+
+1. 一个无法被实现验证的设计 ADR 是「不可证伪的推演」——A2/A3 的可运行实现是 ADR 论断
+   （≥80% reuse / 接口最小性 / panic 隔离 / leak-free）的**验证手段**，不是预建产能。
+2. 当前 repo 只有 gocell 自身、无外部调用方（CLAUDE.md），un-park 决策由 maintainer 行使。
+3. A1–A3 不引入任何业务 cell / `mdm/` 目录（plan-D §10 禁止预建的是业务产能，非 kernel 基建）。
+4. A4–A10（leader adapter / Builder funnel / kernel/command 迁移 / examples 切换）**仍 parked**，
+   `runtime/command.SweeperLifecycle` 旧路径不动（无双轨破裂）。
+
+### 6.3 激活流程（A4–A10）
+
+trigger 满足时：开新 implementation plan（`docs/plans/<ts>-661-kernel-reconcile-active.md`）引用
+本 ADR + spec，按 A4→A10 顺序执行（B4 内 A4∥A5 可并行）；A10 merge 后关闭 #661。激活前核验
+controller-runtime 对标快照（§2 的 5 个 ref）仍有效，否则先修订本 §2。
+
+---
+
+## §7 威胁矩阵
+
+每条含缓解 + AI-robust 评级（评级载体活在对应 archtest 的 godoc，此处给结论）。
+
+| ID | 威胁 | 缓解 | 评级 |
+|----|------|------|------|
+| **T-IFACE** | 接口被错误泛化（加 namespace / Priority / Requeue bool，重新引入 K8s 残留） | `RECONCILE-{INTERFACE,REQUEST-FIELDS,RESULT-FIELDS}-FROZEN-01` reflect golden 锁字段/方法集 + 显式拒残留 + 反向盲区自检（PR-A2 已落地） | **Hard**（违反不可表达——加字段即 CI 红，无 string-anchor 逃逸） |
+| **T-CLOCK** | 控制面 ticker/probe/duration 被注入非实时（fake）clock → Start 死锁 / 时间错乱 | `controlPlaneClock` 包私有 sealed type（包外不可构造/替换）+ `PROD-CLOCK-INJECTION-01` host-set 扩 `kernel/reconcile/`（gate(a) + (method,callee) form-uniqueness：`newProbeTimer/newRequeueTimer→NewTimer`、`now→Now`）+ GREEN/RED fixtures（PR-A3 已落地） | **Medium**（永久天花板——stdlib `time.NewTimer`/`Now` free function 在 Go 不可 uncallable；receiver-type 限制 + form-uniqueness 是该形状可达上限，同 runtime/command controlPlaneClock 自评） |
+| **T-LEAK** | Loop goroutine（worker / pump / requeue 定时）在 Stop/owner-cancel 后泄漏 | 全 goroutine 由 runCtx 派生 + `WaitGroup` 跟踪 + `done` channel；`Stop` cancel→等 done（StopTimeout budget）；per-requeue goroutine 双 select runCtx.Done。`goleak.VerifyNone` 守 6 个生命周期测试（PR-A3 已落地，`-race` 通过） | **Medium**（runtime guard + goleak 测试；Go 无法在类型层表达「无 goroutine 泄漏」） |
+| **T-PANIC** | 单实体 Reconcile panic 杀 worker goroutine → 整进程崩 / 其他实体停摆 | `safeReconcile` recover → 转 transient error → 记 metric → 不影响其他实体；`TestLoop_PanicRecoveredAndOtherEntitiesUnaffected` 守（PR-A3 已落地）。A5 细化 panic 分类/taxonomy | **Medium**（runtime recover guard + 测试；对标 controller-runtime `RecoverPanic`） |
+| **T-DUAL** | 多 cell / 多副本并发扫描 → 重复驱动（mdmcell 重发命令） | `LeaderElector` 单实例保证（§4，PR-A6）；同实例内同 EntityID 由 `inflight` sync.Map 串行（level-triggered 丢重复=skipped，PR-A3 已落地，`TestLoop_SameEntityIDSerial` 守） | 同实例串行 **Medium**（runtime guard + 测试）；跨副本 leader **设计**（A6 落地后补 conformance） |
+| **T-LEADER** | leader 流转失败（双 leader / 长期空窗） | lease/renew/token 模型（§4）；fail-closed（lease 故障 follower 不抢）；RTO ≤ LeaseDuration+1s；2 adapter conformance（PR-A6） | **设计**（A6 落地 + real-failure-injection conformance 后定级） |
+| **T-BUILDER** | 消费方裸构造 Loop 绕过 metric/leader/backoff wiring | Builder funnel：`Loop` 构造私有化 + `RECONCILE-BUILDER-FUNNEL-01`（PR-A7） | **设计**（A7 落地后：上游 Hard 构造私有化 + 下游 Hard callsite） |
+
+> A3 阶段 `Loop` 字段 exported（过渡，支持 struct 字面量 + kernel/command 迁移），故 T-BUILDER
+> 的上游 Hard 在 A7 才闭环；A3–A6 期间「裸构造」由 code review 兜底，不是 silent gap（A7 是
+> 已规划的 funnel 收口 PR）。
+
+---
+
+## §8 不向后兼容声明
+
+A8 删除 `runtime/command.SweeperLifecycle` + `SweepTicker` 命名，`kernel/command.Sweeper` 改为
+实现 `reconcile.Reconciler`：
+
+- **不留 alias / 不留 deprecation**——`SweeperLifecycle` / `SweepTicker` 名字完全删除，由
+  `RECONCILE-NAMING-FROZEN-01`（A8）grep production 0 命中守 frozen。
+- **不留双轨**——A8 后只有 `reconcile.Loop` 一个 control-loop 抽象（A9 把 `examples/iotdevice`
+  端到端切换验证）。
+- `runtime/command/lifecycle.go`（446 LoC）整包删除，调用方（`runtime/command/bootstrap_phase.go`
+  等）同 PR 迁移到 `reconcile.Builder`。
+- A8 同步迁移 `clock_invariants_test.go`：runtime/command 的 controlPlaneClock carve-out 随
+  `lifecycle.go` 删除而退场（reconcile 的 carve-out 已在本 PR/A3 加入 `controlPlaneClockHosts`）。
+
+> 当前 PR（A1–A3）**不**删除 SweeperLifecycle——它仍是 runtime/command 的活跃路径；§8 是 A8
+> 的设计声明，A8 受 §6 trigger gate 封存。
+
+ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
+ref: kubernetes-sigs/controller-runtime pkg/internal/controller/controller.go
+ref: kubernetes-sigs/controller-runtime pkg/builder/controller.go
+ref: kubernetes/client-go util/workqueue/default_rate_limiters.go
+ref: kubernetes/client-go tools/leaderelection/leaderelection.go
+ref: gocell runtime/command/lifecycle.go（SweeperLifecycle，调度骨架平移源）
+ref: gocell kernel/command/sweeper.go（既有 L4 控制环）

--- a/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+++ b/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
@@ -3,21 +3,24 @@
 | 字段 | 值 |
 |------|---|
 | ADR ID | 661 |
-| 状态 | **Accepted（设计冻结）；A1–A3 ahead-of-trigger 验证 stack 依次合入 develop，A4–A10 PARKED-ON-TRIGGER（详见 §6）** |
+| 状态 | **Accepted（设计冻结）。PR-A1（本 ADR，docs-only）= 当前 PR；A2/A3 实现已在同 stack 原型分支 `661-loop-skeleton` 验证，但尚未合入 develop、不在本 PR；A4–A10 PARKED-ON-TRIGGER（详见 §6）** |
 | 日期 | 2026-05-29 |
 | Issue | [#661](https://github.com/ghbvf/gocell/issues/661)（父）/ [#1162](https://github.com/ghbvf/gocell/issues/1162)（PR-A1） |
 | Spec | `docs/plans/specs/202605262359-661-kernel-reconcile-{spec,plan,tasks}.md` |
 | 一致性级别 | **L4 DeviceLatent**（issue 第一性原理重评结论） |
 
-> 本 ADR 是 `kernel/reconcile` 的设计权威源。其设计经本 stack 的 PR-A2（3 件套最小核）+
-> PR-A3（Loop 调度骨架）可运行实现验证（同 stack 开发，`go test -race ./kernel/reconcile/`
-> 通过、coverage 90.8%），故本文记录的是**经代码验证的设计**而非纯前瞻推演——`§2 ≥80%
-> reuse`、`§3 接口形态`、`§7 panic 隔离`等论断均有该实现背书。
+> 本 ADR 是 `kernel/reconcile` 的设计权威源。本 PR（PR-A1）是 **docs-only**——`kernel/reconcile`
+> 的实现代码**不在本 PR、也尚未合入 develop**，而活在同 stack 的原型分支 `661-loop-skeleton`
+> （PR-A2 3 件套最小核 + PR-A3 Loop 调度骨架）。该原型经 `go test -race ./kernel/reconcile/`
+> 通过、coverage 90.8%，为 `§2 ≥80% reuse`、`§3 接口形态`、`§7 panic 隔离` 等论断提供**原型实现
+> 背书**——但这是「**分支原型验证**」而非「trunk 已验证」：A2/A3 作为各自独立 PR（经各自 review）
+> 实际合入 develop 前，develop 上没有任何 `kernel/reconcile` 代码，本文论断在 trunk 维度仍是
+> 「设计 + 待兑现」。引用具体数值（coverage / LoC）时须带此 provenance，勿表述为 trunk 现状。
 > A1–A3 是 **stacked PR，按 A1（base develop）← A2 ← A3 依次合入**（plan.md「每 PR merge
-> 后 trunk 可发布」）；本文用「由 PR-Ax 交付」标注每条论断的承载 PR——读者在 develop 上看到
-> 的实现取决于已合入到哪一 PR：单独合入 A1 时 develop 上尚无 A2/A3 代码，因此 A2/A3 交付的
-> 形态/数值（接口、Loop、metrics、archtest 等）是「设计 + 该 PR 兑现」而非 A1 合入即存在。
-> 设计与实现分歧时以本 ADR 为准，并在同 PR 内修正实现或修订本 ADR。
+> 后 trunk 可发布」）；本文用「由 PR-Ax 交付」标注每条论断的承载 PR——读者在 develop 上看到的
+> 实现取决于已合入到哪一 PR，A2/A3 交付的形态/数值（接口、Loop、metrics、archtest 等）只在其
+> 承载 PR 实际合入 develop 后才成为 trunk 事实。设计与实现分歧时以本 ADR 为准，并在同 PR 内
+> 修正实现或修订本 ADR。
 
 ---
 
@@ -44,11 +47,12 @@
 `PermanentError`/`IsPermanent` ≈ 30 LoC（`reconciler.go` 45 + `result.go` 类型部分）；
 controller-runtime `pkg/reconcile`+`pkg/builder` 公开面 ≥800 LoC，简化 ≥4x。
 
-**交付划分**：本 stack 分三 PR——PR-A1（本 ADR）/ PR-A2（接口 + 3 frozen archtest）/
-PR-A3（Loop 调度骨架 + 4 metrics + clock carve-out），各经 `go test -race` + 90.8% coverage
-验证后依次合入 develop（A1←A2←A3）。下文「由 PR-Ax 交付」标注每条论断的承载 PR——某论断
-背书的代码只有在其承载 PR 合入后才存在于 develop。PR-A4–A10（Trigger / Backoff /
-LeaderElector / Builder / 迁移 / 文档）受 §6 trigger gate 封存。
+**交付划分**：本 stack 分三 PR——PR-A1（本 ADR，docs-only，= 当前 PR）/ PR-A2（接口 + 3 frozen
+archtest）/ PR-A3（Loop 调度骨架 + 4 metrics + clock carve-out）。A2/A3 已在原型分支
+`661-loop-skeleton` 经 `go test -race` + 90.8% coverage 验证，但**尚未作为 PR 合入 develop**；
+合入顺序 A1←A2←A3。下文「由 PR-Ax 交付」标注每条论断的承载 PR——某论断背书的代码只有在其
+承载 PR 实际合入后才存在于 develop。PR-A4–A10（Trigger / Backoff / LeaderElector / Builder /
+迁移 / 文档）受 §6 trigger gate 封存。
 
 ---
 
@@ -93,14 +97,25 @@ ADR `202605041430-adr-architecture-optimization-via-engineering-thinking.md` §3
 
 ---
 
-## §2 对标 controller-runtime（快照 @ main，2026-05-29）
+## §2 对标 controller-runtime（快照 @ pinned commit，2026-05-29）
 
-对标快照固定在以下 5 个上游源；后续 PR commit message 引用对应 `ref:` 行。
+对标快照 **pin 到具体 commit SHA**（不用移动的 `main`/`master` ref，保证可复现）；后续 PR
+commit message 引用对应 `ref:` 行。下方所有 `ref:` 行均锚定于这两个 commit：
+
+| 上游 repo | 默认分支 | pinned commit（2026-05-29 抓取，HEAD-of-default-branch） |
+|-----------|---------|------------------------------------------------------|
+| `kubernetes-sigs/controller-runtime` | `main` | `346f1930fde577d7d5e49c88e5ee625e4ebb7daa`（短 `346f1930fde5`，committed 2026-05-26） |
+| `kubernetes/client-go` | **`master`**（非 `main`） | `5d252d37f7301d279fc55030c9f8e0e1688a6985`（短 `5d252d37f730`，committed 2026-05-28） |
+
+> 上述 5 个引用路径已在对应 pinned SHA 处核验存在。§6.3「激活前核验对标快照仍有效」=
+> 比对 pinned SHA 处源码与本 §2 摘录；上游演进时先 re-pin（更新本表 SHA + 下方 raw URL）
+> 再修订摘录。注意 client-go 默认分支是 `master` 不是 `main`——§2.4 / §2.5 的 raw URL 须用
+> 上表 SHA（commit-pinned，分支无关），勿写 `/main/`。
 
 ### 2.1 `pkg/reconcile/reconcile.go` — Reconciler / Request / Result
 
 ref: `kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go`
-（https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/main/pkg/reconcile/reconcile.go）
+（https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/346f1930fde577d7d5e49c88e5ee625e4ebb7daa/pkg/reconcile/reconcile.go）
 
 ```go
 type TypedReconciler[request comparable] interface {
@@ -270,6 +285,7 @@ type LeaderElector interface {
 type LeaseToken struct {
 	ReconcilerID string
 	HolderID     string
+	Epoch        uint64    // 单调 fencing token（每次换持有者 +1）——见 §4.3
 	AcquiredAt   time.Time
 	ExpiresAt    time.Time
 }
@@ -279,6 +295,11 @@ type LeaseToken struct {
 kernel-driven adapter-implements 模式，满足分层）。`LeaseToken` 字段对标 §2.5
 `LeaderElectionRecord`，但用中立形态（不绑 K8s `coordination.k8s.io/Lease`），扩 etcd 等
 adapter 不改 kernel。
+
+> `LeaseToken` 是 **PR-A6 设计接口**（未 frozen，与 §3.1 三件套 frozen core 不同），A6 落地时
+> 随 `LeaderElector` 一并 frozen。`Epoch` 是 F5 review 引入的**单调 fencing token**——leader
+> election 本身**不是 fencing 保证**（见 §4），正确性闭环靠 `Epoch` + §4.3 `FencedRepository`
+> 写路径 CAS。注意它与 `kernel/outbox` 的 UUID `lease_id`（identity-fencing）语义不同（§4.3）。
 
 ### 3.5 Builder（PR-A7 设计）
 
@@ -306,15 +327,24 @@ struct 字面量构造，供测试 + kernel/command 迁移过渡）；A7 收口�
 `runtime/command.preflightSweepErrorCounter`）。
 
 > result 标签集冻结为 {success/transient/permanent/skipped}（FR-010）；recovered panic 归为
-> transient（可重试）。**spec 内部矛盾备案**：tasks.md T18 提到 `result="panic"` 第 5 标签，
-> 与 FR-010 四标签集冲突；本 ADR 采 FR-010 四标签，panic→transient；若 A5 需独立 panic
-> disposition，由 A5 同 PR 修订 FR-010 + 本 §3.6。
+> transient（可重试），与 FR-009「panic → transient error」一致。单一真值源：spec FR-009/
+> FR-010、tasks.md T18（`TestRecovery_PanicMetricRecorded` 断言 `result="transient"`）、
+> 本 §3.6 三处一致——**不存在** `result="panic"` 第 5 标签。若未来 A5 确需独立 panic
+> disposition，必须由 A5 同 PR 同步修订 FR-010 + tasks.md T18 + 本 §3.6 三处，不得单点漂移。
 
 ---
 
 ## §4 leader-elect 设计
 
-多副本部署时，`Loop` 必须保证**单实例扫描**（否则 mdmcell 会向设备重复发命令）。
+多副本部署时，`Loop` 用 leader election **降低但不消除**跨副本并发 Reconcile——leader election
+**不是 fencing 机制**。client-go `tools/leaderelection` 自身文档明示：*"This implementation does
+not guarantee that only one client is acting as a leader (a.k.a. fencing)."* STW GC 暂停、时钟
+偏移、renew/acquire 竞争都会留下**残余双执行窗口**：旧 leader L1 在 `Reconcile(X)` 中途被暂停
+→ lease 过期 → L2 接管并 `Reconcile(X)` → L1 苏醒后写完 → mdmcell 对 X 发两次命令。
+
+因此单实例正确性**不能**靠 lease 本身，必须靠 **monotonic fencing token + 写路径 CAS**（§4.3）
++ **消费方幂等**（§4.4）兜底。本节 §4.1–§4.2 是 lease 机制（best-effort 收窄窗口），§4.3–§4.4
+是正确性闭环（结构性兜底）。**以下 §4 全节是 PR-A6 设计**（未落地，受 §6 trigger gate 封存）。
 
 ### 4.1 两 adapter
 
@@ -325,13 +355,49 @@ struct 字面量构造，供测试 + kernel/command 迁移过渡）；A7 收口�
 
 复用 `adapters/redis` Cache 的 cell-namespaced key 约定（lease key 带 namespace 前缀）。
 
-### 4.2 lease/token 模型 + RTO
+### 4.2 lease/token 模型 + RTO + lost-lease 中断
 
-- `AcquireLease` 成功返回 `LeaseToken{ExpiresAt = now + LeaseDuration}`；`Loop` 仅在持 lease
-  时调 `Reconcile`，follower 在 `awaitProbe` 等待。
+- `AcquireLease` 成功返回 `LeaseToken{Epoch, ExpiresAt = now + LeaseDuration}`；`Loop` 仅在持
+  lease 时 dispatch `Reconcile`，follower 在 `awaitProbe` 等待。
+- **lost-lease 中断（A6 必做，best-effort 收窄窗口）**：`Loop` 必须从 lease 派生 lease-scoped
+  ctx，并在 `RenewLease` 失败 / lease 被观察到丢失的**瞬间** cancel 该 ctx、中断 in-flight
+  `Reconcile`——镜像 client-go `release()` 文档警告「cancel ctx 前须确保 lease 守护的代码已完成，
+  否则两进程会同时在 critical path」。这只**收窄**不**消除**窗口（暂停/分区下 L1 可能根本来不及
+  观察到丢失），故必须叠加 §4.3 fencing。
 - RTO（SC-004）：leader 崩溃 → follower 接管 P99 ≤ `LeaseDuration + 1s`（默认 LeaseDuration=15s，
-  对标 §2.5）；graceful shutdown（`ReleaseLease`）→ follower 接管 P99 ≤ 1s。
+  对标 §2.5）；graceful shutdown（`ReleaseLease`）→ follower 接管 P99 ≤ 1s。**RTO 是接管延迟
+  指标，不是「双执行不发生」的保证。**
 - `reconcile_leader{reconciler}` gauge：持 lease=1，否则=0（A3 单进程恒置 1，A6 接真实选举）。
+
+### 4.3 fencing：FencedRepository 写路径 CAS（结构性正确性闭环）
+
+leader election 留下的残余窗口由 **monotonic fencing token（Kleppmann DDIA §8.4）+ 写路径
+CAS** 兜底，并以**结构性收口**（而非每消费方自觉）落地：
+
+- **monotonic epoch**：lease store 每次成功 `AcquireLease`（**换持有者**）单调递增 `Epoch`；
+  `RenewLease` 保持 epoch 不变。PG 用 SEQUENCE / 行版本号在 acquire UPDATE 内 bump；Redis 在
+  SETNX-acquire Lua 内 INCR per-reconciler epoch key。
+- **为何不照搬 outbox 的 UUID `lease_id`**：outbox fencing（ADR `202605051600`，archtest
+  `OUTBOX-LEASE-ID-CAS-01`）用 UUID 做 **identity fencing**——CAS 按「等于当前 lease_id」放行，
+  是单次换手语义（任何 stale token != current 即失败）。reconcile 的设备写可能在 **L1→L2→L3
+  多次换手后**才迟到落地；UUID 只能判「不等」不能判「更旧」，无法拒绝乱序迟到写。故 reconcile
+  **必须用单调 epoch**：资源行记「已见最高 epoch」，CAS 拒绝**所有** `incoming_epoch < 已见最高`
+  的写（`UPDATE ... WHERE incoming_epoch >= row.last_epoch`），而不仅是非等值。
+- **FencedRepository seam（结构性收口）**：`Loop` 持 `LeaseToken{Epoch}`，给每次 `Reconcile`
+  注入一个 epoch-bound 的 `FencedWriter`（而非让 `Reconcile` 直接写裸 cell 表）。L4 reconciler
+  **唯一拿到的写面**是这个 epoch-bound handle，CAS 在 handle 内统一注入 epoch 并拒 stale——
+  消费方**结构上无法**发出未 fenced 的设备命令（不是「记得 fence」而是「想绕过都没有 API」），
+  把 fencing 从「每消费方义务」升级为「结构不变式」，对齐 AI-robust「违反不可表达」。enforcement
+  目标（A6 落地）：上游 Hard = `FencedWriter` 是 Reconciler 唯一写面 + sealed 构造；下游 Hard =
+  `RECONCILE-FENCED-WRITE-FUNNEL-01` callsite + `reconciletest.RunFencingConformance`
+  real-failure-injection（epoch-N 写在 epoch-N+1 接管后重放，断言 CAS 拒绝、无重复命令）入列。
+
+### 4.4 消费方幂等契约（残余窗口的最终兜底）
+
+即便有 §4.2 中断 + §4.3 fencing，**残余双执行/迟到窗口仍被 ACCEPTED**（分布式 lease 的本质，
+无法 100% 消除）。故 **L4 reconcile 消费方契约**：所有 `Reconcile` / 设备写 / 命令发射路径
+**必须幂等**（per `EntityID + intent` 的 dedup key）。这与 §5「L4 跨不可靠设备边界」已隐含的
+at-least-once 投递语义一致——幂等是 L4 的入场券，不是可选项。
 
 ---
 
@@ -397,17 +463,33 @@ controller-runtime 对标快照（§2 的 5 个 ref）仍有效，否则先修�
 | **T-CLOCK** | 控制面 ticker/probe/duration 被注入非实时（fake）clock → Start 死锁 / 时间错乱 | `controlPlaneClock` 包私有 sealed type（包外不可构造/替换）+ `PROD-CLOCK-INJECTION-01` host-set 扩 `kernel/reconcile/`（gate(a) + (method,callee) form-uniqueness：`newProbeTimer/newRequeueTimer→NewTimer`、`now→Now`）+ GREEN/RED fixtures（由 PR-A3 交付） | **Medium**（永久天花板——stdlib `time.NewTimer`/`Now` free function 在 Go 不可 uncallable；receiver-type 限制 + form-uniqueness 是该形状可达上限，同 runtime/command controlPlaneClock 自评） |
 | **T-LEAK** | Loop goroutine（worker / pump / requeue 定时）在 Stop/owner-cancel 后泄漏 | 全 goroutine 由 runCtx 派生 + `WaitGroup` 跟踪 + `done` channel；`Stop` cancel→等 done（StopTimeout budget）；per-requeue goroutine 双 select runCtx.Done。`goleak.VerifyNone` 守 6 个生命周期测试（由 PR-A3 交付，`-race` 通过） | **Medium**（runtime guard + goleak 测试；Go 无法在类型层表达「无 goroutine 泄漏」） |
 | **T-PANIC** | 单实体 Reconcile panic 杀 worker goroutine → 整进程崩 / 其他实体停摆 | `safeReconcile` recover → 转 transient error → 记 metric → 不影响其他实体；`TestLoop_PanicRecoveredAndOtherEntitiesUnaffected` 守（由 PR-A3 交付）。A5 细化 panic 分类/taxonomy | **Medium**（runtime recover guard + 测试；对标 controller-runtime `RecoverPanic`） |
-| **T-DUAL** | 多 cell / 多副本并发扫描 → 重复驱动（mdmcell 重发命令） | `LeaderElector` 单实例保证（§4，PR-A6）；同实例内同 EntityID 由 `inflight` sync.Map 串行（level-triggered 丢重复=skipped，由 PR-A3 交付，`TestLoop_SameEntityIDSerial` 守） | 同实例串行 **Medium**（runtime guard + 测试）；跨副本 leader **设计**（A6 落地后补 conformance） |
-| **T-LEADER** | leader 流转失败（双 leader / 长期空窗） | lease/renew/token 模型（§4）；fail-closed（lease 故障 follower 不抢）；RTO ≤ LeaseDuration+1s；2 adapter conformance（PR-A6） | **设计**（A6 落地 + real-failure-injection conformance 后定级） |
-| **T-BUILDER** | 消费方裸构造 Loop 绕过 metric/leader/backoff wiring | Builder funnel：`Loop` 构造私有化 + `RECONCILE-BUILDER-FUNNEL-01`（PR-A7） | **设计**（A7 落地后：上游 Hard 构造私有化 + 下游 Hard callsite） |
+| **T-DUAL** | 多 cell / 多副本并发扫描 → 重复驱动（mdmcell 重发命令） | **leader election 非 fencing**（§4，client-go 明示不保证单 leader）——只 best-effort 收窄窗口。跨副本正确性靠 §4.3 `FencedRepository` + monotonic-epoch 写路径 CAS（结构拒 stale-epoch 写）+ §4.4 消费方幂等；同实例内同 EntityID 由 `inflight` sync.Map 串行（level-triggered 丢重复=skipped，由 PR-A3 交付，`TestLoop_SameEntityIDSerial` 守） | 同实例串行 **Medium**（runtime guard + 测试，已兑现）；跨副本正确性 **设计**（A6：`FencedWriter` 上游 Hard + `RECONCILE-FENCED-WRITE-FUNNEL-01` 下游 Hard + `RunFencingConformance` real-failure-injection 后定级；leader election 永远只是 best-effort 收窄，不计入正确性保证） |
+| **T-LEADER** | leader 流转失败（双 leader / 长期空窗） | lease/renew 模型（§4.1–4.2）+ lost-lease ctx-cancel 中断（§4.2，收窄）；fail-closed（lease 故障 follower 不抢）；RTO ≤ LeaseDuration+1s（接管延迟，**非**双执行保证）。**双 leader 不靠 lease 排除**——靠 §4.3 epoch fencing CAS 让旧 leader 迟到写被结构拒绝 | **设计**（A6 落地 lease 模型 + epoch fencing + real-failure-injection conformance 后定级；明确 leader election ≠ fencing） |
+| **T-FENCE** | 旧 leader 迟到设备写绕过 fencing → 落地为重复命令（leader election 残余窗口的兜底失效） | §4.3 `FencedRepository`：`Loop` 只给 Reconciler epoch-bound `FencedWriter`，写路径 CAS 拒 `incoming_epoch < 已见最高`（**单调 epoch**，非 outbox 的 UUID identity-fencing）；绕过在 type system 不可表达（消费方无裸写面） | **设计**（A6：上游 Hard = `FencedWriter` 唯一写面 + sealed 构造；下游 Hard = `RECONCILE-FENCED-WRITE-FUNNEL-01` callsite + conformance 入列；leader election ≠ fencing 由本行结构兜底） |
+| **T-BUILDER** | 消费方裸构造 Loop 绕过 metric/leader/backoff wiring | 终态 Builder funnel：`Loop` 构造私有化 + `RECONCILE-BUILDER-FUNNEL-01`（PR-A7）；A3–A6 exported-`Loop` 窗口期由临时 Medium archtest `RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01` 机器守（见下注，**非** code review 兜底） | **过渡**（A3–A6：Medium 上游 archtest allowlist + 下游 Hard callsite）→ **A7 闭环**（上游 Hard 构造私有化 + 下游 Hard callsite） |
 
 > A3 阶段 `Loop` 字段 exported（过渡，支持 struct 字面量 + kernel/command 迁移），故 T-BUILDER
-> 的上游 Hard 在 A7 才闭环；A3–A6 期间「裸构造」由 code review 兜底，不是 silent gap（A7 是
-> 已规划的 funnel 收口 PR）。
+> 的**上游 Hard 要到 A7 才闭环**。A3–A6 期间**不以 code review 兜底**——AI-robust 章程明定 code
+> review 是 Soft 机制、严禁作为 standing enforcement，故旧表述「裸构造由 code review 兜底，不是
+> silent gap」本身就是被章程禁止的 Soft gap。替代：A2/A3 同 PR 必须补一条**临时 Medium archtest**
+> `RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01`（callsite allowlist：禁止 `kernel/reconcile` 包外裸
+> 构造 `Loop{}`，仅放行 `*_test.go` + A8 `kernel/command` 迁移点），把 exported-`Loop` 窗口期从
+> 「人审」降到「机器守」。A7 落地 Builder + `Loop` 构造私有化后，该临时 Medium archtest 退役、由
+> 上游 Hard `RECONCILE-BUILDER-FUNNEL-01` 取代。此「Medium 上游 + Hard 下游」过渡形态按章程
+> §Funnel 双向锁评级开 gh issue 跟踪显式 Hard 化（归口父 issue #661 的 A7 任务）。
 
----
-
-## §8 不向后兼容声明
+> **F5 amendment 重评（AI-robust §ADR amendment 落地必查）**：本次 review 把 leader election 从
+> 「单实例 fencing 保证」更正为「best-effort 收窄，非 fencing」。受影响格子逐行重评：
+> - **T-DUAL 缓解列**：原文「`LeaderElector` 单实例保证」是 overclaim（client-go 自身文档否认
+>   fencing），**已同 PR 重写**为「leader election best-effort + §4.3 epoch fencing CAS + §4.4
+>   幂等」——非保留原文加注，避免两套真理源。
+> - **T-LEADER 缓解列**：原文「lease/renew/token 模型」被误当作双 leader 的排除手段，**已重写**
+>   为「lease 收窄 + epoch fencing 结构兜底」。
+> - **新增 T-FENCE 行**：覆盖「旧 leader 迟到写」这一原矩阵漏掉的威胁；评级 **设计**（A6 落地
+>   FencedWriter funnel 后定级）。
+> - 没有格子从 ✅ 退化为 ❌ 而无补偿：跨副本正确性原本就标「设计」（A6 未落地），本次只是把
+>   *保证来源* 从 lease（错）改为 epoch fencing + 幂等（对），并把 A6 验收门槛写死，使 A6 实现者
+>   无法回退到「信 lease」的旧错。fencing 设计是 docs（不建代码），不违反 §6 trigger gate。
 
 A8 删除 `runtime/command.SweeperLifecycle` + `SweepTicker` 命名，`kernel/command.Sweeper` 改为
 实现 `reconcile.Reconciler`：

--- a/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+++ b/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
@@ -3,23 +3,27 @@
 | 字段 | 值 |
 |------|---|
 | ADR ID | 661 |
-| 状态 | **Accepted（设计冻结）；实施 A1–A3 ahead-of-trigger 验证落地，A4–A10 PARKED-ON-TRIGGER（详见 §6）** |
+| 状态 | **Accepted（设计冻结）；A1–A3 ahead-of-trigger 验证 stack 依次合入 develop，A4–A10 PARKED-ON-TRIGGER（详见 §6）** |
 | 日期 | 2026-05-29 |
 | Issue | [#661](https://github.com/ghbvf/gocell/issues/661)（父）/ [#1162](https://github.com/ghbvf/gocell/issues/1162)（PR-A1） |
 | Spec | `docs/plans/specs/202605262359-661-kernel-reconcile-{spec,plan,tasks}.md` |
 | 一致性级别 | **L4 DeviceLatent**（issue 第一性原理重评结论） |
 
-> 本 ADR 是 `kernel/reconcile` 的设计权威源。本 PR（PR-A1）随附 PR-A2/A3 的可运行实现
-> （3 件套最小核 + Loop 调度骨架）一起落地，因此本文档记录的是**经代码验证的设计**，
-> 而非纯前瞻推演——`§2 ≥80% reuse`、`§3 接口形态`、`§7 panic 隔离`等论断均有 PR-A2/A3
-> 的编译 + 测试（`go test -race ./kernel/reconcile/`，coverage 90.8%）背书。
-> 设计与实现产生分歧时以本 ADR 为准，并在同 PR 内修正实现或修订本 ADR。
+> 本 ADR 是 `kernel/reconcile` 的设计权威源。其设计经本 stack 的 PR-A2（3 件套最小核）+
+> PR-A3（Loop 调度骨架）可运行实现验证（同 stack 开发，`go test -race ./kernel/reconcile/`
+> 通过、coverage 90.8%），故本文记录的是**经代码验证的设计**而非纯前瞻推演——`§2 ≥80%
+> reuse`、`§3 接口形态`、`§7 panic 隔离`等论断均有该实现背书。
+> A1–A3 是 **stacked PR，按 A1（base develop）← A2 ← A3 依次合入**（plan.md「每 PR merge
+> 后 trunk 可发布」）；本文用「由 PR-Ax 交付」标注每条论断的承载 PR——读者在 develop 上看到
+> 的实现取决于已合入到哪一 PR：单独合入 A1 时 develop 上尚无 A2/A3 代码，因此 A2/A3 交付的
+> 形态/数值（接口、Loop、metrics、archtest 等）是「设计 + 该 PR 兑现」而非 A1 合入即存在。
+> 设计与实现分歧时以本 ADR 为准，并在同 PR 内修正实现或修订本 ADR。
 
 ---
 
 ## §0 决策摘要
 
-**3 件套最小核**（PR-A2 已落地，archtest frozen）：
+**3 件套最小核**（由 PR-A2 交付，archtest frozen）：
 
 | 件 | 形态 | 对标 controller-runtime |
 |----|------|------------------------|
@@ -40,9 +44,11 @@
 `PermanentError`/`IsPermanent` ≈ 30 LoC（`reconciler.go` 45 + `result.go` 类型部分）；
 controller-runtime `pkg/reconcile`+`pkg/builder` 公开面 ≥800 LoC，简化 ≥4x。
 
-**落地状态**：PR-A1（本 ADR）+ PR-A2（接口 + 3 frozen archtest）+ PR-A3（Loop 调度骨架 +
-4 metrics + clock carve-out）已实现并验证；PR-A4–A10（Trigger / Backoff / LeaderElector /
-Builder / 迁移 / 文档）受 §6 trigger gate 封存。
+**交付划分**：本 stack 分三 PR——PR-A1（本 ADR）/ PR-A2（接口 + 3 frozen archtest）/
+PR-A3（Loop 调度骨架 + 4 metrics + clock carve-out），各经 `go test -race` + 90.8% coverage
+验证后依次合入 develop（A1←A2←A3）。下文「由 PR-Ax 交付」标注每条论断的承载 PR——某论断
+背书的代码只有在其承载 PR 合入后才存在于 develop。PR-A4–A10（Trigger / Backoff /
+LeaderElector / Builder / 迁移 / 文档）受 §6 trigger gate 封存。
 
 ---
 
@@ -140,7 +146,7 @@ for i := 0; i < c.MaxConcurrentReconciles; i++ {
   success→`Queue.Forget`；terminal error→记 metric 不重排；
 - `RecoverPanic`（默认开）：`Reconcile` 内 panic 被 recover → 转 `fmt.Errorf("panic: %v")`。
 
-**GoCell 适配（PR-A3 已落地）**：`Loop` 起 `MaxConcurrentReconciles` 个 worker（默认 1）从
+**GoCell 适配（由 PR-A3 交付）**：`Loop` 起 `MaxConcurrentReconciles` 个 worker（默认 1）从
 内部 queue 取 `Request`；`process()` 做同 ID 串行（`sync.Map` inflight，level-triggered
 下重复触发安全丢弃 = `resultSkipped`）+ panic recovery（`safeReconcile`，单实体 panic 不杀
 worker，转 transient）+ 按 `Result`/error 重排。**未采纳 workqueue 的 dirty/processing 去重 +
@@ -206,7 +212,7 @@ spec SC-002 原文「451 中迁移 ≥360」按「整体平移」估算，实测
 
 ## §3 接口设计
 
-### 3.1 Reconciler / Request / Result（PR-A2 已落地，frozen）
+### 3.1 Reconciler / Request / Result（由 PR-A2 交付，frozen）
 
 ```go
 // INVARIANT: RECONCILE-INTERFACE-FROZEN-01
@@ -234,7 +240,7 @@ func ChannelTrigger(in <-chan Request) Trigger       // outbox 事件唤醒
 产出的原始 channel 接缝（A3 测试直接注入 channel，A4 由 Trigger 产出）。Loop 控制面时钟走
 `controlPlaneClock` carve-out（见 §7 T-CLOCK）。
 
-### 3.3 PermanentError 来源裁决（PR-A2 已落地）
+### 3.3 PermanentError 来源裁决（由 PR-A2 交付）
 
 ```go
 type permanentError struct{ err error }       // unexported sealed marker
@@ -291,7 +297,7 @@ funnel：`Loop` 公开构造私有化（PR-A7 把 A3 的 exported `Loop{}` 字�
 私有化；下游 Hard = callsite allowlist）。**注**：PR-A3 阶段 `Loop` 字段 exported（支持
 struct 字面量构造，供测试 + kernel/command 迁移过渡）；A7 收口为私有 + Builder。
 
-### 3.6 Metrics（PR-A3 已落地）
+### 3.6 Metrics（由 PR-A3 交付）
 
 `RegisterMetrics(p Provider) (Metrics, error)` 单源注册 4 件：`reconcile_total{reconciler,result}`
 （result ∈ success/transient/permanent/skipped）/ `reconcile_duration_seconds{reconciler}` /
@@ -387,11 +393,11 @@ controller-runtime 对标快照（§2 的 5 个 ref）仍有效，否则先修�
 
 | ID | 威胁 | 缓解 | 评级 |
 |----|------|------|------|
-| **T-IFACE** | 接口被错误泛化（加 namespace / Priority / Requeue bool，重新引入 K8s 残留） | `RECONCILE-{INTERFACE,REQUEST-FIELDS,RESULT-FIELDS}-FROZEN-01` reflect golden 锁字段/方法集 + 显式拒残留 + 反向盲区自检（PR-A2 已落地） | **Hard**（违反不可表达——加字段即 CI 红，无 string-anchor 逃逸） |
-| **T-CLOCK** | 控制面 ticker/probe/duration 被注入非实时（fake）clock → Start 死锁 / 时间错乱 | `controlPlaneClock` 包私有 sealed type（包外不可构造/替换）+ `PROD-CLOCK-INJECTION-01` host-set 扩 `kernel/reconcile/`（gate(a) + (method,callee) form-uniqueness：`newProbeTimer/newRequeueTimer→NewTimer`、`now→Now`）+ GREEN/RED fixtures（PR-A3 已落地） | **Medium**（永久天花板——stdlib `time.NewTimer`/`Now` free function 在 Go 不可 uncallable；receiver-type 限制 + form-uniqueness 是该形状可达上限，同 runtime/command controlPlaneClock 自评） |
-| **T-LEAK** | Loop goroutine（worker / pump / requeue 定时）在 Stop/owner-cancel 后泄漏 | 全 goroutine 由 runCtx 派生 + `WaitGroup` 跟踪 + `done` channel；`Stop` cancel→等 done（StopTimeout budget）；per-requeue goroutine 双 select runCtx.Done。`goleak.VerifyNone` 守 6 个生命周期测试（PR-A3 已落地，`-race` 通过） | **Medium**（runtime guard + goleak 测试；Go 无法在类型层表达「无 goroutine 泄漏」） |
-| **T-PANIC** | 单实体 Reconcile panic 杀 worker goroutine → 整进程崩 / 其他实体停摆 | `safeReconcile` recover → 转 transient error → 记 metric → 不影响其他实体；`TestLoop_PanicRecoveredAndOtherEntitiesUnaffected` 守（PR-A3 已落地）。A5 细化 panic 分类/taxonomy | **Medium**（runtime recover guard + 测试；对标 controller-runtime `RecoverPanic`） |
-| **T-DUAL** | 多 cell / 多副本并发扫描 → 重复驱动（mdmcell 重发命令） | `LeaderElector` 单实例保证（§4，PR-A6）；同实例内同 EntityID 由 `inflight` sync.Map 串行（level-triggered 丢重复=skipped，PR-A3 已落地，`TestLoop_SameEntityIDSerial` 守） | 同实例串行 **Medium**（runtime guard + 测试）；跨副本 leader **设计**（A6 落地后补 conformance） |
+| **T-IFACE** | 接口被错误泛化（加 namespace / Priority / Requeue bool，重新引入 K8s 残留） | `RECONCILE-{INTERFACE,REQUEST-FIELDS,RESULT-FIELDS}-FROZEN-01` reflect golden 锁字段/方法集 + 显式拒残留 + 反向盲区自检（由 PR-A2 交付） | **Hard**（违反不可表达——加字段即 CI 红，无 string-anchor 逃逸） |
+| **T-CLOCK** | 控制面 ticker/probe/duration 被注入非实时（fake）clock → Start 死锁 / 时间错乱 | `controlPlaneClock` 包私有 sealed type（包外不可构造/替换）+ `PROD-CLOCK-INJECTION-01` host-set 扩 `kernel/reconcile/`（gate(a) + (method,callee) form-uniqueness：`newProbeTimer/newRequeueTimer→NewTimer`、`now→Now`）+ GREEN/RED fixtures（由 PR-A3 交付） | **Medium**（永久天花板——stdlib `time.NewTimer`/`Now` free function 在 Go 不可 uncallable；receiver-type 限制 + form-uniqueness 是该形状可达上限，同 runtime/command controlPlaneClock 自评） |
+| **T-LEAK** | Loop goroutine（worker / pump / requeue 定时）在 Stop/owner-cancel 后泄漏 | 全 goroutine 由 runCtx 派生 + `WaitGroup` 跟踪 + `done` channel；`Stop` cancel→等 done（StopTimeout budget）；per-requeue goroutine 双 select runCtx.Done。`goleak.VerifyNone` 守 6 个生命周期测试（由 PR-A3 交付，`-race` 通过） | **Medium**（runtime guard + goleak 测试；Go 无法在类型层表达「无 goroutine 泄漏」） |
+| **T-PANIC** | 单实体 Reconcile panic 杀 worker goroutine → 整进程崩 / 其他实体停摆 | `safeReconcile` recover → 转 transient error → 记 metric → 不影响其他实体；`TestLoop_PanicRecoveredAndOtherEntitiesUnaffected` 守（由 PR-A3 交付）。A5 细化 panic 分类/taxonomy | **Medium**（runtime recover guard + 测试；对标 controller-runtime `RecoverPanic`） |
+| **T-DUAL** | 多 cell / 多副本并发扫描 → 重复驱动（mdmcell 重发命令） | `LeaderElector` 单实例保证（§4，PR-A6）；同实例内同 EntityID 由 `inflight` sync.Map 串行（level-triggered 丢重复=skipped，由 PR-A3 交付，`TestLoop_SameEntityIDSerial` 守） | 同实例串行 **Medium**（runtime guard + 测试）；跨副本 leader **设计**（A6 落地后补 conformance） |
 | **T-LEADER** | leader 流转失败（双 leader / 长期空窗） | lease/renew/token 模型（§4）；fail-closed（lease 故障 follower 不抢）；RTO ≤ LeaseDuration+1s；2 adapter conformance（PR-A6） | **设计**（A6 落地 + real-failure-injection conformance 后定级） |
 | **T-BUILDER** | 消费方裸构造 Loop 绕过 metric/leader/backoff wiring | Builder funnel：`Loop` 构造私有化 + `RECONCILE-BUILDER-FUNNEL-01`（PR-A7） | **设计**（A7 落地后：上游 Hard 构造私有化 + 下游 Hard callsite） |
 

--- a/docs/plans/specs/202605262359-661-kernel-reconcile-plan.md
+++ b/docs/plans/specs/202605262359-661-kernel-reconcile-plan.md
@@ -18,7 +18,8 @@
 **Primary Dependencies**: 标准库 + `pkg/errcode` + `pkg/validation` + `kernel/metautil`（kernel 层依赖收口）
 **Storage**:
 - Reconciler 状态：消费方自管（pkicell/mdmcell DB schema）
-- LeaderElector lease：adapters/redis（SETNX + EXPIRE）/ adapters/postgres（pg_try_advisory_lock）
+- LeaderElector lease：adapters/redis（SETNX + EXPIRE）/ adapters/postgres（pg_try_advisory_lock）；lease store 维护单调 `Epoch`（fencing token）
+- Fencing：消费方写经 epoch-bound `FencedWriter`，资源行记「已见最高 epoch」+ CAS 拒 stale（leader election 非 fencing，见 ADR §4.3）
 **Testing**:
 - table-driven test 覆盖率 kernel/ ≥ 90% / 其余 ≥ 80%（CLAUDE.md）
 - `reconciletest.ConformanceFactory` 收口（kernel/command/commandtest 同形态）
@@ -76,10 +77,11 @@ kernel/
 │   ├── trigger.go                       # Trigger interface + TickerTrigger + ChannelTrigger
 │   ├── backoff.go                       # 指数退避（baseDelay=5ms / maxDelay=1000s）
 │   ├── builder.go                       # New(reconciler).WithTrigger(...).Build() 最小 DSL
-│   ├── leader.go                        # LeaderElector interface + LeaseToken
+│   ├── leader.go                        # LeaderElector interface + LeaseToken（含单调 Epoch fencing token）
+│   ├── fenced.go                        # FencedRepository / FencedWriter（epoch-bound 写面 + CAS，PR-A6）
 │   ├── metrics.go                       # 4 个 metric wiring（counter/histogram/gauge）
 │   └── reconciletest/                   # conformance harness
-│       ├── conformance.go               # ReconcilerFactory + 跑遍 leader/RequeueAfter/Permanent
+│       ├── conformance.go               # ReconcilerFactory + 跑遍 leader/RequeueAfter/Permanent/fencing
 │       └── fake.go                      # 测试 fake（fake LeaderElector + fake Trigger）
 │
 ├── command/                             # 现有；改 Sweeper 实现 Reconciler 接口
@@ -106,6 +108,7 @@ tools/archtest/
 ├── reconcile_result_fields_frozen_test.go     # 新增（PR-A2）
 ├── reconcile_loop_clock_carveout_test.go      # 新增（PR-A4）
 ├── reconcile_leader_interface_frozen_test.go  # 新增（PR-A6）
+├── reconcile_fenced_write_funnel_test.go       # 新增（PR-A6：RECONCILE-FENCED-WRITE-FUNNEL-01）
 └── reconcile_builder_funnel_test.go           # 新增（PR-A7）
 
 .claude/rules/gocell/
@@ -136,7 +139,7 @@ docs/architecture/
 | A3 | feat: Loop 调度骨架（从 SweeperLifecycle 平移）+ metrics 4 件 | 1400 | A2 | `kernel/reconcile/{loop,metrics}.go` + tests | **B3** |
 | A4 | feat: Trigger interface + TickerTrigger + ChannelTrigger + Loop clock carve-out archtest | 1000 | A3 | `kernel/reconcile/{trigger}.go` + tests + 1 archtest | **B4**（与 A5 并行）|
 | A5 | feat: Backoff（指数退避）+ panic recovery + 错误分类 transient/permanent | 900 | A2 | `kernel/reconcile/{backoff,recovery}.go` + tests | **B4**（与 A4 并行）|
-| A6 | feat: LeaderElector interface + Redis 实现 + PG advisory lock 实现 + archtest frozen | 1500 | A3 | `kernel/reconcile/leader.go` + `adapters/{redis,postgres}/reconcile_leader.go` + tests + 1 archtest | **B5** |
+| A6 | feat: LeaderElector（含单调 Epoch fencing token）+ FencedWriter 写路径 CAS + Redis/PG 实现 + archtest frozen + fencing conformance | 1900 | A3 | `kernel/reconcile/{leader,fenced}.go` + `adapters/{redis,postgres}/reconcile_leader.go` + tests + 2 archtest（leader frozen + fenced-write funnel）| **B5** |
 | A7 | feat: Builder DSL + reconciletest.ConformanceFactory + funnel archtest | 1100 | A4/A5/A6 | `kernel/reconcile/{builder}.go` + `kernel/reconcile/reconciletest/{conformance,fake}.go` + 1 archtest | **B6** |
 | A8 | refactor: kernel/command.Sweeper 实现 reconcile.Reconciler + runtime/command/lifecycle.go 删除 | 1200 | A7 | `kernel/command/sweeper.go` + `runtime/command/lifecycle.go`（删）+ tests + archtest 名字 frozen 改写 | **B7** |
 | A9 | refactor: examples/iotdevice 切换到 kernel/reconcile.Loop 端到端验证 | 800 | A8 | `examples/iotdevice/cells/devicecell/cell.go` + e2e tests | **B7**（与 A8 同批次，并行可能） |
@@ -263,7 +266,7 @@ B1 (PR-A1) ────────────────────┐
 | controller-runtime 在 trigger 前接口大改 | 对标失效，PR-A2/A3 设计要调 | 本计划锁定 controller-runtime 当前形态作为对标快照（ref hash 在 PR-A1 ADR 中固定）；调整成本接受 |
 | LeaderElector 在 Redis/PG 之外有新需求（如 etcd） | adapter 层需扩展 | 接口设计抽象到 LeaseToken 中立形态，扩 adapter 不改 kernel；扩 adapter 时再开新 issue |
 | examples/iotdevice 迁移破坏端到端 | PR-A9 阻塞 | 在 PR-A9 前先在 fake adapter 里跑过 conformance；PR-A9 单独 e2e test 守 |
-| 单 PR 接近 2000 行（A6） | review 压力大 | A6 内 redis/PG 实现可分两个 sub-commit（同 PR），让 reviewer 按 file 分段 review |
+| 单 PR 超 2000 行（A6：leader + epoch fencing + 2 adapter + conformance） | review 压力大 | A6 内分三段 sub-commit（同 PR）：①LeaderElector + Epoch ②FencedWriter/CAS + funnel archtest ③redis/PG adapter；让 reviewer 按段 review；fencing 必须与 leader 同 PR（否则留「lease 即 fencing」错觉窗口）|
 
 ---
 

--- a/docs/plans/specs/202605262359-661-kernel-reconcile-spec.md
+++ b/docs/plans/specs/202605262359-661-kernel-reconcile-spec.md
@@ -35,7 +35,7 @@
 **Actor**: `pkicell.rotation` slice 维护者（winmdm Stage 1, 2027 Q1）
 
 **Plain Language**:
-作为 `pkicell` 的维护者，我希望声明一个 reconciler 实现，框架会按指定间隔扫描所有 `cert_issued` 行；对每个 `expires_at < now + 30d` 的非终态证书，框架调我的 `Reconcile(ctx, Request{EntityID: certID})`；我返回 `Result{RequeueAfter: nextWindow}` 或 `error` 让框架决定重试。我**不**需要自己写定时器、不需要自己管退避、不需要自己保证多副本下单实例。
+作为 `pkicell` 的维护者，我希望声明一个 reconciler 实现，框架会按指定间隔扫描所有 `cert_issued` 行；对每个 `expires_at < now + 30d` 的非终态证书，框架调我的 `Reconcile(ctx, Request{EntityID: certID})`；我返回 `Result{RequeueAfter: nextWindow}` 或 `error` 让框架决定重试。我**不**需要自己写定时器、不需要自己管退避、不需要自己跑 leader election；但我**必须**保证 `Reconcile` 幂等——leader election 不是 fencing 保证，跨副本残余并发由框架 epoch fencing CAS + 我的幂等兜底（见 ADR §4.3/§4.4）。
 
 **Why this priority**: 证书过期等同生产中断。L4 收敛是 winmdm 上线的必要前提，pkicell 是最先落地的消费方。
 
@@ -53,7 +53,7 @@
 **Actor**: `mdmcell.command` slice 维护者（winmdm Stage 2, 2027 Q2-Q3）
 
 **Plain Language**:
-作为 `mdmcell.command` 的维护者，我希望声明一个 reconciler，扫描所有 Status ∈ {Pending, Sent} 且 `now > sentAt + SendToCompleteTimeout` 的命令；reconciler 触发重发逻辑。多副本部署时，**框架保证单实例扫描**，避免重复发命令到设备。
+作为 `mdmcell.command` 的维护者，我希望声明一个 reconciler，扫描所有 Status ∈ {Pending, Sent} 且 `now > sentAt + SendToCompleteTimeout` 的命令；reconciler 触发重发逻辑。多副本部署时，框架用 leader election（best-effort 收窄）+ epoch fencing CAS（结构兜底）+ reconciler 幂等，把重复命令收敛到 at-most-once-effective；**leader election 本身不是 fencing 保证**（client-go 明示「does not guarantee that only one client is acting as a leader」，见 ADR §4）。
 
 **Why this priority**: 命令丢失会直接影响 MDM 的 SLO（device 收到管理命令的成功率）。leader-elect 是 hard 依赖。
 
@@ -61,8 +61,9 @@
 
 **Acceptance Scenarios**:
 1. **Given** 两个 reconciler 实例 + 同一 reconciler ID，**When** 同时 Start，**Then** 只有获得 lease 的实例调用 Reconcile，另一个 `awaitProbe` 等待
-2. **Given** leader 实例进程崩溃，**When** LeaseDuration（默认 15s）后，**Then** follower 接管，扫描周期对齐 LeaseDuration（不并发也不长期空窗）
-3. **Given** leader 释放 lease（graceful shutdown），**When** stop 完成，**Then** follower 即时接管（< 1s），无空窗
+2. **Given** leader 实例进程崩溃，**When** LeaseDuration（默认 15s）后，**Then** follower 接管，扫描周期对齐 LeaseDuration（接管后单 leader 稳态；流转瞬间的残余并发由 epoch fencing + 幂等兜底，**不**声称零并发）
+3. **Given** leader 释放 lease（graceful shutdown），**When** stop 完成，**Then** follower 即时接管（< 1s），无长期空窗
+4. **Given** 旧 leader L1 在 `Reconcile(X)` 中途 STW 暂停 + lease 过期、L2 以 `Epoch+1` 接管并写 X，**When** L1 苏醒后以旧 `Epoch` 重放写 X，**Then** 写路径 CAS 拒绝 stale-epoch 写、设备**不**收到重复命令（fencing real-failure-injection conformance）
 
 ---
 
@@ -106,7 +107,7 @@
 - **Reconcile panic**：框架 recover → 转 transient error → 走退避路径；不让单个 entity 的 panic 影响其他 entity
 - **Loop 关闭中 Reconcile 在跑**：StopTimeout 内等待，超时强制 cancel ctx；reconciler 必须响应 ctx.Done()
 - **Reconcile 阻塞超长（> 单 tick interval）**：单 entity 串行（不并发同 ID）；多 entity 按 MaxConcurrentReconciles 并发；超长被 ctx deadline 切断
-- **leader 流转期的双扫描**：lease lock 走 Redis SETNX 或 PG advisory lock，幂等保护（claim/commit/release 三阶段）
+- **leader 流转期的双扫描/双写**：lease lock（Redis SETNX / PG advisory lock）只 best-effort 收窄并发窗口——leader election **非 fencing**（client-go 明示）。正确性由 monotonic-epoch 写路径 CAS（拒 `incoming_epoch < 已见最高` 的 stale 写）+ reconciler 幂等兜底（见 ADR §4.3/§4.4）；Loop 须在 lease 丢失瞬间 cancel lease-scoped ctx 收窄窗口
 - **空非终态集合**：scan 返回 0 行 → 跳过本轮，不触发 RequeueAfter（避免无意义自循环）
 - **RequeueAfter = 0**：等价于"按 default tick interval"重入，不立即重试
 - **死信 entity 复活**：reconciler 内部可重置状态把 PermanentError 实体重新激活，由消费方负责（框架不提供 unmark API）
@@ -127,7 +128,9 @@
 
 **FR-005 (Trigger 抽象)**: 框架 MUST 提供 `Trigger` 接口（替代 controller-runtime `Source`），最小实现 `TickerTrigger(interval time.Duration)`；选配 `ChannelTrigger(<-chan Request)` 用于 outbox 事件唤醒。
 
-**FR-006 (LeaderElector 接口)**: 框架 MUST 提供 `LeaderElector` 接口（`AcquireLease(ctx, reconcilerID) (LeaseToken, error)` + `ReleaseLease(ctx, LeaseToken) error` + `RenewLease(ctx, LeaseToken) error`）；adapters/ 层提供 Redis 与 PG advisory lock 两个实现。
+**FR-006 (LeaderElector 接口)**: 框架 MUST 提供 `LeaderElector` 接口（`AcquireLease(ctx, reconcilerID) (LeaseToken, error)` + `ReleaseLease(ctx, LeaseToken) error` + `RenewLease(ctx, LeaseToken) error`）；adapters/ 层提供 Redis 与 PG advisory lock 两个实现。leader election **非 fencing 保证**（client-go 明示），故：`LeaseToken` MUST 携带**单调 fencing token** `Epoch uint64`（每次换持有者 +1，RenewLease 保持不变）；`Loop` MUST 从 lease 派生 lease-scoped ctx、在 lease 丢失瞬间 cancel 中断 in-flight Reconcile。
+
+**FR-006b (FencedRepository 写路径 CAS)**: 框架 MUST 提供 `FencedRepository`/`FencedWriter` seam——`Loop` 给每次 `Reconcile` 注入 epoch-bound 写句柄，reconciler 唯一写面经此 handle，写路径 CAS 拒绝 `incoming_epoch < 资源已见最高 epoch` 的 stale 写（Kleppmann monotonic fencing，**非** `kernel/outbox` 的 UUID identity-fencing）。绕过在 type system 不可表达（上游 Hard = 唯一写面 + sealed 构造；下游 Hard = `RECONCILE-FENCED-WRITE-FUNNEL-01` callsite）。受 §6 trigger gate 封存（A6 设计，不今天建）。
 
 **FR-007 (并发度控制)**: 框架 MUST 支持 `MaxConcurrentReconciles int` 选项；同一 EntityID 串行（防止重入），不同 EntityID 按上限并发。default = 1。
 
@@ -145,7 +148,7 @@
 
 **FR-012 (archtest 守卫)**: 框架的接口冻结 MUST 走 archtest（接口签名 + Result/Request 字段集 frozen + Loop carve-out 等同 `PROD-CLOCK-INJECTION-01`）；`COMMAND-PROJECTION-EXPLICIT-01` MUST 同步扩 kind 枚举。
 
-**FR-013 (conformance harness)**: 框架 MUST 提供 `reconciletest.ConformanceFactory` 复用 `kernel/command/commandtest.QueueFactory` 形态，让消费方一次跑过所有契约（leader 流转 / RequeueAfter / PermanentError / panic recovery）。
+**FR-013 (conformance harness)**: 框架 MUST 提供 `reconciletest.ConformanceFactory` 复用 `kernel/command/commandtest.QueueFactory` 形态，让消费方一次跑过所有契约（leader 流转 / RequeueAfter / PermanentError / panic recovery / **fencing：stale-epoch 写被 CAS 拒、无重复命令**，real-failure-injection）。
 
 ### Key Entities
 
@@ -154,7 +157,8 @@
 - **Result**: reconciler 返回给框架的调度提示；仅包含 RequeueAfter time.Duration（不带 Requeue bool 或 Priority）
 - **Loop**: 框架的调度环；持有 reconciler + trigger + leader + backoff 配置；生命周期挂在 cell registrar
 - **Trigger**: 触发源；最小实现 TickerTrigger；选配 ChannelTrigger
-- **LeaderElector**: 单实例保证接口；adapter 层有 Redis / PG advisory lock 实现
+- **LeaderElector**: best-effort 单 leader 选举接口（**非 fencing**，含单调 `Epoch` token）；adapter 层有 Redis / PG advisory lock 实现
+- **FencedWriter**: epoch-bound 写句柄；reconciler 唯一写面，写路径 CAS 拒 stale-epoch（跨副本正确性闭环，见 ADR §4.3）
 - **PermanentError**: 错误 marker，告诉框架"不要重试，记录到死信 metric"
 
 ---

--- a/docs/plans/specs/202605262359-661-kernel-reconcile-tasks.md
+++ b/docs/plans/specs/202605262359-661-kernel-reconcile-tasks.md
@@ -194,7 +194,7 @@
   - 估算：200 LoC
 - [ ] **T18** [P] [PR-A5] `kernel/reconcile/recovery_test.go`：
   - `TestRecovery_PanicConvertsToError`：reconciler panic 被 catch + 转 error
-  - `TestRecovery_PanicMetricRecorded`：panic 计入 reconcile_total{result="panic"}
+  - `TestRecovery_PanicMetricRecorded`：recovered panic 计入 reconcile_total{result="transient"}（对齐 FR-009「panic → transient error」+ FR-010 四标签集 success/transient/permanent/skipped；**不**新增 result="panic" 第 5 标签）
   - `TestRecovery_OtherEntityNotAffected`：单 entity panic 不影响其他 entity 串行处理
   - 估算：250 LoC
 
@@ -215,11 +215,11 @@
 
 ## Phase 4: Leader Election（B5）
 
-### PR-A6 — feat: LeaderElector interface + Redis 实现 + PG advisory lock 实现 + archtest frozen
+### PR-A6 — feat: LeaderElector + epoch fencing（FencedWriter）+ Redis/PG 实现 + archtest frozen
 
-**Goal**: 在 kernel/ 声明接口；adapters/{redis,postgres} 各提供一个实现；接口字段 frozen。
+**Goal**: 在 kernel/ 声明 `LeaderElector` 接口（含单调 `Epoch` fencing token）+ `FencedRepository`/`FencedWriter` seam；adapters/{redis,postgres} 各提供一个 leader 实现；接口字段 frozen。**leader election 非 fencing**（client-go 明示），跨副本正确性靠 epoch 写路径 CAS + 消费方幂等（见 ADR §4.3/§4.4），不靠 lease 本身。
 
-**Independent Test**: 在 fake adapter 实现 LeaderElector：两个 Loop 实例并起，验证只一个调 Reconcile；leader 实例 ctx cancel 后 follower 在 LeaseDuration + 1s 内接管。
+**Independent Test**: 在 fake adapter 实现 LeaderElector：两个 Loop 实例并起，**稳态下**只一个调 Reconcile；leader ctx cancel 后 follower 在 LeaseDuration + 1s 内接管。**Fencing real-failure-injection**：旧 leader 以 `Epoch=N` 的 in-flight 写在 follower 以 `Epoch=N+1` 接管后重放，断言写路径 CAS 拒绝 stale-epoch 写、设备无重复命令。
 
 #### Tests for PR-A6 (TDD)
 
@@ -240,8 +240,13 @@
 
 - [ ] **T24** [PR-A6] `kernel/reconcile/leader.go`：
   - `type LeaderElector interface { AcquireLease / ReleaseLease / RenewLease }`
-  - `type LeaseToken struct { ReconcilerID string; AcquiredAt time.Time; ExpiresAt time.Time; HolderID string }`
-  - 估算：150 LoC（接口 + 类型 + 文档）
+  - `type LeaseToken struct { ReconcilerID string; HolderID string; Epoch uint64; AcquiredAt time.Time; ExpiresAt time.Time }`（`Epoch` = 单调 fencing token，每次换持有者 +1）
+  - `Loop` 从 lease 派生 lease-scoped ctx + lease 丢失瞬间 cancel（中断 in-flight Reconcile，best-effort 收窄窗口）
+  - 估算：180 LoC（接口 + 类型 + lost-lease ctx 接缝 + 文档）
+- [ ] **T24b** [PR-A6] `kernel/reconcile/fenced.go`：`FencedRepository` / `FencedWriter` seam
+  - `Loop` 给每次 `Reconcile` 注入 epoch-bound `FencedWriter`（reconciler 唯一写面，sealed 构造）
+  - 写路径 CAS：拒 `incoming_epoch < 资源已见最高 epoch`（Kleppmann monotonic fencing，**非** outbox UUID identity-fencing）
+  - 估算：220 LoC
 - [ ] **T25** [PR-A6] `adapters/redis/reconcile_leader.go`：
   - SETNX + EXPIRE 实现 + 续约 goroutine
   - 复用 adapters/redis Cache 命名空间约定（cell-namespaced key）
@@ -251,11 +256,15 @@
   - 续约通过 transaction-scoped lock + heartbeat goroutine
   - 估算：250 LoC
 - [ ] **T27** [PR-A6] `tools/archtest/reconcile_leader_interface_frozen_test.go`：
-  - `RECONCILE-LEADER-INTERFACE-FROZEN-01`：reflect 锁 LeaderElector 三方法
+  - `RECONCILE-LEADER-INTERFACE-FROZEN-01`：reflect 锁 LeaderElector 三方法 + `LeaseToken.Epoch` 字段
   - `RECONCILE-LEADER-IMPL-FUNNEL-01`：消费方使用 LeaderElector 必经 Builder（不可裸构造 Loop）
-  - 估算：100 LoC
+  - `RECONCILE-FENCED-WRITE-FUNNEL-01`：L4 reconciler 写必经 epoch-bound `FencedWriter`（上游 Hard = 唯一写面 + sealed 构造；下游 Hard = callsite allowlist），绕过 fencing CAS 在 type system 不可表达
+  - 估算：160 LoC
+- [ ] **T27b** [PR-A6] `kernel/reconcile/reconciletest/conformance.go` 扩 fencing：
+  - `RunFencingConformance`：real-failure-injection——epoch=N 写在 epoch=N+1 接管后重放，断言 CAS 拒绝 + 无重复命令（对齐 `outboxtest` / `celltest.RunRepoReadinessConformance` 形态）
+  - 估算：120 LoC
 
-**Checkpoint A6**: leader 流转可测；2 个 adapter 通过 conformance
+**Checkpoint A6**: leader 流转可测；2 个 adapter 通过 conformance；**fencing real-failure-injection 通过**（stale-epoch 写被拒、无重复命令）；明确 leader election ≠ fencing
 
 ---
 


### PR DESCRIPTION
## Summary

Architecture Decision Record for `kernel/reconcile` — the **L4 desired-state convergence control loop**, benchmarked against Kubernetes controller-runtime. Pins the 3-piece minimal-core decision + the dropped-K8s-abstractions list so downstream PRs (A2–A10) reference a single source of truth.

**PR-A1** of the #661 plan. It is the base of a 3-PR stack (A1 ADR ← A2 interface ← A3 Loop) landed together so every ADR claim (≥80% reuse, minimal interface, panic isolation, leak-free) is backed by compiling + tested code, not speculation — per the maintainer's directive that an unverifiable design ADR is "不可证伪的推演".

## Key decisions

- **3-piece minimal core**: `Reconciler{Reconcile(ctx,Request)(Result,error)}` / `Result.RequeueAfter` / `PermanentError`.
- **Dropped K8s residue**: Informer / Predicate / Manager / Source / Builder.For·Owns·Watches / `Result.Requeue bool` / `Result.Priority *int` (≥4x API simplification vs controller-runtime).
- **§1 权限模型**: distinguishes *framework self-convergence* (ADR-041 §3.3, compile/CI-time, no host authority) from *host-cell business L4 convergence* (runtime, this ADR — the cell has write authority over its own entity table). Prevents the ADR-041 contradiction.
- **§6 ahead-of-trigger exception**: A1–A3 deliberately un-parked for design validation; A4–A10 remain `PARKED-ON-TRIGGER` (2027+ consumers).

## Test plan

- [x] ADR §0–§8 complete; §2 cites 5 reachable controller-runtime / client-go raw URLs + verbatim snippets
- [x] §1 explicitly reconciles with ADR-041 §3.3 (no contradiction)
- [x] Docs-only — `go build ./...` unaffected
- [x] Internal links (spec / related ADRs / #661 / #1162) reachable

Refs: #661
Closes #1162

ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
ref: kubernetes-sigs/controller-runtime pkg/internal/controller/controller.go
ref: kubernetes-sigs/controller-runtime pkg/builder/controller.go
ref: kubernetes/client-go util/workqueue/default_rate_limiters.go
ref: kubernetes/client-go tools/leaderelection/leaderelection.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)