### PR TITLE
feat(reconcile): Reconciler interface + Request/Result + PermanentError + frozen archtest [#661 PR-A2]

### DIFF
--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -1,7 +1,12 @@
-// Package reconcile is GoCell's L4 desired-state convergence harness: a
+// Package reconcile is GoCell's L4 desired-state convergence harness, a
 // level-triggered control loop modeled on Kubernetes controller-runtime's
-// Reconciler, reduced to a three-piece minimal core plus a scheduling Loop
-// transplanted from runtime/command.SweeperLifecycle.
+// Reconciler. It is delivered across stacked PRs: PR-A2 lands the minimal core
+// documented below (the Reconciler interface, Request / Result, and the
+// PermanentError classifier); the scheduling Loop — transplanted from
+// runtime/command.SweeperLifecycle — lands in PR-A3 and is NOT present at this
+// commit. Comments here describe how each type is consumed by that Loop to pin
+// its contract; any Loop runtime behavior they mention refers to the PR-A3
+// component, not to anything in this commit.
 //
 // # When to use
 //
@@ -13,15 +18,15 @@
 // #1079). See the design ADR for the boundary.
 //
 // The convergence authority is the consuming cell's, not the framework's: the
-// framework provides this Loop harness; the cell exercises write authority over
-// its own entity table inside Reconcile. This is distinct from GoCell's own
-// compile/CI-time self-convergence (ADR 202605041430 §3.3), which this package
-// does not touch.
+// framework provides the Loop harness (PR-A3); the cell exercises write
+// authority over its own entity table inside Reconcile. This is distinct from
+// GoCell's own compile/CI-time self-convergence (ADR 202605041430 §3.3), which
+// this package does not touch.
 //
 // # Three-piece minimal core
 //
-// A consumer implements Reconciler and wires a Loop. The whole public surface a
-// consumer must learn is:
+// A consumer implements Reconciler and, once PR-A3 lands, wires a Loop. The
+// whole public surface a consumer must learn at PR-A2 is:
 //
 //	Reconciler  — Reconcile(ctx, Request) (Result, error)
 //	Request     — { EntityID string }

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -58,15 +58,21 @@
 //
 // # Enforced invariants (tools/archtest)
 //
-//   - RECONCILE-INTERFACE-FROZEN-01: Reconciler's method set is exactly
+// Each invariant is tagged with the stacked PR that delivers it (A1←A2←A3 merge
+// independently; an invariant is CI-enforced for this package only once its
+// delivering PR is on develop):
+//
+//   - RECONCILE-INTERFACE-FROZEN-01 (PR-A2): Reconciler's method set is exactly
 //     Reconcile(context.Context, Request) (Result, error).
-//   - RECONCILE-REQUEST-FIELDS-FROZEN-01: Request's field set is exactly
+//   - RECONCILE-REQUEST-FIELDS-FROZEN-01 (PR-A2): Request's field set is exactly
 //     { EntityID string }.
-//   - RECONCILE-RESULT-FIELDS-FROZEN-01: Result's field set is exactly
+//   - RECONCILE-RESULT-FIELDS-FROZEN-01 (PR-A2): Result's field set is exactly
 //     { RequeueAfter time.Duration } (no Requeue bool / Priority int).
-//   - PROD-CLOCK-INJECTION-01: the Loop's control-plane ticker / probe timers
-//     are confined to the sealed controlPlaneClock type; kernel/reconcile is a
-//     sanctioned control-plane host alongside runtime/command.
+//   - PROD-CLOCK-INJECTION-01 (PR-A3): the Loop's control-plane ticker / probe
+//     timers are confined to the sealed controlPlaneClock type; kernel/reconcile
+//     becomes a sanctioned control-plane host (alongside runtime/command) when
+//     the Loop + clock carve-out land in PR-A3 — it is NOT yet enforced for this
+//     package at the PR-A2 commit.
 //
 // ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
 // ref: docs/architecture/202605291600-661-adr-kernel-reconcile-design.md

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -1,0 +1,73 @@
+// Package reconcile is GoCell's L4 desired-state convergence harness: a
+// level-triggered control loop modeled on Kubernetes controller-runtime's
+// Reconciler, reduced to a three-piece minimal core plus a scheduling Loop
+// transplanted from runtime/command.SweeperLifecycle.
+//
+// # When to use
+//
+// reconcile is for L4 DeviceLatent convergence — periodically observing a set
+// of non-terminal entities a cell OWNS (device commands, certificate rows,
+// trust scores in the cell's own persistence) and driving each toward its
+// desired state. It is deliberately NOT a business orchestrator (that is saga,
+// #969) and NOT a CQRS read-model builder (that is the projection harness,
+// #1079). See the design ADR for the boundary.
+//
+// The convergence authority is the consuming cell's, not the framework's: the
+// framework provides this Loop harness; the cell exercises write authority over
+// its own entity table inside Reconcile. This is distinct from GoCell's own
+// compile/CI-time self-convergence (ADR 202605041430 §3.3), which this package
+// does not touch.
+//
+// # Three-piece minimal core
+//
+// A consumer implements Reconciler and wires a Loop. The whole public surface a
+// consumer must learn is:
+//
+//	Reconciler  — Reconcile(ctx, Request) (Result, error)
+//	Request     — { EntityID string }
+//	Result      — { RequeueAfter time.Duration }
+//	PermanentError / IsPermanent — non-retryable error classification
+//
+// controller-runtime abstractions deliberately dropped: Informer / CRD watch,
+// Predicate, Manager, Source, Builder.For·Owns·Watches, Result.Requeue (bool),
+// Result.Priority. GoCell entities live in a cell-local table addressed by a
+// single opaque EntityID — there is no namespace dimension and no K8s control
+// plane to watch.
+//
+// # Reconciler implementation pattern
+//
+//	type certRenewer struct{ repo CertRepo }
+//
+//	func (r *certRenewer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+//		cert, err := r.repo.Get(ctx, req.EntityID)
+//		if err != nil {
+//			return reconcile.Result{}, err // transient: Loop backs off + retries
+//		}
+//		if cert.Revoked {
+//			// Nothing more to do, and retrying cannot help → do not retry.
+//			return reconcile.Result{}, reconcile.PermanentError(errors.New("cert revoked"))
+//		}
+//		if cert.ExpiresAt.After(r.now().Add(30 * 24 * time.Hour)) {
+//			return reconcile.Result{RequeueAfter: time.Hour}, nil // healthy: re-check later
+//		}
+//		if err := r.repo.Renew(ctx, cert); err != nil {
+//			return reconcile.Result{}, err
+//		}
+//		return reconcile.Result{RequeueAfter: time.Hour}, nil
+//	}
+//
+// # Enforced invariants (tools/archtest)
+//
+//   - RECONCILE-INTERFACE-FROZEN-01: Reconciler's method set is exactly
+//     Reconcile(context.Context, Request) (Result, error).
+//   - RECONCILE-REQUEST-FIELDS-FROZEN-01: Request's field set is exactly
+//     { EntityID string }.
+//   - RECONCILE-RESULT-FIELDS-FROZEN-01: Result's field set is exactly
+//     { RequeueAfter time.Duration } (no Requeue bool / Priority int).
+//   - PROD-CLOCK-INJECTION-01: the Loop's control-plane ticker / probe timers
+//     are confined to the sealed controlPlaneClock type; kernel/reconcile is a
+//     sanctioned control-plane host alongside runtime/command.
+//
+// ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
+// ref: docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+package reconcile

--- a/kernel/reconcile/permanent_spoof_external_test.go
+++ b/kernel/reconcile/permanent_spoof_external_test.go
@@ -1,0 +1,91 @@
+package reconcile_test
+
+// Adversarial regression guard for the PermanentError seal, run from an EXTERNAL
+// package. package reconcile_test can reach the unexported *permanentError only
+// via reflect — exactly the forgery model under threat. All foreign-hook and
+// reflect-forgery vectors MUST classify NOT-permanent; only a genuinely-
+// constructed marker (and errors that structurally wrap one) may be permanent.
+// See reconcile.IsPermanent's godoc for why the non-nil err field is the
+// construction proof.
+//
+// This is the non-vacuous reverse self-check for the seal (AI-robust): it FAILS
+// against errors.As (vector as-returns-true), against errors.As && pe!=nil
+// (as-reflect-set + unwrap-forged), and against a plain type-walk with no
+// construction proof (unwrap-forged). Only the construction-proof walk passes.
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/reconcile"
+)
+
+// permanentErrorStructType recovers the unexported permanentError STRUCT type
+// from the public constructor's return value (*permanentError → Elem()).
+func permanentErrorStructType() reflect.Type {
+	return reflect.TypeOf(reconcile.PermanentError(errors.New("seed"))).Elem()
+}
+
+// asReturnsTrue: As(any) bool returns true without setting target.
+type asReturnsTrue struct{}
+
+func (asReturnsTrue) Error() string { return "as-returns-true" }
+func (asReturnsTrue) As(any) bool   { return true }
+
+// asReflectSetsForged: As uses reflect to set the unexported target to a forged
+// (zero-value, nil-cause) *permanentError.
+type asReflectSetsForged struct{}
+
+func (asReflectSetsForged) Error() string { return "as-reflect-set" }
+func (asReflectSetsForged) As(target any) bool {
+	rv := reflect.ValueOf(target)
+	if rv.Kind() != reflect.Pointer {
+		return false
+	}
+	slot := rv.Elem() // *permanentError, settable
+	if slot.Kind() != reflect.Pointer || !slot.CanSet() {
+		return false
+	}
+	slot.Set(reflect.New(slot.Type().Elem())) // &permanentError{} (err == nil)
+	return true
+}
+
+// unwrapForged: Unwrap returns a reflect-forged (nil-cause) *permanentError —
+// defeats any chain-walk that matches type without a construction proof.
+type unwrapForged struct{}
+
+func (unwrapForged) Error() string { return "unwrap-forged" }
+func (unwrapForged) Unwrap() error {
+	return reflect.New(permanentErrorStructType()).Interface().(error) // &permanentError{} (err == nil)
+}
+
+func TestIsPermanent_ExternalForgeryMatrix(t *testing.T) {
+	t.Parallel()
+	genuine := reconcile.PermanentError(errors.New("revoked"))
+
+	permanent := map[string]error{
+		"genuine":            genuine,
+		"wrapped-genuine-%w": fmt.Errorf("ctx: %w", genuine),
+		"join-with-genuine":  errors.Join(errors.New("transient"), genuine),
+	}
+	for name, err := range permanent {
+		if !reconcile.IsPermanent(err) {
+			t.Errorf("IsPermanent(%s) = false, want true — a genuine marker is structurally present", name)
+		}
+	}
+
+	notPermanent := map[string]error{
+		"transient":              errors.New("plain"),
+		"join-all-transient":     errors.Join(errors.New("a"), errors.New("b")),
+		"as-returns-true":        asReturnsTrue{},
+		"as-reflect-sets-forged": asReflectSetsForged{},
+		"unwrap-forged":          unwrapForged{},
+	}
+	for name, err := range notPermanent {
+		if reconcile.IsPermanent(err) {
+			t.Errorf("IsPermanent(%s) = true, want false — foreign hooks and reflect-forged markers must not classify permanent", name)
+		}
+	}
+}

--- a/kernel/reconcile/reconciler.go
+++ b/kernel/reconcile/reconciler.go
@@ -1,0 +1,45 @@
+package reconcile
+
+import "context"
+
+// Reconciler is the single method a consumer implements to converge ONE entity
+// toward its desired state. The Loop calls it once per scheduled Request.
+//
+// Contract:
+//   - Return (Result{RequeueAfter: d>0}, nil) to re-observe this entity after d.
+//   - Return (Result{}, nil) (RequeueAfter == 0) to re-observe at the default
+//     tick interval.
+//   - Return (Result{}, err) with a transient err to have the Loop back off and
+//     retry (Result is ignored when err != nil).
+//   - Return (Result{}, PermanentError(err)) when retrying cannot help; the
+//     Loop records a dead-letter metric and stops scheduling this entity until a
+//     fresh trigger re-observes it.
+//
+// Reconcile MUST be idempotent (level-triggered: it may be called again before
+// any state changed) and MUST honor ctx cancellation (the Loop cancels ctx on
+// shutdown / StopTimeout).
+//
+// INVARIANT: RECONCILE-INTERFACE-FROZEN-01 — the method set is frozen to exactly
+// Reconcile(context.Context, Request) (Result, error). Adding a method, or
+// changing this signature, trips an exact-set reflect assertion in CI; it is a
+// public-contract change that must be made together with the design ADR.
+//
+// ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go (Reconciler)
+type Reconciler interface {
+	Reconcile(ctx context.Context, req Request) (Result, error)
+}
+
+// Request is the minimal locator the Loop hands a Reconciler. Unlike
+// controller-runtime's reconcile.Request (which carries a types.NamespacedName),
+// a GoCell entity lives in a single cell-local table and is addressed by one
+// opaque EntityID — there is no namespace dimension.
+//
+// INVARIANT: RECONCILE-REQUEST-FIELDS-FROZEN-01 — the field set is frozen to
+// exactly { EntityID string }. Adding a field (e.g. a Namespace or Priority)
+// trips an exact-set reflect assertion in CI.
+type Request struct {
+	// EntityID identifies the single entity to reconcile. It is opaque to the
+	// Loop and meaningful only to the Reconciler (typically a primary key in the
+	// cell's own table).
+	EntityID string
+}

--- a/kernel/reconcile/reconciler.go
+++ b/kernel/reconcile/reconciler.go
@@ -11,9 +11,9 @@ import "context"
 //     tick interval.
 //   - Return (Result{}, err) with a transient err to have the Loop back off and
 //     retry (Result is ignored when err != nil).
-//   - Return (Result{}, PermanentError(err)) when retrying cannot help; the
-//     Loop records a dead-letter metric and stops scheduling this entity until a
-//     fresh trigger re-observes it.
+//   - Return (Result{}, PermanentError(err)) when retrying cannot help; once the
+//     Loop lands (PR-A3) it records a dead-letter metric and stops scheduling
+//     this entity until a fresh trigger re-observes it.
 //
 // Reconcile MUST be idempotent (level-triggered: it may be called again before
 // any state changed) and MUST honor ctx cancellation (the Loop cancels ctx on

--- a/kernel/reconcile/reconciler_test.go
+++ b/kernel/reconcile/reconciler_test.go
@@ -1,0 +1,65 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// reconcilerSampleRequeue is a representative RequeueAfter value for the
+// interface-shape tests (TEST-TIME-LITERAL-01: extracted to a package-level const).
+const reconcilerSampleRequeue = 5 * time.Second
+
+// TestRequest_EntityIDOnly asserts Request carries exactly the EntityID locator
+// and nothing else is needed to construct it (the minimal-core promise: no
+// NamespacedName, no priority).
+func TestRequest_EntityIDOnly(t *testing.T) {
+	t.Parallel()
+	r := Request{EntityID: "entity-1"}
+	if r.EntityID != "entity-1" {
+		t.Fatalf("Request.EntityID = %q, want %q", r.EntityID, "entity-1")
+	}
+}
+
+// TestResult_ZeroValueIsDefaultTick documents the FR-002 zero-value semantic:
+// a Result{} (RequeueAfter == 0) means "requeue at the default tick interval",
+// not "do not requeue". The Loop reads RequeueAfter == 0 as default-tick.
+func TestResult_ZeroValueIsDefaultTick(t *testing.T) {
+	t.Parallel()
+	var res Result
+	if res.RequeueAfter != 0 {
+		t.Fatalf("zero Result.RequeueAfter = %v, want 0 (== default tick)", res.RequeueAfter)
+	}
+}
+
+// fakeReconciler is an out-of-shape consumer implementation proving the
+// interface is satisfiable by an arbitrary external type (the SC-001
+// minimal-interface promise).
+type fakeReconciler struct {
+	calls int
+	res   Result
+	err   error
+}
+
+func (f *fakeReconciler) Reconcile(_ context.Context, _ Request) (Result, error) {
+	f.calls++
+	return f.res, f.err
+}
+
+// Compile-time proof the minimal interface is satisfiable.
+var _ Reconciler = (*fakeReconciler)(nil)
+
+// TestReconciler_InterfaceSatisfiable exercises the interface through the
+// Reconciler abstraction (not the concrete type) to lock the call shape
+// Reconcile(ctx, Request) (Result, error).
+func TestReconciler_InterfaceSatisfiable(t *testing.T) {
+	t.Parallel()
+	var r Reconciler = &fakeReconciler{res: Result{RequeueAfter: reconcilerSampleRequeue}}
+	got, err := r.Reconcile(context.Background(), Request{EntityID: "x"})
+	if err != nil {
+		t.Fatalf("Reconcile err = %v, want nil", err)
+	}
+	if got.RequeueAfter != reconcilerSampleRequeue {
+		t.Fatalf("Result.RequeueAfter = %v, want %v", got.RequeueAfter, reconcilerSampleRequeue)
+	}
+}

--- a/kernel/reconcile/result.go
+++ b/kernel/reconcile/result.go
@@ -1,9 +1,6 @@
 package reconcile
 
-import (
-	"errors"
-	"time"
-)
+import "time"
 
 // Result is the scheduling hint a Reconciler returns to the Loop. Unlike
 // controller-runtime's reconcile.Result { Requeue bool; RequeueAfter Duration },
@@ -34,13 +31,25 @@ func (r Result) normalizedRequeueAfter() time.Duration {
 	return r.RequeueAfter
 }
 
-// permanentError is the sealed marker wrapping a non-retryable error. It is
-// unexported on purpose: PermanentError is the only constructor and IsPermanent
-// is the only classifier, so "a permanent error that did not pass through
-// PermanentError" is unrepresentable outside this package (typed-marker funnel,
-// not a string/sentinel compare). This intentionally does NOT reuse
-// kernel/outbox.PermanentError: reconcile must not couple to the outbox domain
-// (and outbox already keeps its marker exported for its own broker semantics).
+// permanentError is the sealed marker wrapping a non-retryable error. The seal
+// has two layers, because in Go type identity alone is NOT proof of
+// construction: reflect.New can instantiate this unexported type (its
+// reflect.Type is reachable via the public constructor's return value) and
+// inject it through a foreign As hook or Unwrap. So:
+//
+//  1. The type is unexported — no package-external struct literal.
+//  2. The non-nil err field is a construction proof — reflect cannot set an
+//     unexported field (reflect.Value.CanSet is false), and PermanentError(nil)
+//     returns nil, so a genuine marker ALWAYS has a non-nil cause while any
+//     reflect-forged value has a nil one.
+//
+// IsPermanent matches only a *permanentError WITH a non-nil err and never
+// consults a foreign As/Is hook, so within Go's type system a permanent
+// classification cannot be reached without passing through PermanentError.
+//
+// This intentionally does NOT reuse kernel/outbox.PermanentError: reconcile
+// must not couple to the outbox domain (and outbox already keeps its marker
+// exported for its own broker semantics).
 type permanentError struct {
 	err error
 }
@@ -59,7 +68,8 @@ func (e *permanentError) Unwrap() error {
 // change the outcome (revoked cert, malformed row, policy rejection). Once the
 // Loop lands (PR-A3) it records a dead-letter metric and stops scheduling the
 // entity until a fresh trigger re-observes it. PermanentError(nil) returns nil
-// (no spurious wrapper).
+// (no spurious wrapper) — this nil-guard is load-bearing for IsPermanent's
+// construction proof: a genuine permanentError always has a non-nil cause.
 func PermanentError(err error) error {
 	if err == nil {
 		return nil
@@ -67,19 +77,36 @@ func PermanentError(err error) error {
 	return &permanentError{err: err}
 }
 
-// IsPermanent reports whether err, or any error it wraps, is the sealed
-// permanentError marker created by PermanentError. It sees through fmt.Errorf
-// %w chains and errors.Join multi-error trees.
+// IsPermanent reports whether err, or any error it structurally wraps, is a
+// genuinely-constructed permanentError. It walks the unwrap tree itself —
+// single (Unwrap() error) and multi (Unwrap() []error, e.g. errors.Join) — so
+// it sees through fmt.Errorf %w chains.
 //
-// The pe != nil guard is load-bearing for the seal (see permanentError's
-// godoc), NOT a redundant check: errors.As also reports a match when a foreign
-// error's As(any) bool hook merely returns true, but such a hook cannot set pe
-// to a non-nil *permanentError — the type is unexported and no exported
-// function returns it — so a foreign error cannot spoof the classification. pe
-// is non-nil only when a genuine marker that passed through PermanentError is
-// found in the tree, which is what keeps "permanent" unrepresentable outside
-// this package.
+// It deliberately does NOT use errors.As. errors.As honors a foreign error's
+// As(any) bool hook, which a foreign error can use (directly, or via reflect to
+// set the unexported target) to report permanent without passing through
+// PermanentError; this walk never consults that hook. Matching the
+// *permanentError type is necessary but not sufficient — reflect can forge the
+// unexported type and inject it via a foreign Unwrap — so the err != nil check
+// is the construction proof (see permanentError's godoc).
 func IsPermanent(err error) bool {
-	var pe *permanentError
-	return errors.As(err, &pe) && pe != nil
+	for {
+		switch x := err.(type) { //nolint:errorlint // concrete-type walk by design; see IsPermanent godoc
+		case nil:
+			return false
+		case *permanentError:
+			return x.err != nil // construction proof: reflect-forged zero value has a nil cause
+		case interface{ Unwrap() error }:
+			err = x.Unwrap()
+		case interface{ Unwrap() []error }:
+			for _, e := range x.Unwrap() {
+				if IsPermanent(e) {
+					return true
+				}
+			}
+			return false
+		default:
+			return false
+		}
+	}
 }

--- a/kernel/reconcile/result.go
+++ b/kernel/reconcile/result.go
@@ -55,9 +55,9 @@ func (e *permanentError) Unwrap() error {
 	return e.err
 }
 
-// PermanentError wraps err to tell the Loop the entity must NOT be retried:
-// retrying cannot change the outcome (revoked cert, malformed row, policy
-// rejection). The Loop records a dead-letter metric and stops scheduling the
+// PermanentError wraps err to mark the entity non-retryable: retrying cannot
+// change the outcome (revoked cert, malformed row, policy rejection). Once the
+// Loop lands (PR-A3) it records a dead-letter metric and stops scheduling the
 // entity until a fresh trigger re-observes it. PermanentError(nil) returns nil
 // (no spurious wrapper).
 func PermanentError(err error) error {
@@ -67,9 +67,19 @@ func PermanentError(err error) error {
 	return &permanentError{err: err}
 }
 
-// IsPermanent reports whether err, or any error it wraps, was marked by
-// PermanentError. It sees through fmt.Errorf %w chains.
+// IsPermanent reports whether err, or any error it wraps, is the sealed
+// permanentError marker created by PermanentError. It sees through fmt.Errorf
+// %w chains and errors.Join multi-error trees.
+//
+// The pe != nil guard is load-bearing for the seal (see permanentError's
+// godoc), NOT a redundant check: errors.As also reports a match when a foreign
+// error's As(any) bool hook merely returns true, but such a hook cannot set pe
+// to a non-nil *permanentError — the type is unexported and no exported
+// function returns it — so a foreign error cannot spoof the classification. pe
+// is non-nil only when a genuine marker that passed through PermanentError is
+// found in the tree, which is what keeps "permanent" unrepresentable outside
+// this package.
 func IsPermanent(err error) bool {
 	var pe *permanentError
-	return errors.As(err, &pe)
+	return errors.As(err, &pe) && pe != nil
 }

--- a/kernel/reconcile/result.go
+++ b/kernel/reconcile/result.go
@@ -1,0 +1,75 @@
+package reconcile
+
+import (
+	"errors"
+	"time"
+)
+
+// Result is the scheduling hint a Reconciler returns to the Loop. Unlike
+// controller-runtime's reconcile.Result { Requeue bool; RequeueAfter Duration },
+// GoCell carries only RequeueAfter: "requeue immediately / at the default tick"
+// is expressed as RequeueAfter == 0, so the Requeue bool is redundant and
+// dropped. There is no Priority dimension.
+//
+// INVARIANT: RECONCILE-RESULT-FIELDS-FROZEN-01 — the field set is frozen to
+// exactly { RequeueAfter time.Duration }. Re-introducing Requeue bool or a
+// Priority int (controller-runtime / K8s-scheduler residue) trips an exact-set
+// reflect assertion in CI.
+type Result struct {
+	// RequeueAfter, when > 0, asks the Loop to re-observe this entity after the
+	// given duration. When 0, the entity is re-observed at the Loop's default
+	// tick interval. It is ignored when Reconcile also returns a non-nil error
+	// (the error path drives backoff instead).
+	RequeueAfter time.Duration
+}
+
+// normalizedRequeueAfter clamps a negative RequeueAfter to 0. A negative
+// duration is a programmer error; treating it as 0 (== default tick) keeps the
+// Loop from scheduling in the past or panicking. Used by the Loop when reading a
+// Reconciler's Result.
+func (r Result) normalizedRequeueAfter() time.Duration {
+	if r.RequeueAfter < 0 {
+		return 0
+	}
+	return r.RequeueAfter
+}
+
+// permanentError is the sealed marker wrapping a non-retryable error. It is
+// unexported on purpose: PermanentError is the only constructor and IsPermanent
+// is the only classifier, so "a permanent error that did not pass through
+// PermanentError" is unrepresentable outside this package (typed-marker funnel,
+// not a string/sentinel compare). This intentionally does NOT reuse
+// kernel/outbox.PermanentError: reconcile must not couple to the outbox domain
+// (and outbox already keeps its marker exported for its own broker semantics).
+type permanentError struct {
+	err error
+}
+
+func (e *permanentError) Error() string {
+	return "permanent: " + e.err.Error()
+}
+
+// Unwrap lets errors.Is / errors.As reach the wrapped cause, so a consumer that
+// wrapped a sentinel keeps it recoverable through the permanent marker.
+func (e *permanentError) Unwrap() error {
+	return e.err
+}
+
+// PermanentError wraps err to tell the Loop the entity must NOT be retried:
+// retrying cannot change the outcome (revoked cert, malformed row, policy
+// rejection). The Loop records a dead-letter metric and stops scheduling the
+// entity until a fresh trigger re-observes it. PermanentError(nil) returns nil
+// (no spurious wrapper).
+func PermanentError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &permanentError{err: err}
+}
+
+// IsPermanent reports whether err, or any error it wraps, was marked by
+// PermanentError. It sees through fmt.Errorf %w chains.
+func IsPermanent(err error) bool {
+	var pe *permanentError
+	return errors.As(err, &pe)
+}

--- a/kernel/reconcile/result_test.go
+++ b/kernel/reconcile/result_test.go
@@ -59,6 +59,45 @@ func TestIsPermanent_SeesThroughWrapping(t *testing.T) {
 	}
 }
 
+// foreignAsSpoof is an error that never passed through PermanentError but
+// implements the errors.As As(any) bool hook to lie. It exists to prove the
+// sealed-marker funnel holds: IsPermanent must classify it as NOT permanent.
+// (A naive errors.As-based IsPermanent would be spoofed into reporting true —
+// this test is also the regression guard against reverting to errors.As.)
+type foreignAsSpoof struct{}
+
+func (foreignAsSpoof) Error() string { return "foreign spoof" }
+func (foreignAsSpoof) As(any) bool   { return true }
+
+// TestIsPermanent_RejectsForeignAsSpoof asserts a foreign error cannot spoof the
+// permanent classification via the errors.As As(any) bool hook — "permanent"
+// stays unrepresentable outside this package.
+func TestIsPermanent_RejectsForeignAsSpoof(t *testing.T) {
+	t.Parallel()
+	if IsPermanent(foreignAsSpoof{}) {
+		t.Fatal("IsPermanent must NOT be spoofable by a foreign error's As(any) bool hook; " +
+			"only errors that passed through PermanentError may classify permanent")
+	}
+	if IsPermanent(fmt.Errorf("ctx: %w", foreignAsSpoof{})) {
+		t.Fatal("IsPermanent must not be spoofed through a %w chain either")
+	}
+}
+
+// TestIsPermanent_SeesThroughJoinMultiTree asserts classification survives an
+// errors.Join multi-error tree (Unwrap() []error): if any joined cause is
+// permanent the aggregate is permanent (retrying cannot resolve the permanent
+// branch), and a join of only transient causes stays transient.
+func TestIsPermanent_SeesThroughJoinMultiTree(t *testing.T) {
+	t.Parallel()
+	pe := PermanentError(errors.New("revoked"))
+	if !IsPermanent(errors.Join(errors.New("transient"), pe)) {
+		t.Fatal("IsPermanent must see through errors.Join multi-error trees")
+	}
+	if IsPermanent(errors.Join(errors.New("a"), errors.New("b"))) {
+		t.Fatal("errors.Join of only transient errors must classify transient")
+	}
+}
+
 // TestResult_NormalizedRequeueAfter_NegativeClampedToZero asserts FR-002 /
 // SC test T03: a negative RequeueAfter (programmer error) is treated as 0
 // (== default tick) rather than panicking or scheduling in the past.

--- a/kernel/reconcile/result_test.go
+++ b/kernel/reconcile/result_test.go
@@ -1,0 +1,86 @@
+package reconcile
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// resultSampleRequeue is a representative RequeueAfter magnitude for the
+// normalization table (TEST-TIME-LITERAL-01: extracted to a package-level const).
+const resultSampleRequeue = 5 * time.Second
+
+// TestPermanentError_IsClassifiedNonRetry asserts the FR-003 happy path: an
+// error wrapped by PermanentError is classified permanent and still unwraps to
+// the original cause (so callers keep errors.Is reachability).
+func TestPermanentError_IsClassifiedNonRetry(t *testing.T) {
+	t.Parallel()
+	base := errors.New("bad payload")
+	pe := PermanentError(base)
+	if !IsPermanent(pe) {
+		t.Fatal("IsPermanent(PermanentError(...)) = false, want true")
+	}
+	if !errors.Is(pe, base) {
+		t.Fatal("PermanentError must wrap the cause (errors.Is base) so the original error is recoverable")
+	}
+}
+
+// TestPermanentError_NilPassThrough asserts PermanentError(nil) is a nil error
+// (no spurious permanent wrapper) and IsPermanent(nil) is false.
+func TestPermanentError_NilPassThrough(t *testing.T) {
+	t.Parallel()
+	if PermanentError(nil) != nil {
+		t.Fatal("PermanentError(nil) must return nil")
+	}
+	if IsPermanent(nil) {
+		t.Fatal("IsPermanent(nil) = true, want false")
+	}
+}
+
+// TestIsPermanent_TransientIsFalse asserts a plain (transient) error is NOT
+// classified permanent — the Loop must back off and retry it.
+func TestIsPermanent_TransientIsFalse(t *testing.T) {
+	t.Parallel()
+	if IsPermanent(errors.New("transient")) {
+		t.Fatal("plain error classified permanent, want transient (false)")
+	}
+}
+
+// TestIsPermanent_SeesThroughWrapping asserts classification survives
+// fmt.Errorf %w wrapping (a reconciler may add context around a permanent
+// error before returning it).
+func TestIsPermanent_SeesThroughWrapping(t *testing.T) {
+	t.Parallel()
+	pe := PermanentError(errors.New("root"))
+	wrapped := fmt.Errorf("reconcile cert-%s: %w", "abc", pe)
+	if !IsPermanent(wrapped) {
+		t.Fatal("IsPermanent must see through fmt.Errorf %w wrapping")
+	}
+}
+
+// TestResult_NormalizedRequeueAfter_NegativeClampedToZero asserts FR-002 /
+// SC test T03: a negative RequeueAfter (programmer error) is treated as 0
+// (== default tick) rather than panicking or scheduling in the past.
+func TestResult_NormalizedRequeueAfter_NegativeClampedToZero(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{"negative clamps to zero", -resultSampleRequeue, 0},
+		{"zero stays zero", 0, 0},
+		{"positive passes through", resultSampleRequeue, resultSampleRequeue},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Result{RequeueAfter: tc.in}.normalizedRequeueAfter()
+			if got != tc.want {
+				t.Fatalf("Result{RequeueAfter:%v}.normalizedRequeueAfter() = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/kernel/reconcile/result_test.go
+++ b/kernel/reconcile/result_test.go
@@ -59,44 +59,10 @@ func TestIsPermanent_SeesThroughWrapping(t *testing.T) {
 	}
 }
 
-// foreignAsSpoof is an error that never passed through PermanentError but
-// implements the errors.As As(any) bool hook to lie. It exists to prove the
-// sealed-marker funnel holds: IsPermanent must classify it as NOT permanent.
-// (A naive errors.As-based IsPermanent would be spoofed into reporting true —
-// this test is also the regression guard against reverting to errors.As.)
-type foreignAsSpoof struct{}
-
-func (foreignAsSpoof) Error() string { return "foreign spoof" }
-func (foreignAsSpoof) As(any) bool   { return true }
-
-// TestIsPermanent_RejectsForeignAsSpoof asserts a foreign error cannot spoof the
-// permanent classification via the errors.As As(any) bool hook — "permanent"
-// stays unrepresentable outside this package.
-func TestIsPermanent_RejectsForeignAsSpoof(t *testing.T) {
-	t.Parallel()
-	if IsPermanent(foreignAsSpoof{}) {
-		t.Fatal("IsPermanent must NOT be spoofable by a foreign error's As(any) bool hook; " +
-			"only errors that passed through PermanentError may classify permanent")
-	}
-	if IsPermanent(fmt.Errorf("ctx: %w", foreignAsSpoof{})) {
-		t.Fatal("IsPermanent must not be spoofed through a %w chain either")
-	}
-}
-
-// TestIsPermanent_SeesThroughJoinMultiTree asserts classification survives an
-// errors.Join multi-error tree (Unwrap() []error): if any joined cause is
-// permanent the aggregate is permanent (retrying cannot resolve the permanent
-// branch), and a join of only transient causes stays transient.
-func TestIsPermanent_SeesThroughJoinMultiTree(t *testing.T) {
-	t.Parallel()
-	pe := PermanentError(errors.New("revoked"))
-	if !IsPermanent(errors.Join(errors.New("transient"), pe)) {
-		t.Fatal("IsPermanent must see through errors.Join multi-error trees")
-	}
-	if IsPermanent(errors.Join(errors.New("a"), errors.New("b"))) {
-		t.Fatal("errors.Join of only transient errors must classify transient")
-	}
-}
+// Adversarial forgery coverage (reflect-based As / Unwrap spoofs, errors.Join
+// multi-tree) lives in the external package test permanent_spoof_external_test.go
+// (package reconcile_test), which can only reach the unexported marker via
+// reflect — the realistic adversary model.
 
 // TestResult_NormalizedRequeueAfter_NegativeClampedToZero asserts FR-002 /
 // SC test T03: a negative RequeueAfter (programmer error) is treated as 0

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -31,8 +31,10 @@ package archtest
 // below (non-vacuous proof the detectors flag malformed shapes):
 //   - Embedding: an anonymous field would smuggle a whole struct's surface past
 //     a name-keyed check → guarded explicitly (f.Anonymous → violation).
-//   - Type alias re-shape: reflect resolves to the underlying type, so the exact
-//     field/method-set check still fires.
+//   - Type alias re-shape: reflect resolves an alias to its underlying type, so
+//     an alias of the same type (type D = time.Duration) is not a re-shape and is
+//     not flagged, while a distinct named type (type D time.Duration) IS flagged
+//     — both directions proven by the alias-same-type / named-retype self-checks.
 //   - Wrong type / unexported / extra / missing field or method: covered by the
 //     exact name→type maps + NumField / NumMethod checks.
 
@@ -223,6 +225,15 @@ func TestReconcileStructShape_ReverseBlindSpot(t *testing.T) {
 		t.Errorf("RECONCILE-RESULT self-test: detector flagged a conforming Result (vacuous-pass risk): %v", v)
 	}
 
+	// Type-alias re-shape blind spot, proven non-vacuous in both directions: an
+	// alias to the SAME underlying type resolves back via reflect and must NOT be
+	// flagged (over-fire guard) ...
+	type aliasDuration = time.Duration
+	type aliasResult struct{ RequeueAfter aliasDuration }
+	if v := checkReconcileStructShape(reflect.TypeOf(aliasResult{}), reconcileResultWantFields); len(v) != 0 {
+		t.Errorf("RECONCILE-RESULT self-test: detector flagged an alias-of-same-type Result (vacuous over-fire): %v", v)
+	}
+
 	type requeueBoolResidue struct {
 		RequeueAfter time.Duration
 		Requeue      bool
@@ -241,12 +252,18 @@ func TestReconcileStructShape_ReverseBlindSpot(t *testing.T) {
 	type unexportedRequest struct{ entityID string }
 	_ = unexportedRequest{}.entityID // read the field so 'unused' is satisfied; the shape check flags its unexported visibility
 	type wrongTypeResult struct{ RequeueAfter int64 }
+	// ... while a distinct named type (NOT an alias) over the same underlying
+	// kind IS a re-shape and MUST be flagged — reflect reports its declared name,
+	// not time.Duration, so the exact-type check fires.
+	type namedDuration time.Duration
+	type namedRetypeResult struct{ RequeueAfter namedDuration }
 
 	badResult := map[string]reflect.Type{
 		"requeue-bool-residue": reflect.TypeOf(requeueBoolResidue{}),
 		"priority-residue":     reflect.TypeOf(priorityResidue{}),
 		"embedded-field":       reflect.TypeOf(embeddedResult{}),
 		"wrong-type":           reflect.TypeOf(wrongTypeResult{}),
+		"named-retype":         reflect.TypeOf(namedRetypeResult{}),
 	}
 	for name, dt := range badResult {
 		if v := checkReconcileStructShape(dt, reconcileResultWantFields); len(v) == 0 {

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -1,0 +1,265 @@
+package archtest
+
+// reconcile_invariants_test.go locks the three-piece minimal core of
+// kernel/reconcile — the Reconciler interface method set and the Request /
+// Result field sets — via reflect golden freezes.
+//
+//   - INVARIANT: RECONCILE-INTERFACE-FROZEN-01
+//   - INVARIANT: RECONCILE-REQUEST-FIELDS-FROZEN-01
+//   - INVARIANT: RECONCILE-RESULT-FIELDS-FROZEN-01
+//
+// The design ADR (docs/architecture/202605291600-661-adr-kernel-reconcile-design.md)
+// promises a deliberately minimal public surface: a Reconciler whose only method
+// is Reconcile(ctx, Request) (Result, error), a Request that carries exactly one
+// opaque EntityID (no NamespacedName), and a Result that carries exactly one
+// RequeueAfter (no Requeue bool, no Priority int — both are controller-runtime /
+// K8s-scheduler residue GoCell drops). These reflect freezes are what make that
+// promise Hard rather than a godoc convention: any drift (added/removed/renamed/
+// retyped field, extra interface method, changed signature, embedding) trips an
+// exact-set assertion in CI.
+//
+// AI-robust rating (.claude/rules/gocell/ai-robust.md §Hard 范本目录 "codegen
+// funnel + golden" sibling = reflect field-freeze; cf. PEER-IDENTITY-FIELDS-
+// FROZEN-01 / DETAILS-SEALED-FIELD-FROZEN-01 / OUTBOX-HANDLERESULT-FIELDS-
+// FROZEN-01): Hard. A field/method-set drift is inexpressible without a
+// CI-visible failure. Scope boundary: these freeze the type SHAPE only; the
+// scheduling Loop's behavior and the PermanentError marker's seal are enforced
+// elsewhere (PROD-CLOCK-INJECTION-01 and the unexported permanentError type
+// respectively).
+//
+// Blind spots of a reflect freeze, each covered by the reverse self-checks
+// below (non-vacuous proof the detectors flag malformed shapes):
+//   - Embedding: an anonymous field would smuggle a whole struct's surface past
+//     a name-keyed check → guarded explicitly (f.Anonymous → violation).
+//   - Type alias re-shape: reflect resolves to the underlying type, so the exact
+//     field/method-set check still fires.
+//   - Wrong type / unexported / extra / missing field or method: covered by the
+//     exact name→type maps + NumField / NumMethod checks.
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/reconcile"
+)
+
+// -----------------------------------------------------------------------------
+// RECONCILE-INTERFACE-FROZEN-01 — Reconciler method set
+// -----------------------------------------------------------------------------
+
+// checkReconcilerInterface returns violation messages for it against the frozen
+// Reconciler shape (exactly one method: Reconcile(context.Context, Request)
+// (Result, error)). An empty result means it conforms. Extracted so the reverse
+// self-check can prove the detector is non-vacuous.
+func checkReconcilerInterface(it reflect.Type) []string {
+	if it == nil || it.Kind() != reflect.Interface {
+		return []string{fmt.Sprintf("Kind = %v, want interface", it)}
+	}
+	var v []string
+	if it.NumMethod() != 1 {
+		v = append(v, fmt.Sprintf("NumMethod = %d, want exactly 1 (Reconcile)", it.NumMethod()))
+	}
+	m, ok := it.MethodByName("Reconcile")
+	if !ok {
+		return append(v, "missing method Reconcile")
+	}
+	mt := m.Type // interface method Type has NO receiver
+	if mt.IsVariadic() {
+		v = append(v, "Reconcile must not be variadic")
+	}
+	wantIn := []string{"context.Context", "reconcile.Request"}
+	if mt.NumIn() != len(wantIn) {
+		v = append(v, fmt.Sprintf("Reconcile NumIn = %d, want %d", mt.NumIn(), len(wantIn)))
+	} else {
+		for i, w := range wantIn {
+			if got := mt.In(i).String(); got != w {
+				v = append(v, fmt.Sprintf("Reconcile arg %d = %q, want %q", i, got, w))
+			}
+		}
+	}
+	wantOut := []string{"reconcile.Result", "error"}
+	if mt.NumOut() != len(wantOut) {
+		v = append(v, fmt.Sprintf("Reconcile NumOut = %d, want %d", mt.NumOut(), len(wantOut)))
+	} else {
+		for i, w := range wantOut {
+			if got := mt.Out(i).String(); got != w {
+				v = append(v, fmt.Sprintf("Reconcile result %d = %q, want %q", i, got, w))
+			}
+		}
+	}
+	return v
+}
+
+func TestReconcileInterfaceFrozen01(t *testing.T) {
+	t.Parallel()
+	it := reflect.TypeOf((*reconcile.Reconciler)(nil)).Elem()
+	for _, msg := range checkReconcilerInterface(it) {
+		t.Errorf("RECONCILE-INTERFACE-FROZEN-01: %s. The Reconciler method set is frozen to "+
+			"Reconcile(ctx, Request) (Result, error); if this change is intentional, update the "+
+			"design ADR §3 and this golden in the same PR.", msg)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RECONCILE-REQUEST-FIELDS-FROZEN-01 — Request field set
+// -----------------------------------------------------------------------------
+
+var reconcileRequestWantFields = map[string]string{
+	"EntityID": "string",
+}
+
+func checkReconcileStructShape(dt reflect.Type, want map[string]string) []string {
+	if dt == nil || dt.Kind() != reflect.Struct {
+		return []string{fmt.Sprintf("Kind = %v, want struct", dt)}
+	}
+	var v []string
+	if dt.NumField() != len(want) {
+		v = append(v, fmt.Sprintf("NumField = %d, want exactly %d", dt.NumField(), len(want)))
+	}
+	for i := 0; i < dt.NumField(); i++ {
+		f := dt.Field(i)
+		if f.Anonymous {
+			v = append(v, fmt.Sprintf("field %q is embedded (embedding re-opens the frozen surface)", f.Name))
+			continue
+		}
+		if !f.IsExported() {
+			v = append(v, fmt.Sprintf("field %q is unexported (the minimal core surfaces only exported fields)", f.Name))
+		}
+		ts := f.Type.String()
+		// Explicit rejection of the controller-runtime / K8s-scheduler residue the
+		// ADR §0 lists as dropped, with a pointed message.
+		switch f.Name {
+		case "Requeue":
+			v = append(v, fmt.Sprintf("field %q (%s) is dropped K8s residue — express requeue via RequeueAfter==0", f.Name, ts))
+		case "Priority":
+			v = append(v, fmt.Sprintf("field %q (%s) is dropped K8s-scheduler residue — reconcile has no priority dimension", f.Name, ts))
+		}
+		wantType, ok := want[f.Name]
+		if !ok {
+			v = append(v, fmt.Sprintf("unexpected field %q (%s)", f.Name, ts))
+			continue
+		}
+		if ts != wantType {
+			v = append(v, fmt.Sprintf("field %q type = %q, want %q", f.Name, ts, wantType))
+		}
+	}
+	return v
+}
+
+func TestReconcileRequestFieldsFrozen01(t *testing.T) {
+	t.Parallel()
+	for _, msg := range checkReconcileStructShape(reflect.TypeOf(reconcile.Request{}), reconcileRequestWantFields) {
+		t.Errorf("RECONCILE-REQUEST-FIELDS-FROZEN-01: %s. The frozen set is %v; if intentional, "+
+			"update the design ADR §3 and this golden in the same PR.", msg, reconcileRequestWantFields)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RECONCILE-RESULT-FIELDS-FROZEN-01 — Result field set
+// -----------------------------------------------------------------------------
+
+var reconcileResultWantFields = map[string]string{
+	"RequeueAfter": "time.Duration",
+}
+
+func TestReconcileResultFieldsFrozen01(t *testing.T) {
+	t.Parallel()
+	for _, msg := range checkReconcileStructShape(reflect.TypeOf(reconcile.Result{}), reconcileResultWantFields) {
+		t.Errorf("RECONCILE-RESULT-FIELDS-FROZEN-01: %s. The frozen set is %v; if intentional, "+
+			"update the design ADR §3 and this golden in the same PR.", msg, reconcileResultWantFields)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Reverse blind-spot self-checks — prove the detectors are non-vacuous.
+// -----------------------------------------------------------------------------
+
+func TestReconcileInterfaceFrozen01_ReverseBlindSpot(t *testing.T) {
+	t.Parallel()
+
+	type good interface {
+		Reconcile(context.Context, reconcile.Request) (reconcile.Result, error)
+	}
+	if v := checkReconcilerInterface(reflect.TypeOf((*good)(nil)).Elem()); len(v) != 0 {
+		t.Errorf("RECONCILE-INTERFACE-FROZEN-01 self-test: detector flagged a conforming interface "+
+			"(vacuous-pass risk): %v", v)
+	}
+
+	type extraMethod interface {
+		Reconcile(context.Context, reconcile.Request) (reconcile.Result, error)
+		Close() error
+	}
+	type wrongArity interface {
+		Reconcile(context.Context) error
+	}
+	type wrongReturn interface {
+		Reconcile(context.Context, reconcile.Request) error
+	}
+	bad := map[string]reflect.Type{
+		"extra-method": reflect.TypeOf((*extraMethod)(nil)).Elem(),
+		"wrong-arity":  reflect.TypeOf((*wrongArity)(nil)).Elem(),
+		"wrong-return": reflect.TypeOf((*wrongReturn)(nil)).Elem(),
+	}
+	for name, it := range bad {
+		if v := checkReconcilerInterface(it); len(v) == 0 {
+			t.Errorf("RECONCILE-INTERFACE-FROZEN-01 self-test: detector passed malformed interface %q "+
+				"(blind spot): expected at least one violation", name)
+		}
+	}
+}
+
+func TestReconcileStructShape_ReverseBlindSpot(t *testing.T) {
+	t.Parallel()
+
+	type goodRequest struct{ EntityID string }
+	if v := checkReconcileStructShape(reflect.TypeOf(goodRequest{}), reconcileRequestWantFields); len(v) != 0 {
+		t.Errorf("RECONCILE-REQUEST self-test: detector flagged a conforming Request (vacuous-pass risk): %v", v)
+	}
+	type goodResult struct{ RequeueAfter time.Duration }
+	if v := checkReconcileStructShape(reflect.TypeOf(goodResult{}), reconcileResultWantFields); len(v) != 0 {
+		t.Errorf("RECONCILE-RESULT self-test: detector flagged a conforming Result (vacuous-pass risk): %v", v)
+	}
+
+	type requeueBoolResidue struct {
+		RequeueAfter time.Duration
+		Requeue      bool
+	}
+	type priorityResidue struct {
+		RequeueAfter time.Duration
+		Priority     int
+	}
+	type namespacedRequest struct {
+		EntityID  string
+		Namespace string
+	}
+	type embeddedResult struct {
+		time.Duration
+	}
+	type unexportedRequest struct{ entityID string }
+	_ = unexportedRequest{}.entityID // read the field so 'unused' is satisfied; the shape check flags its unexported visibility
+	type wrongTypeResult struct{ RequeueAfter int64 }
+
+	badResult := map[string]reflect.Type{
+		"requeue-bool-residue": reflect.TypeOf(requeueBoolResidue{}),
+		"priority-residue":     reflect.TypeOf(priorityResidue{}),
+		"embedded-field":       reflect.TypeOf(embeddedResult{}),
+		"wrong-type":           reflect.TypeOf(wrongTypeResult{}),
+	}
+	for name, dt := range badResult {
+		if v := checkReconcileStructShape(dt, reconcileResultWantFields); len(v) == 0 {
+			t.Errorf("RECONCILE-RESULT self-test: detector passed malformed Result %q (blind spot)", name)
+		}
+	}
+	badRequest := map[string]reflect.Type{
+		"extra-namespace": reflect.TypeOf(namespacedRequest{}),
+		"unexported":      reflect.TypeOf(unexportedRequest{}),
+	}
+	for name, dt := range badRequest {
+		if v := checkReconcileStructShape(dt, reconcileRequestWantFields); len(v) == 0 {
+			t.Errorf("RECONCILE-REQUEST self-test: detector passed malformed Request %q (blind spot)", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The **3-piece minimal core** of `kernel/reconcile`, validating ADR #661 §3 (see PR #1273). Stacked on PR-A1 (base `661-adr-reconcile-design`).

- `Reconciler{ Reconcile(ctx, Request) (Result, error) }`
- `Request{ EntityID string }` — drops controller-runtime's `types.NamespacedName` (cell-local entities have no namespace dimension)
- `Result{ RequeueAfter time.Duration }` — drops `Requeue bool` (express as `RequeueAfter==0`) and `Priority *int` (K8s-scheduler residue)
- sealed `PermanentError` / `IsPermanent` — reconcile-local marker (does **not** couple to `kernel/outbox.PermanentError`), semantics ≈ controller-runtime `TerminalError`

## AI-robust

3 new reflect golden archtests, **Hard** (violation inexpressible without CI failure), each with reverse blind-spot self-checks:

| Invariant | Locks |
|-----------|-------|
| `RECONCILE-INTERFACE-FROZEN-01` | Reconciler method set = exactly `Reconcile(ctx, Request) (Result, error)` |
| `RECONCILE-REQUEST-FIELDS-FROZEN-01` | Request fields = `{EntityID string}` |
| `RECONCILE-RESULT-FIELDS-FROZEN-01` | Result fields = `{RequeueAfter time.Duration}`; explicitly rejects `Requeue bool` / `Priority int` |

## Contract implementation matrix (per contract-fanout)

```
Contract: kernel/reconcile.Reconciler interface + Request/Result field sets + PermanentError marker
Change: introduce 3-piece minimal core (greenfield kernel package)
Implementations: fakeReconciler (test) — production impls land in A8 (kernel/command.Sweeper) + A9 (examples), parked
Conformance test: reconcile.Test* (reconciler_test.go / result_test.go); reconciletest.RunConformance is PR-A7 (parked)
Repro: go test ./kernel/reconcile/ && go test ./tools/archtest/ -run 'TestReconcile'
Dependent contracts (governance scan): none (greenfield; no contract.yaml — kernel library API, not a wire contract)
```

## Test plan

- [x] `go test -race ./kernel/reconcile/` — green
- [x] `go test ./tools/archtest/ -run 'TestReconcile'` — 3 frozen invariants + reverse self-checks pass
- [x] Builds in isolation (without A3's loop.go/metrics.go) — verified
- [x] `golangci-lint run` — 0 issues

Refs: #661
ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)