### PR TITLE
feat(reconcile): Loop 调度骨架(从 SweeperLifecycle 平移) + 4 metrics + clock carve-out [#661 PR-A3]

### DIFF
--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -18,9 +18,13 @@ const (
 	// defaultMaxConcurrentReconciles is the worker count when unset.
 	defaultMaxConcurrentReconciles = 1
 	defaultLoopName                = "reconcile.loop"
-	// reconcilerIDSentinel labels metrics when ReconcilerID is unset, aligning
-	// with the observability.md "_runtime"-style sentinel convention.
-	reconcilerIDSentinel = "_unknown"
+	// reconcilerIDSentinel labels metrics when ReconcilerID is unset. It reuses
+	// the observability.md "_runtime" framework/unknown-owner sentinel (same as
+	// the HTTP metrics cell label and the transplant source's cellID default) so
+	// owner-dimension filters stay consistent across metrics — e.g. a dashboard
+	// can exclude unowned series with reconciler!="_runtime" exactly as it does
+	// cell!="_runtime".
+	reconcilerIDSentinel = "_runtime"
 	// startProbeTimeout bounds how long Start waits for the worker pool to
 	// confirm it is running before returning (fast-return OnStart contract).
 	startProbeTimeout = 50 * time.Millisecond
@@ -303,25 +307,32 @@ func (l *Loop) scheduleRequeue(runCtx context.Context, req Request, after time.D
 	}()
 }
 
-// awaitProbe waits up to startProbeTimeout for the worker pool to confirm it is
-// running. Returns nil in all non-error cases (mirrors SweeperLifecycle):
+// awaitProbe waits for the worker pool to confirm it is running, returning nil
+// in all non-error cases:
+//   - owner ctx already canceled before we got here: log Warn, clear state so a
+//     later Stop is a no-op, and let the workers self-exit via runCtx.Done().
+//     Checked FIRST (before the select) so this path is deterministic — `ready`
+//     closes at worker spawn and would otherwise race the cancellation, leaving
+//     this branch ~unreachable (and untestable).
 //   - ready closed: a worker started — confirmed.
-//   - probe window elapsed: workers are running, just slow to schedule.
-//   - owner ctx canceled before either: log Warn, clear state so Stop is a no-op.
+//   - probe window elapsed: defensive fallback if a worker is slow to schedule;
+//     workers are spawned, so return anyway (fast-return OnStart contract).
 func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, ready <-chan struct{}) error {
-	probeTimer := controlPlaneClock{}.newProbeTimer(startProbeTimeout)
-	defer probeTimer.Stop()
-
-	select {
-	case <-ready:
-	case <-probeTimer.C:
-	case <-runCtx.Done():
+	if runCtx.Err() != nil {
 		l.logger().Warn("reconcile: owner ctx canceled before loop confirmed running",
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))
 		cancel()
 		l.cancel = nil
 		l.done = nil
+		return nil
+	}
+
+	probeTimer := controlPlaneClock{}.newProbeTimer(startProbeTimeout)
+	defer probeTimer.Stop()
+	select {
+	case <-ready:
+	case <-probeTimer.C:
 	}
 	return nil
 }

--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -1,0 +1,392 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/redaction"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+const (
+	// defaultReconcileInterval is the requeue delay used when a Reconciler
+	// returns Result{} (RequeueAfter == 0) or a transient error.
+	defaultReconcileInterval = 30 * time.Second
+	// defaultMaxConcurrentReconciles is the worker count when unset.
+	defaultMaxConcurrentReconciles = 1
+	defaultLoopName                = "reconcile.loop"
+	// reconcilerIDSentinel labels metrics when ReconcilerID is unset, aligning
+	// with the observability.md "_runtime"-style sentinel convention.
+	reconcilerIDSentinel = "_unknown"
+	// startProbeTimeout bounds how long Start waits for the worker pool to
+	// confirm it is running before returning (fast-return OnStart contract).
+	startProbeTimeout = 50 * time.Millisecond
+	// queueBuffer sizes the internal work queue. Source and requeue both feed
+	// it; backpressure (a full buffer) blocks the producer, never drops.
+	queueBuffer = 1024
+)
+
+// controlPlaneClock is the sealed, real-only clock for control-plane scheduling
+// in kernel/reconcile. It is an empty package-private struct: no package outside
+// kernel/reconcile can name, construct, or substitute it, so "drive the Loop's
+// probe / requeue timers, or its duration measurement, with a non-real (e.g.
+// fake) clock" is unrepresentable. Its three methods are the sole sanctioned
+// sites for stdlib time.NewTimer / time.Now in this package.
+//
+// kernel/reconcile is a sanctioned control-plane host alongside runtime/command:
+// PROD-CLOCK-INJECTION-01's path gate accepts both, and the (method, callee)
+// pairs below are registered in that archtest's exactSanctionedTimeCalls map
+// (RECONCILE-LOOP-CLOCK-CARVEOUT-01). A new method here without a matching map
+// entry — or any other time.* call in a method body — is a violation.
+//
+// Carve-out rationale (mirrors runtime/command): control-plane scheduling and
+// the framework's own duration observability must use real wall-clock time.
+// Injecting a frozen fake clock with no Advance would deadlock Start (the
+// startup probe never fires) and freeze every requeue.
+//
+// AI-robust grade: Medium (permanent ceiling). The stdlib time free functions
+// cannot be made uncallable in Go, so receiver-type confinement + (method,
+// callee) form-uniqueness is the achievable ceiling — identical to the
+// runtime/command controlPlaneClock and the SPAN-SETATTR-REDACT-01
+// package-internal axis.
+type controlPlaneClock struct{}
+
+// newProbeTimer creates a real-time timer for the startup probe window.
+func (controlPlaneClock) newProbeTimer(d time.Duration) *time.Timer {
+	return time.NewTimer(d)
+}
+
+// newRequeueTimer creates a real-time timer for a delayed requeue.
+func (controlPlaneClock) newRequeueTimer(d time.Duration) *time.Timer {
+	return time.NewTimer(d)
+}
+
+// now returns the real wall-clock time, used only to measure reconcile
+// duration for the duration histogram (framework observability, not business
+// time — Reconcilers source their own business clock).
+func (controlPlaneClock) now() time.Time {
+	return time.Now()
+}
+
+// reconcilerReadinessChecker is the optional no-side-effect readiness contract a
+// Reconciler may implement. Loop.Start invokes it before spawning workers so a
+// misconstructed reconciler fails at OnStart (bootstrap rolls back) instead of
+// erroring on every reconcile. Mirrors runtime/command.sweeperReadinessChecker.
+type reconcilerReadinessChecker interface {
+	Validate() error
+}
+
+// Loop is the reconcile scheduling environment: it pulls Requests from a Source,
+// dispatches each to the Reconciler across a bounded worker pool (serializing
+// per EntityID), and requeues per the returned Result. Its lifecycle skeleton
+// (Start fast-return + startup probe, owner-ctx derivation, graceful Stop) is
+// transplanted from runtime/command.SweeperLifecycle; the per-entity worker
+// dispatch and requeue are reconcile-specific.
+//
+// Construct via the Builder (a later PR) in production; the exported fields
+// support direct struct construction for tests and the kernel/command migration.
+//
+// Owner ctx (controller-runtime Runnable.Start semantics): Start receives the
+// long-lived owner ctx and derives the workers' runCtx from it, so assembly
+// shutdown (ownerCancel) drains the Loop even without an explicit Stop.
+//
+// Start must return promptly (spawn pool + fast probe, then return) — it is
+// usable directly as a cell.LifecycleHook.OnStart; Stop as OnStop.
+type Loop struct {
+	// Name labels logs; defaults to "reconcile.loop".
+	Name string
+	// ReconcilerID is the metric/log owner dimension; defaults to "_unknown".
+	ReconcilerID string
+	// Reconciler is the required convergence callback.
+	Reconciler Reconciler
+	// Source feeds Requests into the Loop (a Trigger produces it in a later PR;
+	// tests inject a channel directly). nil means "no external feed" — the Loop
+	// still runs and self-sustains entities already seeded via requeue.
+	Source <-chan Request
+	// Interval is the requeue delay for Result{} (RequeueAfter == 0) and
+	// transient errors; defaults to 30s.
+	Interval time.Duration
+	// MaxConcurrentReconciles bounds concurrent reconciles across distinct
+	// EntityIDs; defaults to 1. Same-EntityID reconciles are always serial.
+	MaxConcurrentReconciles int
+	// StartTimeout / StopTimeout integrate with a lifecycle hook; StopTimeout is
+	// consulted by Stop as the drain budget.
+	StartTimeout time.Duration
+	StopTimeout  time.Duration
+	Logger       *slog.Logger
+	// Metrics holds optional pre-bound instruments (nil-safe).
+	Metrics Metrics
+
+	mu       sync.Mutex
+	cancel   context.CancelFunc
+	done     chan struct{}
+	inflight sync.Map // EntityID(string) -> struct{}: same-entity serial guard
+}
+
+// Start launches the worker pool and returns once it is confirmed running.
+//
+// All stdlib time.* calls are funneled through the sealed controlPlaneClock.
+func (l *Loop) Start(ownerCtx context.Context) error {
+	if l == nil || validation.IsNilInterface(l.Reconciler) {
+		return fmt.Errorf("reconcile: Loop requires non-nil Reconciler")
+	}
+	if rc, ok := l.Reconciler.(reconcilerReadinessChecker); ok {
+		if err := rc.Validate(); err != nil {
+			return fmt.Errorf("reconcile: reconciler not ready: %w", err)
+		}
+	}
+	if err := l.Metrics.preflight(l.reconcilerID()); err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cancel != nil {
+		return nil // already started — idempotent
+	}
+
+	runCtx, cancel := context.WithCancel(ownerCtx)
+	queue := make(chan Request, queueBuffer)
+	ready := make(chan struct{})
+	var readyOnce sync.Once
+	var wg sync.WaitGroup
+
+	workers := l.maxConcurrent()
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			readyOnce.Do(func() { close(ready) }) // first worker confirms the pool is live
+			l.runWorker(runCtx, queue, &wg)
+		}()
+	}
+	if l.Source != nil {
+		wg.Add(1)
+		go l.pump(runCtx, queue, &wg)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	l.cancel = cancel
+	l.done = done
+
+	// Single-process Loop: this instance is the (only) leader. Real lease gating
+	// is the leader-election PR's concern.
+	l.Metrics.setLeader(runCtx, l.reconcilerID(), 1)
+
+	if err := l.awaitProbe(runCtx, cancel, ready); err != nil {
+		return err
+	}
+	if l.cancel != nil {
+		l.logger().Info("reconcile: loop started",
+			slog.String("loop", l.name()),
+			slog.String("reconciler", l.reconcilerID()),
+			slog.Int("workers", workers))
+	}
+	return nil
+}
+
+// pump copies Source into the internal queue until the run ctx is canceled.
+func (l *Loop) pump(runCtx context.Context, queue chan<- Request, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-runCtx.Done():
+			return
+		case req, ok := <-l.Source:
+			if !ok {
+				return // Source closed — no more external feed
+			}
+			select {
+			case queue <- req:
+			case <-runCtx.Done():
+				return
+			}
+		}
+	}
+}
+
+// runWorker pulls Requests from the queue and dispatches each until canceled.
+func (l *Loop) runWorker(runCtx context.Context, queue chan Request, wg *sync.WaitGroup) {
+	for {
+		select {
+		case <-runCtx.Done():
+			return
+		case req := <-queue:
+			l.process(runCtx, req, queue, wg)
+		}
+	}
+}
+
+// process reconciles one Request: it serializes per EntityID (dropping a
+// duplicate while one is in flight — safe under level-triggering, since the next
+// trigger / requeue re-observes), records metrics, and requeues per the result.
+func (l *Loop) process(runCtx context.Context, req Request, queue chan<- Request, wg *sync.WaitGroup) {
+	if _, busy := l.inflight.LoadOrStore(req.EntityID, struct{}{}); busy {
+		l.Metrics.recordResult(runCtx, l.reconcilerID(), resultSkipped)
+		return
+	}
+	defer l.inflight.Delete(req.EntityID)
+
+	l.Metrics.inFlightDelta(runCtx, l.reconcilerID(), 1)
+	defer l.Metrics.inFlightDelta(runCtx, l.reconcilerID(), -1)
+
+	start := controlPlaneClock{}.now()
+	res, err := l.safeReconcile(runCtx, req)
+	l.Metrics.observeDuration(runCtx, l.reconcilerID(), controlPlaneClock{}.now().Sub(start).Seconds())
+
+	switch {
+	case err == nil:
+		l.Metrics.recordResult(runCtx, l.reconcilerID(), resultSuccess)
+		l.scheduleRequeue(runCtx, req, res.normalizedRequeueAfter(), queue, wg)
+	case IsPermanent(err):
+		l.Metrics.recordResult(runCtx, l.reconcilerID(), resultPermanent)
+		l.logger().Error("reconcile: permanent error (dead-letter; not requeued)",
+			slog.String("loop", l.name()),
+			slog.String("reconciler", l.reconcilerID()),
+			slog.String("entity", req.EntityID),
+			slog.Any("error", redaction.RedactError(err)))
+		// Permanent: do NOT requeue. A fresh Source trigger re-observes it if the
+		// consumer resets the entity's state.
+	default:
+		l.Metrics.recordResult(runCtx, l.reconcilerID(), resultTransient)
+		l.logger().Error("reconcile: transient error (requeued)",
+			slog.String("loop", l.name()),
+			slog.String("reconciler", l.reconcilerID()),
+			slog.String("entity", req.EntityID),
+			slog.Any("error", redaction.RedactError(err)))
+		// Transient: requeue at the default interval. Exponential backoff is the
+		// backoff/recovery PR's refinement.
+		l.scheduleRequeue(runCtx, req, 0, queue, wg)
+	}
+}
+
+// safeReconcile invokes the Reconciler with panic recovery so a single entity's
+// panic cannot crash the worker goroutine (and the process). A recovered panic
+// is reported as a transient error (retryable); a dedicated panic disposition /
+// taxonomy is the backoff/recovery PR's concern.
+func (l *Loop) safeReconcile(ctx context.Context, req Request) (res Result, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("reconcile: recovered panic in Reconcile(entity=%q): %v", req.EntityID, r)
+			res = Result{}
+		}
+	}()
+	return l.Reconciler.Reconcile(ctx, req)
+}
+
+// scheduleRequeue re-enqueues req after the given delay (0 → default Interval)
+// via a goroutine bounded by the run ctx. The goroutine is tracked by wg so Stop
+// waits for it, and exits immediately on cancellation (no leak, no requeue into
+// a draining Loop).
+func (l *Loop) scheduleRequeue(runCtx context.Context, req Request, after time.Duration, queue chan<- Request, wg *sync.WaitGroup) {
+	if after <= 0 {
+		after = l.interval()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		timer := controlPlaneClock{}.newRequeueTimer(after)
+		defer timer.Stop()
+		select {
+		case <-runCtx.Done():
+			return
+		case <-timer.C:
+		}
+		select {
+		case queue <- req:
+		case <-runCtx.Done():
+		}
+	}()
+}
+
+// awaitProbe waits up to startProbeTimeout for the worker pool to confirm it is
+// running. Returns nil in all non-error cases (mirrors SweeperLifecycle):
+//   - ready closed: a worker started — confirmed.
+//   - probe window elapsed: workers are running, just slow to schedule.
+//   - owner ctx canceled before either: log Warn, clear state so Stop is a no-op.
+func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, ready <-chan struct{}) error {
+	probeTimer := controlPlaneClock{}.newProbeTimer(startProbeTimeout)
+	defer probeTimer.Stop()
+
+	select {
+	case <-ready:
+	case <-probeTimer.C:
+	case <-runCtx.Done():
+		l.logger().Warn("reconcile: owner ctx canceled before loop confirmed running",
+			slog.String("loop", l.name()),
+			slog.String("reconciler", l.reconcilerID()))
+		cancel()
+		l.cancel = nil
+		l.done = nil
+	}
+	return nil
+}
+
+// Stop cancels the Loop and waits for all goroutines (workers, pump, pending
+// requeues) to exit within ctx's budget.
+func (l *Loop) Stop(ctx context.Context) error {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	cancel := l.cancel
+	done := l.done
+	l.cancel = nil
+	l.done = nil
+	l.mu.Unlock()
+
+	if cancel == nil {
+		return nil
+	}
+	cancel()
+
+	select {
+	case <-done:
+		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
+		l.logger().Info("reconcile: loop stopped",
+			slog.String("loop", l.name()),
+			slog.String("reconciler", l.reconcilerID()))
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (l *Loop) maxConcurrent() int {
+	if l.MaxConcurrentReconciles > 0 {
+		return l.MaxConcurrentReconciles
+	}
+	return defaultMaxConcurrentReconciles
+}
+
+func (l *Loop) interval() time.Duration {
+	if l.Interval > 0 {
+		return l.Interval
+	}
+	return defaultReconcileInterval
+}
+
+func (l *Loop) reconcilerID() string {
+	if l != nil && l.ReconcilerID != "" {
+		return l.ReconcilerID
+	}
+	return reconcilerIDSentinel
+}
+
+func (l *Loop) name() string {
+	if l != nil && l.Name != "" {
+		return l.Name
+	}
+	return defaultLoopName
+}
+
+func (l *Loop) logger() *slog.Logger {
+	if l != nil && l.Logger != nil {
+		return l.Logger
+	}
+	return slog.Default()
+}

--- a/kernel/reconcile/loop_test.go
+++ b/kernel/reconcile/loop_test.go
@@ -185,6 +185,24 @@ func TestLoop_OwnerCtxCancelDrainsWithoutStop(t *testing.T) {
 	ownerCancel() // assembly shutdown — no explicit Stop; goleak verifies drain
 }
 
+// TestLoop_OwnerCtxCanceledBeforeStart mirrors the transplant source's
+// TestSweeperLifecycle_OwnerCtxCancelDuringProbe: the owner ctx is canceled
+// BEFORE Start, so awaitProbe must take the deterministic cancel pre-check —
+// Start returns nil without reporting "started", and the subsequent Stop is a
+// no-op (state was cleared). goleak verifies the spawned workers self-drain.
+func TestLoop_OwnerCtxCanceledBeforeStart(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	l := &Loop{
+		ReconcilerID: "rc",
+		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{RequeueAfter: testtime.D1h}, nil }),
+		Interval:     testtime.D1h,
+	}
+	ownerCtx, ownerCancel := startCtxs(t)
+	ownerCancel() // cancel BEFORE Start — awaitProbe's pre-check path must fire
+	require.NoError(t, l.Start(ownerCtx))
+	require.NoError(t, l.Stop(context.Background())) // no-op: state cleared in awaitProbe
+}
+
 func TestLoop_StopTimeoutReturnsDeadline(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	rec := newBlockingReconciler()

--- a/kernel/reconcile/loop_test.go
+++ b/kernel/reconcile/loop_test.go
@@ -1,0 +1,377 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
+)
+
+// shortRequeue is a fast requeue interval used by tests that observe requeue
+// behavior (transient retry / permanent dead-letter) without long waits.
+const shortRequeue = 20 * testtime.D1ms
+
+// funcReconciler adapts a function to the Reconciler interface.
+type funcReconciler func(ctx context.Context, req Request) (Result, error)
+
+func (f funcReconciler) Reconcile(ctx context.Context, req Request) (Result, error) {
+	return f(ctx, req)
+}
+
+// blockingReconciler blocks each Reconcile on a release channel and tracks
+// global / per-entity concurrency so tests can assert the worker-pool bound and
+// same-entity serialization.
+type blockingReconciler struct {
+	release   chan struct{}
+	ignoreCtx bool // when true, block on release only (simulate a stuck reconcile)
+	result    Result
+	err       error
+
+	mu            sync.Mutex
+	concurrent    int
+	maxConcurrent int
+	perEntity     map[string]int
+	maxPerEntity  int
+	calls         atomic.Int64
+}
+
+func newBlockingReconciler() *blockingReconciler {
+	return &blockingReconciler{
+		release:   make(chan struct{}),
+		perEntity: map[string]int{},
+		result:    Result{RequeueAfter: testtime.D1h}, // requeue far out — no re-fire mid-test
+	}
+}
+
+func (r *blockingReconciler) Reconcile(ctx context.Context, req Request) (Result, error) {
+	r.calls.Add(1)
+	r.enter(req.EntityID)
+	defer r.exit(req.EntityID)
+	if r.ignoreCtx {
+		<-r.release
+	} else {
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+		}
+	}
+	return r.result, r.err
+}
+
+func (r *blockingReconciler) enter(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.concurrent++
+	if r.concurrent > r.maxConcurrent {
+		r.maxConcurrent = r.concurrent
+	}
+	r.perEntity[id]++
+	if r.perEntity[id] > r.maxPerEntity {
+		r.maxPerEntity = r.perEntity[id]
+	}
+}
+
+func (r *blockingReconciler) exit(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.concurrent--
+	r.perEntity[id]--
+}
+
+func (r *blockingReconciler) currentConcurrent() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.concurrent
+}
+
+func (r *blockingReconciler) snapshot() (maxConcurrent, maxPerEntity int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.maxConcurrent, r.maxPerEntity
+}
+
+// notReadyReconciler implements the optional readiness gate and fails it.
+type notReadyReconciler struct{ funcReconciler }
+
+func (notReadyReconciler) Validate() error { return errors.New("not constructed properly") }
+
+func startCtxs(t *testing.T) (ownerCtx context.Context, ownerCancel context.CancelFunc) {
+	t.Helper()
+	return context.WithCancel(context.Background())
+}
+
+func stopCtx(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), testtime.CtxShort)
+}
+
+// -----------------------------------------------------------------------------
+// Construction / readiness gates
+// -----------------------------------------------------------------------------
+
+func TestLoop_NilReconcilerFailsStart(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	l := &Loop{ReconcilerID: "rc"}
+	err := l.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil Reconciler")
+	require.NoError(t, l.Stop(context.Background())) // no-op, goleak stays clean
+}
+
+func TestLoop_ReconcilerNotReadyFailsStart(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	l := &Loop{ReconcilerID: "rc", Reconciler: notReadyReconciler{}}
+	err := l.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not ready")
+	require.NoError(t, l.Stop(context.Background()))
+}
+
+func TestLoop_BadMetricLabelsFailsStart(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	p := newRecordingProvider()
+	bad, err := p.CounterVec(kernelmetrics.CounterOpts{Name: metricReconcileTotal, LabelNames: []string{"wrong"}})
+	require.NoError(t, err)
+	l := &Loop{
+		ReconcilerID: "rc",
+		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{}, nil }),
+		Metrics:      Metrics{Total: bad},
+	}
+	err = l.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metrics label set invalid")
+	require.NoError(t, l.Stop(context.Background()))
+}
+
+// -----------------------------------------------------------------------------
+// Lifecycle skeleton (transplant): start / probe / stop / owner-ctx drain
+// -----------------------------------------------------------------------------
+
+func TestLoop_StartStopGraceful(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	l := &Loop{
+		ReconcilerID: "rc",
+		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{RequeueAfter: testtime.D1h}, nil }),
+		Interval:     testtime.D1h,
+	}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx)) // fast-return probe must unblock
+	sc, cancel := stopCtx(t)
+	defer cancel()
+	require.NoError(t, l.Stop(sc))
+	require.NoError(t, l.Stop(sc)) // idempotent
+}
+
+func TestLoop_OwnerCtxCancelDrainsWithoutStop(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	l := &Loop{
+		ReconcilerID: "rc",
+		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{RequeueAfter: testtime.D1h}, nil }),
+		Interval:     testtime.D1h,
+	}
+	ownerCtx, ownerCancel := startCtxs(t)
+	require.NoError(t, l.Start(ownerCtx))
+	ownerCancel() // assembly shutdown — no explicit Stop; goleak verifies drain
+}
+
+func TestLoop_StopTimeoutReturnsDeadline(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	rec := newBlockingReconciler()
+	rec.ignoreCtx = true // simulate a reconcile stuck mid-work, not yet checking ctx
+	src := make(chan Request)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: testtime.D1h}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	src <- Request{EntityID: "stuck"}
+	testwait.External(t, "reconcile-started", func() bool { return rec.calls.Load() >= 1 },
+		testtime.D500ms, testtime.D1ms, "a reconcile must be running before Stop")
+
+	sc, cancel := context.WithTimeout(context.Background(), testtime.D1ms)
+	defer cancel()
+	err := l.Stop(sc)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "Stop must return its ctx deadline when a reconcile is stuck")
+
+	close(rec.release) // unstick so the worker drains and goleak stays clean
+}
+
+// -----------------------------------------------------------------------------
+// Concurrency bound + same-entity serialization
+// -----------------------------------------------------------------------------
+
+func TestLoop_MaxConcurrencyRespected(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	rec := newBlockingReconciler()
+	src := make(chan Request)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, MaxConcurrentReconciles: 2, Interval: testtime.D1h}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	for i := 0; i < 5; i++ {
+		src <- Request{EntityID: fmt.Sprintf("e%d", i)}
+	}
+	testwait.External(t, "two-concurrent-reconciles", func() bool { return rec.currentConcurrent() == 2 },
+		testtime.D500ms, testtime.D1ms, "exactly 2 reconciles should run with MaxConcurrentReconciles=2")
+	maxC, _ := rec.snapshot()
+	assert.LessOrEqual(t, maxC, 2, "concurrency must never exceed the worker bound")
+
+	close(rec.release)
+	sc, cancel := stopCtx(t)
+	defer cancel()
+	require.NoError(t, l.Stop(sc))
+	maxC, _ = rec.snapshot()
+	assert.Equal(t, 2, maxC, "two workers should have reached 2-way concurrency")
+}
+
+func TestLoop_SameEntityIDSerial(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	rec := newBlockingReconciler()
+	src := make(chan Request)
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, MaxConcurrentReconciles: 4, Interval: testtime.D1h, Metrics: m}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	for i := 0; i < 4; i++ {
+		src <- Request{EntityID: "same"}
+	}
+	// First reconcile holds the entity; the other three are dequeued and dropped
+	// as "skipped" (level-triggered serialization), never running concurrently.
+	testwait.External(t, "three-duplicates-skipped",
+		func() bool {
+			return p.counterValue(kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultSkipped}) >= 3
+		},
+		testtime.D500ms, testtime.D1ms, "duplicate same-entity requests must be skipped while one is in flight")
+	_, maxPE := rec.snapshot()
+	assert.Equal(t, 1, maxPE, "the same EntityID must never reconcile concurrently")
+
+	close(rec.release)
+	sc, cancel := stopCtx(t)
+	defer cancel()
+	require.NoError(t, l.Stop(sc))
+}
+
+// -----------------------------------------------------------------------------
+// Panic isolation + error classification + metrics
+// -----------------------------------------------------------------------------
+
+func TestLoop_PanicRecoveredAndOtherEntitiesUnaffected(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	var okCalls atomic.Int64
+	rec := funcReconciler(func(_ context.Context, req Request) (Result, error) {
+		if req.EntityID == "boom" {
+			panic("kaboom")
+		}
+		okCalls.Add(1)
+		return Result{RequeueAfter: testtime.D1h}, nil
+	})
+	src := make(chan Request)
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: testtime.D1h, Metrics: m}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	src <- Request{EntityID: "boom"}
+	src <- Request{EntityID: "ok"}
+
+	testwait.External(t, "other-entity-reconciled", func() bool { return okCalls.Load() >= 1 },
+		testtime.D500ms, testtime.D1ms, "a panicking entity must not stop other entities from reconciling")
+	testwait.External(t, "panic-counted-transient",
+		func() bool {
+			return p.counterValue(kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultTransient}) >= 1
+		},
+		testtime.D500ms, testtime.D1ms, "a recovered panic must be classified transient")
+
+	sc, cancel := stopCtx(t)
+	defer cancel()
+	require.NoError(t, l.Stop(sc))
+}
+
+func TestLoop_PermanentNotRequeued_TransientRequeued(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	rec := funcReconciler(func(_ context.Context, req Request) (Result, error) {
+		if req.EntityID == "perm" {
+			return Result{}, PermanentError(errors.New("revoked"))
+		}
+		return Result{}, errors.New("transient blip")
+	})
+	src := make(chan Request)
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: shortRequeue, Metrics: m}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	src <- Request{EntityID: "perm"}
+	src <- Request{EntityID: "trans"}
+
+	// Once the transient entity has been requeued+retried several times, enough
+	// intervals have elapsed that the permanent entity would also have requeued
+	// if it were going to — assert it stayed at exactly one reconcile.
+	transLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultTransient}
+	permLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultPermanent}
+	testwait.External(t, "transient-requeued-thrice",
+		func() bool { return p.counterValue(transLabels) >= 3 },
+		testtime.D500ms, testtime.D1ms, "transient errors must be requeued and retried")
+	assert.Equal(t, int64(1), p.counterValue(permLabels),
+		"a PermanentError entity must reconcile exactly once (dead-lettered, not requeued)")
+
+	sc, cancel := stopCtx(t)
+	defer cancel()
+	require.NoError(t, l.Stop(sc))
+}
+
+func TestLoop_RecordsSuccessMetrics(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	rec := funcReconciler(func(context.Context, Request) (Result, error) {
+		return Result{RequeueAfter: testtime.D1h}, nil
+	})
+	src := make(chan Request)
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: testtime.D1h, Metrics: m}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	// Leader is set to 1 at Start (single-process).
+	assert.Equal(t, float64(1), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}))
+
+	src <- Request{EntityID: "e1"}
+	successLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultSuccess}
+	testwait.External(t, "success-recorded",
+		func() bool { return p.counterValue(successLabels) >= 1 },
+		testtime.D500ms, testtime.D1ms, "a successful reconcile must increment reconcile_total{result=success}")
+	assert.GreaterOrEqual(t, p.histogramCount(metricReconcileDuration, kernelmetrics.Labels{labelReconciler: "rc"}), int64(1),
+		"reconcile_duration_seconds must be observed")
+
+	sc, cancel := stopCtx(t)
+	defer cancel()
+	require.NoError(t, l.Stop(sc))
+	// In-flight returns to 0 and leader to 0 after Stop.
+	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileInFlight, kernelmetrics.Labels{labelReconciler: "rc"}))
+	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}))
+}

--- a/kernel/reconcile/metrics.go
+++ b/kernel/reconcile/metrics.go
@@ -1,0 +1,162 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// Metric family names (FR-010). Single source so the Loop, RegisterMetrics, and
+// any dashboard/alert reference the same identifiers.
+const (
+	metricReconcileTotal    = "reconcile_total"
+	metricReconcileDuration = "reconcile_duration_seconds"
+	metricReconcileInFlight = "reconcile_in_flight"
+	metricReconcileLeader   = "reconcile_leader"
+)
+
+// Metric label names.
+const (
+	labelReconciler = "reconciler"
+	labelResult     = "result"
+)
+
+// Reconcile result label values for reconcile_total{result=...}. This is the
+// frozen value set (FR-010): success / transient / permanent / skipped. A
+// recovered reconciler panic is classified transient (it is retryable); a
+// dedicated panic disposition is deferred to the backoff/recovery PR.
+const (
+	resultSuccess   = "success"
+	resultTransient = "transient"
+	resultPermanent = "permanent"
+	resultSkipped   = "skipped"
+)
+
+// reconcileDurationBuckets are explicit upper bounds (seconds) for
+// reconcile_duration_seconds. Reconcile spans range from sub-millisecond
+// (no-op level check) to multi-second (DB write + external call), so the set
+// covers ms→minute. Supplied explicitly because the metric leaves kernel
+// (HistogramOpts godoc: callers should not rely on adapter defaults).
+var reconcileDurationBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60}
+
+// Metrics holds the optional pre-bound instruments the Loop records to. A nil
+// field disables that instrument (the Loop nil-checks before every record).
+// Build via RegisterMetrics at the composition root and inject; the Loop
+// preflights label sets at Start (same wiring shape as
+// runtime/command.preflightSweepErrorCounter).
+type Metrics struct {
+	// Total counts reconcile outcomes, labels {reconciler, result}.
+	Total kernelmetrics.CounterVec
+	// Duration observes reconcile wall-clock seconds, labels {reconciler}.
+	Duration kernelmetrics.HistogramVec
+	// InFlight tracks concurrently-running reconciles, labels {reconciler}.
+	InFlight kernelmetrics.GaugeVec
+	// Leader is 1 when this instance owns the reconcile lease, else 0,
+	// labels {reconciler}. In the single-process Loop it is set to 1 at Start;
+	// real lease gating is the leader-election PR's concern.
+	Leader kernelmetrics.GaugeVec
+}
+
+// RegisterMetrics registers the four reconcile instruments on p with canonical
+// names, labels, and buckets, returning them bundled. It is the single source
+// for reconcile metric identity; consumers call it at the composition root and
+// inject the result into a Loop (or the Builder does so).
+func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
+	total, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name:       metricReconcileTotal,
+		Help:       "Total reconcile attempts by outcome.",
+		LabelNames: []string{labelReconciler, labelResult},
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileTotal, err)
+	}
+	duration, err := p.HistogramVec(kernelmetrics.HistogramOpts{
+		Name:       metricReconcileDuration,
+		Help:       "Reconcile call wall-clock duration in seconds.",
+		LabelNames: []string{labelReconciler},
+		Buckets:    reconcileDurationBuckets,
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileDuration, err)
+	}
+	inFlight, err := p.GaugeVec(kernelmetrics.GaugeOpts{
+		Name:       metricReconcileInFlight,
+		Help:       "Reconciles currently executing.",
+		LabelNames: []string{labelReconciler},
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileInFlight, err)
+	}
+	leader, err := p.GaugeVec(kernelmetrics.GaugeOpts{
+		Name:       metricReconcileLeader,
+		Help:       "1 when this instance holds the reconcile lease, else 0.",
+		LabelNames: []string{labelReconciler},
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileLeader, err)
+	}
+	return Metrics{Total: total, Duration: duration, InFlight: inFlight, Leader: leader}, nil
+}
+
+// preflight probes each non-nil instrument's With() with the exact label set the
+// Loop uses, under recover. With() panics (MustValidateLabels) on a label-set
+// mismatch; without this, the first record would crash a worker goroutine and
+// crashloop the service. Catching it here turns a misconfigured vec into a
+// fail-fast Start error. The recovered value is redacted before wrapping so a
+// credential-bearing panic string cannot leak. Mirrors
+// runtime/command.preflightSweepErrorCounter.
+func (m Metrics) preflight(reconcilerID string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			redacted := redaction.RedactError(fmt.Errorf("%v", r))
+			err = fmt.Errorf("reconcile: metrics label set invalid (reconciler=%q): %w", reconcilerID, redacted)
+		}
+	}()
+	if m.Total != nil {
+		_ = m.Total.With(kernelmetrics.Labels{labelReconciler: reconcilerID, labelResult: resultSuccess})
+	}
+	if m.Duration != nil {
+		_ = m.Duration.With(kernelmetrics.Labels{labelReconciler: reconcilerID})
+	}
+	if m.InFlight != nil {
+		_ = m.InFlight.With(kernelmetrics.Labels{labelReconciler: reconcilerID})
+	}
+	if m.Leader != nil {
+		_ = m.Leader.With(kernelmetrics.Labels{labelReconciler: reconcilerID})
+	}
+	return nil
+}
+
+// recordResult increments reconcile_total{reconciler, result} when wired.
+func (m Metrics) recordResult(ctx context.Context, reconcilerID, result string) {
+	if m.Total == nil {
+		return
+	}
+	m.Total.With(kernelmetrics.Labels{labelReconciler: reconcilerID, labelResult: result}).Inc(ctx)
+}
+
+// observeDuration records reconcile_duration_seconds{reconciler} when wired.
+func (m Metrics) observeDuration(ctx context.Context, reconcilerID string, seconds float64) {
+	if m.Duration == nil {
+		return
+	}
+	m.Duration.With(kernelmetrics.Labels{labelReconciler: reconcilerID}).Observe(ctx, seconds)
+}
+
+// inFlightDelta adds delta to reconcile_in_flight{reconciler} when wired.
+func (m Metrics) inFlightDelta(ctx context.Context, reconcilerID string, delta float64) {
+	if m.InFlight == nil {
+		return
+	}
+	m.InFlight.With(kernelmetrics.Labels{labelReconciler: reconcilerID}).Add(ctx, delta)
+}
+
+// setLeader sets reconcile_leader{reconciler} when wired.
+func (m Metrics) setLeader(ctx context.Context, reconcilerID string, value float64) {
+	if m.Leader == nil {
+		return
+	}
+	m.Leader.With(kernelmetrics.Labels{labelReconciler: reconcilerID}).Set(ctx, value)
+}

--- a/kernel/reconcile/metrics_test.go
+++ b/kernel/reconcile/metrics_test.go
@@ -1,0 +1,293 @@
+package reconcile
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+)
+
+// TestRegisterMetrics_WiresFour asserts RegisterMetrics registers all four
+// instruments with their canonical names + label sets (FR-010).
+func TestRegisterMetrics_WiresFour(t *testing.T) {
+	t.Parallel()
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	require.NotNil(t, m.Total)
+	require.NotNil(t, m.Duration)
+	require.NotNil(t, m.InFlight)
+	require.NotNil(t, m.Leader)
+
+	assert.ElementsMatch(t, []string{labelReconciler, labelResult}, p.counterLabels(metricReconcileTotal))
+	assert.ElementsMatch(t, []string{labelReconciler}, p.histogramLabels(metricReconcileDuration))
+	assert.ElementsMatch(t, []string{labelReconciler}, p.gaugeLabels(metricReconcileInFlight))
+	assert.ElementsMatch(t, []string{labelReconciler}, p.gaugeLabels(metricReconcileLeader))
+}
+
+// TestMetrics_Preflight_GoodLabelsPasses asserts a Metrics built by
+// RegisterMetrics preflights cleanly (the canonical label sets validate).
+func TestMetrics_Preflight_GoodLabelsPasses(t *testing.T) {
+	t.Parallel()
+	m, err := RegisterMetrics(newRecordingProvider())
+	require.NoError(t, err)
+	require.NoError(t, m.preflight("certrotation"))
+}
+
+// TestMetrics_Preflight_BadLabelsFails asserts a hand-built Metrics whose
+// counter has the wrong label set is caught by preflight (recover → error)
+// rather than crashing a worker on first record.
+func TestMetrics_Preflight_BadLabelsFails(t *testing.T) {
+	t.Parallel()
+	p := newRecordingProvider()
+	// Register the Total counter with an intentionally-wrong label set.
+	bad, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name:       metricReconcileTotal,
+		LabelNames: []string{"wrong"},
+	})
+	require.NoError(t, err)
+	m := Metrics{Total: bad}
+	gotErr := m.preflight("certrotation")
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "metrics label set invalid")
+}
+
+// -----------------------------------------------------------------------------
+// recordingProvider — an in-memory metrics.Provider spy for reconcile tests.
+// Mirrors runtime/command's testProvider but covers all three vec kinds.
+// -----------------------------------------------------------------------------
+
+type recordingProvider struct {
+	mu         sync.Mutex
+	counters   map[string]*recordingCounterVec
+	histograms map[string]*recordingHistogramVec
+	gauges     map[string]*recordingGaugeVec
+}
+
+func newRecordingProvider() *recordingProvider {
+	return &recordingProvider{
+		counters:   map[string]*recordingCounterVec{},
+		histograms: map[string]*recordingHistogramVec{},
+		gauges:     map[string]*recordingGaugeVec{},
+	}
+}
+
+func (p *recordingProvider) CounterVec(opts kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if v, ok := p.counters[opts.Name]; ok {
+		return v, nil
+	}
+	v := &recordingCounterVec{labels: append([]string(nil), opts.LabelNames...), obs: map[string]*atomic.Int64{}}
+	p.counters[opts.Name] = v
+	return v, nil
+}
+
+func (p *recordingProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if v, ok := p.histograms[opts.Name]; ok {
+		return v, nil
+	}
+	v := &recordingHistogramVec{labels: append([]string(nil), opts.LabelNames...), obs: map[string]*atomic.Int64{}}
+	p.histograms[opts.Name] = v
+	return v, nil
+}
+
+func (p *recordingProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if v, ok := p.gauges[opts.Name]; ok {
+		return v, nil
+	}
+	v := &recordingGaugeVec{labels: append([]string(nil), opts.LabelNames...), vals: map[string]float64{}}
+	p.gauges[opts.Name] = v
+	return v, nil
+}
+
+func (p *recordingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
+
+func (p *recordingProvider) counterLabels(name string) []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if v, ok := p.counters[name]; ok {
+		return v.labels
+	}
+	return nil
+}
+
+func (p *recordingProvider) histogramLabels(name string) []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if v, ok := p.histograms[name]; ok {
+		return v.labels
+	}
+	return nil
+}
+
+func (p *recordingProvider) gaugeLabels(name string) []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if v, ok := p.gauges[name]; ok {
+		return v.labels
+	}
+	return nil
+}
+
+func (p *recordingProvider) counterValue(l kernelmetrics.Labels) int64 {
+	p.mu.Lock()
+	v, ok := p.counters[metricReconcileTotal]
+	p.mu.Unlock()
+	if !ok {
+		return 0
+	}
+	return v.value(l)
+}
+
+func (p *recordingProvider) histogramCount(name string, l kernelmetrics.Labels) int64 {
+	p.mu.Lock()
+	v, ok := p.histograms[name]
+	p.mu.Unlock()
+	if !ok {
+		return 0
+	}
+	return v.count(l)
+}
+
+func (p *recordingProvider) gaugeValue(name string, l kernelmetrics.Labels) float64 {
+	p.mu.Lock()
+	v, ok := p.gauges[name]
+	p.mu.Unlock()
+	if !ok {
+		return 0
+	}
+	return v.value(l)
+}
+
+type recordingCounterVec struct {
+	labels []string
+	mu     sync.Mutex
+	obs    map[string]*atomic.Int64
+}
+
+func (v *recordingCounterVec) Registered() bool { return true }
+func (v *recordingCounterVec) With(l kernelmetrics.Labels) kernelmetrics.Counter {
+	kernelmetrics.MustValidateLabels(v.labels, l)
+	v.mu.Lock()
+	c, ok := v.obs[labelsKeyR(l)]
+	if !ok {
+		c = &atomic.Int64{}
+		v.obs[labelsKeyR(l)] = c
+	}
+	v.mu.Unlock()
+	return &recordingCounter{n: c}
+}
+
+func (v *recordingCounterVec) value(l kernelmetrics.Labels) int64 {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if c, ok := v.obs[labelsKeyR(l)]; ok {
+		return c.Load()
+	}
+	return 0
+}
+
+type recordingCounter struct{ n *atomic.Int64 }
+
+func (c *recordingCounter) Inc(context.Context)              { c.n.Add(1) }
+func (c *recordingCounter) Add(_ context.Context, d float64) { c.n.Add(int64(d)) }
+
+type recordingHistogramVec struct {
+	labels []string
+	mu     sync.Mutex
+	obs    map[string]*atomic.Int64
+}
+
+func (v *recordingHistogramVec) Registered() bool { return true }
+func (v *recordingHistogramVec) With(l kernelmetrics.Labels) kernelmetrics.Histogram {
+	kernelmetrics.MustValidateLabels(v.labels, l)
+	v.mu.Lock()
+	c, ok := v.obs[labelsKeyR(l)]
+	if !ok {
+		c = &atomic.Int64{}
+		v.obs[labelsKeyR(l)] = c
+	}
+	v.mu.Unlock()
+	return &recordingHistogram{n: c}
+}
+
+func (v *recordingHistogramVec) count(l kernelmetrics.Labels) int64 {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if c, ok := v.obs[labelsKeyR(l)]; ok {
+		return c.Load()
+	}
+	return 0
+}
+
+type recordingHistogram struct{ n *atomic.Int64 }
+
+func (h *recordingHistogram) Observe(context.Context, float64) { h.n.Add(1) }
+
+type recordingGaugeVec struct {
+	labels []string
+	mu     sync.Mutex
+	vals   map[string]float64
+}
+
+func (v *recordingGaugeVec) Registered() bool { return true }
+func (v *recordingGaugeVec) With(l kernelmetrics.Labels) kernelmetrics.Gauge {
+	kernelmetrics.MustValidateLabels(v.labels, l)
+	return &recordingGauge{vec: v, key: labelsKeyR(l)}
+}
+
+func (v *recordingGaugeVec) value(l kernelmetrics.Labels) float64 {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.vals[labelsKeyR(l)]
+}
+
+type recordingGauge struct {
+	vec *recordingGaugeVec
+	key string
+}
+
+func (g *recordingGauge) Set(_ context.Context, val float64) {
+	g.vec.mu.Lock()
+	g.vec.vals[g.key] = val
+	g.vec.mu.Unlock()
+}
+func (g *recordingGauge) Inc(ctx context.Context) { g.Add(ctx, 1) }
+func (g *recordingGauge) Dec(ctx context.Context) { g.Add(ctx, -1) }
+func (g *recordingGauge) Add(_ context.Context, d float64) {
+	g.vec.mu.Lock()
+	g.vec.vals[g.key] += d
+	g.vec.mu.Unlock()
+}
+
+func labelsKeyR(l kernelmetrics.Labels) string {
+	if len(l) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(l))
+	for k := range l {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	b := make([]byte, 0, 64)
+	for i, k := range keys {
+		if i > 0 {
+			b = append(b, ',')
+		}
+		b = append(b, k...)
+		b = append(b, '=')
+		b = append(b, l[k]...)
+	}
+	return string(b)
+}

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -1,7 +1,9 @@
 // invariants:
 //   - INVARIANT: KERNEL-CLOCK-LEAF-FALLBACK-01
 //   - INVARIANT: KERNEL-CLOCK-RESET-RELATIVE-PROD-01
-//   - INVARIANT: PROD-CLOCK-INJECTION-01
+//   - INVARIANT: PROD-CLOCK-INJECTION-01 (control-plane hosts: runtime/command/
+//   - kernel/reconcile/; the kernel/reconcile host realizes
+//     RECONCILE-LOOP-CLOCK-CARVEOUT-01)
 //   - INVARIANT: CLOCK-POSITIONAL-INJECTION-01
 //
 // Package archtest — clock injection invariants.
@@ -465,16 +467,54 @@ var forbiddenTimeFns = map[string]string{
 //
 // Extension policy (HARD form-uniqueness): the only way to add a new
 // (method, callee) pair is a deliberate code change here PLUS adding the
-// method to runtime/command/lifecycle.go controlPlaneClock. A new method on
-// controlPlaneClock without an entry here is a violation for every time.*
-// call it makes (the method exists but exactSanctionedTimeCalls lookup
-// returns ""); a new entry here without a matching method does nothing
-// (no FuncDecl position binds to it). Both halves are required.
+// method to a controlPlaneClock type in a sanctioned host package (see
+// controlPlaneClockHosts: runtime/command/lifecycle.go or
+// kernel/reconcile/loop.go). A new method on controlPlaneClock without an entry
+// here is a violation for every time.* call it makes (the method exists but
+// exactSanctionedTimeCalls lookup returns ""); a new entry here without a
+// matching method does nothing (no FuncDecl position binds to it). Both halves
+// are required.
+//
+// The map is keyed by method name only (not package): each sanctioned host
+// declares the subset it uses (runtime/command: newTicker + newProbeTimer;
+// kernel/reconcile: newProbeTimer + newRequeueTimer + now). A host need not
+// declare every method, but any method it declares MUST appear here.
 //
 // ref: docs/architecture/202605270000-adr-clock-positional-injection-funnel.md §#619
 var exactSanctionedTimeCalls = map[string]string{
-	"newTicker":     "NewTicker",
-	"newProbeTimer": "NewTimer",
+	"newTicker":       "NewTicker", // runtime/command: SweeperLifecycle ticker
+	"newProbeTimer":   "NewTimer",  // runtime/command + kernel/reconcile: startup probe
+	"newRequeueTimer": "NewTimer",  // kernel/reconcile: delayed requeue (RECONCILE-LOOP-CLOCK-CARVEOUT-01)
+	"now":             "Now",       // kernel/reconcile: reconcile-duration measurement
+}
+
+// controlPlaneClockHosts lists the packages sanctioned to host a sealed,
+// package-private controlPlaneClock type (the real-only control-plane scheduling
+// clock). Gate (a) of clockControlPlaneAllowedMethods restricts the carve-out to
+// these paths so no other package can claim it by reusing the type name; each
+// member declares its OWN unexported controlPlaneClock.
+//
+// Members (trailing "/" = directory prefix):
+//   - runtime/command/  — SweeperLifecycle (PROD-CLOCK-INJECTION-01 origin).
+//   - kernel/reconcile/ — reconcile.Loop (RECONCILE-LOOP-CLOCK-CARVEOUT-01).
+//
+// AI-robust grade unchanged: Medium (permanent ceiling) — see
+// clockControlPlaneAllowedMethods. Adding a host is a deliberate, reviewable
+// change here; the per-host seal is the package-private type name + gate (c).
+var controlPlaneClockHosts = []string{
+	"runtime/command/",
+	"kernel/reconcile/",
+}
+
+// hasControlPlaneClockHostPrefix reports whether rel is under a sanctioned
+// control-plane host package (gate (a)).
+func hasControlPlaneClockHostPrefix(rel string) bool {
+	for _, h := range controlPlaneClockHosts {
+		if strings.HasPrefix(rel, h) {
+			return true
+		}
+	}
+	return false
 }
 
 // clockControlPlaneAllowedMethods returns the map of FuncDecl name-positions
@@ -483,11 +523,12 @@ var exactSanctionedTimeCalls = map[string]string{
 //
 // A FuncDecl is a candidate if and only if ALL of:
 //
-//	(a) rel is under "runtime/command/" — this package gate prevents any other
-//	    package from claiming to host a "controlPlaneClock" method; the type is
-//	    package-private (unexported) so only code in runtime/command can declare
-//	    methods on it. This is the structural "seal" that replaces the old
-//	    hand-maintained allowlist map.
+//	(a) rel is under a sanctioned control-plane host package
+//	    (controlPlaneClockHosts: "runtime/command/" or "kernel/reconcile/") —
+//	    this package gate prevents any other package from claiming to host a
+//	    "controlPlaneClock" method; the type is package-private (unexported) so
+//	    only code in a host package can declare methods on it. This is the
+//	    structural "seal" that replaces the old hand-maintained allowlist map.
 //
 //	(b) fd.Recv != nil — it is a method, not a free function.
 //
@@ -528,10 +569,12 @@ var exactSanctionedTimeCalls = map[string]string{
 //     Reverse self-check: control_plane_exempt_func_closure_violates fixture
 //     asserts that time.* inside a closure of an exempt method is still flagged.
 //  2. A method named controlPlaneClock from an entirely different package would
-//     satisfy (b)+(c) without gate (a). Gate (a) prevents this by requiring
-//     the file's module-relative path to be under runtime/command/.
+//     satisfy (b)+(c) without gate (a). Gate (a) prevents this by requiring the
+//     file's module-relative path to be under a sanctioned host package
+//     (controlPlaneClockHosts: runtime/command/ or kernel/reconcile/).
 //     Reverse self-check: control_plane_wrong_path_violates fixture has a struct
-//     named controlPlaneClock with a method outside runtime/command/ → still flagged.
+//     named controlPlaneClock with a method outside any host → still flagged.
+//     GREEN self-check for the kernel/reconcile host: control_plane_reconcile_passes.
 //  3. An unexported method on a different struct inside runtime/command/ with
 //     the name "controlPlaneClock" is not a legitimate bypass because (c) checks
 //     the *receiver type name*, not the method name. A struct named "otherClock"
@@ -552,8 +595,9 @@ var exactSanctionedTimeCalls = map[string]string{
 // ref: PROD-CLOCK-INJECTION-01
 func clockControlPlaneAllowedMethods(fset *token.FileSet, file *ast.File, rel string) map[string]string {
 	out := map[string]string{}
-	// Gate (a): only runtime/command/ files can host controlPlaneClock methods.
-	if !strings.HasPrefix(rel, "runtime/command/") {
+	// Gate (a): only sanctioned control-plane host packages may host
+	// controlPlaneClock methods (see controlPlaneClockHosts).
+	if !hasControlPlaneClockHostPrefix(rel) {
 		return out
 	}
 	EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {

--- a/tools/archtest/prod_clock_injection_fixtures_test.go
+++ b/tools/archtest/prod_clock_injection_fixtures_test.go
@@ -10,6 +10,9 @@
 // Control-plane receiver-type confinement self-checks (per ai-robust.md §"盲区自检"):
 //   - control_plane_method_passes: GREEN — FuncDecls that are methods of
 //     controlPlaneClock in runtime/command/ produce 0 violations.
+//   - control_plane_reconcile_passes: GREEN — methods of controlPlaneClock in
+//     the kernel/reconcile/ host (newProbeTimer / newRequeueTimer / now) produce
+//     0 violations (RECONCILE-LOOP-CLOCK-CARVEOUT-01).
 //   - control_plane_wrong_path_violates: RED — same controlPlaneClock receiver
 //     type but file outside runtime/command/; the path gate must still flag it.
 //   - control_plane_wrong_receiver_type_violates: RED — method of otherClock
@@ -83,6 +86,7 @@ func TestProdClockInjectionFixtures(t *testing.T) {
 		// Control-plane receiver-type confinement self-checks
 		// (per ai-robust.md §"盲区自检" / PROD-CLOCK-INJECTION-01 godoc).
 		"control_plane_method_passes",                // GREEN: controlPlaneClock method in runtime/command/
+		"control_plane_reconcile_passes",             // GREEN: controlPlaneClock method in kernel/reconcile/ (RECONCILE-LOOP-CLOCK-CARVEOUT-01)
 		"control_plane_wrong_path_violates",          // RED: controlPlaneClock method outside runtime/command/
 		"control_plane_wrong_receiver_type_violates", // RED: wrong receiver type in runtime/command/
 		"control_plane_no_marker_violates",           // RED: free function in runtime/command/ (no receiver)

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_reconcile_passes/go.mod
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_reconcile_passes/go.mod
@@ -1,0 +1,3 @@
+module fixturetest/prod_clock_injection/control_plane_reconcile_passes
+
+go 1.22

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_reconcile_passes/kernel/reconcile/loop.go
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_reconcile_passes/kernel/reconcile/loop.go
@@ -1,0 +1,36 @@
+// Package reconcile is the GREEN control-plane receiver-type confinement fixture
+// for the kernel/reconcile host of PROD-CLOCK-INJECTION-01
+// (RECONCILE-LOOP-CLOCK-CARVEOUT-01). It mirrors the real kernel/reconcile/ path
+// so the rel-gate (controlPlaneClockHosts includes "kernel/reconcile/") plus
+// receiver type name "controlPlaneClock" plus the (method, callee) pairs
+// newProbeTimer→NewTimer / newRequeueTimer→NewTimer / now→Now yield 0 violations.
+package reconcile
+
+import "time"
+
+// controlPlaneClock is the sealed, real-only clock for control-plane scheduling.
+// It is an empty package-private struct: no package outside kernel/reconcile can
+// name it. Its methods are the sole sanctioned callsites for stdlib
+// time.NewTimer / time.Now in this package.
+type controlPlaneClock struct{}
+
+// newProbeTimer is exempt: controlPlaneClock method in kernel/reconcile/ whose
+// (method, callee) pair newProbeTimer→NewTimer is registered.
+func (controlPlaneClock) newProbeTimer(d time.Duration) *time.Timer {
+	return time.NewTimer(d) // exempt
+}
+
+// newRequeueTimer is exempt: pair newRequeueTimer→NewTimer is registered.
+func (controlPlaneClock) newRequeueTimer(d time.Duration) *time.Timer {
+	return time.NewTimer(d) // exempt
+}
+
+// now is exempt: pair now→Now is registered (reconcile-duration measurement).
+func (controlPlaneClock) now() time.Time {
+	return time.Now() // exempt
+}
+
+// cleanFunc uses time.Duration only as a type — no forbidden time.* call.
+func cleanFunc(d time.Duration) time.Duration {
+	return d * 2
+}


### PR DESCRIPTION
## Summary

The `reconcile.Loop` scheduling environment, validating ADR #661 §2 (≥80% reuse) + §7 (panic isolation, leak-free). Stacked on PR-A2 (base `661-reconciler-interface`).

- **Lifecycle skeleton transplant** (~270 LoC) from `runtime/command.SweeperLifecycle`: `Start` fast-return + startup probe, `awaitProbe`, graceful `Stop`, owner-ctx derivation, sealed `controlPlaneClock`, metrics preflight. Renamed `Sweep*`→`Reconcile*`; dropped `BusinessClock` (reconcile takes no `now`).
- **New per-entity worker dispatch** (~120 LoC): `MaxConcurrentReconciles` worker pool + same-EntityID serial (`inflight` sync.Map; level-triggered → drop duplicate = `skipped`) + panic isolation (`safeReconcile`) + `RequeueAfter` requeue (per-requeue goroutine, WaitGroup-tracked, leak-free).
- **4 metrics** + `RegisterMetrics` single-source + `preflight` (mirrors `preflightSweepErrorCounter`): `reconcile_total{reconciler,result}` / `reconcile_duration_seconds` / `reconcile_in_flight` / `reconcile_leader`.

## ≥80% reuse (validated, ADR §2.6)

`loop.go` 392 LoC vs `lifecycle.go` 446 LoC. Scheduling **skeleton** transplants ~1:1 (~270 LoC, only rename + drop BusinessClock); whole-Loop reuse ≈ 69% — the gap is the per-entity worker layer Sweeper never had (bulk `SweepTick` → per-entity `Reconcile`). This refines the spec's "整体平移" estimate to "skeleton ≥80% + per-entity layer new".

## Clock carve-out (RECONCILE-LOOP-CLOCK-CARVEOUT-01)

`PROD-CLOCK-INJECTION-01` gate(a) generalized to a 2-host set `{runtime/command/, kernel/reconcile/}` (two independent archtests can't scan the same files — one would flag what the other exempts). Added `newRequeueTimer→NewTimer`, `now→Now` to `exactSanctionedTimeCalls`; new GREEN fixture `control_plane_reconcile_passes`. **AI-robust: Medium** (permanent ceiling — stdlib `time.NewTimer`/`Now` free functions can't be made uncallable in Go; same self-assessment as the runtime/command controlPlaneClock).

## Contract implementation matrix (per contract-fanout)

```
Contract: kernel/reconcile.Loop scheduling + Metrics; PROD-CLOCK-INJECTION-01 host-set extension
Change: transplant SweeperLifecycle skeleton + per-entity dispatch; extend clock carve-out to kernel/reconcile
Implementations: Loop (kernel/reconcile) — single impl; metrics recordingProvider (test) + RegisterMetrics
Conformance test: reconcile.TestLoop_* (loop_test.go) + TestProdClockInjection/Fixtures (clock carve-out)
Repro: go test -race ./kernel/reconcile/ && go test ./tools/archtest/ -run 'TestProdClockInjection|TestReconcile'
Dependent contracts (governance scan): none (kernel library; clock carve-out is an archtest, no contract.yaml)
```

## Test plan

- [x] `go test -race ./kernel/reconcile/` — green; coverage **90.8%** (kernel ≥90% gate)
- [x] `goleak.VerifyNone` guards 6 lifecycle tests (start/stop/probe/owner-cancel/stop-timeout)
- [x] MaxConcurrency + same-EntityID serial + panic isolation + permanent-vs-transient requeue tests
- [x] `go test ./tools/archtest/ -run 'TestProdClockInjection'` — live scan + fixtures (incl. new GREEN reconcile fixture) pass
- [x] full archtest suite green (TEST-TIME-LITERAL-01 + all 627 others)
- [x] `go build -tags=integration ./...` + `golangci-lint run` — 0 issues

Refs: #661
ref: kubernetes-sigs/controller-runtime pkg/internal/controller/controller.go
ref: kubernetes/client-go util/workqueue/default_rate_limiters.go
ref: gocell runtime/command/lifecycle.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)