### PR TITLE
fix(reconcile): A3 review fixes — lifecycle gauge/restart, ReconcilerID validation, host-scoped clock carve-out + Loop construction allowlist [#661 PR-A3 review]

### DIFF
--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -1,12 +1,13 @@
 // Package reconcile is GoCell's L4 desired-state convergence harness, a
 // level-triggered control loop modeled on Kubernetes controller-runtime's
-// Reconciler. It is delivered across stacked PRs: PR-A2 lands the minimal core
+// Reconciler. It is delivered across stacked PRs: PR-A2 landed the minimal core
 // documented below (the Reconciler interface, Request / Result, and the
-// PermanentError classifier); the scheduling Loop — transplanted from
-// runtime/command.SweeperLifecycle — lands in PR-A3 and is NOT present at this
-// commit. Comments here describe how each type is consumed by that Loop to pin
-// its contract; any Loop runtime behavior they mention refers to the PR-A3
-// component, not to anything in this commit.
+// PermanentError classifier); PR-A3 landed the scheduling Loop — transplanted
+// from runtime/command.SweeperLifecycle — which is present from that commit on.
+// Comments here describe how each type is consumed by the Loop to pin its
+// contract. Later PRs refine scheduling (PR-A5 adds a rate-limited delaying
+// queue + dirty dedup) and construction (PR-A7 privatizes the Loop constructor
+// behind a Builder); see the design ADR for the staged plan.
 //
 // # When to use
 //

--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -102,7 +102,12 @@ type reconcilerReadinessChecker interface {
 type Loop struct {
 	// Name labels logs; defaults to "reconcile.loop".
 	Name string
-	// ReconcilerID is the metric/log owner dimension; defaults to "_unknown".
+	// ReconcilerID is the metric/log owner dimension; when empty it defaults to
+	// the "_runtime" sentinel (see reconcilerIDSentinel). When set it MUST be a
+	// low-cardinality, label-safe identifier: Start rejects any value that fails
+	// validateReconcilerID (lowercase [a-z0-9_], leading [a-z_], ≤48 runes) so a
+	// high-cardinality or separator-bearing owner cannot blow up / corrupt the
+	// reconciler metric label.
 	ReconcilerID string
 	// Reconciler is the required convergence callback.
 	Reconciler Reconciler
@@ -141,6 +146,9 @@ func (l *Loop) Start(ownerCtx context.Context) error {
 		if err := rc.Validate(); err != nil {
 			return fmt.Errorf("reconcile: reconciler not ready: %w", err)
 		}
+	}
+	if err := validateReconcilerID(l.ReconcilerID); err != nil {
+		return err
 	}
 	if err := l.Metrics.preflight(l.reconcilerID()); err != nil {
 		return err
@@ -228,6 +236,13 @@ func (l *Loop) runWorker(runCtx context.Context, queue chan Request, wg *sync.Wa
 // process reconciles one Request: it serializes per EntityID (dropping a
 // duplicate while one is in flight — safe under level-triggering, since the next
 // trigger / requeue re-observes), records metrics, and requeues per the result.
+//
+// Scope note (ADR §2.2): A3 deliberately uses skip-if-busy rather than
+// controller-runtime's dirty/processing dedup. A coalesced trigger is NOT lost
+// under level-triggering — the next resync / requeue re-observes the latest
+// state — but a "mark-dirty, re-run once after the in-flight reconcile" queue
+// (so convergence does not wait for the next resync) is deferred to PR-A5's
+// rate-limited delaying queue.
 func (l *Loop) process(runCtx context.Context, req Request, queue chan<- Request, wg *sync.WaitGroup) {
 	if _, busy := l.inflight.LoadOrStore(req.EntityID, struct{}{}); busy {
 		l.Metrics.recordResult(runCtx, l.reconcilerID(), resultSkipped)
@@ -286,6 +301,13 @@ func (l *Loop) safeReconcile(ctx context.Context, req Request) (res Result, err 
 // via a goroutine bounded by the run ctx. The goroutine is tracked by wg so Stop
 // waits for it, and exits immediately on cancellation (no leak, no requeue into
 // a draining Loop).
+//
+// Scope note (ADR §2.2, threat T-LEAK): A3 spawns one short-lived timer
+// goroutine per requeue — simpler than client-go's shared delaying queue, and
+// leak-free (every goroutine is runCtx-derived + WaitGroup-tracked). The
+// concurrent count is bounded by the live entity set, not capped; a shared
+// rate-limited delaying queue (one timer goroutine total, exponential backoff)
+// is deferred to PR-A5.
 func (l *Loop) scheduleRequeue(runCtx context.Context, req Request, after time.Duration, queue chan<- Request, wg *sync.WaitGroup) {
 	if after <= 0 {
 		after = l.interval()
@@ -323,6 +345,12 @@ func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, rea
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))
 		cancel()
+		// Reset the leader gauge optimistically set to 1 in Start: this Loop
+		// never confirmed running and the subsequent Stop is a no-op (cancel is
+		// cleared below), so without this reset reconcile_leader would stay 1
+		// forever. Background ctx because runCtx is already canceled (mirrors
+		// Stop's drained-path reset).
+		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
 		l.cancel = nil
 		l.done = nil
 		return nil
@@ -339,6 +367,15 @@ func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, rea
 
 // Stop cancels the Loop and waits for all goroutines (workers, pump, pending
 // requeues) to exit within ctx's budget.
+//
+// State (l.cancel / l.done) is cleared ONLY after the goroutines actually drain.
+// Until then the fields stay set so that (a) a concurrent Start remains a no-op
+// — it never spawns a second pool racing the one still unwinding — and (b) a
+// Stop that exhausts ctx's budget can simply be called again to keep waiting.
+// cancel() is idempotent, so a retried Stop re-selects on the same done channel
+// without harm. The leader gauge is reset to 0 only on confirmed drain: a
+// timed-out Stop is "not yet stopped", so leader stays 1 until a later Stop
+// drains it.
 func (l *Loop) Stop(ctx context.Context) error {
 	if l == nil {
 		return nil
@@ -346,23 +383,28 @@ func (l *Loop) Stop(ctx context.Context) error {
 	l.mu.Lock()
 	cancel := l.cancel
 	done := l.done
-	l.cancel = nil
-	l.done = nil
 	l.mu.Unlock()
 
 	if cancel == nil {
-		return nil
+		return nil // never started, or already fully stopped
 	}
 	cancel()
 
 	select {
 	case <-done:
+		l.mu.Lock()
+		l.cancel = nil
+		l.done = nil
+		l.mu.Unlock()
 		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
 		l.logger().Info("reconcile: loop stopped",
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))
 		return nil
 	case <-ctx.Done():
+		// Budget exhausted before drain. cancel() has fired so the goroutines
+		// are unwinding; leave l.cancel/l.done intact so Stop is retryable and
+		// Start cannot race the draining pool.
 		return ctx.Err()
 	}
 }
@@ -386,6 +428,39 @@ func (l *Loop) reconcilerID() string {
 		return l.ReconcilerID
 	}
 	return reconcilerIDSentinel
+}
+
+// maxReconcilerIDLen bounds a ReconcilerID, mirroring the owner-dimension length
+// cap used by adapters/redis KeyNamespace and kernel/healthz ProbeName.
+const maxReconcilerIDLen = 48
+
+// validateReconcilerID rejects a non-empty ReconcilerID that is not a
+// low-cardinality, label-safe owner identifier. Empty is allowed (Start then
+// uses the reconcilerIDSentinel). The accepted shape — leading [a-z_], body
+// [a-z0-9_], ≤ maxReconcilerIDLen runes — mirrors the cell-id / ProbeName /
+// KeyNamespace owner conventions: lowercase keeps the metric/log dimension
+// stable, the charset excludes the adapter label separators ('|', '=') plus
+// whitespace / control bytes, and the length cap bounds cardinality. The
+// reconciler metric label is a registration-time owner dimension (set by the
+// Loop's constructor, not request input), so this is a fail-fast guard against a
+// misconfigured owner rather than untrusted-input sanitization. It runs at Start
+// before the metric preflight so a bad ID surfaces at OnStart (bootstrap rolls
+// back) instead of corrupting the time-series.
+func validateReconcilerID(id string) error {
+	if id == "" {
+		return nil
+	}
+	if len(id) > maxReconcilerIDLen {
+		return fmt.Errorf("reconcile: ReconcilerID %q exceeds %d bytes", id, maxReconcilerIDLen)
+	}
+	for i, r := range id {
+		ok := r == '_' || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9')
+		if !ok {
+			return fmt.Errorf("reconcile: ReconcilerID %q has illegal character %q "+
+				"(allowed: leading [a-z_], then [a-z0-9_])", id, r)
+		}
+	}
+	return nil
 }
 
 func (l *Loop) name() string {

--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -255,8 +255,8 @@ func (l *Loop) runWorker(runCtx context.Context, queue chan Request, wg *sync.Wa
 // controller-runtime's dirty/processing dedup. A coalesced trigger is NOT lost
 // under level-triggering — the next resync / requeue re-observes the latest
 // state — but a "mark-dirty, re-run once after the in-flight reconcile" queue
-// (so convergence does not wait for the next resync) is deferred to PR-A5's
-// rate-limited delaying queue.
+// (so convergence does not wait for the next resync) is deferred to PR-A5
+// (#1166, F5) — accepted deferral, not yet implemented.
 func (l *Loop) process(runCtx context.Context, req Request, queue chan<- Request, wg *sync.WaitGroup) {
 	if _, busy := l.inflight.LoadOrStore(req.EntityID, struct{}{}); busy {
 		l.Metrics.recordResult(runCtx, l.reconcilerID(), resultSkipped)
@@ -321,7 +321,7 @@ func (l *Loop) safeReconcile(ctx context.Context, req Request) (res Result, err 
 // leak-free (every goroutine is runCtx-derived + WaitGroup-tracked). The
 // concurrent count is bounded by the live entity set, not capped; a shared
 // rate-limited delaying queue (one timer goroutine total, exponential backoff)
-// is deferred to PR-A5.
+// is deferred to PR-A5 (#1166, F6) — accepted deferral, not yet implemented.
 func (l *Loop) scheduleRequeue(runCtx context.Context, req Request, after time.Duration, queue chan<- Request, wg *sync.WaitGroup) {
 	if after <= 0 {
 		after = l.interval()

--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -181,12 +181,26 @@ func (l *Loop) Start(ownerCtx context.Context) error {
 	}
 
 	done := make(chan struct{})
-	go func() { wg.Wait(); close(done) }()
+	//nolint:gosec // G118: by the time the loop drains, runCtx is already
+	// canceled; the leader-reset metric record must run under a live ctx, so
+	// context.Background() below is deliberate (same rationale as Stop's reset).
+	go func() {
+		wg.Wait()
+		// Single reset site for the leader gauge: when every goroutine has
+		// drained, this instance no longer holds leadership. Resetting here
+		// (rather than in Stop) covers ALL drain paths uniformly — explicit
+		// Stop, owner-ctx cancel without Stop (assembly shutdown), and the
+		// awaitProbe pre-cancel path — so the gauge can never stay stuck at 1.
+		// Background ctx because runCtx is canceled by the time we drain.
+		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
+		close(done)
+	}()
 	l.cancel = cancel
 	l.done = done
 
 	// Single-process Loop: this instance is the (only) leader. Real lease gating
-	// is the leader-election PR's concern.
+	// is the leader-election PR's concern. The matching reset to 0 happens in the
+	// done-watcher above when the loop drains (any path).
 	l.Metrics.setLeader(runCtx, l.reconcilerID(), 1)
 
 	if err := l.awaitProbe(runCtx, cancel, ready); err != nil {
@@ -345,12 +359,10 @@ func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, rea
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))
 		cancel()
-		// Reset the leader gauge optimistically set to 1 in Start: this Loop
-		// never confirmed running and the subsequent Stop is a no-op (cancel is
-		// cleared below), so without this reset reconcile_leader would stay 1
-		// forever. Background ctx because runCtx is already canceled (mirrors
-		// Stop's drained-path reset).
-		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
+		// The leader gauge (optimistically set to 1 in Start) is reset by the
+		// done-watcher once the spawned workers drain via runCtx.Done(); no reset
+		// here (single reset site — see Start). We only clear cancel/done so a
+		// later Stop is a no-op.
 		l.cancel = nil
 		l.done = nil
 		return nil
@@ -373,9 +385,10 @@ func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, rea
 // — it never spawns a second pool racing the one still unwinding — and (b) a
 // Stop that exhausts ctx's budget can simply be called again to keep waiting.
 // cancel() is idempotent, so a retried Stop re-selects on the same done channel
-// without harm. The leader gauge is reset to 0 only on confirmed drain: a
-// timed-out Stop is "not yet stopped", so leader stays 1 until a later Stop
-// drains it.
+// without harm. The leader gauge is reset to 0 by the done-watcher (see Start)
+// when the loop drains — sequenced before close(done), so by the time this Stop
+// observes <-done the gauge is already 0. A timed-out Stop is "not yet stopped",
+// so leader stays 1 until a later Stop (or owner-ctx cancel) drains it.
 func (l *Loop) Stop(ctx context.Context) error {
 	if l == nil {
 		return nil
@@ -392,11 +405,13 @@ func (l *Loop) Stop(ctx context.Context) error {
 
 	select {
 	case <-done:
+		// Drained: the done-watcher has already reset the leader gauge to 0
+		// (sequenced before close(done)). Clear state so a later Start can
+		// restart the loop.
 		l.mu.Lock()
 		l.cancel = nil
 		l.done = nil
 		l.mu.Unlock()
-		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
 		l.logger().Info("reconcile: loop stopped",
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))

--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -129,9 +129,14 @@ type Loop struct {
 	// Metrics holds optional pre-bound instruments (nil-safe).
 	Metrics Metrics
 
-	mu       sync.Mutex
-	cancel   context.CancelFunc
-	done     chan struct{}
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+	// gen is the run generation, bumped under mu on each Start. Each run's
+	// done-watcher captures its generation and only writes the leader gauge /
+	// clears state if it is still the active generation — so a slow watcher from
+	// an old run cannot reset a newer run's leader=1 (generation ownership).
+	gen      uint64
 	inflight sync.Map // EntityID(string) -> struct{}: same-entity serial guard
 }
 
@@ -159,6 +164,8 @@ func (l *Loop) Start(ownerCtx context.Context) error {
 	if l.cancel != nil {
 		return nil // already started — idempotent
 	}
+	l.gen++
+	gen := l.gen
 
 	runCtx, cancel := context.WithCancel(ownerCtx)
 	queue := make(chan Request, queueBuffer)
@@ -181,38 +188,61 @@ func (l *Loop) Start(ownerCtx context.Context) error {
 	}
 
 	done := make(chan struct{})
-	//nolint:gosec // G118: by the time the loop drains, runCtx is already
-	// canceled; the leader-reset metric record must run under a live ctx, so
-	// context.Background() below is deliberate (same rationale as Stop's reset).
-	go func() {
-		wg.Wait()
-		// Single reset site for the leader gauge: when every goroutine has
-		// drained, this instance no longer holds leadership. Resetting here
-		// (rather than in Stop) covers ALL drain paths uniformly — explicit
-		// Stop, owner-ctx cancel without Stop (assembly shutdown), and the
-		// awaitProbe pre-cancel path — so the gauge can never stay stuck at 1.
-		// Background ctx because runCtx is canceled by the time we drain.
-		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
-		close(done)
-	}()
+	//nolint:gosec // G118: watchDrain resets the leader gauge after the run has
+	// drained (runCtx canceled by then), so its metric record must use a live ctx
+	// (context.Background) rather than the dead runCtx — deliberate, see watchDrain.
+	go l.watchDrain(gen, done, &wg)
 	l.cancel = cancel
 	l.done = done
-
-	// Single-process Loop: this instance is the (only) leader. Real lease gating
-	// is the leader-election PR's concern. The matching reset to 0 happens in the
-	// done-watcher above when the loop drains (any path).
-	l.Metrics.setLeader(runCtx, l.reconcilerID(), 1)
 
 	if err := l.awaitProbe(runCtx, cancel, ready); err != nil {
 		return err
 	}
+	// Claim leadership only on the confirmed path. awaitProbe clears l.cancel on
+	// its pre-cancel branch, so a nil l.cancel here means "owner ctx was canceled
+	// before we confirmed running" — we do NOT set leader=1 then (watchDrain will
+	// hold it at 0). This write is under l.mu (held for the whole Start body), so
+	// it strictly precedes this run's watchDrain reset to 0, which can only
+	// acquire l.mu after Start returns — closing the #1292 r2 ordering race.
 	if l.cancel != nil {
+		l.Metrics.setLeader(runCtx, l.reconcilerID(), 1)
 		l.logger().Info("reconcile: loop started",
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()),
 			slog.Int("workers", workers))
 	}
 	return nil
+}
+
+// watchDrain waits for run gen's goroutines to finish, then — if gen is still
+// the active generation — resets the leader gauge to 0 and clears run state, and
+// finally closes done. It is the single site that resets leader / clears state
+// on drain, covering every path uniformly: explicit Stop, owner-ctx cancel
+// without Stop (assembly shutdown), and the awaitProbe pre-cancel branch.
+//
+// Two invariants make the leader gauge race-free (#1292 r2):
+//   - Ordering: it takes l.mu, which Start holds for its entire body, so this
+//     reset to 0 can only run after Start has returned — i.e. after Start's
+//     confirmed-path setLeader(1). The optimistic-then-reset window that let the
+//     gauge end at 1 under -count=1000 is gone.
+//   - Generation ownership: the reset is gated on l.gen == gen, so a slow
+//     watcher from a superseded run cannot clobber a newer run's leader=1.
+//
+// close(done) is sequenced after the reset, so a Stop observing <-done sees the
+// gauge already at 0 (happens-before).
+func (l *Loop) watchDrain(gen uint64, done chan struct{}, wg *sync.WaitGroup) {
+	wg.Wait()
+	l.mu.Lock()
+	if l.gen == gen {
+		// context.Background: the run has drained (runCtx canceled), so the
+		// leader-reset record must use a live ctx. The G118 nolint sits on the
+		// `go l.watchDrain(...)` launch in Start (that is where gosec reports it).
+		l.Metrics.setLeader(context.Background(), l.reconcilerID(), 0)
+		l.cancel = nil
+		l.done = nil
+	}
+	l.mu.Unlock()
+	close(done)
 }
 
 // pump copies Source into the internal queue until the run ctx is canceled.
@@ -345,24 +375,27 @@ func (l *Loop) scheduleRequeue(runCtx context.Context, req Request, after time.D
 
 // awaitProbe waits for the worker pool to confirm it is running, returning nil
 // in all non-error cases:
-//   - owner ctx already canceled before we got here: log Warn, clear state so a
-//     later Stop is a no-op, and let the workers self-exit via runCtx.Done().
-//     Checked FIRST (before the select) so this path is deterministic — `ready`
-//     closes at worker spawn and would otherwise race the cancellation, leaving
-//     this branch ~unreachable (and untestable).
+//   - owner ctx already canceled before we got here: log Warn, clear l.cancel so
+//     Start skips the leader=1 claim (and a later Stop is a no-op), and let the
+//     workers self-exit via runCtx.Done(). Checked FIRST (before the select) so
+//     this path is deterministic — `ready` closes at worker spawn and would
+//     otherwise race the cancellation, leaving this branch ~unreachable (and
+//     untestable).
 //   - ready closed: a worker started — confirmed.
 //   - probe window elapsed: defensive fallback if a worker is slow to schedule;
 //     workers are spawned, so return anyway (fast-return OnStart contract).
+//
+// Runs under Start's l.mu, so clearing l.cancel/l.done here needs no extra lock.
 func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, ready <-chan struct{}) error {
 	if runCtx.Err() != nil {
 		l.logger().Warn("reconcile: owner ctx canceled before loop confirmed running",
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))
 		cancel()
-		// The leader gauge (optimistically set to 1 in Start) is reset by the
-		// done-watcher once the spawned workers drain via runCtx.Done(); no reset
-		// here (single reset site — see Start). We only clear cancel/done so a
-		// later Stop is a no-op.
+		// Clear l.cancel so Start's post-probe check skips the leader=1 claim:
+		// the gauge is never raised on this path, so there is nothing to reset
+		// and no setLeader(1)/setLeader(0) ordering race. watchDrain still runs
+		// (gen-guarded) and leaves the gauge at 0.
 		l.cancel = nil
 		l.done = nil
 		return nil
@@ -380,15 +413,15 @@ func (l *Loop) awaitProbe(runCtx context.Context, cancel context.CancelFunc, rea
 // Stop cancels the Loop and waits for all goroutines (workers, pump, pending
 // requeues) to exit within ctx's budget.
 //
-// State (l.cancel / l.done) is cleared ONLY after the goroutines actually drain.
-// Until then the fields stay set so that (a) a concurrent Start remains a no-op
-// — it never spawns a second pool racing the one still unwinding — and (b) a
-// Stop that exhausts ctx's budget can simply be called again to keep waiting.
-// cancel() is idempotent, so a retried Stop re-selects on the same done channel
-// without harm. The leader gauge is reset to 0 by the done-watcher (see Start)
-// when the loop drains — sequenced before close(done), so by the time this Stop
-// observes <-done the gauge is already 0. A timed-out Stop is "not yet stopped",
-// so leader stays 1 until a later Stop (or owner-ctx cancel) drains it.
+// State (l.cancel / l.done) is cleared by watchDrain ONLY after the goroutines
+// actually drain. Until then the fields stay set so that (a) a concurrent Start
+// remains a no-op — it never spawns a second pool racing the one still unwinding
+// — and (b) a Stop that exhausts ctx's budget can simply be called again to keep
+// waiting. cancel() is idempotent, so a retried Stop re-selects on the same done
+// channel without harm. The leader gauge is reset to 0 by watchDrain (sequenced
+// before close(done)), so by the time this Stop observes <-done the gauge is
+// already 0. A timed-out Stop is "not yet stopped", so leader stays 1 until a
+// later Stop (or owner-ctx cancel) drains it.
 func (l *Loop) Stop(ctx context.Context) error {
 	if l == nil {
 		return nil
@@ -405,13 +438,9 @@ func (l *Loop) Stop(ctx context.Context) error {
 
 	select {
 	case <-done:
-		// Drained: the done-watcher has already reset the leader gauge to 0
-		// (sequenced before close(done)). Clear state so a later Start can
-		// restart the loop.
-		l.mu.Lock()
-		l.cancel = nil
-		l.done = nil
-		l.mu.Unlock()
+		// Drained: watchDrain has already reset the leader gauge to 0 and cleared
+		// l.cancel/l.done (sequenced before close(done)), so a later Start can
+		// restart the loop. Nothing left to do but log.
 		l.logger().Info("reconcile: loop stopped",
 			slog.String("loop", l.name()),
 			slog.String("reconciler", l.reconcilerID()))

--- a/kernel/reconcile/loop_test.go
+++ b/kernel/reconcile/loop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -392,4 +393,129 @@ func TestLoop_RecordsSuccessMetrics(t *testing.T) {
 	// In-flight returns to 0 and leader to 0 after Stop.
 	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileInFlight, kernelmetrics.Labels{labelReconciler: "rc"}))
 	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}))
+}
+
+// -----------------------------------------------------------------------------
+// Review fixes: leader-gauge reset paths (F3/F4) + ReconcilerID validation (F7)
+// -----------------------------------------------------------------------------
+
+// TestLoop_OwnerCtxCanceledBeforeStartResetsLeader covers F3: Start
+// optimistically sets reconcile_leader=1, then awaitProbe's owner-cancel
+// pre-check returns without confirming the loop and makes the subsequent Stop a
+// no-op. The gauge MUST be reset to 0 on that path, else it stays stuck at 1.
+func TestLoop_OwnerCtxCanceledBeforeStartResetsLeader(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	l := &Loop{
+		ReconcilerID: "rc",
+		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{RequeueAfter: testtime.D1h}, nil }),
+		Interval:     testtime.D1h,
+		Metrics:      m,
+	}
+	ownerCtx, ownerCancel := startCtxs(t)
+	ownerCancel() // cancel BEFORE Start — awaitProbe pre-check fires
+	require.NoError(t, l.Start(ownerCtx))
+	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}),
+		"leader must reset to 0 when the owner ctx is canceled before the loop confirms running")
+	require.NoError(t, l.Stop(context.Background())) // no-op; state already cleared
+}
+
+// TestLoop_StopRetryableAfterTimeout covers F4: a Stop that exhausts its budget
+// while a reconcile is stuck must NOT prematurely clear l.cancel/l.done or reset
+// the leader gauge. State is retained so a concurrent Start stays a no-op (no
+// second pool racing the draining one) and a later Stop drains and resets the
+// gauge to 0.
+func TestLoop_StopRetryableAfterTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	rec := newBlockingReconciler()
+	rec.ignoreCtx = true // stuck mid-work, ignores ctx until released
+	src := make(chan Request)
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: testtime.D1h, Metrics: m}
+	ownerCtx, ownerCancel := startCtxs(t)
+	defer ownerCancel()
+	require.NoError(t, l.Start(ownerCtx))
+
+	src <- Request{EntityID: "stuck"}
+	testwait.External(t, "reconcile-started", func() bool { return rec.calls.Load() >= 1 },
+		testtime.D500ms, testtime.D1ms, "a reconcile must be running before Stop")
+
+	// First Stop times out (reconcile stuck): returns deadline, leaves state.
+	sc1, cancel1 := context.WithTimeout(context.Background(), testtime.D1ms)
+	defer cancel1()
+	require.ErrorIs(t, l.Stop(sc1), context.DeadlineExceeded)
+	assert.Equal(t, float64(1), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}),
+		"a timed-out Stop must leave leader=1 (loop not yet drained)")
+	l.mu.Lock()
+	retained := l.cancel != nil && l.done != nil
+	l.mu.Unlock()
+	assert.True(t, retained, "a timed-out Stop must retain l.cancel/l.done so Start stays a no-op and Stop is retryable")
+
+	// Start during draining must be a no-op (does not spawn a second pool).
+	require.NoError(t, l.Start(ownerCtx))
+	assert.EqualValues(t, 1, rec.calls.Load(), "Start during draining must not spawn a second pool / reconcile")
+
+	// Unstick, then a retried Stop drains and resets the gauge.
+	close(rec.release)
+	sc2, cancel2 := stopCtx(t)
+	defer cancel2()
+	require.NoError(t, l.Stop(sc2), "Stop must be retryable after a timeout")
+	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}))
+	l.mu.Lock()
+	cleared := l.cancel == nil && l.done == nil
+	l.mu.Unlock()
+	assert.True(t, cleared, "a drained Stop must clear l.cancel/l.done")
+}
+
+// TestValidateReconcilerID covers F7: the owner-dimension validator that keeps a
+// ReconcilerID label-safe and low-cardinality.
+func TestValidateReconcilerID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		ok   bool
+	}{
+		{"empty uses sentinel", "", true},
+		{"simple", "mdmcell", true},
+		{"digits and underscore", "mdm_cell2", true},
+		{"sentinel", reconcilerIDSentinel, true},
+		{"leading underscore", "_x", true},
+		{"max length", strings.Repeat("a", maxReconcilerIDLen), true},
+		{"leading digit", "2cell", false},
+		{"uppercase", "Cell", false},
+		{"dash", "mdm-cell", false},
+		{"dot", "mdm.cell", false},
+		{"space", "mdm cell", false},
+		{"label separator pipe", "a|b", false},
+		{"label separator equals", "a=b", false},
+		{"too long", strings.Repeat("a", maxReconcilerIDLen+1), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReconcilerID(tc.id)
+			if tc.ok {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestLoop_BadReconcilerIDFailsStart covers F7 at the Start gate: a malformed
+// ReconcilerID fails OnStart (bootstrap rolls back) before any metric record.
+func TestLoop_BadReconcilerIDFailsStart(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	l := &Loop{
+		ReconcilerID: "Bad-ID",
+		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{}, nil }),
+	}
+	err := l.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ReconcilerID")
+	require.NoError(t, l.Stop(context.Background())) // no-op, goleak stays clean
 }

--- a/kernel/reconcile/loop_test.go
+++ b/kernel/reconcile/loop_test.go
@@ -176,14 +176,28 @@ func TestLoop_StartStopGraceful(t *testing.T) {
 
 func TestLoop_OwnerCtxCancelDrainsWithoutStop(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
 	l := &Loop{
 		ReconcilerID: "rc",
 		Reconciler:   funcReconciler(func(context.Context, Request) (Result, error) { return Result{RequeueAfter: testtime.D1h}, nil }),
 		Interval:     testtime.D1h,
+		Metrics:      m,
 	}
 	ownerCtx, ownerCancel := startCtxs(t)
 	require.NoError(t, l.Start(ownerCtx))
+	assert.Equal(t, float64(1), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}),
+		"leader must be 1 while the loop runs")
 	ownerCancel() // assembly shutdown — no explicit Stop; goleak verifies drain
+	// F3: leader must return to 0 on owner-cancel drain even WITHOUT an explicit
+	// Stop — the done-watcher is the single reset site, so this path no longer
+	// leaves reconcile_leader stuck at 1.
+	testwait.External(t, "leader-reset-on-owner-cancel",
+		func() bool {
+			return p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}) == 0
+		},
+		testtime.D500ms, testtime.D1ms, "leader gauge must reset to 0 when owner ctx drains the loop without Stop")
 }
 
 // TestLoop_OwnerCtxCanceledBeforeStart mirrors the transplant source's
@@ -417,8 +431,13 @@ func TestLoop_OwnerCtxCanceledBeforeStartResetsLeader(t *testing.T) {
 	ownerCtx, ownerCancel := startCtxs(t)
 	ownerCancel() // cancel BEFORE Start — awaitProbe pre-check fires
 	require.NoError(t, l.Start(ownerCtx))
-	assert.Equal(t, float64(0), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}),
-		"leader must reset to 0 when the owner ctx is canceled before the loop confirms running")
+	// The reset is via the done-watcher (single reset site), so it is async to
+	// Start returning — poll until the spawned workers drain and reset it.
+	testwait.External(t, "leader-reset-precancel",
+		func() bool {
+			return p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}) == 0
+		},
+		testtime.D500ms, testtime.D1ms, "leader must reset to 0 when owner ctx is canceled before the loop confirms running")
 	require.NoError(t, l.Stop(context.Background())) // no-op; state already cleared
 }
 

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -457,75 +457,73 @@ var forbiddenTimeFns = map[string]string{
 	"Sleep":     "clock.Clock.Sleep",
 }
 
-// exactSanctionedTimeCalls maps each controlPlaneClock method name to the
-// exact stdlib time.* function name (without the "time." prefix) that the
-// method body may call. The carve-out is keyed on the (method name, callee)
-// pair, NOT on receiver type alone — so any other stdlib time.* function call
-// inside a controlPlaneClock method (e.g. time.Sleep inside newTicker) is a
-// violation, and any new exempt method requires extending this map AND adding
-// the method to the sealed type.
+// controlPlaneClockCarveOut maps each sanctioned control-plane host package
+// (directory prefix, trailing "/") to the exact set of (controlPlaneClock method
+// name → stdlib time.* function name, without the "time." prefix) pairs that
+// host's methods may call directly. The carve-out key is the (host, method,
+// callee) TRIPLE: a method is exempt ONLY in the host that declares it.
 //
-// Extension policy (HARD form-uniqueness): the only way to add a new
-// (method, callee) pair is a deliberate code change here PLUS adding the
-// method to a controlPlaneClock type in a sanctioned host package (see
-// controlPlaneClockHosts: runtime/command/lifecycle.go or
-// kernel/reconcile/loop.go). A new method on controlPlaneClock without an entry
-// here is a violation for every time.* call it makes (the method exists but
-// exactSanctionedTimeCalls lookup returns ""); a new entry here without a
-// matching method does nothing (no FuncDecl position binds to it). Both halves
-// are required.
+// Why host-scoped, not a global method→callee map (#1275 review F1): a flat,
+// host-agnostic map let any host borrow any other host's method exception — and
+// let a newly added host inherit ALL methods for free. Binding the method set to
+// its host closes both: runtime/command's newTicker is not exempt in
+// kernel/reconcile, kernel/reconcile's newRequeueTimer/now are not exempt in
+// runtime/command, and adding a third host grants NOTHING until that host gets
+// its own explicit (method→callee) entries here.
 //
-// The map is keyed by method name only (not package): each sanctioned host
-// declares the subset it uses (runtime/command: newTicker + newProbeTimer;
-// kernel/reconcile: newProbeTimer + newRequeueTimer + now). A host need not
-// declare every method, but any method it declares MUST appear here.
+// Host prefixes are disjoint (runtime/command/ vs kernel/reconcile/), so the
+// per-rel lookup in controlPlaneClockHostMethods is unambiguous.
 //
-// ref: docs/architecture/202605270000-adr-clock-positional-injection-funnel.md §#619
-var exactSanctionedTimeCalls = map[string]string{
-	"newTicker":       "NewTicker", // runtime/command: SweeperLifecycle ticker
-	"newProbeTimer":   "NewTimer",  // runtime/command + kernel/reconcile: startup probe
-	"newRequeueTimer": "NewTimer",  // kernel/reconcile: delayed requeue (RECONCILE-LOOP-CLOCK-CARVEOUT-01)
-	"now":             "Now",       // kernel/reconcile: reconcile-duration measurement
-}
-
-// controlPlaneClockHosts lists the packages sanctioned to host a sealed,
-// package-private controlPlaneClock type (the real-only control-plane scheduling
-// clock). Gate (a) of clockControlPlaneAllowedMethods restricts the carve-out to
-// these paths so no other package can claim it by reusing the type name; each
-// member declares its OWN unexported controlPlaneClock.
-//
-// Members (trailing "/" = directory prefix):
-//   - runtime/command/  — SweeperLifecycle (PROD-CLOCK-INJECTION-01 origin).
-//   - kernel/reconcile/ — reconcile.Loop (RECONCILE-LOOP-CLOCK-CARVEOUT-01).
+// Extension policy (HARD form-uniqueness): adding a new exempt callsite requires
+// BOTH a deliberate entry here under the owning host AND a matching method on
+// that host's package-private controlPlaneClock type. A method without an entry
+// is a violation for every time.* call it makes; an entry without a matching
+// method binds to no FuncDecl position and does nothing. Both halves are
+// required, and the host that declares the method must be the host that lists
+// it.
 //
 // AI-robust grade unchanged: Medium (permanent ceiling) — see
-// clockControlPlaneAllowedMethods. Adding a host is a deliberate, reviewable
-// change here; the per-host seal is the package-private type name + gate (c).
-var controlPlaneClockHosts = []string{
-	"runtime/command/",
-	"kernel/reconcile/",
+// clockControlPlaneAllowedMethods. Adding a host/method is a deliberate,
+// reviewable change here; the per-host seal is the package-private type name +
+// gate (c) + this host-scoped table.
+//
+// ref: docs/architecture/202605270000-adr-clock-positional-injection-funnel.md §#619
+var controlPlaneClockCarveOut = map[string]map[string]string{
+	"runtime/command/": {
+		"newTicker":     "NewTicker", // SweeperLifecycle ticker
+		"newProbeTimer": "NewTimer",  // startup probe
+	},
+	"kernel/reconcile/": {
+		"newProbeTimer":   "NewTimer", // startup probe
+		"newRequeueTimer": "NewTimer", // delayed requeue (RECONCILE-LOOP-CLOCK-CARVEOUT-01)
+		"now":             "Now",      // reconcile-duration measurement
+	},
 }
 
-// hasControlPlaneClockHostPrefix reports whether rel is under a sanctioned
-// control-plane host package (gate (a)).
-func hasControlPlaneClockHostPrefix(rel string) bool {
-	for _, h := range controlPlaneClockHosts {
-		if strings.HasPrefix(rel, h) {
-			return true
+// controlPlaneClockHostMethods returns the (method name → sanctioned callee) set
+// for the control-plane host package that rel belongs to, or nil if rel is under
+// no sanctioned host (gate (a)). Host prefixes in controlPlaneClockCarveOut are
+// disjoint, so at most one matches.
+func controlPlaneClockHostMethods(rel string) map[string]string {
+	for host, methods := range controlPlaneClockCarveOut {
+		if strings.HasPrefix(rel, host) {
+			return methods
 		}
 	}
-	return false
+	return nil
 }
 
 // clockControlPlaneAllowedMethods returns the map of FuncDecl name-positions
-// (format: fset.Position(fd.Name.Pos()).String()) to method name for methods
-// in file that are candidates for the PROD-CLOCK-INJECTION-01 carve-out.
+// (format: fset.Position(fd.Name.Pos()).String()) to the sanctioned stdlib
+// callee for methods in file that are candidates for the PROD-CLOCK-INJECTION-01
+// carve-out.
 //
 // A FuncDecl is a candidate if and only if ALL of:
 //
-//	(a) rel is under a sanctioned control-plane host package
-//	    (controlPlaneClockHosts: "runtime/command/" or "kernel/reconcile/") —
-//	    this package gate prevents any other package from claiming to host a
+//	(a) rel is under a sanctioned control-plane host package — i.e.
+//	    controlPlaneClockHostMethods(rel) is non-nil (host keys of
+//	    controlPlaneClockCarveOut: "runtime/command/" or "kernel/reconcile/").
+//	    This package gate prevents any other package from claiming to host a
 //	    "controlPlaneClock" method; the type is package-private (unexported) so
 //	    only code in a host package can declare methods on it. This is the
 //	    structural "seal" that replaces the old hand-maintained allowlist map.
@@ -537,14 +535,16 @@ func hasControlPlaneClockHostPrefix(rel string) bool {
 //	    forms are accepted for robustness, though the current impl uses value
 //	    receivers only.
 //
-//	(d) The method name appears as a key in exactSanctionedTimeCalls — methods
-//	    on controlPlaneClock that lack an entry never grant carve-out. This is
-//	    the form-uniqueness lock that closes the "any time.* in any method
+//	(d) The method name is listed FOR THIS HOST in controlPlaneClockCarveOut.
+//	    A method listed only under a different host is NOT a candidate here (no
+//	    cross-host borrowing — #1275 review F1); a method absent from every host
+//	    set is not a candidate either, closing the "any time.* in any method
 //	    body" gap (#1136 review F2).
 //
-// The returned map value is the method name; callers check the resolved time
-// function name against exactSanctionedTimeCalls[methodName] to decide whether
-// the specific time.* call is sanctioned (exact (method, callee) pair).
+// The returned map value is the sanctioned stdlib callee for that (host, method)
+// pair; callers check the resolved time function name against it to decide
+// whether the specific time.* call is sanctioned (exact (host, method, callee)
+// triple).
 //
 // Uses EachInChildren[ast.FuncDecl](file, ...) — top-level FuncDecls are
 // direct children of *ast.File, so depth=1 is correct and sufficient.
@@ -552,13 +552,17 @@ func hasControlPlaneClockHostPrefix(rel string) bool {
 // AI-robust grade: Medium (permanent ceiling). The stdlib time.NewTicker /
 // time.NewTimer free functions cannot be made uncallable in Go, so receiver-type
 // confinement is the permanent ceiling here (same as SPAN-SETATTR-REDACT-01
-// package-internal axis). Form-uniqueness within that ceiling is now (method,
-// callee) exact-pair — the strongest available form for stdlib free-function
-// callouts. Gain over the former receiver-type-only carve-out (#1136 F2):
+// package-internal axis). Form-uniqueness within that ceiling is now the
+// (host, method, callee) exact-triple — the strongest available form for stdlib
+// free-function callouts. Gain over the former receiver-type-only carve-out
+// (#1136 F2) and the host-agnostic method map (#1275 F1):
 //   - Any time.* call inside a controlPlaneClock method body other than the
-//     declared (method, callee) pair is a violation — no "method body wildcard".
-//   - Adding a controlPlaneClock method without an exactSanctionedTimeCalls
-//     entry leaves it ungated; any time.* call in it is flagged.
+//     declared (host, method, callee) triple is a violation — no "method body
+//     wildcard".
+//   - Adding a controlPlaneClock method without a controlPlaneClockCarveOut
+//     entry for its host leaves it ungated; any time.* call in it is flagged.
+//   - A host cannot use another host's sanctioned method, and a newly added
+//     host inherits no exceptions until it gets its own explicit entries.
 //
 // Blind spots (per ai-robust.md §"工具选定后强制盲区自检"):
 //  1. A FuncLit (anonymous function / closure) cannot be a method; time.* calls
@@ -571,7 +575,7 @@ func hasControlPlaneClockHostPrefix(rel string) bool {
 //  2. A method named controlPlaneClock from an entirely different package would
 //     satisfy (b)+(c) without gate (a). Gate (a) prevents this by requiring the
 //     file's module-relative path to be under a sanctioned host package
-//     (controlPlaneClockHosts: runtime/command/ or kernel/reconcile/).
+//     (controlPlaneClockCarveOut keys: runtime/command/ or kernel/reconcile/).
 //     Reverse self-check: control_plane_wrong_path_violates fixture has a struct
 //     named controlPlaneClock with a method outside any host → still flagged.
 //     GREEN self-check for the kernel/reconcile host: control_plane_reconcile_passes.
@@ -582,22 +586,28 @@ func hasControlPlaneClockHostPrefix(rel string) bool {
 //     Reverse self-check: control_plane_wrong_receiver_type_violates asserts such
 //     a method is flagged (receiver type "otherClock" ≠ "controlPlaneClock").
 //  4. A new controlPlaneClock method (e.g. "harvest") that calls time.Sleep
-//     would have passed under the receiver-type-only form; the (method, callee)
-//     pair lock rejects it because "harvest" is not in exactSanctionedTimeCalls.
+//     would have passed under the receiver-type-only form; the host-scoped table
+//     rejects it because "harvest" is in no host's set.
 //     Reverse self-check: control_plane_wrong_method_name_violates fixture.
 //  5. A sanctioned method (e.g. "newTicker") that calls the wrong time.*
 //     function (e.g. time.Sleep instead of time.NewTicker) would pass under
-//     the receiver-type-only form; the (method, callee) pair lock rejects it
-//     because exactSanctionedTimeCalls["newTicker"] != "Sleep".
+//     the receiver-type-only form; the stored-callee check rejects it because
+//     the host's "newTicker" callee is "NewTicker", not "Sleep".
 //     Reverse self-check: control_plane_wrong_callee_violates fixture.
+//  6. A host using ANOTHER host's sanctioned method (e.g. kernel/reconcile
+//     declaring "newTicker", which is only runtime/command's) would have passed
+//     under the former host-agnostic method map; the host-scoped table rejects
+//     it because "newTicker" is not in the kernel/reconcile set (#1275 F1).
+//     Reverse self-check: control_plane_cross_host_method_violates fixture.
 //
 // ref: docs/architecture/202605270000-adr-clock-positional-injection-funnel.md §#619
 // ref: PROD-CLOCK-INJECTION-01
 func clockControlPlaneAllowedMethods(fset *token.FileSet, file *ast.File, rel string) map[string]string {
 	out := map[string]string{}
-	// Gate (a): only sanctioned control-plane host packages may host
-	// controlPlaneClock methods (see controlPlaneClockHosts).
-	if !hasControlPlaneClockHostPrefix(rel) {
+	// Gate (a): resolve the host's (method→callee) carve-out set. nil ⇒ rel is
+	// under no sanctioned control-plane host, so no method here is a candidate.
+	hostMethods := controlPlaneClockHostMethods(rel)
+	if hostMethods == nil {
 		return out
 	}
 	EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
@@ -606,23 +616,24 @@ func clockControlPlaneAllowedMethods(fset *token.FileSet, file *ast.File, rel st
 			return
 		}
 		// Gate (c): receiver type name must be "controlPlaneClock" (or pointer to it).
-		recvTypeName := clockReceiverTypeName(fd)
-		if recvTypeName != "controlPlaneClock" {
+		if clockReceiverTypeName(fd) != "controlPlaneClock" {
 			return
 		}
 		if fd.Name == nil {
 			return
 		}
-		// Gate (d): method name must be a key in exactSanctionedTimeCalls. Methods
-		// on controlPlaneClock that lack an entry are NOT carve-out candidates —
-		// any time.* call inside them is flagged the same as in any other production
-		// method. This is the form-uniqueness lock that prevents the "any method
-		// body wildcard" loophole (#1136 review F2).
-		if _, ok := exactSanctionedTimeCalls[fd.Name.Name]; !ok {
+		// Gate (d): the method must be listed FOR THIS HOST. A method present in a
+		// different host's set is NOT a candidate here (the host-scoped table
+		// prevents cross-host borrowing — #1275 review F1). Methods absent from
+		// every host set are NOT candidates either, closing the "any method body
+		// wildcard" loophole (#1136 review F2). The stored value is the sanctioned
+		// stdlib callee, so the caller checks the exact (host, method, callee)
+		// triple without a second lookup.
+		callee, ok := hostMethods[fd.Name.Name]
+		if !ok {
 			return
 		}
-		key := fset.Position(fd.Name.Pos()).String()
-		out[key] = fd.Name.Name
+		out[fset.Position(fd.Name.Pos()).String()] = callee
 	})
 	return out
 }
@@ -806,22 +817,22 @@ func scanProdClockInjectionAST(fset *token.FileSet, file *ast.File, rel string, 
 	var out []Diagnostic
 	seen := map[string]bool{}
 
-	// Receiver-type + (method, callee) confinement: compute which FuncDecls in
-	// this file may host a sanctioned time.* call, mapped to the controlPlaneClock
-	// method name. Only FuncDecls that are methods of controlPlaneClock AND whose
-	// file is under runtime/command/ AND whose name appears as a key in
-	// exactSanctionedTimeCalls qualify. The final (method, callee) pair check
-	// happens inside record() against exactSanctionedTimeCalls[methodName].
+	// Receiver-type + (host, method, callee) confinement: compute which FuncDecls
+	// in this file may host a sanctioned time.* call, mapped to the sanctioned
+	// stdlib callee for that (host, method) pair. Only FuncDecls that are methods
+	// of controlPlaneClock AND whose file is under a sanctioned host AND whose
+	// name is listed for THAT host (controlPlaneClockCarveOut) qualify. The final
+	// callee check happens inside record() against the stored callee.
 	allowedFuncs := clockControlPlaneAllowedMethods(fset, file, rel)
 
 	record := func(node ast.Node, name string) {
-		// (method, callee) exact-pair carve-out: skip only if pos is inside an
-		// exempt FuncDecl (not inside a closure) AND the time.* function name
-		// matches exactSanctionedTimeCalls[methodName].
+		// (host, method, callee) exact-triple carve-out: skip only if pos is
+		// inside an exempt FuncDecl (not inside a closure) AND the time.* function
+		// name matches the sanctioned callee stored for that method/host.
 		if funcKey := enclosingFuncDeclKey(fset, file, node.Pos()); funcKey != "" {
-			if methodName, isCandidate := allowedFuncs[funcKey]; isCandidate {
-				if exactSanctionedTimeCalls[methodName] == name {
-					return // sanctioned (method, callee) pair
+			if sanctionedCallee, isCandidate := allowedFuncs[funcKey]; isCandidate {
+				if sanctionedCallee == name {
+					return // sanctioned (host, method, callee) triple
 				}
 				// fall through: method is a carve-out candidate but the callee
 				// does not match the declared pair — record violation.

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -721,12 +721,14 @@ func enclosingFuncDeclKey(fset *token.FileSet, file *ast.File, pos token.Pos) st
 // gated on obj.Pkg().Path() == "time" and obj.Name() in forbiddenTimeFns.
 // This makes the check immune to import aliases and dot-imports.
 //
-// Control-plane carve-out (receiver-type confinement, #619 upgrade):
-// A FuncDecl is exempt from PROD-CLOCK-INJECTION-01 only if it is a METHOD
-// whose receiver type name is "controlPlaneClock" AND the file's module-relative
-// path is under "runtime/command/". This replaces the former comment-marker +
-// hand-maintained allowlist-map form (which was AI-abusable: any marked
-// FuncDecl in any allowlisted file could self-exempt by adding the comment).
+// Control-plane carve-out (host-scoped (host, method, callee) triple, #619 +
+// #1275 F1): a FuncDecl is exempt from PROD-CLOCK-INJECTION-01 only if it is a
+// METHOD whose receiver type name is "controlPlaneClock", whose file is under a
+// sanctioned host (controlPlaneClockCarveOut keys: runtime/command/ or
+// kernel/reconcile/), AND whose name maps to the exact stdlib callee listed for
+// THAT host. This replaces the former comment-marker + hand-maintained
+// allowlist-map form (which was AI-abusable: any marked FuncDecl in any
+// allowlisted file could self-exempt by adding the comment).
 //
 // The exemption does NOT extend to closures/FuncLits within an exempt method
 // body. enclosingFuncDeclKey explicitly rejects positions inside FuncLit nodes.
@@ -743,12 +745,15 @@ func enclosingFuncDeclKey(fset *token.FileSet, file *ast.File, pos token.Pos) st
 //     function's closure calling time.NewTicker is flagged.
 //     Reverse self-check B: control_plane_exempt_func_closure_violates — a
 //     closure inside an exempt controlPlaneClock method is still flagged.
-//  2. A struct named "controlPlaneClock" with methods outside runtime/command/:
-//     the path gate prevents exemption.
+//  2. A struct named "controlPlaneClock" with methods outside any sanctioned
+//     host: the path gate prevents exemption.
 //     Reverse self-check: control_plane_wrong_path_violates fixture.
-//  3. A receiver type other than "controlPlaneClock" inside runtime/command/:
-//     only the exact type name matches; wrong receiver type is NOT exempt.
+//  3. A receiver type other than "controlPlaneClock" inside a host: only the
+//     exact type name matches; wrong receiver type is NOT exempt.
 //     Reverse self-check: control_plane_wrong_receiver_type_violates fixture.
+//  4. A host using another host's sanctioned method (e.g. kernel/reconcile
+//     declaring runtime/command's "newTicker"): the host-scoped table denies it.
+//     Reverse self-check: control_plane_cross_host_method_violates fixture.
 //
 // ref: docs/architecture/202605170000-adr-control-plane-business-plane-decouple.md §D-A
 // ref: docs/architecture/202605270000-adr-clock-positional-injection-funnel.md
@@ -799,16 +804,17 @@ func isAllowedRealClockPath(rel string) bool {
 // violation Diagnostics for every reference to one of the forbidden stdlib
 // time functions.
 //
-// Control-plane carve-out: if the forbidden reference sits inside a top-level
-// *ast.FuncDecl that is a METHOD on receiver type "controlPlaneClock" AND the
-// file's module-relative path is under "runtime/command/", that reference is
-// exempt. The carve-out is method-level only — closures within the exempt
-// method body are NOT exempt (enclosingFuncDeclKey rejects positions in FuncLit
-// nodes). Other methods in the same file with a different receiver type are
-// still checked.
+// Control-plane carve-out: a forbidden reference is exempt only if it sits in a
+// top-level *ast.FuncDecl that is a METHOD on receiver type "controlPlaneClock",
+// in a file under a sanctioned host (controlPlaneClockCarveOut keys:
+// runtime/command/ or kernel/reconcile/), AND the method/callee match the exact
+// (host, method, callee) triple listed for that host. The carve-out is
+// method-level only — closures within the exempt method body are NOT exempt
+// (enclosingFuncDeclKey rejects positions in FuncLit nodes). Other methods in
+// the same file with a different receiver type are still checked.
 //
-// AI-robust grade: Medium (receiver-type confinement; see godoc of
-// clockControlPlaneAllowedMethods for the permanent ceiling rationale).
+// AI-robust grade: Medium ((host, method, callee) triple confinement; see godoc
+// of clockControlPlaneAllowedMethods for the permanent ceiling rationale).
 //
 // scanProdClockInjectionAST is exported within the archtest package so the
 // fixture-based regression tests in prod_clock_injection_fixtures_test.go can

--- a/tools/archtest/internal/reconcileloopredfixture/loop_alias.go
+++ b/tools/archtest/internal/reconcileloopredfixture/loop_alias.go
@@ -1,0 +1,23 @@
+//go:build archtest_fixture
+
+// This file adds the alias-bypass RED forms for
+// RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01 (#1292 r2 F2/F3): an import-aliased
+// selector and a Go 1.23 type alias. The type-alias form is the one a bare
+// *types.Named assertion (without types.Unalias) would miss, so it proves the
+// Unalias fix is load-bearing. Gated by the archtest_fixture build tag.
+package reconcileloopredfixture
+
+import rc "github.com/ghbvf/gocell/kernel/reconcile"
+
+// loopTypeAlias is a Go 1.23 type alias to reconcile.Loop. Under
+// gotypesalias=1, a composite literal of it denotes a *types.Alias, so the
+// scanner must types.Unalias before the *types.Named assertion.
+type loopTypeAlias = rc.Loop
+
+//nolint:all // intentional violations for archtest RED fixture
+var (
+	// import-aliased selector form: rc.Loop{} (resolves to reconcile.Loop).
+	redLoopViaImportAlias = &rc.Loop{} //nolint:unused
+	// Go 1.23 type-alias form: needs types.Unalias to be flagged.
+	redLoopViaTypeAlias = &loopTypeAlias{} //nolint:unused
+)

--- a/tools/archtest/internal/reconcileloopredfixture/loop_literal.go
+++ b/tools/archtest/internal/reconcileloopredfixture/loop_literal.go
@@ -1,0 +1,22 @@
+//go:build archtest_fixture
+
+// Package reconcileloopredfixture contains an intentionally-violating form for
+// the RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01 archtest detector. Gated by the
+// archtest_fixture build tag (must agree with the literal value of the
+// unexported fixtureBuildTag const declared in tools/archtest/fixture.go; Go
+// build-directive syntax cannot reference a Go constant, so this file hard-codes
+// the tag literal).
+//
+// It exercises the RED shape: a bare reconcile.Loop{} composite literal in a
+// package outside the allowlist (not kernel/reconcile, not kernel/command),
+// which sidesteps the Builder wiring (metric / leader / backoff).
+package reconcileloopredfixture
+
+import "github.com/ghbvf/gocell/kernel/reconcile"
+
+// VIOLATION: reconcile.Loop{} — forbidden composite literal outside
+// kernel/reconcile. Production code must construct the Loop via the package
+// Builder (PR-A7).
+//
+//nolint:all // intentional violation for archtest RED fixture
+var redLoopLiteral = &reconcile.Loop{} //nolint:unused

--- a/tools/archtest/prod_clock_injection_fixtures_test.go
+++ b/tools/archtest/prod_clock_injection_fixtures_test.go
@@ -24,6 +24,10 @@
 //   - control_plane_exempt_func_closure_violates: RED — blind-spot-A closure
 //     self-check: time.* inside a FuncLit within an exempt (controlPlaneClock)
 //     method is NOT exempt; still flagged (1 violation).
+//   - control_plane_cross_host_method_violates: RED — blind-spot-6 self-check
+//     (#1275 F1): kernel/reconcile declaring runtime/command's "newTicker" gets
+//     no carve-out (host-scoped controlPlaneClockCarveOut); the borrowed
+//     method's time.NewTicker is flagged (1 violation).
 //
 // ref: docs/plans/202605011500-029-master-roadmap.md Track D #D6
 package archtest
@@ -92,8 +96,9 @@ func TestProdClockInjectionFixtures(t *testing.T) {
 		"control_plane_no_marker_violates",           // RED: free function in runtime/command/ (no receiver)
 		"control_plane_closure_violates",             // RED: closure inside non-exempt func
 		"control_plane_exempt_func_closure_violates", // RED: closure inside exempt controlPlaneClock method
-		"control_plane_wrong_method_name_violates",   // RED: new controlPlaneClock method not in exactSanctionedTimeCalls
+		"control_plane_wrong_method_name_violates",   // RED: new controlPlaneClock method in no host carve-out set
 		"control_plane_wrong_callee_violates",        // RED: sanctioned method calls wrong time.* function
+		"control_plane_cross_host_method_violates",   // RED: host borrows another host's method (#1275 F1)
 	}
 
 	for _, dir := range dirs {

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -1,12 +1,14 @@
 package archtest
 
-// reconcile_invariants_test.go locks the three-piece minimal core of
-// kernel/reconcile — the Reconciler interface method set and the Request /
-// Result field sets — via reflect golden freezes.
+// reconcile_invariants_test.go locks kernel/reconcile's public surface: the
+// three-piece minimal core (Reconciler interface method set + Request / Result
+// field sets) via reflect golden freezes, plus the transition-window guard that
+// no code outside the package bare-constructs the scheduling Loop.
 //
 //   - INVARIANT: RECONCILE-INTERFACE-FROZEN-01
 //   - INVARIANT: RECONCILE-REQUEST-FIELDS-FROZEN-01
 //   - INVARIANT: RECONCILE-RESULT-FIELDS-FROZEN-01
+//   - INVARIANT: RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01
 //
 // The design ADR (docs/architecture/202605291600-661-adr-kernel-reconcile-design.md)
 // promises a deliberately minimal public surface: a Reconciler whose only method
@@ -41,9 +43,13 @@ package archtest
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	"go/types"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/reconcile"
 )
@@ -278,5 +284,155 @@ func TestReconcileStructShape_ReverseBlindSpot(t *testing.T) {
 		if v := checkReconcileStructShape(dt, reconcileRequestWantFields); len(v) == 0 {
 			t.Errorf("RECONCILE-REQUEST self-test: detector passed malformed Request %q (blind spot)", name)
 		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01 — no bare Loop{} outside the package
+// -----------------------------------------------------------------------------
+//
+// # RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01
+//
+// reconcile.Loop currently exposes exported fields, so a consumer could
+// bare-construct `reconcile.Loop{Reconciler: r}` and silently skip the
+// metric / leader / backoff wiring a Builder would inject (threat T-BUILDER,
+// design ADR §"威胁矩阵"). PR-A7 closes this for good by privatizing the Loop
+// constructor behind a Builder (the Hard upstream); until then this archtest
+// holds the line: a production composite literal of reconcile.Loop is forbidden
+// anywhere except the home package itself and the A8 kernel/command migration
+// point. Test files (`*_test.go`) construct Loop directly via exported fields and
+// are out of scope (RunTypedProduction excludes them).
+//
+// AI-robust grade (per .claude/rules/gocell/ai-robust.md §"Funnel 双向锁评级"):
+//   - Downstream: Hard. The forbidden form is a single AST shape —
+//     ast.CompositeLit whose type resolves to (kernel/reconcile, "Loop") — with
+//     no "looks-like-but-isn't" grey zone; the type resolver sees through import
+//     aliases and `&Loop{}` address-of wrappers.
+//   - Upstream: Medium (transition). The package-external ban is an archtest
+//     caller-allowlist, not a type-system seal — Go visibility cannot express
+//     "only package P may compose this exported struct". PR-A7's constructor
+//     privatization is the Hard upstream that retires this guard (replaced by
+//     RECONCILE-BUILDER-FUNNEL-01). Tracked under parent issue #661, task A7.
+//
+// This is the documented Medium-upstream + Hard-downstream transition form the
+// charter permits with an open tracking issue (#661 / A7), named here so a
+// reviewer can follow the upgrade path.
+//
+// Blind spots (per ai-robust.md §"工具选定后强制盲区自检"):
+//   - Import alias (`import rc ".../kernel/reconcile"; rc.Loop{}`): the type
+//     resolver keys on the resolved *types.Named obj package path, not the
+//     source alias, so aliasing does not hide the literal.
+//   - Address-of (`&reconcile.Loop{}`): EachInSubtree visits the inner
+//     CompositeLit regardless of the enclosing UnaryExpr, so `&Loop{}` is caught.
+//   - Reflection construction (`reflect.New(...)`): out of scope, same theoretical
+//     gap accepted by BASESLICE-CTOR-FUNNEL-01.
+//   - Zero-field literal `reconcile.Loop{}`: still a CompositeLit of the type —
+//     flagged; the RED fixture below uses exactly this shape to prove the
+//     detector is non-vacuous.
+
+// reconcileLoopLiteralMsg is the diagnostic for a forbidden reconcile.Loop
+// composite literal. Extracted as a const to keep callsites within the line cap.
+const reconcileLoopLiteralMsg = "forbidden composite literal reconcile.Loop{...} outside kernel/reconcile" +
+	" — construct via the package Builder (PR-A7); the exported-field form skips metric/leader/backoff wiring"
+
+// isReconcileLoopType reports whether expr names reconcile.Loop from reconcilePkgPath.
+func isReconcileLoopType(info *types.Info, expr ast.Expr, reconcilePkgPath string) bool {
+	if info == nil || expr == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	if !ok || tv.Type == nil {
+		return false
+	}
+	named, ok := tv.Type.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == reconcilePkgPath && obj.Name() == "Loop"
+}
+
+// scanReconcileLoopConstruction flags every reconcile.Loop composite literal in
+// p, unless p's package is in allowedPkgPaths (the home package + the A8
+// kernel/command migration point). Test files are excluded by the caller
+// (RunTypedProduction with Tests:false).
+func scanReconcileLoopConstruction(p *Pass, reconcilePkgPath string, allowedPkgPaths map[string]bool) []Diagnostic {
+	if p.Pkg != nil && allowedPkgPaths[p.Pkg.Path()] {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.CompositeLit](file, func(lit *ast.CompositeLit) {
+			if !isReconcileLoopType(p.TypesInfo, lit.Type, reconcilePkgPath) {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:     rel,
+				Line:    p.Fset.Position(lit.Pos()).Line,
+				Message: reconcileLoopLiteralMsg,
+			})
+		})
+	}
+	return diags
+}
+
+// reconcileLoopConstructionAllowed returns the package paths permitted to
+// compose reconcile.Loop: the home package (future Builder host) and the A8
+// kernel/command migration point.
+func reconcileLoopConstructionAllowed(modPath string) (reconcilePkgPath string, allowed map[string]bool) {
+	reconcilePkgPath = modPath + "/kernel/reconcile"
+	return reconcilePkgPath, map[string]bool{
+		reconcilePkgPath:            true,
+		modPath + "/kernel/command": true, // A8 migration point (design ADR)
+	}
+}
+
+// TestReconcileLoopConstructionAllowlist01 is the production GREEN baseline: no
+// package outside the allowlist bare-constructs reconcile.Loop.
+func TestReconcileLoopConstructionAllowlist01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+	reconcilePkgPath, allowed := reconcileLoopConstructionAllowed(modPath)
+
+	diags := RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
+		return scanReconcileLoopConstruction(p, reconcilePkgPath, allowed)
+	})
+	Report(t, "RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01", diags)
+}
+
+// TestReconcileLoopConstructionAllowlist01_RedFixture proves the detector is
+// non-vacuous: a fixture package outside the allowlist that composes
+// reconcile.Loop{} must be flagged at least once.
+func TestReconcileLoopConstructionAllowlist01_RedFixture(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+	reconcilePkgPath, allowed := reconcileLoopConstructionAllowed(modPath)
+
+	diags := RunTypedFixture(
+		t,
+		FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/reconcileloopredfixture/..."},
+		func(p *Pass) []Diagnostic {
+			return scanReconcileLoopConstruction(p, reconcilePkgPath, allowed)
+		},
+	)
+
+	var hits int
+	for _, d := range diags {
+		if d.Message == reconcileLoopLiteralMsg {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Errorf("RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01 RED fixture: scanner found 0 hits; " +
+			"expected ≥ 1 from reconcileloopredfixture — the detector may be broken")
 	}
 }

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -318,24 +318,36 @@ func TestReconcileStructShape_ReverseBlindSpot(t *testing.T) {
 // charter permits with an open tracking issue (#661 / A7), named here so a
 // reviewer can follow the upgrade path.
 //
-// Blind spots (per ai-robust.md §"工具选定后强制盲区自检"):
+// Blind spots (per ai-robust.md §"工具选定后强制盲区自检"), each with a RED
+// fixture form in tools/archtest/internal/reconcileloopredfixture/:
 //   - Import alias (`import rc ".../kernel/reconcile"; rc.Loop{}`): the type
-//     resolver keys on the resolved *types.Named obj package path, not the
-//     source alias, so aliasing does not hide the literal.
+//     resolver keys on the resolved obj package path, not the source alias, so
+//     aliasing does not hide the literal. Covered by redLoopViaImportAlias.
+//   - Type alias (`type LoopAlias = reconcile.Loop; LoopAlias{}`): under Go
+//     1.23+ gotypesalias=1 this denotes a *types.Alias, so isReconcileLoopType
+//     MUST call types.Unalias before the *types.Named assertion or it slips past
+//     (#1292 r2 F2). Covered by redLoopViaTypeAlias; the RED test's ≥3-hit
+//     assertion fails if Unalias regresses.
 //   - Address-of (`&reconcile.Loop{}`): EachInSubtree visits the inner
 //     CompositeLit regardless of the enclosing UnaryExpr, so `&Loop{}` is caught.
 //   - Reflection construction (`reflect.New(...)`): out of scope, same theoretical
 //     gap accepted by BASESLICE-CTOR-FUNNEL-01.
 //   - Zero-field literal `reconcile.Loop{}`: still a CompositeLit of the type —
-//     flagged; the RED fixture below uses exactly this shape to prove the
-//     detector is non-vacuous.
+//     flagged; the RED fixture's direct form (redLoopLiteral) uses exactly this
+//     shape to prove the detector is non-vacuous.
 
 // reconcileLoopLiteralMsg is the diagnostic for a forbidden reconcile.Loop
 // composite literal. Extracted as a const to keep callsites within the line cap.
 const reconcileLoopLiteralMsg = "forbidden composite literal reconcile.Loop{...} outside kernel/reconcile" +
 	" — construct via the package Builder (PR-A7); the exported-field form skips metric/leader/backoff wiring"
 
-// isReconcileLoopType reports whether expr names reconcile.Loop from reconcilePkgPath.
+// isReconcileLoopType reports whether expr names reconcile.Loop from
+// reconcilePkgPath, seeing through type aliases. types.Unalias is required
+// because under Go 1.23+ (gotypesalias=1, the default) a `type LoopAlias =
+// reconcile.Loop` denotes a *types.Alias, not a *types.Named — so a bare
+// tv.Type.(*types.Named) assertion would let `LoopAlias{}` slip past the funnel
+// (#1292 r2 F2). Unalias peels the alias chain to the underlying named type and
+// is a no-op when tv.Type is already a *types.Named.
 func isReconcileLoopType(info *types.Info, expr ast.Expr, reconcilePkgPath string) bool {
 	if info == nil || expr == nil {
 		return false
@@ -344,7 +356,7 @@ func isReconcileLoopType(info *types.Info, expr ast.Expr, reconcilePkgPath strin
 	if !ok || tv.Type == nil {
 		return false
 	}
-	named, ok := tv.Type.(*types.Named)
+	named, ok := types.Unalias(tv.Type).(*types.Named)
 	if !ok {
 		return false
 	}
@@ -407,8 +419,11 @@ func TestReconcileLoopConstructionAllowlist01(t *testing.T) {
 }
 
 // TestReconcileLoopConstructionAllowlist01_RedFixture proves the detector is
-// non-vacuous: a fixture package outside the allowlist that composes
-// reconcile.Loop{} must be flagged at least once.
+// non-vacuous AND alias-aware. The fixture package (outside the allowlist)
+// composes reconcile.Loop three ways — direct `&reconcile.Loop{}`, import-aliased
+// `&rc.Loop{}`, and Go 1.23 type-alias `&loopTypeAlias{}`. All three must be
+// flagged; the type-alias form in particular only fires when the scanner calls
+// types.Unalias (#1292 r2 F2), so the ≥3 assertion is what guards that fix.
 func TestReconcileLoopConstructionAllowlist01_RedFixture(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
@@ -431,8 +446,10 @@ func TestReconcileLoopConstructionAllowlist01_RedFixture(t *testing.T) {
 			hits++
 		}
 	}
-	if hits == 0 {
-		t.Errorf("RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01 RED fixture: scanner found 0 hits; " +
-			"expected ≥ 1 from reconcileloopredfixture — the detector may be broken")
+	const wantForms = 3 // direct + import-alias + type-alias
+	if hits < wantForms {
+		t.Errorf("RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01 RED fixture: scanner found %d hits, "+
+			"want ≥ %d (direct + import-alias + type-alias). A shortfall means the type-alias "+
+			"form slipped past — check that isReconcileLoopType calls types.Unalias.", hits, wantForms)
 	}
 }

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_cross_host_method_violates/diag.golden
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_cross_host_method_violates/diag.golden
@@ -1,0 +1,1 @@
+kernel/reconcile/loop.go:24: time.NewTicker — must use injected clock.Clock.NewTicker instead

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_cross_host_method_violates/go.mod
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_cross_host_method_violates/go.mod
@@ -1,0 +1,3 @@
+module fixturetest/prod_clock_injection/control_plane_cross_host_method_violates
+
+go 1.22

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_cross_host_method_violates/kernel/reconcile/loop.go
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_cross_host_method_violates/kernel/reconcile/loop.go
@@ -1,0 +1,25 @@
+// Package reconcile is a RED fixture for PROD-CLOCK-INJECTION-01 #1275 review F1.
+//
+// It asserts that the host-scoped carve-out (controlPlaneClockCarveOut) rejects
+// a host using ANOTHER host's sanctioned method. "newTicker" is sanctioned only
+// for runtime/command; the former host-agnostic method map would have exempted
+// it in any host. Here kernel/reconcile declares controlPlaneClock.newTicker —
+// not in the kernel/reconcile set {newProbeTimer, newRequeueTimer, now} — so the
+// NewTicker call inside is flagged. The legitimate newProbeTimer pair stays
+// exempt (control case).
+package reconcile
+
+import "time"
+
+type controlPlaneClock struct{}
+
+// newProbeTimer is in the kernel/reconcile set — exempt (control case).
+func (controlPlaneClock) newProbeTimer(d time.Duration) *time.Timer {
+	return time.NewTimer(d) // exempt (sanctioned for kernel/reconcile)
+}
+
+// newTicker belongs to runtime/command, NOT kernel/reconcile. The host-scoped
+// table denies cross-host borrowing, so this NewTicker call is flagged.
+func (controlPlaneClock) newTicker(interval time.Duration) *time.Ticker {
+	return time.NewTicker(interval) // RED: newTicker is not a kernel/reconcile pair
+}

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_reconcile_passes/kernel/reconcile/loop.go
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_reconcile_passes/kernel/reconcile/loop.go
@@ -1,9 +1,10 @@
 // Package reconcile is the GREEN control-plane receiver-type confinement fixture
 // for the kernel/reconcile host of PROD-CLOCK-INJECTION-01
 // (RECONCILE-LOOP-CLOCK-CARVEOUT-01). It mirrors the real kernel/reconcile/ path
-// so the rel-gate (controlPlaneClockHosts includes "kernel/reconcile/") plus
-// receiver type name "controlPlaneClock" plus the (method, callee) pairs
-// newProbeTimer→NewTimer / newRequeueTimer→NewTimer / now→Now yield 0 violations.
+// so the rel-gate (controlPlaneClockCarveOut includes "kernel/reconcile/") plus
+// receiver type name "controlPlaneClock" plus the host-scoped (method, callee)
+// pairs newProbeTimer→NewTimer / newRequeueTimer→NewTimer / now→Now yield 0
+// violations.
 package reconcile
 
 import "time"

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_wrong_callee_violates/runtime/command/lifecycle.go
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_wrong_callee_violates/runtime/command/lifecycle.go
@@ -1,10 +1,10 @@
 // Package command is a RED fixture for PROD-CLOCK-INJECTION-01 #1136 review F2.
 //
-// It asserts that the (method, callee) exact-pair carve-out rejects a
+// It asserts that the (host, method, callee) exact-triple carve-out rejects a
 // sanctioned controlPlaneClock method that calls the WRONG time.* function.
 // Under the receiver-type-only form, time.Sleep inside controlPlaneClock.newTicker
-// would have been exempted; the (method, callee) pair form rejects it because
-// exactSanctionedTimeCalls["newTicker"] == "NewTicker" != "Sleep".
+// would have been exempted; the host-scoped table rejects it because the
+// runtime/command "newTicker" callee is "NewTicker", not "Sleep".
 package command
 
 import "time"

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_wrong_method_name_violates/diag.golden
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_wrong_method_name_violates/diag.golden
@@ -1,1 +1,1 @@
-runtime/command/lifecycle.go:24: time.Sleep — must use injected clock.Clock.Sleep instead
+runtime/command/lifecycle.go:23: time.Sleep — must use injected clock.Clock.Sleep instead

--- a/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_wrong_method_name_violates/runtime/command/lifecycle.go
+++ b/tools/archtest/testdata/prod_clock_injection_fixtures/control_plane_wrong_method_name_violates/runtime/command/lifecycle.go
@@ -1,11 +1,10 @@
 // Package command is a RED fixture for PROD-CLOCK-INJECTION-01 #1136 review F2.
 //
-// It asserts that the (method, callee) exact-pair carve-out rejects a new
-// controlPlaneClock method whose name is NOT in exactSanctionedTimeCalls:
-// the receiver-type-only form would have wrongly exempted any time.* call in
-// any controlPlaneClock method body. Under the tightened rule, `harvest()` —
-// not in {newTicker, newProbeTimer} — gets no carve-out and the time.Sleep
-// call inside is flagged.
+// It asserts that the host-scoped carve-out rejects a new controlPlaneClock
+// method whose name is in NO host's set: the receiver-type-only form would have
+// wrongly exempted any time.* call in any controlPlaneClock method body. Under
+// the tightened rule, `harvest()` — not in the runtime/command set {newTicker,
+// newProbeTimer} — gets no carve-out and the time.Sleep call inside is flagged.
 package command
 
 import "time"
@@ -17,9 +16,9 @@ func (controlPlaneClock) newTicker(interval time.Duration) *time.Ticker {
 	return time.NewTicker(interval) // exempt (sanctioned pair)
 }
 
-// harvest is a NEW method on controlPlaneClock — not in exactSanctionedTimeCalls.
+// harvest is a NEW method on controlPlaneClock — in no host's carve-out set.
 // Any time.* call here MUST be flagged (the receiver-type-only form would have
-// exempted it; the (method, callee) pair form rejects it).
+// exempted it; the host-scoped table rejects it).
 func (controlPlaneClock) harvest(d time.Duration) {
-	time.Sleep(d) // RED: harvest is not in exactSanctionedTimeCalls
+	time.Sleep(d) // RED: harvest is in no host carve-out set
 }


### PR DESCRIPTION
后续修复 PR：#1275（#661 PR-A3「Loop 调度骨架」，已合入 develop）的 code-review findings。原 PR 已合并，故在新分支处理。

## 已修复（6 真缺陷）

| Finding | 维度 | Cx | 摘要 |
|---|---|---|---|
| F3 | 运维可观测 | 1 | **leader gauge 复位收敛到 done-watcher 单一站点**，覆盖全部 4 条 drain 路径（Stop / owner-cancel-with-Stop / **owner-cancel-without-Stop** / awaitProbe pre-cancel）。r1 漏了 owner-cancel-without-Stop（`TestLoop_OwnerCtxCancelDrainsWithoutStop` 文档化路径），r2 补齐并加 metric 断言 |
| F4 | 运维可观测 | 1 | `Stop()` 仅在 drain 后清 `cancel/done`；超时路径保留状态 → 可重试 + Start 不与 draining pool 竞态 |
| F7 | 安全/可观测 | 1 | Start 前校验 `ReconcilerID`（lowercase `[a-z0-9_]`、首字符 `[a-z_]`、≤48）fail-fast；与 kernel `ValidateLabels`（已拒 `|`/`=`）互补 |
| F8 | DX | 1 | `doc.go` 不再声称 Loop "NOT present at this commit"；`ReconcilerID` 默认注释 `_unknown`→`_runtime` |
| F1 | 架构合规 | 2 | clock carve-out 改为 `(host, method, callee)` 三元绑定（`controlPlaneClockCarveOut`），杜绝跨 host 借用 + 新 host 继承全部例外；新增反向自检 fixture `control_plane_cross_host_method_violates` |
| F2 | 架构合规/DX | 2 | 落地 ADR 强制的 `RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01`（Medium 上游 + Hard 下游；A7 Builder 落地后退役，归口 #661 A7）；RED fixture 证明非 vacuous |

## 接受延期（**非本 PR 修复**，已显式跟踪）

- **F5（dirty-dedup）/ F6（per-requeue goroutine 无界 → bounded delaying queue）**：ADR §2.2 + 威胁矩阵 **T-DUAL / T-LEAK** 明确的 A3 范围设计取舍，**deferred to A5，非 resolved**。本 PR 仅在 `process()` / `scheduleRequeue` 补指向 **#1166（PR-A5）** 的 scope 注释，**零行为变更**。
- 跟踪闭合：#1166 scope 已显式扩充纳入 F5 + F6（此前只写 backoff+panic，无行项跟踪）。

## AI-robust 评级

- **F1**：Medium（permanent ceiling，stdlib time 自由函数不可类型层封死）；三元绑定是该形态最强 form-uniqueness。
- **F2**：下游 Hard（单一 AST CompositeLit，类型解析穿透 alias / `&Loop{}`）+ 上游 Medium（caller-allowlist；A7 构造私有化为 Hard 上游，#661 A7 跟踪，godoc 点名）。

## 本地验证

```
go build ./...                                          # OK
go test -race -count=3 ./kernel/reconcile/...           # ok（含 F3 4 路径 / F4 / F7 新测试）
go test ./tools/archtest/ -run 'TestReconcile|TestProdClockInjection|TestKERNEL_CLOCK|TestClock'  # ok
golangci-lint run ./kernel/reconcile/... ./tools/archtest/...  # 0 issues
```

未评 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
