### PR TITLE
test(outbox): RunPrincipalRoundTripConformance store round-trip + fix ADR phantom [FP2 #1291]

### DIFF
--- a/docs/architecture/202605281200-1042-outbox-wire-envelope-principal-occurred-at.md
+++ b/docs/architecture/202605281200-1042-outbox-wire-envelope-principal-occurred-at.md
@@ -373,16 +373,19 @@ Implementations:
 Conformance test:
   - runtime/audit/ledger/storetest.RunPrincipalFieldsRoundTrip (PR-A1)
   - runtime/audit/ledger.TestProtocol_AllElevenFieldsAffectHash (PR-A1)
-  - kernel/outbox/outboxtest.RunPrincipalRoundTripConformance (PR-A2)
+  - runtime/outbox/outboxtest.RunPrincipalRoundTripConformance (FP2, #1291 — wired into RunStoreConformanceSuite; FakeStore + PG)
   - cells/auditcore/internal/appender 全套测试（hash 期望 regen 含 12-字段 HMAC）(PR-A1 zero / PR-A2 真值)
 Repro:
   PR-A1 verify:
     go test ./runtime/audit/ledger/... ./adapters/postgres/... ./cells/auditcore/...
     go test ./tools/archtest/ -run 'AuditHashInputFrozen'
     bash hack/verify-archtest-invariants.sh
-  PR-A2 verify (future):
+  PR-A2 verify:
     go test ./kernel/outbox/... ./pkg/ctxkeys/... ./kernel/wrapper/...
     go test ./tools/archtest/ -run 'PRINCIPAL|SAFEID-WIREMESSAGE|SAFEID-UPSTREAM'
+  FP2 verify (#1291 — principal/occurredAt store round-trip conformance):
+    go test ./runtime/outbox/... -run 'ConformanceSuite/Principal_OccurredAt_RoundTrip'
+    go test -tags=integration ./adapters/postgres/ -run 'PGOutboxStore_ConformanceSuite/Principal_OccurredAt_RoundTrip'
 Dependent contracts (governance scan): none — 三族字段集是 framework 横切，不进 contract.yaml payload.schema.json
 Invariant inventory (DROP COLUMN 043_audit_entries_v2.sql):
   - 6-field hash chain → 12-field canonical JSON via auditHashInput unexported struct + AUDIT-HASH-INPUT-FROZEN-01 双向 Hard 锁
@@ -515,6 +518,39 @@ producer 触达即可伪造审计身份（actor/subject/tenant/session/occurredA
 | migration 044 forward TRUNCATE 误删未投递行 | （未列） | ⚠️→✅ round-1 runbook 用 `CountPending==0`（排除 backoff），且复用 down GUC；F4 改精确判据 + 专属 forward GUC + archtest |
 
 无 round-1 ✅ 因 round-2 退化为 ⚠️/❌ 而未补偿者；上表每个收紧格子均给出 round-2 落地措施。
+
+## Amendment 2026-05-30 — FP2 conformance landed + location corrected (issue #1291)
+
+PR #1272 (PR-A2) shipped the sealed `Entry` + Principal/OccurredAt fields, but the
+Implementation-matrix "Conformance test:" row for the outbox side named a **phantom**
+symbol: `kernel/outbox/outboxtest.RunPrincipalRoundTripConformance` — it was never
+implemented, so the matrix claimed coverage that did not exist, and the outbox-side
+principal/occurredAt **store round-trip had zero conformance coverage**. #1291 FP2 closes this.
+
+**Location corrected (`kernel/outbox/outboxtest` → `runtime/outbox/outboxtest`).** The
+original location is layering-illegal: `kernel/outbox/outboxtest` sits under `kernel/`, which
+the depguard `kernel-isolation` rule forbids from importing `runtime/outbox.Store` — where
+both `FakeStore` and `PGOutboxStore` live. A store-backed conformance therefore **cannot** live
+there. The conformance is store-factory-based (mirroring the audit analog
+`runtime/audit/ledger/storetest.RunPrincipalFieldsRoundTrip` and the existing
+`RunStoreConformanceSuite`), so it lives in `runtime/outbox/outboxtest`. Per ai-robust "ADR
+amendment 落地必查", matrix line 376 and the PR-A2 repro block were rewritten in this same PR
+(no two-truth-source carryover).
+
+**Enrollment is suite-coupled, not opt-in.** `RunPrincipalRoundTripConformance` is invoked from
+inside `RunStoreConformanceSuite` (subtest `Principal_OccurredAt_RoundTrip`), which both store
+impls already run — FakeStore (`fake_store_test.go`) and PG (`outbox_store_integration_test.go`,
+`//go:build integration`). A future 3rd `outbox.Store` impl that runs the mandatory suite gets
+principal round-trip coverage automatically; there is no separate call site to forget — the same
+"claimed-but-absent coverage" failure class this Amendment closes. The seed Entry is built via
+`mustEntry` → `EntryScan.ToEntry` (the sealed reconstruction funnel, already in the conformance
+package), so the harness populates Principal without touching the funnel-locked
+`ctxkeys.With*ID` setters (`CTXKEYS-PRINCIPAL-WRITE-CALLER-01`).
+
+**Threat-matrix re-eval:** no row in §威胁矩阵 degrades. This Amendment is purely additive test
+coverage — it adds no production code path, no new wire field, no new attack surface. It *raises*
+assurance on the existing "principal/occurredAt 端到端携带" guarantee (previously locked only by
+`outbox_fullchain_test.go` at the broker layer) by adding a focused store-layer round-trip check.
 
 ## References
 

--- a/runtime/outbox/outboxtest/principal_conformance.go
+++ b/runtime/outbox/outboxtest/principal_conformance.go
@@ -1,0 +1,83 @@
+package outboxtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	kout "github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/outbox"
+)
+
+// principalRoundTripCreatedAt is a fixed UTC seal time for the principal
+// round-trip seed. Deterministic so the assertion is reproducible.
+var principalRoundTripCreatedAt = time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+
+// principalRoundTripSkew offsets OccurredAt behind CreatedAt so the conformance
+// proves the two timestamps are carried as independent fields (ADR-1042), not
+// collapsed onto a single column.
+const principalRoundTripSkew = -90 * time.Minute
+
+// RunPrincipalRoundTripConformance asserts that an outbox.Store preserves the
+// Principal family (actor/subject/tenant/session) AND the producer-domain
+// OccurredAt across a persist → ClaimPending round-trip, and that OccurredAt
+// stays distinct from CreatedAt.
+//
+// It is the spine for issue #1291 FP2 — the conformance the ADR-1042
+// implementation matrix names. It is invoked from inside
+// RunStoreConformanceSuite, so every store impl that runs the mandatory suite
+// (FakeStore here, PGOutboxStore under //go:build integration) covers principal
+// round-trip automatically — no opt-in call site a future Store impl could
+// silently skip. FP7 extends it with persistence-layer branch cases (empty
+// principal, oversize JSONB drop+warn, validation reject).
+//
+// The seed Entry is built via mustEntry → EntryScan.ToEntry (the sealed
+// reconstruction funnel), so the harness populates Principal without touching
+// the funnel-locked ctxkeys.With*ID setters.
+func RunPrincipalRoundTripConformance(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	created := principalRoundTripCreatedAt
+	occurred := created.Add(principalRoundTripSkew)
+	want := kout.PrincipalMetadata{
+		ActorID:   "actor-imp",
+		SubjectID: "subject-eu",
+		TenantID:  "tenant-a",
+		SessionID: "sess-42",
+	}
+	seed := outbox.ClaimedEntry{
+		Entry: mustEntry(kout.EntryScan{
+			ID:         "principal-roundtrip",
+			EventType:  "user.login",
+			Topic:      "user.login",
+			Payload:    []byte(`{"action":"login"}`),
+			CreatedAt:  created,
+			OccurredAt: occurred,
+			Principal:  want,
+		}),
+	}
+
+	store := factory(t, []outbox.ClaimedEntry{seed})
+
+	claimed, err := store.ClaimPending(context.Background(), 10)
+	if err != nil {
+		t.Fatalf(msgClaimPending, err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf(msgExpect1Claimed, len(claimed))
+	}
+
+	got := claimed[0]
+	if gotP := got.Principal(); gotP != want {
+		t.Errorf("principal mismatch: got %+v, want %+v", gotP, want)
+	}
+	if !got.OccurredAt().Equal(occurred) {
+		t.Errorf("OccurredAt mismatch: got %v, want %v", got.OccurredAt(), occurred)
+	}
+	if !got.CreatedAt().Equal(created) {
+		t.Errorf("CreatedAt mismatch: got %v, want %v", got.CreatedAt(), created)
+	}
+	if got.OccurredAt().Equal(got.CreatedAt()) {
+		t.Errorf("OccurredAt and CreatedAt must remain distinct, both = %v", got.CreatedAt())
+	}
+}

--- a/runtime/outbox/outboxtest/principal_conformance.go
+++ b/runtime/outbox/outboxtest/principal_conformance.go
@@ -10,8 +10,11 @@ import (
 )
 
 // principalRoundTripCreatedAt is a fixed UTC seal time for the principal
-// round-trip seed. Deterministic so the assertion is reproducible.
-var principalRoundTripCreatedAt = time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+// round-trip seed. The specific instant is arbitrary — any constant works;
+// it is pinned only so the assertion is deterministic and independent of the
+// CI runner clock (the seed has no nextRetryAt, so absolute time never affects
+// claimability).
+var principalRoundTripCreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // principalRoundTripSkew offsets OccurredAt behind CreatedAt so the conformance
 // proves the two timestamps are carried as independent fields (ADR-1042), not

--- a/runtime/outbox/outboxtest/store_conformance.go
+++ b/runtime/outbox/outboxtest/store_conformance.go
@@ -130,6 +130,7 @@ func RunStoreConformanceSuite(t *testing.T, factory StoreFactory) {
 	t.Run("OldestEligibleAt_Published_ReturnsMin", func(t *testing.T) { conformOldestEligibleAtPublished(t, factory) })
 	t.Run("OldestEligibleAt_Dead_ReturnsMin", func(t *testing.T) { conformOldestEligibleAtDead(t, factory) })
 	t.Run("OldestEligibleAt_InvalidStatus_ReturnsError", func(t *testing.T) { conformOldestEligibleAtInvalid(t, factory) })
+	t.Run("Principal_OccurredAt_RoundTrip", func(t *testing.T) { RunPrincipalRoundTripConformance(t, factory) })
 }
 
 func conformClaimPendingEmpty(t *testing.T, factory StoreFactory) {


### PR DESCRIPTION
## Summary

**FP2 of #1291** (the EPIC's "spine"). Implements the conformance the ADR-1042 implementation matrix *named but never shipped*, and corrects the matrix phantom.

The phantom (all verified):
- `kernel/outbox/outboxtest.RunPrincipalRoundTripConformance` (matrix line 376) — **the function never existed**; the matrix claimed coverage that wasn't there.
- Outbox-side principal/occurredAt **store round-trip had zero conformance coverage**.
- The named location is *itself wrong*: `kernel/outbox/outboxtest` lives under `kernel/`, which the depguard `kernel-isolation` rule forbids from importing `runtime/outbox.Store` (where `FakeStore` + PG store live). A store-backed conformance **cannot** live there.

## What changed

- **New** `runtime/outbox/outboxtest.RunPrincipalRoundTripConformance(t, factory)`: seeds an `Entry` with full Principal (actor/subject/tenant/session) + `OccurredAt` skewed 90m behind `CreatedAt`, asserts all fields survive `persist → ClaimPending` and that `OccurredAt` stays **distinct** from `CreatedAt`.
- **Wired into `RunStoreConformanceSuite`** (subtest `Principal_OccurredAt_RoundTrip`) — *not* opt-in call sites. Both store impls already run the mandatory suite (FakeStore + PG), so a future 3rd `outbox.Store` impl gets coverage automatically — closing the same "claimed-but-absent coverage" failure class #1291 exists to kill.
- Seed built via `mustEntry → EntryScan.ToEntry` (the sealed reconstruction funnel already in the package, in `store_conformance.go` — the file already on the `OUTBOX-RECONSTRUCTION-CALLER-01` allowlist; no new ToEntry callsite), so Principal is populated **without** touching funnel-locked `ctxkeys.With*ID` setters.
- **ADR `202605281200-1042`**: matrix line 376 location corrected (kernel→runtime, justified by layering) + FP2 repro block + `Amendment 2026-05-30` with §威胁矩阵 re-eval (purely additive coverage — no row degrades).

## Contract-fanout

```
Contract: runtime/outbox.Store — principal/occurredAt persist→claim round-trip
Change: add conformance + wire into mandatory suite
Implementations: [x] FakeStore  [x] PGOutboxStore (//go:build integration)
Conformance test: outboxtest.RunPrincipalRoundTripConformance (via RunStoreConformanceSuite)
Repro:
  go test ./runtime/outbox/... -run 'ConformanceSuite/Principal_OccurredAt_RoundTrip'
  go test -tags=integration ./adapters/postgres/ -run 'PGOutboxStore_ConformanceSuite/Principal_OccurredAt_RoundTrip'
Dependent contracts (governance scan): none
```

## Test plan

- [x] `go build ./...` clean
- [x] FakeStore subtest passes
- [x] **PG subtest passes against real Postgres 15 (testcontainers/docker, local)** — exercises the real `principal` JSONB column + `occurred_at` + `scanClaimedEntry → EntryScan.ToEntry` path
- [x] `go test ./runtime/outbox/...` green
- [x] Harness-correctness sanity check: injected a principal-field mismatch → assertion fired (RED); reverted → GREEN. Proves the spine catches drift (would have caught the phantom).
- [x] `golangci-lint run ./runtime/outbox/...` → 0 issues

## Notes

- `Refs #1291` (not `Closes`) — **#1291 is the tracking EPIC**; its close-conditions require all of FP1–FP9 + Phase 0. This PR is FP2 only.
- AI-robust: a conformance test is **test discipline**, not an enforcement mechanism (ai-robust §适用范围 excludes lint/test/build), so no Hard/Medium/Soft 立项门槛 applies. The tightest in-scope enrollment hardening = suite-coupling (adopted). The true Hard meta-fix (grep-resolvable matrix gate) is Phase 0, out of FP2 scope per the issue DAG.
- Pre-existing baseline lint on `develop` (NOT introduced here, files untouched by this PR): `adapters/postgres/outbox_store.go` gocognit, `kernel/governance/rules_misc_consistency.go` gocognit, `adapters/rabbitmq/rabbitmq_test.go` SA9005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)