### PR TITLE
refactor(archtest): callresolver 通用 callsite 解析框架 + 迁移 8 文件 [#1246]

### DIFF
--- a/tools/archtest/adapter_net_transient_funnel_test.go
+++ b/tools/archtest/adapter_net_transient_funnel_test.go
@@ -597,11 +597,7 @@ func scanErrorsAsNetSubtypeNarrow(p *Pass, allowlist map[string]map[string]struc
 // stdlib errors.As. Robust to import aliases (`stderrors "errors"`) and dot
 // imports.
 func isErrorsAsCall(info *types.Info, call *ast.CallExpr) bool {
-	pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
-	if !ok {
-		return false
-	}
-	return pkgPath == "errors" && name == "As"
+	return IsCallToPkgFunc(info, call, "errors", "As")
 }
 
 // isAddressOfNetErrorIdent reports whether expr is `&<ident>` and ident's

--- a/tools/archtest/audit_hash_input_frozen_test.go
+++ b/tools/archtest/audit_hash_input_frozen_test.go
@@ -175,6 +175,12 @@ func runAuditHashInputA2Rule(p *Pass) []Diagnostic {
 // a same-named method on another type is not exempt). IsCallToPkgFunc is
 // alias-proof: handles `hmac.New`, `h.New` after `import h "crypto/hmac"`, and
 // `New` after `import . "crypto/hmac"`.
+//
+// HasReceiver (via scanner.ReceiverTypeName) also matches generic receivers
+// `Protocol[T]`. Protocol is non-generic today, so this is a no-op; if Protocol
+// ever becomes generic, re-confirm the exemption still scopes to the intended
+// ComputeHash method (the broadening only ever *exempts* more, never detects
+// less, so it cannot cause a missed hmac.New violation on a non-Protocol type).
 func scanFuncBodyForHmacViolations(ctx FuncDeclContext) []Diagnostic {
 	sanctioned := ctx.Func.Name != nil && ctx.Func.Name.Name == "ComputeHash" &&
 		HasReceiver(ctx.Func, "Protocol")

--- a/tools/archtest/audit_hash_input_frozen_test.go
+++ b/tools/archtest/audit_hash_input_frozen_test.go
@@ -160,85 +160,44 @@ func runAuditHashInputA2Rule(p *Pass) []Diagnostic {
 		return nil
 	}
 	var diags []Diagnostic
-	for _, file := range p.Files {
-		rel := p.Rel(file)
-		if strings.HasSuffix(rel, "_test.go") {
-			continue
+	WalkFuncDecls(p, func(ctx FuncDeclContext) {
+		if strings.HasSuffix(ctx.Rel, "_test.go") {
+			return
 		}
-		diags = append(diags, scanFileForHmacViolations(p, file, rel)...)
-	}
-	return diags
-}
-
-// scanFileForHmacViolations iterates top-level funcs in file; for each, checks
-// whether the func is the sanctioned ComputeHash method, then walks the body
-// for hmac.New calls.
-func scanFileForHmacViolations(p *Pass, file *ast.File, rel string) []Diagnostic {
-	var diags []Diagnostic
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
-		}
-		sanctioned := isSanctionedComputeHash(fn)
-		diags = append(diags, scanFuncBodyForHmacViolations(p.TypesInfo, p.Fset, rel, fn, sanctioned)...)
-	}
-	return diags
-}
-
-// scanFuncBodyForHmacViolations walks fn.Body, emits a Diagnostic for each
-// hmac.New call; suppresses them when sanctioned.
-func scanFuncBodyForHmacViolations(info *types.Info, fset *token.FileSet, rel string, fn *ast.FuncDecl, sanctioned bool) []Diagnostic {
-	var diags []Diagnostic
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok || !isHmacNewCall(info, call) || sanctioned {
-			return true
-		}
-		pos := fset.Position(call.Pos())
-		diags = append(diags, Diagnostic{
-			Rel:  rel,
-			Line: pos.Line,
-			Message: fmt.Sprintf(
-				"hmac.New called outside Protocol.ComputeHash (inside %s) — "+
-					"all audit HMAC must flow through Protocol.ComputeHash with the canonical auditHashInput marshaling",
-				fn.Name.Name,
-			),
-		})
-		return true
+		diags = append(diags, scanFuncBodyForHmacViolations(ctx)...)
 	})
 	return diags
 }
 
-// isHmacNewCall resolves call.Fun via go/types and reports whether the callee
-// is crypto/hmac.New. Alias-proof: handles `hmac.New`, `h.New` after
-// `import h "crypto/hmac"`, and `New` after `import . "crypto/hmac"`.
-func isHmacNewCall(info *types.Info, call *ast.CallExpr) bool {
-	pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
-	return ok && pkgPath == "crypto/hmac" && name == "New"
-}
-
-// isSanctionedComputeHash reports whether fn is `func (*Protocol) ComputeHash`
-// (value or pointer receiver). hasProtocolReceiver pins the receiver type.
-func isSanctionedComputeHash(fn *ast.FuncDecl) bool {
-	return fn.Name != nil && fn.Name.Name == "ComputeHash" && hasProtocolReceiver(fn)
-}
-
-// hasProtocolReceiver reports whether fn declares a value-or-pointer receiver
-// whose base type identifier is exactly "Protocol".
-func hasProtocolReceiver(fn *ast.FuncDecl) bool {
-	if fn.Recv == nil || len(fn.Recv.List) == 0 {
-		return false
+// scanFuncBodyForHmacViolations walks the FuncDecl body, emitting a Diagnostic
+// for each crypto/hmac.New call; suppresses them when the enclosing func is the
+// sanctioned `func (*Protocol) ComputeHash` (HasReceiver pins the receiver, so
+// a same-named method on another type is not exempt). IsCallToPkgFunc is
+// alias-proof: handles `hmac.New`, `h.New` after `import h "crypto/hmac"`, and
+// `New` after `import . "crypto/hmac"`.
+func scanFuncBodyForHmacViolations(ctx FuncDeclContext) []Diagnostic {
+	sanctioned := ctx.Func.Name != nil && ctx.Func.Name.Name == "ComputeHash" &&
+		HasReceiver(ctx.Func, "Protocol")
+	if sanctioned {
+		return nil
 	}
-	recvType := fn.Recv.List[0].Type
-	if star, ok := recvType.(*ast.StarExpr); ok {
-		recvType = star.X
-	}
-	ident, ok := recvType.(*ast.Ident)
-	if !ok {
-		return false
-	}
-	return ident.Name == "Protocol"
+	var diags []Diagnostic
+	EachInSubtree[ast.CallExpr](ctx.Func.Body, func(call *ast.CallExpr) {
+		if !IsCallToPkgFunc(ctx.Info, call, "crypto/hmac", "New") {
+			return
+		}
+		pos := ctx.Fset.Position(call.Pos())
+		diags = append(diags, Diagnostic{
+			Rel:  ctx.Rel,
+			Line: pos.Line,
+			Message: fmt.Sprintf(
+				"hmac.New called outside Protocol.ComputeHash (inside %s) — "+
+					"all audit HMAC must flow through Protocol.ComputeHash with the canonical auditHashInput marshaling",
+				ctx.Func.Name.Name,
+			),
+		})
+	})
+	return diags
 }
 
 // TestAuditHashInputFrozen_B_ReverseSelfCheck proves the A2 scanner
@@ -339,14 +298,18 @@ func scanSyntheticSource(t *testing.T, src string) []Diagnostic {
 		t.Fatalf("type-check synthetic source: %v", err)
 	}
 	var diags []Diagnostic
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
+	// Standalone load (own info/fset, no Pass) — build the FuncDeclContext the
+	// same way the WalkFuncDecls engine does so the shared per-func scanner runs
+	// against the synthetic typed info. EachInChildren keeps this depth-1
+	// FuncDecl walk SCANNER-FRAMEWORK-USAGE compliant.
+	EachInChildren[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+		if fn.Body == nil {
+			return
 		}
-		sanctioned := isSanctionedComputeHash(fn)
-		diags = append(diags, scanFuncBodyForHmacViolations(info, fset, "synthetic.go", fn, sanctioned)...)
-	}
+		diags = append(diags, scanFuncBodyForHmacViolations(FuncDeclContext{
+			File: file, Func: fn, Info: info, Fset: fset, Rel: "synthetic.go",
+		})...)
+	})
 	return diags
 }
 

--- a/tools/archtest/baseslice_ctor_funnel_01_test.go
+++ b/tools/archtest/baseslice_ctor_funnel_01_test.go
@@ -166,11 +166,7 @@ func appendIfNewBaseSliceCall(
 	diags []Diagnostic, p *Pass, file *ast.File, rel string,
 	call *ast.CallExpr, cellPkgPath string,
 ) []Diagnostic {
-	pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
-	if !ok {
-		return diags
-	}
-	if pkgPath != cellPkgPath || name != "NewBaseSlice" {
+	if !IsCallToPkgFunc(p.TypesInfo, call, cellPkgPath, "NewBaseSlice") {
 		return diags
 	}
 	pos := p.Fset.Position(call.Pos())

--- a/tools/archtest/callresolver.go
+++ b/tools/archtest/callresolver.go
@@ -62,7 +62,9 @@ func WalkFuncDeclsAST(files []*ast.File, fset *token.FileSet, rel func(*ast.File
 //
 // info must come from the same packages.Load result that produced call —
 // guaranteed when info is pass.TypesInfo. Returns false for method calls (use
-// [ResolveMethodCall]), nil info, or nil call.
+// [ResolveMethodCall]), nil info, or nil call. In particular, a nil info
+// yields false, so this is safe to call from an AST-only WalkFuncDeclsAST
+// callback where ctx.Info == nil (it will simply never match).
 func IsCallToPkgFunc(info *types.Info, call *ast.CallExpr, pkgPath, name string) bool {
 	return callresolver.IsCallToPkgFunc(info, call, pkgPath, name)
 }

--- a/tools/archtest/callresolver.go
+++ b/tools/archtest/callresolver.go
@@ -1,0 +1,75 @@
+// Package archtest callresolver.go — façade re-exports for the callsite
+// resolution convenience layer (internal/callresolver).
+//
+// This completes the façade contract for callsite-resolution: business
+// archtest *_test.go files reach the walker + resolution helpers through
+// archtest.{WalkFuncDecls,WalkFuncDeclsAST,IsCallToPkgFunc,HasReceiver},
+// never importing internal/callresolver directly. PASS-FUNNEL-RESOLVE-01
+// (pass_funnel_test.go) bans the direct-import path.
+//
+// The *Pass-taking walker (WalkFuncDecls) lives here rather than in
+// internal/callresolver because Pass is declared in package archtest: an
+// internal package referencing *archtest.Pass would form an import cycle
+// (archtest already imports internal/callresolver to re-export it). Both
+// walker forms delegate to the single decoupled engine
+// internal/callresolver.WalkFuncDecls, so there is exactly one traversal
+// implementation.
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
+)
+
+// FuncDeclContext is the per-FuncDecl visitor context yielded by
+// [WalkFuncDecls] / [WalkFuncDeclsAST]. Type alias to
+// [callresolver.FuncDeclContext] so the façade and internal engine share one
+// type (mirrors the ImportBan = scanner.ImportBan alias in resolve.go).
+type FuncDeclContext = callresolver.FuncDeclContext
+
+// WalkFuncDecls iterates p.Files; for each top-level *ast.FuncDecl with a
+// non-nil Body it invokes fn with a [FuncDeclContext] bound to p.TypesInfo,
+// p.Fset and p.Rel(file). Works in both AST-only mode (ctx.Info == nil, e.g.
+// a Pass from archtest.Run) and typed mode (Pass from RunTyped).
+//
+// It does NOT auto-skip _test.go / generated files — the callback decides
+// (callers already branch on ctx.Rel suffix and p.IsGenerated). See
+// [callresolver.WalkFuncDecls] for the depth-1 / bodiless-skip contract.
+func WalkFuncDecls(p *Pass, fn func(ctx FuncDeclContext)) {
+	if p == nil || fn == nil {
+		return
+	}
+	callresolver.WalkFuncDecls(p.Files, p.TypesInfo, p.Fset, p.Rel, fn)
+}
+
+// WalkFuncDeclsAST is the no-Pass, AST-only walker for rules that parse files
+// standalone (go/parser, no driver / no *types.Info) — e.g. golden-source
+// scans. ctx.Info is always nil. fn and the same depth-1 / bodiless-skip
+// contract as [WalkFuncDecls] apply.
+func WalkFuncDeclsAST(files []*ast.File, fset *token.FileSet, rel func(*ast.File) string, fn func(ctx FuncDeclContext)) {
+	if fn == nil {
+		return
+	}
+	callresolver.WalkFuncDecls(files, nil, fset, rel, fn)
+}
+
+// IsCallToPkgFunc reports whether call's callee resolves (import-alias /
+// dot-import / generic-instantiation proof) to the package-level function
+// (pkgPath, name). Thin delegation to [callresolver.IsCallToPkgFunc].
+//
+// info must come from the same packages.Load result that produced call —
+// guaranteed when info is pass.TypesInfo. Returns false for method calls (use
+// [ResolveMethodCall]), nil info, or nil call.
+func IsCallToPkgFunc(info *types.Info, call *ast.CallExpr, pkgPath, name string) bool {
+	return callresolver.IsCallToPkgFunc(info, call, pkgPath, name)
+}
+
+// HasReceiver reports whether fn declares a receiver whose base type name
+// equals typeName (handles *T / T / T[P] / T[P,Q]). Thin delegation to
+// [callresolver.HasReceiver]. AST-only; no *types.Info needed.
+func HasReceiver(fn *ast.FuncDecl, typeName string) bool {
+	return callresolver.HasReceiver(fn, typeName)
+}

--- a/tools/archtest/changepassword_inactive_gate_test.go
+++ b/tools/archtest/changepassword_inactive_gate_test.go
@@ -328,8 +328,7 @@ func unconditionalSlots(stmt ast.Stmt) []ast.Node {
 // callee type-resolves to credentialauthority.Assert.
 func nodeContainsAssertCall(info *types.Info, n ast.Node) bool {
 	_, found := FindFirstInSubtree[ast.CallExpr](n, func(call *ast.CallExpr) bool {
-		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
-		return ok && pkgPath == credAuthorityPkgPath && name == credAuthorityFnName
+		return IsCallToPkgFunc(info, call, credAuthorityPkgPath, credAuthorityFnName)
 	})
 	return found
 }

--- a/tools/archtest/credential_authority_assert_funnel_test.go
+++ b/tools/archtest/credential_authority_assert_funnel_test.go
@@ -249,11 +249,7 @@ func TestCredentialAuthorityAssertFunnel_DownstreamCaller_01(t *testing.T) {
 func scanAssertCallSites(p *Pass, file *ast.File, rel string) []string {
 	var out []string
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
-		if !ok {
-			return
-		}
-		if pkgPath != credAuthorityPkgPath || name != credAuthorityFnName {
+		if !IsCallToPkgFunc(p.TypesInfo, call, credAuthorityPkgPath, credAuthorityFnName) {
 			return
 		}
 		line := p.Fset.Position(call.Pos()).Line

--- a/tools/archtest/health_verbose_invariants_test.go
+++ b/tools/archtest/health_verbose_invariants_test.go
@@ -462,13 +462,11 @@ func isRedactedCreation(info *types.Info, expr ast.Expr, tv types.TypeAndValue) 
 // skip — the only sanctioned creation site is literally the funnel body's source
 // range, so a rename can never silently re-open it (guard 3 also fails on rename).
 func funnelBodyRange(p *Pass) (lo, hi token.Pos, found bool) {
-	for _, f := range p.Files {
-		EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-			if fd.Body != nil && fd.Name.Name == healthRedactedErrorMsgFunnelFuncName {
-				lo, hi, found = fd.Body.Pos(), fd.Body.End(), true
-			}
-		})
-	}
+	WalkFuncDecls(p, func(ctx FuncDeclContext) {
+		if ctx.Func.Name.Name == healthRedactedErrorMsgFunnelFuncName {
+			lo, hi, found = ctx.Func.Body.Pos(), ctx.Func.Body.End(), true
+		}
+	})
 	return lo, hi, found
 }
 
@@ -566,15 +564,13 @@ func TestHealthRedactedErrorMsgFunnelBodyRedacts(t *testing.T) {
 				return nil
 			}
 			var ds []Diagnostic
-			for _, f := range p.Files {
-				EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-					if fd.Body == nil || fd.Name.Name != healthRedactedErrorMsgFunnelFuncName {
-						return
-					}
-					checked = true
-					ds = append(ds, funnelBodyRedactViolations(p, f, fd.Body)...)
-				})
-			}
+			WalkFuncDecls(p, func(ctx FuncDeclContext) {
+				if ctx.Func.Name.Name != healthRedactedErrorMsgFunnelFuncName {
+					return
+				}
+				checked = true
+				ds = append(ds, funnelBodyRedactViolations(p, ctx.File, ctx.Func.Body)...)
+			})
 			return ds
 		})
 
@@ -616,8 +612,7 @@ func argIsRedactString(info *types.Info, call *ast.CallExpr) bool {
 	if !ok {
 		return false
 	}
-	pkgPath, name, ok := ResolvePackageRef(info, inner.Fun)
-	return ok && pkgPath == redactionPkgPath && name == redactStringFuncName
+	return IsCallToPkgFunc(info, inner, redactionPkgPath, redactStringFuncName)
 }
 
 // TestHealthRedactedErrorMsgFieldTyped enforces guard 2 (linchpin).

--- a/tools/archtest/internal/callresolver/callresolver.go
+++ b/tools/archtest/internal/callresolver/callresolver.go
@@ -30,6 +30,10 @@ type FuncDeclContext struct {
 	File *ast.File
 	Func *ast.FuncDecl
 	Info *types.Info // nil in AST-only mode
+	// Fset is the caller-supplied FileSet. It is non-nil whenever the caller
+	// supplied one (archtest.WalkFuncDecls passes p.Fset); a callback that
+	// reads ctx.Fset.Position(...) must therefore only be used with a walker
+	// that was given a non-nil FileSet.
 	Fset *token.FileSet
 	Rel  string
 }
@@ -55,6 +59,9 @@ func WalkFuncDecls(
 	rel func(*ast.File) string,
 	fn func(FuncDeclContext),
 ) {
+	if fn == nil {
+		return
+	}
 	for _, f := range files {
 		if f == nil {
 			continue

--- a/tools/archtest/internal/callresolver/callresolver.go
+++ b/tools/archtest/internal/callresolver/callresolver.go
@@ -100,13 +100,28 @@ func IsCallToPkgFunc(info *types.Info, call *ast.CallExpr, pkgPath, name string)
 	return ok && p == pkgPath && n == name
 }
 
-// unwrapCallee strips IndexExpr / IndexListExpr wrappers added by explicit
-// generic type arguments (`Foo[T](...)` / `Foo[T, U](...)`) so the underlying
-// SelectorExpr / Ident can be passed to ResolvePackageRef. Returns nil for any
-// other callee shape. (Consolidated from serviceowned_handler_owner_check_test
-// .go::unwrapCalleeForResolve.)
+// unwrapCallee normalizes a call's Fun expression down to the underlying
+// SelectorExpr / Ident that ResolvePackageRef understands, stripping at any
+// nesting level:
+//   - ParenExpr: a parenthesized callee, e.g. `(hmac.New)(key)` — without this
+//     a parenthesized real call silently fails to resolve (a false negative in
+//     every funnel built on IsCallToPkgFunc).
+//   - IndexExpr / IndexListExpr: explicit generic instantiation, e.g.
+//     `Foo[T](...)` / `Foo[T, U](...)`.
+//
+// The recursion handles interleaved forms — `(pkg.Foo)[int]` (IndexExpr over
+// ParenExpr) and `(pkg.Foo[int])` (ParenExpr over IndexExpr) both reduce to the
+// inner selector. Returns nil for any other callee shape (e.g. a CallExpr or a
+// literal), which IsCallToPkgFunc then treats as a non-match.
+//
+// Mirrors the stdlib idiom go/ast.Unparen + x/tools typeutil.Callee, which
+// unparenthesize before resolving generic-instantiation and ident/selector
+// callees. (Consolidated from serviceowned_handler_owner_check_test.go::
+// unwrapCalleeForResolve, kept there for its expr-returning BFS/ownership uses.)
 func unwrapCallee(fun ast.Expr) ast.Expr {
 	switch v := fun.(type) {
+	case *ast.ParenExpr:
+		return unwrapCallee(v.X)
 	case *ast.SelectorExpr, *ast.Ident:
 		return v
 	case *ast.IndexExpr:

--- a/tools/archtest/internal/callresolver/callresolver.go
+++ b/tools/archtest/internal/callresolver/callresolver.go
@@ -1,0 +1,122 @@
+// Package callresolver is an archtest-internal convenience layer over
+// [internal/typeseval] + [internal/scanner] for the recurring "walk every
+// FuncDecl body, resolve a callee, assert a receiver" shape that several rules
+// (audit_hash_input_frozen, serviceowned_handler_owner_check,
+// changepassword_inactive_gate, …) previously hand-wrote and copy-drifted.
+//
+// Scope: archtest internal helper. Not exported beyond tools/archtest — the
+// public surface is the re-exports in tools/archtest/callresolver.go
+// (archtest.WalkFuncDecls / WalkFuncDeclsAST / IsCallToPkgFunc / HasReceiver).
+// Business archtest *_test.go files MUST use that façade, never import this
+// package directly — enforced by PASS-FUNNEL-RESOLVE-01 (pass_funnel_test.go).
+//
+// This package may import internal/typeseval and internal/scanner
+// (internal↔internal is legal); it must NOT import package archtest, which
+// would form an import cycle (archtest re-exports this package).
+package callresolver
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+)
+
+// FuncDeclContext carries everything a per-FuncDecl visitor needs. In an
+// AST-only walk Info is nil and Rel is "" (when no rel mapping was supplied).
+type FuncDeclContext struct {
+	File *ast.File
+	Func *ast.FuncDecl
+	Info *types.Info // nil in AST-only mode
+	Fset *token.FileSet
+	Rel  string
+}
+
+// WalkFuncDecls is the decoupled engine behind archtest.WalkFuncDecls /
+// WalkFuncDeclsAST. For each file it visits every top-level *ast.FuncDecl with
+// a non-nil Body and invokes fn with a [FuncDeclContext]. rel maps a file to
+// its module-relative slash path; a nil rel yields ctx.Rel == "".
+//
+// It deliberately does NOT auto-skip _test.go / generated files — skip policy
+// differs per rule (some skip test files, some skip generated, some filter by
+// directory), so the callback decides. Bodiless decls (external / forward
+// declarations) are skipped because they cannot enclose statements.
+//
+// Uses scanner.EachInChildren[ast.FuncDecl] (depth-1) rather than a raw
+// `range file.Decls` loop, keeping the engine itself SCANNER-FRAMEWORK-USAGE
+// compliant. FuncDecls only exist at file top level (nested funcs are
+// *ast.FuncLit, not FuncDecl), so depth-1 is complete.
+func WalkFuncDecls(
+	files []*ast.File,
+	info *types.Info,
+	fset *token.FileSet,
+	rel func(*ast.File) string,
+	fn func(FuncDeclContext),
+) {
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		r := ""
+		if rel != nil {
+			r = rel(f)
+		}
+		scanner.EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
+				return
+			}
+			fn(FuncDeclContext{File: f, Func: fd, Info: info, Fset: fset, Rel: r})
+		})
+	}
+}
+
+// IsCallToPkgFunc reports whether call's callee resolves (import-alias /
+// dot-import proof, generic-instantiation proof) to the package-level function
+// (pkgPath, name). It strips generic-instantiation wrappers (*ast.IndexExpr /
+// *ast.IndexListExpr) via [unwrapCallee] before delegating to
+// [typeseval.ResolvePackageRef].
+//
+// Returns false for method calls (a SelectorExpr whose X is a value, not a
+// package — use [typeseval.ResolveMethodCall] for those), nil info, or nil
+// call.
+func IsCallToPkgFunc(info *types.Info, call *ast.CallExpr, pkgPath, name string) bool {
+	if info == nil || call == nil {
+		return false
+	}
+	ref := unwrapCallee(call.Fun)
+	if ref == nil {
+		return false
+	}
+	p, n, ok := typeseval.ResolvePackageRef(info, ref)
+	return ok && p == pkgPath && n == name
+}
+
+// unwrapCallee strips IndexExpr / IndexListExpr wrappers added by explicit
+// generic type arguments (`Foo[T](...)` / `Foo[T, U](...)`) so the underlying
+// SelectorExpr / Ident can be passed to ResolvePackageRef. Returns nil for any
+// other callee shape. (Consolidated from serviceowned_handler_owner_check_test
+// .go::unwrapCalleeForResolve.)
+func unwrapCallee(fun ast.Expr) ast.Expr {
+	switch v := fun.(type) {
+	case *ast.SelectorExpr, *ast.Ident:
+		return v
+	case *ast.IndexExpr:
+		return unwrapCallee(v.X)
+	case *ast.IndexListExpr:
+		return unwrapCallee(v.X)
+	}
+	return nil
+}
+
+// HasReceiver reports whether fn declares a receiver whose base type name
+// equals typeName, handling *T / T / T[P] / T[P,Q] via
+// [scanner.ReceiverTypeName]. Returns false for free functions (no receiver)
+// or a nil fn.
+func HasReceiver(fn *ast.FuncDecl, typeName string) bool {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return false
+	}
+	return scanner.ReceiverTypeName(fn.Recv.List[0].Type) == typeName
+}

--- a/tools/archtest/internal/callresolver/callresolver_test.go
+++ b/tools/archtest/internal/callresolver/callresolver_test.go
@@ -1,0 +1,306 @@
+package callresolver
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+// typeCheck parses + type-checks src against the real stdlib (importer.Default)
+// and returns the file, its *types.Info, and the FileSet. Mirrors
+// scanSyntheticSource in audit_hash_input_frozen_test.go so IsCallToPkgFunc is
+// exercised against genuine go/types resolution (alias / dot-import proof).
+func typeCheck(t *testing.T, src string) (*ast.File, *types.Info, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "synthetic.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	info := &types.Info{
+		Types:      map[ast.Expr]types.TypeAndValue{},
+		Defs:       map[*ast.Ident]types.Object{},
+		Uses:       map[*ast.Ident]types.Object{},
+		Implicits:  map[ast.Node]types.Object{},
+		Selections: map[*ast.SelectorExpr]*types.Selection{},
+	}
+	conf := types.Config{Importer: importer.Default()}
+	if _, err := conf.Check("synthetic", fset, []*ast.File{file}, info); err != nil {
+		t.Fatalf("type-check: %v", err)
+	}
+	return file, info, fset
+}
+
+// parseOnly parses src without type-checking (for AST-only helpers).
+func parseOnly(t *testing.T, src string) (*ast.File, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "synthetic.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return file, fset
+}
+
+// firstCallNamed returns the first CallExpr in file whose callee's trailing
+// identifier (SelectorExpr.Sel or bare/indexed Ident) equals name.
+func firstCallNamed(t *testing.T, file *ast.File, name string) *ast.CallExpr {
+	t.Helper()
+	var found *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if calleeTrailingName(call.Fun) == name {
+			found = call
+			return false
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatalf("no call to %q found", name)
+	}
+	return found
+}
+
+func calleeTrailingName(fun ast.Expr) string {
+	switch v := fun.(type) {
+	case *ast.SelectorExpr:
+		if v.Sel != nil {
+			return v.Sel.Name
+		}
+	case *ast.Ident:
+		return v.Name
+	case *ast.IndexExpr:
+		return calleeTrailingName(v.X)
+	case *ast.IndexListExpr:
+		return calleeTrailingName(v.X)
+	}
+	return ""
+}
+
+// firstFuncDecl returns the first top-level FuncDecl named name.
+func firstFuncDecl(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+	for _, d := range file.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name != nil && fd.Name.Name == name {
+			return fd
+		}
+	}
+	t.Fatalf("no FuncDecl %q", name)
+	return nil
+}
+
+// --- IsCallToPkgFunc -------------------------------------------------------
+
+func TestIsCallToPkgFunc(t *testing.T) {
+	t.Parallel()
+
+	const qualified = `package p
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+)
+func use(key []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	return m.Sum(nil)
+}`
+	const aliased = `package p
+import (
+	h "crypto/hmac"
+	"crypto/sha256"
+)
+func use(key []byte) []byte {
+	m := h.New(sha256.New, key)
+	return m.Sum(nil)
+}`
+	const dotImport = `package p
+import (
+	. "crypto/hmac"
+	"crypto/sha256"
+)
+func use(key []byte) []byte {
+	m := New(sha256.New, key)
+	return m.Sum(nil)
+}`
+	const generic = `package p
+func Foo[T any]() int { return 0 }
+func Pair[K any, V any]() int { return 0 }
+func use() {
+	_ = Foo[int]()
+	_ = Pair[int, string]()
+}`
+	const method = `package p
+type T struct{}
+func (T) New() int { return 0 }
+func use(v T) { _ = v.New() }`
+
+	cases := []struct {
+		name       string
+		src        string
+		callee     string
+		pkgPath    string
+		fnName     string
+		want       bool
+	}{
+		{"qualified-hmac-new", qualified, "New", "crypto/hmac", "New", true},
+		{"alias-hmac-new", aliased, "New", "crypto/hmac", "New", true},
+		{"dot-import-hmac-new", dotImport, "New", "crypto/hmac", "New", true},
+		{"generic-indexexpr", generic, "Foo", "synthetic", "Foo", true},
+		{"generic-indexlistexpr", generic, "Pair", "synthetic", "Pair", true},
+		{"wrong-name", qualified, "New", "crypto/hmac", "Equal", false},
+		{"wrong-pkg", qualified, "New", "crypto/subtle", "New", false},
+		{"method-call-not-pkg-func", method, "New", "synthetic", "New", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			file, info, _ := typeCheck(t, tc.src)
+			call := firstCallNamed(t, file, tc.callee)
+			if got := IsCallToPkgFunc(info, call, tc.pkgPath, tc.fnName); got != tc.want {
+				t.Errorf("IsCallToPkgFunc(%s, %q, %q) = %v, want %v",
+					tc.name, tc.pkgPath, tc.fnName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCallToPkgFunc_NilGuards(t *testing.T) {
+	t.Parallel()
+	file, info, _ := typeCheck(t, `package p
+import "crypto/hmac"
+import "crypto/sha256"
+func use(k []byte) { _ = hmac.New(sha256.New, k) }`)
+	call := firstCallNamed(t, file, "New")
+	if IsCallToPkgFunc(nil, call, "crypto/hmac", "New") {
+		t.Error("nil info must yield false")
+	}
+	if IsCallToPkgFunc(info, nil, "crypto/hmac", "New") {
+		t.Error("nil call must yield false")
+	}
+}
+
+// --- HasReceiver -----------------------------------------------------------
+
+func TestHasReceiver(t *testing.T) {
+	t.Parallel()
+	const src = `package p
+type Protocol struct{}
+type Store[T any] struct{}
+type Pair[K any, V any] struct{}
+func (p *Protocol) PtrM() {}
+func (p Protocol) ValM() {}
+func (s *Store[T]) StoreM() {}
+func (s Pair[K, V]) PairM() {}
+func Free() {}
+`
+	file, _ := parseOnly(t, src)
+
+	cases := []struct {
+		fn       string
+		typeName string
+		want     bool
+	}{
+		{"PtrM", "Protocol", true},
+		{"ValM", "Protocol", true},
+		{"StoreM", "Store", true},
+		{"PairM", "Pair", true},
+		{"PtrM", "Wrong", false},
+		{"Free", "Protocol", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.fn+"/"+tc.typeName, func(t *testing.T) {
+			t.Parallel()
+			fd := firstFuncDecl(t, file, tc.fn)
+			if got := HasReceiver(fd, tc.typeName); got != tc.want {
+				t.Errorf("HasReceiver(%s, %q) = %v, want %v", tc.fn, tc.typeName, got, tc.want)
+			}
+		})
+	}
+	if HasReceiver(nil, "Protocol") {
+		t.Error("nil fn must yield false")
+	}
+}
+
+// --- WalkFuncDecls ---------------------------------------------------------
+
+func TestWalkFuncDecls_BodySkipAndCount(t *testing.T) {
+	t.Parallel()
+	// ext() is an external/bodiless decl (valid Go syntax); must be skipped.
+	const src = `package p
+func a() {}
+func b() { _ = func() {} }
+func ext()
+`
+	file, fset := parseOnly(t, src)
+	var visited []string
+	WalkFuncDecls([]*ast.File{file}, nil, fset, func(*ast.File) string { return "rel.go" },
+		func(ctx FuncDeclContext) {
+			visited = append(visited, ctx.Func.Name.Name)
+			if ctx.Rel != "rel.go" {
+				t.Errorf("ctx.Rel = %q, want rel.go", ctx.Rel)
+			}
+			if ctx.Info != nil {
+				t.Error("AST-only walk must carry nil Info")
+			}
+			if ctx.File != file {
+				t.Error("ctx.File mismatch")
+			}
+		})
+	// a and b only (ext is bodiless; the nested FuncLit in b is not a FuncDecl).
+	if len(visited) != 2 || visited[0] != "a" || visited[1] != "b" {
+		t.Errorf("visited = %v, want [a b]", visited)
+	}
+}
+
+func TestWalkFuncDecls_TypedInfoIsBound(t *testing.T) {
+	t.Parallel()
+	file, info, fset := typeCheck(t, `package p
+func target() int { return 1 }`)
+	var count int
+	WalkFuncDecls([]*ast.File{file}, info, fset, nil, func(ctx FuncDeclContext) {
+		count++
+		if ctx.Rel != "" {
+			t.Errorf("nil rel must yield empty Rel, got %q", ctx.Rel)
+		}
+		obj := ctx.Info.Defs[ctx.Func.Name]
+		if _, ok := obj.(*types.Func); !ok {
+			t.Errorf("ctx.Info.Defs[%s] = %T, want *types.Func", ctx.Func.Name.Name, obj)
+		}
+	})
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+}
+
+func TestWalkFuncDecls_MultiFile(t *testing.T) {
+	t.Parallel()
+	f1, fset := parseOnly(t, "package p\nfunc x() {}")
+	f2, _ := parseOnly(t, "package p\nfunc y() {}")
+	seen := map[string]bool{}
+	WalkFuncDecls([]*ast.File{f1, f2}, nil, fset, nil, func(ctx FuncDeclContext) {
+		seen[ctx.Func.Name.Name] = true
+	})
+	if !seen["x"] || !seen["y"] || len(seen) != 2 {
+		t.Errorf("seen = %v, want {x,y}", seen)
+	}
+}
+
+func TestWalkFuncDecls_NilSafe(t *testing.T) {
+	t.Parallel()
+	called := false
+	WalkFuncDecls(nil, nil, nil, nil, func(FuncDeclContext) { called = true })
+	WalkFuncDecls([]*ast.File{nil}, nil, nil, nil, func(FuncDeclContext) { called = true })
+	if called {
+		t.Error("nil/empty input must not invoke fn")
+	}
+}

--- a/tools/archtest/internal/callresolver/callresolver_test.go
+++ b/tools/archtest/internal/callresolver/callresolver_test.go
@@ -141,6 +141,11 @@ func use() {
 type T struct{}
 func (T) New() int { return 0 }
 func use(v T) { _ = v.New() }`
+	// NOTE: Go forbids generic methods ("method must have no type parameters"),
+	// so an IndexExpr over a *method* selector (val.Method[T]()) cannot occur in
+	// real source — the method→false path is covered by the non-generic
+	// "method-call-not-pkg-func" case below; unwrapCallee's IndexExpr branch is
+	// exercised by the package-level generic funcs (Foo[int] / Pair[int,string]).
 
 	cases := []struct {
 		name    string
@@ -302,5 +307,32 @@ func TestWalkFuncDecls_NilSafe(t *testing.T) {
 	WalkFuncDecls([]*ast.File{nil}, nil, nil, nil, func(FuncDeclContext) { called = true })
 	if called {
 		t.Error("nil/empty input must not invoke fn")
+	}
+	// nil fn with real FuncDecls must not panic (engine guards fn == nil).
+	f, fset := parseOnly(t, "package p\nfunc x() {}")
+	WalkFuncDecls([]*ast.File{f}, nil, fset, nil, nil)
+}
+
+// TestUnwrapCallee directly exercises the generic-unwrap helper, including the
+// default→nil branch (a parenthesized callee, which IsCallToPkgFunc then treats
+// as a non-match — mirroring the donor unwrapCalleeForResolve semantics).
+func TestUnwrapCallee(t *testing.T) {
+	t.Parallel()
+	mustExpr := func(s string) ast.Expr {
+		e, err := parser.ParseExpr(s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		return e
+	}
+	nonNil := []string{"pkg.Foo", "Foo", "pkg.Foo[int]", "pkg.Foo[int, string]"}
+	for _, s := range nonNil {
+		if unwrapCallee(mustExpr(s)) == nil {
+			t.Errorf("unwrapCallee(%q) = nil, want non-nil", s)
+		}
+	}
+	// default branch: ParenExpr (and any other shape) is not unwrapped → nil.
+	if got := unwrapCallee(mustExpr("(pkg.Foo)")); got != nil {
+		t.Errorf("unwrapCallee parenthesized callee = %T, want nil (default branch)", got)
 	}
 }

--- a/tools/archtest/internal/callresolver/callresolver_test.go
+++ b/tools/archtest/internal/callresolver/callresolver_test.go
@@ -72,6 +72,8 @@ func firstCallNamed(t *testing.T, file *ast.File, name string) *ast.CallExpr {
 
 func calleeTrailingName(fun ast.Expr) string {
 	switch v := fun.(type) {
+	case *ast.ParenExpr:
+		return calleeTrailingName(v.X)
 	case *ast.SelectorExpr:
 		if v.Sel != nil {
 			return v.Sel.Name
@@ -137,6 +139,20 @@ func use() {
 	_ = Foo[int]()
 	_ = Pair[int, string]()
 }`
+	// parenthesized callees: (hmac.New)(...) and (Foo[int])() must resolve the
+	// same as their unparenthesized forms (unwrapCallee strips ParenExpr).
+	const parenQualified = `package p
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+)
+func use(key []byte) []byte {
+	m := (hmac.New)(sha256.New, key)
+	return m.Sum(nil)
+}`
+	const parenGeneric = `package p
+func Foo[T any]() int { return 0 }
+func use() { _ = (Foo[int])() }`
 	const method = `package p
 type T struct{}
 func (T) New() int { return 0 }
@@ -163,6 +179,8 @@ func use(v T) { _ = v.New() }`
 		{"wrong-name", qualified, "New", "crypto/hmac", "Equal", false},
 		{"wrong-pkg", qualified, "New", "crypto/subtle", "New", false},
 		{"method-call-not-pkg-func", method, "New", "synthetic", "New", false},
+		{"paren-qualified", parenQualified, "New", "crypto/hmac", "New", true},
+		{"paren-generic", parenGeneric, "Foo", "synthetic", "Foo", true},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -313,9 +331,10 @@ func TestWalkFuncDecls_NilSafe(t *testing.T) {
 	WalkFuncDecls([]*ast.File{f}, nil, fset, nil, nil)
 }
 
-// TestUnwrapCallee directly exercises the generic-unwrap helper, including the
-// default→nil branch (a parenthesized callee, which IsCallToPkgFunc then treats
-// as a non-match — mirroring the donor unwrapCalleeForResolve semantics).
+// TestUnwrapCallee directly exercises the generic/paren-unwrap helper. Paren and
+// generic-instantiation wrappers (including interleaved forms) reduce to the
+// inner selector/ident; genuinely unresolvable callee shapes hit the default→nil
+// branch, which IsCallToPkgFunc then treats as a non-match.
 func TestUnwrapCallee(t *testing.T) {
 	t.Parallel()
 	mustExpr := func(s string) ast.Expr {
@@ -325,14 +344,21 @@ func TestUnwrapCallee(t *testing.T) {
 		}
 		return e
 	}
-	nonNil := []string{"pkg.Foo", "Foo", "pkg.Foo[int]", "pkg.Foo[int, string]"}
+	// Wrappers (paren / generic-instantiation, at any nesting) → non-nil inner.
+	nonNil := []string{
+		"pkg.Foo", "Foo",
+		"pkg.Foo[int]", "pkg.Foo[int, string]",
+		"(pkg.Foo)", "(Foo)", "((pkg.Foo))",
+		"(pkg.Foo)[int]", "(pkg.Foo[int])",
+	}
 	for _, s := range nonNil {
 		if unwrapCallee(mustExpr(s)) == nil {
 			t.Errorf("unwrapCallee(%q) = nil, want non-nil", s)
 		}
 	}
-	// default branch: ParenExpr (and any other shape) is not unwrapped → nil.
-	if got := unwrapCallee(mustExpr("(pkg.Foo)")); got != nil {
-		t.Errorf("unwrapCallee parenthesized callee = %T, want nil (default branch)", got)
+	// default branch: a callee that is neither selector/ident nor a strippable
+	// wrapper (here a CallExpr `f()`) → nil.
+	if got := unwrapCallee(mustExpr("f()")); got != nil {
+		t.Errorf("unwrapCallee(%q) = %T, want nil (default branch)", "f()", got)
 	}
 }

--- a/tools/archtest/internal/callresolver/callresolver_test.go
+++ b/tools/archtest/internal/callresolver/callresolver_test.go
@@ -143,12 +143,12 @@ func (T) New() int { return 0 }
 func use(v T) { _ = v.New() }`
 
 	cases := []struct {
-		name       string
-		src        string
-		callee     string
-		pkgPath    string
-		fnName     string
-		want       bool
+		name    string
+		src     string
+		callee  string
+		pkgPath string
+		fnName  string
+		want    bool
 	}{
 		{"qualified-hmac-new", qualified, "New", "crypto/hmac", "New", true},
 		{"alias-hmac-new", aliased, "New", "crypto/hmac", "New", true},

--- a/tools/archtest/internal/passfunnelfixture/redfixture.go
+++ b/tools/archtest/internal/passfunnelfixture/redfixture.go
@@ -53,6 +53,12 @@ import (
 	// VIOLATION sources for PASS-FUNNEL-RESOLVE-01 — same package, different symbols.
 	"github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
 	te "github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+
+	// VIOLATION sources for PASS-FUNNEL-RESOLVE-01 — callresolver helpers
+	// (qualified + alias forms; a typeseval-style dot-import conflict does not
+	// apply, but two forms suffice — same coverage shape as the typeseval helpers).
+	"github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
+	cr "github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
 )
 
 // VIOLATION samples — value references suffice for typeseval.ResolvePackageRef
@@ -133,6 +139,17 @@ var (
 	_ = scanner.ImportBan{} // qualified (value reference, zero-value struct literal)
 	_ = sn.ImportBan{}      // alias-import
 	_ = ImportBan{}         // dot-import (bare Ident from `. "…/scanner"` above)
+
+	// callresolver helpers (qualified + alias). FuncDeclContext{} exercises the
+	// *types.TypeName struct-literal branch (same shape as scanner.ImportBan{}).
+	_ = callresolver.WalkFuncDecls     // qualified
+	_ = callresolver.IsCallToPkgFunc   // qualified
+	_ = callresolver.HasReceiver       // qualified
+	_ = callresolver.FuncDeclContext{} // qualified (TypeName struct-literal ref)
+	_ = cr.WalkFuncDecls               // alias-import
+	_ = cr.IsCallToPkgFunc             // alias-import
+	_ = cr.HasReceiver                 // alias-import
+	_ = cr.FuncDeclContext{}           // alias-import
 )
 
 // PASS-FUNNEL-FIXTURE-TAG-01 V' RED — type-aware (callee, arg) form-uniqueness.

--- a/tools/archtest/internal/passfunnelfixture/redfixture.go
+++ b/tools/archtest/internal/passfunnelfixture/redfixture.go
@@ -55,9 +55,12 @@ import (
 	te "github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
 
 	// VIOLATION sources for PASS-FUNNEL-RESOLVE-01 — callresolver helpers
-	// (qualified + alias forms; a typeseval-style dot-import conflict does not
-	// apply, but two forms suffice — same coverage shape as the typeseval helpers).
+	// (qualified + alias + dot-import; unlike typeseval, callresolver exports no
+	// name that collides with the scanner dot-import, so all 3 forms coexist —
+	// the dot-import form locks resolveBarePkgSymbol's *types.Func + *types.TypeName
+	// branches for callresolver directly).
 	"github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
+	. "github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
 	cr "github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
 )
 
@@ -150,6 +153,12 @@ var (
 	_ = cr.IsCallToPkgFunc             // alias-import
 	_ = cr.HasReceiver                 // alias-import
 	_ = cr.FuncDeclContext{}           // alias-import
+	// dot-import (bare Ident) — resolveBarePkgSymbol *types.Func (funcs) +
+	// *types.TypeName (FuncDeclContext) branches for callresolver.
+	_ = WalkFuncDecls     // dot-import
+	_ = IsCallToPkgFunc   // dot-import
+	_ = HasReceiver       // dot-import
+	_ = FuncDeclContext{} // dot-import (TypeName bare Ident)
 )
 
 // PASS-FUNNEL-FIXTURE-TAG-01 V' RED — type-aware (callee, arg) form-uniqueness.

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -66,6 +66,7 @@ const (
 	scannerPkgPath        = "github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 	archtestPkgPath       = "github.com/ghbvf/gocell/tools/archtest"
 	typesevalPkgPath      = "github.com/ghbvf/gocell/tools/archtest/internal/typeseval"
+	callresolverPkgPath   = "github.com/ghbvf/gocell/tools/archtest/internal/callresolver"
 	packagesPkgPath       = "golang.org/x/tools/go/packages"
 	usage02FixturesRelDir = "tools/archtest/internal/usage02fixtures"
 )
@@ -343,7 +344,9 @@ func diagsPackagesImport(tgt passFunnelTarget) []scanner.Diagnostic {
 // scannerImportBanCount from 3 to 2, failing the assertion.
 func diagsResolveHelpers(tgt passFunnelTarget) []scanner.Diagnostic {
 	const replacement = "archtest.{ResolvePackageRef,ResolveMethodCall,ResolveEnclosingFunc," +
-		"EvaluateConstString,FlatNonDefaultTags,KnownNonDefaultTags} / Pass.{IsFileInScope,IsGenerated} / archtest.ImportBan"
+		"EvaluateConstString,FlatNonDefaultTags,KnownNonDefaultTags,WalkFuncDecls," +
+		"WalkFuncDeclsAST,IsCallToPkgFunc,HasReceiver,FuncDeclContext} / " +
+		"Pass.{IsFileInScope,IsGenerated} / archtest.ImportBan"
 	return scanForForbiddenCallees(
 		tgt,
 		map[string]map[string]bool{
@@ -360,6 +363,19 @@ func diagsResolveHelpers(tgt passFunnelTarget) []scanner.Diagnostic {
 			},
 			scannerPkgPath: {
 				"ImportBan": true,
+			},
+			// callresolver convenience layer (internal/callresolver). Business
+			// *_test.go must use the archtest.{WalkFuncDecls,WalkFuncDeclsAST,
+			// IsCallToPkgFunc,HasReceiver} façade, not import the internal pkg.
+			// WalkFuncDeclsAST is façade-only (no internal symbol of that name),
+			// so it is not banned here. FuncDeclContext (the *types.TypeName
+			// struct-literal ref) is banned alongside the funcs, mirroring how
+			// scanner.ImportBan is banned as a TypeName.
+			callresolverPkgPath: {
+				"WalkFuncDecls":   true,
+				"IsCallToPkgFunc": true,
+				"HasReceiver":     true,
+				"FuncDeclContext": true,
 			},
 		},
 		replacement,
@@ -1143,6 +1159,42 @@ func TestPassFunnel_FixtureCoverage(t *testing.T) {
 			"(qualified L123 + alias L124 + dot-import L125 must each trip the detector; "+
 			"exact-count regression lock — reverting TypeName fix drops to 2)",
 			scannerImportBanCount, wantImportBanCount)
+	}
+
+	// callresolver helpers (internal/callresolver). Per-symbol assertion matches
+	// the exact "instead of <callresolverPkgPath>.<sym>" clause (the replacement
+	// string says "archtest.<sym>", so this does not collide with the helper
+	// names embedded in every message's replacement). The 3 funcs each appear in
+	// 2 forms (qualified + alias) → ≥1 per symbol; FuncDeclContext (the
+	// *types.TypeName struct-literal ref) is exact-count == 2 (qualified + alias),
+	// mirroring the ImportBan TypeName lock.
+	callresolverFuncs := []string{"WalkFuncDecls", "IsCallToPkgFunc", "HasReceiver"}
+	perCRCount := make(map[string]int, len(callresolverFuncs))
+	var crFuncDeclContextCount int
+	for _, d := range resolveDiags {
+		if strings.Contains(d.Message, callresolverPkgPath+".FuncDeclContext") {
+			crFuncDeclContextCount++
+			continue
+		}
+		for _, sym := range callresolverFuncs {
+			if strings.Contains(d.Message, callresolverPkgPath+"."+sym) {
+				perCRCount[sym]++
+			}
+		}
+	}
+	for _, sym := range callresolverFuncs {
+		if perCRCount[sym] == 0 {
+			t.Errorf("PASS-FUNNEL-RESOLVE-01: callresolver helper %q produced 0 diagnostics on red fixture; "+
+				"either the fixture lines for this symbol were removed from redfixture.go "+
+				"or the detector regressed for this symbol (per-symbol regression lock)",
+				sym)
+		}
+	}
+	const wantCRFuncDeclContextCount = 2
+	if crFuncDeclContextCount != wantCRFuncDeclContextCount {
+		t.Errorf("PASS-FUNNEL-RESOLVE-01: callresolver.FuncDeclContext diagnostics on red fixture = %d, want %d "+
+			"(qualified + alias struct-literal refs must each trip the *types.TypeName branch)",
+			crFuncDeclContextCount, wantCRFuncDeclContextCount)
 	}
 
 	// PASS-FUNNEL-FIXTURE-TAG-01 per-form coverage. Cross-package fixture forms

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -1180,9 +1180,9 @@ func TestPassFunnel_FixtureCoverage(t *testing.T) {
 	// the exact "instead of <callresolverPkgPath>.<sym>" clause (the replacement
 	// string says "archtest.<sym>", so this does not collide with the helper
 	// names embedded in every message's replacement). The 3 funcs each appear in
-	// 2 forms (qualified + alias) → ≥1 per symbol; FuncDeclContext (the
-	// *types.TypeName struct-literal ref) is exact-count == 2 (qualified + alias),
-	// mirroring the ImportBan TypeName lock.
+	// 3 forms (qualified + alias + dot-import) → ≥1 per symbol; FuncDeclContext
+	// (the *types.TypeName struct-literal ref) is exact-count == 3 (qualified +
+	// alias + dot-import bare Ident), mirroring the ImportBan TypeName 3-form lock.
 	callresolverFuncs := []string{"WalkFuncDecls", "IsCallToPkgFunc", "HasReceiver"}
 	perCRCount := make(map[string]int, len(callresolverFuncs))
 	var crFuncDeclContextCount int
@@ -1205,10 +1205,10 @@ func TestPassFunnel_FixtureCoverage(t *testing.T) {
 				sym)
 		}
 	}
-	const wantCRFuncDeclContextCount = 2
+	const wantCRFuncDeclContextCount = 3
 	if crFuncDeclContextCount != wantCRFuncDeclContextCount {
 		t.Errorf("PASS-FUNNEL-RESOLVE-01: callresolver.FuncDeclContext diagnostics on red fixture = %d, want %d "+
-			"(qualified + alias struct-literal refs must each trip the *types.TypeName branch)",
+			"(qualified + alias + dot-import struct-literal refs must each trip the *types.TypeName branch)",
 			crFuncDeclContextCount, wantCRFuncDeclContextCount)
 	}
 

--- a/tools/archtest/pass_funnel_test.go
+++ b/tools/archtest/pass_funnel_test.go
@@ -371,6 +371,21 @@ func diagsResolveHelpers(tgt passFunnelTarget) []scanner.Diagnostic {
 			// so it is not banned here. FuncDeclContext (the *types.TypeName
 			// struct-literal ref) is banned alongside the funcs, mirroring how
 			// scanner.ImportBan is banned as a TypeName.
+			//
+			// Only DIRECT internal-pkg refs trip this: the façade alias
+			// `archtest.FuncDeclContext = callresolver.FuncDeclContext` used
+			// inside package archtest resolves (via types.Info.Uses) to
+			// archtestPkgPath, NOT callresolverPkgPath, so same-package façade
+			// use (e.g. a `FuncDeclContext{...}` literal in an archtest rule) is
+			// intentionally NOT flagged — that is the sanctioned path.
+			//
+			// AI-robust grade: Medium (extends the existing PASS-FUNNEL-RESOLVE-01
+			// Medium funnel with more symbols — NOT a new funnel). Downstream:
+			// type-aware ResolvePackageRef + red-fixture per-symbol lock.
+			// Upstream: Go's internal-import visibility ceiling (a sibling
+			// *_test.go in package archtest CAN import internal/callresolver), the
+			// same permanent ceiling documented for the typeseval-helper ban
+			// above — no low-cost Hard path exists, so no new gh-issue is opened.
 			callresolverPkgPath: {
 				"WalkFuncDecls":   true,
 				"IsCallToPkgFunc": true,

--- a/tools/archtest/projection_state_phase_frozen_test.go
+++ b/tools/archtest/projection_state_phase_frozen_test.go
@@ -277,28 +277,22 @@ func phaseConstNames(f *ast.File) []string {
 // Phase.String() method to its string literal.
 func phaseStringArms(f *ast.File) map[string]string {
 	arms := map[string]string{}
-	for _, d := range f.Decls {
-		fn, ok := d.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != "String" || fn.Recv == nil || !isPhaseReceiver(fn.Recv) {
-			continue
+	WalkFuncDeclsAST([]*ast.File{f}, nil, nil, func(ctx FuncDeclContext) {
+		if ctx.Func.Name.Name != "String" || !HasReceiver(ctx.Func, "Phase") {
+			return
 		}
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			cc, ok := n.(*ast.CaseClause)
-			if !ok {
-				return true
-			}
+		EachInSubtree[ast.CaseClause](ctx.Func.Body, func(cc *ast.CaseClause) {
 			lit := firstReturnedStringLit(cc.Body)
 			if lit == "" {
-				return true
+				return
 			}
 			for _, e := range cc.List {
 				if id, ok := e.(*ast.Ident); ok {
 					arms[id.Name] = lit
 				}
 			}
-			return true
 		})
-	}
+	})
 	return arms
 }
 
@@ -316,43 +310,20 @@ func parseFileOrFatal(t *testing.T, src []byte) *ast.File {
 // literal (BasicLit), so phaseStringArms (which keys on const Idents) excludes
 // it; it is locked separately because "invalid" is also a wire/log contract.
 func phaseZeroLiteralArm(f *ast.File) string {
-	for _, d := range f.Decls {
-		fn, ok := d.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != "String" || fn.Recv == nil || !isPhaseReceiver(fn.Recv) {
-			continue
+	var lit string
+	WalkFuncDeclsAST([]*ast.File{f}, nil, nil, func(ctx FuncDeclContext) {
+		if lit != "" || ctx.Func.Name.Name != "String" || !HasReceiver(ctx.Func, "Phase") {
+			return
 		}
-		var lit string
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			cc, ok := n.(*ast.CaseClause)
-			if !ok {
-				return true
-			}
+		EachInSubtree[ast.CaseClause](ctx.Func.Body, func(cc *ast.CaseClause) {
 			for _, e := range cc.List {
 				if bl, ok := e.(*ast.BasicLit); ok && bl.Kind == token.INT && bl.Value == "0" {
 					lit = firstReturnedStringLit(cc.Body)
 				}
 			}
-			return true
 		})
-		if lit != "" {
-			return lit
-		}
-	}
-	return ""
-}
-
-func isPhaseReceiver(recv *ast.FieldList) bool {
-	if len(recv.List) != 1 {
-		return false
-	}
-	switch t := recv.List[0].Type.(type) {
-	case *ast.Ident:
-		return t.Name == "Phase"
-	case *ast.StarExpr:
-		id, ok := t.X.(*ast.Ident)
-		return ok && id.Name == "Phase"
-	}
-	return false
+	})
+	return lit
 }
 
 func firstReturnedStringLit(body []ast.Stmt) string {

--- a/tools/archtest/serviceowned_handler_owner_check_test.go
+++ b/tools/archtest/serviceowned_handler_owner_check_test.go
@@ -1242,6 +1242,15 @@ func calleeIdentName(ref ast.Expr) string {
 // explicit generic type arguments so the underlying SelectorExpr / Ident can
 // be passed to ResolvePackageRef.
 //
+// NOTE: callresolver.IsCallToPkgFunc folds the unwrap+resolve+(pkg,name)-compare
+// shape, and the errcode-ctor sites here were migrated to it. This local copy is
+// deliberately RETAINED — the ownership/BFS sites (isOwnershipMismatchCall,
+// fileCallsAuthCheckOwnerFromEntries) need the *unwrapped ast.Expr* itself (to
+// feed calleeIdentName for intra-file call-graph naming), not the bool that
+// IsCallToPkgFunc returns, and callresolver.unwrapCallee is unexported. The
+// duplicated 4-line switch is the accepted cost of keeping that expr-returning
+// helper local rather than widening the façade.
+//
 // IndexExpr handles single-type-arg generic dispatch (`CheckOwner[T](...)`,
 // the only currently-instantiable form for `CheckOwner[T any]`). IndexListExpr
 // is defensive coverage for future multi-type-arg signatures (e.g.

--- a/tools/archtest/serviceowned_handler_owner_check_test.go
+++ b/tools/archtest/serviceowned_handler_owner_check_test.go
@@ -1054,8 +1054,7 @@ func checkFunnelReturnForms(pass *Pass, fn *ast.FuncDecl, rel string) []Diagnost
 // expected inside the funnel and is treated as a B2 violation if present
 // (would still be flagged via the otherCalls / notFoundCalls accounting).
 func isErrCodeNewCall(typesInfo *types.Info, call *ast.CallExpr) bool {
-	pkg, name, ok := resolveErrcodeCtor(typesInfo, call)
-	return ok && pkg == serviceOwnedErrcodePkg && name == "New"
+	return IsCallToPkgFunc(typesInfo, call, serviceOwnedErrcodePkg, "New")
 }
 
 // isErrCodeNewOrWrapCall reports whether call resolves via go/types to
@@ -1068,23 +1067,8 @@ func isErrCodeNewCall(typesInfo *types.Info, call *ast.CallExpr) bool {
 // Detection requires SSA dataflow analysis; tracked at gh #1199 alongside
 // the SSA callgraph upgrade.
 func isErrCodeNewOrWrapCall(typesInfo *types.Info, call *ast.CallExpr) bool {
-	pkg, name, ok := resolveErrcodeCtor(typesInfo, call)
-	if !ok || pkg != serviceOwnedErrcodePkg {
-		return false
-	}
-	return name == "New" || name == "Wrap"
-}
-
-// resolveErrcodeCtor resolves a call's callee through go/types and returns
-// the package path and symbol name. Bare-Ident (dot-import) and SelectorExpr
-// (qualified) and IndexExpr (explicit generic, defensive) shapes all
-// resolve correctly.
-func resolveErrcodeCtor(typesInfo *types.Info, call *ast.CallExpr) (pkgPath, name string, ok bool) {
-	ref := unwrapCalleeForResolve(call.Fun)
-	if ref == nil {
-		return "", "", false
-	}
-	return ResolvePackageRef(typesInfo, ref)
+	return IsCallToPkgFunc(typesInfo, call, serviceOwnedErrcodePkg, "New") ||
+		IsCallToPkgFunc(typesInfo, call, serviceOwnedErrcodePkg, "Wrap")
 }
 
 // isKindNotFoundArg reports whether arg evaluates to errcode.KindNotFound,

--- a/tools/archtest/serviceowned_handler_owner_check_test.go
+++ b/tools/archtest/serviceowned_handler_owner_check_test.go
@@ -1238,9 +1238,10 @@ func calleeIdentName(ref ast.Expr) string {
 	return ""
 }
 
-// unwrapCalleeForResolve strips IndexExpr / IndexListExpr wrappers added by
-// explicit generic type arguments so the underlying SelectorExpr / Ident can
-// be passed to ResolvePackageRef.
+// unwrapCalleeForResolve strips ParenExpr (parenthesized callee) and
+// IndexExpr / IndexListExpr (explicit generic type arguments) wrappers, at any
+// nesting level, so the underlying SelectorExpr / Ident can be passed to
+// ResolvePackageRef.
 //
 // NOTE: callresolver.IsCallToPkgFunc folds the unwrap+resolve+(pkg,name)-compare
 // shape, and the errcode-ctor sites here were migrated to it. This local copy is
@@ -1259,6 +1260,10 @@ func calleeIdentName(ref ast.Expr) string {
 // produces IndexListExpr; the branch is defensive only.
 func unwrapCalleeForResolve(fun ast.Expr) ast.Expr {
 	switch v := fun.(type) {
+	case *ast.ParenExpr:
+		// Parenthesized callee, e.g. `(auth.CheckOwner)(...)` — strip parens at
+		// any nesting level (mirrors go/ast.Unparen + callresolver.unwrapCallee).
+		return unwrapCalleeForResolve(v.X)
 	case *ast.SelectorExpr, *ast.Ident:
 		return v
 	case *ast.IndexExpr:


### PR DESCRIPTION
## Summary

抽出 `tools/archtest/internal/callresolver` 便利层，统一散落复制的「遍历 FuncDecl + 解析 callee + 断言 receiver」visitor 形态，并把适配的 archtest 迁移过去（统一形态防漂移）。

Closes #1246
Refs: #1239（AUDIT-HASH-INPUT-FROZEN-01.A2 的 RunTyped+ResolvePackageRef 形态来源）

### 架构形态（与既有 scanner/typeseval 三层约定一致）
- `internal/callresolver`（无状态引擎）→ façade `tools/archtest/callresolver.go` re-export → 业务 `archtest.X`。
- 吃 `*Pass` 的 walker 必须在 façade（`Pass` 在 package archtest，internal 引用会成 import 环）。

### API（4 个均有真实采用者）
- `archtest.WalkFuncDecls(p *Pass, fn)` — 遍历 p.Files 顶层有 Body 的 FuncDecl（采用：audit_hash、health_verbose）
- `archtest.WalkFuncDeclsAST(files, fset, rel, fn)` — 无 Pass 的 AST-only 入口（采用：projection_state_phase）
- `archtest.IsCallToPkgFunc(info, call, pkgPath, name)` — alias/dot-import/泛型实例化 proof 的 callee 判定（采用：6 文件）
- `archtest.HasReceiver(fn, typeName)` — 经 ReceiverTypeName 判 `*T/T/T[P]`（采用：audit_hash、projection_state_phase）
- **自审删除** issue 点名的 `EnclosingFunc`：迁移集零采用者，YAGNI（唯一 enclosing-func 场景用既有 `ResolveEnclosingFunc`）。

### PASS-FUNNEL 强制（防漂移）
扩展 `PASS-FUNNEL-RESOLVE-01`（`diagsResolveHelpers`）禁止业务 `*_test.go` 直接 import `internal/callresolver`，强制走 façade；红 fixture（qualified+alias）+ per-symbol(≥1)/FuncDeclContext(==2) 覆盖断言。**AI-robust 评级：Medium**（下游 type-aware 检测 + red-fixture 锁；上游 Go internal-import 天花板，与既有 typeseval-helper ban 同姿态，非新 funnel 不开 Hard 化 issue，无 Soft）。

### 迁移清单（8 文件）
| 文件 | 采用 |
|---|---|
| audit_hash_input_frozen | WalkFuncDecls + IsCallToPkgFunc + HasReceiver（修 3 处 USAGE-01）|
| serviceowned_handler_owner_check（donor）| IsCallToPkgFunc（删 resolveErrcodeCtor；unwrapCalleeForResolve 留给 BFS/ownership）|
| changepassword_inactive_gate | IsCallToPkgFunc |
| health_verbose_invariants | WalkFuncDecls×2 + IsCallToPkgFunc |
| baseslice_ctor_funnel_01 | IsCallToPkgFunc |
| credential_authority_assert_funnel | IsCallToPkgFunc |
| adapter_net_transient_funnel | IsCallToPkgFunc（130 行 EachInSubtree[FuncDecl] 块留存：已合规，depth-1 swap 是 churn）|
| projection_state_phase_frozen | WalkFuncDeclsAST + HasReceiver（修 4 处 USAGE-01，删 isPhaseReceiver）|

诚实排除（DOES-NOT-FIT，硬塞会变形）：ctxkeys / outbox_reconstruction / mqtt_callsite / projection_checkpoint_owner / codegen_localprefix / eval_predicate(集合比较) / saga / mem_tx(suffix-match callee)。

## Test plan
- [x] `go build ./...`
- [x] `go test ./tools/archtest/internal/callresolver/`（新单测：IsCallToPkgFunc 含 alias/dot-import/泛型/method/nil；HasReceiver 含泛型 recv；WalkFuncDecls 含 body-skip/typed-info/nil-safe）— GREEN（先 RED：包不编译）
- [x] `go test -run TestPassFunnel ./tools/archtest/` — GREEN（新 callresolver ban + 覆盖断言）
- [x] 全部迁移文件各自规则 Test GREEN（含负向 fixture）
- [x] `golangci-lint run ./tools/archtest/...` — 0 issues
- [x] USAGE-01 命中 **21 → 14**（仅迁移文件命中下降，无回归）

## 已知/范围外（需后续 backlog）
- ⚠️ **pre-existing 失败（非本 PR 引入）**：`TestErrcodeMessageConstLiteral` flags `adapters/mqtt/connection.go:503`（`errcode.New` message 是变量非 const literal）— 由 MQTT PR #1277 引入、nightly-only、与本 PR 正交。建议另开修复条目。
- DOES-NOT-FIT 文件的 USAGE-01 残留 14 处是独立 `EachInSubtree` cleanup（非 callresolver 采用），不在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)