### PR TITLE
refactor(sonar): SonarCloud code smell 清零（71→0：重构 + justified 豁免）

### DIFF
--- a/adapters/mqtt/clientid_test.go
+++ b/adapters/mqtt/clientid_test.go
@@ -5,6 +5,39 @@ import (
 	"testing"
 )
 
+// assertEphemeralClientIDValid checks the structural invariants of a valid
+// ParseEphemeralClientID result: prefix matches cellID, role segment follows,
+// and the trailing UUID suffix is 36 characters.
+func assertEphemeralClientIDValid(t *testing.T, cellID, role string) {
+	t.Helper()
+	cid, err := ParseEphemeralClientID(cellID, role)
+	if err != nil {
+		t.Fatalf("ParseEphemeralClientID(%q, %q) unexpected error: %v", cellID, role, err)
+	}
+	s := cid.String()
+	// Must have at least 3 parts: cellID-role-uuid (uuid contains hyphens).
+	parts := strings.Split(s, "-")
+	if len(parts) < 3 {
+		t.Fatalf("String() = %q: expected at least 3 hyphen-separated parts, got %d", s, len(parts))
+	}
+	// First segment must equal cellID (which may itself contain hyphens).
+	cellIDLen := len(cellID)
+	if s[:cellIDLen] != cellID {
+		t.Errorf("String() = %q: expected prefix %q", s, cellID)
+	}
+	// Role must appear after cellID-.
+	rest := s[cellIDLen+1:]
+	roleLen := len(role)
+	if len(rest) <= roleLen || rest[:roleLen] != role {
+		t.Errorf("String() = %q: expected role %q after cellID", s, role)
+	}
+	// Must have uuid suffix (36 chars: 32 hex + 4 hyphens).
+	uuidPart := rest[roleLen+1:]
+	if len(uuidPart) != 36 {
+		t.Errorf("String() = %q: uuid suffix %q has length %d, want 36", s, uuidPart, len(uuidPart))
+	}
+}
+
 func TestParseEphemeralClientID_Valid(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -19,32 +52,7 @@ func TestParseEphemeralClientID_Valid(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cid, err := ParseEphemeralClientID(tc.cellID, tc.role)
-			if err != nil {
-				t.Fatalf("ParseEphemeralClientID(%q, %q) unexpected error: %v", tc.cellID, tc.role, err)
-			}
-			s := cid.String()
-			// Must have at least 3 parts: cellID-role-uuid (uuid contains hyphens).
-			parts := strings.Split(s, "-")
-			if len(parts) < 3 {
-				t.Fatalf("String() = %q: expected at least 3 hyphen-separated parts, got %d", s, len(parts))
-			}
-			// First segment must equal cellID (which may itself contain hyphens).
-			cellIDLen := len(tc.cellID)
-			if s[:cellIDLen] != tc.cellID {
-				t.Errorf("String() = %q: expected prefix %q", s, tc.cellID)
-			}
-			// Role must appear after cellID-.
-			rest := s[cellIDLen+1:]
-			roleLen := len(tc.role)
-			if len(rest) <= roleLen || rest[:roleLen] != tc.role {
-				t.Errorf("String() = %q: expected role %q after cellID", s, tc.role)
-			}
-			// Must have uuid suffix (36 chars: 32 hex + 4 hyphens).
-			uuidPart := rest[roleLen+1:]
-			if len(uuidPart) != 36 {
-				t.Errorf("String() = %q: uuid suffix %q has length %d, want 36", s, uuidPart, len(uuidPart))
-			}
+			assertEphemeralClientIDValid(t, tc.cellID, tc.role)
 		})
 	}
 }

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -503,6 +503,15 @@ func buildConnackError(code errcode.Code, cause error, message string) error {
 	return errcode.New(errcode.KindInternal, code, message, opts...)
 }
 
+// errClosed returns the canonical error for operations attempted on a closed
+// connection. Centralizing the message here keeps the literal single-sourced
+// (no go:S1192 duplication) while preserving the inline BasicLit required by
+// MESSAGE-CONST-LITERAL-01.
+func errClosed() error {
+	return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
+		"mqtt: connection is closed")
+}
+
 // onServerDisconnect records a server-initiated DISCONNECT for diagnostics.
 // reason_name is decoded via disconnectReasonName (MQTT v5 §3.14.2.1) — the
 // DISCONNECT reason-code table, NOT the CONNACK table, which shares numeric
@@ -543,8 +552,7 @@ func (c *Connection) Publish(ctx context.Context, t publishableTopic, payload []
 	closed := c.closed
 	c.mu.RUnlock()
 	if closed {
-		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+		return nil, errClosed()
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishCanceled,
@@ -696,8 +704,7 @@ func (c *Connection) Subscribe(ctx context.Context, f subscribableFilter, qos by
 	closed := c.closed
 	c.mu.RUnlock()
 	if closed {
-		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+		return nil, errClosed()
 	}
 
 	// Capture the subscription ctx + handler into a dispatch closure so the
@@ -785,8 +792,7 @@ func (c *Connection) ack(pb *paho.Publish) error {
 	closed := c.closed
 	c.mu.RUnlock()
 	if closed {
-		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+		return errClosed()
 	}
 	c.subMu.RLock()
 	acker := c.ackClient
@@ -818,8 +824,7 @@ func (c *Connection) Health(_ context.Context) error {
 	defer c.mu.RUnlock()
 
 	if c.closed {
-		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+		return errClosed()
 	}
 	if c.permanentErr != nil {
 		return c.permanentErr
@@ -917,8 +922,7 @@ func (c *Connection) WaitConnected(ctx context.Context) error {
 		c.mu.RUnlock()
 
 		if closed {
-			return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-				"mqtt: connection is closed")
+			return errClosed()
 		}
 		if permErr != nil {
 			return permErr

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -31,6 +31,8 @@ const (
 	phaseDisconnected
 )
 
+const errMsgConnClosed = "mqtt: connection is closed"
+
 // Compile-time interface assertions.
 var (
 	_ lifecycle.ManagedResource = (*Connection)(nil)
@@ -544,7 +546,7 @@ func (c *Connection) Publish(ctx context.Context, t publishableTopic, payload []
 	c.mu.RUnlock()
 	if closed {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+			errMsgConnClosed)
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishCanceled,
@@ -697,7 +699,7 @@ func (c *Connection) Subscribe(ctx context.Context, f subscribableFilter, qos by
 	c.mu.RUnlock()
 	if closed {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+			errMsgConnClosed)
 	}
 
 	// Capture the subscription ctx + handler into a dispatch closure so the
@@ -786,7 +788,7 @@ func (c *Connection) ack(pb *paho.Publish) error {
 	c.mu.RUnlock()
 	if closed {
 		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+			errMsgConnClosed)
 	}
 	c.subMu.RLock()
 	acker := c.ackClient
@@ -819,7 +821,7 @@ func (c *Connection) Health(_ context.Context) error {
 
 	if c.closed {
 		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			"mqtt: connection is closed")
+			errMsgConnClosed)
 	}
 	if c.permanentErr != nil {
 		return c.permanentErr
@@ -918,7 +920,7 @@ func (c *Connection) WaitConnected(ctx context.Context) error {
 
 		if closed {
 			return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-				"mqtt: connection is closed")
+				errMsgConnClosed)
 		}
 		if permErr != nil {
 			return permErr

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -31,8 +31,6 @@ const (
 	phaseDisconnected
 )
 
-const errMsgConnClosed = "mqtt: connection is closed"
-
 // Compile-time interface assertions.
 var (
 	_ lifecycle.ManagedResource = (*Connection)(nil)
@@ -546,7 +544,7 @@ func (c *Connection) Publish(ctx context.Context, t publishableTopic, payload []
 	c.mu.RUnlock()
 	if closed {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			errMsgConnClosed)
+			"mqtt: connection is closed")
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, errcode.Wrap(errcode.KindUnavailable, ErrAdapterMQTTPublishCanceled,
@@ -699,7 +697,7 @@ func (c *Connection) Subscribe(ctx context.Context, f subscribableFilter, qos by
 	c.mu.RUnlock()
 	if closed {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			errMsgConnClosed)
+			"mqtt: connection is closed")
 	}
 
 	// Capture the subscription ctx + handler into a dispatch closure so the
@@ -788,7 +786,7 @@ func (c *Connection) ack(pb *paho.Publish) error {
 	c.mu.RUnlock()
 	if closed {
 		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			errMsgConnClosed)
+			"mqtt: connection is closed")
 	}
 	c.subMu.RLock()
 	acker := c.ackClient
@@ -821,7 +819,7 @@ func (c *Connection) Health(_ context.Context) error {
 
 	if c.closed {
 		return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-			errMsgConnClosed)
+			"mqtt: connection is closed")
 	}
 	if c.permanentErr != nil {
 		return c.permanentErr
@@ -920,7 +918,7 @@ func (c *Connection) WaitConnected(ctx context.Context) error {
 
 		if closed {
 			return errcode.New(errcode.KindInternal, ErrAdapterMQTTClosed,
-				errMsgConnClosed)
+				"mqtt: connection is closed")
 		}
 		if permErr != nil {
 			return permErr

--- a/adapters/redis/mock_test.go
+++ b/adapters/redis/mock_test.go
@@ -265,6 +265,80 @@ func newClaimerMock() *claimerMockCmdable {
 	}
 }
 
+// evalRelease handles the release Lua script: 1 key (leaseKey), 1 arg (token).
+func (m *claimerMockCmdable) evalRelease(cmd *goredis.Cmd, keys []string, args []any) {
+	leaseKey := keys[0]
+	token := toString(args[0])
+	if entry, ok := m.store[leaseKey]; ok && entry.value == token {
+		delete(m.store, leaseKey)
+		cmd.SetVal(int64(1))
+	} else {
+		cmd.SetVal(int64(0))
+	}
+}
+
+// evalExtend handles the extend Lua script: 1 key (leaseKey), 2 args (token, ttlMs).
+func (m *claimerMockCmdable) evalExtend(cmd *goredis.Cmd, keys []string, args []any) {
+	leaseKey := keys[0]
+	token := toString(args[0])
+	ttlMs := toInt64(args[1])
+	if entry, ok := m.store[leaseKey]; ok && entry.value == token {
+		entry.expiry = time.Now().Add(time.Duration(ttlMs) * time.Millisecond)
+		m.store[leaseKey] = entry
+		cmd.SetVal(int64(1))
+	} else {
+		cmd.SetVal(int64(0))
+	}
+}
+
+// evalClaim handles the claim Lua script: 2 keys (doneKey, leaseKey), args (token, leaseMs).
+// keys[0] ends in ":done" (cluster hashtag layout).
+func (m *claimerMockCmdable) evalClaim(cmd *goredis.Cmd, keys []string, args []any) {
+	doneKey, leaseKey := keys[0], keys[1]
+	token := toString(args[0])
+	leaseMs := toInt64(args[1])
+
+	if entry, ok := m.store[doneKey]; ok {
+		// Treat expired done key as absent (same as Get with expiry check).
+		if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {
+			cmd.SetVal(int64(0)) // ClaimDone
+			return
+		}
+		delete(m.store, doneKey) // expired
+	}
+	if entry, ok := m.store[leaseKey]; ok {
+		if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {
+			cmd.SetVal(int64(2)) // ClaimBusy
+			return
+		}
+		delete(m.store, leaseKey) // expired
+	}
+	m.store[leaseKey] = mockEntry{
+		value:  token,
+		expiry: time.Now().Add(time.Duration(leaseMs) * time.Millisecond),
+	}
+	cmd.SetVal(int64(1)) // ClaimAcquired
+}
+
+// evalCommit handles the commit Lua script: 2 keys (leaseKey, doneKey), args (token, doneMs).
+// keys[0] ends in ":lease" (cluster hashtag layout).
+func (m *claimerMockCmdable) evalCommit(cmd *goredis.Cmd, keys []string, args []any) {
+	leaseKey, doneKey := keys[0], keys[1]
+	token := toString(args[0])
+	doneMs := toInt64(args[1])
+
+	if entry, ok := m.store[leaseKey]; ok && entry.value == token {
+		delete(m.store, leaseKey)
+		m.store[doneKey] = mockEntry{
+			value:  "1",
+			expiry: time.Now().Add(time.Duration(doneMs) * time.Millisecond),
+		}
+		cmd.SetVal(int64(1))
+	} else {
+		cmd.SetVal(int64(0))
+	}
+}
+
 // Eval overrides the base mock to simulate the claimer Lua scripts.
 // Distinguishes claim vs commit by key order:
 //   - Claim:   keys=[{k}:done, {k}:lease]  (keys[0] ends in ":done")
@@ -286,78 +360,18 @@ func (m *claimerMockCmdable) Eval(_ context.Context, _ string, keys []string, ar
 	switch {
 	// Release script: 1 key (leaseKey), 1 arg (token)
 	case len(keys) == 1 && len(args) == 1:
-		leaseKey := keys[0]
-		token := toString(args[0])
-		if entry, ok := m.store[leaseKey]; ok && entry.value == token {
-			delete(m.store, leaseKey)
-			cmd.SetVal(int64(1))
-		} else {
-			cmd.SetVal(int64(0))
-		}
-		return cmd
-
+		m.evalRelease(cmd, keys, args)
 	// Extend script: 1 key (leaseKey), 2 args (token, ttlMs)
 	case len(keys) == 1 && len(args) == 2:
-		leaseKey := keys[0]
-		token := toString(args[0])
-		ttlMs := toInt64(args[1])
-		if entry, ok := m.store[leaseKey]; ok && entry.value == token {
-			entry.expiry = time.Now().Add(time.Duration(ttlMs) * time.Millisecond)
-			m.store[leaseKey] = entry
-			cmd.SetVal(int64(1))
-		} else {
-			cmd.SetVal(int64(0))
-		}
-		return cmd
-
+		m.evalExtend(cmd, keys, args)
 	// Claim script: 2 keys, keys[0] ends in ":done" (cluster hashtag layout).
 	case len(keys) == 2 && len(args) >= 2 && strings.HasSuffix(keys[0], ":done"):
-		doneKey, leaseKey := keys[0], keys[1]
-		token := toString(args[0])
-		leaseMs := toInt64(args[1])
-
-		if entry, ok := m.store[doneKey]; ok {
-			// Treat expired done key as absent (same as Get with expiry check).
-			if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {
-				cmd.SetVal(int64(0)) // ClaimDone
-				return cmd
-			}
-			delete(m.store, doneKey) // expired
-		}
-		if entry, ok := m.store[leaseKey]; ok {
-			if entry.expiry.IsZero() || time.Now().Before(entry.expiry) {
-				cmd.SetVal(int64(2)) // ClaimBusy
-				return cmd
-			}
-			delete(m.store, leaseKey) // expired
-		}
-		m.store[leaseKey] = mockEntry{
-			value:  token,
-			expiry: time.Now().Add(time.Duration(leaseMs) * time.Millisecond),
-		}
-		cmd.SetVal(int64(1)) // ClaimAcquired
-		return cmd
-
+		m.evalClaim(cmd, keys, args)
 	// Commit script: 2 keys, keys[0] ends in ":lease" (cluster hashtag layout).
 	case len(keys) == 2 && len(args) == 2 && strings.HasSuffix(keys[0], ":lease"):
-		leaseKey, doneKey := keys[0], keys[1]
-		token := toString(args[0])
-		doneMs := toInt64(args[1])
-
-		if entry, ok := m.store[leaseKey]; ok && entry.value == token {
-			delete(m.store, leaseKey)
-			m.store[doneKey] = mockEntry{
-				value:  "1",
-				expiry: time.Now().Add(time.Duration(doneMs) * time.Millisecond),
-			}
-			cmd.SetVal(int64(1))
-		} else {
-			cmd.SetVal(int64(0))
-		}
-		return cmd
-
+		m.evalCommit(cmd, keys, args)
 	default:
 		cmd.SetVal(int64(0))
-		return cmd
 	}
+	return cmd
 }

--- a/cells/accesscore/auth_integration_test.go
+++ b/cells/accesscore/auth_integration_test.go
@@ -268,7 +268,14 @@ func TestAuthIntent_AccessTokenBlockedAtRefreshPath(t *testing.T) {
 	require.NoError(t, err)
 	refreshSvc, err := sessionrefresh.NewService(
 		clock.Real(),
-		fx.Cell.sessionStore, fx.Cell.roleRepo, fx.Cell.userRepo, fx.Cell.refreshStore, fx.Cell.jwtIssuer, slog.Default(),
+		sessionrefresh.NewServiceParams{
+			SessionStore: fx.Cell.sessionStore,
+			RoleRepo:     fx.Cell.roleRepo,
+			UserRepo:     fx.Cell.userRepo,
+			RefreshStore: fx.Cell.refreshStore,
+			Issuer:       fx.Cell.jwtIssuer,
+		},
+		slog.Default(),
 		sessionrefresh.WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})),
 		sessionrefresh.WithInvalidator(inv1),
 	)
@@ -294,7 +301,14 @@ func TestAuthIntent_RefreshTokenSucceedsAtRefreshPath(t *testing.T) {
 	require.NoError(t, err)
 	refreshSvc, err := sessionrefresh.NewService(
 		clock.Real(),
-		fx.Cell.sessionStore, fx.Cell.roleRepo, fx.Cell.userRepo, fx.Cell.refreshStore, fx.Cell.jwtIssuer, slog.Default(),
+		sessionrefresh.NewServiceParams{
+			SessionStore: fx.Cell.sessionStore,
+			RoleRepo:     fx.Cell.roleRepo,
+			UserRepo:     fx.Cell.userRepo,
+			RefreshStore: fx.Cell.refreshStore,
+			Issuer:       fx.Cell.jwtIssuer,
+		},
+		slog.Default(),
 		sessionrefresh.WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})),
 		sessionrefresh.WithInvalidator(inv2),
 	)

--- a/cells/accesscore/cell_init.go
+++ b/cells/accesscore/cell_init.go
@@ -239,11 +239,13 @@ func (c *AccessCore) initSlices() error {
 	}
 	loginSvc, err := sessionlogin.NewService(
 		c.clk,
-		c.userRepo,
-		c.sessionStore,
-		c.roleRepo,
-		c.refreshStore,
-		c.jwtIssuer,
+		sessionlogin.NewServiceParams{
+			UserRepo:     c.userRepo,
+			SessionStore: c.sessionStore,
+			RoleRepo:     c.roleRepo,
+			RefreshStore: c.refreshStore,
+			Issuer:       c.jwtIssuer,
+		},
 		c.logger,
 		loginOpts...,
 	)
@@ -282,8 +284,14 @@ func (c *AccessCore) initSlices() error {
 	// access JWT replay attempt) returns ErrRejected.
 	refreshSvc, err := sessionrefresh.NewService(
 		c.clk,
-		c.sessionStore, c.roleRepo, c.userRepo, c.refreshStore,
-		c.jwtIssuer, c.logger,
+		sessionrefresh.NewServiceParams{
+			SessionStore: c.sessionStore,
+			RoleRepo:     c.roleRepo,
+			UserRepo:     c.userRepo,
+			RefreshStore: c.refreshStore,
+			Issuer:       c.jwtIssuer,
+		},
+		c.logger,
 		sessionrefresh.WithTxManager(c.txRunner),
 		sessionrefresh.WithInvalidator(c.invalidator),
 	)

--- a/cells/accesscore/internal/domain/admin_test.go
+++ b/cells/accesscore/internal/domain/admin_test.go
@@ -75,14 +75,7 @@ func TestLastAdminGuard_CheckRemove(t *testing.T) {
 	t.Parallel()
 	sentinelInfra := errors.New("counter outage")
 
-	tests := []struct {
-		name              string
-		userIsActiveAdmin bool
-		count             int
-		countErr          error
-		wantCode          errcode.Code
-		wantErrIs         error
-	}{
+	tests := []guardCheckRemoveCase{
 		{
 			name:              "non_effective_admin_short_circuits",
 			userIsActiveAdmin: false,
@@ -118,45 +111,64 @@ func TestLastAdminGuard_CheckRemove(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			stub := &stubEffectiveAdminCounterImpl{count: tc.count, err: tc.countErr}
-			sealed, wrapErr := domain.WrapEffectiveAdminCounter(stub)
-			if wrapErr != nil {
-				t.Fatalf("WrapEffectiveAdminCounter: %v", wrapErr)
-			}
-			guard, err := domain.NewLastAdminGuard(sealed)
-			if err != nil {
-				t.Fatalf("NewLastAdminGuard: %v", err)
-			}
-
-			err = guard.CheckRemove(context.Background(), "user-123", tc.userIsActiveAdmin)
-
-			switch {
-			case tc.wantErrIs != nil:
-				if !errors.Is(err, tc.wantErrIs) {
-					t.Fatalf("expected error wrapping %v, got %v", tc.wantErrIs, err)
-				}
-			case tc.wantCode != "":
-				var coded *errcode.Error
-				if !errors.As(err, &coded) {
-					t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
-				}
-				if coded.Code != tc.wantCode {
-					t.Errorf("code: got %s, want %s", coded.Code, tc.wantCode)
-				}
-				if coded.Kind != errcode.KindPermissionDenied {
-					t.Errorf("kind: got %v, want KindPermissionDenied", coded.Kind)
-				}
-			default:
-				if err != nil {
-					t.Errorf("expected nil error, got %v", err)
-				}
-			}
-
-			// non-effective-admin path must NOT invoke the counter (avoid burning DB
-			// queries when the answer is structurally "allowed").
-			if !tc.userIsActiveAdmin && stub.called {
-				t.Error("non-effective-admin path must short-circuit before invoking counter")
-			}
+			runGuardCheckRemoveCase(t, tc)
 		})
+	}
+}
+
+type guardCheckRemoveCase struct {
+	name              string
+	userIsActiveAdmin bool
+	count             int
+	countErr          error
+	wantCode          errcode.Code
+	wantErrIs         error
+}
+
+func runGuardCheckRemoveCase(t *testing.T, tc guardCheckRemoveCase) {
+	t.Helper()
+	stub := &stubEffectiveAdminCounterImpl{count: tc.count, err: tc.countErr}
+	sealed, wrapErr := domain.WrapEffectiveAdminCounter(stub)
+	if wrapErr != nil {
+		t.Fatalf("WrapEffectiveAdminCounter: %v", wrapErr)
+	}
+	guard, err := domain.NewLastAdminGuard(sealed)
+	if err != nil {
+		t.Fatalf("NewLastAdminGuard: %v", err)
+	}
+
+	err = guard.CheckRemove(context.Background(), "user-123", tc.userIsActiveAdmin)
+
+	assertGuardRemoveError(t, err, tc)
+
+	// non-effective-admin path must NOT invoke the counter (avoid burning DB
+	// queries when the answer is structurally "allowed").
+	if !tc.userIsActiveAdmin && stub.called {
+		t.Error("non-effective-admin path must short-circuit before invoking counter")
+	}
+}
+
+func assertGuardRemoveError(t *testing.T, err error, tc guardCheckRemoveCase) {
+	t.Helper()
+	switch {
+	case tc.wantErrIs != nil:
+		if !errors.Is(err, tc.wantErrIs) {
+			t.Fatalf("expected error wrapping %v, got %v", tc.wantErrIs, err)
+		}
+	case tc.wantCode != "":
+		var coded *errcode.Error
+		if !errors.As(err, &coded) {
+			t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+		}
+		if coded.Code != tc.wantCode {
+			t.Errorf("code: got %s, want %s", coded.Code, tc.wantCode)
+		}
+		if coded.Kind != errcode.KindPermissionDenied {
+			t.Errorf("kind: got %v, want KindPermissionDenied", coded.Kind)
+		}
+	default:
+		if err != nil {
+			t.Errorf("expected nil error, got %v", err)
+		}
 	}
 }

--- a/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/cells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -153,7 +153,14 @@ func newE2EFixture() *e2eFixture {
 	}
 
 	loginSvc, err := sessionlogin.NewService(clock.Real(),
-		userRepo, sessionStore, roleRepo, refreshStore, e2eIssuer, slog.Default(),
+		sessionlogin.NewServiceParams{
+			UserRepo:     userRepo,
+			SessionStore: sessionStore,
+			RoleRepo:     roleRepo,
+			RefreshStore: refreshStore,
+			Issuer:       e2eIssuer,
+		},
+		slog.Default(),
 		sessionlogin.WithTxManager(persistence.WrapForCell(tx)),
 		sessionlogin.WithSessionTTL(time.Hour),
 		sessionlogin.WithAccountLockout(lockoutSvc),

--- a/cells/accesscore/slices/sessionlogin/handler_test.go
+++ b/cells/accesscore/slices/sessionlogin/handler_test.go
@@ -60,8 +60,13 @@ func setup(t *testing.T) http.Handler {
 
 	sessionStore := testutil.RealSessionRepo(t)
 	refreshStore := newHandlerRefreshStore()
-	svc, err := NewService(clock.Real(), userRepo, sessionStore, mem.NewStore(clock.Real()).RoleRepository(),
-		refreshStore, testIssuer, slog.Default(),
+	svc, err := NewService(clock.Real(), NewServiceParams{
+		UserRepo:     userRepo,
+		SessionStore: sessionStore,
+		RoleRepo:     mem.NewStore(clock.Real()).RoleRepository(),
+		RefreshStore: refreshStore,
+		Issuer:       testIssuer,
+	}, slog.Default(),
 		WithTxManager(persistence.WrapForCell(&stubTxRunner{})),
 		WithSessionTTL(time.Hour),
 		WithAccountLockout(newTestLockout(userRepo, sessionStore, refreshStore)))

--- a/cells/accesscore/slices/sessionlogin/handler_test.go
+++ b/cells/accesscore/slices/sessionlogin/handler_test.go
@@ -21,30 +21,11 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
-	"github.com/ghbvf/gocell/runtime/auth/refresh"
-	refreshmem "github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
-	"github.com/ghbvf/gocell/runtime/auth/refresh/storetest"
-
-	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 // testIssuer is declared in service_test.go
 
 const loginPath = "/api/v1/access/sessions/login"
-
-func newHandlerRefreshStore() refresh.Store {
-	clk := storetest.NewFakeClock(time.Now())
-	store, err := refreshmem.New(refresh.Policy{
-		ReuseInterval:  testtime.D2s,
-		MaxAge:         time.Hour,
-		MaxIdle:        refresh.DefaultMaxIdle,
-		GraceMaxReuses: refresh.DefaultGraceMaxReuses,
-	}, clk, nil)
-	if err != nil {
-		panic("test setup: " + err.Error())
-	}
-	return store
-}
 
 // setup wires the slice handler onto a celltest mux via RegisterRoutes — the
 // same code path cell_routes.go takes in production. Tests dispatch via
@@ -59,7 +40,7 @@ func setup(t *testing.T) http.Handler {
 	_ = userRepo.Create(context.Background(), user)
 
 	sessionStore := testutil.RealSessionRepo(t)
-	refreshStore := newHandlerRefreshStore()
+	refreshStore := newTestRefreshStore()
 	svc, err := NewService(clock.Real(), NewServiceParams{
 		UserRepo:     userRepo,
 		SessionStore: sessionStore,

--- a/cells/accesscore/slices/sessionlogin/service.go
+++ b/cells/accesscore/slices/sessionlogin/service.go
@@ -158,16 +158,23 @@ func WithAccountLockout(svc *accountlockout.Service) Option {
 	}
 }
 
+// NewServiceParams holds the required dependencies for NewService. Keeping the
+// required-dependency set in a struct reduces the positional-parameter count
+// and makes call sites self-documenting (S107).
+type NewServiceParams struct {
+	UserRepo     ports.UserRepository
+	SessionStore session.Store
+	RoleRepo     ports.RoleRepository
+	RefreshStore refresh.Store
+	Issuer       *auth.JWTIssuer
+}
+
 // NewService creates a session-login Service. refreshStore issues the opaque
 // refresh token returned to the client; the access JWT is minted by
 // sessionmint.MintAccess.
 func NewService(
 	clk clock.Clock,
-	userRepo ports.UserRepository,
-	sessionStore session.Store,
-	roleRepo ports.RoleRepository,
-	refreshStore refresh.Store,
-	issuer *auth.JWTIssuer,
+	params NewServiceParams,
 	logger *slog.Logger,
 	opts ...Option,
 ) (*Service, error) {
@@ -176,13 +183,13 @@ func NewService(
 		logger = slog.Default()
 	}
 	s := &Service{
-		userRepo:        userRepo,
-		sessionStore:    sessionStore,
-		roleRepo:        roleRepo,
-		refreshStore:    refreshStore,
+		userRepo:        params.UserRepo,
+		sessionStore:    params.SessionStore,
+		roleRepo:        params.RoleRepo,
+		refreshStore:    params.RefreshStore,
 		clock:           clk,
 		emitter:         outbox.DemoCellEmitter(),
-		issuer:          issuer,
+		issuer:          params.Issuer,
 		logger:          logger,
 		comparePassword: bcrypt.CompareHashAndPassword,
 	}

--- a/cells/accesscore/slices/sessionlogin/service_test.go
+++ b/cells/accesscore/slices/sessionlogin/service_test.go
@@ -132,10 +132,14 @@ func mustNewService(
 	opts ...Option,
 ) *Service {
 	lockoutSvc := newTestLockout(userRepo, sessionStore, refreshStore)
-	// clk is the first required positional param; pass clockmock.New() (tests)
-	// or clock.Real() (production).
-	s, err := NewService(clock.Real(), userRepo, sessionStore, roleRepo, refreshStore, issuer, logger,
-		append([]Option{WithAccountLockout(lockoutSvc)}, opts...)...)
+	// clk is the first required positional param; pass clock.Real() (tests).
+	s, err := NewService(clock.Real(), NewServiceParams{
+		UserRepo:     userRepo,
+		SessionStore: sessionStore,
+		RoleRepo:     roleRepo,
+		RefreshStore: refreshStore,
+		Issuer:       issuer,
+	}, logger, append([]Option{WithAccountLockout(lockoutSvc)}, opts...)...)
 	if err != nil {
 		panic("mustNewService: " + err.Error())
 	}
@@ -180,8 +184,13 @@ func TestNewService_TxRunnerRequired(t *testing.T) {
 	sessionStore := testutil.RealSessionRepo(t)
 	roleRepo := mem.NewStore(clock.Real()).RoleRepository()
 	refreshStore := newTestRefreshStore()
-	_, err := NewService(clock.Real(), userRepo, sessionStore, roleRepo, refreshStore, testIssuer,
-		slog.Default() /* no WithTxManager */)
+	_, err := NewService(clock.Real(), NewServiceParams{
+		UserRepo:     userRepo,
+		SessionStore: sessionStore,
+		RoleRepo:     roleRepo,
+		RefreshStore: refreshStore,
+		Issuer:       testIssuer,
+	}, slog.Default() /* no WithTxManager */)
 	require.Error(t, err)
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
@@ -203,28 +212,52 @@ func TestNewService_RejectsTypedNilDependencies(t *testing.T) {
 			name: "typed nil userRepo",
 			run: func() (*Service, error) {
 				var typedNil *mem.UserRepository
-				return NewService(clock.Real(), typedNil, sessionStore, roleRepo, refreshStore, testIssuer, slog.Default())
+				return NewService(clock.Real(), NewServiceParams{
+					UserRepo:     typedNil,
+					SessionStore: sessionStore,
+					RoleRepo:     roleRepo,
+					RefreshStore: refreshStore,
+					Issuer:       testIssuer,
+				}, slog.Default())
 			},
 		},
 		{
 			name: "typed nil sessionStore",
 			run: func() (*Service, error) {
 				var typedNil *session.MemStore
-				return NewService(clock.Real(), userRepo, typedNil, roleRepo, refreshStore, testIssuer, slog.Default())
+				return NewService(clock.Real(), NewServiceParams{
+					UserRepo:     userRepo,
+					SessionStore: typedNil,
+					RoleRepo:     roleRepo,
+					RefreshStore: refreshStore,
+					Issuer:       testIssuer,
+				}, slog.Default())
 			},
 		},
 		{
 			name: "typed nil roleRepo",
 			run: func() (*Service, error) {
 				var typedNil *mem.RoleRepository
-				return NewService(clock.Real(), userRepo, sessionStore, typedNil, refreshStore, testIssuer, slog.Default())
+				return NewService(clock.Real(), NewServiceParams{
+					UserRepo:     userRepo,
+					SessionStore: sessionStore,
+					RoleRepo:     typedNil,
+					RefreshStore: refreshStore,
+					Issuer:       testIssuer,
+				}, slog.Default())
 			},
 		},
 		{
 			name: "typed nil refreshStore",
 			run: func() (*Service, error) {
 				var typedNil *typedNilRefreshStore
-				return NewService(clock.Real(), userRepo, sessionStore, roleRepo, typedNil, testIssuer, slog.Default())
+				return NewService(clock.Real(), NewServiceParams{
+					UserRepo:     userRepo,
+					SessionStore: sessionStore,
+					RoleRepo:     roleRepo,
+					RefreshStore: typedNil,
+					Issuer:       testIssuer,
+				}, slog.Default())
 			},
 		},
 	}

--- a/cells/accesscore/slices/sessionrefresh/handler_test.go
+++ b/cells/accesscore/slices/sessionrefresh/handler_test.go
@@ -54,11 +54,13 @@ func setup(t testing.TB) (http.Handler, string) {
 
 	svc, err := NewService(
 		clock.Real(),
-		sessionStore,
-		mem.NewStore(clock.Real()).RoleRepository(),
-		userRepo,
-		refreshStore,
-		testIssuer,
+		NewServiceParams{
+			SessionStore: sessionStore,
+			RoleRepo:     mem.NewStore(clock.Real()).RoleRepository(),
+			UserRepo:     userRepo,
+			RefreshStore: refreshStore,
+			Issuer:       testIssuer,
+		},
 		slog.Default(),
 		WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})),
 		withTestInvalidator(userRepo, sessionStore, refreshStore),

--- a/cells/accesscore/slices/sessionrefresh/service.go
+++ b/cells/accesscore/slices/sessionrefresh/service.go
@@ -89,6 +89,17 @@ type Service struct {
 	clock       clock.Clock
 }
 
+// NewServiceParams holds the required dependencies for NewService. Keeping the
+// required-dependency set in a struct reduces the positional-parameter count
+// and makes call sites self-documenting (S107).
+type NewServiceParams struct {
+	SessionStore session.Store
+	RoleRepo     ports.RoleRepository
+	UserRepo     ports.UserRepository
+	RefreshStore refresh.Store
+	Issuer       *auth.JWTIssuer
+}
+
 // NewService creates a session-refresh Service.
 //
 // userRepo is required (P1-3 fix): fetchPasswordResetRequired silently
@@ -101,11 +112,7 @@ type Service struct {
 // opts allows future functional extensions without breaking callers (F8).
 func NewService(
 	clk clock.Clock,
-	sessionStore session.Store,
-	roleRepo ports.RoleRepository,
-	userRepo ports.UserRepository,
-	refreshStore refresh.Store,
-	issuer *auth.JWTIssuer,
+	params NewServiceParams,
 	logger *slog.Logger,
 	opts ...Option,
 ) (*Service, error) {
@@ -114,12 +121,12 @@ func NewService(
 		logger = slog.Default()
 	}
 	s := &Service{
-		sessionStore: sessionStore,
-		roleRepo:     roleRepo,
-		userRepo:     userRepo,
-		refreshStore: refreshStore,
+		sessionStore: params.SessionStore,
+		roleRepo:     params.RoleRepo,
+		userRepo:     params.UserRepo,
+		refreshStore: params.RefreshStore,
 		clock:        clk,
-		issuer:       issuer,
+		issuer:       params.Issuer,
 		logger:       logger,
 	}
 	for _, o := range opts {

--- a/cells/accesscore/slices/sessionrefresh/service_test.go
+++ b/cells/accesscore/slices/sessionrefresh/service_test.go
@@ -142,7 +142,13 @@ func mustNewService(
 	logger *slog.Logger,
 	opts ...Option,
 ) *Service {
-	s, err := NewService(clock.Real(), sessionStore, roleRepo, userRepo, refreshStore, issuer, logger, opts...)
+	s, err := NewService(clock.Real(), NewServiceParams{
+		SessionStore: sessionStore,
+		RoleRepo:     roleRepo,
+		UserRepo:     userRepo,
+		RefreshStore: refreshStore,
+		Issuer:       issuer,
+	}, logger, opts...)
 	if err != nil {
 		panic("mustNewService: " + err.Error())
 	}
@@ -183,11 +189,13 @@ func mustNewServiceWithInvalidator(
 	allOpts := append([]Option{WithInvalidator(realInv)}, opts...)
 	svc, err := NewService(
 		clock.Real(),
-		deps.sessionStore,
-		deps.roleRepo,
-		deps.userRepo,
-		deps.refreshStore,
-		deps.issuer,
+		NewServiceParams{
+			SessionStore: deps.sessionStore,
+			RoleRepo:     deps.roleRepo,
+			UserRepo:     deps.userRepo,
+			RefreshStore: deps.refreshStore,
+			Issuer:       deps.issuer,
+		},
 		deps.logger,
 		allOpts...,
 	)
@@ -296,32 +304,52 @@ func TestNewService_RejectsTypedNilDependencies(t *testing.T) {
 			name: "typed nil sessionStore",
 			run: func() (*Service, error) {
 				var typedNil *session.MemStore
-				return NewService(clock.Real(), typedNil, roleRepo, userRepo, refreshStore, testIssuer, slog.Default(),
-					WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
+				return NewService(clock.Real(), NewServiceParams{
+					SessionStore: typedNil,
+					RoleRepo:     roleRepo,
+					UserRepo:     userRepo,
+					RefreshStore: refreshStore,
+					Issuer:       testIssuer,
+				}, slog.Default(), WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
 			},
 		},
 		{
 			name: "typed nil roleRepo",
 			run: func() (*Service, error) {
 				var typedNil *mem.RoleRepository
-				return NewService(clock.Real(), sessionStore, typedNil, userRepo, refreshStore, testIssuer, slog.Default(),
-					WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
+				return NewService(clock.Real(), NewServiceParams{
+					SessionStore: sessionStore,
+					RoleRepo:     typedNil,
+					UserRepo:     userRepo,
+					RefreshStore: refreshStore,
+					Issuer:       testIssuer,
+				}, slog.Default(), WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
 			},
 		},
 		{
 			name: "typed nil userRepo",
 			run: func() (*Service, error) {
 				var typedNil *mem.UserRepository
-				return NewService(clock.Real(), sessionStore, roleRepo, typedNil, refreshStore, testIssuer, slog.Default(),
-					WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
+				return NewService(clock.Real(), NewServiceParams{
+					SessionStore: sessionStore,
+					RoleRepo:     roleRepo,
+					UserRepo:     typedNil,
+					RefreshStore: refreshStore,
+					Issuer:       testIssuer,
+				}, slog.Default(), WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
 			},
 		},
 		{
 			name: "typed nil refreshStore",
 			run: func() (*Service, error) {
 				var typedNil *typedNilRefreshStore
-				return NewService(clock.Real(), sessionStore, roleRepo, userRepo, typedNil, testIssuer, slog.Default(),
-					WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
+				return NewService(clock.Real(), NewServiceParams{
+					SessionStore: sessionStore,
+					RoleRepo:     roleRepo,
+					UserRepo:     userRepo,
+					RefreshStore: typedNil,
+					Issuer:       testIssuer,
+				}, slog.Default(), WithTxManager(persistence.WrapForCell(outbox.DemoTxRunner{})))
 			},
 		},
 	}
@@ -349,7 +377,13 @@ func TestNewService_RequiresTxRunner(t *testing.T) {
 	refreshStore := newTestRefreshStore()
 
 	t.Run("missing WithTxManager option", func(t *testing.T) {
-		_, err := NewService(clock.Real(), sessionStore, roleRepo, userRepo, refreshStore, testIssuer, slog.Default())
+		_, err := NewService(clock.Real(), NewServiceParams{
+			SessionStore: sessionStore,
+			RoleRepo:     roleRepo,
+			UserRepo:     userRepo,
+			RefreshStore: refreshStore,
+			Issuer:       testIssuer,
+		}, slog.Default())
 		require.Error(t, err)
 		var ec *errcode.Error
 		require.ErrorAs(t, err, &ec)
@@ -360,8 +394,13 @@ func TestNewService_RequiresTxRunner(t *testing.T) {
 		// WithTxManager silently ignores nil to keep the option idempotent —
 		// but NewService's final check still rejects the resulting unconfigured
 		// state.
-		_, err := NewService(clock.Real(), sessionStore, roleRepo, userRepo, refreshStore, testIssuer, slog.Default(),
-			WithTxManager(persistence.WrapForCell(nil)))
+		_, err := NewService(clock.Real(), NewServiceParams{
+			SessionStore: sessionStore,
+			RoleRepo:     roleRepo,
+			UserRepo:     userRepo,
+			RefreshStore: refreshStore,
+			Issuer:       testIssuer,
+		}, slog.Default(), WithTxManager(persistence.WrapForCell(nil)))
 		require.Error(t, err)
 		var ec *errcode.Error
 		require.ErrorAs(t, err, &ec)

--- a/cells/auditcore/slices/auditquery/handler_test.go
+++ b/cells/auditcore/slices/auditquery/handler_test.go
@@ -407,16 +407,7 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 		Payload:   []byte(`{"reason":"wrong_credentials"}`),
 	}))
 
-	tests := []struct {
-		name            string
-		query           string
-		subject         string
-		roles           []string
-		injectEmptyAuth bool // inject auth.TestContext("", nil) — authenticated but empty Subject
-		wantStatus      int
-		wantCount       int // -1 = don't check
-		wantActorIDs    []string
-	}{
+	tests := []actorBindingCase{
 		{
 			name:       "self actorId matches subject",
 			query:      "?actorId=usr-1",
@@ -482,31 +473,49 @@ func TestHandleQuery_ActorBinding(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
-			switch {
-			case tc.injectEmptyAuth:
-				req = req.WithContext(auth.TestContext("", tc.roles))
-			case tc.subject != "":
-				req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
-			}
-			securedMux.ServeHTTP(w, req)
-
-			assert.Equal(t, tc.wantStatus, w.Code)
-			if tc.wantCount >= 0 {
-				var resp map[string]any
-				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-				data := resp["data"].([]any)
-				assert.Len(t, data, tc.wantCount)
-				if tc.wantActorIDs != nil {
-					gotActorIDs := make([]string, 0, len(data))
-					for _, raw := range data {
-						item := raw.(map[string]any)
-						gotActorIDs = append(gotActorIDs, item["actorId"].(string))
-					}
-					assert.Equal(t, tc.wantActorIDs, gotActorIDs)
-				}
-			}
+			assertActorBindingCase(t, securedMux, tc)
 		})
 	}
+}
+
+type actorBindingCase struct {
+	name            string
+	query           string
+	subject         string
+	roles           []string
+	injectEmptyAuth bool
+	wantStatus      int
+	wantCount       int
+	wantActorIDs    []string
+}
+
+func assertActorBindingCase(t *testing.T, mux *http.ServeMux, tc actorBindingCase) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries"+tc.query, nil)
+	switch {
+	case tc.injectEmptyAuth:
+		req = req.WithContext(auth.TestContext("", tc.roles))
+	case tc.subject != "":
+		req = req.WithContext(auth.TestContext(tc.subject, tc.roles))
+	}
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, tc.wantStatus, w.Code)
+	if tc.wantCount < 0 {
+		return
+	}
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]any)
+	assert.Len(t, data, tc.wantCount)
+	if tc.wantActorIDs == nil {
+		return
+	}
+	gotActorIDs := make([]string, 0, len(data))
+	for _, raw := range data {
+		item := raw.(map[string]any)
+		gotActorIDs = append(gotActorIDs, item["actorId"].(string))
+	}
+	assert.Equal(t, tc.wantActorIDs, gotActorIDs)
 }

--- a/cmd/gocell/app/helpers_test.go
+++ b/cmd/gocell/app/helpers_test.go
@@ -65,24 +65,31 @@ func TestBuildLocatorOptions(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			opts, err := buildLocatorOptions(tc.layout, tc.manifest)
-			if tc.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if len(opts) != tc.wantOptCount {
-				t.Errorf("option count = %d, want %d", len(opts), tc.wantOptCount)
-			}
+			runBuildLocatorOptionsCase(t, tc.layout, tc.manifest, tc.wantErr, tc.wantOptCount)
 		})
+	}
+}
+
+// runBuildLocatorOptionsCase is a helper for TestBuildLocatorOptions.
+func runBuildLocatorOptionsCase(t *testing.T, layout, manifest, wantErr string, wantOptCount int) {
+	t.Helper()
+	opts, err := buildLocatorOptions(layout, manifest)
+	if wantErr != "" {
+		if err == nil {
+			t.Fatalf("expected error containing %q, got nil", wantErr)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Fatalf("error %q does not contain %q", err.Error(), wantErr)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts) != wantOptCount {
+		t.Errorf("option count = %d, want %d", len(opts), wantOptCount)
 	}
 }
 
@@ -93,73 +100,49 @@ func TestBuildLocatorOptions_ModeApplied(t *testing.T) {
 	manifestContent := []byte("version: v1\nmodules:\n  - path: .\n")
 
 	t.Run("conventional overrides manifest file auto-detect", func(t *testing.T) {
-		opts, err := buildLocatorOptions("conventional", "")
-		if err != nil {
-			t.Fatalf("buildLocatorOptions: %v", err)
-		}
 		// fsys has .gocell/manifest.yaml — auto would pick Manifest;
 		// WithLocatorMode(Conventional) must override that.
 		fsys := fstest.MapFS{
 			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
 		}
-		loc, err := metadata.NewLocatorFS(fsys, opts...)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
-		if loc.Mode() != metadata.LocatorConventional {
-			t.Errorf("mode = %v, want LocatorConventional", loc.Mode())
-		}
+		requireLocatorMode(t, "conventional", "", fsys, metadata.LocatorConventional)
 	})
 
 	t.Run("manifest forces manifest mode", func(t *testing.T) {
-		opts, err := buildLocatorOptions("manifest", "")
-		if err != nil {
-			t.Fatalf("buildLocatorOptions: %v", err)
-		}
 		fsys := fstest.MapFS{
 			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
 		}
-		loc, err := metadata.NewLocatorFS(fsys, opts...)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
-		if loc.Mode() != metadata.LocatorManifest {
-			t.Errorf("mode = %v, want LocatorManifest", loc.Mode())
-		}
+		requireLocatorMode(t, "manifest", "", fsys, metadata.LocatorManifest)
 	})
 
 	t.Run("auto without manifest → conventional", func(t *testing.T) {
-		opts, err := buildLocatorOptions("", "")
-		if err != nil {
-			t.Fatalf("buildLocatorOptions: %v", err)
-		}
 		// No .gocell/manifest.yaml → auto-detect falls back to conventional.
-		fsys := fstest.MapFS{}
-		loc, err := metadata.NewLocatorFS(fsys, opts...)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
-		if loc.Mode() != metadata.LocatorConventional {
-			t.Errorf("mode = %v, want LocatorConventional", loc.Mode())
-		}
+		requireLocatorMode(t, "", "", fstest.MapFS{}, metadata.LocatorConventional)
 	})
 
 	t.Run("auto with manifest → manifest mode", func(t *testing.T) {
-		opts, err := buildLocatorOptions("auto", "")
-		if err != nil {
-			t.Fatalf("buildLocatorOptions: %v", err)
-		}
 		fsys := fstest.MapFS{
 			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
 		}
-		loc, err := metadata.NewLocatorFS(fsys, opts...)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
-		if loc.Mode() != metadata.LocatorManifest {
-			t.Errorf("mode = %v, want LocatorManifest", loc.Mode())
-		}
+		requireLocatorMode(t, "auto", "", fsys, metadata.LocatorManifest)
 	})
+}
+
+// requireLocatorMode builds locator options from layout/manifest, creates a
+// NewLocatorFS with fsys, and asserts the resolved mode equals wantMode.
+func requireLocatorMode(t *testing.T, layout, manifest string, fsys fstest.MapFS, wantMode metadata.LocatorMode) {
+	t.Helper()
+	opts, err := buildLocatorOptions(layout, manifest)
+	if err != nil {
+		t.Fatalf("buildLocatorOptions: %v", err)
+	}
+	loc, err := metadata.NewLocatorFS(fsys, opts...)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	if loc.Mode() != wantMode {
+		t.Errorf("mode = %v, want %v", loc.Mode(), wantMode)
+	}
 }
 
 // TestAddLocatorFlags verifies that addLocatorFlags registers --layout and
@@ -169,25 +152,12 @@ func TestAddLocatorFlags(t *testing.T) {
 	t.Run("defaults are empty strings", func(t *testing.T) {
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		layout, manifestPath := addLocatorFlags(fs)
-
-		if layout == nil {
-			t.Fatal("layout pointer is nil")
-		}
-		if manifestPath == nil {
-			t.Fatal("manifestPath pointer is nil")
-		}
-		if *layout != "" {
-			t.Errorf("default layout = %q, want empty string", *layout)
-		}
-		if *manifestPath != "" {
-			t.Errorf("default manifestPath = %q, want empty string", *manifestPath)
-		}
+		requireFlagsDefaultEmpty(t, layout, manifestPath)
 	})
 
 	t.Run("flags parse correctly", func(t *testing.T) {
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		layout, manifestPath := addLocatorFlags(fs)
-
 		if err := fs.Parse([]string{"--layout=manifest", "--manifest=custom/manifest.yaml"}); err != nil {
 			t.Fatalf("Parse: %v", err)
 		}
@@ -218,21 +188,45 @@ func TestAddLocatorFlags(t *testing.T) {
 	t.Run("invalid layout value: Parse accepts, buildLocatorOptions rejects", func(t *testing.T) {
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		layout, manifestPath := addLocatorFlags(fs)
-
-		// Phase 1: FlagSet accepts any string — no error expected here.
-		if err := fs.Parse([]string{"--layout=bogus"}); err != nil {
-			t.Fatalf("FlagSet.Parse unexpected error for unknown layout string: %v", err)
-		}
-
-		// Phase 2: semantic validation rejects the unknown mode.
-		_, err := buildLocatorOptions(*layout, *manifestPath)
-		if err == nil {
-			t.Fatal("buildLocatorOptions: expected error for layout=bogus, got nil")
-		}
-		if want := "unknown locator mode"; !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q does not contain %q", err.Error(), want)
-		}
+		requireTwoPhaseLayoutRejection(t, fs, layout, manifestPath)
 	})
+}
+
+// requireFlagsDefaultEmpty asserts that both layout and manifestPath pointers
+// are non-nil and point to empty strings.
+func requireFlagsDefaultEmpty(t *testing.T, layout, manifestPath *string) {
+	t.Helper()
+	if layout == nil {
+		t.Fatal("layout pointer is nil")
+	}
+	if manifestPath == nil {
+		t.Fatal("manifestPath pointer is nil")
+	}
+	if *layout != "" {
+		t.Errorf("default layout = %q, want empty string", *layout)
+	}
+	if *manifestPath != "" {
+		t.Errorf("default manifestPath = %q, want empty string", *manifestPath)
+	}
+}
+
+// requireTwoPhaseLayoutRejection exercises the two-phase validation contract:
+// FlagSet.Parse accepts any string value (phase 1), but buildLocatorOptions
+// rejects unknown mode values (phase 2).
+func requireTwoPhaseLayoutRejection(t *testing.T, fs *flag.FlagSet, layout, manifestPath *string) {
+	t.Helper()
+	// Phase 1: FlagSet accepts any string — no error expected here.
+	if err := fs.Parse([]string{"--layout=bogus"}); err != nil {
+		t.Fatalf("FlagSet.Parse unexpected error for unknown layout string: %v", err)
+	}
+	// Phase 2: semantic validation rejects the unknown mode.
+	_, err := buildLocatorOptions(*layout, *manifestPath)
+	if err == nil {
+		t.Fatal("buildLocatorOptions: expected error for layout=bogus, got nil")
+	}
+	if want := "unknown locator mode"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err.Error(), want)
+	}
 }
 
 // TestFindRootFrom verifies that findRootFrom walks up from a starting directory
@@ -240,65 +234,55 @@ func TestAddLocatorFlags(t *testing.T) {
 func TestFindRootFrom(t *testing.T) {
 	cases := []struct {
 		name    string
-		setup   func(base string) string // returns starting dir
-		wantRel string                   // expected root relative to base; "" means base itself
-		wantErr string                   // non-empty → expect error containing this substring
+		setup   func(t *testing.T, base string) string // returns starting dir
+		wantRel string                                  // expected root relative to base; "" means base itself
+		wantErr string                                  // non-empty → expect error containing this substring
 	}{
 		{
 			name: "only go.mod → root found",
-			setup: func(base string) string {
-				if err := os.WriteFile(filepath.Join(base, "go.mod"), []byte("module example.com/m\n"), 0o600); err != nil {
-					t.Fatalf("WriteFile go.mod: %v", err)
-				}
+			setup: func(t *testing.T, base string) string {
+				t.Helper()
+				mustWriteFile(t, filepath.Join(base, "go.mod"), "module example.com/m\n")
 				return base
 			},
 			wantRel: ".",
 		},
 		{
 			name: "only go.work → root found",
-			setup: func(base string) string {
-				if err := os.WriteFile(filepath.Join(base, "go.work"), []byte("go 1.22\n"), 0o600); err != nil {
-					t.Fatalf("WriteFile go.work: %v", err)
-				}
+			setup: func(t *testing.T, base string) string {
+				t.Helper()
+				mustWriteFile(t, filepath.Join(base, "go.work"), "go 1.22\n")
 				return base
 			},
 			wantRel: ".",
 		},
 		{
 			name: "only .gocell/manifest.yaml → root found",
-			setup: func(base string) string {
-				if err := os.MkdirAll(filepath.Join(base, ".gocell"), 0o750); err != nil {
-					t.Fatalf("MkdirAll .gocell: %v", err)
-				}
-				if err := os.WriteFile(filepath.Join(base, ".gocell", "manifest.yaml"), []byte("version: v1\n"), 0o600); err != nil {
-					t.Fatalf("WriteFile manifest.yaml: %v", err)
-				}
+			setup: func(t *testing.T, base string) string {
+				t.Helper()
+				mustMkdirAll(t, filepath.Join(base, ".gocell"))
+				mustWriteFile(t, filepath.Join(base, ".gocell", "manifest.yaml"), "version: v1\n")
 				return base
 			},
 			wantRel: ".",
 		},
 		{
 			name: "nested: lower go.mod found before upper go.work",
-			setup: func(base string) string {
+			setup: func(t *testing.T, base string) string {
+				t.Helper()
 				// base/  has go.work
 				// base/sub/ has go.mod  ← nearest wins
-				if err := os.WriteFile(filepath.Join(base, "go.work"), []byte("go 1.22\n"), 0o600); err != nil {
-					t.Fatalf("WriteFile go.work: %v", err)
-				}
+				mustWriteFile(t, filepath.Join(base, "go.work"), "go 1.22\n")
 				sub := filepath.Join(base, "sub")
-				if err := os.MkdirAll(sub, 0o750); err != nil {
-					t.Fatalf("MkdirAll sub: %v", err)
-				}
-				if err := os.WriteFile(filepath.Join(sub, "go.mod"), []byte("module example.com/sub\n"), 0o600); err != nil {
-					t.Fatalf("WriteFile sub/go.mod: %v", err)
-				}
+				mustMkdirAll(t, sub)
+				mustWriteFile(t, filepath.Join(sub, "go.mod"), "module example.com/sub\n")
 				return sub
 			},
 			wantRel: "sub",
 		},
 		{
 			name: "no marker anywhere → error with new message",
-			setup: func(base string) string {
+			setup: func(_ *testing.T, base string) string {
 				return base
 			},
 			wantErr: "no project root marker",
@@ -306,31 +290,54 @@ func TestFindRootFrom(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			base := t.TempDir()
-			startDir := tc.setup(base)
-
-			got, err := findRootFrom(startDir)
-			if tc.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
-				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			wantAbs := filepath.Join(base, tc.wantRel)
-			if tc.wantRel == "." {
-				wantAbs = base
-			}
-			if got != wantAbs {
-				t.Errorf("findRootFrom(%q) = %q, want %q", startDir, got, wantAbs)
-			}
+			startDir := tc.setup(t, base)
+			runFindRootCase(t, startDir, base, tc.wantRel, tc.wantErr)
 		})
+	}
+}
+
+// runFindRootCase runs findRootFrom(startDir) and asserts the result against
+// wantRel (relative to base) or wantErr.
+func runFindRootCase(t *testing.T, startDir, base, wantRel, wantErr string) {
+	t.Helper()
+	got, err := findRootFrom(startDir)
+	if wantErr != "" {
+		if err == nil {
+			t.Fatalf("expected error containing %q, got nil", wantErr)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("error %q does not contain %q", err.Error(), wantErr)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantAbs := filepath.Join(base, wantRel)
+	if wantRel == "." {
+		wantAbs = base
+	}
+	if got != wantAbs {
+		t.Errorf("findRootFrom(%q) = %q, want %q", startDir, got, wantAbs)
+	}
+}
+
+// mustWriteFile writes content to path, fataling on error.
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+// mustMkdirAll creates dir and any parents, fataling on error.
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("MkdirAll %s: %v", dir, err)
 	}
 }
 

--- a/cmd/gocell/app/helpers_test.go
+++ b/cmd/gocell/app/helpers_test.go
@@ -105,34 +105,34 @@ func TestBuildLocatorOptions_ModeApplied(t *testing.T) {
 		fsys := fstest.MapFS{
 			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
 		}
-		requireLocatorMode(t, "conventional", "", fsys, metadata.LocatorConventional)
+		requireLocatorMode(t, "conventional", fsys, metadata.LocatorConventional)
 	})
 
 	t.Run("manifest forces manifest mode", func(t *testing.T) {
 		fsys := fstest.MapFS{
 			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
 		}
-		requireLocatorMode(t, "manifest", "", fsys, metadata.LocatorManifest)
+		requireLocatorMode(t, "manifest", fsys, metadata.LocatorManifest)
 	})
 
 	t.Run("auto without manifest → conventional", func(t *testing.T) {
 		// No .gocell/manifest.yaml → auto-detect falls back to conventional.
-		requireLocatorMode(t, "", "", fstest.MapFS{}, metadata.LocatorConventional)
+		requireLocatorMode(t, "", fstest.MapFS{}, metadata.LocatorConventional)
 	})
 
 	t.Run("auto with manifest → manifest mode", func(t *testing.T) {
 		fsys := fstest.MapFS{
 			".gocell/manifest.yaml": &fstest.MapFile{Data: manifestContent},
 		}
-		requireLocatorMode(t, "auto", "", fsys, metadata.LocatorManifest)
+		requireLocatorMode(t, "auto", fsys, metadata.LocatorManifest)
 	})
 }
 
-// requireLocatorMode builds locator options from layout/manifest, creates a
+// requireLocatorMode builds locator options from layout, creates a
 // NewLocatorFS with fsys, and asserts the resolved mode equals wantMode.
-func requireLocatorMode(t *testing.T, layout, manifest string, fsys fstest.MapFS, wantMode metadata.LocatorMode) {
+func requireLocatorMode(t *testing.T, layout string, fsys fstest.MapFS, wantMode metadata.LocatorMode) {
 	t.Helper()
-	opts, err := buildLocatorOptions(layout, manifest)
+	opts, err := buildLocatorOptions(layout, "")
 	if err != nil {
 		t.Fatalf("buildLocatorOptions: %v", err)
 	}
@@ -235,8 +235,8 @@ func TestFindRootFrom(t *testing.T) {
 	cases := []struct {
 		name    string
 		setup   func(t *testing.T, base string) string // returns starting dir
-		wantRel string                                  // expected root relative to base; "" means base itself
-		wantErr string                                  // non-empty → expect error containing this substring
+		wantRel string                                 // expected root relative to base; "" means base itself
+		wantErr string                                 // non-empty → expect error containing this substring
 	}{
 		{
 			name: "only go.mod → root found",

--- a/cmd/gocell/app/helpers_test.go
+++ b/cmd/gocell/app/helpers_test.go
@@ -130,6 +130,8 @@ func TestBuildLocatorOptions_ModeApplied(t *testing.T) {
 
 // requireLocatorMode builds locator options from layout, creates a
 // NewLocatorFS with fsys, and asserts the resolved mode equals wantMode.
+// The manifest path is fixed to "" — call buildLocatorOptions + NewLocatorFS
+// directly if a custom manifest path needs exercising.
 func requireLocatorMode(t *testing.T, layout string, fsys fstest.MapFS, wantMode metadata.LocatorMode) {
 	t.Helper()
 	opts, err := buildLocatorOptions(layout, "")

--- a/cmd/gocell/app/signalrun_realsig_test.go
+++ b/cmd/gocell/app/signalrun_realsig_test.go
@@ -66,75 +66,86 @@ func TestSignalRealE2E(t *testing.T) {
 		{"graceful", 1},   // ExitRuntime: ctx-aware command unwound
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.mode, func(t *testing.T) {
-			// os.Args[0] is this test binary (self re-exec, the Go stdlib
-			// os/signal test pattern); not user input.
-			cmd := exec.Command(os.Args[0], //nolint:gosec // self re-exec of the test binary; args are literals
-				"-test.run=^TestSignalRealE2E$", "-test.count=1")
-			cmd.Env = append(os.Environ(), envSignalE2EMode+"="+tc.mode)
-			stdout, err := cmd.StdoutPipe()
-			if err != nil {
-				t.Fatalf("stdout pipe: %v", err)
-			}
-			if err := cmd.Start(); err != nil {
-				t.Fatalf("re-exec child: %v", err)
-			}
-
-			// Drain child stdout; signal `ready` when the handshake marker
-			// is seen. Reading blocks on the pipe (no sleep) and continues
-			// to EOF so cmd.Wait never deadlocks on a full pipe.
-			ready := make(chan struct{})
-			go func() {
-				sc := bufio.NewScanner(stdout)
-				seen := false
-				for sc.Scan() {
-					if !seen && sc.Text() == signalChildReady {
-						seen = true
-						close(ready)
-					}
-				}
-				if !seen {
-					// Child died before printing the marker; unblock the
-					// parent so it fails on the exit-code assertion with
-					// context rather than hanging.
-					close(ready)
-				}
-				_, _ = io.Copy(io.Discard, stdout)
-			}()
-
-			var waitErr error
-			done := make(chan struct{})
-			go func() { waitErr = cmd.Wait(); close(done) }()
-			t.Cleanup(func() {
-				if cmd.Process != nil {
-					_ = cmd.Process.Kill()
-				}
-				<-done
-			})
-
-			select {
-			case <-ready:
-			case <-time.After(testtime.EventuallyExtraLong):
-				t.Fatalf("child never reported %q (mode=%s)", signalChildReady, tc.mode)
-			}
-
-			if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
-				t.Fatalf("send SIGINT to child: %v", err)
-			}
-
-			select {
-			case <-done:
-			case <-time.After(testtime.CtxLong):
-				t.Fatalf("child did not exit within timeout of SIGINT (mode=%s)", tc.mode)
-			}
-
-			code := exitCodeOf(waitErr)
-			if code != tc.wantCode {
-				t.Fatalf("mode=%s: child exit code = %d, want %d",
-					tc.mode, code, tc.wantCode)
-			}
+			runSignalE2ECase(t, tc.mode, tc.wantCode)
 		})
 	}
+}
+
+// runSignalE2ECase forks the test binary in child mode, waits for the
+// handshake marker, sends SIGINT, and asserts the exit code.
+func runSignalE2ECase(t *testing.T, mode string, wantCode int) {
+	t.Helper()
+	// os.Args[0] is this test binary (self re-exec, the Go stdlib
+	// os/signal test pattern); not user input.
+	cmd := exec.Command(os.Args[0], //nolint:gosec // self re-exec of the test binary; args are literals
+		"-test.run=^TestSignalRealE2E$", "-test.count=1")
+	cmd.Env = append(os.Environ(), envSignalE2EMode+"="+mode)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("re-exec child: %v", err)
+	}
+
+	ready := waitForChildReady(t, stdout)
+
+	var waitErr error
+	done := make(chan struct{})
+	go func() { waitErr = cmd.Wait(); close(done) }()
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-done
+	})
+
+	select {
+	case <-ready:
+	case <-time.After(testtime.EventuallyExtraLong):
+		t.Fatalf("child never reported %q (mode=%s)", signalChildReady, mode)
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("send SIGINT to child: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(testtime.CtxLong):
+		t.Fatalf("child did not exit within timeout of SIGINT (mode=%s)", mode)
+	}
+
+	code := exitCodeOf(waitErr)
+	if code != wantCode {
+		t.Fatalf("mode=%s: child exit code = %d, want %d", mode, code, wantCode)
+	}
+}
+
+// waitForChildReady drains stdout in a goroutine, closes the returned channel
+// when the handshake marker is seen (or when the child dies before printing it).
+func waitForChildReady(t *testing.T, stdout io.Reader) <-chan struct{} {
+	t.Helper()
+	ready := make(chan struct{})
+	go func() {
+		sc := bufio.NewScanner(stdout)
+		seen := false
+		for sc.Scan() {
+			if !seen && sc.Text() == signalChildReady {
+				seen = true
+				close(ready)
+			}
+		}
+		if !seen {
+			// Child died before printing the marker; unblock the parent so it
+			// fails on the exit-code assertion with context rather than hanging.
+			close(ready)
+		}
+		_, _ = io.Copy(io.Discard, stdout)
+	}()
+	return ready
 }
 
 // signalE2EChild runs the production signal wiring (real

--- a/kernel/assembly/generator_concurrency_test.go
+++ b/kernel/assembly/generator_concurrency_test.go
@@ -67,47 +67,61 @@ func TestGenerator_PlanAssemblyScaffold_ConcurrentSafe(t *testing.T) {
 
 	// Assert each goroutine got exactly 6 files with its own spec.ID in path.
 	for _, r := range results {
-		if r.err != nil {
-			t.Errorf("goroutine %s: unexpected error: %v", r.id, r.err)
-			continue
-		}
-		if len(r.plan) != 6 {
-			t.Errorf("goroutine %s: expected 6 planned files, got %d", r.id, len(r.plan))
-			continue
-		}
-		for _, f := range r.plan {
-			if !strings.Contains(f.AbsPath, r.id) {
-				t.Errorf("goroutine %s: file path %s does not contain spec ID %q",
-					r.id, f.AbsPath, r.id)
-			}
-		}
-		// Also check the canonical 6 paths are all present.
-		wantPaths := scaffoldSixPaths(r.id)
-		for _, rel := range wantPaths {
-			absWant := filepath.Join(realRoot, rel)
-			found := false
-			for _, f := range r.plan {
-				if f.AbsPath == absWant {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("goroutine %s: expected path %s not found in plan", r.id, absWant)
-			}
-		}
+		assertConcurrentResult(t, r.id, r.plan, r.err, realRoot)
 	}
 
 	// Assert g.project.Assemblies was not polluted by any spec.ID.
+	assertAssembliesNotPolluted(t, pm, specIDs, originalAssemblyIDs)
+}
+
+// assertConcurrentResult validates a single goroutine's PlanAssemblyScaffold result.
+func assertConcurrentResult(t *testing.T, id string, plan []pathsafe.PlannedFile, err error, realRoot string) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("goroutine %s: unexpected error: %v", id, err)
+		return
+	}
+	if len(plan) != 6 {
+		t.Errorf("goroutine %s: expected 6 planned files, got %d", id, len(plan))
+		return
+	}
+	for _, f := range plan {
+		if !strings.Contains(f.AbsPath, id) {
+			t.Errorf("goroutine %s: file path %s does not contain spec ID %q", id, f.AbsPath, id)
+		}
+	}
+	assertAllSixPathsPresent(t, id, plan, realRoot)
+}
+
+// assertAllSixPathsPresent checks that the canonical 6 scaffold paths are all present.
+func assertAllSixPathsPresent(t *testing.T, id string, plan []pathsafe.PlannedFile, realRoot string) {
+	t.Helper()
+	for _, rel := range scaffoldSixPaths(id) {
+		absWant := filepath.Join(realRoot, rel)
+		found := false
+		for _, f := range plan {
+			if f.AbsPath == absWant {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("goroutine %s: expected path %s not found in plan", id, absWant)
+		}
+	}
+}
+
+// assertAssembliesNotPolluted checks that no concurrent call mutated the shared project map.
+func assertAssembliesNotPolluted(t *testing.T, pm *metadata.ProjectMeta, specIDs []string, originalIDs map[string]struct{}) {
+	t.Helper()
 	for _, rawID := range specIDs {
 		if _, ok := pm.Assemblies[rawID]; ok {
 			t.Errorf("g.project.Assemblies[%q] was left behind after concurrent call", rawID)
 		}
 	}
-	// Assert no extra keys were added to (or removed from) the original map.
-	if len(pm.Assemblies) != len(originalAssemblyIDs) {
+	if len(pm.Assemblies) != len(originalIDs) {
 		t.Errorf("g.project.Assemblies size changed: want %d, got %d",
-			len(originalAssemblyIDs), len(pm.Assemblies))
+			len(originalIDs), len(pm.Assemblies))
 	}
 }
 

--- a/kernel/cell/base.go
+++ b/kernel/cell/base.go
@@ -75,6 +75,8 @@ type BaseCell struct {
 	shutdownCancel context.CancelFunc
 }
 
+const errFmtNewBaseCellParse = "cell.NewBaseCell: cell %q: %w"
+
 // NewBaseCell creates a BaseCell from declarative metadata.
 //
 // meta is the canonical source — its Type / ConsistencyLevel string fields
@@ -100,7 +102,7 @@ func NewBaseCell(meta *metadata.CellMeta) (*BaseCell, error) {
 	if meta.Type != "" {
 		ct, err := cellvocab.ParseCellType(meta.Type)
 		if err != nil {
-			return nil, fmt.Errorf("cell.NewBaseCell: cell %q: %w", meta.ID, err)
+			return nil, fmt.Errorf(errFmtNewBaseCellParse, meta.ID, err)
 		}
 		cellType = ct
 	}
@@ -108,7 +110,7 @@ func NewBaseCell(meta *metadata.CellMeta) (*BaseCell, error) {
 	if meta.ConsistencyLevel != "" {
 		lv, err := cellvocab.ParseLevel(meta.ConsistencyLevel)
 		if err != nil {
-			return nil, fmt.Errorf("cell.NewBaseCell: cell %q: %w", meta.ID, err)
+			return nil, fmt.Errorf(errFmtNewBaseCellParse, meta.ID, err)
 		}
 		level = lv
 	}
@@ -119,7 +121,7 @@ func NewBaseCell(meta *metadata.CellMeta) (*BaseCell, error) {
 	if meta.Lifecycle != "" {
 		parsed, err := cellvocab.ParseCellLifecycle(meta.Lifecycle)
 		if err != nil {
-			return nil, fmt.Errorf("cell.NewBaseCell: cell %q: %w", meta.ID, err)
+			return nil, fmt.Errorf(errFmtNewBaseCellParse, meta.ID, err)
 		}
 		lc = parsed
 	}

--- a/kernel/governance/advisory_hints_test.go
+++ b/kernel/governance/advisory_hints_test.go
@@ -157,22 +157,28 @@ func advHintConstNames(t *testing.T) map[string]struct{} {
 
 	names := map[string]struct{}{}
 	for _, decl := range f.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok || gd.Tok != token.CONST {
-			continue
-		}
-		for _, spec := range gd.Specs {
-			vs, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			for _, n := range vs.Names {
-				if strings.HasPrefix(n.Name, "advHint") {
-					names[n.Name] = struct{}{}
-				}
-			}
-		}
+		collectAdvHintNamesFromDecl(decl, names)
 	}
 	require.NotEmpty(t, names, "advisory_hints.go must declare advHint* consts")
 	return names
+}
+
+// collectAdvHintNamesFromDecl adds advHint* const names from a single top-level
+// declaration to the names set.
+func collectAdvHintNamesFromDecl(decl ast.Decl, names map[string]struct{}) {
+	gd, ok := decl.(*ast.GenDecl)
+	if !ok || gd.Tok != token.CONST {
+		return
+	}
+	for _, spec := range gd.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for _, n := range vs.Names {
+			if strings.HasPrefix(n.Name, "advHint") {
+				names[n.Name] = struct{}{}
+			}
+		}
+	}
 }

--- a/kernel/governance/rules_http_test.go
+++ b/kernel/governance/rules_http_test.go
@@ -993,82 +993,112 @@ func handleSomething(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			root := t.TempDir()
-			const contractID = "http.test.uuid.v1"
-			sliceRelDir := "cells/testcell/slices/testslice"
-
-			sliceAbsDir := filepath.Join(root, sliceRelDir)
-			require.NoError(t, os.MkdirAll(sliceAbsDir, 0o755))
-			if !tc.noHandler && tc.handlerSrc != "" {
-				if tc.noAuthMount {
-					// Write handler src without auth.Mount boilerplate to test fail-closed.
-					path := filepath.Join(sliceAbsDir, "handler.go")
-					content := "package x\n\nimport \"net/http\"\nimport \"github.com/ghbvf/gocell/pkg/httputil\"\n\n" + tc.handlerSrc
-					require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
-				} else {
-					writeUUIDHandlerFile(t, sliceAbsDir, contractID, tc.handlerSrc)
-				}
-			}
-
-			project := makeProject(contractID, sliceRelDir)
-			if tc.noHandler {
-				project = &metadata.ProjectMeta{
-					Cells:      map[string]*metadata.CellMeta{},
-					Slices:     map[string]*metadata.SliceMeta{},
-					Contracts:  map[string]*metadata.ContractMeta{},
-					Journeys:   map[string]*metadata.JourneyMeta{},
-					Assemblies: map[string]*metadata.AssemblyMeta{},
-				}
-			}
-
-			// Build a contract with non-uuid params for the "no uuid params" case.
-			var c *metadata.ContractMeta
-			if len(tc.uuidParams) == 0 && !tc.noHandler {
-				c = &metadata.ContractMeta{
-					ID:        contractID,
-					Kind:      "http",
-					OwnerCell: metadatatest.CellIDTestCell,
-					Lifecycle: "active",
-					File:      "contracts/http/test/uuid/v1/contract.yaml",
-					Endpoints: metadata.EndpointsMeta{
-						HTTP: &metadata.HTTPTransportMeta{
-							Method:        "GET",
-							Path:          "/api/v1/config/{key}",
-							SuccessStatus: 200,
-							PathParams: map[string]metadata.ParamSchema{
-								"key": {Type: "string"}, // no format:uuid
-							},
-						},
-					},
-				}
-			} else {
-				c = makeUUIDContract(contractID, "contracts/http/test/uuid/v1/contract.yaml", tc.uuidParams)
-			}
-
-			if c != nil {
-				project.Contracts[contractID] = c
-			}
-			validator := NewValidator(project, root, clock.Real())
-			results := validator.checkCH05()
-
-			var errs []ValidationResult
-			for _, r := range results {
-				if r.Severity == SeverityError {
-					errs = append(errs, r)
-				}
-			}
-
-			require.Len(t, errs, len(tc.wantErrors), "error count mismatch")
-			for i, want := range tc.wantErrors {
-				assert.Contains(t, errs[i].Message, want)
-			}
-
-			if tc.noHandler {
-				assert.Empty(t, results, "expected no findings when no handler exists")
-			}
+			runCheckHTTPPathParamUUIDCase(t, tc.handlerSrc, tc.uuidParams, tc.wantErrors, tc.noHandler, tc.noAuthMount)
 		})
 	}
+}
+
+// runCheckHTTPPathParamUUIDCase sets up a temp dir with handler and contract
+// fixtures for checkCH05 and asserts the expected error messages.
+func runCheckHTTPPathParamUUIDCase(
+	t *testing.T,
+	handlerSrc string,
+	uuidParams []string,
+	wantErrors []string,
+	noHandler bool,
+	noAuthMount bool,
+) {
+	t.Helper()
+	root := t.TempDir()
+	const contractID = "http.test.uuid.v1"
+	sliceRelDir := "cells/testcell/slices/testslice"
+
+	sliceAbsDir := filepath.Join(root, sliceRelDir)
+	require.NoError(t, os.MkdirAll(sliceAbsDir, 0o755))
+	writeUUIDHandlerIfNeeded(t, sliceAbsDir, contractID, handlerSrc, noHandler, noAuthMount)
+
+	project := buildUUIDTestProject(t, contractID, sliceRelDir, uuidParams, noHandler)
+
+	validator := NewValidator(project, root, clock.Real())
+	results := validator.checkCH05()
+
+	var errs []ValidationResult
+	for _, r := range results {
+		if r.Severity == SeverityError {
+			errs = append(errs, r)
+		}
+	}
+
+	require.Len(t, errs, len(wantErrors), "error count mismatch")
+	for i, want := range wantErrors {
+		assert.Contains(t, errs[i].Message, want)
+	}
+
+	if noHandler {
+		assert.Empty(t, results, "expected no findings when no handler exists")
+	}
+}
+
+// writeUUIDHandlerIfNeeded writes the handler Go source file into sliceAbsDir
+// unless noHandler is set.
+func writeUUIDHandlerIfNeeded(t *testing.T, sliceAbsDir, contractID, handlerSrc string, noHandler, noAuthMount bool) {
+	t.Helper()
+	if noHandler || handlerSrc == "" {
+		return
+	}
+	if noAuthMount {
+		// Write handler src without auth.Mount boilerplate to test fail-closed.
+		path := filepath.Join(sliceAbsDir, "handler.go")
+		content := "package x\n\nimport \"net/http\"\nimport \"github.com/ghbvf/gocell/pkg/httputil\"\n\n" + handlerSrc
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	} else {
+		writeUUIDHandlerFile(t, sliceAbsDir, contractID, handlerSrc)
+	}
+}
+
+// buildUUIDTestProject returns the ProjectMeta for a CH-05 test case.
+func buildUUIDTestProject(t *testing.T, contractID, sliceRelDir string, uuidParams []string, noHandler bool) *metadata.ProjectMeta {
+	t.Helper()
+	if noHandler {
+		return &metadata.ProjectMeta{
+			Cells:      map[string]*metadata.CellMeta{},
+			Slices:     map[string]*metadata.SliceMeta{},
+			Contracts:  map[string]*metadata.ContractMeta{},
+			Journeys:   map[string]*metadata.JourneyMeta{},
+			Assemblies: map[string]*metadata.AssemblyMeta{},
+		}
+	}
+
+	project := makeProject(contractID, sliceRelDir)
+	project.Contracts[contractID] = buildUUIDContract(contractID, uuidParams)
+	return project
+}
+
+// buildUUIDContract returns a ContractMeta for the given uuidParams set. When
+// uuidParams is empty, returns a contract with a non-uuid path param instead.
+func buildUUIDContract(contractID string, uuidParams []string) *metadata.ContractMeta {
+	if len(uuidParams) == 0 {
+		return &metadata.ContractMeta{
+			ID:        contractID,
+			Kind:      "http",
+			OwnerCell: metadatatest.CellIDTestCell,
+			Lifecycle: "active",
+			File:      "contracts/http/test/uuid/v1/contract.yaml",
+			Endpoints: metadata.EndpointsMeta{
+				HTTP: &metadata.HTTPTransportMeta{
+					Method:        "GET",
+					Path:          "/api/v1/config/{key}",
+					SuccessStatus: 200,
+					PathParams: map[string]metadata.ParamSchema{
+						"key": {Type: "string"}, // no format:uuid
+					},
+				},
+			},
+		}
+	}
+	return makeUUIDContract(contractID, "contracts/http/test/uuid/v1/contract.yaml", uuidParams)
 }
 
 func TestCheckHTTPPathParamUUID_GeneratedHandlerInternalSegment(t *testing.T) {

--- a/kernel/governance/rules_projection_consistency_test.go
+++ b/kernel/governance/rules_projection_consistency_test.go
@@ -149,30 +149,35 @@ func TestProjectionConsistency01(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			v := NewValidator(tc.project, "", clock.Real())
-			results := v.validateProjectionConsistency()
-
-			// filter to PROJECTION-CONSISTENCY-01 results
-			var got []ValidationResult
-			for _, r := range results {
-				if r.Code == codePROJECTIONCONSISTENCY01 {
-					got = append(got, r)
-				}
-			}
-
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s) with code %s, got %d: %v",
-					tc.wantErrCount, codePROJECTIONCONSISTENCY01, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-			}
+			runProjectionConsistencyCase(t, tc.project, tc.wantErrCount, tc.wantField)
 		})
+	}
+}
+
+// runProjectionConsistencyCase is a helper for TestProjectionConsistency01.
+func runProjectionConsistencyCase(t *testing.T, project *metadata.ProjectMeta, wantErrCount int, wantField string) {
+	t.Helper()
+	v := NewValidator(project, "", clock.Real())
+	results := v.validateProjectionConsistency()
+
+	var got []ValidationResult
+	for _, r := range results {
+		if r.Code == codePROJECTIONCONSISTENCY01 {
+			got = append(got, r)
+		}
+	}
+
+	if len(got) != wantErrCount {
+		t.Fatalf("expected %d result(s) with code %s, got %d: %v",
+			wantErrCount, codePROJECTIONCONSISTENCY01, len(got), got)
+	}
+	if wantErrCount > 0 {
+		r := got[0]
+		if r.Severity != SeverityError {
+			t.Errorf("expected SeverityError, got %s", r.Severity)
+		}
+		if r.Field != wantField {
+			t.Errorf("expected field %q, got %q", wantField, r.Field)
+		}
 	}
 }

--- a/kernel/metadata/locator_manifest_e2e_test.go
+++ b/kernel/metadata/locator_manifest_e2e_test.go
@@ -181,23 +181,14 @@ func TestLocatorManifest_E2E_CellIDDerivation(t *testing.T) {
 		writeFile(t, filepath.Join(root, "cells", "wallet", "cell.yaml"),
 			cellYAML("wallet", "fin", "wallets"))
 
-		loc, err := NewLocator(root, WithLocatorMode(LocatorManifest))
-		if err != nil {
-			t.Fatalf("NewLocator: %v", err)
+		sources := requireE2EDiscover(t, root)
+		s := findSourceByKindPath(sources, SourceCell, "cells/wallet/cell.yaml")
+		if s == nil {
+			t.Fatal("SourceCell for wallet not found")
 		}
-		sources, err := loc.Discover()
-		if err != nil {
-			t.Fatalf("Discover: %v", err)
+		if s.CellID != "wallet" {
+			t.Errorf("CellID = %q, want %q", s.CellID, "wallet")
 		}
-		for _, s := range sources {
-			if s.Kind == SourceCell && s.Path == "cells/wallet/cell.yaml" {
-				if s.CellID != "wallet" {
-					t.Errorf("CellID = %q, want %q", s.CellID, "wallet")
-				}
-				return
-			}
-		}
-		t.Fatal("SourceCell for wallet not found")
 	})
 
 	t.Run("non-conventional layout SourceCell is discoverable", func(t *testing.T) {
@@ -212,30 +203,57 @@ func TestLocatorManifest_E2E_CellIDDerivation(t *testing.T) {
 			filepath.Join(root, "services", "payments", "cells", "charge", "cell.yaml"),
 			cellYAML("charge", "pay", "charges"))
 
-		loc, err := NewLocator(root, WithLocatorMode(LocatorManifest))
-		if err != nil {
-			t.Fatalf("NewLocator: %v", err)
+		sources := requireE2EDiscover(t, root)
+		s := findSourceByKind(sources, SourceCell)
+		if s == nil {
+			t.Fatal("SourceCell not found for non-conventional layout fixture")
 		}
-		sources, err := loc.Discover()
-		if err != nil {
-			t.Fatalf("Discover: %v", err)
+		// Non-conventional layout: the Locator cannot derive CellID
+		// from a path that does not match cells/<id>/cell.yaml.
+		// MetadataSource.CellID must be empty; callers must read
+		// the cell.yaml `id` field or require slice.yaml to declare
+		// belongsToCell explicitly (per MetadataSource.CellID godoc).
+		if s.CellID != "" {
+			t.Errorf("non-conventional layout source CellID = %q, want empty"+
+				" (only conventional walk can derive it)", s.CellID)
 		}
-		for _, s := range sources {
-			if s.Kind == SourceCell {
-				// Non-conventional layout: the Locator cannot derive CellID
-				// from a path that does not match cells/<id>/cell.yaml.
-				// MetadataSource.CellID must be empty; callers must read
-				// the cell.yaml `id` field or require slice.yaml to declare
-				// belongsToCell explicitly (per MetadataSource.CellID godoc).
-				if s.CellID != "" {
-					t.Errorf("non-conventional layout source CellID = %q, want empty"+
-						" (only conventional walk can derive it)", s.CellID)
-				}
-				return
-			}
-		}
-		t.Fatal("SourceCell not found for non-conventional layout fixture")
 	})
+}
+
+// requireE2EDiscover creates a manifest-mode Locator rooted at root, calls
+// Discover, and fatals on any error.
+func requireE2EDiscover(t *testing.T, root string) []MetadataSource {
+	t.Helper()
+	loc, err := NewLocator(root, WithLocatorMode(LocatorManifest))
+	if err != nil {
+		t.Fatalf("NewLocator: %v", err)
+	}
+	sources, err := loc.Discover()
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	return sources
+}
+
+// findSourceByKindPath returns the first MetadataSource with the given kind and
+// path, or nil if not found.
+func findSourceByKindPath(sources []MetadataSource, kind SourceKind, path string) *MetadataSource {
+	for i := range sources {
+		if sources[i].Kind == kind && sources[i].Path == path {
+			return &sources[i]
+		}
+	}
+	return nil
+}
+
+// findSourceByKind returns the first MetadataSource with the given kind, or nil.
+func findSourceByKind(sources []MetadataSource, kind SourceKind) *MetadataSource {
+	for i := range sources {
+		if sources[i].Kind == kind {
+			return &sources[i]
+		}
+	}
+	return nil
 }
 
 // cellKeys returns sorted cell IDs from a ProjectMeta, used in error messages.

--- a/kernel/metadata/locator_test.go
+++ b/kernel/metadata/locator_test.go
@@ -615,10 +615,7 @@ modules:
 			// alt/ does not exist — second pattern matches zero files, but
 			// the emission (cells kind) as a whole matched at least one file.
 		}
-		l, err := NewLocatorFS(fsys)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
+		l := requireLocatorFS(t, fsys)
 		sources, err := l.Discover()
 		if err != nil {
 			t.Fatalf("Discover unexpected error (multi-pattern fallback must succeed): %v", err)
@@ -643,11 +640,8 @@ modules:
 			".gocell/manifest.yaml": &fstest.MapFile{Data: []byte(manifest)},
 			"cells/foo/cell.yaml":   &fstest.MapFile{Data: []byte("id: foo\n")},
 		}
-		l, err := NewLocatorFS(fsys)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
-		_, err = l.Discover()
+		l := requireLocatorFS(t, fsys)
+		_, err := l.Discover()
 		if err == nil {
 			t.Fatal("expected fail-closed error when all patterns for an emission match zero files")
 		}
@@ -669,15 +663,22 @@ modules:
 			"cells/foo/cell.yaml":   &fstest.MapFile{Data: []byte("id: foo\n")},
 			// no journeys, no assemblies, no contracts, no slices
 		}
-		l, err := NewLocatorFS(fsys)
-		if err != nil {
-			t.Fatalf("NewLocatorFS: %v", err)
-		}
-		_, err = l.Discover()
+		l := requireLocatorFS(t, fsys)
+		_, err := l.Discover()
 		if err != nil {
 			t.Errorf("expected no error for default-pattern zero-match, got: %v", err)
 		}
 	})
+}
+
+// requireLocatorFS creates a Locator from fsys and fails the test on error.
+func requireLocatorFS(t *testing.T, fsys fstest.MapFS) *Locator {
+	t.Helper()
+	l, err := NewLocatorFS(fsys)
+	if err != nil {
+		t.Fatalf("NewLocatorFS: %v", err)
+	}
+	return l
 }
 
 // TestManifestGlobFixedPrefix exercises manifestGlobFixedPrefix with the

--- a/kernel/metadata/metadatatest/cellid_test.go
+++ b/kernel/metadata/metadatatest/cellid_test.go
@@ -42,26 +42,34 @@ func TestNewCellID_PanicsOnInvalid(t *testing.T) {
 		{"space", "foo bar"},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil {
-					t.Fatalf("NewCellID(%q) did not panic", tc.in)
-				}
-				err, ok := r.(*errcode.Error)
-				if !ok {
-					t.Fatalf("NewCellID(%q) panic value type = %T, want *errcode.Error", tc.in, r)
-				}
-				if err.Code != errcode.ErrInternal {
-					t.Fatalf("NewCellID(%q) panic err.Code = %s, want %s", tc.in, err.Code, errcode.ErrInternal)
-				}
-				if !strings.HasPrefix(err.Message, "metadatatest: invalid cell id ") {
-					t.Fatalf("NewCellID(%q) panic message = %q, want prefix %q", tc.in, err.Message, "metadatatest: invalid cell id ")
-				}
-			}()
-			_ = metadatatest.NewCellID(tc.in)
+			assertCellIDPanic(t, tc.in)
 		})
 	}
+}
+
+// assertCellIDPanic calls metadatatest.NewCellID(in) and asserts that it panics
+// with an *errcode.Error carrying ErrInternal and the expected message prefix.
+func assertCellIDPanic(t *testing.T, in string) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("NewCellID(%q) did not panic", in)
+		}
+		err, ok := r.(*errcode.Error)
+		if !ok {
+			t.Fatalf("NewCellID(%q) panic value type = %T, want *errcode.Error", in, r)
+		}
+		if err.Code != errcode.ErrInternal {
+			t.Fatalf("NewCellID(%q) panic err.Code = %s, want %s", in, err.Code, errcode.ErrInternal)
+		}
+		if !strings.HasPrefix(err.Message, "metadatatest: invalid cell id ") {
+			t.Fatalf("NewCellID(%q) panic message = %q, want prefix %q", in, err.Message, "metadatatest: invalid cell id ")
+		}
+	}()
+	_ = metadatatest.NewCellID(in)
 }
 
 func TestPredefinedConstants(t *testing.T) {

--- a/kernel/outbox/mode_resolver_test.go
+++ b/kernel/outbox/mode_resolver_test.go
@@ -280,162 +280,188 @@ func (durableEmitter) Durable() bool                                { return tru
 // non-durable Warn log.
 func TestResolveCellEmitter(t *testing.T) {
 	t.Parallel()
-
-	realPub := mrFakePublisher{}
-
-	captureLogger := func() (*slog.Logger, *bytes.Buffer) {
-		var buf bytes.Buffer
-		h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-		return slog.New(h), &buf
-	}
-
 	t.Run("mutual_exclusion", func(t *testing.T) {
 		t.Parallel()
-		_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID:    "testcell",
-				Mode:      outbox.DurabilityDemo,
-				Publisher: realPub,
-			},
-			PreResolved: outbox.WrapEmitterForCell(nonDurableEmitter{}),
-		})
-		if err == nil {
-			t.Fatal("expected mutual-exclusion error, got nil")
-		}
-		var ceMutex *errcode.Error
-		if !errors.As(err, &ceMutex) {
-			t.Fatalf("expected errcode.Error, got %T: %v", err, err)
-		}
-		if !strings.Contains(ceMutex.Message+" "+ceMutex.Error(), "mutually exclusive") {
-			t.Fatalf("error message missing 'mutually exclusive': %v", err)
-		}
+		testResolveCellEmitter_MutualExclusion(t)
 	})
-
 	t.Run("preresolved_durable_mode_requires_durable", func(t *testing.T) {
 		t.Parallel()
-		_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID: "testcell",
-				Mode:   outbox.DurabilityDurable,
-			},
-			PreResolved: outbox.WrapEmitterForCell(nonDurableEmitter{}),
-		})
-		if err == nil {
-			t.Fatal("expected durable-mode guard error, got nil")
-		}
-		var ceDurable *errcode.Error
-		if !errors.As(err, &ceDurable) {
-			t.Fatalf("expected errcode.Error, got %T: %v", err, err)
-		}
-		if !strings.Contains(ceDurable.Message+" "+ceDurable.Error(), "durable") {
-			t.Fatalf("error message missing 'durable': %v", err)
-		}
+		testResolveCellEmitter_DurableModeRequiresDurable(t)
 	})
-
 	t.Run("preresolved_durable_ok", func(t *testing.T) {
 		t.Parallel()
-		outcome, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID: "testcell",
-				Mode:   outbox.DurabilityDurable,
-			},
-			PreResolved: outbox.WrapEmitterForCell(durableEmitter{}),
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !outcome.Durable() {
-			t.Fatal("expected outcome.Durable()=true for durableEmitter")
-		}
+		testResolveCellEmitter_DurableOK(t)
 	})
-
 	t.Run("preresolved_demo_non_durable_warn_at_L2", func(t *testing.T) {
 		t.Parallel()
-		logger, buf := captureLogger()
-		outcome, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID: "testcell",
-				Mode:   outbox.DurabilityDemo,
-				Logger: logger,
-			},
-			PreResolved:      outbox.WrapEmitterForCell(nonDurableEmitter{}),
-			ConsistencyLevel: cellvocab.L2,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if outcome.Durable() {
-			t.Fatal("expected non-durable outcome")
-		}
-		if !strings.Contains(buf.String(), "transactional atomicity not guaranteed") {
-			t.Fatalf("expected non-durable warn log, got: %q", buf.String())
-		}
-		if !strings.Contains(buf.String(), "durability_mode=demo") {
-			t.Fatalf("expected durability_mode=demo in log, got: %q", buf.String())
-		}
+		testResolveCellEmitter_NonDurableWarnAtL2(t)
 	})
-
 	t.Run("preresolved_demo_no_warn_below_L2", func(t *testing.T) {
 		t.Parallel()
-		logger, buf := captureLogger()
-		_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID: "testcell",
-				Mode:   outbox.DurabilityDemo,
-				Logger: logger,
-			},
-			PreResolved:      outbox.WrapEmitterForCell(nonDurableEmitter{}),
-			ConsistencyLevel: cellvocab.L1,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if strings.Contains(buf.String(), "transactional atomicity not guaranteed") {
-			t.Fatalf("expected no non-durable warn at cellvocab.L1, got: %q", buf.String())
-		}
+		testResolveCellEmitter_NoWarnBelowL2(t)
 	})
-
 	t.Run("delegates_to_resolve_emitter_on_demo", func(t *testing.T) {
 		t.Parallel()
-		logger, buf := captureLogger()
-		outcome, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID:            "testcell",
-				Mode:              outbox.DurabilityDemo,
-				Publisher:         realPub,
-				DirectPublishMode: outbox.DirectPublishFailClosed,
-				Logger:            logger,
-				MetricsProvider:   metrics.NopProvider{},
-			},
-			ConsistencyLevel: cellvocab.L2,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if outcome == nil {
-			t.Fatal("expected non-nil Emitter")
-		}
-		if outcome.Durable() {
-			t.Fatal("expected non-durable DirectEmitter")
-		}
-		if !strings.Contains(buf.String(), "transactional atomicity not guaranteed") {
-			t.Fatalf("expected non-durable warn for non-durable demo path, got: %q", buf.String())
-		}
+		testResolveCellEmitter_DelegatesOnDemo(t)
 	})
-
 	t.Run("error_from_resolve_emitter_propagates", func(t *testing.T) {
 		t.Parallel()
-		_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
-			EmitterConfig: outbox.EmitterConfig{
-				CellID: "testcell",
-				Mode:   outbox.DurabilityDemo,
-			},
-			ConsistencyLevel: cellvocab.L2,
-		})
-		if err == nil {
-			t.Fatal("expected no-sink error from ResolveEmitter")
-		}
+		testResolveCellEmitter_ErrorPropagates(t)
 	})
+}
+
+func cellEmitterCaptureLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), &buf
+}
+
+func testResolveCellEmitter_MutualExclusion(t *testing.T) {
+	t.Helper()
+	_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID:    "testcell",
+			Mode:      outbox.DurabilityDemo,
+			Publisher: mrFakePublisher{},
+		},
+		PreResolved: outbox.WrapEmitterForCell(nonDurableEmitter{}),
+	})
+	if err == nil {
+		t.Fatal("expected mutual-exclusion error, got nil")
+	}
+	var ceMutex *errcode.Error
+	if !errors.As(err, &ceMutex) {
+		t.Fatalf("expected errcode.Error, got %T: %v", err, err)
+	}
+	if !strings.Contains(ceMutex.Message+" "+ceMutex.Error(), "mutually exclusive") {
+		t.Fatalf("error message missing 'mutually exclusive': %v", err)
+	}
+}
+
+func testResolveCellEmitter_DurableModeRequiresDurable(t *testing.T) {
+	t.Helper()
+	_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID: "testcell",
+			Mode:   outbox.DurabilityDurable,
+		},
+		PreResolved: outbox.WrapEmitterForCell(nonDurableEmitter{}),
+	})
+	if err == nil {
+		t.Fatal("expected durable-mode guard error, got nil")
+	}
+	var ceDurable *errcode.Error
+	if !errors.As(err, &ceDurable) {
+		t.Fatalf("expected errcode.Error, got %T: %v", err, err)
+	}
+	if !strings.Contains(ceDurable.Message+" "+ceDurable.Error(), "durable") {
+		t.Fatalf("error message missing 'durable': %v", err)
+	}
+}
+
+func testResolveCellEmitter_DurableOK(t *testing.T) {
+	t.Helper()
+	outcome, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID: "testcell",
+			Mode:   outbox.DurabilityDurable,
+		},
+		PreResolved: outbox.WrapEmitterForCell(durableEmitter{}),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !outcome.Durable() {
+		t.Fatal("expected outcome.Durable()=true for durableEmitter")
+	}
+}
+
+func testResolveCellEmitter_NonDurableWarnAtL2(t *testing.T) {
+	t.Helper()
+	logger, buf := cellEmitterCaptureLogger()
+	outcome, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID: "testcell",
+			Mode:   outbox.DurabilityDemo,
+			Logger: logger,
+		},
+		PreResolved:      outbox.WrapEmitterForCell(nonDurableEmitter{}),
+		ConsistencyLevel: cellvocab.L2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Durable() {
+		t.Fatal("expected non-durable outcome")
+	}
+	if !strings.Contains(buf.String(), "transactional atomicity not guaranteed") {
+		t.Fatalf("expected non-durable warn log, got: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "durability_mode=demo") {
+		t.Fatalf("expected durability_mode=demo in log, got: %q", buf.String())
+	}
+}
+
+func testResolveCellEmitter_NoWarnBelowL2(t *testing.T) {
+	t.Helper()
+	logger, buf := cellEmitterCaptureLogger()
+	_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID: "testcell",
+			Mode:   outbox.DurabilityDemo,
+			Logger: logger,
+		},
+		PreResolved:      outbox.WrapEmitterForCell(nonDurableEmitter{}),
+		ConsistencyLevel: cellvocab.L1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(buf.String(), "transactional atomicity not guaranteed") {
+		t.Fatalf("expected no non-durable warn at cellvocab.L1, got: %q", buf.String())
+	}
+}
+
+func testResolveCellEmitter_DelegatesOnDemo(t *testing.T) {
+	t.Helper()
+	logger, buf := cellEmitterCaptureLogger()
+	outcome, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID:            "testcell",
+			Mode:              outbox.DurabilityDemo,
+			Publisher:         mrFakePublisher{},
+			DirectPublishMode: outbox.DirectPublishFailClosed,
+			Logger:            logger,
+			MetricsProvider:   metrics.NopProvider{},
+		},
+		ConsistencyLevel: cellvocab.L2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome == nil {
+		t.Fatal("expected non-nil Emitter")
+	}
+	if outcome.Durable() {
+		t.Fatal("expected non-durable DirectEmitter")
+	}
+	if !strings.Contains(buf.String(), "transactional atomicity not guaranteed") {
+		t.Fatalf("expected non-durable warn for non-durable demo path, got: %q", buf.String())
+	}
+}
+
+func testResolveCellEmitter_ErrorPropagates(t *testing.T) {
+	t.Helper()
+	_, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+		EmitterConfig: outbox.EmitterConfig{
+			CellID: "testcell",
+			Mode:   outbox.DurabilityDemo,
+		},
+		ConsistencyLevel: cellvocab.L2,
+	})
+	if err == nil {
+		t.Fatal("expected no-sink error from ResolveEmitter")
+	}
 }
 
 // TestResolveEmitter_DemoMode_NilMetricsProvider_ReturnsError asserts that

--- a/kernel/projection/coordinator_test.go
+++ b/kernel/projection/coordinator_test.go
@@ -222,19 +222,7 @@ func TestCoordinator_ApplyOne(t *testing.T) {
 	errSave := errors.New("save failed")
 	errCursor := errors.New("cursor error")
 
-	tests := []struct {
-		name           string
-		currentOffset  int64
-		cursorPos      int64
-		cursorErr      error
-		applyErr       error
-		saveFails      bool
-		wantApplyCalls int
-		wantSaved      bool
-		wantLastSaved  int64
-		wantDisp       outbox.Disposition
-		wantLoadErr    bool
-	}{
+	tests := []applyOneCase{
 		{
 			name:           "cold-start: pos=1 applied and saved",
 			currentOffset:  0,
@@ -345,61 +333,7 @@ func TestCoordinator_ApplyOne(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			apply := &recordingApply{err: tc.applyErr}
-			cursor := &fakeCursor{pos: tc.cursorPos, err: tc.cursorErr}
-			txr := &fakeTxRunner{}
-			reg := &fakeRegistrar{}
-
-			var store CheckpointStore
-			if tc.wantLoadErr {
-				store = &seededStore{offsets: make(map[string]int64), loadErr: errors.New("load failed")}
-			} else if tc.saveFails {
-				store = &errSaveStore{currentOffset: tc.currentOffset, saveErr: errSave}
-			} else {
-				store = newSeededStore("testcell", "p1", tc.currentOffset)
-			}
-
-			c, err := NewCoordinator("testcell", reg, txr, store, cursor, wrapper.NoopTracer{})
-			if err != nil {
-				t.Fatalf("NewCoordinator: %v", err)
-			}
-
-			h := c.buildHandler("testcell", "p1", apply.fn)
-			result := h(context.Background(), outbox.Entry{})
-
-			if apply.calls != tc.wantApplyCalls {
-				t.Errorf("apply.calls = %d, want %d", apply.calls, tc.wantApplyCalls)
-			}
-
-			if !tc.saveFails {
-				ss, ok := store.(*seededStore)
-				if ok {
-					if tc.wantSaved && ss.saveCalls == 0 {
-						t.Error("expected SaveOffset to be called, but it was not")
-					}
-					if !tc.wantSaved && ss.saveCalls != 0 {
-						t.Errorf("expected no SaveOffset calls, but got %d", ss.saveCalls)
-					}
-					if tc.wantSaved && ss.lastSaved != tc.wantLastSaved {
-						t.Errorf("lastSaved = %d, want %d", ss.lastSaved, tc.wantLastSaved)
-					}
-				}
-			} else {
-				es := store.(*errSaveStore)
-				if es.saveCalls == 0 {
-					t.Error("expected errSaveStore.SaveOffset to be called")
-				}
-				// After a save error the persisted value must not have changed.
-				got, _ := store.LoadOffset(context.Background(), "testcell", "p1")
-				if got != tc.currentOffset {
-					t.Errorf("after save error LoadOffset = %d, want original %d", got, tc.currentOffset)
-				}
-			}
-
-			if result.Disposition != tc.wantDisp {
-				t.Errorf("Disposition = %v, want %v", result.Disposition, tc.wantDisp)
-			}
+			runApplyOneCase(t, tc, errSave)
 		})
 	}
 
@@ -502,12 +436,7 @@ func TestBuildHandler_SpanStatus(t *testing.T) {
 	errTransient := errors.New("transient")
 	errPermanent := outbox.NewPermanentError(errors.New("permanent"))
 
-	tests := []struct {
-		name     string
-		applyErr error
-		wantCode wrapper.StatusCode
-		wantDesc string
-	}{
+	tests := []spanStatusCase{
 		{
 			name:     "success → StatusOK",
 			applyErr: nil,
@@ -532,32 +461,7 @@ func TestBuildHandler_SpanStatus(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			spy := &spyTracer{}
-			apply := &recordingApply{err: tc.applyErr}
-			store := newSeededStore("testcell", "p1", 0)
-			cursor := &fakeCursor{pos: 1}
-
-			c, err := NewCoordinator("testcell", &fakeRegistrar{}, &fakeTxRunner{}, store, cursor, spy)
-			if err != nil {
-				t.Fatalf("NewCoordinator: %v", err)
-			}
-
-			h := c.buildHandler("testcell", "p1", apply.fn)
-			_ = h(context.Background(), outbox.Entry{})
-
-			if spy.last == nil {
-				t.Fatal("spy tracer: no span was started")
-			}
-			if !spy.last.statusSet {
-				t.Fatal("span.SetStatus was never called")
-			}
-			if spy.last.statusCode != tc.wantCode {
-				t.Errorf("SetStatus code = %v, want %v", spy.last.statusCode, tc.wantCode)
-			}
-			if spy.last.statusDesc != tc.wantDesc {
-				t.Errorf("SetStatus desc = %q, want %q", spy.last.statusDesc, tc.wantDesc)
-			}
+			runSpanStatusCase(t, tc)
 		})
 	}
 }
@@ -694,16 +598,7 @@ func TestNewCoordinator_NilGuards(t *testing.T) {
 	// Typed-nil for store (must be rejected like bare-nil).
 	var typedNilStore *MemCheckpointStore
 
-	tests := []struct {
-		name    string
-		cellID  string
-		reg     cell.Registrar
-		txr     persistence.TxRunner
-		store   CheckpointStore
-		cursor  Cursor
-		tracer  wrapper.Tracer
-		wantErr bool
-	}{
+	tests := []nilGuardCase{
 		{
 			name:    "all valid",
 			cellID:  "testcell",
@@ -790,29 +685,7 @@ func TestNewCoordinator_NilGuards(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			c, err := NewCoordinator(tc.cellID, tc.reg, tc.txr, tc.store, tc.cursor, tc.tracer)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				var e *errcode.Error
-				if !errors.As(err, &e) {
-					t.Fatalf("error is not *errcode.Error: %T %v", err, err)
-				}
-				if e.Kind != errcode.KindInvalid {
-					t.Errorf("Kind = %v, want KindInvalid", e.Kind)
-				}
-				if c != nil {
-					t.Error("expected nil coordinator on error")
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if c == nil {
-					t.Fatal("expected non-nil coordinator")
-				}
-			}
+			runNilGuardCase(t, tc)
 		})
 	}
 }
@@ -826,16 +699,7 @@ func TestCoordinator_Subscribe(t *testing.T) {
 
 	errRegister := errors.New("register failed")
 
-	tests := []struct {
-		name         string
-		projectionID string
-		applyFn      Apply
-		regErr       error
-		wantErr      bool
-		wantSubCalls int
-		wantCG       string
-		wantCellID   string
-	}{
+	tests := []subscribeCase{
 		{
 			name:         "happy path",
 			projectionID: "myproj",
@@ -913,33 +777,7 @@ func TestCoordinator_Subscribe(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			reg := &fakeRegistrar{subscribeErr: tc.regErr}
-			c, err := NewCoordinator("testcell", reg, &fakeTxRunner{}, NewMemCheckpointStore(), &fakeCursor{}, wrapper.NoopTracer{})
-			if err != nil {
-				t.Fatalf("NewCoordinator: %v", err)
-			}
-
-			spec := minimalSpec("projection.myproj.v1")
-			subscribeErr := c.Subscribe(context.Background(), spec, tc.projectionID, tc.applyFn)
-
-			if tc.wantErr && subscribeErr == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !tc.wantErr && subscribeErr != nil {
-				t.Fatalf("unexpected error: %v", subscribeErr)
-			}
-
-			if reg.subscribeCalls != tc.wantSubCalls {
-				t.Errorf("subscribeCalls = %d, want %d", reg.subscribeCalls, tc.wantSubCalls)
-			}
-			if !tc.wantErr && tc.wantCG != "" {
-				if reg.lastCG != tc.wantCG {
-					t.Errorf("consumerGroup = %q, want %q", reg.lastCG, tc.wantCG)
-				}
-				if reg.lastCell != tc.wantCellID {
-					t.Errorf("cellID = %q, want %q", reg.lastCell, tc.wantCellID)
-				}
-			}
+			runSubscribeCase(t, tc)
 		})
 	}
 }
@@ -1057,5 +895,217 @@ func TestPhase_AlwaysLive(t *testing.T) {
 	}
 	if got := c.Phase(); got != PhaseLive {
 		t.Errorf("Phase() = %v, want PhaseLive", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runApplyOneCase — per-case executor for TestCoordinator_ApplyOne
+// ---------------------------------------------------------------------------
+
+type applyOneCase struct {
+	name           string
+	currentOffset  int64
+	cursorPos      int64
+	cursorErr      error
+	applyErr       error
+	saveFails      bool
+	wantApplyCalls int
+	wantSaved      bool
+	wantLastSaved  int64
+	wantDisp       outbox.Disposition
+	wantLoadErr    bool
+}
+
+func runApplyOneCase(t *testing.T, tc applyOneCase, errSave error) {
+	t.Helper()
+
+	apply := &recordingApply{err: tc.applyErr}
+	cursor := &fakeCursor{pos: tc.cursorPos, err: tc.cursorErr}
+	txr := &fakeTxRunner{}
+	reg := &fakeRegistrar{}
+
+	var store CheckpointStore
+	switch {
+	case tc.wantLoadErr:
+		store = &seededStore{offsets: make(map[string]int64), loadErr: errors.New("load failed")}
+	case tc.saveFails:
+		store = &errSaveStore{currentOffset: tc.currentOffset, saveErr: errSave}
+	default:
+		store = newSeededStore("testcell", "p1", tc.currentOffset)
+	}
+
+	c, err := NewCoordinator("testcell", reg, txr, store, cursor, wrapper.NoopTracer{})
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+
+	h := c.buildHandler("testcell", "p1", apply.fn)
+	result := h(context.Background(), outbox.Entry{})
+
+	if apply.calls != tc.wantApplyCalls {
+		t.Errorf("apply.calls = %d, want %d", apply.calls, tc.wantApplyCalls)
+	}
+
+	assertApplyOneSaveState(t, tc, store)
+
+	if result.Disposition != tc.wantDisp {
+		t.Errorf("Disposition = %v, want %v", result.Disposition, tc.wantDisp)
+	}
+}
+
+func assertApplyOneSaveState(t *testing.T, tc applyOneCase, store CheckpointStore) {
+	t.Helper()
+	if tc.saveFails {
+		es := store.(*errSaveStore)
+		if es.saveCalls == 0 {
+			t.Error("expected errSaveStore.SaveOffset to be called")
+		}
+		// After a save error the persisted value must not have changed.
+		got, _ := store.LoadOffset(context.Background(), "testcell", "p1")
+		if got != tc.currentOffset {
+			t.Errorf("after save error LoadOffset = %d, want original %d", got, tc.currentOffset)
+		}
+		return
+	}
+	ss, ok := store.(*seededStore)
+	if !ok {
+		return
+	}
+	if tc.wantSaved && ss.saveCalls == 0 {
+		t.Error("expected SaveOffset to be called, but it was not")
+	}
+	if !tc.wantSaved && ss.saveCalls != 0 {
+		t.Errorf("expected no SaveOffset calls, but got %d", ss.saveCalls)
+	}
+	if tc.wantSaved && ss.lastSaved != tc.wantLastSaved {
+		t.Errorf("lastSaved = %d, want %d", ss.lastSaved, tc.wantLastSaved)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runNilGuardCase — per-case executor for TestNewCoordinator_NilGuards
+// ---------------------------------------------------------------------------
+
+type nilGuardCase struct {
+	name    string
+	cellID  string
+	reg     cell.Registrar
+	txr     persistence.TxRunner
+	store   CheckpointStore
+	cursor  Cursor
+	tracer  wrapper.Tracer
+	wantErr bool
+}
+
+func runNilGuardCase(t *testing.T, tc nilGuardCase) {
+	t.Helper()
+	c, err := NewCoordinator(tc.cellID, tc.reg, tc.txr, tc.store, tc.cursor, tc.tracer)
+	if !tc.wantErr {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c == nil {
+			t.Fatal("expected non-nil coordinator")
+		}
+		return
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var e *errcode.Error
+	if !errors.As(err, &e) {
+		t.Fatalf("error is not *errcode.Error: %T %v", err, err)
+	}
+	if e.Kind != errcode.KindInvalid {
+		t.Errorf("Kind = %v, want KindInvalid", e.Kind)
+	}
+	if c != nil {
+		t.Error("expected nil coordinator on error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runSubscribeCase — per-case executor for TestCoordinator_Subscribe
+// ---------------------------------------------------------------------------
+
+type subscribeCase struct {
+	name         string
+	projectionID string
+	applyFn      Apply
+	regErr       error
+	wantErr      bool
+	wantSubCalls int
+	wantCG       string
+	wantCellID   string
+}
+
+func runSubscribeCase(t *testing.T, tc subscribeCase) {
+	t.Helper()
+	reg := &fakeRegistrar{subscribeErr: tc.regErr}
+	c, err := NewCoordinator("testcell", reg, &fakeTxRunner{}, NewMemCheckpointStore(), &fakeCursor{}, wrapper.NoopTracer{})
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+
+	spec := minimalSpec("projection.myproj.v1")
+	subscribeErr := c.Subscribe(context.Background(), spec, tc.projectionID, tc.applyFn)
+
+	if tc.wantErr && subscribeErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !tc.wantErr && subscribeErr != nil {
+		t.Fatalf("unexpected error: %v", subscribeErr)
+	}
+
+	if reg.subscribeCalls != tc.wantSubCalls {
+		t.Errorf("subscribeCalls = %d, want %d", reg.subscribeCalls, tc.wantSubCalls)
+	}
+	if !tc.wantErr && tc.wantCG != "" {
+		if reg.lastCG != tc.wantCG {
+			t.Errorf("consumerGroup = %q, want %q", reg.lastCG, tc.wantCG)
+		}
+		if reg.lastCell != tc.wantCellID {
+			t.Errorf("cellID = %q, want %q", reg.lastCell, tc.wantCellID)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runSpanStatusCase — per-case executor for TestBuildHandler_SpanStatus
+// ---------------------------------------------------------------------------
+
+type spanStatusCase struct {
+	name     string
+	applyErr error
+	wantCode wrapper.StatusCode
+	wantDesc string
+}
+
+func runSpanStatusCase(t *testing.T, tc spanStatusCase) {
+	t.Helper()
+	spy := &spyTracer{}
+	apply := &recordingApply{err: tc.applyErr}
+	store := newSeededStore("testcell", "p1", 0)
+	cursor := &fakeCursor{pos: 1}
+
+	c, err := NewCoordinator("testcell", &fakeRegistrar{}, &fakeTxRunner{}, store, cursor, spy)
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+
+	h := c.buildHandler("testcell", "p1", apply.fn)
+	_ = h(context.Background(), outbox.Entry{})
+
+	if spy.last == nil {
+		t.Fatal("spy tracer: no span was started")
+	}
+	if !spy.last.statusSet {
+		t.Fatal("span.SetStatus was never called")
+	}
+	if spy.last.statusCode != tc.wantCode {
+		t.Errorf("SetStatus code = %v, want %v", spy.last.statusCode, tc.wantCode)
+	}
+	if spy.last.statusDesc != tc.wantDesc {
+		t.Errorf("SetStatus desc = %q, want %q", spy.last.statusDesc, tc.wantDesc)
 	}
 }

--- a/kernel/projection/projectiontest/conformance.go
+++ b/kernel/projection/projectiontest/conformance.go
@@ -30,6 +30,10 @@ import (
 const (
 	testIsoCellA = "cellA-iso"
 	testIsoProj1 = "p1-iso"
+
+	testBackCell     = "cell-back"
+	testBackProj     = "proj-back"
+	fmtErrLoadOffset = "LoadOffset: %v"
 )
 
 // RunCheckpointConformance runs the six canonical conformance sub-tests against
@@ -107,7 +111,7 @@ func checkSaveLoadRoundtrip(t *testing.T, store projection.CheckpointStore) {
 	}
 	got, err := store.LoadOffset(ctx, "cell-rt", "proj-rt")
 	if err != nil {
-		t.Fatalf("LoadOffset: %v", err)
+		t.Fatalf(fmtErrLoadOffset, err)
 	}
 	if got != 7 {
 		t.Errorf("LoadOffset = %d, want 7", got)
@@ -168,15 +172,15 @@ func checkIsolationEntry(t *testing.T, store projection.CheckpointStore, ctx con
 func checkBackwardWrite(t *testing.T, store projection.CheckpointStore) {
 	t.Helper()
 	ctx := context.Background()
-	if err := store.SaveOffset(ctx, "cell-back", "proj-back", 9); err != nil {
+	if err := store.SaveOffset(ctx, testBackCell, testBackProj, 9); err != nil {
 		t.Fatalf("SaveOffset(9): %v", err)
 	}
-	if err := store.SaveOffset(ctx, "cell-back", "proj-back", 3); err != nil {
+	if err := store.SaveOffset(ctx, testBackCell, testBackProj, 3); err != nil {
 		t.Fatalf("SaveOffset(3) backward write must be accepted, not rejected: %v", err)
 	}
-	got, err := store.LoadOffset(ctx, "cell-back", "proj-back")
+	got, err := store.LoadOffset(ctx, testBackCell, testBackProj)
 	if err != nil {
-		t.Fatalf("LoadOffset: %v", err)
+		t.Fatalf(fmtErrLoadOffset, err)
 	}
 	if got != 3 {
 		t.Errorf("after backward Save(3): LoadOffset = %d, want 3 (unconditional overwrite)", got)
@@ -193,7 +197,7 @@ func checkIdempotentReSave(t *testing.T, store projection.CheckpointStore) {
 	}
 	got, err := store.LoadOffset(ctx, "cell-idem", "proj-idem")
 	if err != nil {
-		t.Fatalf("LoadOffset: %v", err)
+		t.Fatalf(fmtErrLoadOffset, err)
 	}
 	if got != 5 {
 		t.Errorf("LoadOffset after two Save(5) = %d, want 5", got)

--- a/kernel/projection/projectiontest/conformance.go
+++ b/kernel/projection/projectiontest/conformance.go
@@ -27,6 +27,11 @@ import (
 	"github.com/ghbvf/gocell/kernel/projection"
 )
 
+const (
+	testIsoCellA = "cellA-iso"
+	testIsoProj1 = "p1-iso"
+)
+
 // RunCheckpointConformance runs the six canonical conformance sub-tests against
 // store. Each sub-test uses a distinct (cellID, projectionID) key to prevent
 // ordering-dependent interference on a shared store instance.
@@ -129,18 +134,18 @@ func checkMonotonicAdvance(t *testing.T, store projection.CheckpointStore) {
 func checkKeyIsolation(t *testing.T, store projection.CheckpointStore) {
 	t.Helper()
 	ctx := context.Background()
-	if err := store.SaveOffset(ctx, "cellA-iso", "p1-iso", 3); err != nil {
+	if err := store.SaveOffset(ctx, testIsoCellA, testIsoProj1, 3); err != nil {
 		t.Fatalf("SaveOffset cellA/p1: %v", err)
 	}
-	if err := store.SaveOffset(ctx, "cellB-iso", "p1-iso", 4); err != nil {
+	if err := store.SaveOffset(ctx, "cellB-iso", testIsoProj1, 4); err != nil {
 		t.Fatalf("SaveOffset cellB/p1: %v", err)
 	}
-	if err := store.SaveOffset(ctx, "cellA-iso", "p2-iso", 5); err != nil {
+	if err := store.SaveOffset(ctx, testIsoCellA, "p2-iso", 5); err != nil {
 		t.Fatalf("SaveOffset cellA/p2: %v", err)
 	}
-	checkIsolationEntry(t, store, ctx, "cellA-iso", "p1-iso", 3)
-	checkIsolationEntry(t, store, ctx, "cellB-iso", "p1-iso", 4)
-	checkIsolationEntry(t, store, ctx, "cellA-iso", "p2-iso", 5)
+	checkIsolationEntry(t, store, ctx, testIsoCellA, testIsoProj1, 3)
+	checkIsolationEntry(t, store, ctx, "cellB-iso", testIsoProj1, 4)
+	checkIsolationEntry(t, store, ctx, testIsoCellA, "p2-iso", 5)
 }
 
 func checkIsolationEntry(t *testing.T, store projection.CheckpointStore, ctx context.Context, cellID, projID string, want int64) {

--- a/pkg/httputil/path_param_test.go
+++ b/pkg/httputil/path_param_test.go
@@ -16,15 +16,7 @@ func TestParseUUIDPathParam(t *testing.T) {
 
 	const validUUID = "0e8d6e9a-3a6f-4b1f-9c1e-2a3b4c5d6e7f"
 
-	tests := []struct {
-		name       string
-		paramName  string
-		raw        string
-		wantOK     bool
-		wantStatus int
-		wantValue  string
-		wantCode   string
-	}{
+	tests := []uuidPathParamCase{
 		{
 			name:      "valid lowercase",
 			paramName: "id",
@@ -114,53 +106,69 @@ func TestParseUUIDPathParam(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			req := httptest.NewRequest(http.MethodGet, "/x", nil)
-			req.SetPathValue(tt.paramName, tt.raw)
-			rec := httptest.NewRecorder()
-
-			got, ok := httputil.ParseUUIDPathParam(rec, req, tt.paramName)
-			if ok != tt.wantOK {
-				t.Fatalf("ok = %v, want %v (rec.Code=%d body=%s)", ok, tt.wantOK, rec.Code, rec.Body.String())
-			}
-			if !ok {
-				if rec.Code != tt.wantStatus {
-					t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
-				}
-				var body struct {
-					Error struct {
-						Code    string `json:"code"`
-						Message string `json:"message"`
-						Details []struct {
-							Key   string `json:"key"`
-							Value any    `json:"value"`
-						} `json:"details"`
-					} `json:"error"`
-				}
-				if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-					t.Fatalf("decode body: %v (raw=%s)", err, rec.Body.String())
-				}
-				if body.Error.Code != tt.wantCode {
-					t.Fatalf("error.code = %q, want %q", body.Error.Code, tt.wantCode)
-				}
-				// param name is in Details[key="param"], not in Message
-				if tt.paramName != "" {
-					found := false
-					for _, d := range body.Error.Details {
-						if d.Key == "param" && d.Value == tt.paramName {
-							found = true
-							break
-						}
-					}
-					if !found {
-						t.Fatalf("error.details does not contain param=%q, body=%s", tt.paramName, rec.Body.String())
-					}
-				}
-				return
-			}
-			if got != tt.wantValue {
-				t.Fatalf("value = %q, want %q", got, tt.wantValue)
-			}
+			runParseUUIDPathParamCase(t, tt)
 		})
 	}
+}
+
+type uuidPathParamCase struct {
+	name       string
+	paramName  string
+	raw        string
+	wantOK     bool
+	wantStatus int
+	wantValue  string
+	wantCode   string
+}
+
+func runParseUUIDPathParamCase(t *testing.T, tc uuidPathParamCase) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.SetPathValue(tc.paramName, tc.raw)
+	rec := httptest.NewRecorder()
+
+	got, ok := httputil.ParseUUIDPathParam(rec, req, tc.paramName)
+	if ok != tc.wantOK {
+		t.Fatalf("ok = %v, want %v (rec.Code=%d body=%s)", ok, tc.wantOK, rec.Code, rec.Body.String())
+	}
+	if ok {
+		if got != tc.wantValue {
+			t.Fatalf("value = %q, want %q", got, tc.wantValue)
+		}
+		return
+	}
+	assertUUIDPathParamError(t, rec, tc)
+}
+
+func assertUUIDPathParamError(t *testing.T, rec *httptest.ResponseRecorder, tc uuidPathParamCase) {
+	t.Helper()
+	if rec.Code != tc.wantStatus {
+		t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+	}
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details []struct {
+				Key   string `json:"key"`
+				Value any    `json:"value"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v (raw=%s)", err, rec.Body.String())
+	}
+	if body.Error.Code != tc.wantCode {
+		t.Fatalf("error.code = %q, want %q", body.Error.Code, tc.wantCode)
+	}
+	// param name is in Details[key="param"], not in Message
+	if tc.paramName == "" {
+		return
+	}
+	for _, d := range body.Error.Details {
+		if d.Key == "param" && d.Value == tc.paramName {
+			return
+		}
+	}
+	t.Fatalf("error.details does not contain param=%q, body=%s", tc.paramName, rec.Body.String())
 }

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -347,7 +347,7 @@ func TestNewProtocol_OK(t *testing.T) {
 // left untouched — no crash, no silent data alteration.
 type chainHMACKeyCase struct {
 	name       string
-	keyLen     int  // -1 → nil key
+	keyLen     int // -1 → nil key
 	wantErr    bool
 	wantZeroed bool // post-call caller slice all-zero check
 }

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -345,16 +345,57 @@ func TestNewProtocol_OK(t *testing.T) {
 // Boundary cases (nil / short key) verify the documented fail-fast behavior:
 // WithChainHMAC returns an error before clear() runs, and the caller slice is
 // left untouched — no crash, no silent data alteration.
+type chainHMACKeyCase struct {
+	name       string
+	keyLen     int  // -1 → nil key
+	wantErr    bool
+	wantZeroed bool // post-call caller slice all-zero check
+}
+
+func runChainHMACKeyCase(t *testing.T, ns ledger.NamespaceID, tc chainHMACKeyCase) {
+	t.Helper()
+	var key []byte
+	if tc.keyLen >= 0 {
+		key = make([]byte, tc.keyLen)
+		for i := range key {
+			key[i] = byte(i + 1)
+		}
+	}
+	_, err := ledger.NewProtocol(
+		ns,
+		key,
+		ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
+		ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
+	)
+	if tc.wantErr {
+		if err == nil {
+			t.Fatalf("NewProtocol: expected error for %s, got nil", tc.name)
+		}
+		if tc.keyLen > 0 && key[0] == 0 {
+			// Caller slice should be unchanged (no clear ran)
+			t.Errorf("caller key unexpectedly zeroed on error path for %s; clear() must only run on success", tc.name)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("NewProtocol: %v", err)
+	}
+	if !tc.wantZeroed {
+		return
+	}
+	for i, b := range key {
+		if b != 0 {
+			t.Errorf("caller key not zeroed: first non-zero byte at index %d = %#x (additional non-zero bytes suppressed)", i, b)
+			break // C.F2: surface first failure only
+		}
+	}
+}
+
 func TestWithChainHMAC_CallerSliceZeroedAfterCopy(t *testing.T) {
 	t.Parallel()
 	ns, _ := ledger.ParseNamespaceID("auditcore")
 
-	tests := []struct {
-		name       string
-		keyLen     int // -1 → nil key
-		wantErr    bool
-		wantZeroed bool // post-call caller slice all-zero check
-	}{
+	tests := []chainHMACKeyCase{
 		{"happy_32_byte", 32, false, true},
 		{"short_31_byte_rejected", 31, true, false}, // clear() never runs; caller slice untouched
 		{"nil_key_rejected", -1, true, false},       // nil-safe: clear(nil) is no-op
@@ -364,42 +405,7 @@ func TestWithChainHMAC_CallerSliceZeroedAfterCopy(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			var key []byte
-			if tt.keyLen >= 0 {
-				key = make([]byte, tt.keyLen)
-				for i := range key {
-					key[i] = byte(i + 1)
-				}
-			}
-			_, err := ledger.NewProtocol(
-				ns,
-				key,
-				ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
-				ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
-			)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("NewProtocol: expected error for %s, got nil", tt.name)
-				}
-				if tt.keyLen > 0 {
-					// Caller slice should be unchanged (no clear ran)
-					if key[0] == 0 {
-						t.Errorf("caller key unexpectedly zeroed on error path for %s; clear() must only run on success", tt.name)
-					}
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("NewProtocol: %v", err)
-			}
-			if tt.wantZeroed {
-				for i, b := range key {
-					if b != 0 {
-						t.Errorf("caller key not zeroed: first non-zero byte at index %d = %#x (additional non-zero bytes suppressed)", i, b)
-						break // C.F2: surface first failure only
-					}
-				}
-			}
+			runChainHMACKeyCase(t, ns, tt)
 		})
 	}
 }

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -42,6 +42,8 @@ import (
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
 
+const fmtErrGetBySeq1 = "GetBySeq(1): %v"
+
 // entryStoreAssignedFields enumerates Entry fields that Append/GetBySeq write
 // or compute, NOT the caller's source-of-truth. AssertEntryRoundTrip skips
 // these because they intentionally differ between the caller's literal and
@@ -281,7 +283,7 @@ func runAppendTailRoundTrip(t *testing.T, factory Factory) {
 
 	got, err := store.GetBySeq(context.Background(), 1)
 	if err != nil {
-		t.Fatalf("GetBySeq(1): %v", err)
+		t.Fatalf(fmtErrGetBySeq1, err)
 	}
 	if got.EventID != e.EventID {
 		t.Errorf("EventID: got %q, want %q", got.EventID, e.EventID)
@@ -615,7 +617,7 @@ func runAppendMultiKeyPayloadRoundTrip(t *testing.T, factory Factory) {
 
 	got, err := store.GetBySeq(context.Background(), 1)
 	if err != nil {
-		t.Fatalf("GetBySeq(1): %v", err)
+		t.Fatalf(fmtErrGetBySeq1, err)
 	}
 	// A-01: payload bytes must be preserved exactly as supplied — no JSONB normalization.
 	if !bytes.Equal(got.Payload, payload) {
@@ -980,7 +982,7 @@ func RunPrincipalFieldsRoundTrip(t *testing.T, factory Factory, protocol *ledger
 
 	got, err := store.GetBySeq(context.Background(), 1)
 	if err != nil {
-		t.Fatalf("GetBySeq(1): %v", err)
+		t.Fatalf(fmtErrGetBySeq1, err)
 	}
 
 	// AssertEntryRoundTrip walks every caller-supplied Entry field via reflect,

--- a/runtime/http/health/verbose_shape_test.go
+++ b/runtime/http/health/verbose_shape_test.go
@@ -383,38 +383,65 @@ func findLogfmtLine(t *testing.T, out, msg string) string {
 // Known limits (sufficient for the single-line readyz record under test): one
 // line only (caller pre-selects the line); no \n inside values; first
 // occurrence wins on duplicate keys.
+// parseLogfmtKey advances i past leading spaces and reads the next key token
+// (up to '=' or ' '). Returns (key, newI, ok=false) when no '=' follows.
+func parseLogfmtKey(line string, i int) (key string, next int, ok bool) {
+	for i < len(line) && line[i] == ' ' {
+		i++
+	}
+	if i >= len(line) {
+		return "", i, false
+	}
+	start := i
+	for i < len(line) && line[i] != '=' && line[i] != ' ' {
+		i++
+	}
+	if i >= len(line) || line[i] != '=' {
+		return "", i, false // token without '=' — skip
+	}
+	return line[start:i], i + 1, true // +1 to consume '='
+}
+
+// parseLogfmtQuotedVal reads a double-quoted value starting after the opening '"'.
+// Returns the unescaped value and the index after the closing '"'.
+func parseLogfmtQuotedVal(line string, i int) (string, int) {
+	var sb strings.Builder
+	for i < len(line) && line[i] != '"' {
+		if line[i] == '\\' && i+1 < len(line) {
+			i++
+		}
+		sb.WriteByte(line[i])
+		i++
+	}
+	if i < len(line) {
+		i++ // consume closing '"'
+	}
+	return sb.String(), i
+}
+
+// parseLogfmtLine is a minimal logfmt parser for the single-line records that
+// slog.NewTextHandler emitted, so assertions run against decoded values rather
+// than raw substrings.
+//
+// Known limits (sufficient for the single-line readyz record under test): one
+// line only (caller pre-selects the line); no \n inside values; first
+// occurrence wins on duplicate keys.
 func parseLogfmtLine(line string) map[string]string {
 	m := make(map[string]string)
 	i := 0
 	for i < len(line) {
-		for i < len(line) && line[i] == ' ' {
-			i++
-		}
-		if i >= len(line) {
-			break
-		}
-		start := i
-		for i < len(line) && line[i] != '=' && line[i] != ' ' {
-			i++
-		}
-		if i >= len(line) || line[i] != '=' {
-			continue // token without '=' — skip
-		}
-		key := line[start:i]
-		i++ // consume '='
-		var val string
-		if i < len(line) && line[i] == '"' {
-			i++
-			var sb strings.Builder
-			for i < len(line) && line[i] != '"' {
-				if line[i] == '\\' && i+1 < len(line) {
-					i++
-				}
-				sb.WriteByte(line[i])
+		key, next, ok := parseLogfmtKey(line, i)
+		if !ok {
+			// advance past the skipped token to avoid infinite loop
+			for i < len(line) && line[i] != ' ' {
 				i++
 			}
-			i++ // consume closing quote
-			val = sb.String()
+			continue
+		}
+		i = next
+		var val string
+		if i < len(line) && line[i] == '"' {
+			val, i = parseLogfmtQuotedVal(line, i+1)
 		} else {
 			vs := i
 			for i < len(line) && line[i] != ' ' {

--- a/runtime/saga/executor/executor.go
+++ b/runtime/saga/executor/executor.go
@@ -449,10 +449,13 @@ func (e *Executor) executeInner(
 				onStale() // cancel runCtx with errLeaseLost so the in-flight step bails
 			}
 		}()
-		runHeartbeat(hbCtx, e.clk, e.heartbeater,
-			inst.ID, leaseID, inst.DefinitionID,
-			e.heartbeatInterval, e.leaseDuration,
-			e.logger, onStale, onHBFailure)
+		runHeartbeat(hbCtx, e.clk, e.heartbeater, HeartbeatConfig{
+			InstanceID:    inst.ID,
+			LeaseID:       leaseID,
+			DefinitionID:  inst.DefinitionID,
+			Interval:      e.heartbeatInterval,
+			LeaseDuration: e.leaseDuration,
+		}, e.logger, onStale, onHBFailure)
 	}()
 	stopAndJoin := func() { stopHB(); hbWG.Wait() }
 
@@ -561,10 +564,13 @@ func (e *Executor) RunWithHeartbeat(
 				onStale() // cancel runCtx with errLeaseLost so the in-flight fn bails
 			}
 		}()
-		runHeartbeat(hbCtx, e.clk, e.heartbeater,
-			inst.ID, leaseID, inst.DefinitionID,
-			e.heartbeatInterval, e.leaseDuration,
-			e.logger, onStale, onHBFailure)
+		runHeartbeat(hbCtx, e.clk, e.heartbeater, HeartbeatConfig{
+			InstanceID:    inst.ID,
+			LeaseID:       leaseID,
+			DefinitionID:  inst.DefinitionID,
+			Interval:      e.heartbeatInterval,
+			LeaseDuration: e.leaseDuration,
+		}, e.logger, onStale, onHBFailure)
 	}()
 	defer func() {
 		stopHB()

--- a/runtime/saga/executor/executor.go
+++ b/runtime/saga/executor/executor.go
@@ -449,7 +449,7 @@ func (e *Executor) executeInner(
 				onStale() // cancel runCtx with errLeaseLost so the in-flight step bails
 			}
 		}()
-		runHeartbeat(hbCtx, e.clk, e.heartbeater, HeartbeatConfig{
+		runHeartbeat(hbCtx, e.clk, e.heartbeater, heartbeatConfig{
 			InstanceID:    inst.ID,
 			LeaseID:       leaseID,
 			DefinitionID:  inst.DefinitionID,
@@ -564,7 +564,7 @@ func (e *Executor) RunWithHeartbeat(
 				onStale() // cancel runCtx with errLeaseLost so the in-flight fn bails
 			}
 		}()
-		runHeartbeat(hbCtx, e.clk, e.heartbeater, HeartbeatConfig{
+		runHeartbeat(hbCtx, e.clk, e.heartbeater, heartbeatConfig{
 			InstanceID:    inst.ID,
 			LeaseID:       leaseID,
 			DefinitionID:  inst.DefinitionID,

--- a/runtime/saga/executor/executor_test.go
+++ b/runtime/saga/executor/executor_test.go
@@ -859,60 +859,68 @@ func TestCompensate_IgnoresStepTimeout(t *testing.T) {
 func TestCompensate_LeaseIDLogged(t *testing.T) {
 	t.Parallel()
 	const leaseID = idutil.SafeID("lease-comp-logged")
-
 	t.Run("success logs lease_id on Info", func(t *testing.T) {
 		t.Parallel()
-		fc := clockmock.New(time.Now())
-		hb := &alwaysOKHeartbeater{}
-		buf := sloghelper.NewSyncBuffer()
-		logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-		exec, err := NewExecutor(hb, fc, WithLogger(logger))
-		if err != nil {
-			t.Fatal(err)
-		}
-		step := ksaga.Step{
-			Name:       "step-log-success",
-			Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return nil, nil },
-			Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return nil },
-		}
-		if err := exec.Compensate(context.Background(), newTestInstance(), leaseID, step, nil); err != nil {
-			t.Fatalf("Compensate returned error: %v", err)
-		}
-		entry := sloghelper.FindLogEntry(buf.String(), "compensating step")
-		if entry == nil {
-			t.Fatal("expected an INFO log about compensating step")
-		}
-		if entry["lease_id"] != string(leaseID) {
-			t.Errorf("log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
-		}
+		runCompensateLeaseIDSuccess(t, leaseID)
 	})
-
 	t.Run("failure logs lease_id on Warn", func(t *testing.T) {
 		t.Parallel()
-		fc := clockmock.New(time.Now())
-		hb := &alwaysOKHeartbeater{}
-		buf := sloghelper.NewSyncBuffer()
-		logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-		exec, err := NewExecutor(hb, fc, WithLogger(logger))
-		if err != nil {
-			t.Fatal(err)
-		}
-		step := ksaga.Step{
-			Name:       "step-log-fail",
-			Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return nil, nil },
-			Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return errors.New("boom") },
-		}
-		if err := exec.Compensate(context.Background(), newTestInstance(), leaseID, step, nil); err == nil {
-			t.Fatal("expected Compensate to return the compensate error")
-		}
-		entry := sloghelper.FindLogEntry(buf.String(), "compensate failed")
-		if entry == nil {
-			t.Fatal("expected a WARN log about compensate failed")
-		}
-		if entry["lease_id"] != string(leaseID) {
-			t.Errorf("log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
-		}
+		runCompensateLeaseIDFailure(t, leaseID)
 	})
+}
+
+func runCompensateLeaseIDSuccess(t *testing.T, leaseID idutil.SafeID) {
+	t.Helper()
+	fc := clockmock.New(time.Now())
+	hb := &alwaysOKHeartbeater{}
+	buf := sloghelper.NewSyncBuffer()
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	exec, err := NewExecutor(hb, fc, WithLogger(logger))
+	if err != nil {
+		t.Fatal(err)
+	}
+	step := ksaga.Step{
+		Name:       "step-log-success",
+		Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return nil, nil },
+		Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return nil },
+	}
+	if err := exec.Compensate(context.Background(), newTestInstance(), leaseID, step, nil); err != nil {
+		t.Fatalf("Compensate returned error: %v", err)
+	}
+	entry := sloghelper.FindLogEntry(buf.String(), "compensating step")
+	if entry == nil {
+		t.Fatal("expected an INFO log about compensating step")
+	}
+	if entry["lease_id"] != string(leaseID) {
+		t.Errorf("log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
+	}
+}
+
+func runCompensateLeaseIDFailure(t *testing.T, leaseID idutil.SafeID) {
+	t.Helper()
+	fc := clockmock.New(time.Now())
+	hb := &alwaysOKHeartbeater{}
+	buf := sloghelper.NewSyncBuffer()
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	exec, err := NewExecutor(hb, fc, WithLogger(logger))
+	if err != nil {
+		t.Fatal(err)
+	}
+	step := ksaga.Step{
+		Name:       "step-log-fail",
+		Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return nil, nil },
+		Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return errors.New("boom") },
+	}
+	if err := exec.Compensate(context.Background(), newTestInstance(), leaseID, step, nil); err == nil {
+		t.Fatal("expected Compensate to return the compensate error")
+	}
+	entry := sloghelper.FindLogEntry(buf.String(), "compensate failed")
+	if entry == nil {
+		t.Fatal("expected a WARN log about compensate failed")
+	}
+	if entry["lease_id"] != string(leaseID) {
+		t.Errorf("log lease_id = %v, want %q", entry["lease_id"], string(leaseID))
+	}
 }
 
 // TestSafeRun_PanicValueRedactedInInternalAttr asserts that a panic value

--- a/runtime/saga/executor/heartbeat.go
+++ b/runtime/saga/executor/heartbeat.go
@@ -37,11 +37,11 @@ type Heartbeater interface {
 	Heartbeat(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (ok bool, err error)
 }
 
-// HeartbeatConfig holds the identity and timing parameters for runHeartbeat.
+// heartbeatConfig holds the identity and timing parameters for runHeartbeat.
 // Grouping them into a struct keeps runHeartbeat's parameter count within the
 // go:S107 limit (≤7 parameters). All fields are required; Interval and
 // LeaseDuration must be > 0.
-type HeartbeatConfig struct {
+type heartbeatConfig struct {
 	InstanceID    idutil.SafeID
 	LeaseID       idutil.SafeID
 	DefinitionID  idutil.SafeID
@@ -81,7 +81,7 @@ func runHeartbeat(
 	ctx context.Context,
 	clk clock.Clock,
 	hb Heartbeater,
-	cfg HeartbeatConfig,
+	cfg heartbeatConfig,
 	logger *slog.Logger,
 	onStale func(),
 	onHBFailure func(reason HeartbeatFailureReason),

--- a/runtime/saga/executor/heartbeat.go
+++ b/runtime/saga/executor/heartbeat.go
@@ -37,6 +37,16 @@ type Heartbeater interface {
 	Heartbeat(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (ok bool, err error)
 }
 
+// HeartbeatConfig holds the identity and timing parameters for runHeartbeat.
+// Grouping them into a struct reduces the positional-parameter count (S107).
+type HeartbeatConfig struct {
+	InstanceID    idutil.SafeID
+	LeaseID       idutil.SafeID
+	DefinitionID  idutil.SafeID
+	Interval      time.Duration
+	LeaseDuration time.Duration
+}
+
 // runHeartbeat runs in its own goroutine and beats the lease at each ticker
 // interval until:
 //   - ctx is canceled (clean shutdown — caller called stopHB), or
@@ -69,12 +79,16 @@ func runHeartbeat(
 	ctx context.Context,
 	clk clock.Clock,
 	hb Heartbeater,
-	instanceID, leaseID, definitionID idutil.SafeID,
-	interval, leaseDuration time.Duration,
+	cfg HeartbeatConfig,
 	logger *slog.Logger,
 	onStale func(),
 	onHBFailure func(reason HeartbeatFailureReason),
 ) {
+	instanceID := cfg.InstanceID
+	leaseID := cfg.LeaseID
+	definitionID := cfg.DefinitionID
+	interval := cfg.Interval
+	leaseDuration := cfg.LeaseDuration
 	ticker := clk.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/runtime/saga/executor/heartbeat.go
+++ b/runtime/saga/executor/heartbeat.go
@@ -38,7 +38,9 @@ type Heartbeater interface {
 }
 
 // HeartbeatConfig holds the identity and timing parameters for runHeartbeat.
-// Grouping them into a struct reduces the positional-parameter count (S107).
+// Grouping them into a struct keeps runHeartbeat's parameter count within the
+// go:S107 limit (≤7 parameters). All fields are required; Interval and
+// LeaseDuration must be > 0.
 type HeartbeatConfig struct {
 	InstanceID    idutil.SafeID
 	LeaseID       idutil.SafeID

--- a/runtime/saga/executor/heartbeat_test.go
+++ b/runtime/saga/executor/heartbeat_test.go
@@ -95,7 +95,13 @@ func TestHeartbeat_TickerFiresOnAdvance(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, instID, leaseID, "def-x", interval, leaseDur, noopLogger(), noStale, noHBFailure)
+		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+			InstanceID:    instID,
+			LeaseID:       leaseID,
+			DefinitionID:  "def-x",
+			Interval:      interval,
+			LeaseDuration: leaseDur,
+		}, noopLogger(), noStale, noHBFailure)
 	}()
 
 	// Wait for the goroutine to register its ticker.
@@ -139,7 +145,13 @@ func TestHeartbeat_NoLeakOnCancel(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, instID, leaseID, "def-x", testtime.D5s, testtime.D30s, noopLogger(), noStale, noHBFailure)
+		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+			InstanceID:    instID,
+			LeaseID:       leaseID,
+			DefinitionID:  "def-x",
+			Interval:      testtime.D5s,
+			LeaseDuration: testtime.D30s,
+		}, noopLogger(), noStale, noHBFailure)
 	}()
 
 	// Wait for ticker registration then cancel.
@@ -167,7 +179,13 @@ func TestHeartbeat_StaleLease(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, instID, leaseID, "def-x", interval, testtime.D30s, noopLogger(), noStale, noHBFailure)
+		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+			InstanceID:    instID,
+			LeaseID:       leaseID,
+			DefinitionID:  "def-x",
+			Interval:      interval,
+			LeaseDuration: testtime.D30s,
+		}, noopLogger(), noStale, noHBFailure)
 	}()
 
 	// Wait for ticker to be registered.
@@ -218,7 +236,13 @@ func TestHeartbeat_StaleLease_InvokesOnStale(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, instID, leaseID, "def-x", interval, testtime.D30s, noopLogger(), onStale, noHBFailure)
+		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+			InstanceID:    instID,
+			LeaseID:       leaseID,
+			DefinitionID:  "def-x",
+			Interval:      interval,
+			LeaseDuration: testtime.D30s,
+		}, noopLogger(), onStale, noHBFailure)
 	}()
 
 	waitForOneTicker(t, fc)
@@ -244,7 +268,13 @@ func TestHeartbeat_TransientError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, instID, leaseID, "def-x", interval, testtime.D30s, noopLogger(), noStale, noHBFailure)
+		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+			InstanceID:    instID,
+			LeaseID:       leaseID,
+			DefinitionID:  "def-x",
+			Interval:      interval,
+			LeaseDuration: testtime.D30s,
+		}, noopLogger(), noStale, noHBFailure)
 	}()
 
 	// Wait for ticker registration.

--- a/runtime/saga/executor/heartbeat_test.go
+++ b/runtime/saga/executor/heartbeat_test.go
@@ -95,7 +95,7 @@ func TestHeartbeat_TickerFiresOnAdvance(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+		runHeartbeat(ctx, fc, hb, heartbeatConfig{
 			InstanceID:    instID,
 			LeaseID:       leaseID,
 			DefinitionID:  "def-x",
@@ -145,7 +145,7 @@ func TestHeartbeat_NoLeakOnCancel(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+		runHeartbeat(ctx, fc, hb, heartbeatConfig{
 			InstanceID:    instID,
 			LeaseID:       leaseID,
 			DefinitionID:  "def-x",
@@ -179,7 +179,7 @@ func TestHeartbeat_StaleLease(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+		runHeartbeat(ctx, fc, hb, heartbeatConfig{
 			InstanceID:    instID,
 			LeaseID:       leaseID,
 			DefinitionID:  "def-x",
@@ -236,7 +236,7 @@ func TestHeartbeat_StaleLease_InvokesOnStale(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+		runHeartbeat(ctx, fc, hb, heartbeatConfig{
 			InstanceID:    instID,
 			LeaseID:       leaseID,
 			DefinitionID:  "def-x",
@@ -268,7 +268,7 @@ func TestHeartbeat_TransientError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+		runHeartbeat(ctx, fc, hb, heartbeatConfig{
 			InstanceID:    instID,
 			LeaseID:       leaseID,
 			DefinitionID:  "def-x",

--- a/runtime/saga/executor/observer_test.go
+++ b/runtime/saga/executor/observer_test.go
@@ -374,7 +374,7 @@ func TestRunHeartbeat_ObserveHeartbeatFailure_InfraError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+		runHeartbeat(ctx, fc, hb, heartbeatConfig{
 			InstanceID:    "inst-err",
 			LeaseID:       "lease-err",
 			DefinitionID:  "def-x",

--- a/runtime/saga/executor/observer_test.go
+++ b/runtime/saga/executor/observer_test.go
@@ -374,8 +374,13 @@ func TestRunHeartbeat_ObserveHeartbeatFailure_InfraError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		runHeartbeat(ctx, fc, hb, "inst-err", "lease-err", "def-x",
-			testtime.D5s, testtime.D30s, noopLogger(), noStale, onHBFailure)
+		runHeartbeat(ctx, fc, hb, HeartbeatConfig{
+			InstanceID:    "inst-err",
+			LeaseID:       "lease-err",
+			DefinitionID:  "def-x",
+			Interval:      testtime.D5s,
+			LeaseDuration: testtime.D30s,
+		}, noopLogger(), noStale, onHBFailure)
 	}()
 
 	// Wait for ticker registration, then drive 3 ticks.

--- a/runtime/saga/integration_test.go
+++ b/runtime/saga/integration_test.go
@@ -873,6 +873,7 @@ func stopTwoCoordinators(t *testing.T, c1, c2 *Coordinator,
 //   - The lease is expired via clock advance so coordinator-2 can re-claim.
 //     coordinator-2's driveOne sees ci.Instance.Status == StatusCompensating →
 //     recovery path → drives step1.Compensate again → StatusCompensated.
+//
 // makeStep1CompensateFn returns a Compensate function for step1 that:
 // - On first call (coordinator-1): signals compensationStarted, then blocks until ctx is done.
 // - On subsequent calls (coordinator-2 recovery): returns immediately.

--- a/runtime/saga/integration_test.go
+++ b/runtime/saga/integration_test.go
@@ -492,26 +492,7 @@ func TestIntegration_ClaimContention(t *testing.T) {
 	})
 
 	// Stop both coordinators.
-	cancel1()
-	cancel2()
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), testtime.D3s)
-	defer stopCancel()
-	if err := c1.Stop(stopCtx); err != nil && !errors.Is(err, context.Canceled) {
-		t.Errorf("c1 Stop: %v", err)
-	}
-	if err := c2.Stop(stopCtx); err != nil && !errors.Is(err, context.Canceled) {
-		t.Errorf("c2 Stop: %v", err)
-	}
-	select {
-	case <-done1:
-	case <-time.After(testtime.D3s):
-		t.Error("c1 goroutine did not exit")
-	}
-	select {
-	case <-done2:
-	case <-time.After(testtime.D3s):
-		t.Error("c2 goroutine did not exit")
-	}
+	stopTwoCoordinators(t, c1, c2, cancel1, cancel2, done1, done2)
 
 	// Total Kick count across both dispatchers == 1 (only one commit happened).
 	totalKicks := disp1.KickCount() + disp2.KickCount()
@@ -771,19 +752,7 @@ func TestIntegration_PanicRecovery(t *testing.T) {
 		return err == nil && len(evs) == 2
 	})
 
-	evs, err := j.Load(context.Background(), inst.ID)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if len(evs) != 2 {
-		t.Fatalf("journal event count = %d, want 2 (StepFailed + SagaFailed)", len(evs))
-	}
-	if evs[0].Kind != journal.KindStepFailed {
-		t.Errorf("evs[0].Kind = %s, want step_failed", evs[0].Kind)
-	}
-	if evs[1].Kind != journal.KindSagaFailed {
-		t.Errorf("evs[1].Kind = %s, want saga_failed", evs[1].Kind)
-	}
+	assertPanicRecoveryJournal(t, j, inst.ID)
 
 	// No outbox entries on failure path.
 	if got := em.Count(); got != 0 {
@@ -804,7 +773,35 @@ func TestIntegration_PanicRecovery(t *testing.T) {
 		t.Errorf("KickCount = %d, want 1", got)
 	}
 
-	// Stop the coordinator cleanly.
+	stopCoordinator(t, c, cancel, done)
+
+	// Step was called exactly once (the first tick triggered it).
+	if stepCallCount != 1 {
+		t.Errorf("step call count = %d, want 1", stepCallCount)
+	}
+}
+
+// assertPanicRecoveryJournal verifies the journal contains exactly StepFailed + SagaFailed.
+func assertPanicRecoveryJournal(t *testing.T, j *journal.MemJournal, instID idutil.SafeID) {
+	t.Helper()
+	evs, err := j.Load(context.Background(), instID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("journal event count = %d, want 2 (StepFailed + SagaFailed)", len(evs))
+	}
+	if evs[0].Kind != journal.KindStepFailed {
+		t.Errorf("evs[0].Kind = %s, want step_failed", evs[0].Kind)
+	}
+	if evs[1].Kind != journal.KindSagaFailed {
+		t.Errorf("evs[1].Kind = %s, want saga_failed", evs[1].Kind)
+	}
+}
+
+// stopCoordinator cancels ctx, stops the coordinator, and waits for the goroutine to exit.
+func stopCoordinator(t *testing.T, c *Coordinator, cancel context.CancelFunc, done <-chan error) {
+	t.Helper()
 	cancel()
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), testtime.D3s)
 	defer stopCancel()
@@ -816,10 +813,32 @@ func TestIntegration_PanicRecovery(t *testing.T) {
 	case <-time.After(testtime.D3s):
 		t.Error("coordinator goroutine did not exit")
 	}
+}
 
-	// Step was called exactly once (the first tick triggered it).
-	if stepCallCount != 1 {
-		t.Errorf("step call count = %d, want 1", stepCallCount)
+// stopTwoCoordinators stops two coordinators concurrently and waits for both goroutines.
+func stopTwoCoordinators(t *testing.T, c1, c2 *Coordinator,
+	cancel1, cancel2 context.CancelFunc, done1, done2 <-chan error,
+) {
+	t.Helper()
+	cancel1()
+	cancel2()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), testtime.D3s)
+	defer stopCancel()
+	if err := c1.Stop(stopCtx); err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("c1 Stop: %v", err)
+	}
+	if err := c2.Stop(stopCtx); err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("c2 Stop: %v", err)
+	}
+	select {
+	case <-done1:
+	case <-time.After(testtime.D3s):
+		t.Error("c1 goroutine did not exit")
+	}
+	select {
+	case <-done2:
+	case <-time.After(testtime.D3s):
+		t.Error("c2 goroutine did not exit")
 	}
 }
 
@@ -854,6 +873,50 @@ func TestIntegration_PanicRecovery(t *testing.T) {
 //   - The lease is expired via clock advance so coordinator-2 can re-claim.
 //     coordinator-2's driveOne sees ci.Instance.Status == StatusCompensating →
 //     recovery path → drives step1.Compensate again → StatusCompensated.
+// makeStep1CompensateFn returns a Compensate function for step1 that:
+// - On first call (coordinator-1): signals compensationStarted, then blocks until ctx is done.
+// - On subsequent calls (coordinator-2 recovery): returns immediately.
+// compensationStarted is a buffered channel (cap=1); non-blocking sends fall through.
+func makeStep1CompensateFn(compensationStarted chan<- struct{}, calls *atomic.Int64) func(context.Context, *ksaga.Instance, []byte) error {
+	return func(ctx context.Context, _ *ksaga.Instance, _ []byte) error {
+		n := calls.Add(1)
+		if n == 1 {
+			select {
+			case compensationStarted <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		return nil
+	}
+}
+
+// claimAndDriveOne claims exactly one pending instance from j and drives it synchronously.
+func claimAndDriveOne(t *testing.T, c *Coordinator, j *journal.MemJournal, label string) {
+	t.Helper()
+	claimed, _, err := j.ClaimPending(context.Background(), 1, testtime.D60s)
+	if err != nil || len(claimed) == 0 {
+		t.Fatalf("ClaimPending %s: %v / %d", label, err, len(claimed))
+	}
+	if err := c.driveOne(context.Background(), claimed[0]); err != nil {
+		t.Fatalf("driveOne %s: %v", label, err)
+	}
+}
+
+// claimOneAsync claims exactly one pending instance and starts driveOne in a goroutine.
+// Returns the error channel.
+func claimOneAsync(t *testing.T, c *Coordinator, j *journal.MemJournal, label string) <-chan error {
+	t.Helper()
+	claimed, _, err := j.ClaimPending(context.Background(), 1, testtime.D60s)
+	if err != nil || len(claimed) == 0 {
+		t.Fatalf("ClaimPending %s: %v / %d", label, err, len(claimed))
+	}
+	ch := make(chan error, 1)
+	go func() { ch <- c.driveOne(context.Background(), claimed[0]) }()
+	return ch
+}
+
 func TestIntegration_Compensation_LeaseLost_ResumesOnReclaim(t *testing.T) {
 	const defID idutil.SafeID = "compleaselostrecovery"
 
@@ -867,42 +930,16 @@ func TestIntegration_Compensation_LeaseLost_ResumesOnReclaim(t *testing.T) {
 	// causing the RunWithHeartbeat goroutine to cancelCause(errLeaseLost).
 	staleJ := &staleAfterFirstHBJournal{MemJournal: memJ}
 
-	// compensationStarted is signaled (buffered) by step1's Compensate when
-	// coordinator-1 first enters the compensation walk, so the test can sequence
-	// SetStale + clock.Advance precisely.
 	compensationStarted := make(chan struct{}, 1)
-	// step1CompensateCalls tracks how many times step1.Compensate was invoked
-	// so we can assert the recovery (coordinator-2) ran it exactly once.
 	var step1CompensateCalls atomic.Int64
 
 	def := &ksaga.Definition{
 		ID: defID,
 		Steps: []ksaga.Step{
 			{
-				Name: "step1",
-				Run: func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) {
-					return []byte(`{"s":1}`), nil
-				},
-				// Compensation for step1 (the only committed step visited in
-				// reverse walk during coordinator-1's first attempt): signal the
-				// test, then block on ctx until the lease-lost path cancels it.
-				// On coordinator-2's recovery this same function is called again;
-				// compensationStarted is already full (buffered cap=1, non-blocking
-				// send falls through) so the second call returns immediately.
-				Compensate: func(ctx context.Context, _ *ksaga.Instance, _ []byte) error {
-					n := step1CompensateCalls.Add(1)
-					if n == 1 {
-						// First call (coordinator-1): signal and block for lease-lost.
-						select {
-						case compensationStarted <- struct{}{}:
-						default:
-						}
-						<-ctx.Done()
-						return ctx.Err()
-					}
-					// Second call (coordinator-2 recovery): return immediately.
-					return nil
-				},
+				Name:       "step1",
+				Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return []byte(`{"s":1}`), nil },
+				Compensate: makeStep1CompensateFn(compensationStarted, &step1CompensateCalls),
 			},
 			{
 				Name: "step2",
@@ -940,25 +977,13 @@ func TestIntegration_Compensation_LeaseLost_ResumesOnReclaim(t *testing.T) {
 
 	// Phase 1 — c1 drives step1 (succeeds) synchronously.
 	clk.Advance(testtime.D60s + testtime.D1ms) // start fresh lease window
-	claimed1, _, err := memJ.ClaimPending(context.Background(), 1, testtime.D60s)
-	if err != nil || len(claimed1) == 0 {
-		t.Fatalf("ClaimPending phase1: %v / %d", err, len(claimed1))
-	}
-	if err := c1.driveOne(context.Background(), claimed1[0]); err != nil {
-		t.Fatalf("driveOne phase1 (step1): %v", err)
-	}
+	claimAndDriveOne(t, c1, memJ, "phase1 (step1)")
 
 	// Phase 2 — c1 drives step2 (fails) → enters compensation → loses lease.
 	// driveOne runs in a background goroutine so the test can advance the clock
 	// mid-flight after step1.Compensate signals.
 	clk.Advance(testtime.D60s + testtime.D1ms)
-	claimed2, _, err := memJ.ClaimPending(context.Background(), 1, testtime.D60s)
-	if err != nil || len(claimed2) == 0 {
-		t.Fatalf("ClaimPending phase2: %v / %d", err, len(claimed2))
-	}
-
-	driveErrCh := make(chan error, 1)
-	go func() { driveErrCh <- c1.driveOne(context.Background(), claimed2[0]) }()
+	driveErrCh := claimOneAsync(t, c1, memJ, "phase2")
 
 	// Wait until compensation walk has started (step1.Compensate signaled).
 	select {
@@ -977,44 +1002,7 @@ func TestIntegration_Compensation_LeaseLost_ResumesOnReclaim(t *testing.T) {
 		testtime.D2s, testtime.D1ms)
 	clk.Advance(testtime.D5ms)
 
-	// Wait for driveOne to return.
-	select {
-	case driveErr := <-driveErrCh:
-		if driveErr != nil {
-			t.Fatalf("driveOne phase2 should return nil on lease-lost, got: %v", driveErr)
-		}
-	case <-time.After(testtime.D2s):
-		t.Fatal("driveOne phase2 did not return within 2s after lease-lost")
-	}
-
-	// Verify no terminal event written by coordinator-1.
-	evs, err := memJ.Load(context.Background(), inst.ID)
-	if err != nil {
-		t.Fatalf("Load after phase2: %v", err)
-	}
-	for _, ev := range evs {
-		if ev.Kind.IsTerminal() {
-			t.Fatalf("coordinator-1 wrote a terminal event after lease-lost: %s", ev.Kind)
-		}
-	}
-
-	// Phase 2 invariant: instance is in StatusCompensating with no terminal event.
-	// Asserting this before Phase 3 ClaimPending makes failure diagnosis friendlier:
-	// if driveOne (phase2) wrote a terminal event, Phase 3 ClaimPending would find
-	// zero instances, surfacing a confusing "claimed 0" error rather than the root cause.
-	{
-		phase2Evs, loadErr := memJ.Load(context.Background(), inst.ID)
-		if loadErr != nil {
-			t.Fatalf("Phase 2 invariant check: Load: %v", loadErr)
-		}
-		if len(phase2Evs) == 0 {
-			t.Fatal("Phase 2 invariant check: no events in journal after coordinator-1 compensation walk")
-		}
-		last2 := phase2Evs[len(phase2Evs)-1]
-		if last2.Kind.IsTerminal() {
-			t.Fatalf("Phase 2 invariant violated: last event is terminal %s before Phase 3 recovery", last2.Kind)
-		}
-	}
+	assertPhase2LeaseLost(t, memJ, inst.ID, driveErrCh)
 
 	// Phase 3 — coordinator-2 re-claims the StatusCompensating instance and
 	// drives recovery. c2 uses memJ directly so its Heartbeat always returns true.
@@ -1039,8 +1027,54 @@ func TestIntegration_Compensation_LeaseLost_ResumesOnReclaim(t *testing.T) {
 		t.Fatalf("driveOne phase3 (recovery): %v", err)
 	}
 
-	// Final assertions.
-	evsFinal, err := memJ.Load(context.Background(), inst.ID)
+	assertPhase3RecoveryFinal(t, memJ, inst.ID, &step1CompensateCalls)
+}
+
+// assertPhase2LeaseLost verifies that driveOne returned nil on lease-lost and
+// coordinator-1 did not write any terminal event. Also asserts the Phase 2
+// pre-condition: instance in StatusCompensating with non-terminal last event.
+func assertPhase2LeaseLost(t *testing.T, j *journal.MemJournal, instID idutil.SafeID, driveErrCh <-chan error) {
+	t.Helper()
+	select {
+	case driveErr := <-driveErrCh:
+		if driveErr != nil {
+			t.Fatalf("driveOne phase2 should return nil on lease-lost, got: %v", driveErr)
+		}
+	case <-time.After(testtime.D2s):
+		t.Fatal("driveOne phase2 did not return within 2s after lease-lost")
+	}
+
+	evs, err := j.Load(context.Background(), instID)
+	if err != nil {
+		t.Fatalf("Load after phase2: %v", err)
+	}
+	for _, ev := range evs {
+		if ev.Kind.IsTerminal() {
+			t.Fatalf("coordinator-1 wrote a terminal event after lease-lost: %s", ev.Kind)
+		}
+	}
+
+	// Phase 2 invariant: instance is in StatusCompensating with no terminal event.
+	// Asserting this before Phase 3 ClaimPending makes failure diagnosis friendlier.
+	if len(evs) == 0 {
+		t.Fatal("Phase 2 invariant check: no events in journal after coordinator-1 compensation walk")
+	}
+	if evs[len(evs)-1].Kind.IsTerminal() {
+		t.Fatalf("Phase 2 invariant violated: last event is terminal %s before Phase 3 recovery", evs[len(evs)-1].Kind)
+	}
+}
+
+// assertPhase3RecoveryFinal checks the final journal state after coordinator-2 recovery.
+// coordinator-2's recovery: collectCommittedSteps filters step1 (already has
+// KindStepCompensationFailed on the log from coordinator-1's partial attempt).
+// The remaining compensation walk is empty — step1.Compensate is NOT re-run
+// (idempotent: already attempted, not retried, #1181 F2). However,
+// priorFailureCount > 0 so compensateErrors is seeded from history (#1181 F1):
+// the recovery terminates with StatusCompensationFailed, not StatusCompensated,
+// because the prior partial failure must not be silently discarded.
+func assertPhase3RecoveryFinal(t *testing.T, j *journal.MemJournal, instID idutil.SafeID, step1CompensateCalls *atomic.Int64) {
+	t.Helper()
+	evsFinal, err := j.Load(context.Background(), instID)
 	if err != nil {
 		t.Fatalf("Load final: %v", err)
 	}
@@ -1051,13 +1085,6 @@ func TestIntegration_Compensation_LeaseLost_ResumesOnReclaim(t *testing.T) {
 	if !last.Kind.IsTerminal() {
 		t.Errorf("last event = %s, want terminal", last.Kind)
 	}
-	// coordinator-2's recovery: collectCommittedSteps filters step1 (already has
-	// KindStepCompensationFailed on the log from coordinator-1's partial attempt).
-	// The remaining compensation walk is empty — step1.Compensate is NOT re-run
-	// (idempotent: already attempted, not retried, #1181 F2). However,
-	// priorFailureCount > 0 so compensateErrors is seeded from history (#1181 F1):
-	// the recovery terminates with StatusCompensationFailed, not StatusCompensated,
-	// because the prior partial failure must not be silently discarded.
 	if last.Kind != journal.KindSagaCompensationFailed {
 		t.Errorf("last event = %s, want saga_compensation_failed (prior failure preserved across recovery)", last.Kind)
 	}

--- a/runtime/saga/leader_elect_test.go
+++ b/runtime/saga/leader_elect_test.go
@@ -427,6 +427,56 @@ func captureLeaderCoord(t *testing.T, clk *clockmock.FakeClock, locker distlock.
 	return c
 }
 
+// makeContentionLocker builds a Locker whose next SetNX returns false (simulates
+// contention / ErrLockTimeout).
+func makeContentionLocker(t *testing.T, clk *clockmock.FakeClock) distlock.Locker {
+	t.Helper()
+	fd := locktest.NewFakeDriverWithClock(clk.Now)
+	fd.SetNextSetNX(false)
+	l, err := distlock.New(fd, clk)
+	if err != nil {
+		t.Fatalf("distlock.New: %v", err)
+	}
+	return l
+}
+
+// makeNormalLocker builds a Locker backed by a default FakeDriver.
+func makeNormalLocker(t *testing.T, clk *clockmock.FakeClock) distlock.Locker {
+	t.Helper()
+	l, err := distlock.New(locktest.NewFakeDriverWithClock(clk.Now), clk)
+	if err != nil {
+		t.Fatalf("distlock.New: %v", err)
+	}
+	return l
+}
+
+// makeErrLocker builds a Locker whose SetNX always returns an I/O error.
+func makeErrLocker(t *testing.T, clk *clockmock.FakeClock) distlock.Locker {
+	t.Helper()
+	l, err := distlock.New(errSetNXDriver{}, clk)
+	if err != nil {
+		t.Fatalf("distlock.New: %v", err)
+	}
+	return l
+}
+
+// assertLeaderSkipLog checks that the captured log contains the expected level,
+// the skip message, and the lease_id field.
+func assertLeaderSkipLog(t *testing.T, logs, wantLevel string) {
+	t.Helper()
+	if !strings.Contains(logs, `"level":"`+wantLevel+`"`) {
+		t.Errorf("want level %s; logs=%s", wantLevel, logs)
+	}
+	if !strings.Contains(logs, "leader-elect skip") {
+		t.Errorf("missing skip message; logs=%s", logs)
+	}
+	// lease_id (journal fencing token) correlates the skip back to the
+	// ClaimPending cycle; claimedFixture sets LeaseID="lease-inst1".
+	if !strings.Contains(logs, `"lease_id":"lease-inst1"`) {
+		t.Errorf("skip log missing lease_id; logs=%s", logs)
+	}
+}
+
 // TestLogLeaderSkip_Levels asserts acquireLead logs the skip at the level
 // matching its cause: contention (ErrLockTimeout) and ctx cancellation → Debug
 // (expected operational signals); backend I/O error → Warn (fault).
@@ -439,28 +489,14 @@ func TestLogLeaderSkip_Levels(t *testing.T) {
 		wantLevel string
 	}{
 		{
-			name: "contention_debug",
-			locker: func(t *testing.T, clk *clockmock.FakeClock) distlock.Locker {
-				fd := locktest.NewFakeDriverWithClock(clk.Now)
-				fd.SetNextSetNX(false)
-				l, err := distlock.New(fd, clk)
-				if err != nil {
-					t.Fatalf("distlock.New: %v", err)
-				}
-				return l
-			},
+			name:      "contention_debug",
+			locker:    makeContentionLocker,
 			ctx:       context.Background,
 			wantLevel: "DEBUG",
 		},
 		{
-			name: "ctx_canceled_debug",
-			locker: func(t *testing.T, clk *clockmock.FakeClock) distlock.Locker {
-				l, err := distlock.New(locktest.NewFakeDriverWithClock(clk.Now), clk)
-				if err != nil {
-					t.Fatalf("distlock.New: %v", err)
-				}
-				return l
-			},
+			name:   "ctx_canceled_debug",
+			locker: makeNormalLocker,
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
@@ -469,14 +505,8 @@ func TestLogLeaderSkip_Levels(t *testing.T) {
 			wantLevel: "DEBUG",
 		},
 		{
-			name: "io_error_warn",
-			locker: func(t *testing.T, clk *clockmock.FakeClock) distlock.Locker {
-				l, err := distlock.New(errSetNXDriver{}, clk)
-				if err != nil {
-					t.Fatalf("distlock.New: %v", err)
-				}
-				return l
-			},
+			name:      "io_error_warn",
+			locker:    makeErrLocker,
 			ctx:       context.Background,
 			wantLevel: "WARN",
 		},
@@ -491,18 +521,7 @@ func TestLogLeaderSkip_Levels(t *testing.T) {
 			if lead {
 				t.Fatal("expected lead=false (acquire should fail)")
 			}
-			logs := buf.String()
-			if !strings.Contains(logs, `"level":"`+tc.wantLevel+`"`) {
-				t.Errorf("want level %s; logs=%s", tc.wantLevel, logs)
-			}
-			if !strings.Contains(logs, "leader-elect skip") {
-				t.Errorf("missing skip message; logs=%s", logs)
-			}
-			// lease_id (journal fencing token) correlates the skip back to the
-			// ClaimPending cycle; claimedFixture sets LeaseID="lease-inst1".
-			if !strings.Contains(logs, `"lease_id":"lease-inst1"`) {
-				t.Errorf("skip log missing lease_id; logs=%s", logs)
-			}
+			assertLeaderSkipLog(t, buf.String(), tc.wantLevel)
 		})
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -163,7 +163,7 @@ sonar.coverage.exclusions=\
 # go:S117  — Go naming allows abbreviations like dbURL, httpReq
 # go:S1192 — Table-driven tests intentionally repeat string literals for readability
 # go:S1186 — Empty func(){} in test tables are idiomatic Go noop handlers
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55
 
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S100
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
@@ -427,3 +427,183 @@ sonar.issue.ignore.multicriteria.e33.resourceKey=**/runtime/observability/health
 #            and e15 (EffectiveAdminCounterImpl).
 sonar.issue.ignore.multicriteria.e34.ruleKey=godre:S8196
 sonar.issue.ignore.multicriteria.e34.resourceKey=**/kernel/healthz/probe.go
+
+# go:S1186 — internal/pgexec/pgexec.go (4 copies under adapters/postgres,
+#            adapters/postgres/saga, cells/accesscore/.../postgres,
+#            examples/iotdevice/.../postgres) seal the PGExecutor interface via
+#            the unexported sealPGExecutor() marker method, intentionally empty:
+#            it closes the enumeration so external packages cannot implement
+#            PGExecutor (only the package-private pgExecutor satisfies it, routed
+#            through pgexec.ExecDirect). The body never runs; file godoc explains
+#            the seal pattern. Same idiom as e10 (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e35.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e35.resourceKey=**/internal/pgexec/pgexec.go
+
+# go:S1186 — pkg/errcode/details.go publicValue() marker methods (publicString /
+#            publicInt / publicBool / publicDuration / publicTime) are
+#            intentionally empty: publicValue is a sealed marker interface whose
+#            sole unexported method closes the PublicDetail.value type set so
+#            wire-unsafe types are compile-time unexpressible. The bodies never
+#            run; package godoc + DETAILS-SEALED-FIELD-FROZEN-01 archtest document
+#            the seal. Same idiom as e10 (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e36.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e36.resourceKey=**/pkg/errcode/details.go
+
+# go:S1186 — runtime/saga/executor/observer.go NopObserver method bodies
+#            (ObserveOutcome / ObserveRetry / ObserveHeartbeatFailure) are
+#            intentionally empty no-ops: NopObserver is the zero-cost default
+#            Observer used when no observer is wired, discarding all arguments by
+#            design. Same null-object justification model as e18
+#            (kernel/observability/metrics/nop.go) and e31 (NopEventCollector).
+sonar.issue.ignore.multicriteria.e37.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e37.resourceKey=**/runtime/saga/executor/observer.go
+
+# go:S1186 — kernel/healthz/probe.go isHealthzProbe() sealed marker method is
+#            intentionally empty: the unexported marker closes the Probe
+#            interface so external packages cannot forge a healthz probe (probes
+#            must be built via healthz.NewProbe). The body never runs; godoc
+#            explains the seal. Same idiom as e10 (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e38.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e38.resourceKey=**/kernel/healthz/probe.go
+
+# go:S1186 — kernel/healthz/ctxsafe.go isHealthzProbe() sealed marker method on
+#            the ctx-safe probe wrapper is intentionally empty for the same seal
+#            reason as e38 (probe.go): it closes the Probe interface. The body
+#            never runs. Same idiom as e10 (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e39.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e39.resourceKey=**/kernel/healthz/ctxsafe.go
+
+# go:S1186 — kernel/projection/cell_marker.go sealedCellCheckpointStore() marker
+#            method is intentionally empty: the unexported marker closes the
+#            CellCheckpointStore interface so external packages cannot implement
+#            it. The body never runs; godoc explains the seal pattern. Same idiom
+#            as e19/e20 (kernel/outbox + kernel/persistence cell_marker.go).
+sonar.issue.ignore.multicriteria.e40.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e40.resourceKey=**/kernel/projection/cell_marker.go
+
+# go:S1186 — kernel/webhook/signer.go sealed() marker method is intentionally
+#            empty: the unexported marker closes the Signer interface so external
+#            packages cannot supply an alternate webhook signer. The body never
+#            runs; godoc explains the seal. Same idiom as e10
+#            (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e41.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e41.resourceKey=**/kernel/webhook/signer.go
+
+# go:S1186 — kernel/webhook/verifier.go sealed() marker method is intentionally
+#            empty for the same seal reason as e41 (signer.go): it closes the
+#            Verifier interface. The body never runs. Same idiom as e10.
+sonar.issue.ignore.multicriteria.e42.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e42.resourceKey=**/kernel/webhook/verifier.go
+
+# go:S1186 — pkg/pgrepoapproved/pgrepoapproved.go approvedExecDirect() marker
+#            method is intentionally empty: the unexported marker closes the
+#            Approval interface so only pgrepoapproved-issued tokens can authorize
+#            raw ExecDirect. The body never runs; file godoc documents the seal +
+#            funnel. Same idiom as e10 (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e43.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e43.resourceKey=**/pkg/pgrepoapproved/pgrepoapproved.go
+
+# go:S1186 — runtime/auth/credentialfence/fencetoken.go isCredentialFenceToken()
+#            marker method is intentionally empty: the unexported marker closes
+#            the FenceToken interface so a credential fence token cannot be forged
+#            outside the package. The body never runs; godoc documents the seal +
+#            caller restriction. Same idiom as e10 (kernel/auth/auth_plan.go).
+sonar.issue.ignore.multicriteria.e44.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e44.resourceKey=**/runtime/auth/credentialfence/fencetoken.go
+
+# go:S1186 — adapters/mqtt/connection.go noopCollector method bodies
+#            (RecordReconnect / RecordSubscribeFailure) are intentionally empty
+#            no-ops: noopCollector is the null-object default MQTT metrics
+#            collector used when no metrics backend is wired, discarding all
+#            arguments by design. Same null-object justification model as e18
+#            (kernel/observability/metrics/nop.go) and e23 (NoopWatcherCollector).
+sonar.issue.ignore.multicriteria.e45.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e45.resourceKey=**/adapters/mqtt/connection.go
+
+# godre:S8196 — kernel/webhook/source.go SourceStore is a domain concept (a
+#            registry that resolves a SourceID), not a single-method verb role.
+#            An -er form (SourceStorer) is nonsensical and loses the "store"
+#            domain meaning. Same justification as e22 (metrics.Histogram) and e34
+#            (healthz.ProbeSet).
+sonar.issue.ignore.multicriteria.e46.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e46.resourceKey=**/kernel/webhook/source.go
+
+# godre:S8196 — runtime/audit/ledger/query_store.go QueryStore is a domain
+#            concept (read-side aggregator store with a Query capability),
+#            parallel to the audit Store; renaming to "Querier" would break the
+#            Store analogy and lose domain meaning. Same justification as e46
+#            (SourceStore) and e22 (metrics.Histogram).
+sonar.issue.ignore.multicriteria.e47.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e47.resourceKey=**/runtime/audit/ledger/query_store.go
+
+# godre:S8196 — pkg/pgrepoapproved/pgrepoapproved.go Approval is a sealed marker
+#            interface (closed by the unexported approvedExecDirect() method),
+#            not a behavior contract. An -er name (Approver) would mislead that
+#            external types may implement it, defeating the seal. Same
+#            justification model as e25/e27 (sealed marker interfaces).
+sonar.issue.ignore.multicriteria.e48.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e48.resourceKey=**/pkg/pgrepoapproved/pgrepoapproved.go
+
+# godre:S8196 — runtime/auth/credentialfence/fencetoken.go FenceToken is a sealed
+#            marker interface (closed by isCredentialFenceToken()), expressing a
+#            capability proof, not a verb role. An -er suffix would misrepresent
+#            it as externally implementable. Same justification as e48 (Approval)
+#            and e25 (session protocol sealed markers).
+sonar.issue.ignore.multicriteria.e49.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e49.resourceKey=**/runtime/auth/credentialfence/fencetoken.go
+
+# godre:S8196 — runtime/saga/executor/retry_policy.go jitterSource is an
+#            unexported package-internal interface whose method Int64N mirrors
+#            math/rand.Rand.Int64N (a source of jitter values). An -er form
+#            (jitterSourcer) is nonsensical; unexported internal contracts have no
+#            external naming pressure. Same justification as e22 (domain term).
+sonar.issue.ignore.multicriteria.e50.ruleKey=godre:S8196
+sonar.issue.ignore.multicriteria.e50.resourceKey=**/runtime/saga/executor/retry_policy.go
+
+# godre:S8242 — kernel/cell/base.go BaseCell.shutdownCtx is an intentional
+#            lifecycle field, not a smuggled request context: it is created in
+#            Start() and canceled in Stop(), and goroutines spawned by the cell
+#            use it (instead of context.Background()) so they observe cell
+#            shutdown. Passing it per-call would defeat the cell-owned cancel
+#            signal. Documented in the field godoc (base.go).
+sonar.issue.ignore.multicriteria.e51.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e51.resourceKey=**/kernel/cell/base.go
+
+# godre:S8242 — kernel/governance/validate.go Validator.runCtx holds the context
+#            for the current run() invocation, read by ctx-bound rule detection
+#            closures (VERIFY-06). run() overwrites it per invocation; the field
+#            is the deliberate single-read channel for detect funcs that cannot
+#            receive ctx as a parameter through the rule-table indirection.
+sonar.issue.ignore.multicriteria.e52.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e52.resourceKey=**/kernel/governance/validate.go
+
+# godre:S8242 — runtime/bootstrap/bootstrap.go ownerCtx is the long-lived
+#            assembly-runtime owner context (derived from runCtx before
+#            lifecycle.Start) handed to every lifecycle hook's OnStart, so workers
+#            respond to ownerCancel before lifecycle.Stop drains them. This is the
+#            controller-runtime owner-context pattern; passing it per-call would
+#            break the shutdown ordering. Documented in field godoc + ADR
+#            202605102000-adr-lifecycle-hook-ctx-semantics.md.
+sonar.issue.ignore.multicriteria.e53.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e53.resourceKey=**/runtime/bootstrap/bootstrap.go
+
+# godre:S8242 — runtime/bootstrap/lifecycle.go workCtx is the per-invocation
+#            OnStart context (child of the bootstrap ownerCtx) handed to every
+#            hook; workCancel is invoked BEFORE the LIFO rollback on partial Start
+#            failure so a failed hook's already-spawned goroutine is torn down
+#            before sibling OnStop. Written once under the Start goroutine, then
+#            read-only. Essential for correct rollback semantics (review P1-2);
+#            documented in field godoc + ADR 202605102000.
+sonar.issue.ignore.multicriteria.e54.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e54.resourceKey=**/runtime/bootstrap/lifecycle.go
+
+# godre:S8188 — runtime/saga/executor/executor.go heartbeat/step cancel funcs
+#            (stopHB at executeInner/RunWithHeartbeat, cancel at buildStepCtx) are
+#            not leaked: stopHB is always invoked via stopAndJoin() on every
+#            return path or a deferred cleanup, and buildStepCtx returns a wrapper
+#            closure (timer.Stop + cancel) that its caller (runAttempt) owns and
+#            defers. The rule's "defer immediately after creation" heuristic does
+#            not fit a cancel func that is intentionally handed to the caller /
+#            joined with the heartbeat goroutine.
+sonar.issue.ignore.multicriteria.e55.ruleKey=godre:S8188
+sonar.issue.ignore.multicriteria.e55.resourceKey=**/runtime/saga/executor/executor.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -163,7 +163,7 @@ sonar.coverage.exclusions=\
 # go:S117  — Go naming allows abbreviations like dbURL, httpReq
 # go:S1192 — Table-driven tests intentionally repeat string literals for readability
 # go:S1186 — Empty func(){} in test tables are idiomatic Go noop handlers
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55,e56
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55
 
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S100
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
@@ -609,16 +609,3 @@ sonar.issue.ignore.multicriteria.e54.resourceKey=**/runtime/bootstrap/lifecycle.
 #            joined with the heartbeat goroutine.
 sonar.issue.ignore.multicriteria.e55.ruleKey=godre:S8188
 sonar.issue.ignore.multicriteria.e55.resourceKey=**/runtime/saga/executor/executor.go
-
-# go:S1192 — adapters/mqtt/connection.go "mqtt: connection is closed" appears as
-#            the message argument of multiple errcode.New(...) calls. The
-#            MESSAGE-CONST-LITERAL-01 archtest (PII safety, ADR
-#            202605051730) mandates errcode message args be inline string
-#            literals (BasicLit), NOT named consts — a const Ident is rejected.
-#            Extracting this literal to a const is therefore mutually exclusive
-#            with the repo's stronger invariant, so S1192 is waived here. (Other
-#            sites in this file that are NOT errcode messages may still extract;
-#            this waiver is scoped to the file because the duplicated literal is
-#            an errcode message.)
-sonar.issue.ignore.multicriteria.e56.ruleKey=go:S1192
-sonar.issue.ignore.multicriteria.e56.resourceKey=**/adapters/mqtt/connection.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -163,7 +163,7 @@ sonar.coverage.exclusions=\
 # go:S117  — Go naming allows abbreviations like dbURL, httpReq
 # go:S1192 — Table-driven tests intentionally repeat string literals for readability
 # go:S1186 — Empty func(){} in test tables are idiomatic Go noop handlers
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55,e56
 
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S100
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
@@ -607,3 +607,16 @@ sonar.issue.ignore.multicriteria.e54.resourceKey=**/runtime/bootstrap/lifecycle.
 #            joined with the heartbeat goroutine.
 sonar.issue.ignore.multicriteria.e55.ruleKey=godre:S8188
 sonar.issue.ignore.multicriteria.e55.resourceKey=**/runtime/saga/executor/executor.go
+
+# go:S1192 — adapters/mqtt/connection.go "mqtt: connection is closed" appears as
+#            the message argument of multiple errcode.New(...) calls. The
+#            MESSAGE-CONST-LITERAL-01 archtest (PII safety, ADR
+#            202605051730) mandates errcode message args be inline string
+#            literals (BasicLit), NOT named consts — a const Ident is rejected.
+#            Extracting this literal to a const is therefore mutually exclusive
+#            with the repo's stronger invariant, so S1192 is waived here. (Other
+#            sites in this file that are NOT errcode messages may still extract;
+#            this waiver is scoped to the file because the duplicated literal is
+#            an errcode message.)
+sonar.issue.ignore.multicriteria.e56.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.e56.resourceKey=**/adapters/mqtt/connection.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -428,9 +428,11 @@ sonar.issue.ignore.multicriteria.e33.resourceKey=**/runtime/observability/health
 sonar.issue.ignore.multicriteria.e34.ruleKey=godre:S8196
 sonar.issue.ignore.multicriteria.e34.resourceKey=**/kernel/healthz/probe.go
 
-# go:S1186 — internal/pgexec/pgexec.go (4 copies under adapters/postgres,
-#            adapters/postgres/saga, cells/accesscore/.../postgres,
-#            examples/iotdevice/.../postgres) seal the PGExecutor interface via
+# go:S1186 — internal/pgexec/pgexec.go (4 production copies under
+#            adapters/postgres, adapters/postgres/saga, cells/accesscore/.../postgres,
+#            examples/iotdevice/.../postgres; the glob also matches an
+#            archtest_fixture-tagged copy under tools/, which is outside
+#            sonar.sources) seal the PGExecutor interface via
 #            the unexported sealPGExecutor() marker method, intentionally empty:
 #            it closes the enumeration so external packages cannot implement
 #            PGExecutor (only the package-private pgExecutor satisfies it, routed


### PR DESCRIPTION
## Summary

SonarCloud 项目 `ghbvf_gocell` 的 **71 个 OPEN/CONFIRMED code smell** 清零。分两条路径处理：

1. **真实坏味道 → 改代码**（S107 参数过多、S1192 字面量重复、S8193 多余变量、生产/测试认知复杂度）
2. **刻意生产模式被误报 → justified 豁免**（sealed marker S1186、单方法接口命名 S8196、生命周期 ctx-field S8242、executor cancel 误报 S8188），按既有 `e1–e34` 约定加 scoped + 注释说明的 `sonar.issue.ignore.multicriteria` 条目（e35–e55）

> 用户裁定：测试认知复杂度（S3776，~27 个 `_test.go`）**逐个重构**降到 ≤15，而非补 `_test.go` 全局豁免（尽管 `.golangci.yml` 已对测试文件豁免 gocognit）。

## 改动分类

### A. 真实代码修复
- **S107**：`sessionlogin.NewService` / `sessionrefresh.NewService` 收敛为 `NewServiceParams`（clk 保留位置参，符合 `CLOCK-POSITIONAL-INJECTION-01`）；`runHeartbeat` 11→7 参，引入未导出 `heartbeatConfig`（仅服务包内 `runHeartbeat`，不扩 runtime public surface）。全部调用点同步更新。
- **S1192**：`kernel/cell/base.go`、`storetest/suite.go`、`projectiontest/conformance.go` 抽常量；`adapters/mqtt/connection.go` 抽 `errClosed()` helper，5 处 `"mqtt: connection is closed"` errcode.New 折叠单源（helper 内仍内联 BasicLit，与 `MESSAGE-CONST-LITERAL-01` 兼容）——根因消除后**删除 e56 整文件豁免**，不以 file-level 粒度遮蔽同文件其它可抽取重复。
- **S3776（生产）**：`cmd/gocell/app/check.go` —— 复核为已 ≤15（旧扫描数据滞后），无需改。
- **S3776（测试，~27 个）**：逐个重构（table-driven 单 case 体抽 `runCase`/命名 helper/t.Run 切分，**零断言语义改动**），`gocognit -over 15` 全部无输出。

### B. Justified 豁免（e35–e55）
| 规则 | 范围 | 理由 |
|---|---|---|
| S1186 | pgexec / errcode-details / saga-observer / healthz-probe / projection-cell_marker / webhook-signer+verifier / pgrepoapproved / credentialfence / mqtt-noopCollector | sealed marker / null-object no-op |
| S8196 | SourceStore / QueryStore / Approval / FenceToken / jitterSource | domain 概念名 / sealed marker 接口 |
| S8242 | BaseCell.shutdownCtx / Validator.runCtx / bootstrap.ownerCtx / lifecycle.workCtx | 刻意生命周期 ctx 字段（ADR 202605102000） |
| S8188 | executor.go stopHB/cancel | 全返回路径经 stopAndJoin/defer/caller-owned，无泄漏 |

> review /fix 后续（commit `c8215a63f`）：原 e56（S1192 mqtt/connection.go）不再走豁免——改抽 `errClosed()` helper 单源化字面量、根因消除并删除该豁免（见 A 段 S1192）；e55（S8188）file-level 豁免按裁定保留不动。

## Test plan
- [x] `go build ./...` 通过
- [x] `go test ./...` 全绿（仅 3 个 **pre-existing** nightly-archtest 红，已在 clean `origin/develop` 复现，非本 PR 引入：`buildConnackError` MESSAGE-CONST / audit fixture `NewProtocol()` / webhook `MustSourceID`）
- [x] `golangci-lint run --new-from-merge-base=origin/develop ./...` → **0 issues**（CI PR gate）
- [x] `bash hack/verify-archtest-invariants.sh` → 4 核心 invariant 通过
- [x] 每个重构测试函数 `gocognit -over 15` 无输出

## 合并后
SonarCloud 重扫预期 71 → 0 真实 smell；剩余仅 e35–e55 justified 豁免（不计入 OPEN）。

> ⚠️ 重扫验证 gate：删 e56 后 `connection.go` 若仍报其它 S1192（如 `"client_id"` slog key 重复），需补抽常量方能维持 0；本地无法跑 Sonar，以合并前重扫为准。

Refs: SonarCloud ghbvf_gocell OPEN/CONFIRMED code smells

🤖 Generated with [Claude Code](https://claude.com/claude-code)

