### PR TITLE
docs(archtest): A5_ConsumerPathFunnel upstream Medium 永久上限，关闭 #1235 won't-do

### DIFF
--- a/docs/architecture/202605281200-adr-cell-development-external-repo.md
+++ b/docs/architecture/202605281200-adr-cell-development-external-repo.md
@@ -384,12 +384,22 @@ interface + private constructor，在 Go 语言下对于"谁可以调用 `fs.Wal
 | 方向 | 形态 | 评级 |
 |------|------|------|
 | 下游 Hard | A5 form-uniqueness：EvaluateConstString 解析 `filepath.Join` 每个 arg，命中 banned token ("cells", "cmd") 即 CI 红；consumer scope = kernel/governance + cmd/gocell + kernel/metadata（funnel 文件外） | **Hard** |
-| 上游 Medium | archtest caller-allowlist：Go 类型系统无法阻止包内代码任意调用 `filepath.Join`；A5 盲区负向自检补充 | **Medium（过渡形态）** |
+| 上游 Medium | archtest caller-allowlist：Go 类型系统无法阻止包内代码任意调用 `filepath.Join`；A5 盲区负向自检补充 | **Medium（Go 结构性上限）** |
 
-**EXITING 上游升级路径**：Locator sealed envelope（unexported result 类型 + 私有构造函数）/
-typed pathx 包 / 接受 Medium 上限（同 ENTERING）三条路径，
-由 **gh issue #1235** 跟踪显式 Hard 化任务。根据 ai-robust.md §"Funnel 双向锁评级"，
-Medium 上游 + Hard 下游是合法过渡形态；issue #1235 是该条款要求的必开跟踪 issue。
+**EXITING 上游为何不升 Hard（决策 2026-05-30，原 gh issue #1235 → won't-do）**：A5 ban 的语义目标是
+`filepath.Join(_, "cells"/"cmd", …)` 中的**字面量** layout token。评估过两条 Hard 化候选——
+**(A)** Locator sealed envelope（把 `MetadataSource.Path` / `CellMeta.File` 等 seal 成 unexported +
+envelope method）与 **(B)** typed pathx 包（`RelPath` newtype 收口派生）——**均不能**让该字面量在
+type system 层不可表达：字符串常量 `"cells"` 与标准库 public `filepath.Join` 在 Go 下永远可敲，
+seal 派生输出只让"正确派生"更便捷（"no need to reconstruct"），无法表达"**不能** reconstruct"。
+下游字面量 ban 仍只能靠 A5 archtest 兜，A/B 不增量提升上游可表达性。这与 ENTERING 轴
+（`fs.WalkDir` 标准库 public func）完全同构，亦与 `SPAN-SETATTR-HOLDER-SEAL-01` (#851) /
+`HEALTHZ-HOLDER-SEAL-01` (#893) 同范式的 Go 结构性不可达情形。A 方案另需改写 ~166 处 path 派生点
+（93 `.File` read + 73 derive）/ 5 个 metadata 类型 + printers raw-path 透传 + 破坏 M-series
+外部仓库公开 API（`CellMeta.File` 等是已暴露字段），换取 illusory Hard，工作量/收益严重失衡。
+故 ai-robust.md §"Funnel 双向锁评级""存在低成本 Hard 化路径"前提**不成立**，按同 §"ENTERING 上游
+为何不开升级 issue"同款判定，**不开/不留升级 issue**，Medium 是该形态的永久上限；gh issue #1235
+关闭为 won't-do。本 amendment 不改 A5 archtest 行为，下游 Hard 不变，无任何 §安全模型覆盖格降级。
 
 **path 单一真值源**：A5 funnel 的语义边界是 `MetadataSource.Path`（`Locator.Discover()` 输出）——
 governance / CLI 代码必须从 `MetadataSource.Path` / `CellMeta.File` / `SliceMeta.File` 等

--- a/docs/architecture/202605281200-adr-cell-development-external-repo.md
+++ b/docs/architecture/202605281200-adr-cell-development-external-repo.md
@@ -532,5 +532,5 @@ Medium（上游 + 下游残留）+ Hard 下游现实向量为合法过渡形态�
   `cmd/vendor/golang.org/x/mod/modfile/work.go`
 - 关联 ADR（Hard funnel 双向锁参考范式）:
   `docs/architecture/202604242030-adr-kernel-wrapper-contract-observability.md` §8
-- 关联 ADR（Medium 上游 + Hard 下游过渡形态论证范式）:
+- 关联 ADR（Medium 上游 + Hard 下游论证范式；A5 EXITING 轴已据此判定为永久上限 won't-do，见 §"EXITING 上游为何不升 Hard"）:
   `docs/architecture/202605271100-adr-probename-sealed-funnel.md` §AI-robust 评级

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -39,13 +39,18 @@
 //      AI-robust grading: upstream Medium (archtest caller allowlist) +
 //      downstream Hard (form uniqueness via const-eval arg scanning).
 //      Funnel EXITING upstream is Medium (archtest caller-allowlist + blind-spot
-//      self-check); upstream Hard 升级路径 (Locator sealed envelope /
-//      typed pathx package / accept Medium 上限) is tracked by gh issue #1235.
+//      self-check) and is a PERMANENT ceiling, same as A1/A2: the banned token
+//      is a string literal ("cells"/"cmd") and filepath.Join is a stdlib public
+//      func — neither can be made unexpressible by Go's type system. Locator
+//      sealed envelope / typed pathx were evaluated and rejected (sealing the
+//      derived path does not stop a literal "cells" being typed → illusory
+//      Hard); gh issue #1235 closed won't-do (2026-05-30).
 //
 // AI-robust grading: Medium upstream + Hard downstream is a final form per
-// ai-robust §"Funnel 双向锁评级". No follow-up issue is opened for A1/A2; the
+// ai-robust §"Funnel 双向锁评级". No follow-up issue is opened for A1/A2/A5; the
 // upstream ceiling is a Go-language limit, not a deferred TODO. See ADR
-// 202605281200. A5 upstream Hard tracking: gh issue #1235.
+// 202605281200 §"EXITING 上游为何不升 Hard". Same structural-unreachability
+// precedent as #851 / #893.
 
 package archtest
 
@@ -798,7 +803,10 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 // AI-robust grading:
 //   - Upstream: Medium (archtest caller allowlist; Go type system cannot
 //     prevent package-internal code from calling filepath.Join freely).
-//     Upstream Hard upgrade path tracked by gh issue #1235.
+//     This is a PERMANENT Go-language ceiling — the banned token is a string
+//     literal that Go cannot make unexpressible (same as A1/A2; precedent
+//     #851 / #893). gh issue #1235 closed won't-do (2026-05-30); no upgrade
+//     issue remains open. See package godoc + ADR 202605281200.
 //   - Downstream: Hard (form-uniqueness: EvaluateConstString resolves every
 //     filepath.Join argument; any arg that evaluates to a banned token fails).
 //

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -812,13 +812,16 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 //
 // Blind spots enforced by TestLOCATOR_DISCOVERY_FUNNEL_01_A5_BlindSpots.
 //
-// Two files are permanently allowlisted via locatorA5AllowedFiles:
+// Three files are permanently allowlisted via locatorA5AllowedFiles (full
+// rationale on the variable decl):
 //   - cmd/gocell/app/scaffold.go: write path (layout generator); does not
 //     consume discovery paths, produces them.
 //   - kernel/metadata/assembly_derive.go: "cmd" is the conventional output
 //     directory name for the cmd/<id>/main.go entrypoint, guarded by
 //     isConventionalAssemblyPath so Manifest-mode assemblies use
 //     path.Dir(asm.File)/main.go instead.
+//   - kernel/assembly/generator.go: write path; "assemblies"/"cmd" are the
+//     conventional scaffold output directory names, not discovery tokens.
 func TestLOCATOR_DISCOVERY_FUNNEL_01_A5_ConsumerPathFunnel(t *testing.T) {
 	diags := RunTyped(t, TypedOpts{Tests: false}, locatorConsumerScanPatterns(),
 		func(p *Pass) []Diagnostic {


### PR DESCRIPTION
## Summary

落地 #1235 的 **option C** 决策：A5_ConsumerPathFunnel 的 EXITING funnel 上游 **不升 Hard，关闭为 won't-do**。

分析（见 issue #1235 + 前置讨论）确认 A/B 两条 Hard 化候选均**不能真正实现 upstream-Hard**：
- A5 ban 的目标是 `filepath.Join(_, "cells"/"cmd", …)` 中的**字面量** token。
- 字符串常量 `"cells"` + 标准库 public `filepath.Join` 在 Go 下永远可表达，把 `MetadataSource.Path` / `CellMeta.File` seal 成 envelope（A）或 typed `RelPath`（B）只让"正确派生"更便捷，**无法表达"不能 reconstruct"** → illusory Hard。
- 与 ENTERING 轴（`fs.WalkDir` stdlib public func）完全同构，亦同 `SPAN-SETATTR-HOLDER-SEAL-01`(#851) / `HEALTHZ-HOLDER-SEAL-01`(#893) 的 Go 结构性不可达前例。
- A 方案另需改 ~166 处 path 派生点（93 `.File` read + 73 derive）/ 5 个 metadata 类型 + printers raw-path 透传 + 破坏 M-series 外部仓库公开 API，换 illusory Hard，工作量/收益严重失衡。

故按 ai-robust.md §"Funnel 双向锁评级"「存在低成本 Hard 化路径」前提**不成立**，比照 §"ENTERING 上游为何不开升级 issue" 同款判定不留升级 issue，Medium 是该形态的**永久上限**。

## Changes

- `docs/architecture/202605281200-adr-cell-development-external-repo.md` §EXITING：
  - 上游评级 `Medium（过渡形态）` → `Medium（Go 结构性上限）`
  - **重写**（非追加）原与决策矛盾的"EXITING 上游升级路径"段落 → 记录 won't-do 决策（遵 ai-robust §"ADR amendment 落地必查"：矛盾段落同 PR 重写）
- `tools/archtest/locator_discovery_funnel_test.go` godoc 3 处：`#1235 tracking` → `closed won't-do (2026-05-30)`，A1/A2 永久上限表述扩为 A1/A2/A5

## 行为/安全影响

- **A5 archtest 行为零变更**：仅改 ADR markdown + godoc 注释，下游 Hard 不变，无新增/删除 archtest。
- ADR amendment 落地必查：本 amendment 不触及任何 §安全模型 / 威胁矩阵覆盖格（A5 是 path-derivation 不变量，非安全控制），无 ✅→⚠️/❌ 降级。

## Test plan

- [x] `go build ./...` OK
- [x] `go test ./tools/archtest/ -run LOCATOR_DISCOVERY_FUNNEL_01_A5`（含 A5 ConsumerPathFunnel + BlindSpots）pass
- [x] `golangci-lint run ./tools/archtest/...` → 0 issues
- [x] 仓库内 `#1235` 残留引用全部表述为 "closed won't-do"（无 "tracked / will upgrade" 漂移）

Refs: LOCATOR-DISCOVERY-FUNNEL-01.A5
Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)