### PR TITLE
refactor(archtest): AFTERCOMMIT-HOOK-PURE-TRANSIENT-01 迁移到 module-path-agnostic [#1302]

### DIFF
--- a/tools/archtest/aftercommit_pure_transient_invariants.go
+++ b/tools/archtest/aftercommit_pure_transient_invariants.go
@@ -3,18 +3,25 @@ package archtest
 // aftercommit_pure_transient_invariants.go — importable rule logic for
 // AFTERCOMMIT-HOOK-PURE-TRANSIENT-01.
 //
-// This is the non-test home of the scanner so it can be compiled by external
-// consumers (Go never compiles a dependency's _test.go). GoCell's own
-// TestAfterCommitHookPureTransient_* tests (aftercommit_pure_transient_test.go)
-// call the shared helpers here — single source, no parallel rule body.
+// This is the non-test home of the scanner so it can be compiled and imported
+// by external Cell repositories (Go never compiles a dependency's _test.go).
+// GoCell's own TestAfterCommitHookPureTransient_* tests
+// (aftercommit_pure_transient_test.go) call the shared helpers here — single
+// source, no parallel rule body.
+//
+// Note: CheckAfterCommitHookPureTransient is importable but is NOT included in
+// StandardCellRules() — rule A3's drain-caller allowlist names GoCell-internal
+// TxRunner files, so running it against an external module's production code
+// would false-positive on any TxRunner implementation outside that allowlist.
+// External repos that dogfood this rule must maintain their own allowlist via
+// a wrapper. See external.go for the design and StandardCellRules for the
+// portable curated set.
 //
 // Platform-symbol paths (persistence.RegisterAfterCommit, outbox.Writer) are
 // anchored to [PlatformModulePath] (fixed: external repos import these packages
 // as a GoCell dependency at that path). The scan SCOPE is the running module,
-// supplied by RunTyped → findModuleRoot. See external.go for the design.
+// supplied by RunTyped → findModuleRoot.
 
-// INVARIANT: AFTERCOMMIT-HOOK-PURE-TRANSIENT-01
-//
 // aftercommit_pure_transient_invariants.go — funnel guarding persistence
 // after-commit hooks. Hooks run after a durable commit, with the tx stripped
 // from their ctx (kernel/persistence.RunAfterCommitHooks), and must perform
@@ -396,12 +403,23 @@ func scanHookBodyEscapes(p *Pass, rel string, lit *ast.FuncLit) []Diagnostic {
 }
 
 // CheckAfterCommitHookPureTransient runs AFTERCOMMIT-HOOK-PURE-TRANSIENT-01
-// (A1+A2+A3+BlindSpot) over the running module's production code and returns its
+// (A1+A2+A3) over the running module's production code and returns its
 // diagnostics. cfg.BuildTags is passed to the production scan so files behind
 // //go:build directives are covered.
+//
+// This function is intentionally NOT registered in StandardCellRules(): rule
+// A3's drain-caller allowlist names GoCell-internal TxRunner files, so running
+// it against an external module's production code would false-positive on any
+// TxRunner implementation outside that allowlist. GoCell's own dogfood calls
+// this directly from TestAfterCommitHookPureTransient.
+//
+// The B2/B3 blind-spot escape scan (scanRegisterAfterCommitEscapes) is
+// intentionally absent here — it is the dedicated reverse self-check owned by
+// TestAfterCommitHookPureTransient_BlindSpots_NoEscapeInProduction, not part
+// of the forward rule enforcement.
 func CheckAfterCommitHookPureTransient(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
-	var a1a2Diags, a3Diags, bsDiags []Diagnostic
+	var a1a2Diags, a3Diags []Diagnostic
 	_ = RunTypedProduction(t, TypedOpts{Tags: cfg.BuildTags}, func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
@@ -411,13 +429,11 @@ func CheckAfterCommitHookPureTransient(t *testing.T, cfg ConfigForExternalCell) 
 		for _, file := range p.Files {
 			a1a2Diags = append(a1a2Diags, scanRegisterAfterCommitHooks(p, file, localFuncs, ifaces)...)
 			a3Diags = append(a3Diags, scanAfterCommitDrainCallers(p, file)...)
-			bsDiags = append(bsDiags, scanRegisterAfterCommitEscapes(p, file)...)
 		}
 		return nil
 	})
 	var out []Diagnostic
 	out = append(out, a1a2Diags...)
 	out = append(out, a3Diags...)
-	out = append(out, bsDiags...)
 	return out
 }

--- a/tools/archtest/aftercommit_pure_transient_invariants.go
+++ b/tools/archtest/aftercommit_pure_transient_invariants.go
@@ -1,0 +1,423 @@
+package archtest
+
+// aftercommit_pure_transient_invariants.go — importable rule logic for
+// AFTERCOMMIT-HOOK-PURE-TRANSIENT-01.
+//
+// This is the non-test home of the scanner so it can be compiled by external
+// consumers (Go never compiles a dependency's _test.go). GoCell's own
+// TestAfterCommitHookPureTransient_* tests (aftercommit_pure_transient_test.go)
+// call the shared helpers here — single source, no parallel rule body.
+//
+// Platform-symbol paths (persistence.RegisterAfterCommit, outbox.Writer) are
+// anchored to [PlatformModulePath] (fixed: external repos import these packages
+// as a GoCell dependency at that path). The scan SCOPE is the running module,
+// supplied by RunTyped → findModuleRoot. See external.go for the design.
+
+// INVARIANT: AFTERCOMMIT-HOOK-PURE-TRANSIENT-01
+//
+// aftercommit_pure_transient_invariants.go — funnel guarding persistence
+// after-commit hooks. Hooks run after a durable commit, with the tx stripped
+// from their ctx (kernel/persistence.RunAfterCommitHooks), and must perform
+// only transient side effects (saga dispatcher kick, cache invalidation, metrics
+// flush, ws broadcast) — never a persistent operation.
+//
+// Funnel entry = persistence.RegisterAfterCommit(ctx, <hook>). Rules:
+//
+//	A1 The hook argument MUST be a func literal at the call site, so its body is
+//	   always inline-inspectable by A2. Named funcs and method values are
+//	   rejected.
+//	   AI-robust: Hard — (callee=RegisterAfterCommit, arg=FuncLit) form
+//	   uniqueness; any other form fails. Constructively closes blind spot B1.
+//
+//	A2 The hook literal body MUST NOT call a method on a value whose static type
+//	   is pgx.Tx, *database/sql.Tx, or outbox.Writer — resolved via
+//	   info.TypeOf(sel.X), NOT string anchors. A one-level heuristic also flags a
+//	   same-package unexported helper called from the body that itself touches a
+//	   banned type (blind spot B4).
+//	   AI-robust: Medium (NOT Hard — not over-claimed). Closure purity is
+//	   inter-procedurally undecidable: a hook can call a helper >1 level deep or
+//	   capture the enclosing txCtx. The floor is raised STRUCTURALLY, not just by
+//	   this archtest — RunAfterCommitHooks strips TxCtxKey, so the committed tx is
+//	   unreachable through the ctx a hook is handed. There is no low-cost path to
+//	   Hard for this rule shape (see B2/B3/B4); this Medium is the honest ceiling.
+//
+//	A3 persistence.WithAfterCommitRegistry / RunAfterCommitHooks may be called
+//	   only from the five TxRunner implementations (+ _test.go).
+//	   AI-robust: Hard downstream (callsite identity locked to an allowlist) /
+//	   Medium upstream (no type-level seal: the five runners span
+//	   cells+examples+adapters+kernel, so there is no shared internal/ boundary to
+//	   make the call unrepresentable elsewhere). Upstream Hard-seal tracked in
+//	   gh issue #920 (AFTERCOMMIT-DRAIN-CALLER-SEAL).
+//
+// Blind spots (ai-robust 强制反向自检; each has a reverse self-test in the
+// accompanying _test.go):
+//
+//	B1 — named-func / method-value hook arg → closed by A1 (fixture red_non_literal).
+//	B2 — hook body calls persistence.TxFromContext to fetch the committed tx →
+//	     defanged structurally by the TxCtxKey strip; reverse self-test asserts
+//	     no production hook body references persistence.TxFromContext.
+//	B3 — reflection (reflect.Value.MethodByName) to invoke a tx method → reverse
+//	     self-test asserts no production hook body uses MethodByName.
+//	B4 — hook body calls a same-package unexported helper that touches the tx →
+//	     A2's one-level heuristic catches the simplest case (fixture
+//	     red_local_helper); deeper chains remain uncaught (Medium, documented).
+//	     Scope caveat: the heuristic resolves only package-level funcs
+//	     (packageFuncDecls filters Recv==nil), so a same-package *method* helper
+//	     (obj.doWrite() whose body touches the tx) is a B4 deeper-chain miss, not
+//	     a separate gap.
+//
+// ref: spring-tx TransactionSynchronization (afterCommit semantics);
+//
+//	.claude/rules/gocell/ai-robust.md "typed marker funnel for unbounded ops" +
+//	"single sanctioned holder".
+
+import (
+	"go/ast"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/typesutil"
+)
+
+const (
+	ruleAfterCommitHookPureTransient = "AFTERCOMMIT-HOOK-PURE-TRANSIENT-01"
+	// persistencePkgPath is the canonical import path of the kernel/persistence
+	// package — a GoCell platform symbol path, anchored to PlatformModulePath so
+	// a module rename updates exactly one place.
+	persistencePkgPath     = PlatformModulePath + "/kernel/persistence"
+	registerAfterCommitFn  = "RegisterAfterCommit"
+	txFromContextFn        = "TxFromContext"
+	afterCommitFixturesDir = "aftercommit_pure_transient_fixtures"
+)
+
+// afterCommitDrainFns are the registry plumbing functions whose callers are
+// restricted to TxRunner implementations (rule A3).
+var afterCommitDrainFns = map[string]bool{
+	"WithAfterCommitRegistry": true,
+	"RunAfterCommitHooks":     true,
+	"AfterCommitMark":         true,
+	"TruncateAfterCommitTo":   true,
+}
+
+// afterCommitBannedReceivers maps "<pkgpath>.<TypeName>" → display label for
+// types a hook body may not call methods on (rule A2). Paths derived from
+// PlatformModulePath so a module rename updates exactly one place.
+var afterCommitBannedReceivers = map[string]string{
+	"github.com/jackc/pgx/v5.Tx":                 "pgx.Tx",
+	"database/sql.Tx":                            "*sql.Tx",
+	PlatformModulePath + "/kernel/outbox.Writer": "outbox.Writer",
+}
+
+// afterCommitDrainCallerAllowlist is the set of production files permitted to
+// call the registry plumbing funcs — exactly the five TxRunner implementations
+// (rule A3 downstream Hard).
+var afterCommitDrainCallerAllowlist = map[string]bool{
+	"adapters/postgres/tx_manager.go":                true,
+	"kernel/outbox/demo_tx_runner.go":                true,
+	"cells/accesscore/internal/mem/store.go":         true,
+	"cells/configcore/internal/testutil/testutil.go": true,
+	"examples/todoorder/run.go":                      true,
+}
+
+// resolvePkgFuncCall resolves a package-level function call (Selector form
+// pkg.Fn(...), including a generic instantiation pkg.Fn[T](...)) to its
+// declaring package path and name. Returns ok=false for method calls (non-nil
+// receiver), local unqualified calls, or non-func selectors.
+func resolvePkgFuncCall(info *types.Info, call *ast.CallExpr) (pkgPath, name string, ok bool) {
+	sel, isSel := unwrapGenericCallee(call.Fun).(*ast.SelectorExpr)
+	if !isSel {
+		return "", "", false
+	}
+	fn, isFunc := info.Uses[sel.Sel].(*types.Func)
+	if !isFunc || fn.Pkg() == nil {
+		return "", "", false
+	}
+	if sig, _ := fn.Type().(*types.Signature); sig != nil && sig.Recv() != nil {
+		return "", "", false
+	}
+	return fn.Pkg().Path(), fn.Name(), true
+}
+
+// unwrapGenericCallee strips a generic instantiation (Fn[T] / Fn[T1,T2]) to the
+// underlying callee expression, so a generic function such as
+// persistence.TxFromContext[pgx.Tx] resolves to its SelectorExpr rather than the
+// enclosing *ast.IndexExpr / *ast.IndexListExpr (the F4 generic-callee blind spot).
+func unwrapGenericCallee(fun ast.Expr) ast.Expr {
+	switch f := fun.(type) {
+	case *ast.IndexExpr:
+		return f.X
+	case *ast.IndexListExpr:
+		return f.X
+	default:
+		return fun
+	}
+}
+
+// bannedReceiver pairs a resolved banned interface with its display label.
+type bannedReceiver struct {
+	label string
+	iface *types.Interface
+}
+
+// resolveBannedReceivers resolves the banned *interface* receiver types
+// (pgx.Tx, outbox.Writer) from pkg's transitive import closure, once per Pass.
+// *database/sql.Tx is a concrete struct and is matched by exact name, not here.
+func resolveBannedReceivers(pkg *types.Package) []bannedReceiver {
+	var out []bannedReceiver
+	for _, b := range []struct{ path, name, label string }{
+		{"github.com/jackc/pgx/v5", "Tx", "pgx.Tx"},
+		{PlatformModulePath + "/kernel/outbox", "Writer", "outbox.Writer"},
+	} {
+		if iface := lookupInterface(pkg, b.path, b.name); iface != nil {
+			out = append(out, bannedReceiver{label: b.label, iface: iface})
+		}
+	}
+	return out
+}
+
+func lookupInterface(root *types.Package, path, name string) *types.Interface {
+	pkg := findImportedPackage(root, path)
+	if pkg == nil {
+		return nil
+	}
+	obj := pkg.Scope().Lookup(name)
+	if obj == nil {
+		return nil
+	}
+	iface, _ := obj.Type().Underlying().(*types.Interface)
+	return iface
+}
+
+func findImportedPackage(root *types.Package, path string) *types.Package {
+	seen := map[string]bool{}
+	var walk func(*types.Package) *types.Package
+	walk = func(p *types.Package) *types.Package {
+		if p.Path() == path {
+			return p
+		}
+		if seen[p.Path()] {
+			return nil
+		}
+		seen[p.Path()] = true
+		for _, imp := range p.Imports() {
+			if found := walk(imp); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+	return walk(root)
+}
+
+// bannedReceiverLabel reports the display label when sel.X's static type is a
+// banned receiver: the concrete *database/sql.Tx (exact name, one pointer deref)
+// OR any type that implements a banned interface (pgx.Tx / outbox.Writer) —
+// types.Implements, so sealed wrappers (outbox.CellWriter) and other
+// implementers are caught, not just the exact named interface.
+func bannedReceiverLabel(info *types.Info, sel *ast.SelectorExpr, ifaces []bannedReceiver) (string, bool) {
+	t := info.TypeOf(sel.X)
+	if t == nil {
+		return "", false
+	}
+	// 1. Exact concrete match (deref one pointer level for *sql.Tx).
+	nt := t
+	if ptr, isPtr := nt.(*types.Pointer); isPtr {
+		nt = ptr.Elem()
+	}
+	if named, isNamed := nt.(*types.Named); isNamed && named.Obj() != nil && named.Obj().Pkg() != nil {
+		if label, ok := afterCommitBannedReceivers[named.Obj().Pkg().Path()+"."+named.Obj().Name()]; ok {
+			return label, true
+		}
+	}
+	// 2. Implements a banned interface (value or pointer receiver).
+	for _, b := range ifaces {
+		if implementsBannedIface(t, b.iface) {
+			return b.label, true
+		}
+	}
+	return "", false
+}
+
+func implementsBannedIface(t types.Type, iface *types.Interface) bool {
+	return typesutil.ImplementsInterface(t, iface)
+}
+
+// packageFuncDecls maps unexported package-level func name → its FuncDecl across
+// all files of the Pass, for the A2 one-level helper heuristic (B4).
+func packageFuncDecls(p *Pass) map[string]*ast.FuncDecl {
+	decls := map[string]*ast.FuncDecl{}
+	for _, f := range p.Files {
+		EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+			if fd.Recv == nil && fd.Body != nil {
+				decls[fd.Name.Name] = fd
+			}
+		})
+	}
+	return decls
+}
+
+// helperTouchesBannedReceiver reports whether ident refers to a same-package
+// func whose body (one level) calls a banned-receiver method.
+func helperTouchesBannedReceiver(p *Pass, ident *ast.Ident, localFuncs map[string]*ast.FuncDecl, ifaces []bannedReceiver) (string, bool) {
+	fn, ok := p.TypesInfo.Uses[ident].(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != p.Pkg.Path() {
+		return "", false
+	}
+	decl, ok := localFuncs[fn.Name()]
+	if !ok {
+		return "", false
+	}
+	var label string
+	EachInSubtree[ast.CallExpr](decl.Body, func(c *ast.CallExpr) {
+		if sel, isSel := c.Fun.(*ast.SelectorExpr); isSel {
+			if l, banned := bannedReceiverLabel(p.TypesInfo, sel, ifaces); banned {
+				label = l
+			}
+		}
+	})
+	return label, label != ""
+}
+
+func afterCommitDiag(p *Pass, node ast.Node, rel, msg string) Diagnostic {
+	return Diagnostic{Rel: rel, Line: p.Fset.Position(node.Pos()).Line, Message: msg}
+}
+
+// scanRegisterAfterCommitHooks implements A1 + A2 over one file.
+func scanRegisterAfterCommitHooks(p *Pass, file *ast.File, localFuncs map[string]*ast.FuncDecl, ifaces []bannedReceiver) []Diagnostic {
+	info := p.TypesInfo
+	rel := p.Rel(file)
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := resolvePkgFuncCall(info, call)
+		if !ok || pkgPath != persistencePkgPath || name != registerAfterCommitFn || len(call.Args) < 2 {
+			return
+		}
+		lit, isLit := call.Args[1].(*ast.FuncLit)
+		if !isLit {
+			out = append(out, afterCommitDiag(p, call.Args[1], rel,
+				ruleAfterCommitHookPureTransient+"-A1: RegisterAfterCommit hook must be a func literal at the call site; "+
+					"named funcs and method values defeat body inspection"))
+			return
+		}
+		out = append(out, scanHookBodyTransient(p, rel, lit, localFuncs, ifaces)...)
+	})
+	return out
+}
+
+// scanHookBodyTransient implements A2 over one hook literal body.
+func scanHookBodyTransient(
+	p *Pass, rel string, lit *ast.FuncLit, localFuncs map[string]*ast.FuncDecl, ifaces []bannedReceiver,
+) []Diagnostic {
+	info := p.TypesInfo
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](lit.Body, func(call *ast.CallExpr) {
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if label, banned := bannedReceiverLabel(info, fun, ifaces); banned {
+				out = append(out, afterCommitDiag(p, fun, rel,
+					ruleAfterCommitHookPureTransient+"-A2: after-commit hook must be transient; it calls a method on "+
+						label+" (persistent side effects belong in the tx body)"))
+			}
+		case *ast.Ident:
+			if label, viaHelper := helperTouchesBannedReceiver(p, fun, localFuncs, ifaces); viaHelper {
+				out = append(out, afterCommitDiag(p, fun, rel,
+					ruleAfterCommitHookPureTransient+"-A2: after-commit hook calls local helper "+fun.Name+
+						" that touches a "+label+" (one-level heuristic; Medium)"))
+			}
+		}
+	})
+	return out
+}
+
+// scanAfterCommitDrainCallers implements A3 over one file.
+func scanAfterCommitDrainCallers(p *Pass, file *ast.File) []Diagnostic {
+	rel := p.Rel(file)
+	if strings.HasSuffix(rel, "_test.go") || afterCommitDrainCallerAllowlist[filepath.ToSlash(rel)] {
+		return nil
+	}
+	info := p.TypesInfo
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := resolvePkgFuncCall(info, call)
+		if !ok || pkgPath != persistencePkgPath || !afterCommitDrainFns[name] {
+			return
+		}
+		out = append(out, afterCommitDiag(p, call, rel,
+			ruleAfterCommitHookPureTransient+"-A3: persistence."+name+" may only be called from a TxRunner implementation; "+
+				rel+" is not in the allowlist"))
+	})
+	return out
+}
+
+func afterCommitFixturePattern(fix string) (dir, pattern string) {
+	return filepath.Join("tools", "archtest", "testdata", afterCommitFixturesDir, fix),
+		"./tools/archtest/testdata/" + afterCommitFixturesDir + "/" + fix
+}
+
+// scanRegisterAfterCommitEscapes runs the B2/B3 escape scan over every
+// RegisterAfterCommit func-literal hook in file.
+func scanRegisterAfterCommitEscapes(p *Pass, file *ast.File) []Diagnostic {
+	rel := p.Rel(file)
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := resolvePkgFuncCall(p.TypesInfo, call)
+		if !ok || pkgPath != persistencePkgPath || name != registerAfterCommitFn || len(call.Args) < 2 {
+			return
+		}
+		lit, isLit := call.Args[1].(*ast.FuncLit)
+		if !isLit {
+			return
+		}
+		out = append(out, scanHookBodyEscapes(p, rel, lit)...)
+	})
+	return out
+}
+
+// scanHookBodyEscapes flags B2 (persistence.TxFromContext) and B3
+// (reflect Value.MethodByName) inside a hook body.
+func scanHookBodyEscapes(p *Pass, rel string, lit *ast.FuncLit) []Diagnostic {
+	info := p.TypesInfo
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](lit.Body, func(call *ast.CallExpr) {
+		if pkgPath, name, ok := resolvePkgFuncCall(info, call); ok &&
+			pkgPath == persistencePkgPath && name == txFromContextFn {
+			out = append(out, afterCommitDiag(p, call, rel,
+				ruleAfterCommitHookPureTransient+"-B2: after-commit hook must not call persistence.TxFromContext to reach the committed tx"))
+			return
+		}
+		if sel, isSel := call.Fun.(*ast.SelectorExpr); isSel && sel.Sel.Name == "MethodByName" {
+			out = append(out, afterCommitDiag(p, call, rel,
+				ruleAfterCommitHookPureTransient+"-B3: after-commit hook must not use reflection (MethodByName) to invoke a tx method"))
+		}
+	})
+	return out
+}
+
+// CheckAfterCommitHookPureTransient runs AFTERCOMMIT-HOOK-PURE-TRANSIENT-01
+// (A1+A2+A3+BlindSpot) over the running module's production code and returns its
+// diagnostics. cfg.BuildTags is passed to the production scan so files behind
+// //go:build directives are covered.
+func CheckAfterCommitHookPureTransient(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	var a1a2Diags, a3Diags, bsDiags []Diagnostic
+	_ = RunTypedProduction(t, TypedOpts{Tags: cfg.BuildTags}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		localFuncs := packageFuncDecls(p)
+		ifaces := resolveBannedReceivers(p.Pkg)
+		for _, file := range p.Files {
+			a1a2Diags = append(a1a2Diags, scanRegisterAfterCommitHooks(p, file, localFuncs, ifaces)...)
+			a3Diags = append(a3Diags, scanAfterCommitDrainCallers(p, file)...)
+			bsDiags = append(bsDiags, scanRegisterAfterCommitEscapes(p, file)...)
+		}
+		return nil
+	})
+	var out []Diagnostic
+	out = append(out, a1a2Diags...)
+	out = append(out, a3Diags...)
+	out = append(out, bsDiags...)
+	return out
+}

--- a/tools/archtest/aftercommit_pure_transient_invariants.go
+++ b/tools/archtest/aftercommit_pure_transient_invariants.go
@@ -21,10 +21,10 @@ package archtest
 // anchored to [PlatformModulePath] (fixed: external repos import these packages
 // as a GoCell dependency at that path). The scan SCOPE is the running module,
 // supplied by RunTyped → findModuleRoot.
-
-// aftercommit_pure_transient_invariants.go — funnel guarding persistence
-// after-commit hooks. Hooks run after a durable commit, with the tx stripped
-// from their ctx (kernel/persistence.RunAfterCommitHooks), and must perform
+//
+// Funnel: guards persistence after-commit hooks. Hooks run after a durable
+// commit, with the tx stripped from their ctx
+// (kernel/persistence.RunAfterCommitHooks), and must perform
 // only transient side effects (saga dispatcher kick, cache invalidation, metrics
 // flush, ws broadcast) — never a persistent operation.
 //
@@ -82,6 +82,7 @@ import (
 	"go/ast"
 	"go/types"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -251,8 +252,10 @@ func implementsBannedIface(t types.Type, iface *types.Interface) bool {
 	return typesutil.ImplementsInterface(t, iface)
 }
 
-// packageFuncDecls maps unexported package-level func name → its FuncDecl across
-// all files of the Pass, for the A2 one-level helper heuristic (B4).
+// packageFuncDecls maps each package-level func name (exported or not) → its
+// FuncDecl across all files of the Pass, for the A2 one-level helper heuristic
+// (B4). Methods are excluded (Recv != nil); a same-package method helper is the
+// documented B4 deeper-chain miss.
 func packageFuncDecls(p *Pass) map[string]*ast.FuncDecl {
 	decls := map[string]*ast.FuncDecl{}
 	for _, f := range p.Files {
@@ -435,5 +438,11 @@ func CheckAfterCommitHookPureTransient(t *testing.T, cfg ConfigForExternalCell) 
 	var out []Diagnostic
 	out = append(out, a1a2Diags...)
 	out = append(out, a3Diags...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Rel != out[j].Rel {
+			return out[i].Rel < out[j].Rel
+		}
+		return out[i].Line < out[j].Line
+	})
 	return out
 }

--- a/tools/archtest/aftercommit_pure_transient_test.go
+++ b/tools/archtest/aftercommit_pure_transient_test.go
@@ -1,343 +1,29 @@
 // INVARIANT: AFTERCOMMIT-HOOK-PURE-TRANSIENT-01
 //
-// aftercommit_pure_transient_test.go — funnel guarding persistence after-commit
-// hooks. Hooks run after a durable commit, with the tx stripped from their ctx
-// (kernel/persistence.RunAfterCommitHooks), and must perform only transient
-// side effects (saga dispatcher kick, cache invalidation, metrics flush, ws
-// broadcast) — never a persistent operation.
+// aftercommit_pure_transient_test.go — test entry points for
+// AFTERCOMMIT-HOOK-PURE-TRANSIENT-01. Rule logic, consts, and shared scan
+// helpers live in aftercommit_pure_transient_invariants.go (the non-test file,
+// so external Cell repos can compile it via StandardCellRules). This file
+// dogfoods those shared helpers against GoCell itself — single source, no
+// parallel rule body.
 //
-// Funnel entry = persistence.RegisterAfterCommit(ctx, <hook>). Rules:
-//
-//	A1 [TestAfterCommitHookPureTransient_A1A2_Fixtures / _Production]
-//	   The hook argument MUST be a func literal at the call site, so its body is
-//	   always inline-inspectable by A2. Named funcs and method values are
-//	   rejected.
-//	   AI-robust: Hard — (callee=RegisterAfterCommit, arg=FuncLit) form
-//	   uniqueness; any other form fails. Constructively closes blind spot B1.
-//
-//	A2 [TestAfterCommitHookPureTransient_A1A2_Fixtures / _Production]
-//	   The hook literal body MUST NOT call a method on a value whose static type
-//	   is pgx.Tx, *database/sql.Tx, or outbox.Writer — resolved via
-//	   info.TypeOf(sel.X), NOT string anchors. A one-level heuristic also flags a
-//	   same-package unexported helper called from the body that itself touches a
-//	   banned type (blind spot B4).
-//	   AI-robust: Medium (NOT Hard — not over-claimed). Closure purity is
-//	   inter-procedurally undecidable: a hook can call a helper >1 level deep or
-//	   capture the enclosing txCtx. The floor is raised STRUCTURALLY, not just by
-//	   this archtest — RunAfterCommitHooks strips TxCtxKey, so the committed tx is
-//	   unreachable through the ctx a hook is handed. There is no low-cost path to
-//	   Hard for this rule shape (see B2/B3/B4); this Medium is the honest ceiling.
-//
-//	A3 [TestAfterCommitHookPureTransient_A3_Fixture / _Production]
-//	   persistence.WithAfterCommitRegistry / RunAfterCommitHooks may be called
-//	   only from the five TxRunner implementations (+ _test.go).
-//	   AI-robust: Hard downstream (callsite identity locked to an allowlist) /
-//	   Medium upstream (no type-level seal: the five runners span
-//	   cells+examples+adapters+kernel, so there is no shared internal/ boundary to
-//	   make the call unrepresentable elsewhere). Upstream Hard-seal tracked in
-//	   gh issue #920 (AFTERCOMMIT-DRAIN-CALLER-SEAL).
-//
-// Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
-//
-//	B1 — named-func / method-value hook arg → closed by A1 (fixture red_non_literal).
-//	B2 — hook body calls persistence.TxFromContext to fetch the committed tx →
-//	     defanged structurally by the TxCtxKey strip; reverse self-test asserts
-//	     no production hook body references persistence.TxFromContext.
-//	B3 — reflection (reflect.Value.MethodByName) to invoke a tx method → reverse
-//	     self-test asserts no production hook body uses MethodByName.
-//	B4 — hook body calls a same-package unexported helper that touches the tx →
-//	     A2's one-level heuristic catches the simplest case (fixture
-//	     red_local_helper); deeper chains remain uncaught (Medium, documented).
-//	     Scope caveat: the heuristic resolves only package-level funcs
-//	     (packageFuncDecls filters Recv==nil), so a same-package *method* helper
-//	     (obj.doWrite() whose body touches the tx) is a B4 deeper-chain miss, not
-//	     a separate gap.
-//
-// ref: spring-tx TransactionSynchronization (afterCommit semantics);
-//
-//	.claude/rules/gocell/ai-robust.md "typed marker funnel for unbounded ops" +
-//	"single sanctioned holder".
+// Production dogfood: one-liner via CheckAfterCommitHookPureTransient.
+// Fixture/RED tests: RunTypedFixture against testdata/ fixture dirs, reusing
+// the shared per-Pass scan helpers from the non-test file.
 package archtest
 
 import (
-	"go/ast"
-	"go/types"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/ghbvf/gocell/tools/typesutil"
 )
 
-const (
-	afterCommitRuleID      = "AFTERCOMMIT-HOOK-PURE-TRANSIENT-01"
-	persistencePkgPath     = "github.com/ghbvf/gocell/kernel/persistence"
-	registerAfterCommitFn  = "RegisterAfterCommit"
-	txFromContextFn        = "TxFromContext"
-	afterCommitFixturesDir = "aftercommit_pure_transient_fixtures"
-)
-
-// afterCommitDrainFns are the registry plumbing functions whose callers are
-// restricted to TxRunner implementations (rule A3).
-var afterCommitDrainFns = map[string]bool{
-	"WithAfterCommitRegistry": true,
-	"RunAfterCommitHooks":     true,
-	"AfterCommitMark":         true,
-	"TruncateAfterCommitTo":   true,
-}
-
-// afterCommitBannedReceivers maps "<pkgpath>.<TypeName>" → display label for
-// types a hook body may not call methods on (rule A2).
-var afterCommitBannedReceivers = map[string]string{
-	"github.com/jackc/pgx/v5.Tx":                   "pgx.Tx",
-	"database/sql.Tx":                              "*sql.Tx",
-	"github.com/ghbvf/gocell/kernel/outbox.Writer": "outbox.Writer",
-}
-
-// afterCommitDrainCallerAllowlist is the set of production files permitted to
-// call the registry plumbing funcs — exactly the five TxRunner implementations
-// (rule A3 downstream Hard).
-var afterCommitDrainCallerAllowlist = map[string]bool{
-	"adapters/postgres/tx_manager.go":                true,
-	"kernel/outbox/demo_tx_runner.go":                true,
-	"cells/accesscore/internal/mem/store.go":         true,
-	"cells/configcore/internal/testutil/testutil.go": true,
-	"examples/todoorder/run.go":                      true,
-}
-
-// resolvePkgFuncCall resolves a package-level function call (Selector form
-// pkg.Fn(...), including a generic instantiation pkg.Fn[T](...)) to its
-// declaring package path and name. Returns ok=false for method calls (non-nil
-// receiver), local unqualified calls, or non-func selectors.
-func resolvePkgFuncCall(info *types.Info, call *ast.CallExpr) (pkgPath, name string, ok bool) {
-	sel, isSel := unwrapGenericCallee(call.Fun).(*ast.SelectorExpr)
-	if !isSel {
-		return "", "", false
-	}
-	fn, isFunc := info.Uses[sel.Sel].(*types.Func)
-	if !isFunc || fn.Pkg() == nil {
-		return "", "", false
-	}
-	if sig, _ := fn.Type().(*types.Signature); sig != nil && sig.Recv() != nil {
-		return "", "", false
-	}
-	return fn.Pkg().Path(), fn.Name(), true
-}
-
-// unwrapGenericCallee strips a generic instantiation (Fn[T] / Fn[T1,T2]) to the
-// underlying callee expression, so a generic function such as
-// persistence.TxFromContext[pgx.Tx] resolves to its SelectorExpr rather than the
-// enclosing *ast.IndexExpr / *ast.IndexListExpr (the F4 generic-callee blind spot).
-func unwrapGenericCallee(fun ast.Expr) ast.Expr {
-	switch f := fun.(type) {
-	case *ast.IndexExpr:
-		return f.X
-	case *ast.IndexListExpr:
-		return f.X
-	default:
-		return fun
-	}
-}
-
-// bannedReceiver pairs a resolved banned interface with its display label.
-type bannedReceiver struct {
-	label string
-	iface *types.Interface
-}
-
-// resolveBannedReceivers resolves the banned *interface* receiver types
-// (pgx.Tx, outbox.Writer) from pkg's transitive import closure, once per Pass.
-// *database/sql.Tx is a concrete struct and is matched by exact name, not here.
-func resolveBannedReceivers(pkg *types.Package) []bannedReceiver {
-	var out []bannedReceiver
-	for _, b := range []struct{ path, name, label string }{
-		{"github.com/jackc/pgx/v5", "Tx", "pgx.Tx"},
-		{"github.com/ghbvf/gocell/kernel/outbox", "Writer", "outbox.Writer"},
-	} {
-		if iface := lookupInterface(pkg, b.path, b.name); iface != nil {
-			out = append(out, bannedReceiver{label: b.label, iface: iface})
-		}
-	}
-	return out
-}
-
-func lookupInterface(root *types.Package, path, name string) *types.Interface {
-	pkg := findImportedPackage(root, path)
-	if pkg == nil {
-		return nil
-	}
-	obj := pkg.Scope().Lookup(name)
-	if obj == nil {
-		return nil
-	}
-	iface, _ := obj.Type().Underlying().(*types.Interface)
-	return iface
-}
-
-func findImportedPackage(root *types.Package, path string) *types.Package {
-	seen := map[string]bool{}
-	var walk func(*types.Package) *types.Package
-	walk = func(p *types.Package) *types.Package {
-		if p.Path() == path {
-			return p
-		}
-		if seen[p.Path()] {
-			return nil
-		}
-		seen[p.Path()] = true
-		for _, imp := range p.Imports() {
-			if found := walk(imp); found != nil {
-				return found
-			}
-		}
-		return nil
-	}
-	return walk(root)
-}
-
-// bannedReceiverLabel reports the display label when sel.X's static type is a
-// banned receiver: the concrete *database/sql.Tx (exact name, one pointer deref)
-// OR any type that implements a banned interface (pgx.Tx / outbox.Writer) —
-// types.Implements, so sealed wrappers (outbox.CellWriter) and other
-// implementers are caught, not just the exact named interface.
-func bannedReceiverLabel(info *types.Info, sel *ast.SelectorExpr, ifaces []bannedReceiver) (string, bool) {
-	t := info.TypeOf(sel.X)
-	if t == nil {
-		return "", false
-	}
-	// 1. Exact concrete match (deref one pointer level for *sql.Tx).
-	nt := t
-	if ptr, isPtr := nt.(*types.Pointer); isPtr {
-		nt = ptr.Elem()
-	}
-	if named, isNamed := nt.(*types.Named); isNamed && named.Obj() != nil && named.Obj().Pkg() != nil {
-		if label, ok := afterCommitBannedReceivers[named.Obj().Pkg().Path()+"."+named.Obj().Name()]; ok {
-			return label, true
-		}
-	}
-	// 2. Implements a banned interface (value or pointer receiver).
-	for _, b := range ifaces {
-		if implementsBannedIface(t, b.iface) {
-			return b.label, true
-		}
-	}
-	return "", false
-}
-
-func implementsBannedIface(t types.Type, iface *types.Interface) bool {
-	return typesutil.ImplementsInterface(t, iface)
-}
-
-// packageFuncDecls maps unexported package-level func name → its FuncDecl across
-// all files of the Pass, for the A2 one-level helper heuristic (B4).
-func packageFuncDecls(p *Pass) map[string]*ast.FuncDecl {
-	decls := map[string]*ast.FuncDecl{}
-	for _, f := range p.Files {
-		EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-			if fd.Recv == nil && fd.Body != nil {
-				decls[fd.Name.Name] = fd
-			}
-		})
-	}
-	return decls
-}
-
-// helperTouchesBannedReceiver reports whether ident refers to a same-package
-// func whose body (one level) calls a banned-receiver method.
-func helperTouchesBannedReceiver(p *Pass, ident *ast.Ident, localFuncs map[string]*ast.FuncDecl, ifaces []bannedReceiver) (string, bool) {
-	fn, ok := p.TypesInfo.Uses[ident].(*types.Func)
-	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != p.Pkg.Path() {
-		return "", false
-	}
-	decl, ok := localFuncs[fn.Name()]
-	if !ok {
-		return "", false
-	}
-	var label string
-	EachInSubtree[ast.CallExpr](decl.Body, func(c *ast.CallExpr) {
-		if sel, isSel := c.Fun.(*ast.SelectorExpr); isSel {
-			if l, banned := bannedReceiverLabel(p.TypesInfo, sel, ifaces); banned {
-				label = l
-			}
-		}
-	})
-	return label, label != ""
-}
-
-func afterCommitDiag(p *Pass, node ast.Node, rel, msg string) Diagnostic {
-	return Diagnostic{Rel: rel, Line: p.Fset.Position(node.Pos()).Line, Message: msg}
-}
-
-// scanRegisterAfterCommitHooks implements A1 + A2 over one file.
-func scanRegisterAfterCommitHooks(p *Pass, file *ast.File, localFuncs map[string]*ast.FuncDecl, ifaces []bannedReceiver) []Diagnostic {
-	info := p.TypesInfo
-	rel := p.Rel(file)
-	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, name, ok := resolvePkgFuncCall(info, call)
-		if !ok || pkgPath != persistencePkgPath || name != registerAfterCommitFn || len(call.Args) < 2 {
-			return
-		}
-		lit, isLit := call.Args[1].(*ast.FuncLit)
-		if !isLit {
-			out = append(out, afterCommitDiag(p, call.Args[1], rel,
-				afterCommitRuleID+"-A1: RegisterAfterCommit hook must be a func literal at the call site; "+
-					"named funcs and method values defeat body inspection"))
-			return
-		}
-		out = append(out, scanHookBodyTransient(p, rel, lit, localFuncs, ifaces)...)
-	})
-	return out
-}
-
-// scanHookBodyTransient implements A2 over one hook literal body.
-func scanHookBodyTransient(
-	p *Pass, rel string, lit *ast.FuncLit, localFuncs map[string]*ast.FuncDecl, ifaces []bannedReceiver,
-) []Diagnostic {
-	info := p.TypesInfo
-	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](lit.Body, func(call *ast.CallExpr) {
-		switch fun := call.Fun.(type) {
-		case *ast.SelectorExpr:
-			if label, banned := bannedReceiverLabel(info, fun, ifaces); banned {
-				out = append(out, afterCommitDiag(p, fun, rel,
-					afterCommitRuleID+"-A2: after-commit hook must be transient; it calls a method on "+
-						label+" (persistent side effects belong in the tx body)"))
-			}
-		case *ast.Ident:
-			if label, viaHelper := helperTouchesBannedReceiver(p, fun, localFuncs, ifaces); viaHelper {
-				out = append(out, afterCommitDiag(p, fun, rel,
-					afterCommitRuleID+"-A2: after-commit hook calls local helper "+fun.Name+
-						" that touches a "+label+" (one-level heuristic; Medium)"))
-			}
-		}
-	})
-	return out
-}
-
-// scanAfterCommitDrainCallers implements A3 over one file.
-func scanAfterCommitDrainCallers(p *Pass, file *ast.File) []Diagnostic {
-	rel := p.Rel(file)
-	if strings.HasSuffix(rel, "_test.go") || afterCommitDrainCallerAllowlist[filepath.ToSlash(rel)] {
-		return nil
-	}
-	info := p.TypesInfo
-	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, name, ok := resolvePkgFuncCall(info, call)
-		if !ok || pkgPath != persistencePkgPath || !afterCommitDrainFns[name] {
-			return
-		}
-		out = append(out, afterCommitDiag(p, call, rel,
-			afterCommitRuleID+"-A3: persistence."+name+" may only be called from a TxRunner implementation; "+
-				rel+" is not in the allowlist"))
-	})
-	return out
-}
-
-func afterCommitFixturePattern(fix string) (dir, pattern string) {
-	return filepath.Join("tools", "archtest", "testdata", afterCommitFixturesDir, fix),
-		"./tools/archtest/testdata/" + afterCommitFixturesDir + "/" + fix
+// TestAfterCommitHookPureTransient is the production dogfood: runs
+// AFTERCOMMIT-HOOK-PURE-TRANSIENT-01 against GoCell itself via the shared
+// CheckAfterCommitHookPureTransient entry point (single source).
+func TestAfterCommitHookPureTransient(t *testing.T) {
+	t.Parallel()
+	Report(t, ruleAfterCommitHookPureTransient,
+		CheckAfterCommitHookPureTransient(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // TestAfterCommitHookPureTransient_A1A2_Fixtures runs A1 + A2 over the
@@ -372,25 +58,6 @@ func TestAfterCommitHookPureTransient_A1A2_Fixtures(t *testing.T) {
 	}
 }
 
-// TestAfterCommitHookPureTransient_A1A2_Production asserts no production hook
-// violates A1/A2. (No hooks exist yet — saga is a later PR — so the set is
-// empty; this guards future hook authors.)
-func TestAfterCommitHookPureTransient_A1A2_Production(t *testing.T) {
-	diags := RunTypedProduction(t, TypedOpts{Tags: FlatNonDefaultTags()}, func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		localFuncs := packageFuncDecls(p)
-		ifaces := resolveBannedReceivers(p.Pkg)
-		var out []Diagnostic
-		for _, file := range p.Files {
-			out = append(out, scanRegisterAfterCommitHooks(p, file, localFuncs, ifaces)...)
-		}
-		return out
-	})
-	Report(t, afterCommitRuleID+"-A1A2", diags)
-}
-
 // TestAfterCommitHookPureTransient_A3_Fixture asserts a non-allowlisted caller
 // of the registry plumbing funcs is flagged.
 func TestAfterCommitHookPureTransient_A3_Fixture(t *testing.T) {
@@ -407,40 +74,6 @@ func TestAfterCommitHookPureTransient_A3_Fixture(t *testing.T) {
 		return out
 	})
 	AssertGolden(t, filepath.Join(root, relDir, "diag.golden"), diags)
-}
-
-// TestAfterCommitHookPureTransient_A3_Production asserts the registry plumbing
-// funcs are called only from the allowlisted TxRunner implementations.
-func TestAfterCommitHookPureTransient_A3_Production(t *testing.T) {
-	diags := RunTypedProduction(t, TypedOpts{Tags: FlatNonDefaultTags()}, func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		var out []Diagnostic
-		for _, file := range p.Files {
-			out = append(out, scanAfterCommitDrainCallers(p, file)...)
-		}
-		return out
-	})
-	Report(t, afterCommitRuleID+"-A3", diags)
-}
-
-// TestAfterCommitHookPureTransient_BlindSpots_NoEscapeInProduction is the
-// reverse self-test for blind spots B2 (TxFromContext capture) and B3
-// (reflection MethodByName) inside production hook bodies. With no production
-// hooks yet the set is empty; the check bites when saga adds hooks.
-func TestAfterCommitHookPureTransient_BlindSpots_NoEscapeInProduction(t *testing.T) {
-	diags := RunTypedProduction(t, TypedOpts{Tags: FlatNonDefaultTags()}, func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		var out []Diagnostic
-		for _, file := range p.Files {
-			out = append(out, scanRegisterAfterCommitEscapes(p, file)...)
-		}
-		return out
-	})
-	Report(t, afterCommitRuleID+"-BLINDSPOT", diags)
 }
 
 // TestAfterCommitHookPureTransient_Escapes_Fixture asserts the B2/B3 escape scan
@@ -462,41 +95,20 @@ func TestAfterCommitHookPureTransient_Escapes_Fixture(t *testing.T) {
 	AssertGolden(t, filepath.Join(root, relDir, "diag.golden"), diags)
 }
 
-// scanRegisterAfterCommitEscapes runs the B2/B3 escape scan over every
-// RegisterAfterCommit func-literal hook in file.
-func scanRegisterAfterCommitEscapes(p *Pass, file *ast.File) []Diagnostic {
-	rel := p.Rel(file)
-	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, name, ok := resolvePkgFuncCall(p.TypesInfo, call)
-		if !ok || pkgPath != persistencePkgPath || name != registerAfterCommitFn || len(call.Args) < 2 {
-			return
+// TestAfterCommitHookPureTransient_BlindSpots_NoEscapeInProduction is the
+// reverse self-test for blind spots B2 (TxFromContext capture) and B3
+// (reflection MethodByName) inside production hook bodies. With no production
+// hooks yet the set is empty; the check bites when saga adds hooks.
+func TestAfterCommitHookPureTransient_BlindSpots_NoEscapeInProduction(t *testing.T) {
+	diags := RunTypedProduction(t, TypedOpts{Tags: FlatNonDefaultTags()}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
 		}
-		lit, isLit := call.Args[1].(*ast.FuncLit)
-		if !isLit {
-			return
+		var out []Diagnostic
+		for _, file := range p.Files {
+			out = append(out, scanRegisterAfterCommitEscapes(p, file)...)
 		}
-		out = append(out, scanHookBodyEscapes(p, rel, lit)...)
+		return out
 	})
-	return out
-}
-
-// scanHookBodyEscapes flags B2 (persistence.TxFromContext) and B3
-// (reflect Value.MethodByName) inside a hook body.
-func scanHookBodyEscapes(p *Pass, rel string, lit *ast.FuncLit) []Diagnostic {
-	info := p.TypesInfo
-	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](lit.Body, func(call *ast.CallExpr) {
-		if pkgPath, name, ok := resolvePkgFuncCall(info, call); ok &&
-			pkgPath == persistencePkgPath && name == txFromContextFn {
-			out = append(out, afterCommitDiag(p, call, rel,
-				afterCommitRuleID+"-B2: after-commit hook must not call persistence.TxFromContext to reach the committed tx"))
-			return
-		}
-		if sel, isSel := call.Fun.(*ast.SelectorExpr); isSel && sel.Sel.Name == "MethodByName" {
-			out = append(out, afterCommitDiag(p, call, rel,
-				afterCommitRuleID+"-B3: after-commit hook must not use reflection (MethodByName) to invoke a tx method"))
-		}
-	})
-	return out
+	Report(t, ruleAfterCommitHookPureTransient+"-BLINDSPOT", diags)
 }

--- a/tools/archtest/aftercommit_pure_transient_test.go
+++ b/tools/archtest/aftercommit_pure_transient_test.go
@@ -3,9 +3,9 @@
 // aftercommit_pure_transient_test.go — test entry points for
 // AFTERCOMMIT-HOOK-PURE-TRANSIENT-01. Rule logic, consts, and shared scan
 // helpers live in aftercommit_pure_transient_invariants.go (the non-test file,
-// so external Cell repos can compile it via StandardCellRules). This file
-// dogfoods those shared helpers against GoCell itself — single source, no
-// parallel rule body.
+// so external Cell repos can compile and call it directly — it is NOT in
+// StandardCellRules; see that file's godoc for why). This file dogfoods those
+// shared helpers against GoCell itself — single source, no parallel rule body.
 //
 // Production dogfood: one-liner via CheckAfterCommitHookPureTransient.
 // Fixture/RED tests: RunTypedFixture against testdata/ fixture dirs, reusing

--- a/tools/archtest/testdata/module_path_funnel.baseline
+++ b/tools/archtest/testdata/module_path_funnel.baseline
@@ -7,7 +7,6 @@
 # terminal pure ban. Migration tracked by #1302; Hard-ization by #1304.
 # blank lines and # comments are ignored.
 tools/archtest/adapter_returns_declared_types_test.go
-tools/archtest/aftercommit_pure_transient_test.go
 tools/archtest/archtest_test.go
 tools/archtest/audit_hash_input_frozen_test.go
 tools/archtest/auth_authtest_boundary_test.go


### PR DESCRIPTION
## Summary

把 `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01` 规则逻辑从 `_test.go` MOVE 到非 test `aftercommit_pure_transient_invariants.go`，platform 符号路径经 `PlatformModulePath` 派生，gocell `_test.go` dogfood 同一 `CheckAfterCommitHookPureTransient`（单源）。`ARCHTEST-MODULE-PATH-FUNNEL-01` baseline 缩 1（76→75）。

M3 PR-2..N 全量迁移的一批（自包含、internal-layout、已有 RED fixture 的最干净子集之一）。

## 改动性质

以机械为主 + 可证零变：
- 规则逻辑剪切到非 test `.go`（单源，无平行副本）
- const 值 `"github.com/ghbvf/gocell/X"` → `PlatformModulePath + "/X"`（拼接后逐字节相同 → 判定零变）；含 `persistencePkgPath` + `outbox.Writer` 路径表 map key / slice 元素
- 生产 dogfood test 收成 `Report(t, id, CheckAfterCommitHookPureTransient(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))`
- 删 baseline 行

设计决策：新 exported 契约 `CheckAfterCommitHookPureTransient(t, cfg) []Diagnostic`（抄 PR-1 exemplar 形态）；`cfg.BuildTags` 透传生产扫描 `TypedOpts.Tags`；scan 作用域保持自然域不泛化。

## AI-robust 评级

- 规则评级原样保留（搬位置 + 等价字面量替换，不动 AST/type 检查）；`// INVARIANT:` 锚点 + AI-robust godoc 随迁移保留。
- 不引入新 Soft：dogfood 与 import surface 调同一单源 `Check`。
- 本规则判定 gocell-internal 符号（外部 vacuous）→ **不进** `StandardCellRules()`，`external.go` 未改。
- `ARCHTEST-MODULE-PATH-FUNNEL-01`：下游 Hard / 上游 Medium(frozen baseline) 不变；本批朝 Hard 终态（空 baseline→纯 ban，#1304）推进一格。

## Test plan

- [x] `go build ./...`
- [x] `go test ./tools/archtest/...`（production dogfood + A1A2/A3/Escapes/BlindSpots fixtures + ratchet 全 GREEN）
- [x] `TestArchtestModulePathFunnel` GREEN（文件无 bare 字面量值 + baseline 行已删）
- [x] `golangci-lint run ./tools/archtest/...` 0 issues

ref: tools/archtest/panic_invariants.go (PR-1 #1084 exemplar)
Refs #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)