### PR TITLE
refactor(archtest): YAML-QUOTE-FUNNEL-01 迁移到 module-path-agnostic [#1302]

### DIFF
--- a/tools/archtest/testdata/module_path_funnel.baseline
+++ b/tools/archtest/testdata/module_path_funnel.baseline
@@ -81,4 +81,3 @@ tools/archtest/test_polling_external_reason_literal_test.go
 tools/archtest/user_repo_conformance_enrollment_test.go
 tools/archtest/webhook_hmac_funnel_test.go
 tools/archtest/wrapper_location_test.go
-tools/archtest/yaml_quote_funnel_test.go

--- a/tools/archtest/yaml_quote_funnel_invariants.go
+++ b/tools/archtest/yaml_quote_funnel_invariants.go
@@ -1,0 +1,278 @@
+package archtest
+
+// yaml_quote_funnel_invariants.go — importable YAML-QUOTE-FUNNEL-01 rule logic.
+//
+// This is the non-test home of the YAML-QUOTE-FUNNEL-01 scanner so rule logic
+// can be shared between the production dogfood test and the fixture-based
+// reverse self-tests in yaml_quote_funnel_test.go (single source). GoCell's
+// own TestYAMLQuoteFunnel (yaml_quote_funnel_test.go) calls CheckYAMLQuoteFunnel
+// — no parallel rule body.
+//
+// Platform-symbol paths (yamlsafePkgPath) are anchored to [PlatformModulePath]
+// so a module rename updates exactly one place and the ratchet meta-archtest
+// ARCHTEST-MODULE-PATH-FUNNEL-01 can prove no rule reintroduces a bare literal.
+
+// INVARIANT: YAML-QUOTE-FUNNEL-01
+//
+// YAML-QUOTE-FUNNEL-01: every type conversion `yamlsafe.Scalar(x)` outside
+// the pkg/yamlsafe package itself must have x = `yamlsafe.Quote(...)` (or
+// already typed as yamlsafe.Scalar) — raw string conversions bypass the
+// single quoting funnel and reintroduce YAML injection via colons / braces /
+// leading whitespace / metacharacters.
+//
+// AI-robust: Hard (charter §1 string-typed concept funnel template). The
+// conversion callee is resolved via *types.Info.Uses[ident] so a same-name
+// local TypeName cannot bypass the check. Three bypass families are now
+// all covered with no disclosed form-uniqueness blind spot remaining:
+//   - type alias of Scalar: covered by types.Unalias resolution (Commit 2,
+//     verified by TestYAMLQuoteFunnel_DetectsAliasBypass)
+//   - string literal in conversion position: covered by const-value detection
+//     (info.Types[arg].Value != nil guard in allowedScalarConversionArg)
+//   - const concatenation / const ident in conversion position: covered by
+//     the same const-value detection (Go's type checker evaluates all
+//     constant-evaluable expressions to a constant.Value regardless of form)
+//
+// Funnel 双向锁: 下游 Hard（types.Info-resolved Scalar conversion call site
+// must have Quote arg or already-typed Scalar). 上游 Medium — Pass.Pkg 路径
+// 过滤跳过 pkg/yamlsafe 内部即认为是合规上游；任何包外类型化 Scalar 字段
+// 都需经过 Quote 才能赋值（构造点被下游 archtest 守住）。041 plan §3 明确
+// 本 PR 内三件套闭环（typed funnel + archtest 下游 Hard +
+// 反向自检）。
+//
+// Blind spot inventory (covered by reverse self-test):
+//   - bare ident form `Scalar(x)` inside pkg/yamlsafe itself (allowed,
+//     skipped via Pkg.Path() == yamlsafePkgPath)
+//   - selector form `yamlsafe.Scalar(x)` outside pkg/yamlsafe (common case)
+//   - Arg shape: only direct `yamlsafe.Quote(x)` CallExpr is allowed (a value
+//     of declared static type yamlsafe.Scalar is also allowed as a no-op
+//     identity conversion, covering helpers that return a Scalar)
+//   - type alias form `type AliasOfScalar = yamlsafe.Scalar; AliasOfScalar(raw)`
+//     — covered by types.Unalias resolution; verified by
+//     TestYAMLQuoteFunnel_DetectsAliasBypass with yamlquotefixture.
+//   - string literal / const concat / const-typed Ident in conversion position
+//     — Go's contextual typing assigns the target type (yamlsafe.Scalar) to
+//     constant expressions; covered by info.Types[arg].Value != nil check in
+//     allowedScalarConversionArg; verified by
+//     TestYAMLQuoteFunnel_DetectsLiteralBypass with yamlquotefixture.
+//   - reverse self-test fixture: scanner applied to pkg/yamlsafe production
+//     AST (path filter bypassed) MUST report at least one bare Scalar(raw) site
+//     present in Quote() — proves types.Info resolution actually fires
+//
+// ref: pkg/yamlsafe/yamlsafe.go — Quote single funnel definition
+// ref: tools/archtest/prom_cell_label_funnel_test.go — companion Hard pattern
+// ref: docs/architecture/202605141519-adr-archtest-pass-funnel.md — Pass-driver
+//
+//	paradigm; this file uses RunTyped / RunTypedProduction (no direct
+//	packages.Load).
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+const (
+	// yamlsafePkgPath is the canonical import path of the yamlsafe package —
+	// a GoCell platform symbol path, anchored to PlatformModulePath so a module
+	// rename updates exactly one place and no bare literal appears here.
+	yamlsafePkgPath = PlatformModulePath + "/pkg/yamlsafe"
+
+	yamlsafeScalarType  = "Scalar"
+	yamlsafeQuoteFunc   = "Quote"
+	yamlQuoteFunnelRule = "YAML-QUOTE-FUNNEL-01"
+
+	// yamlquotefixturePkgPath is the canonical import path of the yamlquotefixture
+	// test fixture package — anchored to PlatformModulePath.
+	yamlquotefixturePkgPath = PlatformModulePath + "/tools/archtest/internal/yamlquotefixture"
+)
+
+// CheckYAMLQuoteFunnel runs YAML-QUOTE-FUNNEL-01 over the running module's
+// production code and returns its diagnostics. GoCell's TestYAMLQuoteFunnel
+// calls it directly (single source, no parallel rule body). cfg.BuildTags
+// is wired into the TypedOpts.Tags for the production scan.
+func CheckYAMLQuoteFunnel(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+
+	return RunTypedProduction(t, TypedOpts{Tests: false, Tags: cfg.BuildTags},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == yamlsafePkgPath {
+				return nil
+			}
+			var out []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				out = append(out, scanYAMLQuoteFunnel(p, f, rel)...)
+			}
+			return out
+		})
+}
+
+// scanYAMLQuoteFunnel walks the file's AST looking for yamlsafe.Scalar(...)
+// type conversions. For each found conversion, validates that the argument
+// is either (a) a yamlsafe.Quote(...) call or (b) an expression whose
+// declared static type is already yamlsafe.Scalar (allowing identity /
+// helper-returns without forcing redundant Quote wrapping).
+func scanYAMLQuoteFunnel(p *Pass, file *ast.File, rel string) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !isYAMLScalarConversion(p.TypesInfo, call.Fun) {
+			return
+		}
+		if len(call.Args) != 1 {
+			pos := p.Fset.Position(call.Pos())
+			diags = append(diags, Diagnostic{
+				Rel:     rel,
+				Line:    pos.Line,
+				Message: "yamlsafe.Scalar(...) conversion must take exactly one argument",
+			})
+			return
+		}
+		if allowedScalarConversionArg(p.TypesInfo, call.Args[0]) {
+			return
+		}
+		pos := p.Fset.Position(call.Pos())
+		diags = append(diags, Diagnostic{
+			Rel:  rel,
+			Line: pos.Line,
+			Message: fmt.Sprintf(
+				"yamlsafe.Scalar(...) argument must be yamlsafe.Quote(...) " +
+					"or a value of declared yamlsafe.Scalar type",
+			),
+		})
+	})
+	return diags
+}
+
+// isYAMLScalarConversion reports whether fun resolves to the yamlsafe.Scalar
+// TypeName (i.e. the CallExpr is a type conversion, not a function call).
+// Resolution goes through *types.Info.Uses so a same-name local variable
+// does NOT register as the funnel target — the Hard property.
+//
+// Type aliases are handled by routing through types.Unalias before reading
+// the underlying named type, so `type AliasOfScalar = yamlsafe.Scalar`
+// followed by `AliasOfScalar(raw)` is correctly detected as a Scalar
+// conversion (the alias resolves to the canonical yamlsafe.Scalar TypeName).
+func isYAMLScalarConversion(info *types.Info, fun ast.Expr) bool {
+	if info == nil {
+		return false
+	}
+	var ident *ast.Ident
+	switch v := fun.(type) {
+	case *ast.Ident:
+		ident = v
+	case *ast.SelectorExpr:
+		ident = v.Sel
+	default:
+		return false
+	}
+	obj := info.Uses[ident]
+	if obj == nil {
+		return false
+	}
+	tn, ok := obj.(*types.TypeName)
+	if !ok {
+		return false
+	}
+	// Route through types.Unalias so that `type AliasOfScalar = yamlsafe.Scalar`
+	// followed by `AliasOfScalar(raw)` is detected. Without Unalias, the TypeName
+	// resolves to the alias declaration in the caller package, not yamlsafe.Scalar,
+	// and Pkg().Path() returns the caller package — silently bypassing the guard.
+	named, ok := types.Unalias(tn.Type()).(*types.Named)
+	if !ok {
+		return false
+	}
+	nObj := named.Obj()
+	if nObj == nil || nObj.Pkg() == nil {
+		return false
+	}
+	return nObj.Pkg().Path() == yamlsafePkgPath && nObj.Name() == yamlsafeScalarType
+}
+
+// allowedScalarConversionArg reports whether arg is an acceptable input to
+// yamlsafe.Scalar(...) outside pkg/yamlsafe:
+//
+//  1. arg is a CallExpr whose callee resolves to yamlsafe.Quote
+//  2. arg's static type already is yamlsafe.Scalar (no-op identity, e.g. a
+//     helper that returns Scalar feeding through a typed slice / struct field)
+//
+// String literals, fmt.Sprintf results, and arbitrary string-typed values
+// all fail this predicate and must use yamlsafe.Quote.
+//
+// const-value guard: Go's type checker in a conversion position contextually
+// assigns the target type (yamlsafe.Scalar) to constant-evaluable expressions
+// (BasicLit string, const concat, const-typed Ident, iota, etc.), so
+// info.TypeOf(arg) would return yamlsafe.Scalar and the named-type branch
+// below would misclassify Scalar("literal") as an identity conversion.
+// The guard rejects any arg whose types.Info entry carries a non-nil Value
+// before reaching the named-type check.
+func allowedScalarConversionArg(info *types.Info, arg ast.Expr) bool {
+	if call, ok := arg.(*ast.CallExpr); ok {
+		if isYAMLQuoteCall(info, call.Fun) {
+			return true
+		}
+	}
+	// Reject any expression that evaluates to a Go constant (BasicLit string,
+	// string concatenation of consts, const-typed Ident, etc.). Go's
+	// contextual typing in a conversion position assigns the target type
+	// (yamlsafe.Scalar) to constant expressions, so the named-type check
+	// below would otherwise misclassify Scalar("literal") as "already typed
+	// as Scalar" and silently allow the bypass.
+	if tv, ok := info.Types[arg]; ok && tv.Value != nil {
+		return false
+	}
+	t := info.TypeOf(arg)
+	if t == nil {
+		return false
+	}
+	// Route through types.Unalias so that an argument whose declared static type
+	// is `type AliasOfScalar = yamlsafe.Scalar` (i.e. an alias of Scalar used as
+	// an identity no-op conversion target) is also recognized as already-typed Scalar.
+	named, ok := types.Unalias(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == yamlsafePkgPath && obj.Name() == yamlsafeScalarType
+}
+
+// isYAMLQuoteCall resolves fun via *types.Info.Uses and reports whether
+// it refers to yamlsafe.Quote.
+func isYAMLQuoteCall(info *types.Info, fun ast.Expr) bool {
+	if info == nil {
+		return false
+	}
+	var ident *ast.Ident
+	switch v := fun.(type) {
+	case *ast.Ident:
+		ident = v
+	case *ast.SelectorExpr:
+		ident = v.Sel
+	default:
+		return false
+	}
+	obj := info.Uses[ident]
+	if obj == nil {
+		return false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok || fn.Pkg() == nil {
+		return false
+	}
+	return fn.Pkg().Path() == yamlsafePkgPath && fn.Name() == yamlsafeQuoteFunc
+}

--- a/tools/archtest/yaml_quote_funnel_invariants.go
+++ b/tools/archtest/yaml_quote_funnel_invariants.go
@@ -12,8 +12,6 @@ package archtest
 // so a module rename updates exactly one place and the ratchet meta-archtest
 // ARCHTEST-MODULE-PATH-FUNNEL-01 can prove no rule reintroduces a bare literal.
 
-// INVARIANT: YAML-QUOTE-FUNNEL-01
-//
 // YAML-QUOTE-FUNNEL-01: every type conversion `yamlsafe.Scalar(x)` outside
 // the pkg/yamlsafe package itself must have x = `yamlsafe.Quote(...)` (or
 // already typed as yamlsafe.Scalar) — raw string conversions bypass the

--- a/tools/archtest/yaml_quote_funnel_invariants.go
+++ b/tools/archtest/yaml_quote_funnel_invariants.go
@@ -35,7 +35,8 @@ package archtest
 // 过滤跳过 pkg/yamlsafe 内部即认为是合规上游；任何包外类型化 Scalar 字段
 // 都需经过 Quote 才能赋值（构造点被下游 archtest 守住）。041 plan §3 明确
 // 本 PR 内三件套闭环（typed funnel + archtest 下游 Hard +
-// 反向自检）。
+// 反向自检）。上游 Medium → Hard 终态（seal Scalar 构造使包外不可表达
+// 裸转换）的升级路径追踪于 gh issue #1304。
 //
 // Blind spot inventory (covered by reverse self-test):
 //   - bare ident form `Scalar(x)` inside pkg/yamlsafe itself (allowed,
@@ -55,6 +56,12 @@ package archtest
 //   - reverse self-test fixture: scanner applied to pkg/yamlsafe production
 //     AST (path filter bypassed) MUST report at least one bare Scalar(raw) site
 //     present in Quote() — proves types.Info resolution actually fires
+//   - known gap: if pkg/yamlsafe.Quote() is ever reimplemented WITHOUT a bare
+//     Scalar(raw) conversion, TestYAMLQuoteFunnel_DetectsViolation flips RED→
+//     GREEN (it no longer has a live conversion to detect). That is a property
+//     of yamlsafe's own implementation, outside this archtest's control domain;
+//     the fixture-based DetectsAliasBypass / DetectsLiteralBypass tests keep
+//     proving types.Info resolution independently of Quote()'s body.
 //
 // ref: pkg/yamlsafe/yamlsafe.go — Quote single funnel definition
 // ref: tools/archtest/prom_cell_label_funnel_test.go — companion Hard pattern
@@ -64,7 +71,6 @@ package archtest
 //	packages.Load).
 
 import (
-	"fmt"
 	"go/ast"
 	"go/types"
 	"strings"
@@ -92,6 +98,12 @@ const (
 // production code and returns its diagnostics. GoCell's TestYAMLQuoteFunnel
 // calls it directly (single source, no parallel rule body). cfg.BuildTags
 // is wired into the TypedOpts.Tags for the production scan.
+//
+// Deliberately NOT registered in [StandardCellRules]: the rule only constrains
+// conversions of the gocell-internal pkg/yamlsafe.Scalar type, so it is vacuous
+// for an external Cell repo that never imports yamlsafe. It stays importable
+// (non-test file, single source) for the dogfood Test, but external_repo wiring
+// is out of scope — see external.go [StandardCellRules] godoc + M3 issue #1302.
 func CheckYAMLQuoteFunnel(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
 
@@ -121,9 +133,10 @@ func CheckYAMLQuoteFunnel(t *testing.T, cfg ConfigForExternalCell) []Diagnostic 
 // declared static type is already yamlsafe.Scalar (allowing identity /
 // helper-returns without forcing redundant Quote wrapping).
 func scanYAMLQuoteFunnel(p *Pass, file *ast.File, rel string) []Diagnostic {
-	if p.TypesInfo == nil {
-		return nil
-	}
+	// p.TypesInfo is guaranteed non-nil: runRulePasses skips any Pass whose
+	// buildTypedPass returned nil (pkg.TypesInfo == nil), so every Pass that
+	// reaches a typed rule like this one carries a populated TypesInfo. The
+	// callee-resolution helpers below still nil-guard defensively in isolation.
 	var diags []Diagnostic
 	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		if !isYAMLScalarConversion(p.TypesInfo, call.Fun) {
@@ -145,10 +158,8 @@ func scanYAMLQuoteFunnel(p *Pass, file *ast.File, rel string) []Diagnostic {
 		diags = append(diags, Diagnostic{
 			Rel:  rel,
 			Line: pos.Line,
-			Message: fmt.Sprintf(
-				"yamlsafe.Scalar(...) argument must be yamlsafe.Quote(...) " +
-					"or a value of declared yamlsafe.Scalar type",
-			),
+			Message: "yamlsafe.Scalar(...) argument must be yamlsafe.Quote(...) " +
+				"or a value of declared yamlsafe.Scalar type",
 		})
 	})
 	return diags

--- a/tools/archtest/yaml_quote_funnel_test.go
+++ b/tools/archtest/yaml_quote_funnel_test.go
@@ -1,5 +1,7 @@
 package archtest
 
+// INVARIANT: YAML-QUOTE-FUNNEL-01
+//
 // yaml_quote_funnel_test.go — test entry points for YAML-QUOTE-FUNNEL-01.
 //
 // Rule logic, path consts, and helper funcs live in

--- a/tools/archtest/yaml_quote_funnel_test.go
+++ b/tools/archtest/yaml_quote_funnel_test.go
@@ -1,74 +1,18 @@
-// INVARIANT: YAML-QUOTE-FUNNEL-01
-//
-// YAML-QUOTE-FUNNEL-01: every type conversion `yamlsafe.Scalar(x)` outside
-// the pkg/yamlsafe package itself must have x = `yamlsafe.Quote(...)` (or
-// already typed as yamlsafe.Scalar) — raw string conversions bypass the
-// single quoting funnel and reintroduce YAML injection via colons / braces /
-// leading whitespace / metacharacters.
-//
-// AI-robust: Hard (charter §1 string-typed concept funnel template). The
-// conversion callee is resolved via *types.Info.Uses[ident] so a same-name
-// local TypeName cannot bypass the check. Three bypass families are now
-// all covered with no disclosed form-uniqueness blind spot remaining:
-//   - type alias of Scalar: covered by types.Unalias resolution (Commit 2,
-//     verified by TestYAMLQuoteFunnel_DetectsAliasBypass)
-//   - string literal in conversion position: covered by const-value detection
-//     (info.Types[arg].Value != nil guard in allowedScalarConversionArg)
-//   - const concatenation / const ident in conversion position: covered by
-//     the same const-value detection (Go's type checker evaluates all
-//     constant-evaluable expressions to a constant.Value regardless of form)
-//
-// Funnel 双向锁: 下游 Hard（types.Info-resolved Scalar conversion call site
-// must have Quote arg or already-typed Scalar). 上游 Medium — Pass.Pkg 路径
-// 过滤跳过 pkg/yamlsafe 内部即认为是合规上游；任何包外类型化 Scalar 字段
-// 都需经过 Quote 才能赋值（构造点被下游 archtest 守住）。041 plan §3 明确
-// 本 PR 内三件套闭环（typed funnel + archtest 下游 Hard +
-// 反向自检）。
-//
-// Blind spot inventory (covered by reverse self-test):
-//   - bare ident form `Scalar(x)` inside pkg/yamlsafe itself (allowed,
-//     skipped via Pkg.Path() == yamlsafePkgPath)
-//   - selector form `yamlsafe.Scalar(x)` outside pkg/yamlsafe (common case)
-//   - Arg shape: only direct `yamlsafe.Quote(x)` CallExpr is allowed (a value
-//     of declared static type yamlsafe.Scalar is also allowed as a no-op
-//     identity conversion, covering helpers that return a Scalar)
-//   - type alias form `type AliasOfScalar = yamlsafe.Scalar; AliasOfScalar(raw)`
-//     — covered by types.Unalias resolution; verified by
-//     TestYAMLQuoteFunnel_DetectsAliasBypass with yamlquotefixture.
-//   - string literal / const concat / const-typed Ident in conversion position
-//     — Go's contextual typing assigns the target type (yamlsafe.Scalar) to
-//     constant expressions; covered by info.Types[arg].Value != nil check in
-//     allowedScalarConversionArg; verified by
-//     TestYAMLQuoteFunnel_DetectsLiteralBypass with yamlquotefixture.
-//   - reverse self-test fixture: scanner applied to pkg/yamlsafe production
-//     AST (path filter bypassed) MUST report at least one bare Scalar(raw) site
-//     present in Quote() — proves types.Info resolution actually fires
-//
-// ref: pkg/yamlsafe/yamlsafe.go — Quote single funnel definition
-// ref: tools/archtest/prom_cell_label_funnel_test.go — companion Hard pattern
-// ref: docs/architecture/202605141519-adr-archtest-pass-funnel.md — Pass-driver
-//
-//	paradigm; this file uses RunTyped / RunTypedProduction (no direct
-//	packages.Load).
 package archtest
 
+// yaml_quote_funnel_test.go — test entry points for YAML-QUOTE-FUNNEL-01.
+//
+// Rule logic, path consts, and helper funcs live in
+// yaml_quote_funnel_invariants.go (non-test, importable). This file dogfoods
+// CheckYAMLQuoteFunnel against GoCell itself and holds the fixture-based
+// reverse self-tests that share scanYAMLQuoteFunnel — single source, no
+// parallel rule body.
+
 import (
-	"fmt"
-	"go/ast"
-	"go/types"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
-)
-
-const (
-	yamlsafePkgPath     = "github.com/ghbvf/gocell/pkg/yamlsafe"
-	yamlsafeScalarType  = "Scalar"
-	yamlsafeQuoteFunc   = "Quote"
-	yamlQuoteFunnelRule = "YAML-QUOTE-FUNNEL-01"
 )
 
 // TestYAMLQuoteFunnel enforces YAML-QUOTE-FUNNEL-01 on the production
@@ -77,27 +21,7 @@ const (
 // argument.
 func TestYAMLQuoteFunnel(t *testing.T) {
 	t.Parallel()
-
-	diags := RunTypedProduction(t, TypedOpts{Tests: false},
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			if p.Pkg.Path() == yamlsafePkgPath {
-				return nil
-			}
-			var out []Diagnostic
-			for _, f := range p.Files {
-				rel := p.Rel(f)
-				if strings.HasSuffix(rel, "_test.go") {
-					continue
-				}
-				out = append(out, scanYAMLQuoteFunnel(p, f, rel)...)
-			}
-			return out
-		})
-
-	Report(t, yamlQuoteFunnelRule, diags)
+	Report(t, yamlQuoteFunnelRule, CheckYAMLQuoteFunnel(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // TestYAMLQuoteFunnel_DetectsViolation is the reverse self-test: feed the
@@ -141,168 +65,6 @@ func TestYAMLQuoteFunnel_DetectsViolation(t *testing.T) {
 		"scanner must detect at least one bare Scalar(raw) conversion inside yamlsafe.go; "+
 			"empty result means the types.Info-based detection silently regressed")
 }
-
-// scanYAMLQuoteFunnel walks the file's AST looking for yamlsafe.Scalar(...)
-// type conversions. For each found conversion, validates that the argument
-// is either (a) a yamlsafe.Quote(...) call or (b) an expression whose
-// declared static type is already yamlsafe.Scalar (allowing identity /
-// helper-returns without forcing redundant Quote wrapping).
-func scanYAMLQuoteFunnel(p *Pass, file *ast.File, rel string) []Diagnostic {
-	if p.TypesInfo == nil {
-		return nil
-	}
-	var diags []Diagnostic
-	scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		if !isYAMLScalarConversion(p.TypesInfo, call.Fun) {
-			return
-		}
-		if len(call.Args) != 1 {
-			pos := p.Fset.Position(call.Pos())
-			diags = append(diags, Diagnostic{
-				Rel:     rel,
-				Line:    pos.Line,
-				Message: "yamlsafe.Scalar(...) conversion must take exactly one argument",
-			})
-			return
-		}
-		if allowedScalarConversionArg(p.TypesInfo, call.Args[0]) {
-			return
-		}
-		pos := p.Fset.Position(call.Pos())
-		diags = append(diags, Diagnostic{
-			Rel:  rel,
-			Line: pos.Line,
-			Message: fmt.Sprintf(
-				"yamlsafe.Scalar(...) argument must be yamlsafe.Quote(...) " +
-					"or a value of declared yamlsafe.Scalar type",
-			),
-		})
-	})
-	return diags
-}
-
-// isYAMLScalarConversion reports whether fun resolves to the yamlsafe.Scalar
-// TypeName (i.e. the CallExpr is a type conversion, not a function call).
-// Resolution goes through *types.Info.Uses so a same-name local variable
-// does NOT register as the funnel target — the Hard property.
-//
-// Type aliases are handled by routing through types.Unalias before reading
-// the underlying named type, so `type AliasOfScalar = yamlsafe.Scalar`
-// followed by `AliasOfScalar(raw)` is correctly detected as a Scalar
-// conversion (the alias resolves to the canonical yamlsafe.Scalar TypeName).
-func isYAMLScalarConversion(info *types.Info, fun ast.Expr) bool {
-	if info == nil {
-		return false
-	}
-	var ident *ast.Ident
-	switch v := fun.(type) {
-	case *ast.Ident:
-		ident = v
-	case *ast.SelectorExpr:
-		ident = v.Sel
-	default:
-		return false
-	}
-	obj := info.Uses[ident]
-	if obj == nil {
-		return false
-	}
-	tn, ok := obj.(*types.TypeName)
-	if !ok {
-		return false
-	}
-	// Route through types.Unalias so that `type AliasOfScalar = yamlsafe.Scalar`
-	// followed by `AliasOfScalar(raw)` is detected. Without Unalias, the TypeName
-	// resolves to the alias declaration in the caller package, not yamlsafe.Scalar,
-	// and Pkg().Path() returns the caller package — silently bypassing the guard.
-	named, ok := types.Unalias(tn.Type()).(*types.Named)
-	if !ok {
-		return false
-	}
-	nObj := named.Obj()
-	if nObj == nil || nObj.Pkg() == nil {
-		return false
-	}
-	return nObj.Pkg().Path() == yamlsafePkgPath && nObj.Name() == yamlsafeScalarType
-}
-
-// allowedScalarConversionArg reports whether arg is an acceptable input to
-// yamlsafe.Scalar(...) outside pkg/yamlsafe:
-//
-//  1. arg is a CallExpr whose callee resolves to yamlsafe.Quote
-//  2. arg's static type already is yamlsafe.Scalar (no-op identity, e.g. a
-//     helper that returns Scalar feeding through a typed slice / struct field)
-//
-// String literals, fmt.Sprintf results, and arbitrary string-typed values
-// all fail this predicate and must use yamlsafe.Quote.
-//
-// const-value guard: Go's type checker in a conversion position contextually
-// assigns the target type (yamlsafe.Scalar) to constant-evaluable expressions
-// (BasicLit string, const concat, const-typed Ident, iota, etc.), so
-// info.TypeOf(arg) would return yamlsafe.Scalar and the named-type branch
-// below would misclassify Scalar("literal") as an identity conversion.
-// The guard rejects any arg whose types.Info entry carries a non-nil Value
-// before reaching the named-type check.
-func allowedScalarConversionArg(info *types.Info, arg ast.Expr) bool {
-	if call, ok := arg.(*ast.CallExpr); ok {
-		if isYAMLQuoteCall(info, call.Fun) {
-			return true
-		}
-	}
-	// Reject any expression that evaluates to a Go constant (BasicLit string,
-	// string concatenation of consts, const-typed Ident, etc.). Go's
-	// contextual typing in a conversion position assigns the target type
-	// (yamlsafe.Scalar) to constant expressions, so the named-type check
-	// below would otherwise misclassify Scalar("literal") as "already typed
-	// as Scalar" and silently allow the bypass.
-	if tv, ok := info.Types[arg]; ok && tv.Value != nil {
-		return false
-	}
-	t := info.TypeOf(arg)
-	if t == nil {
-		return false
-	}
-	// Route through types.Unalias so that an argument whose declared static type
-	// is `type AliasOfScalar = yamlsafe.Scalar` (i.e. an alias of Scalar used as
-	// an identity no-op conversion target) is also recognized as already-typed Scalar.
-	named, ok := types.Unalias(t).(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	if obj == nil || obj.Pkg() == nil {
-		return false
-	}
-	return obj.Pkg().Path() == yamlsafePkgPath && obj.Name() == yamlsafeScalarType
-}
-
-// isYAMLQuoteCall resolves fun via *types.Info.Uses and reports whether
-// it refers to yamlsafe.Quote.
-func isYAMLQuoteCall(info *types.Info, fun ast.Expr) bool {
-	if info == nil {
-		return false
-	}
-	var ident *ast.Ident
-	switch v := fun.(type) {
-	case *ast.Ident:
-		ident = v
-	case *ast.SelectorExpr:
-		ident = v.Sel
-	default:
-		return false
-	}
-	obj := info.Uses[ident]
-	if obj == nil {
-		return false
-	}
-	fn, ok := obj.(*types.Func)
-	if !ok || fn.Pkg() == nil {
-		return false
-	}
-	return fn.Pkg().Path() == yamlsafePkgPath && fn.Name() == yamlsafeQuoteFunc
-}
-
-const yamlquotefixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/internal/yamlquotefixture"
 
 // TestYAMLQuoteFunnel_DetectsAliasBypass loads the archtest_fixture-gated
 // yamlquotefixture package (which declares `type AliasOfScalar = yamlsafe.Scalar`)

--- a/tools/archtest/yaml_quote_funnel_test.go
+++ b/tools/archtest/yaml_quote_funnel_test.go
@@ -100,11 +100,16 @@ func TestYAMLQuoteFunnel_DetectsAliasBypass(t *testing.T) {
 		})
 
 	require.True(t, found, "yamlquotefixture package must be loaded (check -tags=archtest_fixture)")
-	require.NotEmpty(t, diags,
-		"scanner must detect AliasOfScalar(\"evil-alias-raw\") via types.Unalias; "+
-			"empty result means alias bypass is silently allowed (regression)")
-	require.GreaterOrEqual(t, len(diags), 1,
-		"at least 1 violation expected (BypassViaAlias); CompliantQuoted must not fire. got: %v", diags)
+	// The fixture has exactly 3 bypass sites (BypassViaAlias / BypassViaLiteral /
+	// BypassViaConstConcat) and 2 compliant controls (CompliantQuoted /
+	// CompliantTypedScalar) that must NOT fire. Asserting == 3 (not >= 1) makes
+	// this test red on BOTH directions: if types.Unalias resolution regresses,
+	// BypassViaAlias drops out (count → 2); if a compliant control starts firing,
+	// count → 4. diags[0] is the alias site (AST top-down: it is first in
+	// fixture.go), so the message assertion anchors alias detection specifically.
+	require.Equal(t, 3, len(diags),
+		"expected exactly the 3 bypass sites; alias-detection regression or a "+
+			"compliant control firing would shift the count. got: %v", diags)
 	require.Contains(t, diags[0].Message, "yamlsafe.Scalar(...)")
 }
 
@@ -142,9 +147,12 @@ func TestYAMLQuoteFunnel_DetectsLiteralBypass(t *testing.T) {
 		})
 
 	require.True(t, found, "yamlquotefixture package must be loaded (check -tags=archtest_fixture)")
-	// Expect violations from: BypassViaAlias, BypassViaLiteral, BypassViaConstConcat.
-	// CompliantQuoted and CompliantTypedScalar must NOT fire.
-	require.GreaterOrEqual(t, len(diags), 3,
-		"scanner must detect alias + literal + concat bypass sites; got %d: %v",
-		len(diags), diags)
+	// Expect violations from exactly: BypassViaAlias, BypassViaLiteral,
+	// BypassViaConstConcat. CompliantQuoted and CompliantTypedScalar must NOT
+	// fire. == 3 (not >= 3) closes the over-detection gap: if allowedScalarConversionArg
+	// regresses to flag a compliant control, the count climbs to 4 and this test
+	// goes red instead of silently passing.
+	require.Equal(t, 3, len(diags),
+		"scanner must detect exactly the alias + literal + concat bypass sites "+
+			"(compliant controls must not fire); got %d: %v", len(diags), diags)
 }


### PR DESCRIPTION
## Summary

把 `YAML-QUOTE-FUNNEL-01` 规则逻辑从 `_test.go` MOVE 到非 test `yaml_quote_funnel_invariants.go`，platform 符号路径经 `PlatformModulePath` 派生，gocell `_test.go` dogfood 同一 `CheckYAMLQuoteFunnel`（单源）。`ARCHTEST-MODULE-PATH-FUNNEL-01` baseline 缩 1。

M3 PR-2..N 全量迁移的一批。

## 改动性质

以机械为主 + 可证零变：
- 规则逻辑（`scanYAMLQuoteFunnel` / `isYAMLScalarConversion` / `allowedScalarConversionArg` / `isYAMLQuoteCall`）剪切到非 test `.go`（单源）
- const 值派生：`yamlsafePkgPath = PlatformModulePath + "/pkg/yamlsafe"`、`yamlquotefixturePkgPath = PlatformModulePath + "/tools/archtest/internal/yamlquotefixture"`（逐字节相同 → 判定零变）
- 生产 dogfood test 收成 `Report(t, yamlQuoteFunnelRule, CheckYAMLQuoteFunnel(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))`
- 删 baseline 行

设计决策：新 exported 契约 `CheckYAMLQuoteFunnel(t, cfg) []Diagnostic`；`cfg.BuildTags` 透传；scan 作用域保持自然域（`RunTypedProduction` + `./pkg/yamlsafe/` 窄 origin 扫描相对 pattern 不含模块字面量，**不**泛化成 `./...`）。

## AI-robust 评级

- 规则评级原样保留；`// INVARIANT:` + AI-robust godoc 随迁移保留。
- 不引入新 Soft：dogfood 与 fixture 测试（DetectsViolation/AliasBypass/LiteralBypass）共用单源 `scanYAMLQuoteFunnel`。
- 判定 gocell-internal `pkg/yamlsafe`（外部 vacuous）→ **不进** `StandardCellRules()`，`external.go` 未改。
- `ARCHTEST-MODULE-PATH-FUNNEL-01`：下游 Hard / 上游 Medium 不变；朝 Hard 终态（#1304）推进一格。

## Test plan

- [x] `go build ./...`
- [x] `go test ./tools/archtest/...`（dogfood + DetectsViolation/AliasBypass/LiteralBypass + ratchet 全 GREEN）
- [x] `TestArchtestModulePathFunnel` GREEN
- [x] `golangci-lint run ./tools/archtest/...` 0 issues

ref: tools/archtest/panic_invariants.go (PR-1 #1084 exemplar)
Refs #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)