### PR TITLE
docs(archtest): AUDIT-WIRE-SENSITIVE-FIELD-FUNNEL-01 ceiling 标注 won't-do，关闭 #1299

### DIFF
--- a/tools/archtest/audit_wire_sensitive_funnel_test.go
+++ b/tools/archtest/audit_wire_sensitive_funnel_test.go
@@ -18,10 +18,12 @@
 //     every audit wire-out generation path. That "must-call" cannot be expressed
 //     in Go's type system — schemaToDTOs is shared with the exempt Request path,
 //     so the funnel cannot be folded into it unconditionally. A1 below is the
-//     Go-language ceiling for this shape (call-site allowlist + coverage). The
-//     ceiling — and an optional archtest-Medium strengthening via a
-//     schemaToWireOutDTOs wrapper — is tracked in gh #1299 (same won't-do shape
-//     as the SPAN-SETATTR #851 / HEALTHZ-HOLDER #893 Medium ceilings).
+//     Go-language ceiling for this shape (call-site allowlist + coverage) — a
+//     permanent won't-do ceiling (same shape as the SPAN-SETATTR #851 /
+//     HEALTHZ-HOLDER #893 / SAGA-JOURNAL #982 / outbox-provenance #1282 Medium
+//     ceilings). An optional schemaToWireOutDTOs wrapper could strengthen the
+//     archtest-Medium coverage but does not change the tier; it is left as
+//     optional defense-in-depth, not separately tracked.
 //
 // Two sub-checks:
 //

--- a/tools/codegen/contractgen/sensitive_wire_guard.go
+++ b/tools/codegen/contractgen/sensitive_wire_guard.go
@@ -29,9 +29,11 @@ import (
 //     wire-out path. That "must-call" cannot be expressed in Go's type system
 //     (schemaToDTOs is shared with the exempt Request path), so it is locked by
 //     archtest AUDIT-WIRE-SENSITIVE-FIELD-FUNNEL-01 (call-site allowlist +
-//     coverage). archtest-Medium is the Go ceiling for codegen must-call;
-//     gh #1299 tracks this ceiling (same won't-do shape as #851/#893) and the
-//     optional schemaToWireOutDTOs strengthening.
+//     coverage). archtest-Medium is the Go ceiling for codegen must-call — a
+//     permanent won't-do ceiling (same shape as #851/#893/#982/#1282). An
+//     optional schemaToWireOutDTOs wrapper could co-locate the funnel with
+//     wire-out construction, but it stays archtest-Medium (does not change the
+//     tier) and is left as optional defense-in-depth, not separately tracked.
 //
 // Scope: audit domain only (规则不超前于代码现状 — auditcore is today's sole
 // Principal-aggregating consumer). To extend when another such cell appears:

--- a/tools/codegen/contractgen/sensitive_wire_guard_test.go
+++ b/tools/codegen/contractgen/sensitive_wire_guard_test.go
@@ -28,8 +28,11 @@
 //     expressed in Go's type system (schemaToDTOs is shared with the exempt
 //     Request path), so it is locked by archtest
 //     AUDIT-WIRE-SENSITIVE-FIELD-FUNNEL-01 (call-site allowlist + role coverage).
-//     archtest-Medium is the Go ceiling for codegen must-call; gh #1299 tracks
-//     this ceiling (same won't-do shape as #851/#893).
+//     archtest-Medium is the Go ceiling for codegen must-call — a permanent
+//     won't-do ceiling (same shape as #851/#893/#982/#1282). An optional
+//     schemaToWireOutDTOs wrapper could strengthen the archtest-Medium coverage
+//     but does not change the tier; it is left as optional defense-in-depth,
+//     not separately tracked.
 //   - Scope: audit domain only (规则不超前于代码现状 — auditcore is today's only
 //     Principal-aggregating consumer). When a new such cell appears, extend
 //     isAuditWireContract in the same PR.


### PR DESCRIPTION
## Summary

把 `AUDIT-WIRE-SENSITIVE-FIELD-FUNNEL-01` 两处 godoc 中「tracked in gh #1299」的措辞改为「won't-do ceiling + optional defense-in-depth，不单独跟踪」，配合 close #1299，避免悬空引用。

### 背景

#1299 跟踪两件事：

1. **downstream Medium 天花板** — funnel 的 must-call 无法用 Go type system 表达（`schemaToDTOs` 与豁免的 Request 路径共享），只能由 archtest A1 callsite-allowlist 锁定。与 #851 (SPAN-SETATTR-HOLDER-SEAL) / #893 (HEALTHZ-HOLDER-SEAL) / #982 (SAGA-JOURNAL-HOLDER-SEAL) / #1282 (outbox provenance) **同形永久天花板**，已统一按 won't-do 关闭。
2. **可选强化项** `schemaToWireOutDTOs` wrapper — 经核查**不改 tier**（仍 archtest-Medium），纯 defense-in-depth，无单独跟踪价值。

故 #1299 无可做工作，按 won't-do 关闭；本 PR 同步两处 godoc 措辞，符合「PR 范围切割不留悬空引用」纪律。

### 改动

- `tools/codegen/contractgen/sensitive_wire_guard.go` — funnel godoc ceiling 段
- `tools/archtest/audit_wire_sensitive_funnel_test.go` — INVARIANT godoc ceiling 段

均为注释措辞，无行为/接口变更。

## Test plan

- [x] `go build ./tools/...` 通过
- [x] `go test ./tools/archtest/ -run TestAuditWireSensitiveFieldFunnel` 通过（funnel + reverse fixtures + blind-spot self-checks）
- [x] `go test ./tools/codegen/contractgen/` 通过
- [x] `golangci-lint run`（contractgen + archtest）0 issues

Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)