### PR TITLE
fix(saga,sonar): #1320 testwait 信号等待去 wall-clock 预算 + 清零 21 条 SonarCloud

### DIFF
--- a/adapters/grpc/server_integration_test.go
+++ b/adapters/grpc/server_integration_test.go
@@ -377,7 +377,7 @@ func TestIntegration_GracefulDrain(t *testing.T) {
 		}
 		rpcResp <- resp
 	}()
-	testwait.Deterministic(t, rpcStarted, integServeTimeout, "blocking-rpc-started")
+	testwait.Deterministic(t, rpcStarted, "blocking-rpc-started")
 
 	// Begin graceful stop in the background; it must block until the in-flight
 	// RPC is released.
@@ -405,7 +405,7 @@ func TestIntegration_GracefulDrain(t *testing.T) {
 
 	// Release the RPC; both it and Close should now complete cleanly.
 	close(release)
-	closeErr := testwait.Deterministic(t, closeReturned, integServeTimeout, "close-returns-after-drain")
+	closeErr := testwait.Deterministic(t, closeReturned, "close-returns-after-drain")
 	assert.NoError(t, closeErr, "Close should succeed within shutdown budget")
 	select {
 	case err := <-rpcErr:
@@ -450,8 +450,8 @@ func TestIntegration_WorkerStopAndCloseConcurrent(t *testing.T) {
 	go func() { stopDone <- srv.Worker().Stop(teardownCtx) }()
 	go func() { closeDone <- srv.Close(teardownCtx) }()
 
-	stopErr := testwait.Deterministic(t, stopDone, integServeTimeout, "worker-stop")
-	closeErr := testwait.Deterministic(t, closeDone, integServeTimeout, "close")
+	stopErr := testwait.Deterministic(t, stopDone, "worker-stop")
+	closeErr := testwait.Deterministic(t, closeDone, "close")
 
 	// Both callers must not return a non-nil error in the happy path.
 	// The second caller always returns nil (stopOnce semantic).
@@ -533,7 +533,7 @@ func TestIntegration_ServeContextCancel_GracefulDrain(t *testing.T) {
 		}
 		rpcResp <- resp
 	}()
-	testwait.Deterministic(t, rpcStarted, integServeTimeout, "blocking-rpc-started")
+	testwait.Deterministic(t, rpcStarted, "blocking-rpc-started")
 
 	// Core trigger: cancel the serve ctx while the RPC is in-flight. This drives
 	// serve()'s ctx.Done branch, which must begin a graceful drain bounded by the
@@ -561,7 +561,7 @@ func TestIntegration_ServeContextCancel_GracefulDrain(t *testing.T) {
 	// Release the RPC; the drain now completes and serve returns.
 	close(release)
 
-	serveErr := testwait.Deterministic(t, serveDone, integServeTimeout, "serve-returns-after-drain")
+	serveErr := testwait.Deterministic(t, serveDone, "serve-returns-after-drain")
 	assert.ErrorIs(t, serveErr, context.Canceled,
 		"serve must return context.Canceled after the ctx-cancel drain completes")
 

--- a/adapters/grpc/server_test.go
+++ b/adapters/grpc/server_test.go
@@ -35,19 +35,37 @@ func TestConfig_ApplyDefaults_ShutdownTimeout(t *testing.T) {
 	t.Parallel()
 	chain := genIntegChain(t)
 
-	// Zero ShutdownTimeout must be filled by New (applyDefaults is called internally).
-	cfg := grpcadapter.Config{
-		Addr: ":0",
-		TLS: grpcadapter.TLSConfig{
-			CertPEM: chain.serverCertPEM,
-			KeyPEM:  chain.serverKeyPEM,
-		},
+	// Zero ShutdownTimeout must be accepted: applyDefaults fills it so validate()
+	// does not error. A negative value (tested separately in V1c) must be rejected.
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+		wantErr bool
+	}{
+		{"zero-filled-by-defaults", 0, false},
+		{"negative-rejected-by-validate", negativeShutdownTimeout, true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := grpcadapter.Config{
+				Addr:            ":0",
+				ShutdownTimeout: tc.timeout,
+				TLS: grpcadapter.TLSConfig{
+					CertPEM: chain.serverCertPEM,
+					KeyPEM:  chain.serverKeyPEM,
+				},
+			}
+			srv, err := grpcadapter.New(cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, srv)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, srv)
+			}
+		})
 	}
-	srv, err := grpcadapter.New(cfg)
-	require.NoError(t, err)
-	require.NotNil(t, srv)
-	// We verify indirectly via a successful New — applyDefaults fills ShutdownTimeout
-	// so validate() does not error on it; the actual value is verified by integration tests.
 }
 
 // ─── Config.validate ─────────────────────────────────────────────────────────

--- a/adapters/mqtt/errors_test.go
+++ b/adapters/mqtt/errors_test.go
@@ -336,22 +336,30 @@ func TestBuildConnackOpts_ReasonNameRedaction(t *testing.T) {
 			cause := &autopaho.ConnackError{ReasonCode: tt.reasonCode}
 			e := errcode.New(errcode.KindInternal, ErrAdapterMQTTConnectPermanent,
 				"mqtt: connection rejected", buildConnackOpts(cause)...)
-
-			if !hasPublicDetailKey(e.Details, reasonDetailKeyCode) {
-				t.Errorf("reasonCode must always be a public detail")
-			}
-			if got := hasPublicDetailKey(e.Details, reasonDetailKeyName); got != tt.reasonNamePublic {
-				t.Errorf("reasonName public = %v, want %v", got, tt.reasonNamePublic)
-			}
-			if !tt.reasonNamePublic {
-				if hasPublicDetailKey(e.Details, reasonDetailKeyName) {
-					t.Errorf("auth-related reasonName must NOT be in public details")
-				}
-				if !hasInternalDetailKey(e.InternalDetails, reasonDetailKeyName) {
-					t.Errorf("auth-related reasonName must be present in internal details")
-				}
-			}
+			assertConnackOptsRedaction(t, e, tt.reasonNamePublic)
 		})
+	}
+}
+
+// assertConnackOptsRedaction checks the public/internal channel split for a
+// buildConnackOpts-produced errcode.Error. Extracted to reduce cognitive
+// complexity of TestBuildConnackOpts_ReasonNameRedaction.
+func assertConnackOptsRedaction(t *testing.T, e *errcode.Error, reasonNamePublic bool) {
+	t.Helper()
+	if !hasPublicDetailKey(e.Details, reasonDetailKeyCode) {
+		t.Errorf("reasonCode must always be a public detail")
+	}
+	if got := hasPublicDetailKey(e.Details, reasonDetailKeyName); got != reasonNamePublic {
+		t.Errorf("reasonName public = %v, want %v", got, reasonNamePublic)
+	}
+	if reasonNamePublic {
+		return
+	}
+	if hasPublicDetailKey(e.Details, reasonDetailKeyName) {
+		t.Errorf("auth-related reasonName must NOT be in public details")
+	}
+	if !hasInternalDetailKey(e.InternalDetails, reasonDetailKeyName) {
+		t.Errorf("auth-related reasonName must be present in internal details")
 	}
 }
 

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -544,14 +544,20 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 func itestSessionPhase1Subscribe(t *testing.T, mkCfg func() Config, ns TopicNamespace, subscription outbox.Subscription) {
 	t.Helper()
 	ctx1, cancel1 := context.WithCancel(context.Background())
+	// cancel1 has a dual role:
+	//   1. Functional drop (end of function): canceling ctx1 causes an unclean TCP
+	//      disconnect so the broker retains the persistent session + subscription,
+	//      which is the precondition for phase-2 session-recovery testing.
+	//   2. Cleanup guard (t.Cleanup): prevents autopaho goroutine leak if the
+	//      function returns early (e.g. t.Fatalf on error branches). cancel is
+	//      idempotent so calling it twice is safe.
+	t.Cleanup(cancel1)
 	conn1, err := Open(ctx1, clock.Real(), mkCfg())
 	if err != nil {
-		cancel1()
 		t.Fatalf("Open conn1: %v", err)
 	}
 	sub1, err := NewSubscriber(clock.Real(), conn1, ns, SubscriberConfig{})
 	if err != nil {
-		cancel1()
 		t.Fatalf("NewSubscriber 1: %v", err)
 	}
 	// sub1.Subscribe runs under ctx1: canceling ctx1 both drops the autopaho
@@ -564,9 +570,13 @@ func itestSessionPhase1Subscribe(t *testing.T, mkCfg func() Config, ns TopicName
 	select {
 	case <-sub1.Ready(subscription):
 	case <-time.After(testtime.D10s):
-		cancel1()
 		t.Fatal("phase-1 subscribe not ready")
 	}
+	// Functional drop: intentionally NOT calling conn1.Close() — Close() would
+	// send a DISCONNECT packet, causing the broker to delete the persistent
+	// session. Instead, we cancel ctx1 to produce an unclean TCP drop, which
+	// leaves the persistent session intact on the broker side. This is the
+	// required precondition for phase-2 to test session recovery.
 	cancel1()
 	// archtest:allow:test-sleep teardown-settle: wall-clock must elapse for the
 	// broker to observe the unclean TCP drop before the offline publish.
@@ -632,18 +642,12 @@ func itestSessionPhase2Subscribe(t *testing.T, mkCfg func() Config, ns TopicName
 	}
 	itestPublish(t, conn2, subscription.Topic, itestEnvelope(t, subscription.Topic, []byte(`{"seq":"online"}`)))
 	// HARD assertion: the resumed persistent session MUST deliver the online message.
-	deadline := time.Now().Add(testtime.D15s)
-	for time.Now().Before(deadline) {
-		if onlineReceived.Load() >= 1 {
-			break
-		}
-		time.Sleep(testtime.D20ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
-	}
-	if onlineReceived.Load() < 1 {
-		t.Fatalf("resumed persistent session did not deliver an online message "+
+	testwait.External(t, "broker-online-delivery",
+		func() bool { return onlineReceived.Load() >= 1 },
+		testtime.D15s, testtime.D20ms,
+		"resumed persistent session did not deliver an online message "+
 			"(offline=%d online=%d); session resume / subscription re-arm is broken",
-			offlineReceived.Load(), onlineReceived.Load())
-	}
+		offlineReceived.Load(), onlineReceived.Load())
 }
 
 // isOfflineTaggedPayload reports whether an envelope payload is one of the

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -386,18 +386,7 @@ func TestIntegration_Subscriber_Disposition3State(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			coll := newRecordingSubCollector()
-			sub, conn := newSubscriberForITest(t, "sub-disp-"+tc.name)
-			// Re-bind with collector by constructing a fresh subscriber on same conn.
-			ns, err := ParseTopicNamespace("itest")
-			if err != nil {
-				t.Fatalf("ns: %v", err)
-			}
-			sub, err = NewSubscriber(clock.Real(), conn, ns, SubscriberConfig{}, WithSubscriberCollector(coll))
-			if err != nil {
-				t.Fatalf("NewSubscriber: %v", err)
-			}
-
+			coll, sub := itestNewSubWithCollector(t, "sub-disp-"+tc.name)
 			settlement := &recordingSettlement{}
 			// Per-subtest topic prefix makes each subtest's filter disjoint, so
 			// shared-subscription fanout cannot deliver one subtest's PUBLISH to
@@ -418,35 +407,63 @@ func TestIntegration_Subscriber_Disposition3State(t *testing.T) {
 			case <-time.After(testtime.D10s):
 				t.Fatal("subscribe not ready")
 			}
-
 			topic := prefix + "/" + uuid.NewString()
-			itestPublish(t, conn, topic, itestEnvelope(t, topic, []byte(`{"k":"v"}`)))
-
-			deadline := time.Now().Add(testtime.D10s)
-			for time.Now().Before(deadline) {
-				s, f, _ := coll.snapshot()
-				if s+f >= 1 {
-					break
-				}
-				time.Sleep(testtime.D10ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
-			}
-			success, failure, reason := coll.snapshot()
-			commit, release := settlement.counts()
-			if success != tc.wantSuccess {
-				t.Errorf("success = %d, want %d", success, tc.wantSuccess)
-			}
-			if commit != tc.wantCommit {
-				t.Errorf("commit = %d, want %d", commit, tc.wantCommit)
-			}
-			if release != tc.wantRelease {
-				t.Errorf("release = %d, want %d", release, tc.wantRelease)
-			}
-			if tc.wantReason != "" {
-				if failure < 1 || reason != tc.wantReason {
-					t.Errorf("failure=%d reason=%q, want reason %q", failure, reason, tc.wantReason)
-				}
-			}
+			itestPublish(t, sub.conn, topic, itestEnvelope(t, topic, []byte(`{"k":"v"}`)))
+			itestWaitCollectorEvent(t, coll, testtime.D10s)
+			itestAssertDisposition(t, coll, settlement, tc.wantSuccess, tc.wantCommit, tc.wantRelease, tc.wantReason)
 		})
+	}
+}
+
+// itestNewSubWithCollector builds a new Subscriber with a recording collector
+// for the integration disposition tests. Returns the collector and subscriber.
+func itestNewSubWithCollector(t *testing.T, role string) (*recordingSubCollector, *Subscriber) {
+	t.Helper()
+	coll := newRecordingSubCollector()
+	_, conn := newSubscriberForITest(t, role)
+	ns, err := ParseTopicNamespace("itest")
+	if err != nil {
+		t.Fatalf("ns: %v", err)
+	}
+	sub, err := NewSubscriber(clock.Real(), conn, ns, SubscriberConfig{}, WithSubscriberCollector(coll))
+	if err != nil {
+		t.Fatalf("NewSubscriber: %v", err)
+	}
+	return coll, sub
+}
+
+// itestWaitCollectorEvent polls coll until at least one success or failure event
+// is recorded, up to deadline duration.
+func itestWaitCollectorEvent(t *testing.T, coll *recordingSubCollector, deadline time.Duration) {
+	t.Helper()
+	dl := time.Now().Add(deadline)
+	for time.Now().Before(dl) {
+		s, f, _ := coll.snapshot()
+		if s+f >= 1 {
+			return
+		}
+		time.Sleep(testtime.D10ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
+	}
+}
+
+// itestAssertDisposition checks success/commit/release counts and failure reason.
+func itestAssertDisposition(t *testing.T, coll *recordingSubCollector, settlement *recordingSettlement,
+	wantSuccess, wantCommit, wantRelease int, wantReason ConsumeFailureReason,
+) {
+	t.Helper()
+	success, failure, reason := coll.snapshot()
+	commit, release := settlement.counts()
+	if success != wantSuccess {
+		t.Errorf("success = %d, want %d", success, wantSuccess)
+	}
+	if commit != wantCommit {
+		t.Errorf("commit = %d, want %d", commit, wantCommit)
+	}
+	if release != wantRelease {
+		t.Errorf("release = %d, want %d", release, wantRelease)
+	}
+	if wantReason != "" && (failure < 1 || reason != wantReason) {
+		t.Errorf("failure=%d reason=%q, want reason %q", failure, reason, wantReason)
 	}
 }
 
@@ -472,8 +489,6 @@ func TestIntegration_Subscriber_Disposition3State(t *testing.T) {
 // durability — that comes from the producer-side transactional outbox + QoS1 +
 // idempotent consumers. See the ADR "$share offline redelivery" amendment.
 func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
-	// Mosquitto persists per-clientId sessions. Use a dedicated container so the
-	// session lifecycle is isolated from the shared broker.
 	dedicatedURL, container, err := startDedicatedMosquittoContainer(t)
 	if err != nil {
 		t.Fatalf("start dedicated broker: %v", err)
@@ -494,7 +509,7 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 			Brokers:        []string{testutil.LoopbackIPEndpoint(dedicatedURL)},
 			ConnectTimeout: testtime.D5s,
 			KeepAlive:      testtime.D10s,
-			SessionExpiry:  testtime.D30s, // > 0 → persistent session, clean=false
+			SessionExpiry:  testtime.D30s,
 			Backoff:        BackoffConfig{BaseDelay: testtime.D100ms, MaxDelay: testtime.D2s},
 			PublishTimeout: testtime.D5s,
 		}
@@ -505,15 +520,29 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 		t.Fatalf("ns: %v", err)
 	}
 	filter := "itest/session/data"
-	group := "session-cg-" + uuid.NewString()
-	subscription := itestSubscription(filter, group)
+	subscription := itestSubscription(filter, "session-cg-"+uuid.NewString())
 
 	// Phase 1: subscribe to establish the broker-side shared subscription, then
-	// drop the connection by canceling the Open ctx (NOT Connection.Close, which
-	// runs unsubscribeAll + a clean DISCONNECT). A cancelable (non-timeout) ctx
-	// puts the manager lifecycle solely under cancel1: canceling it tears down the
-	// autopaho manager / TCP uncleanly, so the broker retains the SessionExpiry>0
-	// session + its subscription for the phase-2 resume.
+	// drop the connection uncleanly so the broker retains the persistent session.
+	itestSessionPhase1Subscribe(t, mkCfg, ns, subscription)
+
+	// Publish while offline. Recorded for observability but not asserted.
+	offlineCount := itestSessionPublishOffline(t, dedicatedURL, filter)
+
+	// Phase 2: reconnect with the SAME clientId + persistent session and assert
+	// that a message published while online is delivered (hard assertion).
+	var offlineReceived, onlineReceived atomic.Int64
+	itestSessionPhase2Subscribe(t, mkCfg, ns, subscription, &offlineReceived, &onlineReceived)
+
+	t.Logf("session-recovery observability: offline-redelivered=%d/%d online=%d",
+		offlineReceived.Load(), offlineCount, onlineReceived.Load())
+}
+
+// itestSessionPhase1Subscribe opens a persistent-session subscriber, waits for
+// Ready, then drops the connection uncleanly (ctx cancel) and waits for the
+// broker to observe the TCP drop before returning.
+func itestSessionPhase1Subscribe(t *testing.T, mkCfg func() Config, ns TopicNamespace, subscription outbox.Subscription) {
+	t.Helper()
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	conn1, err := Open(ctx1, clock.Real(), mkCfg())
 	if err != nil {
@@ -525,11 +554,8 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 		cancel1()
 		t.Fatalf("NewSubscriber 1: %v", err)
 	}
-	// sub1.Subscribe runs under ctx1 directly: canceling ctx1 (below) both drops
-	// the autopaho manager (unclean disconnect → session retained) AND unblocks
-	// this Subscribe call. No separate sub-ctx is needed — a derived cancel that
-	// is only invoked on the timeout path would leak on the happy path (govet
-	// lostcancel).
+	// sub1.Subscribe runs under ctx1: canceling ctx1 both drops the autopaho
+	// manager uncleanly (broker retains session) and unblocks Subscribe.
 	go func() {
 		_ = sub1.Subscribe(ctx1, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
 			return outbox.Ack(), nil
@@ -541,21 +567,18 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 		cancel1()
 		t.Fatal("phase-1 subscribe not ready")
 	}
-	// Drop the connection UNCLEANLY (ctx cancel) — do NOT call subCancel1 first
-	// (that would UNSUBSCRIBE via the Subscribe-returned cancel) and do NOT call
-	// conn1.Close (that unsubscribes-all). Canceling ctx1 tears down the manager,
-	// leaving the persistent session + subscription on the broker.
 	cancel1()
 	// archtest:allow:test-sleep teardown-settle: wall-clock must elapse for the
-	// broker to observe the unclean TCP drop before the offline publish; there is
-	// no client-side signal to poll on (the manager is already gone).
+	// broker to observe the unclean TCP drop before the offline publish.
 	time.Sleep(testtime.D1s) //archtest:allow:test-sleep teardown-settle
+}
 
-	// Publish while offline. On some brokers/timings the persistent session +
-	// $share subscription offline-queue these and redeliver on resume; this is
-	// recorded for observability but not asserted (see the doc-comment + ADR).
+// itestSessionPublishOffline publishes offlineCount messages to filter while
+// the persistent-session subscriber is offline. Returns offlineCount.
+func itestSessionPublishOffline(t *testing.T, brokerURL, filter string) int {
+	t.Helper()
 	pubCfg := newTestConfig(t, "session-pub")
-	pubCfg.Brokers = []string{testutil.LoopbackIPEndpoint(dedicatedURL)}
+	pubCfg.Brokers = []string{testutil.LoopbackIPEndpoint(brokerURL)}
 	pubCtx, pubCancel := context.WithTimeout(context.Background(), testtime.D20s)
 	pubConn, err := Open(pubCtx, clock.Real(), pubCfg)
 	if err != nil {
@@ -568,8 +591,17 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 	}
 	_ = pubConn.Close(context.Background())
 	pubCancel()
+	return offlineCount
+}
 
-	// Phase 2: reconnect with the SAME clientId + persistent session.
+// itestSessionPhase2Subscribe opens a new connection with the same stableID +
+// persistent session, subscribes, publishes an online probe message, and asserts
+// that it is delivered (DETERMINISTIC hard assertion). Offline count is
+// observability-only (see TestIntegration_Subscriber_SessionRecovery doc).
+func itestSessionPhase2Subscribe(t *testing.T, mkCfg func() Config, ns TopicNamespace,
+	subscription outbox.Subscription, offlineReceived, onlineReceived *atomic.Int64,
+) {
+	t.Helper()
 	ctx2, cancel2 := context.WithTimeout(context.Background(), testtime.D30s)
 	defer cancel2()
 	conn2, err := Open(ctx2, clock.Real(), mkCfg())
@@ -581,11 +613,6 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSubscriber 2: %v", err)
 	}
-	// Separate offline-tagged deliveries (payload {"seq":<int>}) from the fresh
-	// post-resume online probe ({"seq":"online"}): the online count is the hard
-	// assertion (deterministic), the offline count is observability only.
-	var offlineReceived atomic.Int64
-	var onlineReceived atomic.Int64
 	subCtx2, subCancel2 := context.WithCancel(ctx2)
 	defer subCancel2()
 	go func() {
@@ -603,16 +630,8 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 	case <-time.After(testtime.D10s):
 		t.Fatal("phase-2 subscribe not ready")
 	}
-
-	// Publish a fresh online message AFTER resume. Delivery of a message published
-	// while the resumed shared-subscription member is connected is the
-	// DETERMINISTIC invariant this test asserts: it proves the persistent session
-	// resumed and the $share subscription was re-armed end-to-end.
-	itestPublish(t, conn2, filter, itestEnvelope(t, filter, []byte(`{"seq":"online"}`)))
-
-	// HARD assertion (deterministic, can-go-RED): the resumed persistent session
-	// MUST deliver a message published while it is online. This fails if session
-	// resume or subscription re-arm is broken.
+	itestPublish(t, conn2, subscription.Topic, itestEnvelope(t, subscription.Topic, []byte(`{"seq":"online"}`)))
+	// HARD assertion: the resumed persistent session MUST deliver the online message.
 	deadline := time.Now().Add(testtime.D15s)
 	for time.Now().Before(deadline) {
 		if onlineReceived.Load() >= 1 {
@@ -625,19 +644,6 @@ func TestIntegration_Subscriber_SessionRecovery(t *testing.T) {
 			"(offline=%d online=%d); session resume / subscription re-arm is broken",
 			offlineReceived.Load(), onlineReceived.Load())
 	}
-
-	// Offline-queued redelivery is recorded for observability ONLY — it is NOT a
-	// hard assertion. Whether the broker offline-queues messages for a $share
-	// member that dropped uncleanly is environment- and timing-dependent (it hinges
-	// on the broker observing the disconnect as non-clean AND retaining the share
-	// session before the offline publish): it is reliable on some mosquitto
-	// builds/timings and not others (observed redelivered locally, 0 on CI). The
-	// GoCell consumer-group path does NOT rely on broker offline queues for
-	// durability — that comes from the producer-side transactional outbox (retry
-	// until an online consumer acks) + QoS1 + idempotent consumers. See the ADR
-	// "$share offline redelivery" amendment.
-	t.Logf("session-recovery observability: offline-redelivered=%d/%d online=%d",
-		offlineReceived.Load(), offlineCount, onlineReceived.Load())
 }
 
 // isOfflineTaggedPayload reports whether an envelope payload is one of the

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -432,18 +433,17 @@ func itestNewSubWithCollector(t *testing.T, role string) (*recordingSubCollector
 	return coll, sub
 }
 
-// itestWaitCollectorEvent polls coll until at least one success or failure event
-// is recorded, up to deadline duration.
+// itestWaitCollectorEvent waits until coll has recorded at least one success or
+// failure event, up to deadline. Polling is unavoidable: the event is produced
+// by the real broker's async delivery, which exposes no channel signal — hence
+// testwait.External with a const-literal reason (not a hand-rolled time.Sleep
+// loop), so TEST-POLLING-EXTERNAL-REASON-LITERAL-01 guards the polling site.
 func itestWaitCollectorEvent(t *testing.T, coll *recordingSubCollector, deadline time.Duration) {
 	t.Helper()
-	dl := time.Now().Add(deadline)
-	for time.Now().Before(dl) {
-		s, f, _ := coll.snapshot()
-		if s+f >= 1 {
-			return
-		}
-		time.Sleep(testtime.D10ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
-	}
+	testwait.External(t, "broker-delivery-event",
+		func() bool { s, f, _ := coll.snapshot(); return s+f >= 1 },
+		deadline, testtime.D10ms,
+		"collector recorded no success/failure event")
 }
 
 // itestAssertDisposition checks success/commit/release counts and failure reason.

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -52,6 +52,10 @@ type providerConnectionCollector struct {
 
 var _ ConnectionCollector = (*providerConnectionCollector)(nil)
 
+// errProviderRequired is the error message used when a nil metrics.Provider is
+// passed to any of the three NewProvider*Collector constructors.
+const errProviderRequired = "mqtt: metrics.Provider is required"
+
 // NewProviderConnectionCollector registers mqtt_reconnect_total and
 // mqtt_subscribe_failed_total on p and returns a ConnectionCollector bound to
 // cellID. cellID becomes the "cell" label.
@@ -63,7 +67,7 @@ var _ ConnectionCollector = (*providerConnectionCollector)(nil)
 func NewProviderConnectionCollector(p metrics.Provider, cellID string) (ConnectionCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: metrics.Provider is required")
+			errProviderRequired)
 	}
 	if cellID == "" {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
@@ -231,7 +235,7 @@ var ackDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0
 func NewProviderPublisherCollector(p metrics.Provider, cellID string) (PublisherCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: metrics.Provider is required")
+			errProviderRequired)
 	}
 	if cellID == "" {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
@@ -416,7 +420,7 @@ var consumeDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2
 func NewProviderSubscriberCollector(p metrics.Provider, cellID string) (SubscriberCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: metrics.Provider is required")
+			errProviderRequired)
 	}
 	if cellID == "" {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,

--- a/adapters/mqtt/metrics_test.go
+++ b/adapters/mqtt/metrics_test.go
@@ -516,6 +516,7 @@ func TestProviderSubscriberCollector_RecordConsumeFailure(t *testing.T) {
 		consumeReasonReject,
 		consumeReasonRequeue,
 		consumeReasonCommitFailed,
+		consumeReasonAckFailed,
 		consumeReasonUnknownDisposition,
 	}
 	for _, reason := range allReasons {

--- a/adapters/mqtt/subscriber.go
+++ b/adapters/mqtt/subscriber.go
@@ -416,7 +416,7 @@ func (s *Subscriber) processDelivery(ctx context.Context, pb *paho.Publish, hand
 		// or SettlementObservers to notify (the handler was never invoked); if the
 		// poison ack itself fails, record a distinct ack-failed metric (the broker
 		// will redeliver the un-decodable message and it will be re-acked).
-		if ackErr := s.ackPoison(ctx, pb, "unmarshal"); ackErr != nil {
+		if s.ackPoison(ctx, pb, "unmarshal") != nil {
 			s.collector.RecordConsumeFailure(ctx, consumeReasonAckFailed)
 		}
 		return

--- a/adapters/mqtt/subscriber_dispatchack_test.go
+++ b/adapters/mqtt/subscriber_dispatchack_test.go
@@ -45,7 +45,7 @@ func fakeAckConn(ackErr error) *Connection {
 // Connection (see fakeAckConn) with the given collector, for white-box
 // dispatchAck branch tests. The namespace is the canonical "test" namespace so
 // NewSubscriber's non-zero-namespace guard passes; no broker SUBSCRIBE happens.
-func newDispatchAckSubscriber(t testingT, ackErr error, collector SubscriberCollector) *Subscriber {
+func newDispatchAckSubscriber(t fatalfT, ackErr error, collector SubscriberCollector) *Subscriber {
 	ns, err := ParseTopicNamespace("test")
 	if err != nil {
 		t.Fatalf("ParseTopicNamespace: %v", err)
@@ -58,8 +58,8 @@ func newDispatchAckSubscriber(t testingT, ackErr error, collector SubscriberColl
 	return sub
 }
 
-// testingT is the minimal testing surface newDispatchAckSubscriber needs.
-type testingT interface {
+// fatalfT is the minimal testing surface newDispatchAckSubscriber needs.
+type fatalfT interface {
 	Fatalf(format string, args ...any)
 }
 

--- a/adapters/mqtt/subscriber_testhelpers_test.go
+++ b/adapters/mqtt/subscriber_testhelpers_test.go
@@ -30,7 +30,7 @@ func mustNewEntry(t testing.TB, eventType string, payload []byte, opts ...outbox
 // (integration) both depend on recordingSettlement + recordingSubCollector.
 //
 // Unit-only dispatchAck white-box doubles (subAckRecorder / fakeAckConn /
-// newDispatchAckSubscriber / dispatchAckEntry / ackHandler / testingT) live in
+// newDispatchAckSubscriber / dispatchAckEntry / ackHandler / fatalfT) live in
 // subscriber_dispatchack_test.go (//go:build !integration) — they have no
 // caller in the integration build and would report `unused` if compiled there.
 

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -299,28 +299,30 @@ func checkSliceCoverage(args []string) error {
 		}
 	}
 
-	var results []governance.ValidationResult
-	cellCount := 0
-	sliceCount := 0
-	if *cellID != "" {
+	results, cellCount, sliceCount := collectSliceCoverageResults(root, project, *cellID)
+	return printAndCheck(*format, results, cmdSliceCoverage,
+		fmt.Sprintf("PASS: slice coverage OK (checked %d slices across %d cells)", sliceCount, cellCount))
+}
+
+// collectSliceCoverageResults gathers validation results and counts for either a
+// single cell (when filterCellID is non-empty) or all cells in the project.
+func collectSliceCoverageResults(root string, project *metadata.ProjectMeta, filterCellID string) (results []governance.ValidationResult, cellCount, sliceCount int) {
+	if filterCellID != "" {
 		cellCount = 1
-		// Count slices for this cell.
 		for _, sl := range project.Slices {
-			if sl.BelongsToCell == *cellID {
+			if sl.BelongsToCell == filterCellID {
 				sliceCount++
 			}
 		}
-		results = sliceCoverageForCell(root, project, *cellID)
-	} else {
-		cellCount = len(project.Cells)
-		sliceCount = len(project.Slices)
-		for cid := range project.Cells {
-			results = append(results, sliceCoverageForCell(root, project, cid)...)
-		}
+		results = sliceCoverageForCell(root, project, filterCellID)
+		return results, cellCount, sliceCount
 	}
-
-	return printAndCheck(*format, results, cmdSliceCoverage,
-		fmt.Sprintf("PASS: slice coverage OK (checked %d slices across %d cells)", sliceCount, cellCount))
+	cellCount = len(project.Cells)
+	sliceCount = len(project.Slices)
+	for cid := range project.Cells {
+		results = append(results, sliceCoverageForCell(root, project, cid)...)
+	}
+	return results, cellCount, sliceCount
 }
 
 // sliceCoverageForCell runs the slice-coverage checks for a single cell.

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -306,7 +306,9 @@ func checkSliceCoverage(args []string) error {
 
 // collectSliceCoverageResults gathers validation results and counts for either a
 // single cell (when filterCellID is non-empty) or all cells in the project.
-func collectSliceCoverageResults(root string, project *metadata.ProjectMeta, filterCellID string) (results []governance.ValidationResult, cellCount, sliceCount int) {
+func collectSliceCoverageResults(
+	root string, project *metadata.ProjectMeta, filterCellID string,
+) (results []governance.ValidationResult, cellCount, sliceCount int) {
 	if filterCellID != "" {
 		cellCount = 1
 		for _, sl := range project.Slices {

--- a/kernel/metadata/parser.go
+++ b/kernel/metadata/parser.go
@@ -693,17 +693,20 @@ func indexWebhookSlice(sl *SliceMeta, contracts map[string]*ContractMeta, idx *w
 		if !ok || c.Kind != "webhook" {
 			continue
 		}
-		if cu.Role == string(cellvocab.RoleWebhookReceive) {
-			if err := validateWebhookReceive(cu, sl, c, idx); err != nil {
-				return err
-			}
-		} else {
-			if err := validateWebhookDispatch(cu, sl, c, idx); err != nil {
-				return err
-			}
+		if err := applyWebhookCU(cu, sl, c, idx); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// applyWebhookCU dispatches a single webhook ContractUsage to the appropriate
+// validator based on role (webhook-receive or webhook-dispatch).
+func applyWebhookCU(cu ContractUsage, sl *SliceMeta, c *ContractMeta, idx *webhookCellIndex) error {
+	if cu.Role == string(cellvocab.RoleWebhookReceive) {
+		return validateWebhookReceive(cu, sl, c, idx)
+	}
+	return validateWebhookDispatch(cu, sl, c, idx)
 }
 
 // dedupSorted returns a new sorted slice with duplicate strings removed.

--- a/kernel/reconcile/metrics.go
+++ b/kernel/reconcile/metrics.go
@@ -59,6 +59,10 @@ type Metrics struct {
 	Leader kernelmetrics.GaugeVec
 }
 
+// errRegisterMetricFmt is the format string for metric registration errors.
+// The two %s verbs are the metric name and the underlying error.
+const errRegisterMetricFmt = "reconcile: register %s: %w"
+
 // RegisterMetrics registers the four reconcile instruments on p with canonical
 // names, labels, and buckets, returning them bundled. It is the single source
 // for reconcile metric identity; consumers call it at the composition root and
@@ -70,7 +74,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
 		LabelNames: []string{labelReconciler, labelResult},
 	})
 	if err != nil {
-		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileTotal, err)
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricReconcileTotal, err)
 	}
 	duration, err := p.HistogramVec(kernelmetrics.HistogramOpts{
 		Name:       metricReconcileDuration,
@@ -79,7 +83,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
 		Buckets:    reconcileDurationBuckets,
 	})
 	if err != nil {
-		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileDuration, err)
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricReconcileDuration, err)
 	}
 	inFlight, err := p.GaugeVec(kernelmetrics.GaugeOpts{
 		Name:       metricReconcileInFlight,
@@ -87,7 +91,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
 		LabelNames: []string{labelReconciler},
 	})
 	if err != nil {
-		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileInFlight, err)
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricReconcileInFlight, err)
 	}
 	leader, err := p.GaugeVec(kernelmetrics.GaugeOpts{
 		Name:       metricReconcileLeader,
@@ -95,7 +99,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
 		LabelNames: []string{labelReconciler},
 	})
 	if err != nil {
-		return Metrics{}, fmt.Errorf("reconcile: register %s: %w", metricReconcileLeader, err)
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricReconcileLeader, err)
 	}
 	return Metrics{Total: total, Duration: duration, InFlight: inFlight, Leader: leader}, nil
 }

--- a/pkg/pgrepoapproved/pgrepoapproved_test.go
+++ b/pkg/pgrepoapproved/pgrepoapproved_test.go
@@ -22,7 +22,7 @@ func TestApprove_MintsApproval(t *testing.T) {
 		pgrepoapproved.IntegrationTestDeleteUser,
 	}
 	for _, reason := range cases {
-		if got := pgrepoapproved.Approve(reason); got == nil {
+		if pgrepoapproved.Approve(reason) == nil {
 			t.Fatalf("Approve(%q) returned nil Approval", reason)
 		}
 	}

--- a/pkg/testutil/testwait/export_test.go
+++ b/pkg/testutil/testwait/export_test.go
@@ -1,0 +1,12 @@
+package testwait
+
+import "time"
+
+// DeterministicWithinForTest forwards to the unexported deterministicWithin so
+// the white-box self-test can exercise the safety-net-expiry branch with a
+// short budget. It lives in export_test.go, so it is compiled ONLY into
+// testwait's own test binary — business test code in other packages cannot
+// call it, and the timeout-free public Deterministic funnel is unaffected.
+func DeterministicWithinForTest[T any](t TB, signal <-chan T, budget time.Duration, msgAndArgs ...any) T {
+	return deterministicWithin(t, signal, budget, msgAndArgs...)
+}

--- a/pkg/testutil/testwait/testwait.go
+++ b/pkg/testutil/testwait/testwait.go
@@ -13,10 +13,13 @@
 //     Together they form a Hard funnel per ai-robust.md §"Funnel 双向锁评级"
 //     and Hard 范本 "typed marker funnel for unbounded ops" (sibling of
 //     panicregister.Approved).
-//   - Deterministic: blocks on a channel signal with timeout — no polling,
-//     no race window. The default choice; use External only as carve-out.
-//     Hard via Go type system: <-chan T signature makes "polling via
-//     Deterministic" unrepresentable.
+//   - Deterministic: blocks on a channel signal — no polling, no race window.
+//     The default choice; use External only as carve-out. Hard via Go type
+//     system: <-chan T signature makes "polling via Deterministic"
+//     unrepresentable. The internal safety-net timeout is [signalSafetyNet];
+//     callers do NOT pass a timeout — the signal arrival IS the
+//     synchronization point, so any caller-supplied timeout would be a latency
+//     budget, not a hung-test guard.
 //
 // Polling is the leading source of race-CI flakes in GoCell tests; see
 // docs/plans/202605181600-042-archtest.md §1.1 (TEST-POLLING-DETERMINISM).
@@ -37,6 +40,13 @@ import (
 	"fmt"
 	"time"
 )
+
+// signalSafetyNet bounds Deterministic's wait on a guaranteed signal.
+// It is a hung-test guard, NOT a latency budget — a correct run receives
+// the signal effectively instantly, so this is never hit in a green run
+// even under the race detector. Sized comfortably below `go test -timeout`
+// so a deadlocked signal fails readably here instead of as a whole-suite kill.
+const signalSafetyNet = 30 * time.Second
 
 // TB is the testing surface required by External and Deterministic. It
 // matches the subset of testing.TB the helpers actually use, so test code
@@ -105,9 +115,15 @@ func External(t TB, reason string, condition func() bool,
 	}
 }
 
-// Deterministic blocks on signal until it receives a value or timeout fires.
-// On success returns the received value; on timeout calls t.Fatalf and
-// returns the zero value of T.
+// Deterministic blocks on signal until it receives a value or the internal
+// safety-net timeout fires. On success returns the received value; on safety-net
+// expiry calls t.Fatalf and returns the zero value of T.
+//
+// The timeout is NOT caller-configurable. Deterministic is designed for signals
+// that are guaranteed to arrive in a correct run; the internal [signalSafetyNet]
+// is a hung-test guard only. A caller-supplied timeout would be a latency budget
+// (the root cause of race-CI flakes in observer_test.go, issue #1320). If you
+// genuinely need a poll with a configurable timeout, use External instead.
 //
 // This is the polling-free wait: the channel signal IS the synchronization
 // point. No closure capture, no race window with concurrent producers — Go's
@@ -120,23 +136,21 @@ func External(t TB, reason string, condition func() bool,
 //
 // For CI grep-ability, pass a short label string as the first msgAndArg:
 //
-//	testwait.Deterministic(t, sig, testtime.EventuallyShort, "session-created")
+//	testwait.Deterministic(t, sig, "session-created")
 //
 // The label appears verbatim in the t.Fatalf output, making the timeout
 // site findable via `grep "session-created" ci.log`.
-func Deterministic[T any](t TB, signal <-chan T, timeout time.Duration,
-	msgAndArgs ...any,
-) T {
+func Deterministic[T any](t TB, signal <-chan T, msgAndArgs ...any) T {
 	t.Helper()
 	var zero T
-	timer := time.NewTimer(timeout)
+	timer := time.NewTimer(signalSafetyNet)
 	defer timer.Stop()
 	select {
 	case v := <-signal:
 		return v
 	case <-timer.C:
-		t.Fatalf("testwait.Deterministic: timeout after %v waiting on signal: %s",
-			timeout, formatMsgAndArgs(msgAndArgs))
+		t.Fatalf("testwait.Deterministic: safety-net expired after %v waiting on signal: %s",
+			signalSafetyNet, formatMsgAndArgs(msgAndArgs))
 		return zero
 	}
 }

--- a/pkg/testutil/testwait/testwait.go
+++ b/pkg/testutil/testwait/testwait.go
@@ -142,15 +142,27 @@ func External(t TB, reason string, condition func() bool,
 // site findable via `grep "session-created" ci.log`.
 func Deterministic[T any](t TB, signal <-chan T, msgAndArgs ...any) T {
 	t.Helper()
+	return deterministicWithin(t, signal, signalSafetyNet, msgAndArgs...)
+}
+
+// deterministicWithin is the implementation behind Deterministic. budget is an
+// INTERNAL hung-test guard, never a caller-facing knob — Deterministic always
+// passes signalSafetyNet. It is split out so the white-box self-test
+// (export_test.go) can exercise the safety-net-expiry branch with a short
+// budget instead of waiting the full signalSafetyNet. Business test code in
+// other packages cannot reach it: the export_test.go forwarder is visible only
+// inside testwait's own test binary, so the timeout-free public funnel holds.
+func deterministicWithin[T any](t TB, signal <-chan T, budget time.Duration, msgAndArgs ...any) T {
+	t.Helper()
 	var zero T
-	timer := time.NewTimer(signalSafetyNet)
+	timer := time.NewTimer(budget)
 	defer timer.Stop()
 	select {
 	case v := <-signal:
 		return v
 	case <-timer.C:
 		t.Fatalf("testwait.Deterministic: safety-net expired after %v waiting on signal: %s",
-			signalSafetyNet, formatMsgAndArgs(msgAndArgs))
+			budget, formatMsgAndArgs(msgAndArgs))
 		return zero
 	}
 }

--- a/pkg/testutil/testwait/testwait.go
+++ b/pkg/testutil/testwait/testwait.go
@@ -46,6 +46,16 @@ import (
 // the signal effectively instantly, so this is never hit in a green run
 // even under the race detector. Sized comfortably below `go test -timeout`
 // so a deadlocked signal fails readably here instead of as a whole-suite kill.
+//
+// The default `go test -timeout` is 10 minutes; 30 s is far below that, so a
+// deadlocked signal produces a readable per-test Fatalf with the label (e.g.
+// "session-created") before the whole-suite kill fires — the whole-suite kill
+// carries no per-test location info, making CI diagnosis much harder.
+//
+// If this safety-net fires in a green-path run (signal that should arrive
+// instantly takes 30 s), the root cause is the system under test — the signal
+// channel is broken or the producer is hung. Do not raise this constant;
+// investigate the signal producer instead.
 const signalSafetyNet = 30 * time.Second
 
 // TB is the testing surface required by External and Deterministic. It
@@ -132,7 +142,12 @@ func External(t TB, reason string, condition func() bool,
 //
 // Hard via Go type system: signal's <-chan T signature lets callers receive
 // any payload type but forbids "polling via Deterministic" — the API name
-// and signature together pin the channel-blocking semantics.
+// and signature together pin the channel-blocking semantics. The absence of
+// a caller-facing timeout parameter is additionally locked by archtest
+// TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01 (Hard downstream form-lock; Medium
+// upstream — "no new timeout param" is a Go-language ceiling, same shape as
+// #851/#893/#1282: the axis "who may declare a given function's parameters"
+// is not expressible in the Go type system).
 //
 // For CI grep-ability, pass a short label string as the first msgAndArg:
 //

--- a/pkg/testutil/testwait/testwait_test.go
+++ b/pkg/testutil/testwait/testwait_test.go
@@ -195,6 +195,15 @@ type fooPayload struct{ ID int }
 // TestDeterministic_ClosedChannelReturnsImmediately documents Go channel
 // semantics: receiving from a closed channel returns the zero value immediately,
 // not a timeout. Deterministic must not call t.Fatalf in this case.
+//
+// Semantic distinction: a closed channel and an expired safety-net both return
+// the zero value of T, but they are opposite outcomes. Closed channel is a
+// well-formed immediate return — the producer has signaled completion by
+// closing. Safety-net expiry is a hung-test failure — the producer never sent
+// and Deterministic calls t.Fatalf. The assertion `ft.failed == false` is the
+// load-bearing guard that distinguishes these two zero-value paths: it proves
+// Deterministic treated the closed channel as a successful receive, not as a
+// hung-test.
 func TestDeterministic_ClosedChannelReturnsImmediately(t *testing.T) {
 	t.Parallel()
 	sig := make(chan int)

--- a/pkg/testutil/testwait/testwait_test.go
+++ b/pkg/testutil/testwait/testwait_test.go
@@ -165,11 +165,22 @@ func TestDeterministic_ReceivesValueFromSignal(t *testing.T) {
 	require.Equal(t, 42, got)
 }
 
-// TestDeterministic_TimesOutWhenSilent is intentionally absent: the safety-net
-// timeout is [signalSafetyNet] (30s) — an internal hung-test guard that is
-// never triggered in a correct run. Verifying it in a unit test would require
-// waiting 30 seconds, which is not practical. The safety-net fires readably
-// before `go test -timeout` kills the whole suite.
+// TestDeterministic_SafetyNetExpiresWhenSilent exercises the hung-test
+// safety-net branch via the white-box forwarder with a short budget, so the
+// expiry path is covered without waiting the production signalSafetyNet (30s).
+// A genuinely hung signal must call t.Fatalf with the label, not block forever.
+func TestDeterministic_SafetyNetExpiresWhenSilent(t *testing.T) {
+	t.Parallel()
+	sig := make(chan int) // never sent on
+	ft := &fakeT{T: t}
+	got := testwait.DeterministicWithinForTest(ft, sig, testtime.D5ms, "silent-signal")
+	require.True(t, ft.failed.Load(),
+		"safety-net expiry must call t.Fatalf when the signal never arrives")
+	rendered := fmt.Sprintf(ft.lastMsg, ft.lastArgs...)
+	require.Contains(t, rendered, "silent-signal",
+		"safety-net Fatalf must echo the label for CI grep-ability; got %q", rendered)
+	require.Equal(t, 0, got, "safety-net expiry must return the zero value of T")
+}
 
 func TestDeterministic_GenericOverStructSignal(t *testing.T) {
 	t.Parallel()

--- a/pkg/testutil/testwait/testwait_test.go
+++ b/pkg/testutil/testwait/testwait_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -162,24 +161,21 @@ func TestDeterministic_ReceivesValueFromSignal(t *testing.T) {
 	t.Parallel()
 	sig := make(chan int, 1)
 	sig <- 42
-	got := testwait.Deterministic(t, sig, testtime.EventuallyShort, "expected 42")
+	got := testwait.Deterministic(t, sig, "expected 42")
 	require.Equal(t, 42, got)
 }
 
-func TestDeterministic_TimesOutWhenSilent(t *testing.T) {
-	t.Parallel()
-	ft := &fakeT{T: t}
-	sig := make(chan int) // never sent on
-	got := testwait.Deterministic(ft, sig, testtime.D20ms, "silent signal")
-	assert.True(t, ft.failed.Load(), "expected t.Fatalf on silent signal")
-	assert.Equal(t, 0, got, "timeout must return zero value of T")
-}
+// TestDeterministic_TimesOutWhenSilent is intentionally absent: the safety-net
+// timeout is [signalSafetyNet] (30s) — an internal hung-test guard that is
+// never triggered in a correct run. Verifying it in a unit test would require
+// waiting 30 seconds, which is not practical. The safety-net fires readably
+// before `go test -timeout` kills the whole suite.
 
 func TestDeterministic_GenericOverStructSignal(t *testing.T) {
 	t.Parallel()
 	sig := make(chan struct{}, 1)
 	sig <- struct{}{}
-	got := testwait.Deterministic(t, sig, testtime.EventuallyShort, "struct signal")
+	got := testwait.Deterministic(t, sig, "struct signal")
 	require.Equal(t, struct{}{}, got)
 }
 
@@ -193,7 +189,7 @@ func TestDeterministic_ClosedChannelReturnsImmediately(t *testing.T) {
 	sig := make(chan int)
 	close(sig)
 	ft := &fakeT{T: t}
-	got := testwait.Deterministic(ft, sig, testtime.EventuallyShort, "closed-channel")
+	got := testwait.Deterministic(ft, sig, "closed-channel")
 	require.False(t, ft.failed.Load(),
 		"Deterministic must not call t.Fatalf when channel is already closed")
 	require.Equal(t, 0, got, "receive from closed chan int must return zero value")
@@ -204,6 +200,6 @@ func TestDeterministic_GenericOverTypedSignal(t *testing.T) {
 	sig := make(chan *fooPayload, 1)
 	want := &fooPayload{ID: 7}
 	sig <- want
-	got := testwait.Deterministic(t, sig, testtime.EventuallyShort, "typed signal")
+	got := testwait.Deterministic(t, sig, "typed signal")
 	require.Same(t, want, got, "Deterministic must return the exact value received")
 }

--- a/runtime/http/router/router_clock_required_test.go
+++ b/runtime/http/router/router_clock_required_test.go
@@ -13,7 +13,7 @@ import (
 // programmer error that can slip through.
 func TestNewForListener_NilClockPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatal("expected panic when typed-nil clock is passed")
 		}
 	}()

--- a/runtime/saga/executor/executor_test.go
+++ b/runtime/saga/executor/executor_test.go
@@ -100,7 +100,7 @@ func TestNewExecutor_NilClock(t *testing.T) {
 	t.Parallel()
 	hb := &alwaysOKHeartbeater{}
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Error("expected panic for nil clock")
 		}
 	}()
@@ -243,7 +243,7 @@ func TestExecute_RetryBackoffDeterministic(t *testing.T) {
 		fc.Advance(delay)
 	}
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "retry-backoff-result")
+	result := testwait.Deterministic(t, resultCh, "retry-backoff-result")
 	if result.Outcome != OutcomeSucceeded {
 		t.Errorf("Outcome = %v, want OutcomeSucceeded", result.Outcome)
 	}
@@ -398,7 +398,7 @@ func TestExecute_StepTimeout_Expired(t *testing.T) {
 		resultCh <- exec.Execute(context.Background(), newTestInstance(), "lease-3", step, ksaga.RetryPolicy{}, nil)
 	}()
 
-	testwait.Deterministic(t, started, testtime.EventuallyShort, "step-started")
+	testwait.Deterministic(t, started, "step-started")
 
 	// Negative assertion: advancing the fake clock short of the step deadline
 	// must NOT expire the step (the timeout is clock-driven, not wall-clock).
@@ -413,7 +413,7 @@ func TestExecute_StepTimeout_Expired(t *testing.T) {
 	// Now cross the deadline: the clock-driven AfterFunc fires and expires the step.
 	fc.Advance(testtime.D2ms)
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "step-timeout-result")
+	result := testwait.Deterministic(t, resultCh, "step-timeout-result")
 	if result.Outcome != OutcomeExpired {
 		t.Errorf("Outcome = %v, want OutcomeExpired", result.Outcome)
 	}
@@ -454,10 +454,10 @@ func TestExecute_ParentCancel_Canceled(t *testing.T) {
 		resultCh <- exec.Execute(ctx, newTestInstance(), "lease-4", step, ksaga.RetryPolicy{}, nil)
 	}()
 
-	testwait.Deterministic(t, started, testtime.EventuallyShort, "step-started")
+	testwait.Deterministic(t, started, "step-started")
 	cancel()
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "parent-cancel-result")
+	result := testwait.Deterministic(t, resultCh, "parent-cancel-result")
 	if result.Outcome != OutcomeCanceled {
 		t.Errorf("Outcome = %v, want OutcomeCanceled", result.Outcome)
 	}
@@ -495,7 +495,7 @@ func TestExecute_ParentDeadline_Expired(t *testing.T) {
 		resultCh <- exec.Execute(ctx, newTestInstance(), "lease-deadline", step, ksaga.RetryPolicy{}, nil)
 	}()
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "parent-deadline-result")
+	result := testwait.Deterministic(t, resultCh, "parent-deadline-result")
 	if result.Outcome != OutcomeExpired {
 		t.Errorf("Outcome = %v, want OutcomeExpired (saga-level deadline, not Canceled)", result.Outcome)
 	}
@@ -532,7 +532,7 @@ func TestExecute_BackoffParentCancel_Canceled(t *testing.T) {
 	waitForOnePendingTimer(t, fc)
 	cancel()
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "backoff-cancel-result")
+	result := testwait.Deterministic(t, resultCh, "backoff-cancel-result")
 	if result.Outcome != OutcomeCanceled {
 		t.Errorf("Outcome = %v, want OutcomeCanceled", result.Outcome)
 	}
@@ -572,13 +572,13 @@ func TestExecute_LeaseLost_CancelsStepAndReturnsLeaseLost(t *testing.T) {
 		resultCh <- exec.Execute(context.Background(), newTestInstance(), "lease-lost", step, ksaga.RetryPolicy{}, nil)
 	}()
 
-	testwait.Deterministic(t, started, testtime.EventuallyShort, "step-started")
+	testwait.Deterministic(t, started, "step-started")
 	// Heartbeat goroutine registers its ticker; advancing one interval fires the
 	// (stale) heartbeat → ok=false → the executor must cancel the running step.
 	waitForOneTicker(t, fc)
 	fc.Advance(testtime.D5s)
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "lease-lost-result")
+	result := testwait.Deterministic(t, resultCh, "lease-lost-result")
 	if result.Outcome != OutcomeLeaseLost {
 		t.Errorf("Outcome = %v, want OutcomeLeaseLost", result.Outcome)
 	}
@@ -630,11 +630,11 @@ func TestExecute_LeaseRenewsDuringBackoff(t *testing.T) {
 	// Advance one heartbeat interval (5s) — far short of the ~48-60s backoff, so
 	// only the heartbeat ticker fires, not the backoff timer.
 	fc.Advance(testtime.D5s)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "heartbeat-during-backoff")
+	testwait.Deterministic(t, hb.beat, "heartbeat-during-backoff")
 
 	// Tear down: cancel parent so the backoff Sleep returns and Execute exits.
 	cancel()
-	testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "renew-teardown-result")
+	testwait.Deterministic(t, resultCh, "renew-teardown-result")
 }
 
 // --- Execute: Run panic → convert to error, then retry ---
@@ -670,7 +670,7 @@ func TestExecute_RunPanic_ConvertedToError(t *testing.T) {
 	waitForOnePendingTimer(t, fc)
 	fc.Advance(defaultBaseInterval + testtime.D1ms)
 
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "panic-recover-result")
+	result := testwait.Deterministic(t, resultCh, "panic-recover-result")
 	if result.Outcome != OutcomeSucceeded {
 		t.Errorf("Outcome = %v, want OutcomeSucceeded (panic recovered, second attempt succeeded)", result.Outcome)
 	}
@@ -708,7 +708,7 @@ func TestExecute_LeaseIDPassedToHeartbeater(t *testing.T) {
 		resultCh <- exec.Execute(context.Background(), newTestInstance(), leaseID, step, ksaga.RetryPolicy{}, nil)
 	}()
 
-	testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "lease-id-result")
+	testwait.Deterministic(t, resultCh, "lease-id-result")
 	// The step completes quickly so there may be 0 heartbeats — that's fine.
 	// What we ensure is: no panic occurred and leaseID type was forwarded correctly.
 	// More thorough testing is done in TestHeartbeat_*.

--- a/runtime/saga/executor/heartbeat_test.go
+++ b/runtime/saga/executor/heartbeat_test.go
@@ -109,7 +109,7 @@ func TestHeartbeat_TickerFiresOnAdvance(t *testing.T) {
 
 	// Advance one interval: exactly one heartbeat.
 	fc.Advance(interval)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "heartbeat-tick-1")
+	testwait.Deterministic(t, hb.beat, "heartbeat-tick-1")
 
 	if got := hb.CallCount(); got != 1 {
 		t.Errorf("after one Advance: CallCount = %d, want 1", got)
@@ -117,9 +117,9 @@ func TestHeartbeat_TickerFiresOnAdvance(t *testing.T) {
 
 	// Advance two more intervals.
 	fc.Advance(interval)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "heartbeat-tick-2")
+	testwait.Deterministic(t, hb.beat, "heartbeat-tick-2")
 	fc.Advance(interval)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "heartbeat-tick-3")
+	testwait.Deterministic(t, hb.beat, "heartbeat-tick-3")
 
 	if got := hb.CallCount(); got != 3 {
 		t.Errorf("after three Advances: CallCount = %d, want 3", got)
@@ -193,7 +193,7 @@ func TestHeartbeat_StaleLease(t *testing.T) {
 
 	// First tick → ok=false → goroutine returns.
 	fc.Advance(interval)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "stale-first-tick")
+	testwait.Deterministic(t, hb.beat, "stale-first-tick")
 	wg.Wait() // goroutine should have exited
 
 	callsAfterStale := hb.CallCount()
@@ -249,7 +249,7 @@ func TestHeartbeat_StaleLease_InvokesOnStale(t *testing.T) {
 	fc.Advance(interval)
 	// onStale must fire on the stale tick. If it never fires (e.g. the ok=false
 	// branch only logs+returns) this Deterministic times out → test fails.
-	testwait.Deterministic(t, staleCh, testtime.EventuallyShort, "onstale-invoked")
+	testwait.Deterministic(t, staleCh, "onstale-invoked")
 	wg.Wait()
 }
 
@@ -282,11 +282,11 @@ func TestHeartbeat_TransientError(t *testing.T) {
 
 	// First tick → error (but goroutine keeps going).
 	fc.Advance(interval)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "transient-tick-1")
+	testwait.Deterministic(t, hb.beat, "transient-tick-1")
 
 	// Second tick → success.
 	fc.Advance(interval)
-	testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "transient-tick-2")
+	testwait.Deterministic(t, hb.beat, "transient-tick-2")
 
 	if got := atomic.LoadInt32(hb.count); got < 2 {
 		t.Errorf("transient error: total calls = %d, want >= 2", got)

--- a/runtime/saga/executor/observer_test.go
+++ b/runtime/saga/executor/observer_test.go
@@ -223,7 +223,7 @@ func TestExecute_ObserveOutcome_Failed(t *testing.T) {
 		waitForOnePendingTimer(t, fc)
 		fc.Advance(policy.Backoff(i, jExpected))
 	}
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "fail-result")
+	result := testwait.Deterministic(t, resultCh, "fail-result")
 
 	if result.Outcome != OutcomeFailed {
 		t.Fatalf("outcome = %v, want OutcomeFailed", result.Outcome)
@@ -265,9 +265,9 @@ func TestExecute_ObserveOutcome_Canceled(t *testing.T) {
 	go func() {
 		resultCh <- exec.Execute(ctx, newTestInstance(), "lease-cancel", step, ksaga.RetryPolicy{}, nil)
 	}()
-	testwait.Deterministic(t, stepStarted, testtime.EventuallyShort, "step-started")
+	testwait.Deterministic(t, stepStarted, "step-started")
 	cancel()
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "canceled-result")
+	result := testwait.Deterministic(t, resultCh, "canceled-result")
 
 	if result.Outcome != OutcomeCanceled {
 		t.Fatalf("outcome = %v, want OutcomeCanceled", result.Outcome)
@@ -324,13 +324,13 @@ func TestExecute_ObserveHeartbeatFailure_StaleLease(t *testing.T) {
 	go func() {
 		resultCh <- exec.Execute(context.Background(), newTestInstance(), "lease-stale-x", step, ksaga.RetryPolicy{}, nil)
 	}()
-	testwait.Deterministic(t, stepEntered, testtime.EventuallyShort, "step-entered")
+	testwait.Deterministic(t, stepEntered, "step-entered")
 	// First tick fires Heartbeat → ok=false → onStale cancels runCtx → step ctx done → Outcome=LeaseLost.
 	testwait.External(t, "fakeclock-ticker-registration",
 		func() bool { return fc.PendingTickers() >= 1 },
 		testtime.EventuallyShort, testtime.FastPoll, "no ticker")
 	fc.Advance(testtime.D5s)
-	result := testwait.Deterministic(t, resultCh, testtime.EventuallyShort, "lease-lost-result")
+	result := testwait.Deterministic(t, resultCh, "lease-lost-result")
 
 	if result.Outcome != OutcomeLeaseLost {
 		t.Fatalf("outcome = %v, want OutcomeLeaseLost", result.Outcome)
@@ -389,7 +389,7 @@ func TestRunHeartbeat_ObserveHeartbeatFailure_InfraError(t *testing.T) {
 		testtime.EventuallyShort, testtime.FastPoll, "no ticker")
 	for i := 0; i < 3; i++ {
 		fc.Advance(testtime.D5s)
-		testwait.Deterministic(t, hb.beat, testtime.EventuallyShort, "tick")
+		testwait.Deterministic(t, hb.beat, "tick")
 	}
 	cancel()
 	wg.Wait()
@@ -479,12 +479,12 @@ func TestRunWithHeartbeat_StaleLease_ReturnsLeaseLost(t *testing.T) {
 	go func() {
 		errCh <- exec.RunWithHeartbeat(context.Background(), newTestInstance(), "lease-rw3", fn)
 	}()
-	testwait.Deterministic(t, fnEntered, testtime.EventuallyShort, "fn-entered")
+	testwait.Deterministic(t, fnEntered, "fn-entered")
 	testwait.External(t, "fakeclock-ticker-registration",
 		func() bool { return fc.PendingTickers() >= 1 },
 		testtime.EventuallyShort, testtime.FastPoll, "no ticker")
 	fc.Advance(testtime.D5s)
-	got := testwait.Deterministic(t, errCh, testtime.EventuallyShort, "lease-lost-result")
+	got := testwait.Deterministic(t, errCh, "lease-lost-result")
 
 	if !IsLeaseLost(got) {
 		t.Errorf("got %v, want IsLeaseLost", got)
@@ -557,13 +557,13 @@ func TestRunWithHeartbeat_BlockingObserver_DoesNotStall(t *testing.T) {
 
 	// Wait for the observer call to enter so we know the bounded timer was
 	// created before we advance the clock past its deadline.
-	testwait.Deterministic(t, obs.hbEntered, testtime.EventuallyShort, "observer-call-entered")
+	testwait.Deterministic(t, obs.hbEntered, "observer-call-entered")
 
 	// Advance past the bounded deadline; the timer fires, callObserverBounded
 	// logs Warn and returns, and the preflight branch returns errLeaseLost.
 	fc.Advance(testtime.D50ms)
 
-	got := testwait.Deterministic(t, errCh, testtime.EventuallyShort,
+	got := testwait.Deterministic(t, errCh,
 		"RunWithHeartbeat must return despite blocked observer")
 	if !IsLeaseLost(got) {
 		t.Errorf("got %v, want IsLeaseLost (preflight stale)", got)
@@ -634,9 +634,9 @@ func TestObserverCall_Timeout_LogsCorrelation(t *testing.T) {
 
 	// Wait for the observer call to enter so the bounded timer exists, then
 	// advance past its deadline to fire the timeout branch.
-	testwait.Deterministic(t, obs.hbEntered, testtime.EventuallyShort, "observer-call-entered")
+	testwait.Deterministic(t, obs.hbEntered, "observer-call-entered")
 	fc.Advance(testtime.D50ms)
-	_ = testwait.Deterministic(t, errCh, testtime.EventuallyShort, "RunWithHeartbeat must return")
+	_ = testwait.Deterministic(t, errCh, "RunWithHeartbeat must return")
 
 	entry := sloghelper.FindLogEntry(buf.String(), "observer call exceeded deadline")
 	if entry == nil {

--- a/tools/archtest/test_eventually_funnel_test.go
+++ b/tools/archtest/test_eventually_funnel_test.go
@@ -793,10 +793,10 @@ func TestEventuallyFunnel_DeterministicNoTimeoutParam(t *testing.T) {
 		ruleID                = "TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01"
 	)
 	// Module-path-agnostic (ARCHTEST-MODULE-PATH-FUNNEL-01 / #1302): derive the
-	// testwait import path from PlatformModulePath via PlatformPkg instead of
-	// hard-coding "github.com/ghbvf/gocell/..." so an external Cell repo can run
-	// this rule against its own module.
-	testwaitPkgPath := PlatformPkg("pkg/testutil/testwait")
+	// testwait import path from the single sanctioned PlatformModulePath const
+	// (external.go) instead of hard-coding "github.com/ghbvf/gocell/..." so an
+	// external Cell repo can run this rule against its own module.
+	testwaitPkgPath := PlatformModulePath + "/pkg/testutil/testwait"
 
 	var (
 		sigFound         bool

--- a/tools/archtest/test_eventually_funnel_test.go
+++ b/tools/archtest/test_eventually_funnel_test.go
@@ -787,12 +787,16 @@ func TestEventuallyFunnel_DeterministicNoTimeoutParam(t *testing.T) {
 	t.Parallel()
 
 	const (
-		testwaitPkgPath       = "github.com/ghbvf/gocell/pkg/testutil/testwait"
 		deterministicFuncName = "Deterministic"
 		timePkgPath           = "time"
 		durationTypeName      = "Duration"
 		ruleID                = "TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01"
 	)
+	// Module-path-agnostic (ARCHTEST-MODULE-PATH-FUNNEL-01 / #1302): derive the
+	// testwait import path from PlatformModulePath via PlatformPkg instead of
+	// hard-coding "github.com/ghbvf/gocell/..." so an external Cell repo can run
+	// this rule against its own module.
+	testwaitPkgPath := PlatformPkg("pkg/testutil/testwait")
 
 	var (
 		sigFound         bool

--- a/tools/archtest/test_eventually_funnel_test.go
+++ b/tools/archtest/test_eventually_funnel_test.go
@@ -1,6 +1,7 @@
 package archtest
 
 // INVARIANT: TEST-EVENTUALLY-FUNNEL-01
+//   - INVARIANT: TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01
 //
 // test_eventually_funnel_test.go — Hard upstream funnel for
 // pkg/testutil/testwait.External, paired with the Hard downstream
@@ -738,4 +739,156 @@ func scanFileForIndirectEventuallyReferences(
 	}
 
 	return out
+}
+
+// TestEventuallyFunnel_DeterministicNoTimeoutParam locks the signature of
+// testwait.Deterministic: its non-variadic parameters must not include a
+// time.Duration argument. This enforces the design decision that Deterministic
+// is a deterministic-signal wait, not a latency-budget wait — any
+// caller-supplied timeout would be a latency budget (the root cause of
+// race-CI flakes in observer_test.go, issue #1320).
+//
+// AI-robust grading:
+//   - Hard downstream: archtest resolves the *types.Signature of Deterministic
+//     via go/types and fails immediately if any non-variadic parameter has type
+//     time.Duration. The (callee, form) check is unique — no other shape can
+//     introduce a timeout parameter without tripping this test.
+//   - Medium upstream: "forbid adding a new parameter" is a Go-language ceiling.
+//     The axis "who may declare a given function's parameters" is not expressible
+//     in the Go type system; no type-level gate can prevent a PR from adding
+//     `timeout time.Duration` to the Deterministic signature. This is the same
+//     permanent ceiling shape as #851 (SPAN-SETATTR-HOLDER-SEAL),
+//     #893 (HEALTHZ-HOLDER-SEAL), and #1282 (OUTBOX-RECONSTRUCTION-CALLER);
+//     tracked as gh issue #1352 (won't-do).
+//
+// Blind spots of this archtest tool (per ai-robust §"工具选定后强制盲区自检"):
+//
+//  1. Type alias bypass: `type Budget = time.Duration` — does types.Identical
+//     cover aliases? Yes: types.Identical uses structural identity for named
+//     types and resolves aliases to their underlying type, so
+//     `types.Identical(param.Type(), timeDurationType)` returns true for both
+//     `time.Duration` and any alias thereof. This blind spot is CLOSED.
+//  2. New wrapper function: a PR could add a new exported function
+//     DeterministicWithTimeout(t TB, signal <-chan T, timeout time.Duration)
+//     that internally calls Deterministic. This archtest only locks
+//     Deterministic's own signature, not wrapper patterns; adding such a
+//     wrapper would not be caught. This is a known open blind spot — mitigation
+//     requires a broader "no exported testwait function may accept time.Duration"
+//     rule, which would require scanning all exported funcs in the package.
+//     Accepted as low risk: the exported API of pkg/testutil/testwait is small
+//     and reviewed on every PR.
+//  3. Deterministic renamed: if the function is renamed, this archtest silently
+//     stops guarding it. Mitigated by the fact that any rename is a breaking
+//     change visible in diff and reviewed.
+//
+// Tool: RunTyped + *types.Package.Scope().Lookup + *types.Signature parameter
+// iteration. Reuses the existing module-wide typed load.
+func TestEventuallyFunnel_DeterministicNoTimeoutParam(t *testing.T) {
+	t.Parallel()
+
+	const (
+		testwaitPkgPath       = "github.com/ghbvf/gocell/pkg/testutil/testwait"
+		deterministicFuncName = "Deterministic"
+		timePkgPath           = "time"
+		durationTypeName      = "Duration"
+		ruleID                = "TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01"
+	)
+
+	var (
+		sigFound         bool
+		violations       []string
+		timeDurationType types.Type
+	)
+
+	scan := func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+
+		// Locate time.Duration type once from any package that imports "time".
+		if timeDurationType == nil {
+			for _, imp := range p.Pkg.Imports() {
+				if imp.Path() == timePkgPath {
+					obj := imp.Scope().Lookup(durationTypeName)
+					if obj != nil {
+						timeDurationType = obj.Type()
+					}
+					break
+				}
+			}
+		}
+
+		// Locate the testwait package and inspect Deterministic's signature.
+		if p.Pkg.Path() != testwaitPkgPath {
+			return nil
+		}
+
+		obj := p.Pkg.Scope().Lookup(deterministicFuncName)
+		if obj == nil {
+			violations = append(violations,
+				"testwait.Deterministic not found in package scope — function renamed?")
+			return nil
+		}
+		sigFound = true
+
+		fn, ok := obj.(*types.Func)
+		if !ok {
+			violations = append(violations,
+				"testwait.Deterministic is not a *types.Func")
+			return nil
+		}
+
+		sig, ok := fn.Type().(*types.Signature)
+		if !ok {
+			violations = append(violations,
+				"testwait.Deterministic has no *types.Signature")
+			return nil
+		}
+
+		// Walk non-variadic parameters. The variadic tail (...any for msgAndArgs)
+		// is excluded: sig.Params() includes all params; sig.Variadic() tells us
+		// the last one is variadic. We check all but the last when variadic.
+		params := sig.Params()
+		paramCount := params.Len()
+		checkUpTo := paramCount
+		if sig.Variadic() && paramCount > 0 {
+			checkUpTo = paramCount - 1
+		}
+
+		if timeDurationType == nil {
+			// time package not yet loaded; will be resolved on a later pass.
+			// Return nil and rely on the post-scan check below.
+			sigFound = false // reset so we re-check
+			return nil
+		}
+
+		for i := range checkUpTo {
+			param := params.At(i)
+			if types.Identical(param.Type(), timeDurationType) {
+				violations = append(violations, fmt.Sprintf(
+					"%s: Deterministic non-variadic param %d (%q) has type time.Duration — "+
+						"Deterministic must not accept a caller-facing timeout; it is a "+
+						"deterministic-signal wait. Caller-supplied timeouts are latency "+
+						"budgets (root cause of race-CI flakes, issue #1320). "+
+						"Use External(t, reason, cond, timeout, tick) for latency-budget waits.",
+					ruleID, i, param.Name(),
+				))
+			}
+		}
+		return nil
+	}
+
+	_ = RunTyped(t, TypedOpts{Tests: true}, []string{"./..."}, scan)
+
+	if !sigFound {
+		t.Errorf("%s: testwait.Deterministic signature not resolved — "+
+			"package %q not loaded or function not found. "+
+			"Check that the package path is correct and the module compiles.",
+			ruleID, testwaitPkgPath)
+		return
+	}
+
+	for _, v := range violations {
+		t.Errorf("%s: %s", ruleID, v)
+	}
 }


### PR DESCRIPTION
## Summary

合并两件 develop-health 工作（用户 `/ship #1320 + sonarcloud` 单 PR 决策）：

### 1. #1320 根治 — testwait flake

`TestExecute_ObserveOutcome_Failed` 在 `-race` 高负载 CI 偶发 `testwait 1s 超时`。根因不是 1s 太短，而是**给「保证会到达的确定性信号」套了一个 wall-clock 死线**，与 race 检测器的调度变慢赛跑。

修法（彻底 / 不向后兼容 / 优雅）：
- `testwait.Deterministic` **删除调用方 `timeout` 形参**，签名 `Deterministic[T](t, signal, msgAndArgs...)`；内部用单个 `const signalSafetyNet = 30s` 作 hung-test 兜底（非延迟预算，绿测永不命中，含 -race）。
- 42 处 callsite 的 `testtime.EventuallyShort/EventuallyDefault` 实参全删（executor_test 13 / heartbeat_test 7 / observer_test 12 / grpc integration 6 / testwait_test 4）。
- 无 `-race` build-tag 分支、无放大系数、无兼容 shim。
- enforcement（review F2 修正后的如实评级）：新增 archtest `TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01` 锁定签名不含 `time.Duration` 形参——**Hard 下游**（types-aware form-lock）+ **Medium 上游**（"签名不准新增某类型形参" Go 类型系统不可表达，是与 #851/#893/#1282 同形的语言天花板，won't-do 记于 #1352）。不再声称"类型层不可表达/AI-HARD"。
- `External`（轮询外部状态 / 断言一段时间内某事不发生）保留 timeout——它本质需要有界窗口。

### 2. SonarCloud OPEN/CONFIRMED 清零

> **更正（review F1）**：原 body 称"test S3776 ×11，rules_saga_test.go 抽 `runSagaRuleTable`（8 处）"——这是 rebase 前的描述。本 PR rebase 到含 #1316 的 develop 后，`kernel/governance/rules_saga_test.go` **取了 develop 版**（#1316 已独立把这 8 个 saga test 重构成表驱动，复杂度已 <15），本 PR **不再改该文件**、`runSagaRuleTable` helper 已弃用。故本 PR 实际清零的 test S3776 只有 mqtt 3 处；8 条 saga test S3776 由 develop #1316 解决（下次 Sonar 重扫自动关闭，与本 PR 无关）。

本 PR 实际处理的 finding：

| rule | 处理 |
|------|------|
| go:S3776 (production ×2) | `kernel/metadata/parser.go::indexWebhookSlice` 抽 `applyWebhookCU`；`cmd/gocell/app/check.go::checkSliceCoverage` 抽聚合 helper（均 16→<15） |
| go:S3776 (test ×3) | `adapters/mqtt` errors_test / integration_test ×2 抽 helper（16→<15） |
| go:S1192 ×2 | `kernel/reconcile/metrics.go`、`adapters/mqtt/metrics.go` 抽 const |
| godre:S8193 ×4 | subscriber.go / pgrepoapproved_test / router_clock_required_test / executor_test 内联多余变量 |
| go:S4144 | `adapters/grpc/server_test.go` table-driven 去重（测 zero+negative，无覆盖丢失） |
| godre:S8196 | `subscriber_dispatchack_test.go` 接口 `testingT`→`fatalfT`（-er 命名约定） |

> 8 条 saga test S3776（`rules_saga_test.go`）：由 develop #1316 解决，不在本 PR diff。

**plsql:S125**（`migrations/044_outbox_entries_principal.sql:7`）= SonarCloud 误报：那是 `+goose` 文档注释，非死代码，**不改**。下次 develop 重扫后在 Sonar 标 won't-fix。

合并后触发 SonarCloud 重扫 develop，上述有效 finding 自动关闭。

## Review round-2 修复（本轮）

针对多维 review 的 5 簇 8 finding：

- **F1**（本节上方更正）：PR body 不实声明已修正。
- **F2**：补 archtest 锁 `Deterministic` 签名（见 §1），如实评级 + #1352 天花板记录。
- **F3**：`itestSessionPhase2Subscribe`（本 PR 新增 helper）手写 poll 迁 `testwait.External`；`ClientIDConflict`（develop 既有）归 #1330 不碰。
- **F4**：`metrics_test.go::allReasons` 补 `consumeReasonAckFailed`（5→6，对齐注释 "all 6"，覆盖本 PR ackPoison 路径产物）。
- **F5**：`itestSessionPhase1Subscribe` 补「故意不 Close 保留持久会话」inline 说明 + `t.Cleanup(cancel1)` 防 panic 泄漏。
- **F6**：`subscriber_testhelpers_test.go` 注释残留 `testingT`→`fatalfT`（搭车清 develop 既有残留）。
- **F7**：ClosedChannel 用例补「closed 与 safety-net 均返零值但语义相反」差异注释。
- **F8**：`signalSafetyNet` godoc 补 timeout 依据（go test 默认 10m）+ CI 误触发诊断提示。

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...`（含全量 archtest 628+，含新 `TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01`）— 零 FAIL
- [x] `go test -race -count=3 -run TestExecute_ObserveOutcome ./runtime/saga/executor/...` — 稳定 PASS（#1320 复现路径）
- [x] archtest funnel（TEST-EVENTUALLY-FUNNEL-01 / TEST-POLLING-EXTERNAL-REASON-LITERAL-01 / TEST-TIME-LITERAL-01 / TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01）随全量绿

Closes #1320
Refs: sonarcloud go:S3776 / go:S1192 / godre:S8193 / godre:S8196 / go:S4144
Related: #1352 (Deterministic Hard-上游 ceiling won't-do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
