### PR TITLE
feat(webhook): receiver runtime + capability-token 闭环 [KERNEL-WEBHOOK-01 PR-3]

### DIFF
--- a/contracts/webhook/README.md
+++ b/contracts/webhook/README.md
@@ -10,19 +10,19 @@ in one of two directions:
 | `inbound` | receiver（接收外部回调，HMAC + timestamp + Claimer 三重保护） | `webhook-receive` | 外部 source 推送给我们 |
 | `outbound` | dispatcher（签名后推送，SSRF 防御 + 退避重试） | `webhook-dispatch` | 我们推送给外部 target |
 
-> **Scope note (PR-2)**: 本目录与 cellgen 派生**只覆盖契约识别 + 代码生成层**。运行时
-> （`reg.RegisterWebhookReceiver/Dispatch` 方法本体、HTTP 接收 middleware、dispatcher
-> outbox consumer、SSRF guard、healthz/metrics）在后续 PR 落地（receiver = PR-3，
-> SSRF = PR-4，dispatcher = PR-5）。kernel 纯计算内核（Signer/Verifier/Source）已在
-> PR-1（#1251）落地于 `kernel/webhook/`。
+> **Scope note (PR-2 → PR-3 landed)**: 本目录与 cellgen 派生覆盖**契约识别 + 代码生成层**。
+> PR-3（#1158）已落地 receiver 运行时（`runtime/webhook`：`Receiver`、`BuildRouteGroups`、
+> `bootstrap` phase5 drain），`reg.RegisterWebhookReceiver` 方法本体及 HTTP 接收 pipeline
+> 均已实现。kernel 纯计算内核（Signer/Verifier/Source）已在 PR-1（#1251）落地于 `kernel/webhook/`。
 >
-> **PR-2 → PR-3/5/6 排序约束（forward reference）**：cellgen 的 `cell.tmpl` 已无条件
-> emit `reg.RegisterWebhookReceiver/Dispatch` 调用，但这两个 `cell.Registrar` 方法本体
-> 在 PR-3/PR-5 才落地。PR-2 之所以 `go build ./...` 绿，是因为**当前没有任何真实 webhook
-> cell**——这些调用只存在于 cellgen 的 golden 文本夹具（`*.go.golden`，不参与编译）。
-> 因此 **PR-3（receiver）/ PR-5（dispatcher）必须先把对应 Registrar 方法 + bootstrap drain
-> 落地，才能生成第一个真实 webhook cell（PR-6 demo）**；否则 `gocell generate cell` 会产出
-> 引用不存在方法的 `cell_gen.go`（编译失败）。这是有意的 seam 排序，不是缺陷。
+> 仍待后续 PR 落地：SSRF guard（PR-4）、dispatcher outbox consumer（PR-5）、
+> healthz/metrics 探针（PR-6，KERNEL-WEBHOOK-01）。
+>
+> **PR-3 之后的排序约束**：`gocell generate cell` 现可为声明 `contractUsages[role=webhook-receive]`
+> 的 slice 派生 `reg.RegisterWebhookReceiver` 调用（方法本体已存在）。第一个真实 webhook cell
+> demo 在 PR-6 落地。dispatcher 路径（PR-5）落地前，`contractUsages[role=webhook-dispatch]`
+> 的 cellgen 派生仍引用未实现的 `reg.RegisterWebhookDispatch`，会导致编译失败——这是有意的
+> seam 排序，不是缺陷。
 >
 > **codegen 零产物语义**：webhook 契约即便 `codegen: true`，contractgen 也**有意产出零
 > per-contract 产物**（注册经 cellgen 字面量，不经 contractgen；见 `generator.go` webhook 分支
@@ -153,8 +153,8 @@ func (c *PaymentCoreCell) Init(ctx context.Context, reg cell.Registrar) error {
 
 `webhook.ReceiverSpec` / `DispatchSpec` 是 `kernel/webhook` 的纯数据结构；`CellID` 作为字面量
 由 cellgen 从 cell.yaml 注入（observability owner 溯源 cell 元数据，与 `reg.Subscribe` 的位置
-cellID 同源约束）。`reg.RegisterWebhookReceiver/Dispatch` 这两个 `cell.Registrar` 方法本体在
-PR-3/PR-5 落地。
+cellID 同源约束）。`reg.RegisterWebhookReceiver` 方法本体已在 PR-3（#1158）落地；
+`reg.RegisterWebhookDispatch` 在 PR-5 落地。
 
 ## 静态守卫（archtest）
 

--- a/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+++ b/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
@@ -115,7 +115,7 @@ multi-secret sources are a follow-up.
 | Timestamp outside tolerance window (replay) | 401 | `ErrWebhookTimestampExpired` |
 | Body exceeds configured limit | 413 | `ErrWebhookBodyTooLarge` |
 | Idempotent duplicate (ClaimDone — already processed) | 200 | — (silent success, safe for sender retry) |
-| Concurrent in-flight (ClaimBusy — another goroutine holds lease) | 409 | `ErrWebhookConflict` |
+| Concurrent in-flight (ClaimBusy — another goroutine holds lease) | 409 | `ErrWebhookDuplicateDelivery` |
 | Handler transient error (KindUnavailable / infra fault) | 503 | framework-mapped |
 | Handler permanent error | 500 | framework-mapped |
 
@@ -156,10 +156,9 @@ upstream for external callers).
 | Downstream (callsite) | `WEBHOOK-RECEIVER-PIPELINE-01` A2 locks `invokeHandler` callsites to require a `claimed` argument; A3 locks `claim` callsites to require a `verified` argument | **Hard** |
 
 The package-internal Medium upstream axis follows the same permanent Go-language
-ceiling as `OUTBOX-ENTRY-SEALED-CONSTRUCTION-01` (#1282 won't-do). Tracking
-issue for explicit Hard-ization: **gh #1321** (sealed unexported interface +
-private constructor, following #851/#1282 precedent). The funnel godoc names
-this issue.
+ceiling as `OUTBOX-ENTRY-SEALED-CONSTRUCTION-01` (#1282 won't-do). Package-internal
+upstream Hard-ization is constrained by the Go-language ceiling, the same
+won't-do precedent as #1282/#851; no independent tracking issue exists.
 
 ### 4. Built-in two-phase idempotency (Claimer)
 
@@ -167,8 +166,8 @@ The receiver runtime embeds `kernel/idempotency.Claimer` with key
 `webhook:{sourceID}:{deliveryID}` and 24h TTL. The pipeline is:
 
 ```
-Claim (get lease) → verify signature → invokeHandler → Commit
-                                    ↘ Release (on panic / transient error)
+readBody → verify signature → Claim (get lease) → invokeHandler → Commit
+                                                ↘ Release (on panic / transient error)
 ```
 
 **Rationale vs. Stripe/Svix/GitHub OSS approach:** OSS webhook libraries
@@ -240,4 +239,4 @@ are added and immediately closed by PR-3 controls.
 - Stripe webhook signatures: https://github.com/stripe/stripe-go/blob/master/webhook/client.go
 - ADR `202605051730-adr-errcode-message-pii-safety.md` (Message/Details/Internal redaction)
 - ADR `202604242030-adr-kernel-wrapper-contract-observability.md` §8 (span/error redaction)
-- ai-robust.md §Funnel 双向锁评级; gh #1243 (upstream Hard-ization A3), #851 (precedent), #1321 (pipeline token Hard-ization), #1282 (Go-language ceiling precedent)
+- ai-robust.md §Funnel 双向锁评级; gh #1243 (upstream Hard-ization A3), #851 (precedent), #1282 (Go-language ceiling precedent — pipeline token package-internal upstream Medium is the permanent ceiling, same won't-do shape)

--- a/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+++ b/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
@@ -83,18 +83,156 @@ private construction, following the SPAN-SETATTR-HOLDER-SEAL #851 precedent):
 |--------|-----------|--------|
 | Forged payload (no secret) | HMAC over full signed content; `hmac.Equal` | ✅ |
 | Algorithm downgrade (SHA-1) | single legal `Algorithm`; `Validate` rejects others | ✅ |
-| Replay of a captured valid delivery | bidirectional timestamp tolerance window | ⚠️ partial (bounded to ±tolerance; full idempotency dedupe is the receiver's Claimer, PR-3/PR-6) |
+| Replay of a captured valid delivery | timestamp tolerance window (bounds replay to ±5min) + receiver Claimer two-phase dedupe (key `webhook:{sourceID}:{deliveryID}`, TTL 24h); 409 on concurrent in-flight, Release on handler panic | ✅ (PR-3 #1158 landed — see Amendment below) |
 | Timing side-channel on signature compare | `hmac.Equal` constant-time; A2 AST lock | ✅ |
 | Secret leak via logs/spans/error text | unexported secret + no getter + `Source.LogValue` mask + redaction key set + archtest B6 | ✅ |
 | Secret mutation after construction | `NewSource` defensive copy | ✅ |
 | Body-shifting between signed-content fields | MAC covers the whole string; fields never parsed back | ✅ (no forgery without the secret) |
+| Source enumeration (probing unknown sourceID) | unknown source and signature failure both return 401 (ErrWebhookInvalidSignature); sourceId only in server-side Internal, never in wire details | ✅ (PR-3 #1158 landed — see Amendment below) |
+| Oversized body DoS | `http.MaxBytesReader` enforced before verify; 413 ErrWebhookBodyTooLarge | ✅ (PR-3 #1158 landed — see Amendment below) |
 
 ## Consequences
 
-- The receiver (PR-3) and dispatcher (PR-5) consume `Verifier`/`Signer` as the
-  only signing surface; they cannot introduce a second algorithm.
-- Secret rotation is supported on the verify side (multi-token header); persistent
-  multi-secret sources are a follow-up.
+The receiver (PR-3, now landed as #1158) and dispatcher (PR-5) consume
+`Verifier`/`Signer` as the only signing surface; they cannot introduce a second
+algorithm. The receiver enforces idempotency via a built-in `kernel/idempotency.Claimer`
+(two-phase Claim/Commit/Release); cell handlers do not write their own dedupe.
+Secret rotation is supported on the verify side (multi-token header); persistent
+multi-secret sources are a follow-up.
+
+## Amendment 2026-05-31: receiver runtime (PR-3, #1158)
+
+- Date: 2026-05-31
+- Context: PR-3 #1158 — receiver runtime (`runtime/webhook`) landed
+
+### 1. HTTP status code mapping (receive path)
+
+| Condition | Status | Error sentinel |
+|-----------|--------|----------------|
+| Missing or malformed signature/timestamp/delivery-id header | 400 | `ErrWebhookInvalidHeader` |
+| Signature verification failure | 401 | `ErrWebhookInvalidSignature` |
+| Unknown sourceId (unregistered source) | 401 | `ErrWebhookInvalidSignature` (unified — see §2) |
+| Timestamp outside tolerance window (replay) | 401 | `ErrWebhookTimestampExpired` |
+| Body exceeds configured limit | 413 | `ErrWebhookBodyTooLarge` |
+| Idempotent duplicate (ClaimDone — already processed) | 200 | — (silent success, safe for sender retry) |
+| Concurrent in-flight (ClaimBusy — another goroutine holds lease) | 409 | `ErrWebhookConflict` |
+| Handler transient error (KindUnavailable / infra fault) | 503 | framework-mapped |
+| Handler permanent error | 500 | framework-mapped |
+
+### 2. Source enumeration defense
+
+Unknown sourceId and signature verification failure are **unified to 401**
+(`ErrWebhookInvalidSignature`) on the wire. The distinction is intentionally
+erased: a probe that cycles through guessed source IDs receives the same
+response as a valid source ID with an invalid signature, preventing enumeration
+of registered sources.
+
+`sourceId` is recorded only via `errcode.WithInternal` (server-side slog),
+never in wire `details`. This aligns with the existing §Decision 5 secret-leak
+defense: the `Secret-leak` threat row in the Threat model remains ✅
+(no new leak vector introduced).
+
+### 3. Capability-token pipeline (AI-robust: Hard downstream / Medium upstream)
+
+The receiver pipeline enforces `verify → claim → invokeHandler` ordering at the
+Go type system level using unexported capability tokens:
+
+- `verified` token is produced only by `verify()` (requires valid signature).
+- `claimed` token is produced only by `claim()`, which requires a `verified`
+  argument.
+- `invokeHandler()` accepts only a `claimed` argument.
+
+Skipping `verify` or `claim`, or reordering the steps, is a **compile error**
+for any code in the `runtime/webhook` package. Package-external code cannot
+construct `verified` or `claimed` at all (unexported types — type-system Hard
+upstream for external callers).
+
+**AI-robust rating:**
+
+| Direction | Form | Rating |
+|-----------|------|--------|
+| Upstream (package-external) | `verified`/`claimed` are unexported types; package-external construction is a compile error | **Hard** |
+| Upstream (package-internal) | archtest `WEBHOOK-RECEIVER-PIPELINE-01` A1 locks struct field holder set for both token types; new in-package structs holding a token are caught at CI | **Medium** |
+| Downstream (callsite) | `WEBHOOK-RECEIVER-PIPELINE-01` A2 locks `invokeHandler` callsites to require a `claimed` argument; A3 locks `claim` callsites to require a `verified` argument | **Hard** |
+
+The package-internal Medium upstream axis follows the same permanent Go-language
+ceiling as `OUTBOX-ENTRY-SEALED-CONSTRUCTION-01` (#1282 won't-do). Tracking
+issue for explicit Hard-ization: **gh #1321** (sealed unexported interface +
+private constructor, following #851/#1282 precedent). The funnel godoc names
+this issue.
+
+### 4. Built-in two-phase idempotency (Claimer)
+
+The receiver runtime embeds `kernel/idempotency.Claimer` with key
+`webhook:{sourceID}:{deliveryID}` and 24h TTL. The pipeline is:
+
+```
+Claim (get lease) → verify signature → invokeHandler → Commit
+                                    ↘ Release (on panic / transient error)
+```
+
+**Rationale vs. Stripe/Svix/GitHub OSS approach:** OSS webhook libraries
+(go-github, svix-go) leave deduplication to the application layer (e.g., Svix
+docs recommend consumer-side `webhook-id + Redis/24h`). GoCell's receiver is a
+framework component, not a library: embedding Claimer matches GoCell's own
+event-consumer pattern (`ConsumerBase`) and delivers three structural benefits:
+
+1. **409 on concurrent in-flight** — triggers sender back-off, preventing
+   duplicate processing races.
+2. **Release on handler panic** — prevents lease deadlock that would otherwise
+   permanently block re-delivery.
+3. **Cell handlers are dedupe-free** — cells do not write their own idempotency
+   logic for incoming webhooks, consistent with the event-consumer contract.
+
+**Threat model impact:** `Replay of a captured valid delivery` row updated from
+⚠️ partial to ✅ (see Threat model table above). The ±5min timestamp window
+was already present in PR-1; the Claimer adds the second layer — deliveries that
+arrive within the tolerance window but are exact repeats (same `deliveryID`) are
+caught by the Claimer's 24h dedupe window and returned 200 to the sender.
+
+### 5. Body limiting
+
+`http.MaxBytesReader` is applied to the request body **before** any read,
+capping at `ReceiverSpec.MaxBodyBytes` (default configurable per receiver via
+cellgen-baked `webhook.ReceiverSpec`). Any read beyond the limit returns 413
+`ErrWebhookBodyTooLarge`.
+
+Rationale vs. alternatives: `io.LimitReader` (used by go-github) silently
+truncates — the truncated body would produce a signature mismatch and return
+401, hiding the real cause. `http.MaxBytesReader` returns an explicit error
+that the receiver maps to 413, making the limit visible to the sender.
+
+### 6. Configuration single source (cellgen-baked ReceiverSpec)
+
+Receiver runtime configuration (`pathPattern`, `headers`, `tolerance`,
+`maxBodyBytes`) is baked into `webhook.ReceiverSpec` literals by cellgen from
+`contract.yaml` at code-generation time, analogous to how event-consumer
+`Topic` is baked from `contractUsages[role=subscribe]`. There is no runtime
+config file read or environment variable lookup for these values; they are
+compile-time constants from the cell's perspective.
+
+This means a cell cannot accidentally use a stale or environment-specific
+receiver configuration: the contract.yaml is the single source of truth,
+and a mismatch between contract and runtime requires a regenerate + rebuild.
+
+### Threat model re-evaluation (per ai-robust.md §ADR amendment 落地必查)
+
+All rows re-evaluated against the PR-3 implementation:
+
+| Threat | Pre-PR-3 status | Post-PR-3 status | Change rationale |
+|--------|----------------|-----------------|-----------------|
+| Forged payload (no secret) | ✅ | ✅ | No change. PR-3 only adds HTTP transport; HMAC core unchanged. |
+| Algorithm downgrade (SHA-1) | ✅ | ✅ | No change. `Algorithm.Validate` not touched. |
+| Replay of a captured valid delivery | ⚠️ partial | ✅ | **Upgraded.** PR-3 lands the Claimer (key `webhook:{sourceID}:{deliveryID}`, 24h TTL). Timestamp window was already in PR-1; Claimer adds within-window exact-duplicate dedupe. Both layers now active. |
+| Timing side-channel on signature compare | ✅ | ✅ | No change. `hmac.Equal` path unchanged; A2 archtest still holds. |
+| Secret leak via logs/spans/error text | ✅ | ✅ | PR-3 receiver adds `sourceId` to `errcode.WithInternal` only; wire `details` is empty for 5xx by framework strip, and the 401 path carries no details either. No new leak vector. |
+| Secret mutation after construction | ✅ | ✅ | `NewSource` defensive copy unchanged. |
+| Body-shifting between signed-content fields | ✅ | ✅ | MAC covers whole string; receiver reads body as bytes before passing to verifier, no intermediate parse. |
+| Source enumeration (new row) | n/a | ✅ | PR-3 unifies unknown-source and bad-signature to the same 401 code and message. sourceId confined to Internal. Covered by §2 above. |
+| Oversized body DoS (new row) | n/a | ✅ | PR-3 applies `http.MaxBytesReader` before any body read. Covered by §5 above. |
+
+No previously-✅ row regressed. Two new threats (source enumeration, body DoS)
+are added and immediately closed by PR-3 controls.
 
 ## References
 
@@ -102,4 +240,4 @@ private construction, following the SPAN-SETATTR-HOLDER-SEAL #851 precedent):
 - Stripe webhook signatures: https://github.com/stripe/stripe-go/blob/master/webhook/client.go
 - ADR `202605051730-adr-errcode-message-pii-safety.md` (Message/Details/Internal redaction)
 - ADR `202604242030-adr-kernel-wrapper-contract-observability.md` §8 (span/error redaction)
-- ai-robust.md §Funnel 双向锁评级; gh #1243 (upstream Hard-ization), #851 (precedent)
+- ai-robust.md §Funnel 双向锁评级; gh #1243 (upstream Hard-ization A3), #851 (precedent), #1321 (pipeline token Hard-ization), #1282 (Go-language ceiling precedent)

--- a/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+++ b/docs/architecture/202605291200-adr-webhook-signing-algorithm.md
@@ -83,7 +83,7 @@ private construction, following the SPAN-SETATTR-HOLDER-SEAL #851 precedent):
 |--------|-----------|--------|
 | Forged payload (no secret) | HMAC over full signed content; `hmac.Equal` | ✅ |
 | Algorithm downgrade (SHA-1) | single legal `Algorithm`; `Validate` rejects others | ✅ |
-| Replay of a captured valid delivery | timestamp tolerance window (bounds replay to ±5min) + receiver Claimer two-phase dedupe (key `webhook:{sourceID}:{deliveryID}`, TTL 24h); 409 on concurrent in-flight, Release on handler panic | ✅ (PR-3 #1158 landed — see Amendment below) |
+| Replay of a captured valid delivery | timestamp tolerance window (bounds replay to ±5min) + receiver Claimer two-phase dedupe (key `webhook:{sourceID}:{deliveryID}`, TTL 24h); 409 on concurrent in-flight, Release on handler panic | ✅ under normal operation; degrades to timestamp-window + at-least-once on Commit infra fault or provider-retry-window > done-TTL — handlers must be idempotent (PR-3 #1158; see Amendment §4 Degradation modes) |
 | Timing side-channel on signature compare | `hmac.Equal` constant-time; A2 AST lock | ✅ |
 | Secret leak via logs/spans/error text | unexported secret + no getter + `Source.LogValue` mask + redaction key set + archtest B6 | ✅ |
 | Secret mutation after construction | `NewSource` defensive copy | ✅ |
@@ -222,7 +222,7 @@ All rows re-evaluated against the PR-3 implementation:
 |--------|----------------|-----------------|-----------------|
 | Forged payload (no secret) | ✅ | ✅ | No change. PR-3 only adds HTTP transport; HMAC core unchanged. |
 | Algorithm downgrade (SHA-1) | ✅ | ✅ | No change. `Algorithm.Validate` not touched. |
-| Replay of a captured valid delivery | ⚠️ partial | ✅ | **Upgraded.** PR-3 lands the Claimer (key `webhook:{sourceID}:{deliveryID}`, 24h TTL). Timestamp window was already in PR-1; Claimer adds within-window exact-duplicate dedupe. Both layers now active. |
+| Replay of a captured valid delivery | ⚠️ partial | ✅ (best-effort) | **Upgraded, with documented degradation.** PR-3 lands the Claimer (key `webhook:{sourceID}:{deliveryID}`, 24h TTL). Timestamp window was already in PR-1; Claimer adds within-window exact-duplicate dedupe. Both layers now active. **Not absolute**: Commit infra fault or a provider retry window exceeding the 24h done-TTL drops back to timestamp-window + at-least-once for that delivery — see §4 Degradation modes. Handlers are required to be idempotent ([webhook.WebhookReceiveHandler] godoc). |
 | Timing side-channel on signature compare | ✅ | ✅ | No change. `hmac.Equal` path unchanged; A2 archtest still holds. |
 | Secret leak via logs/spans/error text | ✅ | ✅ | PR-3 receiver adds `sourceId` to `errcode.WithInternal` only; wire `details` is empty for 5xx by framework strip, and the 401 path carries no details either. No new leak vector. |
 | Secret mutation after construction | ✅ | ✅ | `NewSource` defensive copy unchanged. |

--- a/kernel/cell/registry_test.go
+++ b/kernel/cell/registry_test.go
@@ -504,15 +504,21 @@ var _ = RouteGroup{Register: func(m RouteMux) error {
 // Webhook record-only API (PR-2)
 // ---------------------------------------------------------------------------
 
-func noopWebhookHandler(_ context.Context, _ []byte) error { return nil }
+func noopWebhookHandler(_ context.Context, _ webhook.Delivery) error { return nil }
 
 func noopWebhookSelector(_ context.Context, _ []byte) (string, error) { return "target", nil }
 
 func validReceiverSpec() webhook.ReceiverSpec {
 	return webhook.ReceiverSpec{
-		ContractID: "webhook.stripe.payment-events.v1",
-		SourceID:   "stripe",
-		CellID:     "hooks",
+		ContractID:       "webhook.stripe.payment-events.v1",
+		SourceID:         "stripe",
+		CellID:           "hooks",
+		PathPattern:      "/api/webhooks/stripe/payment-events",
+		DeliveryIDHeader: "X-Delivery-Id",
+		TimestampHeader:  "X-Timestamp",
+		SignatureHeader:  "X-Signature",
+		ToleranceSeconds: 300,
+		MaxBodyBytes:     1048576,
 	}
 }
 

--- a/kernel/webhook/conformance_test.go
+++ b/kernel/webhook/conformance_test.go
@@ -1,0 +1,28 @@
+package webhook_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/kernel/webhook/webhooktest"
+)
+
+// TestSignerVerifierConformance wires the HMAC implementations into the
+// sign↔verify behavioral contract suite defined in
+// kernel/webhook/webhooktest. Any future Signer/Verifier implementation
+// must produce a sibling call to RunSignerVerifierConformance in its own
+// package.
+func TestSignerVerifierConformance(t *testing.T) {
+	webhooktest.RunSignerVerifierConformance(t,
+		// newSigner: direct match to webhook.NewHMACSigner signature.
+		webhook.NewHMACSigner,
+		// newVerifier: adapt NewHMACVerifier using a clockmock pinned to ts.
+		// clockmock is imported here (test file) so webhooktest/conformance.go
+		// (non-_test.go) stays within kernel-isolation rules.
+		func(ts time.Time) (webhook.Verifier, error) {
+			return webhook.NewHMACVerifier(clockmock.New(ts))
+		},
+	)
+}

--- a/kernel/webhook/spec.go
+++ b/kernel/webhook/spec.go
@@ -35,6 +35,15 @@ type Delivery struct {
 // handler a Delivery that has already been HMAC-verified and idempotency-claimed;
 // a non-nil error signals the receiver runtime to reject (NACK) the delivery.
 //
+// Handlers MUST be idempotent. The receiver's Claimer is defense-in-depth, not
+// a sole guarantee: webhook delivery is at-least-once by nature (network
+// retries, provider redelivery), and the dedupe window is bounded by the
+// Claimer's done-TTL — a duplicate arriving after that window (e.g. a provider
+// whose retry horizon exceeds the TTL) will re-invoke the handler. This matches
+// the consumer-side guidance of Stripe / Svix, which leave deduplication to the
+// application; GoCell additionally provides the Claimer as a framework-level
+// best-effort layer.
+//
 // PR-3: signature upgraded from func(ctx, []byte) error to func(ctx, Delivery)
 // error in lockstep with the cellgen template and the generated method values it
 // binds. GoCell carries no backward-compat burden (CLAUDE.md).

--- a/kernel/webhook/spec.go
+++ b/kernel/webhook/spec.go
@@ -6,18 +6,39 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// Delivery carries the fully-verified context of an inbound webhook request.
+// The receiver runtime populates a Delivery after reading the body, validating
+// the HMAC signature, and claiming the delivery ID for idempotency. Handlers
+// receive a Delivery and must not mutate its Payload slice.
+type Delivery struct {
+	// DeliveryID is the per-delivery identifier extracted from the configured
+	// DeliveryIDHeader and validated before signature verification.
+	DeliveryID DeliveryID
+
+	// SourceID is the secret-isolation key that was used to verify this
+	// delivery (i.e. the ReceiverSpec.SourceID that matched the inbound request).
+	SourceID SourceID
+
+	// Headers are the signature headers that were verified: DeliveryID,
+	// Timestamp, and Signature. Re-using webhook.Headers avoids a parallel
+	// type; the runtime has already checked all three fields before delivery.
+	Headers Headers
+
+	// Payload is the raw request body after signature verification. The slice
+	// is owned by the receiver runtime; handlers must not retain it past the
+	// handler call.
+	Payload []byte
+}
+
 // WebhookReceiveHandler is the inbound-webhook handler signature cellgen emits
-// as the second argument to reg.RegisterWebhookReceiver. The runtime resolves
-// the verified payload of an inbound webhook request and hands it to the
-// handler; a non-nil error signals the receiver runtime to reject the delivery.
+// as the second argument to reg.RegisterWebhookReceiver. The runtime hands the
+// handler a Delivery that has already been HMAC-verified and idempotency-claimed;
+// a non-nil error signals the receiver runtime to reject (NACK) the delivery.
 //
-// PR-2 record-only seam: this signature is intentionally minimal (stdlib types
-// only) because PR-2 closes the cellgen ↔ Registrar compile gap without wiring
-// any runtime. The PR-3 receiver runtime MAY refine the signature (e.g. carry a
-// richer Delivery value instead of raw []byte) — GoCell carries no
-// backward-compat burden (CLAUDE.md), so PR-3 is free to evolve this type in
-// lockstep with the cellgen template and the generated method values it binds.
-type WebhookReceiveHandler func(ctx context.Context, payload []byte) error
+// PR-3: signature upgraded from func(ctx, []byte) error to func(ctx, Delivery)
+// error in lockstep with the cellgen template and the generated method values it
+// binds. GoCell carries no backward-compat burden (CLAUDE.md).
+type WebhookReceiveHandler func(ctx context.Context, d Delivery) error
 
 // WebhookDispatchSelector is the outbound-webhook target-selector signature
 // cellgen emits as the second argument to reg.RegisterWebhookDispatch. Given an
@@ -33,19 +54,15 @@ type WebhookReceiveHandler func(ctx context.Context, payload []byte) error
 type WebhookDispatchSelector func(ctx context.Context, payload []byte) (string, error)
 
 // ReceiverSpec is the pure-data descriptor cellgen emits into cell_gen.go to
-// register an inbound webhook receiver. It carries only identifiers known at
-// code-generation time — ContractID (slice.yaml contractUsages.contract),
-// SourceID (slice.yaml contractUsages.sourceID, the secret-isolation key that
-// selects the signing secret used to verify inbound requests from the external
-// source), and CellID (cell.yaml id, injected as a literal so the observability
-// owner traces to cell metadata, mirroring reg.Subscribe's positional cellID).
-// The runtime path resolves everything else (HTTP route mount, signature config,
-// Claimer) from contract metadata.
+// register an inbound webhook receiver. ContractID, SourceID, and CellID are
+// the code-generation-time identifiers (stable since PR-2); PathPattern,
+// DeliveryIDHeader, TimestampHeader, SignatureHeader, ToleranceSeconds, and
+// MaxBodyBytes are the receiver runtime configuration that cellgen bakes from
+// contract.yaml (signature / endpoints.inbound / payload sections) in batch B.
 //
 // The reg.RegisterWebhookReceiver Registrar method and its bootstrap drain land
-// in PR-3 (receiver runtime). This struct is the cellgen ↔ runtime seam that
-// PR-2 stabilizes so the generated literal references a real type rather than a
-// forward reference; the dispatch counterpart is [DispatchSpec].
+// in PR-3 (receiver runtime). This struct is the cellgen ↔ runtime seam; the
+// dispatch counterpart is [DispatchSpec].
 type ReceiverSpec struct {
 	ContractID string
 	// SourceID is the secret-isolation key: it selects the signing secret used
@@ -53,12 +70,64 @@ type ReceiverSpec struct {
 	// source. Must match contract.yaml endpoints.inbound.sourceID.
 	SourceID string
 	CellID   string
+
+	// Runtime configuration — cellgen bakes these from contract.yaml fields.
+	// PathPattern is the URL path pattern the receiver runtime mounts
+	// (contract.yaml endpoints.inbound.pathPattern).
+	PathPattern string
+	// DeliveryIDHeader is the HTTP header name carrying the per-delivery
+	// identifier (contract.yaml signature.deliveryIDHeader).
+	DeliveryIDHeader string
+	// TimestampHeader is the HTTP header name carrying the unix-seconds
+	// timestamp that is part of the signed content
+	// (contract.yaml signature.timestampHeader).
+	TimestampHeader string
+	// SignatureHeader is the HTTP header name carrying the space-separated
+	// "v1,<base64>" HMAC tokens (contract.yaml signature.signatureHeader).
+	SignatureHeader string
+	// ToleranceSeconds is the bidirectional timestamp window in seconds within
+	// which a signed delivery is accepted (contract.yaml
+	// signature.toleranceSeconds). Must be > 0.
+	ToleranceSeconds int64
+	// MaxBodyBytes is the maximum accepted request body size in bytes
+	// (contract.yaml payload.maxBodyBytes). Must be > 0.
+	MaxBodyBytes int64
 }
 
 // Validate reports an [errcode.ErrWebhookConfigInvalid] error when any required
-// field is empty. The zero value is invalid.
+// field is empty or out of range. The zero value is invalid.
 func (s ReceiverSpec) Validate() error {
-	return validateSpecFields(s.ContractID, s.SourceID, s.CellID)
+	if err := validateSpecFields(s.ContractID, s.SourceID, s.CellID); err != nil {
+		return err
+	}
+	switch {
+	case s.PathPattern == "":
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: ReceiverSpec requires a non-empty PathPattern",
+			errcode.WithDetails(errcode.PublicString("contractID", s.ContractID)))
+	case s.DeliveryIDHeader == "":
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: ReceiverSpec requires a non-empty DeliveryIDHeader",
+			errcode.WithDetails(errcode.PublicString("contractID", s.ContractID)))
+	case s.TimestampHeader == "":
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: ReceiverSpec requires a non-empty TimestampHeader",
+			errcode.WithDetails(errcode.PublicString("contractID", s.ContractID)))
+	case s.SignatureHeader == "":
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: ReceiverSpec requires a non-empty SignatureHeader",
+			errcode.WithDetails(errcode.PublicString("contractID", s.ContractID)))
+	case s.ToleranceSeconds <= 0:
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: ReceiverSpec ToleranceSeconds must be positive",
+			errcode.WithDetails(errcode.PublicString("contractID", s.ContractID)))
+	case s.MaxBodyBytes <= 0:
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: ReceiverSpec MaxBodyBytes must be positive",
+			errcode.WithDetails(errcode.PublicString("contractID", s.ContractID)))
+	default:
+		return nil
+	}
 }
 
 // DispatchSpec is the pure-data descriptor cellgen emits to register an outbound

--- a/kernel/webhook/spec_test.go
+++ b/kernel/webhook/spec_test.go
@@ -13,14 +13,27 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
-// TestReceiverSpecValidate_ValidAllFieldsSet verifies that ReceiverSpec.Validate()
-// returns nil when ContractID, SourceID, and CellID are all non-empty.
-func TestReceiverSpecValidate_ValidAllFieldsSet(t *testing.T) {
-	spec := webhook.ReceiverSpec{
-		ContractID: "webhook.stripe.events.v1",
-		SourceID:   "stripe",
-		CellID:     "paymentcore",
+// validReceiverSpecExt returns a fully-populated ReceiverSpec for external
+// (webhook_test package) tests. Mirrors the internal validReceiverSpec helper
+// in registry_test.go; kept in sync with any ReceiverSpec field additions.
+func validReceiverSpecExt() webhook.ReceiverSpec {
+	return webhook.ReceiverSpec{
+		ContractID:       "webhook.stripe.events.v1",
+		SourceID:         "stripe",
+		CellID:           "paymentcore",
+		PathPattern:      "/api/webhooks/stripe/events",
+		DeliveryIDHeader: "X-Delivery-Id",
+		TimestampHeader:  "X-Timestamp",
+		SignatureHeader:  "X-Signature",
+		ToleranceSeconds: 300,
+		MaxBodyBytes:     1048576,
 	}
+}
+
+// TestReceiverSpecValidate_ValidAllFieldsSet verifies that ReceiverSpec.Validate()
+// returns nil when all required fields are non-empty and in-range.
+func TestReceiverSpecValidate_ValidAllFieldsSet(t *testing.T) {
+	spec := validReceiverSpecExt()
 	require.NoError(t, spec.Validate())
 }
 
@@ -36,40 +49,61 @@ func TestDispatchSpecValidate_ValidAllFieldsSet(t *testing.T) {
 }
 
 // TestReceiverSpecValidate_MissingFields verifies that ReceiverSpec.Validate()
-// returns an error when any of the three required fields is empty.
+// returns an error when any required field is empty or out of range.
 func TestReceiverSpecValidate_MissingFields(t *testing.T) {
+	base := validReceiverSpecExt()
 	tests := []struct {
-		name string
-		spec webhook.ReceiverSpec
+		name  string
+		mutFn func(s webhook.ReceiverSpec) webhook.ReceiverSpec
 	}{
 		{
-			name: "missing ContractID",
-			spec: webhook.ReceiverSpec{
-				ContractID: "",
-				SourceID:   "stripe",
-				CellID:     "paymentcore",
-			},
+			name:  "missing ContractID",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.ContractID = ""; return s },
 		},
 		{
-			name: "missing SourceID",
-			spec: webhook.ReceiverSpec{
-				ContractID: "webhook.stripe.events.v1",
-				SourceID:   "",
-				CellID:     "paymentcore",
-			},
+			name:  "missing SourceID",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.SourceID = ""; return s },
 		},
 		{
-			name: "missing CellID",
-			spec: webhook.ReceiverSpec{
-				ContractID: "webhook.stripe.events.v1",
-				SourceID:   "stripe",
-				CellID:     "",
-			},
+			name:  "missing CellID",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.CellID = ""; return s },
+		},
+		{
+			name:  "missing PathPattern",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.PathPattern = ""; return s },
+		},
+		{
+			name:  "missing DeliveryIDHeader",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.DeliveryIDHeader = ""; return s },
+		},
+		{
+			name:  "missing TimestampHeader",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.TimestampHeader = ""; return s },
+		},
+		{
+			name:  "missing SignatureHeader",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.SignatureHeader = ""; return s },
+		},
+		{
+			name:  "zero ToleranceSeconds",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.ToleranceSeconds = 0; return s },
+		},
+		{
+			name:  "negative ToleranceSeconds",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.ToleranceSeconds = -1; return s },
+		},
+		{
+			name:  "zero MaxBodyBytes",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.MaxBodyBytes = 0; return s },
+		},
+		{
+			name:  "negative MaxBodyBytes",
+			mutFn: func(s webhook.ReceiverSpec) webhook.ReceiverSpec { s.MaxBodyBytes = -1; return s },
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.spec.Validate()
+			err := tt.mutFn(base).Validate()
 			requireWebhookConfigInvalid(t, err)
 		})
 	}

--- a/kernel/webhook/verifier.go
+++ b/kernel/webhook/verifier.go
@@ -80,7 +80,7 @@ func (v *hmacVerifier) Verify(rawBody []byte, headers Headers, source Source) er
 		// is not a source-ID enumeration oracle (WEBHOOK-HMAC-FUNNEL-01 F8/F9).
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
 			"webhook: no presented signature matches the computed digest",
-			errcode.WithInternal(errcode.InternalAttr("sourceId", string(source.id))))
+			errcode.WithInternal(errcode.InternalAttr("source_id", string(source.id))))
 	}
 	return nil
 }
@@ -99,12 +99,15 @@ func (v *hmacVerifier) validateTimestamp(timestamp string) error {
 		skew = -skew
 	}
 	if skew > v.tolerance {
+		// skewSeconds is server-side only: exposing the exact skew in wire
+		// details would let an attacker calibrate replay timing. toleranceSeconds
+		// is safe to expose (it is the configured window, not a runtime secret).
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookTimestampExpired,
 			"webhook: signature timestamp is outside the tolerance window",
 			errcode.WithDetails(
-				errcode.PublicInt("skewSeconds", int64(skew/time.Second)),
 				errcode.PublicInt("toleranceSeconds", int64(v.tolerance/time.Second)),
-			))
+			),
+			errcode.WithInternal(errcode.InternalAttr("skewSeconds", int64(skew/time.Second))))
 	}
 	return nil
 }

--- a/kernel/webhook/verifier.go
+++ b/kernel/webhook/verifier.go
@@ -15,6 +15,27 @@ import (
 // delivery is accepted (replay defense). ±5min matches Stripe / Svix defaults.
 const defaultTolerance = 5 * time.Minute
 
+// MsgSignatureVerificationFailed is the single, generic wire message returned by
+// every inbound-webhook authentication failure that resolves to HTTP 401 with
+// [errcode.ErrWebhookInvalidSignature]: an unregistered/unknown source (receiver
+// SourceStore miss) and a non-matching HMAC signature (this verifier) MUST be
+// byte-identical on the wire so the receive path is not a source-ID enumeration
+// oracle (OWASP Authentication Cheat Sheet §Generic Error Messages;
+// WEBHOOK-HMAC-FUNNEL-01 F8/F9). The differentiating reason lives in each
+// caller's WithInternal attribute (server-side slog only, never on the wire).
+//
+// This is a shared-const convention (Soft): both 401 emit points reference it,
+// but a future third path could still construct a different literal. The narrow
+// exploitability (source IDs are route-bound, not attacker-supplied) makes an
+// archtest disproportionate; the const + this godoc + the errcode.go contract
+// note are the single source of the required wire text.
+//
+// ref: stripe/stripe-go webhook/client.go@master / svix/svix-webhooks
+// go/webhook.go@main — neither performs a source lookup (secret is caller-
+// supplied), so this oracle surface is GoCell-specific; OWASP provides the
+// governing principle.
+const MsgSignatureVerificationFailed = "webhook: signature verification failed"
+
 // Verifier checks the signature [Headers] of an inbound webhook against a
 // [Source]'s secret. The interface is sealed (unexported sealed() marker): the
 // sole implementation is the HMAC-SHA256 verifier from [NewHMACVerifier]
@@ -79,8 +100,10 @@ func (v *hmacVerifier) Verify(rawBody []byte, headers Headers, source Source) er
 		// 401 must be uniform with the unknown-source case so the receive path
 		// is not a source-ID enumeration oracle (WEBHOOK-HMAC-FUNNEL-01 F8/F9).
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
-			"webhook: no presented signature matches the computed digest",
-			errcode.WithInternal(errcode.InternalAttr("source_id", string(source.id))))
+			MsgSignatureVerificationFailed,
+			errcode.WithInternal(
+				errcode.InternalAttr("source_id", string(source.id)),
+				errcode.InternalAttr("reason", "signature mismatch")))
 	}
 	return nil
 }

--- a/kernel/webhook/webhooktest/conformance.go
+++ b/kernel/webhook/webhooktest/conformance.go
@@ -31,6 +31,11 @@ import (
 
 const (
 	conformanceMinSecretLen = 24
+
+	// conformanceOutOfWindowSkew is the timestamp offset used to put a
+	// delivery outside the default ±5min tolerance window in the bidirectional
+	// timestamp-window test cases.
+	conformanceOutOfWindowSkew = 10 * time.Minute
 )
 
 // VerifierFactory creates a [webhook.Verifier] whose internal clock is pinned
@@ -160,8 +165,8 @@ func runTamperTimestampExpired(
 	t.Helper()
 	t.Run("tamper_timestamp_expired", func(t *testing.T) {
 		t.Parallel()
-		// Clock is 10 minutes past signing time; default tolerance is 5 min.
-		v := verifierAt(t, base.Add(10*time.Minute))
+		// Clock is conformanceOutOfWindowSkew past signing time; default tolerance is 5 min.
+		v := verifierAt(t, base.Add(conformanceOutOfWindowSkew))
 		err := v.Verify(payload, headers, src)
 		requireErrCode(t, err, errcode.ErrWebhookTimestampExpired, errcode.KindUnauthenticated)
 	})
@@ -215,7 +220,7 @@ func runTimestampOutsideWindow(
 	t.Run("timestamp_outside_window", func(t *testing.T) {
 		t.Parallel()
 		// Bidirectional: past the window in the negative direction.
-		v := verifierAt(t, base.Add(-10*time.Minute))
+		v := verifierAt(t, base.Add(-conformanceOutOfWindowSkew))
 		err := v.Verify(payload, headers, src)
 		requireErrCode(t, err, errcode.ErrWebhookTimestampExpired, errcode.KindUnauthenticated)
 	})

--- a/kernel/webhook/webhooktest/conformance.go
+++ b/kernel/webhook/webhooktest/conformance.go
@@ -1,0 +1,314 @@
+// Package webhooktest provides a sign↔verify conformance suite for
+// [webhook.Signer] and [webhook.Verifier] implementations. It is intended for
+// _test.go use only; production code must not import this package.
+//
+// kernel/ layering rule: non-_test.go files in kernel/ must not import testify
+// or kernel/clock/clockmock. This package uses stdlib testing.T helpers only
+// and accepts a VerifierFactory to avoid importing clockmock directly.
+//
+// Usage — wire in the package-level conformance call:
+//
+//	func TestSignerVerifierConformance(t *testing.T) {
+//	    webhooktest.RunSignerVerifierConformance(t,
+//	        webhook.NewHMACSigner,
+//	        func(ts time.Time) (webhook.Verifier, error) {
+//	            return webhook.NewHMACVerifier(clockmock.New(ts))
+//	        },
+//	    )
+//	}
+package webhooktest
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+const (
+	conformanceMinSecretLen = 24
+)
+
+// VerifierFactory creates a [webhook.Verifier] whose internal clock is pinned
+// to ts. The caller provides the factory so conformance.go does not import
+// kernel/clock/clockmock (kernel-isolation rule prohibits clockmock in
+// non-_test.go kernel files).
+type VerifierFactory func(ts time.Time) (webhook.Verifier, error)
+
+// conformanceSecret returns a 24-byte secret adequate for conformance tests.
+func conformanceSecret() []byte {
+	return bytes.Repeat([]byte("k"), conformanceMinSecretLen)
+}
+
+// conformanceSource builds a Source with sourceID "test-source" and the conformance secret.
+func conformanceSource(t *testing.T) webhook.Source {
+	t.Helper()
+	id, err := webhook.NewSourceID("test-source")
+	mustNoError(t, err, "NewSourceID")
+	src, err := webhook.NewSource(id, conformanceSecret())
+	mustNoError(t, err, "NewSource")
+	return src
+}
+
+// RunSignerVerifierConformance runs the sign↔verify behavioral contract suite.
+//
+// newSigner is a factory bound to a given Source.
+// newVerifier is a factory that pins the verifier's clock to the given time.
+//
+// Sub-cases:
+//  1. round_trip: sign produces Headers that verify passes.
+//  2. tamper_body: altering the body after signing → ErrWebhookInvalidSignature.
+//  3. tamper_signature: corrupted signature token → ErrWebhookInvalidSignature.
+//  4. tamper_timestamp_expired: out-of-window timestamp → ErrWebhookTimestampExpired.
+//  5. multi_token_rotation_first_matches: first valid token in multi-token header accepted.
+//  6. multi_token_rotation_second_matches: last token in multi-token header also accepted.
+//  7. timestamp_outside_window: bidirectional tolerance check.
+//  8. empty_secret_source_rejected_by_signer: zero-value Source → ErrWebhookConfigInvalid.
+//  9. no_matching_token: two non-matching tokens → ErrWebhookInvalidSignature.
+func RunSignerVerifierConformance(
+	t *testing.T,
+	newSigner func(webhook.Source) (webhook.Signer, error),
+	newVerifier VerifierFactory,
+) {
+	t.Helper()
+
+	base := time.Unix(1_700_000_000, 0)
+	basePayload := []byte("conformance-payload")
+	src := conformanceSource(t)
+
+	signer, err := newSigner(src)
+	mustNoError(t, err, "newSigner(src)")
+
+	deliveryID, err := webhook.NewDeliveryID("conf-del-01")
+	mustNoError(t, err, "NewDeliveryID")
+
+	goodHeaders, err := signer.Sign(basePayload, base, deliveryID)
+	mustNoError(t, err, "signer.Sign")
+
+	// verifierAt builds a Verifier pinned to ts.
+	verifierAt := func(t *testing.T, ts time.Time) webhook.Verifier {
+		t.Helper()
+		v, verr := newVerifier(ts)
+		mustNoError(t, verr, "newVerifier")
+		return v
+	}
+
+	runRoundTrip(t, src, basePayload, goodHeaders, base, verifierAt)
+	runTamperBody(t, src, basePayload, goodHeaders, base, verifierAt)
+	runTamperSignature(t, src, basePayload, goodHeaders, base, verifierAt)
+	runTamperTimestampExpired(t, src, basePayload, goodHeaders, base, verifierAt)
+	runMultiTokenFirstMatches(t, src, basePayload, goodHeaders, base, deliveryID, newSigner, verifierAt)
+	runMultiTokenSecondMatches(t, src, basePayload, goodHeaders, base, deliveryID, newSigner, verifierAt)
+	runTimestampOutsideWindow(t, src, basePayload, goodHeaders, base, verifierAt)
+	runEmptySecretSourceRejected(t, newSigner)
+	runNoMatchingToken(t, src, basePayload, goodHeaders, base, verifierAt)
+}
+
+func runRoundTrip(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("round_trip", func(t *testing.T) {
+		t.Parallel()
+		v := verifierAt(t, base)
+		requireNoError(t, v.Verify(payload, headers, src),
+			"sign→verify must succeed with matching body/headers/source")
+	})
+}
+
+func runTamperBody(
+	t *testing.T, src webhook.Source, _ []byte,
+	headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("tamper_body", func(t *testing.T) {
+		t.Parallel()
+		v := verifierAt(t, base)
+		err := v.Verify([]byte("tampered-body"), headers, src)
+		requireErrCode(t, err, errcode.ErrWebhookInvalidSignature, errcode.KindUnauthenticated)
+	})
+}
+
+func runTamperSignature(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("tamper_signature", func(t *testing.T) {
+		t.Parallel()
+		v := verifierAt(t, base)
+		tampered := headers
+		tampered.Signature = "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+		err := v.Verify(payload, tampered, src)
+		requireErrCode(t, err, errcode.ErrWebhookInvalidSignature, errcode.KindUnauthenticated)
+	})
+}
+
+func runTamperTimestampExpired(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("tamper_timestamp_expired", func(t *testing.T) {
+		t.Parallel()
+		// Clock is 10 minutes past signing time; default tolerance is 5 min.
+		v := verifierAt(t, base.Add(10*time.Minute))
+		err := v.Verify(payload, headers, src)
+		requireErrCode(t, err, errcode.ErrWebhookTimestampExpired, errcode.KindUnauthenticated)
+	})
+}
+
+func runMultiTokenFirstMatches(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	deliveryID webhook.DeliveryID,
+	newSigner func(webhook.Source) (webhook.Signer, error),
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("multi_token_rotation_first_matches", func(t *testing.T) {
+		t.Parallel()
+		altHeaders := buildAltHeaders(t, payload, base, deliveryID, "test-source-2", newSigner)
+		combined := headers
+		combined.Signature = headers.Signature + " " + altHeaders.Signature
+		v := verifierAt(t, base)
+		requireNoError(t, v.Verify(payload, combined, src),
+			"first matching token should satisfy verification")
+	})
+}
+
+func runMultiTokenSecondMatches(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	deliveryID webhook.DeliveryID,
+	newSigner func(webhook.Source) (webhook.Signer, error),
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("multi_token_rotation_second_matches", func(t *testing.T) {
+		t.Parallel()
+		altHeaders := buildAltHeaders(t, payload, base, deliveryID, "test-source-b", newSigner)
+		// Put the "wrong" token first, then the correct one.
+		combined := headers
+		combined.Signature = altHeaders.Signature + " " + headers.Signature
+		v := verifierAt(t, base)
+		requireNoError(t, v.Verify(payload, combined, src),
+			"any matching token anywhere in the header should satisfy verification")
+	})
+}
+
+func runTimestampOutsideWindow(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("timestamp_outside_window", func(t *testing.T) {
+		t.Parallel()
+		// Bidirectional: past the window in the negative direction.
+		v := verifierAt(t, base.Add(-10*time.Minute))
+		err := v.Verify(payload, headers, src)
+		requireErrCode(t, err, errcode.ErrWebhookTimestampExpired, errcode.KindUnauthenticated)
+	})
+}
+
+func runEmptySecretSourceRejected(
+	t *testing.T,
+	newSigner func(webhook.Source) (webhook.Signer, error),
+) {
+	t.Helper()
+	t.Run("empty_secret_source_rejected_by_signer", func(t *testing.T) {
+		t.Parallel()
+		_, err := newSigner(webhook.Source{})
+		if err == nil {
+			t.Fatal("expected error from newSigner with empty-secret source, got nil")
+		}
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+}
+
+func runNoMatchingToken(
+	t *testing.T, src webhook.Source, payload []byte,
+	headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("no_matching_token", func(t *testing.T) {
+		t.Parallel()
+		v := verifierAt(t, base)
+		bad := headers
+		bad.Signature = strings.Join([]string{
+			"v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+			"v1,BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+		}, " ")
+		err := v.Verify(payload, bad, src)
+		requireErrCode(t, err, errcode.ErrWebhookInvalidSignature, errcode.KindUnauthenticated)
+	})
+}
+
+// buildAltHeaders creates headers signed by an alternate source (different secret).
+func buildAltHeaders(
+	t *testing.T, payload []byte, ts time.Time,
+	deliveryID webhook.DeliveryID, sourceIDStr string,
+	newSigner func(webhook.Source) (webhook.Signer, error),
+) webhook.Headers {
+	t.Helper()
+	id, err := webhook.NewSourceID(sourceIDStr)
+	mustNoError(t, err, "NewSourceID alt")
+	altSecret := bytes.Repeat([]byte("j"), conformanceMinSecretLen)
+	src2, err := webhook.NewSource(id, altSecret)
+	mustNoError(t, err, "NewSource alt")
+	signer2, err := newSigner(src2)
+	mustNoError(t, err, "newSigner alt")
+	h, err := signer2.Sign(payload, ts, deliveryID)
+	mustNoError(t, err, "Sign alt")
+	return h
+}
+
+// ---------------------------------------------------------------------------
+// Internal assertion helpers — stdlib only, no testify in kernel/ non-test files
+// (mirrors kernel/outbox/outboxtest/helpers.go pattern)
+// ---------------------------------------------------------------------------
+
+// mustNoError fails the test immediately if err is non-nil (setup-time guard).
+func mustNoError(t *testing.T, err error, context string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: unexpected error: %v", context, err)
+	}
+}
+
+// requireNoError fails the test immediately if err is non-nil.
+func requireNoError(t *testing.T, err error, msg string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: unexpected error: %v", msg, err)
+	}
+}
+
+// requireErrCode asserts err is an *errcode.Error with the given Code and Kind.
+func requireErrCode(t *testing.T, err error, code errcode.Code, kind errcode.Kind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected *errcode.Error with code=%s kind=%d, got nil", code, kind)
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("want *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != code {
+		t.Errorf("errcode.Code: got %s, want %s", ec.Code, code)
+	}
+	if ec.Kind != kind {
+		t.Errorf("errcode.Kind: got %d, want %d", ec.Kind, kind)
+	}
+}

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -727,11 +727,13 @@ const (
 	// allowed replay window (default ±5min). Constructed with
 	// KindUnauthenticated → HTTP 401.
 	ErrWebhookTimestampExpired Code = "ERR_WEBHOOK_TIMESTAMP_EXPIRED"
-	// ErrWebhookDuplicateDelivery signals a delivery ID was already processed
-	// (idempotent replay). Receiver maps idempotent replay to HTTP 200; this
-	// sentinel classifies the replay for logging. The wire status (200
-	// idempotent vs 409) is decided in PR-3 (receiver runtime). First
-	// constructed in PR-3 (receiver runtime).
+	// ErrWebhookDuplicateDelivery signals a delivery whose idempotency claim did
+	// not acquire a fresh lease. The PR-3 receiver constructs it on the
+	// ClaimBusy branch — another worker currently holds the lease for the same
+	// (sourceID, deliveryID) — and maps it to HTTP 409 (KindConflict) so the
+	// sender retries. The already-completed replay (ClaimDone) is a success and
+	// returns 200 without this sentinel. First constructed in PR-3 (receiver
+	// runtime).
 	ErrWebhookDuplicateDelivery Code = "ERR_WEBHOOK_DUPLICATE_DELIVERY"
 	// ErrWebhookInvalidHeader signals a required signature header is missing or
 	// malformed (bad scheme, unparseable timestamp). Constructed with

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -25,10 +25,12 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	kerneldepgraph "github.com/ghbvf/gocell/kernel/depgraph"
 	"github.com/ghbvf/gocell/kernel/healthz"
+	"github.com/ghbvf/gocell/kernel/idempotency"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/metadata"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
 	"github.com/ghbvf/gocell/kernel/wrapper"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/config"
@@ -142,6 +144,13 @@ type Bootstrap struct {
 	// eventRouterCollector is cached so multiple Router instances (if a future
 	// multi-listener model arrives) share the same collector.
 	eventRouterCollector *metricsmiddleware.EventRouterCollector
+
+	// --- webhook: inbound-webhook receiver dependencies ---
+	// Both are injected via WithWebhookSourceStore / WithWebhookClaimer.
+	// nil means "not configured"; phase5 fail-fasts when any cell registers a
+	// webhook receiver but these fields remain nil.
+	webhookSourceStore kwh.SourceStore
+	webhookClaimer     idempotency.Claimer
 
 	// --- devtools catalog endpoint (J1 PR-A37) ---
 	// All zero/nil = endpoint not registered.

--- a/runtime/bootstrap/options_webhook.go
+++ b/runtime/bootstrap/options_webhook.go
@@ -1,0 +1,48 @@
+package bootstrap
+
+// options_webhook.go — With* option functions for inbound-webhook receiver wiring.
+//
+// Covers: WithWebhookSourceStore, WithWebhookClaimer.
+//
+// Both are "cumulative builder" options (see runtime-api.md §Option 范式分层):
+// nil inputs are silently ignored; the final nil check happens inside
+// phase5DrainWebhookReceivers when a cell has registered receivers.
+
+import (
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// WithWebhookSourceStore injects the [kwh.SourceStore] used by all inbound
+// webhook receivers to look up HMAC secrets by source ID. A nil or typed-nil
+// value is silently ignored; the final nil check happens during phase5 when
+// any cell has declared a webhook receiver.
+//
+// Typical usage: pass a pre-populated [kwh.NewSourceRegistry] that has been
+// seeded with [kwh.Source] values for each expected sender.
+func WithWebhookSourceStore(store kwh.SourceStore) Option {
+	return func(b *Bootstrap) {
+		if validation.IsNilInterface(store) {
+			return
+		}
+		b.webhookSourceStore = store
+	}
+}
+
+// WithWebhookClaimer injects the [idempotency.Claimer] used by all inbound
+// webhook receivers to deduplicate deliveries. A nil or typed-nil value is
+// silently ignored; the final nil check happens during phase5 when any cell
+// has declared a webhook receiver.
+//
+// For tests, [idempotency.NewInMemClaimer] with the bootstrap clock is
+// sufficient. Production deployments should use a distributed claimer backed
+// by Redis or PostgreSQL.
+func WithWebhookClaimer(claimer idempotency.Claimer) Option {
+	return func(b *Bootstrap) {
+		if validation.IsNilInterface(claimer) {
+			return
+		}
+		b.webhookClaimer = claimer
+	}
+}

--- a/runtime/bootstrap/options_webhook.go
+++ b/runtime/bootstrap/options_webhook.go
@@ -7,6 +7,16 @@ package bootstrap
 // Both are "cumulative builder" options (see runtime-api.md §Option 范式分层):
 // nil inputs are silently ignored; the final nil check happens inside
 // phase5DrainWebhookReceivers when a cell has registered receivers.
+//
+// Design note — fail-fast timing: the missing-dependency error is deliberately
+// raised at phase5 (when receivers are drained) rather than at option-apply
+// time. A deployment with zero webhook receivers is a valid configuration that
+// needs neither a SourceStore nor a Claimer, so requiring them unconditionally
+// at option time would reject correct setups. The dependency only becomes
+// mandatory once a cell has actually declared a receiver — which is exactly when
+// phase5 can see both the snapshot and the wired options. This matches the
+// builder-option convention used elsewhere in bootstrap (final validation at the
+// consuming phase, not at the setter).
 
 import (
 	"github.com/ghbvf/gocell/kernel/idempotency"

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -450,7 +450,7 @@ func (b *Bootstrap) phase5DrainWebhookReceivers(s *phaseState) ([]cell.RouteGrou
 			"bootstrap: webhook receivers declared but no claimer configured; "+
 				"add WithWebhookClaimer to bootstrap options")
 	}
-	groups, err := runtimewebhook.BuildRouteGroups(reqs, b.webhookSourceStore, b.webhookClaimer, b.clock)
+	groups, err := runtimewebhook.BuildRouteGroups(b.clock, reqs, b.webhookSourceStore, b.webhookClaimer)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: build webhook route groups: %w", err)
 	}

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ghbvf/gocell/runtime/http/health"
 	"github.com/ghbvf/gocell/runtime/http/router"
 	metricsmiddleware "github.com/ghbvf/gocell/runtime/observability/metrics"
+	runtimewebhook "github.com/ghbvf/gocell/runtime/webhook"
 )
 
 // phase5BuildRouters builds one Router per declared listener, collects
@@ -54,6 +55,11 @@ func (b *Bootstrap) phase5BuildRouters(ctx context.Context, s *phaseState) error
 		return err
 	}
 	groups := b.phase5CollectRouteGroups(s)
+	webhookGroups, err := b.phase5DrainWebhookReceivers(s)
+	if err != nil {
+		return err
+	}
+	groups = append(groups, webhookGroups...)
 	// defense-in-depth: phase0 already validated; re-check after phase4 resolved verifiers
 	if err := b.validateAuthPlanMTLSBindings(); err != nil {
 		return err
@@ -402,4 +408,51 @@ func (b *Bootstrap) buildAuthRouterOptions(v kauth.IntentTokenVerifier) ([]route
 	}
 	opts = append(opts, router.WithAuthMetrics(am))
 	return opts, nil
+}
+
+// phase5DrainWebhookReceivers collects all WebhookReceiverRequest entries from
+// cell snapshots and converts them into RouteGroups via
+// [runtimewebhook.BuildRouteGroups].
+//
+// CellID drift check: each request must carry the same cell ID as the snapshot
+// key (mirroring drainCellSubscriptions). Mismatches are a codegen defect.
+//
+// Empty collection is a no-op (returns nil, nil). Non-empty collection
+// requires both webhookSourceStore and webhookClaimer to be configured; if
+// either is nil, the function returns an errcode explaining which option is missing.
+func (b *Bootstrap) phase5DrainWebhookReceivers(s *phaseState) ([]cell.RouteGroup, error) {
+	var reqs []cell.WebhookReceiverRequest
+	for _, id := range s.asm.CellIDs() {
+		snap, ok := s.cellSnapshots[id]
+		if !ok {
+			continue
+		}
+		for _, req := range snap.WebhookReceivers {
+			if req.Spec.CellID != id {
+				return nil, fmt.Errorf(
+					"bootstrap: cell %s webhook receiver drift: declared CellID=%q but snapshot owner=%q"+
+						" (codegen should inject cellID from cell metadata; check cellgen + contractgen templates)",
+					id, req.Spec.CellID, id)
+			}
+			reqs = append(reqs, req)
+		}
+	}
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+	if b.webhookSourceStore == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"bootstrap: webhook receivers declared but no source store configured; "+
+				"add WithWebhookSourceStore to bootstrap options")
+	}
+	if b.webhookClaimer == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"bootstrap: webhook receivers declared but no claimer configured; "+
+				"add WithWebhookClaimer to bootstrap options")
+	}
+	groups, err := runtimewebhook.BuildRouteGroups(reqs, b.webhookSourceStore, b.webhookClaimer, b.clock)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap: build webhook route groups: %w", err)
+	}
+	return groups, nil
 }

--- a/runtime/bootstrap/phases_webhook_test.go
+++ b/runtime/bootstrap/phases_webhook_test.go
@@ -359,5 +359,27 @@ func TestWithWebhookClaimer_NilIgnored(t *testing.T) {
 	assert.Nil(t, b.webhookClaimer, "typed-nil claimer must be ignored")
 }
 
+// TestWithWebhookSourceStore_BareNilIgnored verifies that a bare untyped nil
+// passed directly to WithWebhookSourceStore is silently ignored (cumulative
+// option semantics — does not clear a previously set store).
+func TestWithWebhookSourceStore_BareNilIgnored(t *testing.T) {
+	b := New(clockmock.New(whFixedNow))
+	// Pass bare nil (not a typed interface variable).
+	opt := WithWebhookSourceStore(nil)
+	opt(b)
+	assert.Nil(t, b.webhookSourceStore, "bare-nil source store must be ignored")
+}
+
+// TestWithWebhookClaimer_BareNilIgnored verifies that a bare untyped nil
+// passed directly to WithWebhookClaimer is silently ignored.
+func TestWithWebhookClaimer_BareNilIgnored(t *testing.T) {
+	clk := clockmock.New(whFixedNow)
+	b := New(clk)
+	// Pass bare nil (not a typed interface variable).
+	opt := WithWebhookClaimer(nil)
+	opt(b)
+	assert.Nil(t, b.webhookClaimer, "bare-nil claimer must be ignored")
+}
+
 // Compile-time check: webhookTestCell implements cell.Cell.
 var _ cell.Cell = (*webhookTestCell)(nil)

--- a/runtime/bootstrap/phases_webhook_test.go
+++ b/runtime/bootstrap/phases_webhook_test.go
@@ -1,0 +1,363 @@
+package bootstrap
+
+// phases_webhook_test.go — unit + end-to-end tests for phase5DrainWebhookReceivers.
+//
+// Coverage:
+//   - empty receiver set → no-op, no errors
+//   - non-empty without WithWebhookSourceStore → fail-fast errcode
+//   - non-empty without WithWebhookClaimer → fail-fast errcode
+//   - CellID drift → fail-fast error
+//   - end-to-end: snapshot with 1 receiver + WithWebhookSourceStore/Claimer →
+//     router mounted at spec.PathPattern; valid HMAC → 200; bad HMAC → 401
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/http/router"
+)
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const (
+	whTestCellID       = "webhookcell"
+	whTestContractID   = "webhook.bootstrap-phase5.v1"
+	whTestSourceID     = "test-source"
+	whTestPathPattern  = "/api/webhooks/bootstrap-test"
+	whTestSecret       = "12345678901234567890abcd" // 24 bytes
+	whTestTolerance    = 300                        // seconds
+	whTestMaxBodyBytes = 1 << 20                    // 1 MiB
+)
+
+var whFixedNow = time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+func whTestSpec() kwh.ReceiverSpec {
+	return kwh.ReceiverSpec{
+		ContractID:       whTestContractID,
+		SourceID:         whTestSourceID,
+		CellID:           whTestCellID,
+		PathPattern:      whTestPathPattern,
+		DeliveryIDHeader: "X-Delivery-Id",
+		TimestampHeader:  "X-Timestamp",
+		SignatureHeader:  "X-Signature",
+		ToleranceSeconds: whTestTolerance,
+		MaxBodyBytes:     whTestMaxBodyBytes,
+	}
+}
+
+func whTestSource(t *testing.T) kwh.Source {
+	t.Helper()
+	id, err := kwh.NewSourceID(whTestSourceID)
+	require.NoError(t, err, "NewSourceID")
+	src, err := kwh.NewSource(id, []byte(whTestSecret))
+	require.NoError(t, err, "NewSource")
+	return src
+}
+
+func whTestStore(t *testing.T) *kwh.SourceRegistry {
+	t.Helper()
+	reg := kwh.NewSourceRegistry()
+	require.NoError(t, reg.Register(whTestSource(t)), "Register source")
+	return reg
+}
+
+// webhookTestCell calls reg.RegisterWebhookReceiver in its Init so bootstrap
+// captures a WebhookReceiverRequest in the RegistrySnapshot.
+type webhookTestCell struct {
+	*cell.BaseCell
+	spec    kwh.ReceiverSpec
+	handler kwh.WebhookReceiveHandler
+	// If non-zero, override the CellID in the spec (to simulate drift).
+	overrideCellID string
+}
+
+func (c *webhookTestCell) Init(ctx context.Context, reg cell.Registrar) error {
+	if err := c.BaseCell.Init(ctx, reg); err != nil {
+		return err
+	}
+	spec := c.spec
+	if c.overrideCellID != "" {
+		spec.CellID = c.overrideCellID
+	}
+	return reg.RegisterWebhookReceiver(spec, c.handler)
+}
+
+// newWebhookCell creates a webhookTestCell with the given spec.
+// The cell ID is always taken from spec.CellID so that the snapshot key
+// matches what the receiver declares.
+func newWebhookCell(spec kwh.ReceiverSpec, handler kwh.WebhookReceiveHandler) *webhookTestCell {
+	return &webhookTestCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{
+			ID:   spec.CellID,
+			Type: "core",
+		}),
+		spec:    spec,
+		handler: handler,
+	}
+}
+
+// buildPhaseStateWithWebhookCell starts an assembly containing cells, returns a
+// phaseState with asm and cellSnapshots populated (mirrors phase3InitAssembly).
+func buildPhaseStateWithWebhookCells(t *testing.T, cells ...cell.Cell) *phaseState {
+	t.Helper()
+	asm := assembly.New(clockmock.New(whFixedNow), assembly.Config{
+		ID:             "webhook-test-asm",
+		DurabilityMode: outbox.DurabilityDemo,
+	})
+	for _, c := range cells {
+		require.NoErrorf(t, asm.Register(c), "Register cell %q", c.ID())
+	}
+	require.NoError(t, asm.Start(context.Background()), "asm.Start")
+	t.Cleanup(func() { _ = asm.Stop(context.Background()) })
+
+	_, s := newPhaseState()
+	s.asm = asm
+	s.cellSnapshots = asm.Snapshots()
+	return s
+}
+
+// noopWebhookHandler is a no-op receiver used for tests that don't exercise handler logic.
+func noopWebhookHandler(_ context.Context, _ kwh.Delivery) error { return nil }
+
+// ---------------------------------------------------------------------------
+// Phase5DrainWebhookReceivers — unit tests
+// ---------------------------------------------------------------------------
+
+// TestPhase5DrainWebhookReceivers_EmptyNoOp verifies that an assembly with no
+// webhook receivers produces zero groups and no error.
+func TestPhase5DrainWebhookReceivers_EmptyNoOp(t *testing.T) {
+	t.Parallel()
+	// Plain test cell with no webhook receivers.
+	tc := &testCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{ID: "plain-cell", Type: "core"}),
+	}
+	s := buildPhaseStateWithWebhookCells(t, tc)
+
+	b := New(clockmock.New(whFixedNow))
+	groups, err := b.phase5DrainWebhookReceivers(s)
+
+	require.NoError(t, err, "empty receivers must not error")
+	assert.Empty(t, groups, "empty receivers must produce no groups")
+}
+
+// TestPhase5DrainWebhookReceivers_FailsWithoutSourceStore verifies that a
+// snapshot with one webhook receiver and no WithWebhookSourceStore causes
+// phase5DrainWebhookReceivers to return an errcode with ErrCellInvalidConfig.
+func TestPhase5DrainWebhookReceivers_FailsWithoutSourceStore(t *testing.T) {
+	t.Parallel()
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	b := New(clockmock.New(whFixedNow))
+	// webhookClaimer set, but webhookSourceStore is nil.
+	b.webhookClaimer = idempotency.NewInMemClaimer(clockmock.New(whFixedNow))
+
+	_, err := b.phase5DrainWebhookReceivers(s)
+
+	require.Error(t, err, "missing source store must error")
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr, "error must be *errcode.Error")
+	assert.Equal(t, errcode.ErrCellInvalidConfig, ecErr.Code,
+		"missing source store must yield ErrCellInvalidConfig")
+	assert.Contains(t, ecErr.Message, "WithWebhookSourceStore",
+		"error message must name the missing option")
+}
+
+// TestPhase5DrainWebhookReceivers_FailsWithoutClaimer verifies that a snapshot
+// with one webhook receiver and no WithWebhookClaimer causes phase5DrainWebhookReceivers
+// to return an errcode with ErrCellInvalidConfig.
+func TestPhase5DrainWebhookReceivers_FailsWithoutClaimer(t *testing.T) {
+	t.Parallel()
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	b := New(clockmock.New(whFixedNow))
+	// webhookSourceStore set, but webhookClaimer is nil.
+	b.webhookSourceStore = whTestStore(t)
+
+	_, err := b.phase5DrainWebhookReceivers(s)
+
+	require.Error(t, err, "missing claimer must error")
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr, "error must be *errcode.Error")
+	assert.Equal(t, errcode.ErrCellInvalidConfig, ecErr.Code,
+		"missing claimer must yield ErrCellInvalidConfig")
+	assert.Contains(t, ecErr.Message, "WithWebhookClaimer",
+		"error message must name the missing option")
+}
+
+// TestPhase5DrainWebhookReceivers_FailsOnCellIDDrift verifies that a snapshot
+// whose webhook receiver has a CellID that doesn't match the snapshot key
+// causes a fail-fast drift error.
+func TestPhase5DrainWebhookReceivers_FailsOnCellIDDrift(t *testing.T) {
+	t.Parallel()
+	// Cell registers with ID "webhookcell" but spec.CellID is overridden to "wrongcell".
+	wc := &webhookTestCell{
+		BaseCell:       cell.MustNewBaseCell(&metadata.CellMeta{ID: whTestCellID, Type: "core"}),
+		spec:           whTestSpec(),
+		handler:        noopWebhookHandler,
+		overrideCellID: "wrongcell",
+	}
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	b := New(clockmock.New(whFixedNow))
+	b.webhookSourceStore = whTestStore(t)
+	b.webhookClaimer = idempotency.NewInMemClaimer(clockmock.New(whFixedNow))
+
+	_, err := b.phase5DrainWebhookReceivers(s)
+
+	require.Error(t, err, "CellID drift must error")
+	assert.Contains(t, err.Error(), "drift", "drift error must mention 'drift'")
+	assert.Contains(t, err.Error(), "wrongcell", "drift error must mention the mismatched CellID")
+}
+
+// TestPhase5DrainWebhookReceivers_HappyPath_ProducesGroups verifies that a
+// well-configured snapshot with one receiver produces one RouteGroup with
+// the correct Listener, Prefix, and CellID.
+func TestPhase5DrainWebhookReceivers_HappyPath_ProducesGroups(t *testing.T) {
+	t.Parallel()
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	clk := clockmock.New(whFixedNow)
+	b := New(clk)
+	b.webhookSourceStore = whTestStore(t)
+	b.webhookClaimer = idempotency.NewInMemClaimer(clk)
+
+	groups, err := b.phase5DrainWebhookReceivers(s)
+
+	require.NoError(t, err, "happy path must not error")
+	require.Len(t, groups, 1, "must produce one group per receiver")
+
+	g := groups[0]
+	assert.Equal(t, cell.PrimaryListener, g.Listener, "webhook groups must target PrimaryListener")
+	assert.Equal(t, whTestPathPattern, g.Prefix, "group Prefix must equal PathPattern")
+	assert.Equal(t, whTestCellID, g.CellID, "group CellID must match spec.CellID")
+	require.NotNil(t, g.Register, "Register func must not be nil")
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end test: phase5DrainWebhookReceivers → router → real HTTP
+// ---------------------------------------------------------------------------
+
+// TestPhase5DrainWebhookReceivers_EndToEnd verifies the full mount pipeline:
+//
+//  1. phase5DrainWebhookReceivers returns a RouteGroup for the registered receiver.
+//  2. MountRouteGroup mounts it on a real Router at the correct prefix (no double-prefix).
+//  3. A valid HMAC-signed POST to spec.PathPattern returns 200.
+//  4. A request with a forged signature returns 401.
+//
+// This is the primary correctness gate for the double-prefix fix: the request
+// must reach the handler at exactly spec.PathPattern, not at a doubled path.
+func TestPhase5DrainWebhookReceivers_EndToEnd(t *testing.T) {
+	clk := clockmock.New(whFixedNow)
+	src := whTestSource(t)
+	store := whTestStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	b := New(clk)
+	b.webhookSourceStore = store
+	b.webhookClaimer = claimer
+
+	groups, err := b.phase5DrainWebhookReceivers(s)
+	require.NoError(t, err, "phase5DrainWebhookReceivers")
+	require.Len(t, groups, 1)
+
+	// Build a real Router and mount the group.
+	rtr, err := router.NewForListener(clk, cell.PrimaryListener)
+	require.NoError(t, err, "NewForListener")
+	require.NoError(t, rtr.MountRouteGroup(groups[0]), "MountRouteGroup")
+
+	// Build a signer for the test source so we can produce valid requests.
+	signer, err := kwh.NewHMACSigner(src)
+	require.NoError(t, err, "NewHMACSigner")
+
+	body := []byte(`{"event":"bootstrap-e2e-test"}`)
+	did, err := kwh.NewDeliveryID("bootstrap-e2e-001")
+	require.NoError(t, err, "NewDeliveryID")
+	headers, err := signer.Sign(body, whFixedNow, did)
+	require.NoError(t, err, "Sign")
+
+	buildReq := func(signature string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, whTestPathPattern, bytes.NewReader(body))
+		req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+		req.Header.Set("X-Timestamp", headers.Timestamp)
+		req.Header.Set("X-Signature", signature)
+		return req
+	}
+
+	t.Run("valid_hmac_returns_200", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		rtr.Handler().ServeHTTP(rec, buildReq(headers.Signature))
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"valid HMAC at %s must return 200 (no double-prefix, handler reached)", whTestPathPattern)
+	})
+
+	t.Run("forged_signature_returns_401", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		rtr.Handler().ServeHTTP(rec, buildReq("v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code,
+			"forged HMAC at %s must return 401", whTestPathPattern)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Options tests: WithWebhookSourceStore / WithWebhookClaimer
+// ---------------------------------------------------------------------------
+
+// TestWithWebhookSourceStore_StoresValue verifies the option sets the field.
+func TestWithWebhookSourceStore_StoresValue(t *testing.T) {
+	store := whTestStore(t)
+	b := New(clockmock.New(whFixedNow), WithWebhookSourceStore(store))
+	assert.Equal(t, store, b.webhookSourceStore, "WithWebhookSourceStore must store the value")
+}
+
+// TestWithWebhookSourceStore_NilIgnored verifies that a typed-nil is silently ignored.
+func TestWithWebhookSourceStore_NilIgnored(t *testing.T) {
+	b := New(clockmock.New(whFixedNow))
+	var nilStore kwh.SourceStore
+	opt := WithWebhookSourceStore(nilStore)
+	opt(b)
+	assert.Nil(t, b.webhookSourceStore, "typed-nil source store must be ignored")
+}
+
+// TestWithWebhookClaimer_StoresValue verifies the option sets the field.
+func TestWithWebhookClaimer_StoresValue(t *testing.T) {
+	clk := clockmock.New(whFixedNow)
+	claimer := idempotency.NewInMemClaimer(clk)
+	b := New(clk, WithWebhookClaimer(claimer))
+	assert.Equal(t, claimer, b.webhookClaimer, "WithWebhookClaimer must store the value")
+}
+
+// TestWithWebhookClaimer_NilIgnored verifies that a typed-nil is silently ignored.
+func TestWithWebhookClaimer_NilIgnored(t *testing.T) {
+	clk := clockmock.New(whFixedNow)
+	b := New(clk)
+	var nilClaimer idempotency.Claimer
+	opt := WithWebhookClaimer(nilClaimer)
+	opt(b)
+	assert.Nil(t, b.webhookClaimer, "typed-nil claimer must be ignored")
+}
+
+// Compile-time check: webhookTestCell implements cell.Cell.
+var _ cell.Cell = (*webhookTestCell)(nil)

--- a/runtime/bootstrap/phases_webhook_test.go
+++ b/runtime/bootstrap/phases_webhook_test.go
@@ -228,6 +228,57 @@ func TestPhase5DrainWebhookReceivers_FailsOnCellIDDrift(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrongcell", "drift error must mention the mismatched CellID")
 }
 
+// TestPhase5DrainWebhookReceivers_SkipsMissingSnapshot verifies the defensive
+// branch where a cell ID returned by asm.CellIDs() has no entry in
+// cellSnapshots: the drain loop must `continue` (skip it) rather than panic,
+// and — with no other receivers — return an empty no-op result.
+func TestPhase5DrainWebhookReceivers_SkipsMissingSnapshot(t *testing.T) {
+	t.Parallel()
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+	// Drop the only cell's snapshot so its ID survives in asm.CellIDs() but the
+	// snapshot lookup misses — exercising the `if !ok { continue }` branch.
+	delete(s.cellSnapshots, whTestCellID)
+
+	b := New(clockmock.New(whFixedNow))
+	groups, err := b.phase5DrainWebhookReceivers(s)
+
+	require.NoError(t, err, "missing snapshot must be skipped, not error")
+	assert.Empty(t, groups, "no resolvable receivers must produce zero groups")
+}
+
+// TestPhase5DrainWebhookReceivers_WrapsBuildError verifies that a receiver
+// request whose spec is invalid (injected past the registry's validation guard
+// to reach the build step) causes BuildRouteGroups to fail and phase5 to wrap
+// the error with the "build webhook route groups" context.
+func TestPhase5DrainWebhookReceivers_WrapsBuildError(t *testing.T) {
+	t.Parallel()
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+	// Replace the validated request with one whose spec is invalid (empty
+	// PathPattern) but whose CellID still matches the snapshot key — so it
+	// passes the drift check and fails inside BuildRouteGroups → NewReceiver.
+	badSpec := whTestSpec()
+	badSpec.PathPattern = ""
+	snap := s.cellSnapshots[whTestCellID]
+	snap.WebhookReceivers = []cell.WebhookReceiverRequest{{
+		Spec:    badSpec,
+		Handler: noopWebhookHandler,
+	}}
+	s.cellSnapshots[whTestCellID] = snap
+
+	clk := clockmock.New(whFixedNow)
+	b := New(clk)
+	b.webhookSourceStore = whTestStore(t)
+	b.webhookClaimer = idempotency.NewInMemClaimer(clk)
+
+	_, err := b.phase5DrainWebhookReceivers(s)
+
+	require.Error(t, err, "invalid spec must surface as a build error")
+	assert.Contains(t, err.Error(), "build webhook route groups",
+		"phase5 must wrap the BuildRouteGroups failure with its own context")
+}
+
 // TestPhase5DrainWebhookReceivers_HappyPath_ProducesGroups verifies that a
 // well-configured snapshot with one receiver produces one RouteGroup with
 // the correct Listener, Prefix, and CellID.

--- a/runtime/webhook/doc.go
+++ b/runtime/webhook/doc.go
@@ -31,6 +31,10 @@
 // values (accumulated by the cell registry during Init) into
 // [kernel/cell.RouteGroup] values that bootstrap mounts onto the HTTP server.
 //
+// # Deferred capabilities
+//
+// Metrics and healthz probes are deferred to PR-6 (KERNEL-WEBHOOK-01).
+//
 // # References
 //
 // ref: svix/svix-webhooks go/webhook.go@main — HMAC-SHA256 header parsing and

--- a/runtime/webhook/doc.go
+++ b/runtime/webhook/doc.go
@@ -1,0 +1,42 @@
+// Package webhook implements the inbound-webhook receiver runtime for GoCell.
+//
+// # Layering
+//
+// runtime/webhook sits in the runtime/ layer. It may import kernel/webhook,
+// kernel/idempotency, kernel/clock, kernel/cell, pkg/errcode, pkg/httputil,
+// and stdlib. It must NOT import cells/, adapters/, or runtime/eventbus.
+//
+// # Capability-token closed loop
+//
+// The core invariant of this package is that the verify → claim → handler
+// execution sequence is enforced at the type level, not merely by convention.
+// Two unexported token types — [verified] and [claimed] — act as unforgeable
+// receipts:
+//
+//   - [verified] can only be produced by [Receiver.verify].
+//   - [claimed] can only be produced by [Receiver.claim], which requires a
+//     [verified] value.
+//   - [Receiver.invokeHandler] requires a [claimed] value and is the only site
+//     that calls the business handler.
+//
+// Package-external code cannot construct either token type (unexported struct
+// + no exported constructor), and [Receiver.verify] / [Receiver.claim] are
+// also unexported, so the ordering invariant is a compile-time guarantee
+// within the package: no business handler invocation can precede a successful
+// verify+claim.
+//
+// # Entry point
+//
+// [BuildRouteGroups] converts a slice of [kernel/cell.WebhookReceiverRequest]
+// values (accumulated by the cell registry during Init) into
+// [kernel/cell.RouteGroup] values that bootstrap mounts onto the HTTP server.
+//
+// # References
+//
+// ref: svix/svix-webhooks go/webhook.go@main — HMAC-SHA256 header parsing and
+// multi-token signature matching pattern.
+// ref: stripe/stripe-go webhook/client.go@master — tolerance-window timestamp
+// check and constant-time signature comparison.
+// ref: ThreeDotsLabs/watermill-http pkg/http/subscriber.go@master — HTTP body
+// read + idempotency integration for inbound event delivery.
+package webhook

--- a/runtime/webhook/doc.go
+++ b/runtime/webhook/doc.go
@@ -31,9 +31,39 @@
 // values (accumulated by the cell registry during Init) into
 // [kernel/cell.RouteGroup] values that bootstrap mounts onto the HTTP server.
 //
+// # Integrating a new receiver
+//
+// The wiring is single-sourced from slice.yaml + contract.yaml; this package is
+// never edited to add a receiver. The full authoring flow (contract.yaml
+// signature/endpoints fields, slice.yaml contractUsages[role=webhook-receive],
+// the cell.go struct field cellgen resolves the handler from, and the cellgen
+// derivation shape) lives in contracts/webhook/README.md — that is the single
+// source, not duplicated here. The runtime steps this package adds on top:
+//
+//   - composition root passes [bootstrap.WithWebhookSourceStore] (seeded with a
+//     [kernel/webhook.Source] per sender) and [bootstrap.WithWebhookClaimer].
+//   - bootstrap phase5 drains RegistrySnapshot.WebhookReceivers through
+//     [BuildRouteGroups] and mounts the resulting route groups.
+//
+// # Troubleshooting
+//
+//   - bootstrap fails with "webhook receiver declared but no SourceStore /
+//     Claimer wired": a cell registered a receiver but the composition root did
+//     not call WithWebhookSourceStore / WithWebhookClaimer (the dependency is
+//     mandatory only once a receiver exists — see options_webhook.go).
+//   - all deliveries return 401: the SourceStore has no [kernel/webhook.Source]
+//     for the receiver's sourceID, or the secret differs from the sender's. The
+//     wire 401 is intentionally identical to a signature mismatch (anti-
+//     enumeration); the real reason is in the server-side slog "reason" field.
+//   - cellgen "no cell.go struct field for slice" / "ambiguous field": see the
+//     contracts/webhook/README.md troubleshooting section (same resolution as
+//     the subscribe path).
+//
 // # Deferred capabilities
 //
 // Metrics and healthz probes are deferred to PR-6 (KERNEL-WEBHOOK-01).
+// Per-contract Claimer TTL configuration is also deferred (the 24h done-TTL is
+// a fixed constant today — see receiver.go).
 //
 // # References
 //

--- a/runtime/webhook/receiver.go
+++ b/runtime/webhook/receiver.go
@@ -1,0 +1,278 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// Claim TTLs used by the receiver's idempotency Claimer.
+const (
+	// receiverLeaseTTL is how long the in-flight processing lease is held.
+	// If the handler goroutine crashes mid-flight, the claimer reclaims after
+	// this window.
+	receiverLeaseTTL = 30 * time.Second
+
+	// receiverDoneTTL is how long a successfully-committed idempotency key
+	// is remembered. Matches the EventBus default (24 h).
+	receiverDoneTTL = 24 * time.Hour
+)
+
+// verified is an unforgeable token produced only by [Receiver.verify].
+// Package-external code cannot construct this type (unexported struct with no
+// exported constructor), so [Receiver.claim] can require it as a parameter to
+// guarantee that claim is never called without a preceding successful verify.
+type verified struct{ d kwh.Delivery }
+
+// claimed is an unforgeable token produced only by [Receiver.claim].
+// [Receiver.invokeHandler] requires it, ensuring that the business handler is
+// never invoked without a prior idempotency claim.
+type claimed struct {
+	d    kwh.Delivery
+	rcpt idempotency.Receipt
+}
+
+// Receiver is an HTTP handler that implements the full inbound-webhook receive
+// pipeline: body-size limit → HMAC verify → idempotency claim → handler
+// dispatch → receipt commit/release.
+//
+// Construct via [NewReceiver]; the zero value is invalid.
+type Receiver struct {
+	clk      clock.Clock
+	spec     kwh.ReceiverSpec
+	verifier kwh.Verifier
+	store    kwh.SourceStore
+	claimer  idempotency.Claimer
+	handler  kwh.WebhookReceiveHandler
+}
+
+// NewReceiver constructs a Receiver. All parameters are mandatory; any nil or
+// invalid argument returns an [errcode.ErrWebhookConfigInvalid] error.
+func NewReceiver(
+	clk clock.Clock,
+	spec kwh.ReceiverSpec,
+	verifier kwh.Verifier,
+	store kwh.SourceStore,
+	claimer idempotency.Claimer,
+	handler kwh.WebhookReceiveHandler,
+) (*Receiver, error) {
+	clock.MustHaveClock(clk, "webhook.NewReceiver")
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+	if validation.IsNilInterface(verifier) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook receiver: verifier must not be nil")
+	}
+	if validation.IsNilInterface(store) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook receiver: store must not be nil")
+	}
+	if validation.IsNilInterface(claimer) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook receiver: claimer must not be nil")
+	}
+	if handler == nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook receiver: handler must not be nil")
+	}
+	return &Receiver{
+		clk:      clk,
+		spec:     spec,
+		verifier: verifier,
+		store:    store,
+		claimer:  claimer,
+		handler:  handler,
+	}, nil
+}
+
+// ServeHTTP implements http.Handler. Pipeline:
+//  1. Read body with max-bytes enforcement.
+//  2. Verify HMAC signature (produces [verified] token).
+//  3. Claim idempotency key (produces [claimed] token).
+//  4. Dispatch handler or short-circuit based on claim state.
+//  5. Commit or release receipt based on handler outcome.
+func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	// 1. Body limit + read.
+	body, err := r.readBody(w, req)
+	if err != nil {
+		return // readBody already wrote the error response.
+	}
+
+	// 2. Verify — produces unforgeable verified token.
+	v, err := r.verify(body, req)
+	if err != nil {
+		httputil.WriteError(ctx, w, err)
+		return
+	}
+
+	// 3. Claim — produces unforgeable claimed token.
+	c, state, err := r.claim(ctx, v)
+	if err != nil {
+		// Claimer infrastructure fault → fail-closed 503.
+		slog.ErrorContext(ctx, "webhook receiver: idempotency claim failed",
+			slog.String("sourceId", r.spec.SourceID),
+			slog.String("contractId", r.spec.ContractID),
+			slog.Any("error", err))
+		httputil.WriteError(ctx, w, errcode.New(errcode.KindUnavailable, errcode.ErrServiceUnavailable,
+			"webhook receiver: idempotency service unavailable"))
+		return
+	}
+
+	// 4. Branch on claim state.
+	switch state {
+	case idempotency.ClaimDone:
+		// Already processed — idempotent 200 without re-invoking handler.
+		writeAccepted(w)
+		return
+
+	case idempotency.ClaimBusy:
+		// Another worker is currently processing — 409 so the sender retries.
+		httputil.WriteError(ctx, w, errcode.New(errcode.KindConflict, errcode.ErrIdempotencyLeaseExpired,
+			"webhook receiver: delivery is already being processed"))
+		return
+
+	case idempotency.ClaimAcquired:
+		// 5. Dispatch handler.
+		if err := r.invokeHandler(ctx, c); err != nil {
+			releaseCtx := context.WithoutCancel(ctx)
+			if releaseErr := c.rcpt.Release(releaseCtx); releaseErr != nil {
+				slog.ErrorContext(ctx, "webhook receiver: receipt release failed",
+					slog.Any("error", releaseErr))
+			}
+			httputil.WriteError(ctx, w, err)
+			return
+		}
+		commitCtx := context.WithoutCancel(ctx)
+		if commitErr := c.rcpt.Commit(commitCtx); commitErr != nil {
+			// Commit failed — log but don't change the 200 that handler already
+			// earned: the business operation succeeded; only the idempotency
+			// record write failed (best-effort).
+			slog.ErrorContext(ctx, "webhook receiver: receipt commit failed",
+				slog.String("sourceId", r.spec.SourceID),
+				slog.String("deliveryId", string(c.d.DeliveryID)),
+				slog.Any("error", commitErr))
+		}
+		writeAccepted(w)
+	}
+}
+
+// readBody applies MaxBytesReader and reads the full request body.
+// On error it writes an appropriate response and returns a non-nil error;
+// the caller must not write any further response.
+func (r *Receiver) readBody(w http.ResponseWriter, req *http.Request) ([]byte, error) {
+	ctx := req.Context()
+
+	// Quick pre-check on Content-Length before allocating.
+	if req.ContentLength > r.spec.MaxBodyBytes {
+		httputil.WriteError(ctx, w, errcode.New(errcode.KindPayloadTooLarge,
+			errcode.ErrWebhookBodyTooLarge, "webhook receiver: request body too large"))
+		return nil, errcode.New(errcode.KindPayloadTooLarge, errcode.ErrWebhookBodyTooLarge,
+			"webhook receiver: request body too large")
+	}
+
+	req.Body = http.MaxBytesReader(w, req.Body, r.spec.MaxBodyBytes)
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			httputil.WriteError(ctx, w, errcode.New(errcode.KindPayloadTooLarge,
+				errcode.ErrWebhookBodyTooLarge, "webhook receiver: request body too large"))
+			return nil, err
+		}
+		slog.ErrorContext(ctx, "webhook receiver: read body failed", slog.Any("error", err))
+		httputil.WriteError(ctx, w, errcode.New(errcode.KindUnavailable,
+			errcode.ErrServiceUnavailable, "webhook receiver: failed to read request body"))
+		return nil, err
+	}
+	return body, nil
+}
+
+// verify reads the configured signature headers from req, looks up the source,
+// and validates the HMAC. Returns an unforgeable [verified] token on success.
+// Errors are already typed *errcode.Error ready for httputil.WriteError.
+func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
+	deliveryIDRaw := req.Header.Get(r.spec.DeliveryIDHeader)
+	timestampRaw := req.Header.Get(r.spec.TimestampHeader)
+	signatureRaw := req.Header.Get(r.spec.SignatureHeader)
+
+	if deliveryIDRaw == "" || timestampRaw == "" || signatureRaw == "" {
+		return verified{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
+			"webhook receiver: one or more required signature headers are missing")
+	}
+
+	deliveryID, err := kwh.NewDeliveryID(deliveryIDRaw)
+	if err != nil {
+		return verified{}, err
+	}
+
+	headers := kwh.Headers{
+		DeliveryID: deliveryID,
+		Timestamp:  timestampRaw,
+		Signature:  signatureRaw,
+	}
+
+	// Look up the source by spec.SourceID. Return ErrWebhookInvalidSignature
+	// (not a source-enumeration error) to avoid disclosing whether the source
+	// exists (WEBHOOK-HMAC-FUNNEL-01 F8/F9).
+	src, ok := r.store.Lookup(kwh.SourceID(r.spec.SourceID))
+	if !ok {
+		return verified{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
+			"webhook receiver: signature verification failed",
+			errcode.WithInternal(errcode.InternalAttr("sourceId", r.spec.SourceID)))
+	}
+
+	if err := r.verifier.Verify(body, headers, src); err != nil {
+		return verified{}, err
+	}
+
+	return verified{d: kwh.Delivery{
+		DeliveryID: deliveryID,
+		SourceID:   kwh.SourceID(r.spec.SourceID),
+		Headers:    headers,
+		Payload:    body,
+	}}, nil
+}
+
+// claim uses the idempotency Claimer to acquire a processing lease keyed on
+// the source+delivery pair. Requires a [verified] token so callers cannot
+// invoke claim before verify.
+func (r *Receiver) claim(ctx context.Context, v verified) (claimed, idempotency.ClaimState, error) {
+	key := "webhook:" + r.spec.SourceID + ":" + string(v.d.DeliveryID)
+	state, rcpt, err := r.claimer.Claim(ctx, key, receiverLeaseTTL, receiverDoneTTL)
+	if err != nil {
+		return claimed{}, state, err
+	}
+	return claimed{d: v.d, rcpt: rcpt}, state, nil
+}
+
+// invokeHandler is the single site in this package that calls the business
+// handler. It requires a [claimed] token, guaranteeing that the full
+// verify → claim sequence has completed.
+func (r *Receiver) invokeHandler(ctx context.Context, c claimed) error {
+	return r.handler(ctx, c.d)
+}
+
+// writeAccepted writes the minimal success response for a processed delivery.
+func writeAccepted(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	body, _ := json.Marshal(map[string]string{"status": "accepted"})
+	_, _ = w.Write(body)
+}
+
+// Compile-time assertion: Receiver satisfies http.Handler.
+var _ http.Handler = (*Receiver)(nil)

--- a/runtime/webhook/receiver.go
+++ b/runtime/webhook/receiver.go
@@ -14,6 +14,7 @@ import (
 	kwh "github.com/ghbvf/gocell/kernel/webhook"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -115,6 +116,10 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// 2. Verify — produces unforgeable verified token.
 	v, err := r.verify(body, req)
 	if err != nil {
+		slog.WarnContext(ctx, "webhook receiver: signature verification failed",
+			slog.String("source_id", r.spec.SourceID),
+			slog.String("contract_id", r.spec.ContractID),
+			slog.Any("error", err))
 		httputil.WriteError(ctx, w, err)
 		return
 	}
@@ -124,8 +129,8 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		// Claimer infrastructure fault → fail-closed 503.
 		slog.ErrorContext(ctx, "webhook receiver: idempotency claim failed",
-			slog.String("sourceId", r.spec.SourceID),
-			slog.String("contractId", r.spec.ContractID),
+			slog.String("source_id", r.spec.SourceID),
+			slog.String("contract_id", r.spec.ContractID),
 			slog.Any("error", err))
 		httputil.WriteError(ctx, w, errcode.New(errcode.KindUnavailable, errcode.ErrServiceUnavailable,
 			"webhook receiver: idempotency service unavailable"))
@@ -141,32 +146,66 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	case idempotency.ClaimBusy:
 		// Another worker is currently processing — 409 so the sender retries.
-		httputil.WriteError(ctx, w, errcode.New(errcode.KindConflict, errcode.ErrIdempotencyLeaseExpired,
+		// ErrWebhookDuplicateDelivery (KindConflict → 409) is the semantically
+		// correct sentinel: the delivery is a known duplicate, not a lease expiry.
+		httputil.WriteError(ctx, w, errcode.New(errcode.KindConflict, errcode.ErrWebhookDuplicateDelivery,
 			"webhook receiver: delivery is already being processed"))
 		return
 
 	case idempotency.ClaimAcquired:
-		// 5. Dispatch handler.
-		if err := r.invokeHandler(ctx, c); err != nil {
-			releaseCtx := context.WithoutCancel(ctx)
-			if releaseErr := c.rcpt.Release(releaseCtx); releaseErr != nil {
-				slog.ErrorContext(ctx, "webhook receiver: receipt release failed",
-					slog.Any("error", releaseErr))
-			}
-			httputil.WriteError(ctx, w, err)
-			return
+		// 5. Dispatch handler (panic-safe — release lease before re-panic).
+		r.dispatch(ctx, w, c)
+	}
+}
+
+// dispatch invokes the business handler for an acquired [claimed] token.
+// If the handler panics, dispatch releases the idempotency lease before
+// re-panicking so the Claimer TTL does not permanently block re-delivery.
+func (r *Receiver) dispatch(ctx context.Context, w http.ResponseWriter, c claimed) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			// C-class re-throw: release the lease so the sender can retry after
+			// the recovery middleware converts the panic to a 500 response.
+			releaseOnPanic(ctx, c, r.spec, string(c.d.DeliveryID))
+			panic(panicregister.Approved("webhook-receiver-handler-panic-release", rec))
 		}
-		commitCtx := context.WithoutCancel(ctx)
-		if commitErr := c.rcpt.Commit(commitCtx); commitErr != nil {
-			// Commit failed — log but don't change the 200 that handler already
-			// earned: the business operation succeeded; only the idempotency
-			// record write failed (best-effort).
-			slog.ErrorContext(ctx, "webhook receiver: receipt commit failed",
-				slog.String("sourceId", r.spec.SourceID),
-				slog.String("deliveryId", string(c.d.DeliveryID)),
-				slog.Any("error", commitErr))
+	}()
+
+	if err := r.invokeHandler(ctx, c); err != nil {
+		releaseCtx := context.WithoutCancel(ctx)
+		if releaseErr := c.rcpt.Release(releaseCtx); releaseErr != nil {
+			slog.ErrorContext(ctx, "webhook receiver: receipt release failed",
+				slog.String("source_id", r.spec.SourceID),
+				slog.String("delivery_id", string(c.d.DeliveryID)),
+				slog.Any("error", releaseErr))
 		}
-		writeAccepted(w)
+		httputil.WriteError(ctx, w, err)
+		return
+	}
+
+	commitCtx := context.WithoutCancel(ctx)
+	if commitErr := c.rcpt.Commit(commitCtx); commitErr != nil {
+		// Commit failed — log but don't change the 200 that handler already
+		// earned: the business operation succeeded; only the idempotency
+		// record write failed (best-effort).
+		slog.ErrorContext(ctx, "webhook receiver: receipt commit failed",
+			slog.String("source_id", r.spec.SourceID),
+			slog.String("delivery_id", string(c.d.DeliveryID)),
+			slog.Any("error", commitErr))
+	}
+	writeAccepted(w)
+}
+
+// releaseOnPanic releases the idempotency lease using a cancel-safe context so
+// the release call is not aborted if the request context was already canceled
+// when the panic occurred.
+func releaseOnPanic(ctx context.Context, c claimed, spec kwh.ReceiverSpec, deliveryID string) {
+	releaseCtx := context.WithoutCancel(ctx)
+	if err := c.rcpt.Release(releaseCtx); err != nil {
+		slog.ErrorContext(ctx, "webhook receiver: receipt release failed after handler panic",
+			slog.String("source_id", spec.SourceID),
+			slog.String("delivery_id", deliveryID),
+			slog.Any("error", err))
 	}
 }
 
@@ -232,7 +271,7 @@ func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
 	if !ok {
 		return verified{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
 			"webhook receiver: signature verification failed",
-			errcode.WithInternal(errcode.InternalAttr("sourceId", r.spec.SourceID)))
+			errcode.WithInternal(errcode.InternalAttr("source_id", r.spec.SourceID)))
 	}
 
 	if err := r.verifier.Verify(body, headers, src); err != nil {
@@ -251,6 +290,8 @@ func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
 // the source+delivery pair. Requires a [verified] token so callers cannot
 // invoke claim before verify.
 func (r *Receiver) claim(ctx context.Context, v verified) (claimed, idempotency.ClaimState, error) {
+	// Idempotency key "webhook:{sourceID}:{deliveryID}" — source-scoped to
+	// prevent cross-source replay collision if two sources share a Claimer.
 	key := "webhook:" + r.spec.SourceID + ":" + string(v.d.DeliveryID)
 	state, rcpt, err := r.claimer.Claim(ctx, key, receiverLeaseTTL, receiverDoneTTL)
 	if err != nil {
@@ -267,6 +308,13 @@ func (r *Receiver) invokeHandler(ctx context.Context, c claimed) error {
 }
 
 // writeAccepted writes the minimal success response for a processed delivery.
+//
+// This response is addressed to the external webhook sender (Stripe, GitHub,
+// Svix …), not to a GoCell API consumer. It intentionally does NOT follow the
+// GoCell standard {"data":{}} envelope — senders only depend on a 2xx status
+// code to confirm receipt; the body {"status":"accepted"} aligns with the Stripe
+// and Svix acknowledgement convention and makes the response self-describing in
+// logs/traces without leaking internal API shape.
 func writeAccepted(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/runtime/webhook/receiver.go
+++ b/runtime/webhook/receiver.go
@@ -19,6 +19,17 @@ import (
 )
 
 // Claim TTLs used by the receiver's idempotency Claimer.
+//
+// These are fixed package-level constants in PR-3, not yet per-contract
+// configurable. The 24h done-window matters operationally: if an external
+// provider's retry window EXCEEDS receiverDoneTTL (Stripe retries up to ~3 days,
+// Svix up to ~5 days), a duplicate that arrives after the done-record expires is
+// no longer deduplicated by the Claimer and will re-invoke the handler — the
+// guarantee degrades to timestamp-window + at-least-once for that late
+// redelivery. Handlers MUST therefore be idempotent regardless (see
+// [kwh.WebhookReceiveHandler] and the signing-algorithm ADR threat model). Making
+// these TTLs per-contract configurable (baked from contract.yaml like the other
+// ReceiverSpec fields) is tracked as a follow-up; see PR / backlog.
 const (
 	// receiverLeaseTTL is how long the in-flight processing lease is held.
 	// If the handler goroutine crashes mid-flight, the claimer reclaims after
@@ -26,9 +37,15 @@ const (
 	receiverLeaseTTL = 30 * time.Second
 
 	// receiverDoneTTL is how long a successfully-committed idempotency key
-	// is remembered. Matches the EventBus default (24 h).
+	// is remembered. Matches the EventBus default (24 h). See the package-level
+	// caveat above on provider retry windows exceeding this value.
 	receiverDoneTTL = 24 * time.Hour
 )
+
+// msgBodyTooLarge is the wire message for an over-limit request body (413).
+// Declared once because it appears in both the Content-Length pre-check and the
+// MaxBytesReader read-time branch of readBody.
+const msgBodyTooLarge = "webhook receiver: request body too large"
 
 // verified is an unforgeable token produced only by [Receiver.verify].
 // Package-external code cannot construct this type (unexported struct with no
@@ -116,6 +133,13 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// 2. Verify — produces unforgeable verified token.
 	v, err := r.verify(body, req)
 	if err != nil {
+		// Warn (not Error): a verification failure is a 4xx caused by an
+		// external caller (bad/missing signature, unknown source, expired
+		// timestamp), not a server-side correctness fault. observability.md
+		// reserves Error for failures that affect correctness; routine 4xx
+		// signature rejection is expected traffic. A sustained spike of these
+		// is a security signal handled by alerting thresholds on the rate, not
+		// by escalating each individual rejection to Error.
 		slog.WarnContext(ctx, "webhook receiver: signature verification failed",
 			slog.String("source_id", r.spec.SourceID),
 			slog.String("contract_id", r.spec.ContractID),
@@ -217,10 +241,10 @@ func (r *Receiver) readBody(w http.ResponseWriter, req *http.Request) ([]byte, e
 
 	// Quick pre-check on Content-Length before allocating.
 	if req.ContentLength > r.spec.MaxBodyBytes {
-		httputil.WriteError(ctx, w, errcode.New(errcode.KindPayloadTooLarge,
-			errcode.ErrWebhookBodyTooLarge, "webhook receiver: request body too large"))
-		return nil, errcode.New(errcode.KindPayloadTooLarge, errcode.ErrWebhookBodyTooLarge,
-			"webhook receiver: request body too large")
+		tooLarge := errcode.New(errcode.KindPayloadTooLarge,
+			errcode.ErrWebhookBodyTooLarge, msgBodyTooLarge)
+		httputil.WriteError(ctx, w, tooLarge)
+		return nil, tooLarge
 	}
 
 	req.Body = http.MaxBytesReader(w, req.Body, r.spec.MaxBodyBytes)
@@ -229,10 +253,13 @@ func (r *Receiver) readBody(w http.ResponseWriter, req *http.Request) ([]byte, e
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			httputil.WriteError(ctx, w, errcode.New(errcode.KindPayloadTooLarge,
-				errcode.ErrWebhookBodyTooLarge, "webhook receiver: request body too large"))
+				errcode.ErrWebhookBodyTooLarge, msgBodyTooLarge))
 			return nil, err
 		}
-		slog.ErrorContext(ctx, "webhook receiver: read body failed", slog.Any("error", err))
+		slog.ErrorContext(ctx, "webhook receiver: read body failed",
+			slog.String("source_id", r.spec.SourceID),
+			slog.String("contract_id", r.spec.ContractID),
+			slog.Any("error", err))
 		httputil.WriteError(ctx, w, errcode.New(errcode.KindUnavailable,
 			errcode.ErrServiceUnavailable, "webhook receiver: failed to read request body"))
 		return nil, err
@@ -265,13 +292,18 @@ func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
 	}
 
 	// Look up the source by spec.SourceID. Return ErrWebhookInvalidSignature
-	// (not a source-enumeration error) to avoid disclosing whether the source
-	// exists (WEBHOOK-HMAC-FUNNEL-01 F8/F9).
+	// with the shared kwh.MsgSignatureVerificationFailed wire message so an
+	// unregistered source is byte-identical to a signature mismatch and cannot
+	// be used as a source-ID enumeration oracle (WEBHOOK-HMAC-FUNNEL-01 F8/F9;
+	// OWASP Generic Error Messages). The "source not registered" reason is kept
+	// in WithInternal (server-side slog only, never on the wire).
 	src, ok := r.store.Lookup(kwh.SourceID(r.spec.SourceID))
 	if !ok {
 		return verified{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
-			"webhook receiver: signature verification failed",
-			errcode.WithInternal(errcode.InternalAttr("source_id", r.spec.SourceID)))
+			kwh.MsgSignatureVerificationFailed,
+			errcode.WithInternal(
+				errcode.InternalAttr("source_id", r.spec.SourceID),
+				errcode.InternalAttr("reason", "source not registered")))
 	}
 
 	if err := r.verifier.Verify(body, headers, src); err != nil {

--- a/runtime/webhook/receiver_integration_test.go
+++ b/runtime/webhook/receiver_integration_test.go
@@ -40,7 +40,7 @@ func buildIntegrationServer(t *testing.T, handler kwh.WebhookReceiveHandler) (*h
 		},
 	}
 
-	groups, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestIntegration_IdempotentReplay(t *testing.T) {
 	}
 
 	// Second request with the same delivery ID — handler must NOT be called again;
-	// response is 200 (idempotent acknowledged).
+	// response is 200 (idempotent acknowledged) with the same {"status":"accepted"} body.
 	resp2 := sendSignedRequest(t, srv, signer, body, deliveryID)
 	if resp2.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp2.Body)
@@ -186,6 +186,14 @@ func TestIntegration_IdempotentReplay(t *testing.T) {
 	}
 	if handlerCalled != 1 {
 		t.Errorf("second request: handler called %d times total, want 1 (idempotent)", handlerCalled)
+	}
+	// Verify idempotent replay response body shape.
+	var result2 map[string]string
+	if err := json.NewDecoder(resp2.Body).Decode(&result2); err != nil {
+		t.Fatalf("decode idempotent replay response: %v", err)
+	}
+	if result2["status"] != "accepted" {
+		t.Errorf("idempotent replay response.status = %q, want accepted", result2["status"])
 	}
 }
 
@@ -293,5 +301,158 @@ func TestIntegration_StatusCodeCoverage(t *testing.T) {
 				t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, tt.wantStatus, raw)
 			}
 		})
+	}
+}
+
+// TestIntegration_BodyTooLarge_Returns413 verifies that a request whose body
+// exceeds MaxBodyBytes is rejected with 413 before HMAC verification.
+func TestIntegration_BodyTooLarge_Returns413(t *testing.T) {
+	// Build a spec with a tiny body limit.
+	spec := testSpec()
+	spec.MaxBodyBytes = 10 // 10 bytes
+
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	reqs := []cell.WebhookReceiverRequest{{Spec: spec, Handler: func(_ context.Context, _ kwh.Delivery) error { return nil }}}
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	for _, g := range groups {
+		stub := &serveMuxAdapter{mux: mux, prefix: g.Prefix}
+		if err := g.Register(stub); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Body is larger than the 10-byte limit.
+	bigBody := bytes.Repeat([]byte("x"), 100)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(bigBody))
+	req.ContentLength = int64(len(bigBody)) // above spec.MaxBodyBytes
+	req.Header.Set("X-Delivery-Id", "int-413-001")
+	req.Header.Set("X-Timestamp", "1234567890")
+	req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 413; body: %s", resp.StatusCode, raw)
+	}
+}
+
+// TestIntegration_TimestampExpired_Returns401 verifies that a delivery signed
+// at fixedNow but received with a clock testReplaySkew in the future is
+// rejected 401 (replay defence — outside ±300s tolerance window).
+func TestIntegration_TimestampExpired_Returns401(t *testing.T) {
+	src := testSource(t)
+	signer, err := kwh.NewHMACSigner(src)
+	if err != nil {
+		t.Fatalf("NewHMACSigner: %v", err)
+	}
+
+	body := []byte(`{"event":"ts-expired"}`)
+	did, _ := kwh.NewDeliveryID("int-ts-expired-001")
+	headers, _ := signer.Sign(body, fixedNow, did) // signed at fixedNow
+
+	// Server clock is testReplaySkew ahead → outside ±testTolerance window.
+	laterClk := clockmock.New(fixedNow.Add(testReplaySkew))
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(laterClk)
+
+	spec := testSpec()
+	reqs := []cell.WebhookReceiverRequest{{Spec: spec, Handler: func(_ context.Context, _ kwh.Delivery) error { return nil }}}
+	groups, err := rtwh.BuildRouteGroups(laterClk, reqs, store, claimer)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	for _, g := range groups {
+		stub := &serveMuxAdapter{mux: mux, prefix: g.Prefix}
+		if err := g.Register(stub); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", headers.Signature)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 401; body: %s", resp.StatusCode, raw)
+	}
+}
+
+// TestIntegration_ConcurrentDelivery_Returns409 verifies that a ClaimBusy
+// state (another goroutine already holds the lease) returns 409.
+func TestIntegration_ConcurrentDelivery_Returns409(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+
+	// fakeClaimer always returns ClaimBusy to simulate a concurrent delivery.
+	fakeCl := &fakeClaimer{results: []claimResult{{state: idempotency.ClaimBusy}}}
+
+	src := testSource(t)
+	signer, err := kwh.NewHMACSigner(src)
+	if err != nil {
+		t.Fatalf("NewHMACSigner: %v", err)
+	}
+
+	spec := testSpec()
+	reqs := []cell.WebhookReceiverRequest{{Spec: spec, Handler: func(_ context.Context, _ kwh.Delivery) error { return nil }}}
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, fakeCl)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	for _, g := range groups {
+		stub := &serveMuxAdapter{mux: mux, prefix: g.Prefix}
+		if err := g.Register(stub); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body := []byte(`{"event":"busy"}`)
+	did, _ := kwh.NewDeliveryID("int-busy-001")
+	headers, _ := signer.Sign(body, fixedNow, did)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", headers.Signature)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 409; body: %s", resp.StatusCode, raw)
 	}
 }

--- a/runtime/webhook/receiver_integration_test.go
+++ b/runtime/webhook/receiver_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	rtwh "github.com/ghbvf/gocell/runtime/webhook"
 )
 
@@ -454,5 +456,42 @@ func TestIntegration_ConcurrentDelivery_Returns409(t *testing.T) {
 	if resp.StatusCode != http.StatusConflict {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 409; body: %s", resp.StatusCode, raw)
+	}
+}
+
+// TestIntegration_Handler503_Returns503 verifies that a handler returning an
+// errcode.KindUnavailable error propagates to HTTP 503 through the full
+// integration stack (BuildRouteGroups → ServeMux → HTTP).
+func TestIntegration_Handler503_Returns503(t *testing.T) {
+	handler := func(_ context.Context, _ kwh.Delivery) error {
+		return errcode.New(errcode.KindUnavailable, errcode.ErrServiceUnavailable,
+			"downstream unavailable")
+	}
+	srv, signer := buildIntegrationServer(t, handler)
+
+	body := []byte(`{"event":"handler-503"}`)
+	resp := sendSignedRequest(t, srv, signer, body, "int-handler503-001")
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 503; body: %s", resp.StatusCode, raw)
+	}
+}
+
+// TestIntegration_HandlerGenericError_Returns500 verifies that a handler
+// returning a plain (non-errcode) error propagates to HTTP 500 through the
+// full integration stack.
+func TestIntegration_HandlerGenericError_Returns500(t *testing.T) {
+	handler := func(_ context.Context, _ kwh.Delivery) error {
+		return errors.New("unexpected handler failure")
+	}
+	srv, signer := buildIntegrationServer(t, handler)
+
+	body := []byte(`{"event":"handler-500"}`)
+	resp := sendSignedRequest(t, srv, signer, body, "int-handler500-001")
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 500; body: %s", resp.StatusCode, raw)
 	}
 }

--- a/runtime/webhook/receiver_integration_test.go
+++ b/runtime/webhook/receiver_integration_test.go
@@ -81,10 +81,12 @@ type serveMuxAdapter struct {
 func (s *serveMuxAdapter) Handle(pattern string, h http.Handler) {
 	s.mux.Handle(pattern, h)
 }
+
 func (s *serveMuxAdapter) Route(pattern string, fn func(cell.RouteMux)) {
 	sub := &serveMuxAdapter{mux: s.mux}
 	fn(sub)
 }
+
 func (s *serveMuxAdapter) Mount(pattern string, h http.Handler) {
 	// BuildRouteGroups calls mux.Mount("/", handler) so the Receiver is mounted
 	// under the adapter's prefix. Compose: effective = prefix + pattern.

--- a/runtime/webhook/receiver_integration_test.go
+++ b/runtime/webhook/receiver_integration_test.go
@@ -1,0 +1,297 @@
+//go:build integration
+
+package webhook_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	rtwh "github.com/ghbvf/gocell/runtime/webhook"
+)
+
+// buildIntegrationServer constructs a real httptest.Server with the full
+// BuildRouteGroups pipeline and a simple chi-like mux backed by stdlib
+// http.ServeMux that routes through the registered handler.
+func buildIntegrationServer(t *testing.T, handler kwh.WebhookReceiveHandler) (*httptest.Server, kwh.Signer) {
+	t.Helper()
+
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	if handler == nil {
+		handler = func(_ context.Context, _ kwh.Delivery) error { return nil }
+	}
+
+	reqs := []cell.WebhookReceiverRequest{
+		{
+			Spec:    testSpec(),
+			Handler: handler,
+		},
+	}
+
+	groups, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+
+	// Wire route groups into a stdlib ServeMux via the stubMux adapter.
+	// Pass g.Prefix so Mount can qualify the "/" argument from BuildRouteGroups.
+	mux := http.NewServeMux()
+	for _, g := range groups {
+		stub := &serveMuxAdapter{mux: mux, prefix: g.Prefix}
+		if err := g.Register(stub); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Return the signer for the test source so callers can produce valid requests.
+	src := testSource(t)
+	signer, err := kwh.NewHMACSigner(src)
+	if err != nil {
+		t.Fatalf("NewHMACSigner: %v", err)
+	}
+	return srv, signer
+}
+
+// serveMuxAdapter adapts cell.RouteMux (Mount) to stdlib *http.ServeMux.
+// prefix is the RouteGroup.Prefix (e.g. "/webhooks/test") that was in effect
+// when Register was called — BuildRouteGroups now mounts at "/" so the adapter
+// must prefix-qualify the registration itself.
+type serveMuxAdapter struct {
+	mux    *http.ServeMux
+	prefix string // RouteGroup.Prefix for this adapter; empty = root
+}
+
+func (s *serveMuxAdapter) Handle(pattern string, h http.Handler) {
+	s.mux.Handle(pattern, h)
+}
+func (s *serveMuxAdapter) Route(pattern string, fn func(cell.RouteMux)) {
+	sub := &serveMuxAdapter{mux: s.mux}
+	fn(sub)
+}
+func (s *serveMuxAdapter) Mount(pattern string, h http.Handler) {
+	// BuildRouteGroups calls mux.Mount("/", handler) so the Receiver is mounted
+	// under the adapter's prefix. Compose: effective = prefix + pattern.
+	effective := s.prefix
+	if effective == "" {
+		effective = pattern
+	} else if pattern != "/" {
+		effective = effective + pattern
+	}
+	effective = strings.TrimSuffix(effective, "/")
+	s.mux.Handle(effective+"/", http.StripPrefix(effective, h))
+	s.mux.Handle(effective, h)
+}
+func (s *serveMuxAdapter) Group(fn func(cell.RouteMux)) { fn(s) }
+func (s *serveMuxAdapter) With(_ ...func(http.Handler) http.Handler) cell.RouteMux {
+	return s
+}
+
+// sendSignedRequest sends a signed webhook delivery to srv and returns the response.
+func sendSignedRequest(t *testing.T, srv *httptest.Server, signer kwh.Signer, body []byte, deliveryID string) *http.Response {
+	t.Helper()
+	did, err := kwh.NewDeliveryID(deliveryID)
+	if err != nil {
+		t.Fatalf("NewDeliveryID: %v", err)
+	}
+	headers, err := signer.Sign(body, fixedNow, did)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", headers.Signature)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func TestIntegration_EndToEnd_ValidDelivery(t *testing.T) {
+	handlerCalled := 0
+	srv, signer := buildIntegrationServer(t, func(_ context.Context, d kwh.Delivery) error {
+		handlerCalled++
+		return nil
+	})
+
+	body := []byte(`{"event":"integration-test"}`)
+	resp := sendSignedRequest(t, srv, signer, body, "int-msg-001")
+
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, raw)
+	}
+	if handlerCalled != 1 {
+		t.Errorf("handler called %d times, want 1", handlerCalled)
+	}
+
+	// Verify response shape.
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result["status"] != "accepted" {
+		t.Errorf("response.status = %q, want accepted", result["status"])
+	}
+}
+
+func TestIntegration_IdempotentReplay(t *testing.T) {
+	handlerCalled := 0
+	srv, signer := buildIntegrationServer(t, func(_ context.Context, _ kwh.Delivery) error {
+		handlerCalled++
+		return nil
+	})
+
+	body := []byte(`{"event":"replay-test"}`)
+	deliveryID := "int-replay-001"
+
+	// First request — handler must be called once, response 200.
+	resp1 := sendSignedRequest(t, srv, signer, body, deliveryID)
+	if resp1.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("first request: status = %d, body = %s", resp1.StatusCode, raw)
+	}
+	if handlerCalled != 1 {
+		t.Fatalf("first request: handler called %d times, want 1", handlerCalled)
+	}
+
+	// Second request with the same delivery ID — handler must NOT be called again;
+	// response is 200 (idempotent acknowledged).
+	resp2 := sendSignedRequest(t, srv, signer, body, deliveryID)
+	if resp2.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("second request: status = %d, body = %s", resp2.StatusCode, raw)
+	}
+	if handlerCalled != 1 {
+		t.Errorf("second request: handler called %d times total, want 1 (idempotent)", handlerCalled)
+	}
+}
+
+func TestIntegration_MissingHeader_Returns400(t *testing.T) {
+	srv, signer := buildIntegrationServer(t, nil)
+	body := []byte(`{}`)
+
+	did, _ := kwh.NewDeliveryID("int-miss-hdr")
+	headers, _ := signer.Sign(body, fixedNow, did)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	// Intentionally omit X-Timestamp and X-Signature.
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, raw)
+	}
+}
+
+func TestIntegration_BadSignature_Returns401(t *testing.T) {
+	srv, signer := buildIntegrationServer(t, nil)
+	body := []byte(`{}`)
+
+	did, _ := kwh.NewDeliveryID("int-bad-sig")
+	headers, _ := signer.Sign(body, fixedNow, did)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=") // forged
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, raw)
+	}
+}
+
+func TestIntegration_StatusCodeCoverage(t *testing.T) {
+	tests := []struct {
+		name       string
+		deliveryID string
+		mutate     func(*http.Request, kwh.Headers)
+		wantStatus int
+	}{
+		{
+			name:       "valid delivery -> 200",
+			deliveryID: "cov-200",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing signature header -> 400",
+			deliveryID: "cov-400",
+			mutate: func(r *http.Request, _ kwh.Headers) {
+				r.Header.Del("X-Signature")
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid signature -> 401",
+			deliveryID: "cov-401",
+			mutate: func(r *http.Request, _ kwh.Headers) {
+				r.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	srv, signer := buildIntegrationServer(t, nil)
+	body := []byte(`{"event":"cov"}`)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			did, _ := kwh.NewDeliveryID(tt.deliveryID)
+			headers, _ := signer.Sign(body, fixedNow, did)
+
+			req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
+			req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+			req.Header.Set("X-Timestamp", headers.Timestamp)
+			req.Header.Set("X-Signature", headers.Signature)
+			if tt.mutate != nil {
+				tt.mutate(req, headers)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatus {
+				raw, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, tt.wantStatus, raw)
+			}
+		})
+	}
+}

--- a/runtime/webhook/receiver_test.go
+++ b/runtime/webhook/receiver_test.go
@@ -28,6 +28,10 @@ const (
 	testSecret       = "12345678901234567890abcd" // 24 bytes
 	testMaxBodyBytes = 1 << 20                    // 1 MiB
 	testTolerance    = 300                        // seconds
+
+	// testReplaySkew is the clock offset used to place a delivery outside the
+	// tolerance window in timestamp-expiry tests (must exceed testTolerance seconds).
+	testReplaySkew = 10 * time.Minute
 )
 
 // fixedNow is a stable reference time used across tests.
@@ -157,9 +161,29 @@ func (nopReceipt) Commit(_ context.Context) error                  { return nil 
 func (nopReceipt) Release(_ context.Context) error                 { return nil }
 func (nopReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
 
+// countingReceipt records how many times Release was called, used by the
+// handler-panic test to assert the lease is released before re-panic.
+type countingReceipt struct {
+	released int
+}
+
+func (r *countingReceipt) Commit(_ context.Context) error                  { return nil }
+func (r *countingReceipt) Release(_ context.Context) error                 { r.released++; return nil }
+func (r *countingReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
+
+// countingClaimer always returns ClaimAcquired with a shared countingReceipt.
+type countingClaimer struct {
+	rcpt *countingReceipt
+}
+
+func (c *countingClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
+	return idempotency.ClaimAcquired, c.rcpt, nil
+}
+
 // ---- NewReceiver construction tests ----
 
 func TestNewReceiver_NilDeps(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 	verifier, _ := kwh.NewHMACVerifier(clk)
@@ -196,6 +220,7 @@ func TestNewReceiver_NilDeps(t *testing.T) {
 // ---- ServeHTTP table-driven tests ----
 
 func TestReceiver_ServeHTTP(t *testing.T) {
+	t.Parallel()
 	body := []byte(`{"event":"test"}`)
 	deliveryID := "msg-001"
 
@@ -302,7 +327,9 @@ func TestReceiver_ServeHTTP(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			recv := buildReceiver(t, receiverOpts{
 				claimer: tt.claimer,
 				handler: tt.handler,
@@ -317,6 +344,7 @@ func TestReceiver_ServeHTTP(t *testing.T) {
 }
 
 func TestReceiver_SuccessResponseShape(t *testing.T) {
+	t.Parallel()
 	body := []byte(`{"event":"test"}`)
 	recv := buildReceiver(t, receiverOpts{})
 	w := httptest.NewRecorder()
@@ -337,6 +365,7 @@ func TestReceiver_SuccessResponseShape(t *testing.T) {
 }
 
 func TestReceiver_ErrorResponseEnvelope(t *testing.T) {
+	t.Parallel()
 	body := []byte(`{}`)
 	recv := buildReceiver(t, receiverOpts{})
 	w := httptest.NewRecorder()
@@ -357,6 +386,7 @@ func TestReceiver_ErrorResponseEnvelope(t *testing.T) {
 }
 
 func TestReceiver_UnknownSource_Returns401(t *testing.T) {
+	t.Parallel()
 	// Build a receiver pointing at a source that isn't in the store.
 	clk := clockmock.New(fixedNow)
 	emptyStore := kwh.NewSourceRegistry()
@@ -376,6 +406,7 @@ func TestReceiver_UnknownSource_Returns401(t *testing.T) {
 }
 
 func TestReceiver_TimestampExpired_Returns401(t *testing.T) {
+	t.Parallel()
 	// The signer uses fixedNow but the verifier's clock is 10 minutes ahead
 	// (outside the 300s tolerance window).
 	body := []byte(`{"event":"test"}`)
@@ -392,8 +423,8 @@ func TestReceiver_TimestampExpired_Returns401(t *testing.T) {
 	req.Header.Set("X-Timestamp", headers.Timestamp)
 	req.Header.Set("X-Signature", headers.Signature)
 
-	// Verifier clock is 10 minutes ahead → outside ±300s window.
-	laterClk := clockmock.New(fixedNow.Add(10 * time.Minute))
+	// Verifier clock is testReplaySkew ahead → outside ±300s window.
+	laterClk := clockmock.New(fixedNow.Add(testReplaySkew))
 	store := testStore(t)
 	verifier, _ := kwh.NewHMACVerifier(laterClk, kwh.WithTolerance(testTolerance*time.Second))
 	claimer := idempotency.NewInMemClaimer(laterClk)
@@ -411,6 +442,7 @@ func TestReceiver_TimestampExpired_Returns401(t *testing.T) {
 }
 
 func TestReceiver_BodyExceedsLimitViaMaxBytesReader(t *testing.T) {
+	t.Parallel()
 	// Build a receiver with a tiny body limit.
 	spec := testSpec()
 	spec.MaxBodyBytes = 10 // 10 bytes limit
@@ -449,6 +481,7 @@ func TestReceiver_BodyExceedsLimitViaMaxBytesReader(t *testing.T) {
 }
 
 func TestReceiver_HandlerReceivesDelivery(t *testing.T) {
+	t.Parallel()
 	body := []byte(`{"event":"check-delivery"}`)
 	deliveryID := "msg-delivery-check"
 
@@ -471,5 +504,57 @@ func TestReceiver_HandlerReceivesDelivery(t *testing.T) {
 	}
 	if string(gotDelivery.SourceID) != testSourceID {
 		t.Errorf("sourceID = %q, want %q", gotDelivery.SourceID, testSourceID)
+	}
+}
+
+// TestReceiver_HandlerPanic_ReleasesLeaseAndRepanics verifies that when the
+// business handler panics, the Receiver:
+//  1. Calls Release on the idempotency receipt (so the TTL does not permanently
+//     block re-delivery).
+//  2. Re-panics with the original value so the HTTP recovery middleware can
+//     convert the panic to a 500 response.
+//
+// This test uses a shared countingReceipt; the handler and release assertions
+// require a specific execution order, so the sub-cases are NOT run in parallel.
+func TestReceiver_HandlerPanic_ReleasesLeaseAndRepanics(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"event":"panic-test"}`)
+	rcpt := &countingReceipt{}
+	claimer := &countingClaimer{rcpt: rcpt}
+
+	panicValue := "test-handler-panic"
+	handler := func(_ context.Context, _ kwh.Delivery) error {
+		panic(panicValue)
+	}
+
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	if err != nil {
+		t.Fatalf("NewHMACVerifier: %v", err)
+	}
+
+	recv, err := rtwh.NewReceiver(clk, testSpec(), verifier, store, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+
+	// Capture the re-panic from dispatch so we can assert it propagated.
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		w := httptest.NewRecorder()
+		recv.ServeHTTP(w, signedRequest(t, body, "msg-panic-001"))
+	}()
+
+	// The lease must have been released before the panic propagated.
+	if rcpt.released != 1 {
+		t.Errorf("Release called %d times, want 1", rcpt.released)
+	}
+
+	// The panic must have re-propagated (recovered is non-nil).
+	if recovered == nil {
+		t.Error("expected panic to re-propagate, but recover() returned nil")
 	}
 }

--- a/runtime/webhook/receiver_test.go
+++ b/runtime/webhook/receiver_test.go
@@ -1,0 +1,475 @@
+package webhook_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	rtwh "github.com/ghbvf/gocell/runtime/webhook"
+)
+
+// ---- test fixtures ----
+
+const (
+	testSourceID     = "test-source"
+	testContractID   = "webhook.test.v1"
+	testCellID       = "testcell"
+	testPathPattern  = "/webhooks/test"
+	testSecret       = "12345678901234567890abcd" // 24 bytes
+	testMaxBodyBytes = 1 << 20                    // 1 MiB
+	testTolerance    = 300                        // seconds
+)
+
+// fixedNow is a stable reference time used across tests.
+var fixedNow = time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+func testSpec() kwh.ReceiverSpec {
+	return kwh.ReceiverSpec{
+		ContractID:       testContractID,
+		SourceID:         testSourceID,
+		CellID:           testCellID,
+		PathPattern:      testPathPattern,
+		DeliveryIDHeader: "X-Delivery-Id",
+		TimestampHeader:  "X-Timestamp",
+		SignatureHeader:  "X-Signature",
+		ToleranceSeconds: testTolerance,
+		MaxBodyBytes:     testMaxBodyBytes,
+	}
+}
+
+func testSource(t *testing.T) kwh.Source {
+	t.Helper()
+	id, err := kwh.NewSourceID(testSourceID)
+	if err != nil {
+		t.Fatalf("NewSourceID: %v", err)
+	}
+	src, err := kwh.NewSource(id, []byte(testSecret))
+	if err != nil {
+		t.Fatalf("NewSource: %v", err)
+	}
+	return src
+}
+
+func testStore(t *testing.T) *kwh.SourceRegistry {
+	t.Helper()
+	reg := kwh.NewSourceRegistry()
+	if err := reg.Register(testSource(t)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	return reg
+}
+
+// signedRequest builds an *http.Request with a valid HMAC signature for body.
+func signedRequest(t *testing.T, body []byte, deliveryID string) *http.Request {
+	t.Helper()
+	src := testSource(t)
+	signer, err := kwh.NewHMACSigner(src)
+	if err != nil {
+		t.Fatalf("NewHMACSigner: %v", err)
+	}
+	did, err := kwh.NewDeliveryID(deliveryID)
+	if err != nil {
+		t.Fatalf("NewDeliveryID: %v", err)
+	}
+	headers, err := signer.Sign(body, fixedNow, did)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(body))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", headers.Signature)
+	return req
+}
+
+// buildReceiver constructs a Receiver with optional overrides.
+type receiverOpts struct {
+	claimer idempotency.Claimer
+	handler kwh.WebhookReceiveHandler
+}
+
+func buildReceiver(t *testing.T, opts receiverOpts) *rtwh.Receiver {
+	t.Helper()
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	if err != nil {
+		t.Fatalf("NewHMACVerifier: %v", err)
+	}
+	claimer := opts.claimer
+	if claimer == nil {
+		claimer = idempotency.NewInMemClaimer(clk)
+	}
+	handler := opts.handler
+	if handler == nil {
+		handler = func(_ context.Context, _ kwh.Delivery) error { return nil }
+	}
+	recv, err := rtwh.NewReceiver(clk, testSpec(), verifier, store, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	return recv
+}
+
+// ---- fakeClaimer — configures the claim state per call ----
+
+type claimResult struct {
+	state idempotency.ClaimState
+	err   error
+}
+
+type fakeClaimer struct {
+	results []claimResult
+	calls   int
+}
+
+func (f *fakeClaimer) Claim(_ context.Context, _ string, _, _ time.Duration) (idempotency.ClaimState, idempotency.Receipt, error) {
+	if f.calls >= len(f.results) {
+		return idempotency.ClaimAcquired, idempotency.NonAcquiredReceipt(), nil
+	}
+	r := f.results[f.calls]
+	f.calls++
+	if r.err != nil {
+		return idempotency.ClaimBusy, nil, r.err
+	}
+	switch r.state {
+	case idempotency.ClaimDone, idempotency.ClaimBusy:
+		return r.state, idempotency.NonAcquiredReceipt(), nil
+	default: // ClaimAcquired
+		return r.state, &nopReceipt{}, nil
+	}
+}
+
+type nopReceipt struct{}
+
+func (nopReceipt) Commit(_ context.Context) error                  { return nil }
+func (nopReceipt) Release(_ context.Context) error                 { return nil }
+func (nopReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
+
+// ---- NewReceiver construction tests ----
+
+func TestNewReceiver_NilDeps(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, _ := kwh.NewHMACVerifier(clk)
+	claimer := idempotency.NewInMemClaimer(clk)
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+	spec := testSpec()
+
+	t.Run("nil verifier", func(t *testing.T) {
+		_, err := rtwh.NewReceiver(clk, spec, nil, store, claimer, handler)
+		if err == nil {
+			t.Fatal("expected error for nil verifier")
+		}
+	})
+	t.Run("nil store", func(t *testing.T) {
+		_, err := rtwh.NewReceiver(clk, spec, verifier, nil, claimer, handler)
+		if err == nil {
+			t.Fatal("expected error for nil store")
+		}
+	})
+	t.Run("nil claimer", func(t *testing.T) {
+		_, err := rtwh.NewReceiver(clk, spec, verifier, store, nil, handler)
+		if err == nil {
+			t.Fatal("expected error for nil claimer")
+		}
+	})
+	t.Run("nil handler", func(t *testing.T) {
+		_, err := rtwh.NewReceiver(clk, spec, verifier, store, claimer, nil)
+		if err == nil {
+			t.Fatal("expected error for nil handler")
+		}
+	})
+}
+
+// ---- ServeHTTP table-driven tests ----
+
+func TestReceiver_ServeHTTP(t *testing.T) {
+	body := []byte(`{"event":"test"}`)
+	deliveryID := "msg-001"
+
+	tests := []struct {
+		name       string
+		req        func() *http.Request
+		claimer    idempotency.Claimer
+		handler    kwh.WebhookReceiveHandler
+		wantStatus int
+	}{
+		{
+			name:       "valid signature + handler success -> 200",
+			req:        func() *http.Request { return signedRequest(t, body, deliveryID) },
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "repeat deliveryID (ClaimDone) -> 200 idempotent",
+			req:  func() *http.Request { return signedRequest(t, body, deliveryID+"-done") },
+			claimer: &fakeClaimer{results: []claimResult{
+				{state: idempotency.ClaimDone},
+			}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "concurrent delivery (ClaimBusy) -> 409",
+			req:  func() *http.Request { return signedRequest(t, body, deliveryID+"-busy") },
+			claimer: &fakeClaimer{results: []claimResult{
+				{state: idempotency.ClaimBusy},
+			}},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name: "claimer infra error -> 503",
+			req:  func() *http.Request { return signedRequest(t, body, deliveryID+"-infra") },
+			claimer: &fakeClaimer{results: []claimResult{
+				{state: idempotency.ClaimBusy, err: errors.New("redis down")},
+			}},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "missing delivery-id header -> 400",
+			req: func() *http.Request {
+				req := signedRequest(t, body, "msg-hdr")
+				req.Header.Del("X-Delivery-Id")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing timestamp header -> 400",
+			req: func() *http.Request {
+				req := signedRequest(t, body, "msg-ts")
+				req.Header.Del("X-Timestamp")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing signature header -> 400",
+			req: func() *http.Request {
+				req := signedRequest(t, body, "msg-sig")
+				req.Header.Del("X-Signature")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "bad signature -> 401",
+			req: func() *http.Request {
+				req := signedRequest(t, body, "msg-badsig")
+				req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "body too large -> 413",
+			req: func() *http.Request {
+				// Use a spec-level Content-Length pre-check: set Content-Length > MaxBodyBytes.
+				bigBody := bytes.Repeat([]byte("x"), int(testMaxBodyBytes)+1)
+				req := signedRequest(t, bigBody[:10], "msg-large")
+				req.ContentLength = int64(testMaxBodyBytes) + 1
+				return req
+			},
+			wantStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name: "handler returns KindUnavailable -> 503",
+			req:  func() *http.Request { return signedRequest(t, body, "msg-handler503") },
+			handler: func(_ context.Context, _ kwh.Delivery) error {
+				return errcode.New(errcode.KindUnavailable, errcode.ErrServiceUnavailable,
+					"downstream unavailable")
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "handler returns generic error -> 500",
+			req:  func() *http.Request { return signedRequest(t, body, "msg-handler500") },
+			handler: func(_ context.Context, _ kwh.Delivery) error {
+				return errors.New("unexpected failure")
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recv := buildReceiver(t, receiverOpts{
+				claimer: tt.claimer,
+				handler: tt.handler,
+			})
+			w := httptest.NewRecorder()
+			recv.ServeHTTP(w, tt.req())
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestReceiver_SuccessResponseShape(t *testing.T) {
+	body := []byte(`{"event":"test"}`)
+	recv := buildReceiver(t, receiverOpts{})
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, signedRequest(t, body, "msg-shape"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["status"] != "accepted" {
+		t.Fatalf("response.status = %q, want accepted", resp["status"])
+	}
+}
+
+func TestReceiver_ErrorResponseEnvelope(t *testing.T) {
+	body := []byte(`{}`)
+	recv := buildReceiver(t, receiverOpts{})
+	w := httptest.NewRecorder()
+	// Trigger a 400 by omitting the delivery-id header.
+	req := signedRequest(t, body, "msg-env-check")
+	req.Header.Del("X-Delivery-Id")
+	recv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := envelope["error"]; !ok {
+		t.Fatalf("response missing 'error' key; got: %s", w.Body.String())
+	}
+}
+
+func TestReceiver_UnknownSource_Returns401(t *testing.T) {
+	// Build a receiver pointing at a source that isn't in the store.
+	clk := clockmock.New(fixedNow)
+	emptyStore := kwh.NewSourceRegistry()
+	verifier, _ := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	claimer := idempotency.NewInMemClaimer(clk)
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+
+	recv, err := rtwh.NewReceiver(clk, testSpec(), verifier, emptyStore, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, signedRequest(t, []byte("payload"), "msg-unknown"))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for unknown source", w.Code)
+	}
+}
+
+func TestReceiver_TimestampExpired_Returns401(t *testing.T) {
+	// The signer uses fixedNow but the verifier's clock is 10 minutes ahead
+	// (outside the 300s tolerance window).
+	body := []byte(`{"event":"test"}`)
+	deliveryID := "msg-expired"
+
+	// Sign at fixedNow.
+	src := testSource(t)
+	signer, _ := kwh.NewHMACSigner(src)
+	did, _ := kwh.NewDeliveryID(deliveryID)
+	headers, _ := signer.Sign(body, fixedNow, did)
+
+	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(body))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", headers.Signature)
+
+	// Verifier clock is 10 minutes ahead → outside ±300s window.
+	laterClk := clockmock.New(fixedNow.Add(10 * time.Minute))
+	store := testStore(t)
+	verifier, _ := kwh.NewHMACVerifier(laterClk, kwh.WithTolerance(testTolerance*time.Second))
+	claimer := idempotency.NewInMemClaimer(laterClk)
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+
+	recv, err := rtwh.NewReceiver(laterClk, testSpec(), verifier, store, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for expired timestamp", w.Code)
+	}
+}
+
+func TestReceiver_BodyExceedsLimitViaMaxBytesReader(t *testing.T) {
+	// Build a receiver with a tiny body limit.
+	spec := testSpec()
+	spec.MaxBodyBytes = 10 // 10 bytes limit
+
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, _ := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	claimer := idempotency.NewInMemClaimer(clk)
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+
+	recv, err := rtwh.NewReceiver(clk, spec, verifier, store, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+
+	// Body that exceeds the 10-byte limit (Content-Length matches so pre-check passes).
+	bigBody := bytes.Repeat([]byte("x"), 100)
+	// Sign with the actually-sent body so signature is plausible (doesn't matter — 413 fires first).
+	src := testSource(t)
+	signer, _ := kwh.NewHMACSigner(src)
+	did, _ := kwh.NewDeliveryID("msg-big-body")
+	headers, _ := signer.Sign(bigBody, fixedNow, did)
+
+	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(bigBody))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Signature", headers.Signature)
+	// Don't set Content-Length above limit — let MaxBytesReader detect it.
+	req.ContentLength = int64(len(bigBody)) // correct but above limit
+
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestReceiver_HandlerReceivesDelivery(t *testing.T) {
+	body := []byte(`{"event":"check-delivery"}`)
+	deliveryID := "msg-delivery-check"
+
+	var gotDelivery kwh.Delivery
+	handler := func(_ context.Context, d kwh.Delivery) error {
+		gotDelivery = d
+		return nil
+	}
+	recv := buildReceiver(t, receiverOpts{handler: handler})
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, signedRequest(t, body, deliveryID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !bytes.Equal(gotDelivery.Payload, body) {
+		t.Errorf("payload = %q, want %q", gotDelivery.Payload, body)
+	}
+	if string(gotDelivery.DeliveryID) != deliveryID {
+		t.Errorf("deliveryID = %q, want %q", gotDelivery.DeliveryID, deliveryID)
+	}
+	if string(gotDelivery.SourceID) != testSourceID {
+		t.Errorf("sourceID = %q, want %q", gotDelivery.SourceID, testSourceID)
+	}
+}

--- a/runtime/webhook/receiver_test.go
+++ b/runtime/webhook/receiver_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -161,14 +162,18 @@ func (nopReceipt) Commit(_ context.Context) error                  { return nil 
 func (nopReceipt) Release(_ context.Context) error                 { return nil }
 func (nopReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
 
-// countingReceipt records how many times Release was called, used by the
-// handler-panic test to assert the lease is released before re-panic.
+// countingReceipt records Commit and Release call counts.
+// commitErr, if non-nil, is returned by Commit to test best-effort commit failure.
+// releaseErr, if non-nil, is returned by Release.
 type countingReceipt struct {
-	released int
+	committed  int
+	released   int
+	commitErr  error
+	releaseErr error
 }
 
-func (r *countingReceipt) Commit(_ context.Context) error                  { return nil }
-func (r *countingReceipt) Release(_ context.Context) error                 { r.released++; return nil }
+func (r *countingReceipt) Commit(_ context.Context) error                  { r.committed++; return r.commitErr }
+func (r *countingReceipt) Release(_ context.Context) error                 { r.released++; return r.releaseErr }
 func (r *countingReceipt) Extend(_ context.Context, _ time.Duration) error { return nil }
 
 // countingClaimer always returns ClaimAcquired with a shared countingReceipt.
@@ -553,8 +558,104 @@ func TestReceiver_HandlerPanic_ReleasesLeaseAndRepanics(t *testing.T) {
 		t.Errorf("Release called %d times, want 1", rcpt.released)
 	}
 
+	// Commit must NOT have been called: handler panicked before success.
+	if rcpt.committed != 0 {
+		t.Errorf("Commit called %d times, want 0 (no commit on handler panic)", rcpt.committed)
+	}
+
 	// The panic must have re-propagated (recovered is non-nil).
 	if recovered == nil {
 		t.Error("expected panic to re-propagate, but recover() returned nil")
+	}
+}
+
+// TestReceiver_CommitFailure_Still200 verifies that a Commit failure after a
+// successful handler invocation does not change the HTTP 200 response. Commit
+// is best-effort: the business operation succeeded; only the idempotency
+// record write failed, so the caller still receives 200 Accepted.
+func TestReceiver_CommitFailure_Still200(t *testing.T) {
+	// Not parallel: uses a shared mutable countingReceipt.
+	body := []byte(`{"event":"commit-fail-test"}`)
+	rcpt := &countingReceipt{commitErr: errors.New("commit boom")}
+	claimer := &countingClaimer{rcpt: rcpt}
+
+	recv := buildReceiver(t, receiverOpts{claimer: claimer})
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, signedRequest(t, body, "msg-commit-fail-001"))
+
+	// Handler succeeded → 200 even though Commit returned an error.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	// Commit was attempted exactly once.
+	if rcpt.committed != 1 {
+		t.Errorf("Commit called %d times, want 1", rcpt.committed)
+	}
+	// Release must NOT have been called: handler succeeded.
+	if rcpt.released != 0 {
+		t.Errorf("Release called %d times, want 0 (successful handler does not release)", rcpt.released)
+	}
+}
+
+// errReader is a minimal io.Reader that always returns a non-MaxBytesError on
+// Read, used to simulate a network/IO error during body reading.
+type errReader struct{ err error }
+
+func (e errReader) Read(_ []byte) (int, error) { return 0, e.err }
+
+// TestReceiver_ReadBodyIOError_Returns503 verifies that an IO error during body
+// reading (that is not a MaxBytesError) is mapped to HTTP 503 Service
+// Unavailable. The handler must not be invoked in this case.
+func TestReceiver_ReadBodyIOError_Returns503(t *testing.T) {
+	t.Parallel()
+
+	spec := testSpec()
+	// Ensure ContentLength is below MaxBodyBytes so the pre-check does not
+	// fire a 413 before the reader is even installed.
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	if err != nil {
+		t.Fatalf("NewHMACVerifier: %v", err)
+	}
+	claimer := idempotency.NewInMemClaimer(clk)
+	handlerCalled := false
+	handler := func(_ context.Context, _ kwh.Delivery) error {
+		handlerCalled = true
+		return nil
+	}
+	recv, err := rtwh.NewReceiver(clk, spec, verifier, store, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+
+	ioErr := errors.New("network read error")
+	req := httptest.NewRequest(http.MethodPost, testPathPattern, nil)
+	// Replace the body with a reader that always fails; set ContentLength to a
+	// small positive value so the Content-Length pre-check passes.
+	req.Body = io.NopCloser(errReader{err: ioErr})
+	req.ContentLength = 5 // below MaxBodyBytes; pre-check passes
+
+	// Set required signature headers so the error is not caused by header parsing.
+	req.Header.Set("X-Delivery-Id", "msg-ioerr-001")
+	req.Header.Set("X-Timestamp", "1705312800")
+	req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+	}
+	if handlerCalled {
+		t.Error("handler must not be invoked when body read fails")
+	}
+	// Verify the error envelope contains the error field.
+	var envelope map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if _, ok := envelope["error"]; !ok {
+		t.Errorf("response missing 'error' key; got: %s", w.Body.String())
 	}
 }

--- a/runtime/webhook/receiver_test.go
+++ b/runtime/webhook/receiver_test.go
@@ -659,3 +659,127 @@ func TestReceiver_ReadBodyIOError_Returns503(t *testing.T) {
 		t.Errorf("response missing 'error' key; got: %s", w.Body.String())
 	}
 }
+
+// TestNewReceiver_InvalidSpec covers the spec.Validate() failure branch in
+// NewReceiver (a zero-value spec fails validation before any dependency check).
+func TestNewReceiver_InvalidSpec(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, _ := kwh.NewHMACVerifier(clk)
+	claimer := idempotency.NewInMemClaimer(clk)
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+
+	_, err := rtwh.NewReceiver(clk, kwh.ReceiverSpec{}, verifier, store, claimer, handler)
+	if err == nil {
+		t.Fatal("expected error for invalid (zero-value) spec")
+	}
+}
+
+// TestReceiver_HandlerError_ReleaseError covers the branch where the handler
+// returns an error AND the subsequent Release also fails (the release-error is
+// logged, the handler error still drives the HTTP status).
+func TestReceiver_HandlerError_ReleaseError(t *testing.T) {
+	// Not parallel: uses a shared mutable countingReceipt.
+	body := []byte(`{"event":"handler-err-release-err"}`)
+	rcpt := &countingReceipt{releaseErr: errors.New("release boom")}
+	claimer := &countingClaimer{rcpt: rcpt}
+	handler := func(_ context.Context, _ kwh.Delivery) error {
+		return errcode.New(errcode.KindUnavailable, errcode.ErrServiceUnavailable,
+			"handler transient failure")
+	}
+	recv := buildReceiver(t, receiverOpts{claimer: claimer, handler: handler})
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, signedRequest(t, body, "msg-handler-err-rel-001"))
+
+	// KindUnavailable handler error → 503.
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+	}
+	if rcpt.released != 1 {
+		t.Errorf("Release called %d times, want 1", rcpt.released)
+	}
+	if rcpt.committed != 0 {
+		t.Errorf("Commit called %d times, want 0 (handler failed)", rcpt.committed)
+	}
+}
+
+// TestReceiver_HandlerPanic_ReleaseError covers releaseOnPanic's branch where
+// Release itself returns an error during the panic-recovery path.
+func TestReceiver_HandlerPanic_ReleaseError(t *testing.T) {
+	// Not parallel: shared mutable countingReceipt + specific execution order.
+	body := []byte(`{"event":"panic-release-err"}`)
+	rcpt := &countingReceipt{releaseErr: errors.New("release boom")}
+	claimer := &countingClaimer{rcpt: rcpt}
+	handler := func(_ context.Context, _ kwh.Delivery) error {
+		panic("handler panic with failing release")
+	}
+	recv := buildReceiver(t, receiverOpts{claimer: claimer, handler: handler})
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		w := httptest.NewRecorder()
+		recv.ServeHTTP(w, signedRequest(t, body, "msg-panic-rel-err-001"))
+	}()
+
+	if rcpt.released != 1 {
+		t.Errorf("Release called %d times, want 1", rcpt.released)
+	}
+	if recovered == nil {
+		t.Error("expected panic to re-propagate even when Release fails")
+	}
+}
+
+// TestReceiver_MaxBytesReaderTruncation_Returns413 covers the MaxBytesReader
+// (read-time) 413 branch — distinct from the Content-Length pre-check. With an
+// unknown Content-Length (-1) the pre-check is skipped and MaxBytesReader is the
+// only enforcer.
+func TestReceiver_MaxBytesReaderTruncation_Returns413(t *testing.T) {
+	t.Parallel()
+	spec := testSpec()
+	spec.MaxBodyBytes = 10
+
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	if err != nil {
+		t.Fatalf("NewHMACVerifier: %v", err)
+	}
+	claimer := idempotency.NewInMemClaimer(clk)
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+	recv, err := rtwh.NewReceiver(clk, spec, verifier, store, claimer, handler)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+
+	bigBody := bytes.Repeat([]byte("x"), 100)
+	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(bigBody))
+	req.Header.Set("X-Delivery-Id", "msg-maxbytes-001")
+	req.Header.Set("X-Timestamp", "1705312800")
+	req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	// Unknown Content-Length → pre-check skipped; MaxBytesReader enforces the cap.
+	req.ContentLength = -1
+
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestReceiver_InvalidDeliveryIDFormat_Returns400 covers verify()'s
+// NewDeliveryID error branch: a non-empty but malformed delivery-id header
+// (whitespace is forbidden by the delivery-id pattern) → 400.
+func TestReceiver_InvalidDeliveryIDFormat_Returns400(t *testing.T) {
+	t.Parallel()
+	recv := buildReceiver(t, receiverOpts{})
+	req := signedRequest(t, []byte(`{"e":1}`), "valid-id")
+	// Override with a non-empty value that fails the delivery-id pattern (space).
+	req.Header.Set("X-Delivery-Id", "bad id with spaces")
+	w := httptest.NewRecorder()
+	recv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}

--- a/runtime/webhook/registry.go
+++ b/runtime/webhook/registry.go
@@ -21,13 +21,14 @@ import (
 // verifier and [Receiver] for each request happens eagerly so configuration
 // errors are reported at startup rather than at request time.
 //
+// clk is the mandatory positional clock (CLOCK-POSITIONAL-INJECTION-01); it
+// is the first parameter per the GoCell clock-injection convention.
 // store and claimer are shared across all receivers; they must not be nil.
-// clk is the mandatory positional clock (CLOCK-POSITIONAL-INJECTION-01).
 func BuildRouteGroups(
+	clk clock.Clock,
 	reqs []cell.WebhookReceiverRequest,
 	store kwh.SourceStore,
 	claimer idempotency.Claimer,
-	clk clock.Clock,
 ) ([]cell.RouteGroup, error) {
 	clock.MustHaveClock(clk, "webhook.BuildRouteGroups")
 	if validation.IsNilInterface(store) {
@@ -41,7 +42,7 @@ func BuildRouteGroups(
 
 	groups := make([]cell.RouteGroup, 0, len(reqs))
 	for _, req := range reqs {
-		rg, err := buildRouteGroup(req, store, claimer, clk)
+		rg, err := buildRouteGroup(clk, req, store, claimer)
 		if err != nil {
 			return nil, fmt.Errorf("webhook BuildRouteGroups: contract %q: %w",
 				req.Spec.ContractID, err)
@@ -52,11 +53,17 @@ func BuildRouteGroups(
 }
 
 // buildRouteGroup builds a single RouteGroup from one WebhookReceiverRequest.
+//
+// clk is the first parameter per CLOCK-POSITIONAL-INJECTION-01.
+// Prefix carries the full PathPattern for cell ownership attribution in the
+// HTTP metrics cell label. Register mounts at "/" so that the bootstrap adapter
+// composes joinPrefix(Prefix, "/") = Prefix — avoiding a double-prefix when
+// the adapter walks RouteGroup.Prefix + the Mount argument.
 func buildRouteGroup(
+	clk clock.Clock,
 	req cell.WebhookReceiverRequest,
 	store kwh.SourceStore,
 	claimer idempotency.Claimer,
-	clk clock.Clock,
 ) (cell.RouteGroup, error) {
 	tolerance := time.Duration(req.Spec.ToleranceSeconds) * time.Second
 	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(tolerance))

--- a/runtime/webhook/registry.go
+++ b/runtime/webhook/registry.go
@@ -1,0 +1,89 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// BuildRouteGroups converts a slice of [cell.WebhookReceiverRequest] values
+// (accumulated by the cell registry during Init) into [cell.RouteGroup] values
+// ready for bootstrap to mount onto the HTTP server.
+//
+// Each request produces exactly one RouteGroup. Construction of the HMAC
+// verifier and [Receiver] for each request happens eagerly so configuration
+// errors are reported at startup rather than at request time.
+//
+// store and claimer are shared across all receivers; they must not be nil.
+// clk is the mandatory positional clock (CLOCK-POSITIONAL-INJECTION-01).
+func BuildRouteGroups(
+	reqs []cell.WebhookReceiverRequest,
+	store kwh.SourceStore,
+	claimer idempotency.Claimer,
+	clk clock.Clock,
+) ([]cell.RouteGroup, error) {
+	clock.MustHaveClock(clk, "webhook.BuildRouteGroups")
+	if validation.IsNilInterface(store) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook BuildRouteGroups: store must not be nil")
+	}
+	if validation.IsNilInterface(claimer) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook BuildRouteGroups: claimer must not be nil")
+	}
+
+	groups := make([]cell.RouteGroup, 0, len(reqs))
+	for _, req := range reqs {
+		rg, err := buildRouteGroup(req, store, claimer, clk)
+		if err != nil {
+			return nil, fmt.Errorf("webhook BuildRouteGroups: contract %q: %w",
+				req.Spec.ContractID, err)
+		}
+		groups = append(groups, rg)
+	}
+	return groups, nil
+}
+
+// buildRouteGroup builds a single RouteGroup from one WebhookReceiverRequest.
+func buildRouteGroup(
+	req cell.WebhookReceiverRequest,
+	store kwh.SourceStore,
+	claimer idempotency.Claimer,
+	clk clock.Clock,
+) (cell.RouteGroup, error) {
+	tolerance := time.Duration(req.Spec.ToleranceSeconds) * time.Second
+	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(tolerance))
+	if err != nil {
+		return cell.RouteGroup{}, fmt.Errorf("build verifier: %w", err)
+	}
+
+	recv, err := NewReceiver(clk, req.Spec, verifier, store, claimer, req.Handler)
+	if err != nil {
+		return cell.RouteGroup{}, fmt.Errorf("build receiver: %w", err)
+	}
+
+	// Capture recv for the closure (loop variable capture is safe in Go 1.22+
+	// but we capture explicitly for clarity).
+	handler := http.Handler(recv)
+	pattern := req.Spec.PathPattern
+
+	// Prefix carries the full path pattern for cell ownership attribution.
+	// Register mounts at "/" so the adapter composes
+	// joinPrefix(Prefix, "/") = Prefix — no double-prefix.
+	return cell.RouteGroup{
+		Listener: cell.PrimaryListener,
+		Prefix:   pattern,
+		CellID:   req.Spec.CellID,
+		Register: func(mux cell.RouteMux) error {
+			mux.Mount("/", handler)
+			return nil
+		},
+	}, nil
+}

--- a/runtime/webhook/registry_test.go
+++ b/runtime/webhook/registry_test.go
@@ -21,6 +21,7 @@ func validReceiverRequest(t *testing.T) cell.WebhookReceiverRequest {
 }
 
 func TestBuildRouteGroups_HappyPath(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
@@ -29,7 +30,7 @@ func TestBuildRouteGroups_HappyPath(t *testing.T) {
 		validReceiverRequest(t),
 	}
 
-	groups, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -58,6 +59,7 @@ func TestBuildRouteGroups_HappyPath(t *testing.T) {
 }
 
 func TestBuildRouteGroups_MultipleRequests(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
@@ -75,7 +77,7 @@ func TestBuildRouteGroups_MultipleRequests(t *testing.T) {
 		},
 	}
 
-	groups, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -85,11 +87,12 @@ func TestBuildRouteGroups_MultipleRequests(t *testing.T) {
 }
 
 func TestBuildRouteGroups_EmptyReqs(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
 
-	groups, err := rtwh.BuildRouteGroups(nil, store, claimer, clk)
+	groups, err := rtwh.BuildRouteGroups(clk, nil, store, claimer)
 	if err != nil {
 		t.Fatalf("BuildRouteGroups(nil): %v", err)
 	}
@@ -99,26 +102,29 @@ func TestBuildRouteGroups_EmptyReqs(t *testing.T) {
 }
 
 func TestBuildRouteGroups_NilStore(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	claimer := idempotency.NewInMemClaimer(clk)
 
-	_, err := rtwh.BuildRouteGroups(nil, nil, claimer, clk)
+	_, err := rtwh.BuildRouteGroups(clk, nil, nil, claimer)
 	if err == nil {
 		t.Fatal("expected error for nil store")
 	}
 }
 
 func TestBuildRouteGroups_NilClaimer(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 
-	_, err := rtwh.BuildRouteGroups(nil, store, nil, clk)
+	_, err := rtwh.BuildRouteGroups(clk, nil, store, nil)
 	if err == nil {
 		t.Fatal("expected error for nil claimer")
 	}
 }
 
 func TestBuildRouteGroups_InvalidSpec(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
@@ -131,18 +137,19 @@ func TestBuildRouteGroups_InvalidSpec(t *testing.T) {
 		},
 	}
 
-	_, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
 	if err == nil {
 		t.Fatal("expected error for invalid spec")
 	}
 }
 
 func TestBuildRouteGroups_Register_IsMountCall(t *testing.T) {
+	t.Parallel()
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
 
-	groups, err := rtwh.BuildRouteGroups([]cell.WebhookReceiverRequest{validReceiverRequest(t)}, store, claimer, clk)
+	groups, err := rtwh.BuildRouteGroups(clk, []cell.WebhookReceiverRequest{validReceiverRequest(t)}, store, claimer)
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}

--- a/runtime/webhook/registry_test.go
+++ b/runtime/webhook/registry_test.go
@@ -188,3 +188,30 @@ func (m *recordingMux) Group(fn func(cell.RouteMux)) { fn(m) }
 func (m *recordingMux) With(_ ...func(http.Handler) http.Handler) cell.RouteMux {
 	return m
 }
+
+// TestBuildRouteGroups_NewReceiverError covers buildRouteGroup's branch where
+// NewHMACVerifier succeeds (ToleranceSeconds > 0) but NewReceiver fails because
+// the spec is otherwise invalid (empty ContractID). This exercises the
+// post-verifier NewReceiver error return that an all-zero spec does not reach
+// (an all-zero spec fails earlier at WithTolerance(0)).
+func TestBuildRouteGroups_NewReceiverError(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	spec := testSpec()
+	spec.ContractID = "" // tolerance stays valid → verifier OK → NewReceiver.Validate fails
+
+	reqs := []cell.WebhookReceiverRequest{
+		{
+			Spec:    spec,
+			Handler: func(_ context.Context, _ kwh.Delivery) error { return nil },
+		},
+	}
+
+	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	if err == nil {
+		t.Fatal("expected error from NewReceiver inside buildRouteGroup")
+	}
+}

--- a/runtime/webhook/registry_test.go
+++ b/runtime/webhook/registry_test.go
@@ -1,0 +1,183 @@
+package webhook_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	rtwh "github.com/ghbvf/gocell/runtime/webhook"
+)
+
+func validReceiverRequest(t *testing.T) cell.WebhookReceiverRequest {
+	t.Helper()
+	return cell.WebhookReceiverRequest{
+		Spec:    testSpec(),
+		Handler: func(_ context.Context, _ kwh.Delivery) error { return nil },
+	}
+}
+
+func TestBuildRouteGroups_HappyPath(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	reqs := []cell.WebhookReceiverRequest{
+		validReceiverRequest(t),
+	}
+
+	groups, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+
+	g := groups[0]
+
+	// Listener must be PrimaryListener.
+	if g.Listener != cell.PrimaryListener {
+		t.Errorf("Listener = %v, want PrimaryListener", g.Listener)
+	}
+	// Prefix must match PathPattern.
+	if g.Prefix != testPathPattern {
+		t.Errorf("Prefix = %q, want %q", g.Prefix, testPathPattern)
+	}
+	// CellID must match spec.CellID.
+	if g.CellID != testCellID {
+		t.Errorf("CellID = %q, want %q", g.CellID, testCellID)
+	}
+	// Register must not be nil.
+	if g.Register == nil {
+		t.Error("Register is nil")
+	}
+}
+
+func TestBuildRouteGroups_MultipleRequests(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	spec2 := testSpec()
+	spec2.ContractID = "webhook.test2.v1"
+	spec2.PathPattern = "/webhooks/test2"
+	spec2.CellID = "testcell2"
+
+	reqs := []cell.WebhookReceiverRequest{
+		validReceiverRequest(t),
+		{
+			Spec:    spec2,
+			Handler: func(_ context.Context, _ kwh.Delivery) error { return nil },
+		},
+	}
+
+	groups, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(groups))
+	}
+}
+
+func TestBuildRouteGroups_EmptyReqs(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	groups, err := rtwh.BuildRouteGroups(nil, store, claimer, clk)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups(nil): %v", err)
+	}
+	if len(groups) != 0 {
+		t.Fatalf("got %d groups, want 0", len(groups))
+	}
+}
+
+func TestBuildRouteGroups_NilStore(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	_, err := rtwh.BuildRouteGroups(nil, nil, claimer, clk)
+	if err == nil {
+		t.Fatal("expected error for nil store")
+	}
+}
+
+func TestBuildRouteGroups_NilClaimer(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+
+	_, err := rtwh.BuildRouteGroups(nil, store, nil, clk)
+	if err == nil {
+		t.Fatal("expected error for nil claimer")
+	}
+}
+
+func TestBuildRouteGroups_InvalidSpec(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	// Zero-value spec should fail Validate().
+	reqs := []cell.WebhookReceiverRequest{
+		{
+			Spec:    kwh.ReceiverSpec{},
+			Handler: func(_ context.Context, _ kwh.Delivery) error { return nil },
+		},
+	}
+
+	_, err := rtwh.BuildRouteGroups(reqs, store, claimer, clk)
+	if err == nil {
+		t.Fatal("expected error for invalid spec")
+	}
+}
+
+func TestBuildRouteGroups_Register_IsMountCall(t *testing.T) {
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	groups, err := rtwh.BuildRouteGroups([]cell.WebhookReceiverRequest{validReceiverRequest(t)}, store, claimer, clk)
+	if err != nil {
+		t.Fatalf("BuildRouteGroups: %v", err)
+	}
+
+	// Register mounts at "/" so that the adapter composes
+	// joinPrefix(Prefix, "/") == Prefix — no double-prefix.
+	// Prefix (RouteGroup.Prefix) carries the full path pattern.
+	var mountPattern string
+	mux := &recordingMux{onMount: func(p string) { mountPattern = p }}
+	if err := groups[0].Register(mux); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	const wantMountArg = "/"
+	if mountPattern != wantMountArg {
+		t.Errorf("mounted pattern = %q, want %q (Prefix carries the full path; Register uses '/' to avoid double-prefix)",
+			mountPattern, wantMountArg)
+	}
+}
+
+// recordingMux is a minimal RouteMux stub for testing Register callbacks.
+type recordingMux struct {
+	onMount func(string)
+}
+
+func (m *recordingMux) Handle(_ string, _ http.Handler) {}
+func (m *recordingMux) Route(_ string, fn func(cell.RouteMux)) {
+	fn(m)
+}
+
+func (m *recordingMux) Mount(pattern string, _ http.Handler) {
+	if m.onMount != nil {
+		m.onMount(pattern)
+	}
+}
+func (m *recordingMux) Group(fn func(cell.RouteMux)) { fn(m) }
+func (m *recordingMux) With(_ ...func(http.Handler) http.Handler) cell.RouteMux {
+	return m
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -109,6 +109,18 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 # coverage-feeding run. Excluded at package level — the package is pure test-helper,
 # no sibling production code.
 #
+# kernel/webhook/webhooktest/ is the sign↔verify conformance suite
+# (RunSignerVerifierConformance + VerifierFactory) for webhook.Signer/Verifier
+# implementations. Same conformance-suite exclusion pattern as kernel/outbox/
+# outboxtest/** above: the suite is invoked only from OTHER packages' tests
+# (kernel/webhook/conformance_test.go, external webhook_test package; future
+# Signer/Verifier implementations add sibling calls), so its line hits attribute
+# to the caller package, not back to conformance.go. Per-shard CI runs go test
+# without -coverpkg=./..., and the kernel coverage gate in
+# .github/workflows/_build-lint.yml already skips it via the `/[a-z0-9_]+test$`
+# helper-package regex; mirror that here for SonarCloud new-code honesty. Excluded
+# at package level — the package is pure test-helper, no sibling production code.
+#
 # Cross-platform stubs and Windows-only code are excluded from Sonar coverage:
 # - *_windows.go files compile only on Windows, where the os-smoke matrix runs
 #   them but does not feed coverage into Sonar (Linux is the Sonar baseline).
@@ -142,6 +154,7 @@ sonar.coverage.exclusions=\
   **/kernel/persistence/persistencetest/**,\
   **/kernel/projection/projectiontest/**,\
   **/kernel/saga/sagajournaltest/**,\
+  **/kernel/webhook/webhooktest/**,\
   **/examples/**,\
   **/cells/accesscore/initialadmin/credfile_security_windows.go,\
   **/cells/accesscore/initialadmin/path_default_windows.go,\

--- a/tools/archtest/testdata/webhook_pipeline_violate/go.mod
+++ b/tools/archtest/testdata/webhook_pipeline_violate/go.mod
@@ -1,0 +1,3 @@
+module fixturetest/webhook_pipeline_violate
+
+go 1.25.10

--- a/tools/archtest/testdata/webhook_pipeline_violate/violations.go
+++ b/tools/archtest/testdata/webhook_pipeline_violate/violations.go
@@ -1,0 +1,70 @@
+// Package webhook_pipeline_violate is a synthetic violation fixture for the
+// WEBHOOK-RECEIVER-PIPELINE-01 archtest rule. Each violation form is exercised
+// once so TestWebhookReceiverPipeline_ReverseFixture can assert that A1 (token
+// sealed-construction) and A2 (handler callsite allowlist) fire on each form.
+//
+// DO NOT use this package in production code.
+package webhook_pipeline_violate
+
+import "context"
+
+// ── token type stubs (mirrors runtime/webhook unexported types) ──────────────
+// These mirror the production verified/claimed types; the scanner checks the
+// enclosing-function allowlist against the same struct names.
+
+type delivery struct{ id string }
+type receipt interface{ Commit(context.Context) error }
+
+// verified mirrors runtime/webhook.verified — produced only by verify().
+type verified struct{ d delivery }
+
+// claimed mirrors runtime/webhook.claimed — produced only by claim().
+type claimed struct {
+	d    delivery
+	rcpt receipt
+}
+
+type handler func(context.Context, delivery) error
+
+type Receiver struct {
+	handler handler
+}
+
+// ── legitimate construction sites (A1 must NOT fire here) ──────────────────
+
+func (r *Receiver) verify(_ []byte) (verified, error) {
+	// Legitimate: enclosing func IS "verify"
+	return verified{d: delivery{id: "ok"}}, nil
+}
+
+func (r *Receiver) claim(_ context.Context, v verified) (claimed, error) {
+	// Legitimate: enclosing func IS "claim"
+	return claimed{d: v.d, rcpt: nil}, nil
+}
+
+func (r *Receiver) invokeHandler(ctx context.Context, c claimed) error {
+	// Legitimate: enclosing func IS "invokeHandler"
+	return r.handler(ctx, c.d)
+}
+
+// ── A1 VIOLATIONS: verified/claimed constructed outside allowed functions ────
+
+// forgeBadVerified constructs verified{} outside of the verify function.
+// VIOLATION A1 (verified{} outside "verify")
+func forgeBadVerified() verified {
+	return verified{d: delivery{id: "forged"}} // VIOLATION A1 — wrong enclosing func
+}
+
+// forgeBadClaimed constructs claimed{} outside of the claim function.
+// VIOLATION A1 (claimed{} outside "claim")
+func forgeBadClaimed() claimed {
+	return claimed{d: delivery{id: "forged"}, rcpt: nil} // VIOLATION A1 — wrong enclosing func
+}
+
+// ── A2 VIOLATION: r.handler called outside invokeHandler ─────────────────────
+
+// callHandlerDirectly calls r.handler outside of invokeHandler.
+// VIOLATION A2 (r.handler called outside "invokeHandler")
+func (r *Receiver) callHandlerDirectly(ctx context.Context, d delivery) error {
+	return r.handler(ctx, d) // VIOLATION A2 — wrong enclosing func
+}

--- a/tools/archtest/webhook_receiver_pipeline_test.go
+++ b/tools/archtest/webhook_receiver_pipeline_test.go
@@ -1,0 +1,351 @@
+// INVARIANT: WEBHOOK-RECEIVER-PIPELINE-01
+//
+// WEBHOOK-RECEIVER-PIPELINE-01 — runtime/webhook receive-pipeline token
+// sealed-construction + handler callsite allowlist (KERNEL-WEBHOOK-01 PR-3).
+//
+// # AI-robust rating
+//
+// Both A1 and A2 are downstream Hard (callsite allowlist + types.Info form
+// uniqueness). Upstream is Medium — Go's package visibility guarantees that
+// package-external code cannot construct or reference the unexported verified /
+// claimed structs or the unexported handler field, but inside the package Go
+// cannot compile-time forbid a new function from constructing those types.
+// This Medium upstream ceiling is the permanent Go-language limit, the same
+// shape as OUTBOX-ENTRY-SEALED-CONSTRUCTION-01 (tracked in gh #1282, won't-do)
+// and SPAN-SETATTR-HOLDER-SEAL-01 (#851). The external axis is Hard by the
+// type system (unexported struct → package-external construction is a compile
+// error); the internal axis is Medium archtest. Both axes are documented here
+// as the authoritative source (ai-robust.md §"落地实例与符号清单活在代码 godoc").
+//
+// # Sub-rules
+//
+//   - A1 (downstream Hard, sealed construction): every composite literal of
+//     type runtime/webhook.verified must be in an enclosing function named
+//     "verify"; every composite literal of type runtime/webhook.claimed must be
+//     in an enclosing function named "claim". types.Info.TypeOf(cl.Type) resolves
+//     the composite literal's declared type to *types.Named; obj.Pkg().Path() and
+//     obj.Name() provide exact package-path + type-name identity, defeating any
+//     import alias or type alias re-shape. Only production files are scanned
+//     (_test.go excluded), so white-box test helpers in package webhook are not
+//     incorrectly flagged.
+//
+//   - A2 (downstream Hard, handler callsite): every call expression of the form
+//     `r.handler(...)` where the SelectorExpr resolves via types.Info.Selections
+//     to a FieldVal selection of the "handler" field on *Receiver must occur in
+//     an enclosing function named "invokeHandler". A new function that calls
+//     r.handler directly without going through invokeHandler is flagged.
+//
+//   - A3 (blind-spot reverse self-check): a synthetic fixture module
+//     (testdata/webhook_pipeline_violate/) defines its own verified / claimed /
+//     Receiver types with identical names and produces both A1 and A2 violations.
+//     TestWebhookReceiverPipeline_ReverseFixture asserts each check fires, proving
+//     the scanner does not vacuously pass.
+//
+// # Blind spots (ai-robust mandatory reverse self-check)
+//
+// B1 — reflect-based construction: `reflect.New(reflect.TypeOf(verified{}))` can
+// create a zero verified value at runtime without a composite literal. This
+// blind spot is structural (AST scan cannot see reflect call intent); bounded
+// response: reflect.New produces a zero-value token that the handler chain would
+// reject at claim-stage (Claimer.Claim would fail on an empty delivery ID), so
+// the security impact is limited to a nil-delivery invoke, not bypass of HMAC
+// verify. No reverse self-test added because the reflect path is untypeable at
+// AST level with the current tooling.
+//
+// B2 — handler stored in a local variable before call: `h := r.handler; h(ctx, d)`
+// extracts the handler field into a local, then calls the variable. The A2 scan
+// detects only direct `r.handler(...)` SelectorExpr call expressions in call
+// position; a local variable capture breaks the SelectorExpr form. Bounded
+// response: the local-var form requires two statements and is visually distinct;
+// any future function that does this will be caught in code review, and the
+// existing invokeHandler is the only caller today (locked by A2 on the
+// SelectorExpr form). A3 does not exercise this form because the fixture would
+// need to also detect the AssignStmt + CallExpr combo, which is a separate rule.
+//
+// B3 — alias type re-shape: if verified or claimed were re-exported under an
+// alias in another package inside runtime/webhook (impossible today because the
+// package has no subdirectories), a composite literal of the alias type would
+// resolve to a different *types.Named with the alias package path and name, not
+// matching the allowlist. Bounded response: runtime/webhook has no
+// subdirectories; layout enforced by repository structure (LAYER-07).
+//
+// B4 — handler passed as function value then called: `fn := r.handler` followed
+// by `fn(ctx, d)` in another package — impossible because handler is unexported;
+// package-external callers cannot form the SelectorExpr `r.handler` at all
+// (compile error). This vector is therefore Hard-closed by the type system even
+// though B2 exists for the within-package form.
+//
+// ref: runtime/webhook/receiver.go (production pipeline)
+// ref: tools/archtest/webhook_hmac_funnel_test.go (callsite-allowlist template)
+// ref: gh #1282 (OUTBOX-ENTRY-SEALED upstream Medium permanent ceiling)
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	runtimeWebhookPkgPath = PlatformModulePath + "/runtime/webhook"
+	runtimeWebhookPattern = "./runtime/webhook/..."
+
+	// allowedVerifiedConstructor is the only function in runtime/webhook
+	// that may construct a verified{} composite literal.
+	allowedVerifiedConstructor = "verify"
+	// allowedClaimedConstructor is the only function in runtime/webhook
+	// that may construct a claimed{} composite literal.
+	allowedClaimedConstructor = "claim"
+	// allowedHandlerCaller is the only function in runtime/webhook
+	// that may call the r.handler field.
+	allowedHandlerCaller = "invokeHandler"
+
+	// token type names in runtime/webhook — must match receiver.go exactly.
+	verifiedTypeName = "verified"
+	claimedTypeName  = "claimed"
+
+	// receiverHandlerField is the field name on *Receiver that holds the handler.
+	receiverHandlerField = "handler"
+	// webhookReceiverStructName is the Receiver struct name in runtime/webhook.
+	webhookReceiverStructName = "Receiver"
+)
+
+// scanWebhookTokenConstruction implements A1: composite literals of type
+// verified / claimed may only appear in the enclosing functions "verify" /
+// "claim" respectively.
+//
+// Detection: EachInSubtree[ast.CompositeLit] walks every composite literal.
+// For each one, info.TypeOf(cl.Type) resolves the declared type (handles bare
+// Ident "verified{}" and qualified "webhook.verified{}" shapes alike). The
+// resulting *types.Named is checked against (pkgPath, typeName). The enclosing
+// function is resolved with ResolveEnclosingFunc; if the function name is not
+// in the per-type allowlist, a diagnostic is emitted.
+//
+// pkgPath is the Go package import path of the package being scanned. In
+// production it is runtimeWebhookPkgPath; in the A3 reverse fixture it is the
+// fixture package path. This parameterisation allows the same scanner to serve
+// both contexts.
+func scanWebhookTokenConstruction(fset *token.FileSet, file *ast.File, rel string, info *types.Info, pkgPath string) []Diagnostic {
+	var out []Diagnostic
+
+	// allowedConstructors maps type name → the single function name that may
+	// construct a composite literal of that type.
+	allowedConstructors := map[string]string{
+		verifiedTypeName: allowedVerifiedConstructor,
+		claimedTypeName:  allowedClaimedConstructor,
+	}
+
+	EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
+		if cl.Type == nil {
+			// Implicit-type composite literals (e.g., array element shorthand)
+			// cannot be verified/claimed because those types have no exported
+			// constructors and no parent composite that could infer them.
+			return
+		}
+		t := info.TypeOf(cl.Type)
+		if t == nil {
+			return
+		}
+		named, ok := t.(*types.Named)
+		if !ok {
+			return
+		}
+		obj := named.Obj()
+		if obj == nil || obj.Pkg() == nil {
+			return
+		}
+		if obj.Pkg().Path() != pkgPath {
+			return
+		}
+		allowedFunc, isToken := allowedConstructors[obj.Name()]
+		if !isToken {
+			return
+		}
+		// This is a verified{} or claimed{} composite literal. Verify it is
+		// inside the single allowed enclosing function.
+		fn, ok := ResolveEnclosingFunc(info, file, cl)
+		if !ok || fn == nil {
+			out = append(out, Diagnostic{
+				Rel:  rel,
+				Line: fset.Position(cl.Pos()).Line,
+				Message: obj.Name() + "{} constructed outside any function in " + pkgPath +
+					"; must be inside " + allowedFunc + " (WEBHOOK-RECEIVER-PIPELINE-01/A1)",
+			})
+			return
+		}
+		if fn.Name() != allowedFunc {
+			out = append(out, Diagnostic{
+				Rel:  rel,
+				Line: fset.Position(cl.Pos()).Line,
+				Message: obj.Name() + "{} constructed in " + fn.Name() + " in " + pkgPath +
+					"; only " + allowedFunc + " may construct " + obj.Name() +
+					" (WEBHOOK-RECEIVER-PIPELINE-01/A1)",
+			})
+		}
+	})
+	return out
+}
+
+// scanWebhookHandlerCallsite implements A2: `r.handler(...)` (a field-value
+// call on *Receiver.handler) may only appear inside invokeHandler.
+//
+// Detection: EachInSubtree[ast.CallExpr] walks every call expression. For each
+// call whose Fun is a *ast.SelectorExpr with selector name == "handler",
+// info.Selections[sel] is consulted. A FieldVal selection whose Obj().Name()
+// == "handler" and whose Recv() (the receiver type of the selection) is
+// *Receiver (the pointer-to-named whose obj.Pkg().Path() == pkgPath and
+// obj.Name() == "Receiver") confirms this is the target field. The enclosing
+// function must be "invokeHandler".
+//
+// pkgPath is parameterised for the same reason as scanWebhookTokenConstruction.
+func scanWebhookHandlerCallsite(fset *token.FileSet, file *ast.File, rel string, info *types.Info, pkgPath string) []Diagnostic {
+	var out []Diagnostic
+
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		if sel.Sel.Name != receiverHandlerField {
+			return
+		}
+		// Confirm this is a FieldVal selection of *Receiver.handler in pkgPath.
+		selection, ok := info.Selections[sel]
+		if !ok {
+			// Not a selection (e.g., a package-level function named "handler").
+			return
+		}
+		if selection.Kind() != types.FieldVal {
+			// Method, not field — not our target.
+			return
+		}
+		// Check that the selected field belongs to pkgPath.Receiver.
+		// selection.Recv() is the type of the receiver (the base type, possibly pointer).
+		recv := selection.Recv()
+		// Unwrap pointer.
+		if ptr, ok := recv.(*types.Pointer); ok {
+			recv = ptr.Elem()
+		}
+		named, ok := recv.(*types.Named)
+		if !ok {
+			return
+		}
+		obj := named.Obj()
+		if obj == nil || obj.Pkg() == nil {
+			return
+		}
+		if obj.Pkg().Path() != pkgPath || obj.Name() != webhookReceiverStructName {
+			return
+		}
+		// This is genuinely *Receiver.handler in pkgPath. Check enclosing func.
+		fn, ok := ResolveEnclosingFunc(info, file, call)
+		if !ok || fn == nil {
+			out = append(out, Diagnostic{
+				Rel:  rel,
+				Line: fset.Position(call.Pos()).Line,
+				Message: "r.handler called outside any function in " + pkgPath +
+					"; must be inside invokeHandler (WEBHOOK-RECEIVER-PIPELINE-01/A2)",
+			})
+			return
+		}
+		if fn.Name() != allowedHandlerCaller {
+			out = append(out, Diagnostic{
+				Rel:  rel,
+				Line: fset.Position(call.Pos()).Line,
+				Message: "r.handler called in " + fn.Name() + " in " + pkgPath +
+					"; only invokeHandler may call r.handler (WEBHOOK-RECEIVER-PIPELINE-01/A2)",
+			})
+		}
+	})
+	return out
+}
+
+// TestWebhookReceiverPipeline verifies the WEBHOOK-RECEIVER-PIPELINE-01
+// invariant against the production runtime/webhook package:
+//
+//   - A1: verified{}/claimed{} composite literals only in verify/claim.
+//   - A2: r.handler(...) calls only in invokeHandler.
+//
+// _test.go files are excluded so that white-box test helpers in package webhook
+// are not incorrectly flagged (token types are unexported; external test package
+// cannot reach them; internal _test.go helpers could legitimately construct
+// them for testing purposes).
+func TestWebhookReceiverPipeline(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var a1, a2 []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false}, []string{runtimeWebhookPattern},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != runtimeWebhookPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanWebhookTokenConstruction(p.Fset, f, rel, p.TypesInfo, runtimeWebhookPkgPath)...)
+				a2 = append(a2, scanWebhookHandlerCallsite(p.Fset, f, rel, p.TypesInfo, runtimeWebhookPkgPath)...)
+			}
+			return nil
+		})
+
+	Report(t, "WEBHOOK-RECEIVER-PIPELINE-01/A1", a1)
+	Report(t, "WEBHOOK-RECEIVER-PIPELINE-01/A2", a2)
+}
+
+// TestWebhookReceiverPipeline_ReverseFixture loads the synthetic violation
+// fixture and asserts A1 (token construction outside allowed functions) and A2
+// (handler call outside invokeHandler) fire — guards against the rule logic
+// silently regressing to a vacuous pass.
+//
+// The fixture (testdata/webhook_pipeline_violate/) is a standalone Go module
+// that defines its own verified / claimed / Receiver types with the same names
+// as the production runtime/webhook types, then violates the construction and
+// callsite rules. The scanner is parameterised with the fixture package path so
+// the types.Info resolution points at the fixture's named types.
+func TestWebhookReceiverPipeline_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_pipeline_violate")
+
+	const fixturePkgPath = "fixturetest/webhook_pipeline_violate"
+
+	var a1, a2 []Diagnostic
+	_ = RunTypedDir(t, fixtureDir, TypedOpts{Tests: false}, []string{"./..."},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanWebhookTokenConstruction(p.Fset, f, rel, p.TypesInfo, fixturePkgPath)...)
+				a2 = append(a2, scanWebhookHandlerCallsite(p.Fset, f, rel, p.TypesInfo, fixturePkgPath)...)
+			}
+			return nil
+		})
+
+	// A1: both verified{} (forgeBadVerified) and claimed{} (forgeBadClaimed)
+	// construction outside the allowed functions must fire.
+	assert.GreaterOrEqual(t, len(a1), 2,
+		"A1 reverse fixture: expected ≥2 diagnostics (verified{} outside verify + claimed{} outside claim)")
+	// A2: r.handler called in callHandlerDirectly (outside invokeHandler) must fire.
+	assert.GreaterOrEqual(t, len(a2), 1,
+		"A2 reverse fixture: expected ≥1 diagnostic (r.handler called outside invokeHandler)")
+}

--- a/tools/archtest/webhook_receiver_pipeline_test.go
+++ b/tools/archtest/webhook_receiver_pipeline_test.go
@@ -61,6 +61,10 @@
 // existing invokeHandler is the only caller today (locked by A2 on the
 // SelectorExpr form). A3 does not exercise this form because the fixture would
 // need to also detect the AssignStmt + CallExpr combo, which is a separate rule.
+// No reverse self-test added for B2 because the local-variable-capture form is
+// not expressible as an AST-level SelectorExpr with types.Info.Selections — the
+// same Go-language ceiling that makes package-internal upstream Hard-ization
+// impossible for this pattern (same precedent as gh #1282 won't-do and #851).
 //
 // B3 — alias type re-shape: if verified or claimed were re-exported under an
 // alias in another package inside runtime/webhook (impossible today because the
@@ -342,10 +346,13 @@ func TestWebhookReceiverPipeline_ReverseFixture(t *testing.T) {
 		})
 
 	// A1: both verified{} (forgeBadVerified) and claimed{} (forgeBadClaimed)
-	// construction outside the allowed functions must fire.
-	assert.GreaterOrEqual(t, len(a1), 2,
-		"A1 reverse fixture: expected ≥2 diagnostics (verified{} outside verify + claimed{} outside claim)")
-	// A2: r.handler called in callHandlerDirectly (outside invokeHandler) must fire.
-	assert.GreaterOrEqual(t, len(a2), 1,
-		"A2 reverse fixture: expected ≥1 diagnostic (r.handler called outside invokeHandler)")
+	// construction outside the allowed functions must fire — exactly 2 diagnostics
+	// matching the two known violation sites in the fixture.
+	assert.Equal(t, 2, len(a1),
+		"A1 reverse fixture: expected exactly 2 diagnostics (verified{} outside verify + claimed{} outside claim)")
+	// A2: r.handler called in callHandlerDirectly (outside invokeHandler) must fire —
+	// exactly 1 diagnostic matching the one known violation site in the fixture.
+	// Also asserts that the legitimate invokeHandler callsite does NOT produce a diagnostic.
+	assert.Equal(t, 1, len(a2),
+		"A2 reverse fixture: expected exactly 1 diagnostic (r.handler called outside invokeHandler)")
 }

--- a/tools/codegen/cellgen/builder.go
+++ b/tools/codegen/cellgen/builder.go
@@ -403,8 +403,10 @@ func resolveWebhookField(
 //
 // The cell struct field is resolved via fieldIndex.resolveSliceField.
 // HandlerExpr is rendered as `c.<fieldName>.<cu.Handler>`.
-//
-//nolint:dupl // symmetric to buildWebhookDispatchSpecFromCU; different role, fields, and return types
+// Runtime configuration fields (PathPattern, headers, ToleranceSeconds,
+// MaxBodyBytes) are baked from contract.yaml at code-generation time via
+// extractReceiverRuntimeConfig so the generated spec is single-source
+// and zero-IO at runtime.
 func buildWebhookReceiverSpecFromCU(
 	p *metadata.ProjectMeta,
 	cellID, sliceID string,
@@ -436,11 +438,100 @@ func buildWebhookReceiverSpecFromCU(
 	if err != nil {
 		return WebhookReceiverGenSpec{}, err
 	}
+	rc, err := extractReceiverRuntimeConfig(p, cellID, sliceID, cu.Contract)
+	if err != nil {
+		return WebhookReceiverGenSpec{}, err
+	}
 	return WebhookReceiverGenSpec{
-		ContractID:  cu.Contract,
-		SliceID:     sliceID,
-		SourceID:    cu.SourceID,
-		HandlerExpr: "c." + fieldName + "." + cu.Handler,
+		ContractID:       cu.Contract,
+		SliceID:          sliceID,
+		SourceID:         cu.SourceID,
+		HandlerExpr:      "c." + fieldName + "." + cu.Handler,
+		PathPattern:      rc.PathPattern,
+		DeliveryIDHeader: rc.DeliveryIDHeader,
+		TimestampHeader:  rc.TimestampHeader,
+		SignatureHeader:  rc.SignatureHeader,
+		ToleranceSeconds: rc.ToleranceSeconds,
+		MaxBodyBytes:     rc.MaxBodyBytes,
+	}, nil
+}
+
+// receiverRuntimeConfig holds the contract.yaml-derived runtime fields baked
+// into a WebhookReceiverGenSpec. Extracted into a named struct so that
+// extractReceiverRuntimeConfig stays below cognitive-complexity 15 and its
+// return type is self-documenting.
+type receiverRuntimeConfig struct {
+	PathPattern      string
+	DeliveryIDHeader string
+	TimestampHeader  string
+	SignatureHeader  string
+	ToleranceSeconds int64
+	MaxBodyBytes     int64
+}
+
+// extractReceiverRuntimeConfig reads contract.yaml's signature / endpoints.inbound
+// / payload sections for an inbound webhook contract and returns the runtime
+// configuration that cellgen bakes into webhook.ReceiverSpec literals.
+//
+// Fails fast (FMT-37 defense-in-depth) when the contract is missing required
+// sections or sub-fields, so a misconfigured contract.yaml produces a codegen
+// error rather than a zero-valued or silently broken spec.
+func extractReceiverRuntimeConfig(
+	p *metadata.ProjectMeta,
+	cellID, sliceID, contractID string,
+) (receiverRuntimeConfig, error) {
+	contract := p.Contracts[contractID] // already validated non-nil by resolveWebhookField
+	details := []errcode.Option{
+		errcode.WithDetails(
+			errcode.PublicString("contractID", contractID),
+			errcode.PublicString("cellID", cellID),
+			errcode.PublicString("sliceID", sliceID),
+		),
+	}
+	if contract.Signature == nil {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract is missing signature section — required for ReceiverSpec",
+			details...)
+	}
+	if contract.Endpoints.Inbound == nil {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract is missing endpoints.inbound section — required for ReceiverSpec",
+			details...)
+	}
+	if contract.Payload == nil {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract is missing payload section — required for ReceiverSpec",
+			details...)
+	}
+	sig := contract.Signature
+	inbound := contract.Endpoints.Inbound
+	if sig.DeliveryIDHeader == "" || sig.TimestampHeader == "" || sig.SignatureHeader == "" {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract signature is missing required header fields",
+			details...)
+	}
+	if inbound.PathPattern == "" {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract endpoints.inbound.pathPattern is empty",
+			details...)
+	}
+	if sig.ToleranceSeconds <= 0 {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract signature.toleranceSeconds must be positive",
+			details...)
+	}
+	if contract.Payload.MaxBodyBytes <= 0 {
+		return receiverRuntimeConfig{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"cellgen build: inbound webhook contract payload.maxBodyBytes must be positive",
+			details...)
+	}
+	return receiverRuntimeConfig{
+		PathPattern:      inbound.PathPattern,
+		DeliveryIDHeader: sig.DeliveryIDHeader,
+		TimestampHeader:  sig.TimestampHeader,
+		SignatureHeader:  sig.SignatureHeader,
+		ToleranceSeconds: int64(sig.ToleranceSeconds), // metadata is int; spec is int64
+		MaxBodyBytes:     contract.Payload.MaxBodyBytes,
 	}, nil
 }
 
@@ -460,8 +551,6 @@ func buildWebhookDispatchesFromSlices(
 //
 // The cell struct field is resolved via fieldIndex.resolveSliceField.
 // SelectorExpr is rendered as `c.<fieldName>.<cu.TargetSelector>`.
-//
-//nolint:dupl // symmetric to buildWebhookReceiverSpecFromCU; different role, fields, and return types
 func buildWebhookDispatchSpecFromCU(
 	p *metadata.ProjectMeta,
 	cellID, sliceID string,

--- a/tools/codegen/cellgen/builder_webhook_test.go
+++ b/tools/codegen/cellgen/builder_webhook_test.go
@@ -9,9 +9,35 @@ import (
 	"github.com/ghbvf/gocell/tools/codegen/markergen"
 )
 
+// stripeInboundContract returns a fully-configured inbound webhook contract for
+// stripe, usable as a fixture in receiver happy-path tests.
+func stripeInboundContract() *metadata.ContractMeta {
+	return &metadata.ContractMeta{
+		ID:        "webhook.stripe.payment-events.v1",
+		Kind:      "webhook",
+		Direction: "inbound",
+		Signature: &metadata.WebhookSignatureMeta{
+			Algorithm:        "hmac-sha256",
+			DeliveryIDHeader: "svix-id",
+			TimestampHeader:  "svix-timestamp",
+			SignatureHeader:  "svix-signature",
+			ToleranceSeconds: 300,
+		},
+		Endpoints: metadata.EndpointsMeta{
+			Inbound: &metadata.WebhookInboundMeta{
+				PathPattern: "/api/webhooks/stripe/payment-events",
+				SourceID:    "stripe",
+			},
+		},
+		Payload: &metadata.WebhookPayloadMeta{
+			MaxBodyBytes: 1048576,
+		},
+	}
+}
+
 // TestBuildWebhookReceiversFromSlices_HappyPath verifies that a slice with
 // role=webhook-receive produces a WebhookReceiverGenSpec with the correct
-// ContractID, SourceID, and HandlerExpr.
+// ContractID, SourceID, HandlerExpr, and baked runtime config fields.
 func TestBuildWebhookReceiversFromSlices_HappyPath(t *testing.T) {
 	t.Parallel()
 	cell := &metadata.CellMeta{
@@ -34,11 +60,7 @@ func TestBuildWebhookReceiversFromSlices_HappyPath(t *testing.T) {
 			},
 		},
 	}
-	contract := &metadata.ContractMeta{
-		ID:   "webhook.stripe.payment-events.v1",
-		Kind: "webhook",
-	}
-	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{contract})
+	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{stripeInboundContract()})
 	fieldIndex := idxOf(map[string]string{"stripeingest": "stripeSvc"})
 
 	spec, err := BuildCellSpec(p, "hooks", markergen.WireBundle{}, fieldIndex)
@@ -57,6 +79,25 @@ func TestBuildWebhookReceiversFromSlices_HappyPath(t *testing.T) {
 	}
 	if recv.HandlerExpr != "c.stripeSvc.HandleStripeEvent" {
 		t.Errorf("HandlerExpr = %q, want c.stripeSvc.HandleStripeEvent", recv.HandlerExpr)
+	}
+	// Baked runtime config assertions.
+	if recv.PathPattern != "/api/webhooks/stripe/payment-events" {
+		t.Errorf("PathPattern = %q, want /api/webhooks/stripe/payment-events", recv.PathPattern)
+	}
+	if recv.DeliveryIDHeader != "svix-id" {
+		t.Errorf("DeliveryIDHeader = %q, want svix-id", recv.DeliveryIDHeader)
+	}
+	if recv.TimestampHeader != "svix-timestamp" {
+		t.Errorf("TimestampHeader = %q, want svix-timestamp", recv.TimestampHeader)
+	}
+	if recv.SignatureHeader != "svix-signature" {
+		t.Errorf("SignatureHeader = %q, want svix-signature", recv.SignatureHeader)
+	}
+	if recv.ToleranceSeconds != 300 {
+		t.Errorf("ToleranceSeconds = %d, want 300", recv.ToleranceSeconds)
+	}
+	if recv.MaxBodyBytes != 1048576 {
+		t.Errorf("MaxBodyBytes = %d, want 1048576", recv.MaxBodyBytes)
 	}
 }
 
@@ -92,8 +133,24 @@ func TestBuildWebhookReceivers_SortedBySliceIDThenContractID(t *testing.T) {
 		}},
 	}
 	contracts := []*metadata.ContractMeta{
-		{ID: "webhook.zzz.events.v1", Kind: "webhook"},
-		{ID: "webhook.aaa.events.v1", Kind: "webhook"},
+		{
+			ID: "webhook.zzz.events.v1", Kind: "webhook", Direction: "inbound",
+			Signature: &metadata.WebhookSignatureMeta{
+				DeliveryIDHeader: "x-delivery-id", TimestampHeader: "x-ts", SignatureHeader: "x-sig",
+				ToleranceSeconds: 60,
+			},
+			Endpoints: metadata.EndpointsMeta{Inbound: &metadata.WebhookInboundMeta{PathPattern: "/webhooks/zzz", SourceID: "zzz"}},
+			Payload:   &metadata.WebhookPayloadMeta{MaxBodyBytes: 65536},
+		},
+		{
+			ID: "webhook.aaa.events.v1", Kind: "webhook", Direction: "inbound",
+			Signature: &metadata.WebhookSignatureMeta{
+				DeliveryIDHeader: "x-delivery-id", TimestampHeader: "x-ts", SignatureHeader: "x-sig",
+				ToleranceSeconds: 60,
+			},
+			Endpoints: metadata.EndpointsMeta{Inbound: &metadata.WebhookInboundMeta{PathPattern: "/webhooks/aaa", SourceID: "aaa"}},
+			Payload:   &metadata.WebhookPayloadMeta{MaxBodyBytes: 65536},
+		},
 	}
 	p := fixtureProject(cell, []*metadata.SliceMeta{alpha, zebra}, contracts)
 	fieldIndex := idxOf(map[string]string{"alphaingest": "alphaSvc", "zebraingest": "zebraSvc"})
@@ -529,6 +586,216 @@ func TestBuildWebhookDispatches_InvalidSourceID(t *testing.T) {
 				t.Errorf("error should mention sourceID, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestBuildWebhookReceivers_MissingSignature verifies that a webhook-receive CU
+// whose contract lacks a signature section is rejected at codegen time.
+func TestBuildWebhookReceivers_MissingSignature(t *testing.T) {
+	t.Parallel()
+	cell := &metadata.CellMeta{
+		ID:           "hooks",
+		Dir:          "hooks",
+		File:         "cells/hooks/cell.yaml",
+		GoStructName: metadata.MustNewGoIdentifier("HooksCell"),
+	}
+	slc := &metadata.SliceMeta{
+		ID:            "stripeingest",
+		BelongsToCell: "hooks",
+		Dir:           "stripeingest",
+		File:          "cells/hooks/slices/stripeingest/slice.yaml",
+		ContractUsages: []metadata.ContractUsage{
+			{Contract: "webhook.stripe.payment-events.v1", Role: "webhook-receive", Handler: "HandleStripeEvent", SourceID: "stripe"},
+		},
+	}
+	// Contract with no Signature section.
+	contract := &metadata.ContractMeta{
+		ID:   "webhook.stripe.payment-events.v1",
+		Kind: "webhook",
+		Endpoints: metadata.EndpointsMeta{
+			Inbound: &metadata.WebhookInboundMeta{PathPattern: "/webhooks/stripe", SourceID: "stripe"},
+		},
+		Payload: &metadata.WebhookPayloadMeta{MaxBodyBytes: 65536},
+	}
+	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{contract})
+	fieldIndex := idxOf(map[string]string{"stripeingest": "stripeSvc"})
+
+	_, err := BuildCellSpec(p, "hooks", markergen.WireBundle{}, fieldIndex)
+	if err == nil {
+		t.Fatal("expected error for missing signature section, got nil")
+	}
+	if !strings.Contains(err.Error(), "signature") {
+		t.Errorf("error should mention signature, got: %v", err)
+	}
+}
+
+// TestBuildWebhookReceivers_MissingInbound verifies that a webhook-receive CU
+// whose contract lacks an endpoints.inbound section is rejected at codegen time.
+func TestBuildWebhookReceivers_MissingInbound(t *testing.T) {
+	t.Parallel()
+	cell := &metadata.CellMeta{
+		ID:           "hooks",
+		Dir:          "hooks",
+		File:         "cells/hooks/cell.yaml",
+		GoStructName: metadata.MustNewGoIdentifier("HooksCell"),
+	}
+	slc := &metadata.SliceMeta{
+		ID:            "stripeingest",
+		BelongsToCell: "hooks",
+		Dir:           "stripeingest",
+		File:          "cells/hooks/slices/stripeingest/slice.yaml",
+		ContractUsages: []metadata.ContractUsage{
+			{Contract: "webhook.stripe.payment-events.v1", Role: "webhook-receive", Handler: "HandleStripeEvent", SourceID: "stripe"},
+		},
+	}
+	// Contract with signature but no Inbound section.
+	contract := &metadata.ContractMeta{
+		ID:   "webhook.stripe.payment-events.v1",
+		Kind: "webhook",
+		Signature: &metadata.WebhookSignatureMeta{
+			DeliveryIDHeader: "svix-id", TimestampHeader: "svix-timestamp", SignatureHeader: "svix-signature",
+			ToleranceSeconds: 300,
+		},
+		Payload: &metadata.WebhookPayloadMeta{MaxBodyBytes: 65536},
+	}
+	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{contract})
+	fieldIndex := idxOf(map[string]string{"stripeingest": "stripeSvc"})
+
+	_, err := BuildCellSpec(p, "hooks", markergen.WireBundle{}, fieldIndex)
+	if err == nil {
+		t.Fatal("expected error for missing endpoints.inbound section, got nil")
+	}
+	if !strings.Contains(err.Error(), "inbound") {
+		t.Errorf("error should mention inbound, got: %v", err)
+	}
+}
+
+// TestBuildWebhookReceivers_MissingPayload verifies that a webhook-receive CU
+// whose contract lacks a payload section is rejected at codegen time.
+func TestBuildWebhookReceivers_MissingPayload(t *testing.T) {
+	t.Parallel()
+	cell := &metadata.CellMeta{
+		ID:           "hooks",
+		Dir:          "hooks",
+		File:         "cells/hooks/cell.yaml",
+		GoStructName: metadata.MustNewGoIdentifier("HooksCell"),
+	}
+	slc := &metadata.SliceMeta{
+		ID:            "stripeingest",
+		BelongsToCell: "hooks",
+		Dir:           "stripeingest",
+		File:          "cells/hooks/slices/stripeingest/slice.yaml",
+		ContractUsages: []metadata.ContractUsage{
+			{Contract: "webhook.stripe.payment-events.v1", Role: "webhook-receive", Handler: "HandleStripeEvent", SourceID: "stripe"},
+		},
+	}
+	// Contract with signature and inbound but no Payload section.
+	contract := &metadata.ContractMeta{
+		ID:   "webhook.stripe.payment-events.v1",
+		Kind: "webhook",
+		Signature: &metadata.WebhookSignatureMeta{
+			DeliveryIDHeader: "svix-id", TimestampHeader: "svix-timestamp", SignatureHeader: "svix-signature",
+			ToleranceSeconds: 300,
+		},
+		Endpoints: metadata.EndpointsMeta{
+			Inbound: &metadata.WebhookInboundMeta{PathPattern: "/webhooks/stripe", SourceID: "stripe"},
+		},
+	}
+	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{contract})
+	fieldIndex := idxOf(map[string]string{"stripeingest": "stripeSvc"})
+
+	_, err := BuildCellSpec(p, "hooks", markergen.WireBundle{}, fieldIndex)
+	if err == nil {
+		t.Fatal("expected error for missing payload section, got nil")
+	}
+	if !strings.Contains(err.Error(), "payload") {
+		t.Errorf("error should mention payload, got: %v", err)
+	}
+}
+
+// TestBuildWebhookReceivers_ZeroToleranceSeconds verifies that a contract with
+// toleranceSeconds=0 is rejected (must be positive).
+func TestBuildWebhookReceivers_ZeroToleranceSeconds(t *testing.T) {
+	t.Parallel()
+	cell := &metadata.CellMeta{
+		ID:           "hooks",
+		Dir:          "hooks",
+		File:         "cells/hooks/cell.yaml",
+		GoStructName: metadata.MustNewGoIdentifier("HooksCell"),
+	}
+	slc := &metadata.SliceMeta{
+		ID:            "stripeingest",
+		BelongsToCell: "hooks",
+		Dir:           "stripeingest",
+		File:          "cells/hooks/slices/stripeingest/slice.yaml",
+		ContractUsages: []metadata.ContractUsage{
+			{Contract: "webhook.stripe.payment-events.v1", Role: "webhook-receive", Handler: "HandleStripeEvent", SourceID: "stripe"},
+		},
+	}
+	contract := &metadata.ContractMeta{
+		ID:   "webhook.stripe.payment-events.v1",
+		Kind: "webhook",
+		Signature: &metadata.WebhookSignatureMeta{
+			DeliveryIDHeader: "svix-id", TimestampHeader: "svix-timestamp", SignatureHeader: "svix-signature",
+			ToleranceSeconds: 0, // invalid
+		},
+		Endpoints: metadata.EndpointsMeta{
+			Inbound: &metadata.WebhookInboundMeta{PathPattern: "/webhooks/stripe", SourceID: "stripe"},
+		},
+		Payload: &metadata.WebhookPayloadMeta{MaxBodyBytes: 65536},
+	}
+	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{contract})
+	fieldIndex := idxOf(map[string]string{"stripeingest": "stripeSvc"})
+
+	_, err := BuildCellSpec(p, "hooks", markergen.WireBundle{}, fieldIndex)
+	if err == nil {
+		t.Fatal("expected error for zero toleranceSeconds, got nil")
+	}
+	if !strings.Contains(err.Error(), "toleranceSeconds") && !strings.Contains(err.Error(), "tolerance") {
+		t.Errorf("error should mention toleranceSeconds, got: %v", err)
+	}
+}
+
+// TestBuildWebhookReceivers_ZeroMaxBodyBytes verifies that a contract with
+// maxBodyBytes=0 is rejected (must be positive).
+func TestBuildWebhookReceivers_ZeroMaxBodyBytes(t *testing.T) {
+	t.Parallel()
+	cell := &metadata.CellMeta{
+		ID:           "hooks",
+		Dir:          "hooks",
+		File:         "cells/hooks/cell.yaml",
+		GoStructName: metadata.MustNewGoIdentifier("HooksCell"),
+	}
+	slc := &metadata.SliceMeta{
+		ID:            "stripeingest",
+		BelongsToCell: "hooks",
+		Dir:           "stripeingest",
+		File:          "cells/hooks/slices/stripeingest/slice.yaml",
+		ContractUsages: []metadata.ContractUsage{
+			{Contract: "webhook.stripe.payment-events.v1", Role: "webhook-receive", Handler: "HandleStripeEvent", SourceID: "stripe"},
+		},
+	}
+	contract := &metadata.ContractMeta{
+		ID:   "webhook.stripe.payment-events.v1",
+		Kind: "webhook",
+		Signature: &metadata.WebhookSignatureMeta{
+			DeliveryIDHeader: "svix-id", TimestampHeader: "svix-timestamp", SignatureHeader: "svix-signature",
+			ToleranceSeconds: 300,
+		},
+		Endpoints: metadata.EndpointsMeta{
+			Inbound: &metadata.WebhookInboundMeta{PathPattern: "/webhooks/stripe", SourceID: "stripe"},
+		},
+		Payload: &metadata.WebhookPayloadMeta{MaxBodyBytes: 0}, // invalid
+	}
+	p := fixtureProject(cell, []*metadata.SliceMeta{slc}, []*metadata.ContractMeta{contract})
+	fieldIndex := idxOf(map[string]string{"stripeingest": "stripeSvc"})
+
+	_, err := BuildCellSpec(p, "hooks", markergen.WireBundle{}, fieldIndex)
+	if err == nil {
+		t.Fatal("expected error for zero maxBodyBytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "maxBodyBytes") && !strings.Contains(err.Error(), "body") {
+		t.Errorf("error should mention maxBodyBytes, got: %v", err)
 	}
 }
 

--- a/tools/codegen/cellgen/generator_webhook_test.go
+++ b/tools/codegen/cellgen/generator_webhook_test.go
@@ -105,8 +105,25 @@ func buildWebhookSyntheticProject() *metadata.ProjectMeta {
 		},
 	}
 	stripeContract := &metadata.ContractMeta{
-		ID:   "webhook.stripe.payment-events.v1",
-		Kind: "webhook",
+		ID:        "webhook.stripe.payment-events.v1",
+		Kind:      "webhook",
+		Direction: "inbound",
+		Signature: &metadata.WebhookSignatureMeta{
+			Algorithm:        "hmac-sha256",
+			DeliveryIDHeader: "svix-id",
+			TimestampHeader:  "svix-timestamp",
+			SignatureHeader:  "svix-signature",
+			ToleranceSeconds: 300,
+		},
+		Endpoints: metadata.EndpointsMeta{
+			Inbound: &metadata.WebhookInboundMeta{
+				PathPattern: "/api/webhooks/stripe/payment-events",
+				SourceID:    "stripe",
+			},
+		},
+		Payload: &metadata.WebhookPayloadMeta{
+			MaxBodyBytes: 1048576,
+		},
 	}
 	shopifyContract := &metadata.ContractMeta{
 		ID:   "webhook.shopify.orders.v1",

--- a/tools/codegen/cellgen/generator_webhook_test.go
+++ b/tools/codegen/cellgen/generator_webhook_test.go
@@ -64,6 +64,15 @@ func TestRenderCell_GoldenWebhook(t *testing.T) {
 	if !bytes.Equal(out, golden) {
 		t.Errorf("rendered output diverges from golden:\n--- got ---\n%s\n--- want ---\n%s", out, golden)
 	}
+
+	// Lightweight assertion: the receiver registration block must carry the
+	// correct CellID field value ("hooks"). This guards against regressions
+	// where the cellgen template omits or mis-derives CellID from the cell
+	// metadata, which would silently break observability labeling at runtime.
+	outStr := string(out)
+	if !bytes.Contains(out, []byte(`CellID:           "hooks"`)) {
+		t.Errorf("generated output does not contain CellID field for receiver registration; got:\n%s", outStr)
+	}
 }
 
 // buildWebhookSyntheticProject builds the in-memory ProjectMeta for the

--- a/tools/codegen/cellgen/spec.go
+++ b/tools/codegen/cellgen/spec.go
@@ -129,6 +129,26 @@ type WebhookReceiverGenSpec struct {
 	SourceID string
 	// HandlerExpr is the dotted handler reference, e.g. "c.stripeSvc.HandleStripeEvent".
 	HandlerExpr string
+
+	// Runtime configuration baked from contract.yaml at code-generation time.
+	// PathPattern is the HTTP path the receiver runtime mounts
+	// (contract.yaml endpoints.inbound.pathPattern).
+	PathPattern string
+	// DeliveryIDHeader is the HTTP header name carrying the per-delivery
+	// identifier (contract.yaml signature.deliveryIDHeader).
+	DeliveryIDHeader string
+	// TimestampHeader is the HTTP header name carrying the unix-seconds
+	// timestamp (contract.yaml signature.timestampHeader).
+	TimestampHeader string
+	// SignatureHeader is the HTTP header name carrying the HMAC signature tokens
+	// (contract.yaml signature.signatureHeader).
+	SignatureHeader string
+	// ToleranceSeconds is the bidirectional timestamp window in seconds
+	// (contract.yaml signature.toleranceSeconds). Must be > 0.
+	ToleranceSeconds int64
+	// MaxBodyBytes is the maximum accepted request body size in bytes
+	// (contract.yaml payload.maxBodyBytes). Must be > 0.
+	MaxBodyBytes int64
 }
 
 // WebhookDispatchGenSpec describes one reg.RegisterWebhookDispatch() call.

--- a/tools/codegen/cellgen/templates/cell.tmpl
+++ b/tools/codegen/cellgen/templates/cell.tmpl
@@ -75,9 +75,15 @@ func (c *{{.StructName}}) Init(ctx context.Context, reg cell.Registrar) error {
 {{ end }}
 {{- range .WebhookReceivers }}
 	if err := reg.RegisterWebhookReceiver(webhook.ReceiverSpec{
-		ContractID: {{ printf "%q" .ContractID }},
-		SourceID:   {{ printf "%q" .SourceID }},
-		CellID:     {{ printf "%q" $.CellID }},
+		ContractID:       {{ printf "%q" .ContractID }},
+		SourceID:         {{ printf "%q" .SourceID }},
+		CellID:           {{ printf "%q" $.CellID }},
+		PathPattern:      {{ printf "%q" .PathPattern }},
+		DeliveryIDHeader: {{ printf "%q" .DeliveryIDHeader }},
+		TimestampHeader:  {{ printf "%q" .TimestampHeader }},
+		SignatureHeader:  {{ printf "%q" .SignatureHeader }},
+		ToleranceSeconds: {{ .ToleranceSeconds }},
+		MaxBodyBytes:     {{ .MaxBodyBytes }},
 	}, {{ .HandlerExpr }}); err != nil {
 		return fmt.Errorf({{ printf "%q" (printf "%s: webhook-receive %s: %%w" $.CellID .ContractID) }}, err)
 	}

--- a/tools/codegen/cellgen/testdata/golden/synth_webhook_cell_gen.go.golden
+++ b/tools/codegen/cellgen/testdata/golden/synth_webhook_cell_gen.go.golden
@@ -36,9 +36,15 @@ func (c *HooksCell) Init(ctx context.Context, reg cell.Registrar) error {
 	}
 
 	if err := reg.RegisterWebhookReceiver(webhook.ReceiverSpec{
-		ContractID: "webhook.stripe.payment-events.v1",
-		SourceID:   "stripe",
-		CellID:     "hooks",
+		ContractID:       "webhook.stripe.payment-events.v1",
+		SourceID:         "stripe",
+		CellID:           "hooks",
+		PathPattern:      "/api/webhooks/stripe/payment-events",
+		DeliveryIDHeader: "svix-id",
+		TimestampHeader:  "svix-timestamp",
+		SignatureHeader:  "svix-signature",
+		ToleranceSeconds: 300,
+		MaxBodyBytes:     1048576,
 	}, c.stripeSvc.HandleStripeEvent); err != nil {
 		return fmt.Errorf("hooks: webhook-receive webhook.stripe.payment-events.v1: %w", err)
 	}


### PR DESCRIPTION
## Summary
`KERNEL-WEBHOOK-01` PR-3 — webhook **receiver 运行时**。把 receiver 从"已声明未连线"变为编译期安全、运行时可挂载的闭环。

闭环:HTTP 接收 → body 限流(MaxBytesReader) → HMAC 验签 + 双向时间窗 → 两阶段 `kernel/idempotency.Claimer` 幂等 → 业务 handler → Commit/Release → errcode→HTTP 状态码。

**AI-HARD 核心**:`verify→claim→handler` 顺序由未导出 capability-token(`verified`/`claimed`)在 Go type system **编译期不可绕过**——`claimed` 仅 `claim()`(需 `verified`)产、handler 仅 `invokeHandler`(需 `claimed`)调。下游 archtest `WEBHOOK-RECEIVER-PIPELINE-01` 锁令牌 sealed-construction + handler callsite。

> 范围:经用户裁定按最彻底方向落地,合并了原属 PR-2(handler 富签名 + cellgen bake)与 PR-6(bootstrap drain + claimer 守卫)的相关面。**#1161(PR-6)收缩**为 observability/metrics/healthz + 真实 demo cell + closeout。

## 状态码映射
| 条件 | HTTP |
|---|---|
| 有效签名 / 幂等重复(ClaimDone) | 200 |
| 并发在途(ClaimBusy) | 409 |
| 缺/非法 header | 400 |
| 验签失败 / 未知 source(防枚举,统一) | 401 |
| timestamp 超窗(replay) | 401 |
| body 超限 | 413 |
| handler 瞬态(KindUnavailable) | 503 |
| handler 永久错误 | 500 |

## Implementation Matrix
```
Contract: webhook.Verifier 消费 + WebhookReceiveHandler 富 Delivery 类型 + ReceiverSpec enrich(cellgen bake)
Change: receiver 运行时 + capability-token 闭环 + bootstrap phase5 drain + cellgen 配置 bake + pipeline archtest
Implementations: [x] hmacVerifier(PR-1,唯一消费方) [x] Receiver(新)
Conformance: kernel/webhook/webhooktest.RunSignerVerifierConformance
Repro: go test ./runtime/webhook/... ./kernel/webhook/... ./tools/codegen/cellgen/... ./tools/archtest/... -run 'Webhook|Receiver'
Dependent contracts (governance scan): 无 contract.yaml 变更;cellgen 输出由 golden 锁
Invariant inventory: N/A(无 DROP COLUMN)
```

## 开源对标(WebFetch 核验)
- 采纳:双向时间窗(Svix>Stripe 单向)、多 token 轮换、`hmac.Equal` 常时、`http.MaxBytesReader`(>go-github io.LimitReader 静默截断)、verify↔handler 解耦(Watermill)。
- 偏离(刻意):receiver **内置 Claimer 两阶段幂等**——Stripe/Svix/GitHub 库把 dedupe 留应用(它们是 SDK),GoCell receiver 是框架组件,Svix 文档本身建议消费端 webhook-id+Redis/24h dedupe,GoCell 结构化内置,与自身 event-consumer 一致。增值:409 触发发送方退避、Release 防 panic 死锁、cell 免写 dedupe。

ref: svix/svix-webhooks go/webhook.go@main · stripe/stripe-go webhook/client.go@master · ThreeDotsLabs/watermill-http pkg/http/subscriber.go@master

## Test plan
- [x] `go build ./...` + `-tags=integration` clean
- [x] `go test ./kernel/webhook/... ./kernel/cell/... ./runtime/webhook/... ./runtime/bootstrap/... ./tools/codegen/cellgen/...` PASS
- [x] `go test -tags=integration ./runtime/webhook/... ./runtime/bootstrap/...` PASS(httptest 合成 cell 端到端断状态码全表 + 幂等重放)
- [x] archtest `WEBHOOK-RECEIVER-PIPELINE-01`(A1/A2 + 反向 fixture)PASS
- [x] 覆盖率 kernel/webhook 92.7% / runtime/webhook 88.5%(均超阈)
- [x] golangci-lint 0 issues

Closes #1158
Refs: KERNEL-WEBHOOK-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)