### PR TITLE
test(audit-ledger): storetest property-based fuzzing + tighten NamespaceID to [a-z_] [#1249]

### DIFF
--- a/adapters/postgres/audit_ledger_store_test.go
+++ b/adapters/postgres/audit_ledger_store_test.go
@@ -83,6 +83,28 @@ func TestAuditLedgerStore_StoretestSuite(t *testing.T) {
 	storetest.Run(t, factory, protocol)
 }
 
+// FuzzAuditLedgerStore_EntryRoundTrip runs the property-based Entry round-trip
+// + HMAC parity fuzz against a real PostgreSQL backend, sharing the seed corpus
+// and fuzz body with the MemStore target (storetest.RunEntryRoundTripFuzz). The
+// migrated pool and store are constructed once and reused across all fuzz
+// iterations — a fresh migrated database per iteration is infeasible at fuzz
+// throughput. Running the same independent reference against PG and mem proves
+// cross-store HMAC byte parity in fuzz form.
+func FuzzAuditLedgerStore_EntryRoundTrip(f *testing.F) {
+	protocol := storetest.NewTestProtocol(f)
+	fc := clockmock.New(storetest.EpochAnchor())
+
+	p := migratedPool(f)
+	f.Cleanup(func() { _ = p.Close(context.Background()) })
+	txm := NewTxManager(p)
+	store, err := NewLedgerStore(p.DB(), txm, protocol, fc)
+	if err != nil {
+		f.Fatalf("NewLedgerStore: %v", err)
+	}
+
+	storetest.RunEntryRoundTripFuzz(f, store, protocol)
+}
+
 // ---------------------------------------------------------------------------
 // TestAuditLedgerStore_RestartRecovery_AcrossPool (B2-C-14)
 // ---------------------------------------------------------------------------

--- a/runtime/audit/bootstrap_namespace.go
+++ b/runtime/audit/bootstrap_namespace.go
@@ -9,8 +9,8 @@ import "github.com/ghbvf/gocell/runtime/audit/ledger"
 // separate hash chains and cannot fork a shared chain under concurrency.
 //
 // Validation happens by construction: NamespaceID format rules
-// (lowercase / [a-z_] first char / length ≤ 48 / no ':' '{' '}') are checked
-// in TestBootstrapNamespace_LiteralPassesValidate so any future drift in the
+// (every byte in [a-z_] / length ≤ 48) are checked in
+// TestBootstrapNamespace_LiteralPassesValidate so any future drift in the
 // validation rules surfaces at unit-test time rather than at first request.
 //
 // ref: google/trillian storage/log_storage.go — per-tree_id partition with

--- a/runtime/audit/bootstrap_namespace.go
+++ b/runtime/audit/bootstrap_namespace.go
@@ -9,7 +9,7 @@ import "github.com/ghbvf/gocell/runtime/audit/ledger"
 // separate hash chains and cannot fork a shared chain under concurrency.
 //
 // Validation happens by construction: NamespaceID format rules
-// (every byte in [a-z_] / length ≤ 48) are checked in
+// (non-empty / every byte in [a-z_] / length ≤ 48) are checked in
 // TestBootstrapNamespace_LiteralPassesValidate so any future drift in the
 // validation rules surfaces at unit-test time rather than at first request.
 //

--- a/runtime/audit/bootstrap_namespace_test.go
+++ b/runtime/audit/bootstrap_namespace_test.go
@@ -17,7 +17,7 @@ func TestBootstrapNamespace_LiteralPassesValidate(t *testing.T) {
 	t.Parallel()
 	ns := audit.BootstrapNamespace()
 	require.NoError(t, ns.Validate(),
-		"bootstrap namespace literal must satisfy NamespaceID.Validate (lowercase / [a-z_] first char / length ≤ 48 / no ':' '{' '}')")
+		"bootstrap namespace literal must satisfy NamespaceID.Validate (non-empty / [a-z_] only / length ≤ 48)")
 }
 
 // TestBootstrapNamespace_NotEmpty is the partition invariant: the bootstrap

--- a/runtime/audit/ledger/mem_store_test.go
+++ b/runtime/audit/ledger/mem_store_test.go
@@ -2,10 +2,6 @@ package ledger_test
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -18,52 +14,8 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
+	"github.com/ghbvf/gocell/runtime/audit/ledger/storetest"
 )
-
-// referenceHashInput mirrors the unexported auditHashInput struct in
-// protocol.go. Tests use this as an external, independent reference for the
-// canonical-JSON HMAC format so that any drift between the production struct
-// (locked by archtest AUDIT-HASH-INPUT-FROZEN-01) and this reference surfaces
-// as a test failure as well as an archtest failure.
-type referenceHashInput struct {
-	Namespace          string `json:"namespace"`
-	PrevHash           string `json:"prev_hash"`
-	EventID            string `json:"event_id"`
-	EventType          string `json:"event_type"`
-	ActorID            string `json:"actor_id"`
-	SubjectID          string `json:"subject_id"`
-	TenantID           string `json:"tenant_id"`
-	SessionID          string `json:"session_id"`
-	CorrelationID      string `json:"correlation_id"`
-	OccurredAtUnixNano int64  `json:"occurred_at_unix_nano"`
-	TimestampUnixNano  int64  `json:"timestamp_unix_nano"`
-	Payload            []byte `json:"payload"`
-}
-
-// referenceComputeHash recomputes the canonical HMAC for an Entry independently
-// of Protocol.ComputeHash. The namespace is supplied explicitly because
-// production embeds Protocol.Namespace() as the first signed field
-// (cross-namespace HMAC replay attack vector — see ADR-1042 §威胁矩阵 §A).
-func referenceComputeHash(key []byte, ns ledger.NamespaceID, prevHash string, e *ledger.Entry) string {
-	in := referenceHashInput{
-		Namespace:          string(ns),
-		PrevHash:           prevHash,
-		EventID:            e.EventID,
-		EventType:          e.EventType,
-		ActorID:            e.ActorID,
-		SubjectID:          e.SubjectID,
-		TenantID:           e.TenantID,
-		SessionID:          e.SessionID,
-		CorrelationID:      e.CorrelationID,
-		OccurredAtUnixNano: e.OccurredAt.UnixNano(),
-		TimestampUnixNano:  e.Timestamp.UnixNano(),
-		Payload:            e.Payload,
-	}
-	msgBytes, _ := json.Marshal(in)
-	mac := hmac.New(sha256.New, key)
-	mac.Write(msgBytes)
-	return hex.EncodeToString(mac.Sum(nil))
-}
 
 // redeliveryAdvance is the clock advance used in at-least-once redelivery
 // simulation tests (F-CR-2 idempotency regression guard).
@@ -137,7 +89,7 @@ func TestNewMemStore_TypedNilClock_Rejected(t *testing.T) {
 // TestMemStore_Append_HashEquivalence verifies the HMAC-SHA256 computation
 // matches the 12-field canonical-JSON reference (auditHashInput struct shape +
 // json.Marshal source-order). The reference is recomputed independently via
-// referenceComputeHash (above) so any drift between production and the spec
+// storetest.ReferenceComputeHash so any drift between production and the spec
 // surfaces both here and in archtest AUDIT-HASH-INPUT-FROZEN-01.
 func TestMemStore_Append_HashEquivalence(t *testing.T) {
 	t.Parallel()
@@ -164,7 +116,7 @@ func TestMemStore_Append_HashEquivalence(t *testing.T) {
 		t.Fatalf("Append: %v", err)
 	}
 
-	expectedHash := referenceComputeHash(key, ledger.NamespaceID("auditcore"), "", entry)
+	expectedHash := storetest.ReferenceComputeHash(t, key, ledger.NamespaceID("auditcore"), "", entry)
 
 	tail, err := store.Tail(context.Background())
 	if err != nil {
@@ -723,7 +675,7 @@ func TestProtocol_ComputeHash_ByteForByte(t *testing.T) {
 		PrevHash:      "deadbeef",
 	}
 
-	expected := referenceComputeHash(keyCopy, ns, e.PrevHash, e)
+	expected := storetest.ReferenceComputeHash(t, keyCopy, ns, e.PrevHash, e)
 	got := p.ComputeHash(e.PrevHash, e)
 	if got != expected {
 		t.Errorf("ComputeHash mismatch:\n  got  %s\n  want %s", got, expected)

--- a/runtime/audit/ledger/protocol.go
+++ b/runtime/audit/ledger/protocol.go
@@ -97,7 +97,11 @@ func (ns NamespaceID) Validate() error {
 		c := s[i]
 		if c != '_' && (c < 'a' || c > 'z') {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-				"audit ledger: namespace ID must contain only [a-z_]")
+				"audit ledger: namespace ID must contain only [a-z_]",
+				errcode.WithDetails(
+					errcode.PublicInt("offset", i),
+					errcode.PublicInt("byte", int(c)),
+				))
 		}
 	}
 	return nil

--- a/runtime/audit/ledger/protocol.go
+++ b/runtime/audit/ledger/protocol.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"unicode"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
@@ -69,13 +68,17 @@ type IdempotencyContentFingerprint struct{}
 func (IdempotencyContentFingerprint) idempotencyModeOK() {}
 
 // NamespaceID is a typed string that identifies the owner of a ledger store
-// (e.g. a cell ID). It mirrors adapters/redis.KeyNamespace validation rules:
-// lowercase only, no ':', '{', '}', length ≤ 48, first char [a-z_].
+// (e.g. a cell ID). The legal set is restricted to [a-z_] with length ≤ 48:
+// every byte must be a lowercase ASCII letter or underscore. This is stricter
+// than adapters/redis.KeyNamespace ([a-z0-9_-]) on purpose — the namespace is
+// the first signed field of the HMAC chain (cross-namespace domain separation,
+// ADR-1042 §A), so its character set is frozen narrow to avoid any ambiguity in
+// the canonical digest input.
 type NamespaceID string
 
-// Validate reports whether the NamespaceID satisfies all format constraints.
-// Rejects: empty, contains ':', '{', '}', uppercase letters, length > 48,
-// first character not in [a-z_].
+// Validate reports whether the NamespaceID satisfies all format constraints:
+// non-empty, length ≤ 48, and every byte in [a-z_]. Any digit, dash, dot,
+// uppercase letter, ':' / '{' / '}', or non-ASCII byte is rejected.
 func (ns NamespaceID) Validate() error {
 	s := string(ns)
 	if s == "" {
@@ -90,19 +93,11 @@ func (ns NamespaceID) Validate() error {
 				errcode.PublicInt("actualLength", len(s)),
 			))
 	}
-	first := rune(s[0])
-	if first != '_' && (first < 'a' || first > 'z') {
-		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"audit ledger: namespace ID first character must be [a-z_]")
-	}
-	for _, r := range s {
-		if r == ':' || r == '{' || r == '}' {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != '_' && (c < 'a' || c > 'z') {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-				"audit ledger: namespace ID must not contain ':', '{', or '}'")
-		}
-		if unicode.IsUpper(r) {
-			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-				"audit ledger: namespace ID must be lowercase")
+				"audit ledger: namespace ID must contain only [a-z_]")
 		}
 	}
 	return nil

--- a/runtime/audit/ledger/protocol_test.go
+++ b/runtime/audit/ledger/protocol_test.go
@@ -139,8 +139,10 @@ func TestNamespaceID_Validate(t *testing.T) {
 		{"starts_dash", "-audit", true},
 		{"starts_underscore", "_audit", false},
 		{"valid_simple", "auditcore", false},
-		{"valid_with_dash", "audit-core", false},
 		{"valid_with_underscore", "audit_core", false},
+		{"contains_dash", "audit-core", true},
+		{"contains_digit", "audit1core", true},
+		{"contains_dot", "a.b", true},
 		{"contains_brace_open", "audit{core", true},
 		{"contains_brace_close", "audit}core", true},
 	}

--- a/runtime/audit/ledger/storetest/fuzz.go
+++ b/runtime/audit/ledger/storetest/fuzz.go
@@ -27,15 +27,21 @@ const fuzzTimePrecision = time.Microsecond
 //     Append → GetBySeq (via AssertEntryRoundTrip, reflect-driven so new Entry
 //     fields are covered automatically), and
 //   - the store-persisted Hash equals an INDEPENDENT canonical HMAC recomputed
-//     by referenceComputeHash (the external mirror, never Protocol.ComputeHash),
-//     so a silently dropped field in ComputeHash is caught.
+//     by ReferenceComputeHash (the external mirror, never Protocol.ComputeHash)
+//     over an independently reconstructed prev_hash, so a silently dropped
+//     field in ComputeHash or a mis-linked chain entry is caught.
+//
+// store and protocol MUST be same-source: protocol must be the very protocol
+// the store was constructed with, and it must use TestHMACKey() as its HMAC key
+// (i.e. built via NewTestProtocol) — the parity assertion recomputes the
+// reference digest with TestHMACKey() and protocol.Namespace(), so a mismatched
+// key or namespace would surface as a spurious parity failure, not a store bug.
 //
 // store and protocol are constructed once by the caller and reused across all
 // fuzz iterations — PG cannot afford a fresh migrated database per iteration.
 // The chain therefore grows unbounded over a long run (every accepted Append
 // adds an entry); bound it with -fuzztime rather than expecting per-iteration
-// reset.
-// The same exported helper is wired into both the MemStore fuzz
+// reset. The same exported helper is wired into both the MemStore fuzz
 // (suite_test.go) and the PG fuzz (adapters/postgres, integration tag) with a
 // shared seed corpus, so mem-vs-PG round-trip + HMAC parity is exercised in
 // fuzz form: both backends must satisfy the same independent reference.
@@ -89,10 +95,13 @@ func RunEntryRoundTripFuzz(f *testing.F, store ledger.Store, protocol *ledger.Pr
 
 // assertEntryRoundTripParity appends src, and on a successful (non-rejected)
 // Append asserts the persisted entry round-trips byte-for-byte and its Hash
-// matches the independent reference HMAC. ErrValidationFailed (payload is not a
-// JSON object/null) and ErrAuditLedgerAlreadyExists (duplicate EventID
-// fingerprint) are legitimate protocol rejections, not store defects, and are
-// skipped.
+// matches the independent reference HMAC.
+//
+// Only ErrValidationFailed (payload is not a JSON object/null) and
+// ErrAuditLedgerAlreadyExists (duplicate EventID fingerprint) are legitimate
+// protocol rejections to skip. Every other error — any other errcode, or a
+// non-errcode error such as a PG infrastructure failure — is a t.Fatalf, so an
+// infra fault can never be silently mistaken for "covered".
 func assertEntryRoundTripParity(t *testing.T, store ledger.Store, protocol *ledger.Protocol, src *ledger.Entry) {
 	t.Helper()
 	ctx := context.Background()
@@ -119,7 +128,22 @@ func assertEntryRoundTripParity(t *testing.T, store ledger.Store, protocol *ledg
 
 	AssertEntryRoundTrip(t, src, got)
 
-	want := referenceComputeHash(TestHMACKey(), protocol.Namespace(), got.PrevHash, got)
+	// Reconstruct the chain link independently rather than trusting the store's
+	// own got.PrevHash: the previous entry's persisted Hash (already parity-
+	// verified in an earlier iteration) is the canonical prev_hash. Feeding the
+	// store's got.PrevHash back into the reference would let a store that links
+	// to the wrong predecessor stay self-consistent and pass. seq==1 is the
+	// chain root (prev_hash = "").
+	prevHash := ""
+	if src.SeqNo > 1 {
+		prev, perr := store.GetBySeq(ctx, src.SeqNo-1)
+		if perr != nil {
+			t.Fatalf("GetBySeq(%d) for chain link: %v", src.SeqNo-1, perr)
+		}
+		prevHash = prev.Hash
+	}
+
+	want := ReferenceComputeHash(t, TestHMACKey(), protocol.Namespace(), prevHash, got)
 	if got.Hash != want {
 		t.Errorf("HMAC parity broken under fuzz:\n  store=%s\n  ref  =%s", got.Hash, want)
 	}

--- a/runtime/audit/ledger/storetest/fuzz.go
+++ b/runtime/audit/ledger/storetest/fuzz.go
@@ -1,0 +1,178 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/audit/ledger"
+)
+
+// fuzzTimePrecision is the timestamp granularity the round-trip fuzz normalises
+// to. PostgreSQL timestamptz stores microseconds; nanosecond-granular fuzzed
+// timestamps would survive on MemStore but truncate on PG, breaking both the
+// byte-for-byte field round-trip (time.Equal) and the HMAC parity (the digest
+// signs *UnixNano). Truncating fuzz inputs to microseconds keeps the input
+// inside the precision both backends can represent identically.
+const fuzzTimePrecision = time.Microsecond
+
+// RunEntryRoundTripFuzz is the property-based complement to the example-based
+// Run suite: it generates random 12-field [ledger.Entry] values plus a binary
+// payload corpus and asserts, for every accepted Append, that
+//
+//   - every caller-supplied field round-trips byte-for-byte through
+//     Append → GetBySeq (via AssertEntryRoundTrip, reflect-driven so new Entry
+//     fields are covered automatically), and
+//   - the store-persisted Hash equals an INDEPENDENT canonical HMAC recomputed
+//     by referenceComputeHash (the external mirror, never Protocol.ComputeHash),
+//     so a silently dropped field in ComputeHash is caught.
+//
+// store and protocol are constructed once by the caller and reused across all
+// fuzz iterations — PG cannot afford a fresh migrated database per iteration.
+// The same exported helper is wired into both the MemStore fuzz
+// (suite_test.go) and the PG fuzz (adapters/postgres, integration tag) with a
+// shared seed corpus, so mem-vs-PG round-trip + HMAC parity is exercised in
+// fuzz form: both backends must satisfy the same independent reference.
+//
+// The HMAC canonical-input invariant itself is statically frozen Hard by
+// archtest AUDIT-HASH-INPUT-FROZEN-01 (sealed auditHashInput + locked hmac.New
+// callsite); this fuzz adds the runtime behavior that a static archtest cannot
+// express — µs precision handling, payload binary safety, and namespace domain
+// separation under arbitrary inputs.
+func RunEntryRoundTripFuzz(f *testing.F, store ledger.Store, protocol *ledger.Protocol) {
+	if store == nil {
+		f.Fatal("storetest.RunEntryRoundTripFuzz: store must not be nil")
+	}
+	if protocol == nil {
+		f.Fatal("storetest.RunEntryRoundTripFuzz: protocol must not be nil")
+	}
+	seedEntryRoundTripCorpus(f)
+
+	f.Fuzz(func(t *testing.T,
+		eventID, eventType, actorID, subjectID, sessionID, tenantID, correlationID string,
+		occNano, tsNano int64, payload []byte,
+	) {
+		// Restrict string fields to the domain both backends can store
+		// identically: PostgreSQL text columns reject NUL (U+0000) and
+		// non-UTF-8 bytes, while a Go string (MemStore) accepts them. Inputs
+		// outside that shared domain are not a store bug — skip them so the
+		// parity assertion only fires on values both stores can represent.
+		// Arbitrary binary content is exercised through the BYTEA Payload
+		// (within valid-JSON-object framing), not the text identity fields.
+		for _, s := range []string{eventID, eventType, actorID, subjectID, sessionID, tenantID, correlationID} {
+			if !pgRepresentableString(s) {
+				return
+			}
+		}
+
+		src := &ledger.Entry{
+			EventID:       eventID,
+			EventType:     eventType,
+			ActorID:       actorID,
+			SubjectID:     subjectID,
+			SessionID:     sessionID,
+			TenantID:      tenantID,
+			CorrelationID: correlationID,
+			OccurredAt:    time.Unix(0, occNano).UTC().Truncate(fuzzTimePrecision),
+			Timestamp:     time.Unix(0, tsNano).UTC().Truncate(fuzzTimePrecision),
+			Payload:       payload,
+		}
+		assertEntryRoundTripParity(t, store, protocol, src)
+	})
+}
+
+// assertEntryRoundTripParity appends src, and on a successful (non-rejected)
+// Append asserts the persisted entry round-trips byte-for-byte and its Hash
+// matches the independent reference HMAC. ErrValidationFailed (payload is not a
+// JSON object/null) and ErrAuditLedgerAlreadyExists (duplicate EventID
+// fingerprint) are legitimate protocol rejections, not store defects, and are
+// skipped.
+func assertEntryRoundTripParity(t *testing.T, store ledger.Store, protocol *ledger.Protocol, src *ledger.Entry) {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := store.Append(ctx, src); err != nil {
+		var ec *errcode.Error
+		if errors.As(err, &ec) &&
+			(ec.Code == errcode.ErrValidationFailed || ec.Code == errcode.ErrAuditLedgerAlreadyExists) {
+			return
+		}
+		t.Fatalf("Append: %v", err)
+	}
+
+	tail, err := store.Tail(ctx)
+	if err != nil {
+		t.Fatalf("Tail: %v", err)
+	}
+	got, err := store.GetBySeq(ctx, tail.SeqNo)
+	if err != nil {
+		t.Fatalf("GetBySeq(%d): %v", tail.SeqNo, err)
+	}
+
+	AssertEntryRoundTrip(t, src, got)
+
+	want := referenceComputeHash(TestHMACKey(), protocol.Namespace(), got.PrevHash, got)
+	if got.Hash != want {
+		t.Errorf("HMAC parity broken under fuzz:\n  store=%s\n  ref  =%s", got.Hash, want)
+	}
+}
+
+// pgRepresentableString reports whether s can be stored verbatim in a
+// PostgreSQL text column: valid UTF-8 with no NUL byte. MemStore accepts any
+// Go string, so this is the narrower of the two backends and defines the
+// shared parity domain for the identity fields.
+func pgRepresentableString(s string) bool {
+	if !utf8.ValidString(s) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// seedEntryRoundTripCorpus adds the issue #1249 payload corpus and a few field
+// permutations as fuzz seeds. Timestamps derive from the suite epochAnchor +
+// principalOccurredAtSkew (no new time literals; TEST-TIME-LITERAL-01). Every
+// payload is a valid JSON object/null so the seed survives validatePayloadJSON;
+// the interesting binary content (pipe byte, Unicode boundary, escaped NUL,
+// non-alphabetical multi-key) lives inside JSON string values, which is the
+// only shape a strict-JSON-object payload can carry.
+func seedEntryRoundTripCorpus(f *testing.F) {
+	tsNano := epochAnchor.UnixNano()
+	occNano := epochAnchor.Add(principalOccurredAtSkew).UnixNano()
+
+	add := func(eventID string, payload string) {
+		f.Add(
+			eventID, "audit.test", "actor-1", "subject-1", "session-1", "tenant-1", "corr-1",
+			occNano, tsNano, []byte(payload),
+		)
+	}
+
+	add("seed-empty-object", `{}`)
+	add("seed-null", `null`)
+	add("seed-empty-bytes", ``)
+	add("seed-pipe-byte", `{"k":"a|b|c"}`)        // pipe byte (legacy HMAC delimiter)
+	add("seed-unicode", `{"k":"日本語"}`)            // multi-byte UTF-8 boundary
+	add("seed-emoji", `{"k":"😀🔒"}`)               // surrogate-range / 4-byte runes
+	add("seed-escaped-nul", `{"k":"a\u0000b"}`)   // NUL byte as JSON escape (raw 0x00 is invalid JSON)
+	add("seed-multikey", `{"b":1,"a":2,"c":"x"}`) // non-alphabetical multi-key (A-01 guard)
+	add("seed-nested", `{"x":{"y":[1,2,3]},"z":true}`)
+
+	// Field-permutation seeds: distinct values across every identity field so
+	// the fuzzer starts from a corpus that would surface a field-swap bug
+	// (e.g. SubjectID/TenantID crossed) through AssertEntryRoundTrip.
+	f.Add(
+		"seed-perm-a", "user.login", "impersonator", "end-user", "sess-42", "tenant-alpha", "corr-xyz",
+		occNano, tsNano, []byte(`{"action":"login"}`),
+	)
+	f.Add(
+		"e", "t", "a", "s", "se", "te", "c",
+		occNano, tsNano, []byte(`{}`),
+	)
+}

--- a/runtime/audit/ledger/storetest/fuzz.go
+++ b/runtime/audit/ledger/storetest/fuzz.go
@@ -32,6 +32,9 @@ const fuzzTimePrecision = time.Microsecond
 //
 // store and protocol are constructed once by the caller and reused across all
 // fuzz iterations — PG cannot afford a fresh migrated database per iteration.
+// The chain therefore grows unbounded over a long run (every accepted Append
+// adds an entry); bound it with -fuzztime rather than expecting per-iteration
+// reset.
 // The same exported helper is wired into both the MemStore fuzz
 // (suite_test.go) and the PG fuzz (adapters/postgres, integration tag) with a
 // shared seed corpus, so mem-vs-PG round-trip + HMAC parity is exercised in
@@ -103,13 +106,15 @@ func assertEntryRoundTripParity(t *testing.T, store ledger.Store, protocol *ledg
 		t.Fatalf("Append: %v", err)
 	}
 
-	tail, err := store.Tail(ctx)
+	// Append writes the assigned SeqNo back onto src (both MemStore and the PG
+	// store do this), so the read-back targets the exact sequence number this
+	// call produced — no reliance on Tail pointing at our entry, hence no
+	// assumption about iteration ordering. AssertEntryRoundTrip skips the
+	// store-assigned fields (SeqNo/ID/PrevHash/Hash), so populating src here is
+	// harmless to the field comparison.
+	got, err := store.GetBySeq(ctx, src.SeqNo)
 	if err != nil {
-		t.Fatalf("Tail: %v", err)
-	}
-	got, err := store.GetBySeq(ctx, tail.SeqNo)
-	if err != nil {
-		t.Fatalf("GetBySeq(%d): %v", tail.SeqNo, err)
+		t.Fatalf("GetBySeq(%d): %v", src.SeqNo, err)
 	}
 
 	AssertEntryRoundTrip(t, src, got)

--- a/runtime/audit/ledger/storetest/fuzz_internal_test.go
+++ b/runtime/audit/ledger/storetest/fuzz_internal_test.go
@@ -45,6 +45,9 @@ func namespaceLegalSet(s string) bool {
 //     Protocol.ComputeHash output (proven by Run's Protocol_HashParity /
 //     PrincipalFields_RoundTrip on both backends), this transitively guarantees
 //     cross-store HMAC parity across the whole namespace set.
+//
+// Lives in package storetest (white-box) rather than runtime/audit/ledger so it
+// can reuse the independent HMAC mirror (referenceComputeHash) and TestHMACKey.
 func FuzzNamespaceID(f *testing.F) {
 	// Legal seeds.
 	for _, s := range []string{"auditcore", "bootstrap", "_runtime", "a", strings.Repeat("a", namespaceMaxLen)} {
@@ -75,8 +78,9 @@ func FuzzNamespaceID(f *testing.F) {
 		}
 
 		// HMAC namespace domain separation: ComputeHash must match the
-		// independent reference for this namespace.
-		key := TestHMACKey()
+		// independent reference for this namespace. NewProtocol zeroes the key
+		// slice it receives, so the reference computation gets its own fresh
+		// TestHMACKey() copy (same deterministic bytes).
 		p, perr := ledger.NewProtocol(
 			ns, TestHMACKey(),
 			ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
@@ -87,7 +91,7 @@ func FuzzNamespaceID(f *testing.F) {
 		}
 		e := NewEntryFixture(t, "ns-fuzz", "", "", epochAnchor)
 		got := p.ComputeHash("", e)
-		want := referenceComputeHash(key, ns, "", e)
+		want := referenceComputeHash(TestHMACKey(), ns, "", e)
 		if got != want {
 			t.Errorf("namespace %q HMAC parity broken:\n  ComputeHash=%s\n  reference  =%s", s, got, want)
 		}

--- a/runtime/audit/ledger/storetest/fuzz_internal_test.go
+++ b/runtime/audit/ledger/storetest/fuzz_internal_test.go
@@ -1,0 +1,95 @@
+package storetest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/runtime/audit/ledger"
+)
+
+// namespaceMaxLen mirrors the unexported ledger.maxNamespaceIDLen. Like
+// referenceHashInput mirrors auditHashInput, this independent copy lets the
+// fuzz pin the documented contract without importing the production constant;
+// drift surfaces as a fuzz failure here.
+const namespaceMaxLen = 48
+
+// namespaceLegalSet reports whether s is in the documented NamespaceID legal
+// set: non-empty, length ≤ 48, every byte in [a-z_]. This is the contract the
+// fuzz holds ledger.NamespaceID.Validate to — independent of Validate's own
+// implementation.
+func namespaceLegalSet(s string) bool {
+	if s == "" || len(s) > namespaceMaxLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != '_' && (c < 'a' || c > 'z') {
+			return false
+		}
+	}
+	return true
+}
+
+// FuzzNamespaceID exercises the full NamespaceID legal set ([a-z_], ≤48) on two
+// orthogonal axes, both pure (no store, so the namespace can be enumerated
+// freely):
+//
+//   - Validation contract: ParseNamespaceID accepts s iff namespaceLegalSet(s),
+//     and an accepted value round-trips string(ns) == s. This pins the tightened
+//     [a-z_]-only contract (issue #1249) and guards against over- or
+//     under-rejection.
+//   - HMAC domain separation: for every accepted namespace, the production
+//     Protocol.ComputeHash agrees byte-for-byte with the independent
+//     referenceComputeHash mirror over the same entry. The namespace is the
+//     first signed field (ADR-1042 §A); since both MemStore and PG persist
+//     Protocol.ComputeHash output (proven by Run's Protocol_HashParity /
+//     PrincipalFields_RoundTrip on both backends), this transitively guarantees
+//     cross-store HMAC parity across the whole namespace set.
+func FuzzNamespaceID(f *testing.F) {
+	// Legal seeds.
+	for _, s := range []string{"auditcore", "bootstrap", "_runtime", "a", strings.Repeat("a", namespaceMaxLen)} {
+		f.Add(s)
+	}
+	// Illegal seeds (each violates exactly one rule).
+	illegal := []string{
+		"", "AuditCore", "audit:core", "audit{core", "audit}core",
+		"audit-core", "audit1core", "a.b", "-audit",
+		strings.Repeat("a", namespaceMaxLen+1),
+	}
+	for _, s := range illegal {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		ns, err := ledger.ParseNamespaceID(s)
+		legal := namespaceLegalSet(s)
+
+		if (err == nil) != legal {
+			t.Fatalf("ParseNamespaceID(%q): accepted=%v, want legal=%v", s, err == nil, legal)
+		}
+		if err != nil {
+			return
+		}
+		if string(ns) != s {
+			t.Fatalf("ParseNamespaceID(%q): round-trip changed value to %q", s, string(ns))
+		}
+
+		// HMAC namespace domain separation: ComputeHash must match the
+		// independent reference for this namespace.
+		key := TestHMACKey()
+		p, perr := ledger.NewProtocol(
+			ns, TestHMACKey(),
+			ledger.WithRestartRecovery(ledger.RestartRecoveryStrictTailVerify{}),
+			ledger.WithIdempotency(ledger.IdempotencyContentFingerprint{}),
+		)
+		if perr != nil {
+			t.Fatalf("NewProtocol(ns=%q): %v", s, perr)
+		}
+		e := NewEntryFixture(t, "ns-fuzz", "", "", epochAnchor)
+		got := p.ComputeHash("", e)
+		want := referenceComputeHash(key, ns, "", e)
+		if got != want {
+			t.Errorf("namespace %q HMAC parity broken:\n  ComputeHash=%s\n  reference  =%s", s, got, want)
+		}
+	})
+}

--- a/runtime/audit/ledger/storetest/fuzz_internal_test.go
+++ b/runtime/audit/ledger/storetest/fuzz_internal_test.go
@@ -49,8 +49,10 @@ func namespaceLegalSet(s string) bool {
 // Lives in package storetest (white-box) rather than runtime/audit/ledger so it
 // can reuse the independent HMAC mirror (referenceComputeHash) and TestHMACKey.
 func FuzzNamespaceID(f *testing.F) {
-	// Legal seeds.
-	for _, s := range []string{"auditcore", "bootstrap", "_runtime", "a", strings.Repeat("a", namespaceMaxLen)} {
+	// Legal seeds. "_test" exercises the leading-underscore case without
+	// borrowing "_runtime", which carries an unrelated framework-sentinel
+	// meaning (HTTP metrics cell / Redis namespace) and would mislead readers.
+	for _, s := range []string{"auditcore", "bootstrap", "_test", "a", strings.Repeat("a", namespaceMaxLen)} {
 		f.Add(s)
 	}
 	// Illegal seeds (each violates exactly one rule).
@@ -91,7 +93,7 @@ func FuzzNamespaceID(f *testing.F) {
 		}
 		e := NewEntryFixture(t, "ns-fuzz", "", "", epochAnchor)
 		got := p.ComputeHash("", e)
-		want := referenceComputeHash(TestHMACKey(), ns, "", e)
+		want := ReferenceComputeHash(t, TestHMACKey(), ns, "", e)
 		if got != want {
 			t.Errorf("namespace %q HMAC parity broken:\n  ComputeHash=%s\n  reference  =%s", s, got, want)
 		}

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -158,7 +158,10 @@ func TestHMACKey() []byte {
 // This call routes through ledger.NewProtocol; the archtest
 // AUDIT-LEDGER-PROTOCOL-COMPOSITION-ROOT-01 allowlist must include
 // runtime/audit/ledger/storetest/ for this to compile-link cleanly.
-func NewTestProtocol(t *testing.T) *ledger.Protocol {
+//
+// Accepts testing.TB (not *testing.T) so fuzz targets can construct the
+// protocol in their setup phase, where only a *testing.F is in scope.
+func NewTestProtocol(t testing.TB) *ledger.Protocol {
 	t.Helper()
 	key := TestHMACKey()
 	ns, err := ledger.ParseNamespaceID("auditcore")

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -141,10 +141,14 @@ func EpochAnchor() time.Time { return epochAnchor }
 
 // TestHMACKey returns the deterministic 32-byte HMAC key NewTestProtocol uses.
 // Exposed so cross-implementation parity tests (RunPrincipalFieldsRoundTrip)
-// can recompute the canonical HMAC byte-for-byte via referenceComputeHash
+// can recompute the canonical HMAC byte-for-byte via ReferenceComputeHash
 // without going through Protocol.ComputeHash. The returned slice is a fresh
 // copy each call so callers may zero or mutate it (e.g. before passing into
 // WithChainHMAC, which itself wipes the input slice after a defensive copy).
+//
+// TEST ONLY. This is a fixed, public, low-entropy key (bytes 1..32) for
+// deterministic test parity — it provides no secrecy and must never be used to
+// seal a production audit chain.
 func TestHMACKey() []byte {
 	key := make([]byte, 32)
 	for i := range key {
@@ -947,12 +951,21 @@ type referenceHashInput struct {
 	Payload            []byte `json:"payload"`
 }
 
-// referenceComputeHash recomputes the canonical HMAC for an Entry without
-// touching Protocol.ComputeHash. Callers supply the HMAC key, the namespace,
-// and the expected prev_hash; the function marshals the mirror struct and
-// returns the hex digest. The namespace is the first signed field, mirroring
-// the production cross-namespace HMAC domain separation (ADR-1042 §A).
-func referenceComputeHash(key []byte, ns ledger.NamespaceID, prevHash string, e *ledger.Entry) string {
+// ReferenceComputeHash recomputes the canonical HMAC for an Entry without
+// touching Protocol.ComputeHash, serving as the single independent oracle for
+// every audit-ledger hash-parity test (both the storetest suite and the
+// ledger-package white-box tests call it — there is no second copy). Callers
+// supply the HMAC key, the namespace, and the expected prev_hash; the function
+// marshals the mirror struct and returns the hex digest. The namespace is the
+// first signed field, mirroring the production cross-namespace HMAC domain
+// separation (ADR-1042 §A).
+//
+// The marshal cannot fail for referenceHashInput (only string/int64/[]byte
+// fields), but the error is surfaced via t.Fatalf rather than discarded — the
+// project forbids silently dropping errors, and a future field of an
+// unmarshalable type must fail loudly.
+func ReferenceComputeHash(t testing.TB, key []byte, ns ledger.NamespaceID, prevHash string, e *ledger.Entry) string {
+	t.Helper()
 	in := referenceHashInput{
 		Namespace:          string(ns),
 		PrevHash:           prevHash,
@@ -967,7 +980,10 @@ func referenceComputeHash(key []byte, ns ledger.NamespaceID, prevHash string, e 
 		TimestampUnixNano:  e.Timestamp.UnixNano(),
 		Payload:            e.Payload,
 	}
-	msgBytes, _ := json.Marshal(in)
+	msgBytes, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("ReferenceComputeHash: marshal referenceHashInput: %v", err)
+	}
 	mac := hmac.New(sha256.New, key)
 	mac.Write(msgBytes)
 	return hex.EncodeToString(mac.Sum(nil))
@@ -1029,13 +1045,13 @@ func RunPrincipalFieldsRoundTrip(t *testing.T, factory Factory, protocol *ledger
 	AssertEntryRoundTrip(t, entry, got)
 
 	// HMAC parity: store-persisted Hash must equal an INDEPENDENT canonical
-	// HMAC over the loaded entry — recomputed via referenceComputeHash, which
+	// HMAC over the loaded entry — recomputed via ReferenceComputeHash, which
 	// marshals an external mirror struct (referenceHashInput) and never calls
 	// Protocol.ComputeHash. A regression that silently drops a field from
 	// ComputeHash (e.g. forgetting to wire SubjectID into auditHashInput)
 	// would still produce a self-consistent hash via protocol.ComputeHash;
 	// the independent reference catches it.
-	want := referenceComputeHash(TestHMACKey(), protocol.Namespace(), "", got)
+	want := ReferenceComputeHash(t, TestHMACKey(), protocol.Namespace(), "", got)
 	if got.Hash != want {
 		t.Errorf("Hash parity broken with populated Principal fields:\n  store=%s\n  ref  =%s",
 			got.Hash, want)

--- a/runtime/audit/ledger/storetest/suite_test.go
+++ b/runtime/audit/ledger/storetest/suite_test.go
@@ -26,3 +26,17 @@ func TestSuite_MemStore(t *testing.T) {
 
 	storetest.Run(t, factory, protocol)
 }
+
+// FuzzEntryRoundTrip runs the property-based Entry round-trip + HMAC parity
+// fuzz against the in-memory store. The store and protocol are built once and
+// reused across iterations; seed corpus + fuzz body live in
+// storetest.RunEntryRoundTripFuzz so the PG integration target shares them.
+func FuzzEntryRoundTrip(f *testing.F) {
+	protocol := storetest.NewTestProtocol(f)
+	fc := clockmock.New(storetest.EpochAnchor())
+	store, err := ledger.NewMemStore(protocol, fc)
+	if err != nil {
+		f.Fatalf("NewMemStore: %v", err)
+	}
+	storetest.RunEntryRoundTripFuzz(f, store, protocol)
+}


### PR DESCRIPTION
## Summary

audit-ledger `storetest` 升级为 property-based fuzzing（仓库首个 Go native fuzz target），让 mem vs PG 的 HMAC 字节 parity 在 fuzz 形态下持续验证。顺带收紧 `NamespaceID.Validate` 到文档声明的 `[a-z_]` 合法集（修 doc/impl gap）。

`Closes #1249`

### 改动
- **`RunEntryRoundTripFuzz`**（`storetest/fuzz.go`，exported plain-`.go` helper）— 随机 12 字段 Entry + payload binary corpus → `Append`+`GetBySeq`+`AssertEntryRoundTrip`（reflect 驱动，自动覆盖未来加字段）+ HMAC parity vs 独立 `referenceComputeHash`。store 构造一次跨 iteration 复用（PG 无法每 iter 重建迁移库）。
  - 同一 helper 接入 **mem**（`FuzzEntryRoundTrip`，suite_test.go）与 **PG**（`FuzzAuditLedgerStore_EntryRoundTrip`，integration tag）→ 两后端跑同 seed + 同独立 reference = 跨 store HMAC 字节 parity。
  - payload corpus：`{}` / `null` / 空 / pipe 字节 / Unicode boundary / emoji / escaped NUL(``) / 非字母序多键(A-01) / 嵌套；外加字段排列 seed。
- **`FuzzNamespaceID`**（`storetest/fuzz_internal_test.go`，纯函数无 store）— 钉收紧后的 `[a-z_]` 校验契约 + 全合法集上 `ComputeHash` vs reference 的 namespace 域分隔。
- **收紧 `NamespaceID.Validate`** 到 `非空 ∧ ≤48 ∧ 每字节[a-z_]`（删 first-char/uppercase/`:{}` 三分支 + `unicode` import）。命中真 chokepoint（`NewProtocol.Validate`）；3 个实际 namespace `auditcore`/`bootstrap`/`fixture` 全 `[a-z_]`。同步 `bootstrap_namespace.go` godoc（doc fanout）。

### 两个 parity 域归一（mem/PG 一致性必需）
- **时间**：fuzz 后 `Truncate(µs)` —— PG `timestamptz` 是 µs 精度，纳秒级会破坏 round-trip(`time.Equal`) 与 HMAC(`UnixNano`)。
- **标识串**：限 UTF-8 + 无 NUL —— PG text 列拒 NUL/非 UTF-8，mem `string` 接受。任意二进制走 BYTEA payload（valid-JSON 框内）。

### AI-robust 评级（honest）
- fuzz = **test discipline**，非 enforcement 机制，不评 Hard/Medium/Soft（同 skill smoke）。
- 唯一 enforcement 触碰 = `Validate` 收紧 = **Medium runtime guard**（`type NamespaceID string` 开放 newtype，Go 无法 type-seal）；与代码库现有评级一致，不新增 Soft。
- fuzz 验证的 HMAC canonical 不变式**本就 Hard**（`AUDIT-HASH-INPUT-FROZEN-01`）；fuzz 是 static archtest 表达不了的运行时补充（µs 精度 / payload 二进制安全 / namespace 域分隔），**不加冗余 archtest**。

## Implementation matrix
- **Contract**: `ledger.Store` (Append/GetBySeq/Tail round-trip + HMAC parity) / `ledger.NamespaceID.Validate`
- **Change**: 加 property-based fuzz；收紧 NamespaceID 合法集到 `[a-z_]`
- **Implementations**: [x] memstore  [x] PG  [ ] fake (n/a)
- **Conformance test**: `storetest.RunEntryRoundTripFuzz`（mem `FuzzEntryRoundTrip` + PG `FuzzAuditLedgerStore_EntryRoundTrip`）
- **Dependent contracts (governance scan)**: none（未导出类型 `auditHashInput` 不触发扇出；wire schema 未变）
- **NamespaceID 收紧载体（同步追溯，非 contract-fanout 强触发——校验收紧不在触发清单）**: `Validate` 实现（protocol.go）/ 表测试（protocol_test.go）/ godoc（protocol.go `NamespaceID` + bootstrap_namespace.go + bootstrap_namespace_test.go message）—— 4 处已在本 PR 内同步

`ref: golang/go src/testing/fuzz.go`（f.Add/f.Fuzz seed-corpus + skip 非法输入）
`ref: google/trillian storage/leafdata.go`（typed canonical HMAC input）

## Test plan
- [x] `go build ./...`
- [x] `go test ./runtime/audit/...`（含收紧后 Validate 表 + fuzz seed 语料）
- [x] `go vet -tags integration ./adapters/postgres/`（PG fuzz 编译）
- [x] `golangci-lint run ./runtime/audit/... ./adapters/postgres/...` → 0 issues
- [x] archtest 绿：AUDIT-HASH-INPUT-FROZEN-01 / AUDIT-LEDGER-PROTOCOL-COMPOSITION-ROOT-01 / AUDIT-NS-DISJOINT-01 / TEST-TIME-LITERAL-01
- [x] 手动 fuzz smoke（CI 不跑）：`FuzzEntryRoundTrip -fuzztime=25s`（670k execs）+ `FuzzNamespaceID -fuzztime=20s`（1.19M execs），无 crasher
- [ ] PG fuzz seed 语料 `go test -tags integration -run='FuzzAuditLedgerStore_EntryRoundTrip' ./adapters/postgres/`（需 DB，CI integration job 覆盖）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
