### PR TITLE
docs(analysis): archtest 独立化可行性分析（引擎抽离 + 293 条规则编目）

### DIFF
--- a/docs/analysis/archtest-spinout/01-extraction-manifest.md
+++ b/docs/analysis/archtest-spinout/01-extraction-manifest.md
@@ -1,0 +1,157 @@
+# 交付物 #1：archtest 引擎抽离清单（精确）
+
+> 目标：把 archtest 的**引擎层**抽成一个独立仓库 `archtest`（或 `go-archrules`），可被任意 Go 项目作为库依赖、用 `go test` 写自己的架构不变式。**规则层不搬**（理由见交付物 #3）。
+
+---
+
+## 1. 引擎 / 规则边界
+
+archtest 实际是两层叠在一起：
+
+| 层 | 内容 | 去向 |
+|----|------|------|
+| **引擎** | `tools/archtest/*.go`（非 `_test.go`）+ `internal/scanner` + `internal/typeseval` | ✅ 整体搬走 |
+| **引擎自检（meta-archtest）** | `pass_test.go` / `pass_funnel_test.go` / `scanner_framework_usage_test.go` / `golden_test.go` / `eval_predicate_centralization_test.go` / `production_loader_funnel_test.go` / `reflect_string_arg_test.go` / `taggroup_loop_no_runtyped_test.go` / `build_constraint_test.go` / `implements_funnel_test.go` / `testmain_test.go` | ✅ 搬走（验证引擎本身，与业务无关；见交付物 A 编目） |
+| **规则 + 规则自检** | 其余 ~170 个 `*_test.go` + `testdata/` | ❌ 留在 gocell |
+
+判定依据已用 `go list` 核实：引擎的**非测试代码零 gocell 业务包依赖**，第三方依赖只有 `golang.org/x/tools` 与 `golang.org/x/sync`（见 §4）。
+
+---
+
+## 2. 必搬文件清单（精确，含行数）
+
+### 2.1 façade 包 `tools/archtest/*.go`（公开 API，1259 行）
+
+| 文件 | 行 | 作用 | 搬迁处理 |
+|------|----|------|---------|
+| `pass.go` | 515 | `Pass` / `Run` / `RunTyped` / `RunTypedProduction` / `RunTypedDir` 驱动 | 原样 |
+| `resolve.go` | 194 | `ResolvePackageRef` / `ResolveMethodCall` / `EvaluateConstString` / build-tag helper re-export | 原样 |
+| `walk.go` | 117 | 泛型 AST 遍历 `EachInSubtree` / `EachInChildren` / `FindFirstChild` re-export | 原样 |
+| `fixture.go` | 113 | `RunTypedFixture`（加载独立 go.mod 夹具模块） | 原样 |
+| `golden.go` | 98 | `AssertGolden`（regenerate-and-diff 字节锁） | 原样 |
+| `scope.go` | 89 | `ModuleScope` / `DirsScope` / `ScopeOption` re-export | 原样 |
+| `doc.go` | 85 | 包文档 | **改写**：删 LAYER-*/GoCell 规则清单，改为通用引擎说明 |
+| `module_root.go` | 64 | `findModuleRoot`（向上找 `go.mod`） | 原样（已通用，见 §3） |
+| `content.go` | 31 | `LoadContentFiles` / `EachContentFile`（YAML/JSON 元数据扫描） | 原样 |
+| `passfunnel_inpkg_redfixture.go` | 34 | meta-archtest 的包内红夹具 | 搬走（属引擎自检） |
+| `warm.go` | 19 | 进程内 warmup（`SharedResolver` 预热） | 原样 |
+
+### 2.2 `internal/scanner`（AST 扫描原语，1408 行）
+
+`content.go`(92) `diagnostic.go`(80) `doc.go`(89) `eachnode.go`(356) `importban.go`(129) `literal.go`(86) `parse.go`(79) `receiver.go`(32) `scope.go`(357) `walk.go`(108) — **全部原样搬走**。
+
+### 2.3 `internal/typeseval`（go/types 求值层，838 行）
+
+`buildtag_predicate.go`(84) `buildtags_extract.go`(194) `buildtags.go`(72) `call_target.go`(89) `eachfile.go`(62) `production_resolver.go`(73) `receiver_type.go`(59) `skip.go`(41) `typeseval.go`(164) — **基本原样**，仅 `buildtags.go` 需参数化（见 §3）。
+
+**引擎核心总计 ≈ 3500 行非测试代码**（façade 1259 + scanner 1408 + typeseval 838）。配套引擎自检约 8000 行测试。
+
+---
+
+## 3. 必改的 repo 耦合点（逐处）
+
+引擎的全部 repo 耦合集中在 **3 处**，都是小修：
+
+### 耦合点 1 — `typeseval/buildtags.go::KnownNonDefaultTags()`（硬编码本仓 build tag）
+
+```
+24  return [][]string{
+25      nil,
+26      {"integration"}, {"e2e"}, {"e2e", "pg"}, {"examples_smoke"},
+30      {"integration", "otelcollector"}, {"integration_cluster"},
+```
+
+`FlatNonDefaultTags()` / `KnownNonDefaultTags()` 把 gocell 的 build tag 集写死。
+**改法**：提成构造参数或 `archtest.Config{ BuildTags [][]string }`，由调用方在 `TestMain` 注入；默认空集（`nil` 一项）。
+
+### 耦合点 2 — `typeseval/skip.go::IsGeneratedRelPath()`（硬编码 `generated/` 前缀）
+
+```
+40  return strings.HasPrefix(rel, "generated/")
+```
+
+代表"codegen 产物根目录"约定。
+**改法**：提成 `Config.GeneratedPrefix string`（默认 `"generated/"`，可空表示无 codegen）。`RunTypedProduction` 据此过滤。
+
+### 耦合点 3 — `scanner/scope.go` 默认跳过目录集
+
+```
+28  "vendor": {}, "testdata": {}, "generated": {}, ".git": {}, "node_modules": {}
+```
+
+这其实是**合理的通用默认**，唯一沾 repo 约定的是 `"generated"`。
+**改法**：与耦合点 2 合并到 `Config`，或保留默认 + 暴露 `ScopeOption` 覆盖。**优先级最低**，默认值即可用。
+
+> `module_root.go::findModuleRoot`（向上找 `go.mod`）**已经是通用实现**，无需改。`doc.go` 的包文档需重写（删 LAYER-01..10 / PGQUERY-01 等 GoCell 规则枚举）。
+
+---
+
+## 4. 新仓库 `go.mod`（外部依赖极少）
+
+`go list -deps` 核实，引擎真实第三方依赖只有两个家族：
+
+```
+require (
+    golang.org/x/tools  // go/packages, go/ast/inspector, gcexportdata, objectpath, typeutil
+    golang.org/x/sync   // singleflight, errgroup
+)
+```
+
+无需 pgx / prometheus / rabbitmq / yaml 等——之前 grep 看到的那些全部来自规则文件的字符串字面量或规则 import，不在引擎里。**这是引擎可独立的最强信号：依赖面干净到只剩 `x/tools` + `x/sync`。**
+
+---
+
+## 5. 抽离后的目录结构
+
+```
+archtest/                       (新 module: github.com/<you>/archtest)
+├── go.mod                      x/tools + x/sync
+├── archtest.go                 ← 原 pass.go（驱动）
+├── resolve.go walk.go scope.go fixture.go golden.go content.go warm.go module_root.go
+├── doc.go                      ← 重写为通用引擎文档
+├── config.go                   ← 新增：BuildTags / GeneratedPrefix / SkipDirs 注入点（吸收 §3 三处耦合）
+├── internal/
+│   ├── scanner/                ← 原样
+│   └── typeseval/              ← buildtags.go 改为读 Config
+└── meta_test.go ...            ← 引擎自检（编目 A 中标"meta-archtest"的那些）
+```
+
+调用方（你的项目）用法不变：
+
+```go
+// yourproject/arch/layering_test.go
+func TestLayering(t *testing.T) {
+    diags := archtest.Run(t, archtest.ModuleScope(root), func(p *archtest.Pass) []archtest.Diagnostic {
+        // ... 你自己的规则
+    })
+    archtest.Report(t, "MY-LAYER-01", diags)
+}
+```
+
+---
+
+## 6. 搬迁步骤（可执行）
+
+1. `git subtree split` 或手动 `cp` §2 清单文件到新 repo，保留 `internal/` 层级。
+2. 改 import 路径 `github.com/ghbvf/gocell/tools/archtest/internal/*` → `github.com/<you>/archtest/internal/*`（仅引擎内部互引，~10 处）。
+3. 落地 §3 三处耦合到 `config.go`；`buildtags.go` / `skip.go` 改读 Config。
+4. 重写 `doc.go`。
+5. `go mod tidy` → 应只拉到 `x/tools` + `x/sync`。
+6. `go test ./...` 跑引擎自检（meta-archtest）全绿即验证成功。
+7. （可选）gocell 侧反向依赖新库：删 `tools/archtest/internal/`，规则文件改 import 新 module——但**不建议**，见下。
+
+> ⚠️ 反向依赖的代价：gocell 的规则文件目前直接用 façade（`archtest.Run` 等），若新库的 `Config` 注入方式变了，183 个规则文件都要适配。若只是"给自己将来用"，**fork 出去单独演进**比"gocell 反依赖新库"更省事，二者不必同时做。
+
+---
+
+## 7. 工作量估算
+
+| 任务 | 量级 |
+|------|------|
+| 文件搬迁 + import 改写 | ~0.5 天 |
+| §3 三处耦合参数化 + `config.go` | ~0.5 天 |
+| `doc.go` 重写 + meta-archtest 跑通 | ~0.5 天 |
+| **引擎独立可用** | **~1.5 天** |
+| 重写规则（按需，每个新项目） | 不在此列，见交付物 #3 |
+
+**结论：引擎抽离是低风险、~1.5 天的活。真正的成本不在搬引擎，而在"引擎搬走后规则要重写"——而规则本就不该搬。**

--- a/docs/analysis/archtest-spinout/02-catalog-A-engine-meta-layering.md
+++ b/docs/analysis/archtest-spinout/02-catalog-A-engine-meta-layering.md
@@ -1,0 +1,94 @@
+# archtest 不变式编目 A — 引擎自检 / meta-archtest / 分层 import 规则
+
+本文件汇总 `tools/archtest/` 下与「引擎自检、meta-archtest、分层 import」主题相关的源文件中
+所有去重 INVARIANT ID，分析其评级、机制类型、gocell 耦合度与可移植性。
+
+覆盖源文件（共 19 个）：
+`archtest_test.go`, `pgquery_boundary_test.go`, `archtest_ci_shard_count_test.go`,
+`archtest_invariants_coverage_test.go`, `archtest_verify_coverage_test.go`,
+`helpers_test.go`, `testmain_test.go`, `pass_test.go`, `pass_funnel_test.go`,
+`eval_predicate_centralization_test.go`, `implements_funnel_test.go`,
+`scanner_framework_usage_test.go`, `reflect_string_arg_test.go`, `golden_test.go`,
+`production_loader_funnel_test.go`, `taggroup_loop_no_runtyped_test.go`,
+`build_constraint_test.go`, `inventory_anchor_required_test.go`,
+`kernel_internal_dag_test.go`
+
+**本文件 30 条 | Hard 12 / Medium 17 / Soft 0 (推断 1) | 通用 11 / 半通用 12 / 专属 7**
+
+---
+
+### 批次 1 — 分层 import 规则（LAYER-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途(≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| LAYER-05 | Medium (推断) | import-ban | 禁止 cells 跨 Cell 直接 import 对方的 internal/ 包 | kernel/depgraph, cells/ | 半通用 |
+| LAYER-05T | Medium (推断) | import-ban | LAYER-05 的传递闭包变体，拦截 utility 中介绕行 | kernel/depgraph, cells/ | 半通用 |
+| LAYER-06 | Medium (推断) | import-ban | cell 自有公开子包仅限本 cell / cmd / examples 引用 | kernel/depgraph, cells/ | 半通用 |
+| LAYER-06T | Medium (推断) | import-ban | LAYER-06 传递闭包变体，捕获多跳绕行 | kernel/depgraph, cells/ | 半通用 |
+| LAYER-07 | Medium (推断) | import-ban | 禁止 cells/ 直接 import runtime/http/router | cells/, runtime/http/router | 半通用 |
+| LAYER-08 | Medium | type-system-seal | 禁止任何包重新声明 HTTPRegistrar 类型（已删除旧接口） | — | 半通用 |
+| LAYER-09 | Medium (推断) | import-ban | 禁止 cells/X 直接 import cells/Y/events 跨 Cell 事件包 | kernel/depgraph, cells/ | 半通用 |
+| LAYER-09T | Medium (推断) | import-ban | LAYER-09 传递闭包变体 | kernel/depgraph, cells/ | 半通用 |
+| LAYER-10 | Medium | callsite-allowlist | cells root 包导出 API 不得暴露 adapter/driver 具体类型 | kernel/depgraph, cells/, adapters/ | 半通用 |
+
+> 注：LAYER-01..04 由 `.golangci.yml` depguard 执行，不在本批次。LAYER-* 规则均无显式 AI-robust 标注，依机制（depgraph 图 + typed 包扫描）推断为 Medium。
+
+---
+
+### 批次 2 — 引擎自检 / meta-archtest
+
+| INVARIANT ID | 评级 | 机制类型 | 用途(≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01 | Medium | metadata/yaml-derive | 守卫 CI yaml 中 verify-archtest 步骤必须显式设 SHARD_COUNT=16 | — | 通用 |
+| ARCHTEST-INVARIANTS-COVERAGE-01 | Medium | AST-pattern | verify-archtest-invariants.sh 中 -run 正则引用的 Test 函数必须在 AST 中存在 | — | 通用 |
+| ARCHTEST-VERIFY-COVERAGE-01 | Medium | AST-pattern | verify-archtest.sh 发现集与 AST 扫描集一致；shard 分区不重叠不遗漏 | — | 通用 |
+| ARCHTEST-HELPERS-01 | Medium (推断) | conformance-test | 共享测试 helper（类型工具、文件枚举）的单元覆盖锚点 | kernel/metadata | 半通用 |
+| ARCHTEST-TESTMAIN-01 | Medium (推断) | conformance-test | TestMain 预热 SharedResolver 缓存，防止 OOM 及 shard 超时 | — | 通用 |
+| ARCHTEST-PASS-DRIVER-UNIT-01 | Medium (推断) | conformance-test | archtest.Pass 驱动 API（Run/RunTyped/RunTypedDir 等）单元覆盖 | — | 通用 |
+
+---
+
+### 批次 3 — Pass Funnel 规则（PASS-FUNNEL-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途(≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| PASS-FUNNEL-EACHFILE-01 | Medium | callsite-allowlist | 禁止 archtest *_test.go 直接调用 scanner.EachFile，必须走 archtest.Run | — | 通用 |
+| PASS-FUNNEL-LOADPACKAGES-01 | Medium | callsite-allowlist | 禁止 archtest *_test.go 直接调用 typeseval 加载符号，必须走 Pass 驱动 | — | 通用 |
+| PASS-FUNNEL-PACKAGES-IMPORT-01 | Medium | callsite-allowlist | 禁止 archtest *_test.go 直接 import golang.org/x/tools/go/packages | — | 通用 |
+| PASS-FUNNEL-RESOLVE-01 | Medium | callsite-allowlist | 禁止直接调用 typeseval 解析辅助函数，必须用 Pass facade 封装 | — | 通用 |
+| PASS-FUNNEL-FIXTURE-TAG-01 | Hard | typed-marker-funnel | 禁止向 loader 传 archtest_fixture build tag 绕过 RunTypedFixture funnel | — | 通用 |
+
+---
+
+### 批次 4 — 内部工具约束
+
+| INVARIANT ID | 评级 | 机制类型 | 用途(≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01 | Hard | typed-marker-funnel | constraint.Expr.Eval 调用必须经 BuildContextPredicate 或 all-false sentinel | — | 通用 |
+| TYPESUTIL-IMPLEMENTS-FUNNEL-01 | Hard | typed-marker-funnel | go/types.Implements 仅允许在 typesutil 单一 funnel 文件中调用 | — | 通用 |
+| SCANNER-FRAMEWORK-USAGE-01 | Hard↓/Medium↑ | callsite-allowlist | archtest *_test.go 禁止绕过 scanner 框架直接使用 ast/fs/inspector 遍历 | — | 通用 |
+| SCANNER-FRAMEWORK-USAGE-02 | Hard↓/Medium↑ | typed-marker-funnel | 禁止在 EachInChildren 上手写 closure+done 哨兵，必须用 FindFirstChild | — | 通用 |
+| REFLECT-STRING-ARG-SCANNER-01 | Medium | AST-pattern | reflect.Value.FieldByName/MethodByName 字符串参数扫描共享辅助自检 | — | 通用 |
+| GOLDEN-HELPER-UNIT-01 | Medium (推断) | conformance-test | AssertGolden 与 scanner.Canonical 排序去重逻辑的单元覆盖 | — | 通用 |
+| PRODUCTION-LOADER-FUNNEL-01 | Hard | typed-marker-funnel | 禁止 archtest *_test.go 用 ./... 直调原始 loader，必须经 ProductionResolver | — | 通用 |
+| TAGGROUP-LOOP-FORBIDS-RUNTYPED-01 | Hard | typed-marker-funnel | 禁止在 KnownNonDefaultTags() range 循环体内调用 RunTyped（防 OOM shard） | — | 通用 |
+
+---
+
+### 批次 5 — 构建约束 / 库边界 / 锚点元规则
+
+| INVARIANT ID | 评级 | 机制类型 | 用途(≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| BUILD-CONSTRAINT-INTEGRATION-TAG-01 | Medium | AST-pattern | *_integration_test.go 必须携带正确 //go:build integration 约束 | — | 通用 |
+| INVENTORY-ANCHOR-REQUIRED-01 | Medium | AST-pattern | tools/archtest/*_test.go 每个文件头必须有 INVARIANT: 锚点 | — | 通用 |
+| INVENTORY-ANCHOR-VALID-ID-01 | Medium | AST-pattern | 所有 INVARIANT: <ID> 必须符合规范语法正则，防止拼写漂移 | — | 通用 |
+| PGQUERY-01 | Medium (推断) | import-ban | SQL Builder/keyset 辅助函数必须在 pkg/pgquery，pkg/query 只留通用分页 | pkg/query, pkg/pgquery | 专属 |
+| KERNEL-INTERNAL-DAG-01 | Medium | callsite-allowlist | kernel 内部子模块跨 owner 依赖必须与 allowedKernelEdges 精确匹配 | kernel/depgraph, kernel/* | 专属 |
+
+---
+
+## 可移植性说明
+
+- **通用**：规则概念（Pass funnel、分片脚本覆盖、build tag 约束、锚点格式）可直接迁移到任意 Go 项目，无需了解 GoCell 架构。
+- **半通用**：规则概念可迁移（分层 import 禁令、adapter 泄漏），但涉及 GoCell 专属层名（cells/kernel/adapters）或包路径，需适配替换。
+- **专属**：仅在 GoCell 架构语义（Cell/Slice 模型、kernel 内部 owner 拓扑、pgquery 迁移约定）下成立，搬到无关项目无意义。

--- a/docs/analysis/archtest-spinout/02-catalog-B-outbox-rmq-saga.md
+++ b/docs/analysis/archtest-spinout/02-catalog-B-outbox-rmq-saga.md
@@ -1,0 +1,126 @@
+# Archtest 不变式编目 B — Outbox / EventBus / RMQ / Saga / Relay / Subscription
+
+本文件覆盖主题：事件驱动与最终一致性约束（outbox 生命周期、RabbitMQ 频道/发布/停机、Saga 执行纪律、Relay 生命周期隔离、订阅身份语义、SafeID 封装、健康聚合、事件 DTO 命名规范）。
+
+来源文件（均位于 `tools/archtest/`）：
+`outbox_invariants_test.go`, `outboxtest_import_boundary_test.go`, `rmq_invariants_test.go`,
+`saga_journal_conformance_enrollment_test.go`, `saga_journal_holder_seal_test.go`,
+`saga_leader_gate_test.go`, `saga_step_run_outside_tx_test.go`, `relay_isolation_test.go`,
+`subscription_invariants_test.go`, `event_subscription_contractgen_coverage_test.go`,
+`safeid_funnel_test.go`, `aftercommit_pure_transient_test.go`,
+`visit_buffer_then_commit_test.go`, `l2_outbox_atomicity_coverage_test.go`,
+`health_aggregation_test.go`, `event_camelcase_invariants_test.go`
+
+**本文件 35 条 | Hard 18 / Medium 15 / Soft 2 | 通用 2 / 半通用 4 / 专属 29**
+
+> 计数说明：funnel 双向评级（如 `Hard↓/Medium↑`）按整体较低档计入 Medium；Soft 条均为子规则内遗留形态（B1 盲区逆向自检），不新引入。
+
+---
+
+### 批次 1 — Outbox 核心（OUTBOX-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| OUTBOX-LEASE-ID-CAS-01 | Medium（推断） | AST-pattern | 五条 outbox SQL 常量必须以 lease_id 做 CAS 防重，防止陈旧 worker 覆写新 owner 行 | adapters/postgres | 专属 |
+| OUTBOX-MARK-RETURNS-BOOL-01 | Medium（推断） | AST-pattern | relay*.go 调用 MarkPublished/MarkRetry/MarkDead 必须绑定 bool 返回，禁止 `_` 丢弃，防止 CAS 未命中被误计成功 | runtime/outbox, adapters/postgres | 专属 |
+| OUTBOX-METADATA-MAX-BYTES-01 | Medium（推断） | AST-pattern | outbox_writer.go 的 Write 和 encodeBatchEntry 方法必须引用 MaxMetadataBytes 常量，确保 metadata 写入有上限 | adapters/postgres, kernel/outbox | 专属 |
+| OUTBOX-PAYLOAD-SIZE-01 | Medium（推断） | AST-pattern | kernel/outbox.Entry.Validate 必须用 MaxPayloadBytes 做 `len(Payload) > MaxPayloadBytes` 比较，单纯声明常量不够 | kernel/outbox | 专属 |
+| OUTBOX-HANDLERESULT-NO-RECEIPT-FIELD-01 | Medium（推断） | reflect-field-freeze | HandleResult 结构体禁止声明 Receipt 字段，阻止 cell handler 写已废弃的 Settlement 路径 | kernel/outbox | 专属 |
+| OUTBOX-RELAY-LOST-METRIC-01 | Medium（推断） | AST-pattern | 含 A/B 子条：handleFailedEntry 必须绑定 Mark{Retry,Dead} 的 bool 返回；PollCycleResult 必须声明 Lost 字段，使 stale-lease 路径可观测 | runtime/outbox, kernel/outbox | 专属 |
+| OUTBOX-SERVICE-01 | Medium（推断） | AST-pattern | slice service.go 禁止对 txRunner == nil 做 nil 分支（SERVICE-01..05 联合测试） | cells/**/slices | 专属 |
+| OUTBOX-SERVICE-02 | Medium（推断） | AST-pattern | slice service.go 禁止直接调用 Publisher.Publish，必须走 outbox 事务路径 | cells/**/slices, kernel/outbox | 专属 |
+| OUTBOX-SERVICE-03 | Medium（推断） | import-ban | slice service.go 禁止 import runtime/outbox，保持 cell 层不依赖 runtime 层 | cells/**/slices, runtime/outbox | 专属 |
+| OUTBOX-SERVICE-04 | Medium（推断） | AST-pattern | slice service.go 禁止依赖 outbox.Publisher 或构造 DirectEmitter，mode 解析属于 Cell 边界 | cells/**/slices, kernel/outbox | 专属 |
+| OUTBOX-SERVICE-05 | Medium（推断） | AST-pattern | slice service.go 禁止定义 WithOutboxWriter option，服务层只允许 WithEmitter/WithTxManager | cells/**/slices, kernel/outbox | 专属 |
+| OUTBOX-TOPIC-FAILOPEN-01 | Medium（推断） | AST-pattern | 安全敏感 topic（session.*、user.*、role.*、audit.*、event.* 安全合约）禁止设置 FailurePolicyFailOpen，via go/types 常量折叠 | kernel/outbox | 专属 |
+
+---
+
+### 批次 2 — Outbox 结构冻结与工厂优先（OUTBOX-HANDLERESULT-*、OUTBOXTEST-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| OUTBOX-HANDLERESULT-FIELDS-FROZEN-01 | Medium（推断） | reflect-field-freeze | kernel/outbox.HandleResult 字段集冻结为 4 个（Disposition/Err/ProcessReason/SettlementObservers），新增须过 allowlist | kernel/outbox | 专属 |
+| OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01 | Medium（推断） | callsite-allowlist | 生产代码必须用 Ack/Requeue/Reject 工厂，禁止 HandleResult{...} 字面量构造（allowlist 限内核 plumbing），via go/types 类型感知扫描 | kernel/outbox | 专属 |
+| METADATA-LIMITS-SINGLE-SOURCE-01 | Medium（推断） | AST-pattern | MaxMetadataKeys/KeyLen/ValueLen/TotalSize 仅允许在 kernel/metautil 声明一次，禁止其他包重复定义 | kernel/metautil | 半通用 |
+| OUTBOXTEST-CLOSE-VIA-BUDGET-01 | Medium | callsite-allowlist | outboxtest 包内所有 Subscriber.Close 调用必须位于 closeWithBudget 函数内，防止裸 Close 泄漏 goroutine；via ResolveMethodCall 类型感知 | kernel/outbox/outboxtest | 专属 |
+| OUTBOXTEST-IMPORT-BOUNDARY-01 | Hard（推断） | import-ban | 生产 Go 文件禁止 import kernel/outbox/outboxtest，防止通过 Recorder.CellEmitter() 绕过 sealed emitter funnel | kernel/outbox/outboxtest | 专属 |
+
+---
+
+### 批次 3 — RabbitMQ 频道与连接（RMQ-CHANNEL-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| RMQ-CHANNEL-DESTRUCTION-VIA-CONN-01 | Hard（推断） | type-system-seal | adapters/rabbitmq 内 AMQPChannel.Close() 必须通过 Connection.CloseEphemeralChannel，防止绕过 inUseChannels 计数；via go/types.Implements 类型感知，命名免疫 | adapters/rabbitmq | 专属 |
+| RMQ-CHANNEL-MAX-PER-CONN-01 | Medium（推断） | AST-pattern | 含 A/B/C 子条：Config.MaxChannelsPerConn 字段必须存在；setDefaults 必须用 `<= 0` 条件赋默认值常量；AcquireChannel 必须引用 inUseChannels 计数器 | adapters/rabbitmq | 专属 |
+
+---
+
+### 批次 4 — RabbitMQ 发布与停机（RMQ-PUBLISHER-*、RMQ-STOPINTAKE-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| RMQ-PUBLISHER-FAILURE-HANDLING-01 | Medium（推断） | AST-pattern | 含 A/B/C/D 子条：Publish 必须引用 ErrAdapterAMQPNack；至少 3 次 slog.Warn；调用 RecordPublishFailure；每个非成功 return 分支必须含 RecordPublishFailure | adapters/rabbitmq | 专属 |
+| RMQ-PUBLISHER-RELEASES-CHANNEL-01 | Medium（推断） | AST-pattern | Publisher.Publish 必须将 AcquireChannel 与 defer CloseEphemeralChannel/ReleaseChannel 配对，防止 inUseChannels 泄漏 | adapters/rabbitmq | 专属 |
+| RMQ-STOPINTAKE-INFLIGHT-WAIT-01 | Medium（推断） | AST-pattern | 含 A/B 子条：StopIntake 必须等待 in-flight 投递（inflightCount poll）；drainRemaining 禁止 `case <-ctx.Done()` 且必须使用 context.WithoutCancel | adapters/rabbitmq | 专属 |
+
+---
+
+### 批次 5 — Saga 执行纪律（SAGA-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01 | Medium | conformance-test | 每个实现 SagaJournal 接口的类型必须出现在合规测试调用点，防止新实现逃过测试覆盖 | kernel/saga | 专属 |
+| SAGA-JOURNAL-HOLDER-SEAL-01 | Hard↓/Medium↑ | single sanctioned holder | 持有 kernel/saga.Journal 字段的 struct 仅限 Coordinator，via go/types 类型感知扫描；upstream 仅 Medium（无包私有 seal） | kernel/saga | 专属 |
+| SAGA-DRIVE-BEHIND-LEADER-GATE-01 | Medium | AST-pattern | 含 A1/A2/A3 子条：driveOne 只能在 tickOnce 内调用；tickOnce 必须调用 AcquireLead；lead 返回值必须控制 driveOne 是否执行 | runtime/saga | 专属 |
+| SAGA-STEP-RUN-OUTSIDE-TX-01 | Hard（A1）/ Medium（A2）/ Soft（B1 逆向自检） | typed-marker-funnel | A1：runtime/saga 生产文件里 StepFunc 调用仅限在 safeRun 内（typed callsite-uniqueness，Hard）；A2：safeRun 禁止出现在 RunInTx closure 内（Medium）；B1：禁止 StepFunc 类型别名（Soft，追踪升级） | runtime/saga, kernel/saga | 专属 |
+
+---
+
+### 批次 6 — Relay 生命周期隔离（RELAY-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| RELAY-NOT-MANAGEDRESOURCE-01 | Hard↓/Hard↑ | type-system-seal | *runtime/outbox.Relay 禁止实现 ManagedResource 接口，防止 WithManagedResource(relay) 绕过封装；via go/types.Implements | runtime/outbox, kernel/lifecycle | 专属 |
+| RELAY-SOLE-HOLDER-01 | Hard↓/Hard↑ | single sanctioned holder | 满足 ManagedResource 且持有 *Relay 字段的 struct 仅限 runtime/bootstrap.relayAdapter，via RunTypedProduction 字段遍历 | runtime/outbox, runtime/bootstrap | 专属 |
+
+---
+
+### 批次 7 — 订阅身份约束（SUBSCRIPTION-*、REGISTRY-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SUBSCRIPTION-FIELDS-FROZEN-01 | Medium | reflect-field-freeze | kernel/outbox.Subscription 字段集冻结为 7 个，防止静默扩展改变 codegen 生成契约 | kernel/outbox | 专属 |
+| SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01 | Medium | AST-pattern | ObservabilityID 方法体必须是单条 `return s.CellID`，禁止 CellID 为空时 fallback 到 ConsumerGroup | kernel/outbox | 专属 |
+| REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01 | Medium | AST-pattern | Registrar.Subscribe 接口方法签名中 cellID 必须是第 4 个位置参数 string，防止被降级为可选 SubscriptionOption | kernel/cell | 专属 |
+
+---
+
+### 批次 8 — 合约 codegen 覆盖与 SafeID（EVENT-SUBSCRIPTION-*、SAFEID-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| EVENT-SUBSCRIPTION-CONTRACTGEN-COVERAGE-01 | Hard（推断） | codegen-funnel+golden | 每个 kind=event codegen=true 的 contract 必须有生成的 subscription_gen.go 且含 func NewSubscription | contracts/event, generated/ | 专属 |
+| SAFEID-WIREMESSAGE-USAGE-01 | Hard↓ | string-typed-funnel | 所有使用 wireMessage 结构体字段的代码必须经过 outbox.SafeID 类型 funnel；via go/types 形态唯一性锁 | kernel/outbox | 专属 |
+| SAFEID-UPSTREAM-FUNNEL-HARD-01 | Hard↑ | type-system-seal | wireMessage 及其字段全部 unexported，包外无法构造或作为 json.Unmarshal target，封闭上游 Hard | kernel/outbox | 专属 |
+
+---
+
+### 批次 9 — After-Commit Hook、Buffer-Then-Commit、L2 原子性（AFTERCOMMIT-*、VISIT-*、L2-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| AFTERCOMMIT-HOOK-PURE-TRANSIENT-01 | Hard（A1/A3↓）/ Medium（A2/A3↑） | typed-marker-funnel | A1：RegisterAfterCommit 入参必须是 func literal（Hard，形态唯一）；A2：hook 体禁止调用 pgx.Tx/sql.Tx/outbox.Writer 方法（Medium）；A3：调用方限五个 TxRunner 实现（Hard↓/Medium↑） | kernel/persistence | 半通用 |
+| VISIT-BUFFER-THEN-COMMIT-01 | Medium（推断） | codegen-funnel+golden | generated/contracts 下 types_gen.go 的 Visit 方法必须先 json.Encode 到 bytes.Buffer 再 WriteHeader，防止 commit-then-stream 反模式 | generated/contracts | 半通用 |
+| L2-OUTBOX-ATOMICITY-COVERAGE-01 | Hard（主路径）/ Medium（B1/B2/B4/B5 盲区） | codegen-funnel+golden | 每个 L2 slice 的 Service 必须有对应的 L2 原子性测试函数（TestXxxL2OutboxAtomicity），via YAML 扫描 + go/types 派生 + AST 名称匹配三层 Hard | cells/**/slices, kernel/outbox | 专属 |
+
+---
+
+### 批次 10 — 健康聚合与事件命名（HEALTH-*、EVENT-*）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| HEALTH-AGG-01 | Medium（推断） | conformance-test | runtime/和 adapters/ 中暴露 Checkers()/HealthCheckers() 的导出类型必须同时实现 ManagedResource（含 Worker+Close），via go/types 方法集推导（含 embedding） | runtime/*, adapters/* | 半通用 |
+| EVENT-PAYLOAD-CAMELCASE-01 | Medium（推断） | metadata/yaml-derive | contracts/event/**/payload.schema.json 的顶层属性名禁止包含下划线，必须使用 camelCase | contracts/event | 通用 |
+| EVENT-DTO-CAMELCASE-01 | Medium（推断） | AST-pattern | cells/**/dto/*event*.go 中结构体 json tag 字段名禁止包含下划线，与事件 payload schema 保持一致 | cells/**/dto | 通用 |

--- a/docs/analysis/archtest-spinout/02-catalog-C-cell-contract-assembly.md
+++ b/docs/analysis/archtest-spinout/02-catalog-C-cell-contract-assembly.md
@@ -1,0 +1,92 @@
+# Archtest 编目 C — Cell / Contract / Assembly / Metadata / Celltest 边界
+
+本批次覆盖 GoCell 声明模型核心约束：Cell 接口 ISP 拆分、元数据单源、codegen funnel、
+celltest 边界、Contract 命名与结构、Assembly 代组成与推导、以及跨主题 schema 守卫。
+
+本文件 **43 条** | Hard 14 / Medium 26 / Soft 0 | 通用 0 / 半通用 3 / 专属 40
+
+---
+
+### 批次 1 — Cell 接口 / 初始化 / 层隔离
+
+| INVARIANT ID | 评级 | 机制类型 | 用途 (≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CELL-IFACE-ISP-COMPOSITE-01 | Medium | AST-pattern | Cell 接口必须是4子接口的纯内嵌复合，本身不直接声明方法 | kernel/cell | 专属 |
+| CELL-IFACE-ISP-METHODSETS-01 | Medium | AST-pattern | 每个子接口方法集合必须精确匹配契约（hash guard） | kernel/cell | 专属 |
+| CELL-IFACE-ISP-BASECELL-CHECK-01 | Medium | AST-pattern | BaseCell 编译期 check 必须四段式分写，对应4子接口 | kernel/cell | 专属 |
+| CELL-L2-INIT-CHECKNOTNOOP-CALLED-01 | Medium | AST-pattern | L2+ Cell 的 Init 方法必须调用 kernel/outbox.CheckNotNoop | kernel/cell, kernel/outbox | 专属 |
+| CELL-INIT-CONTRACTUSAGE-01 | Medium | import-ban | kernel/cell 不得 import runtime/ 或 adapters/；Registrar 类型必须本地定义 | kernel/cell | 专属 |
+| CELL-TEST-NO-ADAPTER-IMPORT-01 | Medium | import-ban | Cell 单元测试禁止 import adapters/ 层；必须用 in-mem fake | adapters/ | 半通用 |
+| CELLS-NO-CONTRACTSPEC-IMPORT-01 | Medium | import-ban | cells/ 非生成文件禁止 import kernel/contractspec 并引用 ContractSpec | kernel/contractspec | 专属 |
+| CELLTEST-IMPORT-BOUNDARY-01 | Medium | import-ban | 非_test.go / kernel/ / examples/ 生产文件禁止 import kernel/cell/celltest | kernel/cell/celltest | 专属 |
+| CELLTEST-IMPORT-SCOPE-01 | Medium | import-ban | 生产文件禁止 import cells/{X}/{X}test 命名的 celltest 包 | cells/ | 专属 |
+
+---
+
+### 批次 2 — Cell 元数据单源 / DTO 漂移 / Raw-infra 封印
+
+| INVARIANT ID | 评级 | 机制类型 | 用途 (≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CELLMETA-SINGLE-SOURCE-01 | Medium (推断) | AST-pattern | kernel/cell 禁止声明已迁至 kernel/metadata 的5个旧类型名 | kernel/cell, kernel/metadata | 专属 |
+| CELLMETA-SINGLE-SOURCE-02 | Medium (推断) | AST-pattern | kernel/cell.NewBaseCell 接收单一 *metadata.CellMeta 参数 | kernel/cell, kernel/metadata | 专属 |
+| CELLMETA-SINGLE-SOURCE-03 | Medium (推断) | AST-pattern | CellInventory.Metadata() 返回 *metadata.CellMeta，非旧类型 | kernel/cell, kernel/metadata | 专属 |
+| CELL-META-DTO-COVERAGE-01 | Medium (推断) | reflect-field-freeze | CellMeta 顶层 yaml 字段必须全部映射到 catalog.CellSpec 或显式排除 | kernel/metadata, runtime/devtools/catalog | 专属 |
+| CELL-ID-PATTERN-SINGLE-SOURCE-01 | Medium | AST-pattern | Cell/Assembly ID 正则字面量只能存在于 kernel/metadata/contract_constraints.go | kernel/metadata | 专属 |
+| CELL-RAW-INFRA-PUBLIC-OPTION-PARAM-01 | Medium | callsite-allowlist | cell 子树内 With* Option 函数禁止接收原始 infra 类型参数 | kernel/persistence, kernel/outbox | 专属 |
+| CELL-RAW-INFRA-WRAPPER-LOCATION-01 | Medium | callsite-allowlist | WrapForCell 等4个 wrapper 只能在 composition root 或 _test.go 调用 | kernel/persistence, kernel/outbox | 专属 |
+| CELL-REPO-READYZ-PROBE-01 | Medium | conformance-test | 每个 kernel/healthz.RepoProber 实现都必须经过 conformance harness 测试 | kernel/healthz, kernel/cell/celltest | 专属 |
+
+---
+
+### 批次 3 — Cellgen / Celltest 边界 / Contract 契约种类
+
+| INVARIANT ID | 评级 | 机制类型 | 用途 (≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CELLGEN-ERRCODE-FUNNEL-01 | Hard | typed-marker-funnel | tools/codegen/cellgen/ 禁止使用 fmt.Errorf / errors.New / errors.Join | pkg/errcode | 专属 |
+| CONTRACT-KINDS-CLOSED-SET-01 | Medium (推断) | metadata/yaml-derive | contract.yaml 的 kind 必须是 {http,event,command,projection} 封闭集 | kernel/metadata | 专属 |
+| CONTRACT-PATH-QUERY-COVERAGE-01 | Medium | conformance-test | 每个声明 pathParams/queryParams 的 HTTP contract 必须有对应的 MustReject 调用 | kernel/metadata, tests/contracttest | 专属 |
+| CONTRACT-PATH-QUERY-PARAM-NAME-LITERAL-01 | Medium | callsite-allowlist | MustReject{Path,Query}Param 第二参数必须是编译期常量字符串 | tests/contracttest | 专属 |
+| CONTRACT-WIRE-FIELD-CAMELCASE-01 | Hard | metadata/yaml-derive | contracts/ 下 wire 字段名必须是 camelCase，不得 snake_case | contracts/ | 半通用 |
+| CONTRACT-PAGINATION-PARAM-LIMIT-01 | Hard | metadata/yaml-derive | 分页 queryParam 必须命名为 "limit"，不得用其他名称 | contracts/ | 专属 |
+| CONTRACT-PAGINATION-LIMIT-MAXIMUM-01 | Hard | metadata/yaml-derive | 分页 limit 参数必须声明 maximum 约束 | contracts/ | 专属 |
+| CONTRACT-EVENT-IDEMPOTENCY-KEY-EVENTID-01 | Hard | metadata/yaml-derive | event contract payload 必须包含名为 "eventId" 的幂等键字段 | contracts/ | 专属 |
+
+---
+
+### 批次 4 — Contract subscribers 单源 / codegen funnel / contracttest 边界
+
+| INVARIANT ID | 评级 | 机制类型 | 用途 (≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SUBSCRIBERS-DERIVED-FIELD-FROZEN-01 | Hard↓/Medium↑ | reflect-field-freeze | EndpointsMeta.Subscribers 字段必须携带 yaml:"-"，防止手写 subscribers 键 | kernel/metadata | 专属 |
+| CONTRACT-YAML-NO-SUBSCRIBERS-KEY-01 | Medium | metadata/yaml-derive | contract.yaml 禁止出现手写 subscribers: 键（该字段为派生字段） | kernel/metadata | 专属 |
+| SUBSCRIBE-MARKER-RETIRED-01 | Medium | AST-pattern | cell.go 禁止出现已退役的 `// +slice:subscribe` marker | cells/ | 专属 |
+| CONTRACT-YAML-NO-CODEGEN-TRUE-LITERAL-01 | Medium | metadata/yaml-derive | contract.yaml 禁止显式写 `codegen: true`（默认值，冗余） | kernel/metadata | 专属 |
+| CONTRACTTEST-BOUNDARY-01 | Medium (推断) | import-ban | tests/contracttest 仅供 _test.go 使用；legacy pkg/contracts 路径必须已删除 | tests/contracttest | 专属 |
+| CONTRACTTEST-LOADBYID-LITERAL-01 | Medium (推断) | callsite-allowlist | contracttest.LoadByID 第三参数必须是编译期常量字符串 | tests/contracttest | 专属 |
+| NO-MANUAL-CONTRACTSPEC-LITERAL-01 | Hard | callsite-allowlist | cells/examples/runtime 禁止手写 ContractSpec{} 字面量；必须用 codegen 生成或 typed funnel | kernel/contractspec | 专属 |
+| CONTRACTSPEC-FRAMEWORK-BUILDERS-EXIST-01 | Medium | callsite-allowlist | NewEventDerivation 调用方限于单文件 allowlist（eventrouter/contract_tracing_subscriber.go） | kernel/contractspec | 专属 |
+
+---
+
+### 批次 5 — Assembly 不变式 / Metadata DTO / Parser 对称性
+
+| INVARIANT ID | 评级 | 机制类型 | 用途 (≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| ASSEMBLY-MODULES-GEN-01 | Medium | codegen-funnel+golden | modules_gen.go 必须带 DO NOT EDIT marker、package main、generatedCellModules() | kernel/metadata | 专属 |
+| ASSEMBLY-MODULES-SWITCH-FORBIDDEN-02 | Medium | AST-pattern | assembly 组合入口禁止对 cell ID 字面量做 switch | kernel/metadata | 专属 |
+| ASSEMBLY-MAXCONSISTENCY-DERIVED-03 | Hard | reflect-field-freeze | AssemblyMeta.MaxConsistencyLevel 必须携带 yaml:"-"，防止手写 | kernel/metadata | 专属 |
+| ASSEMBLY-CELLMODULE-TYPE-04 | Medium | AST-pattern | assembly 组合入口必须声明顶层 CellModule 类型 | kernel/metadata | 专属 |
+| ASSEMBLY-SNAPSHOTS-LOCKED-01 | Medium (推断) | AST-pattern | kernel/assembly/ 中对 *.snapshots 的写入必须在 mu.Lock() 临界区内 | kernel/assembly | 专属 |
+| ASSEMBLYREF-METHOD-SET-01 | Medium (推断) | AST-pattern | auth.AssemblyRef 接口必须恰好有 3 个方法（ID/CellIDs/Cell） | kernel/auth | 专属 |
+| ASSEMBLY-META-DTO-COVERAGE-01 | Medium (推断) | reflect-field-freeze | AssemblyMeta 顶层 yaml 字段必须全部映射到 catalog.AssemblySpec 或显式排除 | kernel/metadata, runtime/devtools/catalog | 专属 |
+| PARSER-MATCHER-EXAMPLES-SYMMETRY-01 | Medium | AST-pattern | kernel/metadata/parser.go 中每个 match*YAML 函数必须同时覆盖 root 和 examples/ 形式 | kernel/metadata | 专属 |
+
+---
+
+### 批次 6 — Schema / Query / CAS 守卫
+
+| INVARIANT ID | 评级 | 机制类型 | 用途 (≤30字中文) | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| PATCH-OPTIONAL-BOOL-POINTER-01 | Hard (推断) | metadata/yaml-derive | PATCH Request 中可选 bool 字段必须是 *bool，不得是 bool | generated/contracts | 半通用 |
+| META-QUERYPARAM-DRIFT-01 | Medium (推断) | metadata/yaml-derive | HTTP handler 读取的 query param 必须在 contract.yaml 中声明，反之亦然 | kernel/metadata | 专属 |
+| CAS-CONTRACT-EXPECTED-VERSION-SCHEMA-01 | Hard | metadata/yaml-derive | CAS guard 字段 expectedVersion 必须通过 $ref 引用共享 mixin，禁止 inline 副本 | contracts/shared/cas | 专属 |

--- a/docs/analysis/archtest-spinout/02-catalog-D-codegen-scaffold-bootstrap.md
+++ b/docs/analysis/archtest-spinout/02-catalog-D-codegen-scaffold-bootstrap.md
@@ -1,0 +1,148 @@
+# Archtest 编目 D — Codegen 漏斗 / Scaffold / Bootstrap 装配 / 依赖注入 funnel
+
+本文件编目 24 个源文件中的所有 INVARIANT，主题覆盖：
+
+- **Codegen 漏斗**：cell/contract 代码生成输出完整性、marker 单源、YAML 字段禁止、spec 字段奇偶性
+- **HTTP handler 漏斗**：contractgen 内部 `httpEndpointSpec` sealed 构造与渲染唯一性
+- **Scaffold 输出一致性**：bundle 标记嵌入、强制覆盖权限、OS 写禁止、typed ID 构造
+- **Pathsafe / PlanSet**：`PlanSet` sealed 构造 + dup-reject
+- **Bootstrap 装配**：auth 路由互斥、admin 路径限制、module 顺序、audit observer funnel、capability provider funnel
+- **依赖注入 funnel**：required-dep nil guard、accesscore bundle、baseslice 构造、shared schema mirror、sealed marker noop
+
+本文件 **35 条** | Hard 15 / Medium 17 / Soft 0 / 推断 3 | 通用 2 / 半通用 12 / 专属 21
+
+---
+
+### 批次 1 — Codegen Cell/Contract 生成完整性（codegen_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CODEGEN-CELL-GEN-01 | Medium（推断） | codegen-funnel+golden | 已启用 codegen 的 cell 必须存在 cell_gen.go | tools/codegen/markergen, kernel/metadata | 半通用 |
+| CODEGEN-CELL-GEN-02 | Medium（推断） | codegen-funnel+golden | cell_gen.go 必须有标准生成头注释 | tools/codegen/markergen | 半通用 |
+| CODEGEN-CELL-GEN-03 | Medium（推断） | codegen-funnel+golden | 不详（merged from cell_gen_test，推断为 initInternal 存在性约束） | kernel/metadata | 半通用 |
+| CODEGEN-CELL-GEN-04 | Medium（推断） | codegen-funnel+golden | 不详（merged from cell_gen_test，推断为 goStructName 相关完整性约束） | kernel/metadata | 半通用 |
+| CODEGEN-CONTRACT-GEN-01 | Medium（推断） | codegen-funnel+golden | 已启用 codegen 的 contract 必须存在 types_gen.go / iface_gen.go / handler_gen.go | tools/codegen, contracts/ | 半通用 |
+| CODEGEN-CONTRACT-GEN-02 | Medium（推断） | codegen-funnel+golden | contract 生成文件必须有标准生成头注释 | tools/codegen | 半通用 |
+| CODEGEN-CONTRACT-USER-OVERLAP-01 | Medium（推断） | AST-pattern | 用户文件不得定义与 codegen 重叠的 Init 方法 | tools/codegen/cellgen | 专属 |
+| COMMAND-PROJECTION-EXPLICIT-01 | Medium（推断） | codegen-funnel+golden | command/projection 合约不得有 http/event 专属生成文件 | contracts/, kernel/metadata | 专属 |
+| SPEC-GEN-VALUE-PARITY-01 | Medium（推断） | codegen-funnel+golden | spec_gen.go 中 ID / Topic 值须与 contract.yaml 一致 | contracts/, tools/codegen | 专属 |
+| SPEC-GEN-TOPIC-EQUALS-CONTRACT-ID-01 | Medium（推断） | codegen-funnel+golden | event contract 的 spec_gen.go topic 字段须等于 contract ID | contracts/, tools/codegen | 专属 |
+
+---
+
+### 批次 2 — K#05 Marker / Wire 单源（codegen_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| NO-METADATA-LITERAL-IN-CELLGO-01 | Medium（推断） | AST-pattern | cell.go 禁止手写 metadata.CellMeta 复合字面量 | kernel/metadata, tools/codegen | 专属 |
+| NO-WIRE-FIELDS-IN-YAML-01 | Medium（推断） | metadata/yaml-derive | cell.yaml 禁止 listeners: 字段；slice.yaml 禁止 routeMounts:/subscribes: 字段 | kernel/metadata, contracts/ | 专属 |
+| MARKER-MISSING-FOR-WIRE-CALL-01 | Medium（推断） | AST-pattern | wire call 调用点须有对应 marker 注释，不能孤立调用 | tools/codegen/markergen | 专属 |
+| MARKERGEN-DRIFT-VERIFY-01 | Medium（推断） | codegen-funnel+golden | markergen 输出须与源 marker 注释一一对应，不能漂移 | tools/codegen/markergen | 专属 |
+| MARKER-WIRE-SINGLE-SOURCE-01 | Medium（推断） | codegen-funnel+golden | wire 标记必须单源；禁止同时在 marker 和字面量双写 | tools/codegen/markergen | 专属 |
+
+---
+
+### 批次 3 — HTTP Handler Funnel（codegen_http_handler_funnel_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01（A1a） | Hard | type-system-seal | contractgen.httpEndpointSpec 为 unexported，包外不可构造 | tools/codegen/contractgen | 半通用 |
+| CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01（A1b） | Medium | callsite-allowlist | buildHTTPEndpointSpec 唯一构造+调用点在 contractgen 内 | tools/codegen/contractgen | 半通用 |
+| CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01（A2） | Medium | AST-pattern | handler emit 模板在 contractgen 内唯一，禁止同义副本 | tools/codegen/contractgen | 半通用 |
+| CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01（A3） | Medium | AST-pattern | handler 模板渲染只在 contractgen 内调用 | tools/codegen/contractgen | 半通用 |
+| CODEGEN-BUILDHTTPENDPOINTSPEC-SOLE-CALLER-01（A4） | Hard | type-system-seal | 无导出 spec 类型泄漏到 contractgen 包外 | tools/codegen/contractgen | 半通用 |
+
+> 注：上述 5 条均属同一 INVARIANT ID，按 A1a/A1b/A2/A3/A4 腿分别编目，因评级不同。
+
+---
+
+### 批次 4 — Scaffold 输出与写入漏斗
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SCAFFOLD-BUNDLE-MARKER-01 | Medium | AST-pattern | scaffold 产出的 cell.go 必须嵌入 K#05 listener marker 注释 | tools/codegen/cellgen | 专属 |
+| SCAFFOLD-BUNDLE-NO-CODEGEN-LITERAL-01 | Medium | AST-pattern | scaffold 产出的 contract.yaml 禁止含 codegen: 字面量键 | tools/codegen/cellgen | 专属 |
+| SCAFFOLD-LISTENER-MARKER-TYPED-CONST-01 | Medium | typed-marker-funnel | scaffold 使用 cellgen.ListenerMarker typed const 而非手写字符串 | tools/codegen/cellgen | 半通用 |
+| SCAFFOLD-DERIVED-FORCEOVERWRITE-01 | Hard↓/Hard↑ | codegen-funnel+golden | ForceOverwrite 只能在 PlanFile 构造函数内设置，业务路径不可绕过 | pkg/pathsafe, tools/codegen | 半通用 |
+| SCAFFOLD-WRITE-FUNNEL-01 | Medium | callsite-allowlist | scaffold 层禁止直接调用 os.Write 系列，必须走 pathsafe.WritePlannedFiles | pkg/pathsafe | 半通用 |
+| SCAFFOLD-INPUT-CONTRACT-TYPED-ID-01 | Hard（推断） | type-system-seal | ScaffoldID 只能通过 scaffoldid.Parse 构造，无 MustParse 后门 | pkg/scaffoldid | 通用 |
+
+---
+
+### 批次 5 — Pathsafe PlanSet Funnel
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| PATHSAFE-PLANSET-FUNNEL-01 | Hard | type-system-seal | PlanSet.items 字段私有，外部只能通过 NewPlanSet 构造，dup-reject 不可绕过 | pkg/pathsafe | 通用 |
+
+---
+
+### 批次 6 — Shared Schema Mirror Funnel
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SHARED-SCHEMA-MIRROR-FUNNEL-01（A1） | Medium | AST-pattern | 检测新增 schema 副本（反向枚举），防止 shared schema 多处手写 | contracts/shared | 专属 |
+| SHARED-SCHEMA-MIRROR-FUNNEL-01（A2） | Medium | callsite-allowlist | Headerless 构造仅在 allowlist callsite 调用，不泄漏到外部包 | contracts/shared, tools/codegen | 专属 |
+
+---
+
+### 批次 7 — Sealed Marker Noop Transparency
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SEALED-MARKER-NOOP-TRANSPARENCY-01 | Hard | type-system-seal | sealed marker 类型的所有实现必须有 Noop()，通过 go/types 自动发现 | kernel/cell | 专属 |
+
+---
+
+### 批次 8 — BaseSlice 构造漏斗 & Required-Dep Nil Guard
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| BASESLICE-CTOR-FUNNEL-01 | Medium | callsite-allowlist | BaseSlice/SliceMeta 复合字面量禁止在 production 代码手写，必须走构造函数 | kernel/cell, cells/ | 专属 |
+| REQUIRED-DEP-NIL-GUARD-01 | Hard | codegen-funnel+golden | `gocell:"required"` tag 派生 validateRequired()，regenerate-and-diff 字节级锁；callsite 唯一性+IsNilInterface ban+tag 白名单四件套 | tools/codegen, kernel/cell, cells/ | 专属 |
+
+---
+
+### 批次 9 — Auth Bootstrap 装配不变式
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CELLS-NO-ROUTEMUX-WRAPPER-01 | Hard | AST-pattern | cells/ 禁止嵌入 cell.RouteMux，防止接口扇出静默截断 | kernel/cell, cells/ | 专属 |
+| AUTH-ROUTE-BOOTSTRAP-FLAG-REMOVED-01 | Hard | AST-pattern | runtime/auth.Route 禁止声明 Bootstrap bool 字段，唯一表达方式是 BootstrapAuth 函数值 | runtime/auth | 专属 |
+| SETUP-ADMIN-CODEGEN-BOOTSTRAP-AUTH-WIRED-01 | Hard | codegen-funnel+golden | 生成的 setup/admin handler 必须传入非零 BootstrapAuth 参数，锁定 codegen 模板 | tools/codegen/contractgen, runtime/auth | 专属 |
+| AUTH-BOOTSTRAP-CLIENTS-MUTEX-01 | Hard | type-system-seal | auth.Route 声明 BootstrapAuth 时 Contract.Clients 必须为空；type-checked Var key 比较，0 已知盲区 | runtime/auth | 专属 |
+
+---
+
+### 批次 10 — Setup Admin Auth 路径约束
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SETUP-ADMIN-NOT-PUBLIC-01 | Medium（推断） | metadata/yaml-derive | bootstrap 路径上的 contract 禁止声明 auth.public:true | kernel/metadata | 专属 |
+| AUTH-BOOTSTRAP-PATH-RESTRICTED-01 | Medium（推断） | metadata/yaml-derive | auth.bootstrap:true 只允许在 IsBootstrapPath 路径的 contract 上 | kernel/metadata | 专属 |
+| BOOTSTRAP-PATH-PREDICATE-SOLE-01 | Medium（推断） | AST-pattern | strings.Contains(_, "setup/admin") 只允许在 kernel/metadata/bootstrap_path.go 内 | kernel/metadata | 半通用 |
+
+---
+
+### 批次 11 — 其他 Bootstrap / Module 装配约束
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| BOOTSTRAP-AUDIT-OBSERVER-FUNNEL-DOWNSTREAM-HARD-01 | Hard | typed-marker-funnel | audit.NewBootstrapAuthFailObserver 返回的闭包体必须满足 3 conjunction 条件（下游 Hard） | cells/accesscore, cells/auditcore, runtime/auth | 专属 |
+| BOOTSTRAP-AUDIT-OBSERVER-FUNNEL-UPSTREAM-MEDIUM-01 | Medium | callsite-allowlist | 每个 bootstrap middleware 对 AppendBootstrapAuthFail 的赋值必须经过 funnel 调用（上游 Medium） | cells/auditcore, runtime/auth | 专属 |
+| MODULE-ORDER-AUDITCORE-BEFORE-ACCESSCORE-01 | Medium（推断） | metadata/yaml-derive | assembly.yaml 中 auditcore module 必须在 accesscore 之前，保证 SharedDeps.BootstrapLedgerStore 先就绪 | assemblies/ | 专属 |
+| CAPABILITY-PROVIDER-FUNNEL-01 | Hard↑/Medium↓ | typed-marker-funnel | postgres.NewPool/NewTxManager/NewOutboxWriter/redis.NewClient 只能在 cap_wiring.go 构造；上游 Hard（sealed interface），下游 Medium（callsite allowlist） | adapters/postgres, adapters/redis, runtime/capability, cmd/corebundle | 专属 |
+
+---
+
+### 批次 12 — 其余杂项约束
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| NO-TEST-SERVICE-CONTEXT-IN-PRODUCTION-01 | Medium（推断） | AST-pattern | auth.TestServiceContext 只能在 _test.go 中调用，禁止出现在生产路径 | runtime/auth | 半通用 |
+| PROVISION-STATE-AND-USERSOURCE-BOOTSTRAP-REMOVED-01 | Medium（推断） | AST-pattern | 10 个 bootstrap provision 状态机标识符在 cells/accesscore 中永久禁止出现 | cells/accesscore | 专属 |
+| COREBUNDLE-DEPS-01 | Medium（推断） | import-ban | cmd/corebundle 禁止依赖 tools/depgraph 或 golang.org/x/tools | cmd/corebundle, tools/depgraph | 半通用 |
+| ACCESSCORE-BUNDLE-FUNNEL-01 | Hard | type-system-seal | accesscore 的散装 With*Repository/WithSetupLock/WithTxManager 选项必须保持 unexported；Go 可见性即 Hard 载体 | cells/accesscore | 专属 |
+| ACCESSCORE-FACADE-A61-01 | Medium（推断） | AST-pattern | accesscore 禁止重新暴露 bootstrap credential-path forwarding API | cells/accesscore | 专属 |
+| LISTENER-DX-01 | Medium（推断） | AST-pattern | 已删除的 listener 选项 API 和 legacy auth.Route Delegated surface 禁止重新引入 | runtime/http, runtime/auth | 专属 |
+| MANAGED-RESOURCE-COMPLETENESS-01 | Medium（推断） | conformance-test | adapters/ 导出类型必须实现 ManagedResource 或在 opt-out 表中明确豁免 | adapters/, kernel/lifecycle | 半通用 |

--- a/docs/analysis/archtest-spinout/02-catalog-E-auth-session-security.md
+++ b/docs/analysis/archtest-spinout/02-catalog-E-auth-session-security.md
@@ -1,0 +1,108 @@
+# 批次 E：认证 / 会话 / 凭证 / Refresh / 安全默认 / 角色 / UserRepo
+
+本批次覆盖 GoCell 安全与身份语义核心。源文件均位于 `tools/archtest/` 下，主题围绕
+访问控制路径（session lifecycle、凭证权限、JWT claims、bcrypt 成本）、运行时安全默认
+（TLS、WebSocket、监听器鉴权链）以及 UserRepo 接口完整性。
+
+本文件 47 条 | Hard 17 / Medium 26 / Soft 0（含 1 条 RETIRED）| 通用 4 / 半通用 21 / 专属 22
+
+---
+
+### 批次 1：AuthPlan / 鉴权测试包边界（auth_plan_test.go, auth_authtest_boundary_test.go, auth_keystest_boundary_test.go, no_deleted_auth_symbols_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| AUTH-PLAN-01 | Medium (推断) | AST-pattern | 禁止旧 cell.Policy 字符串字面量（jwt/mtls/service-token）在生产代码出现 | runtime/auth, kernel/cell | 半通用 |
+| AUTH-PLAN-02 | Medium (推断) | AST-pattern | 禁止已删除的 bootstrap.Policy{None,JWT,…} 选择器表达式 | runtime/bootstrap | 专属 |
+| AUTH-PLAN-03 | Medium (推断) | AST-pattern | 禁止已删除的 cell.Policy 类型引用或字面量 | kernel/cell | 专属 |
+| AUTH-PLAN-04 | Medium (推断) | callsite-allowlist | cells/ 代码禁止直接构造 AuthPlan 结构体（组合根职责） | kernel/cell, runtime/auth | 专属 |
+| AUTH-AUTHTEST-BOUNDARY-01 | Medium | import-ban | authtest 子包仅限 _test.go 引入；auth.Authenticated() 已删除 | runtime/internal/authtest, kernel/auth/authtest | 半通用 |
+| AUTH-KEYSTEST-IMPORT-BOUNDARY-01 | Medium | import-ban | keystest（Must* key helpers）禁止被非测试文件引入 | runtime/auth/keystest | 半通用 |
+| NO-DELETED-AUTH-SYMBOLS-01 | Medium | AST-pattern | 已删除的 auth.RoleInternalAdmin 等符号不得在白名单外引用 | runtime/auth | 专属 |
+
+---
+
+### 批次 2：会话生命周期（caching_session, session_protocol, session_revoked, sessionrefresh）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CACHING-SESSION-REVOKE-DELEGATE-ONLY-01 | Hard | AST-pattern | CachingSessionStore.Revoke 体必须是单句纯委托，禁止本地 cache 操作 | adapters/redis（session 相关） | 半通用 |
+| SESSION-PROTOCOL-COMPOSITION-ROOT-01 | Medium | callsite-allowlist | session.NewProtocol 只能从 cmd/（组合根）或 session 包本身调用 | runtime/auth/session | 专属 |
+| SESSION-REVOKED-FIELD-ACCESS-01 | Hard | callsite-allowlist | session.Session.RevokedAt 字段读取限定允许列表包 | runtime/auth/session, cells/accesscore | 专属 |
+| SESSIONREFRESH-NO-SESSION-CREATE-01 | Medium | callsite-allowlist | refresh 路径禁止调用 session.Store 的 Create/Revoke/RevokeForSubject | cells/accesscore/slices/sessionrefresh, runtime/auth/session | 专属 |
+
+---
+
+### 批次 3：Epoch 安全约束（sessionrefresh_stale_epoch, sessionvalidate_epoch）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SESSIONREFRESH-STALE-EPOCH-REJECT-01 | Medium | AST-pattern | rejectIfStaleEpoch 必须用 `==` 比较、调用 cascadeRevoke、不得混用 reuse-attack 路径 | cells/accesscore/slices/sessionrefresh | 专属 |
+| SESSIONVALIDATE-EPOCH-COMPARE-01 | Medium | AST-pattern | enforceSessionState 必须含 AuthzEpoch 比较和 GetByID 调用，且用 `!=` 运算符 | cells/accesscore/slices/sessionvalidate | 专属 |
+| SESSIONVALIDATE-EPOCH-SOURCE-01 | Hard | AST-pattern | enforceSessionState 的 epoch 比较必须引用行来源字段 AuthzEpochAtIssue（而非 JWT claim） | cells/accesscore/slices/sessionvalidate | 专属 |
+
+---
+
+### 批次 4：凭证权限 funnel（credential_authority, credential_invalidate, domain_authz_mutation, reconstitute_user, jwt_claims）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CREDENTIAL-AUTHORITY-ASSERT-FUNNEL-01 | Hard↓/Hard↑ | callsite-allowlist | credentialauthority.Assert 只能从限定 slice 调用；直接读 CanAuthenticate/PasswordVersion 被拦截 | cells/accesscore/slices/{sessionlogin,sessionrefresh,sessionvalidate,credentialauthority} | 专属 |
+| CREDENTIAL-INVALIDATE-FUNNEL-01 | Hard | callsite-allowlist | session.Store.RevokeForSubject 只能从 credentialinvalidate funnel 内调用 | runtime/auth/session, cells/accesscore | 专属 |
+| USER-AUTHZ-EPOCH-BUMP-FUNNEL-01 | Hard | callsite-allowlist | ports.UserRepository.BumpAuthzEpoch 只能从 credentialinvalidate funnel 内调用 | cells/accesscore/internal/ports | 专属 |
+| REFRESH-REVOKE-USER-FUNNEL-01 | Hard | callsite-allowlist | refresh.Store.RevokeUser 只能从 credentialinvalidate funnel 内调用 | runtime/auth/refresh | 专属 |
+| CREDENTIAL-INVALIDATE-UPSTREAM-CALLER-01 | Medium | callsite-allowlist | Invalidator.Apply 入口调用方限定（Medium：捕获错误调用点，不能阻止遗漏调用点） | cells/accesscore/slices/credentialinvalidate | 专属 |
+| DOMAIN-AUTHZ-FIELD-PRIVATE-01 | Hard | type-system-seal | domain.User authz 字段（status/passwordResetRequired/authzEpoch）unexported，跨包写编译失败 | cells/accesscore/internal/domain | 专属 |
+| AUTHZ-MUTATION-APPLY-FUNNEL-01 | Hard↓/Medium↑ | callsite-allowlist | SetStatus/SetPasswordResetRequired 调用方限定到文件级别 allowlist | cells/accesscore/internal/domain | 专属 |
+| RECONSTITUTE-USER-CALLER-01 | Medium | callsite-allowlist | domain.ReconstituteUser 只能被 mem/、postgres adapter、domain 包本身调用 | cells/accesscore/internal/domain | 专属 |
+| JWT-CLAIMS-NO-AUTHZ-EPOCH-01 | Hard | AST-pattern | JWT Claims 结构体禁止含 AuthzEpoch 字段或 JSON tag "authz_epoch" | kernel/auth, runtime/auth/jwt | 专属 |
+
+---
+
+### 批次 5：Refresh 事务约束（refresh_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| REFRESH-CROSS-STORE-TX-01 | Medium | callsite-allowlist | sessionrefresh.Refresh 必须把 Peek/Get/GetByID/Rotate/RevokeSession 包在单个 RunInTx 闭包内 | cells/accesscore/slices/sessionrefresh, runtime/auth/{refresh,session} | 半通用 |
+| REFRESH-INVALID-INDEX-SINGLE-SOURCE-01 | Medium (推断) | AST-pattern | DetectInvalidIndexes 函数只能在 adapters/postgres/schema_guard.go 中声明一处 | adapters/postgres | 专属 |
+| REFRESH-AMBIENT-TX-01 | Medium (推断) | AST-pattern | adapters/postgres/refresh_store.go 禁止直接调用 pool.Begin（必须委托 TxRunner） | adapters/postgres | 半通用 |
+
+---
+
+### 批次 6：安全默认（security_defaults_test.go，SEC-FAIL-CLOSED-01..10）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SEC-FAIL-CLOSED-01 | —（RETIRED） | AST-pattern | addr 驱动的 WithListener if-gate 已退役（SEC-02 覆盖真正 fail-open 风险） | runtime/bootstrap | 专属 |
+| SEC-FAIL-CLOSED-02 | Medium (推断) | AST-pattern | package main 中 bootstrap.WithListener 第三参数禁止裸 nil | runtime/bootstrap, kernel/cell | 半通用 |
+| SEC-FAIL-CLOSED-03 | Medium (推断) | AST-pattern | redis/vault/s3 adapter 必须引入并调用 secutil.ValidateTLSEndpoint | adapters/{redis,vault,s3}, pkg/secutil | 半通用 |
+| SEC-FAIL-CLOSED-04 | Medium (推断) | AST-pattern | adapters/websocket 禁止赋值 opts.InsecureSkipVerify = true | adapters/websocket | 半通用 |
+| SEC-FAIL-CLOSED-05 | Medium (推断) | metadata/yaml-derive | examples docker-compose 密码字段必须用 `${VAR:?required}` 环境插值 | examples/ | 半通用 |
+| SEC-FAIL-CLOSED-06 | Medium (推断) | AST-pattern | InternalListener 禁止搭配裸 AuthNone 链 | runtime/bootstrap, kernel/cell | 半通用 |
+| SEC-FAIL-CLOSED-07 | Medium (推断) | AST-pattern | adapters/websocket UpgradeConfig 字面量必须包含 Authenticator 字段 | adapters/websocket | 半通用 |
+| SEC-FAIL-CLOSED-08 | Medium (推断) | AST-pattern | 禁止调用已删除的 runtime/websocket.Hub.Broadcast（替换为 BroadcastFilter/BroadcastToSubject） | runtime/websocket | 专属 |
+| SEC-FAIL-CLOSED-09 | Medium (推断) | AST-pattern | hub.go 中 conns 删除操作必须在 removeConnLocked/shutdown 内（防 subjectIdx 不同步） | runtime/websocket | 专属 |
+| SEC-FAIL-CLOSED-10 | Medium | callsite-allowlist | 引用 PrimaryListener 的 package main 必须同时引用 HealthListener | kernel/cell, runtime/bootstrap | 半通用 |
+
+---
+
+### 批次 7：角色 / SvcToken / Bcrypt（role_admin_literal, seed_role_iface, svctoken_caller_cell, bcrypt_cost_funnel）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| ROLE-ADMIN-LITERAL-01 | Medium (推断) | AST-pattern | 禁止重复定义值为 "admin" 的 Admin 常量（单源 runtime/auth/roles.go） | runtime/auth | 通用 |
+| ROLE-ADMIN-LITERAL-02 | Medium | AST-pattern | auth.AnyRole 等调用参数禁止裸字符串 "admin"，必须用 auth.RoleAdmin 常量 | runtime/auth | 半通用 |
+| SEED-ROLE-IFACE-01 | Hard | AST-pattern | 生产代码禁止命名 `*mem.RoleRepository` 类型（测试专用 seed helper 不泄漏） | cells/accesscore/internal/{mem,ports} | 专属 |
+| SVCTOKEN-CALLER-CELL-REQUIRED-01 | Medium | callsite-allowlist | auth.GenerateServiceToken 第二参数必须是合法已注册的 cell ID 字面量 | runtime/auth, kernel/metadata | 专属 |
+| BCRYPT-COST-FUNNEL-01 | Hard↓/Medium↑ | callsite-allowlist | bcrypt.GenerateFromPassword 仅限 credential/hasher.go；NewTestHasher 仅限测试白名单 | cells/accesscore/internal/credential | 专属 |
+
+---
+
+### 批次 8：UserRepo 完整性（identitymanage_last_admin, user_repo_conformance, userrepo_method_set, userrepo_nonempty_cast）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| IDENTITYMANAGE-LAST-ADMIN-PROTECTION-WIRING-01 | Medium | callsite-allowlist | identitymanage.NewService 每个调用处必须在同文件内包含 WithLastAdminProtection 选项 | cells/accesscore/slices/identitymanage | 专属 |
+| USERREPO-CONFORMANCE-ENROLLMENT-01 | Medium | conformance-test | 每个实现 ports.UserRepository 的具体类型必须在其包的测试文件中调用合规测试 | cells/accesscore/internal/ports/conformance | 半通用 |
+| USERREPO-METHOD-SET-FROZEN-01 | Medium | reflect-field-freeze | ports.UserRepository 方法集合与每方法签名精确锁定，防止回退宽泛 Update 形态 | cells/accesscore/internal/ports | 半通用 |
+| USERREPO-NONEMPTY-CAST-FUNNEL-01 | Medium↓/Medium↑ | callsite-allowlist | domain.NonEmpty(_) 显式类型转换只允许 allowlist 文件（防绕过 NewNonEmpty 验证 funnel） | cells/accesscore/internal/domain | 专属 |

--- a/docs/analysis/archtest-spinout/02-catalog-F1-hygiene-errcode-clock-test-ci.md
+++ b/docs/analysis/archtest-spinout/02-catalog-F1-hygiene-errcode-clock-test-ci.md
@@ -1,0 +1,109 @@
+# F1 批次：跨切面代码卫生——errcode / panic / clock / 测试纪律 / governance / CI 固定
+
+本文件覆盖 tools/archtest/ 下 17 个源文件、共 **28 条** 去重 INVARIANT。主题是「跨切面代码卫生」，是「通用 Go 检查器」候选规则最集中的一批：其中约半数规则的思路可直接移植到任意 Go 项目，仅需替换包路径。
+
+本文件 28 条 | Hard 12 / Medium 13 / Soft 0 / Hard↓Medium↑(funnel 双向) 3 | 通用 9 / 半通用 14 / 专属 5
+
+---
+
+### 批次 1：errcode 错误模型（errcode_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| ERRCODE-KIND-LITERAL-01 | Medium（推断） | callsite-allowlist + AST-pattern | 禁止在 pkg/errcode 外直接构造 errcode.Error{} 字面量，强制走 New/Wrap | pkg/errcode | 半通用：思路通用（禁裸结构体字面量），移植需替换目标类型路径 |
+| ERRCODE-CARVEOUT-ADR-CONSISTENCY-01 | Hard | metadata/yaml-derive | 代码侧 carve-out 映射与 ADR registry 表严格双向一致 | pkg/errcode | 专属：双向锁的两端都是 GoCell 专属（carve-out ADR + errcode 映射） |
+| MESSAGE-CONST-LITERAL-01 | Medium | AST-pattern | errcode.New/Wrap 的 message 参数必须是 const 字面量，禁止 fmt.Sprintf/拼接 | pkg/errcode | 半通用：思路通用（禁 API 参数 runtime 拼接 PII），移植需绑定目标函数签名 |
+| ERROR-FIRST-API-01 | Medium | AST-pattern | 无 error 返回的函数禁止 panic（入 enrollment 文件白名单） | — | 半通用：思路通用（error-first API 约定），移植需维护 enforced file 清单 |
+| ERROR-FIRST-TYPED-NIL-01 | Medium | AST-pattern | error 返回的 New* 构造函数必须对 nil-able 参数做类型安全 nil 检测 | — | 半通用：思路通用（构造函数 nil-guard），移植需适配 nil 检测形态规则 |
+| DETAILS-SLOG-ATTR-01 | Medium（推断） | AST-pattern | WithDetails 参数禁止旧式 map[string]any 字面量，必须用 slog.Attr | pkg/errcode | 半通用：思路通用（类型签名切换后防回退），移植需绑 WithDetails 函数路径 |
+| EXPORTED-ERROR-NEW-01 | Medium（推断） | AST-pattern | 生产代码禁止 package-scope exported `var Err* = errors.New(...)`，必须走 errcode.New | pkg/errcode | 通用：换任何有统一 error code 模型的项目均成立；仅需替换目标 New 函数路径 |
+
+---
+
+### 批次 2：panic 分类（panic_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| PANIC-REDACT-01 | Medium（推断） | AST-pattern | slog.Any("panic", X) 必须用 redaction.RedactAny 包裹，防 panic 值泄漏日志 | pkg/redaction | 半通用：思路通用（panic 日志脱敏），移植需替换 redact 函数路径 |
+| PANIC-REGISTERED-01 | Hard（typed-marker-funnel，ai-robust.md §Hard 范本明确） | typed-marker-funnel | 每个生产 panic 调用必须用 panicregister.Approved(reason, value) 包裹，reason 为 kebab-case 字面量 | pkg/panicregister | 通用：思路完全可移植（任意项目可引入 `panicregister` 模式）；移植需创建等价 Approved 包 |
+
+---
+
+### 批次 3：clock 注入（clock_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CLOCK-INJECTION-TEST-CALLSITE-01 | Medium | callsite-allowlist + typed AST | 测试文件调用带 WithClock 的构造函数时必须传入 WithClock option | kernel/clock | 半通用：思路通用（测试注入 clock），移植需项目有 clock 抽象 + WithClock option 模式 |
+| CLOCK-INJECTION-PROD-CALLSITE-01 | Medium（推断） | callsite-allowlist + typed AST | 生产组合根（cmd/ + examples/）调用带 WithClock 的构造函数时必须传入 WithClock | kernel/clock | 半通用：同上，生产侧检查；移植前提相同 |
+| KERNEL-CLOCK-LEAF-FALLBACK-01 | Medium | callsite-allowlist + typed AST | 禁止在组合根外的生产文件调用 clock.Real()，防止叶层重新引入 wall-clock | kernel/clock | 半通用：思路通用（禁叶层 fallback 构造），移植需项目有 clock.Real() 等价入口 |
+| KERNEL-CLOCK-RESET-RELATIVE-PROD-01 | Medium（推断） | typed AST | 生产代码禁止调用 Timer.Reset(duration)（相对），必须用 ResetAt(deadline) | kernel/clock | 半通用：思路通用（绝对 deadline vs 相对 duration 竞态），移植需项目有 ResetAt/Reset 拆分 |
+| PROD-CLOCK-INJECTION-01 | Medium | callsite-allowlist + typed AST | 生产代码禁止直接引用 stdlib time.Now/Since/Until/NewTimer 等 wall-clock 入口 | kernel/clock | 通用：思路完全通用（生产禁裸 time.Now），移植前提：项目有 clock 抽象；仅需替换 forbidden 函数集 |
+| CONTROL-PLANE-CARVEOUT-ALLOWLIST-LIVE-01 | Medium | callsite-allowlist | 校验控制平面 clock carve-out 白名单条目真实存在（防 rename 孤立） | kernel/clock | 通用：「白名单自验证」模式与任何项目的 carve-out allowlist 完全对等；移植直接照搬 |
+
+---
+
+### 批次 4：生产时长常量（prod_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| PROD-DURATION-CONST-01 | Medium（推断） | typed AST | 生产代码中 time.Duration 字面量必须出现在 package-level const，禁止内联字面量 | — | 通用：不依赖任何 gocell 专属包；换任何 Go 项目均成立，实现可几乎照搬 |
+
+---
+
+### 批次 5：Governance 规则体系（governance_rules_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| GOVERNANCE-RULES-REGISTRATION-GUARD-01 | Hard↓ / Medium↑ | callsite-allowlist + AST-pattern | 声明的 validate*/checkDEP*/checkCH* 方法与 allRules 注册集严格相等，防漏注册 | kernel/governance | 专属：守护的是 GoCell kernel/governance 的注册机制，换项目需完全重新定义 |
+| GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01 | Hard | string-typed-funnel + typed AST | governance 规则 Code 参数必须是 rulecodes.go 里的 RuleCode const，禁止字面量和拼接 | kernel/governance | 专属：RuleCode typed-string 模式绑 kernel/governance 单源文件；思路通用但载体专属 |
+| GOVERNANCE-RULE-ERROR-FIX-FIELD-01 | Hard↓ / Medium↑ | typed-marker-funnel + AST-pattern | governance newError/newWarning 等构造调用的 Fix 参数必须非空且可解析为字面内容 | kernel/governance | 专属：守护 kernel/governance 内部构造函数 Fix 字段；换项目需重定义目标构造函数 |
+| GOVERNANCE-RULE-CODE-DETECT-BINDING-01 | Medium | typed AST | allRules 中每个 Rule.Code 必须在其 Detect 方法体（含 BFS 同 receiver 方法）中被 newError 等引用 | kernel/governance | 专属：闭环验证的是 governance allRules 结构，换项目需重新定义 rule 注册模型 |
+
+---
+
+### 批次 6：cmd 侧 ValidationResult（check_result_fix_field_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CMD-VALIDATIONRESULT-FIX-FIELD-01 | Hard↓ / Medium↑ | AST-pattern + typed AST | cmd/gocell/app 中所有 ValidationResult 字面量必须有非空 Fix 字段 | kernel/governance | 专属：守护 cmd 侧对 kernel/governance.ValidationResult 的直接构造，换项目需重定义目标 |
+
+---
+
+### 批次 7：测试纪律——Eventually / 轮询 / Sleep（test_eventually_funnel_test.go, test_polling_external_reason_literal_test.go, test_sleep_discipline_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| TEST-EVENTUALLY-FUNNEL-01 | Hard（ai-robust.md §Hard 范本，typed-marker-funnel，上游封禁） | typed-marker-funnel | 禁止测试代码直接调用 require/assert.Eventually*，必须走 testwait.External 或 Deterministic | pkg/testutil/testwait | 通用：思路完全通用（统一 wall-clock 轮询出口）；移植需创建等价 testwait 包 + 替换 banned 函数集 |
+| TEST-POLLING-EXTERNAL-REASON-LITERAL-01 | Hard（ai-robust.md §Hard 范本，typed-marker-funnel，下游锁） | typed-marker-funnel | testwait.External 调用必须传 kebab-case const 字面量 reason，禁止变量/空串 | pkg/testutil/testwait | 通用：思路完全通用（强制轮询等待要附理由字面量）；移植需替换 testwait.External 路径 |
+| TEST-SLEEP-DISCIPLINE-01 | Medium（推断） | AST-pattern | 测试文件中每个 time.Sleep 必须携带 `//archtest:allow:test-sleep <reason>` 行注释 | — | 通用：不依赖任何 gocell 专属包，模式完全可移植；换任何 Go 项目照搬 |
+
+---
+
+### 批次 8：测试时间字面量 / testutil 边界 / tracer（test_time_literal_test.go, testutil_boundary_test.go, tracing_simpletracer_test_only_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| TEST-TIME-LITERAL-01 | Medium（推断） | typed AST | 测试代码中 time.Duration 字面量必须在 package-level const，禁止内联（与 PROD-DURATION-CONST-01 互补） | — | 通用：无 gocell 专属依赖，与 PROD-DURATION-CONST-01 互补；可直接移植 |
+| TESTUTIL-BOUNDARY-01 | Medium（推断） | import-ban | 含 "testutil" 路径段的包只能被 _test.go 或测试基础设施包导入 | — | 通用：「testutil 包不得被生产代码 import」是任何 Go 项目均成立的约定；可几乎原样移植 |
+| TRACING-SIMPLETRACER-TEST-ONLY-01 | Medium | import-ban + AST-pattern | 保证 runtime/observability/tracingtest 不被生产代码导入，in-process simpleTracer 仅测试可用 | runtime/observability/tracingtest | 半通用：import-ban 模式通用，但守护的是 GoCell 特定包被删除/隔离的历史决策 |
+
+---
+
+### 批次 9：CI 发现 / race lane（ci_integration_discovery_invariants_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CI-INTEGRATION-DISCOVERY-01 | Medium（推断） | metadata/yaml-derive | CI integration-test step 用 `go list -tags=integration` 发现包，而非硬编码 glob | — | 通用：思路完全通用（CI 测试发现机制防 hardcode），换任何 Go 项目均成立 |
+| CI-RACE-LANE-SUBSET-01 | Medium（推断） | metadata/yaml-derive | CI race lane 的硬编码包列表必须是 integration 发现集的子集，防止 drift | — | 通用：同上，守护 curated 子集与发现集的包含关系；可移植 |
+
+---
+
+### 批次 10：CI 依赖固定 / lint 冒烟 / 集成容器 / slowgate（ci_pinning_test.go, lintgate_smoke_test.go, integration_guard_test.go, slowgate_allowlist_test.go）
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CI-PINNING-WORKFLOW-DIGEST-01 | Medium（推断） | metadata/yaml-derive | 所有外部 GitHub Actions uses 固定到 SHA digest，golangci-lint 固定到 patch 版本 | — | 通用：CI workflow digest pin 是任何 GitHub Actions 项目的供应链安全基准，直接可移植 |
+| DEPENDABOT-COVERAGE-GOLANGCI-01 | Medium（推断） | metadata/yaml-derive | dependabot.yml 必须同时覆盖 golangci-lint-action 和 root gomod block | — | 通用：dependabot 覆盖校验模式与项目无关；换任何使用 dependabot 的项目均成立 |
+| LINT-GATE-SMOKE-01 | Medium（推断） | conformance-test | 用真实 .golangci.yml 跑合成 fixture 模块，行为级证明 lint 规则真实触发（防配置漂移） | — | 通用：lint 配置冒烟验证思路适用任何 Go 项目；移植需替换 golangci-lint 路径和 fixture 内容 |
+| INTEGRATION-GUARD-01 | Medium（推断） | AST-pattern | vault 集成容器失败必须 fail-fast（调用 RequireDocker 预检），禁止 Skip 静默吞错 | — | 通用：集成测试容器启动失败应 fail-fast 而非 skip 是普适约定；移植仅需替换容器函数名 |
+| SLOWGATE-ALLOWLIST-01 | Medium（推断） | AST-pattern + metadata/yaml-derive | slowgate allowlist.txt 中每条记录必须对应真实 TestXxx 函数，且有 # reason 注释 | — | 通用：「慢测试白名单防孤立」模式与 gocell 无关；换项目照搬，替换 allowlist 路径即可 |

--- a/docs/analysis/archtest-spinout/02-catalog-F2-http-obs-pg-adapter.md
+++ b/docs/analysis/archtest-spinout/02-catalog-F2-http-obs-pg-adapter.md
@@ -1,0 +1,125 @@
+# F2 批次编目：HTTP / 可观测性 / Postgres+迁移 / 分布式锁 / Redis / Adapter 契约 / kernel 杂项
+
+本批次覆盖运行时与适配器层约束，主题横跨 HTTP metrics cell 归因、span/health 脱敏漏斗、
+Postgres 迁移安全、分布式锁正确性、Redis keyspace 治理、adapter 错误分类，以及
+kernel 层杂项边界。
+
+本文件 **47 条** | Hard 17 / Medium 23 / Soft 0 / 推断 7 | 通用 3 / 半通用 27 / 专属 17
+
+---
+
+### 批次 1：HTTP metrics 与 HTTP 契约可见性
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01 | Medium（推断） | AST-pattern | 确保 HTTP metrics cell label 来自 ctxkeys 而非构造函数 | `runtime/http/middleware`, `kernel/ctxkeys` | 专属 |
+| HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01 | Medium（推断） | AST-pattern | 禁止从 assembly/config 中派生 cell label | `runtime/http/middleware` | 专属 |
+| HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01 | Medium（推断） | AST-pattern | 禁止在 ProviderCollectorConfig 中注入 CellID | `runtime/http/middleware` | 专属 |
+| HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01 | Medium（推断） | AST-pattern | 缺失 cell 上下文时必须使用 `_runtime` 哨兵 | `runtime/http/middleware` | 专属 |
+| HTTP-METRICS-LABEL-ROUTER-ATTRIBUTION-01 | Medium（推断） | AST-pattern | cell label 归因必须在 router-root 请求上下文写入 | `runtime/http/router` | 专属 |
+| HTTP-CONTRACT-VISIBILITY-TYPE-SEGREGATION-01 | Medium | conformance-test | 禁止单一 Go 类型同时实现公开和内部路径的 contract 接口 | `generated/contracts/http` | 专属 |
+
+### 批次 2：HTTP 工具层与 5xx 单源
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| HTTPUTIL-5XX-KIND-NORMALIZE-01 | Medium（推断） | AST-pattern | 5xx 路径必须使用 errcode.KindXxx 常量而非透传 ecErr.Kind | `pkg/httputil`, `pkg/errcode` | 半通用 |
+| HTTPUTIL-5XX-LOG-REDACT-01 | Medium（推断） | AST-pattern | log5xx 必须经 redaction.RedactSlogAttr 处理 Details 后再写 slog | `pkg/httputil`, `pkg/redaction` | 半通用 |
+| HTTPUTIL-SURFACE-REGISTERED-01 | Medium（推断） | callsite-allowlist | pkg/httputil 每个导出函数必须在 doc.go 或治理 map 中注册 | `pkg/httputil`, `kernel/governance` | 半通用 |
+| WIRE-CODE-5XX-SINGLE-SOURCE-01 | Medium（推断） | AST-pattern | 5xx wire code 单源：PublicCode() 与 PublicCodeForStatus 必须同步扩展 | `pkg/errcode` | 半通用 |
+
+### 批次 3：Metrics 漏斗与 Prometheus cell label
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| OBS-01 | Medium（推断） | conformance-test | errcode classifier 函数需机器可读 ack 才能作 metric label | `tools/metricschema`, `pkg/errcode` | 专属 |
+| METRICS-GAUGEVEC-FUNNEL-01 | Hard | typed-marker-funnel | 禁止在 promwrap/otelwrap 外直接调用 prom.New*/Meter 构造 | `adapters/prometheus/internal/promwrap`, `adapters/otel/internal/otelwrap` | 半通用 |
+| METRICS-GAUGEVEC-UPSTREAM-HARD-01 | Hard | reflect-field-freeze | 冻结 promwrap/otelwrap 内 funnel 导出符号集 | `adapters/prometheus`, `adapters/otel` | 半通用 |
+| METRICS-ADAPTERPROM-CALLER-ALLOWLIST-01 | Hard↓/Medium↑ | callsite-allowlist | 锁定 adapters/prometheus 公开 funnel 函数的调用方文件集 | `adapters/prometheus` | 半通用 |
+| METRICS-CANCEL-CTX-CONFORMANCE-01 | Medium | conformance-test | adapters/ 下每个 metrics.Provider 实现必须入列取消上下文合规测试 | `adapters/otel`, `adapters/prometheus`, `kernel/observability/metrics` | 半通用 |
+| PROM-CELL-LABEL-FUNNEL-01 | Hard | typed-marker-funnel | HookEvent.CellID 读取必须过 promCellLabel 漏斗避免高基数 label | `adapters/prometheus`, `kernel/cell` | 专属 |
+
+### 批次 4：Span 脱敏漏斗
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| SPAN-RECORD-ERROR-REDACT-01 | Hard | typed-marker-funnel | span.RecordError 参数必须包裹 redaction.RedactError | `kernel/wrapper`, `runtime/http/middleware`, `pkg/redaction` | 半通用 |
+| SPAN-RECORD-ERROR-REDACT-ARCHTEST-01 | Medium（推断） | meta-archtest | 确保 span redact 扫描目录覆盖所有含 RecordError 调用的新目录 | `kernel/wrapper`, `runtime/http/middleware` | 半通用 |
+| SPAN-SETATTR-REDACT-01 | Hard | typed-marker-funnel | adapters/otel 所有字符串 span attribute 必须过 safeStringAttr 两层脱敏 | `adapters/otel`, `pkg/redaction` | 半通用 |
+
+### 批次 5：Health verbose 与 healthz 漏斗
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| HEALTH-VERBOSE-WIRE-SHAPE-FROZEN-01 | Hard | reflect-field-freeze | 冻结 /readyz?verbose 响应体 dependency entry 字段集与 json tag | `runtime/http/health` | 专属 |
+| HEALTH-REDACTED-ERROR-MSG-FUNNEL-01 | Hard | typed-marker-funnel | readyz slog error text 必须经 newRedactedErrorMsg→RedactString 漏斗 | `runtime/http/health`, `pkg/redaction` | 半通用 |
+| HEALTHZ-WRITE-01 | Hard | callsite-allowlist | healthz/readyz HTTP handler 注册必须经 healthz.Aggregator 漏斗 | `runtime/http/health`, `runtime/observability/healthz`, `kernel/healthz` | 专属 |
+| HEALTHZ-TYPED-REGISTER-01 | Hard | callsite-allowlist | cells/ 包内调用 reg.Healthz() 必须在 cellgen 生成的 healthz_gen.go 中 | `kernel/cell`, `cells/*` | 专属 |
+| HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01 | Medium | conformance-test | 以 bash 黑盒测试验证 docker cleanup 失败时 exit code 正确传播 | — | 半通用 |
+
+### 批次 6：Readyz probe 命名与 ops-contract funnel
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| READYZ-PROBE-NAMING-01 | Medium | string-typed-funnel | healthz.NewProbe 调用的 probe name 禁止含连字符 | `kernel/healthz` | 专属 |
+| OPS-CONTRACT-STRING-FUNNEL-01 | Hard | string-typed-funnel | adapter 就绪探针名必须是 ReadyProbeName 类型常量且在许可包中声明 | `kernel/healthz`, `adapters/*` | 专属 |
+
+### 批次 7：Postgres 迁移安全
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| MIGRATION-NO-TRANSACTION-RERUN-SAFE-01 | Medium（推断） | metadata/yaml-derive | NO TRANSACTION 迁移的每条 DDL 必须幂等（IF NOT EXISTS 等） | `adapters/postgres/migrations` | 半通用 |
+| MIGRATION-PAIR-DEPLOY-01 | Medium | metadata/yaml-derive | pair-deploy 指令引用的伴侣迁移文件必须存在 | `adapters/postgres/migrations` | 半通用 |
+| MIGRATION-DESTRUCTIVE-DOWN-GUC-GUARD-01 | Medium | AST-pattern | 含破坏性 DDL 的 Down section 必须含 GUC fail-closed 保护 | `adapters/postgres/migrations` | 半通用 |
+| SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE-01 | Medium | metadata/yaml-derive | migration 017+ 创建的每张表必须在 schema_guard expectedColumns 中注册 | `adapters/postgres` | 专属 |
+
+### 批次 8：Postgres 运行时与 SQL builder
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| PG-REPO-AMBIENT-TX-01 | Hard↓/Medium↑ | typed-marker-funnel | pgxpool.Pool 字段只能由 pgExecutor 持有；New* 构造必须过 newPGExecutor | `adapters/postgres` | 半通用 |
+| PG-CONSTRUCTOR-MUST-FREE-01 | Medium（推断） | AST-pattern | adapters/postgres 中禁止声明 MustNew* 类名构造函数 | `adapters/postgres` | 半通用 |
+| PG-TESTCONTAINER-FUNNEL-01 | Medium | callsite-allowlist | PG 集成测试必须通过 pgclone 而非自起 testcontainer 容器 | `tests/testutil/pgclone` | 半通用 |
+| POSTGRES-NOTFOUND-TEST-OTHER-ERROR-MIXUP-ARCHTEST-01 | Hard | typed-marker-funnel | _NotFound 测试必须调 errcodetest.AssertCode 断言正确错误码 | `pkg/errcode/errcodetest` | 半通用 |
+| GOOSE-SESSION-LOCKER-01 | Medium（推断） | callsite-allowlist | goose.NewProvider 必须配置 WithSessionLocker 防并发迁移竞争 | `adapters/postgres` | 半通用 |
+| POSTGRES-MIGRATOR-LOCK-ORDER-REGRESSION-01 | Medium（推断） | callsite-allowlist | 同上，作为 GOOSE-SESSION-LOCKER-01 的回归标签 | `adapters/postgres` | 半通用 |
+| SQLSTATE-SINGLE-SOURCE-01 | Medium | string-typed-funnel | pgconn.PgError.Code 对 pkg/pgquery 所拥有 SQLSTATE 的比较只能在 pkg/pgquery 中 | `pkg/pgquery` | 半通用 |
+
+### 批次 9：CAS 协议、分布式锁与内存事务锁
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| CAS-PROTOCOL-COMPOSITION-ROOT-01 | Medium | callsite-allowlist | cas.NewProtocol 只能在 cmd/* 或 runtime/state/cas/* 内构造 | `runtime/state/cas` | 专属 |
+| DISTLOCK-LOCK-NOT-CONTEXT-01 | Hard↓/Medium↑ | type-system-seal | distlock.Lock 不能实现 context.Context 接口 | `runtime/distlock` | 通用 |
+| MEM-TX-LOCK-OWNERSHIP-01 | Hard（核心）/Medium（层） | AST-pattern | txlock.Acquire 只能在 runLocked 函数体直接调用，inLiveTx 必须委托 Live | `cells/accesscore/internal/mem` | 专属 |
+
+### 批次 10：Redis 不变式
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| IDEMPOTENCY-LUA-HASHTAG-01 | Medium（推断） | AST-pattern | Redis 幂等 Lua EVAL 的 leaseKey/doneKey 必须经 applyHashtag 保证同 slot | `adapters/redis` | 半通用 |
+| REDIS-KEY-NAMESPACE-01 | Medium（推断） | AST-pattern | adapters/redis 四个公开构造函数必须接受 KeyNamespace 并在顶部 Validate | `adapters/redis` | 半通用 |
+
+### 批次 11：Adapter 错误契约
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| ADAPTER-ERROR-CLASSIFICATION-TRANSIENT-01 | Hard | typed-marker-funnel | adapter transient 标记只能由 errcode.WrapInfra 写入；各 adapter 必须路由到该函数 | `pkg/errcode`, `adapters/postgres`, `adapters/redis`, `adapters/s3`, `adapters/rabbitmq` | 半通用 |
+| ADAPTER-NET-TRANSIENT-FUNNEL-01 | Hard | typed-marker-funnel | net.Error 判定只能在许可的 (pkgPath, funcName) 中处理，其余必须委托 errcode.IsTransientNet | `pkg/errcode` | 半通用 |
+| TRANSIENT-NET-HELPER-FORM-01 | Hard | AST-pattern | pkg/errcode.IsTransientNet 体必须含 errors.As(…, net.Error) 且不能 .Timeout() 收窄 | `pkg/errcode` | 半通用 |
+| ADAPTER-RETURNS-DECLARED-TYPES-01 | Medium（推断） | metadata/yaml-derive | adapter HTTP 返回的 status code 必须在 contract.yaml 中声明 | `kernel/metadata`, `cells/*/slices/*/handler.go` | 专属 |
+
+### 批次 12：kernel 杂项与 audit
+
+| INVARIANT ID | 评级 | 机制类型 | 用途（≤30字中文） | 依赖 gocell 包 | 可移植性 |
+|---|---|---|---|---|---|
+| KERNEL-METADATA-NO-WIRE-01 | Medium（推断） | import-ban | kernel/metadata 禁止声明 wire 格式符号（Document/Entity 等） | `kernel/metadata` | 专属 |
+| KERNEL-MUSTCTOR-PRODUCTION-DECL-01 | Medium | callsite-allowlist | 生产包禁止声明 Must* 名前缀函数（carve-out 列表除外） | `kernel/`, `runtime/`, `adapters/`, `cells/` | 通用 |
+| KERNEL-POOLSTATS-LOCATION-01a | Medium（推断） | import-ban | 禁止导入已废弃的 runtime/observability/poolstats 路径 | `kernel/observability/poolstats` | 专属 |
+| KERNEL-POOLSTATS-LOCATION-01b | Medium（推断） | import-ban | kernel/observability/poolstats 包必须保持 import-zero | `kernel/observability/poolstats` | 专属 |
+| PKG-CTXKEYS-NO-CELL-MODEL-01 | Hard↓/Medium↑ | reflect-field-freeze | pkg/ctxkeys 禁止声明 cell/slice/journey/contract 相关标识符 | `pkg/ctxkeys`, `kernel/ctxkeys` | 专属 |
+| CTXCANCEL-LOCAL-IMPL-BAN-01 | Medium（推断） | AST-pattern | cells/*/adapters 禁止本地重新实现 ctx-cancel 错误类型或预检逻辑 | `pkg/ctxcancel`, `cells/` | 半通用 |
+| REPO-LOG-KEY-ID-REDACT-01 | Medium（推断） | AST-pattern | cells/ 禁止在 slog 属性 key 中出现密钥 ID 字面量 | `cells/` | 半通用 |
+| AUDIT-LEDGER-PROTOCOL-COMPOSITION-ROOT-01 | Medium | callsite-allowlist | ledger.NewProtocol 只能在 cmd/* 或 runtime/audit/ledger 中构造 | `runtime/audit/ledger` | 专属 |
+| AUDITCORE-APPENDER-SINGLE-SOURCE-01 | Medium | AST-pattern | auditappend* slice 包必须是 appender.Service 的薄 facade，不能重新定义类型 | `cells/auditcore/internal/appender` | 专属 |
+| YAML-QUOTE-FUNNEL-01 | Hard↓/Medium↑ | string-typed-funnel | yamlsafe.Scalar 转换的参数必须是 yamlsafe.Quote 或已类型化的 Scalar | `pkg/yamlsafe` | 通用 |

--- a/docs/analysis/archtest-spinout/03-rule-reusability-assessment.md
+++ b/docs/analysis/archtest-spinout/03-rule-reusability-assessment.md
@@ -1,0 +1,124 @@
+# 交付物 #3：规则层可移植性评估——哪些能给其他项目用？
+
+> 数据来源：交付物 #2 的 7 份编目（293 条规则行，按实际表格统计；下列数字以表格行为准，与各 agent 汇总行的口径略有出入是因为子规则 -A/-B/-C 拆行）。
+
+---
+
+## 1. 聚合数据
+
+### 1.1 可移植性三档（全局）
+
+| 档 | 条数 | 占比 | 含义 |
+|----|------|------|------|
+| **通用** | 46 | ~16% | 概念可直接迁移、实现近乎照搬 |
+| **半通用** | 87 | ~30% | 思路可迁移，但绑了项目专属包/抽象，需重写载体 |
+| **专属** | 160 | ~55% | 只在 GoCell 架构语义下成立 |
+
+### 1.2 按主题分布（可移植性）
+
+| 编目 | 主题 | 通用 | 半通用 | 专属 |
+|------|------|:----:|:-----:|:----:|
+| A | 引擎自检 / meta / 分层 | **21** | 10 | 2 |
+| B | outbox / rmq / saga | 2 | 4 | **34** |
+| C | cell / contract / assembly | 0 | 3 | **41** |
+| D | codegen / scaffold / bootstrap | 2 | 13 | **28** |
+| E | auth / session / security | 1 | 16 | **28** |
+| F1 | 卫生：errcode/clock/test/ci | **17** | 11 | 6 |
+| F2 | http/obs/pg/adapter | 3 | **30** | 21 |
+
+**两个信号一眼可见：**
+1. **通用规则高度集中在 A（21）和 F1（17）= 38/46**。其余主题几乎全是专属或半通用。
+2. **Soft 档全局 ≈ 0**（293 条里仅个位数）。这是 GoCell「AI-robust 严禁 Soft 立项」纪律的直接体现——绝大多数是 Hard 或 Medium。这点对"给自己用"是好事：搬过去的规则要么编译期挡死，要么 archtest 静态挡死，不靠字符串约定。
+
+---
+
+## 2. 关键纠偏：A 的 21 条「通用」是引擎自带，不是「业务规则」
+
+A 组那 21 条标"通用"的（`PASS-FUNNEL-*`、`SCANNER-FRAMEWORK-USAGE-*`、`INVENTORY-ANCHOR-*`、`TYPESEVAL-EVAL-PREDICATE-CENTRALIZED-01`、`ARCHTEST-TESTMAIN-01`、`PRODUCTION-LOADER-FUNNEL-01` …）是**引擎用来约束"规则作者别乱用引擎"的 meta-archtest**。
+
+- 它们"通用"是指**不含 gocell 业务语义**，但**只有在你使用 archtest 引擎本身时才有意义**。
+- 它们**随引擎自动搬走**（交付物 #1 已把它们划入引擎自检），不需要你单独"采纳"。
+- 所以谈"哪些业务规则能给新项目用"时，**应把 A 的 21 条排除**——它们是引擎的一部分，不是可挑选的卫生规则。
+
+**排除 A 后，真正"可挑选移植到任意 Go 项目"的通用规则 = 25 条**（F1 17 + F2 3 + B 2 + D 2 + E 1）。
+
+---
+
+## 3. 第一档：真正可直接移植的规则（~20 条，建议照搬）
+
+排除引擎自检后，这些是**换任意 Go 项目都成立、实现可几乎照搬**的——它们就是你想要的"Go 编码规范检查器"的内容：
+
+### 3.1 测试纪律（最干净，零 gocell 依赖）
+
+| 规则 | 作用 | 移植前提 |
+|------|------|---------|
+| `TEST-SLEEP-DISCIPLINE-01` | 测试禁裸 `time.Sleep` | 无，照搬 |
+| `TEST-TIME-LITERAL-01` | 测试禁裸 wall-clock 时间字面量 | 无，照搬 |
+| `TEST-EVENTUALLY-FUNNEL-01` | 轮询等待统一走 testwait 出口 | 建等价 testwait 包 |
+| `TEST-POLLING-EXTERNAL-REASON-LITERAL-01` | 强制轮询附理由字面量 | 同上 |
+| `TESTUTIL-BOUNDARY-01` | testutil 包不得被生产代码 import | 无，照搬 |
+| `INTEGRATION-GUARD-01` | 集成测试容器启动失败 fail-fast 而非 skip | 替容器函数名 |
+| `SLOWGATE-ALLOWLIST-01` | 慢测试白名单防孤立 | 替 allowlist 路径 |
+
+### 3.2 错误 / panic / 时钟卫生（思路通用，绑一个你自己的小抽象）
+
+| 规则 | 作用 | 移植前提 |
+|------|------|---------|
+| `EXPORTED-ERROR-NEW-01` | 禁 exported `errors.New`，走统一 error code | 项目有统一 error 包 |
+| `PANIC-REGISTERED-01` | 所有 panic 过统一 `Approved` 标记 | 建等价 panicregister 包 |
+| `PROD-CLOCK-INJECTION-01` | 生产禁裸 `time.Now` | 项目有 clock 抽象 |
+| `PROD-DURATION-CONST-01` | 时长必须命名常量，禁裸字面量 | 无，照搬 |
+| `CONTROL-PLANE-CARVEOUT-ALLOWLIST-LIVE-01` | carve-out 白名单自验证（白名单项必须真实存在） | 照搬模式 |
+| `KERNEL-MUSTCTOR-PRODUCTION-DECL-01` | 生产包禁 `Must*` 前缀函数 | 调整 carve-out |
+
+### 3.3 CI / 供应链 / 配置卫生（与 Go 项目无关，纯工程纪律）
+
+| 规则 | 作用 | 移植前提 |
+|------|------|---------|
+| `CI-PINNING-WORKFLOW-DIGEST-01` | GitHub Actions 按 digest pin | 任何用 GHA 的项目 |
+| `DEPENDABOT-COVERAGE-GOLANGCI-01` | dependabot 覆盖校验 | 用 dependabot 即可 |
+| `LINT-GATE-SMOKE-01` | lint 配置冒烟自验 | 替 golangci 路径 |
+| `CI-INTEGRATION-DISCOVERY-01` / `CI-RACE-LANE-SUBSET-01` | CI 测试发现防 hardcode、lane 子集包含 | 调整发现脚本 |
+
+### 3.4 其他零散通用
+
+`EVENT-PAYLOAD-CAMELCASE-01` / `EVENT-DTO-CAMELCASE-01`（JSON 字段 camelCase）、`ROLE-ADMIN-LITERAL-01`（魔法字符串单源常量）、`YAML-QUOTE-FUNNEL-01`（YAML 转义统一出口）、`DISTLOCK-LOCK-NOT-CONTEXT-01`（类型不得意外实现某接口）、`SCAFFOLD-INPUT-CONTRACT-TYPED-ID-01` / `PATHSAFE-PLANSET-FUNNEL-01`（typed-id / 私有字段 funnel，模式通用）。
+
+> **这 ~20 条就是 archtest 规则库里"可作通用 Go 检查器"的全部内容。** 注意它们几乎全是"卫生 / 纪律"类，没有一条是"架构语义"类——后者天然绑项目。
+
+---
+
+## 4. 第二档：可移植的「机制模式」（87 条半通用 → 收敛为 ~8 个模式）
+
+87 条半通用不值得逐条搬（载体都绑了 gocell 包），但它们体现的**机制模式**可在新项目复用。把它们去重，得到约 8 个可复用模式：
+
+| 模式 | 代表规则 | 在新项目怎么用 |
+|------|---------|---------------|
+| **clock 注入 funnel** | `CLOCK-INJECTION-*` / `KERNEL-CLOCK-*` | 你引入 clock 抽象后，照此约束注入点 |
+| **error-first 构造** | `ERROR-FIRST-API-01` / `ERROR-FIRST-TYPED-NIL-01` | 构造函数 `(*T, error)` + nil-guard |
+| **message const-literal（防 PII）** | `MESSAGE-CONST-LITERAL-01` / `DETAILS-SLOG-ATTR-01` | 错误 message 禁 runtime 拼接 |
+| **redaction funnel** | `SPAN-*-REDACT-*` / `PANIC-REDACT-01` / `REPO-LOG-KEY-ID-REDACT-01` | 日志/trace 出站统一脱敏出口 |
+| **single-source const / string-typed funnel** | `*-SINGLE-SOURCE-*` / `OPS-CONTRACT-STRING-FUNNEL-01` | 魔法字符串类型化 + 单源声明 |
+| **sealed holder / 私有字段** | `*-HOLDER-SEAL-*` / `*-FIELDS-FROZEN-*` | 唯一持有者 + 包外不可构造 |
+| **callsite allowlist** | `*-CALLER-ALLOWLIST-*` / `*-CALLER-01` | 某敏感方法只能在 N 处被调 |
+| **migration / SQL 纪律** | `MIGRATION-*` / `SQLSTATE-SINGLE-SOURCE-01` / `PGQUERY-01` | 迁移可重入、SQL builder 归位 |
+
+**这一档才是引擎的真正价值落点**：引擎提供"语法"（`ResolveMethodCall` / `EvaluateConstString` / `AssertGolden` / sealed-holder 检测），你用这些语法把上述模式**贴着自己项目的包**重新表达成规则。
+
+---
+
+## 5. 第三档：160 条专属，不可移植
+
+B（outbox/rmq/saga 34）、C（cell/contract/assembly 41）、E（auth/session 28）、D（codegen 28）的主体——它们锁的是 GoCell 的 cell/slice/contract/outbox/saga/assembly 模型与 accesscore 的 session/credential/epoch 协议。**换项目这些概念不存在，规则一文不值。** 这 55% 是 archtest 不可作为"通用规则库"分发的根本原因。
+
+---
+
+## 6. 给「自己用」的结论
+
+| 你想要的东西 | 该怎么做 |
+|-------------|---------|
+| 一套现成的「Go 编码规范」规则 | **只有 ~20 条可搬**（§3），且全是卫生/纪律类。值得抄进新项目，但量不大——很多还能直接用 golangci-lint 现成 linter 覆盖（见交付物 #4）。 |
+| 写自己架构不变式的「引擎」 | **搬引擎（交付物 #1），自己写规则**。86% 的规则（半通用+专属）证明：规则必须贴着每个项目的架构长出来，引擎给你写规则的能力，而不是规则本身。 |
+| 「重武器级」约束（sealed holder / golden funnel / callsite allowlist） | 引擎能给——这是 golangci/ruleguard/depguard 给不了的（交付物 #4 §5）。但**先确认你的个人项目真有这种需求**，否则是过度工程。 |
+
+**一句话**：可直接移植的规则只有 ~20 条卫生规则（占 7%），且大半能被 golangci-lint 覆盖；archtest 真正值得带走的是**引擎 + 第二档那 8 个机制模式的"写法"**，而不是规则清单。这与交付物 #1 的结论一致：**搬引擎，不搬规则。**

--- a/docs/analysis/archtest-spinout/04-why-not-existing-tools.md
+++ b/docs/analysis/archtest-spinout/04-why-not-existing-tools.md
@@ -1,0 +1,113 @@
+# 交付物 #4：为什么没用 go/analysis / analysistest / gorules DSL / depguard——是不是重复造轮子？
+
+> 结论先行：**不是整体重复造轮子，但引擎层有一处"薄重复"且团队有据可查地主动选择了它。** archtest 实际是「在 `go/packages` 上自建了一个比 `go/analysis` 更轻、且多了一道安全闸的 Pass 模型」。它对 depguard 不是重复——它**主动把能交给 depguard 的都交了出去**。
+
+---
+
+## 0. 先厘清"轮子"指哪一层
+
+| 候选工具 | 解决的问题 | 与 archtest 的关系 |
+|---------|-----------|-------------------|
+| **depguard** | 路径级 import 禁止 | archtest **依赖并复用**它，不重复 |
+| **go-ruleguard (gorules DSL)** | AST 模式匹配（DSL 写规则） | 未采用；archtest 用全 Go 写规则 |
+| **go/analysis + analysistest** | 标准 analyzer 框架（Pass / Fact / Requires DAG） | archtest **自建了等价但更轻的 Pass**，这是唯一的"薄重复" |
+
+下面逐个说清"用了 / 没用 / 为什么"。
+
+---
+
+## 1. depguard —— 没有重复，反而是边界自觉的范例
+
+`.golangci.yml` 里能直接读到 archtest 的自我克制：
+
+```
+# Architecturally equivalent to archtest's former LAYER-01..04 allow-list
+#   ... [moved to depguard (.golangci.yml linters.settings.depguard.rules)]
+```
+
+`doc.go` 也写明：`LAYER-01..04` 这种"纯 import 路径禁止"**已经从 archtest 迁出，交给 depguard**。archtest 只保留 depguard **表达不了**的：
+
+- `LAYER-05/06` 子包归属（"cell A 不能 import cell B 的 `internal/`"，需要 owner 语义）
+- `LAYER-05T/06T` **传递闭包**（depguard 只看直接 import，看不到 N 层间接）
+- `LAYER-08` 类型级缺席（走 `types.Scope()`，字符串扫描会误伤注释/struct tag）
+- `LAYER-10` exported API 不得暴露具体 adapter 类型（需要类型信息）
+
+**判定：对 depguard 零重复。** archtest 的载体决策原则（`.claude/rules/gocell/ai-robust.md`）明文规定"路径级 import ban → depguard"，这是分工不是重叠。
+
+---
+
+## 2. go-ruleguard（gorules DSL）—— 主动不用，理由成立
+
+ruleguard 让你用一种类 Go 的 DSL 写 AST 模式（`m.Match("$x == nil")`）。archtest 没用它，全部规则是**纯 Go 测试函数**。
+
+**为什么这个选择对 archtest 成立**（结合本项目宪法 `ai-robust.md`）：
+
+1. **AI-robust 要"违反不可表达"，DSL 给不了类型系统级保证。** archtest 的 Hard 档大量依赖 Go 类型系统本身（sealed interface、unexported envelope、`*types.Package` 而非 `*packages.Package`、reflect 字段冻结）。这些在 ruleguard DSL 里**无法表达**——DSL 只能做语法/有限语义匹配，做不到"让违反编译不过"。
+2. **archtest 的规则远超模式匹配。** 典型规则形态是「callsite allowlist + golden 字节锁 + 跨包 const 求值」，例如 `OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01`、`SPAN-SETATTR-REDACT-01` 的双向锁。ruleguard 的单模式匹配做不了这种组合断言。
+3. **全 Go 可调试、可复用 helper。** 规则作者直接用 `EvaluateConstString` / `ResolveMethodCall`，比在 DSL 里拼模式更可控。
+
+**代价（诚实）**：archtest 规则比 ruleguard 啰嗦得多——一条规则动辄几百行，而 ruleguard 可能 3 行。对"只想要简单模式检查"的项目，archtest 是重武器。
+
+**判定：不是重复造轮子，是为 AI-robust 目标做的有意取舍。** 但若你的个人项目只需要"禁止某 AST 模式"，ruleguard 更划算。
+
+---
+
+## 3. go/analysis + analysistest —— 唯一的"薄重复"，但有白纸黑字的理由
+
+这是最值得审视的一点。`pass.go` 的 `Pass`/`Run`/`RunTyped` 本质是在 `golang.org/x/tools/go/packages` 上**自建了一个 Pass 模型**，而没有用标准的 `go/analysis.Pass` + `analysistest.Run`。
+
+引擎甚至**完全没有 import `go/analysis`**——它只在 `// ref:` 注释里参照其设计。`scanner/doc.go` 有专门一节解释：
+
+> **# Why not go/analysis**
+> GoCell archtests have no inter-rule dependencies (no Requires/FactType DAG), so the lighter AST scanner API is preferred over go/analysis.Analyzer.
+
+### 3.1 团队给出的理由（成立）
+
+go/analysis 的核心增量价值是 **analyzer 之间的依赖编排**：`Analyzer.Requires` 形成 DAG，`Fact` 在 analyzer 间传递，driver 负责拓扑排序与缓存。archtest 的规则**彼此完全独立**（一条规则一个 `Test*`，无 Requires/Fact），所以 go/analysis 的 DAG/Fact 机制对它是纯负担——白付框架复杂度，拿不到收益。
+
+### 3.2 自建 Pass 还多换来一道闸（INV-1 防护）
+
+archtest 的自建 Pass 不是简单重复，它故意做了一件 go/analysis 不做的事：
+
+- `Pass.Pkg` 类型是 **`*types.Package`（go/types 标准库）而非 `*packages.Package`（x/tools）**。
+- 因此规则作者**拿不到 `.Syntax`**，无法重新发起一次 `packages.Load`。
+- 这从编译期消除了一类 bug（ADR 命名 **INV-1**）：拿 A 次 load 的 AST 节点去配 B 次 load 的 `types.Info`，会得到静默错误结果。
+
+go/analysis 的 `Pass.Files` + `Pass.TypesInfo` 是平铺暴露的，挡不住这类误用。archtest 用"窄化的 Pass + depguard 禁止直接 import `go/packages` + meta-archtest 再查一遍"三道防线把它变成**不可表达**。这是 AI-robust 哲学（主要作者是 AI，要"违反不可表达"）的直接产物。
+
+### 3.3 代价（诚实）
+
+- **放弃了 analysistest 的 `// want "..."` 黄金范式**——archtest 自己实现了 `RunTypedDir`（红夹具独立 module）+ `AssertGolden` 来替代，确实是重写了 analysistest 已有的能力。
+- **放弃了 go vet / golangci-lint 的 analyzer 生态对接**——archtest 规则只能 `go test` 跑，不能作为 `go vet` analyzer 被复用。
+- 自建 Pass 的驱动逻辑（test-variant 排序、`*ast.File` 指针去重）是 ~200 行本可省掉的代码。
+
+### 3.4 判定
+
+**这是一处真实但理性的薄重复。** 衡量标准：
+- 若目标是"接入 go vet / 标准 analyzer 生态 / 用 `// want` 写测试" → 用了 go/analysis 更好，archtest 在这点上是重复造轮子。
+- 若目标是"AI-robust：让一类跨 load 误用编译期不可表达 + 不需要 analyzer DAG" → go/analysis 给不了 INV-1 闸，自建 Pass 是合理的。
+
+GoCell 选了后者，并在 ADR `202605141519-adr-archtest-pass-funnel.md` 与 `scanner/doc.go` 留了决策记录——属于"知情的重复"，不是"无知的重复"。
+
+---
+
+## 4. 综合裁决
+
+| 维度 | 是否重复造轮子 | 说明 |
+|------|--------------|------|
+| import 层禁止 | ❌ 否 | 主动交给 depguard，边界清晰 |
+| AST 模式匹配 | ❌ 否（但更重） | 弃 ruleguard DSL 换全 Go + 类型系统级 Hard 保证 |
+| Pass / 加载 / 测试范式 | ⚠️ **薄重复** | 自建 Pass 而非用 go/analysis，为 INV-1 闸 + 免 DAG 负担，有 ADR 背书 |
+| 规则本身 | ❌ 否 | 313 条领域不变式，无任何现成工具能替代（见交付物 #2/#3） |
+
+**一句话**：archtest 不是"不知道有 go/analysis 而瞎造"，而是"知道 go/analysis，判断它的 DAG/Fact 用不上、且它的平铺 Pass 挡不住 INV-1，于是造了一个更轻、约束更强的替代"。**重复的只是 Pass 驱动那 ~200 行，且换来了一道编译期安全闸。**
+
+---
+
+## 5. 对"独立给自己用"的影响
+
+如果你把引擎抽出去自己用，这个"薄重复"决定了它的定位：
+
+- 它**不会**变成一个 go vet 插件或 golangci-lint linter——它是个 `go test` 库。
+- 它的卖点正是 go/analysis / ruleguard / depguard **都给不了**的那部分：**类型感知的、编译期不可绕过的架构不变式 funnel**（sealed holder / golden 字节锁 / callsite allowlist / `*types.Package` 窄化）。
+- 反过来说：**如果你的个人项目用不到这种"重武器级"约束，直接上 golangci-lint（含 depguard + 内置 ruleguard 通道）就够了，搬这个引擎是过度工程。** 这条判断是交付物 #3 的前提。

--- a/docs/analysis/archtest-spinout/README.md
+++ b/docs/analysis/archtest-spinout/README.md
@@ -1,0 +1,77 @@
+# archtest 独立化分析
+
+> 问题：**tools/archtest 能否独立出仓库，成为一个 Go 编码规范检查器，给自己用？**
+> 分析日期：2026-05-27 ｜ 范围：`tools/archtest`（629 个 `*_test.go`，~95k 行；183 个文件含 INVARIANT 锚点，293 条去重规则行）
+
+---
+
+## 一句话结论
+
+archtest 是**两层叠加**：一个**项目无关、依赖干净（仅 `x/tools`+`x/sync`）的规则引擎**，加上**一套 86% 绑死 GoCell 架构的规则**。
+
+- ✅ **引擎可以独立**，~1.5 天工作量，是真正值钱、可复用的资产。
+- ❌ **规则不能作为"现成规范库"分发**：仅 ~16% 通用，其中可挑选移植的只有 ~20 条卫生规则。
+- ⚠️ **没用 go/analysis 是知情取舍**（自建 Pass 换 INV-1 安全闸 + 免 DAG 负担），不是无知造轮子；对 depguard/ruleguard 是分工不是重复。
+
+**行动建议：搬引擎，自己写规则。** 若个人项目用不到 sealed-holder / golden-funnel 这类重武器，直接用 golangci-lint（含 depguard + ruleguard）更划算。
+
+---
+
+## 交付物
+
+| # | 文件 | 内容 |
+|---|------|------|
+| 1 | [01-extraction-manifest.md](01-extraction-manifest.md) | **精确抽离清单**：必搬文件（含行数）、3 处 repo 耦合改点、新 go.mod、搬迁步骤、~1.5 天工作量估算 |
+| 2 | [02-catalog-A …](02-catalog-A-engine-meta-layering.md) ~ [F2](02-catalog-F2-http-obs-pg-adapter.md) | **完整能力清单**：293 条规则，逐条评级 / 机制类型 / 用途 / gocell 依赖 / 可移植性。按主题 7 个文件，每文件分批次 |
+| 3 | [03-rule-reusability-assessment.md](03-rule-reusability-assessment.md) | **规则可移植性评估**：三档统计、可直接移植的 ~20 条点名、8 个可复用机制模式、为何 55% 专属 |
+| 4 | [04-why-not-existing-tools.md](04-why-not-existing-tools.md) | **是否重复造轮子**：逐一对比 go/analysis / analysistest / ruleguard / depguard，裁决"薄重复但有据" |
+
+### 交付物 #2 编目分册
+
+| 分册 | 主题 | 规则数 |
+|------|------|:------:|
+| [A](02-catalog-A-engine-meta-layering.md) | 引擎自检 / meta-archtest / 分层 import | 33 |
+| [B](02-catalog-B-outbox-rmq-saga.md) | Outbox / RMQ / Saga / Relay / Subscription | 40 |
+| [C](02-catalog-C-cell-contract-assembly.md) | Cell / Contract / Assembly / Metadata | 44 |
+| [D](02-catalog-D-codegen-scaffold-bootstrap.md) | Codegen / Scaffold / Bootstrap 装配 | 43 |
+| [E](02-catalog-E-auth-session-security.md) | 认证 / 会话 / 凭证 / 安全 / 角色 | 45 |
+| [F1](02-catalog-F1-hygiene-errcode-clock-test-ci.md) | 卫生：errcode / panic / clock / 测试纪律 / CI | 34 |
+| [F2](02-catalog-F2-http-obs-pg-adapter.md) | HTTP / 可观测性 / Postgres / Adapter | 54 |
+
+---
+
+## 聚合看板
+
+### 可移植性（293 条）
+
+```
+通用    ████████                          46  (16%)   ← 含 21 条引擎自检（随引擎走），真正可挑选 ~25
+半通用  ███████████████                   87  (30%)   ← 收敛为 ~8 个可复用机制模式
+专属    ███████████████████████████      160  (55%)   ← cell/contract/outbox/saga/session 语义，不可移植
+```
+
+### AI-robust 评级
+
+```
+Hard / Medium 占绝对多数，Soft ≈ 0
+```
+GoCell「严禁 Soft 立项」纪律的结果：搬走的规则要么编译期挡死、要么 archtest 静态挡死，不靠字符串约定。
+
+### 引擎纯净度（已用 go list 核实）
+
+```
+引擎非测试代码  →  零 gocell 业务包依赖
+第三方依赖      →  仅 golang.org/x/tools + golang.org/x/sync
+repo 耦合点     →  仅 3 处（build-tag 清单 / generated 前缀 / 默认跳过目录），均易参数化
+```
+
+---
+
+## 怎么读
+
+- 想知道**搬不搬、怎么搬** → 先读 **#1**。
+- 想知道**到底有哪些能力、哪条规则干什么** → 查 **#2** 对应主题分册。
+- 想知道**哪些规则能抄进自己项目** → 读 **#3**。
+- 想知道**为什么不用现成工具、是不是造轮子** → 读 **#4**。
+
+> 注：`_master_data.txt` 是生成编目用的原始 ID→文件→依赖映射，可删。


### PR DESCRIPTION
## 摘要

分析 `tools/archtest` 能否独立成通用 Go 编码规范检查器，产出 4 类交付物：

- **#1 引擎抽离清单** — 仅 `x/tools` + `x/sync` 依赖，3 处 repo 耦合，约 1.5 天工作量
- **#2 完整能力编目** — 293 条规则（评级 / 机制 / 用途 / 依赖 / 可移植性，7 主题分册 A–F2）
- **#3 规则可移植性评估** — 通用 46 / 半通用 87 / 专属 160
- **#4 与 go/analysis / ruleguard / depguard 对比裁决**

**结论：搬引擎、不搬规则**；55% 规则绑死 GoCell 架构语义不可移植。

## 改动

`docs/analysis/archtest-spinout/` 下 11 个新文档，纯新增 1273 行，无代码改动、无冲突风险。

🤖 Generated with [Claude Code](https://claude.com/claude-code)