### PR TITLE
chore: 归集本地游离改动（rubric 例外 + pr-review skill + shell-tools hook）

### DIFF
--- a/.claude/hooks/bash-storm-guard.sh
+++ b/.claude/hooks/bash-storm-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: 抑制 bash 风暴。
+#   1) 去重：同一条命令在 DUP_WINDOW 秒内重复 → deny。
+#   2) 限流：BURST_WINDOW 秒内 bash 调用数 >= BURST_MAX → deny。
+# fail-open：任何内部异常一律放行——绝不因 hook 自身故障 brick 掉 bash。
+# 阈值按需调。harness 直接执行本脚本，内部 awk/cksum 不经 Bash 工具、不被拦。
+
+DUP_WINDOW=12
+BURST_WINDOW=6
+BURST_MAX=5
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat) || exit 0
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+[ -z "$cmd" ] && exit 0
+
+sid=$(printf '%s' "$input" | jq -r '.session_id // "default"' 2>/dev/null)
+sid=$(printf '%s' "${sid:-default}" | tr -cd 'A-Za-z0-9-')
+[ -z "$sid" ] && sid=default
+
+now=$(date +%s 2>/dev/null) || exit 0
+hash=$(printf '%s' "$cmd" | cksum 2>/dev/null | cut -d' ' -f1)
+[ -z "$hash" ] && exit 0
+log="${TMPDIR:-/tmp}/claude-bashguard-${sid}.log"   # 行: "<epoch> <hash>"
+
+emit_deny() {
+  jq -nc --arg r "$1" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}' 2>/dev/null
+  exit 0
+}
+
+maxw=$DUP_WINDOW; [ "$BURST_WINDOW" -gt "$maxw" ] 2>/dev/null && maxw=$BURST_WINDOW
+recent=$(awk -v c="$now" -v w="$maxw" '($1+w)>=c' "$log" 2>/dev/null)
+dup=$(printf '%s\n' "$recent" | awk -v c="$now" -v w="$DUP_WINDOW" -v h="$hash" '($1+w)>=c && $2==h{n++} END{print n+0}' 2>/dev/null)
+cnt=$(printf '%s\n' "$recent" | awk -v c="$now" -v w="$BURST_WINDOW" '($1+w)>=c && NF{n++} END{print n+0}' 2>/dev/null)
+
+[ "${dup:-0}" -ge 1 ] 2>/dev/null && emit_deny "重复命令：近 ${DUP_WINDOW}s 内已发过同一条 bash。停手，等上一条结果回来再决定，别重发。"
+[ "${cnt:-0}" -ge "$BURST_MAX" ] 2>/dev/null && emit_deny "bash 过密：近 ${BURST_WINDOW}s 内已 ${cnt} 条 bash（上限 ${BURST_MAX}）。停手——等结果、合并意图，确需多条时逐条来。"
+
+{ printf '%s %s\n' "$now" "$hash" >> "$log"
+  t=$(mktemp 2>/dev/null) && awk -v c="$now" -v w="$maxw" '($1+w)>=c' "$log" > "$t" 2>/dev/null && mv "$t" "$log"
+} 2>/dev/null || true
+exit 0

--- a/.claude/hooks/exitplan-self-audit.sh
+++ b/.claude/hooks/exitplan-self-audit.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
-# PreToolUse(ExitPlanMode) hook: 首次退出 plan mode 时注入一次计划自检。
-# 本会话首次调用 ExitPlanMode 时 deny 并回喂自检问题，迫使重审计划；
-# 重新提交（第二次调用）即放行。状态按 session_id 隔离，每会话仅一次。
-#
-# 本脚本由 harness 直接执行，不经 Bash 工具，故不受 permissions.deny 约束。
+# PreToolUse(ExitPlanMode) hook: 本会话首次退出 plan mode 时 deny 并回喂自检问题，
+# 迫使重审计划后重新提交即放行。状态按 session_id 隔离，每会话仅一次。
 set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0   # jq 缺失则放行，不阻塞退出 plan mode
 
 input=$(cat)
 sid=$(printf '%s' "$input" | jq -r '.session_id // "default"')
+sid=$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9-')   # 消毒：杜绝路径穿越
+[ -n "$sid" ] || sid="default"
 state="${TMPDIR:-/tmp}/claude-exitplan-audited-${sid}"
 
-# 本会话已自检过 → 放行（无输出等价 allow）
-if [ -f "$state" ]; then
-  exit 0
-fi
+[ -f "$state" ] && exit 0   # 已自检过 → 放行
 
-# 首次：打标记 + deny，把自检问题回喂模型，迫使重审后重新提交计划
-touch "$state"
+# 先 deny 后打标记：jq 失败则标记不落盘，避免 hook 被永久旁路
 jq -nc '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
@@ -24,3 +21,4 @@ jq -nc '{
     permissionDecisionReason: "措施符合彻底、不向后兼容 措施优雅简洁、AI HARD的原则吗"
   }
 }'
+touch "$state"

--- a/.claude/hooks/exitplan-self-audit.sh
+++ b/.claude/hooks/exitplan-self-audit.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse(ExitPlanMode) hook: 首次退出 plan mode 时注入一次计划自检。
+# 本会话首次调用 ExitPlanMode 时 deny 并回喂自检问题，迫使重审计划；
+# 重新提交（第二次调用）即放行。状态按 session_id 隔离，每会话仅一次。
+#
+# 本脚本由 harness 直接执行，不经 Bash 工具，故不受 permissions.deny 约束。
+set -euo pipefail
+
+input=$(cat)
+sid=$(printf '%s' "$input" | jq -r '.session_id // "default"')
+state="${TMPDIR:-/tmp}/claude-exitplan-audited-${sid}"
+
+# 本会话已自检过 → 放行（无输出等价 allow）
+if [ -f "$state" ]; then
+  exit 0
+fi
+
+# 首次：打标记 + deny，把自检问题回喂模型，迫使重审后重新提交计划
+touch "$state"
+jq -nc '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: "措施符合彻底、不向后兼容 措施优雅简洁、AI HARD的原则吗"
+  }
+}'

--- a/.claude/hooks/no-shell-text-tools.sh
+++ b/.claude/hooks/no-shell-text-tools.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: 禁止用 shell 文本工具替代专用工具。
+# 拦截 awk / sed / grep / python / python3 / echo / cat —— 包括出现在
+# 管道、&&、;、$()、反引号等复合命令中的用法（prefix deny 规则无法覆盖）。
+#
+# 替代方案：读文件用 Read；搜索用 Grep / Glob；改文件用 Edit / Write；
+# bash 只跑真命令（go / git / gh / rm 等）。
+#
+# 本脚本由 harness 直接执行，不经 Bash 工具，故不受 permissions.deny 约束。
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+# 命令调用位置：行首 / 空白 / | / & / ; / ( / 反引号 / $( 之后，
+# 后接可选空白与目标命令名，且其后不是标识符字符（避免误伤 catalog / sedna 等）。
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]|&;(`]|\$\()[[:space:]]*(awk|sed|grep|python3?|echo|cat)([^A-Za-z0-9_./-]|$)'; then
+  jq -nc '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "禁止 awk/sed/grep/python/python3/echo/cat：读文件用 Read，搜索用 Grep/Glob，改文件用 Edit/Write，bash 只跑真命令(go/git/gh/rm 等)。"
+    }
+  }'
+fi

--- a/.claude/hooks/no-shell-text-tools.sh
+++ b/.claude/hooks/no-shell-text-tools.sh
@@ -1,25 +1,21 @@
 #!/usr/bin/env bash
-# PreToolUse(Bash) hook: 禁止用 shell 文本工具替代专用工具。
-# 拦截 awk / sed / grep / python / python3 / echo / cat —— 包括出现在
-# 管道、&&、;、$()、反引号等复合命令中的用法（prefix deny 规则无法覆盖）。
-#
-# 替代方案：读文件用 Read；搜索用 Grep / Glob；改文件用 Edit / Write；
-# bash 只跑真命令（go / git / gh / rm 等）。
-#
-# 本脚本由 harness 直接执行，不经 Bash 工具，故不受 permissions.deny 约束。
+# PreToolUse(Bash) hook: 拦截 awk/sed/grep/echo/cat（含管道/复合命令内），强制改用
+# Read/Grep/Glob/Edit/Write。harness 直接执行、不经 Bash 工具，故本脚本自身用 grep/jq
+# 不被拦也不递归。
 set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0   # jq 缺失则放行
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 
-# 命令调用位置：行首 / 空白 / | / & / ; / ( / 反引号 / $( 之后，
-# 后接可选空白与目标命令名，且其后不是标识符字符（避免误伤 catalog / sedna 等）。
-if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]|&;(`]|\$\()[[:space:]]*(awk|sed|grep|python3?|echo|cat)([^A-Za-z0-9_./-]|$)'; then
+# 命令名出现在 行首/空白/|/&/;/(/反引号/$( 之后，且其后非标识符字符（避免误伤 catalog/sedna）
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]|&;(`]|\$\()[[:space:]]*(awk|sed|grep|echo|cat)([^A-Za-z0-9_./-]|$)'; then
   jq -nc '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: "禁止 awk/sed/grep/python/python3/echo/cat：读文件用 Read，搜索用 Grep/Glob，改文件用 Edit/Write，bash 只跑真命令(go/git/gh/rm 等)。"
+      permissionDecisionReason: "禁止 awk/sed/grep/echo/cat：读文件用 Read，搜索用 Grep/Glob，改文件用 Edit/Write。"
     }
   }'
 fi

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -35,7 +35,7 @@ gh pr view <N> --json additions,deletions --jq '.additions + .deletions'
 
 ```bash
 BRANCH=$(gh pr view <N> --json headRefName --jq .headRefName)
-WORKTREE=$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH" '/^worktree /{w=$2} $0=="branch "b{print w; exit}')
+git worktree list   # 从输出中找 [<BRANCH>] 所在行，其首列路径即该分支 worktree，记为 WORKTREE；无匹配行 → 情况 B
 ```
 
 **情况 A：找到既有 worktree** → 直接用 `$WORKTREE`，不动其状态。

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -132,13 +132,15 @@ PR body 包含：Summary、`Refs: <ID>`、`ref: framework file`、Test plan chec
 
 **L1/L2**：1 个 `reviewer` agent（GoCell 六维度）。
 
-**L3**：按 PR diff 净增删行数确定 `reviewer` agent 数量。取数命令（求和 numstat，避开 `--stat` 末行格式随单文件/无删除变化的解析坑）：
+**L3**：按 PR diff 净增删行数确定 `reviewer` agent 数量。用 `--shortstat` 直接读增删行（避开 `--stat` 末行格式坑，也无需 awk 求和）：
 
 ```bash
-git -C worktrees/<NNN> diff --numstat origin/develop | awk '{i+=$1; d+=$2} END{print i+d}'
+git -C worktrees/<NNN> diff --shortstat origin/develop
 ```
 
-> 阶段 7 被单独调用（非 ship 完整流程、无 worktree）时，回退到仓库根执行 `git diff --numstat origin/develop | awk '{i+=$1; d+=$2} END{print i+d}'`。
+输出形如 `N files changed, X insertions(+), Y deletions(-)`；diff 行数 = X + Y（某项为 0 时该子句省略，按 0 计）。
+
+> 阶段 7 被单独调用（非 ship 完整流程、无 worktree）时，回退到仓库根执行 `git diff --shortstat origin/develop`。
 
 GoCell 六维度 = 架构合规 / 安全 / 测试 / 运维可观测 / DX / 产品。分档（区间左闭右开，边界值归入更高档）：
 

--- a/.codex/skills/pr-review/SKILL.md
+++ b/.codex/skills/pr-review/SKILL.md
@@ -8,4 +8,4 @@ disable-model-invocation: true
 
 See .claude/skills/pr-review/SKILL.md
 
-完成后对根因进行开源对标，给出修复方向
+**完成后对根因进行开源对标，给出修复方向**

--- a/docs/backlog/20260520/RERATING-RUBRIC.md
+++ b/docs/backlog/20260520/RERATING-RUBRIC.md
@@ -101,6 +101,12 @@
 | P2 | **P1** |
 | P1 | 维持（架构 refactor 顶到 P1，不再上调）|
 
+> **触发型例外（架构信号升级封顶 P2）**：`flag-cond` 触发型条目，若其守护的 invariant **已被 Medium archtest / governance 守住**（CI 绿，Hard 升级仅关闭理论 AI 逃逸面、无线上正确性/安全缺口），架构信号升级**封顶 P2，不升 P1**——P1 留给尚未被守住的真实缺口。trigger fire 后随实施 PR 再评。
+>
+> 根因：架构命中升级（type=arch-opt + 描述含 "Hard 升级"/funnel + 触 `tools/archtest/` typed funnel + AI-robust "Medium 上游升 Hard"）会四信号全中把 P2 顶到 P1，但下方"反向降级"的触发型口子原只覆盖 `feat/bug`，`arch-opt` 触发型掉进缝里——吃到升级、豁免于降级。本例外补上该缝。
+>
+> 反例（2026-05-27 批量回落 P2）：`SERVICEOWNED-HANDLER-OWNER-CHECK-01` (#719) / `PASS-PRODUCTION-UPSTREAM-HARD-01` (#722) / `ARCHTEST-FUNNEL-CALLSITE-LEVEL-01` (#732) / `PG-REPO-AMBIENT-TX-01` (#738) 等"Medium→Hard 升级（触发型）"被自动升 P1，污染 daily 主线 wave（P0+P1 默认队列）。
+
 ### 反向降级规则（避免重评放水）
 
 | 信号 | 降级 |
@@ -116,6 +122,7 @@
 |---|---|---|
 | ✅ 命中 | P3 | P2 |
 | ✅ 命中 | P2 | P1 |
+| ✅ 命中（`flag-cond` 触发型 + invariant 已被 Medium 守住）| P2 / P3 | **P2 封顶**（见"触发型例外"）|
 | ✅ 命中 | P1 | P1（维持）|
 | ❌ 未命中 + 降级信号 | P2 | P3 |
 | ❌ 未命中 | 任意 | 维持 |


### PR DESCRIPTION
## 摘要

收口本地游离改动 + 三个 PreToolUse hook（脚本入 repo，接线在本地 gitignore 的 `settings.local.json`），并修复 hook 自身 bug、放开 python、清理被 hook 拦的 skill 内联命令。

| 文件 | 改动 |
|------|------|
| `.claude/hooks/no-shell-text-tools.sh` | PreToolUse(Bash)：拦 `awk/sed/grep/echo/cat`（含管道/复合命令内）。放开 `python/python3`；加 jq 守卫 |
| `.claude/hooks/exitplan-self-audit.sh` | PreToolUse(ExitPlanMode)：本会话首次退出 plan mode 时 deny 回喂计划自检、每会话一次。修 session_id 消毒 / 先 deny 后 touch / jq 守卫 |
| `.claude/hooks/bash-storm-guard.sh` | PreToolUse(Bash)：**bash 风暴护栏**——同一命令 `DUP_WINDOW(12s)` 内重复 → deny；`BURST_WINDOW(6s)` 内 bash 调用数 ≥ `BURST_MAX(5)` → deny。per-session 滑动窗口日志（`<epoch> <cksum>`）+ awk 计数。**fail-open**：脚本任何异常一律放行，绝不反向 brick |
| `.claude/skills/ship/SKILL.md` | 阶段 7 diff 行数统计：`… \| awk` 求和 → `git diff --shortstat` |
| `.claude/skills/pr-review/SKILL.md` | 阶段 2.5 worktree 定位：`… \| awk` 一行流 → `git worktree list` 指令式读取 |
| `.codex/skills/pr-review/SKILL.md` | 末行提示加粗 |
| `docs/backlog/20260520/RERATING-RUBRIC.md` | 补「触发型例外」规则（arch-opt 触发型 invariant 已被 Medium 守住时升级封顶 P2） |

## Test plan（hook 本地 smoke，无 CI 框架）

- [x] no-shell：`python3 foo.py` 放行；`… | awk …` 等文本工具拦截
- [x] exitplan：首次 deny / 同会话二次放行；`session_id="itX/../etc"` 消毒成 `itXetc`（无路径穿越）
- [x] storm-guard：限流 1-5 放行 / 6 起拦；同命令第二次拦
- [x] `bash -n` 语法检查三个脚本通过

## 说明

- 三个 hook 的**接线**在本地 `.claude/settings.local.json`（gitignore，不进 repo）；本 PR 只收脚本。
- storm-guard 局限（已知）：无锁，真正同瞬并发的一批可能漏几条（绊线非硬闸）；被拦调用仍有小额 round-trip 成本；只管 Bash，不覆盖 agent fan-out。阈值为脚本顶部可调常量。
- 触碰 `.claude/skills/{ship,pr-review}` → 触发 skill-test-discipline；二者无专属 CI smoke job，已本地验证改写后命令等价（见 Test plan），按规则在此记录。
- `RERATING-RUBRIC.md` 位于 `docs/backlog/` 冻结目录（约定无 CI 强制），经确认保留作未来 re-rating 活文档。
- sonar-scan 的 `python3` 调用因放开 python 不再被拦，无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
