### PR TITLE
fix(ci): rabbitmq+reconcile flake 去墙钟 + SonarCloud 18 项清理 [#1354]

### DIFF
--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -392,63 +392,112 @@ func TestIntegration_Subscriber_Disposition3State(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			coll, sub := itestNewSubWithCollector(t, "sub-disp-"+tc.name)
-			settlement := &recordingSettlement{}
-			// Per-subtest topic prefix makes each subtest's filter disjoint, so
-			// shared-subscription fanout cannot deliver one subtest's PUBLISH to
-			// another (mirrors the unit DispositionMatrix fix). Consumer group is
-			// still unique per subtest as a second layer of isolation.
-			prefix := "itest/disp/" + tc.name
-			filter := prefix + "/+"
-			subscription := itestSubscription(filter, "disp-"+tc.name+"-"+uuid.NewString())
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			go func() {
-				_ = sub.Subscribe(ctx, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-					return tc.result, settlement
-				})
-			}()
-			select {
-			case <-sub.Ready(subscription):
-			case <-time.After(testtime.D10s):
-				t.Fatal("subscribe not ready")
-			}
-			topic := prefix + "/" + uuid.NewString()
-			itestPublish(t, sub.conn, topic, itestEnvelope(t, topic, []byte(`{"k":"v"}`)))
-
-			// Wait for the TERMINAL settlement, not just "failure recorded":
-			// A4 (#1142) moved releaseSettlement to AFTER routeDeadLetter +
-			// ackPoison (release the claim only once the broker disposition is
-			// final), so RecordConsumeFailure (early) no longer implies the claim
-			// has been released. With a real broker the $dead round-trip widens
-			// that window — poll until success (ack) or release (requeue/reject)
-			// reaches the expected terminal count.
-			deadline := time.Now().Add(testtime.D10s)
-			for time.Now().Before(deadline) {
-				s, f, _ := coll.snapshot()
-				_, rel := settlement.counts()
-				if s >= tc.wantSuccess && rel >= tc.wantRelease && (tc.wantReason == "" || f >= 1) {
-					break
-				}
-				time.Sleep(testtime.D10ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
-			}
-			success, failure, reason := coll.snapshot()
-			commit, release := settlement.counts()
-			if success != tc.wantSuccess {
-				t.Errorf("success = %d, want %d", success, tc.wantSuccess)
-			}
-			if commit != tc.wantCommit {
-				t.Errorf("commit = %d, want %d", commit, tc.wantCommit)
-			}
-			if release != tc.wantRelease {
-				t.Errorf("release = %d, want %d", release, tc.wantRelease)
-			}
-			if tc.wantReason != "" {
-				if failure < 1 || reason != tc.wantReason {
-					t.Errorf("failure=%d reason=%q, want reason %q", failure, reason, tc.wantReason)
-				}
-			}
+			itestRunDispositionCase(t, tc.name, tc.result, tc.wantSuccess, tc.wantReason, tc.wantCommit, tc.wantRelease)
 		})
+	}
+}
+
+// itestRunDispositionCase runs a single disposition sub-case for
+// TestIntegration_Subscriber_Disposition3State: it builds the subscriber,
+// publishes one message, polls for the terminal settlement, and asserts all
+// expected counters.
+func itestRunDispositionCase(
+	t *testing.T,
+	name string,
+	result outbox.HandleResult,
+	wantSuccess int,
+	wantReason ConsumeFailureReason,
+	wantCommit int,
+	wantRelease int,
+) {
+	t.Helper()
+	coll, sub := itestNewSubWithCollector(t, "sub-disp-"+name)
+	settlement := &recordingSettlement{}
+	// Per-subtest topic prefix makes each subtest's filter disjoint, so
+	// shared-subscription fanout cannot deliver one subtest's PUBLISH to
+	// another (mirrors the unit DispositionMatrix fix). Consumer group is
+	// still unique per subtest as a second layer of isolation.
+	prefix := "itest/disp/" + name
+	filter := prefix + "/+"
+	subscription := itestSubscription(filter, "disp-"+name+"-"+uuid.NewString())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = sub.Subscribe(ctx, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			return result, settlement
+		})
+	}()
+	itestWaitSubscribeReady(t, sub, subscription)
+	topic := prefix + "/" + uuid.NewString()
+	itestPublish(t, sub.conn, topic, itestEnvelope(t, topic, []byte(`{"k":"v"}`)))
+	itestPollDispositionSettlement(t, coll, settlement, wantSuccess, wantReason, wantRelease)
+	itestAssertDispositionCounts(t, coll, settlement, wantSuccess, wantReason, wantCommit, wantRelease)
+}
+
+// itestWaitSubscribeReady blocks until sub reports Ready for subscription or
+// the 10-second deadline is exceeded.
+func itestWaitSubscribeReady(t *testing.T, sub *Subscriber, subscription outbox.Subscription) {
+	t.Helper()
+	select {
+	case <-sub.Ready(subscription):
+	case <-time.After(testtime.D10s):
+		t.Fatal("subscribe not ready")
+	}
+}
+
+// itestPollDispositionSettlement polls until the collector and settlement reach
+// the expected terminal counts or the 10-second deadline is exceeded.
+// A4 (#1142) moved releaseSettlement to AFTER routeDeadLetter + ackPoison
+// (release the claim only once the broker disposition is final), so
+// RecordConsumeFailure (early) no longer implies the claim has been released.
+// With a real broker the $dead round-trip widens that window.
+func itestPollDispositionSettlement(
+	t *testing.T,
+	coll *recordingSubCollector,
+	settlement *recordingSettlement,
+	wantSuccess int,
+	wantReason ConsumeFailureReason,
+	wantRelease int,
+) {
+	t.Helper()
+	deadline := time.Now().Add(testtime.D10s)
+	for time.Now().Before(deadline) {
+		s, f, _ := coll.snapshot()
+		_, rel := settlement.counts()
+		if s >= wantSuccess && rel >= wantRelease && (wantReason == "" || f >= 1) {
+			break
+		}
+		time.Sleep(testtime.D10ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
+	}
+}
+
+// itestAssertDispositionCounts reads the final snapshot from coll and settlement
+// and asserts all expected counters match.
+func itestAssertDispositionCounts(
+	t *testing.T,
+	coll *recordingSubCollector,
+	settlement *recordingSettlement,
+	wantSuccess int,
+	wantReason ConsumeFailureReason,
+	wantCommit int,
+	wantRelease int,
+) {
+	t.Helper()
+	success, failure, reason := coll.snapshot()
+	commit, release := settlement.counts()
+	if success != wantSuccess {
+		t.Errorf("success = %d, want %d", success, wantSuccess)
+	}
+	if commit != wantCommit {
+		t.Errorf("commit = %d, want %d", commit, wantCommit)
+	}
+	if release != wantRelease {
+		t.Errorf("release = %d, want %d", release, wantRelease)
+	}
+	if wantReason != "" {
+		if failure < 1 || reason != wantReason {
+			t.Errorf("failure=%d reason=%q, want reason %q", failure, reason, wantReason)
+		}
 	}
 }
 

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -509,25 +509,29 @@ func NewProviderSubscriberCollector(p metrics.Provider, cellID string) (Subscrib
 
 	consumeTotal, cErr := p.CounterVec(subConsumeTotalOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register consume total counter", cErr))
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register consume total counter", cErr))
 	}
 	registered = append(registered, consumeTotal)
 
 	consumeFailed, cErr := p.CounterVec(subConsumeFailedOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register consume failed counter", cErr))
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register consume failed counter", cErr))
 	}
 	registered = append(registered, consumeFailed)
 
 	dlxTotal, cErr := p.CounterVec(subDlxTotalOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register dlx counter", cErr))
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register dlx counter", cErr))
 	}
 	registered = append(registered, dlxTotal)
 
 	dlxFailed, cErr := p.CounterVec(subDlxFailedOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register dlx failed counter", cErr))
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register dlx failed counter", cErr))
 	}
 	registered = append(registered, dlxFailed)
 

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -59,7 +59,7 @@ const errProviderRequired = "mqtt: metrics.Provider is required"
 // helpCellLabel is the common suffix appended to metric Help strings to document
 // that the "cell" label is bound at construction time (registration-time
 // enumerated, not derived from request context).
-const helpCellLabel = "Label: cell = construction-time cell identifier."
+const helpCellLabel = "Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx)."
 
 // NewProviderConnectionCollector registers mqtt_reconnect_total and
 // mqtt_subscribe_failed_total on p and returns a ConnectionCollector bound to
@@ -261,7 +261,7 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 	publishTotal, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_publish_total",
 		Help: "Total number of MQTT publish attempts that completed successfully (broker PUBACK received). " +
-			"Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).",
+			helpCellLabel,
 		LabelNames: []string{"cell"},
 	})
 	if err != nil {

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -56,6 +56,11 @@ var _ ConnectionCollector = (*providerConnectionCollector)(nil)
 // passed to any of the three NewProvider*Collector constructors.
 const errProviderRequired = "mqtt: metrics.Provider is required"
 
+// helpCellLabel is the common suffix appended to metric Help strings to document
+// that the "cell" label is bound at construction time (registration-time
+// enumerated, not derived from request context).
+const helpCellLabel = "Label: cell = construction-time cell identifier."
+
 // NewProviderConnectionCollector registers mqtt_reconnect_total and
 // mqtt_subscribe_failed_total on p and returns a ConnectionCollector bound to
 // cellID. cellID becomes the "cell" label.
@@ -97,7 +102,7 @@ func NewProviderConnectionCollector(p metrics.Provider, cellID string) (Connecti
 		Name: "mqtt_subscribe_failed_total",
 		Help: "Total number of receive-path SUBSCRIBE failures (initial SUBACK rejection or reconnect re-arm), " +
 			"classified by reason. reason ∈ {suback_reject, transport} — closed set; alerting rules can rely on " +
-			"the literals. Label: cell = construction-time cell identifier.",
+			"the literals. " + helpCellLabel,
 		LabelNames: []string{"cell", "reason"},
 	})
 	if err != nil {
@@ -270,7 +275,7 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		Help: "Total number of MQTT publish attempts that failed, classified by reason. " +
 			"reason ∈ {payload_too_large, closed, puback_timeout, context_canceled, publish_error, " +
 			"topic_outside_namespace, rate_limited, not_authorized, payload_format_invalid, rejected} — " +
-			"closed set; alerting rules can rely on the literals. Label: cell = construction-time cell identifier.",
+			"closed set; alerting rules can rely on the literals. " + helpCellLabel,
 		LabelNames: []string{"cell", "reason"},
 	})
 	if err != nil {
@@ -282,8 +287,7 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 	ackDuration, err := p.HistogramVec(metrics.HistogramOpts{
 		Name: "mqtt_publish_ack_duration_seconds",
 		Help: "End-to-end MQTT publish ack round-trip duration in seconds, from Publish() call to broker PUBACK. " +
-			"Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. " +
-			"Label: cell = construction-time cell identifier.",
+			"Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. " + helpCellLabel,
 		LabelNames: []string{"cell"},
 		Buckets:    ackDurationBuckets,
 	})

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -89,7 +89,7 @@ func NewProviderConnectionCollector(p metrics.Provider, cellID string) (Connecti
 
 	reconnect, err := p.CounterVec(metrics.CounterOpts{
 		Name:       "mqtt_reconnect_total",
-		Help:       "Total MQTT reconnect events observed by the adapter, by cell.",
+		Help:       "Total MQTT reconnect events observed by the adapter. " + helpCellLabel,
 		LabelNames: []string{"cell"},
 	})
 	if err != nil {
@@ -447,21 +447,21 @@ var (
 	subConsumeTotalOpts = metrics.CounterOpts{
 		Name: "mqtt_consume_total",
 		Help: "Total number of MQTT messages consumed successfully (handler Ack + Settlement Commit). " +
-			"Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).",
+			helpCellLabel,
 		LabelNames: []string{"cell"},
 	}
 	subConsumeFailedOpts = metrics.CounterOpts{
 		Name: "mqtt_consume_failed_total",
 		Help: "Total number of MQTT messages that did not result in a successful Ack, classified by reason. " +
 			"reason ∈ {unmarshal, reject, requeue, commit_failed, ack_failed, unknown_disposition} — closed set; " +
-			"alerting rules can rely on the literals. Label: cell = construction-time cell identifier.",
+			"alerting rules can rely on the literals. " + helpCellLabel,
 		LabelNames: []string{"cell", "reason"},
 	}
 	subDlxTotalOpts = metrics.CounterOpts{
 		Name: "mqtt_dlx_total",
 		Help: "Total number of messages routed to the app-level dead-letter sink $dead/<topic>. " +
 			"reason ∈ {unmarshal, reject} — closed set (poison / permanent failure). " +
-			"Label: cell = construction-time cell identifier.",
+			helpCellLabel,
 		LabelNames: []string{"cell", "reason"},
 	}
 	subDlxFailedOpts = metrics.CounterOpts{
@@ -469,14 +469,14 @@ var (
 		Help: "Total number of messages whose dead-letter publish to $dead/<topic> FAILED (topic " +
 			"unmintable or broker publish error); the message was acked-as-poison WITHOUT $dead capture. " +
 			"A distinct, higher-severity signal from mqtt_consume_failed_total: it means the dead-letter " +
-			"sink itself is unhealthy. reason ∈ {unmarshal, reject} — closed set. Label: cell.",
+			"sink itself is unhealthy. reason ∈ {unmarshal, reject} — closed set. " + helpCellLabel,
 		LabelNames: []string{"cell", "reason"},
 	}
 	subConsumeDurOpts = metrics.HistogramOpts{
 		Name: "mqtt_consume_duration_seconds",
 		Help: "End-to-end MQTT consume duration in seconds, from handler invocation to Settlement Commit. " +
 			"Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. " +
-			"Label: cell = construction-time cell identifier.",
+			helpCellLabel,
 		LabelNames: []string{"cell"},
 		Buckets:    consumeDurationBuckets,
 	}

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -507,33 +507,29 @@ func NewProviderSubscriberCollector(p metrics.Provider, cellID string) (Subscrib
 		return wrapErr
 	}
 
-	// registerCounter registers one CounterVec, tracks it for rollback, and on
-	// failure returns the rollback-wrapped error so the caller just propagates it.
-	registerCounter := func(opts metrics.CounterOpts, wrapCtx string) (metrics.CounterVec, error) {
-		cv, cErr := p.CounterVec(opts)
-		if cErr != nil {
-			return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, wrapCtx, cErr))
-		}
-		registered = append(registered, cv)
-		return cv, nil
+	consumeTotal, cErr := p.CounterVec(subConsumeTotalOpts)
+	if cErr != nil {
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register consume total counter", cErr))
 	}
+	registered = append(registered, consumeTotal)
 
-	consumeTotal, err := registerCounter(subConsumeTotalOpts, "mqtt: register consume total counter")
-	if err != nil {
-		return nil, err
+	consumeFailed, cErr := p.CounterVec(subConsumeFailedOpts)
+	if cErr != nil {
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register consume failed counter", cErr))
 	}
-	consumeFailed, err := registerCounter(subConsumeFailedOpts, "mqtt: register consume failed counter")
-	if err != nil {
-		return nil, err
+	registered = append(registered, consumeFailed)
+
+	dlxTotal, cErr := p.CounterVec(subDlxTotalOpts)
+	if cErr != nil {
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register dlx counter", cErr))
 	}
-	dlxTotal, err := registerCounter(subDlxTotalOpts, "mqtt: register dlx counter")
-	if err != nil {
-		return nil, err
+	registered = append(registered, dlxTotal)
+
+	dlxFailed, cErr := p.CounterVec(subDlxFailedOpts)
+	if cErr != nil {
+		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "mqtt: register dlx failed counter", cErr))
 	}
-	dlxFailed, err := registerCounter(subDlxFailedOpts, "mqtt: register dlx failed counter")
-	if err != nil {
-		return nil, err
-	}
+	registered = append(registered, dlxFailed)
 
 	consumeDur, err := p.HistogramVec(subConsumeDurOpts)
 	if err != nil {

--- a/adapters/mqtt/metrics_test.go
+++ b/adapters/mqtt/metrics_test.go
@@ -481,6 +481,40 @@ func TestNewProviderSubscriberCollector_RegistrationFailure_RollsBack(t *testing
 	assert.Equal(t, 4, spy.unregisterCount, "all four counters must be rolled back on histogram failure")
 }
 
+// TestNewProviderSubscriberCollector_CounterRegistrationFailure_RollsBack covers
+// each of the four counter registration error branches: when the Nth CounterVec
+// call fails, the N-1 already-registered counters must be unregistered (rollback)
+// and the error wrapped as an errcode.Error. Pins the per-counter failure paths
+// (consume_total / consume_failed / dlx_total / dlx_failed) that the inlined
+// errcode.Wrap branches introduced.
+func TestNewProviderSubscriberCollector_CounterRegistrationFailure_RollsBack(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name             string
+		failAtCounter    int // 1-based: fail the Nth CounterVec call
+		wantUnregistered int // counters registered before the failing one
+	}{
+		{"consume_total", 1, 0},
+		{"consume_failed", 2, 1},
+		{"dlx_total", 3, 2},
+		{"dlx_failed", 4, 3},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spy := &subRollbackProvider{failAtCounter: tc.failAtCounter}
+			_, err := NewProviderSubscriberCollector(spy, "testcell")
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec))
+			assert.Equal(t, errcode.KindInternal, ec.Kind)
+			assert.Equal(t, tc.wantUnregistered, spy.unregisterCount,
+				"counters registered before the failing one must be rolled back")
+		})
+	}
+}
+
 // TestProviderSubscriberCollector_RecordConsumeSuccess verifies success
 // increments mqtt_consume_total and observes mqtt_consume_duration_seconds.
 func TestProviderSubscriberCollector_RecordConsumeSuccess(t *testing.T) {
@@ -643,16 +677,22 @@ func TestNoopSubscriberCollector_Methods(t *testing.T) {
 // Subscriber test doubles
 // ---------------------------------------------------------------------------
 
-// subRollbackProvider registers the two counters successfully then fails the
-// histogram, recording how many Unregister calls the rollback issues.
+// subRollbackProvider registers counters successfully until a configured failure
+// point, recording how many Unregister calls the rollback issues. failHistogram
+// fails the histogram (after all 4 counters); failAtCounter (1-based, 0=disabled)
+// fails the Nth CounterVec call so the per-counter error branches can be exercised.
 type subRollbackProvider struct {
 	failHistogram   bool
+	failAtCounter   int
 	counterCount    int
 	unregisterCount int
 }
 
 func (p *subRollbackProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
 	p.counterCount++
+	if p.failAtCounter > 0 && p.counterCount == p.failAtCounter {
+		return nil, errors.New("duplicate counter")
+	}
 	return &subSpyCounterVec{name: opts.Name, labelNames: opts.LabelNames}, nil
 }
 

--- a/adapters/mqtt/subscriber_dispatchack_test.go
+++ b/adapters/mqtt/subscriber_dispatchack_test.go
@@ -45,7 +45,7 @@ func fakeAckConn(ackErr error) *Connection {
 // Connection (see fakeAckConn) with the given collector, for white-box
 // dispatchAck branch tests. The namespace is the canonical "test" namespace so
 // NewSubscriber's non-zero-namespace guard passes; no broker SUBSCRIBE happens.
-func newDispatchAckSubscriber(t fataler, ackErr error, collector SubscriberCollector) *Subscriber {
+func newDispatchAckSubscriber(t testing.TB, ackErr error, collector SubscriberCollector) *Subscriber {
 	ns, err := ParseTopicNamespace("test")
 	if err != nil {
 		t.Fatalf("ParseTopicNamespace: %v", err)
@@ -56,11 +56,6 @@ func newDispatchAckSubscriber(t fataler, ackErr error, collector SubscriberColle
 		t.Fatalf("NewSubscriber: %v", err)
 	}
 	return sub
-}
-
-// fataler is the minimal testing surface newDispatchAckSubscriber needs.
-type fataler interface {
-	Fatalf(format string, args ...any)
 }
 
 // dispatchAckEntry returns a benign entry + publish pair for dispatchAck tests.

--- a/adapters/mqtt/subscriber_dispatchack_test.go
+++ b/adapters/mqtt/subscriber_dispatchack_test.go
@@ -45,7 +45,7 @@ func fakeAckConn(ackErr error) *Connection {
 // Connection (see fakeAckConn) with the given collector, for white-box
 // dispatchAck branch tests. The namespace is the canonical "test" namespace so
 // NewSubscriber's non-zero-namespace guard passes; no broker SUBSCRIBE happens.
-func newDispatchAckSubscriber(t fatalfT, ackErr error, collector SubscriberCollector) *Subscriber {
+func newDispatchAckSubscriber(t fataler, ackErr error, collector SubscriberCollector) *Subscriber {
 	ns, err := ParseTopicNamespace("test")
 	if err != nil {
 		t.Fatalf("ParseTopicNamespace: %v", err)
@@ -58,8 +58,8 @@ func newDispatchAckSubscriber(t fatalfT, ackErr error, collector SubscriberColle
 	return sub
 }
 
-// fatalfT is the minimal testing surface newDispatchAckSubscriber needs.
-type fatalfT interface {
+// fataler is the minimal testing surface newDispatchAckSubscriber needs.
+type fataler interface {
 	Fatalf(format string, args ...any)
 }
 

--- a/adapters/mqtt/subscriber_testhelpers_test.go
+++ b/adapters/mqtt/subscriber_testhelpers_test.go
@@ -30,7 +30,7 @@ func mustNewEntry(t testing.TB, eventType string, payload []byte, opts ...outbox
 // (integration) both depend on recordingSettlement + recordingSubCollector.
 //
 // Unit-only dispatchAck white-box doubles (subAckRecorder / fakeAckConn /
-// newDispatchAckSubscriber / dispatchAckEntry / ackHandler / fatalfT) live in
+// newDispatchAckSubscriber / dispatchAckEntry / ackHandler) live in
 // subscriber_dispatchack_test.go (//go:build !integration) — they have no
 // caller in the integration build and would report `unused` if compiled there.
 

--- a/adapters/rabbitmq/subscriber_close_ctx_test.go
+++ b/adapters/rabbitmq/subscriber_close_ctx_test.go
@@ -394,7 +394,18 @@ func TestSubscriber_Close_InFlightHandlerCompletesBeforeDeadline(t *testing.T) {
 	assert.NoError(t, err, "Close must return nil when handler completes before ctx deadline")
 }
 
-// TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg: context.Background() + 150ms handler → nil.
+// TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg: context.Background() → Close blocks
+// until the in-flight handler completes, then returns nil.
+//
+// Deterministic design (no wall-clock sleep or lower-bound assertion):
+//  1. Handler blocks on <-release until the test unlocks it.
+//  2. entered is closed when the handler starts, so the test knows the handler
+//     is genuinely in-flight before calling Close.
+//  3. Close is started in a goroutine; closeReturned is closed when it returns.
+//  4. Before releasing the handler the test asserts Close has NOT returned yet
+//     (non-blocking select on closeReturned), proving Close actually blocks.
+//  5. After close(release) the test uses testwait.Deterministic to wait for
+//     closeReturned — deterministic, no race window.
 func TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 
@@ -404,8 +415,12 @@ func TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg(t *testing.T) {
 	mockConn.nextCh = ch
 	mockConn.mu.Unlock()
 
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
 	handler := entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-		time.Sleep(testtime.D150ms) //archtest:allow:test-sleep slow handler fixture; sleep IS the test parameter
+		close(entered)
+		<-release
 		return outbox.Ack()
 	})
 
@@ -421,7 +436,9 @@ func TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg(t *testing.T) {
 		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "nodeadline.topic", CellID: "test-cell"}, handler)
 	}()
 
-	time.Sleep(testtime.D20ms) //archtest:allow:test-sleep wait for goroutine to enter blocking handler; no started observable
+	// Wait until the handler is genuinely in-flight.
+	testwait.Deterministic(t, entered, "handler-entered")
+
 	cancel()
 
 	select {
@@ -430,13 +447,25 @@ func TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg(t *testing.T) {
 		t.Fatal("Subscribe did not return")
 	}
 
-	start := time.Now()
-	err := sub.Close(context.Background())
-	elapsed := time.Since(start)
+	closeReturned := make(chan struct{})
+	var closeErr error
+	go func() {
+		closeErr = sub.Close(context.Background())
+		close(closeReturned)
+	}()
 
-	assert.NoError(t, err, "Close with Background ctx must wait indefinitely and return nil")
-	assert.GreaterOrEqual(t, elapsed, testtime.SlowPoll,
-		"Close with Background ctx must have actually waited for handler; got %s", elapsed)
+	// Prove Close is blocking: it must not have returned before we release the handler.
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned before handler released")
+	default:
+	}
+
+	// Release the handler, then wait deterministically for Close to finish.
+	close(release)
+	testwait.Deterministic(t, closeReturned, "Close with Background ctx must return after handler released")
+
+	assert.NoError(t, closeErr, "Close with Background ctx must return nil")
 }
 
 // TestSubscriber_Reconnect_WaitsForInflightBeforeClose — A19 core regression test.

--- a/kernel/governance/rules_saga_test.go
+++ b/kernel/governance/rules_saga_test.go
@@ -71,6 +71,52 @@ func filterByCode(results []ValidationResult, code RuleCode) []ValidationResult 
 	return out
 }
 
+// assertSagaFinding checks that got contains exactly wantErrCount results and,
+// when wantErrCount > 0, that the first result has SeverityError, Field ==
+// wantField (empty wantField skips the field check), and a non-empty Fix.
+// Extracted to lower the cognitive complexity of each table-driven saga rule test.
+func assertSagaFinding(t *testing.T, got []ValidationResult, wantErrCount int, wantField string) {
+	t.Helper()
+	if len(got) != wantErrCount {
+		t.Fatalf("expected %d result(s), got %d: %v", wantErrCount, len(got), got)
+	}
+	if wantErrCount == 0 {
+		return
+	}
+	r := got[0]
+	if r.Severity != SeverityError {
+		t.Errorf("expected SeverityError, got %s", r.Severity)
+	}
+	if wantField != "" && r.Field != wantField {
+		t.Errorf("expected field %q, got %q", wantField, r.Field)
+	}
+	if r.Fix == "" {
+		t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
+	}
+}
+
+// assertSagaFindingPrefix is like assertSagaFinding but uses strings.HasPrefix
+// for the field check (used by retry/timeout tests where field varies by subpath).
+func assertSagaFindingPrefix(t *testing.T, got []ValidationResult, wantErrCount int, wantField string) {
+	t.Helper()
+	if len(got) != wantErrCount {
+		t.Fatalf("expected %d result(s), got %d: %v", wantErrCount, len(got), got)
+	}
+	if wantErrCount == 0 {
+		return
+	}
+	r := got[0]
+	if r.Severity != SeverityError {
+		t.Errorf("expected SeverityError, got %s", r.Severity)
+	}
+	if wantField != "" && !strings.HasPrefix(r.Field, wantField) {
+		t.Errorf("expected field with prefix %q, got %q", wantField, r.Field)
+	}
+	if r.Fix == "" {
+		t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
+	}
+}
+
 // ---- SAGA-CONTRACT-STEPS-NONEMPTY-01 ----------------------------------------
 
 func TestSagaStepsNonempty01(t *testing.T) {
@@ -113,21 +159,7 @@ func TestSagaStepsNonempty01(t *testing.T) {
 			project := buildSagaProject("L3", tc.saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTSTEPSNONEMPTY01(), codeSAGACONTRACTSTEPSNONEMPTY01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }
@@ -200,21 +232,7 @@ func TestSagaStepNameValid01(t *testing.T) {
 			project := buildSagaProject("L3", saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTSTEPNAMEVALID01(), codeSAGACONTRACTSTEPNAMEVALID01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }
@@ -271,21 +289,7 @@ func TestSagaStepNameUnique01(t *testing.T) {
 			project := buildSagaProject("L3", saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTSTEPNAMEUNIQUE01(), codeSAGACONTRACTSTEPNAMEUNIQUE01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }
@@ -339,21 +343,7 @@ func TestSagaStepSchemaRef01(t *testing.T) {
 			project := buildSagaProject("L3", saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTSTEPSCHEMAREF01(), codeSAGACONTRACTSTEPSCHEMAREF01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }
@@ -404,21 +394,7 @@ func TestSagaCompensationOrder01(t *testing.T) {
 			project := buildSagaProject("L3", saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTCOMPENSATIONORDER01(), codeSAGACONTRACTCOMPENSATIONORDER01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }
@@ -469,68 +445,46 @@ func TestSagaConsistencyL301(t *testing.T) {
 			consistencyLevel: "L3",
 			wantErrCount:     0,
 		},
-		{
-			name:             "non-saga kind → not checked (http at L2 is fine)",
-			consistencyLevel: "L2",
-			// use a non-saga contract via separate project
-		},
 	}
+
+	// non-saga contract at L2 must not trigger the saga rule (rule only fires for kind=saga).
+	t.Run("non-saga kind → not checked (http at L2 is fine)", func(t *testing.T) {
+		t.Parallel()
+		c := &metadata.ContractMeta{
+			ID:               "http.test.action.v1",
+			Kind:             "http",
+			OwnerCell:        metadatatest.CellIDTestCell,
+			ConsistencyLevel: "L2",
+			Lifecycle:        "active",
+			Endpoints: metadata.EndpointsMeta{
+				Server:  metadatatest.CellIDTestCell,
+				Clients: []string{metadatatest.CellIDEdgeBFF},
+			},
+			Dir:  "contracts/http/test/action/v1",
+			File: "contracts/http/test/action/v1/contract.yaml",
+		}
+		project := &metadata.ProjectMeta{
+			Cells:      map[string]*metadata.CellMeta{},
+			Slices:     map[string]*metadata.SliceMeta{},
+			Contracts:  map[string]*metadata.ContractMeta{c.ID: c},
+			Journeys:   map[string]*metadata.JourneyMeta{},
+			Assemblies: map[string]*metadata.AssemblyMeta{},
+		}
+		v := NewValidator(project, "", clock.Real())
+		got := filterByCode(v.validateSAGACONTRACTCONSISTENCYL301(), codeSAGACONTRACTCONSISTENCYL301)
+		if len(got) != 0 {
+			t.Fatalf("non-saga contract must not trigger SAGA-CONTRACT-CONSISTENCY-L3-01, got %d: %v", len(got), got)
+		}
+	})
 
 	for _, tc := range tests {
 		tc := tc
-		// Skip the non-saga test case with a comment; it shares infrastructure.
-		if tc.name == "non-saga kind → not checked (http at L2 is fine)" {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				// Build an http contract with L2 — should not trigger saga rule.
-				c := &metadata.ContractMeta{
-					ID:               "http.test.action.v1",
-					Kind:             "http",
-					OwnerCell:        metadatatest.CellIDTestCell,
-					ConsistencyLevel: "L2",
-					Lifecycle:        "active",
-					Endpoints: metadata.EndpointsMeta{
-						Server:  metadatatest.CellIDTestCell,
-						Clients: []string{metadatatest.CellIDEdgeBFF},
-					},
-					Dir:  "contracts/http/test/action/v1",
-					File: "contracts/http/test/action/v1/contract.yaml",
-				}
-				project := &metadata.ProjectMeta{
-					Cells:      map[string]*metadata.CellMeta{},
-					Slices:     map[string]*metadata.SliceMeta{},
-					Contracts:  map[string]*metadata.ContractMeta{c.ID: c},
-					Journeys:   map[string]*metadata.JourneyMeta{},
-					Assemblies: map[string]*metadata.AssemblyMeta{},
-				}
-				v := NewValidator(project, "", clock.Real())
-				got := filterByCode(v.validateSAGACONTRACTCONSISTENCYL301(), codeSAGACONTRACTCONSISTENCYL301)
-				if len(got) != 0 {
-					t.Fatalf("non-saga contract must not trigger SAGA-CONTRACT-CONSISTENCY-L3-01, got %d: %v", len(got), got)
-				}
-			})
-			continue
-		}
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			project := buildSagaProject(tc.consistencyLevel, wellFormedSaga())
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTCONSISTENCYL301(), codeSAGACONTRACTCONSISTENCYL301)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }
@@ -571,21 +525,7 @@ func TestSagaContractBlockPresent01(t *testing.T) {
 			project := buildSagaProject("L3", tc.saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTBLOCKPRESENT01(), codeSAGACONTRACTBLOCKPRESENT01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 
@@ -723,21 +663,7 @@ func TestSagaCellLevelL3Declare01(t *testing.T) {
 			project := buildCellLevelProject(tc.cellLevel, tc.role)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACELLLEVELL3DECLARE01(), codeSAGACELLLEVELL3DECLARE01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if r.Field != tc.wantField {
-					t.Errorf("expected Field %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFinding(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 
@@ -924,21 +850,7 @@ func TestSagaContractRetryTimeout01(t *testing.T) {
 			project := buildSagaProject("L3", tc.saga)
 			v := NewValidator(project, "", clock.Real())
 			got := filterByCode(v.validateSAGACONTRACTRETRYTIMEOUT01(), codeSAGACONTRACTRETRYTIMEOUT01)
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s), got %d: %v", tc.wantErrCount, len(got), got)
-			}
-			if tc.wantErrCount > 0 {
-				r := got[0]
-				if r.Severity != SeverityError {
-					t.Errorf("expected SeverityError, got %s", r.Severity)
-				}
-				if tc.wantField != "" && !strings.HasPrefix(r.Field, tc.wantField) {
-					t.Errorf("expected field with prefix %q, got %q", tc.wantField, r.Field)
-				}
-				if r.Fix == "" {
-					t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-				}
-			}
+			assertSagaFindingPrefix(t, got, tc.wantErrCount, tc.wantField)
 		})
 	}
 }

--- a/kernel/governance/rules_saga_test.go
+++ b/kernel/governance/rules_saga_test.go
@@ -74,6 +74,8 @@ func filterByCode(results []ValidationResult, code RuleCode) []ValidationResult 
 // assertSagaFinding checks that got contains exactly wantErrCount results and,
 // when wantErrCount > 0, that the first result has SeverityError, Field ==
 // wantField (empty wantField skips the field check), and a non-empty Fix.
+// When wantErrCount > 1, all results are also verified to have SeverityError and
+// non-empty Fix (Field varies per-finding so only the first is field-checked).
 // Extracted to lower the cognitive complexity of each table-driven saga rule test.
 func assertSagaFinding(t *testing.T, got []ValidationResult, wantErrCount int, wantField string) {
 	t.Helper()
@@ -83,15 +85,25 @@ func assertSagaFinding(t *testing.T, got []ValidationResult, wantErrCount int, w
 	if wantErrCount == 0 {
 		return
 	}
+	// Verify the first result's field (callers only provide wantField for got[0]).
 	r := got[0]
 	if r.Severity != SeverityError {
-		t.Errorf("expected SeverityError, got %s", r.Severity)
+		t.Errorf("got[0]: expected SeverityError, got %s", r.Severity)
 	}
 	if wantField != "" && r.Field != wantField {
-		t.Errorf("expected field %q, got %q", wantField, r.Field)
+		t.Errorf("got[0]: expected field %q, got %q", wantField, r.Field)
 	}
 	if r.Fix == "" {
-		t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
+		t.Error("got[0]: error finding must carry non-empty Fix guidance (typed-Fix contract)")
+	}
+	// For multi-finding cases, verify every result carries Severity + Fix.
+	for i, ri := range got[1:] {
+		if ri.Severity != SeverityError {
+			t.Errorf("got[%d]: expected SeverityError, got %s", i+1, ri.Severity)
+		}
+		if ri.Fix == "" {
+			t.Errorf("got[%d]: error finding must carry non-empty Fix guidance (typed-Fix contract)", i+1)
+		}
 	}
 }
 
@@ -107,13 +119,22 @@ func assertSagaFindingPrefix(t *testing.T, got []ValidationResult, wantErrCount 
 	}
 	r := got[0]
 	if r.Severity != SeverityError {
-		t.Errorf("expected SeverityError, got %s", r.Severity)
+		t.Errorf("got[0]: expected SeverityError, got %s", r.Severity)
 	}
 	if wantField != "" && !strings.HasPrefix(r.Field, wantField) {
-		t.Errorf("expected field with prefix %q, got %q", wantField, r.Field)
+		t.Errorf("got[0]: expected field with prefix %q, got %q", wantField, r.Field)
 	}
 	if r.Fix == "" {
-		t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
+		t.Error("got[0]: error finding must carry non-empty Fix guidance (typed-Fix contract)")
+	}
+	// For multi-finding cases, verify every result carries Severity + Fix.
+	for i, ri := range got[1:] {
+		if ri.Severity != SeverityError {
+			t.Errorf("got[%d]: expected SeverityError, got %s", i+1, ri.Severity)
+		}
+		if ri.Fix == "" {
+			t.Errorf("got[%d]: error finding must carry non-empty Fix guidance (typed-Fix contract)", i+1)
+		}
 	}
 }
 

--- a/kernel/governance/rules_saga_test.go
+++ b/kernel/governance/rules_saga_test.go
@@ -597,8 +597,8 @@ func TestSagaCellLevelL3Declare01(t *testing.T) {
 	buildCellLevelProject := func(cellLevel, role string) *metadata.ProjectMeta {
 		return &metadata.ProjectMeta{
 			Cells: map[string]*metadata.CellMeta{
-				"orchestratorcell": {
-					ID:               "orchestratorcell",
+				metadatatest.NewCellID("orchestratorcell"): {
+					ID:               metadatatest.NewCellID("orchestratorcell"),
 					ConsistencyLevel: cellLevel,
 					File:             "cells/orchestratorcell/cell.yaml",
 				},
@@ -606,7 +606,7 @@ func TestSagaCellLevelL3Declare01(t *testing.T) {
 			Slices: map[string]*metadata.SliceMeta{
 				"orchestratorcell/saga-orchestrate": {
 					ID:            "saga-orchestrate",
-					BelongsToCell: "orchestratorcell",
+					BelongsToCell: metadatatest.NewCellID("orchestratorcell"),
 					ContractUsages: []metadata.ContractUsage{
 						{Contract: "saga.order.v1", Role: role},
 					},
@@ -697,7 +697,7 @@ func TestSagaCellLevelL3Declare01(t *testing.T) {
 			Slices: map[string]*metadata.SliceMeta{
 				"unknowncell/saga-orchestrate": {
 					ID:            "saga-orchestrate",
-					BelongsToCell: "unknowncell",
+					BelongsToCell: metadatatest.NewCellID("unknowncell"),
 					ContractUsages: []metadata.ContractUsage{
 						{Contract: "saga.order.v1", Role: "orchestrate"},
 					},
@@ -722,15 +722,15 @@ func TestSagaCellLevelL3Declare01(t *testing.T) {
 		t.Parallel()
 		project := &metadata.ProjectMeta{
 			Cells: map[string]*metadata.CellMeta{
-				"orchestratorcell": {
-					ID: "orchestratorcell", ConsistencyLevel: "L2",
+				metadatatest.NewCellID("orchestratorcell"): {
+					ID: metadatatest.NewCellID("orchestratorcell"), ConsistencyLevel: "L2",
 					File: "cells/orchestratorcell/cell.yaml",
 				},
 			},
 			Slices: map[string]*metadata.SliceMeta{
 				"orchestratorcell/bad-orchestrate": {
 					ID:            "bad-orchestrate",
-					BelongsToCell: "orchestratorcell",
+					BelongsToCell: metadatatest.NewCellID("orchestratorcell"),
 					ContractUsages: []metadata.ContractUsage{
 						{Contract: "http.order.v1", Role: "orchestrate"},
 					},

--- a/kernel/projection/coordinator_test.go
+++ b/kernel/projection/coordinator_test.go
@@ -1174,31 +1174,52 @@ type subscribeCase struct {
 	wantCellID   string
 }
 
+// runSubscribeEmptyProjID handles the empty-projectionID edge case for runSubscribeCase.
+// In PR-03, projectionID moved to NewCoordinator; an empty projID is rejected there.
+func runSubscribeEmptyProjID(t *testing.T, wantErr bool) {
+	t.Helper()
+	clk := clockmock.New(time.Now())
+	_, err := NewCoordinator(clk, CoordinatorConfig{
+		CellID:       "testcell",
+		ProjectionID: "",
+		Registrar:    &fakeRegistrar{},
+		TxRunner:     &fakeTxRunner{},
+		Store:        NewMemCheckpointStore(),
+		Cursor:       &fakeCursor{},
+		Replay:       NewMemReplaySource(),
+		Tracer:       wrapper.NoopTracer{},
+	})
+	if wantErr && err == nil {
+		t.Fatal("expected error for empty projectionID from NewCoordinator, got nil")
+	}
+	if !wantErr && err != nil {
+		t.Fatalf("unexpected NewCoordinator error: %v", err)
+	}
+}
+
+// assertSubscribeRegistrar checks registrar-side outcomes after a Subscribe call.
+func assertSubscribeRegistrar(t *testing.T, reg *fakeRegistrar, tc subscribeCase) {
+	t.Helper()
+	if reg.subscribeCalls != tc.wantSubCalls {
+		t.Errorf("subscribeCalls = %d, want %d", reg.subscribeCalls, tc.wantSubCalls)
+	}
+	if !tc.wantErr && tc.wantCG != "" {
+		if reg.lastCG != tc.wantCG {
+			t.Errorf("consumerGroup = %q, want %q", reg.lastCG, tc.wantCG)
+		}
+		if reg.lastCell != tc.wantCellID {
+			t.Errorf("cellID = %q, want %q", reg.lastCell, tc.wantCellID)
+		}
+	}
+}
+
 func runSubscribeCase(t *testing.T, tc subscribeCase) {
 	t.Helper()
 	// In PR-03, projectionID is in NewCoordinator, not Subscribe. The "empty
 	// projectionID" case is now a NewCoordinator validation; we thread it through
 	// the constructor instead of Subscribe.
-	projID := tc.projectionID
-	if projID == "" {
-		// Test case wants an error from empty projectionID — NewCoordinator rejects.
-		clk := clockmock.New(time.Now())
-		_, err := NewCoordinator(clk, CoordinatorConfig{
-			CellID:       "testcell",
-			ProjectionID: "",
-			Registrar:    &fakeRegistrar{},
-			TxRunner:     &fakeTxRunner{},
-			Store:        NewMemCheckpointStore(),
-			Cursor:       &fakeCursor{},
-			Replay:       NewMemReplaySource(),
-			Tracer:       wrapper.NoopTracer{},
-		})
-		if tc.wantErr && err == nil {
-			t.Fatal("expected error for empty projectionID from NewCoordinator, got nil")
-		}
-		if !tc.wantErr && err != nil {
-			t.Fatalf("unexpected NewCoordinator error: %v", err)
-		}
+	if tc.projectionID == "" {
+		runSubscribeEmptyProjID(t, tc.wantErr)
 		return
 	}
 
@@ -1206,7 +1227,7 @@ func runSubscribeCase(t *testing.T, tc subscribeCase) {
 	clk := clockmock.New(time.Now())
 	c, err := NewCoordinator(clk, CoordinatorConfig{
 		CellID:       "testcell",
-		ProjectionID: projID,
+		ProjectionID: tc.projectionID,
 		Registrar:    reg,
 		TxRunner:     &fakeTxRunner{},
 		Store:        NewMemCheckpointStore(),
@@ -1228,17 +1249,7 @@ func runSubscribeCase(t *testing.T, tc subscribeCase) {
 		t.Fatalf("unexpected error: %v", subscribeErr)
 	}
 
-	if reg.subscribeCalls != tc.wantSubCalls {
-		t.Errorf("subscribeCalls = %d, want %d", reg.subscribeCalls, tc.wantSubCalls)
-	}
-	if !tc.wantErr && tc.wantCG != "" {
-		if reg.lastCG != tc.wantCG {
-			t.Errorf("consumerGroup = %q, want %q", reg.lastCG, tc.wantCG)
-		}
-		if reg.lastCell != tc.wantCellID {
-			t.Errorf("cellID = %q, want %q", reg.lastCell, tc.wantCellID)
-		}
-	}
+	assertSubscribeRegistrar(t, reg, tc)
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/projection/metrics.go
+++ b/kernel/projection/metrics.go
@@ -23,7 +23,8 @@ const (
 )
 
 // errRegisterFmt is the format string used when a metric instrument registration
-// fails. Extracted to avoid S1192 (string literal repeated ≥3 times).
+// fails. Extracted to avoid duplicating the registration error format across the
+// three instrument registrations.
 const errRegisterFmt = "projection: register %s: %w"
 
 // projectionRebuildDurationBuckets covers sub-millisecond to multi-hour

--- a/kernel/projection/metrics.go
+++ b/kernel/projection/metrics.go
@@ -22,6 +22,10 @@ const (
 	labelProjection = "projection"
 )
 
+// errRegisterFmt is the format string used when a metric instrument registration
+// fails. Extracted to avoid S1192 (string literal repeated ≥3 times).
+const errRegisterFmt = "projection: register %s: %w"
+
 // projectionRebuildDurationBuckets covers sub-millisecond to multi-hour
 // rebuild durations. Smaller projections complete in ms; large historical
 // replays may take many minutes. Buckets extend to 1800s (30min) so that the
@@ -55,7 +59,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (*Metrics, error) {
 		LabelNames: []string{labelCell, labelProjection},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("projection: register %s: %w", metricProjectionReplayLag, err)
+		return nil, fmt.Errorf(errRegisterFmt, metricProjectionReplayLag, err)
 	}
 	dur, err := p.HistogramVec(kernelmetrics.HistogramOpts{
 		Name:       metricProjectionRebuildDuration,
@@ -64,7 +68,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (*Metrics, error) {
 		Buckets:    projectionRebuildDurationBuckets,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("projection: register %s: %w", metricProjectionRebuildDuration, err)
+		return nil, fmt.Errorf(errRegisterFmt, metricProjectionRebuildDuration, err)
 	}
 	pending, err := p.GaugeVec(kernelmetrics.GaugeOpts{
 		Name:       metricProjectionPendingEvents,
@@ -72,7 +76,7 @@ func RegisterMetrics(p kernelmetrics.Provider) (*Metrics, error) {
 		LabelNames: []string{labelCell, labelProjection},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("projection: register %s: %w", metricProjectionPendingEvents, err)
+		return nil, fmt.Errorf(errRegisterFmt, metricProjectionPendingEvents, err)
 	}
 	return &Metrics{ReplayLag: lag, RebuildDuration: dur, PendingEvents: pending}, nil
 }

--- a/kernel/projection/metrics_test.go
+++ b/kernel/projection/metrics_test.go
@@ -2,6 +2,7 @@ package projection
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -41,6 +42,38 @@ func TestRegisterProjectionMetrics_WiresThree(t *testing.T) {
 	}
 	if labels := p.gaugeLabels(metricProjectionPendingEvents); !labelsMatch(labels, []string{"cell", "projection"}) {
 		t.Errorf("PendingEvents labels = %v, want [cell projection]", labels)
+	}
+}
+
+// TestRegisterProjectionMetrics_RegistrationFailure covers the three error
+// branches in RegisterMetrics: a Provider that fails the Nth instrument
+// registration must return the wrapped error. RegisterMetrics registers in
+// order: ReplayLag (gauge) → RebuildDuration (histogram) → PendingEvents (gauge).
+func TestRegisterProjectionMetrics_RegistrationFailure(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		failGaugeN int // fail the Nth GaugeVec call (1=lag, 2=pending); 0=disabled
+		failHist   bool
+		wantSubstr string
+	}{
+		{"lag gauge fails", 1, false, metricProjectionReplayLag},
+		{"rebuild duration histogram fails", 0, true, metricProjectionRebuildDuration},
+		{"pending events gauge fails", 2, false, metricProjectionPendingEvents},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := &projFailProvider{failGaugeN: tc.failGaugeN, failHist: tc.failHist}
+			_, err := RegisterMetrics(p)
+			if err == nil {
+				t.Fatal("RegisterMetrics: expected error, got nil")
+			}
+			if !containsStr(err.Error(), tc.wantSubstr) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.wantSubstr)
+			}
+		})
 	}
 }
 
@@ -130,6 +163,38 @@ func TestProjectionMetrics_RecordsPendingEvents(t *testing.T) {
 		t.Errorf("PendingEvents gauge = %f, want 7.0", v)
 	}
 }
+
+// projFailProvider fails a configured instrument registration so RegisterMetrics's
+// three error branches can be exercised. failGaugeN (1-based, 0=disabled) fails
+// the Nth GaugeVec call; failHist fails HistogramVec.
+type projFailProvider struct {
+	failGaugeN int
+	failHist   bool
+	gaugeCount int
+}
+
+func (p *projFailProvider) CounterVec(opts kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
+	return kernelmetrics.NopProvider{}.CounterVec(opts)
+}
+
+func (p *projFailProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
+	if p.failHist {
+		return nil, errProjRegistration
+	}
+	return kernelmetrics.NopProvider{}.HistogramVec(opts)
+}
+
+func (p *projFailProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
+	p.gaugeCount++
+	if p.failGaugeN > 0 && p.gaugeCount == p.failGaugeN {
+		return nil, errProjRegistration
+	}
+	return kernelmetrics.NopProvider{}.GaugeVec(opts)
+}
+
+func (p *projFailProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
+
+var errProjRegistration = errors.New("duplicate instrument")
 
 // ---------------------------------------------------------------------------
 // recordingProvider — spy metrics.Provider for projection metrics tests.

--- a/kernel/projection/probe_test.go
+++ b/kernel/projection/probe_test.go
@@ -132,7 +132,7 @@ func TestCoordinator_Probes_Names(t *testing.T) {
 	t.Parallel()
 	src := NewMemReplaySource()
 	clk := clockmock.New(time.Now())
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, NewMemCheckpointStore(), newMemCursor(src), src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", cursor: newMemCursor(src), replay: src})
 
 	probes, err := c.Probes()
 	if err != nil {
@@ -164,7 +164,7 @@ func TestCoordinator_StoreReady_Healthy(t *testing.T) {
 	cur := newMemCursor(src)
 	store := NewMemCheckpointStore()
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	probes, err := c.Probes()
@@ -188,7 +188,7 @@ func TestCoordinator_StoreReady_HeadError(t *testing.T) {
 	store := NewMemCheckpointStore()
 	cur := &fakeCursor{pos: 1}
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, errSrc)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: errSrc})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	probes, err := c.Probes()
@@ -219,7 +219,7 @@ func TestCoordinator_Lag_Idle(t *testing.T) {
 	cur := newMemCursor(src)
 	store := NewMemCheckpointStore()
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	probes, err := c.Probes()
@@ -247,7 +247,7 @@ func TestCoordinator_Lag_ColdStartHealthy(t *testing.T) {
 	src.Append(mustNewTestEntry(t, clk2, "topic.v1"))
 	src.Append(mustNewTestEntry(t, clk2, "topic.v1"))
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	probes, err := c.Probes()
@@ -271,7 +271,7 @@ func TestCoordinator_Lag_NegativePending_Warn(t *testing.T) {
 	cur := newMemCursor(src)
 	store := NewMemCheckpointStore()
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	// Set checkpoint > head (anomaly: head=0, checkpoint=5).
@@ -305,7 +305,7 @@ func TestCoordinator_Lag_Unhealthy(t *testing.T) {
 	src.Append(mustNewTestEntry(t, clk2, "topic.v1"))
 	src.Append(mustNewTestEntry(t, clk2, "topic.v1"))
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	// pending=1, last=farPast → lag > threshold → unhealthy.
@@ -344,7 +344,7 @@ func TestCoordinator_Lag_BelowThreshold(t *testing.T) {
 	src.Append(mustNewTestEntry(t, clk2, "topic.v1"))
 	src.Append(mustNewTestEntry(t, clk2, "topic.v1"))
 
-	c := newCoordinatorFull(t, clk, "myproj", &fakeRegistrar{}, &fakeTxRunner{}, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	c.lastAppliedUnixNano.Store(recentPast.UnixNano())

--- a/kernel/projection/rebuild_test.go
+++ b/kernel/projection/rebuild_test.go
@@ -1157,7 +1157,7 @@ func (b *blockingReplaySource) Head(context.Context) (int64, error) {
 // loop. The wait observes real-clock goroutine progress, not simulated time.
 func waitForPhase(t *testing.T, c *Coordinator, want Phase) {
 	t.Helper()
-	testwait.External(t, "projection-rebuild-phase-transition",
+	testwait.External(t, "projection-rebuild-wait-for-phase",
 		func() bool { return c.Phase() == want },
 		testtime.EventuallyLong, testtime.FastPoll,
 		"phase != %v", want)
@@ -1169,7 +1169,7 @@ func waitForPhase(t *testing.T, c *Coordinator, want Phase) {
 //nolint:unparam // notWant=PhaseLive in current callers; param kept for future tests
 func waitUntilPhaseNot(t *testing.T, c *Coordinator, notWant Phase) {
 	t.Helper()
-	testwait.External(t, "projection-rebuild-phase-transition",
+	testwait.External(t, "projection-rebuild-wait-phase-changed",
 		func() bool { return c.Phase() != notWant },
 		testtime.EventuallyLong, testtime.FastPoll,
 		"phase still == %v", notWant)

--- a/kernel/projection/rebuild_test.go
+++ b/kernel/projection/rebuild_test.go
@@ -26,30 +26,47 @@ const rebuildTestHandlerTimeout = 2 * time.Second
 // helpers for rebuild tests
 // ---------------------------------------------------------------------------
 
+// coordinatorFullParams groups the non-testing parameters for newCoordinatorFull.
+// Introduced to reduce the argument count below the S107 limit of 7.
+type coordinatorFullParams struct {
+	clk          *clockmock.FakeClock
+	projectionID string // defaults to "p1" when empty
+	reg          *fakeRegistrar
+	txr          *fakeTxRunner
+	store        CheckpointStore
+	cursor       Cursor
+	replay       ReplaySource
+}
+
 // newCoordinatorFull creates a Coordinator with all dependencies including
-// clock and replay source. projectionID defaults to "p1".
-func newCoordinatorFull(
-	t *testing.T,
-	clk *clockmock.FakeClock,
-	projectionID string,
-	reg *fakeRegistrar,
-	txr *fakeTxRunner,
-	store CheckpointStore,
-	cursor Cursor,
-	replay ReplaySource,
-) *Coordinator {
+// clock and replay source. Nil fields default to safe in-memory fakes so callers
+// only need to set the fields they care about.
+func newCoordinatorFull(t *testing.T, p coordinatorFullParams) *Coordinator {
 	t.Helper()
-	if projectionID == "" {
-		projectionID = "p1"
+	projID := p.projectionID
+	if projID == "" {
+		projID = "p1"
 	}
-	c, err := NewCoordinator(clk, CoordinatorConfig{
+	if p.reg == nil {
+		p.reg = &fakeRegistrar{}
+	}
+	if p.txr == nil {
+		p.txr = &fakeTxRunner{}
+	}
+	if p.store == nil {
+		p.store = NewMemCheckpointStore()
+	}
+	if p.cursor == nil {
+		p.cursor = &fakeCursor{pos: 1}
+	}
+	c, err := NewCoordinator(p.clk, CoordinatorConfig{
 		CellID:       "testcell",
-		ProjectionID: projectionID,
-		Registrar:    reg,
-		TxRunner:     txr,
-		Store:        store,
-		Cursor:       cursor,
-		Replay:       replay,
+		ProjectionID: projID,
+		Registrar:    p.reg,
+		TxRunner:     p.txr,
+		Store:        p.store,
+		Cursor:       p.cursor,
+		Replay:       p.replay,
 		Tracer:       wrapper.NoopTracer{},
 		Metrics:      nil, // metrics optional
 	})
@@ -119,7 +136,7 @@ func TestRebuild_ColdFull(t *testing.T) {
 	reg := &fakeRegistrar{}
 	clk := clockmock.New(time.Now())
 
-	c := newCoordinatorFull(t, clk, "p1", reg, txr, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, reg: reg, txr: txr, store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, applyNoop)
 
 	if err := c.Rebuild(context.Background()); err != nil {
@@ -152,7 +169,7 @@ func TestRebuild_OnResetCalledInTx(t *testing.T) {
 	reg := &fakeRegistrar{}
 	clk := clockmock.New(time.Now())
 
-	c := newCoordinatorFull(t, clk, "p1", reg, txr, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, reg: reg, txr: txr, store: store, cursor: cur, replay: src})
 
 	var resetCalls int32
 	onReset := func(ctx context.Context) error {
@@ -191,7 +208,7 @@ func TestRebuild_OnResetErrorRollback(t *testing.T) {
 	reg := &fakeRegistrar{}
 	clk := clockmock.New(time.Now())
 
-	c := newCoordinatorFull(t, clk, "p1", reg, txr, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, reg: reg, txr: txr, store: store, cursor: cur, replay: src})
 
 	errReset := errors.New("reset failed")
 	onReset := func(ctx context.Context) error {
@@ -239,7 +256,7 @@ func TestRebuild_ReplayErrorReturnLive(t *testing.T) {
 	reg := &fakeRegistrar{}
 	clk := clockmock.New(time.Now())
 
-	c := newCoordinatorFull(t, clk, "p1", reg, txr, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, reg: reg, txr: txr, store: store, cursor: cur, replay: src})
 	subscribeWithDefaults(t, c, apply)
 
 	if err := c.Rebuild(context.Background()); err != nil {
@@ -312,7 +329,7 @@ func TestRebuild_BeforeSubscribe(t *testing.T) {
 	t.Parallel()
 	src := NewMemReplaySource()
 	clk := clockmock.New(time.Now())
-	c := newCoordinatorFull(t, clk, "p1", &fakeRegistrar{}, &fakeTxRunner{}, NewMemCheckpointStore(), &fakeCursor{pos: 1}, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, cursor: &fakeCursor{pos: 1}, replay: src})
 
 	// Rebuild before Subscribe must return an error.
 	err := c.Rebuild(context.Background())
@@ -413,7 +430,7 @@ func TestSubscribe_SecondCallError(t *testing.T) {
 	t.Parallel()
 	src := NewMemReplaySource()
 	clk := clockmock.New(time.Now())
-	c := newCoordinatorFull(t, clk, "p1", &fakeRegistrar{}, &fakeTxRunner{}, NewMemCheckpointStore(), &fakeCursor{pos: 1}, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, cursor: &fakeCursor{pos: 1}, replay: src})
 
 	spec := minimalSpec("projection.p1.v1")
 	// First Subscribe succeeds.
@@ -434,6 +451,27 @@ func TestSubscribe_SecondCallError(t *testing.T) {
 // ---------------------------------------------------------------------------
 // TestNewCoordinator_NilGuards_PR03 — new params: clk, projectionID, replay
 // ---------------------------------------------------------------------------
+
+// assertCoordinatorResult checks that (c, err) matches wantErr. Extracted to
+// reduce the cognitive complexity of the outer table-driven loop.
+func assertCoordinatorResult(t *testing.T, c *Coordinator, err error, wantErr bool) {
+	t.Helper()
+	if wantErr {
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if c != nil {
+			t.Error("expected nil Coordinator on error")
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil Coordinator")
+	}
+}
 
 func TestNewCoordinator_NilGuards_PR03(t *testing.T) {
 	t.Parallel()
@@ -496,21 +534,7 @@ func TestNewCoordinator_NilGuards_PR03(t *testing.T) {
 				Replay:       tc.replay,
 				Tracer:       wrapper.NoopTracer{},
 			})
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if c != nil {
-					t.Error("expected nil Coordinator on error")
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if c == nil {
-					t.Fatal("expected non-nil Coordinator")
-				}
-			}
+			assertCoordinatorResult(t, c, err, tc.wantErr)
 		})
 	}
 }
@@ -720,7 +744,7 @@ func TestRebuild_OnResetError_GateReopened(t *testing.T) {
 	reg := &fakeRegistrar{}
 	clk := clockmock.New(time.Now())
 
-	c := newCoordinatorFull(t, clk, "p1", reg, txr, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, reg: reg, txr: txr, store: store, cursor: cur, replay: src})
 
 	errReset := errors.New("reset failed")
 	subscribeWithDefaults(t, c, applyNoop, WithOnReset(func(_ context.Context) error {
@@ -815,6 +839,101 @@ func TestRebuild_CatchupIsCaughtUpError(t *testing.T) {
 // on degraded catchup path, IS recorded on clean catchup path (Task 4)
 // ---------------------------------------------------------------------------
 
+// runDegradedCatchupSubtest is the degraded-path sub-case for
+// TestRebuild_DegradedCatchup_NoDurationObserved: Head fails on 2nd call (during
+// catchup) → rebuild_duration histogram receives ZERO observations.
+func runDegradedCatchupSubtest(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	p := newProjectionRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+
+	// Head returns error on calls >= failAt (2 = first captureHead succeeds, catchup fails).
+	catchupSrc := &catchupErrReplaySource{failAt: 2, headErr: errors.New("catchup head error")}
+	clk := clockmock.New(time.Now())
+
+	c, err := NewCoordinator(clk, CoordinatorConfig{
+		CellID:       "testcell",
+		ProjectionID: "p1",
+		Registrar:    &fakeRegistrar{},
+		TxRunner:     &fakeTxRunner{},
+		Store:        NewMemCheckpointStore(),
+		Cursor:       &fakeCursor{pos: 1},
+		Replay:       catchupSrc,
+		Tracer:       wrapper.NoopTracer{},
+		Metrics:      m,
+	})
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+	subscribeWithDefaults(t, c, applyNoop)
+
+	if err := c.Rebuild(context.Background()); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	waitForPhase(t, c, PhaseLive)
+
+	count := p.histogramCount(
+		metricProjectionRebuildDuration,
+		kernelmetrics.Labels{"cell": "testcell", "projection": "p1"},
+	)
+	if count != 0 {
+		t.Errorf("degraded catchup: rebuild_duration observations = %d, want 0", count)
+	}
+	if c.Phase() != PhaseLive {
+		t.Errorf("Phase = %v after degraded catchup, want PhaseLive", c.Phase())
+	}
+}
+
+// runCleanCatchupSubtest is the clean-path sub-case for
+// TestRebuild_DegradedCatchup_NoDurationObserved: full replay, caughtUp=true →
+// rebuild_duration histogram receives ≥1 observation.
+func runCleanCatchupSubtest(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	p := newProjectionRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+
+	const n = 3
+	src, cur := makeReplayWithEntries(t, n)
+	clk := clockmock.New(time.Now())
+
+	c, err := NewCoordinator(clk, CoordinatorConfig{
+		CellID:       "testcell",
+		ProjectionID: "p1",
+		Registrar:    &fakeRegistrar{},
+		TxRunner:     &fakeTxRunner{},
+		Store:        NewMemCheckpointStore(),
+		Cursor:       cur,
+		Replay:       src,
+		Tracer:       wrapper.NoopTracer{},
+		Metrics:      m,
+	})
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+	subscribeWithDefaults(t, c, applyNoop)
+
+	if err := c.Rebuild(context.Background()); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	waitForPhase(t, c, PhaseLive)
+
+	count := p.histogramCount(
+		metricProjectionRebuildDuration,
+		kernelmetrics.Labels{"cell": "testcell", "projection": "p1"},
+	)
+	if count < 1 {
+		t.Errorf("clean rebuild: rebuild_duration observations = %d, want ≥1", count)
+	}
+}
+
 // TestRebuild_DegradedCatchup_NoDurationObserved asserts that:
 //  1. Degraded path (catchupPhase returns caughtUp=false due to Head error) → the
 //     rebuild_duration histogram receives ZERO observations.
@@ -825,104 +944,8 @@ func TestRebuild_CatchupIsCaughtUpError(t *testing.T) {
 // ONLY when caughtUp==true; degraded logs Warn and skips the Observe call.
 func TestRebuild_DegradedCatchup_NoDurationObserved(t *testing.T) {
 	t.Parallel()
-
-	// --- Degraded path: Head fails on 2nd call (during catchup) ---
-	t.Run("degraded: Head error in catchup → duration NOT observed", func(t *testing.T) {
-		t.Parallel()
-		p := newProjectionRecordingProvider()
-		m, err := RegisterMetrics(p)
-		if err != nil {
-			t.Fatalf("RegisterMetrics: %v", err)
-		}
-
-		// catchupErrReplaySource defined earlier in this file:
-		// Head returns error on calls >= failAt (2 = first captureHead succeeds, catchup fails).
-		catchupSrc := &catchupErrReplaySource{failAt: 2, headErr: errors.New("catchup head error")}
-		store := NewMemCheckpointStore()
-		txr := &fakeTxRunner{}
-		reg := &fakeRegistrar{}
-		clk := clockmock.New(time.Now())
-		cur := &fakeCursor{pos: 1}
-
-		c, err := NewCoordinator(clk, CoordinatorConfig{
-			CellID:       "testcell",
-			ProjectionID: "p1",
-			Registrar:    reg,
-			TxRunner:     txr,
-			Store:        store,
-			Cursor:       cur,
-			Replay:       catchupSrc,
-			Tracer:       wrapper.NoopTracer{},
-			Metrics:      m,
-		})
-		if err != nil {
-			t.Fatalf("NewCoordinator: %v", err)
-		}
-		subscribeWithDefaults(t, c, applyNoop)
-
-		if err := c.Rebuild(context.Background()); err != nil {
-			t.Fatalf("Rebuild: %v", err)
-		}
-		waitForPhase(t, c, PhaseLive)
-
-		count := p.histogramCount(
-			metricProjectionRebuildDuration,
-			kernelmetrics.Labels{"cell": "testcell", "projection": "p1"},
-		)
-		if count != 0 {
-			t.Errorf("degraded catchup: rebuild_duration observations = %d, want 0", count)
-		}
-		// Phase must still return to Live (degraded is non-fatal).
-		if c.Phase() != PhaseLive {
-			t.Errorf("Phase = %v after degraded catchup, want PhaseLive", c.Phase())
-		}
-	})
-
-	// --- Clean path: all events replayed, caughtUp=true → duration IS observed ---
-	t.Run("clean: full catchup → duration observed ≥1", func(t *testing.T) {
-		t.Parallel()
-		p := newProjectionRecordingProvider()
-		m, err := RegisterMetrics(p)
-		if err != nil {
-			t.Fatalf("RegisterMetrics: %v", err)
-		}
-
-		const n = 3
-		src, cur := makeReplayWithEntries(t, n)
-		store := NewMemCheckpointStore()
-		txr := &fakeTxRunner{}
-		reg := &fakeRegistrar{}
-		clk := clockmock.New(time.Now())
-
-		c, err := NewCoordinator(clk, CoordinatorConfig{
-			CellID:       "testcell",
-			ProjectionID: "p1",
-			Registrar:    reg,
-			TxRunner:     txr,
-			Store:        store,
-			Cursor:       cur,
-			Replay:       src,
-			Tracer:       wrapper.NoopTracer{},
-			Metrics:      m,
-		})
-		if err != nil {
-			t.Fatalf("NewCoordinator: %v", err)
-		}
-		subscribeWithDefaults(t, c, applyNoop)
-
-		if err := c.Rebuild(context.Background()); err != nil {
-			t.Fatalf("Rebuild: %v", err)
-		}
-		waitForPhase(t, c, PhaseLive)
-
-		count := p.histogramCount(
-			metricProjectionRebuildDuration,
-			kernelmetrics.Labels{"cell": "testcell", "projection": "p1"},
-		)
-		if count < 1 {
-			t.Errorf("clean rebuild: rebuild_duration observations = %d, want ≥1", count)
-		}
-	})
+	t.Run("degraded: Head error in catchup → duration NOT observed", runDegradedCatchupSubtest)
+	t.Run("clean: full catchup → duration observed ≥1", runCleanCatchupSubtest)
 }
 
 // TestRebuild_CatchupCtxCancel asserts that a ctx cancel during catchup routes
@@ -1024,7 +1047,7 @@ func TestClose_Idempotent(t *testing.T) {
 	t.Parallel()
 	src := NewMemReplaySource()
 	clk := clockmock.New(time.Now())
-	c := newCoordinatorFull(t, clk, "p1", &fakeRegistrar{}, &fakeTxRunner{}, NewMemCheckpointStore(), &fakeCursor{pos: 1}, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, cursor: &fakeCursor{pos: 1}, replay: src})
 
 	const n = 10
 	errs := make([]error, n)
@@ -1060,7 +1083,7 @@ func TestRebuild_PanicRecovered(t *testing.T) {
 	reg := &fakeRegistrar{}
 	clk := clockmock.New(time.Now())
 
-	c := newCoordinatorFull(t, clk, "p1", reg, txr, store, cur, src)
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, reg: reg, txr: txr, store: store, cursor: cur, replay: src})
 
 	// apply panics on the first entry.
 	panicApply := func(_ context.Context, _ outbox.Entry) error {

--- a/kernel/reconcile/loop_test.go
+++ b/kernel/reconcile/loop_test.go
@@ -44,18 +44,27 @@ type blockingReconciler struct {
 	perEntity     map[string]int
 	maxPerEntity  int
 	calls         atomic.Int64
+
+	// firstCallOnce and firstCallSig together form a deterministic signal:
+	// firstCallSig is closed the first time Reconcile is entered. Tests that
+	// need to know "at least one reconcile has started" use
+	// testwait.Deterministic(t, r.firstCallSig) instead of polling calls.Load.
+	firstCallOnce sync.Once
+	firstCallSig  chan struct{}
 }
 
 func newBlockingReconciler() *blockingReconciler {
 	return &blockingReconciler{
-		release:   make(chan struct{}),
-		perEntity: map[string]int{},
-		result:    Result{RequeueAfter: testtime.D1h}, // requeue far out — no re-fire mid-test
+		release:      make(chan struct{}),
+		perEntity:    map[string]int{},
+		result:       Result{RequeueAfter: testtime.D1h}, // requeue far out — no re-fire mid-test
+		firstCallSig: make(chan struct{}),
 	}
 }
 
 func (r *blockingReconciler) Reconcile(ctx context.Context, req Request) (Result, error) {
 	r.calls.Add(1)
+	r.firstCallOnce.Do(func() { close(r.firstCallSig) })
 	r.enter(req.EntityID)
 	defer r.exit(req.EntityID)
 	if r.ignoreCtx {
@@ -193,11 +202,14 @@ func TestLoop_OwnerCtxCancelDrainsWithoutStop(t *testing.T) {
 	// F3: leader must return to 0 on owner-cancel drain even WITHOUT an explicit
 	// Stop — the done-watcher is the single reset site, so this path no longer
 	// leaves reconcile_leader stuck at 1.
+	// gaugeValue is a transient read (not a monotone counter), so no channel
+	// signal is producible — polling is required here. Timeout raised from
+	// D500ms to EventuallyDefault (3 s) for race-CI headroom.
 	testwait.External(t, "leader-reset-on-owner-cancel",
 		func() bool {
 			return p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}) == 0
 		},
-		testtime.D500ms, testtime.D1ms, "leader gauge must reset to 0 when owner ctx drains the loop without Stop")
+		testtime.EventuallyDefault, testtime.D1ms, "leader gauge must reset to 0 when owner ctx drains the loop without Stop")
 }
 
 // TestLoop_OwnerCtxCanceledBeforeStart mirrors the transplant source's
@@ -229,8 +241,9 @@ func TestLoop_StopTimeoutReturnsDeadline(t *testing.T) {
 	require.NoError(t, l.Start(ownerCtx))
 
 	src <- Request{EntityID: "stuck"}
-	testwait.External(t, "reconcile-started", func() bool { return rec.calls.Load() >= 1 },
-		testtime.D500ms, testtime.D1ms, "a reconcile must be running before Stop")
+	// blockingReconciler.firstCallSig is closed on the first Reconcile entry —
+	// deterministic signal, no polling needed.
+	testwait.Deterministic(t, rec.firstCallSig, "reconcile-started")
 
 	sc, cancel := context.WithTimeout(context.Background(), testtime.D1ms)
 	defer cancel()
@@ -257,8 +270,12 @@ func TestLoop_MaxConcurrencyRespected(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		src <- Request{EntityID: fmt.Sprintf("e%d", i)}
 	}
+	// currentConcurrent() is a transient peak (not a monotone counter): the
+	// value may drop back below 2 before we observe it. A channel signal would
+	// require peeking into the scheduler, which is not possible. Keep External
+	// but raise the timeout from D500ms to EventuallyDefault (3 s) for CI headroom.
 	testwait.External(t, "two-concurrent-reconciles", func() bool { return rec.currentConcurrent() == 2 },
-		testtime.D500ms, testtime.D1ms, "exactly 2 reconciles should run with MaxConcurrentReconciles=2")
+		testtime.EventuallyDefault, testtime.D1ms, "exactly 2 reconciles should run with MaxConcurrentReconciles=2")
 	maxC, _ := rec.snapshot()
 	assert.LessOrEqual(t, maxC, 2, "concurrency must never exceed the worker bound")
 
@@ -280,6 +297,10 @@ func TestLoop_SameEntityIDSerial(t *testing.T) {
 	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, MaxConcurrentReconciles: 4, Interval: testtime.D1h, Metrics: m}
 	ownerCtx, ownerCancel := startCtxs(t)
 	defer ownerCancel()
+	// Register the deterministic signal BEFORE Start so no skip increment is
+	// missed between Start and the first Request send.
+	skippedThrice := p.signalWhenCounterReaches(
+		kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultSkipped}, 3)
 	require.NoError(t, l.Start(ownerCtx))
 
 	for i := 0; i < 4; i++ {
@@ -287,11 +308,14 @@ func TestLoop_SameEntityIDSerial(t *testing.T) {
 	}
 	// First reconcile holds the entity; the other three are dequeued and dropped
 	// as "skipped" (level-triggered serialization), never running concurrently.
-	testwait.External(t, "three-duplicates-skipped",
-		func() bool {
-			return p.counterValue(kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultSkipped}) >= 3
-		},
-		testtime.D500ms, testtime.D1ms, "duplicate same-entity requests must be skipped while one is in flight")
+	// recordingProvider.signalWhenCounterReaches installs a notify callback on
+	// the counter vec; the channel is closed as soon as skip count reaches 3 —
+	// no wall-clock polling, no race window.
+	testwait.Deterministic(t, skippedThrice, "three-duplicates-skipped")
+	// The skip counter fires before Reconcile.enter() is guaranteed to have run
+	// (skip is recorded in the dispatch goroutine, before the lock into perEntity).
+	// Wait for the first Reconcile entry to ensure maxPerEntity is observable.
+	testwait.Deterministic(t, rec.firstCallSig, "first-reconcile-entered")
 	_, maxPE := rec.snapshot()
 	assert.Equal(t, 1, maxPE, "the same EntityID must never reconcile concurrently")
 
@@ -307,18 +331,23 @@ func TestLoop_SameEntityIDSerial(t *testing.T) {
 
 func TestLoop_PanicRecoveredAndOtherEntitiesUnaffected(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	var okCalls atomic.Int64
+	// okSig is closed the first time the non-panicking "ok" entity is reconciled.
+	okSig := make(chan struct{})
+	var okOnce sync.Once
 	rec := funcReconciler(func(_ context.Context, req Request) (Result, error) {
 		if req.EntityID == "boom" {
 			panic("kaboom")
 		}
-		okCalls.Add(1)
+		okOnce.Do(func() { close(okSig) })
 		return Result{RequeueAfter: testtime.D1h}, nil
 	})
 	src := make(chan Request)
 	p := newRecordingProvider()
 	m, err := RegisterMetrics(p)
 	require.NoError(t, err)
+	// Register the transient-counter signal before Start so no increment is missed.
+	panicTransient := p.signalWhenCounterReaches(
+		kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultTransient}, 1)
 	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: testtime.D1h, Metrics: m}
 	ownerCtx, ownerCancel := startCtxs(t)
 	defer ownerCancel()
@@ -327,13 +356,11 @@ func TestLoop_PanicRecoveredAndOtherEntitiesUnaffected(t *testing.T) {
 	src <- Request{EntityID: "boom"}
 	src <- Request{EntityID: "ok"}
 
-	testwait.External(t, "other-entity-reconciled", func() bool { return okCalls.Load() >= 1 },
-		testtime.D500ms, testtime.D1ms, "a panicking entity must not stop other entities from reconciling")
-	testwait.External(t, "panic-counted-transient",
-		func() bool {
-			return p.counterValue(kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultTransient}) >= 1
-		},
-		testtime.D500ms, testtime.D1ms, "a recovered panic must be classified transient")
+	// okSig is closed deterministically when the "ok" entity completes its first
+	// reconcile — channel signal, no polling.
+	testwait.Deterministic(t, okSig, "other-entity-reconciled")
+	// panicTransient is closed deterministically when the transient counter hits 1.
+	testwait.Deterministic(t, panicTransient, "panic-counted-transient")
 
 	sc, cancel := stopCtx(t)
 	defer cancel()
@@ -352,6 +379,11 @@ func TestLoop_PermanentNotRequeued_TransientRequeued(t *testing.T) {
 	p := newRecordingProvider()
 	m, err := RegisterMetrics(p)
 	require.NoError(t, err)
+	// Register the deterministic signal before Start so no increment is missed
+	// between Start and the first Request send.
+	transLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultTransient}
+	permLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultPermanent}
+	transientThrice := p.signalWhenCounterReaches(transLabels, 3)
 	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: shortRequeue, Metrics: m}
 	ownerCtx, ownerCancel := startCtxs(t)
 	defer ownerCancel()
@@ -363,11 +395,8 @@ func TestLoop_PermanentNotRequeued_TransientRequeued(t *testing.T) {
 	// Once the transient entity has been requeued+retried several times, enough
 	// intervals have elapsed that the permanent entity would also have requeued
 	// if it were going to — assert it stayed at exactly one reconcile.
-	transLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultTransient}
-	permLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultPermanent}
-	testwait.External(t, "transient-requeued-thrice",
-		func() bool { return p.counterValue(transLabels) >= 3 },
-		testtime.D500ms, testtime.D1ms, "transient errors must be requeued and retried")
+	// Channel signal from recordingProvider.signalWhenCounterReaches; no polling.
+	testwait.Deterministic(t, transientThrice, "transient-requeued-thrice")
 	assert.Equal(t, int64(1), p.counterValue(permLabels),
 		"a PermanentError entity must reconcile exactly once (dead-lettered, not requeued)")
 
@@ -385,6 +414,9 @@ func TestLoop_RecordsSuccessMetrics(t *testing.T) {
 	p := newRecordingProvider()
 	m, err := RegisterMetrics(p)
 	require.NoError(t, err)
+	// Register the deterministic signal before Start so no increment is missed.
+	successLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultSuccess}
+	successSig := p.signalWhenCounterReaches(successLabels, 1)
 	l := &Loop{ReconcilerID: "rc", Reconciler: rec, Source: src, Interval: testtime.D1h, Metrics: m}
 	ownerCtx, ownerCancel := startCtxs(t)
 	defer ownerCancel()
@@ -394,10 +426,8 @@ func TestLoop_RecordsSuccessMetrics(t *testing.T) {
 	assert.Equal(t, float64(1), p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}))
 
 	src <- Request{EntityID: "e1"}
-	successLabels := kernelmetrics.Labels{labelReconciler: "rc", labelResult: resultSuccess}
-	testwait.External(t, "success-recorded",
-		func() bool { return p.counterValue(successLabels) >= 1 },
-		testtime.D500ms, testtime.D1ms, "a successful reconcile must increment reconcile_total{result=success}")
+	// Channel signal from recordingProvider.signalWhenCounterReaches; no polling.
+	testwait.Deterministic(t, successSig, "success-recorded")
 	assert.GreaterOrEqual(t, p.histogramCount(metricReconcileDuration, kernelmetrics.Labels{labelReconciler: "rc"}), int64(1),
 		"reconcile_duration_seconds must be observed")
 
@@ -433,11 +463,13 @@ func TestLoop_OwnerCtxCanceledBeforeStartResetsLeader(t *testing.T) {
 	require.NoError(t, l.Start(ownerCtx))
 	// The reset is via the done-watcher (single reset site), so it is async to
 	// Start returning — poll until the spawned workers drain and reset it.
+	// gaugeValue is a transient read (not a monotone counter), so no channel
+	// signal is producible. Timeout raised from D500ms to EventuallyDefault (3 s).
 	testwait.External(t, "leader-reset-precancel",
 		func() bool {
 			return p.gaugeValue(metricReconcileLeader, kernelmetrics.Labels{labelReconciler: "rc"}) == 0
 		},
-		testtime.D500ms, testtime.D1ms, "leader must reset to 0 when owner ctx is canceled before the loop confirms running")
+		testtime.EventuallyDefault, testtime.D1ms, "leader must reset to 0 when owner ctx is canceled before the loop confirms running")
 	require.NoError(t, l.Stop(context.Background())) // no-op; state already cleared
 }
 
@@ -460,8 +492,9 @@ func TestLoop_StopRetryableAfterTimeout(t *testing.T) {
 	require.NoError(t, l.Start(ownerCtx))
 
 	src <- Request{EntityID: "stuck"}
-	testwait.External(t, "reconcile-started", func() bool { return rec.calls.Load() >= 1 },
-		testtime.D500ms, testtime.D1ms, "a reconcile must be running before Stop")
+	// blockingReconciler.firstCallSig is closed on the first Reconcile entry —
+	// deterministic signal, no polling needed.
+	testwait.Deterministic(t, rec.firstCallSig, "reconcile-started")
 
 	// First Stop times out (reconcile stuck): returns deadline, leaves state.
 	sc1, cancel1 := context.WithTimeout(context.Background(), testtime.D1ms)

--- a/kernel/reconcile/metrics_test.go
+++ b/kernel/reconcile/metrics_test.go
@@ -176,11 +176,11 @@ func (p *recordingProvider) signalWhenCounterReaches(l kernelmetrics.Labels, thr
 
 	labelKey := labelsKeyR(l)
 	vec.mu.Lock()
-	vec.notify = func(labels kernelmetrics.Labels, newVal int64) {
+	vec.notifiers = append(vec.notifiers, func(labels kernelmetrics.Labels, newVal int64) {
 		if labelsKeyR(labels) == labelKey && newVal >= threshold {
 			fire()
 		}
-	}
+	})
 	// Check if threshold is already reached (race-free: vec.mu held).
 	if cur, exists := vec.obs[labelKey]; exists && cur.Load() >= threshold {
 		fire()
@@ -214,11 +214,13 @@ type recordingCounterVec struct {
 	labels []string
 	mu     sync.Mutex
 	obs    map[string]*atomic.Int64
-	// notify is an optional per-increment callback set by tests. It is called
+	// notifiers is a list of per-increment callbacks set by tests. Each is called
 	// after every Inc/Add with the label set and the new counter value.
-	// The callback is invoked outside recordingCounterVec.mu to avoid inversion
-	// with any mutex the callback itself may acquire.
-	notify func(labels kernelmetrics.Labels, newVal int64)
+	// Callbacks are invoked outside recordingCounterVec.mu to avoid inversion
+	// with any mutex the callbacks themselves may acquire.
+	// Using a slice (append) rather than a single field prevents a second
+	// signalWhenCounterReaches registration from silently overwriting the first.
+	notifiers []func(labels kernelmetrics.Labels, newVal int64)
 }
 
 func (v *recordingCounterVec) Registered() bool { return true }
@@ -262,9 +264,10 @@ type recordingCounter struct {
 func (c *recordingCounter) Inc(_ context.Context) {
 	newVal := c.n.Add(1)
 	c.vec.mu.Lock()
-	fn := c.vec.notify
+	fns := make([]func(kernelmetrics.Labels, int64), len(c.vec.notifiers))
+	copy(fns, c.vec.notifiers)
 	c.vec.mu.Unlock()
-	if fn != nil {
+	for _, fn := range fns {
 		fn(c.labels, newVal)
 	}
 }
@@ -272,9 +275,10 @@ func (c *recordingCounter) Inc(_ context.Context) {
 func (c *recordingCounter) Add(_ context.Context, d float64) {
 	newVal := c.n.Add(int64(d))
 	c.vec.mu.Lock()
-	fn := c.vec.notify
+	fns := make([]func(kernelmetrics.Labels, int64), len(c.vec.notifiers))
+	copy(fns, c.vec.notifiers)
 	c.vec.mu.Unlock()
-	if fn != nil {
+	for _, fn := range fns {
 		fn(c.labels, newVal)
 	}
 }

--- a/kernel/reconcile/metrics_test.go
+++ b/kernel/reconcile/metrics_test.go
@@ -150,6 +150,46 @@ func (p *recordingProvider) counterValue(l kernelmetrics.Labels) int64 {
 	return v.value(l)
 }
 
+// signalWhenCounterReaches returns a channel that is closed once the
+// reconcile_total counter for the given labels reaches or exceeds threshold.
+// The channel is closed at most once (sync.Once). Callers MUST register this
+// before starting the loop (or before sending requests) so no increment is
+// missed. The returned channel is safe to pass to testwait.Deterministic.
+//
+// Thread safety: the notify callback is installed under vec.mu and is read
+// under vec.mu in Inc/Add, so there is no data race between registration and
+// concurrent counter increments.
+func (p *recordingProvider) signalWhenCounterReaches(l kernelmetrics.Labels, threshold int64) <-chan struct{} {
+	ch := make(chan struct{})
+	var once sync.Once
+	fire := func() { once.Do(func() { close(ch) }) }
+
+	// Install the notify callback on the reconcile_total counter vec.
+	// RegisterMetrics must be called before signalWhenCounterReaches so the vec
+	// already exists; callers that violate this ordering will get a clear panic.
+	p.mu.Lock()
+	vec, ok := p.counters[metricReconcileTotal]
+	p.mu.Unlock()
+	if !ok {
+		panic("signalWhenCounterReaches: RegisterMetrics must be called before registering a signal")
+	}
+
+	labelKey := labelsKeyR(l)
+	vec.mu.Lock()
+	vec.notify = func(labels kernelmetrics.Labels, newVal int64) {
+		if labelsKeyR(labels) == labelKey && newVal >= threshold {
+			fire()
+		}
+	}
+	// Check if threshold is already reached (race-free: vec.mu held).
+	if cur, exists := vec.obs[labelKey]; exists && cur.Load() >= threshold {
+		fire()
+	}
+	vec.mu.Unlock()
+
+	return ch
+}
+
 func (p *recordingProvider) histogramCount(name string, l kernelmetrics.Labels) int64 {
 	p.mu.Lock()
 	v, ok := p.histograms[name]
@@ -174,11 +214,22 @@ type recordingCounterVec struct {
 	labels []string
 	mu     sync.Mutex
 	obs    map[string]*atomic.Int64
+	// notify is an optional per-increment callback set by tests. It is called
+	// after every Inc/Add with the label set and the new counter value.
+	// The callback is invoked outside recordingCounterVec.mu to avoid inversion
+	// with any mutex the callback itself may acquire.
+	notify func(labels kernelmetrics.Labels, newVal int64)
 }
 
 func (v *recordingCounterVec) Registered() bool { return true }
 func (v *recordingCounterVec) With(l kernelmetrics.Labels) kernelmetrics.Counter {
 	kernelmetrics.MustValidateLabels(v.labels, l)
+	// Snapshot labels for the counter so the notify callback can reference them
+	// without holding v.mu.
+	labelsCopy := make(kernelmetrics.Labels, len(l))
+	for k, val := range l {
+		labelsCopy[k] = val
+	}
 	v.mu.Lock()
 	c, ok := v.obs[labelsKeyR(l)]
 	if !ok {
@@ -186,7 +237,9 @@ func (v *recordingCounterVec) With(l kernelmetrics.Labels) kernelmetrics.Counter
 		v.obs[labelsKeyR(l)] = c
 	}
 	v.mu.Unlock()
-	return &recordingCounter{n: c}
+	// Pass a pointer to the vec so Inc/Add always read the latest notify
+	// callback, even if it is installed after With is first called.
+	return &recordingCounter{n: c, labels: labelsCopy, vec: v}
 }
 
 func (v *recordingCounterVec) value(l kernelmetrics.Labels) int64 {
@@ -198,10 +251,33 @@ func (v *recordingCounterVec) value(l kernelmetrics.Labels) int64 {
 	return 0
 }
 
-type recordingCounter struct{ n *atomic.Int64 }
+type recordingCounter struct {
+	n      *atomic.Int64
+	labels kernelmetrics.Labels
+	// vec is a back-reference to the parent vec so Inc/Add always read the
+	// latest notify callback, even if it is installed after With is first called.
+	vec *recordingCounterVec
+}
 
-func (c *recordingCounter) Inc(context.Context)              { c.n.Add(1) }
-func (c *recordingCounter) Add(_ context.Context, d float64) { c.n.Add(int64(d)) }
+func (c *recordingCounter) Inc(_ context.Context) {
+	newVal := c.n.Add(1)
+	c.vec.mu.Lock()
+	fn := c.vec.notify
+	c.vec.mu.Unlock()
+	if fn != nil {
+		fn(c.labels, newVal)
+	}
+}
+
+func (c *recordingCounter) Add(_ context.Context, d float64) {
+	newVal := c.n.Add(int64(d))
+	c.vec.mu.Lock()
+	fn := c.vec.notify
+	c.vec.mu.Unlock()
+	if fn != nil {
+		fn(c.labels, newVal)
+	}
+}
 
 type recordingHistogramVec struct {
 	labels []string

--- a/runtime/audit/ledger/storetest/fuzz.go
+++ b/runtime/audit/ledger/storetest/fuzz.go
@@ -176,7 +176,7 @@ func seedEntryRoundTripCorpus(f *testing.F) {
 	tsNano := epochAnchor.UnixNano()
 	occNano := epochAnchor.Add(principalOccurredAtSkew).UnixNano()
 
-	add := func(eventID string, payload string) {
+	add := func(eventID, payload string) {
 		f.Add(
 			eventID, "audit.test", "actor-1", "subject-1", "session-1", "tenant-1", "corr-1",
 			occNano, tsNano, []byte(payload),

--- a/tools/archtest/kernel_internal_dag_test.go
+++ b/tools/archtest/kernel_internal_dag_test.go
@@ -102,7 +102,7 @@ var allowedKernelEdges = map[string][]string{
 	"observability": nil,
 	"outbox":        {"cellvocab", "clock", "fsm", "healthz", "idempotency", "metautil", "observability", "persistence"},
 	"persistence":   nil,
-	"projection":    {"cell", "cellvocab", "contractspec", "outbox", "persistence", "wrapper"},
+	"projection":    {"cell", "cellvocab", "clock", "contractspec", "healthz", "observability", "outbox", "persistence", "wrapper"},
 	"reconcile":     {"observability"},
 	"registry":      {"metadata"},
 	"saga":          {"clock", "fsm", "healthz"},

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -4003,16 +4003,15 @@ func scanConstructorNilGuards(p *Pass) []Diagnostic {
 			continue
 		}
 		rel := p.Rel(file)
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv != nil || fd.Body == nil {
-				continue
+		EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || fd.Body == nil {
+				return
 			}
 			if !strings.HasPrefix(fd.Name.Name, "New") {
-				continue
+				return
 			}
 			if fd.Type.Params == nil {
-				continue
+				return
 			}
 			// Collect interface parameters and their types.Object.
 			type ifaceParam struct {
@@ -4067,29 +4066,26 @@ func scanConstructorNilGuards(p *Pass) []Diagnostic {
 				}
 			}
 			if len(ifaces) == 0 {
-				continue
+				return
 			}
 			// For each interface param, check if a guard call referencing it exists
 			// in the body.
 			for _, ip := range ifaces {
-				guarded := false
-				EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
-					if guarded || !sagaIsGuardCall(p, call) {
-						return
+				_, guarded := FindFirstInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) bool {
+					if !sagaIsGuardCall(p, call) {
+						return false
 					}
 					// Check first argument is the parameter object. ast.Unparen
 					// strips redundant parens so IsNilInterface((dep)) is still
 					// recognized as a guard (closes the parenthesized-arg bypass).
 					if len(call.Args) == 0 {
-						return
+						return false
 					}
 					firstArg, ok2 := ast.Unparen(call.Args[0]).(*ast.Ident)
 					if !ok2 {
-						return
+						return false
 					}
-					if p.TypesInfo.ObjectOf(firstArg) == ip.obj {
-						guarded = true
-					}
+					return p.TypesInfo.ObjectOf(firstArg) == ip.obj
 				})
 				if !guarded {
 					out = append(out, sagaDiag(p, fd.Name, rel,
@@ -4099,7 +4095,7 @@ func scanConstructorNilGuards(p *Pass) []Diagnostic {
 							"add validation.IsNilInterface("+ip.name+") or clock.MustHaveClock("+ip.name+", ...)"))
 				}
 			}
-		}
+		})
 	}
 	return out
 }
@@ -4234,14 +4230,13 @@ func TestSagaConstructorNilGuard_BlindSpot_B2_NoParamReassignment(t *testing.T) 
 				continue
 			}
 			rel := p.Rel(file)
-			for _, decl := range file.Decls {
-				fd, ok := decl.(*ast.FuncDecl)
-				if !ok || fd.Body == nil || fd.Recv != nil || !strings.HasPrefix(fd.Name.Name, "New") {
-					continue
+			EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+				if fd.Body == nil || fd.Recv != nil || !strings.HasPrefix(fd.Name.Name, "New") {
+					return
 				}
 				paramObjs := sagaConstructorIfaceParamObjs(p, fd)
 				if len(paramObjs) == 0 {
-					continue
+					return
 				}
 				EachInSubtree[ast.AssignStmt](fd.Body, func(as *ast.AssignStmt) {
 					for _, rhs := range as.Rhs {
@@ -4257,7 +4252,7 @@ func TestSagaConstructorNilGuard_BlindSpot_B2_NoParamReassignment(t *testing.T) 
 						}
 					}
 				})
-			}
+			})
 		}
 		return out
 	})

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -332,13 +332,13 @@ func classifyExpr(expr ast.Expr) compensateFuncAssignment {
 	return compensateFuncAssignment{}
 }
 
-// sagaFuncDeclsByName collects all top-level FuncDecls in the Pass (across
+// sagaFuncDeclsByObject collects all top-level FuncDecls in the Pass (across
 // all files) keyed by the types.Func pointer (via info.ObjectOf). This is
 // used to resolve named CompensateFunc assignments to their declaration bodies.
 func sagaFuncDeclsByObject(p *Pass) map[*types.Func]*ast.FuncDecl {
 	out := make(map[*types.Func]*ast.FuncDecl)
 	for _, f := range p.Files {
-		scanner.EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+		EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
 			if fd.Body == nil {
 				return
 			}


### PR DESCRIPTION
## Summary

一个 PR 修四类 CI/质量卫生问题（互相独立、均不改业务行为）：

1. **develop CI 红修复**（rabbitmq Close 计时 flake）—— 让 develop 转绿
2. **#1354** reconcile flake —— 彻底去 wall-clock
3. **SonarCloud** 18 项真实 code smell 清理 + 4 项误报标 won't-fix
4. **5 个 pre-existing archtest 失败**一并清除（让全量 `go test ./...` 0 FAIL）

> **#1356（MQTT `$dead` 无损）本 PR 不处理**：它要推翻已 Accepted 的 ADR-050（fail-closed-and-drop，对标 Kafka Connect KIP-298），属行为重设计 + ADR amendment，方向未定。issue 保持 OPEN，留作独立 PR。

Closes #1354
Closes #1362

---

## 1. develop CI 红修复（与 #1354 是两个不同的 flake）

CI job `full-ci / integration-test (adapters)`（run 26692210635 / job 78670531557）偶发红，根因日志原文：

```
--- FAIL: TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg (0.15s)
    subscriber_close_ctx_test.go:438:
        Error: "97.229717ms" is not greater than or equal to "100ms"
        Messages: Close with Background ctx must have actually waited for handler; got 97.229717ms
```

病根是**墙钟下界断言** `assert.GreaterOrEqual(elapsed, SlowPoll=100ms)`：CI 调度抖动使实测 97.2ms < 100ms。

**修复（彻底去墙钟）**：`adapters/rabbitmq/subscriber_close_ctx_test.go` —— handler 改为阻塞在 `release` channel（替代固定 `Sleep(150ms)`），用 `testwait.Deterministic` 确定性等待 Close 返回；`close(release)` 前用非阻塞 select 证明 Close 仍在等待 in-flight handler。删除 `elapsed`/`SlowPoll` 墙钟下界断言。`-race -count=50` 全绿。

> 触发该 CI run 的 W10 PR-03（projection rebuild）merge 改动 0 个 `adapters/` 文件 —— 此 flake 是 develop 上 pre-existing，非回归。

## 2. #1354 — reconcile flake 彻底去 wall-clock

`kernel/reconcile/loop_test.go::TestLoop_SameEntityIDSerial` 的 `testwait.External(..., D500ms, ...)` 收敛窗口在 `-race` 下太紧 → 偶发 `t.Fatalf`。

**修复（Deterministic，零 production 改动，正是 #1354 作者建议）**：给测试自有替身 `recordingProvider` 加测试侧 counter 回调 + `signalWhenCounterReaches` helper，skip 计数达 3 时 close channel，用 `testwait.Deterministic` 取代轮询。`-race -count=200` 全绿。

**sweep 一致性裁决**（loop_test.go 10 处 `testwait.External` 逐处判断）：7 处迁移到 Deterministic（计数类单调信号，经测试替身 channel）；3 处保留 External 但 `D500ms`→`EventuallyDefault(3s)`（`leader-reset` ×2 / `two-concurrent-reconciles` 读 gauge/瞬时并发峰值，无单调完成语义，不可发 channel）。依据 `pkg/testutil/testwait` 包 doc：「Deterministic 为 default choice；External only as carve-out」。

## 3. SonarCloud 清理

### Fixed（18 项 / 11 文件）

| 规则 | 文件 | 处理 |
|------|------|------|
| S1192 | `kernel/projection/metrics.go` | `"projection: register %s: %w"` 3× → 包级 const |
| S1192 | `adapters/mqtt/metrics.go` | `"Label: cell = ..."` 3× → 包级 const（含完整后缀，4 metric 描述字节一致） |
| S107 (8参) | `kernel/projection/rebuild_test.go` | `newCoordinatorFull` 参数聚合为 opts struct（含 `probe_test.go` 同包调用点同步） |
| S8209 | `runtime/audit/ledger/storetest/fuzz.go` | `func(eventID string, payload string)` → `func(eventID, payload string)` |
| S8196 | `adapters/mqtt/subscriber_dispatchack_test.go` | 接口 `fatalfT` → 标准库 `testing.TB`（review 进一步简化） |
| S3776 ×14 | `kernel/projection/{rebuild_test,coordinator_test}.go`、`kernel/governance/rules_saga_test.go`（9处）、`adapters/mqtt/integration_test.go` | 抽具名 helper 降认知复杂度 ≤15，断言语义不变 |

### won't-fix（4 项，误报 / 框架约束，不改代码）

| 规则 | 位置 | 理由（reviewer 已独立复核成立） |
|------|------|------|
| S8239 | `kernel/projection/rebuild.go:44` | `context.Background()` 是**刻意 detached**——rebuild goroutine 只由 `Close` 取消（rebuild.go godoc 明载）。用 ctx 参数会让 rebuild 在 HTTP 请求返回时被取消，破坏功能。 |
| S8188 | `kernel/projection/rebuild.go:44` | `cancel` 存入 `c.rebuildCancel` 由 `Close` 调用，非 leak；defer 会立即取消，破坏功能。 |
| S107 (11参) | `runtime/audit/ledger/storetest/fuzz.go:63` | Go fuzzing 强制 `f.Fuzz` 回调用扁平 scalar 形参，不可包装 struct——框架约束。 |
| S125 | `adapters/postgres/migrations/044_*.sql:7` | 该行是 runbook 文档示例查询，非死代码；migration 已提交，「只增不改」禁改。 |

## 4. 5 个 pre-existing archtest 失败（本 PR 一并清除，让 CI 全绿）

`go test ./...` 全量曾跑出 5 个 `tools/archtest` 失败（已实测验证为 develop pre-existing）。本 PR 目标是让 develop CI 转绿，archtest 失败也是 CI 红的一部分 → **一并修复**：

| archtest | 修复 |
|----------|------|
| TestKernelInternalDAG | `tools/archtest/kernel_internal_dag_test.go`：`allowedKernelEdges["projection"]` 补入 `clock`/`healthz`/`observability`（projection 是 W10 consumer-layer kernel，这三个均 leaf 依赖，无环）|
| TestErrcodeMessageConstLiteral | `adapters/mqtt/metrics.go`：消除 `registerCounter` 闭包对 `errcode.Wrap` 的封装（message 经 `wrapCtx` 变量中转违反 const-literal），展开为各调用点直接 const literal，行为等价 |
| TestScannerFrameworkUsage01 | `tools/archtest/saga_invariants_test.go`：`for range file.Decls + type assertion` ×2 → `EachInChildren[ast.FuncDecl]` |
| TestScannerFrameworkUsage02 | `saga_invariants_test.go`：`closure + guarded sentinel` → `FindFirstInSubtree[ast.CallExpr]`（typed find-first funnel） |
| TestFixtureCellIDTypedBuilder | `kernel/governance/rules_saga_test.go`：7 处 `"orchestratorcell"`/`"unknowncell"` 裸字面量 → `metadatatest.NewCellID(...)` |

**验证**：`go test ./tools/archtest/` 完全 PASS（455s）；`go test ./...` 全量 **0 FAIL**。被重构的 archtest 规则（SAGA-CONSTRUCTOR-NIL-GUARD-01 等）行为不变（对应测试仍 PASS）。

---

## Review 修复（3 reviewer 六维度，已处理）

Cx1/Cx2 findings 已合入：
- **F1**（安全/运维，3 reviewer 共识）：`helpCellLabel` const 之前截断 Help 文本 → 已补全为完整版并让 `mqtt_publish_total` 复用，4 个 metric 描述字节一致。
- **F2**（测试）：`recordingCounterVec.notify` 单槽覆盖 → 改 `[]func` 累积。
- **F3**（DX）：`fataler` 接口 → 标准库 `testing.TB`。
- **F5/F6/F7**：两处 External reason 语义分离 / 去注释 linter ID / `assertSagaFinding` 在 `wantErrCount>1` 时验证所有 finding。

**OUT_OF_SCOPE（人工确认）**：`projRecordingProvider`（kernel/projection）与 `recordingProvider`（kernel/reconcile）双份克隆（Cx2 DX）——跨包提取公共 test spy，独立重构，未在本 PR 处理。

---

## Test plan

- [x] `go build ./...` 通过
- [x] `go test ./...` 完整跑通，**0 FAIL**（含 `tools/archtest` 全量 PASS）
- [x] `golangci-lint run ./...` 0 issues
- [x] `go test -race -count=50 -run TestSubscriber_Close_NoDeadlineCtx_WaitsUntilWg ./adapters/rabbitmq/` 全绿
- [x] `go test -race -count=200 -run TestLoop_SameEntityIDSerial ./kernel/reconcile/` 全绿
- [x] `kernel/reconcile/loop.go`（production）零改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)
