### PR TITLE
feat(iotdevice): MQTT 发布演示路径 — 单通道 DI swap [V11-4 PR-5]

### DIFF
--- a/examples/iotdevice/docs/mqtt.md
+++ b/examples/iotdevice/docs/mqtt.md
@@ -43,7 +43,8 @@ envelope）原样透传。
 
 ```bash
 # 1. 启动 MQTT broker（先于 demo）
-docker run --rm -p 1883:1883 eclipse-mosquitto:2.0 \
+# 仅绑 127.0.0.1：无认证 broker 不可暴露到宿主机外部网卡，本命令仅供本机 demo。
+docker run --rm -p 127.0.0.1:1883:1883 eclipse-mosquitto:2.0 \
   mosquitto -c /mosquitto-no-auth.conf
 
 # 2. 另开终端：订阅 device-registered 主题（外部观测者）

--- a/examples/iotdevice/docs/mqtt.md
+++ b/examples/iotdevice/docs/mqtt.md
@@ -32,7 +32,12 @@ envelope）原样透传。
 
 **fail-fast，无 noop 回退**：通道开启后，配置/解析/连接错误会让启动失败并报错
 （不静默降级到 noop publisher）。`Open` 会阻塞直到 broker 可达——**先启动 broker
-再跑 demo**。仅"未设环境变量"是合法的关闭方式。
+再跑 demo**（broker 未就绪时 `go run` 会停在连接重试，Ctrl-C 可中断）。仅"未设环境
+变量"是合法的关闭方式。
+
+**认证**：当前 demo 仅连接**无认证** broker（示例用 `mosquitto-no-auth.conf`）。未提供
+用户名/密码环境变量；连接有认证的 broker 需扩展 `buildMQTTDirectPublisher` 注入
+`mqtt.Config.Auth`（out-of-scope for this demo）。
 
 ## 跑通命令
 

--- a/examples/iotdevice/docs/mqtt.md
+++ b/examples/iotdevice/docs/mqtt.md
@@ -1,0 +1,79 @@
+# iotdevice MQTT 发布演示路径
+
+本文档说明 iotdevice 的可选 MQTT 发布通道：把 `device-registered` 事件外发到真实
+MQTT v5 broker（`adapters/mqtt`），用于端到端演示该 adapter。设备 HTTP/WS 主路径
+（注册 API、命令轮询）不受影响。
+
+## 设计：单通道 DI swap
+
+iotdevice 是 L4 DeviceLatent，默认用进程内 `eventbus` 发布 `device-registered`
+事件——该事件在进程内**没有订阅者**（contract 的 `actorSubscribers: [example-iot-platform]`
+是外部 actor 占位），所以默认通道对它是一个演示用空 sink。
+
+当设置环境变量 `GOCELL_IOTDEVICE_MQTT_BROKERS` 时，组合根（`run.go`）把 cell 的
+direct publisher **切换**为 MQTT publisher——事件改发往 broker，可用 `mosquitto_sub`
+观测。这是**单通道切换**，不是并行镜像：没有第二个进程内 sink 需要镜像。
+
+> 对标：Watermill / go-micro / Kratos 演示某 transport 的惯用法是切换/配置 Publisher
+> 实现（DI），而非 fan-out。fan-out/tee 是真·多 sink 或迁移双写专用。
+> ref: `ThreeDotsLabs/watermill` `message/decorator.go`（transform decorator）。
+
+事件类型是点号形式 `event.device-registered.v1`；MQTT topic 是斜杠分层 + namespace
+前缀。`mqttTopicPublisher` 把它映射为 `<ns>/event/device-registered/v1`（默认 ns =
+`iotdevice` → `iotdevice/event/device-registered/v1`），payload（序列化后的 outbox
+envelope）原样透传。
+
+## 环境变量
+
+| 变量 | 说明 | 默认 |
+|------|------|------|
+| `GOCELL_IOTDEVICE_MQTT_BROKERS` | 逗号分隔的 broker URL（如 `tcp://127.0.0.1:1883`）。**未设 = 通道关闭**，行为与今天逐字节一致 | 未设 |
+| `GOCELL_IOTDEVICE_MQTT_TOPIC_NS` | topic namespace 前缀 | `iotdevice` |
+
+**fail-fast，无 noop 回退**：通道开启后，配置/解析/连接错误会让启动失败并报错
+（不静默降级到 noop publisher）。`Open` 会阻塞直到 broker 可达——**先启动 broker
+再跑 demo**。仅"未设环境变量"是合法的关闭方式。
+
+## 跑通命令
+
+```bash
+# 1. 启动 MQTT broker（先于 demo）
+docker run --rm -p 1883:1883 eclipse-mosquitto:2.0 \
+  mosquitto -c /mosquitto-no-auth.conf
+
+# 2. 另开终端：订阅 device-registered 主题（外部观测者）
+mosquitto_sub -h 127.0.0.1 -p 1883 -t 'iotdevice/#' -v
+
+# 3. 启动 iotdevice，开启 MQTT 通道（in-memory 持久化 + MQTT 事件）
+GOCELL_IOTDEVICE_MQTT_BROKERS=tcp://127.0.0.1:1883 \
+  go run ./examples/iotdevice
+
+# 4. 再开终端：注册一个设备（需要 RS256 bearer token，见 README.md）
+curl -sS -X POST http://127.0.0.1:8083/api/v1/devices \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"sensor-1"}'
+```
+
+步骤 2 的 `mosquitto_sub` 会打印一条 `iotdevice/event/device-registered/v1` 消息，
+body 是 outbox envelope（含 `eventId` 与 `payload`，payload 内 `name=sensor-1`、
+`status=online`）。
+
+## 可观测性
+
+- `/readyz`（HealthListener，默认 `127.0.0.1:9093`）开启 MQTT 通道时包含
+  `mqtt_ready` 探针，反映 broker 可达性（broker 断开 → 探针非 nil → readyz 降级）。
+- 连接由框架 LIFO shutdown 关闭（`bootstrap.WithManagedCloser`）。
+
+## broker 不可用时
+
+L4 emitter 使用 `DirectPublishFailOpen`：注册请求本身**不因发布失败而失败**（设备已
+持久化，事件丢失是运维跟进项，非请求失败）。运行期 broker 断开时 register 仍返回
+201，`mqtt_ready` 转为不健康，事件不外发。
+
+## 测试
+
+- `examples/iotdevice/mqtt_test.go`：topic 映射单测。
+- `examples/iotdevice/mqtt_smoke_test.go`：端到端 smoke（in-process mochi broker，
+  真实 register → DirectEmitter → topic mapper → `mqtt.Publisher` → `mqtt.Subscriber`
+  → 校验 payload），在普通 `go test ./examples/iotdevice/` 与 PR CI 中运行。

--- a/examples/iotdevice/generated/metrics-schema.yaml
+++ b/examples/iotdevice/generated/metrics-schema.yaml
@@ -179,6 +179,97 @@ metrics:
         - status
         - cell
       file: runtime/bootstrap/phases_http.go
+    - name: mqtt_consume_duration_seconds
+      type: histogram
+      help: 'End-to-end MQTT consume duration in seconds, from handler invocation to Settlement Commit. Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+      buckets:
+        - "0.001"
+        - "0.005"
+        - "0.01"
+        - "0.025"
+        - "0.05"
+        - "0.1"
+        - "0.25"
+        - "0.5"
+        - "1"
+        - "2.5"
+        - "5"
+        - "10"
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_consume_failed_total
+      type: counter
+      help: 'Total number of MQTT messages that did not result in a successful Ack, classified by reason. reason ∈ {unmarshal, reject, requeue, commit_failed, ack_failed, unknown_disposition} — closed set; alerting rules can rely on the literals. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+        - reason
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_consume_total
+      type: counter
+      help: 'Total number of MQTT messages consumed successfully (handler Ack + Settlement Commit). Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_dlx_failed_total
+      type: counter
+      help: 'Total number of messages whose dead-letter publish to $dead/<topic> FAILED (topic unmintable or broker publish error); the message was acked-as-poison WITHOUT $dead capture. A distinct, higher-severity signal from mqtt_consume_failed_total: it means the dead-letter sink itself is unhealthy. reason ∈ {unmarshal, reject} — closed set. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+        - reason
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_dlx_total
+      type: counter
+      help: 'Total number of messages routed to the app-level dead-letter sink $dead/<topic>. reason ∈ {unmarshal, reject} — closed set (poison / permanent failure). Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+        - reason
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_publish_ack_duration_seconds
+      type: histogram
+      help: 'End-to-end MQTT publish ack round-trip duration in seconds, from Publish() call to broker PUBACK. Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+      buckets:
+        - "0.001"
+        - "0.005"
+        - "0.01"
+        - "0.025"
+        - "0.05"
+        - "0.1"
+        - "0.25"
+        - "0.5"
+        - "1"
+        - "2.5"
+        - "5"
+        - "10"
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_publish_failed_total
+      type: counter
+      help: 'Total number of MQTT publish attempts that failed, classified by reason. reason ∈ {payload_too_large, closed, puback_timeout, context_canceled, publish_error, topic_outside_namespace, rate_limited, not_authorized, payload_format_invalid, rejected} — closed set; alerting rules can rely on the literals. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+        - reason
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_publish_total
+      type: counter
+      help: 'Total number of MQTT publish attempts that completed successfully (broker PUBACK received). Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_reconnect_total
+      type: counter
+      help: 'Total MQTT reconnect events observed by the adapter. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+      file: adapters/mqtt/metrics.go
+    - name: mqtt_subscribe_failed_total
+      type: counter
+      help: 'Total number of receive-path SUBSCRIBE failures (initial SUBACK rejection or reconnect re-arm), classified by reason. reason ∈ {suback_reject, transport} — closed set; alerting rules can rely on the literals. Label: cell = construction-time cell identifier (registration-time enumerated, not from request ctx).'
+      labels:
+        - cell
+        - reason
+      file: adapters/mqtt/metrics.go
     - name: outbox_consumer_rejected_total
       type: counter
       help: Total number of terminal Reject dispositions from outbox ConsumerBase. consumerGroup is not included as a label to bound time-series cardinality.

--- a/examples/iotdevice/mqtt.go
+++ b/examples/iotdevice/mqtt.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/ghbvf/gocell/adapters/mqtt"
 	"github.com/ghbvf/gocell/kernel/clock"
+	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
 // Environment variables controlling the MQTT publish demo channel.
@@ -150,6 +152,45 @@ func buildMQTTDirectPublisher(
 		return nil, nil, false, fmt.Errorf("mqtt publisher: %w", err)
 	}
 	return &mqttTopicPublisher{inner: pub, ns: ns}, conn, true, nil
+}
+
+// mqttChannelWiring is the bootstrap lifecycle wiring derived from an enabled
+// MQTT publish channel. It carries the two resources that MUST BOTH participate
+// in graceful shutdown:
+//
+//   - Resource: the *mqtt.Connection (lifecycle.ManagedResource). Registered via
+//     WithManagedResource — it wires the mqtt_ready readiness probe + LIFO
+//     disconnect, the standard adapter path (postgres/rabbitmq/redis).
+//   - Closer: the publisher (lifecycle.ContextCloser). Publisher.Close drains
+//     in-flight publishes; Connection.Close only disconnects (no drain), so the
+//     publisher closer is mandatory, not redundant — omitting it silently drops
+//     in-flight publishes on shutdown (PR #1364 review F1).
+//
+// Ordering is correctness, not cosmetic: bootstrap appends WithManagedResource
+// teardowns first (they run LAST under LIFO) and WithManagedCloser teardowns
+// later (they run earlier), so the publisher drains BEFORE the connection
+// disconnects. See runtime/bootstrap LIFO teardown.
+type mqttChannelWiring struct {
+	Resource kernellifecycle.ManagedResource
+	Closer   kernellifecycle.ContextCloser
+}
+
+// mqttChannelWiringFor pairs the enabled channel's publisher and connection into
+// the lifecycle wiring. outbox.Publisher already requires Close(ctx) error, so
+// the publisher always satisfies lifecycle.ContextCloser by interface.
+func mqttChannelWiringFor(pub outbox.Publisher, conn *mqtt.Connection) mqttChannelWiring {
+	return mqttChannelWiring{Resource: conn, Closer: pub}
+}
+
+// bootstrapOptions renders the wiring into bootstrap options. It always yields
+// exactly two — the managed resource (connection) and the managed closer
+// (publisher drain). Dropping either regresses shutdown drain/teardown; the
+// count is locked by TestMQTTChannelWiring_RegistersPublisherDrainAndConnection.
+func (w mqttChannelWiring) bootstrapOptions() []bootstrap.Option {
+	return []bootstrap.Option{
+		bootstrap.WithManagedResource(w.Resource),
+		bootstrap.WithManagedCloser(w.Closer),
+	}
 }
 
 // redactedBrokers returns broker URLs with any userinfo password masked, safe

--- a/examples/iotdevice/mqtt.go
+++ b/examples/iotdevice/mqtt.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -108,6 +109,11 @@ func buildMQTTDirectPublisher(
 		return nil, nil, false, fmt.Errorf("mqtt topic namespace %q: %w", nsStr, err)
 	}
 
+	// The clientID's cellID segment is the cell identity ("iotdevice"), NOT the
+	// configurable topic namespace: the two have different validation rules
+	// (clientID cellID forbids "/" and is ≤32 chars; a topic namespace allows
+	// "/" and is ≤128), and clientID only needs to be globally unique (the uuid
+	// suffix guarantees that). It is deliberately independent of nsStr.
 	clientID, err := mqtt.ParseEphemeralClientID(defaultMQTTTopicNS, "publisher")
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("mqtt client id: %w", err)
@@ -129,17 +135,37 @@ func buildMQTTDirectPublisher(
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("mqtt connect: %w", err)
 	}
+	// Redact any userinfo (e.g. tcp://user:pass@host) before logging broker URLs.
 	logger.Info("iotdevice: MQTT publish channel connected",
-		slog.Any("brokers", brokers), slog.String("topicNamespace", ns.String()))
+		slog.Any("brokers", redactedBrokers(brokers)), slog.String("topicNamespace", ns.String()))
 
 	pub, err := mqtt.NewPublisher(clk, conn, ns)
 	if err != nil {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = conn.Close(closeCtx)
+		if cerr := conn.Close(closeCtx); cerr != nil {
+			logger.Warn("iotdevice: mqtt connection close after publisher-init failure",
+				slog.Any("error", cerr))
+		}
 		return nil, nil, false, fmt.Errorf("mqtt publisher: %w", err)
 	}
 	return &mqttTopicPublisher{inner: pub, ns: ns}, conn, true, nil
+}
+
+// redactedBrokers returns broker URLs with any userinfo password masked, safe
+// for structured logging. Unparseable entries fall back to a placeholder rather
+// than risk leaking embedded credentials. ref: net/url.URL.Redacted().
+func redactedBrokers(brokers []string) []string {
+	out := make([]string, 0, len(brokers))
+	for _, b := range brokers {
+		u, err := url.Parse(b)
+		if err != nil {
+			out = append(out, "<unparseable-broker-url>")
+			continue
+		}
+		out = append(out, u.Redacted())
+	}
+	return out
 }
 
 // splitBrokers parses a comma-separated broker list, trimming whitespace and

--- a/examples/iotdevice/mqtt.go
+++ b/examples/iotdevice/mqtt.go
@@ -1,0 +1,156 @@
+// mqtt.go wires the optional MQTT publish demo channel for iotdevice. When
+// GOCELL_IOTDEVICE_MQTT_BROKERS is set, the device-register event channel is
+// swapped from the in-memory event bus to a real MQTT v5 broker (adapters/mqtt)
+// so the demo can be observed end-to-end with `mosquitto_sub`. The HTTP/WS main
+// path (register API, command polling) is unchanged. See examples/iotdevice/docs/mqtt.md.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ghbvf/gocell/adapters/mqtt"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// Environment variables controlling the MQTT publish demo channel.
+const (
+	// envMQTTBrokers is a comma-separated list of broker URLs (e.g.
+	// "tcp://127.0.0.1:1883"). Unset = the channel is disabled and iotdevice
+	// keeps its in-memory event bus (today's default behavior, byte-for-byte).
+	envMQTTBrokers = "GOCELL_IOTDEVICE_MQTT_BROKERS"
+	// envMQTTTopicNS overrides the topic namespace prefix; defaults to "iotdevice".
+	envMQTTTopicNS     = "GOCELL_IOTDEVICE_MQTT_TOPIC_NS"
+	defaultMQTTTopicNS = "iotdevice"
+)
+
+// mqttTopicPublisher adapts an mqtt.Publisher to iotdevice's event-type naming.
+// GoCell event types are dotted ("event.device-registered.v1"); MQTT topics are
+// slash-separated and namespace-scoped. It maps the dotted event type to a
+// namespaced slash topic before delegating, leaving the payload (the serialized
+// outbox envelope) untouched.
+//
+// Single-backend transform decorator — ref: ThreeDotsLabs/watermill
+// message/decorator.go messageTransformPublisherDecorator (embed Publisher +
+// transform, delegate). No fan-out: the demo swaps the cell's direct publisher
+// to MQTT rather than mirroring to a second sink (device-registered has no
+// in-process subscriber, so there is no second sink to mirror).
+type mqttTopicPublisher struct {
+	inner outbox.Publisher
+	ns    mqtt.TopicNamespace
+}
+
+var _ outbox.Publisher = (*mqttTopicPublisher)(nil)
+
+// mqttEventTopic maps a dotted GoCell event type to a namespaced MQTT topic:
+// dots become slashes and the namespace prefix is prepended, e.g.
+// ("iotdevice", "event.device-registered.v1") -> "iotdevice/event/device-registered/v1".
+// The result is always under ns, so mqtt.Publisher.Publish → ns.Mint accepts it
+// (asserted by TestMQTTEventTopic).
+func mqttEventTopic(ns mqtt.TopicNamespace, eventType string) string {
+	return ns.String() + "/" + strings.ReplaceAll(eventType, ".", "/")
+}
+
+// Publish maps the event-type topic to the namespaced MQTT topic and delegates.
+func (p *mqttTopicPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
+	return p.inner.Publish(ctx, mqttEventTopic(p.ns, topic), payload)
+}
+
+// Close forwards to the inner MQTT publisher (drains in-flight publishes). The
+// underlying Connection is closed separately via bootstrap.WithManagedCloser.
+func (p *mqttTopicPublisher) Close(ctx context.Context) error {
+	return p.inner.Close(ctx)
+}
+
+// buildMQTTDirectPublisher constructs the MQTT publish channel from the
+// environment. When GOCELL_IOTDEVICE_MQTT_BROKERS is unset it returns
+// (nil, nil, false, nil) — the demo keeps its in-memory event bus unchanged.
+//
+// When set, it opens an MQTT connection (Open blocks until the broker is
+// reachable — start the broker before running the demo) and returns the
+// topic-mapping publisher plus the connection (for the mqtt_ready readiness
+// probe and shutdown close). Any config/parse/connect error is returned
+// (fail-fast); there is intentionally no silent noop fallback
+// (go-standards.md "生产配置使用真实 adapter，非 noop 回退"). Only the unset
+// env var disables the channel.
+//
+// ctx is the app lifecycle context — autopaho binds the ConnectionManager to it,
+// so the connection lives for the app's lifetime and is torn down on shutdown
+// (in addition to the explicit bootstrap.WithManagedCloser close).
+//
+// ref: ThreeDotsLabs/watermill message/decorator.go (transform decorator).
+func buildMQTTDirectPublisher(
+	ctx context.Context, clk clock.Clock, logger *slog.Logger,
+) (outbox.Publisher, *mqtt.Connection, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(envMQTTBrokers))
+	if raw == "" {
+		// Channel disabled: the bool (ok=false) is the discriminant, mirroring
+		// buildDevicePersistence's demo-mode nil pool signal.
+		//nolint:nilnil // ok=false is the disabled-channel discriminant; see godoc
+		return nil, nil, false, nil
+	}
+	brokers := splitBrokers(raw)
+	if len(brokers) == 0 {
+		return nil, nil, false, fmt.Errorf("%s is set but contains no broker URLs", envMQTTBrokers)
+	}
+
+	nsStr := strings.TrimSpace(os.Getenv(envMQTTTopicNS))
+	if nsStr == "" {
+		nsStr = defaultMQTTTopicNS
+	}
+	ns, err := mqtt.ParseTopicNamespace(nsStr)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("mqtt topic namespace %q: %w", nsStr, err)
+	}
+
+	clientID, err := mqtt.ParseEphemeralClientID(defaultMQTTTopicNS, "publisher")
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("mqtt client id: %w", err)
+	}
+
+	cfg := mqtt.Config{
+		ClientID:       clientID,
+		Brokers:        brokers,
+		ConnectTimeout: 10 * time.Second,
+		KeepAlive:      30 * time.Second,
+		PublishTimeout: 5 * time.Second,
+		Backoff: mqtt.BackoffConfig{
+			BaseDelay: 500 * time.Millisecond,
+			MaxDelay:  30 * time.Second,
+		},
+	}
+
+	conn, err := mqtt.Open(ctx, clk, cfg)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("mqtt connect: %w", err)
+	}
+	logger.Info("iotdevice: MQTT publish channel connected",
+		slog.Any("brokers", brokers), slog.String("topicNamespace", ns.String()))
+
+	pub, err := mqtt.NewPublisher(clk, conn, ns)
+	if err != nil {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = conn.Close(closeCtx)
+		return nil, nil, false, fmt.Errorf("mqtt publisher: %w", err)
+	}
+	return &mqttTopicPublisher{inner: pub, ns: ns}, conn, true, nil
+}
+
+// splitBrokers parses a comma-separated broker list, trimming whitespace and
+// dropping empty entries.
+func splitBrokers(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/examples/iotdevice/mqtt_smoke_test.go
+++ b/examples/iotdevice/mqtt_smoke_test.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net"
 	"testing"
-	"time"
 
 	mqttserver "github.com/mochi-mqtt/server/v2"
 	mqttallow "github.com/mochi-mqtt/server/v2/hooks/auth"
@@ -206,11 +205,11 @@ func TestMQTTSmoke_DeviceRegisterPublishesToBroker(t *testing.T) {
 				return outbox.Ack(), noopSettlement{}
 			})
 	}()
-	select {
-	case <-sub.Ready(subscription):
-	case <-time.After(testtime.D10s):
-		t.Fatal("subscriber not ready before deadline")
-	}
+	// Deterministic channel waits — no caller-supplied wall-clock budget (issue
+	// #1320): sub.Ready() closes when SUBACK confirms, received carries the
+	// delivered entry. testwait.Deterministic blocks on the signal with only an
+	// internal hung-test safety net.
+	testwait.Deterministic(t, sub.Ready(subscription), "smoke-mqtt-subscriber-ready")
 
 	// Drive the real register flow.
 	const deviceName = "smoke-sensor"
@@ -219,29 +218,25 @@ func TestMQTTSmoke_DeviceRegisterPublishesToBroker(t *testing.T) {
 	}
 
 	// Verify the MQTT side received the envelope with the matching payload.
-	select {
-	case entry := <-received:
-		if got := entry.EventType(); got != deviceregister.TopicDeviceRegistered {
-			t.Fatalf("entry EventType = %q, want %q", got, deviceregister.TopicDeviceRegistered)
-		}
-		var ev struct {
-			ID     string `json:"id"`
-			Name   string `json:"name"`
-			Status string `json:"status"`
-		}
-		if err := json.Unmarshal(entry.Payload(), &ev); err != nil {
-			t.Fatalf("unmarshal payload %q: %v", entry.Payload(), err)
-		}
-		if ev.Name != deviceName {
-			t.Fatalf("payload name = %q, want %q", ev.Name, deviceName)
-		}
-		if ev.Status != "online" {
-			t.Fatalf("payload status = %q, want %q", ev.Status, "online")
-		}
-		if ev.ID == "" {
-			t.Fatal("payload id is empty")
-		}
-	case <-time.After(testtime.D10s):
-		t.Fatal("did not receive device-registered event on MQTT broker before deadline")
+	entry := testwait.Deterministic(t, received, "smoke-mqtt-device-registered")
+	if got := entry.EventType(); got != deviceregister.TopicDeviceRegistered {
+		t.Fatalf("entry EventType = %q, want %q", got, deviceregister.TopicDeviceRegistered)
+	}
+	var ev struct {
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(entry.Payload(), &ev); err != nil {
+		t.Fatalf("unmarshal payload %q: %v", entry.Payload(), err)
+	}
+	if ev.Name != deviceName {
+		t.Fatalf("payload name = %q, want %q", ev.Name, deviceName)
+	}
+	if ev.Status != "online" {
+		t.Fatalf("payload status = %q, want %q", ev.Status, "online")
+	}
+	if ev.ID == "" {
+		t.Fatal("payload id is empty")
 	}
 }

--- a/examples/iotdevice/mqtt_smoke_test.go
+++ b/examples/iotdevice/mqtt_smoke_test.go
@@ -109,6 +109,38 @@ func openSmokeConn(t *testing.T, clk clock.Clock, addr, role string) *mqtt.Conne
 	return conn
 }
 
+// TestBuildMQTTDirectPublisher_ConnectedHappyPath covers the env-driven
+// connected path of buildMQTTDirectPublisher (the function run.go calls):
+// against a live in-process broker it returns ok=true with a usable publisher
+// and connection. The early-return error paths are covered (without a broker)
+// by TestBuildMQTTDirectPublisher_EarlyReturns in mqtt_test.go.
+func TestBuildMQTTDirectPublisher_ConnectedHappyPath(t *testing.T) {
+	addr := startSmokeBroker(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	t.Setenv(envMQTTBrokers, fmt.Sprintf("tcp://%s", addr))
+
+	// autopaho binds the ConnectionManager to this ctx; scope it to the test.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pub, conn, ok, err := buildMQTTDirectPublisher(ctx, clock.Real(), logger)
+	if err != nil {
+		t.Fatalf("buildMQTTDirectPublisher: %v", err)
+	}
+	if !ok || pub == nil || conn == nil {
+		t.Fatalf("connected path = (ok=%v, pub=%v, conn=%v), want (true, non-nil, non-nil)", ok, pub, conn)
+	}
+	t.Cleanup(func() {
+		closeCtx, cn := context.WithTimeout(context.Background(), testtime.D5s)
+		defer cn()
+		_ = pub.Close(closeCtx)
+		_ = conn.Close(closeCtx)
+	})
+	if err := conn.Health(context.Background()); err != nil {
+		t.Fatalf("connection unhealthy after connect: %v", err)
+	}
+}
+
 // TestMQTTSmoke_DeviceRegisterPublishesToBroker is the end-to-end demo smoke:
 // it drives the real device-register service through a DirectCellEmitter wired
 // to the MQTT topic-mapping publisher, then verifies an independent MQTT
@@ -152,6 +184,8 @@ func TestMQTTSmoke_DeviceRegisterPublishesToBroker(t *testing.T) {
 		t.Fatalf("NewSubscriber: %v", err)
 	}
 	subscription := outbox.Subscription{
+		// The trailing "+" single-level wildcard matches any version suffix,
+		// e.g. the "v1" produced by mqttEventTopic for event.device-registered.v1.
 		Topic:             smokeNamespace + "/event/device-registered/+",
 		ConsumerGroup:     "smoke-verifier",
 		CellID:            smokeNamespace,

--- a/examples/iotdevice/mqtt_smoke_test.go
+++ b/examples/iotdevice/mqtt_smoke_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	mqttserver "github.com/mochi-mqtt/server/v2"
+	mqttallow "github.com/mochi-mqtt/server/v2/hooks/auth"
+	"github.com/mochi-mqtt/server/v2/listeners"
+
+	"github.com/ghbvf/gocell/adapters/mqtt"
+	devicemem "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/mem"
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/slices/deviceregister"
+	registercontract "github.com/ghbvf/gocell/generated/contracts/http/device/register/v1"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
+)
+
+// smokeNamespace is the MQTT topic namespace the demo publishes under; it must
+// match the namespace wired in mqtt.go (buildMQTTDirectPublisher).
+const smokeNamespace = "iotdevice"
+
+// noopSettlement is the broker-side commit/release handle the MQTT subscriber
+// hands the verification handler; the smoke only asserts payload receipt, so
+// both ops are no-ops.
+type noopSettlement struct{}
+
+func (noopSettlement) Commit(context.Context) error  { return nil }
+func (noopSettlement) Release(context.Context) error { return nil }
+
+// startSmokeBroker boots an in-process mochi MQTT v2 broker on a random
+// loopback port (AllowHook permits all clients) and returns its address.
+// Mirrors adapters/mqtt/connection_test.go startEmbeddedBroker.
+func startSmokeBroker(t *testing.T) string {
+	t.Helper()
+	srv := mqttserver.New(&mqttserver.Options{InlineClient: false})
+	if err := srv.AddHook(new(mqttallow.AllowHook), nil); err != nil {
+		t.Fatalf("add allow hook: %v", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen random port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if cerr := ln.Close(); cerr != nil {
+		t.Logf("close probe listener: %v", cerr)
+	}
+	if err := srv.AddListener(listeners.NewTCP(listeners.Config{ID: "smoke", Address: addr})); err != nil {
+		t.Fatalf("add listener: %v", err)
+	}
+	go func() { _ = srv.Serve() }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	testwait.External(t, "smoke-mqtt-broker-accepts", func() bool {
+		c, derr := net.Dial("tcp", addr)
+		if derr != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, testtime.D2s, testtime.D10ms)
+	return addr
+}
+
+// smokeConfig returns a minimal valid mqtt.Config pointing at the loopback
+// broker for the given role (publisher / subscriber → distinct client IDs).
+func smokeConfig(t *testing.T, addr, role string) mqtt.Config {
+	t.Helper()
+	id, err := mqtt.ParseEphemeralClientID(smokeNamespace, role)
+	if err != nil {
+		t.Fatalf("ParseEphemeralClientID(%q): %v", role, err)
+	}
+	return mqtt.Config{
+		ClientID:       id,
+		Brokers:        []string{fmt.Sprintf("tcp://%s", addr)},
+		ConnectTimeout: testtime.D5s,
+		KeepAlive:      testtime.D30s,
+		Backoff: mqtt.BackoffConfig{
+			BaseDelay: testtime.D100ms,
+			MaxDelay:  testtime.D2s,
+		},
+	}
+}
+
+// openSmokeConn opens an mqtt.Connection whose lifecycle is bound to t.Cleanup
+// (autopaho ties the ConnectionManager to the ctx passed to Open).
+func openSmokeConn(t *testing.T, clk clock.Clock, addr, role string) *mqtt.Connection {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	conn, err := mqtt.Open(ctx, clk, smokeConfig(t, addr, role))
+	if err != nil {
+		t.Fatalf("mqtt.Open(%q): %v", role, err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cn := context.WithTimeout(context.Background(), testtime.D5s)
+		defer cn()
+		_ = conn.Close(closeCtx)
+	})
+	return conn
+}
+
+// TestMQTTSmoke_DeviceRegisterPublishesToBroker is the end-to-end demo smoke:
+// it drives the real device-register service through a DirectCellEmitter wired
+// to the MQTT topic-mapping publisher, then verifies an independent MQTT
+// subscriber receives the device-registered envelope with the matching payload.
+//
+// Link: register → DirectEmitter → mqttTopicPublisher → broker → mqtt.Subscriber.
+func TestMQTTSmoke_DeviceRegisterPublishesToBroker(t *testing.T) {
+	addr := startSmokeBroker(t)
+	clk := clock.Real()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ns, err := mqtt.ParseTopicNamespace(smokeNamespace)
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+
+	// Publisher side: the cell's emitter publishes through the topic mapper.
+	pubConn := openSmokeConn(t, clk, addr, "publisher")
+	mqttPub, err := mqtt.NewPublisher(clk, pubConn, ns)
+	if err != nil {
+		t.Fatalf("NewPublisher: %v", err)
+	}
+	cellPub := outbox.WrapPublisherForCell(&mqttTopicPublisher{inner: mqttPub, ns: ns})
+	emitter, err := outbox.NewDirectCellEmitter(
+		cellPub, outbox.DirectPublishFailOpen, metrics.NopProvider{}, clk, "devicecell",
+		outbox.WithLogger(logger),
+	)
+	if err != nil {
+		t.Fatalf("NewDirectCellEmitter: %v", err)
+	}
+	svc, err := deviceregister.NewService(clk, devicemem.NewDeviceRepository(), logger,
+		deviceregister.WithEmitter(emitter))
+	if err != nil {
+		t.Fatalf("deviceregister.NewService: %v", err)
+	}
+
+	// Verifier side: an independent MQTT subscriber captures the envelope.
+	subConn := openSmokeConn(t, clk, addr, "subscriber")
+	sub, err := mqtt.NewSubscriber(clk, subConn, ns, mqtt.SubscriberConfig{})
+	if err != nil {
+		t.Fatalf("NewSubscriber: %v", err)
+	}
+	subscription := outbox.Subscription{
+		Topic:             smokeNamespace + "/event/device-registered/+",
+		ConsumerGroup:     "smoke-verifier",
+		CellID:            smokeNamespace,
+		ContractID:        "event.device-registered.v1",
+		ContractKind:      "event",
+		ContractTransport: "mqtt",
+	}
+	received := make(chan outbox.Entry, 1)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	t.Cleanup(runCancel)
+	go func() {
+		_ = sub.Subscribe(runCtx, subscription,
+			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+				select {
+				case received <- e:
+				default:
+				}
+				return outbox.Ack(), noopSettlement{}
+			})
+	}()
+	select {
+	case <-sub.Ready(subscription):
+	case <-time.After(testtime.D10s):
+		t.Fatal("subscriber not ready before deadline")
+	}
+
+	// Drive the real register flow.
+	const deviceName = "smoke-sensor"
+	if _, err := svc.Register(context.Background(), &registercontract.Request{Name: deviceName}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Verify the MQTT side received the envelope with the matching payload.
+	select {
+	case entry := <-received:
+		if got := entry.EventType(); got != deviceregister.TopicDeviceRegistered {
+			t.Fatalf("entry EventType = %q, want %q", got, deviceregister.TopicDeviceRegistered)
+		}
+		var ev struct {
+			ID     string `json:"id"`
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(entry.Payload(), &ev); err != nil {
+			t.Fatalf("unmarshal payload %q: %v", entry.Payload(), err)
+		}
+		if ev.Name != deviceName {
+			t.Fatalf("payload name = %q, want %q", ev.Name, deviceName)
+		}
+		if ev.Status != "online" {
+			t.Fatalf("payload status = %q, want %q", ev.Status, "online")
+		}
+		if ev.ID == "" {
+			t.Fatal("payload id is empty")
+		}
+	case <-time.After(testtime.D10s):
+		t.Fatal("did not receive device-registered event on MQTT broker before deadline")
+	}
+}

--- a/examples/iotdevice/mqtt_smoke_test.go
+++ b/examples/iotdevice/mqtt_smoke_test.go
@@ -185,11 +185,18 @@ func TestMQTTSmoke_DeviceRegisterPublishesToBroker(t *testing.T) {
 	subscription := outbox.Subscription{
 		// The trailing "+" single-level wildcard matches any version suffix,
 		// e.g. the "v1" produced by mqttEventTopic for event.device-registered.v1.
-		Topic:             smokeNamespace + "/event/device-registered/+",
-		ConsumerGroup:     "smoke-verifier",
-		CellID:            smokeNamespace,
-		ContractID:        "event.device-registered.v1",
-		ContractKind:      "event",
+		Topic:         smokeNamespace + "/event/device-registered/+",
+		ConsumerGroup: "smoke-verifier",
+		CellID:        smokeNamespace,
+		ContractID:    "event.device-registered.v1",
+		ContractKind:  "event",
+		// ContractTransport here is the verifier subscriber's own MQTT delivery
+		// channel for this demo smoke — it is NOT a claim about the contract's
+		// transport truth source. event.device-registered.v1's contract does not
+		// declare an MQTT transport (it defaults to amqp); MQTT is a demo-only
+		// observation channel wired by the single-channel DI swap. Folding MQTT
+		// into the contract/codegen transports truth source is deferred V11 work
+		// (plan §7), tracked separately.
 		ContractTransport: "mqtt",
 	}
 	received := make(chan outbox.Entry, 1)

--- a/examples/iotdevice/mqtt_test.go
+++ b/examples/iotdevice/mqtt_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestMQTTTopicPublisher_MapsTopicAndDelegates(t *testing.T) {
 	if want := "iotdevice/event/device-registered/v1"; fake.gotTopic != want {
 		t.Fatalf("inner topic = %q, want %q", fake.gotTopic, want)
 	}
-	if string(fake.gotPayload) != string(payload) {
+	if !bytes.Equal(fake.gotPayload, payload) {
 		t.Fatalf("payload mutated: got %q want %q", fake.gotPayload, payload)
 	}
 	if err := pub.Close(context.Background()); err != nil {

--- a/examples/iotdevice/mqtt_test.go
+++ b/examples/iotdevice/mqtt_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/ghbvf/gocell/adapters/mqtt"
+	"github.com/ghbvf/gocell/kernel/clock"
 )
 
 // TestMQTTEventTopic verifies the dotted-event-type → namespaced-slash-topic
@@ -82,4 +85,85 @@ func TestMQTTTopicPublisher_MapsTopicAndDelegates(t *testing.T) {
 	if !fake.closed {
 		t.Fatal("Close did not delegate to inner publisher")
 	}
+}
+
+func TestSplitBrokers(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", []string{}},
+		{"single", "tcp://127.0.0.1:1883", []string{"tcp://127.0.0.1:1883"}},
+		{"multiple", "tcp://a:1883,tcp://b:1883", []string{"tcp://a:1883", "tcp://b:1883"}},
+		{"trims whitespace", " tcp://a:1883 , tcp://b:1883 ", []string{"tcp://a:1883", "tcp://b:1883"}},
+		{"drops empty entries", "tcp://a:1883,,  ,tcp://b:1883", []string{"tcp://a:1883", "tcp://b:1883"}},
+		{"all empty", " , , ", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitBrokers(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitBrokers(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("splitBrokers(%q)[%d] = %q, want %q", tt.raw, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRedactedBrokers(t *testing.T) {
+	// Third entry contains a control character → url.Parse fails → placeholder.
+	in := []string{"tcp://user:secret@host:1883", "tcp://127.0.0.1:1883", "tcp://\x7fbad"}
+	got := redactedBrokers(in)
+	if len(got) != 3 {
+		t.Fatalf("redactedBrokers len = %d, want 3", len(got))
+	}
+	if got[0] == in[0] {
+		t.Fatalf("password not redacted: %q", got[0])
+	}
+	for _, g := range got {
+		if bytes.Contains([]byte(g), []byte("secret")) {
+			t.Fatalf("redacted broker still contains secret: %q", g)
+		}
+	}
+	if got[2] != "<unparseable-broker-url>" {
+		t.Fatalf("unparseable broker = %q, want placeholder", got[2])
+	}
+}
+
+// TestBuildMQTTDirectPublisher_EarlyReturns covers the env-driven paths that
+// return before mqtt.Open (so no broker is needed): disabled channel, empty
+// broker list, and invalid topic namespace. The connected happy path is
+// covered end-to-end by TestMQTTSmoke_DeviceRegisterPublishesToBroker.
+func TestBuildMQTTDirectPublisher_EarlyReturns(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("disabled when broker env unset", func(t *testing.T) {
+		t.Setenv(envMQTTBrokers, "")
+		pub, conn, ok, err := buildMQTTDirectPublisher(context.Background(), clock.Real(), logger)
+		if err != nil || ok || pub != nil || conn != nil {
+			t.Fatalf("disabled channel = (%v, %v, %v, %v), want (nil, nil, false, nil)", pub, conn, ok, err)
+		}
+	})
+
+	t.Run("error when brokers env has no valid URLs", func(t *testing.T) {
+		t.Setenv(envMQTTBrokers, " , , ")
+		_, _, ok, err := buildMQTTDirectPublisher(context.Background(), clock.Real(), logger)
+		if ok || err == nil {
+			t.Fatalf("empty broker list = (ok=%v, err=%v), want (false, non-nil)", ok, err)
+		}
+	})
+
+	t.Run("error when topic namespace invalid", func(t *testing.T) {
+		t.Setenv(envMQTTBrokers, "tcp://127.0.0.1:1883")
+		t.Setenv(envMQTTTopicNS, "Bad/NS/") // trailing slash + uppercase → ParseTopicNamespace rejects
+		_, _, ok, err := buildMQTTDirectPublisher(context.Background(), clock.Real(), logger)
+		if ok || err == nil {
+			t.Fatalf("invalid namespace = (ok=%v, err=%v), want (false, non-nil)", ok, err)
+		}
+	})
 }

--- a/examples/iotdevice/mqtt_test.go
+++ b/examples/iotdevice/mqtt_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/adapters/mqtt"
+)
+
+// TestMQTTEventTopic verifies the dotted-event-type → namespaced-slash-topic
+// mapping, and that every mapped topic is accepted by the namespace's PublishOK
+// (so mqtt.Publisher.Publish → ns.Mint will not reject it at runtime).
+func TestMQTTEventTopic(t *testing.T) {
+	ns, err := mqtt.ParseTopicNamespace("iotdevice")
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	tests := []struct {
+		name      string
+		eventType string
+		want      string
+	}{
+		{"device-registered", "event.device-registered.v1", "iotdevice/event/device-registered/v1"},
+		{"single segment", "ping", "iotdevice/ping"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mqttEventTopic(ns, tt.eventType)
+			if got != tt.want {
+				t.Fatalf("mqttEventTopic(%q) = %q, want %q", tt.eventType, got, tt.want)
+			}
+			if err := ns.PublishOK(got); err != nil {
+				t.Fatalf("mapped topic %q rejected by PublishOK: %v", got, err)
+			}
+		})
+	}
+}
+
+// captureFakePublisher records the last Publish call so the topic-mapping
+// delegation can be asserted without a live broker.
+type captureFakePublisher struct {
+	gotTopic   string
+	gotPayload []byte
+	closed     bool
+}
+
+func (f *captureFakePublisher) Publish(_ context.Context, topic string, payload []byte) error {
+	f.gotTopic = topic
+	f.gotPayload = payload
+	return nil
+}
+
+func (f *captureFakePublisher) Close(_ context.Context) error {
+	f.closed = true
+	return nil
+}
+
+// TestMQTTTopicPublisher_MapsTopicAndDelegates asserts the decorator maps the
+// topic, leaves the payload untouched, and forwards Close to the inner publisher.
+func TestMQTTTopicPublisher_MapsTopicAndDelegates(t *testing.T) {
+	ns, err := mqtt.ParseTopicNamespace("iotdevice")
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	fake := &captureFakePublisher{}
+	pub := &mqttTopicPublisher{inner: fake, ns: ns}
+
+	payload := []byte(`{"id":"dev-1","name":"sensor"}`)
+	if err := pub.Publish(context.Background(), "event.device-registered.v1", payload); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if want := "iotdevice/event/device-registered/v1"; fake.gotTopic != want {
+		t.Fatalf("inner topic = %q, want %q", fake.gotTopic, want)
+	}
+	if string(fake.gotPayload) != string(payload) {
+		t.Fatalf("payload mutated: got %q want %q", fake.gotPayload, payload)
+	}
+	if err := pub.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !fake.closed {
+		t.Fatal("Close did not delegate to inner publisher")
+	}
+}

--- a/examples/iotdevice/mqtt_wiring_test.go
+++ b/examples/iotdevice/mqtt_wiring_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/adapters/mqtt"
+	"github.com/ghbvf/gocell/kernel/clock"
+)
+
+// TestMQTTChannelWiring_RegistersPublisherDrainAndConnection locks the PR #1364
+// review F1 regression: an enabled MQTT publish channel must wire BOTH the
+// connection (managed resource: mqtt_ready probe + disconnect) AND the publisher
+// (managed closer: drains in-flight publishes). Connection.Close does NOT drain,
+// so dropping the publisher closer silently loses in-flight publishes on
+// shutdown. The smoke tests exercise the adapter publish path but bypass this
+// run.go composition wiring (review F2); this test covers the seam directly.
+func TestMQTTChannelWiring_RegistersPublisherDrainAndConnection(t *testing.T) {
+	addr := startSmokeBroker(t)
+	clk := clock.Real()
+
+	conn := openSmokeConn(t, clk, addr, "publisher")
+	ns, err := mqtt.ParseTopicNamespace(smokeNamespace)
+	if err != nil {
+		t.Fatalf("ParseTopicNamespace: %v", err)
+	}
+	mqttPub, err := mqtt.NewPublisher(clk, conn, ns)
+	if err != nil {
+		t.Fatalf("NewPublisher: %v", err)
+	}
+	pub := &mqttTopicPublisher{inner: mqttPub, ns: ns}
+
+	w := mqttChannelWiringFor(pub, conn)
+	if w.Resource == nil {
+		t.Fatal("wiring.Resource is nil — connection mqtt_ready probe + disconnect would not register")
+	}
+	if w.Closer == nil {
+		t.Fatal("wiring.Closer is nil — in-flight publishes would not drain on shutdown (Connection.Close does not drain)")
+	}
+	// The closer MUST be the publisher (drains in-flight), not the connection.
+	if _, ok := w.Closer.(*mqttTopicPublisher); !ok {
+		t.Fatalf("wiring.Closer = %T, want *mqttTopicPublisher (the drain-capable publisher)", w.Closer)
+	}
+	if got := len(w.bootstrapOptions()); got != 2 {
+		t.Fatalf("bootstrapOptions() = %d, want 2 (managed resource + managed closer)", got)
+	}
+}

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/auth"
 
-	"github.com/ghbvf/gocell/adapters/mqtt"
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	devicecell "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell"
 	devicemem "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/mem"
@@ -81,11 +80,12 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	}
 	if mqttOK {
 		directPub = mqttPub
-		// mqtt_ready surfaces broker reachability on /readyz; WithManagedCloser
-		// closes the connection during framework LIFO shutdown.
+		// Connection implements lifecycle.ManagedResource: WithManagedResource
+		// registers its mqtt_ready readiness probe (with the default probe
+		// timeout) + LIFO Close in one call — the standard adapter wiring path,
+		// matching postgres/rabbitmq/redis.
 		mqttBootstrapOpts = append(mqttBootstrapOpts,
-			bootstrap.WithHealthChecker(mqtt.ProbeReady, mqttConn.Health),
-			bootstrap.WithManagedCloser(mqttConn),
+			bootstrap.WithManagedResource(mqttConn),
 		)
 	}
 

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -80,12 +80,14 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	}
 	if mqttOK {
 		directPub = mqttPub
-		// Connection implements lifecycle.ManagedResource: WithManagedResource
-		// registers its mqtt_ready readiness probe (with the default probe
-		// timeout) + LIFO Close in one call — the standard adapter wiring path,
-		// matching postgres/rabbitmq/redis.
+		// Register BOTH the connection (managed resource: mqtt_ready probe +
+		// disconnect) AND the publisher (managed closer: drains in-flight
+		// publishes). Connection.Close only disconnects — it does NOT drain, so
+		// the publisher closer is mandatory, not redundant (PR #1364 review F1).
+		// mqttChannelWiringFor derives both; its godoc documents the LIFO
+		// drain-before-disconnect ordering.
 		mqttBootstrapOpts = append(mqttBootstrapOpts,
-			bootstrap.WithManagedResource(mqttConn),
+			mqttChannelWiringFor(mqttPub, mqttConn).bootstrapOptions()...,
 		)
 	}
 

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/auth"
 
+	"github.com/ghbvf/gocell/adapters/mqtt"
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	devicecell "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell"
 	devicemem "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/mem"
@@ -65,6 +66,29 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	// In-memory event bus for demo mode.
 	eb := eventbus.New(clk)
 
+	// Event publish channel selection. By default the cell publishes
+	// device-registered events to the in-memory bus (no in-process subscriber —
+	// it is a demo sink). When GOCELL_IOTDEVICE_MQTT_BROKERS is set, swap the
+	// cell's direct publisher to MQTT so events flow to a real broker, observable
+	// with `mosquitto_sub`. This is a single-channel swap, not a parallel mirror:
+	// device-registered has no second sink to mirror to. The HTTP/WS main path is
+	// unchanged. See examples/iotdevice/docs/mqtt.md.
+	var directPub outbox.Publisher = eb
+	var mqttBootstrapOpts []bootstrap.Option
+	mqttPub, mqttConn, mqttOK, err := buildMQTTDirectPublisher(ctx, clk, logger)
+	if err != nil {
+		return fmt.Errorf("build mqtt publish channel: %w", err)
+	}
+	if mqttOK {
+		directPub = mqttPub
+		// mqtt_ready surfaces broker reachability on /readyz; WithManagedCloser
+		// closes the connection during framework LIFO shutdown.
+		mqttBootstrapOpts = append(mqttBootstrapOpts,
+			bootstrap.WithHealthChecker(mqtt.ProbeReady, mqttConn.Health),
+			bootstrap.WithManagedCloser(mqttConn),
+		)
+	}
+
 	// Resolve persistence: durable PG wiring when GOCELL_IOTDEVICE_DSN is set,
 	// otherwise explicit in-memory wiring. The cell never falls back silently
 	// (B2.B: no soft fallback), so demo runs MUST inject mem implementations.
@@ -87,7 +111,7 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	dc := devicecell.NewDeviceCell(
 		clk,
 		devicecell.WithDeviceRepository(deviceRepo),
-		devicecell.WithDirectPublisher(outbox.WrapPublisherForCell(eb)),
+		devicecell.WithDirectPublisher(outbox.WrapPublisherForCell(directPub)),
 		devicecell.WithCursorCodec(cursorCodec),
 		devicecell.WithLogger(logger),
 	)
@@ -127,6 +151,8 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 		bootstrap.WithListener(cell.HealthListener, "127.0.0.1:9093", []auth.ListenerAuth{auth.AuthNone{}}),
 		bootstrap.WithHealthRoutes(healthOpts...),
 	}
+	// MQTT channel options (health probe + managed closer) when enabled.
+	opts = append(opts, mqttBootstrapOpts...)
 	// Durable mode: register the PG pool as a managed closer so framework
 	// LIFO teardown closes it even when app.Run returns an error followed by
 	// os.Exit(1). Defer-based cleanup would be skipped on that path.


### PR DESCRIPTION
## Summary

MQTT adapter epic（V11-4，parent #1138）最后一片 **PR-5**：给 `examples/iotdevice` 的
device-register 流程接入 **MQTT 发布演示路径**。设 `GOCELL_IOTDEVICE_MQTT_BROKERS` 时，
devicecell 的 direct publisher 从进程内 `eventbus` **切换**为 MQTT publisher，
`device-registered` 事件外发到真实 broker（`adapters/mqtt`），`mosquitto_sub` 可观测。
未设环境变量时行为与 develop 逐字节一致。设备 HTTP/WS 主路径不变。

Refs: V11-4 PR-5
Closes #1143

## 关键设计决策

- **单通道 DI swap，非双通道 tee/镜像**：devicecell 所有 slice 的 contractUsage role 仅
  `serve`/`publish`/`handle`，`device-registered` 在进程内**无订阅者**（`actorSubscribers`
  是外部 actor 占位）→ 没有第二个 sink 需要镜像。双通道是过度设计。对标
  Watermill/go-micro/Kratos：演示某 transport = 切换 Publisher 实现（DI），fan-out/tee
  专用于真·多 sink / 迁移双写。
- **env 配置**（与 iotdevice 现有全 env 风格一致，不引 configs/*.yaml）。
- **不改 contract.yaml**：device-registered 经组合根 publisher 透明发往 MQTT，对契约不可见；
  plan §7 明确不引 codegen `transports` 多值。MQTT 路径在 `docs/mqtt.md` 文档化。
- **fail-fast，无 noop 回退**：通道开启后配置/解析/连接错误让启动失败；仅"未设 env"是合法关闭。
  broker 运行期断开时 register 仍 201（cell L4 `DirectPublishFailOpen` 既有语义），`mqtt_ready` 转不健康。

> 测试文件放在 `examples/iotdevice/`（`package main`）而非 `test/` 子包：topic mapper 为
> 未导出符号，独立 test 包会强制导出 test-only 内部；package-main 复用未导出 helper，且
> 与现有 `run_test.go`/`main_test.go` 布局一致。

## ref: framework file

`ref: ThreeDotsLabs/watermill message/decorator.go`（`messageTransformPublisherDecorator` — 单后端 transform decorator 同构）

## 改动文件（5 files, +560 / -1）

- `examples/iotdevice/mqtt.go` — `mqttTopicPublisher`（dotted→namespaced-slash topic transform）+ `buildMQTTDirectPublisher`
- `examples/iotdevice/run.go` — 单通道 swap + `mqtt_ready` 探针 + `WithManagedCloser`
- `examples/iotdevice/mqtt_test.go` — topic 映射单测
- `examples/iotdevice/mqtt_smoke_test.go` — 端到端 smoke（in-process mochi broker）
- `examples/iotdevice/docs/mqtt.md` — 演示文档

## Test plan

- [x] `go build ./...`
- [x] `go test ./examples/iotdevice/...`（含 smoke：真实 register → DirectEmitter → topic mapper → `mqtt.Publisher` → broker → `mqtt.Subscriber` → 校验 payload；in-process mochi，PR CI 可跑）
- [x] `golangci-lint run ./examples/iotdevice/...` → 0 issues
- [x] diff 实测 561 行（< 1500 → fallback `examples/mqttdemo/` 不触发，spec §8）
- [ ] 手动：`docker run eclipse-mosquitto` + `GOCELL_IOTDEVICE_MQTT_BROKERS=tcp://127.0.0.1:1883 go run ./examples/iotdevice` + `mosquitto_sub -t 'iotdevice/#' -v` → 注册设备观测事件；`/readyz` 含 `mqtt_ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
