### PR TITLE
feat(reconcile): Trigger interface + TickerTrigger + ChannelTrigger [KERNEL-RECONCILE-01 PR-A4]

### DIFF
--- a/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+++ b/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
@@ -243,17 +243,34 @@ type Result struct { RequeueAfter time.Duration }
 盲区自检。`RequeueAfter` 语义：`>0` N 后重入；`==0` 按 default tick 重入；error≠nil 时忽略
 （走退避）；负值 clamp 到 0（`normalizedRequeueAfter`，PR-A2 测试）。
 
-### 3.2 Trigger（PR-A4 设计）
+### 3.2 Trigger（PR-A4 落地）
 
 ```go
 type Trigger interface { Start(ctx context.Context, queue chan<- Request) error }
-func TickerTrigger(interval time.Duration) Trigger   // 周期全量重观察（替代 controller-runtime resync Source）
-func ChannelTrigger(in <-chan Request) Trigger       // outbox 事件唤醒
+func TickerTrigger(clk clock.Clock, interval time.Duration) Trigger // 周期全量重观察脉冲（替代 controller-runtime resync Source）
+func ChannelTrigger(in <-chan Request) Trigger                      // outbox 事件唤醒
 ```
 
-替代 controller-runtime `Source`，最小 2 实现。PR-A3 的 `Loop.Source <-chan Request` 是 Trigger
-产出的原始 channel 接缝（A3 测试直接注入 channel，A4 由 Trigger 产出）。Loop 控制面时钟走
-`controlPlaneClock` carve-out（见 §7 T-CLOCK）。
+替代 controller-runtime `Source`，最小 2 实现。`Trigger.Start` 非阻塞（spawn producer 即返回）+
+block-don't-drop（queue 满阻塞不丢，level-triggered 安全）——对标 `source.Source.Start` 形态，但
+sink 削为裸 `chan<- Request`（去 client-go workqueue：去重/退避归 Loop，不归 Trigger）。
+PR-A3 的 `Loop.Source <-chan Request` 是 Trigger 产出的原始 channel 接缝（A3 测试直接注入 channel，
+A7 Builder 把 Trigger 输出 channel 接进 Loop.Source）。
+
+`TickerTrigger` 发**零值 `Request{}` resync 脉冲**（无 entity 上下文的间隔 ticker 只能发空 ID
+脉冲，消费方 `Reconcile` 从中扇出）；其节拍走**注入的 `clock.Clock`**（`clk.NewTicker(interval)`，
+fake clock `Advance` 可确定性测试，不依赖 wall-clock），构造期 `clock.MustHaveClock` +
+`clock.MustHavePositiveInterval` 守——clock 是强制位置参（`CLOCK-POSITIONAL-INJECTION-01`，禁
+`WithClock` option / 禁 Config.Clock 字段），不是 control-plane sealed clock。
+
+> **时钟归属澄清（F4 amendment 决议，AI-robust §ADR amendment 落地必查 → 见 §7 T-CLOCK 重评）**：
+> `controlPlaneClock` carve-out（§7 T-CLOCK）只覆盖 **Loop 自身**的 probe / requeue 定时器与 duration
+> 测量（real wall-clock 必需，否则 Start 死锁）；as-built 的 Loop **没有 ticker**（它是 Source +
+> requeue 驱动）。周期节拍由 `TickerTrigger` 持有，走注入 clock，**不**进 carve-out。原 spec 草图
+> `TickerTrigger(interval)`（无 clock）与 TDD「注入业务时钟、不依赖 wall-clock」+
+> `CLOCK-POSITIONAL-INJECTION-01` 冲突，A4 落地裁决为注入 clock 位置参——本节即重写后真值源，不留
+> 旧签名作历史。`RECONCILE-TRIGGER-INTERFACE-FROZEN-01`（reflect 锁 `Start(ctx, chan<- Request)
+> error`，含 send-only chan 方向）冻结接口形态。
 
 ### 3.3 PermanentError 来源裁决（由 PR-A2 交付）
 
@@ -460,7 +477,7 @@ controller-runtime 对标快照（§2 的 5 个 ref）仍有效，否则先修�
 | ID | 威胁 | 缓解 | 评级 |
 |----|------|------|------|
 | **T-IFACE** | 接口被错误泛化（加 namespace / Priority / Requeue bool，重新引入 K8s 残留） | `RECONCILE-{INTERFACE,REQUEST-FIELDS,RESULT-FIELDS}-FROZEN-01` reflect golden 锁字段/方法集 + 显式拒残留 + 反向盲区自检（由 PR-A2 交付） | **Hard**（违反不可表达——加字段即 CI 红，无 string-anchor 逃逸） |
-| **T-CLOCK** | 控制面 ticker/probe/duration 被注入非实时（fake）clock → Start 死锁 / 时间错乱 | `controlPlaneClock` 包私有 sealed type（包外不可构造/替换）+ `PROD-CLOCK-INJECTION-01` host-set 扩 `kernel/reconcile/`（gate(a) + (method,callee) form-uniqueness：`newProbeTimer/newRequeueTimer→NewTimer`、`now→Now`）+ GREEN/RED fixtures（由 PR-A3 交付） | **Medium**（永久天花板——stdlib `time.NewTimer`/`Now` free function 在 Go 不可 uncallable；receiver-type 限制 + form-uniqueness 是该形状可达上限，同 runtime/command controlPlaneClock 自评） |
+| **T-CLOCK** | 控制面 probe/requeue/duration 被注入非实时（fake）clock → Start 死锁 / 时间错乱 | `controlPlaneClock` 包私有 sealed type（包外不可构造/替换）+ `PROD-CLOCK-INJECTION-01` host-set 扩 `kernel/reconcile/`（gate(a) + (method,callee) form-uniqueness：`newProbeTimer/newRequeueTimer→NewTimer`、`now→Now`）+ GREEN/RED fixtures（由 PR-A3 交付）。**F4 amendment 重评（A4）**：原描述含「ticker」，但 as-built Loop **无 ticker**（Source + requeue 驱动）；周期节拍由 `TickerTrigger`（§3.2）持有并走**注入 clock**（fake-able 是刻意可测性，非威胁），故 carve-out **不加** `newTicker`——格子不退化，威胁面反而收窄（少一个 real-clock 调用点）。 | **Medium**（永久天花板——stdlib `time.NewTimer`/`Now` free function 在 Go 不可 uncallable；receiver-type 限制 + form-uniqueness 是该形状可达上限，同 runtime/command controlPlaneClock 自评） |
 | **T-LEAK** | Loop goroutine（worker / pump / requeue 定时）在 Stop/owner-cancel 后泄漏 | 全 goroutine 由 runCtx 派生 + `WaitGroup` 跟踪 + `done` channel；`Stop` cancel→等 done（StopTimeout budget）；per-requeue goroutine 双 select runCtx.Done。`goleak.VerifyNone` 守 6 个生命周期测试（由 PR-A3 交付，`-race` 通过） | **Medium**（runtime guard + goleak 测试；Go 无法在类型层表达「无 goroutine 泄漏」） |
 | **T-PANIC** | 单实体 Reconcile panic 杀 worker goroutine → 整进程崩 / 其他实体停摆 | `safeReconcile` recover → 转 transient error → 记 metric → 不影响其他实体；`TestLoop_PanicRecoveredAndOtherEntitiesUnaffected` 守（由 PR-A3 交付）。A5 细化 panic 分类/taxonomy | **Medium**（runtime recover guard + 测试；对标 controller-runtime `RecoverPanic`） |
 | **T-DUAL** | 多 cell / 多副本并发扫描 → 重复驱动（mdmcell 重发命令） | **leader election 非 fencing**（§4，client-go 明示不保证单 leader）——只 best-effort 收窄窗口。跨副本正确性靠 §4.3 `FencedRepository` + monotonic-epoch 写路径 CAS（结构拒 stale-epoch 写）+ §4.4 消费方幂等；同实例内同 EntityID 由 `inflight` sync.Map 串行（level-triggered 丢重复=skipped，由 PR-A3 交付，`TestLoop_SameEntityIDSerial` 守） | 同实例串行 **Medium**（runtime guard + 测试，已兑现）；跨副本正确性 **设计**（A6：`FencedWriter` 上游 Hard + `RECONCILE-FENCED-WRITE-FUNNEL-01` 下游 Hard + `RunFencingConformance` real-failure-injection 后定级；leader election 永远只是 best-effort 收窄，不计入正确性保证） |

--- a/docs/plans/specs/202605262359-661-kernel-reconcile-spec.md
+++ b/docs/plans/specs/202605262359-661-kernel-reconcile-spec.md
@@ -126,7 +126,7 @@
 
 **FR-004 (Loop 调度骨架)**: 框架 MUST 提供 `Loop` 类型（`NewLoop(opts)` + `Start(ctx) error` + Lifecycle 集成），复用 `runtime/command.SweeperLifecycle` 451 LoC 的 control-plane ticker / start / stop / awaitProbe 实现，仅改名 + 解耦命令实体。
 
-**FR-005 (Trigger 抽象)**: 框架 MUST 提供 `Trigger` 接口（替代 controller-runtime `Source`），最小实现 `TickerTrigger(interval time.Duration)`；选配 `ChannelTrigger(<-chan Request)` 用于 outbox 事件唤醒。
+**FR-005 (Trigger 抽象)**: 框架 MUST 提供 `Trigger` 接口（`Start(ctx, chan<- Request) error`，替代 controller-runtime `Source`），最小实现 `TickerTrigger(clk clock.Clock, interval time.Duration)`（发零值 `Request{}` resync 脉冲，节拍走注入 clock——clock 为强制位置参 per `CLOCK-POSITIONAL-INJECTION-01`，原草图 `TickerTrigger(interval)` 与 TDD「注入时钟、不依赖 wall-clock」冲突，A4 落地裁决为注入 clock，详见 ADR §3.2 F4 amendment）；选配 `ChannelTrigger(<-chan Request)` 用于 outbox 事件唤醒。
 
 **FR-006 (LeaderElector 接口)**: 框架 MUST 提供 `LeaderElector` 接口（`AcquireLease(ctx, reconcilerID) (LeaseToken, error)` + `ReleaseLease(ctx, LeaseToken) error` + `RenewLease(ctx, LeaseToken) error`）；adapters/ 层提供 Redis 与 PG advisory lock 两个实现。leader election **非 fencing 保证**（client-go 明示），故：`LeaseToken` MUST 携带**单调 fencing token** `Epoch uint64`（每次换持有者 +1，RenewLease 保持不变）；`Loop` MUST 从 lease 派生 lease-scoped ctx、在 lease 丢失瞬间 cancel 中断 in-flight Reconcile。
 

--- a/docs/plans/specs/202605262359-661-kernel-reconcile-tasks.md
+++ b/docs/plans/specs/202605262359-661-kernel-reconcile-tasks.md
@@ -147,11 +147,11 @@
 
 ## Phase 3: Triggers + Backoff（B4 — 并行）
 
-### PR-A4 — feat: Trigger interface + TickerTrigger + ChannelTrigger + clock carve-out archtest
+### PR-A4 — feat: Trigger interface + TickerTrigger + ChannelTrigger + interface-frozen archtest
 
-**Goal**: 抽象触发源（最小 2 种实现）；Loop clock 走 carve-out 等同 `PROD-CLOCK-INJECTION-01`。
+**Goal**: 抽象触发源（最小 2 种实现）；TickerTrigger 节拍走注入 `clock.Clock`（无 carve-out，因 ticker 不调 stdlib `time.*`，`PROD-CLOCK-INJECTION-01` 保持 GREEN）。
 
-**Independent Test**: `TickerTrigger(1*time.Second)` 在 1s 内触发 1 次（业务时钟可注入测试不依赖 wall-clock）；`ChannelTrigger(ch)` 在 ch 写入 Request 后立即调度。
+**Independent Test**: `TickerTrigger(clk, 1*time.Second)` 在 1s 内触发 1 次（业务时钟可注入测试不依赖 wall-clock）；`ChannelTrigger(ch)` 在 ch 写入 Request 后立即调度。
 
 #### Tests for PR-A4 (TDD)
 
@@ -166,17 +166,17 @@
 
 - [ ] **T14** [PR-A4] `kernel/reconcile/trigger.go`：
   - `type Trigger interface { Start(ctx context.Context, queue chan<- Request) error }`
-  - `func TickerTrigger(interval time.Duration) Trigger`
+  - `func TickerTrigger(clk clock.Clock, interval time.Duration) Trigger`（clock 强制位置参 per `CLOCK-POSITIONAL-INJECTION-01`）
   - `func ChannelTrigger(in <-chan Request) Trigger`
   - 估算：250 LoC
-- [ ] **T15** [PR-A4] `tools/archtest/reconcile_loop_clock_carveout_test.go`：
-  - `RECONCILE-LOOP-CLOCK-CARVEOUT-01`：mirror `PROD-CLOCK-INJECTION-01`，把 kernel/reconcile.Loop 的 control-plane ticker 加入白名单
-  - 估算：100 LoC
-- [ ] **T16** [PR-A4] `tools/archtest/reconcile_trigger_interface_frozen_test.go`：
-  - `RECONCILE-TRIGGER-INTERFACE-FROZEN-01`：reflect 锁 Trigger 接口
-  - 估算：50 LoC（合并到 T15 文件可选）
+- [ ] **T15** [PR-A4] clock carve-out archtest（取消）：
+  - TickerTrigger 节拍走注入 `clock.Clock`，不调 stdlib `time.*`，故无需 mirror `PROD-CLOCK-INJECTION-01` 的白名单；clock discipline 由既有 `CLOCK-POSITIONAL-INJECTION-01`（漏传 clk = 编译错误）守，`PROD-CLOCK-INJECTION-01` 保持 GREEN
+  - 估算：0 LoC（删除原计划的 `reconcile_loop_clock_carveout_test.go`）
+- [ ] **T16** [PR-A4] `tools/archtest/reconcile_invariants_test.go`：
+  - `RECONCILE-TRIGGER-INTERFACE-FROZEN-01`：reflect 锁 Trigger 接口（含 send-only sink 方向）+ 反向盲区自检；并入既有 reconcile 主题文件
+  - 估算：50 LoC
 
-**Checkpoint A4**: Trigger 接口 frozen；Loop 业务时钟可注入
+**Checkpoint A4**: Trigger 接口 frozen；TickerTrigger 业务时钟可注入
 
 ---
 
@@ -344,7 +344,7 @@
   - 估算：50 LoC（diff）
 - [ ] **T40** [PR-A8] 更新 `tools/archtest/clock_invariants_test.go`：
   - 删除 `controlPlaneTicker` / `controlPlaneProbeTimer` 在 runtime/command 的 carve-out（已迁出）
-  - kernel/reconcile.Loop 的 carve-out 在 PR-A4 已加
+  - kernel/reconcile.Loop 的 carve-out 在 PR-A3 已加（Loop 平移自 SweeperLifecycle，control-plane clock 同步纳入 `PROD-CLOCK-INJECTION-01`；PR-A4 的 TickerTrigger 不用此 carve-out，走注入 clock）
   - 估算：30 LoC（diff）
 
 **Checkpoint A8**: SweeperLifecycle 命名完全删除；kernel/command.Sweeper 成为 reconcile 首个示例消费方
@@ -369,7 +369,7 @@
 #### Implementation for PR-A9
 
 - [ ] **T43** [PR-A9] `examples/iotdevice/cells/devicecell/cell.go`：
-  - 从 `runtime/command.NewSweeperLifecycle(...)` 切换到 `reconcile.New(sweeper).WithTrigger(reconcile.TickerTrigger(30*time.Second)).Build()`
+  - 从 `runtime/command.NewSweeperLifecycle(...)` 切换到 `reconcile.New(sweeper).WithTrigger(reconcile.TickerTrigger(clk, 30*time.Second)).Build()`（clk 为 cell 注入的业务时钟）
   - 估算：200 LoC（含 wiring 重写）
 - [ ] **T44** [PR-A9] `examples/iotdevice/cells/devicecell/sweeper_lifecycle_test.go`：
   - 删除（被 cell_reconcile_test.go 取代）

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -3,11 +3,13 @@
 // Reconciler. It is delivered across stacked PRs: PR-A2 landed the minimal core
 // documented below (the Reconciler interface, Request / Result, and the
 // PermanentError classifier); PR-A3 landed the scheduling Loop — transplanted
-// from runtime/command.SweeperLifecycle — which is present from that commit on.
+// from runtime/command.SweeperLifecycle — which is present from that commit on;
+// PR-A4 landed the Trigger source abstraction (TickerTrigger / ChannelTrigger).
 // Comments here describe how each type is consumed by the Loop to pin its
 // contract. Later PRs refine scheduling (PR-A5 adds a rate-limited delaying
 // queue + dirty dedup) and construction (PR-A7 privatizes the Loop constructor
-// behind a Builder); see the design ADR for the staged plan.
+// behind a Builder, wiring a Trigger's output into the Loop's queue); see the
+// design ADR for the staged plan.
 //
 // # When to use
 //
@@ -35,10 +37,25 @@
 //	PermanentError / IsPermanent — non-retryable error classification
 //
 // controller-runtime abstractions deliberately dropped: Informer / CRD watch,
-// Predicate, Manager, Source, Builder.For·Owns·Watches, Result.Requeue (bool),
-// Result.Priority. GoCell entities live in a cell-local table addressed by a
-// single opaque EntityID — there is no namespace dimension and no K8s control
-// plane to watch.
+// Predicate, Manager, Source.Informer (informer-bound watch),
+// Builder.For·Owns·Watches, Result.Requeue (bool), Result.Priority. GoCell
+// entities live in a cell-local table addressed by a single opaque EntityID —
+// there is no namespace dimension and no K8s control plane to watch.
+//
+// # Trigger (PR-A4)
+//
+// A Trigger is the source of reconcile work — GoCell's minimal analog of
+// controller-runtime's source.Source, feeding Requests into the Loop's queue:
+//
+//	Trigger       — Start(ctx, chan<- Request) error  (non-blocking; block-don't-drop)
+//	TickerTrigger — emits a zero-value Request{} resync pulse every interval, off
+//	                an injected clock.Clock (deterministically testable; replaces
+//	                the informer resync GoCell lacks)
+//	ChannelTrigger— forwards Requests from an external <-chan (e.g. an outbox
+//	                consumer waking specific entities)
+//
+// The Loop's Source field is the seam a Trigger feeds; the Builder (PR-A7) wires
+// a Trigger's output channel into it.
 //
 // # Reconciler implementation pattern
 //
@@ -74,11 +91,15 @@
 //     { EntityID string }.
 //   - RECONCILE-RESULT-FIELDS-FROZEN-01 (PR-A2): Result's field set is exactly
 //     { RequeueAfter time.Duration } (no Requeue bool / Priority int).
-//   - PROD-CLOCK-INJECTION-01 (PR-A3): the Loop's control-plane ticker / probe
+//   - PROD-CLOCK-INJECTION-01 (PR-A3): the Loop's control-plane probe / requeue
 //     timers are confined to the sealed controlPlaneClock type; kernel/reconcile
 //     becomes a sanctioned control-plane host (alongside runtime/command) when
 //     the Loop + clock carve-out land in PR-A3 — it is NOT yet enforced for this
-//     package at the PR-A2 commit.
+//     package at the PR-A2 commit. The TickerTrigger (PR-A4) does NOT use this
+//     carve-out: its cadence is driven by an injected clock.Clock, so it makes
+//     no stdlib time.* call.
+//   - RECONCILE-TRIGGER-INTERFACE-FROZEN-01 (PR-A4): Trigger's method set is
+//     exactly Start(context.Context, chan<- Request) error (send-only sink).
 //
 // ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
 // ref: docs/architecture/202605291600-661-adr-kernel-reconcile-design.md

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -65,6 +65,23 @@
 //	type certRenewer struct{ repo CertRepo }
 //
 //	func (r *certRenewer) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+//		// A zero-value Request{} (empty EntityID) is the TickerTrigger resync
+//		// pulse — "re-observe everything you own". Fan out to every owned entity;
+//		// the targeted branch below handles each concrete EntityID. The ticker
+//		// re-emits the pulse each interval, so a sweep that aborts early is
+//		// re-driven on the next tick (level-triggered — nothing is lost).
+//		if req.EntityID == "" {
+//			ids, err := r.repo.ListPending(ctx)
+//			if err != nil {
+//				return reconcile.Result{}, err // transient: Loop backs off + retries
+//			}
+//			for _, id := range ids {
+//				if _, err := r.Reconcile(ctx, reconcile.Request{EntityID: id}); err != nil {
+//					return reconcile.Result{}, err // re-driven on the next resync pulse
+//				}
+//			}
+//			return reconcile.Result{}, nil
+//		}
 //		cert, err := r.repo.Get(ctx, req.EntityID)
 //		if err != nil {
 //			return reconcile.Result{}, err // transient: Loop backs off + retries

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -55,7 +55,10 @@
 //	                consumer waking specific entities)
 //
 // The Loop's Source field is the seam a Trigger feeds; the Builder (PR-A7) wires
-// a Trigger's output channel into it.
+// a Trigger's output channel into it. Until PR-A7 lands there is no direct
+// Trigger→Loop wiring entry point — a Trigger is exercised standalone (tests /
+// prototypes) by calling Start with a channel; the Builder's .WithTrigger(t)
+// DSL will own production wiring.
 //
 // # Reconciler implementation pattern
 //

--- a/kernel/reconcile/reconciler.go
+++ b/kernel/reconcile/reconciler.go
@@ -41,5 +41,10 @@ type Request struct {
 	// EntityID identifies the single entity to reconcile. It is opaque to the
 	// Loop and meaningful only to the Reconciler (typically a primary key in the
 	// cell's own table).
+	//
+	// An empty EntityID is the "resync-all" sentinel emitted by TickerTrigger
+	// (a context-free interval ticker has no entity to name): a Reconciler wired
+	// to a TickerTrigger MUST treat req.EntityID == "" as a "re-observe every
+	// entity you own" sweep, fanning out to its own entity set.
 	EntityID string
 }

--- a/kernel/reconcile/trigger.go
+++ b/kernel/reconcile/trigger.go
@@ -62,10 +62,12 @@ func TickerTrigger(clk clock.Clock, interval time.Duration) Trigger {
 	return &tickerTrigger{clk: clk, interval: interval}
 }
 
+// Start creates the ticker synchronously (before spawning the producer
+// goroutine), so a caller — or a test — that advances the injected clock
+// immediately after Start deterministically observes the first tick: there is no
+// race against the goroutine's first scheduling. It is non-blocking and never
+// returns a non-nil error (config is validated at construction; see Trigger).
 func (t *tickerTrigger) Start(ctx context.Context, queue chan<- Request) error {
-	// Create the ticker synchronously before returning so a caller (or test) that
-	// advances the clock right after Start deterministically observes a tick — no
-	// startup race with the goroutine's first scheduling.
 	ticker := t.clk.NewTicker(t.interval)
 	go func() {
 		defer ticker.Stop()
@@ -94,7 +96,10 @@ type channelTrigger struct {
 
 // ChannelTrigger returns a Trigger that forwards every Request from in into the
 // work queue (block-don't-drop). A nil source channel would block forever and is
-// a programmer error: it panics at construction.
+// a programmer error: it panics at construction. When in is closed, the
+// forwarding goroutine exits cleanly — the Loop keeps running but receives no
+// further Requests from this Trigger (the source is responsible for its own
+// lifecycle, mirroring Loop.pump over a closed Source).
 func ChannelTrigger(in <-chan Request) Trigger {
 	if in == nil {
 		panic(panicregister.Approved("reconcile-channel-trigger-nil-source",

--- a/kernel/reconcile/trigger.go
+++ b/kernel/reconcile/trigger.go
@@ -1,0 +1,130 @@
+package reconcile
+
+import (
+	"context"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
+)
+
+// Trigger is the source of reconcile work: Start launches a producer that feeds
+// Requests into the Loop's work queue until ctx is canceled. It is GoCell's
+// minimal analog of controller-runtime's source.Source — the K8s informer /
+// predicate machinery is dropped (GoCell has no control plane to watch), so the
+// sink is a plain chan<- Request rather than a rate-limiting workqueue
+// (deduplication / backoff live in the Loop, not the Trigger).
+//
+// Contract:
+//   - Start MUST be non-blocking: spawn the producer goroutine and return. It
+//     is invoked once by the Loop (later: the Builder) with the Loop's internal
+//     queue. (Mirrors source.Source's "Start must be non-blocking".)
+//   - The producer MUST honor ctx: exit promptly on ctx.Done(), and never block
+//     a queue send past cancellation (no goroutine leak on shutdown).
+//   - The producer forwards with backpressure — it blocks on a full queue rather
+//     than dropping (level-triggered: a coalesced signal is re-observed on the
+//     next trigger / requeue, never silently lost).
+//   - Start's error return is for genuine runtime startup failures. The two
+//     minimal triggers below validate their configuration at CONSTRUCTION (a
+//     misconfigured trigger is a programmer error, surfaced via panic — the
+//     clock funnel + panic taxonomy convention), so their Start never fails; the
+//     return is kept for source.Source parity and future triggers (e.g. one that
+//     dials a broker) that can fail at startup.
+//
+// INVARIANT: RECONCILE-TRIGGER-INTERFACE-FROZEN-01 — the method set is frozen to
+// exactly Start(context.Context, chan<- Request) error.
+//
+// ref: kubernetes-sigs/controller-runtime pkg/source/source.go
+type Trigger interface {
+	Start(ctx context.Context, queue chan<- Request) error
+}
+
+// tickerTrigger emits a zero-value resync pulse on every clock tick. It replaces
+// controller-runtime's informer resync (which GoCell lacks): a context-free
+// interval ticker has no entity to name, so it emits Request{} — a "re-observe
+// everything you own" pulse the consumer's Reconcile fans out from.
+type tickerTrigger struct {
+	clk      clock.Clock
+	interval time.Duration
+}
+
+// TickerTrigger returns a Trigger that emits a zero-value Request every interval,
+// off the injected clock so the cadence is deterministically testable (advance a
+// fake clock) rather than wall-clock-bound. clk and interval are required: a nil
+// clock or non-positive interval is a programmer error and panics at
+// construction (clock.MustHaveClock / clock.MustHavePositiveInterval) — clock is
+// a mandatory positional dependency per CLOCK-POSITIONAL-INJECTION-01, not a
+// WithClock option.
+func TickerTrigger(clk clock.Clock, interval time.Duration) Trigger {
+	clock.MustHaveClock(clk, "reconcile.TickerTrigger")
+	clock.MustHavePositiveInterval(interval, "reconcile.TickerTrigger")
+	return &tickerTrigger{clk: clk, interval: interval}
+}
+
+func (t *tickerTrigger) Start(ctx context.Context, queue chan<- Request) error {
+	// Create the ticker synchronously before returning so a caller (or test) that
+	// advances the clock right after Start deterministically observes a tick — no
+	// startup race with the goroutine's first scheduling.
+	ticker := t.clk.NewTicker(t.interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C():
+				select {
+				case queue <- Request{}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// channelTrigger forwards Requests from an external source channel into the work
+// queue. It is the analog of controller-runtime's source.Channel — the wakeup
+// path for event-driven reconcile (e.g. an outbox consumer pushing entity IDs).
+type channelTrigger struct {
+	in <-chan Request
+}
+
+// ChannelTrigger returns a Trigger that forwards every Request from in into the
+// work queue (block-don't-drop). A nil source channel would block forever and is
+// a programmer error: it panics at construction.
+func ChannelTrigger(in <-chan Request) Trigger {
+	if in == nil {
+		panic(panicregister.Approved("reconcile-channel-trigger-nil-source",
+			errcode.Assertion("reconcile.ChannelTrigger: source channel must not be nil")))
+	}
+	return &channelTrigger{in: in}
+}
+
+func (t *channelTrigger) Start(ctx context.Context, queue chan<- Request) error {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case req, ok := <-t.in:
+				if !ok {
+					return // source closed — no more work to forward
+				}
+				select {
+				case queue <- req:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+var (
+	_ Trigger = (*tickerTrigger)(nil)
+	_ Trigger = (*channelTrigger)(nil)
+)

--- a/kernel/reconcile/trigger_test.go
+++ b/kernel/reconcile/trigger_test.go
@@ -69,10 +69,15 @@ func TestTickerTrigger_NilClockPanics(t *testing.T) {
 }
 
 // TestTickerTrigger_NonPositiveIntervalPanics asserts construction fails fast on
-// a non-positive interval (clock.MustHavePositiveInterval).
+// a non-positive interval (clock.MustHavePositiveInterval). Both boundary cases
+// of d <= 0 are checked: a negative interval and the zero value.
 func TestTickerTrigger_NonPositiveIntervalPanics(t *testing.T) {
 	fc := clockmock.New(time.Time{})
-	assert.Panics(t, func() { TickerTrigger(fc, testtime.DNeg1s) })
+	for _, interval := range []time.Duration{testtime.DNeg1s, 0} {
+		interval := interval
+		assert.Panics(t, func() { TickerTrigger(fc, interval) },
+			"non-positive interval %v must panic at construction", interval)
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -138,7 +143,8 @@ func TestChannelTrigger_SourceClosedExits(t *testing.T) {
 }
 
 // TestChannelTrigger_RespectsCtxCancel asserts the goroutine exits on ctx
-// cancellation (goleak proves no leak).
+// cancellation while idle (blocked on the source) — the outer select's ctx.Done
+// path (goleak proves no leak).
 func TestChannelTrigger_RespectsCtxCancel(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -148,6 +154,27 @@ func TestChannelTrigger_RespectsCtxCancel(t *testing.T) {
 	queue := make(chan Request)
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, trig.Start(ctx, queue))
+	cancel()
+}
+
+// TestChannelTrigger_CancelWhileBlockedOnQueue exercises the INNER select's
+// ctx.Done path: the goroutine has a Request in hand and is blocked forwarding
+// it to an unread queue when ctx is canceled. The unbuffered source handshake
+// (in <- req completes only after the goroutine receives) guarantees the
+// goroutine is committed to the inner `queue <- req` select — which can never
+// proceed (no reader) — so cancel deterministically drives the inner exit (no
+// leak, no hang).
+func TestChannelTrigger_CancelWhileBlockedOnQueue(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	in := make(chan Request) // unbuffered: send completes after the goroutine receives
+	trig := ChannelTrigger(in)
+
+	queue := make(chan Request) // unbuffered, never read → the forward blocks
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, trig.Start(ctx, queue))
+
+	in <- Request{EntityID: "stuck"}
 	cancel()
 }
 

--- a/kernel/reconcile/trigger_test.go
+++ b/kernel/reconcile/trigger_test.go
@@ -1,0 +1,158 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
+)
+
+// tickerInterval is the fake-clock interval used by the ticker tests. Its
+// wall-clock magnitude is irrelevant — cadence is driven by FakeClock.Advance,
+// not real time — but it must be positive so construction does not panic.
+const tickerInterval = testtime.D1s
+
+// -----------------------------------------------------------------------------
+// TickerTrigger
+// -----------------------------------------------------------------------------
+
+// TestTickerTrigger_EmitsAtInterval drives the trigger off an injected fake
+// clock: each Advance(interval) fires exactly one zero-value resync pulse, with
+// no dependence on wall-clock time.
+func TestTickerTrigger_EmitsAtInterval(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	fc := clockmock.New(time.Time{})
+	trig := TickerTrigger(fc, tickerInterval)
+
+	queue := make(chan Request, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Start registers the ticker synchronously before returning, so the Advance
+	// below deterministically fires it (no startup race).
+	require.NoError(t, trig.Start(ctx, queue))
+
+	fc.Advance(tickerInterval)
+	got := testwait.Deterministic(t, queue, "ticker-pulse-1")
+	assert.Equal(t, Request{}, got, "TickerTrigger emits a zero-value resync pulse")
+
+	fc.Advance(tickerInterval)
+	got2 := testwait.Deterministic(t, queue, "ticker-pulse-2")
+	assert.Equal(t, Request{}, got2, "second interval emits a second pulse")
+}
+
+// TestTickerTrigger_RespectsCtxCancel asserts the ticker goroutine exits on ctx
+// cancellation (goleak proves no leak).
+func TestTickerTrigger_RespectsCtxCancel(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	fc := clockmock.New(time.Time{})
+	trig := TickerTrigger(fc, tickerInterval)
+
+	queue := make(chan Request, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, trig.Start(ctx, queue))
+	cancel() // goroutine must observe ctx.Done() and return
+}
+
+// TestTickerTrigger_NilClockPanics asserts construction fails fast on a nil
+// clock (clock.MustHaveClock), not at Start.
+func TestTickerTrigger_NilClockPanics(t *testing.T) {
+	assert.Panics(t, func() { TickerTrigger(nil, tickerInterval) })
+}
+
+// TestTickerTrigger_NonPositiveIntervalPanics asserts construction fails fast on
+// a non-positive interval (clock.MustHavePositiveInterval).
+func TestTickerTrigger_NonPositiveIntervalPanics(t *testing.T) {
+	fc := clockmock.New(time.Time{})
+	assert.Panics(t, func() { TickerTrigger(fc, testtime.DNeg1s) })
+}
+
+// -----------------------------------------------------------------------------
+// ChannelTrigger
+// -----------------------------------------------------------------------------
+
+// TestChannelTrigger_PassesRequest asserts an external Request written to the
+// source channel is forwarded to the work queue with its EntityID intact.
+func TestChannelTrigger_PassesRequest(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	in := make(chan Request, 1)
+	trig := ChannelTrigger(in)
+
+	queue := make(chan Request, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, trig.Start(ctx, queue))
+
+	in <- Request{EntityID: "x"}
+	got := testwait.Deterministic(t, queue, "channel-forward")
+	assert.Equal(t, "x", got.EntityID)
+}
+
+// TestChannelTrigger_BlockedOnFull proves block-don't-drop backpressure: with an
+// unbuffered work queue, the trigger forwards every Request in order, blocking
+// on each send until the consumer reads it — nothing is dropped.
+func TestChannelTrigger_BlockedOnFull(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	in := make(chan Request)
+	trig := ChannelTrigger(in)
+
+	queue := make(chan Request) // unbuffered: each forward blocks until read
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, trig.Start(ctx, queue))
+
+	go func() {
+		in <- Request{EntityID: "a"}
+		in <- Request{EntityID: "b"}
+		in <- Request{EntityID: "c"}
+	}()
+
+	assert.Equal(t, "a", testwait.Deterministic(t, queue, "bp-a").EntityID)
+	assert.Equal(t, "b", testwait.Deterministic(t, queue, "bp-b").EntityID)
+	assert.Equal(t, "c", testwait.Deterministic(t, queue, "bp-c").EntityID)
+}
+
+// TestChannelTrigger_SourceClosedExits asserts the goroutine exits cleanly when
+// the source channel is closed (no leak, no further forwarding).
+func TestChannelTrigger_SourceClosedExits(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	in := make(chan Request)
+	trig := ChannelTrigger(in)
+
+	queue := make(chan Request, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, trig.Start(ctx, queue))
+	close(in) // source closed → goroutine returns
+}
+
+// TestChannelTrigger_RespectsCtxCancel asserts the goroutine exits on ctx
+// cancellation (goleak proves no leak).
+func TestChannelTrigger_RespectsCtxCancel(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	in := make(chan Request)
+	trig := ChannelTrigger(in)
+
+	queue := make(chan Request)
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, trig.Start(ctx, queue))
+	cancel()
+}
+
+// TestChannelTrigger_NilSourcePanics asserts construction fails fast on a nil
+// source channel (a nil channel would block forever — a programmer error).
+func TestChannelTrigger_NilSourcePanics(t *testing.T) {
+	assert.Panics(t, func() { ChannelTrigger(nil) })
+}

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -2,12 +2,14 @@ package archtest
 
 // reconcile_invariants_test.go locks kernel/reconcile's public surface: the
 // three-piece minimal core (Reconciler interface method set + Request / Result
-// field sets) via reflect golden freezes, plus the transition-window guard that
-// no code outside the package bare-constructs the scheduling Loop.
+// field sets) and the Trigger interface method set via reflect golden freezes,
+// plus the transition-window guard that no code outside the package
+// bare-constructs the scheduling Loop.
 //
 //   - INVARIANT: RECONCILE-INTERFACE-FROZEN-01
 //   - INVARIANT: RECONCILE-REQUEST-FIELDS-FROZEN-01
 //   - INVARIANT: RECONCILE-RESULT-FIELDS-FROZEN-01
+//   - INVARIANT: RECONCILE-TRIGGER-INTERFACE-FROZEN-01
 //   - INVARIANT: RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01
 //
 // The design ADR (docs/architecture/202605291600-661-adr-kernel-reconcile-design.md)
@@ -283,6 +285,109 @@ func TestReconcileStructShape_ReverseBlindSpot(t *testing.T) {
 	for name, dt := range badRequest {
 		if v := checkReconcileStructShape(dt, reconcileRequestWantFields); len(v) == 0 {
 			t.Errorf("RECONCILE-REQUEST self-test: detector passed malformed Request %q (blind spot)", name)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RECONCILE-TRIGGER-INTERFACE-FROZEN-01 — Trigger method set
+// -----------------------------------------------------------------------------
+
+// checkTriggerInterface returns violation messages for it against the frozen
+// Trigger shape (exactly one method: Start(context.Context, chan<- Request)
+// error). An empty result means it conforms. The send-only channel direction is
+// part of the freeze: a bidirectional `chan` or receive-only `<-chan` sink is a
+// different contract (it would let a Trigger drain the Loop's queue rather than
+// feed it), and reflect .String() captures the direction, so the exact-string
+// check rejects both. Extracted so the reverse self-check can prove the detector
+// is non-vacuous.
+func checkTriggerInterface(it reflect.Type) []string {
+	if it == nil || it.Kind() != reflect.Interface {
+		return []string{fmt.Sprintf("Kind = %v, want interface", it)}
+	}
+	var v []string
+	if it.NumMethod() != 1 {
+		v = append(v, fmt.Sprintf("NumMethod = %d, want exactly 1 (Start)", it.NumMethod()))
+	}
+	m, ok := it.MethodByName("Start")
+	if !ok {
+		return append(v, "missing method Start")
+	}
+	mt := m.Type // interface method Type has NO receiver
+	if mt.IsVariadic() {
+		v = append(v, "Start must not be variadic")
+	}
+	wantIn := []string{"context.Context", "chan<- reconcile.Request"}
+	if mt.NumIn() != len(wantIn) {
+		v = append(v, fmt.Sprintf("Start NumIn = %d, want %d", mt.NumIn(), len(wantIn)))
+	} else {
+		for i, w := range wantIn {
+			if got := mt.In(i).String(); got != w {
+				v = append(v, fmt.Sprintf("Start arg %d = %q, want %q", i, got, w))
+			}
+		}
+	}
+	wantOut := []string{"error"}
+	if mt.NumOut() != len(wantOut) {
+		v = append(v, fmt.Sprintf("Start NumOut = %d, want %d", mt.NumOut(), len(wantOut)))
+	} else {
+		for i, w := range wantOut {
+			if got := mt.Out(i).String(); got != w {
+				v = append(v, fmt.Sprintf("Start result %d = %q, want %q", i, got, w))
+			}
+		}
+	}
+	return v
+}
+
+func TestReconcileTriggerInterfaceFrozen01(t *testing.T) {
+	t.Parallel()
+	it := reflect.TypeOf((*reconcile.Trigger)(nil)).Elem()
+	for _, msg := range checkTriggerInterface(it) {
+		t.Errorf("RECONCILE-TRIGGER-INTERFACE-FROZEN-01: %s. The Trigger method set is frozen to "+
+			"Start(ctx, chan<- Request) error (send-only sink); if this change is intentional, update the "+
+			"design ADR §3.2 and this golden in the same PR.", msg)
+	}
+}
+
+func TestReconcileTriggerInterfaceFrozen01_ReverseBlindSpot(t *testing.T) {
+	t.Parallel()
+
+	type good interface {
+		Start(context.Context, chan<- reconcile.Request) error
+	}
+	if v := checkTriggerInterface(reflect.TypeOf((*good)(nil)).Elem()); len(v) != 0 {
+		t.Errorf("RECONCILE-TRIGGER-INTERFACE-FROZEN-01 self-test: detector flagged a conforming interface "+
+			"(vacuous-pass risk): %v", v)
+	}
+
+	type extraMethod interface {
+		Start(context.Context, chan<- reconcile.Request) error
+		Stop() error
+	}
+	type wrongArity interface {
+		Start(context.Context) error
+	}
+	type bidirectionalChan interface {
+		Start(context.Context, chan reconcile.Request) error
+	}
+	type recvOnlyChan interface {
+		Start(context.Context, <-chan reconcile.Request) error
+	}
+	type wrongReturn interface {
+		Start(context.Context, chan<- reconcile.Request)
+	}
+	bad := map[string]reflect.Type{
+		"extra-method":       reflect.TypeOf((*extraMethod)(nil)).Elem(),
+		"wrong-arity":        reflect.TypeOf((*wrongArity)(nil)).Elem(),
+		"bidirectional-chan": reflect.TypeOf((*bidirectionalChan)(nil)).Elem(),
+		"recv-only-chan":     reflect.TypeOf((*recvOnlyChan)(nil)).Elem(),
+		"wrong-return":       reflect.TypeOf((*wrongReturn)(nil)).Elem(),
+	}
+	for name, it := range bad {
+		if v := checkTriggerInterface(it); len(v) == 0 {
+			t.Errorf("RECONCILE-TRIGGER-INTERFACE-FROZEN-01 self-test: detector passed malformed interface %q "+
+				"(blind spot): expected at least one violation", name)
 		}
 	}
 }

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -377,12 +377,16 @@ func TestReconcileTriggerInterfaceFrozen01_ReverseBlindSpot(t *testing.T) {
 	type wrongReturn interface {
 		Start(context.Context, chan<- reconcile.Request)
 	}
+	type wrongReturnType interface {
+		Start(context.Context, chan<- reconcile.Request) int
+	}
 	bad := map[string]reflect.Type{
 		"extra-method":       reflect.TypeOf((*extraMethod)(nil)).Elem(),
 		"wrong-arity":        reflect.TypeOf((*wrongArity)(nil)).Elem(),
 		"bidirectional-chan": reflect.TypeOf((*bidirectionalChan)(nil)).Elem(),
 		"recv-only-chan":     reflect.TypeOf((*recvOnlyChan)(nil)).Elem(),
 		"wrong-return":       reflect.TypeOf((*wrongReturn)(nil)).Elem(),
+		"wrong-return-type":  reflect.TypeOf((*wrongReturnType)(nil)).Elem(),
 	}
 	for name, it := range bad {
 		if v := checkTriggerInterface(it); len(v) == 0 {


### PR DESCRIPTION
## Summary

PR-A4 of the kernel-reconcile epic (#661, FR-005). Adds the **trigger source abstraction** that feeds the `reconcile.Loop`:

- **`Trigger`** — `Start(ctx, chan<- Request) error`; non-blocking, **block-don't-drop** backpressure. GoCell's minimal analog of controller-runtime `source.Source` (sink simplified from `workqueue.TypedRateLimitingInterface` to a plain `chan<- Request`; dedup/backoff live in the Loop).
- **`TickerTrigger(clk clock.Clock, interval)`** — emits a zero-value `Request{}` **resync pulse** each interval off an **injected clock** (deterministically fake-clock testable, not wall-clock-bound). Replaces the informer resync GoCell lacks.
- **`ChannelTrigger(<-chan Request)`** — forwards external Requests (e.g. outbox wakeups), exits cleanly on ctx cancel / source close.

`Loop` is **unchanged** — the Trigger is standalone; wiring `Trigger → Loop.Source` is the Builder's job (PR-A7).

## Key decision: injected clock (confirmed with maintainer)

The un-frozen ADR §3.2 sketch was `TickerTrigger(interval)` (no clock). That conflicts with the TDD spec ("注入业务时钟、不依赖 wall-clock") and `CLOCK-POSITIONAL-INJECTION-01` (clock must be a positional param; no `WithClock`/`Config.Clock`). Resolution: **`TickerTrigger(clk clock.Clock, interval)`**, guarded at construction by `clock.MustHaveClock` + `clock.MustHavePositiveInterval`. The as-built `Loop` has **no ticker** (Source + requeue driven), so the periodic cadence belongs to the Trigger, not the control-plane carve-out.

ADR §3.2 + §7 T-CLOCK + spec FR-005 **rewritten in this PR** (no dual-truth; per AI-robust §ADR-amendment-必查 the T-CLOCK threat row was re-evaluated — the cell does not degrade, threat surface narrows).

## Enforcement (AI-robust)

- **`RECONCILE-TRIGGER-INTERFACE-FROZEN-01`** (new) — reflect method-set freeze incl. **send-only sink direction**, with reverse blind-spot self-checks (extra-method / wrong-arity / bidirectional-chan / recv-only-chan / wrong-return). Grade: **Hard** (sibling of `RECONCILE-INTERFACE-FROZEN-01` in the same consolidated theme file).
- **No carve-out change**: `TickerTrigger` makes no stdlib `time.*` call, so `PROD-CLOCK-INJECTION-01` stays GREEN. Clock discipline rides the existing **Hard-upstream** `CLOCK-POSITIONAL-INJECTION-01` (compiler: omitting `clk` is a compile error). No new Soft convention.

## Test plan

- [x] `go test -race ./kernel/reconcile/...` — TickerTrigger (fake-clock interval / ctx-cancel / nil-clock panic / non-positive-interval panic), ChannelTrigger (forward / block-don't-drop in-order / source-closed exit / ctx-cancel / nil-source panic). Deterministic via `clockmock.Advance` + `testwait.Deterministic` (no wall-clock, no goroutine leak — `goleak.VerifyNone`).
- [x] `go test ./tools/archtest/ -run Reconcile` — frozen archtest + reverse blind-spot (non-vacuous).
- [x] `go test ./tools/archtest/ -run 'TestProdClockInjection|TestClockPositionalInjection'` — GREEN.
- [x] Coverage `kernel/reconcile` 94.2% (≥90%).
- [x] `go build ./...` + `go build -tags=integration ./...` OK.
- [x] `golangci-lint run ./...` — 0 issues.

## Implementation matrix (contract-fanout)

```
Contract: kernel/reconcile.Trigger (new interface)
Change: add Trigger + TickerTrigger + ChannelTrigger
Implementations: [x] tickerTrigger  [x] channelTrigger (both in-package)
Frozen test: archtest.TestReconcileTriggerInterfaceFrozen01
Repro: go test ./tools/archtest/ -run TestReconcileTriggerInterfaceFrozen01
Dependent contracts (governance scan): none (new kernel surface; no consumers until PR-A7 Builder)
```

Closes #1165
Refs: #661
ref: kubernetes-sigs/controller-runtime pkg/source/source.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)
