### PR TITLE
feat(webhook): SSRF guard + ADR ssrf-policy [KERNEL-WEBHOOK-01 PR-4]

### DIFF
--- a/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
+++ b/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
@@ -30,13 +30,16 @@ code IS the decision, and the blocklist is security-critical.
    the connection target is the already-checked literal IP — never a re-resolved
    hostname — there is no DNS-rebinding (TOCTOU) window between check and connect.
 
-2. **Deny-by-CIDR blocklist, explicit list as source of truth.** A 29-entry IPv4
+2. **Deny-by-CIDR blocklist, explicit list as source of truth.** A 30-entry IPv4
    + IPv6 CIDR list (`ssrfBlockedCIDRStrings`) is the single source of truth,
    cross-checked against `kernel/webhook/testdata/webhook-ssrf-deny.yaml` by a
    drift-guard test. It is the IETF-reserved-range superset from
    doyensec/safeurl, covering RFC1918, loopback, link-local (incl.
-   169.254.169.254 metadata), CGNAT (RFC6598), benchmarking, TEST-NET, multicast,
-   reserved/broadcast, ULA, NAT64, 6to4, Teredo, documentation, and ORCHID
+   169.254.169.254 metadata), CGNAT (RFC6598, incl. Alibaba ECS
+   `100.100.100.200`), benchmarking, TEST-NET, multicast, reserved/broadcast,
+   ULA (incl. AWS IMDSv6 `fd00:ec2::254`), NAT64 (RFC6052 well-known
+   `64:ff9b::/96` + RFC8215 local-use `64:ff9b:1::/48`, which would otherwise
+   embed arbitrary IPv4 incl. private), 6to4, Teredo, documentation, and ORCHID
    ranges.
 
 3. **IPv4-mapped IPv6 normalization is the SOLE mapped-IPv4 defense.** `vet`
@@ -148,14 +151,41 @@ alone.
 
 ## Consequences
 
-PR-5's dispatcher consumes `NewSafeDialer` as the only outbound dialer
-(`http.Transport{DialContext: safeDial}`), sets `CheckRedirect: DenyRedirect`,
-and calls `ValidateTargetURL` before issuing a request; the A1/A2/A3 bans mean it
-cannot wire an un-vetted egress path without tripping CI. The blocklist evolves
-by editing `ssrfBlockedCIDRStrings` **and** the fixture in the same change (the
-drift guard enforces this). The upstream holder-axis Hard-ization remains a
-won't-do permanent ceiling (#1375); PR-5 adds the dispatcher-specific
-`Dispatcher.client` typed-field lock as the practical upstream tightening.
+PR-5's dispatcher consumes `NewSafeDialer` as the only outbound dialer, sets
+`CheckRedirect: DenyRedirect`, and calls `ValidateTargetURL` before issuing a
+request; the A1/A2/A3 bans mean it cannot wire an un-vetted egress path without
+tripping CI. The intended wiring:
+
+```go
+// PR-5 dispatcher (canonical wiring).
+t := &http.Transport{DialContext: webhook.NewSafeDialer()} // ONLY DialContext;
+// do NOT set DialTLSContext — http.Transport derives the TLS ServerName (SNI +
+// cert host) from the request URL host above the dialer, so dialing a vetted
+// literal IP does not break TLS. A custom DialTLSContext would bypass the vet.
+client := &http.Client{Transport: t, CheckRedirect: webhook.DenyRedirect}
+if err := webhook.ValidateTargetURL(targetURL); err != nil { /* reject before send */ }
+```
+
+The blocklist evolves by editing `ssrfBlockedCIDRStrings` **and** the fixture in
+the same change (the drift guard enforces this).
+
+**Observability.** PR-4 surfaces an SSRF rejection only via
+`errcode.ErrWebhookSSRFBlocked` + server-side `slog` Internal attributes
+(`reason` / `host` / `target_host` / `ip` / `from_url`, correlated by
+`request_id`) — there is no metric, because `kernel/webhook` is pure-computation
+and must not depend on an instrumentation adapter. PR-5's wiring layer is the
+place to increment a counter (e.g. `webhook_ssrf_blocked_total{reason}`) on
+`errors.As(err, &ec) && ec.Code == ErrWebhookSSRFBlocked` at the
+`Transport`/`CheckRedirect` error boundary.
+
+**`WithAllowLoopback` production guard.** The option is dev/CI-only and guarded
+today only by godoc (a Soft constraint). PR-5's wiring layer (corebundle /
+assembly) must not pass it; a Medium archtest banning `WithAllowLoopback`
+references in non-`_test.go` production files should land with PR-5 once there is
+a production callsite to guard (tracked alongside #1375 follow-ups). The upstream
+holder-axis Hard-ization remains a won't-do permanent ceiling (#1375); PR-5 adds
+the dispatcher-specific `Dispatcher.client` typed-field lock as the practical
+upstream tightening.
 
 ## References
 

--- a/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
+++ b/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
@@ -13,17 +13,21 @@ who can register or influence a target URL points it at `169.254.169.254` (cloud
 metadata), an internal service, or loopback, turning the dispatcher into a
 confused-deputy proxy into the trust boundary.
 
-This PR ships the pure-computation SSRF guard (`kernel/webhook/ssrf.go`): a
-`SafeDialContext` plus a redirect-deny `http.Client.CheckRedirect` and a
-scheme/URL pre-flight. There is **no production consumer in this PR** — the
-dispatcher that wires the guard into an `http.Transport` is PR-5. The policy is
-decided here, in the same PR that implements it, rather than deferred: the dialer
-code IS the decision, and the blocklist is security-critical.
+This PR ships the pure-computation SSRF guard (`kernel/webhook/ssrf.go`) as a
+**single-source policy object**, `SafePolicy`, whose three methods —
+`DialContext` (the vetted dialer), `DenyRedirect` (an `http.Client.CheckRedirect`)
+and `ValidateTargetURL` (the scheme/URL pre-flight) — share one config. Bundling
+them means a policy knob (e.g. `WithAllowLoopback`) applies **identically** to the
+pre-flight and the dial, with no divergent per-surface vetting path. There is **no
+production consumer in this PR** — the dispatcher that holds a `*SafePolicy` and
+wires its methods into an `*http.Client` is PR-5. The policy is decided here, in
+the same PR that implements it, rather than deferred: the dialer code IS the
+decision, and the blocklist is security-critical.
 
 ## Decision
 
-1. **`resolve → vet → dial-literal-IP`, single path.** `SafeDialContext` parses
-   the address; if the host is an IP literal it vets it directly; otherwise it
+1. **`resolve → vet → dial-literal-IP`, single path.** `SafePolicy.DialContext`
+   parses the address; if the host is an IP literal it vets it directly; otherwise it
    resolves the hostname via an injectable resolver, vets **every** returned IP
    against the blocklist (fail-closed: any blocked IP rejects the whole dial),
    then dials the **first vetted IP literal** with an inner `net.Dialer`. Because
@@ -50,19 +54,27 @@ code IS the decision, and the blocklist is security-critical.
    dead weight, and without normalization it would over-block legitimate public
    IPv4-mapped addresses. Listing it would be a redundant/incorrect double path.
 
-4. **Redirect deny-all.** `DenyRedirect` (an `http.Client.CheckRedirect`) refuses
-   every 3xx. A redirect from a vetted target could otherwise bounce egress to an
-   unvetted internal `Location`; webhook delivery is one-shot, so any redirect is
-   an error.
+4. **Redirect deny-all.** `SafePolicy.DenyRedirect` (an `http.Client.CheckRedirect`)
+   refuses every 3xx. A redirect from a vetted target could otherwise bounce egress
+   to an unvetted internal `Location`; webhook delivery is one-shot, so any redirect
+   is an error.
 
-5. **Scheme allowlist {http, https}.** `ValidateTargetURL` rejects every other
-   scheme (`file`, `gopher`, `ftp`, …) and rejects a target whose host is an IP
-   literal already in the blocklist (cheap pre-flight; hostnames are still vetted
-   at dial time).
+5. **Scheme allowlist {http, https} + fail-closed pre-flight.**
+   `SafePolicy.ValidateTargetURL` rejects every other scheme (`file`, `gopher`,
+   `ftp`, …), rejects an **empty host** (an un-vettable target — e.g. `http:///x` —
+   fails closed rather than passing silently), and rejects a target whose host is
+   an IP literal blocked by the policy. The IP-literal check **reuses the same
+   `vet`** as the dial path, so the pre-flight and the dial cannot diverge (a
+   literal the dialer would accept is never falsely rejected at pre-flight, and
+   vice versa). Hostnames are still vetted at dial time (resolving at pre-flight
+   would create a TOCTOU window).
 
-6. **`WithAllowLoopback` is dev/CI only.** It exempts ONLY loopback (so
-   testcontainers can reach `127.0.0.1`); every other private/reserved range
-   stays blocked even when it is set. It must never be enabled in production.
+6. **`WithAllowLoopback` is dev/CI only — and policy-coherent.** It exempts ONLY
+   loopback (so testcontainers can reach `127.0.0.1`); every other private/reserved
+   range stays blocked even when it is set. Because the pre-flight and the dial
+   share one config and one `vet`, the exemption applies to **both** surfaces: with
+   it set, `ValidateTargetURL("http://127.0.0.1/")` passes exactly as the dial
+   does. It must never be enabled in production.
 
 7. **All errors are `KindPermissionDenied` → HTTP 403** via the existing
    `errcode.ErrWebhookSSRFBlocked` sentinel (no new sentinel). The blocked IP is
@@ -104,11 +116,21 @@ blind-spot list live in that test's package godoc (per ai-robust.md "落地实�
 | Sub-rule | Guards | Rating |
 |----------|--------|--------|
 | A1 | `net.Dial`/`DialTCP`/`DialUDP`/`DialIP`/`DialUnix`/`DialTimeout` package funcs banned in kernel/webhook | downstream **Hard** |
-| A2 | `net.Dialer.DialContext` has a single callsite (`dial` in ssrf.go) — the sole vetted outbound | downstream **Hard** |
+| A2 | `net.Dialer.DialContext` callable only from `(*SafePolicy).DialContext` — allowance bound to the go/types **FullName method identity** (not a func name or filename), the sole vetted outbound | downstream **Hard** |
 | A3 | `http.DefaultClient`/`DefaultTransport`/`Get`/`Post`/`PostForm`/`Head` banned in kernel/webhook | downstream **Hard** |
 
+A2 legitimately covers **two** callsites inside `(*SafePolicy).DialContext` (the
+IP-literal and the resolved-hostname dial); the identity binding allows exactly
+that method and nothing else. A rename of the method flips every `DialContext`
+callsite to a violation (fail-closed), forcing the author to update the
+sanctioned-identity const in the same change. The reverse fixture
+(`testdata/webhook_ssrf_violate`) exercises the full A1 banned set, a raw
+`net.Dialer{}.DialContext` (A2), and **every** A3 global + convenience callee
+(`Get`/`Post`/`PostForm`/`Head`), so dropping any one banned entry fails the
+blind-spot self-test instead of passing on the others.
+
 **Upstream is Medium = a permanent Go-language ceiling.** The holder axis —
-"only `NewSafeDialer` may produce a dialer that a struct holds" — is
+"only a `*SafePolicy` that a dispatcher holds may produce egress" — is
 inexpressible in Go's type system; package visibility constrains implementers,
 not who may declare a field of a type. This is the same permanent ceiling as
 `SPAN-SETATTR-HOLDER-SEAL` (#851) and `HEALTHZ-HOLDER-SEAL` (#893). Per
@@ -118,13 +140,14 @@ issue: **won't-do gh #1375**, named in the funnel godoc.
 **PR-4 vs PR-5 split.** The implementation plan's PR-4 row called for a
 `Dispatcher.client` field-type downstream lock. `Dispatcher` does not exist until
 PR-5 — a field scan now would pass vacuously, which is worse than absent. The
-`Dispatcher.client` typed-field lock (a single-sanctioned-holder Hard: a typed
-field whose only constructor wraps `NewSafeDialer`) is therefore deferred to
-PR-5, where it is the dispatcher-specific upstream tightening that complements
-this PR's package-level callsite ban.
+single-source `SafePolicy` makes that future lock **cleaner**: PR-5's dispatcher
+holds one `*SafePolicy` field (not three free funcs), so the single-sanctioned-
+holder Hard is a typed field whose only constructor is `NewSafePolicy`. It is
+therefore deferred to PR-5, where it is the dispatcher-specific upstream
+tightening that complements this PR's package-level callsite ban.
 
 **Documented blind spot (B1).** A hand-rolled `http.Transport` whose
-`DialContext` is not the SafeDialContext, invoked via `Transport.RoundTrip`,
+`DialContext` is not `SafePolicy.DialContext`, invoked via `Transport.RoundTrip`,
 bypasses the funnel. `RoundTrip` has no resolvable package-callee form
 distinguishing a safe vs unsafe transport; catching it needs type-level dataflow
 we do not have. Bounded response: the realistic egress path is `http.Client.Do`
@@ -141,40 +164,48 @@ over the SSRF transport, locked when the dispatcher lands in PR-5.
 | Multi-answer split (one public + one private A record) | every resolved IP vetted; any blocked IP fails the whole dial (fail-closed) | ✅ |
 | Redirect to internal `Location` after passing vet | `DenyRedirect` refuses all 3xx | ✅ |
 | Non-HTTP scheme abuse (`file://`, `gopher://`) | `ValidateTargetURL` scheme allowlist {http, https} | ✅ |
+| Un-vettable empty-host URL (`http:///x`) slipping past pre-flight | `ValidateTargetURL` rejects empty host (fail-closed) | ✅ |
+| Pre-flight ↔ dial policy divergence (loopback exempt at dial but rejected at pre-flight, or a blocklist drift between the two) | both share one `vet` on one config — single source, structurally cannot diverge | ✅ |
 | Resolver failure / empty answer fail-open | both return `ErrWebhookSSRFBlocked` (fail-closed) | ✅ |
 | Blocked-IP value leaking to wire client | IP only in `WithInternal` (server slog); 403 wire body carries no IP | ✅ |
 | CIDR list drift (code vs fixture) | `ssrf_fixtures_test.go` bidirectional set-equality drift guard | ✅ |
 | Un-vetted egress added later in kernel/webhook | WEBHOOK-SSRF-GUARD-01 A1/A2/A3 callsite bans (downstream Hard) | ✅ in-package; ⚠️ `Transport.RoundTrip` (B1) is a documented static blind spot, closed by the PR-5 `Client.Do` funnel |
 
 No row depends on `WithAllowLoopback`, which is dev/CI-only and exempts loopback
-alone.
+alone — uniformly across the pre-flight and the dial (one shared `vet`).
 
 ## Consequences
 
-PR-5's dispatcher consumes `NewSafeDialer` as the only outbound dialer, sets
-`CheckRedirect: DenyRedirect`, and calls `ValidateTargetURL` before issuing a
-request; the A1/A2/A3 bans mean it cannot wire an un-vetted egress path without
-tripping CI. The intended wiring:
+PR-5's dispatcher holds one `*SafePolicy` and wires its three methods: the
+`DialContext` as the only outbound dialer, `DenyRedirect` as `CheckRedirect`, and
+`ValidateTargetURL` before issuing a request; the A1/A2/A3 bans mean it cannot
+wire an un-vetted egress path without tripping CI. The intended wiring:
 
 ```go
 // PR-5 dispatcher (canonical wiring).
-t := &http.Transport{DialContext: webhook.NewSafeDialer()} // ONLY DialContext;
+policy := webhook.NewSafePolicy()                          // one policy, shared config
+t := &http.Transport{DialContext: policy.DialContext}      // ONLY DialContext;
 // do NOT set DialTLSContext — http.Transport derives the TLS ServerName (SNI +
 // cert host) from the request URL host above the dialer, so dialing a vetted
 // literal IP does not break TLS. A custom DialTLSContext would bypass the vet.
-client := &http.Client{Transport: t, CheckRedirect: webhook.DenyRedirect}
-if err := webhook.ValidateTargetURL(targetURL); err != nil { /* reject before send */ }
+client := &http.Client{Transport: t, CheckRedirect: policy.DenyRedirect}
+if err := policy.ValidateTargetURL(targetURL); err != nil { /* reject before send */ }
 ```
 
 The blocklist evolves by editing `ssrfBlockedCIDRStrings` **and** the fixture in
 the same change (the drift guard enforces this).
 
 **Observability.** PR-4 surfaces an SSRF rejection only via
-`errcode.ErrWebhookSSRFBlocked` + server-side `slog` Internal attributes
-(`reason` / `host` / `target_host` / `ip` / `from_url`, correlated by
-`request_id`) — there is no metric, because `kernel/webhook` is pure-computation
-and must not depend on an instrumentation adapter. PR-5's wiring layer is the
-place to increment a counter (e.g. `webhook_ssrf_blocked_total{reason}`) on
+`errcode.ErrWebhookSSRFBlocked` + server-side `slog` Internal attributes — there
+is no metric, because `kernel/webhook` is pure-computation and must not depend on
+an instrumentation adapter. **Every** reject path carries a stable `reason`
+enum suitable for a future `{reason}` metric label —
+`malformed_address` / `resolution_failed` / `no_addresses` / `ssrf_blocked`
+(dial); `unparseable` / `empty_host` / `scheme_not_allowed` / `ssrf_blocked`
+(pre-flight); `redirect_denied` (redirect) — alongside the relevant target field
+(`address` / `host` / `ip` / `scheme` / `target_host` / `from_url`), correlated by
+`request_id`. PR-5's wiring layer is the place to increment a counter (e.g.
+`webhook_ssrf_blocked_total{reason}`) on
 `errors.As(err, &ec) && ec.Code == ErrWebhookSSRFBlocked` at the
 `Transport`/`CheckRedirect` error boundary.
 
@@ -182,7 +213,7 @@ place to increment a counter (e.g. `webhook_ssrf_blocked_total{reason}`) on
 today only by godoc (a Soft constraint). PR-5's wiring layer (corebundle /
 assembly) must not pass it; a Medium archtest banning `WithAllowLoopback`
 references in non-`_test.go` production files should land with PR-5 once there is
-a production callsite to guard (tracked alongside #1375 follow-ups). The upstream
+a production callsite to guard (tracked: gh #1378). The upstream
 holder-axis Hard-ization remains a won't-do permanent ceiling (#1375); PR-5 adds
 the dispatcher-specific `Dispatcher.client` typed-field lock as the practical
 upstream tightening.

--- a/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
+++ b/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
@@ -1,0 +1,169 @@
+# ADR: Webhook SSRF policy — resolve→vet→dial-literal, deny-by-CIDR, redirect deny
+
+- Status: Accepted
+- Date: 2026-05-31
+- Context: KERNEL-WEBHOOK-01 PR-4 (#1159)
+- Supersedes / amends: none (greenfield)
+
+## Context
+
+The outbound dispatcher (PR-5) will POST webhook deliveries to **operator-supplied
+target URLs** — a classic Server-Side Request Forgery (SSRF) surface: an attacker
+who can register or influence a target URL points it at `169.254.169.254` (cloud
+metadata), an internal service, or loopback, turning the dispatcher into a
+confused-deputy proxy into the trust boundary.
+
+This PR ships the pure-computation SSRF guard (`kernel/webhook/ssrf.go`): a
+`SafeDialContext` plus a redirect-deny `http.Client.CheckRedirect` and a
+scheme/URL pre-flight. There is **no production consumer in this PR** — the
+dispatcher that wires the guard into an `http.Transport` is PR-5. The policy is
+decided here, in the same PR that implements it, rather than deferred: the dialer
+code IS the decision, and the blocklist is security-critical.
+
+## Decision
+
+1. **`resolve → vet → dial-literal-IP`, single path.** `SafeDialContext` parses
+   the address; if the host is an IP literal it vets it directly; otherwise it
+   resolves the hostname via an injectable resolver, vets **every** returned IP
+   against the blocklist (fail-closed: any blocked IP rejects the whole dial),
+   then dials the **first vetted IP literal** with an inner `net.Dialer`. Because
+   the connection target is the already-checked literal IP — never a re-resolved
+   hostname — there is no DNS-rebinding (TOCTOU) window between check and connect.
+
+2. **Deny-by-CIDR blocklist, explicit list as source of truth.** A 29-entry IPv4
+   + IPv6 CIDR list (`ssrfBlockedCIDRStrings`) is the single source of truth,
+   cross-checked against `kernel/webhook/testdata/webhook-ssrf-deny.yaml` by a
+   drift-guard test. It is the IETF-reserved-range superset from
+   doyensec/safeurl, covering RFC1918, loopback, link-local (incl.
+   169.254.169.254 metadata), CGNAT (RFC6598), benchmarking, TEST-NET, multicast,
+   reserved/broadcast, ULA, NAT64, 6to4, Teredo, documentation, and ORCHID
+   ranges.
+
+3. **IPv4-mapped IPv6 normalization is the SOLE mapped-IPv4 defense.** `vet`
+   calls `normalizeIP` (`net.IP.To4()` dewrap) before the `Contains` check, so
+   `::ffff:10.0.0.1` is checked as `10.0.0.1` (blocked by `10.0.0.0/8`) while
+   `::ffff:8.8.8.8` dewraps to the public `8.8.8.8` and is allowed. The blocklist
+   **deliberately omits `::ffff:0:0/96`**: with normalization it is unreachable
+   dead weight, and without normalization it would over-block legitimate public
+   IPv4-mapped addresses. Listing it would be a redundant/incorrect double path.
+
+4. **Redirect deny-all.** `DenyRedirect` (an `http.Client.CheckRedirect`) refuses
+   every 3xx. A redirect from a vetted target could otherwise bounce egress to an
+   unvetted internal `Location`; webhook delivery is one-shot, so any redirect is
+   an error.
+
+5. **Scheme allowlist {http, https}.** `ValidateTargetURL` rejects every other
+   scheme (`file`, `gopher`, `ftp`, …) and rejects a target whose host is an IP
+   literal already in the blocklist (cheap pre-flight; hostnames are still vetted
+   at dial time).
+
+6. **`WithAllowLoopback` is dev/CI only.** It exempts ONLY loopback (so
+   testcontainers can reach `127.0.0.1`); every other private/reserved range
+   stays blocked even when it is set. It must never be enabled in production.
+
+7. **All errors are `KindPermissionDenied` → HTTP 403** via the existing
+   `errcode.ErrWebhookSSRFBlocked` sentinel (no new sentinel). The blocked IP is
+   carried in `errcode.WithInternal` (server-side slog only), never on the wire.
+
+## Rationale / alternatives considered
+
+- **`resolve→vet→dial-literal` vs `net.Dialer.Control`.** The Control-callback
+  approach (doyensec/safeurl, mccutchen/safedialer) vets the IP the runtime
+  resolver picked, inside a `syscall.RawConn` callback — simpler, but the DNS
+  resolution still happens inside `net.Dialer` where a test cannot substitute a
+  fake answer without monkeypatching, and it leaves a theoretical rebinding
+  window on connection reuse. The resolve-then-dial-literal model
+  (stripe/smokescreen `dialContext`, stealthrocket/netjail `Rules.DialFunc`,
+  which Convoy adopts) is the industry-strictest, rebinding-proof form and puts
+  resolution behind an interface we own — exactly what makes the DNS-rebinding
+  test clean. Per the project's no-double-path rule we ship **only** this design;
+  there is no Control fallback alongside it.
+- **TLS/SNI is unaffected.** `http.Transport` derives `ServerName` (SNI + cert
+  verification host) from the request URL host *above* the dialer, independent of
+  the literal IP the dialer connects to. PR-5 wires `Transport{DialContext: safeDial}`
+  without a custom `DialTLSContext`.
+- **Explicit CIDR list vs `net.IP.IsPrivate()`.** `IsPrivate`/`IsGlobalUnicast`
+  miss SSRF-critical ranges (CGNAT 100.64/10, IETF protocol 192.0.0/24, 6to4
+  relay 192.88.99/24, NAT64) and bundle policy that cannot be fixture-diffed. An
+  explicit declared list is auditable, version-independent, and is the only form
+  the drift-guard cross-check can operate on. (smokescreen leans partly on
+  stdlib + a few explicit IPv6 ranges; we enumerate fully for auditability.)
+- **Deny-all redirect vs re-check-on-redirect.** netjail/Convoy re-apply the
+  rules on each redirect's dial; we deny outright. Webhook endpoints should not
+  redirect, and deny-all is simpler and matches Stripe/GitHub webhook delivery.
+
+## AI-robust enforcement: WEBHOOK-SSRF-GUARD-01
+
+Carrier: `tools/archtest/webhook_ssrf_guard_test.go`. Symbol inventory and
+blind-spot list live in that test's package godoc (per ai-robust.md "落地实例与
+符号清单活在代码 godoc"); this ADR records only the ratings.
+
+| Sub-rule | Guards | Rating |
+|----------|--------|--------|
+| A1 | `net.Dial`/`DialTCP`/`DialUDP`/`DialIP`/`DialUnix`/`DialTimeout` package funcs banned in kernel/webhook | downstream **Hard** |
+| A2 | `net.Dialer.DialContext` has a single callsite (`dial` in ssrf.go) — the sole vetted outbound | downstream **Hard** |
+| A3 | `http.DefaultClient`/`DefaultTransport`/`Get`/`Post`/`PostForm`/`Head` banned in kernel/webhook | downstream **Hard** |
+
+**Upstream is Medium = a permanent Go-language ceiling.** The holder axis —
+"only `NewSafeDialer` may produce a dialer that a struct holds" — is
+inexpressible in Go's type system; package visibility constrains implementers,
+not who may declare a field of a type. This is the same permanent ceiling as
+`SPAN-SETATTR-HOLDER-SEAL` (#851) and `HEALTHZ-HOLDER-SEAL` (#893). Per
+ai-robust.md §Funnel 双向锁评级, the Medium-upstream axis carries a tracking
+issue: **won't-do gh #1375**, named in the funnel godoc.
+
+**PR-4 vs PR-5 split.** The implementation plan's PR-4 row called for a
+`Dispatcher.client` field-type downstream lock. `Dispatcher` does not exist until
+PR-5 — a field scan now would pass vacuously, which is worse than absent. The
+`Dispatcher.client` typed-field lock (a single-sanctioned-holder Hard: a typed
+field whose only constructor wraps `NewSafeDialer`) is therefore deferred to
+PR-5, where it is the dispatcher-specific upstream tightening that complements
+this PR's package-level callsite ban.
+
+**Documented blind spot (B1).** A hand-rolled `http.Transport` whose
+`DialContext` is not the SafeDialContext, invoked via `Transport.RoundTrip`,
+bypasses the funnel. `RoundTrip` has no resolvable package-callee form
+distinguishing a safe vs unsafe transport; catching it needs type-level dataflow
+we do not have. Bounded response: the realistic egress path is `http.Client.Do`
+over the SSRF transport, locked when the dispatcher lands in PR-5.
+
+## Threat model
+
+| Threat | Mitigation | Status |
+|--------|-----------|--------|
+| Target → cloud metadata (169.254.169.254) | `169.254.0.0/16` in blocklist; vetted at dial time | ✅ |
+| Target → RFC1918 / loopback / ULA internal host | full CIDR blocklist; `vet` rejects | ✅ |
+| DNS rebinding (public name → private IP) | resolve→vet→dial-literal; no re-resolution between check and connect; all resolved IPs vetted | ✅ |
+| IPv4-mapped IPv6 evasion (`::ffff:10.0.0.1`) | `normalizeIP` To4 dewrap before `Contains` | ✅ |
+| Multi-answer split (one public + one private A record) | every resolved IP vetted; any blocked IP fails the whole dial (fail-closed) | ✅ |
+| Redirect to internal `Location` after passing vet | `DenyRedirect` refuses all 3xx | ✅ |
+| Non-HTTP scheme abuse (`file://`, `gopher://`) | `ValidateTargetURL` scheme allowlist {http, https} | ✅ |
+| Resolver failure / empty answer fail-open | both return `ErrWebhookSSRFBlocked` (fail-closed) | ✅ |
+| Blocked-IP value leaking to wire client | IP only in `WithInternal` (server slog); 403 wire body carries no IP | ✅ |
+| CIDR list drift (code vs fixture) | `ssrf_fixtures_test.go` bidirectional set-equality drift guard | ✅ |
+| Un-vetted egress added later in kernel/webhook | WEBHOOK-SSRF-GUARD-01 A1/A2/A3 callsite bans (downstream Hard) | ✅ in-package; ⚠️ `Transport.RoundTrip` (B1) is a documented static blind spot, closed by the PR-5 `Client.Do` funnel |
+
+No row depends on `WithAllowLoopback`, which is dev/CI-only and exempts loopback
+alone.
+
+## Consequences
+
+PR-5's dispatcher consumes `NewSafeDialer` as the only outbound dialer
+(`http.Transport{DialContext: safeDial}`), sets `CheckRedirect: DenyRedirect`,
+and calls `ValidateTargetURL` before issuing a request; the A1/A2/A3 bans mean it
+cannot wire an un-vetted egress path without tripping CI. The blocklist evolves
+by editing `ssrfBlockedCIDRStrings` **and** the fixture in the same change (the
+drift guard enforces this). The upstream holder-axis Hard-ization remains a
+won't-do permanent ceiling (#1375); PR-5 adds the dispatcher-specific
+`Dispatcher.client` typed-field lock as the practical upstream tightening.
+
+## References
+
+- stripe/smokescreen `pkg/smokescreen/smokescreen.go` — `resolveTCPAddr` / `selectTargetAddr` / `classifyAddr` / `dialContext` (resolve→vet→dial-literal)
+- stealthrocket/netjail `security.go` `Rules.DialFunc` (resolve→vet→dial-literal; Convoy adopts)
+- doyensec/safeurl `ip.go` `privateNetworks` (CIDR superset source) + `client.go` (Control mode — deliberately not used)
+- mccutchen/safedialer — Control-mode minimal reference
+- Convoy SSRF guide: https://www.getconvoy.io/docs/webhook-guides/tackling-ssrf
+- ADR `202605291200-adr-webhook-signing-algorithm.md` (sibling webhook ADR; HTTP status mapping, secret-leak defense)
+- ADR `202605051730-adr-errcode-message-pii-safety.md` (Message/Details/Internal redaction; blocked IP → Internal channel)
+- ai-robust.md §Funnel 双向锁评级; gh #1375 (upstream holder-axis won't-do), #851 / #893 (Go-language-ceiling precedents)

--- a/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
+++ b/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
@@ -97,9 +97,13 @@ func (d *Dispatcher) Handle(ctx context.Context, entry outbox.Entry) outbox.Hand
 
 // kernel/webhook/ssrf.go
 type SafeDialContext func(ctx context.Context, network, address string) (net.Conn, error)
-func NewSafeDialer(opts ...SafeOption) SafeDialContext
-type SafeOption func(*safeConfig)
-func WithAllowLoopback() SafeOption  // dev-only opt-in
+type SafePolicy struct{ /* unexported config */ }         // single-source SSRF policy
+func NewSafePolicy(opts ...SafeOption) *SafePolicy
+func (p *SafePolicy) DialContext(ctx context.Context, network, address string) (net.Conn, error)
+func (p *SafePolicy) ValidateTargetURL(rawURL string) error
+func (p *SafePolicy) DenyRedirect(_ *http.Request, via []*http.Request) error
+type SafeOption func(*SafePolicy)
+func WithAllowLoopback() SafeOption  // dev-only opt-in (applies to dial AND pre-flight)
 ```
 
 ### 2.3 cellgen 派生模式（K42 接缝）
@@ -149,7 +153,7 @@ func (c *MyCell) Init(ctx context.Context, reg cell.Registrar) error {
 |----|---------|------|----------------|
 | WEBHOOK-HMAC-FUNNEL-01 | `crypto/hmac.New` callsite 限定 `kernel/webhook/signer.go` | Hard 下游 + Medium 上游 | 下游 callsite allowlist；上游 `Signer` sealed interface（`sealed()` unexported marker → 包外不可实现） |
 | WEBHOOK-SIGNER-FUNNEL-01 | `Webhook-Signature` header 写入只经 Signer | Medium | 下游 AST ban literal `Header.Set("X-Webhook-Signature", ...)`；上游 Dispatcher struct field typed |
-| WEBHOOK-SSRF-GUARD-01 | dispatcher 所有 HTTP 出站经 SafeDialContext | Hard 下游 + Medium 上游 | 下游 `Dispatcher.client` 字段类型必须经 `webhook.NewSafeDialer` 包装；上游 archtest ban `http.DefaultClient` + `net.Dial` / `net.DialTCP` 直调 |
+| WEBHOOK-SSRF-GUARD-01 | dispatcher 所有 HTTP 出站经 SafePolicy | Hard 下游 + Medium 上游 | 下游 `Dispatcher.client` 持有 `*webhook.SafePolicy`（唯一构造器 `NewSafePolicy`），`net.Dialer.DialContext` 仅 `(*SafePolicy).DialContext` 可调；上游 archtest ban `http.DefaultClient` + `net.Dial` / `net.DialTCP` 直调 |
 | WEBHOOK-IDEMPOTENCY-CLAIMER-01 | Receiver 处理前必经 Claimer | Medium | 复用 `REQUIRED-DEP-NIL-GUARD-01` 框架，receiver struct claimer 字段 `gocell:"required"` |
 | WEBHOOK-SIGNED-STRING-FORM-01 | 签名串格式 `{webhookID}.{timestamp}.{body}` 与 Svix 对齐 | Medium | golden fixture（Svix 官方 test vector）+ AST 锁 `fmt.Sprintf` 模板字面量 |
 

--- a/kernel/webhook/ssrf.go
+++ b/kernel/webhook/ssrf.go
@@ -1,0 +1,232 @@
+package webhook
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
+)
+
+// SafeDialContext is the dial function signature shared with net.Dialer.DialContext,
+// so it drops directly into http.Transport.DialContext (wired by the dispatcher
+// in PR-5). It resolves the host, vets every resolved IP against the SSRF
+// blocklist, then dials a vetted IP literal — closing the DNS-rebinding (TOCTOU)
+// window because the connection target is the already-checked literal, never a
+// re-resolved hostname.
+//
+// ref: stripe/smokescreen pkg/smokescreen (resolve→vet→dial-literal)
+// ref: stealthrocket/netjail security.go Rules.DialFunc
+// ref: doyensec/safeurl ip.go privateNetworks (CIDR superset; Control mode not used)
+type SafeDialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+// resolver is the injectable DNS seam; *net.Resolver (net.DefaultResolver)
+// satisfies it. It is an unexported interface so withResolver cannot be named —
+// let alone called — from outside this package: the DNS-rebinding tests inject a
+// fake from within package webhook, while production has no resolver knob.
+type resolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+type safeConfig struct {
+	allowLoopback bool
+	resolver      resolver
+	dialer        *net.Dialer
+	blockedNets   []*net.IPNet
+}
+
+// SafeOption customizes a SafeDialContext at construction time.
+type SafeOption func(*safeConfig)
+
+// WithAllowLoopback permits loopback (127.0.0.0/8, ::1) dial targets. It is for
+// dev / CI only (e.g. testcontainers) and must never be set in production. It
+// exempts ONLY loopback — every other private/reserved range stays blocked.
+func WithAllowLoopback() SafeOption {
+	return func(c *safeConfig) { c.allowLoopback = true }
+}
+
+// withResolver injects a DNS resolver. Unexported (and typed on the unexported
+// resolver interface) so it is a same-package-test-only seam — production code
+// cannot reach it, so there is no public surface to misuse and no fallback path.
+func withResolver(r resolver) SafeOption {
+	return func(c *safeConfig) { c.resolver = r }
+}
+
+// NewSafeDialer returns a SafeDialContext that blocks dialing any address
+// resolving into the SSRF blocklist (see ssrfBlockedCIDRStrings).
+func NewSafeDialer(opts ...SafeOption) SafeDialContext {
+	cfg := &safeConfig{
+		resolver:    net.DefaultResolver,
+		dialer:      &net.Dialer{},
+		blockedNets: ssrfBlockedNets,
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return cfg.dial
+}
+
+func (c *safeConfig) dial(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: malformed dial address", err)
+	}
+
+	// IP literal: vet directly, no DNS.
+	if ip := net.ParseIP(host); ip != nil {
+		if verr := c.vet(ip); verr != nil {
+			return nil, verr
+		}
+		return c.dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+
+	// Hostname: resolve once, vet ALL answers (fail-closed if any is blocked),
+	// then dial the first vetted IP literal. No re-resolution → rebinding-proof.
+	addrs, err := c.resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: dial host resolution failed", err)
+	}
+	if len(addrs) == 0 {
+		return nil, errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: dial host resolved to no addresses")
+	}
+	for _, a := range addrs {
+		if verr := c.vet(a.IP); verr != nil {
+			return nil, verr
+		}
+	}
+	vetted := addrs[0].IP
+	return c.dialer.DialContext(ctx, network, net.JoinHostPort(vetted.String(), port))
+}
+
+// vet rejects ip when it falls in any blocked CIDR. The IP is normalized via
+// To4() first so IPv4-mapped IPv6 (::ffff:10.0.0.1) is checked as its embedded
+// IPv4. Loopback is exempted only when allowLoopback is set.
+func (c *safeConfig) vet(ip net.IP) error {
+	norm := normalizeIP(ip)
+	if c.allowLoopback && norm.IsLoopback() {
+		return nil
+	}
+	for _, n := range c.blockedNets {
+		if n.Contains(norm) {
+			return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+				"webhook: dial target resolved to a blocked address",
+				errcode.WithInternal(errcode.InternalAttr("ip", norm.String())),
+				errcode.WithDetails(errcode.PublicString("reason", "ssrf_blocked")))
+		}
+	}
+	return nil
+}
+
+// normalizeIP dewraps an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its 4-byte
+// IPv4 form so the IPv4 blocklist entries match. Non-mapped addresses are
+// returned unchanged. This is the SOLE IPv4-mapped defense — the blocklist
+// deliberately omits ::ffff:0:0/96 (which would be dead after this dewrap, or
+// would over-block public mapped addresses without it).
+func normalizeIP(ip net.IP) net.IP {
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}
+
+// DenyRedirect is an http.Client.CheckRedirect that refuses ALL redirects. A 3xx
+// from a vetted target could otherwise bounce egress to an unvetted (internal)
+// Location; webhook delivery is one-shot, so any redirect is rejected
+// (matching Stripe / GitHub webhook delivery semantics).
+func DenyRedirect(_ *http.Request, via []*http.Request) error {
+	return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+		"webhook: redirects are not permitted on outbound delivery",
+		errcode.WithInternal(errcode.InternalAttr("redirect_chain_len", len(via))))
+}
+
+// ValidateTargetURL enforces the {http, https} scheme allowlist and rejects a
+// target whose host is an IP literal already in the SSRF blocklist (a cheap
+// pre-flight; hostnames are still vetted at dial time by SafeDialContext).
+func ValidateTargetURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: dispatch target URL is not parseable", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: dispatch target scheme is not allowed",
+			errcode.WithDetails(errcode.PublicString("reason", "scheme_not_allowed")))
+	}
+	host := u.Hostname() // strips port and IPv6 brackets
+	if ip := net.ParseIP(host); ip != nil {
+		norm := normalizeIP(ip)
+		for _, n := range ssrfBlockedNets {
+			if n.Contains(norm) {
+				return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+					"webhook: dispatch target IP literal is blocked",
+					errcode.WithInternal(errcode.InternalAttr("ip", norm.String())))
+			}
+		}
+	}
+	return nil
+}
+
+// ssrfBlockedCIDRStrings is the authoritative SSRF dial-time blocklist and the
+// SINGLE source of truth, cross-checked against testdata/webhook-ssrf-deny.yaml
+// by ssrf_fixtures_test.go (drift guard). It is the IETF-reserved-range superset
+// from doyensec/safeurl ip.go, minus ::ffff:0:0/96 (handled by normalizeIP).
+var ssrfBlockedCIDRStrings = []string{
+	// ── IPv4 ──
+	"0.0.0.0/8",          // unspecified / this-host
+	"10.0.0.0/8",         // RFC1918 private
+	"100.64.0.0/10",      // RFC6598 CGNAT
+	"127.0.0.0/8",        // loopback
+	"169.254.0.0/16",     // RFC3927 link-local — INCLUDES 169.254.169.254 cloud metadata
+	"172.16.0.0/12",      // RFC1918 private
+	"192.0.0.0/24",       // IETF protocol assignments
+	"192.0.2.0/24",       // TEST-NET-1 documentation
+	"192.88.99.0/24",     // 6to4 relay anycast (deprecated)
+	"192.168.0.0/16",     // RFC1918 private
+	"198.18.0.0/15",      // benchmarking
+	"198.51.100.0/24",    // TEST-NET-2 documentation
+	"203.0.113.0/24",     // TEST-NET-3 documentation
+	"224.0.0.0/4",        // multicast
+	"240.0.0.0/4",        // reserved
+	"255.255.255.255/32", // limited broadcast
+	// ── IPv6 ──
+	"::/128",        // unspecified
+	"::1/128",       // loopback
+	"64:ff9b::/96",  // RFC6052 NAT64 well-known prefix
+	"100::/64",      // discard-only
+	"2001::/23",     // IETF protocol assignments (incl. Teredo 2001::/32)
+	"2001:2::/48",   // benchmarking
+	"2001:db8::/32", // documentation
+	"2001:10::/28",  // deprecated ORCHID
+	"2001:20::/28",  // ORCHIDv2
+	"2002::/16",     // 6to4
+	"fc00::/7",      // RFC4193 ULA (unique local)
+	"fe80::/10",     // link-local
+	"ff00::/8",      // multicast
+}
+
+// ssrfBlockedNets is ssrfBlockedCIDRStrings parsed once at package init. A
+// malformed literal is a programmer error (the strings are compile-time
+// constants), surfaced fail-fast via the Approved panic funnel.
+var ssrfBlockedNets = ssrfBlockedCIDRs()
+
+func ssrfBlockedCIDRs() []*net.IPNet {
+	out := make([]*net.IPNet, 0, len(ssrfBlockedCIDRStrings))
+	for _, s := range ssrfBlockedCIDRStrings {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			panic(panicregister.Approved("webhook-ssrf-cidr-literal",
+				errcode.Assertion("webhook: invalid SSRF CIDR literal %q: %v", s, err)))
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/kernel/webhook/ssrf.go
+++ b/kernel/webhook/ssrf.go
@@ -12,15 +12,8 @@ import (
 )
 
 // SafeDialContext is the dial function signature shared with net.Dialer.DialContext,
-// so it drops directly into http.Transport.DialContext (wired by the dispatcher
-// in PR-5). It resolves the host, vets every resolved IP against the SSRF
-// blocklist, then dials a vetted IP literal — closing the DNS-rebinding (TOCTOU)
-// window because the connection target is the already-checked literal, never a
-// re-resolved hostname.
-//
-// ref: stripe/smokescreen pkg/smokescreen (resolve→vet→dial-literal)
-// ref: stealthrocket/netjail security.go Rules.DialFunc
-// ref: doyensec/safeurl ip.go privateNetworks (CIDR superset; Control mode not used)
+// so SafePolicy.DialContext drops directly into http.Transport.DialContext (wired
+// by the dispatcher in PR-5).
 type SafeDialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
 // resolver is the injectable DNS seam; *net.Resolver (net.DefaultResolver)
@@ -31,7 +24,22 @@ type resolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
-type safeConfig struct {
+// SafePolicy is the single source of webhook outbound SSRF policy. Its three
+// methods — DialContext (resolve→vet→dial-literal), ValidateTargetURL (cheap
+// pre-flight) and DenyRedirect (redirect deny-all) — all share one config, so a
+// policy knob (e.g. WithAllowLoopback) applies identically to the pre-flight and
+// the dial. PR-5 holds one *SafePolicy and wires all three into an *http.Client;
+// there is no divergent per-surface vetting path.
+//
+// DialContext resolves the host, vets every resolved IP against the SSRF
+// blocklist, then dials a vetted IP literal — closing the DNS-rebinding (TOCTOU)
+// window because the connection target is the already-checked literal, never a
+// re-resolved hostname.
+//
+// ref: stripe/smokescreen pkg/smokescreen (resolve→vet→dial-literal)
+// ref: stealthrocket/netjail security.go Rules.DialFunc
+// ref: doyensec/safeurl ip.go privateNetworks (CIDR superset; Control mode not used)
+type SafePolicy struct {
 	allowLoopback bool
 	resolver      resolver
 	dialer        *net.Dialer
@@ -41,87 +49,102 @@ type safeConfig struct {
 	blockedNets []*net.IPNet
 }
 
-// SafeOption customizes a SafeDialContext at construction time.
-type SafeOption func(*safeConfig)
+// SafeOption customizes a SafePolicy at construction time.
+type SafeOption func(*SafePolicy)
 
-// WithAllowLoopback permits loopback (127.0.0.0/8, ::1) dial targets. It is for
-// dev / CI only (e.g. testcontainers) and must never be set in production. It
-// exempts ONLY loopback — every other private/reserved range stays blocked.
+// WithAllowLoopback permits loopback (127.0.0.0/8, ::1) dial AND pre-flight
+// targets. It is for dev / CI only (e.g. testcontainers) and must never be set
+// in production. It exempts ONLY loopback — every other private/reserved range
+// stays blocked, on both the DialContext and ValidateTargetURL paths.
 func WithAllowLoopback() SafeOption {
-	return func(c *safeConfig) { c.allowLoopback = true }
+	return func(p *SafePolicy) { p.allowLoopback = true }
 }
 
 // withResolver injects a DNS resolver. Unexported (and typed on the unexported
 // resolver interface) so it is a same-package-test-only seam — production code
 // cannot reach it, so there is no public surface to misuse and no fallback path.
 func withResolver(r resolver) SafeOption {
-	return func(c *safeConfig) { c.resolver = r }
+	return func(p *SafePolicy) { p.resolver = r }
 }
 
-// NewSafeDialer returns a SafeDialContext that blocks dialing any address
-// resolving into the SSRF blocklist (see ssrfBlockedCIDRStrings).
-func NewSafeDialer(opts ...SafeOption) SafeDialContext {
-	cfg := &safeConfig{
+// NewSafePolicy returns a SafePolicy that blocks any address resolving into the
+// SSRF blocklist (see ssrfBlockedCIDRStrings).
+func NewSafePolicy(opts ...SafeOption) *SafePolicy {
+	p := &SafePolicy{
 		resolver:    net.DefaultResolver,
 		dialer:      &net.Dialer{},
 		blockedNets: ssrfBlockedNets,
 	}
 	for _, o := range opts {
-		o(cfg)
+		o(p)
 	}
-	return cfg.dial
+	return p
 }
 
-func (c *safeConfig) dial(ctx context.Context, network, address string) (net.Conn, error) {
+// DialContext is the SafeDialContext-compatible dial: resolve→vet-all→dial the
+// vetted IP literal. It is the SOLE sanctioned outbound callsite for
+// net.Dialer.DialContext in kernel/webhook (WEBHOOK-SSRF-GUARD-01/A2).
+func (p *SafePolicy) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-			"webhook: malformed dial address", err)
+			"webhook: malformed dial address", err,
+			errcode.WithInternal(
+				errcode.InternalAttr("reason", "malformed_address"),
+				errcode.InternalAttr("address", address)))
 	}
 
 	// IP literal: vet directly, no DNS.
 	if ip := net.ParseIP(host); ip != nil {
-		if verr := c.vet(host, ip); verr != nil {
+		if verr := p.vet(host, ip); verr != nil {
 			return nil, verr
 		}
-		return c.dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		return p.dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
 	}
 
 	// Hostname: resolve once, vet ALL answers (fail-closed if any is blocked),
 	// then dial the first vetted IP literal. No re-resolution → rebinding-proof.
-	addrs, err := c.resolver.LookupIPAddr(ctx, host)
+	addrs, err := p.resolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-			"webhook: dial host resolution failed", err)
+			"webhook: dial host resolution failed", err,
+			errcode.WithInternal(
+				errcode.InternalAttr("reason", "resolution_failed"),
+				errcode.InternalAttr("host", host)))
 	}
 	if len(addrs) == 0 {
 		return nil, errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-			"webhook: dial host resolved to no addresses")
+			"webhook: dial host resolved to no addresses",
+			errcode.WithInternal(
+				errcode.InternalAttr("reason", "no_addresses"),
+				errcode.InternalAttr("host", host)))
 	}
 	for _, a := range addrs {
-		if verr := c.vet(host, a.IP); verr != nil {
+		if verr := p.vet(host, a.IP); verr != nil {
 			return nil, verr
 		}
 	}
 	vetted := addrs[0].IP
-	return c.dialer.DialContext(ctx, network, net.JoinHostPort(vetted.String(), port))
+	return p.dialer.DialContext(ctx, network, net.JoinHostPort(vetted.String(), port))
 }
 
 // vet rejects ip when it falls in any blocked CIDR. The IP is normalized via
 // To4() first so IPv4-mapped IPv6 (::ffff:10.0.0.1) is checked as its embedded
-// IPv4. Loopback is exempted only when allowLoopback is set. host (the dial
-// target before resolution) is recorded server-side for incident triage; the
-// reject "reason" is an Internal (server-only) attribute, never on the wire, so
-// the 403 does not advertise which targets the SSRF policy blocks.
-func (c *safeConfig) vet(host string, ip net.IP) error {
+// IPv4. Loopback is exempted only when allowLoopback is set. host (the target
+// before resolution) is recorded server-side for incident triage; the reject
+// "reason" is an Internal (server-only) attribute, never on the wire, so the 403
+// does not advertise which targets the SSRF policy blocks. Shared by DialContext
+// (resolved IPs) and ValidateTargetURL (literal pre-flight) so the policy is
+// single-source.
+func (p *SafePolicy) vet(host string, ip net.IP) error {
 	norm := normalizeIP(ip)
-	if c.allowLoopback && norm.IsLoopback() {
+	if p.allowLoopback && norm.IsLoopback() {
 		return nil
 	}
-	for _, n := range c.blockedNets {
+	for _, n := range p.blockedNets {
 		if n.Contains(norm) {
 			return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-				"webhook: dial target resolved to a blocked address",
+				"webhook: target address is blocked by SSRF policy",
 				errcode.WithInternal(
 					errcode.InternalAttr("reason", "ssrf_blocked"),
 					errcode.InternalAttr("host", host),
@@ -131,42 +154,18 @@ func (c *safeConfig) vet(host string, ip net.IP) error {
 	return nil
 }
 
-// normalizeIP dewraps an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its 4-byte
-// IPv4 form so the IPv4 blocklist entries match. Non-mapped addresses are
-// returned unchanged. This is the SOLE IPv4-mapped defense — the blocklist
-// deliberately omits ::ffff:0:0/96 (which would be dead after this dewrap, or
-// would over-block public mapped addresses without it).
-func normalizeIP(ip net.IP) net.IP {
-	if v4 := ip.To4(); v4 != nil {
-		return v4
-	}
-	return ip
-}
-
-// DenyRedirect is an http.Client.CheckRedirect that refuses ALL redirects. A 3xx
-// from a vetted target could otherwise bounce egress to an unvetted (internal)
-// Location; webhook delivery is one-shot, so any redirect is rejected
-// (matching Stripe / GitHub webhook delivery semantics).
-func DenyRedirect(_ *http.Request, via []*http.Request) error {
-	from := ""
-	if n := len(via); n > 0 && via[n-1] != nil && via[n-1].URL != nil {
-		from = via[n-1].URL.String()
-	}
-	return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-		"webhook: redirects are not permitted on outbound delivery",
-		errcode.WithInternal(
-			errcode.InternalAttr("redirect_chain_len", len(via)),
-			errcode.InternalAttr("from_url", from)))
-}
-
-// ValidateTargetURL enforces the {http, https} scheme allowlist and rejects a
-// target whose host is an IP literal already in the SSRF blocklist (a cheap
-// pre-flight; hostnames are still vetted at dial time by SafeDialContext).
-func ValidateTargetURL(rawURL string) error {
+// ValidateTargetURL is a cheap pre-flight: it enforces the {http, https} scheme
+// allowlist, rejects an empty host (fail-closed — an un-vettable target), and
+// rejects a target whose host is an IP literal already blocked by the SSRF
+// policy. The IP-literal check reuses vet, so WithAllowLoopback exempts loopback
+// here exactly as it does at dial time. Hostnames are still vetted at dial time
+// by DialContext (resolving here would create a TOCTOU window).
+func (p *SafePolicy) ValidateTargetURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-			"webhook: dispatch target URL is not parseable", err)
+			"webhook: dispatch target URL is not parseable", err,
+			errcode.WithInternal(errcode.InternalAttr("reason", "unparseable")))
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https":
@@ -179,20 +178,47 @@ func ValidateTargetURL(rawURL string) error {
 				errcode.InternalAttr("target_host", u.Hostname())))
 	}
 	host := u.Hostname() // strips port and IPv6 brackets
+	if host == "" {
+		return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: dispatch target URL has no host",
+			errcode.WithInternal(
+				errcode.InternalAttr("reason", "empty_host"),
+				errcode.InternalAttr("scheme", u.Scheme)))
+	}
 	if ip := net.ParseIP(host); ip != nil {
-		norm := normalizeIP(ip)
-		for _, n := range ssrfBlockedNets {
-			if n.Contains(norm) {
-				return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
-					"webhook: dispatch target IP literal is blocked",
-					errcode.WithInternal(
-						errcode.InternalAttr("reason", "ssrf_blocked"),
-						errcode.InternalAttr("target_host", host),
-						errcode.InternalAttr("ip", norm.String())))
-			}
-		}
+		return p.vet(host, ip)
 	}
 	return nil
+}
+
+// DenyRedirect is an http.Client.CheckRedirect that refuses ALL redirects. A 3xx
+// from a vetted target could otherwise bounce egress to an unvetted (internal)
+// Location; webhook delivery is one-shot, so any redirect is rejected
+// (matching Stripe / GitHub webhook delivery semantics). It is a method so the
+// SSRF policy surface stays coherent, though redirect deny-all needs no config.
+func (p *SafePolicy) DenyRedirect(_ *http.Request, via []*http.Request) error {
+	from := ""
+	if n := len(via); n > 0 && via[n-1] != nil && via[n-1].URL != nil {
+		from = via[n-1].URL.String()
+	}
+	return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+		"webhook: redirects are not permitted on outbound delivery",
+		errcode.WithInternal(
+			errcode.InternalAttr("reason", "redirect_denied"),
+			errcode.InternalAttr("redirect_chain_len", len(via)),
+			errcode.InternalAttr("from_url", from)))
+}
+
+// normalizeIP dewraps an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its 4-byte
+// IPv4 form so the IPv4 blocklist entries match. Non-mapped addresses are
+// returned unchanged. This is the SOLE IPv4-mapped defense — the blocklist
+// deliberately omits ::ffff:0:0/96 (which would be dead after this dewrap, or
+// would over-block public mapped addresses without it).
+func normalizeIP(ip net.IP) net.IP {
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
 }
 
 // ssrfBlockedCIDRStrings is the authoritative SSRF dial-time blocklist and the

--- a/kernel/webhook/ssrf.go
+++ b/kernel/webhook/ssrf.go
@@ -35,7 +35,10 @@ type safeConfig struct {
 	allowLoopback bool
 	resolver      resolver
 	dialer        *net.Dialer
-	blockedNets   []*net.IPNet
+	// blockedNets is the shared, read-only package slice (ssrfBlockedNets).
+	// It must not be mutated through this field — there is no option that
+	// rewrites it, and elements are shared *net.IPNet pointers.
+	blockedNets []*net.IPNet
 }
 
 // SafeOption customizes a SafeDialContext at construction time.
@@ -78,7 +81,7 @@ func (c *safeConfig) dial(ctx context.Context, network, address string) (net.Con
 
 	// IP literal: vet directly, no DNS.
 	if ip := net.ParseIP(host); ip != nil {
-		if verr := c.vet(ip); verr != nil {
+		if verr := c.vet(host, ip); verr != nil {
 			return nil, verr
 		}
 		return c.dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
@@ -96,7 +99,7 @@ func (c *safeConfig) dial(ctx context.Context, network, address string) (net.Con
 			"webhook: dial host resolved to no addresses")
 	}
 	for _, a := range addrs {
-		if verr := c.vet(a.IP); verr != nil {
+		if verr := c.vet(host, a.IP); verr != nil {
 			return nil, verr
 		}
 	}
@@ -106,8 +109,11 @@ func (c *safeConfig) dial(ctx context.Context, network, address string) (net.Con
 
 // vet rejects ip when it falls in any blocked CIDR. The IP is normalized via
 // To4() first so IPv4-mapped IPv6 (::ffff:10.0.0.1) is checked as its embedded
-// IPv4. Loopback is exempted only when allowLoopback is set.
-func (c *safeConfig) vet(ip net.IP) error {
+// IPv4. Loopback is exempted only when allowLoopback is set. host (the dial
+// target before resolution) is recorded server-side for incident triage; the
+// reject "reason" is an Internal (server-only) attribute, never on the wire, so
+// the 403 does not advertise which targets the SSRF policy blocks.
+func (c *safeConfig) vet(host string, ip net.IP) error {
 	norm := normalizeIP(ip)
 	if c.allowLoopback && norm.IsLoopback() {
 		return nil
@@ -116,8 +122,10 @@ func (c *safeConfig) vet(ip net.IP) error {
 		if n.Contains(norm) {
 			return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
 				"webhook: dial target resolved to a blocked address",
-				errcode.WithInternal(errcode.InternalAttr("ip", norm.String())),
-				errcode.WithDetails(errcode.PublicString("reason", "ssrf_blocked")))
+				errcode.WithInternal(
+					errcode.InternalAttr("reason", "ssrf_blocked"),
+					errcode.InternalAttr("host", host),
+					errcode.InternalAttr("ip", norm.String())))
 		}
 	}
 	return nil
@@ -140,9 +148,15 @@ func normalizeIP(ip net.IP) net.IP {
 // Location; webhook delivery is one-shot, so any redirect is rejected
 // (matching Stripe / GitHub webhook delivery semantics).
 func DenyRedirect(_ *http.Request, via []*http.Request) error {
+	from := ""
+	if n := len(via); n > 0 && via[n-1] != nil && via[n-1].URL != nil {
+		from = via[n-1].URL.String()
+	}
 	return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
 		"webhook: redirects are not permitted on outbound delivery",
-		errcode.WithInternal(errcode.InternalAttr("redirect_chain_len", len(via))))
+		errcode.WithInternal(
+			errcode.InternalAttr("redirect_chain_len", len(via)),
+			errcode.InternalAttr("from_url", from)))
 }
 
 // ValidateTargetURL enforces the {http, https} scheme allowlist and rejects a
@@ -159,7 +173,10 @@ func ValidateTargetURL(rawURL string) error {
 	default:
 		return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
 			"webhook: dispatch target scheme is not allowed",
-			errcode.WithDetails(errcode.PublicString("reason", "scheme_not_allowed")))
+			errcode.WithInternal(
+				errcode.InternalAttr("reason", "scheme_not_allowed"),
+				errcode.InternalAttr("scheme", u.Scheme),
+				errcode.InternalAttr("target_host", u.Hostname())))
 	}
 	host := u.Hostname() // strips port and IPv6 brackets
 	if ip := net.ParseIP(host); ip != nil {
@@ -168,7 +185,10 @@ func ValidateTargetURL(rawURL string) error {
 			if n.Contains(norm) {
 				return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
 					"webhook: dispatch target IP literal is blocked",
-					errcode.WithInternal(errcode.InternalAttr("ip", norm.String())))
+					errcode.WithInternal(
+						errcode.InternalAttr("reason", "ssrf_blocked"),
+						errcode.InternalAttr("target_host", host),
+						errcode.InternalAttr("ip", norm.String())))
 			}
 		}
 	}
@@ -198,19 +218,20 @@ var ssrfBlockedCIDRStrings = []string{
 	"240.0.0.0/4",        // reserved
 	"255.255.255.255/32", // limited broadcast
 	// ── IPv6 ──
-	"::/128",        // unspecified
-	"::1/128",       // loopback
-	"64:ff9b::/96",  // RFC6052 NAT64 well-known prefix
-	"100::/64",      // discard-only
-	"2001::/23",     // IETF protocol assignments (incl. Teredo 2001::/32)
-	"2001:2::/48",   // benchmarking
-	"2001:db8::/32", // documentation
-	"2001:10::/28",  // deprecated ORCHID
-	"2001:20::/28",  // ORCHIDv2
-	"2002::/16",     // 6to4
-	"fc00::/7",      // RFC4193 ULA (unique local)
-	"fe80::/10",     // link-local
-	"ff00::/8",      // multicast
+	"::/128",         // unspecified
+	"::1/128",        // loopback
+	"64:ff9b::/96",   // RFC6052 NAT64 well-known prefix
+	"64:ff9b:1::/48", // RFC8215 NAT64 local-use prefix (embeds arbitrary IPv4 incl. private)
+	"100::/64",       // discard-only
+	"2001::/23",      // IETF protocol assignments (incl. Teredo 2001::/32)
+	"2001:2::/48",    // benchmarking
+	"2001:db8::/32",  // documentation
+	"2001:10::/28",   // deprecated ORCHID
+	"2001:20::/28",   // ORCHIDv2
+	"2002::/16",      // 6to4
+	"fc00::/7",       // RFC4193 ULA (unique local)
+	"fe80::/10",      // link-local
+	"ff00::/8",       // multicast
 }
 
 // ssrfBlockedNets is ssrfBlockedCIDRStrings parsed once at package init. A

--- a/kernel/webhook/ssrf_fixtures_test.go
+++ b/kernel/webhook/ssrf_fixtures_test.go
@@ -1,0 +1,99 @@
+package webhook
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// ssrfDenyFixture mirrors testdata/webhook-ssrf-deny.yaml. The fixture is the
+// human-auditable source of truth; ssrfBlockedCIDRStrings (ssrf.go) is the
+// machine source. TestSSRFBlocklistFixtureNoDrift asserts the two are the same
+// set, so a CIDR cannot be added/removed in one without the other.
+type ssrfDenyFixture struct {
+	Blocked struct {
+		IPv4 []ssrfDenyEntry `yaml:"ipv4"`
+		IPv6 []ssrfDenyEntry `yaml:"ipv6"`
+	} `yaml:"blocked"`
+}
+
+type ssrfDenyEntry struct {
+	CIDR   string `yaml:"cidr"`
+	Reason string `yaml:"reason"`
+}
+
+func loadSSRFDenyFixture(t *testing.T) ssrfDenyFixture {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "webhook-ssrf-deny.yaml"))
+	require.NoError(t, err)
+	var doc ssrfDenyFixture
+	require.NoError(t, yaml.Unmarshal(data, &doc))
+	require.NotEmpty(t, doc.Blocked.IPv4)
+	require.NotEmpty(t, doc.Blocked.IPv6)
+	return doc
+}
+
+// TestSSRFBlocklistFixtureNoDrift is the drift guard: the fixture CIDR set and
+// the code CIDR set (ssrfBlockedCIDRStrings) must be exactly equal. The
+// symmetric difference is reported on failure so the offending side is obvious.
+func TestSSRFBlocklistFixtureNoDrift(t *testing.T) {
+	t.Parallel()
+	doc := loadSSRFDenyFixture(t)
+
+	fixtureSet := map[string]struct{}{}
+	for _, e := range append(append([]ssrfDenyEntry{}, doc.Blocked.IPv4...), doc.Blocked.IPv6...) {
+		require.NotContains(t, fixtureSet, e.CIDR, "fixture has duplicate CIDR %q", e.CIDR)
+		fixtureSet[e.CIDR] = struct{}{}
+		require.NotEmpty(t, e.Reason, "fixture CIDR %q missing reason", e.CIDR)
+	}
+
+	codeSet := map[string]struct{}{}
+	for _, c := range ssrfBlockedCIDRStrings {
+		require.NotContains(t, codeSet, c, "ssrfBlockedCIDRStrings has duplicate CIDR %q", c)
+		codeSet[c] = struct{}{}
+	}
+
+	var onlyFixture, onlyCode []string
+	for c := range fixtureSet {
+		if _, ok := codeSet[c]; !ok {
+			onlyFixture = append(onlyFixture, c)
+		}
+	}
+	for c := range codeSet {
+		if _, ok := fixtureSet[c]; !ok {
+			onlyCode = append(onlyCode, c)
+		}
+	}
+	sort.Strings(onlyFixture)
+	sort.Strings(onlyCode)
+	require.Empty(t, onlyFixture, "CIDRs only in fixture (missing from ssrfBlockedCIDRStrings): %v", onlyFixture)
+	require.Empty(t, onlyCode, "CIDRs only in code (missing from webhook-ssrf-deny.yaml): %v", onlyCode)
+}
+
+// TestSSRFBlocklistFixtureParses asserts every fixture CIDR is a valid CIDR
+// literal (so the fixture itself cannot drift into an unparseable form).
+func TestSSRFBlocklistFixtureParses(t *testing.T) {
+	t.Parallel()
+	doc := loadSSRFDenyFixture(t)
+	for _, e := range append(append([]ssrfDenyEntry{}, doc.Blocked.IPv4...), doc.Blocked.IPv6...) {
+		_, _, err := net.ParseCIDR(e.CIDR)
+		require.NoErrorf(t, err, "fixture CIDR %q does not parse", e.CIDR)
+	}
+}
+
+// TestSSRFBlocklistExcludesMappedPrefix locks the deliberate exclusion of
+// ::ffff:0:0/96 (the IPv4-mapped IPv6 prefix). normalizeIP (To4 dewrap) is the
+// single mapped-IPv4 defense; listing the prefix would be a dead/over-blocking
+// double path. See the fixture header + ADR.
+func TestSSRFBlocklistExcludesMappedPrefix(t *testing.T) {
+	t.Parallel()
+	for _, c := range ssrfBlockedCIDRStrings {
+		require.NotEqual(t, "::ffff:0:0/96", c,
+			"::ffff:0:0/96 must NOT be in the blocklist; normalizeIP handles IPv4-mapped")
+	}
+}

--- a/kernel/webhook/ssrf_test.go
+++ b/kernel/webhook/ssrf_test.go
@@ -1,0 +1,243 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// fakeResolver returns a fixed set of addresses regardless of host. It drives
+// the DNS-rebinding tests: a public-looking hostname can be made to "resolve"
+// to a private IP, which the dial-time vet must reject before connecting.
+type fakeResolver struct {
+	addrs []net.IPAddr
+	err   error
+}
+
+func (f fakeResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	return f.addrs, f.err
+}
+
+func ipAddrs(ips ...string) []net.IPAddr {
+	out := make([]net.IPAddr, 0, len(ips))
+	for _, s := range ips {
+		out = append(out, net.IPAddr{IP: net.ParseIP(s)})
+	}
+	return out
+}
+
+// isSSRFBlocked reports whether err carries the ErrWebhookSSRFBlocked code (a
+// KindPermissionDenied → 403 errcode.Error).
+func isSSRFBlocked(t *testing.T, err error) bool {
+	t.Helper()
+	var ec *errcode.Error
+	return errors.As(err, &ec) && ec.Code == errcode.ErrWebhookSSRFBlocked
+}
+
+// canceledContext returns a context that is already canceled, so a dial that
+// passes the SSRF vet fails fast at the transport layer (no real network I/O)
+// rather than hanging on a real connection attempt.
+func canceledContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+// TestSafeDialer_BlocksEveryBlocklistCIDR drives one case per blocklist entry:
+// the network address of each CIDR must be rejected. Driven from
+// ssrfBlockedCIDRStrings so a newly added CIDR is automatically covered.
+func TestSafeDialer_BlocksEveryBlocklistCIDR(t *testing.T) {
+	t.Parallel()
+	dial := NewSafeDialer()
+	for _, cidr := range ssrfBlockedCIDRStrings {
+		host := strings.SplitN(cidr, "/", 2)[0] // network address is contained in the CIDR
+		t.Run(cidr, func(t *testing.T) {
+			t.Parallel()
+			_, err := dial(context.Background(), "tcp", net.JoinHostPort(host, "443"))
+			require.Error(t, err)
+			assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked for %s, got %v", host, err)
+		})
+	}
+}
+
+func TestSafeDialer_IPLiteralCases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		host        string
+		opts        []SafeOption
+		wantBlocked bool
+	}{
+		{name: "cloud_metadata", host: "169.254.169.254", wantBlocked: true},
+		{name: "private_10", host: "10.0.0.5", wantBlocked: true},
+		{name: "loopback_default", host: "127.0.0.1", wantBlocked: true},
+		{name: "ipv6_loopback_default", host: "::1", wantBlocked: true},
+		{name: "ula_v6", host: "fc00::1", wantBlocked: true},
+		{name: "mapped_private", host: "::ffff:10.0.0.1", wantBlocked: true},
+		{name: "mapped_metadata", host: "::ffff:169.254.169.254", wantBlocked: true},
+		// Public addresses pass the vet (and then fail fast on the canceled ctx).
+		{name: "public_v4", host: "8.8.8.8", wantBlocked: false},
+		{name: "public_v4_cloudflare", host: "1.1.1.1", wantBlocked: false},
+		{name: "public_v6", host: "2606:4700::1111", wantBlocked: false},
+		// A PUBLIC IPv4 wrapped as IPv4-mapped IPv6 must NOT be over-blocked —
+		// proves normalizeIP dewraps before the blocklist check (and that we
+		// correctly excluded ::ffff:0:0/96).
+		{name: "mapped_public", host: "::ffff:8.8.8.8", wantBlocked: false},
+		// Loopback opt-in: only loopback is exempted, not other private ranges.
+		{name: "loopback_optin_allowed", host: "127.0.0.1", opts: []SafeOption{WithAllowLoopback()}, wantBlocked: false},
+		{name: "ipv6_loopback_optin_allowed", host: "::1", opts: []SafeOption{WithAllowLoopback()}, wantBlocked: false},
+		{name: "private_still_blocked_with_optin", host: "10.0.0.5", opts: []SafeOption{WithAllowLoopback()}, wantBlocked: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dial := NewSafeDialer(tc.opts...)
+			ctx := context.Background()
+			if !tc.wantBlocked {
+				ctx = canceledContext(t) // got past vet → fail fast, no network
+			}
+			_, err := dial(ctx, "tcp", net.JoinHostPort(tc.host, "443"))
+			require.Error(t, err)
+			if tc.wantBlocked {
+				assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
+			} else {
+				assert.Falsef(t, isSSRFBlocked(t, err), "expected to pass vet (non-SSRF error), got SSRF block: %v", err)
+			}
+		})
+	}
+}
+
+func TestSafeDialer_DNSRebinding(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		resolver    fakeResolver
+		wantBlocked bool
+	}{
+		{
+			name:        "public_name_resolves_private",
+			resolver:    fakeResolver{addrs: ipAddrs("10.0.0.5")},
+			wantBlocked: true,
+		},
+		{
+			name:        "mixed_answers_fail_closed",
+			resolver:    fakeResolver{addrs: ipAddrs("1.1.1.1", "10.0.0.5")},
+			wantBlocked: true,
+		},
+		{
+			name:        "metadata_via_dns",
+			resolver:    fakeResolver{addrs: ipAddrs("169.254.169.254")},
+			wantBlocked: true,
+		},
+		{
+			name:        "all_public_passes_vet",
+			resolver:    fakeResolver{addrs: ipAddrs("93.184.216.34")},
+			wantBlocked: false,
+		},
+		{
+			name:        "resolver_error_fail_closed",
+			resolver:    fakeResolver{err: errors.New("dns boom")},
+			wantBlocked: true,
+		},
+		{
+			name:        "resolver_empty_fail_closed",
+			resolver:    fakeResolver{addrs: nil},
+			wantBlocked: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dial := NewSafeDialer(withResolver(tc.resolver))
+			ctx := context.Background()
+			if !tc.wantBlocked {
+				ctx = canceledContext(t)
+			}
+			_, err := dial(ctx, "tcp", "evil.example.com:443")
+			require.Error(t, err)
+			if tc.wantBlocked {
+				assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
+			} else {
+				assert.Falsef(t, isSSRFBlocked(t, err), "expected to pass vet, got SSRF block: %v", err)
+			}
+		})
+	}
+}
+
+func TestSafeDialer_MalformedAddress(t *testing.T) {
+	t.Parallel()
+	dial := NewSafeDialer()
+	for _, addr := range []string{"noport", "", "[::1", "host:port:extra"} {
+		t.Run(addr, func(t *testing.T) {
+			t.Parallel()
+			_, err := dial(context.Background(), "tcp", addr)
+			require.Error(t, err)
+			assert.Truef(t, isSSRFBlocked(t, err), "malformed address must fail closed as SSRF-blocked, got %v", err)
+		})
+	}
+}
+
+func TestValidateTargetURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{name: "https_ok", rawURL: "https://hooks.example.com/v1", wantErr: false},
+		{name: "http_ok", rawURL: "http://internal-mesh.svc/webhook", wantErr: false},
+		{name: "public_ip_literal_ok", rawURL: "https://8.8.8.8/x", wantErr: false},
+		{name: "ftp_blocked", rawURL: "ftp://x.example.com/f", wantErr: true},
+		{name: "file_blocked", rawURL: "file:///etc/passwd", wantErr: true},
+		{name: "gopher_blocked", rawURL: "gopher://x.example.com/", wantErr: true},
+		{name: "private_ip_literal_blocked", rawURL: "http://10.0.0.1/x", wantErr: true},
+		{name: "metadata_ip_literal_blocked", rawURL: "http://169.254.169.254/latest/meta-data/", wantErr: true},
+		{name: "mapped_private_literal_blocked", rawURL: "http://[::ffff:10.0.0.1]/x", wantErr: true},
+		{name: "unparseable_blocked", rawURL: "ht!tp://\x7f", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateTargetURL(tc.rawURL)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
+		})
+	}
+}
+
+func TestDenyRedirect(t *testing.T) {
+	t.Parallel()
+	req, err := http.NewRequest(http.MethodGet, "https://x.example.com/", nil)
+	require.NoError(t, err)
+
+	rerr := DenyRedirect(req, []*http.Request{req})
+	require.Error(t, rerr)
+	assert.True(t, isSSRFBlocked(t, rerr))
+
+	var ec *errcode.Error
+	require.ErrorAs(t, rerr, &ec)
+	assert.Equal(t, errcode.KindPermissionDenied, ec.Kind)
+	assert.Equal(t, http.StatusForbidden, ec.Status())
+}
+
+// TestNormalizeIP locks the IPv4-mapped dewrap behavior in isolation.
+func TestNormalizeIP(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, net.ParseIP("10.0.0.1").To4(), normalizeIP(net.ParseIP("::ffff:10.0.0.1")))
+	assert.Equal(t, net.ParseIP("8.8.8.8").To4(), normalizeIP(net.ParseIP("8.8.8.8")))
+	v6 := net.ParseIP("2606:4700::1111")
+	assert.Equal(t, v6, normalizeIP(v6))
+}

--- a/kernel/webhook/ssrf_test.go
+++ b/kernel/webhook/ssrf_test.go
@@ -57,12 +57,12 @@ func canceledContext(t *testing.T) context.Context {
 // ssrfBlockedCIDRStrings so a newly added CIDR is automatically covered.
 func TestSafeDialer_BlocksEveryBlocklistCIDR(t *testing.T) {
 	t.Parallel()
-	dial := NewSafeDialer()
+	p := NewSafePolicy()
 	for _, cidr := range ssrfBlockedCIDRStrings {
 		host := strings.SplitN(cidr, "/", 2)[0] // network address is contained in the CIDR
 		t.Run(cidr, func(t *testing.T) {
 			t.Parallel()
-			_, err := dial(context.Background(), "tcp", net.JoinHostPort(host, "443"))
+			_, err := p.DialContext(context.Background(), "tcp", net.JoinHostPort(host, "443"))
 			require.Error(t, err)
 			assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked for %s, got %v", host, err)
 		})
@@ -100,12 +100,12 @@ func TestSafeDialer_IPLiteralCases(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			dial := NewSafeDialer(tc.opts...)
+			p := NewSafePolicy(tc.opts...)
 			ctx := context.Background()
 			if !tc.wantBlocked {
 				ctx = canceledContext(t) // got past vet → fail fast, no network
 			}
-			_, err := dial(ctx, "tcp", net.JoinHostPort(tc.host, "443"))
+			_, err := p.DialContext(ctx, "tcp", net.JoinHostPort(tc.host, "443"))
 			require.Error(t, err)
 			if tc.wantBlocked {
 				assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
@@ -160,12 +160,12 @@ func TestSafeDialer_DNSRebinding(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			dial := NewSafeDialer(withResolver(tc.resolver))
+			p := NewSafePolicy(withResolver(tc.resolver))
 			ctx := context.Background()
 			if !tc.wantBlocked {
 				ctx = canceledContext(t)
 			}
-			_, err := dial(ctx, "tcp", "evil.example.com:443")
+			_, err := p.DialContext(ctx, "tcp", "evil.example.com:443")
 			require.Error(t, err)
 			if tc.wantBlocked {
 				assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
@@ -179,7 +179,7 @@ func TestSafeDialer_DNSRebinding(t *testing.T) {
 
 func TestSafeDialer_MalformedAddress(t *testing.T) {
 	t.Parallel()
-	dial := NewSafeDialer()
+	p := NewSafePolicy()
 	tests := []struct {
 		name string
 		addr string
@@ -192,41 +192,78 @@ func TestSafeDialer_MalformedAddress(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := dial(context.Background(), "tcp", tc.addr)
+			_, err := p.DialContext(context.Background(), "tcp", tc.addr)
 			require.Error(t, err)
 			assert.Truef(t, isSSRFBlocked(t, err), "malformed address must fail closed as SSRF-blocked, got %v", err)
+			assert.Equalf(t, "malformed_address", internalReason(t, err),
+				"malformed address reject must carry stable Internal reason, got %v", err)
 		})
 	}
+}
+
+// internalReason extracts the stable "reason" InternalDetail from an
+// errcode.Error reject path (server-only observability field, never on the
+// wire). Returns "" when absent.
+func internalReason(t *testing.T, err error) string {
+	t.Helper()
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		return ""
+	}
+	for _, d := range ec.InternalDetails {
+		if a := d.AsSlogAttr(); a.Key == "reason" {
+			return a.Value.String()
+		}
+	}
+	return ""
 }
 
 func TestValidateTargetURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name    string
-		rawURL  string
-		wantErr bool
+		name       string
+		rawURL     string
+		opts       []SafeOption
+		wantErr    bool
+		wantReason string // stable Internal "reason" when wantErr (empty = don't assert)
 	}{
 		{name: "https_ok", rawURL: "https://hooks.example.com/v1", wantErr: false},
 		{name: "http_ok", rawURL: "http://internal-mesh.svc/webhook", wantErr: false},
 		{name: "public_ip_literal_ok", rawURL: "https://8.8.8.8/x", wantErr: false},
-		{name: "ftp_blocked", rawURL: "ftp://x.example.com/f", wantErr: true},
-		{name: "file_blocked", rawURL: "file:///etc/passwd", wantErr: true},
-		{name: "gopher_blocked", rawURL: "gopher://x.example.com/", wantErr: true},
-		{name: "private_ip_literal_blocked", rawURL: "http://10.0.0.1/x", wantErr: true},
-		{name: "metadata_ip_literal_blocked", rawURL: "http://169.254.169.254/latest/meta-data/", wantErr: true},
-		{name: "mapped_private_literal_blocked", rawURL: "http://[::ffff:10.0.0.1]/x", wantErr: true},
-		{name: "unparseable_blocked", rawURL: "ht!tp://\x7f", wantErr: true},
+		{name: "ftp_blocked", rawURL: "ftp://x.example.com/f", wantErr: true, wantReason: "scheme_not_allowed"},
+		{name: "file_blocked", rawURL: "file:///etc/passwd", wantErr: true, wantReason: "scheme_not_allowed"},
+		{name: "gopher_blocked", rawURL: "gopher://x.example.com/", wantErr: true, wantReason: "scheme_not_allowed"},
+		{name: "private_ip_literal_blocked", rawURL: "http://10.0.0.1/x", wantErr: true, wantReason: "ssrf_blocked"},
+		{name: "metadata_ip_literal_blocked", rawURL: "http://169.254.169.254/latest/meta-data/", wantErr: true, wantReason: "ssrf_blocked"},
+		{name: "mapped_private_literal_blocked", rawURL: "http://[::ffff:10.0.0.1]/x", wantErr: true, wantReason: "ssrf_blocked"},
+		{name: "unparseable_blocked", rawURL: "ht!tp://\x7f", wantErr: true, wantReason: "unparseable"},
+		// F1: an empty host (http:///x) is un-vettable → fail closed, not silently OK.
+		{name: "empty_host_blocked", rawURL: "http:///x", wantErr: true, wantReason: "empty_host"},
+		// F2: loopback exemption is policy-coherent — the pre-flight honors
+		// WithAllowLoopback exactly as the dial does, instead of rejecting a
+		// literal loopback the dialer is configured to allow.
+		{name: "loopback_literal_blocked_default", rawURL: "http://127.0.0.1:8080/", wantErr: true, wantReason: "ssrf_blocked"},
+		{name: "loopback_literal_ok_with_optin", rawURL: "http://127.0.0.1:8080/", opts: []SafeOption{WithAllowLoopback()}, wantErr: false},
+		{name: "ipv6_loopback_ok_with_optin", rawURL: "http://[::1]:8080/", opts: []SafeOption{WithAllowLoopback()}, wantErr: false},
+		{
+			name: "private_still_blocked_with_optin", rawURL: "http://10.0.0.1/x",
+			opts: []SafeOption{WithAllowLoopback()}, wantErr: true, wantReason: "ssrf_blocked",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := ValidateTargetURL(tc.rawURL)
+			err := NewSafePolicy(tc.opts...).ValidateTargetURL(tc.rawURL)
 			if !tc.wantErr {
 				require.NoError(t, err)
 				return
 			}
 			require.Error(t, err)
 			assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
+			if tc.wantReason != "" {
+				assert.Equalf(t, tc.wantReason, internalReason(t, err),
+					"reject must carry stable Internal reason, got %v", err)
+			}
 		})
 	}
 }
@@ -251,9 +288,10 @@ func TestDenyRedirect(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			rerr := DenyRedirect(req, tc.via)
+			rerr := NewSafePolicy().DenyRedirect(req, tc.via)
 			require.Error(t, rerr)
 			assert.True(t, isSSRFBlocked(t, rerr))
+			assert.Equal(t, "redirect_denied", internalReason(t, rerr))
 
 			var ec *errcode.Error
 			require.ErrorAs(t, rerr, &ec)

--- a/kernel/webhook/ssrf_test.go
+++ b/kernel/webhook/ssrf_test.go
@@ -110,7 +110,10 @@ func TestSafeDialer_IPLiteralCases(t *testing.T) {
 			if tc.wantBlocked {
 				assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
 			} else {
+				// Passed the vet → the only error is the canceled-ctx dial,
+				// proving rejection happened at the transport, not the guard.
 				assert.Falsef(t, isSSRFBlocked(t, err), "expected to pass vet (non-SSRF error), got SSRF block: %v", err)
+				assert.ErrorIsf(t, err, context.Canceled, "expected canceled-ctx dial error after vet, got %v", err)
 			}
 		})
 	}
@@ -168,6 +171,7 @@ func TestSafeDialer_DNSRebinding(t *testing.T) {
 				assert.Truef(t, isSSRFBlocked(t, err), "expected SSRF-blocked, got %v", err)
 			} else {
 				assert.Falsef(t, isSSRFBlocked(t, err), "expected to pass vet, got SSRF block: %v", err)
+				assert.ErrorIsf(t, err, context.Canceled, "expected canceled-ctx dial error after vet, got %v", err)
 			}
 		})
 	}
@@ -176,10 +180,19 @@ func TestSafeDialer_DNSRebinding(t *testing.T) {
 func TestSafeDialer_MalformedAddress(t *testing.T) {
 	t.Parallel()
 	dial := NewSafeDialer()
-	for _, addr := range []string{"noport", "", "[::1", "host:port:extra"} {
-		t.Run(addr, func(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+	}{
+		{name: "no_port", addr: "noport"},
+		{name: "empty", addr: ""},
+		{name: "unterminated_v6", addr: "[::1"},
+		{name: "extra_colon", addr: "host:port:extra"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := dial(context.Background(), "tcp", addr)
+			_, err := dial(context.Background(), "tcp", tc.addr)
 			require.Error(t, err)
 			assert.Truef(t, isSSRFBlocked(t, err), "malformed address must fail closed as SSRF-blocked, got %v", err)
 		})
@@ -222,15 +235,32 @@ func TestDenyRedirect(t *testing.T) {
 	t.Parallel()
 	req, err := http.NewRequest(http.MethodGet, "https://x.example.com/", nil)
 	require.NoError(t, err)
+	req2, err := http.NewRequest(http.MethodGet, "https://y.example.com/", nil)
+	require.NoError(t, err)
 
-	rerr := DenyRedirect(req, []*http.Request{req})
-	require.Error(t, rerr)
-	assert.True(t, isSSRFBlocked(t, rerr))
+	// DenyRedirect must fail closed for any via chain — single, multi, and the
+	// nil/empty first-redirect form net/http may pass.
+	for _, tc := range []struct {
+		name string
+		via  []*http.Request
+	}{
+		{name: "single", via: []*http.Request{req}},
+		{name: "multi", via: []*http.Request{req, req2}},
+		{name: "empty", via: []*http.Request{}},
+		{name: "nil", via: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rerr := DenyRedirect(req, tc.via)
+			require.Error(t, rerr)
+			assert.True(t, isSSRFBlocked(t, rerr))
 
-	var ec *errcode.Error
-	require.ErrorAs(t, rerr, &ec)
-	assert.Equal(t, errcode.KindPermissionDenied, ec.Kind)
-	assert.Equal(t, http.StatusForbidden, ec.Status())
+			var ec *errcode.Error
+			require.ErrorAs(t, rerr, &ec)
+			assert.Equal(t, errcode.KindPermissionDenied, ec.Kind)
+			assert.Equal(t, http.StatusForbidden, ec.Status())
+		})
+	}
 }
 
 // TestNormalizeIP locks the IPv4-mapped dewrap behavior in isolation.

--- a/kernel/webhook/testdata/webhook-ssrf-deny.yaml
+++ b/kernel/webhook/testdata/webhook-ssrf-deny.yaml
@@ -1,0 +1,46 @@
+# SSRF dial-time blocklist — single source of truth.
+#
+# ssrf_fixtures_test.go asserts this set is EXACTLY equal (as a set) to
+# ssrfBlockedCIDRStrings in ssrf.go. Adding/removing a CIDR in code without
+# mirroring it here (or vice-versa) fails the drift guard.
+#
+# IPv4-mapped IPv6 (::ffff:0:0/96) is deliberately ABSENT: the dial-time vet
+# normalizes every IP via net.IP.To4() before the Contains check, so a mapped
+# private address (::ffff:10.0.0.1) is dewrapped to 10.0.0.1 and caught by
+# 10.0.0.0/8, while a mapped public address (::ffff:8.8.8.8) is correctly
+# allowed. Listing ::ffff:0:0/96 would be a dead entry (unreachable after To4)
+# or, without normalization, would wrongly block public mapped addresses.
+#
+# Source superset: doyensec/safeurl ip.go privateNetworks (IETF reserved ranges).
+blocked:
+  ipv4:
+    - { cidr: "0.0.0.0/8",       reason: "unspecified / this-host" }
+    - { cidr: "10.0.0.0/8",      reason: "rfc1918-private" }
+    - { cidr: "100.64.0.0/10",   reason: "rfc6598-cgnat" }
+    - { cidr: "127.0.0.0/8",     reason: "loopback" }
+    - { cidr: "169.254.0.0/16",  reason: "link-local-incl-cloud-metadata-169.254.169.254" }
+    - { cidr: "172.16.0.0/12",   reason: "rfc1918-private" }
+    - { cidr: "192.0.0.0/24",    reason: "ietf-protocol-assignments" }
+    - { cidr: "192.0.2.0/24",    reason: "test-net-1-documentation" }
+    - { cidr: "192.88.99.0/24",  reason: "6to4-relay-anycast" }
+    - { cidr: "192.168.0.0/16",  reason: "rfc1918-private" }
+    - { cidr: "198.18.0.0/15",   reason: "benchmarking" }
+    - { cidr: "198.51.100.0/24", reason: "test-net-2-documentation" }
+    - { cidr: "203.0.113.0/24",  reason: "test-net-3-documentation" }
+    - { cidr: "224.0.0.0/4",     reason: "multicast" }
+    - { cidr: "240.0.0.0/4",     reason: "reserved" }
+    - { cidr: "255.255.255.255/32", reason: "limited-broadcast" }
+  ipv6:
+    - { cidr: "::/128",          reason: "unspecified" }
+    - { cidr: "::1/128",         reason: "loopback" }
+    - { cidr: "64:ff9b::/96",    reason: "rfc6052-nat64" }
+    - { cidr: "100::/64",        reason: "discard-only" }
+    - { cidr: "2001::/23",       reason: "ietf-protocol-assignments-incl-teredo" }
+    - { cidr: "2001:2::/48",     reason: "benchmarking" }
+    - { cidr: "2001:db8::/32",   reason: "documentation" }
+    - { cidr: "2001:10::/28",    reason: "deprecated-orchid" }
+    - { cidr: "2001:20::/28",    reason: "orchidv2" }
+    - { cidr: "2002::/16",       reason: "6to4" }
+    - { cidr: "fc00::/7",        reason: "rfc4193-ula" }
+    - { cidr: "fe80::/10",       reason: "link-local" }
+    - { cidr: "ff00::/8",        reason: "multicast" }

--- a/kernel/webhook/testdata/webhook-ssrf-deny.yaml
+++ b/kernel/webhook/testdata/webhook-ssrf-deny.yaml
@@ -33,7 +33,8 @@ blocked:
   ipv6:
     - { cidr: "::/128",          reason: "unspecified" }
     - { cidr: "::1/128",         reason: "loopback" }
-    - { cidr: "64:ff9b::/96",    reason: "rfc6052-nat64" }
+    - { cidr: "64:ff9b::/96",    reason: "rfc6052-nat64-well-known" }
+    - { cidr: "64:ff9b:1::/48",  reason: "rfc8215-nat64-local-use" }
     - { cidr: "100::/64",        reason: "discard-only" }
     - { cidr: "2001::/23",       reason: "ietf-protocol-assignments-incl-teredo" }
     - { cidr: "2001:2::/48",     reason: "benchmarking" }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -176,7 +176,7 @@ sonar.coverage.exclusions=\
 # go:S117  — Go naming allows abbreviations like dbURL, httpReq
 # go:S1192 — Table-driven tests intentionally repeat string literals for readability
 # go:S1186 — Empty func(){} in test tables are idiomatic Go noop handlers
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55,e56
 
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S100
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
@@ -622,3 +622,16 @@ sonar.issue.ignore.multicriteria.e54.resourceKey=**/runtime/bootstrap/lifecycle.
 #            joined with the heartbeat goroutine.
 sonar.issue.ignore.multicriteria.e55.ruleKey=godre:S8188
 sonar.issue.ignore.multicriteria.e55.resourceKey=**/runtime/saga/executor/executor.go
+
+# go:S1313 — kernel/webhook/ssrf.go ssrfBlockedCIDRStrings is a deliberate SSRF
+#            dial-time blocklist: every entry is a hardcoded reserved/private
+#            CIDR by design (RFC1918 / loopback / link-local / CGNAT / NAT64 /
+#            multicast / documentation, etc.). The "is this hardcoded IP safe"
+#            hotspot is inverted here — enumerating the unsafe ranges IS the
+#            security control. The list is cross-checked against
+#            testdata/webhook-ssrf-deny.yaml by a drift guard and documented in
+#            ADR 202605312300-1159-adr-webhook-ssrf-policy.md. Same false-positive
+#            justification as e9 (S1313 in test fixtures), scoped to the one
+#            production file that owns the blocklist.
+sonar.issue.ignore.multicriteria.e56.ruleKey=go:S1313
+sonar.issue.ignore.multicriteria.e56.resourceKey=**/kernel/webhook/ssrf.go

--- a/tools/archtest/testdata/webhook_ssrf_violate/go.mod
+++ b/tools/archtest/testdata/webhook_ssrf_violate/go.mod
@@ -1,0 +1,7 @@
+module fixturetest/webhook_ssrf_violate
+
+go 1.25.10
+
+replace github.com/ghbvf/gocell => ../../../..
+
+require github.com/ghbvf/gocell v0.0.0

--- a/tools/archtest/testdata/webhook_ssrf_violate/violations.go
+++ b/tools/archtest/testdata/webhook_ssrf_violate/violations.go
@@ -10,15 +10,35 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"time"
 )
 
-// ── A1 violations: net package dial-family functions ─────────────────────────
+// ── A1 violations: every net package dial-family function in the banned set ──
+// One callsite per banned func so the reverse self-test asserts each is caught
+// (a regression deleting any one entry from the banned set would fail the ≥6
+// assertion).
 func dialViaNetDial(ctx context.Context) (net.Conn, error) {
 	return net.Dial("tcp", "10.0.0.1:80") // VIOLATION A1 (net.Dial)
 }
 
 func dialViaDialTCP() (net.Conn, error) {
 	return net.DialTCP("tcp", nil, &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 80}) // VIOLATION A1 (net.DialTCP)
+}
+
+func dialViaDialUDP() (net.Conn, error) {
+	return net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 80}) // VIOLATION A1 (net.DialUDP)
+}
+
+func dialViaDialIP() (net.Conn, error) {
+	return net.DialIP("ip4:icmp", nil, &net.IPAddr{IP: net.ParseIP("10.0.0.1")}) // VIOLATION A1 (net.DialIP)
+}
+
+func dialViaDialUnix() (net.Conn, error) {
+	return net.DialUnix("unix", nil, &net.UnixAddr{Name: "/tmp/x.sock", Net: "unix"}) // VIOLATION A1 (net.DialUnix)
+}
+
+func dialViaDialTimeout() (net.Conn, error) {
+	return net.DialTimeout("tcp", "10.0.0.1:80", time.Second) // VIOLATION A1 (net.DialTimeout)
 }
 
 // ── A2 violation: raw net.Dialer.DialContext outside ssrf.go dial() ──────────

--- a/tools/archtest/testdata/webhook_ssrf_violate/violations.go
+++ b/tools/archtest/testdata/webhook_ssrf_violate/violations.go
@@ -56,6 +56,18 @@ func fetchViaGet() (*http.Response, error) {
 	return http.Get("http://10.0.0.1/") // VIOLATION A3 (http.Get)
 }
 
+func fetchViaPost() (*http.Response, error) {
+	return http.Post("http://10.0.0.1/", "application/json", http.NoBody) // VIOLATION A3 (http.Post)
+}
+
+func fetchViaPostForm() (*http.Response, error) {
+	return http.PostForm("http://10.0.0.1/", nil) // VIOLATION A3 (http.PostForm)
+}
+
+func fetchViaHead() (*http.Response, error) {
+	return http.Head("http://10.0.0.1/") // VIOLATION A3 (http.Head)
+}
+
 func transportRef() http.RoundTripper {
 	return http.DefaultTransport // VIOLATION A3 (http.DefaultTransport)
 }

--- a/tools/archtest/testdata/webhook_ssrf_violate/violations.go
+++ b/tools/archtest/testdata/webhook_ssrf_violate/violations.go
@@ -1,0 +1,41 @@
+// Package webhook_ssrf_violate is a synthetic violation fixture for the
+// WEBHOOK-SSRF-GUARD-01 archtest rule. Each violation form is exercised once so
+// the reverse self-test (TestWebhookSSRFGuard_ReverseFixture) can assert the
+// corresponding sub-rule fires.
+//
+// DO NOT use this package in production code.
+package webhook_ssrf_violate
+
+import (
+	"context"
+	"net"
+	"net/http"
+)
+
+// ── A1 violations: net package dial-family functions ─────────────────────────
+func dialViaNetDial(ctx context.Context) (net.Conn, error) {
+	return net.Dial("tcp", "10.0.0.1:80") // VIOLATION A1 (net.Dial)
+}
+
+func dialViaDialTCP() (net.Conn, error) {
+	return net.DialTCP("tcp", nil, &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 80}) // VIOLATION A1 (net.DialTCP)
+}
+
+// ── A2 violation: raw net.Dialer.DialContext outside ssrf.go dial() ──────────
+func dialViaRawDialer(ctx context.Context) (net.Conn, error) {
+	d := &net.Dialer{}
+	return d.DialContext(ctx, "tcp", "10.0.0.1:80") // VIOLATION A2 (un-vetted dialer)
+}
+
+// ── A3 violations: net/http global client / transport / convenience funcs ────
+func fetchViaDefaultClient(req *http.Request) (*http.Response, error) {
+	return http.DefaultClient.Do(req) // VIOLATION A3 (http.DefaultClient)
+}
+
+func fetchViaGet() (*http.Response, error) {
+	return http.Get("http://10.0.0.1/") // VIOLATION A3 (http.Get)
+}
+
+func transportRef() http.RoundTripper {
+	return http.DefaultTransport // VIOLATION A3 (http.DefaultTransport)
+}

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -242,7 +242,8 @@ func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
 			return nil
 		})
 
-	assert.GreaterOrEqual(t, len(a1), 2, "A1 reverse fixture: expected ≥2 net.Dial* diagnostics (net.Dial + net.DialTCP)")
+	assert.GreaterOrEqual(t, len(a1), len(ssrfBannedNetDialFuncs),
+		"A1 reverse fixture: expected one diagnostic per banned net.Dial* func (Dial/DialTCP/DialUDP/DialIP/DialUnix/DialTimeout)")
 	assert.GreaterOrEqual(t, len(a2), 1, "A2 reverse fixture: expected ≥1 raw net.Dialer.DialContext diagnostic")
 	assert.GreaterOrEqual(t, len(a3), 2, "A3 reverse fixture: expected ≥2 http global diagnostics")
 }

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -37,7 +37,7 @@
 //	  system; package visibility only constrains implementers, not who may
 //	  declare a field of a type. This is the same permanent ceiling as
 //	  SPAN-SETATTR-HOLDER-SEAL (#851) / HEALTHZ-HOLDER-SEAL (#893). Tracked
-//	  won't-do: gh #1431. The PR-5 Dispatcher.client typed-field lock is the
+//	  won't-do: gh #1375. The PR-5 Dispatcher.client typed-field lock is the
 //	  dispatcher-specific single-sanctioned-holder Hard that complements this
 //	  package-level ban.
 //
@@ -69,7 +69,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -192,7 +192,7 @@ func TestWebhookSSRFGuard(t *testing.T) {
 	var a1, a2, a3 []Diagnostic
 	_ = RunTyped(t, TypedOpts{Tests: false}, []string{webhookPkgPattern},
 		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil || p.Pkg.Path() != "github.com/ghbvf/gocell/kernel/webhook" {
+			if p.Pkg == nil || p.Pkg.Path() != PlatformModulePath+"/kernel/webhook" {
 				return nil
 			}
 			for _, f := range p.Files {

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -2,25 +2,29 @@
 //
 // WEBHOOK-SSRF-GUARD-01 — kernel/webhook outbound network funnel (KERNEL-WEBHOOK-01).
 //
-// PR-4 ships the pure SSRF building block (SafeDialContext). The dispatcher
-// that holds the SSRF-wrapped *http.Client is PR-5; the Dispatcher.client
-// typed-field upstream lock is therefore deferred to PR-5 (the struct does not
-// exist yet — a field scan now would pass vacuously). This invariant locks the
-// package-level callsite bans that ARE meaningful for a pure building block:
-// any outbound network primitive in kernel/webhook must funnel through the
-// vetted dialer, so PR-5 cannot wire an un-vetted egress path.
+// PR-4 ships the pure SSRF building block: SafePolicy, the single-source policy
+// whose DialContext / ValidateTargetURL / DenyRedirect methods share one config.
+// The dispatcher that HOLDS the *SafePolicy and wires its methods into an
+// *http.Client is PR-5; the Dispatcher.client typed-field upstream lock is
+// therefore deferred to PR-5 (the struct does not exist yet — a field scan now
+// would pass vacuously). This invariant locks the package-level callsite bans
+// that ARE meaningful for a pure building block: any outbound network primitive
+// in kernel/webhook must funnel through the vetted dialer, so PR-5 cannot wire
+// an un-vetted egress path.
 //
 //   - A1 (downstream Hard): the net package dial-family FUNCTIONS
 //     (net.Dial / DialTCP / DialUDP / DialIP / DialUnix / DialTimeout) are
 //     banned anywhere in kernel/webhook production code. Detection:
 //     ResolvePackageRef(callee) == ("net", <dial-func>).
-//   - A2 (downstream Hard): the net.Dialer.DialContext METHOD has exactly one
-//     callsite — the dial function in ssrf.go (the sanctioned vetted dialer).
-//     A DialContext on any net.Dialer anywhere else fails. This is the
-//     callsite-uniqueness lock analogous to computeMAC/hmac.New: a rogue raw
-//     net.Dialer{}.DialContext would bypass the IP vet. Detection:
-//     ResolveMethodCall(sel) == net.DialContext AND (basename != ssrf.go OR
-//     enclosing func != dial).
+//   - A2 (downstream Hard): the net.Dialer.DialContext METHOD may be called
+//     ONLY from inside (*SafePolicy).DialContext — the sanctioned vetted dialer
+//     (which legitimately has two callsites: the IP-literal and the
+//     resolved-hostname dial). The allowance binds to the go/types FullName
+//     identity of the enclosing func, not its name or file, so a rogue func
+//     that merely shares the name cannot inherit it and the method may move
+//     files freely. A raw net.Dialer{}.DialContext anywhere else bypasses the
+//     IP vet and fails. Detection: ResolveMethodCall(sel) == net.DialContext
+//     AND enclosing-func FullName != (*SafePolicy).DialContext.
 //   - A3 (downstream Hard): the global HTTP client/transport in net/http —
 //     http.DefaultClient / http.DefaultTransport (package vars) and the
 //     convenience callees http.Get / Post / PostForm / Head — are banned in
@@ -31,13 +35,15 @@
 //
 //	下游 Hard — A1/A2/A3 are form-unique, type-resolved callsite bans
 //	  (ResolvePackageRef / ResolveMethodCall resolve import aliases and
-//	  value-refs; there is no "looks-like" grey zone).
-//	上游 Medium = Go 永久天花板 — the holder axis ("only NewSafeDialer may
-//	  produce a dialer that a struct holds") is inexpressible in Go's type
+//	  value-refs; A2 binds the allowance to a go/types FullName method identity,
+//	  not a name or filename — there is no "looks-like" grey zone).
+//	上游 Medium = Go 永久天花板 — the holder axis ("only a *SafePolicy a
+//	  dispatcher holds may produce egress") is inexpressible in Go's type
 //	  system; package visibility only constrains implementers, not who may
 //	  declare a field of a type. This is the same permanent ceiling as
 //	  SPAN-SETATTR-HOLDER-SEAL (#851) / HEALTHZ-HOLDER-SEAL (#893). Tracked
-//	  won't-do: gh #1375. The PR-5 Dispatcher.client typed-field lock is the
+//	  won't-do: gh #1375. The PR-5 Dispatcher.client typed-field lock — now a
+//	  single *SafePolicy field rather than three free funcs — is the
 //	  dispatcher-specific single-sanctioned-holder Hard that complements this
 //	  package-level ban.
 //
@@ -72,10 +78,17 @@ import (
 )
 
 const (
-	ssrfFileBasename = "ssrf.go"
-	ssrfDialFuncName = "dial"
-	ssrfNetPkgPath   = "net"
-	ssrfHTTPPkgPath  = "net/http"
+	ssrfNetPkgPath  = "net"
+	ssrfHTTPPkgPath = "net/http"
+	// ssrfSanctionedDialFunc is the go/types canonical FullName of the ONE
+	// method allowed to call net.Dialer.DialContext: (*SafePolicy).DialContext.
+	// Binding the A2 allowance to this type-resolved identity (not a func name
+	// or a filename) means a stray func that merely shares the name "dial" /
+	// "DialContext" elsewhere cannot inherit the allowance, and the sanctioned
+	// method can move files freely. A rename of the method flips every
+	// DialContext callsite to a violation (fail-closed), forcing the author to
+	// update this const in the same change.
+	ssrfSanctionedDialFunc = "(*" + PlatformModulePath + "/kernel/webhook.SafePolicy).DialContext"
 )
 
 // ssrfBannedNetDialFuncs is the A1 banned set: net package functions that open
@@ -124,10 +137,10 @@ func scanSSRFNetDial(fset *token.FileSet, file *ast.File, rel string, info *type
 }
 
 // scanSSRFDialerDialContext implements A2: net.Dialer.DialContext may be called
-// only inside the dial function of ssrf.go (callsite uniqueness).
+// only from inside the (*SafePolicy).DialContext method (callsite identity,
+// resolved via go/types FullName — file- and name-independent).
 func scanSSRFDialerDialContext(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
-	inSSRFFile := filepath.Base(filepath.ToSlash(rel)) == ssrfFileBasename
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if !ok {
@@ -137,16 +150,14 @@ func scanSSRFDialerDialContext(fset *token.FileSet, file *ast.File, rel string, 
 		if !ok || fn == nil || fn.Pkg() == nil || fn.Pkg().Path() != ssrfNetPkgPath || fn.Name() != "DialContext" {
 			return
 		}
-		if inSSRFFile {
-			if enc, ok := ResolveEnclosingFunc(info, file, call); ok && enc != nil && enc.Name() == ssrfDialFuncName {
-				return
-			}
+		if enc, ok := ResolveEnclosingFunc(info, file, call); ok && enc != nil && enc.FullName() == ssrfSanctionedDialFunc {
+			return
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
 			Line: fset.Position(call.Pos()).Line,
-			Message: "net.Dialer.DialContext called outside ssrf.go dial(); the vetted dialer is the " +
-				"sole sanctioned outbound callsite (WEBHOOK-SSRF-GUARD-01/A2)",
+			Message: "net.Dialer.DialContext called outside (*SafePolicy).DialContext; the vetted dialer is " +
+				"the sole sanctioned outbound callsite (WEBHOOK-SSRF-GUARD-01/A2)",
 		})
 	})
 	return out
@@ -245,5 +256,9 @@ func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
 	assert.GreaterOrEqual(t, len(a1), len(ssrfBannedNetDialFuncs),
 		"A1 reverse fixture: expected one diagnostic per banned net.Dial* func (Dial/DialTCP/DialUDP/DialIP/DialUnix/DialTimeout)")
 	assert.GreaterOrEqual(t, len(a2), 1, "A2 reverse fixture: expected ≥1 raw net.Dialer.DialContext diagnostic")
-	assert.GreaterOrEqual(t, len(a3), 2, "A3 reverse fixture: expected ≥2 http global diagnostics")
+	// Cover the FULL A3 banned set — both globals (DefaultClient/DefaultTransport)
+	// AND every convenience callee (Get/Post/PostForm/Head) — so dropping any one
+	// banned entry fails this self-test instead of passing on the others.
+	assert.GreaterOrEqual(t, len(a3), len(ssrfBannedHTTPGlobals)+len(ssrfBannedHTTPCallees),
+		"A3 reverse fixture: expected one diagnostic per banned http global + convenience func")
 }

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -1,0 +1,249 @@
+// INVARIANT: WEBHOOK-SSRF-GUARD-01
+//
+// WEBHOOK-SSRF-GUARD-01 — kernel/webhook outbound network funnel (KERNEL-WEBHOOK-01).
+//
+// PR-4 ships the pure SSRF building block (SafeDialContext). The dispatcher
+// that holds the SSRF-wrapped *http.Client is PR-5; the Dispatcher.client
+// typed-field upstream lock is therefore deferred to PR-5 (the struct does not
+// exist yet — a field scan now would pass vacuously). This invariant locks the
+// package-level callsite bans that ARE meaningful for a pure building block:
+// any outbound network primitive in kernel/webhook must funnel through the
+// vetted dialer, so PR-5 cannot wire an un-vetted egress path.
+//
+//   - A1 (downstream Hard): the net package dial-family FUNCTIONS
+//     (net.Dial / DialTCP / DialUDP / DialIP / DialUnix / DialTimeout) are
+//     banned anywhere in kernel/webhook production code. Detection:
+//     ResolvePackageRef(callee) == ("net", <dial-func>).
+//   - A2 (downstream Hard): the net.Dialer.DialContext METHOD has exactly one
+//     callsite — the dial function in ssrf.go (the sanctioned vetted dialer).
+//     A DialContext on any net.Dialer anywhere else fails. This is the
+//     callsite-uniqueness lock analogous to computeMAC/hmac.New: a rogue raw
+//     net.Dialer{}.DialContext would bypass the IP vet. Detection:
+//     ResolveMethodCall(sel) == net.DialContext AND (basename != ssrf.go OR
+//     enclosing func != dial).
+//   - A3 (downstream Hard): the global HTTP client/transport in net/http —
+//     http.DefaultClient / http.DefaultTransport (package vars) and the
+//     convenience callees http.Get / Post / PostForm / Head — are banned in
+//     kernel/webhook; they bypass the SSRF-wrapped transport. Detection:
+//     ResolvePackageRef → ("net/http", <global|callee>).
+//
+// AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
+//
+//	下游 Hard — A1/A2/A3 are form-unique, type-resolved callsite bans
+//	  (ResolvePackageRef / ResolveMethodCall resolve import aliases and
+//	  value-refs; there is no "looks-like" grey zone).
+//	上游 Medium = Go 永久天花板 — the holder axis ("only NewSafeDialer may
+//	  produce a dialer that a struct holds") is inexpressible in Go's type
+//	  system; package visibility only constrains implementers, not who may
+//	  declare a field of a type. This is the same permanent ceiling as
+//	  SPAN-SETATTR-HOLDER-SEAL (#851) / HEALTHZ-HOLDER-SEAL (#893). Tracked
+//	  won't-do: gh #1431. The PR-5 Dispatcher.client typed-field lock is the
+//	  dispatcher-specific single-sanctioned-holder Hard that complements this
+//	  package-level ban.
+//
+// Blind spots (ai-robust 强制反向自检; reverse fixture below):
+//
+//	B-A1/A2/A3 — rule-logic regression: testdata/webhook_ssrf_violate exercises
+//	  net.Dial + net.DialTCP (A1), a raw net.Dialer{}.DialContext (A2), and
+//	  http.DefaultClient.Do + http.Get + http.DefaultTransport (A3);
+//	  TestWebhookSSRFGuard_ReverseFixture asserts each sub-rule fires.
+//	B1 — http.Transport.RoundTrip direct call: a hand-rolled Transport whose
+//	  DialContext is NOT the SafeDialContext, invoked via RoundTrip, bypasses
+//	  the funnel. RoundTrip is a method with no resolvable package-callee form
+//	  that distinguishes a safe vs unsafe transport; catching it needs
+//	  type-level dataflow we do not have. Bounded response: the realistic
+//	  egress path is http.Client.Do over the SSRF transport, locked when the
+//	  dispatcher lands in PR-5; documented here so a reviewer knows the AST scan
+//	  does not cover raw Transport.RoundTrip.
+//
+// ref: docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
+// ref: tools/archtest/webhook_hmac_funnel_test.go (callsite-allowlist template)
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ssrfFileBasename = "ssrf.go"
+	ssrfDialFuncName = "dial"
+	ssrfNetPkgPath   = "net"
+	ssrfHTTPPkgPath  = "net/http"
+)
+
+// ssrfBannedNetDialFuncs is the A1 banned set: net package functions that open
+// a connection without the SSRF vet. The sanctioned path is the
+// net.Dialer.DialContext METHOD inside ssrf.go (A2), not any of these.
+var ssrfBannedNetDialFuncs = map[string]bool{
+	"Dial":        true,
+	"DialTCP":     true,
+	"DialUDP":     true,
+	"DialIP":      true,
+	"DialUnix":    true,
+	"DialTimeout": true,
+}
+
+// ssrfBannedHTTPGlobals is the A3 banned package-var set (global client /
+// transport that skips the SSRF-wrapped transport).
+var ssrfBannedHTTPGlobals = map[string]bool{
+	"DefaultClient":    true,
+	"DefaultTransport": true,
+}
+
+// ssrfBannedHTTPCallees is the A3 banned convenience-function set.
+var ssrfBannedHTTPCallees = map[string]bool{
+	"Get":      true,
+	"Post":     true,
+	"PostForm": true,
+	"Head":     true,
+}
+
+// scanSSRFNetDial implements A1: net.Dial* package functions are banned.
+func scanSSRFNetDial(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != ssrfNetPkgPath || !ssrfBannedNetDialFuncs[name] {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "net." + name + " called in kernel/webhook; outbound dial must funnel through " +
+				"NewSafeDialer / SafeDialContext (WEBHOOK-SSRF-GUARD-01/A1)",
+		})
+	})
+	return out
+}
+
+// scanSSRFDialerDialContext implements A2: net.Dialer.DialContext may be called
+// only inside the dial function of ssrf.go (callsite uniqueness).
+func scanSSRFDialerDialContext(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	inSSRFFile := filepath.Base(filepath.ToSlash(rel)) == ssrfFileBasename
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		fn, ok := ResolveMethodCall(info, sel)
+		if !ok || fn == nil || fn.Pkg() == nil || fn.Pkg().Path() != ssrfNetPkgPath || fn.Name() != "DialContext" {
+			return
+		}
+		if inSSRFFile {
+			if enc, ok := ResolveEnclosingFunc(info, file, call); ok && enc != nil && enc.Name() == ssrfDialFuncName {
+				return
+			}
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "net.Dialer.DialContext called outside ssrf.go dial(); the vetted dialer is the " +
+				"sole sanctioned outbound callsite (WEBHOOK-SSRF-GUARD-01/A2)",
+		})
+	})
+	return out
+}
+
+// scanSSRFHTTPGlobal implements A3: net/http global client/transport vars and
+// convenience funcs are banned in kernel/webhook.
+func scanSSRFHTTPGlobal(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, sel)
+		if !ok || pkgPath != ssrfHTTPPkgPath || !ssrfBannedHTTPGlobals[name] {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(sel.Pos()).Line,
+			Message: "http." + name + " referenced in kernel/webhook; use an SSRF-wrapped *http.Client " +
+				"(WEBHOOK-SSRF-GUARD-01/A3)",
+		})
+	})
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != ssrfHTTPPkgPath || !ssrfBannedHTTPCallees[name] {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "http." + name + " called in kernel/webhook; use an SSRF-wrapped *http.Client " +
+				"(WEBHOOK-SSRF-GUARD-01/A3)",
+		})
+	})
+	return out
+}
+
+func TestWebhookSSRFGuard(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var a1, a2, a3 []Diagnostic
+	_ = RunTyped(t, TypedOpts{Tests: false}, []string{webhookPkgPattern},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != "github.com/ghbvf/gocell/kernel/webhook" {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanSSRFNetDial(p.Fset, f, rel, p.TypesInfo)...)
+				a2 = append(a2, scanSSRFDialerDialContext(p.Fset, f, rel, p.TypesInfo)...)
+				a3 = append(a3, scanSSRFHTTPGlobal(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+
+	Report(t, "WEBHOOK-SSRF-GUARD-01/A1", a1)
+	Report(t, "WEBHOOK-SSRF-GUARD-01/A2", a2)
+	Report(t, "WEBHOOK-SSRF-GUARD-01/A3", a3)
+}
+
+// TestWebhookSSRFGuard_ReverseFixture loads the synthetic violation fixture and
+// asserts each sub-rule fires — guards against the rule logic silently
+// regressing to a vacuous pass.
+func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_ssrf_violate")
+
+	var a1, a2, a3 []Diagnostic
+	_ = RunTypedDir(t, fixtureDir, TypedOpts{Tests: false}, []string{"./..."},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanSSRFNetDial(p.Fset, f, rel, p.TypesInfo)...)
+				a2 = append(a2, scanSSRFDialerDialContext(p.Fset, f, rel, p.TypesInfo)...)
+				a3 = append(a3, scanSSRFHTTPGlobal(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, len(a1), 2, "A1 reverse fixture: expected ≥2 net.Dial* diagnostics (net.Dial + net.DialTCP)")
+	assert.GreaterOrEqual(t, len(a2), 1, "A2 reverse fixture: expected ≥1 raw net.Dialer.DialContext diagnostic")
+	assert.GreaterOrEqual(t, len(a3), 2, "A3 reverse fixture: expected ≥2 http global diagnostics")
+}


### PR DESCRIPTION
## Summary

`KERNEL-WEBHOOK-01` epic 的 **PR-4：webhook SSRF guard**（纯 kernel building block）。PR-5 dispatcher 会向运营方提供的 URL 发起出站 POST——经典 SSRF 面（云元数据 `169.254.169.254` / 内网 / loopback）。本 PR 交付防御构件，PR-5 才接入 `http.Transport`。

**设计经开源对标验证**：`resolve→vet→dial-literal-IP` 单路径 dialer——对标 **stripe/smokescreen** + **stealthrocket/netjail（convoy 采用）**，业界最严格、rebinding-proof；刻意不用 doyensec/safeurl 的 `net.Dialer.Control`（理论 rebinding 窗口 + 双路径）。

### 交付物

- `kernel/webhook/ssrf.go`：
  - `NewSafeDialer` / `SafeDialContext`：解析 host → vet 所有解析 IP（fail-closed，任一命中即拒）→ dial 已校验 IP 字面量（无二次解析 ⟹ rebinding-proof）
  - 30 条 IETF CIDR 黑名单（safeurl 超集 + RFC8215 NAT64 local-use `64:ff9b:1::/48`）；`normalizeIP`（`To4` 去包）作 IPv4-mapped 唯一防线，**刻意去除 `::ffff:0:0/96` 死条目**（与归一化冲突，会误杀公网 mapped）
  - `DenyRedirect`（`http.Client.CheckRedirect` deny-all，对标 Stripe/GitHub）+ `ValidateTargetURL`（scheme {http,https}）
  - `WithAllowLoopback`（dev/CI only，仅豁免 loopback）
  - 复用既有 `errcode.ErrWebhookSSRFBlocked`（`KindPermissionDenied` → 403），无新增 sentinel
- `testdata/webhook-ssrf-deny.yaml` + `ssrf_fixtures_test.go`：CIDR 单源真值 + 双向漂移守卫
- `tools/archtest/webhook_ssrf_guard_test.go`（**WEBHOOK-SSRF-GUARD-01**）+ reverse violate fixture
- `docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md`

### AI-robust 评级（WEBHOOK-SSRF-GUARD-01）

- **下游 Hard**：A1（`net.Dial*` 包函数禁用）/ A2（`net.Dialer.DialContext` 唯一 ssrf.go::dial 出站点）/ A3（`http.DefaultClient`/`DefaultTransport`/`Get`/`Post`/`PostForm`/`Head` 禁用）——form-unique、type-resolved callsite ban。
- **上游 Medium = Go 永久天花板**（holder 轴不可表达，同 #851/#893）→ won't-do 跟踪 **#1375**，archtest godoc 点名。
- **PR-4 vs PR-5 split**：spec 的 `Dispatcher.client` field-type 锁推迟到 PR-5（Dispatcher 尚不存在，现在锁会 vacuous pass）；B1（`Transport.RoundTrip` 直调）静态盲区由 PR-5 `Client.Do` funnel 兜底。ADR 记录。

## Implementation Matrix

```
Contract: kernel/webhook SafeDialContext + DenyRedirect + ValidateTargetURL (SSRF guard)
Change: resolve→vet→dial-literal dialer + 29-CIDR blocklist + redirect deny + scheme allowlist
Implementations: [x] safeConfig.dial（唯一出站路径）
Conformance test: kernel/webhook.TestSafeDialer_* + TestSSRFBlocklistFixtureNoDrift（漂移守卫）
Repro: go test ./kernel/webhook/... ./tools/archtest/... -run 'SSRF|SafeDialer|ValidateTargetURL|DenyRedirect|WebhookSSRFGuard'
Dependent contracts (governance scan): none（greenfield building block，无消费方）
Invariant inventory: N/A（greenfield，无 DROP COLUMN）
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./kernel/webhook/ -cover` → **98.9%**（kernel 基线 ≥90%）
- [x] `go test ./tools/archtest/ -run 'WebhookSSRFGuard|InventoryAnchor'` → forward 清空 / reverse fixture A1≥2·A2≥1·A3≥2 fire / inventory anchor valid
- [x] `golangci-lint run ./kernel/webhook/... ./tools/archtest/...` → 0 issues
- DNS rebinding（fake resolver public-name→private-IP）、IPv4-mapped（`::ffff:8.8.8.8` 不误杀）、multi-answer fail-closed、resolver error/empty fail-closed、29 条 CIDR 逐条 blocked、loopback opt-in 行为、ValidateTargetURL/DenyRedirect 全覆盖

ref: stripe/smokescreen pkg/smokescreen/smokescreen.go
ref: stealthrocket/netjail security.go
ref: doyensec/safeurl ip.go

## Review 后续（已登记，非 silent）

- #1375 — WEBHOOK-SSRF-GUARD-01 上游 holder 轴 Hard 化（won't-do 永久天花板）
- #1378 — `WithAllowLoopback` 生产守卫 archtest（Soft→Medium，PR-5 落地）
- `Dispatcher.client` typed-field 上游锁 + B1 `Transport.RoundTrip` 兜底 → PR-5（ADR 记录）

3 reviewer（架构+测试 / 安全+产品 / 运维+DX）已审，Cx1/Cx2 全部修复（NAT64 local-use 补漏、reason 移入 server-only、可观测字段补全、A1 反向 fixture 6/6 覆盖、测试断言收紧）。

Closes #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
