### PR TITLE
feat(tenancy): PR-1 tenant 类型地基 + JWT claim source [#1339]

### DIFF
--- a/.claude/rules/gocell/tenancy.md
+++ b/.claude/rules/gocell/tenancy.md
@@ -1,0 +1,31 @@
+# 多租户 / ABAC / 行列级数据权限规则导航
+
+> 本文件是 EPIC #1337（多租户隔离 + ABAC policy-as-code + 行列级数据权限）的规则导航索引，随各 PR 增量补充。设计真值源：`docs/plans/specs/1220-tenancy-abac-dataperm/`（spec.md / plan.md / tasks.md / research.md）。每条 enforcement 的完整盲区清单 + AI-robust 评级举证活在对应 archtest 的 package godoc（单源，本文件只汇总 ID / 一行摘要 / 评级供导航）。
+
+## 类型地基（`pkg/tenant/`）
+
+- **`tenant.TenantID`**（`pkg/tenant/tenant_id.go`）：隔离域边界 sealed newtype，对齐 `idutil.SafeID` 范式。与 SafeID 不同——**空值无效**（tenant 查询不可缺 tenant），非空须为 canonical UUID。`Validate` / `ParseTenantID` / `UnmarshalJSON` runtime fail-fast（Medium；type-system Hard 来源 = PR-2 repo 方法收 `TenantID` typed 位置参，漏传=编译错误）。
+- **`tenant.RowScope`**（`pkg/tenant/rowscope.go`）：行可见范围 typed obligation enum `{self, device, tenant, all}`，零值 invalid。XACML PDP→PEP obligation 模型的有界 Go 投影。**仅类型，消费在 PR-4**（repo list/get typed 位置参）。取值扩张超 4 值则迁 `pkg/authz/`。
+
+## Principal / claim source（`runtime/auth/`）
+
+- **`PrincipalKind` 增 `PrincipalDevice`**（`runtime/auth/principal.go`）：device 一等主体类型地基（喂下游 MDM #1051 / 零信任 #1052）。develop 无 device-token 签发方，`jwtClaimsToPrincipal` 仍产 `PrincipalUser`；device 分类随真实签发方落地。
+- **JWT `tenant_id` claim → `ctxkeys.TenantID`**（`runtime/auth/jwt.go` + `authenticator.go` + `middleware.go`）：消除「no source on develop」。claim 在 JWT authenticator 边界经 `tenant.ParseTenantID` fail-closed 校验 + canonical 归一（malformed UUID → 401）。service 主体无 tenant（callerCellID ≠ tenant）。
+
+## Enforcement 索引
+
+| ID | 摘要 | 评级 | 载体 |
+|----|------|------|------|
+| `CTXKEYS-PRINCIPAL-WRITE-CALLER-01` | principal ctxkey setter（含 `WithTenantID`）写入方锁定在 auth 边界桥 + consumer restore | Hard 下游 / Medium 上游（Go 可见性天花板，#1282） | `tools/archtest/ctxkeys_principal_write_caller_test.go` |
+| `PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01` | 生产 `switch` on `PrincipalKind` 必须显式覆盖全部常量（default 不豁免） | Medium | `tools/archtest/principal_kind_exhaustive_switch_test.go` |
+| `tenant.TenantID.Validate()` 空值 + UUID | repo 拿到空 tenant 是 bug → 拒；非空须 UUID | Medium（Hard 来源 = PR-2 typed 位置参） | `pkg/tenant/tenant_id.go` runtime guard |
+
+## 后续 PR 增量（占位，落地时补）
+
+- PR-2：平台 repo `tenant.TenantID` 强制 typed 位置参 + 列迁移（`TENANT-REPO-PARAM-FUNNEL-01`）；auditcore `INV-SINGLE-TENANT-ONLY` 哨兵移除 + tenant-scoped audit 过滤。
+- PR-3：PG `FORCE ROW LEVEL SECURITY` + `TxRunner` `SET LOCAL app.tenant_id`。
+- PR-4：`RowScope` typed 位置参 + `ROWSCOPE-REPO-PARAM-FUNNEL-01`。
+- PR-5：身份 → RowScope 收窄 + `RowScope=all` 强制审计。
+- PR-6..10：ABAC policy 域模型 / 评估引擎 / `Authorizer` 重做 / policymanage / 接线（#914）。
+- PR-11/12：`pkg/projection.ResourceProjection` sealed + `FieldMask` 列 masking。
+- PR-13：跨层 ADR ×3 + 扇出收口。

--- a/cells/auditcore/internal/appender/service.go
+++ b/cells/auditcore/internal/appender/service.go
@@ -208,23 +208,26 @@ func (s *Service) HandleEvent(ctx context.Context, entry outbox.Entry) outbox.Ha
 // (#1289, epic #1296).
 //
 // This is an OPERATIONAL tripwire, NOT a tenant-isolation security boundary.
-// develop is single-tenant: no producer writes principal.TenantID (the auth
-// middleware never calls ctxkeys.WithTenantID — CTXKEYS-PRINCIPAL-WRITE-CALLER-01
-// locks the only writer to consumer-side RestoreToContext), so this branch is
-// dead today. A non-empty TenantID reaching audit persistence means
-// multi-tenancy (#1296) landed without wiring tenant-scoped audit filtering —
-// a security-relevant gap. Trip loudly (Error, alertable) but DO NOT drop the
+// As of the multi-tenancy epic PR-1 (#1339), the auth bridge DOES write
+// principal.TenantID from the JWT "tenant_id" claim (CTXKEYS-PRINCIPAL-WRITE-CALLER-01
+// now allowlists runtime/auth/middleware.go as a WithTenantID producer), so this
+// branch is no longer structurally dead: any audit-producing request carrying a
+// valid tenant claim reaches here with a non-empty TenantID. That is the intended
+// alarm for the PR-1→PR-2 window — multi-tenant identity now flows, but
+// tenant-scoped audit query filtering has NOT yet landed (PR-2), which is a
+// security-relevant gap. Trip loudly (Error, alertable) but DO NOT drop the
 // audit record: compliance evidence is never discarded (the caller continues to
-// Append). When #1296 lands, this tripwire is removed and replaced by
-// tenant-scoped query filtering. It guards the persistence-reach path;
-// CTXKEYS-PRINCIPAL-WRITE-CALLER-01 orthogonally guards the ctx-write path.
+// Append). PR-2 removes this tripwire and replaces it with tenant-scoped query
+// filtering. It guards the persistence-reach path; CTXKEYS-PRINCIPAL-WRITE-CALLER-01
+// orthogonally guards the ctx-write path.
 //
 // Firing cadence: logs once PER event with a non-empty tenant. That is
-// intentional — until #1296 lands the branch is dead (no producer), so any
-// firing is a real regression worth a per-event alert; the temporary nature of
-// the stopgap does not warrant sampling/rate-limiting machinery. tenant_id is an
-// opaque, non-credential identifier (observability.md), so logging its value
-// server-side is safe and aids #1296 debugging.
+// intentional for the PR-1→PR-2 window — on a default deployment the gocell
+// issuer emits no tenant_id claim, so the branch stays cold; any firing means a
+// tenant-bearing token is in use before tenant-scoped audit filtering exists, a
+// real gap worth a per-event alert. tenant_id is an opaque, non-credential
+// identifier (observability.md), so logging its value server-side is safe and
+// aids #1296 debugging.
 func (s *Service) tripSingleTenantInvariant(logPrefix string, entry outbox.Entry, principal outbox.PrincipalMetadata) {
 	if principal.TenantID == "" {
 		return

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -165,18 +165,16 @@ func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
 // generation time, so SessionID cannot re-enter ResponseDataItem via schema.
 //
 // TenantID is not exposed, and — critically — this is NOT a tenant-isolation
-// security guarantee (#1289, INV-SINGLE-TENANT-ONLY). develop is single-tenant:
-// no producer writes principal.TenantID (the auth middleware never calls
-// ctxkeys.WithTenantID — CTXKEYS-PRINCIPAL-WRITE-CALLER-01 locks the only writer
-// to consumer-side RestoreToContext), so the column is always empty and there is
-// nothing to scope by. The earlier "type-system Hard isolation by absence"
-// framing was an over-claim and has been removed: "no tenantId query parameter"
-// is not the same as "queries are isolated by tenant". This endpoint performs NO
-// tenant scoping whatsoever. Real multi-tenant isolation — a JWT tenant claim
-// producer source, AuditFilters.TenantID, and a tenant-scoped WHERE — is tracked
-// by epic #1296; the appender carries an INV-SINGLE-TENANT-ONLY tripwire
-// (cells/auditcore/internal/appender) that fires loudly if a non-empty tenant
-// ever reaches audit persistence before #1296 wires that filtering.
+// security guarantee (#1289, INV-SINGLE-TENANT-ONLY). As of multi-tenancy PR-1
+// (#1339) the auth bridge DOES write principal.TenantID from the JWT tenant_id
+// claim, so the audit column is no longer guaranteed empty — but this endpoint
+// still performs NO tenant scoping whatsoever (no tenantId query parameter, no
+// AuditFilters.TenantID, no tenant-scoped WHERE). "No tenantId query parameter"
+// is not the same as "queries are isolated by tenant". Real multi-tenant
+// isolation — AuditFilters.TenantID + a tenant-scoped WHERE + tenantId exposure —
+// lands in PR-2/PR-12 of epic #1337. Until then the appender carries the
+// INV-SINGLE-TENANT-ONLY tripwire (cells/auditcore/internal/appender) that fires
+// loudly when a non-empty tenant reaches audit persistence.
 func toListResponseDataItem(e *ledger.Entry) *auditlist.ResponseDataItem {
 	// Both audit-evidence timestamps use RFC3339Nano: sub-second precision is
 	// part of the evidence (the HMAC chain pins occurred_at/timestamp at nanosecond

--- a/cells/auditcore/slices/auditquery/handler.go
+++ b/cells/auditcore/slices/auditquery/handler.go
@@ -17,6 +17,9 @@ import (
 )
 
 // auditQueryPolicy permits the request when:
+//   - the caller is NOT tenant-bearing (p.TenantID == ""); a tenant-bearing
+//     caller is rejected 403 outright (#1339 F2) because this endpoint has no
+//     tenant isolation yet (epic #1337 PR-2), AND
 //   - actorId query param is empty. List scopes non-admin callers to self and
 //     treats admin callers as global queries.
 //   - OR actorId equals authenticated subject (self-access)
@@ -31,6 +34,17 @@ func auditQueryPolicy(r *http.Request) error {
 	p, ok := auth.FromContext(ctx)
 	if !ok || p.Subject == "" {
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "authentication required")
+	}
+	// Tenant-bearing fail-closed (#1339 F2): this endpoint performs NO tenant
+	// isolation yet (no AuditFilters.TenantID, no tenant-scoped WHERE — landing
+	// in epic #1337 PR-2). Serving a tenant-bearing caller un-isolated results
+	// would leak cross-tenant audit rows, so deny outright until PR-2 adds real
+	// filtering. Denial is independent of admin role / actorId — fail-closed for
+	// every tenant-bearing request.
+	if p.TenantID != "" {
+		return errcode.New(errcode.KindPermissionDenied, errcode.ErrAuthForbidden,
+			"tenant-scoped audit query is not yet supported",
+			errcode.WithInternal(errcode.InternalAttr("_", "tenant-bearing audit query rejected; tenant-scoped filtering lands in epic #1337 PR-2")))
 	}
 	actorID := r.URL.Query().Get("actorId")
 	if actorID == "" || actorID == p.Subject {
@@ -168,9 +182,9 @@ func (h *Handler) RegisterRoutes(mux cell.RouteHandler) error {
 // security guarantee (#1289, INV-SINGLE-TENANT-ONLY). As of multi-tenancy PR-1
 // (#1339) the auth bridge DOES write principal.TenantID from the JWT tenant_id
 // claim, so the audit column is no longer guaranteed empty — but this endpoint
-// still performs NO tenant scoping whatsoever (no tenantId query parameter, no
-// AuditFilters.TenantID, no tenant-scoped WHERE). "No tenantId query parameter"
-// is not the same as "queries are isolated by tenant". Real multi-tenant
+// has no tenant-scoped READ path (no AuditFilters.TenantID, no tenant-scoped
+// WHERE), so auditQueryPolicy fails closed: a tenant-bearing caller is rejected
+// 403 rather than served un-isolated cross-tenant rows (#1339 F2). Real multi-tenant
 // isolation — AuditFilters.TenantID + a tenant-scoped WHERE + tenantId exposure —
 // lands in PR-2/PR-12 of epic #1337. Until then the appender carries the
 // INV-SINGLE-TENANT-ONLY tripwire (cells/auditcore/internal/appender) that fires

--- a/cells/auditcore/slices/auditquery/handler_test.go
+++ b/cells/auditcore/slices/auditquery/handler_test.go
@@ -380,6 +380,48 @@ func TestHandler_RegisterRoutes_AuthzNegative(t *testing.T) {
 	}
 }
 
+// TestHandler_RegisterRoutes_TenantBearing_FailClosed proves the audit query
+// endpoint fails closed for any tenant-bearing caller (#1339 F2). Until
+// tenant-scoped audit filtering lands (epic #1337 PR-2: AuditFilters.TenantID +
+// tenant-scoped WHERE), a request whose principal carries a non-empty TenantID
+// must be REJECTED (403) rather than silently served un-isolated, cross-tenant
+// results. Denial is independent of admin role / actorId — fail-closed for
+// everyone tenant-bearing.
+func TestHandler_RegisterRoutes_TenantBearing_FailClosed(t *testing.T) {
+	store := newHandlerStore(t)
+	svc, err := NewService(store, testCodec(), slog.Default(), query.RunModeProd)
+	require.NoError(t, err)
+	h := NewHandler(svc)
+
+	mux := http.NewServeMux()
+	require.NoError(t, h.RegisterRoutes(mux))
+
+	const tenantUUID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+	for _, tc := range []struct {
+		name  string
+		roles []string
+	}{
+		{"non_admin_tenant_bearing", []string{"viewer"}},
+		{"admin_tenant_bearing", []string{"admin"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &auth.Principal{
+				Kind:       auth.PrincipalUser,
+				Subject:    "usr-1",
+				Roles:      tc.roles,
+				TenantID:   tenantUUID,
+				AuthMethod: "test",
+			}
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil).
+				WithContext(auth.WithPrincipal(context.Background(), p))
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusForbidden, w.Code,
+				"tenant-bearing audit query must fail closed until PR-2 tenant filtering lands")
+		})
+	}
+}
+
 // Trust boundary tests (#27q).
 func TestHandleQuery_ActorBinding(t *testing.T) {
 	store := newHandlerStore(t)

--- a/contracts/http/audit/list/v1/contract.yaml
+++ b/contracts/http/audit/list/v1/contract.yaml
@@ -61,7 +61,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — authenticated but lacks admin role, or a tenant-bearing caller (tenant-scoped audit query not yet supported; epic #1337 PR-2)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
 schemaRefs:
   response: response.schema.json

--- a/docs/plans/specs/1220-tenancy-abac-dataperm/tasks.md
+++ b/docs/plans/specs/1220-tenancy-abac-dataperm/tasks.md
@@ -120,6 +120,7 @@ graph TD
 - [ ] T2.4 [P] 三 cell `internal/mem/`：mem 实现加 tenant 过滤
 - [ ] T2.5 archtest `TENANT-REPO-PARAM-FUNNEL-01`（**`[R1 F-A8]` 评级澄清**：repo 方法签名收 `tenant.TenantID` → 「漏传」是**编译器 Hard**，无需 fixture；archtest 守的不变式 = 「无 repo 方法在 production 接受 plain string 充当 tenant」typed scan，**Medium**；反向自检用 `testdata/tenant_repo_param/violates/` 放一个收 string 的假 repo，断言 archtest 红）
 - [ ] T2.6 conformance + unit：三 cell 跨租户查询返回空
+- [ ] T2.7 **`[#1339 F2 carryover]` auditquery tenant-scoped 读路径**：PR-1（#1384）落了最小 fail-closed 闸门（`auditQueryPolicy` 在 `p.TenantID != ""` 时 403）作为临时止血。本任务用真隔离替换它——`ledger.AuditFilters` 加 `TenantID` + MemStore/PG `WHERE tenant_id` + auditquery 从认证 `principal.TenantID`（**非 query param**，否则成跨租户入口）注入 filter；**删除该 403 闸门**（`cells/auditcore/slices/auditquery/handler.go::auditQueryPolicy`）+ appender `INV-SINGLE-TENANT-ONLY` tripwire（`cells/auditcore/internal/appender/service.go`）；Store 接口变更走 contract-fanout implementation matrix（MemStore+PG+conformance）。验收：tenant-bearing 请求只见本租户行（不再 403），跨租户查询返回空。
 
 ### PR-3 — PG RLS FORCE + TxRunner SET LOCAL（W2, ~1200, dep: PR-2）
 - [ ] T3.1 migration：各租户表 `ENABLE` + `FORCE ROW LEVEL SECURITY`（防 table owner bypass）+ tenant_isolation policy（`NULLIF(current_setting('app.tenant_id',true),'')::uuid`）。**`[R1 F-B11]`** ADR/migration 注释明确：应用连接 PG role **不得是 table owner 且无 `BYPASSRLS`**；integration 断言 `SELECT rolbypassrls FROM pg_roles WHERE rolname=current_user` 为 false

--- a/kernel/auth/auth_types.go
+++ b/kernel/auth/auth_types.go
@@ -56,10 +56,12 @@ type Claims struct {
 	// TenantID is the "tenant_id" claim identifying the tenant isolation
 	// boundary the subject belongs to. Empty in single-tenant deployments (no
 	// tenant claim issued). When non-empty it MUST be a valid UUID; the
-	// runtime/auth JWT authenticator validates and canonicalizes it via
-	// pkg/tenant.ParseTenantID at the request trust boundary (a malformed tenant
-	// claim fails closed), so consumers may treat a non-empty value as a
-	// canonical lowercase UUID.
+	// runtime/auth JWTVerifier.VerifyIntent validates and canonicalizes it via
+	// pkg/tenant.ParseTenantID before returning Claims (a malformed tenant claim
+	// fails closed), so consumers may treat a non-empty value as a canonical
+	// lowercase UUID. Typed string (not pkg/tenant.TenantID) to keep this kernel
+	// wire type free of the tenant package's UUID dependency; the runtime
+	// boundary owns validation.
 	TenantID string
 	// PasswordResetRequired indicates that the subject must change their password.
 	PasswordResetRequired bool

--- a/kernel/auth/auth_types.go
+++ b/kernel/auth/auth_types.go
@@ -53,6 +53,14 @@ type Claims struct {
 	TokenUse TokenIntent
 	// SessionID is the "sid" claim binding the token to a specific session.
 	SessionID string
+	// TenantID is the "tenant_id" claim identifying the tenant isolation
+	// boundary the subject belongs to. Empty in single-tenant deployments (no
+	// tenant claim issued). When non-empty it MUST be a valid UUID; the
+	// runtime/auth JWT authenticator validates and canonicalizes it via
+	// pkg/tenant.ParseTenantID at the request trust boundary (a malformed tenant
+	// claim fails closed), so consumers may treat a non-empty value as a
+	// canonical lowercase UUID.
+	TenantID string
 	// PasswordResetRequired indicates that the subject must change their password.
 	PasswordResetRequired bool
 	// JTI is the JWT ID claim ("jti"), a unique identifier for the token.

--- a/pkg/ctxkeys/keys.go
+++ b/pkg/ctxkeys/keys.go
@@ -113,8 +113,9 @@ func RealIPFrom(ctx context.Context) (string, bool) {
 // to at most two callers — the auth request-boundary bridge
 // (runtime/auth/middleware.go::injectPrincipalCtxKeys, shared by JWT +
 // service-token) and the consumer-side restore (kernel/outbox.RestoreToContext).
-// WithTenantID has only the consumer-side restore caller today: auth.Principal
-// carries no tenant field on develop, so the auth bridge never writes it.
+// All four setters — including WithTenantID — now have both writers: the auth
+// bridge populates TenantID from the JWT "tenant_id" claim (multi-tenancy epic
+// #1337), and the consumer restore re-hydrates it after the async hop.
 // Business producers (cells/, examples/) must never call them: principal injection
 // is the framework's responsibility (#1229; ADR 202605281200-1042 §Amendment
 // 2026-05-29 round-2). Read side (the XxxIDFrom getters) is unrestricted.

--- a/pkg/tenant/rowscope.go
+++ b/pkg/tenant/rowscope.go
@@ -1,0 +1,66 @@
+package tenant
+
+import "fmt"
+
+// RowScope is the authorization obligation that decides the row-visibility
+// predicate a tenant-scoped list/get repo method must apply. It is the GoCell
+// typed projection of the XACML PDP→PEP obligation model (a bounded set of
+// scopes, not an OPA-style partial-evaluation AST residue): the policy layer
+// emits a RowScope, the repo layer (PEP) enforces it.
+//
+// RowScope lives in pkg/tenant only because it must be referenceable from
+// every layer with no dependency cycle; it is NOT a tenancy primitive. Should
+// the value set ever grow past these four, the migration target is pkg/authz/.
+//
+// The zero value is intentionally invalid (iota+1, mirroring kernel/saga.Status
+// and kernel/outbox.Disposition) so an unset obligation can never be mistaken
+// for a permissive scope.
+//
+// This is a TYPE-ONLY foundation in PR-1; repo methods begin taking RowScope as
+// a mandatory positional parameter in PR-4.
+type RowScope uint8
+
+const (
+	// RowScopeSelf restricts visibility to rows owned by the subject
+	// (owner_id = $subject); the non-privileged user default.
+	RowScopeSelf RowScope = iota + 1
+	// RowScopeDevice restricts visibility to rows belonging to the device
+	// subject (device_id = $subject); the principalKind=device default.
+	RowScopeDevice
+	// RowScopeTenant grants visibility to all rows within the caller's tenant;
+	// the admin default.
+	RowScopeTenant
+	// RowScopeAll grants cross-tenant visibility; reserved for the explicit,
+	// audited platform super-admin path only.
+	RowScopeAll
+)
+
+// Valid reports whether rs is one of the four defined scopes.
+func (rs RowScope) Valid() bool {
+	return rs >= RowScopeSelf && rs <= RowScopeAll
+}
+
+// String returns the wire/log spelling of the scope, or "invalid" for the zero
+// value and any out-of-range value.
+func (rs RowScope) String() string {
+	switch rs {
+	case RowScopeSelf:
+		return "self"
+	case RowScopeDevice:
+		return "device"
+	case RowScopeTenant:
+		return "tenant"
+	case RowScopeAll:
+		return "all"
+	default:
+		return "invalid"
+	}
+}
+
+// Validate returns an error for the zero value or any out-of-range value.
+func (rs RowScope) Validate() error {
+	if !rs.Valid() {
+		return fmt.Errorf("tenant: invalid RowScope %d", rs)
+	}
+	return nil
+}

--- a/pkg/tenant/rowscope_test.go
+++ b/pkg/tenant/rowscope_test.go
@@ -1,0 +1,56 @@
+package tenant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRowScope_Valid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   RowScope
+		want bool
+	}{
+		{"zero value invalid", RowScope(0), false},
+		{"self valid", RowScopeSelf, true},
+		{"device valid", RowScopeDevice, true},
+		{"tenant valid", RowScopeTenant, true},
+		{"all valid", RowScopeAll, true},
+		{"out of range invalid", RowScope(99), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.in.Valid())
+		})
+	}
+}
+
+func TestRowScope_Validate(t *testing.T) {
+	t.Parallel()
+	assert.Error(t, RowScope(0).Validate(), "zero value must fail Validate")
+	assert.Error(t, RowScope(99).Validate(), "out of range must fail Validate")
+	for _, rs := range []RowScope{RowScopeSelf, RowScopeDevice, RowScopeTenant, RowScopeAll} {
+		assert.NoError(t, rs.Validate())
+	}
+}
+
+func TestRowScope_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   RowScope
+		want string
+	}{
+		{RowScopeSelf, "self"},
+		{RowScopeDevice, "device"},
+		{RowScopeTenant, "tenant"},
+		{RowScopeAll, "all"},
+		{RowScope(0), "invalid"},
+		{RowScope(99), "invalid"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, tc.in.String())
+	}
+}

--- a/pkg/tenant/tenant_id.go
+++ b/pkg/tenant/tenant_id.go
@@ -44,14 +44,17 @@ const canonicalUUIDLen = 36
 // String returns the underlying string.
 func (t TenantID) String() string { return string(t) }
 
-// Validate returns nil only for a non-empty, canonical (36-char dashed) UUID.
-// The empty value is rejected (a tenant boundary cannot be absent at the
-// point a TenantID is required); any non-canonical-UUID string is rejected.
+// Validate returns nil only for a non-empty TenantID that is ALREADY in
+// canonical form: a 36-char dashed, lowercase UUID. The empty value is rejected
+// (a tenant boundary cannot be absent at the point a TenantID is required), and
+// any non-canonical form — including a valid-but-uppercase UUID — is rejected.
 //
-// Validate only CHECKS validity; it does NOT normalize the receiver. A value
-// that passes Validate is already canonical only if it was produced by
-// ParseTenantID / UnmarshalJSON. To obtain the canonical lowercase form from a
-// raw string, use ParseTenantID.
+// Validate does NOT normalize the receiver: it asserts the value is canonical
+// rather than coercing it. This makes Validate a true post-construction
+// invariant check (e.g. on a TenantID repo parameter) — a value that passes is
+// safe to use verbatim against the PostgreSQL uuid column / RLS predicate. To
+// obtain the canonical lowercase form from a raw (possibly uppercase) string,
+// use ParseTenantID, which normalizes.
 func (t TenantID) Validate() error {
 	return validateTenantIDString(string(t))
 }
@@ -106,9 +109,18 @@ func parseCanonical(s string) (TenantID, error) {
 	return TenantID(u.String()), nil
 }
 
-// validateTenantIDString validates without producing the canonical form, so
-// Validate() can run on an already-constructed value (e.g. a struct field).
+// validateTenantIDString asserts that s is ALREADY canonical: it must parse as
+// a valid TenantID AND equal its own canonical form. parseCanonical normalizes
+// (lowercases) on the way through, so comparing s to the canonical result is
+// what rejects a valid-but-uppercase UUID — a check Validate needs but
+// ParseTenantID / UnmarshalJSON (which deliberately normalize) must not apply.
 func validateTenantIDString(s string) error {
-	_, err := parseCanonical(s)
-	return err
+	canonical, err := parseCanonical(s)
+	if err != nil {
+		return err
+	}
+	if string(canonical) != s {
+		return fmt.Errorf("tenant: TenantID must be a canonical lowercase UUID; use ParseTenantID to normalize")
+	}
+	return nil
 }

--- a/pkg/tenant/tenant_id.go
+++ b/pkg/tenant/tenant_id.go
@@ -24,9 +24,9 @@ import (
 // the key, never by an empty TenantID reaching a repo.
 //
 // A non-empty TenantID MUST be a canonical (lowercase) UUID. GoCell issues
-// tenant identifiers itself and stores them in a PostgreSQL `uuid` column with
-// RLS `NULLIF(current_setting('app.tenant_id', true), '')::uuid` (PR-3), so
-// the type boundary enforces the same UUID shape the database casts to.
+// tenant identifiers itself and stores them in a PostgreSQL uuid column whose
+// RLS predicate casts the app.tenant_id setting to uuid (PR-3), so the type
+// boundary enforces the same UUID shape the database casts to.
 //
 // Empty/malformed rejection is RUNTIME fail-fast (Validate / ParseTenantID /
 // UnmarshalJSON), not type-system Hard — an empty string is a legal Go

--- a/pkg/tenant/tenant_id.go
+++ b/pkg/tenant/tenant_id.go
@@ -33,15 +33,25 @@ import (
 // expression. The type-system Hard guarantee ("漏传 tenant 编译失败") comes from
 // repo methods taking TenantID as a mandatory positional parameter (PR-2).
 //
-// ref: pkg/idutil.SafeID — sealed-newtype + UnmarshalJSON-fail-close范式.
+// ref: pkg/idutil.SafeID — sealed-newtype + UnmarshalJSON fail-closed pattern.
 type TenantID string
+
+// canonicalUUIDLen is the length of a canonical dashed UUID
+// (8-4-4-4-12 = 36 chars). The non-dashed/brace/urn variants that
+// github.com/google/uuid.Parse also accepts are rejected — see parseCanonical.
+const canonicalUUIDLen = 36
 
 // String returns the underlying string.
 func (t TenantID) String() string { return string(t) }
 
-// Validate returns nil only for a non-empty, canonical-or-parseable UUID.
+// Validate returns nil only for a non-empty, canonical (36-char dashed) UUID.
 // The empty value is rejected (a tenant boundary cannot be absent at the
-// point a TenantID is required); any non-UUID string is rejected.
+// point a TenantID is required); any non-canonical-UUID string is rejected.
+//
+// Validate only CHECKS validity; it does NOT normalize the receiver. A value
+// that passes Validate is already canonical only if it was produced by
+// ParseTenantID / UnmarshalJSON. To obtain the canonical lowercase form from a
+// raw string, use ParseTenantID.
 func (t TenantID) Validate() error {
 	return validateTenantIDString(string(t))
 }
@@ -75,10 +85,19 @@ func ParseTenantID(s string) (TenantID, error) {
 }
 
 // parseCanonical is the single source of truth for TenantID's invariant:
-// non-empty + valid UUID, normalized to canonical lowercase form.
+// non-empty + canonical 36-char dashed UUID, normalized to lowercase.
+//
+// The explicit length guard is load-bearing: github.com/google/uuid.Parse is
+// lenient — it also accepts 32-char compact ("3f25...3301"), brace-wrapped
+// ("{...}"), and "urn:uuid:..." forms. A tenant boundary identifier must have a
+// single canonical shape (the one the PostgreSQL uuid column / RLS cast round-
+// trips), so anything that is not exactly 36 chars is rejected before Parse.
 func parseCanonical(s string) (TenantID, error) {
 	if s == "" {
 		return "", fmt.Errorf("tenant: TenantID required (empty)")
+	}
+	if len(s) != canonicalUUIDLen {
+		return "", fmt.Errorf("tenant: TenantID must be a canonical 36-char dashed UUID")
 	}
 	u, err := uuid.Parse(s)
 	if err != nil {

--- a/pkg/tenant/tenant_id.go
+++ b/pkg/tenant/tenant_id.go
@@ -1,0 +1,95 @@
+// Package tenant holds the layer-free tenancy value types shared across all
+// GoCell layers: the TenantID sealed newtype (the multi-tenant isolation
+// boundary identifier) and the RowScope authorization obligation enum.
+//
+// It lives under pkg/ (stdlib + google/uuid only) precisely because every
+// layer — kernel/, runtime/, cells/, adapters/ — must be able to reference
+// these types: TenantID becomes a mandatory typed positional parameter on
+// tenant-scoped repo methods (PR-2; "漏传" = compile error), and RowScope
+// becomes a typed obligation consumed by list/get repo methods (PR-4).
+package tenant
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// TenantID identifies the tenant isolation boundary. Unlike idutil.SafeID —
+// whose zero value is the legitimate "absent" representation — an empty
+// TenantID is INVALID: a tenant-scoped query without a tenant cannot express
+// a valid isolation predicate (Validate rejects it). The "no tenant"
+// (single-tenant) case is represented at the ctx/wire layer by the absence of
+// the key, never by an empty TenantID reaching a repo.
+//
+// A non-empty TenantID MUST be a canonical (lowercase) UUID. GoCell issues
+// tenant identifiers itself and stores them in a PostgreSQL `uuid` column with
+// RLS `NULLIF(current_setting('app.tenant_id', true), '')::uuid` (PR-3), so
+// the type boundary enforces the same UUID shape the database casts to.
+//
+// Empty/malformed rejection is RUNTIME fail-fast (Validate / ParseTenantID /
+// UnmarshalJSON), not type-system Hard — an empty string is a legal Go
+// expression. The type-system Hard guarantee ("漏传 tenant 编译失败") comes from
+// repo methods taking TenantID as a mandatory positional parameter (PR-2).
+//
+// ref: pkg/idutil.SafeID — sealed-newtype + UnmarshalJSON-fail-close范式.
+type TenantID string
+
+// String returns the underlying string.
+func (t TenantID) String() string { return string(t) }
+
+// Validate returns nil only for a non-empty, canonical-or-parseable UUID.
+// The empty value is rejected (a tenant boundary cannot be absent at the
+// point a TenantID is required); any non-UUID string is rejected.
+func (t TenantID) Validate() error {
+	return validateTenantIDString(string(t))
+}
+
+// UnmarshalJSON decodes data into t, failing closed if the JSON value is not a
+// string OR if the decoded string is empty / not a valid UUID. On success the
+// value is canonicalized to lowercase UUID form. Implements json.Unmarshaler.
+func (t *TenantID) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("tenant: TenantID: %w", err)
+	}
+	parsed, err := parseCanonical(raw)
+	if err != nil {
+		return err
+	}
+	*t = parsed
+	return nil
+}
+
+// MarshalJSON emits t as a JSON string. Implements json.Marshaler.
+func (t TenantID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(t))
+}
+
+// ParseTenantID validates s and returns a canonical (lowercase) TenantID.
+// Empty input is an error (TenantID has no absent semantic). Non-UUID input
+// is an error.
+func ParseTenantID(s string) (TenantID, error) {
+	return parseCanonical(s)
+}
+
+// parseCanonical is the single source of truth for TenantID's invariant:
+// non-empty + valid UUID, normalized to canonical lowercase form.
+func parseCanonical(s string) (TenantID, error) {
+	if s == "" {
+		return "", fmt.Errorf("tenant: TenantID required (empty)")
+	}
+	u, err := uuid.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("tenant: TenantID must be a UUID: %w", err)
+	}
+	return TenantID(u.String()), nil
+}
+
+// validateTenantIDString validates without producing the canonical form, so
+// Validate() can run on an already-constructed value (e.g. a struct field).
+func validateTenantIDString(s string) error {
+	_, err := parseCanonical(s)
+	return err
+}

--- a/pkg/tenant/tenant_id_test.go
+++ b/pkg/tenant/tenant_id_test.go
@@ -25,7 +25,7 @@ func TestTenantID_Validate(t *testing.T) {
 		{"empty rejected", TenantID(""), true},
 		{"non-uuid rejected", TenantID("not-a-uuid"), true},
 		{"safe-charset but not uuid rejected", TenantID("acme-tenant"), true},
-		{"uppercase uuid accepted by parser", TenantID(validTenantUUIDUp), false},
+		{"uppercase uuid rejected as non-canonical", TenantID(validTenantUUIDUp), true},
 		{"injection chars rejected", TenantID("3f2504e0-4f89-41d3-9a0c-0305e82c3301\n"), true},
 		// Forms google/uuid.Parse accepts but the canonical 36-char guard rejects:
 		{"compact 32-char rejected", TenantID("3f2504e04f8941d39a0c0305e82c3301"), true},

--- a/pkg/tenant/tenant_id_test.go
+++ b/pkg/tenant/tenant_id_test.go
@@ -27,6 +27,11 @@ func TestTenantID_Validate(t *testing.T) {
 		{"safe-charset but not uuid rejected", TenantID("acme-tenant"), true},
 		{"uppercase uuid accepted by parser", TenantID(validTenantUUIDUp), false},
 		{"injection chars rejected", TenantID("3f2504e0-4f89-41d3-9a0c-0305e82c3301\n"), true},
+		// Forms google/uuid.Parse accepts but the canonical 36-char guard rejects:
+		{"compact 32-char rejected", TenantID("3f2504e04f8941d39a0c0305e82c3301"), true},
+		{"brace-wrapped rejected", TenantID("{3f2504e0-4f89-41d3-9a0c-0305e82c3301}"), true},
+		{"urn-prefixed rejected", TenantID("urn:uuid:3f2504e0-4f89-41d3-9a0c-0305e82c3301"), true},
+		{"leading-space rejected", TenantID(" 3f2504e0-4f89-41d3-9a0c-0305e82c330"), true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -61,6 +66,18 @@ func TestParseTenantID(t *testing.T) {
 		t.Parallel()
 		_, err := ParseTenantID("garbage")
 		assert.Error(t, err)
+	})
+
+	t.Run("non-canonical UUID forms rejected", func(t *testing.T) {
+		t.Parallel()
+		for _, in := range []string{
+			"3f2504e04f8941d39a0c0305e82c3301",              // compact 32
+			"{3f2504e0-4f89-41d3-9a0c-0305e82c3301}",        // brace
+			"urn:uuid:3f2504e0-4f89-41d3-9a0c-0305e82c3301", // urn
+		} {
+			_, err := ParseTenantID(in)
+			assert.Error(t, err, "non-canonical form %q must be rejected", in)
+		}
 	})
 
 	t.Run("uppercase normalized to canonical lowercase", func(t *testing.T) {

--- a/pkg/tenant/tenant_id_test.go
+++ b/pkg/tenant/tenant_id_test.go
@@ -1,0 +1,122 @@
+package tenant
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	validTenantUUID   = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+	validTenantUUIDUp = "3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+)
+
+func TestTenantID_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      TenantID
+		wantErr bool
+	}{
+		{"valid uuid", TenantID(validTenantUUID), false},
+		{"empty rejected", TenantID(""), true},
+		{"non-uuid rejected", TenantID("not-a-uuid"), true},
+		{"safe-charset but not uuid rejected", TenantID("acme-tenant"), true},
+		{"uppercase uuid accepted by parser", TenantID(validTenantUUIDUp), false},
+		{"injection chars rejected", TenantID("3f2504e0-4f89-41d3-9a0c-0305e82c3301\n"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.in.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseTenantID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid uuid returns typed value", func(t *testing.T) {
+		t.Parallel()
+		got, err := ParseTenantID(validTenantUUID)
+		require.NoError(t, err)
+		assert.Equal(t, validTenantUUID, got.String())
+	})
+
+	t.Run("empty rejected (no absent semantic)", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseTenantID("")
+		assert.Error(t, err)
+	})
+
+	t.Run("non-uuid rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseTenantID("garbage")
+		assert.Error(t, err)
+	})
+
+	t.Run("uppercase normalized to canonical lowercase", func(t *testing.T) {
+		t.Parallel()
+		got, err := ParseTenantID(validTenantUUIDUp)
+		require.NoError(t, err)
+		assert.Equal(t, validTenantUUID, got.String(), "ParseTenantID must canonicalize to lowercase")
+	})
+}
+
+func TestTenantID_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		data    string
+		want    TenantID
+		wantErr bool
+	}{
+		{"valid uuid", `"` + validTenantUUID + `"`, TenantID(validTenantUUID), false},
+		{"uppercase canonicalized", `"` + validTenantUUIDUp + `"`, TenantID(validTenantUUID), false},
+		{"empty string rejected", `""`, "", true},
+		{"non-uuid rejected", `"garbage"`, "", true},
+		{"null rejected (no absent over wire)", `null`, "", true},
+		{"non-string json rejected", `123`, "", true},
+		{"malformed json rejected", `{`, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got TenantID
+			err := json.Unmarshal([]byte(tc.data), &got)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTenantID_MarshalJSONRoundtrip(t *testing.T) {
+	t.Parallel()
+	orig := TenantID(validTenantUUID)
+	b, err := json.Marshal(orig)
+	require.NoError(t, err)
+	assert.Equal(t, `"`+validTenantUUID+`"`, string(b))
+
+	var back TenantID
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, orig, back)
+}
+
+func TestTenantID_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, validTenantUUID, TenantID(validTenantUUID).String())
+	assert.Equal(t, "", TenantID("").String())
+	assert.False(t, strings.Contains(TenantID(validTenantUUID).String(), `"`))
+}

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -99,6 +100,19 @@ func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
 		if claims.Subject == "" {
 			return nil, false, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "token subject missing")
 		}
+		// Validate + canonicalize the tenant claim at the request trust
+		// boundary (fail-closed): a present-but-malformed tenant_id is a broken
+		// or forged token, mapped to the generic unauthorized response like
+		// every other verify failure (enumeration defense). Absent tenant is
+		// the single-tenant path and passes through. Downstream therefore sees
+		// either an empty tenant or a canonical lowercase UUID.
+		if claims.TenantID != "" {
+			tid, err := tenant.ParseTenantID(claims.TenantID)
+			if err != nil {
+				return nil, false, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "invalid token")
+			}
+			claims.TenantID = tid.String()
+		}
 		return jwtClaimsToPrincipal(claims), true, nil
 	})
 }
@@ -114,6 +128,7 @@ func jwtClaimsToPrincipal(c Claims) *Principal {
 		Subject:               c.Subject,
 		Roles:                 roles,
 		AuthMethod:            "jwt",
+		TenantID:              c.TenantID,
 		PasswordResetRequired: c.PasswordResetRequired,
 		Claims: map[string]string{
 			"sid":       c.SessionID,

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -100,19 +99,10 @@ func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
 		if claims.Subject == "" {
 			return nil, false, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "token subject missing")
 		}
-		// Validate + canonicalize the tenant claim at the request trust
-		// boundary (fail-closed): a present-but-malformed tenant_id is a broken
-		// or forged token, mapped to the generic unauthorized response like
-		// every other verify failure (enumeration defense). Absent tenant is
-		// the single-tenant path and passes through. Downstream therefore sees
-		// either an empty tenant or a canonical lowercase UUID.
-		if claims.TenantID != "" {
-			tid, err := tenant.ParseTenantID(claims.TenantID)
-			if err != nil {
-				return nil, false, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "invalid token")
-			}
-			claims.TenantID = tid.String()
-		}
+		// claims.TenantID is already validated + canonicalized by the verifier
+		// (JWTVerifier.VerifyIntent, the single unbypassable chokepoint); no
+		// per-authenticator tenant check is needed or wanted here (a second
+		// validation site would be a redundant truth source).
 		return jwtClaimsToPrincipal(claims), true, nil
 	})
 }
@@ -120,7 +110,9 @@ func NewJWTAuthenticator(v IntentTokenVerifier) Authenticator {
 // jwtClaimsToPrincipal converts verified JWT Claims to a Principal.
 // Roles is a defensive copy so callers cannot mutate the underlying slice.
 // The Claims map contains exactly three entries (sid, iss, token_use);
-// other JWT fields (aud, exp, iat, …) are intentionally excluded.
+// other JWT fields (aud, exp, iat, …) are intentionally excluded. TenantID is
+// carried in the dedicated Principal.TenantID field (already canonicalized by
+// the verifier), not in the Claims map.
 func jwtClaimsToPrincipal(c Claims) *Principal {
 	roles := append([]string(nil), c.Roles...)
 	return &Principal{

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -472,6 +472,12 @@ func mapClaimsToClaims(mc jwt.MapClaims) Claims {
 	if sid, ok := mc["sid"].(string); ok {
 		c.SessionID = sid
 	}
+	// tenant_id is mapped verbatim here (pure decode, like sub/sid); the
+	// authenticator validates/canonicalizes it via pkg/tenant.ParseTenantID and
+	// fails closed on a malformed value. A non-string tenant_id leaves it empty.
+	if tid, ok := mc["tenant_id"].(string); ok {
+		c.TenantID = tid
+	}
 	// password_reset_required is only written when true; absence means false
 	// (backward compatible with tokens issued before Phase 3.5).
 	if v, ok := mc["password_reset_required"].(bool); ok && v {
@@ -527,6 +533,7 @@ var standardClaims = map[string]struct{}{
 	"exp": {}, "iat": {}, "nbf": {}, "roles": {},
 	tokenUseClaim:             {},
 	"sid":                     {},
+	"tenant_id":               {},
 	"password_reset_required": {},
 	"jti":                     {},
 	// S4d: authz_epoch removed from standardClaims so that any token still

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -209,26 +209,11 @@ func (v *JWTVerifier) VerifyIntent(ctx context.Context, tokenStr string, expecte
 	if err := v.checkIssuer(claims); err != nil {
 		return Claims{}, err
 	}
-	// Tenant claim validation (fail-closed) — armed at the single unbypassable
-	// chokepoint: VerifyIntent is the sole producer of Claims (mapClaimsToClaims
-	// is reachable only through parseAndVerify→VerifyIntent), so EVERY path that
-	// turns a JWT into a Principal (the HTTP AuthMiddleware path AND the
-	// NewJWTAuthenticator path) sees an already-validated, canonical tenant.
-	// A present-but-malformed tenant_id is a broken/forged token; reject it with
-	// the generic unauthorized envelope (enumeration defense), distinguishable
-	// only in server-side logs. Absent tenant is the single-tenant path and
-	// passes through. Downstream therefore sees either an empty tenant or a
-	// canonical lowercase UUID — never an unvalidated string.
-	if claims.TenantID != "" {
-		tid, perr := tenant.ParseTenantID(claims.TenantID)
-		if perr != nil {
-			return Claims{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
-				"invalid token",
-				errcode.WithInternal(errcode.InternalAttr("_", "tenant_id claim is not a valid UUID")),
-				errcode.WithCategory(errcode.CategoryAuth))
-		}
-		claims.TenantID = tid.String()
-	}
+	// Tenant claim is validated + canonicalized inside parseAndVerify (the decode
+	// boundary where the raw claims map is available, so present-but-non-string
+	// and present-but-empty are distinguishable from absent). By the time
+	// VerifyIntent sees claims, claims.TenantID is either empty (single-tenant
+	// path) or a canonical lowercase UUID — never an unvalidated string.
 	return claims, nil
 }
 
@@ -274,8 +259,9 @@ func stringFromHeader(header map[string]any, key string) string {
 }
 
 // parseAndVerify decodes the token, validates its signature, and returns both
-// the Claims and the raw JOSE header. It is the shared path of Verify and
-// VerifyIntent.
+// the Claims and the raw JOSE header. It is the sole internal path of
+// VerifyIntent (the only public verifier entry point), so the tenant-claim
+// fail-closed gate it arms covers every JWT→Principal path.
 func (v *JWTVerifier) parseAndVerify(_ context.Context, tokenStr string) (Claims, map[string]any, error) {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (any, error) {
 		// Inner errors use bare fmt.Errorf because jwt.Parse wraps them
@@ -339,7 +325,46 @@ func (v *JWTVerifier) parseAndVerify(_ context.Context, tokenStr string) (Claims
 		return Claims{}, nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "invalid token claims")
 	}
 
-	return mapClaimsToClaims(mapClaims), token.Header, nil
+	claims := mapClaimsToClaims(mapClaims)
+	if err := validateAndCanonicalizeTenant(mapClaims, &claims); err != nil {
+		return Claims{}, nil, err
+	}
+	return claims, token.Header, nil
+}
+
+// validateAndCanonicalizeTenant fails closed on the tenant_id claim and, on
+// success, rewrites claims.TenantID to its canonical lowercase UUID form. It
+// reads the RAW claims map (not the lossy mapped string) so that the three
+// cases are distinguishable:
+//
+//   - absent           → single-tenant path, claims.TenantID stays empty.
+//   - present non-string → 401 (broken/forged or federated-IdP-misconfigured token).
+//   - present string     → tenant.ParseTenantID rejects empty / non-canonical /
+//     non-UUID values with 401; a valid value is canonicalized.
+//
+// All rejections use the generic unauthorized envelope (enumeration defense);
+// the specific reason lives only in the server-side internal detail.
+func validateAndCanonicalizeTenant(mc jwt.MapClaims, claims *Claims) error {
+	raw, present := mc["tenant_id"]
+	if !present {
+		return nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
+			"invalid token",
+			errcode.WithInternal(errcode.InternalAttr("_", "tenant_id claim is not a string")),
+			errcode.WithCategory(errcode.CategoryAuth))
+	}
+	tid, err := tenant.ParseTenantID(s)
+	if err != nil {
+		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
+			"invalid token",
+			errcode.WithInternal(errcode.InternalAttr("_", "tenant_id claim is not a valid UUID")),
+			errcode.WithCategory(errcode.CategoryAuth))
+	}
+	claims.TenantID = tid.String()
+	return nil
 }
 
 // JWTIssuer signs JWT tokens with RS256 using the active key from a SigningKeyProvider.

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -207,6 +208,26 @@ func (v *JWTVerifier) VerifyIntent(ctx context.Context, tokenStr string, expecte
 	// independently distinguishable in structured logs.
 	if err := v.checkIssuer(claims); err != nil {
 		return Claims{}, err
+	}
+	// Tenant claim validation (fail-closed) — armed at the single unbypassable
+	// chokepoint: VerifyIntent is the sole producer of Claims (mapClaimsToClaims
+	// is reachable only through parseAndVerify→VerifyIntent), so EVERY path that
+	// turns a JWT into a Principal (the HTTP AuthMiddleware path AND the
+	// NewJWTAuthenticator path) sees an already-validated, canonical tenant.
+	// A present-but-malformed tenant_id is a broken/forged token; reject it with
+	// the generic unauthorized envelope (enumeration defense), distinguishable
+	// only in server-side logs. Absent tenant is the single-tenant path and
+	// passes through. Downstream therefore sees either an empty tenant or a
+	// canonical lowercase UUID — never an unvalidated string.
+	if claims.TenantID != "" {
+		tid, perr := tenant.ParseTenantID(claims.TenantID)
+		if perr != nil {
+			return Claims{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
+				"invalid token",
+				errcode.WithInternal(errcode.InternalAttr("_", "tenant_id claim is not a valid UUID")),
+				errcode.WithCategory(errcode.CategoryAuth))
+		}
+		claims.TenantID = tid.String()
 	}
 	return claims, nil
 }

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -163,7 +163,7 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 //   - session_id = p.Claims["sid"] — server-side session binding, when present.
 //   - tenant_id  = p.TenantID — the tenant isolation boundary, sourced from the
 //     JWT "tenant_id" claim (already validated + canonicalized by the JWT
-//     authenticator). Empty for service principals (a service token's callerCell
+//     verifier, JWTVerifier.VerifyIntent). Empty for service principals (a service token's callerCell
 //     is NOT a tenant — spec §service-token: tenant must come from a subject/
 //     tenant claim, never the caller cell id), anonymous principals, and
 //     single-tenant deployments.

--- a/runtime/auth/middleware.go
+++ b/runtime/auth/middleware.go
@@ -161,11 +161,15 @@ func handleAuthRequest(w http.ResponseWriter, r *http.Request, next http.Handler
 //   - subject_id = p.Subject  — the subject-of-record (JWT "sub"); empty for
 //     service principals.
 //   - session_id = p.Claims["sid"] — server-side session binding, when present.
-//   - tenant_id  is intentionally NOT written: auth.Principal carries no tenant
-//     field on develop (no source yet), so the key stays unset/empty.
+//   - tenant_id  = p.TenantID — the tenant isolation boundary, sourced from the
+//     JWT "tenant_id" claim (already validated + canonicalized by the JWT
+//     authenticator). Empty for service principals (a service token's callerCell
+//     is NOT a tenant — spec §service-token: tenant must come from a subject/
+//     tenant claim, never the caller cell id), anonymous principals, and
+//     single-tenant deployments.
 //
-// Only non-empty values are written so anonymous / sessionless / subjectless
-// tokens do not stamp empty principal fields onto produced entries.
+// Only non-empty values are written so anonymous / sessionless / subjectless /
+// tenantless tokens do not stamp empty principal fields onto produced entries.
 func injectPrincipalCtxKeys(ctx context.Context, p *Principal) context.Context {
 	if actor := actorOf(p); actor != "" {
 		ctx = ctxkeys.WithActorID(ctx, actor)
@@ -176,7 +180,9 @@ func injectPrincipalCtxKeys(ctx context.Context, p *Principal) context.Context {
 	if sid := p.Claims["sid"]; sid != "" {
 		ctx = ctxkeys.WithSessionID(ctx, sid)
 	}
-	// TenantID has no source on develop — see godoc above.
+	if p.TenantID != "" {
+		ctx = ctxkeys.WithTenantID(ctx, p.TenantID)
+	}
 	return ctx
 }
 

--- a/runtime/auth/middleware_test.go
+++ b/runtime/auth/middleware_test.go
@@ -868,7 +868,10 @@ func TestMatchPathTemplate(t *testing.T) {
 // bridge: after successful auth, the principal ctxkeys are populated so a
 // downstream outbox.NewEntry carries the principal across the async boundary.
 // actor_id == subject (no "act" impersonation claim on develop), session_id is
-// the "sid" claim, and tenant_id stays unset (auth.Principal has no tenant).
+// the "sid" claim, and tenant_id stays unset when the token carries no tenant_id
+// claim (the verifier here returns claims with no tenant — the single-tenant
+// path). The valid-tenant and malformed-tenant HTTP paths are covered by
+// TestAuthMiddleware_ValidTenant_InjectsCtxKey / _MalformedTenant_Returns401.
 func TestAuthMiddleware_InjectsPrincipalCtxKeys(t *testing.T) {
 	verifier := &mockVerifier{
 		claims: Claims{Subject: "usr-alice", SessionID: "sess-42", Roles: []string{"admin"}},
@@ -896,7 +899,7 @@ func TestAuthMiddleware_InjectsPrincipalCtxKeys(t *testing.T) {
 	assert.Equal(t, "usr-alice", gotActor, "actor_id equals subject when no act claim exists")
 	assert.True(t, sessionOK)
 	assert.Equal(t, "sess-42", gotSession)
-	assert.False(t, tenantOK, "tenant_id has no source on develop and must stay unset")
+	assert.False(t, tenantOK, "tenant_id stays unset when the token carries no tenant_id claim")
 	assert.Empty(t, gotTenant)
 }
 

--- a/runtime/auth/principal.go
+++ b/runtime/auth/principal.go
@@ -73,13 +73,22 @@ type Principal struct {
 	// user and anonymous principals.
 	CallerCellID string
 	// TenantID is the tenant isolation boundary the request belongs to, sourced
-	// from the JWT "tenant_id" claim. The JWT authenticator has already
-	// validated and canonicalized it via pkg/tenant.ParseTenantID (a malformed
-	// claim is rejected before a Principal is built), so a non-empty value is a
+	// from the JWT "tenant_id" claim. JWTVerifier.VerifyIntent (the single
+	// unbypassable chokepoint for JWT→Claims) has already validated and
+	// canonicalized it via pkg/tenant.ParseTenantID (a malformed claim is
+	// rejected before any Principal is built), so a non-empty value is a
 	// canonical lowercase UUID. Empty for service principals (a service token's
 	// callerCell is NOT a tenant), anonymous principals, and single-tenant
 	// deployments. injectPrincipalCtxKeys propagates a non-empty value to
 	// ctxkeys.TenantID for the outbox principal envelope.
+	//
+	// Deliberately typed string, not pkg/tenant.TenantID: the ctx/wire principal
+	// bridge is type-uniform string/SafeID (ctxkeys.With{Actor,Subject,Tenant,
+	// Session}ID all take string; outbox.PrincipalMetadata.TenantID is a frozen
+	// idutil.SafeID). tenant.TenantID is the REPO-layer typed parameter (PR-2's
+	// "漏传=compile error" Hard funnel); threading it through the wire path would
+	// only add string↔TenantID↔SafeID conversions. The repo layer re-types this
+	// string via tenant.ParseTenantID at its boundary.
 	TenantID string
 	// Claims is a read-only snapshot of supplementary JWT claims (e.g. "sid",
 	// "iss", "token_use"). Callers must treat Claims as a read-only snapshot;

--- a/runtime/auth/principal.go
+++ b/runtime/auth/principal.go
@@ -16,6 +16,15 @@ const (
 	PrincipalUser                    // JWT user
 	PrincipalService                 // service token / mTLS machine
 	PrincipalAnonymous               // public endpoint
+	// PrincipalDevice is a first-class device subject (e.g. an MDM-enrolled
+	// device), distinct from a human user — it feeds device-posture attributes
+	// to downstream ABAC / zero-trust evaluation. No device-token issuer exists
+	// on develop yet (the JWT authenticator still classifies every verified
+	// token as PrincipalUser); the kind is the type-foundation half of the
+	// multi-tenancy/ABAC epic. Adding it forces every PrincipalKind switch to
+	// gain an explicit branch — guarded by archtest
+	// PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01.
+	PrincipalDevice
 )
 
 func (k PrincipalKind) String() string {
@@ -28,6 +37,8 @@ func (k PrincipalKind) String() string {
 		return "service"
 	case PrincipalAnonymous:
 		return "anonymous"
+	case PrincipalDevice:
+		return "device"
 	default:
 		return "unknown"
 	}
@@ -61,6 +72,15 @@ type Principal struct {
 	// checked against ContractSpec.Clients by RequireCallerCell. Empty for
 	// user and anonymous principals.
 	CallerCellID string
+	// TenantID is the tenant isolation boundary the request belongs to, sourced
+	// from the JWT "tenant_id" claim. The JWT authenticator has already
+	// validated and canonicalized it via pkg/tenant.ParseTenantID (a malformed
+	// claim is rejected before a Principal is built), so a non-empty value is a
+	// canonical lowercase UUID. Empty for service principals (a service token's
+	// callerCell is NOT a tenant), anonymous principals, and single-tenant
+	// deployments. injectPrincipalCtxKeys propagates a non-empty value to
+	// ctxkeys.TenantID for the outbox principal envelope.
+	TenantID string
 	// Claims is a read-only snapshot of supplementary JWT claims (e.g. "sid",
 	// "iss", "token_use"). Callers must treat Claims as a read-only snapshot;
 	// mutating it has no effect on authentication decisions and may corrupt

--- a/runtime/auth/principal_test.go
+++ b/runtime/auth/principal_test.go
@@ -14,6 +14,7 @@ func TestPrincipalKind_String(t *testing.T) {
 		{PrincipalUser, "user"},
 		{PrincipalService, "service"},
 		{PrincipalAnonymous, "anonymous"},
+		{PrincipalDevice, "device"},
 		{PrincipalKind(99), "unknown"},
 	}
 	for _, tc := range tests {

--- a/runtime/auth/tenant_claim_test.go
+++ b/runtime/auth/tenant_claim_test.go
@@ -46,6 +46,29 @@ func signAccessTokenWithTenant(t *testing.T, ks *KeySet, tenantID string) string
 	return s
 }
 
+// signAccessTokenWithRawTenant signs an access JWT whose tenant_id claim is
+// ALWAYS present and set to the given raw value (any JSON type). Unlike
+// signAccessTokenWithTenant it does not omit the claim, so it can exercise the
+// present-but-empty-string and present-but-non-string fail-closed paths.
+func signAccessTokenWithRawTenant(t *testing.T, ks *KeySet, tenantVal any) string {
+	t.Helper()
+	raw := jwt.MapClaims{
+		"sub":       "user-1",
+		"iss":       "gocell",
+		"aud":       "gocell",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"token_use": string(TokenIntentAccess),
+		"tenant_id": tenantVal,
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, raw)
+	tok.Header["kid"] = ks.SigningKeyID()
+	tok.Header["typ"] = TypHeaderForIntent(TokenIntentAccess)
+	s, err := tok.SignedString(ks.SigningKey())
+	require.NoError(t, err)
+	return s
+}
+
 func newTenantTestVerifier(t *testing.T) (IntentTokenVerifier, *KeySet) {
 	t.Helper()
 	ks := mustTestKeySet(t)
@@ -71,10 +94,12 @@ func TestMapClaimsToClaims_TenantID_NotInExtra(t *testing.T) {
 	assert.False(t, inExtra, "tenant_id must not leak into Claims.Extra")
 }
 
-// TestMapClaimsToClaims_TenantID_NonString_Absent verifies a non-string
-// tenant_id claim leaves Claims.TenantID empty (treated as absent at the pure
-// mapping layer; the verifier never sees a value to reject).
-func TestMapClaimsToClaims_TenantID_NonString_Absent(t *testing.T) {
+// TestMapClaimsToClaims_TenantID_NonString_Empty verifies a non-string
+// tenant_id claim leaves Claims.TenantID empty at the PURE mapping layer. This
+// is not the security gate: the verifier (parseAndVerify) independently inspects
+// the raw claims map and fails closed on a present-but-non-string tenant_id —
+// see TestVerifyIntent_TenantClaim_NonString_Rejected.
+func TestMapClaimsToClaims_TenantID_NonString_Empty(t *testing.T) {
 	mc := jwt.MapClaims{"sub": "u1", "tenant_id": 12345}
 	c := mapClaimsToClaims(mc)
 	assert.Equal(t, "", c.TenantID, "non-string tenant_id must not populate Claims.TenantID")
@@ -119,6 +144,32 @@ func TestVerifyIntent_TenantClaim_Absent_OK(t *testing.T) {
 	claims, err := v.VerifyIntent(context.Background(), signAccessTokenWithTenant(t, ks, ""), TokenIntentAccess)
 	require.NoError(t, err)
 	assert.Equal(t, "", claims.TenantID)
+}
+
+// TestVerifyIntent_TenantClaim_EmptyString_Rejected verifies a present-but-empty
+// tenant_id claim fails closed. An empty string is a malformed tenant identifier
+// (TenantID has no absent semantic) and must NOT be silently collapsed to the
+// single-tenant path — that conflation is exactly the fail-open this guards.
+func TestVerifyIntent_TenantClaim_EmptyString_Rejected(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	_, err := v.VerifyIntent(context.Background(), signAccessTokenWithRawTenant(t, ks, ""), TokenIntentAccess)
+	require.Error(t, err, "present-but-empty tenant_id must be rejected, not treated as absent")
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ec.Code)
+}
+
+// TestVerifyIntent_TenantClaim_NonString_Rejected verifies a present-but-non-
+// string tenant_id claim (e.g. a JSON number) fails closed. A non-string tenant
+// claim is a broken/forged or federated-IdP-misconfigured token; treating it as
+// "no tenant" would bypass the fail-closed boundary.
+func TestVerifyIntent_TenantClaim_NonString_Rejected(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	_, err := v.VerifyIntent(context.Background(), signAccessTokenWithRawTenant(t, ks, 12345), TokenIntentAccess)
+	require.Error(t, err, "present-but-non-string tenant_id must be rejected, not treated as absent")
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ec.Code)
 }
 
 // --- production HTTP path (AuthMiddleware → handleAuthRequest) ---

--- a/runtime/auth/tenant_claim_test.go
+++ b/runtime/auth/tenant_claim_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -19,13 +21,12 @@ const (
 	tenantClaimUUIDUp = "3F2504E0-4F89-41D3-9A0C-0305E82C3301"
 )
 
-// TestClaims_TenantID_Parsed verifies the "tenant_id" claim is mapped to
-// Claims.TenantID by the real verifier (mirrors TestClaims_JTI_Parsed).
-func TestClaims_TenantID_Parsed(t *testing.T) {
-	ks := mustTestKeySet(t)
-	verifier, err := NewJWTVerifier(ks, clock.Real(), WithExpectedAudiences("gocell"))
-	require.NoError(t, err)
-
+// signAccessTokenWithTenant signs an access JWT carrying the given tenant_id
+// claim value (empty omits the claim). Mirrors the inline signing in
+// claims_test.go; used to exercise the REAL verifier (where tenant validation
+// is armed), not the stub.
+func signAccessTokenWithTenant(t *testing.T, ks *KeySet, tenantID string) string {
+	t.Helper()
 	raw := jwt.MapClaims{
 		"sub":       "user-1",
 		"iss":       "gocell",
@@ -33,18 +34,27 @@ func TestClaims_TenantID_Parsed(t *testing.T) {
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"iat":       time.Now().Unix(),
 		"token_use": string(TokenIntentAccess),
-		"tenant_id": tenantClaimUUID,
+	}
+	if tenantID != "" {
+		raw["tenant_id"] = tenantID
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, raw)
 	tok.Header["kid"] = ks.SigningKeyID()
 	tok.Header["typ"] = TypHeaderForIntent(TokenIntentAccess)
-	tokenStr, err := tok.SignedString(ks.SigningKey())
+	s, err := tok.SignedString(ks.SigningKey())
 	require.NoError(t, err)
-
-	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
-	require.NoError(t, err)
-	assert.Equal(t, tenantClaimUUID, claims.TenantID, "Claims.TenantID must be populated from tenant_id claim")
+	return s
 }
+
+func newTenantTestVerifier(t *testing.T) (IntentTokenVerifier, *KeySet) {
+	t.Helper()
+	ks := mustTestKeySet(t)
+	v, err := NewJWTVerifier(ks, clock.Real(), WithExpectedAudiences("gocell"))
+	require.NoError(t, err)
+	return v, ks
+}
+
+// --- mapping (pure decode) ---
 
 // TestMapClaimsToClaims_TenantID_NotInExtra verifies tenant_id is a standard
 // claim and does not leak into Claims.Extra.
@@ -62,79 +72,101 @@ func TestMapClaimsToClaims_TenantID_NotInExtra(t *testing.T) {
 }
 
 // TestMapClaimsToClaims_TenantID_NonString_Absent verifies a non-string
-// tenant_id claim leaves Claims.TenantID empty (treated as absent, like other
-// claim mappings — rejection of malformed *values* happens at the authenticator).
+// tenant_id claim leaves Claims.TenantID empty (treated as absent at the pure
+// mapping layer; the verifier never sees a value to reject).
 func TestMapClaimsToClaims_TenantID_NonString_Absent(t *testing.T) {
 	mc := jwt.MapClaims{"sub": "u1", "tenant_id": 12345}
 	c := mapClaimsToClaims(mc)
 	assert.Equal(t, "", c.TenantID, "non-string tenant_id must not populate Claims.TenantID")
 }
 
-// TestJWTAuthenticator_TenantClaim_Valid verifies a valid UUID tenant claim is
-// carried onto Principal.TenantID.
-func TestJWTAuthenticator_TenantClaim_Valid(t *testing.T) {
-	v := &stubVerifier{claims: Claims{
-		Subject:  "user-1",
-		Issuer:   "gocell",
-		TokenUse: TokenIntentAccess,
-		TenantID: tenantClaimUUID,
-	}}
-	a := NewJWTAuthenticator(v)
-	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+// --- verifier-level validation (the unbypassable chokepoint) ---
+
+// TestVerifyIntent_TenantClaim_Valid verifies a valid UUID tenant claim is
+// carried through the real verifier.
+func TestVerifyIntent_TenantClaim_Valid(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	claims, err := v.VerifyIntent(context.Background(), signAccessTokenWithTenant(t, ks, tenantClaimUUID), TokenIntentAccess)
 	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, tenantClaimUUID, p.TenantID)
+	assert.Equal(t, tenantClaimUUID, claims.TenantID)
 }
 
-// TestJWTAuthenticator_TenantClaim_Canonicalized verifies an uppercase tenant
-// claim is normalized to canonical lowercase on the Principal.
-func TestJWTAuthenticator_TenantClaim_Canonicalized(t *testing.T) {
-	v := &stubVerifier{claims: Claims{
-		Subject:  "user-1",
-		Issuer:   "gocell",
-		TokenUse: TokenIntentAccess,
-		TenantID: tenantClaimUUIDUp,
-	}}
-	a := NewJWTAuthenticator(v)
-	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+// TestVerifyIntent_TenantClaim_Canonicalized verifies the verifier normalizes
+// an uppercase tenant claim to canonical lowercase.
+func TestVerifyIntent_TenantClaim_Canonicalized(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	claims, err := v.VerifyIntent(context.Background(), signAccessTokenWithTenant(t, ks, tenantClaimUUIDUp), TokenIntentAccess)
 	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, tenantClaimUUID, p.TenantID, "tenant claim must be canonicalized to lowercase UUID")
+	assert.Equal(t, tenantClaimUUID, claims.TenantID, "verifier must canonicalize tenant claim to lowercase UUID")
 }
 
-// TestJWTAuthenticator_TenantClaim_Malformed_Rejected verifies a present-but-
-// malformed tenant claim fails closed (generic 401), not silently dropped.
-func TestJWTAuthenticator_TenantClaim_Malformed_Rejected(t *testing.T) {
-	v := &stubVerifier{claims: Claims{
-		Subject:  "user-1",
-		Issuer:   "gocell",
-		TokenUse: TokenIntentAccess,
-		TenantID: "not-a-uuid",
-	}}
-	a := NewJWTAuthenticator(v)
-	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+// TestVerifyIntent_TenantClaim_Malformed_Rejected verifies a present-but-
+// malformed tenant claim fails closed at the verifier (generic 401 envelope),
+// arming EVERY downstream JWT→Principal path.
+func TestVerifyIntent_TenantClaim_Malformed_Rejected(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	_, err := v.VerifyIntent(context.Background(), signAccessTokenWithTenant(t, ks, "not-a-uuid"), TokenIntentAccess)
 	require.Error(t, err)
-	assert.False(t, ok)
-	assert.Nil(t, p)
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
 	assert.Equal(t, errcode.ErrAuthUnauthorized, ec.Code)
 }
 
-// TestJWTAuthenticator_TenantClaim_Absent_OK verifies the single-tenant path:
-// no tenant claim → no error, empty Principal.TenantID.
-func TestJWTAuthenticator_TenantClaim_Absent_OK(t *testing.T) {
-	v := &stubVerifier{claims: Claims{
-		Subject:  "user-1",
-		Issuer:   "gocell",
-		TokenUse: TokenIntentAccess,
-	}}
-	a := NewJWTAuthenticator(v)
-	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+// TestVerifyIntent_TenantClaim_Absent_OK verifies the single-tenant path: no
+// tenant claim → no error, empty TenantID.
+func TestVerifyIntent_TenantClaim_Absent_OK(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	claims, err := v.VerifyIntent(context.Background(), signAccessTokenWithTenant(t, ks, ""), TokenIntentAccess)
 	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, "", p.TenantID)
+	assert.Equal(t, "", claims.TenantID)
 }
+
+// --- production HTTP path (AuthMiddleware → handleAuthRequest) ---
+
+// TestAuthMiddleware_MalformedTenant_Returns401 proves the production HTTP path
+// is armed: a malformed tenant_id JWT claim is rejected with 401 BEFORE the
+// handler runs. Uses the REAL verifier (validation lives there); the handler
+// must never be reached.
+func TestAuthMiddleware_MalformedTenant_Returns401(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	reached := false
+	handler := AuthMiddleware(clock.Real(), v)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	req.Header.Set("Authorization", "Bearer "+signAccessTokenWithTenant(t, ks, "not-a-uuid"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "malformed tenant_id must be rejected on the production HTTP path")
+	assert.False(t, reached, "handler must not run when the tenant claim is malformed")
+}
+
+// TestAuthMiddleware_ValidTenant_InjectsCtxKey proves a valid tenant claim on
+// the production HTTP path is canonicalized and propagated to ctxkeys.TenantID
+// for the downstream outbox principal envelope.
+func TestAuthMiddleware_ValidTenant_InjectsCtxKey(t *testing.T) {
+	v, ks := newTenantTestVerifier(t)
+	var gotTenant string
+	var tenantOK bool
+	handler := AuthMiddleware(clock.Real(), v)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant, tenantOK = ctxkeys.TenantIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data", nil)
+	req.Header.Set("Authorization", "Bearer "+signAccessTokenWithTenant(t, ks, tenantClaimUUIDUp))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, tenantOK, "tenant id must be written to ctx on the HTTP path")
+	assert.Equal(t, tenantClaimUUID, gotTenant, "ctx tenant must be the canonical lowercase UUID")
+}
+
+// --- injectPrincipalCtxKeys unit ---
 
 // TestInjectPrincipalCtxKeys_TenantWritten verifies a JWT principal with a
 // tenant writes ctxkeys.TenantID for downstream outbox propagation.
@@ -147,10 +179,13 @@ func TestInjectPrincipalCtxKeys_TenantWritten(t *testing.T) {
 }
 
 // TestInjectPrincipalCtxKeys_NoTenant_NotWritten verifies principals without a
-// tenant (service / single-tenant user) do not stamp the key.
+// tenant (service / single-tenant user) do not stamp the key, and asserts a
+// service principal carries no tenant (callerCellID is not a tenant).
 func TestInjectPrincipalCtxKeys_NoTenant_NotWritten(t *testing.T) {
+	svc := &Principal{Kind: PrincipalService, CallerCellID: "accesscore"}
+	assert.Empty(t, svc.TenantID, "service principals must not carry a tenant (callerCellID is not a tenant)")
 	for _, p := range []*Principal{
-		{Kind: PrincipalService, CallerCellID: "accesscore"},
+		svc,
 		{Kind: PrincipalUser, Subject: "u1"},
 	} {
 		ctx := injectPrincipalCtxKeys(context.Background(), p)

--- a/runtime/auth/tenant_claim_test.go
+++ b/runtime/auth/tenant_claim_test.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+const (
+	tenantClaimUUID   = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+	tenantClaimUUIDUp = "3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+)
+
+// TestClaims_TenantID_Parsed verifies the "tenant_id" claim is mapped to
+// Claims.TenantID by the real verifier (mirrors TestClaims_JTI_Parsed).
+func TestClaims_TenantID_Parsed(t *testing.T) {
+	ks := mustTestKeySet(t)
+	verifier, err := NewJWTVerifier(ks, clock.Real(), WithExpectedAudiences("gocell"))
+	require.NoError(t, err)
+
+	raw := jwt.MapClaims{
+		"sub":       "user-1",
+		"iss":       "gocell",
+		"aud":       "gocell",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"token_use": string(TokenIntentAccess),
+		"tenant_id": tenantClaimUUID,
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, raw)
+	tok.Header["kid"] = ks.SigningKeyID()
+	tok.Header["typ"] = TypHeaderForIntent(TokenIntentAccess)
+	tokenStr, err := tok.SignedString(ks.SigningKey())
+	require.NoError(t, err)
+
+	claims, err := verifier.VerifyIntent(context.Background(), tokenStr, TokenIntentAccess)
+	require.NoError(t, err)
+	assert.Equal(t, tenantClaimUUID, claims.TenantID, "Claims.TenantID must be populated from tenant_id claim")
+}
+
+// TestMapClaimsToClaims_TenantID_NotInExtra verifies tenant_id is a standard
+// claim and does not leak into Claims.Extra.
+func TestMapClaimsToClaims_TenantID_NotInExtra(t *testing.T) {
+	mc := jwt.MapClaims{
+		"sub":       "u1",
+		"tenant_id": tenantClaimUUID,
+		"custom":    "val",
+	}
+	c := mapClaimsToClaims(mc)
+	assert.Equal(t, tenantClaimUUID, c.TenantID)
+	assert.Equal(t, "val", c.Extra["custom"])
+	_, inExtra := c.Extra["tenant_id"]
+	assert.False(t, inExtra, "tenant_id must not leak into Claims.Extra")
+}
+
+// TestMapClaimsToClaims_TenantID_NonString_Absent verifies a non-string
+// tenant_id claim leaves Claims.TenantID empty (treated as absent, like other
+// claim mappings — rejection of malformed *values* happens at the authenticator).
+func TestMapClaimsToClaims_TenantID_NonString_Absent(t *testing.T) {
+	mc := jwt.MapClaims{"sub": "u1", "tenant_id": 12345}
+	c := mapClaimsToClaims(mc)
+	assert.Equal(t, "", c.TenantID, "non-string tenant_id must not populate Claims.TenantID")
+}
+
+// TestJWTAuthenticator_TenantClaim_Valid verifies a valid UUID tenant claim is
+// carried onto Principal.TenantID.
+func TestJWTAuthenticator_TenantClaim_Valid(t *testing.T) {
+	v := &stubVerifier{claims: Claims{
+		Subject:  "user-1",
+		Issuer:   "gocell",
+		TokenUse: TokenIntentAccess,
+		TenantID: tenantClaimUUID,
+	}}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, tenantClaimUUID, p.TenantID)
+}
+
+// TestJWTAuthenticator_TenantClaim_Canonicalized verifies an uppercase tenant
+// claim is normalized to canonical lowercase on the Principal.
+func TestJWTAuthenticator_TenantClaim_Canonicalized(t *testing.T) {
+	v := &stubVerifier{claims: Claims{
+		Subject:  "user-1",
+		Issuer:   "gocell",
+		TokenUse: TokenIntentAccess,
+		TenantID: tenantClaimUUIDUp,
+	}}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, tenantClaimUUID, p.TenantID, "tenant claim must be canonicalized to lowercase UUID")
+}
+
+// TestJWTAuthenticator_TenantClaim_Malformed_Rejected verifies a present-but-
+// malformed tenant claim fails closed (generic 401), not silently dropped.
+func TestJWTAuthenticator_TenantClaim_Malformed_Rejected(t *testing.T) {
+	v := &stubVerifier{claims: Claims{
+		Subject:  "user-1",
+		Issuer:   "gocell",
+		TokenUse: TokenIntentAccess,
+		TenantID: "not-a-uuid",
+	}}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, p)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ec.Code)
+}
+
+// TestJWTAuthenticator_TenantClaim_Absent_OK verifies the single-tenant path:
+// no tenant claim → no error, empty Principal.TenantID.
+func TestJWTAuthenticator_TenantClaim_Absent_OK(t *testing.T) {
+	v := &stubVerifier{claims: Claims{
+		Subject:  "user-1",
+		Issuer:   "gocell",
+		TokenUse: TokenIntentAccess,
+	}}
+	a := NewJWTAuthenticator(v)
+	p, ok, err := a.Authenticate(newGetRequest(t, "Bearer t"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "", p.TenantID)
+}
+
+// TestInjectPrincipalCtxKeys_TenantWritten verifies a JWT principal with a
+// tenant writes ctxkeys.TenantID for downstream outbox propagation.
+func TestInjectPrincipalCtxKeys_TenantWritten(t *testing.T) {
+	p := &Principal{Kind: PrincipalUser, Subject: "u1", TenantID: tenantClaimUUID}
+	ctx := injectPrincipalCtxKeys(context.Background(), p)
+	got, ok := ctxkeys.TenantIDFrom(ctx)
+	require.True(t, ok, "tenant id must be written to ctx")
+	assert.Equal(t, tenantClaimUUID, got)
+}
+
+// TestInjectPrincipalCtxKeys_NoTenant_NotWritten verifies principals without a
+// tenant (service / single-tenant user) do not stamp the key.
+func TestInjectPrincipalCtxKeys_NoTenant_NotWritten(t *testing.T) {
+	for _, p := range []*Principal{
+		{Kind: PrincipalService, CallerCellID: "accesscore"},
+		{Kind: PrincipalUser, Subject: "u1"},
+	} {
+		ctx := injectPrincipalCtxKeys(context.Background(), p)
+		_, ok := ctxkeys.TenantIDFrom(ctx)
+		assert.False(t, ok, "no tenant key when Principal.TenantID empty (kind=%v)", p.Kind)
+	}
+}

--- a/runtime/http/middleware/access_log.go
+++ b/runtime/http/middleware/access_log.go
@@ -94,7 +94,7 @@ func appendAccessLogContextAttrs(attrs []any, ctx context.Context) []any {
 // appendPrincipalAttrs adds caller identity fields from the auth.Principal:
 //   - service principal: caller_cell (non-empty CallerCellID only)
 //   - user principal:    subject
-//   - device principal:  device (the device id carried in Subject)
+//   - device principal:  device_id (the device id carried in Subject)
 //   - anonymous/unknown: no identity attr (nothing to attribute)
 //
 // The switch is exhaustive over auth.PrincipalKind by design — guarded by
@@ -116,7 +116,7 @@ func appendPrincipalAttrs(ctx context.Context, attrs []any) []any {
 		}
 	case auth.PrincipalDevice:
 		if p.Subject != "" {
-			attrs = append(attrs, slog.String("device", p.Subject))
+			attrs = append(attrs, slog.String("device_id", p.Subject))
 		}
 	case auth.PrincipalAnonymous, auth.PrincipalUnknown:
 		// No caller identity to log for anonymous or uninitialised principals.

--- a/runtime/http/middleware/access_log.go
+++ b/runtime/http/middleware/access_log.go
@@ -93,7 +93,13 @@ func appendAccessLogContextAttrs(attrs []any, ctx context.Context) []any {
 
 // appendPrincipalAttrs adds caller identity fields from the auth.Principal:
 //   - service principal: caller_cell (non-empty CallerCellID only)
-//   - user principal: subject
+//   - user principal:    subject
+//   - device principal:  device (the device id carried in Subject)
+//   - anonymous/unknown: no identity attr (nothing to attribute)
+//
+// The switch is exhaustive over auth.PrincipalKind by design — guarded by
+// archtest PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01 so a new kind forces a conscious
+// access-log decision here.
 func appendPrincipalAttrs(ctx context.Context, attrs []any) []any {
 	p, ok := auth.FromContext(ctx)
 	if !ok {
@@ -108,6 +114,12 @@ func appendPrincipalAttrs(ctx context.Context, attrs []any) []any {
 		if p.Subject != "" {
 			attrs = append(attrs, slog.String("subject", p.Subject))
 		}
+	case auth.PrincipalDevice:
+		if p.Subject != "" {
+			attrs = append(attrs, slog.String("device", p.Subject))
+		}
+	case auth.PrincipalAnonymous, auth.PrincipalUnknown:
+		// No caller identity to log for anonymous or uninitialised principals.
 	}
 	return attrs
 }

--- a/tools/archtest/ctxkeys_principal_write_caller_test.go
+++ b/tools/archtest/ctxkeys_principal_write_caller_test.go
@@ -89,17 +89,20 @@ import (
 const ctxkeysPkgPath = "github.com/ghbvf/gocell/pkg/ctxkeys"
 
 // principalSetterAllowlist maps each principal ctx-key setter to the
-// module-relative production files allowed to call it. WithTenantID has only the
-// consumer-restore writer because auth.Principal carries no tenant field on
-// develop (no producer source yet), so middleware.go never writes it.
+// module-relative production files allowed to call it. All four setters share
+// the same two writers: the auth request-boundary bridge (producer) and the
+// consumer-side RestoreToContext.
 //
-// This single-writer WithTenantID entry is the ctx-write half of
-// INV-SINGLE-TENANT-ONLY (#1289): it is intentional-but-latent — the absence of a
-// producer is the single-tenant invariant, not an oversight. It pairs with the
-// persistence-reach tripwire in cells/auditcore/internal/appender (a non-empty
-// principal.TenantID reaching audit persistence logs Error). When multi-tenancy
-// (epic #1296) lands, runtime/auth/middleware.go gains a WithTenantID call and
-// must be added to this allowlist. See ADR 202605281200-1042 §Amendment 2026-05-30.
+// WithTenantID gained its producer writer (runtime/auth/middleware.go) with the
+// multi-tenancy epic (#1337 PR-1): injectPrincipalCtxKeys now writes the JWT
+// "tenant_id" claim. This lifts the former ctx-write half of
+// INV-SINGLE-TENANT-ONLY (#1289) — the single-writer entry was a deliberate
+// placeholder for exactly this moment, not an oversight. The persistence-reach
+// tripwire in cells/auditcore/internal/appender (a non-empty principal.TenantID
+// reaching audit persistence logs Error) intentionally REMAINS until PR-2 wires
+// tenant-scoped audit query filtering; on develop the gocell issuer emits no
+// tenant_id claim, so ctx tenant stays empty and the tripwire is dead.
+// See ADR 202605281200-1042 §Amendment 2026-05-30.
 var principalSetterAllowlist = map[string]map[string]struct{}{
 	"WithActorID": {
 		"runtime/auth/middleware.go": {}, // producer bridge (JWT + service-token)
@@ -114,7 +117,8 @@ var principalSetterAllowlist = map[string]map[string]struct{}{
 		"kernel/outbox/principal.go": {},
 	},
 	"WithTenantID": {
-		"kernel/outbox/principal.go": {}, // only RestoreToContext (no producer source on develop)
+		"runtime/auth/middleware.go": {}, // producer bridge — JWT tenant_id claim (#1337)
+		"kernel/outbox/principal.go": {}, // consumer-side RestoreToContext
 	},
 }
 

--- a/tools/archtest/internal/principalkindfixture/fixture.go
+++ b/tools/archtest/internal/principalkindfixture/fixture.go
@@ -1,0 +1,28 @@
+//go:build archtest_fixture
+
+// Package principalkindfixture is the PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01
+// reverse self-check corpus. It imports the real runtime/auth.PrincipalKind and
+// contains a deliberately NON-exhaustive switch (covers only PrincipalUser, no
+// default) so the detector scanPrincipalKindSwitches, pointed at this package,
+// must report the missing constants (PrincipalUnknown / PrincipalService /
+// PrincipalAnonymous / PrincipalDevice). Bypassing the reverse check requires
+// editing this real, type-checked source — not a hand-crafted AST.
+//
+// Loaded as a real Go package via packages.Load with the archtest_fixture build
+// tag (RunTypedFixture); the tag keeps it out of every production scan and
+// `go build ./...`.
+//
+// DO NOT use this package in production code.
+package principalkindfixture
+
+import "github.com/ghbvf/gocell/runtime/auth"
+
+// nonExhaustive is the RED case: a switch on auth.PrincipalKind that handles
+// only PrincipalUser and omits every other constant, with no default clause.
+func nonExhaustive(k auth.PrincipalKind) string {
+	switch k {
+	case auth.PrincipalUser:
+		return "user"
+	}
+	return ""
+}

--- a/tools/archtest/internal/principalkindifchainfixture/fixture.go
+++ b/tools/archtest/internal/principalkindifchainfixture/fixture.go
@@ -1,0 +1,25 @@
+//go:build archtest_fixture
+
+// Package principalkindifchainfixture is the PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01
+// blind-spot reverse self-check (charter §"强制盲区自检"). The rule deliberately
+// scopes itself to `switch` statements; if/else-if chains comparing PrincipalKind
+// are OUT of scope. This fixture contains ONLY a non-exhaustive if/else-if chain
+// over auth.PrincipalKind (no switch). The detector scanPrincipalKindSwitches,
+// pointed at this package, MUST produce ZERO diagnostics — proving the if-chain
+// blind spot is a true non-false-positive, not an accidental gap.
+//
+// DO NOT use this package in production code.
+package principalkindifchainfixture
+
+import "github.com/ghbvf/gocell/runtime/auth"
+
+// ifChain handles only some PrincipalKind values via an if/else-if chain (no
+// PrincipalDevice, no switch). The exhaustiveness rule must NOT flag this.
+func ifChain(k auth.PrincipalKind) string {
+	if k == auth.PrincipalUser {
+		return "user"
+	} else if k == auth.PrincipalService {
+		return "service"
+	}
+	return "other"
+}

--- a/tools/archtest/principal_kind_exhaustive_switch_test.go
+++ b/tools/archtest/principal_kind_exhaustive_switch_test.go
@@ -1,0 +1,240 @@
+// principal_kind_exhaustive_switch_test.go — forces every production switch on
+// runtime/auth.PrincipalKind to explicitly handle every declared constant, so
+// adding a new kind (e.g. PrincipalDevice for the multi-tenancy/ABAC epic)
+// breaks CI until each switch gains a conscious branch.
+//
+//   - INVARIANT: PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01
+//
+// # What this guards
+//
+// PrincipalKind is an open enum that downstream authz / observability code
+// switches on. A `default:` clause silently absorbs a newly-added kind
+// (PrincipalDevice would fall through PrincipalKind.String()'s default and
+// stringify as "unknown"), hiding the fanout obligation. This rule enumerates
+// the full constant set of runtime/auth.PrincipalKind via go/types and requires
+// every production switch whose tag is that type to list each constant as an
+// explicit case. A `default:` clause does NOT excuse a missing constant — the
+// point is to force a deliberate per-kind decision at every switch.
+//
+// # AI-robust rating (charter §"立项硬门槛")
+//
+//   - Medium. Detection is go/types-aware (the tag's *types.Named is resolved
+//     by package path + type name, and case exprs are resolved to *types.Const
+//     of that type — import aliases and dot-imports resolve identically), but it
+//     is archtest-bound, not type-system-Hard: Go has no compile-time exhaustive
+//     switch. The only Hard path would be a codegen funnel that generates the
+//     String() method + a keyless-struct-literal compile-exhaustion table from a
+//     single enum source (the SAGA-STATUS-FANOUT-COVERAGE-01 shape); that is
+//     disproportionate for a five-value enum with a single fan-out site today.
+//     This matches the spec's Medium rating (tasks.md T1.3). No gh upgrade issue
+//     is opened: the codegen-funnel cost exceeds its benefit here, recorded in
+//     this godoc rather than tracked as latent work.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//   - if/else-if chains comparing p.Kind (e.g. `if p.Kind == PrincipalUser`) are
+//     NOT switches and are out of scope — they are not exhaustiveness carriers,
+//     and a new kind that falls through such a chain is handled by the chain's
+//     terminal branch by construction. The fanout review (#1339) confirmed the
+//     only PrincipalKind switch today is String(); the if-chains in authz.go are
+//     correct for PrincipalDevice without change (device is neither user nor
+//     service). Asserted indirectly: the reverse fixture proves the scanner
+//     fires on a real switch, and the production pass proves String() is covered.
+//   - Nested switches: only direct CaseClause children of the matched SwitchStmt
+//     are read (sw.Body.List), so a PrincipalKind switch nested inside a case of
+//     an unrelated switch is still evaluated on its own tag — no contamination.
+//   - A switch with no tag (`switch { case x == PrincipalUser: }`) has no single
+//     enum tag type and is not matched; such a form expresses arbitrary boolean
+//     predicates, not enum exhaustiveness.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	principalKindPkgPath  = "github.com/ghbvf/gocell/runtime/auth"
+	principalKindTypeName = "PrincipalKind"
+)
+
+// TestPrincipalKindExhaustiveSwitch01 asserts every production switch on
+// runtime/auth.PrincipalKind explicitly covers all declared constants.
+func TestPrincipalKindExhaustiveSwitch01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	diags := RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		return scanPrincipalKindSwitches(p)
+	})
+	Report(t, "PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01", diags)
+}
+
+// TestPrincipalKindExhaustiveSwitch01_ReverseFixture is the anti-vacuity
+// reverse self-check: a real type-checked fixture package with a non-exhaustive
+// PrincipalKind switch MUST be flagged, and the missing kind must be named.
+func TestPrincipalKindExhaustiveSwitch01_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/principalkindfixture/..."},
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			return scanPrincipalKindSwitches(p)
+		})
+	require.NotEmpty(t, diags,
+		"non-exhaustive PrincipalKind switch in the fixture must be flagged; "+
+			"an empty result means the scanner regressed (vacuous pass)")
+	var joined strings.Builder
+	for _, d := range diags {
+		joined.WriteString(d.Message)
+		joined.WriteByte('\n')
+	}
+	assert.Contains(t, joined.String(), "PrincipalDevice",
+		"the missing-case diagnostic must name the newly-added kind")
+}
+
+// scanPrincipalKindSwitches reports every production switch whose tag type is
+// runtime/auth.PrincipalKind and whose explicit case set omits any declared
+// constant of that type. A default clause is irrelevant (does not excuse a
+// missing constant).
+func scanPrincipalKindSwitches(p *Pass) []Diagnostic {
+	var ds []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		if strings.HasSuffix(rel, "_test.go") {
+			continue
+		}
+		EachInSubtree[ast.SwitchStmt](file, func(sw *ast.SwitchStmt) {
+			if sw.Tag == nil {
+				return
+			}
+			tv, ok := p.TypesInfo.Types[sw.Tag]
+			if !ok || !isPrincipalKindType(tv.Type) {
+				return
+			}
+			want := principalKindDeclaredConsts(tv.Type)
+			if len(want) == 0 {
+				return
+			}
+			got := principalKindCaseConsts(sw, p.TypesInfo)
+			missing := make([]string, 0, len(want))
+			for name := range want {
+				if !got[name] {
+					missing = append(missing, name)
+				}
+			}
+			if len(missing) == 0 {
+				return
+			}
+			sort.Strings(missing)
+			ds = append(ds, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(sw.Pos()).Line,
+				Message: fmt.Sprintf(
+					"PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01: switch on %s.%s is missing explicit "+
+						"case(s) for %s. A default clause does NOT excuse a missing enum constant — "+
+						"add the case so a newly-added kind (e.g. PrincipalDevice) forces a conscious "+
+						"branch at every switch.",
+					principalKindPkgPath, principalKindTypeName, strings.Join(missing, ", ")),
+			})
+		})
+	}
+	return ds
+}
+
+// isPrincipalKindType reports whether t is the named type
+// runtime/auth.PrincipalKind (resolved by package path + name, alias-proof).
+func isPrincipalKindType(t types.Type) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Pkg() != nil &&
+		obj.Pkg().Path() == principalKindPkgPath &&
+		obj.Name() == principalKindTypeName
+}
+
+// principalKindDeclaredConsts enumerates, via go/types, every package-scope
+// constant whose named type is runtime/auth.PrincipalKind. The scope is reached
+// through the switch tag's own *types.Named, so enumeration works from any
+// package that switches on PrincipalKind, not just runtime/auth itself.
+func principalKindDeclaredConsts(t types.Type) map[string]bool {
+	out := map[string]bool{}
+	named, ok := t.(*types.Named)
+	if !ok || named.Obj().Pkg() == nil {
+		return out
+	}
+	scope := named.Obj().Pkg().Scope()
+	for _, name := range scope.Names() {
+		if cn, ok := principalKindConstName(scope.Lookup(name)); ok {
+			out[cn] = true
+		}
+	}
+	return out
+}
+
+// principalKindCaseConsts returns the set of PrincipalKind constant names listed
+// in the direct case clauses of sw (a default clause contributes nothing).
+func principalKindCaseConsts(sw *ast.SwitchStmt, info *types.Info) map[string]bool {
+	got := map[string]bool{}
+	for _, stmt := range sw.Body.List {
+		cc, ok := stmt.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, e := range cc.List {
+			if name, ok := principalKindCaseConstName(e, info); ok {
+				got[name] = true
+			}
+		}
+	}
+	return got
+}
+
+// principalKindCaseConstName resolves a case expression (bare Ident or
+// pkg.Selector) to a PrincipalKind constant name.
+func principalKindCaseConstName(e ast.Expr, info *types.Info) (string, bool) {
+	var id *ast.Ident
+	switch x := e.(type) {
+	case *ast.Ident:
+		id = x
+	case *ast.SelectorExpr:
+		id = x.Sel
+	default:
+		return "", false
+	}
+	if id == nil {
+		return "", false
+	}
+	return principalKindConstName(info.ObjectOf(id))
+}
+
+// principalKindConstName reports the constant's name when obj is a *types.Const
+// whose named type is runtime/auth.PrincipalKind.
+func principalKindConstName(obj types.Object) (string, bool) {
+	c, ok := obj.(*types.Const)
+	if !ok {
+		return "", false
+	}
+	if !isPrincipalKindType(c.Type()) {
+		return "", false
+	}
+	return c.Name(), true
+}

--- a/tools/archtest/principal_kind_exhaustive_switch_test.go
+++ b/tools/archtest/principal_kind_exhaustive_switch_test.go
@@ -38,8 +38,9 @@
 //     terminal branch by construction. The fanout review (#1339) confirmed the
 //     only PrincipalKind switch today is String(); the if-chains in authz.go are
 //     correct for PrincipalDevice without change (device is neither user nor
-//     service). Asserted indirectly: the reverse fixture proves the scanner
-//     fires on a real switch, and the production pass proves String() is covered.
+//     service). This blind spot is proven a non-false-positive by
+//     TestPrincipalKindExhaustiveSwitch01_IfChainNotScanned (a non-exhaustive
+//     if-chain fixture must yield ZERO diagnostics).
 //   - Nested switches: only direct CaseClause children of the matched SwitchStmt
 //     are read (sw.Body.List), so a PrincipalKind switch nested inside a case of
 //     an unrelated switch is still evaluated on its own tag — no contamination.
@@ -107,6 +108,27 @@ func TestPrincipalKindExhaustiveSwitch01_ReverseFixture(t *testing.T) {
 	}
 	assert.Contains(t, joined.String(), "PrincipalDevice",
 		"the missing-case diagnostic must name the newly-added kind")
+}
+
+// TestPrincipalKindExhaustiveSwitch01_IfChainNotScanned is the blind-spot
+// reverse self-check: a non-exhaustive if/else-if chain over PrincipalKind (no
+// switch) MUST yield zero diagnostics — proving the rule's switch-only scope is
+// a deliberate non-false-positive, not an accidental gap.
+func TestPrincipalKindExhaustiveSwitch01_IfChainNotScanned(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/principalkindifchainfixture/..."},
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			return scanPrincipalKindSwitches(p)
+		})
+	assert.Empty(t, diags,
+		"if/else-if chains over PrincipalKind are out of scope and must not be flagged")
 }
 
 // scanPrincipalKindSwitches reports every production switch whose tag type is

--- a/tools/archtest/principal_kind_exhaustive_switch_test.go
+++ b/tools/archtest/principal_kind_exhaustive_switch_test.go
@@ -25,7 +25,8 @@
 //     switch. The only Hard path would be a codegen funnel that generates the
 //     String() method + a keyless-struct-literal compile-exhaustion table from a
 //     single enum source (the SAGA-STATUS-FANOUT-COVERAGE-01 shape); that is
-//     disproportionate for a five-value enum with a single fan-out site today.
+//     disproportionate for a five-value enum with only a couple of fan-out sites
+//     today (PrincipalKind.String() and middleware.appendPrincipalAttrs).
 //     This matches the spec's Medium rating (tasks.md T1.3). No gh upgrade issue
 //     is opened: the codegen-funnel cost exceeds its benefit here, recorded in
 //     this godoc rather than tracked as latent work.
@@ -35,10 +36,11 @@
 //   - if/else-if chains comparing p.Kind (e.g. `if p.Kind == PrincipalUser`) are
 //     NOT switches and are out of scope — they are not exhaustiveness carriers,
 //     and a new kind that falls through such a chain is handled by the chain's
-//     terminal branch by construction. The fanout review (#1339) confirmed the
-//     only PrincipalKind switch today is String(); the if-chains in authz.go are
-//     correct for PrincipalDevice without change (device is neither user nor
-//     service). This blind spot is proven a non-false-positive by
+//     terminal branch by construction. The production PrincipalKind switches
+//     today are PrincipalKind.String() and middleware.appendPrincipalAttrs (the
+//     access-log fanout #1339 added); the if-chains in authz.go are correct for
+//     PrincipalDevice without change (device is neither user nor service). This
+//     blind spot is proven a non-false-positive by
 //     TestPrincipalKindExhaustiveSwitch01_IfChainNotScanned (a non-exhaustive
 //     if-chain fixture must yield ZERO diagnostics).
 //   - Nested switches: only direct CaseClause children of the matched SwitchStmt
@@ -62,7 +64,9 @@ import (
 )
 
 const (
-	principalKindPkgPath  = "github.com/ghbvf/gocell/runtime/auth"
+	// Derived from PlatformModulePath (ARCHTEST-MODULE-PATH-FUNNEL-01) so a
+	// module rename updates exactly one place — never a bare literal.
+	principalKindPkgPath  = PlatformModulePath + "/runtime/auth"
 	principalKindTypeName = "PrincipalKind"
 )
 
@@ -216,17 +220,13 @@ func principalKindDeclaredConsts(t types.Type) map[string]bool {
 // in the direct case clauses of sw (a default clause contributes nothing).
 func principalKindCaseConsts(sw *ast.SwitchStmt, info *types.Info) map[string]bool {
 	got := map[string]bool{}
-	for _, stmt := range sw.Body.List {
-		cc, ok := stmt.(*ast.CaseClause)
-		if !ok {
-			continue
-		}
+	EachInChildren[ast.CaseClause](sw.Body, func(cc *ast.CaseClause) {
 		for _, e := range cc.List {
 			if name, ok := principalKindCaseConstName(e, info); ok {
 				got[name] = true
 			}
 		}
-	}
+	})
 	return got
 }
 


### PR DESCRIPTION
## Summary

EPIC #1337 Wave 0 类型地基（全员前置）。落地多租户/ABAC 的类型底座 + 打通 JWT tenant claim 生产来源，消除 `injectPrincipalCtxKeys` 的「no source on develop」。

- **`pkg/tenant/tenant_id.go`** — `TenantID` sealed newtype，对齐 `idutil.SafeID`。与 SafeID 不同：**空值无效**（tenant 查询不可缺 tenant），非空须 canonical UUID。runtime fail-fast（`Validate`/`ParseTenantID`/`UnmarshalJSON`）。
- **`pkg/tenant/rowscope.go`** — `RowScope` typed obligation enum `{self,device,tenant,all}`，零值 invalid。**仅类型，消费在 PR-4**。
- **`runtime/auth` + `kernel/auth`** — `Claims.TenantID` / `Principal.TenantID` 一等字段（镜像 SessionID）；`jwt.go` 映射 `tenant_id` claim（standardClaims，不入 Extra）；JWT authenticator 边界经 `tenant.ParseTenantID` **fail-closed 校验 + canonical 归一**（malformed UUID → 401）；`injectPrincipalCtxKeys` 写 `ctxkeys.WithTenantID`（service 主体无 tenant）。
- **`PrincipalKind` 增 `PrincipalDevice`** — device 一等主体类型地基；`jwtClaimsToPrincipal` 仍产 `PrincipalUser`（develop 无 device 签发方，device 分类随 MDM #1051）。

## Enforcement（同 PR 闭环）

| ID | 评级 | 说明 |
|----|------|------|
| `CTXKEYS-PRINCIPAL-WRITE-CALLER-01`（扩） | Hard 下游 / Medium 上游（#1282） | `WithTenantID` allowlist 增 producer 写入方 |
| `PRINCIPAL-KIND-EXHAUSTIVE-SWITCH-01`（新） | Medium | 生产 `switch on PrincipalKind` 须显式覆盖全部常量（default 不豁免）+ 反向自检 fixture |
| `tenant.TenantID.Validate()` 空值+UUID | Medium（Hard 来源=PR-2 repo typed param） | runtime fail-fast |

> 新 archtest 实跑时**捕获了一处手工 fanout 扫描漏掉的 switch**（`access_log.go`），已修（device 真实分支）。auditcore `INV-SINGLE-TENANT-ONLY` 哨兵刻意保留给 PR-2。

## 设计决策（与用户确认）

- device 只做类型地基（不投机 device-claim 分类）；tenant 走一等 typed 字段；TenantID = 非空 + UUID。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] `go test ./...`（全绿）
- [x] `go vet -tags=integration ./...` + `go vet -tags=e2e ./tests/e2e/...`（编译校验导出签名变更）
- [x] `golangci-lint run ./...`（0 issues）
- [x] 全 archtest suite `go test ./tools/archtest/`（含新 invariant + 反向自检，全绿）
- [x] `pkg/tenant` 100% 覆盖；T1.7 claim present/missing/malformed 全覆盖

ref: pkg/idutil/safeid.go; Microsoft Entra idtyp claim; XACML 3.0 obligation model; openfga typesystem.

Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)