### PR TITLE
fix(ci): otel attribute Value.Emit 弃用替换为 Value.String

### DIFF
--- a/adapters/otel/tracer_test.go
+++ b/adapters/otel/tracer_test.go
@@ -108,7 +108,7 @@ func TestTracer_SetAttribute(t *testing.T) {
 	// Build attribute map for precise assertions.
 	got := make(map[string]string, len(spans[0].Attributes))
 	for _, kv := range spans[0].Attributes {
-		got[string(kv.Key)] = kv.Value.Emit()
+		got[string(kv.Key)] = kv.Value.String()
 	}
 
 	assert.Equal(t, "[redacted bytes len=5 sha256=277089d91c0bdf4f]", got["bytes_key"],


### PR DESCRIPTION
## Summary

go-opentelemetry group bump (#1363, commit 693b5c651) 升到 otel `v1.44.0` 后，`attribute.Value.Emit()` 被标记 deprecated（SA1019）。kernel `build-test` 的 `golangci-lint` 步骤 staticcheck 报红，develop 分支 CI 失败（run 26703619227 / job 78700789068）。

`adapters/otel/tracer_test.go:111` 是全仓库唯一占用点（golangci-lint root-scan 仅报 1 处），替换为官方推荐的 `Value.String()`——对所有 attribute 类型返回相同字符串表示，测试断言不变。

## Root cause
弃用 API：`kv.Value.Emit()` → `kv.Value.String()`。

## Test plan
- [x] `go test ./adapters/otel/ -run TestTracer` 通过（int=42 / struct={1} / redacted-bytes 断言保持）
- [x] `golangci-lint run ./adapters/otel/...` → 0 issues

ref: open-telemetry/opentelemetry-go attribute/value.go (Value.String replaces deprecated Emit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)