### PR TITLE
feat(metrics): http_request_body_limit_rejections_total counter [#1166]

### DIFF
--- a/assemblies/corebundle/generated/metrics-schema.yaml
+++ b/assemblies/corebundle/generated/metrics-schema.yaml
@@ -253,6 +253,15 @@ metrics:
       labels:
         - reason
       file: kernel/assembly/hook_dispatcher.go
+    - name: http_request_body_limit_rejections_total
+      fqName: gocell_http_request_body_limit_rejections_total
+      namespace: gocell
+      type: counter
+      help: Total number of HTTP requests rejected for exceeding the body size limit (Content-Length fast-path).
+      labels:
+        - cell
+        - route
+      file: runtime/bootstrap/phases_http.go
     - name: http_request_duration_seconds
       fqName: gocell_http_request_duration_seconds
       namespace: gocell

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -59,6 +59,8 @@ remote-write 或业务专用 Prometheus 若不需要 runtime series，可在 scr
 metric_relabel_configs:
 - source_labels: [__name__, cell]
   regex: 'gocell_http_(requests_total|request_duration_seconds(_bucket|_sum|_count)?|request_body_limit_rejections_total);_runtime'
+  # Note: request_body_limit_rejections_total is a counter — it has no _bucket/_sum/_count
+  # suffixes (those belong to histograms/summaries only). The regex matches the bare metric name.
   action: drop
 ```
 
@@ -73,7 +75,7 @@ Label 语义：
 | label | 含义 |
 |---|---|
 | `cell` | 同 `http_requests_total.cell`：路由归属 cell ID，或 `_runtime`（框架路径） |
-| `route` | 低基数路由模板（同 RouteFor 返回值；fast-path 期间 ServeMux 尚未写入 pattern recorder，回退到 RouteResolver 或 `"unmatched"`） |
+| `route` | 低基数路由模板（同 RouteFor 返回值）。当请求路径与已注册路由匹配时，RouteResolver 返回路由模板（如 `/api/v1/upload/blob`）；仅当路径无法匹配任何已注册路由时才回退到 `"unmatched"`。fast-path 期间 ServeMux 尚未写入 pattern recorder，故由 RouteResolver（ctx 中由 CellAttribution 注入）负责模板解析。 |
 
 推荐告警（短时突增，提示 client 配置错误或资源滥用）：
 

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -67,8 +67,11 @@ metric_relabel_configs:
 ## HTTP Body-Limit 拒绝计数器
 
 `gocell_http_request_body_limit_rejections_total{cell, route}` 记录 BodyLimit 中间件
-因 Content-Length 超限（fast-path）返回 413 的次数。流式超限（MaxBytesReader）已通过
-`gocell_http_requests_total{status="413"}` 覆盖，不重复计数。
+因 Content-Length 超限（fast-path）返回 413 的次数。流式超限（MaxBytesReader 在读
+body 时触发）依赖 handler 将 `*http.MaxBytesError` 通过 `pkg/httputil.WriteError`
+映射为 413：框架生成的 handler 走此路径，其产生的 413 会计入
+`gocell_http_requests_total{status="413"}`；自定义 handler 若不调用 `httputil.WriteError`
+则不会产生 413 计数。两路 413 计数来源不同，不重复。
 
 Label 语义：
 
@@ -93,7 +96,11 @@ Label 语义：
       with Content-Length > body limit at >1/sec for 5m.
       Possible causes: client sending oversized payloads, misconfigured body limit,
       or DDoS amplification attempt.
-      Check slog for "request body too large" and review WithBodyLimit configuration.
+      排查：通过结构化日志字段定位拒绝请求（注意 4xx 日志默认每 100 条采样一条）：
+        code=ERR_BODY_TOO_LARGE status=413 cell_id=<cell> route=<route>
+      其中 cell_id 字段对应 kernel/ctxkeys.CellIDFrom（access log 记为 cell_id，
+      非 cell），request_id 字段可关联同一请求的跨日志记录。
+      同步检查 BodyLimit 配置（WithBodyLimit 参数）与客户端 Content-Length 分布。
 ```
 
 调试 PromQL：

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -58,8 +58,47 @@ remote-write 或业务专用 Prometheus 若不需要 runtime series，可在 scr
 ```yaml
 metric_relabel_configs:
 - source_labels: [__name__, cell]
-  regex: 'gocell_http_(requests_total|request_duration_seconds(_bucket|_sum|_count)?);_runtime'
+  regex: 'gocell_http_(requests_total|request_duration_seconds(_bucket|_sum|_count)?|request_body_limit_rejections_total);_runtime'
   action: drop
+```
+
+## HTTP Body-Limit 拒绝计数器
+
+`gocell_http_request_body_limit_rejections_total{cell, route}` 记录 BodyLimit 中间件
+因 Content-Length 超限（fast-path）返回 413 的次数。流式超限（MaxBytesReader）已通过
+`gocell_http_requests_total{status="413"}` 覆盖，不重复计数。
+
+Label 语义：
+
+| label | 含义 |
+|---|---|
+| `cell` | 同 `http_requests_total.cell`：路由归属 cell ID，或 `_runtime`（框架路径） |
+| `route` | 低基数路由模板（同 RouteFor 返回值；fast-path 期间 ServeMux 尚未写入 pattern recorder，回退到 RouteResolver 或 `"unmatched"`） |
+
+推荐告警（短时突增，提示 client 配置错误或资源滥用）：
+
+```yaml
+- alert: GoCellHTTPBodyLimitRejectionSpike
+  expr: |
+    sum(rate(gocell_http_request_body_limit_rejections_total{cell!="_runtime"}[5m])) by (cell, route) > 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "HTTP body-limit rejections spiking ({{ $labels.cell }}/{{ $labels.route }})"
+    description: |
+      Cell {{ $labels.cell }} route {{ $labels.route }} is rejecting requests
+      with Content-Length > body limit at >1/sec for 5m.
+      Possible causes: client sending oversized payloads, misconfigured body limit,
+      or DDoS amplification attempt.
+      Check slog for "request body too large" and review WithBodyLimit configuration.
+```
+
+调试 PromQL：
+
+```promql
+# 按 cell / route 分组的 body-limit 拒绝速率
+sum(rate(gocell_http_request_body_limit_rejections_total[5m])) by (cell, route)
 ```
 
 ---

--- a/examples/iotdevice/generated/metrics-schema.yaml
+++ b/examples/iotdevice/generated/metrics-schema.yaml
@@ -149,6 +149,13 @@ metrics:
       labels:
         - reason
       file: kernel/assembly/hook_dispatcher.go
+    - name: http_request_body_limit_rejections_total
+      type: counter
+      help: Total number of HTTP requests rejected for exceeding the body size limit (Content-Length fast-path).
+      labels:
+        - cell
+        - route
+      file: runtime/bootstrap/phases_http.go
     - name: http_request_duration_seconds
       type: histogram
       help: HTTP request duration in seconds.

--- a/examples/todoorder/generated/metrics-schema.yaml
+++ b/examples/todoorder/generated/metrics-schema.yaml
@@ -119,6 +119,13 @@ metrics:
       labels:
         - reason
       file: kernel/assembly/hook_dispatcher.go
+    - name: http_request_body_limit_rejections_total
+      type: counter
+      help: Total number of HTTP requests rejected for exceeding the body size limit (Content-Length fast-path).
+      labels:
+        - cell
+        - route
+      file: runtime/bootstrap/phases_http.go
     - name: http_request_duration_seconds
       type: histogram
       help: HTTP request duration in seconds.

--- a/runtime/http/middleware/body_limit.go
+++ b/runtime/http/middleware/body_limit.go
@@ -2,25 +2,34 @@ package middleware
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 
+	"github.com/ghbvf/gocell/kernel/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/observability"
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
 // DefaultBodyLimit is the default maximum request body size (1 MB).
 const DefaultBodyLimit int64 = 1 << 20
 
 // BodyLimit restricts the request body to at most maxBytes bytes.
-// If the body exceeds the limit, a 413 JSON error response is returned.
+// If the Content-Length header exceeds the limit, a 413 JSON error response is
+// returned immediately (fast-path) and the rejection is recorded via collector
+// when collector is non-nil. Streaming overruns after MaxBytesReader kicks in
+// are captured by http_requests_total{status=413} through RecordRequest.
 // Pass 0 or a negative value to use DefaultBodyLimit.
-func BodyLimit(maxBytes int64) func(http.Handler) http.Handler {
+// Pass nil collector to disable body-limit rejection recording.
+func BodyLimit(maxBytes int64, collector metrics.Collector) func(http.Handler) http.Handler {
 	if maxBytes <= 0 {
 		maxBytes = DefaultBodyLimit
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.ContentLength > maxBytes {
+				recordBodyLimitRejection(collector, r)
 				writeBodyTooLarge(r.Context(), w)
 				return
 			}
@@ -28,6 +37,24 @@ func BodyLimit(maxBytes int64) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// recordBodyLimitRejection extracts cell and route from the request context and
+// calls collector.RecordBodyLimitRejection. It is a no-op when collector is nil.
+// Complexity extracted here to keep BodyLimit's cognitive complexity ≤ 15.
+func recordBodyLimitRejection(collector metrics.Collector, r *http.Request) {
+	if collector == nil {
+		return
+	}
+	ctx := r.Context()
+	cellID := RuntimeCellIDSentinel
+	if v, ok := ctxkeys.CellIDFrom(ctx); ok && v != "" {
+		cellID = v
+	}
+	route := RouteFor(ctx, r.Method, r.URL.Path)
+	observability.SafeObserve(slog.Default(), func() {
+		collector.RecordBodyLimitRejection(ctx, cellID, route)
+	})
 }
 
 func writeBodyTooLarge(ctx context.Context, w http.ResponseWriter) {

--- a/runtime/http/middleware/body_limit.go
+++ b/runtime/http/middleware/body_limit.go
@@ -21,7 +21,11 @@ const DefaultBodyLimit int64 = 1 << 20
 // when collector is non-nil. Streaming overruns after MaxBytesReader kicks in
 // are captured by http_requests_total{status=413} through RecordRequest.
 // Pass 0 or a negative value to use DefaultBodyLimit.
-// Pass nil collector to disable body-limit rejection recording.
+//
+// collector=nil disables only the body-limit fast-path rejection counter
+// (RecordBodyLimitRejection); it does not affect streaming 413 accounting.
+// Streaming overruns are independently recorded by the Metrics middleware via
+// RecordRequest and remain observable regardless of the collector value here.
 func BodyLimit(maxBytes int64, collector metrics.Collector) func(http.Handler) http.Handler {
 	if maxBytes <= 0 {
 		maxBytes = DefaultBodyLimit

--- a/runtime/http/middleware/body_limit.go
+++ b/runtime/http/middleware/body_limit.go
@@ -18,14 +18,20 @@ const DefaultBodyLimit int64 = 1 << 20
 // BodyLimit restricts the request body to at most maxBytes bytes.
 // If the Content-Length header exceeds the limit, a 413 JSON error response is
 // returned immediately (fast-path) and the rejection is recorded via collector
-// when collector is non-nil. Streaming overruns after MaxBytesReader kicks in
-// are captured by http_requests_total{status=413} through RecordRequest.
+// when collector is non-nil.
+//
+// Streaming overruns (MaxBytesReader kick-in after the body starts being read)
+// are handler-dependent: the handler receives *http.MaxBytesError when reading
+// the body. Framework-generated handlers propagate this error through
+// pkg/httputil.WriteError, which maps it to a 413 response captured in
+// http_requests_total{status="413"} via the Metrics middleware's RecordRequest.
+// Custom handlers that do not call httputil.WriteError will not produce a 413
+// in http_requests_total.
+//
 // Pass 0 or a negative value to use DefaultBodyLimit.
 //
 // collector=nil disables only the body-limit fast-path rejection counter
 // (RecordBodyLimitRejection); it does not affect streaming 413 accounting.
-// Streaming overruns are independently recorded by the Metrics middleware via
-// RecordRequest and remain observable regardless of the collector value here.
 func BodyLimit(maxBytes int64, collector metrics.Collector) func(http.Handler) http.Handler {
 	if maxBytes <= 0 {
 		maxBytes = DefaultBodyLimit

--- a/runtime/http/middleware/body_limit_test.go
+++ b/runtime/http/middleware/body_limit_test.go
@@ -11,10 +11,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
 func TestBodyLimit_UnderLimit(t *testing.T) {
-	handler := BodyLimit(1024)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := BodyLimit(1024, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "hello", string(body))
@@ -30,7 +33,7 @@ func TestBodyLimit_UnderLimit(t *testing.T) {
 }
 
 func TestBodyLimit_ExactContentLengthOverLimit(t *testing.T) {
-	handler := BodyLimit(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := BodyLimit(10, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
 
@@ -51,7 +54,7 @@ func TestBodyLimit_ExactContentLengthOverLimit(t *testing.T) {
 }
 
 func TestBodyLimit_MaxBytesReaderTriggered(t *testing.T) {
-	handler := BodyLimit(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := BodyLimit(10, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.ReadAll(r.Body)
 		// MaxBytesReader returns an error when body exceeds limit
 		assert.Error(t, err)
@@ -66,7 +69,7 @@ func TestBodyLimit_MaxBytesReaderTriggered(t *testing.T) {
 }
 
 func TestBodyLimit_DefaultLimit(t *testing.T) {
-	handler := BodyLimit(0)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := BodyLimit(0, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -76,4 +79,98 @@ func TestBodyLimit_DefaultLimit(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestBodyLimit_RecordsRejectionMetric verifies that the Content-Length
+// fast-path rejection increments the body-limit rejection counter.
+func TestBodyLimit_RecordsRejectionMetric(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	handler := BodyLimit(10, mc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run when body limit rejects")
+	}))
+
+	body := bytes.Repeat([]byte("x"), 20)
+	req := httptest.NewRequest(http.MethodPost, "/upload", bytes.NewReader(body))
+	req.ContentLength = 20
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	snap := mc.Snapshot()
+	// No ctxkeys.CellID in ctx → falls back to RuntimeCellIDSentinel.
+	// No RouteResolver in ctx → RouteFor falls back to UnmatchedRoute.
+	key := metrics.BodyLimitRejectionKey{
+		Cell:  RuntimeCellIDSentinel,
+		Route: UnmatchedRoute,
+	}
+	assert.Equal(t, int64(1), snap.BodyLimitRejections[key],
+		"body-limit rejection counter must be incremented exactly once on Content-Length fast-path reject")
+}
+
+// TestBodyLimit_NilCollector_NoRejectionCounted verifies that passing nil
+// collector does not panic and no counter is incremented.
+func TestBodyLimit_NilCollector_NoRejectionCounted(t *testing.T) {
+	handler := BodyLimit(10, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run")
+	}))
+
+	body := bytes.Repeat([]byte("x"), 20)
+	req := httptest.NewRequest(http.MethodPost, "/upload", bytes.NewReader(body))
+	req.ContentLength = 20
+	rec := httptest.NewRecorder()
+
+	// Must not panic.
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// TestBodyLimit_UnderLimit_NoRejectionCounted verifies that under-limit
+// requests do not increment the body-limit rejection counter.
+func TestBodyLimit_UnderLimit_NoRejectionCounted(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	handler := BodyLimit(1024, mc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader("small"))
+	req.ContentLength = 5
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	snap := mc.Snapshot()
+	assert.Empty(t, snap.BodyLimitRejections,
+		"under-limit requests must not increment the body-limit rejection counter")
+}
+
+// TestBodyLimit_CellFromContext ensures the production code uses
+// ctxkeys.CellIDFrom for the cell label when a cell ID is present in ctx.
+func TestBodyLimit_CellFromContext(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	handler := BodyLimit(10, mc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run")
+	}))
+
+	body := bytes.Repeat([]byte("x"), 20)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/upload", bytes.NewReader(body))
+	req.ContentLength = 20
+
+	// Simulate CellAttribution having written the cell into ctx.
+	const cellID = "mycell"
+	req = req.WithContext(ctxkeys.WithCellID(req.Context(), cellID))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	snap := mc.Snapshot()
+	// Cell should come from context; route falls back to UnmatchedRoute.
+	key := metrics.BodyLimitRejectionKey{
+		Cell:  cellID,
+		Route: UnmatchedRoute,
+	}
+	assert.Equal(t, int64(1), snap.BodyLimitRejections[key],
+		"body-limit rejection cell label must come from ctxkeys.CellIDFrom")
 }

--- a/runtime/http/middleware/body_limit_test.go
+++ b/runtime/http/middleware/body_limit_test.go
@@ -54,7 +54,8 @@ func TestBodyLimit_ExactContentLengthOverLimit(t *testing.T) {
 }
 
 func TestBodyLimit_MaxBytesReaderTriggered(t *testing.T) {
-	handler := BodyLimit(10, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mc := metrics.NewInMemoryCollector()
+	handler := BodyLimit(10, mc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.ReadAll(r.Body)
 		// MaxBytesReader returns an error when body exceeds limit
 		assert.Error(t, err)
@@ -66,6 +67,13 @@ func TestBodyLimit_MaxBytesReaderTriggered(t *testing.T) {
 	req.ContentLength = -1 // unknown
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
+
+	// Streaming overruns (MaxBytesReader path) must NOT increment the
+	// body-limit rejection counter — only the Content-Length fast-path does.
+	// The 413 from streaming is captured separately by http_requests_total via RecordRequest.
+	snap := mc.Snapshot()
+	assert.Empty(t, snap.BodyLimitRejections,
+		"streaming MaxBytesReader overrun must not increment the body-limit rejection counter")
 }
 
 func TestBodyLimit_DefaultLimit(t *testing.T) {
@@ -142,6 +150,39 @@ func TestBodyLimit_UnderLimit_NoRejectionCounted(t *testing.T) {
 	snap := mc.Snapshot()
 	assert.Empty(t, snap.BodyLimitRejections,
 		"under-limit requests must not increment the body-limit rejection counter")
+}
+
+// TestBodyLimit_UnmatchedRoutesDoNotExpandCardinality verifies that N requests
+// arriving on distinct arbitrary paths — with no RouteResolver context — all
+// fold into the single {Cell:"_runtime", Route:"unmatched"} bucket.  This
+// guards against the cardinality-explosion attack vector: an adversary sending
+// oversized bodies on random paths must not be able to inflate label space.
+func TestBodyLimit_UnmatchedRoutesDoNotExpandCardinality(t *testing.T) {
+	mc := metrics.NewInMemoryCollector()
+	handler := BodyLimit(10, mc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run when body limit rejects")
+	}))
+
+	body := bytes.Repeat([]byte("x"), 20)
+	paths := []string{"/foo", "/bar/baz", "/api/v99/evil", "/etc/passwd", "/a/b/c/d/e"}
+	for _, p := range paths {
+		req := httptest.NewRequest(http.MethodPost, p, bytes.NewReader(body))
+		req.ContentLength = 20
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	}
+
+	snap := mc.Snapshot()
+	// All rejections must collapse into a single key — no per-path cardinality growth.
+	require.Len(t, snap.BodyLimitRejections, 1,
+		"distinct arbitrary paths must not expand body-limit rejection label cardinality")
+	key := metrics.BodyLimitRejectionKey{
+		Cell:  RuntimeCellIDSentinel,
+		Route: UnmatchedRoute,
+	}
+	assert.Equal(t, int64(len(paths)), snap.BodyLimitRejections[key],
+		"all unmatched-route rejections must fold into the _runtime/unmatched bucket")
 }
 
 // TestBodyLimit_CellFromContext ensures the production code uses

--- a/runtime/http/middleware/body_limit_test.go
+++ b/runtime/http/middleware/body_limit_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
@@ -183,6 +185,46 @@ func TestBodyLimit_UnmatchedRoutesDoNotExpandCardinality(t *testing.T) {
 	}
 	assert.Equal(t, int64(len(paths)), snap.BodyLimitRejections[key],
 		"all unmatched-route rejections must fold into the _runtime/unmatched bucket")
+}
+
+// TestBodyLimit_StreamingOverrun_Via_HttputilWriteError proves that when a
+// handler uses httputil.WriteError to propagate *http.MaxBytesError, the
+// framework path produces a 413 response with the canonical ERR_BODY_TOO_LARGE
+// code. This validates the claim in the BodyLimit godoc that "framework-
+// generated handlers produce a 413 captured in http_requests_total{status=413}"
+// via RecordRequest — the 413 originates from WriteError, not from BodyLimit.
+func TestBodyLimit_StreamingOverrun_Via_HttputilWriteError(t *testing.T) {
+	// A handler that reads the body and propagates any error through WriteError,
+	// mimicking what framework-generated handlers do.
+	frameworkLikeHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			httputil.WriteError(context.Background(), w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := BodyLimit(10, nil)(frameworkLikeHandler)
+
+	// Send a body larger than the limit, without a matching Content-Length
+	// (so the fast-path does not trigger — only MaxBytesReader kicks in).
+	body := bytes.Repeat([]byte("x"), 20)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/upload", bytes.NewReader(body))
+	req.ContentLength = -1 // unknown → skip fast-path
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// The framework path via httputil.WriteError maps MaxBytesError → 413.
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code,
+		"streaming overrun with httputil.WriteError propagation must produce 413")
+
+	var respBody map[string]any
+	err := json.NewDecoder(rec.Body).Decode(&respBody)
+	require.NoError(t, err)
+	errObj, ok := respBody["error"].(map[string]any)
+	require.True(t, ok, "response must have 'error' object")
+	assert.Equal(t, "ERR_BODY_TOO_LARGE", errObj["code"],
+		"error code must be ERR_BODY_TOO_LARGE for MaxBytesError via WriteError")
 }
 
 // TestBodyLimit_CellFromContext ensures the production code uses

--- a/runtime/http/router/router.go
+++ b/runtime/http/router/router.go
@@ -687,7 +687,7 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	if r.authVerifier != nil {
 		r.use(auth.AuthMiddleware(r.clock, r.authVerifier, r.buildAuthOpts()...))
 	}
-	r.use(middleware.BodyLimit(r.bodyLimit))
+	r.use(middleware.BodyLimit(r.bodyLimit, r.metricsCollector))
 	r.composeHandler()
 	return nil
 }

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -466,6 +466,13 @@ func TestMountRouteGroup_CellAttribution_BodyLimitReject(t *testing.T) {
 	assert.Equal(t, int64(1), snap.RequestCounts[routerRequestKey(
 		"configcore", http.MethodPost, "/api/v1/upload/blob", http.StatusRequestEntityTooLarge,
 	)])
+	// Verify body-limit rejection counter is incremented with the correct labels.
+	// The Content-Length fast-path fires after CellAttribution has set cellID,
+	// so the cell label must be "configcore" and the route must be the matched template.
+	assert.Equal(t, int64(1), snap.BodyLimitRejections[metrics.BodyLimitRejectionKey{
+		Cell:  "configcore",
+		Route: "/api/v1/upload/blob",
+	}], "body-limit rejection counter must record cell=configcore and route template")
 }
 
 func TestMountRouteGroup_CellAttribution_EmptyPrefixNestedRoutes(t *testing.T) {

--- a/runtime/http/router/router_test.go
+++ b/runtime/http/router/router_test.go
@@ -459,6 +459,7 @@ func TestMountRouteGroup_CellAttribution_BodyLimitReject(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/upload/blob", strings.NewReader("too-large"))
+	req.ContentLength = int64(len("too-large"))
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -35,8 +35,15 @@ type Collector interface {
 	// RecordBodyLimitRejection increments the body-limit rejection counter for
 	// the given cell and route. It is called only on the Content-Length
 	// fast-path reject (r.ContentLength > maxBytes before the request body is
-	// read). Streaming overruns after MaxBytesReader kicks in are already
-	// captured by http_requests_total{status=413} via RecordRequest.
+	// read).
+	//
+	// Streaming overruns (MaxBytesReader kick-in, after the body has started
+	// being read) are handler-dependent: the handler receives
+	// *http.MaxBytesError when it reads the body, and if it propagates the
+	// error through pkg/httputil.WriteError, the framework maps it to a 413
+	// response captured in http_requests_total{status="413"} via RecordRequest.
+	// Framework-generated handlers follow this path; custom handlers that do not
+	// call httputil.WriteError will not produce a 413 in http_requests_total.
 	//
 	// cellID follows the same semantics as RecordRequest: use the owning cell
 	// ID or RuntimeCellIDSentinel ("_runtime") for framework paths.

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -60,9 +60,9 @@ type BodyLimitRejectionKey struct {
 
 // Snapshot is a point-in-time view of recorded metrics.
 type Snapshot struct {
-	RequestCounts        map[RequestKey]int64
-	DurationSumsMs       map[RequestKey]int64
-	BodyLimitRejections  map[BodyLimitRejectionKey]int64
+	RequestCounts       map[RequestKey]int64
+	DurationSumsMs      map[RequestKey]int64
+	BodyLimitRejections map[BodyLimitRejectionKey]int64
 }
 
 // InMemoryCollector is a simple in-memory metrics collector for development

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -31,6 +31,17 @@ type Collector interface {
 	// framework-owned paths (healthz/readyz/metrics, unmatched 404s, listeners
 	// with no business RouteGroup attached).
 	RecordRequest(ctx context.Context, cellID, method, route string, status int, durationSeconds float64)
+
+	// RecordBodyLimitRejection increments the body-limit rejection counter for
+	// the given cell and route. It is called only on the Content-Length
+	// fast-path reject (r.ContentLength > maxBytes before the request body is
+	// read). Streaming overruns after MaxBytesReader kicks in are already
+	// captured by http_requests_total{status=413} via RecordRequest.
+	//
+	// cellID follows the same semantics as RecordRequest: use the owning cell
+	// ID or RuntimeCellIDSentinel ("_runtime") for framework paths.
+	// route is the low-cardinality route pattern from RouteFor.
+	RecordBodyLimitRejection(ctx context.Context, cellID, route string)
 }
 
 // RequestKey identifies one low-cardinality HTTP request metric series.
@@ -41,25 +52,35 @@ type RequestKey struct {
 	Status int
 }
 
+// BodyLimitRejectionKey identifies one body-limit rejection metric series.
+type BodyLimitRejectionKey struct {
+	Cell  string
+	Route string
+}
+
 // Snapshot is a point-in-time view of recorded metrics.
 type Snapshot struct {
-	RequestCounts  map[RequestKey]int64
-	DurationSumsMs map[RequestKey]int64
+	RequestCounts        map[RequestKey]int64
+	DurationSumsMs       map[RequestKey]int64
+	BodyLimitRejections  map[BodyLimitRejectionKey]int64
 }
 
 // InMemoryCollector is a simple in-memory metrics collector for development
-// and testing. It records request counts and cumulative duration.
+// and testing. It records request counts, cumulative duration, and body-limit
+// rejection counts.
 type InMemoryCollector struct {
-	mu        sync.RWMutex
-	counts    map[RequestKey]*atomic.Int64
-	durations map[RequestKey]*atomic.Int64 // cumulative duration in microseconds
+	mu                  sync.RWMutex
+	counts              map[RequestKey]*atomic.Int64
+	durations           map[RequestKey]*atomic.Int64 // cumulative duration in microseconds
+	bodyLimitRejections map[BodyLimitRejectionKey]*atomic.Int64
 }
 
 // NewInMemoryCollector creates an InMemoryCollector.
 func NewInMemoryCollector() *InMemoryCollector {
 	return &InMemoryCollector{
-		counts:    make(map[RequestKey]*atomic.Int64),
-		durations: make(map[RequestKey]*atomic.Int64),
+		counts:              make(map[RequestKey]*atomic.Int64),
+		durations:           make(map[RequestKey]*atomic.Int64),
+		bodyLimitRejections: make(map[BodyLimitRejectionKey]*atomic.Int64),
 	}
 }
 
@@ -93,20 +114,46 @@ func (c *InMemoryCollector) RecordRequest(_ context.Context, cellID, method, rou
 	dur.Add(int64(durationSeconds * 1e6)) // microseconds
 }
 
+// RecordBodyLimitRejection increments the body-limit rejection counter for the
+// given cell and route. Mirrors the RLock fast-path + Lock lazy-init pattern
+// of RecordRequest.
+func (c *InMemoryCollector) RecordBodyLimitRejection(_ context.Context, cellID, route string) {
+	key := BodyLimitRejectionKey{Cell: cellID, Route: route}
+
+	c.mu.RLock()
+	ctr, ok := c.bodyLimitRejections[key]
+	c.mu.RUnlock()
+
+	if !ok {
+		c.mu.Lock()
+		if _, exists := c.bodyLimitRejections[key]; !exists {
+			c.bodyLimitRejections[key] = &atomic.Int64{}
+		}
+		ctr = c.bodyLimitRejections[key]
+		c.mu.Unlock()
+	}
+
+	ctr.Add(1)
+}
+
 // Snapshot returns a point-in-time copy of all metrics.
 func (c *InMemoryCollector) Snapshot() Snapshot {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	snap := Snapshot{
-		RequestCounts:  make(map[RequestKey]int64, len(c.counts)),
-		DurationSumsMs: make(map[RequestKey]int64, len(c.durations)),
+		RequestCounts:       make(map[RequestKey]int64, len(c.counts)),
+		DurationSumsMs:      make(map[RequestKey]int64, len(c.durations)),
+		BodyLimitRejections: make(map[BodyLimitRejectionKey]int64, len(c.bodyLimitRejections)),
 	}
 	for k, v := range c.counts {
 		snap.RequestCounts[k] = v.Load()
 	}
 	for k, v := range c.durations {
 		snap.DurationSumsMs[k] = v.Load() / 1000 // microseconds → milliseconds
+	}
+	for k, v := range c.bodyLimitRejections {
+		snap.BodyLimitRejections[k] = v.Load()
 	}
 	return snap
 }

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -75,6 +75,9 @@ type InMemoryCollector struct {
 	bodyLimitRejections map[BodyLimitRejectionKey]*atomic.Int64
 }
 
+// Compile-time interface compliance check.
+var _ Collector = (*InMemoryCollector)(nil)
+
 // NewInMemoryCollector creates an InMemoryCollector.
 func NewInMemoryCollector() *InMemoryCollector {
 	return &InMemoryCollector{
@@ -158,54 +161,90 @@ func (c *InMemoryCollector) Snapshot() Snapshot {
 	return snap
 }
 
+// handlerRequestEntry is the JSON shape for a single request metric entry.
+type handlerRequestEntry struct {
+	Cell       string `json:"cell"`
+	Method     string `json:"method"`
+	Route      string `json:"route"`
+	Status     int    `json:"status"`
+	Count      int64  `json:"count"`
+	DurationMs int64  `json:"duration_sum_ms"`
+}
+
+// handlerBodyLimitEntry is the JSON shape for a single body-limit rejection entry.
+type handlerBodyLimitEntry struct {
+	Cell  string `json:"cell"`
+	Route string `json:"route"`
+	Count int64  `json:"count"`
+}
+
+// buildHandlerPayload converts a Snapshot into sorted JSON-serialisable slices.
+func buildHandlerPayload(snap Snapshot) ([]handlerRequestEntry, []handlerBodyLimitEntry) {
+	requests := make([]handlerRequestEntry, 0, len(snap.RequestCounts))
+	for key, count := range snap.RequestCounts {
+		requests = append(requests, handlerRequestEntry{
+			Cell:       key.Cell,
+			Method:     key.Method,
+			Route:      key.Route,
+			Status:     key.Status,
+			Count:      count,
+			DurationMs: snap.DurationSumsMs[key],
+		})
+	}
+	sort.Slice(requests, func(i, j int) bool {
+		if requests[i].Cell != requests[j].Cell {
+			return requests[i].Cell < requests[j].Cell
+		}
+		if requests[i].Route != requests[j].Route {
+			return requests[i].Route < requests[j].Route
+		}
+		if requests[i].Method != requests[j].Method {
+			return requests[i].Method < requests[j].Method
+		}
+		return requests[i].Status < requests[j].Status
+	})
+
+	rejections := make([]handlerBodyLimitEntry, 0, len(snap.BodyLimitRejections))
+	for key, count := range snap.BodyLimitRejections {
+		rejections = append(rejections, handlerBodyLimitEntry{
+			Cell:  key.Cell,
+			Route: key.Route,
+			Count: count,
+		})
+	}
+	sort.Slice(rejections, func(i, j int) bool {
+		if rejections[i].Cell != rejections[j].Cell {
+			return rejections[i].Cell < rejections[j].Cell
+		}
+		return rejections[i].Route < rejections[j].Route
+	})
+
+	return requests, rejections
+}
+
 // Handler returns an http.Handler that serves metrics as JSON.
+// The response shape is:
+//
+//	{"data": {"requests": [...], "bodyLimitRejections": [...]}}
+//
+// requests entries are sorted by cell→route→method→status.
+// bodyLimitRejections entries are sorted by cell→route.
+//
+// collector=nil fields are omitted (nil collector disables body-limit rejection
+// recording; streaming 413s are still captured by the Metrics middleware via
+// RecordRequest and appear in the requests array).
+//
 // For Prometheus-compatible output, wire adapters/prometheus.NewMetricProvider
 // into NewProviderCollector and serve the registry via promhttp.
 func (c *InMemoryCollector) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		snap := c.Snapshot()
-
+		requests, rejections := buildHandlerPayload(c.Snapshot())
 		w.Header().Set("Content-Type", "application/json")
-
-		type entry struct {
-			Cell       string `json:"cell"`
-			Method     string `json:"method"`
-			Route      string `json:"route"`
-			Status     int    `json:"status"`
-			Count      int64  `json:"count"`
-			DurationMs int64  `json:"duration_sum_ms"`
-		}
-
-		var entries []entry
-		for key, count := range snap.RequestCounts {
-			entries = append(entries, entry{
-				Cell:       key.Cell,
-				Method:     key.Method,
-				Route:      key.Route,
-				Status:     key.Status,
-				Count:      count,
-				DurationMs: snap.DurationSumsMs[key],
-			})
-		}
-		sort.Slice(entries, func(i, j int) bool {
-			if entries[i].Cell != entries[j].Cell {
-				return entries[i].Cell < entries[j].Cell
-			}
-			if entries[i].Route != entries[j].Route {
-				return entries[i].Route < entries[j].Route
-			}
-			if entries[i].Method != entries[j].Method {
-				return entries[i].Method < entries[j].Method
-			}
-			return entries[i].Status < entries[j].Status
-		})
-
-		// Use the unified list response envelope ({"data": [...]}) consistent
-		// with .claude/rules/gocell/api-versioning.md and the other HTTP list
-		// endpoints. Inherited "metrics" wrapper would have left this dev/test
-		// handler the only inconsistent shape on the metrics surface.
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": entries,
+			"data": map[string]any{
+				"requests":            requests,
+				"bodyLimitRejections": rejections,
+			},
 		})
 	})
 }

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -20,6 +20,9 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 	c.RecordRequest(ctx, "accesscore", http.MethodGet, "/api", 200, 0.05)
 	c.RecordRequest(ctx, "accesscore", http.MethodGet, "/api", 200, 0.03)
 	c.RecordRequest(ctx, "accesscore", http.MethodGet, "/admin", 404, 0.002)
+	c.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+	c.RecordBodyLimitRejection(ctx, "configcore", "/api/v1/config")
+	c.RecordBodyLimitRejection(ctx, "configcore", "/api/v1/config")
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -30,7 +33,7 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 	body, err := io.ReadAll(rec.Body)
 	require.NoError(t, err)
 
-	type entry struct {
+	type requestEntry struct {
 		Cell       string `json:"cell"`
 		Method     string `json:"method"`
 		Route      string `json:"route"`
@@ -38,16 +41,28 @@ func TestInMemoryCollector_Handler(t *testing.T) {
 		Count      int64  `json:"count"`
 		DurationMs int64  `json:"duration_sum_ms"`
 	}
+	type bodyLimitEntry struct {
+		Cell  string `json:"cell"`
+		Route string `json:"route"`
+		Count int64  `json:"count"`
+	}
 	var result struct {
-		Data []entry `json:"data"`
+		Data struct {
+			Requests            []requestEntry   `json:"requests"`
+			BodyLimitRejections []bodyLimitEntry `json:"bodyLimitRejections"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(body, &result))
-	assert.Equal(t, []entry{
+	assert.Equal(t, []requestEntry{
 		{Cell: "accesscore", Method: http.MethodGet, Route: "/admin", Status: 404, Count: 1, DurationMs: 2},
 		{Cell: "accesscore", Method: http.MethodGet, Route: "/api", Status: 200, Count: 2, DurationMs: 80},
 		{Cell: "accesscore", Method: http.MethodPost, Route: "/api", Status: 201, Count: 1, DurationMs: 100},
 		{Cell: "auditcore", Method: http.MethodPost, Route: "/z", Status: 500, Count: 1, DurationMs: 4},
-	}, result.Data, "Handler must emit typed request keys sorted by cell, route, method, status")
+	}, result.Data.Requests, "Handler must emit typed request keys sorted by cell, route, method, status")
+	assert.Equal(t, []bodyLimitEntry{
+		{Cell: "accesscore", Route: "/api/v1/upload", Count: 1},
+		{Cell: "configcore", Route: "/api/v1/config", Count: 2},
+	}, result.Data.BodyLimitRejections, "Handler must emit body-limit rejections sorted by cell, route")
 }
 
 func TestInMemoryCollector_Snapshot(t *testing.T) {
@@ -107,6 +122,3 @@ func TestInMemoryCollector_RecordBodyLimitRejection_NoSideEffectOnRequest(t *tes
 	assert.Empty(t, snap.RequestCounts,
 		"body-limit rejection must not affect the request counts map")
 }
-
-// Verify interface compliance at compile time.
-var _ Collector = (*InMemoryCollector)(nil)

--- a/runtime/observability/metrics/collector_test.go
+++ b/runtime/observability/metrics/collector_test.go
@@ -77,5 +77,36 @@ func TestInMemoryCollector_PerCellSeparation(t *testing.T) {
 	}])
 }
 
+func TestInMemoryCollector_RecordBodyLimitRejection(t *testing.T) {
+	ctx := context.Background()
+	c := NewInMemoryCollector()
+
+	c.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+	c.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+	c.RecordBodyLimitRejection(ctx, "configcore", "/api/v1/config")
+
+	snap := c.Snapshot()
+	assert.Equal(t, int64(2), snap.BodyLimitRejections[BodyLimitRejectionKey{
+		Cell:  "accesscore",
+		Route: "/api/v1/upload",
+	}])
+	assert.Equal(t, int64(1), snap.BodyLimitRejections[BodyLimitRejectionKey{
+		Cell:  "configcore",
+		Route: "/api/v1/config",
+	}])
+}
+
+func TestInMemoryCollector_RecordBodyLimitRejection_NoSideEffectOnRequest(t *testing.T) {
+	ctx := context.Background()
+	c := NewInMemoryCollector()
+
+	c.RecordBodyLimitRejection(ctx, "_runtime", "unmatched")
+
+	snap := c.Snapshot()
+	// RecordRequest map must remain empty.
+	assert.Empty(t, snap.RequestCounts,
+		"body-limit rejection must not affect the request counts map")
+}
+
 // Verify interface compliance at compile time.
 var _ Collector = (*InMemoryCollector)(nil)

--- a/runtime/observability/metrics/inmemory_conformance_test.go
+++ b/runtime/observability/metrics/inmemory_conformance_test.go
@@ -17,7 +17,7 @@ func TestInMemoryCollector_Conformance(t *testing.T) {
 
 // inMemoryHarness implements metricstest.CollectorHarness for InMemoryCollector.
 // It holds no mutable state; each New call returns a self-contained
-// (Collector, CollectorObserver) pair, making parallel subtests race-free.
+// (Collector, CollectorObserver) pair, fully isolating each subtest.
 type inMemoryHarness struct{}
 
 func (inMemoryHarness) New(_ *testing.T) (metrics.Collector, metricstest.CollectorObserver) {

--- a/runtime/observability/metrics/inmemory_conformance_test.go
+++ b/runtime/observability/metrics/inmemory_conformance_test.go
@@ -1,0 +1,43 @@
+package metrics_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
+	"github.com/ghbvf/gocell/runtime/observability/metrics/metricstest"
+)
+
+// TestInMemoryCollector_Conformance runs the shared Collector conformance
+// suite against InMemoryCollector. This satisfies the enrollment requirement
+// checked by COLLECTOR-CONFORMANCE-ENROLLMENT-01.
+func TestInMemoryCollector_Conformance(t *testing.T) {
+	metricstest.RunCollectorConformance(t, &inMemoryHarness{})
+}
+
+// inMemoryHarness adapts InMemoryCollector to metricstest.CollectorHarness.
+// Snapshot() provides the observation surface.
+type inMemoryHarness struct {
+	col *metrics.InMemoryCollector
+}
+
+func (h *inMemoryHarness) New(_ *testing.T) metrics.Collector {
+	h.col = metrics.NewInMemoryCollector()
+	return h.col
+}
+
+func (h *inMemoryHarness) RequestCount(key metricstest.RequestKey) int64 {
+	snap := h.col.Snapshot()
+	return snap.RequestCounts[key]
+}
+
+func (h *inMemoryHarness) BodyLimitRejectionCount(key metricstest.BodyLimitRejectionKey) int64 {
+	snap := h.col.Snapshot()
+	return snap.BodyLimitRejections[key]
+}
+
+// LastCtxForBodyLimitRejection — InMemoryCollector discards the ctx (it only
+// stores counts), so return nil to skip the ctx-forwarding assertion.
+func (h *inMemoryHarness) LastCtxForBodyLimitRejection() context.Context {
+	return nil
+}

--- a/runtime/observability/metrics/inmemory_conformance_test.go
+++ b/runtime/observability/metrics/inmemory_conformance_test.go
@@ -12,32 +12,37 @@ import (
 // suite against InMemoryCollector. This satisfies the enrollment requirement
 // checked by COLLECTOR-CONFORMANCE-ENROLLMENT-01.
 func TestInMemoryCollector_Conformance(t *testing.T) {
-	metricstest.RunCollectorConformance(t, &inMemoryHarness{})
+	metricstest.RunCollectorConformance(t, inMemoryHarness{})
 }
 
-// inMemoryHarness adapts InMemoryCollector to metricstest.CollectorHarness.
-// Snapshot() provides the observation surface.
-type inMemoryHarness struct {
+// inMemoryHarness implements metricstest.CollectorHarness for InMemoryCollector.
+// It holds no mutable state; each New call returns a self-contained
+// (Collector, CollectorObserver) pair, making parallel subtests race-free.
+type inMemoryHarness struct{}
+
+func (inMemoryHarness) New(_ *testing.T) (metrics.Collector, metricstest.CollectorObserver) {
+	col := metrics.NewInMemoryCollector()
+	return col, &inMemoryObserver{col: col}
+}
+
+// inMemoryObserver is the read-side for a single InMemoryCollector instance.
+// It is bound to one collector and never shared across subtests.
+type inMemoryObserver struct {
 	col *metrics.InMemoryCollector
 }
 
-func (h *inMemoryHarness) New(_ *testing.T) metrics.Collector {
-	h.col = metrics.NewInMemoryCollector()
-	return h.col
-}
-
-func (h *inMemoryHarness) RequestCount(key metricstest.RequestKey) int64 {
-	snap := h.col.Snapshot()
+func (o *inMemoryObserver) RequestCount(key metricstest.RequestKey) int64 {
+	snap := o.col.Snapshot()
 	return snap.RequestCounts[key]
 }
 
-func (h *inMemoryHarness) BodyLimitRejectionCount(key metricstest.BodyLimitRejectionKey) int64 {
-	snap := h.col.Snapshot()
+func (o *inMemoryObserver) BodyLimitRejectionCount(key metricstest.BodyLimitRejectionKey) int64 {
+	snap := o.col.Snapshot()
 	return snap.BodyLimitRejections[key]
 }
 
 // LastCtxForBodyLimitRejection — InMemoryCollector discards the ctx (it only
 // stores counts), so return nil to skip the ctx-forwarding assertion.
-func (h *inMemoryHarness) LastCtxForBodyLimitRejection() context.Context {
+func (o *inMemoryObserver) LastCtxForBodyLimitRejection() context.Context {
 	return nil
 }

--- a/runtime/observability/metrics/metricstest/conformance.go
+++ b/runtime/observability/metrics/metricstest/conformance.go
@@ -6,7 +6,10 @@
 // Because Collector is a write-only sink and the two production implementations
 // have different observation mechanisms (InMemoryCollector.Snapshot vs. spy
 // counter on a provider), the suite is parameterised through CollectorHarness:
-// each implementation supplies its own New() constructor and read-back helpers.
+// each implementation supplies its own New() constructor that returns a
+// self-contained (Collector, CollectorObserver) pair. All observation state is
+// local to that pair; the harness itself holds no mutable shared state, making
+// parallel subtest execution safe.
 //
 // The suite file is a plain .go file (not _test.go) so it can be imported by
 // _test.go files in other packages without being stripped from the build graph
@@ -27,38 +30,36 @@ type RequestKey = metrics.RequestKey
 // BodyLimitRejectionKey mirrors metrics.BodyLimitRejectionKey.
 type BodyLimitRejectionKey = metrics.BodyLimitRejectionKey
 
-// CollectorHarness wraps one Collector implementation with the observation
-// surface the conformance suite needs. Each implementation provides:
+// CollectorObserver is the read-side companion returned by
+// CollectorHarness.New. It is bound exclusively to the Collector returned in
+// the same New call; parallel subtests each hold their own observer instance
+// with no cross-subtest sharing.
 //
-//   - New: builds a fresh, isolated Collector instance. Called once per subtest.
 //   - RequestCount: returns how many times RecordRequest was called for the
-//     given key on the last collector produced by New. Returns 0 if the key has
-//     not been recorded.
+//     given key on that Collector. Returns 0 if the key has not been recorded.
 //   - BodyLimitRejectionCount: returns how many times RecordBodyLimitRejection
 //     was called for the given key. Returns 0 if never recorded.
 //   - LastCtxForBodyLimitRejection: returns the context that was passed to the
 //     most recent RecordBodyLimitRejection call, or nil if no call was made.
 //     Implementations that cannot observe ctx may return nil; the corresponding
 //     harness subtest will skip the ctx-forwarding assertion.
-type CollectorHarness interface {
-	// New constructs a fresh Collector instance for one subtest. The returned
-	// Collector is the target of all subsequent Read-side observations until
-	// the next New call.
-	New(t *testing.T) metrics.Collector
-
-	// RequestCount returns the accumulated count for the given key on the
-	// last Collector created by New.
+type CollectorObserver interface {
 	RequestCount(key RequestKey) int64
-
-	// BodyLimitRejectionCount returns the accumulated count for the given
-	// key on the last Collector created by New.
 	BodyLimitRejectionCount(key BodyLimitRejectionKey) int64
-
-	// LastCtxForBodyLimitRejection returns the context.Context that was
-	// supplied to the most recent RecordBodyLimitRejection call, or nil if
-	// no call was made or the implementation cannot observe the ctx. A nil
-	// return causes the ctx-forwarding assertion to be skipped.
 	LastCtxForBodyLimitRejection() context.Context
+}
+
+// CollectorHarness wraps one Collector implementation with a factory that
+// produces self-contained (Collector, CollectorObserver) pairs. The harness
+// itself must hold no mutable state; all per-subtest state lives in the
+// returned pair. This guarantees race-freedom when RunCollectorConformance
+// runs subtests in parallel.
+type CollectorHarness interface {
+	// New constructs a fresh Collector and its bound CollectorObserver for one
+	// subtest. The returned observer's read methods reflect only the Collector
+	// returned alongside it. New may be called concurrently from different
+	// goroutines; implementations must not write to shared harness fields.
+	New(t *testing.T) (metrics.Collector, CollectorObserver)
 }
 
 // RunCollectorConformance runs the full Collector conformance suite against
@@ -102,14 +103,14 @@ func RunCollectorConformance(t *testing.T, h CollectorHarness) {
 // conformRecordRequestCount verifies RecordRequest increments per unique key.
 func conformRecordRequestCount(t *testing.T, h CollectorHarness) {
 	t.Helper()
-	col := h.New(t)
+	col, obs := h.New(t)
 
 	ctx := context.Background()
 	col.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
 	col.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.02)
 
 	key := RequestKey{Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
-	got := h.RequestCount(key)
+	got := obs.RequestCount(key)
 	if got != 2 {
 		t.Errorf("RecordRequest count: got %d, want 2 (two calls same key)", got)
 	}
@@ -120,7 +121,7 @@ func conformRecordRequestCount(t *testing.T, h CollectorHarness) {
 // counter entry.
 func conformRecordRequestLabelIsolation(t *testing.T, h CollectorHarness) {
 	t.Helper()
-	col := h.New(t)
+	col, obs := h.New(t)
 
 	ctx := context.Background()
 	col.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
@@ -128,10 +129,10 @@ func conformRecordRequestLabelIsolation(t *testing.T, h CollectorHarness) {
 
 	key1 := RequestKey{Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
 	key2 := RequestKey{Cell: "auditcore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
-	if got := h.RequestCount(key1); got != 1 {
+	if got := obs.RequestCount(key1); got != 1 {
 		t.Errorf("accesscore count: got %d, want 1", got)
 	}
-	if got := h.RequestCount(key2); got != 1 {
+	if got := obs.RequestCount(key2); got != 1 {
 		t.Errorf("auditcore count: got %d, want 1", got)
 	}
 }
@@ -140,14 +141,14 @@ func conformRecordRequestLabelIsolation(t *testing.T, h CollectorHarness) {
 // the body-limit rejection counter.
 func conformBodyLimitRejectionCount(t *testing.T, h CollectorHarness) {
 	t.Helper()
-	col := h.New(t)
+	col, obs := h.New(t)
 
 	ctx := context.Background()
 	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
 	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
 
 	key := BodyLimitRejectionKey{Cell: "accesscore", Route: "/api/v1/upload"}
-	if got := h.BodyLimitRejectionCount(key); got != 2 {
+	if got := obs.BodyLimitRejectionCount(key); got != 2 {
 		t.Errorf("BodyLimitRejection count: got %d, want 2", got)
 	}
 }
@@ -157,14 +158,14 @@ func conformBodyLimitRejectionCount(t *testing.T, h CollectorHarness) {
 // LastCtxForBodyLimitRejection (implementation cannot observe ctx).
 func conformBodyLimitRejectionCtxForwarded(t *testing.T, h CollectorHarness) {
 	t.Helper()
-	col := h.New(t)
+	col, obs := h.New(t)
 
 	type sentinelKey struct{}
 	want := "sentinel-ctx-value"
 	ctx := context.WithValue(context.Background(), sentinelKey{}, want)
 	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
 
-	lastCtx := h.LastCtxForBodyLimitRejection()
+	lastCtx := obs.LastCtxForBodyLimitRejection()
 	if lastCtx == nil {
 		t.Skip("harness cannot observe forwarded ctx — skipping ctx-forwarding assertion")
 	}
@@ -178,9 +179,8 @@ func conformBodyLimitRejectionCtxForwarded(t *testing.T, h CollectorHarness) {
 // not pollute the RecordRequest counter series.
 func conformBodyLimitRejectionNoSideEffect(t *testing.T, h CollectorHarness) {
 	t.Helper()
-	col := h.New(t)
+	col, obs := h.New(t)
 
-	_ = col
 	ctx := context.Background()
 	col.RecordBodyLimitRejection(ctx, "_runtime", "unmatched")
 
@@ -190,7 +190,7 @@ func conformBodyLimitRejectionNoSideEffect(t *testing.T, h CollectorHarness) {
 	for _, status := range []int{200, 413, 500} {
 		for _, method := range []string{"GET", "POST"} {
 			key := RequestKey{Cell: "_runtime", Method: method, Route: "unmatched", Status: status}
-			if got := h.RequestCount(key); got != 0 {
+			if got := obs.RequestCount(key); got != 0 {
 				t.Errorf("RecordBodyLimitRejection polluted request counter at %+v: got %d, want 0", key, got)
 			}
 		}
@@ -201,7 +201,7 @@ func conformBodyLimitRejectionNoSideEffect(t *testing.T, h CollectorHarness) {
 // keyed per (cell, route): two distinct keys must not affect each other.
 func conformBodyLimitRejectionKeyIsolation(t *testing.T, h CollectorHarness) {
 	t.Helper()
-	col := h.New(t)
+	col, obs := h.New(t)
 
 	ctx := context.Background()
 	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
@@ -209,10 +209,10 @@ func conformBodyLimitRejectionKeyIsolation(t *testing.T, h CollectorHarness) {
 
 	key1 := BodyLimitRejectionKey{Cell: "accesscore", Route: "/api/v1/upload"}
 	key2 := BodyLimitRejectionKey{Cell: "configcore", Route: "/api/v1/config"}
-	if got := h.BodyLimitRejectionCount(key1); got != 1 {
+	if got := obs.BodyLimitRejectionCount(key1); got != 1 {
 		t.Errorf("accesscore/upload count: got %d, want 1", got)
 	}
-	if got := h.BodyLimitRejectionCount(key2); got != 1 {
+	if got := obs.BodyLimitRejectionCount(key2); got != 1 {
 		t.Errorf("configcore/config count: got %d, want 1", got)
 	}
 }

--- a/runtime/observability/metrics/metricstest/conformance.go
+++ b/runtime/observability/metrics/metricstest/conformance.go
@@ -8,8 +8,8 @@
 // counter on a provider), the suite is parameterised through CollectorHarness:
 // each implementation supplies its own New() constructor that returns a
 // self-contained (Collector, CollectorObserver) pair. All observation state is
-// local to that pair; the harness itself holds no mutable shared state, making
-// parallel subtest execution safe.
+// local to that pair; the harness itself holds no mutable shared state. Subtests
+// run serially (see RunCollectorConformance) so the suite is deterministic.
 //
 // The suite file is a plain .go file (not _test.go) so it can be imported by
 // _test.go files in other packages without being stripped from the build graph
@@ -32,8 +32,8 @@ type BodyLimitRejectionKey = metrics.BodyLimitRejectionKey
 
 // CollectorObserver is the read-side companion returned by
 // CollectorHarness.New. It is bound exclusively to the Collector returned in
-// the same New call; parallel subtests each hold their own observer instance
-// with no cross-subtest sharing.
+// the same New call; each subtest holds its own observer instance with no
+// cross-subtest sharing.
 //
 //   - RequestCount: returns how many times RecordRequest was called for the
 //     given key on that Collector. Returns 0 if the key has not been recorded.
@@ -52,13 +52,12 @@ type CollectorObserver interface {
 // CollectorHarness wraps one Collector implementation with a factory that
 // produces self-contained (Collector, CollectorObserver) pairs. The harness
 // itself must hold no mutable state; all per-subtest state lives in the
-// returned pair. This guarantees race-freedom when RunCollectorConformance
-// runs subtests in parallel.
+// returned pair, so each subtest is fully isolated.
 type CollectorHarness interface {
 	// New constructs a fresh Collector and its bound CollectorObserver for one
 	// subtest. The returned observer's read methods reflect only the Collector
-	// returned alongside it. New may be called concurrently from different
-	// goroutines; implementations must not write to shared harness fields.
+	// returned alongside it. Implementations must not write to shared harness
+	// fields, so the harness can be reused across subtests.
 	New(t *testing.T) (metrics.Collector, CollectorObserver)
 }
 
@@ -91,10 +90,12 @@ func RunCollectorConformance(t *testing.T, h CollectorHarness) {
 		{"RecordBodyLimitRejection_NoSideEffectOnRequest", conformBodyLimitRejectionNoSideEffect},
 		{"RecordBodyLimitRejection_KeyIsolation", conformBodyLimitRejectionKeyIsolation},
 	}
+	// Subtests run serially, not in parallel: each case is a sub-millisecond
+	// in-memory counting check, so parallelism yields no wall-clock benefit and
+	// only widens the surface for harness/observer state races. Serial execution
+	// makes the suite deterministic.
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			tc.run(t, h)
 		})
 	}

--- a/runtime/observability/metrics/metricstest/conformance.go
+++ b/runtime/observability/metrics/metricstest/conformance.go
@@ -1,0 +1,218 @@
+// Package metricstest provides a shared conformance suite for implementations
+// of [metrics.Collector]. Any implementation — InMemoryCollector (dev/test) or
+// providerCollector (production Prometheus/OTel-backed) — runs
+// RunCollectorConformance to verify the shared recording contract.
+//
+// Because Collector is a write-only sink and the two production implementations
+// have different observation mechanisms (InMemoryCollector.Snapshot vs. spy
+// counter on a provider), the suite is parameterised through CollectorHarness:
+// each implementation supplies its own New() constructor and read-back helpers.
+//
+// The suite file is a plain .go file (not _test.go) so it can be imported by
+// _test.go files in other packages without being stripped from the build graph
+// (mirrors the sagajournaltest pattern).
+package metricstest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
+)
+
+// RequestKey mirrors metrics.RequestKey for harness observation without
+// requiring the test-side to import the internal key type directly.
+type RequestKey = metrics.RequestKey
+
+// BodyLimitRejectionKey mirrors metrics.BodyLimitRejectionKey.
+type BodyLimitRejectionKey = metrics.BodyLimitRejectionKey
+
+// CollectorHarness wraps one Collector implementation with the observation
+// surface the conformance suite needs. Each implementation provides:
+//
+//   - New: builds a fresh, isolated Collector instance. Called once per subtest.
+//   - RequestCount: returns how many times RecordRequest was called for the
+//     given key on the last collector produced by New. Returns 0 if the key has
+//     not been recorded.
+//   - BodyLimitRejectionCount: returns how many times RecordBodyLimitRejection
+//     was called for the given key. Returns 0 if never recorded.
+//   - LastCtxForBodyLimitRejection: returns the context that was passed to the
+//     most recent RecordBodyLimitRejection call, or nil if no call was made.
+//     Implementations that cannot observe ctx may return nil; the corresponding
+//     harness subtest will skip the ctx-forwarding assertion.
+type CollectorHarness interface {
+	// New constructs a fresh Collector instance for one subtest. The returned
+	// Collector is the target of all subsequent Read-side observations until
+	// the next New call.
+	New(t *testing.T) metrics.Collector
+
+	// RequestCount returns the accumulated count for the given key on the
+	// last Collector created by New.
+	RequestCount(key RequestKey) int64
+
+	// BodyLimitRejectionCount returns the accumulated count for the given
+	// key on the last Collector created by New.
+	BodyLimitRejectionCount(key BodyLimitRejectionKey) int64
+
+	// LastCtxForBodyLimitRejection returns the context.Context that was
+	// supplied to the most recent RecordBodyLimitRejection call, or nil if
+	// no call was made or the implementation cannot observe the ctx. A nil
+	// return causes the ctx-forwarding assertion to be skipped.
+	LastCtxForBodyLimitRejection() context.Context
+}
+
+// RunCollectorConformance runs the full Collector conformance suite against
+// the supplied harness. Every subtest is registered as a t.Run so individual
+// cases can be filtered with -run.
+//
+// Conformance assertions cover:
+//  1. RecordRequest: count increments correctly per unique label set.
+//  2. RecordRequest: cell and route labels are independent dimensions (no
+//     label cross-contamination).
+//  3. RecordBodyLimitRejection: count increments correctly.
+//  4. RecordBodyLimitRejection: the caller ctx is forwarded to the
+//     underlying instrument (OTel exemplar/baggage passthrough). Skipped
+//     when the harness cannot observe ctx (LastCtxForBodyLimitRejection nil).
+//  5. RecordBodyLimitRejection: must not pollute the RecordRequest series.
+//  6. RecordBodyLimitRejection: body-limit counter is isolated per
+//     (cell, route) key.
+func RunCollectorConformance(t *testing.T, h CollectorHarness) {
+	t.Helper()
+
+	cases := []struct {
+		name string
+		run  func(*testing.T, CollectorHarness)
+	}{
+		{"RecordRequest_CountIncrements", conformRecordRequestCount},
+		{"RecordRequest_LabelIsolation_CellRoute", conformRecordRequestLabelIsolation},
+		{"RecordBodyLimitRejection_CountIncrements", conformBodyLimitRejectionCount},
+		{"RecordBodyLimitRejection_CtxForwarded", conformBodyLimitRejectionCtxForwarded},
+		{"RecordBodyLimitRejection_NoSideEffectOnRequest", conformBodyLimitRejectionNoSideEffect},
+		{"RecordBodyLimitRejection_KeyIsolation", conformBodyLimitRejectionKeyIsolation},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.run(t, h)
+		})
+	}
+}
+
+// conformRecordRequestCount verifies RecordRequest increments per unique key.
+func conformRecordRequestCount(t *testing.T, h CollectorHarness) {
+	t.Helper()
+	col := h.New(t)
+
+	ctx := context.Background()
+	col.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
+	col.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.02)
+
+	key := RequestKey{Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
+	got := h.RequestCount(key)
+	if got != 2 {
+		t.Errorf("RecordRequest count: got %d, want 2 (two calls same key)", got)
+	}
+}
+
+// conformRecordRequestLabelIsolation verifies that cell and route labels are
+// independent: two calls with different cell values must not collapse into one
+// counter entry.
+func conformRecordRequestLabelIsolation(t *testing.T, h CollectorHarness) {
+	t.Helper()
+	col := h.New(t)
+
+	ctx := context.Background()
+	col.RecordRequest(ctx, "accesscore", "GET", "/api/v1/sessions", 200, 0.01)
+	col.RecordRequest(ctx, "auditcore", "GET", "/api/v1/sessions", 200, 0.01)
+
+	key1 := RequestKey{Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
+	key2 := RequestKey{Cell: "auditcore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
+	if got := h.RequestCount(key1); got != 1 {
+		t.Errorf("accesscore count: got %d, want 1", got)
+	}
+	if got := h.RequestCount(key2); got != 1 {
+		t.Errorf("auditcore count: got %d, want 1", got)
+	}
+}
+
+// conformBodyLimitRejectionCount verifies RecordBodyLimitRejection increments
+// the body-limit rejection counter.
+func conformBodyLimitRejectionCount(t *testing.T, h CollectorHarness) {
+	t.Helper()
+	col := h.New(t)
+
+	ctx := context.Background()
+	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+
+	key := BodyLimitRejectionKey{Cell: "accesscore", Route: "/api/v1/upload"}
+	if got := h.BodyLimitRejectionCount(key); got != 2 {
+		t.Errorf("BodyLimitRejection count: got %d, want 2", got)
+	}
+}
+
+// conformBodyLimitRejectionCtxForwarded verifies the caller ctx is forwarded
+// to the underlying instrument. Skipped when the harness returns nil from
+// LastCtxForBodyLimitRejection (implementation cannot observe ctx).
+func conformBodyLimitRejectionCtxForwarded(t *testing.T, h CollectorHarness) {
+	t.Helper()
+	col := h.New(t)
+
+	type sentinelKey struct{}
+	want := "sentinel-ctx-value"
+	ctx := context.WithValue(context.Background(), sentinelKey{}, want)
+	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+
+	lastCtx := h.LastCtxForBodyLimitRejection()
+	if lastCtx == nil {
+		t.Skip("harness cannot observe forwarded ctx — skipping ctx-forwarding assertion")
+	}
+	got, _ := lastCtx.Value(sentinelKey{}).(string)
+	if got != want {
+		t.Errorf("forwarded ctx value = %q, want %q (implementation substituted a different ctx — exemplar/baggage lost)", got, want)
+	}
+}
+
+// conformBodyLimitRejectionNoSideEffect verifies RecordBodyLimitRejection does
+// not pollute the RecordRequest counter series.
+func conformBodyLimitRejectionNoSideEffect(t *testing.T, h CollectorHarness) {
+	t.Helper()
+	col := h.New(t)
+
+	_ = col
+	ctx := context.Background()
+	col.RecordBodyLimitRejection(ctx, "_runtime", "unmatched")
+
+	// The request counter for the same (cell, route) tuple must remain zero.
+	// RequestKey has Method and Status in addition; check that no request was
+	// recorded by verifying all common label combinations return 0.
+	for _, status := range []int{200, 413, 500} {
+		for _, method := range []string{"GET", "POST"} {
+			key := RequestKey{Cell: "_runtime", Method: method, Route: "unmatched", Status: status}
+			if got := h.RequestCount(key); got != 0 {
+				t.Errorf("RecordBodyLimitRejection polluted request counter at %+v: got %d, want 0", key, got)
+			}
+		}
+	}
+}
+
+// conformBodyLimitRejectionKeyIsolation verifies the body-limit counter is
+// keyed per (cell, route): two distinct keys must not affect each other.
+func conformBodyLimitRejectionKeyIsolation(t *testing.T, h CollectorHarness) {
+	t.Helper()
+	col := h.New(t)
+
+	ctx := context.Background()
+	col.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+	col.RecordBodyLimitRejection(ctx, "configcore", "/api/v1/config")
+
+	key1 := BodyLimitRejectionKey{Cell: "accesscore", Route: "/api/v1/upload"}
+	key2 := BodyLimitRejectionKey{Cell: "configcore", Route: "/api/v1/config"}
+	if got := h.BodyLimitRejectionCount(key1); got != 1 {
+		t.Errorf("accesscore/upload count: got %d, want 1", got)
+	}
+	if got := h.BodyLimitRejectionCount(key2); got != 1 {
+		t.Errorf("configcore/config count: got %d, want 1", got)
+	}
+}

--- a/runtime/observability/metrics/provider_collector.go
+++ b/runtime/observability/metrics/provider_collector.go
@@ -28,8 +28,9 @@ type ProviderCollectorConfig struct {
 // metrics.Provider. The Provider owns registry ownership; this collector
 // only records observations.
 type providerCollector struct {
-	requests kernelmetrics.CounterVec
-	duration kernelmetrics.HistogramVec
+	requests            kernelmetrics.CounterVec
+	duration            kernelmetrics.HistogramVec
+	bodyLimitRejections kernelmetrics.CounterVec
 }
 
 var _ Collector = (*providerCollector)(nil)
@@ -69,7 +70,17 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 			"(likely duplicate — another collector on this Provider may already own the name): %w", err)
 	}
 
-	return &providerCollector{requests: reqs, duration: dur}, nil
+	blr, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name:       "http_request_body_limit_rejections_total",
+		Help:       "Total number of HTTP requests rejected for exceeding the body size limit (Content-Length fast-path).",
+		LabelNames: []string{"cell", "route"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("runtime/observability/metrics: register http_request_body_limit_rejections_total "+
+			"(likely duplicate — another collector on this Provider may already own the name): %w", err)
+	}
+
+	return &providerCollector{requests: reqs, duration: dur, bodyLimitRejections: blr}, nil
 }
 
 // RecordRequest emits an increment on http_requests_total and a sample on
@@ -85,4 +96,13 @@ func (c *providerCollector) RecordRequest(ctx context.Context, cellID, method, r
 	}
 	c.requests.With(labels).Inc(ctx)
 	c.duration.With(labels).Observe(ctx, durationSeconds)
+}
+
+// RecordBodyLimitRejection emits an increment on
+// http_request_body_limit_rejections_total labeled by cell and route.
+func (c *providerCollector) RecordBodyLimitRejection(ctx context.Context, cellID, route string) {
+	c.bodyLimitRejections.With(kernelmetrics.Labels{
+		"cell":  cellID,
+		"route": route,
+	}).Inc(ctx)
 }

--- a/runtime/observability/metrics/provider_collector_test.go
+++ b/runtime/observability/metrics/provider_collector_test.go
@@ -87,6 +87,40 @@ func TestProviderCollector_ForwardsCallerCtx(t *testing.T) {
 	assertForwardedCtx("http_request_duration_seconds", p.histogramOps["http_request_duration_seconds"])
 }
 
+func TestProviderCollector_RecordBodyLimitRejection_NopProviderNoPanic(t *testing.T) {
+	c, err := metrics.NewProviderCollector(kernelmetrics.NopProvider{}, metrics.ProviderCollectorConfig{})
+	if err != nil {
+		t.Fatalf("NewProviderCollector: %v", err)
+	}
+	// Must not panic.
+	ctx := context.Background()
+	c.RecordBodyLimitRejection(ctx, "accesscore", "/api/v1/upload")
+}
+
+func TestProviderCollector_RecordBodyLimitRejection_EmitsLabels(t *testing.T) {
+	p := newSpyProvider()
+	c, err := metrics.NewProviderCollector(p, metrics.ProviderCollectorConfig{})
+	if err != nil {
+		t.Fatalf("NewProviderCollector: %v", err)
+	}
+	c.RecordBodyLimitRejection(context.Background(), "configcore", "/api/v1/config")
+
+	ops := p.counterOps["http_request_body_limit_rejections_total"]
+	if len(ops) != 1 {
+		t.Fatalf("want 1 body-limit counter op, got %d", len(ops))
+	}
+	got := ops[0].labels
+	wants := map[string]string{
+		"cell":  "configcore",
+		"route": "/api/v1/config",
+	}
+	for k, v := range wants {
+		if got[k] != v {
+			t.Errorf("label %s = %q, want %q (all=%v)", k, got[k], v, got)
+		}
+	}
+}
+
 func TestProviderCollector_PerCallCellLabel(t *testing.T) {
 	// Two calls with different cellID values must yield two distinct label sets;
 	// no global / cached cellID can leak between calls.

--- a/runtime/observability/metrics/provider_conformance_test.go
+++ b/runtime/observability/metrics/provider_conformance_test.go
@@ -20,7 +20,7 @@ func TestProviderCollector_Conformance(t *testing.T) {
 // providerCollectorHarness implements metricstest.CollectorHarness for
 // providerCollector. It holds no mutable state; each New call returns a
 // self-contained (Collector, CollectorObserver) pair backed by a fresh
-// spyProvider, so parallel subtests are race-free.
+// spyProvider, fully isolating each subtest.
 type providerCollectorHarness struct{}
 
 func (providerCollectorHarness) New(t *testing.T) (metrics.Collector, metricstest.CollectorObserver) {

--- a/runtime/observability/metrics/provider_conformance_test.go
+++ b/runtime/observability/metrics/provider_conformance_test.go
@@ -14,28 +14,34 @@ import (
 // suite against providerCollector (via spyProvider). This satisfies the
 // enrollment requirement checked by COLLECTOR-CONFORMANCE-ENROLLMENT-01.
 func TestProviderCollector_Conformance(t *testing.T) {
-	metricstest.RunCollectorConformance(t, &providerCollectorHarness{})
+	metricstest.RunCollectorConformance(t, providerCollectorHarness{})
 }
 
-// providerCollectorHarness adapts providerCollector (built on spyProvider) to
-// metricstest.CollectorHarness.
-type providerCollectorHarness struct {
-	spy *spyProvider
-}
+// providerCollectorHarness implements metricstest.CollectorHarness for
+// providerCollector. It holds no mutable state; each New call returns a
+// self-contained (Collector, CollectorObserver) pair backed by a fresh
+// spyProvider, so parallel subtests are race-free.
+type providerCollectorHarness struct{}
 
-func (h *providerCollectorHarness) New(t *testing.T) metrics.Collector {
+func (providerCollectorHarness) New(t *testing.T) (metrics.Collector, metricstest.CollectorObserver) {
 	t.Helper()
-	h.spy = newSpyProvider()
-	col, err := metrics.NewProviderCollector(h.spy, metrics.ProviderCollectorConfig{})
+	spy := newSpyProvider()
+	col, err := metrics.NewProviderCollector(spy, metrics.ProviderCollectorConfig{})
 	if err != nil {
 		t.Fatalf("providerCollectorHarness.New: %v", err)
 	}
-	return col
+	return col, &providerCollectorObserver{spy: spy}
 }
 
-func (h *providerCollectorHarness) RequestCount(key metricstest.RequestKey) int64 {
+// providerCollectorObserver is the read-side for a single providerCollector
+// instance. It is bound to one spyProvider and never shared across subtests.
+type providerCollectorObserver struct {
+	spy *spyProvider
+}
+
+func (o *providerCollectorObserver) RequestCount(key metricstest.RequestKey) int64 {
 	var total int64
-	for _, op := range h.spy.counterOps["http_requests_total"] {
+	for _, op := range o.spy.counterOps["http_requests_total"] {
 		if matchRequestKey(op.labels, key) {
 			total += int64(op.value)
 		}
@@ -43,9 +49,9 @@ func (h *providerCollectorHarness) RequestCount(key metricstest.RequestKey) int6
 	return total
 }
 
-func (h *providerCollectorHarness) BodyLimitRejectionCount(key metricstest.BodyLimitRejectionKey) int64 {
+func (o *providerCollectorObserver) BodyLimitRejectionCount(key metricstest.BodyLimitRejectionKey) int64 {
 	var total int64
-	for _, op := range h.spy.counterOps["http_request_body_limit_rejections_total"] {
+	for _, op := range o.spy.counterOps["http_request_body_limit_rejections_total"] {
 		if op.labels["cell"] == key.Cell && op.labels["route"] == key.Route {
 			total += int64(op.value)
 		}
@@ -55,8 +61,8 @@ func (h *providerCollectorHarness) BodyLimitRejectionCount(key metricstest.BodyL
 
 // LastCtxForBodyLimitRejection returns the ctx from the most recent
 // RecordBodyLimitRejection call, proving ctx forwarding to the instrument.
-func (h *providerCollectorHarness) LastCtxForBodyLimitRejection() context.Context {
-	ops := h.spy.counterOps["http_request_body_limit_rejections_total"]
+func (o *providerCollectorObserver) LastCtxForBodyLimitRejection() context.Context {
+	ops := o.spy.counterOps["http_request_body_limit_rejections_total"]
 	if len(ops) == 0 {
 		return nil
 	}

--- a/runtime/observability/metrics/provider_conformance_test.go
+++ b/runtime/observability/metrics/provider_conformance_test.go
@@ -1,0 +1,73 @@
+package metrics_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
+	"github.com/ghbvf/gocell/runtime/observability/metrics/metricstest"
+)
+
+// TestProviderCollector_Conformance runs the shared Collector conformance
+// suite against providerCollector (via spyProvider). This satisfies the
+// enrollment requirement checked by COLLECTOR-CONFORMANCE-ENROLLMENT-01.
+func TestProviderCollector_Conformance(t *testing.T) {
+	metricstest.RunCollectorConformance(t, &providerCollectorHarness{})
+}
+
+// providerCollectorHarness adapts providerCollector (built on spyProvider) to
+// metricstest.CollectorHarness.
+type providerCollectorHarness struct {
+	spy *spyProvider
+}
+
+func (h *providerCollectorHarness) New(t *testing.T) metrics.Collector {
+	t.Helper()
+	h.spy = newSpyProvider()
+	col, err := metrics.NewProviderCollector(h.spy, metrics.ProviderCollectorConfig{})
+	if err != nil {
+		t.Fatalf("providerCollectorHarness.New: %v", err)
+	}
+	return col
+}
+
+func (h *providerCollectorHarness) RequestCount(key metricstest.RequestKey) int64 {
+	var total int64
+	for _, op := range h.spy.counterOps["http_requests_total"] {
+		if matchRequestKey(op.labels, key) {
+			total += int64(op.value)
+		}
+	}
+	return total
+}
+
+func (h *providerCollectorHarness) BodyLimitRejectionCount(key metricstest.BodyLimitRejectionKey) int64 {
+	var total int64
+	for _, op := range h.spy.counterOps["http_request_body_limit_rejections_total"] {
+		if op.labels["cell"] == key.Cell && op.labels["route"] == key.Route {
+			total += int64(op.value)
+		}
+	}
+	return total
+}
+
+// LastCtxForBodyLimitRejection returns the ctx from the most recent
+// RecordBodyLimitRejection call, proving ctx forwarding to the instrument.
+func (h *providerCollectorHarness) LastCtxForBodyLimitRejection() context.Context {
+	ops := h.spy.counterOps["http_request_body_limit_rejections_total"]
+	if len(ops) == 0 {
+		return nil
+	}
+	return ops[len(ops)-1].ctx
+}
+
+// matchRequestKey reports whether a spy counter label set matches the given
+// RequestKey. Status is stored as a decimal string in the spy (strconv.Itoa).
+func matchRequestKey(labels kernelmetrics.Labels, key metricstest.RequestKey) bool {
+	return labels["cell"] == key.Cell &&
+		labels["method"] == key.Method &&
+		labels["route"] == key.Route &&
+		labels["status"] == strconv.Itoa(key.Status)
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -121,6 +121,17 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 # helper-package regex; mirror that here for SonarCloud new-code honesty. Excluded
 # at package level — the package is pure test-helper, no sibling production code.
 #
+# runtime/observability/metrics/metricstest/ is the Collector conformance suite
+# (RunCollectorConformance + CollectorHarness/CollectorObserver). Same
+# conformance-suite exclusion pattern as kernel/saga/sagajournaltest/** above:
+# conformance.go is published as a plain .go file (not _test.go) so caller
+# packages can import it, but its assertion bodies are exercised only from OTHER
+# packages' tests (runtime/observability/metrics/{inmemory,provider}_conformance_test.go,
+# and future Collector implementations add sibling calls). Per-shard CI runs go
+# test without -coverpkg=./..., so cross-package line hits never attribute back to
+# conformance.go. Excluded at package level — the package is pure test-helper, no
+# sibling production code.
+#
 # Cross-platform stubs and Windows-only code are excluded from Sonar coverage:
 # - *_windows.go files compile only on Windows, where the os-smoke matrix runs
 #   them but does not feed coverage into Sonar (Linux is the Sonar baseline).
@@ -155,6 +166,7 @@ sonar.coverage.exclusions=\
   **/kernel/projection/projectiontest/**,\
   **/kernel/saga/sagajournaltest/**,\
   **/kernel/webhook/webhooktest/**,\
+  **/runtime/observability/metrics/metricstest/**,\
   **/examples/**,\
   **/cells/accesscore/initialadmin/credfile_security_windows.go,\
   **/cells/accesscore/initialadmin/path_default_windows.go,\

--- a/tools/archtest/collector_conformance_enrollment_test.go
+++ b/tools/archtest/collector_conformance_enrollment_test.go
@@ -1,0 +1,302 @@
+// INVARIANT: COLLECTOR-CONFORMANCE-ENROLLMENT-01
+//
+// AI-robust: Medium
+//
+// Enforces: every concrete type in the production source tree that implements
+// runtime/observability/metrics.Collector must have at least one
+// metricstest.RunCollectorConformance call in a _test.go file of its package
+// (or the corresponding external _test variant). Packages without such a call
+// are reported as violations.
+//
+// # Detection mechanism
+//
+//   - Implementation scan: types.Implements(*types.Interface) — type-aware;
+//     identifies every concrete named type (exported AND unexported) that
+//     satisfies runtime/observability/metrics.Collector in the production
+//     source tree (Tests=false pass).
+//   - Conformance call scan: RunTyped with Tests=true; for every _test.go file
+//     containing a RunCollectorConformance call, walk all CallExpr nodes to find
+//     the first argument to New() within the same file's harness. Because the
+//     harness pattern stores the Collector in a field, impl-level resolution is
+//     not required — package co-location is the enrollment granule here (one
+//     conformance call per package covers all impls in that package).
+//
+// # AI-robust rating
+//
+// Medium is the ceiling by construction — Go cannot require a _test.go file
+// to exist for a type at compile time. The enforcement is archtest-bound (CI
+// fails on violation), not compile-time. The Hard upgrade path is a codegen
+// funnel that enumerates Collector impls from a single source of truth and
+// byte-locks the enrollment registry; deferred to backlog issue #1398 (same
+// issue tracking archtest Hard-ization).
+//
+// # Blind-spot catalog (forms not reachable by *types.Info)
+//
+//   - B1. reflect-based implicit implementations: no production code uses this
+//     pattern. Confirmed by
+//     TestCollectorConformanceEnrollment_ReverseBlindSpot_NoReflectImpl, which
+//     asserts zero occurrences of "Collector" as a string literal in
+//     production non-test files (beyond the interface declaration itself).
+//
+//   - B2. Generated mock implementations (mockery/gomock in _test.go) are
+//     excluded: test-file types are not scanned for implementations (Tests=false
+//     in the production load pass). A generated mock in a production non-test
+//     file would be flagged — intentionally.
+//
+//   - B3. Embedded interface forwarding (struct embedding metrics.Collector):
+//     such a type structurally satisfies the interface. Production structs that
+//     embed the interface are treated as implementations and must enroll.
+//
+// Hard-ization path: codegen funnel from a single golden registry of Collector
+// implementations; tracked in gh #1398.
+//
+// ref: tools/archtest/saga_invariants_test.go SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01
+// ref: tools/archtest/cell_repo_readyz_probe_test.go CELL-REPO-READYZ-PROBE-01
+// ref: runtime/observability/metrics/metricstest/conformance.go RunCollectorConformance
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/internal/prodscan"
+)
+
+const (
+	collectorIfacePkg            = "github.com/ghbvf/gocell/runtime/observability/metrics"
+	collectorIfaceName           = "Collector"
+	collectorConformancePkg      = "github.com/ghbvf/gocell/runtime/observability/metrics/metricstest"
+	collectorConformanceFuncName = "RunCollectorConformance"
+)
+
+// TestCollectorConformanceEnrollment enforces COLLECTOR-CONFORMANCE-
+// ENROLLMENT-01: every concrete type implementing
+// runtime/observability/metrics.Collector in the production tree must have a
+// metricstest.RunCollectorConformance call in a _test.go file of its package.
+func TestCollectorConformanceEnrollment(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+
+	// ─── Step 1: resolve Collector interface + collect impl pkgs ───────────
+	// Use prodscan.Patterns directly (runtime/observability/metrics is already
+	// included). A single RunTyped load resolves both the interface and all
+	// candidate impl packages, sharing the SharedResolver cache.
+	prodPatterns := prodscan.Patterns(root)
+
+	var collectorIface *types.Interface
+	var implPkgs []*types.Package
+
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, prodPatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == collectorIfacePkg {
+				if obj := p.Pkg.Scope().Lookup(collectorIfaceName); obj != nil {
+					if named, ok := obj.Type().(*types.Named); ok {
+						if i, ok := named.Underlying().(*types.Interface); ok {
+							collectorIface = i.Complete()
+						}
+					}
+				}
+			}
+			implPkgs = append(implPkgs, p.Pkg)
+			return nil
+		})
+
+	require.NotNil(t, collectorIface,
+		"COLLECTOR-CONFORMANCE-ENROLLMENT-01: failed to resolve %s.%s interface; "+
+			"check import path %s", collectorIfacePkg, collectorIfaceName, collectorIfacePkg)
+
+	// ─── Step 2: collect all concrete implementations (pkg-level granule) ──
+	// Each impl is stored as its package path; one RunCollectorConformance call
+	// in the package is sufficient (unlike SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01
+	// which uses impl-level keys). The two production impls live in separate
+	// packages, so per-package enrollment is the correct granule here.
+	implPkgPaths := make(map[string]bool) // package path → true
+
+	for _, pkg := range implPkgs {
+		if pkg == nil {
+			continue
+		}
+		collectCollectorImpls(pkg, collectorIface, implPkgPaths)
+	}
+
+	require.NotEmpty(t, implPkgPaths,
+		"COLLECTOR-CONFORMANCE-ENROLLMENT-01: zero Collector implementations collected — "+
+			"likely a type-universe regression. Expect at least InMemoryCollector "+
+			"(runtime/observability/metrics) and providerCollector "+
+			"(runtime/observability/metrics, unexported).")
+
+	// ─── Step 3: scan test corpus for RunCollectorConformance calls ─────────
+	enrolledPkgs := make(map[string]bool)
+
+	testPatterns := prodscan.Patterns(root)
+	_ = RunTyped(t, TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, testPatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if !strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				if !hasCollectorConformanceCall(f, p.TypesInfo) {
+					continue
+				}
+				// Credit the package that contains this test file.
+				// Strip the "_test" suffix that Go adds to external test packages.
+				pkgPath := strings.TrimSuffix(p.Pkg.Path(), "_test")
+				enrolledPkgs[pkgPath] = true
+			}
+			return nil
+		})
+
+	// ─── Step 4: flag unenrolled implementation packages ───────────────────
+	var diags []Diagnostic
+	for pkgPath := range implPkgPaths {
+		if enrolledPkgs[pkgPath] {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Rel:  pkgPath,
+			Line: 0,
+			Message: fmt.Sprintf(
+				"archtest: runtime/observability/metrics.Collector impl in package %q "+
+					"not enrolled (COLLECTOR-CONFORMANCE-ENROLLMENT-01). "+
+					"Add a _test.go in package %s (or its external _test) that "+
+					"calls metricstest.RunCollectorConformance(t, harness).",
+				pkgPath, pkgPath),
+		})
+	}
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	Report(t, "COLLECTOR-CONFORMANCE-ENROLLMENT-01", diags)
+}
+
+// collectCollectorImpls walks pkg's scope and adds the path of any package
+// that contains a concrete type implementing metrics.Collector.
+func collectCollectorImpls(pkg *types.Package, iface *types.Interface, out map[string]bool) {
+	if pkg == nil || iface == nil {
+		return
+	}
+	scope := pkg.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if obj == nil {
+			continue
+		}
+		named, ok := obj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		// Check value receiver.
+		if types.Implements(named, iface) {
+			out[pkg.Path()] = true
+			return
+		}
+		// Check pointer receiver.
+		if types.Implements(types.NewPointer(named), iface) {
+			out[pkg.Path()] = true
+			return
+		}
+	}
+}
+
+// hasCollectorConformanceCall reports whether the file contains a call to
+// metricstest.RunCollectorConformance. Resolution uses TypesInfo when available
+// (typed load) to bind the callee to its package path.
+func hasCollectorConformanceCall(file *ast.File, info *types.Info) bool {
+	found := false
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if found {
+			return
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != collectorConformanceFuncName {
+			return
+		}
+		if info == nil {
+			// Fallback: AST-only — check the qualifier name.
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == "metricstest" {
+				found = true
+			}
+			return
+		}
+		// Typed resolution: resolve the callee's package.
+		if obj := info.ObjectOf(sel.Sel); obj != nil && obj.Pkg() != nil {
+			if obj.Pkg().Path() == collectorConformancePkg {
+				found = true
+			}
+		}
+	})
+	return found
+}
+
+// TestCollectorConformanceEnrollment_ReverseBlindSpot_NoReflectImpl is the B1
+// reverse self-test: asserts no production non-test file uses string literal
+// "Collector" with MethodByName to drive reflect-based implicit implementation
+// (the most common bypass path for archtest impl scans). Zero occurrences are
+// expected in production non-test files.
+func TestCollectorConformanceEnrollment_ReverseBlindSpot_NoReflectImpl(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+
+	var diags []Diagnostic
+
+	// Scan production non-test files for MethodByName("Collector") calls.
+	_ = RunTyped(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		prodscan.Patterns(root),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok || sel.Sel == nil || sel.Sel.Name != "MethodByName" {
+						return
+					}
+					if len(call.Args) != 1 {
+						return
+					}
+					lit, ok := call.Args[0].(*ast.BasicLit)
+					if !ok {
+						return
+					}
+					if strings.Trim(lit.Value, `"`) == collectorIfaceName {
+						diags = append(diags, Diagnostic{
+							Rel:  rel,
+							Line: 0,
+							Message: fmt.Sprintf(
+								"B1 blind-spot (COLLECTOR-CONFORMANCE-ENROLLMENT-01): "+
+									"reflect.MethodByName(%q) in production non-test file %s — "+
+									"implicit Collector impl bypasses archtest impl scan",
+								collectorIfaceName, rel),
+						})
+					}
+				})
+			}
+			return nil
+		})
+
+	Report(t, "COLLECTOR-CONFORMANCE-ENROLLMENT-01/B1-reverse-self-test", diags)
+}

--- a/tools/archtest/collector_conformance_enrollment_test.go
+++ b/tools/archtest/collector_conformance_enrollment_test.go
@@ -69,9 +69,9 @@ import (
 )
 
 const (
-	collectorIfacePkg            = "github.com/ghbvf/gocell/runtime/observability/metrics"
+	collectorIfacePkg            = PlatformModulePath + "/runtime/observability/metrics"
 	collectorIfaceName           = "Collector"
-	collectorConformancePkg      = "github.com/ghbvf/gocell/runtime/observability/metrics/metricstest"
+	collectorConformancePkg      = PlatformModulePath + "/runtime/observability/metrics/metricstest"
 	collectorConformanceFuncName = "RunCollectorConformance"
 )
 

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -6,6 +6,7 @@ package archtest
 //   - INVARIANT: HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01
 //   - INVARIANT: HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01
 //   - INVARIANT: HTTP-METRICS-LABEL-ROUTER-ATTRIBUTION-01
+//   - INVARIANT: HTTP-METRICS-LABEL-BODYLIMIT-CTXSOURCE-01
 //
 // http_metrics_label_test.go enforces the HTTP-METRICS-LABEL-REALIGN
 // contract (D1, 2026-05-04): cell identity is a router-root request
@@ -26,11 +27,12 @@ import (
 )
 
 const (
-	ruleHTTPMetricsLabelCtxSource01       = "HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01"
-	ruleHTTPMetricsLabelNoAssemblyDerive  = "HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01"
-	ruleHTTPMetricsLabelNoConfigCellID    = "HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01"
-	ruleHTTPMetricsLabelRuntimeSentinel   = "HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01"
-	ruleHTTPMetricsLabelRouterAttribution = "HTTP-METRICS-LABEL-ROUTER-ATTRIBUTION-01"
+	ruleHTTPMetricsLabelCtxSource01          = "HTTP-METRICS-LABEL-CELLID-CTXSOURCE-01"
+	ruleHTTPMetricsLabelNoAssemblyDerive     = "HTTP-METRICS-LABEL-NO-ASSEMBLY-DERIVE-01"
+	ruleHTTPMetricsLabelNoConfigCellID       = "HTTP-METRICS-LABEL-NO-CONFIG-CELLID-01"
+	ruleHTTPMetricsLabelRuntimeSentinel      = "HTTP-METRICS-LABEL-RUNTIME-SENTINEL-01"
+	ruleHTTPMetricsLabelRouterAttribution    = "HTTP-METRICS-LABEL-ROUTER-ATTRIBUTION-01"
+	ruleHTTPMetricsLabelBodyLimitCtxSource01 = "HTTP-METRICS-LABEL-BODYLIMIT-CTXSOURCE-01"
 )
 
 func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
@@ -401,6 +403,93 @@ func isRouterUseWithDefaultMiddleware(call *ast.CallExpr) bool {
 		}
 	}
 	return false
+}
+
+// TestHTTPMetricsLabelBodyLimitCtxSource01 enforces that the body-limit
+// rejection recording helper (recordBodyLimitRejection in body_limit.go):
+//
+//  1. Reads the cell label from ctxkeys.CellIDFrom.
+//  2. Falls back to RuntimeCellIDSentinel when the ctx key is absent.
+//  3. Calls collector.RecordBodyLimitRejection AFTER the CellIDFrom read.
+//
+// AI-robust rating: Medium (AST form check + position ordering; Hard path =
+// sealed collector interface that forces routing through a typed funnel,
+// tracked in gh #1166).
+//
+// Blind spots:
+//   - Does not trace through function-value fields (the collector argument is
+//     passed as a parameter, not stored in a named struct field).
+//   - Does not verify that the ctx passed to RecordBodyLimitRejection equals
+//     r.Context() — only that RecordBodyLimitRejection is called.
+//
+// Reverse self-check: asserts the old shape (inline ctxkeys read without
+// SafeObserve) does not appear in body_limit.go production code.
+func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
+	root := findModuleRoot(t)
+	target := filepath.Join(root, "runtime", "http", "middleware", "body_limit.go")
+	rel := slashRel(t, root, target)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, target, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "%s: parse failed", rel)
+
+	// Find the recordBodyLimitRejection helper function.
+	helperFn := findHTTPMetricsFuncDecl(t, file, "recordBodyLimitRejection")
+
+	var (
+		readsCellIDFrom     bool
+		usesRuntimeSentinel bool
+		callsRecordBLR      bool
+		ctxCellIDPos        token.Pos
+		runtimeSentinelPos  token.Pos
+		recordBLRPos        token.Pos
+	)
+
+	scanner.EachInSubtree[ast.CallExpr](helperFn.Body, func(v *ast.CallExpr) {
+		if isSelectorCall(v, "ctxkeys", "CellIDFrom") {
+			readsCellIDFrom = true
+			rememberFirstPos(&ctxCellIDPos, v.Pos())
+		}
+		if isSelectorCall(v, "collector", "RecordBodyLimitRejection") {
+			callsRecordBLR = true
+			rememberFirstPos(&recordBLRPos, v.Pos())
+		}
+	})
+	scanner.EachInSubtree[ast.Ident](helperFn.Body, func(v *ast.Ident) {
+		if v.Name == "RuntimeCellIDSentinel" {
+			usesRuntimeSentinel = true
+			rememberFirstPos(&runtimeSentinelPos, v.Pos())
+		}
+	})
+
+	assert.Truef(t, readsCellIDFrom,
+		"%s: %s — recordBodyLimitRejection must read cell label from ctxkeys.CellIDFrom",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, usesRuntimeSentinel,
+		"%s: %s — recordBodyLimitRejection must fall back to RuntimeCellIDSentinel when ctx key is absent",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, callsRecordBLR,
+		"%s: %s — recordBodyLimitRejection must call collector.RecordBodyLimitRejection",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, ctxCellIDPos.IsValid() && recordBLRPos.IsValid() && ctxCellIDPos < recordBLRPos,
+		"%s: %s — ctxkeys.CellIDFrom must be called before collector.RecordBodyLimitRejection",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, runtimeSentinelPos.IsValid() && recordBLRPos.IsValid() && runtimeSentinelPos < recordBLRPos,
+		"%s: %s — RuntimeCellIDSentinel fallback must appear before collector.RecordBodyLimitRejection",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+
+	// Reverse self-check: the BodyLimit outer function must NOT contain a
+	// direct ctxkeys.CellIDFrom call (it must delegate to the helper).
+	bodyLimitFn := findHTTPMetricsFuncDecl(t, file, "BodyLimit")
+	var outerCellIDFromCalls int
+	scanner.EachInSubtree[ast.CallExpr](bodyLimitFn.Body, func(v *ast.CallExpr) {
+		if isSelectorCall(v, "ctxkeys", "CellIDFrom") {
+			outerCellIDFromCalls++
+		}
+	})
+	assert.Zerof(t, outerCellIDFromCalls,
+		"%s: %s — BodyLimit must delegate cell resolution to recordBodyLimitRejection, not call ctxkeys.CellIDFrom directly",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 }
 
 func rememberFirstPos(dst *token.Pos, pos token.Pos) {

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -414,7 +414,7 @@ func isRouterUseWithDefaultMiddleware(call *ast.CallExpr) bool {
 //
 // AI-robust rating: Medium (AST form check + position ordering; Hard path =
 // sealed collector interface that forces routing through a typed funnel,
-// tracked in gh #1166).
+// tracked in gh #1398).
 //
 // Blind spots:
 //   - Does not trace through function-value fields (the collector argument is

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -411,19 +411,42 @@ func isRouterUseWithDefaultMiddleware(call *ast.CallExpr) bool {
 //  1. Reads the cell label from ctxkeys.CellIDFrom.
 //  2. Falls back to RuntimeCellIDSentinel when the ctx key is absent.
 //  3. Calls collector.RecordBodyLimitRejection AFTER the CellIDFrom read.
+//  4. Derives the route label via RouteFor (not a bare string literal or URL path).
+//  5. Passes ctx (derived from r.Context()) as the first argument to
+//     RecordBodyLimitRejection so OTel exemplar/baggage correlation is preserved.
+//  6. Passes a named route variable (not a bare RouteFor call expression) as
+//     the third argument to RecordBodyLimitRejection.
 //
 // AI-robust rating: Medium (AST form check + position ordering; Hard path =
 // sealed collector interface that forces routing through a typed funnel,
 // tracked in gh #1398).
 //
-// Blind spots:
-//   - Does not trace through function-value fields (the collector argument is
-//     passed as a parameter, not stored in a named struct field).
-//   - Does not verify that the ctx passed to RecordBodyLimitRejection equals
-//     r.Context() — only that RecordBodyLimitRejection is called.
+// # Covered forms (reverse self-tests assert these are the only forms present)
+//
+//   - ctxkeys.CellIDFrom appears in the helper body before RecordBodyLimitRejection.
+//   - RuntimeCellIDSentinel appears in the helper body before RecordBodyLimitRejection.
+//   - RouteFor is called in the helper body (route is not a bare literal or URL path).
+//   - RecordBodyLimitRejection arg[0] is an *ast.Ident (ctx variable, not a call expr
+//     such as context.Background() or r.Context() directly).
+//   - RecordBodyLimitRejection arg[2] is an *ast.Ident (route variable, not a bare
+//     RouteFor call expression inlined into the argument).
+//
+// # Blind spots (forms not locked by this archtest)
+//
+//   - B1. The archtest does not trace function-value fields: collector is a
+//     parameter, not a struct field, so pointer-chasing is unnecessary.
+//   - B2. The archtest does not verify that the ctx identifier was initialized
+//     from r.Context() vs some other source (e.g. context.Background()). This
+//     is partially mitigated by the AST check that arg[0] is an identifier (not
+//     a call expression), combined with the naming convention enforced by the
+//     reverse self-check on BodyLimit's outer body.
+//   - B3. The archtest does not verify that the route variable was produced by
+//     RouteFor (not e.g. a constant). It only asserts RouteFor is called
+//     somewhere in the helper body and that the call-site arg[2] is an ident.
 //
 // Reverse self-check: asserts the old shape (inline ctxkeys read without
-// SafeObserve) does not appear in body_limit.go production code.
+// SafeObserve) does not appear in body_limit.go production code, and that
+// BodyLimit's outer function does not bypass the helper.
 func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 	root := findModuleRoot(t)
 	target := filepath.Join(root, "runtime", "http", "middleware", "body_limit.go")
@@ -437,12 +460,15 @@ func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 	helperFn := findHTTPMetricsFuncDecl(t, file, "recordBodyLimitRejection")
 
 	var (
-		readsCellIDFrom     bool
-		usesRuntimeSentinel bool
-		callsRecordBLR      bool
-		ctxCellIDPos        token.Pos
-		runtimeSentinelPos  token.Pos
-		recordBLRPos        token.Pos
+		readsCellIDFrom      bool
+		usesRuntimeSentinel  bool
+		callsRecordBLR       bool
+		callsRouteFor        bool
+		recordBLRArg0IsCtx   bool // arg[0] is an identifier (ctx var, not a call expr)
+		recordBLRArg2IsIdent bool // arg[2] is an identifier (route var, not inline call)
+		ctxCellIDPos         token.Pos
+		runtimeSentinelPos   token.Pos
+		recordBLRPos         token.Pos
 	)
 
 	scanner.EachInSubtree[ast.CallExpr](helperFn.Body, func(v *ast.CallExpr) {
@@ -450,9 +476,28 @@ func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 			readsCellIDFrom = true
 			rememberFirstPos(&ctxCellIDPos, v.Pos())
 		}
+		if isIdent(v.Fun, "RouteFor") || isSelectorCall(v, "middleware", "RouteFor") {
+			callsRouteFor = true
+		}
+		// RouteFor may also be called as a plain identifier in the same package.
+		if id, ok := v.Fun.(*ast.Ident); ok && id.Name == "RouteFor" {
+			callsRouteFor = true
+		}
 		if isSelectorCall(v, "collector", "RecordBodyLimitRejection") {
 			callsRecordBLR = true
 			rememberFirstPos(&recordBLRPos, v.Pos())
+			// arg[0]: must be an identifier (the ctx variable, not a call expr).
+			if len(v.Args) > 0 {
+				if _, ok := v.Args[0].(*ast.Ident); ok {
+					recordBLRArg0IsCtx = true
+				}
+			}
+			// arg[2]: must be an identifier (the route variable, not an inline call).
+			if len(v.Args) > 2 {
+				if _, ok := v.Args[2].(*ast.Ident); ok {
+					recordBLRArg2IsIdent = true
+				}
+			}
 		}
 	})
 	scanner.EachInSubtree[ast.Ident](helperFn.Body, func(v *ast.Ident) {
@@ -470,6 +515,19 @@ func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 	assert.Truef(t, callsRecordBLR,
 		"%s: %s — recordBodyLimitRejection must call collector.RecordBodyLimitRejection",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, callsRouteFor,
+		"%s: %s — recordBodyLimitRejection must derive route via RouteFor (not a bare literal or URL path)",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, recordBLRArg0IsCtx,
+		"%s: %s — RecordBodyLimitRejection arg[0] must be an identifier (the ctx variable), "+
+			"not a call expression such as r.Context() or context.Background() directly; "+
+			"ctx must be extracted before the SafeObserve closure so the ctx is bound at "+
+			"the outer scope (OTel exemplar/baggage correlation preserved)",
+		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
+	assert.Truef(t, recordBLRArg2IsIdent,
+		"%s: %s — RecordBodyLimitRejection arg[2] must be an identifier (the route variable), "+
+			"not an inline RouteFor call expression",
 		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 	assert.Truef(t, ctxCellIDPos.IsValid() && recordBLRPos.IsValid() && ctxCellIDPos < recordBLRPos,
 		"%s: %s — ctxkeys.CellIDFrom must be called before collector.RecordBodyLimitRejection",

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -664,6 +664,12 @@ func (sp *scanPackage) providerCollectorEntries(call *ast.CallExpr, rel string) 
 	labels := []string{"method", "route", "status", "cell"}
 	return []Entry{
 		sp.entryFromOpts("counter", opts{
+			name:      "http_request_body_limit_rejections_total",
+			namespace: sp.namespace,
+			help:      "Total number of HTTP requests rejected for exceeding the body size limit (Content-Length fast-path).",
+			labels:    []string{"cell", "route"},
+		}, rel, call.Pos()),
+		sp.entryFromOpts("counter", opts{
 			name:      "http_requests_total",
 			namespace: sp.namespace,
 			help:      "Total number of HTTP requests.",

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -63,6 +63,11 @@ func TestBuild_CorebundleCapturesReachableTypedMetrics(t *testing.T) {
 	assert.Empty(t, httpDuration.BucketSource)
 	assert.Equal(t, "runtime/bootstrap/phases_http.go", httpDuration.File)
 
+	httpBodyLimitRejections := requireMetric(t, schema, "http_request_body_limit_rejections_total")
+	assert.Equal(t, []string{"cell", "route"}, httpBodyLimitRejections.Labels)
+	assert.Equal(t, "gocell_http_request_body_limit_rejections_total", httpBodyLimitRejections.FQName)
+	assert.Equal(t, "counter", httpBodyLimitRejections.Type)
+
 	vaultLogin := requireMetric(t, schema, "auth_login_total")
 	assert.Equal(t, "gocell_vault_auth_login_total", vaultLogin.FQName)
 	assert.Equal(t, []string{"method", "result", "reason"}, vaultLogin.Labels)


### PR DESCRIPTION
## Summary

给 `runtime/http/middleware` 的 BodyLimit 中间件加 metric counter
`http_request_body_limit_rejections_total`（label `cell` / `route`），在 body 超限
Content-Length fast-path 拒绝处递增。此前运维只能从 `http_requests_total{status="413"}`
间接观测、且与其它 413 混淆。

`Closes #1166`

## 实现要点

- **注入 seam = `runtime/observability/metrics.Collector` 接口**。issue 描述的「参考
  circuit_breaker metrics」不准确——仓库里 circuit breaker 不发任何 metric、无
  `circuit_breaker_metrics.go`；本 PR 改用真正现有的 Collector seam。新增方法
  `RecordBodyLimitRejection(ctx, cellID, route)`，两个实现（`InMemoryCollector` /
  `providerCollector`）补齐。
- **记录点 = BodyLimit fast-path reject**（Content-Length 头超限）。cell/route 解析与
  Metrics 中间件完全一致：cell 取 `ctxkeys.CellIDFrom`（缺失回退
  `RuntimeCellIDSentinel="_runtime"`），route 取 `RouteFor`；记录包在
  `observability.SafeObserve` 内，metric 故障不打断 413 响应；nil collector 守卫。
- **已知边界（非静默缺口）**：流式 `http.MaxBytesReader` 超限的 413 在下游 handler
  产生、不在中间件控制流内，**不**计入本 counter，继续由
  `http_requests_total{status="413"}` 覆盖。godoc + docs 已显式写明。
- **codegen 闭环**：`tools/metricschema/schema.go::providerCollectorEntries` 同步合成新
  条目，regenerate 3 个含 HTTP metric 的 golden（corebundle / iotdevice / todoorder）。
- **archtest 守卫**：新增 `HTTP-METRICS-LABEL-BODYLIMIT-CTXSOURCE-01`（含反向 guard），
  断言记录点 cell 取自 ctx、缺失回退 sentinel、解析先于记录调用。AI-robust 评级 Medium。

## Contract-fanout（Collector 接口新增方法）

- Contract: `runtime/observability/metrics.Collector`
- Change: add `RecordBodyLimitRejection(ctx, cellID, route)`
- Implementations: [x] InMemoryCollector  [x] providerCollector
- Conformance: Go 类型系统（仅 2 实现，`var _ Collector = ...` 编译期断言）

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`（改动包 + archtest 全绿）
- [x] `golangci-lint run ./...`（0 issues）
- [x] `body_limit_test.go`：`TestBodyLimit_RecordsRejectionMetric` + nil-collector + under-limit + cell-from-ctx 反向用例 + 4 既有用例改新签名
- [x] `collector_test.go` / `provider_collector_test.go`：新方法两实现单测（含 label 断言）
- [x] `router_test.go`：端到端 `TestMountRouteGroup_CellAttribution_BodyLimitReject` 断言新 counter 递增（cell=configcore, route=/api/v1/upload/blob）
- [x] archtest `HTTP-METRICS-LABEL-BODYLIMIT-CTXSOURCE-01` + 反向自检
- [x] golden diff 仅新增 3 条预期条目

🤖 Generated with [Claude Code](https://claude.com/claude-code)
