### PR TITLE
docs(saga): ADR + ops runbook + CLAUDE.md + capability-inventory (W6 step 10/10)

### DIFF
--- a/.claude/rules/gocell/saga.md
+++ b/.claude/rules/gocell/saga.md
@@ -77,6 +77,7 @@ GoCell 中有三个 L3 cell 并非 saga 编排：
 ## 参考
 
 - 实施计划：`docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md` §4 PR-08（governance + archtest 落地 PR）
-- Saga 专属 ADR：**尚未创建**（PR-10 deliverable，计划命名 `…-adr-saga-l3-orchestration-engine.md`）；在它落地前，权威视图以上述实施计划和代码 godoc 为准——本文件刻意不给出可点击路径以免 404
+- Saga 专属 ADR：`docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md`（决策 D1–D10 + enforcement 档位映射 + 威胁矩阵 + 演进路径）；本文件是 archtest / governance 导航索引，决策权威以该 ADR 为准
+- 运维故障 runbook：`docs/ops/saga-runbook.md`（lease 卡死 / 补偿失败 / journal 增长三场景诊断 SQL + 决策树）
 - 契约变更扇出闭环：`.claude/rules/gocell/contract-fanout.md`（`saga.Status` / `journal.EventKind` 新常量触发扇出规则）
 - AI-robust 治理章程：`.claude/rules/gocell/ai-robust.md`（评级定义、archtest 文件命名约定）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,18 @@ actors.yaml   — 外部 Actor 注册（参与 contract 但不属于 Cell 模型
 | L3 WorkflowEventual | 跨 cell 最终一致 | 查询投影、合规追踪 |
 | L4 DeviceLatent | 设备长延迟闭环 | 命令回执、证书续期 |
 
+### L3 Saga 编排
+
+L3 覆盖两类场景——**单向蕴含**：用 saga 编排 ⟹ L3，但 L3 ≠ saga（`accesscore` / `configcore` / `examples/todoorder/ordercell` 是投影型 / CQRS 的 L3，不用 saga 引擎）。
+
+saga 引擎分三层：状态机原语 `kernel/saga`（`Status` 8 态 / `Step` / `SagaDefinition`）+ append-only journal `kernel/saga/journal`（mem）与 `adapters/postgres/saga`（PG，lease_id CAS）+ 编排运行时 `runtime/saga`（Coordinator + leader-elect via `runtime/distlock` + executor 重试/heartbeat）。Step 编程式（Go func），Compensate 必须纯反向幂等（archtest Hard 守）。
+
+约束 enforcement / 故障 runbook / 设计决策三处单源，不在此复制：
+
+- archtest + governance 索引：`.claude/rules/gocell/saga.md`
+- 设计决策 D1–D10 + 威胁矩阵 + 演进路径：ADR `docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md`
+- 运维故障 runbook：`docs/ops/saga-runbook.md`
+
 ## Go 编码规范
 
 - 错误用 `pkg/errcode` 包

--- a/docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md
+++ b/docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md
@@ -1,0 +1,139 @@
+# ADR: L3 Saga / Workflow 编排引擎
+
+- 日期：2026-06-02
+- 状态：Accepted
+- 范围：framework-capability-roadmap **W6** / 实施计划 `docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md`（PR-00 … PR-10，本 ADR 是 PR-10 收尾交付物）
+- 关联规则导航：`.claude/rules/gocell/saga.md`（archtest / governance 索引，单源）
+
+> **本 ADR 与 046 实施计划的真值边界**：046 计划是**执行视图**（PR 切片 / LOC / ship 阶段），其顶部已声明「单条 PR 的最终行为以 PR body + ADR + 落地 godoc 为准」。本 PR 已修正 046 §2 的事实漂移（终态图 line 64 由 3 终态补全为 5 终态）并在 §2 加指向本 ADR 的权威指针；D 表与本 ADR D1–D8 对应，D2/D3/D6 的细节演进与新增 D9/D10 以本 ADR 为准。不存在两套真理源。
+
+---
+
+## 1. 上下文与问题
+
+`kernel/cellvocab.L3 = WorkflowEventual` 这个 enum 早已存在，但运行时长期"名实分离"——没有 `runtime/workflow`，所有跨 cell 编排场景靠业务手撕事件消费 + 手工补偿。004 capability-gap 缺口 2 与产品 roadmap V11-3 要求补齐一个**可复用的 L3 saga 编排引擎**：声明步骤序列、自动正向驱动、失败时反向补偿、跨进程单 leader 驱动、durable 状态可 replay。
+
+本 ADR 记录该引擎落地的 8 个关键决策（D1–D8）、拒绝的备选、终态模型、威胁矩阵与演进路径。每条决策附其 **enforcement 载体 + AI-robust 档位**，使决策可机器追溯到守卫，而非纯文字约定。
+
+---
+
+## 2. 决策 D1–D8
+
+| # | 决策 | enforcement 载体 | AI-robust 档位 |
+|---|------|-----------------|---------------|
+| D1 | **编程式优先**：Step 是 Go func（`Run`/`Compensate`），声明式 YAML DSL 留 v1.2+。业务编排不可避免读外部 state、调多 ports，声明式覆盖率低且 YAML 反成新约束源 | 无机器守卫（设计取向）；contract `kind: saga` 只声明步骤元数据，行为在 Go | **Soft / 文档约定**（刻意——这是取向不是不变式） |
+| D2 | **state journal = append-only**：每个状态变化一条 `journal.Event`，instance/step 状态是事件折叠的投影，非独立可变行。replay / forensic / time-travel 自然得到。journal 接口按消费者能力**窄接口拆分**（见 §3） | `journal.Journal`/`JournalCore`/`Enqueuer`/`Reader`/`ProducerReader`/`Heartbeater` 接口分层 + `SAGA-JOURNAL-HOLDER-SEAL-01`（仅 `runtime/saga.Coordinator` 可持有 `JournalCore`） | **Medium**（archtest 字段类型解析；Hard 路径 = sealed construction，gh **#982**；业务 cell 持 `JournalCore` 未机器拦截 = gh **#1415**） |
+| D3 | **每 saga instance 单 leader**：distlock key 颗粒到 instance；无 leader 不驱动。leader 经 `runtime/distlock` 复用，含 per-lock `Orphan()` 优雅交接（graceful shutdown/handoff，bounded-TTL takeover） | `SAGA-DRIVE-BEHIND-LEADER-GATE-01`（`driveOne` 仅在 `tickOnce`/`acquireLead` 门控下调用）；`distlock.Lock.Orphan()` | **Medium**（AST selector + 控制依赖门控；Hard 路径 = typed gate token 穿入 `driveOne` 签名，gh **#1110**） |
+| D4 | **Step dispatch 与 journal append 共享事务边界**，步骤**不在持有 DB 事务时执行**（避免长事务持锁）。与 L2 outbox-fact 模型同源 | `SAGA-STEP-RUN-OUTSIDE-TX-01`（`StepFunc` 调用只在 `safeRun`；`safeRun` 禁出现在 `RunInTx` closure 内） | A1 **Hard**（typed callsite 唯一性 + body gate）/ A2 **Medium**（closure AST scan；helper 传递链 gh **#980**） |
+| D5 | **Compensate 必须幂等 + 纯反向**：不读外部 state、不持事务层。dtm/Temporal 实战经验：Compensate 带分支 = bug 温床 | `SAGA-STEP-COMPENSATE-PURE-01`（`CompensateFunc` 赋值槽函数体禁调 `outbox.Writer/Emitter`、`persistence.TxRunner`、`*sql.Tx`、`pgx.Tx`） | **Hard**（类型识别赋值槽 + `types.Implements` 识别禁用 receiver；import alias 无效） |
+| D6 | **三层 timeout**：`Step.Timeout`（单步执行）/ `SagaDefinition.Timeout`（总）/ `Heartbeat`（长步续租）。复用 `kernel/command` 三层 timeout 模板。心跳由 `runtime/saga/executor` 的 per-step goroutine 独立维护，Coordinator **不持集中式心跳循环** | `SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01`（`Coordinator.journal` 收窄为无 `Heartbeat` 方法的 `JournalCore`）+ `SAGA-EXECUTOR-RAND-INJECTED-01`（jitter 源可注入） | **Hard 上游**（`JournalCore` 无 Heartbeat，集中循环 compile 不可表达）+ **Medium 下游**（callsite 残留扫描） |
+| D7 | **L3 cell 必须声明 saga contractUsage**：`role: orchestrate` ⟹ `cell.yaml consistencyLevel: L3`（**单向**蕴含，L3 ≠ saga，详见 §5） | governance rule `SAGA-CELL-LEVEL-L3-DECLARE-01`（`gocell validate` PhaseBase CI gate） | **Medium**（governance rule） |
+| D8 | **AfterCommit hook 仅 transient 副作用**：cache invalidation / metric / log / WS broadcast / saga dispatcher kick。allow stateful 必复活 outbox 想消灭的反模式 | `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01`（PR-00 落地，funnel 白名单） | **Hard**（archtest funnel）；语义边界中非 archtest 覆盖部分 = **Soft / 文档约定** |
+
+**追加决策（046 §2 凝固后落地，本 ADR 首次正式记录）：**
+
+| # | 决策 | enforcement | 档位 |
+|---|------|-------------|------|
+| D9 | **`StatusCompensationFailed` 独立终态**（#1210）：补偿阶段本身失败（≥1 个 `CompensateFunc` 返回非 nil）落入第 8 态，与 `StatusFailed`（前向失败无回滚）结构区分，运维只读终态即可辨根因。**废弃** 早期"dead-letter saga 表"方案 | `SAGA-STATUS-FANOUT-COVERAGE-01`（新 status/eventkind 必须同步四载体：conformance 终态 / readyz 状态表 / alerting kind legend / `TerminalEventKind` 映射） | **Hard**（codegen funnel + golden + keyless literal 编译穷举） |
+| D10 | **构造器必填 interface 依赖 nil 守卫**：`NewCoordinator` / `NewExecutor` 的非 variadic interface 位置参数经 `validation.IsNilInterface` 守，`clock.Clock` 经 `clock.MustHaveClock` | `SAGA-CONSTRUCTOR-NIL-GUARD-01` | **Medium**（非 funnel 单轴；Hard 路径 = `gocell:"required"` tag funnel，gh **#1317**） |
+
+---
+
+## 3. journal 窄接口分层（D2 细化）
+
+`kernel/saga/journal` 按消费者**最小能力**拆分接口，配合 `SAGA-JOURNAL-HOLDER-SEAL-01` 的"单一许可持有者"约束：
+
+| 接口 | 能力 | 许可持有者 |
+|------|------|-----------|
+| `JournalCore` | 全协调面：`Enqueue` / `Append` / `Load` / `ClaimPending` / `MarkTerminal` / `RepoReady`（无 `Heartbeat`） | **仅** `runtime/saga.Coordinator` |
+| `Heartbeater` | `Heartbeat`（lease 续租，#1209 拆出） | `runtime/saga/executor` per-step goroutine（声明自己同构的 `Heartbeater`，不 import kernel journal） |
+| `Journal` | `JournalCore` + `Heartbeater`（PG / mem 实现满足全集） | 实现侧 |
+| `Enqueuer` | 仅 `Enqueue` | 业务 producer（如下单 HTTP slice） |
+| `Reader` | 仅 `Load` | 状态查询 slice |
+| `ProducerReader` | `Enqueuer` + `Reader` | 既要登记又要读的业务 cell（结构上无法驱动 saga） |
+
+> **已知盲区**：`SAGA-JOURNAL-HOLDER-SEAL-01` 当前只扫 `runtime/saga`；业务 cell（`cells/`、`examples/`）持有 `JournalCore` 尚未机器拒绝，gh **#1415** 追踪。
+
+---
+
+## 4. 终态模型（D9 扇出真值，机器守卫 `SAGA-STATUS-FANOUT-COVERAGE-01`）
+
+`saga.Status`（`kernel/saga/status.go`，iota+1，零值非法）8 个值，其中 5 个终态：
+
+| Status | 值 | 阶段 | 终态 |
+|--------|----|------|------|
+| `Pending` | 1 | 未启动 | 否 |
+| `Running` | 2 | 正向执行 | 否 |
+| `Compensating` | 3 | 反向补偿中 | 否 |
+| `Succeeded` | 4 | 全部步骤提交 | ✅ |
+| `Failed` | 5 | 前向失败，未进补偿 | ✅ |
+| `Compensated` | 6 | 回滚干净完成 | ✅ |
+| `Expired` | 7 | 总超时 | ✅ |
+| `CompensationFailed` | 8 | 回滚本身遇步骤失败（仅从 `Compensating` 可达） | ✅ |
+
+`journal.EventKind`（`kernel/saga/journal/event.go`）11 个，终态事件经 `TerminalEventKind` 1:1 映射（`MarkTerminal` 专属写）。**状态表/kind legend 的权威渲染**活在 `docs/ops/readyz.md` §Saga（`saga-status-table` 生成区）与 `docs/ops/alerting-rules.md` §Saga（`saga-event-kind-legend` 生成区）——均由 `gocell generate saga-coverage` 单源生成，**禁手改**。
+
+---
+
+## 5. L3 ≠ Saga（单向蕴含澄清）
+
+D7 是**单向**：用 saga 编排 ⟹ L3；但 L3 不等价于 saga。`accesscore` / `configcore` / `examples/todoorder/ordercell` 是 L3 查询投影 / CQRS，**不用** saga 引擎。`SAGA-CELL-LEVEL-L3-DECLARE-01` 只在 cell 存在 `kind: saga` contractUsage 时触发，不误伤投影型 L3 cell。详见 `.claude/rules/gocell/saga.md` §"L3 与 Saga 的关键澄清"。
+
+---
+
+## 6. 拒绝的备选
+
+| 备选 | 拒绝理由 | 对应决策 |
+|------|---------|---------|
+| YAML DSL 第一版 | 业务编排读外部 state，DSL 覆盖率低，反成新约束源 | D1 |
+| mutable instance row | 与 outbox/audit hash chain 不一致，丢 replay/forensic | D2 |
+| 无 leader / 分片路由 | 多进程同驱一 instance 复杂化 lease fencing | D3 |
+| in-proc 同步直调 Step.Run | 破坏与 L2 outbox-fact 一致性 + 事务安全 | D4 |
+| 复杂分支 Compensate | dtm/Temporal 实证 = bug 温床 | D5 |
+| 单层 Step timeout | 长步无续租机制 | D6 |
+| 集中式心跳循环（Coordinator 持有） | 单点心跳 = 失败放大；per-step goroutine 隔离更稳 | D6 |
+| **dead-letter saga 表** | 已被 `StatusCompensationFailed` 独立终态取代——终态值本身承载根因，无需第二张表 | D9 |
+
+---
+
+## 7. 威胁矩阵
+
+| 威胁 | 当前补偿 | 覆盖 | 遗留 |
+|------|---------|------|------|
+| lease 失效 / leader 假死 | per-instance lease CAS + `Heartbeat` 续租 + `ClaimPending` 接管过期 lease；`gocell_saga_heartbeat_failed_total{reason="stale_lease"}` 可观测 | ✅ | — |
+| 旧 leader 复活继续驱动 | lease fencing（旧 lease 的 `Append`/`MarkTerminal` 必 `ErrSagaStaleLease`）+ `SAGA-DRIVE-BEHIND-LEADER-GATE-01` | ✅ | gate token 仍 AST 门控（Hard 路径 gh #1110） |
+| Compensate 读外部 state / 持事务 | `SAGA-STEP-COMPENSATE-PURE-01` Hard | ✅ | — |
+| 补偿本身失败 | `StatusCompensationFailed` 终态 + `KindStepCompensationFailed`/`KindSagaCompensationFailed`；运维经 `saga_events` 人工介入（runbook `docs/ops/saga-runbook.md`） | ⚠️ | 无自动二级补偿（刻意）——人工 runbook 兜底；自动重试入口未做 |
+| step 在持锁事务内长执行 | `SAGA-STEP-RUN-OUTSIDE-TX-01` A1 Hard | ✅ | A2 closure 传递链 Medium（gh #980） |
+| journal 无界增长 | `Event.MaxPayloadBytes` 64KiB cap；append-only 增长需归档 | ⚠️ | 归档/replay 截断 = W10 独立 wave，未做 |
+| Coordinator 无 leader 误并发 | `WithLeaderElect` option 注入 distlock；缺省 unsafe 模式 `Start()` 打 `UnsafeModeLabel` 警告 | ⚠️ | 生产装配必须显式注入 leader；缺注入只告警不强制 |
+| coordinator readiness 不可观测 | `ProbeCoordinatorReady` (`saga_coordinator_ready`) 已声明 | ❌ | **未 wired**——coordinator 尚非一等 Cell，cell-side `RegisterReadiness` 待 saga-as-cell 迁移（gh **#978**） |
+
+> ⚠️/❌ 行的遗留项均有 gh issue 跟踪或属显式 out-of-scope（W10 / 人工 runbook）；无 silent 缺口。
+
+---
+
+## 8. 演进路径
+
+| 方向 | 触发条件 / 追踪 |
+|------|----------------|
+| saga-as-cell 迁移（coordinator 成一等 Cell + `saga_coordinator_ready` wiring） | gh **#978** |
+| 业务 cell 持 `JournalCore` 机器拒绝 | gh **#1415** |
+| `JournalCore` sealed construction（D2 上游 Hard 化） | gh **#982** |
+| `driveOne` typed gate token（D3 下游 Hard 化） | gh **#1110** |
+| `safeRun` helper 传递链覆盖（D4 A2 Hard 化） | gh **#980** |
+| saga 构造器接入 `gocell:"required"` funnel（D10 Hard 化） | gh **#1317** |
+| journal conformance codegen golden 枚举（实现自动入列 Hard 化） | gh **#1003** |
+| 声明式 Saga DSL（D1 v2） | 业务场景 ≥ 3 个相似 saga 后立项 |
+| 跨 cell child workflow / nested saga | v1.2+ ADR（outbox 触发新 saga 已覆盖，parent-child 引用 + 联合 compensate 待做） |
+| Activity / Workflow worker pool 分层 | step concurrency 出现明确瓶颈再做 |
+| Projection / Replay（从 `saga_events` replay 任意时点状态） | W10 独立 wave |
+
+---
+
+## 9. ref
+
+ref: docs/architecture/202605051600-adr-pg-outbox-fencing.md (in-repo) — adapted lease_id CAS fencing pattern
+ref: dtm-labs/dtm dtmsvr/storage saga_branch.go — saga branch state + CompensateFailed
+ref: temporalio/temporal service/history/workflow — workflow state machine
+ref: ThreeDotsLabs/watermill components — outbox-driven message dispatch

--- a/docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md
+++ b/docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md
@@ -28,7 +28,7 @@
 | D5 | **Compensate 必须幂等 + 纯反向**：不读外部 state、不持事务层。dtm/Temporal 实战经验：Compensate 带分支 = bug 温床 | `SAGA-STEP-COMPENSATE-PURE-01`（`CompensateFunc` 赋值槽函数体禁调 `outbox.Writer/Emitter`、`persistence.TxRunner`、`*sql.Tx`、`pgx.Tx`） | **Hard**（类型识别赋值槽 + `types.Implements` 识别禁用 receiver；import alias 无效） |
 | D6 | **三层 timeout**：`Step.Timeout`（单步执行）/ `SagaDefinition.Timeout`（总）/ `Heartbeat`（长步续租）。复用 `kernel/command` 三层 timeout 模板。心跳由 `runtime/saga/executor` 的 per-step goroutine 独立维护，Coordinator **不持集中式心跳循环** | `SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01`（`Coordinator.journal` 收窄为无 `Heartbeat` 方法的 `JournalCore`）+ `SAGA-EXECUTOR-RAND-INJECTED-01`（jitter 源可注入） | **Hard 上游**（`JournalCore` 无 Heartbeat，集中循环 compile 不可表达）+ **Medium 下游**（callsite 残留扫描） |
 | D7 | **L3 cell 必须声明 saga contractUsage**：`role: orchestrate` ⟹ `cell.yaml consistencyLevel: L3`（**单向**蕴含，L3 ≠ saga，详见 §5） | governance rule `SAGA-CELL-LEVEL-L3-DECLARE-01`（`gocell validate` PhaseBase CI gate） | **Medium**（governance rule） |
-| D8 | **AfterCommit hook 仅 transient 副作用**：cache invalidation / metric / log / WS broadcast / saga dispatcher kick。allow stateful 必复活 outbox 想消灭的反模式 | `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01`（PR-00 落地，funnel 白名单） | **Hard**（archtest funnel）；语义边界中非 archtest 覆盖部分 = **Soft / 文档约定** |
+| D8 | **AfterCommit hook 仅 transient 副作用**：cache invalidation / metric / log / WS broadcast / saga dispatcher kick。allow stateful 必复活 outbox 想消灭的反模式 | `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01`（PR-00 落地，funnel 白名单） | A1 **Hard**（callee=RegisterAfterCommit + arg=FuncLit 形态唯一）/ A2 **Medium**（closure body 禁调持久化接口，one-level helper 启发，深层链未覆盖）/ A3 **Hard 下游**（callsite allowlist）+ **Medium 上游**（五 runner 跨包，无 type-seal） |
 
 **追加决策（046 §2 凝固后落地，本 ADR 首次正式记录）：**
 
@@ -57,6 +57,8 @@
 ---
 
 ## 4. 终态模型（D9 扇出真值，机器守卫 `SAGA-STATUS-FANOUT-COVERAGE-01`）
+
+> 下表是决策快照（便于 ADR 自包含阅读）。**权威渲染**在 `docs/ops/readyz.md` §Saga 与 `alerting-rules.md` §Saga 的生成区（受 fanout archtest 守）。本表**不在**生成区、不受 `SAGA-STATUS-FANOUT-COVERAGE-01` 自动守护——新增 status/eventkind 时需随 §8 演进手工跟随本表。
 
 `saga.Status`（`kernel/saga/status.go`，iota+1，零值非法）8 个值，其中 5 个终态：
 
@@ -106,10 +108,10 @@ D7 是**单向**：用 saga 编排 ⟹ L3；但 L3 不等价于 saga。`accessco
 | 补偿本身失败 | `StatusCompensationFailed` 终态 + `KindStepCompensationFailed`/`KindSagaCompensationFailed`；运维经 `saga_events` 人工介入（runbook `docs/ops/saga-runbook.md`） | ⚠️ | 无自动二级补偿（刻意）——人工 runbook 兜底；自动重试入口未做 |
 | step 在持锁事务内长执行 | `SAGA-STEP-RUN-OUTSIDE-TX-01` A1 Hard | ✅ | A2 closure 传递链 Medium（gh #980） |
 | journal 无界增长 | `Event.MaxPayloadBytes` 64KiB cap；append-only 增长需归档 | ⚠️ | 归档/replay 截断 = W10 独立 wave，未做 |
-| Coordinator 无 leader 误并发 | `WithLeaderElect` option 注入 distlock；缺省 unsafe 模式 `Start()` 打 `UnsafeModeLabel` 警告 | ⚠️ | 生产装配必须显式注入 leader；缺注入只告警不强制 |
+| Coordinator 无 leader 误并发 | `WithLeaderElect` option 注入 distlock；缺省 unsafe 模式 `Start()` 打 `UnsafeModeLabel` 警告 | ⚠️ | 刻意设计取舍（非待修缺陷，故无 issue）：unsafe 模式供单进程/开发；生产装配契约 = 必须经 `WithLeaderElect` 注入 leader |
 | coordinator readiness 不可观测 | `ProbeCoordinatorReady` (`saga_coordinator_ready`) 已声明 | ❌ | **未 wired**——coordinator 尚非一等 Cell，cell-side `RegisterReadiness` 待 saga-as-cell 迁移（gh **#978**） |
 
-> ⚠️/❌ 行的遗留项均有 gh issue 跟踪或属显式 out-of-scope（W10 / 人工 runbook）；无 silent 缺口。
+> ⚠️/❌ 行的遗留项均有 gh issue 跟踪、属显式 out-of-scope（W10 / 人工 runbook），或为刻意设计取舍（unsafe-mode leader）；无 silent 缺口。
 
 ---
 

--- a/docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md
+++ b/docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md
@@ -13,7 +13,7 @@
 
 `kernel/cellvocab.L3 = WorkflowEventual` 这个 enum 早已存在，但运行时长期"名实分离"——没有 `runtime/workflow`，所有跨 cell 编排场景靠业务手撕事件消费 + 手工补偿。004 capability-gap 缺口 2 与产品 roadmap V11-3 要求补齐一个**可复用的 L3 saga 编排引擎**：声明步骤序列、自动正向驱动、失败时反向补偿、跨进程单 leader 驱动、durable 状态可 replay。
 
-本 ADR 记录该引擎落地的 8 个关键决策（D1–D8）、拒绝的备选、终态模型、威胁矩阵与演进路径。每条决策附其 **enforcement 载体 + AI-robust 档位**，使决策可机器追溯到守卫，而非纯文字约定。
+本 ADR 记录该引擎落地的 10 个关键决策（D1–D8 核心 + D9/D10 为 046 §2 凝固后追加）、拒绝的备选、终态模型、威胁矩阵与演进路径。每条决策附其 **enforcement 载体 + AI-robust 档位**，使决策可机器追溯到守卫，而非纯文字约定。
 
 ---
 

--- a/docs/design/capability-inventory.md
+++ b/docs/design/capability-inventory.md
@@ -216,7 +216,7 @@
 
 ## 5. Cells 层（3 platform Cells, 22 platform Slices）
 
-### 5.1 accesscore (L2, core)
+### 5.1 accesscore (L3, core)
 | Slice | 功能 | 端点 |
 |-------|------|------|
 | sessionlogin | 密码登录 + JWT 签发 | POST /api/v1/access/sessions/login |
@@ -234,7 +234,7 @@ Domain: User (PasswordHash/Status/CreatedAt) + Session (TokenPair/ExpiresAt/Prev
 Ports: UserRepository + SessionRepository + RoleRepository
 Adapters: internal/mem (in-memory)
 
-### 5.2 auditcore (L3, core)
+### 5.2 auditcore (L2, core)
 | Slice | 功能 |
 |-------|------|
 | auditappendconfig | event.config.entry-upserted.v1 → event.audit.appended.v1（hash chain 追加） |
@@ -244,10 +244,10 @@ Adapters: internal/mem (in-memory)
 | auditquery | GET /api/v1/audit/entries + time.Parse 400 校验 + 出站 redaction |
 
 Domain: AuditEntry (PrevHash/Hash/Payload)，HMAC-SHA256 hash chain
-Ports: `runtime/audit/ledger.Store`（Append/Tail + RepoReady → `audit_ledger_ready` probe）
+Ports: `runtime/audit/ledger.Store`（Append/Tail + RepoReady → `auditcore_repo_ready` probe）
 Adapters: internal/mem + PG-backed ledger store（`audit_entries` JSONB）
 
-### 5.3 configcore (L2, core)
+### 5.3 configcore (L3, core)
 | Slice | 功能 |
 |-------|------|
 | configread | GET /api/v1/config/{key} + GET /api/v1/config/ (public, admin-gated) |

--- a/docs/design/capability-inventory.md
+++ b/docs/design/capability-inventory.md
@@ -1,6 +1,6 @@
 # GoCell 完整能力清单
 
-> 更新日期: 2026-04-24 | A13 文档事实源收口后
+> 更新日期: 2026-06-02 | A13 文档事实源收口后（W6 saga 章节补入）
 
 ---
 
@@ -21,7 +21,7 @@
 
 ---
 
-## 2. Kernel 层（11 包）
+## 2. Kernel 层（12 包）
 
 ### 2.1 cell — Cell/Slice/Contract 核心模型
 - `Cell` interface — ID/Type/ConsistencyLevel/Init/Start/Stop/Health/Ready

--- a/docs/design/capability-inventory.md
+++ b/docs/design/capability-inventory.md
@@ -8,8 +8,8 @@
 
 | 层 | 模块数 | 状态 | 说明 |
 |----|--------|------|------|
-| **kernel/** | 11 包 | 全部 IMPL | cell/assembly/metadata/governance/outbox/idempotency/journey/registry/scaffold/slice + schemas |
-| **runtime/** | 11 子包 | 全部 IMPL | auth/bootstrap/config/eventbus/http×3/observability×3/shutdown/worker |
+| **kernel/** | 12 包 | 全部 IMPL | cell/assembly/metadata/governance/outbox/idempotency/journey/registry/scaffold/slice/saga + schemas |
+| **runtime/** | 12 子包 | 全部 IMPL | auth/bootstrap/config/eventbus/http×3/observability×3/shutdown/worker/saga |
 | **adapters/** | 6 包 | 全部 IMPL | postgres/redis/rabbitmq/oidc/s3/websocket |
 | **cells/** | 3 platform Cell, 22 platform slices | 全部 IMPL | accesscore(10s) / auditcore(5s) / configcore(7s) |
 | **cmd/** | 2 CLI | 全部 IMPL | gocell (validate/scaffold/generate/check/verify) + corebundle |
@@ -85,9 +85,15 @@
 - 7 个 schema（cell/slice/contract/assembly/journey/status-board/actors）
 - `//go:embed *.json` 内嵌
 
+### 2.12 saga — L3 Saga 状态机原语 + journal
+- `kernel/saga` — `Status`（8 态，iota+1 零值非法，5 终态）+ `Step{Run, Compensate, Timeout, Retries}` + `SagaDefinition` + `Instance` + `RetryPolicy`；状态机 `Transition` / `IsTerminal` 纯函数
+- `kernel/saga/journal` — append-only 事件日志接口（`EventKind` 11 种 + `Event` + `TerminalEventKind` 映射）；窄接口分层 `JournalCore`（Coordinator 持有）/ `Enqueuer` / `Reader` / `ProducerReader`（业务 cell 持有）/ `Heartbeater`
+- `MemJournal` — 进程内实现；PG 实现见 §4.1 `adapters/postgres/saga`
+- `sagajournaltest.RunConformanceSuite` — Journal 契约一致性套件，mem 与 PG 必须同时通过
+
 ---
 
-## 3. Runtime 层（11 子包）
+## 3. Runtime 层（12 子包）
 
 ### 3.1 auth — 认证授权
 - `JWTVerifier` — RS256 验证 + exp/iss/aud 检查
@@ -154,6 +160,13 @@
 - `MarshalEnvelope(Entry) ([]byte, error)` / `UnmarshalEnvelope(topic, raw) (Entry, error)` — outbox → broker 的标准 v1 wire envelope I/O（package-private `wireMessage` struct，跨包不可构造；替代 adapters/postgres + adapters/rabbitmq + runtime/eventbus 三处重复 struct，S28）
 - `outboxtest.RunStoreConformanceSuite` — Store 契约 18 子测，FakeStore 与 PGOutboxStore 必须同时通过
 
+### 3.14 saga — L3 Saga 编排运行时
+- `Coordinator` — saga 实例驱动器：`ClaimPending` 认领 → 正向 `Step.Run` → 失败反向 `Compensate`；持 `JournalCore`（无 Heartbeat，集中心跳 compile 不可表达）
+- leader-elect — 经 `runtime/distlock` 每 instance 单 leader（`WithLeaderElect` 注入；缺省 unsafe 模式打 `UnsafeModeLabel` 警告）；`distlock.Lock.Orphan()` 支持优雅交接
+- `executor` 子包 — per-step 重试（可注入 jitter 源）+ heartbeat goroutine（lease 续租）+ 三层 timeout
+- `ProbeCoordinatorReady`（`saga_coordinator_ready`）— 已声明，cell-side 注册待 saga-as-cell 迁移（#978）
+- 设计决策见 ADR `docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md`
+
 ---
 
 ## 4. Adapters 层（6 包）
@@ -165,6 +178,7 @@
 - `OutboxWriter` — 实现 outbox.Writer + fail-fast ERR_ADAPTER_NO_TX
 - `PGOutboxStore` — 实现 `runtime/outbox.Store`（FOR UPDATE SKIP LOCKED claim + 数据驱动 cleanup via OldestEligibleAt）。relay 调度循环搬到 `runtime/outbox.Relay`，本适配器只承担 SQL 边界
 - `RowScanner` — pgx Row/Rows 抽象（QueryBuilder 已迁至 `pkg/pgquery.Builder`）
+- `adapters/postgres/saga` — `journal.Journal` 的 PG 实现（`saga_instances` / `saga_events` 表 + lease_id CAS fencing）；与 `MemJournal` 共用 `sagajournaltest.RunConformanceSuite`
 - migrations/001_create_outbox_entries.sql
 
 ### 4.2 redis — Redis (go-redis/v9)

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -773,80 +773,13 @@ increase(gocell_saga_step_outcome_total{outcome="failed"}[5m])
 increase(gocell_saga_heartbeat_failed_total{reason="stale_lease"}[5m])
 ```
 
-### GoCellSagaCompensationFailed Runbook
-
-**症状**: `saga_instance_status_total{status="compensation_failed"} > 0` — 至少一个
-saga 实例的补偿阶段本身失败（`status=8` in PG，即 `StatusCompensationFailed`）。
-这与 `status=failed`（前向阶段失败，未进入补偿）是不同的终态；两者可通过终态值本身
-区分，无需读取事件日志。
-
-**诊断 SQL**:
-
-```sql
--- 列出近 1h 进入 CompensationFailed 的实例（status=8）
-SELECT id, definition_id, started_at, updated_at
-FROM saga_instances
-WHERE status = 8 AND updated_at > NOW() - INTERVAL '1 hour'
-ORDER BY updated_at DESC;
-
--- 查看特定实例的失败补偿步骤（kind=10 = KindStepCompensationFailed）
-SELECT instance_id, version, step_name, created_at
-FROM saga_events
-WHERE kind = 10 AND instance_id = '<instance_id>'
-ORDER BY version ASC;
-
--- 对比同实例的完整事件日志（kind 1-11，按 version 升序）
-SELECT version, kind, step_name, created_at
-FROM saga_events
-WHERE instance_id = '<instance_id>'
-ORDER BY version ASC;
-```
+### Saga event kind 速查
 
 <!-- gocell:generated:saga-event-kind-legend — DO NOT EDIT (regen: gocell generate saga-coverage) -->
 `kind` 速查：1=step_started，2=step_completed，3=step_failed，4=step_compensated，5=compensation_started，6=saga_succeeded，7=saga_failed，8=saga_compensated，9=saga_expired，10=step_compensation_failed，11=saga_compensation_failed。
 <!-- /gocell:generated:saga-event-kind-legend -->
 
-**决策树**:
-
-1. **失败步骤是幂等外部副作用**（如发 HTTP 请求、写远端系统）：
-   - 验证外部系统当前状态，确认副作用是否已生效。
-   - 若已生效，视为幂等成功——在 `saga_events` 手动插入一条 `kind=4`
-     (step_compensated) 审计记录，并用运维工具将实例状态置为 `status=6`
-     (compensated)。所有操作需携带 operator、ticket、instance_id 字段写入
-     audit log（见下方审计要求）。
-   - 若未生效，重新触发补偿动作后同上标记。
-
-2. **失败步骤是不可逆操作**（如已下发的物理动作、已消费的外部资源）：
-   - 评估业务影响范围，判断是否需要人工补偿（线下流程）。
-   - 将实例标记为已接受失败（保留 `status=8` 作为运维 audit trail），在
-     `saga_events` 插入一条业务注释行（`kind=11` 的 payload 写 `{"operator_note":"...","ticket":"..."}`）。
-   - 通知相关业务方走线下补偿流程。
-
-3. **失败步骤是基础设施故障**（DB 宕机、外部服务不可达）：
-   - 等待基础设施自愈（监控 `saga_coordinator_ready` 探针）。
-   - 基础设施恢复后，该 saga 实例已是终态（`status=8`），**不会自动重试**——
-     需运维人员将 `status` 回拨到 `3` (compensating) 后由 Coordinator 重新
-     认领驱动。此操作需谨慎评估幂等性，建议开独立 PR 引入重试入口（当前
-     tracking #1210）。
-
-**审计要求**:
-
-所有决策与处置动作必须在 audit log 中留存，最低字段集：
-
-```json
-{
-  "instance_id": "<id>",
-  "definition_id": "<def>",
-  "decision": "accepted_irreversible | re_triggered | awaiting_retry",
-  "operator": "<email>",
-  "ticket": "<jira/linear ticket>",
-  "timestamp": "<ISO8601>",
-  "notes": "<optional free text>"
-}
-```
-
-若系统已接入 `auditcore`，通过 `cells/auditcore/slices/auditwrite` 写入；
-否则直接写运维 audit log 系统，保存 ≥ 90 天。
+**诊断与处置 runbook**：补偿失败（CompensationFailed）/ lease 卡死 / journal 增长的完整诊断 SQL、决策树（幂等外部副作用 / 不可逆操作 / 基础设施故障三分支）与审计要求见 **`docs/ops/saga-runbook.md`**。本节只保留指标告警职责；上面的 `kind` 速查生成区供 runbook 诊断 SQL 交叉引用。
 
 ---
 

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -472,7 +472,7 @@ statuses:
   daemon fault.
 
 Ops diagnostics for `CompensationFailed` instances use the `saga_events` table
-(see `docs/ops/alerting-rules.md` §Saga runbook), not readyz.
+(see `docs/ops/saga-runbook.md` §场景 2), not readyz.
 
 ## Concurrent probe storms
 

--- a/docs/ops/saga-runbook.md
+++ b/docs/ops/saga-runbook.md
@@ -1,0 +1,137 @@
+# Saga 运维 Runbook
+
+L3 saga 编排引擎（`runtime/saga`）的故障诊断与处置手册。三个互补载体：
+
+- **本文件** — 故障场景的诊断 SQL、决策树、人工处置流程。
+- `docs/ops/alerting-rules.md` §Saga — 指标（`gocell_saga_*`）告警规则 + `kind` 速查生成区。
+- `docs/ops/readyz.md` §Saga probes — `saga_coordinator_ready` 探针语义 + status 状态表生成区。
+
+设计决策真值源：ADR `docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md`。
+
+> **Saga instance status / event kind 速查**：状态表见 `docs/ops/readyz.md` §Saga（`saga-status-table` 生成区），`kind` 数值映射见 `docs/ops/alerting-rules.md` §Saga（`saga-event-kind-legend` 生成区）。两处均由 `gocell generate saga-coverage` 单源生成，本 runbook 不复制以免漂移。
+
+---
+
+## 场景 1：lease 卡死 / stale leader（实例停滞）
+
+**症状**：某 saga instance 长时间停在 `Running` / `Compensating` 不推进；`gocell_saga_heartbeat_failed_total{reason="stale_lease"}` 持续增长。
+
+**根因**：saga 每 instance 单 leader 经 `runtime/distlock` 选举；lease 由 per-step heartbeat goroutine 续租。leader 进程崩溃 / 网络分区 / heartbeat 失败 → lease 不再续租。
+
+**诊断 SQL**：
+
+```sql
+-- 停滞实例：非终态但 updated_at 超过预期 lease 周期
+SELECT id, definition_id, status, lease_id, lease_expires_at, updated_at
+FROM saga_instances
+WHERE status IN (2, 3)            -- Running / Compensating
+  AND updated_at < NOW() - INTERVAL '5 minutes'
+ORDER BY updated_at ASC;
+```
+
+**处置**：
+
+1. **正常自愈路径（优先）**：lease TTL 过期后，任一存活 Coordinator 的 `ClaimPending` 会自动接管过期 lease 并继续驱动——**无需人工介入**。先确认是否有存活 Coordinator（检查 `saga_coordinator_ready` 探针 / leader 选举日志）。
+2. **graceful handoff**：滚动重启 / 缩容时，退出中的 Coordinator 应调用 `distlock.Lock.Orphan()` 主动释放 lease（停止续租，key 按其 TTL 自然过期），让新 leader 在 bounded-TTL 内接管，而非等满超时。这是 `Orphan()` 的设计用途（graceful shutdown/handoff，见 `runtime/distlock` godoc）。
+3. **无存活 Coordinator**：若集群无任何 Coordinator 在跑（全部崩溃），实例会停滞直到至少一个 Coordinator 恢复。恢复后经 `ClaimPending` 自动接管，无需手工改库。
+4. **leader 未注入（unsafe 模式）**：若 Coordinator 启动日志含 `UnsafeModeLabel` 警告，说明未经 `WithLeaderElect` 注入 distlock——生产装配 bug。修复装配，不要手工改库绕过。
+
+---
+
+## 场景 2：补偿失败（StatusCompensationFailed，status=8）
+
+**症状**：`saga_instance_status_total{status="compensation_failed"} > 0` — 至少一个 saga 实例的补偿阶段本身失败（`status=8` in PG，即 `StatusCompensationFailed`）。这与 `status=failed`（前向阶段失败，未进入补偿）是不同的终态；两者可通过终态值本身区分，无需读取事件日志。
+
+**诊断 SQL**：
+
+```sql
+-- 列出近 1h 进入 CompensationFailed 的实例（status=8）
+SELECT id, definition_id, started_at, updated_at
+FROM saga_instances
+WHERE status = 8 AND updated_at > NOW() - INTERVAL '1 hour'
+ORDER BY updated_at DESC;
+
+-- 查看特定实例的失败补偿步骤（kind=10 = KindStepCompensationFailed）
+SELECT instance_id, version, step_name, created_at
+FROM saga_events
+WHERE kind = 10 AND instance_id = '<instance_id>'
+ORDER BY version ASC;
+
+-- 对比同实例的完整事件日志（kind 1-11，按 version 升序）
+SELECT version, kind, step_name, created_at
+FROM saga_events
+WHERE instance_id = '<instance_id>'
+ORDER BY version ASC;
+```
+
+> `kind` 数值速查见 `docs/ops/alerting-rules.md` §Saga（`saga-event-kind-legend` 生成区，`kind=10` = `step_compensation_failed`，`kind=11` = `saga_compensation_failed`）。
+
+**决策树**：
+
+1. **失败步骤是幂等外部副作用**（如发 HTTP 请求、写远端系统）：
+   - 验证外部系统当前状态，确认副作用是否已生效。
+   - 若已生效，视为幂等成功——在 `saga_events` 手动插入一条 `kind=4`
+     (step_compensated) 审计记录，并用运维工具将实例状态置为 `status=6`
+     (compensated)。所有操作需携带 operator、ticket、instance_id 字段写入
+     audit log（见下方审计要求）。
+   - 若未生效，重新触发补偿动作后同上标记。
+
+2. **失败步骤是不可逆操作**（如已下发的物理动作、已消费的外部资源）：
+   - 评估业务影响范围，判断是否需要人工补偿（线下流程）。
+   - 将实例标记为已接受失败（保留 `status=8` 作为运维 audit trail），在
+     `saga_events` 插入一条业务注释行（`kind=11` 的 payload 写 `{"operator_note":"...","ticket":"..."}`）。
+   - 通知相关业务方走线下补偿流程。
+
+3. **失败步骤是基础设施故障**（DB 宕机、外部服务不可达）：
+   - 等待基础设施自愈（监控 `saga_coordinator_ready` 探针）。
+   - 基础设施恢复后，该 saga 实例已是终态（`status=8`），**不会自动重试**——
+     需运维人员将 `status` 回拨到 `3` (compensating) 后由 Coordinator 重新
+     认领驱动。此操作需谨慎评估幂等性，建议开独立 PR 引入重试入口（当前
+     tracking #1210）。
+
+---
+
+## 场景 3：journal 增长失控
+
+**症状**：`saga_events` / `saga_instances` 表体积持续增长，无界。
+
+**根因**：journal 是 append-only（D2）——每个状态变化一行，刻意不就地更新。终态实例的事件历史保留用于 replay / forensic。
+
+**诊断 SQL**：
+
+```sql
+-- 终态实例占比（可归档候选）
+SELECT status, count(*) FROM saga_instances GROUP BY status ORDER BY status;
+
+-- 事件表增长热点（按 definition 聚合）
+SELECT definition_id, count(*) AS events
+FROM saga_events e JOIN saga_instances i ON e.instance_id = i.id
+GROUP BY definition_id ORDER BY events DESC;
+```
+
+**处置**：
+
+- 单事件已有 `Event.MaxPayloadBytes`（64 KiB）上限，单行不会无界。
+- 整表归档 / 截断是 **W10 Projection / Replay**（从 `saga_events` replay 任意时点状态）的范畴，独立 wave，当前未实现——在它落地前不要手工 `DELETE` 终态实例的事件（会破坏 replay/forensic 能力）。
+- 短期容量压力：扩 PG 存储 / 调整 retention 策略，不删 saga_events。
+
+---
+
+## 审计要求
+
+场景 2 / 场景 3 的所有人工决策与处置动作必须在 audit log 中留存，最低字段集：
+
+```json
+{
+  "instance_id": "<id>",
+  "definition_id": "<def>",
+  "decision": "accepted_irreversible | re_triggered | awaiting_retry",
+  "operator": "<email>",
+  "ticket": "<jira/linear ticket>",
+  "timestamp": "<ISO8601>",
+  "notes": "<optional free text>"
+}
+```
+
+若系统已接入 `auditcore`，通过 `cells/auditcore/slices/auditwrite` 写入；
+否则直接写运维 audit log 系统，保存 ≥ 90 天。

--- a/docs/ops/saga-runbook.md
+++ b/docs/ops/saga-runbook.md
@@ -40,7 +40,9 @@ ORDER BY updated_at ASC;
 
 ## 场景 2：补偿失败（StatusCompensationFailed，status=8）
 
-**症状**：`saga_instance_status_total{status="compensation_failed"} > 0` — 至少一个 saga 实例的补偿阶段本身失败（`status=8` in PG，即 `StatusCompensationFailed`）。这与 `status=failed`（前向阶段失败，未进入补偿）是不同的终态；两者可通过终态值本身区分，无需读取事件日志。
+**症状**：`saga_instances` 表中出现 `status=8`（`StatusCompensationFailed`）的行 —— 至少一个 saga 实例的补偿阶段本身失败（≥1 个 `CompensateFunc` 返回非 nil）。这与 `status=failed`（前向阶段失败，未进入补偿）是不同的终态；两者可通过终态值本身区分，无需读取事件日志。
+
+**检测**：无 instance-level status counter 指标；CompensationFailed 是终态，经下方诊断 SQL 直接查 `saga_instances`，或在前向 step 失败率告警（`gocell_saga_step_outcome_total{outcome="failed"}`，见 `docs/ops/alerting-rules.md` §Saga）触发后下钻确认是否进入补偿失败终态。
 
 **诊断 SQL**：
 
@@ -66,7 +68,7 @@ ORDER BY version ASC;
 
 > `kind` 数值速查见 `docs/ops/alerting-rules.md` §Saga（`saga-event-kind-legend` 生成区，`kind=10` = `step_compensation_failed`，`kind=11` = `saga_compensation_failed`）。
 
-> **⚠️ 手工改库前提（所有分支通用）**：下列处置涉及直接写 `saga_instances` / `saga_events`，绕过 `MarkTerminal` 的 lease fencing CAS。执行前**必须**：(1) 确认无 Coordinator 仍在驱动该 instance——lease 已过期或经 `Orphan()` 主动释放（否则 `ClaimPending` 会与你的手工写产生竞争）；(2) 在维护窗口内操作；(3) **不要手工 INSERT 终态 kind**（`kind` ∈ {6,7,8,9,11}）——终态事件只能由 `MarkTerminal` 原子写入并翻转 status 投影，手插会使 event log 折叠结果与 `saga_instances.status` 不一致，破坏 append-only journal 不变式。处置决策优先写 audit log，而非改 `saga_events`。
+> **⚠️ 手工改库前提（所有分支通用）**：下列处置涉及直接写 `saga_instances` / `saga_events`，绕过 `MarkTerminal` 的 lease fencing CAS。执行前**必须**：(1) 确认无 Coordinator 仍在驱动该 instance——lease 已过期或经 `Orphan()` 主动释放（否则 `ClaimPending` 会与你的手工写产生竞争）；验证 lease 状态用场景 1 的诊断 SQL（查 `lease_id` / `lease_expires_at`）；(2) 在维护窗口内操作；(3) **不要手工 INSERT 终态 kind**（`kind` ∈ {6,7,8,9,11}）——终态事件只能由 `MarkTerminal` 原子写入并翻转 status 投影，手插会使 event log 折叠结果与 `saga_instances.status` 不一致，破坏 append-only journal 不变式。处置决策优先写 audit log，而非改 `saga_events`。
 
 **决策树**：
 
@@ -116,6 +118,7 @@ GROUP BY definition_id ORDER BY events DESC;
 - 单事件已有 `Event.MaxPayloadBytes`（64 KiB）上限，单行不会无界。
 - 整表归档 / 截断是 **W10 Projection / Replay**（从 `saga_events` replay 任意时点状态）的范畴，独立 wave，当前未实现——在它落地前不要手工 `DELETE` 终态实例的事件（会破坏 replay/forensic 能力）。
 - 短期容量压力：扩 PG 存储 / 调整 retention 策略，不删 saga_events。
+- **告警引导**：无专属增长指标；用 PG 表体积监控（`pg_total_relation_size('saga_events')`）设容量阈值告警，或监控 `saga_instances` 中长期非终态行数（`status IN (1,2,3)` 且 `updated_at` 老化）作为驱动停滞的间接信号。
 
 ---
 

--- a/docs/ops/saga-runbook.md
+++ b/docs/ops/saga-runbook.md
@@ -66,28 +66,30 @@ ORDER BY version ASC;
 
 > `kind` 数值速查见 `docs/ops/alerting-rules.md` §Saga（`saga-event-kind-legend` 生成区，`kind=10` = `step_compensation_failed`，`kind=11` = `saga_compensation_failed`）。
 
+> **⚠️ 手工改库前提（所有分支通用）**：下列处置涉及直接写 `saga_instances` / `saga_events`，绕过 `MarkTerminal` 的 lease fencing CAS。执行前**必须**：(1) 确认无 Coordinator 仍在驱动该 instance——lease 已过期或经 `Orphan()` 主动释放（否则 `ClaimPending` 会与你的手工写产生竞争）；(2) 在维护窗口内操作；(3) **不要手工 INSERT 终态 kind**（`kind` ∈ {6,7,8,9,11}）——终态事件只能由 `MarkTerminal` 原子写入并翻转 status 投影，手插会使 event log 折叠结果与 `saga_instances.status` 不一致，破坏 append-only journal 不变式。处置决策优先写 audit log，而非改 `saga_events`。
+
 **决策树**：
 
 1. **失败步骤是幂等外部副作用**（如发 HTTP 请求、写远端系统）：
    - 验证外部系统当前状态，确认副作用是否已生效。
-   - 若已生效，视为幂等成功——在 `saga_events` 手动插入一条 `kind=4`
-     (step_compensated) 审计记录，并用运维工具将实例状态置为 `status=6`
-     (compensated)。所有操作需携带 operator、ticket、instance_id 字段写入
-     audit log（见下方审计要求）。
+   - 若已生效，视为幂等成功——处置决策（operator / ticket / instance_id）写
+     audit log（见下方审计要求）；`saga_events` 可补一条**非终态** `kind=4`
+     (step_compensated) 审计记录。status 由 8 改为 6 (compensated) 须经运维
+     工具走正常 journal 路径，不直接 UPDATE。
    - 若未生效，重新触发补偿动作后同上标记。
 
 2. **失败步骤是不可逆操作**（如已下发的物理动作、已消费的外部资源）：
    - 评估业务影响范围，判断是否需要人工补偿（线下流程）。
-   - 将实例标记为已接受失败（保留 `status=8` 作为运维 audit trail），在
-     `saga_events` 插入一条业务注释行（`kind=11` 的 payload 写 `{"operator_note":"...","ticket":"..."}`）。
+   - **保留 `status=8` 不动**（它已是合规终态，本身就是运维 audit trail）；
+     处置决策与 operator_note / ticket 写 audit log，**不**向 `saga_events`
+     插入终态 `kind=11`（见上方前提，终态 kind 仅 MarkTerminal 可写）。
    - 通知相关业务方走线下补偿流程。
 
 3. **失败步骤是基础设施故障**（DB 宕机、外部服务不可达）：
    - 等待基础设施自愈（监控 `saga_coordinator_ready` 探针）。
-   - 基础设施恢复后，该 saga 实例已是终态（`status=8`），**不会自动重试**——
-     需运维人员将 `status` 回拨到 `3` (compensating) 后由 Coordinator 重新
-     认领驱动。此操作需谨慎评估幂等性，建议开独立 PR 引入重试入口（当前
-     tracking #1210）。
+   - 基础设施恢复后，该 saga 实例已是终态（`status=8`），**不会自动重试**。
+     自动重试入口尚未实现（无专属 issue，需另开 backlog）；在它落地前，重新
+     驱动须经运维工具走正常 journal 路径，谨慎评估幂等性，不直接 UPDATE status。
 
 ---
 

--- a/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
+++ b/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
@@ -17,7 +17,7 @@
 - `kernel/saga/` —— 状态机原语（`Step{Run, Compensate, Timeout, Retries}` + `SagaDefinition` + `SagaInstance` + `Journal` 接口）
 - `kernel/persistence` 新增 `RunTxWithBestEffortAfterCommit` —— 004 W1 缺口 5（**Saga 引擎依赖**）
 - `runtime/saga/` —— Coordinator（state journal + leader-elect 通过 `runtime/distlock` + 步骤 dispatch 通过 `kernel/outbox`）
-- `adapters/postgres/saga/` —— `saga_instances` / `saga_steps` 表 + 迁移 + lease_id CAS fencing
+- `adapters/postgres/saga/` —— `saga_instances` / `saga_events` 表 + 迁移 + lease_id CAS fencing（计划期暂记为 `saga_steps`，落地为 append-only `saga_events`）
 - `contracts/saga/` schema + `tools/codegen` `kind: saga` 派生 typed `SagaDefinition`/`Step` 接口
 - governance rules + archtest（FMT/REF/TOPO `kind:saga` ↔ `consistencyLevel:L3` 约束 + Coordinator funnel + Compensate 纯函数 archtest）
 - example：`examples/orderfulfillment` 全链 saga journey
@@ -499,17 +499,17 @@ go run ./cmd/gocell validate  # 0 error
 ## 7. 进度跟踪表
 
 ```
-PR-00  AfterCommit hook          [ ]  worktrees/200-aftercommit-hook
-PR-01  kernel/saga skeleton      [ ]  worktrees/060-saga-kernel-skeleton
-PR-02  kernel/saga/journal       [ ]  worktrees/061-saga-journal
-PR-03  runtime/saga Coordinator  [ ]  worktrees/062-saga-coordinator
-PR-04  adapters/postgres/saga    [ ]  worktrees/063-saga-pg-journal
-PR-05  runtime/saga leader-elect [ ]  worktrees/064-saga-leader
-PR-06  runtime/saga/executor     [ ]  worktrees/065-saga-executor
-PR-07  contracts/saga + codegen  [ ]  worktrees/066-saga-contractgen
-PR-08  governance + archtest     [ ]  worktrees/067-saga-archtest
-PR-09  example orderfulfillment  [ ]  worktrees/068-saga-example
-PR-10  ADR + runbook + docs      [x]  worktrees/069-saga-docs  (PR 待填)
+PR-00  AfterCommit hook          [x]  已 merge 入 develop
+PR-01  kernel/saga skeleton      [x]  已 merge 入 develop
+PR-02  kernel/saga/journal       [x]  已 merge 入 develop
+PR-03  runtime/saga Coordinator  [x]  已 merge 入 develop
+PR-04  adapters/postgres/saga    [x]  已 merge 入 develop
+PR-05  runtime/saga leader-elect [x]  已 merge 入 develop
+PR-06  runtime/saga/executor     [x]  已 merge 入 develop
+PR-07  contracts/saga + codegen  [x]  已 merge 入 develop
+PR-08  governance + archtest     [x]  #1316 (#956)
+PR-09  example orderfulfillment  [x]  #1374 (#967)
+PR-10  ADR + runbook + docs      [x]  worktrees/069-saga-docs  #1433
 ```
 
 合并后回此处把 `[ ]` 改 `[x]`，注明 PR 号 + merge SHA。

--- a/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
+++ b/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
@@ -499,17 +499,17 @@ go run ./cmd/gocell validate  # 0 error
 ## 7. 进度跟踪表
 
 ```
-PR-00  AfterCommit hook          [x]  已 merge 入 develop
-PR-01  kernel/saga skeleton      [x]  已 merge 入 develop
-PR-02  kernel/saga/journal       [x]  已 merge 入 develop
-PR-03  runtime/saga Coordinator  [x]  已 merge 入 develop
-PR-04  adapters/postgres/saga    [x]  已 merge 入 develop
-PR-05  runtime/saga leader-elect [x]  已 merge 入 develop
-PR-06  runtime/saga/executor     [x]  已 merge 入 develop
-PR-07  contracts/saga + codegen  [x]  已 merge 入 develop
-PR-08  governance + archtest     [x]  #1316 (#956)
-PR-09  example orderfulfillment  [x]  #1374 (#967)
-PR-10  ADR + runbook + docs      [x]  worktrees/069-saga-docs  #1433
+PR-00  AfterCommit hook          [x]  #923
+PR-01  kernel/saga skeleton      [x]  #932
+PR-02  kernel/saga/journal       [x]  #952
+PR-03  runtime/saga Coordinator  [x]  #977
+PR-04  adapters/postgres/saga    [x]  #1004
+PR-05  runtime/saga leader-elect [x]  #1108
+PR-06  runtime/saga/executor     [x]  #1179
+PR-07  contracts/saga + codegen  [x]  #1283
+PR-08  governance + archtest     [x]  #1316
+PR-09  example orderfulfillment  [x]  #1374
+PR-10  ADR + runbook + docs      [x]  #1433
 ```
 
 合并后回此处把 `[ ]` 改 `[x]`，注明 PR 号 + merge SHA。

--- a/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
+++ b/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
@@ -48,6 +48,8 @@
 
 ## 2. 设计骨架（一句话总结）
 
+> **权威指针**：本节是计划期设计骨架快照。落地后的权威决策（D1–D10 + enforcement 档位 + 威胁矩阵 + 演进路径）见 ADR `docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md`；与下文冲突时以 ADR + 代码 godoc 为准。
+
 ```
 Saga Instance (PG/mem) ── lease_id CAS ──► Coordinator (leader-elect via distlock)
         │
@@ -61,8 +63,10 @@ Saga Instance (PG/mem) ── lease_id CAS ──► Coordinator (leader-elect v
         │              Step.Compensate(ctx, state)
         │
         ▼
-Journal.MarkSagaTerminal(Succeeded | Failed | Compensated)
+Journal.MarkSagaTerminal(Succeeded | Failed | Compensated | Expired | CompensationFailed)
 ```
+
+> 终态共 5 个（`saga.Status` 8 态中的终态子集）：`Succeeded` / `Failed`（前向失败无回滚）/ `Compensated`（回滚干净）/ `Expired`（总超时）/ `CompensationFailed`（回滚本身失败，#1210 新增）。早期"dead-letter saga 表"方案已被 `CompensationFailed` 独立终态取代。
 
 **关键决策**（每条决策都对应一个 ADR 段落）：
 
@@ -439,14 +443,14 @@ PR-10 ────────────────────────�
 | 2 计划 | 跳过（L1） |
 | 3 worktree | `worktrees/069-saga-docs` |
 | 4 TDD | n/a |
-| 5 实施 | (i) ADR `202605231400-adr-saga-l3-orchestration-engine.md`：决策 D1–D8 + 拒绝的备选 + 威胁矩阵；(ii) `docs/ops/saga-runbook.md`：故障排查（lease 卡死 / 补偿失败 / journal 满）；(iii) `CLAUDE.md` 加一节 "L3 Saga"；(iv) `docs/design/capability-inventory.md` 加 saga 一节；(v) `.claude/rules/gocell/saga.md` 终稿 |
+| 5 实施 | (i) ADR `202606021000-adr-saga-l3-orchestration-engine.md`（实际落地名；计划期钦定的 `202605231400-...` 因时间戳撞 `202605231400-002-required-dep...` 且不合 `yyyyMMddHHmm-编号-名` 格式而改名）：决策 D1–D10 + 拒绝的备选 + 威胁矩阵；(ii) `docs/ops/saga-runbook.md`：故障排查（lease 卡死 / 补偿失败 / journal 满）；(iii) `CLAUDE.md` 加一节 "L3 Saga"；(iv) `docs/design/capability-inventory.md` 加 saga 一节；(v) `.claude/rules/gocell/saga.md` 终稿 |
 | 6 PR | title: `docs(saga): ADR + ops runbook + CLAUDE.md + capability-inventory (W6 step 10/10)` |
 | 7 review | 1 reviewer |
 | 8 fix | Cx3：CLAUDE.md 加章节位置 |
 | 9 人工确认 | ADR 威胁矩阵覆盖 |
 
 **Files**：
-- `docs/architecture/202605231400-adr-saga-l3-orchestration-engine.md` +400
+- `docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md` +400
 - `docs/ops/saga-runbook.md` +200
 - `CLAUDE.md` +30
 - `docs/design/capability-inventory.md` +50
@@ -505,7 +509,7 @@ PR-06  runtime/saga/executor     [ ]  worktrees/065-saga-executor
 PR-07  contracts/saga + codegen  [ ]  worktrees/066-saga-contractgen
 PR-08  governance + archtest     [ ]  worktrees/067-saga-archtest
 PR-09  example orderfulfillment  [ ]  worktrees/068-saga-example
-PR-10  ADR + runbook + docs      [ ]  worktrees/069-saga-docs
+PR-10  ADR + runbook + docs      [x]  worktrees/069-saga-docs  (PR 待填)
 ```
 
 合并后回此处把 `[ ]` 改 `[x]`，注明 PR 号 + merge SHA。

--- a/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
+++ b/docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md
@@ -75,7 +75,7 @@ Journal.MarkSagaTerminal(Succeeded | Failed | Compensated | Expired | Compensati
 | D1 | **编程式（Go func Step）** 优先；声明式 DSL 留 v1.2+ | YAML DSL 第一版 | 业务编排不可避免读外部 state、调多个 ports；声明式覆盖率低，YAML 反而成新约束源 |
 | D2 | **state journal = append-only**（每个状态变化一行），instance/step 状态 = 投影 | mutable instance row | 与现有 outbox / audit hash chain 一致；replay / forensic / time-travel 自然得到 |
 | D3 | **每个 saga instance 单 leader**（distlock key = `saga:{definitionID}:{instanceID}`） | 无 leader / 分片路由 | 反应式编排里多个进程同时驱动同一 instance 会复杂化 lease fencing；现有 distlock 复用零成本 |
-| D4 | **Step dispatch 走 outbox**（payload 含 step 名 + input snapshot），不直接 in-proc 调 | 直接同步调用 Step.Run | 一致性：与 L2 outbox-fact 模型同源；transactional safety：journal append + outbox emit 共享同一 Tx |
+| D4 | **Step dispatch 走 outbox**（payload 含 step 名 + input snapshot），不直接 in-proc 调 〔计划期形态；实际 step 执行/事务边界以 ADR D4 + `SAGA-STEP-RUN-OUTSIDE-TX-01` 为准〕 | 直接同步调用 Step.Run | 一致性：与 L2 outbox-fact 模型同源；transactional safety：journal append + outbox emit 共享同一 Tx |
 | D5 | **Compensate 必须幂等 + 纯反向**（不读外部 state）| 复杂 Compensate（含分支） | dtm / Temporal 实战经验：Compensate 有分支 = bug 温床；archtest 静态拦 |
 | D6 | **三层 timeout**：`Step.Timeout`（执行）/`SagaDefinition.Timeout`（总）/`Heartbeat`（长 Step 续期） | 单层 Step timeout | 复用 `kernel/command` 三层 timeout 模板（已 production-proven） |
 | D7 | **L3 cell.yaml** 强制声明 `saga.*` contractUsage，governance rule 拦 | 让 L3 cell 隐式可用 | 与 `consistencyLevel` 名实对齐：L3 不持有 saga 声明 = governance error |


### PR DESCRIPTION
## Summary

Saga L3 实施计划（`docs/plans/202605230231-046-...`）的 **PR-10 文档收尾**。PR-00…PR-09 代码已全部 ship；本 PR 是纯文档 PR，把 saga 子系统的**设计决策 / 运维 / 能力清单 / 协作规则**四类文档与当前代码对齐，消除所有 404 占位与计划-代码漂移。

`Refs: #967 (PR-09 example), 046 plan PR-10`

## 交付物

| 文件 | 动作 |
|------|------|
| `docs/architecture/202606021000-adr-saga-l3-orchestration-engine.md` | **新建** — 决策 D1–D10（每条挂 enforcement 载体 + AI-robust 档位）+ 威胁矩阵 + 演进路径 |
| `docs/ops/saga-runbook.md` | **新建** — lease 卡死 / 补偿失败 / journal 增长三场景 |
| `CLAUDE.md` | L3 Saga 节（指针式，不复制规则） |
| `docs/design/capability-inventory.md` | kernel/saga + journal + runtime/saga + adapters/postgres/saga 条目 + 计数同步 |
| `.claude/rules/gocell/saga.md` | 替换「ADR 尚未创建(404)」占位为真实路径 |
| `docs/ops/alerting-rules.md` / `readyz.md` | runbook 搬迁 + 交叉引用改向 |
| `docs/plans/...046....md` §2/§7 | 修正终态图(3→5终态) + ADR 权威指针 + PR-10 勾选 |

## 关键决策（实施中的激进自审 + 用户裁定）

1. **ADR 改名**：计划钦定的 `202605231400-adr-saga-...` 撞已存在 `202605231400-002-required-dep...` 时间戳且不合 `yyyyMMddHHmm-编号-名` 格式 → 改合规新名 `202606021000-...`，同 PR 改 saga.md + 046 全部引用（不为省一次同步保留坏名）。
2. **漂移对账**：046 §2 凝固后落地的 4 处变更并入 ADR——`StatusCompensationFailed` 独立终态(#1210)、distlock `Orphan()`(#1116)、journal 窄接口拆分(#1209)、`saga_coordinator_ready` deferred(#978)；威胁矩阵逐行标 ✅/⚠️/❌ + 遗留 issue。
3. **runbook 单源**：发现 `alerting-rules.md` §Saga 已有 CompensationFailed runbook（readyz 已指向）。用户裁定**新建独立 `saga-runbook.md`** 统一三场景，alerting 保留告警职责 + 指过去，readyz 引用改向。
4. **生成区不动**：`sagacoveragegen` 生成区（saga-status-table / saga-event-kind-legend）硬绑 readyz.md / alerting-rules.md，移动它=codegen 改动超 L1 范围 → 原位保留，新 runbook 交叉引用。

## 诚实标注的 Soft 缺口（已开 backlog）

「文档内 in-repo 路径引用不得 404 / 指向已落地 ADR 的占位必须清零」目前无机器守卫，本 PR 用人工 grep（Soft）兜底。Hard 化路径 = 加 archtest/CI 扫 docs 内部链接。merge 后开 backlog 跟踪，不 silent carryover。

## Test plan

- [x] `SAGA-STATUS-FANOUT-COVERAGE-01` archtest PASS（生成区一致性，证明重组 alerting/readyz 未破坏生成区）
- [x] `gocell validate`：0 error（2 warning 是 journey status-board pre-existing，与本 PR 无关）
- [x] 全仓零残留：旧 404 占位 + 撞号旧 ADR 名 0 命中
- [x] 4 个生成区 marker 完整
- [x] 撞号旧 ADR `202605231400-002-*` 未被覆盖

ref: docs/architecture/202605051600-adr-pg-outbox-fencing.md (in-repo) — adapted CAS pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)