### PR TITLE
test(mqtt): consolidate duplicated closeBrokerSafely broker-close helper [#1315]

### DIFF
--- a/adapters/mqtt/brokerclose_test.go
+++ b/adapters/mqtt/brokerclose_test.go
@@ -32,9 +32,11 @@ import (
 //     deadlock is a known library bug, not a real-test-assertion failure, so
 //     failing here would trade a rare hang for a rare flaky FAIL.
 //
-// t may be nil when called from TestMain after m.Run() (e.g. the shared
-// broker stop path). In that case drain is skipped and slog.Warn is used
-// instead of t.Logf so the goroutine does not reference a finished test.
+// t may be nil: the shared-broker stop closure (initSharedInternalBroker)
+// captures CloseBrokerSafely(nil, srv) and is invoked from TestMain via
+// stopSharedInternalBroker after m.Run(). In that case drain is skipped and
+// slog.Warn is used instead of t.Logf so the goroutine does not reference a
+// finished test.
 func CloseBrokerSafely(t testing.TB, srv *mqttserver.Server) {
 	if t != nil {
 		t.Helper()
@@ -53,6 +55,7 @@ func CloseBrokerSafely(t testing.TB, srv *mqttserver.Server) {
 			case <-drainTimer.C:
 				break drainLoop
 			case <-drainTick.C:
+				// tick: re-check srv.Clients.Len() on the next iteration.
 			}
 		}
 		drainTimer.Stop()

--- a/adapters/mqtt/brokerclose_test.go
+++ b/adapters/mqtt/brokerclose_test.go
@@ -27,10 +27,10 @@ import (
 //  2. Timeout-guarded close: runs srv.Close() in a goroutine and selects on
 //     done vs testtime.D5s. If Close returns, we're done. If it exceeds the
 //     budget (the mochi Clients-lock deadlock) a diagnostic is logged and the
-//     helper returns so the test fails fast instead of hanging for ~10 min.
-//     The timeout path only logs (it does not fail the test): a teardown Close
-//     deadlock is a known library bug, not a real-test-assertion failure, so
-//     failing here would trade a rare hang for a rare flaky FAIL.
+//     helper returns promptly so teardown completes instead of hanging for
+//     ~10 min. The timeout path only logs (it does not fail the test): a
+//     teardown Close deadlock is a known library bug, not a real-test-assertion
+//     failure, so failing here would trade a rare hang for a rare flaky FAIL.
 //
 // t may be nil: the shared-broker stop closure (initSharedInternalBroker)
 // captures CloseBrokerSafely(nil, srv) and is invoked from TestMain via

--- a/adapters/mqtt/brokerclose_test.go
+++ b/adapters/mqtt/brokerclose_test.go
@@ -10,23 +10,32 @@ import (
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
-// closeBrokerSafely closes a mochi v2 broker with two defenses against the
-// mochi v2.7.9 Clients-lock deadlock:
+// CloseBrokerSafely is the single shared helper that closes a mochi v2 broker
+// across both the internal (package mqtt) and external (package mqtt_test) test
+// packages in this directory. It is exported only so the external test package
+// can reach it via mqtt.CloseBrokerSafely; it never appears in non-test builds.
 //
-//  1. Best-effort drain: when t is non-nil, polls srv.Clients.Len() == 0 for
-//     up to testtime.D2s so any in-flight client disconnects settle before
-//     Close is called. Drain is non-fatal; if the budget expires the guarded
-//     close proceeds regardless.
+// It applies two defenses against the mochi v2.7.9 Clients-lock deadlock
+// (issue #1315 — there is no fixed upstream release; v2.7.9 is the latest):
+//
+//  1. Best-effort drain (quiesce-before-Close): when t is non-nil, polls
+//     srv.Clients.Len() == 0 for up to testtime.D2s so any in-flight client
+//     disconnects settle before Close is called — this closes the deadlock
+//     window. Drain is non-fatal; if the budget expires the guarded close
+//     proceeds regardless.
 //
 //  2. Timeout-guarded close: runs srv.Close() in a goroutine and selects on
 //     done vs testtime.D5s. If Close returns, we're done. If it exceeds the
 //     budget (the mochi Clients-lock deadlock) a diagnostic is logged and the
 //     helper returns so the test fails fast instead of hanging for ~10 min.
+//     The timeout path only logs (it does not fail the test): a teardown Close
+//     deadlock is a known library bug, not a real-test-assertion failure, so
+//     failing here would trade a rare hang for a rare flaky FAIL.
 //
 // t may be nil when called from TestMain after m.Run() (e.g. the shared
 // broker stop path). In that case drain is skipped and slog.Warn is used
 // instead of t.Logf so the goroutine does not reference a finished test.
-func closeBrokerSafely(t testing.TB, srv *mqttserver.Server) {
+func CloseBrokerSafely(t testing.TB, srv *mqttserver.Server) {
 	if t != nil {
 		t.Helper()
 	}

--- a/adapters/mqtt/connection_publish_test.go
+++ b/adapters/mqtt/connection_publish_test.go
@@ -87,7 +87,7 @@ func initSharedInternalBroker(t *testing.T) {
 			return true
 		}, testtime.D2s, testtime.D10ms)
 
-		sharedInternalBrokerStop = func() { closeBrokerSafely(nil, srv) }
+		sharedInternalBrokerStop = func() { CloseBrokerSafely(nil, srv) }
 	})
 }
 

--- a/adapters/mqtt/connection_test.go
+++ b/adapters/mqtt/connection_test.go
@@ -63,7 +63,7 @@ func startEmbeddedBroker(t *testing.T, hook mqttserver.Hook, hookID string) (add
 	}, testtime.D2s, testtime.D10ms)
 
 	return addr, func() {
-		closeBrokerSafely(t, srv)
+		mqtt.CloseBrokerSafely(t, srv)
 	}
 }
 
@@ -352,9 +352,9 @@ func TestConnection_ReconnectMetric_Counted(t *testing.T) {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), testtime.D2s)
 		defer closeCancel()
 		require.NoError(t, conn.Close(closeCtx), "connection cleanup")
-		// closeBrokerSafely drains then guards srv.Close; the explicit
+		// mqtt.CloseBrokerSafely drains then guards srv.Close; the explicit
 		// testwait drain above is now subsumed by the helper's own drain.
-		closeBrokerSafely(t, srv)
+		mqtt.CloseBrokerSafely(t, srv)
 	}()
 
 	// Initial connection must not count as a reconnect.
@@ -427,45 +427,3 @@ func (f *fakeCollector) RecordReconnect(_ context.Context) { f.count.Add(1) }
 // RecordSubscribeFailure satisfies the ConnectionCollector interface (added by
 // PR-3 review fix F7). This fake only counts reconnects, so it is a no-op here.
 func (f *fakeCollector) RecordSubscribeFailure(_ context.Context, _ mqtt.SubscribeFailureReason) {}
-
-// closeBrokerSafely closes a mochi v2 broker with two defenses against the
-// mochi v2.7.9 Clients-lock deadlock:
-//
-//  1. Best-effort drain: polls srv.Clients.Len() == 0 for up to testtime.D2s
-//     so any in-flight client disconnects settle before Close is called.
-//     Drain is non-fatal; if the budget expires the guarded close proceeds.
-//
-//  2. Timeout-guarded close: runs srv.Close() in a goroutine and selects on
-//     done vs testtime.D5s. If Close returns, we're done. If it exceeds the
-//     budget (the mochi Clients-lock deadlock) a clear diagnostic is logged
-//     via t.Logf and the helper returns so the test fails fast instead of
-//     hanging for ~10 min.
-func closeBrokerSafely(t *testing.T, srv *mqttserver.Server) {
-	t.Helper()
-
-	// Defense 1: best-effort drain (non-fatal on timeout).
-	drainTimer := time.NewTimer(testtime.D2s)
-	drainTick := time.NewTicker(testtime.D10ms)
-drainLoop:
-	for srv.Clients.Len() > 0 {
-		select {
-		case <-drainTimer.C:
-			break drainLoop
-		case <-drainTick.C:
-		}
-	}
-	drainTimer.Stop()
-	drainTick.Stop()
-
-	// Defense 2: timeout-guarded close.
-	done := make(chan error, 1)
-	go func() { done <- srv.Close() }()
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Logf("mqtt-test: srv.Close() returned error: %v", err)
-		}
-	case <-time.After(testtime.D5s):
-		t.Logf("mqtt-test: srv.Close() exceeded %v — suspected mochi v2.7.9 Clients-lock deadlock; abandoning close", testtime.D5s)
-	}
-}

--- a/adapters/mqtt/connection_test.go
+++ b/adapters/mqtt/connection_test.go
@@ -352,8 +352,9 @@ func TestConnection_ReconnectMetric_Counted(t *testing.T) {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), testtime.D2s)
 		defer closeCancel()
 		require.NoError(t, conn.Close(closeCtx), "connection cleanup")
-		// mqtt.CloseBrokerSafely drains then guards srv.Close; the explicit
-		// testwait drain above is now subsumed by the helper's own drain.
+		// mqtt.CloseBrokerSafely's Defense 1 drains in-flight client
+		// disconnects before guarding srv.Close, so no separate pre-close
+		// drain is needed here.
 		mqtt.CloseBrokerSafely(t, srv)
 	}()
 

--- a/adapters/mqtt/publisher_test.go
+++ b/adapters/mqtt/publisher_test.go
@@ -663,7 +663,7 @@ func startBrokerWithHook(t *testing.T, h mqttserver.Hook) (addr string, stop fun
 		return true
 	}, testtime.D2s, testtime.D10ms)
 
-	return addr, func() { closeBrokerSafely(t, srv) }
+	return addr, func() { CloseBrokerSafely(t, srv) }
 }
 
 // rejectingPubAckHook returns a broker-rejection PUBACK reason code (>= 0x80)
@@ -773,7 +773,7 @@ func startBrokerWithNoSubscribersHook(t *testing.T) (addr string, stop func()) {
 		return true
 	}, testtime.D2s, testtime.D10ms)
 
-	return addr, func() { closeBrokerSafely(t, srv) }
+	return addr, func() { CloseBrokerSafely(t, srv) }
 }
 
 // TestPublisher_Publish_NoMatchingSubscribers_Success verifies that PUBACK 0x10


### PR DESCRIPTION
## Summary

`adapters/mqtt` had **two near-identical `closeBrokerSafely` helpers** — one in `package mqtt` (`brokerclose_test.go`) and a duplicate in `package mqtt_test` (`connection_test.go`) — both added by #1319. This consolidates them into a single exported `CloseBrokerSafely` in `brokerclose_test.go`; the external test package now calls `mqtt.CloseBrokerSafely`. The helper is test-binary-only (never in non-test builds).

### Context: #1315 is already mitigated; this is cleanup + verification

The rare ~10min hang of `TestConnection_HappyPath_HealthOk` (mochi v2.7.9 `srv.Close()` `ClientsWg.Wait()` deadlock) is **already fixed on develop** by the `closeBrokerSafely` **drain (quiesce-before-Close)** + **5s timeout guard** landed in #1319 — that drain *is* candidate-mitigation #1 from the issue. The 5s guard caps any residual deadlock at 5s instead of the 10min `go test` timeout.

The issue's other candidate — **bump/pin mochi — is not viable**: `v2.7.9` is the latest mochi release (confirmed via Go proxy `go list -m -versions`), with no upstream deadlock fix. We are already pinned at the latest.

So this PR delivers the remaining genuine work: **dedupe the band-aid into one source** + **empirically verify** no-hang, then close #1315.

### Timeout-path behavior (unchanged, deliberate)

The 5s-timeout path only logs (`t.Log`) and abandons the stuck `srv.Close()` goroutine — it does **not** fail the test. A teardown Close deadlock is a known library bug, not a real-assertion failure; failing there would trade a rare hang for a rare flaky FAIL. Kept as-is (documented in the consolidated helper's godoc).

## Test plan

- [x] `go vet ./adapters/mqtt/` — pass (untagged + `-tags=integration`)
- [x] `go build -tags=integration ./...` — pass
- [x] `go test ./adapters/mqtt/ -count=1` — full package pass
- [x] **200× acceptance**: `go test ./adapters/mqtt -run TestConnection_HappyPath_HealthOk -count=200 -timeout=300s` → `ok 31.7s`, **no hang**
- [x] `golangci-lint run ./adapters/mqtt/...` — 0 issues

> No production `Connection.Close` semantics change (test-scaffold only) — satisfies the issue's "不引入对生产 Connection.Close 路径的语义改动".

Closes #1315