### PR TITLE
test(archtest): slog/span hardening — cmd/gocell seal + C4 typed regression locks + A1/A2/span form-locks [#1432]

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -98,8 +98,11 @@ slog.SetDefault(slog.New(logging.NewHandler(logging.Options{Format: logging.Form
 For **generated assemblies** the seal is injected by the `gocell generate
 assembly` template (`kernel/assembly/gentpl/main.go.tpl`) as the first statement
 of the generated `run()` — no hand-maintained list, covers every current and
-future assembly automatically. For the two **hand-written** entry points
-(`examples/ssobff`, `examples/corebundlestarter`) the seal is hand-written.
+future assembly automatically. For the **hand-written** entry points
+(`examples/ssobff`, `examples/corebundlestarter`, and `cmd/gocell`) the seal is
+hand-written. Long-running services seal with `FormatJSON` (above); the
+`cmd/gocell` governance/codegen CLI seals with `FormatText` (human-readable
+output) — both route through the same redacting `contextHandler`.
 
 The `contextHandler` provides three layers of protection on every `Handle` call:
 
@@ -116,7 +119,8 @@ Entry points:
 - **Generated** (seal in generated `run()`, via assembly template): `cmd/corebundle`,
   `examples/iotdevice`, `examples/todoorder`, `examples/orderfulfillment`, + any
   future `gocell generate assembly` output.
-- **Hand-written** (seal in `main()`): `examples/ssobff`, `examples/corebundlestarter`.
+- **Hand-written** (seal in `main()`): `examples/ssobff`, `examples/corebundlestarter`,
+  `cmd/gocell` (CLI — `FormatText`).
 
 **Archtest**: `SLOG-HANDLER-SEALED-FUNNEL-01`
 (`tools/archtest/slog_handler_sealed_funnel_test.go`):

--- a/cmd/gocell/main.go
+++ b/cmd/gocell/main.go
@@ -8,11 +8,21 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/ghbvf/gocell/cmd/gocell/app"
+	"github.com/ghbvf/gocell/runtime/observability/logging"
 )
 
 func main() {
+	// Fail-closed sink-side redaction: seal the redacting slog default FIRST,
+	// before any log-relevant action, so cmd/gocell's production slog.Warn/Error
+	// (e.g. export wire-summary / dep-graph scan failures) are scrubbed
+	// (SLOG-HANDLER-SEALED-FUNNEL-01 A3 handwritten segment). cmd/gocell is a
+	// governance/codegen CLI, not a runtime binary, so it seals with FormatText
+	// (human-readable) rather than FormatJSON — both route through the redacting
+	// contextHandler. Tests invoke app.RunWithSignal directly and are unaffected.
+	slog.SetDefault(slog.New(logging.NewHandler(logging.Options{Format: logging.FormatText})))
 	os.Exit(app.RunWithSignal(os.Args[1:]))
 }

--- a/cmd/gocell/main.go
+++ b/cmd/gocell/main.go
@@ -23,6 +23,15 @@ func main() {
 	// governance/codegen CLI, not a runtime binary, so it seals with FormatText
 	// (human-readable) rather than FormatJSON — both route through the redacting
 	// contextHandler. Tests invoke app.RunWithSignal directly and are unaffected.
-	slog.SetDefault(slog.New(logging.NewHandler(logging.Options{Format: logging.FormatText})))
+	//
+	// Writer MUST be os.Stderr: cmd/gocell writes machine output (export JSON/YAML,
+	// validate/check/verify results, SARIF) to STDOUT, so diagnostics must go to
+	// STDERR or they corrupt that data stream (CLI convention stdout=data /
+	// stderr=diagnostics, cf. spf13/cobra OutOrStdout / ErrOrStderr). The
+	// logging.NewHandler default Writer is os.Stdout — do not rely on it here.
+	slog.SetDefault(slog.New(logging.NewHandler(logging.Options{
+		Format: logging.FormatText,
+		Writer: os.Stderr,
+	})))
 	os.Exit(app.RunWithSignal(os.Args[1:]))
 }

--- a/cmd/gocell/main_seal_test.go
+++ b/cmd/gocell/main_seal_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestMainSealsLogsToStderr is a regression test for #1432 C1.
+//
+// cmd/gocell is a governance/codegen CLI: it writes MACHINE output (export
+// JSON/YAML, validate/check/verify results, SARIF) to STDOUT. The redacting slog
+// seal installed in main() must therefore direct diagnostics to os.Stderr — if it
+// writes to stdout, graceful-degrade slog.Warn/Error (e.g. export's wire-summary /
+// dep-graph scan failures) corrupt that machine data stream. Because
+// logging.NewHandler defaults Writer to os.Stdout, main() MUST pass
+// Writer: os.Stderr explicitly. This asserts the source shape so a revert to the
+// stdout default fails loudly. (CLI convention stdout=data / stderr=diagnostics,
+// cf. spf13/cobra OutOrStdout / ErrOrStderr.)
+func TestMainSealsLogsToStderr(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	var found, writerStderr bool
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "NewHandler" {
+			return true
+		}
+		if len(call.Args) != 1 {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		found = true
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "Writer" {
+				continue
+			}
+			vsel, ok := kv.Value.(*ast.SelectorExpr)
+			if !ok || vsel.Sel == nil {
+				continue
+			}
+			if vx, ok := vsel.X.(*ast.Ident); ok && vx.Name == "os" && vsel.Sel.Name == "Stderr" {
+				writerStderr = true
+			}
+		}
+		return true
+	})
+
+	if !found {
+		t.Fatal("cmd/gocell/main.go: no logging.NewHandler(logging.Options{...}) seal found")
+	}
+	if !writerStderr {
+		t.Error("cmd/gocell main() seal must set logging.Options.Writer: os.Stderr —" +
+			" logging.NewHandler defaults to os.Stdout, which would corrupt machine output" +
+			" (export JSON/YAML/SARIF) written to stdout (#1432 C1)")
+	}
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -145,6 +145,14 @@ sonar.go.coverage.reportPaths=coverage-merged.out
 #   bodies toward coverage. It pairs with platform_unsupported.go (excluded
 #   above for build-tag reasons), so excluding both keeps the V-A15 platform
 #   guard pair symmetric in the coverage report.
+#
+# cmd/gocell/main.go is the governance/codegen CLI's thin entry point: it installs
+# the redacting slog seal (→ os.Stderr, #1432 C1) then calls os.Exit(
+# app.RunWithSignal(...)). os.Exit makes main() unreachable from unit tests, so its
+# lines can never accrue coverage. The one meaningful invariant (the seal writes to
+# os.Stderr, NOT stdout, so machine output is not corrupted) is locked by
+# cmd/gocell/main_seal_test.go::TestMainSealsLogsToStderr — line coverage adds
+# nothing. Analogous to the **/examples/** entry-point exclusion below.
 sonar.exclusions=\
   **/*_gen.go,\
   **/testdata/**,\
@@ -168,6 +176,7 @@ sonar.coverage.exclusions=\
   **/kernel/webhook/webhooktest/**,\
   **/runtime/observability/metrics/metricstest/**,\
   **/examples/**,\
+  **/cmd/gocell/main.go,\
   **/cells/accesscore/initialadmin/credfile_security_windows.go,\
   **/cells/accesscore/initialadmin/path_default_windows.go,\
   **/cells/accesscore/initialadmin/path_default_unsupported.go,\

--- a/tools/archtest/httputil_invariants_test.go
+++ b/tools/archtest/httputil_invariants_test.go
@@ -330,7 +330,7 @@ func TestHTTPUtil5xxLogRedact(t *testing.T) {
 func TestHTTPUtil5xxLogRedact_DetectsViolation(t *testing.T) {
 	t.Parallel()
 
-	const fixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/testdata/httputil_log_redact_fixtures/violation"
+	const fixturePkgPath = PlatformModulePath + "/tools/archtest/testdata/httputil_log_redact_fixtures/violation"
 
 	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/testdata/httputil_log_redact_fixtures/violation"},

--- a/tools/archtest/httputil_invariants_test.go
+++ b/tools/archtest/httputil_invariants_test.go
@@ -3,27 +3,35 @@ package archtest
 // invariants:
 //   - INVARIANT: HTTPUTIL-5XX-KIND-NORMALIZE-01
 //   - INVARIANT: HTTPUTIL-SURFACE-REGISTERED-01
+//   - INVARIANT: HTTPUTIL-5XX-LOG-REDACT-01
 //
 // httputil_invariants_test.go — consolidated AST guards for pkg/httputil invariants.
 //
 // Invariants covered:
 //   HTTPUTIL-5XX-KIND-NORMALIZE-01   errcode.New() in 5xx path must use errcode.KindXxx constant, not .Kind field access
 //   HTTPUTIL-SURFACE-REGISTERED-01   every exported pkg/httputil function must appear in doc.go or governance maps
+//   HTTPUTIL-5XX-LOG-REDACT-01       every Detail AsSlogAttr() in log4xx/log5xx must be wrapped in redaction.RedactSlogAttr
 //
-// Note: HTTPUTIL-5XX-LOG-REDACT-01 (log5xx must call redaction.RedactSlogAttr on
-// ecErr.Details) was retired in PR #1036 Batch 2. slog sink-side redaction
-// (SLOG-HANDLER-SEALED-FUNNEL-01, tools/archtest/slog_handler_sealed_funnel_test.go)
-// now provides fail-closed value redaction at the slog.Handler level for all log
-// output, superseding the call-site Soft archtest. The call-site
-// redaction.RedactSlogAttr calls in log5xx are preserved as defense-in-depth but
-// are no longer enforced by archtest.
+// HTTPUTIL-5XX-LOG-REDACT-01 was retired as a Soft "RedactSlogAttr appears" check
+// in PR #1036 Batch 2 (sink-side redaction superseded its value-redaction role).
+// It is RESTORED here (#1432) as a NARROW Medium form-lock — not the old global
+// Soft form — to keep the call-site defense-in-depth from silently regressing in
+// the two named functions (log4xx / log5xx) that log error Details: those run in
+// library code that may execute before any process-global slog seal is installed
+// (pkg/httputil is imported by tests / tools), so the call-site wrap is the only
+// protection there. The lock binds every `d.AsSlogAttr()` call in those two
+// functions to a `redaction.RedactSlogAttr(...)` wrapper (AST form-lock); a bare
+// AsSlogAttr append is flagged.
 
 import (
 	"go/ast"
+	"go/parser"
+	"go/token"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/testutil/fileutil"
@@ -205,6 +213,149 @@ func TestHttputilExportedRegistry(t *testing.T) {
 		}
 	}
 	Report(t, "HTTPUTIL-SURFACE-REGISTERED-01", diags)
+}
+
+// httputilLogRedactTargets are the two named functions that log error Details
+// and must wrap every AsSlogAttr() in redaction.RedactSlogAttr (HTTPUTIL-5XX-LOG-REDACT-01).
+var httputilLogRedactTargets = map[string]bool{
+	"log4xx": true,
+	"log5xx": true,
+}
+
+// httputilLogRedactViolations is the HTTPUTIL-5XX-LOG-REDACT-01 detector: within
+// each target function, every `<d>.AsSlogAttr()` call must be a direct argument
+// of a `redaction.RedactSlogAttr(...)` call. A bare AsSlogAttr append (no wrap)
+// is flagged. Shared by the production rule and the reverse self-check.
+func httputilLogRedactViolations(p *Pass, f *ast.File) []Diagnostic {
+	redactionLocal := redactionLocalName(f)
+	var ds []Diagnostic
+	EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+		if fn.Name == nil || fn.Body == nil || !httputilLogRedactTargets[fn.Name.Name] {
+			return
+		}
+		// Collect AsSlogAttr() CallExprs that are direct args of redaction.RedactSlogAttr(...).
+		wrapped := make(map[*ast.CallExpr]bool)
+		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+			if redactionLocal == "" || !callMatches(call, redactionLocal, slogFunnelRedactSlogAttrFunc) {
+				return
+			}
+			// Direct CallExpr children of this RedactSlogAttr(...) call are its
+			// argument calls (its Fun is a SelectorExpr, not a CallExpr).
+			EachInChildren[ast.CallExpr](call, func(ac *ast.CallExpr) {
+				wrapped[ac] = true
+			})
+		})
+		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "AsSlogAttr" {
+				return
+			}
+			if wrapped[call] {
+				return
+			}
+			pos := p.Fset.Position(call.Pos())
+			ds = append(ds, Diagnostic{
+				Rel:  filepath.ToSlash(p.Rel(f)),
+				Line: pos.Line,
+				Message: "AsSlogAttr() in " + fn.Name.Name + " must be wrapped in" +
+					" redaction.RedactSlogAttr(...) — call-site defense-in-depth must not" +
+					" regress (HTTPUTIL-5XX-LOG-REDACT-01)",
+			})
+		})
+	})
+	return ds
+}
+
+// INVARIANT: HTTPUTIL-5XX-LOG-REDACT-01
+//
+// TestHTTPUtil5xxLogRedact enforces HTTPUTIL-5XX-LOG-REDACT-01: log4xx and log5xx
+// in pkg/httputil/response.go must wrap every error-Detail AsSlogAttr() in
+// redaction.RedactSlogAttr. AI-robust rating: Medium (AST form-lock scoped to two
+// named functions, callee resolved via the redaction import local name; not the
+// retired global Soft form). See file-header note for the defense-in-depth rationale.
+func TestHTTPUtil5xxLogRedact(t *testing.T) {
+	t.Parallel()
+	diags := runHTTPUtilResponseRule(t, "HTTPUTIL-5XX-LOG-REDACT-01", func(p *Pass) []Diagnostic {
+		var ds []Diagnostic
+		for _, f := range p.Files {
+			ds = append(ds, httputilLogRedactViolations(p, f)...)
+		}
+		return ds
+	})
+	Report(t, "HTTPUTIL-5XX-LOG-REDACT-01", diags)
+}
+
+// TestHTTPUtil5xxLogRedact_DetectsViolation is the reverse self-check: a synthetic
+// log5xx whose AsSlogAttr() append drops the redaction.RedactSlogAttr wrap must be
+// flagged; the wrapped form must not be.
+func TestHTTPUtil5xxLogRedact_DetectsViolation(t *testing.T) {
+	t.Parallel()
+
+	const redactionImport = `"github.com/ghbvf/gocell/pkg/redaction"`
+	cases := map[string]struct {
+		src     string
+		wantVio bool
+		desc    string
+	}{
+		"bare_asslogattr": {
+			src: `package httputil
+import (
+	"log/slog"
+	` + redactionImport + `
+)
+func log5xx(ecErr fakeErr) {
+	logAttrs := []any{}
+	for _, d := range ecErr.Details {
+		logAttrs = append(logAttrs, d.AsSlogAttr())  // VIOLATION: not wrapped
+	}
+	_ = logAttrs
+	_ = slog.Int
+	_ = redaction.Mask
+}
+`,
+			wantVio: true,
+			desc:    "bare d.AsSlogAttr() append (no RedactSlogAttr wrap) must be flagged",
+		},
+		"wrapped_asslogattr": {
+			src: `package httputil
+import (
+	"log/slog"
+	` + redactionImport + `
+)
+func log5xx(ecErr fakeErr) {
+	logAttrs := []any{}
+	for _, d := range ecErr.Details {
+		logAttrs = append(logAttrs, redaction.RedactSlogAttr(d.AsSlogAttr()))
+	}
+	_ = logAttrs
+	_ = slog.Int
+}
+`,
+			wantVio: false,
+			desc:    "wrapped redaction.RedactSlogAttr(d.AsSlogAttr()) is compliant",
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "response.go", tc.src, parser.SkipObjectResolution)
+			require.NoError(t, err, "fixture must parse: %s", tc.desc)
+			p := &Pass{
+				Fset:  fset,
+				Files: []*ast.File{file},
+				Rel:   func(*ast.File) string { return "pkg/httputil/response.go" },
+			}
+			diags := httputilLogRedactViolations(p, file)
+			if tc.wantVio {
+				assert.NotEmpty(t, diags, "must detect %q: %s", name, tc.desc)
+			} else {
+				assert.Empty(t, diags, "must not flag %q: %s; got %v", name, tc.desc, diags)
+			}
+		})
+	}
 }
 
 // collectExportedFuncs returns a set of top-level exported function names

--- a/tools/archtest/httputil_invariants_test.go
+++ b/tools/archtest/httputil_invariants_test.go
@@ -14,24 +14,24 @@ package archtest
 //
 // HTTPUTIL-5XX-LOG-REDACT-01 was retired as a Soft "RedactSlogAttr appears" check
 // in PR #1036 Batch 2 (sink-side redaction superseded its value-redaction role).
-// It is RESTORED here (#1432) as a NARROW Medium form-lock — not the old global
-// Soft form — to keep the call-site defense-in-depth from silently regressing in
-// the two named functions (log4xx / log5xx) that log error Details: those run in
-// library code that may execute before any process-global slog seal is installed
-// (pkg/httputil is imported by tests / tools), so the call-site wrap is the only
-// protection there. The lock binds every `d.AsSlogAttr()` call in those two
-// functions to a `redaction.RedactSlogAttr(...)` wrapper (AST form-lock); a bare
-// AsSlogAttr append is flagged.
+// It is RESTORED here (#1432) as a NARROW Medium TYPED form-lock — NOT the old
+// global Soft string-anchor form — to keep the call-site defense-in-depth from
+// silently regressing in the two named functions (log4xx / log5xx) that log error
+// Details: those run in library code that may execute before any process-global
+// slog seal is installed (pkg/httputil is imported by tests / tools), so the
+// call-site wrap is the only protection there. The lock binds every errcode-detail
+// `d.AsSlogAttr()` call (go/types ObjectOf → pkg/errcode method) in those two
+// functions to a `redaction.RedactSlogAttr(...)` wrapper (IsCallToPkgFunc →
+// pkg/redaction); both callee and locator are typed-resolved, not string-anchored.
+// A bare AsSlogAttr append is flagged.
 
 import (
 	"go/ast"
-	"go/parser"
-	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/testutil/fileutil"
@@ -222,21 +222,47 @@ var httputilLogRedactTargets = map[string]bool{
 	"log5xx": true,
 }
 
+// isErrcodeAsSlogAttrCall reports whether call is `<d>.AsSlogAttr()` where the
+// resolved method is defined in pkg/errcode (go/types ObjectOf → *types.Func →
+// defining package). This is the typed locator for the detail-attr appends that
+// must be redacted — NOT a bare method-name string anchor.
+func isErrcodeAsSlogAttrCall(info *types.Info, call *ast.CallExpr) bool {
+	if info == nil {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "AsSlogAttr" {
+		return false
+	}
+	fn, ok := info.ObjectOf(sel.Sel).(*types.Func)
+	if !ok || fn.Pkg() == nil {
+		return false
+	}
+	return fn.Pkg().Path() == errcodePkgPath
+}
+
 // httputilLogRedactViolations is the HTTPUTIL-5XX-LOG-REDACT-01 detector: within
-// each target function, every `<d>.AsSlogAttr()` call must be a direct argument
-// of a `redaction.RedactSlogAttr(...)` call. A bare AsSlogAttr append (no wrap)
-// is flagged. Shared by the production rule and the reverse self-check.
+// each target function, every `<d>.AsSlogAttr()` call (typed-resolved to a
+// pkg/errcode method) must be a direct argument of a redaction.RedactSlogAttr(...)
+// call (typed-resolved via IsCallToPkgFunc). A bare AsSlogAttr append (no wrap) is
+// flagged. Both the wrapper callee and the AsSlogAttr locator are resolved through
+// go/types (not import-local-name / method-name string anchors), so the rule is
+// Medium, not Soft. Requires p.TypesInfo (typed load). Shared by the production
+// rule and the fixture reverse self-check.
 func httputilLogRedactViolations(p *Pass, f *ast.File) []Diagnostic {
-	redactionLocal := redactionLocalName(f)
+	if p.TypesInfo == nil {
+		return nil
+	}
 	var ds []Diagnostic
 	EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
 		if fn.Name == nil || fn.Body == nil || !httputilLogRedactTargets[fn.Name.Name] {
 			return
 		}
-		// Collect AsSlogAttr() CallExprs that are direct args of redaction.RedactSlogAttr(...).
+		// Collect AsSlogAttr() CallExprs that are direct args of a typed
+		// redaction.RedactSlogAttr(...) call.
 		wrapped := make(map[*ast.CallExpr]bool)
 		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
-			if redactionLocal == "" || !callMatches(call, redactionLocal, slogFunnelRedactSlogAttrFunc) {
+			if !IsCallToPkgFunc(p.TypesInfo, call, redactionPkgPath, slogFunnelRedactSlogAttrFunc) {
 				return
 			}
 			// Direct CallExpr children of this RedactSlogAttr(...) call are its
@@ -246,8 +272,7 @@ func httputilLogRedactViolations(p *Pass, f *ast.File) []Diagnostic {
 			})
 		})
 		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel == nil || sel.Sel.Name != "AsSlogAttr" {
+			if !isErrcodeAsSlogAttrCall(p.TypesInfo, call) {
 				return
 			}
 			if wrapped[call] {
@@ -257,8 +282,8 @@ func httputilLogRedactViolations(p *Pass, f *ast.File) []Diagnostic {
 			ds = append(ds, Diagnostic{
 				Rel:  filepath.ToSlash(p.Rel(f)),
 				Line: pos.Line,
-				Message: "AsSlogAttr() in " + fn.Name.Name + " must be wrapped in" +
-					" redaction.RedactSlogAttr(...) — call-site defense-in-depth must not" +
+				Message: "errcode-detail AsSlogAttr() in " + fn.Name.Name + " must be wrapped" +
+					" in redaction.RedactSlogAttr(...) — call-site defense-in-depth must not" +
 					" regress (HTTPUTIL-5XX-LOG-REDACT-01)",
 			})
 		})
@@ -269,93 +294,60 @@ func httputilLogRedactViolations(p *Pass, f *ast.File) []Diagnostic {
 // INVARIANT: HTTPUTIL-5XX-LOG-REDACT-01
 //
 // TestHTTPUtil5xxLogRedact enforces HTTPUTIL-5XX-LOG-REDACT-01: log4xx and log5xx
-// in pkg/httputil/response.go must wrap every error-Detail AsSlogAttr() in
-// redaction.RedactSlogAttr. AI-robust rating: Medium (AST form-lock scoped to two
-// named functions, callee resolved via the redaction import local name; not the
-// retired global Soft form). See file-header note for the defense-in-depth rationale.
+// in pkg/httputil/response.go must wrap every pkg/errcode-detail AsSlogAttr() in
+// redaction.RedactSlogAttr. AI-robust rating: Medium — both the redaction wrapper
+// (IsCallToPkgFunc → pkg/redaction.RedactSlogAttr) and the AsSlogAttr locator
+// (go/types ObjectOf → pkg/errcode method) are typed-resolved, scoped to two named
+// function bodies; NOT the retired Soft string-anchor form. Typed load required.
 func TestHTTPUtil5xxLogRedact(t *testing.T) {
 	t.Parallel()
-	diags := runHTTPUtilResponseRule(t, "HTTPUTIL-5XX-LOG-REDACT-01", func(p *Pass) []Diagnostic {
+	const targetRel = "pkg/httputil/response.go"
+	var foundFile bool
+	diags := RunTyped(t, TypedOpts{Tests: false}, []string{"./pkg/httputil"}, func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
 		var ds []Diagnostic
 		for _, f := range p.Files {
+			if filepath.ToSlash(p.Rel(f)) != targetRel {
+				continue
+			}
+			foundFile = true
 			ds = append(ds, httputilLogRedactViolations(p, f)...)
 		}
 		return ds
 	})
+	require.True(t, foundFile, "HTTPUTIL-5XX-LOG-REDACT-01: %s not found (renamed/deleted/scope drift)", targetRel)
 	Report(t, "HTTPUTIL-5XX-LOG-REDACT-01", diags)
 }
 
-// TestHTTPUtil5xxLogRedact_DetectsViolation is the reverse self-check: a synthetic
-// log5xx whose AsSlogAttr() append drops the redaction.RedactSlogAttr wrap must be
-// flagged; the wrapped form must not be.
+// TestHTTPUtil5xxLogRedact_DetectsViolation is the reverse self-check: it runs the
+// typed detector against a real fixture package (loaded type-checked via
+// RunTypedFixture) whose log4xx/log5xx contain bare (unwrapped) errcode-detail
+// AsSlogAttr() appends alongside a compliant wrapped one — asserting exactly the
+// two bare appends are flagged. Type-checking is required for the go/types
+// resolution of both RedactSlogAttr and the errcode AsSlogAttr methods.
 func TestHTTPUtil5xxLogRedact_DetectsViolation(t *testing.T) {
 	t.Parallel()
 
-	const redactionImport = `"github.com/ghbvf/gocell/pkg/redaction"`
-	cases := map[string]struct {
-		src     string
-		wantVio bool
-		desc    string
-	}{
-		"bare_asslogattr": {
-			src: `package httputil
-import (
-	"log/slog"
-	` + redactionImport + `
-)
-func log5xx(ecErr fakeErr) {
-	logAttrs := []any{}
-	for _, d := range ecErr.Details {
-		logAttrs = append(logAttrs, d.AsSlogAttr())  // VIOLATION: not wrapped
-	}
-	_ = logAttrs
-	_ = slog.Int
-	_ = redaction.Mask
-}
-`,
-			wantVio: true,
-			desc:    "bare d.AsSlogAttr() append (no RedactSlogAttr wrap) must be flagged",
-		},
-		"wrapped_asslogattr": {
-			src: `package httputil
-import (
-	"log/slog"
-	` + redactionImport + `
-)
-func log5xx(ecErr fakeErr) {
-	logAttrs := []any{}
-	for _, d := range ecErr.Details {
-		logAttrs = append(logAttrs, redaction.RedactSlogAttr(d.AsSlogAttr()))
-	}
-	_ = logAttrs
-	_ = slog.Int
-}
-`,
-			wantVio: false,
-			desc:    "wrapped redaction.RedactSlogAttr(d.AsSlogAttr()) is compliant",
-		},
-	}
+	const fixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/testdata/httputil_log_redact_fixtures/violation"
 
-	for name, tc := range cases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, "response.go", tc.src, parser.SkipObjectResolution)
-			require.NoError(t, err, "fixture must parse: %s", tc.desc)
-			p := &Pass{
-				Fset:  fset,
-				Files: []*ast.File{file},
-				Rel:   func(*ast.File) string { return "pkg/httputil/response.go" },
+	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/testdata/httputil_log_redact_fixtures/violation"},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
+				return nil
 			}
-			diags := httputilLogRedactViolations(p, file)
-			if tc.wantVio {
-				assert.NotEmpty(t, diags, "must detect %q: %s", name, tc.desc)
-			} else {
-				assert.Empty(t, diags, "must not flag %q: %s; got %v", name, tc.desc, diags)
+			var ds []Diagnostic
+			for _, f := range p.Files {
+				ds = append(ds, httputilLogRedactViolations(p, f)...)
 			}
+			return ds
 		})
-	}
+
+	require.Len(t, diags, 2,
+		"HTTPUTIL-5XX-LOG-REDACT-01 must flag exactly 2 bare AsSlogAttr() appends"+
+			" (log5xx + log4xx); the wrapped one must NOT be flagged; got: %v", diags)
 }
 
 // collectExportedFuncs returns a set of top-level exported function names

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -1,6 +1,8 @@
 package archtest
 
-// INVARIANT: PANIC-REGISTERED-01
+// invariants:
+//   - INVARIANT: PANIC-REGISTERED-01
+//   - INVARIANT: PANIC-LOG-REDACT-01
 //
 // panic_invariants_test.go — test entry points for panic-related invariants.
 //
@@ -12,13 +14,23 @@ package archtest
 //	                    logic against GoCell itself — single source, no parallel
 //	                    rule body. See pkg/panicregister and
 //	                    docs/architecture/202604270030-architectural-panic-whitelist.md.
+//	PANIC-LOG-REDACT-01 every production slog.Any("panic", X) must have
+//	                    X = redaction.RedactAny(...).
 //
-// Note: PANIC-REDACT-01 (slog.Any("panic", X) must wrap X with redaction.RedactAny)
-// was retired in PR #1036 Batch 2. slog sink-side redaction (SLOG-HANDLER-SEALED-FUNNEL-01,
-// tools/archtest/slog_handler_sealed_funnel_test.go) now provides fail-closed
-// value redaction at the slog.Handler level for all log output, superseding the
-// call-site Soft archtest. The call-site redaction.RedactAny calls are preserved
-// as defense-in-depth but are no longer enforced by archtest.
+// PANIC-LOG-REDACT-01 was retired as a Soft string-anchor check in PR #1036
+// Batch 2 (sink-side redaction superseded its value-redaction role). It is
+// RESTORED here (#1432) as a Medium TYPED form-lock — NOT the old Soft form: the
+// callee (log/slog.Any) and the value wrapper (pkg/redaction.RedactAny) are both
+// resolved via go/types (IsCallToPkgFunc), and the "panic" key literal is only
+// the locator. This keeps the call-site defense-in-depth from silently
+// regressing across all production recovery sites, which matters because panic
+// logging runs in recovery paths that may execute in contexts where the
+// process-global slog seal is not active (library/test code).
+//
+// Residual (accepted): a panic value logged under a non-literal key, or via a
+// different slog constructor than slog.Any, is not matched — the same locator
+// limitation as the retired rule, but the form within the "panic"-keyed slog.Any
+// set is now typed-locked rather than string-anchored.
 
 import (
 	"go/ast"
@@ -26,8 +38,103 @@ import (
 	"go/token"
 	"go/types"
 	"path/filepath"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// panicRedactionPkgPath is the import path of pkg/redaction, used by
+// PANIC-LOG-REDACT-01 to resolve redaction.RedactAny via go/types.
+const panicRedactionPkgPath = "github.com/ghbvf/gocell/pkg/redaction"
+
+// panicLogRedactViol is the PANIC-LOG-REDACT-01 diagnostic.
+const panicLogRedactViol = `slog.Any("panic", X) must wrap X with redaction.RedactAny(X)` +
+	` — call-site defense-in-depth must not regress (PANIC-LOG-REDACT-01)`
+
+// panicLogRedactViolations is the PANIC-LOG-REDACT-01 detector: every
+// slog.Any("panic", X) call (callee resolved via go/types) must have X be a
+// redaction.RedactAny(...) call (also go/types-resolved). Shared by the
+// production scan and the reverse self-check fixture.
+func panicLogRedactViolations(p *Pass, f *ast.File, rel string) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	var ds []Diagnostic
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		if !IsCallToPkgFunc(p.TypesInfo, call, slogFunnelStdlibPkgPath, "Any") {
+			return
+		}
+		if len(call.Args) != 2 {
+			return
+		}
+		bl, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || bl.Kind != token.STRING {
+			return
+		}
+		key, err := strconv.Unquote(bl.Value)
+		if err != nil || key != "panic" {
+			return
+		}
+		if valCall, ok := call.Args[1].(*ast.CallExpr); ok &&
+			IsCallToPkgFunc(p.TypesInfo, valCall, panicRedactionPkgPath, "RedactAny") {
+			return // compliant
+		}
+		pos := p.Fset.Position(call.Pos())
+		ds = append(ds, Diagnostic{Rel: rel, Line: pos.Line, Message: panicLogRedactViol})
+	})
+	return ds
+}
+
+// INVARIANT: PANIC-LOG-REDACT-01
+//
+// TestPanicLogRedact enforces PANIC-LOG-REDACT-01 across the production tree:
+// every slog.Any("panic", X) must have X = redaction.RedactAny(...). AI-robust
+// rating: Medium (typed (callee, arg) form-lock; the "panic" key literal is the
+// locator, the RedactAny wrapper is the typed lock). See file-header note.
+func TestPanicLogRedact(t *testing.T) {
+	t.Parallel()
+	diags := RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
+		var ds []Diagnostic
+		for _, f := range p.Files {
+			ds = append(ds, panicLogRedactViolations(p, f, filepath.ToSlash(p.Rel(f)))...)
+		}
+		return ds
+	})
+	Report(t, "PANIC-LOG-REDACT-01", diags)
+}
+
+// TestPanicLogRedact_DetectsViolation is the reverse self-check: it runs the
+// detector against a real fixture package (loaded type-checked via
+// RunTypedFixture) that contains one compliant call plus two violations (a bare
+// value and a non-RedactAny wrapper) — asserting exactly the two violations are
+// flagged. This proves the typed form-lock is non-vacuous.
+func TestPanicLogRedact_DetectsViolation(t *testing.T) {
+	t.Parallel()
+
+	const fixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/testdata/panic_log_redact_fixtures/violation"
+
+	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/testdata/panic_log_redact_fixtures/violation"},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
+				return nil
+			}
+			var ds []Diagnostic
+			for _, f := range p.Files {
+				ds = append(ds, panicLogRedactViolations(p, f, filepath.ToSlash(p.Rel(f)))...)
+			}
+			return ds
+		})
+
+	require.Len(t, diags, 2,
+		"PANIC-LOG-REDACT-01 must flag exactly 2 violations (bare value + non-RedactAny"+
+			" wrapper); the RedactAny-wrapped call must NOT be flagged; got: %v", diags)
+	for _, d := range diags {
+		assert.Contains(t, d.Message, "PANIC-LOG-REDACT-01")
+	}
+}
 
 // INVARIANT: PANIC-REGISTERED-01
 //

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -109,7 +109,7 @@ func TestPanicLogRedact(t *testing.T) {
 func TestPanicLogRedact_DetectsViolation(t *testing.T) {
 	t.Parallel()
 
-	const fixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/testdata/panic_log_redact_fixtures/violation"
+	const fixturePkgPath = PlatformModulePath + "/tools/archtest/testdata/panic_log_redact_fixtures/violation"
 
 	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/testdata/panic_log_redact_fixtures/violation"},

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -45,10 +45,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// panicRedactionPkgPath is the import path of pkg/redaction, used by
-// PANIC-LOG-REDACT-01 to resolve redaction.RedactAny via go/types.
-const panicRedactionPkgPath = "github.com/ghbvf/gocell/pkg/redaction"
-
 // panicLogRedactViol is the PANIC-LOG-REDACT-01 diagnostic.
 const panicLogRedactViol = `slog.Any("panic", X) must wrap X with redaction.RedactAny(X)` +
 	` — call-site defense-in-depth must not regress (PANIC-LOG-REDACT-01)`
@@ -78,7 +74,7 @@ func panicLogRedactViolations(p *Pass, f *ast.File, rel string) []Diagnostic {
 			return
 		}
 		if valCall, ok := call.Args[1].(*ast.CallExpr); ok &&
-			IsCallToPkgFunc(p.TypesInfo, valCall, panicRedactionPkgPath, "RedactAny") {
+			IsCallToPkgFunc(p.TypesInfo, valCall, redactionPkgPath, "RedactAny") {
 			return // compliant
 		}
 		pos := p.Fset.Position(call.Pos())

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -91,14 +91,32 @@ func panicLogRedactViolations(p *Pass, f *ast.File, rel string) []Diagnostic {
 // locator, the RedactAny wrapper is the typed lock). See file-header note.
 func TestPanicLogRedact(t *testing.T) {
 	t.Parallel()
-	diags := RunTypedProduction(t, TypedOpts{Tests: false}, func(p *Pass) []Diagnostic {
+	rule := func(p *Pass) []Diagnostic {
 		var ds []Diagnostic
 		for _, f := range p.Files {
 			ds = append(ds, panicLogRedactViolations(p, f, filepath.ToSlash(p.Rel(f)))...)
 		}
 		return ds
-	})
-	Report(t, "PANIC-LOG-REDACT-01", diags)
+	}
+	// Two passes: default build tags PLUS the project's full non-default tag union
+	// (FlatNonDefaultTags), so tag-gated production files (`//go:build integration`
+	// etc.) that recover-and-log a panic are also scanned — same coverage discipline
+	// as the sibling PANIC-REGISTERED-01. A single default-tag pass would silently
+	// skip those files. Dedup by rel:line:message (a file may appear in both passes).
+	seen := make(map[string]bool)
+	var all []Diagnostic
+	both := append(
+		RunTypedProduction(t, TypedOpts{Tests: false}, rule),
+		RunTypedProduction(t, TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, rule)...,
+	)
+	for _, d := range both {
+		key := d.Rel + ":" + strconv.Itoa(d.Line) + ":" + d.Message
+		if !seen[key] {
+			seen[key] = true
+			all = append(all, d)
+		}
+	}
+	Report(t, "PANIC-LOG-REDACT-01", all)
 }
 
 // TestPanicLogRedact_DetectsViolation is the reverse self-check: it runs the

--- a/tools/archtest/slog_handler_sealed_funnel_test.go
+++ b/tools/archtest/slog_handler_sealed_funnel_test.go
@@ -803,7 +803,7 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 func TestSlogHandlerSealedFunnel_A1_DetectsViolation(t *testing.T) {
 	t.Parallel()
 
-	const fixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/testdata/slog_bare_handler_fixtures/external_violation"
+	const fixturePkgPath = PlatformModulePath + "/tools/archtest/testdata/slog_bare_handler_fixtures/external_violation"
 
 	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/testdata/slog_bare_handler_fixtures/external_violation"},

--- a/tools/archtest/slog_handler_sealed_funnel_test.go
+++ b/tools/archtest/slog_handler_sealed_funnel_test.go
@@ -168,6 +168,11 @@ var slogHandwrittenEntryPoints = []struct {
 }{
 	{"./examples/ssobff", "main", "examples/ssobff/main.go"},
 	{"./examples/corebundlestarter", "main", "examples/corebundlestarter/main.go"},
+	// cmd/gocell is the governance/codegen CLI: it does NOT import runtime/bootstrap
+	// (so C3 reverse-coverage does not require it) but it emits production
+	// slog.Warn/Error, so it seals (FormatText, human-readable) and is enrolled here
+	// for A3 handwritten seal verification.
+	{"./cmd/gocell", "main", "cmd/gocell/main.go"},
 }
 
 // isGocellAssemblyGenerated reports whether f carries the `gocell generate
@@ -207,16 +212,20 @@ func fileDeclaresFunc(f *ast.File, name string) bool {
 
 // sealStatusInFunc locates the FuncDecl named funcName in f and reports whether
 // its body (a) contains a slog.SetDefault(slog.New(logging.NewHandler(...))) call
-// and (b) has that call as the first call-bearing statement. Shared by the A3
-// generated segment (funcName="run") and handwritten segment (funcName="main").
-func sealStatusInFunc(info *types.Info, f *ast.File, funcName, loggingPkgPath string) (found, sealFirst bool) {
+// and (b) has that call as the first call-bearing statement, plus the FuncDecl's
+// position (token.NoPos if the func is absent) so callers can emit a line-anchored
+// diagnostic. Shared by the A3 generated segment (funcName="run") and handwritten
+// segment (funcName="main").
+func sealStatusInFunc(info *types.Info, f *ast.File, funcName, loggingPkgPath string) (found, sealFirst bool, funcPos token.Pos) {
 	if info == nil {
-		return false, false
+		return false, false, token.NoPos
 	}
+	funcPos = token.NoPos
 	EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
 		if fn.Name == nil || fn.Body == nil || fn.Name.Name != funcName {
 			return
 		}
+		funcPos = fn.Pos()
 		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
 			if slogSetDefaultShape(info, call, loggingPkgPath) {
 				found = true
@@ -226,7 +235,7 @@ func sealStatusInFunc(info *types.Info, f *ast.File, funcName, loggingPkgPath st
 			return slogSetDefaultShape(info, call, loggingPkgPath)
 		})
 	})
-	return found, sealFirst
+	return found, sealFirst, funcPos
 }
 
 // ---------------------------------------------------------------------------
@@ -253,32 +262,43 @@ func TestSlogHandlerSealedFunnel_A1_NoBareConstruction(t *testing.T) {
 			if strings.HasPrefix(rel, slogFunnelLoggingPkgRelDir+"/") || rel == slogFunnelLoggingPkgRelDir {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-				if p.TypesInfo == nil {
-					return
-				}
-				isJSON := IsCallToPkgFunc(p.TypesInfo, call, slogFunnelStdlibPkgPath, slogFunnelNewJSONHandlerFunc)
-				isText := IsCallToPkgFunc(p.TypesInfo, call, slogFunnelStdlibPkgPath, slogFunnelNewTextHandlerFunc)
-				if !isJSON && !isText {
-					return
-				}
-				funcName := slogFunnelNewJSONHandlerFunc
-				if isText {
-					funcName = slogFunnelNewTextHandlerFunc
-				}
-				pos := p.Fset.Position(call.Pos())
-				ds = append(ds, Diagnostic{
-					Rel:  rel,
-					Line: pos.Line,
-					Message: "slog." + funcName + "(...) called outside runtime/observability/logging" +
-						" — non-redacting handler bypasses SLOG-HANDLER-SEALED-FUNNEL-01 A1;" +
-						" use logging.NewHandler instead",
-				})
-			})
+			ds = append(ds, slogBareHandlerViolations(p, f, rel)...)
 		}
 		return ds
 	})
 	Report(t, "SLOG-HANDLER-SEALED-FUNNEL-01", diags)
+}
+
+// slogBareHandlerViolations is the A1 per-file detector: it reports every
+// slog.NewJSONHandler / slog.NewTextHandler call in f, resolved via go/types
+// (IsCallToPkgFunc, so import aliases do not bypass it). Shared by the production
+// A1 scan (which skips the logging package) and the A1 reverse self-check, which
+// runs it on an external fixture package to prove the detector is non-vacuous.
+func slogBareHandlerViolations(p *Pass, f *ast.File, rel string) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	var ds []Diagnostic
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		isJSON := IsCallToPkgFunc(p.TypesInfo, call, slogFunnelStdlibPkgPath, slogFunnelNewJSONHandlerFunc)
+		isText := IsCallToPkgFunc(p.TypesInfo, call, slogFunnelStdlibPkgPath, slogFunnelNewTextHandlerFunc)
+		if !isJSON && !isText {
+			return
+		}
+		funcName := slogFunnelNewJSONHandlerFunc
+		if isText {
+			funcName = slogFunnelNewTextHandlerFunc
+		}
+		pos := p.Fset.Position(call.Pos())
+		ds = append(ds, Diagnostic{
+			Rel:  rel,
+			Line: pos.Line,
+			Message: "slog." + funcName + "(...) called outside runtime/observability/logging" +
+				" — non-redacting handler bypasses SLOG-HANDLER-SEALED-FUNNEL-01 A1;" +
+				" use logging.NewHandler instead",
+		})
+	})
+	return ds
 }
 
 // ---------------------------------------------------------------------------
@@ -298,23 +318,36 @@ func contextHandlerHandleRedactCheck(p *Pass, f *ast.File, fn *ast.FuncDecl) []D
 	redactionLocal := redactionLocalName(f)
 	var ds []Diagnostic
 
-	// Check 1: Message must pass through redaction.RedactString.
-	foundRedactString := false
+	// Check 1 (form-lock, #1432): the redacted record must be built via
+	// slog.NewRecord(..., redaction.RedactString(<recordParam>.Message), ...).
+	// The message argument (3rd positional) is bound to RedactString applied to
+	// the record formal parameter's .Message — a bare <r>.Message, or RedactString
+	// of some other expression, is rejected. Upgraded from a presence check
+	// ("RedactString appears somewhere"), which would pass even if the message
+	// itself was forwarded raw and RedactString was only applied elsewhere.
+	recordParam := recordParamName(fn)
+	var newRecordCall *ast.CallExpr
 	EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
-		if redactionLocal == "" {
-			return
-		}
-		if callMatches(call, redactionLocal, slogFunnelRedactStringFunc) {
-			foundRedactString = true
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel != nil && sel.Sel.Name == "NewRecord" {
+			newRecordCall = call
 		}
 	})
-	if !foundRedactString {
+	msgOK := false
+	if newRecordCall != nil && len(newRecordCall.Args) >= 3 && redactionLocal != "" && recordParam != "" {
+		if msgArg, ok := newRecordCall.Args[2].(*ast.CallExpr); ok &&
+			callMatches(msgArg, redactionLocal, slogFunnelRedactStringFunc) &&
+			len(msgArg.Args) == 1 && isSelectorOf(msgArg.Args[0], recordParam, "Message") {
+			msgOK = true
+		}
+	}
+	if !msgOK {
 		pos := p.Fset.Position(fn.Pos())
 		ds = append(ds, Diagnostic{
 			Rel:  filepath.ToSlash(p.Rel(f)),
 			Line: pos.Line,
-			Message: "contextHandler.Handle must pass the log message through" +
-				" redaction.RedactString — SLOG-HANDLER-SEALED-FUNNEL-01 A2",
+			Message: "contextHandler.Handle must build the record message via" +
+				" slog.NewRecord(..., redaction.RedactString(<record>.Message), ...)" +
+				" — SLOG-HANDLER-SEALED-FUNNEL-01 A2 message form-lock",
 		})
 	}
 
@@ -380,6 +413,39 @@ func contextHandlerHandleRedactCheck(p *Pass, f *ast.File, fn *ast.FuncDecl) []D
 		})
 	}
 	return ds
+}
+
+// recordParamName returns the name of the slog.Record formal parameter of fn
+// (the parameter whose type is a selector expression ending in "Record"), or ""
+// if not found. Used to bind the A2 message form-lock to the actual record param.
+func recordParamName(fn *ast.FuncDecl) string {
+	if fn.Type == nil || fn.Type.Params == nil {
+		return ""
+	}
+	for _, field := range fn.Type.Params.List {
+		sel, ok := field.Type.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "Record" {
+			continue
+		}
+		if len(field.Names) > 0 {
+			return field.Names[0].Name
+		}
+	}
+	return ""
+}
+
+// isSelectorOf reports whether expr is the selector `<xName>.<selName>` with a
+// plain identifier receiver named xName (xName must be non-empty).
+func isSelectorOf(expr ast.Expr, xName, selName string) bool {
+	if xName == "" {
+		return false
+	}
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != selName {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == xName
 }
 
 // contextHandlerWithAttrsRedactCheck form-locks contextHandler.WithAttrs
@@ -617,12 +683,16 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 			}
 			generatedCount++
 			rel := filepath.ToSlash(p.Rel(f))
-			found, sealFirst := sealStatusInFunc(p.TypesInfo, f, slogFunnelGeneratedRunFunc, loggingPkgPath)
+			found, sealFirst, funcPos := sealStatusInFunc(p.TypesInfo, f, slogFunnelGeneratedRunFunc, loggingPkgPath)
+			line := 0
+			if funcPos != token.NoPos {
+				line = p.Fset.Position(funcPos).Line
+			}
 			switch {
 			case !found:
 				all = append(all, Diagnostic{
 					Rel:  rel,
-					Line: 0,
+					Line: line,
 					Message: "generated assembly entry point (" + slogFunnelGeneratedRunFunc +
 						") must call slog.SetDefault(slog.New(logging.NewHandler(...))) —" +
 						" the seal is injected by kernel/assembly/gentpl/main.go.tpl;" +
@@ -632,7 +702,7 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 			case !sealFirst:
 				all = append(all, Diagnostic{
 					Rel:  rel,
-					Line: 0,
+					Line: line,
 					Message: "generated assembly entry point (" + slogFunnelGeneratedRunFunc +
 						") must call slog.SetDefault(...) as the FIRST call-bearing statement" +
 						" (SLOG-HANDLER-SEALED-FUNNEL-01 A3 generated segment)",
@@ -652,6 +722,7 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 	for _, ep := range slogHandwrittenEntryPoints {
 		found := false
 		sealIsFirstCall := false
+		funcLine := 0
 		RunTyped(t, TypedOpts{Tests: false}, []string{ep.pkgPattern},
 			func(p *Pass) []Diagnostic {
 				if p.TypesInfo == nil {
@@ -665,12 +736,15 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 					if isGocellAssemblyGenerated(f) {
 						continue
 					}
-					fFound, fFirst := sealStatusInFunc(p.TypesInfo, f, ep.funcName, loggingPkgPath)
+					fFound, fFirst, fPos := sealStatusInFunc(p.TypesInfo, f, ep.funcName, loggingPkgPath)
 					if fFound {
 						found = true
 					}
 					if fFirst {
 						sealIsFirstCall = true
+					}
+					if fPos != token.NoPos {
+						funcLine = p.Fset.Position(fPos).Line
 					}
 				}
 				return nil
@@ -680,7 +754,7 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 		case !found:
 			all = append(all, Diagnostic{
 				Rel:  ep.relPath,
-				Line: 0,
+				Line: funcLine,
 				Message: "hand-written entry point function " + ep.funcName +
 					" must call slog.SetDefault(slog.New(logging.NewHandler(...)))" +
 					" — SLOG-HANDLER-SEALED-FUNNEL-01 A3 handwritten segment; gh #1424",
@@ -688,7 +762,7 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 		case !sealIsFirstCall:
 			all = append(all, Diagnostic{
 				Rel:  ep.relPath,
-				Line: 0,
+				Line: funcLine,
 				Message: "hand-written entry point function " + ep.funcName +
 					" must call slog.SetDefault(...) as the FIRST call-bearing" +
 					" statement (no fallible or logging call before the seal) —" +
@@ -705,52 +779,44 @@ func TestSlogHandlerSealedFunnel_A3_EntryPointSeal(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestSlogHandlerSealedFunnel_A1_DetectsViolation is the reverse self-check for
-// A1: confirms that a slog.NewJSONHandler call outside the logging package would
-// be detected. Uses go/types synthesis to construct a minimal CallExpr scenario.
-// Since we cannot easily inject a fake package via RunTypedDir for this check,
-// we verify the detection logic operates correctly by confirming A1 passes on
-// the production tree (no false positives) AND by asserting the callsite check
-// logic fires when applied to a mock types.Info+AST scenario.
+// A1. It runs the production A1 detector (slogBareHandlerViolations) against a
+// real external fixture package (testdata/slog_bare_handler_fixtures/external_violation,
+// loaded type-checked via RunTypedFixture) that calls slog.NewJSONHandler /
+// NewTextHandler outside runtime/observability/logging — and asserts BOTH call
+// sites are flagged. This is a true external-violation RED proof (replacing the
+// earlier "production tree self-proof", which only showed the logging package
+// uses the constructors, not that an external violation is detected).
+//
+// The fixture imports log/slog under a non-default alias (slogsink), so a passing
+// result also proves the detector resolves the callee by go/types package path,
+// not by a textual "slog." prefix.
 func TestSlogHandlerSealedFunnel_A1_DetectsViolation(t *testing.T) {
 	t.Parallel()
 
-	// Verify production tree passes A1 (no bare slog.NewJSONHandler outside logging/).
-	// If A1 is vacuous, it would pass even with violations — but the production tree
-	// itself is the canonical non-vacuity proof (confirmed in PR #1036 Batch 2
-	// red→green cycle).
-	root := findModuleRoot(t)
-	scope := DirsScope(root, []string{slogFunnelLoggingPkgRelDir})
+	const fixturePkgPath = "github.com/ghbvf/gocell/tools/archtest/testdata/slog_bare_handler_fixtures/external_violation"
 
-	// The logging pkg itself should use slog.NewJSONHandler/NewTextHandler.
-	var foundInLogging bool
-	Run(t, scope, func(p *Pass) []Diagnostic {
-		for _, f := range p.Files {
-			// Scan the logging package for the raw constructor calls.
-			EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel == nil {
-					return
-				}
-				ident, ok := sel.X.(*ast.Ident)
-				if !ok {
-					return
-				}
-				// AST-level check: look for slog.NewJSONHandler or slog.NewTextHandler
-				// in the logging package itself (where it is allowed).
-				if ident.Name == "slog" &&
-					(sel.Sel.Name == slogFunnelNewJSONHandlerFunc || sel.Sel.Name == slogFunnelNewTextHandlerFunc) {
-					foundInLogging = true
-				}
-			})
-		}
-		return nil
-	})
-	if !foundInLogging {
-		t.Errorf("SLOG-HANDLER-SEALED-FUNNEL-01 A1 non-vacuity: expected to find"+
-			" slog.NewJSONHandler or slog.NewTextHandler in %s (the sanctioned location),"+
-			" but found none — if the logging implementation changed, update this check",
-			slogFunnelLoggingPkgRelDir)
+	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/testdata/slog_bare_handler_fixtures/external_violation"},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
+				return nil
+			}
+			var ds []Diagnostic
+			for _, f := range p.Files {
+				ds = append(ds, slogBareHandlerViolations(p, f, filepath.ToSlash(p.Rel(f)))...)
+			}
+			return ds
+		})
+
+	require.Len(t, diags, 2,
+		"A1 detector must flag exactly 2 external violations (NewJSONHandler +"+
+			" NewTextHandler) in the fixture; got: %v", diags)
+	joined := ""
+	for _, d := range diags {
+		joined += d.Message + "\n"
 	}
+	assert.Contains(t, joined, slogFunnelNewJSONHandlerFunc)
+	assert.Contains(t, joined, slogFunnelNewTextHandlerFunc)
 }
 
 // TestSlogHandlerSealedFunnel_A2_DetectsViolation is the reverse self-check for
@@ -819,6 +885,51 @@ func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
 `,
 			wantVio: false,
 			desc:    "Handle calls RedactString + RedactSlogAttr — compliant",
+		},
+		{
+			name: "bare_message_no_redact",
+			src: `package logging
+import (
+	"context"
+	"log/slog"
+	` + redactionImport + `
+)
+type contextHandler struct{ inner slog.Handler }
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	nr := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)  // VIOLATION: raw r.Message
+	r.Attrs(func(a slog.Attr) bool {
+		nr.AddAttrs(redaction.RedactSlogAttr(a))
+		return true
+	})
+	return h.inner.Handle(ctx, nr)
+}
+`,
+			wantVio: true,
+			desc:    "message form-lock: bare r.Message (not RedactString-wrapped) must be flagged",
+		},
+		{
+			name: "redact_wrong_expr",
+			src: `package logging
+import (
+	"context"
+	"log/slog"
+	` + redactionImport + `
+)
+type contextHandler struct{ inner slog.Handler }
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	var other string
+	// VIOLATION: RedactString applied to some other value, not r.Message — the
+	// presence-check predecessor would pass this since RedactString "appears".
+	nr := slog.NewRecord(r.Time, r.Level, redaction.RedactString(other), r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		nr.AddAttrs(redaction.RedactSlogAttr(a))
+		return true
+	})
+	return h.inner.Handle(ctx, nr)
+}
+`,
+			wantVio: true,
+			desc:    "message form-lock: RedactString of a non-Message expression must be flagged",
 		},
 	}
 
@@ -1093,7 +1204,7 @@ func TestSlogHandlerSealedFunnel_A3_DetectsViolation(t *testing.T) {
 					continue
 				}
 				sawGeneratedMain = true
-				if found, sealFirst := sealStatusInFunc(p.TypesInfo, f, slogFunnelGeneratedRunFunc, loggingPkgPath); found && sealFirst {
+				if found, sealFirst, _ := sealStatusInFunc(p.TypesInfo, f, slogFunnelGeneratedRunFunc, loggingPkgPath); found && sealFirst {
 					generatedSealed = true
 				}
 			}

--- a/tools/archtest/slog_handler_sealed_funnel_test.go
+++ b/tools/archtest/slog_handler_sealed_funnel_test.go
@@ -325,6 +325,16 @@ func contextHandlerHandleRedactCheck(p *Pass, f *ast.File, fn *ast.FuncDecl) []D
 	// of some other expression, is rejected. Upgraded from a presence check
 	// ("RedactString appears somewhere"), which would pass even if the message
 	// itself was forwarded raw and RedactString was only applied elsewhere.
+	//
+	// Accepted constraint (NOT a false-negative): the form-lock requires the
+	// INLINE form. A pre-assigned variable — `msg := redaction.RedactString(r.Message);
+	// slog.NewRecord(..., msg, ...)` — is flagged even though it is safe, because
+	// the 3rd arg is then an *ast.Ident, not the RedactString CallExpr. This is a
+	// false-POSITIVE (rejects a safe refactor), never a false-negative (an unsafe
+	// bare-message variable is likewise an Ident and rejected). The canonical
+	// inline form is the sanctioned shape; the WithAttrs / A3 form-locks share the
+	// same "must be the canonical inline form" property. Reverse self-check case
+	// "var_assigned_message" pins this behavior.
 	recordParam := recordParamName(fn)
 	var newRecordCall *ast.CallExpr
 	EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
@@ -930,6 +940,30 @@ func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
 `,
 			wantVio: true,
 			desc:    "message form-lock: RedactString of a non-Message expression must be flagged",
+		},
+		{
+			name: "var_assigned_message",
+			src: `package logging
+import (
+	"context"
+	"log/slog"
+	` + redactionImport + `
+)
+type contextHandler struct{ inner slog.Handler }
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Pinned accepted constraint: the inline form is required, so this safe
+	// pre-assigned form is FLAGGED (false-positive, never false-negative).
+	msg := redaction.RedactString(r.Message)
+	nr := slog.NewRecord(r.Time, r.Level, msg, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		nr.AddAttrs(redaction.RedactSlogAttr(a))
+		return true
+	})
+	return h.inner.Handle(ctx, nr)
+}
+`,
+			wantVio: true,
+			desc:    "message form-lock requires the INLINE form; a pre-assigned RedactString var is flagged",
 		},
 	}
 

--- a/tools/archtest/span_record_error_seal_test.go
+++ b/tools/archtest/span_record_error_seal_test.go
@@ -50,9 +50,12 @@
 //     require the call argument to also be renamed consistently for B to
 //     pass. TestSpanRecordErrorSeal_B_DetectsViolation covers the
 //     wrong-identifier shape.
-//   - Method-value expressions (f := s.inner.RecordError; f(err)) are not
-//     detected. TestSpanRecordErrorSeal_NoBlindspotsInProduction asserts
-//     this shape is absent from production code.
+//   - Method-value expressions on a FIELD receiver (f := s.inner.RecordError;
+//     f(err)) ARE now detected by sealAMethodValueViolationsInFile (#1432):
+//     RecordError SelectorExprs not in CallExpr.Fun position, outside the sink
+//     body, on a field receiver are flagged. A method-value on a plain Ident
+//     receiver remains the same Ident blind spot as the call form (see above).
+//     TestSpanRecordErrorSeal_MethodValue_DetectsViolation is the RED proof.
 //
 // ref: tools/archtest/span_setattr_redact_test.go (sibling INVARIANT, upstream
 // holder seal + A3b parameter-binding technique)
@@ -120,6 +123,14 @@ const recordErrorSinkFile = "adapters/otel/span.go"
 const violSealA = "RecordError call on field receiver outside otelSpan.RecordError body" +
 	" — bypass of sink funnel (SPAN-RECORD-ERROR-SEAL-01 A)"
 
+// violSealAMethodValue is the diagnostic for the A method-value sub-check: a
+// RecordError method-value reference (f := s.inner.RecordError) on a field
+// receiver outside otelSpan.RecordError body. Taking the method as a value lets
+// it be invoked later with a raw error, bypassing the sink redaction.
+const violSealAMethodValue = "RecordError taken as a method-value on a field receiver" +
+	" outside otelSpan.RecordError body — bypass of sink funnel via deferred" +
+	" invocation (SPAN-RECORD-ERROR-SEAL-01 A method-value)"
+
 // violSealB is the diagnostic for SPAN-RECORD-ERROR-SEAL-01 B.
 const violSealB = "otelSpan.RecordError body: inner.RecordError arg must be" +
 	" redaction.RedactError(<formalParam>) — argument identity-bound to formal" +
@@ -184,6 +195,45 @@ func sealAViolationsInFile(fset *token.FileSet, file *ast.File, relPath string) 
 			pos := fset.Position(call.Pos())
 			ds = append(ds, Diagnostic{Rel: relPath, Line: pos.Line, Message: violSealA})
 		}
+	})
+	return ds
+}
+
+// sealAMethodValueViolationsInFile closes the A method-value blind spot: a
+// RecordError SelectorExpr on a field receiver (e.g. s.inner.RecordError) that
+// is NOT the Fun of a CallExpr — i.e. taken as a method-value (f :=
+// s.inner.RecordError) — outside otelSpan.RecordError's body. sealAViolationsInFile
+// only scans CallExpr.Fun, so a method-value reference would slip past it and
+// could later be invoked with a raw (unredacted) error. The receiver constraint
+// (field selector, not plain Ident) mirrors sealAViolationsInFile; an Ident
+// receiver method-value remains the same declared Ident blind spot as the call
+// form.
+func sealAMethodValueViolationsInFile(fset *token.FileSet, file *ast.File, relPath string) []Diagnostic {
+	implRanges := collectOtelSpanRecordErrorBodyRanges(file)
+	// Collect the SelectorExpr nodes that are the Fun of a CallExpr — those are
+	// invocations (covered by sealAViolationsInFile), not method-values.
+	calledFuns := make(map[*ast.SelectorExpr]bool)
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			calledFuns[sel] = true
+		}
+	})
+	var ds []Diagnostic
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != "RecordError" {
+			return
+		}
+		if calledFuns[sel] {
+			return // invocation, not a method-value — covered by the call check
+		}
+		if posInRanges(sel.Pos(), implRanges) {
+			return // inside the sanctioned sink body
+		}
+		if _, isSel := sel.X.(*ast.SelectorExpr); !isSel {
+			return // Ident receiver — declared blind spot, same as call form
+		}
+		pos := fset.Position(sel.Pos())
+		ds = append(ds, Diagnostic{Rel: relPath, Line: pos.Line, Message: violSealAMethodValue})
 	})
 	return ds
 }
@@ -298,6 +348,8 @@ func TestSpanRecordErrorSeal(t *testing.T) {
 			rel := filepath.ToSlash(p.Rel(file))
 			// A: callsite locality — all files in the package.
 			ds = append(ds, sealAViolationsInFile(p.Fset, file, rel)...)
+			// A method-value: deferred-invocation form — all files.
+			ds = append(ds, sealAMethodValueViolationsInFile(p.Fset, file, rel)...)
 			// B: argument form — only the sink file.
 			if rel == recordErrorSinkFile {
 				redactionLocal := redactionLocalName(file)
@@ -313,15 +365,15 @@ func TestSpanRecordErrorSeal(t *testing.T) {
 // spots of SPAN-RECORD-ERROR-SEAL-01 do not appear in production adapters/otel
 // code, per .claude/rules/gocell/ai-robust.md §"工具选定后强制盲区自检".
 //
-// Checked blind spots:
+// Checked blind spot:
 //  1. RecordError on plain *ast.Ident receiver (local variable, not a field
-//     access): `var s Span; s.RecordError(err)`.
-//  2. RecordError used as a method-value (not as a call Fun): the AST
-//     for this looks like a SelectorExpr whose parent is NOT a CallExpr.
-//     Checking (1) is sufficient here because a method-value on s.inner would
-//     still have a SelectorExpr receiver and be indistinguishable at the
-//     syntactic level — this shape is still caught by A for any SelectorExpr
-//     receiver. Only (1) is a genuine blind spot.
+//     access): `var s Span; s.RecordError(err)`. This is the sole remaining
+//     A blind spot.
+//
+// The method-value form on a FIELD receiver (f := s.inner.RecordError) is NO
+// LONGER a blind spot (#1432): sealAMethodValueViolationsInFile flags it, since
+// sealAViolationsInFile alone only scans CallExpr.Fun and would miss the deferred
+// invocation. Only the Ident-receiver form (1) remains uncovered.
 func TestSpanRecordErrorSeal_NoBlindspotsInProduction(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
@@ -425,6 +477,94 @@ func leakViaInterface(s Span, err error) {
 			} else {
 				assert.Empty(t, diags,
 					"A must not flag %q: %s; got %v", name, tc.desc, diags)
+			}
+		})
+	}
+}
+
+// TestSpanRecordErrorSeal_MethodValue_DetectsViolation is the reverse-fixture for
+// the A method-value sub-check (#1432): sealAMethodValueViolationsInFile must
+// flag a RecordError method-value taken on a field receiver outside the sink
+// body, must NOT flag a normal call (covered by sealAViolationsInFile), must NOT
+// flag a method-value taken inside the sink body, and must NOT flag an
+// Ident-receiver method-value (declared blind spot).
+func TestSpanRecordErrorSeal_MethodValue_DetectsViolation(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		src     string
+		wantVio bool
+		desc    string
+	}{
+		"method_value_outside_body": {
+			src: `package otel
+import oteltrace "go.opentelemetry.io/otel/trace"
+type otelSpan struct { inner oteltrace.Span }
+func (s *otelSpan) RecordError(err error) {
+	s.inner.RecordError(err)
+}
+// VIOLATION: RecordError taken as a method-value on a field receiver, outside body
+func leakViaMethodValue(s *otelSpan) func(error) {
+	f := s.inner.RecordError
+	return f
+}
+`,
+			wantVio: true,
+			desc:    "field.RecordError method-value outside otelSpan body",
+		},
+		"call_not_method_value": {
+			src: `package otel
+import oteltrace "go.opentelemetry.io/otel/trace"
+type otelSpan struct { inner oteltrace.Span }
+func (s *otelSpan) RecordError(err error) {
+	s.inner.RecordError(err)
+}
+func helper(s *otelSpan, err error) {
+	s.inner.RecordError(err)  // a CALL, not a method-value — not this check's concern
+}
+`,
+			wantVio: false,
+			desc:    "plain call is covered by sealAViolationsInFile, not the method-value check",
+		},
+		"method_value_inside_body": {
+			src: `package otel
+import oteltrace "go.opentelemetry.io/otel/trace"
+type otelSpan struct { inner oteltrace.Span }
+func (s *otelSpan) RecordError(err error) {
+	f := s.inner.RecordError  // inside sink body — compliant
+	f(err)
+}
+`,
+			wantVio: false,
+			desc:    "method-value inside the sink body is sanctioned",
+		},
+		"ident_receiver_method_value": {
+			src: `package otel
+type Span interface{ RecordError(error) }
+func leak(s Span) func(error) {
+	return s.RecordError  // Ident receiver method-value — declared blind spot
+}
+`,
+			wantVio: false,
+			desc:    "Ident-receiver method-value is the declared blind spot",
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "span.go", tc.src, parser.SkipObjectResolution)
+			require.NoError(t, err, "fixture must parse")
+
+			diags := sealAMethodValueViolationsInFile(fset, file, "span.go")
+			if tc.wantVio {
+				assert.NotEmpty(t, diags,
+					"method-value check must detect violation for %q: %s; got no diags", name, tc.desc)
+			} else {
+				assert.Empty(t, diags,
+					"method-value check must not flag %q: %s; got %v", name, tc.desc, diags)
 			}
 		})
 	}

--- a/tools/archtest/testdata/httputil_log_redact_fixtures/violation/violator.go
+++ b/tools/archtest/testdata/httputil_log_redact_fixtures/violation/violator.go
@@ -1,0 +1,43 @@
+//go:build archtest_fixture
+
+// Package violation is the RED/GREEN fixture for HTTPUTIL-5XX-LOG-REDACT-01. Its
+// log4xx / log5xx (the two locked target functions) append real
+// pkg/errcode-detail AsSlogAttr() values both bare (VIOLATION) and wrapped in
+// redaction.RedactSlogAttr (compliant). The typed detector
+// (httputilLogRedactViolations: IsCallToPkgFunc for RedactSlogAttr +
+// go/types ObjectOf for the errcode AsSlogAttr methods) must flag exactly the two
+// bare appends — the non-vacuity proof for TestHTTPUtil5xxLogRedact_DetectsViolation.
+//
+// Real pkg/errcode + pkg/redaction imports are required so go/types resolves the
+// AsSlogAttr methods to their defining package. Parsed + type-checked via
+// RunTypedFixture; the archtest_fixture build tag keeps it out of normal builds.
+package violation
+
+import (
+	"log/slog"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// log5xx: a bare InternalDetail AsSlogAttr() (VIOLATION) plus a compliant wrapped
+// Detail AsSlogAttr().
+func log5xx(err *errcode.Error) {
+	logAttrs := []any{}
+	for _, d := range err.InternalDetails {
+		logAttrs = append(logAttrs, d.AsSlogAttr()) // VIOLATION: not wrapped
+	}
+	for _, d := range err.Details {
+		logAttrs = append(logAttrs, redaction.RedactSlogAttr(d.AsSlogAttr())) // compliant
+	}
+	slog.Error("5xx", logAttrs...)
+}
+
+// log4xx: a bare Detail AsSlogAttr() (VIOLATION).
+func log4xx(err *errcode.Error) {
+	logAttrs := []any{}
+	for _, d := range err.Details {
+		logAttrs = append(logAttrs, d.AsSlogAttr()) // VIOLATION: not wrapped
+	}
+	slog.Warn("4xx", logAttrs...)
+}

--- a/tools/archtest/testdata/panic_log_redact_fixtures/violation/violator.go
+++ b/tools/archtest/testdata/panic_log_redact_fixtures/violation/violator.go
@@ -1,0 +1,35 @@
+//go:build archtest_fixture
+
+// Package violation is the RED/GREEN fixture for PANIC-LOG-REDACT-01. It contains
+// one compliant slog.Any("panic", redaction.RedactAny(v)) call and two violations
+// (a bare value, and a non-RedactAny wrapper). The detector
+// (panicLogRedactViolations, go/types IsCallToPkgFunc) must flag exactly the two
+// violations — the non-vacuity proof for TestPanicLogRedact_DetectsViolation.
+//
+// Parsed + type-checked by archtest via RunTypedFixture; intentionally violates
+// the funnel, so the archtest_fixture build tag keeps it out of normal builds.
+package violation
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// compliant is the sanctioned form — must NOT be flagged.
+func compliant(v any) {
+	slog.Error("recovered", slog.Any("panic", redaction.RedactAny(v)))
+}
+
+// bareValue logs the recovered value with no redaction wrapper — VIOLATION.
+func bareValue(v any) {
+	slog.Error("recovered", slog.Any("panic", v))
+}
+
+// wrongWrapper uses RedactString(fmt.Sprint(...)) instead of RedactAny — the
+// value is still scrubbed, but the form-lock requires RedactAny specifically, so
+// this is a VIOLATION (the canonical recovery form across production is RedactAny).
+func wrongWrapper(v any) {
+	slog.Error("recovered", slog.Any("panic", redaction.RedactString(fmt.Sprint(v))))
+}

--- a/tools/archtest/testdata/slog_bare_handler_fixtures/external_violation/violator.go
+++ b/tools/archtest/testdata/slog_bare_handler_fixtures/external_violation/violator.go
@@ -1,0 +1,34 @@
+//go:build archtest_fixture
+
+// Package externalviolation is a RED fixture for SLOG-HANDLER-SEALED-FUNNEL-01
+// A1: a production-shaped package OUTSIDE runtime/observability/logging that
+// constructs raw, non-redacting slog handlers. The A1 detector
+// (slogBareHandlerViolations, go/types IsCallToPkgFunc) must flag both call
+// sites — the external-violation non-vacuity proof for A1
+// (TestSlogHandlerSealedFunnel_A1_DetectsViolation).
+//
+// The slog import uses a NON-default local name (slogsink) on purpose: A1
+// resolves the callee by package PATH via go/types, not by a textual "slog."
+// prefix, so this fixture also proves import-alias resolution.
+//
+// Parsed + type-checked by archtest via RunTypedFixture; intentionally violates
+// the funnel, so it must NEVER be compiled into a production build (the
+// archtest_fixture build tag keeps it out of normal builds).
+package externalviolation
+
+import (
+	"os"
+
+	slogsink "log/slog"
+)
+
+// leakingJSON builds a non-redacting JSON handler directly — bypasses
+// logging.NewHandler, so it never routes through the redacting contextHandler.
+func leakingJSON() slogsink.Handler {
+	return slogsink.NewJSONHandler(os.Stdout, nil)
+}
+
+// leakingText is the same violation via the text constructor.
+func leakingText() slogsink.Handler {
+	return slogsink.NewTextHandler(os.Stdout, nil)
+}


### PR DESCRIPTION
## Summary

No-design-disagreement hardening batch from review cluster C1 (旧真值源/防线未同步). The deeper C1 item — fail-closed **structured-recursive** redaction (replacing KindAny/LogValuer passthrough Option A) — is tracked separately at **#1431**; this PR closes the six archtest/coverage items.

| # | Item | Rating | Reverse self-check |
|---|------|--------|--------------------|
| C2 | `cmd/gocell/main.go` seals redacting slog default (**FormatText**, human-readable CLI) + enrolled in A3 handwritten allowlist. Closes the gap where the governance CLI emits production `slog.Warn/Error` (export.go) via the unsealed stdlib default. | Medium (A3 handwritten) | A3 verifies seal present + first |
| A3 Line | A3 diagnostics now point at the `run()`/`main()` FuncDecl line (was `Line: 0`). | — | — |
| A2 msg | `Handle`'s `slog.NewRecord` 3rd arg form-locked to `redaction.RedactString(<record>.Message)` (bound to the formal param) — upgraded from a presence check. | **Hard** | +2 RED (bare message / RedactString-of-wrong-expr) |
| A1 fixture | Real external RED fixture (`testdata/slog_bare_handler_fixtures`) runs the production detector against an out-of-`logging`-pkg `NewJSONHandler`/`NewTextHandler` call; non-default slog alias proves go/types resolution. Replaces the production-self-proof. | **Hard** | flags exactly 2 |
| span method-value | `SPAN-RECORD-ERROR-SEAL-01` A now flags `f := s.inner.RecordError` (method-value on a field receiver outside the sink body) — the call-only scan missed it. **Corrected the prior godoc that wrongly claimed this was already covered.** | **Hard** | +4 cases |
| C4 (HTTPUTIL) | `HTTPUTIL-5XX-LOG-REDACT-01` restored as a **typed** Medium form-lock (not the retired Soft): `log4xx`/`log5xx` must wrap every Detail `AsSlogAttr()` in `redaction.RedactSlogAttr`. | Medium | +RED/GREEN |
| C4 (PANIC) | `PANIC-LOG-REDACT-01` restored as a **typed** Medium form-lock: every `slog.Any("panic", X)` must have `X = redaction.RedactAny(...)` (go/types (callee, arg) resolution; `"panic"` literal = locator). **Review decision A** — global typed lock (real regression protection for all 18 recovery sites), not a token single-function lock; materially stronger than the old Soft string-anchor. | Medium | fixture flags exactly 2 |

## AI-robust notes
- Every new/modified enforcement is ≥ Medium with a reverse self-check (ai-robust §"工具选定后强制盲区自检"). No Soft introduced.
- C4 restores were deliberately made **typed** (go/types callee+arg resolution), so they are NOT a re-introduction of the retired Soft string-anchor forms.

## Test plan
- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] `go test ./tools/archtest -run 'TestSlogHandlerSealedFunnel|TestSpanRecordError|TestHTTPUtil5xx|TestPanicLogRedact|TestPanicRegistered'` — all green (incl. all reverse self-checks; production scans yield 0 violations)
- [x] meta-archtests (`TestScannerFrameworkUsage01/02`, `TestTypesutilImplementsFunnel01`) — **none of my files flagged**; the remaining hits are **pre-existing** in `collector_conformance_enrollment_test.go` / `distlock_orphan_no_io_test.go` (not in this diff — nightly-only develop breakage from #1397/#1402)
- [x] `go test $(go list ./... | grep -v tools/archtest)` — full unit suite green (incl. cmd/gocell with the new FormatText seal)
- [x] `golangci-lint run` on changed packages — 0 issues

Refs: #1432
Refs: #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)