### PR TITLE
perf(httputil): single-pass error envelope marshal — drop double JSON round-trip [#622]

### DIFF
--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -974,6 +974,16 @@ type errorEnvelope struct {
 // 5xx detail-strip + public-code normalization and never emits the operator-only
 // SourceCode/Status fields on the public surface, so the HTTP wire body matches
 // the v1 schema's additionalProperties:false error object exactly.
+//
+// Caller contract: this is a framework-layer primitive — business handlers must
+// emit errors via httputil.WriteError / WriteErrorWithStatus, which call this
+// and add the fail-closed sentinel fallback. requestID is trusted as opaque
+// correlation metadata sourced from ctxkeys.RequestIDFrom (framework RequestID
+// middleware, UUID-shaped); it is written to the wire verbatim, so callers must
+// not pass user-controlled input. The receiver may be nil (PublicProjection
+// returns a valid ErrInternal 500 envelope). The output carries no trailing
+// newline (unlike json.Encoder.Encode); joined error chains are not expanded —
+// use the package-level PublicProjection(error) for those.
 func (e *Error) MarshalHTTPEnvelope(requestID string) ([]byte, error) {
 	pub := e.PublicProjection()
 	pub.RequestID = requestID

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -803,6 +803,13 @@ type PublicError struct {
 	// failures without exposing InternalDetails, Cause, or server-side Details.
 	SourceCode Code `json:"sourceCode,omitempty"`
 	Status     int  `json:"status,omitempty"`
+
+	// RequestID is the ctx-derived correlation id injected only on the HTTP
+	// wire path (MarshalHTTPEnvelope). The v1 error-response schema places it
+	// inside the inner error object alongside code/message/details. omitempty
+	// keeps CLI/operator and machine-output projections unchanged — only the
+	// HTTP envelope path ever sets it.
+	RequestID string `json:"requestId,omitempty"`
 }
 
 // MarshalJSON keeps the details field schema-stable even when callers build a
@@ -946,6 +953,31 @@ func (e *Error) FindAttr(key string) (PublicDetail, bool) {
 // Go compile error rather than a runtime panic.
 func (e *Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.PublicProjection())
+}
+
+// errorEnvelope is the canonical outer {"error":{...}} wrapper defined by
+// contracts/shared/errors/error-response-v1.schema.json. It exists so the wire
+// envelope can be produced in a single marshal pass (see MarshalHTTPEnvelope).
+type errorEnvelope struct {
+	Error PublicError `json:"error"`
+}
+
+// MarshalHTTPEnvelope renders the canonical v1 wire envelope {"error":{...}} in
+// a single marshal pass, injecting requestID into the inner error object
+// (omitted when empty). It is the choke point all HTTP error responses funnel
+// through via pkg/httputil.writeErrorBody.
+//
+// Because the result is built directly from PublicProjection — with no
+// intermediate map[string]any — int64 detail values retain full precision
+// (json.Marshal encodes int64 exactly; a map[string]any round-trip would coerce
+// them to float64 and truncate beyond 2^53). PublicProjection also performs the
+// 5xx detail-strip + public-code normalization and never emits the operator-only
+// SourceCode/Status fields on the public surface, so the HTTP wire body matches
+// the v1 schema's additionalProperties:false error object exactly.
+func (e *Error) MarshalHTTPEnvelope(requestID string) ([]byte, error) {
+	pub := e.PublicProjection()
+	pub.RequestID = requestID
+	return json.Marshal(errorEnvelope{Error: pub})
 }
 
 // Error returns a formatted string representation for logging/diagnostics.

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -803,13 +803,6 @@ type PublicError struct {
 	// failures without exposing InternalDetails, Cause, or server-side Details.
 	SourceCode Code `json:"sourceCode,omitempty"`
 	Status     int  `json:"status,omitempty"`
-
-	// RequestID is the ctx-derived correlation id injected only on the HTTP
-	// wire path (MarshalHTTPEnvelope). The v1 error-response schema places it
-	// inside the inner error object alongside code/message/details. omitempty
-	// keeps CLI/operator and machine-output projections unchanged — only the
-	// HTTP envelope path ever sets it.
-	RequestID string `json:"requestId,omitempty"`
 }
 
 // MarshalJSON keeps the details field schema-stable even when callers build a
@@ -955,11 +948,26 @@ func (e *Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.PublicProjection())
 }
 
+// httpErrorObject is the inner error object of the v1 HTTP wire envelope. It is
+// deliberately NARROWER than PublicError: it carries only the four wire fields
+// (code/message/details/requestId) and structurally cannot express the
+// operator-only SourceCode/Status fields, so those can never leak onto the HTTP
+// wire regardless of how the projection is constructed — the type system is the
+// guard, not an omitempty zero-value coincidence. Field set is frozen by the v1
+// schema's additionalProperties:false constraint (any new field must update
+// contracts/shared/errors/error-response-v1.schema.json + the envelope tests).
+type httpErrorObject struct {
+	Code      Code           `json:"code"`
+	Message   string         `json:"message"`
+	Details   []PublicDetail `json:"details"`
+	RequestID string         `json:"requestId,omitempty"`
+}
+
 // errorEnvelope is the canonical outer {"error":{...}} wrapper defined by
 // contracts/shared/errors/error-response-v1.schema.json. It exists so the wire
 // envelope can be produced in a single marshal pass (see MarshalHTTPEnvelope).
 type errorEnvelope struct {
-	Error PublicError `json:"error"`
+	Error httpErrorObject `json:"error"`
 }
 
 // MarshalHTTPEnvelope renders the canonical v1 wire envelope {"error":{...}} in
@@ -970,10 +978,11 @@ type errorEnvelope struct {
 // Because the result is built directly from PublicProjection — with no
 // intermediate map[string]any — int64 detail values retain full precision
 // (json.Marshal encodes int64 exactly; a map[string]any round-trip would coerce
-// them to float64 and truncate beyond 2^53). PublicProjection also performs the
-// 5xx detail-strip + public-code normalization and never emits the operator-only
-// SourceCode/Status fields on the public surface, so the HTTP wire body matches
-// the v1 schema's additionalProperties:false error object exactly.
+// them to float64 and truncate beyond 2^53). PublicProjection performs the 5xx
+// detail-strip + public-code normalization, and the narrowed httpErrorObject
+// makes the operator-only SourceCode/Status fields type-level unrepresentable on
+// the wire, so the body matches the v1 schema's additionalProperties:false error
+// object exactly.
 //
 // Caller contract: this is a framework-layer primitive — business handlers must
 // emit errors via httputil.WriteError / WriteErrorWithStatus, which call this
@@ -986,8 +995,12 @@ type errorEnvelope struct {
 // use the package-level PublicProjection(error) for those.
 func (e *Error) MarshalHTTPEnvelope(requestID string) ([]byte, error) {
 	pub := e.PublicProjection()
-	pub.RequestID = requestID
-	return json.Marshal(errorEnvelope{Error: pub})
+	return json.Marshal(errorEnvelope{Error: httpErrorObject{
+		Code:      pub.Code,
+		Message:   pub.Message,
+		Details:   pub.Details,
+		RequestID: requestID,
+	}})
 }
 
 // Error returns a formatted string representation for logging/diagnostics.

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -687,4 +687,16 @@ func TestError_MarshalHTTPEnvelope(t *testing.T) {
 		assert.Contains(t, string(raw), `"value":9007199254740993`,
 			"single-pass marshal must not coerce int64 to float64")
 	})
+
+	t.Run("nil receiver yields valid ErrInternal 500 envelope", func(t *testing.T) {
+		t.Parallel()
+		var ec *Error
+		raw, err := ec.MarshalHTTPEnvelope("req-nil")
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"error":{"code":"ERR_INTERNAL","message":"internal server error",`+
+				`"details":[],"requestId":"req-nil"}}`,
+			string(raw),
+			"nil *Error must fall back to the PublicProjection ErrInternal envelope")
+	})
 }

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -626,3 +626,65 @@ func TestProjectionFallbacksAndMethodStrings(t *testing.T) {
 	assert.Empty(t, nilErr.PublicString())
 	assert.Empty(t, nilErr.OperatorString())
 }
+
+// TestError_MarshalHTTPEnvelope locks the single-pass wire envelope contract:
+// MarshalHTTPEnvelope renders {"error":{...}} with requestId injected into the
+// inner error object (omitted when empty), applies the 5xx detail-strip +
+// public-code normalization via PublicProjection, and preserves int64 detail
+// precision (no map[string]any float64 coercion). This is the choke point all
+// HTTP error responses funnel through (pkg/httputil.writeErrorBody).
+func TestError_MarshalHTTPEnvelope(t *testing.T) {
+	t.Parallel()
+
+	const bigInt int64 = 9007199254740993 // 2^53 + 1, not representable in float64
+
+	t.Run("4xx with details and requestID", func(t *testing.T) {
+		t.Parallel()
+		ec := New(KindNotFound, ErrCellNotFound, "cell not found",
+			WithDetails(PublicString("cellId", "abc"), PublicInt("retryCount", 3)))
+		raw, err := ec.MarshalHTTPEnvelope("req-123")
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"error":{"code":"ERR_CELL_NOT_FOUND","message":"cell not found",`+
+				`"details":[{"key":"cellId","value":"abc"},{"key":"retryCount","value":3}],`+
+				`"requestId":"req-123"}}`,
+			string(raw))
+	})
+
+	t.Run("empty requestID omits the key", func(t *testing.T) {
+		t.Parallel()
+		ec := New(KindInvalid, ErrValidationFailed, "bad input")
+		raw, err := ec.MarshalHTTPEnvelope("")
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "requestId",
+			"omitempty must drop requestId when empty")
+		assert.JSONEq(t,
+			`{"error":{"code":"ERR_VALIDATION_FAILED","message":"bad input","details":[]}}`,
+			string(raw))
+	})
+
+	t.Run("5xx strips details and normalizes code, no operator fields", func(t *testing.T) {
+		t.Parallel()
+		ec := New(KindInternal, ErrAuthRoleFetchFailed, "role lookup failed",
+			WithDetails(PublicString("dsn", "postgres://u:p@h")))
+		raw, err := ec.MarshalHTTPEnvelope("req-5xx")
+		require.NoError(t, err)
+		s := string(raw)
+		assert.Contains(t, s, `"code":"ERR_INTERNAL"`, "5xx code normalized to public sentinel")
+		assert.Contains(t, s, `"details":[]`, "5xx details stripped")
+		assert.NotContains(t, s, "postgres://", "5xx must not leak detail values")
+		assert.NotContains(t, s, "sourceCode", "public envelope must not carry operator fields")
+		assert.NotContains(t, s, `"status"`, "public envelope must not carry operator fields")
+		assert.Contains(t, s, `"requestId":"req-5xx"`)
+	})
+
+	t.Run("int64 detail beyond 2^53 retains precision", func(t *testing.T) {
+		t.Parallel()
+		ec := New(KindInvalid, ErrValidationFailed, "too big",
+			WithDetails(PublicInt("size", bigInt)))
+		raw, err := ec.MarshalHTTPEnvelope("")
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"value":9007199254740993`,
+			"single-pass marshal must not coerce int64 to float64")
+	})
+}

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -2,11 +2,9 @@
 package httputil
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 
@@ -295,71 +293,41 @@ func writeErrcodeError(ctx context.Context, w http.ResponseWriter, label string,
 var sentinelInternalErrorBody = []byte(
 	`{"error":{"code":"ERR_INTERNAL","message":"internal server error","details":[]}}`)
 
-// writeErrorBody serializes ecErr through Error.MarshalJSON so the wire form
-// is governed by the errcode package alone (single source of truth for the
-// details: array<{key,value}> shape and 5xx details strip). requestId is
-// merged into the inner error object before encoding because the canonical
-// error envelope places it alongside code/message/details, not in the outer
-// wrapper (see contracts/shared/errors/error-response-v1.schema.json).
+// writeErrorBody serializes ecErr through errcode.MarshalHTTPEnvelope so the
+// wire form is governed by the errcode package alone (single source of truth
+// for the {"error":{...}} envelope, the details: array<{key,value}> shape, the
+// 5xx details strip, and requestId injection into the inner error object — the
+// canonical envelope places requestId alongside code/message/details, not in
+// the outer wrapper; see contracts/shared/errors/error-response-v1.schema.json).
 //
-// Buffer-then-commit: the full pipeline (marshal → decode → merge → encode)
-// runs into a bytes.Buffer before any header or status is written to w. Only
-// when the buffer is ready does the function commit headers + status + body.
-// Pipeline failure → sentinelInternalErrorBody at HTTP 500 (headers not yet
-// written). ref: oapi-codegen strict-responses pattern.
+// Single-pass marshal: the envelope is produced directly from PublicProjection
+// with no intermediate map[string]any, so int64/uint64 details retain full
+// precision (a map round-trip would coerce them to float64 and truncate beyond
+// 2^53). The prior marshal → decode(UseNumber) → merge → encode round-trip
+// existed only to inject requestId; MarshalHTTPEnvelope does that in one pass.
 //
-// Numeric precision: the merge step decodes ecErr's marshaled bytes back
-// through json.Decoder with UseNumber() so int64/uint64 details survive
-// the round-trip without being coerced to float64. The default decoder
-// would silently truncate any int beyond 2^53.
-//
-// Fail-closed: if any pipeline step fails, the response still gets HTTP 500 +
-// sentinelInternalErrorBody. There is no path that returns an empty 200 body.
-// ref: net/http.Error — stdlib never returns a body without first writing a
-// status; this function holds the same invariant.
+// Marshal-then-commit fail-closed: the body is marshaled into a []byte before
+// any header or status is written. Only on success does the function commit
+// headers + status + body. Marshal failure → sentinelInternalErrorBody at HTTP
+// 500 (headers not yet written). Marshal failure is unreachable in production
+// (sealed PublicDetail scalars + copyDetails filter never fail to marshal); the
+// branch is kept as a defensive guard. There is no path that returns an empty
+// 200 body. ref: net/http.Error — stdlib never returns a body without first
+// writing a status; this function holds the same invariant.
 func writeErrorBody(ctx context.Context, w http.ResponseWriter, status int, ecErr *errcode.Error) {
-	var buf bytes.Buffer
-	if err := encodeErrorEnvelopeTo(&buf, ctx, ecErr); err != nil {
+	reqID, _ := ctxkeys.RequestIDFrom(ctx)
+	body, err := ecErr.MarshalHTTPEnvelope(reqID)
+	if err != nil {
 		attrs := AppendCorrelationAttrs(ctx, []any{slog.Any("error", err)})
-		slog.ErrorContext(ctx, "httputil: encode error envelope", attrs...)
+		slog.ErrorContext(ctx, "httputil: marshal error envelope", attrs...)
 		writeInternalErrorSentinel(w)
 		return
 	}
 	w.Header().Set(headerContentType, contentTypeJSON)
 	w.WriteHeader(status)
-	if _, writeErr := buf.WriteTo(w); writeErr != nil {
+	if _, writeErr := w.Write(body); writeErr != nil {
 		slog.Error("httputil: write error response", slog.Any("error", writeErr))
 	}
-}
-
-// encodeErrorEnvelopeTo writes the canonical wire envelope into out, including
-// numeric-precision merge and requestId injection. Returns an error if any
-// step fails — caller writes sentinelInternalErrorBody to the wire instead.
-//
-// Three error paths exist:
-//  1. json.Marshal(ecErr) — unreachable in production: errcode.Error has a
-//     custom MarshalJSON that emits a fixed schema and never returns err.
-//  2. dec.Decode(&inner) — unreachable: input is the bytes we just marshaled,
-//     so it is well-formed JSON object by construction.
-//  3. json.NewEncoder(out).Encode(...) — reachable: io.Writer can fail (this
-//     is the path TestEncodeErrorEnvelopeTo_FailingWriter exercises).
-func encodeErrorEnvelopeTo(out io.Writer, ctx context.Context, ecErr *errcode.Error) error {
-	innerJSON, err := json.Marshal(ecErr)
-	if err != nil {
-		return err
-	}
-	dec := json.NewDecoder(bytes.NewReader(innerJSON))
-	dec.UseNumber()
-	var inner map[string]any
-	if err := dec.Decode(&inner); err != nil {
-		return err
-	}
-	if reqID, ok := ctxkeys.RequestIDFrom(ctx); ok {
-		inner["requestId"] = reqID
-	}
-	return json.NewEncoder(out).Encode(map[string]any{
-		"error": inner,
-	})
 }
 
 // writeInternalErrorSentinel writes a hard-coded 500 response with the

--- a/pkg/httputil/response_test.go
+++ b/pkg/httputil/response_test.go
@@ -566,10 +566,11 @@ func TestWriteErrorBody_HappyPathStatusReachesWire(t *testing.T) {
 // TestWriteErrorBody_FailClosedOnMarshalFailure verifies writeErrorBody's
 // fail-closed contract via the sentinel writer in isolation: marshal
 // failure → 500 + canonical body. The body+status invariant is validated
-// directly because reaching the in-flow marshal-error branch would require
-// monkey-patching encoding/json (not a useful test seam). With the sealed
-// PublicDetail newtype, a non-serializable value injected via direct field
-// assignment triggers this path (see TestWriteError_DetailsBypassFencedBySentinel).
+// directly because the in-flow marshal-error branch is unreachable in
+// production — errcode.MarshalHTTPEnvelope cannot fail for any value the
+// sealed PublicDetail newtype admits (copyDetails filters invalid entries;
+// every wire-safe scalar marshals cleanly), so the branch is a defensive
+// guard rather than a reachable test seam.
 func TestWriteErrorBody_FailClosedOnMarshalFailure(t *testing.T) {
 	rec := httptest.NewRecorder()
 	writeInternalErrorSentinel(rec)
@@ -672,10 +673,11 @@ func TestLog5xx_DetailsRedacted(t *testing.T) {
 }
 
 // TestWriteErrorBody_PreservesInt64Precision verifies that int64 detail
-// values larger than 2^53 round-trip through writeErrorBody without
-// precision loss. The default json.Decoder coerces JSON numbers into
-// float64 for map[string]any, which silently truncates anything beyond
-// 2^53 — writeErrorBody mitigates this with json.Decoder.UseNumber().
+// values larger than 2^53 reach the wire without precision loss. The single-
+// pass errcode.MarshalHTTPEnvelope path encodes int64 directly (json.Marshal
+// is exact); there is no intermediate map[string]any that would coerce JSON
+// numbers to float64 and silently truncate anything beyond 2^53. This is the
+// regression guard for the round-trip removal in issue #622.
 //
 // Reproduces the "Medium F4" finding from PR #391 round-2 review:
 // slog.Int64("size", 9007199254740993) would otherwise lose precision.
@@ -694,36 +696,4 @@ func TestWriteErrorBody_PreservesInt64Precision(t *testing.T) {
 	// notation, no ".0", no "9007199254740992" rounding.
 	assert.Contains(t, rec.Body.String(), `"value":9007199254740993`,
 		"int64 detail must round-trip without precision loss")
-}
-
-// ioFailingWriter is a writer that fails after writing failAfter bytes.
-// Used to exercise the io.Writer error path in encodeErrorEnvelopeTo.
-type ioFailingWriter struct {
-	failAfter int
-	written   int
-}
-
-func (w *ioFailingWriter) Write(p []byte) (int, error) {
-	if w.written >= w.failAfter {
-		return 0, errors.New("simulated io failure")
-	}
-	n := len(p)
-	if n > w.failAfter-w.written {
-		n = w.failAfter - w.written
-	}
-	w.written += n
-	return n, nil
-}
-
-// TestEncodeErrorEnvelopeTo_FailingWriter verifies that encodeErrorEnvelopeTo
-// propagates a write error when the underlying io.Writer fails. This is only
-// reachable now that the parameter type is io.Writer (not *bytes.Buffer), which
-// makes the function directly testable with a synthetic failing writer.
-func TestEncodeErrorEnvelopeTo_FailingWriter(t *testing.T) {
-	ec := errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "fail path test")
-	w := &ioFailingWriter{failAfter: 0}
-	err := encodeErrorEnvelopeTo(w, context.Background(), ec)
-	if err == nil {
-		t.Fatal("want err on io failure, got nil")
-	}
 }


### PR DESCRIPTION
## Summary

每个 HTTP 错误响应（含全部 codegen typed-envelope 错误结构，经 `WriteErrorWithStatus` 汇聚）都走唯一 choke point `pkg/httputil.writeErrorBody`，此前执行**三趟 JSON**：`json.Marshal(ecErr)` → `json.Decode` 进 `map[string]any`（`UseNumber()`）→ 重新 `Encode`。第 2/3 趟 round-trip 唯一目的是把 ctx 的 `requestId` 注入内层 error 对象；`UseNumber()` 只是抵消第 2 趟 decode 自身引入的 float64 截断。HTTP 错误是 hot path，三趟是纯开销。

本 PR 让 errcode 单趟 marshal 产出完整 wire envelope：

- 新增 `errcode.(*Error).MarshalHTTPEnvelope(requestID)`：从 `PublicProjection` 一趟 `json.Marshal` 出 `{"error":{…,"requestId":…}}`。
- 内层对象用**专用窄类型** `httpErrorObject{code,message,details,requestId}`（unexported）：operator-only `SourceCode/Status` 字段在类型层**不可表达**，绝不会泄漏到 HTTP wire（不是靠 `omitempty` 零值巧合）。`requestId` `omitempty`，ctx 无 request id 时省略。
- `int64` detail 精度天然保留——不再经过会强转 float64 的 `map[string]any`。
- `writeErrorBody` 收敛为直接 marshal-then-commit（fail-closed 不变式保留）；删除 `encodeErrorEnvelopeTo`、`bytes.Buffer`、`bytes`/`io` import，以及仅为该 helper 测试 seam 而生的 `ioFailingWriter` + `TestEncodeErrorEnvelopeTo_FailingWriter`（`w.Write` 失败路径仍由 `TestWriteError_EncodeFail` 覆盖）。

净删代码；HTTP wire error-object 形状由 `httpErrorObject` 单一承载，operator 字段类型层隔离。

Closes #622
Refs: PR #391 review round-2

## Test plan
- [x] `go build ./...` + `go build -tags=integration ./...`（clean）
- [x] `go test ./pkg/errcode/... ./pkg/httputil/...`（含 `-tags=integration`，green）；`go vet` + `gofmt` clean
- [x] `TestError_MarshalHTTPEnvelope`：4xx+details+requestID / 空 requestID omitempty / 5xx strip+code 归一+**无 operator 字段** / int64 2^53+1 精度 / nil-receiver 兜底
- [x] 现有回归保留：requestId 注入（4xx/5xx/typed-404/typed-500）、`TestWriteErrorBody_PreservesInt64Precision`、fail-closed sentinel
- [x] `golangci-lint run ./pkg/errcode/... ./pkg/httputil/...` → 0 issues
- [x] 全量 `go test ./...`：仅 4 个 archtest 在**未触碰包**（cmd/corebundle 行数、kernel/reconcile DAG、tools/archtest scanner 用法）失败，已 stash 验证为 base 分支 pre-existing，与本 PR 无关

## Review 处理
- **F1（架构/安全，双 reviewer P1）**：requestId 原放在共享 `PublicError` 上使 operator 字段仅靠 omitempty 防泄漏 → 改用窄类型 `httpErrorObject`，类型层隔离（commit `88fc52f0b`）。
- nil-receiver 测试 + caller-contract godoc（commit `14098caae`）。
- slog 消息 rename（`encode`→`marshal`）经 grep 确认无 dashboard/alert 依赖。

## AI-robust
bugfix，不属约束 enforcement 机制范围，不新增 archtest（为它立 archtest 只能是 Soft，严禁立项）。robust 增益 = HTTP wire error-object 收敛到 `httpErrorObject` 单一窄类型，operator 字段类型层不可达。

🤖 Generated with [Claude Code](https://claude.com/claude-code)