### PR TITLE
feat(webhook): KERNEL-WEBHOOK-01 PR-5 — dispatcher + retry Classify + signer/SSRF archtest + ADR [#1160]

### DIFF
--- a/contracts/webhook/README.md
+++ b/contracts/webhook/README.md
@@ -10,19 +10,20 @@ in one of two directions:
 | `inbound` | receiver（接收外部回调，HMAC + timestamp + Claimer 三重保护） | `webhook-receive` | 外部 source 推送给我们 |
 | `outbound` | dispatcher（签名后推送，SSRF 防御 + 退避重试） | `webhook-dispatch` | 我们推送给外部 target |
 
-> **Scope note (PR-2 → PR-3 landed)**: 本目录与 cellgen 派生覆盖**契约识别 + 代码生成层**。
+> **Scope note (PR-2 → PR-5 landed)**: 本目录与 cellgen 派生覆盖**契约识别 + 代码生成层**。
 > PR-3（#1158）已落地 receiver 运行时（`runtime/webhook`：`Receiver`、`BuildRouteGroups`、
 > `bootstrap` phase5 drain），`reg.RegisterWebhookReceiver` 方法本体及 HTTP 接收 pipeline
 > 均已实现。kernel 纯计算内核（Signer/Verifier/Source）已在 PR-1（#1251）落地于 `kernel/webhook/`。
+> PR-4（#1159）已落地 SSRF guard（`kernel/webhook.SafePolicy`）。
+> PR-5（#1160）已落地 dispatcher 运行时（`kernel/webhook.Dispatcher` + retry/Classify、
+> `runtime/webhook/dispatch` outbox consumer、bootstrap drain），`reg.RegisterWebhookDispatch`
+> 方法本体已实现。
 >
-> 仍待后续 PR 落地：SSRF guard（PR-4）、dispatcher outbox consumer（PR-5）、
-> healthz/metrics 探针（PR-6，KERNEL-WEBHOOK-01）。
+> 仍待后续 PR 落地：healthz/metrics 探针（PR-6，KERNEL-WEBHOOK-01）。
 >
-> **PR-3 之后的排序约束**：`gocell generate cell` 现可为声明 `contractUsages[role=webhook-receive]`
-> 的 slice 派生 `reg.RegisterWebhookReceiver` 调用（方法本体已存在）。第一个真实 webhook cell
-> demo 在 PR-6 落地。dispatcher 路径（PR-5）落地前，`contractUsages[role=webhook-dispatch]`
-> 的 cellgen 派生仍引用未实现的 `reg.RegisterWebhookDispatch`，会导致编译失败——这是有意的
-> seam 排序，不是缺陷。
+> **PR-5 之后的排序约束**：`gocell generate cell` 现可为声明 `contractUsages[role=webhook-receive]`
+> 或 `contractUsages[role=webhook-dispatch]` 的 slice 派生对应注册调用（两个方法本体均已存在）。
+> 第一个真实 webhook cell demo 在 PR-6 落地。
 >
 > **codegen 零产物语义**：webhook 契约即便 `codegen: true`，contractgen 也**有意产出零
 > per-contract 产物**（注册经 cellgen 字面量，不经 contractgen；见 `generator.go` webhook 分支
@@ -154,7 +155,7 @@ func (c *PaymentCoreCell) Init(ctx context.Context, reg cell.Registrar) error {
 `webhook.ReceiverSpec` / `DispatchSpec` 是 `kernel/webhook` 的纯数据结构；`CellID` 作为字面量
 由 cellgen 从 cell.yaml 注入（observability owner 溯源 cell 元数据，与 `reg.Subscribe` 的位置
 cellID 同源约束）。`reg.RegisterWebhookReceiver` 方法本体已在 PR-3（#1158）落地；
-`reg.RegisterWebhookDispatch` 在 PR-5 落地。
+`reg.RegisterWebhookDispatch` 已在 PR-5（#1160）落地。
 
 ## 静态守卫（archtest）
 

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -59,26 +59,33 @@ backoff, capped 30 s). `RetrySchedule.DelayFor` is the seam the follow-up
 
 ### D2 — HTTP status code → `outbox.HandleResult` mapping (standard-webhooks aligned)
 
+> **Amendment 2026-06-02 (review #1455, finding F3).** D2 originally rejected 3xx
+> and all 4xx (except 408/429) as **permanent**. That contradicted this ADR's own
+> "standard-webhooks / Svix aligned" claim: Svix, Standard Webhooks, and Convoy
+> all treat **every non-2xx as a delivery failure the sender retries** — the
+> sender cannot tell a permanent 4xx (e.g. a receiver bug) from a transient one
+> (secret rotation → 401, deploy gap → 404, throttle). The mapping below is the
+> amended, aligned truth; the pre-amendment "Reject 4xx/3xx" rows are removed (no
+> dual truth source, per `.claude/rules/gocell/ai-robust.md` "ADR amendment 落地必查").
+
 The single classification function is `kernel/webhook/retry.go::Classify(statusCode
-int, transportErr error) outbox.Disposition`.
+int, transportErr error) outbox.Disposition`. The rule is now simply: **2xx → Ack;
+every other status → Requeue; an SSRF-blocked transport error → Reject**.
 
 | Outcome | Disposition | Rationale |
 |---------|-------------|-----------|
-| 2xx | `DispositionAck` (Ack) | Delivery succeeded. |
-| 5xx | `DispositionRequeue` (transient) | Server-side fault; the request itself is well-formed, a retry after back-off is appropriate. Aligned with Svix, Convoy, and the standard-webhooks guidance that senders should retry on server errors. |
-| 408 Request Timeout | `DispositionRequeue` (transient) | The server timed out processing the request; back off and retry is the spec-recommended sender behaviour. |
-| 429 Too Many Requests | `DispositionRequeue` (transient) | Throttled; the standard-webhooks spec asks senders to respect rate limits and retry. |
-| 3xx | `DispositionReject` (permanent → DLX) | Redirects are denied at the transport layer by `SafePolicy.DenyRedirect` and surface as an SSRF transport error (see below); they never reach status classification in practice. If one did reach this branch, a redirect indicates the target endpoint has moved and won't become valid on retry without operator intervention. |
-| Other 4xx (400, 401, 403, 404, 410, …) | `DispositionReject` (permanent → DLX) | The request itself is malformed, unauthorized, forbidden, or targeting a non-existent resource. Retrying an identical request against the same endpoint will not produce a different result. Svix and Convoy treat the 4xx set (excluding 408/429) as permanent. |
-| SSRF-blocked (`ErrWebhookSSRFBlocked`) | `DispositionReject` (permanent → DLX) | A misconfigured or hostile target URL (bad scheme, blocked dial, denied redirect). The target will not become safe on retry; operator intervention is required to correct the webhook endpoint registration. |
-| Transport timeout / connection refused / network error (non-SSRF) | `DispositionRequeue` (transient) | Transient connectivity fault; retry after back-off. |
+| 2xx | `DispositionAck` (Ack) | Delivery succeeded — the only acknowledgement. |
+| Every non-2xx status (3xx, 4xx, 5xx) | `DispositionRequeue` (transient) | standard-webhooks / Svix: the receiver MUST return 2xx to acknowledge; any other status is a delivery failure. A receiver's 4xx/3xx is usually transient on its side (deploy gap → 404, secret rotation → 401, throttle → 429, server fault → 5xx), and the sender cannot distinguish permanent from transient — so it retries until the budget is exhausted, at which point `ConsumerBase` escalates to Reject → DLX. |
+| SSRF-blocked (`ErrWebhookSSRFBlocked`) | `DispositionReject` (permanent → DLX) | A misconfigured or hostile target URL (bad scheme, embedded userinfo, blocked dial, denied redirect). The target will not become safe on retry; operator intervention is required to correct the webhook endpoint registration. This is the **only** permanent classification outcome. |
+| DNS resolution failure / connection refused / timeout / network error (non-SSRF) | `DispositionRequeue` (transient) | Transient connectivity fault; retry after back-off. A DNS failure is fail-closed at the dial layer (no connection is made) but is **not** an SSRF block — conflating "could not resolve" with "resolved to a blocked address" would permanently dead-letter deliveries on a DNS hiccup (review #1455 F1). |
 
-**Note on 3xx**: in normal operation 3xx responses never reach the `Classify`
-switch because `SafePolicy.DenyRedirect` (wired as the `*http.Client`
+**Note on 3xx and redirects**: a 3xx status almost never reaches the `Classify`
+status branch, because `SafePolicy.DenyRedirect` (wired as the `*http.Client`
 `CheckRedirect`) returns an error on the first redirect, which surfaces as a
-transport error carrying `ErrWebhookSSRFBlocked` → `DispositionReject`.
-The 3xx row in the table describes the fallback behaviour if that layer were
-absent or bypassed; it is included for completeness and auditability.
+transport error carrying `ErrWebhookSSRFBlocked` → `DispositionReject`. So a
+redirect attempt is **permanent** (an SSRF safety stance: one-shot delivery
+never follows a redirect to a potentially-unvetted Location). A bare 3xx that
+somehow reached the status branch is treated like any other non-2xx → Requeue.
 
 ### D3 — Delivery timeout default 30 s
 
@@ -127,6 +134,19 @@ The sole writer of these headers in the codebase is `(webhook.Headers).Apply`
 `WEBHOOK-SIGNER-FUNNEL-01`. No callsite may call `Header.Set` on these header
 name constants directly.
 
+> **Amendment 2026-06-02 (review #1455).** F9: the `WEBHOOK-SIGNER-FUNNEL-01`
+> scan scope used exact package-path matching, which silently excluded the
+> `runtime/webhook/dispatch` subpackage (the consumer layer that actually calls
+> `Headers.Apply`). The scope is now subtree-matched (`base` or `base+"/"`), so
+> the dispatch subpackage and any future subpackage are covered. F5 (open
+> hardening): `webhook.Headers` is still a public struct with exported fields, so
+> a caller could construct `Headers{Signature: …}.Apply(h)` outside `Signer.Sign`
+> — the funnel locks the *header write site*, not *Headers provenance*. Severity
+> is low (a forged `Headers` carries an invalid HMAC the receiver rejects; no
+> secret is exposed). Closing the gap via sealed construction (unexported fields,
+> only `Signer.Sign` produces `Headers`) is tracked as a backlog item, not done
+> in PR-5.
+
 ### D5 — Schedule is the canonical default seam; per-attempt wall-clock delays and RetryCount are NOT yet wired (explicit boundary + tracked follow-up)
 
 This is the most important honesty section of this ADR.
@@ -167,13 +187,19 @@ explicitly.
   retry interval). PR-5 does NOT set a per-dispatcher `ConsumerBaseConfig.RetryCount`
   from the schedule — `DefaultSvixSchedule` is the canonical default and the
   seam for the broker-delay follow-up (gh #1458), not yet runtime-honored.
-- **Permanent failures** (SSRF-blocked, non-2xx 4xx excluding 408/429, selector
-  error, signing failure, URL validation failure) route to DLX via
-  `outbox.Reject`; operators must inspect the DLX queue and fix the registration
-  before re-enqueuing.
-- **Transient failures** (5xx, 408, 429, transport errors) trigger
-  `ConsumerBase` retry with default backoff; on budget exhaustion they are
-  escalated to Reject → DLX.
+- **Permanent failures** (amended 2026-06-02) are now only: SSRF-blocked target,
+  a selector that signals `ErrWebhookPermanentFailure` (no subscription
+  configured), signing failure, delivery-id derivation failure, and URL
+  validation failure (including embedded userinfo). These route to DLX via
+  `outbox.Reject` at preflight/transport; operators must inspect the DLX queue
+  and fix the registration before re-enqueuing. **Non-2xx delivery responses are
+  no longer permanent** — they are retried (review #1455 F3).
+- **Transient failures** — every non-2xx delivery response (3xx/4xx/5xx) and all
+  non-SSRF transport errors (DNS resolution failure, timeout, connection
+  refused) — trigger `ConsumerBase` retry with default backoff; on budget
+  exhaustion they are escalated to Reject → DLX. A generic target-selector error
+  is also transient (review #1455 F2): a store/config hiccup retries rather than
+  dead-lettering.
 - **Wire protocol**: receivers that verify GoCell outbound webhooks must use the
   `webhook-id` / `webhook-timestamp` / `webhook-signature` header names, not
   `svix-*`. GoCell's example receiver (`kernel/webhook.Verifier`) already uses

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -1,0 +1,199 @@
+# ADR: Webhook retry defaults — Svix schedule, HTTP status mapping, delivery timeout, header names
+
+- Status: Accepted
+- Date: 2026-06-01
+- Context: KERNEL-WEBHOOK-01 PR-5 (#1160)
+- Supersedes / amends: none (greenfield)
+
+## Context
+
+The outbound webhook dispatcher (`kernel/webhook.Dispatcher`, PR-5) delivers
+signed HTTP POST requests to external targets and must define:
+
+1. How many times to retry a failed delivery, and with what inter-attempt delays.
+2. Which HTTP status codes and transport errors are permanent failures (→ DLX)
+   versus transient (→ retry).
+3. How long each single attempt may run before being aborted.
+4. Which header names carry the three signature fields on the wire.
+
+These choices are made once at the kernel level and drive the runtime dispatch
+consumer in `runtime/webhook/dispatch`. Recording them in an ADR makes the
+trade-offs explicit, citable, and auditable.
+
+## Decision
+
+### D1 — Svix retry schedule as the canonical default
+
+`DefaultSvixSchedule()` returns a `RetrySchedule` with **7 retries** after the
+immediate first attempt — **8 deliveries total** — at the following inter-attempt
+delays:
+
+| Retry # | Delay before this attempt |
+|---------|--------------------------|
+| 1       | 5 s                      |
+| 2       | 5 min                    |
+| 3       | 30 min                   |
+| 4       | 2 h                      |
+| 5       | 5 h                      |
+| 6       | 10 h                     |
+| 7       | 10 h                     |
+
+Source of truth: the Svix official retry table at
+`https://docs.svix.com/retries`. The standard-webhooks specification
+(`standard-webhooks/standard-webhooks spec/standard-webhooks.md`) describes a
+10-step variant; we adopt the Svix 8-delivery default as the more widely
+deployed real-world baseline. Operators can override the schedule by providing
+a custom `RetrySchedule` via a future `WithSchedule` option (not in PR-5 scope).
+
+`RetrySchedule.MaxRetries()` returns 7 (the retry count excluding the initial
+attempt); `RetrySchedule.Attempts()` returns 8 (the total delivery count).
+`DefaultSvixSchedule().MaxRetries()` is consumed by the runtime dispatch
+consumer to size `ConsumerBaseConfig.RetryCount` — the schedule is a real
+parameter, not a dead abstraction.
+
+### D2 — HTTP status code → `outbox.HandleResult` mapping (standard-webhooks aligned)
+
+The single classification function is `kernel/webhook/retry.go::Classify(statusCode
+int, transportErr error) outbox.Disposition`.
+
+| Outcome | Disposition | Rationale |
+|---------|-------------|-----------|
+| 2xx | `DispositionAck` (Ack) | Delivery succeeded. |
+| 5xx | `DispositionRequeue` (transient) | Server-side fault; the request itself is well-formed, a retry after back-off is appropriate. Aligned with Svix, Convoy, and the standard-webhooks guidance that senders should retry on server errors. |
+| 408 Request Timeout | `DispositionRequeue` (transient) | The server timed out processing the request; back off and retry is the spec-recommended sender behaviour. |
+| 429 Too Many Requests | `DispositionRequeue` (transient) | Throttled; the standard-webhooks spec asks senders to respect rate limits and retry. |
+| 3xx | `DispositionReject` (permanent → DLX) | Redirects are denied at the transport layer by `SafePolicy.DenyRedirect` and surface as an SSRF transport error (see below); they never reach status classification in practice. If one did reach this branch, a redirect indicates the target endpoint has moved and won't become valid on retry without operator intervention. |
+| Other 4xx (400, 401, 403, 404, 410, …) | `DispositionReject` (permanent → DLX) | The request itself is malformed, unauthorized, forbidden, or targeting a non-existent resource. Retrying an identical request against the same endpoint will not produce a different result. Svix and Convoy treat the 4xx set (excluding 408/429) as permanent. |
+| SSRF-blocked (`ErrWebhookSSRFBlocked`) | `DispositionReject` (permanent → DLX) | A misconfigured or hostile target URL (bad scheme, blocked dial, denied redirect). The target will not become safe on retry; operator intervention is required to correct the webhook endpoint registration. |
+| Transport timeout / connection refused / network error (non-SSRF) | `DispositionRequeue` (transient) | Transient connectivity fault; retry after back-off. |
+
+**Note on 3xx**: in normal operation 3xx responses never reach the `Classify`
+switch because `SafePolicy.DenyRedirect` (wired as the `*http.Client`
+`CheckRedirect`) returns an error on the first redirect, which surfaces as a
+transport error carrying `ErrWebhookSSRFBlocked` → `DispositionReject`.
+The 3xx row in the table describes the fallback behaviour if that layer were
+absent or bypassed; it is included for completeness and auditability.
+
+### D3 — Delivery timeout default 30 s
+
+`defaultDeliveryTimeout = 30 * time.Second` bounds each individual HTTP
+delivery attempt. This is the `*http.Client.Timeout` value set in
+`NewDispatcher`.
+
+Three reference points bracket the choice:
+
+- **Svix**: 15 s (`https://docs.svix.com/retries`).
+- **standard-webhooks spec**: recommends 15–30 s for sender-side timeouts
+  (`standard-webhooks/standard-webhooks spec/standard-webhooks.md`).
+- **Convoy**: 30 s (`https://www.getconvoy.io/docs`).
+
+We default to 30 s — the upper end of the standard-webhooks recommendation and
+Convoy's default — because some downstream receivers perform synchronous work
+(database writes, synchronous API calls) before acknowledging. A generous
+default reduces spurious timeouts that would unnecessarily consume retry budget.
+Operators who need tighter control can call `WithDeliveryTimeout(d)`.
+
+### D4 — Vendor-neutral outbound signature header names
+
+Outbound HTTP deliveries carry three signature headers:
+
+| Header name | Content |
+|-------------|---------|
+| `webhook-id` | Per-delivery identifier (idempotency key on receiver side) |
+| `webhook-timestamp` | Unix seconds as decimal string |
+| `webhook-signature` | One or more space-separated `v1,<base64>` HMAC-SHA256 tokens |
+
+These names are the **standard-webhooks neutral names** defined in
+`standard-webhooks/standard-webhooks spec/standard-webhooks.md`
+(`webhook-id` / `webhook-timestamp` / `webhook-signature`), NOT the
+Svix-branded `svix-id` / `svix-timestamp` / `svix-signature`.
+
+Rationale: GoCell is the **sender** defining its own outbound protocol. Embedding
+a third-party vendor name (`svix-*`) in GoCell's own protocol header names would
+be inappropriate — it implies a dependency on Svix's naming that GoCell does not
+have. The signed content format (concatenated `"{id}.{timestamp}.{body}"`),
+HMAC-SHA256, and the `v1,<base64>` token format are identical to the signer
+implementation (`kernel/webhook/signer.go`) and are Svix/standard-webhooks
+aligned; only the header names are GoCell's deliberate choice.
+
+The sole writer of these headers in the codebase is `(webhook.Headers).Apply`
+(`kernel/webhook/webhook.go`), locked downstream by archtest
+`WEBHOOK-SIGNER-FUNNEL-01`. No callsite may call `Header.Set` on these header
+name constants directly.
+
+### D5 — Schedule drives retry budget; exact per-attempt wall-clock delays are NOT yet honoured (explicit boundary + tracked follow-up)
+
+This is the most important honesty section of this ADR.
+
+`DefaultSvixSchedule().MaxRetries()` sizes `ConsumerBaseConfig.RetryCount` in
+the runtime dispatch consumer. The schedule is **genuinely consumed** at the
+constructor site; it is not a dead abstraction.
+
+**However**, the exact per-attempt wall-clock delays (5 s → 5 min → 30 min →
+2 h → 5 h → 10 h → 10 h, totalling approximately 40 h) are **NOT yet honoured
+at runtime**. `kernel/outbox.ConsumerBase` uses in-process exponential backoff
+with a hard cap at 30 s per retry interval. It has no mechanism to hold a 10 h
+delay across process restarts — it would require broker-level delayed re-delivery
+(e.g. RabbitMQ `x-delayed-message`, a delayed queue, or a scheduler) that
+GoCell does not yet wire for the dispatch consumer.
+
+This gap is **deliberate and explicitly tracked**, not silent. The schedule is
+retained in the implementation because honouring the full Svix timeline is a
+real future need: the `RetrySchedule` type and `DelayFor(n int)` method
+provide exactly the per-retry delay seam that the broker-delay wiring will
+consume. Removing the schedule now and re-adding it later would be churn with
+no benefit.
+
+The follow-up work — broker-delay long-schedule wiring for the dispatch consumer
+(extend `ConsumerBase` per-attempt delay, or replace with a delay-aware relay
+that calls `DelayFor(attemptNumber)`) — is registered as a backlog item
+(label: `cap-webhook`, `pri-p2`).
+
+The `RetrySchedule` godoc (`kernel/webhook/retry.go`) also states this gap
+explicitly:
+
+> PR-5 scope: the schedule is the canonical default and drives the consumer's
+> retry budget (MaxRetries == len(delays)); the exact per-attempt wall-clock
+> delays are NOT yet honoured by the in-process ConsumerBase backoff (capped at
+> 30s). Honouring the full Svix timeline (up to ~40h) needs broker-delay
+> support and is a tracked follow-up (see ADR webhook-retry-default). The
+> schedule is retained because that follow-up is a real future need, not a dead
+> abstraction.
+
+## Consequences
+
+- **Runtime dispatch consumer** (`runtime/webhook/dispatch`) calls
+  `dispatcher.Schedule().MaxRetries()` to set `ConsumerBaseConfig.RetryCount`
+  to 7; the consumer inherits `ConsumerBase` exponential back-off (capped at
+  30 s) for all seven retries.
+- **Permanent failures** (SSRF-blocked, non-2xx 4xx excluding 408/429, selector
+  error, signing failure, URL validation failure) route to DLX via
+  `outbox.Reject`; operators must inspect the DLX queue and fix the registration
+  before re-enqueuing.
+- **Transient failures** (5xx, 408, 429, transport errors) trigger
+  `ConsumerBase` retry up to `MaxRetries` times; on budget exhaustion they are
+  escalated to Reject → DLX.
+- **Wire protocol**: receivers that verify GoCell outbound webhooks must use the
+  `webhook-id` / `webhook-timestamp` / `webhook-signature` header names, not
+  `svix-*`. GoCell's example receiver (`kernel/webhook.Verifier`) already uses
+  these names.
+- **Broker-delay gap**: until the tracked follow-up lands, high-retry-count
+  deliveries will exhaust their budget faster than the 40 h Svix envelope
+  because ConsumerBase back-off is capped at 30 s per interval rather than
+  honouring the schedule's 2 h / 5 h / 10 h steps.
+
+## References
+
+- Svix retry table: `https://docs.svix.com/retries`
+- standard-webhooks specification: `standard-webhooks/standard-webhooks
+  spec/standard-webhooks.md` (retry guidance; header names `webhook-id` /
+  `webhook-timestamp` / `webhook-signature`)
+- Convoy webhook delivery docs: `https://www.getconvoy.io/docs`
+- ADR `202605312300-1159-adr-webhook-ssrf-policy.md` (SSRF guard; `SafePolicy`
+  and `ErrWebhookSSRFBlocked` referenced in D2)
+- ADR `202605291200-adr-webhook-signing-algorithm.md` (HMAC-SHA256 algorithm;
+  signed content format; `v1,<base64>` token form)
+- ref: svix/svix-webhooks `RetrySchedule` default delays
+- ref: standard-webhooks/standard-webhooks `spec/standard-webhooks.md` timeout
+  and retry guidance
+- ref: getconvoy/convoy `internal/config` delivery timeout default

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -47,9 +47,15 @@ a custom `RetrySchedule` via a future `WithSchedule` option (not in PR-5 scope).
 
 `RetrySchedule.MaxRetries()` returns 7 (the retry count excluding the initial
 attempt); `RetrySchedule.Attempts()` returns 8 (the total delivery count).
-`DefaultSvixSchedule().MaxRetries()` is consumed by the runtime dispatch
-consumer to size `ConsumerBaseConfig.RetryCount` — the schedule is a real
-parameter, not a dead abstraction.
+
+**PR-5 ships `DefaultSvixSchedule` as a tested primitive and the documented
+seam for the broker-delay follow-up. PR-5 does NOT wire per-attempt delays or
+a per-dispatcher RetryCount at runtime**: `Dispatcher` has no schedule field,
+`runtime/webhook/dispatch.BuildConsumers` never sets `ConsumerBaseConfig.RetryCount`,
+and the global `kernel/outbox.ConsumerBase` cannot accept a per-dispatcher
+count. The dispatch consumer rides the shared ConsumerBase (default exponential
+backoff, capped 30 s). `RetrySchedule.DelayFor` is the seam the follow-up
+(gh #1458) will consume.
 
 ### D2 — HTTP status code → `outbox.HandleResult` mapping (standard-webhooks aligned)
 
@@ -121,66 +127,62 @@ The sole writer of these headers in the codebase is `(webhook.Headers).Apply`
 `WEBHOOK-SIGNER-FUNNEL-01`. No callsite may call `Header.Set` on these header
 name constants directly.
 
-### D5 — Schedule drives retry budget; exact per-attempt wall-clock delays are NOT yet honoured (explicit boundary + tracked follow-up)
+### D5 — Schedule is the canonical default seam; per-attempt wall-clock delays and RetryCount are NOT yet wired (explicit boundary + tracked follow-up)
 
 This is the most important honesty section of this ADR.
 
-`DefaultSvixSchedule().MaxRetries()` sizes `ConsumerBaseConfig.RetryCount` in
-the runtime dispatch consumer. The schedule is **genuinely consumed** at the
-constructor site; it is not a dead abstraction.
+**PR-5 does NOT wire per-attempt delays or a per-dispatcher RetryCount at
+runtime.** Specifically:
 
-**However**, the exact per-attempt wall-clock delays (5 s → 5 min → 30 min →
-2 h → 5 h → 10 h → 10 h, totalling approximately 40 h) are **NOT yet honoured
-at runtime**. `kernel/outbox.ConsumerBase` uses in-process exponential backoff
-with a hard cap at 30 s per retry interval. It has no mechanism to hold a 10 h
-delay across process restarts — it would require broker-level delayed re-delivery
-(e.g. RabbitMQ `x-delayed-message`, a delayed queue, or a scheduler) that
-GoCell does not yet wire for the dispatch consumer.
+- `Dispatcher` has no schedule field.
+- `runtime/webhook/dispatch.BuildConsumers` never sets
+  `ConsumerBaseConfig.RetryCount` from the schedule.
+- The global `kernel/outbox.ConsumerBase` cannot accept a per-dispatcher retry
+  count; the dispatch consumer rides the shared ConsumerBase with its default
+  exponential backoff capped at 30 s.
 
-This gap is **deliberate and explicitly tracked**, not silent. The schedule is
-retained in the implementation because honouring the full Svix timeline is a
-real future need: the `RetrySchedule` type and `DelayFor(n int)` method
-provide exactly the per-retry delay seam that the broker-delay wiring will
-consume. Removing the schedule now and re-adding it later would be churn with
-no benefit.
+The exact per-attempt wall-clock delays (5 s → 5 min → 30 min → 2 h → 5 h →
+10 h → 10 h, totalling approximately 40 h) are therefore **NOT honoured at
+runtime**. Honouring the full Svix timeline requires broker-level delayed
+re-delivery (e.g. RabbitMQ `x-delayed-message`, a delayed queue, or a
+scheduler) that GoCell does not yet wire for the dispatch consumer.
+
+This gap is **deliberate and explicitly tracked**, not silent. `DefaultSvixSchedule`
+is retained as the canonical default because honouring the full Svix timeline
+is a real future need: `RetrySchedule.DelayFor(n int)` is exactly the per-retry
+delay seam the broker-delay wiring will consume. Removing the schedule now and
+re-adding it later would be churn with no benefit.
 
 The follow-up work — broker-delay long-schedule wiring for the dispatch consumer
 (extend `ConsumerBase` per-attempt delay, or replace with a delay-aware relay
-that calls `DelayFor(attemptNumber)`) — is registered as a backlog item
-(label: `cap-webhook`, `pri-p2`).
+that calls `DelayFor(attemptNumber)`) — is tracked at **gh #1458**.
 
 The `RetrySchedule` godoc (`kernel/webhook/retry.go`) also states this gap
-explicitly:
-
-> PR-5 scope: the schedule is the canonical default and drives the consumer's
-> retry budget (MaxRetries == len(delays)); the exact per-attempt wall-clock
-> delays are NOT yet honoured by the in-process ConsumerBase backoff (capped at
-> 30s). Honouring the full Svix timeline (up to ~40h) needs broker-delay
-> support and is a tracked follow-up (see ADR webhook-retry-default). The
-> schedule is retained because that follow-up is a real future need, not a dead
-> abstraction.
+explicitly.
 
 ## Consequences
 
-- **Runtime dispatch consumer** (`runtime/webhook/dispatch`) calls
-  `dispatcher.Schedule().MaxRetries()` to set `ConsumerBaseConfig.RetryCount`
-  to 7; the consumer inherits `ConsumerBase` exponential back-off (capped at
-  30 s) for all seven retries.
+- **Runtime dispatch consumer** (`runtime/webhook/dispatch`) rides the shared
+  `ConsumerBase` with its default exponential back-off (capped at 30 s per
+  retry interval). PR-5 does NOT set a per-dispatcher `ConsumerBaseConfig.RetryCount`
+  from the schedule — `DefaultSvixSchedule` is the canonical default and the
+  seam for the broker-delay follow-up (gh #1458), not yet runtime-honored.
 - **Permanent failures** (SSRF-blocked, non-2xx 4xx excluding 408/429, selector
   error, signing failure, URL validation failure) route to DLX via
   `outbox.Reject`; operators must inspect the DLX queue and fix the registration
   before re-enqueuing.
 - **Transient failures** (5xx, 408, 429, transport errors) trigger
-  `ConsumerBase` retry up to `MaxRetries` times; on budget exhaustion they are
+  `ConsumerBase` retry with default backoff; on budget exhaustion they are
   escalated to Reject → DLX.
 - **Wire protocol**: receivers that verify GoCell outbound webhooks must use the
   `webhook-id` / `webhook-timestamp` / `webhook-signature` header names, not
   `svix-*`. GoCell's example receiver (`kernel/webhook.Verifier`) already uses
   these names.
-- **Broker-delay gap**: until the tracked follow-up lands, high-retry-count
-  deliveries will exhaust their budget faster than the 40 h Svix envelope
-  because ConsumerBase back-off is capped at 30 s per interval rather than
-  honouring the schedule's 2 h / 5 h / 10 h steps.
+- **Broker-delay gap (tracked gh #1458)**: until the follow-up lands, deliveries
+  exhaust their retry budget faster than the 40 h Svix envelope because
+  ConsumerBase back-off is capped at 30 s per interval rather than honouring
+  the schedule's 2 h / 5 h / 10 h steps. `RetrySchedule.DelayFor` is the seam
+  that follow-up will consume.
 
 ## References
 

--- a/kernel/webhook/dispatcher.go
+++ b/kernel/webhook/dispatcher.go
@@ -109,12 +109,12 @@ func NewDispatcher(
 //
 // Consumer: cg-webhook-dispatch (per-cell consumer group)
 // Idempotency: outbox lease_id CAS (producer side); handler is stateless
-// Disposition: Ack on 2xx / Requeue on 5xx·408·429·transport / Reject on other 4xx·3xx·SSRF
+// Disposition: Ack on 2xx / Requeue on every non-2xx + transient transport / Reject on SSRF-blocked + permanent prepare failure
 // DLX: broker-native via DispositionReject -> Nack(requeue=false)
 //
-//	2xx                              → Ack
-//	5xx / 408 / 429 / timeout / conn → Requeue (transient)
-//	other 4xx / 3xx / SSRF-blocked   → Reject  (permanent → DLX)
+//	2xx                                    → Ack
+//	non-2xx (3xx/4xx/5xx) / timeout / conn  → Requeue (transient; standard-webhooks aligned)
+//	SSRF-blocked transport / bad config     → Reject  (permanent → DLX)
 func (d *Dispatcher) Handle(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 	req, fail := d.prepare(ctx, entry)
 	if req == nil {
@@ -128,11 +128,15 @@ func (d *Dispatcher) Handle(ctx context.Context, entry outbox.Entry) outbox.Hand
 		logDelivery(ctx, deliveryID, result.Disposition, reason)
 		return result
 	}
-	defer drainAndClose(resp)
-	reason := statusReason(resp.StatusCode)
-	result := mapDisposition(Classify(resp.StatusCode, nil), reason)
-	logDelivery(ctx, deliveryID, result.Disposition, reason)
-	return result
+	defer func() { _ = resp.Body.Close() }()
+	summary := drainBodySummary(resp.Body)
+	disp := Classify(resp.StatusCode, nil)
+	if disp == outbox.DispositionAck {
+		return outbox.Ack()
+	}
+	reason := statusReason(resp.StatusCode, summary)
+	logDelivery(ctx, deliveryID, disp, reason)
+	return mapDisposition(disp, reason)
 }
 
 // logDelivery emits a structured slog record for non-Ack delivery outcomes.
@@ -160,8 +164,7 @@ func (d *Dispatcher) prepare(ctx context.Context, entry outbox.Entry) (*http.Req
 
 	target, err := d.selector(ctx, payload)
 	if err != nil {
-		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
-			"webhook dispatcher: target selector failed", err))
+		return nil, selectorReason(err)
 	}
 	if err := d.policy.ValidateTargetURL(target); err != nil {
 		return nil, outbox.Reject(err) // already ErrWebhookSSRFBlocked
@@ -215,27 +218,43 @@ func transportReason(err error) error {
 		"webhook dispatcher: delivery transport error", err)
 }
 
-// statusReason builds the diagnostic error for a non-2xx response. The status
-// code is server-side only (Internal) — it is not wire-relevant for a dispatch
-// consumer. Transient vs permanent mirrors Classify.
-func statusReason(status int) error {
-	transient := status == http.StatusRequestTimeout ||
-		status == http.StatusTooManyRequests || status >= 500
-	if transient {
-		return errcode.New(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
-			"webhook dispatcher: transient non-success delivery response",
-			errcode.WithInternal(errcode.InternalAttr("status_code", status)))
+// selectorReason maps a target-selector error to a disposition result. A
+// selector that signals ErrWebhookPermanentFailure (e.g. no subscription is
+// configured for the event) is permanent → Reject; any other error (a store /
+// config lookup hiccup) is transient → Requeue, so an infrastructure blip does
+// not dead-letter the delivery. Mirrors the SSRF-tag inspection in
+// transportReason: the disposition is driven by the error's errcode, not by a
+// blanket assumption that all selector failures are permanent.
+func selectorReason(err error) outbox.HandleResult {
+	var ee *errcode.Error
+	if errors.As(err, &ee) && ee.Code == errcode.ErrWebhookPermanentFailure {
+		return outbox.Reject(ee)
 	}
-	return errcode.New(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
-		"webhook dispatcher: permanent non-success delivery response",
-		errcode.WithInternal(errcode.InternalAttr("status_code", status)))
+	return outbox.Requeue(errcode.Wrap(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
+		"webhook dispatcher: target selector failed", err))
 }
 
-// drainAndClose drains a bounded prefix of the response body (for keep-alive
-// reuse) and closes it.
-func drainAndClose(resp *http.Response) {
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, dispatchBodyDrainLimit))
-	_ = resp.Body.Close()
+// statusReason builds the transient diagnostic error for a non-2xx response. Per
+// Classify (standard-webhooks aligned) every non-2xx status is a transient
+// delivery failure, so there is a single outcome here. The status code and the
+// bounded response-body summary are server-side only (Internal) — never
+// wire-relevant for a dispatch consumer — and are sink-redacted in slog; they
+// aid debugging which receiver rejected and why.
+func statusReason(status int, bodySummary string) error {
+	return errcode.New(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
+		"webhook dispatcher: non-success delivery response",
+		errcode.WithInternal(
+			errcode.InternalAttr("status_code", status),
+			errcode.InternalAttr("response_body", bodySummary)))
+}
+
+// drainBodySummary reads a bounded prefix of the response body
+// (≤ dispatchBodyDrainLimit) so the connection can be reused for keep-alive and
+// returns it as a diagnostic summary. The summary is attached to the non-2xx
+// Internal diagnostic (server-side slog only, sink-redacted, never on the wire).
+func drainBodySummary(body io.Reader) string {
+	b, _ := io.ReadAll(io.LimitReader(body, dispatchBodyDrainLimit))
+	return string(b)
 }
 
 // Compile-time assertion: Dispatcher.Handle satisfies outbox.EntryHandler.

--- a/kernel/webhook/dispatcher.go
+++ b/kernel/webhook/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -33,7 +34,7 @@ const dispatchBodyDrainLimit = 4 << 10 // 4 KiB
 // Construct via [NewDispatcher]; the zero value is invalid. All HTTP egress
 // flows through an *http.Client built from the injected [SafePolicy] — there is
 // no client-injection option, so SSRF protection cannot be bypassed
-// (WEBHOOK-SSRF-GUARD-01 downstream).
+// (WEBHOOK-SSRF-GUARD-01 downstream; see tools/archtest/webhook_ssrf_guard_test.go).
 type Dispatcher struct {
 	clk      clock.Clock
 	signer   Signer
@@ -106,6 +107,11 @@ func NewDispatcher(
 // Handle implements [outbox.EntryHandler]: it delivers one outbound webhook and
 // maps the outcome to a disposition via [Classify].
 //
+// Consumer: cg-webhook-dispatch (per-cell consumer group)
+// Idempotency: outbox lease_id CAS (producer side); handler is stateless
+// Disposition: Ack on 2xx / Requeue on 5xx·408·429·transport / Reject on other 4xx·3xx·SSRF
+// DLX: broker-native via DispositionReject -> Nack(requeue=false)
+//
 //	2xx                              → Ack
 //	5xx / 408 / 429 / timeout / conn → Requeue (transient)
 //	other 4xx / 3xx / SSRF-blocked   → Reject  (permanent → DLX)
@@ -114,12 +120,35 @@ func (d *Dispatcher) Handle(ctx context.Context, entry outbox.Entry) outbox.Hand
 	if req == nil {
 		return fail
 	}
+	deliveryID := entry.ID()
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return mapDisposition(Classify(0, err), transportReason(err))
+		reason := transportReason(err)
+		result := mapDisposition(Classify(0, err), reason)
+		logDelivery(ctx, deliveryID, result.Disposition, reason)
+		return result
 	}
 	defer drainAndClose(resp)
-	return mapDisposition(Classify(resp.StatusCode, nil), statusReason(resp.StatusCode))
+	reason := statusReason(resp.StatusCode)
+	result := mapDisposition(Classify(resp.StatusCode, nil), reason)
+	logDelivery(ctx, deliveryID, result.Disposition, reason)
+	return result
+}
+
+// logDelivery emits a structured slog record for non-Ack delivery outcomes.
+// delivery_id is the outbox entry ID used as the per-delivery idempotency key.
+// Payload, Source, and Signer are never logged to avoid secret leakage.
+func logDelivery(ctx context.Context, deliveryID string, disp outbox.Disposition, err error) {
+	switch disp {
+	case outbox.DispositionReject:
+		slog.ErrorContext(ctx, "webhook dispatcher: permanent delivery failure",
+			slog.String("delivery_id", deliveryID),
+			slog.Any("error", err))
+	case outbox.DispositionRequeue:
+		slog.WarnContext(ctx, "webhook dispatcher: transient delivery failure",
+			slog.String("delivery_id", deliveryID),
+			slog.Any("error", err))
+	}
 }
 
 // prepare runs the per-entry preflight (select target → vet URL → derive
@@ -169,6 +198,7 @@ func mapDisposition(disp outbox.Disposition, reason error) outbox.HandleResult {
 	case outbox.DispositionReject:
 		return outbox.Reject(reason)
 	default:
+		// DispositionRequeue + any unknown future disposition -> Requeue (fail-closed; never silently Ack)
 		return outbox.Requeue(reason)
 	}
 }

--- a/kernel/webhook/dispatcher.go
+++ b/kernel/webhook/dispatcher.go
@@ -1,0 +1,212 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// defaultDeliveryTimeout bounds a single outbound delivery attempt. 30s sits at
+// the upper end of the standard-webhooks recommendation (15–30s) and matches
+// Convoy's default; Svix uses 15s. The generous default gives downstream
+// receivers room to process synchronously; tighten via WithDeliveryTimeout.
+const defaultDeliveryTimeout = 30 * time.Second
+
+// dispatchBodyDrainLimit bounds how much of a response body is drained to allow
+// HTTP keep-alive connection reuse. The body is otherwise irrelevant — only the
+// status code drives the disposition.
+const dispatchBodyDrainLimit = 4 << 10 // 4 KiB
+
+// Dispatcher delivers an outbound webhook for each consumed outbox [outbox.Entry]:
+// it selects the target URL, vets it against the SSRF policy, HMAC-signs the
+// payload, POSTs it, and maps the outcome to an [outbox.HandleResult]. It
+// implements [outbox.EntryHandler] via [Dispatcher.Handle].
+//
+// Construct via [NewDispatcher]; the zero value is invalid. All HTTP egress
+// flows through an *http.Client built from the injected [SafePolicy] — there is
+// no client-injection option, so SSRF protection cannot be bypassed
+// (WEBHOOK-SSRF-GUARD-01 downstream).
+type Dispatcher struct {
+	clk      clock.Clock
+	signer   Signer
+	policy   *SafePolicy
+	selector WebhookDispatchSelector
+	client   *http.Client
+	timeout  time.Duration
+}
+
+// DispatcherOption customizes a Dispatcher at construction time.
+type DispatcherOption func(*Dispatcher)
+
+// WithDeliveryTimeout overrides the per-attempt delivery timeout
+// (default defaultDeliveryTimeout). A non-positive value is ignored.
+func WithDeliveryTimeout(d time.Duration) DispatcherOption {
+	return func(dp *Dispatcher) {
+		if d > 0 {
+			dp.timeout = d
+		}
+	}
+}
+
+// NewDispatcher constructs a Dispatcher. clk is the mandatory positional clock
+// (CLOCK-POSITIONAL-INJECTION-01). signer, policy, and selector are mandatory;
+// a nil argument returns an [errcode.ErrWebhookConfigInvalid] error. The
+// outbound *http.Client is always built internally from policy — its
+// DialContext (resolve→vet→dial) and DenyRedirect (3xx deny-all) are wired so
+// every request is SSRF-vetted.
+func NewDispatcher(
+	clk clock.Clock,
+	signer Signer,
+	policy *SafePolicy,
+	selector WebhookDispatchSelector,
+	opts ...DispatcherOption,
+) (*Dispatcher, error) {
+	clock.MustHaveClock(clk, "webhook.NewDispatcher")
+	if validation.IsNilInterface(signer) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatcher: signer must not be nil")
+	}
+	if policy == nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatcher: SSRF policy must not be nil")
+	}
+	if selector == nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatcher: target selector must not be nil")
+	}
+	d := &Dispatcher{
+		clk:      clk,
+		signer:   signer,
+		policy:   policy,
+		selector: selector,
+		timeout:  defaultDeliveryTimeout,
+	}
+	for _, o := range opts {
+		o(d)
+	}
+	// Build the client AFTER options so WithDeliveryTimeout is honored. The
+	// transport's DialContext and the CheckRedirect both come from the SSRF
+	// policy; there is intentionally no way to inject a foreign client.
+	d.client = &http.Client{
+		Timeout:       d.timeout,
+		Transport:     &http.Transport{DialContext: policy.DialContext},
+		CheckRedirect: policy.DenyRedirect,
+	}
+	return d, nil
+}
+
+// Handle implements [outbox.EntryHandler]: it delivers one outbound webhook and
+// maps the outcome to a disposition via [Classify].
+//
+//	2xx                              → Ack
+//	5xx / 408 / 429 / timeout / conn → Requeue (transient)
+//	other 4xx / 3xx / SSRF-blocked   → Reject  (permanent → DLX)
+func (d *Dispatcher) Handle(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
+	req, fail := d.prepare(ctx, entry)
+	if req == nil {
+		return fail
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return mapDisposition(Classify(0, err), transportReason(err))
+	}
+	defer drainAndClose(resp)
+	return mapDisposition(Classify(resp.StatusCode, nil), statusReason(resp.StatusCode))
+}
+
+// prepare runs the per-entry preflight (select target → vet URL → derive
+// delivery id → sign → build request). On success it returns the request and a
+// zero HandleResult; on failure it returns a nil request and the Reject result
+// to return. Splitting this out keeps Handle's cognitive complexity low.
+func (d *Dispatcher) prepare(ctx context.Context, entry outbox.Entry) (*http.Request, outbox.HandleResult) {
+	payload := entry.Payload()
+
+	target, err := d.selector(ctx, payload)
+	if err != nil {
+		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
+			"webhook dispatcher: target selector failed", err))
+	}
+	if err := d.policy.ValidateTargetURL(target); err != nil {
+		return nil, outbox.Reject(err) // already ErrWebhookSSRFBlocked
+	}
+
+	deliveryID, err := NewDeliveryID(entry.ID())
+	if err != nil {
+		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
+			"webhook dispatcher: outbox entry id is not a valid delivery id", err))
+	}
+	headers, err := d.signer.Sign(payload, d.clk.Now(), deliveryID)
+	if err != nil {
+		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
+			"webhook dispatcher: signing failed", err))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(payload))
+	if err != nil {
+		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
+			"webhook dispatcher: build request failed", err))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	headers.Apply(req.Header) // SOLE sanctioned signature-header writer.
+	return req, outbox.HandleResult{}
+}
+
+// mapDisposition converts a [Classify] disposition to an [outbox.HandleResult].
+// reason is the diagnostic error for the non-Ack branches; it is ignored for
+// Ack.
+func mapDisposition(disp outbox.Disposition, reason error) outbox.HandleResult {
+	switch disp {
+	case outbox.DispositionAck:
+		return outbox.Ack()
+	case outbox.DispositionReject:
+		return outbox.Reject(reason)
+	default:
+		return outbox.Requeue(reason)
+	}
+}
+
+// transportReason builds the diagnostic error for a failed client.Do. An SSRF
+// rejection (already an *errcode.Error tagged ErrWebhookSSRFBlocked) is passed
+// through; any other transport fault becomes a transient delivery error.
+func transportReason(err error) error {
+	var ee *errcode.Error
+	if errors.As(err, &ee) && ee.Code == errcode.ErrWebhookSSRFBlocked {
+		return ee
+	}
+	return errcode.Wrap(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
+		"webhook dispatcher: delivery transport error", err)
+}
+
+// statusReason builds the diagnostic error for a non-2xx response. The status
+// code is server-side only (Internal) — it is not wire-relevant for a dispatch
+// consumer. Transient vs permanent mirrors Classify.
+func statusReason(status int) error {
+	transient := status == http.StatusRequestTimeout ||
+		status == http.StatusTooManyRequests || status >= 500
+	if transient {
+		return errcode.New(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
+			"webhook dispatcher: transient non-success delivery response",
+			errcode.WithInternal(errcode.InternalAttr("status_code", status)))
+	}
+	return errcode.New(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
+		"webhook dispatcher: permanent non-success delivery response",
+		errcode.WithInternal(errcode.InternalAttr("status_code", status)))
+}
+
+// drainAndClose drains a bounded prefix of the response body (for keep-alive
+// reuse) and closes it.
+func drainAndClose(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, dispatchBodyDrainLimit))
+	_ = resp.Body.Close()
+}
+
+// Compile-time assertion: Dispatcher.Handle satisfies outbox.EntryHandler.
+var _ outbox.EntryHandler = (*Dispatcher)(nil).Handle

--- a/kernel/webhook/dispatcher_test.go
+++ b/kernel/webhook/dispatcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,8 +21,12 @@ import (
 const dispatchTestTS = 1700000000
 
 // shortDeliveryTimeout is the per-attempt delivery timeout for the timeout-path
-// test (TEST-TIME-LITERAL-01: named package-level const, not an inline literal).
-const shortDeliveryTimeout = 20 * time.Millisecond
+// test; negativeTimeout exercises the WithDeliveryTimeout non-positive guard
+// (TEST-TIME-LITERAL-01: named package-level consts, not inline literals).
+const (
+	shortDeliveryTimeout = 20 * time.Millisecond
+	negativeTimeout      = -1 * time.Second
+)
 
 func dispatchTestSource(t *testing.T) Source {
 	t.Helper()
@@ -202,4 +207,121 @@ func TestDispatcher_Handle_Timeout_Requeue(t *testing.T) {
 
 	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
 	assert.Equal(t, outbox.DispositionRequeue, res.Disposition)
+}
+
+// T-02: 408 Request Timeout must map to Requeue (covers the statusReason 408
+// branch end-to-end, which is the same as 429 but from the opposite side of
+// the switch: both are explicit cases, so dropping either case fails here).
+func TestDispatcher_Handle_StatusMapping_408Requeue(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusRequestTimeout)
+	}))
+	defer srv.Close()
+
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition,
+		"408 Request Timeout must be transient (Requeue)")
+}
+
+// errSigner is a white-box test stub Signer whose Sign always fails.
+// It implements sealed() because this file is package webhook (white-box).
+type errSigner struct{}
+
+func (errSigner) Sign(_ []byte, _ time.Time, _ DeliveryID) (Headers, error) {
+	return Headers{}, errors.New("inject signer error")
+}
+func (errSigner) sealed() {}
+
+// T-03: a Signer that always errors must produce DispositionReject (permanent
+// failure; signing errors are not transient).
+func TestDispatcher_Handle_SignerError_Reject(t *testing.T) {
+	t.Parallel()
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		errSigner{}, NewSafePolicy(WithAllowLoopback()), staticSelector("http://127.0.0.1/"))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	assert.Equal(t, outbox.DispositionReject, res.Disposition,
+		"signer error must produce Reject (permanent)")
+}
+
+// T-04 SKIPPED — infeasible to isolate the request-build branch deterministically.
+//
+// The request-build branch in prepare() is reached only when
+// http.NewRequestWithContext rejects the URL. URLs with control characters
+// (\x00, \x01, \x7f, etc.) are rejected by url.Parse inside ValidateTargetURL
+// before ever reaching http.NewRequestWithContext — so those cannot isolate
+// the request-build path without also triggering the SSRF pre-flight. URLs with
+// spaces are accepted by url.Parse AND by http.NewRequestWithContext (the stdlib
+// percent-encodes them), so they bypass both checks and reach the dial phase.
+// There is no URL form that passes ValidateTargetURL but fails
+// http.NewRequestWithContext without producing a flaky (network-dependent) test.
+// The branch remains covered by integration if a caller selects a malformed URL
+// at runtime. Tracking: no backlog entry needed (infeasible, not a gap in
+// coverage intent).
+
+// T-05: SSRF blocked at DIAL TIME (DNS-resolved private IP).
+//
+// The existing TestDispatcher_Handle_SSRFBlocked_Reject covers the
+// ValidateTargetURL pre-flight path (IP literal rejected before any dial).
+// This test covers the DIAL-TIME path: a public-looking hostname that passes
+// ValidateTargetURL, but whose DNS lookup (via the fake resolver injected
+// through withResolver) returns a private IP so the SafePolicy.DialContext
+// vet fires and rejects the connection. The transport error wraps the SSRF
+// errcode, which Classify maps to DispositionReject.
+func TestDispatcher_Handle_SSRFBlocked_ViaDialContext_Reject(t *testing.T) {
+	t.Parallel()
+	// Build a SafePolicy with a fake resolver that always returns a private IP.
+	// withResolver is the unexported test seam used by ssrf_test.go.
+	privateResolver := fakeResolver{addrs: []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}}
+	policy := NewSafePolicy(withResolver(privateResolver))
+
+	// The selector returns a public-looking hostname; ValidateTargetURL passes
+	// (no IP literal, scheme is http, host is non-empty). The dial-time vet
+	// then resolves the name and blocks the private IP.
+	sel := staticSelector("http://blocked.example.test/")
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), policy, sel)
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	require.Equal(t, outbox.DispositionReject, res.Disposition,
+		"dial-time SSRF block must produce Reject")
+
+	var ee *errcode.Error
+	require.True(t, errors.As(res.Err, &ee),
+		"res.Err must be *errcode.Error, got %T: %v", res.Err, res.Err)
+	assert.Equal(t, errcode.ErrWebhookSSRFBlocked, ee.Code,
+		"dial-time SSRF error must carry ErrWebhookSSRFBlocked code")
+}
+
+// T-06: WithDeliveryTimeout ignores non-positive durations; the effective
+// timeout stays defaultDeliveryTimeout.
+//
+// White-box test: reads the unexported timeout field directly.
+func TestWithDeliveryTimeout_NonPositiveIgnored(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		d    time.Duration
+	}{
+		{"zero", 0},
+		{"negative", negativeTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+				dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector("http://127.0.0.1/"),
+				WithDeliveryTimeout(tc.d))
+			require.NoError(t, err)
+			assert.Equal(t, defaultDeliveryTimeout, d.timeout,
+				"non-positive duration %v must leave timeout at defaultDeliveryTimeout", tc.d)
+		})
+	}
 }

--- a/kernel/webhook/dispatcher_test.go
+++ b/kernel/webhook/dispatcher_test.go
@@ -1,0 +1,197 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+const dispatchTestTS = 1700000000
+
+func dispatchTestSource(t *testing.T) Source {
+	t.Helper()
+	src, err := NewSource(MustSourceID("dispatch-src"), minSecret())
+	require.NoError(t, err)
+	return src
+}
+
+func dispatchTestSigner(t *testing.T) Signer {
+	t.Helper()
+	s, err := NewHMACSigner(dispatchTestSource(t))
+	require.NoError(t, err)
+	return s
+}
+
+// staticSelector returns a WebhookDispatchSelector that always yields target.
+func staticSelector(target string) WebhookDispatchSelector {
+	return func(_ context.Context, _ []byte) (string, error) { return target, nil }
+}
+
+// newTestEntry builds an outbox Entry with the given payload at the fixed test
+// clock so signing is deterministic.
+func newTestEntry(t *testing.T, payload []byte) outbox.Entry {
+	t.Helper()
+	e, err := outbox.NewEntry(clockmock.New(time.Unix(dispatchTestTS, 0)), context.Background(),
+		"webhook.test.v1", payload)
+	require.NoError(t, err)
+	return e
+}
+
+func TestNewDispatcher_NilDeps(t *testing.T) {
+	t.Parallel()
+	policy := NewSafePolicy(WithAllowLoopback())
+	sel := staticSelector("http://example.test/")
+	signer := dispatchTestSigner(t)
+	clk := clockmock.New(time.Unix(dispatchTestTS, 0))
+
+	t.Run("nil signer", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewDispatcher(clk, nil, policy, sel)
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+	t.Run("nil policy", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewDispatcher(clk, signer, nil, sel)
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+	t.Run("nil selector", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewDispatcher(clk, signer, policy, nil)
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+}
+
+// TestDispatcher_Handle_StatusMapping covers the response-status branch of the
+// disposition mapping against a live loopback server.
+func TestDispatcher_Handle_StatusMapping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status int
+		want   outbox.Disposition
+	}{
+		{"200_ack", http.StatusOK, outbox.DispositionAck},
+		{"202_ack", http.StatusAccepted, outbox.DispositionAck},
+		{"500_requeue", http.StatusInternalServerError, outbox.DispositionRequeue},
+		{"429_requeue", http.StatusTooManyRequests, outbox.DispositionRequeue},
+		{"404_reject", http.StatusNotFound, outbox.DispositionReject},
+		{"410_reject", http.StatusGone, outbox.DispositionReject},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+				dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
+			require.NoError(t, err)
+
+			res := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
+			assert.Equal(t, tc.want, res.Disposition)
+		})
+	}
+}
+
+// TestDispatcher_Handle_SignsRequest verifies the dispatcher injects the
+// vendor-neutral webhook-* signature headers and that they round-trip through
+// the verifier (dispatcher↔verifier interop).
+func TestDispatcher_Handle_SignsRequest(t *testing.T) {
+	t.Parallel()
+	src := dispatchTestSource(t)
+	payload := []byte(`{"event":"order.created"}`)
+
+	var gotID, gotTS, gotSig string
+	var verifyErr error
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotID = r.Header.Get(HeaderID)
+		gotTS = r.Header.Get(HeaderTimestamp)
+		gotSig = r.Header.Get(HeaderSignature)
+		verifier, err := NewHMACVerifier(clockmock.New(time.Unix(dispatchTestTS, 0)))
+		require.NoError(t, err)
+		verifyErr = verifier.Verify(body, Headers{
+			DeliveryID: DeliveryID(gotID), Timestamp: gotTS, Signature: gotSig,
+		}, src)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		signer, NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
+	require.NoError(t, err)
+
+	entry := newTestEntry(t, payload)
+	res := d.Handle(context.Background(), entry)
+
+	assert.Equal(t, outbox.DispositionAck, res.Disposition)
+	assert.Equal(t, entry.ID(), gotID, "webhook-id header == entry id (delivery id)")
+	assert.NotEmpty(t, gotTS, "webhook-timestamp header set")
+	assert.Contains(t, gotSig, "v1,", "webhook-signature header is a v1 token")
+	assert.NoError(t, verifyErr, "server-side verify of dispatcher signature")
+}
+
+func TestDispatcher_Handle_SelectorError_Reject(t *testing.T) {
+	t.Parallel()
+	sel := func(_ context.Context, _ []byte) (string, error) {
+		return "", errors.New("no target configured")
+	}
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), sel)
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+}
+
+// TestDispatcher_Handle_SSRFBlocked_Reject uses a policy WITHOUT loopback and a
+// blocked metadata IP literal so ValidateTargetURL rejects before any dial.
+func TestDispatcher_Handle_SSRFBlocked_Reject(t *testing.T) {
+	t.Parallel()
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(), staticSelector("http://169.254.169.254/latest/meta-data/"))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	require.Equal(t, outbox.DispositionReject, res.Disposition)
+
+	var ee *errcode.Error
+	require.True(t, errors.As(res.Err, &ee))
+	assert.Equal(t, errcode.ErrWebhookSSRFBlocked, ee.Code)
+}
+
+// TestDispatcher_Handle_Timeout_Requeue drives a slow server past a short
+// delivery timeout; a transport timeout is transient → Requeue. The handler
+// sleeps a bounded interval (not block-on-context) so srv.Close cannot hang if
+// the server is slow to observe the client disconnect.
+func TestDispatcher_Handle_Timeout_Requeue(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond) // outlasts the 20ms delivery timeout
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL),
+		WithDeliveryTimeout(20*time.Millisecond))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition)
+}

--- a/kernel/webhook/dispatcher_test.go
+++ b/kernel/webhook/dispatcher_test.go
@@ -94,8 +94,9 @@ func TestDispatcher_Handle_StatusMapping(t *testing.T) {
 		{"202_ack", http.StatusAccepted, outbox.DispositionAck},
 		{"500_requeue", http.StatusInternalServerError, outbox.DispositionRequeue},
 		{"429_requeue", http.StatusTooManyRequests, outbox.DispositionRequeue},
-		{"404_reject", http.StatusNotFound, outbox.DispositionReject},
-		{"410_reject", http.StatusGone, outbox.DispositionReject},
+		// standard-webhooks aligned: non-2xx (incl. 4xx) is a retryable failure.
+		{"404_requeue", http.StatusNotFound, outbox.DispositionRequeue},
+		{"410_requeue", http.StatusGone, outbox.DispositionRequeue},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -155,17 +156,41 @@ func TestDispatcher_Handle_SignsRequest(t *testing.T) {
 	assert.NoError(t, verifyErr, "server-side verify of dispatcher signature")
 }
 
-func TestDispatcher_Handle_SelectorError_Reject(t *testing.T) {
+// TestDispatcher_Handle_SelectorError covers F2: a generic selector error is
+// transient (Requeue) so a store/config hiccup does not dead-letter the
+// delivery; only a selector that signals ErrWebhookPermanentFailure (e.g. no
+// subscription configured) is permanent (Reject).
+func TestDispatcher_Handle_SelectorError(t *testing.T) {
 	t.Parallel()
-	sel := func(_ context.Context, _ []byte) (string, error) {
-		return "", errors.New("no target configured")
-	}
-	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
-		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), sel)
-	require.NoError(t, err)
 
-	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
-	assert.Equal(t, outbox.DispositionReject, res.Disposition)
+	t.Run("generic_error_requeue", func(t *testing.T) {
+		t.Parallel()
+		sel := func(_ context.Context, _ []byte) (string, error) {
+			return "", errors.New("config store temporarily unavailable")
+		}
+		d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+			dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), sel)
+		require.NoError(t, err)
+
+		res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+		assert.Equal(t, outbox.DispositionRequeue, res.Disposition,
+			"a generic selector error is transient (Requeue), not permanent")
+	})
+
+	t.Run("permanent_error_reject", func(t *testing.T) {
+		t.Parallel()
+		sel := func(_ context.Context, _ []byte) (string, error) {
+			return "", errcode.New(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
+				"no webhook subscription configured for event")
+		}
+		d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+			dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), sel)
+		require.NoError(t, err)
+
+		res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+		assert.Equal(t, outbox.DispositionReject, res.Disposition,
+			"a selector signaling ErrWebhookPermanentFailure is permanent (Reject)")
+	})
 }
 
 // TestDispatcher_Handle_SSRFBlocked_Reject uses a policy WITHOUT loopback and a
@@ -298,6 +323,65 @@ func TestDispatcher_Handle_SSRFBlocked_ViaDialContext_Reject(t *testing.T) {
 		"res.Err must be *errcode.Error, got %T: %v", res.Err, res.Err)
 	assert.Equal(t, errcode.ErrWebhookSSRFBlocked, ee.Code,
 		"dial-time SSRF error must carry ErrWebhookSSRFBlocked code")
+}
+
+// F1: a DNS resolution FAILURE at dial time is transient (Requeue), not a
+// permanent SSRF block. The fail-closed refusal to dial is preserved (no
+// connection is made to an un-vettable target); only the disposition changes so
+// a DNS hiccup does not dead-letter the delivery.
+func TestDispatcher_Handle_DNSResolutionFailure_Requeue(t *testing.T) {
+	t.Parallel()
+	failingResolver := fakeResolver{err: errors.New("dns timeout")}
+	policy := NewSafePolicy(withResolver(failingResolver))
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), policy, staticSelector("http://unresolvable.example.test/"))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	assert.Equal(t, outbox.DispositionRequeue, res.Disposition,
+		"DNS resolution failure must be transient (Requeue), not Reject")
+
+	var ee *errcode.Error
+	require.True(t, errors.As(res.Err, &ee))
+	assert.Equal(t, errcode.ErrWebhookDeliveryFailed, ee.Code,
+		"DNS failure must carry the transient delivery-failed code, not SSRF-blocked")
+}
+
+// F8: a non-2xx response body is captured (bounded) into the server-side
+// Internal diagnostic so ops can see WHY a receiver rejected — without the body
+// ever reaching the wire.
+func TestDispatcher_Handle_NonSuccessBodyDiagnostic(t *testing.T) {
+	t.Parallel()
+	const bodyText = "upstream says: tenant quota exceeded"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, bodyText)
+	}))
+	defer srv.Close()
+
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	require.Equal(t, outbox.DispositionRequeue, res.Disposition)
+
+	var ee *errcode.Error
+	require.True(t, errors.As(res.Err, &ee))
+	assert.Contains(t, internalAttrValue(t, ee, "response_body"), "tenant quota exceeded",
+		"non-2xx response body must be captured in the server-side diagnostic")
+}
+
+// internalAttrValue extracts a named InternalDetail value from an errcode.Error
+// as a string (server-only observability; never on the wire). Returns "" absent.
+func internalAttrValue(t *testing.T, ee *errcode.Error, key string) string {
+	t.Helper()
+	for _, d := range ee.InternalDetails {
+		if a := d.AsSlogAttr(); a.Key == key {
+			return a.Value.String()
+		}
+	}
+	return ""
 }
 
 // T-06: WithDeliveryTimeout ignores non-positive durations; the effective

--- a/kernel/webhook/dispatcher_test.go
+++ b/kernel/webhook/dispatcher_test.go
@@ -19,6 +19,10 @@ import (
 
 const dispatchTestTS = 1700000000
 
+// shortDeliveryTimeout is the per-attempt delivery timeout for the timeout-path
+// test (TEST-TIME-LITERAL-01: named package-level const, not an inline literal).
+const shortDeliveryTimeout = 20 * time.Millisecond
+
 func dispatchTestSource(t *testing.T) Source {
 	t.Helper()
 	src, err := NewSource(MustSourceID("dispatch-src"), minSecret())
@@ -175,21 +179,25 @@ func TestDispatcher_Handle_SSRFBlocked_Reject(t *testing.T) {
 	assert.Equal(t, errcode.ErrWebhookSSRFBlocked, ee.Code)
 }
 
-// TestDispatcher_Handle_Timeout_Requeue drives a slow server past a short
-// delivery timeout; a transport timeout is transient → Requeue. The handler
-// sleeps a bounded interval (not block-on-context) so srv.Close cannot hang if
-// the server is slow to observe the client disconnect.
+// TestDispatcher_Handle_Timeout_Requeue drives a server that never responds
+// within the short delivery timeout; a transport timeout is transient →
+// Requeue. The handler blocks on a test-controlled channel (deterministic, no
+// time.Sleep) that is closed BEFORE srv.Close — so the handler unblocks and
+// srv.Close cannot hang, independent of how the server observes the client
+// disconnect.
 func TestDispatcher_Handle_Timeout_Requeue(t *testing.T) {
 	t.Parallel()
+	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(300 * time.Millisecond) // outlasts the 20ms delivery timeout
+		<-release // block until the test releases, after the client has timed out
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer srv.Close()
+	defer srv.Close()    // runs second: handler already released, returns promptly
+	defer close(release) // runs first (LIFO): unblock the handler
 
 	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
 		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL),
-		WithDeliveryTimeout(20*time.Millisecond))
+		WithDeliveryTimeout(shortDeliveryTimeout))
 	require.NoError(t, err)
 
 	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))

--- a/kernel/webhook/retry.go
+++ b/kernel/webhook/retry.go
@@ -14,12 +14,15 @@ import (
 // wait before retry i+1. The schedule is value-immutable: DefaultSvixSchedule
 // returns a fresh copy and there is no setter.
 //
-// PR-5 scope: DefaultSvixSchedule is the canonical default + the seam for the
-// broker-delay follow-up; the exact per-attempt wall-clock delays are NOT yet
-// honored at runtime (the in-process ConsumerBase backoff is capped at 30s).
-// Honoring the full Svix timeline (up to ~40h) needs broker-delay support and
-// is a tracked follow-up (see ADR webhook-retry-default). The schedule is
-// retained because that follow-up is a real future need, not a dead abstraction.
+// PR-5 ships DefaultSvixSchedule as the canonical default and the seam for the
+// broker-delay follow-up (gh #1458). PR-5 does NOT wire per-attempt delays or a
+// per-dispatcher RetryCount at runtime: the dispatch consumer rides the shared
+// ConsumerBase (default exponential backoff, capped 30 s). Honoring the full
+// Svix timeline (up to ~40 h) needs broker-delay support; DelayFor is the seam
+// the follow-up will consume. The schedule is retained because that follow-up is
+// a real future need, not a dead abstraction.
+//
+// See docs/architecture/202606012052-1160-adr-webhook-retry-default.md §D5.
 type RetrySchedule struct {
 	delays []time.Duration
 }
@@ -71,7 +74,8 @@ func (s RetrySchedule) DelayFor(n int) (delay time.Duration, ok bool) {
 // webhook retry-default ADR (standard-webhooks / Svix aligned). Exactly one of
 // the two inputs is meaningful per call: pass the transport error (statusCode
 // ignored) when client.Do failed, or statusCode with a nil error when a
-// response was received.
+// response was received. When transportErr is non-nil the statusCode is
+// ignored; pass 0 by convention.
 //
 // Mapping:
 //   - transportErr != nil:

--- a/kernel/webhook/retry.go
+++ b/kernel/webhook/retry.go
@@ -24,6 +24,19 @@ type RetrySchedule struct {
 	delays []time.Duration
 }
 
+// svixRetryDelayN are the 7 Svix default retry intervals (PROD-DURATION-CONST-01:
+// production duration literals must be named package-level consts). Steps 6 and
+// 7 are both 10h by Svix's table — the tail interval is capped, not growing.
+const (
+	svixRetryDelay1 = 5 * time.Second
+	svixRetryDelay2 = 5 * time.Minute
+	svixRetryDelay3 = 30 * time.Minute
+	svixRetryDelay4 = 2 * time.Hour
+	svixRetryDelay5 = 5 * time.Hour
+	svixRetryDelay6 = 10 * time.Hour
+	svixRetryDelay7 = 10 * time.Hour
+)
+
 // DefaultSvixSchedule returns the Svix default retry schedule: 7 retries after
 // the immediate first attempt (8 deliveries total), spaced
 // 5s / 5min / 30min / 2h / 5h / 10h / 10h.
@@ -32,13 +45,8 @@ type RetrySchedule struct {
 // ref: standard-webhooks/standard-webhooks spec/standard-webhooks.md (retry guidance)
 func DefaultSvixSchedule() RetrySchedule {
 	return RetrySchedule{delays: []time.Duration{
-		5 * time.Second,
-		5 * time.Minute,
-		30 * time.Minute,
-		2 * time.Hour,
-		5 * time.Hour,
-		10 * time.Hour,
-		10 * time.Hour,
+		svixRetryDelay1, svixRetryDelay2, svixRetryDelay3, svixRetryDelay4,
+		svixRetryDelay5, svixRetryDelay6, svixRetryDelay7,
 	}}
 }
 

--- a/kernel/webhook/retry.go
+++ b/kernel/webhook/retry.go
@@ -1,0 +1,100 @@
+package webhook
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// RetrySchedule is the fixed sequence of wait intervals between outbound
+// delivery retries. The first delivery attempt is immediate; delays[i] is the
+// wait before retry i+1. The schedule is value-immutable: DefaultSvixSchedule
+// returns a fresh copy and there is no setter.
+//
+// PR-5 scope: DefaultSvixSchedule is the canonical default + the seam for the
+// broker-delay follow-up; the exact per-attempt wall-clock delays are NOT yet
+// honored at runtime (the in-process ConsumerBase backoff is capped at 30s).
+// Honoring the full Svix timeline (up to ~40h) needs broker-delay support and
+// is a tracked follow-up (see ADR webhook-retry-default). The schedule is
+// retained because that follow-up is a real future need, not a dead abstraction.
+type RetrySchedule struct {
+	delays []time.Duration
+}
+
+// DefaultSvixSchedule returns the Svix default retry schedule: 7 retries after
+// the immediate first attempt (8 deliveries total), spaced
+// 5s / 5min / 30min / 2h / 5h / 10h / 10h.
+//
+// ref: svix/svix-webhooks docs.svix.com/retries (official retry table)
+// ref: standard-webhooks/standard-webhooks spec/standard-webhooks.md (retry guidance)
+func DefaultSvixSchedule() RetrySchedule {
+	return RetrySchedule{delays: []time.Duration{
+		5 * time.Second,
+		5 * time.Minute,
+		30 * time.Minute,
+		2 * time.Hour,
+		5 * time.Hour,
+		10 * time.Hour,
+		10 * time.Hour,
+	}}
+}
+
+// MaxRetries is the number of retries after the first (immediate) attempt.
+func (s RetrySchedule) MaxRetries() int { return len(s.delays) }
+
+// Attempts is the total number of delivery attempts: the immediate first
+// delivery plus MaxRetries retries.
+func (s RetrySchedule) Attempts() int { return len(s.delays) + 1 }
+
+// DelayFor returns the wait before retry n (1-based: n==1 is the first retry).
+// ok is false when n is out of range (n < 1 or n > MaxRetries), i.e. the retry
+// budget is exhausted.
+func (s RetrySchedule) DelayFor(n int) (delay time.Duration, ok bool) {
+	if n < 1 || n > len(s.delays) {
+		return 0, false
+	}
+	return s.delays[n-1], true
+}
+
+// Classify maps an outbound delivery outcome to an outbox.Disposition per the
+// webhook retry-default ADR (standard-webhooks / Svix aligned). Exactly one of
+// the two inputs is meaningful per call: pass the transport error (statusCode
+// ignored) when client.Do failed, or statusCode with a nil error when a
+// response was received.
+//
+// Mapping:
+//   - transportErr != nil:
+//   - SSRF-blocked (ErrWebhookSSRFBlocked — bad target URL, blocked dial,
+//     or denied redirect) → Reject (permanent: a misconfigured/hostile
+//     target never succeeds on retry).
+//   - otherwise (timeout, connection refused, …) → Requeue (transient).
+//   - 2xx → Ack.
+//   - 408 Request Timeout / 429 Too Many Requests → Requeue (throttle/timeout
+//     are transient; the spec asks senders to back off and retry).
+//   - 5xx → Requeue (transient server fault).
+//   - 3xx and every other 4xx (400/401/403/404/410 …) → Reject (the request
+//     itself is faulty; retrying will not help). 3xx normally never reaches
+//     this branch because redirects are denied at the transport layer and
+//     surface as an SSRF transport error.
+func Classify(statusCode int, transportErr error) outbox.Disposition {
+	if transportErr != nil {
+		var ee *errcode.Error
+		if errors.As(transportErr, &ee) && ee.Code == errcode.ErrWebhookSSRFBlocked {
+			return outbox.DispositionReject
+		}
+		return outbox.DispositionRequeue
+	}
+	switch {
+	case statusCode >= 200 && statusCode < 300:
+		return outbox.DispositionAck
+	case statusCode == http.StatusRequestTimeout || statusCode == http.StatusTooManyRequests:
+		return outbox.DispositionRequeue
+	case statusCode >= 500:
+		return outbox.DispositionRequeue
+	default:
+		return outbox.DispositionReject
+	}
+}

--- a/kernel/webhook/retry.go
+++ b/kernel/webhook/retry.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"errors"
-	"net/http"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -77,20 +76,22 @@ func (s RetrySchedule) DelayFor(n int) (delay time.Duration, ok bool) {
 // response was received. When transportErr is non-nil the statusCode is
 // ignored; pass 0 by convention.
 //
-// Mapping:
+// Mapping (standard-webhooks / Svix: the receiver MUST return 2xx to acknowledge;
+// every other outcome is a delivery failure the sender retries):
 //   - transportErr != nil:
 //   - SSRF-blocked (ErrWebhookSSRFBlocked — bad target URL, blocked dial,
 //     or denied redirect) → Reject (permanent: a misconfigured/hostile
 //     target never succeeds on retry).
-//   - otherwise (timeout, connection refused, …) → Requeue (transient).
+//   - otherwise (DNS resolution failure, timeout, connection refused, …) →
+//     Requeue (transient).
 //   - 2xx → Ack.
-//   - 408 Request Timeout / 429 Too Many Requests → Requeue (throttle/timeout
-//     are transient; the spec asks senders to back off and retry).
-//   - 5xx → Requeue (transient server fault).
-//   - 3xx and every other 4xx (400/401/403/404/410 …) → Reject (the request
-//     itself is faulty; retrying will not help). 3xx normally never reaches
-//     this branch because redirects are denied at the transport layer and
-//     surface as an SSRF transport error.
+//   - every non-2xx status (3xx / 4xx / 5xx) → Requeue. A receiver's non-2xx
+//     usually reflects a transient condition on its side (deploy gap → 404,
+//     secret rotation → 401, throttle → 429, server fault → 5xx); the sender
+//     cannot distinguish a "permanent" 4xx from a transient one, so it retries
+//     until the budget is exhausted (then ConsumerBase dead-letters). 3xx
+//     normally never reaches this branch because redirects are denied at the
+//     transport layer and surface as an SSRF transport error (→ Reject above).
 func Classify(statusCode int, transportErr error) outbox.Disposition {
 	if transportErr != nil {
 		var ee *errcode.Error
@@ -99,14 +100,8 @@ func Classify(statusCode int, transportErr error) outbox.Disposition {
 		}
 		return outbox.DispositionRequeue
 	}
-	switch {
-	case statusCode >= 200 && statusCode < 300:
+	if statusCode >= 200 && statusCode < 300 {
 		return outbox.DispositionAck
-	case statusCode == http.StatusRequestTimeout || statusCode == http.StatusTooManyRequests:
-		return outbox.DispositionRequeue
-	case statusCode >= 500:
-		return outbox.DispositionRequeue
-	default:
-		return outbox.DispositionReject
 	}
+	return outbox.DispositionRequeue
 }

--- a/kernel/webhook/retry_test.go
+++ b/kernel/webhook/retry_test.go
@@ -20,14 +20,13 @@ func TestDefaultSvixSchedule_GoldenSteps(t *testing.T) {
 	t.Parallel()
 	s := DefaultSvixSchedule()
 
+	// Reference the production consts (same package): the test locks the count
+	// and ordering of DefaultSvixSchedule against the declared svixRetryDelayN
+	// values (whose literals are reviewed in retry.go), satisfying
+	// TEST-TIME-LITERAL-01 without re-stating duration literals here.
 	want := []time.Duration{
-		5 * time.Second,
-		5 * time.Minute,
-		30 * time.Minute,
-		2 * time.Hour,
-		5 * time.Hour,
-		10 * time.Hour,
-		10 * time.Hour,
+		svixRetryDelay1, svixRetryDelay2, svixRetryDelay3, svixRetryDelay4,
+		svixRetryDelay5, svixRetryDelay6, svixRetryDelay7,
 	}
 	assert.Equal(t, len(want), s.MaxRetries(), "MaxRetries")
 	assert.Equal(t, len(want)+1, s.Attempts(), "Attempts (1 immediate + retries)")

--- a/kernel/webhook/retry_test.go
+++ b/kernel/webhook/retry_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// goldenSvixDelayN is an INDEPENDENT golden copy of the Svix retry schedule,
+// declared separately from retry.go's svixRetryDelayN. Referencing the
+// production consts (the prior form) made the golden vacuous: editing a
+// production delay would change both sides and the test would still pass. With
+// an independent copy, any drift of a production delay constant breaks
+// TestDefaultSvixSchedule_GoldenSteps. TEST-TIME-LITERAL-01: durations live in a
+// package-level const initializer.
+const (
+	goldenSvixDelay1 = 5 * time.Second
+	goldenSvixDelay2 = 5 * time.Minute
+	goldenSvixDelay3 = 30 * time.Minute
+	goldenSvixDelay4 = 2 * time.Hour
+	goldenSvixDelay5 = 5 * time.Hour
+	goldenSvixDelay6 = 10 * time.Hour
+	goldenSvixDelay7 = 10 * time.Hour
+)
+
 // TestDefaultSvixSchedule_GoldenSteps locks the canonical Svix retry schedule:
 // 7 retries after the immediate first attempt (8 deliveries total).
 // ref: svix/svix-webhooks docs.svix.com/retries
@@ -20,13 +37,12 @@ func TestDefaultSvixSchedule_GoldenSteps(t *testing.T) {
 	t.Parallel()
 	s := DefaultSvixSchedule()
 
-	// Reference the production consts (same package): the test locks the count
-	// and ordering of DefaultSvixSchedule against the declared svixRetryDelayN
-	// values (whose literals are reviewed in retry.go), satisfying
-	// TEST-TIME-LITERAL-01 without re-stating duration literals here.
+	// Lock DefaultSvixSchedule against the INDEPENDENT golden copy (goldenSvixDelayN,
+	// declared at the top of this file) — not the production svixRetryDelayN — so
+	// editing a production delay constant fails this golden instead of passing it.
 	want := []time.Duration{
-		svixRetryDelay1, svixRetryDelay2, svixRetryDelay3, svixRetryDelay4,
-		svixRetryDelay5, svixRetryDelay6, svixRetryDelay7,
+		goldenSvixDelay1, goldenSvixDelay2, goldenSvixDelay3, goldenSvixDelay4,
+		goldenSvixDelay5, goldenSvixDelay6, goldenSvixDelay7,
 	}
 	assert.Equal(t, len(want), s.MaxRetries(), "MaxRetries")
 	assert.Equal(t, len(want)+1, s.Attempts(), "Attempts (1 immediate + retries)")
@@ -69,11 +85,14 @@ func TestClassify(t *testing.T) {
 		{"5xx_503", http.StatusServiceUnavailable, nil, outbox.DispositionRequeue},
 		{"408_timeout", http.StatusRequestTimeout, nil, outbox.DispositionRequeue},
 		{"429_throttle", http.StatusTooManyRequests, nil, outbox.DispositionRequeue},
-		{"4xx_400", http.StatusBadRequest, nil, outbox.DispositionReject},
-		{"4xx_401", http.StatusUnauthorized, nil, outbox.DispositionReject},
-		{"4xx_404", http.StatusNotFound, nil, outbox.DispositionReject},
-		{"4xx_410_gone", http.StatusGone, nil, outbox.DispositionReject},
-		{"3xx_302", http.StatusFound, nil, outbox.DispositionReject},
+		// standard-webhooks / Svix aligned: every non-2xx is a retryable delivery
+		// failure (the receiver's 4xx/3xx may be transient — deploy gap, secret
+		// rotation, throttle — and the sender cannot tell permanent from transient).
+		{"4xx_400_requeue", http.StatusBadRequest, nil, outbox.DispositionRequeue},
+		{"4xx_401_requeue", http.StatusUnauthorized, nil, outbox.DispositionRequeue},
+		{"4xx_404_requeue", http.StatusNotFound, nil, outbox.DispositionRequeue},
+		{"4xx_410_gone_requeue", http.StatusGone, nil, outbox.DispositionRequeue},
+		{"3xx_302_requeue", http.StatusFound, nil, outbox.DispositionRequeue},
 		{"transport_ssrf_reject", 0, ssrf, outbox.DispositionReject},
 		{"transport_ssrf_wrapped_reject", 0, errors.Join(errors.New("Get x:"), ssrf), outbox.DispositionReject},
 		{"transport_generic_requeue", 0, errors.New("connection refused"), outbox.DispositionRequeue},

--- a/kernel/webhook/retry_test.go
+++ b/kernel/webhook/retry_test.go
@@ -1,0 +1,88 @@
+package webhook
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// TestDefaultSvixSchedule_GoldenSteps locks the canonical Svix retry schedule:
+// 7 retries after the immediate first attempt (8 deliveries total).
+// ref: svix/svix-webhooks docs.svix.com/retries
+func TestDefaultSvixSchedule_GoldenSteps(t *testing.T) {
+	t.Parallel()
+	s := DefaultSvixSchedule()
+
+	want := []time.Duration{
+		5 * time.Second,
+		5 * time.Minute,
+		30 * time.Minute,
+		2 * time.Hour,
+		5 * time.Hour,
+		10 * time.Hour,
+		10 * time.Hour,
+	}
+	assert.Equal(t, len(want), s.MaxRetries(), "MaxRetries")
+	assert.Equal(t, len(want)+1, s.Attempts(), "Attempts (1 immediate + retries)")
+
+	for i, w := range want {
+		d, ok := s.DelayFor(i + 1)
+		require.Truef(t, ok, "DelayFor(%d) ok", i+1)
+		assert.Equalf(t, w, d, "DelayFor(%d)", i+1)
+	}
+}
+
+func TestRetrySchedule_DelayFor_OutOfRange(t *testing.T) {
+	t.Parallel()
+	s := DefaultSvixSchedule()
+	cases := []int{-1, 0, s.MaxRetries() + 1, 100}
+	for _, n := range cases {
+		_, ok := s.DelayFor(n)
+		assert.Falsef(t, ok, "DelayFor(%d) should be exhausted", n)
+	}
+}
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+	ssrf := errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked, "blocked")
+	// Wrapped to mimic http.Client wrapping a dial error in *url.Error.
+	wrappedSSRF := errcode.Wrap(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
+		"transport", ssrf)
+	_ = wrappedSSRF // see dedicated case below
+
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		want       outbox.Disposition
+	}{
+		{"2xx_200", http.StatusOK, nil, outbox.DispositionAck},
+		{"2xx_202", http.StatusAccepted, nil, outbox.DispositionAck},
+		{"2xx_299", 299, nil, outbox.DispositionAck},
+		{"5xx_500", http.StatusInternalServerError, nil, outbox.DispositionRequeue},
+		{"5xx_503", http.StatusServiceUnavailable, nil, outbox.DispositionRequeue},
+		{"408_timeout", http.StatusRequestTimeout, nil, outbox.DispositionRequeue},
+		{"429_throttle", http.StatusTooManyRequests, nil, outbox.DispositionRequeue},
+		{"4xx_400", http.StatusBadRequest, nil, outbox.DispositionReject},
+		{"4xx_401", http.StatusUnauthorized, nil, outbox.DispositionReject},
+		{"4xx_404", http.StatusNotFound, nil, outbox.DispositionReject},
+		{"4xx_410_gone", http.StatusGone, nil, outbox.DispositionReject},
+		{"3xx_302", http.StatusFound, nil, outbox.DispositionReject},
+		{"transport_ssrf_reject", 0, ssrf, outbox.DispositionReject},
+		{"transport_ssrf_wrapped_reject", 0, errors.Join(errors.New("Get x:"), ssrf), outbox.DispositionReject},
+		{"transport_generic_requeue", 0, errors.New("connection refused"), outbox.DispositionRequeue},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, Classify(tc.statusCode, tc.err))
+		})
+	}
+}

--- a/kernel/webhook/ssrf.go
+++ b/kernel/webhook/ssrf.go
@@ -104,16 +104,23 @@ func (p *SafePolicy) DialContext(ctx context.Context, network, address string) (
 
 	// Hostname: resolve once, vet ALL answers (fail-closed if any is blocked),
 	// then dial the first vetted IP literal. No re-resolution → rebinding-proof.
+	//
+	// A resolution FAILURE (or an empty answer set) is fail-closed at the dial
+	// layer — we refuse to connect to an un-vettable target — but it is a
+	// TRANSIENT delivery error, NOT an SSRF policy block: a DNS hiccup or
+	// propagation delay may resolve on retry, so Classify must Requeue (not
+	// Reject/DLX) it. Conflating "could not resolve" with "resolved to a blocked
+	// address" would permanently dead-letter deliveries on a transient DNS fault.
 	addrs, err := p.resolver.LookupIPAddr(ctx, host)
 	if err != nil {
-		return nil, errcode.Wrap(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+		return nil, errcode.Wrap(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
 			"webhook: dial host resolution failed", err,
 			errcode.WithInternal(
 				errcode.InternalAttr("reason", "resolution_failed"),
 				errcode.InternalAttr("host", host)))
 	}
 	if len(addrs) == 0 {
-		return nil, errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+		return nil, errcode.New(errcode.KindUnavailable, errcode.ErrWebhookDeliveryFailed,
 			"webhook: dial host resolved to no addresses",
 			errcode.WithInternal(
 				errcode.InternalAttr("reason", "no_addresses"),
@@ -167,6 +174,14 @@ func (p *SafePolicy) ValidateTargetURL(rawURL string) error {
 			"webhook: dispatch target URL is not parseable", err,
 			errcode.WithInternal(errcode.InternalAttr("reason", "unparseable")))
 	}
+	// Reject embedded userinfo (user:pass@host): the HTTP client would emit it as
+	// a Basic-Auth header, and it would otherwise leak into redirect/error logs.
+	// A webhook target's auth belongs in the signed payload / headers, not the URL.
+	if u.User != nil {
+		return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
+			"webhook: dispatch target URL must not embed userinfo credentials",
+			errcode.WithInternal(errcode.InternalAttr("reason", "userinfo_not_allowed")))
+	}
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https":
 	default:
@@ -199,7 +214,7 @@ func (p *SafePolicy) ValidateTargetURL(rawURL string) error {
 func (p *SafePolicy) DenyRedirect(_ *http.Request, via []*http.Request) error {
 	from := ""
 	if n := len(via); n > 0 && via[n-1] != nil && via[n-1].URL != nil {
-		from = via[n-1].URL.String()
+		from = via[n-1].URL.Redacted() // mask any userinfo password before it reaches slog
 	}
 	return errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked,
 		"webhook: redirects are not permitted on outbound delivery",

--- a/kernel/webhook/ssrf_test.go
+++ b/kernel/webhook/ssrf_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// userinfoTestURL embeds userinfo (user:pass@) to prove ValidateTargetURL
+// rejects it (F10). Declared as a const so the gosec G101 suppression stays on a
+// short line instead of bloating the table row past the lll limit.
+const userinfoTestURL = "https://user:pass@hooks.example.com/v1" //nolint:gosec // G101: deliberate test fixture, not a real credential
+
 // fakeResolver returns a fixed set of addresses regardless of host. It drives
 // the DNS-rebinding tests: a public-looking hostname can be made to "resolve"
 // to a private IP, which the dial-time vet must reject before connecting.
@@ -146,16 +151,10 @@ func TestSafeDialer_DNSRebinding(t *testing.T) {
 			resolver:    fakeResolver{addrs: ipAddrs("93.184.216.34")},
 			wantBlocked: false,
 		},
-		{
-			name:        "resolver_error_fail_closed",
-			resolver:    fakeResolver{err: errors.New("dns boom")},
-			wantBlocked: true,
-		},
-		{
-			name:        "resolver_empty_fail_closed",
-			resolver:    fakeResolver{addrs: nil},
-			wantBlocked: true,
-		},
+		// Note: resolver-error / empty-answer cases moved to
+		// TestSafeDialer_ResolutionFailure_Transient — those are fail-closed at
+		// the dial layer but TRANSIENT (ErrWebhookDeliveryFailed → Requeue), not
+		// SSRF blocks, so they no longer belong in this isSSRFBlocked table.
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -173,6 +172,38 @@ func TestSafeDialer_DNSRebinding(t *testing.T) {
 				assert.Falsef(t, isSSRFBlocked(t, err), "expected to pass vet, got SSRF block: %v", err)
 				assert.ErrorIsf(t, err, context.Canceled, "expected canceled-ctx dial error after vet, got %v", err)
 			}
+		})
+	}
+}
+
+// TestSafeDialer_ResolutionFailure_Transient (F1): a resolver FAILURE or empty
+// answer set is fail-closed at the dial layer (still an error — no connection is
+// made), but it carries the TRANSIENT ErrWebhookDeliveryFailed code, NOT
+// ErrWebhookSSRFBlocked. Classify therefore maps it to Requeue, not a permanent
+// Reject/DLX — a DNS hiccup must not dead-letter the delivery.
+func TestSafeDialer_ResolutionFailure_Transient(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		resolver fakeResolver
+		reason   string
+	}{
+		{name: "resolver_error", resolver: fakeResolver{err: errors.New("dns boom")}, reason: "resolution_failed"},
+		{name: "resolver_empty", resolver: fakeResolver{addrs: nil}, reason: "no_addresses"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewSafePolicy(withResolver(tc.resolver))
+			_, err := p.DialContext(context.Background(), "tcp", "evil.example.com:443")
+			require.Error(t, err)
+			assert.Falsef(t, isSSRFBlocked(t, err),
+				"DNS failure must be transient, not an SSRF block, got %v", err)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.ErrWebhookDeliveryFailed, ec.Code,
+				"DNS failure must carry the transient ErrWebhookDeliveryFailed code")
+			assert.Equal(t, tc.reason, internalReason(t, err))
 		})
 	}
 }
@@ -237,6 +268,10 @@ func TestValidateTargetURL(t *testing.T) {
 		{name: "metadata_ip_literal_blocked", rawURL: "http://169.254.169.254/latest/meta-data/", wantErr: true, wantReason: "ssrf_blocked"},
 		{name: "mapped_private_literal_blocked", rawURL: "http://[::ffff:10.0.0.1]/x", wantErr: true, wantReason: "ssrf_blocked"},
 		{name: "unparseable_blocked", rawURL: "ht!tp://\x7f", wantErr: true, wantReason: "unparseable"},
+		// F10: embedded userinfo is rejected (it would otherwise become a Basic-Auth
+		// header and leak into redirect/error logs).
+		{name: "userinfo_user_pass_blocked", rawURL: userinfoTestURL, wantErr: true, wantReason: "userinfo_not_allowed"},
+		{name: "userinfo_user_only_blocked", rawURL: "https://user@hooks.example.com/v1", wantErr: true, wantReason: "userinfo_not_allowed"},
 		// F1: an empty host (http:///x) is un-vettable → fail closed, not silently OK.
 		{name: "empty_host_blocked", rawURL: "http:///x", wantErr: true, wantReason: "empty_host"},
 		// F2: loopback exemption is policy-coherent — the pre-flight honors
@@ -299,6 +334,24 @@ func TestDenyRedirect(t *testing.T) {
 			assert.Equal(t, http.StatusForbidden, ec.Status())
 		})
 	}
+}
+
+// TestDenyRedirect_RedactsUserinfo (F10): DenyRedirect records the source URL in
+// the server-side diagnostic; any userinfo password must be masked (url.Redacted)
+// so it cannot leak into slog.
+func TestDenyRedirect_RedactsUserinfo(t *testing.T) {
+	t.Parallel()
+	src, err := http.NewRequest(http.MethodGet, "https://user:supersecret@x.example.com/hook", nil)
+	require.NoError(t, err)
+
+	rerr := NewSafePolicy().DenyRedirect(src, []*http.Request{src})
+	require.Error(t, rerr)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, rerr, &ec)
+	from := internalAttrValue(t, ec, "from_url")
+	assert.NotContains(t, from, "supersecret", "userinfo password must be redacted from the diagnostic")
+	assert.Contains(t, from, "xxxxx", "url.Redacted masks the password as xxxxx")
 }
 
 // TestNormalizeIP locks the IPv4-mapped dewrap behavior in isolation.

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
 	"regexp"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -204,4 +205,34 @@ type Headers struct {
 	DeliveryID DeliveryID
 	Timestamp  string
 	Signature  string
+}
+
+// Outbound signature header names. GoCell signs outbound webhooks under the
+// vendor-neutral standard-webhooks header names (webhook-id / webhook-timestamp
+// / webhook-signature) rather than the Svix-branded svix-* names: the dispatcher
+// is the sender, so these headers define GoCell's own outbound protocol and must
+// not embed a third-party vendor name. The signed content, HMAC-SHA256, and
+// "v1,<base64>" token format are Svix / standard-webhooks aligned (see signer.go
+// and ADR webhook-signing-algorithm); only the header names differ.
+//
+// ref: standard-webhooks/standard-webhooks spec/standard-webhooks.md (webhook-id
+// / webhook-timestamp / webhook-signature header names).
+const (
+	HeaderID        = "webhook-id"
+	HeaderTimestamp = "webhook-timestamp"
+	HeaderSignature = "webhook-signature"
+)
+
+// Apply writes the three signature headers (HeaderID, HeaderTimestamp,
+// HeaderSignature) onto an outbound request's http.Header.
+//
+// It is the SOLE sanctioned writer of these headers (WEBHOOK-SIGNER-FUNNEL-01
+// downstream funnel): the dispatcher MUST call headers.Apply(req.Header) rather
+// than Header.Set the signature header from an arbitrary value, so the only
+// value that can reach the wire is one produced by a sealed [Signer.Sign]. The
+// archtest locks Header.Set of these header-name constants to this method body.
+func (h Headers) Apply(header http.Header) {
+	header.Set(HeaderID, string(h.DeliveryID))
+	header.Set(HeaderTimestamp, h.Timestamp)
+	header.Set(HeaderSignature, h.Signature)
 }

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -777,8 +777,10 @@ const (
 	// PR-5 (dispatcher).
 	ErrWebhookDeliveryTimeout Code = "ERR_WEBHOOK_DELIVERY_TIMEOUT"
 	// ErrWebhookPermanentFailure signals a non-retryable delivery failure
-	// (retry budget exhausted, endpoint disabled). Constructed with KindInternal
-	// → HTTP 500. First constructed in PR-5 (dispatcher).
+	// (bad target/selector/permanent non-2xx response). Constructed with the
+	// Kind appropriate to the failure — e.g. KindInvalid (HTTP 400) for a bad
+	// target URL or permanent non-2xx response. First constructed in PR-5
+	// (dispatcher).
 	ErrWebhookPermanentFailure Code = "ERR_WEBHOOK_PERMANENT_FAILURE"
 	// ErrWebhookBodyTooLarge signals the inbound webhook body exceeded the size
 	// limit. Constructed with KindPayloadTooLarge → HTTP 413. First constructed

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -772,15 +772,12 @@ const (
 	// refused, 5xx from target). Constructed with KindUnavailable → HTTP 503.
 	// First constructed in PR-5 (dispatcher).
 	ErrWebhookDeliveryFailed Code = "ERR_WEBHOOK_DELIVERY_FAILED"
-	// ErrWebhookDeliveryTimeout signals delivery exceeded its deadline.
-	// Constructed with KindDeadlineExceeded → HTTP 504. First constructed in
-	// PR-5 (dispatcher).
-	ErrWebhookDeliveryTimeout Code = "ERR_WEBHOOK_DELIVERY_TIMEOUT"
 	// ErrWebhookPermanentFailure signals a non-retryable delivery failure
-	// (bad target/selector/permanent non-2xx response). Constructed with the
-	// Kind appropriate to the failure — e.g. KindInvalid (HTTP 400) for a bad
-	// target URL or permanent non-2xx response. First constructed in PR-5
-	// (dispatcher).
+	// (bad delivery id / signing failure / a selector that signals no
+	// subscription is configured). Constructed with the Kind appropriate to the
+	// failure — e.g. KindInvalid (HTTP 400). Non-2xx delivery RESPONSES are not
+	// permanent (standard-webhooks aligned: every non-2xx is retried). First
+	// constructed in PR-5 (dispatcher).
 	ErrWebhookPermanentFailure Code = "ERR_WEBHOOK_PERMANENT_FAILURE"
 	// ErrWebhookBodyTooLarge signals the inbound webhook body exceeded the size
 	// limit. Constructed with KindPayloadTooLarge → HTTP 413. First constructed

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -49,13 +49,12 @@ func TestWebhookSentinelCodes(t *testing.T) {
 		{ErrWebhookSourceNotFound, "ERR_WEBHOOK_SOURCE_NOT_FOUND"},
 		{ErrWebhookSSRFBlocked, "ERR_WEBHOOK_SSRF_BLOCKED"},
 		{ErrWebhookDeliveryFailed, "ERR_WEBHOOK_DELIVERY_FAILED"},
-		{ErrWebhookDeliveryTimeout, "ERR_WEBHOOK_DELIVERY_TIMEOUT"},
 		{ErrWebhookPermanentFailure, "ERR_WEBHOOK_PERMANENT_FAILURE"},
 		{ErrWebhookBodyTooLarge, "ERR_WEBHOOK_BODY_TOO_LARGE"},
 		{ErrWebhookConfigInvalid, "ERR_WEBHOOK_CONFIG_INVALID"},
 	}
-	if len(cases) != 12 {
-		t.Fatalf("expected 12 webhook sentinels, got %d", len(cases))
+	if len(cases) != 11 {
+		t.Fatalf("expected 11 webhook sentinels, got %d", len(cases))
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -154,6 +154,13 @@ type Bootstrap struct {
 	webhookSourceStore kwh.SourceStore
 	webhookClaimer     idempotency.Claimer
 
+	// --- webhook: outbound-webhook dispatcher dependency ---
+	// Injected via WithWebhookSSRFPolicy. nil means "use the default
+	// production policy" (kwh.NewSafePolicy(): block all private/reserved
+	// ranges, no loopback) — phase6 builds it when any cell registers a webhook
+	// dispatcher. The dispatcher reuses webhookSourceStore for signing secrets.
+	webhookSSRFPolicy *kwh.SafePolicy
+
 	// --- projection: L3 CQRS projection harness dependencies ---
 	// Injected via WithProjectionCheckpointStore / WithProjectionTxRunner /
 	// WithProjectionReplaySource / WithProjectionCursor. nil means "not

--- a/runtime/bootstrap/options_webhook.go
+++ b/runtime/bootstrap/options_webhook.go
@@ -1,8 +1,9 @@
 package bootstrap
 
-// options_webhook.go — With* option functions for inbound-webhook receiver wiring.
+// options_webhook.go — With* option functions for webhook wiring.
 //
-// Covers: WithWebhookSourceStore, WithWebhookClaimer.
+// Covers: WithWebhookSourceStore, WithWebhookClaimer (inbound receiver),
+// WithWebhookSSRFPolicy (outbound dispatcher).
 //
 // Both are "cumulative builder" options (see runtime-api.md §Option 范式分层):
 // nil inputs are silently ignored; the final nil check happens inside
@@ -54,5 +55,24 @@ func WithWebhookClaimer(claimer idempotency.Claimer) Option {
 			return
 		}
 		b.webhookClaimer = claimer
+	}
+}
+
+// WithWebhookSSRFPolicy injects the [kwh.SafePolicy] wired into every outbound
+// webhook dispatcher's *http.Client. A nil value is silently ignored; when any
+// cell registers a webhook dispatcher and no policy was set, phase6 builds the
+// default production policy [kwh.NewSafePolicy] (block all private/reserved
+// ranges, no loopback). Override only for dev / CI — e.g.
+// kwh.NewSafePolicy(kwh.WithAllowLoopback()) to deliver to a local test server.
+//
+// Cumulative builder option (see runtime-api.md §Option 范式分层): the final
+// decision happens at phase6 drain, not at option-apply time, because a
+// deployment with zero dispatchers needs no policy.
+func WithWebhookSSRFPolicy(policy *kwh.SafePolicy) Option {
+	return func(b *Bootstrap) {
+		if policy == nil {
+			return
+		}
+		b.webhookSSRFPolicy = policy
 	}
 }

--- a/runtime/bootstrap/phases_dispatch_test.go
+++ b/runtime/bootstrap/phases_dispatch_test.go
@@ -5,6 +5,7 @@ package bootstrap
 // Coverage:
 //   - empty dispatchers → no-op (no error, router not required)
 //   - dispatchers present + nil webhookSourceStore → fail-fast ErrWebhookConfigInvalid
+//   - dispatchers present + nil Subscriber → phase6 fail-fast (no silent drop)
 //   - CellID drift (req.Spec.CellID != snapshot owner) → drift error
 //   - happy path: a snapshot with one WebhookDispatchRequest + a seeded SourceStore
 //     + a non-nil Subscriber + a ConsumerBase → drainWebhookDispatchers registers
@@ -136,6 +137,27 @@ func TestDrainWebhookDispatchers_FailsWithoutSourceStore(t *testing.T) {
 		"missing source store must yield ErrWebhookConfigInvalid")
 	assert.Contains(t, ecErr.Message, "WithWebhookSourceStore",
 		"error message must name the missing option")
+}
+
+// TestDrainWebhookDispatchers_FailsWhenSubscriberNil (F13) covers the phase6
+// guard at phases_events.go checkNoEventConsumersWhenSubscriberNil: a cell that
+// registers a webhook dispatcher but no Subscriber is configured must fail fast,
+// not silently drop the dispatcher. Drives phase6StartEventRouter with s.sub ==
+// nil (buildPhaseStateWithWebhookCells leaves it unset).
+func TestDrainWebhookDispatchers_FailsWhenSubscriberNil(t *testing.T) {
+	t.Parallel()
+	dc := newWebhookDispatchCell(whTestCellID, dispatchTestContractID, whTestSourceID)
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	b := New(clockmock.New(whFixedNow)) // no WithSubscriber → s.sub stays nil
+
+	err := b.phase6StartEventRouter(context.Background(), s)
+
+	require.Error(t, err, "a webhook dispatcher with no subscriber must fail fast")
+	assert.Contains(t, err.Error(), "webhook dispatcher",
+		"error must identify the webhook dispatcher as the unconsumed event consumer")
+	assert.Contains(t, err.Error(), "no subscriber is configured",
+		"error must tell the operator to add WithSubscriber")
 }
 
 // TestDrainWebhookDispatchers_FailsOnCellIDDrift verifies that a dispatcher

--- a/runtime/bootstrap/phases_dispatch_test.go
+++ b/runtime/bootstrap/phases_dispatch_test.go
@@ -1,0 +1,188 @@
+package bootstrap
+
+// phases_dispatch_test.go — unit tests for the phase6 drainWebhookDispatchers drain.
+//
+// Coverage:
+//   - empty dispatchers → no-op (no error, router not required)
+//   - dispatchers present + nil webhookSourceStore → fail-fast ErrWebhookConfigInvalid
+//   - CellID drift (req.Spec.CellID != snapshot owner) → drift error
+//   - happy path: a snapshot with one WebhookDispatchRequest + a seeded SourceStore
+//     + a non-nil Subscriber + a ConsumerBase → drainWebhookDispatchers registers
+//     the consumer on the event router (HandlerCount == 1, no error).
+//
+// Mirrors the phase5 receiver drain tests in phases_webhook_test.go (same
+// buildPhaseStateWithWebhookCells / whTestCellID / whTestSourceID fixtures).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/metadata"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/ghbvf/gocell/runtime/eventrouter"
+)
+
+// ---------------------------------------------------------------------------
+// webhookDispatchTestCell — registers one outbound dispatcher via Init.
+// ---------------------------------------------------------------------------
+
+// webhookDispatchTestCell registers one WebhookDispatchRequest via
+// reg.RegisterWebhookDispatch in its Init. overrideCellID is used to simulate
+// codegen drift (spec.CellID != snapshot owner).
+type webhookDispatchTestCell struct {
+	*cell.BaseCell
+	spec           kwh.DispatchSpec
+	selector       kwh.WebhookDispatchSelector
+	overrideCellID string
+}
+
+func (c *webhookDispatchTestCell) Init(ctx context.Context, reg cell.Registrar) error {
+	if err := c.BaseCell.Init(ctx, reg); err != nil {
+		return err
+	}
+	spec := c.spec
+	if c.overrideCellID != "" {
+		spec.CellID = c.overrideCellID
+	}
+	return reg.RegisterWebhookDispatch(spec, c.selector)
+}
+
+// newWebhookDispatchCell creates a webhookDispatchTestCell whose spec.CellID
+// equals the BaseCell ID (matching the snapshot key produced by assembly.Snapshots).
+func newWebhookDispatchCell(cellID, contractID, sourceID string) *webhookDispatchTestCell {
+	spec := kwh.DispatchSpec{
+		ContractID: contractID,
+		SourceID:   sourceID,
+		CellID:     cellID,
+	}
+	sel := func(_ context.Context, _ []byte) (string, error) {
+		return "http://example.test/hook", nil
+	}
+	return &webhookDispatchTestCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{
+			ID:   cellID,
+			Type: "core",
+		}),
+		spec:     spec,
+		selector: sel,
+	}
+}
+
+// Compile-time check.
+var _ cell.Cell = (*webhookDispatchTestCell)(nil)
+
+// dispatchTestContractID is the contract ID for dispatch drain tests.
+// Using a unique value avoids collision with the receiver contract.
+const dispatchTestContractID = "webhook.dispatch-test.v1"
+
+// ---------------------------------------------------------------------------
+// newDispatchEvtRouter builds a minimal eventrouter.Router with a real
+// subscriber (eventbus) and consumerBase for the happy-path test.
+// ---------------------------------------------------------------------------
+
+func newDispatchEvtRouter(t *testing.T, b *Bootstrap) *eventrouter.Router {
+	t.Helper()
+	bus := eventbus.New(clockmock.New(whFixedNow))
+	swm, err := b.buildEventRouter(bus)
+	require.NoError(t, err, "buildEventRouter must succeed for dispatch happy path")
+	return swm
+}
+
+// ---------------------------------------------------------------------------
+// drainWebhookDispatchers — unit tests
+// ---------------------------------------------------------------------------
+
+// TestDrainWebhookDispatchers_EmptyNoOp verifies that a phase state with no
+// webhook dispatchers returns nil without touching the router.
+func TestDrainWebhookDispatchers_EmptyNoOp(t *testing.T) {
+	t.Parallel()
+	// Plain cell with no webhook dispatchers.
+	tc := &testCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{ID: "plain-cell", Type: "core"}),
+	}
+	s := buildPhaseStateWithWebhookCells(t, tc)
+
+	b := New(clockmock.New(whFixedNow))
+	// Pass a nil router: empty dispatch must not touch it.
+	err := b.drainWebhookDispatchers(s, nil)
+
+	require.NoError(t, err, "no dispatchers must be a no-op (nil router is fine)")
+}
+
+// TestDrainWebhookDispatchers_FailsWithoutSourceStore verifies that a snapshot
+// with one dispatcher but no WithWebhookSourceStore causes drainWebhookDispatchers
+// to return ErrWebhookConfigInvalid.
+func TestDrainWebhookDispatchers_FailsWithoutSourceStore(t *testing.T) {
+	t.Parallel()
+	dc := newWebhookDispatchCell(whTestCellID, dispatchTestContractID, whTestSourceID)
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	b := New(clockmock.New(whFixedNow))
+	// webhookSourceStore is nil (not set via WithWebhookSourceStore).
+
+	err := b.drainWebhookDispatchers(s, nil)
+
+	require.Error(t, err, "missing source store must error")
+	var ecErr *errcode.Error
+	require.ErrorAs(t, err, &ecErr, "error must be *errcode.Error")
+	assert.Equal(t, errcode.ErrWebhookConfigInvalid, ecErr.Code,
+		"missing source store must yield ErrWebhookConfigInvalid")
+	assert.Contains(t, ecErr.Message, "WithWebhookSourceStore",
+		"error message must name the missing option")
+}
+
+// TestDrainWebhookDispatchers_FailsOnCellIDDrift verifies that a dispatcher
+// whose spec.CellID differs from the snapshot owner causes a drift error.
+func TestDrainWebhookDispatchers_FailsOnCellIDDrift(t *testing.T) {
+	t.Parallel()
+	dc := &webhookDispatchTestCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{ID: whTestCellID, Type: "core"}),
+		spec: kwh.DispatchSpec{
+			ContractID: dispatchTestContractID,
+			SourceID:   whTestSourceID,
+			CellID:     whTestCellID,
+		},
+		selector: func(_ context.Context, _ []byte) (string, error) {
+			return "http://example.test/hook", nil
+		},
+		overrideCellID: "wrongcell", // spec.CellID will be "wrongcell" != snapshot key "webhookcell"
+	}
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	b := New(clockmock.New(whFixedNow))
+	b.webhookSourceStore = whTestStore(t)
+
+	err := b.drainWebhookDispatchers(s, nil)
+
+	require.Error(t, err, "CellID drift must error")
+	assert.Contains(t, err.Error(), "drift", "drift error must mention 'drift'")
+	assert.Contains(t, err.Error(), "wrongcell", "drift error must mention the mismatched CellID")
+}
+
+// TestDrainWebhookDispatchers_HappyPath_RegistersHandler verifies that a
+// well-configured snapshot with one dispatcher and a seeded SourceStore
+// successfully registers one handler on the event router (HandlerCount == 1).
+func TestDrainWebhookDispatchers_HappyPath_RegistersHandler(t *testing.T) {
+	t.Parallel()
+	dc := newWebhookDispatchCell(whTestCellID, dispatchTestContractID, whTestSourceID)
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	clk := clockmock.New(whFixedNow)
+	b := New(clk, WithConsumerBase(newTestConsumerBase(t)))
+	b.webhookSourceStore = whTestStore(t)
+
+	evtRouter := newDispatchEvtRouter(t, b)
+
+	err := b.drainWebhookDispatchers(s, evtRouter)
+
+	require.NoError(t, err, "happy path must not error")
+	assert.Equal(t, 1, evtRouter.HandlerCount(),
+		"one dispatcher must register exactly one handler on the event router")
+}

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -26,8 +26,11 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/eventrouter"
 	metricsmiddleware "github.com/ghbvf/gocell/runtime/observability/metrics"
+	webhookdispatch "github.com/ghbvf/gocell/runtime/webhook/dispatch"
 )
 
 // Compile-time check: EventRouterCollector satisfies eventrouter.EventCollector.
@@ -57,11 +60,11 @@ func (b *Bootstrap) phase6StartEventRouter(runCtx context.Context, s *phaseState
 		// subscriptions once drained) need a Subscriber to consume.
 		return b.checkNoEventConsumersWhenSubscriberNil(s)
 	}
-	if !cellSnapshotsHaveSubscriptions(s) && !cellSnapshotsHaveProjections(s) {
-		// No subscriptions or projections to drain: skip router build entirely.
-		// Avoids invoking NewSubscriberWithMiddleware (which requires a non-nil
-		// ConsumerBase) when the deployment wires a Subscriber for future use
-		// but has no current handlers.
+	if !cellSnapshotsHaveSubscriptions(s) && !cellSnapshotsHaveProjections(s) && !cellSnapshotsHaveDispatchers(s) {
+		// No subscriptions, projections, or webhook dispatchers to drain: skip
+		// router build entirely. Avoids invoking NewSubscriberWithMiddleware
+		// (which requires a non-nil ConsumerBase) when the deployment wires a
+		// Subscriber for future use but has no current handlers.
 		return nil
 	}
 	if err := b.checkConsumerBaseConfiguredForSubscriptions(s); err != nil {
@@ -76,6 +79,9 @@ func (b *Bootstrap) phase6StartEventRouter(runCtx context.Context, s *phaseState
 		return err
 	}
 	if err := b.drainCellProjections(runCtx, s, evtRouter); err != nil {
+		return err
+	}
+	if err := b.drainWebhookDispatchers(s, evtRouter); err != nil {
 		return err
 	}
 
@@ -96,6 +102,73 @@ func cellSnapshotsHaveSubscriptions(s *phaseState) bool {
 		}
 	}
 	return false
+}
+
+// cellSnapshotsHaveDispatchers reports whether any cell snapshot declared at
+// least one outbound webhook dispatcher (reg.RegisterWebhookDispatch). Used
+// alongside cellSnapshotsHaveSubscriptions/Projections to decide whether the
+// event router must be built — dispatchers consume from the broker like
+// subscriptions.
+func cellSnapshotsHaveDispatchers(s *phaseState) bool {
+	for _, id := range s.asm.CellIDs() {
+		snap, ok := s.cellSnapshots[id]
+		if !ok {
+			continue
+		}
+		if len(snap.WebhookDispatchers) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// drainWebhookDispatchers collects all WebhookDispatchRequest entries from cell
+// snapshots, builds an SSRF-guarded HMAC dispatcher for each, and registers it
+// on the event router as an event-kind subscription (Topic == contract ID).
+//
+// CellID drift check mirrors drainCellSubscriptions. Empty collection is a
+// no-op. A non-empty collection requires webhookSourceStore (for signing
+// secrets); the SSRF policy defaults to kwh.NewSafePolicy when unset.
+func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventrouter.Router) error {
+	var reqs []cell.WebhookDispatchRequest
+	for _, id := range s.asm.CellIDs() {
+		snap, ok := s.cellSnapshots[id]
+		if !ok {
+			continue
+		}
+		for _, req := range snap.WebhookDispatchers {
+			if req.Spec.CellID != id {
+				return fmt.Errorf(
+					"bootstrap: cell %s webhook dispatcher drift: declared CellID=%q but snapshot owner=%q"+
+						" (codegen should inject cellID from cell metadata; check cellgen + contractgen templates)",
+					id, req.Spec.CellID, id)
+			}
+			reqs = append(reqs, req)
+		}
+	}
+	if len(reqs) == 0 {
+		return nil
+	}
+	if b.webhookSourceStore == nil {
+		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"bootstrap: webhook dispatchers declared but no source store configured; "+
+				"add WithWebhookSourceStore to bootstrap options")
+	}
+	policy := b.webhookSSRFPolicy
+	if policy == nil {
+		// Default production policy: block all private/reserved ranges, no loopback.
+		policy = kwh.NewSafePolicy()
+	}
+	consumers, err := webhookdispatch.BuildConsumers(b.clock, reqs, b.webhookSourceStore, policy)
+	if err != nil {
+		return fmt.Errorf("bootstrap: build webhook dispatch consumers: %w", err)
+	}
+	for _, c := range consumers {
+		if err := evtRouter.AddContractHandler(c.Spec, c.Handler, c.ConsumerGroup, c.CellID); err != nil {
+			return fmt.Errorf("bootstrap: webhook dispatch setup failed for contract %q: %w", c.Spec.ID, err)
+		}
+	}
+	return nil
 }
 
 // autoWireEventRouterCollector creates an EventRouterCollector (once, cached in
@@ -251,6 +324,11 @@ func (b *Bootstrap) checkNoEventConsumersWhenSubscriberNil(s *phaseState) error 
 				"bootstrap: cell %s registered a projection but no subscriber is configured; "+
 					"add WithSubscriber to bootstrap options", id)
 		}
+		if len(snap.WebhookDispatchers) > 0 {
+			return fmt.Errorf(
+				"bootstrap: cell %s registered a webhook dispatcher but no subscriber is configured; "+
+					"add WithSubscriber to bootstrap options", id)
+		}
 	}
 	return nil
 }
@@ -327,31 +405,43 @@ func (b *Bootstrap) checkConsumerBaseConfiguredForSubscriptions(s *phaseState) e
 		if !ok {
 			continue
 		}
-		for _, sub := range snap.Subscriptions {
-			if b.consumerBase == nil {
-				return fmt.Errorf(
-					"bootstrap: cell %s registered subscription topic %q but no ConsumerBase is configured; "+
-						"add WithConsumerBase to bootstrap options", id, sub.Spec.Topic)
-			}
-			return fmt.Errorf(
-				"bootstrap: cell %s registered subscription topic %q but ConsumerBase (%T) was not constructed via "+
-					"outbox.NewConsumerBase (got a zero-value `&outbox.ConsumerBase{}` literal); "+
-					"call outbox.NewConsumerBase to obtain a properly initialized value",
-				id, sub.Spec.Topic, b.consumerBase)
-		}
-		for _, proj := range snap.Projections {
-			if b.consumerBase == nil {
-				return fmt.Errorf(
-					"bootstrap: cell %s registered projection topic %q but no ConsumerBase is configured; "+
-						"projections consume via the same ConsumerBase path as subscriptions — "+
-						"add WithConsumerBase to bootstrap options", id, proj.Spec.Topic)
-			}
-			return fmt.Errorf(
-				"bootstrap: cell %s registered projection topic %q but ConsumerBase (%T) was not constructed via "+
-					"outbox.NewConsumerBase (got a zero-value `&outbox.ConsumerBase{}` literal); "+
-					"call outbox.NewConsumerBase to obtain a properly initialized value",
-				id, proj.Spec.Topic, b.consumerBase)
+		if kind, topic, found := firstConsumerInSnapshot(snap); found {
+			return b.consumerBaseMisconfigError(id, kind, topic)
 		}
 	}
 	return nil
+}
+
+// firstConsumerInSnapshot returns the kind ("subscription" / "projection" /
+// "webhook dispatcher") and topic of the first ConsumerBase-backed consumer
+// declared in snap, or found=false when there are none. All three consume via
+// the same ConsumerBase path, so any one of them makes a configured
+// ConsumerBase mandatory.
+func firstConsumerInSnapshot(snap cell.RegistrySnapshot) (kind, topic string, found bool) {
+	if len(snap.Subscriptions) > 0 {
+		return "subscription topic", snap.Subscriptions[0].Spec.Topic, true
+	}
+	if len(snap.Projections) > 0 {
+		return "projection topic", snap.Projections[0].Spec.Topic, true
+	}
+	if len(snap.WebhookDispatchers) > 0 {
+		return "webhook dispatcher", snap.WebhookDispatchers[0].Spec.ContractID, true
+	}
+	return "", "", false
+}
+
+// consumerBaseMisconfigError formats the fail-fast error for a cell that
+// declared a ConsumerBase-backed consumer while no constructed ConsumerBase is
+// wired — distinguishing "missing" from "zero-value literal" (N8 (b)).
+func (b *Bootstrap) consumerBaseMisconfigError(cellID, kind, topic string) error {
+	if b.consumerBase == nil {
+		return fmt.Errorf(
+			"bootstrap: cell %s registered %s %q but no ConsumerBase is configured; "+
+				"add WithConsumerBase to bootstrap options", cellID, kind, topic)
+	}
+	return fmt.Errorf(
+		"bootstrap: cell %s registered %s %q but ConsumerBase (%T) was not constructed via "+
+			"outbox.NewConsumerBase (got a zero-value `&outbox.ConsumerBase{}` literal); "+
+			"call outbox.NewConsumerBase to obtain a properly initialized value",
+		cellID, kind, topic, b.consumerBase)
 }

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -150,7 +150,7 @@ func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventroute
 		return nil
 	}
 	if b.webhookSourceStore == nil {
-		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
 			"bootstrap: webhook dispatchers declared but no source store configured; "+
 				"add WithWebhookSourceStore to bootstrap options")
 	}

--- a/runtime/webhook/dispatch/dispatch.go
+++ b/runtime/webhook/dispatch/dispatch.go
@@ -1,0 +1,132 @@
+// Package dispatch wires outbound-webhook dispatchers into the event router.
+//
+// An outbound webhook is modeled as an event subscription: the producing cell
+// emits a domain event to the broker on a topic equal to the webhook-dispatch
+// contract ID, and this package registers a [kwh.Dispatcher] as that
+// subscription's handler. Each consumed [outbox.Entry] is signed (HMAC-SHA256,
+// vendor-neutral webhook-* headers) and POSTed to the selector-resolved target
+// through an SSRF-guarded *http.Client. Delivery outcomes map to outbox
+// dispositions via [kwh.Classify] (2xx Ack / 5xx·408·429·timeout Requeue /
+// other 4xx·3xx·SSRF Reject).
+//
+// This mirrors the inbound receiver pattern (runtime/webhook/registry.go
+// BuildRouteGroups) but the dispatch side consumes from the broker rather than
+// mounting HTTP routes, so it drains through the event router (phase6) rather
+// than the HTTP route-group drain (phase5).
+package dispatch
+
+import (
+	"fmt"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cellvocab"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/contractspec"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
+)
+
+// dispatchTransport is the broker transport for webhook-dispatch subscriptions.
+// The dispatcher consumes outbound-intent entries from the outbox broker, same
+// as any event subscription.
+const dispatchTransport = "amqp"
+
+// Consumer is a built outbound-webhook dispatcher paired with the subscription
+// identity needed to register it on the event router via AddContractHandler.
+type Consumer struct {
+	// Spec is the synthesized event-kind ContractSpec the router subscribes on.
+	// Topic == the webhook-dispatch contract ID: the producing cell emits to
+	// that topic, this consumer signs and POSTs each delivered entry.
+	Spec contractspec.ContractSpec
+	// Handler is the dispatcher's Handle method (an outbox.EntryHandler).
+	Handler outbox.EntryHandler
+	// ConsumerGroup and CellID are both the owning cell ID: replicas of the
+	// same cell compete for delivery (one POST per entry), and the cell is the
+	// observability owner.
+	ConsumerGroup string
+	CellID        string
+}
+
+// BuildConsumers turns the accumulated [cell.WebhookDispatchRequest] values
+// (from RegistrySnapshot.WebhookDispatchers) into [Consumer] values ready for
+// the bootstrap phase6 drain to register on the event router.
+//
+// clk is the mandatory positional clock (CLOCK-POSITIONAL-INJECTION-01). store
+// resolves each request's signing secret by SourceID; policy is the shared
+// SSRF guard wired into every dispatcher's *http.Client. Both must be non-nil.
+// Construction is eager so a missing source or bad config fails at startup
+// rather than at first delivery.
+func BuildConsumers(
+	clk clock.Clock,
+	reqs []cell.WebhookDispatchRequest,
+	store kwh.SourceStore,
+	policy *kwh.SafePolicy,
+) ([]Consumer, error) {
+	clock.MustHaveClock(clk, "webhook/dispatch.BuildConsumers")
+	if validation.IsNilInterface(store) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch: source store must not be nil")
+	}
+	if policy == nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch: SSRF policy must not be nil")
+	}
+	out := make([]Consumer, 0, len(reqs))
+	for _, req := range reqs {
+		c, err := buildConsumer(clk, req, store, policy)
+		if err != nil {
+			return nil, fmt.Errorf("webhook dispatch: contract %q: %w", req.Spec.ContractID, err)
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// buildConsumer constructs a single Consumer: resolve source → HMAC signer →
+// SSRF-guarded Dispatcher → synthesized event-kind subscription spec.
+func buildConsumer(
+	clk clock.Clock,
+	req cell.WebhookDispatchRequest,
+	store kwh.SourceStore,
+	policy *kwh.SafePolicy,
+) (Consumer, error) {
+	spec := req.Spec
+	if err := spec.Validate(); err != nil {
+		return Consumer{}, err
+	}
+	if req.Selector == nil {
+		return Consumer{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch: target selector must not be nil")
+	}
+	sourceID, err := kwh.NewSourceID(spec.SourceID)
+	if err != nil {
+		return Consumer{}, err
+	}
+	src, ok := store.Lookup(sourceID)
+	if !ok {
+		return Consumer{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch: signing source not registered",
+			errcode.WithInternal(errcode.InternalAttr("source_id", spec.SourceID)))
+	}
+	signer, err := kwh.NewHMACSigner(src)
+	if err != nil {
+		return Consumer{}, err
+	}
+	dispatcher, err := kwh.NewDispatcher(clk, signer, policy, req.Selector)
+	if err != nil {
+		return Consumer{}, err
+	}
+	return Consumer{
+		Spec: contractspec.ContractSpec{
+			ID:        spec.ContractID,
+			Kind:      cellvocab.ContractEvent,
+			Transport: dispatchTransport,
+			Topic:     spec.ContractID,
+		},
+		Handler:       dispatcher.Handle,
+		ConsumerGroup: spec.CellID,
+		CellID:        spec.CellID,
+	}, nil
+}

--- a/runtime/webhook/dispatch/dispatch.go
+++ b/runtime/webhook/dispatch/dispatch.go
@@ -13,6 +13,27 @@
 // BuildRouteGroups) but the dispatch side consumes from the broker rather than
 // mounting HTTP routes, so it drains through the event router (phase6) rather
 // than the HTTP route-group drain (phase5).
+//
+// # Troubleshooting
+//
+// "webhook dispatchers declared but no source store configured":
+// Bootstrap failed because at least one cell registered a webhook-dispatch
+// contract but WithWebhookSourceStore was not passed to bootstrap. Add the
+// option and provide a populated [kwh.SourceStore].
+//
+// "webhook dispatch: signing source not registered" (sourceId in error details):
+// BuildConsumers found no entry in the SourceStore for the SourceID declared in
+// DispatchSpec. The missing sourceId is reported in the error details. Register
+// the source secret in the store before starting.
+//
+// "no cell.go struct field for subscribing slice" from gocell generate cell:
+// The cell struct lacks a field whose pointer type package name matches the
+// webhook-dispatch slice ID. Add *<sliceID>.Consumer (or equivalent) to the
+// cell struct and re-run codegen.
+//
+// "ambiguous field for slice <sliceID>" from gocell generate cell:
+// Multiple cell struct fields match the slice ID. Add field: <fieldName> to
+// the webhook-dispatch contractUsage in slice.yaml to disambiguate.
 package dispatch
 
 import (
@@ -49,6 +70,29 @@ type Consumer struct {
 	CellID        string
 }
 
+// Validate checks that all required Consumer fields are populated. buildConsumer
+// calls this as a belt-and-suspenders guard before returning, consistent with
+// ReceiverSpec.Validate and DispatchSpec.Validate.
+func (c Consumer) Validate() error {
+	if c.Spec.ID == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch consumer: Spec.ID must not be empty")
+	}
+	if c.Handler == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch consumer: Handler must not be nil")
+	}
+	if c.ConsumerGroup == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch consumer: ConsumerGroup must not be empty")
+	}
+	if c.CellID == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch consumer: CellID must not be empty")
+	}
+	return nil
+}
+
 // BuildConsumers turns the accumulated [cell.WebhookDispatchRequest] values
 // (from RegistrySnapshot.WebhookDispatchers) into [Consumer] values ready for
 // the bootstrap phase6 drain to register on the event router.
@@ -58,6 +102,10 @@ type Consumer struct {
 // SSRF guard wired into every dispatcher's *http.Client. Both must be non-nil.
 // Construction is eager so a missing source or bad config fails at startup
 // rather than at first delivery.
+//
+// DLX: the composition root must configure the broker subscriber's DLX exchange
+// for dispatch subscription topics; permanently-failed deliveries (Reject) are
+// Nack(requeue=false)→DLX and are otherwise silently discarded.
 func BuildConsumers(
 	clk clock.Clock,
 	reqs []cell.WebhookDispatchRequest,
@@ -86,6 +134,10 @@ func BuildConsumers(
 
 // buildConsumer constructs a single Consumer: resolve source → HMAC signer →
 // SSRF-guarded Dispatcher → synthesized event-kind subscription spec.
+//
+// Producer contract: Topic == spec.ContractID — the producing cell MUST emit
+// outbox entries on a broker topic whose value equals the webhook-dispatch
+// contract ID (same convention as event subscriptions).
 func buildConsumer(
 	clk clock.Clock,
 	req cell.WebhookDispatchRequest,
@@ -108,6 +160,7 @@ func buildConsumer(
 	if !ok {
 		return Consumer{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
 			"webhook dispatch: signing source not registered",
+			errcode.WithDetails(errcode.PublicString("sourceId", spec.SourceID)),
 			errcode.WithInternal(errcode.InternalAttr("source_id", spec.SourceID)))
 	}
 	signer, err := kwh.NewHMACSigner(src)
@@ -118,7 +171,7 @@ func buildConsumer(
 	if err != nil {
 		return Consumer{}, err
 	}
-	return Consumer{
+	c := Consumer{
 		Spec: contractspec.ContractSpec{
 			ID:        spec.ContractID,
 			Kind:      cellvocab.ContractEvent,
@@ -128,5 +181,9 @@ func buildConsumer(
 		Handler:       dispatcher.Handle,
 		ConsumerGroup: spec.CellID,
 		CellID:        spec.CellID,
-	}, nil
+	}
+	if err := c.Validate(); err != nil {
+		return Consumer{}, err
+	}
+	return c, nil
 }

--- a/runtime/webhook/dispatch/dispatch.go
+++ b/runtime/webhook/dispatch/dispatch.go
@@ -6,8 +6,8 @@
 // subscription's handler. Each consumed [outbox.Entry] is signed (HMAC-SHA256,
 // vendor-neutral webhook-* headers) and POSTed to the selector-resolved target
 // through an SSRF-guarded *http.Client. Delivery outcomes map to outbox
-// dispositions via [kwh.Classify] (2xx Ack / 5xx·408·429·timeout Requeue /
-// other 4xx·3xx·SSRF Reject).
+// dispositions via [kwh.Classify] (standard-webhooks aligned: 2xx Ack / every
+// non-2xx + transient transport Requeue / SSRF-blocked Reject).
 //
 // This mirrors the inbound receiver pattern (runtime/webhook/registry.go
 // BuildRouteGroups) but the dispatch side consumes from the broker rather than

--- a/runtime/webhook/dispatch/dispatch_test.go
+++ b/runtime/webhook/dispatch/dispatch_test.go
@@ -1,0 +1,124 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cellvocab"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+const dispatchTS = 1700000000
+
+// testStore returns a SourceRegistry seeded with one source under sourceID.
+func testStore(t *testing.T, sourceID string) kwh.SourceStore {
+	t.Helper()
+	reg := kwh.NewSourceRegistry()
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = byte(i + 1)
+	}
+	sid, err := kwh.NewSourceID(sourceID)
+	require.NoError(t, err)
+	src, err := kwh.NewSource(sid, secret)
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(src))
+	return reg
+}
+
+func okSelector(_ context.Context, _ []byte) (string, error) {
+	return "https://hooks.example.test/", nil
+}
+
+func dispatchReq(contractID, sourceID, cellID string) cell.WebhookDispatchRequest {
+	return cell.WebhookDispatchRequest{
+		Spec:     kwh.DispatchSpec{ContractID: contractID, SourceID: sourceID, CellID: cellID},
+		Selector: okSelector,
+	}
+}
+
+func testClock() *clockmock.FakeClock { return clockmock.New(time.Unix(dispatchTS, 0)) }
+
+func TestBuildConsumers_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := testStore(t, "shopify")
+	reqs := []cell.WebhookDispatchRequest{
+		dispatchReq("webhook.shopify.orders.v1", "shopify", "ordercore"),
+	}
+	consumers, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy())
+	require.NoError(t, err)
+	require.Len(t, consumers, 1)
+
+	c := consumers[0]
+	assert.Equal(t, "webhook.shopify.orders.v1", c.Spec.ID)
+	assert.Equal(t, cellvocab.ContractEvent, c.Spec.Kind, "registered as event-kind so AddContractHandler accepts it")
+	assert.Equal(t, "webhook.shopify.orders.v1", c.Spec.Topic, "Topic == contract ID")
+	assert.NotEmpty(t, c.Spec.Transport)
+	assert.Equal(t, "ordercore", c.ConsumerGroup)
+	assert.Equal(t, "ordercore", c.CellID)
+	require.NotNil(t, c.Handler)
+	// Synthesized spec must pass the contractspec event validator (what
+	// eventrouter.AddContractHandler enforces).
+	require.NoError(t, c.Spec.Validate())
+}
+
+func TestBuildConsumers_Empty(t *testing.T) {
+	t.Parallel()
+	consumers, err := BuildConsumers(testClock(), nil, testStore(t, "s"), kwh.NewSafePolicy())
+	require.NoError(t, err)
+	assert.Empty(t, consumers)
+}
+
+func TestBuildConsumers_NilStore(t *testing.T) {
+	t.Parallel()
+	_, err := BuildConsumers(testClock(), nil, nil, kwh.NewSafePolicy())
+	requireWebhookConfigErr(t, err)
+}
+
+func TestBuildConsumers_NilPolicy(t *testing.T) {
+	t.Parallel()
+	_, err := BuildConsumers(testClock(), nil, testStore(t, "s"), nil)
+	requireWebhookConfigErr(t, err)
+}
+
+func TestBuildConsumers_UnregisteredSource(t *testing.T) {
+	t.Parallel()
+	store := testStore(t, "shopify")
+	reqs := []cell.WebhookDispatchRequest{dispatchReq("webhook.x.v1", "stripe", "c")} // "stripe" not registered
+	_, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy())
+	requireWebhookConfigErr(t, err)
+}
+
+func TestBuildConsumers_NilSelector(t *testing.T) {
+	t.Parallel()
+	store := testStore(t, "shopify")
+	req := cell.WebhookDispatchRequest{
+		Spec:     kwh.DispatchSpec{ContractID: "webhook.x.v1", SourceID: "shopify", CellID: "c"},
+		Selector: nil,
+	}
+	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy())
+	requireWebhookConfigErr(t, err)
+}
+
+func TestBuildConsumers_InvalidSpec(t *testing.T) {
+	t.Parallel()
+	store := testStore(t, "shopify")
+	req := dispatchReq("", "shopify", "c") // empty ContractID → spec invalid
+	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy())
+	requireWebhookConfigErr(t, err)
+}
+
+func requireWebhookConfigErr(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var ee *errcode.Error
+	require.ErrorAs(t, err, &ee)
+	assert.Equal(t, errcode.ErrWebhookConfigInvalid, ee.Code)
+}

--- a/tools/archtest/testdata/webhook_signer_violate/go.mod
+++ b/tools/archtest/testdata/webhook_signer_violate/go.mod
@@ -1,0 +1,3 @@
+module fixturetest/webhook_signer_violate
+
+go 1.25.10

--- a/tools/archtest/testdata/webhook_signer_violate/violations.go
+++ b/tools/archtest/testdata/webhook_signer_violate/violations.go
@@ -1,0 +1,40 @@
+// Package webhook_signer_violate is a synthetic violation fixture for the
+// WEBHOOK-SIGNER-FUNNEL-01 archtest rule. It exercises the one violation form
+// that the rule is designed to catch: Header.Set called with a signature-header
+// key from outside (Headers).Apply.
+//
+// DO NOT use this package in production code.
+package webhook_signer_violate
+
+import "net/http"
+
+const (
+	// Redeclared locally so the fixture module needs no replace directive and no
+	// import of kernel/webhook. The rule scans for the STRING VALUE of these
+	// constants (EvaluateConstString), not their identity, so a local redeclaration
+	// is sufficient to exercise the violation form.
+	headerSignature = "webhook-signature"
+	headerID        = "webhook-id"
+	headerTimestamp = "webhook-timestamp"
+)
+
+// forgeSignatureHeader directly writes the webhook-signature header outside
+// (Headers).Apply — the canonical violation the rule prohibits.
+func forgeSignatureHeader(h http.Header) {
+	h.Set("webhook-signature", "v1,forged") // VIOLATION: literal string key
+}
+
+// forgeViaConst uses a local const whose value is the signature header name.
+func forgeViaConst(h http.Header) {
+	h.Set(headerSignature, "v1,forged") // VIOLATION: const that evaluates to "webhook-signature"
+}
+
+// forgeIDHeader writes the webhook-id header directly.
+func forgeIDHeader(h http.Header) {
+	h.Set(headerID, "bad-delivery-id") // VIOLATION: const that evaluates to "webhook-id"
+}
+
+// forgeTimestampHeader writes the webhook-timestamp header directly.
+func forgeTimestampHeader(h http.Header) {
+	h.Set(headerTimestamp, "0") // VIOLATION: const that evaluates to "webhook-timestamp"
+}

--- a/tools/archtest/testdata/webhook_ssrf_violate/violations.go
+++ b/tools/archtest/testdata/webhook_ssrf_violate/violations.go
@@ -71,3 +71,10 @@ func fetchViaHead() (*http.Response, error) {
 func transportRef() http.RoundTripper {
 	return http.DefaultTransport // VIOLATION A3 (http.DefaultTransport)
 }
+
+// ── A4 violation: &http.Transport{} composite literal with no DialContext ──
+// The absence of DialContext lets the transport fall back to the net default
+// dialer, which bypasses SSRF vetting.
+func buildUnsafeTransport() *http.Transport {
+	return &http.Transport{} // VIOLATION A4 (no DialContext field)
+}

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -1,0 +1,265 @@
+// INVARIANT: WEBHOOK-SIGNER-FUNNEL-01
+//
+// WEBHOOK-SIGNER-FUNNEL-01 — kernel/webhook signature-header write funnel.
+//
+// The three outbound webhook signature headers (webhook-id / webhook-timestamp
+// / webhook-signature) define GoCell's outbound identity protocol: only a value
+// produced by a sealed [Signer.Sign] (which returns a [Headers]) may reach the
+// wire. That guarantee is worthless if any code can bypass it by calling
+// http.Header.Set with one of the three header-name strings directly.
+//
+// This rule locks every http.Header.Set call whose key argument evaluates to
+// one of the three header-name constant values to the sole sanctioned body:
+// [(Headers).Apply] in kernel/webhook/webhook.go.
+//
+//   - A1 (downstream Hard): scan production (non-_test.go) files in
+//     kernel/webhook/... and runtime/webhook/... for any
+//     (net/http.Header).Set call whose key argument evaluates (via
+//     EvaluateConstString) to one of the three header-name strings
+//     ("webhook-id" / "webhook-timestamp" / "webhook-signature"). Any such
+//     call whose enclosing function is NOT [signerSanctionedApplyFunc] is a
+//     violation. Detection uses ResolveMethodCall to confirm the callee is
+//     net/http.Header.Set (alias-safe), EvaluateConstString to fold the key
+//     argument across const refs and raw literals, and ResolveEnclosingFunc to
+//     bind the allowance to a go/types FullName identity (file- and
+//     name-independent).
+//
+// AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
+//
+//	下游 Hard — A1 is form-unique, type-resolved callsite-allowlist.
+//	  ResolveMethodCall resolves import aliases and value-refs so alias bypass
+//	  is ineffective. EvaluateConstString folds across const definitions.
+//	  ResolveEnclosingFunc binds the allowance to a go/types FullName — a
+//	  stray func that merely shares the name "Apply" cannot inherit it.
+//	上游 Hard (external) — [Headers] is produced only by a sealed
+//	  [Signer.Sign]: Signer carries an unexported sealed() marker method
+//	  (WEBHOOK-HMAC-FUNNEL-01/A3) so package-external Signer implementations
+//	  are a compile error; Sign() is the only path to a Headers value; and
+//	  Headers has no exported constructor outside of Sign. Thus an
+//	  externally-created Headers value (and hence a call to Apply) is
+//	  inexpressible at the type-system level.
+//	上游 Medium (package-internal) — Go package visibility cannot express
+//	  "only one struct within the same package may declare a Headers field".
+//	  A new package-internal struct that holds a Headers value and calls
+//	  Apply is syntactically expressible; it is caught by the downstream A1
+//	  scan at CI time, not at compile time. This is the same permanent ceiling
+//	  as SPAN-SETATTR-HOLDER-SEAL (#851) / HEALTHZ-HOLDER-SEAL (#893) /
+//	  WEBHOOK-SSRF-GUARD-01 (#1375). Explicit Hard-ization of the
+//	  package-internal axis is tracked in gh #1243 (inherited from the Signer
+//	  sealing issue, which already covers this axis).
+//
+// Note: WEBHOOK-SIGNED-STRING-FORM-01 (signed-string "{deliveryID}.{timestamp}
+// .{body}" form) is NOT a new archtest here. It is already locked by:
+//   - TestSign_MatchesSvixGoldenVector in kernel/webhook/signer_test.go
+//     (byte-exact Svix golden vector: any change to the signed-string format
+//     breaks this test immediately)
+//   - WEBHOOK-HMAC-FUNNEL-01/A1 (sole computeMAC callsite — the MAC covers
+//     the signed string, so the format cannot change without also changing the
+//     unique computeMAC callsite, which is in the archtest allowlist)
+//
+// A duplicate AST literal-lock would create parallel structure without
+// additional safety; both existing locks are already behavioral. (Per
+// ai-robust.md: avoid parallel structure.)
+//
+// Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
+//
+//	B-A1 — rule-logic regression: testdata/webhook_signer_violate exercises
+//	  Header.Set with a raw string literal key and with a const key that
+//	  evaluates to each of the three header names;
+//	  TestWebhookSignerFunnel_ReverseFixture asserts A1 fires on each form.
+//	B3 — fmt.Fprintf raw-write bypass: code that writes the header via
+//	  fmt.Fprintf(w, "webhook-signature: %s\r\n", val) on a raw net.Conn or
+//	  bufio.Writer cannot be caught by the Set-callee scan (no CallExpr with a
+//	  resolvable net/http.Header.Set callee). Bounded response: the realistic
+//	  egress path for outbound webhooks is http.Client.Do over an *http.Request
+//	  (which uses header.Set internally); raw TCP writes that happen to embed
+//	  the header name would be caught by WEBHOOK-SSRF-GUARD-01/A1 (net.Dial*
+//	  ban) before they could produce a valid delivery.
+//
+// ref: docs/architecture/202605291200-adr-webhook-signing-algorithm.md
+// ref: tools/archtest/webhook_hmac_funnel_test.go (A3 sealed-interface template)
+// ref: tools/archtest/webhook_ssrf_guard_test.go (FullName-bound allowance template)
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// signerSanctionedApplyFunc is the go/types canonical FullName of the ONE
+	// function allowed to call Header.Set with a webhook signature-header key.
+	// Headers has a value receiver, so FullName does NOT have a leading "*".
+	// Binding the A1 allowance to this type-resolved identity means a stray func
+	// that merely shares the name "Apply" cannot inherit it, and the method can
+	// move files freely without updating this const. A rename of the method flips
+	// every violation to caught (fail-closed), forcing the author to update here.
+	signerSanctionedApplyFunc = "(" + PlatformModulePath + "/kernel/webhook.Headers).Apply"
+
+	httpPkgPath = "net/http"
+)
+
+// webhookSignatureHeaders is the set of header-name string VALUES that are
+// locked to (Headers).Apply. The scan evaluates the key argument to a string
+// constant (EvaluateConstString) and checks membership here — covering both
+// raw string literals and const references from any package.
+var webhookSignatureHeaders = map[string]bool{
+	"webhook-id":        true,
+	"webhook-timestamp": true,
+	"webhook-signature": true,
+}
+
+// scanSignerHeaderSet implements A1: http.Header.Set calls whose key evaluates
+// to one of the three signature-header names must be enclosed by
+// signerSanctionedApplyFunc. Any other enclosing function (including the
+// package-level init or a FuncLit) is a violation.
+func scanSignerHeaderSet(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		// Confirm the callee is (net/http.Header).Set — type-resolved, so import
+		// aliases cannot bypass.
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		fn, ok := ResolveMethodCall(info, sel)
+		if !ok || fn == nil || fn.Pkg() == nil ||
+			fn.Pkg().Path() != httpPkgPath || fn.Name() != "Set" {
+			return
+		}
+		// Confirm the receiver type is net/http.Header (not some other type
+		// that also has a Set method).
+		recvType := info.TypeOf(sel.X)
+		if recvType == nil {
+			return
+		}
+		// Unwrap pointer if needed.
+		if ptr, ok := recvType.(*types.Pointer); ok {
+			recvType = ptr.Elem()
+		}
+		named, ok := recvType.(*types.Named)
+		if !ok {
+			return
+		}
+		if named.Obj() == nil || named.Obj().Pkg() == nil ||
+			named.Obj().Pkg().Path() != httpPkgPath || named.Obj().Name() != "Header" {
+			return
+		}
+
+		// Call is confirmed to be (net/http.Header).Set. Evaluate the key arg.
+		if len(call.Args) < 1 {
+			return
+		}
+		keyVal, ok := EvaluateConstString(info, call.Args[0])
+		if !ok || !webhookSignatureHeaders[keyVal] {
+			return
+		}
+
+		// Key matches a signature header. Check the enclosing function.
+		enc, ok := ResolveEnclosingFunc(info, file, call)
+		if ok && enc != nil && enc.FullName() == signerSanctionedApplyFunc {
+			return // sanctioned
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "http.Header.Set with key \"" + keyVal + "\" called outside " +
+				"(Headers).Apply; signature headers must only be written by " +
+				"Headers.Apply (WEBHOOK-SIGNER-FUNNEL-01/A1)",
+		})
+	})
+	return out
+}
+
+// webhookSignerPkgPatterns are the package patterns scanned by
+// TestWebhookSignerFunnel. Covers both the kernel types and the runtime
+// consumer layer.
+var webhookSignerPkgPatterns = []string{
+	"./kernel/webhook/...",
+	"./runtime/webhook/...",
+}
+
+func TestWebhookSignerFunnel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var a1 []Diagnostic
+
+	_ = RunTyped(t, TypedOpts{Tests: false}, webhookSignerPkgPatterns,
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			// Scope: kernel/webhook and runtime/webhook production only.
+			pkgPath := p.Pkg.Path()
+			if pkgPath != PlatformModulePath+"/kernel/webhook" &&
+				pkgPath != PlatformModulePath+"/runtime/webhook" {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanSignerHeaderSet(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+
+	Report(t, "WEBHOOK-SIGNER-FUNNEL-01/A1", a1)
+}
+
+// TestWebhookSignerFunnel_ReverseFixture loads the synthetic violation fixture
+// and asserts A1 fires on every violation form — guards against the rule logic
+// silently regressing to a vacuous pass (B-A1 blind-spot self-test).
+//
+// The fixture covers:
+//
+//   - raw string literal key "webhook-signature"
+//   - const key whose value is "webhook-signature"
+//   - const key whose value is "webhook-id"
+//   - const key whose value is "webhook-timestamp"
+//
+// so that dropping any one of the three header names from webhookSignatureHeaders
+// causes this test to fail.
+func TestWebhookSignerFunnel_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_signer_violate")
+
+	var a1 []Diagnostic
+	_ = RunTypedDir(t, fixtureDir, TypedOpts{Tests: false}, []string{"./..."},
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				a1 = append(a1, scanSignerHeaderSet(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+
+	// Expect at least one diagnostic per header name (3 headers × raw-literal + const forms).
+	// The fixture has 4 violations (1 raw literal + 3 const refs covering each header),
+	// asserting ≥3 ensures all three header-name entries in webhookSignatureHeaders are
+	// exercised — a regression removing any one header from the set fails here.
+	assert.GreaterOrEqual(t, len(a1), len(webhookSignatureHeaders),
+		"A1 reverse fixture: expected ≥1 diagnostic per signature header name "+
+			"(webhook-id / webhook-timestamp / webhook-signature)")
+}

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -255,11 +255,15 @@ func TestWebhookSignerFunnel_ReverseFixture(t *testing.T) {
 			return nil
 		})
 
-	// Expect at least one diagnostic per header name (3 headers × raw-literal + const forms).
-	// The fixture has 4 violations (1 raw literal + 3 const refs covering each header),
-	// asserting ≥3 ensures all three header-name entries in webhookSignatureHeaders are
-	// exercised — a regression removing any one header from the set fails here.
-	assert.GreaterOrEqual(t, len(a1), len(webhookSignatureHeaders),
-		"A1 reverse fixture: expected ≥1 diagnostic per signature header name "+
-			"(webhook-id / webhook-timestamp / webhook-signature)")
+	// The fixture has exactly 4 violations:
+	//   - 1 raw string literal key "webhook-signature"
+	//   - 3 const-keyed calls, one per header name (webhook-id / webhook-timestamp
+	//     / webhook-signature)
+	// Asserting ≥4 ensures that dropping ANY single fixture violation (e.g. removing
+	// one const form or one header name from webhookSignatureHeaders) causes this
+	// self-test to fail immediately, rather than passing on the remaining 3.
+	const webhookSignerFixtureMinViolations = 4
+	assert.GreaterOrEqual(t, len(a1), webhookSignerFixtureMinViolations,
+		"A1 reverse fixture: expected ≥4 diagnostics (1 raw literal + 3 const refs, "+
+			"one per header name webhook-id / webhook-timestamp / webhook-signature)")
 }

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -198,10 +198,19 @@ func TestWebhookSignerFunnel(t *testing.T) {
 			if p.Pkg == nil {
 				return nil
 			}
-			// Scope: kernel/webhook and runtime/webhook production only.
+			// Scope: the kernel/webhook and runtime/webhook production trees,
+			// INCLUDING subpackages. Exact-match previously excluded
+			// runtime/webhook/dispatch — the ./runtime/webhook/... pattern loads
+			// it, but the filter dropped it — so a bare Header.Set of a signature
+			// header in the dispatcher consumer layer (where Headers.Apply is
+			// actually called) would have slipped past the funnel. Subtree-match
+			// (exact base or base+"/") also auto-covers any future subpackage.
 			pkgPath := p.Pkg.Path()
-			if pkgPath != PlatformModulePath+"/kernel/webhook" &&
-				pkgPath != PlatformModulePath+"/runtime/webhook" {
+			inTree := func(base string) bool {
+				return pkgPath == base || strings.HasPrefix(pkgPath, base+"/")
+			}
+			if !inTree(PlatformModulePath+"/kernel/webhook") &&
+				!inTree(PlatformModulePath+"/runtime/webhook") {
 				return nil
 			}
 			for _, f := range p.Files {

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -2,15 +2,12 @@
 //
 // WEBHOOK-SSRF-GUARD-01 — kernel/webhook outbound network funnel (KERNEL-WEBHOOK-01).
 //
-// PR-4 ships the pure SSRF building block: SafePolicy, the single-source policy
-// whose DialContext / ValidateTargetURL / DenyRedirect methods share one config.
-// The dispatcher that HOLDS the *SafePolicy and wires its methods into an
-// *http.Client is PR-5; the Dispatcher.client typed-field upstream lock is
-// therefore deferred to PR-5 (the struct does not exist yet — a field scan now
-// would pass vacuously). This invariant locks the package-level callsite bans
-// that ARE meaningful for a pure building block: any outbound network primitive
-// in kernel/webhook must funnel through the vetted dialer, so PR-5 cannot wire
-// an un-vetted egress path.
+// PR-4 shipped the pure SSRF building block: SafePolicy, the single-source
+// policy whose DialContext / ValidateTargetURL / DenyRedirect methods share one
+// config. PR-5 delivers the Dispatcher, which HOLDS a *SafePolicy and wires its
+// methods into an *http.Client. A4 locks the Transport composite-literal form in
+// the dispatcher — the dispatcher-specific single-sanctioned-holder Hard that
+// complements the package-level bans.
 //
 //   - A1 (downstream Hard): the net package dial-family FUNCTIONS
 //     (net.Dial / DialTCP / DialUDP / DialIP / DialUnix / DialTimeout) are
@@ -30,37 +27,51 @@
 //     convenience callees http.Get / Post / PostForm / Head — are banned in
 //     kernel/webhook; they bypass the SSRF-wrapped transport. Detection:
 //     ResolvePackageRef → ("net/http", <global|callee>).
+//   - A4 (downstream Hard): any &http.Transport{} composite literal in
+//     kernel/webhook production code MUST set a DialContext field (non-absent).
+//     A Transport without DialContext silently falls back to the net default
+//     dialer, bypassing SafePolicy. Detection: EachInSubtree[CompositeLit],
+//     resolve lit type via TypesInfo.Types[cl.Type], check for "DialContext"
+//     key in the literal's Elts. Only fires on named literals whose resolved
+//     type is net/http.Transport (not on un-typed / other-package literals).
 //
 // AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
 //
-//	下游 Hard — A1/A2/A3 are form-unique, type-resolved callsite bans
+//	下游 Hard — A1/A2/A3/A4 are form-unique, type-resolved checks
 //	  (ResolvePackageRef / ResolveMethodCall resolve import aliases and
 //	  value-refs; A2 binds the allowance to a go/types FullName method identity,
-//	  not a name or filename — there is no "looks-like" grey zone).
+//	  not a name or filename; A4 uses TypesInfo.Types to confirm the literal type
+//	  is net/http.Transport — there is no "looks-like" grey zone).
 //	上游 Medium = Go 永久天花板 — the holder axis ("only a *SafePolicy a
 //	  dispatcher holds may produce egress") is inexpressible in Go's type
 //	  system; package visibility only constrains implementers, not who may
 //	  declare a field of a type. This is the same permanent ceiling as
 //	  SPAN-SETATTR-HOLDER-SEAL (#851) / HEALTHZ-HOLDER-SEAL (#893). Tracked
-//	  won't-do: gh #1375. The PR-5 Dispatcher.client typed-field lock — now a
-//	  single *SafePolicy field rather than three free funcs — is the
-//	  dispatcher-specific single-sanctioned-holder Hard that complements this
-//	  package-level ban.
+//	  won't-do: gh #1375.
 //
 // Blind spots (ai-robust 强制反向自检; reverse fixture below):
 //
-//	B-A1/A2/A3 — rule-logic regression: testdata/webhook_ssrf_violate exercises
-//	  net.Dial + net.DialTCP (A1), a raw net.Dialer{}.DialContext (A2), and
-//	  http.DefaultClient.Do + http.Get + http.DefaultTransport (A3);
+//	B-A1/A2/A3/A4 — rule-logic regression: testdata/webhook_ssrf_violate
+//	  exercises net.Dial + net.DialTCP (A1), a raw net.Dialer{}.DialContext
+//	  (A2), http.DefaultClient.Do + http.Get + http.DefaultTransport (A3), and
+//	  &http.Transport{} with no DialContext (A4);
 //	  TestWebhookSSRFGuard_ReverseFixture asserts each sub-rule fires.
 //	B1 — http.Transport.RoundTrip direct call: a hand-rolled Transport whose
 //	  DialContext is NOT the SafeDialContext, invoked via RoundTrip, bypasses
 //	  the funnel. RoundTrip is a method with no resolvable package-callee form
 //	  that distinguishes a safe vs unsafe transport; catching it needs
 //	  type-level dataflow we do not have. Bounded response: the realistic
-//	  egress path is http.Client.Do over the SSRF transport, locked when the
-//	  dispatcher lands in PR-5; documented here so a reviewer knows the AST scan
-//	  does not cover raw Transport.RoundTrip.
+//	  egress path is http.Client.Do over the SSRF transport, locked by A4
+//	  (the Transport must declare DialContext); documented here so a reviewer
+//	  knows the AST scan does not cover raw Transport.RoundTrip.
+//	B4-A4 — unnamed/inferred Transport type: if the composite literal appears
+//	  in a context where its type is inferred (no explicit type annotation,
+//	  e.g. assigned to a var of type http.RoundTripper), TypesInfo.Types[cl.Type]
+//	  returns false (cl.Type is nil). The scan only fires when cl.Type is
+//	  explicitly present. Bounded response: NewDispatcher always writes
+//	  &http.Transport{...} with an explicit type in production (checked by the
+//	  reverse fixture); a type-inferred literal assigned to an interface would
+//	  still fail A3 (non-DefaultTransport) if it ever made an egress call.
 //
 // ref: docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
 // ref: tools/archtest/webhook_hmac_funnel_test.go (callsite-allowlist template)
@@ -75,6 +86,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// dialContextFieldName is the struct field name in net/http.Transport that
+	// wires a custom dialer. A Transport literal that omits this field falls back
+	// to the net default dialer, silently bypassing SafePolicy (A4).
+	dialContextFieldName = "DialContext"
+
+	httpTransportTypeName = "Transport"
 )
 
 const (
@@ -194,13 +214,72 @@ func scanSSRFHTTPGlobal(fset *token.FileSet, file *ast.File, rel string, info *t
 	return out
 }
 
+// scanSSRFTransportDialContext implements A4: any &http.Transport{} composite
+// literal in kernel/webhook production code must include a DialContext field.
+// A Transport without DialContext silently falls back to the net default dialer,
+// bypassing the SafePolicy SSRF vet. Detection uses TypesInfo.Types[cl.Type] to
+// resolve the literal's type to net/http.Transport (alias-safe), then checks
+// whether any KeyValueExpr in the literal's Elts has the key "DialContext".
+//
+// Blind spot B4-A4: if the literal has no explicit type annotation (cl.Type is
+// nil, type is inferred from context), TypesInfo.Types[cl.Type] is not
+// available and the scan skips it. See file-header B4-A4 godoc.
+func scanSSRFTransportDialContext(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
+		if cl.Type == nil {
+			return // inferred-type literal — B4-A4 blind spot, skip
+		}
+		tv, ok := info.Types[cl.Type]
+		if !ok {
+			return
+		}
+		// Unwrap pointer: &http.Transport{} has type *http.Transport in context,
+		// but the literal's own type expression is http.Transport (no pointer).
+		t := tv.Type
+		if ptr, ok := t.(*types.Pointer); ok {
+			t = ptr.Elem()
+		}
+		named, ok := t.(*types.Named)
+		if !ok {
+			return
+		}
+		obj := named.Obj()
+		if obj == nil || obj.Pkg() == nil {
+			return
+		}
+		if obj.Pkg().Path() != ssrfHTTPPkgPath || obj.Name() != httpTransportTypeName {
+			return
+		}
+		// Confirmed: literal is net/http.Transport. Check for DialContext key.
+		for _, elt := range cl.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if ok && key.Name == dialContextFieldName {
+				return // DialContext is set — compliant
+			}
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(cl.Pos()).Line,
+			Message: "&http.Transport{} literal in kernel/webhook is missing a DialContext field; " +
+				"omitting DialContext falls back to the net default dialer, bypassing SafePolicy " +
+				"(WEBHOOK-SSRF-GUARD-01/A4)",
+		})
+	})
+	return out
+}
+
 func TestWebhookSSRFGuard(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	var a1, a2, a3 []Diagnostic
+	var a1, a2, a3, a4 []Diagnostic
 	_ = RunTyped(t, TypedOpts{Tests: false}, []string{webhookPkgPattern},
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != PlatformModulePath+"/kernel/webhook" {
@@ -214,6 +293,7 @@ func TestWebhookSSRFGuard(t *testing.T) {
 				a1 = append(a1, scanSSRFNetDial(p.Fset, f, rel, p.TypesInfo)...)
 				a2 = append(a2, scanSSRFDialerDialContext(p.Fset, f, rel, p.TypesInfo)...)
 				a3 = append(a3, scanSSRFHTTPGlobal(p.Fset, f, rel, p.TypesInfo)...)
+				a4 = append(a4, scanSSRFTransportDialContext(p.Fset, f, rel, p.TypesInfo)...)
 			}
 			return nil
 		})
@@ -221,6 +301,7 @@ func TestWebhookSSRFGuard(t *testing.T) {
 	Report(t, "WEBHOOK-SSRF-GUARD-01/A1", a1)
 	Report(t, "WEBHOOK-SSRF-GUARD-01/A2", a2)
 	Report(t, "WEBHOOK-SSRF-GUARD-01/A3", a3)
+	Report(t, "WEBHOOK-SSRF-GUARD-01/A4", a4)
 }
 
 // TestWebhookSSRFGuard_ReverseFixture loads the synthetic violation fixture and
@@ -235,7 +316,7 @@ func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
 	root := findModuleRoot(t)
 	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_ssrf_violate")
 
-	var a1, a2, a3 []Diagnostic
+	var a1, a2, a3, a4 []Diagnostic
 	_ = RunTypedDir(t, fixtureDir, TypedOpts{Tests: false}, []string{"./..."},
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
@@ -249,6 +330,7 @@ func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
 				a1 = append(a1, scanSSRFNetDial(p.Fset, f, rel, p.TypesInfo)...)
 				a2 = append(a2, scanSSRFDialerDialContext(p.Fset, f, rel, p.TypesInfo)...)
 				a3 = append(a3, scanSSRFHTTPGlobal(p.Fset, f, rel, p.TypesInfo)...)
+				a4 = append(a4, scanSSRFTransportDialContext(p.Fset, f, rel, p.TypesInfo)...)
 			}
 			return nil
 		})
@@ -261,4 +343,6 @@ func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
 	// banned entry fails this self-test instead of passing on the others.
 	assert.GreaterOrEqual(t, len(a3), len(ssrfBannedHTTPGlobals)+len(ssrfBannedHTTPCallees),
 		"A3 reverse fixture: expected one diagnostic per banned http global + convenience func")
+	assert.GreaterOrEqual(t, len(a4), 1,
+		"A4 reverse fixture: expected ≥1 diagnostic for &http.Transport{} with no DialContext field")
 }

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -1,18 +1,25 @@
 // INVARIANT: WEBHOOK-SSRF-GUARD-01
 //
-// WEBHOOK-SSRF-GUARD-01 — kernel/webhook outbound network funnel (KERNEL-WEBHOOK-01).
+// WEBHOOK-SSRF-GUARD-01 — outbound network funnel for kernel/webhook and
+// runtime/webhook/dispatch (KERNEL-WEBHOOK-01).
 //
 // PR-4 shipped the pure SSRF building block: SafePolicy, the single-source
 // policy whose DialContext / ValidateTargetURL / DenyRedirect methods share one
-// config. PR-5 delivers the Dispatcher, which HOLDS a *SafePolicy and wires its
-// methods into an *http.Client. A4 locks the Transport composite-literal form in
-// the dispatcher — the dispatcher-specific single-sanctioned-holder Hard that
-// complements the package-level bans.
+// config. PR-5 delivers the Dispatcher (kernel/webhook) and the dispatch
+// consumer wiring (runtime/webhook/dispatch). A4 locks the Transport
+// composite-literal form in the dispatcher — the dispatcher-specific
+// single-sanctioned-holder Hard that complements the package-level bans.
+//
+// Scan scope (PR-5 extension): both kernel/webhook and runtime/webhook/dispatch
+// production files are scanned. runtime/webhook/dispatch only wires kernel types
+// (no raw dials, no global clients, no Transport literals) so A1–A4 are
+// vacuously satisfied there today; the scan extension ensures that future
+// additions to the package cannot silently bypass the SSRF funnel.
 //
 //   - A1 (downstream Hard): the net package dial-family FUNCTIONS
 //     (net.Dial / DialTCP / DialUDP / DialIP / DialUnix / DialTimeout) are
-//     banned anywhere in kernel/webhook production code. Detection:
-//     ResolvePackageRef(callee) == ("net", <dial-func>).
+//     banned in kernel/webhook and runtime/webhook/dispatch production code.
+//     Detection: ResolvePackageRef(callee) == ("net", <dial-func>).
 //   - A2 (downstream Hard): the net.Dialer.DialContext METHOD may be called
 //     ONLY from inside (*SafePolicy).DialContext — the sanctioned vetted dialer
 //     (which legitimately has two callsites: the IP-literal and the
@@ -25,15 +32,16 @@
 //   - A3 (downstream Hard): the global HTTP client/transport in net/http —
 //     http.DefaultClient / http.DefaultTransport (package vars) and the
 //     convenience callees http.Get / Post / PostForm / Head — are banned in
-//     kernel/webhook; they bypass the SSRF-wrapped transport. Detection:
-//     ResolvePackageRef → ("net/http", <global|callee>).
+//     kernel/webhook and runtime/webhook/dispatch; they bypass the SSRF-wrapped
+//     transport. Detection: ResolvePackageRef → ("net/http", <global|callee>).
 //   - A4 (downstream Hard): any &http.Transport{} composite literal in
-//     kernel/webhook production code MUST set a DialContext field (non-absent).
-//     A Transport without DialContext silently falls back to the net default
-//     dialer, bypassing SafePolicy. Detection: EachInSubtree[CompositeLit],
-//     resolve lit type via TypesInfo.Types[cl.Type], check for "DialContext"
-//     key in the literal's Elts. Only fires on named literals whose resolved
-//     type is net/http.Transport (not on un-typed / other-package literals).
+//     kernel/webhook or runtime/webhook/dispatch production code MUST set a
+//     DialContext field (non-absent). A Transport without DialContext silently
+//     falls back to the net default dialer, bypassing SafePolicy. Detection:
+//     EachInSubtree[CompositeLit], resolve lit type via TypesInfo.Types[cl.Type],
+//     check for "DialContext" key in the literal's Elts. Only fires on named
+//     literals whose resolved type is net/http.Transport (not on un-typed /
+//     other-package literals).
 //
 // AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
 //
@@ -273,6 +281,26 @@ func scanSSRFTransportDialContext(fset *token.FileSet, file *ast.File, rel strin
 	return out
 }
 
+// ssrfScannedPkgPaths is the set of production package paths covered by the
+// WEBHOOK-SSRF-GUARD-01 scan. Using a set (not a string prefix) keeps the scope
+// explicit: only packages that actually handle outbound webhook egress or directly
+// wrap kernel/webhook types are included.
+//
+//   - kernel/webhook: SafePolicy + Dispatcher (all four sub-rules apply)
+//   - runtime/webhook/dispatch: wires kernel types only (no raw dials today;
+//     extended so future additions cannot silently bypass the funnel)
+var ssrfScannedPkgPaths = map[string]bool{
+	PlatformModulePath + "/kernel/webhook":           true,
+	PlatformModulePath + "/runtime/webhook/dispatch": true,
+}
+
+// ssrfPkgPatterns is the packages.Load pattern list for TestWebhookSSRFGuard.
+// It covers kernel/webhook and runtime/webhook/dispatch (PR-5 extension).
+var ssrfPkgPatterns = []string{
+	"./kernel/webhook/...",
+	"./runtime/webhook/dispatch",
+}
+
 func TestWebhookSSRFGuard(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -280,9 +308,9 @@ func TestWebhookSSRFGuard(t *testing.T) {
 	}
 
 	var a1, a2, a3, a4 []Diagnostic
-	_ = RunTyped(t, TypedOpts{Tests: false}, []string{webhookPkgPattern},
+	_ = RunTyped(t, TypedOpts{Tests: false}, ssrfPkgPatterns,
 		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil || p.Pkg.Path() != PlatformModulePath+"/kernel/webhook" {
+			if p.Pkg == nil || !ssrfScannedPkgPaths[p.Pkg.Path()] {
 				return nil
 			}
 			for _, f := range p.Files {

--- a/tools/archtest/webhook_ssrf_guard_test.go
+++ b/tools/archtest/webhook_ssrf_guard_test.go
@@ -146,6 +146,17 @@ var ssrfBannedHTTPCallees = map[string]bool{
 	"Head":     true,
 }
 
+// wantSSRF*Violations are INDEPENDENT expected floors for the reverse fixture
+// (F12). Deriving the expected count from len(ssrfBanned*) was vacuous: removing
+// a banned entry (weakening the rule) also shrank the expected count, so the
+// self-test still passed. These hardcoded floors make a dropped banned form fail
+// the GreaterOrEqual assertions; a paired Equal golden-lock (in the reverse-
+// fixture test) forces a conscious bump here whenever the banned set changes.
+const (
+	wantSSRFNetDialViolations = 6 // Dial/DialTCP/DialUDP/DialIP/DialUnix/DialTimeout
+	wantSSRFHTTPGlobalCallees = 6 // DefaultClient/DefaultTransport + Get/Post/PostForm/Head
+)
+
 // scanSSRFNetDial implements A1: net.Dial* package functions are banned.
 func scanSSRFNetDial(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
@@ -363,13 +374,22 @@ func TestWebhookSSRFGuard_ReverseFixture(t *testing.T) {
 			return nil
 		})
 
-	assert.GreaterOrEqual(t, len(a1), len(ssrfBannedNetDialFuncs),
+	// Golden-lock: the fixture-violation floors are independent consts (F12), not
+	// len(ssrfBanned*). These equalities force a conscious const bump (and a paired
+	// fixture update) whenever the banned set changes; the GreaterOrEqual checks
+	// below then fail if the rule stops catching a banned form on the fixture.
+	assert.Equal(t, wantSSRFNetDialViolations, len(ssrfBannedNetDialFuncs),
+		"banned net.Dial* set changed — bump wantSSRFNetDialViolations and the reverse fixture")
+	assert.Equal(t, wantSSRFHTTPGlobalCallees, len(ssrfBannedHTTPGlobals)+len(ssrfBannedHTTPCallees),
+		"banned http global/callee set changed — bump wantSSRFHTTPGlobalCallees and the reverse fixture")
+
+	assert.GreaterOrEqual(t, len(a1), wantSSRFNetDialViolations,
 		"A1 reverse fixture: expected one diagnostic per banned net.Dial* func (Dial/DialTCP/DialUDP/DialIP/DialUnix/DialTimeout)")
 	assert.GreaterOrEqual(t, len(a2), 1, "A2 reverse fixture: expected ≥1 raw net.Dialer.DialContext diagnostic")
 	// Cover the FULL A3 banned set — both globals (DefaultClient/DefaultTransport)
 	// AND every convenience callee (Get/Post/PostForm/Head) — so dropping any one
 	// banned entry fails this self-test instead of passing on the others.
-	assert.GreaterOrEqual(t, len(a3), len(ssrfBannedHTTPGlobals)+len(ssrfBannedHTTPCallees),
+	assert.GreaterOrEqual(t, len(a3), wantSSRFHTTPGlobalCallees,
 		"A3 reverse fixture: expected one diagnostic per banned http global + convenience func")
 	assert.GreaterOrEqual(t, len(a4), 1,
 		"A4 reverse fixture: expected ≥1 diagnostic for &http.Transport{} with no DialContext field")


### PR DESCRIPTION
## Summary

PR-5 of `KERNEL-WEBHOOK-01` (plan `docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md` §3): the **outbound webhook dispatcher**. Builds on the merged PR-1..4 (kernel signer/verifier/source/spec, SSRF policy, receiver runtime).

- **`kernel/webhook`** — `Dispatcher` implements `outbox.EntryHandler`: select target → SSRF-vet URL → HMAC-sign → POST via a policy-built `*http.Client` → map outcome via `Classify`. `Headers.Apply` is the **sole writer** of the vendor-neutral `webhook-id` / `webhook-timestamp` / `webhook-signature` headers. `retry.go` adds `DefaultSvixSchedule` + `Classify`.
- **`runtime/webhook/dispatch`** — `BuildConsumers` resolves each dispatcher's signing source, builds an SSRF-guarded `Dispatcher`, and registers it as an event-kind subscription (`Topic == contract ID`).
- **`runtime/bootstrap`** — phase6 `drainWebhookDispatchers` + `WithWebhookSSRFPolicy`; ConsumerBase / no-subscriber guards extended to dispatchers.
- **archtest** — `WEBHOOK-SIGNER-FUNNEL-01` (Hard: signature headers only via `Headers.Apply`) + `WEBHOOK-SSRF-GUARD-01/A4` (Hard: `http.Transport` literals must set `DialContext`).
- **ADR** `docs/architecture/202606012052-1160-adr-webhook-retry-default.md`.

Closes #1160
Refs: KERNEL-WEBHOOK-01 PR-5

## Design decisions (open-source benchmarked)

- **Status → disposition** (standard-webhooks aligned): 2xx Ack / 5xx·408·429·timeout Requeue / other 4xx·3xx·SSRF Reject. Single point: `kernel/webhook/retry.go::Classify`.
- **Headers**: vendor-neutral `webhook-*` (not Svix-branded `svix-*`) — the dispatcher is the sender defining GoCell's own protocol. Signed content / HMAC-SHA256 / `v1,<base64>` identical to PR-1.
- **Retry schedule**: `DefaultSvixSchedule` = 8 deliveries (5s/5min/30min/2h/5h/10h/10h). **delivery timeout 30s** (`WithDeliveryTimeout` to override).
- **No client injection** — the `*http.Client` is always built from the `SafePolicy` (SSRF cannot be bypassed). `WithHTTPClient`/`WithRetrySchedule` deliberately omitted (YAGNI; the former was an SSRF backdoor).

## Implementation Matrix (contract-fanout.md)

```
Contract: webhook Dispatcher / RetrySchedule / Classify / Headers.Apply
Change: add outbound dispatcher runtime + bootstrap drain (PR-5)
Implementations: [x] hmacDispatcher (kernel/webhook)  [x] dispatch consumer (runtime/webhook/dispatch)
Conformance test: kernel/webhook (dispatcher_test/retry_test, 97.2% pkg cov); runtime/webhook/dispatch (dispatch_test)
Repro: go test ./kernel/webhook/... ./runtime/webhook/... ./tools/archtest/ -run Webhook
Dependent contracts (governance scan): none (first real webhook-dispatch contract + cell demo is PR-6)
Invariant inventory (DROP COLUMN): N/A (greenfield, no migration)
```

## Follow-up (backlogged, not silent)

`DefaultSvixSchedule().MaxRetries()` is the canonical retry budget, but the **exact per-attempt wall-clock delays (up to ~40h) are not yet honored at runtime** — `kernel/outbox.ConsumerBase` uses in-process exponential backoff capped at 30s and cannot hold a 10h delay across restarts. Honoring the full Svix timeline needs broker-delay (delayed re-delivery) support; `RetrySchedule.DelayFor` is the seam. Tracked as a backlog item; documented in ADR §Decision 5. (Plan §1.2 follow-ups — Ed25519/KMS, source persistence, circuit-breaker — open in PR-6 closeout.)

## Note on base

Branched from `origin/develop@29ec9e6ea`; `develop` since advanced with a concurrent gRPC refactor that also touched `runtime/bootstrap/bootstrap.go` — a trivial additive merge conflict (one struct field) is possible at merge time.

ref: svix/svix-webhooks docs.svix.com/retries
ref: standard-webhooks/standard-webhooks spec/standard-webhooks.md
ref: frain-dev/convoy

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...`
- [x] `go test ./kernel/webhook/... ./runtime/webhook/... ./runtime/bootstrap/...` (kernel/webhook 97.2% cov)
- [x] `golangci-lint run` — 0 issues
- [x] `bash hack/verify-archtest-invariants.sh` (incl. webhook signer-funnel + SSRF A4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
