### PR TITLE
test(archtest): subscription invariants RED-fixture self-checks [#658]

### DIFF
--- a/tools/archtest/subscription_invariants_test.go
+++ b/tools/archtest/subscription_invariants_test.go
@@ -50,7 +50,10 @@
 // (Go cannot force two test functions to share a function), the same permanent
 // language ceiling as #851 / #893 holder-seals. The reachable maximum is a
 // single shared collector per invariant (no duplicated logic), which this file
-// satisfies.
+// satisfies. No gh issue tracks a Hard upgrade: the ceiling is identical to
+// #851 / #893 (Go cannot express "two test functions must share a function"),
+// so there is no deferred low-cost Hard path to track — this is a permanent
+// ceiling, not a shortcut.
 package archtest
 
 import (
@@ -297,13 +300,18 @@ func collectObservabilityIDViolations(f *ast.File, fset *token.FileSet, label st
 			return
 		}
 		// Receiver type must be Subscription (value or pointer).
-		recvType := fn.Recv.List[0].Type
+		recvField := fn.Recv.List[0]
+		recvType := recvField.Type
 		if star, ok := recvType.(*ast.StarExpr); ok {
 			recvType = star.X
 		}
 		ident, ok := recvType.(*ast.Ident)
 		if !ok || ident.Name != "Subscription" {
 			return
+		}
+		var recvName string
+		if len(recvField.Names) == 1 && recvField.Names[0] != nil {
+			recvName = recvField.Names[0].Name
 		}
 		found = true
 		if fn.Body == nil {
@@ -329,6 +337,18 @@ func collectObservabilityIDViolations(f *ast.File, fset *token.FileSet, label st
 		if !ok || sel.Sel == nil || sel.Sel.Name != "CellID" {
 			violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must return s.CellID "+
 				"directly (no fallback)", label, fset.Position(fn.Body.Pos()).Line))
+			return
+		}
+		// The selector base must be the receiver itself (s.CellID), not some
+		// other value's CellID field — `return other.CellID` would otherwise
+		// satisfy the field-name check while reading a different source.
+		if recvName != "" {
+			base, ok := sel.X.(*ast.Ident)
+			if !ok || base.Name != recvName {
+				violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must return the "+
+					"receiver's CellID (%s.CellID), not another value's CellID",
+					label, fset.Position(fn.Body.Pos()).Line, recvName))
+			}
 		}
 	})
 	return found, violations
@@ -380,6 +400,21 @@ func TestSubscriptionObservabilityNoFallback_DetectorFixtures(t *testing.T) {
 type Subscription struct{}
 func (s Subscription) ObservabilityID() string { return s.CellID }`,
 			wantFound: true,
+		},
+		{
+			name: "green_ptr_receiver",
+			src: `package fixture
+type Subscription struct{}
+func (s *Subscription) ObservabilityID() string { return s.CellID }`,
+			wantFound: true,
+		},
+		{
+			name: "red_returns_other_dot_cellid",
+			src: `package fixture
+type Subscription struct{}
+func (s Subscription) ObservabilityID() string { return other.CellID }`,
+			wantFound:      true,
+			wantViolations: true,
 		},
 		{
 			name: "red_if_fallback",
@@ -579,6 +614,7 @@ func subscribeFuncTypeFromSrc(t *testing.T, src string) (*ast.FuncType, *token.F
 				if name.Name == "Subscribe" {
 					if mt, ok := m.Type.(*ast.FuncType); ok {
 						ft = mt
+						return
 					}
 				}
 			}
@@ -613,6 +649,14 @@ type Registrar interface {
 			src: `package fixture
 type Registrar interface {
 	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup, cellID string, opts ...SubscriptionOption) error
+}`,
+			wantViolations: true,
+		},
+		{
+			name: "red_3rd_not_string",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup ConsumerGroupID, cellID string, opts ...SubscriptionOption) error
 }`,
 			wantViolations: true,
 		},

--- a/tools/archtest/subscription_invariants_test.go
+++ b/tools/archtest/subscription_invariants_test.go
@@ -27,9 +27,34 @@
 //     for an AI session that tries to re-introduce the historical
 //     "CellID==\"\" → fallback to ConsumerGroup" behavior or to add a
 //     WithSubscriptionCellID option that would relax the Hard contract.
+//
+// RED-fixture self-checks (K#07 follow-up, gh #658):
+//
+// Each invariant's detection logic is extracted into a pure collector
+// (collectSubscriptionFieldViolations / collectObservabilityIDViolations /
+// collectSubscribeSignatureViolations) that returns violations instead of
+// calling t.Errorf. The production test parses the real source and asserts
+// the collector reports nothing; a sibling *_DetectorFixtures test feeds
+// synthetic GREEN/RED source through the SAME collector and asserts it does
+// (RED) / does not (GREEN) fire. This guards against the collector becoming
+// structurally unable to fire — a vacuous pass that the production assertion,
+// running only against already-valid source, cannot detect (e.g. an inverted
+// allowlist check, an EachInSubtree that walks nothing, a dropped body-shape
+// branch). Note: an allowlist-content typo is already caught by the production
+// test directly (the real field lands in `unknown` AND the typo'd key lands in
+// `missing`); the RED fixtures specifically cover detector-logic regressions.
+//
+// AI-robust rating: this is a Medium test-of-test reinforcement. The residual
+// risk — a future refactor wiring a RED test to a *copy* of the detection
+// logic rather than the shared collector — cannot be sealed at compile time
+// (Go cannot force two test functions to share a function), the same permanent
+// language ceiling as #851 / #893 holder-seals. The reachable maximum is a
+// single shared collector per invariant (no duplicated logic), which this file
+// satisfies.
 package archtest
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -40,6 +65,21 @@ import (
 
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
+
+// parseSubscriptionFixtureSrc parses a synthetic Go source string into an AST
+// for the RED/GREEN detector fixtures. It uses the same parser flags as the
+// production paths (parser.SkipObjectResolution) so the collectors observe an
+// identical AST shape; type resolution is intentionally absent — all three
+// invariants are pure-AST checks.
+func parseSubscriptionFixtureSrc(t *testing.T, src string) (*ast.File, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse synthetic fixture: %v", err)
+	}
+	return f, fset
+}
 
 // ---------------------------------------------------------------------------
 // SUBSCRIPTION-FIELDS-FROZEN-01
@@ -59,6 +99,51 @@ var subscriptionAllowedFields = map[string]struct{}{
 	"ContractID":        {},
 	"ContractKind":      {},
 	"ContractTransport": {},
+}
+
+// collectSubscriptionFieldViolations walks an AST for a struct named
+// Subscription and reports field-set drift against subscriptionAllowedFields:
+//   - unknown: declared fields not in the allowlist (and any embedded field).
+//   - missing: allowlist fields not declared on the struct.
+//
+// found reports whether the Subscription struct was located at all. label
+// prefixes the position in violation messages (real relative path in
+// production; "fixture.go" in synthetic detector tests).
+func collectSubscriptionFieldViolations(f *ast.File, fset *token.FileSet, label string) (found bool, unknown, missing []string) {
+	seen := make(map[string]struct{})
+	scanner.EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Name == nil || ts.Name.Name != "Subscription" {
+			return
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok || st.Fields == nil {
+			return
+		}
+		found = true
+		for _, field := range st.Fields.List {
+			if len(field.Names) == 0 {
+				line := fset.Position(field.Type.Pos()).Line
+				unknown = append(unknown, label+":"+strconv.Itoa(line)+": <embedded field>")
+				continue
+			}
+			for _, name := range field.Names {
+				seen[name.Name] = struct{}{}
+				if _, ok := subscriptionAllowedFields[name.Name]; !ok {
+					line := fset.Position(name.Pos()).Line
+					unknown = append(unknown, label+":"+strconv.Itoa(line)+": "+name.Name)
+				}
+			}
+		}
+	})
+
+	for k := range subscriptionAllowedFields {
+		if _, ok := seen[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(unknown)
+	sort.Strings(missing)
+	return found, unknown, missing
 }
 
 // TestSubscriptionFieldsFrozen enforces SUBSCRIPTION-FIELDS-FROZEN-01:
@@ -81,50 +166,12 @@ func TestSubscriptionFieldsFrozen(t *testing.T) {
 		t.Fatalf("parse %s: %v", path, err)
 	}
 
-	var (
-		found   bool
-		seen    = make(map[string]struct{})
-		unknown []string
-	)
-	scanner.EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
-		if ts.Name == nil || ts.Name.Name != "Subscription" {
-			return
-		}
-		st, ok := ts.Type.(*ast.StructType)
-		if !ok || st.Fields == nil {
-			return
-		}
-		found = true
-		for _, field := range st.Fields.List {
-			if len(field.Names) == 0 {
-				line := fset.Position(field.Type.Pos()).Line
-				unknown = append(unknown, "kernel/outbox/subscription.go:"+strconv.Itoa(line)+": <embedded field>")
-				continue
-			}
-			for _, name := range field.Names {
-				seen[name.Name] = struct{}{}
-				if _, ok := subscriptionAllowedFields[name.Name]; !ok {
-					line := fset.Position(name.Pos()).Line
-					unknown = append(unknown, "kernel/outbox/subscription.go:"+strconv.Itoa(line)+": "+name.Name)
-				}
-			}
-		}
-	})
-
+	found, unknown, missing := collectSubscriptionFieldViolations(f, fset, "kernel/outbox/subscription.go")
 	if !found {
 		t.Fatalf("Subscription struct definition not found in kernel/outbox/subscription.go " +
 			"— if the type was relocated, update this test's hardcoded path along with the move")
 	}
 
-	var missing []string
-	for k := range subscriptionAllowedFields {
-		if _, ok := seen[k]; !ok {
-			missing = append(missing, k)
-		}
-	}
-
-	sort.Strings(unknown)
-	sort.Strings(missing)
 	for _, u := range unknown {
 		t.Errorf("SUBSCRIPTION-FIELDS-FROZEN-01: %s — field not in allowlist; "+
 			"to add a field, update subscriptionAllowedFields and review "+
@@ -140,9 +187,152 @@ func TestSubscriptionFieldsFrozen(t *testing.T) {
 	}
 }
 
+// TestSubscriptionFieldsFrozen_DetectorFixtures is the RED-fixture self-check
+// for SUBSCRIPTION-FIELDS-FROZEN-01. It exercises collectSubscriptionFieldViolations
+// (the same collector the production test uses) against synthetic source so a
+// regression that makes the collector unable to report drift fails here even
+// while the production test keeps passing against valid real source.
+func TestSubscriptionFieldsFrozen_DetectorFixtures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		src         string
+		wantFound   bool
+		wantUnknown bool
+		wantMissing bool
+	}{
+		{
+			name: "green_exact_seven",
+			src: `package fixture
+type Subscription struct {
+	Topic             string
+	ConsumerGroup     string
+	CellID            string
+	SliceID           string
+	ContractID        string
+	ContractKind      string
+	ContractTransport string
+}`,
+			wantFound: true,
+		},
+		{
+			name: "red_extra_field",
+			src: `package fixture
+type Subscription struct {
+	Topic             string
+	ConsumerGroup     string
+	CellID            string
+	SliceID           string
+	ContractID        string
+	ContractKind      string
+	ContractTransport string
+	Extra             string
+}`,
+			wantFound:   true,
+			wantUnknown: true,
+		},
+		{
+			name: "red_missing_cellid",
+			src: `package fixture
+type Subscription struct {
+	Topic             string
+	ConsumerGroup     string
+	SliceID           string
+	ContractID        string
+	ContractKind      string
+	ContractTransport string
+}`,
+			wantFound:   true,
+			wantMissing: true,
+		},
+		{
+			name: "red_embedded_field",
+			src: `package fixture
+type Subscription struct {
+	Topic             string
+	ConsumerGroup     string
+	CellID            string
+	SliceID           string
+	ContractID        string
+	ContractKind      string
+	ContractTransport string
+	EmbeddedBase
+}`,
+			wantFound:   true,
+			wantUnknown: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f, fset := parseSubscriptionFixtureSrc(t, tc.src)
+			found, unknown, missing := collectSubscriptionFieldViolations(f, fset, "fixture.go")
+			if found != tc.wantFound {
+				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			}
+			if got := len(unknown) > 0; got != tc.wantUnknown {
+				t.Errorf("unknown non-empty = %v (%v), want %v", got, unknown, tc.wantUnknown)
+			}
+			if got := len(missing) > 0; got != tc.wantMissing {
+				t.Errorf("missing non-empty = %v (%v), want %v", got, missing, tc.wantMissing)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01
 // ---------------------------------------------------------------------------
+
+// collectObservabilityIDViolations walks an AST for a method named
+// ObservabilityID on a (value or pointer) Subscription receiver and reports any
+// deviation from the canonical single-statement `return s.CellID` body. found
+// reports whether the method was located at all.
+func collectObservabilityIDViolations(f *ast.File, fset *token.FileSet, label string) (found bool, violations []string) {
+	scanner.EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+		if fn.Name == nil || fn.Name.Name != "ObservabilityID" {
+			return
+		}
+		if fn.Recv == nil || len(fn.Recv.List) == 0 {
+			return
+		}
+		// Receiver type must be Subscription (value or pointer).
+		recvType := fn.Recv.List[0].Type
+		if star, ok := recvType.(*ast.StarExpr); ok {
+			recvType = star.X
+		}
+		ident, ok := recvType.(*ast.Ident)
+		if !ok || ident.Name != "Subscription" {
+			return
+		}
+		found = true
+		if fn.Body == nil {
+			violations = append(violations, label+": ObservabilityID has no body")
+			return
+		}
+		// Body must contain exactly one statement: a return.
+		if len(fn.Body.List) != 1 {
+			violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must be a single "+
+				"`return s.CellID` statement; got %d statements. Any if/switch fallback to ConsumerGroup "+
+				"re-introduces a second source of truth — CellID is HARD-required by Registry.Subscribe "+
+				"at codegen time. Delete the fallback.",
+				label, fset.Position(fn.Body.Pos()).Line, len(fn.Body.List)))
+			return
+		}
+		ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must be `return s.CellID`",
+				label, fset.Position(fn.Body.Pos()).Line))
+			return
+		}
+		sel, ok := ret.Results[0].(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "CellID" {
+			violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must return s.CellID "+
+				"directly (no fallback)", label, fset.Position(fn.Body.Pos()).Line))
+		}
+	})
+	return found, violations
+}
 
 // TestSubscriptionObservabilityNoFallback enforces
 // SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01: the body of
@@ -163,59 +353,142 @@ func TestSubscriptionObservabilityNoFallback(t *testing.T) {
 		t.Fatalf("parse %s: %v", path, err)
 	}
 
-	var found bool
-	scanner.EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
-		if fn.Name == nil || fn.Name.Name != "ObservabilityID" {
-			return
-		}
-		if fn.Recv == nil || len(fn.Recv.List) == 0 {
-			return
-		}
-		// Receiver type must be Subscription (value or pointer).
-		recvType := fn.Recv.List[0].Type
-		if star, ok := recvType.(*ast.StarExpr); ok {
-			recvType = star.X
-		}
-		ident, ok := recvType.(*ast.Ident)
-		if !ok || ident.Name != "Subscription" {
-			return
-		}
-		found = true
-		if fn.Body == nil {
-			t.Errorf("SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01: ObservabilityID has no body")
-			return
-		}
-		// Body must contain exactly one statement: a return.
-		if len(fn.Body.List) != 1 {
-			t.Errorf("SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01: ObservabilityID body must be a single "+
-				"`return s.CellID` statement; got %d statements at kernel/outbox/subscription.go:%d. "+
-				"Any if/switch fallback to ConsumerGroup re-introduces a second source of truth — "+
-				"CellID is HARD-required by Registry.Subscribe at codegen time. Delete the fallback.",
-				len(fn.Body.List), fset.Position(fn.Body.Pos()).Line)
-			return
-		}
-		ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
-		if !ok || len(ret.Results) != 1 {
-			t.Errorf("SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01: ObservabilityID body must be "+
-				"`return s.CellID` at kernel/outbox/subscription.go:%d",
-				fset.Position(fn.Body.Pos()).Line)
-			return
-		}
-		sel, ok := ret.Results[0].(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil || sel.Sel.Name != "CellID" {
-			t.Errorf("SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01: ObservabilityID body must return "+
-				"s.CellID directly (no fallback); got at kernel/outbox/subscription.go:%d",
-				fset.Position(fn.Body.Pos()).Line)
-		}
-	})
+	found, violations := collectObservabilityIDViolations(f, fset, "kernel/outbox/subscription.go")
 	if !found {
 		t.Fatalf("ObservabilityID method on Subscription not found in kernel/outbox/subscription.go")
+	}
+	for _, v := range violations {
+		t.Errorf("SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01: %s", v)
+	}
+}
+
+// TestSubscriptionObservabilityNoFallback_DetectorFixtures is the RED-fixture
+// self-check for SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01. It drives
+// collectObservabilityIDViolations against synthetic source so a regression
+// that stops detecting a ConsumerGroup fallback fails here.
+func TestSubscriptionObservabilityNoFallback_DetectorFixtures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		src            string
+		wantFound      bool
+		wantViolations bool
+	}{
+		{
+			name: "green_return_cellid",
+			src: `package fixture
+type Subscription struct{}
+func (s Subscription) ObservabilityID() string { return s.CellID }`,
+			wantFound: true,
+		},
+		{
+			name: "red_if_fallback",
+			src: `package fixture
+type Subscription struct{}
+func (s Subscription) ObservabilityID() string {
+	if s.CellID == "" {
+		return s.ConsumerGroup
+	}
+	return s.CellID
+}`,
+			wantFound:      true,
+			wantViolations: true,
+		},
+		{
+			name: "red_returns_consumergroup",
+			src: `package fixture
+type Subscription struct{}
+func (s Subscription) ObservabilityID() string { return s.ConsumerGroup }`,
+			wantFound:      true,
+			wantViolations: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f, fset := parseSubscriptionFixtureSrc(t, tc.src)
+			found, violations := collectObservabilityIDViolations(f, fset, "fixture.go")
+			if found != tc.wantFound {
+				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			}
+			if got := len(violations) > 0; got != tc.wantViolations {
+				t.Errorf("violations non-empty = %v (%v), want %v", got, violations, tc.wantViolations)
+			}
+		})
 	}
 }
 
 // ---------------------------------------------------------------------------
 // REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01
 // ---------------------------------------------------------------------------
+
+// collectSubscribeSignatureViolations verifies the FuncType describes
+// `Subscribe(spec, handler, consumerGroup string, cellID string, opts ...SubscriptionOption) error`.
+// It reports violations of:
+//   - exactly 5 parameter groups (each group is one field; we forbid `a, b string` merging)
+//   - 3rd parameter type is `string` (consumerGroup)
+//   - 4th parameter type is `string` and named `cellID` (HARD positional)
+//   - 5th parameter is variadic, element type `SubscriptionOption`
+//
+// label prefixes positions in violation messages. The merged-param, arity, and
+// non-variadic branches return early because subsequent positional indexing
+// would be meaningless once those structural preconditions fail.
+func collectSubscribeSignatureViolations(fset *token.FileSet, ft *ast.FuncType, label string) []string {
+	if ft.Params == nil {
+		return []string{label + ": Subscribe method missing param list"}
+	}
+	var violations []string
+	params := ft.Params.List
+	// Each param must be its own Field (one Name per Field) — no `(a, b string)` style merging.
+	flat := make([]*ast.Field, 0, len(params))
+	for _, p := range params {
+		if len(p.Names) <= 1 {
+			flat = append(flat, p)
+			continue
+		}
+		// Reject merged params: each named position must be its own Field so
+		// we can pin "4th positional param is cellID string" by index.
+		return append(violations, fmt.Sprintf("%s:%d: Subscribe must declare each parameter on its own "+
+			"Field (no `a, b string` merging) — found %d names sharing type",
+			label, fset.Position(p.Pos()).Line, len(p.Names)))
+	}
+	if len(flat) != 5 {
+		return append(violations, fmt.Sprintf("%s:%d: Subscribe must have exactly 5 positional parameters "+
+			"(spec, handler, consumerGroup, cellID, opts...); got %d",
+			label, fset.Position(ft.Pos()).Line, len(flat)))
+	}
+	// 3rd param (consumerGroup) must be `string`.
+	if !isIdent(flat[2].Type, "string") {
+		violations = append(violations, fmt.Sprintf("%s:%d: Subscribe 3rd parameter must be `string` "+
+			"(consumerGroup)", label, fset.Position(flat[2].Pos()).Line))
+	}
+	// 4th param (cellID) must be `string` and named cellID.
+	if len(flat[3].Names) != 1 || flat[3].Names[0].Name != "cellID" {
+		gotName := "<unnamed>"
+		if len(flat[3].Names) == 1 {
+			gotName = flat[3].Names[0].Name
+		}
+		violations = append(violations, fmt.Sprintf("%s:%d: Subscribe 4th parameter must be named `cellID`; "+
+			"got %q. CellID is the AI-HARD positional contract — renaming or replacing it with a "+
+			"SubscriptionOption demotes the contract from compile-time enforcement to opt-in.",
+			label, fset.Position(flat[3].Pos()).Line, gotName))
+	}
+	if !isIdent(flat[3].Type, "string") {
+		violations = append(violations, fmt.Sprintf("%s:%d: Subscribe 4th parameter must be `string` "+
+			"(cellID); got non-string type", label, fset.Position(flat[3].Pos()).Line))
+	}
+	// 5th param must be variadic SubscriptionOption.
+	ell, ok := flat[4].Type.(*ast.Ellipsis)
+	if !ok {
+		return append(violations, fmt.Sprintf("%s:%d: Subscribe 5th parameter must be variadic "+
+			"(`...SubscriptionOption`)", label, fset.Position(flat[4].Pos()).Line))
+	}
+	if !isIdent(ell.Elt, "SubscriptionOption") {
+		violations = append(violations, fmt.Sprintf("%s:%d: Subscribe variadic parameter element must be "+
+			"`SubscriptionOption`", label, fset.Position(flat[4].Pos()).Line))
+	}
+	return violations
+}
 
 // TestRegistrySubscribeCellIDPositional enforces
 // REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: the kernel/cell.Registrar.Subscribe
@@ -269,11 +542,13 @@ func TestRegistrySubscribeCellIDPositional(t *testing.T) {
 				}
 				foundMethod = true
 				ft, ok := m.Type.(*ast.FuncType)
-				if !ok || ft.Params == nil {
-					t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe method missing param list")
+				if !ok {
+					t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe method type is not a func")
 					return
 				}
-				assertSubscribeSignature(t, fset, ft)
+				for _, v := range collectSubscribeSignatureViolations(fset, ft, "kernel/cell/registry.go") {
+					t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: %s", v)
+				}
 			}
 		}
 	})
@@ -285,72 +560,96 @@ func TestRegistrySubscribeCellIDPositional(t *testing.T) {
 	}
 }
 
-// assertSubscribeSignature verifies the FuncType describes
-// `Subscribe(spec, handler, consumerGroup string, cellID string, opts ...SubscriptionOption) error`.
-// It enforces:
-//   - exactly 5 parameter groups (each group is one field; we forbid `a, b string` merging)
-//   - 3rd parameter type is `string` (consumerGroup)
-//   - 4th parameter type is `string` and named `cellID` (HARD positional)
-//   - 5th parameter is variadic, element type `SubscriptionOption`
-func assertSubscribeSignature(t *testing.T, fset *token.FileSet, ft *ast.FuncType) {
+// subscribeFuncTypeFromSrc parses synthetic source and extracts the FuncType of
+// the Subscribe method on a Registrar interface, for the detector fixtures.
+func subscribeFuncTypeFromSrc(t *testing.T, src string) (*ast.FuncType, *token.FileSet) {
 	t.Helper()
-	params := ft.Params.List
-	// Each param must be its own Field (one Name per Field) — no `(a, b string)` style merging.
-	flat := make([]*ast.Field, 0, len(params))
-	for _, p := range params {
-		if len(p.Names) <= 1 {
-			flat = append(flat, p)
-			continue
+	f, fset := parseSubscriptionFixtureSrc(t, src)
+	var ft *ast.FuncType
+	scanner.EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Name == nil || ts.Name.Name != "Registrar" {
+			return
 		}
-		// Reject merged params: each named position must be its own Field so
-		// we can pin "4th positional param is cellID string" by index.
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe must declare each "+
-			"parameter on its own Field (no `a, b string` merging) at "+
-			"kernel/cell/registry.go:%d — found %d names sharing type",
-			fset.Position(p.Pos()).Line, len(p.Names))
-		return
-	}
-	if len(flat) != 5 {
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe must have exactly 5 positional "+
-			"parameters (spec, handler, consumerGroup, cellID, opts...); got %d at "+
-			"kernel/cell/registry.go:%d", len(flat), fset.Position(ft.Pos()).Line)
-		return
-	}
-	// 3rd param (consumerGroup) must be `string`.
-	if !isIdent(flat[2].Type, "string") {
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe 3rd parameter must be `string` "+
-			"(consumerGroup) at kernel/cell/registry.go:%d",
-			fset.Position(flat[2].Pos()).Line)
-	}
-	// 4th param (cellID) must be `string` and named cellID.
-	if len(flat[3].Names) != 1 || flat[3].Names[0].Name != "cellID" {
-		gotName := "<unnamed>"
-		if len(flat[3].Names) == 1 {
-			gotName = flat[3].Names[0].Name
+		iface, ok := ts.Type.(*ast.InterfaceType)
+		if !ok || iface.Methods == nil {
+			return
 		}
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe 4th parameter must be named "+
-			"`cellID`; got %q at kernel/cell/registry.go:%d. CellID is the AI-HARD positional "+
-			"contract — renaming or replacing it with a SubscriptionOption demotes the contract "+
-			"from compile-time enforcement to opt-in.",
-			gotName, fset.Position(flat[3].Pos()).Line)
+		for _, m := range iface.Methods.List {
+			for _, name := range m.Names {
+				if name.Name == "Subscribe" {
+					if mt, ok := m.Type.(*ast.FuncType); ok {
+						ft = mt
+					}
+				}
+			}
+		}
+	})
+	if ft == nil {
+		t.Fatalf("setup: Subscribe FuncType not found in synthetic fixture")
 	}
-	if !isIdent(flat[3].Type, "string") {
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe 4th parameter must be `string` "+
-			"(cellID); got non-string type at kernel/cell/registry.go:%d",
-			fset.Position(flat[3].Pos()).Line)
+	return ft, fset
+}
+
+// TestRegistrySubscribeCellIDPositional_DetectorFixtures is the RED-fixture
+// self-check for REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01. It drives
+// collectSubscribeSignatureViolations against synthetic interface declarations
+// so a regression that stops detecting a demoted cellID positional fails here.
+func TestRegistrySubscribeCellIDPositional_DetectorFixtures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		src            string
+		wantViolations bool
+	}{
+		{
+			name: "green_canonical",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup string, cellID string, opts ...SubscriptionOption) error
+}`,
+		},
+		{
+			name: "red_merged_params",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup, cellID string, opts ...SubscriptionOption) error
+}`,
+			wantViolations: true,
+		},
+		{
+			name: "red_wrong_4th_name",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup string, id string, opts ...SubscriptionOption) error
+}`,
+			wantViolations: true,
+		},
+		{
+			name: "red_4th_not_string",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup string, cellID int, opts ...SubscriptionOption) error
+}`,
+			wantViolations: true,
+		},
+		{
+			name: "red_5th_not_variadic",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup string, cellID string, opts SubscriptionOption) error
+}`,
+			wantViolations: true,
+		},
 	}
-	// 5th param must be variadic SubscriptionOption.
-	ell, ok := flat[4].Type.(*ast.Ellipsis)
-	if !ok {
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe 5th parameter must be "+
-			"variadic (`...SubscriptionOption`) at kernel/cell/registry.go:%d",
-			fset.Position(flat[4].Pos()).Line)
-		return
-	}
-	if !isIdent(ell.Elt, "SubscriptionOption") {
-		t.Errorf("REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01: Subscribe variadic parameter element "+
-			"must be `SubscriptionOption` at kernel/cell/registry.go:%d",
-			fset.Position(flat[4].Pos()).Line)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ft, fset := subscribeFuncTypeFromSrc(t, tc.src)
+			violations := collectSubscribeSignatureViolations(fset, ft, "fixture.go")
+			if got := len(violations) > 0; got != tc.wantViolations {
+				t.Errorf("violations non-empty = %v (%v), want %v", got, violations, tc.wantViolations)
+			}
+		})
 	}
 }
 

--- a/tools/archtest/subscription_invariants_test.go
+++ b/tools/archtest/subscription_invariants_test.go
@@ -291,6 +291,12 @@ type Subscription struct {
 // ObservabilityID on a (value or pointer) Subscription receiver and reports any
 // deviation from the canonical single-statement `return s.CellID` body. found
 // reports whether the method was located at all.
+//
+// The receiver must be named: an anonymous receiver cannot reference s.CellID,
+// so it can never express the canonical body, and it would silently disable the
+// selector-base check (there is no receiver name to anchor `s.CellID` against),
+// letting `return other.CellID` read a foreign value while still passing the
+// field-name check. An anonymous receiver is therefore a violation outright.
 func collectObservabilityIDViolations(f *ast.File, fset *token.FileSet, label string) (found bool, violations []string) {
 	scanner.EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
 		if fn.Name == nil || fn.Name.Name != "ObservabilityID" {
@@ -314,6 +320,13 @@ func collectObservabilityIDViolations(f *ast.File, fset *token.FileSet, label st
 			recvName = recvField.Names[0].Name
 		}
 		found = true
+		if recvName == "" {
+			violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID must use a named receiver "+
+				"(`func (s Subscription) ObservabilityID()`); an anonymous receiver cannot reference s.CellID "+
+				"and disables the selector-base check, letting `return other.CellID` read a foreign value",
+				label, fset.Position(recvField.Pos()).Line))
+			return
+		}
 		if fn.Body == nil {
 			violations = append(violations, label+": ObservabilityID has no body")
 			return
@@ -341,14 +354,14 @@ func collectObservabilityIDViolations(f *ast.File, fset *token.FileSet, label st
 		}
 		// The selector base must be the receiver itself (s.CellID), not some
 		// other value's CellID field — `return other.CellID` would otherwise
-		// satisfy the field-name check while reading a different source.
-		if recvName != "" {
-			base, ok := sel.X.(*ast.Ident)
-			if !ok || base.Name != recvName {
-				violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must return the "+
-					"receiver's CellID (%s.CellID), not another value's CellID",
-					label, fset.Position(fn.Body.Pos()).Line, recvName))
-			}
+		// satisfy the field-name check while reading a different source. recvName
+		// is guaranteed non-empty here (anonymous receivers returned above), so
+		// this check is unconditional.
+		base, ok := sel.X.(*ast.Ident)
+		if !ok || base.Name != recvName {
+			violations = append(violations, fmt.Sprintf("%s:%d: ObservabilityID body must return the "+
+				"receiver's CellID (%s.CellID), not another value's CellID",
+				label, fset.Position(fn.Body.Pos()).Line, recvName))
 		}
 	})
 	return found, violations
@@ -413,6 +426,19 @@ func (s *Subscription) ObservabilityID() string { return s.CellID }`,
 			src: `package fixture
 type Subscription struct{}
 func (s Subscription) ObservabilityID() string { return other.CellID }`,
+			wantFound:      true,
+			wantViolations: true,
+		},
+		{
+			// Anonymous receiver: there is no receiver name to anchor the
+			// selector base against, so `other.CellID` satisfies the field-name
+			// check while reading a foreign value. An anonymous receiver also
+			// cannot reference s.CellID at all, so it can never express the
+			// canonical body — it must be a violation outright.
+			name: "red_anonymous_receiver_other_cellid",
+			src: `package fixture
+type Subscription struct{}
+func (Subscription) ObservabilityID() string { return other.CellID }`,
 			wantFound:      true,
 			wantViolations: true,
 		},
@@ -681,6 +707,18 @@ type Registrar interface {
 			src: `package fixture
 type Registrar interface {
 	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup string, cellID string, opts SubscriptionOption) error
+}`,
+			wantViolations: true,
+		},
+		{
+			// Variadic, but the element type is not SubscriptionOption. Guards
+			// the ell.Elt type check at the bottom of the collector — without
+			// this row, an inverted/dropped element-type branch would pass
+			// vacuously (every other red row returns early before reaching it).
+			name: "red_5th_wrong_variadic_element",
+			src: `package fixture
+type Registrar interface {
+	Subscribe(spec ContractSpec, handler EntryHandler, consumerGroup string, cellID string, opts ...OtherOption) error
 }`,
 			wantViolations: true,
 		},


### PR DESCRIPTION
## Summary

K#07 follow-up (`K07-SUBSCRIPTION-ARCHTEST-RED-FIXTURE-01`). The three subscription invariants in `tools/archtest/subscription_invariants_test.go` parsed real source with detection logic **inlined** into the test functions (`t.Errorf` directly), with no independent negative fixture. A detector that became structurally unable to fire — inverted allowlist check, `EachInSubtree` walking nothing, dropped body-shape branch — would pass **vacuously** against already-valid source, silently disabling the invariant.

This PR extracts each invariant's detection into a pure collector returning `[]string` violations, exercised by **both** the production assertion (real source) and synthetic GREEN/RED detector fixtures (same collector):

- `collectSubscriptionFieldViolations` (SUBSCRIPTION-FIELDS-FROZEN-01)
- `collectObservabilityIDViolations` (SUBSCRIPTION-OBSERVABILITY-NO-FALLBACK-01)
- `collectSubscribeSignatureViolations` (REGISTRY-SUBSCRIBE-CELLID-POSITIONAL-01; replaces `assertSubscribeSignature`)

Synthetic in-test AST (Pattern A, à la `internal/scanner/eachnode_test.go` T1+T2 / `jwt_claims_no_authz_epoch_test.go`) — no `testdata/` dir, no `RunTyped`; all three are pure-AST checks. Hardcoded `"kernel/outbox/subscription.go:"` path literal collapsed into a `label` parameter.

### Precise threat scope
An allowlist-content **typo** is already caught by the production test (the real field lands in `unknown` AND the typo'd key in `missing`). The RED fixtures specifically cover **detector-logic regressions** that the production test (running only against valid source) cannot surface.

### AI-robust rating
Medium test-of-test reinforcement (per #658: flag-soft, non-blocking). Hard is **unreachable** — Go cannot force two test functions to share a collector (same permanent ceiling as #851 / #893 holder-seals). Reachable maximum = a single shared collector per invariant (no duplicated logic), which this PR satisfies. No backlog carryover owed (ceiling, not a deferred shortcut).

Refs: #658

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./tools/archtest/ -run 'TestSubscription|TestRegistrySubscribe'` — 6 tests PASS (3 production + 3 detector-fixture)
- [x] `golangci-lint run ./tools/archtest/...` — 0 issues
- [x] **Non-vacuity proof**: temporarily neutered each collector (inverted allowlist check / disabled body-shape branches / disabled 4th-param-name check) → corresponding `*_DetectorFixtures` RED+GREEN rows FAIL as expected; restored to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)