### PR TITLE
refactor(observability): unify _runtime sentinel + lock gRPC metrics cell-label source [#1383]

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -191,7 +191,7 @@ emitter health probe（`outbox_failopen_rate_<cell>`）的注册同理收口：c
 - **业务请求**：`cell=<cellID>` — 由 `runtime/http/router.Router.MountRouteGroup` 记录 `RouteGroup.CellID` 与 HTTP namespace 的 ownership，listener-root `CellAttribution` middleware 在 tracing/access-log/metrics/protection 之前写入 `kernel/ctxkeys.CellID`。成功 handler、auth/rate-limit/circuit-breaker/body-limit 前置拒绝、chi 405 都必须使用同一 cell。
 - **框架/未匹配请求**：`cell="_runtime"` 哨兵 — `runtime/http/middleware.Metrics` 在 `ctxkeys.CellID` 缺失时使用 `metrics.RuntimeCellSentinel`，覆盖 `/healthz`、`/readyz`、`/metrics` 自身、listener 外 404 等所有未落入业务 RouteGroup 的请求。
 
-`_runtime` 哨兵单源 = `runtime/observability/metrics.RuntimeCellSentinel`（HTTP middleware 与 gRPC metrics interceptor 共读同一常量，全仓仅此一处 `"_runtime"` 字面量）。**gRPC 指标**（`grpc_server_requests_total` / `grpc_server_request_duration_seconds`）复用同一 `cell` label 语义，但 gRPC cell attribution 接线尚未落地（`FullMethod → cellID` 归属随 epic PR-7/8，tracking #1383），故当前 gRPC 的 `cell` 恒为 `_runtime`——运维侧不要对 gRPC 指标用 `cell!="_runtime"` 过滤，详见 `docs/ops/alerting-rules.md`。reader 侧契约（取自 `ctxkeys.CellID` + 缺失回退 sentinel）由 archtest `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01` 守卫。
+`_runtime` 哨兵单源 = `runtime/observability/metrics.RuntimeCellSentinel`（HTTP middleware 与 gRPC metrics interceptor 共读同一常量，全仓仅此一处 `"_runtime"` 字面量）。
 
 `RouteGroup.Prefix` 非空时按 path segment 前缀归属；`Prefix == ""` 不表示拥有整个 listener，而是从该 RouteGroup 内实际注册的 `Route` / `Handle` / `Mount` / `auth.Mount` 合同路径派生归属。重叠 namespace 按最长前缀/最长模板胜出；同一 listener 内跨 cell 声明完全相同的 owner path/template 必须 fail-fast，不能靠注册顺序抢占。
 
@@ -202,6 +202,10 @@ emitter health probe（`outbox_failopen_rate_<cell>`）的注册同理收口：c
 - 不做代码侧 backward-compat / double-write：禁止恢复 `ProviderCollectorConfig.CellID`、assembly/default 推导、旧 label 复制，或同时写新旧 HTTP 指标序列。
 - `cell` 是粗粒度 owner 维度，不是 slice / contract / tenant / user 维度；业务 SLO / 告警默认过滤 `cell!="_runtime"`，运行时探针与未匹配流量排查使用 `cell="_runtime"`。
 - 旧 dashboard / alert 需要过渡时，在 Prometheus 侧用 recording rule 聚合新序列；remote-write 或业务专用 Prometheus 需要降噪时，用 metric relabel drop `_runtime` 序列。示例见 `docs/ops/alerting-rules.md`。
+
+## gRPC Metrics `cell` Label（当前恒为 `_runtime`）
+
+`grpc_server_requests_total` / `grpc_server_request_duration_seconds` 复用与 HTTP 同一 `cell` label 语义与同一 `_runtime` 哨兵单源（`runtime/observability/metrics.RuntimeCellSentinel`）。但 gRPC cell attribution 接线尚未落地——HTTP 侧 router-root `CellAttribution` 从 `RouteGroup.CellID` 归属 cell，gRPC 对应的 `FullMethod → cellID` 归属（生成式 registrar 派生）随 epic PR-7/8 落地（tracking #1383）。**在此之前所有 gRPC 流量的 `cell` 恒为 `_runtime`，运维侧不要对 gRPC 指标用 `cell!="_runtime"` 过滤**（详见 `docs/ops/alerting-rules.md`）。reader 侧契约（cell label 取自 `ctxkeys.CellID`，缺失回退 `RuntimeCellSentinel`，禁硬编码）由 archtest `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01` 守卫，故 attribution 一旦接线，`cell` 自动反映归属 cell 而无需改 interceptor。
 
 ## Redis Key Namespace（owner 维度的 keyspace 等价物）
 

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -189,7 +189,9 @@ emitter health probe（`outbox_failopen_rate_<cell>`）的注册同理收口：c
 `http_requests_total` 与 `http_request_duration_seconds` 的 `cell` label 表示请求落入的 cell：
 
 - **业务请求**：`cell=<cellID>` — 由 `runtime/http/router.Router.MountRouteGroup` 记录 `RouteGroup.CellID` 与 HTTP namespace 的 ownership，listener-root `CellAttribution` middleware 在 tracing/access-log/metrics/protection 之前写入 `kernel/ctxkeys.CellID`。成功 handler、auth/rate-limit/circuit-breaker/body-limit 前置拒绝、chi 405 都必须使用同一 cell。
-- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — `runtime/http/middleware.Metrics` 在 `ctxkeys.CellID` 缺失时使用 `RuntimeCellIDSentinel`，覆盖 `/healthz`、`/readyz`、`/metrics` 自身、listener 外 404 等所有未落入业务 RouteGroup 的请求。
+- **框架/未匹配请求**：`cell="_runtime"` 哨兵 — `runtime/http/middleware.Metrics` 在 `ctxkeys.CellID` 缺失时使用 `metrics.RuntimeCellSentinel`，覆盖 `/healthz`、`/readyz`、`/metrics` 自身、listener 外 404 等所有未落入业务 RouteGroup 的请求。
+
+`_runtime` 哨兵单源 = `runtime/observability/metrics.RuntimeCellSentinel`（HTTP middleware 与 gRPC metrics interceptor 共读同一常量，全仓仅此一处 `"_runtime"` 字面量）。**gRPC 指标**（`grpc_server_requests_total` / `grpc_server_request_duration_seconds`）复用同一 `cell` label 语义，但 gRPC cell attribution 接线尚未落地（`FullMethod → cellID` 归属随 epic PR-7/8，tracking #1383），故当前 gRPC 的 `cell` 恒为 `_runtime`——运维侧不要对 gRPC 指标用 `cell!="_runtime"` 过滤，详见 `docs/ops/alerting-rules.md`。reader 侧契约（取自 `ctxkeys.CellID` + 缺失回退 sentinel）由 archtest `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01` 守卫。
 
 `RouteGroup.Prefix` 非空时按 path segment 前缀归属；`Prefix == ""` 不表示拥有整个 listener，而是从该 RouteGroup 内实际注册的 `Route` / `Handle` / `Mount` / `auth.Mount` 合同路径派生归属。重叠 namespace 按最长前缀/最长模板胜出；同一 listener 内跨 cell 声明完全相同的 owner path/template 必须 fail-fast，不能靠注册顺序抢占。
 

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -191,7 +191,7 @@ emitter health probe（`outbox_failopen_rate_<cell>`）的注册同理收口：c
 - **业务请求**：`cell=<cellID>` — 由 `runtime/http/router.Router.MountRouteGroup` 记录 `RouteGroup.CellID` 与 HTTP namespace 的 ownership，listener-root `CellAttribution` middleware 在 tracing/access-log/metrics/protection 之前写入 `kernel/ctxkeys.CellID`。成功 handler、auth/rate-limit/circuit-breaker/body-limit 前置拒绝、chi 405 都必须使用同一 cell。
 - **框架/未匹配请求**：`cell="_runtime"` 哨兵 — `runtime/http/middleware.Metrics` 在 `ctxkeys.CellID` 缺失时使用 `metrics.RuntimeCellSentinel`，覆盖 `/healthz`、`/readyz`、`/metrics` 自身、listener 外 404 等所有未落入业务 RouteGroup 的请求。
 
-`_runtime` 哨兵单源 = `runtime/observability/metrics.RuntimeCellSentinel`（HTTP middleware 与 gRPC metrics interceptor 共读同一常量，全仓仅此一处 `"_runtime"` 字面量）。
+HTTP/gRPC **request-metrics** `cell` label 的 `_runtime` 哨兵单源 = `runtime/observability/metrics.RuntimeCellSentinel`（HTTP middleware 与 gRPC metrics interceptor 共读同一常量，metrics 维度仅此一处声明）。注意这不是「全仓唯一 `"_runtime"` 字面量」：`_runtime` 作为「框架 / 无 owner」字符串约定在仓内更广泛复用——`kernel/reconcile.reconcilerIDSentinel`（reconcile owner label）、Redis `KeyNamespace` 的 idempotency-claimer 哨兵（`cmd/corebundle`）、`runtime/command/lifecycle` 的 cell 默认值等都各自声明同值字面量。它们**不能**共享 `RuntimeCellSentinel`：`kernel/` 不可 import `runtime/observability/metrics`（分层依赖规则），故按层独立声明是刻意为之，`RuntimeCellSentinel` 只能是 metrics 维度的单源。
 
 `RouteGroup.Prefix` 非空时按 path segment 前缀归属；`Prefix == ""` 不表示拥有整个 listener，而是从该 RouteGroup 内实际注册的 `Route` / `Handle` / `Mount` / `auth.Mount` 合同路径派生归属。重叠 namespace 按最长前缀/最长模板胜出；同一 listener 内跨 cell 声明完全相同的 owner path/template 必须 fail-fast，不能靠注册顺序抢占。
 

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -64,6 +64,29 @@ metric_relabel_configs:
   action: drop
 ```
 
+## gRPC Metrics `cell` Label（当前恒为 `_runtime`）
+
+gRPC 指标 `gocell_grpc_server_requests_total` 与
+`gocell_grpc_server_request_duration_seconds` 的 `cell` label 与 HTTP 共享同一
+`_runtime` 哨兵语义与单源（`runtime/observability/metrics.RuntimeCellSentinel`）。
+
+**重要**：gRPC cell attribution 尚未接线——HTTP 侧从 router-root `CellAttribution`
+中间件按 `RouteGroup.CellID` 归属 cell，gRPC 侧对应的 `FullMethod → cellID` 归属
+机制（由生成式 registrar 派生）随 epic PR-7/8 落地（tracking issue #1383）。在此
+之前，**所有 gRPC 流量的 `cell` label 恒为 `_runtime`**。
+
+运维影响：
+
+- 业务 SLO / 告警**不要**对 gRPC 指标使用 `{cell!="_runtime"}` 过滤——会过滤掉
+  全部 gRPC 流量。在 attribution 落地前，gRPC 流量按 `{cell="_runtime"}` 或不
+  过滤 `cell` 来观察。
+- gRPC 指标的 reader 侧契约（cell label 取自 `ctxkeys.CellID`，缺失回退
+  `RuntimeCellSentinel`）由 archtest `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01`
+  守卫，故 attribution 一旦接线，`cell` label 会自动反映归属 cell 而无需改
+  interceptor。
+- attribution 落地（#1383）后，本节将更新为与 HTTP 一致的 `{cell!="_runtime"}`
+  推荐过滤。
+
 ## HTTP Body-Limit 拒绝计数器
 
 `gocell_http_request_body_limit_rejections_total{cell, route}` 记录 BodyLimit 中间件

--- a/runtime/http/middleware/body_limit.go
+++ b/runtime/http/middleware/body_limit.go
@@ -57,7 +57,7 @@ func recordBodyLimitRejection(collector metrics.Collector, r *http.Request) {
 		return
 	}
 	ctx := r.Context()
-	cellID := RuntimeCellIDSentinel
+	cellID := metrics.RuntimeCellSentinel
 	if v, ok := ctxkeys.CellIDFrom(ctx); ok && v != "" {
 		cellID = v
 	}

--- a/runtime/http/middleware/body_limit_test.go
+++ b/runtime/http/middleware/body_limit_test.go
@@ -108,10 +108,10 @@ func TestBodyLimit_RecordsRejectionMetric(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 
 	snap := mc.Snapshot()
-	// No ctxkeys.CellID in ctx → falls back to RuntimeCellIDSentinel.
+	// No ctxkeys.CellID in ctx → falls back to metrics.RuntimeCellSentinel.
 	// No RouteResolver in ctx → RouteFor falls back to UnmatchedRoute.
 	key := metrics.BodyLimitRejectionKey{
-		Cell:  RuntimeCellIDSentinel,
+		Cell:  metrics.RuntimeCellSentinel,
 		Route: UnmatchedRoute,
 	}
 	assert.Equal(t, int64(1), snap.BodyLimitRejections[key],
@@ -180,7 +180,7 @@ func TestBodyLimit_UnmatchedRoutesDoNotExpandCardinality(t *testing.T) {
 	require.Len(t, snap.BodyLimitRejections, 1,
 		"distinct arbitrary paths must not expand body-limit rejection label cardinality")
 	key := metrics.BodyLimitRejectionKey{
-		Cell:  RuntimeCellIDSentinel,
+		Cell:  metrics.RuntimeCellSentinel,
 		Route: UnmatchedRoute,
 	}
 	assert.Equal(t, int64(len(paths)), snap.BodyLimitRejections[key],

--- a/runtime/http/middleware/cell_id.go
+++ b/runtime/http/middleware/cell_id.go
@@ -6,16 +6,13 @@ import (
 	"github.com/ghbvf/gocell/kernel/ctxkeys"
 )
 
-// RuntimeCellIDSentinel is the framework "owner" used as the cell label for
-// requests that do not belong to any cell-owned HTTP namespace.
-const RuntimeCellIDSentinel = "_runtime"
-
 // CellResolver maps a concrete request to the owning cell ID.
 type CellResolver func(method, path string) (string, bool)
 
 // CellAttribution writes the owning cell ID into request context before
 // protection middleware can short-circuit. Requests with no resolved cell keep
-// an absent ctx key; Metrics converts absence to RuntimeCellIDSentinel.
+// an absent ctx key; Metrics converts absence to the transport-neutral
+// metrics.RuntimeCellSentinel ("_runtime") sentinel.
 func CellAttribution(resolve CellResolver) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/runtime/http/middleware/cell_id_test.go
+++ b/runtime/http/middleware/cell_id_test.go
@@ -34,7 +34,3 @@ func TestCellAttribution_UnresolvedLeavesCtxkeyAbsent(t *testing.T) {
 
 	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/healthz", nil))
 }
-
-func TestRuntimeCellIDSentinel_IsExportedConstant(t *testing.T) {
-	assert.Equal(t, "_runtime", RuntimeCellIDSentinel)
-}

--- a/runtime/http/middleware/metrics.go
+++ b/runtime/http/middleware/metrics.go
@@ -21,7 +21,7 @@ import (
 // Cell-label resolution reads kernel/ctxkeys.CellID from request context.
 // Router-owned root attribution installs that key before short-circuiting
 // protection middleware. Absence means framework/runtime traffic and records
-// as RuntimeCellIDSentinel.
+// as metrics.RuntimeCellSentinel.
 //
 // Route label resolution uses RouteFor, which reads the dispatch-time
 // recorder first and then falls back to the RouteResolver injected by the
@@ -50,7 +50,7 @@ func metricsWithClock(collector metrics.Collector, clk clock.Clock) func(http.Ha
 
 			observability.SafeObserve(slog.Default(), func() {
 				route := RouteFor(r.Context(), r.Method, r.URL.Path)
-				cellID := RuntimeCellIDSentinel
+				cellID := metrics.RuntimeCellSentinel
 				if v, ok := ctxkeys.CellIDFrom(r.Context()); ok && v != "" {
 					cellID = v
 				}

--- a/runtime/observability/metrics/collector.go
+++ b/runtime/observability/metrics/collector.go
@@ -46,7 +46,7 @@ type Collector interface {
 	// call httputil.WriteError will not produce a 413 in http_requests_total.
 	//
 	// cellID follows the same semantics as RecordRequest: use the owning cell
-	// ID or RuntimeCellIDSentinel ("_runtime") for framework paths.
+	// ID or RuntimeCellSentinel ("_runtime") for framework paths.
 	// route is the low-cardinality route pattern from RouteFor.
 	RecordBodyLimitRejection(ctx context.Context, cellID, route string)
 }

--- a/runtime/observability/metrics/grpc_collector.go
+++ b/runtime/observability/metrics/grpc_collector.go
@@ -10,11 +10,11 @@ import (
 )
 
 // RuntimeCellSentinel is the framework "owner" used as the cell label for
-// requests that do not belong to any cell-owned namespace. It is the
-// transport-neutral home for the "_runtime" sentinel (the HTTP middleware
-// exposes the same value as RuntimeCellIDSentinel); the gRPC metrics
-// interceptor reads it from here so it does not depend on the HTTP middleware
-// package. See observability.md "HTTP Metrics cell Label".
+// requests that do not belong to any cell-owned namespace. It is the single,
+// transport-neutral source of the "_runtime" sentinel: both the HTTP middleware
+// (runtime/http/middleware.Metrics / CellAttribution / body-limit rejection) and
+// the gRPC metrics interceptor read this constant, so the value is declared
+// exactly once. See observability.md "HTTP Metrics cell Label".
 const RuntimeCellSentinel = "_runtime"
 
 // GRPCCollector records gRPC unary server request metrics. It mirrors the HTTP

--- a/tools/archtest/grpc_metrics_label_red_fixture_test.go
+++ b/tools/archtest/grpc_metrics_label_red_fixture_test.go
@@ -1,0 +1,77 @@
+// invariants:
+//   - INVARIANT: GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01 (RED fixture coverage)
+package archtest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected asserts the
+// production scan (scanGRPCMetricsLabelPkg) catches the unrelated-identifier
+// form that the pre-provenance rule silently accepted (blind spot B2). The
+// fixture at tools/archtest/internal/grpcmetricsfixture/grpc_metrics_red.go
+// (gated `//go:build archtest_fixture`) reads ctxkeys.CellIDFrom +
+// RuntimeCellSentinel and calls RecordRPC, but passes a bogus identifier as the
+// cell label. Every structural assertion therefore passes; only the two
+// cellIDProvenance assertions fire, so the scan must yield exactly 2
+// diagnostics.
+//
+// # Why a RED fixture is required
+//
+// Without it, the production rule's zero-diagnostic outcome on real UnaryMetrics
+// carries no information: the object-identity provenance binding could be
+// silently broken AND the production code happens to comply. The fixture is a
+// known-positive sample, so an accidental regression of cellIDProvenance turns
+// this test red.
+func TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	diags := RunTypedFixture(t,
+		FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/grpcmetricsfixture/..."},
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() || !strings.HasSuffix(p.Pkg.Path(), "/grpcmetricsfixture") {
+				return nil
+			}
+			return scanGRPCMetricsLabelPkg(p)
+		},
+	)
+
+	for _, d := range diags {
+		t.Logf("RED fixture hit: %s:%d %s", d.Rel, d.Line, d.Message)
+	}
+
+	// Exact equality (not ≥ 2): the fixture is intentionally minimal so that
+	// every non-provenance assertion passes and ONLY the two object-identity
+	// provenance checks fire. If the fixture changes intentionally, update the
+	// expected count.
+	assert.Len(t, diags, 2,
+		"GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01 must yield exactly 2 hits on the "+
+			"unrelated-ident fixture (the RuntimeCellSentinel-init + CellIDFrom-branch "+
+			"provenance bindings)")
+
+	// Strong specificity: the two diagnostics must be the provenance pair, not
+	// some other assertion regressing. The sentinel-provenance message is the
+	// only emitted one containing "RuntimeCellSentinel" (the usesSentinel
+	// assertion passes, so its message is not emitted); the ctx-provenance
+	// message is the only one containing "CellIDFrom(ctx) branch".
+	var sawSentinelProvenance, sawCtxProvenance bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "RuntimeCellSentinel") {
+			sawSentinelProvenance = true
+		}
+		if strings.Contains(d.Message, "CellIDFrom(ctx) branch") {
+			sawCtxProvenance = true
+		}
+	}
+	assert.True(t, sawSentinelProvenance,
+		"the rule must flag that the bogus arg is not the variable initialized from RuntimeCellSentinel")
+	assert.True(t, sawCtxProvenance,
+		"the rule must flag that the bogus arg is not the variable assigned from the CellIDFrom(ctx) branch")
+}

--- a/tools/archtest/grpc_metrics_label_test.go
+++ b/tools/archtest/grpc_metrics_label_test.go
@@ -2,7 +2,7 @@
 // source contract, the gRPC mirror of the HTTP CELLID-CTXSOURCE / RUNTIME-SENTINEL
 // invariants in http_metrics_label_test.go.
 //
-//   - INVARIANT: GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01
+// INVARIANT: GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01
 //
 // # What this guards
 //
@@ -101,12 +101,20 @@ func TestGRPCMetricsLabelCellIDCtxSource01(t *testing.T) {
 		if !p.Typed() || p.Pkg.Path() != grpcInterceptorPkgPath {
 			return nil
 		}
+		// The interceptor package loaded; the outer !visited Fatalf below now
+		// only fires for a genuine "package not loaded" (production scope gap),
+		// never for a renamed UnaryMetrics — that case emits its own diagnostic.
+		visited = true
 
 		fn := findUnaryMetricsFuncDecl(p.Files)
 		if fn == nil {
-			return nil
+			return []Diagnostic{{
+				Rel: p.Rel(p.Files[0]),
+				Message: fmt.Sprintf("%s: func %s not found in %s — renamed or moved? "+
+					"the gRPC metrics cell-label reader contract is no longer locked",
+					grpcMetricsRuleCtxSource, grpcMetricsUnaryMetricsName, grpcInterceptorPkgPath),
+			}}
 		}
-		visited = true
 
 		rel := relForFunc(p, fn)
 		info := p.TypesInfo

--- a/tools/archtest/grpc_metrics_label_test.go
+++ b/tools/archtest/grpc_metrics_label_test.go
@@ -28,11 +28,17 @@
 //
 // # AI-robust rating (charter §"Funnel 双向锁评级")
 //
-//   - Downstream: MEDIUM (archtest type-aware AST form + position ordering).
-//     The CellIDFrom / RuntimeCellSentinel origin checks resolve through
-//     go/types (ResolvePackageRef / ResolveMethodCall on the package's
-//     TypesInfo), so the kernelctxkeys import alias in metrics.go cannot evade
-//     detection and a same-named symbol from another package cannot satisfy it.
+//   - Downstream: MEDIUM (archtest type-aware AST form + position ordering +
+//     object-identity data-flow binding). The CellIDFrom / RuntimeCellSentinel
+//     origin checks resolve through go/types (ResolvePackageRef /
+//     ResolveMethodCall on the package's TypesInfo), so the kernelctxkeys import
+//     alias in metrics.go cannot evade detection and a same-named symbol from
+//     another package cannot satisfy it. The RecordRPC cell-label argument is
+//     additionally bound to its data-flow origin by go/types *object identity*
+//     (cellIDProvenance): the passed identifier MUST be the same var.Object that
+//     is both initialized from metrics.RuntimeCellSentinel and (re)assigned from
+//     the ctxkeys.CellIDFrom(ctx) branch value — an unrelated identifier of the
+//     correct AST shape no longer satisfies the rule (closes B2, see below).
 //   - Upstream: HARD is UNREACHABLE in this slice — a Go-language ceiling, not a
 //     deferred TODO at the archtest layer. The Hard form is a sealed CellLabel
 //     type that makes a hardcoded cell label compile-impossible (only producible
@@ -49,21 +55,34 @@
 //     produced from the interceptor's ctx param vs some other context value; it
 //     only asserts arg[0] is an identifier (not a fresh context.Background() /
 //     context.TODO() call expression). Mirrors the HTTP body_limit arg[0] check.
-//   - B2. The rule does not verify the cellID variable was assigned from
-//     CellIDFrom's return; it asserts (a) CellIDFrom is called and (b) the
-//     RecordRPC cellID arg is an identifier (not a string literal). A pathological
-//     body that reads CellIDFrom but passes an unrelated ident would pass — but
-//     such a body cannot pass a HARDCODED literal, which is the actual threat.
+//   - B2 (CLOSED). Earlier revisions only asserted the RecordRPC cellID arg was
+//     an identifier (not a string literal), so a body that read CellIDFrom but
+//     passed an *unrelated* identifier would pass. cellIDProvenance now binds the
+//     arg by go/types object identity to BOTH the metrics.RuntimeCellSentinel
+//     init and the ctxkeys.CellIDFrom(ctx) branch assignment, so the unrelated-
+//     ident form is rejected. Proven by the RED fixture
+//     (TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected). Residual: only
+//     direct (single-hop) assignments are followed — an indirect alias chain
+//     (cellID = tmp; tmp = v) is NOT recognized, but that fails CLOSED (the
+//     provenance asserts fire), so it cannot smuggle a bad label through.
 //   - B3. A RecordRPC call added in a //go:build-gated production file under a
 //     non-default tag would be missed by the default-tags load. UnaryMetrics is
 //     default-build; documented.
 //
 // # Reverse self-check
 //
-// The cellID argument of RecordRPC must be an *ast.Ident, never an *ast.BasicLit
-// — i.e. a hardcoded cell label string passed directly to RecordRPC fails the
-// rule. This is the durable guard that survives independent of the ctx-read
-// assertions above.
+// The cellID argument of RecordRPC must be an *ast.Ident (never an *ast.BasicLit)
+// whose go/types object is provenance-bound to both the RuntimeCellSentinel init
+// and the CellIDFrom(ctx) branch. Two reverse guards prove this is enforced, not
+// merely asserted on compliant source:
+//
+//   - A hardcoded cell-label string passed directly to RecordRPC fails the rule
+//     (the !BasicLit assertion).
+//   - An unrelated identifier of the correct AST shape (a valid ident that is NOT
+//     the ctx-derived cellID) fails the rule — exercised by the RED fixture
+//     internal/grpcmetricsfixture (gated `//go:build archtest_fixture`), which
+//     reads CellIDFrom + sentinel but feeds a bogus ident to RecordRPC and must
+//     yield exactly the two cellIDProvenance diagnostics.
 package archtest
 
 import (
@@ -88,8 +107,9 @@ const (
 // TestGRPCMetricsLabelCellIDCtxSource01 asserts that
 // runtime/grpc/interceptor.UnaryMetrics sources its `cell` label from
 // kernel/ctxkeys.CellIDFrom with a runtime/observability/metrics.RuntimeCellSentinel
-// fallback, feeding a ctx-derived identifier (never a literal) into
-// GRPCCollector.RecordRPC, with both reads ordered before the RecordRPC call.
+// fallback, feeding a ctx-derived identifier (never a literal, never an unrelated
+// var) into GRPCCollector.RecordRPC, with both reads ordered before the
+// RecordRPC call.
 func TestGRPCMetricsLabelCellIDCtxSource01(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -105,99 +125,7 @@ func TestGRPCMetricsLabelCellIDCtxSource01(t *testing.T) {
 		// only fires for a genuine "package not loaded" (production scope gap),
 		// never for a renamed UnaryMetrics — that case emits its own diagnostic.
 		visited = true
-
-		fn := findUnaryMetricsFuncDecl(p.Files)
-		if fn == nil {
-			return []Diagnostic{{
-				Rel: p.Rel(p.Files[0]),
-				Message: fmt.Sprintf("%s: func %s not found in %s — renamed or moved? "+
-					"the gRPC metrics cell-label reader contract is no longer locked",
-					grpcMetricsRuleCtxSource, grpcMetricsUnaryMetricsName, grpcInterceptorPkgPath),
-			}}
-		}
-
-		rel := relForFunc(p, fn)
-		info := p.TypesInfo
-
-		// Narrowest FuncLit whose body issues GRPCCollector.RecordRPC — the
-		// SafeObserve closure that builds and records the metric.
-		recordLit := narrowestFuncLitWithRecordRPC(info, fn.Body)
-		if recordLit == nil {
-			return []Diagnostic{{
-				Rel:  rel,
-				Line: p.Fset.Position(fn.Pos()).Line,
-				Message: fmt.Sprintf("%s: %s.UnaryMetrics must record gRPC metrics through "+
-					"GRPCCollector.RecordRPC", grpcMetricsRuleCtxSource, grpcInterceptorPkgPath),
-			}}
-		}
-
-		var (
-			readsCtxCellID   bool
-			usesSentinel     bool
-			ctxCellIDPos     token.Pos
-			sentinelPos      token.Pos
-			recordPos        token.Pos
-			cellIDArgIsIdent bool
-			cellIDArgIsLit   bool
-			ctxArgIsIdent    bool
-			sawRecordRPC     bool
-		)
-
-		EachInSubtree[ast.CallExpr](recordLit.Body, func(call *ast.CallExpr) {
-			// kernel/ctxkeys.CellIDFrom(ctx) — alias-robust via go/types.
-			if pkg, name, ok := ResolvePackageRef(info, call.Fun); ok &&
-				pkg == grpcCtxkeysPkgPath && name == grpcMetricsCellIDFromName {
-				readsCtxCellID = true
-				rememberFirstPos(&ctxCellIDPos, call.Pos())
-			}
-			// GRPCCollector.RecordRPC(ctx, cellID, method, code, duration).
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return
-			}
-			rpc, ok := ResolveMethodCall(info, sel)
-			if !ok || rpc.Name() != grpcMetricsRecordRPCName ||
-				rpc.Pkg() == nil || rpc.Pkg().Path() != grpcMetricsPkgPath {
-				return
-			}
-			sawRecordRPC = true
-			rememberFirstPos(&recordPos, call.Pos())
-			if len(call.Args) > 0 {
-				_, ctxArgIsIdent = call.Args[0].(*ast.Ident)
-			}
-			if len(call.Args) > 1 {
-				_, cellIDArgIsIdent = call.Args[1].(*ast.Ident)
-				_, cellIDArgIsLit = call.Args[1].(*ast.BasicLit)
-			}
-		})
-		// runtime/observability/metrics.RuntimeCellSentinel fallback — resolved
-		// via go/types on selector/ident value references (alias-robust).
-		EachInSubtree[ast.SelectorExpr](recordLit.Body, func(sel *ast.SelectorExpr) {
-			if pkg, name, ok := ResolvePackageRef(info, sel); ok &&
-				pkg == grpcMetricsPkgPath && name == grpcMetricsSentinelName {
-				usesSentinel = true
-				rememberFirstPos(&sentinelPos, sel.Pos())
-			}
-		})
-
-		var d []Diagnostic
-		add := func(cond bool, msg string) {
-			if !cond {
-				d = append(d, Diagnostic{Rel: rel, Line: p.Fset.Position(recordLit.Pos()).Line, Message: grpcMetricsRuleCtxSource + ": " + msg})
-			}
-		}
-		add(readsCtxCellID, "UnaryMetrics must read the cell label from kernel/ctxkeys.CellIDFrom(ctx)")
-		add(usesSentinel, "UnaryMetrics must default a missing cell context to metrics.RuntimeCellSentinel before RecordRPC")
-		add(sawRecordRPC, "UnaryMetrics must call GRPCCollector.RecordRPC")
-		add(cellIDArgIsIdent, "RecordRPC arg[1] (cell label) must be the ctx-derived cellID identifier, not a constructor/config value")
-		add(!cellIDArgIsLit, "RecordRPC arg[1] (cell label) must NOT be a string literal — "+
-			"a hardcoded cell label is forbidden (reverse self-check)")
-		add(ctxArgIsIdent, "RecordRPC arg[0] must be the ctx identifier, not a fresh context.Background()/TODO() call expression")
-		add(ctxCellIDPos.IsValid() && recordPos.IsValid() && ctxCellIDPos < recordPos,
-			"ctxkeys.CellIDFrom must be read before GRPCCollector.RecordRPC")
-		add(sentinelPos.IsValid() && recordPos.IsValid() && sentinelPos < recordPos,
-			"metrics.RuntimeCellSentinel fallback must appear before GRPCCollector.RecordRPC")
-		return d
+		return scanGRPCMetricsLabelPkg(p)
 	})
 
 	if !visited {
@@ -205,6 +133,183 @@ func TestGRPCMetricsLabelCellIDCtxSource01(t *testing.T) {
 			grpcMetricsRuleCtxSource, grpcInterceptorPkgPath, grpcMetricsUnaryMetricsName)
 	}
 	Report(t, grpcMetricsRuleCtxSource, diags)
+}
+
+// scanGRPCMetricsLabelPkg runs the GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01 checks
+// against the already-package-filtered Pass p — the production interceptor
+// package (TestGRPCMetricsLabelCellIDCtxSource01) or the RED fixture
+// (TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected). The package-path
+// filter and the production `visited` tracking stay in the callers so the same
+// scan serves both RunTypedProduction and RunTypedFixture.
+func scanGRPCMetricsLabelPkg(p *Pass) []Diagnostic {
+	fn := findUnaryMetricsFuncDecl(p.Files)
+	if fn == nil {
+		return []Diagnostic{{
+			Rel: p.Rel(p.Files[0]),
+			Message: fmt.Sprintf("%s: func %s not found in %s — renamed or moved? "+
+				"the gRPC metrics cell-label reader contract is no longer locked",
+				grpcMetricsRuleCtxSource, grpcMetricsUnaryMetricsName, p.Pkg.Path()),
+		}}
+	}
+
+	rel := relForFunc(p, fn)
+	info := p.TypesInfo
+
+	// Narrowest FuncLit whose body issues GRPCCollector.RecordRPC — the
+	// SafeObserve closure that builds and records the metric.
+	recordLit := narrowestFuncLitWithRecordRPC(info, fn.Body)
+	if recordLit == nil {
+		return []Diagnostic{{
+			Rel:  rel,
+			Line: p.Fset.Position(fn.Pos()).Line,
+			Message: fmt.Sprintf("%s: %s.UnaryMetrics must record gRPC metrics through "+
+				"GRPCCollector.RecordRPC", grpcMetricsRuleCtxSource, p.Pkg.Path()),
+		}}
+	}
+
+	var (
+		readsCtxCellID   bool
+		usesSentinel     bool
+		ctxCellIDPos     token.Pos
+		sentinelPos      token.Pos
+		recordPos        token.Pos
+		cellIDArgIsIdent bool
+		cellIDArgIsLit   bool
+		ctxArgIsIdent    bool
+		sawRecordRPC     bool
+		cellIDArgExpr    ast.Expr // arg[1] of RecordRPC; fed to cellIDProvenance.
+	)
+
+	EachInSubtree[ast.CallExpr](recordLit.Body, func(call *ast.CallExpr) {
+		// kernel/ctxkeys.CellIDFrom(ctx) — alias-robust via go/types.
+		if pkg, name, ok := ResolvePackageRef(info, call.Fun); ok &&
+			pkg == grpcCtxkeysPkgPath && name == grpcMetricsCellIDFromName {
+			readsCtxCellID = true
+			rememberFirstPos(&ctxCellIDPos, call.Pos())
+		}
+		// GRPCCollector.RecordRPC(ctx, cellID, method, code, duration).
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		rpc, ok := ResolveMethodCall(info, sel)
+		if !ok || rpc.Name() != grpcMetricsRecordRPCName ||
+			rpc.Pkg() == nil || rpc.Pkg().Path() != grpcMetricsPkgPath {
+			return
+		}
+		sawRecordRPC = true
+		rememberFirstPos(&recordPos, call.Pos())
+		if len(call.Args) > 0 {
+			_, ctxArgIsIdent = call.Args[0].(*ast.Ident)
+		}
+		if len(call.Args) > 1 {
+			cellIDArgExpr = call.Args[1]
+			_, cellIDArgIsIdent = call.Args[1].(*ast.Ident)
+			_, cellIDArgIsLit = call.Args[1].(*ast.BasicLit)
+		}
+	})
+	// runtime/observability/metrics.RuntimeCellSentinel fallback — resolved
+	// via go/types on selector/ident value references (alias-robust).
+	EachInSubtree[ast.SelectorExpr](recordLit.Body, func(sel *ast.SelectorExpr) {
+		if pkg, name, ok := ResolvePackageRef(info, sel); ok &&
+			pkg == grpcMetricsPkgPath && name == grpcMetricsSentinelName {
+			usesSentinel = true
+			rememberFirstPos(&sentinelPos, sel.Pos())
+		}
+	})
+
+	// Data-flow provenance: bind the cell-label argument to its origin by
+	// go/types object identity (closes blind spot B2). An unrelated identifier
+	// — even a valid *ast.Ident that is not a literal — satisfies neither.
+	cellIDFromSentinel, cellIDFromCtx := cellIDProvenance(info, recordLit.Body, cellIDArgExpr)
+
+	var d []Diagnostic
+	add := func(cond bool, msg string) {
+		if !cond {
+			d = append(d, Diagnostic{Rel: rel, Line: p.Fset.Position(recordLit.Pos()).Line, Message: grpcMetricsRuleCtxSource + ": " + msg})
+		}
+	}
+	add(readsCtxCellID, "UnaryMetrics must read the cell label from kernel/ctxkeys.CellIDFrom(ctx)")
+	add(usesSentinel, "UnaryMetrics must default a missing cell context to metrics.RuntimeCellSentinel before RecordRPC")
+	add(sawRecordRPC, "UnaryMetrics must call GRPCCollector.RecordRPC")
+	add(cellIDArgIsIdent, "RecordRPC arg[1] (cell label) must be an identifier (a ctx-derived variable), not an inline expression")
+	add(!cellIDArgIsLit, "RecordRPC arg[1] (cell label) must NOT be a string literal — "+
+		"a hardcoded cell label is forbidden (reverse self-check)")
+	add(cellIDFromSentinel, "RecordRPC arg[1] (cell label) must be the same variable initialized from "+
+		"metrics.RuntimeCellSentinel — provenance binding by go/types object identity (closes B2)")
+	add(cellIDFromCtx, "RecordRPC arg[1] (cell label) must be the same variable (re)assigned from the "+
+		"ctxkeys.CellIDFrom(ctx) branch value — provenance binding by go/types object identity (closes B2)")
+	add(ctxArgIsIdent, "RecordRPC arg[0] must be the ctx identifier, not a fresh context.Background()/TODO() call expression")
+	add(ctxCellIDPos.IsValid() && recordPos.IsValid() && ctxCellIDPos < recordPos,
+		"ctxkeys.CellIDFrom must be read before GRPCCollector.RecordRPC")
+	add(sentinelPos.IsValid() && recordPos.IsValid() && sentinelPos < recordPos,
+		"metrics.RuntimeCellSentinel fallback must appear before GRPCCollector.RecordRPC")
+	return d
+}
+
+// cellIDProvenance binds the RecordRPC cell-label argument to its data-flow
+// origin by go/types object identity (closes blind spot B2). It reports whether
+// the object referenced by argExpr is (a) initialized from
+// metrics.RuntimeCellSentinel and (b) (re)assigned from the value bound by a
+// kernel/ctxkeys.CellIDFrom(ctx) call within body. An unrelated identifier — even
+// a valid *ast.Ident that is not a string literal — is the same var.Object in
+// neither assignment, so both results are false and the rule rejects it.
+//
+// Only direct (single-hop) assignments are followed; an indirect alias chain
+// (cellID = tmp; tmp = v) is not recognized but fails CLOSED — see godoc B2.
+func cellIDProvenance(info *types.Info, body ast.Node, argExpr ast.Expr) (fromSentinel, fromCtx bool) {
+	argIdent, ok := argExpr.(*ast.Ident)
+	if !ok {
+		return false, false
+	}
+	argObj := info.ObjectOf(argIdent)
+	if argObj == nil {
+		return false, false
+	}
+
+	// Pass 1: collect the objects bound by `<v>, <ok> := ctxkeys.CellIDFrom(ctx)`
+	// — the ctx-derived value candidates the cell label may be assigned from.
+	ctxValueObjs := map[types.Object]bool{}
+	EachInSubtree[ast.AssignStmt](body, func(as *ast.AssignStmt) {
+		if len(as.Lhs) == 0 || len(as.Rhs) != 1 {
+			return
+		}
+		call, ok := as.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return
+		}
+		if pkg, name, ok := ResolvePackageRef(info, call.Fun); !ok ||
+			pkg != grpcCtxkeysPkgPath || name != grpcMetricsCellIDFromName {
+			return
+		}
+		if id, ok := as.Lhs[0].(*ast.Ident); ok {
+			if obj := info.ObjectOf(id); obj != nil {
+				ctxValueObjs[obj] = true
+			}
+		}
+	})
+
+	// Pass 2: inspect every assignment whose LHS is the cell-label object, and
+	// classify its RHS as the sentinel init or a ctx-derived value assignment.
+	EachInSubtree[ast.AssignStmt](body, func(as *ast.AssignStmt) {
+		for i, lhs := range as.Lhs {
+			id, isIdent := lhs.(*ast.Ident)
+			if !isIdent || info.ObjectOf(id) != argObj || i >= len(as.Rhs) {
+				continue
+			}
+			rhs := as.Rhs[i]
+			if pkg, name, ok := ResolvePackageRef(info, rhs); ok &&
+				pkg == grpcMetricsPkgPath && name == grpcMetricsSentinelName {
+				fromSentinel = true
+			}
+			if rid, ok := rhs.(*ast.Ident); ok {
+				if obj := info.ObjectOf(rid); obj != nil && ctxValueObjs[obj] {
+					fromCtx = true
+				}
+			}
+		}
+	})
+	return fromSentinel, fromCtx
 }
 
 // findUnaryMetricsFuncDecl returns the UnaryMetrics top-level FuncDecl across the

--- a/tools/archtest/grpc_metrics_label_test.go
+++ b/tools/archtest/grpc_metrics_label_test.go
@@ -1,0 +1,255 @@
+// grpc_metrics_label_test.go — locks the gRPC metrics interceptor's cell-label
+// source contract, the gRPC mirror of the HTTP CELLID-CTXSOURCE / RUNTIME-SENTINEL
+// invariants in http_metrics_label_test.go.
+//
+//   - INVARIANT: GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01
+//
+// # What this guards
+//
+// runtime/grpc/interceptor.UnaryMetrics records grpc_server_requests_total /
+// grpc_server_request_duration_seconds. Its `cell` label MUST be sourced from
+// kernel/ctxkeys.CellIDFrom(ctx), defaulting to
+// runtime/observability/metrics.RuntimeCellSentinel ("_runtime") when the ctx
+// key is absent — never a hand-written cell literal, a constructor field, or an
+// assembly-derived value. This is the reader-side half of cell attribution: it
+// is correct TODAY (the interceptor already reads ctx + sentinel), and it must
+// stay correct so that when the writer side lands (the FullMethod→cellID
+// attribution interceptor, epic PR-7/8) the recorded `cell` label automatically
+// reflects the attributed cell instead of regressing to a hardcoded value.
+//
+// Scope note: gRPC cell ATTRIBUTION (writing ctxkeys.CellID from a FullMethod→
+// cellID map) is NOT yet wired — that needs the generated registrar (epic PR-7)
+// + an example service (epic PR-8), tracked by gh #1383. So there is no gRPC
+// analog of HTTP's ROUTER-ATTRIBUTION-01 (which asserts the attribution
+// middleware is installed) — there is no interceptor to assert yet. This
+// archtest deliberately covers ONLY the reader contract; the attribution-wiring
+// archtest lands with PR-7/8. Until then the recorded label is always
+// "_runtime" (see docs/ops/alerting-rules.md).
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Downstream: MEDIUM (archtest type-aware AST form + position ordering).
+//     The CellIDFrom / RuntimeCellSentinel origin checks resolve through
+//     go/types (ResolvePackageRef / ResolveMethodCall on the package's
+//     TypesInfo), so the kernelctxkeys import alias in metrics.go cannot evade
+//     detection and a same-named symbol from another package cannot satisfy it.
+//   - Upstream: HARD is UNREACHABLE in this slice — a Go-language ceiling, not a
+//     deferred TODO at the archtest layer. The Hard form is a sealed CellLabel
+//     type that makes a hardcoded cell label compile-impossible (only producible
+//     from ctx or the sentinel). That is the SAME sealed-collector funnel the
+//     HTTP side already deferred and tracks at gh #1398 (HTTP's symmetric
+//     RecordRequest(cellID string) is also Medium-guarded). Introducing a
+//     gRPC-only sealed type now would break HTTP/gRPC symmetry and front-run
+//     #1398, so the Hard upgrade is bound to that unified funnel — HTTP + gRPC
+//     convert together. Tracked: gh #1398.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//   - B1. The rule does not verify that the `ctx` passed to RecordRPC was itself
+//     produced from the interceptor's ctx param vs some other context value; it
+//     only asserts arg[0] is an identifier (not a fresh context.Background() /
+//     context.TODO() call expression). Mirrors the HTTP body_limit arg[0] check.
+//   - B2. The rule does not verify the cellID variable was assigned from
+//     CellIDFrom's return; it asserts (a) CellIDFrom is called and (b) the
+//     RecordRPC cellID arg is an identifier (not a string literal). A pathological
+//     body that reads CellIDFrom but passes an unrelated ident would pass — but
+//     such a body cannot pass a HARDCODED literal, which is the actual threat.
+//   - B3. A RecordRPC call added in a //go:build-gated production file under a
+//     non-default tag would be missed by the default-tags load. UnaryMetrics is
+//     default-build; documented.
+//
+// # Reverse self-check
+//
+// The cellID argument of RecordRPC must be an *ast.Ident, never an *ast.BasicLit
+// — i.e. a hardcoded cell label string passed directly to RecordRPC fails the
+// rule. This is the durable guard that survives independent of the ctx-read
+// assertions above.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+const (
+	grpcMetricsRuleCtxSource = "GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01"
+	// grpcInterceptorPkgPath is declared in grpc_interceptor_chain_invariants_test.go.
+	grpcCtxkeysPkgPath          = PlatformModulePath + "/kernel/ctxkeys"
+	grpcMetricsPkgPath          = PlatformModulePath + "/runtime/observability/metrics"
+	grpcMetricsCellIDFromName   = "CellIDFrom"
+	grpcMetricsSentinelName     = "RuntimeCellSentinel"
+	grpcMetricsRecordRPCName    = "RecordRPC"
+	grpcMetricsUnaryMetricsName = "UnaryMetrics"
+)
+
+// TestGRPCMetricsLabelCellIDCtxSource01 asserts that
+// runtime/grpc/interceptor.UnaryMetrics sources its `cell` label from
+// kernel/ctxkeys.CellIDFrom with a runtime/observability/metrics.RuntimeCellSentinel
+// fallback, feeding a ctx-derived identifier (never a literal) into
+// GRPCCollector.RecordRPC, with both reads ordered before the RecordRPC call.
+func TestGRPCMetricsLabelCellIDCtxSource01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var visited bool
+	diags := RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+		if !p.Typed() || p.Pkg.Path() != grpcInterceptorPkgPath {
+			return nil
+		}
+
+		fn := findUnaryMetricsFuncDecl(p.Files)
+		if fn == nil {
+			return nil
+		}
+		visited = true
+
+		rel := relForFunc(p, fn)
+		info := p.TypesInfo
+
+		// Narrowest FuncLit whose body issues GRPCCollector.RecordRPC — the
+		// SafeObserve closure that builds and records the metric.
+		recordLit := narrowestFuncLitWithRecordRPC(info, fn.Body)
+		if recordLit == nil {
+			return []Diagnostic{{
+				Rel:  rel,
+				Line: p.Fset.Position(fn.Pos()).Line,
+				Message: fmt.Sprintf("%s: %s.UnaryMetrics must record gRPC metrics through "+
+					"GRPCCollector.RecordRPC", grpcMetricsRuleCtxSource, grpcInterceptorPkgPath),
+			}}
+		}
+
+		var (
+			readsCtxCellID   bool
+			usesSentinel     bool
+			ctxCellIDPos     token.Pos
+			sentinelPos      token.Pos
+			recordPos        token.Pos
+			cellIDArgIsIdent bool
+			cellIDArgIsLit   bool
+			ctxArgIsIdent    bool
+			sawRecordRPC     bool
+		)
+
+		EachInSubtree[ast.CallExpr](recordLit.Body, func(call *ast.CallExpr) {
+			// kernel/ctxkeys.CellIDFrom(ctx) — alias-robust via go/types.
+			if pkg, name, ok := ResolvePackageRef(info, call.Fun); ok &&
+				pkg == grpcCtxkeysPkgPath && name == grpcMetricsCellIDFromName {
+				readsCtxCellID = true
+				rememberFirstPos(&ctxCellIDPos, call.Pos())
+			}
+			// GRPCCollector.RecordRPC(ctx, cellID, method, code, duration).
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return
+			}
+			rpc, ok := ResolveMethodCall(info, sel)
+			if !ok || rpc.Name() != grpcMetricsRecordRPCName ||
+				rpc.Pkg() == nil || rpc.Pkg().Path() != grpcMetricsPkgPath {
+				return
+			}
+			sawRecordRPC = true
+			rememberFirstPos(&recordPos, call.Pos())
+			if len(call.Args) > 0 {
+				_, ctxArgIsIdent = call.Args[0].(*ast.Ident)
+			}
+			if len(call.Args) > 1 {
+				_, cellIDArgIsIdent = call.Args[1].(*ast.Ident)
+				_, cellIDArgIsLit = call.Args[1].(*ast.BasicLit)
+			}
+		})
+		// runtime/observability/metrics.RuntimeCellSentinel fallback — resolved
+		// via go/types on selector/ident value references (alias-robust).
+		EachInSubtree[ast.SelectorExpr](recordLit.Body, func(sel *ast.SelectorExpr) {
+			if pkg, name, ok := ResolvePackageRef(info, sel); ok &&
+				pkg == grpcMetricsPkgPath && name == grpcMetricsSentinelName {
+				usesSentinel = true
+				rememberFirstPos(&sentinelPos, sel.Pos())
+			}
+		})
+
+		var d []Diagnostic
+		add := func(cond bool, msg string) {
+			if !cond {
+				d = append(d, Diagnostic{Rel: rel, Line: p.Fset.Position(recordLit.Pos()).Line, Message: grpcMetricsRuleCtxSource + ": " + msg})
+			}
+		}
+		add(readsCtxCellID, "UnaryMetrics must read the cell label from kernel/ctxkeys.CellIDFrom(ctx)")
+		add(usesSentinel, "UnaryMetrics must default a missing cell context to metrics.RuntimeCellSentinel before RecordRPC")
+		add(sawRecordRPC, "UnaryMetrics must call GRPCCollector.RecordRPC")
+		add(cellIDArgIsIdent, "RecordRPC arg[1] (cell label) must be the ctx-derived cellID identifier, not a constructor/config value")
+		add(!cellIDArgIsLit, "RecordRPC arg[1] (cell label) must NOT be a string literal — "+
+			"a hardcoded cell label is forbidden (reverse self-check)")
+		add(ctxArgIsIdent, "RecordRPC arg[0] must be the ctx identifier, not a fresh context.Background()/TODO() call expression")
+		add(ctxCellIDPos.IsValid() && recordPos.IsValid() && ctxCellIDPos < recordPos,
+			"ctxkeys.CellIDFrom must be read before GRPCCollector.RecordRPC")
+		add(sentinelPos.IsValid() && recordPos.IsValid() && sentinelPos < recordPos,
+			"metrics.RuntimeCellSentinel fallback must appear before GRPCCollector.RecordRPC")
+		return d
+	})
+
+	if !visited {
+		t.Fatalf("%s: package %s with func %s not loaded — rule did not run against real source",
+			grpcMetricsRuleCtxSource, grpcInterceptorPkgPath, grpcMetricsUnaryMetricsName)
+	}
+	Report(t, grpcMetricsRuleCtxSource, diags)
+}
+
+// findUnaryMetricsFuncDecl returns the UnaryMetrics top-level FuncDecl across the
+// Pass's files, or nil if absent.
+func findUnaryMetricsFuncDecl(files []*ast.File) *ast.FuncDecl {
+	var result *ast.FuncDecl
+	for _, f := range files {
+		EachInSubtree[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+			if result == nil && fn.Recv == nil && fn.Name.Name == grpcMetricsUnaryMetricsName {
+				result = fn
+			}
+		})
+	}
+	return result
+}
+
+// relForFunc returns the module-relative path of the file owning fn.
+func relForFunc(p *Pass, fn *ast.FuncDecl) string {
+	for _, f := range p.Files {
+		if fn.Pos() >= f.Pos() && fn.Pos() <= f.End() {
+			return p.Rel(f)
+		}
+	}
+	return grpcInterceptorPkgPath
+}
+
+// narrowestFuncLitWithRecordRPC returns the smallest *ast.FuncLit under root
+// whose body issues a call resolving to GRPCCollector.RecordRPC.
+func narrowestFuncLitWithRecordRPC(info *types.Info, root ast.Node) *ast.FuncLit {
+	var best *ast.FuncLit
+	EachInSubtree[ast.FuncLit](root, func(fl *ast.FuncLit) {
+		if !bodyCallsRecordRPC(info, fl.Body) {
+			return
+		}
+		if best == nil || fl.End()-fl.Pos() < best.End()-best.Pos() {
+			best = fl
+		}
+	})
+	return best
+}
+
+// bodyCallsRecordRPC reports whether root contains a call resolving to
+// runtime/observability/metrics.GRPCCollector.RecordRPC. Uses the typed
+// find-first funnel (SCANNER-FRAMEWORK-USAGE-02) rather than a closure sentinel.
+func bodyCallsRecordRPC(info *types.Info, root ast.Node) bool {
+	_, ok := FindFirstInSubtree[ast.CallExpr](root, func(call *ast.CallExpr) bool {
+		sel, isSel := call.Fun.(*ast.SelectorExpr)
+		if !isSel {
+			return false
+		}
+		rpc, resolved := ResolveMethodCall(info, sel)
+		return resolved && rpc.Name() == grpcMetricsRecordRPCName &&
+			rpc.Pkg() != nil && rpc.Pkg().Path() == grpcMetricsPkgPath
+	})
+	return ok
+}

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -92,8 +92,8 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 			}
 		}
 	})
-	scanner.EachInSubtree[ast.Ident](metricsPath.Body, func(v *ast.Ident) {
-		if v.Name == "RuntimeCellIDSentinel" {
+	scanner.EachInSubtree[ast.SelectorExpr](metricsPath.Body, func(v *ast.SelectorExpr) {
+		if isRuntimeCellSentinelRef(v) {
 			usesRuntimeSentinel = true
 			rememberFirstPos(&runtimeSentinelPos, v.Pos())
 		}
@@ -103,7 +103,7 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 		"%s: %s — middleware.Metrics must read cell labels from kernel/ctxkeys.CellIDFrom",
 		rel, ruleHTTPMetricsLabelCtxSource01)
 	assert.Truef(t, usesRuntimeSentinel,
-		"%s: %s — middleware.Metrics must default missing cell context to RuntimeCellIDSentinel in the RecordRequest path",
+		"%s: %s — middleware.Metrics must default missing cell context to metrics.RuntimeCellSentinel in the RecordRequest path",
 		rel, ruleHTTPMetricsLabelRuntimeSentinel)
 	assert.Truef(t, recordUsesCellIDArg,
 		"%s: %s — collector.RecordRequest must receive the ctx-derived cellID variable, not a constructor/config value",
@@ -116,7 +116,7 @@ func TestHTTPMetricsLabelCellIDCtxSource01(t *testing.T) {
 		"%s: %s — ctxkeys.CellIDFrom must feed the metrics path before collector.RecordRequest",
 		rel, ruleHTTPMetricsLabelCtxSource01)
 	assert.Truef(t, runtimeSentinelPos.IsValid() && recordRequestPos.IsValid() && runtimeSentinelPos < recordRequestPos,
-		"%s: %s — RuntimeCellIDSentinel must be the fallback before collector.RecordRequest",
+		"%s: %s — metrics.RuntimeCellSentinel must be the fallback before collector.RecordRequest",
 		rel, ruleHTTPMetricsLabelRuntimeSentinel)
 	assert.Falsef(t, callsOldState,
 		"%s: %s — old mutable cell helper is deleted; cell attribution must happen at router root",
@@ -409,7 +409,7 @@ func isRouterUseWithDefaultMiddleware(call *ast.CallExpr) bool {
 // rejection recording helper (recordBodyLimitRejection in body_limit.go):
 //
 //  1. Reads the cell label from ctxkeys.CellIDFrom.
-//  2. Falls back to RuntimeCellIDSentinel when the ctx key is absent.
+//  2. Falls back to metrics.RuntimeCellSentinel when the ctx key is absent.
 //  3. Calls collector.RecordBodyLimitRejection AFTER the CellIDFrom read.
 //  4. Derives the route label via RouteFor (not a bare string literal or URL path).
 //  5. Passes ctx (derived from r.Context()) as the first argument to
@@ -424,7 +424,7 @@ func isRouterUseWithDefaultMiddleware(call *ast.CallExpr) bool {
 // # Covered forms (reverse self-tests assert these are the only forms present)
 //
 //   - ctxkeys.CellIDFrom appears in the helper body before RecordBodyLimitRejection.
-//   - RuntimeCellIDSentinel appears in the helper body before RecordBodyLimitRejection.
+//   - metrics.RuntimeCellSentinel appears in the helper body before RecordBodyLimitRejection.
 //   - RouteFor is called in the helper body (route is not a bare literal or URL path).
 //   - RecordBodyLimitRejection arg[0] is an *ast.Ident (ctx variable, not a call expr
 //     such as context.Background() or r.Context() directly).
@@ -500,8 +500,8 @@ func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 			}
 		}
 	})
-	scanner.EachInSubtree[ast.Ident](helperFn.Body, func(v *ast.Ident) {
-		if v.Name == "RuntimeCellIDSentinel" {
+	scanner.EachInSubtree[ast.SelectorExpr](helperFn.Body, func(v *ast.SelectorExpr) {
+		if isRuntimeCellSentinelRef(v) {
 			usesRuntimeSentinel = true
 			rememberFirstPos(&runtimeSentinelPos, v.Pos())
 		}
@@ -511,7 +511,7 @@ func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 		"%s: %s — recordBodyLimitRejection must read cell label from ctxkeys.CellIDFrom",
 		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 	assert.Truef(t, usesRuntimeSentinel,
-		"%s: %s — recordBodyLimitRejection must fall back to RuntimeCellIDSentinel when ctx key is absent",
+		"%s: %s — recordBodyLimitRejection must fall back to metrics.RuntimeCellSentinel when ctx key is absent",
 		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 	assert.Truef(t, callsRecordBLR,
 		"%s: %s — recordBodyLimitRejection must call collector.RecordBodyLimitRejection",
@@ -533,7 +533,7 @@ func TestHTTPMetricsLabelBodyLimitCtxSource01(t *testing.T) {
 		"%s: %s — ctxkeys.CellIDFrom must be called before collector.RecordBodyLimitRejection",
 		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 	assert.Truef(t, runtimeSentinelPos.IsValid() && recordBLRPos.IsValid() && runtimeSentinelPos < recordBLRPos,
-		"%s: %s — RuntimeCellIDSentinel fallback must appear before collector.RecordBodyLimitRejection",
+		"%s: %s — metrics.RuntimeCellSentinel fallback must appear before collector.RecordBodyLimitRejection",
 		rel, ruleHTTPMetricsLabelBodyLimitCtxSource01)
 
 	// Reverse self-check: the BodyLimit outer function must NOT contain a
@@ -554,4 +554,13 @@ func rememberFirstPos(dst *token.Pos, pos token.Pos) {
 	if !dst.IsValid() || pos < *dst {
 		*dst = pos
 	}
+}
+
+// isRuntimeCellSentinelRef reports whether sel is a reference to the
+// single-source sentinel metrics.RuntimeCellSentinel ("_runtime"). The HTTP
+// middleware no longer declares its own RuntimeCellIDSentinel constant; it reads
+// the transport-neutral runtime/observability/metrics.RuntimeCellSentinel, so
+// the fallback now appears as a qualified selector rather than a bare ident.
+func isRuntimeCellSentinelRef(sel *ast.SelectorExpr) bool {
+	return selectorQualifier(sel.X) == "metrics" && sel.Sel != nil && sel.Sel.Name == "RuntimeCellSentinel"
 }

--- a/tools/archtest/http_metrics_label_test.go
+++ b/tools/archtest/http_metrics_label_test.go
@@ -558,9 +558,10 @@ func rememberFirstPos(dst *token.Pos, pos token.Pos) {
 
 // isRuntimeCellSentinelRef reports whether sel is a reference to the
 // single-source sentinel metrics.RuntimeCellSentinel ("_runtime"). The HTTP
-// middleware no longer declares its own RuntimeCellIDSentinel constant; it reads
-// the transport-neutral runtime/observability/metrics.RuntimeCellSentinel, so
-// the fallback now appears as a qualified selector rather than a bare ident.
+// middleware used to declare a local sentinel constant of its own; that was
+// deleted in favor of reading the transport-neutral
+// runtime/observability/metrics.RuntimeCellSentinel, so the fallback now appears
+// as a qualified selector rather than a bare ident.
 func isRuntimeCellSentinelRef(sel *ast.SelectorExpr) bool {
 	return selectorQualifier(sel.X) == "metrics" && sel.Sel != nil && sel.Sel.Name == "RuntimeCellSentinel"
 }

--- a/tools/archtest/internal/grpcmetricsfixture/grpc_metrics_red.go
+++ b/tools/archtest/internal/grpcmetricsfixture/grpc_metrics_red.go
@@ -1,0 +1,39 @@
+//go:build archtest_fixture
+
+// Package grpcmetricsfixture is a RED fixture for
+// GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01 (see
+// tools/archtest/grpc_metrics_label_test.go). It is gated by the
+// archtest_fixture build tag and loaded only by
+// TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected via RunTypedFixture;
+// it is never part of a production build.
+package grpcmetricsfixture
+
+import (
+	"context"
+	"time"
+
+	kernelctxkeys "github.com/ghbvf/gocell/kernel/ctxkeys"
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
+)
+
+// UnaryMetrics deliberately mimics the shape of
+// runtime/grpc/interceptor.UnaryMetrics — it reads kernel/ctxkeys.CellIDFrom and
+// metrics.RuntimeCellSentinel and calls GRPCCollector.RecordRPC — but feeds an
+// UNRELATED identifier (bogus) as the cell label instead of the ctx-derived
+// cellID. This is exactly the blind spot B2 that the pre-provenance rule
+// accepted: every structural assertion (reads ctx, uses sentinel, calls
+// RecordRPC, arg is an ident and not a literal, ctx before record, sentinel
+// before record) passes, so the scan must fire ONLY the two cellIDProvenance
+// diagnostics — the bogus var is the object referenced by neither the sentinel
+// init nor the CellIDFrom branch assignment.
+func UnaryMetrics(collector metrics.GRPCCollector) func(context.Context, string) {
+	return func(ctx context.Context, method string) {
+		cellID := metrics.RuntimeCellSentinel
+		if v, ok := kernelctxkeys.CellIDFrom(ctx); ok && v != "" {
+			cellID = v
+		}
+		_ = cellID                   // correctly-attributed value, intentionally unused
+		bogus := "constructor-value" // unrelated ident — NOT the ctx-derived cellID
+		collector.RecordRPC(ctx, bogus, method, "OK", time.Second.Seconds())
+	}
+}


### PR DESCRIPTION
## Summary

Unblocked slice of **#1383** (epic PR-9, gRPC observability parity). The core
deliverable — wiring gRPC `FullMethod → cellID` attribution — is **blocked** on
epic PR-6/7/8 (generated registrar + real proto codegen + example service),
which have not landed. So this PR ships only what's doable today and **#1383
stays open** (this is `Refs`, not `Closes`).

### What landed

1. **Archtest `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01`** (`tools/archtest/grpc_metrics_label_test.go`)
   — mirrors HTTP's `CELLID-CTXSOURCE` + `RUNTIME-SENTINEL` invariants against
   `runtime/grpc/interceptor.UnaryMetrics`: the `cell` label must be read from
   `kernel/ctxkeys.CellIDFrom` with a `metrics.RuntimeCellSentinel` fallback and
   fed into `GRPCCollector.RecordRPC` — never a hardcoded literal, and (review
   follow-up) never an unrelated identifier: the cell-label argument is bound to
   its `RuntimeCellSentinel`-init + `CellIDFrom(ctx)`-branch origin by go/types
   object identity (`cellIDProvenance`), with a `//go:build archtest_fixture` RED
   fixture (`internal/grpcmetricsfixture`) proving the rule bites. Locks the
   reader contract so it cannot regress when the writer side (PR-7/8) lands.
   Alias-robust via the typed façade (`ResolvePackageRef`/`ResolveMethodCall`).
2. **Single-source the HTTP/gRPC request-metrics `_runtime` sentinel** — delete
   the parallel `middleware.RuntimeCellIDSentinel`; HTTP now reads the
   transport-neutral `runtime/observability/metrics.RuntimeCellSentinel`
   directly, so the HTTP middleware and the gRPC metrics interceptor share one
   sentinel source for the **metrics cell-label** dimension. (This is *not* a
   repo-wide single `"_runtime"` literal: `_runtime` as a "framework / no-owner"
   string convention is still declared per-layer elsewhere —
   `kernel/reconcile.reconcilerIDSentinel`, the Redis `KeyNamespace`
   idempotency-claimer sentinel, `runtime/command/lifecycle` — and `kernel/`
   cannot import `runtime/observability/metrics`, so a repo-wide single literal
   is structurally impossible.) HTTP archtest updated ident→selector.
3. **Docs** — `docs/ops/alerting-rules.md` + `.claude/rules/gocell/observability.md`:
   gRPC metrics carry `cell="_runtime"` until attribution lands; operators must
   **not** filter gRPC on `cell!="_runtime"`. The single-source statement is
   scoped to the HTTP/gRPC request-metrics cell label (matching the
   `RuntimeCellSentinel` const godoc), not a repo-wide claim.

### Deferred / still blocked on epic PR-6/7/8 (tracked by #1383, kept open)

- The `FullMethod → cellID` resolver + a gRPC `CellAttribution` interceptor
  writing `ctxkeys.WithCellID` (needs PR-7 generated registrar + PR-6 proto codegen).
- A `ROUTER-ATTRIBUTION`-equivalent archtest (no attribution interceptor exists yet).
- End-to-end test of a non-`_runtime` label (needs an example gRPC service, PR-8).

### AI-robust rating

- `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01`: **Medium** (type-aware AST form +
  ordering + go/types object-identity provenance binding of the cell-label arg).
  Hard is structurally unreachable in this slice — the Hard form is a sealed
  `CellLabel` funnel, the same one HTTP's symmetric `RecordRequest(cellID string)`
  defers and tracks at **gh #1398**; HTTP + gRPC convert together. Named in the
  archtest godoc.
- Sentinel unification: deletion of the parallel symbol (no shim) — HTTP/gRPC
  request-metrics sentinel single source (not a repo-wide single literal; see
  "What landed" #2).

`ref: tools/archtest/http_metrics_label_test.go`

### Test plan

- [x] `go build ./...`
- [x] `go test ./runtime/http/middleware/... ./runtime/observability/metrics/... ./runtime/grpc/...`
- [x] `go test ./tools/archtest/ -run 'TestGRPCMetricsLabel|TestHTTPMetricsLabel'`
- [x] `golangci-lint run` (changed pkgs) → 0 issues
- [x] Verified archtest **bites**: a hardcoded cell literal in `RecordRPC`'s cellID slot fails the rule; and (review follow-up) an unrelated ident fails it too (RED fixture yields exactly the 2 provenance diagnostics)
- [x] Confirmed no new `SCANNER-FRAMEWORK-USAGE-01/02` violations vs develop baseline (USAGE-01/02 are pre-existing-red on develop; my files add none)

Refs #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
