### PR TITLE
fix(governance): renew sessionlogin http.config.get.v1 waiver — unblock develop CI [#1472]

### DIFF
--- a/cells/accesscore/slices/sessionlogin/slice.yaml
+++ b/cells/accesscore/slices/sessionlogin/slice.yaml
@@ -24,8 +24,8 @@ verify:
   waivers:
     - contract: http.config.get.v1
       owner: platform-team
-      reason: 只读配置调用，集成测试已覆盖
-      expiresAt: 2026-06-01
+      reason: "只读配置调用，集成测试已覆盖；waiver 由 #1467 续期解阻塞 develop CI，补测试还债见 #1472"
+      expiresAt: 2026-09-01
 
 allowedFiles:
   - cells/accesscore/slices/sessionlogin/**

--- a/cells/accesscore/slices/sessionlogin/slice_gen.go
+++ b/cells/accesscore/slices/sessionlogin/slice_gen.go
@@ -34,7 +34,7 @@ var sliceMeta = &metadata.SliceMeta{
 			"contract.event.user.unlocked.v1.publish",
 		},
 		Waivers: []metadata.WaiverMeta{
-			{Contract: "http.config.get.v1", Owner: "platform-team", Reason: "只读配置调用，集成测试已覆盖", ExpiresAt: "2026-06-01"},
+			{Contract: "http.config.get.v1", Owner: "platform-team", Reason: "只读配置调用，集成测试已覆盖；waiver 由 #1467 续期解阻塞 develop CI，补测试还债见 #1472", ExpiresAt: "2026-09-01"},
 		},
 	},
 	AllowedFiles: []string{


### PR DESCRIPTION
## Summary

develop 上 `gocell validate` 因 `cells/accesscore/slices/sessionlogin/slice.yaml` 的 `http.config.get.v1`（role=call）waiver `expiresAt: 2026-06-01` 已到期而报错，导致 `make verify` 全局红、**阻塞所有 PR 的 governance gate**（非仅某一 PR）：

```
[VERIFY-01] usage of contract "http.config.get.v1" (role "call") in slice "sessionlogin"
            has no verify.contract entry or valid waiver
[VERIFY-02] waiver for contract "http.config.get.v1" expired on 2026-06-01
```

本 PR **照搬 PR #1467 的解阻塞做法**：将 waiver `expiresAt` 续期至 `2026-09-01` 并更新 reason。#1467 是一个大型 OPEN 重构（#1423），develop 在其合并前持续红；本 PR 把同一处续期独立落到 develop，立即恢复绿。

补测试还债（登记 `contract.http.config.get.v1.call` + 删除 waiver，永久消债）由 **#1472** 跟踪——本 PR 不消除技术债，仅恢复 develop CI。

## Changes

- `cells/accesscore/slices/sessionlogin/slice.yaml`：waiver `expiresAt` `2026-06-01 → 2026-09-01`，reason 更新引用 #1467 / #1472
- `cells/accesscore/slices/sessionlogin/slice_gen.go`：经 `gocell generate cell accesscore` 重新派生（非手写）

Refs: #1472, #1467

## Test plan

- [x] `gocell validate` → 0 errors（修复前 2 errors）
- [x] `go build ./cells/accesscore/... ./cmd/gocell/...`
- [x] `go test ./cells/accesscore/slices/sessionlogin/...` → ok
- [x] `golangci-lint run ./cells/accesscore/slices/sessionlogin/...` → 0 issues
- [x] `gocell generate cell accesscore` → slice_gen.go 与 slice.yaml 一致（无其他漂移）

🤖 Generated with [Claude Code](https://claude.com/claude-code)