### PR TITLE
fix(webhook): PR-5 review round-2 — correct funnel overclaims + dispatcher ConsumerBase coverage

### DIFF
--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -226,11 +226,19 @@ const (
 // Apply writes the three signature headers (HeaderID, HeaderTimestamp,
 // HeaderSignature) onto an outbound request's http.Header.
 //
-// It is the SOLE sanctioned writer of these headers (WEBHOOK-SIGNER-FUNNEL-01
-// downstream funnel): the dispatcher MUST call headers.Apply(req.Header) rather
-// than Header.Set the signature header from an arbitrary value, so the only
-// value that can reach the wire is one produced by a sealed [Signer.Sign]. The
-// archtest locks Header.Set of these header-name constants to this method body.
+// It is the SOLE sanctioned writer of these header-name constants
+// (WEBHOOK-SIGNER-FUNNEL-01 downstream funnel): the dispatcher MUST call
+// headers.Apply(req.Header) rather than Header.Set a signature header from an
+// arbitrary value, and the archtest locks every Header.Set of these constants to
+// this method body. That makes the *write site* uniform.
+//
+// It does NOT guarantee Headers *provenance*. Headers is a public struct with
+// exported fields — it is also the inbound DTO that [Verifier.Verify] consumes,
+// constructed by the receiver from request headers — so a caller could build a
+// Headers literal and call Apply with a value that did not come from
+// [Signer.Sign]. Such a forged value carries an invalid HMAC the receiver
+// rejects (low severity); sealing provenance via a dedicated sealed outbound
+// type is tracked at gh #1492.
 func (h Headers) Apply(header http.Header) {
 	header.Set(HeaderID, string(h.DeliveryID))
 	header.Set(HeaderTimestamp, h.Timestamp)

--- a/runtime/bootstrap/options_webhook.go
+++ b/runtime/bootstrap/options_webhook.go
@@ -32,7 +32,8 @@ import (
 // secrets by source ID. It serves BOTH directions: inbound webhook receivers
 // (phase5) verify incoming signatures against it, and outbound webhook
 // dispatchers (phase6) resolve each dispatcher's signing secret from it
-// (BuildConsumers → SourceStore.Lookup). A nil or typed-nil value is silently
+// (inbound: BuildRouteGroups → SourceStore.Lookup; outbound: BuildConsumers →
+// SourceStore.Lookup). A nil or typed-nil value is silently
 // ignored; the final nil check happens at the consuming phase — phase5 if any
 // cell declared a receiver, phase6 if any cell declared a dispatcher.
 //

--- a/runtime/bootstrap/options_webhook.go
+++ b/runtime/bootstrap/options_webhook.go
@@ -2,22 +2,25 @@ package bootstrap
 
 // options_webhook.go — With* option functions for webhook wiring.
 //
-// Covers: WithWebhookSourceStore, WithWebhookClaimer (inbound receiver),
-// WithWebhookSSRFPolicy (outbound dispatcher).
+// Covers: WithWebhookSourceStore (inbound receivers phase5 AND outbound
+// dispatchers phase6), WithWebhookClaimer (inbound receiver), WithWebhookSSRFPolicy
+// (outbound dispatcher).
 //
-// Both are "cumulative builder" options (see runtime-api.md §Option 范式分层):
-// nil inputs are silently ignored; the final nil check happens inside
-// phase5DrainWebhookReceivers when a cell has registered receivers.
+// WithWebhookSourceStore and WithWebhookClaimer are "cumulative builder" options
+// (see runtime-api.md §Option 范式分层): nil inputs are silently ignored; the
+// final nil check happens at the consuming phase.
 //
 // Design note — fail-fast timing: the missing-dependency error is deliberately
-// raised at phase5 (when receivers are drained) rather than at option-apply
-// time. A deployment with zero webhook receivers is a valid configuration that
-// needs neither a SourceStore nor a Claimer, so requiring them unconditionally
-// at option time would reject correct setups. The dependency only becomes
-// mandatory once a cell has actually declared a receiver — which is exactly when
-// phase5 can see both the snapshot and the wired options. This matches the
-// builder-option convention used elsewhere in bootstrap (final validation at the
-// consuming phase, not at the setter).
+// raised at the consuming phase (phase5 when inbound receivers are drained;
+// phase6 when outbound dispatchers are built) rather than at option-apply time.
+// A deployment with zero webhook receivers AND zero dispatchers is a valid
+// configuration that needs neither a SourceStore nor a Claimer, so requiring
+// them unconditionally at option time would reject correct setups. The
+// dependency only becomes mandatory once a cell has actually declared a receiver
+// (phase5) or a dispatcher (phase6) — exactly when that phase can see both the
+// snapshot and the wired options. This matches the builder-option convention
+// used elsewhere in bootstrap (final validation at the consuming phase, not at
+// the setter).
 
 import (
 	"github.com/ghbvf/gocell/kernel/idempotency"
@@ -25,10 +28,13 @@ import (
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
-// WithWebhookSourceStore injects the [kwh.SourceStore] used by all inbound
-// webhook receivers to look up HMAC secrets by source ID. A nil or typed-nil
-// value is silently ignored; the final nil check happens during phase5 when
-// any cell has declared a webhook receiver.
+// WithWebhookSourceStore injects the [kwh.SourceStore] used to look up HMAC
+// secrets by source ID. It serves BOTH directions: inbound webhook receivers
+// (phase5) verify incoming signatures against it, and outbound webhook
+// dispatchers (phase6) resolve each dispatcher's signing secret from it
+// (BuildConsumers → SourceStore.Lookup). A nil or typed-nil value is silently
+// ignored; the final nil check happens at the consuming phase — phase5 if any
+// cell declared a receiver, phase6 if any cell declared a dispatcher.
 //
 // Typical usage: pass a pre-populated [kwh.NewSourceRegistry] that has been
 // seeded with [kwh.Source] values for each expected sender.

--- a/runtime/bootstrap/phases_dispatch_test.go
+++ b/runtime/bootstrap/phases_dispatch_test.go
@@ -173,7 +173,10 @@ func TestDrainWebhookDispatchers_FailsWhenSubscriberNil(t *testing.T) {
 // an event consumer, so a Subscriber that is present but backed by a nil or
 // zero-value ConsumerBase (the latter passes the bare nil check but
 // IsConstructed()==false) must fail fast, naming the dispatcher — not silently
-// dispatch through an uninitialized ConsumerBase. Mirrors
+// dispatch through an uninitialized ConsumerBase. The guard lives in
+// checkConsumerBaseConfiguredForSubscriptions (called by phase6StartEventRouter),
+// not in drainWebhookDispatchers itself, so these subtests drive
+// phase6StartEventRouter. Mirrors
 // TestPhase6_SubscriptionsWithZeroValueConsumerBase_FailsFast for the dispatcher
 // consumer kind.
 func TestDrainWebhookDispatchers_FailsWhenConsumerBaseMissing(t *testing.T) {

--- a/runtime/bootstrap/phases_dispatch_test.go
+++ b/runtime/bootstrap/phases_dispatch_test.go
@@ -6,6 +6,9 @@ package bootstrap
 //   - empty dispatchers → no-op (no error, router not required)
 //   - dispatchers present + nil webhookSourceStore → fail-fast ErrWebhookConfigInvalid
 //   - dispatchers present + nil Subscriber → phase6 fail-fast (no silent drop)
+//   - dispatchers present + Subscriber but nil / zero-value ConsumerBase →
+//     phase6 fail-fast (dispatcher is an event consumer; needs a constructed
+//     ConsumerBase)
 //   - CellID drift (req.Spec.CellID != snapshot owner) → drift error
 //   - happy path: a snapshot with one WebhookDispatchRequest + a seeded SourceStore
 //     + a non-nil Subscriber + a ConsumerBase → drainWebhookDispatchers registers
@@ -24,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/outbox"
 	kwh "github.com/ghbvf/gocell/kernel/webhook"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -55,20 +59,23 @@ func (c *webhookDispatchTestCell) Init(ctx context.Context, reg cell.Registrar) 
 	return reg.RegisterWebhookDispatch(spec, c.selector)
 }
 
-// newWebhookDispatchCell creates a webhookDispatchTestCell whose spec.CellID
-// equals the BaseCell ID (matching the snapshot key produced by assembly.Snapshots).
-func newWebhookDispatchCell(cellID, contractID, sourceID string) *webhookDispatchTestCell {
+// newWebhookDispatchCell creates a webhookDispatchTestCell with the standard
+// test identifiers (whTestCellID / dispatchTestContractID / whTestSourceID),
+// whose spec.CellID equals the BaseCell ID (matching the snapshot key produced
+// by assembly.Snapshots). Tests that need a drifted CellID build the cell inline
+// (see TestDrainWebhookDispatchers_FailsOnCellIDDrift).
+func newWebhookDispatchCell() *webhookDispatchTestCell {
 	spec := kwh.DispatchSpec{
-		ContractID: contractID,
-		SourceID:   sourceID,
-		CellID:     cellID,
+		ContractID: dispatchTestContractID,
+		SourceID:   whTestSourceID,
+		CellID:     whTestCellID,
 	}
 	sel := func(_ context.Context, _ []byte) (string, error) {
 		return "http://example.test/hook", nil
 	}
 	return &webhookDispatchTestCell{
 		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{
-			ID:   cellID,
+			ID:   whTestCellID,
 			Type: "core",
 		}),
 		spec:     spec,
@@ -122,7 +129,7 @@ func TestDrainWebhookDispatchers_EmptyNoOp(t *testing.T) {
 // to return ErrWebhookConfigInvalid.
 func TestDrainWebhookDispatchers_FailsWithoutSourceStore(t *testing.T) {
 	t.Parallel()
-	dc := newWebhookDispatchCell(whTestCellID, dispatchTestContractID, whTestSourceID)
+	dc := newWebhookDispatchCell()
 	s := buildPhaseStateWithWebhookCells(t, dc)
 
 	b := New(clockmock.New(whFixedNow))
@@ -146,7 +153,7 @@ func TestDrainWebhookDispatchers_FailsWithoutSourceStore(t *testing.T) {
 // nil (buildPhaseStateWithWebhookCells leaves it unset).
 func TestDrainWebhookDispatchers_FailsWhenSubscriberNil(t *testing.T) {
 	t.Parallel()
-	dc := newWebhookDispatchCell(whTestCellID, dispatchTestContractID, whTestSourceID)
+	dc := newWebhookDispatchCell()
 	s := buildPhaseStateWithWebhookCells(t, dc)
 
 	b := New(clockmock.New(whFixedNow)) // no WithSubscriber → s.sub stays nil
@@ -158,6 +165,52 @@ func TestDrainWebhookDispatchers_FailsWhenSubscriberNil(t *testing.T) {
 		"error must identify the webhook dispatcher as the unconsumed event consumer")
 	assert.Contains(t, err.Error(), "no subscriber is configured",
 		"error must tell the operator to add WithSubscriber")
+}
+
+// TestDrainWebhookDispatchers_FailsWhenConsumerBaseMissing (F13, review #1455
+// round-2) covers the phase6 checkConsumerBaseConfiguredForSubscriptions guard
+// for the webhook-dispatcher branch of firstConsumerInSnapshot. A dispatcher is
+// an event consumer, so a Subscriber that is present but backed by a nil or
+// zero-value ConsumerBase (the latter passes the bare nil check but
+// IsConstructed()==false) must fail fast, naming the dispatcher — not silently
+// dispatch through an uninitialized ConsumerBase. Mirrors
+// TestPhase6_SubscriptionsWithZeroValueConsumerBase_FailsFast for the dispatcher
+// consumer kind.
+func TestDrainWebhookDispatchers_FailsWhenConsumerBaseMissing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_consumer_base", func(t *testing.T) {
+		t.Parallel()
+		dc := newWebhookDispatchCell()
+		s := buildPhaseStateWithWebhookCells(t, dc)
+		s.sub = eventbus.New(clockmock.New(whFixedNow)) // non-nil subscriber → reach the ConsumerBase guard
+
+		b := New(clockmock.New(whFixedNow)) // no WithConsumerBase → consumerBase nil
+
+		err := b.phase6StartEventRouter(context.Background(), s)
+		require.Error(t, err, "a dispatcher with a Subscriber but no ConsumerBase must fail fast")
+		assert.Contains(t, err.Error(), "no ConsumerBase is configured",
+			"nil ConsumerBase must produce the missing-ConsumerBase error")
+		assert.Contains(t, err.Error(), "webhook dispatcher",
+			"error must identify the webhook dispatcher as the offending consumer")
+	})
+
+	t.Run("zero_value_consumer_base", func(t *testing.T) {
+		t.Parallel()
+		dc := newWebhookDispatchCell()
+		s := buildPhaseStateWithWebhookCells(t, dc)
+		s.sub = eventbus.New(clockmock.New(whFixedNow))
+
+		// zero-value literal passes the bare nil check but IsConstructed()==false.
+		b := New(clockmock.New(whFixedNow), WithConsumerBase(&outbox.ConsumerBase{}))
+
+		err := b.phase6StartEventRouter(context.Background(), s)
+		require.Error(t, err, "a zero-value ConsumerBase must fail fast")
+		assert.Contains(t, err.Error(), "not constructed via outbox.NewConsumerBase",
+			"zero-value ConsumerBase must produce the not-constructed error")
+		assert.Contains(t, err.Error(), "webhook dispatcher",
+			"error must identify the webhook dispatcher as the offending consumer")
+	})
 }
 
 // TestDrainWebhookDispatchers_FailsOnCellIDDrift verifies that a dispatcher
@@ -193,7 +246,7 @@ func TestDrainWebhookDispatchers_FailsOnCellIDDrift(t *testing.T) {
 // successfully registers one handler on the event router (HandlerCount == 1).
 func TestDrainWebhookDispatchers_HappyPath_RegistersHandler(t *testing.T) {
 	t.Parallel()
-	dc := newWebhookDispatchCell(whTestCellID, dispatchTestContractID, whTestSourceID)
+	dc := newWebhookDispatchCell()
 	s := buildPhaseStateWithWebhookCells(t, dc)
 
 	clk := clockmock.New(whFixedNow)

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -33,8 +33,9 @@
 //	  is ineffective. EvaluateConstString folds across const definitions.
 //	  ResolveEnclosingFunc binds the allowance to a go/types FullName — a
 //	  stray func that merely shares the name "Apply" cannot inherit it.
-//	上游 (provenance) — NOT closed; this is a Hard-downstream + open-upstream
-//	  funnel, NOT a closed double-lock. [Headers] is a PUBLIC struct with
+//	上游 (provenance) — NOT closed (low-severity provenance gap; risk analysis
+//	  below). This is a Hard-downstream + open-upstream funnel, NOT a closed
+//	  double-lock. [Headers] is a PUBLIC struct with
 //	  EXPORTED fields and is ALSO the inbound DTO consumed by [Verifier.Verify]
 //	  (the receiver constructs a Headers from request headers), so a caller CAN
 //	  build a `webhook.Headers{Signature: …}` literal and call Apply with a value

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -3,10 +3,12 @@
 // WEBHOOK-SIGNER-FUNNEL-01 — kernel/webhook signature-header write funnel.
 //
 // The three outbound webhook signature headers (webhook-id / webhook-timestamp
-// / webhook-signature) define GoCell's outbound identity protocol: only a value
-// produced by a sealed [Signer.Sign] (which returns a [Headers]) may reach the
-// wire. That guarantee is worthless if any code can bypass it by calling
-// http.Header.Set with one of the three header-name strings directly.
+// / webhook-signature) define GoCell's outbound identity protocol. This rule
+// makes [(Headers).Apply] the SOLE write site for these header names, so no code
+// can emit a signature header by calling http.Header.Set with one of the three
+// strings directly. (Provenance — guaranteeing the written value actually came
+// from a sealed [Signer.Sign] rather than a hand-built Headers literal — is a
+// separate, NOT-yet-closed axis; see the rating below and gh #1492.)
 //
 // This rule locks every http.Header.Set call whose key argument evaluates to
 // one of the three header-name constant values to the sole sanctioned body:
@@ -31,22 +33,29 @@
 //	  is ineffective. EvaluateConstString folds across const definitions.
 //	  ResolveEnclosingFunc binds the allowance to a go/types FullName — a
 //	  stray func that merely shares the name "Apply" cannot inherit it.
-//	上游 Hard (external) — [Headers] is produced only by a sealed
-//	  [Signer.Sign]: Signer carries an unexported sealed() marker method
-//	  (WEBHOOK-HMAC-FUNNEL-01/A3) so package-external Signer implementations
-//	  are a compile error; Sign() is the only path to a Headers value; and
-//	  Headers has no exported constructor outside of Sign. Thus an
-//	  externally-created Headers value (and hence a call to Apply) is
-//	  inexpressible at the type-system level.
-//	上游 Medium (package-internal) — Go package visibility cannot express
-//	  "only one struct within the same package may declare a Headers field".
-//	  A new package-internal struct that holds a Headers value and calls
-//	  Apply is syntactically expressible; it is caught by the downstream A1
-//	  scan at CI time, not at compile time. This is the same permanent ceiling
-//	  as SPAN-SETATTR-HOLDER-SEAL (#851) / HEALTHZ-HOLDER-SEAL (#893) /
-//	  WEBHOOK-SSRF-GUARD-01 (#1375). Explicit Hard-ization of the
-//	  package-internal axis is tracked in gh #1243 (inherited from the Signer
-//	  sealing issue, which already covers this axis).
+//	上游 (provenance) — NOT closed; this is a Hard-downstream + open-upstream
+//	  funnel, NOT a closed double-lock. [Headers] is a PUBLIC struct with
+//	  EXPORTED fields and is ALSO the inbound DTO consumed by [Verifier.Verify]
+//	  (the receiver constructs a Headers from request headers), so a caller CAN
+//	  build a `webhook.Headers{Signature: …}` literal and call Apply with a value
+//	  that never came from a sealed [Signer.Sign]. The sealed Signer interface
+//	  (unexported sealed() marker, WEBHOOK-HMAC-FUNNEL-01/A3) prevents external
+//	  *Signer implementations*, but it does NOT prevent external *Headers
+//	  construction* — a struct literal needs no constructor. So this funnel
+//	  guarantees only uniform *where* the signature headers are written (A1
+//	  downstream Hard), NOT the *provenance* of the written value. A forged
+//	  Headers carries an invalid HMAC the receiver rejects, so the gap is
+//	  low-severity, not an exploitable forgery.
+//	  Closing it requires splitting Headers into a sealed outbound type (only
+//	  [Signer.Sign] produces it, only Apply consumes it) separate from the
+//	  inbound parse DTO — a real type change tracked at gh #1492. Per
+//	  .claude/rules/gocell/ai-robust.md Funnel 双向锁评级, a Hard-downstream +
+//	  open-upstream funnel must track the upstream Hard-化 in an issue and name
+//	  it here (#1492). The package-internal holder axis (a same-package struct
+//	  that holds a Headers field, caught by the A1 scan at CI not compile time)
+//	  is the same permanent ceiling as SPAN-SETATTR-HOLDER-SEAL (#851) /
+//	  HEALTHZ-HOLDER-SEAL (#893) / WEBHOOK-SSRF-GUARD-01 (#1375); #1492 subsumes
+//	  it for this funnel.
 //
 // Note: WEBHOOK-SIGNED-STRING-FORM-01 (signed-string "{deliveryID}.{timestamp}
 // .{body}" form) is NOT a new archtest here. It is already locked by:


### PR DESCRIPTION
## Summary

Round-2 of the PR #1455 (KERNEL-WEBHOOK-01 PR-5) review. #1455 was **squash-merged
before this round was pushed**, so these three follow-ups never reached develop —
this PR lands them. No production logic change — doc corrections + test coverage only.

1. **Headers provenance overclaim corrected.** `(Headers).Apply` godoc and the
   `WEBHOOK-SIGNER-FUNNEL-01` archtest rating claimed an externally-constructed
   `Headers` is "inexpressible at the type-system level" / "only a value produced
   by a sealed `Signer.Sign` may reach the wire" — both false. `Headers` is a
   bidirectional PUBLIC DTO (`Verifier.Verify(_, headers Headers, _)` takes it as
   a parameter; the inbound receiver constructs it from request headers), so the
   funnel is **Hard downstream (Header.Set write-site locked to Apply) + open
   upstream (provenance NOT sealed)**. Both doc sites corrected to the honest
   rating; full sealing (split Headers into a sealed outbound type) is tracked at #1492.
2. **WithWebhookSourceStore godoc** now documents the outbound dispatcher (phase6
   `BuildConsumers -> SourceStore.Lookup`) dependency, not just inbound receivers (phase5).
3. **Dispatcher-only phase6 ConsumerBase coverage.** Added
   `TestDrainWebhookDispatchers_FailsWhenConsumerBaseMissing` (nil + zero-value
   `&outbox.ConsumerBase{}`) for the webhook-dispatcher branch of
   `firstConsumerInSnapshot`. Refactored `newWebhookDispatchCell` to drop
   now-constant params (unparam).

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./kernel/webhook/... ./runtime/bootstrap/...\` (incl. new ConsumerBase tests)
- [x] \`go test ./tools/archtest -run Webhook\`
- [x] \`golangci-lint run\` (kernel/webhook + runtime/bootstrap + tools/archtest) — 0 issues

Refs: KERNEL-WEBHOOK-01 PR-5, review #1455 round-2
Related: #1492 (Headers provenance sealed construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)