### PR TITLE
fix(archtest): un-break tools/archtest [#1500] + #1470 review follow-ups

### DIFF
--- a/docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md
+++ b/docs/architecture/202605101900-adr-cell-raw-infra-sealed-marker.md
@@ -202,7 +202,7 @@ sealed marker 集从 3 扩展为 4：新增 `outbox.CellEmitter`（embed `Emitte
 
 ### A.7 — SEALED-MARKER-NOOP-TRANSPARENCY-01 升级 Medium → Hard
 
-`tools/archtest/sealed_marker_noop_transparency_test.go` 从手工 `sealedMarkerFiles` 文件清单改为 `RunTyped(./kernel/...)` + `pass.Pkg.Scope().Names()` 自动发现 `internalCell*` struct，断言每个有 `Noop() bool`。去掉了"新 sealed marker 文件漏登记则静默跳过"的 Soft 维护点。残留 convention：发现 keys on `internalCell` 前缀；全名无关发现（按 sealed*() marker method）是进一步 Hard 化方向，本 PR 未做。
+`tools/archtest/sealed_marker_noop_transparency_test.go` 从手工 `sealedMarkerFiles` 文件清单改为 `Run(t, Typed(TypedOpts{}, []string{"./kernel/..."}))` + `pass.Pkg.Scope().Names()` 自动发现 `internalCell*` struct，断言每个有 `Noop() bool`。去掉了"新 sealed marker 文件漏登记则静默跳过"的 Soft 维护点。残留 convention：发现 keys on `internalCell` 前缀；全名无关发现（按 sealed*() marker method）是进一步 Hard 化方向，本 PR 未做。
 
 ### 威胁矩阵 / Consequences 一致性
 

--- a/docs/architecture/202605141519-adr-archtest-pass-funnel.md
+++ b/docs/architecture/202605141519-adr-archtest-pass-funnel.md
@@ -79,13 +79,17 @@ ref: `golang.org/x/tools go/analysis/analysistest/analysistest.go` (`dir` positi
 
 Four independent failure modes: type system, lint, archtest (symbol-level), archtest ((callee, arg) form-uniqueness). Bypassing all four requires editing four independent locations in a single PR — reviewer-detectable by construction.
 
-**`RunTypedDir` AI-robust grade: Hard — three defenses hold unchanged.**
+**`StandaloneModule` AI-robust grade: Hard — three defenses hold unchanged.**
+(The scope was introduced at Stage 1.6 as `RunTypedDir` and renamed to the
+`Run(t, StandaloneModule(dir, …), rule)` form by #1037 §1d — see the amendment
+subsection; the grade below describes the current scope, whose construction
+mechanism is unchanged.)
 
-| # | Defense | Status after RunTypedDir |
+| # | Defense | Status under StandaloneModule |
 |---|---------|--------------------------|
-| 1 | `Pass.Pkg` is `*types.Package`, no `.Syntax` | **Unchanged** — `RunTypedDir` produces the same `*Pass` shape via `runTypedWithRoot`; authors still cannot reach `.Syntax`. |
-| 2 | depguard bans direct `packages` import in `*_test.go` | **Unchanged** — `RunTypedDir` is a façade in `tools/archtest/pass.go`; business `*_test.go` files call the façade, not `packages.Load` directly. |
-| 3 | `PASS-FUNNEL-LOADPACKAGES-01` funnel | **Widened (not weakened)** — `RunTypedDir` is the now-unique legitimate entry for fixture-module scanning. The banned set (`typeseval.LoadPackages` / `typeseval.SharedResolver`) is unchanged; `RunTypedDir` adds no new bypass surface because the fixture-module form previously had no approved entry point at all. Introducing `RunTypedDir` closes the gap rather than opening one. |
+| 1 | `Pass.Pkg` is `*types.Package`, no `.Syntax` | **Unchanged** — `StandaloneModule` produces the same `*Pass` shape via `runTypedWithRoot`; authors still cannot reach `.Syntax`. |
+| 2 | depguard bans direct `packages` import in `*_test.go` | **Unchanged** — `StandaloneModule` is a sealed scope dispatched in `tools/archtest/pass.go`; business `*_test.go` files call `Run` with it, not `packages.Load` directly. |
+| 3 | `PASS-FUNNEL-LOADPACKAGES-01` funnel | **Widened (not weakened)** — `StandaloneModule` is the now-unique legitimate entry for fixture-module scanning. The banned set (`typeseval.LoadPackages` / `typeseval.SharedResolver`) is unchanged; `StandaloneModule` adds no new bypass surface because the fixture-module form previously had no approved entry point at all. Introducing it closes the gap rather than opening one. |
 
 **Design decision D1 (Stage 1.6) — dual entry RunTyped / RunTypedDir, not a single merged function.**
 

--- a/docs/architecture/202605141519-adr-archtest-pass-funnel.md
+++ b/docs/architecture/202605141519-adr-archtest-pass-funnel.md
@@ -4,7 +4,7 @@
 
 Accepted — 2026-05-14. Refactor 574 is the stage-1 PR-1 implementation; stages 2 / 3 / 4 are tracked in `docs/plans/archive/202605141519-040-archtest-pass-funnel-plan.md`.
 
-**Amended 2026-06-02 (#1037 §1d)**: the five `Run*` entry points (`Run`(AST) / `RunTyped` / `RunTypedProduction` / `RunTypedDir` / `RunTypedFixture`) were collapsed into a single `Run(t, scope RunScope, rule Rule)` + a sealed `RunScope` interface with five typed constructors. The current authoritative API surface + threat-matrix re-evaluation is the **#1037 §1d amendment** subsection below; the original Decision code block and the Stage 1.6/1.7/4 narrative are retained as the historical decision record and read through that amendment.
+**Amended 2026-06-02 (#1037 §1d)**: the five `Run*` entry points (`Run`(AST) / `RunTyped` / `RunTypedProduction` / `RunTypedDir` / `RunTypedFixture`) were collapsed into a single `Run(t, scope RunScope, rule Rule)` + a sealed `RunScope` interface with five typed constructors. The Decision code block below has been updated in place to the current signatures (no stale dual-entry surface presented as the API). The Stage 1.6/1.7/4 narrative further down is dated decision-provenance — it records *why* the now-superseded dual-entry shape was chosen at each stage and which PRs migrated it (past-tense history, not current API guidance). The **#1037 §1d amendment** subsection is the authoritative source for the full old→new mapping, sealed grading, and threat-matrix re-evaluation.
 
 ## Context
 
@@ -32,29 +32,39 @@ type Pass struct {
 
 type Rule func(*Pass) []Diagnostic
 
-func Run(t *testing.T, scope Scope, rule Rule) []Diagnostic
-func RunTyped(t *testing.T, opts TypedOpts, patterns []string, rule Rule) []Diagnostic
-func RunTypedDir(t testing.TB, dir string, opts TypedOpts, patterns []string, rule Rule) []Diagnostic
+// Single rule-dispatch entry + sealed scope descriptor (#1037 §1d, 2026-06-02).
+func Run(t testing.TB, scope RunScope, rule Rule) []Diagnostic
+
+// RunScope is sealed (unexported isRunScope); the five constructors below are
+// the only ways to build one.
+func AST(fs Scope) RunScope                                          // AST-only
+func Typed(opts TypedOpts, patterns []string) RunScope              // typed, main module
+func Production(opts TypedOpts) RunScope                            // typed, generated/ excluded
+func Fixture(opts FixtureOpts, patterns []string) RunScope          // typed, archtest_fixture tag injected
+func StandaloneModule(dir string, opts TypedOpts, patterns []string) RunScope // typed, standalone module
 ```
 
-> **Superseded by the #1037 §1d amendment (2026-06-02)** — the multiple `Run*`
-> entries above were collapsed into a single `Run(t, scope RunScope, rule Rule)`
-> + a sealed `RunScope` with five typed constructors (`AST` / `Typed` /
-> `Production` / `Fixture` / `StandaloneModule`). See the amendment subsection
-> below for the current signatures and grading. The block above is retained as
-> the original (2026-05-14) decision record.
+> **Evolution note (#1037 §1d, 2026-06-02).** The original 2026-05-14 decision
+> exposed five separate entry points — `Run`(AST-only) / `RunTyped` /
+> `RunTypedProduction` / `RunTypedDir` / `RunTypedFixture`. #1037 §1d collapsed
+> them into the single `Run(t, scope RunScope, rule Rule)` shown above, moving
+> the mode/source choice into the sealed `RunScope` value (which also removes the
+> public build-tag parameter, sealing the fixture-tag bypass surface). The
+> signatures above are current; the **#1037 §1d amendment subsection** below is
+> the authoritative source for the full old→new mapping, sealed grading, and
+> threat-matrix re-evaluation.
 
 Rule authors write `Rule` closures and let the driver (`Run` with its scope
 constructors) construct `*Pass` from a single load. The framework owns
 `packages.Load` / `parser.ParseFile` timing; rule authors receive only `*Pass`.
 
-**`RunTypedDir` API surface:**
+**Standalone fixture-module scope (`StandaloneModule`):**
 
-- **Purpose**: load a standalone fixture module living under `testdata/` that carries its own `go.mod` + `replace` directives (intentional-violation isolation). This form is not addressable by `RunTyped` because `findModuleRoot` resolves the repo root, not the fixture subdirectory.
-- **Internals**: delegates to `runTypedWithRoot(t, dir, opts, patterns, rule)` — the same single construction path shared with `RunTyped` (which delegates to `runTypedWithRoot(t, findModuleRoot(t), opts, patterns, rule)`). No fork in the driver logic.
-- **`dir` constraint**: must be an absolute path; `filepath.IsAbs(dir)` is checked at entry with `t.Fatal` on violation.
-- **Parameter type**: `testing.TB` (not `*testing.T`) to support fatal-path spy tests and `TestMain` callsites; consistent with `analysistest.Run`'s `Testing` interface.
-- **Precedent**: `golang.org/x/tools/go/analysis/analysistest.Run(t, dir, analysers…)` feeds `dir` as `packages.Config.Dir`, allowing the loader to resolve imports relative to an arbitrary directory. `RunTypedDir` adopts the same position-parameter shape.
+- **Purpose**: load a standalone fixture module living under `testdata/` that carries its own `go.mod` + `replace` directives (intentional-violation isolation). This form is not addressable by `Typed` because `findModuleRoot` resolves the repo root, not the fixture subdirectory.
+- **Internals**: delegates to `runTypedWithRoot(t, dir, opts, patterns, rule)` — the same single construction path shared with `Typed` (which delegates to `runTypedWithRoot(t, findModuleRoot(t), opts, patterns, rule)`). No fork in the driver logic.
+- **`dir` constraint**: must be an absolute path; `filepath.IsAbs(dir)` is checked in the `Run` dispatch with `t.Fatal` on violation.
+- **Parameter type**: `Run` takes `testing.TB` (not `*testing.T`) to support fatal-path spy tests and `TestMain` callsites; consistent with `analysistest.Run`'s `Testing` interface.
+- **Precedent**: `golang.org/x/tools/go/analysis/analysistest.Run(t, dir, analysers…)` feeds `dir` as `packages.Config.Dir`, allowing the loader to resolve imports relative to an arbitrary directory. `StandaloneModule` adopts the same position-parameter shape.
 
 ref: `golang.org/x/tools go/analysis/analysistest/analysistest.go` (`dir` position param → `packages.Config.Dir`)
 

--- a/docs/architecture/202605190000-adr-archtest-in-process-warmup.md
+++ b/docs/architecture/202605190000-adr-archtest-in-process-warmup.md
@@ -35,15 +35,15 @@ Accepted (2026-05-19)
 
 ### 改造 2 — tagGroup 循环范本拆除（B 轴：两次 Load + 共享 seen dedup）
 
-把 `for tagGroup := range KnownNonDefaultTags() { RunTyped(...) }` 替换为两次 RunTyped：
-1. `RunTyped(t, TypedOpts{}, patterns, scan)` — tags=nil 覆盖默认 build + 反向 directive 文件
-2. `RunTyped(t, TypedOpts{Tags: archtest.FlatNonDefaultTags()}, patterns, scan)` — 覆盖所有正向 tag 激活文件 union（#944 起 `FlatNonDefaultTags()` 已不含 fixture tag，原 `ProductionFlatTags()` band-aid 已删，二者合一）
+把 `for tagGroup := range KnownNonDefaultTags() { Run(t, Typed(...), scan) }` 替换为两次 `Run(t, Typed(...), scan)`：
+1. `Run(t, Typed(TypedOpts{}, patterns), scan)` — tags=nil 覆盖默认 build + 反向 directive 文件
+2. `Run(t, Typed(TypedOpts{Tags: archtest.FlatNonDefaultTags()}, patterns), scan)` — 覆盖所有正向 tag 激活文件 union（#944 起 `FlatNonDefaultTags()` 已不含 fixture tag，原 `ProductionFlatTags()` band-aid 已删，二者合一）
 
 共享 seen map dedup（文件集有重合，dedup 保证 violations 唯一）。N=7 → 2，RSS 峰值从 N×全模块 → 单次峰值（GC 可在两次 Load 间释放中间体）。
 
 ### 改造 3 — AI Hard archtest 防复抄
 
-新建 `tools/archtest/taggroup_loop_no_typed_run_test.go`，`TAGGROUP-LOOP-FORBIDS-TYPED-RUN-01` 用 (callee, body) 双因子 form-uniqueness 锁 RangeStmt+RunTyped 范本。fresh Claude 复抄 = CI 红。
+新建 `tools/archtest/taggroup_loop_no_typed_run_test.go`，`TAGGROUP-LOOP-FORBIDS-TYPED-RUN-01` 用 (callee, body) 双因子 form-uniqueness 锁 RangeStmt+`Run(t, Typed(...))` 范本。fresh Claude 复抄 = CI 红。
 
 ## 开源对标参考
 
@@ -78,7 +78,7 @@ Accepted (2026-05-19)
 | 反向 build directive 监控 | 不感知 | 未来加 `//go:build !X` (X ∈ KnownNonDefaultTags) 需 review 两次 Load 设计完整性 | 新增隐含约束 |
 | 复抄范本 | 已 2 处实证 + fresh Claude 必复发 | archtest 静态拦截 | 改造 3 解 |
 | `warm.go` 直调 typeseval | 不存在 | 不受 PASS-FUNNEL-LOADPACKAGES-01 保护（该规则仅扫 `_test.go`） | 已接受：warm.go 是 archtest 包内 unexported helper，仅 TestMain 调用，无外部 _test.go 滥用风险；future-proof 升级路径见 backlog `PASS-FUNNEL-NONTESTGO-EXEMPT-UPGRADE-01` |
-| TAGGROUP-LOOP scope gap | 不存在 | `tools/archtest/internal/<subpkg>/*_test.go` (e.g. internal/scanner/, internal/typeseval/) 不被 TAGGROUP-LOOP-FORBIDS-TYPED-RUN-01 扫描 | 已接受：internal 子包测试内部符号，不调 archtest.RunTyped；若未来某 internal _test.go 加直调 RunTyped 形态需扩 scope |
+| TAGGROUP-LOOP scope gap | 不存在 | `tools/archtest/internal/<subpkg>/*_test.go` (e.g. internal/scanner/, internal/typeseval/) 不被 TAGGROUP-LOOP-FORBIDS-TYPED-RUN-01 扫描 | 已接受：internal 子包测试内部符号，不调 `archtest.Run(t, Typed(...))`；若未来某 internal _test.go 加直调 `Run(t, Typed(...))` 形态需扩 scope |
 | CI log path exposure | 不存在 | TestMain fail-fast 时 slog.Error 输出含完整 modRoot/cwd 路径，会出现在 GHA artifact 中 | 已接受：路径非凭据，且 testmain 是 perf/bootstrap 路径，无 PII；如未来仓库公开化需重评 |
 | Total CI wall (16 shard) | 受 borderline test 跨 budget 影响 + B 轴 OOM SIGTERM 重跑 | 预期：单 shard wall ≤ 5s (warm) + 0-3 个 borderline ≤ 10s (warm 后)；16 shard parallel wall ~30-40s + 启动开销 | warmup 在轻 shard (e.g. shard 0 = 33 tests / 4.78s) 上付 +15-25s 启动成本是 wash 或微亏；在重 shard / borderline shard 上净赚；实测需 CI 矩阵观察 2-3 次 |
 

--- a/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
+++ b/docs/architecture/202605241400-003-pg-repo-ambient-tx-discovery-hard.md
@@ -219,7 +219,7 @@ ExecDirect(f("x"), …)`）由 gate #2 callee 解析失败兜住（main rule 即
 | 拷贝 `pgrepoapproved` 包到其他位置绕过 funnel | callee 解析锁 `Pkg().Path()` 到精确字符串 `"github.com/ghbvf/gocell/pkg/pgrepoapproved"`，重定向 import 不改 package path ✓ |
 | import 别名绕过 `Approve` callee 识别 | callee 解析锁 `fn.Pkg().Path()`（via *types.Info.Uses），import alias 不改 package path ✓ |
 | `Approve` 当函数值间接调用（`f := Approve; ExecDirect(f("x"), …)`） | R3 gate #2：`Approve` callsite 的 callee `f` 解析到 `*types.Var` 而非 `*types.Func` → `resolveCalleeFunc` 返回 nil → flag；main rule 即捕获（盲区 BS-7，见 archtest godoc）✓ |
-| build-tag 隔离的条件性 ExecDirect 调用 | RunTyped 用 default build context；如需覆盖须扩展 TypedOpts；当前 production 代码库无 build-tag 隔离 ExecDirect 先例；以 code review 兜底（accepted threat） |
+| build-tag 隔离的条件性 ExecDirect 调用 | `Run(t, Typed(...))` 用 default build context；如需覆盖须扩展 TypedOpts；当前 production 代码库无 build-tag 隔离 ExecDirect 先例；以 code review 兜底（accepted threat） |
 | ExecDirect 仅 adapters/postgres 当前持有 | accesscore 的 pgexec.PGExecutor 暴露 ExecDirect（仅集成测试用，无 production callsite）；devicecell / saga 不暴露（saga 用 AcquireTx 进行 tx ownership） ✓ |
 
 ## Implementation matrix

--- a/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
+++ b/docs/architecture/202605241940-adr-l2-atomicity-subtypes.md
@@ -109,7 +109,7 @@ archtest 将期望名集合与实际 `go/ast` FuncDecl 精确名 match，任何�
 
 形态参照 `.claude/rules/gocell/ai-robust.md` §"Hard 范本目录"中的"codegen funnel + golden"（metadata-driven 枚举 + 代码 SoR 派生）与"string-typed concept funnel"（类型信息精确解析代替字符串启发式）的近亲组合。
 
-**Enforcement 运行位置（nightly，非 PR-time）**：`L2-OUTBOX-ATOMICITY-COVERAGE-01` 由 `archtest-nightly.yml`（16-shard）执行；**不**纳入 PR-time `hack/verify-archtest-invariants.sh`。后者由 ADR `202605120000` §Amendment 2026-05-23 §D8 冻结为 4 类核心运行时 invariant（clock / duration / testtime / panic），扩充该集合需另行 amend 该 ADR，不在本 PR 范围。本 coverage gate 选择 nightly 的理由：(1) 它守护的是 integration 测试的**存在性**，而被守护的测试本身 `//go:build integration` 依赖 Docker、只在 CI integration 分片实跑，PR-time 无法验证其真实通过；(2) `RunTypedProduction` 全量 typed-load 成本与 nightly 预算更匹配。新 L2 单元漏测试 → 当晚 nightly 红 + 本地 `make verify` 即时红。若未来需 PR-time 即时阻断，走 ADR `202605120000` §D8 amendment 把本 ID 加入冻结集（届时按 §"ADR amendment 落地必查"逐行重评威胁矩阵）。
+**Enforcement 运行位置（nightly，非 PR-time）**：`L2-OUTBOX-ATOMICITY-COVERAGE-01` 由 `archtest-nightly.yml`（16-shard）执行；**不**纳入 PR-time `hack/verify-archtest-invariants.sh`。后者由 ADR `202605120000` §Amendment 2026-05-23 §D8 冻结为 4 类核心运行时 invariant（clock / duration / testtime / panic），扩充该集合需另行 amend 该 ADR，不在本 PR 范围。本 coverage gate 选择 nightly 的理由：(1) 它守护的是 integration 测试的**存在性**，而被守护的测试本身 `//go:build integration` 依赖 Docker、只在 CI integration 分片实跑，PR-time 无法验证其真实通过；(2) `Run(t, Production(...))` 全量 typed-load 成本与 nightly 预算更匹配。新 L2 单元漏测试 → 当晚 nightly 红 + 本地 `make verify` 即时红。若未来需 PR-time 即时阻断，走 ADR `202605120000` §D8 amendment 把本 ID 加入冻结集（届时按 §"ADR amendment 落地必查"逐行重评威胁矩阵）。
 
 **Gate 粒度 = per-unit（非 per-mutation）**：本 archtest 对每个 L2 slice 强制**一个** canonical `TestL2Atomicity_<pkg>_RollsBack`（hybrid 另加 `_ReplayIdempotent`），对齐 issue #876 的明文粒度「按 `consistencyLevel: L2` 枚举所有 L2 单元」。同一 slice 的多条 outbox mutation 路径（如 configwrite 的 Create/Update/Delete、configpublish 的 Publish/Rollback）各自的 `*_RollsBack_<Mutation>` 测试是**有意保留的 defense-in-depth，不在本 gate 的 Hard 期望集内**——删除它们不会触发 archtest 红。这是**已知且文档化**的边界，不是隐式 false-green：
 
@@ -130,7 +130,7 @@ archtest 将期望名集合与实际 `go/ast` FuncDecl 精确名 match，任何�
 | auditappend 去 alias 绕过折叠 | `_AliasFoldsToSinglePackage` 反向自检：断言 4 个 slice 的 Unalias 均指向 `appender` 包，去 alias 后自检失败 ✓ |
 | 测试漏 `//go:build integration` tag | archtest 解析 build constraint，要求 producer/hybrid 的 `_RollsBack` / `_ReplayIdempotent` 测试携带 integration tag（否则无 PG 实例的 CI 会静默 skip，无原子性保护） ✓ |
 | L2 slice 的 Service 改名/删除致期望集静默缩水 | `_ServiceLookupTotal` 反向自检：断言 go/types 加载到的 L2 Service 总数 ≥ 已知下限，防 Service 符号消失导致枚举静默归零 ✓ |
-| 期望名派生公式依赖 go/types，但 go/types 加载失败静默跳过 | archtest 在 `RunTyped` 错误路径 `t.Fatal`，不静默跳过；`_ServiceLookupTotal` 额外守 ✓ |
+| 期望名派生公式依赖 go/types，但 go/types 加载失败静默跳过 | archtest 在 `Run(t, Typed(...))` 错误路径 `t.Fatal`，不静默跳过；`_ServiceLookupTotal` 额外守 ✓ |
 
 ---
 

--- a/docs/architecture/202605281200-adr-cell-development-external-repo.md
+++ b/docs/architecture/202605281200-adr-cell-development-external-repo.md
@@ -436,7 +436,7 @@ M3 (#1084) 解 R1：让外部 Cell 仓库 `go get github.com/ghbvf/gocell/tools/
 
 规则对 **GoCell 平台符号路径**（errcode / redaction / panicregister，外部仓库作依赖在固定
 路径导入）的引用保持锚定 `PlatformModulePath`；规则的**扫描范围**（扫哪个 module 找违规）
-由 driver（`RunTyped`→`findModuleRoot` 从运行 module 的 go.mod 解析）供给。二者对应
+由 driver（`Run(t, Typed(...))`→`findModuleRoot` 从运行 module 的 go.mod 解析）供给。二者对应
 `go/analysis` 中 `printf` 硬编码 `"fmt.Printf"` / `copylock` 硬编码 `"sync"`（稳定依赖路径）
 vs `pass.Pkg`（被分析目标）的标准分离。
 

--- a/examples/orderfulfillment/cells/orderfulfillmentcell/slices/placeorder/journey_verify_test.go
+++ b/examples/orderfulfillment/cells/orderfulfillmentcell/slices/placeorder/journey_verify_test.go
@@ -178,7 +178,7 @@ func (e journeyEnv) getStatus(t *testing.T, orderID string) (int, string) {
 func (e journeyEnv) waitStatus(t *testing.T, orderID, want string) {
 	t.Helper()
 	var last string
-	testwait.External(t, "orderstatus-"+want, func() bool {
+	testwait.External(t, "orderstatus-poll", func() bool {
 		if e.ctx.Err() != nil {
 			return true // abort on context cancellation
 		}

--- a/tools/archtest/adapter_error_classification_test.go
+++ b/tools/archtest/adapter_error_classification_test.go
@@ -138,7 +138,6 @@ func TestAdapterErrorClassificationTransient01_FixturePattern(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/adapter_net_transient_funnel_test.go
+++ b/tools/archtest/adapter_net_transient_funnel_test.go
@@ -210,7 +210,6 @@ func TestADAPTER_NET_TRANSIENT_FUNNEL_01_FixturePattern(t *testing.T) {
 	// types.Unalias resolution path; without Unalias it slips past).
 	allowlistDiags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -244,7 +243,6 @@ func TestADAPTER_NET_TRANSIENT_FUNNEL_01_FixturePattern(t *testing.T) {
 	// allowedSite (no narrow form) and forbiddenSite (no narrow form).
 	narrowFormDiags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -277,7 +275,6 @@ func TestADAPTER_NET_TRANSIENT_FUNNEL_01_FixturePattern(t *testing.T) {
 		regressed := regressed
 		emptyDiags := Run(t, Fixture(FixtureOpts{Tests: false},
 			[]string{fixturePattern}),
-
 			func(p *Pass) []Diagnostic {
 				if p.Pkg == nil || p.TypesInfo == nil {
 					return nil
@@ -300,7 +297,6 @@ func TestADAPTER_NET_TRANSIENT_FUNNEL_01_FixturePattern(t *testing.T) {
 	// function name; expect 1 RED diag (Timeout SelectorExpr present).
 	helperDiags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -324,7 +320,6 @@ func TestADAPTER_NET_TRANSIENT_FUNNEL_01_FixturePattern(t *testing.T) {
 	// (asserts the detector catches both regressed forms, each verified independently).
 	narrowDiags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -345,7 +340,6 @@ func TestADAPTER_NET_TRANSIENT_FUNNEL_01_FixturePattern(t *testing.T) {
 	// Also confirm the clean shape (allowedSite) is NOT flagged when targeted.
 	cleanDiags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/audit_ledger_composition_root_test.go
+++ b/tools/archtest/audit_ledger_composition_root_test.go
@@ -155,7 +155,6 @@ func TestAuditLedgerProtocol_ScannerCatchesAliasBypass(t *testing.T) {
 	var hits []ledgerHit
 	_ = Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/auditledgerfixture"}),
-
 		func(p *Pass) []Diagnostic {
 			hits = append(hits, scanLedgerCompositionRootPass(p, modulePath, false)...)
 			return nil

--- a/tools/archtest/auth_bootstrap_invariants_test.go
+++ b/tools/archtest/auth_bootstrap_invariants_test.go
@@ -361,7 +361,6 @@ func TestAuthRouteBootstrapClientsMutex_FixturePattern(t *testing.T) {
 	specVars := map[*types.Var]bool{}
 	_ = Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			collectContractSpecVars(p, specTypePath, specVars)
 			return nil
@@ -370,7 +369,6 @@ func TestAuthRouteBootstrapClientsMutex_FixturePattern(t *testing.T) {
 	// Phase 2: scan fixture packages for mutex violations.
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			return scanRouteBootstrapClients(p, routeTypePath, specTypePath, specVars)
 		})

--- a/tools/archtest/baseslice_ctor_funnel_01_test.go
+++ b/tools/archtest/baseslice_ctor_funnel_01_test.go
@@ -233,7 +233,6 @@ func TestBASESLICE_CTOR_FUNNEL_01_RedFixture_BaseSliceLiteral(t *testing.T) {
 			FixtureOpts{Tests: false},
 			[]string{"./tools/archtest/internal/basesliceredfixture/..."},
 		),
-
 		func(p *Pass) []Diagnostic {
 			return scanBaseSliceFunnel(p, cellPkgPath, metaPkgPath)
 		},
@@ -292,7 +291,6 @@ func TestBASESLICE_CTOR_FUNNEL_01_RedFixture_SliceMetaLiteral(t *testing.T) {
 			FixtureOpts{Tests: false},
 			[]string{"./tools/archtest/internal/basesliceredfixture/..."},
 		),
-
 		func(p *Pass) []Diagnostic {
 			return scanBaseSliceFunnel(p, cellPkgPath, metaPkgPath)
 		},

--- a/tools/archtest/bootstrap_autowire_collector_funnel_test.go
+++ b/tools/archtest/bootstrap_autowire_collector_funnel_test.go
@@ -167,7 +167,7 @@ func TestBootstrapAutoWireCollectorFunnel01(t *testing.T) {
 
 	observed := map[string]bool{}
 
-	diags := RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() || p.Pkg.Path() != autoWireBootstrapPkgPath {
 			return nil
 		}
@@ -226,8 +226,7 @@ func TestBootstrapAutoWireCollectorFunnel01_PlantedBypass(t *testing.T) {
 		{collectorsPkgPath, "NewBeta"}:  "collectors.NewBeta",
 	}
 
-	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
-		[]string{fixturePattern},
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{fixturePattern}),
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/bootstrap_autowire_collector_funnel_test.go
+++ b/tools/archtest/bootstrap_autowire_collector_funnel_test.go
@@ -167,6 +167,9 @@ func TestBootstrapAutoWireCollectorFunnel01(t *testing.T) {
 
 	observed := map[string]bool{}
 
+	// Migrated from RunTypedProduction (#1500 / #1037 §1d). Production() routes
+	// through the same runProduction → LoadProductionPackages path with the
+	// identical generated/ filter — semantically equivalent to the old entry.
 	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() || p.Pkg.Path() != autoWireBootstrapPkgPath {
 			return nil
@@ -226,6 +229,10 @@ func TestBootstrapAutoWireCollectorFunnel01_PlantedBypass(t *testing.T) {
 		{collectorsPkgPath, "NewBeta"}:  "collectors.NewBeta",
 	}
 
+	// Migrated from RunTypedFixture (#1500 / #1037 §1d). Fixture() injects the
+	// same archtest_fixture build tag inside the Run dispatch — semantically
+	// equivalent to the old entry (FixtureOpts has no Tags field, so the tag
+	// stays framework-owned).
 	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{fixturePattern}),
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() || p.Pkg.Path() != fixturePkgPath {

--- a/tools/archtest/bootstrap_reason_set_equivalence_test.go
+++ b/tools/archtest/bootstrap_reason_set_equivalence_test.go
@@ -31,7 +31,7 @@
 // constants from runtime/audit (authoritative source) and compares them against
 // string literals extracted via AST scan from runtime/auth/bootstrap.go and
 // the const-eval'd map keys in cells/accesscore/slices/setup. Typed loading
-// (RunTypedProduction) prevents const-value indirection from bypassing the check.
+// (Run with a Production scope) prevents const-value indirection from bypassing the check.
 //
 // Hard upgrade path: generate a shared compile-time constant set from the three
 // sites via a codegen funnel so the compiler enforces equivalence. Tracked as
@@ -146,13 +146,13 @@ func TestBootstrapReasonSetEquivalence01(t *testing.T) {
 	})
 
 	require.True(t, auditVisited,
-		"%s: RunTypedProduction did not visit %q — scope gap, rule would pass vacuously",
+		"%s: Production scope did not visit %q — scope gap, rule would pass vacuously",
 		ruleBootstrapReasonSetEquivalence01, auditPkg)
 	require.NotEmpty(t, auditReasons,
 		"%s: no Reason* consts found in %q — authoritative set is empty (bug)",
 		ruleBootstrapReasonSetEquivalence01, auditPkg)
 	require.True(t, setupVisited,
-		"%s: RunTypedProduction did not visit %q — scope gap, rule would pass vacuously",
+		"%s: Production scope did not visit %q — scope gap, rule would pass vacuously",
 		ruleBootstrapReasonSetEquivalence01, setupPkg)
 	require.NotEmpty(t, setupReasons,
 		"%s: no %s map keys resolved in %q — whitelist set is empty (bug)",

--- a/tools/archtest/cell_public_option_param_test.go
+++ b/tools/archtest/cell_public_option_param_test.go
@@ -409,7 +409,6 @@ func TestCellRawInfraPublicOptionParam01_ScannerCatchesViolation(t *testing.T) {
 	var violations []rawPublicOptionViolation
 	_ = Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/rawparamfixture"}),
-
 		func(p *Pass) []Diagnostic {
 			violations = append(violations, scanPassForRawPublicOption(p, false)...)
 			return nil

--- a/tools/archtest/cellgen_errcode_funnel_test.go
+++ b/tools/archtest/cellgen_errcode_funnel_test.go
@@ -212,7 +212,6 @@ func TestCellgenErrcodeFunnel(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{},
 		[]string{"./tools/codegen/cellgen/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -364,7 +363,6 @@ func TestCellgenErrcodeFunnelBlindSpotsAbsent(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{},
 		[]string{"./tools/codegen/cellgen/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/changepassword_inactive_gate_test.go
+++ b/tools/archtest/changepassword_inactive_gate_test.go
@@ -116,7 +116,6 @@ func TestChangePasswordInactiveGate_01(t *testing.T) {
 	diags := Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/slices/identitymanage/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() || p.Fset == nil {
 				return nil

--- a/tools/archtest/collector_conformance_enrollment_test.go
+++ b/tools/archtest/collector_conformance_enrollment_test.go
@@ -252,7 +252,6 @@ func TestCollectorConformanceEnrollment_ReverseBlindSpot_NoReflectImpl(t *testin
 	// Scan production non-test files for MethodByName("Collector") calls.
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.Patterns(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil

--- a/tools/archtest/contract_path_query_coverage_test.go
+++ b/tools/archtest/contract_path_query_coverage_test.go
@@ -314,7 +314,6 @@ func TestContractPathQueryParamNameLiteral01_RedComputedParamName(t *testing.T) 
 			FixtureOpts{Tests: true},
 			[]string{fixturePattern},
 		),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/contracttest_loadbyid_literal_test.go
+++ b/tools/archtest/contracttest_loadbyid_literal_test.go
@@ -83,7 +83,6 @@ func TestContracttestLoadByIDLiteral01_RedComputedID(t *testing.T) {
 	fixturePattern := "./tools/archtest/contracttest_loadbyid_literal_fixtures/red_computed_id/..."
 	diags := Run(t, Fixture(FixtureOpts{Tests: true},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -110,7 +109,6 @@ func TestContracttestLoadByIDLiteral01_RedStructFieldID(t *testing.T) {
 	fixturePattern := "./tools/archtest/contracttest_loadbyid_literal_fixtures/red_struct_field_id/..."
 	diags := Run(t, Fixture(FixtureOpts{Tests: true},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/credential_authority_assert_funnel_test.go
+++ b/tools/archtest/credential_authority_assert_funnel_test.go
@@ -215,7 +215,6 @@ func TestCredentialAuthorityAssertFunnel_DownstreamCaller_01(t *testing.T) {
 		"./cells/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -305,7 +304,6 @@ func TestCredentialAuthorityAssertFunnel_UpstreamMandatory_02(t *testing.T) {
 		"./cells/accesscore/slices/sessionrefresh/...",
 		"./cells/accesscore/slices/sessionvalidate/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -461,7 +459,6 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_MethodValueAssignment(t *test
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -509,7 +506,6 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectMethodByName(t *testin
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -553,7 +549,6 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_ReflectFieldByName(t *testing
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -597,7 +592,6 @@ func TestCredentialAuthorityAssertFunnel_BlindSpot_UnsafePointerRead(t *testing.
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Fset == nil {
 				return nil
@@ -664,7 +658,6 @@ func TestCredentialAuthorityAssertFunnel_UpstreamSealed_03(t *testing.T) {
 	_ = Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/internal/credentialauthority/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -789,7 +782,6 @@ func TestCredentialAuthorityAssertFunnel_UpstreamCalleeReference_04(t *testing.T
 		"./cmd/...",
 		"./runtime/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/credential_invalidate_funnel_invariants_test.go
+++ b/tools/archtest/credential_invalidate_funnel_invariants_test.go
@@ -626,7 +626,6 @@ func TestCredentialInvalidateFunnel_AllowlistEntriesAreLive(t *testing.T) {
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -700,7 +699,6 @@ func TestCredentialInvalidateFunnel_BlindSpot_ReflectMethodByName(t *testing.T) 
 	var violations []string
 	_ = Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/...", "./runtime/auth/...", "./adapters/...", "./cmd/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
+++ b/tools/archtest/domain_authz_mutation_funnel_invariants_test.go
@@ -372,7 +372,6 @@ func TestAuthzMutationApplyFunnel_SetStatus_01(t *testing.T) {
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -513,7 +512,6 @@ func TestAuthzMutationApplyFunnel_AllowlistEntriesAreLive(t *testing.T) {
 		"./cells/accesscore/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -598,7 +596,6 @@ func TestDomainAuthzMutation_ValueCapture_Detected(t *testing.T) {
 	_ = Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/internal/domain/testdata/value_capture_setstatus_red",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -644,7 +641,6 @@ func TestDomainAuthzMutation_BlindSpot_ReflectMethodByName(t *testing.T) {
 	_ = Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/...", "./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -693,7 +689,6 @@ func TestDomainAuthzMutation_BlindSpot_UnsafePointerWrite(t *testing.T) {
 	_ = Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/...", "./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Fset == nil {
 				return nil
@@ -752,7 +747,6 @@ func TestDomainAuthzMutation_BlindSpot_ReflectFieldByName(t *testing.T) {
 	_ = Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/...", "./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -800,7 +794,6 @@ func TestDomainAuthzMutation_BlindSpot_VarInitCall(t *testing.T) {
 	_ = Run(t, Typed(TypedOpts{}, []string{
 		"./cells/accesscore/internal/domain/testdata/var_init_setstatus_red",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/errcode_invariants_test.go
+++ b/tools/archtest/errcode_invariants_test.go
@@ -893,7 +893,6 @@ func TestErrcodeMessageConstLiteral(t *testing.T) {
 		TypedOpts{Tests: false, Tags: []string{"e2e", "integration", "pg"}},
 		patterns,
 	),
-
 		func(p *Pass) []Diagnostic {
 			var out []Diagnostic
 			for _, file := range p.Files {
@@ -1112,7 +1111,6 @@ func TestErrorFirstAPI01(t *testing.T) {
 		_, ok := enforcedSet[rel]
 		return ok
 	}))),
-
 		func(p *Pass) []Diagnostic {
 			var out []Diagnostic
 			for _, file := range p.Files {
@@ -1640,7 +1638,6 @@ func TestExportedErrorNew(t *testing.T) {
 		TypedOpts{Tests: false, Tags: []string{"e2e", "integration", "pg"}},
 		patterns,
 	),
-
 		func(p *Pass) []Diagnostic {
 			var out []Diagnostic
 			for _, file := range p.Files {

--- a/tools/archtest/grpc_metrics_label_test.go
+++ b/tools/archtest/grpc_metrics_label_test.go
@@ -140,7 +140,7 @@ func TestGRPCMetricsLabelCellIDCtxSource01(t *testing.T) {
 // package (TestGRPCMetricsLabelCellIDCtxSource01) or the RED fixture
 // (TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected). The package-path
 // filter and the production `visited` tracking stay in the callers so the same
-// scan serves both RunTypedProduction and RunTypedFixture.
+// scan serves both Run(t, Production(...)) and Run(t, Fixture(...)).
 func scanGRPCMetricsLabelPkg(p *Pass) []Diagnostic {
 	fn := findUnaryMetricsFuncDecl(p.Files)
 	if fn == nil {

--- a/tools/archtest/healthz_invariants_test.go
+++ b/tools/archtest/healthz_invariants_test.go
@@ -464,7 +464,6 @@ func TestHealthzInvariants_ReverseBlindSpot_NoDynamicHealthzPath(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(findModuleRoot(t))),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil

--- a/tools/archtest/http_idempotency_conformance_enrollment_test.go
+++ b/tools/archtest/http_idempotency_conformance_enrollment_test.go
@@ -20,8 +20,8 @@
 //     path note below).
 //
 //   - Medium (downstream): the callsite scan proves a _test.go file CALLS
-//     RunConformanceSuite. The scan uses RunTyped(Tests: true,
-//     Tags: FlatNonDefaultTags()) which includes the "integration" build tag in
+//     RunConformanceSuite. The scan uses Run(t, Typed(TypedOpts{Tests: true,
+//     Tags: FlatNonDefaultTags()}, ...)) which includes the "integration" build tag in
 //     the union load — so integration-gated enrollment files such as
 //     adapters/redis/http_idempotency_conformance_test.go (//go:build
 //     integration) are always visible to the callsite scan without raw-AST
@@ -36,7 +36,7 @@
 //
 // The Redis Store enrollment (adapters/redis.HTTPIdempotencyStore) lives in
 // adapters/redis/http_idempotency_conformance_test.go, which is gated by
-// //go:build integration. The callsite scan runs via RunTyped with
+// //go:build integration. The callsite scan runs via Run(t, Typed(...)) with
 // Tags: FlatNonDefaultTags(), which is the flat union of all known non-default
 // build tags in the repo including "integration". This means packages.Load
 // evaluates the integration build constraint as satisfied, loading the
@@ -165,7 +165,7 @@ func TestHTTPIdempotencyConformanceEnrollment(t *testing.T) {
 
 	// ─── Step 3: typed callsite scan for RunConformanceSuite ─────────────────
 	//
-	// We use RunTyped(Tests: true, Tags: FlatNonDefaultTags()) so that ALL
+	// We use Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, ...)) so that ALL
 	// _test.go files are visible including integration-tagged files such as
 	// adapters/redis/http_idempotency_conformance_test.go. FlatNonDefaultTags()
 	// includes "integration" in its flat union, causing packages.Load to
@@ -313,7 +313,7 @@ func TestHTTPIdempotencyConformanceEnrollment_REDFixture(t *testing.T) {
 }
 
 // TestHTTPIdempotencyConformanceEnrollment_BuildTagBlindspot_RedisAlwaysVisible
-// (integration-tag handling) confirms that RunTyped with FlatNonDefaultTags()
+// (integration-tag handling) confirms that Run(t, Typed(...)) with FlatNonDefaultTags()
 // sees the Redis enrollment package (adapters/redis) because "integration" is
 // included in the flat tag union. This means that
 // adapters/redis/http_idempotency_conformance_test.go (//go:build integration)

--- a/tools/archtest/httputil_invariants_test.go
+++ b/tools/archtest/httputil_invariants_test.go
@@ -337,7 +337,6 @@ func TestHTTPUtil5xxLogRedact_DetectsViolation(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/testdata/httputil_log_redact_fixtures/violation"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/internal/autowirefunnelfixture/fixture.go
+++ b/tools/archtest/internal/autowirefunnelfixture/fixture.go
@@ -14,7 +14,7 @@
 //   - bypassSwallowClosure — FIRE (multi-statement degrade-swallowing FuncLit)
 //
 // Nothing here is wired into production; it exists only to be type-checked and
-// scanned by RunTypedFixture.
+// scanned by Run(t, Fixture(...), rule).
 package autowirefunnelfixture
 
 import (

--- a/tools/archtest/internal/grpcmetricsfixture/grpc_metrics_red.go
+++ b/tools/archtest/internal/grpcmetricsfixture/grpc_metrics_red.go
@@ -4,7 +4,7 @@
 // GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01 (see
 // tools/archtest/grpc_metrics_label_test.go). It is gated by the
 // archtest_fixture build tag and loaded only by
-// TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected via RunTypedFixture;
+// TestGRPCMetricsLabelCellIDCtxSource01_RedFixtureDetected via Run(t, Fixture(...));
 // it is never part of a production build.
 package grpcmetricsfixture
 

--- a/tools/archtest/locator_discovery_funnel_test.go
+++ b/tools/archtest/locator_discovery_funnel_test.go
@@ -576,7 +576,6 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
 	// Uses EvaluateConstString to resolve the second argument.
 	replaceDiags := Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./kernel/metadata/...", "./kernel/governance/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -631,7 +630,6 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_BlindSpotInventory(t *testing.T) {
 	// Uses EvaluateConstString to resolve the second argument.
 	trimPrefixDiags := Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./kernel/metadata/...", "./kernel/governance/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -705,7 +703,6 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 	// bypass the funnel this way.
 	hasPrefixConstDiags := Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./kernel/metadata/...", "./kernel/governance/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -750,7 +747,6 @@ func TestLOCATOR_DISCOVERY_FUNNEL_01_A2_ConstEvalBypassBlindSpots(t *testing.T) 
 	// Blind-spot BS-B: const Ident as equality operand evaluating to a banned token.
 	equalityConstDiags := Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./kernel/metadata/...", "./kernel/governance/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
+++ b/tools/archtest/mem_tx_lock_ownership_red_fixture_test.go
@@ -34,7 +34,6 @@ func TestMemTxLockOwnership01_FixturePattern(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/mqtt_callsite_funnel_test.go
+++ b/tools/archtest/mqtt_callsite_funnel_test.go
@@ -227,7 +227,6 @@ func scanMQTTCallsiteFunnel(t *testing.T, ruleID, targetFull string, allowedKeys
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -530,7 +529,6 @@ func scanMQTTTokenConstruction(t *testing.T, typeName string, allowedFuncs []str
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -557,7 +555,6 @@ func countMQTTTokenLiteralsInsideFunc(t *testing.T, typeName, funcName string) i
 	var inside int
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -633,7 +630,6 @@ func scanMQTTTokenFieldAssignment(t *testing.T, typeName string, fieldNames []st
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -791,7 +787,6 @@ func mqttAssertTokenFieldFreeze(t *testing.T, typeName string, wantFields []mqtt
 	var checked bool
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -879,7 +874,6 @@ func scanMQTTCMMethodValue(t *testing.T, methodNames []string, ruleID string) []
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -938,7 +932,6 @@ func TestMQTTCallsiteFunnel_A4S4_ScannerNonVacuous(t *testing.T) {
 	cmMethods := []string{publishMethodName, subscribeMethodName, unsubscribeMethodName}
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -1008,7 +1001,6 @@ func scanMQTTCMMethodExpression(t *testing.T, methodNames, allowedKeys []string,
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -1112,7 +1104,6 @@ func scanMQTTReflectMethodByName(t *testing.T, methodNames []string, ruleID stri
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -1207,7 +1198,6 @@ func TestMQTTPublishCallsiteFunnel_A7_BlindSpot_NoConnectionManagerAlias(t *test
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil

--- a/tools/archtest/mqtt_config_validate_first_test.go
+++ b/tools/archtest/mqtt_config_validate_first_test.go
@@ -75,7 +75,6 @@ func TestMQTTConfigValidateFirst01(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil

--- a/tools/archtest/mqtt_connect_deadline_decoupled_test.go
+++ b/tools/archtest/mqtt_connect_deadline_decoupled_test.go
@@ -66,7 +66,6 @@ func TestMQTTConnectDeadlineDecoupled01(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil

--- a/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
+++ b/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
@@ -263,7 +263,6 @@ func withRouteDeadLetter(t *testing.T, fn func(p *Pass, f *ast.File, fd *ast.Fun
 	// the found==false assertion below fails loudly (rule cannot go vacuous).
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil

--- a/tools/archtest/mqtt_funnel_test.go
+++ b/tools/archtest/mqtt_funnel_test.go
@@ -377,7 +377,6 @@ func TestMQTTClientIDNamespace01(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -458,7 +457,6 @@ func TestMQTTTopicNamespace01(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -592,7 +590,6 @@ func TestMQTTFunnel_BlindSpot_NoReflectNew(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -668,7 +665,6 @@ func TestMQTTFunnel_BlindSpot_NoUnsafePtr(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil
@@ -755,7 +751,6 @@ func TestMQTTFunnel_A2ScannerFires(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -844,7 +839,6 @@ func TestMQTTFunnel_A2ScannerFiresOnRedFixture(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{fixturePkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/mqtt_reason_redaction_test.go
+++ b/tools/archtest/mqtt_reason_redaction_test.go
@@ -66,7 +66,6 @@ func TestMQTTReasonNameRedaction_FunnelOnly(t *testing.T) {
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -113,7 +112,6 @@ func TestMQTTReasonNameRedaction_ScannerNonVacuous(t *testing.T) {
 	var inside int
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil

--- a/tools/archtest/no_deleted_auth_symbols_test.go
+++ b/tools/archtest/no_deleted_auth_symbols_test.go
@@ -284,7 +284,6 @@ func TestNO_DELETED_AUTH_SYMBOLS_01(t *testing.T) {
 		TypedOpts{Tests: true, Tags: FlatNonDefaultTags()},
 		productionScanPatterns,
 	),
-
 		func(p *Pass) []Diagnostic {
 			return scanDeletedAuthSymbolsAgainst(p, authRuntimeImportPath)
 		})
@@ -326,7 +325,6 @@ func TestNO_DELETED_AUTH_SYMBOLS_01_FixtureCatchesAllForms(t *testing.T) {
 		FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/nodeletedauthsymbolsfixture/..."},
 	),
-
 		func(p *Pass) []Diagnostic {
 			return scanDeletedAuthSymbolsAgainst(p, fixtureAuthImportPath)
 		})

--- a/tools/archtest/outbox_entry_sealed_construction_test.go
+++ b/tools/archtest/outbox_entry_sealed_construction_test.go
@@ -167,7 +167,6 @@ func TestOutboxEntrySealedConstruction01_SoleReconstructionSurface(t *testing.T)
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./kernel/outbox/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != outboxPkgPath {
 				return nil

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1852,7 +1852,6 @@ func TestOutboxtestCloseViaBudget01(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: true},
 		[]string{outboxtestPattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -1913,7 +1912,6 @@ func TestOutboxtestCloseViaBudget01_BlindSpot_NoMethodValue(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: true},
 		[]string{outboxtestPattern}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -131,7 +131,6 @@ func TestPanicLogRedact_DetectsViolation(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/testdata/panic_log_redact_fixtures/violation"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/pass.go
+++ b/tools/archtest/pass.go
@@ -259,11 +259,15 @@ func StandaloneModule(dir string, opts TypedOpts, patterns []string) RunScope {
 // satisfies it) so the [StandaloneModule] fatal-path spy tests can drive Run
 // with a tbFatalSpy.
 //
-// scope selects the mode and source: [AST] (AST-only), [Typed] (typed main
-// module), [Production] (typed main module, generated/ excluded), [Fixture]
-// (typed archtest_fixture packages), [StandaloneModule] (typed standalone
-// module). All failure modes (module-root not found, load error, parse error,
-// non-absolute StandaloneModule dir) fail-loud via t.Fatalf.
+// scope selects the mode and source. Scope quick-pick:
+//   - No go/types needed (pure AST) → [AST]
+//   - Need go/types over the main module → [Typed]
+//   - Same as Typed but generated/ excluded (hand-written-source rules) → [Production]
+//   - Loading archtest_fixture-tagged fixture packages → [Fixture]
+//   - Standalone testdata module with its own go.mod → [StandaloneModule]
+//
+// All failure modes (nil scope, nil rule, module-root not found, load error,
+// parse error, non-absolute StandaloneModule dir) fail-loud via t.Fatalf.
 //
 // Typed rules read pass.TypesInfo (and pass.Pkg) for resolution; AST-only
 // helpers ([EachInSubtree] etc.) work unchanged on pass.Files in either mode.
@@ -271,6 +275,10 @@ func Run(t testing.TB, scope RunScope, rule Rule) []Diagnostic {
 	t.Helper()
 	if rule == nil {
 		t.Fatalf("archtest.Run: nil rule")
+	}
+	if scope == nil {
+		t.Fatalf("archtest.Run: nil scope; use AST/Typed/Production/Fixture/StandaloneModule")
+		return nil
 	}
 	switch s := scope.(type) {
 	case astRunScope:
@@ -290,7 +298,7 @@ func Run(t testing.TB, scope RunScope, rule Rule) []Diagnostic {
 	case productionRunScope:
 		return runProduction(t, s.opts, rule)
 	default:
-		t.Fatalf("archtest.Run: nil RunScope; use AST/Typed/Production/Fixture/StandaloneModule")
+		t.Fatalf("archtest.Run: unknown RunScope %T; use AST/Typed/Production/Fixture/StandaloneModule", scope)
 		return nil
 	}
 }
@@ -339,7 +347,8 @@ func runProduction(t testing.TB, opts TypedOpts, rule Rule) []Diagnostic {
 	}
 	resolver, err := typeseval.LoadProductionPackages(root, modPath, opts.Tests, opts.Tags)
 	if err != nil {
-		t.Fatalf("archtest.Run: Production: LoadProductionPackages: %v", err)
+		t.Fatalf("archtest.Run: Production: LoadProductionPackages(root=%s, tests=%v, tags=%v): %v",
+			root, opts.Tests, opts.Tags, err)
 	}
 	return runRulePasses(root, resolver.Production(), rule)
 }
@@ -416,11 +425,12 @@ func collectASTFiles(t testing.TB, scope Scope) (
 func runTypedWithRoot(t testing.TB, root string, opts TypedOpts, patterns []string, rule Rule) []Diagnostic {
 	t.Helper()
 	if len(patterns) == 0 {
-		t.Fatalf("archtest.Run: typed scope requires at least one pattern")
+		t.Fatalf("archtest.Run: typed scope (Typed/Fixture/StandaloneModule) requires at least one pattern; got none")
 	}
 	resolver, err := typeseval.SharedResolver(root, opts.Tests, opts.Tags, patterns...)
 	if err != nil {
-		t.Fatalf("archtest.Run: SharedResolver: %v", err)
+		t.Fatalf("archtest.Run: SharedResolver(root=%s, tests=%v, tags=%v, patterns=%v): %v",
+			root, opts.Tests, opts.Tags, patterns, err)
 	}
 	return runRulePasses(root, resolver.Packages(), rule)
 }

--- a/tools/archtest/pass_test.go
+++ b/tools/archtest/pass_test.go
@@ -1302,6 +1302,12 @@ func TestRun_rejectsNilScope(t *testing.T) {
 	if !strings.Contains(spy.lastMsg, "nil scope") {
 		t.Errorf("Run(t, nil, rule) fatal message %q does not mention \"nil scope\"", spy.lastMsg)
 	}
+	// The nil-scope guard must be distinct from the unknown-type default branch
+	// (which prints %T): both name the five constructors, so assert the guidance
+	// list is present to prove the dedicated nil path fired.
+	if !strings.Contains(spy.lastMsg, "StandaloneModule") {
+		t.Errorf("Run(t, nil, rule) fatal message %q does not list the scope constructors", spy.lastMsg)
+	}
 }
 
 // TestRun_Fixture_delegatesToRunTypedWithRoot verifies the regression contract

--- a/tools/archtest/pass_test.go
+++ b/tools/archtest/pass_test.go
@@ -1285,6 +1285,25 @@ func TestRun_StandaloneModule_rejectsEmptyPatterns(t *testing.T) {
 	}
 }
 
+// TestRun_rejectsNilScope verifies that Run(t, nil, rule) fails loud with a
+// message naming the five constructors, rather than the ambiguous former
+// "nil RunScope" wording that also covered the unknown-type default branch.
+func TestRun_rejectsNilScope(t *testing.T) {
+	spy := &tbFatalSpy{TB: t}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Run(spy, nil, func(*Pass) []Diagnostic { return nil })
+	}()
+	<-done
+	if !spy.fatal {
+		t.Errorf("Run(t, nil, rule): expected t.Fatalf, got none")
+	}
+	if !strings.Contains(spy.lastMsg, "nil scope") {
+		t.Errorf("Run(t, nil, rule) fatal message %q does not mention \"nil scope\"", spy.lastMsg)
+	}
+}
+
 // TestRun_Fixture_delegatesToRunTypedWithRoot verifies the regression contract
 // for the typed scopes' shared delegation: Fixture (like Typed) routes through
 // runTypedWithRoot and still produces a valid typed Pass after the Stage 1.6

--- a/tools/archtest/principal_kind_exhaustive_switch_test.go
+++ b/tools/archtest/principal_kind_exhaustive_switch_test.go
@@ -97,7 +97,6 @@ func TestPrincipalKindExhaustiveSwitch01_ReverseFixture(t *testing.T) {
 	}
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/principalkindfixture/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() {
 				return nil
@@ -128,7 +127,6 @@ func TestPrincipalKindExhaustiveSwitch01_IfChainNotScanned(t *testing.T) {
 	}
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/principalkindifchainfixture/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() {
 				return nil

--- a/tools/archtest/probename_sealed_funnel_test.go
+++ b/tools/archtest/probename_sealed_funnel_test.go
@@ -907,7 +907,6 @@ func collectProbeNameConsts(t *testing.T, root string) []string {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -1228,7 +1227,6 @@ func TestProbenameSealedFunnel_ReverseBlindSpot_NoReflectBypass(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil
@@ -1286,7 +1284,6 @@ func TestProbenameSealedFunnel_ReverseBlindSpot_NoStringCastBypass(t *testing.T)
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil
@@ -1358,7 +1355,6 @@ func TestProbenameSealedFunnel_ReverseBlindSpot_NoHelperWrapper(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil
@@ -1418,7 +1414,6 @@ func TestProbenameSealedFunnel_ReverseBlindSpot_NoNewProbeImpl(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"github.com/ghbvf/gocell/kernel/healthz/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != "github.com/ghbvf/gocell/kernel/healthz" {
 				return nil

--- a/tools/archtest/projection_checkpoint_conformance_enroll_test.go
+++ b/tools/archtest/projection_checkpoint_conformance_enroll_test.go
@@ -306,7 +306,6 @@ func TestProjectionCheckpointConformanceEnroll01_RedFixture(t *testing.T) {
 	enrolledImpls := make(map[string]bool)
 	_ = Run(t, Fixture(FixtureOpts{Tests: true},
 		[]string{"./tools/archtest/internal/projectioncheckpointenrollfixture/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/projection_checkpoint_tx_bound_test.go
+++ b/tools/archtest/projection_checkpoint_tx_bound_test.go
@@ -230,7 +230,6 @@ func TestProjectionCheckpointTxBound01_RedFixture(t *testing.T) {
 			FixtureOpts{Tests: false},
 			[]string{"./tools/archtest/internal/projectioncheckpointtxfixture/..."},
 		),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/projection_replay_source_conformance_enroll_test.go
+++ b/tools/archtest/projection_replay_source_conformance_enroll_test.go
@@ -247,7 +247,6 @@ func TestProjectionReplaySourceConformanceEnroll01_RedFixture(t *testing.T) {
 	enrolledImpls := make(map[string]bool)
 	_ = Run(t, Fixture(FixtureOpts{Tests: true},
 		[]string{"./tools/archtest/internal/projectionreplayenrollfixture/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/reconcile_invariants_test.go
+++ b/tools/archtest/reconcile_invariants_test.go
@@ -552,7 +552,6 @@ func TestReconcileLoopConstructionAllowlist01_RedFixture(t *testing.T) {
 			FixtureOpts{Tests: false},
 			[]string{"./tools/archtest/internal/reconcileloopredfixture/..."},
 		),
-
 		func(p *Pass) []Diagnostic {
 			return scanReconcileLoopConstruction(p, reconcilePkgPath, allowed)
 		},

--- a/tools/archtest/reconstitute_user_caller_allowlist_test.go
+++ b/tools/archtest/reconstitute_user_caller_allowlist_test.go
@@ -145,7 +145,6 @@ func TestReconstituteUserCallerAllowlist(t *testing.T) {
 	var allDiags []Diagnostic
 	Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/...", "./cmd/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -193,7 +192,6 @@ func TestReconstituteUserCallerAllowlist_REDFixture(t *testing.T) {
 	var found int
 	Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/internal/domain/testdata/reconstitute_user_caller_red"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -239,7 +237,6 @@ func TestReconstituteUser_BlindSpot_NoMethodValueOrReflectInProd(t *testing.T) {
 	var allDiags []Diagnostic
 	Run(t, Typed(TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/...", "./cmd/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/refresh_invariants_test.go
+++ b/tools/archtest/refresh_invariants_test.go
@@ -190,7 +190,6 @@ func TestRefreshCrossStoreTX01_BlindSpot_ServiceRefreshReceiverIsS(t *testing.T)
 		TypedOpts{Tests: false},
 		[]string{"./cells/accesscore/slices/sessionrefresh/..."},
 	),
-
 		func(p *Pass) []Diagnostic {
 			var out []Diagnostic
 			for _, file := range p.Files {

--- a/tools/archtest/role_admin_literal_test.go
+++ b/tools/archtest/role_admin_literal_test.go
@@ -159,7 +159,6 @@ func TestRoleAdminCallSiteLiteralIsForbidden(t *testing.T) {
 	diags := Run(t, Typed(TypedOpts{}, []string{
 		"./runtime/...", "./cells/...", "./adapters/...", "./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/runscope_constructor_funnel_test.go
+++ b/tools/archtest/runscope_constructor_funnel_test.go
@@ -36,13 +36,17 @@
 //
 // In-package is Medium: Go package visibility cannot express "no code INSIDE
 // package archtest may construct typedRunScope". This archtest is the
-// type-aware CI backstop — it resolves each composite literal's type via
-// *types.Info (p.TypesInfo.TypeOf) to a *types.Named whose object is one of the
-// five scope structs in package archtest, then asserts the enclosing top-level
-// FuncDecl (via ResolveEnclosingFunc) is one of the five sanctioned
-// constructors. Name matching alone is insufficient (same-package construction
-// is a bare Ident, not a qualified selector), so the rule is types-bound, not
-// string-bound — an import alias / rename cannot bypass it.
+// type-aware CI backstop. It flags two construction forms — composite literals
+// (`typedRunScope{…}`, including `&…` and type-alias literals) and zero-value
+// var declarations (`var s typedRunScope`, whose fields are then
+// same-package-assignable) — resolving each via *types.Info (TypeOf +
+// types.Unalias) to a *types.Named whose object is one of the five scope structs
+// in package archtest, then asserts the enclosing top-level FuncDecl (via
+// ResolveEnclosingFunc) is that struct's OWN sanctioned constructor (exact
+// pairing — a typedRunScope built inside Fixture is still a violation). Name
+// matching alone is insufficient (same-package construction is a bare Ident, not
+// a qualified selector), so the rule is types-bound, not string-bound — an
+// import alias / rename / type alias cannot bypass it.
 //
 // The permanent Go-language ceiling (a same-package *_test.go CAN construct the
 // unexported struct, Go cannot forbid it at compile time) is the same shape
@@ -54,35 +58,46 @@
 //
 // # Blind spots (per ai-robust.md Medium evidence requirement)
 //
-//   - New named type derived from a scope struct (`type x typedRunScope;
-//     x{}`): NOT detected — but harmless, because the method set of a struct is
-//     NOT carried to a new named type, so x does not implement isRunScope() and
-//     cannot reach Run. (A type ALIAS `type x = typedRunScope` IS detected:
-//     TypeOf(x{}) resolves to the identical named typedRunScope.)
-//   - Pointer-elided literal `&typedRunScope{}`: IS detected — the inner
-//     CompositeLit node is typed `typedRunScope` (not `*typedRunScope`), so
-//     TypeOf(comp) resolves it. Even were it missed, isRunScope() has a VALUE
-//     receiver, so `*typedRunScope` does not implement RunScope and
-//     `Run(t, &typedRunScope{}, rule)` is a compile error — a type-system
-//     backstop. Not a bypass.
+//   - New named type DERIVED from a scope struct (`type x typedRunScope; x{}`):
+//     NOT detected — but harmless, because a defined type does NOT inherit the
+//     method set of its underlying struct, so x does not implement isRunScope()
+//     and cannot reach Run. (A type ALIAS `type x = typedRunScope` IS detected:
+//     under gotypesalias=1 TypeOf(x{}) is a *types.Alias, and types.Unalias in
+//     runScopeNamedType resolves it to the identical named typedRunScope.)
+//   - Pointer literal `&typedRunScope{}`: IS detected — the inner CompositeLit
+//     node is typed `typedRunScope`, so TypeOf(comp) resolves it. (Note: a
+//     VALUE-receiver isRunScope() IS promoted to the `*typedRunScope` method
+//     set, so `*typedRunScope` DOES implement RunScope and
+//     `Run(t, &typedRunScope{}, rule)` compiles — it is NOT a compile error; it
+//     fails at runtime in Run's default branch because the dispatch switch has no
+//     `case *typedRunScope`. Either way the inner literal is flagged, so this is
+//     not a bypass.)
 //   - Reflect / runtime construction: outside Go static AST + types.Info scope,
 //     same accepted boundary as the entire archtest framework.
 //   - A scope struct returned from a non-constructor helper that is itself
 //     wrapped by a constructor: not applicable — the five structs have no
 //     factory other than their five constructors, and adding one is exactly the
-//     change this rule's per-member fixture lock would force into the allowlist.
+//     change this rule's per-member fixture lock would force into the pairing.
 //
 // # Reverse self-check
 //
 //   - TestRunScopeConstructorFunnel01_FixtureCoverage loads the archtest_fixture
 //     in-package RED fixture (runscope_ctor_redfixture.go) and asserts each of
 //     the five struct names is flagged (per-member trip-wire) AND that the total
-//     count equals exactly five — so the five sanctioned constructors NOT being
-//     flagged is load-bearing (a constructor wrongly flagged would push the
-//     count above five).
+//     count equals exactly SEVEN — five direct composite literals + one
+//     type-alias literal (locks types.Unalias) + one zero-value var declaration
+//     (locks the Form-2 var-decl scan). Both new precision legs are thus
+//     load-bearing: dropping Unalias or the var-decl scan drops the count below
+//     seven, and a constructor wrongly flagged would push it above seven.
 //   - TestRunScopeConstructorFunnel01 (the live gate) asserts production package
-//     archtest (no fixture tag) has ZERO violations — every scope-struct literal
-//     in pass.go / fixture.go is inside its constructor.
+//     archtest (no fixture tag) has ZERO violations — every scope-struct
+//     construction in pass.go / fixture.go is inside its own constructor. This
+//     is also the only reverse-check for the exact-pairing leg (F3): a mispaired
+//     construction can structurally only live inside a sanctioned-named ctor
+//     (anywhere else is already flagged by the not-in-a-ctor check), and a
+//     fixture cannot redefine AST/Typed/Production/StandaloneModule/Fixture
+//     without a name collision — so a mispairing surfaces as a live-gate red on
+//     pass.go / fixture.go, not as an isolated fixture trip-wire.
 package archtest
 
 import (
@@ -95,74 +110,96 @@ import (
 
 const runScopeConstructorFunnelRuleID = "RUNSCOPE-CONSTRUCTOR-FUNNEL-01"
 
-// runScopeStructNames is the set of sealed RunScope struct names whose
-// composite-literal construction is funneled to the sanctioned constructors.
-// Adding a sixth RunScope struct MUST add it here (and a sanctioned constructor
-// to runScopeSanctionedCtors) or the new struct is constructible anywhere
-// in-package — the red fixture's per-member trip-wire forces this maintenance.
-var runScopeStructNames = map[string]struct{}{
-	"astRunScope":        {},
-	"typedRunScope":      {},
-	"productionRunScope": {},
-	"dirRunScope":        {},
-	"fixtureRunScope":    {},
+// runScopeStructToCtor is the single source pairing each sealed RunScope struct
+// with the ONE sanctioned constructor allowed to build it. It is both the
+// membership set (a name absent from the map is not a tracked scope struct) and
+// the struct→constructor pairing (F3: a scope-struct construction inside a
+// DIFFERENT scope constructor is a mispairing, still a violation). Adding a
+// sixth RunScope struct MUST add it here (with its constructor) or the new
+// struct is constructible anywhere in-package — the red fixture's per-member
+// trip-wire forces this maintenance.
+var runScopeStructToCtor = map[string]string{
+	"astRunScope":        "AST",
+	"typedRunScope":      "Typed",
+	"productionRunScope": "Production",
+	"dirRunScope":        "StandaloneModule",
+	"fixtureRunScope":    "Fixture",
 }
 
-// runScopeSanctionedCtors is the set of top-level constructor func names allowed
-// to construct a RunScope struct literal. These are the five typed RunScope
-// constructors (pass.go: AST / Typed / Production / StandaloneModule; fixture.go:
-// Fixture).
-var runScopeSanctionedCtors = map[string]struct{}{
-	"AST":              {},
-	"Typed":            {},
-	"Production":       {},
-	"StandaloneModule": {},
-	"Fixture":          {},
-}
-
-// scanRunScopeConstructorViolations walks file for composite literals of the
-// five sealed RunScope structs and reports each one not lexically inside a
-// sanctioned constructor body.
+// scanRunScopeConstructorViolations walks file for constructions of the five
+// sealed RunScope structs and reports each one not lexically inside its OWN
+// sanctioned constructor body. Two construction forms are covered:
+//
+//	Form 1 — composite literal `typedRunScope{…}` (incl. `&typedRunScope{}` and
+//	         type-alias `aliasOfTyped{…}`, both resolved via types.Unalias).
+//	Form 2 — zero-value var declaration `var s typedRunScope` (no composite
+//	         literal node, so Form 1's CompositeLit scan cannot see it; the
+//	         fields are then same-package-assignable: `s.opts = …`).
 func scanRunScopeConstructorViolations(p *Pass, file *ast.File, rel string) []Diagnostic {
 	if p.TypesInfo == nil {
 		return nil
 	}
 	var out []Diagnostic
-	EachInSubtree[ast.CompositeLit](file, func(comp *ast.CompositeLit) {
-		name, ok := runScopeStructLiteralName(p, comp)
-		if !ok {
+	flag := func(name string, node ast.Node) {
+		if scopeConstructionSanctioned(p, file, node, name) {
 			return
-		}
-		fn, found := ResolveEnclosingFunc(p.TypesInfo, file, comp)
-		// archtestPkgPath ("github.com/ghbvf/gocell/tools/archtest") is the
-		// shared meta-archtest const declared in pass_funnel_test.go (same
-		// package archtest test binary).
-		if found && fn.Pkg() != nil && fn.Pkg().Path() == archtestPkgPath {
-			if _, sanctioned := runScopeSanctionedCtors[fn.Name()]; sanctioned {
-				return
-			}
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
-			Line: p.Fset.Position(comp.Pos()).Line,
-			Message: "composite literal " + name + "{…} constructs a sealed RunScope " +
-				"outside its sanctioned constructor; build the scope via " +
+			Line: p.Fset.Position(node.Pos()).Line,
+			Message: "construction of sealed RunScope " + name + " outside its " +
+				"sanctioned constructor; build the scope via " +
 				"archtest.{AST,Typed,Production,StandaloneModule,Fixture} and pass it " +
 				"to Run(t, <RunScope>, rule) — RUNSCOPE-CONSTRUCTOR-FUNNEL-01",
 		})
+	}
+	// Form 1: composite literals (alias + &-elided resolve via types.Unalias).
+	EachInSubtree[ast.CompositeLit](file, func(comp *ast.CompositeLit) {
+		if name, ok := runScopeNamedType(p.TypesInfo.TypeOf(comp)); ok {
+			flag(name, comp)
+		}
+	})
+	// Form 2: zero-value var declarations `var s typedRunScope`. A spec with no
+	// explicit Type (`var s = typedRunScope{}`) carries its construction in a
+	// composite literal already covered by Form 1, so only typed specs are
+	// scanned here (no double counting).
+	EachInSubtree[ast.ValueSpec](file, func(vs *ast.ValueSpec) {
+		if vs.Type == nil {
+			return
+		}
+		if name, ok := runScopeNamedType(p.TypesInfo.TypeOf(vs.Type)); ok {
+			flag(name, vs.Type)
+		}
 	})
 	return out
 }
 
-// runScopeStructLiteralName resolves comp's type via *types.Info to a named
-// struct in package archtest and returns its name when it is one of the five
-// sealed RunScope structs.
-func runScopeStructLiteralName(p *Pass, comp *ast.CompositeLit) (string, bool) {
-	t := p.TypesInfo.TypeOf(comp)
+// scopeConstructionSanctioned reports whether a construction of the scope struct
+// structName at node sits inside that struct's OWN sanctioned constructor in
+// package archtest. Pairing is exact (F3): a typedRunScope built inside
+// Fixture's body is NOT sanctioned. archtestPkgPath
+// ("github.com/ghbvf/gocell/tools/archtest") is the shared meta-archtest const
+// declared in pass_funnel_test.go (same package archtest test binary).
+func scopeConstructionSanctioned(p *Pass, file *ast.File, node ast.Node, structName string) bool {
+	fn, found := ResolveEnclosingFunc(p.TypesInfo, file, node)
+	if !found || fn.Pkg() == nil || fn.Pkg().Path() != archtestPkgPath {
+		return false
+	}
+	wantCtor, ok := runScopeStructToCtor[structName]
+	return ok && fn.Name() == wantCtor
+}
+
+// runScopeNamedType resolves t via *types.Info to a named struct in package
+// archtest and returns its name when it is one of the five sealed RunScope
+// structs. types.Unalias is mandatory: under gotypesalias=1 (the default since
+// Go 1.23) the type of a type-alias literal `aliasOfTyped{}` is a *types.Alias,
+// which a bare `.(*types.Named)` assertion would miss — letting an in-package
+// alias literal bypass the funnel (F2).
+func runScopeNamedType(t types.Type) (string, bool) {
 	if t == nil {
 		return "", false
 	}
-	named, ok := t.(*types.Named)
+	named, ok := types.Unalias(t).(*types.Named)
 	if !ok || named.Obj() == nil || named.Obj().Pkg() == nil {
 		return "", false
 	}
@@ -170,7 +207,7 @@ func runScopeStructLiteralName(p *Pass, comp *ast.CompositeLit) (string, bool) {
 		return "", false
 	}
 	name := named.Obj().Name()
-	if _, ok := runScopeStructNames[name]; ok {
+	if _, ok := runScopeStructToCtor[name]; ok {
 		return name, true
 	}
 	return "", false
@@ -207,12 +244,15 @@ func TestRunScopeConstructorFunnel01(t *testing.T) {
 // holds — business *_test.go would add only ctor-mediated Run calls, never bare
 // scope-struct literals — but Tests:false keeps this coverage load minimal.
 //
-// The scope-struct literals seen are: the five sanctioned constructors (NOT
-// flagged) + the five RED fixture constructions (flagged). The GREEN-negative
-// fixture (runScopeConstructorGreenNegatives: TypedOpts{}/FixtureOpts{}/
-// Diagnostic{} outside any ctor) MUST add zero — so the exact-count==5 lock is
-// also a false-positive guard: a non-scope name mistakenly added to
-// runScopeStructNames would trip a GREEN line and push the count past five.
+// The constructions seen are: the five sanctioned constructors (NOT flagged) +
+// the RED fixture constructions (flagged): five direct composite literals + one
+// type-alias literal (Form 1, F2 — proves types.Unalias) + one zero-value var
+// declaration (Form 2, F1 — proves the var-decl scan) = seven. The
+// GREEN-negative fixture (runScopeConstructorGreenNegatives: TypedOpts /
+// FixtureOpts / Diagnostic literals AND a non-scope var-decl, outside any ctor)
+// MUST add zero — so the exact-count==7 lock is also a false-positive guard: a
+// non-scope name mistakenly tracked, or a Form-2 scan that over-flags non-scope
+// vars, would trip a GREEN line and push the count past seven.
 func TestRunScopeConstructorFunnel01_FixtureCoverage(t *testing.T) {
 	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{"./tools/archtest"}),
 		func(p *Pass) []Diagnostic {
@@ -223,16 +263,16 @@ func TestRunScopeConstructorFunnel01_FixtureCoverage(t *testing.T) {
 			return out
 		})
 
-	perStruct := make(map[string]int, len(runScopeStructNames))
+	perStruct := make(map[string]int, len(runScopeStructToCtor))
 	for _, d := range diags {
-		for name := range runScopeStructNames {
+		for name := range runScopeStructToCtor {
 			if containsStructName(d.Message, name) {
 				perStruct[name]++
 			}
 		}
 	}
 	missing := make([]string, 0)
-	for name := range runScopeStructNames {
+	for name := range runScopeStructToCtor {
 		if perStruct[name] == 0 {
 			missing = append(missing, name)
 		}
@@ -244,24 +284,26 @@ func TestRunScopeConstructorFunnel01_FixtureCoverage(t *testing.T) {
 			"dropped this struct's construction or the detector regressed for it "+
 			"(per-member regression lock)", runScopeConstructorFunnelRuleID, name)
 	}
-	// Exact-count lock: exactly five RED constructions, and the five sanctioned
-	// constructors + the three GREEN-negative non-scope literals must add zero.
-	// Drift (a constructor wrongly flagged, a non-scope name wrongly added to
-	// runScopeStructNames, or a new RED construction without updating this count)
-	// fails here.
-	const wantViolations = 5
+	// Exact-count lock: seven RED constructions (5 direct literals + 1 alias
+	// literal + 1 var-decl), and the five sanctioned constructors + the
+	// GREEN-negative non-scope constructions must add zero. Drift (a constructor
+	// wrongly flagged, a non-scope name wrongly tracked, types.Unalias or the
+	// Form-2 var-decl scan dropped, or a new RED construction without updating
+	// this count) fails here.
+	const wantViolations = 7
 	if got := len(diags); got != wantViolations {
 		t.Errorf("%s FixtureCoverage: %d violations, want %d "+
-			"(five RED fixture constructions trip once each; the five sanctioned "+
-			"constructors and the GREEN-negative non-scope literals must add 0) — "+
-			"over-detection regression or fixture set changed",
-			runScopeConstructorFunnelRuleID, got, wantViolations)
+			"(5 direct + 1 alias + 1 var-decl RED constructions trip once each; the "+
+			"five sanctioned constructors and the GREEN-negative non-scope "+
+			"constructions must add 0) — over/under-detection regression or fixture "+
+			"set changed", runScopeConstructorFunnelRuleID, got, wantViolations)
 	}
 }
 
-// containsStructName reports whether msg embeds the struct name as the
-// "<name>{…}" token the diagnostic uses. The "{" suffix avoids a substring
+// containsStructName reports whether msg attributes the diagnostic to the scope
+// struct name. The diagnostic embeds the name as "RunScope <name> outside", so
+// the " outside" suffix anchors an exact-token match — avoiding a substring
 // collision between "typedRunScope" and a hypothetical longer name.
 func containsStructName(msg, name string) bool {
-	return strings.Contains(msg, name+"{")
+	return strings.Contains(msg, name+" outside")
 }

--- a/tools/archtest/runscope_ctor_redfixture.go
+++ b/tools/archtest/runscope_ctor_redfixture.go
@@ -18,14 +18,16 @@
 //
 // Each construction below is at NON-constructor scope (helper func body, never
 // AST / Typed / Production / StandaloneModule / Fixture), so each of the five
-// scope structs must be flagged — making every entry in runScopeStructNames a
+// scope structs must be flagged — making every entry in runScopeStructToCtor a
 // load-bearing per-member trip-wire. The functions are never invoked; they
-// exist only as *ast.CompositeLit + *types.Info source for the detector.
+// exist only as *ast.CompositeLit / *ast.ValueSpec + *types.Info source for the
+// detector. Total RED count = seven (5 direct + 1 alias + 1 var-decl).
 
 package archtest
 
 // runScopeConstructorBypassFixture constructs each of the five sealed RunScope
-// structs OUTSIDE its sanctioned constructor — every line is a RED violation.
+// structs OUTSIDE its sanctioned constructor — every line is a RED violation
+// (Form 1: composite literal).
 func runScopeConstructorBypassFixture() {
 	_ = astRunScope{}        // bypass: astRunScope outside AST
 	_ = typedRunScope{}      // bypass: typedRunScope outside Typed
@@ -34,14 +36,34 @@ func runScopeConstructorBypassFixture() {
 	_ = fixtureRunScope{}    // bypass: fixtureRunScope outside Fixture
 }
 
+// aliasOfTypedRunScope is a same-package type alias to typedRunScope. Under
+// gotypesalias=1 (Go 1.23+ default) the type of aliasOfTypedRunScope{} is a
+// *types.Alias, so the detector must types.Unalias it to flag the literal below
+// — this fixture proves the Unalias leg (F2) is load-bearing.
+type aliasOfTypedRunScope = typedRunScope
+
+// runScopeConstructorAliasBypassFixture builds typedRunScope via a type-alias
+// literal outside Typed — RED only if the detector unaliases (Form 1, F2).
+func runScopeConstructorAliasBypassFixture() {
+	_ = aliasOfTypedRunScope{} // bypass: alias of typedRunScope outside Typed
+}
+
+// runScopeConstructorVarDeclBypassFixture builds typedRunScope by a zero-value
+// var declaration outside Typed — RED only if the detector scans Form 2 (F1); a
+// composite-literal-only scan misses it (there is no CompositeLit node).
+func runScopeConstructorVarDeclBypassFixture() {
+	var _ typedRunScope // bypass: zero-value var-decl construction outside Typed
+}
+
 // runScopeConstructorGreenNegatives constructs NON-scope structs of package
 // archtest outside any constructor — these MUST NOT be flagged. They are the
-// GREEN false-positive control: the FixtureCoverage exact-count lock (== 5,
-// the RED lines above) makes them load-bearing — if a non-scope name were
-// mistakenly added to runScopeStructNames, one of these would trip and the
-// count would exceed 5.
+// GREEN false-positive control: the FixtureCoverage exact-count lock (== 7, the
+// RED lines above) makes them load-bearing — if a non-scope name were mistakenly
+// tracked, or the Form-2 var-decl scan over-flagged non-scope vars, one of these
+// would trip and the count would exceed 7.
 func runScopeConstructorGreenNegatives() {
-	_ = TypedOpts{}   // not a RunScope struct → must NOT be flagged
-	_ = FixtureOpts{} // not a RunScope struct → must NOT be flagged
-	_ = Diagnostic{}  // not a RunScope struct → must NOT be flagged
+	_ = TypedOpts{}   // not a RunScope struct → must NOT be flagged (Form 1)
+	_ = FixtureOpts{} // not a RunScope struct → must NOT be flagged (Form 1)
+	_ = Diagnostic{}  // not a RunScope struct → must NOT be flagged (Form 1)
+	var _ TypedOpts   // not a RunScope struct → must NOT be flagged (Form 2)
 }

--- a/tools/archtest/safeid_funnel_test.go
+++ b/tools/archtest/safeid_funnel_test.go
@@ -192,7 +192,6 @@ func TestSAFEIDWireMessageUsage01(t *testing.T) {
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./kernel/outbox/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != outboxPkgPath {
 				return nil
@@ -319,7 +318,6 @@ func TestSAFEIDWireMessageUsage01_BlindSpot_NewWireStruct(t *testing.T) {
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./kernel/outbox/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != outboxPkgPath {
 				return nil
@@ -407,7 +405,6 @@ func TestSAFEIDUpstreamFunnelHard01(t *testing.T) {
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./kernel/outbox/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != outboxPkgPath {
 				return nil

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -2290,7 +2290,6 @@ func TestSagaJournalHolderSeal_A1_AliasFieldResolvedViaUnalias(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{},
 		[]string{"./tools/archtest/testdata/saga_journal_holder_seal_fixtures/aliasholder"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -2348,7 +2347,6 @@ func TestSagaJournalHolderSeal_A1_HeartbeatFuncFieldFlagged(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{},
 		[]string{"./tools/archtest/testdata/saga_journal_holder_seal_fixtures/funcfieldholder"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil {
 				return nil
@@ -3217,7 +3215,6 @@ func TestSagaStatusFanoutCoverageC4(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./kernel/saga/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -3268,7 +3265,6 @@ func TestSagaStatusFanoutCoverageC5(t *testing.T) {
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{"./kernel/saga/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil

--- a/tools/archtest/scaffold_write_funnel_test.go
+++ b/tools/archtest/scaffold_write_funnel_test.go
@@ -172,7 +172,6 @@ func TestScaffoldWriteFunnel_NoDirectOSWrites(t *testing.T) {
 		"./kernel/assembly/...",
 		"./cmd/gocell/app/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil

--- a/tools/archtest/scanner_framework_usage_test.go
+++ b/tools/archtest/scanner_framework_usage_test.go
@@ -153,7 +153,6 @@ func TestScannerFrameworkUsage01_InspectorMethodBanLive(t *testing.T) {
 	var diags []scanner.Diagnostic
 	Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/inspectorredfixture"}),
-
 		func(p *Pass) []Diagnostic {
 			for _, file := range p.Files {
 				rel := p.Rel(file)

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -1311,7 +1311,6 @@ func testSEC10FixtureCatchesPrimaryWithoutHealth(t *testing.T) {
 	var violations []string
 	_ = Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/healthlistenerfixture"}),
-
 		func(p *Pass) []Diagnostic {
 			violations = append(violations, sec10Violations(p)...)
 			return nil

--- a/tools/archtest/session_revoked_field_access_test.go
+++ b/tools/archtest/session_revoked_field_access_test.go
@@ -110,7 +110,6 @@ func TestSessionRevokedFieldAccess_Upstream_01(t *testing.T) {
 		"./runtime/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -219,7 +218,6 @@ func TestSessionRevokedFieldAccess_BlindSpot_ReflectFieldByName(t *testing.T) {
 		"./runtime/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
 				return nil
@@ -265,7 +263,6 @@ func TestSessionRevokedFieldAccess_BlindSpot_UnsafePointerImport(t *testing.T) {
 		"./cells/...",
 		"./cmd/...",
 	}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Fset == nil {
 				return nil

--- a/tools/archtest/single_run_entry_test.go
+++ b/tools/archtest/single_run_entry_test.go
@@ -26,8 +26,11 @@
 // # Blind spots (per ai-robust.md Medium evidence requirement)
 //
 //   - A new Run* entry point declared under a different func type (method,
-//     closure assigned to a var) is not detected. Only top-level FuncDecl
-//     with no receiver is scanned.
+//     closure assigned to a var) is not detected by the MAIN scan, which only
+//     visits top-level receiver-less FuncDecls. This blind spot has its own
+//     reverse self-check: TestArchtestSingleRunEntry_BlindSpotProbe asserts
+//     neither form occurs in the façade (currently vacuous), so introducing one
+//     fires the probe.
 //   - This scan covers only direct-child non-test .go files of
 //     tools/archtest/ (the façade boundary). Sub-packages are not scanned
 //     (they are inaccessible to business archtest authors who import only
@@ -35,11 +38,13 @@
 //
 // Reverse self-check: the test verifies that [Run] and [RunStandardCellRules]
 // ARE present (non-empty allowlist) so a future removal of the main entry
-// point also fails CI.
+// point also fails CI; TestArchtestSingleRunEntry_BlindSpotProbe covers the
+// method / var-closure blind-spot forms.
 package archtest
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 	"testing"
 )
@@ -110,5 +115,75 @@ func TestArchtestSingleRunEntry(t *testing.T) {
 				"the allowlist entry is stale or the function was accidentally removed",
 				name)
 		}
+	}
+}
+
+// TestArchtestSingleRunEntry_BlindSpotProbe is the reverse self-check for the
+// first documented blind spot of ARCHTEST-SINGLE-RUN-ENTRY-01: a Run* entry
+// declared under a func type the main scan does not cover — a method
+// (`func (x X) RunFoo()`) or a package-level var bound to a func literal
+// (`var RunFoo = func(){...}`). The main test only scans top-level FuncDecls
+// with no receiver, so these two forms slip past it.
+//
+// Per ai-robust.md (each blind spot needs a reverse self-check asserting it does
+// NOT occur in production AST), this probe scans the façade for both forms and
+// asserts zero. It is currently vacuous (no such forms exist), which is exactly
+// the point: if a future change introduces a method or var-closure Run* entry,
+// this probe — not the main rule — fires, keeping the blind spot from going
+// silently live.
+func TestArchtestSingleRunEntry_BlindSpotProbe(t *testing.T) {
+	type hit struct {
+		rel, name, form string
+		line            int
+	}
+	var hits []hit
+	Run(t, AST(facadeScopeForArchtest(t)), func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			// Method-receiver form: exported Run* method.
+			EachInChildren[ast.FuncDecl](f, func(fn *ast.FuncDecl) {
+				if fn.Recv == nil || fn.Name == nil || !fn.Name.IsExported() {
+					return
+				}
+				if !strings.HasPrefix(fn.Name.Name, "Run") || runEntryAllowlist[fn.Name.Name] {
+					return
+				}
+				hits = append(hits, hit{
+					rel, fn.Name.Name, "method",
+					p.Fset.Position(fn.Name.Pos()).Line,
+				})
+			})
+			// Var-closure form: package-level exported Run* var bound to a func
+			// literal. EachInChildren[ast.ValueSpec] is the sanctioned depth-1
+			// walk over GenDecl.Specs (SCANNER-FRAMEWORK-USAGE-01 funnel).
+			EachInChildren[ast.GenDecl](f, func(gd *ast.GenDecl) {
+				if gd.Tok != token.VAR {
+					return
+				}
+				EachInChildren[ast.ValueSpec](gd, func(vs *ast.ValueSpec) {
+					hasFuncLit := false
+					EachInChildren[ast.FuncLit](vs, func(*ast.FuncLit) { hasFuncLit = true })
+					if !hasFuncLit {
+						return
+					}
+					EachInChildren[ast.Ident](vs, func(id *ast.Ident) {
+						if !id.IsExported() || !strings.HasPrefix(id.Name, "Run") ||
+							runEntryAllowlist[id.Name] {
+							return
+						}
+						hits = append(hits, hit{
+							rel, id.Name, "var-closure",
+							p.Fset.Position(id.Pos()).Line,
+						})
+					})
+				})
+			})
+		}
+		return nil
+	})
+	for _, h := range hits {
+		t.Errorf("ARCHTEST-SINGLE-RUN-ENTRY-01 blind-spot probe: %s:%d declares %s Run* entry %q — "+
+			"the main rule only scans top-level receiver-less FuncDecls, so this form would slip past it; "+
+			"express it as Run(t, <RunScope>, rule) instead", h.rel, h.line, h.form, h.name)
 	}
 }

--- a/tools/archtest/single_run_entry_test.go
+++ b/tools/archtest/single_run_entry_test.go
@@ -25,12 +25,14 @@
 //
 // # Blind spots (per ai-robust.md Medium evidence requirement)
 //
-//   - A new Run* entry point declared under a different func type (method,
-//     closure assigned to a var) is not detected by the MAIN scan, which only
-//     visits top-level receiver-less FuncDecls. This blind spot has its own
-//     reverse self-check: TestArchtestSingleRunEntry_BlindSpotProbe asserts
-//     neither form occurs in the façade (currently vacuous), so introducing one
-//     fires the probe.
+//   - A new Run* entry point declared under a different func type — a method
+//     (`func (x X) RunFoo()`) or a package-level func-typed var, whether a
+//     closure (`var RunFoo = func(){}`) or a function-value alias
+//     (`var RunFoo = Run`) — is not detected by the MAIN scan, which only visits
+//     top-level receiver-less FuncDecls. This blind spot has its own reverse
+//     self-check: TestArchtestSingleRunEntry_BlindSpotProbe (types-bound, so it
+//     catches the alias too) asserts none of these forms occur in the façade
+//     (currently vacuous), so introducing one fires the probe.
 //   - This scan covers only direct-child non-test .go files of
 //     tools/archtest/ (the façade boundary). Sub-packages are not scanned
 //     (they are inaccessible to business archtest authors who import only
@@ -39,12 +41,13 @@
 // Reverse self-check: the test verifies that [Run] and [RunStandardCellRules]
 // ARE present (non-empty allowlist) so a future removal of the main entry
 // point also fails CI; TestArchtestSingleRunEntry_BlindSpotProbe covers the
-// method / var-closure blind-spot forms.
+// method / var-func (closure + function-value alias) blind-spot forms.
 package archtest
 
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"strings"
 	"testing"
 )
@@ -121,23 +124,31 @@ func TestArchtestSingleRunEntry(t *testing.T) {
 // TestArchtestSingleRunEntry_BlindSpotProbe is the reverse self-check for the
 // first documented blind spot of ARCHTEST-SINGLE-RUN-ENTRY-01: a Run* entry
 // declared under a func type the main scan does not cover — a method
-// (`func (x X) RunFoo()`) or a package-level var bound to a func literal
-// (`var RunFoo = func(){...}`). The main test only scans top-level FuncDecls
-// with no receiver, so these two forms slip past it.
+// (`func (x X) RunFoo()`) or a package-level var of FUNCTION type, whether a
+// closure (`var RunFoo = func(){...}`) or a function-value ALIAS
+// (`var RunFoo = Run`). The main test only scans top-level receiver-less
+// FuncDecls, so all of these slip past it.
+//
+// The var leg is types-bound, not "value is a func literal": a Run* alias
+// `var RunFoo = Run` binds the existing Run function value and has no FuncLit
+// node, so an AST-only literal check would miss it. Resolving each declared name
+// through *types.Info and keeping only those whose type underlying is
+// *types.Signature catches both the closure and the alias while excluding a
+// non-callable `var RunCount int`. The probe therefore loads the façade typed
+// (Typed over ./tools/archtest, non-test = the facadeScopeForArchtest file set).
 //
 // Per ai-robust.md (each blind spot needs a reverse self-check asserting it does
-// NOT occur in production AST), this probe scans the façade for both forms and
-// asserts zero. It is currently vacuous (no such forms exist), which is exactly
-// the point: if a future change introduces a method or var-closure Run* entry,
-// this probe — not the main rule — fires, keeping the blind spot from going
-// silently live.
+// NOT occur in production), this probe asserts zero. It is currently vacuous (no
+// such forms exist), which is exactly the point: a future method or var-func
+// Run* entry fires this probe — not the main rule — keeping the blind spot from
+// going silently live.
 func TestArchtestSingleRunEntry_BlindSpotProbe(t *testing.T) {
 	type hit struct {
 		rel, name, form string
 		line            int
 	}
 	var hits []hit
-	Run(t, AST(facadeScopeForArchtest(t)), func(p *Pass) []Diagnostic {
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./tools/archtest"}), func(p *Pass) []Diagnostic {
 		for _, f := range p.Files {
 			rel := p.Rel(f)
 			// Method-receiver form: exported Run* method.
@@ -153,32 +164,33 @@ func TestArchtestSingleRunEntry_BlindSpotProbe(t *testing.T) {
 					p.Fset.Position(fn.Name.Pos()).Line,
 				})
 			})
-			// Var-closure form: package-level exported Run* var bound to a func
-			// literal. EachInChildren[ast.ValueSpec] is the sanctioned depth-1
-			// walk over GenDecl.Specs (SCANNER-FRAMEWORK-USAGE-01 funnel).
+			// Var-func form: package-level exported Run* var whose type is a
+			// function signature — a closure OR a function-value alias. go/types
+			// (not an AST FuncLit check) is required to catch `var RunFoo = Run`.
+			// EachInChildren[ast.ValueSpec] is the sanctioned depth-1 walk over
+			// GenDecl.Specs (SCANNER-FRAMEWORK-USAGE-01 funnel).
 			EachInChildren[ast.GenDecl](f, func(gd *ast.GenDecl) {
 				if gd.Tok != token.VAR {
 					return
 				}
 				EachInChildren[ast.ValueSpec](gd, func(vs *ast.ValueSpec) {
-					hasFuncLit := false
-					EachInChildren[ast.FuncLit](vs, func(*ast.FuncLit) { hasFuncLit = true })
-					if !hasFuncLit {
-						return
-					}
-					// Match only the declared names (vs.Names). EachInChildren is
-					// depth-1 so it never descends into the FuncLit body, but a
-					// bare-ident var Type (`var x RunType = func(){}`) would be a
-					// direct-child Ident too — ranging vs.Names is exact and avoids
-					// that spurious match. (`range vs.Names` over []*ast.Ident is
-					// SCANNER-FRAMEWORK-USAGE-01-safe: no AST-list type assertion.)
+					// Match only the declared names (vs.Names), resolved via
+					// *types.Info — ranging vs.Names over []*ast.Ident is
+					// SCANNER-FRAMEWORK-USAGE-01-safe (no AST-list type assertion).
 					for _, name := range vs.Names {
 						if !name.IsExported() || !strings.HasPrefix(name.Name, "Run") ||
 							runEntryAllowlist[name.Name] {
 							continue
 						}
+						obj := p.TypesInfo.Defs[name]
+						if obj == nil {
+							continue
+						}
+						if _, isFunc := obj.Type().Underlying().(*types.Signature); !isFunc {
+							continue
+						}
 						hits = append(hits, hit{
-							rel, name.Name, "var-closure",
+							rel, name.Name, "var-func",
 							p.Fset.Position(name.Pos()).Line,
 						})
 					}

--- a/tools/archtest/single_run_entry_test.go
+++ b/tools/archtest/single_run_entry_test.go
@@ -166,16 +166,22 @@ func TestArchtestSingleRunEntry_BlindSpotProbe(t *testing.T) {
 					if !hasFuncLit {
 						return
 					}
-					EachInChildren[ast.Ident](vs, func(id *ast.Ident) {
-						if !id.IsExported() || !strings.HasPrefix(id.Name, "Run") ||
-							runEntryAllowlist[id.Name] {
-							return
+					// Match only the declared names (vs.Names). EachInChildren is
+					// depth-1 so it never descends into the FuncLit body, but a
+					// bare-ident var Type (`var x RunType = func(){}`) would be a
+					// direct-child Ident too — ranging vs.Names is exact and avoids
+					// that spurious match. (`range vs.Names` over []*ast.Ident is
+					// SCANNER-FRAMEWORK-USAGE-01-safe: no AST-list type assertion.)
+					for _, name := range vs.Names {
+						if !name.IsExported() || !strings.HasPrefix(name.Name, "Run") ||
+							runEntryAllowlist[name.Name] {
+							continue
 						}
 						hits = append(hits, hit{
-							rel, id.Name, "var-closure",
-							p.Fset.Position(id.Pos()).Line,
+							rel, name.Name, "var-closure",
+							p.Fset.Position(name.Pos()).Line,
 						})
-					})
+					}
 				})
 			})
 		}

--- a/tools/archtest/slog_handler_sealed_funnel_test.go
+++ b/tools/archtest/slog_handler_sealed_funnel_test.go
@@ -810,7 +810,6 @@ func TestSlogHandlerSealedFunnel_A1_DetectsViolation(t *testing.T) {
 
 	diags := Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/testdata/slog_bare_handler_fixtures/external_violation"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/svctoken_caller_cell_test.go
+++ b/tools/archtest/svctoken_caller_cell_test.go
@@ -73,7 +73,6 @@ func TestSVCTOKEN_CALLER_CELL_REQUIRED_01(t *testing.T) {
 	var diags []Diagnostic
 	_ = Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()},
 		[]string{"./runtime/...", "./cells/...", "./cmd/...", "./examples/...", "./tests/..."}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -221,7 +220,6 @@ func TestSVCTOKEN_CALLER_CELL_REQUIRED_01_BuildTaggedFilesScanned_Wave5_RED(t *t
 	loadedFiles := map[string]bool{}
 	_ = Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()},
 		[]string{"./runtime/...", "./cells/...", "./cmd/...", "./examples/...", "./tests/..."}),
-
 		func(p *Pass) []Diagnostic {
 			for _, file := range p.Files {
 				loadedFiles[p.Rel(file)] = true

--- a/tools/archtest/taggroup_loop_no_typed_run_invariants.go
+++ b/tools/archtest/taggroup_loop_no_typed_run_invariants.go
@@ -339,11 +339,12 @@ func taggroupObjectOf(info *types.Info, id *ast.Ident) types.Object {
 // the typed-scope constructors in taggroupTypedScopeCtors
 // (Typed/Production/Fixture/StandaloneModule), or (b) an *ast.Ident bound
 // (file-level) to such a call — the scope-var-indirection form
-// `scope := Typed(...); Run(t, scope, ...)` (F2). Returns the line number of the
-// first matching Run CallExpr (first in preorder). Walks the entire subtree (no
-// early-return) — RangeStmt body sizes in archtest tests are small, so the
-// constant-factor cost is irrelevant; the API choice keeps the rule honest
-// about scanner usage.
+// `scope := Typed(...); Run(t, scope, ...)` (F2). Uses FindFirstInSubtree, so it
+// stops at the FIRST matching Run CallExpr (preorder) and returns its line
+// number — one offending Run is enough to flag the enclosing loop body. The
+// find-first scanner walker keeps the rule honest about scanner usage
+// (SCANNER-FRAMEWORK-USAGE-02 sanctions FindFirstInSubtree for this early-return
+// shape rather than an EachInSubtree + done-sentinel hand-roll).
 //
 // Both callee resolutions go through *types.Info (ResolvePackageRef), so the
 // qualified / dot-import / aliased forms of archtest.Run AND of the scope

--- a/tools/archtest/wrapper_location_test.go
+++ b/tools/archtest/wrapper_location_test.go
@@ -243,7 +243,6 @@ func TestCellRawInfraWrapperLocation01_ScannerDetectsViolation(t *testing.T) {
 	var violations []wrapperViolation
 	Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/wrapfixture/violation"}),
-
 		func(p *Pass) []Diagnostic {
 			violations = append(violations, scanWrapperViolationsFromPass(p)...)
 			return nil
@@ -304,7 +303,6 @@ func TestCellRawInfraWrapperLocation01_RejectsKernelCellSibling(t *testing.T) {
 	var violations []wrapperViolation
 	Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/wrapfixture/kernelcellsibling"}),
-
 		func(p *Pass) []Diagnostic {
 			violations = append(violations, scanWrapperViolationsFromPass(p)...)
 			return nil

--- a/tools/archtest/yaml_quote_funnel_test.go
+++ b/tools/archtest/yaml_quote_funnel_test.go
@@ -84,7 +84,6 @@ func TestYAMLQuoteFunnel_DetectsAliasBypass(t *testing.T) {
 
 	_ = Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/yamlquotefixture/"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != yamlquotefixturePkgPath {
 				return nil
@@ -132,7 +131,6 @@ func TestYAMLQuoteFunnel_DetectsLiteralBypass(t *testing.T) {
 
 	_ = Run(t, Fixture(FixtureOpts{Tests: false},
 		[]string{"./tools/archtest/internal/yamlquotefixture/"}),
-
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != yamlquotefixturePkgPath {
 				return nil


### PR DESCRIPTION
## Summary

承接 PR #1470（`#1037 §1d` single-Run collapse）的 code review，并修复 **#1500**（develop `tools/archtest` 整包编译破坏）。基于已合并 #1470 的 develop。

## 修复 #1500 — develop archtest 编译破坏（merge 撞车）

`#1037 §1d`（`be57075e2`）删除 `RunTyped*`，但 **#1477（早于 §1d 分支）合并后残留两处调用点**，导致 `tools/archtest` 整包测试编译失败（`undefined: RunTypedProduction / RunTypedFixture`）→ nightly / `make verify` / `go test ./tools/archtest` 全在 build 期红，**掩盖了所有 archtest 规则**（包不编译就跑不了任何测试）。

- `bootstrap_autowire_collector_funnel_test.go:170` → `Run(t, Production(...))`
- `bootstrap_autowire_collector_funnel_test.go:229` → `Run(t, Fixture(...))`

### #1500 point 3（防漂移）— 刻意不新增机制
- **「扩 `retired_run_entry_name_test.go` 扫残留调用点」自欺**：该 archtest 与违规文件同包，残留引用 = 整包编译失败 = 该 archtest 自身也编译不出，违规存在时根本无法执行（编译器严格强于 archtest）。
- **「go build 编译 gate」已存在**：`hack/verify-archtest-invariants.sh` 的 `go test ./tools/archtest -run …` 在 governance.yml 每个 PR + push-to-develop 编译整包。
- 真正残留 gap = **merge 撞车**（两 PR 各自对 base 绿，合并才坏），只能靠 branch-protection「require up-to-date branch」/ merge queue（仓库设置层，非 workflow）。

## #1470 review follow-ups（C1–C4）

- **C2** `pass.go` dispatch 诊断：显式 nil-scope guard（与 unknown-type default 分离）+ `%T` unknown-scope 消息 + SharedResolver/Production 错误带 root/opts/patterns + 空 patterns 消息点名 scope + Run godoc scope 选型向导。
- **C3** `single_run_entry_test.go`：`TestArchtestSingleRunEntry_BlindSpotProbe` 盲区反向自检（method / 包级 var-closure `Run*` 形态断言为 0，遵 ai-robust.md「每盲区配反向自检」）。
- **C1** stale `RunTyped*` → 新 `Run(t, Typed/Production/Fixture(...))`：3 处 archtest 注释 + 5 个规范性 ADR 段；ADR `202605141519` Decision block 就地重写 + line-7 重构（消除两套真理源，遵 ai-robust §ADR amendment 落地必查；历史时间点事实/Stage provenance 按 line-7 框定保留）。
- **C4** 清理 `#1037 §1d` `gofmt -r` 迁移残留散落空行（110 处 / 48 文件）。

> reviewer 提的「`AST(nil)` typed-nil → panic」前提有误——`Scope = scanner.Scope` 是非空值类型，`AST(nil)` 本就编译不过，故未加该 guard（核实 finding 后的修正）。

## ⚠️ 修复 #1500 后显形的 pre-existing develop 违规（非本 PR 引入，超范围）

修了编译破坏后 `tools/archtest` 才能跑，**暴露出一批被编译破坏掩盖的既有 develop 违规**（违规行均非本 PR 改动行，pristine develop 同样存在，仅因整包不编译而 nightly 一直跑不到）。本 PR **不**处理这些（多为近期 webhook/vault PR 的架构债，非机械修复）：

- `TestKernelInternalDAG` — `kernel/webhook imports kernel/outbox`（DAG allowlist）
- `TestOutboxHandleResultFactoryPreferred` — `kernel/webhook/dispatcher.go:191`
- `TestNO_MANUAL_CONTRACTSPEC_LITERAL_01` — `runtime/webhook/dispatch/dispatch.go:175`
- `TestEventuallyFunnel` — `adapters/vault/k8s_auth_e2e_integration_test.go:182`（#1468）
- `TestScannerFrameworkUsage01` — mqtt/saga/projection/webhook/bootstrap 多处（含 #1222 跟踪项）
- `TestAdaptersExportedTypesManagedResourceOrOptOut`

> 本 PR 是修复 nightly 的**必要第一步**：不修编译破坏，nightly 连编译都过不了，这些违规永远看不见也修不了。显形的违规建议各自开 issue / 归并 #1222 跟踪。

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./tools/archtest/... ./examples/...` 0 issues（含 gofumpt）
- [x] 本 PR 触碰的规则测试全绿：`TestArchtestSingleRunEntry` / `TestArchtestSingleRunEntry_BlindSpotProbe` / `TestRunScopeConstructorFunnel01` / `TestBootstrapAutoWireCollectorFunnel01*` / `TestRun_rejectsNilScope` / `TestExternalReasonLiteral`
- [x] 本 PR 改动**零新增** archtest 违规（失败均为上述 pre-existing develop 债，违规行非本 PR 改动行）

Closes #1500
Refs #1470 #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 补充轮：#1470 `RUNSCOPE-CONSTRUCTOR-FUNNEL-01` 同包 backstop 加固（commit 5）

针对 #1470 已合入 develop 的该 meta-archtest 的补充审查（逐条对照真实代码核验，非盲信报告）：

- **F2 `types.Unalias`（真 bug + 假 godoc 宣称）**：Go 1.23+ 默认 `gotypesalias=1`，`TypeOf(别名字面量{})` 是 `*types.Alias`，裸 `.(*types.Named)` 漏检同包 type-alias 字面量。`runScopeNamedType` 加 `types.Unalias`；旧 godoc 宣称「alias IS detected」现在才成立。
- **F1 零值 var-decl 形态**：CompositeLit-only 扫描漏 `var s typedRunScope; s.opts=…; Run(t,s,…)`。新增 Form-2 `ValueSpec` 扫描（仅 typed spec；`var s = typedRunScope{}` 仍由 Form 1 覆盖，无双计）。
- **F3 struct→ctor 精确配对**：flat allowlist → `map[scopeStruct]ctor`，`typedRunScope` 建在 `Fixture()` body 内现也判违规（live gate 为其反向检查）。
- **value-receiver godoc 论据修正**：旧称「`*typedRunScope` 不实现 RunScope、编译错误」**错**——value receiver 进 `*T` method set，`Run(t,&typedRunScope{},…)` 能编译、runtime default fatal；结论「not a bypass」仍成立（内层字面量被抓）。
- **RED fixture**：+alias 字面量（锁 Unalias）+var-decl（锁 Form 2）+非-scope var-decl green；exact-count 锁 **5→7**（少 Unalias 或 var-decl scan 任一 → count<7 → 红）。
- **单源**：`runScopeStructNames`+`runScopeSanctionedCtors` 合并为 `runScopeStructToCtor` 配对 map。
- **F6**：`bodyContainsTypedRun` godoc「walks entire subtree (no early-return)」→ 反映 `FindFirstInSubtree`（首个命中即停）。
- **F4** 本 PR 早先已修；**F5**（`docs/backlog/20260520/cap-14-tooling.md` stale RunTyped 指导）按决策**冻结快照不改**（新 backlog 走 GitHub Issues）。

**校验**：vet 0 / golangci-lint 0 / **live gate 生产 0 违规** + **FixtureCoverage count==7**（Unalias + var-decl scan 双双 load-bearing）+ taggroup 全绿。
