### PR TITLE
refactor(composition): 单源 ModuleResult 资源契约 + configcore 字段收口 [#1420][#1413]

### DIFF
--- a/adapters/prometheus/registration.go
+++ b/adapters/prometheus/registration.go
@@ -44,6 +44,12 @@ import (
 // outside the metrics.Provider abstraction — adapter-internal idempotent
 // register-or-reuse pattern, originally lifted from cmd/corebundle.
 //
+// Note: as of #1413 there is no production caller — configcore's stale-cipher
+// counter (its sole consumer) migrated to the kernel MetricsProvider. The export
+// is retained as the sanctioned bare-counter helper for future adapter-internal
+// use; its caller-allowlist (METRICS-ADAPTERPROM-CALLER-ALLOWLIST-01) is empty, so
+// a new caller must add its file there with justification.
+//
 // ref: kubernetes component-base/metrics/counter.go (idempotent registration pattern)
 func RegisterOrReuseCounter(reg prom.Registerer, opts prom.CounterOpts) (prom.Counter, error) {
 	c := promwrap.NewCounter(opts)

--- a/assemblies/corebundle/generated/metrics-schema.yaml
+++ b/assemblies/corebundle/generated/metrics-schema.yaml
@@ -191,6 +191,13 @@ metrics:
         - disposition
         - result
       file: cmd/corebundle/shared_deps_build.go
+    - name: config_stale_cipher_total
+      fqName: gocell_config_stale_cipher_total
+      namespace: gocell
+      type: counter
+      help: Number of config values read that are encrypted with a non-current key version.
+      labels: []
+      file: runtime/observability/metrics/config_stale_cipher.go
     - name: event_router_ready_wait_seconds
       fqName: gocell_event_router_ready_wait_seconds
       namespace: gocell
@@ -538,14 +545,6 @@ metrics:
         - cell
         - result
       file: runtime/observability/metrics/saga.go
-    - name: stale_cipher_total
-      fqName: gocell_config_stale_cipher_total
-      namespace: gocell
-      subsystem: config
-      type: counter
-      help: Number of config values read that are encrypted with a non-current key version.
-      labels: []
-      file: cmd/corebundle/configcore_key_provider.go
     - name: token_auth_healthy
       fqName: gocell_vault_token_auth_healthy
       namespace: gocell

--- a/cellmodules/accesscore/module.go
+++ b/cellmodules/accesscore/module.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ghbvf/gocell/cells/accesscore/configgetter"
 	accessmem "github.com/ghbvf/gocell/cells/accesscore/mem"
 	accesspg "github.com/ghbvf/gocell/cells/accesscore/postgres"
-	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/healthz"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -41,7 +40,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	refreshmem "github.com/ghbvf/gocell/runtime/auth/refresh/memstore"
 	"github.com/ghbvf/gocell/runtime/auth/session"
-	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/composition"
 	"github.com/ghbvf/gocell/runtime/state/cas"
 )
@@ -85,34 +83,34 @@ const bootstrapAppendDetachedTimeout = 2 * time.Second
 // the environment.
 func (m module) Provide(
 	_ context.Context, shared *composition.SharedDeps,
-) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
+) (composition.ModuleResult, error) {
 	creds, err := loadBootstrapCredentials(
 		os.Getenv("GOCELL_BOOTSTRAP_ADMIN_USERNAME"),
 		os.Getenv("GOCELL_BOOTSTRAP_ADMIN_PASSWORD"),
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 	if creds.Username == nil {
-		return nil, nil, nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+		return composition.ModuleResult{}, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			"GOCELL_BOOTSTRAP_ADMIN_USERNAME and GOCELL_BOOTSTRAP_ADMIN_PASSWORD are required "+
 				"to protect setup/admin endpoint")
 	}
 
 	accessOpts, sessionProto, err := buildAccessBaseOpts(shared)
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	innerSessionStore, storageOpts, err := resolveAccessStorageOpts(shared, sessionProto, accessOpts)
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 	accessOpts = storageOpts
 
 	sessionStore, err := wrapSessionStoreWithCache(innerSessionStore, shared, nil)
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 	accessOpts = append(accessOpts, accesscell.WithSessionStore(sessionStore))
 
@@ -139,19 +137,18 @@ func (m module) Provide(
 	// only after HTTP servers start (post-Init), so Load always sees non-nil.
 	cellAtomicPtr.Store(c)
 
-	// The bootstrap rate limiter spawns a cleanup goroutine, so it must be
-	// managed in two places (pg-cell-template Chapter 4 contract):
-	//   - opts: bootstrap.WithManagedResource so bootstrap.Run closes it at
-	//     phase10 shutdown during the normal run (the steady-state lifecycle).
-	//   - 3rd return value: so Builder.Build closes it (LIFO) if a *later*
-	//     module's Provide fails before bootstrap.Run starts (rollback).
-	// The same value flows through both; bootstrap registers it once (only the
-	// success path reaches bootstrap.Run), the rollback path only fires on
-	// pre-Run failure, so there is no double-close.
+	// The bootstrap rate limiter spawns a cleanup goroutine, so it is a
+	// ManagedResource. Return it ONLY in ModuleResult.Resources (single source,
+	// PR #591 / #1420): Builder.Build derives BOTH the steady-state
+	// bootstrap.WithManagedResource registration (phase10 LIFO Close on the
+	// normal run) AND the pre-Run rollback Close (if a later module's Provide
+	// fails before bootstrap.Run starts) from that one entry. The module does not
+	// call bootstrap.WithManagedResource itself (WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
 	limiterRes := bootstrapLimiterResource{lim: rlLimiter}
-	return c,
-		[]bootstrap.Option{bootstrap.WithManagedResource(limiterRes)},
-		[]kernellifecycle.ManagedResource{limiterRes}, nil
+	return composition.ModuleResult{
+		Cell:      c,
+		Resources: []kernellifecycle.ManagedResource{limiterRes},
+	}, nil
 }
 
 // buildAccessBaseOpts builds the base accesscore options and session protocol.

--- a/cellmodules/accesscore/module_test.go
+++ b/cellmodules/accesscore/module_test.go
@@ -50,10 +50,10 @@ func TestModule_Provide_MemMode(t *testing.T) {
 	ctx := context.Background()
 	shared := buildMemSharedDeps(t)
 
-	c, _, _, err := accesscore.Module().Provide(ctx, shared)
+	res, err := accesscore.Module().Provide(ctx, shared)
 	require.NoError(t, err)
-	require.NotNil(t, c)
-	assert.Equal(t, "accesscore", c.ID())
+	require.NotNil(t, res.Cell)
+	assert.Equal(t, "accesscore", res.Cell.ID())
 }
 
 // buildMemSharedDeps constructs a memory-mode *composition.SharedDeps suitable

--- a/cellmodules/accesscore/module_test.go
+++ b/cellmodules/accesscore/module_test.go
@@ -83,21 +83,19 @@ func buildMemSharedDeps(t *testing.T) *composition.SharedDeps {
 	require.NoError(t, err)
 
 	shared, err := composition.NewSharedDeps(composition.SharedDeps{
-		Clock:                  clk,
-		Topology:               topo,
-		JWTIssuer:              issuer,
-		JWTVerifier:            verifier,
-		MetricsProvider:        kernelmetrics.NopProvider{},
-		EventBus:               eb,
-		ConfigEventCollector:   obmetrics.NoopConfigEventCollector{},
-		EventbusCacheCollector: obmetrics.NoopEventbusCacheCollector{},
-		ConsumerClaimer:        claimer,
-		InternalHMACRing:       ring,
-		PrimaryHTTPAddr:        ":8080",
-		InternalHTTPAddr:       "127.0.0.1:9090",
-		HealthHTTPAddr:         "127.0.0.1:9091",
-		VerboseDisabled:        true,
-		ConfigStaleCipherInc:   func() {},
+		Clock:                clk,
+		Topology:             topo,
+		JWTIssuer:            issuer,
+		JWTVerifier:          verifier,
+		MetricsProvider:      kernelmetrics.NopProvider{},
+		EventBus:             eb,
+		ConfigEventCollector: obmetrics.NoopConfigEventCollector{},
+		ConsumerClaimer:      claimer,
+		InternalHMACRing:     ring,
+		PrimaryHTTPAddr:      ":8080",
+		InternalHTTPAddr:     "127.0.0.1:9090",
+		HealthHTTPAddr:       "127.0.0.1:9091",
+		VerboseDisabled:      true,
 	})
 	require.NoError(t, err)
 	return shared

--- a/cellmodules/auditcore/module.go
+++ b/cellmodules/auditcore/module.go
@@ -19,14 +19,11 @@ import (
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/cellmodules/cellsecrets"
 	auditcell "github.com/ghbvf/gocell/cells/auditcore"
-	"github.com/ghbvf/gocell/kernel/cell"
-	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/audit"
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
-	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/composition"
 )
 
@@ -47,25 +44,25 @@ func (module) ID() string { return "auditcore" }
 //   - GOCELL_AUDITCORE_CURSOR_KEY / *_PREVIOUS_KEY (cursor codec)
 func (m module) Provide(
 	ctx context.Context, shared *composition.SharedDeps,
-) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
+) (composition.ModuleResult, error) {
 	cursorCodec, auditProtocol, bootstrapProtocol, err := buildAuditProtocols(shared)
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	// Build the two ledger.Store instances (PG or mem).
 	auditcoreStore, bootstrapInnerStore, err := buildAuditStores(shared, auditProtocol, bootstrapProtocol)
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	// Run strict tail verify against the bootstrap chain at composition time.
 	bootstrapWrapped, err := audit.NewBootstrapLedgerStore(bootstrapInnerStore)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("wrap bootstrap audit store: %w", err)
+		return composition.ModuleResult{}, fmt.Errorf("wrap bootstrap audit store: %w", err)
 	}
 	if err := audit.VerifyBootstrapTailOnStartup(ctx, bootstrapWrapped, nil); err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	// C4 durable-mode fail-fast: in durable (postgres) mode, bootstrapWrapped
@@ -75,14 +72,14 @@ func (m module) Provide(
 	// Demo/memory mode allows nil (in-memory stores are always non-nil here
 	// anyway, but the guard is storage-mode scoped to mirror existing patterns).
 	if bootstrapWrapped == nil && shared.Topology.StorageBackend() == "postgres" {
-		return nil, nil, nil, fmt.Errorf("auditcore: bootstrap ledger store is nil in durable mode (postgres); " +
+		return composition.ModuleResult{}, fmt.Errorf("auditcore: bootstrap ledger store is nil in durable mode (postgres); " +
 			"this is a permanent misconfiguration — auditappendbootstrap would Reject all events")
 	}
 
 	// Build the read-side aggregator. auditquery reads across both chains.
 	multiStore, err := ledger.NewMultiStore(auditcoreStore, bootstrapInnerStore)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("audit multi-store: %w", err)
+		return composition.ModuleResult{}, fmt.Errorf("audit multi-store: %w", err)
 	}
 
 	auditOpts := []auditcell.Option{
@@ -111,7 +108,7 @@ func (m module) Provide(
 
 	c := auditcell.NewAuditCore(shared.Clock, auditOpts...)
 
-	return c, nil, nil, nil
+	return composition.ModuleResult{Cell: c}, nil
 }
 
 // buildAuditProtocols builds the cursor codec and both ledger protocols

--- a/cellmodules/auditcore/module_test.go
+++ b/cellmodules/auditcore/module_test.go
@@ -74,21 +74,19 @@ func buildMemSharedDeps(t *testing.T) *composition.SharedDeps {
 	require.NoError(t, err)
 
 	shared, err := composition.NewSharedDeps(composition.SharedDeps{
-		Clock:                  clk,
-		Topology:               topo,
-		JWTIssuer:              issuer,
-		JWTVerifier:            verifier,
-		MetricsProvider:        kernelmetrics.NopProvider{},
-		EventBus:               eb,
-		ConfigEventCollector:   obmetrics.NoopConfigEventCollector{},
-		EventbusCacheCollector: obmetrics.NoopEventbusCacheCollector{},
-		ConsumerClaimer:        claimer,
-		InternalHMACRing:       ring,
-		PrimaryHTTPAddr:        ":8080",
-		InternalHTTPAddr:       "127.0.0.1:9090",
-		HealthHTTPAddr:         "127.0.0.1:9091",
-		VerboseDisabled:        true,
-		ConfigStaleCipherInc:   func() {},
+		Clock:                clk,
+		Topology:             topo,
+		JWTIssuer:            issuer,
+		JWTVerifier:          verifier,
+		MetricsProvider:      kernelmetrics.NopProvider{},
+		EventBus:             eb,
+		ConfigEventCollector: obmetrics.NoopConfigEventCollector{},
+		ConsumerClaimer:      claimer,
+		InternalHMACRing:     ring,
+		PrimaryHTTPAddr:      ":8080",
+		InternalHTTPAddr:     "127.0.0.1:9090",
+		HealthHTTPAddr:       "127.0.0.1:9091",
+		VerboseDisabled:      true,
 	})
 	require.NoError(t, err)
 	return shared

--- a/cellmodules/auditcore/module_test.go
+++ b/cellmodules/auditcore/module_test.go
@@ -42,10 +42,10 @@ func TestModule_Provide_MemMode(t *testing.T) {
 	ctx := context.Background()
 	shared := buildMemSharedDeps(t)
 
-	c, _, _, err := auditcore.Module().Provide(ctx, shared)
+	res, err := auditcore.Module().Provide(ctx, shared)
 	require.NoError(t, err)
-	require.NotNil(t, c)
-	assert.Equal(t, "auditcore", c.ID())
+	require.NotNil(t, res.Cell)
+	assert.Equal(t, "auditcore", res.Cell.ID())
 }
 
 // buildMemSharedDeps constructs a memory-mode *composition.SharedDeps for tests.

--- a/cellmodules/configcore/module.go
+++ b/cellmodules/configcore/module.go
@@ -24,11 +24,8 @@ import (
 
 	"github.com/ghbvf/gocell/cellmodules/cellsecrets"
 	configcell "github.com/ghbvf/gocell/cells/configcore"
-	"github.com/ghbvf/gocell/kernel/cell"
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
-	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/composition"
 	"github.com/ghbvf/gocell/runtime/crypto"
 	"github.com/ghbvf/gocell/runtime/state/cas"
@@ -66,10 +63,11 @@ func Module(opts ...ModuleOption) composition.CellModule {
 func (*module) ID() string { return "configcore" }
 
 // Provide resolves all configcore-specific dependencies and returns the
-// constructed cell, bootstrap options, and provisional resources.
+// constructed cell, non-resource bootstrap options, and the single-source
+// ManagedResource list (Builder derives WithManagedResource + rollback from it).
 func (m *module) Provide(
 	_ context.Context, shared *composition.SharedDeps,
-) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
+) (composition.ModuleResult, error) {
 	// 1. Cursor codec.
 	cfgPrimary, cfgPrevious := cellsecrets.LoadCursorKeys("CONFIGCORE")
 	cursorCodec, err := cellsecrets.BuildCursorCodec(cellsecrets.CursorCodecConfig{
@@ -82,14 +80,14 @@ func (m *module) Provide(
 		Label:       "config",
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("configcore cursor codec: %w", err)
+		return composition.ModuleResult{}, fmt.Errorf("configcore cursor codec: %w", err)
 	}
 
 	// 2. KeyProvider (test override OR cmd-supplied via SharedDeps).
 	kp := m.resolveKeyProvider(shared)
 	vt, err := resolveValueTransformer(kp, shared.Topology.StorageBackend() == "postgres")
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	// 3. Stale-cipher increment callback (supplied by cmd via SharedDeps).
@@ -110,13 +108,13 @@ func (m *module) Provide(
 		},
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	// 5. CAS protocol (CAS-PROTOCOL-COMPOSITION-ROOT-01 archtest).
 	casProto, err := newConfigCoreCASProtocol()
 	if err != nil {
-		return nil, nil, nil, err
+		return composition.ModuleResult{}, err
 	}
 
 	baseOpts := []configcell.Option{
@@ -130,7 +128,7 @@ func (m *module) Provide(
 	c := configcell.NewConfigCore(shared.Clock, baseOpts...)
 
 	builtCell, opts, res := buildConfigCoreResult(c, kp, modResult)
-	return builtCell, opts, res, nil
+	return composition.ModuleResult{Cell: builtCell, Opts: opts, Resources: res}, nil
 }
 
 // resolveKeyProvider returns the test override when set, otherwise uses the

--- a/cellmodules/configcore/module.go
+++ b/cellmodules/configcore/module.go
@@ -6,14 +6,17 @@
 // and cellmodules/cellsecrets/. It must NOT be imported by cells/, runtime/, or
 // adapters/.
 //
-// # Key provider and stale-cipher counter routing
+// # Key provider routing
 //
-// The configcore key provider and stale-cipher prometheus counter are
-// constructed in cmd/corebundle (which may import adapters/vault and
-// github.com/prometheus/client_golang). They are passed to this module via
-// composition.SharedDeps.ConfigKeyProvider and
-// composition.SharedDeps.ConfigStaleCipherInc so that cellmodules/configcore
-// never imports those adapter-specific packages.
+// The configcore key provider is constructed in cmd/corebundle (which may import
+// adapters/vault and github.com/prometheus/client_golang) and passed via
+// composition.SharedDeps.ConfigKeyProvider, so cellmodules/configcore never
+// imports those adapter-specific packages. This is the last cmd-supplied
+// configcore dependency; its removal is gated on #885 (vault TransitMetrics →
+// kernel MetricsProvider). The stale-cipher and eventbus-cache collectors were
+// moved here (#1413): they route through the kernel MetricsProvider, so this
+// module self-builds them from SharedDeps.MetricsProvider via
+// runtime/observability/metrics without importing client_golang.
 //
 // ref: uber-go/fx fx.Module("configcore", ...) — self-contained module.
 package configcore
@@ -28,6 +31,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/composition"
 	"github.com/ghbvf/gocell/runtime/crypto"
+	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 	"github.com/ghbvf/gocell/runtime/state/cas"
 )
 
@@ -90,10 +94,18 @@ func (m *module) Provide(
 		return composition.ModuleResult{}, err
 	}
 
-	// 3. Stale-cipher increment callback (supplied by cmd via SharedDeps).
-	staleCipherInc := shared.ConfigStaleCipherInc
-	if staleCipherInc == nil {
-		staleCipherInc = func() {} // no-op fallback for tests without prom setup
+	// 3. Config observability collectors — self-built from the shared kernel
+	// MetricsProvider (#1413). These route through the kernel Provider (not raw
+	// github.com/prometheus/client_golang), so configcore owns them without
+	// tripping the "no client_golang in cellmodules" posture. Metric names are
+	// unchanged (gocell_config_stale_cipher_total / gocell_eventbus_cache_*).
+	staleCipherCollector, err := obmetrics.NewProviderConfigStaleCipherCollector(shared.MetricsProvider)
+	if err != nil {
+		return composition.ModuleResult{}, fmt.Errorf("configcore stale-cipher collector: %w", err)
+	}
+	ebcCollector, err := obmetrics.NewProviderEventbusCacheCollector(shared.MetricsProvider)
+	if err != nil {
+		return composition.ModuleResult{}, fmt.Errorf("configcore eventbus-cache collector: %w", err)
 	}
 
 	// 4. PG storage and cell options.
@@ -104,7 +116,11 @@ func (m *module) Provide(
 		metricsProvider:  shared.MetricsProvider,
 		valueTransformer: vt,
 		onStaleCipher: func(_, _, _ string) {
-			staleCipherInc()
+			// The onStaleCipher callback is ctx-less (it fires deep in the PG
+			// repo read path). Use a background ctx for the counter Inc — matching
+			// the prior raw-prometheus behavior, an unlabeled global counter with
+			// no trace correlation.
+			staleCipherCollector.RecordStaleCipher(context.Background())
 		},
 	})
 	if err != nil {
@@ -121,7 +137,7 @@ func (m *module) Provide(
 		configcell.WithCursorCodec(cursorCodec),
 		configcell.WithMetricsProvider(shared.MetricsProvider),
 		configcell.WithConfigEventCollector(shared.ConfigEventCollector),
-		configcell.WithEventbusCacheCollector(shared.EventbusCacheCollector),
+		configcell.WithEventbusCacheCollector(ebcCollector),
 		configcell.WithCASProtocol(casProto),
 	}
 	baseOpts = append(baseOpts, modResult.cellOptions...)

--- a/cellmodules/configcore/module.go
+++ b/cellmodules/configcore/module.go
@@ -116,10 +116,9 @@ func (m *module) Provide(
 		metricsProvider:  shared.MetricsProvider,
 		valueTransformer: vt,
 		onStaleCipher: func(_, _, _ string) {
-			// The onStaleCipher callback is ctx-less (it fires deep in the PG
-			// repo read path). Use a background ctx for the counter Inc — matching
-			// the prior raw-prometheus behavior, an unlabeled global counter with
-			// no trace correlation.
+			// onStaleCipher fires deep in the PG repo read path with no request
+			// context, so a background ctx is intentional here: this is an
+			// unlabeled global counter with no per-request trace correlation.
 			staleCipherCollector.RecordStaleCipher(context.Background())
 		},
 	})

--- a/cellmodules/configcore/module_test.go
+++ b/cellmodules/configcore/module_test.go
@@ -80,22 +80,22 @@ func buildMemSharedDeps(t *testing.T) *composition.SharedDeps {
 	require.NoError(t, err)
 
 	shared, err := composition.NewSharedDeps(composition.SharedDeps{
-		Clock:                  clk,
-		Topology:               topo,
-		JWTIssuer:              issuer,
-		JWTVerifier:            verifier,
-		MetricsProvider:        kernelmetrics.NopProvider{},
-		EventBus:               eb,
-		ConfigEventCollector:   obmetrics.NoopConfigEventCollector{},
-		EventbusCacheCollector: obmetrics.NoopEventbusCacheCollector{},
-		ConsumerClaimer:        claimer,
-		InternalHMACRing:       ring,
-		PrimaryHTTPAddr:        ":8080",
-		InternalHTTPAddr:       "127.0.0.1:9090",
-		HealthHTTPAddr:         "127.0.0.1:9091",
-		VerboseDisabled:        true,
+		Clock:                clk,
+		Topology:             topo,
+		JWTIssuer:            issuer,
+		JWTVerifier:          verifier,
+		MetricsProvider:      kernelmetrics.NopProvider{},
+		EventBus:             eb,
+		ConfigEventCollector: obmetrics.NoopConfigEventCollector{},
+		ConsumerClaimer:      claimer,
+		InternalHMACRing:     ring,
+		PrimaryHTTPAddr:      ":8080",
+		InternalHTTPAddr:     "127.0.0.1:9090",
+		HealthHTTPAddr:       "127.0.0.1:9091",
+		VerboseDisabled:      true,
 		// ConfigKeyProvider: nil — dev mode uses an explicit NoopTransformer.
-		ConfigStaleCipherInc: func() {},
+		// EventbusCacheCollector / ConfigStaleCipherInc removed (#1413): configcore
+		// self-builds them from MetricsProvider (NopProvider here).
 	})
 	require.NoError(t, err)
 	return shared

--- a/cellmodules/configcore/module_test.go
+++ b/cellmodules/configcore/module_test.go
@@ -48,10 +48,10 @@ func TestModule_Provide_MemMode(t *testing.T) {
 	ctx := context.Background()
 	shared := buildMemSharedDeps(t)
 
-	c, _, _, err := configcore.Module().Provide(ctx, shared)
+	res, err := configcore.Module().Provide(ctx, shared)
 	require.NoError(t, err)
-	require.NotNil(t, c)
-	assert.Equal(t, "configcore", c.ID())
+	require.NotNil(t, res.Cell)
+	assert.Equal(t, "configcore", res.Cell.ID())
 }
 
 // buildMemSharedDeps constructs a memory-mode *composition.SharedDeps for tests.

--- a/cellmodules/configcore/module_test.go
+++ b/cellmodules/configcore/module_test.go
@@ -2,6 +2,7 @@ package configcore_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -52,6 +53,32 @@ func TestModule_Provide_MemMode(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res.Cell)
 	assert.Equal(t, "configcore", res.Cell.ID())
+}
+
+// errCounterVecProvider is a metrics Provider whose CounterVec always fails,
+// used to exercise the configcore self-built collector error branches (#1413):
+// stale-cipher / eventbus-cache construction failures must propagate out of
+// Provide rather than being swallowed.
+type errCounterVecProvider struct{ kernelmetrics.NopProvider }
+
+func (errCounterVecProvider) CounterVec(kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
+	return nil, errors.New("counter registration failed")
+}
+
+// TestModule_Provide_CollectorRegistrationError verifies that when the kernel
+// MetricsProvider rejects collector registration, configcore.Provide fail-fasts
+// with a wrapped error (the self-built stale-cipher collector is constructed
+// before the cell, so its failure surfaces first).
+func TestModule_Provide_CollectorRegistrationError(t *testing.T) {
+	ctx := context.Background()
+	shared := buildMemSharedDeps(t)
+	// Swap in a Provider whose CounterVec fails; Provide builds the stale-cipher
+	// and eventbus-cache collectors from shared.MetricsProvider (#1413).
+	shared.MetricsProvider = errCounterVecProvider{}
+
+	_, err := configcore.Module().Provide(ctx, shared)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collector")
 }
 
 // buildMemSharedDeps constructs a memory-mode *composition.SharedDeps for tests.

--- a/cellmodules/configcore/storage.go
+++ b/cellmodules/configcore/storage.go
@@ -98,23 +98,25 @@ func buildConfigCorePostgresOpts(clk clock.Clock, cfg configCoreModuleConfig) (c
 	}, nil
 }
 
-// buildConfigCoreResult wires the provisional resources, relay opts, and
-// key-provider managed resource.
+// buildConfigCoreResult assembles the configcore module result: the cell, the
+// non-resource bootstrap opts (relay), and the single-source ManagedResource
+// list. When the KeyProvider is itself a ManagedResource (vault-transit) it is
+// returned ONLY in the resources slice — Builder.Build derives both the
+// steady-state bootstrap.WithManagedResource registration and the pre-Run
+// rollback from it. This function must NOT call bootstrap.WithManagedResource
+// (banned in cellmodules/ by WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
 func buildConfigCoreResult(
 	c *configcell.ConfigCore,
 	kp kcrypto.KeyProvider,
 	modResult configCoreModuleResult,
 ) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource) {
-	var opts []bootstrap.Option
-	var provisional []kernellifecycle.ManagedResource
+	opts := modResult.bootstrapOpts
 
-	opts = append(opts, modResult.bootstrapOpts...)
-
+	var resources []kernellifecycle.ManagedResource
 	if kpRes, ok := kp.(kernellifecycle.ManagedResource); ok {
-		opts = append(opts, bootstrap.WithManagedResource(kpRes))
-		provisional = append(provisional, kpRes)
+		resources = append(resources, kpRes)
 	}
-	return c, opts, provisional
+	return c, opts, resources
 }
 
 // buildConfigCorePGRelay constructs the configcore PG relay.

--- a/cellmodules/configcore/storage_internal_test.go
+++ b/cellmodules/configcore/storage_internal_test.go
@@ -54,37 +54,38 @@ var (
 	_ kernellifecycle.ManagedResource = fakeManagedKeyProvider{}
 )
 
-// TestBuildConfigCoreResult_ManagedKeyProvider_DualWrite is the F4 regression:
-// when the configcore KeyProvider implements ManagedResource it MUST be written
-// to BOTH channels — the provisional slice (pre-Run rollback) and a
-// bootstrap.Option (WithManagedResource → bootstrap registers its Probes() as
-// /readyz health probes and a LIFO teardown). Dropping either half silently
-// regresses: missing provisional leaks the provider on sibling-module failure;
-// missing the opt drops its readiness probe from /readyz and skips shutdown
-// Close. The opt→probe expansion itself is covered by bootstrap's
-// managed_resource_test.go; this test locks configcore's dual-write decision.
-func TestBuildConfigCoreResult_ManagedKeyProvider_DualWrite(t *testing.T) {
+// TestBuildConfigCoreResult_ManagedKeyProvider_SingleSourceResource locks the
+// single-source contract (PR #591 / #1420): when the configcore KeyProvider
+// implements ManagedResource it is returned ONLY in the Resources channel (3rd
+// return). buildConfigCoreResult no longer calls bootstrap.WithManagedResource
+// (banned in cellmodules/ by WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01) — the
+// Builder derives BOTH the steady-state WithManagedResource registration (its
+// Probes() become /readyz checks + a LIFO teardown) AND the pre-Run rollback
+// from this one Resources entry. Before #1420 the provider was written to two
+// channels and forgetting either half silently regressed (leak / dropped probe);
+// now both halves come from one source so they cannot diverge.
+func TestBuildConfigCoreResult_ManagedKeyProvider_SingleSourceResource(t *testing.T) {
 	kp := fakeManagedKeyProvider{}
 
-	_, opts, provisional := buildConfigCoreResult(nil, kp, configCoreModuleResult{})
+	_, opts, resources := buildConfigCoreResult(nil, kp, configCoreModuleResult{})
 
-	// Rollback channel: directly inspectable.
-	require.Len(t, provisional, 1, "managed KeyProvider must be returned as a provisional resource for rollback")
-	assert.Equal(t, kernellifecycle.ManagedResource(kp), provisional[0], "the provisional resource must be the KeyProvider itself")
+	// Single source: the managed KeyProvider is the one Resources entry.
+	require.Len(t, resources, 1, "managed KeyProvider must be returned as a Resources entry (single source)")
+	assert.Equal(t, kernellifecycle.ManagedResource(kp), resources[0], "the resource must be the KeyProvider itself")
 
-	// Happy-path channel: WithManagedResource is opaque, so assert exactly one
-	// bootstrap.Option was appended on top of the (empty) modResult opts.
-	require.Len(t, opts, 1, "managed KeyProvider must add exactly one WithManagedResource bootstrap.Option")
+	// No WithManagedResource is added here — the Builder derives it from
+	// Resources. With an empty configCoreModuleResult (no relay opt), opts is empty.
+	assert.Empty(t, opts, "buildConfigCoreResult must not call WithManagedResource; Builder funnels Resources")
 }
 
-// TestBuildConfigCoreResult_PlainKeyProvider_NoManagedWrite verifies the inverse:
-// a KeyProvider that is NOT a ManagedResource must not be registered in either
-// channel (no spurious probe, no rollback entry).
-func TestBuildConfigCoreResult_PlainKeyProvider_NoManagedWrite(t *testing.T) {
+// TestBuildConfigCoreResult_PlainKeyProvider_NoResource verifies the inverse:
+// a KeyProvider that is NOT a ManagedResource must not appear in the Resources
+// channel (no spurious probe, no rollback entry) and adds no option.
+func TestBuildConfigCoreResult_PlainKeyProvider_NoResource(t *testing.T) {
 	kp := fakePlainKeyProvider{}
 
-	_, opts, provisional := buildConfigCoreResult(nil, kp, configCoreModuleResult{})
+	_, opts, resources := buildConfigCoreResult(nil, kp, configCoreModuleResult{})
 
-	assert.Empty(t, provisional, "non-managed KeyProvider must not appear in the rollback channel")
-	assert.Empty(t, opts, "non-managed KeyProvider must not add a WithManagedResource option")
+	assert.Empty(t, resources, "non-managed KeyProvider must not appear in the Resources channel")
+	assert.Empty(t, opts, "non-managed KeyProvider must not add any option")
 }

--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -83,15 +83,26 @@ bootstrap.WithListener(cell.HealthListener, shared.HealthHTTPAddr,
 
 ## CellModule 接口
 
-每个模块实现 `composition.CellModule`，提供 Cell + bootstrap.Option + ManagedResource：
+每个模块实现 `composition.CellModule`，通过单一 `ModuleResult` 返回 Cell +
+非资源 bootstrap.Option + ManagedResource（#1420 单源化，取代旧 4 返回值）：
 
 ```go
+type ModuleResult struct {
+    Cell      cell.Cell                        // 构造的 Cell，成功时非 nil
+    Opts      []bootstrap.Option               // 非资源 option（如 WithRelay）
+    Resources []lifecycle.ManagedResource      // 本模块打开的资源（PG pool / vault…）
+}
+
 type CellModule interface {
     ID() string
-    Provide(ctx context.Context, shared *SharedDeps) (
-        cell.Cell, []bootstrap.Option, []lifecycle.ManagedResource, error)
+    Provide(ctx context.Context, shared *SharedDeps) (ModuleResult, error)
 }
 ```
+
+资源**只**放进 `Resources`，模块自身**不**调 `bootstrap.WithManagedResource`
+（由 `WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01` type-aware 守卫）；`Builder.Build`
+从 `Resources` 一处同时派生稳态注册（`WithManagedResource`）与 pre-Run rollback
+栈，两条生命周期通道不可能漂移（#1420 收口前的双写 bug）。
 
 Wave-1 #1423 删除了跨 module value handoff（`ModuleExports` + `in` 参数）；
 跨 cell 通信改为 event（contract-based）。不再经可变 `*SharedDeps` 字段或

--- a/cmd/corebundle/bundle_test.go
+++ b/cmd/corebundle/bundle_test.go
@@ -86,24 +86,21 @@ func buildTestSharedDepsAndLocals(t *testing.T) (*composition.SharedDeps, *cmdLo
 	require.NoError(t, err)
 	configEventCollector, err := obmetrics.NewProviderConfigEventCollector(ps.metricProvider)
 	require.NoError(t, err)
-	eventbusCacheCollector, err := obmetrics.NewProviderEventbusCacheCollector(ps.metricProvider)
-	require.NoError(t, err)
 
 	guard := newTestInternalGuard(t)
 
 	shared, err := composition.NewSharedDeps(composition.SharedDeps{
-		Clock:                  clock.Real(),
-		Topology:               mkTopo("", "memory", false),
-		JWTIssuer:              issuer,
-		JWTVerifier:            verifier,
-		MetricsProvider:        ps.metricProvider,
-		EventBus:               eb,
-		ConfigEventCollector:   configEventCollector,
-		EventbusCacheCollector: eventbusCacheCollector,
-		ConsumerClaimer:        idempotency.NewInMemClaimer(clock.Real()),
-		InternalHMACRing:       guard.ring,
-		InternalHTTPAddr:       "127.0.0.1:9090",
-		HealthHTTPAddr:         "127.0.0.1:9091",
+		Clock:                clock.Real(),
+		Topology:             mkTopo("", "memory", false),
+		JWTIssuer:            issuer,
+		JWTVerifier:          verifier,
+		MetricsProvider:      ps.metricProvider,
+		EventBus:             eb,
+		ConfigEventCollector: configEventCollector,
+		ConsumerClaimer:      idempotency.NewInMemClaimer(clock.Real()),
+		InternalHMACRing:     guard.ring,
+		InternalHTTPAddr:     "127.0.0.1:9090",
+		HealthHTTPAddr:       "127.0.0.1:9091",
 		// PR-A35: verbose endpoint is gated in every mode. Memory/dev tests
 		// just waive it — nothing here exercises the verbose body.
 		VerboseDisabled: true,
@@ -143,24 +140,21 @@ func newValidatedSharedDepsAndLocals(t *testing.T, topo bootstrap.Topology) (*co
 	require.NoError(t, err)
 	configEventCollector, err := obmetrics.NewProviderConfigEventCollector(ps.metricProvider)
 	require.NoError(t, err)
-	eventbusCacheCollector, err := obmetrics.NewProviderEventbusCacheCollector(ps.metricProvider)
-	require.NoError(t, err)
 
 	guard := newTestInternalGuard(t)
 
 	shared := &composition.SharedDeps{
-		Clock:                  clock.Real(),
-		Topology:               topo,
-		JWTIssuer:              issuer,
-		JWTVerifier:            verifier,
-		MetricsProvider:        ps.metricProvider,
-		EventBus:               eventbus.New(clock.Real()),
-		ConfigEventCollector:   configEventCollector,
-		EventbusCacheCollector: eventbusCacheCollector,
-		ConsumerClaimer:        idempotency.NewInMemClaimer(clock.Real()),
-		InternalHMACRing:       guard.ring,
-		InternalHTTPAddr:       "127.0.0.1:9090",
-		HealthHTTPAddr:         ":9091",
+		Clock:                clock.Real(),
+		Topology:             topo,
+		JWTIssuer:            issuer,
+		JWTVerifier:          verifier,
+		MetricsProvider:      ps.metricProvider,
+		EventBus:             eventbus.New(clock.Real()),
+		ConfigEventCollector: configEventCollector,
+		ConsumerClaimer:      idempotency.NewInMemClaimer(clock.Real()),
+		InternalHMACRing:     guard.ring,
+		InternalHTTPAddr:     "127.0.0.1:9090",
+		HealthHTTPAddr:       ":9091",
 		// PR-A35: verbose endpoint is now gated in every mode. A test-time
 		// token keeps the dev baseline valid; prod tests override via the
 		// mutate callback when they want to exercise the missing-token path.

--- a/cmd/corebundle/configcore_key_provider.go
+++ b/cmd/corebundle/configcore_key_provider.go
@@ -5,9 +5,6 @@ import (
 	"log/slog"
 	"strings"
 
-	prom "github.com/prometheus/client_golang/prometheus"
-
-	promadapter "github.com/ghbvf/gocell/adapters/prometheus"
 	adaptervault "github.com/ghbvf/gocell/adapters/vault"
 	"github.com/ghbvf/gocell/cellmodules/cellsecrets"
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -16,41 +13,12 @@ import (
 	"github.com/ghbvf/gocell/runtime/crypto"
 )
 
-// buildConfigCoreKeyProvider constructs the configcore KeyProvider and
-// the stale-cipher counter callback from the supplied providerName, key
-// material, prometheus registry, and vault-transit metrics factory.
-//
-// Supported providerName values: "local-aes", "vault-transit".
-// When providerName is empty:
-//   - memory mode → returns noKeyProvider sentinel (NoopTransformer path)
-//   - postgres mode → fails fast (unencrypted persistence is rejected)
-//
-// The stale-cipher callback is always non-nil: it increments a prometheus
-// counter when m.registry is non-nil, otherwise it is a silent no-op.
-func buildConfigCoreKeyProvider(
-	storageBackend, adapterMode, providerName, masterKey, prevMasterKey string,
-	clk clock.Clock,
-	registry *prom.Registry,
-	vaultMetrics func() (*adaptervault.TransitMetrics, error),
-) (kcrypto.KeyProvider, func(), error) {
-	kp, err := buildKeyProviderFromName(
-		storageBackend, adapterMode, providerName, masterKey, prevMasterKey, clk,
-		vaultMetrics,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	incFn, err := buildStaleCipherInc(registry)
-	if err != nil {
-		return nil, nil, fmt.Errorf("configcore: register stale_cipher counter: %w", err)
-	}
-	return kp, incFn, nil
-}
-
 // buildKeyProviderFromName is the adapter-aware key-provider factory that lives
-// in cmd/ rather than cellmodules/configcore because it imports adapters/vault
-// (vault-transit path).
+// in cmd/ rather than cellmodules/configcore because the vault-transit path
+// builds adapters/vault.TransitMetrics from a raw prometheus registry. The
+// stale-cipher counter (formerly built here) moved to cellmodules/configcore in
+// #1413 — it routes through the kernel MetricsProvider, not raw prometheus, so
+// configcore can own it. Migrating the vault key provider here is gated on #885.
 //
 // Returns nil (no provider) when providerName is empty and storageBackend is
 // not postgres. Callers must treat nil as "use NoopTransformer".
@@ -118,30 +86,4 @@ func buildCmdVaultTransitKeyProvider(
 	}
 	slog.Info("configcore: key provider initialized", slog.String("provider", "vault-transit"))
 	return kp, nil
-}
-
-// configStaleCipherOpts is the Prometheus counter descriptor for M3 stale-key
-// observability. Declared at package scope (not inline in buildStaleCipherInc)
-// so the metricschema reachable-typed-metrics tool can statically resolve the
-// CounterOpts literal — a function-local var is not a resolvable metric helper
-// argument (TestBuild_CorebundleCapturesReachableTypedMetrics).
-var configStaleCipherOpts = prom.CounterOpts{
-	Namespace: "gocell",
-	Subsystem: "config",
-	Name:      "stale_cipher_total",
-	Help:      "Number of config values read that are encrypted with a non-current key version.",
-}
-
-// buildStaleCipherInc registers (or reuses) the stale-cipher prometheus counter
-// against registry and returns an Inc callback. When registry is nil, returns a
-// silent no-op (acceptable in test environments).
-func buildStaleCipherInc(registry *prom.Registry) (func(), error) {
-	if registry == nil {
-		return func() {}, nil
-	}
-	counter, err := promadapter.RegisterOrReuseCounter(registry, configStaleCipherOpts)
-	if err != nil {
-		return nil, err
-	}
-	return counter.Inc, nil
 }

--- a/cmd/corebundle/configcore_key_provider_test.go
+++ b/cmd/corebundle/configcore_key_provider_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"testing"
 
-	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -63,47 +62,8 @@ func TestBuildKeyProviderFromName_LocalAES(t *testing.T) {
 	assert.NotNil(t, kp)
 }
 
-// TestBuildStaleCipherInc_NilRegistryNoop verifies the stale-cipher callback is
-// always non-nil and is a safe silent no-op when no registry is supplied.
-func TestBuildStaleCipherInc_NilRegistryNoop(t *testing.T) {
-	inc, err := buildStaleCipherInc(nil)
-
-	require.NoError(t, err)
-	require.NotNil(t, inc)
-	assert.NotPanics(t, inc, "nil-registry callback must be a safe no-op")
-}
-
-// TestBuildStaleCipherInc_RegistersAndCounts is the stale-cipher registration
-// regression (F3): with a registry the counter must be registered and the
-// returned callback must increment the gocell_config_stale_cipher_total series.
-func TestBuildStaleCipherInc_RegistersAndCounts(t *testing.T) {
-	registry := prom.NewRegistry()
-
-	inc, err := buildStaleCipherInc(registry)
-	require.NoError(t, err)
-	require.NotNil(t, inc)
-
-	inc()
-	inc()
-
-	assert.InDelta(t, 2.0, gatherCounterValue(t, registry, "gocell_config_stale_cipher_total"), 1e-9,
-		"stale-cipher callback must increment the registered counter")
-}
-
-// gatherCounterValue gathers registry and returns the value of the named counter
-// metric family. Fails the test if the family is absent.
-func gatherCounterValue(t *testing.T, registry *prom.Registry, name string) float64 {
-	t.Helper()
-	mfs, err := registry.Gather()
-	require.NoError(t, err)
-	for _, mf := range mfs {
-		if mf.GetName() != name {
-			continue
-		}
-		metrics := mf.GetMetric()
-		require.NotEmpty(t, metrics, "metric family %q has no samples", name)
-		return metrics[0].GetCounter().GetValue()
-	}
-	t.Fatalf("metric family %q not found in registry (counter not registered)", name)
-	return 0
-}
+// Stale-cipher counter coverage moved to
+// runtime/observability/metrics/config_stale_cipher_test.go in #1413 (the counter
+// is now built by configcore via the kernel MetricsProvider, not by a raw
+// prometheus registry here). The former TestBuildStaleCipherInc_* tests +
+// gatherCounterValue helper were removed with buildStaleCipherInc.

--- a/cmd/corebundle/integration_testhelpers_test.go
+++ b/cmd/corebundle/integration_testhelpers_test.go
@@ -152,12 +152,12 @@ func buildConfigCoreCellFromShared(
 	t testing.TB, ctx context.Context, shared *composition.SharedDeps,
 ) configCoreProvideResult {
 	t.Helper()
-	c, opts, res, err := cellmodulesconfigcore.Module().Provide(ctx, shared)
+	mr, err := cellmodulesconfigcore.Module().Provide(ctx, shared)
 	require.NoError(t, err, "cellmodules/configcore.Module().Provide must succeed")
-	require.NotNil(t, c, "configcore cell must be non-nil")
+	require.NotNil(t, mr.Cell, "configcore cell must be non-nil")
 	return configCoreProvideResult{
-		Cell:          c,
-		BootstrapOpts: opts,
-		Resources:     res,
+		Cell:          mr.Cell,
+		BootstrapOpts: mr.Opts,
+		Resources:     mr.Resources,
 	}
 }

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -104,15 +104,16 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*composition.SharedDeps, *cmdLo
 	locals.redisClient = replay.RedisClient
 	locals.initVaultMetricsFactory()
 
-	// Build configcore key provider + stale-cipher counter callback.
-	// These live in cmd because they import adapters/vault + prometheus which
-	// must not reach runtime/composition or cellmodules/configcore.
+	// Build configcore key provider. It lives in cmd because the vault-transit
+	// path builds adapters/vault.TransitMetrics from a raw prometheus registry
+	// (migrating it into configcore is gated on #885). The stale-cipher counter
+	// moved to cellmodules/configcore in #1413 — it routes through the kernel
+	// MetricsProvider, so configcore self-builds it.
 	cfgProviderName, cfgMasterKey, cfgPrevMasterKey := cellsecrets.LoadConfigCoreKeyProvider()
-	cfgKeyProvider, cfgStaleCipherInc, err := buildConfigCoreKeyProvider(
+	cfgKeyProvider, err := buildKeyProviderFromName(
 		topo.StorageBackend(), adapterMode,
 		cfgProviderName, cfgMasterKey, cfgPrevMasterKey,
 		clk,
-		metricsDeps.PromStack.registry,
 		locals.vaultTransitMetrics,
 	)
 	if err != nil {
@@ -123,26 +124,24 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*composition.SharedDeps, *cmdLo
 	// platform cell modules). Prometheus adapter types, internalGuard, and
 	// consumerClaimerKind stay in cmdLocals.
 	compShared, err := composition.NewSharedDeps(composition.SharedDeps{
-		Clock:                  clk,
-		Topology:               topo,
-		JWTIssuer:              jwt.issuer,
-		JWTVerifier:            jwt.verifier,
-		MetricsProvider:        metricsDeps.PromStack.metricProvider,
-		EventBus:               eb,
-		ConfigEventCollector:   metricsDeps.ConfigEventCollector,
-		EventbusCacheCollector: metricsDeps.EventbusCacheCollector,
-		ConsumerClaimer:        replay.ConsumerClaimer,
-		InternalHMACRing:       guard.ring,
-		PrimaryHTTPAddr:        primaryAddr,
-		InternalHTTPAddr:       internalAddr,
-		HealthHTTPAddr:         healthAddr,
-		HealthLocalOnly:        healthLocalOnly,
-		MetricsToken:           metricsToken,
-		VerboseToken:           verboseToken,
-		VerboseDisabled:        verboseDisabled,
-		ProjectRoot:            os.Getenv("GOCELL_PROJECT_ROOT"),
-		ConfigKeyProvider:      cfgKeyProvider,
-		ConfigStaleCipherInc:   cfgStaleCipherInc,
+		Clock:                clk,
+		Topology:             topo,
+		JWTIssuer:            jwt.issuer,
+		JWTVerifier:          jwt.verifier,
+		MetricsProvider:      metricsDeps.PromStack.metricProvider,
+		EventBus:             eb,
+		ConfigEventCollector: metricsDeps.ConfigEventCollector,
+		ConsumerClaimer:      replay.ConsumerClaimer,
+		InternalHMACRing:     guard.ring,
+		PrimaryHTTPAddr:      primaryAddr,
+		InternalHTTPAddr:     internalAddr,
+		HealthHTTPAddr:       healthAddr,
+		HealthLocalOnly:      healthLocalOnly,
+		MetricsToken:         metricsToken,
+		VerboseToken:         verboseToken,
+		VerboseDisabled:      verboseDisabled,
+		ProjectRoot:          os.Getenv("GOCELL_PROJECT_ROOT"),
+		ConfigKeyProvider:    cfgKeyProvider,
 	})
 	if err != nil {
 		slog.Warn("corebundle: SharedDeps validation failed",

--- a/cmd/corebundle/shared_deps_build.go
+++ b/cmd/corebundle/shared_deps_build.go
@@ -24,16 +24,18 @@ type sharedReplayDeps struct {
 }
 
 type sharedMetricsDeps struct {
-	PromStack              promStack
-	ConfigEventCollector   obmetrics.ConfigEventCollector
-	EventbusCacheCollector obmetrics.EventbusCacheCollector
+	PromStack            promStack
+	ConfigEventCollector obmetrics.ConfigEventCollector
 }
 
 // buildSharedMetricsDeps assembles framework-level always-on metric collectors
-// (config events, eventbus cache). Provider-conditional metrics (vault) live
-// in dedicated lazy methods on cmdLocals (initVaultMetricsFactory) so deployments
-// that don't use the corresponding backend don't pollute their scrape footprint
-// with always-zero series.
+// (config events). The eventbus-cache and stale-cipher collectors moved to
+// cellmodules/configcore (#1413) — they are configcore-specific and route
+// through the kernel MetricsProvider, so configcore self-builds them.
+// Provider-conditional metrics (vault) live in dedicated lazy methods on
+// cmdLocals (initVaultMetricsFactory) so deployments that don't use the
+// corresponding backend don't pollute their scrape footprint with always-zero
+// series.
 //
 // Failure here is composition-root fatal (LoadSharedDepsFromEnv returns the
 // error and the process exits); no LIFO rollback needed because every
@@ -47,14 +49,9 @@ func buildSharedMetricsDeps() (sharedMetricsDeps, error) {
 	if err != nil {
 		return sharedMetricsDeps{}, fmt.Errorf("build config event metrics collector: %w", err)
 	}
-	eventbusCacheCollector, err := obmetrics.NewProviderEventbusCacheCollector(ps.metricProvider)
-	if err != nil {
-		return sharedMetricsDeps{}, fmt.Errorf("build eventbus cache metrics collector: %w", err)
-	}
 	return sharedMetricsDeps{
-		PromStack:              ps,
-		ConfigEventCollector:   configEventCollector,
-		EventbusCacheCollector: eventbusCacheCollector,
+		PromStack:            ps,
+		ConfigEventCollector: configEventCollector,
 	}, nil
 }
 

--- a/docs/architecture/202605311000-1085-adr-cellmodule-composition-public-api.md
+++ b/docs/architecture/202605311000-1085-adr-cellmodule-composition-public-api.md
@@ -198,7 +198,10 @@ Enforcement 演进：
 **#1413（configcore 字段收口）**：`SharedDeps` 移除 `EventbusCacheCollector`（required）+ `ConfigStaleCipherInc`（optional）两个 configcore 专属字段——configcore 经 kernel `MetricsProvider` 用 `obmetrics.NewProviderEventbusCacheCollector` / `NewProviderConfigStaleCipherCollector` 自建（这两个 collector 走 kernel Provider，非 raw `client_golang`，不违反「cellmodules 不 import client_golang」治理姿态）。
 
 威胁/正确性再评：
-- **metric 契约不变**：`gocell_config_stale_cipher_total` / `gocell_eventbus_cache_tombstone_evicted_total` 的 fqName/label 与迁移前字节一致（仅 metricschema 的构造点 `file` 字段从 cmd/ 移到 `runtime/observability/metrics/`，且因移入 shared 包，现与 sibling `eventbus_cache` 一样出现在全部 assembly 的 metrics-schema，非仅 corebundle）。无 wire 改名分支。
+- **Prometheus wire 不变，但 generated metrics-schema 是可见 contract 载体且本 PR 改了它**（F5 披露补全——原表述只说「wire 名不变」不完整）：`gocell_config_stale_cipher_total` / `gocell_eventbus_cache_tombstone_evicted_total` 的 **fqName（Prometheus series 名）+ label 与迁移前字节一致**——运维侧按 series 名 key 的 dashboard/alert 不受影响。但 `gocell generate metrics-schema` 派生的 golden（contract-fanout 5 载体之一、消费方可读的 inventory）有两类**可感知**变化：
+  1. **corebundle**：schema `name` 字段由 `stale_cipher_total` **rename** 为 `config_stale_cipher_total`（新 Provider collector `Name="config_stale_cipher_total"`，旧 raw-prom 为 `Subsystem="config" Name="stale_cipher_total"`；二者 fqName 同为 `gocell_config_stale_cipher_total`），外加 `file` 字段从 `cmd/` 移到 `runtime/observability/metrics/`。
+  2. **examples/iotdevice / orderfulfillment / todoorder**：collector 移入 shared `runtime/observability/metrics` 包后，`config_stale_cipher_total` 成为这三个 assembly schema 的**净新增条目**（迁移前不在其 inventory），与 sibling `eventbus_cache_tombstone_evicted_total` 同行为。
+  4 份 golden 已 `gocell generate metrics-schema --all` regen + `go test ./tools/metricschema/...` 绿；无 wire 改名分支。
 - **无双注册**：两 collector 各仅 configcore 消费；configcore 自建一次 + corebundle 停建 = 恰一次。
 - **`ConfigEventCollector` 前提纠正**：原表述「configcore 专属」有误——它由 accesscore + configcore + corebundle config-event middleware 共同消费且 `Validate` required，是真·跨 cell 字段，**保留**在 `SharedDeps`。
 - **`ConfigKeyProvider` 残留（唯一未收口字段）**：vault-transit 路径经 `adapters/vault.TransitMetrics`（raw prometheus registry），受 `adapterPromCallerAllowlist` 姿态阻挡，configcore 自建被 **#885**（vault TransitMetrics → kernel Provider）gate；#885 落地后该字段随之移入 configcore，`SharedDeps` 即完全 cell-agnostic。`#1413` 保持 open 跟踪此残留。

--- a/docs/architecture/202605311000-1085-adr-cellmodule-composition-public-api.md
+++ b/docs/architecture/202605311000-1085-adr-cellmodule-composition-public-api.md
@@ -23,7 +23,8 @@
 
 | 类型 | 职责 |
 |---|---|
-| `CellModule` | 接口：`ID() string` + `Provide(ctx, *SharedDeps) (cell.Cell, []Option, []ManagedResource, error)` |
+| `CellModule` | 接口：`ID() string` + `Provide(ctx, *SharedDeps) (ModuleResult, error)`（出参形态见 `ModuleResult`，Amendment 2026-06-03 #1420 单源化） |
+| `ModuleResult` | 结构体 `{Cell cell.Cell; Opts []bootstrap.Option; Resources []lifecycle.ManagedResource}`——`Provide` 的单源出参；Builder 从 `Resources` 派生 happy-path `WithManagedResource` + pre-Run rollback 两条通道（Amendment 2026-06-03 #1420） |
 | `SharedDeps` | 跨 cell 共享依赖的公开 bag（接口字段，无 adapter 具体类型）；**sealed construction**——经 `NewSharedDeps(...)` 构造盖 marker，`Build` 拒未盖戳实例 |
 | `Builder` | `New() / With(...) / Build(ctx, *SharedDeps, RuntimeOptionsFunc) (*App, error)`；`Build` 校验 marker + `runtimeOptsFn` 非 nil |
 | `App` | `Run(ctx) error`（委托 bootstrap.New(...).Run） |
@@ -31,7 +32,9 @@
 
 `SharedDeps` 字段全部为接口或 kernel/runtime 类型（`kernelmetrics.Provider`、`idempotency.Claimer`、`*auth.JWTIssuer` 等），**不包含**任何 `adapters/prometheus` 或 `prometheus/client_golang` 具体类型，使 `runtime/composition` 不向 adapters/ 引入依赖。
 
-**Amendment 2026-06-02 #1423**：`CellModule.Provide` 签名已从 `Provide(ctx, *SharedDeps, in ModuleExports) (cell.Cell, ModuleExports, []bootstrap.Option, []ManagedResource, error)` 简化为 `Provide(ctx, *SharedDeps) (cell.Cell, []bootstrap.Option, []ManagedResource, error)`。`ModuleExports` 类型已完全删除（详见本文末尾 §Amendment 2026-06-02）。
+**Amendment 2026-06-02 #1423**：`CellModule.Provide` 签名已从 `Provide(ctx, *SharedDeps, in ModuleExports) (cell.Cell, ModuleExports, []bootstrap.Option, []ManagedResource, error)` 简化为 `Provide(ctx, *SharedDeps) (cell.Cell, []bootstrap.Option, []ManagedResource, error)`。`ModuleExports` 类型已完全删除（详见 §Amendment 2026-06-02）。
+
+**Amendment 2026-06-03 #1420 / #1413**：`Provide` 出参进一步收口为单一 `ModuleResult` 结构体——`Provide(ctx, *SharedDeps) (ModuleResult, error)`，`ModuleResult{Cell, Opts, Resources}`。资源生命周期改为**单源**：模块只在 `Resources` 列资源，`Builder.Build` 从该一处同时派生 happy-path `bootstrap.WithManagedResource` 注册与 pre-Run rollback 栈，消除原「同一资源双写 opts + provisional」漂移面。同时（#1413）`SharedDeps` 移除两个 configcore 专属字段（`EventbusCacheCollector` / `ConfigStaleCipherInc`），configcore 经 kernel `MetricsProvider` 自建（详见本文末尾 §Amendment 2026-06-03）。
 
 ### 新建 `cellmodules/` Composition Root 层
 
@@ -95,7 +98,8 @@ composition.New().
 | prom 构造只在允许位置调用 | archtest `PROM-CALLER-*`（nightly CI allowlist 含 cellmodules/） | Medium（同上） |
 | `Build()` error-first，无 Must | type system（函数签名，无 MustBuild 导出符号） | Hard |
 | `cellmodules/` 独立层分类（`LayerCellModules = "cellmodules"`，区别于 `LayerCmd`） | `kernel/depgraph/layer.go` + `tools/archtest/archtest_test.go` LAYER-06 豁免扩展 | Medium（archtest LAYER-06，nightly CI） |
-| `CellModule.Provide` 签名冻结：2 入参（context.Context, *SharedDeps）/ 4 出参（cell.Cell, []Option, []ManagedResource, error），无跨 module 值传递通道 | archtest `MODULE-PROVIDE-NO-VALUE-HANDOFF-01`（`tools/archtest/module_provide_signature_frozen_test.go`）——reflect 冻结接口方法签名；重新引入 handoff 通道 = 签名变 → CI 红 | **Hard**（reflect interface method 签名；重引入 handoff 使签名变，archtest pin 即断——上下游均 Hard） |
+| `CellModule.Provide` 签名冻结：2 入参（context.Context, *SharedDeps）/ 2 出参（ModuleResult, error）+ `ModuleResult` 字段集冻结 `{Cell, Opts, Resources}`，无跨 module 值传递通道（Amendment 2026-06-03 #1420 由 4-out 收口为 ModuleResult） | archtest `MODULE-PROVIDE-NO-VALUE-HANDOFF-01`（`tools/archtest/module_provide_signature_frozen_test.go`）——reflect 冻结接口方法签名 + ModuleResult struct 字段（NumField()==3 + 字段名/类型）；重新引入 handoff 字段/通道 = 形态变 → CI 红 | **Hard**（reflect interface method 签名 + struct 字段集；重引入 handoff 使形态变，archtest pin 即断——上下游均 Hard） |
+| cellmodules/ 不得调 `bootstrap.WithManagedResource`（资源经 `ModuleResult.Resources` 单源，Builder 是唯一漏斗） | archtest `WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01`（`tools/archtest/withmanagedresource_cellmodule_funnel_test.go`）（Amendment 2026-06-03 #1420 新增） | 下游 **Hard**（cellmodules 内零容忍 caller-ban）/ 上游 **Medium**（Go 无法令「调某导出 func」编译不可表达，同 #851/#893/#1282 天花板） |
 
 **注**：`cellmodules/` 与 `cmd/` 同属 composition-root 层，既有 composition-root archtests（cas/session/ledger 协议位置、wrapper 调用点）已通过 `cellmodules/` 前缀覆盖，不存在扫描盲区。
 
@@ -156,7 +160,7 @@ composition.New().
    - **新**：accesscore observer 调 `setup.Service.RecordBootstrapAuthFail`，在 tx 内 emit `event.auth.bootstrap-failed.v1`（持久 L2 outbox）→ relay 异步投递 → auditcore `auditappendbootstrap` subscriber 消费 → `AppendBootstrapAuthFail` 写 bootstrap-namespace ledger。
 4. `*audit.BootstrapLedgerStore` 类型保留，现由 auditcore cell 通过 `auditcell.WithBootstrapStore(bootstrapWrapped)` 在 auditcore 内部持有（不再 export）。Namespace/HMAC 隔离保持不变（独立 `"bootstrap"` namespace + 独立 HMAC key `GOCELL_AUDIT_BOOTSTRAP_HMAC_KEY`，见 ADR-1121）。
 5. **archtest 变更**：
-   - **新增** `MODULE-PROVIDE-NO-VALUE-HANDOFF-01`（`tools/archtest/module_provide_signature_frozen_test.go`）：Hard，reflect 冻结 `CellModule.Provide` 签名（2 入参 / 4 出参）——重新引入跨 module 值传递通道必须改签名，archtest 即断。
+   - **新增** `MODULE-PROVIDE-NO-VALUE-HANDOFF-01`（`tools/archtest/module_provide_signature_frozen_test.go`）：Hard，reflect 冻结 `CellModule.Provide` 签名（2 入参 / 出参——#1423 时为 4-out，后经 #1420 收口为 `ModuleResult` 2-out + struct 字段集冻结，见 §Amendment 2026-06-03）——重新引入跨 module 值传递通道必须改形态，archtest 即断。
    - **退役** `MODULE-ORDER-AUDITCORE-BEFORE-ACCESSCORE-01`：事件消费者经 EventRouter 路由，Provide 时不存在顺序依赖，前提消失。
    - **退役** `BOOTSTRAP-AUDIT-OBSERVER-FUNNEL-{DOWNSTREAM-HARD,UPSTREAM-MEDIUM}-01`：observer 不再写 ledger；emit 路径由 `EMIT-DECL-COVER-01`（已存在）+ event contract + auditcore subscriber conformance test 覆盖。
 
@@ -178,3 +182,29 @@ composition.New().
 - ADR-1121 `docs/architecture/202605270230-1121-audit-chain-bootstrap-namespace-isolation.md`（bootstrap namespace 隔离原始决策）
 - Archtest `MODULE-PROVIDE-NO-VALUE-HANDOFF-01`：`tools/archtest/module_provide_signature_frozen_test.go`（符号清单与盲区清单活在该文件的 package godoc）
 - Plan：`.claude/plans/1423-issues-foamy-orbit.md`（设计裁决历程 + HTTP 方案被否原因 + DEP-02 环分析）
+
+---
+
+## Amendment 2026-06-03 #1420 / #1413 — 单源 ModuleResult + configcore 字段收口
+
+**#1420（资源双写单源化）**：`CellModule.Provide` 原出参 `(cell.Cell, []bootstrap.Option, []ManagedResource, error)` 要求每个模块把同一个 `ManagedResource` 写进**两条**通道——`opts` 经 `bootstrap.WithManagedResource`（happy-path probe/worker/LIFO-Close）+ 第 3 返回值 `provisional`（pre-Run rollback）。双写仅靠 godoc 约定（Soft），漏写任一半 → 资源泄漏或 /readyz 缺 probe。
+
+收口为单一 `ModuleResult{Cell, Opts, Resources}`：模块只在 `Resources` 列资源，`Builder.Build` 从该一处**同时**派生 `WithManagedResource` 注册（`managedResourceOpts` 助手）与 provisional rollback 栈，两通道结构上不可能分叉。模块禁止自行调 `bootstrap.WithManagedResource`（cellmodules 内由 `WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01` 零容忍拦截）。
+
+Enforcement 演进：
+- `MODULE-PROVIDE-NO-VALUE-HANDOFF-01` 由「reflect 冻结 4-out 返回列表」升级为「冻结 2-out（`ModuleResult`, error）+ `ModuleResult` struct 字段集（`NumField()==3` + 字段名 `{Cell,Opts,Resources}` + 类型）」。**威胁矩阵强化**：原 #1423 矩阵「accesscore 拿到 nil BootstrapLedgerStore」「进程内跨 cell 直写」两行依赖「ModuleExports 通道无法被重新引入」——该保证此前只覆盖「返回列表新增 handoff 出参」，现 `NumField()==3` 冻结**额外**封闭「把 Exports 夹带为 `ModuleResult` 结构体字段」这一新向量（✅ → ✅ 强化）。其余矩阵行不受影响（资源生命周期与跨 cell handoff 正交）。
+- **新增** `WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01`（下游 Hard cellmodules 内 caller-ban / 上游 Medium，同 #851/#893/#1282 天花板）。
+
+**#1413（configcore 字段收口）**：`SharedDeps` 移除 `EventbusCacheCollector`（required）+ `ConfigStaleCipherInc`（optional）两个 configcore 专属字段——configcore 经 kernel `MetricsProvider` 用 `obmetrics.NewProviderEventbusCacheCollector` / `NewProviderConfigStaleCipherCollector` 自建（这两个 collector 走 kernel Provider，非 raw `client_golang`，不违反「cellmodules 不 import client_golang」治理姿态）。
+
+威胁/正确性再评：
+- **metric 契约不变**：`gocell_config_stale_cipher_total` / `gocell_eventbus_cache_tombstone_evicted_total` 的 fqName/label 与迁移前字节一致（仅 metricschema 的构造点 `file` 字段从 cmd/ 移到 `runtime/observability/metrics/`，且因移入 shared 包，现与 sibling `eventbus_cache` 一样出现在全部 assembly 的 metrics-schema，非仅 corebundle）。无 wire 改名分支。
+- **无双注册**：两 collector 各仅 configcore 消费；configcore 自建一次 + corebundle 停建 = 恰一次。
+- **`ConfigEventCollector` 前提纠正**：原表述「configcore 专属」有误——它由 accesscore + configcore + corebundle config-event middleware 共同消费且 `Validate` required，是真·跨 cell 字段，**保留**在 `SharedDeps`。
+- **`ConfigKeyProvider` 残留（唯一未收口字段）**：vault-transit 路径经 `adapters/vault.TransitMetrics`（raw prometheus registry），受 `adapterPromCallerAllowlist` 姿态阻挡，configcore 自建被 **#885**（vault TransitMetrics → kernel Provider）gate；#885 落地后该字段随之移入 configcore，`SharedDeps` 即完全 cell-agnostic。`#1413` 保持 open 跟踪此残留。
+- `adapters/prometheus.RegisterOrReuseCounter` 迁移后无生产调用方，其 `adapterPromCallerAllowlist` 置空（symbol 仍受治理，未来调用方须带理由加入）；export + 自测保留（删除留作后续 cleanup）。
+
+**参考**：
+- 单源生命周期对标：uber-go/fx `fx.Lifecycle.Append(Hook{OnStart,OnStop})`——一次注册派生 start/stop 双向，对应 `ModuleResult.Resources → {WithManagedResource, rollback}`。
+- Archtest：`WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01`（`tools/archtest/withmanagedresource_cellmodule_funnel_test.go`）；`MODULE-PROVIDE-NO-VALUE-HANDOFF-01`（已扩展 ModuleResult 字段冻结）。
+- gh #885（vault metrics → kernel Provider，解锁 ConfigKeyProvider 收口）；gh #1413（剩余范围跟踪）。

--- a/examples/corebundlestarter/run.go
+++ b/examples/corebundlestarter/run.go
@@ -118,9 +118,8 @@ func buildStarterMemSharedDeps(_ context.Context) (*composition.SharedDeps, erro
 	// MetricsProvider: kernel NopProvider — avoids prometheus import.
 	mp := kernelmetrics.NopProvider{}
 
-	// Noop collectors satisfy SharedDeps.Validate without prometheus.
+	// Noop collector satisfies SharedDeps.Validate without prometheus.
 	cfgEventCollector := obmetrics.NoopConfigEventCollector{}
-	ebCacheCollector := obmetrics.NoopEventbusCacheCollector{}
 
 	// ConsumerClaimer: in-memory idempotency claimer (single-process only).
 	claimer := idempotency.NewInMemClaimer(clk)
@@ -132,21 +131,21 @@ func buildStarterMemSharedDeps(_ context.Context) (*composition.SharedDeps, erro
 	}
 
 	shared, err := composition.NewSharedDeps(composition.SharedDeps{
-		Clock:                  clk,
-		Topology:               topo,
-		JWTIssuer:              jwtIssuer,
-		JWTVerifier:            jwtVerifier,
-		MetricsProvider:        mp,
-		EventBus:               eb,
-		ConfigEventCollector:   cfgEventCollector,
-		EventbusCacheCollector: ebCacheCollector,
-		ConsumerClaimer:        claimer,
-		InternalHMACRing:       ring,
-		PrimaryHTTPAddr:        starterPrimaryAddr,
-		InternalHTTPAddr:       starterInternalAddr,
-		HealthHTTPAddr:         starterHealthAddr,
-		VerboseDisabled:        true,
-		ConfigStaleCipherInc:   func() {}, // no-op in this example
+		Clock:                clk,
+		Topology:             topo,
+		JWTIssuer:            jwtIssuer,
+		JWTVerifier:          jwtVerifier,
+		MetricsProvider:      mp,
+		EventBus:             eb,
+		ConfigEventCollector: cfgEventCollector,
+		ConsumerClaimer:      claimer,
+		InternalHMACRing:     ring,
+		PrimaryHTTPAddr:      starterPrimaryAddr,
+		InternalHTTPAddr:     starterInternalAddr,
+		HealthHTTPAddr:       starterHealthAddr,
+		VerboseDisabled:      true,
+		// EventbusCacheCollector / ConfigStaleCipherInc removed (#1413): configcore
+		// self-builds them from MetricsProvider (NopProvider here).
 		// PG / Redis are nil → all platform modules take the in-memory path.
 	})
 	if err != nil {

--- a/examples/iotdevice/generated/metrics-schema.yaml
+++ b/examples/iotdevice/generated/metrics-schema.yaml
@@ -99,6 +99,11 @@ metrics:
       labels:
         - outcome
       file: runtime/observability/metrics/shutdown.go
+    - name: config_stale_cipher_total
+      type: counter
+      help: Number of config values read that are encrypted with a non-current key version.
+      labels: []
+      file: runtime/observability/metrics/config_stale_cipher.go
     - name: event_router_ready_wait_seconds
       type: histogram
       help: Time in seconds waited for event router Ready signal. Ready usually completes in <100ms; bootstrap timeout is 30s.

--- a/examples/orderfulfillment/generated/metrics-schema.yaml
+++ b/examples/orderfulfillment/generated/metrics-schema.yaml
@@ -69,6 +69,11 @@ metrics:
       labels:
         - outcome
       file: runtime/observability/metrics/shutdown.go
+    - name: config_stale_cipher_total
+      type: counter
+      help: Number of config values read that are encrypted with a non-current key version.
+      labels: []
+      file: runtime/observability/metrics/config_stale_cipher.go
     - name: event_router_ready_wait_seconds
       type: histogram
       help: Time in seconds waited for event router Ready signal. Ready usually completes in <100ms; bootstrap timeout is 30s.

--- a/examples/todoorder/generated/metrics-schema.yaml
+++ b/examples/todoorder/generated/metrics-schema.yaml
@@ -69,6 +69,11 @@ metrics:
       labels:
         - outcome
       file: runtime/observability/metrics/shutdown.go
+    - name: config_stale_cipher_total
+      type: counter
+      help: Number of config values read that are encrypted with a non-current key version.
+      labels: []
+      file: runtime/observability/metrics/config_stale_cipher.go
     - name: event_router_ready_wait_seconds
       type: histogram
       help: Time in seconds waited for event router Ready signal. Ready usually completes in <100ms; bootstrap timeout is 30s.

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -158,15 +158,14 @@ func (b *Builder) Build(
 				"(use explicit Optional semantics if cell is optional)", m.ID())
 		}
 		cells = append(cells, res.Cell)
-		cellOpts = append(cellOpts, res.Opts...)
 		// Single source: derive BOTH the steady-state WithManagedResource
-		// registration and the pre-Run rollback stack from res.Resources, so the
-		// two can never diverge (the former double-write bug). Modules do not call
-		// WithManagedResource themselves (WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
-		for _, r := range res.Resources {
-			cellOpts = append(cellOpts, bootstrap.WithManagedResource(r))
-			provisional = append(provisional, r)
-		}
+		// registration (via managedResourceOpts) AND the pre-Run rollback stack
+		// (provisional) from res.Resources, so the two can never diverge (the
+		// former double-write bug). Modules do not call WithManagedResource
+		// themselves (WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
+		cellOpts = append(cellOpts, res.Opts...)
+		cellOpts = append(cellOpts, managedResourceOpts(res.Resources)...)
+		provisional = append(provisional, res.Resources...)
 	}
 
 	runtimeOpts, err := runtimeOptsFn(cells)
@@ -177,4 +176,18 @@ func (b *Builder) Build(
 
 	allOpts := append(runtimeOpts, cellOpts...) //nolint:gocritic // intentional: runtime opts first, then cell opts
 	return &App{clk: shared.Clock, opts: allOpts}, nil
+}
+
+// managedResourceOpts derives one bootstrap.WithManagedResource option per
+// resource — the steady-state half of the single-source resource contract. The
+// caller ([Builder.Build]) appends the same resources to its provisional
+// rollback stack, so both lifecycle channels come from the one Resources slice
+// and cannot diverge. Extracted from Build so the per-module loop body stays
+// within the cognitive-complexity budget.
+func managedResourceOpts(resources []kernellifecycle.ManagedResource) []bootstrap.Option {
+	opts := make([]bootstrap.Option, 0, len(resources))
+	for _, r := range resources {
+		opts = append(opts, bootstrap.WithManagedResource(r))
+	}
+	return opts
 }

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -58,30 +58,32 @@ func (b *Builder) With(modules ...CellModule) *Builder {
 //  1. Guard that shared was produced by [NewSharedDeps] (sealed-construction
 //     marker check) and that runtimeOptsFn is non-nil — startup invariants.
 //  2. For each module: nil-guard, call [CellModule.Provide], accumulate cells +
-//     cellOpts + provisional ManagedResources, with LIFO Close(ctx) rollback on
-//     any failure; nil-cell guard.
+//     cellOpts (module opts + one bootstrap.WithManagedResource derived per
+//     ModuleResult.Resources entry) + a provisional ManagedResource stack, with
+//     LIFO Close(ctx) rollback on any failure; nil-cell guard.
 //  3. Call runtimeOptsFn(cells) to get runtimeOpts.  If it errors, rollback
 //     provisional resources and return.
 //  4. allOpts := runtimeOpts ++ cellOpts.
 //  5. Return &App{clk: shared.Clock, opts: allOpts}.
 //
-// Resource ownership (two channels, distinct phases — see pg-cell-template
-// Chapter 4):
-//   - Steady-state lifecycle: a module registers a resource by returning
-//     bootstrap.WithManagedResource(res) in its opts (2nd return value). Those
-//     opts flow into allOpts, so bootstrap.Run manages health/worker/LIFO-Close
+// Resource ownership (single source — PR #591 / #1420): a module lists every
+// ManagedResource it opened in ModuleResult.Resources and does NOT call
+// bootstrap.WithManagedResource itself. Build derives BOTH channels from that
+// one slice:
+//   - Steady-state lifecycle: Build appends one bootstrap.WithManagedResource(r)
+//     per resource to cellOpts, so bootstrap.Run manages health/worker/LIFO-Close
 //     for the resource during the normal run (phase10 shutdown closes it).
-//   - Pre-Run rollback: the module ALSO returns the same resource in its 3rd
-//     return value ([]ManagedResource). Build accumulates these into a
-//     provisional stack and, if any later step fails before returning the App,
-//     calls Close(ctx) in reverse order (LIFO) so resources opened so far are
-//     released even though bootstrap.Run never starts.
+//   - Pre-Run rollback: Build also appends r to a provisional stack and, if any
+//     later step fails before returning the App, calls Close(ctx) in reverse
+//     order (LIFO) so resources opened so far are released even though
+//     bootstrap.Run never starts.
 //
 // The two channels never double-close: the rollback path fires only on failure
 // (bootstrap.Run does not run), and the WithManagedResource path fires only on
-// success. Build does not itself convert provisional resources into bootstrap
-// options — steady-state registration is the module's responsibility via its
-// opts, so a resource appears at most once in the bootstrap managed set.
+// success. Deriving both from the single Resources slice makes the former
+// double-write divergence (resource in opts but not provisional, or vice versa)
+// structurally impossible — guarded by WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01,
+// which bans WithManagedResource calls inside cellmodules/.
 //
 // Cross-module value handoff (formerly via ModuleExports) has been removed.
 // Cell modules are now fully self-contained; cross-cell communication happens
@@ -145,19 +147,26 @@ func (b *Builder) Build(
 			rollback()
 			return nil, fmt.Errorf("composition.Builder.Build: module list contains nil")
 		}
-		c, mOpts, mRes, err := m.Provide(ctx, shared)
+		res, err := m.Provide(ctx, shared)
 		if err != nil {
 			rollback()
 			return nil, fmt.Errorf("composition.Builder.Build: module %q Provide: %w", m.ID(), err)
 		}
-		if c == nil {
+		if res.Cell == nil {
 			rollback()
 			return nil, fmt.Errorf("composition.Builder.Build: module %q returned nil Cell "+
 				"(use explicit Optional semantics if cell is optional)", m.ID())
 		}
-		cells = append(cells, c)
-		cellOpts = append(cellOpts, mOpts...)
-		provisional = append(provisional, mRes...)
+		cells = append(cells, res.Cell)
+		cellOpts = append(cellOpts, res.Opts...)
+		// Single source: derive BOTH the steady-state WithManagedResource
+		// registration and the pre-Run rollback stack from res.Resources, so the
+		// two can never diverge (the former double-write bug). Modules do not call
+		// WithManagedResource themselves (WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
+		for _, r := range res.Resources {
+			cellOpts = append(cellOpts, bootstrap.WithManagedResource(r))
+			provisional = append(provisional, r)
+		}
 	}
 
 	runtimeOpts, err := runtimeOptsFn(cells)

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -184,6 +184,11 @@ func (b *Builder) Build(
 // rollback stack, so both lifecycle channels come from the one Resources slice
 // and cannot diverge. Extracted from Build so the per-module loop body stays
 // within the cognitive-complexity budget.
+//
+// Nil entries: ModuleResult.Resources MUST NOT contain nil (see its godoc).
+// bootstrap.WithManagedResource itself fail-fasts on a nil/typed-nil resource at
+// phase0, so a stray nil reaching the steady-state path is caught at startup; the
+// rollback path (Build's provisional Close) relies on the same non-nil contract.
 func managedResourceOpts(resources []kernellifecycle.ManagedResource) []bootstrap.Option {
 	opts := make([]bootstrap.Option, 0, len(resources))
 	for _, r := range resources {

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
+	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
@@ -130,7 +131,9 @@ func (b *Builder) Build(
 	var cells []cell.Cell
 	var cellOpts []bootstrap.Option
 	// provisional holds resources opened so far; closed in reverse order if
-	// any subsequent step fails.
+	// any subsequent step fails. INVARIANT: every entry is non-nil — the loop
+	// below rejects nil/typed-nil resources via validateModuleResources before
+	// appending, so Close() below can never panic on a nil interface.
 	var provisional []kernellifecycle.ManagedResource
 
 	rollback := func() {
@@ -143,19 +146,10 @@ func (b *Builder) Build(
 	}
 
 	for _, m := range b.modules {
-		if m == nil {
-			rollback()
-			return nil, fmt.Errorf("composition.Builder.Build: module list contains nil")
-		}
-		res, err := m.Provide(ctx, shared)
+		res, err := resolveModuleResult(ctx, m, shared)
 		if err != nil {
 			rollback()
-			return nil, fmt.Errorf("composition.Builder.Build: module %q Provide: %w", m.ID(), err)
-		}
-		if res.Cell == nil {
-			rollback()
-			return nil, fmt.Errorf("composition.Builder.Build: module %q returned nil Cell "+
-				"(use explicit Optional semantics if cell is optional)", m.ID())
+			return nil, err
 		}
 		cells = append(cells, res.Cell)
 		// Single source: derive BOTH the steady-state WithManagedResource
@@ -178,6 +172,58 @@ func (b *Builder) Build(
 	return &App{clk: shared.Clock, opts: allOpts}, nil
 }
 
+// resolveModuleResult calls one module's Provide and validates the result before
+// it enters either lifecycle channel: the module must be non-nil, must return a
+// non-nil Cell, and must not return any nil/typed-nil ManagedResource. Extracted
+// from [Builder.Build] so the per-module loop body stays within the
+// cognitive-complexity budget (same rationale as [managedResourceOpts]); the
+// single returned error lets Build run rollback + return once.
+func resolveModuleResult(ctx context.Context, m CellModule, shared *SharedDeps) (ModuleResult, error) {
+	if m == nil {
+		return ModuleResult{}, fmt.Errorf("composition.Builder.Build: module list contains nil")
+	}
+	res, err := m.Provide(ctx, shared)
+	if err != nil {
+		return ModuleResult{}, fmt.Errorf("composition.Builder.Build: module %q Provide: %w", m.ID(), err)
+	}
+	if res.Cell == nil {
+		return ModuleResult{}, fmt.Errorf("composition.Builder.Build: module %q returned nil Cell "+
+			"(use explicit Optional semantics if cell is optional)", m.ID())
+	}
+	// Reject nil resources BEFORE they enter the provisional rollback stack, so
+	// rollback's Close() can never panic on a nil interface. The steady-state path
+	// (managedResourceOpts → bootstrap.WithManagedResource) fail-fasts a nil
+	// resource only at phase0; doing it here keeps both lifecycle channels
+	// symmetric and fails fast at Build time instead.
+	if err := validateModuleResources(m.ID(), res.Resources); err != nil {
+		return ModuleResult{}, err
+	}
+	return res, nil
+}
+
+// validateModuleResources rejects nil/typed-nil entries in a module's Resources
+// slice. [Builder.Build] calls it on each module's result before the resources
+// enter either lifecycle channel (steady-state opts + provisional rollback
+// stack), guaranteeing the provisional stack holds only non-nil resources so its
+// Close() can never panic. A nil resource is a module wiring bug; surfacing it as
+// a Build-time error keeps the rollback path symmetric with the steady-state path
+// (where bootstrap.WithManagedResource fail-fasts a nil resource at phase0).
+//
+// Extracted from Build so the per-module loop body stays within the
+// cognitive-complexity budget.
+//
+// ref: uber-go/fx internal/lifecycle/lifecycle.go — Stop runs only hooks that
+// were successfully appended; bad inputs surface before any component starts.
+func validateModuleResources(moduleID string, resources []kernellifecycle.ManagedResource) error {
+	for i, r := range resources {
+		if validation.IsNilInterface(r) {
+			return fmt.Errorf("composition.Builder.Build: module %q returned nil "+
+				"ManagedResource at Resources[%d] (resources must be non-nil)", moduleID, i)
+		}
+	}
+	return nil
+}
+
 // managedResourceOpts derives one bootstrap.WithManagedResource option per
 // resource — the steady-state half of the single-source resource contract. The
 // caller ([Builder.Build]) appends the same resources to its provisional
@@ -186,9 +232,10 @@ func (b *Builder) Build(
 // within the cognitive-complexity budget.
 //
 // Nil entries: ModuleResult.Resources MUST NOT contain nil (see its godoc).
-// bootstrap.WithManagedResource itself fail-fasts on a nil/typed-nil resource at
-// phase0, so a stray nil reaching the steady-state path is caught at startup; the
-// rollback path (Build's provisional Close) relies on the same non-nil contract.
+// [validateModuleResources] rejects any nil/typed-nil resource at Build time
+// before it reaches this function or the rollback stack, so both channels only
+// ever see non-nil resources. bootstrap.WithManagedResource additionally
+// fail-fasts a stray nil at phase0 as defense in depth.
 func managedResourceOpts(resources []kernellifecycle.ManagedResource) []bootstrap.Option {
 	opts := make([]bootstrap.Option, 0, len(resources))
 	for _, r := range resources {

--- a/runtime/composition/builder_test.go
+++ b/runtime/composition/builder_test.go
@@ -230,6 +230,51 @@ func TestBuilder_NilCell_RollsBack(t *testing.T) {
 	assert.Equal(t, "r1", order.calls[0])
 }
 
+// TestBuilder_NilResource_FailFast verifies that a module returning a
+// nil/typed-nil ManagedResource is rejected at Build time (fail-fast) instead of
+// panicking on the rollback path. Before this guard, the steady-state path
+// (managedResourceOpts → WithManagedResource) caught nil at phase0, but the
+// pre-Run rollback called Close() directly on the provisional stack and would
+// panic on a nil interface (bare nil) or nil receiver (typed nil). The validation
+// keeps the resource out of the provisional stack entirely, so a prior module's
+// valid resource still rolls back cleanly and Build returns a descriptive error.
+func TestBuilder_NilResource_FailFast(t *testing.T) {
+	ctx := context.Background()
+
+	var typedNil *orderedMR // typed-nil: non-nil interface wrapping a nil *orderedMR
+
+	tests := []struct {
+		name string
+		bad  kernellifecycle.ManagedResource
+	}{
+		{name: "bare nil", bad: nil},
+		{name: "typed nil", bad: typedNil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			order := &closedOrder{}
+			r1 := &orderedMR{id: "r1", order: order}
+
+			c1 := stubCell("cell-1")
+			m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1}}
+			c2 := stubCell("cell-2")
+			m2 := &fakeCellModule{id: "mod2", cell: c2, mres: []kernellifecycle.ManagedResource{tc.bad}}
+
+			// Must NOT panic; must return a fail-fast error naming the module.
+			_, err := New().With(m1, m2).Build(ctx, minimalSharedDeps(t),
+				func([]cell.Cell) ([]bootstrap.Option, error) { return nil, nil })
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "mod2")
+			assert.Contains(t, err.Error(), "nil ManagedResource")
+
+			// The prior module's valid resource rolled back without panic; the
+			// nil resource never entered the provisional stack.
+			require.Len(t, order.calls, 1, "prior valid resource must roll back")
+			assert.Equal(t, "r1", order.calls[0])
+		})
+	}
+}
+
 // TestBuilder_RuntimeFnError_RollsBack verifies rollback when the RuntimeOptionsFunc errors.
 func TestBuilder_RuntimeFnError_RollsBack(t *testing.T) {
 	ctx := context.Background()

--- a/runtime/composition/builder_test.go
+++ b/runtime/composition/builder_test.go
@@ -36,12 +36,12 @@ type fakeCellModule struct {
 func (f *fakeCellModule) ID() string { return f.id }
 func (f *fakeCellModule) Provide(
 	_ context.Context, _ *SharedDeps,
-) (cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error) {
+) (ModuleResult, error) {
 	f.called = true
 	if f.provideErr != nil {
-		return nil, nil, nil, f.provideErr
+		return ModuleResult{}, f.provideErr
 	}
-	return f.cell, f.opts, f.mres, nil
+	return ModuleResult{Cell: f.cell, Opts: f.opts, Resources: f.mres}, nil
 }
 
 // closedOrder captures the sequence of Close calls for LIFO verification.
@@ -94,18 +94,20 @@ func TestBuilder_HappyPath(t *testing.T) {
 	assert.True(t, m2.called)
 }
 
-// TestBuilder_HappyPath_TwoChannelResourceContract verifies the two-channel
-// resource ownership contract (pg-cell-template Chapter 4):
-//   - A module's bootstrap.Option (3rd return, e.g. bootstrap.WithManagedResource)
-//     flows into App.opts so bootstrap.Run owns the steady-state lifecycle.
-//   - A module's []ManagedResource (4th return) is rollback-only: Build must NOT
-//     additionally convert it into bootstrap opts on the success path, or the
-//     resource would be registered twice (the module already registered it via
-//     its own opts) and double-closed at shutdown.
+// TestBuilder_HappyPath_SingleSourceResourceContract verifies the single-source
+// resource ownership contract (PR #591 / #1420):
+//   - A module returns its ManagedResources ONLY in ModuleResult.Resources. It
+//     does NOT call bootstrap.WithManagedResource itself.
+//   - Build derives BOTH channels from that one source: it appends one
+//     bootstrap.WithManagedResource(r) per resource to cellOpts (steady-state
+//     lifecycle, owned by bootstrap.Run) AND appends r to the provisional
+//     rollback stack. The two can never diverge — the former double-write bug
+//     where a module forgot one half is now structurally impossible.
 //
-// Mirrors cellmodules/accesscore: WithManagedResource(limiter) in opts +
-// the same limiter in the 4th channel for pre-Run rollback.
-func TestBuilder_HappyPath_TwoChannelResourceContract(t *testing.T) {
+// Mirrors cellmodules/accesscore: the rate limiter is returned only in
+// Resources; the Builder, not the module, registers it for steady-state and
+// for pre-Run rollback.
+func TestBuilder_HappyPath_SingleSourceResourceContract(t *testing.T) {
 	ctx := context.Background()
 
 	order := &closedOrder{}
@@ -115,7 +117,9 @@ func TestBuilder_HappyPath_TwoChannelResourceContract(t *testing.T) {
 	m1 := &fakeCellModule{
 		id:   "mod1",
 		cell: c1,
-		opts: []bootstrap.Option{bootstrap.WithManagedResource(r1)},
+		// Single source: resource declared ONLY in Resources; no opts. The
+		// module does NOT call bootstrap.WithManagedResource (banned in
+		// cellmodules/ by WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
 		mres: []kernellifecycle.ManagedResource{r1},
 	}
 
@@ -124,13 +128,35 @@ func TestBuilder_HappyPath_TwoChannelResourceContract(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, app)
 
-	// Exactly the module's own opt is present — the 4th-channel resource is NOT
-	// additionally threaded (that would double-register against the module's
-	// own WithManagedResource).
+	// Build derived exactly one WithManagedResource opt from the single
+	// Resources entry — the module supplied no opts of its own.
 	assert.Len(t, app.opts, 1,
-		"module opts flow through; Builder must not also convert mres into opts")
+		"Builder derives one WithManagedResource opt from ModuleResult.Resources (single source)")
 	// Success path never rolls back.
 	assert.Empty(t, order.calls, "no resource may be Closed on the success path")
+}
+
+// TestBuilder_SingleSourceResource_RollsBack verifies the rollback half of the
+// single-source contract: a resource returned only in ModuleResult.Resources is
+// closed (LIFO) when a later module fails — without the module ever calling
+// WithManagedResource. This pairs with the happy-path test above to prove BOTH
+// channels are derived from the one Resources source.
+func TestBuilder_SingleSourceResource_RollsBack(t *testing.T) {
+	ctx := context.Background()
+
+	order := &closedOrder{}
+	r1 := &orderedMR{id: "r1", order: order}
+
+	c1 := stubCell("cell-1")
+	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1}}
+	m2 := &fakeCellModule{id: "mod2", provideErr: errors.New("provide failed")}
+
+	_, err := New().With(m1, m2).Build(ctx, minimalSharedDeps(t),
+		func([]cell.Cell) ([]bootstrap.Option, error) { return nil, nil })
+	require.Error(t, err)
+
+	require.Len(t, order.calls, 1, "the single-source resource must be rolled back on failure")
+	assert.Equal(t, "r1", order.calls[0])
 }
 
 // TestBuilder_NilModule_RollsBack verifies LIFO rollback when a nil module is encountered.

--- a/runtime/composition/cell_module.go
+++ b/runtime/composition/cell_module.go
@@ -8,6 +8,48 @@ import (
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 )
 
+// ModuleResult is the single-source result of [CellModule.Provide].
+//
+// It carries the constructed Cell plus the two kinds of bootstrap contribution a
+// module can make:
+//
+//   - Opts: non-resource bootstrap options (e.g. bootstrap.WithRelay). These
+//     flow into the assembly verbatim.
+//   - Resources: the ManagedResources the module opened during Provide (PG pool,
+//     vault client, rate-limiter cleanup goroutine, …). This is the SINGLE source
+//     for resource lifecycle: [Builder.Build] derives BOTH the steady-state
+//     registration (one bootstrap.WithManagedResource(r) per resource, so
+//     bootstrap.Run owns its Probes()/Worker()/LIFO-Close on the happy path) AND
+//     the pre-Run rollback stack (Close(ctx) in reverse order if a later module
+//     fails before bootstrap.Run starts). Because both are derived from the one
+//     slice, they can never diverge.
+//
+// Modules MUST NOT call bootstrap.WithManagedResource themselves — that is
+// forbidden inside cellmodules/ by WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01. List
+// the resource in Resources and the Builder funnels it. Before #1420 a module had
+// to write the same resource into both an opt and a provisional return; forgetting
+// either half leaked the resource or dropped its /readyz probe. The single
+// Resources field closes that double-write.
+//
+// No cross-module value-handoff field is permitted (no Exports): the former
+// ModuleExports channel was removed in Wave-1 #1423 and MUST stay removed. The
+// field set is frozen by MODULE-PROVIDE-NO-VALUE-HANDOFF-01.
+type ModuleResult struct {
+	// Cell is the constructed Cell. Must be non-nil on success.
+	Cell cell.Cell
+
+	// Opts are non-resource bootstrap options the Cell needs (e.g.
+	// bootstrap.WithRelay). Resources MUST NOT be registered here via
+	// bootstrap.WithManagedResource — use the Resources field; the Builder
+	// derives the WithManagedResource registration from it.
+	Opts []bootstrap.Option
+
+	// Resources are the ManagedResources opened during Provide. The Builder
+	// derives both steady-state registration and pre-Run rollback from this one
+	// slice (single source). Entries MUST be non-nil.
+	Resources []kernellifecycle.ManagedResource
+}
+
 // CellModule is the contract by which a Cell declares itself to [Builder.Build].
 // Each Cell provides a single *_module.go file that implements this interface,
 // self-managing all Cell-specific dependency wiring (KeyProvider, PoolResource,
@@ -34,23 +76,15 @@ type CellModule interface {
 	// ID returns a stable identifier used in error messages and logs.
 	ID() string
 
-	// Provide resolves Cell-specific dependencies from the shared context
-	// and returns:
+	// Provide resolves Cell-specific dependencies from the shared context and
+	// returns a [ModuleResult] (the constructed Cell + non-resource opts +
+	// the single-source ManagedResource list) or an error.
 	//
-	//   - cell: the constructed Cell. Must be non-nil on success.
-	//   - opts: bootstrap.Options the Cell needs (e.g. WithManagedResource for
-	//     its PoolResource).
-	//   - provisional: ManagedResources opened during Provide that must be
-	//     closed if a subsequent module's Provide fails before bootstrap.Run
-	//     activates the lifecycle. The caller ([Builder.Build]) owns rollback:
-	//     on any failure it calls Close(ctx) in reverse order on all accumulated
-	//     provisional resources.
-	//
-	// Modules MUST include in provisional every external connection opened
-	// during Provide (PG pool, vault client, …) so Build can release them when
-	// the assembly cannot complete. The same resources must also appear in the
-	// returned opts via bootstrap.WithManagedResource so that bootstrap.Run
-	// manages their lifecycle on the happy path.
+	// Resource lifecycle is single-source: the module lists every external
+	// connection it opened (PG pool, vault client, …) in ModuleResult.Resources,
+	// and [Builder.Build] derives BOTH the happy-path bootstrap.WithManagedResource
+	// registration AND the pre-Run rollback from that one slice. The module MUST
+	// NOT call bootstrap.WithManagedResource itself.
 	//
 	// Cross-module value handoff via the former ModuleExports type has been
 	// removed (Wave-1 #1423). Cell modules are now fully self-contained; cross-cell
@@ -59,8 +93,7 @@ type CellModule interface {
 	//
 	// MODULE-PROVIDE-NO-VALUE-HANDOFF-01 (tools/archtest/module_provide_signature_frozen_test.go)
 	// enforces that this signature has exactly two inputs (context.Context, *SharedDeps)
-	// and four outputs (cell.Cell, []bootstrap.Option, []lifecycle.ManagedResource, error)
-	// with no cross-module value-handoff channel.
-	Provide(ctx context.Context, shared *SharedDeps) (
-		cell.Cell, []bootstrap.Option, []kernellifecycle.ManagedResource, error)
+	// and two outputs (ModuleResult, error), and that ModuleResult has exactly the
+	// fields {Cell, Opts, Resources} with no cross-module value-handoff channel.
+	Provide(ctx context.Context, shared *SharedDeps) (ModuleResult, error)
 }

--- a/runtime/composition/shared_deps.go
+++ b/runtime/composition/shared_deps.go
@@ -39,6 +39,15 @@ import (
 // sub-struct layout would make cross-cutting consumptions look like boundary
 // violations when in fact they are the natural shape of a composition root.
 //
+// Fields are genuinely cross-cutting (consumed by multiple cells or the runtime
+// itself), with one transitional exception — ConfigKeyProvider, the last
+// configcore-specific field, whose removal is gated on #885 (see its godoc). The
+// former configcore-specific metric fields (EventbusCacheCollector,
+// ConfigStaleCipherInc) were removed in #1413: configcore now self-builds those
+// collectors from MetricsProvider via runtime/observability/metrics, since they
+// route through the kernel Provider (not raw prometheus) and so do not trip the
+// "no client_golang in cellmodules" posture.
+//
 // ref: uber-go/fx fx.Supply — shared values provided once to all modules.
 // ref: kubernetes/kubernetes cmd/kube-apiserver/app/options/validation.go —
 // all required fields validated in one place before startup.
@@ -77,14 +86,12 @@ type SharedDeps struct {
 	// EventBus is the in-process event bus for publish and subscribe.
 	EventBus *eventbus.InMemoryEventBus
 
-	// ConfigEventCollector records config consumer process and settlement metrics.
-	// Registered once against MetricsProvider and injected into accesscore and
-	// configcore.
+	// ConfigEventCollector records config consumer process and settlement
+	// metrics. It is genuinely cross-cell — consumed by accesscore, configcore,
+	// AND the corebundle config-event consumer middleware — so it stays on the
+	// shared bag (registered once against MetricsProvider, injected into all
+	// consumers). It is NOT a configcore-specific field.
 	ConfigEventCollector obmetrics.ConfigEventCollector
-
-	// EventbusCacheCollector records configsubscribe subscriber-cache tombstone
-	// GC evictions.
-	EventbusCacheCollector obmetrics.EventbusCacheCollector
 
 	// ConsumerClaimer coordinates outbox consumer idempotency.
 	ConsumerClaimer idempotency.Claimer
@@ -133,18 +140,24 @@ type SharedDeps struct {
 	ProjectRoot string
 
 	// ConfigKeyProvider is the configcore value-encryption key provider.
-	// Built in cmd/corebundle (which may import adapters/vault + prometheus),
-	// passed to cellmodules/configcore.Module so that the composition module
-	// layer never imports adapter-specific packages. Nil means no key provider;
-	// in real adapter mode configcore rejects nil (NoopTransformer is dev-only).
+	//
+	// This is the LAST configcore-specific field on the shared bag. It remains
+	// here (rather than being self-built inside cellmodules/configcore like the
+	// stale-cipher and eventbus-cache collectors) because the vault-transit
+	// provider needs adapters/vault.TransitMetrics, which is built from a raw
+	// github.com/prometheus/client_golang registry — and the
+	// adapterPromCallerAllowlist governance posture (archtest
+	// observability_metrics_test.go, #1085 Batch 4 Part A) keeps raw-prometheus
+	// construction in cmd/ so cellmodules/configcore never imports client_golang.
+	// configcore self-building the key provider is gated on #885 (migrating vault
+	// TransitMetrics to the kernel MetricsProvider); once #885 lands this field
+	// moves into configcore too and SharedDeps becomes fully cell-agnostic.
+	// Refs #1413 / #885.
+	//
+	// Built in cmd/corebundle, passed to cellmodules/configcore.Module. Nil means
+	// no key provider; in real adapter mode configcore rejects nil (NoopTransformer
+	// is dev-only).
 	ConfigKeyProvider kcrypto.KeyProvider
-
-	// ConfigStaleCipherInc is a zero-arg callback that increments the
-	// stale-cipher counter once per config value read that is encrypted with a
-	// non-current key version. Built in cmd/corebundle from a prometheus counter
-	// so that runtime/composition never imports github.com/prometheus/client_golang.
-	// Nil means no-op (acceptable in tests that do not exercise PG + encryption).
-	ConfigStaleCipherInc func()
 }
 
 // NewSharedDeps validates a populated SharedDeps and returns a sealed copy. The
@@ -210,9 +223,6 @@ func (d *SharedDeps) validate() error {
 	}
 	if validation.IsNilInterface(d.ConfigEventCollector) {
 		missing("ConfigEventCollector")
-	}
-	if validation.IsNilInterface(d.EventbusCacheCollector) {
-		missing("EventbusCacheCollector")
 	}
 	if validation.IsNilInterface(d.ConsumerClaimer) {
 		missing("ConsumerClaimer")

--- a/runtime/composition/shared_deps_test.go
+++ b/runtime/composition/shared_deps_test.go
@@ -43,9 +43,6 @@ func buildTestSharedDeps(t *testing.T) *SharedDeps {
 	cec, err := obmetrics.NewProviderConfigEventCollector(mp)
 	require.NoError(t, err)
 
-	ebc, err := obmetrics.NewProviderEventbusCacheCollector(mp)
-	require.NoError(t, err)
-
 	eb := eventbus.New(clk)
 	claimer := idempotency.NewInMemClaimer(clk)
 	issuer, verifier := buildTestJWTPair(t, clk)
@@ -54,15 +51,14 @@ func buildTestSharedDeps(t *testing.T) *SharedDeps {
 	require.NoError(t, err)
 
 	s, err := NewSharedDeps(SharedDeps{
-		Clock:                  clk,
-		Topology:               topo,
-		JWTIssuer:              issuer,
-		JWTVerifier:            verifier,
-		MetricsProvider:        mp,
-		EventBus:               eb,
-		ConfigEventCollector:   cec,
-		EventbusCacheCollector: ebc,
-		ConsumerClaimer:        claimer,
+		Clock:                clk,
+		Topology:             topo,
+		JWTIssuer:            issuer,
+		JWTVerifier:          verifier,
+		MetricsProvider:      mp,
+		EventBus:             eb,
+		ConfigEventCollector: cec,
+		ConsumerClaimer:      claimer,
 	})
 	require.NoError(t, err)
 	return s
@@ -226,10 +222,6 @@ func TestSharedDeps_Validate_MissingFields(t *testing.T) {
 		{
 			name:  "ConfigEventCollector nil",
 			mutFn: func(s *SharedDeps) { s.ConfigEventCollector = nil },
-		},
-		{
-			name:  "EventbusCacheCollector nil",
-			mutFn: func(s *SharedDeps) { s.EventbusCacheCollector = nil },
 		},
 		{
 			name:  "ConsumerClaimer nil",

--- a/runtime/observability/metrics/config_stale_cipher.go
+++ b/runtime/observability/metrics/config_stale_cipher.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// ConfigStaleCipherCollector records reads of config values that are encrypted
+// with a non-current key version (M3 stale-key observability).
+type ConfigStaleCipherCollector interface {
+	RecordStaleCipher(ctx context.Context)
+}
+
+// NoopConfigStaleCipherCollector drops stale-cipher observations.
+type NoopConfigStaleCipherCollector struct{}
+
+func (NoopConfigStaleCipherCollector) RecordStaleCipher(_ context.Context) {
+	// Intentionally empty: callers can inject this collector when stale-cipher
+	// metrics are disabled while keeping service code free of nil checks.
+}
+
+type providerConfigStaleCipherCollector struct {
+	staleCipher kernelmetrics.CounterVec
+}
+
+var _ ConfigStaleCipherCollector = (*providerConfigStaleCipherCollector)(nil)
+
+// NewProviderConfigStaleCipherCollector registers the config stale-cipher counter
+// on p. The Prometheus provider namespace supplies the "gocell_" fqName prefix,
+// so Name "config_stale_cipher_total" yields the wire metric
+// "gocell_config_stale_cipher_total" — byte-identical to the prior raw-prometheus
+// counter that lived in cmd/corebundle (configStaleCipherOpts). The metric is
+// unlabeled (a single global count), so RecordStaleCipher increments the one
+// series via the empty label set.
+func NewProviderConfigStaleCipherCollector(p kernelmetrics.Provider) (ConfigStaleCipherCollector, error) {
+	if p == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"runtime/observability/metrics: config stale-cipher Provider is required")
+	}
+	staleCipher, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name: "config_stale_cipher_total",
+		Help: "Number of config values read that are encrypted with a non-current key version.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("runtime/observability/metrics: register config_stale_cipher_total: %w", err)
+	}
+	return &providerConfigStaleCipherCollector{staleCipher: staleCipher}, nil
+}
+
+func (c *providerConfigStaleCipherCollector) RecordStaleCipher(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.staleCipher.With(kernelmetrics.Labels{}).Inc(ctx)
+}

--- a/runtime/observability/metrics/config_stale_cipher_test.go
+++ b/runtime/observability/metrics/config_stale_cipher_test.go
@@ -1,0 +1,57 @@
+package metrics_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
+)
+
+func TestProviderConfigStaleCipherCollector_RejectsNilProvider(t *testing.T) {
+	collector, err := obmetrics.NewProviderConfigStaleCipherCollector(nil)
+	require.Error(t, err)
+	assert.Nil(t, collector)
+}
+
+func TestProviderConfigStaleCipherCollector_NopProviderNoPanic(t *testing.T) {
+	ctx := context.Background()
+	collector, err := obmetrics.NewProviderConfigStaleCipherCollector(kernelmetrics.NopProvider{})
+	require.NoError(t, err)
+
+	collector.RecordStaleCipher(ctx)
+}
+
+func TestProviderConfigStaleCipherCollector_ReturnsRegistrationError(t *testing.T) {
+	collector, err := obmetrics.NewProviderConfigStaleCipherCollector(failingCounterProvider{})
+	require.Error(t, err)
+	assert.Nil(t, collector)
+	assert.Contains(t, err.Error(), "register config_stale_cipher_total")
+}
+
+func TestProviderConfigStaleCipherCollector_EmitsExpectedMetric(t *testing.T) {
+	ctx := context.Background()
+	p := newSpyProvider()
+	collector, err := obmetrics.NewProviderConfigStaleCipherCollector(p)
+	require.NoError(t, err)
+
+	collector.RecordStaleCipher(ctx)
+
+	ops := p.counterOps["config_stale_cipher_total"]
+	require.Len(t, ops, 1)
+	assert.Empty(t, ops[0].labels, "config_stale_cipher_total is an unlabeled counter")
+	assert.Equal(t, 1.0, ops[0].value)
+
+	collector.RecordStaleCipher(ctx)
+
+	ops = p.counterOps["config_stale_cipher_total"]
+	require.Len(t, ops, 2)
+	assert.Equal(t, 1.0, ops[1].value)
+}
+
+func TestNoopConfigStaleCipherCollector_NoPanic(t *testing.T) {
+	obmetrics.NoopConfigStaleCipherCollector{}.RecordStaleCipher(context.Background())
+}

--- a/tools/archtest/bootstrap_autowire_collector_funnel_test.go
+++ b/tools/archtest/bootstrap_autowire_collector_funnel_test.go
@@ -167,7 +167,7 @@ func TestBootstrapAutoWireCollectorFunnel01(t *testing.T) {
 
 	observed := map[string]bool{}
 
-	diags := RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() || p.Pkg.Path() != autoWireBootstrapPkgPath {
 			return nil
 		}
@@ -226,8 +226,7 @@ func TestBootstrapAutoWireCollectorFunnel01_PlantedBypass(t *testing.T) {
 		{collectorsPkgPath, "NewBeta"}:  "collectors.NewBeta",
 	}
 
-	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
-		[]string{fixturePattern},
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{fixturePattern}),
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/module_provide_signature_frozen_test.go
+++ b/tools/archtest/module_provide_signature_frozen_test.go
@@ -7,19 +7,31 @@
 // The `CellModule.Provide` method in `runtime/composition` MUST have exactly
 // the signature:
 //
-//	Provide(context.Context, *SharedDeps) (cell.Cell, []bootstrap.Option, []lifecycle.ManagedResource, error)
+//	Provide(context.Context, *SharedDeps) (ModuleResult, error)
+//
+// and the `ModuleResult` struct MUST have exactly three exported fields:
+//
+//	type ModuleResult struct {
+//	    Cell      cell.Cell
+//	    Opts      []bootstrap.Option
+//	    Resources []lifecycle.ManagedResource
+//	}
 //
 // No cross-module value-handoff parameter (formerly `in ModuleExports`) and no
-// cross-module value-handoff return (formerly `ModuleExports`) are permitted.
-// Adding either would re-open the in-process Go-handle channel that Wave-1
-// #1423 closed.
+// cross-module value-handoff field/return (formerly `ModuleExports`) are
+// permitted. Adding either would re-open the in-process Go-handle channel that
+// Wave-1 #1423 closed. The single-source `Resources` field (PR #591 / #1420)
+// is the only resource channel: Builder derives BOTH the steady-state
+// `bootstrap.WithManagedResource` registration AND the pre-Run rollback stack
+// from it, so a module cannot diverge the two (the former double-write bug).
 //
-// ## AI-robust rating: Hard (reflect interface method signature)
+// ## AI-robust rating: Hard (reflect interface method signature + struct fields)
 //
-// The archtest uses reflect.TypeOf to inspect the interface method set and
-// pins the exact In/Out type list. Changing the signature changes the reflect
-// shape → test fails immediately. There is no string-anchor or comment
-// allowlist; the rule is form-locked.
+// The archtest uses reflect.TypeOf to inspect (1) the interface method set,
+// pinning the exact In/Out type list, and (2) the ModuleResult struct field
+// set, pinning NumField()==3, the field names, types, and exported-ness.
+// Changing either reflect shape → test fails immediately. There is no
+// string-anchor or comment allowlist; the rule is form-locked.
 //
 // ## Blind spots and reverse self-checks
 //
@@ -35,8 +47,15 @@
 //     so hidden embedding with a shadowed Provide is caught.
 //  3. **Wrong package path**: if a different `CellModule` type in a sibling
 //     package were frozen instead, the archtest would pass vacuously. Mitigation:
-//     the test loads the type via `go/types` package path and asserts the
-//     canonical path suffix matches `/runtime/composition`.
+//     the reflect handle is taken from `composition.CellModule` / `composition.ModuleResult`
+//     directly (canonical import path), so a sibling type cannot be substituted.
+//  4. **Handoff field smuggled into ModuleResult**: a new exported field on
+//     ModuleResult (e.g. `Exports any`) would re-open value handoff without
+//     touching the method signature. `TestModuleProvideSignatureFrozen01_ModuleResultFieldsFrozen`
+//     asserts NumField()==3 and the exact field-name set {Cell,Opts,Resources},
+//     so any extra/renamed field fails. This is the structural successor of the
+//     old Out[]-list freeze (the resource/opts channels moved from positional
+//     returns into ModuleResult fields).
 //
 // ## Symbol inventory (lives here, not in ai-robust.md per the charter)
 //
@@ -44,10 +63,12 @@
 //   - Frozen method: `Provide`
 //   - Required In[0]: `context.Context`
 //   - Required In[1]: `*runtime/composition.SharedDeps`
-//   - Required Out[0]: `kernel/cell.Cell`
-//   - Required Out[1]: `[]runtime/bootstrap.Option`
-//   - Required Out[2]: `[]kernel/lifecycle.ManagedResource`
-//   - Required Out[3]: `error`
+//   - Required Out[0]: `runtime/composition.ModuleResult`
+//   - Required Out[1]: `error`
+//   - Frozen struct: `github.com/ghbvf/gocell/runtime/composition.ModuleResult`
+//   - Field "Cell": `kernel/cell.Cell`
+//   - Field "Opts": `[]runtime/bootstrap.Option`
+//   - Field "Resources": `[]kernel/lifecycle.ManagedResource`
 //
 // See also: `runtime/composition/cell_module.go` godoc §MODULE-PROVIDE-NO-VALUE-HANDOFF-01.
 package archtest
@@ -71,7 +92,7 @@ const ruleModuleProvideNoValueHandoff01 = "MODULE-PROVIDE-NO-VALUE-HANDOFF-01"
 // TestModuleProvideSignatureFrozen01 reflects over the composition.CellModule
 // interface and asserts that Provide has exactly the expected signature:
 //
-//	Provide(context.Context, *SharedDeps) (cell.Cell, []bootstrap.Option, []lifecycle.ManagedResource, error)
+//	Provide(context.Context, *SharedDeps) (ModuleResult, error)
 //
 // Any deviation — extra parameter, extra return, wrong types in any position —
 // causes an immediate test failure, preventing re-introduction of the
@@ -115,35 +136,72 @@ func TestModuleProvideSignatureFrozen01(t *testing.T) {
 		"%s: Provide In[1] must be *composition.SharedDeps; got %s",
 		ruleModuleProvideNoValueHandoff01, mt.In(1))
 
-	// Assert exactly 4 outputs.
-	require.Equal(t, 4, mt.NumOut(),
-		"%s: Provide must have exactly 4 output values (cell.Cell, []bootstrap.Option, []lifecycle.ManagedResource, error); got %d. "+
+	// Assert exactly 2 outputs (ModuleResult, error). The resource/opts channels
+	// now live as ModuleResult fields (single-source), not positional returns.
+	require.Equal(t, 2, mt.NumOut(),
+		"%s: Provide must have exactly 2 output values (ModuleResult, error); got %d. "+
 			"A ModuleExports or other cross-module handoff return is forbidden.",
 		ruleModuleProvideNoValueHandoff01, mt.NumOut())
 
-	// Assert Out[0] = cell.Cell
-	cellType := reflect.TypeOf((*cell.Cell)(nil)).Elem()
-	assert.Equal(t, cellType, mt.Out(0),
-		"%s: Provide Out[0] must be cell.Cell; got %s",
+	// Assert Out[0] = composition.ModuleResult
+	moduleResultType := reflect.TypeOf(composition.ModuleResult{})
+	assert.Equal(t, moduleResultType, mt.Out(0),
+		"%s: Provide Out[0] must be composition.ModuleResult; got %s",
 		ruleModuleProvideNoValueHandoff01, mt.Out(0))
 
-	// Assert Out[1] = []bootstrap.Option
-	bootstrapOptSliceType := reflect.TypeOf([]bootstrap.Option(nil))
-	assert.Equal(t, bootstrapOptSliceType, mt.Out(1),
-		"%s: Provide Out[1] must be []bootstrap.Option; got %s",
-		ruleModuleProvideNoValueHandoff01, mt.Out(1))
-
-	// Assert Out[2] = []lifecycle.ManagedResource
-	managedResSliceType := reflect.TypeOf([]kernellifecycle.ManagedResource(nil))
-	assert.Equal(t, managedResSliceType, mt.Out(2),
-		"%s: Provide Out[2] must be []lifecycle.ManagedResource; got %s",
-		ruleModuleProvideNoValueHandoff01, mt.Out(2))
-
-	// Assert Out[3] = error
+	// Assert Out[1] = error
 	errType := reflect.TypeOf((*error)(nil)).Elem()
-	assert.Equal(t, errType, mt.Out(3),
-		"%s: Provide Out[3] must be error; got %s",
-		ruleModuleProvideNoValueHandoff01, mt.Out(3))
+	assert.Equal(t, errType, mt.Out(1),
+		"%s: Provide Out[1] must be error; got %s",
+		ruleModuleProvideNoValueHandoff01, mt.Out(1))
+}
+
+// TestModuleProvideSignatureFrozen01_ModuleResultFieldsFrozen verifies blind
+// spot 4: the ModuleResult struct must have exactly three exported fields
+// {Cell, Opts, Resources} with the exact types. An extra field (e.g. a smuggled
+// `Exports any` handoff channel), a rename, or a type change fails immediately.
+func TestModuleProvideSignatureFrozen01_ModuleResultFieldsFrozen(t *testing.T) {
+	t.Parallel()
+
+	rt := reflect.TypeOf(composition.ModuleResult{})
+	require.Equal(t, reflect.Struct, rt.Kind(),
+		"%s: composition.ModuleResult must be a struct; got %s",
+		ruleModuleProvideNoValueHandoff01, rt.Kind())
+
+	// Exactly 3 fields — bans an extra handoff field.
+	require.Equal(t, 3, rt.NumField(),
+		"%s: ModuleResult must have exactly 3 fields {Cell, Opts, Resources}; got %d. "+
+			"A new field (e.g. an Exports handoff channel) is forbidden.",
+		ruleModuleProvideNoValueHandoff01, rt.NumField())
+
+	// Exact field-name set (catches a rename to a handoff-y field).
+	names := map[string]struct{}{}
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		assert.True(t, f.IsExported(),
+			"%s: ModuleResult field %q must be exported", ruleModuleProvideNoValueHandoff01, f.Name)
+		names[f.Name] = struct{}{}
+	}
+	assert.Equal(t, map[string]struct{}{"Cell": {}, "Opts": {}, "Resources": {}}, names,
+		"%s: ModuleResult field-name set must be exactly {Cell, Opts, Resources}",
+		ruleModuleProvideNoValueHandoff01)
+
+	// Exact field types.
+	cellField, ok := rt.FieldByName("Cell")
+	require.True(t, ok, "%s: ModuleResult.Cell must exist", ruleModuleProvideNoValueHandoff01)
+	assert.Equal(t, reflect.TypeOf((*cell.Cell)(nil)).Elem(), cellField.Type,
+		"%s: ModuleResult.Cell must be cell.Cell; got %s", ruleModuleProvideNoValueHandoff01, cellField.Type)
+
+	optsField, ok := rt.FieldByName("Opts")
+	require.True(t, ok, "%s: ModuleResult.Opts must exist", ruleModuleProvideNoValueHandoff01)
+	assert.Equal(t, reflect.TypeOf([]bootstrap.Option(nil)), optsField.Type,
+		"%s: ModuleResult.Opts must be []bootstrap.Option; got %s", ruleModuleProvideNoValueHandoff01, optsField.Type)
+
+	resField, ok := rt.FieldByName("Resources")
+	require.True(t, ok, "%s: ModuleResult.Resources must exist", ruleModuleProvideNoValueHandoff01)
+	assert.Equal(t, reflect.TypeOf([]kernellifecycle.ManagedResource(nil)), resField.Type,
+		"%s: ModuleResult.Resources must be []lifecycle.ManagedResource; got %s",
+		ruleModuleProvideNoValueHandoff01, resField.Type)
 }
 
 // TestModuleProvideSignatureFrozen_ReverseCheck_AliasNotPresent verifies blind

--- a/tools/archtest/observability_metrics_test.go
+++ b/tools/archtest/observability_metrics_test.go
@@ -396,10 +396,12 @@ const adapterPromPkg = "github.com/ghbvf/gocell/adapters/prometheus"
 // surface entirely. Once #885 lands, these four entries and the public
 // NewCounter/NewCounterVec/NewGauge/NewGaugeFunc exports are deleted.
 var adapterPromCallerAllowlist = map[string]map[string]struct{}{
-	// configcore stale-cipher counter wiring moved back to cmd/corebundle (#1085,
-	// Batch 4 Part A): adapter construction lives in cmd/ so cellmodules/configcore
-	// never imports github.com/prometheus/client_golang.
-	"RegisterOrReuseCounter": {"cmd/corebundle/configcore_key_provider.go": {}},
+	// RegisterOrReuseCounter has no production caller: configcore's stale-cipher
+	// counter migrated to the kernel MetricsProvider (runtime/observability/metrics)
+	// in #1413, so cmd/corebundle no longer builds it from a raw prom registry. The
+	// symbol stays governed (empty allowlist = no sanctioned external caller); a
+	// future caller must add its file here with justification.
+	"RegisterOrReuseCounter": {},
 	"NewCounter":             {"adapters/vault/transit_metrics.go": {}},
 	// NewCounterVec is a labeled-metric carve-out pending removal (issue #885):
 	// vault's loginOutcome migrates to metrics.Provider.CounterVec, after which

--- a/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/decoypkg/decoy.go
+++ b/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/decoypkg/decoy.go
@@ -1,0 +1,9 @@
+// Package decoypkg provides a homonym of runtime/bootstrap.WithManagedResource.
+// The GREEN fixture calls it to prove the funnel's type-resolution discriminates
+// by package path (Pkg().Path()) and does NOT over-fire on a same-named func from
+// an unrelated package.
+package decoypkg
+
+// WithManagedResource is intentionally named identically to
+// runtime/bootstrap.WithManagedResource but belongs to a different package.
+func WithManagedResource(_ any) any { return nil }

--- a/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/green/usage.go
+++ b/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/green/usage.go
@@ -1,0 +1,9 @@
+// Package green is a GREEN reverse-self-check fixture for
+// WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01. It references a same-named func from a
+// DIFFERENT package; the funnel's type-resolution must NOT flag it (Pkg().Path()
+// is decoypkg, not runtime/bootstrap).
+package green
+
+import decoy "github.com/ghbvf/gocell/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/decoypkg"
+
+var _ = decoy.WithManagedResource(nil)

--- a/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/red/alias.go
+++ b/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/red/alias.go
@@ -1,0 +1,7 @@
+package red
+
+// import-alias form: bs.WithManagedResource(...) — the alias collapses to the
+// same *types.Func under Uses, so the alias does not disguise the reference.
+import bs "github.com/ghbvf/gocell/runtime/bootstrap"
+
+var _ = bs.WithManagedResource(nil)

--- a/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/red/call.go
+++ b/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/red/call.go
@@ -1,0 +1,17 @@
+// Package red is a RED reverse-self-check fixture for
+// WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01. It references
+// runtime/bootstrap.WithManagedResource in every form a cell module might use to
+// bypass a CallExpr-only scan. The funnel's Uses-sweep detector must flag each.
+//
+// This file covers the CALL form and the FUNC-VALUE form (the latter is the
+// reference a CallExpr.Fun-only walk would miss).
+package red
+
+import bootstrap "github.com/ghbvf/gocell/runtime/bootstrap"
+
+// call form: bootstrap.WithManagedResource(...) in CallExpr.Fun position.
+var _ = bootstrap.WithManagedResource(nil)
+
+// func-value form: the reference is NOT in CallExpr.Fun position — a
+// CallExpr-only walk misses it, but Uses[ident] still resolves to the func.
+var _ = bootstrap.WithManagedResource

--- a/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/red/dotimport.go
+++ b/tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/red/dotimport.go
@@ -1,0 +1,8 @@
+package red
+
+// dot-import form: a bare WithManagedResource(...) ident with no package
+// qualifier — a SelectorExpr-based scan misses it entirely, but Uses[ident]
+// resolves the bare ident to runtime/bootstrap's func.
+import . "github.com/ghbvf/gocell/runtime/bootstrap"
+
+var _ = WithManagedResource(nil)

--- a/tools/archtest/withmanagedresource_cellmodule_funnel_test.go
+++ b/tools/archtest/withmanagedresource_cellmodule_funnel_test.go
@@ -1,0 +1,161 @@
+package archtest
+
+// invariants:
+//   - INVARIANT: WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01
+//
+// # WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01 — cellmodules must not call bootstrap.WithManagedResource
+//
+// ## Rule
+//
+// No production file under `cellmodules/` may call
+// `runtime/bootstrap.WithManagedResource(...)`. Cell modules declare their
+// managed resources by returning them in `composition.ModuleResult.Resources`
+// (the single-source channel introduced by PR #591 / #1420). The Builder
+// (`runtime/composition/builder.go`) is the sole sanctioned caller that turns a
+// module's `Resources` into `bootstrap.WithManagedResource(r)` AND into the
+// pre-Run rollback stack — deriving BOTH from one source so the two can never
+// diverge.
+//
+// Before #1420 each module wrote the same resource twice: once via
+// `bootstrap.WithManagedResource(res)` in its opts (steady-state) and once in
+// its provisional return (rollback). Forgetting either half leaked a resource or
+// dropped a /readyz probe. Banning the call in cellmodules/ closes that
+// double-write: a module CANNOT register a resource for the happy path except by
+// listing it in `Resources`, which the Builder also rolls back.
+//
+// ## AI-robust rating
+//
+//   - Downstream: **Hard** — the funnel is closed by a zero-tolerance
+//     caller-ban: `WithManagedResource` may not appear at any callsite under
+//     cellmodules/. The qualifier is resolved to `runtime/bootstrap` via the
+//     file's imports (so an import alias collapses to the same path and a decoy
+//     `x.WithManagedResource` from another package does not match). Same shape
+//     and tool as CONFIG-NOOP-TRANSFORMER-FUNNEL-01.
+//   - Upstream: **Medium** — Go cannot make "call this exported func from
+//     package X" inexpressible; a future cellmodules file CAN add the call and
+//     only this archtest (CI) catches it. Same permanent ceiling as
+//     MIGRATOR-PROVIDER-UP-CALLSITE-01 / CONFIG-NOOP-TRANSFORMER-FUNNEL-01 and
+//     the holder-seal funnels (#851 / #893 / #1282).
+//
+// ## Blind spots (AST-only Run; documented per ai-robust §载体决策原则)
+//
+//   - `WithManagedResource` stored as a func value then called indirectly is not
+//     tracked (no corpus case; the construction reference itself — the
+//     SelectorExpr `bootstrap.WithManagedResource` — would still appear and is
+//     out of scope of the CallExpr scan). A reverse self-check documents the
+//     matched form.
+//   - A new package added under cellmodules/ is auto-covered: the scope is the
+//     `cellmodules/` path prefix, not an enumerated package list.
+//   - Test files (_test.go) are excluded: builder/module unit tests legitimately
+//     construct WithManagedResource to assemble fakes.
+//   - Out-of-scope callers (cmd/corebundle, examples/iotdevice, examples/ssobff)
+//     call bootstrap.New directly and are composition roots, not CellModules;
+//     they live outside cellmodules/ and are never visited — the path-prefix
+//     scope IS the allowlist boundary, so no per-caller carve-out is needed.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ruleWithManagedResourceCellmoduleFunnel01 = "WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01"
+	// bootstrapPkgPath derived from PlatformModulePath per ARCHTEST-MODULE-PATH-FUNNEL-01.
+	bootstrapPkgPath        = PlatformModulePath + "/runtime/bootstrap"
+	withManagedResourceFunc = "WithManagedResource"
+	cellmodulesScopePrefix  = "cellmodules/"
+)
+
+// TestWithManagedResourceCellmoduleFunnel01 enforces that no production file
+// under cellmodules/ calls bootstrap.WithManagedResource — modules must return
+// resources via ModuleResult.Resources and let the Builder funnel them.
+func TestWithManagedResourceCellmoduleFunnel01(t *testing.T) {
+	root := findModuleRoot(t)
+
+	var violations []string
+	Run(t, AST(ModuleScope(root)), func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if !strings.HasPrefix(rel, cellmodulesScopePrefix) {
+				continue
+			}
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != withManagedResourceFunc {
+					return
+				}
+				qual, isIdent := sel.X.(*ast.Ident)
+				if !isIdent || importPathForQualifier(file, qual.Name) != bootstrapPkgPath {
+					return
+				}
+				fnName := enclosingFuncName(file, call.Pos())
+				if fnName == "" {
+					fnName = "<package-level>"
+				}
+				violations = append(violations, rel+"::"+fnName)
+			})
+		}
+		return nil
+	})
+
+	assert.Emptyf(t, violations,
+		"%s: bootstrap.WithManagedResource called inside cellmodules/ (offending sites: %v). "+
+			"Cell modules must declare resources via composition.ModuleResult.Resources; the "+
+			"Builder is the sole funnel that calls WithManagedResource (and derives rollback from "+
+			"the same source). Move the resource into the returned ModuleResult.Resources slice.",
+		ruleWithManagedResourceCellmoduleFunnel01, violations)
+}
+
+// TestWithManagedResourceCellmoduleFunnel01_DetectsViolation is the reverse
+// self-check: it proves the scan's predicate flags a bootstrap.WithManagedResource
+// call and does NOT mis-flag a same-named call from a different (non-bootstrap)
+// package. Without this, a regression that silently stopped matching would pass
+// the forward test vacuously.
+func TestWithManagedResourceCellmoduleFunnel01_DetectsViolation(t *testing.T) {
+	const src = `package foo
+
+import (
+	bootstrap "github.com/ghbvf/gocell/runtime/bootstrap"
+	other "example.com/other"
+)
+
+func bad() any { return bootstrap.WithManagedResource(nil) }
+
+func decoy() any { return other.WithManagedResource(nil) }
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "module.go", src, 0)
+	require.NoError(t, err)
+
+	var bootstrapHits, decoyHits []string
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != withManagedResourceFunc {
+			return
+		}
+		qual, isIdent := sel.X.(*ast.Ident)
+		if !isIdent {
+			return
+		}
+		fnName := enclosingFuncName(file, call.Pos())
+		if importPathForQualifier(file, qual.Name) == bootstrapPkgPath {
+			bootstrapHits = append(bootstrapHits, fnName)
+		} else {
+			decoyHits = append(decoyHits, fnName)
+		}
+	})
+
+	assert.Equal(t, []string{"bad"}, bootstrapHits,
+		"the bootstrap.WithManagedResource call in bad() must be detected")
+	assert.Equal(t, []string{"decoy"}, decoyHits,
+		"a same-named call from a non-bootstrap package must NOT resolve to runtime/bootstrap")
+}

--- a/tools/archtest/withmanagedresource_cellmodule_funnel_test.go
+++ b/tools/archtest/withmanagedresource_cellmodule_funnel_test.go
@@ -66,11 +66,12 @@ import (
 
 const (
 	ruleWithManagedResourceCellmoduleFunnel01 = "WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01"
-	// bootstrapPkgPath derived from PlatformModulePath per ARCHTEST-MODULE-PATH-FUNNEL-01.
-	bootstrapPkgPath        = PlatformModulePath + "/runtime/bootstrap"
-	withManagedResourceFunc = "WithManagedResource"
-	cellmodulesScopePrefix  = "cellmodules/"
+	withManagedResourceFunc                   = "WithManagedResource"
+	cellmodulesScopePrefix                    = "cellmodules/"
 )
+
+// bootstrapPkgPath ("github.com/ghbvf/gocell/runtime/bootstrap") is declared in
+// probename_sealed_funnel_test.go and reused here (same package).
 
 // TestWithManagedResourceCellmoduleFunnel01 enforces that no production file
 // under cellmodules/ calls bootstrap.WithManagedResource — modules must return

--- a/tools/archtest/withmanagedresource_cellmodule_funnel_test.go
+++ b/tools/archtest/withmanagedresource_cellmodule_funnel_test.go
@@ -3,60 +3,76 @@ package archtest
 // invariants:
 //   - INVARIANT: WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01
 //
-// # WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01 — cellmodules must not call bootstrap.WithManagedResource
+// # WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01 — cellmodules must not reference bootstrap.WithManagedResource
 //
 // ## Rule
 //
-// No production file under `cellmodules/` may call
-// `runtime/bootstrap.WithManagedResource(...)`. Cell modules declare their
-// managed resources by returning them in `composition.ModuleResult.Resources`
-// (the single-source channel introduced by PR #591 / #1420). The Builder
-// (`runtime/composition/builder.go`) is the sole sanctioned caller that turns a
+// No production file under `cellmodules/` may reference
+// `runtime/bootstrap.WithManagedResource` in ANY form (call, func-value,
+// import-alias, or dot-import). Cell modules declare their managed resources by
+// returning them in `composition.ModuleResult.Resources` (the single-source
+// channel introduced by PR #591 / #1420). The Builder
+// (`runtime/composition/builder.go`) is the sole sanctioned site that turns a
 // module's `Resources` into `bootstrap.WithManagedResource(r)` AND into the
 // pre-Run rollback stack — deriving BOTH from one source so the two can never
-// diverge.
+// diverge (the former double-write bug).
 //
-// Before #1420 each module wrote the same resource twice: once via
-// `bootstrap.WithManagedResource(res)` in its opts (steady-state) and once in
-// its provisional return (rollback). Forgetting either half leaked a resource or
-// dropped a /readyz probe. Banning the call in cellmodules/ closes that
-// double-write: a module CANNOT register a resource for the happy path except by
-// listing it in `Resources`, which the Builder also rolls back.
+// Composition roots OUTSIDE cellmodules/ (`cmd/corebundle`, `examples/iotdevice`,
+// `examples/ssobff`) legitimately call WithManagedResource directly — they are
+// not CellModules. The `cellmodules/` path prefix IS the scope boundary, so no
+// per-caller carve-out is needed.
 //
 // ## AI-robust rating
 //
-//   - Downstream: **Hard** — the funnel is closed by a zero-tolerance
-//     caller-ban: `WithManagedResource` may not appear at any callsite under
-//     cellmodules/. The qualifier is resolved to `runtime/bootstrap` via the
-//     file's imports (so an import alias collapses to the same path and a decoy
-//     `x.WithManagedResource` from another package does not match). Same shape
-//     and tool as CONFIG-NOOP-TRANSFORMER-FUNNEL-01.
-//   - Upstream: **Medium** — Go cannot make "call this exported func from
-//     package X" inexpressible; a future cellmodules file CAN add the call and
-//     only this archtest (CI) catches it. Same permanent ceiling as
-//     MIGRATOR-PROVIDER-UP-CALLSITE-01 / CONFIG-NOOP-TRANSFORMER-FUNNEL-01 and
-//     the holder-seal funnels (#851 / #893 / #1282).
+//   - Downstream: **Hard** — the reference identity is resolved through
+//     `p.TypesInfo.Uses[ident] → *types.Func → Pkg().Path()=="…/runtime/bootstrap"
+//     && Name()=="WithManagedResource"`, exactly the PANIC-REGISTERED-01 /
+//     TYPESUTIL-IMPLEMENTS-FUNNEL-01 type-resolution kernel. Because the Uses
+//     sweep covers EVERY reference form — call `bootstrap.WithManagedResource(r)`,
+//     func-value `f := bootstrap.WithManagedResource`, import-alias
+//     `bs.WithManagedResource(r)`, dot-import bare `WithManagedResource(r)` —
+//     there is no "looks like a reference but isn't" gray zone and no shape a
+//     CallExpr-only walk would miss. (The pre-#1511 AST walk matched only
+//     `CallExpr.Fun` SelectorExprs, so func-value and dot-import bypassed it;
+//     this is the F3 finding that motivated the type-aware upgrade.)
+//   - Upstream: **Medium** — Go cannot make "reference this exported func from a
+//     package under cellmodules/" inexpressible; a future cellmodules file CAN add
+//     the reference and only this archtest (CI) catches it. Same permanent ceiling
+//     as the holder-seal funnels (#851 / #893 / #1282). For an exported symbol Go
+//     cannot seal against a chosen importer set, archtest-bound type-resolution +
+//     fail-on-deviation is the Hard ceiling for the downstream axis; the upstream
+//     axis stays an honest Medium.
 //
-// ## Blind spots (AST-only Run; documented per ai-robust §载体决策原则)
+// ## Blind spots (charter §"工具选定后强制盲区自检"; each has a reverse self-check fixture)
 //
-//   - `WithManagedResource` stored as a func value then called indirectly is not
-//     tracked (no corpus case; the construction reference itself — the
-//     SelectorExpr `bootstrap.WithManagedResource` — would still appear and is
-//     out of scope of the CallExpr scan). A reverse self-check documents the
-//     matched form.
-//   - A new package added under cellmodules/ is auto-covered: the scope is the
-//     `cellmodules/` path prefix, not an enumerated package list.
-//   - Test files (_test.go) are excluded: builder/module unit tests legitimately
-//     construct WithManagedResource to assemble fakes.
-//   - Out-of-scope callers (cmd/corebundle, examples/iotdevice, examples/ssobff)
-//     call bootstrap.New directly and are composition roots, not CellModules;
-//     they live outside cellmodules/ and are never visited — the path-prefix
-//     scope IS the allowlist boundary, so no per-caller carve-out is needed.
+//   - call form `bootstrap.WithManagedResource(r)` — red fixture `red/call.go`.
+//   - func-value form `f := bootstrap.WithManagedResource` (reference NOT in
+//     CallExpr.Fun position) — red fixture `red/call.go`. The Uses sweep makes
+//     this a guarded case, not a blind spot.
+//   - import-alias form `bs.WithManagedResource(r)` — red fixture `red/alias.go`.
+//   - dot-import bare form `WithManagedResource(r)` (`import . "…/bootstrap"`) —
+//     red fixture `red/dotimport.go`.
+//   - homonym from a different package (`other.WithManagedResource`) — green
+//     fixture `green/usage.go` proves the type-resolution discriminates by
+//     Pkg().Path() and does NOT over-fire.
+//   - `_test.go` files are excluded (Production scope is Tests:false AND the
+//     detector skips _test.go): builder/module unit tests legitimately construct
+//     WithManagedResource to assemble fakes.
+//   - generated/ output excluded by Run(t, Production(...)); codegen does not emit
+//     WithManagedResource references. Honest scope declaration.
+//   - testdata/ RED/GREEN fixtures are excluded from the forward Production scan
+//     (Go excludes testdata/ from ./...) and loaded explicitly by the reverse
+//     self-check via Run(t, Typed(...)) non-recursive patterns.
+//
+// ref: tools/archtest/implements_funnel_test.go — the companion Hard pattern
+//
+//	(Uses → *types.Func identity, every reference form covered).
+//
+// ref: runtime/composition/builder.go — managedResourceOpts, the sole sanctioned site.
 
 import (
 	"go/ast"
-	"go/parser"
-	"go/token"
+	"go/types"
 	"strings"
 	"testing"
 
@@ -68,95 +84,151 @@ const (
 	ruleWithManagedResourceCellmoduleFunnel01 = "WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01"
 	withManagedResourceFunc                   = "WithManagedResource"
 	cellmodulesScopePrefix                    = "cellmodules/"
+	// withManagedResourceFixturePrefix is the module-relative prefix of this
+	// rule's reverse-self-check fixtures; the reverse test passes it as the
+	// scope so the SAME detector predicate exercises the RED/GREEN fixtures.
+	withManagedResourceFixturePrefix = "tools/archtest/testdata/withmanagedresource_cellmodule_fixtures/"
 )
 
 // bootstrapPkgPath ("github.com/ghbvf/gocell/runtime/bootstrap") is declared in
 // probename_sealed_funnel_test.go and reused here (same package).
 
-// TestWithManagedResourceCellmoduleFunnel01 enforces that no production file
-// under cellmodules/ calls bootstrap.WithManagedResource — modules must return
-// resources via ModuleResult.Resources and let the Builder funnel them.
-func TestWithManagedResourceCellmoduleFunnel01(t *testing.T) {
-	root := findModuleRoot(t)
-
-	var violations []string
-	Run(t, AST(ModuleScope(root)), func(p *Pass) []Diagnostic {
-		for _, file := range p.Files {
-			rel := p.Rel(file)
-			if !strings.HasPrefix(rel, cellmodulesScopePrefix) {
-				continue
-			}
-			if strings.HasSuffix(rel, "_test.go") {
-				continue
-			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != withManagedResourceFunc {
-					return
-				}
-				qual, isIdent := sel.X.(*ast.Ident)
-				if !isIdent || importPathForQualifier(file, qual.Name) != bootstrapPkgPath {
-					return
-				}
-				fnName := enclosingFuncName(file, call.Pos())
-				if fnName == "" {
-					fnName = "<package-level>"
-				}
-				violations = append(violations, rel+"::"+fnName)
-			})
+// collectWithManagedResourceFunnelViolations sweeps p.TypesInfo.Uses across every
+// file under scopePrefix in the Pass and reports each *ast.Ident that resolves to
+// the runtime/bootstrap.WithManagedResource *types.Func. Sweeping Uses (rather
+// than only CallExpr.Fun) is what makes the rule Hard: call form, func-value form,
+// import-alias form, and dot-import bare form all produce a Uses entry whose object
+// is the same *types.Func, so no reference shape escapes.
+//
+// scopePrefix is the only allowlist boundary: the forward test passes
+// cellmodulesScopePrefix; the reverse self-check passes the fixture prefix. The
+// type-resolution predicate is identical in both — only the path scope differs,
+// which is inherent to a path-scoped (not single-file-allowlist) rule.
+func collectWithManagedResourceFunnelViolations(p *Pass, scopePrefix string) []Diagnostic {
+	if p.TypesInfo == nil || p.Fset == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, f := range p.Files {
+		rel := p.Rel(f)
+		if !strings.HasPrefix(rel, scopePrefix) {
+			continue
 		}
+		if strings.HasSuffix(rel, "_test.go") {
+			continue // module unit tests may construct WithManagedResource for fakes
+		}
+		EachInSubtree[ast.Ident](f, func(id *ast.Ident) {
+			fn, ok := p.TypesInfo.Uses[id].(*types.Func)
+			if !ok || fn.Pkg() == nil {
+				return
+			}
+			if fn.Pkg().Path() != bootstrapPkgPath || fn.Name() != withManagedResourceFunc {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(id.Pos()).Line,
+				Message: "bootstrap.WithManagedResource referenced inside " + scopePrefix +
+					"; cell modules must declare resources via composition.ModuleResult.Resources " +
+					"(the Builder is the sole sanctioned site that calls WithManagedResource and " +
+					"derives rollback from the same source).",
+			})
+		})
+	}
+	return diags
+}
+
+// TestWithManagedResourceCellmoduleFunnel01 enforces that no production file under
+// cellmodules/ references bootstrap.WithManagedResource in any form. sawCellmodulesFile
+// is a structural regression guard: if a future refactor renames the cellmodules/
+// tree, the scan would otherwise pass vacuously green.
+func TestWithManagedResourceCellmoduleFunnel01(t *testing.T) {
+	t.Parallel()
+
+	var violations []Diagnostic
+	sawCellmodulesFile := false
+
+	_ = Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			if strings.HasPrefix(rel, cellmodulesScopePrefix) && !strings.HasSuffix(rel, "_test.go") {
+				sawCellmodulesFile = true
+			}
+		}
+		violations = append(violations, collectWithManagedResourceFunnelViolations(p, cellmodulesScopePrefix)...)
 		return nil
 	})
 
+	require.Truef(t, sawCellmodulesFile,
+		"%s scope regression: no production cellmodules/ file was scanned (tree renamed?). "+
+			"A vacuous green here would hide every future violation.",
+		ruleWithManagedResourceCellmoduleFunnel01)
+
 	assert.Emptyf(t, violations,
-		"%s: bootstrap.WithManagedResource called inside cellmodules/ (offending sites: %v). "+
+		"%s: bootstrap.WithManagedResource referenced inside cellmodules/ (offending sites: %v). "+
 			"Cell modules must declare resources via composition.ModuleResult.Resources; the "+
-			"Builder is the sole funnel that calls WithManagedResource (and derives rollback from "+
-			"the same source). Move the resource into the returned ModuleResult.Resources slice.",
+			"Builder is the sole sanctioned site that calls WithManagedResource (and derives "+
+			"rollback from the same source). Move the resource into the returned "+
+			"ModuleResult.Resources slice.",
 		ruleWithManagedResourceCellmoduleFunnel01, violations)
 }
 
-// TestWithManagedResourceCellmoduleFunnel01_DetectsViolation is the reverse
-// self-check: it proves the scan's predicate flags a bootstrap.WithManagedResource
-// call and does NOT mis-flag a same-named call from a different (non-bootstrap)
-// package. Without this, a regression that silently stopped matching would pass
-// the forward test vacuously.
-func TestWithManagedResourceCellmoduleFunnel01_DetectsViolation(t *testing.T) {
-	const src = `package foo
+// TestWithManagedResourceCellmoduleFunnel01_Fixtures is the reverse self-check
+// mandated by charter §"工具选定后强制盲区自检": it proves the detector actually
+// fires for every reference form (call / func-value / import-alias / dot-import)
+// and does NOT over-fire on a same-named func from another package.
+//
+// Each fixture pattern is non-recursive (Run(t, Typed(...))) so a typed Run yields
+// exactly the fixture package as a Pass (deps loaded for type info but not yielded).
+// Typed (rather than StandaloneModule) is used because the RED fixtures import the
+// main-module package runtime/bootstrap to reference the REAL WithManagedResource
+// *types.Func — an isolated module would need a replace directive.
+func TestWithManagedResourceCellmoduleFunnel01_Fixtures(t *testing.T) {
+	t.Parallel()
 
-import (
-	bootstrap "github.com/ghbvf/gocell/runtime/bootstrap"
-	other "example.com/other"
-)
+	tests := []struct {
+		name string
+		dir  string
+		// wantMin is the minimum violation count for RED dirs (4 reference forms:
+		// call + func-value in call.go, alias in alias.go, dot-import in
+		// dotimport.go). wantZero marks the GREEN dir (homonym, must not fire).
+		wantMin  int
+		wantZero bool
+	}{
+		{name: "red all reference forms", dir: "red", wantMin: 4},
+		{name: "green homonym decoy", dir: "green", wantZero: true},
+	}
 
-func bad() any { return bootstrap.WithManagedResource(nil) }
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-func decoy() any { return other.WithManagedResource(nil) }
-`
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "module.go", src, 0)
-	require.NoError(t, err)
+			pattern := "./" + withManagedResourceFixturePrefix + tc.dir
 
-	var bootstrapHits, decoyHits []string
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != withManagedResourceFunc {
-			return
-		}
-		qual, isIdent := sel.X.(*ast.Ident)
-		if !isIdent {
-			return
-		}
-		fnName := enclosingFuncName(file, call.Pos())
-		if importPathForQualifier(file, qual.Name) == bootstrapPkgPath {
-			bootstrapHits = append(bootstrapHits, fnName)
-		} else {
-			decoyHits = append(decoyHits, fnName)
-		}
-	})
+			var diags []Diagnostic
+			scanned := false
+			_ = Run(t, Typed(TypedOpts{}, []string{pattern}), func(p *Pass) []Diagnostic {
+				if len(p.Files) > 0 {
+					scanned = true
+				}
+				diags = append(diags, collectWithManagedResourceFunnelViolations(p, withManagedResourceFixturePrefix)...)
+				return nil
+			})
 
-	assert.Equal(t, []string{"bad"}, bootstrapHits,
-		"the bootstrap.WithManagedResource call in bad() must be detected")
-	assert.Equal(t, []string{"decoy"}, decoyHits,
-		"a same-named call from a non-bootstrap package must NOT resolve to runtime/bootstrap")
+			require.Truef(t, scanned, "fixture %s: no package loaded (path renamed?)", tc.dir)
+
+			if tc.wantZero {
+				assert.Emptyf(t, diags,
+					"%s green fixture %s: a same-named func from another package must NOT resolve "+
+						"to runtime/bootstrap.WithManagedResource (offending: %v)",
+					ruleWithManagedResourceCellmoduleFunnel01, tc.dir, diags)
+				return
+			}
+			assert.GreaterOrEqualf(t, len(diags), tc.wantMin,
+				"%s red fixture %s: detector must flag every reference form "+
+					"(call / func-value / import-alias / dot-import); got %d, want >= %d",
+				ruleWithManagedResourceCellmoduleFunnel01, tc.dir, len(diags), tc.wantMin)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

重构 `runtime/composition` 公开 API，落地两个 backlog issue：

- **#1420（P1）** `CellModule.Provide` 资源**双写单源化**：原 `(cell.Cell, []bootstrap.Option, []ManagedResource, error)` 要求每个模块把同一 `ManagedResource` 写进 `opts`（`WithManagedResource`，happy-path）+ 第 3 返回值 `provisional`（pre-Run rollback）两条通道，仅靠 godoc 约定（Soft）。收口为单一 `ModuleResult{Cell, Opts, Resources}`：`Builder.Build` 从 `Resources` 一处**同时**派生两条通道，双写漂移结构上不可能。
- **#1413（P2，最大彻底·不拖 #885）** `SharedDeps` 移除 2 个 configcore 专属字段 `EventbusCacheCollector`(required) + `ConfigStaleCipherInc`(optional)——configcore 经 kernel `MetricsProvider` 自建（走 obmetrics，非 raw `client_golang`，不违反治理姿态）。**纠正前提**：`ConfigEventCollector` 实为跨 cell（accesscore+configcore+corebundle），保留。`ConfigKeyProvider` 是唯一残留（vault-transit 经 raw-prom `TransitMetrics`，受 `adapterPromCallerAllowlist` 阻挡），收口 gated on **#885**。

> 探索期发现并修正：早先误判「#1413 全量需改 assembly 生成器」——实为 cellmodules 可 import adapters，真正阻挡 ConfigKeyProvider 的是 `adapterPromCallerAllowlist`(#1085 Batch 4) + 未落地 #885。

### Enforcement
- `MODULE-PROVIDE-NO-VALUE-HANDOFF-01` 由「reflect 冻结 4-out 返回列表」升级为「2-out（ModuleResult, error）+ `ModuleResult` struct 字段集冻结（`NumField()==3`+名+类型）」——**Hard**。额外封闭「把 Exports 夹带为结构体字段」向量。
- **新增** `WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01`：cellmodules 内禁调 `bootstrap.WithManagedResource`（资源单源经 `ModuleResult.Resources`，Builder 唯一漏斗）。下游 **Hard** / 上游 **Medium**（同 #851/#893/#1282 天花板）。
- 新 obmetrics `NewProviderConfigStaleCipherCollector`（kernel Provider）；metric 名 `gocell_config_stale_cipher_total` 与迁移前**字节一致**（零 wire 改名）。

### 顺带修复（broken merge on develop）
`tools/archtest/bootstrap_autowire_collector_funnel_test.go`（#1477 引入）调用 `RunTypedProduction`/`RunTypedFixture`，而 #1470(`#1037 §1d`) 已删除这两个 API → archtest 测试包在 develop 上**无法编译**，阻塞本 PR 新增 archtest。迁移其 2 处调用为 `Run(t, Production(...))` / `Run(t, Fixture(...))`。

## Contract / Implementation matrix（contract-fanout：interface 签名变更触发）

```
Contract: composition.CellModule.Provide (Go interface 方法签名)
Change:   (cell.Cell, []bootstrap.Option, []ManagedResource, error) -> (ModuleResult, error)
Implementations: [x] cellmodules/accesscore  [x] cellmodules/auditcore  [x] cellmodules/configcore
Conformance: tools/archtest MODULE-PROVIDE-NO-VALUE-HANDOFF-01 (reflect 冻结接口+struct)
             runtime/composition TestBuilder_HappyPath_SingleSourceResourceContract / _RollsBack
Repro: go test ./tools/archtest/ -run 'ModuleProvideSignatureFrozen01|WithManagedResourceCellmoduleFunnel01'
       go test ./runtime/composition/...
Dependent contracts (governance scan): none (composition 是 in-process 组装 API，无 contract.yaml)
Metric fanout: gocell_config_stale_cipher_total 构造点 cmd/ -> runtime/observability/metrics;
       fqName/label 不变; metrics-schema golden 4 assembly 已 regen (gocell generate metrics-schema --all)
```

## Test plan
- [x] `go build ./...`
- [x] `go test ./runtime/composition/... ./runtime/observability/metrics/... ./cellmodules/... ./cmd/corebundle/... ./examples/corebundlestarter/... ./adapters/prometheus/... ./tools/metricschema/...`
- [x] `go test ./tools/archtest/ -run 'ModuleProvideSignatureFrozen01|WithManagedResourceCellmoduleFunnel01|MetricsFunnel|BootstrapAutowireCollectorFunnel'`
- [x] `golangci-lint run` 0 issues（changed packages）
- [x] metrics-schema golden regen + `go test ./tools/metricschema/...` 绿

ref: uber-go/fx fx/lifecycle.go（`Lifecycle.Append(Hook{OnStart,OnStop})` 一次注册派生双向 — 对应 `ModuleResult.Resources → {WithManagedResource, rollback}`）
ADR: docs/architecture/202605311000-1085-adr-cellmodule-composition-public-api.md §Amendment 2026-06-03

TDD：Wave 0 测试先 RED（commit 1）→ Wave 1 Part A GREEN → Wave 2 Part B GREEN → Wave 3 docs。

Closes #1420
Refs #1413 #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-up (round-2, F1–F5 — commit 1459088e8)

- **F1 (P1, CI blocker)**: `cmd/corebundle/integration_testhelpers_test.go` 仍按旧 4 返回值调 `Provide` → `go test -tags=integration ./cmd/corebundle` 编译失败（唯一遗漏点：build-tagged，默认 build/test 跳过）。迁移到 `(ModuleResult, error)`。
- **F2 (P1)**: `Builder.Build` rollback 直接 `v.Close(ctx)`，`provisional` 含 nil/typed-nil resource 时失败路径 panic（绕过 `WithManagedResource` phase0 nil 守卫）。改为 `resolveModuleResult → validateModuleResources` 上游 fail-fast，`provisional` 只含非 nil → rollback 不再 panic；repro 覆盖 bare-nil + typed-nil。
- **F3 (P2)**: `WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01` 原只扫 direct `CallExpr.Fun`，func-value 别名 + dot-import 可绕过「Hard」funnel。升级为 type-aware（`Run(t, Production)` + `TypesInfo.Uses → *types.Func` 身份），call/func-value/alias/dot-import 统一收口 → **下游真 Hard**；补 RED（4 形态）+ GREEN（同名 decoy）反向自检 fixture。
- **F4 (P2)**: `cmd/CLAUDE.md` CellModule 接口块更新为 `(ModuleResult, error)` + Resources 单源 / funnel 说明。
- **F5 (P2) — metrics-schema 可见性披露补全**: 原 PR 说明只强调「wire 名不变」不完整。`gocell_config_stale_cipher_total` 的 **fqName（Prometheus series 名）+ label 与迁移前字节一致**——按 series 名 key 的 dashboard/alert 不受影响。但 generated metrics-schema（contract-fanout 5 载体之一、消费方可读 inventory）有两类可感知变化：(1) **corebundle** schema `name` 字段由 `stale_cipher_total` **rename** 为 `config_stale_cipher_total`（fqName 不变；新 Provider collector `Name="config_stale_cipher_total"` vs 旧 raw-prom `Subsystem="config" Name="stale_cipher_total"`），外加 `file` 字段移到 `runtime/observability/metrics/`；(2) **examples/iotdevice / orderfulfillment / todoorder** 因 collector 移入 shared 包，`config_stale_cipher_total` 成为这三个 assembly schema 的**净新增条目**。详见 ADR `202605311000-1085` §Amendment 威胁/正确性再评。

**Verify**: `go vet -tags=integration ./...` green（CI blocker 已修）；`go test ./runtime/composition/... ./cmd/corebundle/... ./tools/metricschema/...` + funnel/signature archtests green；`golangci-lint` 0 issues（含 `Build` gocognit ≤ 15）。
