### PR TITLE
feat(assembly): cross-module cell refs + build-time cellID closed-set [#1086][#1093]

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -205,7 +205,7 @@ HTTP/gRPC **request-metrics** `cell` label 的 `_runtime` 哨兵单源 = `runtim
 
 ### cellID closed set（M12a #1093）
 
-业务 `cell` label 的合法取值集 = assembly.yaml 列举的 cell 集合。该 closed set 的 build 期真值源是 `composition.Builder.Build`（`runtime/composition/builder.go`）：`composition.New(assemblyCellIDs...)` 注入 assembly 声明的 cell-id 集，`Build` 对每个被装配 module 的 `ID()` 做双射校验（越界 / 缺失 / 重复 fail-fast），**越界 cellID 硬拒、不降级 `_runtime`**（外部 cell 注册不在 assembly 的 cellID 是配置 bug，混入 `_runtime` 会污染哨兵语义）。对标 K8s `runtime.Scheme` 注册期枚举 → 越界拒绝。
+业务 `cell` label 的合法取值集 = assembly.yaml 列举的 cell 集合。该 closed set 的 build 期真值源是 `composition.Builder.Build`（`runtime/composition/builder.go`），**两阶段**：(1) pre-Provide 对每个被装配 module 的 `ID()` 做双射校验（越界 / 缺失 / 重复 fail-fast）；(2) post-Provide 对每个 module 构造出的 cell 校验 `c.ID() == m.ID()`。`composition.New(assemblyCellIDs...)` 注入 assembly 声明的 cell-id 集（内部 `slices.Clone` 防 caller 篡改）。**越界 cellID 硬拒、不降级 `_runtime`**（外部 cell 注册不在 assembly 的 cellID 是配置 bug，混入 `_runtime` 会污染哨兵语义）。对标 K8s `runtime.Scheme` 注册期枚举 → 越界拒绝。第二阶段是必要的：runtime `cell` label 取自 `c.ID()`（cell metadata 派生），与 module 自报的 `m.ID()` 独立来源；只校验 `m.ID()` 会让 module 构造出越界身份的 cell 蒙混过双射（PR #1514 review F1）。
 
 **覆盖范围**：该 funnel 覆盖**走 `composition.Builder` 的 compositionAPI assembly**——当前 `cmd/corebundle` + `examples/corebundlestarter`，`cmd/corebundle` 原手写 `assertModuleIDsMatch` 已删。**legacy-form 示例 assembly**（`examples/todoorder` / `iotdevice` / `orderfulfillment`，用 `generatedCellModules() []CellModule` 本地类型形态，不经 `composition.Builder`）仍保留各自的手写 `assertModuleIDsMatch`；它们迁移到 `composition.New` closed set 是后续工作（待这些示例采用 compositionAPI/cellmodules 形态时）。详见 ADR `docs/architecture/202606030230-adr-assembly-cross-module-composition.md` §D4。
 

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -203,6 +203,12 @@ HTTP/gRPC **request-metrics** `cell` label 的 `_runtime` 哨兵单源 = `runtim
 - `cell` 是粗粒度 owner 维度，不是 slice / contract / tenant / user 维度；业务 SLO / 告警默认过滤 `cell!="_runtime"`，运行时探针与未匹配流量排查使用 `cell="_runtime"`。
 - 旧 dashboard / alert 需要过渡时，在 Prometheus 侧用 recording rule 聚合新序列；remote-write 或业务专用 Prometheus 需要降噪时，用 metric relabel drop `_runtime` 序列。示例见 `docs/ops/alerting-rules.md`。
 
+### cellID closed set（M12a #1093）
+
+业务 `cell` label 的合法取值集 = assembly.yaml 列举的 cell 集合。该 closed set 的 build 期真值源是 `composition.Builder.Build`（`runtime/composition/builder.go`）：`composition.New(assemblyCellIDs...)` 注入 assembly 声明的 cell-id 集，`Build` 对每个被装配 module 的 `ID()` 做双射校验（越界 / 缺失 / 重复 fail-fast），**越界 cellID 硬拒、不降级 `_runtime`**（外部 cell 注册不在 assembly 的 cellID 是配置 bug，混入 `_runtime` 会污染哨兵语义）。对标 K8s `runtime.Scheme` 注册期枚举 → 越界拒绝。取代旧 `cmd/corebundle.assertModuleIDsMatch`（仅覆盖 corebundle），现所有 assembly 自动继承。详见 ADR `docs/architecture/202606030230-adr-assembly-cross-module-composition.md` §D4。
+
+> **M12b（label 写入点 defense-in-depth）未并入本 PR**：`http_requests_total{cell}` 的 label value 在 registration-time enumerated set + `MustValidateLabels` 拒分隔符 + cardinality 上限 2000 + overflow bucket 已覆盖大部分；缺的「外部 cellID 是否 ∈ closed set」这层留在 #1093 M12b。
+
 ## gRPC Metrics `cell` Label（当前恒为 `_runtime`）
 
 `grpc_server_requests_total` / `grpc_server_request_duration_seconds` 复用与 HTTP 同一 `cell` label 语义与同一 `_runtime` 哨兵单源（`runtime/observability/metrics.RuntimeCellSentinel`）。但 gRPC cell attribution 接线尚未落地——HTTP 侧 router-root `CellAttribution` 从 `RouteGroup.CellID` 归属 cell，gRPC 对应的 `FullMethod → cellID` 归属（生成式 registrar 派生）随 epic PR-7/8 落地（tracking #1383）。**在此之前所有 gRPC 流量的 `cell` 恒为 `_runtime`，运维侧不要对 gRPC 指标用 `cell!="_runtime"` 过滤**（详见 `docs/ops/alerting-rules.md`）。reader 侧契约（cell label 取自 `ctxkeys.CellID`，缺失回退 `RuntimeCellSentinel`，禁硬编码）由 archtest `GRPC-METRICS-LABEL-CELLID-CTXSOURCE-01` 守卫，故 attribution 一旦接线，`cell` 自动反映归属 cell 而无需改 interceptor。

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -205,7 +205,9 @@ HTTP/gRPC **request-metrics** `cell` label 的 `_runtime` 哨兵单源 = `runtim
 
 ### cellID closed set（M12a #1093）
 
-业务 `cell` label 的合法取值集 = assembly.yaml 列举的 cell 集合。该 closed set 的 build 期真值源是 `composition.Builder.Build`（`runtime/composition/builder.go`）：`composition.New(assemblyCellIDs...)` 注入 assembly 声明的 cell-id 集，`Build` 对每个被装配 module 的 `ID()` 做双射校验（越界 / 缺失 / 重复 fail-fast），**越界 cellID 硬拒、不降级 `_runtime`**（外部 cell 注册不在 assembly 的 cellID 是配置 bug，混入 `_runtime` 会污染哨兵语义）。对标 K8s `runtime.Scheme` 注册期枚举 → 越界拒绝。取代旧 `cmd/corebundle.assertModuleIDsMatch`（仅覆盖 corebundle），现所有 assembly 自动继承。详见 ADR `docs/architecture/202606030230-adr-assembly-cross-module-composition.md` §D4。
+业务 `cell` label 的合法取值集 = assembly.yaml 列举的 cell 集合。该 closed set 的 build 期真值源是 `composition.Builder.Build`（`runtime/composition/builder.go`）：`composition.New(assemblyCellIDs...)` 注入 assembly 声明的 cell-id 集，`Build` 对每个被装配 module 的 `ID()` 做双射校验（越界 / 缺失 / 重复 fail-fast），**越界 cellID 硬拒、不降级 `_runtime`**（外部 cell 注册不在 assembly 的 cellID 是配置 bug，混入 `_runtime` 会污染哨兵语义）。对标 K8s `runtime.Scheme` 注册期枚举 → 越界拒绝。
+
+**覆盖范围**：该 funnel 覆盖**走 `composition.Builder` 的 compositionAPI assembly**——当前 `cmd/corebundle` + `examples/corebundlestarter`，`cmd/corebundle` 原手写 `assertModuleIDsMatch` 已删。**legacy-form 示例 assembly**（`examples/todoorder` / `iotdevice` / `orderfulfillment`，用 `generatedCellModules() []CellModule` 本地类型形态，不经 `composition.Builder`）仍保留各自的手写 `assertModuleIDsMatch`；它们迁移到 `composition.New` closed set 是后续工作（待这些示例采用 compositionAPI/cellmodules 形态时）。详见 ADR `docs/architecture/202606030230-adr-assembly-cross-module-composition.md` §D4。
 
 > **M12b（label 写入点 defense-in-depth）未并入本 PR**：`http_requests_total{cell}` 的 label value 在 registration-time enumerated set + `MustValidateLabels` 拒分隔符 + cardinality 上限 2000 + overflow bucket 已覆盖大部分；缺的「外部 cellID 是否 ∈ closed set」这层留在 #1093 M12b。
 

--- a/cmd/corebundle/corebundle_pg_env_integration_test.go
+++ b/cmd/corebundle/corebundle_pg_env_integration_test.go
@@ -114,7 +114,7 @@ func TestCorebundlePG_UsesConfigCoreDatabaseURL(t *testing.T) {
 	// auth, consumer base, etc.) are not under test here.
 	_ = locals // locals used only for shared deps construction, not module wiring
 	mods := generatedCellModules()
-	app, err := composition.New().With(mods...).Build(ctx, shared,
+	app, err := composition.New(corebundleCellIDs()...).With(mods...).Build(ctx, shared,
 		func(_ []cell.Cell) ([]bootstrap.Option, error) {
 			return nil, nil
 		})

--- a/cmd/corebundle/integration_testhelpers_test.go
+++ b/cmd/corebundle/integration_testhelpers_test.go
@@ -84,7 +84,21 @@ func buildBootstrapFromShared(
 		return opts, nil
 	}
 
-	return composition.New().With(mods...).Build(ctx, shared, runtimeOptsFunc)
+	return composition.New(corebundleCellIDs()...).With(mods...).Build(ctx, shared, runtimeOptsFunc)
+}
+
+// corebundleCellIDs returns the cell-id closed set for the corebundle assembly,
+// derived from generatedCellModules() so integration tests satisfy
+// composition.Builder.Build's M12a closed-set guard without hardcoding the cell
+// list. In production the set comes from the generated main.go's assembly cell
+// slice; both are derived from assembly.yaml.
+func corebundleCellIDs() []string {
+	mods := generatedCellModules()
+	ids := make([]string, len(mods))
+	for i, m := range mods {
+		ids[i] = m.ID()
+	}
+	return ids
 }
 
 // withCorebundleTestInternalListener returns a bootstrap.Option that registers

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -81,7 +81,7 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMatched(t *testing.T) {
 	// with the PG capability. Bootstrap options (listeners, auth) are omitted
 	// in this unit-level wiring test.
 	mods := generatedCellModules()
-	app, buildErr := composition.New().With(mods...).Build(ctx, shared,
+	app, buildErr := composition.New(corebundleCellIDs()...).With(mods...).Build(ctx, shared,
 		func(_ []cell.Cell) ([]bootstrap.Option, error) { return nil, nil })
 	require.NoError(t, buildErr, "Builder.Build must succeed with a fully migrated DB")
 	assert.NotNil(t, app, "App must be non-nil after successful Build")

--- a/cmd/corebundle/main_test.go
+++ b/cmd/corebundle/main_test.go
@@ -47,42 +47,29 @@ func setPodReachableHealthAddr(t *testing.T) {
 	t.Setenv("GOCELL_HTTP_HEALTH_ADDR", ":9091")
 }
 
-func TestCorebundleModulesMatchAssemblyMetadataOrder(t *testing.T) {
+// TestCorebundleAssemblyMatchesGeneratedModules verifies the corebundle
+// assembly.yaml cell set equals the generatedCellModules() ID set — the
+// assembly.yaml ↔ modules_gen.go drift guard. That guard is now enforced at
+// runtime by composition.Builder.Build's closed-set check (M12a #1093; the
+// hand-written assertModuleIDsMatch was removed); this test asserts the
+// production wiring satisfies the bijection. Order-agnostic because the
+// closed-set check is set membership, not positional equality.
+func TestCorebundleAssemblyMatchesGeneratedModules(t *testing.T) {
 	root := findRepoRoot(t)
 	project, err := metadata.NewParser(root).Parse()
 	require.NoError(t, err)
 	asm := project.Assemblies["corebundle"]
 	require.NotNil(t, asm)
 
-	modules, err := corebundleModules(asm.ID, asm.Cells)
-	require.NoError(t, err)
-	require.Len(t, modules, len(asm.Cells))
-
-	gotIDs := make([]string, 0, len(modules))
-	for _, module := range modules {
-		gotIDs = append(gotIDs, module.ID())
+	want := metadata.CellIDs(asm.Cells)
+	mods := generatedCellModules()
+	got := make([]string, len(mods))
+	for i, m := range mods {
+		got[i] = m.ID()
 	}
-	assert.Equal(t, asm.Cells, gotIDs)
-}
-
-// TestCorebundleModulesRejectDrift verifies that corebundleModules returns an
-// error when the provided cellIDs diverge from the generated module list. This
-// guards against assembly.yaml ↔ modules_gen.go drift where the caller forgets
-// to run `gocell generate assembly --id=corebundle` after editing assembly.yaml.
-func TestCorebundleModulesRejectDrift(t *testing.T) {
-	// Length mismatch: 2 IDs vs 3 generated modules.
-	modules, err := corebundleModules("corebundle", []string{"configcore", "ghostcore"})
-	require.Error(t, err)
-	assert.Nil(t, modules)
-	assert.Contains(t, err.Error(), "length mismatch")
-	assert.Contains(t, err.Error(), "gocell generate assembly")
-
-	// ID drift: correct count but wrong IDs.
-	modules, err = corebundleModules("corebundle", []string{"configcore", "ghostcore", "auditcore"})
-	require.Error(t, err)
-	assert.Nil(t, modules)
-	assert.Contains(t, err.Error(), "drift")
-	assert.Contains(t, err.Error(), "gocell generate assembly")
+	assert.ElementsMatch(t, want, got,
+		"corebundle assembly.yaml cells must match generatedCellModules() IDs; "+
+			"run `gocell generate assembly --id=corebundle` after editing assembly.yaml")
 }
 
 // TestLoadKeySet collapses 5 fragmented per-mode tests into a single

--- a/cmd/corebundle/outbox_wiring_integration_test.go
+++ b/cmd/corebundle/outbox_wiring_integration_test.go
@@ -55,7 +55,7 @@ func TestBuildConfigCoreOpts_PGMode_ManagedResourceNonNil(t *testing.T) {
 	// the composition.Builder.Build call here; we assert they are non-empty to guard
 	// the A11 regression (relay not started).
 	var capturedBootstrapOpts []bootstrap.Option
-	app, buildErr := composition.New().With(mods...).Build(ctx, shared,
+	app, buildErr := composition.New(corebundleCellIDs()...).With(mods...).Build(ctx, shared,
 		func(cells []cell.Cell) ([]bootstrap.Option, error) {
 			// Return nil from the runtime func; bootstrap opts from cell modules
 			// are appended inside Build and returned as part of App.opts.

--- a/cmd/corebundle/run.go
+++ b/cmd/corebundle/run.go
@@ -68,10 +68,7 @@ func runCorebundle(ctx context.Context, assemblyID string, assemblyCellIDs []str
 		return err
 	}
 
-	mods, err := corebundleModules(assemblyID, assemblyCellIDs)
-	if err != nil {
-		return err
-	}
+	mods := generatedCellModules()
 
 	adapterInfo := adapterInfoForSharedDeps(compShared, locals)
 	slog.Info("corebundle: startup configuration",
@@ -107,7 +104,10 @@ func runCorebundle(ctx context.Context, assemblyID string, assemblyCellIDs []str
 		return opts, nil
 	}
 
-	app, err := composition.New().With(mods...).Build(ctx, compShared, runtimeOptsFunc)
+	// composition.New(assemblyCellIDs...) seals the assembly's cell-id closed set
+	// (M12a #1093): Build fail-fasts if generatedCellModules drifts from the
+	// assembly.yaml cell list (replaces the former hand-written assertModuleIDsMatch).
+	app, err := composition.New(assemblyCellIDs...).With(mods...).Build(ctx, compShared, runtimeOptsFunc)
 	if err != nil {
 		return err
 	}
@@ -131,14 +131,6 @@ func releaseUnhandedResources(ctx context.Context, locals *cmdLocals, handedToBo
 		_ = locals.poolMR.Close(ctx)
 	}
 	closeRedisClientAfterFailedLoad(ctx, locals.redisClient)
-}
-
-func corebundleModules(assemblyID string, cellIDs []string) ([]composition.CellModule, error) {
-	mods := generatedCellModules()
-	if err := assertModuleIDsMatch(assemblyID, cellIDs, mods); err != nil {
-		return nil, err
-	}
-	return mods, nil
 }
 
 // logAssemblyMaturity emits a startup Info log of the running assembly's
@@ -184,26 +176,6 @@ func logAssemblyMaturity(cells []cell.Cell) {
 		slog.Int("total_cells", len(cells)),
 		slog.Group("lifecycle", lcAttrs...),
 	)
-}
-
-// assertModuleIDsMatch fails-fast when assembly.yaml.cells (cellIDs) drifts from
-// the generated module list. The two should be 1:1 in declaration order; any
-// mismatch indicates a missing `gocell generate assembly` run.
-func assertModuleIDsMatch(assemblyID string, cellIDs []string, mods []composition.CellModule) error {
-	hint := fmt.Sprintf("run `gocell generate assembly --id=%s`", assemblyID)
-	if len(cellIDs) != len(mods) {
-		return fmt.Errorf(
-			"%s: assembly.yaml cells (%d) ↔ modules_gen.go (%d) length mismatch; %s",
-			assemblyID, len(cellIDs), len(mods), hint)
-	}
-	for i, want := range cellIDs {
-		if got := mods[i].ID(); got != want {
-			return fmt.Errorf(
-				"%s: assembly.yaml cells[%d]=%q ↔ modules_gen.go=%q drift; %s",
-				assemblyID, i, want, got, hint)
-		}
-	}
-	return nil
 }
 
 // logSinglePodNonceStoreAcknowledgement emits a positive-path Info log when

--- a/cmd/gocell/app/check.go
+++ b/cmd/gocell/app/check.go
@@ -473,7 +473,8 @@ func checkAssemblyCompleteness(args []string) error {
 	var results []governance.ValidationResult
 
 	seen := make(map[string]bool, len(asm.Cells))
-	for _, cid := range asm.Cells {
+	for _, ref := range asm.Cells {
+		cid := ref.ID
 		if seen[cid] {
 			results = append(results, governance.ValidationResult{
 				Code:      governance.RuleCode("CHECK-ASSEMBLY-DUPLICATE-CELL"),

--- a/docs/architecture/202605271000-adr-fixture-cellid-typed-builder.md
+++ b/docs/architecture/202605271000-adr-fixture-cellid-typed-builder.md
@@ -49,7 +49,7 @@ Source: `kernel/metadata/types.go` + `kernel/metadata/derived.go`. The enumerati
 | `EndpointsMeta`               | `Provider`      | `string`                      | direct (projection provider cell) |
 | `EndpointsMeta`               | `Readers`       | `[]string`                    | slice element                     |
 | `JourneyMeta`                 | `Cells`         | `[]string`                    | slice element                     |
-| `AssemblyMeta`                | `Cells`         | `[]string`                    | slice element                     |
+| `AssemblyCellRef`             | `ID`            | `string`                      | direct (was `AssemblyMeta.Cells` slice element; the cell-id moved into the new `AssemblyCellRef.ID` struct field in #1086) |
 | `CellWireSummary` (derived.go)| `CellID`        | `string`                      | direct                            |
 
 Note: `CellWireSummary.CellID` fixtures live in `runtime/` (outside A1's current `kernel/` scope); this entry is forward-compatible and will be enforced once issue #1201 expands scope to non-kernel packages.

--- a/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
+++ b/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
@@ -82,6 +82,20 @@ registering a cellID outside the assembly is a configuration bug, and `_runtime`
 is reserved for framework/unmatched traffic. Mirrors K8s `runtime.Scheme`:
 registration-time enumeration + hard rejection of unregistered identities.
 
+The bijection above keys on `CellModule.ID()` (the module's self-reported
+identifier) so it can fail fast **before** any `Provide` opens resources. But the
+cell identity that actually reaches runtime — the metric `cell` label, healthz
+probe names — is `c.ID()` of the cell each module *constructs*, sourced
+independently from the cell's metadata and not bound to `m.ID()`. So `Build` adds
+a second, **post-Provide identity guard**: for each module it requires
+`c.ID() == m.ID()`. Because `m.ID() ∈ set` is already proven, this transitively
+binds the constructed cell identity into the closed set. Without it a module whose
+ID is in the set could construct a cell with an out-of-set ID, smuggling an
+unenumerated identity past the pre-Provide bijection (F1 / cluster C1, PR #1514
+review). The two phases together — pre-Provide set bijection on `m.ID()` +
+post-Provide `c.ID() == m.ID()` binding — are what make "the closed set constrains
+the runtime cell identity" true, not just "constrains the module label."
+
 This **replaces** the hand-written `cmd/corebundle.assertModuleIDsMatch` (deleted
 in this PR). The framework guard is inherited by every assembly **that composes
 via `composition.Builder`** — today `cmd/corebundle` + `examples/corebundlestarter`
@@ -101,7 +115,7 @@ in #1423).
 | module resolvability | `go build` of generated `cellmodules` import | **Hard** (compiler) |
 | generated import ⊆ assembly.yaml | regenerate-diff byte-lock (modules_gen.go DO NOT EDIT) | **Hard** (codegen golden) |
 | no rogue cellmodules import construction | archtest `ASSEMBLY-CROSS-MODULE-IMPORT-01` — `"/cellmodules/"` interpolation callsite-uniqueness ⊆ `cellModuleImportPath` body | **Hard** downstream (callsite/form uniqueness) + Hard upstream (codegen golden) |
-| cellID closed set at compose time | `composition.Builder.Build` bijection guard (fail-closed, table-driven) | **Medium** (runtime invariant guard; cell IDs are runtime strings → Hard not reachable, same ceiling as `SAGA-CONSTRUCTOR-NIL-GUARD`) |
+| cellID closed set at compose time | `composition.Builder.Build` two-phase guard: pre-Provide bijection on `m.ID()` + post-Provide `c.ID() == m.ID()` identity binding (fail-closed, table-driven) | **Medium** (runtime invariant guard; cell IDs are runtime strings → Hard not reachable, same ceiling as `SAGA-CONSTRUCTOR-NIL-GUARD`) |
 | AssemblyCellRef.ID typed-builder | `FIXTURE-CELLID-TYPED-BUILDER-01/A1` field position moved `AssemblyMeta.Cells` (slice elem) → `AssemblyCellRef.ID` (struct field) | unchanged rating (Hard downstream / upstream per its godoc) |
 
 M12a's Medium is the honest ceiling, not a settle: `CellModule.ID()` is a runtime

--- a/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
+++ b/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
@@ -82,9 +82,15 @@ registering a cellID outside the assembly is a configuration bug, and `_runtime`
 is reserved for framework/unmatched traffic. Mirrors K8s `runtime.Scheme`:
 registration-time enumeration + hard rejection of unregistered identities.
 
-This **replaces** the hand-written `cmd/corebundle.assertModuleIDsMatch` (which
-covered corebundle only); the framework guard is inherited by every assembly,
-including future external ones. The check is order-agnostic set membership
+This **replaces** the hand-written `cmd/corebundle.assertModuleIDsMatch` (deleted
+in this PR). The framework guard is inherited by every assembly **that composes
+via `composition.Builder`** — today `cmd/corebundle` + `examples/corebundlestarter`
+(compositionAPI form) and any future external one. The legacy-form example
+assemblies (`examples/todoorder` / `iotdevice` / `orderfulfillment`, which use the
+local-CellModule `generatedCellModules() []CellModule` form and do **not** go
+through `composition.Builder`) retain their own per-assembly `assertModuleIDsMatch`;
+migrating them to `composition.New` closed-set is deferred until they adopt the
+compositionAPI/cellmodules form. The check is order-agnostic set membership
 (slice order carries no runtime meaning — cross-module value handoff was removed
 in #1423).
 

--- a/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
+++ b/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
@@ -1,0 +1,124 @@
+# ADR: assembly.yaml cross-module cell references + build-time cellID closed-set
+
+- Status: Accepted
+- Date: 2026-06-03
+- Issues: #1086 (M5), #1093 M12a (bundled), epic #1081
+- Supersedes/relates: depends on #1082 (M1 metadata locator), #1083 (M2 codegen module path)
+
+## Context
+
+GoCell only supported monorepo single-module development. `gocell generate
+assembly` built each cellmodule import as `<current module>/cellmodules/<cellID>`
+(one hardcoded module), and `assembly.yaml.cells` was a bare `[]string`. A cell
+developed in an independent Go module (epic #1081: Operator-SDK / Workspace
+modes) could not be referenced by an assembly.
+
+M5 (#1086) makes `assembly.yaml` able to declare *which module* each cell comes
+from. M12a (#1093, bundled here) freezes the resulting cell-id set into a
+build-time closed set with fail-fast rejection of out-of-set cell identities.
+
+## Decision
+
+### D1 — `cells:` is a scalar-or-object union; per-cell `module`, no `version`
+
+`assembly.yaml.cells[]` accepts two forms:
+
+```yaml
+cells:
+  - configcore                               # same-module shorthand
+  - id: payment
+    module: github.com/acme/payment-cell     # cross-module (developed elsewhere)
+```
+
+`module` omitted = the assembly's own Go module. The Go type is
+`metadata.AssemblyCellRef{ID, Module}` with a custom `UnmarshalYAML` (the
+mapping branch enforces the `{id, module}` key set itself, since `KnownFields`
+does not propagate into a custom Unmarshaler).
+
+**No `version:` field, no pull semantics.** Version resolution is `go.mod` +
+`go.sum` (MVS + hash). Duplicating it in a weaker YAML would create a
+second-source-of-truth that necessarily drifts. This aligns with the
+external-as-top composition frameworks (uber-go/fx, controller-runtime,
+Backstage): the composition layer carries *identity only*; versions are the
+package manager's job. (If platform-aggregates-third-party-cell-by-version is
+ever needed, the correct analog is xcaddy `--with mod@ver` → go.mod require →
+`go build` — a separate `gocell-build` tool, not assembly.yaml.) See #1086
+comment "OSS 对标重排 (2026-06-02)".
+
+### D2 — codegen is multi-module via the per-cell module funnel
+
+`gocell generate assembly` resolves the import prefix per cell from
+`AssemblyCellRef.Module` (empty → the assembly's own module) through a single
+funnel, `kernel/assembly.cellModuleImportPath`. Cross-module assembly
+composition requires `build.compositionAPI: true` (the `cellmodules/{cell}.Module()`
+form, which carries a per-cell import path); the legacy local-CellModule-type
+form has no import path and so fail-fasts on a cross-module ref.
+
+**Scope (workspace-first):** external cell *metadata* (cell.yaml `requires` etc.)
+is read through the existing M1 manifest locator (go.work multi-module local
+discovery). Reading dependency cell.yaml from the Go module cache via
+`go list -json` (Operator-SDK mode) is deferred until a real external module
+exists (gated on M11 #1092); see Deferred.
+
+### D3 — "module declared in go.mod" is enforced by the Go compiler, not governance
+
+A referenced module that is not a declared `go.mod` require / `go.work` use makes
+the generated `import "<module>/cellmodules/<id>"` unbuildable: `go build ./...`
+fails. A `gocell validate` governance rule duplicating this would be a Medium
+runtime check shadowing a Hard compiler check, and would force `golang.org/x/mod`
+data into `kernel/` (a layering violation — kernel may only depend on stdlib +
+pkg/ + yaml). We therefore do **not** add a metadata governance rule for module
+declaration. The upstream regenerate-diff (`gocell verify codegen`) byte-locks
+the generated import set to what the funnel produces from assembly.yaml.
+
+### D4 — M12a: build-time cellID closed set in `composition.Builder.Build`
+
+`composition.New(expectedCellIDs ...string)` seals the assembly's declared cell
+set. `Build` validates a **bijection** before any module `Provide`: every
+composed module ID ∈ set (no out-of-set cell), every declared cell provided by
+some module (no missing cell), no duplicate module ID. Out-of-set cells are
+**rejected outright, not degraded to the `_runtime` sentinel** — an external cell
+registering a cellID outside the assembly is a configuration bug, and `_runtime`
+is reserved for framework/unmatched traffic. Mirrors K8s `runtime.Scheme`:
+registration-time enumeration + hard rejection of unregistered identities.
+
+This **replaces** the hand-written `cmd/corebundle.assertModuleIDsMatch` (which
+covered corebundle only); the framework guard is inherited by every assembly,
+including future external ones. The check is order-agnostic set membership
+(slice order carries no runtime meaning — cross-module value handoff was removed
+in #1423).
+
+## Enforcement / AI-robust rating
+
+| Carrier | Mechanism | Rating |
+|---|---|---|
+| module resolvability | `go build` of generated `cellmodules` import | **Hard** (compiler) |
+| generated import ⊆ assembly.yaml | regenerate-diff byte-lock (modules_gen.go DO NOT EDIT) | **Hard** (codegen golden) |
+| no rogue cellmodules import construction | archtest `ASSEMBLY-CROSS-MODULE-IMPORT-01` — `"/cellmodules/"` interpolation callsite-uniqueness ⊆ `cellModuleImportPath` body | **Hard** downstream (callsite/form uniqueness) + Hard upstream (codegen golden) |
+| cellID closed set at compose time | `composition.Builder.Build` bijection guard (fail-closed, table-driven) | **Medium** (runtime invariant guard; cell IDs are runtime strings → Hard not reachable, same ceiling as `SAGA-CONSTRUCTOR-NIL-GUARD`) |
+| AssemblyCellRef.ID typed-builder | `FIXTURE-CELLID-TYPED-BUILDER-01/A1` field position moved `AssemblyMeta.Cells` (slice elem) → `AssemblyCellRef.ID` (struct field) | unchanged rating (Hard downstream / upstream per its godoc) |
+
+M12a's Medium is the honest ceiling, not a settle: `CellModule.ID()` is a runtime
+string, so set membership is inherently a runtime guard.
+
+## Deferred (backlog, not silent)
+
+- **Operator-SDK module-cache metadata read** (`go list -json` to read a
+  dependency module's cell.yaml): no in-repo consumer until examples/ split into
+  modules (M11 #1092). Tracked as a backlog issue.
+- **Scaffold `--module` flag** (cross-module assembly scaffolding): `gocell
+  scaffold assembly` emits same-module string-form cells; cross-module entries
+  are hand-authored. Backlog.
+- **M12b** (metric-label closed-set defense at the write point +
+  `CELL-ID-CLOSED-SET-01` archtest): mostly already present (`_runtime` sentinel +
+  cardinality cap); remains in #1093.
+- **CellMeta source-module tracking** (cross-check that assembly.yaml `module`
+  matches the module a cell.yaml was discovered in): needs a `MetadataSource`
+  module field; the compiler catches the non-existent-import case today. Backlog.
+
+## References
+
+- uber-go/fx module.go / app.go · kubernetes-sigs/controller-runtime manager.go ·
+  operator-sdk init docs · helm.sh charts · backstage building-apps ·
+  kubernetes/apimachinery scheme.go · prometheus/client_golang registry.go
+  (#1086 + #1093 comments, 2026-06-02 OSS 对标).

--- a/examples/corebundlestarter/run.go
+++ b/examples/corebundlestarter/run.go
@@ -76,7 +76,10 @@ func runStarter(ctx context.Context) error {
 	// auditcore→accesscore BootstrapLedgerStore handoff was removed in #1423
 	// (bootstrap auth-fail is now event-driven via event.auth.bootstrap-failed.v1),
 	// so module Provide order carries no cross-cell dependency.
-	app, err := composition.New().
+	// composition.New(<cell ids>) seals the assembly's cell-id closed set (M12a
+	// #1093): Build fail-fasts if the composed modules drift from this declared
+	// set. corebundlestarter mirrors the corebundle cell set.
+	app, err := composition.New("auditcore", "accesscore", "configcore").
 		With(
 			cellmodulesauditcore.Module(),
 			cellmodulesaccesscore.Module(),

--- a/examples/corebundlestarter/run_test.go
+++ b/examples/corebundlestarter/run_test.go
@@ -45,7 +45,7 @@ func TestStarterBuildSucceeds(t *testing.T) {
 	require.NoError(t, err, "buildStarterMemSharedDeps must succeed in memory mode")
 	require.NotNil(t, shared, "shared deps must be non-nil")
 
-	app, err := composition.New().
+	app, err := composition.New("auditcore", "accesscore", "configcore").
 		With(
 			cellmodulesauditcore.Module(),
 			cellmodulesaccesscore.Module(),
@@ -79,7 +79,7 @@ func TestStarterBootsAndRespondsHealthz(t *testing.T) {
 	shared.InternalHTTPAddr = "127.0.0.1:0"
 	shared.HealthHTTPAddr = "127.0.0.1:0"
 
-	app, err := composition.New().
+	app, err := composition.New("auditcore", "accesscore", "configcore").
 		With(
 			cellmodulesauditcore.Module(),
 			cellmodulesaccesscore.Module(),
@@ -140,7 +140,7 @@ func TestStarterHealthzHTTP(t *testing.T) {
 	shared.InternalHTTPAddr = "127.0.0.1:18089"
 	shared.HealthHTTPAddr = healthAddr
 
-	app, err := composition.New().
+	app, err := composition.New("auditcore", "accesscore", "configcore").
 		With(
 			cellmodulesauditcore.Module(),
 			cellmodulesaccesscore.Module(),

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -97,7 +97,7 @@ func (g *Generator) GenerateEntrypoint(assemblyID string) ([]byte, error) {
 		Module:     g.module,
 		AssemblyID: assemblyID,
 		HelperName: helperName,
-		Cells:      append([]string(nil), asm.Cells...),
+		Cells:      metadata.CellIDs(asm.Cells),
 	}
 
 	return g.executeTemplate("main.go.tpl", ctx)
@@ -213,8 +213,8 @@ func (g *Generator) GenerateBoundary(assemblyID string) ([]byte, error) {
 	}
 
 	cellSet := make(map[string]bool, len(asm.Cells))
-	for _, c := range asm.Cells {
-		cellSet[c] = true
+	for _, ref := range asm.Cells {
+		cellSet[ref.ID] = true
 	}
 
 	exported, imported, err := g.computeBoundaryContracts(cellSet)
@@ -276,14 +276,14 @@ func (g *Generator) GenerateModulesGen(assemblyID string) ([]byte, error) {
 
 // collectCapabilityConsts returns the sorted de-duplicated capability.Kind
 // const names for all cells in the assembly.
-func (g *Generator) collectCapabilityConsts(assemblyID string, cellIDs []string) ([]string, error) {
+func (g *Generator) collectCapabilityConsts(assemblyID string, cellRefs []metadata.AssemblyCellRef) ([]string, error) {
 	capSet := make(map[string]struct{})
-	for _, cellID := range cellIDs {
-		cm := g.cells.Get(cellID)
+	for _, ref := range cellRefs {
+		cm := g.cells.Get(ref.ID)
 		if cm == nil {
 			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
 				"assembly references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, cellID))))
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
 		}
 		for _, c := range cm.Requires {
 			capSet[c] = struct{}{}
@@ -313,17 +313,28 @@ func (g *Generator) generateModulesGenLegacy(
 	assemblyID string, asm *metadata.AssemblyMeta, capConsts []string,
 ) ([]byte, error) {
 	modules := make([]string, 0, len(asm.Cells))
-	for _, cellID := range asm.Cells {
-		cm := g.cells.Get(cellID)
+	for _, ref := range asm.Cells {
+		// The legacy form references a local CellModule type ({GoStructName}Module)
+		// hand-written in cmd/{assemblyID}/; it has no import path and therefore
+		// cannot express a cell sourced from another Go module. Cross-module
+		// assembly composition requires build.compositionAPI: true (the
+		// cellmodules/{cell}.Module() form, which carries a per-cell import path).
+		if g.isCrossModule(ref) {
+			return nil, errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
+				"cross-module cell requires build.compositionAPI: true",
+				errcode.WithInternal(errcode.InternalAttr("_",
+					fmt.Sprintf("assembly=%q cell=%q module=%q", assemblyID, ref.ID, ref.Module))))
+		}
+		cm := g.cells.Get(ref.ID)
 		if cm == nil {
 			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
 				"assembly references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, cellID))))
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
 		}
 		if cm.GoStructName.IsZero() {
 			return nil, errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 				"cell missing GoStructName for modules_gen factory derivation",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, cellID))))
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
 		}
 		modules = append(modules, cm.GoStructName.String()+"Module")
 	}
@@ -336,6 +347,32 @@ func (g *Generator) generateModulesGenLegacy(
 	return g.executeTemplate("modules_gen.go.tpl", ctx)
 }
 
+// isCrossModule reports whether ref names a cell sourced from a Go module other
+// than the assembly's own (g.module). An empty ref.Module, or one equal to
+// g.module, is same-module.
+func (g *Generator) isCrossModule(ref metadata.AssemblyCellRef) bool {
+	return ref.Module != "" && ref.Module != g.module
+}
+
+// moduleOf returns the Go module path a cell's cellmodules/ package lives in:
+// ref.Module when set, otherwise the assembly's own module (g.module).
+func (g *Generator) moduleOf(ref metadata.AssemblyCellRef) string {
+	if ref.Module != "" {
+		return ref.Module
+	}
+	return g.module
+}
+
+// cellModuleImportPath is the SINGLE sanctioned construction site for a
+// cellmodules import path. The module prefix is resolved per-cell upstream
+// (g.moduleOf, from AssemblyCellRef.Module — the cross-module funnel); this
+// function is the sole place that interpolates "/cellmodules/". Archtest
+// ASSEMBLY-CROSS-MODULE-IMPORT-01 locks that uniqueness so no second code path
+// can fabricate a cellmodules import outside the per-cell module funnel.
+func cellModuleImportPath(module, cellID string) string {
+	return module + "/cellmodules/" + cellID
+}
+
 // generateModulesGenComposition emits the composition.CellModule form used by
 // platform assemblies (assembly.yaml build.compositionAPI: true).
 // Each cell maps to cellmodules{cellID}.Module() with a matching import alias.
@@ -345,18 +382,18 @@ func (g *Generator) generateModulesGenComposition(
 	moduleCalls := make([]string, 0, len(asm.Cells))
 	importLines := make([]string, 0, len(asm.Cells))
 	seen := make(map[string]bool, len(asm.Cells))
-	for _, cellID := range asm.Cells {
-		cm := g.cells.Get(cellID)
+	for _, ref := range asm.Cells {
+		cm := g.cells.Get(ref.ID)
 		if cm == nil {
 			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
 				"assembly references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, cellID))))
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
 		}
-		alias := "cellmodules" + cellID
-		if !seen[cellID] {
-			seen[cellID] = true
+		alias := "cellmodules" + ref.ID
+		if !seen[ref.ID] {
+			seen[ref.ID] = true
 			importLines = append(importLines, fmt.Sprintf("%s %q",
-				alias, g.module+"/cellmodules/"+cellID))
+				alias, cellModuleImportPath(g.moduleOf(ref), ref.ID)))
 		}
 		moduleCalls = append(moduleCalls, alias+".Module()")
 	}
@@ -546,13 +583,16 @@ func synthesizeAssemblyMeta(spec AssemblyScaffoldSpec) *metadata.AssemblyMeta {
 		// which the boundary sourceFingerprint depends on.
 		deployTemplate = "k8s"
 	}
-	cellsAsString := make([]string, len(spec.Cells))
+	// Scaffolded assemblies are always same-module (cross-module authoring is a
+	// hand-edit / future scaffold flag, tracked in backlog); synthesize bare
+	// same-module cell refs via the metadata.CellRefs constructor.
+	cellIDs := make([]string, len(spec.Cells))
 	for i, c := range spec.Cells {
-		cellsAsString[i] = c.String()
+		cellIDs[i] = c.String()
 	}
 	return &metadata.AssemblyMeta{
 		ID:    spec.ID.String(),
-		Cells: cellsAsString,
+		Cells: metadata.CellRefs(cellIDs...),
 		Owner: metadata.OwnerMeta{
 			Team: spec.OwnerTeam,
 			Role: spec.OwnerRole,
@@ -881,13 +921,21 @@ func (g *Generator) hashAssemblyIdentity(h io.Writer, asm *metadata.AssemblyMeta
 	if err := writeHash(h, "build.deployTemplate:%s\n", asm.Build.DeployTemplate); err != nil {
 		return err
 	}
-	for i, c := range asm.Cells {
-		if err := writeHash(h, "cells.order:%d:%s\n", i, c); err != nil {
+	for i, ref := range asm.Cells {
+		if err := writeHash(h, "cells.order:%d:%s\n", i, ref.ID); err != nil {
 			return err
 		}
+		// Same-module entries (Module == "") keep the historical fingerprint
+		// byte-for-byte so existing boundary.yaml outputs do not churn; a
+		// cross-module entry adds its module to the hash.
+		if ref.Module != "" {
+			if err := writeHash(h, "cells.module:%d:%s\n", i, ref.Module); err != nil {
+				return err
+			}
+		}
 	}
-	for _, cellID := range asm.Cells {
-		if err := g.hashCellIdentity(h, cellID); err != nil {
+	for _, ref := range asm.Cells {
+		if err := g.hashCellIdentity(h, ref.ID); err != nil {
 			return err
 		}
 	}

--- a/kernel/assembly/generator_crossmodule_test.go
+++ b/kernel/assembly/generator_crossmodule_test.go
@@ -62,6 +62,33 @@ func TestGenerateModulesGen_CrossModuleImportPath(t *testing.T) {
 		"cross-module cell must NOT fall back to the current module")
 }
 
+// TestGenerateModulesGen_ExplicitSameModuleIsNotCrossModule verifies that a cell
+// declaring `module: <the assembly's own module>` explicitly renders identically
+// to the omitted-module form (moduleOf treats module == current as same-module).
+func TestGenerateModulesGen_ExplicitSameModuleIsNotCrossModule(t *testing.T) {
+	const currentModule = "github.com/ghbvf/gocell"
+	project := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			metadatatest.CellIDConfigCore: {ID: metadatatest.CellIDConfigCore},
+		},
+		Slices:    make(map[string]*metadata.SliceMeta),
+		Contracts: make(map[string]*metadata.ContractMeta),
+		Journeys:  make(map[string]*metadata.JourneyMeta),
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"explicitsame": {
+				ID:    "explicitsame",
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDConfigCore, Module: currentModule}},
+				Build: metadata.BuildMeta{CompositionAPI: true},
+				File:  "assemblies/explicitsame/assembly.yaml",
+			},
+		},
+	}
+	out, err := NewGenerator(project, currentModule, "").GenerateModulesGen("explicitsame")
+	require.NoError(t, err)
+	assert.Contains(t, string(out), currentModule+"/cellmodules/configcore",
+		"module == current module must render the same import as an omitted module")
+}
+
 // TestGenerateModulesGen_CrossModuleRequiresCompositionAPI verifies that a
 // cross-module cell in a legacy (non-compositionAPI) assembly fail-fasts: the
 // legacy local-CellModule-type form has no import path and cannot express a

--- a/kernel/assembly/generator_crossmodule_test.go
+++ b/kernel/assembly/generator_crossmodule_test.go
@@ -1,0 +1,102 @@
+package assembly
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/metadata/metadatatest"
+)
+
+const acmePayModule = "github.com/acme/payment-cell"
+
+// buildCrossModuleProject builds a compositionAPI assembly that mixes a
+// same-module cell (configcore) and a cross-module cell (payment, sourced from
+// acmePayModule). Both cells are present in ProjectMeta.Cells so the generator
+// can resolve them (workspace-mode discovery, #1086).
+func buildCrossModuleProject(compositionAPI bool) *metadata.ProjectMeta {
+	return &metadata.ProjectMeta{
+		// GoStructName is set so the legacy-form path (compositionAPI=false) gets
+		// past the same-module configcore cell and reaches the cross-module payment
+		// ref — where the "requires compositionAPI" guard fires. The composition
+		// form ignores GoStructName.
+		Cells: map[string]*metadata.CellMeta{
+			metadatatest.CellIDConfigCore:     {ID: metadatatest.CellIDConfigCore, GoStructName: metadata.MustNewGoIdentifier("ConfigCore")},
+			metadatatest.NewCellID("payment"): {ID: metadatatest.NewCellID("payment"), GoStructName: metadata.MustNewGoIdentifier("Payment")},
+		},
+		Slices:    make(map[string]*metadata.SliceMeta),
+		Contracts: make(map[string]*metadata.ContractMeta),
+		Journeys:  make(map[string]*metadata.JourneyMeta),
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"mixedbundle": {
+				ID: "mixedbundle",
+				Cells: []metadata.AssemblyCellRef{
+					{ID: metadatatest.CellIDConfigCore},
+					{ID: metadatatest.NewCellID("payment"), Module: acmePayModule},
+				},
+				Build: metadata.BuildMeta{CompositionAPI: compositionAPI},
+				File:  "assemblies/mixedbundle/assembly.yaml",
+			},
+		},
+	}
+}
+
+// TestGenerateModulesGen_CrossModuleImportPath verifies the per-cell module
+// funnel (#1086): a same-module cell renders <currentModule>/cellmodules/<id>
+// while a cross-module cell renders <declaredModule>/cellmodules/<id>.
+func TestGenerateModulesGen_CrossModuleImportPath(t *testing.T) {
+	const currentModule = "github.com/ghbvf/gocell"
+	gen := NewGenerator(buildCrossModuleProject(true), currentModule, "")
+
+	out, err := gen.GenerateModulesGen("mixedbundle")
+	require.NoError(t, err)
+	content := string(out)
+
+	assert.Contains(t, content, currentModule+"/cellmodules/configcore",
+		"same-module cell must import from the assembly's own module")
+	assert.Contains(t, content, acmePayModule+"/cellmodules/payment",
+		"cross-module cell must import from its declared module")
+	assert.NotContains(t, content, currentModule+"/cellmodules/payment",
+		"cross-module cell must NOT fall back to the current module")
+}
+
+// TestGenerateModulesGen_CrossModuleRequiresCompositionAPI verifies that a
+// cross-module cell in a legacy (non-compositionAPI) assembly fail-fasts: the
+// legacy local-CellModule-type form has no import path and cannot express a
+// foreign module.
+func TestGenerateModulesGen_CrossModuleRequiresCompositionAPI(t *testing.T) {
+	gen := NewGenerator(buildCrossModuleProject(false), "github.com/ghbvf/gocell", "")
+
+	_, err := gen.GenerateModulesGen("mixedbundle")
+	require.Error(t, err)
+	// The cross-module guard is the only generateModulesGenLegacy error that
+	// carries module= in its internal context (the unknown-cell / GoStructName
+	// errors omit it), so these markers uniquely identify it.
+	assert.Contains(t, err.Error(), "payment")
+	assert.Contains(t, err.Error(), "module="+`"`+acmePayModule+`"`)
+}
+
+// TestModuleOfAndImportPath unit-tests the per-cell module resolution funnel
+// directly (moduleOf / cellModuleImportPath / isCrossModule).
+func TestModuleOfAndImportPath(t *testing.T) {
+	g := &Generator{module: "github.com/ghbvf/gocell"}
+
+	same := metadata.AssemblyCellRef{ID: metadatatest.NewCellID("configcore")}
+	cross := metadata.AssemblyCellRef{ID: metadatatest.NewCellID("payment"), Module: acmePayModule}
+	explicitSame := metadata.AssemblyCellRef{ID: metadatatest.NewCellID("configcore"), Module: "github.com/ghbvf/gocell"}
+
+	assert.Equal(t, "github.com/ghbvf/gocell", g.moduleOf(same))
+	assert.Equal(t, acmePayModule, g.moduleOf(cross))
+	assert.Equal(t, "github.com/ghbvf/gocell", g.moduleOf(explicitSame))
+
+	assert.False(t, g.isCrossModule(same))
+	assert.True(t, g.isCrossModule(cross))
+	assert.False(t, g.isCrossModule(explicitSame), "module == current module is not cross-module")
+
+	assert.Equal(t, "github.com/ghbvf/gocell/cellmodules/configcore",
+		cellModuleImportPath(g.moduleOf(same), same.ID))
+	assert.Equal(t, acmePayModule+"/cellmodules/payment",
+		cellModuleImportPath(g.moduleOf(cross), cross.ID))
+}

--- a/kernel/assembly/generator_fingerprint_test.go
+++ b/kernel/assembly/generator_fingerprint_test.go
@@ -112,7 +112,7 @@ func fingerprintProject() *metadata.ProjectMeta {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"ssobff": {
 				ID:    "ssobff",
-				Cells: []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}, {ID: metadatatest.CellIDAuditCore}},
 				Build: metadata.BuildMeta{
 					Entrypoint: "cmd/ssobff/main.go",
 					Binary:     "ssobff",

--- a/kernel/assembly/generator_modulesgen_test.go
+++ b/kernel/assembly/generator_modulesgen_test.go
@@ -37,8 +37,12 @@ func buildModulesTestProject() *metadata.ProjectMeta {
 		Journeys:  make(map[string]*metadata.JourneyMeta),
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"corebundle": {
-				ID:    "corebundle",
-				Cells: []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore, metadatatest.CellIDConfigCore},
+				ID: "corebundle",
+				Cells: []metadata.AssemblyCellRef{
+					{ID: metadatatest.CellIDAccessCore},
+					{ID: metadatatest.CellIDAuditCore},
+					{ID: metadatatest.CellIDConfigCore},
+				},
 			},
 		},
 	}
@@ -210,7 +214,7 @@ func TestGenerateModulesGen_UnknownCellRef(t *testing.T) {
 	// Add assembly with an unregistered cell ID.
 	project.Assemblies["ghostbundle"] = &metadata.AssemblyMeta{
 		ID:    "ghostbundle",
-		Cells: []string{metadatatest.CellIDAccessCore, metadatatest.NewCellID("ghostcellnotregistered")},
+		Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}, {ID: metadatatest.NewCellID("ghostcellnotregistered")}},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 
@@ -234,7 +238,7 @@ func TestGenerateModulesGen_PreservesCellsOrder(t *testing.T) {
 	project.Cells[metadatatest.CellIDCC] = &metadata.CellMeta{ID: metadatatest.CellIDCC, GoStructName: metadata.MustNewGoIdentifier("C")}
 	project.Assemblies["ordered"] = &metadata.AssemblyMeta{
 		ID:    "ordered",
-		Cells: []string{metadatatest.CellIDBB, metadatatest.CellIDAA, metadatatest.CellIDCC},
+		Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDBB}, {ID: metadatatest.CellIDAA}, {ID: metadatatest.CellIDCC}},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 
@@ -266,10 +270,10 @@ func TestGenerateModulesGen_CompositionForm(t *testing.T) {
 	asm.Build.CompositionAPI = true
 	// Order configcore, auditcore, accesscore to assert the call list preserves
 	// assembly (not sorted) order.
-	asm.Cells = []string{
-		metadatatest.CellIDConfigCore,
-		metadatatest.CellIDAuditCore,
-		metadatatest.CellIDAccessCore,
+	asm.Cells = []metadata.AssemblyCellRef{
+		{ID: metadatatest.CellIDConfigCore},
+		{ID: metadatatest.CellIDAuditCore},
+		{ID: metadatatest.CellIDAccessCore},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 
@@ -342,7 +346,7 @@ func TestGenerateModulesGen_CompositionUnknownCellRef(t *testing.T) {
 	project.Assemblies["ghostcomp"] = &metadata.AssemblyMeta{
 		ID:    "ghostcomp",
 		Build: metadata.BuildMeta{CompositionAPI: true},
-		Cells: []string{metadatatest.CellIDAccessCore, metadatatest.NewCellID("ghostcellnotregistered")},
+		Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}, {ID: metadatatest.NewCellID("ghostcellnotregistered")}},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 

--- a/kernel/assembly/generator_test.go
+++ b/kernel/assembly/generator_test.go
@@ -102,7 +102,7 @@ func buildTestProject() *metadata.ProjectMeta {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"ssobff": {
 				ID:    "ssobff",
-				Cells: []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}, {ID: metadatatest.CellIDAuditCore}},
 				Build: metadata.BuildMeta{
 					Entrypoint:     "cmd/ssobff/main.go",
 					Binary:         "ssobff",
@@ -384,7 +384,7 @@ func TestSourceFingerprint_MissingCellInAssembly(t *testing.T) {
 	// Add an assembly that references a cell not in project.Cells.
 	project.Assemblies["ghost-bundle"] = &metadata.AssemblyMeta{
 		ID:    "ghost-bundle",
-		Cells: []string{metadatatest.NewCellID("ghostcell")},
+		Cells: []metadata.AssemblyCellRef{{ID: metadatatest.NewCellID("ghostcell")}},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 	fp, err := gen.sourceFingerprint("ghost-bundle", nil, nil)
@@ -401,7 +401,7 @@ func TestGenerateBoundary_EmptyAssembly(t *testing.T) {
 	project := buildTestProject()
 	project.Assemblies["empty"] = &metadata.AssemblyMeta{
 		ID:    "empty",
-		Cells: []string{},
+		Cells: []metadata.AssemblyCellRef{},
 		Build: metadata.BuildMeta{},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
@@ -448,7 +448,7 @@ func TestGenerateEntrypoint_EmptyAssembly(t *testing.T) {
 	project := buildTestProject()
 	project.Assemblies["empty"] = &metadata.AssemblyMeta{
 		ID:    "empty",
-		Cells: []string{},
+		Cells: []metadata.AssemblyCellRef{},
 		Build: metadata.BuildMeta{},
 	}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
@@ -493,7 +493,7 @@ func TestSourceFingerprint_CellOrderIsStructural(t *testing.T) {
 	baseline, err := gen.sourceFingerprint("ssobff", exported, imported)
 	require.NoError(t, err)
 
-	project.Assemblies["ssobff"].Cells = []string{metadatatest.CellIDAuditCore, metadatatest.CellIDAccessCore}
+	project.Assemblies["ssobff"].Cells = []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAuditCore}, {ID: metadatatest.CellIDAccessCore}}
 	got, err := gen.sourceFingerprint("ssobff", exported, imported)
 	require.NoError(t, err)
 	assert.NotEqual(t, baseline, got, "assembly cells order is runtime order and must change fingerprint")

--- a/kernel/assembly/synthesize_field_guard_test.go
+++ b/kernel/assembly/synthesize_field_guard_test.go
@@ -115,7 +115,7 @@ func TestAssemblyMetaSynthesisFieldGuard_DetectsViolation(t *testing.T) {
 		// All top-level set but BuildMeta.Binary missing.
 		partial := metadata.AssemblyMeta{
 			ID:    "x",
-			Cells: []string{metadatatest.CellIDYY},
+			Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDYY}},
 			Owner: metadata.OwnerMeta{Team: "t", Role: "r"},
 			Build: metadata.BuildMeta{Entrypoint: "cmd/x/main.go", DeployTemplate: "k8s"},
 		}
@@ -132,7 +132,7 @@ func TestAssemblyMetaSynthesisFieldGuard_DetectsViolation(t *testing.T) {
 		// sibling must still surface.
 		partial := metadata.AssemblyMeta{
 			ID:    "x",
-			Cells: []string{metadatatest.CellIDYY},
+			Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDYY}},
 			Owner: metadata.OwnerMeta{Team: "t", Role: "r"},
 			Build: metadata.BuildMeta{Entrypoint: "cmd/x/main.go"}, // missing Binary and DeployTemplate
 		}

--- a/kernel/governance/depcheck.go
+++ b/kernel/governance/depcheck.go
@@ -183,8 +183,8 @@ func (v *Validator) checkDEP03() []ValidationResult {
 
 	cellToAssembly := make(map[string]string)
 	for _, a := range v.project.Assemblies {
-		for _, cellRef := range a.Cells {
-			cellToAssembly[cellRef] = a.ID
+		for _, ref := range a.Cells {
+			cellToAssembly[ref.ID] = a.ID
 		}
 	}
 

--- a/kernel/governance/depcheck_test.go
+++ b/kernel/governance/depcheck_test.go
@@ -276,7 +276,7 @@ func TestDEP03_SameAssembly(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"main-bundle": {
 				ID:    "main-bundle",
-				Cells: []string{metadatatest.CellIDAppCore, metadatatest.CellIDSharedCrypto},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAppCore}, {ID: metadatatest.CellIDSharedCrypto}},
 			},
 		},
 	}
@@ -307,11 +307,11 @@ func TestDEP03_DifferentAssembly(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"bundle-a": {
 				ID:    "bundle-a",
-				Cells: []string{metadatatest.CellIDAppCore},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAppCore}},
 			},
 			"bundle-b": {
 				ID:    "bundle-b",
-				Cells: []string{metadatatest.CellIDSharedCrypto},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDSharedCrypto}},
 			},
 		},
 	}
@@ -426,7 +426,7 @@ func TestDEP03_CellNotInAnyAssembly(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"bundle-a": {
 				ID:    "bundle-a",
-				Cells: []string{metadatatest.CellIDSharedCrypto}, // app-core not in any assembly
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDSharedCrypto}}, // app-core not in any assembly
 			},
 		},
 	}

--- a/kernel/governance/rules_fmt_test.go
+++ b/kernel/governance/rules_fmt_test.go
@@ -668,7 +668,7 @@ func buildFMT29Project(team, role string) *metadata.ProjectMeta {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"testasm": {
 				ID:    "testasm",
-				Cells: []string{},
+				Cells: []metadata.AssemblyCellRef{},
 				Owner: metadata.OwnerMeta{Team: team, Role: role},
 				Dir:   "testasm",
 				File:  "assemblies/testasm/assembly.yaml",

--- a/kernel/governance/rules_misc_strict_test.go
+++ b/kernel/governance/rules_misc_strict_test.go
@@ -719,7 +719,7 @@ func TestValidator_FMTA1_AssemblyIDPattern(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"baz-qux": {
 				ID:    "baz-qux",
-				Cells: []string{},
+				Cells: []metadata.AssemblyCellRef{},
 				Build: metadata.BuildMeta{Entrypoint: "cmd/bazqux/main.go", Binary: "bazqux"},
 				Dir:   "bazqux",
 			},
@@ -787,7 +787,7 @@ func TestStrictValidator_FMT16_KebabAssemblyDir(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"bazqux": {
 				ID:    "bazqux",
-				Cells: []string{},
+				Cells: []metadata.AssemblyCellRef{},
 				Build: metadata.BuildMeta{Entrypoint: "cmd/bazqux/main.go", Binary: "bazqux"},
 				Dir:   "baz-qux", // id clean but dir kebab
 			},
@@ -831,7 +831,7 @@ func TestStrictValidator_FMTC1_FMTA1_NoDashClean(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"corebundle": {
 				ID:    "corebundle",
-				Cells: []string{metadatatest.CellIDAccessCore},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}},
 				Build: metadata.BuildMeta{Entrypoint: "cmd/corebundle/main.go", Binary: "corebundle"},
 				Dir:   "corebundle",
 			},

--- a/kernel/governance/rules_ref.go
+++ b/kernel/governance/rules_ref.go
@@ -152,13 +152,13 @@ func (v *Validator) validateREF07() []ValidationResult {
 func (v *Validator) validateREF08() []ValidationResult {
 	var results []ValidationResult
 	for _, a := range v.project.Assemblies {
-		for i, cellRef := range a.Cells {
-			if _, ok := v.project.Cells[cellRef]; !ok {
+		for i, ref := range a.Cells {
+			if _, ok := v.project.Cells[ref.ID]; !ok {
 				results = append(results, v.newError(
 					codeREF08, IssueRefNotFound,
 					assemblyFile(a),
 					fmt.Sprintf("cells[%d]", i),
-					fmt.Sprintf("assembly %q references non-existent cell %q", a.ID, cellRef),
+					fmt.Sprintf("assembly %q references non-existent cell %q", a.ID, ref.ID),
 					"remove the cell reference or create the cell",
 				))
 			}

--- a/kernel/governance/rules_topo.go
+++ b/kernel/governance/rules_topo.go
@@ -411,8 +411,8 @@ func (v *Validator) validateTOPO09() []ValidationResult {
 // unparseable level.
 func computeExpectedMax(pm *metadata.ProjectMeta, asm *metadata.AssemblyMeta) (cellvocab.Level, bool) {
 	var maxLvl cellvocab.Level
-	for i, cellID := range asm.Cells {
-		c, found := pm.Cells[cellID]
+	for i, ref := range asm.Cells {
+		c, found := pm.Cells[ref.ID]
 		if !found {
 			return 0, false
 		}
@@ -441,20 +441,20 @@ func (v *Validator) validateTOPO06() []ValidationResult {
 
 	for _, key := range assemblyKeys {
 		a := v.project.Assemblies[key]
-		for i, cellRef := range a.Cells {
-			if existing, ok := cellAssembly[cellRef]; ok {
+		for i, ref := range a.Cells {
+			if existing, ok := cellAssembly[ref.ID]; ok {
 				results = append(results, v.newError(
 					codeTOPO06, IssueDuplicate,
 					assemblyFile(a),
 					fmt.Sprintf("cells[%d]", i),
 					fmt.Sprintf(
 						"cell %q is already assigned to assembly %q, cannot also be in %q",
-						cellRef, existing, a.ID,
+						ref.ID, existing, a.ID,
 					),
 					"remove this cell from one of the two assemblies",
 				))
 			} else {
-				cellAssembly[cellRef] = a.ID
+				cellAssembly[ref.ID] = a.ID
 			}
 		}
 	}

--- a/kernel/governance/rules_topo_test.go
+++ b/kernel/governance/rules_topo_test.go
@@ -34,6 +34,11 @@ func buildTOPO09Project(cellIDs []string, cellLevels []string, asmMaxLevel strin
 		cm.ID = validated
 		cells[validated] = cm
 	}
+	// Build refs via the CellRefs constructor (validated above per cell). A1
+	// cannot trace a runtime ident back to NewCellID, so an inline
+	// AssemblyCellRef{ID: validated} literal would be rejected; CellRefs (a call,
+	// not a composite literal) is the sanctioned dynamic-id path.
+	refs := metadata.CellRefs(cellIDs...)
 	return &metadata.ProjectMeta{
 		Cells:     cells,
 		Slices:    map[string]*metadata.SliceMeta{},
@@ -42,7 +47,7 @@ func buildTOPO09Project(cellIDs []string, cellLevels []string, asmMaxLevel strin
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"testasm": {
 				ID:                  "testasm",
-				Cells:               cellIDs,
+				Cells:               refs,
 				MaxConsistencyLevel: asmMaxLevel,
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
 				Dir:                 "testasm",
@@ -94,7 +99,7 @@ func TestTOPO09_AssemblyEmptyCells(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"emptyasm": {
 				ID:                  "emptyasm",
-				Cells:               []string{},
+				Cells:               []metadata.AssemblyCellRef{},
 				MaxConsistencyLevel: "",
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
 				Dir:                 "emptyasm",
@@ -129,7 +134,7 @@ func TestTOPO09_InvalidCellLevelSkips(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"badasm": {
 				ID:                  "badasm",
-				Cells:               []string{metadatatest.NewCellID("badlevelcell")},
+				Cells:               []metadata.AssemblyCellRef{{ID: metadatatest.NewCellID("badlevelcell")}},
 				MaxConsistencyLevel: "L2",
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
 				Dir:                 "badasm",
@@ -152,8 +157,9 @@ func TestTOPO09_AssemblyUnknownCellRef(t *testing.T) {
 		Journeys:  map[string]*metadata.JourneyMeta{},
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"ghostasm": {
-				ID:                  "ghostasm",
-				Cells:               []string{metadatatest.NewCellID("unknowncell")}, // legacy "unknown-cell" (kebab → compliant)
+				ID: "ghostasm",
+				// legacy "unknown-cell" (kebab → compliant)
+				Cells:               []metadata.AssemblyCellRef{{ID: metadatatest.NewCellID("unknowncell")}},
 				MaxConsistencyLevel: "L2",
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
 				Dir:                 "ghostasm",

--- a/kernel/governance/targets.go
+++ b/kernel/governance/targets.go
@@ -237,8 +237,8 @@ func (ts *TargetSelector) matchFromAssemblyPath(f string, cellSet map[string]str
 			continue
 		}
 		if pathWithin(f, path.Dir(asm.File)) {
-			for _, cellID := range asm.Cells {
-				cellSet[cellID] = struct{}{}
+			for _, ref := range asm.Cells {
+				cellSet[ref.ID] = struct{}{}
 			}
 			return true
 		}

--- a/kernel/governance/targets_test.go
+++ b/kernel/governance/targets_test.go
@@ -97,7 +97,7 @@ func targetsProject() *metadata.ProjectMeta {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"corebundle": {
 				ID:    "corebundle",
-				Cells: []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}, {ID: metadatatest.CellIDAuditCore}},
 				Build: metadata.BuildMeta{
 					Entrypoint: "cmd/corebundle/main.go",
 					Binary:     "corebundle",
@@ -634,7 +634,7 @@ func TestSelectFromFiles_ExampleAssemblyPath(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"todoorder": {
 				ID:    "todoorder",
-				Cells: []string{metadatatest.CellIDOrderCell, metadatatest.NewCellID("auditcell")},
+				Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDOrderCell}, {ID: metadatatest.NewCellID("auditcell")}},
 				File:  "examples/todoorder/assembly.yaml",
 			},
 		},

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -224,8 +224,12 @@ func validProject() *metadata.ProjectMeta {
 		},
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"corebundle": {
-				ID:                  "corebundle",
-				Cells:               []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore, metadatatest.CellIDSharedCrypto},
+				ID: "corebundle",
+				Cells: []metadata.AssemblyCellRef{
+					{ID: metadatatest.CellIDAccessCore},
+					{ID: metadatatest.CellIDAuditCore},
+					{ID: metadatatest.CellIDSharedCrypto},
+				},
 				MaxConsistencyLevel: "L3", // derived: max of L3, L2, L0
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "assembly-owner"},
 				Build: metadata.BuildMeta{
@@ -555,7 +559,8 @@ func TestREF08(t *testing.T) {
 		{
 			name: "assembly references missing cell",
 			setup: func(pm *metadata.ProjectMeta) {
-				pm.Assemblies["corebundle"].Cells = append(pm.Assemblies["corebundle"].Cells, "nonexistent")
+				pm.Assemblies["corebundle"].Cells = append(pm.Assemblies["corebundle"].Cells,
+					metadata.AssemblyCellRef{ID: metadatatest.NewCellID("nonexistent")})
 			},
 			wantCount: 1,
 		},
@@ -941,7 +946,7 @@ func TestTOPO06(t *testing.T) {
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Assemblies["edge-bundle"] = &metadata.AssemblyMeta{
 					ID:    "edge-bundle",
-					Cells: []string{metadatatest.CellIDAccessCore}, // also in corebundle
+					Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}}, // also in corebundle
 					Build: metadata.BuildMeta{
 						Entrypoint:     "cmd/edge-bundle/main.go",
 						Binary:         "edge-bundle",
@@ -2995,7 +3000,7 @@ func TestREF15(t *testing.T) {
 			setup: func(pm *metadata.ProjectMeta) {
 				pm.Assemblies["wrong-key"] = &metadata.AssemblyMeta{
 					ID:    "actual-id",
-					Cells: []string{metadatatest.CellIDAccessCore},
+					Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}},
 					Build: metadata.BuildMeta{Entrypoint: "cmd/main.go"},
 				}
 			},
@@ -4398,7 +4403,7 @@ func TestREF16(t *testing.T) {
 		pm := validProject()
 		pm.Assemblies["../../etc"] = &metadata.AssemblyMeta{
 			ID:    "../../etc",
-			Cells: []string{metadatatest.CellIDAccessCore},
+			Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}},
 			Build: metadata.BuildMeta{
 				Entrypoint: "cmd/evil/main.go",
 				Binary:     "evil",
@@ -4433,7 +4438,7 @@ func TestREF16(t *testing.T) {
 		pm := validProject()
 		pm.Assemblies["edge-bundle"] = &metadata.AssemblyMeta{
 			ID:    "edge-bundle",
-			Cells: []string{metadatatest.CellIDAccessCore},
+			Cells: []metadata.AssemblyCellRef{{ID: metadatatest.CellIDAccessCore}},
 			Build: metadata.BuildMeta{
 				Entrypoint:     "cmd/edge-bundle/main.go",
 				Binary:         "edge-bundle",

--- a/kernel/metadata/assembly_cellref_test.go
+++ b/kernel/metadata/assembly_cellref_test.go
@@ -47,6 +47,11 @@ func TestAssemblyCellRef_UnmarshalYAML_Rejections(t *testing.T) {
 		{"missing id", "- {module: github.com/acme/x}", "id"},
 		{"empty id", `- {id: ""}`, "id"},
 		{"non-scalar-non-mapping element", "- [nested, seq]", "must be a string"},
+		// module hygiene (defense-in-depth on the generated import path):
+		{"explicit empty module", `- {id: x, module: ""}`, "non-empty"},
+		{"null module", "- {id: x, module: ~}", "non-empty"},
+		{"module with space", `- {id: x, module: "github.com/a b/c"}`, "invalid character"},
+		{"module with quote", `- {id: x, module: "a\"b"}`, "invalid character"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -58,7 +63,8 @@ func TestAssemblyCellRef_UnmarshalYAML_Rejections(t *testing.T) {
 	}
 }
 
-// TestCellRefsAndCellIDs covers the ergonomic constructor/projection helpers.
+// TestCellRefsAndCellIDs covers the ergonomic constructor/projection helpers,
+// including empty/zero boundaries.
 func TestCellRefsAndCellIDs(t *testing.T) {
 	refs := metadata.CellRefs("configcore", "auditcore")
 	require.Len(t, refs, 2)
@@ -67,5 +73,9 @@ func TestCellRefsAndCellIDs(t *testing.T) {
 	assert.Equal(t, "auditcore", refs[1].ID)
 
 	assert.Equal(t, []string{"configcore", "auditcore"}, metadata.CellIDs(refs))
-	assert.Empty(t, metadata.CellIDs(nil))
+
+	// Empty/zero boundaries.
+	assert.Empty(t, metadata.CellRefs(), "CellRefs() with no ids is empty")
+	assert.Empty(t, metadata.CellIDs(nil), "CellIDs(nil) is empty")
+	assert.Empty(t, metadata.CellIDs([]metadata.AssemblyCellRef{}), "CellIDs(empty) is empty")
 }

--- a/kernel/metadata/assembly_cellref_test.go
+++ b/kernel/metadata/assembly_cellref_test.go
@@ -1,0 +1,71 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// TestAssemblyCellRef_UnmarshalYAML_UnionForms covers the scalar-or-object
+// union accepted by AssemblyCellRef.UnmarshalYAML (#1086): bare-string
+// shorthand (same-module) and the {id, module} object form (cross-module).
+func TestAssemblyCellRef_UnmarshalYAML_UnionForms(t *testing.T) {
+	const doc = `
+- configcore
+- id: payment
+  module: github.com/acme/payment-cell
+- id: auditcore
+`
+	var refs []metadata.AssemblyCellRef
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &refs))
+	require.Len(t, refs, 3)
+
+	assert.Equal(t, "configcore", refs[0].ID)
+	assert.Empty(t, refs[0].Module, "scalar shorthand is same-module (empty Module)")
+
+	assert.Equal(t, "payment", refs[1].ID)
+	assert.Equal(t, "github.com/acme/payment-cell", refs[1].Module)
+
+	assert.Equal(t, "auditcore", refs[2].ID)
+	assert.Empty(t, refs[2].Module, "object form without module is same-module")
+}
+
+// TestAssemblyCellRef_UnmarshalYAML_Rejections covers the strict-decode parity
+// the custom Unmarshaler enforces itself (KnownFields does not propagate into a
+// custom Unmarshaler).
+func TestAssemblyCellRef_UnmarshalYAML_Rejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{"unknown field", "- {id: x, bogus: y}", "unknown field"},
+		{"missing id", "- {module: github.com/acme/x}", "id"},
+		{"empty id", `- {id: ""}`, "id"},
+		{"non-scalar-non-mapping element", "- [nested, seq]", "must be a string"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var refs []metadata.AssemblyCellRef
+			err := yaml.Unmarshal([]byte(tc.doc), &refs)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestCellRefsAndCellIDs covers the ergonomic constructor/projection helpers.
+func TestCellRefsAndCellIDs(t *testing.T) {
+	refs := metadata.CellRefs("configcore", "auditcore")
+	require.Len(t, refs, 2)
+	assert.Equal(t, "configcore", refs[0].ID)
+	assert.Empty(t, refs[0].Module)
+	assert.Equal(t, "auditcore", refs[1].ID)
+
+	assert.Equal(t, []string{"configcore", "auditcore"}, metadata.CellIDs(refs))
+	assert.Empty(t, metadata.CellIDs(nil))
+}

--- a/kernel/metadata/assembly_derive.go
+++ b/kernel/metadata/assembly_derive.go
@@ -123,8 +123,8 @@ func computeMaxConsistencyLevel(pm *ProjectMeta, asm *AssemblyMeta) (string, boo
 	}
 	maxRank := -1
 	maxLevel := "L0"
-	for _, cellID := range asm.Cells {
-		c, ok := pm.Cells[cellID]
+	for _, ref := range asm.Cells {
+		c, ok := pm.Cells[ref.ID]
 		if !ok {
 			return "", false
 		}

--- a/kernel/metadata/assembly_derive_test.go
+++ b/kernel/metadata/assembly_derive_test.go
@@ -12,7 +12,9 @@ import (
 // buildAssemblyProject constructs a minimal *metadata.ProjectMeta with the given cells
 // and one assembly referencing them. Used to drive ExportedApplyAssemblyDerivations
 // without touching the filesystem.
-func buildAssemblyProject(cellLevels map[string]string, asmCells []string, asm *metadata.AssemblyMeta) *metadata.ProjectMeta {
+func buildAssemblyProject(
+	cellLevels map[string]string, asmCells []metadata.AssemblyCellRef, asm *metadata.AssemblyMeta,
+) *metadata.ProjectMeta {
 	pm := &metadata.ProjectMeta{
 		Cells:      make(map[string]*metadata.CellMeta),
 		Slices:     make(map[string]*metadata.SliceMeta),
@@ -39,7 +41,7 @@ func TestApplyAssemblyDerivations_BuildAllOmitted(t *testing.T) {
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
 	mycelll1 := metadatatest.NewCellID("mycelll1")
-	pm := buildAssemblyProject(map[string]string{mycelll1: "L1"}, []string{mycelll1}, asm)
+	pm := buildAssemblyProject(map[string]string{mycelll1: "L1"}, metadata.CellRefs(mycelll1), asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -56,7 +58,7 @@ func TestApplyAssemblyDerivations_PartialBuildOverride(t *testing.T) {
 		Build: metadata.BuildMeta{Binary: "custom-bin"},
 	}
 	somecell := metadatatest.NewCellID("somecell")
-	pm := buildAssemblyProject(map[string]string{somecell: "L2"}, []string{somecell}, asm)
+	pm := buildAssemblyProject(map[string]string{somecell: "L2"}, metadata.CellRefs(somecell), asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -79,7 +81,7 @@ func TestApplyAssemblyDerivations_MaxConsistencyMultipleCells(t *testing.T) {
 			metadatatest.CellIDCellB: "L2",
 			metadatatest.CellIDCellC: "L4",
 		},
-		[]string{metadatatest.CellIDCellA, metadatatest.CellIDCellB, metadatatest.CellIDCellC},
+		[]metadata.AssemblyCellRef{{ID: metadatatest.CellIDCellA}, {ID: metadatatest.CellIDCellB}, {ID: metadatatest.CellIDCellC}},
 		asm,
 	)
 
@@ -94,7 +96,7 @@ func TestApplyAssemblyDerivations_MaxConsistencyAllL0(t *testing.T) {
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
 	purecalc := metadatatest.NewCellID("purecalc")
-	pm := buildAssemblyProject(map[string]string{purecalc: "L0"}, []string{purecalc}, asm)
+	pm := buildAssemblyProject(map[string]string{purecalc: "L0"}, metadata.CellRefs(purecalc), asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -111,7 +113,7 @@ func TestApplyAssemblyDerivations_MissingCellRefSkipsMaxLevel(t *testing.T) {
 		ID:    "badbundle",
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
-	pm := buildAssemblyProject(map[string]string{}, []string{metadatatest.NewCellID("nonexistent")}, asm)
+	pm := buildAssemblyProject(map[string]string{}, []metadata.AssemblyCellRef{{ID: metadatatest.NewCellID("nonexistent")}}, asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -133,7 +135,9 @@ func TestApplyAssemblyDerivations_ExamplesEntrypoint(t *testing.T) {
 		File:  "examples/todoorder/assembly.yaml",
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
-	pm := buildAssemblyProject(map[string]string{metadatatest.CellIDOrderCell: "L2"}, []string{metadatatest.CellIDOrderCell}, asm)
+	pm := buildAssemblyProject(
+		map[string]string{metadatatest.CellIDOrderCell: "L2"},
+		[]metadata.AssemblyCellRef{{ID: metadatatest.CellIDOrderCell}}, asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -204,7 +208,7 @@ func TestApplyAssemblyDerivations_ConventionalAssemblyEntrypoint(t *testing.T) {
 		File:  "assemblies/corebundle/assembly.yaml",
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
-	pm := buildAssemblyProject(map[string]string{}, []string{}, asm)
+	pm := buildAssemblyProject(map[string]string{}, []metadata.AssemblyCellRef{}, asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -223,7 +227,7 @@ func TestApplyAssemblyDerivations_ManifestCustomEntrypoint(t *testing.T) {
 		File:  "services/payment/assembly.yaml",
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
-	pm := buildAssemblyProject(map[string]string{}, []string{}, asm)
+	pm := buildAssemblyProject(map[string]string{}, []metadata.AssemblyCellRef{}, asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 
@@ -262,7 +266,7 @@ func TestApplyAssemblyDerivations_InvalidLevelSkipsMaxLevel(t *testing.T) {
 		Owner: metadata.OwnerMeta{Team: "platform", Role: "cell-owner"},
 	}
 	badlevelcell := metadatatest.NewCellID("badlevelcell")
-	pm := buildAssemblyProject(map[string]string{badlevelcell: "L9"}, []string{badlevelcell}, asm)
+	pm := buildAssemblyProject(map[string]string{badlevelcell: "L9"}, metadata.CellRefs(badlevelcell), asm)
 
 	metadata.ExportedApplyAssemblyDerivations(pm)
 

--- a/kernel/metadata/contract_constraints.go
+++ b/kernel/metadata/contract_constraints.go
@@ -53,6 +53,18 @@ const (
 	// kernel/governance SAGA-CONTRACT-STEP-NAME-VALID-01 compiles it (replacing
 	// the prior hand-duplicated literal).
 	SagaStepNamePattern = `^[a-zA-Z][a-zA-Z0-9]*$`
+	// AssemblyModulePathPattern is the single source for assembly.yaml cell
+	// `module` hygiene (the cross-module Go module path, #1086): a non-empty
+	// string carrying no rune that could break out of the generated
+	// "<module>/cellmodules/<id>" import string literal. The negated character
+	// class is exactly the blocklist enforced by metadata.MatchAssemblyModulePath
+	// (and consumed by AssemblyCellRef.decodeMapping): the control+space range
+	// \x00-\x20, DEL \x7f, double-quote, backtick (\x60), and backslash (\\).
+	// Mirrors schemas/assembly.schema.json
+	// cells.items.oneOf[1].properties.module.pattern, byte-locked by
+	// TestAssemblyCellRefSchemaPatternsMatchConstants. Defense-in-depth on top of
+	// the %q-quoting + Go-compiler import-resolvability gate (ADR §D3).
+	AssemblyModulePathPattern = "^[^\\x00-\\x20\\x7f\"\\x60\\\\]+$"
 )
 
 // DeployTemplateEnum lists the canonical values accepted for
@@ -71,6 +83,8 @@ var CapabilityEnum = []string{"postgres", "redis", "rabbitmq"}
 
 var goStructNameRe = regexp.MustCompile(GoStructNamePattern)
 
+var assemblyModulePathRe = regexp.MustCompile(AssemblyModulePathPattern)
+
 // MatchAssemblyID reports whether s satisfies AssemblyIDPattern. Forwards
 // to pkg/scaffoldid.Match so the regex is compiled exactly once across the
 // codebase (CELL-ID-PATTERN-SINGLE-SOURCE-01).
@@ -82,6 +96,11 @@ func MatchCellID(s string) bool { return scaffoldid.Match(s) }
 
 // MatchGoStructName reports whether s satisfies GoStructNamePattern.
 func MatchGoStructName(s string) bool { return goStructNameRe.MatchString(s) }
+
+// MatchAssemblyModulePath reports whether s satisfies AssemblyModulePathPattern:
+// a non-empty assembly cell `module` path free of runes that could break out of
+// the generated cellmodules import string literal.
+func MatchAssemblyModulePath(s string) bool { return assemblyModulePathRe.MatchString(s) }
 
 // IsValidMetadataText reports whether value is free of the control characters
 // (\n, \r, \x00, \t) that would break inline YAML scalar emission or fabricate

--- a/kernel/metadata/parser_test.go
+++ b/kernel/metadata/parser_test.go
@@ -294,7 +294,11 @@ func TestParseFS_FullProject(t *testing.T) {
 	assert.Len(t, pm.Assemblies, 1)
 	assert.Contains(t, pm.Assemblies, "corebundle")
 	a := pm.Assemblies["corebundle"]
-	assert.Equal(t, []string{"accesscore", "auditcore"}, a.Cells)
+	// CellRefs (a call, not a composite literal) is the sanctioned same-module
+	// constructor here: parser_test.go is package metadata (internal), so it
+	// cannot import metadatatest (import cycle), and A1 does not scan CellRefs
+	// call args.
+	assert.Equal(t, CellRefs("accesscore", "auditcore"), a.Cells)
 	assert.Equal(t, "k8s", a.Build.DeployTemplate)
 
 	// Status Board

--- a/kernel/metadata/schemas/assembly.schema.json
+++ b/kernel/metadata/schemas/assembly.schema.json
@@ -78,7 +78,7 @@
         },
         "compositionAPI": {
           "type": "boolean",
-          "description": "When true, GenerateModulesGen emits the runtime/composition.CellModule form (cellmodules/{cell}.Module() constructors) instead of the legacy local-CellModule-type form. Set true only in cellmodules-based assemblies (currently assemblies/corebundle)."
+          "description": "When true, GenerateModulesGen emits the runtime/composition.CellModule form (cellmodules/{cell}.Module() constructors) instead of the legacy local-CellModule-type form. Set true for cellmodules-based assemblies; REQUIRED when any cell declares a non-empty `module` (cross-module cell from an independent Go module, #1086) — the legacy form has no import path and cannot reference a foreign module."
         }
       }
     }

--- a/kernel/metadata/schemas/assembly.schema.json
+++ b/kernel/metadata/schemas/assembly.schema.json
@@ -19,7 +19,8 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Same-module cell id shorthand."
+            "description": "Same-module cell id shorthand.",
+            "pattern": "^[a-z][a-z0-9]{1,31}$"
           },
           {
             "type": "object",
@@ -29,11 +30,14 @@
             "properties": {
               "id": {
                 "type": "string",
-                "description": "Cell id."
+                "description": "Cell id.",
+                "pattern": "^[a-z][a-z0-9]{1,31}$"
               },
               "module": {
                 "type": "string",
-                "description": "Go module path the cell's cellmodules/ package lives in (e.g. github.com/acme/payment-cell). Omit for the assembly's own module. Must be a declared go.mod/go.work dependency; the Go compiler enforces resolvability at build time."
+                "description": "Go module path the cell's cellmodules/ package lives in (e.g. github.com/acme/payment-cell). Omit for the assembly's own module. Must be a declared go.mod/go.work dependency; the Go compiler enforces resolvability at build time.",
+                "minLength": 1,
+                "pattern": "^[^\\x00-\\x20\\x7f\"\\x60\\\\]+$"
               }
             }
           }

--- a/kernel/metadata/schemas/assembly.schema.json
+++ b/kernel/metadata/schemas/assembly.schema.json
@@ -14,9 +14,30 @@
     },
     "cells": {
       "type": "array",
-      "description": "List of cell ids included in this assembly.",
+      "description": "Cells included in this assembly. Each entry is either a bare cell id string (same-module shorthand) or an object {id, module} where module names the external Go module the cell is developed in (cell development in an independent repository, #1086). module omitted = the assembly's own module.",
       "items": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Same-module cell id shorthand."
+          },
+          {
+            "type": "object",
+            "description": "Cross-module cell reference.",
+            "required": ["id"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Cell id."
+              },
+              "module": {
+                "type": "string",
+                "description": "Go module path the cell's cellmodules/ package lives in (e.g. github.com/acme/payment-cell). Omit for the assembly's own module. Must be a declared go.mod/go.work dependency; the Go compiler enforces resolvability at build time."
+              }
+            }
+          }
+        ]
       },
       "minItems": 1
     },

--- a/kernel/metadata/schemas/assembly_schema_test.go
+++ b/kernel/metadata/schemas/assembly_schema_test.go
@@ -99,6 +99,47 @@ func TestAssemblySchema_NoCapabilitiesProperty(t *testing.T) {
 		"assembly capabilities property was removed; it must be rejected by additionalProperties:false")
 }
 
+// TestAssemblySchema_CellRefUnion verifies the cells[] scalar-or-object union
+// (#1086) accepts valid forms and rejects the same shapes the Go parser
+// (AssemblyCellRef.UnmarshalYAML) rejects — closing the schema↔parser drift
+// (F3/cluster C3): empty/non-canonical cell id (both forms), empty module, and
+// module paths carrying runes that could break the generated cellmodules import.
+func TestAssemblySchema_CellRefUnion(t *testing.T) {
+	schema := compileAssemblySchema(t)
+	const before = `{"id": "corebundle", "owner": {"team": "platform", "role": "cell-owner"}, "cells": `
+	const after = `}`
+
+	accepted := map[string]string{
+		"scalar shorthand":      `["configcore"]`,
+		"object same-module":    `[{"id": "configcore"}]`,
+		"object cross-module":   `[{"id": "payment", "module": "github.com/acme/payment-cell"}]`,
+		"mixed scalar + object": `["accesscore", {"id": "payment", "module": "github.com/acme/pay"}]`,
+	}
+	for name, cells := range accepted {
+		t.Run("accept/"+name, func(t *testing.T) {
+			doc := parseAssemblyDoc(t, before+cells+after)
+			assert.NoError(t, schema.Validate(doc), "%s must pass schema validation", name)
+		})
+	}
+
+	rejected := map[string]string{
+		"empty scalar id":       `[""]`,
+		"non-canonical scalar":  `["NotACell"]`,
+		"empty object id":       `[{"id": ""}]`,
+		"empty module":          `[{"id": "payment", "module": ""}]`,
+		"module with space":     `[{"id": "payment", "module": "github.com/a b/c"}]`,
+		"module with quote":     `[{"id": "payment", "module": "a\"b"}]`,
+		"module with backslash": `[{"id": "payment", "module": "a\\b"}]`,
+	}
+	for name, cells := range rejected {
+		t.Run("reject/"+name, func(t *testing.T) {
+			doc := parseAssemblyDoc(t, before+cells+after)
+			assert.Error(t, schema.Validate(doc),
+				"%s must fail schema validation (parser rejects it too)", name)
+		})
+	}
+}
+
 // formatf is a helper that avoids importing fmt in a test-only file.
 func formatf(format, arg string) string {
 	out := make([]byte, 0, len(format)+len(arg))

--- a/kernel/metadata/schemas/schema_const_consistency_test.go
+++ b/kernel/metadata/schemas/schema_const_consistency_test.go
@@ -147,6 +147,47 @@ func TestSchemaConstantsMatchSchemaLiterals(t *testing.T) {
 	})
 }
 
+// TestAssemblyCellRefSchemaPatternsMatchConstants byte-locks the assembly.yaml
+// `cells[]` union patterns (#1086) to their Go single-source constants:
+//   - oneOf[0] (scalar shorthand) .pattern        == metadata.CellIDPattern
+//   - oneOf[1] (object) .properties.id.pattern    == metadata.CellIDPattern
+//   - oneOf[1] .properties.module.pattern         == metadata.AssemblyModulePathPattern
+//
+// The cells.items.oneOf branches are addressed by array index (scalar = 0,
+// object = 1), the stable shape declared in assembly.schema.json. Drift in
+// either direction (schema looser/stricter than the parser's accepted set) is a
+// hard failure: the schema is the on-disk authority for IDE/standalone tooling,
+// the constants are the runtime authority used by AssemblyCellRef.decodeMapping
+// (via metadata.MatchAssemblyModulePath) and governance cell-existence checks.
+func TestAssemblyCellRefSchemaPatternsMatchConstants(t *testing.T) {
+	t.Parallel()
+
+	oneOf, ok := walkSchema(t, "assembly.schema.json",
+		[]string{"properties", "cells", "items", "oneOf"}).([]any)
+	require.True(t, ok, "assembly.schema.json cells.items.oneOf must be an array")
+	require.Len(t, oneOf, 2, "cells.items.oneOf must have exactly 2 branches (scalar, object)")
+
+	scalar, ok := oneOf[0].(map[string]any)
+	require.True(t, ok, "oneOf[0] (scalar shorthand) must be an object")
+	require.Equal(t, metadata.CellIDPattern, scalar["pattern"],
+		"assembly.schema.json cells scalar-shorthand pattern drifted from metadata.CellIDPattern")
+
+	object, ok := oneOf[1].(map[string]any)
+	require.True(t, ok, "oneOf[1] (object form) must be an object")
+	objProps, ok := object["properties"].(map[string]any)
+	require.True(t, ok, "oneOf[1].properties must be an object")
+
+	idProp, ok := objProps["id"].(map[string]any)
+	require.True(t, ok, "oneOf[1].properties.id must be an object")
+	require.Equal(t, metadata.CellIDPattern, idProp["pattern"],
+		"assembly.schema.json cells object-form id.pattern drifted from metadata.CellIDPattern")
+
+	moduleProp, ok := objProps["module"].(map[string]any)
+	require.True(t, ok, "oneOf[1].properties.module must be an object")
+	require.Equal(t, metadata.AssemblyModulePathPattern, moduleProp["pattern"],
+		"assembly.schema.json cells object-form module.pattern drifted from metadata.AssemblyModulePathPattern")
+}
+
 // walkGRPCEndpointField returns the leaf value at
 // then.properties.endpoints.properties.grpc.properties.<field>.<leaf> inside the
 // contract.schema.json allOf branch guarded by kind=grpc. The branch is located

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -481,13 +481,111 @@ type PassCriterion struct {
 	CheckRef string `yaml:"checkRef,omitempty"`
 }
 
+// AssemblyCellRef is one entry in assembly.yaml `cells:`. It accepts two YAML
+// forms (see UnmarshalYAML):
+//
+//   - scalar shorthand       `- configcore`                          → {ID: "configcore"}
+//   - object (cross-module)  `- {id: payment, module: github.com/acme/pay}`
+//
+// Module empty = the cell's cellmodules/ package lives in the assembly's own Go
+// module (the common same-module case). A non-empty Module references a cell
+// developed in an independent Go module (#1086); codegen renders the import as
+// "<Module>/cellmodules/<ID>" instead of "<current module>/cellmodules/<ID>".
+// The module must be a declared dependency (go.mod require / go.work use) — that
+// is enforced by the Go compiler when the generated modules_gen.go is built, not
+// by a metadata governance rule (a declared-but-unresolvable module fails
+// `go build`).
+type AssemblyCellRef struct {
+	ID     string
+	Module string
+}
+
+// UnmarshalYAML decodes the scalar-or-object union form of an assembly cell
+// entry. The decoder's KnownFields(true) strictness does not propagate into a
+// custom Unmarshaler, so the mapping branch enforces the {id, module} key set
+// itself to preserve strict-decode parity with the rest of the schema.
+func (r *AssemblyCellRef) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		r.ID, r.Module = node.Value, ""
+		return nil
+	case yaml.MappingNode:
+		return r.decodeMapping(node)
+	default:
+		return fmt.Errorf("line %d: assembly cell entry must be a string or {id, module} mapping", node.Line)
+	}
+}
+
+// decodeMapping handles the object form `{id, module}` of an assembly cell
+// entry, enforcing the known-field set (id, module) and the required id.
+func (r *AssemblyCellRef) decodeMapping(node *yaml.Node) error {
+	var id, module string
+	var sawID bool
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode, valNode := node.Content[i], node.Content[i+1]
+		switch keyNode.Value {
+		case "id":
+			if err := valNode.Decode(&id); err != nil {
+				return err
+			}
+			sawID = true
+		case "module":
+			if err := valNode.Decode(&module); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("line %d: unknown field %q in assembly cell entry (allowed: id, module)",
+				keyNode.Line, keyNode.Value)
+		}
+	}
+	if !sawID || id == "" {
+		return fmt.Errorf("line %d: assembly cell entry missing required field \"id\"", node.Line)
+	}
+	r.ID, r.Module = id, module
+	return nil
+}
+
+// CellRefs builds a same-module []AssemblyCellRef from bare cell ids. It is the
+// ergonomic constructor for the common case (every cell in the assembly's own
+// module); cross-module entries are constructed as AssemblyCellRef{ID, Module}
+// literals.
+//
+// This function body is the single sanctioned site that embeds an
+// AssemblyCellRef{ID: <runtime value>} composite literal; it is allowlisted by
+// FIXTURE-CELLID-TYPED-BUILDER-01/A1 (this file). A1 does not scan CellRefs
+// call arguments. Usage guidance by A1 scope (kernel/):
+//   - external kernel/ test packages with static ids → prefer explicit
+//     []AssemblyCellRef{{ID: metadatatest.CellID*}} literals (A1-checked);
+//   - internal `package metadata` tests (cannot import metadatatest — import
+//     cycle) and dynamic-id helpers (ids are runtime params, not literals) →
+//     use CellRefs (the only A1-compatible path);
+//   - non-kernel ergonomics + production synthesis from validated runtime ids.
+func CellRefs(ids ...string) []AssemblyCellRef {
+	refs := make([]AssemblyCellRef, len(ids))
+	for i, id := range ids {
+		refs[i] = AssemblyCellRef{ID: id}
+	}
+	return refs
+}
+
+// CellIDs projects an []AssemblyCellRef to the bare cell-id slice, dropping
+// module attribution. Used where only identity matters (entrypoint cell-id
+// list, boundary cell set, devtools catalog wire shape).
+func CellIDs(refs []AssemblyCellRef) []string {
+	ids := make([]string, len(refs))
+	for i, r := range refs {
+		ids[i] = r.ID
+	}
+	return ids
+}
+
 // AssemblyMeta maps to assemblies/{id}/assembly.yaml (platform assemblies)
 // or examples/{id}/assembly.yaml (example assemblies).
 // See parser.matchAssemblyYAML for the recognized path forms.
 type AssemblyMeta struct {
-	ID    string    `yaml:"id"`
-	Cells []string  `yaml:"cells"`
-	Owner OwnerMeta `yaml:"owner"`
+	ID    string            `yaml:"id"`
+	Cells []AssemblyCellRef `yaml:"cells"`
+	Owner OwnerMeta         `yaml:"owner"`
 	// The assembly's provisioned capability set is NOT declared here — it is the
 	// derived union of its cells' CellMeta.Requires (Design Y, #855). There is no
 	// hand-authored assembly-level `capabilities` field; the single source is

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -571,10 +571,13 @@ func validateOptionalModulePath(present bool, module string) error {
 	if module == "" {
 		return fmt.Errorf("assembly cell entry \"module\" must be non-empty when set (omit it for same-module)")
 	}
-	for _, rn := range module {
-		if rn < 0x20 || rn == 0x7f || rn == ' ' || rn == '"' || rn == '`' || rn == '\\' {
-			return fmt.Errorf("invalid character %q in assembly cell module %q", rn, module)
-		}
+	// Single source: the char blocklist lives in metadata.AssemblyModulePathPattern
+	// (byte-locked to the JSON schema). MatchAssemblyModulePath rejects the same
+	// runes the prior imperative loop did — control+space range, DEL, quote,
+	// backtick, backslash — that could break out of the generated cellmodules
+	// import string literal.
+	if !MatchAssemblyModulePath(module) {
+		return fmt.Errorf("invalid character in assembly cell module %q", module)
 	}
 	return nil
 }

--- a/kernel/metadata/types.go
+++ b/kernel/metadata/types.go
@@ -495,9 +495,17 @@ type PassCriterion struct {
 // is enforced by the Go compiler when the generated modules_gen.go is built, not
 // by a metadata governance rule (a declared-but-unresolvable module fails
 // `go build`).
+//
+// A non-empty Module also requires the owning assembly to declare
+// `build.compositionAPI: true`; otherwise `gocell generate assembly` fails with
+// ErrMetadataInvalid (the legacy local-CellModule form has no import path and
+// cannot express a foreign module).
 type AssemblyCellRef struct {
-	ID     string
-	Module string
+	// yaml tags drive only marshaling (decode is the custom UnmarshalYAML below);
+	// module is omitempty so a round-trip of a same-module ref emits `id: x`
+	// rather than `module: ""` (which the decoder rejects as explicit-empty).
+	ID     string `yaml:"id"`
+	Module string `yaml:"module,omitempty"`
 }
 
 // UnmarshalYAML decodes the scalar-or-object union form of an assembly cell
@@ -517,10 +525,13 @@ func (r *AssemblyCellRef) UnmarshalYAML(node *yaml.Node) error {
 }
 
 // decodeMapping handles the object form `{id, module}` of an assembly cell
-// entry, enforcing the known-field set (id, module) and the required id.
+// entry, enforcing the known-field set (id, module), the required non-empty id,
+// and module-path hygiene (a non-empty module must not carry characters that
+// could be smuggled into the generated cellmodules import — defense-in-depth on
+// top of the %q-quoting + Go-compiler gate; see ADR §D3).
 func (r *AssemblyCellRef) decodeMapping(node *yaml.Node) error {
 	var id, module string
-	var sawID bool
+	var sawID, sawModule bool
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		keyNode, valNode := node.Content[i], node.Content[i+1]
 		switch keyNode.Value {
@@ -533,6 +544,7 @@ func (r *AssemblyCellRef) decodeMapping(node *yaml.Node) error {
 			if err := valNode.Decode(&module); err != nil {
 				return err
 			}
+			sawModule = true
 		default:
 			return fmt.Errorf("line %d: unknown field %q in assembly cell entry (allowed: id, module)",
 				keyNode.Line, keyNode.Value)
@@ -541,7 +553,29 @@ func (r *AssemblyCellRef) decodeMapping(node *yaml.Node) error {
 	if !sawID || id == "" {
 		return fmt.Errorf("line %d: assembly cell entry missing required field \"id\"", node.Line)
 	}
+	if err := validateOptionalModulePath(sawModule, module); err != nil {
+		return fmt.Errorf("line %d: %w", node.Line, err)
+	}
 	r.ID, r.Module = id, module
+	return nil
+}
+
+// validateOptionalModulePath rejects an explicit-but-empty module (meaningless
+// noise — omit it for same-module) and any module carrying control characters,
+// whitespace, or quote/backslash runes that could break out of the generated
+// import-path string literal.
+func validateOptionalModulePath(present bool, module string) error {
+	if !present {
+		return nil
+	}
+	if module == "" {
+		return fmt.Errorf("assembly cell entry \"module\" must be non-empty when set (omit it for same-module)")
+	}
+	for _, rn := range module {
+		if rn < 0x20 || rn == 0x7f || rn == ' ' || rn == '"' || rn == '`' || rn == '\\' {
+			return fmt.Errorf("invalid character %q in assembly cell module %q", rn, module)
+		}
+	}
 	return nil
 }
 

--- a/kernel/metadata/types_test.go
+++ b/kernel/metadata/types_test.go
@@ -355,8 +355,12 @@ func loadJourneySchema(t *testing.T) *jsonschema.Schema {
 
 func TestAssemblyMetaRoundTrip(t *testing.T) {
 	orig := metadata.AssemblyMeta{
-		ID:    "corebundle",
-		Cells: []string{metadatatest.CellIDAccessCore, metadatatest.CellIDAuditCore, metadatatest.CellIDConfigCore},
+		ID: "corebundle",
+		Cells: []metadata.AssemblyCellRef{
+			{ID: metadatatest.CellIDAccessCore},
+			{ID: metadatatest.CellIDAuditCore},
+			{ID: metadatatest.CellIDConfigCore},
+		},
 		Build: metadata.BuildMeta{
 			Entrypoint:     "cmd/corebundle/main.go",
 			Binary:         "corebundle",

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -54,7 +54,12 @@ type Builder struct {
 // `_runtime` sentinel. Mirrors K8s runtime.Scheme: registration-time enumeration
 // + hard rejection of out-of-set identities.
 func New(expectedCellIDs ...string) *Builder {
-	return &Builder{expectedCellIDs: expectedCellIDs}
+	// Defensive copy: a variadic parameter aliases the caller's backing array
+	// when invoked in spread form (composition.New(ids...) — see
+	// cmd/corebundle/run.go). Without the clone the caller could mutate the
+	// sealed closed set after New but before Build. slices.Clone of a nil/empty
+	// slice yields nil/empty, preserving the empty-assembly degenerate case.
+	return &Builder{expectedCellIDs: slices.Clone(expectedCellIDs)}
 }
 
 // With appends modules to the builder.  Calls are accumulating: successive
@@ -70,9 +75,10 @@ func (b *Builder) With(modules ...CellModule) *Builder {
 // Flow:
 //  1. Guard that shared was produced by [NewSharedDeps] (sealed-construction
 //     marker check) and that runtimeOptsFn is non-nil — startup invariants.
-//  2. For each module: nil-guard, call [CellModule.Provide], accumulate cells +
+//  2. For each module: nil-guard, call [CellModule.Provide], nil-cell guard,
+//     closed-set identity guard (c.ID() == m.ID(), see below), accumulate cells +
 //     cellOpts + provisional ManagedResources, with LIFO Close(ctx) rollback on
-//     any failure; nil-cell guard.
+//     any failure.
 //  3. Call runtimeOptsFn(cells) to get runtimeOpts.  If it errors, rollback
 //     provisional resources and return.
 //  4. allOpts := runtimeOpts ++ cellOpts.
@@ -141,6 +147,12 @@ func validateBuildInputs(shared *SharedDeps, runtimeOptsFn RuntimeOptionsFunc) e
 // nil modules are deliberately skipped here: the Build provide loop owns the
 // nil-module path (with provisional-resource rollback), so the closed-set guard
 // must not pre-empt it.
+//
+// This guard keys on the module's self-reported ID() so it can fail fast before
+// any Provide opens resources. It does NOT see the cell each module constructs;
+// the Build provide loop closes that gap with a post-Provide c.ID() == m.ID()
+// identity guard (F1/cluster C1), so the runtime cell identity is bound to the
+// declaration validated here.
 func (b *Builder) validateClosedSet() error {
 	expected := make(map[string]struct{}, len(b.expectedCellIDs))
 	for _, id := range b.expectedCellIDs {
@@ -215,6 +227,23 @@ func (b *Builder) Build(
 			rollback()
 			return nil, fmt.Errorf("composition.Builder.Build: module %q returned nil Cell "+
 				"(use explicit Optional semantics if cell is optional)", m.ID())
+		}
+		// Closed-set identity guard (M12a #1093, F1/cluster C1): validateClosedSet
+		// runs pre-Provide against the module's self-reported ID(), but the cell
+		// identity that actually reaches runtime (metric `cell` label, healthz
+		// probe names) is c.ID() — sourced independently from the cell's metadata,
+		// not bound to m.ID(). A module whose ID is in the closed set could still
+		// construct a cell with an out-of-set ID. Requiring c.ID() == m.ID()
+		// binds the validated declaration to the constructed identity; since
+		// m.ID() ∈ closed set was already proven, this transitively guarantees
+		// c.ID() ∈ closed set. Mirrors K8s runtime.Scheme: registration enumerates
+		// the real object identity, not a wrapper label.
+		if c.ID() != m.ID() {
+			rollback()
+			return nil, fmt.Errorf("composition.Builder.Build: module %q provided a cell whose ID is %q; "+
+				"a module's ID must equal the ID of the cell it constructs — the closed-set guard validates "+
+				"the module ID pre-Provide, so a mismatch would let an out-of-set cell identity reach runtime "+
+				"(metric labels, healthz probes)", m.ID(), c.ID())
 		}
 		cells = append(cells, c)
 		cellOpts = append(cellOpts, mOpts...)

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	kernellifecycle "github.com/ghbvf/gocell/kernel/lifecycle"
@@ -145,6 +146,9 @@ func (b *Builder) validateClosedSet() error {
 	for _, id := range b.expectedCellIDs {
 		expected[id] = struct{}{}
 	}
+	// Sorted display for deterministic, readable diagnostics regardless of set size.
+	closedSet := strings.Join(slices.Sorted(slices.Values(b.expectedCellIDs)), ", ")
+	const fixHint = "add it to assembly.yaml cells or run `gocell generate assembly`"
 	provided := make(map[string]struct{}, len(b.modules))
 	for _, m := range b.modules {
 		if m == nil {
@@ -153,13 +157,12 @@ func (b *Builder) validateClosedSet() error {
 		id := m.ID()
 		if _, dup := provided[id]; dup {
 			return fmt.Errorf("composition.Builder.Build: duplicate cell module %q; "+
-				"each assembly cell must be provided by exactly one module", id)
+				"each assembly cell must be provided by exactly one module; %s", id, fixHint)
 		}
 		provided[id] = struct{}{}
 		if _, ok := expected[id]; !ok {
 			return fmt.Errorf("composition.Builder.Build: cell %q is not in the assembly "+
-				"closed set %v; add it to assembly.yaml cells or correct the cell ID",
-				id, b.expectedCellIDs)
+				"closed set [%s]; %s", id, closedSet, fixHint)
 		}
 	}
 	for _, id := range b.expectedCellIDs {

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -36,12 +36,24 @@ type RuntimeOptionsFunc func(cells []cell.Cell) ([]bootstrap.Option, error)
 // ref: kubernetes-sigs/controller-runtime pkg/manager/manager.go — Manager
 // accumulates options via functional options.
 type Builder struct {
-	modules []CellModule
+	modules         []CellModule
+	expectedCellIDs []string
 }
 
-// New returns a new Builder with no modules.
-func New() *Builder {
-	return &Builder{}
+// New returns a new Builder whose composed cells must form exactly the
+// assembly's declared cell-id closed set (expectedCellIDs — the assembly.yaml
+// cells list, threaded in by the generated entrypoint). Build fail-fasts if any
+// composed module's ID is not in the set, if a declared cell is not provided by
+// any module, or on duplicate module IDs (see Build).
+//
+// This is the M12a build-time closed-set guard (#1093): once multi-module
+// assembly composition exists (#1086), the assembly.yaml cell set is the
+// authoritative enumeration of legal cell identities, and a module composing a
+// cell outside it is a configuration bug — rejected outright, not degraded to a
+// `_runtime` sentinel. Mirrors K8s runtime.Scheme: registration-time enumeration
+// + hard rejection of out-of-set identities.
+func New(expectedCellIDs ...string) *Builder {
+	return &Builder{expectedCellIDs: expectedCellIDs}
 }
 
 // With appends modules to the builder.  Calls are accumulating: successive
@@ -116,12 +128,58 @@ func validateBuildInputs(shared *SharedDeps, runtimeOptsFn RuntimeOptionsFunc) e
 	return nil
 }
 
+// validateClosedSet enforces the M12a build-time closed-set invariant: the set
+// of composed cell IDs must equal the assembly's declared cell-id set
+// (b.expectedCellIDs) — a bijection. It runs before any module Provide so a
+// misconfiguration fails fast without opening resources.
+//
+//   - every module ID must be in the declared set (no out-of-set cell),
+//   - every declared cell must be provided by some module (no missing cell),
+//   - no two modules may share a cell ID (no duplicate).
+//
+// nil modules are deliberately skipped here: the Build provide loop owns the
+// nil-module path (with provisional-resource rollback), so the closed-set guard
+// must not pre-empt it.
+func (b *Builder) validateClosedSet() error {
+	expected := make(map[string]struct{}, len(b.expectedCellIDs))
+	for _, id := range b.expectedCellIDs {
+		expected[id] = struct{}{}
+	}
+	provided := make(map[string]struct{}, len(b.modules))
+	for _, m := range b.modules {
+		if m == nil {
+			continue
+		}
+		id := m.ID()
+		if _, dup := provided[id]; dup {
+			return fmt.Errorf("composition.Builder.Build: duplicate cell module %q; "+
+				"each assembly cell must be provided by exactly one module", id)
+		}
+		provided[id] = struct{}{}
+		if _, ok := expected[id]; !ok {
+			return fmt.Errorf("composition.Builder.Build: cell %q is not in the assembly "+
+				"closed set %v; add it to assembly.yaml cells or correct the cell ID",
+				id, b.expectedCellIDs)
+		}
+	}
+	for _, id := range b.expectedCellIDs {
+		if _, ok := provided[id]; !ok {
+			return fmt.Errorf("composition.Builder.Build: assembly declares cell %q but no "+
+				"module provides it; run `gocell generate assembly`", id)
+		}
+	}
+	return nil
+}
+
 func (b *Builder) Build(
 	ctx context.Context,
 	shared *SharedDeps,
 	runtimeOptsFn RuntimeOptionsFunc,
 ) (*App, error) {
 	if err := validateBuildInputs(shared, runtimeOptsFn); err != nil {
+		return nil, err
+	}
+	if err := b.validateClosedSet(); err != nil {
 		return nil, err
 	}
 

--- a/runtime/composition/builder_closedset_test.go
+++ b/runtime/composition/builder_closedset_test.go
@@ -83,6 +83,27 @@ func TestBuilder_ClosedSet_HappyPathBijection(t *testing.T) {
 	assert.Equal(t, "auditcore", runtimeCells[1].ID())
 }
 
+// TestBuilder_ClosedSet_RejectsCellIdentityMismatch verifies the post-Provide
+// identity guard (F1 / cluster C1): a module whose ID() IS in the closed set but
+// whose Provide constructs a cell with a DIFFERENT runtime ID is rejected.
+//
+// validateClosedSet runs pre-Provide against m.ID() (the module's self-reported,
+// hardcoded identifier). The identity that actually reaches runtime — the metric
+// `cell` label, healthz probe names — is c.ID(), sourced independently from cell
+// metadata. Without the post-Provide c.ID() == m.ID() guard, a module declared
+// "configcore" could smuggle an out-of-set cell identity ("imposter") past the
+// closed set. The guard runs AFTER Provide (so the module IS invoked).
+func TestBuilder_ClosedSet_RejectsCellIdentityMismatch(t *testing.T) {
+	ctx := context.Background()
+	mMismatch := &fakeCellModule{id: "configcore", cell: stubCell("imposter")}
+
+	_, err := New("configcore").With(mMismatch).Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configcore")
+	assert.Contains(t, err.Error(), "imposter")
+	assert.True(t, mMismatch.called, "identity mismatch is detected after Provide, not before")
+}
+
 // TestBuilder_ClosedSet_EmptyAssembly verifies the degenerate bijection: a
 // cell-less assembly (no declared ids, no modules) Builds successfully.
 func TestBuilder_ClosedSet_EmptyAssembly(t *testing.T) {

--- a/runtime/composition/builder_closedset_test.go
+++ b/runtime/composition/builder_closedset_test.go
@@ -1,0 +1,70 @@
+package composition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+)
+
+// noopRuntimeOpts is a RuntimeOptionsFunc that adds nothing — used by the
+// closed-set tests, which only exercise the pre-Provide closed-set guard.
+func noopRuntimeOpts([]cell.Cell) ([]bootstrap.Option, error) { return nil, nil }
+
+// TestBuilder_ClosedSet_RejectsCellOutsideSet verifies the M12a build-time
+// guard (#1093): a composed module whose ID is not in the assembly's declared
+// cell-id closed set is rejected fail-fast, before any module Provide runs.
+func TestBuilder_ClosedSet_RejectsCellOutsideSet(t *testing.T) {
+	ctx := context.Background()
+	mOutsider := &fakeCellModule{id: "outsider", cell: stubCell("outsider")}
+
+	_, err := New("configcore").With(mOutsider).Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outsider")
+	assert.Contains(t, err.Error(), "closed set")
+	assert.False(t, mOutsider.called, "out-of-set cell must be rejected before Provide")
+}
+
+// TestBuilder_ClosedSet_RejectsMissingDeclaredCell verifies that a cell
+// declared in the assembly closed set but not provided by any module is
+// rejected (bijection completeness half).
+func TestBuilder_ClosedSet_RejectsMissingDeclaredCell(t *testing.T) {
+	ctx := context.Background()
+	mA := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
+
+	_, err := New("configcore", "auditcore").With(mA).Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auditcore")
+	assert.Contains(t, err.Error(), "no module provides it")
+	assert.False(t, mA.called, "missing declared cell must be detected before Provide")
+}
+
+// TestBuilder_ClosedSet_RejectsDuplicateModule verifies that two modules
+// composing the same cell ID are rejected.
+func TestBuilder_ClosedSet_RejectsDuplicateModule(t *testing.T) {
+	ctx := context.Background()
+	m1 := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
+	m2 := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
+
+	_, err := New("configcore").With(m1, m2).Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+	assert.Contains(t, err.Error(), "configcore")
+}
+
+// TestBuilder_ClosedSet_HappyPathBijection verifies that an exact bijection
+// (every declared cell provided once, no extras) Builds successfully.
+func TestBuilder_ClosedSet_HappyPathBijection(t *testing.T) {
+	ctx := context.Background()
+	mA := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
+	mB := &fakeCellModule{id: "auditcore", cell: stubCell("auditcore")}
+
+	app, err := New("auditcore", "configcore").With(mA, mB).Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.NoError(t, err)
+	require.NotNil(t, app)
+	assert.True(t, mA.called && mB.called, "happy-path bijection must run all module Provides")
+}

--- a/runtime/composition/builder_closedset_test.go
+++ b/runtime/composition/builder_closedset_test.go
@@ -57,14 +57,37 @@ func TestBuilder_ClosedSet_RejectsDuplicateModule(t *testing.T) {
 }
 
 // TestBuilder_ClosedSet_HappyPathBijection verifies that an exact bijection
-// (every declared cell provided once, no extras) Builds successfully.
+// (every declared cell provided once, no extras) Builds successfully — and that
+// the closed-set guard (set membership, order-agnostic on the declared set)
+// does not disturb the module Provide order, which stays the With() order.
 func TestBuilder_ClosedSet_HappyPathBijection(t *testing.T) {
 	ctx := context.Background()
 	mA := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
 	mB := &fakeCellModule{id: "auditcore", cell: stubCell("auditcore")}
 
-	app, err := New("auditcore", "configcore").With(mA, mB).Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	var runtimeCells []cell.Cell
+	rtFn := func(cells []cell.Cell) ([]bootstrap.Option, error) {
+		runtimeCells = cells
+		return nil, nil
+	}
+
+	// expectedCellIDs order ("auditcore","configcore") is intentionally the
+	// reverse of the With() order to prove the guard is order-agnostic on the
+	// declared set while Provide order follows With().
+	app, err := New("auditcore", "configcore").With(mA, mB).Build(ctx, minimalSharedDeps(t), rtFn)
 	require.NoError(t, err)
 	require.NotNil(t, app)
 	assert.True(t, mA.called && mB.called, "happy-path bijection must run all module Provides")
+	require.Len(t, runtimeCells, 2)
+	assert.Equal(t, "configcore", runtimeCells[0].ID(), "Provide order follows With(), not the declared-set order")
+	assert.Equal(t, "auditcore", runtimeCells[1].ID())
+}
+
+// TestBuilder_ClosedSet_EmptyAssembly verifies the degenerate bijection: a
+// cell-less assembly (no declared ids, no modules) Builds successfully.
+func TestBuilder_ClosedSet_EmptyAssembly(t *testing.T) {
+	ctx := context.Background()
+	app, err := New().Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.NoError(t, err)
+	require.NotNil(t, app)
 }

--- a/runtime/composition/builder_test.go
+++ b/runtime/composition/builder_test.go
@@ -81,7 +81,7 @@ func TestBuilder_HappyPath(t *testing.T) {
 	}
 
 	shared := minimalSharedDeps(t)
-	app, err := New().With(m1, m2).Build(ctx, shared, rtFn)
+	app, err := New("mod1", "mod2").With(m1, m2).Build(ctx, shared, rtFn)
 	require.NoError(t, err)
 	require.NotNil(t, app)
 
@@ -119,7 +119,7 @@ func TestBuilder_HappyPath_TwoChannelResourceContract(t *testing.T) {
 		mres: []kernellifecycle.ManagedResource{r1},
 	}
 
-	app, err := New().With(m1).Build(ctx, minimalSharedDeps(t),
+	app, err := New("mod1").With(m1).Build(ctx, minimalSharedDeps(t),
 		func([]cell.Cell) ([]bootstrap.Option, error) { return nil, nil })
 	require.NoError(t, err)
 	require.NotNil(t, app)
@@ -145,7 +145,7 @@ func TestBuilder_NilModule_RollsBack(t *testing.T) {
 	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1, r2}}
 
 	shared := minimalSharedDeps(t)
-	_, err := New().With(m1, nil).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
+	_, err := New("mod1").With(m1, nil).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
 		return nil, nil
 	})
 	require.Error(t, err)
@@ -170,7 +170,7 @@ func TestBuilder_ProvideError_RollsBack(t *testing.T) {
 	m2 := &fakeCellModule{id: "mod2", provideErr: errors.New("provide failed")}
 
 	shared := minimalSharedDeps(t)
-	_, err := New().With(m1, m2).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
+	_, err := New("mod1", "mod2").With(m1, m2).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
 		return nil, nil
 	})
 	require.Error(t, err)
@@ -194,7 +194,7 @@ func TestBuilder_NilCell_RollsBack(t *testing.T) {
 	m2 := &fakeCellModule{id: "mod2", cell: nil} // nil cell
 
 	shared := minimalSharedDeps(t)
-	_, err := New().With(m1, m2).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
+	_, err := New("mod1", "mod2").With(m1, m2).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
 		return nil, nil
 	})
 	require.Error(t, err)
@@ -215,7 +215,7 @@ func TestBuilder_RuntimeFnError_RollsBack(t *testing.T) {
 	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1}}
 
 	shared := minimalSharedDeps(t)
-	_, err := New().With(m1).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
+	_, err := New("mod1").With(m1).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
 		return nil, errors.New("runtime fn error")
 	})
 	require.Error(t, err)
@@ -265,7 +265,7 @@ func TestBuilder_MutatedAfterSeal_Rejected(t *testing.T) {
 
 	c1 := stubCell("cell-1")
 	m1 := &fakeCellModule{id: "mod1", cell: c1}
-	_, err := New().With(m1).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
+	_, err := New("mod1").With(m1).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
 		return nil, nil
 	})
 	require.Error(t, err)

--- a/runtime/composition/builder_test.go
+++ b/runtime/composition/builder_test.go
@@ -68,8 +68,8 @@ func (o *orderedMR) Close(_ context.Context) error {
 func TestBuilder_HappyPath(t *testing.T) {
 	ctx := context.Background()
 
-	c1 := stubCell("cell-1")
-	c2 := stubCell("cell-2")
+	c1 := stubCell("mod1")
+	c2 := stubCell("mod2")
 
 	m1 := &fakeCellModule{id: "mod1", cell: c1}
 	m2 := &fakeCellModule{id: "mod2", cell: c2}
@@ -87,8 +87,8 @@ func TestBuilder_HappyPath(t *testing.T) {
 
 	// runtimeFn received cells in module order.
 	require.Len(t, runtimeCells, 2)
-	assert.Equal(t, "cell-1", runtimeCells[0].ID())
-	assert.Equal(t, "cell-2", runtimeCells[1].ID())
+	assert.Equal(t, "mod1", runtimeCells[0].ID())
+	assert.Equal(t, "mod2", runtimeCells[1].ID())
 
 	assert.True(t, m1.called)
 	assert.True(t, m2.called)
@@ -111,7 +111,7 @@ func TestBuilder_HappyPath_TwoChannelResourceContract(t *testing.T) {
 	order := &closedOrder{}
 	r1 := &orderedMR{id: "r1", order: order}
 
-	c1 := stubCell("cell-1")
+	c1 := stubCell("mod1")
 	m1 := &fakeCellModule{
 		id:   "mod1",
 		cell: c1,
@@ -141,7 +141,7 @@ func TestBuilder_NilModule_RollsBack(t *testing.T) {
 	r1 := &orderedMR{id: "r1", order: order}
 	r2 := &orderedMR{id: "r2", order: order}
 
-	c1 := stubCell("cell-1")
+	c1 := stubCell("mod1")
 	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1, r2}}
 
 	shared := minimalSharedDeps(t)
@@ -165,7 +165,7 @@ func TestBuilder_ProvideError_RollsBack(t *testing.T) {
 	r1 := &orderedMR{id: "r1", order: order}
 	r2 := &orderedMR{id: "r2", order: order}
 
-	c1 := stubCell("cell-1")
+	c1 := stubCell("mod1")
 	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1, r2}}
 	m2 := &fakeCellModule{id: "mod2", provideErr: errors.New("provide failed")}
 
@@ -189,7 +189,7 @@ func TestBuilder_NilCell_RollsBack(t *testing.T) {
 	order := &closedOrder{}
 	r1 := &orderedMR{id: "r1", order: order}
 
-	c1 := stubCell("cell-1")
+	c1 := stubCell("mod1")
 	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1}}
 	m2 := &fakeCellModule{id: "mod2", cell: nil} // nil cell
 
@@ -211,7 +211,7 @@ func TestBuilder_RuntimeFnError_RollsBack(t *testing.T) {
 	order := &closedOrder{}
 	r1 := &orderedMR{id: "r1", order: order}
 
-	c1 := stubCell("cell-1")
+	c1 := stubCell("mod1")
 	m1 := &fakeCellModule{id: "mod1", cell: c1, mres: []kernellifecycle.ManagedResource{r1}}
 
 	shared := minimalSharedDeps(t)
@@ -263,7 +263,7 @@ func TestBuilder_MutatedAfterSeal_Rejected(t *testing.T) {
 	shared.JWTVerifier = nil
 	require.True(t, shared.valid, "precondition: marker still set after mutation")
 
-	c1 := stubCell("cell-1")
+	c1 := stubCell("mod1")
 	m1 := &fakeCellModule{id: "mod1", cell: c1}
 	_, err := New("mod1").With(m1).Build(ctx, shared, func([]cell.Cell) ([]bootstrap.Option, error) {
 		return nil, nil
@@ -285,8 +285,8 @@ func TestBuilder_NilRuntimeOptsFn_Rejected(t *testing.T) {
 
 // TestBuilder_With_Accumulates verifies that With() calls accumulate modules.
 func TestBuilder_With_Accumulates(t *testing.T) {
-	c1 := stubCell("c1")
-	c2 := stubCell("c2")
+	c1 := stubCell("m1")
+	c2 := stubCell("m2")
 	m1 := &fakeCellModule{id: "m1", cell: c1}
 	m2 := &fakeCellModule{id: "m2", cell: c2}
 

--- a/runtime/devtools/catalog/assembly_field_coverage_test.go
+++ b/runtime/devtools/catalog/assembly_field_coverage_test.go
@@ -25,7 +25,7 @@ func TestAssemblySpec_OwnerAndMaxConsistencyLevelRoundTrip(t *testing.T) {
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"mainbundle": {
 				ID:                  "mainbundle",
-				Cells:               []string{"alpha"},
+				Cells:               metadata.CellRefs("alpha"),
 				Owner:               metadata.OwnerMeta{Team: "platform", Role: "bundle-owner"},
 				MaxConsistencyLevel: "L2",
 				Build: metadata.BuildMeta{

--- a/runtime/devtools/catalog/build.go
+++ b/runtime/devtools/catalog/build.go
@@ -317,7 +317,7 @@ func buildJourneyEntity(j *metadata.JourneyMeta, inc IncludeOptions) Entity {
 // buildAssemblyEntity converts AssemblyMeta to an Entity.
 func buildAssemblyEntity(a *metadata.AssemblyMeta, inc IncludeOptions) Entity {
 	spec := AssemblySpec{
-		Cells:               a.Cells,
+		Cells:               metadata.CellIDs(a.Cells),
 		Owner:               CellSpecOwner{Team: a.Owner.Team, Role: a.Owner.Role},
 		MaxConsistencyLevel: a.MaxConsistencyLevel,
 		Build: AssemblySpecBuild{
@@ -329,8 +329,8 @@ func buildAssemblyEntity(a *metadata.AssemblyMeta, inc IncludeOptions) Entity {
 
 	var rels []Relation
 	if inc.Relations {
-		for _, cellID := range a.Cells {
-			rels = append(rels, Relation{Type: "contains", TargetRef: "cell/" + cellID})
+		for _, ref := range a.Cells {
+			rels = append(rels, Relation{Type: "contains", TargetRef: "cell/" + ref.ID})
 		}
 		sortRelations(rels)
 	}

--- a/runtime/devtools/catalog/build_test.go
+++ b/runtime/devtools/catalog/build_test.go
@@ -114,7 +114,7 @@ func fullPM() *metadata.ProjectMeta {
 	}
 	pm.Assemblies["mainbundle"] = &metadata.AssemblyMeta{
 		ID:    "mainbundle",
-		Cells: []string{"accesscore", "auditcore"},
+		Cells: metadata.CellRefs("accesscore", "auditcore"),
 		Build: metadata.BuildMeta{Entrypoint: "cmd/server/main.go", Binary: "gocell-server"},
 	}
 	pm.Actors = []metadata.ActorMeta{

--- a/tools/archtest/assembly_invariants_test.go
+++ b/tools/archtest/assembly_invariants_test.go
@@ -7,6 +7,7 @@ package archtest
 //   - INVARIANT: ASSEMBLY-CELLMODULE-TYPE-04
 //   - INVARIANT: ASSEMBLY-SNAPSHOTS-LOCKED-01
 //   - INVARIANT: ASSEMBLYREF-METHOD-SET-01
+//   - INVARIANT: ASSEMBLY-CROSS-MODULE-IMPORT-01
 //
 // assembly_invariants_test.go — consolidated AST guards for assembly-related invariants.
 //
@@ -24,6 +25,19 @@ package archtest
 //                                       cmd/<id>/ and examples/<id>/ path forms).
 //   ASSEMBLY-SNAPSHOTS-LOCKED-01        writes to *.snapshots in kernel/assembly/ must be inside mu.Lock()
 //   ASSEMBLYREF-METHOD-SET-01           auth.AssemblyRef interface must have exactly 3 methods
+//   ASSEMBLY-CROSS-MODULE-IMPORT-01     the cellmodules import-path interpolation ("/cellmodules/" string
+//                                       literal) in kernel/assembly production code must appear at exactly
+//                                       one site: the body of generator.go's cellModuleImportPath funnel.
+//                                       That funnel resolves the per-cell module prefix from
+//                                       AssemblyCellRef.Module (#1086), so a cross-module assembly's
+//                                       generated modules_gen.go imports are provably ⊆ the assembly.yaml
+//                                       declared module set. Downstream callsite-uniqueness (this archtest)
+//                                       + upstream codegen funnel (modules_gen.go DO NOT EDIT +
+//                                       `gocell verify codegen` regenerate-diff byte-lock) = closed Hard
+//                                       funnel. AI-robust: Hard ("codegen funnel + golden" +
+//                                       "single sanctioned holder" templates). A second inline
+//                                       module+"/cellmodules/"+id construction anywhere in kernel/assembly
+//                                       fails this archtest immediately.
 
 import (
 	"bufio"
@@ -1544,4 +1558,80 @@ func formatExpr(e ast.Expr) string {
 	// signature that uses an expression shape this helper does not yet
 	// handle, prompting a same-PR extension rather than silent acceptance.
 	panic("assemblyref_method_set_test: unsupported ast.Expr shape; extend formatExpr when AssemblyRef gains a new signature kind")
+}
+
+// ---- ASSEMBLY-CROSS-MODULE-IMPORT-01 ----
+
+const ruleAssemblyCrossModuleImport01 = "ASSEMBLY-CROSS-MODULE-IMPORT-01"
+
+// cellModulesPathSeg is the import-path segment that every cellmodules import
+// must contain. It is the funnel anchor: the only sanctioned site that
+// interpolates it is generator.go's cellModuleImportPath.
+const cellModulesPathSeg = "/cellmodules/"
+
+// TestAssemblyCrossModuleImportFunnel enforces ASSEMBLY-CROSS-MODULE-IMPORT-01:
+// within kernel/assembly production code, the "/cellmodules/" import-path
+// string literal must appear at exactly one site — the body of the
+// cellModuleImportPath funnel function. The funnel resolves the per-cell module
+// prefix from AssemblyCellRef.Module (#1086); locking it as the sole
+// construction site means no second code path can fabricate a cellmodules
+// import that bypasses the per-cell module funnel. Combined with the upstream
+// codegen golden (modules_gen.go DO NOT EDIT + regenerate-diff), generated
+// cross-module imports are provably bounded by the assembly.yaml declared set.
+func TestAssemblyCrossModuleImportFunnel(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+
+	scope := DirsScope(root, []string{"kernel/assembly"}, MatchRels(func(rel string) bool {
+		return strings.HasPrefix(filepath.ToSlash(rel), "kernel/assembly/") &&
+			strings.HasSuffix(rel, ".go") && !strings.HasSuffix(rel, "_test.go")
+	}))
+
+	var funnelStart, funnelEnd token.Pos
+	type litSite struct {
+		rel  string
+		line int
+		pos  token.Pos
+	}
+	var sites []litSite
+
+	Run(t, AST(scope), func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			// Record the cellModuleImportPath funnel range.
+			EachInChildren[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+				if fn.Name != nil && fn.Name.Name == "cellModuleImportPath" {
+					funnelStart, funnelEnd = fn.Pos(), fn.End()
+				}
+			})
+			// Record every "/cellmodules/" string literal.
+			EachInSubtree[ast.BasicLit](file, func(lit *ast.BasicLit) {
+				if lit.Kind != token.STRING {
+					return
+				}
+				unq, err := strconv.Unquote(lit.Value)
+				if err != nil || unq != cellModulesPathSeg {
+					return
+				}
+				sites = append(sites, litSite{rel: rel, line: p.Fset.Position(lit.Pos()).Line, pos: lit.Pos()})
+			})
+		}
+		return nil
+	})
+
+	require.NotZero(t, funnelStart,
+		"%s: cellModuleImportPath funnel not found in kernel/assembly — the single sanctioned "+
+			"cellmodules import-path construction site must exist", ruleAssemblyCrossModuleImport01)
+	require.NotEmpty(t, sites,
+		"%s: no %q literal found — the funnel must actually construct the import path "+
+			"(guards against a vacuous pass)", ruleAssemblyCrossModuleImport01, cellModulesPathSeg)
+
+	for _, s := range sites {
+		if s.pos < funnelStart || s.pos >= funnelEnd {
+			t.Errorf("%s: %s:%d constructs a cellmodules import path (%q) outside the "+
+				"cellModuleImportPath funnel — route per-cell module resolution through that "+
+				"single site so cross-module imports stay bounded by assembly.yaml",
+				ruleAssemblyCrossModuleImport01, s.rel, s.line, cellModulesPathSeg)
+		}
+	}
 }

--- a/tools/archtest/assembly_invariants_test.go
+++ b/tools/archtest/assembly_invariants_test.go
@@ -1578,6 +1578,19 @@ const cellModulesPathSeg = "/cellmodules/"
 // import that bypasses the per-cell module funnel. Combined with the upstream
 // codegen golden (modules_gen.go DO NOT EDIT + regenerate-diff), generated
 // cross-module imports are provably bounded by the assembly.yaml declared set.
+//
+// AI-robust: Hard downstream (callsite/form uniqueness of the "/cellmodules/"
+// BasicLit) + Hard upstream (codegen regenerate-diff golden).
+//
+// Known blind spot (ai-robust.md §载体决策原则 强制盲区自检): the scan keys on the
+// exact `"/cellmodules/"` STRING BasicLit. A construction that assembles the
+// segment without that literal — e.g. strings.Join([]string{mod, "cellmodules",
+// id}, "/") or a split fmt.Sprintf format — is not detected. This is acceptable:
+// the upstream regenerate-diff golden byte-locks the generated output regardless
+// of how the funnel builds the string, so a divergent construction cannot reach
+// a committed modules_gen.go undetected. No fixture is added (the upstream lock
+// is the real guard); documented so a contributor does not mistake the literal
+// scan for total coverage.
 func TestAssemblyCrossModuleImportFunnel(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)

--- a/tools/archtest/bootstrap_autowire_collector_funnel_test.go
+++ b/tools/archtest/bootstrap_autowire_collector_funnel_test.go
@@ -167,7 +167,7 @@ func TestBootstrapAutoWireCollectorFunnel01(t *testing.T) {
 
 	observed := map[string]bool{}
 
-	diags := RunTypedProduction(t, TypedOpts{}, func(p *Pass) []Diagnostic {
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() || p.Pkg.Path() != autoWireBootstrapPkgPath {
 			return nil
 		}
@@ -226,8 +226,7 @@ func TestBootstrapAutoWireCollectorFunnel01_PlantedBypass(t *testing.T) {
 		{collectorsPkgPath, "NewBeta"}:  "collectors.NewBeta",
 	}
 
-	diags := RunTypedFixture(t, FixtureOpts{Tests: false},
-		[]string{fixturePattern},
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{fixturePattern}),
 		func(p *Pass) []Diagnostic {
 			if !p.Typed() || p.Pkg.Path() != fixturePkgPath {
 				return nil

--- a/tools/archtest/fixture_cellid_typed_builder_test.go
+++ b/tools/archtest/fixture_cellid_typed_builder_test.go
@@ -181,7 +181,10 @@ var cellIDFieldPositions = []cellIDFieldPosition{
 	{"EndpointsMeta", "Provider", false},
 	{"EndpointsMeta", "Readers", true},
 	{"JourneyMeta", "Cells", true},
-	{"AssemblyMeta", "Cells", true},
+	// AssemblyMeta.Cells is []AssemblyCellRef (#1086): the cell-id moved from
+	// the slice element to AssemblyCellRef.ID, so the enforced position is the
+	// ID field of each AssemblyCellRef struct literal (not the slice element).
+	{"AssemblyCellRef", "ID", false},
 	// CellWireSummary.CellID: the derived wire-catalog struct in derived.go whose
 	// CellID field carries cell-id semantics. Fixtures constructing CellWireSummary
 	// live in runtime/ (outside A1's current kernel/ scope) and will be enforced
@@ -220,6 +223,11 @@ func TestFixtureCellIDTypedBuilder(t *testing.T) {
 		// cellIDFieldPositions for forward-compatible enforcement in runtime/ test
 		// fixtures (tracked by #1201), not to gate this production constructor.
 		"kernel/metadata/derived.go": {},
+		// types.go holds metadata.CellRefs — the single sanctioned constructor that
+		// embeds AssemblyCellRef{ID: <runtime param>} (cell development in an
+		// independent repository, #1086). Same rationale as derived.go: production
+		// construction from a runtime value, not a fixture literal.
+		"kernel/metadata/types.go": {},
 	}
 
 	violations := scanCellIDFixtureViolations(t, allowSelfFile, fixtureCellIDCarveOuts)

--- a/tools/archtest/internal/fixturecellidnegfixture/bad_assembly_cells.go
+++ b/tools/archtest/internal/fixturecellidnegfixture/bad_assembly_cells.go
@@ -4,10 +4,13 @@ package fixturecellidnegfixture
 
 import "github.com/ghbvf/gocell/kernel/metadata"
 
-// BadAssemblyCells uses bare string literals as elements of
-// AssemblyMeta.Cells — each element must be flagged by A1 (slice
-// element position).
+// BadAssemblyCells uses bare string literals at the AssemblyCellRef.ID
+// position — each must be flagged by A1 (struct-field position; the cell-id
+// moved from the slice element to AssemblyCellRef.ID in #1086).
 var BadAssemblyCells = &metadata.AssemblyMeta{
-	ID:    "myassembly",
-	Cells: []string{"bareliteralcellone", "bareliteralcelltwo"},
+	ID: "myassembly",
+	Cells: []metadata.AssemblyCellRef{
+		{ID: "bareliteralcellone"},
+		{ID: "bareliteralcelltwo"},
+	},
 }

--- a/tools/generatedverify/generatedverify_test.go
+++ b/tools/generatedverify/generatedverify_test.go
@@ -432,7 +432,7 @@ func (PlaceholderModule) ID() string { return "placeholder" }
 	// Update the fixture assembly to include the placeholder cell.
 	project.Assemblies["fixture"] = &metadata.AssemblyMeta{
 		ID:    "fixture",
-		Cells: []string{metadatatest.NewCellID("placeholder")},
+		Cells: metadata.CellRefs(metadatatest.NewCellID("placeholder")),
 		Build: metadata.BuildMeta{
 			Entrypoint: "cmd/fixture/main.go",
 			Binary:     "bin/fixture",
@@ -596,7 +596,7 @@ func runFixture(context.Context, string, []string) error {
 	}
 	project.Assemblies["fixture"] = &metadata.AssemblyMeta{
 		ID:    "fixture",
-		Cells: []string{},
+		Cells: metadata.CellRefs(),
 		Build: metadata.BuildMeta{
 			Entrypoint: "cmd/fixture/main.go",
 			Binary:     "bin/fixture",


### PR DESCRIPTION
## Summary

**M5 (#1086)** — `assembly.yaml` `cells[]` now accepts a scalar-or-object **union**: a bare cell-id string (same-module shorthand) or `{id, module}` for a cell developed in an independent Go module. **No `version:` field** — `go.mod`+`go.sum` is the single version source (aligns with fx / controller-runtime / Backstage; see #1086 OSS 对标). `AssemblyMeta.Cells` is now `[]AssemblyCellRef`; codegen resolves each cell's `cellmodules` import prefix per-cell from `AssemblyCellRef.Module` (empty → the assembly's own module) through the single `cellModuleImportPath` funnel. Cross-module composition requires `build.compositionAPI: true`.

**M12a (#1093, bundled per #1093 裁决)** — `composition.New(expectedCellIDs...)` seals the assembly's cell-id closed set; `Build` enforces a **bijection** (out-of-set / missing / duplicate → fail-fast) before any module `Provide`. Out-of-set cells are **hard-rejected, not degraded to `_runtime`** (mirrors K8s `runtime.Scheme`). Replaces the corebundle-only hand-written `assertModuleIDsMatch` — every assembly now inherits the framework guard.

Refs: `#1086`, `#1093` (M12a) · epic `#1081` · depends on closed `#1082` (M1) / `#1083` (M2)
ref: uber-go/fx · kubernetes-sigs/controller-runtime · kubernetes/apimachinery scheme.go

## Key decisions (ADR `docs/architecture/202606030230-adr-assembly-cross-module-composition.md`)

- **Drop `version:`** — pull/lockfile semantics belong to go.mod, not a weaker YAML (no second source of truth).
- **`module ∈ go.mod` enforced by the Go compiler**, not a governance rule: an undeclared module makes the generated `import "<module>/cellmodules/<id>"` unbuildable (`go build` fails). A Medium governance rule would duplicate a Hard compiler check and force `golang.org/x/mod` into `kernel/` (layering violation). → **kernel/ touches zero x/mod.**
- **Workspace-first** — external cell metadata is read via the existing M1 manifest locator. `go list -json` dependency-cache reading (Operator-SDK mode) is deferred (no in-repo consumer until M11).

## Enforcement / AI-robust

| Carrier | Mechanism | Rating |
|---|---|---|
| module resolvability | `go build` of generated cellmodules import | **Hard** (compiler) |
| generated import ⊆ assembly.yaml | regenerate-diff byte-lock (modules_gen.go DO NOT EDIT) | **Hard** (codegen golden) |
| no rogue cellmodules import construction | archtest `ASSEMBLY-CROSS-MODULE-IMPORT-01` (`/cellmodules/` callsite-uniqueness ⊆ funnel) | **Hard** down + up |
| cellID closed set at compose time | `composition.Builder.Build` bijection guard | **Medium** (runtime invariant; cell IDs are runtime strings → Hard not reachable, same ceiling as SAGA-CONSTRUCTOR-NIL-GUARD) |
| AssemblyCellRef.ID typed-builder | `FIXTURE-CELLID-TYPED-BUILDER-01/A1` field position `AssemblyMeta.Cells`→`AssemblyCellRef.ID` (+ types.go allowlist; ADR §1 table synced) | unchanged |

## Deferred (backlog — not silent)

- Operator-SDK `go list -json` module-cache cell.yaml read → new backlog issue (gated on M11 #1092).
- scaffold `--module` flag (cross-module assembly scaffolding) → backlog.
- M12b (metric-label closed-set + `CELL-ID-CLOSED-SET-01`) → remains in #1093.
- CellMeta source-module tracking (assembly.yaml `module` ↔ discovered module cross-check) → backlog.

## Incidental fix

`tools/archtest/bootstrap_autowire_collector_funnel_test.go` referenced the **retired** `RunTypedProduction`/`RunTypedFixture` symbols on origin/develop (pre-existing compile break of the archtest test binary, unrelated to this PR but blocking local verification). Fixed to the documented `Run(t, Production/Fixture(...))` form.

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./...` (full suite, exit 0)
- [x] new behavior tests: `AssemblyCellRef.UnmarshalYAML` union + rejections; generator cross-module import path + compositionAPI guard + `moduleOf`/`cellModuleImportPath`; Builder closed-set bijection (out-of-set / missing / duplicate / happy) — written RED-first.
- [x] `go test ./tools/archtest/` — `ASSEMBLY-CROSS-MODULE-IMPORT-01` + `FIXTURE-CELLID-TYPED-BUILDER-01` green.
- [x] `gocell generate assembly --all` → **no generated diff** (same-module byte-identical; regenerate-diff Hard lock holds).
- [x] `gocell validate` → 0 errors (2 pre-existing unrelated journey warnings).
- [x] `golangci-lint run` on all changed packages → **0 issues** (full-repo run times out on local wall-clock; CI authoritative).

Implementation matrix (metadata schema, not a cross-cell contract): `assembly.schema.json` + `AssemblyMeta`/`AssemblyCellRef` Go type changed together; all `asm.Cells` consumers (generator, assembly_derive, governance REF-08/TOPO-06/09, devtools catalog, cmd/gocell check) migrated to `.ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)