### PR TITLE
feat(projection): HTTP rebuild 控制面端点 — framework-mounted RouteGroup [W10 PR-04e] [#1370]

### DIFF
--- a/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+++ b/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
@@ -681,8 +681,11 @@ the host-cell/`DEAD-CONTRACT-01` complication the original framing introduced.
   helper that the lag readyz probe (`checkLag`) also calls — so the wire snapshot
   can never diverge from the probe (single-source, type-system Hard). A degraded
   snapshot read after admission is logged but never downgrades the 202 (the
-  rebuild was already admitted). `projection.RebuildController` is the narrow
-  consumer interface the bootstrap handler holds (`*Coordinator` satisfies it).
+  rebuild was already admitted). The bootstrap handler consumes the Coordinator
+  through a narrow consumer-local interface (`runtime/bootstrap.rebuildController`
+  = `Rebuild` + `Snapshot`; `*Coordinator` satisfies it) — declared at the
+  consumer per Go idiom, keeping kernel/projection's exported surface free of a
+  bootstrap-only seam.
 
 ### Deferred (scope carve-out)
 

--- a/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
+++ b/docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md
@@ -348,11 +348,14 @@ when the budget is exceeded, rather than silently dropping the probe.
 
 ### Rebuild control-plane endpoint (forward contract)
 
-The rebuild trigger is a per-cell HTTP endpoint. Its `contract.yaml` + handler
-land in **PR-04** (cellgen `kind: projection` derivation, #1176); PR-03 ships
-only the kernel/runtime harness — there is **no host cell or internal listener**
-to mount it on until cellgen wiring lands. A platform-level `active` contract
-with no cell impl would trip `DEAD-CONTRACT-01`.
+The rebuild trigger is a framework control-plane HTTP endpoint. PR-03 freezes its
+forward contract (below) and ships only the kernel/runtime harness with no HTTP
+surface. **The original framing of this endpoint as a per-cell `contract.yaml` +
+cellgen handler (with a host cell to satisfy `DEAD-CONTRACT-01`) was superseded by
+PR-04e (#1370)**: it is mounted by bootstrap itself as a framework-owned
+RouteGroup — the same pattern as `/healthz`·`/readyz`·`/metrics` — so it has **no
+`contract.yaml`, no host cell, and never reaches `DEAD-CONTRACT-01`**. See
+§Amendment 2026-06-03.
 
 **PR-03 freezes the programmatic trigger surface** and forward contract for PR-04:
 
@@ -372,10 +375,12 @@ with no cell impl would trip `DEAD-CONTRACT-01`.
   CAS `PhaseLive→PhaseStopped`) + `Coordinator.Close(ctx)` for graceful drain.
   The snapshot is computed by the readyz probe / metrics path delivered in PR-03.
 
-**PR-04 authors the HTTP wrapper**: the `POST /internal/v1/<cell>/projection/
-<name>/rebuild` contract.yaml + per-cell handler (cellgen output) calling
-`Coordinator.Rebuild`, with the **unchanged** auth model / network boundary /
-202·409·404 status semantics frozen above.
+**PR-04e (#1370) authors the HTTP endpoint** as a framework-owned RouteGroup
+(bootstrap-mounted via `WithProjectionRebuildEndpoint`, **not** cellgen output)
+calling `Coordinator.Rebuild`, with the **unchanged** auth model / network
+boundary / 202·409·404 status semantics frozen above. Mechanism detail
+(framework-mount, the `Coordinator.Snapshot` accessor, and the deferred
+operator-credential admin surface) in §Amendment 2026-06-03.
 
 **Threat-matrix re-evaluation.** No cell flips: row 3 (rebuild-period read
 consistency) is discharged by `Phase()` + readyz, **both delivered in PR-03** as
@@ -629,3 +634,73 @@ contracts declare `triggers:`. This is harmless today because the parser does
 not run `jsonschema.Validate`. If a broad parse-time schema validator is ever
 introduced (an independent **Medium** DX improvement, orthogonal to this Hard
 gate), `triggers` must be added to the schema first. Tracked at gh #1486.
+
+## Amendment 2026-06-03 (PR-04e #1370 — HTTP rebuild endpoint landed; framework-mount, not cellgen)
+
+The rebuild control-plane endpoint frozen in §5 landed. Its **mechanism** changed
+from the original "per-cell `contract.yaml` + cellgen handler + host cell to
+satisfy `DEAD-CONTRACT-01`" framing to a **framework-owned RouteGroup mounted by
+bootstrap** (the §5 forward-contract text is rewritten in place to match). The
+**auth model, network boundary, path, and 202·409·404 status semantics are
+unchanged** — only the carrier moved.
+
+### Why framework-mount (open-source benchmark + GoCell consistency)
+
+Across mature CQRS/event-sourcing systems the dominant pattern is a **generic
+framework/server-provided control plane keyed by projection name**, not a
+per-application endpoint: EventStoreDB `POST /projection/{name}/command/reset`
+(server-mounted admin HTTP, name is a path param), Axon Server's generic
+processor-reset primitives, Marten's `projections rebuild` CLI by name. GoCell's
+own health endpoints (`/healthz`·`/readyz`·`/metrics`) already use exactly this
+shape: `contractbuild.NewFrameworkHTTP` builds an `http.framework.*` ContractSpec
+and bootstrap mounts a framework-owned RouteGroup (`runtime/bootstrap/health.go`),
+with **no `contract.yaml`, no codegen, no host cell, and no `DEAD-CONTRACT-01`
+participation** (that invariant scans `contracts/*.yaml`, of which there is none
+here). The rebuild endpoint is the same kind of framework control-plane surface,
+so it reuses that pattern rather than inventing a per-cell contract — eliminating
+the host-cell/`DEAD-CONTRACT-01` complication the original framing introduced.
+
+### What landed
+
+- **Endpoint**: `POST /internal/v1/{cell}/projection/{name}/rebuild`, mounted on
+  the `cell.InternalListener` by `phase5CollectRouteGroups`, opt-in via
+  `bootstrap.WithProjectionRebuildEndpoint(allowedCallers...)`. phase0
+  (`validateProjectionRebuildEndpoint`) fails fast when opted in without an
+  InternalListener. The handler dispatches by `{cell}/{name}` to
+  `b.projectionCoordinators` (the phase6 drain registry, read lazily at request
+  time — phase6 runs after phase5 mount but before serving).
+- **Auth** (unchanged from §5): `/internal/` + service-token listener chain +
+  caller-cell allowlist. The allowlist rides on `ContractSpec.Clients` via the
+  extended `contractbuild.NewFrameworkHTTP(id, method, path, clients...)`; an
+  `/internal/` path REQUIRES non-empty `Clients` (`ContractSpec.validateHTTP`
+  fail-closed — every internal API names its callers), so `auth.Mount`
+  auto-injects `RequireCallerCell`. 404 uses the new `errcode.ErrProjectionNotFound`.
+- **Kernel surface**: `Coordinator.Snapshot(ctx) (Snapshot, error)` returns the
+  `{phase, pendingEvents, replayLagSeconds}` 202 body. Phase is always populated
+  (in-memory); pending/lag go through the shared **pure** `computeLagPending`
+  helper that the lag readyz probe (`checkLag`) also calls — so the wire snapshot
+  can never diverge from the probe (single-source, type-system Hard). A degraded
+  snapshot read after admission is logged but never downgrades the 202 (the
+  rebuild was already admitted). `projection.RebuildController` is the narrow
+  consumer interface the bootstrap handler holds (`*Coordinator` satisfies it).
+
+### Deferred (scope carve-out)
+
+A purer **operator-credential admin surface** (EventStoreDB-style: a dedicated
+network-isolated `cell.AdminListener` + an operator-credential `ListenerAuth`,
+off `/internal/`) is a cross-cutting auth foundation beyond this endpoint — it
+needs a new sealed listener class + a new `ListenerAuth` implementer (operator
+basic-auth exists only as the per-cell setup/admin middleware today, FMT-28
+restricted). Tracked at **gh #1505**; rebuild migrates to it if/when it lands.
+Until then `/internal/` + caller-cell allowlist (GoCell's existing structural
+invariant for internal endpoints) is the correct, no-new-foundation carrier.
+
+### Threat-matrix re-evaluation (ai-robust ADR-amendment requirement)
+
+No row flips to ⚠️/❌. Row 3 (rebuild-period read consistency) was already
+discharged by `Phase()` + readyz in PR-03; the HTTP trigger is a convenience
+surface, not a threat-discharge mechanism (a rebuild is equally triggerable via
+`Coordinator.Rebuild`). The discharge mechanism is unchanged by moving the trigger
+from a hypothetical cellgen handler to a framework-mounted RouteGroup. Auth is
+unchanged (service-token + caller-cell allowlist), so the endpoint's exposure
+surface is identical to the §5 freeze. No new threat row is introduced.

--- a/examples/todoorder/README.md
+++ b/examples/todoorder/README.md
@@ -158,10 +158,14 @@ The loop has four parts, all inside `ordercell`:
    natural next step tracked in #1482, out of scope for this single-stream
    harness reference.
 3. **Query** — `GET /api/v1/orders/projection/summary` reads the projection.
-4. **Rebuild** — rebuild is framework-owned (`projection.Coordinator.Rebuild`,
-   programmatic); no HTTP endpoint is exposed in v1. The Coordinator drives
-   `onReset + replay` automatically. A future framework HTTP endpoint is tracked
-   in #1370.
+4. **Rebuild** — rebuild is framework-owned (`projection.Coordinator.Rebuild`),
+   exposed as the internal control-plane endpoint `POST
+   /internal/v1/ordercell/projection/order_status/rebuild` (mounted by bootstrap
+   on the internal listener via `WithProjectionRebuildEndpoint("controlplane")`).
+   It admits a background rebuild that drives `onReset + replay` automatically:
+   `202` admitted (body carries `{phase, pendingEvents, replayLagSeconds}`), `409`
+   if a rebuild is already running, `404` for an unknown projection, `403` for a
+   caller cell outside the allowlist.
 
 > **Security note (demo simplification)**: this demo's `Order` has no
 > `ownerID`; `projection/summary` exposes all `orderIds` and `orderconfirm`
@@ -188,9 +192,13 @@ curl -H "Authorization: Bearer $TODOORDER_TOKEN" \
   http://localhost:8082/api/v1/orders/projection/summary
 # {"data":{"statuses":[{"status":"confirmed","count":1,"orderIds":["ord-..."]}],"totalOrders":1}}
 
-# Rebuild is now framework-owned (projection.Coordinator.Rebuild, programmatic).
-# No HTTP rebuild endpoint is exposed in v1; the harness drives onReset+replay
-# automatically. A backlog item tracks a future /internal/v1/.../rebuild endpoint.
+# Rebuild the projection read model via the internal control-plane endpoint
+# (internal listener :9082, framework-owned). The Coordinator drives onReset+replay.
+#   POST /internal/v1/ordercell/projection/order_status/rebuild
+#   → 202 admitted {phase,pendingEvents,replayLagSeconds} / 409 already running /
+#     404 unknown projection / 403 caller cell not in allowlist.
+# Auth: HMAC service token (ts:nonce:controlplane:mac over GOCELL_TODOORDER_SERVICE_SECRET),
+# callerCell=controlplane — not the JWT above; the demo ships no service-token generator.
 ```
 
 > **Demo note**: the orderprojection slice is the canonical L3 CQRS harness reference:

--- a/examples/todoorder/cells/ordercell/slices/orderprojection/handler.go
+++ b/examples/todoorder/cells/ordercell/slices/orderprojection/handler.go
@@ -2,8 +2,9 @@
 // (L3 CQRS harness reference): reg.RegisterProjection drives HandleOrderCreated
 // (apply) and ResetOrderStatus (onReset) via the framework projection.Coordinator.
 // This slice serves the summary query endpoint on the PrimaryListener (/api/v1).
-// Rebuild is now framework-owned (Coordinator.Rebuild, programmatic — no HTTP
-// rebuild endpoint); the separate orderprojectionrebuild slice has been removed.
+// Rebuild is framework-owned (Coordinator.Rebuild), triggerable via the internal
+// control-plane endpoint POST /internal/v1/{cell}/projection/{name}/rebuild; the
+// separate orderprojectionrebuild slice has been removed.
 package orderprojection
 
 import (

--- a/examples/todoorder/journeys/J-orderprojection.yaml
+++ b/examples/todoorder/journeys/J-orderprojection.yaml
@@ -20,5 +20,5 @@ passCriteria:
     mode: manual
   - text: "GET /api/v1/orders/projection/summary reflects the created order in the status-grouped read model after L3 async consumption (eventual; demo mode delivers in-process best-effort via the framework projection.Coordinator)"
     mode: manual
-  - text: "Framework-owned rebuild (Coordinator.Rebuild, programmatic — no HTTP endpoint in v1) calls ResetOrderStatus then replays event.order-created.v1 from MemReplaySource to reconstruct a byte-identical projection snapshot (rebuild idempotence)"
+  - text: "Framework-owned rebuild (Coordinator.Rebuild, triggerable via the internal control-plane endpoint POST /internal/v1/ordercell/projection/order_status/rebuild — caller cell controlplane) calls ResetOrderStatus then replays event.order-created.v1 from MemReplaySource to reconstruct a byte-identical projection snapshot (rebuild idempotence)"
     mode: manual

--- a/examples/todoorder/run.go
+++ b/examples/todoorder/run.go
@@ -154,6 +154,12 @@ func runTodoorder(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 		bootstrap.WithProjectionTxRunner(demoTxRunner{}),
 		bootstrap.WithProjectionReplaySource(projReplay),
 		bootstrap.WithProjectionCursor(projCursor),
+		// Framework projection rebuild control-plane endpoint
+		// (POST /internal/v1/{cell}/projection/{name}/rebuild) on the internal
+		// listener. "controlplane" is the demo caller-cell allowlist; an ops tool
+		// presents a service token with callerCell=controlplane to trigger a
+		// rebuild of ordercell's order_status projection.
+		bootstrap.WithProjectionRebuildEndpoint("controlplane"),
 	)
 
 	logger.Info("todoorder: starting on :8082; protected routes require an RS256 bearer token")

--- a/kernel/projection/metrics_test.go
+++ b/kernel/projection/metrics_test.go
@@ -331,6 +331,26 @@ func (v *projRecordingGaugeVec) value(l kernelmetrics.Labels) float64 {
 	return v.vals[projLabelsKey(l)]
 }
 
+// wasSet reports whether Set was ever called for the given label series —
+// distinguishing "never written" from "written to 0", which value() cannot.
+func (v *projRecordingGaugeVec) wasSet(l kernelmetrics.Labels) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	_, ok := v.vals[projLabelsKey(l)]
+	return ok
+}
+
+// gaugeWasSet reports whether the named gauge's label series has had Set called.
+func (p *projRecordingProvider) gaugeWasSet(name string, l kernelmetrics.Labels) bool {
+	p.mu.Lock()
+	v, ok := p.gauges[name]
+	p.mu.Unlock()
+	if !ok {
+		return false
+	}
+	return v.wasSet(l)
+}
+
 type projRecordingGauge struct {
 	vec *projRecordingGaugeVec
 	key string

--- a/kernel/projection/probe.go
+++ b/kernel/projection/probe.go
@@ -71,47 +71,77 @@ func (c *Coordinator) checkStoreReady(ctx context.Context) error {
 	return nil
 }
 
-// checkLag is the operational-health probe check. It computes pending events
-// and lag on demand (no background ticker).
+// computeLagPending is the single-source pending-events / replay-lag computation
+// shared by the lag readyz probe (checkLag) and the rebuild control-plane
+// snapshot (Coordinator.Snapshot). It is PURE — no metric side-effects — so the
+// two consumers cannot diverge: checkLag adds the gauge writes + threshold
+// verdict, Snapshot reads the values for the wire response.
 //
-// F13: if pending < 0 (checkpoint > head anomaly), log a warning and treat as
-// healthy (set lag gauge to 0 — do NOT write a negative gauge).
-func (c *Coordinator) checkLag(ctx context.Context) error {
+// It reads the replay head and stored checkpoint and derives:
+//   - pending: head − checkpoint, clamped to ≥ 0. A checkpoint > head anomaly
+//     (negative raw difference, F13) yields pending=0 (treated as caught up),
+//     mirroring the lag probe's "no negative gauge" rule.
+//   - lagSecs: 0 when there are no pending events, or when nothing has been
+//     applied yet (lastApplied == 0 — cold start / fresh rebuild). Otherwise it
+//     is the wall-clock time since the last applied event's domain OccurredAt.
+//   - lagApplicable: false when pending == 0 OR lastApplied == 0. checkLag uses
+//     it to decide whether to WRITE the lag gauge — under startup grace
+//     (pending > 0 but nothing applied) the gauge is deliberately left untouched
+//     so an idle cold start does not report a false-healthy zero lag.
+func (c *Coordinator) computeLagPending(ctx context.Context) (pending int64, lagSecs float64, lagApplicable bool, err error) {
 	head, err := c.replay.Head(ctx)
 	if err != nil {
-		return fmt.Errorf("projection.probe: Head: %w", err)
+		return 0, 0, false, fmt.Errorf("projection.probe: Head: %w", err)
 	}
 	cp, err := c.store.LoadOffset(ctx, c.cellID, c.projectionID)
 	if err != nil {
-		return fmt.Errorf("projection.probe: LoadOffset: %w", err)
+		return 0, 0, false, fmt.Errorf("projection.probe: LoadOffset: %w", err)
 	}
-	pending := head - cp
+	pending = head - cp
+	// F13: checkpoint > head anomaly (pending < 0) → clamp to 0 (caught up).
+	// pending == 0 → caught up. Either way lag is not applicable.
+	if pending <= 0 {
+		return 0, 0, false, nil
+	}
+	// Startup grace: nothing has been applied yet (cold start or fresh rebuild) →
+	// lag is unknown, not zero. lagApplicable=false so checkLag skips the gauge.
+	last := c.lastAppliedUnixNano.Load()
+	if last == 0 {
+		return pending, 0, false, nil
+	}
+	// Lag = time since the last applied event's domain time (OccurredAt).
+	return pending, c.clk.Since(time.Unix(0, last)).Seconds(), true, nil
+}
 
-	// F13: checkpoint > head anomaly — log warn and treat as healthy (0 gauge).
-	if pending < 0 {
-		c.metrics.setPendingEvents(ctx, c.cellID, c.projectionID, 0)
-		c.metrics.setReplayLag(ctx, c.cellID, c.projectionID, 0)
-		return nil
+// checkLag is the operational-health probe check. It computes pending events and
+// lag on demand (no background ticker) via computeLagPending, writes the gauges,
+// and returns unhealthy when the lag exceeds the threshold.
+//
+// F13: a checkpoint > head anomaly is collapsed into the pending==0 branch by
+// computeLagPending (clamped to 0), so both write pending=0/lag=0 and report
+// healthy. Startup grace (pending > 0, nothing applied) leaves the lag gauge
+// untouched (lagApplicable == false) so a stuck cold start is not masked healthy.
+func (c *Coordinator) checkLag(ctx context.Context) error {
+	pending, lagSecs, lagApplicable, err := c.computeLagPending(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Update pending_events gauge on demand.
 	c.metrics.setPendingEvents(ctx, c.cellID, c.projectionID, float64(pending))
 
-	// No pending events → always healthy; zero the lag gauge so it does not
-	// produce false-positive GoCellProjectionReplayLagHigh alerts on idle streams.
 	if pending == 0 {
+		// No pending events → always healthy; zero the lag gauge so it does not
+		// produce false-positive GoCellProjectionReplayLagHigh alerts on idle streams.
 		c.metrics.setReplayLag(ctx, c.cellID, c.projectionID, 0)
 		return nil
 	}
 
-	// Startup grace: nothing has been applied yet (cold start or fresh rebuild).
-	last := c.lastAppliedUnixNano.Load()
-	if last == 0 {
+	if !lagApplicable {
+		// Startup grace: nothing applied yet. Leave the lag gauge untouched.
 		return nil
 	}
 
-	// Lag = time since the last applied event's domain time (OccurredAt).
-	lagSecs := c.clk.Since(time.Unix(0, last)).Seconds()
 	// Update replay lag gauge on demand.
 	c.metrics.setReplayLag(ctx, c.cellID, c.projectionID, lagSecs)
 

--- a/kernel/projection/probe_test.go
+++ b/kernel/projection/probe_test.go
@@ -9,8 +9,53 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/healthz"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
+
+// TestCoordinator_Lag_StartupGrace_DoesNotWriteLagGauge guards the invariant
+// preserved by computeLagPending's lagApplicable flag: when there are pending
+// events but nothing has been applied yet (cold start / fresh rebuild), the lag
+// probe is healthy AND must NOT write the replay-lag gauge. Writing 0 there would
+// report a false-healthy "no lag" for a stuck cold-start projection. A future
+// refactor that drops the flag and writes lag=0 would fail this test.
+func TestCoordinator_Lag_StartupGrace_DoesNotWriteLagGauge(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(time.Now())
+	provider := newProjectionRecordingProvider()
+	m, err := RegisterMetrics(provider)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	src := NewMemReplaySource()
+	src.Append(mustNewTestEntry(t, clockmock.New(time.Now()), "topic.v1"))
+	src.Append(mustNewTestEntry(t, clockmock.New(time.Now()), "topic.v1")) // head=2
+	store := NewMemCheckpointStore()                                       // checkpoint=0 → pending=2
+	cur := newMemCursor(src)
+
+	// lastApplied defaults to 0 (nothing applied) → startup grace.
+	c := newCoordinatorFull(t, coordinatorFullParams{
+		clk: clk, projectionID: "myproj", store: store, cursor: cur, replay: src, metrics: m,
+	})
+	subscribeWithDefaults(t, c, applyNoop)
+
+	probes, err := c.Probes()
+	if err != nil {
+		t.Fatalf("Probes: %v", err)
+	}
+	if err := probes[1].Check(context.Background()); err != nil {
+		t.Errorf("lag probe should be healthy during startup grace, got %v", err)
+	}
+
+	labels := kernelmetrics.Labels{labelCell: "testcell", labelProjection: "myproj"}
+	if !provider.gaugeWasSet(metricProjectionPendingEvents, labels) {
+		t.Error("pending_events gauge must be set (pending=2)")
+	}
+	if provider.gaugeWasSet(metricProjectionReplayLag, labels) {
+		t.Error("replay_lag gauge must NOT be written during startup grace " +
+			"(writing 0 would mask a stuck cold-start as healthy)")
+	}
+}
 
 // probeTestRecentLagOffset is a site-specific deadline offset for the
 // "lag below threshold" probe test: an event applied this far in the past is

--- a/kernel/projection/rebuild.go
+++ b/kernel/projection/rebuild.go
@@ -29,8 +29,11 @@ var ErrRebuildInProgress = errcode.New(errcode.KindConflict, errcode.ErrConflict
 // Subscribe must have been called before Rebuild — the projection must have a
 // registered apply function and spec before rebuild can start.
 //
-// The rebuild goroutine is detached from the request context: it is only
-// canceled by Close (which sets rebuildCancel).
+// The rebuild goroutine is detached from the request's cancellation and
+// deadline (via context.WithoutCancel) but inherits its values — request_id /
+// trace_id / correlation_id / cell_id — so the async lifecycle logs correlate
+// to the request that admitted the rebuild. It is canceled only by Close (which
+// sets rebuildCancel), never by the triggering request completing.
 func (c *Coordinator) Rebuild(ctx context.Context) error {
 	if !c.subscribed.Load() {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
@@ -41,7 +44,10 @@ func (c *Coordinator) Rebuild(ctx context.Context) error {
 		return ErrRebuildInProgress
 	}
 
-	rctx, cancel := context.WithCancel(context.Background())
+	// WithoutCancel detaches from the request's cancellation/deadline (a rebuild
+	// must outlive the short-lived 202 request) while preserving its values for
+	// log correlation; WithCancel layers the Close-driven cancellation on top.
+	rctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	c.rebuildCancel.Store(&cancel)
 	c.rebuildWG.Add(1)
 	go c.runRebuild(rctx)
@@ -181,8 +187,10 @@ var errReplayDone = errors.New("projection.rebuild: replay reached head0")
 // Each event is applied via applyOne in its own tx (exactly-once skip + pos<1
 // guard apply). Stops at head0 (catchup picks up from there).
 //
-// v1: replay is bounded only by ctx cancellation (no max-entries / max-duration).
-// Operators bound duration via the ctx timeout passed to Rebuild.
+// v1: replay is bounded only by Close()/process shutdown (no max-entries /
+// max-duration). The triggering request's deadline does NOT bound it — the
+// rebuild ctx is derived via context.WithoutCancel, which strips the parent
+// deadline so a detached rebuild outlives the short-lived 202 request.
 func (c *Coordinator) replayPhase(ctx context.Context, head0 int64) error {
 	err := c.replay.Replay(ctx, 0, func(entry outbox.Entry) error {
 		if err := ctx.Err(); err != nil {

--- a/kernel/projection/rebuild_test.go
+++ b/kernel/projection/rebuild_test.go
@@ -36,6 +36,7 @@ type coordinatorFullParams struct {
 	store        CheckpointStore
 	cursor       Cursor
 	replay       ReplaySource
+	metrics      *Metrics // optional; nil leaves instruments disabled
 }
 
 // newCoordinatorFull creates a Coordinator with all dependencies including
@@ -68,7 +69,7 @@ func newCoordinatorFull(t *testing.T, p coordinatorFullParams) *Coordinator {
 		Cursor:       p.cursor,
 		Replay:       p.replay,
 		Tracer:       wrapper.NoopTracer{},
-		Metrics:      nil, // metrics optional
+		Metrics:      p.metrics, // nil leaves instruments disabled
 	})
 	if err != nil {
 		t.Fatalf("NewCoordinator: %v", err)

--- a/kernel/projection/rebuild_test.go
+++ b/kernel/projection/rebuild_test.go
@@ -13,6 +13,7 @@ import (
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/wrapper"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
@@ -1105,6 +1106,70 @@ func TestRebuild_PanicRecovered(t *testing.T) {
 		// any disposition is fine — gate is open
 	case <-time.After(rebuildTestHandlerTimeout):
 		t.Fatal("buildHandler hung after panic recovery (gate not reopened)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRebuild_PropagatesRequestCorrelation — F1: the detached rebuild goroutine
+// must inherit request-scoped correlation values from the triggering ctx.
+//
+// The HTTP rebuild endpoint calls Rebuild(r.Context()); the request ctx carries
+// request_id/trace_id/correlation_id that the slog sink (contextHandler) emits
+// as log attrs. A context.Background()-rooted goroutine drops them, so the async
+// started/completed/failed/panic logs cannot be correlated to the request that
+// admitted the rebuild. context.WithoutCancel preserves the Values while still
+// detaching from request cancellation/deadline (cancellation stays via Close).
+// ---------------------------------------------------------------------------
+
+// ctxRecordingReplaySource records the request_id observed in the ctx passed to
+// Head — the first I/O the detached rebuild goroutine performs (via captureHead),
+// so it witnesses exactly the ctx that runRebuild runs under.
+type ctxRecordingReplaySource struct {
+	mu        sync.Mutex
+	requestID string
+	seen      bool
+}
+
+func (s *ctxRecordingReplaySource) Head(ctx context.Context) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.seen {
+		s.requestID, _ = ctxkeys.RequestIDFrom(ctx)
+		s.seen = true
+	}
+	return 0, nil
+}
+
+func (s *ctxRecordingReplaySource) Replay(_ context.Context, _ int64, _ func(outbox.Entry) error) error {
+	return nil
+}
+
+func (s *ctxRecordingReplaySource) observedRequestID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requestID
+}
+
+func TestRebuild_PropagatesRequestCorrelation(t *testing.T) {
+	t.Parallel()
+	src := &ctxRecordingReplaySource{}
+	clk := clockmock.New(time.Now())
+	c := newCoordinatorFull(t, coordinatorFullParams{
+		clk: clk, cursor: &fakeCursor{pos: 1}, replay: src,
+	})
+	subscribeWithDefaults(t, c, applyNoop)
+
+	const wantReqID = "req-corr-123"
+	ctx := ctxkeys.WithRequestID(context.Background(), wantReqID)
+	if err := c.Rebuild(ctx); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	waitForPhase(t, c, PhaseLive)
+
+	if got := src.observedRequestID(); got != wantReqID {
+		t.Errorf("detached rebuild ctx request_id = %q, want %q "+
+			"(rebuild goroutine must inherit request correlation via context.WithoutCancel)",
+			got, wantReqID)
 	}
 }
 

--- a/kernel/projection/snapshot.go
+++ b/kernel/projection/snapshot.go
@@ -15,7 +15,10 @@ type RebuildController interface {
 	// Rebuild triggers a background full rebuild; nil = admitted (caller → 202),
 	// ErrRebuildInProgress = already running (caller → 409).
 	Rebuild(ctx context.Context) error
-	// Snapshot returns the current phase plus best-effort pending/lag.
+	// Snapshot returns the current phase plus best-effort pending/lag. On a
+	// store/replay read error the returned Snapshot still carries a valid Phase
+	// (in-memory, never fails); only PendingEvents and ReplayLagSeconds are
+	// zeroed, and the error is returned for the caller to log.
 	Snapshot(ctx context.Context) (Snapshot, error)
 }
 
@@ -32,6 +35,13 @@ var _ RebuildController = (*Coordinator)(nil)
 // non-nil error. Callers (the rebuild handler) log the error but MUST NOT fail
 // an already-admitted rebuild over a degraded snapshot read — the rebuild has
 // been accepted regardless of whether its current lag could be read.
+//
+// ReplayLagSeconds == 0 is ambiguous by design and must be read together with
+// PendingEvents: it means either "caught up" (PendingEvents == 0) OR "lag
+// unknown" (PendingEvents > 0 but nothing applied yet — cold start / fresh
+// rebuild, so there is no last-applied time to measure from). The lag readyz
+// probe distinguishes these (it leaves the lag gauge unwritten during the
+// startup-grace case rather than reporting a false-healthy zero).
 type Snapshot struct {
 	Phase            Phase
 	PendingEvents    int64

--- a/kernel/projection/snapshot.go
+++ b/kernel/projection/snapshot.go
@@ -1,0 +1,56 @@
+package projection
+
+import "context"
+
+// RebuildController is the narrow control-plane surface the rebuild HTTP
+// endpoint consumes from a projection Coordinator: trigger a background rebuild
+// and read a status snapshot. *Coordinator satisfies it.
+//
+// The endpoint (runtime/bootstrap) holds this interface rather than the concrete
+// *Coordinator so the handler's dependency is honest (it only triggers + reads,
+// never touches the raw checkpoint store / tx runner) and is unit-testable with
+// a fake. This is the standard accept-interfaces-at-the-consumer idiom, not a
+// speculative abstraction — there is exactly one production implementer.
+type RebuildController interface {
+	// Rebuild triggers a background full rebuild; nil = admitted (caller → 202),
+	// ErrRebuildInProgress = already running (caller → 409).
+	Rebuild(ctx context.Context) error
+	// Snapshot returns the current phase plus best-effort pending/lag.
+	Snapshot(ctx context.Context) (Snapshot, error)
+}
+
+// Compile-time assertion that *Coordinator satisfies RebuildController.
+var _ RebuildController = (*Coordinator)(nil)
+
+// Snapshot is a point-in-time view of a projection's lifecycle and replay lag,
+// returned by the rebuild control-plane endpoint as the 202 response body
+// ({phase, pendingEvents, replayLagSeconds}).
+//
+// Phase is always populated (read from the in-memory atomic — no I/O, never
+// fails). PendingEvents and ReplayLagSeconds are best-effort: on a
+// checkpoint-store / replay read error they are zero and Snapshot returns a
+// non-nil error. Callers (the rebuild handler) log the error but MUST NOT fail
+// an already-admitted rebuild over a degraded snapshot read — the rebuild has
+// been accepted regardless of whether its current lag could be read.
+type Snapshot struct {
+	Phase            Phase
+	PendingEvents    int64
+	ReplayLagSeconds float64
+}
+
+// Snapshot returns the Coordinator's current lifecycle phase plus a best-effort
+// pending-events / replay-lag reading. Phase is read from the live atomic
+// (Coordinator.Phase, never errors). PendingEvents and ReplayLagSeconds are
+// derived from the replay head, stored checkpoint, and last-applied domain time
+// via computeLagPending — the same single-source computation the lag readyz
+// probe uses (so the wire snapshot can never diverge from the probe). On a
+// store/replay read error the Snapshot carries the valid Phase with zeroed
+// pending/lag and the error is returned for the caller to log.
+func (c *Coordinator) Snapshot(ctx context.Context) (Snapshot, error) {
+	pending, lagSecs, _, err := c.computeLagPending(ctx)
+	return Snapshot{
+		Phase:            c.Phase(),
+		PendingEvents:    pending,
+		ReplayLagSeconds: lagSecs,
+	}, err
+}

--- a/kernel/projection/snapshot.go
+++ b/kernel/projection/snapshot.go
@@ -2,29 +2,6 @@ package projection
 
 import "context"
 
-// RebuildController is the narrow control-plane surface the rebuild HTTP
-// endpoint consumes from a projection Coordinator: trigger a background rebuild
-// and read a status snapshot. *Coordinator satisfies it.
-//
-// The endpoint (runtime/bootstrap) holds this interface rather than the concrete
-// *Coordinator so the handler's dependency is honest (it only triggers + reads,
-// never touches the raw checkpoint store / tx runner) and is unit-testable with
-// a fake. This is the standard accept-interfaces-at-the-consumer idiom, not a
-// speculative abstraction — there is exactly one production implementer.
-type RebuildController interface {
-	// Rebuild triggers a background full rebuild; nil = admitted (caller → 202),
-	// ErrRebuildInProgress = already running (caller → 409).
-	Rebuild(ctx context.Context) error
-	// Snapshot returns the current phase plus best-effort pending/lag. On a
-	// store/replay read error the returned Snapshot still carries a valid Phase
-	// (in-memory, never fails); only PendingEvents and ReplayLagSeconds are
-	// zeroed, and the error is returned for the caller to log.
-	Snapshot(ctx context.Context) (Snapshot, error)
-}
-
-// Compile-time assertion that *Coordinator satisfies RebuildController.
-var _ RebuildController = (*Coordinator)(nil)
-
 // Snapshot is a point-in-time view of a projection's lifecycle and replay lag,
 // returned by the rebuild control-plane endpoint as the 202 response body
 // ({phase, pendingEvents, replayLagSeconds}).

--- a/kernel/projection/snapshot_test.go
+++ b/kernel/projection/snapshot_test.go
@@ -102,6 +102,32 @@ func TestCoordinator_Snapshot_Degraded(t *testing.T) {
 	}
 }
 
+// TestCoordinator_Snapshot_DegradedLoadOffset covers the second computeLagPending
+// error edge — replay.Head succeeds but the checkpoint store's LoadOffset fails.
+// Snapshot must still return a valid Phase with zeroed pending/lag + the error.
+func TestCoordinator_Snapshot_DegradedLoadOffset(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(time.Now())
+	src := NewMemReplaySource()
+	src.Append(mustNewTestEntry(t, clockmock.New(time.Now()), "topic.v1")) // Head succeeds (=1)
+	store := &seededStore{offsets: make(map[string]int64), loadErr: errors.New("checkpoint load failed")}
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, store: store, replay: src})
+
+	snap, err := c.Snapshot(context.Background())
+	if err == nil {
+		t.Fatal("Snapshot: expected non-nil error on LoadOffset failure, got nil")
+	}
+	if !errors.Is(err, store.loadErr) {
+		t.Errorf("error does not wrap loadErr: %v", err)
+	}
+	if snap.Phase != PhaseLive {
+		t.Errorf("Phase = %v, want PhaseLive", snap.Phase)
+	}
+	if snap.PendingEvents != 0 || snap.ReplayLagSeconds != 0 {
+		t.Errorf("degraded snapshot must zero pending/lag, got pending=%d lag=%v", snap.PendingEvents, snap.ReplayLagSeconds)
+	}
+}
+
 // TestCoordinator_Snapshot_PhaseReflectsCoordinator asserts Snapshot.Phase mirrors
 // Coordinator.Phase() (in-memory read, never errors).
 func TestCoordinator_Snapshot_PhaseReflectsCoordinator(t *testing.T) {

--- a/kernel/projection/snapshot_test.go
+++ b/kernel/projection/snapshot_test.go
@@ -1,0 +1,121 @@
+package projection
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+)
+
+// TestCoordinator_Snapshot_Values exercises the value cases of Coordinator.Snapshot:
+// the Phase is always reported, and PendingEvents / ReplayLagSeconds are derived
+// from the replay head, checkpoint, and last-applied domain time via the shared
+// computeLagPending helper (same source as the lag probe).
+func TestCoordinator_Snapshot_Values(t *testing.T) {
+	t.Parallel()
+
+	const lagOffset = 10 * time.Second
+
+	cases := []struct {
+		name         string
+		headEntries  int   // number of replay entries (= head)
+		checkpoint   int64 // stored offset
+		lastAppliedT bool  // when true, lastApplied = now-lagOffset; else 0 (startup grace)
+		wantPending  int64
+		wantLagSecs  float64
+	}{
+		{name: "live empty", headEntries: 0, checkpoint: 0, lastAppliedT: false, wantPending: 0, wantLagSecs: 0},
+		{name: "pending with recent apply", headEntries: 2, checkpoint: 0, lastAppliedT: true, wantPending: 2, wantLagSecs: lagOffset.Seconds()},
+		{name: "pending startup grace", headEntries: 2, checkpoint: 0, lastAppliedT: false, wantPending: 2, wantLagSecs: 0},
+		{name: "negative pending clamped", headEntries: 0, checkpoint: 5, lastAppliedT: true, wantPending: 0, wantLagSecs: 0},
+		{name: "caught up", headEntries: 2, checkpoint: 2, lastAppliedT: true, wantPending: 0, wantLagSecs: 0},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Now()
+			clk := clockmock.New(now)
+			entryClk := clockmock.New(now)
+			src := NewMemReplaySource()
+			for i := 0; i < tc.headEntries; i++ {
+				src.Append(mustNewTestEntry(t, entryClk, "topic.v1"))
+			}
+			store := NewMemCheckpointStore()
+			if tc.checkpoint > 0 {
+				if err := store.SaveOffset(context.Background(), "testcell", "p1", tc.checkpoint); err != nil {
+					t.Fatalf("SaveOffset: %v", err)
+				}
+			}
+			c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, store: store, replay: src})
+			if tc.lastAppliedT {
+				c.lastAppliedUnixNano.Store(now.Add(-lagOffset).UnixNano())
+			}
+
+			snap, err := c.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot: unexpected error: %v", err)
+			}
+			if snap.Phase != PhaseLive {
+				t.Errorf("Phase = %v, want PhaseLive", snap.Phase)
+			}
+			if snap.PendingEvents != tc.wantPending {
+				t.Errorf("PendingEvents = %d, want %d", snap.PendingEvents, tc.wantPending)
+			}
+			if snap.ReplayLagSeconds != tc.wantLagSecs {
+				t.Errorf("ReplayLagSeconds = %v, want %v", snap.ReplayLagSeconds, tc.wantLagSecs)
+			}
+		})
+	}
+}
+
+// TestCoordinator_Snapshot_Degraded asserts that a checkpoint-store / replay read
+// error yields a Snapshot carrying the valid Phase with zeroed pending/lag plus a
+// non-nil error — the caller (the rebuild HTTP handler) logs it but does not fail
+// an already-admitted rebuild over a degraded snapshot read.
+func TestCoordinator_Snapshot_Degraded(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	clk := clockmock.New(now)
+	headErr := errors.New("replay head unavailable")
+	c := newCoordinatorFull(t, coordinatorFullParams{
+		clk:    clk,
+		store:  NewMemCheckpointStore(),
+		replay: &errHeadReplaySource{headErr: headErr},
+	})
+
+	snap, err := c.Snapshot(context.Background())
+	if err == nil {
+		t.Fatal("Snapshot: expected non-nil error on replay Head failure, got nil")
+	}
+	if !errors.Is(err, headErr) {
+		t.Errorf("error does not wrap headErr: %v", err)
+	}
+	if snap.Phase != PhaseLive {
+		t.Errorf("Phase = %v, want PhaseLive (always populated even on degraded read)", snap.Phase)
+	}
+	if snap.PendingEvents != 0 || snap.ReplayLagSeconds != 0 {
+		t.Errorf("degraded snapshot must zero pending/lag, got pending=%d lag=%v", snap.PendingEvents, snap.ReplayLagSeconds)
+	}
+}
+
+// TestCoordinator_Snapshot_PhaseReflectsCoordinator asserts Snapshot.Phase mirrors
+// Coordinator.Phase() (in-memory read, never errors).
+func TestCoordinator_Snapshot_PhaseReflectsCoordinator(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(time.Now())
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, replay: NewMemReplaySource()})
+
+	// Force a non-live phase to prove Snapshot reads the live atomic, not a constant.
+	c.phase.Store(uint32(PhaseReplay))
+	snap, err := c.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.Phase != PhaseReplay {
+		t.Errorf("Phase = %v, want PhaseReplay (must reflect c.Phase())", snap.Phase)
+	}
+}

--- a/kernel/projection/snapshot_test.go
+++ b/kernel/projection/snapshot_test.go
@@ -9,14 +9,17 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 )
 
+// snapshotTestLagOffset is the fixed last-applied age for the "recent apply"
+// snapshot case (lag ≈ this value). Extracted to a package-level const per
+// TEST-TIME-LITERAL-01.
+const snapshotTestLagOffset = 10 * time.Second
+
 // TestCoordinator_Snapshot_Values exercises the value cases of Coordinator.Snapshot:
 // the Phase is always reported, and PendingEvents / ReplayLagSeconds are derived
 // from the replay head, checkpoint, and last-applied domain time via the shared
 // computeLagPending helper (same source as the lag probe).
 func TestCoordinator_Snapshot_Values(t *testing.T) {
 	t.Parallel()
-
-	const lagOffset = 10 * time.Second
 
 	cases := []struct {
 		name         string
@@ -27,7 +30,10 @@ func TestCoordinator_Snapshot_Values(t *testing.T) {
 		wantLagSecs  float64
 	}{
 		{name: "live empty", headEntries: 0, checkpoint: 0, lastAppliedT: false, wantPending: 0, wantLagSecs: 0},
-		{name: "pending with recent apply", headEntries: 2, checkpoint: 0, lastAppliedT: true, wantPending: 2, wantLagSecs: lagOffset.Seconds()},
+		{
+			name: "pending with recent apply", headEntries: 2, checkpoint: 0,
+			lastAppliedT: true, wantPending: 2, wantLagSecs: snapshotTestLagOffset.Seconds(),
+		},
 		{name: "pending startup grace", headEntries: 2, checkpoint: 0, lastAppliedT: false, wantPending: 2, wantLagSecs: 0},
 		{name: "negative pending clamped", headEntries: 0, checkpoint: 5, lastAppliedT: true, wantPending: 0, wantLagSecs: 0},
 		{name: "caught up", headEntries: 2, checkpoint: 2, lastAppliedT: true, wantPending: 0, wantLagSecs: 0},
@@ -52,7 +58,7 @@ func TestCoordinator_Snapshot_Values(t *testing.T) {
 			}
 			c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, store: store, replay: src})
 			if tc.lastAppliedT {
-				c.lastAppliedUnixNano.Store(now.Add(-lagOffset).UnixNano())
+				c.lastAppliedUnixNano.Store(now.Add(-snapshotTestLagOffset).UnixNano())
 			}
 
 			snap, err := c.Snapshot(context.Background())

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -752,6 +752,11 @@ const (
 	// ErrConflict so operator dashboards can route saga producer-side races
 	// separately from cell-wide conflict signals.
 	ErrSagaDuplicateInstance Code = "ERR_SAGA_DUPLICATE_INSTANCE"
+	// ErrProjectionNotFound signals that the projection rebuild control-plane
+	// endpoint (POST /internal/v1/<cell>/projection/<name>/rebuild) was given a
+	// <cell>/<name> path that resolves to no registered projection Coordinator.
+	// Constructed with KindNotFound → HTTP 404.
+	ErrProjectionNotFound Code = "ERR_PROJECTION_NOT_FOUND"
 
 	// Webhook signing / verification / delivery codes (KERNEL-WEBHOOK-01).
 	// Each comment notes the intended Kind the construction site passes to

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -188,7 +188,7 @@ type Bootstrap struct {
 	projectionTxRunner persistence.TxRunner
 	projectionReplay   projection.ReplaySource
 	projectionCursor   projection.Cursor
-	// projectionCoordinators maps "<cellID>/<projectionID>" → the constructed
+	// projectionRebuilds maps "<cellID>/<projectionID>" → the constructed
 	// projection.RebuildController (a *projection.Coordinator), so the framework
 	// rebuild control-plane endpoint can resolve a {cell}/{name} path and trigger
 	// Rebuild + read a Snapshot.
@@ -204,7 +204,7 @@ type Bootstrap struct {
 	// therefore fully populated and frozen before any request can observe it; no
 	// mutex/sync.Map is needed (same pattern as the phase5-built health/router
 	// state). Do NOT add concurrent writers after phase6.
-	projectionCoordinators map[string]projection.RebuildController
+	projectionRebuilds map[string]projection.RebuildController
 
 	// projectionRebuildCallers is the caller-cell allowlist for the framework
 	// projection rebuild endpoint, set by WithProjectionRebuildEndpoint. Non-empty

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -191,9 +191,19 @@ type Bootstrap struct {
 	// projectionCoordinators maps "<cellID>/<projectionID>" → the constructed
 	// projection.RebuildController (a *projection.Coordinator), so the framework
 	// rebuild control-plane endpoint can resolve a {cell}/{name} path and trigger
-	// Rebuild + read a Snapshot. Populated by the phase6 projection drain; read by
-	// the rebuild handler at request time (phase6 runs after phase5 mounts the
-	// route but before any request is served, so the lazy read sees a full map).
+	// Rebuild + read a Snapshot.
+	//
+	// Concurrency: this is a plain map with no lock, and that is safe by
+	// construction — it is written ONLY by the phase6 projection drain
+	// (phase6StartEventRouter, Run() line ~104) and read ONLY by the rebuild
+	// handler. HTTP serving goroutines are launched in phase7
+	// (phase7StartHTTPServer, Run() line ~107) via `go server.Serve(...)`, which
+	// is sequenced AFTER phase6. The Go memory model's goroutine-start
+	// happens-before (the `go` statement happens-before the goroutine body) gives
+	// phase6 writes → phase7 serve-goroutine launch → handler reads. The map is
+	// therefore fully populated and frozen before any request can observe it; no
+	// mutex/sync.Map is needed (same pattern as the phase5-built health/router
+	// state). Do NOT add concurrent writers after phase6.
 	projectionCoordinators map[string]projection.RebuildController
 
 	// projectionRebuildCallers is the caller-cell allowlist for the framework

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -189,8 +189,8 @@ type Bootstrap struct {
 	projectionReplay   projection.ReplaySource
 	projectionCursor   projection.Cursor
 	// projectionRebuilds maps "<cellID>/<projectionID>" → the constructed
-	// projection.RebuildController (a *projection.Coordinator), so the framework
-	// rebuild control-plane endpoint can resolve a {cell}/{name} path and trigger
+	// rebuildController (a *projection.Coordinator), so the framework rebuild
+	// control-plane endpoint can resolve a {cell}/{name} path and trigger
 	// Rebuild + read a Snapshot.
 	//
 	// Concurrency: this is a plain map with no lock, and that is safe by
@@ -204,7 +204,7 @@ type Bootstrap struct {
 	// therefore fully populated and frozen before any request can observe it; no
 	// mutex/sync.Map is needed (same pattern as the phase5-built health/router
 	// state). Do NOT add concurrent writers after phase6.
-	projectionRebuilds map[string]projection.RebuildController
+	projectionRebuilds map[string]rebuildController
 
 	// projectionRebuildCallers is the caller-cell allowlist for the framework
 	// projection rebuild endpoint, set by WithProjectionRebuildEndpoint. Non-empty

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -189,9 +189,19 @@ type Bootstrap struct {
 	projectionReplay   projection.ReplaySource
 	projectionCursor   projection.Cursor
 	// projectionCoordinators maps "<cellID>/<projectionID>" → the constructed
-	// Coordinator, so the PR-04 HTTP rebuild endpoint can resolve and trigger
-	// Coordinator.Rebuild. Populated by phase6 projection drain.
-	projectionCoordinators map[string]*projection.Coordinator
+	// projection.RebuildController (a *projection.Coordinator), so the framework
+	// rebuild control-plane endpoint can resolve a {cell}/{name} path and trigger
+	// Rebuild + read a Snapshot. Populated by the phase6 projection drain; read by
+	// the rebuild handler at request time (phase6 runs after phase5 mounts the
+	// route but before any request is served, so the lazy read sees a full map).
+	projectionCoordinators map[string]projection.RebuildController
+
+	// projectionRebuildCallers is the caller-cell allowlist for the framework
+	// projection rebuild endpoint, set by WithProjectionRebuildEndpoint. Non-empty
+	// = opt-in: phase5 mounts POST /internal/v1/{cell}/projection/{name}/rebuild on
+	// the InternalListener with a RequireCallerCell guard over these IDs. Empty =
+	// endpoint not mounted (rebuild remains programmatic-only).
+	projectionRebuildCallers []string
 
 	// --- devtools catalog endpoint (J1 PR-A37) ---
 	// All zero/nil = endpoint not registered.

--- a/runtime/bootstrap/options_projection.go
+++ b/runtime/bootstrap/options_projection.go
@@ -119,10 +119,15 @@ func WithProjectionCursor(cursor projection.Cursor) Option {
 // InternalListener MUST be declared via WithListener — phase0
 // (validateProjectionRebuildEndpoint) fails fast otherwise.
 //
-// Not calling this option (or calling it with no callers) leaves the endpoint
-// unmounted: projection rebuilds remain triggerable only programmatically via
-// Coordinator.Rebuild. This is a wiring option — a later call replaces the
-// allowlist set by an earlier one.
+// Opt-in is determined solely by len(allowedCallers) > 0. Not calling this
+// option — OR calling it with zero callers, WithProjectionRebuildEndpoint() —
+// leaves the endpoint unmounted with NO error: projection rebuilds remain
+// triggerable only programmatically via Coordinator.Rebuild. (A zero-caller call
+// is therefore a no-op, not a misconfiguration; an /internal/ endpoint with a
+// non-empty caller list is the only mounted form.)
+//
+// This is a wiring option — a later call REPLACES the allowlist set by an
+// earlier one (including clearing it back to unmounted with a zero-caller call).
 func WithProjectionRebuildEndpoint(allowedCallers ...string) Option {
 	return func(b *Bootstrap) {
 		b.projectionRebuildCallers = allowedCallers

--- a/runtime/bootstrap/options_projection.go
+++ b/runtime/bootstrap/options_projection.go
@@ -99,3 +99,32 @@ func WithProjectionCursor(cursor projection.Cursor) Option {
 		b.projectionCursor = cursor
 	}
 }
+
+// WithProjectionRebuildEndpoint opts the assembly into the framework projection
+// rebuild control-plane endpoint:
+//
+//	POST /internal/v1/{cell}/projection/{name}/rebuild
+//
+// mounted by bootstrap on the InternalListener (the framework-owned-RouteGroup
+// pattern, like /healthz·/readyz·/metrics — no contract.yaml, no host cell). The
+// handler dispatches by {cell}/{name} to the Coordinator wired in the phase6
+// drain and returns 202 (rebuild admitted, body carries the {phase,
+// pendingEvents, replayLagSeconds} snapshot) / 409 (already running) / 404
+// (unknown cell/projection).
+//
+// allowedCallers is the caller-cell allowlist (service-token callerCell segment).
+// A non-listed caller is rejected 403 via RequireCallerCell. At least one caller
+// is REQUIRED: an /internal/ endpoint must name its callers
+// (ContractSpec.validateHTTP fails closed on empty Clients), and the
+// InternalListener MUST be declared via WithListener — phase0
+// (validateProjectionRebuildEndpoint) fails fast otherwise.
+//
+// Not calling this option (or calling it with no callers) leaves the endpoint
+// unmounted: projection rebuilds remain triggerable only programmatically via
+// Coordinator.Rebuild. This is a wiring option — a later call replaces the
+// allowlist set by an earlier one.
+func WithProjectionRebuildEndpoint(allowedCallers ...string) Option {
+	return func(b *Bootstrap) {
+		b.projectionRebuildCallers = allowedCallers
+	}
+}

--- a/runtime/bootstrap/phases_assembly.go
+++ b/runtime/bootstrap/phases_assembly.go
@@ -72,6 +72,9 @@ func (b *Bootstrap) phase0ValidateOptions() error {
 	if err := b.validateHTTPListenerConfigs(); err != nil {
 		return err
 	}
+	if err := b.validateProjectionRebuildEndpoint(); err != nil {
+		return err
+	}
 	if err := b.validateAssemblyClockAlignment(); err != nil {
 		return err
 	}

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -138,6 +138,12 @@ func (b *Bootstrap) phase5CollectRouteGroups(s *phaseState) []cell.RouteGroup {
 	if s.devtoolsHandler != nil {
 		groups = append(groups, devtools.RouteGroup(s.devtoolsHandler))
 	}
+	// Framework projection rebuild control-plane endpoint (opt-in via
+	// WithProjectionRebuildEndpoint). phase0 (validateProjectionRebuildEndpoint)
+	// guaranteed the InternalListener exists when callers are set.
+	if len(b.projectionRebuildCallers) > 0 {
+		groups = append(groups, b.projectionRebuildRouteGroup())
+	}
 	for _, id := range s.asm.CellIDs() {
 		snap, ok := s.cellSnapshots[id]
 		if !ok {

--- a/runtime/bootstrap/phases_projection.go
+++ b/runtime/bootstrap/phases_projection.go
@@ -433,9 +433,9 @@ func (b *Bootstrap) wireOneProjection(s *phaseState, evtRouter *eventrouter.Rout
 		func(c context.Context) error { return coord.Close(c) })
 
 	if b.projectionRebuilds == nil {
-		b.projectionRebuilds = make(map[string]projection.RebuildController)
+		b.projectionRebuilds = make(map[string]rebuildController)
 	}
-	// coord (*projection.Coordinator) satisfies projection.RebuildController.
+	// coord (*projection.Coordinator) satisfies rebuildController.
 	b.projectionRebuilds[w.cellID+"/"+w.projectionID] = coord
 	return nil
 }

--- a/runtime/bootstrap/phases_projection.go
+++ b/runtime/bootstrap/phases_projection.go
@@ -432,10 +432,10 @@ func (b *Bootstrap) wireOneProjection(s *phaseState, evtRouter *eventrouter.Rout
 	s.addNamedTeardown("projection:"+w.cellID+"/"+w.projectionID,
 		func(c context.Context) error { return coord.Close(c) })
 
-	if b.projectionCoordinators == nil {
-		b.projectionCoordinators = make(map[string]projection.RebuildController)
+	if b.projectionRebuilds == nil {
+		b.projectionRebuilds = make(map[string]projection.RebuildController)
 	}
 	// coord (*projection.Coordinator) satisfies projection.RebuildController.
-	b.projectionCoordinators[w.cellID+"/"+w.projectionID] = coord
+	b.projectionRebuilds[w.cellID+"/"+w.projectionID] = coord
 	return nil
 }

--- a/runtime/bootstrap/phases_projection.go
+++ b/runtime/bootstrap/phases_projection.go
@@ -433,8 +433,9 @@ func (b *Bootstrap) wireOneProjection(s *phaseState, evtRouter *eventrouter.Rout
 		func(c context.Context) error { return coord.Close(c) })
 
 	if b.projectionCoordinators == nil {
-		b.projectionCoordinators = make(map[string]*projection.Coordinator)
+		b.projectionCoordinators = make(map[string]projection.RebuildController)
 	}
+	// coord (*projection.Coordinator) satisfies projection.RebuildController.
 	b.projectionCoordinators[w.cellID+"/"+w.projectionID] = coord
 	return nil
 }

--- a/runtime/bootstrap/phases_projection_test.go
+++ b/runtime/bootstrap/phases_projection_test.go
@@ -377,7 +377,7 @@ func TestPhase6_ProjectionDrain_WiresCoordinatorAndProbes(t *testing.T) {
 		"phase6 must drain the projection cleanly")
 
 	// Coordinator indexed for the rebuild HTTP endpoint (held as the narrow
-	// RebuildController interface; assert the concrete type to inspect probes).
+	// rebuildController interface; assert the concrete type to inspect probes).
 	ctrl, ok := b.projectionRebuilds[projTestCellID+"/"+projTestProjID]
 	require.True(t, ok, "coordinator must be indexed by <cell>/<projection>")
 	require.NotNil(t, ctrl)

--- a/runtime/bootstrap/phases_projection_test.go
+++ b/runtime/bootstrap/phases_projection_test.go
@@ -375,10 +375,13 @@ func TestPhase6_ProjectionDrain_WiresCoordinatorAndProbes(t *testing.T) {
 	require.NoError(t, b.phase6StartEventRouter(runCtx, s),
 		"phase6 must drain the projection cleanly")
 
-	// Coordinator indexed for the rebuild HTTP endpoint.
-	coord, ok := b.projectionCoordinators[projTestCellID+"/"+projTestProjID]
+	// Coordinator indexed for the rebuild HTTP endpoint (held as the narrow
+	// RebuildController interface; assert the concrete type to inspect probes).
+	ctrl, ok := b.projectionCoordinators[projTestCellID+"/"+projTestProjID]
 	require.True(t, ok, "coordinator must be indexed by <cell>/<projection>")
-	require.NotNil(t, coord)
+	require.NotNil(t, ctrl)
+	coord, ok := ctrl.(*projection.Coordinator)
+	require.True(t, ok, "registry must hold a *projection.Coordinator")
 
 	// Probes were registered (Register returns an error on dup/invalid; a clean
 	// phase6 proves both store-ready and lag probes registered without collision).

--- a/runtime/bootstrap/phases_projection_test.go
+++ b/runtime/bootstrap/phases_projection_test.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -377,7 +378,7 @@ func TestPhase6_ProjectionDrain_WiresCoordinatorAndProbes(t *testing.T) {
 
 	// Coordinator indexed for the rebuild HTTP endpoint (held as the narrow
 	// RebuildController interface; assert the concrete type to inspect probes).
-	ctrl, ok := b.projectionCoordinators[projTestCellID+"/"+projTestProjID]
+	ctrl, ok := b.projectionRebuilds[projTestCellID+"/"+projTestProjID]
 	require.True(t, ok, "coordinator must be indexed by <cell>/<projection>")
 	require.NotNil(t, ctrl)
 	coord, ok := ctrl.(*projection.Coordinator)
@@ -395,14 +396,20 @@ func TestPhase6_ProjectionDrain_WiresCoordinatorAndProbes(t *testing.T) {
 	}
 }
 
+// projectionApplyRoundTripTimeout bounds the publish→Apply round-trip wait. The
+// in-mem bus fires Apply in milliseconds; this generous deadline only matters on
+// a wiring regression, where it produces an actionable failure. Package-level
+// const per TEST-TIME-LITERAL-01.
+const projectionApplyRoundTripTimeout = 10 * time.Second
+
 // TestPhase6_ProjectionDrain_PublishApplyRoundTrip verifies that after phase6
 // drains the projection into the running event router, publishing a real event
 // on the projection's topic causes the business Apply to be invoked. This is the
 // true E2E guarantee: coordinator wired, handler registered, router running, and
 // publish → Apply round-trip confirmed.
 //
-// The test uses an atomic counter + Eventually to avoid sleep-based polling.
-// In-mem eventbus + mem projection deps ensure no external deps and determinism.
+// In-mem eventbus + mem projection deps ensure no external deps and determinism;
+// the Apply channel gives deterministic sync with a bounded, diagnosable deadline.
 func TestPhase6_ProjectionDrain_PublishApplyRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -459,10 +466,16 @@ func TestPhase6_ProjectionDrain_PublishApplyRoundTrip(t *testing.T) {
 	require.NoError(t, bus.Publish(context.Background(), projTestTopic, payload),
 		"Publish must succeed when the router is running")
 
-	// Wait for Apply to be called. The in-mem bus dispatches into a goroutine so
-	// we use a channel for deterministic sync — no wall-clock literal required,
-	// satisfying TEST-TIME-LITERAL-CONST-01. Failure is bounded by go test -timeout.
-	<-applied
+	// Wait for Apply to be called. The in-mem bus dispatches into a goroutine, so
+	// sync on the channel; a generous bounded deadline (package-level const per
+	// TEST-TIME-LITERAL-01) turns a wiring regression into an actionable failure
+	// message instead of a generic `go test -timeout` kill.
+	select {
+	case <-applied:
+	case <-time.After(projectionApplyRoundTripTimeout):
+		t.Fatal("phase6 round-trip: projection Apply was not invoked within the deadline " +
+			"after publishing to the projection topic — check the coordinator/router wiring")
+	}
 
 	// Teardown: LIFO stop the router + coordinator.
 	for _, v := range slices.Backward(s.teardowns) {
@@ -560,7 +573,7 @@ func TestPhase6_Projection_RejectsConcurrentSubscriber(t *testing.T) {
 	// offending transport type, so ops can see which declarations are blocked.
 	assert.Contains(t, err.Error(), projTestCellID+"/"+projTestProjID,
 		"error must name the projection that triggered the serial-delivery guard")
-	assert.Empty(t, b.projectionCoordinators,
+	assert.Empty(t, b.projectionRebuilds,
 		"no projection coordinator must be wired when the guard rejects the transport")
 }
 

--- a/runtime/bootstrap/projection_rebuild.go
+++ b/runtime/bootstrap/projection_rebuild.go
@@ -27,10 +27,12 @@ package bootstrap
 // ref: runtime/bootstrap/health.go — framework-owned RouteGroup mount pattern.
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/projection"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/runtime/auth"
@@ -40,7 +42,22 @@ import (
 const (
 	projectionRebuildContractID = "http.framework.projection.rebuild.v1"
 	projectionRebuildPath       = "/internal/v1/{cell}/projection/{name}/rebuild"
+	// maxPathParamReport bounds the cell/projection path-param length echoed in
+	// the 404 body / logs. Path params reach the handler unvalidated; registered
+	// projection keys are far shorter (cell ≤32, projection snake_case), so a
+	// value beyond this is necessarily a miss — truncating bounds the response
+	// body and log line against an oversized (authorized-caller) path.
+	maxPathParamReport = 64
 )
+
+// clampReport truncates an unvalidated path-param value to maxPathParamReport
+// runes for safe echoing in the 404 body / logs.
+func clampReport(s string) string {
+	if len(s) <= maxPathParamReport {
+		return s
+	}
+	return s[:maxPathParamReport]
+}
 
 // projectionRebuildResponseData is the data object of the 202 response body.
 // JSON field names are camelCase per the API convention.
@@ -78,6 +95,11 @@ func (b *Bootstrap) validateProjectionRebuildEndpoint() error {
 // and phase0 verified an InternalListener exists. The caller-cell allowlist rides
 // on ContractSpec.Clients (NewFrameworkHTTP variadic), so auth.Mount auto-injects
 // RequireCallerCell — no explicit Route.Policy needed.
+//
+// The RouteGroup carries no CellID (like the health groups), so HTTP metrics
+// attribute it to cell="_runtime" (RuntimeCellSentinel) — correct for a
+// framework control-plane endpoint that is not owned by a business cell. Filter
+// rebuild traffic by route template, not by the cell label.
 func (b *Bootstrap) projectionRebuildRouteGroup() cell.RouteGroup {
 	spec := contractbuild.NewFrameworkHTTP(
 		projectionRebuildContractID, http.MethodPost, projectionRebuildPath,
@@ -105,22 +127,44 @@ func (b *Bootstrap) newProjectionRebuildHandler() http.Handler {
 			httputil.WriteError(ctx, w, errcode.New(errcode.KindNotFound, errcode.ErrProjectionNotFound,
 				"projection not found",
 				errcode.WithDetails(
-					errcode.PublicString("cell", cellID),
-					errcode.PublicString("projection", projID),
+					errcode.PublicString("cell", clampReport(cellID)),
+					errcode.PublicString("projection", clampReport(projID)),
 				)))
 			return
 		}
 
 		if err := ctrl.Rebuild(ctx); err != nil {
-			// ErrRebuildInProgress is KindConflict → 409. Any other error (e.g. the
-			// unreachable Subscribe-not-called invariant) maps via its own Kind.
-			httputil.WriteError(ctx, w, err)
+			if errors.Is(err, projection.ErrRebuildInProgress) {
+				httputil.WriteError(ctx, w, err) // KindConflict → 409
+				return
+			}
+			// Any other Rebuild error is unreachable for a registered Coordinator
+			// (the phase6 drain always Subscribes before registering, so the
+			// Subscribe-not-called invariant cannot fire here). Treat it as a
+			// framework fault (500), not a client 400 — the caller did nothing
+			// wrong. Keeps the wire status set to the ADR-frozen 202/409/404 plus
+			// the implicit framework 5xx.
+			httputil.WriteError(ctx, w, errcode.New(errcode.KindInternal, errcode.ErrInternal,
+				"projection rebuild: unexpected coordinator state",
+				errcode.WithInternal(errcode.InternalAttr("error", err.Error()))))
 			return
 		}
 
-		// Rebuild admitted (202). Read a best-effort snapshot for the body; a
-		// degraded read (store/replay error) is logged but never downgrades an
-		// already-admitted rebuild to a 5xx — Phase is always valid.
+		// Rebuild admitted (202). Audit-log the control-plane action with the
+		// caller cell (the access log correlates the rest via request_id, but a
+		// rebuild is an operator action worth an explicit Info record).
+		admitAttrs := httputil.AppendCorrelationAttrs(ctx, []any{
+			slog.String("cell", cellID),
+			slog.String("projection", projID),
+		})
+		if p, ok := auth.FromContext(ctx); ok && p.CallerCellID != "" {
+			admitAttrs = append(admitAttrs, slog.String("caller_cell", p.CallerCellID))
+		}
+		slog.InfoContext(ctx, "projection rebuild admitted", admitAttrs...)
+
+		// Read a best-effort snapshot for the body; a degraded read (store/replay
+		// error) is logged but never downgrades an already-admitted rebuild to a
+		// 5xx — Phase is always valid.
 		snap, snapErr := ctrl.Snapshot(ctx)
 		if snapErr != nil {
 			attrs := httputil.AppendCorrelationAttrs(ctx, []any{

--- a/runtime/bootstrap/projection_rebuild.go
+++ b/runtime/bootstrap/projection_rebuild.go
@@ -1,0 +1,142 @@
+package bootstrap
+
+// projection_rebuild.go — the framework-owned projection rebuild control-plane
+// endpoint.
+//
+//	POST /internal/v1/{cell}/projection/{name}/rebuild
+//
+// It is mounted by bootstrap itself (not a cell) on the InternalListener, the
+// same framework-owned-RouteGroup pattern as the health endpoints in health.go —
+// no contract.yaml, no codegen, no host cell. Opt-in via
+// WithProjectionRebuildEndpoint(callers...); phase5CollectRouteGroups appends the
+// RouteGroup when callers are set, and phase0 guarantees an InternalListener is
+// declared.
+//
+// The endpoint dispatches by {cell}/{name} path params to the projection
+// Coordinator registered in the phase6 drain (b.projectionCoordinators, read
+// lazily at request time — phase6 runs after phase5 mounts the route but before
+// any request is served). It honors the ADR-frozen status semantics: 202
+// Accepted (rebuild admitted; body carries the {phase, pendingEvents,
+// replayLagSeconds} snapshot) / 409 Conflict (a rebuild is already running) / 404
+// Not Found (unknown cell/projection). The caller-cell allowlist (service-token
+// + RequireCallerCell) is carried on the framework ContractSpec.Clients, so
+// auth.Mount auto-injects the guard.
+//
+// ref: EventStoreDB projections HTTP admin API (POST /projection/{name}/command/
+// reset) — generic server-provided control-plane keyed by projection name.
+// ref: runtime/bootstrap/health.go — framework-owned RouteGroup mount pattern.
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/runtime/auth"
+	"github.com/ghbvf/gocell/runtime/internal/contractbuild"
+)
+
+const (
+	projectionRebuildContractID = "http.framework.projection.rebuild.v1"
+	projectionRebuildPath       = "/internal/v1/{cell}/projection/{name}/rebuild"
+)
+
+// projectionRebuildResponseData is the data object of the 202 response body.
+// JSON field names are camelCase per the API convention.
+type projectionRebuildResponseData struct {
+	Phase            string  `json:"phase"`
+	PendingEvents    int64   `json:"pendingEvents"`
+	ReplayLagSeconds float64 `json:"replayLagSeconds"`
+}
+
+// projectionRebuildResponse is the unified {"data": {...}} single-resource
+// envelope for the 202 response.
+type projectionRebuildResponse struct {
+	Data projectionRebuildResponseData `json:"data"`
+}
+
+// validateProjectionRebuildEndpoint fails fast in phase0 when the rebuild
+// endpoint was opted in (WithProjectionRebuildEndpoint with ≥1 caller) but no
+// InternalListener is declared to mount it on. A no-caller opt-in is a no-op
+// (the endpoint stays unmounted), so it needs no listener and passes here.
+func (b *Bootstrap) validateProjectionRebuildEndpoint() error {
+	if len(b.projectionRebuildCallers) == 0 {
+		return nil
+	}
+	if _, ok := b.listenerConfigs[cell.InternalListener]; !ok {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"bootstrap: WithProjectionRebuildEndpoint requires a cell.InternalListener; "+
+				"declare it via WithListener(cell.InternalListener, addr, authChain)")
+	}
+	return nil
+}
+
+// projectionRebuildRouteGroup builds the framework-owned RouteGroup for the
+// rebuild endpoint on the InternalListener. It is only called when
+// WithProjectionRebuildEndpoint opted in (b.projectionRebuildCallers non-empty)
+// and phase0 verified an InternalListener exists. The caller-cell allowlist rides
+// on ContractSpec.Clients (NewFrameworkHTTP variadic), so auth.Mount auto-injects
+// RequireCallerCell — no explicit Route.Policy needed.
+func (b *Bootstrap) projectionRebuildRouteGroup() cell.RouteGroup {
+	spec := contractbuild.NewFrameworkHTTP(
+		projectionRebuildContractID, http.MethodPost, projectionRebuildPath,
+		b.projectionRebuildCallers...)
+	handler := b.newProjectionRebuildHandler()
+	return cell.RouteGroup{
+		Listener: cell.InternalListener,
+		Register: func(mux cell.RouteMux) error {
+			return auth.Mount(mux, auth.Route{Contract: spec, Handler: handler})
+		},
+	}
+}
+
+// newProjectionRebuildHandler returns the http.Handler for the rebuild endpoint.
+// It reads b.projectionCoordinators lazily (populated by the phase6 drain), so it
+// captures the receiver, not a snapshot of the map.
+func (b *Bootstrap) newProjectionRebuildHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		cellID := r.PathValue("cell")
+		projID := r.PathValue("name")
+
+		ctrl, ok := b.projectionCoordinators[cellID+"/"+projID]
+		if !ok {
+			httputil.WriteError(ctx, w, errcode.New(errcode.KindNotFound, errcode.ErrProjectionNotFound,
+				"projection not found",
+				errcode.WithDetails(
+					errcode.PublicString("cell", cellID),
+					errcode.PublicString("projection", projID),
+				)))
+			return
+		}
+
+		if err := ctrl.Rebuild(ctx); err != nil {
+			// ErrRebuildInProgress is KindConflict → 409. Any other error (e.g. the
+			// unreachable Subscribe-not-called invariant) maps via its own Kind.
+			httputil.WriteError(ctx, w, err)
+			return
+		}
+
+		// Rebuild admitted (202). Read a best-effort snapshot for the body; a
+		// degraded read (store/replay error) is logged but never downgrades an
+		// already-admitted rebuild to a 5xx — Phase is always valid.
+		snap, snapErr := ctrl.Snapshot(ctx)
+		if snapErr != nil {
+			attrs := httputil.AppendCorrelationAttrs(ctx, []any{
+				slog.String("cell", cellID),
+				slog.String("projection", projID),
+				slog.Any("error", snapErr),
+			})
+			slog.WarnContext(ctx, "projection rebuild: snapshot read degraded after admission", attrs...)
+		}
+
+		httputil.WriteJSON(w, http.StatusAccepted, projectionRebuildResponse{
+			Data: projectionRebuildResponseData{
+				Phase:            snap.Phase.String(),
+				PendingEvents:    snap.PendingEvents,
+				ReplayLagSeconds: snap.ReplayLagSeconds,
+			},
+		})
+	})
+}

--- a/runtime/bootstrap/projection_rebuild.go
+++ b/runtime/bootstrap/projection_rebuild.go
@@ -27,6 +27,7 @@ package bootstrap
 // ref: runtime/bootstrap/health.go — framework-owned RouteGroup mount pattern.
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -38,6 +39,28 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/internal/contractbuild"
 )
+
+// rebuildController is the narrow control-plane surface the rebuild HTTP handler
+// consumes from a projection Coordinator: trigger a background rebuild and read a
+// status snapshot. *projection.Coordinator satisfies it.
+//
+// It is declared here — the consumer — rather than in kernel/projection: the
+// accept-interfaces-at-the-consumer idiom keeps kernel's exported surface free of
+// a bootstrap-only seam while keeping the handler honest (it only triggers + reads,
+// never touches the raw checkpoint store / tx runner) and unit-testable with a fake.
+type rebuildController interface {
+	// Rebuild triggers a background full rebuild; nil = admitted (caller → 202),
+	// projection.ErrRebuildInProgress = already running (caller → 409).
+	Rebuild(ctx context.Context) error
+	// Snapshot returns the current phase plus best-effort pending/lag. On a
+	// store/replay read error the Phase is still valid; only PendingEvents and
+	// ReplayLagSeconds are zeroed, and the error is returned for the caller to log
+	// (a degraded snapshot never downgrades an already-admitted rebuild).
+	Snapshot(ctx context.Context) (projection.Snapshot, error)
+}
+
+// Compile-time assertion that *projection.Coordinator satisfies rebuildController.
+var _ rebuildController = (*projection.Coordinator)(nil)
 
 const (
 	projectionRebuildContractID = "http.framework.projection.rebuild.v1"

--- a/runtime/bootstrap/projection_rebuild.go
+++ b/runtime/bootstrap/projection_rebuild.go
@@ -13,7 +13,7 @@ package bootstrap
 // declared.
 //
 // The endpoint dispatches by {cell}/{name} path params to the projection
-// Coordinator registered in the phase6 drain (b.projectionCoordinators, read
+// Coordinator registered in the phase6 drain (b.projectionRebuilds, read
 // lazily at request time — phase6 runs after phase5 mounts the route but before
 // any request is served). It honors the ADR-frozen status semantics: 202
 // Accepted (rebuild admitted; body carries the {phase, pendingEvents,
@@ -114,7 +114,7 @@ func (b *Bootstrap) projectionRebuildRouteGroup() cell.RouteGroup {
 }
 
 // newProjectionRebuildHandler returns the http.Handler for the rebuild endpoint.
-// It reads b.projectionCoordinators lazily (populated by the phase6 drain), so it
+// It reads b.projectionRebuilds lazily (populated by the phase6 drain), so it
 // captures the receiver, not a snapshot of the map.
 func (b *Bootstrap) newProjectionRebuildHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +122,7 @@ func (b *Bootstrap) newProjectionRebuildHandler() http.Handler {
 		cellID := r.PathValue("cell")
 		projID := r.PathValue("name")
 
-		ctrl, ok := b.projectionCoordinators[cellID+"/"+projID]
+		ctrl, ok := b.projectionRebuilds[cellID+"/"+projID]
 		if !ok {
 			httputil.WriteError(ctx, w, errcode.New(errcode.KindNotFound, errcode.ErrProjectionNotFound,
 				"projection not found",

--- a/runtime/bootstrap/projection_rebuild_test.go
+++ b/runtime/bootstrap/projection_rebuild_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/ghbvf/gocell/runtime/auth"
 )
 
-// fakeRebuildController is a test double for projection.RebuildController so the
-// rebuild handler can be exercised without constructing a full Coordinator. The
-// real implementer is *projection.Coordinator (kernel-tested separately).
+// fakeRebuildController is a test double for the unexported rebuildController so
+// the rebuild handler can be exercised without constructing a full Coordinator.
+// The real implementer is *projection.Coordinator (kernel-tested separately).
 type fakeRebuildController struct {
 	rebuildErr   error
 	snap         projection.Snapshot
@@ -38,7 +38,7 @@ func (f *fakeRebuildController) Snapshot(context.Context) (projection.Snapshot, 
 	return f.snap, f.snapErr
 }
 
-var _ projection.RebuildController = (*fakeRebuildController)(nil)
+var _ rebuildController = (*fakeRebuildController)(nil)
 
 // serveMuxRouteMux adapts *http.ServeMux to cell.RouteMux so a RouteGroup's
 // Register (which only calls Handle for a top-level non-prefixed mount) can be
@@ -66,7 +66,7 @@ func mountRebuildEndpoint(t *testing.T, b *Bootstrap) *http.ServeMux {
 
 // rebuildBootstrap returns a Bootstrap with the rebuild endpoint opted in for
 // caller "controlplane" and the given registry contents.
-func rebuildBootstrap(reg map[string]projection.RebuildController) *Bootstrap {
+func rebuildBootstrap(reg map[string]rebuildController) *Bootstrap {
 	b := New(clock.Real(), WithProjectionRebuildEndpoint("controlplane"))
 	b.projectionRebuilds = reg
 	return b
@@ -89,7 +89,7 @@ func doRebuild(mux *http.ServeMux, caller, cellID, projID string) *httptest.Resp
 func TestProjectionRebuild_202(t *testing.T) {
 	t.Parallel()
 	fake := &fakeRebuildController{snap: projection.Snapshot{Phase: projection.PhaseLive, PendingEvents: 5, ReplayLagSeconds: 12.5}}
-	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	b := rebuildBootstrap(map[string]rebuildController{"ordercell/order_status": fake})
 	mux := mountRebuildEndpoint(t, b)
 
 	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
@@ -107,7 +107,7 @@ func TestProjectionRebuild_202(t *testing.T) {
 func TestProjectionRebuild_409(t *testing.T) {
 	t.Parallel()
 	fake := &fakeRebuildController{rebuildErr: projection.ErrRebuildInProgress}
-	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	b := rebuildBootstrap(map[string]rebuildController{"ordercell/order_status": fake})
 	mux := mountRebuildEndpoint(t, b)
 
 	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
@@ -121,7 +121,7 @@ func TestProjectionRebuild_409(t *testing.T) {
 func TestProjectionRebuild_404(t *testing.T) {
 	t.Parallel()
 	// Registry holds only ordercell/order_status.
-	b := rebuildBootstrap(map[string]projection.RebuildController{
+	b := rebuildBootstrap(map[string]rebuildController{
 		"ordercell/order_status": &fakeRebuildController{},
 	})
 	mux := mountRebuildEndpoint(t, b)
@@ -151,7 +151,7 @@ func TestProjectionRebuild_DegradedSnapshotStill202(t *testing.T) {
 		snap:    projection.Snapshot{Phase: projection.PhaseLive},
 		snapErr: errors.New("checkpoint store unreachable"),
 	}
-	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	b := rebuildBootstrap(map[string]rebuildController{"ordercell/order_status": fake})
 	mux := mountRebuildEndpoint(t, b)
 
 	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
@@ -170,7 +170,7 @@ func TestProjectionRebuild_DegradedSnapshotStill202(t *testing.T) {
 func TestProjectionRebuild_UnexpectedRebuildError500(t *testing.T) {
 	t.Parallel()
 	fake := &fakeRebuildController{rebuildErr: errors.New("coordinator not subscribed")}
-	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	b := rebuildBootstrap(map[string]rebuildController{"ordercell/order_status": fake})
 	mux := mountRebuildEndpoint(t, b)
 
 	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
@@ -182,7 +182,7 @@ func TestProjectionRebuild_UnexpectedRebuildError500(t *testing.T) {
 // truncated in the 404 body (bounds the response/log against an oversized path).
 func TestProjectionRebuild_LongPathParamClamped(t *testing.T) {
 	t.Parallel()
-	b := rebuildBootstrap(map[string]projection.RebuildController{})
+	b := rebuildBootstrap(map[string]rebuildController{})
 	mux := mountRebuildEndpoint(t, b)
 
 	longName := strings.Repeat("a", 200)
@@ -200,7 +200,7 @@ func TestProjectionRebuild_LongPathParamClamped(t *testing.T) {
 func TestProjectionRebuild_CallerCellAllowlist(t *testing.T) {
 	t.Parallel()
 	fake := &fakeRebuildController{snap: projection.Snapshot{Phase: projection.PhaseLive}}
-	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	b := rebuildBootstrap(map[string]rebuildController{"ordercell/order_status": fake})
 	mux := mountRebuildEndpoint(t, b)
 
 	// Caller not in the allowlist → 403 (and the handler never runs).

--- a/runtime/bootstrap/projection_rebuild_test.go
+++ b/runtime/bootstrap/projection_rebuild_test.go
@@ -1,0 +1,208 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kauth "github.com/ghbvf/gocell/kernel/auth"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/projection"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// fakeRebuildController is a test double for projection.RebuildController so the
+// rebuild handler can be exercised without constructing a full Coordinator. The
+// real implementer is *projection.Coordinator (kernel-tested separately).
+type fakeRebuildController struct {
+	rebuildErr   error
+	snap         projection.Snapshot
+	snapErr      error
+	rebuildCalls int
+}
+
+func (f *fakeRebuildController) Rebuild(context.Context) error {
+	f.rebuildCalls++
+	return f.rebuildErr
+}
+
+func (f *fakeRebuildController) Snapshot(context.Context) (projection.Snapshot, error) {
+	return f.snap, f.snapErr
+}
+
+var _ projection.RebuildController = (*fakeRebuildController)(nil)
+
+// serveMuxRouteMux adapts *http.ServeMux to cell.RouteMux so a RouteGroup's
+// Register (which only calls Handle for a top-level non-prefixed mount) can be
+// invoked in tests and the result served through Go 1.22 path-value routing.
+type serveMuxRouteMux struct{ *http.ServeMux }
+
+func (serveMuxRouteMux) Route(string, func(cell.RouteMux))                       {}
+func (serveMuxRouteMux) Mount(string, http.Handler)                              {}
+func (serveMuxRouteMux) Group(func(cell.RouteMux))                               {}
+func (m serveMuxRouteMux) With(...func(http.Handler) http.Handler) cell.RouteMux { return m }
+
+var _ cell.RouteMux = serveMuxRouteMux{}
+
+// mountRebuildEndpoint wires b's rebuild RouteGroup onto a fresh ServeMux via the
+// real production projectionRebuildRouteGroup().Register, asserting the group
+// targets the InternalListener.
+func mountRebuildEndpoint(t *testing.T, b *Bootstrap) *http.ServeMux {
+	t.Helper()
+	rg := b.projectionRebuildRouteGroup()
+	require.Equal(t, cell.InternalListener, rg.Listener, "rebuild endpoint must mount on the InternalListener")
+	mux := http.NewServeMux()
+	require.NoError(t, rg.Register(serveMuxRouteMux{mux}))
+	return mux
+}
+
+// rebuildBootstrap returns a Bootstrap with the rebuild endpoint opted in for
+// caller "controlplane" and the given registry contents.
+func rebuildBootstrap(reg map[string]projection.RebuildController) *Bootstrap {
+	b := New(clock.Real(), WithProjectionRebuildEndpoint("controlplane"))
+	b.projectionCoordinators = reg
+	return b
+}
+
+// doRebuild issues a POST to the mux as the given caller cell (empty = no service
+// principal) and returns the recorder.
+func doRebuild(mux *http.ServeMux, caller, cellID, projID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/"+cellID+"/projection/"+projID+"/rebuild", nil)
+	if caller != "" {
+		req = req.WithContext(auth.TestServiceContext(caller))
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestProjectionRebuild_202 asserts an admitted rebuild returns 202 with the
+// {phase, pendingEvents, replayLagSeconds} snapshot body.
+func TestProjectionRebuild_202(t *testing.T) {
+	t.Parallel()
+	fake := &fakeRebuildController{snap: projection.Snapshot{Phase: projection.PhaseLive, PendingEvents: 5, ReplayLagSeconds: 12.5}}
+	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	mux := mountRebuildEndpoint(t, b)
+
+	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Equal(t, 1, fake.rebuildCalls)
+	var got projectionRebuildResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "live", got.Data.Phase)
+	assert.Equal(t, int64(5), got.Data.PendingEvents)
+	assert.InDelta(t, 12.5, got.Data.ReplayLagSeconds, 0.0001)
+}
+
+// TestProjectionRebuild_409 asserts an in-progress rebuild returns 409.
+func TestProjectionRebuild_409(t *testing.T) {
+	t.Parallel()
+	fake := &fakeRebuildController{rebuildErr: projection.ErrRebuildInProgress}
+	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	mux := mountRebuildEndpoint(t, b)
+
+	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// TestProjectionRebuild_404 asserts an unknown projection — on either the cell or
+// the name dimension of the {cell}/{name} key — returns 404 with the
+// ErrProjectionNotFound code.
+func TestProjectionRebuild_404(t *testing.T) {
+	t.Parallel()
+	// Registry holds only ordercell/order_status.
+	b := rebuildBootstrap(map[string]projection.RebuildController{
+		"ordercell/order_status": &fakeRebuildController{},
+	})
+	mux := mountRebuildEndpoint(t, b)
+
+	cases := []struct{ name, cell, proj string }{
+		{"unknown projection name", "ordercell", "nosuchprojection"},
+		{"unknown cell", "nosuchcell", "order_status"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := doRebuild(mux, "controlplane", tc.cell, tc.proj)
+			require.Equal(t, http.StatusNotFound, rec.Code)
+			assert.Contains(t, rec.Body.String(), "ERR_PROJECTION_NOT_FOUND")
+		})
+	}
+}
+
+// TestProjectionRebuild_DegradedSnapshotStill202 asserts a snapshot read error
+// after admission does not downgrade the already-admitted rebuild to a 5xx.
+func TestProjectionRebuild_DegradedSnapshotStill202(t *testing.T) {
+	t.Parallel()
+	fake := &fakeRebuildController{
+		snap:    projection.Snapshot{Phase: projection.PhaseStopped},
+		snapErr: errors.New("checkpoint store unreachable"),
+	}
+	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	mux := mountRebuildEndpoint(t, b)
+
+	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	var got projectionRebuildResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "stopped", got.Data.Phase) // Phase still valid; pending/lag zeroed
+	assert.Equal(t, int64(0), got.Data.PendingEvents)
+}
+
+// TestProjectionRebuild_CallerCellAllowlist asserts the auto-injected
+// RequireCallerCell guard (from ContractSpec.Clients) rejects a caller that is
+// not in the allowlist with 403, and admits the allowlisted caller.
+func TestProjectionRebuild_CallerCellAllowlist(t *testing.T) {
+	t.Parallel()
+	fake := &fakeRebuildController{snap: projection.Snapshot{Phase: projection.PhaseLive}}
+	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	mux := mountRebuildEndpoint(t, b)
+
+	// Caller not in the allowlist → 403 (and the handler never runs).
+	rec := doRebuild(mux, "evilcell", "ordercell", "order_status")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, 0, fake.rebuildCalls, "denied caller must not reach the rebuild handler")
+
+	// Allowlisted caller → admitted.
+	rec = doRebuild(mux, "controlplane", "ordercell", "order_status")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+// TestValidateProjectionRebuildEndpoint covers the phase0 fail-fast: opting into
+// the endpoint requires an InternalListener; a no-caller opt-in is a no-op.
+func TestValidateProjectionRebuildEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not opted in → ok", func(t *testing.T) {
+		t.Parallel()
+		b := New(clock.Real())
+		require.NoError(t, b.validateProjectionRebuildEndpoint())
+	})
+
+	t.Run("opted in without InternalListener → error", func(t *testing.T) {
+		t.Parallel()
+		b := New(clock.Real(), WithProjectionRebuildEndpoint("controlplane"))
+		err := b.validateProjectionRebuildEndpoint()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "InternalListener")
+	})
+
+	t.Run("opted in with InternalListener → ok", func(t *testing.T) {
+		t.Parallel()
+		b := New(clock.Real(),
+			WithListener(cell.InternalListener, "127.0.0.1:0", []kauth.ListenerAuth{kauth.AuthNone{}}),
+			WithProjectionRebuildEndpoint("controlplane"))
+		require.NoError(t, b.validateProjectionRebuildEndpoint())
+	})
+}

--- a/runtime/bootstrap/projection_rebuild_test.go
+++ b/runtime/bootstrap/projection_rebuild_test.go
@@ -68,7 +68,7 @@ func mountRebuildEndpoint(t *testing.T, b *Bootstrap) *http.ServeMux {
 // caller "controlplane" and the given registry contents.
 func rebuildBootstrap(reg map[string]projection.RebuildController) *Bootstrap {
 	b := New(clock.Real(), WithProjectionRebuildEndpoint("controlplane"))
-	b.projectionCoordinators = reg
+	b.projectionRebuilds = reg
 	return b
 }
 

--- a/runtime/bootstrap/projection_rebuild_test.go
+++ b/runtime/bootstrap/projection_rebuild_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -144,8 +145,10 @@ func TestProjectionRebuild_404(t *testing.T) {
 // after admission does not downgrade the already-admitted rebuild to a 5xx.
 func TestProjectionRebuild_DegradedSnapshotStill202(t *testing.T) {
 	t.Parallel()
+	// Distinctive non-default Phase so the assertion proves the handler passed the
+	// (degraded) snapshot's valid Phase through, not a zeroed/default Snapshot.
 	fake := &fakeRebuildController{
-		snap:    projection.Snapshot{Phase: projection.PhaseStopped},
+		snap:    projection.Snapshot{Phase: projection.PhaseLive},
 		snapErr: errors.New("checkpoint store unreachable"),
 	}
 	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
@@ -156,8 +159,39 @@ func TestProjectionRebuild_DegradedSnapshotStill202(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, rec.Code)
 	var got projectionRebuildResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	assert.Equal(t, "stopped", got.Data.Phase) // Phase still valid; pending/lag zeroed
+	assert.Equal(t, "live", got.Data.Phase) // Phase still valid; pending/lag zeroed
 	assert.Equal(t, int64(0), got.Data.PendingEvents)
+}
+
+// TestProjectionRebuild_UnexpectedRebuildError500 asserts that a Rebuild error
+// other than ErrRebuildInProgress (unreachable for a registered coordinator) maps
+// to a framework 500, not a client 400 — keeping the wire status set to the
+// ADR-frozen 202/409/404 plus the implicit framework 5xx.
+func TestProjectionRebuild_UnexpectedRebuildError500(t *testing.T) {
+	t.Parallel()
+	fake := &fakeRebuildController{rebuildErr: errors.New("coordinator not subscribed")}
+	b := rebuildBootstrap(map[string]projection.RebuildController{"ordercell/order_status": fake})
+	mux := mountRebuildEndpoint(t, b)
+
+	rec := doRebuild(mux, "controlplane", "ordercell", "order_status")
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// TestProjectionRebuild_LongPathParamClamped asserts an oversized path param is
+// truncated in the 404 body (bounds the response/log against an oversized path).
+func TestProjectionRebuild_LongPathParamClamped(t *testing.T) {
+	t.Parallel()
+	b := rebuildBootstrap(map[string]projection.RebuildController{})
+	mux := mountRebuildEndpoint(t, b)
+
+	longName := strings.Repeat("a", 200)
+	rec := doRebuild(mux, "controlplane", "ordercell", longName)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	// The full 200-char value must NOT appear verbatim — it is clamped to 64.
+	assert.NotContains(t, rec.Body.String(), longName)
+	assert.Contains(t, rec.Body.String(), strings.Repeat("a", maxPathParamReport))
 }
 
 // TestProjectionRebuild_CallerCellAllowlist asserts the auto-injected

--- a/runtime/internal/contractbuild/contractbuild.go
+++ b/runtime/internal/contractbuild/contractbuild.go
@@ -23,8 +23,16 @@ import (
 const frameworkHTTPIDPrefix = "http.framework."
 
 // NewFrameworkHTTP constructs a ContractSpec for runtime-owned HTTP
-// infrastructure endpoints (health probes, devtools catalog, etc.). Kind is
-// fixed as cellvocab.ContractHTTP; Transport is fixed as "http".
+// infrastructure endpoints (health probes, devtools catalog, projection rebuild
+// control-plane, etc.). Kind is fixed as cellvocab.ContractHTTP; Transport is
+// fixed as "http".
+//
+// The optional clients carry the caller-cell allowlist. An /internal/ path
+// REQUIRES a non-empty allowlist (ContractSpec.validateHTTP fails closed
+// otherwise — every internal API must name its callers); public framework
+// endpoints (/healthz, /readyz, /metrics, devtools) pass no clients. Validation
+// of the path↔clients pairing is deferred to ContractSpec.Validate() at the
+// mount site, so the funnel itself stays a pure constructor.
 //
 // The id MUST start with "http.framework.". This constraint is enforced at
 // construction time with a panic (A-class assertion), not merely by code
@@ -38,7 +46,7 @@ const frameworkHTTPIDPrefix = "http.framework."
 // The package lives under runtime/internal/ so the Go compiler refuses imports
 // from outside the runtime/ subtree — business code physically cannot call
 // this funnel (see doc.go for the compiler-Hard upstream rationale).
-func NewFrameworkHTTP(id, method, path string) contractspec.ContractSpec {
+func NewFrameworkHTTP(id, method, path string, clients ...string) contractspec.ContractSpec {
 	if !strings.HasPrefix(id, frameworkHTTPIDPrefix) {
 		panic(panicregister.Approved(
 			"contractspec-framework-id-prefix",
@@ -51,6 +59,7 @@ func NewFrameworkHTTP(id, method, path string) contractspec.ContractSpec {
 		Transport: "http",
 		Method:    method,
 		Path:      path,
+		Clients:   clients,
 	}
 }
 

--- a/runtime/internal/contractbuild/contractbuild_test.go
+++ b/runtime/internal/contractbuild/contractbuild_test.go
@@ -48,11 +48,12 @@ func assertSpecEqual(t *testing.T, got, want contractspec.ContractSpec) {
 func TestNewFrameworkHTTP(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name   string
-		id     string
-		method string
-		path   string
-		want   contractspec.ContractSpec
+		name    string
+		id      string
+		method  string
+		path    string
+		clients []string
+		want    contractspec.ContractSpec
 	}{
 		{
 			name:   "valid health livez",
@@ -106,12 +107,30 @@ func TestNewFrameworkHTTP(t *testing.T) {
 				Path:      "/api/v1/test",
 			},
 		},
+		{
+			// Internal control-plane framework endpoint: an /internal/ path requires
+			// a non-empty Clients allowlist (ContractSpec.validateHTTP invariant), so
+			// the variadic clients carry the caller-cell allowlist into the spec.
+			name:    "internal endpoint with caller-cell allowlist",
+			id:      "http.framework.projection.rebuild.v1",
+			method:  "POST",
+			path:    "/internal/v1/{cell}/projection/{name}/rebuild",
+			clients: []string{"controlplane"},
+			want: contractspec.ContractSpec{
+				ID:        "http.framework.projection.rebuild.v1",
+				Kind:      cellvocab.ContractHTTP,
+				Transport: "http",
+				Method:    "POST",
+				Path:      "/internal/v1/{cell}/projection/{name}/rebuild",
+				Clients:   []string{"controlplane"},
+			},
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := contractbuild.NewFrameworkHTTP(tc.id, tc.method, tc.path)
+			got := contractbuild.NewFrameworkHTTP(tc.id, tc.method, tc.path, tc.clients...)
 			assertSpecEqual(t, got, tc.want)
 			if err := got.Validate(); err != nil {
 				t.Errorf("Validate() unexpected error: %v", err)


### PR DESCRIPTION
## Summary

`POST /internal/v1/{cell}/projection/{name}/rebuild` — the projection rebuild control-plane endpoint frozen in ADR §5. Mounted by **bootstrap itself as a framework-owned RouteGroup** (the `/healthz`·`/readyz`·`/metrics` pattern), so it has **no contract.yaml, no codegen, no host cell, and never reaches DEAD-CONTRACT-01** — opt-in via `bootstrap.WithProjectionRebuildEndpoint(callers...)`.

Closes #1370.

### 开源对标
Dominant pattern across EventStoreDB / Axon / Marten / Watermill / Akka is a **generic framework/server control plane keyed by projection name** (not per-application). Strongest precedent: EventStoreDB `POST /projection/{name}/command/reset` (server-mounted admin HTTP, name = path param, admin-auth + network isolation). GoCell's own health endpoints already use this exact `contractbuild.NewFrameworkHTTP` + bootstrap-mounted RouteGroup shape — reused here. `ref: EventStoreDB projections HTTP API; runtime/bootstrap/health.go`.

### What changed
- **kernel/projection**: `Coordinator.Snapshot(ctx) (Snapshot,error)` (202 body `{phase,pendingEvents,replayLagSeconds}`) + `RebuildController` consumer interface. `probe.checkLag` refactored to share a **pure** `computeLagPending` helper → the wire snapshot can never diverge from the lag probe (single-source). Degraded snapshot read never downgrades an admitted 202.
- **runtime/internal/contractbuild**: `NewFrameworkHTTP(id,method,path, clients...)` variadic — an `/internal/` framework spec carries the caller-cell allowlist so it passes `ContractSpec.Validate` and `auth.Mount` auto-injects `RequireCallerCell`.
- **runtime/bootstrap**: `WithProjectionRebuildEndpoint` opt-in + phase5 mount on InternalListener + handler (dispatch `{cell}/{name}` → registry → 202/409/404) + phase0 fail-fast (opt-in requires InternalListener). Registry value type `*Coordinator` → `RebuildController`.
- **pkg/errcode**: `ErrProjectionNotFound` (KindNotFound → 404).
- **examples/todoorder**: endpoint enabled (caller `controlplane`) over ordercell's `order_status` projection.
- **ADR amendment 2026-06-03**: framework-mount mechanism rewrites the §5 cellgen framing; auth/path/status unchanged; threat matrix re-evaluated — no row flips.

### Auth (unchanged from ADR §5)
`/internal/` + service-token listener chain + caller-cell allowlist. The purer operator-credential admin surface (EventStoreDB-style `AdminListener` + operator `ListenerAuth`) is a cross-cutting auth foundation deferred to **#1505**; `/internal/`+allowlist is GoCell's existing structural invariant for internal endpoints (no new foundation).

## Implementation matrix (contract-fanout)
- **Contract**: framework `ContractSpec` `http.framework.projection.rebuild.v1` (via `NewFrameworkHTTP` funnel — no contract.yaml).
- **Change**: new control-plane endpoint + `Coordinator.Snapshot` accessor + `ErrProjectionNotFound` sentinel.
- **Implementations**: bootstrap framework handler (`runtime/bootstrap/projection_rebuild.go`); `*projection.Coordinator` satisfies `RebuildController`.
- **Tests**: `kernel/projection` (Snapshot values/degraded/phase) · `runtime/bootstrap` (202/409/404 cell+name/degraded/caller-cell-allowlist/phase0) · `contractbuild` (variadic clients).
- **Repro**: `go test ./kernel/projection/... ./runtime/bootstrap/... ./runtime/internal/contractbuild/...`
- **Dependent contracts (governance scan)**: none (no contract.yaml).

## Test plan
- [x] `go build ./...`
- [x] `go test ./kernel/projection/... ./runtime/bootstrap/... ./runtime/internal/contractbuild/... ./pkg/errcode/... ./examples/todoorder/...` — all pass
- [x] `go run ./cmd/gocell validate` — 0 errors (2 pre-existing journey warnings)
- [x] `golangci-lint run` on changed packages — 0 issues
- [ ] e2e: `go run ./examples/todoorder`; service-token POST (callerCell=controlplane) `/internal/v1/ordercell/projection/order_status/rebuild` → 202+snapshot; unknown → 404; concurrent 2nd → 409; non-allowlisted caller → 403

## ⚠️ Pre-existing develop breakage (NOT from this PR)
`go test ./...` shows `tools/archtest` fails to compile (`undefined: RunTypedProduction` / `RunTypedFixture` in 7 archtest `_test.go` files — a façade-migration gap), which cascades to `cmd/gocell/app` `TestCheckUnconditionalSkip*` (they load the archtest package). **Identical failure reproduces on clean `develop` HEAD (8de38c365); none of these files are touched by this PR.** This PR's relevant invariants are clean by construction (spec via the `NewFrameworkHTTP` Hard funnel; no contract.yaml → no DEAD-CONTRACT-01; const-literal errcode messages). Needs a separate develop fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)