### PR TITLE
chore(deps): bump go 1.25.10 → 1.25.11 (govulncheck GO-2026-5037/5039)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ghbvf/gocell
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9

--- a/tools/archtest/testdata/clock_leaf_fallback_fixtures/compliant/go.mod
+++ b/tools/archtest/testdata/clock_leaf_fallback_fixtures/compliant/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_leaf_fallback/compliant
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture compiles against the same
 // API the gate guards. The compliant fixture only consumes types/values it

--- a/tools/archtest/testdata/clock_leaf_fallback_fixtures/violates/go.mod
+++ b/tools/archtest/testdata/clock_leaf_fallback_fixtures/violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_leaf_fallback/violates
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture can resolve
 // kernel/clock.Real() and exercise the type-aware leaf-fallback gate.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/aliased_import_selector_violates/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/aliased_import_selector_violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/aliased_import_selector_violates
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture uses the canonical
 // clock.Clock type and clock.MustHaveClock resolves via go/types even with an

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/ctx_param_passes/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/ctx_param_passes/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/ctx_param_passes
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture uses the canonical
 // clock.Clock type and clock.MustHaveClock resolves via go/types.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/param_passes/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/param_passes/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/param_passes
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture can resolve
 // kernel/clock.MustHaveClock and exercise the type-aware positional-injection gate.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/selector_violates/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/selector_violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/selector_violates
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture can resolve
 // kernel/clock.MustHaveClock and exercise the type-aware positional-injection gate.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/struct_field_unexported_ok/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/struct_field_unexported_ok/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/struct_field_unexported_ok
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture uses the canonical
 // clock.Clock type for the typed predicate in sub-check C.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/struct_field_violates/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/struct_field_violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/struct_field_violates
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture uses the canonical
 // clock.Clock type for the typed predicate in sub-check C.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/withclock_violates/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/withclock_violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/withclock_violates
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture uses the canonical
 // clock.Clock type for the typed predicate in sub-check B.

--- a/tools/archtest/testdata/clock_positional_injection_fixtures/withfooclock_violates/go.mod
+++ b/tools/archtest/testdata/clock_positional_injection_fixtures/withfooclock_violates/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/clock_positional_injection/withfooclock_violates
 
-go 1.25.10
+go 1.25.11
 
 // Pin to the worktree's kernel/clock so the fixture uses the canonical
 // clock.Clock type for the typed predicate in sub-check B.

--- a/tools/archtest/testdata/healthz_violate/go.mod
+++ b/tools/archtest/testdata/healthz_violate/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/healthz_violate
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/bare_literal_arg_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/bare_literal_arg_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/bare_literal_arg_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/decl_bypass_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/decl_bypass_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/decl_bypass_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/invalid_value_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/invalid_value_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/invalid_value_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/newprobename_dynamic_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/newprobename_dynamic_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/newprobename_dynamic_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/non_funnel_register_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/non_funnel_register_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/non_funnel_register_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/phases_with_health_checker_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/phases_with_health_checker_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/phases_with_health_checker_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/reflect_bypass_const_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/reflect_bypass_const_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/reflect_bypass_const_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/reflect_bypass_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/reflect_bypass_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/reflect_bypass_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/string_cast_bypass_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/string_cast_bypass_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/string_cast_bypass_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/value_shape_double_underscore_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/value_shape_double_underscore_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/value_shape_double_underscore_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/value_shape_multi_const_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/value_shape_multi_const_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/value_shape_multi_const_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/probename_sealed_funnel_fixtures/value_shape_uppercase_red/go.mod
+++ b/tools/archtest/testdata/probename_sealed_funnel_fixtures/value_shape_uppercase_red/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/probename_sealed_funnel/value_shape_uppercase_red
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../../..
 

--- a/tools/archtest/testdata/projection_apply_hook_violate/go.mod
+++ b/tools/archtest/testdata/projection_apply_hook_violate/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/projection_apply_hook_violate
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../..
 

--- a/tools/archtest/testdata/projection_register_violate/go.mod
+++ b/tools/archtest/testdata/projection_register_violate/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/projection_register_violate
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../..
 

--- a/tools/archtest/testdata/webhook_hmac_violate/go.mod
+++ b/tools/archtest/testdata/webhook_hmac_violate/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/webhook_hmac_violate
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../..
 

--- a/tools/archtest/testdata/webhook_pipeline_violate/go.mod
+++ b/tools/archtest/testdata/webhook_pipeline_violate/go.mod
@@ -1,3 +1,3 @@
 module fixturetest/webhook_pipeline_violate
 
-go 1.25.10
+go 1.25.11

--- a/tools/archtest/testdata/webhook_signer_violate/go.mod
+++ b/tools/archtest/testdata/webhook_signer_violate/go.mod
@@ -1,3 +1,3 @@
 module fixturetest/webhook_signer_violate
 
-go 1.25.10
+go 1.25.11

--- a/tools/archtest/testdata/webhook_ssrf_violate/go.mod
+++ b/tools/archtest/testdata/webhook_ssrf_violate/go.mod
@@ -1,6 +1,6 @@
 module fixturetest/webhook_ssrf_violate
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/ghbvf/gocell => ../../../..
 


### PR DESCRIPTION
## Summary

The repo-wide **govulncheck** gate flipped red on every open PR — the live Go vuln DB gained two **standard-library** entries, both **Fixed in go1.25.11**, while `go.mod` pinned `go 1.25.10`:

| Vuln | Package | Issue |
|------|---------|-------|
| GO-2026-5039 | `net/textproto` | arbitrary inputs included in errors without escaping |
| GO-2026-5037 | `crypto/x509` | inefficient candidate hostname parsing |

Call traces run through `runtime/http/idempotency` + `pkg/errcode` (stdlib reachability) — not introduced by any feature PR. develop's earlier govulncheck run passed only because it executed before these DB entries were published.

## Fix

Bump the `go` directive to `1.25.11`. All CI jobs install Go via `actions/setup-go` with `go-version-file: go.mod`, so this installs go1.25.11 across the matrix → govulncheck analyzes the patched stdlib → green.

## Scope — root + all archtest fixture modules

Bumps **every** `go.mod` in the repo to `1.25.11`: the root module **and all 29 `tools/archtest/testdata/**/go.mod` fixture modules**.

> The fixtures are **not** optional churn. archtest loads its testdata fixture modules in the root module's toolchain context; a root(1.25.11)/fixture(1.25.10) go-directive **skew makes go/packages fail to load the fixtures**, so the rule sees 0 packages → 0 diagnostics → `diag.golden` set-comparison breaks (caught by `TestKernelClockLeafFallbackFixtures/violates` in the PR-time `verify-archtest-invariants.sh` gate: want 3 `clock.Real` diags, got 0). Every module directive must move together. (Reproduced + fix verified locally.)

## Verification
- [x] `go mod verify` → all modules verified
- [x] `go build ./...` → OK (local Go 1.26.1)
- [x] `bash hack/verify-archtest-invariants.sh` → `ok` (the 4-core PR-time gate that make-verify runs; previously red on the clock fixture, now green)
- govulncheck clears once CI installs go1.25.11.

> Note: the full nightly `go test ./tools/archtest/...` has some **pre-existing** failures unrelated to this bump (SCANNER-FRAMEWORK-USAGE / NO-MANUAL-CONTRACTSPEC / OUTBOX-HANDLERESULT-FACTORY / ERRCODE-PREFIX-OWNERSHIP / TEST-EVENTUALLY-FUNNEL — all referencing production/test files this PR does not touch). They are not part of the PR-time `make verify` gate (full archtest is `VERIFY_SKIP`-ped in PR CI) and are out of scope here.

Unblocks **#1526** (GAP-1 PR-6 gRPC codegen) and any other PR currently red on govulncheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)