### PR TITLE
feat(webhook): KERNEL-WEBHOOK-01 PR-6 — observability metrics + frozen-label/claimer archtests + closeout [#1161]

### DIFF
--- a/assemblies/corebundle/generated/metrics-schema.yaml
+++ b/assemblies/corebundle/generated/metrics-schema.yaml
@@ -569,3 +569,47 @@ metrics:
       help: Number of successful Vault token renewals.
       labels: []
       file: adapters/vault/transit_metrics.go
+    - name: webhook_deliveries_total
+      fqName: gocell_webhook_deliveries_total
+      namespace: gocell
+      type: counter
+      help: Total outbound webhook deliveries by outcome.
+      labels:
+        - result
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_delivery_duration_seconds
+      fqName: gocell_webhook_delivery_duration_seconds
+      namespace: gocell
+      type: histogram
+      help: Outbound webhook delivery wall-clock duration in seconds.
+      labels:
+        - source
+      buckets:
+        - ".05"
+        - ".1"
+        - ".25"
+        - ".5"
+        - "1"
+        - "2.5"
+        - "5"
+        - "10"
+        - "30"
+      file: kernel/webhook/metrics.go
+    - name: webhook_idempotency_hits_total
+      fqName: gocell_webhook_idempotency_hits_total
+      namespace: gocell
+      type: counter
+      help: Total inbound webhook duplicate deliveries deduplicated by the idempotency claimer.
+      labels:
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_signature_failures_total
+      fqName: gocell_webhook_signature_failures_total
+      namespace: gocell
+      type: counter
+      help: Total inbound webhook signature-verification failures by reason.
+      labels:
+        - source
+        - reason
+      file: kernel/webhook/metrics.go

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -1014,6 +1014,86 @@ specified series).
 
 ---
 
+## Webhook（KERNEL-WEBHOOK-01 PR-6）
+
+四个指标：`gocell_webhook_deliveries_total{result,source}`（发端投递结果）/
+`gocell_webhook_delivery_duration_seconds{source}`（发端时延）/
+`gocell_webhook_signature_failures_total{source,reason}`（收端验签失败）/
+`gocell_webhook_idempotency_hits_total{source}`（收端重复投递去重）。`result` 值集
+`{success, client_error, server_error, transport_error, blocked}`（冻结于
+`WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01`）；`reason` 值集
+`{missing_header, invalid_header, unknown_source, bad_signature, timestamp_expired}`。
+
+### WebhookDeliveryServerErrorRate
+
+下游 5xx 持续高比率 = 目标端点过载/故障（可重试，但持续高表示对端不可用）。
+
+```yaml
+- alert: GoCellWebhookDeliveryServerErrorRate
+  expr: |
+    sum by (source) (rate(gocell_webhook_deliveries_total{result="server_error"}[5m]))
+      / sum by (source) (rate(gocell_webhook_deliveries_total[5m])) > 0.2
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Webhook delivery 5xx rate high (source={{ $labels.source }})"
+    description: |
+      >20% of webhook deliveries to source={{ $labels.source }} returned 5xx over
+      10m. The dispatcher requeues these (standard-webhooks aligned), but a
+      sustained high ratio means the target endpoint is degraded. The result label
+      separates this from client_error (endpoint misconfiguration).
+```
+
+### WebhookDeliveryClientErrorRate
+
+4xx 持续高比率 = 端点配置/认证错误（与 5xx 区分是 status-aware result label 的核心价值）。
+
+```yaml
+- alert: GoCellWebhookDeliveryClientErrorRate
+  expr: |
+    sum by (source) (rate(gocell_webhook_deliveries_total{result="client_error"}[5m]))
+      / sum by (source) (rate(gocell_webhook_deliveries_total[5m])) > 0.2
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Webhook delivery 4xx rate high (source={{ $labels.source }})"
+    description: |
+      >20% of webhook deliveries to source={{ $labels.source }} returned 4xx over
+      10m — likely a target endpoint misconfiguration (auth, path, payload schema),
+      NOT a transient outage. Unlike server_error these keep failing on retry.
+```
+
+### WebhookSignatureFailureSpike
+
+验签失败速率突增 = 安全信号（密钥轮换错配、replay、或源未注册）。
+
+```yaml
+- alert: GoCellWebhookSignatureFailureSpike
+  expr: |
+    sum by (source, reason) (rate(gocell_webhook_signature_failures_total[5m])) > 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Webhook signature failures (source={{ $labels.source }} reason={{ $labels.reason }})"
+    description: |
+      Sustained webhook signature-verification failures. reason distinguishes
+      missing_header / invalid_header / unknown_source / bad_signature /
+      timestamp_expired. A bad_signature or timestamp_expired spike is a
+      key-rotation misconfiguration or replay signal; unknown_source means the
+      configured sourceID has no registered secret (server-side only — the wire
+      401 is uniform to avoid an enumeration oracle).
+```
+
+> **超时与时延分位**：`gocell_webhook_delivery_duration_seconds` 的最大 bucket（30s）等于
+> 默认 delivery timeout，故超时样本（`result=transport_error`，约 30s）钉在最后一个
+> bucket，`histogram_quantile` p99 在超时率高时会饱和在 30s。运维应将
+> `rate(...{result="transport_error"})` 计数器与 duration 分位联合判读，而非只看 p99。
+
+---
+
 ## 注意事项
 
 1. **fqName 单前缀**：所有规则中的指标名已包含 `gocell_` 前缀。若部署时 Prometheus

--- a/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
+++ b/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
@@ -481,3 +481,32 @@ make verify
 - `specs/516-webhook-dual-capability/data-model.md` — 5 实体 + 2 状态机
 - `specs/516-webhook-dual-capability/contracts/webhook-contract.md` — webhook contract kind schema 草图
 - `specs/516-webhook-dual-capability/analyze-report.md` — 跨制品一致性分析（含 Medium/Low findings）
+
+## Closeout（PR-6 落地，#1161）
+
+6 个 PR 全部合入。PR-6（observability + healthz + closeout）相对原 §3 PR-6 计划有经两轮激进自审 + 开源对标的实质偏离，逐条记录如下。
+
+### 交付内容
+
+| 项 | 状态 | 载体 |
+|----|------|------|
+| 4 个 OTel metrics | ✅ | `kernel/webhook/metrics.go`：`webhook_deliveries_total{result,source}` / `webhook_delivery_duration_seconds{source}` / `webhook_signature_failures_total{source,reason}` / `webhook_idempotency_hits_total{source}`。收集器在 kernel（镜像 `kernel/reconcile`），`Dispatcher.Handle`（发端，status-aware）+ runtime `Receiver.ServeHTTP`（收端）记录；bootstrap `autoWireWebhookMetricsCollector` 经 `autoWireCachedCollector` funnel 单源接线 phase5+phase6 |
+| `WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01` archtest | ✅ Medium | 双 sealed 枚举（`webhookDeliveryResult` 5 值 + `SignatureFailureReason` 5 值）按 TYPE 冻结 + `recordDelivery` callsite guard；Hard 路径并入 metricschema golden #1416 |
+| `WEBHOOK-IDEMPOTENCY-CLAIMER-01` archtest | ✅ Medium | type-keyed data-flow：`claimed.rcpt` 必须溯源自 `idempotency.Claimer.Claim`（object identity + method resolution，rename-proof）。**与计划假设的 `gocell:"required"` tag 形态不同**——receiver 用构造器 nil-guard；本规则锁 substance（claim 做真实幂等工作），与 PIPELINE-01 锁 ordering 正交 |
+| backlog `KERNEL-WEBHOOK-01` | ✅ | EPIC #831 关闭；follow-up issues 见下 |
+
+### 相对计划的偏离（激进自审 + 开源对标）
+
+- **healthz probes 全删**（计划列为 in-scope）：`webhook_receiver_ready`/`webhook_dispatcher_ready` 在当前架构 vacuous/synonymous（依赖已被 `redis_ready`/`postgres_ready`/`rabbitmq_ready` 覆盖，source store 启动期 eager 校验且运行时不可变），违反 observability.md「禁止同义/vacuous probe」。carve 到 follow-up（store 变运行时可变时加 `webhook_source_store_ready`）。
+- **result label status-aware 5 值**（非计划隐含的 disposition 折叠）：开源对标 Alertmanager（clientError/serverError 分）/ K8s admission（error_type）/ Convoy（Discarded）均保留 status 维度，折叠 4xx/5xx 丢 SLO 信号。值集 `{success, client_error, server_error, transport_error, blocked}`，时延 buckets 到 30s（standard-webhooks 超时量级）。
+- **不做 auditcore webhook 二次 redaction**（计划「若适用」行）：auditcore 已对所有订阅事件 payload 在 auditquery 出口统一 `RedactPayload`，webhook 敏感 key 已在 PR-1 入 pattern——无需额外工作。
+- **examples 真实 demo carve 到 follow-up**：webhook receiver `buildRouteGroup` 硬编 `cell.PrimaryListener`（JWT-gated）且未标 `Public`，故真实 assembly 中 webhook 路径被 JWT 拦截——可运行的真实 demo 需 webhook 专属 listener 或 Public 标记，属 PR-3 运行时范围而非 PR-6。cellgen→drain→RouteGroup→Router→signed-200 全链路已由 `TestPhase5DrainWebhookReceivers_EndToEnd`（真实链 + 合成 cell）+ cellgen golden fixtures 覆盖。
+
+### Follow-up issues（实施期开）
+
+1. Ed25519 / Vault Transit KMS 签名（pri-p3）
+2. Source secret 持久化 configcore/vault（pri-p2）
+3. Circuit-breaker 全状态机（pri-p3）
+4. Per-contract Claim TTL 配置（pri-p2，`receiver.go` 固定 24h doneTTL < provider 重试窗口）
+5. `webhook_source_store_ready` probe（pri-p3，store 变运行时可变时开）
+6. examples webhook demo（receive + dispatch）+ webhook listener auth 接线（pri-p2，含 PrimaryListener-JWT gap）

--- a/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
+++ b/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
@@ -493,7 +493,7 @@ make verify
 | 4 个 OTel metrics | ✅ | `kernel/webhook/metrics.go`：`webhook_deliveries_total{result,source}` / `webhook_delivery_duration_seconds{source}` / `webhook_signature_failures_total{source,reason}` / `webhook_idempotency_hits_total{source}`。收集器在 kernel（镜像 `kernel/reconcile`），`Dispatcher.Handle`（发端，status-aware）+ runtime `Receiver.ServeHTTP`（收端）记录；bootstrap `autoWireWebhookMetricsCollector` 经 `autoWireCachedCollector` funnel 单源接线 phase5+phase6 |
 | `WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01` archtest | ✅ Medium | 双 sealed 枚举（`webhookDeliveryResult` 5 值 + `SignatureFailureReason` 5 值）按 TYPE 冻结 + `recordDelivery` callsite guard；Hard 路径并入 metricschema golden #1416 |
 | `WEBHOOK-IDEMPOTENCY-CLAIMER-01` archtest | ✅ Medium | type-keyed data-flow：`claimed.rcpt` 必须溯源自 `idempotency.Claimer.Claim`（object identity + method resolution，rename-proof）。**与计划假设的 `gocell:"required"` tag 形态不同**——receiver 用构造器 nil-guard；本规则锁 substance（claim 做真实幂等工作），与 PIPELINE-01 锁 ordering 正交 |
-| backlog `KERNEL-WEBHOOK-01` | ✅ | EPIC #831 关闭；follow-up issues 见下 |
+| backlog `KERNEL-WEBHOOK-01` | PR-6 交付完成；EPIC #831 关闭**待人工裁定** | 6 个 PR 全合入 + follow-up issues #1539–#1544 全开；但 follow-up #1544（webhook receiver 在 JWT-gated PrimaryListener 上功能阻断）是 capability 级未竟项，EPIC 是否就此关闭由维护者决定。`docs/backlog/20260520/cap-x-cross.md` 是冻结快照，不编辑 |
 
 ### 相对计划的偏离（激进自审 + 开源对标）
 
@@ -502,11 +502,13 @@ make verify
 - **不做 auditcore webhook 二次 redaction**（计划「若适用」行）：auditcore 已对所有订阅事件 payload 在 auditquery 出口统一 `RedactPayload`，webhook 敏感 key 已在 PR-1 入 pattern——无需额外工作。
 - **examples 真实 demo carve 到 follow-up**：webhook receiver `buildRouteGroup` 硬编 `cell.PrimaryListener`（JWT-gated）且未标 `Public`，故真实 assembly 中 webhook 路径被 JWT 拦截——可运行的真实 demo 需 webhook 专属 listener 或 Public 标记，属 PR-3 运行时范围而非 PR-6。cellgen→drain→RouteGroup→Router→signed-200 全链路已由 `TestPhase5DrainWebhookReceivers_EndToEnd`（真实链 + 合成 cell）+ cellgen golden fixtures 覆盖。
 
-### Follow-up issues（实施期开）
+### Follow-up issues（已开）
 
-1. Ed25519 / Vault Transit KMS 签名（pri-p3）
-2. Source secret 持久化 configcore/vault（pri-p2）
-3. Circuit-breaker 全状态机（pri-p3）
-4. Per-contract Claim TTL 配置（pri-p2，`receiver.go` 固定 24h doneTTL < provider 重试窗口）
-5. `webhook_source_store_ready` probe（pri-p3，store 变运行时可变时开）
-6. examples webhook demo（receive + dispatch）+ webhook listener auth 接线（pri-p2，含 PrimaryListener-JWT gap）
+1. #1539 Ed25519 / Vault Transit KMS 签名（pri-p3）
+2. #1540 Source secret 持久化 configcore/vault（pri-p2）
+3. #1541 Circuit-breaker 全状态机（pri-p3）
+4. #1542 Per-contract Claim TTL 配置（pri-p2，`receiver.go` 固定 24h doneTTL < provider 重试窗口）
+5. #1543 `webhook_source_store_ready` probe（pri-p3，store 变运行时可变时开）
+6. **#1544 webhook receiver 在 JWT-gated PrimaryListener 上不可运行（功能阻断，非仅 demo）+ examples demo**（pri-p2）
+
+> #1544 是 review（产品维度）揭示的真实功能缺陷：`buildRouteGroup` 硬编 `cell.PrimaryListener` 且不标 `Public`，真实 assembly 中 webhook POST（携 HMAC 而非 JWT）被 JWT middleware 401 拦截。属 PR-3 运行时范围（webhook listener / Public 标记），非 PR-6 observability。详见 `runtime/webhook/doc.go` §"Known gap"。

--- a/examples/iotdevice/generated/metrics-schema.yaml
+++ b/examples/iotdevice/generated/metrics-schema.yaml
@@ -428,3 +428,39 @@ metrics:
         - cell
         - result
       file: runtime/observability/metrics/saga.go
+    - name: webhook_deliveries_total
+      type: counter
+      help: Total outbound webhook deliveries by outcome.
+      labels:
+        - result
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_delivery_duration_seconds
+      type: histogram
+      help: Outbound webhook delivery wall-clock duration in seconds.
+      labels:
+        - source
+      buckets:
+        - ".05"
+        - ".1"
+        - ".25"
+        - ".5"
+        - "1"
+        - "2.5"
+        - "5"
+        - "10"
+        - "30"
+      file: kernel/webhook/metrics.go
+    - name: webhook_idempotency_hits_total
+      type: counter
+      help: Total inbound webhook duplicate deliveries deduplicated by the idempotency claimer.
+      labels:
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_signature_failures_total
+      type: counter
+      help: Total inbound webhook signature-verification failures by reason.
+      labels:
+        - source
+        - reason
+      file: kernel/webhook/metrics.go

--- a/examples/orderfulfillment/generated/metrics-schema.yaml
+++ b/examples/orderfulfillment/generated/metrics-schema.yaml
@@ -268,3 +268,39 @@ metrics:
         - cell
         - result
       file: runtime/observability/metrics/saga.go
+    - name: webhook_deliveries_total
+      type: counter
+      help: Total outbound webhook deliveries by outcome.
+      labels:
+        - result
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_delivery_duration_seconds
+      type: histogram
+      help: Outbound webhook delivery wall-clock duration in seconds.
+      labels:
+        - source
+      buckets:
+        - ".05"
+        - ".1"
+        - ".25"
+        - ".5"
+        - "1"
+        - "2.5"
+        - "5"
+        - "10"
+        - "30"
+      file: kernel/webhook/metrics.go
+    - name: webhook_idempotency_hits_total
+      type: counter
+      help: Total inbound webhook duplicate deliveries deduplicated by the idempotency claimer.
+      labels:
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_signature_failures_total
+      type: counter
+      help: Total inbound webhook signature-verification failures by reason.
+      labels:
+        - source
+        - reason
+      file: kernel/webhook/metrics.go

--- a/examples/todoorder/generated/metrics-schema.yaml
+++ b/examples/todoorder/generated/metrics-schema.yaml
@@ -268,3 +268,39 @@ metrics:
         - cell
         - result
       file: runtime/observability/metrics/saga.go
+    - name: webhook_deliveries_total
+      type: counter
+      help: Total outbound webhook deliveries by outcome.
+      labels:
+        - result
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_delivery_duration_seconds
+      type: histogram
+      help: Outbound webhook delivery wall-clock duration in seconds.
+      labels:
+        - source
+      buckets:
+        - ".05"
+        - ".1"
+        - ".25"
+        - ".5"
+        - "1"
+        - "2.5"
+        - "5"
+        - "10"
+        - "30"
+      file: kernel/webhook/metrics.go
+    - name: webhook_idempotency_hits_total
+      type: counter
+      help: Total inbound webhook duplicate deliveries deduplicated by the idempotency claimer.
+      labels:
+        - source
+      file: kernel/webhook/metrics.go
+    - name: webhook_signature_failures_total
+      type: counter
+      help: Total inbound webhook signature-verification failures by reason.
+      labels:
+        - source
+        - reason
+      file: kernel/webhook/metrics.go

--- a/kernel/cell/listener.go
+++ b/kernel/cell/listener.go
@@ -40,4 +40,13 @@ var (
 	InternalListener = ListenerRef{"internal"}
 	// HealthListener is the dedicated listener for /healthz, /readyz, /metrics.
 	HealthListener = ListenerRef{"health"}
+	// WebhookListener is the dedicated listener for inbound webhook receive
+	// endpoints. Inbound webhooks authenticate at the application layer via HMAC
+	// signature verification inside the receiver (kernel/webhook), NOT via a
+	// transport auth chain — so its WithListener auth chain is auth.AuthNone{}.
+	// It is kept off PrimaryListener precisely because PrimaryListener typically
+	// carries a JWT chain that would 401 an HMAC-signed (non-JWT) webhook before
+	// it ever reaches the verifier. See .claude/rules/gocell/runtime-api.md
+	// §"单 listener 单 auth scheme".
+	WebhookListener = ListenerRef{"webhook"}
 )

--- a/kernel/cell/listener_test.go
+++ b/kernel/cell/listener_test.go
@@ -39,6 +39,12 @@ func TestListenerRef(t *testing.T) {
 			wantString: "health",
 			wantIsZero: false,
 		},
+		{
+			name:       "WebhookListener",
+			ref:        cell.WebhookListener,
+			wantString: "webhook",
+			wantIsZero: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/kernel/webhook/dispatcher.go
+++ b/kernel/webhook/dispatcher.go
@@ -42,6 +42,12 @@ type Dispatcher struct {
 	selector WebhookDispatchSelector
 	client   *http.Client
 	timeout  time.Duration
+	// recorder + source are the optional observability dependency (PR-6). The
+	// zero Metrics value disables every record (no-op); source is the {source}
+	// label, set together via WithMetrics. Each Dispatcher is bound to one source
+	// (buildConsumer constructs one per webhook-dispatch contract).
+	recorder Metrics
+	source   string
 }
 
 // DispatcherOption customizes a Dispatcher at construction time.
@@ -54,6 +60,16 @@ func WithDeliveryTimeout(d time.Duration) DispatcherOption {
 		if d > 0 {
 			dp.timeout = d
 		}
+	}
+}
+
+// WithMetrics injects the optional delivery observability recorder and the
+// {source} label this dispatcher records under. Omitting it leaves the zero
+// Metrics value, which records as a no-op (the disabled / NopProvider case).
+func WithMetrics(rec Metrics, source string) DispatcherOption {
+	return func(dp *Dispatcher) {
+		dp.recorder = rec
+		dp.source = source
 	}
 }
 
@@ -118,25 +134,60 @@ func NewDispatcher(
 func (d *Dispatcher) Handle(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 	req, fail := d.prepare(ctx, entry)
 	if req == nil {
+		// Prepare failed before any HTTP attempt (SSRF pre-flight reject /
+		// permanent or transient prepare failure): record the outcome but no
+		// duration sample (no delivery was attempted).
+		d.recorder.recordDelivery(ctx, d.source, dispositionResult(fail.Disposition))
 		return fail
 	}
 	deliveryID := entry.ID()
+	start := d.clk.Now()
 	resp, err := d.client.Do(req)
+	d.recorder.observeDeliveryDuration(ctx, d.source, d.clk.Now().Sub(start).Seconds())
 	if err != nil {
+		disp := Classify(0, err)
 		reason := transportReason(err)
-		result := mapDisposition(Classify(0, err), reason)
-		logDelivery(ctx, deliveryID, result.Disposition, reason)
-		return result
+		d.recorder.recordDelivery(ctx, d.source, dispositionResult(disp))
+		logDelivery(ctx, deliveryID, disp, reason)
+		return mapDisposition(disp, reason)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	summary := drainBodySummary(resp.Body)
 	disp := Classify(resp.StatusCode, nil)
+	d.recorder.recordDelivery(ctx, d.source, statusResult(resp.StatusCode))
 	if disp == outbox.DispositionAck {
 		return outbox.Ack()
 	}
 	reason := statusReason(resp.StatusCode, summary)
 	logDelivery(ctx, deliveryID, disp, reason)
 	return mapDisposition(disp, reason)
+}
+
+// dispositionResult maps a non-HTTP-response outcome (a prepare failure or a
+// transport fault) to the metric result label. A Reject disposition is the SSRF
+// pre-flight block / permanent prepare failure (deliveryBlocked); any other
+// disposition is a transient failure with no HTTP response (deliveryTransportError).
+func dispositionResult(disp outbox.Disposition) webhookDeliveryResult {
+	if disp == outbox.DispositionReject {
+		return deliveryBlocked
+	}
+	return deliveryTransportError
+}
+
+// statusResult maps a received HTTP status code to the metric result label. 2xx
+// is success; 5xx is a downstream-transient server_error; every other response
+// (4xx, and the rare 1xx/3xx that reaches here) is a client_error. 3xx is
+// normally intercepted by the SSRF redirect-deny and surfaces as a transport
+// fault instead, so it seldom lands in this branch.
+func statusResult(code int) webhookDeliveryResult {
+	switch {
+	case code >= 200 && code < 300:
+		return deliverySuccess
+	case code >= 500:
+		return deliveryServerError
+	default:
+		return deliveryClientError
+	}
 }
 
 // logDelivery emits a structured slog record for non-Ack delivery outcomes.

--- a/kernel/webhook/dispatcher_metrics_test.go
+++ b/kernel/webhook/dispatcher_metrics_test.go
@@ -73,15 +73,28 @@ func TestDispatcher_Handle_RecordsResultMetric(t *testing.T) {
 	}
 }
 
+// dispatchTransportTimeout is the per-attempt delivery timeout used by the
+// transport-error test: short enough that the client aborts the request while
+// the server handler is still blocked, forcing a transport fault.
+const dispatchTransportTimeout = 10 * time.Millisecond
+
 // TestDispatcher_Handle_TransportError_RecordsTransportResult asserts a transport
 // fault (timeout, no HTTP response) records result=transport_error and a
 // duration sample (the time spent before the failure).
 func TestDispatcher_Handle_TransportError_RecordsTransportResult(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
+	// The handler parks on a channel the test closes at teardown: the client's
+	// short delivery timeout fires first (forcing the transport fault) while the
+	// server goroutine stays blocked, and `defer close(done)` runs before
+	// `defer srv.Close()` (LIFO) so Close never waits on a stuck handler. This is
+	// deterministic with no wall-clock sleep (blocking on r.Context().Done() does
+	// NOT work — the HTTP/1.1 server does not cancel the request context promptly
+	// on a client timeout, which deadlocks srv.Close).
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-done
 	}))
 	defer srv.Close()
+	defer close(done)
 
 	p := newRecordingProvider()
 	m, err := RegisterMetrics(p)
@@ -89,7 +102,7 @@ func TestDispatcher_Handle_TransportError_RecordsTransportResult(t *testing.T) {
 
 	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
 		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL),
-		WithMetrics(m, "stripe"), WithDeliveryTimeout(10*time.Millisecond))
+		WithMetrics(m, "stripe"), WithDeliveryTimeout(dispatchTransportTimeout))
 	require.NoError(t, err)
 
 	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))

--- a/kernel/webhook/dispatcher_metrics_test.go
+++ b/kernel/webhook/dispatcher_metrics_test.go
@@ -1,0 +1,116 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDispatcher_Handle_RecordsResultMetric asserts Handle records
+// webhook_deliveries_total{result,source} with the status-aware result label
+// for each delivery-outcome class, and a duration sample when an HTTP attempt
+// was made.
+func TestDispatcher_Handle_RecordsResultMetric(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int    // HTTP status the fake target returns (0 = use SSRF target)
+		ssrfTarget  string // when non-empty, use this target with a no-loopback policy
+		wantResult  string
+		wantHTTPDur bool // whether a delivery-duration sample is expected
+	}{
+		{name: "2xx_success", status: http.StatusOK, wantResult: "success", wantHTTPDur: true},
+		{name: "4xx_client_error", status: http.StatusNotFound, wantResult: "client_error", wantHTTPDur: true},
+		{name: "5xx_server_error", status: http.StatusInternalServerError, wantResult: "server_error", wantHTTPDur: true},
+		{name: "ssrf_blocked", ssrfTarget: "http://169.254.169.254/latest/meta-data/", wantResult: "blocked", wantHTTPDur: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newRecordingProvider()
+			m, err := RegisterMetrics(p)
+			require.NoError(t, err)
+
+			var target string
+			var policy *SafePolicy
+			if tc.ssrfTarget != "" {
+				target = tc.ssrfTarget
+				policy = NewSafePolicy() // no loopback → link-local target blocked
+			} else {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(tc.status)
+				}))
+				defer srv.Close()
+				target = srv.URL
+				policy = NewSafePolicy(WithAllowLoopback())
+			}
+
+			d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+				dispatchTestSigner(t), policy, staticSelector(target),
+				WithMetrics(m, "stripe"))
+			require.NoError(t, err)
+
+			d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
+
+			got := p.counterValue("webhook_deliveries_total",
+				kernelmetrics.Labels{"result": tc.wantResult, "source": "stripe"})
+			require.Equal(t, int64(1), got, "deliveries_total{result=%q} should be 1", tc.wantResult)
+
+			durCount := p.histogramCount("webhook_delivery_duration_seconds",
+				kernelmetrics.Labels{"source": "stripe"})
+			if tc.wantHTTPDur {
+				require.Equal(t, int64(1), durCount, "expected one delivery-duration sample")
+			} else {
+				require.Equal(t, int64(0), durCount, "prepare-failure must not record a delivery-duration sample")
+			}
+		})
+	}
+}
+
+// TestDispatcher_Handle_TransportError_RecordsTransportResult asserts a transport
+// fault (timeout, no HTTP response) records result=transport_error and a
+// duration sample (the time spent before the failure).
+func TestDispatcher_Handle_TransportError_RecordsTransportResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	require.NoError(t, err)
+
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL),
+		WithMetrics(m, "stripe"), WithDeliveryTimeout(10*time.Millisecond))
+	require.NoError(t, err)
+
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
+	require.Equal(t, outbox.DispositionRequeue, res.Disposition)
+
+	got := p.counterValue("webhook_deliveries_total",
+		kernelmetrics.Labels{"result": "transport_error", "source": "stripe"})
+	require.Equal(t, int64(1), got)
+	require.Equal(t, int64(1), p.histogramCount("webhook_delivery_duration_seconds",
+		kernelmetrics.Labels{"source": "stripe"}))
+}
+
+// TestDispatcher_Handle_NoMetrics_NoPanic asserts a dispatcher constructed
+// without WithMetrics (zero recorder) records as a no-op.
+func TestDispatcher_Handle_NoMetrics_NoPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	d, err := NewDispatcher(clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
+	require.NoError(t, err)
+	res := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
+	require.Equal(t, outbox.DispositionAck, res.Disposition)
+}

--- a/kernel/webhook/dispatcher_metrics_test.go
+++ b/kernel/webhook/dispatcher_metrics_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
-	"github.com/stretchr/testify/require"
 )
 
 // TestDispatcher_Handle_RecordsResultMetric asserts Handle records

--- a/kernel/webhook/metrics.go
+++ b/kernel/webhook/metrics.go
@@ -1,0 +1,239 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// Webhook metric family names. Single source so the Dispatcher (dispatch side),
+// the runtime Receiver (receive side), RegisterMetrics, and any dashboard/alert
+// reference the same identifiers.
+//
+// Naming aligns with the OTel webhook-delivery convention
+// (webhook.delivery.*) and Convoy's convoy_event_delivery_* family; see the
+// PR-6 open-source benchmark.
+const (
+	metricWebhookDeliveriesTotal   = "webhook_deliveries_total"
+	metricWebhookDeliveryDuration  = "webhook_delivery_duration_seconds"
+	metricWebhookSignatureFailures = "webhook_signature_failures_total"
+	metricWebhookIdempotencyHits   = "webhook_idempotency_hits_total"
+)
+
+// Webhook metric label names.
+const (
+	labelResult = "result"
+	labelSource = "source"
+	labelReason = "reason"
+)
+
+// webhookDeliveryResult is the sealed (package-private) string type for the
+// webhook_deliveries_total{result=...} label. recordDelivery deals only in
+// webhookDeliveryResult, so the value set is enumerable by TYPE (not by name
+// prefix). The remaining hole — an untyped string literal is assignable to
+// webhookDeliveryResult — is closed downstream by the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 callsite guard, which bans any
+// recordDelivery argument that is not one of the declared delivery* consts.
+//
+// The taxonomy is status-aware rather than a 3-way disposition collapse: the
+// kernel Classify maps every non-2xx + transient transport to Requeue, but a
+// metric that folds 4xx and 5xx into one bucket loses SLO signal (an endpoint
+// misconfiguration flood vs. a downstream outage). Aligned to Alertmanager
+// notify (clientError/serverError split), Kubernetes admission webhook
+// (error_type), and Convoy (Discarded). The label therefore carries finer
+// information than the outbox Disposition — the same shape as Convoy's
+// status+http_status_code and K8s' code+rejected dimensions.
+type webhookDeliveryResult string
+
+const (
+	// deliverySuccess: a 2xx response (Disposition=Ack).
+	deliverySuccess webhookDeliveryResult = "success"
+	// deliveryClientError: a 4xx (or other non-2xx HTTP) response — endpoint
+	// config/auth issue (Disposition=Requeue, standard-webhooks aligned).
+	deliveryClientError webhookDeliveryResult = "client_error"
+	// deliveryServerError: a 5xx response — downstream transient
+	// (Disposition=Requeue).
+	deliveryServerError webhookDeliveryResult = "server_error"
+	// deliveryTransportError: connection failure / timeout with no HTTP
+	// response received (Disposition=Requeue).
+	deliveryTransportError webhookDeliveryResult = "transport_error"
+	// deliveryBlocked: SSRF pre-flight reject or a permanent prepare failure
+	// (Disposition=Reject → DLX).
+	deliveryBlocked webhookDeliveryResult = "blocked"
+)
+
+// SignatureFailureReason is the exported sealed string type for the
+// webhook_signature_failures_total{reason=...} label. It is exported because
+// the receive-side classification happens in runtime/webhook (the Receiver's
+// verify step), which returns a typed reason that flows into
+// [Metrics.RecordSignatureFailure]. The value set is enumerable by TYPE; the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 archtest freezes it.
+//
+// The wire 401 is deliberately uniform for ReasonUnknownSource and
+// ReasonBadSignature (anti-enumeration oracle, see the Receiver verify godoc),
+// but the server-side metric distinguishes them — the metric is not a wire
+// oracle, and missing/invalid/unknown/bad/expired enable distinct alerts (the
+// Kubernetes admission error_type / Vault audit reason precedent).
+type SignatureFailureReason string
+
+const (
+	// ReasonMissingHeader: one or more required signature headers were absent.
+	ReasonMissingHeader SignatureFailureReason = "missing_header"
+	// ReasonInvalidHeader: a header was present but unparseable (bad delivery
+	// id, non-integer timestamp).
+	ReasonInvalidHeader SignatureFailureReason = "invalid_header"
+	// ReasonUnknownSource: the configured source id was not registered in the
+	// source store.
+	ReasonUnknownSource SignatureFailureReason = "unknown_source"
+	// ReasonBadSignature: the HMAC did not match for any candidate secret.
+	ReasonBadSignature SignatureFailureReason = "bad_signature"
+	// ReasonTimestampExpired: the timestamp skew exceeded the tolerance window.
+	ReasonTimestampExpired SignatureFailureReason = "timestamp_expired"
+)
+
+// webhookDeliveryDurationBuckets are explicit upper bounds (seconds) for
+// webhook_delivery_duration_seconds. Outbound webhook delivery spans fast
+// successes (50–500ms) to slow responses near the delivery timeout (default
+// 30s, the standard-webhooks 15–30s recommendation). The bucket set therefore
+// extends to 30s, mirroring the Kubernetes admission-webhook histogram (which
+// adds 10/25s for webhook timeouts) rather than the kernel reconcile buckets
+// (sub-ms→minute internal work). Supplied explicitly because the metric leaves
+// kernel (HistogramOpts godoc: callers should not rely on adapter defaults).
+var webhookDeliveryDurationBuckets = []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30}
+
+// Metrics holds the optional pre-bound webhook instruments. A nil field
+// disables that instrument (every record method nil-checks before recording),
+// so a zero Metrics value — the disabled / NopProvider case — is a safe no-op.
+// Build via RegisterMetrics at the composition root (bootstrap auto-wire) and
+// inject into both the Dispatcher (dispatch side) and the runtime Receiver
+// (receive side); one instance serves both, the instrument sets are disjoint.
+type Metrics struct {
+	// Deliveries counts outbound delivery outcomes, labels {result, source}.
+	Deliveries kernelmetrics.CounterVec
+	// DeliveryDuration observes outbound delivery wall-clock seconds, labels {source}.
+	DeliveryDuration kernelmetrics.HistogramVec
+	// SignatureFailures counts inbound signature-verification failures, labels {source, reason}.
+	SignatureFailures kernelmetrics.CounterVec
+	// IdempotencyHits counts inbound duplicate deliveries (claim already done /
+	// in-flight), labels {source}.
+	IdempotencyHits kernelmetrics.CounterVec
+}
+
+// errRegisterMetricFmt is the format string for metric registration errors.
+// The two verbs are the metric name and the underlying error.
+const errRegisterMetricFmt = "webhook: register %s: %w"
+
+// RegisterMetrics registers the four webhook instruments on p with canonical
+// names, labels, and buckets, returning them bundled. It is the single source
+// for webhook metric identity; the bootstrap auto-wire calls it once and injects
+// the result into the Dispatcher and the runtime Receiver.
+func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
+	deliveries, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name:       metricWebhookDeliveriesTotal,
+		Help:       "Total outbound webhook deliveries by outcome.",
+		LabelNames: []string{labelResult, labelSource},
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricWebhookDeliveriesTotal, err)
+	}
+	duration, err := p.HistogramVec(kernelmetrics.HistogramOpts{
+		Name:       metricWebhookDeliveryDuration,
+		Help:       "Outbound webhook delivery wall-clock duration in seconds.",
+		LabelNames: []string{labelSource},
+		Buckets:    webhookDeliveryDurationBuckets,
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricWebhookDeliveryDuration, err)
+	}
+	sigFailures, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name:       metricWebhookSignatureFailures,
+		Help:       "Total inbound webhook signature-verification failures by reason.",
+		LabelNames: []string{labelSource, labelReason},
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricWebhookSignatureFailures, err)
+	}
+	idempotencyHits, err := p.CounterVec(kernelmetrics.CounterOpts{
+		Name:       metricWebhookIdempotencyHits,
+		Help:       "Total inbound webhook duplicate deliveries deduplicated by the idempotency claimer.",
+		LabelNames: []string{labelSource},
+	})
+	if err != nil {
+		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricWebhookIdempotencyHits, err)
+	}
+	return Metrics{
+		Deliveries:        deliveries,
+		DeliveryDuration:  duration,
+		SignatureFailures: sigFailures,
+		IdempotencyHits:   idempotencyHits,
+	}, nil
+}
+
+// preflight probes each non-nil instrument's With() with a representative label
+// set, under recover. With() panics (MustValidateLabels) on a label-set
+// mismatch; catching it here turns a misconfigured vec into a fail-fast wiring
+// error instead of a crash on first record. The recovered value is redacted
+// before wrapping so a credential-bearing panic string cannot leak. Mirrors
+// reconcile.Metrics.preflight.
+func (m Metrics) preflight() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			redacted := redaction.RedactError(fmt.Errorf("%v", r))
+			err = fmt.Errorf("webhook: metrics label set invalid: %w", redacted)
+		}
+	}()
+	if m.Deliveries != nil {
+		_ = m.Deliveries.With(kernelmetrics.Labels{labelResult: string(deliverySuccess), labelSource: "_preflight"})
+	}
+	if m.DeliveryDuration != nil {
+		_ = m.DeliveryDuration.With(kernelmetrics.Labels{labelSource: "_preflight"})
+	}
+	if m.SignatureFailures != nil {
+		_ = m.SignatureFailures.With(kernelmetrics.Labels{labelSource: "_preflight", labelReason: string(ReasonBadSignature)})
+	}
+	if m.IdempotencyHits != nil {
+		_ = m.IdempotencyHits.With(kernelmetrics.Labels{labelSource: "_preflight"})
+	}
+	return nil
+}
+
+// recordDelivery increments webhook_deliveries_total{result, source} when wired.
+// The result parameter is the sealed webhookDeliveryResult type; the archtest
+// callsite guard (WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01) additionally bans any
+// caller passing a value that is not one of the declared delivery* consts.
+func (m Metrics) recordDelivery(ctx context.Context, source string, result webhookDeliveryResult) {
+	if m.Deliveries == nil {
+		return
+	}
+	m.Deliveries.With(kernelmetrics.Labels{labelResult: string(result), labelSource: source}).Inc(ctx)
+}
+
+// observeDeliveryDuration records webhook_delivery_duration_seconds{source} when wired.
+func (m Metrics) observeDeliveryDuration(ctx context.Context, source string, seconds float64) {
+	if m.DeliveryDuration == nil {
+		return
+	}
+	m.DeliveryDuration.With(kernelmetrics.Labels{labelSource: source}).Observe(ctx, seconds)
+}
+
+// RecordSignatureFailure increments webhook_signature_failures_total{source, reason}
+// when wired. Called by the runtime Receiver after a verification failure with
+// the typed reason its verify step classified.
+func (m Metrics) RecordSignatureFailure(ctx context.Context, source string, reason SignatureFailureReason) {
+	if m.SignatureFailures == nil {
+		return
+	}
+	m.SignatureFailures.With(kernelmetrics.Labels{labelSource: source, labelReason: string(reason)}).Inc(ctx)
+}
+
+// RecordIdempotencyHit increments webhook_idempotency_hits_total{source} when
+// wired. Called by the runtime Receiver when a delivery is a known duplicate
+// (claim already done or in-flight).
+func (m Metrics) RecordIdempotencyHit(ctx context.Context, source string) {
+	if m.IdempotencyHits == nil {
+		return
+	}
+	m.IdempotencyHits.With(kernelmetrics.Labels{labelSource: source}).Inc(ctx)
+}

--- a/kernel/webhook/metrics.go
+++ b/kernel/webhook/metrics.go
@@ -109,16 +109,27 @@ var webhookDeliveryDurationBuckets = []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 
 // Build via RegisterMetrics at the composition root (bootstrap auto-wire) and
 // inject into both the Dispatcher (dispatch side) and the runtime Receiver
 // (receive side); one instance serves both, the instrument sets are disjoint.
+//
+// The instrument fields are intentionally UNEXPORTED. This seals the upstream of
+// the WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 funnel: outside kernel/webhook the
+// only metric-write surface is the record* methods below (recordDelivery /
+// observeDeliveryDuration / RecordSignatureFailure / RecordIdempotencyHit), which
+// take the sealed typed label enums — there is no `m.Deliveries.With(Labels{...})`
+// escape hatch for a holder to write an off-set label value. Within the package a
+// new struct cannot be populated except by RegisterMetrics (the sole constructor),
+// and the WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 callsite guard locks the
+// `.With(...)` calls to the record* method bodies. See
+// tools/archtest/webhook_metric_label_values_frozen_test.go.
 type Metrics struct {
-	// Deliveries counts outbound delivery outcomes, labels {result, source}.
-	Deliveries kernelmetrics.CounterVec
-	// DeliveryDuration observes outbound delivery wall-clock seconds, labels {source}.
-	DeliveryDuration kernelmetrics.HistogramVec
-	// SignatureFailures counts inbound signature-verification failures, labels {source, reason}.
-	SignatureFailures kernelmetrics.CounterVec
-	// IdempotencyHits counts inbound duplicate deliveries (claim already done /
+	// deliveries counts outbound delivery outcomes, labels {result, source}.
+	deliveries kernelmetrics.CounterVec
+	// deliveryDuration observes outbound delivery wall-clock seconds, labels {source}.
+	deliveryDuration kernelmetrics.HistogramVec
+	// signatureFailures counts inbound signature-verification failures, labels {source, reason}.
+	signatureFailures kernelmetrics.CounterVec
+	// idempotencyHits counts inbound duplicate deliveries (claim already done /
 	// in-flight), labels {source}.
-	IdempotencyHits kernelmetrics.CounterVec
+	idempotencyHits kernelmetrics.CounterVec
 }
 
 // errRegisterMetricFmt is the format string for metric registration errors.
@@ -164,10 +175,10 @@ func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
 		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricWebhookIdempotencyHits, err)
 	}
 	m := Metrics{
-		Deliveries:        deliveries,
-		DeliveryDuration:  duration,
-		SignatureFailures: sigFailures,
-		IdempotencyHits:   idempotencyHits,
+		deliveries:        deliveries,
+		deliveryDuration:  duration,
+		signatureFailures: sigFailures,
+		idempotencyHits:   idempotencyHits,
 	}
 	// Validate the label sets at registration time (fail-fast). A label-set
 	// mismatch on a just-registered vec would otherwise panic at first record
@@ -192,17 +203,17 @@ func (m Metrics) preflight() (err error) {
 			err = fmt.Errorf("webhook: metrics label set invalid: %w", redacted)
 		}
 	}()
-	if m.Deliveries != nil {
-		_ = m.Deliveries.With(kernelmetrics.Labels{labelResult: string(deliverySuccess), labelSource: "_preflight"})
+	if m.deliveries != nil {
+		_ = m.deliveries.With(kernelmetrics.Labels{labelResult: string(deliverySuccess), labelSource: "_preflight"})
 	}
-	if m.DeliveryDuration != nil {
-		_ = m.DeliveryDuration.With(kernelmetrics.Labels{labelSource: "_preflight"})
+	if m.deliveryDuration != nil {
+		_ = m.deliveryDuration.With(kernelmetrics.Labels{labelSource: "_preflight"})
 	}
-	if m.SignatureFailures != nil {
-		_ = m.SignatureFailures.With(kernelmetrics.Labels{labelSource: "_preflight", labelReason: string(ReasonBadSignature)})
+	if m.signatureFailures != nil {
+		_ = m.signatureFailures.With(kernelmetrics.Labels{labelSource: "_preflight", labelReason: string(ReasonBadSignature)})
 	}
-	if m.IdempotencyHits != nil {
-		_ = m.IdempotencyHits.With(kernelmetrics.Labels{labelSource: "_preflight"})
+	if m.idempotencyHits != nil {
+		_ = m.idempotencyHits.With(kernelmetrics.Labels{labelSource: "_preflight"})
 	}
 	return nil
 }
@@ -212,36 +223,36 @@ func (m Metrics) preflight() (err error) {
 // callsite guard (WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01) additionally bans any
 // caller passing a value that is not one of the declared delivery* consts.
 func (m Metrics) recordDelivery(ctx context.Context, source string, result webhookDeliveryResult) {
-	if m.Deliveries == nil {
+	if m.deliveries == nil {
 		return
 	}
-	m.Deliveries.With(kernelmetrics.Labels{labelResult: string(result), labelSource: source}).Inc(ctx)
+	m.deliveries.With(kernelmetrics.Labels{labelResult: string(result), labelSource: source}).Inc(ctx)
 }
 
 // observeDeliveryDuration records webhook_delivery_duration_seconds{source} when wired.
 func (m Metrics) observeDeliveryDuration(ctx context.Context, source string, seconds float64) {
-	if m.DeliveryDuration == nil {
+	if m.deliveryDuration == nil {
 		return
 	}
-	m.DeliveryDuration.With(kernelmetrics.Labels{labelSource: source}).Observe(ctx, seconds)
+	m.deliveryDuration.With(kernelmetrics.Labels{labelSource: source}).Observe(ctx, seconds)
 }
 
 // RecordSignatureFailure increments webhook_signature_failures_total{source, reason}
 // when wired. Called by the runtime Receiver after a verification failure with
 // the typed reason its verify step classified.
 func (m Metrics) RecordSignatureFailure(ctx context.Context, source string, reason SignatureFailureReason) {
-	if m.SignatureFailures == nil {
+	if m.signatureFailures == nil {
 		return
 	}
-	m.SignatureFailures.With(kernelmetrics.Labels{labelSource: source, labelReason: string(reason)}).Inc(ctx)
+	m.signatureFailures.With(kernelmetrics.Labels{labelSource: source, labelReason: string(reason)}).Inc(ctx)
 }
 
 // RecordIdempotencyHit increments webhook_idempotency_hits_total{source} when
 // wired. Called by the runtime Receiver when a delivery is a known duplicate
 // (claim already done or in-flight).
 func (m Metrics) RecordIdempotencyHit(ctx context.Context, source string) {
-	if m.IdempotencyHits == nil {
+	if m.idempotencyHits == nil {
 		return
 	}
-	m.IdempotencyHits.With(kernelmetrics.Labels{labelSource: source}).Inc(ctx)
+	m.idempotencyHits.With(kernelmetrics.Labels{labelSource: source}).Inc(ctx)
 }

--- a/kernel/webhook/metrics.go
+++ b/kernel/webhook/metrics.go
@@ -163,12 +163,20 @@ func RegisterMetrics(p kernelmetrics.Provider) (Metrics, error) {
 	if err != nil {
 		return Metrics{}, fmt.Errorf(errRegisterMetricFmt, metricWebhookIdempotencyHits, err)
 	}
-	return Metrics{
+	m := Metrics{
 		Deliveries:        deliveries,
 		DeliveryDuration:  duration,
 		SignatureFailures: sigFailures,
 		IdempotencyHits:   idempotencyHits,
-	}, nil
+	}
+	// Validate the label sets at registration time (fail-fast). A label-set
+	// mismatch on a just-registered vec would otherwise panic at first record
+	// in a worker goroutine; catching it here turns it into a startup error.
+	// preflight uses a placeholder source, so no runtime data is needed.
+	if err := m.preflight(); err != nil {
+		return Metrics{}, err
+	}
+	return m, nil
 }
 
 // preflight probes each non-nil instrument's With() with a representative label

--- a/kernel/webhook/metrics_test.go
+++ b/kernel/webhook/metrics_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
@@ -15,8 +16,8 @@ func TestRegisterWebhookMetrics_WiresFour(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterMetrics: %v", err)
 	}
-	if m.Deliveries == nil || m.DeliveryDuration == nil ||
-		m.SignatureFailures == nil || m.IdempotencyHits == nil {
+	if m.deliveries == nil || m.deliveryDuration == nil ||
+		m.signatureFailures == nil || m.idempotencyHits == nil {
 		t.Fatalf("RegisterMetrics left a nil instrument: %+v", m)
 	}
 	wantLabels := map[string][]string{
@@ -133,6 +134,29 @@ func TestWebhookMetrics_PreflightClean(t *testing.T) {
 	}
 }
 
+// TestWebhookMetrics_DeliveryDurationBucketsFrozen asserts the EXACT bucket
+// boundaries RegisterMetrics registers for webhook_delivery_duration_seconds
+// (F5). These buckets are an operational contract — dashboards, SLO burn-rate
+// rules, and histogram_quantile() recording rules pin to these le boundaries, so
+// an accidental edit (a dropped 30s tail, a reordered split) would silently break
+// latency panels. The assertion is against the registered slice (what the
+// provider received), not just the package var, so it also catches a future
+// refactor that passes a different slice to HistogramVec. Compared against an
+// independent hardcoded golden (anti-tautology): update both in the same PR if
+// the bucket contract intentionally changes, alongside the dashboards/alerts.
+func TestWebhookMetrics_DeliveryDurationBucketsFrozen(t *testing.T) {
+	p := newRecordingProvider()
+	if _, err := RegisterMetrics(p); err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	want := []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30}
+	got := p.bucketsOf("webhook_delivery_duration_seconds")
+	if !slices.Equal(got, want) {
+		t.Errorf("webhook_delivery_duration_seconds buckets = %v, want %v "+
+			"(ops contract: update dashboards/alerts + this golden together)", got, want)
+	}
+}
+
 // --- recordingProvider: in-memory metrics.Provider spy for webhook tests. ---
 
 // recordingProvider embeds NopProvider so the unused GaugeVec / Unregister
@@ -158,9 +182,22 @@ func (p *recordingProvider) CounterVec(opts kernelmetrics.CounterOpts) (kernelme
 }
 
 func (p *recordingProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
-	v := &recordingHistogramVec{labels: append([]string(nil), opts.LabelNames...), obs: map[string]int64{}}
+	v := &recordingHistogramVec{
+		labels:  append([]string(nil), opts.LabelNames...),
+		buckets: append([]float64(nil), opts.Buckets...),
+		obs:     map[string]int64{},
+	}
 	p.histograms[opts.Name] = v
 	return v, nil
+}
+
+// bucketsOf returns the exact bucket boundaries RegisterMetrics passed to the
+// provider for the named histogram (the registered ops contract), or nil.
+func (p *recordingProvider) bucketsOf(name string) []float64 {
+	if h, ok := p.histograms[name]; ok {
+		return h.buckets
+	}
+	return nil
 }
 
 func (p *recordingProvider) labelsOf(name string) []string {
@@ -209,8 +246,9 @@ func (c *recordingCounter) Inc(_ context.Context)            { c.vec.obs[c.key]+
 func (c *recordingCounter) Add(_ context.Context, n float64) { c.vec.obs[c.key] += int64(n) }
 
 type recordingHistogramVec struct {
-	labels []string
-	obs    map[string]int64
+	labels  []string
+	buckets []float64
+	obs     map[string]int64
 }
 
 func (v *recordingHistogramVec) Registered() bool { return true }

--- a/kernel/webhook/metrics_test.go
+++ b/kernel/webhook/metrics_test.go
@@ -1,0 +1,251 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+)
+
+// TestRegisterWebhookMetrics_WiresFour asserts RegisterMetrics registers all
+// four webhook instruments with the canonical names and label sets.
+func TestRegisterWebhookMetrics_WiresFour(t *testing.T) {
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	if m.Deliveries == nil || m.DeliveryDuration == nil ||
+		m.SignatureFailures == nil || m.IdempotencyHits == nil {
+		t.Fatalf("RegisterMetrics left a nil instrument: %+v", m)
+	}
+	wantLabels := map[string][]string{
+		"webhook_deliveries_total":          {"result", "source"},
+		"webhook_delivery_duration_seconds": {"source"},
+		"webhook_signature_failures_total":  {"source", "reason"},
+		"webhook_idempotency_hits_total":    {"source"},
+	}
+	for name, want := range wantLabels {
+		got := p.labelsOf(name)
+		if !equalStrings(got, want) {
+			t.Errorf("metric %q labels = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// TestWebhookMetrics_RecordDelivery asserts each frozen delivery-result value
+// increments webhook_deliveries_total{result,source}.
+func TestWebhookMetrics_RecordDelivery(t *testing.T) {
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	results := []webhookDeliveryResult{
+		deliverySuccess, deliveryClientError, deliveryServerError,
+		deliveryTransportError, deliveryBlocked,
+	}
+	ctx := context.Background()
+	for _, r := range results {
+		m.recordDelivery(ctx, "stripe", r)
+		got := p.counterValue("webhook_deliveries_total",
+			kernelmetrics.Labels{"result": string(r), "source": "stripe"})
+		if got != 1 {
+			t.Errorf("recordDelivery(%q): counter = %d, want 1", r, got)
+		}
+	}
+}
+
+// TestWebhookMetrics_ObserveDeliveryDuration asserts the histogram observes one
+// sample per call under {source}.
+func TestWebhookMetrics_ObserveDeliveryDuration(t *testing.T) {
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	m.observeDeliveryDuration(context.Background(), "stripe", 0.42)
+	if c := p.histogramCount("webhook_delivery_duration_seconds",
+		kernelmetrics.Labels{"source": "stripe"}); c != 1 {
+		t.Errorf("histogram count = %d, want 1", c)
+	}
+}
+
+// TestWebhookMetrics_RecordSignatureFailure asserts each frozen reason value
+// increments webhook_signature_failures_total{source,reason}.
+func TestWebhookMetrics_RecordSignatureFailure(t *testing.T) {
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	reasons := []SignatureFailureReason{
+		ReasonMissingHeader, ReasonInvalidHeader, ReasonUnknownSource,
+		ReasonBadSignature, ReasonTimestampExpired,
+	}
+	ctx := context.Background()
+	for _, r := range reasons {
+		m.RecordSignatureFailure(ctx, "stripe", r)
+		got := p.counterValue("webhook_signature_failures_total",
+			kernelmetrics.Labels{"source": "stripe", "reason": string(r)})
+		if got != 1 {
+			t.Errorf("RecordSignatureFailure(%q): counter = %d, want 1", r, got)
+		}
+	}
+}
+
+// TestWebhookMetrics_RecordIdempotencyHit asserts the duplicate-delivery counter
+// increments under {source}.
+func TestWebhookMetrics_RecordIdempotencyHit(t *testing.T) {
+	p := newRecordingProvider()
+	m, err := RegisterMetrics(p)
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	m.RecordIdempotencyHit(context.Background(), "stripe")
+	if got := p.counterValue("webhook_idempotency_hits_total",
+		kernelmetrics.Labels{"source": "stripe"}); got != 1 {
+		t.Errorf("idempotency hit counter = %d, want 1", got)
+	}
+}
+
+// TestWebhookMetrics_NilInstrumentsNoPanic asserts the zero Metrics value (all
+// instruments nil — the disabled/NopProvider case) records as a no-op without
+// panicking.
+func TestWebhookMetrics_NilInstrumentsNoPanic(t *testing.T) {
+	var m Metrics
+	ctx := context.Background()
+	m.recordDelivery(ctx, "s", deliverySuccess)
+	m.observeDeliveryDuration(ctx, "s", 1.0)
+	m.RecordSignatureFailure(ctx, "s", ReasonBadSignature)
+	m.RecordIdempotencyHit(ctx, "s")
+}
+
+// TestWebhookMetrics_PreflightClean asserts RegisterMetrics' canonical label
+// sets validate without panic.
+func TestWebhookMetrics_PreflightClean(t *testing.T) {
+	m, err := RegisterMetrics(newRecordingProvider())
+	if err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	if err := m.preflight(); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+}
+
+// --- recordingProvider: in-memory metrics.Provider spy for webhook tests. ---
+
+type recordingProvider struct {
+	counters   map[string]*recordingCounterVec
+	histograms map[string]*recordingHistogramVec
+}
+
+func newRecordingProvider() *recordingProvider {
+	return &recordingProvider{
+		counters:   map[string]*recordingCounterVec{},
+		histograms: map[string]*recordingHistogramVec{},
+	}
+}
+
+func (p *recordingProvider) CounterVec(opts kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
+	v := &recordingCounterVec{labels: append([]string(nil), opts.LabelNames...), obs: map[string]int64{}}
+	p.counters[opts.Name] = v
+	return v, nil
+}
+
+func (p *recordingProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
+	v := &recordingHistogramVec{labels: append([]string(nil), opts.LabelNames...), obs: map[string]int64{}}
+	p.histograms[opts.Name] = v
+	return v, nil
+}
+
+func (p *recordingProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
+	return nil, nil
+}
+
+func (p *recordingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
+
+func (p *recordingProvider) labelsOf(name string) []string {
+	if c, ok := p.counters[name]; ok {
+		return c.labels
+	}
+	if h, ok := p.histograms[name]; ok {
+		return h.labels
+	}
+	return nil
+}
+
+func (p *recordingProvider) counterValue(name string, l kernelmetrics.Labels) int64 {
+	c, ok := p.counters[name]
+	if !ok {
+		return -1
+	}
+	return c.obs[labelKey(c.labels, l)]
+}
+
+func (p *recordingProvider) histogramCount(name string, l kernelmetrics.Labels) int64 {
+	h, ok := p.histograms[name]
+	if !ok {
+		return -1
+	}
+	return h.obs[labelKey(h.labels, l)]
+}
+
+type recordingCounterVec struct {
+	labels []string
+	obs    map[string]int64
+}
+
+func (v *recordingCounterVec) Registered() bool { return true }
+func (v *recordingCounterVec) With(l kernelmetrics.Labels) kernelmetrics.Counter {
+	kernelmetrics.MustValidateLabels(v.labels, l)
+	return &recordingCounter{vec: v, key: labelKey(v.labels, l)}
+}
+
+type recordingCounter struct {
+	vec *recordingCounterVec
+	key string
+}
+
+func (c *recordingCounter) Inc(_ context.Context)            { c.vec.obs[c.key]++ }
+func (c *recordingCounter) Add(_ context.Context, n float64) { c.vec.obs[c.key] += int64(n) }
+
+type recordingHistogramVec struct {
+	labels []string
+	obs    map[string]int64
+}
+
+func (v *recordingHistogramVec) Registered() bool { return true }
+func (v *recordingHistogramVec) With(l kernelmetrics.Labels) kernelmetrics.Histogram {
+	kernelmetrics.MustValidateLabels(v.labels, l)
+	return &recordingHistogram{vec: v, key: labelKey(v.labels, l)}
+}
+
+type recordingHistogram struct {
+	vec *recordingHistogramVec
+	key string
+}
+
+func (h *recordingHistogram) Observe(_ context.Context, _ float64) { h.vec.obs[h.key]++ }
+
+func labelKey(order []string, l kernelmetrics.Labels) string {
+	key := ""
+	for _, k := range order {
+		key += k + "=" + l[k] + ";"
+	}
+	return key
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+var _ kernelmetrics.Provider = (*recordingProvider)(nil)

--- a/kernel/webhook/metrics_test.go
+++ b/kernel/webhook/metrics_test.go
@@ -135,7 +135,11 @@ func TestWebhookMetrics_PreflightClean(t *testing.T) {
 
 // --- recordingProvider: in-memory metrics.Provider spy for webhook tests. ---
 
+// recordingProvider embeds NopProvider so the unused GaugeVec / Unregister
+// methods are inherited (webhook metrics have no gauges); it overrides only the
+// CounterVec / HistogramVec it needs to record.
 type recordingProvider struct {
+	kernelmetrics.NopProvider
 	counters   map[string]*recordingCounterVec
 	histograms map[string]*recordingHistogramVec
 }
@@ -158,12 +162,6 @@ func (p *recordingProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kern
 	p.histograms[opts.Name] = v
 	return v, nil
 }
-
-func (p *recordingProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
-	return nil, nil
-}
-
-func (p *recordingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
 
 func (p *recordingProvider) labelsOf(name string) []string {
 	if c, ok := p.counters[name]; ok {

--- a/kernel/webhook/spec.go
+++ b/kernel/webhook/spec.go
@@ -166,20 +166,27 @@ func (s DispatchSpec) Validate() error {
 // offending field is named in the message itself, no runtime data leaks.
 // When contractID is non-empty (i.e. the error comes from SourceID or CellID
 // validation), it is included in the details to pinpoint which spec failed.
+//
+// SourceID is validated through the typed [SourceID.Validate] rather than a bare
+// empty-check: it is the {source} label on every webhook metric, so a
+// label-unsafe value (containing '=' or '|', or otherwise off the
+// [a-z][a-z0-9_-]* shape) must fail here at spec validation — which NewReceiver /
+// NewDispatcher run at construction (startup) — instead of slipping through to
+// panic at first record via MustValidateLabels in a request/worker goroutine.
 func validateSpecFields(contractID, sourceID, cellID string) error {
-	switch {
-	case contractID == "":
+	if contractID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
 			"webhook: spec requires a non-empty ContractID")
-	case sourceID == "":
-		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
-			"webhook: spec requires a non-empty SourceID",
+	}
+	if err := SourceID(sourceID).Validate(); err != nil {
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: spec SourceID invalid", err,
 			errcode.WithDetails(errcode.PublicString("contractID", contractID)))
-	case cellID == "":
+	}
+	if cellID == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
 			"webhook: spec requires a non-empty CellID",
 			errcode.WithDetails(errcode.PublicString("contractID", contractID)))
-	default:
-		return nil
 	}
+	return nil
 }

--- a/kernel/webhook/spec_test.go
+++ b/kernel/webhook/spec_test.go
@@ -149,6 +149,42 @@ func TestDispatchSpecValidate_MissingFields(t *testing.T) {
 	}
 }
 
+// TestSpecValidate_InvalidSourceID asserts that a non-empty SourceID that is not
+// metric-label-safe (off the [a-z][a-z0-9_-]* shape, or over the length budget)
+// fails Validate() for BOTH spec kinds. This is the startup fail-fast that
+// prevents a request/worker-time MustValidateLabels panic when the SourceID
+// reaches a metric {source} label (regression for the C1/F1 finding): the label
+// separators '=' and '|' are the panic triggers; uppercase / leading digit /
+// over-length are rejected by the shared SourceID validator.
+func TestSpecValidate_InvalidSourceID(t *testing.T) {
+	badSources := []struct {
+		name   string
+		source string
+	}{
+		{"equals separator", "bad=source"},
+		{"pipe separator", "bad|source"},
+		{"uppercase", "Stripe"},
+		{"leading digit", "1stripe"},
+		{"space", "bad source"},
+		{"over length budget", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+	}
+	for _, bs := range badSources {
+		t.Run("receiver/"+bs.name, func(t *testing.T) {
+			s := validReceiverSpecExt()
+			s.SourceID = bs.source
+			requireWebhookConfigInvalid(t, s.Validate())
+		})
+		t.Run("dispatch/"+bs.name, func(t *testing.T) {
+			s := webhook.DispatchSpec{
+				ContractID: "webhook.shopify.dispatch.v1",
+				SourceID:   bs.source,
+				CellID:     "ordercore",
+			}
+			requireWebhookConfigInvalid(t, s.Validate())
+		})
+	}
+}
+
 // TestReceiverSpec_ZeroValueIsInvalid asserts that the zero value of ReceiverSpec
 // fails Validate() — all three fields are required.
 func TestReceiverSpec_ZeroValueIsInvalid(t *testing.T) {

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -298,7 +298,7 @@ func (b *Bootstrap) validateHTTPListenerConfigs() error {
 func validateListenerConfig(ref cell.ListenerRef, cfg listenerConfig) error {
 	if ref.IsZero() {
 		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
-			"bootstrap: zero listener ref is invalid; use cell.PrimaryListener, cell.InternalListener, or cell.HealthListener")
+			"bootstrap: zero listener ref is invalid; use cell.PrimaryListener, cell.InternalListener, cell.HealthListener, or cell.WebhookListener")
 	}
 	// SEC-FAIL-CLOSED: nil OR empty authChain is rejected at phase0. Empty
 	// slices are behaviorally identical to nil — both produce an

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -177,6 +177,14 @@ type Bootstrap struct {
 	// dispatcher. The dispatcher reuses webhookSourceStore for signing secrets.
 	webhookSSRFPolicy *kwh.SafePolicy
 
+	// webhookMetrics is the single shared kwh.Metrics collector registered once
+	// (cached here) so the receiver (phase5) and dispatcher (phase6) record to
+	// the same fixed-name instruments instead of re-registering the metric
+	// family. The zero value means "not wired" (no provider / NopProvider) and
+	// records as a no-op. Wired by autoWireWebhookMetricsCollector, mirroring
+	// httpCollector / eventRouterCollector / outboxRejectCollector / projectionMetrics.
+	webhookMetrics kwh.Metrics
+
 	// --- projection: L3 CQRS projection harness dependencies ---
 	// Injected via WithProjectionCheckpointStore / WithProjectionTxRunner /
 	// WithProjectionReplaySource / WithProjectionCursor. nil means "not

--- a/runtime/bootstrap/metrics_autowire.go
+++ b/runtime/bootstrap/metrics_autowire.go
@@ -98,8 +98,9 @@ func autoWireCachedCollector[T comparable](
 // could panic on a non-comparable dynamic type).
 func (b *Bootstrap) autoWireWebhookMetricsCollector() (kwh.Metrics, error) {
 	m, _, err := autoWireCachedCollector(b, &b.webhookMetrics, kwh.RegisterMetrics,
-		"bootstrap: webhook metrics auto-wire conflict: WithMetricsProvider constructs the webhook collector; "+
-			"do not also register webhook_deliveries_total manually on the same provider. Remove one side")
+		"bootstrap: webhook metrics auto-wire conflict: WithMetricsProvider constructs the webhook collector "+
+			"(webhook_deliveries_total / _delivery_duration_seconds / _signature_failures_total / "+
+			"_idempotency_hits_total); do not also register any of these manually on the same provider. Remove one side")
 	if err != nil {
 		return kwh.Metrics{}, err
 	}

--- a/runtime/bootstrap/metrics_autowire.go
+++ b/runtime/bootstrap/metrics_autowire.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
 )
 
 // autoWireCachedCollector registers a metrics collector exactly ONCE, caching it
@@ -81,4 +82,26 @@ func autoWireCachedCollector[T comparable](
 		*cache = c
 	}
 	return *cache, true, nil
+}
+
+// autoWireWebhookMetricsCollector registers the shared webhook metrics collector
+// (once, cached in b.webhookMetrics) and returns it for injection into the
+// receiver (phase5 BuildRouteGroups) and the dispatcher (phase6 BuildConsumers) —
+// one collector instance serves both sides, the instrument sets are disjoint.
+// Returns the zero kwh.Metrics (records as a no-op) when no real metrics provider
+// is configured. A duplicate-registration conflict is startup-fatal, never a
+// silent degrade — the autoWireCachedCollector discipline.
+//
+// kwh.Metrics satisfies the comparable constraint (a struct of interface-typed
+// instrument fields); the cache check only ever compares the populated value
+// against the all-nil zero, so it never compares two live instruments (which
+// could panic on a non-comparable dynamic type).
+func (b *Bootstrap) autoWireWebhookMetricsCollector() (kwh.Metrics, error) {
+	m, _, err := autoWireCachedCollector(b, &b.webhookMetrics, kwh.RegisterMetrics,
+		"bootstrap: webhook metrics auto-wire conflict: WithMetricsProvider constructs the webhook collector; "+
+			"do not also register webhook_deliveries_total manually on the same provider. Remove one side")
+	if err != nil {
+		return kwh.Metrics{}, err
+	}
+	return m, nil
 }

--- a/runtime/bootstrap/metrics_wiring_test.go
+++ b/runtime/bootstrap/metrics_wiring_test.go
@@ -63,6 +63,12 @@ func (s *registrationSpy) counters() []string {
 	return append([]string(nil), s.counterNames...)
 }
 
+func (s *registrationSpy) histograms() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.histogramNames...)
+}
+
 // TestBootstrap_DefaultAssembly_WiresMetricsProvider is the regression
 // test for the F1 finding: before the fix, WithMetricsProvider only
 // populated Bootstrap.metricsProvider while the default assembly.New()

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -128,7 +128,10 @@ func cellSnapshotsHaveDispatchers(s *phaseState) bool {
 // CellID drift check mirrors drainCellSubscriptions. Empty collection is a
 // no-op. A non-empty collection requires webhookSourceStore (for signing
 // secrets); the SSRF policy defaults to kwh.NewSafePolicy when unset.
-func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventrouter.Router) error {
+// collectWebhookDispatchRequests gathers all WebhookDispatchRequest entries from
+// cell snapshots, fail-fasting on a CellID drift (codegen defect). Extracted from
+// drainWebhookDispatchers to keep that function's cognitive complexity bounded.
+func (b *Bootstrap) collectWebhookDispatchRequests(s *phaseState) ([]cell.WebhookDispatchRequest, error) {
 	var reqs []cell.WebhookDispatchRequest
 	for _, id := range s.asm.CellIDs() {
 		snap, ok := s.cellSnapshots[id]
@@ -137,13 +140,21 @@ func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventroute
 		}
 		for _, req := range snap.WebhookDispatchers {
 			if req.Spec.CellID != id {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"bootstrap: cell %s webhook dispatcher drift: declared CellID=%q but snapshot owner=%q"+
 						" (codegen should inject cellID from cell metadata; check cellgen + contractgen templates)",
 					id, req.Spec.CellID, id)
 			}
 			reqs = append(reqs, req)
 		}
+	}
+	return reqs, nil
+}
+
+func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventrouter.Router) error {
+	reqs, err := b.collectWebhookDispatchRequests(s)
+	if err != nil {
+		return err
 	}
 	if len(reqs) == 0 {
 		return nil

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -158,7 +158,11 @@ func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventroute
 		// Default production policy: block all private/reserved ranges, no loopback.
 		policy = kwh.NewSafePolicy()
 	}
-	consumers, err := webhookdispatch.BuildConsumers(b.clock, reqs, b.webhookSourceStore, policy)
+	rec, err := b.autoWireWebhookMetricsCollector()
+	if err != nil {
+		return err
+	}
+	consumers, err := webhookdispatch.BuildConsumers(b.clock, reqs, b.webhookSourceStore, policy, rec)
 	if err != nil {
 		return fmt.Errorf("bootstrap: build webhook dispatch consumers: %w", err)
 	}

--- a/runtime/bootstrap/phases_http.go
+++ b/runtime/bootstrap/phases_http.go
@@ -446,7 +446,11 @@ func (b *Bootstrap) phase5DrainWebhookReceivers(s *phaseState) ([]cell.RouteGrou
 			"bootstrap: webhook receivers declared but no claimer configured; "+
 				"add WithWebhookClaimer to bootstrap options")
 	}
-	groups, err := runtimewebhook.BuildRouteGroups(b.clock, reqs, b.webhookSourceStore, b.webhookClaimer)
+	rec, err := b.autoWireWebhookMetricsCollector()
+	if err != nil {
+		return nil, err
+	}
+	groups, err := runtimewebhook.BuildRouteGroups(b.clock, reqs, b.webhookSourceStore, b.webhookClaimer, rec)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: build webhook route groups: %w", err)
 	}

--- a/runtime/bootstrap/phases_webhook_test.go
+++ b/runtime/bootstrap/phases_webhook_test.go
@@ -22,10 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/auth"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/kernel/idempotency"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	kwh "github.com/ghbvf/gocell/kernel/webhook"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -298,7 +300,9 @@ func TestPhase5DrainWebhookReceivers_HappyPath_ProducesGroups(t *testing.T) {
 	require.Len(t, groups, 1, "must produce one group per receiver")
 
 	g := groups[0]
-	assert.Equal(t, cell.PrimaryListener, g.Listener, "webhook groups must target PrimaryListener")
+	assert.Equal(t, cell.WebhookListener, g.Listener,
+		"webhook groups must target the dedicated WebhookListener, not PrimaryListener "+
+			"(HMAC auth happens at the app layer; a JWT chain on PrimaryListener would 401 first)")
 	assert.Equal(t, whTestPathPattern, g.Prefix, "group Prefix must equal PathPattern")
 	assert.Equal(t, whTestCellID, g.CellID, "group CellID must match spec.CellID")
 	require.NotNil(t, g.Register, "Register func must not be nil")
@@ -370,6 +374,160 @@ func TestPhase5DrainWebhookReceivers_EndToEnd(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, rec.Code,
 			"forged HMAC at %s must return 401", whTestPathPattern)
 	})
+}
+
+// TestPhase5_WebhookListener_IsolatedFromPrimary is the F6a regression: a
+// webhook receiver mounts on the dedicated cell.WebhookListener router and is
+// ABSENT from the cell.PrimaryListener router. In a real assembly PrimaryListener
+// carries a JWT auth chain that would 401 an HMAC-signed (non-JWT) webhook before
+// the verifier; routing the webhook onto its own AuthNone listener is what makes
+// it reachable. The proof here is routing isolation: a valid signed request hits
+// the WebhookListener router with 200, while the SAME path on the PrimaryListener
+// router is 404 (the route was never mounted there, so no PrimaryListener auth
+// chain can ever see it).
+func TestPhase5_WebhookListener_IsolatedFromPrimary(t *testing.T) {
+	clk := clockmock.New(whFixedNow)
+	src := whTestSource(t)
+	store := whTestStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	b := New(clk,
+		// PrimaryListener stands in for the business listener; in production it
+		// carries a JWT chain. WebhookListener carries AuthNone (HMAC is the auth).
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+		WithListener(cell.WebhookListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+	)
+	b.webhookSourceStore = store
+	b.webhookClaimer = claimer
+
+	groups, err := b.phase5DrainWebhookReceivers(s)
+	require.NoError(t, err, "phase5DrainWebhookReceivers")
+	require.Len(t, groups, 1)
+
+	routers, err := b.phase5BuildPerListenerRouters(s)
+	require.NoError(t, err, "phase5BuildPerListenerRouters")
+	require.NoError(t, b.phase5MountRouteGroups(routers, groups), "phase5MountRouteGroups")
+
+	// Build a valid signed request for whTestPathPattern.
+	signer, err := kwh.NewHMACSigner(src)
+	require.NoError(t, err, "NewHMACSigner")
+	body := []byte(`{"event":"isolation-test"}`)
+	did, err := kwh.NewDeliveryID("isolation-001")
+	require.NoError(t, err, "NewDeliveryID")
+	headers, err := signer.Sign(body, whFixedNow, did)
+	require.NoError(t, err, "Sign")
+	newReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodPost, whTestPathPattern, bytes.NewReader(body))
+		req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+		req.Header.Set("X-Timestamp", headers.Timestamp)
+		req.Header.Set("X-Signature", headers.Signature)
+		return req
+	}
+
+	// Reachable on the WebhookListener router.
+	whRec := httptest.NewRecorder()
+	routers[cell.WebhookListener].Handler().ServeHTTP(whRec, newReq())
+	assert.Equal(t, http.StatusOK, whRec.Code,
+		"signed webhook must reach the verifier on WebhookListener (200)")
+
+	// Absent from the PrimaryListener router — a JWT chain there can never see it.
+	primRec := httptest.NewRecorder()
+	routers[cell.PrimaryListener].Handler().ServeHTTP(primRec, newReq())
+	assert.Equal(t, http.StatusNotFound, primRec.Code,
+		"webhook path must NOT be mounted on PrimaryListener (404) — proves listener isolation")
+}
+
+// TestPhase5MountRouteGroups_FailsWhenWebhookListenerUndeclared asserts the
+// bootstrap safety net: if a webhook RouteGroup names WebhookListener but the
+// assembly never declared it via WithListener, mounting fail-fasts with an
+// actionable message (this is the Hard upstream guard backing F6a — a forgotten
+// WithListener(WebhookListener,...) is a startup error, not a silent 404).
+func TestPhase5MountRouteGroups_FailsWhenWebhookListenerUndeclared(t *testing.T) {
+	clk := clockmock.New(whFixedNow)
+	wc := newWebhookCell(whTestSpec(), noopWebhookHandler)
+	s := buildPhaseStateWithWebhookCells(t, wc)
+
+	// Only PrimaryListener declared — WebhookListener intentionally missing.
+	b := New(clk, WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}))
+	b.webhookSourceStore = whTestStore(t)
+	b.webhookClaimer = idempotency.NewInMemClaimer(clk)
+
+	groups, err := b.phase5DrainWebhookReceivers(s)
+	require.NoError(t, err)
+	routers, err := b.phase5BuildPerListenerRouters(s)
+	require.NoError(t, err)
+
+	err = b.phase5MountRouteGroups(routers, groups)
+	require.Error(t, err, "missing WebhookListener must fail-fast at mount")
+	assert.Contains(t, err.Error(), "webhook",
+		"error must name the undeclared webhook listener")
+}
+
+// TestAutoWireWebhookMetricsCollector_RealProvider_OnceAndShared is the F4
+// regression: with a REAL metrics provider, autoWireWebhookMetricsCollector
+// registers the four webhook instruments EXACTLY once and returns the SAME cached
+// collector to every caller. phase5 (receiver, phases_http.go) and phase6
+// (dispatcher, phases_events.go) each call it; the cache is what guarantees one
+// instrument set serves both sides rather than a duplicate registration (which a
+// real Prometheus provider would reject). Before this test the autowire had no
+// real-provider coverage — the existing webhook tests injected a zero/fake
+// Metrics directly and never exercised RegisterMetrics through the bootstrap path.
+func TestAutoWireWebhookMetricsCollector_RealProvider_OnceAndShared(t *testing.T) {
+	spy := &registrationSpy{}
+	b := New(clockmock.New(whFixedNow), WithMetricsProvider(spy))
+
+	// First wire — the phase5 (receiver) side.
+	m1, err := b.autoWireWebhookMetricsCollector()
+	require.NoError(t, err, "first auto-wire must succeed")
+	// Second wire — the phase6 (dispatcher) side — returns the cached collector.
+	_, err = b.autoWireWebhookMetricsCollector()
+	require.NoError(t, err, "second auto-wire must succeed")
+
+	// "Same cached instance" is proven by registration happening exactly ONCE
+	// across the two wire calls (below): RegisterMetrics ran a single time, so
+	// both phases received the one cached b.webhookMetrics. (kwh.Metrics is not
+	// runtime-comparable once populated — its instrument fields can wrap slice-
+	// bearing nop types — so this is asserted via the registration count, not ==.)
+	// Registered exactly once despite two wire calls.
+	count := func(names []string, want string) int {
+		n := 0
+		for _, x := range names {
+			if x == want {
+				n++
+			}
+		}
+		return n
+	}
+	cnts := spy.counters()
+	for _, name := range []string{
+		"webhook_deliveries_total",
+		"webhook_signature_failures_total",
+		"webhook_idempotency_hits_total",
+	} {
+		assert.Equalf(t, 1, count(cnts, name),
+			"%s must be registered exactly once across both auto-wire calls (got %v)", name, cnts)
+	}
+	assert.Equal(t, 1, count(spy.histograms(), "webhook_delivery_duration_seconds"),
+		"delivery duration histogram must be registered exactly once")
+
+	// The wired collector is a real (non-zero) recorder: a record call exercises
+	// a live instrument rather than the disabled no-op zero value.
+	m1.RecordIdempotencyHit(context.Background(), whTestSourceID)
+}
+
+// TestAutoWireWebhookMetricsCollector_NopProvider_NoWire confirms the disabled
+// path: with no real provider (NopProvider default), auto-wire returns the zero
+// no-op collector and registers nothing.
+func TestAutoWireWebhookMetricsCollector_NopProvider_NoWire(t *testing.T) {
+	b := New(clockmock.New(whFixedNow))
+	b.metricsProvider = kernelmetrics.NopProvider{}
+
+	m, err := b.autoWireWebhookMetricsCollector()
+	require.NoError(t, err)
+	assert.Equal(t, kwh.Metrics{}, m, "NopProvider must yield the zero (no-op) collector")
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/webhook/dispatch/dispatch.go
+++ b/runtime/webhook/dispatch/dispatch.go
@@ -106,11 +106,15 @@ func (c Consumer) Validate() error {
 // DLX: the composition root must configure the broker subscriber's DLX exchange
 // for dispatch subscription topics; permanently-failed deliveries (Reject) are
 // Nack(requeue=false)→DLX and are otherwise silently discarded.
+// rec is the optional dispatch-side metrics recorder (the zero value disables
+// recording); the bootstrap auto-wire passes the registered collector when a
+// metrics provider is configured.
 func BuildConsumers(
 	clk clock.Clock,
 	reqs []cell.WebhookDispatchRequest,
 	store kwh.SourceStore,
 	policy *kwh.SafePolicy,
+	rec kwh.Metrics,
 ) ([]Consumer, error) {
 	clock.MustHaveClock(clk, "webhook/dispatch.BuildConsumers")
 	if validation.IsNilInterface(store) {
@@ -123,7 +127,7 @@ func BuildConsumers(
 	}
 	out := make([]Consumer, 0, len(reqs))
 	for _, req := range reqs {
-		c, err := buildConsumer(clk, req, store, policy)
+		c, err := buildConsumer(clk, req, store, policy, rec)
 		if err != nil {
 			return nil, fmt.Errorf("webhook dispatch: contract %q: %w", req.Spec.ContractID, err)
 		}
@@ -143,6 +147,7 @@ func buildConsumer(
 	req cell.WebhookDispatchRequest,
 	store kwh.SourceStore,
 	policy *kwh.SafePolicy,
+	rec kwh.Metrics,
 ) (Consumer, error) {
 	spec := req.Spec
 	if err := spec.Validate(); err != nil {
@@ -167,7 +172,8 @@ func buildConsumer(
 	if err != nil {
 		return Consumer{}, err
 	}
-	dispatcher, err := kwh.NewDispatcher(clk, signer, policy, req.Selector)
+	dispatcher, err := kwh.NewDispatcher(clk, signer, policy, req.Selector,
+		kwh.WithMetrics(rec, spec.SourceID))
 	if err != nil {
 		return Consumer{}, err
 	}

--- a/runtime/webhook/dispatch/dispatch_test.go
+++ b/runtime/webhook/dispatch/dispatch_test.go
@@ -52,7 +52,7 @@ func TestBuildConsumers_HappyPath(t *testing.T) {
 	reqs := []cell.WebhookDispatchRequest{
 		dispatchReq("webhook.shopify.orders.v1", "shopify", "ordercore"),
 	}
-	consumers, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy())
+	consumers, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy(), kwh.Metrics{})
 	require.NoError(t, err)
 	require.Len(t, consumers, 1)
 
@@ -71,20 +71,20 @@ func TestBuildConsumers_HappyPath(t *testing.T) {
 
 func TestBuildConsumers_Empty(t *testing.T) {
 	t.Parallel()
-	consumers, err := BuildConsumers(testClock(), nil, testStore(t, "s"), kwh.NewSafePolicy())
+	consumers, err := BuildConsumers(testClock(), nil, testStore(t, "s"), kwh.NewSafePolicy(), kwh.Metrics{})
 	require.NoError(t, err)
 	assert.Empty(t, consumers)
 }
 
 func TestBuildConsumers_NilStore(t *testing.T) {
 	t.Parallel()
-	_, err := BuildConsumers(testClock(), nil, nil, kwh.NewSafePolicy())
+	_, err := BuildConsumers(testClock(), nil, nil, kwh.NewSafePolicy(), kwh.Metrics{})
 	requireWebhookConfigErr(t, err)
 }
 
 func TestBuildConsumers_NilPolicy(t *testing.T) {
 	t.Parallel()
-	_, err := BuildConsumers(testClock(), nil, testStore(t, "s"), nil)
+	_, err := BuildConsumers(testClock(), nil, testStore(t, "s"), nil, kwh.Metrics{})
 	requireWebhookConfigErr(t, err)
 }
 
@@ -92,7 +92,7 @@ func TestBuildConsumers_UnregisteredSource(t *testing.T) {
 	t.Parallel()
 	store := testStore(t, "shopify")
 	reqs := []cell.WebhookDispatchRequest{dispatchReq("webhook.x.v1", "stripe", "c")} // "stripe" not registered
-	_, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy())
+	_, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy(), kwh.Metrics{})
 	requireWebhookConfigErr(t, err)
 }
 
@@ -103,7 +103,7 @@ func TestBuildConsumers_NilSelector(t *testing.T) {
 		Spec:     kwh.DispatchSpec{ContractID: "webhook.x.v1", SourceID: "shopify", CellID: "c"},
 		Selector: nil,
 	}
-	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy())
+	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy(), kwh.Metrics{})
 	requireWebhookConfigErr(t, err)
 }
 
@@ -111,7 +111,7 @@ func TestBuildConsumers_InvalidSpec(t *testing.T) {
 	t.Parallel()
 	store := testStore(t, "shopify")
 	req := dispatchReq("", "shopify", "c") // empty ContractID → spec invalid
-	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy())
+	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy(), kwh.Metrics{})
 	requireWebhookConfigErr(t, err)
 }
 

--- a/runtime/webhook/doc.go
+++ b/runtime/webhook/doc.go
@@ -59,11 +59,32 @@
 //     contracts/webhook/README.md troubleshooting section (same resolution as
 //     the subscribe path).
 //
+// # Observability
+//
+// Metrics are auto-wired by bootstrap: when WithMetricsProvider is configured,
+// phase5 injects the shared kwh.Metrics collector into each Receiver (recording
+// webhook_signature_failures_total and webhook_idempotency_hits_total) and
+// phase6 into each Dispatcher (webhook_deliveries_total and
+// webhook_delivery_duration_seconds). A nil/NopProvider leaves the zero
+// kwh.Metrics, which records as a no-op — callers do nothing. See
+// kernel/webhook/metrics.go.
+//
+// # Known gap: listener auth (KERNEL-WEBHOOK-01 follow-up)
+//
+// BuildRouteGroups mounts the receiver on cell.PrimaryListener WITHOUT a Public
+// marker. In any assembly whose PrimaryListener carries a JWT auth chain, an
+// external webhook POST (which carries an HMAC signature, not a JWT) is rejected
+// by the JWT middleware with 401 before reaching the HMAC verifier. A runnable
+// deployment therefore needs the webhook path marked Public or a dedicated
+// webhook ListenerRef (see .claude/rules/gocell/runtime-api.md §"单 listener 单
+// auth scheme"). Tracked as a KERNEL-WEBHOOK-01 follow-up; out of PR-6 scope.
+//
 // # Deferred capabilities
 //
-// Metrics and healthz probes are deferred to PR-6 (KERNEL-WEBHOOK-01).
-// Per-contract Claimer TTL configuration is also deferred (the 24h done-TTL is
-// a fixed constant today — see receiver.go).
+// Healthz probes were evaluated and dropped (vacuous/synonymous with the
+// adapter _ready probes under today's immutable source store; tracked for when
+// the store becomes runtime-mutable). Per-contract Claimer TTL configuration is
+// deferred (the 24h done-TTL is a fixed constant today — see receiver.go).
 //
 // # References
 //

--- a/runtime/webhook/doc.go
+++ b/runtime/webhook/doc.go
@@ -69,15 +69,24 @@
 // kwh.Metrics, which records as a no-op — callers do nothing. See
 // kernel/webhook/metrics.go.
 //
-// # Known gap: listener auth (KERNEL-WEBHOOK-01 follow-up)
+// # Listener auth: dedicated WebhookListener (HMAC at the application layer)
 //
-// BuildRouteGroups mounts the receiver on cell.PrimaryListener WITHOUT a Public
-// marker. In any assembly whose PrimaryListener carries a JWT auth chain, an
-// external webhook POST (which carries an HMAC signature, not a JWT) is rejected
-// by the JWT middleware with 401 before reaching the HMAC verifier. A runnable
-// deployment therefore needs the webhook path marked Public or a dedicated
-// webhook ListenerRef (see .claude/rules/gocell/runtime-api.md §"单 listener 单
-// auth scheme"). Tracked as a KERNEL-WEBHOOK-01 follow-up; out of PR-6 scope.
+// BuildRouteGroups mounts each receiver on cell.WebhookListener — a dedicated
+// listener, NOT PrimaryListener. Inbound webhooks authenticate at the
+// application layer via HMAC signature verification inside the Receiver, so the
+// composition root configures the webhook listener with an auth.AuthNone{} chain:
+//
+//	bootstrap.WithListener(cell.WebhookListener, ":8090",
+//	    []auth.ListenerAuth{auth.AuthNone{}})
+//
+// Mounting on PrimaryListener would be wrong: that listener typically carries a
+// JWT auth chain that would 401 an HMAC-signed (non-JWT) webhook POST before it
+// ever reached the verifier. Keeping the webhook path on its own listener (the
+// canonical pattern in .claude/rules/gocell/runtime-api.md §"单 listener 单 auth
+// scheme") gives it its own port and HMAC-only auth without a Public carve-out on
+// the business listener. If a webhook RouteGroup names a listener the assembly
+// did not declare, bootstrap fail-fasts at startup with an actionable message
+// (runtime/bootstrap phase5: "add WithListener(webhook,...)").
 //
 // # Deferred capabilities
 //

--- a/runtime/webhook/receiver.go
+++ b/runtime/webhook/receiver.go
@@ -73,10 +73,26 @@ type Receiver struct {
 	store    kwh.SourceStore
 	claimer  idempotency.Claimer
 	handler  kwh.WebhookReceiveHandler
+	// recorder is the optional receive-side observability dependency (PR-6).
+	// The zero kwh.Metrics value disables every record (no-op); injected via
+	// WithMetrics. It is NOT a required dep — like logger/emitter it falls back
+	// to no-op rather than failing construction.
+	recorder kwh.Metrics
 }
 
-// NewReceiver constructs a Receiver. All parameters are mandatory; any nil or
-// invalid argument returns an [errcode.ErrWebhookConfigInvalid] error.
+// ReceiverOption customizes a Receiver at construction time.
+type ReceiverOption func(*Receiver)
+
+// WithMetrics injects the optional receive-side metrics recorder. Omitting it
+// leaves the zero kwh.Metrics value, which records as a no-op (the disabled /
+// NopProvider case). The {source} label is the receiver's configured SourceID.
+func WithMetrics(rec kwh.Metrics) ReceiverOption {
+	return func(r *Receiver) { r.recorder = rec }
+}
+
+// NewReceiver constructs a Receiver. All positional parameters are mandatory;
+// any nil or invalid argument returns an [errcode.ErrWebhookConfigInvalid]
+// error. opts carry optional dependencies (metrics).
 func NewReceiver(
 	clk clock.Clock,
 	spec kwh.ReceiverSpec,
@@ -84,6 +100,7 @@ func NewReceiver(
 	store kwh.SourceStore,
 	claimer idempotency.Claimer,
 	handler kwh.WebhookReceiveHandler,
+	opts ...ReceiverOption,
 ) (*Receiver, error) {
 	clock.MustHaveClock(clk, "webhook.NewReceiver")
 	if err := spec.Validate(); err != nil {
@@ -105,14 +122,18 @@ func NewReceiver(
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
 			"webhook receiver: handler must not be nil")
 	}
-	return &Receiver{
+	r := &Receiver{
 		clk:      clk,
 		spec:     spec,
 		verifier: verifier,
 		store:    store,
 		claimer:  claimer,
 		handler:  handler,
-	}, nil
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r, nil
 }
 
 // ServeHTTP implements http.Handler. Pipeline:
@@ -131,8 +152,12 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// 2. Verify — produces unforgeable verified token.
-	v, err := r.verify(body, req)
+	v, reason, err := r.verify(body, req)
 	if err != nil {
+		// Record the failure by classified reason (server-side metric; the wire
+		// 401 stays uniform for unknown_source/bad_signature per the anti-oracle
+		// design in verify, but the metric distinguishes them).
+		r.recorder.RecordSignatureFailure(ctx, r.spec.SourceID, reason)
 		// Warn (not Error): a verification failure is a 4xx caused by an
 		// external caller (bad/missing signature, unknown source, expired
 		// timestamp), not a server-side correctness fault. observability.md
@@ -165,6 +190,8 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch state {
 	case idempotency.ClaimDone:
 		// Already processed — idempotent 200 without re-invoking handler.
+		// A duplicate delivery the claimer deduplicated.
+		r.recorder.RecordIdempotencyHit(ctx, r.spec.SourceID)
 		writeAccepted(w)
 		return
 
@@ -172,6 +199,8 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Another worker is currently processing — 409 so the sender retries.
 		// ErrWebhookDuplicateDelivery (KindConflict → 409) is the semantically
 		// correct sentinel: the delivery is a known duplicate, not a lease expiry.
+		// Also a duplicate (concurrent in-flight), counted as an idempotency hit.
+		r.recorder.RecordIdempotencyHit(ctx, r.spec.SourceID)
 		httputil.WriteError(ctx, w, errcode.New(errcode.KindConflict, errcode.ErrWebhookDuplicateDelivery,
 			"webhook receiver: delivery is already being processed"))
 		return
@@ -269,20 +298,23 @@ func (r *Receiver) readBody(w http.ResponseWriter, req *http.Request) ([]byte, e
 
 // verify reads the configured signature headers from req, looks up the source,
 // and validates the HMAC. Returns an unforgeable [verified] token on success.
-// Errors are already typed *errcode.Error ready for httputil.WriteError.
-func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
+// Errors are already typed *errcode.Error ready for httputil.WriteError. The
+// second return is the classified [kwh.SignatureFailureReason] for the
+// webhook_signature_failures_total{reason} metric; it is meaningful only when
+// err != nil (the success path returns the zero reason, which is never recorded).
+func (r *Receiver) verify(body []byte, req *http.Request) (verified, kwh.SignatureFailureReason, error) {
 	deliveryIDRaw := req.Header.Get(r.spec.DeliveryIDHeader)
 	timestampRaw := req.Header.Get(r.spec.TimestampHeader)
 	signatureRaw := req.Header.Get(r.spec.SignatureHeader)
 
 	if deliveryIDRaw == "" || timestampRaw == "" || signatureRaw == "" {
-		return verified{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
+		return verified{}, kwh.ReasonMissingHeader, errcode.New(errcode.KindInvalid, errcode.ErrWebhookInvalidHeader,
 			"webhook receiver: one or more required signature headers are missing")
 	}
 
 	deliveryID, err := kwh.NewDeliveryID(deliveryIDRaw)
 	if err != nil {
-		return verified{}, err
+		return verified{}, kwh.ReasonInvalidHeader, err
 	}
 
 	headers := kwh.Headers{
@@ -296,10 +328,11 @@ func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
 	// unregistered source is byte-identical to a signature mismatch and cannot
 	// be used as a source-ID enumeration oracle (WEBHOOK-HMAC-FUNNEL-01 F8/F9;
 	// OWASP Generic Error Messages). The "source not registered" reason is kept
-	// in WithInternal (server-side slog only, never on the wire).
+	// in WithInternal (server-side slog only, never on the wire) — and in the
+	// server-side metric reason (unknown_source), which is not a wire oracle.
 	src, ok := r.store.Lookup(kwh.SourceID(r.spec.SourceID))
 	if !ok {
-		return verified{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
+		return verified{}, kwh.ReasonUnknownSource, errcode.New(errcode.KindUnauthenticated, errcode.ErrWebhookInvalidSignature,
 			kwh.MsgSignatureVerificationFailed,
 			errcode.WithInternal(
 				errcode.InternalAttr("source_id", r.spec.SourceID),
@@ -307,7 +340,7 @@ func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
 	}
 
 	if err := r.verifier.Verify(body, headers, src); err != nil {
-		return verified{}, err
+		return verified{}, verifyErrReason(err), err
 	}
 
 	return verified{d: kwh.Delivery{
@@ -315,7 +348,24 @@ func (r *Receiver) verify(body []byte, req *http.Request) (verified, error) {
 		SourceID:   kwh.SourceID(r.spec.SourceID),
 		Headers:    headers,
 		Payload:    body,
-	}}, nil
+	}}, "", nil
+}
+
+// verifyErrReason classifies a kwh.Verifier.Verify error into the metric reason.
+// The verifier returns ErrWebhookTimestampExpired for skew beyond tolerance,
+// ErrWebhookInvalidHeader for a malformed timestamp, and ErrWebhookInvalidSignature
+// for a MAC mismatch; any unexpected error defaults to bad_signature (fail-closed).
+func verifyErrReason(err error) kwh.SignatureFailureReason {
+	var ee *errcode.Error
+	if errors.As(err, &ee) {
+		switch ee.Code {
+		case errcode.ErrWebhookTimestampExpired:
+			return kwh.ReasonTimestampExpired
+		case errcode.ErrWebhookInvalidHeader:
+			return kwh.ReasonInvalidHeader
+		}
+	}
+	return kwh.ReasonBadSignature
 }
 
 // claim uses the idempotency Claimer to acquire a processing lease keyed on

--- a/runtime/webhook/receiver.go
+++ b/runtime/webhook/receiver.go
@@ -168,6 +168,7 @@ func (r *Receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		slog.WarnContext(ctx, "webhook receiver: signature verification failed",
 			slog.String("source_id", r.spec.SourceID),
 			slog.String("contract_id", r.spec.ContractID),
+			slog.String("reason", string(reason)),
 			slog.Any("error", err))
 		httputil.WriteError(ctx, w, err)
 		return

--- a/runtime/webhook/receiver_integration_test.go
+++ b/runtime/webhook/receiver_integration_test.go
@@ -42,7 +42,7 @@ func buildIntegrationServer(t *testing.T, handler kwh.WebhookReceiveHandler) (*h
 		},
 	}
 
-	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -320,7 +320,7 @@ func TestIntegration_BodyTooLarge_Returns413(t *testing.T) {
 	claimer := idempotency.NewInMemClaimer(clk)
 
 	reqs := []cell.WebhookReceiverRequest{{Spec: spec, Handler: func(_ context.Context, _ kwh.Delivery) error { return nil }}}
-	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestIntegration_TimestampExpired_Returns401(t *testing.T) {
 
 	spec := testSpec()
 	reqs := []cell.WebhookReceiverRequest{{Spec: spec, Handler: func(_ context.Context, _ kwh.Delivery) error { return nil }}}
-	groups, err := rtwh.BuildRouteGroups(laterClk, reqs, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(laterClk, reqs, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestIntegration_ConcurrentDelivery_Returns409(t *testing.T) {
 
 	spec := testSpec()
 	reqs := []cell.WebhookReceiverRequest{{Spec: spec, Handler: func(_ context.Context, _ kwh.Delivery) error { return nil }}}
-	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, fakeCl)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, fakeCl, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}

--- a/runtime/webhook/receiver_log_test.go
+++ b/runtime/webhook/receiver_log_test.go
@@ -1,0 +1,90 @@
+package webhook_test
+
+// receiver_log_test.go covers the C4/F7 finding: the signature-verification
+// failure log must carry the classified "reason" field that doc.go promises
+// ("the real reason is in the server-side slog 'reason' field"). Prior to the
+// fix the metric carried {reason} but the slog record did not, so the doc and
+// the code disagreed.
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+)
+
+// capturingHandler is a minimal slog.Handler that records every Record it
+// receives. It deliberately does NOT use slog.NewJSONHandler/NewTextHandler
+// (those are banned outside the logging package by SLOG-HANDLER-SEALED-FUNNEL-01)
+// — it captures structured attrs directly.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// attr returns the string value of the named attr in r, and whether it existed.
+func attr(r slog.Record, key string) (string, bool) {
+	var val string
+	var found bool
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			val = a.Value.String()
+			found = true
+			return false
+		}
+		return true
+	})
+	return val, found
+}
+
+// TestReceiver_LogsSignatureFailureReason asserts the verification-failure log
+// record carries the classified reason field (doc.go promise; C4/F7). Not
+// parallel: it swaps the process-global slog default.
+func TestReceiver_LogsSignatureFailureReason(t *testing.T) {
+	h := &capturingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Bad signature → ReasonBadSignature classification.
+	req := signedRequest(t, []byte(`{"k":"v"}`), "d1")
+	req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	recv := newMetricReceiver(t, testStore(t), fixedNow, kwh.Metrics{})
+
+	recv.ServeHTTP(httptest.NewRecorder(), req)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var found bool
+	for _, r := range h.records {
+		if r.Message != "webhook receiver: signature verification failed" {
+			continue
+		}
+		found = true
+		reason, ok := attr(r, "reason")
+		if !ok {
+			t.Fatalf("signature-failure log is missing the 'reason' field (doc.go promises it); attrs present did not include reason")
+		}
+		if reason != "bad_signature" {
+			t.Errorf("log reason = %q, want %q", reason, "bad_signature")
+		}
+	}
+	if !found {
+		t.Fatal("no signature-verification-failed log record captured")
+	}
+}

--- a/runtime/webhook/receiver_metrics_test.go
+++ b/runtime/webhook/receiver_metrics_test.go
@@ -35,6 +35,17 @@ func TestReceiver_RecordsSignatureFailureReason(t *testing.T) {
 			},
 		},
 		{
+			name:       "invalid_header",
+			wantReason: "invalid_header",
+			build: func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request) {
+				req := signedRequest(t, []byte(`{"k":"v"}`), "d1")
+				// Non-integer timestamp → verifier.validateTimestamp →
+				// ErrWebhookInvalidHeader → ReasonInvalidHeader (runs before HMAC).
+				req.Header.Set("X-Timestamp", "not-a-number")
+				return newMetricReceiver(t, testStore(t), fixedNow, m), req
+			},
+		},
+		{
 			name:       "bad_signature",
 			wantReason: "bad_signature",
 			build: func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request) {

--- a/runtime/webhook/receiver_metrics_test.go
+++ b/runtime/webhook/receiver_metrics_test.go
@@ -1,0 +1,168 @@
+package webhook_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	rtwh "github.com/ghbvf/gocell/runtime/webhook"
+)
+
+// TestReceiver_RecordsSignatureFailureReason asserts ServeHTTP records
+// webhook_signature_failures_total{source,reason} with the correctly classified
+// reason for each verification-failure branch.
+func TestReceiver_RecordsSignatureFailureReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantReason string
+		// build returns the receiver under test and the request to drive it.
+		build func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request)
+	}{
+		{
+			name:       "missing_header",
+			wantReason: "missing_header",
+			build: func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request) {
+				req := signedRequest(t, []byte(`{"k":"v"}`), "d1")
+				req.Header.Del("X-Signature")
+				return newMetricReceiver(t, testStore(t), fixedNow, m), req
+			},
+		},
+		{
+			name:       "bad_signature",
+			wantReason: "bad_signature",
+			build: func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request) {
+				req := signedRequest(t, []byte(`{"k":"v"}`), "d1")
+				req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+				return newMetricReceiver(t, testStore(t), fixedNow, m), req
+			},
+		},
+		{
+			name:       "unknown_source",
+			wantReason: "unknown_source",
+			build: func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request) {
+				req := signedRequest(t, []byte(`{"k":"v"}`), "d1")
+				// Empty store → spec.SourceID lookup miss.
+				return newMetricReceiver(t, kwh.NewSourceRegistry(), fixedNow, m), req
+			},
+		},
+		{
+			name:       "timestamp_expired",
+			wantReason: "timestamp_expired",
+			build: func(t *testing.T, m kwh.Metrics) (*rtwh.Receiver, *http.Request) {
+				req := signedRequest(t, []byte(`{"k":"v"}`), "d1")
+				// Verifier clock advanced beyond tolerance vs. the fixedNow signature.
+				return newMetricReceiver(t, testStore(t), fixedNow.Add(testReplaySkew), m), req
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := &fakeCounterVec{obs: map[string]int{}}
+			m := kwh.Metrics{SignatureFailures: sig}
+			recv, req := tc.build(t, m)
+
+			recv.ServeHTTP(httptest.NewRecorder(), req)
+
+			got := sig.value(kernelmetrics.Labels{"source": testSourceID, "reason": tc.wantReason})
+			if got != 1 {
+				t.Errorf("signature_failures{reason=%q} = %d, want 1 (recorded keys: %v)",
+					tc.wantReason, got, sig.keys())
+			}
+		})
+	}
+}
+
+// TestReceiver_RecordsIdempotencyHit asserts a duplicate delivery (ClaimDone /
+// ClaimBusy) records webhook_idempotency_hits_total{source}.
+func TestReceiver_RecordsIdempotencyHit(t *testing.T) {
+	for _, state := range []idempotency.ClaimState{idempotency.ClaimDone, idempotency.ClaimBusy} {
+		idem := &fakeCounterVec{obs: map[string]int{}}
+		m := kwh.Metrics{IdempotencyHits: idem}
+		clk := clockmock.New(fixedNow)
+		verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+		if err != nil {
+			t.Fatalf("NewHMACVerifier: %v", err)
+		}
+		claimer := &fakeClaimer{results: []claimResult{{state: state}}}
+		handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+		recv, err := rtwh.NewReceiver(clk, testSpec(), verifier, testStore(t), claimer, handler, rtwh.WithMetrics(m))
+		if err != nil {
+			t.Fatalf("NewReceiver: %v", err)
+		}
+
+		recv.ServeHTTP(httptest.NewRecorder(), signedRequest(t, []byte(`{"k":"v"}`), "d1"))
+
+		if got := idem.value(kernelmetrics.Labels{"source": testSourceID}); got != 1 {
+			t.Errorf("state %v: idempotency_hits{source} = %d, want 1", state, got)
+		}
+	}
+}
+
+// newMetricReceiver builds a Receiver whose verifier clock is verifierNow (to
+// drive the timestamp-expiry branch) and injects metrics m.
+func newMetricReceiver(t *testing.T, store kwh.SourceStore, verifierNow time.Time, m kwh.Metrics) *rtwh.Receiver {
+	t.Helper()
+	clk := clockmock.New(verifierNow)
+	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
+	if err != nil {
+		t.Fatalf("NewHMACVerifier: %v", err)
+	}
+	handler := func(_ context.Context, _ kwh.Delivery) error { return nil }
+	recv, err := rtwh.NewReceiver(clk, testSpec(), verifier, store,
+		idempotency.NewInMemClaimer(clk), handler, rtwh.WithMetrics(m))
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	return recv
+}
+
+// --- fakeCounterVec: records With(labels).Inc calls by label tuple. ---
+
+type fakeCounterVec struct {
+	obs map[string]int
+}
+
+func (v *fakeCounterVec) Registered() bool { return true }
+func (v *fakeCounterVec) With(l kernelmetrics.Labels) kernelmetrics.Counter {
+	return &fakeCounter{vec: v, key: labelKey(l)}
+}
+
+func (v *fakeCounterVec) value(l kernelmetrics.Labels) int { return v.obs[labelKey(l)] }
+func (v *fakeCounterVec) keys() []string {
+	out := make([]string, 0, len(v.obs))
+	for k := range v.obs {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+type fakeCounter struct {
+	vec *fakeCounterVec
+	key string
+}
+
+func (c *fakeCounter) Inc(_ context.Context)            { c.vec.obs[c.key]++ }
+func (c *fakeCounter) Add(_ context.Context, n float64) { c.vec.obs[c.key] += int(n) }
+
+func labelKey(l kernelmetrics.Labels) string {
+	keys := make([]string, 0, len(l))
+	for k := range l {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	key := ""
+	for _, k := range keys {
+		key += k + "=" + l[k] + ";"
+	}
+	return key
+}
+
+var _ kernelmetrics.CounterVec = (*fakeCounterVec)(nil)

--- a/runtime/webhook/receiver_metrics_test.go
+++ b/runtime/webhook/receiver_metrics_test.go
@@ -75,16 +75,24 @@ func TestReceiver_RecordsSignatureFailureReason(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sig := &fakeCounterVec{obs: map[string]int{}}
-			m := kwh.Metrics{SignatureFailures: sig}
+			// The Metrics instrument fields are sealed (unexported) — the only way
+			// to build a recording Metrics is RegisterMetrics over a Provider
+			// (WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 upstream seal). The test drives
+			// the real constructor and reads back from the fake provider.
+			p := newFakeProvider()
+			m, err := kwh.RegisterMetrics(p)
+			if err != nil {
+				t.Fatalf("RegisterMetrics: %v", err)
+			}
 			recv, req := tc.build(t, m)
 
 			recv.ServeHTTP(httptest.NewRecorder(), req)
 
-			got := sig.value(kernelmetrics.Labels{"source": testSourceID, "reason": tc.wantReason})
+			got := p.counterValue("webhook_signature_failures_total",
+				kernelmetrics.Labels{"source": testSourceID, "reason": tc.wantReason})
 			if got != 1 {
 				t.Errorf("signature_failures{reason=%q} = %d, want 1 (recorded keys: %v)",
-					tc.wantReason, got, sig.keys())
+					tc.wantReason, got, p.counters["webhook_signature_failures_total"].keys())
 			}
 		})
 	}
@@ -94,8 +102,11 @@ func TestReceiver_RecordsSignatureFailureReason(t *testing.T) {
 // ClaimBusy) records webhook_idempotency_hits_total{source}.
 func TestReceiver_RecordsIdempotencyHit(t *testing.T) {
 	for _, state := range []idempotency.ClaimState{idempotency.ClaimDone, idempotency.ClaimBusy} {
-		idem := &fakeCounterVec{obs: map[string]int{}}
-		m := kwh.Metrics{IdempotencyHits: idem}
+		p := newFakeProvider()
+		m, err := kwh.RegisterMetrics(p)
+		if err != nil {
+			t.Fatalf("RegisterMetrics: %v", err)
+		}
 		clk := clockmock.New(fixedNow)
 		verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(testTolerance*time.Second))
 		if err != nil {
@@ -110,7 +121,7 @@ func TestReceiver_RecordsIdempotencyHit(t *testing.T) {
 
 		recv.ServeHTTP(httptest.NewRecorder(), signedRequest(t, []byte(`{"k":"v"}`), "d1"))
 
-		if got := idem.value(kernelmetrics.Labels{"source": testSourceID}); got != 1 {
+		if got := p.counterValue("webhook_idempotency_hits_total", kernelmetrics.Labels{"source": testSourceID}); got != 1 {
 			t.Errorf("state %v: idempotency_hits{source} = %d, want 1", state, got)
 		}
 	}
@@ -177,3 +188,36 @@ func labelKey(l kernelmetrics.Labels) string {
 }
 
 var _ kernelmetrics.CounterVec = (*fakeCounterVec)(nil)
+
+// --- fakeProvider: minimal recording Provider for the sealed-Metrics path. ---
+//
+// The kwh.Metrics instrument fields are unexported (WEBHOOK-METRIC-LABEL-VALUES-
+// FROZEN-01 upstream seal), so external tests can no longer inject a fake vec via
+// a struct literal. They must build a Metrics through the real RegisterMetrics
+// constructor over a Provider; fakeProvider returns recording fakeCounterVecs
+// keyed by metric name and leaves histograms to the embedded NopProvider.
+type fakeProvider struct {
+	kernelmetrics.NopProvider
+	counters map[string]*fakeCounterVec
+}
+
+func newFakeProvider() *fakeProvider {
+	return &fakeProvider{counters: map[string]*fakeCounterVec{}}
+}
+
+func (p *fakeProvider) CounterVec(opts kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
+	v := &fakeCounterVec{obs: map[string]int{}}
+	p.counters[opts.Name] = v
+	return v, nil
+}
+
+// counterValue returns the recorded count for name+labels, or -1 if the metric
+// was never registered.
+func (p *fakeProvider) counterValue(name string, l kernelmetrics.Labels) int {
+	if v, ok := p.counters[name]; ok {
+		return v.value(l)
+	}
+	return -1
+}
+
+var _ kernelmetrics.Provider = (*fakeProvider)(nil)

--- a/runtime/webhook/registry.go
+++ b/runtime/webhook/registry.go
@@ -24,11 +24,15 @@ import (
 // clk is the mandatory positional clock (CLOCK-POSITIONAL-INJECTION-01); it
 // is the first parameter per the GoCell clock-injection convention.
 // store and claimer are shared across all receivers; they must not be nil.
+// rec is the optional receive-side metrics recorder (the zero value disables
+// recording); the bootstrap auto-wire passes the registered collector when a
+// metrics provider is configured.
 func BuildRouteGroups(
 	clk clock.Clock,
 	reqs []cell.WebhookReceiverRequest,
 	store kwh.SourceStore,
 	claimer idempotency.Claimer,
+	rec kwh.Metrics,
 ) ([]cell.RouteGroup, error) {
 	clock.MustHaveClock(clk, "webhook.BuildRouteGroups")
 	if validation.IsNilInterface(store) {
@@ -42,7 +46,7 @@ func BuildRouteGroups(
 
 	groups := make([]cell.RouteGroup, 0, len(reqs))
 	for _, req := range reqs {
-		rg, err := buildRouteGroup(clk, req, store, claimer)
+		rg, err := buildRouteGroup(clk, req, store, claimer, rec)
 		if err != nil {
 			return nil, fmt.Errorf("webhook BuildRouteGroups: contract %q: %w",
 				req.Spec.ContractID, err)
@@ -64,6 +68,7 @@ func buildRouteGroup(
 	req cell.WebhookReceiverRequest,
 	store kwh.SourceStore,
 	claimer idempotency.Claimer,
+	rec kwh.Metrics,
 ) (cell.RouteGroup, error) {
 	tolerance := time.Duration(req.Spec.ToleranceSeconds) * time.Second
 	verifier, err := kwh.NewHMACVerifier(clk, kwh.WithTolerance(tolerance))
@@ -71,7 +76,7 @@ func buildRouteGroup(
 		return cell.RouteGroup{}, fmt.Errorf("build verifier: %w", err)
 	}
 
-	recv, err := NewReceiver(clk, req.Spec, verifier, store, claimer, req.Handler)
+	recv, err := NewReceiver(clk, req.Spec, verifier, store, claimer, req.Handler, WithMetrics(rec))
 	if err != nil {
 		return cell.RouteGroup{}, fmt.Errorf("build receiver: %w", err)
 	}

--- a/runtime/webhook/registry.go
+++ b/runtime/webhook/registry.go
@@ -89,8 +89,16 @@ func buildRouteGroup(
 	// Prefix carries the full path pattern for cell ownership attribution.
 	// Register mounts at "/" so the adapter composes
 	// joinPrefix(Prefix, "/") = Prefix — no double-prefix.
+	//
+	// Listener is the dedicated cell.WebhookListener (NOT PrimaryListener):
+	// inbound webhooks authenticate via HMAC inside the Receiver, so the listener
+	// auth chain is auth.AuthNone{}. Mounting on PrimaryListener (which typically
+	// carries a JWT chain) would 401 an HMAC-signed request before it reached the
+	// verifier. The composition root MUST configure
+	// WithListener(cell.WebhookListener, addr, []auth.ListenerAuth{auth.AuthNone{}});
+	// bootstrap fail-fasts if a webhook RouteGroup names an unconfigured listener.
 	return cell.RouteGroup{
-		Listener: cell.PrimaryListener,
+		Listener: cell.WebhookListener,
 		Prefix:   pattern,
 		CellID:   req.Spec.CellID,
 		Register: func(mux cell.RouteMux) error {

--- a/runtime/webhook/registry_test.go
+++ b/runtime/webhook/registry_test.go
@@ -30,7 +30,7 @@ func TestBuildRouteGroups_HappyPath(t *testing.T) {
 		validReceiverRequest(t),
 	}
 
-	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestBuildRouteGroups_MultipleRequests(t *testing.T) {
 		},
 	}
 
-	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestBuildRouteGroups_EmptyReqs(t *testing.T) {
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
 
-	groups, err := rtwh.BuildRouteGroups(clk, nil, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(clk, nil, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups(nil): %v", err)
 	}
@@ -106,7 +106,7 @@ func TestBuildRouteGroups_NilStore(t *testing.T) {
 	clk := clockmock.New(fixedNow)
 	claimer := idempotency.NewInMemClaimer(clk)
 
-	_, err := rtwh.BuildRouteGroups(clk, nil, nil, claimer)
+	_, err := rtwh.BuildRouteGroups(clk, nil, nil, claimer, kwh.Metrics{})
 	if err == nil {
 		t.Fatal("expected error for nil store")
 	}
@@ -117,7 +117,7 @@ func TestBuildRouteGroups_NilClaimer(t *testing.T) {
 	clk := clockmock.New(fixedNow)
 	store := testStore(t)
 
-	_, err := rtwh.BuildRouteGroups(clk, nil, store, nil)
+	_, err := rtwh.BuildRouteGroups(clk, nil, store, nil, kwh.Metrics{})
 	if err == nil {
 		t.Fatal("expected error for nil claimer")
 	}
@@ -137,7 +137,7 @@ func TestBuildRouteGroups_InvalidSpec(t *testing.T) {
 		},
 	}
 
-	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err == nil {
 		t.Fatal("expected error for invalid spec")
 	}
@@ -149,7 +149,7 @@ func TestBuildRouteGroups_Register_IsMountCall(t *testing.T) {
 	store := testStore(t)
 	claimer := idempotency.NewInMemClaimer(clk)
 
-	groups, err := rtwh.BuildRouteGroups(clk, []cell.WebhookReceiverRequest{validReceiverRequest(t)}, store, claimer)
+	groups, err := rtwh.BuildRouteGroups(clk, []cell.WebhookReceiverRequest{validReceiverRequest(t)}, store, claimer, kwh.Metrics{})
 	if err != nil {
 		t.Fatalf("BuildRouteGroups: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestBuildRouteGroups_NewReceiverError(t *testing.T) {
 		},
 	}
 
-	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer)
+	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err == nil {
 		t.Fatal("expected error from NewReceiver inside buildRouteGroup")
 	}

--- a/runtime/webhook/registry_test.go
+++ b/runtime/webhook/registry_test.go
@@ -40,9 +40,10 @@ func TestBuildRouteGroups_HappyPath(t *testing.T) {
 
 	g := groups[0]
 
-	// Listener must be PrimaryListener.
-	if g.Listener != cell.PrimaryListener {
-		t.Errorf("Listener = %v, want PrimaryListener", g.Listener)
+	// Listener must be the dedicated WebhookListener (HMAC-at-app-layer; kept off
+	// PrimaryListener so a JWT chain cannot 401 the HMAC-signed request).
+	if g.Listener != cell.WebhookListener {
+		t.Errorf("Listener = %v, want WebhookListener", g.Listener)
 	}
 	// Prefix must match PathPattern.
 	if g.Prefix != testPathPattern {
@@ -140,6 +141,35 @@ func TestBuildRouteGroups_InvalidSpec(t *testing.T) {
 	_, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{})
 	if err == nil {
 		t.Fatal("expected error for invalid spec")
+	}
+}
+
+// TestBuildRouteGroups_InvalidSourceID is the runtime-side startup fail-fast
+// regression for the C1/F1 finding: a non-empty but metric-label-unsafe SourceID
+// (containing '=' or '|') must be rejected at BuildRouteGroups (construction)
+// time — NewReceiver → spec.Validate() → SourceID.Validate() — rather than
+// slipping through to panic at first signature-failure record via
+// MustValidateLabels in a request goroutine.
+func TestBuildRouteGroups_InvalidSourceID(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(fixedNow)
+	store := testStore(t)
+	claimer := idempotency.NewInMemClaimer(clk)
+
+	for _, bad := range []string{"bad=source", "bad|source"} {
+		t.Run(bad, func(t *testing.T) {
+			spec := testSpec()
+			spec.SourceID = bad
+			reqs := []cell.WebhookReceiverRequest{
+				{
+					Spec:    spec,
+					Handler: func(_ context.Context, _ kwh.Delivery) error { return nil },
+				},
+			}
+			if _, err := rtwh.BuildRouteGroups(clk, reqs, store, claimer, kwh.Metrics{}); err == nil {
+				t.Fatalf("expected startup error for label-unsafe SourceID %q", bad)
+			}
+		})
 	}
 }
 

--- a/tools/archtest/bootstrap_autowire_collector_funnel_test.go
+++ b/tools/archtest/bootstrap_autowire_collector_funnel_test.go
@@ -127,6 +127,7 @@ const autoWireHelperName = "autoWireCachedCollector"
 const (
 	autoWireRuntimeMetricsPkgPath = PlatformModulePath + "/runtime/observability/metrics"
 	autoWireProjectionPkgPath     = PlatformModulePath + "/kernel/projection"
+	autoWireWebhookPkgPath        = PlatformModulePath + "/kernel/webhook"
 )
 
 // autoWireCtorSymbols maps each {pkgPath, funcName} metric-collector constructor
@@ -137,6 +138,7 @@ var autoWireCtorSymbols = map[[2]string]string{
 	{autoWireRuntimeMetricsPkgPath, "NewEventRouterCollector"}:  "metricsmiddleware.NewEventRouterCollector",
 	{autoWireRuntimeMetricsPkgPath, "NewOutboxRejectCollector"}: "metricsmiddleware.NewOutboxRejectCollector",
 	{autoWireProjectionPkgPath, "RegisterMetrics"}:              "projection.RegisterMetrics",
+	{autoWireWebhookPkgPath, "RegisterMetrics"}:                 "webhook.RegisterMetrics",
 }
 
 // autoWireFunneledPkgs is the set of packages whose collector constructors the
@@ -146,6 +148,7 @@ var autoWireCtorSymbols = map[[2]string]string{
 var autoWireFunneledPkgs = map[string]struct{}{
 	autoWireRuntimeMetricsPkgPath: {},
 	autoWireProjectionPkgPath:     {},
+	autoWireWebhookPkgPath:        {},
 }
 
 // autoWireConstructArgIndex is the positional index of the construct argument in

--- a/tools/archtest/testdata/webhook_claimer_violate/fixture.go
+++ b/tools/archtest/testdata/webhook_claimer_violate/fixture.go
@@ -1,0 +1,33 @@
+//go:build archtest_fixture
+
+// Package webhookclaimerviolate is a RED fixture for
+// WEBHOOK-IDEMPOTENCY-CLAIMER-01/A1: a `claim` that fabricates the idempotency
+// receipt instead of sourcing it from r.claimer.Claim must be flagged. It mirrors
+// the runtime/webhook claimed token shape (sealed struct with an rcpt field).
+package webhookclaimerviolate
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/kernel/idempotency"
+)
+
+// claimed mirrors runtime/webhook.claimed: an unforgeable token carrying the
+// idempotency receipt.
+type claimed struct {
+	rcpt idempotency.Receipt
+}
+
+// Receiver mirrors the runtime/webhook Receiver's claimer dependency.
+type Receiver struct {
+	claimer idempotency.Claimer
+}
+
+// claim FORGES the receipt with NonAcquiredReceipt instead of calling
+// r.claimer.Claim — the data-flow violation the archtest must detect. The
+// forged var is an Ident (so it passes a naive "rcpt must be an Ident" check),
+// but its object is not bound from a Claimer.Claim call.
+func (r *Receiver) claim(_ context.Context) claimed {
+	forged := idempotency.NonAcquiredReceipt()
+	return claimed{rcpt: forged}
+}

--- a/tools/archtest/testdata/webhook_metric_callsite_fixtures/green/fixture.go
+++ b/tools/archtest/testdata/webhook_metric_callsite_fixtures/green/fixture.go
@@ -1,0 +1,26 @@
+//go:build archtest_fixture
+
+// Package recorddeliverygreen is the GREEN over-fire guard for the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 callsite guard: a declared const and a
+// typed (non-constant) webhookDeliveryResult value are both allowed — only
+// inline constants are banned.
+package recorddeliverygreen
+
+import "context"
+
+type webhookDeliveryResult string
+
+const deliverySuccess webhookDeliveryResult = "success"
+
+// Metrics mirrors kernel/webhook.Metrics' recordDelivery method shape.
+type Metrics struct{}
+
+func (m Metrics) recordDelivery(_ context.Context, _ string, _ webhookDeliveryResult) {}
+
+func classify() webhookDeliveryResult { return deliverySuccess }
+
+func caller(ctx context.Context, m Metrics, result webhookDeliveryResult) {
+	m.recordDelivery(ctx, "stripe", deliverySuccess) // named const — allowed
+	m.recordDelivery(ctx, "stripe", result)          // typed (non-constant) var — allowed
+	m.recordDelivery(ctx, "stripe", classify())      // typed (non-constant) call — allowed
+}

--- a/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_dr_conversion/fixture.go
+++ b/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_dr_conversion/fixture.go
@@ -1,0 +1,22 @@
+//go:build archtest_fixture
+
+// Package recorddeliveryconversion is a RED fixture for the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 delivery-side conversion ban: a
+// webhookDeliveryResult("x") conversion mints a value outside the declared
+// delivery* const set. Banning the conversion is what makes the callsite guard's
+// "typed non-constant value is allowed" branch safe (the trusted classifiers
+// return declared consts, never conversions); a value laundered through a var or
+// helper would otherwise slip past the callsite guard. The conversion scanner
+// must flag this.
+package recorddeliveryconversion
+
+type webhookDeliveryResult string
+
+const deliverySuccess webhookDeliveryResult = "success"
+
+func sink(_ webhookDeliveryResult) {}
+
+func caller() {
+	sink(webhookDeliveryResult("rogue")) // conversion — MUST be flagged
+	_ = deliverySuccess
+}

--- a/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_literal/fixture.go
+++ b/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_literal/fixture.go
@@ -1,0 +1,24 @@
+//go:build archtest_fixture
+
+// Package recorddeliveryred is a RED fixture for the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 callsite guard: recordDelivery called
+// with an inline string literal (the residual hole the sealed
+// webhookDeliveryResult type cannot close — an untyped string constant is
+// assignable to a defined string type) must be flagged.
+package recorddeliveryred
+
+import "context"
+
+type webhookDeliveryResult string
+
+const deliverySuccess webhookDeliveryResult = "success"
+
+// Metrics mirrors kernel/webhook.Metrics' recordDelivery method shape.
+type Metrics struct{}
+
+func (m Metrics) recordDelivery(_ context.Context, _ string, _ webhookDeliveryResult) {}
+
+func caller(ctx context.Context, m Metrics) {
+	m.recordDelivery(ctx, "stripe", "rogue") // inline literal — MUST be flagged
+	_ = deliverySuccess
+}

--- a/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_reason_literal/fixture.go
+++ b/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_reason_literal/fixture.go
@@ -1,0 +1,26 @@
+//go:build archtest_fixture
+
+// Package recordsignaturefailurereasonliteral is a RED fixture for the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 RecordSignatureFailure callsite guard: an
+// inline string literal passed as the reason. This is the F2′ hole — the reason
+// side previously had NO callsite guard, and a bare string literal implicitly
+// converts to SignatureFailureReason (so the conversion-ban scanner, which only
+// matches an explicit SignatureFailureReason(...) CallExpr, never saw it). The new
+// callsite guard must flag this.
+package recordsignaturefailurereasonliteral
+
+import "context"
+
+type SignatureFailureReason string
+
+const ReasonBadSignature SignatureFailureReason = "bad_signature"
+
+// Metrics mirrors kernel/webhook.Metrics' RecordSignatureFailure method shape.
+type Metrics struct{}
+
+func (m Metrics) RecordSignatureFailure(_ context.Context, _ string, _ SignatureFailureReason) {}
+
+func caller(ctx context.Context, m Metrics) {
+	m.RecordSignatureFailure(ctx, "stripe", "rogue") // inline literal — MUST be flagged
+	_ = ReasonBadSignature
+}

--- a/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_untyped_const/fixture.go
+++ b/tools/archtest/testdata/webhook_metric_callsite_fixtures/red_untyped_const/fixture.go
@@ -1,0 +1,30 @@
+//go:build archtest_fixture
+
+// Package recorddeliveryuntypedconst is a RED fixture for the
+// WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 recordDelivery callsite guard: an UNTYPED
+// string constant assigned through to the sealed webhookDeliveryResult parameter.
+// This is the F2 hole the prior guard let through — it accepted ANY *types.Const,
+// not just a declared delivery* const, so `const x = "rogue"; recordDelivery(x)`
+// implicitly converted and bypassed the freeze. The tightened guard checks the
+// const's TYPE is identical to the enum type and must flag this.
+package recorddeliveryuntypedconst
+
+import "context"
+
+type webhookDeliveryResult string
+
+const deliverySuccess webhookDeliveryResult = "success"
+
+// rogue is an UNTYPED string constant — its object type is untyped string, NOT
+// webhookDeliveryResult, so it must not be accepted as a frozen label value.
+const rogue = "rogue"
+
+// Metrics mirrors kernel/webhook.Metrics' recordDelivery method shape.
+type Metrics struct{}
+
+func (m Metrics) recordDelivery(_ context.Context, _ string, _ webhookDeliveryResult) {}
+
+func caller(ctx context.Context, m Metrics) {
+	m.recordDelivery(ctx, "stripe", rogue) // untyped const — MUST be flagged
+	_ = deliverySuccess
+}

--- a/tools/archtest/webhook_idempotency_claimer_test.go
+++ b/tools/archtest/webhook_idempotency_claimer_test.go
@@ -1,0 +1,229 @@
+// INVARIANT: WEBHOOK-IDEMPOTENCY-CLAIMER-01
+//
+// This file owns ONE invariant: in runtime/webhook, every constructed `claimed`
+// token whose `rcpt` field is set MUST source that receipt from a real
+// idempotency.Claimer.Claim(...) call — the receipt's provenance is the Claimer,
+// never a fabricated / zero / NonAcquiredReceipt value.
+//
+// # Why this is NOT redundant with WEBHOOK-RECEIVER-PIPELINE-01
+//
+// PIPELINE-01 seals ORDERING: a `claimed` token can only be constructed inside
+// the function `claim`, and the business handler can only be invoked with a
+// `claimed` token (verify → claim → invokeHandler). It does NOT prove that the
+// `claim` step does real idempotency work — a refactor could build
+// `claimed{rcpt: someZeroReceipt}` inside `claim` and still pass PIPELINE-01,
+// silently disabling deduplication while keeping the receive pipeline's shape.
+// CLAIMER-01 locks SUBSTANCE: the rcpt field must data-flow from Claimer.Claim.
+// The two invariants are orthogonal axes (ordering vs. provenance).
+//
+// # Mechanism (type-keyed data-flow, rename-proof)
+//
+// A1: build the set of var objects that are bound, anywhere in the package, by an
+// assignment whose sole RHS is a CallExpr resolving (via go/types) to the method
+// idempotency.Claimer.Claim — `state, rcpt, err := r.claimer.Claim(...)` puts the
+// `rcpt` object into the set. Then, for every CompositeLit whose declared type is
+// the package's sealed `claimed` named type (types.Identical, not name-prefix),
+// require the `rcpt` field's value (when present) to be an Ident whose object is
+// in that set. The empty `claimed{}` literal (the error-path zero token, which is
+// never fed to the handler) has no rcpt field and is therefore exempt.
+//
+// The check keys on the `claimed` TYPE identity + the Claimer.Claim METHOD
+// identity + Go object identity for the rcpt var — NOT on the function name
+// `claim`. Renaming `claim` to anything does not escape it (unlike a name-keyed
+// "function claim must call Claim" check, which would be a Soft, rename-escapable
+// convention and is deliberately NOT what this archtest does).
+//
+// # AI-robust rating
+//
+// Single-axis Medium (NOT a funnel — there is no caller-allowlist downstream /
+// sealed-interface upstream to split, so the two-column funnel grading does not
+// apply; same shape as SAGA-CONSTRUCTOR-NIL-GUARD-01). Downstream: archtest
+// type-aware data-flow (object identity + method resolution); a fabricated rcpt
+// is detectable but Go cannot make it a compile error. Upstream: Go cannot force
+// a function to call a method — the permanent ceiling shared with
+// WEBHOOK-RECEIVER-PIPELINE-01 upstream and the gh #1282 family (won't-do).
+//
+// # Blind spots (per ai-robust.md §"工具选定后强制盲区自检")
+//
+//   - Intra-function reflect/aliasing: a receipt laundered through reflect or an
+//     interface round-trip before reaching the rcpt field is not traced. Bounded:
+//     reflect on idempotency.Receipt is not expressible at the AST layer and is
+//     not used anywhere in runtime/webhook; the single production construction
+//     site (receiver.go claim) is the GREEN baseline.
+//   - rcpt sourced from a Claim call whose result is reassigned through an
+//     intermediate var chain (rcpt2 := rcpt; claimed{rcpt: rcpt2}) is not traced
+//     past one hop. Bounded: the production form is the direct multi-assign; a
+//     chain would be visually distinct and caught in review.
+//
+// # Reverse self-check (non-vacuous proof)
+//
+// TestWebhookIdempotencyClaimer01_Fixture runs the scanner on a fixture whose
+// claim fabricates the receipt (no Claimer.Claim) and asserts it is flagged; the
+// production runtime/webhook Pass is the GREEN baseline (0 diagnostics).
+package archtest
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+const idempotencyClaimerPkgPath = PlatformModulePath + "/kernel/idempotency"
+
+// namedName unwraps pointers and returns the named type's name, or "".
+func namedName(t types.Type) string {
+	for {
+		switch tt := t.(type) {
+		case *types.Pointer:
+			t = tt.Elem()
+		case *types.Named:
+			if tt.Obj() != nil {
+				return tt.Obj().Name()
+			}
+			return ""
+		default:
+			return ""
+		}
+	}
+}
+
+// isClaimerClaimCall reports whether call resolves to idempotency.Claimer.Claim.
+func isClaimerClaimCall(info *types.Info, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Claim" {
+		return false
+	}
+	fn, ok := ResolveMethodCall(info, sel)
+	if !ok || fn == nil || fn.Name() != "Claim" || fn.Pkg() == nil {
+		return false
+	}
+	if fn.Pkg().Path() != idempotencyClaimerPkgPath {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	return namedName(sig.Recv().Type()) == "Claimer"
+}
+
+// scanClaimerProvenance implements WEBHOOK-IDEMPOTENCY-CLAIMER-01/A1: every
+// `claimed{... rcpt: X ...}` literal in the scanned package must have X be an
+// Ident bound from an idempotency.Claimer.Claim call. The scanner detects the
+// package's own `claimed` type by name, so it serves both the production Pass
+// (runtime/webhook) and the reverse fixture Pass.
+func scanClaimerProvenance(p *Pass) []Diagnostic {
+	info := p.TypesInfo
+	if info == nil || p.Pkg == nil {
+		return nil
+	}
+	tn, ok := p.Pkg.Scope().Lookup("claimed").(*types.TypeName)
+	if !ok {
+		return nil
+	}
+	claimedType := tn.Type()
+
+	// Pass 1: collect var objects sourced from a Claimer.Claim call.
+	claimSourced := map[types.Object]bool{}
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		EachInSubtree[ast.AssignStmt](file, func(as *ast.AssignStmt) {
+			if len(as.Rhs) != 1 {
+				return
+			}
+			call, ok := as.Rhs[0].(*ast.CallExpr)
+			if !ok || !isClaimerClaimCall(info, call) {
+				return
+			}
+			for _, lhs := range as.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok {
+					if obj := info.ObjectOf(id); obj != nil {
+						claimSourced[obj] = true
+					}
+				}
+			}
+		})
+	}
+
+	// Pass 2: every claimed{...rcpt:...} literal must source rcpt from the set.
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
+			if cl.Type == nil {
+				return
+			}
+			t := info.TypeOf(cl.Type)
+			if t == nil || !types.Identical(t, claimedType) {
+				return
+			}
+			for _, elt := range cl.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok || key.Name != "rcpt" {
+					continue
+				}
+				valIdent, ok := kv.Value.(*ast.Ident)
+				if ok && claimSourced[info.ObjectOf(valIdent)] {
+					continue // provenance confirmed
+				}
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(kv.Value.Pos()).Line,
+					Message: "claimed.rcpt is not sourced from idempotency.Claimer.Claim — the receipt " +
+						"must data-flow from a `... := r.claimer.Claim(...)` call, not a fabricated / " +
+						"zero / NonAcquiredReceipt value (WEBHOOK-IDEMPOTENCY-CLAIMER-01/A1)",
+				})
+			}
+		})
+	}
+	return diags
+}
+
+// TestWebhookIdempotencyClaimer01 is the production GREEN baseline: the single
+// claimed{rcpt: rcpt} construction in runtime/webhook sources rcpt from
+// r.claimer.Claim, so the scanner reports nothing.
+func TestWebhookIdempotencyClaimer01(t *testing.T) {
+	t.Parallel()
+
+	const runtimeWebhookPkg = PlatformModulePath + "/runtime/webhook"
+	var allDiags []Diagnostic
+	sawClaimed := false
+	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != runtimeWebhookPkg {
+			return nil
+		}
+		if _, ok := p.Pkg.Scope().Lookup("claimed").(*types.TypeName); ok {
+			sawClaimed = true
+		}
+		allDiags = append(allDiags, scanClaimerProvenance(p)...)
+		return nil
+	})
+
+	if !sawClaimed {
+		t.Fatal("WEBHOOK-IDEMPOTENCY-CLAIMER-01: `claimed` type not found in runtime/webhook — " +
+			"renamed or removed? The scanner cannot anchor without it.")
+	}
+	Report(t, "WEBHOOK-IDEMPOTENCY-CLAIMER-01", allDiags)
+}
+
+// TestWebhookIdempotencyClaimer01_Fixture proves the scanner is non-vacuous: a
+// claim that fabricates the receipt (no Claimer.Claim) is flagged.
+func TestWebhookIdempotencyClaimer01_Fixture(t *testing.T) {
+	t.Parallel()
+	pattern := "./tools/archtest/testdata/webhook_claimer_violate"
+	diags := Run(t, Fixture(FixtureOpts{}, []string{pattern}), scanClaimerProvenance)
+	if len(diags) != 1 {
+		t.Fatalf("WEBHOOK-IDEMPOTENCY-CLAIMER-01 reverse fixture: want exactly 1 diagnostic "+
+			"(the fabricated-receipt claim), got %d: %v", len(diags), diags)
+	}
+}

--- a/tools/archtest/webhook_metric_label_values_frozen_test.go
+++ b/tools/archtest/webhook_metric_label_values_frozen_test.go
@@ -41,9 +41,11 @@
 //     verify step, which RETURNS a typed SignatureFailureReason — the type system
 //     already constrains the value, and the cross-package callsite would require a
 //     separate scan of runtime/webhook. The residual hole (a SignatureFailureReason("x")
-//     conversion at a RecordSignatureFailure callsite) is a bounded blind spot: the
-//     value-set freeze (A1) still catches any new declared const, and there is one
-//     production caller (receiver.go ServeHTTP) passing a verify-derived typed value.
+//     conversion at a RecordSignatureFailure callsite) is a bounded blind spot, and is
+//     closed by a reverse self-check: TestWebhookMetricLabelValuesFrozen01_NoReasonConversion
+//     asserts zero SignatureFailureReason(...) conversions exist in production
+//     kernel/webhook + runtime/webhook (the value-set freeze A1 catches new declared
+//     consts; the conversion form is forbidden outright).
 //
 //   - The test runs only on the kernel/webhook package Pass (filtered by path).
 //
@@ -247,6 +249,81 @@ func TestWebhookMetricLabelValuesFrozen01_NegativeControl(t *testing.T) {
 		t.Fatalf("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 negative control: the frozen want-set compared "+
 			"against itself produced a non-empty diff — the comparison has a bug: %s", diff)
 	}
+}
+
+// scanSignatureFailureReasonConversions flags any production conversion
+// expression `SignatureFailureReason(x)` (kernel/webhook) — the documented
+// blind spot of the recordDelivery-only callsite guard. The receive-side reason
+// flows from runtime/webhook's verify() as a typed value and is only ever a
+// declared ReasonX const; a conversion would be the bypass that introduces a
+// label value outside the frozen set without touching the const declarations.
+// The reverse self-check asserts production code contains zero such conversions.
+func scanSignatureFailureReasonConversions(p *Pass) []Diagnostic {
+	info := p.TypesInfo
+	if info == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if len(call.Args) != 1 {
+				return
+			}
+			var obj types.Object
+			switch fn := call.Fun.(type) {
+			case *ast.Ident:
+				obj = info.ObjectOf(fn)
+			case *ast.SelectorExpr:
+				obj = info.ObjectOf(fn.Sel)
+			default:
+				return
+			}
+			tn, ok := obj.(*types.TypeName)
+			if !ok || tn.Name() != "SignatureFailureReason" || tn.Pkg() == nil {
+				return
+			}
+			if tn.Pkg().Path() != PlatformModulePath+"/kernel/webhook" {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(call.Pos()).Line,
+				Message: "SignatureFailureReason(...) conversion in production — pass a declared " +
+					"ReasonX const (the value-set freeze caps that set), never a conversion that could " +
+					"introduce an off-set label value (WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 blind-spot self-check)",
+			})
+		})
+	}
+	return diags
+}
+
+// TestWebhookMetricLabelValuesFrozen01_NoReasonConversion is the blind-spot
+// reverse self-check (ai-robust.md §"工具选定后强制盲区自检"): the recordDelivery
+// callsite guard does not cover RecordSignatureFailure (cross-package, exported),
+// so a `SignatureFailureReason("x")` conversion would bypass it. This test proves
+// that form does not appear in production kernel/webhook or runtime/webhook.
+func TestWebhookMetricLabelValuesFrozen01_NoReasonConversion(t *testing.T) {
+	t.Parallel()
+	const (
+		kernelWebhookPkg  = PlatformModulePath + "/kernel/webhook"
+		runtimeWebhookPkg = PlatformModulePath + "/runtime/webhook"
+	)
+	var allDiags []Diagnostic
+	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		if p.Pkg.Path() != kernelWebhookPkg && p.Pkg.Path() != runtimeWebhookPkg {
+			return nil
+		}
+		allDiags = append(allDiags, scanSignatureFailureReasonConversions(p)...)
+		return nil
+	})
+	Report(t, "WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01", allDiags)
 }
 
 // TestWebhookMetricLabelValuesFrozen01_CallsiteGuard_Fixtures proves the callsite

--- a/tools/archtest/webhook_metric_label_values_frozen_test.go
+++ b/tools/archtest/webhook_metric_label_values_frozen_test.go
@@ -1,0 +1,276 @@
+// INVARIANT: WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01
+//
+// This file owns ONE invariant: the value sets of the two sealed string-typed
+// label enums in kernel/webhook — the `result` label on webhook_deliveries_total
+// and the `reason` label on webhook_signature_failures_total — are frozen to
+// exactly:
+//
+//	webhookDeliveryResult  → {success, client_error, server_error, transport_error, blocked}
+//	SignatureFailureReason → {missing_header, invalid_header, unknown_source, bad_signature, timestamp_expired}
+//
+// The delivery result is status-aware (NOT a 3-way disposition collapse): the
+// kernel Classify maps every non-2xx + transient transport to Requeue, but the
+// metric distinguishes 4xx (client_error) from 5xx (server_error) so an endpoint
+// misconfiguration flood and a downstream outage are separable on dashboards.
+// This mirrors Alertmanager's clientError/serverError split, Kubernetes admission
+// webhook's error_type, and Convoy's Discarded. Runtime drift (a 6th const, a
+// renamed value) would break dashboards/SLOs without a compile error.
+//
+// # AI-robust rating
+//
+// Medium. Mechanism: go/types const-value enumeration by sealed TYPE +
+// order-insensitive comparison against an independent hardcoded want-set, plus a
+// downstream callsite guard on recordDelivery. Not Hard because the enum consts
+// are package-scoped string types (an in-package author can add a new const and
+// the compiler does not object); the archtest is the external frozen-witness.
+//
+// Hard upgrade path: enroll both value sets into the metricschema golden so a
+// value-freeze is byte-locked at codegen time (a 6th value without a golden
+// update → codegen-diff CI failure). Shared with saga/reconcile at gh #1416 —
+// do NOT open a duplicate tracking issue.
+//
+// # Blind spots (per ai-robust.md §"工具选定后强制盲区自检")
+//
+//   - Enumeration is by enum TYPE identity (types.Identical), not by name prefix:
+//     a const renamed off the Reason*/delivery* convention but still typed as the
+//     enum is still counted, and a new const of the enum type is still caught.
+//
+//   - The callsite guard covers recordDelivery (the delivery-result enum mapped
+//     from a switch in Dispatcher.Handle). It does NOT cover RecordSignatureFailure:
+//     that exported method's reason argument originates from runtime/webhook's
+//     verify step, which RETURNS a typed SignatureFailureReason — the type system
+//     already constrains the value, and the cross-package callsite would require a
+//     separate scan of runtime/webhook. The residual hole (a SignatureFailureReason("x")
+//     conversion at a RecordSignatureFailure callsite) is a bounded blind spot: the
+//     value-set freeze (A1) still catches any new declared const, and there is one
+//     production caller (receiver.go ServeHTTP) passing a verify-derived typed value.
+//
+//   - The test runs only on the kernel/webhook package Pass (filtered by path).
+//
+// # Reverse self-check (non-vacuous proof)
+//
+// TestWebhookMetricLabelValuesFrozen01_NegativeControl demonstrates a synthetic
+// extra/renamed value is detected; the callsite-guard fixture test proves the
+// recordDelivery guard flags an inline literal and passes a declared const.
+package archtest
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+// webhookLabelEnumWant is the frozen membership of the two webhook metric label
+// value sets, keyed by the sealed enum type name in kernel/webhook. Updating any
+// entry requires a simultaneous update to: (1) this map, (2) the enum consts in
+// kernel/webhook/metrics.go, (3) dashboards/alerts referencing
+// webhook_deliveries_total{result} / webhook_signature_failures_total{reason},
+// and (4) the PR-6 observability documentation.
+var webhookLabelEnumWant = map[string][]string{
+	"webhookDeliveryResult": {
+		"success", "client_error", "server_error", "transport_error", "blocked",
+	},
+	"SignatureFailureReason": {
+		"missing_header", "invalid_header", "unknown_source", "bad_signature", "timestamp_expired",
+	},
+}
+
+// collectWebhookEnumConsts enumerates the string constant values of every
+// package-scope const in p whose TYPE is the named enum typeName. Returns the
+// values and whether the type was found.
+func collectWebhookEnumConsts(p *Pass, typeName string) ([]string, bool) {
+	if p.Pkg == nil || p.TypesInfo == nil {
+		return nil, false
+	}
+	tn, ok := p.Pkg.Scope().Lookup(typeName).(*types.TypeName)
+	if !ok {
+		return nil, false
+	}
+	labelType := tn.Type()
+	scope := p.Pkg.Scope()
+	var values []string
+	for _, name := range scope.Names() {
+		c, ok := scope.Lookup(name).(*types.Const)
+		if !ok {
+			continue
+		}
+		if !types.Identical(c.Type(), labelType) {
+			continue
+		}
+		if c.Val().Kind() != constant.String {
+			continue
+		}
+		values = append(values, constant.StringVal(c.Val()))
+	}
+	return values, true
+}
+
+// TestWebhookMetricLabelValuesFrozen01 freezes both enum VALUE sets in
+// kernel/webhook against the independent hardcoded want-sets (anti-tautology),
+// both directions: nothing missing, nothing extra.
+func TestWebhookMetricLabelValuesFrozen01(t *testing.T) {
+	t.Parallel()
+
+	const webhookPkg = PlatformModulePath + "/kernel/webhook"
+	got := map[string][]string{}
+	found := map[string]bool{}
+
+	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != webhookPkg {
+			return nil
+		}
+		for typeName := range webhookLabelEnumWant {
+			if vals, ok := collectWebhookEnumConsts(p, typeName); ok {
+				got[typeName] = vals
+				found[typeName] = true
+			}
+		}
+		return nil
+	})
+
+	for typeName, want := range webhookLabelEnumWant {
+		if !found[typeName] {
+			t.Fatalf("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01: enum type %q not found in %s — "+
+				"renamed or removed?", typeName, webhookPkg)
+		}
+		vals := got[typeName]
+		if len(vals) == 0 {
+			t.Fatalf("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01: found 0 consts of type %q in %s",
+				typeName, webhookPkg)
+		}
+		if diff := resultValuesDiff(vals, want); diff != "" {
+			t.Fatalf("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01: %q value set drifted from the frozen want-set.\n%s\n"+
+				"If intentional, update ALL sync points in the same PR: (1) webhookLabelEnumWant here, "+
+				"(2) kernel/webhook/metrics.go enum consts, (3) dashboards/alerts, (4) PR-6 observability docs.",
+				typeName, diff)
+		}
+		if len(vals) != len(want) {
+			t.Errorf("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01: type %q has %d consts, want exactly %d",
+				typeName, len(vals), len(want))
+		}
+	}
+}
+
+// scanWebhookRecordDeliveryCallsites is the downstream callsite guard: it flags
+// any (Metrics).recordDelivery call whose result argument (index 2) is a
+// compile-time CONSTANT that is not a bare reference to a declared const. This
+// closes the hole the sealed webhookDeliveryResult type cannot — an untyped
+// string literal is assignable to the defined type. Allowed: a named const Ident
+// (deliverySuccess/…/deliveryBlocked) or any non-constant webhookDeliveryResult
+// expression (dispositionResult(...) / statusResult(...) calls). Banned: a string
+// literal or a webhookDeliveryResult("x") conversion.
+func scanWebhookRecordDeliveryCallsites(p *Pass) []Diagnostic {
+	info := p.TypesInfo
+	if info == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "recordDelivery" {
+				return
+			}
+			fn, ok := ResolveMethodCall(info, sel)
+			if !ok || fn.Name() != "recordDelivery" || len(call.Args) < 3 {
+				return
+			}
+			arg := call.Args[2]
+			tv, ok := info.Types[arg]
+			if !ok || tv.Value == nil {
+				return // non-constant (typed var / func call) — allowed
+			}
+			if id, isIdent := arg.(*ast.Ident); isIdent {
+				if _, isConst := info.ObjectOf(id).(*types.Const); isConst {
+					return
+				}
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(arg.Pos()).Line,
+				Message: "recordDelivery result argument is an inline constant — pass a declared " +
+					"delivery* const or a typed (non-constant) webhookDeliveryResult, not a string " +
+					"literal or webhookDeliveryResult(...) conversion " +
+					"(WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 callsite guard)",
+			})
+		})
+	}
+	return diags
+}
+
+// TestWebhookMetricLabelValuesFrozen01_CallsiteGuard is the production GREEN
+// baseline: every recordDelivery call in kernel/webhook passes a declared const
+// or a typed (non-constant) value — never an inline literal.
+func TestWebhookMetricLabelValuesFrozen01_CallsiteGuard(t *testing.T) {
+	t.Parallel()
+
+	const webhookPkg = PlatformModulePath + "/kernel/webhook"
+	var allDiags []Diagnostic
+	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != webhookPkg {
+			return nil
+		}
+		allDiags = append(allDiags, scanWebhookRecordDeliveryCallsites(p)...)
+		return nil
+	})
+	Report(t, "WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01", allDiags)
+}
+
+// TestWebhookMetricLabelValuesFrozen01_NegativeControl proves the value-set
+// comparison is non-vacuous: a synthetically drifted set MUST produce a
+// non-empty diff, and the correct set MUST produce an empty diff.
+func TestWebhookMetricLabelValuesFrozen01_NegativeControl(t *testing.T) {
+	t.Parallel()
+
+	want := webhookLabelEnumWant["webhookDeliveryResult"]
+
+	withExtra := append([]string{}, want...)
+	withExtra = append(withExtra, "panic")
+	if diff := resultValuesDiff(withExtra, want); diff == "" {
+		t.Fatal("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 negative control: a set with an extra 'panic' " +
+			"value produced an empty diff — the comparison is vacuous")
+	}
+
+	withRenamed := []string{"success", "retry", "server_error", "transport_error", "blocked"}
+	if diff := resultValuesDiff(withRenamed, want); diff == "" {
+		t.Fatal("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 negative control: 'client_error' renamed to " +
+			"'retry' produced an empty diff — the comparison is vacuous")
+	}
+
+	if diff := resultValuesDiff(want, want); diff != "" {
+		t.Fatalf("WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 negative control: the frozen want-set compared "+
+			"against itself produced a non-empty diff — the comparison has a bug: %s", diff)
+	}
+}
+
+// TestWebhookMetricLabelValuesFrozen01_CallsiteGuard_Fixtures proves the callsite
+// guard is non-vacuous: the RED fixture (inline literal) is flagged, the GREEN
+// fixture (named const + typed var) is not.
+func TestWebhookMetricLabelValuesFrozen01_CallsiteGuard_Fixtures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		dir  string
+		want int
+	}{
+		{"red_literal", 1},
+		{"green", 0},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.dir, func(t *testing.T) {
+			t.Parallel()
+			pattern := "./tools/archtest/testdata/webhook_metric_callsite_fixtures/" + c.dir
+			diags := Run(t, Fixture(FixtureOpts{}, []string{pattern}), scanWebhookRecordDeliveryCallsites)
+			if len(diags) != c.want {
+				t.Fatalf("callsite-guard fixture %s: want %d diagnostic(s), got %d: %v",
+					c.dir, c.want, len(diags), diags)
+			}
+		})
+	}
+}

--- a/tools/archtest/webhook_metric_label_values_frozen_test.go
+++ b/tools/archtest/webhook_metric_label_values_frozen_test.go
@@ -16,18 +16,41 @@
 // webhook's error_type, and Convoy's Discarded. Runtime drift (a 6th const, a
 // renamed value) would break dashboards/SLOs without a compile error.
 //
-// # AI-robust rating
+// # AI-robust rating (closed two-direction funnel)
 //
-// Medium. Mechanism: go/types const-value enumeration by sealed TYPE +
-// order-insensitive comparison against an independent hardcoded want-set, plus a
-// downstream callsite guard on recordDelivery. Not Hard because the enum consts
-// are package-scoped string types (an in-package author can add a new const and
-// the compiler does not object); the archtest is the external frozen-witness.
+// The funnel has three locked dimensions; grade each direction separately
+// (ai-robust.md §"Funnel 双向锁评级"):
 //
-// Hard upgrade path: enroll both value sets into the metricschema golden so a
-// value-freeze is byte-locked at codegen time (a 6th value without a golden
-// update → codegen-diff CI failure). Shared with saga/reconcile at gh #1416 —
-// do NOT open a duplicate tracking issue.
+//	Upstream — metric write surface
+//	  • OUTSIDE kernel/webhook: Hard. The kwh.Metrics instrument fields are
+//	    unexported, so no holder can call `m.Deliveries.With(Labels{...})` — the
+//	    only metric-write surface is the record* methods, which take the sealed
+//	    typed enums. A populated Metrics is constructible only by RegisterMetrics
+//	    (the sole constructor) in-package.
+//	  • WITHIN kernel/webhook: Medium. A new in-package function could still call
+//	    `m.<field>.With(...)` directly; scanWebhookMetricSoleWriter locks those
+//	    callsites to the sanctioned record* methods. This is the Go package-
+//	    visibility ceiling (same family as SPAN-SETATTR-HOLDER-SEAL #851 /
+//	    HEALTHZ-HOLDER-SEAL #893).
+//
+//	Downstream — label value reaching a record* method
+//	  • Medium. scanEnumLabelCallsite resolves the arg to a declared const of the
+//	    sealed enum TYPE (object identity via the method's own signature, so it is
+//	    rename-proof and cross-package). It covers recordDelivery (delivery) AND
+//	    RecordSignatureFailure (reason) — closing the prior gaps where (a) the
+//	    delivery guard accepted ANY *types.Const, not just delivery* consts (F2),
+//	    and (b) the reason side had no callsite guard at all, so a bare string
+//	    literal implicitly converted to SignatureFailureReason (F2′). The residual
+//	    is the trusted "typed non-constant value" path (classifier output), which
+//	    the conversion bans make safe (a value cannot be minted off-set without a
+//	    conversion). Hard ceiling = the same package-scoped string type as above.
+//
+//	Value-set membership
+//	  • Medium. go/types const enumeration by sealed TYPE identity vs an
+//	    independent hardcoded want-set (both directions: nothing missing, nothing
+//	    extra). Hard upgrade path = enroll both value sets into the metricschema
+//	    golden so a 6th value is byte-locked at codegen time. Shared with saga/
+//	    reconcile at gh #1416 — do NOT open a duplicate tracking issue.
 //
 // # Blind spots (per ai-robust.md §"工具选定后强制盲区自检")
 //
@@ -35,25 +58,27 @@
 //     a const renamed off the Reason*/delivery* convention but still typed as the
 //     enum is still counted, and a new const of the enum type is still caught.
 //
-//   - The callsite guard covers recordDelivery (the delivery-result enum mapped
-//     from a switch in Dispatcher.Handle). It does NOT cover RecordSignatureFailure:
-//     that exported method's reason argument originates from runtime/webhook's
-//     verify step, which RETURNS a typed SignatureFailureReason — the type system
-//     already constrains the value, and the cross-package callsite would require a
-//     separate scan of runtime/webhook. The residual hole (a SignatureFailureReason("x")
-//     conversion at a RecordSignatureFailure callsite) is a bounded blind spot, and is
-//     closed by a reverse self-check: TestWebhookMetricLabelValuesFrozen01_NoReasonConversion
-//     asserts zero SignatureFailureReason(...) conversions exist in production
-//     kernel/webhook + runtime/webhook (the value-set freeze A1 catches new declared
-//     consts; the conversion form is forbidden outright).
+//   - Conversions are the only way to mint an off-set value of either enum.
+//     scanWebhookDeliveryResultConversions bans webhookDeliveryResult(...) in
+//     kernel/webhook (the type is unexported, so it cannot be named elsewhere) and
+//     scanSignatureFailureReasonConversions bans SignatureFailureReason(...) across
+//     kernel/webhook + runtime/webhook (it is exported). Together with the callsite
+//     guards (which reject untyped-const and literal forms reaching the record*
+//     methods) and the unexported-field upstream seal, all three mint/bypass
+//     vectors — literal, untyped const, conversion-laundered-through-var/func — are
+//     closed.
 //
-//   - The test runs only on the kernel/webhook package Pass (filtered by path).
+//   - The sole-writer lock and the delivery conversion ban run only on the
+//     kernel/webhook Pass; the RecordSignatureFailure callsite guard additionally
+//     runs on runtime/webhook (its only cross-package caller).
 //
 // # Reverse self-check (non-vacuous proof)
 //
 // TestWebhookMetricLabelValuesFrozen01_NegativeControl demonstrates a synthetic
-// extra/renamed value is detected; the callsite-guard fixture test proves the
-// recordDelivery guard flags an inline literal and passes a declared const.
+// extra/renamed value is detected. The CallsiteGuard_Fixtures test proves every
+// guard is non-vacuous against real-source fixtures: red_literal / red_untyped_const
+// (recordDelivery guard), red_reason_literal (RecordSignatureFailure guard), and
+// red_dr_conversion (delivery conversion ban) are each flagged, while green passes.
 package archtest
 
 import (
@@ -155,15 +180,46 @@ func TestWebhookMetricLabelValuesFrozen01(t *testing.T) {
 	}
 }
 
-// scanWebhookRecordDeliveryCallsites is the downstream callsite guard: it flags
-// any (Metrics).recordDelivery call whose result argument (index 2) is a
-// compile-time CONSTANT that is not a bare reference to a declared const. This
-// closes the hole the sealed webhookDeliveryResult type cannot — an untyped
-// string literal is assignable to the defined type. Allowed: a named const Ident
-// (deliverySuccess/…/deliveryBlocked) or any non-constant webhookDeliveryResult
-// expression (dispositionResult(...) / statusResult(...) calls). Banned: a string
-// literal or a webhookDeliveryResult("x") conversion.
-func scanWebhookRecordDeliveryCallsites(p *Pass) []Diagnostic {
+// constObjectOf resolves the declared object an argument expression refers to
+// when it is a bare identifier (e.g. deliverySuccess) or a package-qualified
+// selector (e.g. kwh.ReasonBadSignature). Any other expression form returns nil.
+func constObjectOf(info *types.Info, arg ast.Expr) types.Object {
+	switch e := arg.(type) {
+	case *ast.Ident:
+		return info.ObjectOf(e)
+	case *ast.SelectorExpr:
+		return info.ObjectOf(e.Sel)
+	}
+	return nil
+}
+
+// scanEnumLabelCallsite is the downstream callsite guard for a sealed-string-typed
+// metric label argument: it flags any call to method methodName whose argument at
+// argIdx is a compile-time CONSTANT that is NOT a reference to a declared const of
+// the sealed enum type. The enum type is taken from the method's own signature
+// (param argIdx), so the check is rename-proof and works cross-package (a runtime/
+// webhook caller of the exported RecordSignatureFailure resolves to the kernel/
+// webhook SignatureFailureReason consts).
+//
+// Allowed:
+//   - a non-constant value of the enum type (the trusted classifier output:
+//     statusResult(...) / dispositionResult(...) for delivery; verify()'s typed
+//     return for the reason side), AND
+//   - a declared const whose TYPE is identical to the enum type
+//     (deliverySuccess/… or ReasonBadSignature/…).
+//
+// Banned — every other constant form:
+//   - an inline string literal ("rogue"),
+//   - an untyped string const ident (const x = "rogue"; …(x)) whose object type is
+//     untyped string, NOT the enum type (this is the F2 hole the prior guard let
+//     through — it accepted ANY *types.Const),
+//   - a `webhookDeliveryResult("x")` / `SignatureFailureReason("x")` conversion
+//     (also independently banned by the conversion scanners).
+//
+// Matching is by method NAME (+ arg arity); the production tests scope the scan to
+// the webhook packages, and the fixtures declare a local Metrics with the same
+// method shape.
+func scanEnumLabelCallsite(p *Pass, methodName string, argIdx int) []Diagnostic {
 	info := p.TypesInfo
 	if info == nil {
 		return nil
@@ -176,29 +232,35 @@ func scanWebhookRecordDeliveryCallsites(p *Pass) []Diagnostic {
 		rel := p.Rel(file)
 		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "recordDelivery" {
+			if !ok || sel.Sel.Name != methodName {
 				return
 			}
 			fn, ok := ResolveMethodCall(info, sel)
-			if !ok || fn.Name() != "recordDelivery" || len(call.Args) < 3 {
+			if !ok || fn.Name() != methodName || len(call.Args) <= argIdx {
 				return
 			}
-			arg := call.Args[2]
+			sig, ok := fn.Type().(*types.Signature)
+			if !ok || sig.Params().Len() <= argIdx {
+				return
+			}
+			enumType := sig.Params().At(argIdx).Type()
+			arg := call.Args[argIdx]
 			tv, ok := info.Types[arg]
 			if !ok || tv.Value == nil {
-				return // non-constant (typed var / func call) — allowed
+				return // non-constant typed value (trusted classifier output) — allowed
 			}
-			if id, isIdent := arg.(*ast.Ident); isIdent {
-				if _, isConst := info.ObjectOf(id).(*types.Const); isConst {
-					return
+			if obj := constObjectOf(info, arg); obj != nil {
+				if _, isConst := obj.(*types.Const); isConst && types.Identical(obj.Type(), enumType) {
+					return // a declared const OF the sealed enum type — allowed
 				}
 			}
 			diags = append(diags, Diagnostic{
 				Rel:  rel,
 				Line: p.Fset.Position(arg.Pos()).Line,
-				Message: "recordDelivery result argument is an inline constant — pass a declared " +
-					"delivery* const or a typed (non-constant) webhookDeliveryResult, not a string " +
-					"literal or webhookDeliveryResult(...) conversion " +
+				Message: methodName + " label argument is a constant that is not a declared " +
+					enumType.String() + " const — pass a declared enum const or a typed " +
+					"(non-constant) value, never a string literal, an untyped const, or a " +
+					enumType.String() + "(...) conversion " +
 					"(WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 callsite guard)",
 			})
 		})
@@ -206,19 +268,172 @@ func scanWebhookRecordDeliveryCallsites(p *Pass) []Diagnostic {
 	return diags
 }
 
+// scanWebhookRecordDeliveryCallsites guards the delivery-result enum on
+// (Metrics).recordDelivery (arg index 2).
+func scanWebhookRecordDeliveryCallsites(p *Pass) []Diagnostic {
+	return scanEnumLabelCallsite(p, "recordDelivery", 2)
+}
+
+// scanWebhookRecordSignatureFailureCallsites guards the reason enum on the
+// exported (Metrics).RecordSignatureFailure (arg index 2). Exported + called
+// cross-package, so the production test scopes it to kernel/webhook + runtime/
+// webhook. Closes the F2′ hole: a bare string literal implicitly converts to
+// SignatureFailureReason and the conversion-ban scanner (which matches only an
+// explicit SignatureFailureReason(...) CallExpr) cannot see it.
+func scanWebhookRecordSignatureFailureCallsites(p *Pass) []Diagnostic {
+	return scanEnumLabelCallsite(p, "RecordSignatureFailure", 2)
+}
+
+// scanWebhookDeliveryResultConversions flags any `webhookDeliveryResult(...)`
+// conversion in the scanned package — the delivery-side mirror of
+// scanSignatureFailureReasonConversions. webhookDeliveryResult is unexported, so
+// the enum type is resolved from the scanned package's own scope (the production
+// kernel/webhook package and each red fixture both declare it locally); a
+// conversion is the only way to mint a value outside the declared const set, so
+// banning it makes the "non-constant typed value" allowance of the callsite guard
+// safe (the trusted classifiers return declared consts, never conversions).
+func scanWebhookDeliveryResultConversions(p *Pass) []Diagnostic {
+	info := p.TypesInfo
+	if info == nil || p.Pkg == nil {
+		return nil
+	}
+	tn, ok := p.Pkg.Scope().Lookup("webhookDeliveryResult").(*types.TypeName)
+	if !ok {
+		return nil
+	}
+	enumType := tn.Type()
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if len(call.Args) != 1 {
+				return
+			}
+			obj := constObjectOf(info, call.Fun)
+			tnObj, ok := obj.(*types.TypeName)
+			if !ok || !types.Identical(tnObj.Type(), enumType) {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(call.Pos()).Line,
+				Message: "webhookDeliveryResult(...) conversion in production — pass a declared " +
+					"delivery* const (the value-set freeze caps that set), never a conversion that " +
+					"could introduce an off-set label value " +
+					"(WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 blind-spot self-check)",
+			})
+		})
+	}
+	return diags
+}
+
+// scanWebhookMetricSoleWriter is the within-package upstream lock: with the
+// kwh.Metrics instrument fields unexported, the only metric-write surface OUTSIDE
+// kernel/webhook is the record* methods (Go visibility — Hard). WITHIN the package
+// a new function could still call `m.<field>.With(...)` directly and bypass the
+// record* funnel; this scanner asserts every `<Metrics>.<instrument>.With(...)`
+// call sits inside one of the sanctioned writer methods. Medium (package-internal
+// allowlist; the Go-visibility ceiling is the same as the #851/#893 holder-seal
+// family). Hard upgrade path = metricschema golden byte-lock, gh #1416.
+func scanWebhookMetricSoleWriter(p *Pass) []Diagnostic {
+	info := p.TypesInfo
+	if info == nil || p.Pkg == nil {
+		return nil
+	}
+	tn, ok := p.Pkg.Scope().Lookup("Metrics").(*types.TypeName)
+	if !ok {
+		return nil
+	}
+	metricsType := tn.Type()
+	instrumentFields := map[string]bool{
+		"deliveries": true, "deliveryDuration": true,
+		"signatureFailures": true, "idempotencyHits": true,
+	}
+	sanctioned := map[string]bool{
+		"recordDelivery": true, "observeDeliveryDuration": true,
+		"RecordSignatureFailure": true, "RecordIdempotencyHit": true, "preflight": true,
+	}
+	isInstrumentWith := func(call *ast.CallExpr) bool {
+		withSel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || withSel.Sel.Name != "With" {
+			return false
+		}
+		fieldSel, ok := withSel.X.(*ast.SelectorExpr)
+		if !ok || !instrumentFields[fieldSel.Sel.Name] {
+			return false
+		}
+		recvType := info.TypeOf(fieldSel.X)
+		if recvType == nil {
+			return false
+		}
+		if ptr, ok := recvType.(*types.Pointer); ok {
+			recvType = ptr.Elem()
+		}
+		return types.Identical(recvType, metricsType)
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+			if fn.Body == nil {
+				return
+			}
+			EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+				if !isInstrumentWith(call) || sanctioned[fn.Name.Name] {
+					return
+				}
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(call.Pos()).Line,
+					Message: "Metrics instrument .With(...) called outside the sanctioned record* " +
+						"writers (recordDelivery/observeDeliveryDuration/RecordSignatureFailure/" +
+						"RecordIdempotencyHit/preflight) in " + fn.Name.Name + " — the unexported " +
+						"instrument fields must only be written through the record* funnel " +
+						"(WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01 upstream sole-writer lock)",
+				})
+			})
+		})
+	}
+	return diags
+}
+
 // TestWebhookMetricLabelValuesFrozen01_CallsiteGuard is the production GREEN
-// baseline: every recordDelivery call in kernel/webhook passes a declared const
-// or a typed (non-constant) value — never an inline literal.
+// baseline for the full downstream + upstream funnel:
+//   - recordDelivery (kernel/webhook): every result arg is a declared delivery*
+//     const or a typed non-constant (statusResult/dispositionResult output).
+//   - RecordSignatureFailure (kernel/webhook + runtime/webhook): every reason arg
+//     is a declared Reason* const or the typed verify() return — never a literal.
+//   - webhookDeliveryResult(...) conversions (kernel/webhook): zero.
+//   - Metrics instrument .With(...) sole-writer lock (kernel/webhook): every
+//     instrument write sits inside a sanctioned record* method.
 func TestWebhookMetricLabelValuesFrozen01_CallsiteGuard(t *testing.T) {
 	t.Parallel()
 
-	const webhookPkg = PlatformModulePath + "/kernel/webhook"
+	const (
+		kernelWebhookPkg  = PlatformModulePath + "/kernel/webhook"
+		runtimeWebhookPkg = PlatformModulePath + "/runtime/webhook"
+	)
 	var allDiags []Diagnostic
 	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
-		if p.Pkg == nil || p.Pkg.Path() != webhookPkg {
+		if p.Pkg == nil {
 			return nil
 		}
-		allDiags = append(allDiags, scanWebhookRecordDeliveryCallsites(p)...)
+		switch p.Pkg.Path() {
+		case kernelWebhookPkg:
+			allDiags = append(allDiags, scanWebhookRecordDeliveryCallsites(p)...)
+			allDiags = append(allDiags, scanWebhookRecordSignatureFailureCallsites(p)...)
+			allDiags = append(allDiags, scanWebhookDeliveryResultConversions(p)...)
+			allDiags = append(allDiags, scanWebhookMetricSoleWriter(p)...)
+		case runtimeWebhookPkg:
+			// RecordSignatureFailure is exported and called from the receiver here.
+			allDiags = append(allDiags, scanWebhookRecordSignatureFailureCallsites(p)...)
+		}
 		return nil
 	})
 	Report(t, "WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01", allDiags)
@@ -326,24 +541,36 @@ func TestWebhookMetricLabelValuesFrozen01_NoReasonConversion(t *testing.T) {
 	Report(t, "WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01", allDiags)
 }
 
-// TestWebhookMetricLabelValuesFrozen01_CallsiteGuard_Fixtures proves the callsite
-// guard is non-vacuous: the RED fixture (inline literal) is flagged, the GREEN
-// fixture (named const + typed var) is not.
+// TestWebhookMetricLabelValuesFrozen01_CallsiteGuard_Fixtures proves each guard is
+// non-vacuous against real-source RED/GREEN fixtures:
+//   - green               → recordDelivery guard: declared const + typed non-const
+//   - classifier call are all allowed (0).
+//   - red_literal         → recordDelivery guard: inline string literal flagged (1).
+//   - red_untyped_const   → recordDelivery guard: untyped string const (the F2 hole
+//     the prior "any *types.Const" check let through) flagged (1).
+//   - red_reason_literal  → RecordSignatureFailure guard: inline literal reason (the
+//     F2′ implicit-conversion hole the reason side had no callsite guard for) (1).
+//   - red_dr_conversion   → delivery conversion ban: webhookDeliveryResult("x")
+//     conversion flagged (1).
 func TestWebhookMetricLabelValuesFrozen01_CallsiteGuard_Fixtures(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		dir  string
+		scan func(*Pass) []Diagnostic
 		want int
 	}{
-		{"red_literal", 1},
-		{"green", 0},
+		{"green", scanWebhookRecordDeliveryCallsites, 0},
+		{"red_literal", scanWebhookRecordDeliveryCallsites, 1},
+		{"red_untyped_const", scanWebhookRecordDeliveryCallsites, 1},
+		{"red_reason_literal", scanWebhookRecordSignatureFailureCallsites, 1},
+		{"red_dr_conversion", scanWebhookDeliveryResultConversions, 1},
 	}
 	for _, c := range cases {
 		c := c
 		t.Run(c.dir, func(t *testing.T) {
 			t.Parallel()
 			pattern := "./tools/archtest/testdata/webhook_metric_callsite_fixtures/" + c.dir
-			diags := Run(t, Fixture(FixtureOpts{}, []string{pattern}), scanWebhookRecordDeliveryCallsites)
+			diags := Run(t, Fixture(FixtureOpts{}, []string{pattern}), c.scan)
 			if len(diags) != c.want {
 				t.Fatalf("callsite-guard fixture %s: want %d diagnostic(s), got %d: %v",
 					c.dir, c.want, len(diags), diags)


### PR DESCRIPTION
## Summary

KERNEL-WEBHOOK-01 **PR-6**（6-PR webhook 系列收尾）：webhook 链路 observability + closeout。经两轮激进自审（彻底/不向后兼容/优雅简洁/AI-HARD）+ 开源对标，与原 §3 PR-6 计划有实质偏离（见下）。

### 交付
- **4 个 OTel metrics**（`kernel/webhook/metrics.go`，镜像 `kernel/reconcile/metrics.go`）：
  - `webhook_deliveries_total{result,source}` — 发端，`Dispatcher.Handle` status-aware 记录
  - `webhook_delivery_duration_seconds{source}` — 发端，buckets `[.05,.1,.25,.5,1,2.5,5,10,30]`
  - `webhook_signature_failures_total{source,reason}` — 收端，`Receiver.ServeHTTP`
  - `webhook_idempotency_hits_total{source}` — 收端
  - bootstrap `autoWireWebhookMetricsCollector` 经既有 `autoWireCachedCollector` funnel 单源接线 phase5(receiver)+phase6(dispatcher)，一个 collector 两侧共享。
- **`WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01`**（Medium）：双 sealed 枚举按 TYPE 冻结 + `recordDelivery` callsite guard；Hard 路径并入 metricschema golden #1416。
- **`WEBHOOK-IDEMPOTENCY-CLAIMER-01`**（Medium）：type-keyed data-flow——`claimed.rcpt` 必须溯源自 `idempotency.Claimer.Claim`（object identity + method resolution，rename-proof），与 PIPELINE-01（ordering）正交。

### 开源对标（webhook 可观测性，WebFetch 实拉）
result label 采 status-aware 5 值 `{success,client_error,server_error,transport_error,blocked}` 而非 disposition 折叠——对标 Alertmanager（clientError/serverError 分）/ K8s admission（error_type）/ Convoy（Discarded）均保留 status 维度，折叠 4xx/5xx 丢 SLO 信号。

ref: prometheus/alertmanager notify/util.go GetFailureReasonFromStatusCode
ref: kubernetes/apiserver pkg/admission/metrics/metrics.go
ref: frain-dev/convoy datastore/models.go EventDeliveryStatus

### 相对计划的偏离（均经自审，carve 显式登记）
- **删两个 healthz probe**（计划 in-scope）：vacuous/synonymous（依赖已被 adapter `_ready` 覆盖，store 启动期 eager 校验且运行时不可变），违反 observability.md「禁同义/vacuous probe」。
- **不做 auditcore webhook 二次 redaction**：已被 auditquery 出口统一 `RedactPayload` 覆盖。
- **examples 真实 demo carve 到 follow-up**：webhook receiver `buildRouteGroup` 硬编 `cell.PrimaryListener`（JWT-gated）且未标 Public → 真实 assembly 中 webhook 被 JWT 拦截，可运行 demo 需 webhook listener / Public 标记（PR-3 运行时范围，非 PR-6）。cellgen→drain→RouteGroup→Router→signed-200 全链路已由 `TestPhase5DrainWebhookReceivers_EndToEnd` + cellgen golden 覆盖。

详见计划文档 `docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md` §Closeout。

## Implementation Matrix

```
Contract: kwh.Metrics collector + SignatureFailureReason/webhookDeliveryResult sealed enums
Change: PR-6 — 4 webhook metrics recorded at Dispatcher.Handle (dispatch) + Receiver.ServeHTTP (receive); bootstrap autowire
Implementations: [x] kernel/webhook.Metrics (RegisterMetrics) [x] Dispatcher.Handle [x] Receiver.ServeHTTP
Conformance test: kernel/webhook.TestRegisterWebhookMetrics_WiresFour + runtime/webhook.TestReceiver_RecordsSignatureFailureReason
Repro: go test ./kernel/webhook/... ./runtime/webhook/... && go test ./tools/archtest/ -run 'WEBHOOK'
Dependent contracts (governance scan): none (no contract.yaml / cell changes)
Invariant inventory: N/A (greenfield observability, no DROP COLUMN)
```

## Test plan
- [x] `go build ./...`
- [x] `go test ./kernel/webhook/... ./runtime/webhook/... ./runtime/bootstrap/...`（kernel/webhook 96.6% / runtime/webhook 99.2%）
- [x] `go test ./tools/archtest/ -run 'WEBHOOK'`（freeze + callsite guard + claimer provenance + 反向 fixtures）
- [x] `golangci-lint run ./kernel/webhook/... ./runtime/webhook/... ./runtime/bootstrap/... ./tools/archtest/...` → 0 issues

## Review-fix round (C1/C2/C4 + F6a)

PR-6 评审 findings 闭环（F1–F7 + 新增 F2′），全绿 + golangci-lint 0 issues：

- **F1** (P1): `validateSpecFields` 改走 typed `SourceID.Validate()` — label-unsafe source 启动期 fail-fast，不再请求期 `MustValidateLabels` panic。
- **C2 / F2-F3-F2′-F4-F5** (P1+P2): `WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01` 升级为闭环双向锁 — **unexport** `Metrics` instrument 字段（上游 Hard 包外 + sole-writer archtest 包内 Medium）；callsite guard 改 object-identity ∈ 声明集（F2）+ `RecordSignatureFailure` callsite guard（F2′）+ `webhookDeliveryResult(...)` conversion ban（F3）；bootstrap real-provider 回归（F4）+ duration buckets 断言（F5）；3 个新 red fixtures。
- **F7** (P2): 验签失败 slog 增 `reason` 字段，与 doc.go 一致。
- **F6a** (P1): 新增 `cell.WebhookListener`，webhook receiver 挂专属 listener（AuthNone，HMAC 即应用层 auth），JWT PrimaryListener 不再拦截；未声明 listener 启动 fail-fast。回归证明 WebhookListener 200 / PrimaryListener 404。
- **F6b** (greenfield examples webhook demo): 拆为 follow-up（无现存 webhook example，属 #1161 examples 接入部分）。

## Follow-up issues
Ed25519/Vault KMS（p3）· source 持久化（p2）· circuit-breaker（p3）· per-contract Claim TTL（p2）· `webhook_source_store_ready` probe（p3）· examples webhook demo（p2，greenfield；listener-auth / PrimaryListener-JWT gap 已由本 PR review-fix 的 dedicated cell.WebhookListener 解决）

Refs #1161 — observability + P1 hardening complete; the examples-demo portion of #1161 is split to a follow-up (see below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

