### PR TITLE
feat(postgres,composition): per-namespace migration tracking via sealed migration.Namespace [#1089]

### DIFF
--- a/adapters/postgres/integration_test.go
+++ b/adapters/postgres/integration_test.go
@@ -186,7 +186,7 @@ func TestIntegration_Migrator(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err, "NewMigrator should succeed")
 
 	t.Run("up", func(t *testing.T) {
@@ -373,7 +373,7 @@ func TestMigrator_Applies004_WithConcurrentlyIndexes(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_004")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_004")
 	require.NoError(t, err)
 
 	// First Up: applies all 5 migrations including 004.
@@ -424,7 +424,7 @@ func TestMigration004_StructuralAssertions(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_struct")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_struct")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
 
@@ -483,7 +483,7 @@ func TestMigration006_ConfigVersionsConfigIDIndex(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_006")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_006")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations including 006")
 
@@ -535,7 +535,7 @@ func TestMigrator_Up_RefusesIfInvalidIndexExists(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations so tables and indexes exist.
-	prep, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_guard_prep")
+	prep, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_guard_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "preparatory Up() must succeed")
 
@@ -555,7 +555,7 @@ func TestMigrator_Up_RefusesIfInvalidIndexExists(t *testing.T) {
 	// Construct a fresh migrator using the same pool (with invalid index present).
 	// Use a new tracking table so Up() attempts to run from scratch (pre-check
 	// fires before any migration runs).
-	migrator2, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_guard_test")
+	migrator2, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_guard_test")
 	require.NoError(t, err)
 
 	// Up() must return an error: refusing to migrate due to invalid indexes.
@@ -628,7 +628,7 @@ func TestMigrator_ConcurrentUp_NoRaceWithSessionLocker(t *testing.T) {
 	errs := make(chan error, N)
 	for range N {
 		go func() {
-			m, err := NewMigrator(pool, fixtureFS, tableName)
+			m, err := newMigratorForTable(pool, fixtureFS, tableName)
 			if err != nil {
 				errs <- err
 				return
@@ -694,7 +694,7 @@ func TestMigrator_NineBeforeTen_OrderRegression(t *testing.T) {
 	const tableName = "schema_migrations_seq910"
 	fixtureFS := sequenceFixtureFS_910()
 
-	m, err := NewMigrator(pool, fixtureFS, tableName)
+	m, err := newMigratorForTable(pool, fixtureFS, tableName)
 	require.NoError(t, err)
 	defer func() { _ = m.Close() }()
 
@@ -750,7 +750,7 @@ func TestMigrator_Down_AtVersionZero_Idempotent(t *testing.T) {
 	}
 
 	const tableName = "schema_migrations_down_v0"
-	m, err := NewMigrator(pool, fixtureFS, tableName)
+	m, err := newMigratorForTable(pool, fixtureFS, tableName)
 	require.NoError(t, err)
 	defer func() { _ = m.Close() }()
 
@@ -782,7 +782,7 @@ func TestMigrator_Down_WithPermit_Succeeds(t *testing.T) {
 	// Apply migrations up to 012 so there is a migration to roll back.
 	// Migration 012 Down has no GUC SQL guard — permit is the only gate.
 	mfs := migrationsUpToFS(t, 12)
-	migrator, err := NewMigrator(pool, mfs, "schema_migrations_permit_down")
+	migrator, err := newMigratorForTable(pool, mfs, "schema_migrations_permit_down")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply through migration 012")
 
@@ -820,7 +820,7 @@ func TestMigrator_ForwardRebuild_EmptyTable_Up(t *testing.T) {
 	pool := emptyPool(t)
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_fwd_empty")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_fwd_empty")
 	require.NoError(t, err)
 
 	// Fresh DB: all rebuild targets are empty/missing — Up() must succeed without permits.
@@ -844,7 +844,7 @@ func TestMigrator_ForwardRebuild_PopulatedTable_UpFailClosed(t *testing.T) {
 
 	// Apply migrations up through 011 (refresh_tokens exists and can be populated).
 	mfs011 := migrationsUpToFS(t, 11)
-	prep, err := NewMigrator(pool, mfs011, "schema_migrations_fwd_prep")
+	prep, err := newMigratorForTable(pool, mfs011, "schema_migrations_fwd_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 011 must succeed")
 
@@ -856,7 +856,7 @@ func TestMigrator_ForwardRebuild_PopulatedTable_UpFailClosed(t *testing.T) {
 	require.NoError(t, execErr, "must be able to insert a row into pre-012 refresh_tokens")
 
 	// Now create a migrator with the full FS so migration 012 is pending.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_fwd_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_fwd_prep")
 	require.NoError(t, err)
 
 	upErr := migrator.Up(ctx)
@@ -878,7 +878,7 @@ func TestMigrator_ForwardRebuild_PopulatedTable_WithPermit(t *testing.T) {
 
 	// Apply migrations up through 011.
 	mfs011 := migrationsUpToFS(t, 11)
-	prep, err := NewMigrator(pool, mfs011, "schema_migrations_permit_prep")
+	prep, err := newMigratorForTable(pool, mfs011, "schema_migrations_permit_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 011 must succeed")
 
@@ -890,7 +890,7 @@ func TestMigrator_ForwardRebuild_PopulatedTable_WithPermit(t *testing.T) {
 	require.NoError(t, execErr)
 
 	// ForwardRebuild with permit for migration 12 must succeed.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_permit_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_permit_prep")
 	require.NoError(t, err)
 
 	permit := mustAllowForwardRebuild(t, 12, "integration test: approved refresh_tokens v2 rebuild")
@@ -917,7 +917,7 @@ func TestMigrator_ForwardRebuild_MisconfiguredPermit(t *testing.T) {
 
 	// Fresh DB — no migrations applied yet, so version 999 cannot be a pending
 	// forward-rebuild (it does not exist in the FS at all).
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_misconfig")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_misconfig")
 	require.NoError(t, err)
 
 	permit := mustAllowForwardRebuild(t, 999, "misconfig test")
@@ -947,7 +947,7 @@ func TestMigrator_ForwardRebuild_Migration043_PopulatedAuditEntries(t *testing.T
 
 	// Apply migrations up through 042 so audit_entries (from 020) exists.
 	mfs042 := migrationsUpToFS(t, 42)
-	prep, err := NewMigrator(pool, mfs042, "schema_migrations_043_prep")
+	prep, err := newMigratorForTable(pool, mfs042, "schema_migrations_043_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 042 must succeed")
 
@@ -962,7 +962,7 @@ func TestMigrator_ForwardRebuild_Migration043_PopulatedAuditEntries(t *testing.T
 	require.NoError(t, execErr, "must be able to insert a row into pre-043 audit_entries")
 
 	// Up() must fail-closed: 043 is pending and audit_entries has rows.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_043_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_043_prep")
 	require.NoError(t, err)
 
 	upErr := migrator.Up(ctx)
@@ -975,7 +975,7 @@ func TestMigrator_ForwardRebuild_Migration043_PopulatedAuditEntries(t *testing.T
 	assert.Equal(t, int64(43), migDetail.Value(), "migration detail value must be 43")
 
 	// ForwardRebuild with the correct permit must succeed.
-	migrator2, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_043_prep")
+	migrator2, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_043_prep")
 	require.NoError(t, err)
 
 	permit := mustAllowForwardRebuild(t, 43, "043 audit_entries v2 rebuild integration test")
@@ -1003,7 +1003,7 @@ func TestMigrator_ForwardRebuild_Migrations043And044_DualPermit(t *testing.T) {
 
 	// Apply migrations up through 042 so audit_entries and outbox_entries exist.
 	mfs042 := migrationsUpToFS(t, 42)
-	prep, err := NewMigrator(pool, mfs042, "schema_migrations_044_prep")
+	prep, err := newMigratorForTable(pool, mfs042, "schema_migrations_044_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 042 must succeed")
 
@@ -1026,7 +1026,7 @@ func TestMigrator_ForwardRebuild_Migrations043And044_DualPermit(t *testing.T) {
 	`, entryID)
 	require.NoError(t, outboxErr, "must be able to insert a row into pre-044 outbox_entries")
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_044_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_044_prep")
 	require.NoError(t, err)
 
 	// Up() without permits: must fail-closed.
@@ -1037,7 +1037,7 @@ func TestMigrator_ForwardRebuild_Migrations043And044_DualPermit(t *testing.T) {
 	assert.Equal(t, ErrAdapterPGMigrate, ec.Code)
 
 	// ForwardRebuild with only permit 43 must fail-closed (044 still needs one).
-	migrator2, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_044_prep")
+	migrator2, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_044_prep")
 	require.NoError(t, err)
 	permit43Only := mustAllowForwardRebuild(t, 43, "043 dual-test permit")
 	onlyPermit43Err := migrator2.ForwardRebuild(ctx, permit43Only)
@@ -1047,7 +1047,7 @@ func TestMigrator_ForwardRebuild_Migrations043And044_DualPermit(t *testing.T) {
 	assert.Equal(t, ErrAdapterPGMigrate, ec2.Code)
 
 	// ForwardRebuild with both permits must succeed.
-	migrator3, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_044_prep")
+	migrator3, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_044_prep")
 	require.NoError(t, err)
 	permit43 := mustAllowForwardRebuild(t, 43, "043 dual-test permit final")
 	permit44 := mustAllowForwardRebuild(t, 44, "044 outbox_entries principal dual-test permit")
@@ -1078,7 +1078,7 @@ func TestMigrator_TableHasRows_DBError_FailClosed(t *testing.T) {
 
 	// Apply migrations up through 011 so refresh_tokens exists and can be populated.
 	mfs011 := migrationsUpToFS(t, 11)
-	prep, err := NewMigrator(pool, mfs011, "schema_migrations_dbfail_prep")
+	prep, err := newMigratorForTable(pool, mfs011, "schema_migrations_dbfail_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 011 must succeed")
 
@@ -1093,7 +1093,7 @@ func TestMigrator_TableHasRows_DBError_FailClosed(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	cancel() // immediately cancel
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_dbfail_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_dbfail_prep")
 	require.NoError(t, err)
 
 	// ForwardRebuild with cancelled context must fail — either due to context
@@ -1115,7 +1115,7 @@ func TestMigrator_ForwardRebuild_Migration044_EmptyTable_Up(t *testing.T) {
 	pool := emptyPool(t)
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_044_empty")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_044_empty")
 	require.NoError(t, err)
 
 	// Fresh DB: all rebuild targets are empty/missing — Up() must succeed without permits.
@@ -1147,7 +1147,7 @@ func TestMigrator_ForwardRebuild_Migration044_PopulatedOutbox_UpFailClosed(t *te
 
 	// Apply migrations up through 043 (so outbox_entries exists post-043 TRUNCATE).
 	mfs043 := migrationsUpToFS(t, 43)
-	prep, err := NewMigrator(pool, mfs043, "schema_migrations_044_failclosed_prep")
+	prep, err := newMigratorForTable(pool, mfs043, "schema_migrations_044_failclosed_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 043 must succeed")
 
@@ -1161,7 +1161,7 @@ func TestMigrator_ForwardRebuild_Migration044_PopulatedOutbox_UpFailClosed(t *te
 	require.NoError(t, execErr, "must be able to insert a row into post-043 outbox_entries")
 
 	// Up() without permits: must fail-closed.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_044_failclosed_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_044_failclosed_prep")
 	require.NoError(t, err)
 
 	upErr := migrator.Up(ctx)
@@ -1186,7 +1186,7 @@ func TestMigrator_ForwardRebuild_Migration044_PopulatedOutbox_WithPermit(t *test
 
 	// Apply migrations up through 043.
 	mfs043 := migrationsUpToFS(t, 43)
-	prep, err := NewMigrator(pool, mfs043, "schema_migrations_044_permit_prep")
+	prep, err := newMigratorForTable(pool, mfs043, "schema_migrations_044_permit_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 043 must succeed")
 
@@ -1201,7 +1201,7 @@ func TestMigrator_ForwardRebuild_Migration044_PopulatedOutbox_WithPermit(t *test
 
 	// ForwardRebuild with only permit 44 must succeed — audit_entries is empty
 	// so migration 043 is not pending-dangerous (no rows → no permit needed).
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_044_permit_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_044_permit_prep")
 	require.NoError(t, err)
 
 	permit44 := mustAllowForwardRebuild(t, 44, "044 outbox_entries principal permit integration test")
@@ -1238,7 +1238,7 @@ func TestMigrator_ForwardRebuild_Migration050_EmptyTable_Up(t *testing.T) {
 
 	// Apply all migrations from scratch: all rebuild targets are empty/missing →
 	// Up() must succeed without any permit.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_empty")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_empty")
 	require.NoError(t, err)
 
 	require.NoError(t, migrator.Up(ctx),
@@ -1285,7 +1285,7 @@ func TestMigrator_ForwardRebuild_Migration050_PopulatedUsers_UpFailClosed(t *tes
 	// Apply migrations up through 049 so users table exists (from migration 017)
 	// but migration 050 is still pending.
 	mfs049 := migrationsUpToFS(t, 49)
-	prep, err := NewMigrator(pool, mfs049, "schema_migrations_050_failclosed_prep")
+	prep, err := newMigratorForTable(pool, mfs049, "schema_migrations_050_failclosed_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 049 must succeed")
 
@@ -1301,7 +1301,7 @@ func TestMigrator_ForwardRebuild_Migration050_PopulatedUsers_UpFailClosed(t *tes
 	require.NoError(t, execErr, "must be able to insert a row into pre-050 users table")
 
 	// Up() without permits: must fail-closed because users has rows.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_failclosed_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_failclosed_prep")
 	require.NoError(t, err)
 
 	upErr := migrator.Up(ctx)
@@ -1327,7 +1327,7 @@ func TestMigrator_ForwardRebuild_Migration050_DeclaredTargets(t *testing.T) {
 
 	// Empty DB → every migration is pending; collectPendingForwardRebuilds parses
 	// the +gocell annotations from each pending migration's Up section.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_targets")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_targets")
 	require.NoError(t, err)
 
 	pending, err := migrator.collectPendingForwardRebuilds(ctx)
@@ -1350,7 +1350,7 @@ func TestMigrator_ForwardRebuild_Migration050_PopulatedRoles_UpFailClosed(t *tes
 
 	// Apply through 049 so roles exists (migration 019) but 050 is still pending.
 	mfs049 := migrationsUpToFS(t, 49)
-	prep, err := NewMigrator(pool, mfs049, "schema_migrations_050_roles_failclosed")
+	prep, err := newMigratorForTable(pool, mfs049, "schema_migrations_050_roles_failclosed")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 049 must succeed")
 
@@ -1359,7 +1359,7 @@ func TestMigrator_ForwardRebuild_Migration050_PopulatedRoles_UpFailClosed(t *tes
 	_, execErr := pool.DB().Exec(ctx, `INSERT INTO roles (id, name) VALUES ('viewer', 'Viewer')`)
 	require.NoError(t, execErr, "must be able to insert a row into pre-050 roles table")
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_roles_failclosed")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_roles_failclosed")
 	require.NoError(t, err)
 
 	upErr := migrator.Up(ctx)
@@ -1402,7 +1402,7 @@ func TestMigrator_ForwardRebuild_Migration050_PopulatedUsers_WithPermit(t *testi
 
 	// Apply migrations up through 049.
 	mfs049 := migrationsUpToFS(t, 49)
-	prep, err := NewMigrator(pool, mfs049, "schema_migrations_050_permit_prep")
+	prep, err := newMigratorForTable(pool, mfs049, "schema_migrations_050_permit_prep")
 	require.NoError(t, err)
 	require.NoError(t, prep.Up(ctx), "Up() through 049 must succeed")
 
@@ -1424,7 +1424,7 @@ func TestMigrator_ForwardRebuild_Migration050_PopulatedUsers_WithPermit(t *testi
 
 	// ForwardRebuild with permit 50 must succeed. The users target has rows;
 	// roles and role_assignments are empty so only one permit is needed.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_permit_prep")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_permit_prep")
 	require.NoError(t, err)
 
 	permit50 := mustAllowForwardRebuild(t, 50, "050 accesscore tenant rebuild integration test")

--- a/adapters/postgres/migration_set.go
+++ b/adapters/postgres/migration_set.go
@@ -121,6 +121,13 @@ func (s *MigrationSet) Namespaces() []migration.Namespace {
 // platform-only break-glass operation via Migrator.ForwardRebuild, and Up's
 // fail-closed gate still refuses an unpermitted populated rebuild. Idempotent:
 // already-applied namespaces are no-ops.
+//
+// Fails fast on the first namespace error; subsequent namespaces are NOT
+// attempted. This is intentional with platform-first ordering: if platform
+// migrations fail, external namespaces that FK platform tables must not proceed.
+// An external namespace whose migration is a forward-rebuild of a populated
+// table must be applied directly via NewMigrator(pool, fs, ns).ForwardRebuild
+// (with a permit), not through ApplyAll's plain Up.
 func (s *MigrationSet) ApplyAll(ctx context.Context, pool *Pool) error {
 	for _, e := range s.entries {
 		if err := applyNamespace(ctx, pool, e); err != nil {
@@ -156,7 +163,9 @@ func applyNamespace(ctx context.Context, pool *Pool, e migrationSetEntry) (retEr
 func (s *MigrationSet) VerifyAll(ctx context.Context, pool *Pool) error {
 	for _, e := range s.entries {
 		if err := VerifyExpectedVersion(ctx, pool, e.fsys, e.ns); err != nil {
-			return err
+			// Carry the namespace so a multi-namespace VerifyAll failure is
+			// attributable (mirrors applyNamespace's wrapping in ApplyAll).
+			return fmt.Errorf("postgres: verify schema for namespace %q: %w", e.ns, err)
 		}
 	}
 	return nil

--- a/adapters/postgres/migration_set.go
+++ b/adapters/postgres/migration_set.go
@@ -1,0 +1,163 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
+)
+
+// trackingTablePrefix is the fixed prefix for every per-namespace goose tracking
+// table. trackingTableFor is the SINGLE source that derives a table name from a
+// namespace; no other code path constructs a tracking-table string.
+const trackingTablePrefix = "schema_migrations_"
+
+// trackingTableFor derives the goose version-tracking table for a namespace:
+// schema_migrations_<namespace>. The namespace is a migration.Namespace
+// (validated lowercase identifier, bounded length), so the result is always a
+// safe SQL identifier within PostgreSQL's 63-byte limit. This is the only
+// function that builds a tracking-table name — guarded by archtest
+// MIGRATION-TRACKING-TABLE-DERIVED-01 so newGooseProvider's tableName argument
+// can never be an inlined literal.
+func trackingTableFor(ns migration.Namespace) string {
+	return trackingTablePrefix + ns.String()
+}
+
+// PlatformTrackingTable is the tracking table for the platform's own embedded
+// migrations: schema_migrations_platform. Platform is not special — it is the
+// reserved migration.PlatformNamespace flowing through the same derivation as
+// every external namespace (full symmetry, #1089 decision #3).
+var PlatformTrackingTable = trackingTableFor(migration.PlatformNamespace)
+
+// MigrationSet is an ordered registry of per-namespace migration sources. Each
+// namespace owns an independent 001..N version lineage tracked in its own
+// schema_migrations_<namespace> table (Django-style (namespace, version)
+// composite key, #1089). There is no global version sequence: namespaces are
+// independent, applied in registration order.
+//
+// ref: pressly/goose v3 Provider.WithTableName — per-table version counter.
+type MigrationSet struct {
+	entries []migrationSetEntry
+	seen    map[migration.Namespace]struct{}
+}
+
+type migrationSetEntry struct {
+	ns   migration.Namespace
+	fsys fs.FS
+}
+
+// NewMigrationSet returns an empty MigrationSet. Use NewMigrationSetWithPlatform
+// for the common case (platform + external namespaces).
+func NewMigrationSet() *MigrationSet {
+	return &MigrationSet{seen: map[migration.Namespace]struct{}{}}
+}
+
+// NewMigrationSetWithPlatform returns a MigrationSet pre-seeded with the
+// platform namespace (adapters/postgres embedded migrations) FIRST. Platform
+// applies before any external namespace registered via Add, so an external
+// Cell module's migrations may reference platform tables (e.g. foreign keys) —
+// platform-first ordering is the concrete cross-namespace guarantee.
+func NewMigrationSetWithPlatform() (*MigrationSet, error) {
+	fsys, err := MigrationsFS()
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGMigrate,
+			"postgres: load platform migrations fs", err)
+	}
+	s := NewMigrationSet()
+	if err := s.addNamespace(migration.PlatformNamespace, fsys); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Add registers an external Cell module's migration set under ns. The reserved
+// platform namespace is rejected (only the internal seed in
+// NewMigrationSetWithPlatform may use it); ns must be valid and fsys non-nil;
+// duplicate namespaces are rejected.
+func (s *MigrationSet) Add(ns migration.Namespace, fsys fs.FS) error {
+	if ns == migration.PlatformNamespace {
+		return errcode.New(errcode.KindInvalid, ErrAdapterPGMigrate,
+			"postgres: namespace \"platform\" is reserved for platform migrations; "+
+				"external modules must register under their own namespace")
+	}
+	return s.addNamespace(ns, fsys)
+}
+
+func (s *MigrationSet) addNamespace(ns migration.Namespace, fsys fs.FS) error {
+	if err := ns.Validate(); err != nil {
+		return errcode.Wrap(errcode.KindInvalid, ErrAdapterPGMigrate,
+			"postgres: invalid migration namespace", err)
+	}
+	if fsys == nil {
+		return errcode.New(errcode.KindInvalid, ErrAdapterPGMigrate,
+			"postgres: migration set entry requires a non-nil fs.FS",
+			errcode.WithDetails(errcode.PublicString("namespace", ns.String())))
+	}
+	if _, dup := s.seen[ns]; dup {
+		return errcode.New(errcode.KindInvalid, ErrAdapterPGMigrate,
+			"postgres: duplicate migration namespace",
+			errcode.WithDetails(errcode.PublicString("namespace", ns.String())))
+	}
+	s.seen[ns] = struct{}{}
+	s.entries = append(s.entries, migrationSetEntry{ns: ns, fsys: fsys})
+	return nil
+}
+
+// Namespaces returns the registered namespaces in registration (application)
+// order.
+func (s *MigrationSet) Namespaces() []migration.Namespace {
+	out := make([]migration.Namespace, len(s.entries))
+	for i, e := range s.entries {
+		out[i] = e.ns
+	}
+	return out
+}
+
+// ApplyAll applies every namespace's pending migrations in registration order,
+// each against its own schema_migrations_<namespace> tracking table. It uses
+// plain Up per namespace; a populated-table forward-rebuild stays a
+// platform-only break-glass operation via Migrator.ForwardRebuild, and Up's
+// fail-closed gate still refuses an unpermitted populated rebuild. Idempotent:
+// already-applied namespaces are no-ops.
+func (s *MigrationSet) ApplyAll(ctx context.Context, pool *Pool) error {
+	for _, e := range s.entries {
+		if err := applyNamespace(ctx, pool, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyNamespace opens a Migrator for one namespace, runs Up, and closes it.
+// Extracted so ApplyAll stays within the cognitive-complexity budget and the
+// per-namespace *sql.DB is always released (Close error surfaces only when Up
+// succeeded).
+func applyNamespace(ctx context.Context, pool *Pool, e migrationSetEntry) (retErr error) {
+	m, err := NewMigrator(pool, e.fsys, e.ns)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := m.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+	if err := m.Up(ctx); err != nil {
+		return fmt.Errorf("postgres: apply migrations for namespace %q: %w", e.ns, err)
+	}
+	return nil
+}
+
+// VerifyAll checks each namespace's database version against the max version in
+// its embedded migration FS (see VerifyExpectedVersion). Used by the schema
+// guard on startup paths that verify (not apply) migrations.
+func (s *MigrationSet) VerifyAll(ctx context.Context, pool *Pool) error {
+	for _, e := range s.entries {
+		if err := VerifyExpectedVersion(ctx, pool, e.fsys, e.ns); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/adapters/postgres/migration_set.go
+++ b/adapters/postgres/migration_set.go
@@ -38,9 +38,12 @@ var PlatformTrackingTable = trackingTableFor(migration.PlatformNamespace)
 // independent, applied in registration order.
 //
 // ref: pressly/goose v3 Provider.WithTableName — per-table version counter.
+//
+// The zero value (MigrationSet{}) is usable: Add appends to a nil slice and
+// dedups by scanning entries, so there is no nil-map hazard for a caller who
+// constructs MigrationSet{} directly instead of via NewMigrationSet.
 type MigrationSet struct {
 	entries []migrationSetEntry
-	seen    map[migration.Namespace]struct{}
 }
 
 type migrationSetEntry struct {
@@ -49,9 +52,10 @@ type migrationSetEntry struct {
 }
 
 // NewMigrationSet returns an empty MigrationSet. Use NewMigrationSetWithPlatform
-// for the common case (platform + external namespaces).
+// for the common case (platform + external namespaces). The zero value is also
+// usable (see MigrationSet docs), so this is a convenience, not a requirement.
 func NewMigrationSet() *MigrationSet {
-	return &MigrationSet{seen: map[migration.Namespace]struct{}{}}
+	return &MigrationSet{}
 }
 
 // NewMigrationSetWithPlatform returns a MigrationSet pre-seeded with the
@@ -95,12 +99,20 @@ func (s *MigrationSet) addNamespace(ns migration.Namespace, fsys fs.FS) error {
 			"postgres: migration set entry requires a non-nil fs.FS",
 			errcode.WithDetails(errcode.PublicString("namespace", ns.String())))
 	}
-	if _, dup := s.seen[ns]; dup {
-		return errcode.New(errcode.KindInvalid, ErrAdapterPGMigrate,
-			"postgres: duplicate migration namespace",
-			errcode.WithDetails(errcode.PublicString("namespace", ns.String())))
+	// Strict fail-fast at registration (#1089 / codex C2): reject a namespace
+	// whose FS carries a non-goose-parseable .sql now, naming the namespace, so
+	// a malformed external-cell migration never silently vanishes at apply/verify.
+	if _, err := ExpectedVersion(fsys); err != nil {
+		return errcode.Wrap(errcode.KindInvalid, ErrAdapterPGMigrate,
+			fmt.Sprintf("postgres: migration set namespace %q has a malformed migration file", ns), err)
 	}
-	s.seen[ns] = struct{}{}
+	for _, e := range s.entries {
+		if e.ns == ns {
+			return errcode.New(errcode.KindInvalid, ErrAdapterPGMigrate,
+				"postgres: duplicate migration namespace",
+				errcode.WithDetails(errcode.PublicString("namespace", ns.String())))
+		}
+	}
 	s.entries = append(s.entries, migrationSetEntry{ns: ns, fsys: fsys})
 	return nil
 }

--- a/adapters/postgres/migration_set_integration_test.go
+++ b/adapters/postgres/migration_set_integration_test.go
@@ -71,6 +71,33 @@ func TestMigrationSet_ApplyAll_IndependentNamespaceTables(t *testing.T) {
 	require.NoError(t, set.ApplyAll(ctx, pool), "re-apply must be a no-op")
 }
 
+// TestMigrationSet_VerifyAll_FailsWhenNamespaceUnapplied covers the failure path:
+// VerifyAll over a namespace whose migrations have NOT been applied must fail,
+// and the error must name the offending namespace (F3 — attributable VerifyAll).
+func TestMigrationSet_VerifyAll_FailsWhenNamespaceUnapplied(t *testing.T) {
+	ctx := context.Background()
+	pool := emptyPool(t)
+
+	ext, err := migration.ParseNamespace("extunapplied")
+	require.NoError(t, err)
+
+	// Apply ONLY platform.
+	platformOnly, err := NewMigrationSetWithPlatform()
+	require.NoError(t, err)
+	require.NoError(t, platformOnly.ApplyAll(ctx, pool))
+
+	// VerifyAll over platform + an unapplied external namespace must fail and
+	// the wrapped error must name the offending namespace.
+	full, err := NewMigrationSetWithPlatform()
+	require.NoError(t, err)
+	require.NoError(t, full.Add(ext, extWidgetsFS()))
+
+	err = full.VerifyAll(ctx, pool)
+	require.Error(t, err, "VerifyAll must fail when an external namespace is unapplied")
+	assert.Contains(t, err.Error(), "extunapplied",
+		"VerifyAll error must name the unapplied namespace (F3)")
+}
+
 func tableExists(ctx context.Context, t *testing.T, pool *Pool, table string) bool {
 	t.Helper()
 	var exists bool

--- a/adapters/postgres/migration_set_integration_test.go
+++ b/adapters/postgres/migration_set_integration_test.go
@@ -98,6 +98,32 @@ func TestMigrationSet_VerifyAll_FailsWhenNamespaceUnapplied(t *testing.T) {
 		"VerifyAll error must name the unapplied namespace (F3)")
 }
 
+// TestMigrator_RejectsLegacyPlatformTrackingTable covers the #1089 transition
+// guard (codex C3): applying the platform set against a DB that still carries
+// the pre-rename `schema_migrations` table (without `schema_migrations_platform`)
+// must fail fast with a clear rename message, not silently re-apply everything
+// at version 0.
+func TestMigrator_RejectsLegacyPlatformTrackingTable(t *testing.T) {
+	ctx := context.Background()
+	pool := emptyPool(t)
+
+	// Simulate a DB migrated under the pre-#1089 scheme.
+	_, err := pool.DB().Exec(ctx,
+		`CREATE TABLE schema_migrations (id BIGSERIAL PRIMARY KEY, version_id BIGINT NOT NULL, `+
+			`is_applied BOOLEAN NOT NULL, tstamp TIMESTAMP DEFAULT now())`)
+	require.NoError(t, err)
+
+	fsys, err := MigrationsFS()
+	require.NoError(t, err)
+	m, err := NewMigrator(pool, fsys, migration.PlatformNamespace)
+	require.NoError(t, err)
+	defer func() { _ = m.Close() }()
+
+	err = m.Up(ctx)
+	require.Error(t, err, "Up against a legacy schema_migrations (no platform table) must fail fast")
+	assert.Contains(t, err.Error(), "renamed", "error must explain the #1089 rename + recovery")
+}
+
 func tableExists(ctx context.Context, t *testing.T, pool *Pool, table string) bool {
 	t.Helper()
 	var exists bool

--- a/adapters/postgres/migration_set_integration_test.go
+++ b/adapters/postgres/migration_set_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/migration"
+)
+
+// extWidgetsFS is a synthetic external Cell module migration set: its own
+// independent 001 sequence, goose-native naming, creating a table that does not
+// collide with any platform table.
+func extWidgetsFS() fstest.MapFS {
+	return fstest.MapFS{
+		"001_create_ext_widgets.sql": &fstest.MapFile{Data: []byte(
+			"-- +goose Up\n" +
+				"CREATE TABLE IF NOT EXISTS ext_widgets (id TEXT PRIMARY KEY);\n" +
+				"-- +goose Down\n" +
+				"DROP TABLE IF EXISTS ext_widgets;\n")},
+	}
+}
+
+// TestMigrationSet_ApplyAll_IndependentNamespaceTables dogfoods the full #1089
+// path end to end: platform + a synthetic external namespace apply against their
+// OWN tracking tables (schema_migrations_platform / schema_migrations_extwidgets),
+// each with an independent version lineage, and ApplyAll is idempotent.
+func TestMigrationSet_ApplyAll_IndependentNamespaceTables(t *testing.T) {
+	ctx := context.Background()
+	pool := emptyPool(t)
+
+	ext, err := migration.ParseNamespace("extwidgets")
+	require.NoError(t, err)
+
+	set, err := NewMigrationSetWithPlatform()
+	require.NoError(t, err)
+	require.NoError(t, set.Add(ext, extWidgetsFS()))
+
+	// platform-first ordering guarantee.
+	require.Equal(t, []migration.Namespace{migration.PlatformNamespace, ext}, set.Namespaces())
+
+	require.NoError(t, set.ApplyAll(ctx, pool), "apply platform + external")
+
+	// Both per-namespace tracking tables exist and are physically distinct.
+	assertTableExists(ctx, t, pool, "schema_migrations_platform")
+	assertTableExists(ctx, t, pool, "schema_migrations_extwidgets")
+	assert.False(t, tableExists(ctx, t, pool, "schema_migrations"),
+		"the bare global schema_migrations table must NOT exist (R3 sealed)")
+
+	// The external migration ran against the same DB as platform.
+	assertTableExists(ctx, t, pool, "ext_widgets")
+
+	// Independent version lineages: platform at its embedded max, external at 1.
+	platformFS, err := MigrationsFS()
+	require.NoError(t, err)
+	platformMax, err := ExpectedVersion(platformFS)
+	require.NoError(t, err)
+	assert.Equal(t, platformMax, maxTrackedVersion(ctx, t, pool, "schema_migrations_platform"))
+	assert.Equal(t, int64(1), maxTrackedVersion(ctx, t, pool, "schema_migrations_extwidgets"),
+		"external namespace keeps its own 001..N sequence, not a global one")
+
+	// VerifyAll confirms each namespace's DB version matches its embedded max.
+	require.NoError(t, set.VerifyAll(ctx, pool))
+
+	// Idempotent: re-applying is a no-op (no pending migrations in either table).
+	require.NoError(t, set.ApplyAll(ctx, pool), "re-apply must be a no-op")
+}
+
+func tableExists(ctx context.Context, t *testing.T, pool *Pool, table string) bool {
+	t.Helper()
+	var exists bool
+	require.NoError(t, pool.DB().QueryRow(ctx, `SELECT to_regclass($1) IS NOT NULL`, table).Scan(&exists))
+	return exists
+}
+
+func assertTableExists(ctx context.Context, t *testing.T, pool *Pool, table string) {
+	t.Helper()
+	assert.Truef(t, tableExists(ctx, t, pool, table), "expected table %q to exist", table)
+}
+
+func maxTrackedVersion(ctx context.Context, t *testing.T, pool *Pool, trackingTable string) int64 {
+	t.Helper()
+	if err := validateIdentifier(trackingTable); err != nil {
+		t.Fatalf("invalid tracking table %q: %v", trackingTable, err)
+	}
+	var maxV int64
+	// #nosec G201 -- trackingTable validated by validateIdentifier above.
+	q := `SELECT COALESCE(MAX(version_id), 0) FROM ` + trackingTable
+	require.NoError(t, pool.DB().QueryRow(ctx, q).Scan(&maxV))
+	return maxV
+}

--- a/adapters/postgres/migration_set_test.go
+++ b/adapters/postgres/migration_set_test.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
+)
+
+func fakeMigrationsFS() fstest.MapFS {
+	return fstest.MapFS{
+		"001_init.sql": &fstest.MapFile{Data: []byte("-- +goose Up\n-- +goose Down\n")},
+	}
+}
+
+func TestTrackingTableFor(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "schema_migrations_platform", trackingTableFor(migration.PlatformNamespace),
+		"platform is not special — it is namespace \"platform\" → schema_migrations_platform")
+	assert.Equal(t, "schema_migrations_platform", PlatformTrackingTable)
+
+	ns, err := migration.ParseNamespace("acme_payment")
+	require.NoError(t, err)
+	assert.Equal(t, "schema_migrations_acme_payment", trackingTableFor(ns))
+}
+
+func TestMigrationSet_Add(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid external namespace", func(t *testing.T) {
+		t.Parallel()
+		s := NewMigrationSet()
+		ns, err := migration.ParseNamespace("payment")
+		require.NoError(t, err)
+		require.NoError(t, s.Add(ns, fakeMigrationsFS()))
+		assert.Equal(t, []migration.Namespace{ns}, s.Namespaces())
+	})
+
+	t.Run("reserved platform namespace rejected", func(t *testing.T) {
+		t.Parallel()
+		s := NewMigrationSet()
+		err := s.Add(migration.PlatformNamespace, fakeMigrationsFS())
+		require.Error(t, err)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, ErrAdapterPGMigrate, ec.Code)
+	})
+
+	t.Run("duplicate namespace rejected", func(t *testing.T) {
+		t.Parallel()
+		s := NewMigrationSet()
+		ns, err := migration.ParseNamespace("payment")
+		require.NoError(t, err)
+		require.NoError(t, s.Add(ns, fakeMigrationsFS()))
+		require.Error(t, s.Add(ns, fakeMigrationsFS()), "duplicate namespace must be rejected")
+	})
+
+	t.Run("nil fs rejected", func(t *testing.T) {
+		t.Parallel()
+		s := NewMigrationSet()
+		ns, err := migration.ParseNamespace("payment")
+		require.NoError(t, err)
+		require.Error(t, s.Add(ns, nil))
+	})
+
+	t.Run("invalid namespace conversion-literal rejected", func(t *testing.T) {
+		t.Parallel()
+		s := NewMigrationSet()
+		require.Error(t, s.Add(migration.Namespace("acme-payment"), fakeMigrationsFS()))
+	})
+}
+
+func TestNewMigrationSetWithPlatform_SeedsPlatformFirst(t *testing.T) {
+	t.Parallel()
+	s, err := NewMigrationSetWithPlatform()
+	require.NoError(t, err)
+
+	nss := s.Namespaces()
+	require.NotEmpty(t, nss)
+	assert.Equal(t, migration.PlatformNamespace, nss[0],
+		"platform must be seeded first so external namespaces apply after it")
+
+	ext, err := migration.ParseNamespace("payment")
+	require.NoError(t, err)
+	require.NoError(t, s.Add(ext, fakeMigrationsFS()))
+	assert.Equal(t, []migration.Namespace{migration.PlatformNamespace, ext}, s.Namespaces(),
+		"external namespaces append in registration order after platform")
+}

--- a/adapters/postgres/migration_set_test.go
+++ b/adapters/postgres/migration_set_test.go
@@ -72,6 +72,34 @@ func TestMigrationSet_Add(t *testing.T) {
 		s := NewMigrationSet()
 		require.Error(t, s.Add(migration.Namespace("acme-payment"), fakeMigrationsFS()))
 	})
+
+	t.Run("malformed migration file rejected at registration", func(t *testing.T) {
+		t.Parallel()
+		// A namespace FS carrying a non-goose-parseable .sql is rejected fail-fast
+		// at Add, naming the namespace + file (#1089 / codex C2 strict validation).
+		badFS := fstest.MapFS{
+			"notamigration.sql": &fstest.MapFile{Data: []byte("-- up")},
+		}
+		ns, err := migration.ParseNamespace("payment")
+		require.NoError(t, err)
+		addErr := NewMigrationSet().Add(ns, badFS)
+		require.Error(t, addErr, "malformed .sql must be rejected at Add")
+		assert.Contains(t, addErr.Error(), "payment", "error must name the namespace")
+		assert.Contains(t, addErr.Error(), "notamigration.sql", "error must name the offending file")
+	})
+}
+
+func TestMigrationSet_ZeroValueAddNoPanic(t *testing.T) {
+	t.Parallel()
+	// A caller that constructs MigrationSet{} directly (not via NewMigrationSet)
+	// must not panic on Add — regression for the nil-map write (F7).
+	var s MigrationSet
+	ns, err := migration.ParseNamespace("payment")
+	require.NoError(t, err)
+	require.NoError(t, s.Add(ns, fakeMigrationsFS()))
+	assert.Equal(t, []migration.Namespace{ns}, s.Namespaces())
+	// dedup still works on the zero-value path.
+	require.Error(t, s.Add(ns, fakeMigrationsFS()), "duplicate must be rejected even for zero-value set")
 }
 
 func TestNewMigrationSetWithPlatform_SeedsPlatformFirst(t *testing.T) {

--- a/adapters/postgres/migrator.go
+++ b/adapters/postgres/migrator.go
@@ -237,6 +237,15 @@ func (m *Migrator) ForwardRebuild(ctx context.Context, permits ...ForwardRebuild
 }
 
 func (m *Migrator) forwardRun(ctx context.Context, permits []ForwardRebuildPermit) error {
+	// Strict precheck (#1089 / codex C2): reject a migration FS that carries a
+	// non-goose-parseable .sql before applying, so a malformed/misnamed file
+	// fails fast (naming it) instead of being silently skipped by goose.
+	if _, err := ExpectedVersion(m.migrations); err != nil {
+		return err
+	}
+	if err := m.checkNoLegacyPlatformTable(ctx); err != nil {
+		return err
+	}
 	if err := m.checkNoInvalidIndexes(ctx); err != nil {
 		return err
 	}
@@ -265,6 +274,52 @@ func (m *Migrator) forwardRun(ctx context.Context, permits []ForwardRebuildPermi
 		"applied", len(results),
 		"final_version", finalVersion)
 	return nil
+}
+
+// legacyPlatformTrackingTable is the pre-#1089 goose tracking table name for the
+// platform migration set, renamed to PlatformTrackingTable
+// (schema_migrations_platform). It is referenced only by the transition guard.
+const legacyPlatformTrackingTable = "schema_migrations"
+
+// checkNoLegacyPlatformTable fails fast when applying the platform migration set
+// (m.tableName == PlatformTrackingTable) against a database that still carries
+// the pre-#1089 `schema_migrations` tracking table but NOT the renamed
+// `schema_migrations_platform`. In that state goose would treat the platform
+// lineage as version 0 and re-apply every migration against an already-populated
+// schema — a confusing cascade of "already exists" errors. Pre-v1.0 there is no
+// production database and ephemeral test DBs are recreated fresh each run, so
+// this only guards a developer's long-lived local DB; the message tells them how
+// to recover. Non-platform namespaces and fresh DBs are a no-op.
+//
+// codex C3 minimal方案 (fail-fast detect legacy table); the project's accepted
+// transition policy is "recreate the ephemeral DB" (#1089 decision #3).
+func (m *Migrator) checkNoLegacyPlatformTable(ctx context.Context) error {
+	if m.tableName != PlatformTrackingTable {
+		return nil
+	}
+	var legacyExists bool
+	if err := m.pool.DB().QueryRow(ctx,
+		`SELECT to_regclass($1) IS NOT NULL`, legacyPlatformTrackingTable).Scan(&legacyExists); err != nil {
+		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGMigrate,
+			"postgres: probe legacy tracking table", err)
+	}
+	if !legacyExists {
+		return nil
+	}
+	var newExists bool
+	if err := m.pool.DB().QueryRow(ctx,
+		`SELECT to_regclass($1) IS NOT NULL`, m.tableName).Scan(&newExists); err != nil {
+		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGMigrate,
+			"postgres: probe platform tracking table", err)
+	}
+	if newExists {
+		return nil // both present — already transitioned / coexisting; not this guard's concern
+	}
+	return errcode.New(errcode.KindInternal, ErrAdapterPGMigrate,
+		"postgres: legacy goose tracking table \"schema_migrations\" present without "+
+			"\"schema_migrations_platform\" — the platform tracking table was renamed (#1089). "+
+			"Recreate the ephemeral database, or run "+
+			"`ALTER TABLE schema_migrations RENAME TO schema_migrations_platform`.")
 }
 
 // checkNoInvalidIndexes returns an error if any INVALID indexes are present.
@@ -412,6 +467,7 @@ func (m *Migrator) requirePermitIfDangerous(
 	permit, ok := permitByNum[version]
 	if ok {
 		slog.InfoContext(ctx, "postgres: forward-rebuild authorized",
+			"tracking_table", m.tableName,
 			"migration", version,
 			"target", target,
 			"reason", permit.Reason())
@@ -506,7 +562,8 @@ func (m *Migrator) Down(ctx context.Context, permit DestructiveDownPermit) error
 		}
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGMigrate, "postgres: rollback migration", err)
 	}
-	slog.InfoContext(ctx, "postgres: migration rolled back", "reason", permit.Reason())
+	slog.InfoContext(ctx, "postgres: migration rolled back",
+		"tracking_table", m.tableName, "reason", permit.Reason())
 	return nil
 }
 

--- a/adapters/postgres/migrator.go
+++ b/adapters/postgres/migrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pressly/goose/v3/lock"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -150,13 +151,27 @@ type Migrator struct {
 // Migration files must follow the goose annotated format with -- +goose Up
 // and -- +goose Down sections.
 //
-// The tableName parameter controls the tracking table name (default:
-// "schema_migrations"). It must be a valid SQL identifier
-// ([a-zA-Z_][a-zA-Z0-9_]*) to prevent SQL injection.
-func NewMigrator(p *Pool, migrations fs.FS, tableName string) (*Migrator, error) {
-	if tableName == "" {
-		tableName = "schema_migrations"
+// ns identifies the migration lineage; the goose tracking table is derived as
+// schema_migrations_<namespace> (see trackingTableFor). Passing a typed
+// migration.Namespace — not a free table-name string — makes "track migrations
+// in the bare global schema_migrations table" (the #1089 / R3 collision
+// footgun) unexpressible by construction. ns must be valid (fail-fast).
+func NewMigrator(p *Pool, migrations fs.FS, ns migration.Namespace) (*Migrator, error) {
+	if err := ns.Validate(); err != nil {
+		return nil, errcode.Wrap(errcode.KindInvalid, ErrAdapterPGMigrate,
+			"postgres: invalid migration namespace", err)
 	}
+	return newMigratorForTable(p, migrations, trackingTableFor(ns))
+}
+
+// newMigratorForTable builds a Migrator against an explicit goose tracking table.
+// It is the unexported construction core; the only production caller is
+// NewMigrator, which derives the table from a migration.Namespace via
+// trackingTableFor (so the exported surface never accepts a free table string —
+// the #1089 / R3 seal). In-package tests call it directly to provision isolated
+// per-test tracking tables. The non-test caller allowlist (= NewMigrator only)
+// is held by archtest MIGRATION-TRACKING-TABLE-DERIVED-01.
+func newMigratorForTable(p *Pool, migrations fs.FS, tableName string) (*Migrator, error) {
 	if err := validateIdentifier(tableName); err != nil {
 		return nil, err
 	}

--- a/adapters/postgres/migrator.go
+++ b/adapters/postgres/migrator.go
@@ -248,7 +248,10 @@ func (m *Migrator) forwardRun(ctx context.Context, permits []ForwardRebuildPermi
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGMigrate, "postgres: apply migrations", err)
 	}
 	if len(results) == 0 {
-		slog.InfoContext(ctx, "postgres: migrations already up to date", "applied", 0)
+		// tracking_table = schema_migrations_<namespace>, so a MigrationSet.ApplyAll
+		// over multiple namespaces stays attributable in the log stream.
+		slog.InfoContext(ctx, "postgres: migrations already up to date",
+			"tracking_table", m.tableName, "applied", 0)
 		return nil
 	}
 	var finalVersion int64
@@ -258,6 +261,7 @@ func (m *Migrator) forwardRun(ctx context.Context, permits []ForwardRebuildPermi
 		}
 	}
 	slog.InfoContext(ctx, "postgres: migrations applied",
+		"tracking_table", m.tableName,
 		"applied", len(results),
 		"final_version", finalVersion)
 	return nil

--- a/adapters/postgres/migrator_lock_timeout_test.go
+++ b/adapters/postgres/migrator_lock_timeout_test.go
@@ -56,7 +56,7 @@ func TestMigrator_LockTimeoutSessionLocker_SetsAndResets(t *testing.T) {
 
 // TestMigrator_LockTimeoutAppliedViaProvider guards the wiring (not just the
 // locker type): it runs probe migrations through the REAL
-// NewMigrator(...).Up(ctx) → newGooseProvider → goose → SessionLock path, where
+// newMigratorForTable(...).Up(ctx) → newGooseProvider → goose → SessionLock path, where
 // each migration body RAISEs unless current_setting('lock_timeout') = '5s'. If
 // the lockTimeoutSessionLocker wrapper in newGooseProvider were removed, the
 // session would carry the default lock_timeout and Up would fail here — which
@@ -97,7 +97,7 @@ END $$;
 		"002_locktimeout_probe_notxn.sql": &fstest.MapFile{Data: []byte(noTxnProbe)},
 	}
 
-	migrator, err := NewMigrator(pool, fixtureFS, "schema_migrations_locktimeout_probe")
+	migrator, err := newMigratorForTable(pool, fixtureFS, "schema_migrations_locktimeout_probe")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = migrator.Close() })
 
@@ -138,7 +138,7 @@ DROP TABLE IF EXISTS _locktimeout_down_probe;
 		"001_locktimeout_down_probe.sql": &fstest.MapFile{Data: []byte(downProbe)},
 	}
 
-	migrator, err := NewMigrator(pool, fixtureFS, "schema_migrations_locktimeout_down_probe")
+	migrator, err := newMigratorForTable(pool, fixtureFS, "schema_migrations_locktimeout_down_probe")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = migrator.Close() })
 

--- a/adapters/postgres/migrator_test.go
+++ b/adapters/postgres/migrator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
 )
 
 // stubMigrationFS returns a minimal valid goose-annotated migration FS
@@ -26,23 +27,56 @@ func stubMigrationFS() fstest.MapFS {
 	}
 }
 
-func TestNewMigrator_DefaultTableName(t *testing.T) {
+func TestNewMigrator_DerivesTrackingTableFromNamespace(t *testing.T) {
 	p := &Pool{inner: nil}
-	m, err := NewMigrator(p, stubMigrationFS(), "")
+
+	m, err := NewMigrator(p, stubMigrationFS(), migration.PlatformNamespace)
 	require.NoError(t, err)
-	assert.Equal(t, "schema_migrations", m.tableName)
+	assert.Equal(t, "schema_migrations_platform", m.tableName,
+		"platform namespace must derive schema_migrations_platform (no special-casing)")
 	_ = m.Close()
+
+	ns, err := migration.ParseNamespace("payment")
+	require.NoError(t, err)
+	m2, err := NewMigrator(p, stubMigrationFS(), ns)
+	require.NoError(t, err)
+	assert.Equal(t, "schema_migrations_payment", m2.tableName,
+		"external namespace must derive schema_migrations_<namespace>")
+	_ = m2.Close()
 }
 
-func TestNewMigrator_CustomTableName(t *testing.T) {
-	p := &Pool{inner: nil}
-	m, err := NewMigrator(p, stubMigrationFS(), "custom_migrations")
-	require.NoError(t, err)
-	assert.Equal(t, "custom_migrations", m.tableName)
-	_ = m.Close()
+func TestNewMigrator_InvalidNamespace(t *testing.T) {
+	// A typed migration.Namespace makes omission / bare-string a COMPILE error;
+	// these invalid VALUES (incl. the Namespace("x") conversion-literal escape)
+	// are caught fail-fast at runtime by NewMigrator's ns.Validate().
+	tests := []struct {
+		name string
+		ns   migration.Namespace
+	}{
+		{name: "empty (zero value)", ns: migration.Namespace("")},
+		{name: "dash conversion-literal escape", ns: migration.Namespace("acme-payment")},
+		{name: "uppercase", ns: migration.Namespace("Payment")},
+		{name: "leading digit", ns: migration.Namespace("2pay")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pool{inner: nil}
+			m, err := NewMigrator(p, stubMigrationFS(), tt.ns)
+			assert.Nil(t, m)
+			require.Error(t, err)
+
+			var ecErr *errcode.Error
+			require.True(t, errors.As(err, &ecErr))
+			assert.Equal(t, ErrAdapterPGMigrate, ecErr.Code)
+		})
+	}
 }
 
-func TestNewMigrator_InvalidTableName(t *testing.T) {
+func TestNewMigratorForTable_InvalidTableName(t *testing.T) {
+	// newMigratorForTable is the unexported in-package escape hatch for tests
+	// that need isolated tracking tables; it still validates the table identifier
+	// (production code reaches it only via NewMigrator's trackingTableFor(ns)).
 	tests := []struct {
 		name      string
 		tableName string
@@ -52,15 +86,12 @@ func TestNewMigrator_InvalidTableName(t *testing.T) {
 		{name: "contains spaces", tableName: "my table"},
 		{name: "contains dash", tableName: "my-table"},
 		{name: "contains dot", tableName: "schema.table"},
-		{name: "contains semicolon", tableName: "table;"},
-		{name: "contains parentheses", tableName: "table()"},
-		{name: "unicode characters", tableName: "tbl\u00e9"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Pool{inner: nil}
-			m, err := NewMigrator(p, stubMigrationFS(), tt.tableName)
+			m, err := newMigratorForTable(p, stubMigrationFS(), tt.tableName)
 			assert.Nil(t, m)
 			require.Error(t, err)
 
@@ -71,28 +102,12 @@ func TestNewMigrator_InvalidTableName(t *testing.T) {
 	}
 }
 
-func TestNewMigrator_ValidTableNames(t *testing.T) {
-	tests := []struct {
-		name      string
-		tableName string
-	}{
-		{name: "lowercase", tableName: "migrations"},
-		{name: "with underscore", tableName: "schema_migrations"},
-		{name: "starts with underscore", tableName: "_private"},
-		{name: "uppercase", tableName: "MIGRATIONS"},
-		{name: "mixed case", tableName: "SchemaMigrations"},
-		{name: "with digits", tableName: "migrations_v2"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Pool{inner: nil}
-			m, err := NewMigrator(p, stubMigrationFS(), tt.tableName)
-			require.NoError(t, err)
-			assert.Equal(t, tt.tableName, m.tableName)
-			_ = m.Close()
-		})
-	}
+func TestNewMigratorForTable_ValidTableName(t *testing.T) {
+	p := &Pool{inner: nil}
+	m, err := newMigratorForTable(p, stubMigrationFS(), "schema_migrations_iso_probe")
+	require.NoError(t, err)
+	assert.Equal(t, "schema_migrations_iso_probe", m.tableName)
+	_ = m.Close()
 }
 
 func TestValidateIdentifier(t *testing.T) {

--- a/adapters/postgres/refresh_store_integration_test.go
+++ b/adapters/postgres/refresh_store_integration_test.go
@@ -72,7 +72,7 @@ func TestMigration012_StructuralAssertions(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_012_struct")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_012_struct")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations through 012")
 

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pressly/goose/v3"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
 )
 
 // Tables owned by the adapters/postgres migration set (in migration order).
@@ -111,15 +112,14 @@ func ExpectedVersion(fsys fs.FS) (int64, error) {
 	return max, nil
 }
 
-// defaultSchemaTable is the goose migration tracking table used by GoCell.
-// Must match the tableName passed to NewMigrator in production code.
-const defaultSchemaTable = "schema_migrations"
-
 // VerifyExpectedVersion compares the database's current goose schema version
-// against the expected version derived from the embedded migration FS.
+// against the expected version derived from the embedded migration FS for the
+// given namespace.
 //
-// tableName is the goose tracking table (pass "" to use the default
-// "schema_migrations"). It must match the table used by NewMigrator.
+// ns identifies the migration lineage; the goose tracking table is derived as
+// schema_migrations_<namespace> (see trackingTableFor) and must match the table
+// NewMigrator(_, _, ns) writes. Taking a typed migration.Namespace rather than a
+// free table string keeps the read and write sides on the same derivation.
 //
 // Returns ErrAdapterPGSchemaMismatch if:
 //   - actual < expected: DB schema is behind the binary (migrations not run).
@@ -128,12 +128,22 @@ const defaultSchemaTable = "schema_migrations"
 // Returns nil when actual == expected.
 //
 // ref: pressly/goose v3.27 Provider.GetDBVersion — GetDBVersion reads max version
-// from the goose version table (schema_migrations by default).
-func VerifyExpectedVersion(ctx context.Context, pool *Pool, fsys fs.FS, tableName ...string) error {
-	tbl := defaultSchemaTable
-	if len(tableName) > 0 && tableName[0] != "" {
-		tbl = tableName[0]
+// from the goose version table.
+func VerifyExpectedVersion(ctx context.Context, pool *Pool, fsys fs.FS, ns migration.Namespace) error {
+	if err := ns.Validate(); err != nil {
+		return errcode.Wrap(errcode.KindInvalid, ErrAdapterPGSchemaMismatch,
+			"schema_guard: invalid migration namespace", err)
 	}
+	return verifyExpectedVersionForTable(ctx, pool, fsys, trackingTableFor(ns))
+}
+
+// verifyExpectedVersionForTable is the unexported core of VerifyExpectedVersion
+// against an explicit goose tracking table. The only production caller is
+// VerifyExpectedVersion, which derives the table from a migration.Namespace via
+// trackingTableFor; in-package tests call it directly to verify isolated
+// per-test tracking tables. Non-test caller allowlist held by archtest
+// MIGRATION-TRACKING-TABLE-DERIVED-01.
+func verifyExpectedVersionForTable(ctx context.Context, pool *Pool, fsys fs.FS, tbl string) error {
 	if err := validateIdentifier(tbl); err != nil {
 		return err
 	}

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -97,13 +97,26 @@ func ExpectedVersion(fsys fs.FS) (int64, error) {
 		if !strings.HasSuffix(name, ".sql") {
 			continue
 		}
+		// STRICT (#1089 / codex C2): a top-level .sql whose name goose cannot
+		// derive a version from is NOT silently skipped. Silent-skip is a
+		// fail-open — goose's own collector would also ignore the file, so a
+		// malformed/misnamed (e.g. namespace-prefixed) external-cell migration
+		// would vanish from BOTH ExpectedVersion and apply, and VerifyAll would
+		// pass against a DB missing it. Fail fast and name the file. cf. Flyway
+		// `validate`, Django (app,name) explicit migration records.
 		m := migrationVersionRe.FindStringSubmatch(name)
 		if m == nil {
-			continue
+			return 0, errcode.New(errcode.KindInvalid, ErrAdapterPGSchemaMismatch,
+				"schema_guard: migration filename has no leading NNN_ version prefix; must be goose-native NNN_desc.sql",
+				errcode.WithInternal(errcode.InternalAttr("file", name)))
 		}
 		v, parseErr := strconv.ParseInt(m[1], 10, 64)
 		if parseErr != nil {
-			continue
+			return 0, errcode.New(errcode.KindInvalid, ErrAdapterPGSchemaMismatch,
+				"schema_guard: migration filename version prefix is not a parseable int64",
+				errcode.WithInternal(
+					errcode.InternalAttr("file", name),
+					errcode.InternalAttr("parse_error", parseErr.Error())))
 		}
 		if v > max {
 			max = v

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -180,10 +180,17 @@ func verifyExpectedVersionForTable(ctx context.Context, pool *Pool, fsys fs.FS, 
 	if actual != expected {
 		return errcode.New(errcode.KindInternal, ErrAdapterPGSchemaMismatch,
 			"schema version mismatch",
-			errcode.WithDetails(errcode.PublicInt("db", actual), errcode.PublicInt("binary", expected)))
+			errcode.WithDetails(
+				errcode.PublicString("trackingTable", tbl),
+				errcode.PublicInt("db", actual),
+				errcode.PublicInt("binary", expected)))
 	}
 
-	slog.Info("schema_guard: schema version matched",
+	// Carry the tracking table (schema_migrations_<namespace>) so a VerifyAll
+	// over multiple namespaces is attributable in slog; use the request ctx so
+	// the entry keeps its correlation fields.
+	slog.InfoContext(ctx, "schema_guard: schema version matched",
+		slog.String("tracking_table", tbl),
 		slog.Int64("version", actual))
 	return nil
 }

--- a/adapters/postgres/schema_guard_integration_test.go
+++ b/adapters/postgres/schema_guard_integration_test.go
@@ -21,12 +21,12 @@ func TestVerifyExpectedVersion_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations first.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
 	// VerifyExpectedVersion should pass: DB version == FS max version.
-	err = VerifyExpectedVersion(ctx, pool, testMigrationsFS(t), "schema_migrations")
+	err = verifyExpectedVersionForTable(ctx, pool, testMigrationsFS(t), "schema_migrations")
 	assert.NoError(t, err, "VerifyExpectedVersion should return nil after full Up()")
 }
 
@@ -40,7 +40,7 @@ func TestDetectInvalidIndexes_WithInjectedInvalid(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply migrations to create tables/indexes.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_invalid_idx")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_invalid_idx")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply")
 
@@ -92,7 +92,7 @@ func TestVerifyExpectedVersion_DBAhead_Integration(t *testing.T) {
 	const tbl = "schema_migrations_ahead"
 
 	// Apply all migrations.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), tbl)
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), tbl)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "initial Up() must succeed")
 
@@ -109,7 +109,7 @@ func TestVerifyExpectedVersion_DBAhead_Integration(t *testing.T) {
 	require.NoError(t, execErr, "inserting extra version record must succeed")
 
 	// VerifyExpectedVersion must now return a schema mismatch error (DB ahead).
-	err = VerifyExpectedVersion(ctx, pool, testMigrationsFS(t), tbl)
+	err = verifyExpectedVersionForTable(ctx, pool, testMigrationsFS(t), tbl)
 	require.Error(t, err, "should return error when DB version is ahead of binary")
 	assert.Contains(t, err.Error(), "schema version mismatch",
 		"error message should mention schema version mismatch")
@@ -130,7 +130,7 @@ func TestOutboxClaimingLeaseCheckConstraint_RejectsNullLeaseInsert(t *testing.T)
 	pool := emptyPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_lease_check")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_lease_check")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly through 015")
 
@@ -170,7 +170,7 @@ func TestOutboxMigration014_AbortsOnClaimingResidue(t *testing.T) {
 	pool := emptyPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_014_residue")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_014_residue")
 	require.NoError(t, err)
 
 	// Migrate up to but NOT including 014 — pre-014 schema lacks lease_id and
@@ -213,7 +213,7 @@ func TestOutboxMigration015_RejectsExistingClaimingNullLeaseRow(t *testing.T) {
 	pool := emptyPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_015_existing_bad")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_015_existing_bad")
 	require.NoError(t, err)
 
 	// Apply through 014: lease_id column exists, but the CHECK constraint
@@ -249,7 +249,7 @@ func TestOutboxMigration015_RejectsUpdateIntoClaimingNullLease(t *testing.T) {
 	pool := emptyPool(t)
 
 	ctx := context.Background()
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_015_update_path")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_015_update_path")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly through 015")
 
@@ -283,7 +283,7 @@ func TestVerifyExpectedVersion_DBLagged_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_lagged")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_lagged")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "initial Up() must succeed")
 
@@ -299,7 +299,7 @@ func TestVerifyExpectedVersion_DBLagged_Integration(t *testing.T) {
 	require.NoError(t, execErr, "deleting version records should succeed")
 
 	// VerifyExpectedVersion must now return a schema mismatch error.
-	err = VerifyExpectedVersion(ctx, pool, testMigrationsFS(t), "schema_migrations_lagged")
+	err = verifyExpectedVersionForTable(ctx, pool, testMigrationsFS(t), "schema_migrations_lagged")
 	require.Error(t, err, "should return error when DB is lagged")
 	assert.Contains(t, err.Error(), "schema version mismatch",
 		"error message should mention schema version mismatch")
@@ -331,7 +331,7 @@ func TestVerifyExpectedShape_AllColumnsPresent(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_happy")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_happy")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -347,7 +347,7 @@ func TestVerifyExpectedShape_MissingRequiredColumn(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_missing")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_missing")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -381,7 +381,7 @@ func TestVerifyExpectedShape_SeqIdentityDropped(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_seq_identity")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_seq_identity")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -412,7 +412,7 @@ func TestVerifyExpectedShape_ForbiddenColumnPresent(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_forbidden")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_forbidden")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -446,7 +446,7 @@ func TestVerifyNoInvalidIndexes_NoneInvalid(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_valid_idx")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_valid_idx")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -461,7 +461,7 @@ func TestVerifyNoInvalidIndexes_DetectInvalid(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_invalidcheck")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_invalidcheck")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -521,7 +521,7 @@ func TestDetectInvalidIndexes_Empty(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_detect_empty")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_detect_empty")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -538,7 +538,7 @@ func TestDetectInvalidIndexes_WithInvalidIndex(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_detect_invalid")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_detect_invalid")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -583,7 +583,7 @@ func TestInvalidIndexCheck_NoInvalidIndexes(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_probe_happy")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_probe_happy")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -617,7 +617,7 @@ func TestVerifyExpectedShape_AllDimensionsHappy(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_9dim_happy")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_9dim_happy")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -633,7 +633,7 @@ func TestVerifyExpectedShape_DetectsMissingForeignKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_fk")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_fk")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -658,7 +658,7 @@ func TestVerifyExpectedShape_DetectsWrongFKOnDeleteAction(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_fk_ondel")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_fk_ondel")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -686,7 +686,7 @@ func TestVerifyExpectedShape_DetectsMissingUniqueIndex(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_uidx")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_uidx")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -713,7 +713,7 @@ func TestVerifyExpectedShape_DetectsIndexColumnsMismatch(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_idxcols")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_idxcols")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -749,7 +749,7 @@ func TestVerifyExpectedShape_DetectsMissingTrigger(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_trig")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_trig")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -777,7 +777,7 @@ func TestVerifyExpectedShape_DetectsMissingUsersTrigger(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_users_trig")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_users_trig")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -802,7 +802,7 @@ func TestVerifyExpectedShape_DetectsDisabledTrigger(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_trig_dis")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_trig_dis")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -827,7 +827,7 @@ func TestVerifyExpectedShape_DetectsWrongColumnType(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_coltype")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_coltype")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -853,7 +853,7 @@ func TestVerifyExpectedShape_DetectsNullableColumn(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_nullable")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_nullable")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -880,7 +880,7 @@ func TestVerifyExpectedShape_DetectsMissingColumnDefault(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_default")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_default")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -911,7 +911,7 @@ func TestVerifyExpectedShape_DetectsMissingCheckConstraint(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_chk")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_chk")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -936,7 +936,7 @@ func TestVerifyExpectedShape_DetectsMissingPrimaryKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_pk")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_pk")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -965,7 +965,7 @@ func TestVerifyExpectedShape_DetectsMissingFunction(t *testing.T) {
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_fn")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_fn")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -1001,7 +1001,7 @@ func TestUsersMigration033_PasswordVersionNonNegative(t *testing.T) {
 	pool := emptyPool(t)
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_033_pw_version")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_033_pw_version")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "all migrations must apply cleanly through 033")
 
@@ -1049,7 +1049,7 @@ func TestDetectInvalidIndexes_StillReportsOrphanWithProgressFilterAdded(t *testi
 
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_inprogress_filter")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_inprogress_filter")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -1089,7 +1089,7 @@ func TestVerifyExpectedShape_DetectsWrongFKLocalColumns(t *testing.T) {
 	pool := emptyPool(t)
 	ctx := context.Background()
 
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_shape_fk_localcols")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_shape_fk_localcols")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 
@@ -1125,7 +1125,7 @@ func TestMigration050_UpDownUpIdempotency(t *testing.T) {
 	ctx := context.Background()
 
 	// First Up pass: apply all migrations (tables are empty, no permit needed).
-	m1, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_idem")
+	m1, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_idem")
 	require.NoError(t, err)
 	require.NoError(t, m1.Up(ctx), "initial Up() through all migrations must succeed")
 
@@ -1140,14 +1140,14 @@ func TestMigration050_UpDownUpIdempotency(t *testing.T) {
 	// Down rolls back the most-recently-applied migration. With 050 as the highest
 	// migration, a single Down rolls it back to version 049, so 050 is the next
 	// pending migration for the second Up pass.
-	m2, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_idem")
+	m2, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_idem")
 	require.NoError(t, err)
 
 	// Roll back migration 050 (the destructive users/roles/role_assignments rebuild).
 	require.NoError(t, m2.Down(ctx, downPermit), "Down() migration 050 must succeed")
 
 	// Second Up pass: from version 049 → re-applies 050 (empty tables → no permit).
-	m3, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_idem")
+	m3, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_idem")
 	require.NoError(t, err)
 	require.NoError(t, m3.Up(ctx),
 		"second Up() (after Down through 050) must succeed (empty tables, no permit needed)")
@@ -1165,7 +1165,7 @@ func TestMigration050_DestructiveDownPermitRejection(t *testing.T) {
 	ctx := context.Background()
 
 	// Apply all migrations.
-	migrator, err := NewMigrator(pool, testMigrationsFS(t), "schema_migrations_050_downpermit")
+	migrator, err := newMigratorForTable(pool, testMigrationsFS(t), "schema_migrations_050_downpermit")
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "Up() must succeed on a fresh DB")
 

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -122,14 +122,6 @@ func TestExpectedVersion_SyntheticFS(t *testing.T) {
 			wantMax: 1,
 		},
 		{
-			name: "files without numeric prefix are ignored",
-			files: map[string][]byte{
-				"create_foo.sql":    []byte("-- up"),
-				"002_something.sql": []byte("-- up"),
-			},
-			wantMax: 2,
-		},
-		{
 			name: "subdirectory entries are skipped",
 			files: map[string][]byte{
 				"subdir/nested.sql": []byte("-- up"),
@@ -239,19 +231,34 @@ func TestExpectedVersion_ReadDirError(t *testing.T) {
 	assert.ErrorIs(t, err, sentinel, "original error must be wrapped")
 }
 
-// TestExpectedVersion_OverflowVersionIgnored verifies that a migration file
-// with a numeric prefix too large for int64 is silently skipped (ParseInt
-// overflow → parseErr != nil → continue).
-func TestExpectedVersion_OverflowVersionIgnored(t *testing.T) {
-	// 99999999999999999999 overflows int64.
-	fsys := fstest.MapFS{
-		"99999999999999999999_too_big.sql": &fstest.MapFile{Data: []byte("-- up")},
-		"003_normal.sql":                   &fstest.MapFile{Data: []byte("-- up")},
+// TestExpectedVersion_RejectsNonGooseParseable verifies the STRICT behavior
+// (#1089 / codex C2): a top-level .sql whose name goose cannot derive a version
+// from is rejected fail-fast (naming the file), NOT silently skipped — so a
+// malformed/misnamed external-cell migration cannot vanish from ExpectedVersion
+// (and thus VerifyAll) while goose's collector also ignores it.
+func TestExpectedVersion_RejectsNonGooseParseable(t *testing.T) {
+	tests := []struct {
+		name    string
+		badFile string
+	}{
+		{name: "no numeric prefix", badFile: "create_foo.sql"},
+		{name: "namespace-prefixed", badFile: "payment_001.sql"},
+		{name: "int64 overflow prefix", badFile: "99999999999999999999_too_big.sql"},
 	}
-	v, err := ExpectedVersion(fsys)
-	require.NoError(t, err)
-	assert.Equal(t, int64(3), v,
-		"overflow version must be skipped; normal max must be returned")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys := fstest.MapFS{
+				tc.badFile:       &fstest.MapFile{Data: []byte("-- up")},
+				"003_normal.sql": &fstest.MapFile{Data: []byte("-- up")},
+			}
+			_, err := ExpectedVersion(fsys)
+			require.Error(t, err, "malformed migration filename must be rejected, not skipped")
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, ErrAdapterPGSchemaMismatch, ec.Code)
+			assert.Contains(t, err.Error(), tc.badFile, "error must name the offending file")
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
 )
 
 // errDirFile implements fs.File and fs.ReadDirFile, returning error from ReadDir.
@@ -155,17 +156,19 @@ func TestExpectedVersion_SyntheticFS(t *testing.T) {
 // TestVerifyExpectedVersion — unit tests for the validation guard
 // ---------------------------------------------------------------------------
 
-// TestVerifyExpectedVersion_InvalidTableName verifies that an invalid SQL
-// identifier in the tableName argument is rejected before any DB interaction.
-func TestVerifyExpectedVersion_InvalidTableName(t *testing.T) {
+// TestVerifyExpectedVersion_InvalidNamespace verifies that an invalid
+// migration.Namespace is rejected before any DB interaction. The exported API
+// takes a typed Namespace (not a free table string), so the table can never be
+// invalid for a valid namespace — the only fail path is an invalid namespace.
+func TestVerifyExpectedVersion_InvalidNamespace(t *testing.T) {
 	tests := []struct {
-		name      string
-		tableName string
+		name string
+		ns   migration.Namespace
 	}{
-		{name: "semicolon injection", tableName: "schema_migrations; DROP TABLE users"},
-		{name: "dash in name", tableName: "schema-migrations"},
-		{name: "space in name", tableName: "schema migrations"},
-		{name: "leading digit", tableName: "1_schema_migrations"},
+		{name: "empty", ns: migration.Namespace("")},
+		{name: "dash conversion-literal escape", ns: migration.Namespace("schema-migrations")},
+		{name: "space", ns: migration.Namespace("schema migrations")},
+		{name: "leading digit", ns: migration.Namespace("1pay")},
 	}
 
 	fsys := fstest.MapFS{
@@ -174,14 +177,29 @@ func TestVerifyExpectedVersion_InvalidTableName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// VerifyExpectedVersion validates tableName before opening any DB connection.
-			err := VerifyExpectedVersion(context.Background(), nil, fsys, tc.tableName)
-			require.Error(t, err, "invalid tableName should return error")
+			// ns.Validate runs before opening any DB connection (pool=nil proves it).
+			err := VerifyExpectedVersion(context.Background(), nil, fsys, tc.ns)
+			require.Error(t, err, "invalid namespace should return error")
 			var ec *errcode.Error
 			require.ErrorAs(t, err, &ec, "error should be an errcode.Error")
-			assert.Equal(t, errcode.ErrValidationFailed, ec.Code,
-				"error code should be ErrValidationFailed")
+			assert.Equal(t, ErrAdapterPGSchemaMismatch, ec.Code)
 		})
+	}
+}
+
+// TestVerifyExpectedVersionForTable_InvalidTableName verifies the unexported
+// in-package escape hatch still rejects an invalid table identifier (production
+// reaches it only via VerifyExpectedVersion's trackingTableFor(ns)).
+func TestVerifyExpectedVersionForTable_InvalidTableName(t *testing.T) {
+	fsys := fstest.MapFS{
+		"001_create.sql": &fstest.MapFile{Data: []byte("-- +goose Up")},
+	}
+	for _, tbl := range []string{"schema_migrations; DROP TABLE users", "schema-migrations", "1_schema_migrations"} {
+		err := verifyExpectedVersionForTable(context.Background(), nil, fsys, tbl)
+		require.Error(t, err)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
 	}
 }
 
@@ -247,9 +265,9 @@ func TestVerifyExpectedVersion_ExpectedVersionError(t *testing.T) {
 	sentinel := errors.New("disk I/O error")
 	fsys := readDirErrFS{err: sentinel}
 
-	// Valid table name → passes validateIdentifier, then fails at ExpectedVersion.
-	// pool=nil is intentional: we must NOT reach stdlib.OpenDBFromPool.
-	err := VerifyExpectedVersion(context.Background(), nil, fsys)
+	// Valid namespace → passes ns.Validate + table validateIdentifier, then fails
+	// at ExpectedVersion. pool=nil is intentional: we must NOT reach stdlib.OpenDBFromPool.
+	err := VerifyExpectedVersion(context.Background(), nil, fsys, migration.PlatformNamespace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "schema_guard: compute expected version",
 		"error must include context prefix")

--- a/adapters/postgres/testmain_integration_test.go
+++ b/adapters/postgres/testmain_integration_test.go
@@ -39,7 +39,7 @@ var sharedPG = pgclone.New("gocell_adapters_postgres_test_template",
 		if err != nil {
 			return fmt.Errorf("load migrations fs: %w", err)
 		}
-		migrator, err := NewMigrator(pool, fsys, "schema_migrations")
+		migrator, err := newMigratorForTable(pool, fsys, "schema_migrations")
 		if err != nil {
 			return fmt.Errorf("new migrator: %w", err)
 		}

--- a/cells/accesscore/slices/identitymanage/service_pg_integration_test.go
+++ b/cells/accesscore/slices/identitymanage/service_pg_integration_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth/refresh"
@@ -98,7 +99,7 @@ func setupIdentityManagePG(t *testing.T) (*accesspgrepo.PGUserRepo, *adapterpg.T
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, pgIntegMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, pgIntegMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -6,6 +6,7 @@ import (
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/runtime/capability"
 	"github.com/ghbvf/gocell/runtime/composition"
 )
@@ -129,7 +130,7 @@ func verifyConfigCorePGSchema(ctx context.Context, pool *adapterpg.Pool) error {
 	if err != nil {
 		return fmt.Errorf("configcore PG migrations fs: %w", err)
 	}
-	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS); err != nil {
+	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, migration.PlatformNamespace); err != nil {
 		return fmt.Errorf("configcore PG schema guard: %w", err)
 	}
 	return nil

--- a/cmd/corebundle/corebundle_pg_env_integration_test.go
+++ b/cmd/corebundle/corebundle_pg_env_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
@@ -23,7 +24,7 @@ func applyMigrationsForMain(t *testing.T, ctx context.Context, dsn string) {
 	t.Helper()
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "migration prep pool must open")
-	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
 	_ = pool.Close(ctx)

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -113,7 +113,7 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMismatch(t *testing.T) {
 	// Simulate lag: remove entries for versions > 3 so VerifyExpectedVersion sees
 	// actual < expected and returns a schema mismatch error.
 	_, execErr := pool.DB().Exec(ctx,
-		"DELETE FROM schema_migrations WHERE version_id > 3")
+		"DELETE FROM schema_migrations_platform WHERE version_id > 3")
 	require.NoError(t, execErr, "deleting version records must succeed")
 
 	// Schema verification now lives in verifyPGPreconditions (provisionPostgres).

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/composition"
 	"github.com/ghbvf/gocell/tests/testutil"
@@ -60,7 +61,7 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMatched(t *testing.T) {
 	migPool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "pool for migration prep must succeed")
 
-	migrator, err := adapterpg.NewMigrator(migPool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(migPool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations")
 	_ = migPool.Close(ctx)
@@ -105,7 +106,7 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMismatch(t *testing.T) {
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "pool for migration prep must succeed")
 
-	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations initially")
 

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
@@ -148,7 +149,7 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 
 	migrationPool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: pgConnStr})
 	require.NoError(t, err, "create migration PG pool")
-	migrator, err := adapterpg.NewMigrator(migrationPool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(migrationPool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err, "create migrator")
 	require.NoError(t, migrator.Up(ctx), "run migrations")
 	_ = migrationPool.Close(ctx)
@@ -471,7 +472,7 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 
 	migrationPool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: pgConnStr})
 	require.NoError(t, err, "create migration PG pool")
-	migrator, err := adapterpg.NewMigrator(migrationPool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(migrationPool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err, "create migrator")
 	require.NoError(t, migrator.Up(ctx), "run migrations")
 	_ = migrationPool.Close(ctx)

--- a/cmd/corebundle/setup_pg_integration_test.go
+++ b/cmd/corebundle/setup_pg_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
@@ -74,7 +75,7 @@ func newSetupPGHarness(t *testing.T, pgOutboxWriter outbox.Writer) *setupPGHarne
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pool.Close(ctx) })
 
-	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 
@@ -358,7 +359,7 @@ func newSessionPGHarnessWithWriter(t *testing.T, pgOutboxOverride outbox.Writer)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pool.Close(ctx) })
 
-	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 	require.NoError(t, adapterpg.VerifyExpectedShape(ctx, pool))

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -144,6 +144,44 @@ modules:
 
 `gocell validate --root=.` 会聚合两个 module 的 cell/slice/contract。预期退出码 0，输出末尾包含 `No issues found.` 或仅 advisory warnings。
 
+### 6. Migrations（per-namespace，M8 #1089）
+
+外部 Cell module 自带数据库 migration 时，**不**共享平台的全局版本空间——每个 namespace 独立追踪，互不撞号。
+
+**写法约定**：
+
+- migration 文件用 goose-native `NNN_desc.sql` 命名（自己的 `001..N` 序列），**不要**在文件名里加 namespace 前缀。`platform_001_x.sql` 这类前缀会让 goose 的版本解析器（`NumericComponent` = `ParseInt(strings.Cut(name,"_")[0])`）失败；namespace 活在**追踪表名**里，不在文件名里。由 archtest `MIGRATION-FILENAME-GOOSE-PARSEABLE-01` 守。
+- 用 `embed.FS` 嵌入自己的 `migrations/*.sql`。
+- 经 `composition.WithMigrations(ns, fs)` 注册，`ns` 是 `pkg/migration.Namespace`（`migration.ParseNamespace("yourcell")`，小写标识符，长度 ≤ 45）。
+- 该 namespace 的 migration 追踪在独立的 `schema_migrations_<namespace>` 表；平台自身是保留 namespace `"platform"`（追踪表 `schema_migrations_platform`），外部 module **不可**注册 `"platform"`。
+
+```go
+//go:embed migrations/*.sql
+var paymentMigrations embed.FS
+
+paymentNS, err := migration.ParseNamespace("payment")
+if err != nil { return err }
+paymentFS, err := fs.Sub(paymentMigrations, "migrations")
+if err != nil { return err }
+
+builder := composition.New(cellIDs...).
+    With(platformModules..., paymentcell.Module()).
+    WithMigrations(paymentNS, paymentFS)
+```
+
+**执行桥**：`composition.Build()` 本身**不**跑 migration（cell 启动前 schema 必须已就位，且 `runtime/` 不依赖 `adapters/`）。在 composition root（可同时 import 两层）里，于 `Build` **之前**把注册的 migration set drain 进 `adapters/postgres.MigrationSet` 并应用——`NewMigrationSetWithPlatform` 已把平台 namespace 排在最前（platform-first 顺序保证：外部 cell 的 migration 可以 FK 平台表）：
+
+```go
+set, err := adapterpg.NewMigrationSetWithPlatform() // seeds "platform" first
+if err != nil { return err }
+for _, r := range builder.Migrations() {
+    if err := set.Add(r.Namespace, r.FS); err != nil { return err }
+}
+if err := set.ApplyAll(ctx, pool); err != nil { return err } // or set.VerifyAll(ctx, pool) in prod
+
+app, err := builder.Build(ctx, shared, runtimeOpts)
+```
+
 ## 已知限制（M1 范围）
 
 | 限制 | 影响 | 解锁条件 |

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -150,7 +150,7 @@ modules:
 
 **写法约定**：
 
-- migration 文件用 goose-native `NNN_desc.sql` 命名（自己的 `001..N` 序列），**不要**在文件名里加 namespace 前缀。`platform_001_x.sql` 这类前缀会让 goose 的版本解析器（`NumericComponent` = `ParseInt(strings.Cut(name,"_")[0])`）失败；namespace 活在**追踪表名**里，不在文件名里。由 archtest `MIGRATION-FILENAME-GOOSE-PARSEABLE-01` 守。
+- migration 文件用 goose-native `NNN_desc.sql` 命名（自己的 `001..N` 序列），**不要**在文件名里加 namespace 前缀。`platform_001_x.sql` 这类前缀会让 goose 的版本解析器（`NumericComponent` = `ParseInt(strings.Cut(name,"_")[0])`）失败；namespace 活在**追踪表名**里，不在文件名里。⚠️ **非 `NNN_` 前缀的 `.sql` 会被 goose 静默跳过、不被应用**（goose 默认非严格收集），所以务必遵守该命名。平台自身的 migration 由 archtest `MIGRATION-FILENAME-GOOSE-PARSEABLE-01` 守，但该规则**只扫 `adapters/postgres/migrations/`**——外部仓库目前不在其覆盖内，需自行遵守约定（随 M3 archtest library #1302 迁入外部规则集后可机器守）。
 - 用 `embed.FS` 嵌入自己的 `migrations/*.sql`。
 - 经 `composition.WithMigrations(ns, fs)` 注册，`ns` 是 `pkg/migration.Namespace`（`migration.ParseNamespace("yourcell")`，小写标识符，长度 ≤ 45）。
 - 该 namespace 的 migration 追踪在独立的 `schema_migrations_<namespace>` 表；平台自身是保留 namespace `"platform"`（追踪表 `schema_migrations_platform`），外部 module **不可**注册 `"platform"`。

--- a/docs/patterns/pg-cell-template.md
+++ b/docs/patterns/pg-cell-template.md
@@ -278,17 +278,13 @@ func buildFooCoreOpts(clk clock.Clock, cfg fooCoreModuleConfig) (fooCoreModuleRe
 		if err != nil {
 			return fooCoreModuleResult{}, fmt.Errorf("foocore: %w", err)
 		}
-		// foocore ships its own migration set under its own namespace; the goose
-		// tracking table is schema_migrations_foocore (derived from the typed
-		// migration.Namespace — NewMigrator/VerifyExpectedVersion no longer take a
-		// free table string). See docs/guides/cell-external-repo-quickstart.md.
-		fooNS, err := migration.ParseNamespace("foocore")
-		if err != nil {
-			return fooCoreModuleResult{}, fmt.Errorf("foocore migration namespace: %w", err)
-		}
-		if schemaErr := adapterpg.VerifyExpectedVersion(ctx, pool, foocorecell.MigrationsFS(), fooNS); schemaErr != nil {
-			return fooCoreModuleResult{}, fmt.Errorf("foocore PG schema guard: %w", schemaErr)
-		}
+		// foocore ships its own migration set under its own namespace
+		// (migration.ParseNamespace("foocore") → goose tracking table
+		// schema_migrations_foocore). Applying + verifying that namespace is an
+		// ops / bootstrap concern, NOT a cellmodule one: register the set via
+		// composition.WithMigrations(ns, fs) and apply/verify it
+		// (adapters/postgres.MigrationSet.ApplyAll / VerifyAll) BEFORE Build —
+		// see docs/guides/cell-external-repo-quickstart.md "Migrations".
 		txMgr := cfg.pg.TxManager()
 		outboxWriter := cfg.pg.OutboxWriter()
 

--- a/docs/patterns/pg-cell-template.md
+++ b/docs/patterns/pg-cell-template.md
@@ -278,7 +278,15 @@ func buildFooCoreOpts(clk clock.Clock, cfg fooCoreModuleConfig) (fooCoreModuleRe
 		if err != nil {
 			return fooCoreModuleResult{}, fmt.Errorf("foocore: %w", err)
 		}
-		if schemaErr := adapterpg.VerifyExpectedVersion(db, foocorecell.MigrationsFS()); schemaErr != nil {
+		// foocore ships its own migration set under its own namespace; the goose
+		// tracking table is schema_migrations_foocore (derived from the typed
+		// migration.Namespace — NewMigrator/VerifyExpectedVersion no longer take a
+		// free table string). See docs/guides/cell-external-repo-quickstart.md.
+		fooNS, err := migration.ParseNamespace("foocore")
+		if err != nil {
+			return fooCoreModuleResult{}, fmt.Errorf("foocore migration namespace: %w", err)
+		}
+		if schemaErr := adapterpg.VerifyExpectedVersion(ctx, pool, foocorecell.MigrationsFS(), fooNS); schemaErr != nil {
 			return fooCoreModuleResult{}, fmt.Errorf("foocore PG schema guard: %w", schemaErr)
 		}
 		txMgr := cfg.pg.TxManager()
@@ -425,7 +433,9 @@ func TestFooCoreModule_Postgres_SchemaMatched(t *testing.T) {
 	// 预先跑 migration
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err)
-	migrator, err := adapterpg.NewMigrator(pool, foocorecell.MigrationsFS(), "schema_migrations")
+	fooNS, err := migration.ParseNamespace("foocore") // tracking table schema_migrations_foocore
+	require.NoError(t, err)
+	migrator, err := adapterpg.NewMigrator(pool, foocorecell.MigrationsFS(), fooNS)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx))
 

--- a/examples/iotdevice/cells/devicecell/internal/adapters/postgres/device_repo_conformance_integration_test.go
+++ b/examples/iotdevice/cells/devicecell/internal/adapters/postgres/device_repo_conformance_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
 
@@ -72,7 +73,7 @@ func setupSharedDeviceRepoPG(t *testing.T) (*adapterpg.Pool, *adapterpg.TxManage
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
 	require.NoError(t, err)
 
-	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, testAdapterMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err)
 	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
 

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -29,6 +29,7 @@ import (
 	kcommand "github.com/ghbvf/gocell/kernel/command"
 	"github.com/ghbvf/gocell/kernel/command/commandtest"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/eventbus"
@@ -214,7 +215,7 @@ func buildDevicePersistence(ctx context.Context, clk clock.Clock, logger *slog.L
 		closePool()
 		return nil, nil, 0, nil, fmt.Errorf("migrations fs: %w", err)
 	}
-	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, migration.PlatformNamespace)
 	if err != nil {
 		closePool()
 		return nil, nil, 0, nil, fmt.Errorf("migrator: %w", err)
@@ -225,7 +226,7 @@ func buildDevicePersistence(ctx context.Context, clk clock.Clock, logger *slog.L
 	}
 	logger.Info("iotdevice: migrations applied")
 
-	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, "schema_migrations"); err != nil {
+	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, migration.PlatformNamespace); err != nil {
 		closePool()
 		return nil, nil, 0, nil, fmt.Errorf("schema version verify: %w", err)
 	}

--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/ctxutil"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/pkg/redaction"
 	"github.com/ghbvf/gocell/runtime/audit"
@@ -562,7 +563,7 @@ func newSSOBFFPool(ctx context.Context, databaseURL string) (*adapterpg.Pool, er
 		_ = pool.Close(ctx)
 		return nil, fmt.Errorf("ssobff: get migrations FS: %w", err)
 	}
-	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, migration.PlatformNamespace)
 	if err != nil {
 		_ = pool.Close(ctx)
 		return nil, fmt.Errorf("ssobff: create migrator: %w", err)

--- a/pkg/migration/namespace.go
+++ b/pkg/migration/namespace.go
@@ -1,0 +1,96 @@
+// Package migration holds the layer-free database-migration value types shared
+// across all GoCell layers. Today that is the Namespace sealed newtype — the
+// per-module migration-lineage identity that partitions the goose tracking
+// table so multiple Cell modules (the platform plus any external Cell module)
+// each own an independent 001..N migration sequence without colliding on a
+// single global version space (issue #1089 / root cause R3).
+//
+// It lives under pkg/ (stdlib only) precisely because every layer must be able
+// to reference it: runtime/composition exposes WithMigrations(Namespace, fs.FS)
+// for external Cell registration, and adapters/postgres takes Namespace as a
+// mandatory typed positional parameter on NewMigrator / VerifyExpectedVersion
+// and derives the tracking table schema_migrations_<namespace> from it. Because
+// the table is a pure function of a validated Namespace and no public API
+// accepts a free tableName string, "track migrations in the bare global
+// schema_migrations table" — the R3 collision footgun — is unexpressible.
+//
+// ref: pkg/tenant.TenantID — sealed-newtype + typed-positional-param pattern.
+package migration
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Namespace identifies an independent migration lineage. Platform migrations
+// belong to the reserved PlatformNamespace; each external Cell module declares
+// its own. The namespace is used to derive the goose tracking table name
+// (schema_migrations_<namespace>) and therefore must be a safe SQL identifier.
+//
+// Unlike a free string, Namespace is a typed value that production APIs take as
+// a mandatory positional parameter: omitting it or passing a bare string is a
+// COMPILE error. Validity (non-empty, lowercase identifier, bounded length) is
+// a RUNTIME fail-fast invariant checked by ParseNamespace / Validate — an empty
+// or malformed string is a legal Go expression, so the type system cannot reject
+// it, exactly as pkg/tenant.TenantID documents. The Namespace("x") conversion
+// residual is caught at every entry's Validate() guard.
+type Namespace string
+
+// PlatformNamespace is the reserved namespace for the platform's own embedded
+// migrations (adapters/postgres/migrations). Its tracking table is
+// schema_migrations_platform. External Cell modules MUST NOT register under
+// this namespace (adapters/postgres.MigrationSet.Add rejects it); only the
+// internal platform seed uses it.
+const PlatformNamespace Namespace = "platform"
+
+// maxNamespaceLen bounds a namespace so the derived tracking table identifier
+// schema_migrations_<namespace> stays within PostgreSQL's 63-byte identifier
+// limit. len("schema_migrations_") == 18, leaving 45 bytes for the namespace.
+const maxNamespaceLen = 45
+
+// namespaceRe matches a valid namespace: a lowercase identifier starting with a
+// letter, followed by lowercase letters, digits, or underscores. This mirrors
+// GoCell's no-dash cell/slice id convention and guarantees the value is a safe
+// SQL identifier fragment (it cannot inject when concatenated into a table name
+// that cannot be parameterised).
+var namespaceRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// String returns the underlying string.
+func (n Namespace) String() string { return string(n) }
+
+// Validate returns nil only for a non-empty, well-formed Namespace: a lowercase
+// identifier (^[a-z][a-z0-9_]*$) no longer than maxNamespaceLen. The zero value
+// ("") is invalid — a migration set cannot derive a tracking table from an
+// absent namespace. Validate asserts the invariant on a value that already has
+// the Namespace type (e.g. a Namespace("x") conversion or a struct field),
+// catching the conversion-literal escape that the type system cannot.
+func (n Namespace) Validate() error {
+	return validateNamespaceString(string(n))
+}
+
+// ParseNamespace validates s and returns it as a Namespace. It is the sole
+// validated constructor for an externally-supplied namespace string (e.g. from
+// an external module's registration). Empty or malformed input is an error.
+func ParseNamespace(s string) (Namespace, error) {
+	if err := validateNamespaceString(s); err != nil {
+		return "", err
+	}
+	return Namespace(s), nil
+}
+
+// validateNamespaceString is the single source of truth for the Namespace
+// invariant, shared by ParseNamespace and Namespace.Validate.
+func validateNamespaceString(s string) error {
+	if s == "" {
+		return fmt.Errorf("migration: Namespace required (empty)")
+	}
+	if len(s) > maxNamespaceLen {
+		return fmt.Errorf("migration: Namespace %q exceeds %d chars (tracking table "+
+			"schema_migrations_<namespace> must fit PostgreSQL's 63-byte identifier limit)", s, maxNamespaceLen)
+	}
+	if !namespaceRe.MatchString(s) {
+		return fmt.Errorf("migration: Namespace %q must match %s (lowercase letter, then "+
+			"lowercase letters / digits / underscores)", s, namespaceRe.String())
+	}
+	return nil
+}

--- a/pkg/migration/namespace_test.go
+++ b/pkg/migration/namespace_test.go
@@ -1,0 +1,80 @@
+package migration_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/migration"
+)
+
+func TestParseNamespace(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		want    migration.Namespace
+		wantErr bool
+	}{
+		{name: "platform", in: "platform", want: migration.PlatformNamespace},
+		{name: "simple", in: "payment", want: "payment"},
+		{name: "with_digits", in: "billing2", want: "billing2"},
+		{name: "with_underscore", in: "acme_payment", want: "acme_payment"},
+		{name: "empty rejected", in: "", wantErr: true},
+		{name: "uppercase rejected", in: "Payment", wantErr: true},
+		{name: "leading digit rejected", in: "2pay", wantErr: true},
+		{name: "leading underscore rejected", in: "_pay", wantErr: true},
+		{name: "dash rejected", in: "acme-payment", wantErr: true},
+		{name: "dot rejected", in: "acme.payment", wantErr: true},
+		{name: "space rejected", in: "acme pay", wantErr: true},
+		{name: "too long rejected", in: strings.Repeat("a", 46), wantErr: true},
+		{name: "max length ok", in: strings.Repeat("a", 45), want: migration.Namespace(strings.Repeat("a", 45))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := migration.ParseNamespace(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseNamespace(%q) = nil error, want error", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseNamespace(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseNamespace(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamespaceValidate(t *testing.T) {
+	t.Parallel()
+	// Zero value is invalid — catches the conversion-literal escape the type
+	// system cannot (Namespace("") is a legal Go expression).
+	var zero migration.Namespace
+	if err := zero.Validate(); err == nil {
+		t.Fatal("zero-value Namespace.Validate() = nil, want error")
+	}
+	if err := migration.Namespace("Bad-NS").Validate(); err == nil {
+		t.Fatal("Namespace(\"Bad-NS\").Validate() = nil, want error (conversion-literal escape must be caught)")
+	}
+	if err := migration.PlatformNamespace.Validate(); err != nil {
+		t.Fatalf("PlatformNamespace.Validate() = %v, want nil", err)
+	}
+}
+
+func TestNamespaceString(t *testing.T) {
+	t.Parallel()
+	if got := migration.PlatformNamespace.String(); got != "platform" {
+		t.Fatalf("PlatformNamespace.String() = %q, want %q", got, "platform")
+	}
+	ns, err := migration.ParseNamespace("payment")
+	if err != nil {
+		t.Fatalf("ParseNamespace: %v", err)
+	}
+	if got := ns.String(); got != "payment" {
+		t.Fatalf("String() round-trip = %q, want %q", got, "payment")
+	}
+}

--- a/runtime/composition/builder.go
+++ b/runtime/composition/builder.go
@@ -40,6 +40,7 @@ type RuntimeOptionsFunc func(cells []cell.Cell) ([]bootstrap.Option, error)
 type Builder struct {
 	modules         []CellModule
 	expectedCellIDs []string
+	migrations      []MigrationRegistration
 }
 
 // New returns a new Builder whose composed cells must form exactly the
@@ -202,6 +203,9 @@ func (b *Builder) Build(
 		return nil, err
 	}
 	if err := b.validateClosedSet(); err != nil {
+		return nil, err
+	}
+	if err := b.validateMigrations(); err != nil {
 		return nil, err
 	}
 

--- a/runtime/composition/migrations.go
+++ b/runtime/composition/migrations.go
@@ -1,0 +1,73 @@
+package composition
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/ghbvf/gocell/pkg/migration"
+)
+
+// MigrationRegistration is a layer-neutral (namespace, fs.FS) migration source
+// registered via [Builder.WithMigrations]. composition does NOT execute
+// migrations — runtime/ must not depend on adapters/, and migrations run
+// out-of-band BEFORE Build brings up cells (cells need their schema first).
+// The registrations are surfaced via [Builder.Migrations] for an ops /
+// composition-root entry point (which may import adapters/postgres) to drain
+// into an adapters/postgres.MigrationSet and apply against a real database.
+//
+// ref: docs/guides/cell-external-repo-quickstart.md "Migrations" — the
+// execution-bridge loop external Cell modules write.
+type MigrationRegistration struct {
+	// Namespace identifies the migration lineage; its tracking table is
+	// schema_migrations_<namespace> (derived adapter-side). The reserved
+	// "platform" namespace is the platform's own migrations and is seeded by the
+	// ops entry point (adapters/postgres.NewMigrationSetWithPlatform), not here.
+	Namespace migration.Namespace
+	// FS is the embed.FS (or any fs.FS) of goose-native NNN_desc.sql files for
+	// this namespace, with its own independent 001..N sequence.
+	FS fs.FS
+}
+
+// WithMigrations registers an external Cell module's migration set under ns.
+// Calls accumulate (successive calls append). The registration is validated at
+// [Builder.Build] (namespace validity, non-nil FS, no duplicate namespace);
+// Build does not execute the migrations.
+func (b *Builder) WithMigrations(ns migration.Namespace, fsys fs.FS) *Builder {
+	b.migrations = append(b.migrations, MigrationRegistration{Namespace: ns, FS: fsys})
+	return b
+}
+
+// Migrations returns the registered migration sets in registration order, for
+// the ops / composition-root entry point to apply before Build. Returns a copy
+// so callers cannot mutate the builder's backing slice.
+func (b *Builder) Migrations() []MigrationRegistration {
+	if len(b.migrations) == 0 {
+		return nil
+	}
+	out := make([]MigrationRegistration, len(b.migrations))
+	copy(out, b.migrations)
+	return out
+}
+
+// validateMigrations checks the accumulated migration registrations are
+// well-formed: each namespace is valid, each FS is non-nil, and no namespace is
+// registered twice. It runs at Build time (before any module Provide). It does
+// NOT execute migrations — authoritative reserved-namespace / table derivation
+// lives in adapters/postgres.MigrationSet.Add at apply time.
+func (b *Builder) validateMigrations() error {
+	seen := make(map[migration.Namespace]struct{}, len(b.migrations))
+	for _, r := range b.migrations {
+		if err := r.Namespace.Validate(); err != nil {
+			return fmt.Errorf("composition.Builder.Build: invalid migration namespace: %w", err)
+		}
+		if r.FS == nil {
+			return fmt.Errorf("composition.Builder.Build: WithMigrations(%q) requires a non-nil fs.FS",
+				r.Namespace)
+		}
+		if _, dup := seen[r.Namespace]; dup {
+			return fmt.Errorf("composition.Builder.Build: duplicate migration namespace %q", r.Namespace)
+		}
+		seen[r.Namespace] = struct{}{}
+	}
+	return nil
+}

--- a/runtime/composition/migrations.go
+++ b/runtime/composition/migrations.go
@@ -30,8 +30,13 @@ type MigrationRegistration struct {
 
 // WithMigrations registers an external Cell module's migration set under ns.
 // Calls accumulate (successive calls append). The registration is validated at
-// [Builder.Build] (namespace validity, non-nil FS, no duplicate namespace);
-// Build does not execute the migrations.
+// [Builder.Build] (namespace validity, NOT the reserved "platform" namespace,
+// non-nil FS, no duplicate namespace); Build does not execute the migrations.
+//
+// The reserved migration.PlatformNamespace MUST NOT be used here — it is seeded
+// automatically by adapters/postgres.NewMigrationSetWithPlatform. Passing it is
+// rejected fail-fast at Build (and again at adapters/postgres.MigrationSet.Add),
+// so an external module cannot clobber the platform schema lineage.
 func (b *Builder) WithMigrations(ns migration.Namespace, fsys fs.FS) *Builder {
 	b.migrations = append(b.migrations, MigrationRegistration{Namespace: ns, FS: fsys})
 	return b
@@ -50,15 +55,26 @@ func (b *Builder) Migrations() []MigrationRegistration {
 }
 
 // validateMigrations checks the accumulated migration registrations are
-// well-formed: each namespace is valid, each FS is non-nil, and no namespace is
-// registered twice. It runs at Build time (before any module Provide). It does
-// NOT execute migrations — authoritative reserved-namespace / table derivation
-// lives in adapters/postgres.MigrationSet.Add at apply time.
+// well-formed: each namespace is valid, is NOT the reserved "platform"
+// namespace, each FS is non-nil, and no namespace is registered twice. It runs
+// at Build time (before any module Provide). It does NOT execute migrations.
+//
+// Rejecting migration.PlatformNamespace here is the Build-time half of a
+// defense-in-depth pair: adapters/postgres.MigrationSet.Add also rejects it at
+// apply time. Failing fast at Build (the composition boundary) means an external
+// module that tries to register under "platform" — which would clobber the
+// platform schema lineage if an ops bridge ignored the later Add error — cannot
+// even produce a runnable App.
 func (b *Builder) validateMigrations() error {
 	seen := make(map[migration.Namespace]struct{}, len(b.migrations))
 	for _, r := range b.migrations {
 		if err := r.Namespace.Validate(); err != nil {
 			return fmt.Errorf("composition.Builder.Build: invalid migration namespace: %w", err)
+		}
+		if r.Namespace == migration.PlatformNamespace {
+			return fmt.Errorf("composition.Builder.Build: namespace %q is reserved for platform "+
+				"migrations (seeded by adapters/postgres.NewMigrationSetWithPlatform); external modules "+
+				"must register under their own namespace", r.Namespace)
 		}
 		if r.FS == nil {
 			return fmt.Errorf("composition.Builder.Build: WithMigrations(%q) requires a non-nil fs.FS",

--- a/runtime/composition/migrations_test.go
+++ b/runtime/composition/migrations_test.go
@@ -1,0 +1,99 @@
+package composition
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/migration"
+)
+
+func stubMigrationFS() fstest.MapFS {
+	return fstest.MapFS{
+		"001_init.sql": &fstest.MapFile{Data: []byte("-- +goose Up\n-- +goose Down\n")},
+	}
+}
+
+func TestBuilder_WithMigrations_AccumulatesInOrder(t *testing.T) {
+	payment, err := migration.ParseNamespace("payment")
+	require.NoError(t, err)
+	billing, err := migration.ParseNamespace("billing")
+	require.NoError(t, err)
+
+	b := New("configcore").
+		WithMigrations(payment, stubMigrationFS()).
+		WithMigrations(billing, stubMigrationFS())
+
+	regs := b.Migrations()
+	require.Len(t, regs, 2)
+	assert.Equal(t, payment, regs[0].Namespace)
+	assert.Equal(t, billing, regs[1].Namespace, "registrations accumulate in call order")
+
+	// Migrations() returns a copy: mutating it must not affect the builder.
+	regs[0].Namespace = "tampered"
+	assert.Equal(t, payment, b.Migrations()[0].Namespace, "Migrations() must return a defensive copy")
+}
+
+func TestBuilder_WithMigrations_NilWhenNoneRegistered(t *testing.T) {
+	assert.Nil(t, New("configcore").Migrations())
+}
+
+func TestBuilder_Build_AcceptsValidMigration(t *testing.T) {
+	ctx := context.Background()
+	payment, err := migration.ParseNamespace("payment")
+	require.NoError(t, err)
+
+	mA := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
+	app, err := New("configcore").
+		With(mA).
+		WithMigrations(payment, stubMigrationFS()).
+		Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.NoError(t, err)
+	require.NotNil(t, app)
+}
+
+func TestBuilder_Build_RejectsBadMigration(t *testing.T) {
+	tests := []struct {
+		name    string
+		apply   func(b *Builder) *Builder
+		wantSub string
+	}{
+		{
+			name: "invalid namespace conversion-literal",
+			apply: func(b *Builder) *Builder {
+				return b.WithMigrations(migration.Namespace("acme-payment"), stubMigrationFS())
+			},
+			wantSub: "invalid migration namespace",
+		},
+		{
+			name: "nil fs",
+			apply: func(b *Builder) *Builder {
+				ns, _ := migration.ParseNamespace("payment")
+				return b.WithMigrations(ns, nil)
+			},
+			wantSub: "non-nil fs.FS",
+		},
+		{
+			name: "duplicate namespace",
+			apply: func(b *Builder) *Builder {
+				ns, _ := migration.ParseNamespace("payment")
+				return b.WithMigrations(ns, stubMigrationFS()).WithMigrations(ns, stubMigrationFS())
+			},
+			wantSub: "duplicate migration namespace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mA := &fakeCellModule{id: "configcore", cell: stubCell("configcore")}
+			b := tt.apply(New("configcore").With(mA))
+			_, err := b.Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantSub)
+			assert.False(t, mA.called, "bad migration registration must be rejected before Provide")
+		})
+	}
+}

--- a/runtime/composition/migrations_test.go
+++ b/runtime/composition/migrations_test.go
@@ -69,6 +69,13 @@ func TestBuilder_Build_RejectsBadMigration(t *testing.T) {
 			wantSub: "invalid migration namespace",
 		},
 		{
+			name: "reserved platform namespace rejected at Build",
+			apply: func(b *Builder) *Builder {
+				return b.WithMigrations(migration.PlatformNamespace, stubMigrationFS())
+			},
+			wantSub: "reserved for platform",
+		},
+		{
 			name: "nil fs",
 			apply: func(b *Builder) *Builder {
 				ns, _ := migration.ParseNamespace("payment")

--- a/tests/integration/l2atomicity/testmain_test.go
+++ b/tests/integration/l2atomicity/testmain_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/tests/testutil/pgclone"
 )
 
@@ -41,7 +42,7 @@ var sharedPG = pgclone.New("gocell_l2atomicity_test_template",
 		if err != nil {
 			return fmt.Errorf("load migrations fs: %w", err)
 		}
-		migrator, err := adapterpg.NewMigrator(pool, fsys, "schema_migrations")
+		migrator, err := adapterpg.NewMigrator(pool, fsys, migration.PlatformNamespace)
 		if err != nil {
 			return fmt.Errorf("new migrator: %w", err)
 		}

--- a/tests/integration/outbox_failure_paths_test.go
+++ b/tests/integration/outbox_failure_paths_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
@@ -231,7 +232,7 @@ func runRelay(t *testing.T, relay *outboxruntime.Relay) (stop func()) {
 func setupPGOnly(t *testing.T) (*postgres.Pool, func()) {
 	t.Helper()
 	pool, cleanup := setupPostgresContainer(t)
-	migrator, err := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
+	migrator, err := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, err, "NewMigrator")
 	require.NoError(t, migrator.Up(context.Background()), "migrations must apply")
 	return pool, cleanup

--- a/tests/integration/outbox_fullchain_test.go
+++ b/tests/integration/outbox_fullchain_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
@@ -227,7 +228,7 @@ func TestIntegration_OutboxFullChain(t *testing.T) {
 	// ---------------------------------------------------------------
 	// Step 2: Run migrations to create outbox_entries table.
 	// ---------------------------------------------------------------
-	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -546,7 +547,7 @@ func TestIntegration_OutboxFullChain_NoTrace(t *testing.T) {
 	// ---------------------------------------------------------------
 	// Step 2: Run migrations.
 	// ---------------------------------------------------------------
-	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -725,7 +726,7 @@ func TestIntegration_OutboxWriteRelayMockPublisher(t *testing.T) {
 	defer cleanup()
 
 	// Run migrations.
-	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, mErr, "NewMigrator should succeed")
 	require.NoError(t, migrator.Up(ctx), "migrations must succeed")
 
@@ -814,7 +815,7 @@ func TestIntegration_OutboxObservability_ZeroRoundtrip(t *testing.T) {
 	pool, cleanup := setupPostgresContainer(t)
 	defer cleanup()
 
-	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), "schema_migrations")
+	migrator, mErr := postgres.NewMigrator(pool, testPostgresMigrationsFS(t), migration.PlatformNamespace)
 	require.NoError(t, mErr)
 	require.NoError(t, migrator.Up(ctx))
 

--- a/tests/integration/sagaleader/testmain_test.go
+++ b/tests/integration/sagaleader/testmain_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/tests/testutil/pgclone"
 )
 
@@ -35,7 +36,7 @@ var sharedPG = pgclone.New("gocell_sagaleader_test_template",
 		if err != nil {
 			return fmt.Errorf("load migrations fs: %w", err)
 		}
-		migrator, err := adapterpg.NewMigrator(pool, fsys, "schema_migrations")
+		migrator, err := adapterpg.NewMigrator(pool, fsys, migration.PlatformNamespace)
 		if err != nil {
 			return fmt.Errorf("new migrator: %w", err)
 		}

--- a/tests/testutil/pgshare/pgshare.go
+++ b/tests/testutil/pgshare/pgshare.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/pkg/migration"
 	"github.com/ghbvf/gocell/tests/testutil/pgclone"
 )
 
@@ -71,7 +72,7 @@ func applyMigrations(ctx context.Context, templateDSN string) (err error) {
 	if err != nil {
 		return fmt.Errorf("load migrations fs: %w", err)
 	}
-	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, migration.PlatformNamespace)
 	if err != nil {
 		return fmt.Errorf("new migrator: %w", err)
 	}

--- a/tests/testutil/pgshare/pgshare_test.go
+++ b/tests/testutil/pgshare/pgshare_test.go
@@ -89,11 +89,13 @@ func TestNewPerTestPool_TemplateSchemaApplied(t *testing.T) {
 	ctx := context.Background()
 
 	var migrationCount int
-	row := pool.DB().QueryRow(ctx, "SELECT COUNT(*) FROM schema_migrations")
+	// Platform migrations track in schema_migrations_platform (the "platform"
+	// namespace, #1089), not the bare goose default schema_migrations.
+	row := pool.DB().QueryRow(ctx, "SELECT COUNT(*) FROM schema_migrations_platform")
 	if err := row.Scan(&migrationCount); err != nil {
-		t.Fatalf("schema_migrations probe: %v — migrations may not have been applied to template", err)
+		t.Fatalf("schema_migrations_platform probe: %v — migrations may not have been applied to template", err)
 	}
 	if migrationCount == 0 {
-		t.Fatal("schema_migrations is empty in cloned DB; template did not receive migrations")
+		t.Fatal("schema_migrations_platform is empty in cloned DB; template did not receive migrations")
 	}
 }

--- a/tools/archtest/managed_resource_contract_test.go
+++ b/tools/archtest/managed_resource_contract_test.go
@@ -63,6 +63,7 @@ var adapterManagedResourceOptOut = map[string]string{
 	"adapters/postgres.InvalidIndex":              "value-object: schema validation diagnostic",
 	"adapters/postgres.LedgerStore":               "subresource-not-owner: storage facade over caller-owned pool; no independent lifecycle",
 	"adapters/postgres.MigrationDirection":        "value-object: migration enum",
+	"adapters/postgres.MigrationSet":              "registry: namespace migration sources; opens+closes Migrators over caller-owned pool",
 	"adapters/postgres.MigrationStatus":           "value-object: migration diagnostic snapshot",
 	"adapters/postgres.Migrator":                  "subresource-not-owner: uses caller-owned pool, no independent lifecycle",
 	"adapters/postgres.OutboxWriter":              "stateless-adapter: writes through ctx-bound transaction",

--- a/tools/archtest/migration_filename_convention_test.go
+++ b/tools/archtest/migration_filename_convention_test.go
@@ -1,0 +1,113 @@
+// INVARIANT: MIGRATION-FILENAME-GOOSE-PARSEABLE-01
+package archtest
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// migrationFilenameRe is the goose-native migration filename convention enforced
+// by MIGRATION-FILENAME-GOOSE-PARSEABLE-01: a zero-padded 3-digit version, an
+// underscore, then a lowercase snake_case descriptor, then ".sql".
+//
+// It is intentionally STRICTER than goose's own parser (goose.NumericComponent
+// does strconv.ParseInt(strings.Cut(base,"_")[0])): any name matching this regex
+// is trivially goose-parseable, and — the load-bearing point for #1089 — a
+// namespace-PREFIXED name like "platform_001_x.sql" FAILS this regex (starts
+// with a letter, not a digit), exactly as it would fail goose's ParseInt. Under
+// the namespace model the namespace lives in the goose TRACKING TABLE
+// (schema_migrations_<namespace>), never in the filename; embedding it in the
+// filename would silently break version parsing.
+var migrationFilenameRe = regexp.MustCompile(`^[0-9]{3}_[a-z][a-z0-9_]*\.sql$`)
+
+// MIGRATION-FILENAME-GOOSE-PARSEABLE-01: every migration file under
+// adapters/postgres/migrations/ must be goose-native NNN_desc.sql (no namespace
+// prefix). The platform's migrations are namespace "platform"; their tracking
+// table is schema_migrations_platform, but the FILES stay goose-parseable so
+// goose's NumericComponent can derive the version. An external Cell module ships
+// its own migrations/ with the same convention (its own 001..N), registered via
+// composition.WithMigrations(namespace, fs) — the namespace partitions the
+// tracking table, not the filename.
+//
+// AI-robust 评级：Medium (permanent ceiling) — a filename is an on-disk artifact
+// the Go type system cannot express. This is a value-level scan of every real
+// .sql migration (no comment-anchor / name-convention escape; the regex mirrors
+// goose's own parse contract as the single source). A "Hard via codegen" form is
+// structurally unreachable for hand-authored SQL filenames — the same Go ceiling
+// as the locator path funnel (gh #1235 won't-do) and #851. The downstream API
+// that consumes namespaces IS Hard: composition.WithMigrations /
+// adapters/postgres.NewMigrator take a typed migration.Namespace, so a bare
+// table string is a compile error (see MIGRATION-TRACKING-TABLE-DERIVED-01 for
+// the in-package backstop). Blind spots + negative control: TestMigrationFilenameConvention01_NegativeControl.
+//
+// ref: github.com/pressly/goose/v3 migration.go NumericComponent — strings.Cut + ParseInt.
+// ref: pkg/migration.Namespace / adapters/postgres.trackingTableFor — namespace → table.
+func TestMigrationFilenameConvention01(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	const migrationsDir = "adapters/postgres/migrations"
+	scope := scanner.DirsScope(
+		root, []string{migrationsDir},
+		scanner.MatchRels(func(rel string) bool {
+			return filepath.ToSlash(filepath.Dir(rel)) == migrationsDir
+		}),
+	)
+
+	seen := 0
+	scanner.EachContentFile(t, scope, []string{".sql"}, func(t *testing.T, fc scanner.ContentContext) {
+		seen++
+		name := filepath.Base(fc.Rel)
+		if !migrationFilenameRe.MatchString(name) {
+			t.Errorf("MIGRATION-FILENAME-GOOSE-PARSEABLE-01: %s does not match the goose-native "+
+				"convention %s (zero-padded 3-digit version + '_' + lowercase snake_case + '.sql'). "+
+				"Namespaces live in the tracking table schema_migrations_<namespace>, NOT in the filename — "+
+				"a name like 'platform_001_x.sql' breaks goose's NumericComponent version parser.",
+				fc.Rel, migrationFilenameRe.String())
+		}
+	})
+
+	// Anti-vacuity: the platform migration set is non-empty, so the rule actually
+	// scanned files. A directory that silently scanned zero .sql would make this
+	// invariant a no-op.
+	if seen == 0 {
+		t.Fatalf("MIGRATION-FILENAME-GOOSE-PARSEABLE-01: scanned 0 .sql files under %s/ — "+
+			"the rule must verify at least the platform migration set", migrationsDir)
+	}
+}
+
+// TestMigrationFilenameConvention01_NegativeControl proves the rule is not
+// vacuous: the convention regex must REJECT the forms the invariant exists to
+// catch — chiefly a namespace-prefixed filename (which would break goose) — and
+// ACCEPT the canonical goose-native form.
+func TestMigrationFilenameConvention01_NegativeControl(t *testing.T) {
+	t.Parallel()
+	reject := []string{
+		"platform_001_init.sql", // namespace prefix → breaks goose NumericComponent (the #1089 footgun)
+		"payment_002_charges.sql",
+		"1_foo.sql",      // not zero-padded 3-digit
+		"0001_foo.sql",   // 4-digit
+		"001-foo.sql",    // dash separator
+		"001_Foo.sql",    // uppercase descriptor
+		"001_foo.up.sql", // dotted (still ends .sql but contains '.')
+		"001_foo.txt",    // wrong extension
+		"abc_foo.sql",    // non-numeric version
+	}
+	for _, name := range reject {
+		if migrationFilenameRe.MatchString(name) {
+			t.Errorf("negative control: %q must be REJECTED by the convention regex but matched", name)
+		}
+	}
+	accept := []string{
+		"001_create_outbox_entries.sql",
+		"050_accesscore_tenant_id.sql",
+		"999_z9.sql",
+	}
+	for _, name := range accept {
+		if !migrationFilenameRe.MatchString(name) {
+			t.Errorf("negative control: %q must be ACCEPTED by the convention regex but did not match", name)
+		}
+	}
+}

--- a/tools/archtest/migration_filename_convention_test.go
+++ b/tools/archtest/migration_filename_convention_test.go
@@ -32,6 +32,13 @@ var migrationFilenameRe = regexp.MustCompile(`^[0-9]{3}_[a-z][a-z0-9_]*\.sql$`)
 // composition.WithMigrations(namespace, fs) — the namespace partitions the
 // tracking table, not the filename.
 //
+// SCOPE: this rule scans ONLY adapters/postgres/migrations/ (the platform set).
+// External Cell modules in their own repos are NOT covered here — they obtain
+// the equivalent guard by enrolling this rule into the M3 archtest library
+// (RunStandardCellRules, #1302); until then external repos rely on the
+// documented convention (a non-NNN_ .sql is silently skipped by goose, never
+// applied). The quickstart "Migrations" section states this explicitly.
+//
 // AI-robust 评级：Medium (permanent ceiling) — a filename is an on-disk artifact
 // the Go type system cannot express. This is a value-level scan of every real
 // .sql migration (no comment-anchor / name-convention escape; the regex mirrors

--- a/tools/archtest/migration_tracking_table_derived_test.go
+++ b/tools/archtest/migration_tracking_table_derived_test.go
@@ -35,10 +35,14 @@ var migrationTableHelpers = map[string]struct{}{
 // hatch. Tests (which legitimately pass literal tables to the helpers) are out of
 // scope via Production{Tests:false}.
 //
-// Blind spot: a production caller that assigns trackingTableFor(ns) to a local
-// var and then passes the var would be flagged (the canonical form inlines the
-// call, which both production sites do). Tightening to data-flow tracking is not
-// worth the brittleness at Medium; the inline form is the package idiom.
+// Blind spot (false-positive direction): a production caller that assigns
+// trackingTableFor(ns) to a local var and then passes the var would be reported
+// as a violation even though it is legitimate — the rule only accepts a direct
+// inlined trackingTableFor(...) call in the table-name slot. Both production
+// sites inline the call (migrator.go NewMigrator, schema_guard.go
+// VerifyExpectedVersion), which is the package idiom, so the rule does not
+// misfire today. Tightening to data-flow tracking is not worth the brittleness
+// at Medium.
 //
 // ref: adapters/postgres/migrator.go newMigratorForTable / NewMigrator
 // ref: adapters/postgres/schema_guard.go verifyExpectedVersionForTable / VerifyExpectedVersion

--- a/tools/archtest/migration_tracking_table_derived_test.go
+++ b/tools/archtest/migration_tracking_table_derived_test.go
@@ -1,0 +1,106 @@
+// INVARIANT: MIGRATION-TRACKING-TABLE-DERIVED-01
+package archtest
+
+import (
+	"go/ast"
+	"testing"
+)
+
+// migrationTableHelpers are the unexported adapters/postgres construction cores
+// that accept an explicit goose tracking-table string. In production the table
+// MUST be derived from a migration.Namespace via trackingTableFor; only
+// in-package TEST code may pass an arbitrary table string (to provision isolated
+// per-test tracking tables). Production callers of these helpers = NewMigrator
+// and VerifyExpectedVersion, both of which pass trackingTableFor(ns).
+var migrationTableHelpers = map[string]struct{}{
+	"newMigratorForTable":           {},
+	"verifyExpectedVersionForTable": {},
+}
+
+// MIGRATION-TRACKING-TABLE-DERIVED-01: in NON-test adapters/postgres code, every
+// call to newMigratorForTable / verifyExpectedVersionForTable must pass a
+// trackingTableFor(...) call as its tracking-table argument. This pins the one
+// in-package seam where a raw tracking-table string could enter production: the
+// table is always a pure function of a validated migration.Namespace
+// (schema_migrations_<namespace>), so no production path can re-introduce the
+// bare global schema_migrations table (#1089 / root cause R3).
+//
+// AI-robust 评级：Medium (downstream caller-allowlist) — go/types resolution
+// would be overkill: the two helper names are unexported and unique within
+// package adapters/postgres, so an AST ident match within that single package is
+// exact. The EXPORTED surface is already Hard (NewMigrator / VerifyExpectedVersion
+// take a typed migration.Namespace — a bare string is a compile error), and goose
+// provider construction is pinned to adapters/postgres by GOOSE-SESSION-LOCKER-01.
+// This archtest is the package-internal backstop for the unexported test escape
+// hatch. Tests (which legitimately pass literal tables to the helpers) are out of
+// scope via Production{Tests:false}.
+//
+// Blind spot: a production caller that assigns trackingTableFor(ns) to a local
+// var and then passes the var would be flagged (the canonical form inlines the
+// call, which both production sites do). Tightening to data-flow tracking is not
+// worth the brittleness at Medium; the inline form is the package idiom.
+//
+// ref: adapters/postgres/migrator.go newMigratorForTable / NewMigrator
+// ref: adapters/postgres/schema_guard.go verifyExpectedVersionForTable / VerifyExpectedVersion
+func TestMigrationTrackingTableDerived01(t *testing.T) {
+	t.Parallel()
+	const pkgPath = PlatformModulePath + "/adapters/postgres"
+
+	checked := 0
+	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != pkgPath {
+			return nil
+		}
+		var ds []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.CallExpr](file, func(ce *ast.CallExpr) {
+				callee, ok := ce.Fun.(*ast.Ident)
+				if !ok {
+					return
+				}
+				if _, isHelper := migrationTableHelpers[callee.Name]; !isHelper {
+					return
+				}
+				checked++
+				if len(ce.Args) == 0 || !isTrackingTableForCall(ce.Args[len(ce.Args)-1]) {
+					ds = append(ds, Diagnostic{
+						Rel:  rel,
+						Line: p.Fset.Position(ce.Pos()).Line,
+						Message: "MIGRATION-TRACKING-TABLE-DERIVED-01: production call to " + callee.Name +
+							" must pass trackingTableFor(ns) as the tracking-table argument — the table must be " +
+							"derived from a migration.Namespace, never a raw string (else the global-table " +
+							"collision footgun #1089/R3 returns).",
+					})
+				}
+			})
+		}
+		return ds
+	})
+
+	// Anti-vacuity: the production callers (NewMigrator, VerifyExpectedVersion)
+	// must actually exist and be scanned, or the rule silently passes.
+	if checked == 0 {
+		t.Fatalf("MIGRATION-TRACKING-TABLE-DERIVED-01: found 0 production calls to %v — "+
+			"the rule must observe NewMigrator / VerifyExpectedVersion delegating through the helpers",
+			keysOf(migrationTableHelpers))
+	}
+}
+
+// isTrackingTableForCall reports whether expr is a direct call to trackingTableFor(...).
+func isTrackingTableForCall(expr ast.Expr) bool {
+	ce, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	id, ok := ce.Fun.(*ast.Ident)
+	return ok && id.Name == "trackingTableFor"
+}
+
+func keysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tools/pg-migrate/main.go
+++ b/tools/pg-migrate/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/pkg/migration"
 )
 
 // defaultMigrationTimeout is the default overall timeout for applying
@@ -87,7 +88,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "pg-migrate: migrations fs: %v\n", err)
 		os.Exit(1)
 	}
-	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, "schema_migrations")
+	migrator, err := adapterpg.NewMigrator(pool, migrationsFS, migration.PlatformNamespace)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pg-migrate: build migrator: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

M8: per-namespace database migration tracking. Each Cell module (the platform + any external Cell module) owns an independent `001..N` migration lineage tracked in its own `schema_migrations_<namespace>` table — sealing root cause **R3** (single global `schema_migrations` version space → external modules collide on version numbers). The namespace is a **sealed `pkg/migration.Namespace`** (mirroring `pkg/tenant.TenantID`): the tracking table is a pure function of a validated namespace and no public API accepts a free `tableName` string, so "track migrations in the bare global `schema_migrations` table" is unexpressible at the type system.

Implements the parent epic #1081's resolved **Open decision #4** (Django model: namespace identity, not a filename prefix; platform migration **files unchanged**). A hard goose constraint forces this design: `goose.NumericComponent` parses the version via `ParseInt(strings.Cut(name,"_")[0])`, so a namespace-prefixed filename like `platform_001_x.sql` fails to parse — the namespace must live in the **tracking table**, never the filename.

Key changes:
- **`pkg/migration.Namespace`** sealed newtype (`ParseNamespace` / `Validate` / `PlatformNamespace`). Typed positional param ⇒ bare string / omission is a **compile error** (Hard downstream).
- **`adapters/postgres`**: `NewMigrator` / `VerifyExpectedVersion` take a typed `Namespace` (free `tableName` removed from the exported surface); `MigrationSet` aggregator (`NewMigrationSetWithPlatform` / `Add` / `ApplyAll` / `VerifyAll`, **platform-first** ordering); platform tracking table renamed `schema_migrations` → `schema_migrations_platform` (full symmetry — platform is just the reserved `"platform"` namespace, no special-casing). Unexported `newMigratorForTable` / `verifyExpectedVersionForTable` are the in-package test escape hatch for isolated per-test tracking tables.
- **`runtime/composition`**: `Builder.WithMigrations(ns, fs)` registration + `Migrations()` execution bridge; `Build` validates registrations but stays migration-free (`runtime/` must not import `adapters/`; cells need schema before Build, so migrations run out-of-band first).
- **archtest** `MIGRATION-FILENAME-GOOSE-PARSEABLE-01` (goose-native `NNN_desc.sql`; Medium — on-disk artifact, permanent ceiling per #1235/#851) + `MIGRATION-TRACKING-TABLE-DERIVED-01` (Medium in-package backstop: production helpers must pass `trackingTableFor(ns)`).
- **docs**: `cell-external-repo-quickstart.md` Migration section (write-up + execution-bridge loop).

### Implementation matrix
- **Contract**: `adapters/postgres.NewMigrator` + `VerifyExpectedVersion` signatures (Go func signature change)
- **Change**: `tableName string` → `ns migration.Namespace` (typed); tracking table derived `schema_migrations_<ns>`
- **Implementations**: concrete (`Migrator`) — no multi-impl interface; `MigrationSet` is the new aggregator
- **Conformance test**: `adapters/postgres.TestMigrationSet_ApplyAll_IndependentNamespaceTables` (integration) + `TestNewMigrator_DerivesTrackingTableFromNamespace` (unit)
- **Repro**: `go test -tags=integration -run 'TestMigrationSet' ./adapters/postgres/`
- **Dependent contracts (governance scan)**: none (the migration runner is not a cross-cell contract; tracking-table rename is a goose internal table, no DROP COLUMN / no `forbiddenColumns` entry; migration `.sql` files unchanged)

### AI-robust ratings
| Surface | Rating |
|---|---|
| `NewMigrator`/`VerifyExpectedVersion`/`MigrationSet.Add`/`WithMigrations` take typed `Namespace` | **Hard downstream** (compile error on bare string/omission; R3 sealed) |
| `Namespace` validity (`ParseNamespace`/`Validate`) | Medium (runtime guard; `Namespace("x")` residual = same ceiling as `tenant.TenantID`) |
| `MIGRATION-TRACKING-TABLE-DERIVED-01` | Medium (in-package caller-allowlist backstop) |
| `MIGRATION-FILENAME-GOOSE-PARSEABLE-01` | Medium (permanent ceiling — filename artifact; cite #1235/#851) |

## Refs

Closes #1089
Parent epic: #1081 (Open decision #4 — Django model)
ref: github.com/pressly/goose/v3 migration.go `NumericComponent`
ref: pkg/tenant.TenantID (sealed-newtype precedent)

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go build -tags=integration ./...` 本地通过（导出签名变更，module-wide 编译）
- [x] `go test ./pkg/migration/... ./adapters/postgres/ ./runtime/composition/...` 本地通过
- [x] `go test ./tools/archtest/ -run 'TestMigrationFilenameConvention01|TestMigrationTrackingTableDerived01|TestAdaptersExportedTypesManagedResourceOrOptOut'` 通过
- [x] 模块级非集成测试通过（排除 tools/archtest 的 2 个 pre-existing nightly 红：kernel/webhook→observability DAG、scanner-framework-usage，均与本 PR 文件无关）
- [x] `golangci-lint run --new-from-rev=origin/develop`（default + `--build-tags=integration`）= 0 new issues
- [ ] 集成测试（real PG）：`TestMigrationSet_ApplyAll_IndependentNamespaceTables` 等需 CI integration job 跑（本地无 PG）
