### PR TITLE
docs(ai-robust): §Hard 范本目录补全 reflect schema freeze 形态 [#1037 §4]

### DIFF
--- a/.claude/rules/gocell/ai-robust.md
+++ b/.claude/rules/gocell/ai-robust.md
@@ -58,6 +58,7 @@
 - **input-struct field exclusion** — framework 收口的横切字段（build tag / 加载 mode）从公开 input struct 删除，使"业务自传"在 type system 上编译不可表达。只锁字面量值不锁 callee 是反模式（同 PR 新 const 即新绕过路径），必须 (callee resolve 到 loader 集) AND (arg 求值到禁止值集) 双锁，并同 PR 补 meta-archtest 锁 façade 旁路，否则只是 funnel 内 Hard / funnel 外 Soft。
 - **single sanctioned holder** — 仅一个 struct 可持有某 raw 基建字段时，用类型信息解析字段类型 + 断言宿主 struct 名 = 唯一许可名，无需 hand-maintained allowlist。包级可见性使包内绕过不可阻挡（上游 Medium）；闭环上游需 seal interface + 私有构造使包外不可表达跳过。
 - **sealed construction** — 让"包外构造该类型"在 Go 可见性层面编译不可表达：unexported envelope struct（包外不可构造、不可作 unmarshal target）或 `internal/` wrap 包（包外不可 import），公开 surface 只过领域类型 / `[]byte`。**任意名 re-export（alias / 同字段集 re-shape）是闭环必查点**——exact-name lookup 不足以拦住重新可构造路径。
+- **reflect schema freeze** — wire/schema struct 的字段集（字段数 + 逐字段 name / json-或-yaml tag / 类型 identity）经 `reflect` 枚举 + 冻结 tuple 清单精确比对锁定，捕获 Go 类型系统允许、但破坏 wire / 派生契约的 in-package drift（rename / reorder / retag / 增删字段）。与 **sealed construction** 正交并常并存于同一 wire 类型：后者封"包外能否构造该类型"，本范本封"字段集能否静默漂移"。Hard 源自 reflect 字段数 / 类型是运行时枚举的客观结构事实（非字符串锚点 / 非注释），任何 drift 必触发 tuple 比对失败 → 强制改动落到冻结清单这一显式审查检查点；派生字段经 tag 值（如 `yaml:"-"`）锁定其不可手写性。与 **codegen funnel + golden** 区别：本范本的冻结清单是测试内 reflect 枚举的手写 tuple，非生成源的字节 diff。
 - **codegen funnel + golden** — 见 §载体决策原则 #1：schema / marker / struct tag 单源 → 派生执行体 → regenerate-and-diff 字节级锁（上游 Hard）+ callsite 唯一性 / ban 手写等价 guard（下游 Hard）。
 
 ## archtest 文件命名


### PR DESCRIPTION
## Summary

向 `ai-robust.md §Hard 范本目录` 补 1 条抽象机制形态 `reflect schema freeze`，交付 #1037 §4「wire 字段集单源 archtest 写作示例」——以补全权威单源而非新建独立 guide 的方式（两轮自审：独立 guide 违反 优雅简洁 / 非 AI-HARD）。

#1037 实质工作已先期合并：§1d façade collapse（PR #1470 + #1502）/ §2 typeseval façade（resolve.go「completes the façade contract」）/ §3（#722）。本 PR 收尾 §4 并 close #1037。

**审出的真缺口**：三档分级表（`ai-robust.md:25`）已把 **"reflect 字段数"** 列为 Hard 载体，但 §Hard 范本目录（封闭集）**无对应条目** → grading 表↔catalog 内部不一致。新增条目同时修此不一致。

**为何只补 1 条**（初版提议 2 条，逐条核验后修正）：
- ✅ `reflect schema freeze` = 真 Hard 形态（reflect 枚举字段集 + 冻结 tuple 比对），≥3 落地 exemplar 共享（`PRINCIPAL` / `DETAILS` / `SUBSCRIBERS-DERIVED`-`*-FIELD-FROZEN`），现有 7 条范本描述不了 → 加入。
- ❌ relationship coverage enrollment（三方一致 conformance，`SAGA-JOURNAL` / `USERREPO` / `COLLECTOR`）实为 **Medium**（Hard 路径 = codegen golden 枚举实现 gh #1003，即已在 catalog 的 `codegen funnel + golden`）→ 按「落入现有范本不新增条目」+ Hard 封闭集语义不加；其 Medium 写作示例留 exemplar godoc（ai-robust.md 规定的 Medium 实例归处）。

条目仅写**抽象形态描述**，符合 catalog「禁止 deployment 命名 / 符号清单活 godoc」纪律。

> **Review 提示**：本 PR 是对**既有 Hard** reflect-freeze archtest 的 catalog **文档化**，**非新增 enforcement 机制**——ai-robust「立项 ≥ Medium / Soft 严禁立项」门槛仅约束新 enforcement，不适用。需核验条目为抽象形态、未列 deployment 符号、未与现有范本（尤其 `sealed construction` / `codegen funnel + golden`）重叠。

## Refs

Closes #1037

- ref: ai-robust.md 三档分级表 `reflect 字段数` Hard 载体（补全其 catalog 条目）
- ref: in-repo exemplars `tools/archtest/{principal_sealed_field_frozen,errcode_invariants,contract_subscribers_funnel}_test.go`（reflect schema freeze 形态）
- 已合并前序：#1395（§1a/b/c）/ #1470 + #1502（§1d）/ #722（§3）
- 相邻 deferred forward-consumer：#1090 M9 contract publisher/consumer registry（跨仓库 contract-fanout，P3，本 PR 不实现）

## Test plan

- [x] diff 仅 1 行 markdown 插入（`git diff --stat` = `.claude/rules/gocell/ai-robust.md | 1 +`），零 Go 影响，无需 build/test
- [x] 形态独立性核验：vs `sealed construction`（构造封闭 ≠ 字段集冻结）、vs `codegen funnel + golden`（reflect 运行时枚举 ≠ 生成源字节 diff）——条目内显式声明区别
- [x] 非预设核验：3 个 `*-FIELD-FROZEN` exemplar 均存在且用 `reflect.TypeOf` 枚举字段
- [x] 内部一致性核验：条目补全 grading 表 line 25 "reflect 字段数" Hard 载体承诺
