### PR TITLE
feat(grpc): Cell.GRPCService registrar API + bootstrap drain [GAP-1 PR-7] [#1150]

### DIFF
--- a/adapters/grpc/doc.go
+++ b/adapters/grpc/doc.go
@@ -27,21 +27,36 @@
 // and auth interceptors are composed at the bootstrap layer (PR-4) and
 // plumbed in via grpc.ServerOption; they are not a concern of this adapter.
 //
+// # Service registration (PR-7: Form B callback, cell-facing)
+//
+// Services are registered via the cell-facing drain model introduced in PR-7:
+//  1. Cells declare GRPCServiceSpec in Cell.Init via reg.GRPCService(spec).
+//  2. bootstrap drains RegistrySnapshot.GRPCServices in phase7b and calls
+//     srv.Registrar().Register(spec) for each spec — AFTER binding the gRPC
+//     listener but BEFORE grpcServeAll.
+//  3. The Registrar intercepts the spec.Register callback's RegisterService
+//     call to record /{service}/{method}→cellID attribution.
+//
+// Composition-root wiring (cmd/ or examples/):
+//
+//	chain := interceptor.NewUnaryChain(interceptor.Deps{...})
+//	srv, _ := adaptersgrpc.New(adaptersgrpc.Config{..., ServerOptions: []grpc.ServerOption{chain}})
+//	bootstrap.New(clk,
+//	    bootstrap.WithGRPCListener(cell.PrimaryListener, srv, ":9000"),
+//	)
+//	// Services are registered automatically from cell declarations — no manual
+//	// srv.Registrar().Register(...) needed in the composition root.
+//
 // # Readiness probe
 //
 // ProbeReady ("grpc_ready") is healthy while grpcServer.Serve is active.
 // The serving flag is set after grpcServer.Serve starts its accept loop, so
 // there is a sub-millisecond window between flag flip and the first Accept.
 // At typical readiness-probe polling intervals (≥100 ms) this window is
-// invisible. Wire it via lifecycle.ManagedResource.Probes() drain in bootstrap:
-//
-//	srv, _ := grpc.New(cfg)
-//	grpc_health_v1.RegisterHealthServer(srv.ServiceRegistrar(), healthSrv)
-//	bootstrap.WithManagedResource(srv)
+// invisible.
 //
 // # Scope boundary
 //
-// This adapter provides server-side lifecycle only. Client-side gRPC adapters,
-// ServiceRegistrar wiring (PR-7), and codegen/proto plumbing (PR-2/6) are
-// delivered in subsequent PRs.
+// This adapter provides server-side lifecycle only. Client-side gRPC adapters
+// and codegen/proto plumbing (PR-2/6) are delivered in other PRs.
 package grpc

--- a/adapters/grpc/server.go
+++ b/adapters/grpc/server.go
@@ -11,10 +11,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/healthz"
 	"github.com/ghbvf/gocell/kernel/lifecycle"
 	"github.com/ghbvf/gocell/kernel/worker"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	runtimegrpc "github.com/ghbvf/gocell/runtime/grpc"
 	"github.com/ghbvf/gocell/runtime/http/tlsutil"
 )
 
@@ -36,8 +38,10 @@ var (
 // It wraps a *grpc.Server with the GoCell lifecycle contract:
 // Probes() / Worker() / Close().
 //
-// Construction: call New(cfg) to obtain a configured *Server, then register
-// services via ServiceRegistrar() before starting the Worker.
+// Construction: call New(cfg) to obtain a configured *Server. Services are
+// registered during bootstrap via Registrar().Register(spec) — cells declare
+// GRPCServiceSpec in Cell.Init; bootstrap drains the snapshot and calls
+// Registrar().Register for each spec in phase7b, before grpcServeAll.
 //
 // Concurrency: all public methods are safe for concurrent use. GracefulStop
 // is idempotent via stopOnce — calling Worker().Stop() and Close() simultaneously
@@ -45,6 +49,7 @@ var (
 type Server struct {
 	cfg        Config
 	grpcServer *grpc.Server
+	registrar  *runtimegrpc.ServiceRegistrar
 
 	// serving is true while grpcServer.Serve is actively running.
 	// Flipped to true inside serve() after Serve returns from the initial
@@ -92,18 +97,30 @@ func New(cfg Config) (*Server, error) {
 		opts = append(opts, grpc.Creds(creds))
 	}
 
+	inner := grpc.NewServer(opts...)
 	return &Server{
 		cfg:        cfg,
-		grpcServer: grpc.NewServer(opts...),
+		grpcServer: inner,
+		registrar:  runtimegrpc.NewServiceRegistrar(inner),
 		serveDone:  make(chan struct{}),
 	}, nil
 }
 
-// ServiceRegistrar returns the grpc.ServiceRegistrar so callers can register
-// gRPC service implementations before the Worker starts. Must be called before
-// Worker().Start() to avoid data races on the service registry.
-func (s *Server) ServiceRegistrar() grpc.ServiceRegistrar {
-	return s.grpcServer
+// Registrar returns the cell-facing service registrar that bootstrap uses to
+// register gRPC services (GAP-1 PR-7 [#1150]). It wraps the underlying
+// *grpc.Server and intercepts RegisterService calls to record method→cellID
+// attribution for each spec.
+//
+// The return type is cell.GRPCServiceRegistrar (the narrow kernel-defined
+// interface) so bootstrap's GRPCServer interface can reference it without
+// importing adapters/grpc or google.golang.org/grpc. The concrete value is
+// *runtime/grpc.ServiceRegistrar, which callers that import adapters/grpc may
+// type-assert to access CellIDForMethod (PR-9).
+//
+// All service registrations must happen before Serve/Worker().Start() to avoid
+// data races — the bootstrap drain (phase7b) guarantees this ordering.
+func (s *Server) Registrar() cell.GRPCServiceRegistrar {
+	return s.registrar
 }
 
 // Probes implements lifecycle.ManagedResource. It returns a single probe named

--- a/adapters/grpc/server_integration_test.go
+++ b/adapters/grpc/server_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	grpcadapter "github.com/ghbvf/gocell/adapters/grpc"
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
@@ -139,6 +140,36 @@ func healthCheck(t *testing.T, cc *grpc.ClientConn) (grpc_health_v1.HealthCheckR
 	return resp.GetStatus(), nil
 }
 
+// integRegisterHealth registers the gRPC health service on srv via the Form B
+// callback path (srv.Registrar().Register(spec)).
+func integRegisterHealth(t *testing.T, srv *grpcadapter.Server, healthSrv *health.Server) {
+	t.Helper()
+	spec := cell.GRPCServiceSpec{
+		ContractID: "grpc.health.v1",
+		CellID:     "_integration-test",
+		Listener:   cell.PrimaryListener,
+		Register: func(r grpc.ServiceRegistrar) {
+			grpc_health_v1.RegisterHealthServer(r, healthSrv)
+		},
+	}
+	require.NoError(t, srv.Registrar().Register(spec))
+}
+
+// integRegisterDesc registers an arbitrary ServiceDesc on srv via the Form B
+// callback path (srv.Registrar().Register(spec)).
+func integRegisterDesc(t *testing.T, srv *grpcadapter.Server, contractID string, desc *grpc.ServiceDesc, impl any) {
+	t.Helper()
+	spec := cell.GRPCServiceSpec{
+		ContractID: contractID,
+		CellID:     "_integration-test",
+		Listener:   cell.PrimaryListener,
+		Register: func(r grpc.ServiceRegistrar) {
+			r.RegisterService(desc, impl)
+		},
+	}
+	require.NoError(t, srv.Registrar().Register(spec))
+}
+
 // ─── Integration tests ────────────────────────────────────────────────────────
 
 // TestIntegration_Plaintext_BufconnCheck verifies plaintext gRPC via bufconn.
@@ -156,7 +187,7 @@ func TestIntegration_Plaintext_BufconnCheck(t *testing.T) {
 	// Register health service so the RPC call has something to hit.
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(srv.ServiceRegistrar(), healthSrv)
+	integRegisterHealth(t, srv, healthSrv)
 
 	// Use bufconn for in-process networking.
 	bufSize := 1024 * 1024
@@ -207,7 +238,7 @@ func TestIntegration_ServerTLS(t *testing.T) {
 
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(srv.ServiceRegistrar(), healthSrv)
+	integRegisterHealth(t, srv, healthSrv)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -255,7 +286,7 @@ func TestIntegration_ServerOptionsCannotOverrideTLS(t *testing.T) {
 
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(srv.ServiceRegistrar(), healthSrv)
+	integRegisterHealth(t, srv, healthSrv)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -301,7 +332,7 @@ func TestIntegration_MTLS_WithValidClientCert(t *testing.T) {
 
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(srv.ServiceRegistrar(), healthSrv)
+	integRegisterHealth(t, srv, healthSrv)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -344,7 +375,7 @@ func TestIntegration_MTLS_NoClientCert(t *testing.T) {
 
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(srv.ServiceRegistrar(), healthSrv)
+	integRegisterHealth(t, srv, healthSrv)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -396,7 +427,7 @@ func TestIntegration_GracefulDrain(t *testing.T) {
 	rpcStarted := make(chan struct{})
 	release := make(chan struct{})
 	desc := blockingServiceDesc(rpcStarted, release)
-	srv.ServiceRegistrar().RegisterService(&desc, new(any))
+	integRegisterDesc(t, srv, "grpc.test.blocker.v1", &desc, new(any))
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -549,7 +580,7 @@ func TestIntegration_ServeContextCancel_GracefulDrain(t *testing.T) {
 	rpcStarted := make(chan struct{})
 	release := make(chan struct{})
 	desc := blockingServiceDesc(rpcStarted, release)
-	srv.ServiceRegistrar().RegisterService(&desc, new(any))
+	integRegisterDesc(t, srv, "grpc.test.blocker.v1", &desc, new(any))
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/docs/plans/specs/202605262300-048-grpc-adapter/checklists/requirements.md
+++ b/docs/plans/specs/202605262300-048-grpc-adapter/checklists/requirements.md
@@ -35,5 +35,5 @@
 ## Notes
 
 - The spec was written after a 3-explorer research pass (see [research.md](../research.md)); decisions documented there pre-empt clarification markers.
-- Constitution check (in plan.md) flagged one Medium archtest as a known funnel-pair Hard upgrade — tracked, not blocking.
+- Constitution check (in plan.md) flagged one Medium archtest (`GRPC-CELL-REGISTRAR-LAYER-01`) whose Hard upgrade is **infeasible** — a permanent Go-language ceiling (won't-do #1582), not a deferred upgrade. Tracked, not blocking.
 - The 12 PR slicing (in plan.md §"Phase 2") is the delivery contract for FR-014.

--- a/docs/plans/specs/202605262300-048-grpc-adapter/data-model.md
+++ b/docs/plans/specs/202605262300-048-grpc-adapter/data-model.md
@@ -325,6 +325,6 @@ None. Transport-only feature; no stateful entities.
 | `(package, service, method)` globally unique | ProtoRegistry at codegen time | PR 6 |
 | Handler signature MUST match generated interface | Go compiler (interface assertion) | PR 7 |
 | Service registration MUST happen before `Serve()` | `ServiceRegistrar.Register` ordering | PR 7 |
-| `*grpc.ServiceDesc` type assertion safety | adapter layer panic with Approved marker | PR 7 |
+| `func(grpc.ServiceRegistrar)` callback (Form B) type assertion safety | runtime/grpc panics with Approved marker on bad/typed-nil callback type | PR 7 |
 | Hand-written grpc method registration banned in `cells/` | archtest `GRPC-METHOD-IN-CONTRACT-01` | PR 8 |
 | Exhaustive `errcode.Kind → codes.Code` mapping | archtest `GRPC-ERRCODE-MAPPING-01` | PR 12 |

--- a/docs/plans/specs/202605262300-048-grpc-adapter/data-model.md
+++ b/docs/plans/specs/202605262300-048-grpc-adapter/data-model.md
@@ -118,20 +118,32 @@ grpc:
 
 ### `GRPCServiceSpec` (new)
 
+**As-built (PR-7 #1150): Form B (callback).** The spec carries a `Register` callback —
+`func(grpc.ServiceRegistrar)` held as `any` — instead of a `(ServiceDesc, Impl)` pair. This is
+isomorphic with GoCell's own `RouteGroup.Register func(mux) error` and matches the go-zero
+`RegisterFn func(*grpc.Server)` / Kratos `pb.RegisterXxxServer(srv, impl)` idiom: the cell supplies
+a closure that calls the generated `pb.RegisterXxxServer` helper. Plus a `Listener` ref for
+per-listener routing (symmetric with `RouteGroup.Listener`).
+
 ```go
-// GRPCServiceSpec carries the registration intent for a gRPC service belonging
-// to a cell. It deliberately stores the grpc.ServiceDesc as `any` so that
-// kernel/ does NOT import google.golang.org/grpc.
-//
-// Hard upgrade tracked: replace `any` with a sealed marker interface defined
-// in adapters/grpc with a private constructor — see plan.md Complexity Tracking.
 type GRPCServiceSpec struct {
-    ContractID  string
-    CellID      string
-    ServiceDesc any  // expected *grpc.ServiceDesc, asserted in adapter layer
-    Impl        any  // expected the service interface impl, asserted in adapter layer
+    ContractID string
+    CellID     string
+    Listener   ListenerRef // target gRPC listener; matches a WithGRPCListener(ref, …)
+    Register   any         // expected func(grpc.ServiceRegistrar); asserted in runtime/grpc
 }
 ```
+
+> **AI-robust — permanent ceiling, not a feasible upgrade.** `Register` is `any` because
+> `kernel/ ⊥ grpc` makes naming `func(grpc.ServiceRegistrar)` impossible. The earlier "sealed
+> marker interface in adapters/grpc" idea is **infeasible** (kernel ⊥ adapters; an exported kernel
+> marker seals nothing; an unexported kernel marker can't be implemented by cell/adapter closures)
+> — same family as #851/#893/#1282. `GRPC-CELL-REGISTRAR-LAYER-01` is Medium (reflect field-lock) +
+> the existing kernel⊥grpc depguard/`kernel_internal_dag_test.go` gate. Won't-do tracked at **#1582**.
+
+`kernel/cell` also defines the narrow `GRPCServiceRegistrar interface { Register(GRPCServiceSpec) error }`
+(bottom-of-graph home so both `adapters/grpc` and `runtime/bootstrap` import it without a cycle);
+`*runtime/grpc.ServiceRegistrar` satisfies it structurally.
 
 ### `Registrar` (extended)
 
@@ -166,25 +178,31 @@ type RegistrySnapshot struct {
 
 ### `ServiceRegistrar` (new)
 
+**As-built (PR-7 #1150): single public path + unexported interceptor.** The public
+`ServiceRegistrar` exposes only `Register(spec)` + `CellIDForMethod` — it does **not** implement
+`grpc.ServiceRegistrar` (no raw `RegisterService` bypass). Attribution is captured by an unexported
+`cellScopedRegistrar` that *does* implement `grpc.ServiceRegistrar`: `Register(spec)` hands it to
+the spec's callback, and it intercepts the callback's `RegisterService(sd, impl)` to record
+`/{ServiceName}/{method} → cellID` (Methods + Streams) before delegating to the real server.
+
 ```go
-// ServiceRegistrar is the bootstrap-side drain target for kernel/cell
-// GRPCServices. It owns the grpc.Server and performs the actual
-// RegisterService call with proper type assertions.
 type ServiceRegistrar struct {
-    server   *grpc.Server                              // adapters/grpc value
-    methods  map[string]string                         // "/svc/method" → cellID, used by attribution interceptor
+    inner   grpc.ServiceRegistrar // typically *grpc.Server; NOT re-exported
+    methods map[string]string     // "/svc/method" → cellID (for PR-9 attribution)
+    names   map[string]struct{}   // ServiceName dedup across specs
 }
 
-func NewServiceRegistrar(server *grpc.Server) *ServiceRegistrar
-
+func NewServiceRegistrar(inner grpc.ServiceRegistrar) *ServiceRegistrar
 func (r *ServiceRegistrar) Register(spec cell.GRPCServiceSpec) error
 func (r *ServiceRegistrar) CellIDForMethod(fullMethod string) (cellID string, ok bool)
 ```
 
 **Invariants**:
-- `Register` MUST be called before `grpc.Server.Serve()`.
-- Duplicate `ContractID` → fail-fast.
-- `(spec.ServiceDesc).(*grpc.ServiceDesc)` assertion MUST succeed; on failure, panic via `panicregister.Approved("grpc-registrar-bad-servicedesc", ...)`.
+- `Register` MUST be called before `grpc.Server.Serve()` (drain runs in bootstrap phase7b before `grpcServeAll`).
+- Duplicate `ContractID` → fail-fast error at the recorder (`RegistryRecorder.GRPCService`).
+- `spec.Register.(func(grpc.ServiceRegistrar))` assertion MUST succeed; on failure, panic via `panicregister.Approved("grpc-registrar-bad-register-fn", ...)`.
+- Duplicate `ServiceName` across specs → panic via `panicregister.Approved("grpc-registrar-dup-service", ...)` before grpc-go's own fatal.
+- `adapters/grpc.Server.Registrar()` returns the `cell.GRPCServiceRegistrar` interface (the concrete `*ServiceRegistrar`, carrying `CellIDForMethod`, is held inside the adapter for PR-9). `WithGRPCListener` gained a leading `ref cell.ListenerRef`.
 
 ---
 

--- a/docs/plans/specs/202605262300-048-grpc-adapter/plan.md
+++ b/docs/plans/specs/202605262300-048-grpc-adapter/plan.md
@@ -311,18 +311,18 @@ PR3 (adapters/grpc server) ── PR4 (interceptors) ── PR5 (bootstrap wirin
 
 ### PR 7 — ServiceRegistrar + Cell.GRPCService API ⚡
 
-- **Scope**: new `runtime/grpc/registrar.go` `ServiceRegistrar.RegisterService(desc, impl)`; `kernel/cell.Registrar` gains `GRPCService(spec GRPCServiceSpec, impl any)`; bootstrap phase5 drains `RegistrySnapshot.GRPCServices` to registrar.
-- **Files**:
-  - `runtime/grpc/registrar.go` ~150
-  - `runtime/grpc/registrar_test.go` ~150
-  - `kernel/cell/registrar.go` (+`GRPCService` method) ~60
-  - `kernel/cell/registry.go` (+`GRPCServiceSpec` `any`-typed) ~60
-  - `runtime/bootstrap/bootstrap.go` (+drain `GRPCServices`) ~80
-- **TDD**: register-then-call happy path; duplicate service desc → fail-fast; cellID resolution from `GRPCServiceSpec.CellID`
+- **Scope** (as-built PR-7 #1150, **Form B**): new `runtime/grpc/registrar.go` — public `ServiceRegistrar.Register(spec cell.GRPCServiceSpec) error` + `CellIDForMethod` (single public path; an unexported `cellScopedRegistrar` implements `grpc.ServiceRegistrar` for attribution); `kernel/cell.Registrar` gains `GRPCService(spec GRPCServiceSpec) error` (one arg — impl folds into the `spec.Register func(grpc.ServiceRegistrar)` callback); `WithGRPCListener` gains a leading `ref cell.ListenerRef`; bootstrap **phase7b** (after bind, before `grpcServeAll`) drains `RegistrySnapshot.GRPCServices` routed by `spec.Listener` ref.
+- **Files** (as-built):
+  - `kernel/cell/grpc_service.go` (new — `GRPCServiceSpec{…Register any}` + `Validate` + `GRPCServiceRegistrar` iface)
+  - `kernel/cell/registry.go` (+`GRPCService` method + recorder dedup + `RegistrySnapshot.GRPCServices` + Snapshot copy)
+  - `runtime/grpc/registrar.go` + `_test.go`
+  - `adapters/grpc/server.go` (`Registrar()` replaces `ServiceRegistrar()`)
+  - `runtime/bootstrap/grpc_listener.go` + `grpc_serve.go` (+`ref` + drain)
+  - `tools/archtest/grpc_cell_registrar_layer_test.go`
+- **TDD**: register-then-invoke (bufconn); bad-`Register`-fn-type panic; dup-`ServiceName` panic; dup-`ContractID` recorder error; `CellIDForMethod`; bootstrap drain happy + undeclared-ref/dup-ref/CellID-mismatch fail-fast.
 - **archtest**:
-  - `GRPC-CELL-REGISTRAR-LAYER-01` (Medium: `kernel/cell.GRPCServiceSpec` holds `interface{}` for `*grpc.ServiceDesc`; `kernel/` MUST NOT import `google.golang.org/grpc` — AST + import scan)
-- **Est.**: 500 lines
-- **Risk**: `kernel/` ↛ grpc constraint enforced via `any`-typed field, with runtime type assertion in the adapter layer. Upgrade path to type-safe sealed interface tracked in a follow-up gh issue (Hard upgrade per AI-robust §Funnel 双向锁评级).
+  - `GRPC-CELL-REGISTRAR-LAYER-01` (Medium: reflect field-lock that `GRPCServiceSpec.Register` is untyped `any` + negative control. kernel⊥grpc itself is enforced by the existing depguard + `kernel/depgraph/layer_test.go` gate — **not** duplicated here.)
+- **Risk**: `kernel/` ↛ grpc enforced via the `any`-typed `Register` field. The "sealed interface" Hard upgrade is **infeasible** (kernel ⊥ adapters / unexported-marker rule) — a **permanent Go-language ceiling**, won't-do, tracked **#1582** (#851/#893/#1282 family). See Complexity Tracking below.
 
 ### PR 8 — examples/iotdevice gRPC handler (first end-to-end) ⚡
 
@@ -436,13 +436,16 @@ PR3 (adapters/grpc server) ── PR4 (interceptors) ── PR5 (bootstrap wirin
 
 No constitution violations require justification.
 
-One **funnel-pair Medium → Hard upgrade** is tracked as a follow-up rather than blocking this feature:
+One archtest carries a **Medium rating with a permanent upstream ceiling** (corrected PR-7 #1150 —
+the earlier "Hard upgrade" framing was found infeasible):
 
-| Item | Why Medium now | Path to Hard | Tracking |
-|------|---------------|--------------|----------|
-| `GRPC-CELL-REGISTRAR-LAYER-01` | `kernel/cell.GRPCServiceSpec` field is `any`; archtest enforces `kernel/` ↛ grpc, but a kernel-internal struct could still hold a `*grpc.ServiceDesc` indirectly | Introduce a sealed interface in `adapters/grpc` with private constructor; `kernel/cell` references only the interface; archtest upgrade to Hard form (single sanctioned holder) | gh issue (to open at PR 7 merge) |
+| Item | Why Medium | Why true-Hard is unreachable (permanent ceiling) | Tracking |
+|------|-----------|--------------------------------------------------|----------|
+| `GRPC-CELL-REGISTRAR-LAYER-01` | `kernel/cell.GRPCServiceSpec.Register` is `any` (reflect field-lock); kernel⊥grpc itself is the existing depguard + `kernel/depgraph/layer_test.go` gate | Sealing the `any` is infeasible: a kernel **unexported** marker can't be implemented by cell/adapter closures; a kernel **exported** marker seals nothing; a marker in `adapters/grpc` can't be referenced by `kernel/cell` (kernel ⊥ adapters). The `any` is irreducible because kernel cannot name `func(grpc.ServiceRegistrar)`. | **#1582** (won't-do) |
 
-This matches AI-robust §Hard 范本目录 "single sanctioned holder" — currently Medium because upgrade path requires the adapter layer to exist (PR 3+).
+This is the same permanent Go-language ceiling family as #851 / #893 / #1282 — **not** a "single
+sanctioned holder" upgrade (that pattern needs the holder type to be nameable across the boundary,
+which kernel ⊥ grpc / ⊥ adapters forbids).
 
 ---
 

--- a/docs/plans/specs/202605262300-048-grpc-adapter/plan.md
+++ b/docs/plans/specs/202605262300-048-grpc-adapter/plan.md
@@ -43,7 +43,7 @@ GoCell project constitution (`.specify/memory/constitution.md`) gates re-evaluat
 
 | Principle | Gate | Status |
 |-----------|------|--------|
-| **I. Cell-Native Layering** | `kernel/` ↛ `runtime/`/`adapters/`/`cells/`; `cells/` ↛ `adapters/grpc` | ✅ — `kernel/cell.GRPCServiceSpec` holds `any` (interface), grpc.ServiceDesc injected from adapter layer; archtest `GRPC-CELL-REGISTRAR-LAYER-01` (Medium) enforces |
+| **I. Cell-Native Layering** | `kernel/` ↛ `runtime/`/`adapters/`/`cells/`; `cells/` ↛ `adapters/grpc` | ✅ — `kernel/cell.GRPCServiceSpec.Register` holds `any` (Form B: a `func(grpc.ServiceRegistrar)` callback; the cell's closure builds the `*ServiceDesc` via the generated `pb.RegisterXxxServer`, so kernel never names a grpc type); archtest `GRPC-CELL-REGISTRAR-LAYER-01` (Medium, permanent ceiling — see Complexity Tracking) enforces |
 | **II. Cell Governance + Six Truths** | contract.yaml is boundary truth | ✅ — `kind: grpc` is a kind extension; proto file is referenced from contract.yaml (`grpc.proto`), not a parallel SoR. archtest `GRPC-PROTO-REGISTRY-SINGLE-SOURCE-01` (Hard) ensures no hand-written proto import paths in generated code |
 | **III. Contract Boundary Discipline** | RPC contracts use existing kind taxonomy | ⚠️ — current closed set is `http \| event \| command \| projection`; this plan extends to add `grpc`. Constitution defines contract kinds in table at §III but the runtime closed set (`kernel/governance.builder.go`) is the enforced gate. **Decision**: extend the kind enumeration as a one-line addition; archtest `CONTRACT-KINDS-CLOSED-SET-01` updated in PR 1. No constitution amendment needed — `command` is the analogous precedent. Provider/consumer role pair for `grpc`: `server` / `clients`; provider role `serve`, consumer role `call` (mirrors `http`). |
 | **IV. TDD non-negotiable** | every PR ships its tests | ✅ — each PR lists `*_test.go` first in the file list per PR section below |
@@ -345,11 +345,11 @@ PR3 (adapters/grpc server) ── PR4 (interceptors) ── PR5 (bootstrap wirin
 
 ### PR 9 — observability parity: cell label + readyz probe + AccessLog
 
-- **Scope**: complete metrics cell label injection; new `grpc_ready` readiness probe; AccessLog interceptor; full slog field set (`cell`, `method`, `code`, `duration_ms`, `request_id`, `correlation_id`, `trace_id`).
+- **Scope**: complete metrics cell label injection; readyz integration of the existing `grpc_ready` probe (the `adapters/grpc.ProbeReady` const was already minted in PR-5; PR-9 wires it into the healthz aggregator/observability, not a new const); AccessLog interceptor; full slog field set (`cell`, `method`, `code`, `duration_ms`, `request_id`, `correlation_id`, `trace_id`).
 - **Files**:
   - `runtime/grpc/interceptor/metrics.go` (+cell label injection finalised) ~80
   - `runtime/grpc/interceptor/access_log.go` ~80
-  - `adapters/grpc/readyz.go` (+`ProbeReady healthz.ReadyProbeName = "grpc_ready"`) ~80
+  - `adapters/grpc/server.go` (wire the existing `ProbeReady healthz.ProbeName = "grpc_ready"` into the readyz aggregator) ~80
   - `runtime/grpc/interceptor/metrics_test.go` ~120
   - `runtime/grpc/interceptor/access_log_test.go` ~100
   - `adapters/grpc/readyz_test.go` ~80
@@ -418,7 +418,7 @@ PR3 (adapters/grpc server) ── PR4 (interceptors) ── PR5 (bootstrap wirin
 ### Highest-risk PRs
 
 1. **PR 5 (bootstrap wiring)** — Bootstrap.Run is the most complex lifecycle code in repo. Mitigation: mirror HTTP listener wiring shape exactly; no novel phase sequencing; same-PR regression test against existing bootstrap test suite.
-2. **PR 7 (kernel/cell GRPCServiceSpec)** — `kernel/` ↛ grpc enforced via `any` field rather than type system. Mitigation: archtest `GRPC-CELL-REGISTRAR-LAYER-01` (Medium) + gh issue tracking Hard upgrade (sealed interface via private constructor in `adapters/grpc` once feasible).
+2. **PR 7 (kernel/cell GRPCServiceSpec)** — `kernel/` ↛ grpc enforced via `any` field rather than type system. Mitigation: archtest `GRPC-CELL-REGISTRAR-LAYER-01` (Medium). Sealing the `any` is infeasible (kernel cannot name `func(grpc.ServiceRegistrar)`; an unexported marker can't be implemented by cell/adapter closures, an exported marker seals nothing, an `adapters/grpc` marker is unreachable from `kernel/cell`) — this is a permanent ceiling, not a deferred Hard upgrade. Tracked as won't-do at **#1582** (see Complexity Tracking).
 3. **PR 12 (errcode mapping)** — wire-side semantics fixed; future client migrations expensive. Mitigation: ADR `202605260100` reviewed before PR 12 lands; explicit table; exhaustiveness archtest.
 
 ### Milestones

--- a/kernel/cell/grpc_service.go
+++ b/kernel/cell/grpc_service.go
@@ -16,8 +16,8 @@ package cell
 // makes naming func(grpc.ServiceRegistrar) impossible. The archtest
 // GRPC-CELL-REGISTRAR-LAYER-01 reflect-locks this field to stay untyped any;
 // the kernel⊥grpc import-ban itself is enforced by depguard + kernel_internal_dag_test.go.
-// Sealing the field (permanent-ceiling won't-do) is tracked as a gh issue in the
-// archtest godoc — same family as #851/#893/#1282.
+// Sealing the field (permanent-ceiling won't-do) is tracked as gh #1582 —
+// same family as #851/#893/#1282.
 //
 // ref: zeromicro/go-zero zrpc/internal/rpcserver.go — RegisterFn func(*grpc.Server) (Form B precedent)
 // ref: go-kratos/kratos transport/grpc/server.go — pb.RegisterXxxServer before Start

--- a/kernel/cell/grpc_service.go
+++ b/kernel/cell/grpc_service.go
@@ -35,6 +35,9 @@ import (
 type GRPCServiceRegistrar interface {
 	// Register invokes the spec.Register callback on a cellScopedRegistrar
 	// interceptor, recording method→cellID attribution for each service.
+	// The canonical implementation (runtime/grpc.ServiceRegistrar) always returns
+	// nil; contract violations (bad callback type, duplicate ServiceName) panic
+	// via panicregister.Approved.
 	Register(spec GRPCServiceSpec) error
 }
 

--- a/kernel/cell/grpc_service.go
+++ b/kernel/cell/grpc_service.go
@@ -1,0 +1,105 @@
+package cell
+
+// grpc_service.go — GRPCServiceSpec declaration type (GAP-1 PR-7 [#1150]).
+//
+// Layering: kernel/ must NOT import google.golang.org/grpc. The Register field
+// therefore holds any (the zero-import representation of a callback). The expected
+// dynamic type is func(grpc.ServiceRegistrar); the type-assert is performed by the
+// runtime layer (runtime/grpc.ServiceRegistrar.Register).
+//
+// This is the symmetric counterpart of RouteGroup (HTTP) and follows the same
+// write-side-accumulate / read-side-drain split: cells declare GRPCServiceSpec
+// during Init via reg.GRPCService(spec), and bootstrap drains GRPCServices from
+// the RegistrySnapshot in phase7b before calling grpcServeAll.
+//
+// AI-robust note: Register is `any` — not a named interface — because kernel⊥grpc
+// makes naming func(grpc.ServiceRegistrar) impossible. The archtest
+// GRPC-CELL-REGISTRAR-LAYER-01 reflect-locks this field to stay untyped any;
+// the kernel⊥grpc import-ban itself is enforced by depguard + kernel_internal_dag_test.go.
+// Sealing the field (permanent-ceiling won't-do) is tracked as a gh issue in the
+// archtest godoc — same family as #851/#893/#1282.
+//
+// ref: zeromicro/go-zero zrpc/internal/rpcserver.go — RegisterFn func(*grpc.Server) (Form B precedent)
+// ref: go-kratos/kratos transport/grpc/server.go — pb.RegisterXxxServer before Start
+
+import (
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// GRPCServiceRegistrar is the narrow cell-service-registration contract exposed
+// by adapters/grpc.Server and consumed by runtime/bootstrap's drain (GAP-1 PR-7
+// [#1150]). It lives in kernel/cell so both layers can import it without cycles:
+// kernel/ is the bottom of the dependency graph.
+//
+// *runtime/grpc.ServiceRegistrar satisfies this interface structurally.
+type GRPCServiceRegistrar interface {
+	// Register invokes the spec.Register callback on a cellScopedRegistrar
+	// interceptor, recording method→cellID attribution for each service.
+	Register(spec GRPCServiceSpec) error
+}
+
+// GRPCServiceSpec declares a gRPC service that a cell wants to expose on a
+// specific listener. The registration callback (Register) is the Form B idiom
+// popularized by go-zero (RegisterFn) and go-kratos (pb.RegisterXxxServer):
+// the cell supplies a closure that calls the generated pb.RegisterXxxServer
+// helper, which internally calls grpc.ServiceRegistrar.RegisterService with the
+// fully-populated *ServiceDesc.
+//
+// Kernel holds Register as any (not func(grpc.ServiceRegistrar)) because kernel/
+// must not import google.golang.org/grpc. The type-assert from any to the
+// concrete func type happens in runtime/grpc.ServiceRegistrar.Register; a wrong
+// dynamic type panics via panicregister.Approved("grpc-registrar-bad-register-fn", …).
+//
+// # Usage in Cell.Init
+//
+//	func (c *MyCell) Init(ctx context.Context, reg cell.Registrar) error {
+//	    return reg.GRPCService(cell.GRPCServiceSpec{
+//	        ContractID: "grpc.myservice.v1",
+//	        CellID:     c.ID(),
+//	        Listener:   cell.PrimaryListener,
+//	        Register:   func(r grpc.ServiceRegistrar) {
+//	            pb.RegisterMyServiceServer(r, c.svc)
+//	        },
+//	    })
+//	}
+type GRPCServiceSpec struct {
+	// ContractID is the stable contract identifier (matches contract.yaml id).
+	// Used for deduplication: a cell may not register the same ContractID twice.
+	ContractID string
+
+	// CellID is the cell that owns this service. bootstrap asserts spec.CellID
+	// equals the snapshot key when draining (mirrors the subscription drain check).
+	CellID string
+
+	// Listener identifies the target gRPC listener (must match a ref passed to
+	// WithGRPCListener). Symmetric with RouteGroup.Listener for HTTP.
+	Listener ListenerRef
+
+	// Register holds a func(grpc.ServiceRegistrar) callback. Kernel stores it as
+	// any to avoid a grpc import dependency. The runtime layer type-asserts it.
+	// A nil value fails Validate; a non-func value panics in runtime/grpc at
+	// registration time (panicregister.Approved("grpc-registrar-bad-register-fn",…)).
+	Register any
+}
+
+// Validate returns a non-nil error when any required field is missing.
+// Called by RegistryRecorder.GRPCService before accumulating the spec.
+func (s GRPCServiceSpec) Validate() error {
+	if s.ContractID == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"GRPCServiceSpec: ContractID must not be empty")
+	}
+	if s.CellID == "" {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"GRPCServiceSpec: CellID must not be empty")
+	}
+	if s.Listener.IsZero() {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"GRPCServiceSpec: Listener must not be the zero ListenerRef; use cell.PrimaryListener or another declared ref")
+	}
+	if s.Register == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"GRPCServiceSpec: Register must not be nil; supply a func(grpc.ServiceRegistrar) callback")
+	}
+	return nil
+}

--- a/kernel/cell/grpc_service_test.go
+++ b/kernel/cell/grpc_service_test.go
@@ -125,23 +125,38 @@ func TestRegistryRecorder_GRPCService_AfterSnapshot_Panics(t *testing.T) {
 	})
 }
 
-// TestRegistrySnapshot_GRPCServices_DefensiveCopy verifies that mutating the
-// returned slice does not affect the recorder's internal state.
+// TestRegistrySnapshot_GRPCServices_DefensiveCopy verifies that GRPCServices
+// returns a defensive copy: mutating the returned slice must not affect a
+// separately taken snapshot from an independent recorder with identical inputs.
+//
+// Design note: Snapshot() finalizes the recorder, so a single recorder cannot
+// produce two snapshots. Instead we use two independent recorders seeded with
+// identical specs, take one snapshot each, mutate snap1, and assert that:
+//  1. The mutation visibly landed on snap1 (the test is not vacuous).
+//  2. snap2 from the second, unaffected recorder still holds the original value.
 func TestRegistrySnapshot_GRPCServices_DefensiveCopy(t *testing.T) {
 	t.Parallel()
-	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
-	require.NoError(t, r.GRPCService(validGRPCSpec("grpc.svc.v1")))
-	require.NoError(t, r.GRPCService(validGRPCSpec("grpc.svc.v2")))
 
-	snap1 := r.Snapshot()
-	// Mutate the first snapshot's slice.
-	snap1.GRPCServices[0] = cell.GRPCServiceSpec{ContractID: "CORRUPTED"}
+	// Recorder 1 → snap1 (will be mutated).
+	r1 := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	require.NoError(t, r1.GRPCService(validGRPCSpec("grpc.svc.v1")))
+	require.NoError(t, r1.GRPCService(validGRPCSpec("grpc.svc.v2")))
+	snap1 := r1.Snapshot()
 
-	// A second Snapshot call on an already-finalized recorder would panic, so
-	// we construct a fresh recorder for the second snapshot check.
+	// Recorder 2 → snap2 (control: same inputs, independent recorder).
 	r2 := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
 	require.NoError(t, r2.GRPCService(validGRPCSpec("grpc.svc.v1")))
+	require.NoError(t, r2.GRPCService(validGRPCSpec("grpc.svc.v2")))
 	snap2 := r2.Snapshot()
-	// The fresh recorder is unaffected; original IDs are preserved.
-	assert.Equal(t, "grpc.svc.v1", snap2.GRPCServices[0].ContractID)
+
+	// Mutate snap1's first element in-place.
+	snap1.GRPCServices[0] = cell.GRPCServiceSpec{ContractID: "CORRUPTED"}
+
+	// Assert 1: the mutation landed on snap1 (non-vacuous check).
+	assert.Equal(t, "CORRUPTED", snap1.GRPCServices[0].ContractID,
+		"mutation must be visible on snap1 to confirm the test is non-vacuous")
+
+	// Assert 2: snap2 from the independent recorder is unaffected.
+	assert.Equal(t, "grpc.svc.v1", snap2.GRPCServices[0].ContractID,
+		"snap2 from an independent recorder must not be affected by snap1 mutation")
 }

--- a/kernel/cell/grpc_service_test.go
+++ b/kernel/cell/grpc_service_test.go
@@ -109,7 +109,7 @@ func TestRegistryRecorder_GRPCService_DuplicateContractID(t *testing.T) {
 func TestRegistryRecorder_GRPCService_ValidateError(t *testing.T) {
 	t.Parallel()
 	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
-	spec := validGRPCSpec("")  // empty ContractID → Validate fails
+	spec := validGRPCSpec("") // empty ContractID → Validate fails
 	err := r.GRPCService(spec)
 	require.Error(t, err)
 }

--- a/kernel/cell/grpc_service_test.go
+++ b/kernel/cell/grpc_service_test.go
@@ -1,0 +1,147 @@
+package cell_test
+
+// grpc_service_test.go — TDD coverage for GRPCServiceSpec + GRPCService recorder
+// method (GAP-1 PR-7 [#1150]).
+//
+// Cases:
+//   1. GRPCServiceSpec.Validate() accepts valid spec
+//   2. GRPCServiceSpec.Validate() rejects missing ContractID / CellID / Listener / Register
+//   3. RegistryRecorder.GRPCService: happy path accumulates spec
+//   4. RegistryRecorder.GRPCService: duplicate ContractID returns error
+//   5. RegistryRecorder.GRPCService: validate error propagates
+//   6. RegistryRecorder.GRPCService: called after Snapshot() panics
+//   7. RegistrySnapshot.GRPCServices is a defensive copy (mutation doesn't affect recorder)
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// validGRPCSpec returns a well-formed GRPCServiceSpec for testing.
+func validGRPCSpec(contractID string) cell.GRPCServiceSpec {
+	return cell.GRPCServiceSpec{
+		ContractID: contractID,
+		CellID:     "test-cell",
+		Listener:   cell.PrimaryListener,
+		Register:   func() {}, // non-nil any; type check happens in runtime/grpc layer
+	}
+}
+
+// TestGRPCServiceSpec_Validate_HappyPath verifies a complete spec passes Validate.
+func TestGRPCServiceSpec_Validate_HappyPath(t *testing.T) {
+	t.Parallel()
+	spec := validGRPCSpec("grpc.my.service.v1")
+	require.NoError(t, spec.Validate())
+}
+
+// TestGRPCServiceSpec_Validate_MissingFields verifies each required field is checked.
+func TestGRPCServiceSpec_Validate_MissingFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		mutate  func(*cell.GRPCServiceSpec)
+		wantErr string
+	}{
+		{
+			name:    "missing ContractID",
+			mutate:  func(s *cell.GRPCServiceSpec) { s.ContractID = "" },
+			wantErr: "ContractID",
+		},
+		{
+			name:    "missing CellID",
+			mutate:  func(s *cell.GRPCServiceSpec) { s.CellID = "" },
+			wantErr: "CellID",
+		},
+		{
+			name:    "zero Listener",
+			mutate:  func(s *cell.GRPCServiceSpec) { s.Listener = cell.ListenerRef{} },
+			wantErr: "Listener",
+		},
+		{
+			name:    "nil Register",
+			mutate:  func(s *cell.GRPCServiceSpec) { s.Register = nil },
+			wantErr: "Register",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spec := validGRPCSpec("grpc.svc.v1")
+			tc.mutate(&spec)
+			err := spec.Validate()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestRegistryRecorder_GRPCService_HappyPath verifies a valid spec is accumulated.
+func TestRegistryRecorder_GRPCService_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	spec := validGRPCSpec("grpc.my.service.v1")
+	require.NoError(t, r.GRPCService(spec))
+
+	snap := r.Snapshot()
+	require.Len(t, snap.GRPCServices, 1)
+	assert.Equal(t, "grpc.my.service.v1", snap.GRPCServices[0].ContractID)
+}
+
+// TestRegistryRecorder_GRPCService_DuplicateContractID verifies that registering
+// the same ContractID twice returns a non-nil error.
+func TestRegistryRecorder_GRPCService_DuplicateContractID(t *testing.T) {
+	t.Parallel()
+	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	spec := validGRPCSpec("grpc.my.service.v1")
+	require.NoError(t, r.GRPCService(spec))
+	err := r.GRPCService(spec)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicate")
+}
+
+// TestRegistryRecorder_GRPCService_ValidateError verifies validation errors propagate.
+func TestRegistryRecorder_GRPCService_ValidateError(t *testing.T) {
+	t.Parallel()
+	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	spec := validGRPCSpec("")  // empty ContractID → Validate fails
+	err := r.GRPCService(spec)
+	require.Error(t, err)
+}
+
+// TestRegistryRecorder_GRPCService_AfterSnapshot_Panics verifies that calling
+// GRPCService after Snapshot() has been called panics with the registry-finalized panic.
+func TestRegistryRecorder_GRPCService_AfterSnapshot_Panics(t *testing.T) {
+	t.Parallel()
+	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	_ = r.Snapshot() // finalize
+	require.Panics(t, func() {
+		_ = r.GRPCService(validGRPCSpec("grpc.svc.v1"))
+	})
+}
+
+// TestRegistrySnapshot_GRPCServices_DefensiveCopy verifies that mutating the
+// returned slice does not affect the recorder's internal state.
+func TestRegistrySnapshot_GRPCServices_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+	r := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	require.NoError(t, r.GRPCService(validGRPCSpec("grpc.svc.v1")))
+	require.NoError(t, r.GRPCService(validGRPCSpec("grpc.svc.v2")))
+
+	snap1 := r.Snapshot()
+	// Mutate the first snapshot's slice.
+	snap1.GRPCServices[0] = cell.GRPCServiceSpec{ContractID: "CORRUPTED"}
+
+	// A second Snapshot call on an already-finalized recorder would panic, so
+	// we construct a fresh recorder for the second snapshot check.
+	r2 := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	require.NoError(t, r2.GRPCService(validGRPCSpec("grpc.svc.v1")))
+	snap2 := r2.Snapshot()
+	// The fresh recorder is unaffected; original IDs are preserved.
+	assert.Equal(t, "grpc.svc.v1", snap2.GRPCServices[0].ContractID)
+}

--- a/kernel/cell/grpc_service_test.go
+++ b/kernel/cell/grpc_service_test.go
@@ -10,7 +10,11 @@ package cell_test
 //   4. RegistryRecorder.GRPCService: duplicate ContractID returns error
 //   5. RegistryRecorder.GRPCService: validate error propagates
 //   6. RegistryRecorder.GRPCService: called after Snapshot() panics
-//   7. RegistrySnapshot.GRPCServices is a defensive copy (mutation doesn't affect recorder)
+//
+// The defensive-copy invariant (snapshot must not alias the recorder's internal
+// slice) needs to observe the recorder's unexported grpcServices field, so it
+// lives in the in-package test registry_test.go
+// (TestRegistrySnapshot_GRPCServices_DefensiveCopy) rather than here.
 
 import (
 	"testing"
@@ -123,40 +127,4 @@ func TestRegistryRecorder_GRPCService_AfterSnapshot_Panics(t *testing.T) {
 	require.Panics(t, func() {
 		_ = r.GRPCService(validGRPCSpec("grpc.svc.v1"))
 	})
-}
-
-// TestRegistrySnapshot_GRPCServices_DefensiveCopy verifies that GRPCServices
-// returns a defensive copy: mutating the returned slice must not affect a
-// separately taken snapshot from an independent recorder with identical inputs.
-//
-// Design note: Snapshot() finalizes the recorder, so a single recorder cannot
-// produce two snapshots. Instead we use two independent recorders seeded with
-// identical specs, take one snapshot each, mutate snap1, and assert that:
-//  1. The mutation visibly landed on snap1 (the test is not vacuous).
-//  2. snap2 from the second, unaffected recorder still holds the original value.
-func TestRegistrySnapshot_GRPCServices_DefensiveCopy(t *testing.T) {
-	t.Parallel()
-
-	// Recorder 1 → snap1 (will be mutated).
-	r1 := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
-	require.NoError(t, r1.GRPCService(validGRPCSpec("grpc.svc.v1")))
-	require.NoError(t, r1.GRPCService(validGRPCSpec("grpc.svc.v2")))
-	snap1 := r1.Snapshot()
-
-	// Recorder 2 → snap2 (control: same inputs, independent recorder).
-	r2 := cell.NewRegistryRecorder(nil, outbox.DurabilityDemo)
-	require.NoError(t, r2.GRPCService(validGRPCSpec("grpc.svc.v1")))
-	require.NoError(t, r2.GRPCService(validGRPCSpec("grpc.svc.v2")))
-	snap2 := r2.Snapshot()
-
-	// Mutate snap1's first element in-place.
-	snap1.GRPCServices[0] = cell.GRPCServiceSpec{ContractID: "CORRUPTED"}
-
-	// Assert 1: the mutation landed on snap1 (non-vacuous check).
-	assert.Equal(t, "CORRUPTED", snap1.GRPCServices[0].ContractID,
-		"mutation must be visible on snap1 to confirm the test is non-vacuous")
-
-	// Assert 2: snap2 from the independent recorder is unaffected.
-	assert.Equal(t, "grpc.svc.v1", snap2.GRPCServices[0].ContractID,
-		"snap2 from an independent recorder must not be affected by snap1 mutation")
 }

--- a/kernel/cell/registry.go
+++ b/kernel/cell/registry.go
@@ -880,7 +880,12 @@ func (r *RegistryRecorder) GRPCService(spec GRPCServiceSpec) error {
 	if _, dup := r.grpcServiceIDs[spec.ContractID]; dup {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"registry GRPCService: duplicate ContractID; each gRPC service must have a "+
-				"unique ContractID within its cell (ContractID="+spec.ContractID+")")
+				"unique ContractID within its cell (the ContractID is used as the dedup key — "+
+				"a duplicate would silently shadow the first registration)",
+			errcode.WithInternal(
+				errcode.InternalAttr("reason", "duplicate"),
+				errcode.InternalAttr("contractID", spec.ContractID),
+				errcode.InternalAttr("cellID", spec.CellID)))
 	}
 
 	r.grpcServiceIDs[spec.ContractID] = struct{}{}

--- a/kernel/cell/registry.go
+++ b/kernel/cell/registry.go
@@ -279,6 +279,25 @@ type Registrar interface {
 	// invoked only when at least one changed key matches a prefix. An empty
 	// string inside prefixes is a programming error and panics.
 	OnConfigReload(prefixes []string, fn func(context.Context, ConfigChangeEvent) error)
+
+	// GRPCService records a gRPC service declaration (GAP-1 PR-7 [#1150]).
+	// The spec is validated and accumulated during Init; bootstrap drains
+	// RegistrySnapshot.GRPCServices in phase7b — after binding listeners but
+	// before calling grpcServeAll — so services are reachable from the first
+	// accepted connection.
+	//
+	// spec.Register holds a func(grpc.ServiceRegistrar) callback (stored as any
+	// because kernel/ must not import grpc). The runtime/grpc layer type-asserts
+	// and invokes it. A nil Register fails Validate; a wrong dynamic type panics
+	// via panicregister.Approved("grpc-registrar-bad-register-fn", …) in
+	// runtime/grpc.ServiceRegistrar.Register.
+	//
+	// Returns a non-nil error when:
+	//   - spec.Validate() fails (empty ContractID / CellID / zero Listener / nil Register)
+	//   - the ContractID has already been registered by this cell (dedup by ContractID)
+	//
+	// Cell.Init should propagate the error via `if err := ...; err != nil { return err }`.
+	GRPCService(spec GRPCServiceSpec) error
 }
 
 // ---------------------------------------------------------------------------
@@ -612,6 +631,12 @@ type RegistrySnapshot struct {
 	// projection.Coordinator per request and calls Coordinator.Subscribe — same
 	// write-side-accumulate / read-side-drain split as Subscriptions.
 	Projections []ProjectionRequest
+
+	// GRPCServices are the gRPC service declarations accumulated via
+	// reg.GRPCService(...) during Init (GAP-1 PR-7 [#1150]). bootstrap drains
+	// them in phase7b — after binding gRPC listeners but before grpcServeAll —
+	// routing each spec to the listener identified by spec.Listener.
+	GRPCServices []GRPCServiceSpec
 }
 
 // ---------------------------------------------------------------------------
@@ -638,6 +663,8 @@ type RegistryRecorder struct {
 	webhookDispatchers []WebhookDispatchRequest
 	projections        []ProjectionRequest
 	projectionIDs      map[string]struct{}
+	grpcServices       []GRPCServiceSpec
+	grpcServiceIDs     map[string]struct{}
 
 	finalized bool
 }
@@ -659,11 +686,12 @@ func NewRegistryRecorder(cfg map[string]any, mode outbox.DurabilityMode) *Regist
 // logger. Provided for testing so log output can be captured.
 func NewRegistryRecorderWithLogger(cfg map[string]any, mode outbox.DurabilityMode, log *slog.Logger) *RegistryRecorder {
 	return &RegistryRecorder{
-		cfg:           cfg,
-		mode:          mode,
-		log:           log,
-		probeNames:    make(map[healthz.ProbeName]struct{}),
-		projectionIDs: make(map[string]struct{}),
+		cfg:            cfg,
+		mode:           mode,
+		log:            log,
+		probeNames:     make(map[healthz.ProbeName]struct{}),
+		projectionIDs:  make(map[string]struct{}),
+		grpcServiceIDs: make(map[string]struct{}),
 	}
 }
 
@@ -840,6 +868,26 @@ func (r *RegistryRecorder) RegisterProjection(req ProjectionRequest) error {
 	return nil
 }
 
+// GRPCService validates and appends a GRPCServiceSpec (record-only — see
+// Registrar.GRPCService godoc). Mirrors RegisterProjection: validate →
+// dedup-by-ContractID → append.
+func (r *RegistryRecorder) GRPCService(spec GRPCServiceSpec) error {
+	r.mustNotBeFinalized("GRPCService")
+
+	if err := spec.Validate(); err != nil {
+		return err
+	}
+	if _, dup := r.grpcServiceIDs[spec.ContractID]; dup {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"registry GRPCService: duplicate ContractID; each gRPC service must have a "+
+				"unique ContractID within its cell (ContractID="+spec.ContractID+")")
+	}
+
+	r.grpcServiceIDs[spec.ContractID] = struct{}{}
+	r.grpcServices = append(r.grpcServices, spec)
+	return nil
+}
+
 // RegisterReadiness accumulates a probe under the typed name. First-wins
 // duplicate semantics match the runtime aggregator: a second registration
 // with the same name returns [healthz.ErrDuplicateProbe] and is not stored.
@@ -947,6 +995,9 @@ func (r *RegistryRecorder) Snapshot() RegistrySnapshot {
 	projs := make([]ProjectionRequest, len(r.projections))
 	copy(projs, r.projections)
 
+	grpcSvcs := make([]GRPCServiceSpec, len(r.grpcServices))
+	copy(grpcSvcs, r.grpcServices)
+
 	return RegistrySnapshot{
 		RouteGroups:        rgs,
 		Subscriptions:      subs,
@@ -956,6 +1007,7 @@ func (r *RegistryRecorder) Snapshot() RegistrySnapshot {
 		WebhookReceivers:   whRecv,
 		WebhookDispatchers: whDisp,
 		Projections:        projs,
+		GRPCServices:       grpcSvcs,
 	}
 }
 

--- a/kernel/cell/registry_test.go
+++ b/kernel/cell/registry_test.go
@@ -760,3 +760,44 @@ func TestRegistry_Subscribe_SpecValidate_RejectsInvalidSpec(t *testing.T) {
 		})
 	}
 }
+
+// validGRPCSpecInternal returns a well-formed GRPCServiceSpec for in-package tests.
+func validGRPCSpecInternal(contractID string) GRPCServiceSpec {
+	return GRPCServiceSpec{
+		ContractID: contractID,
+		CellID:     "test-cell",
+		Listener:   PrimaryListener,
+		Register:   func() {}, // non-nil any; type check happens in runtime/grpc layer
+	}
+}
+
+// TestRegistrySnapshot_GRPCServices_DefensiveCopy verifies Snapshot().GRPCServices
+// is a defensive copy: mutating the returned slice must NOT corrupt the recorder's
+// internal grpcServices slice. This is an in-package test so it can observe the
+// SAME recorder's unexported field — an external test mutating one recorder's
+// snapshot and asserting on a second independent recorder would pass even if
+// Snapshot aliased the internal slice (the mutation could never reach the other
+// recorder regardless), making it vacuous.
+func TestRegistrySnapshot_GRPCServices_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistryRecorder(nil, outbox.DurabilityDemo)
+	require.NoError(t, r.GRPCService(validGRPCSpecInternal("grpc.svc.v1")))
+	require.NoError(t, r.GRPCService(validGRPCSpecInternal("grpc.svc.v2")))
+
+	snap := r.Snapshot()
+	require.Len(t, snap.GRPCServices, 2)
+
+	// Mutate the snapshot's first element in-place.
+	snap.GRPCServices[0] = GRPCServiceSpec{ContractID: "CORRUPTED"}
+
+	// Assert 1: the mutation landed on the snapshot (non-vacuous check).
+	assert.Equal(t, "CORRUPTED", snap.GRPCServices[0].ContractID,
+		"mutation must be visible on the snapshot to confirm the test is non-vacuous")
+
+	// Assert 2: the SAME recorder's internal slice is untainted — proving Snapshot
+	// returned a copy, not an alias.
+	require.Len(t, r.grpcServices, 2)
+	assert.Equal(t, "grpc.svc.v1", r.grpcServices[0].ContractID,
+		"recorder's internal grpcServices[0] must not be corrupted by mutating the snapshot")
+}

--- a/runtime/bootstrap/grpc_drain_test.go
+++ b/runtime/bootstrap/grpc_drain_test.go
@@ -1,0 +1,245 @@
+package bootstrap
+
+// grpc_drain_test.go — TDD coverage for the gRPC service drain in phase7b
+// (GAP-1 PR-7 [#1150]).
+//
+// Cases:
+//   1. happy path: cell's GRPCServices are drained and registered before Serve
+//   2. undeclared listener ref → fail-fast
+//   3. duplicate gRPC listener ref → fail-fast
+//   4. CellID mismatch → fail-fast
+//   5. registration precedes Serve (services callable immediately after Run starts)
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/test/bufconn"
+
+	adaptersgrpc "github.com/ghbvf/gocell/adapters/grpc"
+	"github.com/ghbvf/gocell/kernel/assembly"
+	kauth "github.com/ghbvf/gocell/kernel/auth"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
+	runtimegrpc "github.com/ghbvf/gocell/runtime/grpc"
+	"github.com/ghbvf/gocell/runtime/grpc/interceptor"
+	"github.com/ghbvf/gocell/runtime/observability/metrics"
+)
+
+// GRPCServiceRegistrar is the bootstrap-local narrow interface (defined in grpc_listener.go).
+// We reference it here to verify the fake satisfies it.
+var _ GRPCServiceRegistrar = (*runtimegrpc.ServiceRegistrar)(nil)
+
+// buildDrainAdapterServer builds an adapters/grpc.Server with no auth (all public),
+// for use in drain tests that don't care about auth.
+func buildDrainAdapterServer(t *testing.T) *adaptersgrpc.Server {
+	t.Helper()
+	chain := interceptor.NewUnaryChain(interceptor.Deps{
+		Collector:   metrics.NewInMemoryGRPCCollector(),
+		Clock:       clock.Real(),
+		Verifier:    &bootstrapTestVerifier{},
+		AuthOptions: []interceptor.AuthOption{interceptor.WithPublicMethod(func(string) bool { return true })},
+	})
+	srv, err := adaptersgrpc.New(adaptersgrpc.Config{
+		Addr:          ":0",
+		TLS:           adaptersgrpc.TLSConfig{AllowInsecure: true},
+		ServerOptions: []grpc.ServerOption{chain},
+	})
+	require.NoError(t, err)
+	return srv
+}
+
+// grpcBufDial dials a bufconn listener with insecure credentials.
+func grpcBufDial(t *testing.T, lis *bufconn.Listener) *grpc.ClientConn {
+	t.Helper()
+	cc, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	return cc
+}
+
+// drainTestAssembly builds a CoreAssembly containing one stub cell that
+// registers a GRPCServiceSpec targeting the given listener ref.
+func drainTestAssembly(t *testing.T, id string, ref cell.ListenerRef, registerFn func(grpc.ServiceRegistrar)) *assembly.CoreAssembly {
+	t.Helper()
+	asm := assembly.New(clock.Real(), assembly.Config{ID: id, DurabilityMode: outbox.DurabilityDemo})
+	c := &grpcDrainCell{id: id, ref: ref, registerFn: registerFn}
+	require.NoError(t, asm.Register(c))
+	return asm
+}
+
+// --- Case 1: happy path — drain + register before Serve ----------------------
+
+func TestGRPCDrain_HappyPath(t *testing.T) {
+	const cellID = "grpc-drain-happy"
+	lis := bufconn.Listen(grpcTestBufSize)
+
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	asm := drainTestAssembly(t, cellID, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, healthSrv)
+	})
+
+	srv := buildDrainAdapterServer(t)
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		healthListenerOpt(t),
+		WithGRPCListener(cell.PrimaryListener, srv, ":0", WithGRPCListenerNet(lis)),
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	cc := grpcBufDial(t, lis)
+	defer cc.Close()
+
+	// Wait for health to be SERVING (proves service was registered before Serve).
+	testwait.External(t, "grpc-drain-serving", func() bool {
+		rctx, rcancel := context.WithTimeout(context.Background(), testtime.D2s)
+		defer rcancel()
+		resp, err := grpc_health_v1.NewHealthClient(cc).Check(rctx, &grpc_health_v1.HealthCheckRequest{})
+		return err == nil && resp.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
+	}, testtime.EventuallyDefault, testtime.MediumPoll, "gRPC health must be SERVING after drain")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// --- Case 2: undeclared listener ref → fail-fast ----------------------------
+
+func TestGRPCDrain_UndeclaredRef_FailFast(t *testing.T) {
+	const cellID = "grpc-drain-undeclared"
+	// Cell declares PrimaryListener but bootstrap only declares a different ref.
+	asm := drainTestAssembly(t, cellID, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {})
+
+	srv := buildDrainAdapterServer(t)
+	// WithGRPCListener with InternalListener ref — PrimaryListener is undeclared.
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		healthListenerOpt(t),
+		WithGRPCListener(cell.InternalListener, srv, ":0"),
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- b.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "undeclared")
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not fail-fast on undeclared ref")
+	}
+}
+
+// --- Case 3: duplicate gRPC listener ref → fail-fast ------------------------
+
+func TestGRPCDrain_DuplicateRef_FailFast(t *testing.T) {
+	asm := assembly.New(clock.Real(), assembly.Config{ID: "grpc-dup-ref", DurabilityMode: outbox.DurabilityDemo})
+	srvA := buildDrainAdapterServer(t)
+	srvB := buildDrainAdapterServer(t)
+
+	// Two listeners registered with the same ref.
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		healthListenerOpt(t),
+		WithGRPCListener(cell.PrimaryListener, srvA, ":0"),
+		WithGRPCListener(cell.PrimaryListener, srvB, ":0"),
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- b.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "duplicate")
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not fail-fast on duplicate ref")
+	}
+}
+
+// --- Case 4: CellID mismatch → fail-fast ------------------------------------
+
+func TestGRPCDrain_CellIDMismatch_FailFast(t *testing.T) {
+	const cellID = "grpc-cellid-mismatch"
+	lis := bufconn.Listen(grpcTestBufSize)
+	// The cell registers a spec with a different CellID than the snapshot key.
+	asm := drainTestAssembly(t, cellID, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {})
+	// Patch the cell so its spec has a mismatched CellID.
+	c := &grpcDrainCell{id: cellID, ref: cell.PrimaryListener, overrideCellID: "wrong-cell"}
+	asm2 := assembly.New(clock.Real(), assembly.Config{ID: cellID + "2", DurabilityMode: outbox.DurabilityDemo})
+	// We use a different approach: use a cell that registers the spec with wrong CellID.
+	require.NoError(t, asm2.Register(c))
+
+	srv := buildDrainAdapterServer(t)
+	b := New(
+		clock.Real(),
+		WithAssembly(asm2),
+		healthListenerOpt(t),
+		WithGRPCListener(cell.PrimaryListener, srv, ":0", WithGRPCListenerNet(lis)),
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- b.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "CellID")
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not fail-fast on CellID mismatch")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// grpcDrainCell — minimal Cell implementation for drain tests.
+// ---------------------------------------------------------------------------
+
+type grpcDrainCell struct {
+	cell.BaseCell
+	id             string
+	ref            cell.ListenerRef
+	registerFn     func(grpc.ServiceRegistrar)
+	overrideCellID string // non-empty → use this CellID in the spec (mismatch test)
+}
+
+func (c *grpcDrainCell) Init(_ context.Context, reg cell.Registrar) error {
+	cellID := c.id
+	if c.overrideCellID != "" {
+		cellID = c.overrideCellID
+	}
+	spec := cell.GRPCServiceSpec{
+		ContractID: "grpc." + c.id + ".v1",
+		CellID:     cellID,
+		Listener:   c.ref,
+		Register:   c.registerFn,
+	}
+	return reg.GRPCService(spec)
+}

--- a/runtime/bootstrap/grpc_drain_test.go
+++ b/runtime/bootstrap/grpc_drain_test.go
@@ -8,11 +8,14 @@ package bootstrap
 //   2. undeclared listener ref → fail-fast
 //   3. duplicate gRPC listener ref → fail-fast
 //   4. CellID mismatch → fail-fast
-//   5. registration precedes Serve (services callable immediately after Run starts)
+//   5. registration precedes Serve — spy GRPCServiceRegistrar records ordering
+//   6. multi-listener routing: two cells, two refs, each service only on its listener
+//   7. F2 fix: cell declares GRPCServices + zero WithGRPCListener → fail-fast
 
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -250,4 +253,250 @@ func (c *grpcDrainCell) Init(ctx context.Context, reg cell.Registrar) error {
 		Register:   c.registerFn,
 	}
 	return reg.GRPCService(spec)
+}
+
+// ---------------------------------------------------------------------------
+// Case 5: registration precedes Serve — spy GRPCServiceRegistrar
+// ---------------------------------------------------------------------------
+
+// spyGRPCServer is a GRPCServer that records whether Register was called before
+// the first Serve call. It wraps a real adapters/grpc.Server so the spy can
+// observe ordering while the real server handles actual gRPC traffic.
+type spyGRPCServer struct {
+	// inner is the real server; calls are always forwarded.
+	inner GRPCServer
+	// registeredBeforeServe is set to 1 atomically the moment Register is
+	// invoked; Serve checks the flag to verify ordering.
+	registeredBeforeServe atomic.Int32
+	// serveStarted is closed when Serve is first called.
+	serveStarted chan struct{}
+	// serveOnce guards serveStarted close.
+	serveOnce atomic.Int32
+}
+
+func (s *spyGRPCServer) Registrar() GRPCServiceRegistrar {
+	return &spyGRPCServiceRegistrar{inner: s.inner.Registrar(), spy: s}
+}
+
+func (s *spyGRPCServer) Serve(ctx context.Context, lis net.Listener) error {
+	if s.serveOnce.CompareAndSwap(0, 1) {
+		close(s.serveStarted)
+	}
+	return s.inner.Serve(ctx, lis)
+}
+
+func (s *spyGRPCServer) Close(ctx context.Context) error {
+	return s.inner.Close(ctx)
+}
+
+// spyGRPCServiceRegistrar records that Register was called, then forwards.
+type spyGRPCServiceRegistrar struct {
+	inner GRPCServiceRegistrar
+	spy   *spyGRPCServer
+}
+
+func (r *spyGRPCServiceRegistrar) Register(spec cell.GRPCServiceSpec) error {
+	r.spy.registeredBeforeServe.Store(1)
+	return r.inner.Register(spec)
+}
+
+// TestGRPCDrain_RegistrationPrecedesServe verifies that bootstrap calls
+// Register on each service BEFORE the gRPC server's Serve goroutine starts,
+// so services are reachable from the very first accepted connection (no race).
+//
+// This test pins the key safety invariant: grpc-go fatals if RegisterService
+// is called after Serve has started; the drain ordering (phase7b: register →
+// grpcServeAll) must hold.
+func TestGRPCDrain_RegistrationPrecedesServe(t *testing.T) {
+	const cellID = "grpc-order-spy"
+	lis := bufconn.Listen(grpcTestBufSize)
+
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	realSrv := buildDrainAdapterServer(t)
+	spy := &spyGRPCServer{inner: realSrv, serveStarted: make(chan struct{})}
+
+	asm := drainTestAssembly(t, cellID, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, healthSrv)
+	})
+
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		healthListenerOpt(t),
+		WithGRPCListener(cell.PrimaryListener, spy, ":0", WithGRPCListenerNet(lis)),
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	// Wait for Serve to start (so the ordering window is observable).
+	select {
+	case <-spy.serveStarted:
+	case <-time.After(testtime.D5s):
+		t.Fatal("spy Serve was never called")
+	}
+
+	// Assert: Register must have been called BEFORE Serve.
+	assert.Equal(t, int32(1), spy.registeredBeforeServe.Load(),
+		"Register must be called before Serve starts")
+
+	// Also verify the service is actually reachable (defense-in-depth).
+	cc := grpcBufDial(t, lis)
+	defer func() { _ = cc.Close() }()
+	testwait.External(t, "grpc-spy-serving", func() bool {
+		rctx, rcancel := context.WithTimeout(context.Background(), testtime.D2s)
+		defer rcancel()
+		resp, err := grpc_health_v1.NewHealthClient(cc).Check(rctx, &grpc_health_v1.HealthCheckRequest{})
+		return err == nil && resp.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
+	}, testtime.EventuallyDefault, testtime.MediumPoll, "gRPC health must be SERVING after drain")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Case 6: multi-listener routing
+// ---------------------------------------------------------------------------
+
+// TestGRPCDrain_MultiListenerRouting verifies that when two cells each declare
+// a GRPCServiceSpec on a DIFFERENT ListenerRef, each service is reachable only
+// on its declared listener (correct routing) and unreachable on the other.
+func TestGRPCDrain_MultiListenerRouting(t *testing.T) {
+	const (
+		cellA = "grpc-multi-a"
+		cellB = "grpc-multi-b"
+	)
+	lisA := bufconn.Listen(grpcTestBufSize)
+	lisB := bufconn.Listen(grpcTestBufSize)
+
+	// Cell A registers the gRPC Health service on PrimaryListener.
+	healthSrvA := health.NewServer()
+	healthSrvA.SetServingStatus("cell-a", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// Cell B registers a synthetic no-op service on InternalListener.
+	// We use a different grpc.ServiceDesc ServiceName to distinguish the two.
+	const bServiceName = "test.CellBService"
+	bDesc := &grpc.ServiceDesc{
+		ServiceName: bServiceName,
+		HandlerType: (*any)(nil),
+		Methods: []grpc.MethodDesc{{
+			MethodName: "Ping",
+			Handler: func(_ any, ctx context.Context, _ func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+			},
+		}},
+	}
+
+	// Assembly with two cells, each targeting a different listener.
+	asm := assembly.New(clock.Real(), assembly.Config{ID: cellA + cellB, DurabilityMode: outbox.DurabilityDemo})
+	cA := newGRPCDrainCell(t, cellA, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, healthSrvA)
+	})
+	cB := newGRPCDrainCell(t, cellB, cell.InternalListener, func(r grpc.ServiceRegistrar) {
+		r.RegisterService(bDesc, struct{}{})
+	})
+	require.NoError(t, asm.Register(cA))
+	require.NoError(t, asm.Register(cB))
+
+	srvA := buildDrainAdapterServer(t)
+	srvB := buildDrainAdapterServer(t)
+
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		healthListenerOpt(t),
+		WithGRPCListener(cell.PrimaryListener, srvA, ":0", WithGRPCListenerNet(lisA)),
+		WithGRPCListener(cell.InternalListener, srvB, ":0", WithGRPCListenerNet(lisB)),
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+
+	ccA := grpcBufDial(t, lisA)
+	defer func() { _ = ccA.Close() }()
+	ccB := grpcBufDial(t, lisB)
+	defer func() { _ = ccB.Close() }()
+
+	// Cell A's Health service is reachable on lisA.
+	testwait.External(t, "grpc-multi-a-serving", func() bool {
+		rctx, rcancel := context.WithTimeout(context.Background(), testtime.D2s)
+		defer rcancel()
+		resp, err := grpc_health_v1.NewHealthClient(ccA).Check(rctx,
+			&grpc_health_v1.HealthCheckRequest{Service: "cell-a"})
+		return err == nil && resp.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING
+	}, testtime.EventuallyDefault, testtime.MediumPoll, "cell-a health must be SERVING on lisA")
+
+	// Cell B's Ping service is reachable on lisB.
+	testwait.External(t, "grpc-multi-b-serving", func() bool {
+		rctx, rcancel := context.WithTimeout(context.Background(), testtime.D2s)
+		defer rcancel()
+		var resp grpc_health_v1.HealthCheckResponse
+		err := ccB.Invoke(rctx, "/"+bServiceName+"/Ping",
+			&grpc_health_v1.HealthCheckRequest{}, &resp)
+		return err == nil
+	}, testtime.EventuallyDefault, testtime.MediumPoll, "cell-b Ping must be reachable on lisB")
+
+	// Cell A's Health service is NOT registered on lisB (different listener).
+	rctx, rcancel := context.WithTimeout(context.Background(), testtime.D500ms)
+	defer rcancel()
+	_, errHealthOnB := grpc_health_v1.NewHealthClient(ccB).Check(rctx,
+		&grpc_health_v1.HealthCheckRequest{Service: "cell-a"})
+	// grpc-go returns "unknown service grpc.health.v1.Health" when the service
+	// is not registered; we expect a non-nil error here.
+	assert.Error(t, errHealthOnB, "cell-a Health service must NOT be reachable on cell-b's listener")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Case 7: F2 fix — GRPCServices declared but no WithGRPCListener → fail-fast
+// ---------------------------------------------------------------------------
+
+// TestGRPCDrain_OrphanServices_FailFast verifies that when a cell declares
+// GRPCServiceSpec(s) but the composition root adds no WithGRPCListener, Run
+// returns a descriptive error instead of silently dropping the services.
+func TestGRPCDrain_OrphanServices_FailFast(t *testing.T) {
+	const cellID = "grpc-orphan"
+	// Cell declares a GRPCServiceSpec; bootstrap has no gRPC listener at all.
+	asm := drainTestAssembly(t, cellID, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, health.NewServer())
+	})
+
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		healthListenerOpt(t),
+		// Intentionally NO WithGRPCListener.
+		WithShutdownTimeout(testtime.D2s),
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- b.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "orphan gRPC services must cause a fail-fast error")
+		assert.ErrorContains(t, err, "gRPC service",
+			"error must identify the orphan gRPC service situation")
+		assert.ErrorContains(t, err, cellID,
+			"error must name the cell with orphan services")
+	case <-time.After(testtime.D5s):
+		t.Fatal("Run did not fail-fast on orphan gRPC services")
+	}
 }

--- a/runtime/bootstrap/grpc_drain_test.go
+++ b/runtime/bootstrap/grpc_drain_test.go
@@ -265,9 +265,15 @@ func (c *grpcDrainCell) Init(ctx context.Context, reg cell.Registrar) error {
 type spyGRPCServer struct {
 	// inner is the real server; calls are always forwarded.
 	inner GRPCServer
-	// registeredBeforeServe is set to 1 atomically the moment Register is
-	// invoked; Serve checks the flag to verify ordering.
+	// registeredBeforeServe is set to 1 atomically the moment Register is invoked.
 	registeredBeforeServe atomic.Int32
+	// registeredAtServe captures registeredBeforeServe's value at the exact
+	// instant Serve begins. The assertion reads THIS snapshot — not the live
+	// registeredBeforeServe flag — to avoid a false positive: a regressed
+	// register-after-Serve implementation could still flip the live flag to 1
+	// between the test observing serveStarted and reading the flag. The snapshot
+	// pins the value as-of Serve entry.
+	registeredAtServe atomic.Int32
 	// serveStarted is closed when Serve is first called.
 	serveStarted chan struct{}
 	// serveOnce guards serveStarted close.
@@ -280,6 +286,10 @@ func (s *spyGRPCServer) Registrar() GRPCServiceRegistrar {
 
 func (s *spyGRPCServer) Serve(ctx context.Context, lis net.Listener) error {
 	if s.serveOnce.CompareAndSwap(0, 1) {
+		// Snapshot the registration flag BEFORE signaling serveStarted, so the
+		// asserted value is fixed at Serve entry and cannot be tainted by a later
+		// (regressed) registration.
+		s.registeredAtServe.Store(s.registeredBeforeServe.Load())
 		close(s.serveStarted)
 	}
 	return s.inner.Serve(ctx, lis)
@@ -340,9 +350,11 @@ func TestGRPCDrain_RegistrationPrecedesServe(t *testing.T) {
 		t.Fatal("spy Serve was never called")
 	}
 
-	// Assert: Register must have been called BEFORE Serve.
-	assert.Equal(t, int32(1), spy.registeredBeforeServe.Load(),
-		"Register must be called before Serve starts")
+	// Assert: Register must have been called BEFORE Serve. Read the snapshot
+	// captured at Serve entry (not the live flag) so a register-after-Serve
+	// regression cannot pass by flipping the flag after serveStarted fires.
+	assert.Equal(t, int32(1), spy.registeredAtServe.Load(),
+		"Register must be called before Serve starts (snapshot at Serve entry)")
 
 	// Also verify the service is actually reachable (defense-in-depth).
 	cc := grpcBufDial(t, lis)

--- a/runtime/bootstrap/grpc_drain_test.go
+++ b/runtime/bootstrap/grpc_drain_test.go
@@ -26,9 +26,9 @@ import (
 
 	adaptersgrpc "github.com/ghbvf/gocell/adapters/grpc"
 	"github.com/ghbvf/gocell/kernel/assembly"
-	kauth "github.com/ghbvf/gocell/kernel/auth"
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
@@ -73,12 +73,19 @@ func grpcBufDial(t *testing.T, lis *bufconn.Listener) *grpc.ClientConn {
 	return cc
 }
 
+// newGRPCDrainCell constructs a grpcDrainCell with a properly initialized BaseCell.
+func newGRPCDrainCell(t *testing.T, id string, ref cell.ListenerRef, registerFn func(grpc.ServiceRegistrar)) *grpcDrainCell {
+	t.Helper()
+	base := cell.MustNewBaseCell(&metadata.CellMeta{ID: id})
+	return &grpcDrainCell{BaseCell: base, id: id, ref: ref, registerFn: registerFn}
+}
+
 // drainTestAssembly builds a CoreAssembly containing one stub cell that
 // registers a GRPCServiceSpec targeting the given listener ref.
 func drainTestAssembly(t *testing.T, id string, ref cell.ListenerRef, registerFn func(grpc.ServiceRegistrar)) *assembly.CoreAssembly {
 	t.Helper()
 	asm := assembly.New(clock.Real(), assembly.Config{ID: id, DurabilityMode: outbox.DurabilityDemo})
-	c := &grpcDrainCell{id: id, ref: ref, registerFn: registerFn}
+	c := newGRPCDrainCell(t, id, ref, registerFn)
 	require.NoError(t, asm.Register(c))
 	return asm
 }
@@ -110,7 +117,7 @@ func TestGRPCDrain_HappyPath(t *testing.T) {
 	go func() { done <- b.Run(ctx) }()
 
 	cc := grpcBufDial(t, lis)
-	defer cc.Close()
+	defer func() { _ = cc.Close() }()
 
 	// Wait for health to be SERVING (proves service was registered before Serve).
 	testwait.External(t, "grpc-drain-serving", func() bool {
@@ -191,11 +198,9 @@ func TestGRPCDrain_CellIDMismatch_FailFast(t *testing.T) {
 	const cellID = "grpc-cellid-mismatch"
 	lis := bufconn.Listen(grpcTestBufSize)
 	// The cell registers a spec with a different CellID than the snapshot key.
-	asm := drainTestAssembly(t, cellID, cell.PrimaryListener, func(r grpc.ServiceRegistrar) {})
-	// Patch the cell so its spec has a mismatched CellID.
-	c := &grpcDrainCell{id: cellID, ref: cell.PrimaryListener, overrideCellID: "wrong-cell"}
+	base := cell.MustNewBaseCell(&metadata.CellMeta{ID: cellID})
+	c := &grpcDrainCell{BaseCell: base, id: cellID, ref: cell.PrimaryListener, overrideCellID: "wrong-cell"}
 	asm2 := assembly.New(clock.Real(), assembly.Config{ID: cellID + "2", DurabilityMode: outbox.DurabilityDemo})
-	// We use a different approach: use a cell that registers the spec with wrong CellID.
 	require.NoError(t, asm2.Register(c))
 
 	srv := buildDrainAdapterServer(t)
@@ -223,14 +228,17 @@ func TestGRPCDrain_CellIDMismatch_FailFast(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type grpcDrainCell struct {
-	cell.BaseCell
+	*cell.BaseCell
 	id             string
 	ref            cell.ListenerRef
 	registerFn     func(grpc.ServiceRegistrar)
 	overrideCellID string // non-empty → use this CellID in the spec (mismatch test)
 }
 
-func (c *grpcDrainCell) Init(_ context.Context, reg cell.Registrar) error {
+func (c *grpcDrainCell) Init(ctx context.Context, reg cell.Registrar) error {
+	if err := c.BaseCell.Init(ctx, reg); err != nil {
+		return err
+	}
 	cellID := c.id
 	if c.overrideCellID != "" {
 		cellID = c.overrideCellID

--- a/runtime/bootstrap/grpc_listener.go
+++ b/runtime/bootstrap/grpc_listener.go
@@ -82,9 +82,10 @@ func WithGRPCListenerShutdownGrace(d time.Duration) GRPCListenerOption {
 //
 // ref identifies this listener so that cells can route their GRPCServiceSpecs
 // to the correct server via GRPCServiceSpec.Listener — fully symmetric with
-// HTTP's WithListener(ref, addr, authChain). Each ref must be unique across all
-// WithGRPCListener calls; a duplicate ref causes a fail-fast error in phase7b
-// when building the ref→boundGRPC routing map.
+// HTTP's WithListener(ref, addr, authChain). ref must be non-zero and unique
+// across all WithGRPCListener calls; a zero or duplicate ref is rejected at
+// phase0 (validateGRPCListenerConfigs), mirroring the HTTP listener ref gate,
+// before any socket binds.
 //
 // The server must be non-nil — both bare-nil and typed-nil are rejected at
 // phase0 with ErrGRPCServerMissing (mirroring WithRateLimiter / WithManagedResource).

--- a/runtime/bootstrap/grpc_listener.go
+++ b/runtime/bootstrap/grpc_listener.go
@@ -18,14 +18,22 @@ import (
 	"net"
 	"time"
 
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
+// GRPCServiceRegistrar is an alias for the kernel-defined interface; kept here
+// as a local name so existing test code (bootstrapTestFakeGRPCServer.Registrar()
+// returns GRPCServiceRegistrar) compiles without importing kernel/cell directly.
+// The canonical definition is cell.GRPCServiceRegistrar (kernel/cell/grpc_service.go).
+type GRPCServiceRegistrar = cell.GRPCServiceRegistrar
+
 // GRPCServer is the narrow lifecycle contract bootstrap needs from a gRPC
 // server. adapters/grpc.Server satisfies it (Serve serves a pre-bound listener;
-// Close gracefully drains in-flight RPCs bounded by the passed ctx). Defining it
-// here — rather than importing the adapter — keeps runtime/bootstrap free of any
-// adapters/ dependency (LAYER-03 / GRPC-ADAPTER-LAYER-01).
+// Close gracefully drains in-flight RPCs bounded by the passed ctx; Registrar
+// returns the cell-facing service registrar used by the drain in phase7b).
+// Defining it here — rather than importing the adapter — keeps runtime/bootstrap
+// free of any adapters/ dependency (LAYER-03 / GRPC-ADAPTER-LAYER-01).
 type GRPCServer interface {
 	// Serve serves RPCs on the pre-bound listener until ctx is canceled or the
 	// server stops (e.g. via Close). It blocks; bootstrap calls it in a goroutine.
@@ -33,11 +41,16 @@ type GRPCServer interface {
 	// Close initiates a graceful drain of in-flight RPCs bounded by ctx, hard
 	// stopping if the budget is exceeded. Idempotent.
 	Close(ctx context.Context) error
+	// Registrar returns the cell-facing service registrar. bootstrap calls
+	// Registrar().Register(spec) in phase7b for each GRPCServiceSpec drained from
+	// the cell snapshots, before grpcServeAll.
+	Registrar() GRPCServiceRegistrar
 }
 
 // grpcListenerConfig is the resolved per-gRPC-listener wiring captured by
 // WithGRPCListener and consumed by phase7b (serve) + phase10 stage2 (drain).
 type grpcListenerConfig struct {
+	ref       cell.ListenerRef // identity for routing cell GRPCServiceSpecs (GAP-1 PR-7)
 	server    GRPCServer
 	addr      string
 	net       net.Listener  // optional pre-bound socket (bufconn/test); nil → bootstrap binds addr
@@ -63,14 +76,19 @@ func WithGRPCListenerShutdownGrace(d time.Duration) GRPCListenerOption {
 }
 
 // WithGRPCListener declares a gRPC listener served on addr by the
-// composition-root-constructed server. The server must be non-nil — both
-// bare-nil and typed-nil are rejected at phase0 with ErrGRPCServerMissing
-// (strong-dependency wiring option, mirroring WithRateLimiter / WithManagedResource).
+// composition-root-constructed server (GAP-1 PR-7 [#1150]).
 //
-// The server is expected to already have its interceptor chain wired and its
-// services registered before being passed here. bootstrap drives Serve in
-// phase7b (in parallel with HTTP) and Close in phase10 stage2 (before LIFO
-// teardown, so in-flight RPCs drain while backends are alive).
+// ref identifies this listener so that cells can route their GRPCServiceSpecs
+// to the correct server via GRPCServiceSpec.Listener — fully symmetric with
+// HTTP's WithListener(ref, addr, authChain). Each ref must be unique across all
+// WithGRPCListener calls; a duplicate ref causes a fail-fast error in phase7b
+// when building the ref→boundGRPC routing map.
+//
+// The server must be non-nil — both bare-nil and typed-nil are rejected at
+// phase0 with ErrGRPCServerMissing (mirroring WithRateLimiter / WithManagedResource).
+// bootstrap drives Serve in phase7b (in parallel with HTTP) and Close in
+// phase10 stage2 (before LIFO teardown, so in-flight RPCs drain while backends
+// are alive).
 //
 // Composition-root wiring (cmd/ or examples/, which may import adapters/grpc and
 // runtime/grpc/interceptor — cells/ may not):
@@ -82,15 +100,19 @@ func WithGRPCListenerShutdownGrace(d time.Duration) GRPCListenerOption {
 //	    Addr: ":9000", TLS: tlsCfg,
 //	    ServerOptions: []grpc.ServerOption{chain},
 //	})
-//	// register services on srv.ServiceRegistrar() ...
-//	bootstrap.New(clk, bootstrap.WithGRPCListener(srv, ":9000"))
-func WithGRPCListener(server GRPCServer, addr string, opts ...GRPCListenerOption) Option {
+//	bootstrap.New(clk, bootstrap.WithGRPCListener(cell.PrimaryListener, srv, ":9000"))
+//
+// Cell services are drained from RegistrySnapshot.GRPCServices in phase7b
+// (after binding, before grpcServeAll) and registered via
+// server.Registrar().Register(spec) — the stopgap of pre-passing registered
+// services is replaced by this drain.
+func WithGRPCListener(ref cell.ListenerRef, server GRPCServer, addr string, opts ...GRPCListenerOption) Option {
 	return func(b *Bootstrap) {
 		if validation.IsNilInterface(server) {
 			b.grpcServerNil = true // sentinel → phase0 fail-fast
 			return
 		}
-		cfg := grpcListenerConfig{server: server, addr: addr}
+		cfg := grpcListenerConfig{ref: ref, server: server, addr: addr}
 		for _, o := range opts {
 			o(&cfg)
 		}

--- a/runtime/bootstrap/grpc_listener.go
+++ b/runtime/bootstrap/grpc_listener.go
@@ -22,10 +22,12 @@ import (
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
-// GRPCServiceRegistrar is an alias for the kernel-defined interface; kept here
-// as a local name so existing test code (bootstrapTestFakeGRPCServer.Registrar()
-// returns GRPCServiceRegistrar) compiles without importing kernel/cell directly.
-// The canonical definition is cell.GRPCServiceRegistrar (kernel/cell/grpc_service.go).
+// GRPCServiceRegistrar is a local alias for [cell.GRPCServiceRegistrar] (the
+// canonical definition in kernel/cell/grpc_service.go). The alias lets the
+// bootstrap-package [GRPCServer] interface and bootstrap-package tests name the
+// type without an additional import path; the canonical definition lives in
+// kernel/cell so both adapters/grpc and bootstrap can import it without an
+// import cycle.
 type GRPCServiceRegistrar = cell.GRPCServiceRegistrar
 
 // GRPCServer is the narrow lifecycle contract bootstrap needs from a gRPC

--- a/runtime/bootstrap/grpc_listener_test.go
+++ b/runtime/bootstrap/grpc_listener_test.go
@@ -375,23 +375,40 @@ func TestWithGRPCListener_BindFailure_DrainsHTTP(t *testing.T) {
 func TestWithGRPCListener_Phase0ConfigValidation(t *testing.T) {
 	cases := []struct {
 		name string
-		opt  Option
+		opts []Option
 		want string
 	}{
 		{
 			name: "negative_shutdown_grace",
-			opt:  WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ":0", WithGRPCListenerShutdownGrace(-testtime.D2s)),
+			opts: []Option{WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ":0", WithGRPCListenerShutdownGrace(-testtime.D2s))},
 			want: "negative shutdownGrace",
 		},
 		{
 			name: "empty_addr_no_net",
-			opt:  WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ""),
+			opts: []Option{WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, "")},
 			want: "non-empty addr or a pre-bound listener",
+		},
+		{
+			// F4: a zero ListenerRef can never be targeted by GRPCServiceSpec.Listener,
+			// so the cell's services would be silently dropped. Reject at phase0.
+			name: "zero_ref",
+			opts: []Option{WithGRPCListener(cell.ListenerRef{}, stubGRPCServer{}, ":0")},
+			want: "zero gRPC listener ref",
+		},
+		{
+			// F4: two WithGRPCListener calls sharing a ref make spec routing
+			// ambiguous; reject at phase0 rather than in phase7b after sockets bind.
+			name: "duplicate_ref",
+			opts: []Option{
+				WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ":0"),
+				WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ":0"),
+			},
+			want: "duplicate WithGRPCListener call for ref",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := New(clock.Real(), tc.opt)
+			b := New(clock.Real(), tc.opts...)
 			err := b.Run(context.Background())
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tc.want)

--- a/runtime/bootstrap/grpc_listener_test.go
+++ b/runtime/bootstrap/grpc_listener_test.go
@@ -47,8 +47,9 @@ const grpcTestBufSize = 1024 * 1024
 
 // buildAdapterServer constructs an adapters/grpc.Server with the full unary
 // interceptor chain wired (as the composition root would), registering the
-// caller-supplied services. authPublic, when non-nil, marks methods exempt from
-// the auth interceptor so RPCs can be issued without a bearer token.
+// caller-supplied services via the Form B Registrar path. authPublic, when
+// non-nil, marks methods exempt from the auth interceptor so RPCs can be issued
+// without a bearer token.
 func buildAdapterServer(
 	t *testing.T,
 	authPublic func(fullMethod string) bool,
@@ -72,7 +73,16 @@ func buildAdapterServer(
 	})
 	require.NoError(t, err)
 	if register != nil {
-		register(srv.ServiceRegistrar())
+		// Register via Form B callback using a synthetic spec (grpc_listener_test
+		// plays the composition-root role; it may import adapters/grpc and call
+		// Registrar() directly — identical to how cmd/ would wire things pre-cell).
+		spec := cell.GRPCServiceSpec{
+			ContractID: "grpc.listener.test.v1",
+			CellID:     "_listener-test",
+			Listener:   cell.PrimaryListener,
+			Register:   register,
+		}
+		require.NoError(t, srv.Registrar().Register(spec))
 	}
 	return srv
 }
@@ -121,6 +131,12 @@ type stubGRPCServer struct{}
 
 func (stubGRPCServer) Serve(context.Context, net.Listener) error { return nil }
 func (stubGRPCServer) Close(context.Context) error               { return nil }
+func (stubGRPCServer) Registrar() GRPCServiceRegistrar           { return &noopGRPCServiceRegistrar{} }
+
+// noopGRPCServiceRegistrar is a no-op GRPCServiceRegistrar for config-validation tests.
+type noopGRPCServiceRegistrar struct{}
+
+func (n *noopGRPCServiceRegistrar) Register(_ cell.GRPCServiceSpec) error { return nil }
 
 // --- Case 1: phase0 fail-fast on nil server -------------------------------
 
@@ -134,7 +150,7 @@ func TestWithGRPCListener_NilServer_Phase0FailFast(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := New(clock.Real(), WithGRPCListener(tc.server, ":0"))
+			b := New(clock.Real(), WithGRPCListener(cell.PrimaryListener, tc.server, ":0"))
 			err := b.Run(context.Background())
 			require.Error(t, err)
 			assert.ErrorContains(t, err, string(errcode.ErrGRPCServerMissing),
@@ -154,7 +170,7 @@ func TestWithGRPCListener_HappyPath_ServeThenGracefulStop(t *testing.T) {
 		clock.Real(),
 		WithAssembly(asm),
 		healthListenerOpt(t),
-		WithGRPCListener(srv, ":0", WithGRPCListenerNet(lis)),
+		WithGRPCListener(cell.PrimaryListener, srv, ":0", WithGRPCListenerNet(lis)),
 		WithShutdownTimeout(testtime.D2s),
 	)
 
@@ -195,7 +211,7 @@ func TestBootstrap_HTTPAndGRPC_ConcurrentServe_ErrorPropagation(t *testing.T) {
 		clock.Real(),
 		WithAssembly(asm),
 		healthListenerOpt(t),
-		WithGRPCListener(srv, ":0", WithGRPCListenerNet(lis)),
+		WithGRPCListener(cell.PrimaryListener, srv, ":0", WithGRPCListenerNet(lis)),
 		WithShutdownTimeout(testtime.D2s),
 	)
 
@@ -221,8 +237,8 @@ func TestWithGRPCListener_TwoListeners_BothServeAndDrain(t *testing.T) {
 		clock.Real(),
 		WithAssembly(asm),
 		healthListenerOpt(t),
-		WithGRPCListener(buildAdapterServer(t, healthPublic, registerHealth), ":0", WithGRPCListenerNet(lisA)),
-		WithGRPCListener(buildAdapterServer(t, healthPublic, registerHealth), ":0", WithGRPCListenerNet(lisB)),
+		WithGRPCListener(cell.PrimaryListener, buildAdapterServer(t, healthPublic, registerHealth), ":0", WithGRPCListenerNet(lisA)),
+		WithGRPCListener(cell.InternalListener, buildAdapterServer(t, healthPublic, registerHealth), ":0", WithGRPCListenerNet(lisB)),
 		WithShutdownTimeout(testtime.D2s),
 	)
 
@@ -283,7 +299,7 @@ func TestGRPCDrain_BudgetExceeded_HardStop(t *testing.T) {
 		clock.Real(),
 		WithAssembly(asm),
 		healthListenerOpt(t),
-		WithGRPCListener(srv, ":0",
+		WithGRPCListener(cell.PrimaryListener, srv, ":0",
 			WithGRPCListenerNet(lis),
 			WithGRPCListenerShutdownGrace(testtime.D50ms),
 		),
@@ -338,7 +354,7 @@ func TestWithGRPCListener_BindFailure_DrainsHTTP(t *testing.T) {
 		clock.Real(),
 		WithAssembly(asm),
 		healthListenerOpt(t),
-		WithGRPCListener(srv, occupied.Addr().String()), // no WithGRPCListenerNet → net.Listen on occupied addr
+		WithGRPCListener(cell.PrimaryListener, srv, occupied.Addr().String()), // no WithGRPCListenerNet → net.Listen on occupied addr
 		WithShutdownTimeout(testtime.D2s),
 	)
 
@@ -364,12 +380,12 @@ func TestWithGRPCListener_Phase0ConfigValidation(t *testing.T) {
 	}{
 		{
 			name: "negative_shutdown_grace",
-			opt:  WithGRPCListener(stubGRPCServer{}, ":0", WithGRPCListenerShutdownGrace(-testtime.D2s)),
+			opt:  WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ":0", WithGRPCListenerShutdownGrace(-testtime.D2s)),
 			want: "negative shutdownGrace",
 		},
 		{
 			name: "empty_addr_no_net",
-			opt:  WithGRPCListener(stubGRPCServer{}, ""),
+			opt:  WithGRPCListener(cell.PrimaryListener, stubGRPCServer{}, ""),
 			want: "non-empty addr or a pre-bound listener",
 		},
 	}

--- a/runtime/bootstrap/grpc_serve.go
+++ b/runtime/bootstrap/grpc_serve.go
@@ -40,7 +40,7 @@ type boundGRPC struct {
 // otherwise leak the serving HTTP goroutines.
 func (b *Bootstrap) phase7bStartGRPCServers(serveCtx context.Context, s *phaseState) error {
 	if len(b.grpcListenerConfigs) == 0 {
-		return nil
+		return b.checkOrphanGRPCServices(s)
 	}
 
 	bounds := make([]boundGRPC, 0, len(b.grpcListenerConfigs))
@@ -232,6 +232,29 @@ func drainAllGRPCServers(parent context.Context, bounds []boundGRPC) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// checkOrphanGRPCServices is called when no WithGRPCListener was configured. If
+// any cell snapshot has a non-empty GRPCServices slice it means a cell called
+// reg.GRPCService but the composition root forgot to add WithGRPCListener — a
+// silent data-loss bug. Fail-fast to surface the misconfiguration, mirroring the
+// HTTP undeclared-listener fail-fast intent.
+func (b *Bootstrap) checkOrphanGRPCServices(s *phaseState) error {
+	if s.asm == nil || len(s.cellSnapshots) == 0 {
+		return nil
+	}
+	for _, id := range s.asm.CellIDs() {
+		snap, ok := s.cellSnapshots[id]
+		if !ok {
+			continue
+		}
+		if n := len(snap.GRPCServices); n > 0 {
+			return fmt.Errorf("bootstrap: cell %q declares %d gRPC service(s) but no "+
+				"WithGRPCListener is configured; add WithGRPCListener(ref, server, addr) "+
+				"to bootstrap options", id, n)
+		}
+	}
+	return nil
 }
 
 // drainHTTPOnGRPCStartFailure drains the HTTP servers started in phase7 when a

--- a/runtime/bootstrap/grpc_serve.go
+++ b/runtime/bootstrap/grpc_serve.go
@@ -17,6 +17,8 @@ import (
 	"log/slog"
 	"net"
 	"sync/atomic"
+
+	"github.com/ghbvf/gocell/kernel/cell"
 )
 
 // boundGRPC pairs a resolved gRPC listener config with its bound socket.
@@ -56,8 +58,94 @@ func (b *Bootstrap) phase7bStartGRPCServers(serveCtx context.Context, s *phaseSt
 		bounds = append(bounds, boundGRPC{cfg: gc, lis: lis, owned: owned})
 	}
 
+	// Drain cell GRPCServiceSpecs: AFTER binding, BEFORE grpcServeAll, so
+	// services are reachable from the first accepted connection. This replaces
+	// the PR-5 stopgap of pre-registering services before bootstrap.Run.
+	if err := b.drainCellGRPCServices(s, bounds); err != nil {
+		closeOwnedGRPCSockets(bounds)
+		b.drainHTTPOnGRPCStartFailure(s)
+		return err
+	}
+
 	s.grpcErrCh = b.grpcServeAll(serveCtx, bounds)
 	s.grpcDrain = func(ctx context.Context) error { return drainAllGRPCServers(ctx, bounds) }
+	return nil
+}
+
+// drainCellGRPCServices drains GRPCServiceSpecs from all cell snapshots and
+// routes each to the gRPC listener identified by spec.Listener. Called in
+// phase7b after binding but before grpcServeAll (GAP-1 PR-7 [#1150]).
+//
+// Fail-fast conditions (mirroring the HTTP phase5 + subscription drain patterns):
+//   - duplicate ref across gRPC listeners (ambiguous routing)
+//   - spec.CellID != snapshot key (config bug — mirrors subscription drain check)
+//   - spec.Listener ref not found in the bound gRPC listener set (undeclared listener)
+//
+// ref: runtime/bootstrap/phases_http.go phase4CollectRouteGroups + phase5MountRouteGroups
+// ref: runtime/bootstrap/phases_events.go drainCellSubscriptions
+func (b *Bootstrap) drainCellGRPCServices(s *phaseState, bounds []boundGRPC) error {
+	refMap, err := buildGRPCRefMap(bounds)
+	if err != nil {
+		return err
+	}
+	if s.asm == nil || len(s.cellSnapshots) == 0 {
+		return nil
+	}
+	for _, id := range s.asm.CellIDs() {
+		snap, ok := s.cellSnapshots[id]
+		if !ok {
+			continue
+		}
+		if err := registerCellGRPCServices(id, snap.GRPCServices, refMap); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildGRPCRefMap builds a map from ListenerRef to boundGRPC. Returns an error
+// when two configs share the same ref (duplicate ref is a config bug).
+func buildGRPCRefMap(bounds []boundGRPC) (map[cell.ListenerRef]*boundGRPC, error) {
+	refMap := make(map[cell.ListenerRef]*boundGRPC, len(bounds))
+	for i := range bounds {
+		bd := &bounds[i]
+		if _, dup := refMap[bd.cfg.ref]; dup {
+			return nil, fmt.Errorf("bootstrap: duplicate gRPC listener ref %q; "+
+				"each WithGRPCListener must use a distinct cell.ListenerRef",
+				bd.cfg.ref.String())
+		}
+		refMap[bd.cfg.ref] = bd
+	}
+	return refMap, nil
+}
+
+// registerCellGRPCServices routes each spec from a single cell snapshot to its
+// target listener and calls Register. Returns on first error.
+func registerCellGRPCServices(cellID string, specs []cell.GRPCServiceSpec, refMap map[cell.ListenerRef]*boundGRPC) error {
+	for _, spec := range specs {
+		if spec.CellID != cellID {
+			return fmt.Errorf("bootstrap: gRPC service spec CellID mismatch: "+
+				"spec.CellID=%q does not match snapshot key %q "+
+				"(cell must use its own ID in GRPCServiceSpec)",
+				spec.CellID, cellID)
+		}
+		bd, ok := refMap[spec.Listener]
+		if !ok {
+			return fmt.Errorf("bootstrap: gRPC service %q (cell %q) references "+
+				"undeclared listener ref %q; add WithGRPCListener(%s, server, addr) "+
+				"to bootstrap options",
+				spec.ContractID, cellID, spec.Listener.String(), spec.Listener.String())
+		}
+		if err := bd.cfg.server.Registrar().Register(spec); err != nil {
+			return fmt.Errorf("bootstrap: failed to register gRPC service %q "+
+				"(cell %q, listener %q): %w",
+				spec.ContractID, cellID, spec.Listener.String(), err)
+		}
+		slog.Info("bootstrap: registered gRPC service",
+			slog.String("contractID", spec.ContractID),
+			slog.String("cellID", cellID),
+			slog.String("listener", spec.Listener.String()))
+	}
 	return nil
 }
 

--- a/runtime/bootstrap/phases_assembly.go
+++ b/runtime/bootstrap/phases_assembly.go
@@ -113,12 +113,32 @@ func (b *Bootstrap) validateNilDependencySentinels() error {
 	return nil
 }
 
-// validateGRPCListenerConfigs rejects per-listener shutdown-grace budgets that
-// are negative, mirroring the HTTP validateListenerConfig shutGrace check. A
-// negative budget would make the drain ctx expire immediately, silently
-// degrading every graceful stop into a hard stop.
+// validateGRPCListenerConfigs phase0-validates every declared gRPC listener,
+// inheriting the same ref discipline as the HTTP listener gate so a
+// misconfiguration surfaces before any socket binds (not in phase7b after HTTP
+// has already started serving). It rejects:
+//
+//   - a zero ListenerRef — no GRPCServiceSpec.Listener can target it, so the
+//     cell's services would be silently dropped (mirrors validateListenerConfig).
+//   - a duplicate ref across WithGRPCListener calls — ambiguous spec routing
+//     (mirrors validateNoDuplicateListenerRefs; phase7b's buildGRPCRefMap is the
+//     later lifecycle backstop, now unreachable in normal startup).
+//   - a listener with neither addr nor a pre-bound socket — cannot bind.
+//   - a negative per-listener shutdown-grace budget — would degrade every
+//     graceful stop into an immediate hard stop.
 func (b *Bootstrap) validateGRPCListenerConfigs() error {
+	seen := make(map[cell.ListenerRef]struct{}, len(b.grpcListenerConfigs))
 	for _, gc := range b.grpcListenerConfigs {
+		if gc.ref.IsZero() {
+			return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+				"bootstrap: zero gRPC listener ref is invalid; use cell.PrimaryListener, "+
+					"cell.InternalListener, or another declared ref")
+		}
+		if _, dup := seen[gc.ref]; dup {
+			return fmt.Errorf("bootstrap: duplicate WithGRPCListener call for ref %q;"+
+				" each gRPC listener ref may only be declared once", gc.ref.String())
+		}
+		seen[gc.ref] = struct{}{}
 		// Mirror HTTP validateListenerConfig: a listener with neither an addr nor
 		// a pre-bound socket cannot bind. Fail fast at phase0 rather than letting
 		// net.Listen("tcp", "") fail in phase7b after HTTP has already started.

--- a/runtime/grpc/registrar.go
+++ b/runtime/grpc/registrar.go
@@ -1,0 +1,164 @@
+package grpc
+
+// registrar.go — Cell-facing gRPC service registration seam (GAP-1 PR-7 [#1150]).
+//
+// This is the single public registration path for gRPC services in GoCell.
+// The key design decisions:
+//
+//  1. ServiceRegistrar does NOT implement grpc.ServiceRegistrar — there is only ONE
+//     public registration entry (Register(spec)), preventing raw RegisterService calls
+//     that would bypass attribution.
+//
+//  2. An unexported cellScopedRegistrar implements grpc.ServiceRegistrar. It is handed
+//     to the spec.Register callback, intercepts RegisterService(sd,impl) to record
+//     /{ServiceName}/{method}→cellID for every sd.Methods and sd.Streams, then
+//     delegates to the real server.
+//
+//  3. ServiceName deduplication is across ALL specs (shared names map). A second
+//     spec whose callback registers the same service name panics before grpc-go's own
+//     fatal (which gives a less helpful message about cross-cell collision).
+//
+//  4. The attribution map built here (method→cellID) is the foundation for PR-9
+//     (gRPC metrics cell label) and PR-10 (streaming interceptors). PR-7 does not
+//     wire it into any interceptor — it only exposes CellIDForMethod.
+//
+// ref: zeromicro/go-zero zrpc/internal/rpcserver.go — RegisterFn (Form B precedent)
+// ref: go-kratos/kratos transport/grpc/server.go — pb.RegisterXxxServer before Start
+// ref: grpc/grpc-go server.go — RegisterService fatals after Serve + dup ServiceName
+
+import (
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
+)
+
+// ServiceRegistrar is the cell-facing gRPC service registration seam.
+// It is constructed by adapters/grpc.Server.Registrar() and handed to bootstrap
+// which calls Register(spec) for each GRPCServiceSpec drained from the cell
+// snapshot. The grpc.ServiceRegistrar interface is NOT exported — the only entry
+// point is Register(spec), which routes through the attribution-aware
+// cellScopedRegistrar interceptor.
+//
+// All public methods are safe for concurrent use after construction.
+type ServiceRegistrar struct {
+	inner grpc.ServiceRegistrar
+	mu    sync.RWMutex
+	// methods maps /{ServiceName}/{methodName} → cellID.
+	methods map[string]string
+	// names tracks registered service names for dedup (shared with cellScopedRegistrar).
+	names map[string]struct{}
+}
+
+// NewServiceRegistrar wraps inner (typically *grpc.Server) into a ServiceRegistrar.
+// inner must not be nil (caller's responsibility; adapters/grpc.New guarantees this).
+func NewServiceRegistrar(inner grpc.ServiceRegistrar) *ServiceRegistrar {
+	return &ServiceRegistrar{
+		inner:   inner,
+		methods: make(map[string]string),
+		names:   make(map[string]struct{}),
+	}
+}
+
+// Register invokes the spec.Register callback via an attribution-aware
+// cellScopedRegistrar interceptor, then records every method/stream exposed by
+// the registered service under spec.CellID.
+//
+// spec.Register must be a func(grpc.ServiceRegistrar). Any other dynamic type
+// panics with panicregister.Approved("grpc-registrar-bad-register-fn", …).
+//
+// If the callback attempts to register a service whose ServiceName is already
+// registered (cross-cell collision), cellScopedRegistrar panics with
+// panicregister.Approved("grpc-registrar-dup-service", …) before grpc-go's own
+// fatal — providing a more informative message.
+//
+// Register must be called before grpcServer.Serve (enforced by the drain ordering:
+// bootstrap calls Register in phase7b before grpcServeAll).
+func (r *ServiceRegistrar) Register(spec cell.GRPCServiceSpec) error {
+	// Type-assert: kernel stores Register as `any` to stay grpc-import-free.
+	fn, ok := spec.Register.(func(grpc.ServiceRegistrar))
+	if !ok {
+		panic(panicregister.Approved("grpc-registrar-bad-register-fn",
+			errcode.Assertion(
+				"grpc: GRPCServiceSpec.Register must be func(grpc.ServiceRegistrar); "+
+					"got %T (contractID=%q, cellID=%q)",
+				spec.Register, spec.ContractID, spec.CellID)))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	scoped := &cellScopedRegistrar{
+		inner:   r.inner,
+		cellID:  spec.CellID,
+		methods: r.methods,
+		names:   r.names,
+	}
+	fn(scoped)
+	return nil
+}
+
+// CellIDForMethod returns the cellID attributed to fullMethod (e.g.
+// "/grpc.health.v1.Health/Check"). The second return value is false when the
+// method has not been registered via Register. Safe for concurrent use.
+func (r *ServiceRegistrar) CellIDForMethod(fullMethod string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	id, ok := r.methods[fullMethod]
+	return id, ok
+}
+
+// ---------------------------------------------------------------------------
+// cellScopedRegistrar — unexported attribution interceptor
+// ---------------------------------------------------------------------------
+
+// cellScopedRegistrar implements grpc.ServiceRegistrar. It is the value handed
+// to each spec.Register callback. It records every /{ServiceName}/{method} →
+// cellID entry into the shared methods map, deduplicates service names across
+// specs, and delegates to the real server.
+//
+// It shares the methods and names maps with its parent ServiceRegistrar, so
+// attribution data is immediately visible via CellIDForMethod once Register
+// returns.
+type cellScopedRegistrar struct {
+	inner   grpc.ServiceRegistrar
+	cellID  string
+	methods map[string]string   // shared with ServiceRegistrar
+	names   map[string]struct{} // shared with ServiceRegistrar
+}
+
+// RegisterService implements grpc.ServiceRegistrar. It:
+//
+//  1. Deduplicates by sd.ServiceName — panics on collision (cross-cell bug).
+//  2. Records /{ServiceName}/{method} → cellID for every Methods + Streams entry.
+//  3. Delegates to r.inner.RegisterService(sd, impl) so grpc-go actually registers
+//     the service (which fatals if called after Serve — the drain ordering prevents this).
+func (c *cellScopedRegistrar) RegisterService(sd *grpc.ServiceDesc, impl any) {
+	svcName := sd.ServiceName
+	if _, dup := c.names[svcName]; dup {
+		panic(panicregister.Approved("grpc-registrar-dup-service",
+			errcode.Assertion(
+				"grpc: duplicate ServiceName %q: this service is already registered "+
+					"(cross-cell collision or duplicate spec.Register callback). "+
+					"Each gRPC service must be registered exactly once.",
+				svcName)))
+	}
+	c.names[svcName] = struct{}{}
+
+	// Record every unary method.
+	for _, m := range sd.Methods {
+		key := fmt.Sprintf("/%s/%s", svcName, m.MethodName)
+		c.methods[key] = c.cellID
+	}
+	// Record every streaming method.
+	for _, s := range sd.Streams {
+		key := fmt.Sprintf("/%s/%s", svcName, s.StreamName)
+		c.methods[key] = c.cellID
+	}
+
+	c.inner.RegisterService(sd, impl)
+}

--- a/runtime/grpc/registrar.go
+++ b/runtime/grpc/registrar.go
@@ -51,8 +51,17 @@ type ServiceRegistrar struct {
 	mu    sync.RWMutex
 	// methods maps /{ServiceName}/{methodName} → cellID.
 	methods map[string]string
-	// names tracks registered service names for dedup (shared with cellScopedRegistrar).
-	names map[string]struct{}
+	// names maps a registered gRPC ServiceName → its owning spec, used both for
+	// cross-spec dedup and to report first/current owner on a collision (shared
+	// with cellScopedRegistrar).
+	names map[string]serviceOwner
+}
+
+// serviceOwner records which spec first registered a given gRPC ServiceName, so
+// a later duplicate registration can name both sides of the collision.
+type serviceOwner struct {
+	cellID     string
+	contractID string
 }
 
 // NewServiceRegistrar wraps inner (typically *grpc.Server) into a ServiceRegistrar.
@@ -66,27 +75,36 @@ func NewServiceRegistrar(inner grpc.ServiceRegistrar) *ServiceRegistrar {
 	return &ServiceRegistrar{
 		inner:   inner,
 		methods: make(map[string]string),
-		names:   make(map[string]struct{}),
+		names:   make(map[string]serviceOwner),
 	}
 }
 
-// Register invokes the spec.Register callback via an attribution-aware
-// cellScopedRegistrar interceptor, then records every method/stream exposed by
-// the registered service under spec.CellID.
+// Register invokes the spec.Register callback via an attribution-aware,
+// single-use cellScopedRegistrar interceptor, then records every method/stream
+// exposed by the registered service under spec.CellID.
 //
-// This implementation always returns nil; contract violations (bad callback
-// type, duplicate ServiceName) panic via panicregister.Approved.
+// This implementation always returns nil; every contract violation panics via
+// panicregister.Approved (B-class programmer / config error, fail-fast at
+// startup — the drain runs in phase7b before any RPC is served):
 //
-// spec.Register must be a func(grpc.ServiceRegistrar). Any other dynamic type
-// panics with panicregister.Approved("grpc-registrar-bad-register-fn", …).
-//
-// If the callback attempts to register a service whose ServiceName is already
-// registered (cross-cell collision), cellScopedRegistrar panics with
-// panicregister.Approved("grpc-registrar-dup-service", …) before grpc-go's own
-// fatal — providing a more informative message.
+//   - spec.Register is not a func(grpc.ServiceRegistrar):
+//     panicregister.Approved("grpc-registrar-bad-register-fn", …).
+//   - spec.Register is a typed-nil callback (a nil func(grpc.ServiceRegistrar)
+//     boxed in any — passes kernel's bare-nil Validate but is uninvokable):
+//     panicregister.Approved("grpc-registrar-nil-register-fn", …).
+//   - the callback does not register exactly one service (zero = silently
+//     unserved spec; >1 = a single spec smuggling multiple services):
+//     panicregister.Approved("grpc-registrar-service-count", …).
+//   - the callback registers a ServiceName already owned by another spec
+//     (cross-cell collision): panicregister.Approved("grpc-registrar-dup-service",
+//     …) before grpc-go's own fatal — with first/current owner context.
+//   - the cellScopedRegistrar is retained and used after the callback returns
+//     (escaped scope — would let registration leak past Serve):
+//     panicregister.Approved("grpc-registrar-escaped-scope", …).
 //
 // Register must be called before grpcServer.Serve (enforced by the drain ordering:
-// bootstrap calls Register in phase7b before grpcServeAll).
+// bootstrap calls Register in phase7b before grpcServeAll). The scope is closed
+// once the callback returns so a retained registrar cannot register after Serve.
 func (r *ServiceRegistrar) Register(spec cell.GRPCServiceSpec) error {
 	// Type-assert: kernel stores Register as `any` to stay grpc-import-free.
 	fn, ok := spec.Register.(func(grpc.ServiceRegistrar))
@@ -97,6 +115,17 @@ func (r *ServiceRegistrar) Register(spec cell.GRPCServiceSpec) error {
 					"got %T (contractID=%q, cellID=%q)",
 				spec.Register, spec.ContractID, spec.CellID)))
 	}
+	// A typed-nil func passes the assert (ok==true, fn==nil) and slips through
+	// kernel's bare-nil GRPCServiceSpec.Validate (which only checks `Register ==
+	// nil` on the any). Invoking it would raise an unregistered Go runtime panic;
+	// fail-fast through the Approved funnel instead.
+	if fn == nil {
+		panic(panicregister.Approved("grpc-registrar-nil-register-fn",
+			errcode.Assertion(
+				"grpc: GRPCServiceSpec.Register is a typed-nil func(grpc.ServiceRegistrar) "+
+					"(contractID=%q, cellID=%q); supply a non-nil callback",
+				spec.ContractID, spec.CellID)))
+	}
 
 	// NOTE: fn(scoped) runs UNDER the write lock. Do NOT call CellIDForMethod
 	// inside fn — it takes an RLock and would deadlock. This is safe today
@@ -106,12 +135,29 @@ func (r *ServiceRegistrar) Register(spec cell.GRPCServiceSpec) error {
 	defer r.mu.Unlock()
 
 	scoped := &cellScopedRegistrar{
-		inner:   r.inner,
-		cellID:  spec.CellID,
-		methods: r.methods,
-		names:   r.names,
+		inner:      r.inner,
+		cellID:     spec.CellID,
+		contractID: spec.ContractID,
+		methods:    r.methods,
+		names:      r.names,
+		active:     true,
 	}
 	fn(scoped)
+	// Close the scope: a registrar retained by the callback can no longer register
+	// (it would otherwise be able to RegisterService after Serve, which grpc-go
+	// fatals on). All further RegisterService calls now fail-fast.
+	scoped.active = false
+
+	// Each GRPCServiceSpec maps to exactly one gRPC service. Zero means the spec
+	// is declared but silently unserved; more than one means a single spec is
+	// smuggling multiple services past the contract/attribution model.
+	if scoped.count != 1 {
+		panic(panicregister.Approved("grpc-registrar-service-count",
+			errcode.Assertion(
+				"grpc: GRPCServiceSpec.Register callback must register exactly one service "+
+					"(contractID=%q, cellID=%q); got %d RegisterService call(s)",
+				spec.ContractID, spec.CellID, scoped.count)))
+	}
 	return nil
 }
 
@@ -129,38 +175,62 @@ func (r *ServiceRegistrar) CellIDForMethod(fullMethod string) (string, bool) {
 // cellScopedRegistrar — unexported attribution interceptor
 // ---------------------------------------------------------------------------
 
-// cellScopedRegistrar implements grpc.ServiceRegistrar. It is the value handed
-// to each spec.Register callback. It records every /{ServiceName}/{method} →
-// cellID entry into the shared methods map, deduplicates service names across
-// specs, and delegates to the real server.
+// cellScopedRegistrar implements grpc.ServiceRegistrar. It is the single-use
+// value handed to one spec.Register callback. It records every
+// /{ServiceName}/{method} → cellID entry into the shared methods map,
+// deduplicates service names across specs (reporting first/current owner on a
+// collision), counts its own RegisterService calls, and delegates to the real
+// server.
 //
 // It shares the methods and names maps with its parent ServiceRegistrar, so
 // attribution data is immediately visible via CellIDForMethod once Register
-// returns.
+// returns. active gates the registrar to the dynamic extent of the callback:
+// Register sets it true before fn(scoped) and false after, so a registrar
+// retained past the callback (or used after Serve) fails fast.
 type cellScopedRegistrar struct {
-	inner   grpc.ServiceRegistrar
-	cellID  string
-	methods map[string]string   // shared with ServiceRegistrar
-	names   map[string]struct{} // shared with ServiceRegistrar
+	inner      grpc.ServiceRegistrar
+	cellID     string
+	contractID string
+	methods    map[string]string       // shared with ServiceRegistrar
+	names      map[string]serviceOwner // shared with ServiceRegistrar
+	active     bool                    // true only during the spec.Register callback
+	count      int                     // number of RegisterService calls in this scope
 }
 
 // RegisterService implements grpc.ServiceRegistrar. It:
 //
-//  1. Deduplicates by sd.ServiceName — panics on collision (cross-cell bug).
-//  2. Records /{ServiceName}/{method} → cellID for every Methods + Streams entry.
-//  3. Delegates to r.inner.RegisterService(sd, impl) so grpc-go actually registers
+//  1. Rejects use outside its registration scope (escaped / post-Serve registrar).
+//  2. Deduplicates by sd.ServiceName — panics on collision, naming both owners.
+//  3. Records /{ServiceName}/{method} → cellID for every Methods + Streams entry.
+//  4. Delegates to r.inner.RegisterService(sd, impl) so grpc-go actually registers
 //     the service (which fatals if called after Serve — the drain ordering prevents this).
+//
+// The active/count fields are read and written only under the parent
+// ServiceRegistrar write lock held across the whole callback, so the in-extent
+// path is race-free; the active guard is a best-effort fail-fast for a registrar
+// that escaped its callback (a programmer error that grpc-go's own concurrency
+// rules already forbid).
 func (c *cellScopedRegistrar) RegisterService(sd *grpc.ServiceDesc, impl any) {
+	if !c.active {
+		panic(panicregister.Approved("grpc-registrar-escaped-scope",
+			errcode.Assertion(
+				"grpc: cellScopedRegistrar.RegisterService called outside its registration "+
+					"scope (contractID=%q, cellID=%q, service=%q); the registrar must not be "+
+					"retained past the spec.Register callback",
+				c.contractID, c.cellID, sd.ServiceName)))
+	}
+	c.count++
+
 	svcName := sd.ServiceName
-	if _, dup := c.names[svcName]; dup {
+	if owner, dup := c.names[svcName]; dup {
 		panic(panicregister.Approved("grpc-registrar-dup-service",
 			errcode.Assertion(
-				"grpc: duplicate ServiceName %q: this service is already registered "+
-					"(cross-cell collision or duplicate spec.Register callback). "+
-					"Each gRPC service must be registered exactly once.",
-				svcName)))
+				"grpc: duplicate gRPC ServiceName %q: already registered by cell %q "+
+					"(contractID=%q); re-registered by cell %q (contractID=%q). "+
+					"Each gRPC service must be registered exactly once across all cells.",
+				svcName, owner.cellID, owner.contractID, c.cellID, c.contractID)))
 	}
-	c.names[svcName] = struct{}{}
+	c.names[svcName] = serviceOwner{cellID: c.cellID, contractID: c.contractID}
 
 	// Record every unary method.
 	for _, m := range sd.Methods {

--- a/runtime/grpc/registrar.go
+++ b/runtime/grpc/registrar.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
+	"github.com/ghbvf/gocell/pkg/validation"
 )
 
 // ServiceRegistrar is the cell-facing gRPC service registration seam.
@@ -55,8 +56,13 @@ type ServiceRegistrar struct {
 }
 
 // NewServiceRegistrar wraps inner (typically *grpc.Server) into a ServiceRegistrar.
-// inner must not be nil (caller's responsibility; adapters/grpc.New guarantees this).
+// inner must not be nil — both bare-nil and typed-nil are rejected with a
+// panicregister.Approved("grpc-registrar-nil-inner", …) panic (B-class programmer error).
 func NewServiceRegistrar(inner grpc.ServiceRegistrar) *ServiceRegistrar {
+	if validation.IsNilInterface(inner) {
+		panic(panicregister.Approved("grpc-registrar-nil-inner",
+			errcode.Assertion("NewServiceRegistrar: inner must not be nil")))
+	}
 	return &ServiceRegistrar{
 		inner:   inner,
 		methods: make(map[string]string),
@@ -67,6 +73,9 @@ func NewServiceRegistrar(inner grpc.ServiceRegistrar) *ServiceRegistrar {
 // Register invokes the spec.Register callback via an attribution-aware
 // cellScopedRegistrar interceptor, then records every method/stream exposed by
 // the registered service under spec.CellID.
+//
+// This implementation always returns nil; contract violations (bad callback
+// type, duplicate ServiceName) panic via panicregister.Approved.
 //
 // spec.Register must be a func(grpc.ServiceRegistrar). Any other dynamic type
 // panics with panicregister.Approved("grpc-registrar-bad-register-fn", …).
@@ -89,6 +98,10 @@ func (r *ServiceRegistrar) Register(spec cell.GRPCServiceSpec) error {
 				spec.Register, spec.ContractID, spec.CellID)))
 	}
 
+	// NOTE: fn(scoped) runs UNDER the write lock. Do NOT call CellIDForMethod
+	// inside fn — it takes an RLock and would deadlock. This is safe today
+	// because the drain runs serially in phase7b (pre-Serve, single goroutine).
+	// Post-Serve registration safety is a PR-9 concern (out of scope here).
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/runtime/grpc/registrar_test.go
+++ b/runtime/grpc/registrar_test.go
@@ -1,0 +1,185 @@
+package grpc_test
+
+// registrar_test.go — TDD coverage for ServiceRegistrar (GAP-1 PR-7 [#1150]).
+//
+// Cases:
+//   1. Register+Invoke over bufconn: real gRPC round-trip via callback
+//   2. CellIDForMethod: unary Methods mapped after Register
+//   3. CellIDForMethod: stream Streams mapped after Register
+//   4. CellIDForMethod: unknown method returns (_, false)
+//   5. bad Register fn type panics with panicregister.Approved (grpc-registrar-bad-register-fn)
+//   6. duplicate ServiceName panics with panicregister.Approved (grpc-registrar-dup-service)
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	runtimegrpc "github.com/ghbvf/gocell/runtime/grpc"
+)
+
+const registrarBufSize = 1 << 20 // 1 MiB
+
+// newRegistrar returns a *runtimegrpc.ServiceRegistrar wrapping a fresh grpc.Server.
+func newRegistrar() (*runtimegrpc.ServiceRegistrar, *grpc.Server) {
+	inner := grpc.NewServer()
+	return runtimegrpc.NewServiceRegistrar(inner), inner
+}
+
+// dialBufconn dials via bufconn with insecure credentials.
+func dialBufconn(t *testing.T, lis *bufconn.Listener) *grpc.ClientConn {
+	t.Helper()
+	cc, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	return cc
+}
+
+// synthSpec returns a GRPCServiceSpec whose Register calls the given fn.
+func synthSpec(contractID, cellID string, fn func(grpc.ServiceRegistrar)) cell.GRPCServiceSpec {
+	return cell.GRPCServiceSpec{
+		ContractID: contractID,
+		CellID:     cellID,
+		Listener:   cell.PrimaryListener,
+		Register:   fn,
+	}
+}
+
+// --- Case 1: Register+Invoke bufconn round-trip ----------------------------
+
+// TestServiceRegistrar_Register_BufconnRoundTrip verifies that Register invokes the
+// callback so services are reachable via real gRPC transport.
+func TestServiceRegistrar_Register_BufconnRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	reg, srv := newRegistrar()
+
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	spec := synthSpec("grpc.health.v1", "test-cell", func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, healthSrv)
+	})
+	require.NoError(t, reg.Register(spec))
+
+	// Serve on bufconn.
+	lis := bufconn.Listen(registrarBufSize)
+	defer lis.Close()
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.GracefulStop()
+
+	cc := dialBufconn(t, lis)
+	defer cc.Close()
+
+	ctx := context.Background()
+	resp, err := grpc_health_v1.NewHealthClient(cc).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+// --- Case 2: CellIDForMethod unary -------------------------------------------
+
+// TestServiceRegistrar_CellIDForMethod_Unary verifies /{svc}/{method} → cellID
+// is recorded for unary methods after Register.
+func TestServiceRegistrar_CellIDForMethod_Unary(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+
+	healthSrv := health.NewServer()
+	spec := synthSpec("grpc.health.v1", "health-cell", func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, healthSrv)
+	})
+	require.NoError(t, reg.Register(spec))
+
+	// grpc_health_v1.Health service has method "Check".
+	cellID, ok := reg.CellIDForMethod("/grpc.health.v1.Health/Check")
+	require.True(t, ok, "Check method should be attributed")
+	assert.Equal(t, "health-cell", cellID)
+}
+
+// --- Case 3: CellIDForMethod stream ------------------------------------------
+
+// TestServiceRegistrar_CellIDForMethod_Stream verifies stream Streams are also mapped.
+func TestServiceRegistrar_CellIDForMethod_Stream(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+
+	healthSrv := health.NewServer()
+	spec := synthSpec("grpc.health.v1", "stream-cell", func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, healthSrv)
+	})
+	require.NoError(t, reg.Register(spec))
+
+	// grpc_health_v1.Health service has streaming method "Watch".
+	cellID, ok := reg.CellIDForMethod("/grpc.health.v1.Health/Watch")
+	require.True(t, ok, "Watch stream should be attributed")
+	assert.Equal(t, "stream-cell", cellID)
+}
+
+// --- Case 4: CellIDForMethod unknown -----------------------------------------
+
+// TestServiceRegistrar_CellIDForMethod_Unknown verifies unknown methods return (_, false).
+func TestServiceRegistrar_CellIDForMethod_Unknown(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+	_, ok := reg.CellIDForMethod("/nonexistent.Svc/Method")
+	assert.False(t, ok)
+}
+
+// --- Case 5: bad Register fn type panics -------------------------------------
+
+// TestServiceRegistrar_Register_BadFnType_Panics verifies a non-func Register field
+// causes a panic with panicregister.Approved wrapping (grpc-registrar-bad-register-fn).
+func TestServiceRegistrar_Register_BadFnType_Panics(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+	spec := cell.GRPCServiceSpec{
+		ContractID: "grpc.bad.v1",
+		CellID:     "test-cell",
+		Listener:   cell.PrimaryListener,
+		Register:   "not-a-function", // wrong type
+	}
+	assert.Panics(t, func() {
+		_ = reg.Register(spec)
+	}, "bad Register fn type must panic")
+}
+
+// --- Case 6: duplicate ServiceName panics ------------------------------------
+
+// TestServiceRegistrar_Register_DupServiceName_Panics verifies that registering
+// two specs whose callbacks register the SAME grpc ServiceName panics.
+func TestServiceRegistrar_Register_DupServiceName_Panics(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+
+	registerHealth := func(cellID string) {
+		healthSrv := health.NewServer()
+		_ = reg.Register(synthSpec("grpc.health."+cellID, cellID, func(r grpc.ServiceRegistrar) {
+			grpc_health_v1.RegisterHealthServer(r, healthSrv)
+		}))
+	}
+
+	registerHealth("cell-a") // first registration — should succeed
+
+	assert.Panics(t, func() {
+		registerHealth("cell-b") // duplicate grpc.health.v1.Health ServiceName
+	}, "duplicate ServiceName must panic")
+}

--- a/runtime/grpc/registrar_test.go
+++ b/runtime/grpc/registrar_test.go
@@ -77,12 +77,12 @@ func TestServiceRegistrar_Register_BufconnRoundTrip(t *testing.T) {
 
 	// Serve on bufconn.
 	lis := bufconn.Listen(registrarBufSize)
-	defer lis.Close()
+	defer func() { _ = lis.Close() }()
 	go func() { _ = srv.Serve(lis) }()
 	defer srv.GracefulStop()
 
 	cc := dialBufconn(t, lis)
-	defer cc.Close()
+	defer func() { _ = cc.Close() }()
 
 	ctx := context.Background()
 	resp, err := grpc_health_v1.NewHealthClient(cc).Check(ctx, &grpc_health_v1.HealthCheckRequest{})

--- a/runtime/grpc/registrar_test.go
+++ b/runtime/grpc/registrar_test.go
@@ -9,9 +9,15 @@ package grpc_test
 //   4. CellIDForMethod: unknown method returns (_, false)
 //   5. bad Register fn type panics with panicregister.Approved (grpc-registrar-bad-register-fn)
 //   6. duplicate ServiceName panics with panicregister.Approved (grpc-registrar-dup-service)
+//   7. duplicate ServiceName panic names both first/current owner (F3)
+//   8. typed-nil Register callback panics (grpc-registrar-nil-register-fn) (F2)
+//   9. no-op callback (0 services) panics (grpc-registrar-service-count) (F1)
+//  10. multi-register callback (>1 service) panics (grpc-registrar-service-count) (F1)
+//  11. registrar retained past callback (escaped scope) panics (grpc-registrar-escaped-scope) (F1)
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -182,4 +188,118 @@ func TestServiceRegistrar_Register_DupServiceName_Panics(t *testing.T) {
 	assert.Panics(t, func() {
 		registerHealth("cell-b") // duplicate grpc.health.v1.Health ServiceName
 	}, "duplicate ServiceName must panic")
+}
+
+// --- Case 7: duplicate ServiceName panic names both owners (F3) ---------------
+
+// TestServiceRegistrar_Register_DupServiceName_OwnerContext verifies the dup
+// panic message identifies BOTH the first owner (cell + contractID) and the
+// re-registering owner, so an operator can pinpoint the colliding cells without
+// guessing.
+func TestServiceRegistrar_Register_DupServiceName_OwnerContext(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+
+	require.NoError(t, reg.Register(synthSpec("grpc.health.first.v1", "cell-first", func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, health.NewServer())
+	})))
+
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "duplicate ServiceName must panic")
+		msg := fmt.Sprint(rec)
+		assert.Contains(t, msg, "cell-first", "panic must name the first owner cell")
+		assert.Contains(t, msg, "grpc.health.first.v1", "panic must name the first owner contractID")
+		assert.Contains(t, msg, "cell-second", "panic must name the re-registering cell")
+		assert.Contains(t, msg, "grpc.health.second.v1", "panic must name the re-registering contractID")
+	}()
+
+	_ = reg.Register(synthSpec("grpc.health.second.v1", "cell-second", func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, health.NewServer())
+	}))
+}
+
+// --- Case 8: typed-nil Register callback panics (F2) -------------------------
+
+// TestServiceRegistrar_Register_TypedNilCallback_Panics verifies a typed-nil
+// func(grpc.ServiceRegistrar) boxed in any — which slips past kernel's bare-nil
+// Validate — fails fast through the Approved funnel instead of an unregistered
+// Go runtime nil-func panic.
+func TestServiceRegistrar_Register_TypedNilCallback_Panics(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+	var nilFn func(grpc.ServiceRegistrar) // typed nil
+	spec := cell.GRPCServiceSpec{
+		ContractID: "grpc.typednil.v1",
+		CellID:     "test-cell",
+		Listener:   cell.PrimaryListener,
+		Register:   nilFn, // boxed: spec.Register != nil (typed), but the func is nil
+	}
+	// Sanity: the kernel-level bare-nil guard does NOT catch a typed-nil.
+	require.NoError(t, spec.Validate(), "kernel Validate only catches bare-nil Register")
+
+	assert.Panics(t, func() {
+		_ = reg.Register(spec)
+	}, "typed-nil Register callback must panic")
+}
+
+// --- Case 9: no-op callback (0 services) panics (F1) -------------------------
+
+// TestServiceRegistrar_Register_NoOpCallback_Panics verifies a callback that
+// registers nothing panics: a declared spec that serves no service is a bug.
+func TestServiceRegistrar_Register_NoOpCallback_Panics(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+	spec := synthSpec("grpc.noop.v1", "noop-cell", func(_ grpc.ServiceRegistrar) {
+		// registers nothing
+	})
+	assert.Panics(t, func() {
+		_ = reg.Register(spec)
+	}, "no-op callback (0 services) must panic")
+}
+
+// --- Case 10: multi-register callback (>1 service) panics (F1) ---------------
+
+// TestServiceRegistrar_Register_MultiRegister_Panics verifies a callback that
+// registers more than one service panics: one spec must map to one service.
+func TestServiceRegistrar_Register_MultiRegister_Panics(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+	spec := synthSpec("grpc.multi.v1", "multi-cell", func(r grpc.ServiceRegistrar) {
+		grpc_health_v1.RegisterHealthServer(r, health.NewServer())
+		r.RegisterService(&grpc.ServiceDesc{ServiceName: "test.ExtraService"}, struct{}{})
+	})
+	assert.Panics(t, func() {
+		_ = reg.Register(spec)
+	}, "callback registering >1 service must panic")
+}
+
+// --- Case 11: escaped registrar use after callback panics (F1) ---------------
+
+// TestServiceRegistrar_Register_EscapedScope_Panics verifies that a registrar
+// retained by the callback and used after it returns fails fast — closing the
+// loophole where a cell could register a service after Serve (which grpc-go
+// fatals on).
+func TestServiceRegistrar_Register_EscapedScope_Panics(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newRegistrar()
+
+	var captured grpc.ServiceRegistrar
+	spec := synthSpec("grpc.escape.v1", "escape-cell", func(r grpc.ServiceRegistrar) {
+		captured = r // stash the registrar to use later
+		grpc_health_v1.RegisterHealthServer(r, health.NewServer())
+	})
+	// In-scope registration succeeds (exactly one service).
+	require.NoError(t, reg.Register(spec))
+	require.NotNil(t, captured)
+
+	// Using the escaped registrar after the scope closed must panic.
+	assert.Panics(t, func() {
+		captured.RegisterService(&grpc.ServiceDesc{ServiceName: "test.EscapedService"}, struct{}{})
+	}, "escaped registrar use after callback must panic")
 }

--- a/tools/archtest/grpc_cell_registrar_layer_test.go
+++ b/tools/archtest/grpc_cell_registrar_layer_test.go
@@ -27,7 +27,7 @@
 //
 // This is the same permanent ceiling family as SPAN-SETATTR-HOLDER-SEAL (#851),
 // HEALTHZ-HOLDER-SEAL (#893), and CTXKEYS-PRINCIPAL-WRITE-CALLER (#1282).
-// Tracked as a permanent-ceiling won't-do at gh issue (see GRPCServiceSpec godoc).
+// Tracked as a permanent-ceiling won't-do at gh #1582.
 //
 // # What this archtest DOES assert (A1 only)
 //

--- a/tools/archtest/grpc_cell_registrar_layer_test.go
+++ b/tools/archtest/grpc_cell_registrar_layer_test.go
@@ -39,7 +39,7 @@
 // # Blind spots (per AI-robust §载体决策原则 "强制盲区自检")
 //
 //   - reflect.TypeOf cannot observe the runtime dynamic type stored in the field;
-//     the type-assert behaviour is covered by registrar_test.go (cases 5/6).
+//     the type-assert behavior is covered by registrar_test.go (cases 5/6).
 //   - This archtest does NOT verify kernel⊥grpc directly — that is handled by the
 //     existing depguard + kernel_internal_dag_test.go gate (see above); duplication
 //     would be a Soft override of a Hard gate, which ai-robust.md prohibits.

--- a/tools/archtest/grpc_cell_registrar_layer_test.go
+++ b/tools/archtest/grpc_cell_registrar_layer_test.go
@@ -1,0 +1,108 @@
+// INVARIANT: GRPC-CELL-REGISTRAR-LAYER-01
+//
+// This file owns ONE invariant: the kernel/cell.GRPCServiceSpec.Register field
+// is an untyped interface{} (any) with Kind==Interface and an empty name.
+//
+// # Why the field must stay `any`
+//
+// kernel/ must NOT import google.golang.org/grpc (depguard / kernel_internal_dag_test.go
+// already enforce kernel⊥grpc; that existing gate is the load-bearing guarantee —
+// do NOT add a duplicate archtest here). The only way kernel/cell can hold a
+// "func(grpc.ServiceRegistrar)" value without naming the grpc type is `any`.
+// The actual type-assert happens in runtime/grpc.ServiceRegistrar.Register.
+//
+// # AI-robust rating (per .claude/rules/gocell/ai-robust.md)
+//
+// Medium with a PERMANENT upstream ceiling.
+//
+// The true-Hard upstream path — sealing the `any` field via a marker interface
+// defined in kernel/ that adapters/grpc can implement — is infeasible:
+//
+//   - A kernel-defined unexported marker (e.g. `registerFn interface{ gRPCRegisterFn() }`)
+//     requires all implementers to be in the kernel package (Go unexported methods),
+//     which is impossible for closure values from cells/ or adapters/.
+//   - A kernel-defined exported marker interface is importable by adapters/grpc, but
+//     can also be trivially implemented by any struct anywhere → no sealing.
+//   - A marker in adapters/grpc cannot be imported by kernel/cell (kernel⊥adapters).
+//
+// This is the same permanent ceiling family as SPAN-SETATTR-HOLDER-SEAL (#851),
+// HEALTHZ-HOLDER-SEAL (#893), and CTXKEYS-PRINCIPAL-WRITE-CALLER (#1282).
+// Tracked as a permanent-ceiling won't-do at gh issue (see GRPCServiceSpec godoc).
+//
+// # What this archtest DOES assert (A1 only)
+//
+// A1 — reflect field-type lock: GRPCServiceSpec.Register is exactly `any`
+// (reflect.Interface kind + empty Name). A drift to a concrete function type, a
+// named interface, or `interface{ gRPCRegister() }` — any of which would add a
+// grpc dependency to kernel/ — is caught by the reflect check.
+//
+// # Blind spots (per AI-robust §载体决策原则 "强制盲区自检")
+//
+//   - reflect.TypeOf cannot observe the runtime dynamic type stored in the field;
+//     the type-assert behaviour is covered by registrar_test.go (cases 5/6).
+//   - This archtest does NOT verify kernel⊥grpc directly — that is handled by the
+//     existing depguard + kernel_internal_dag_test.go gate (see above); duplication
+//     would be a Soft override of a Hard gate, which ai-robust.md prohibits.
+//
+// Negative-control test: TestGRPCCellRegistrarLayer_A1_NegativeControl confirms
+// that a type with a named/typed Register field produces ≥1 violation, ensuring
+// the check is not vacuously true.
+package archtest
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+)
+
+// TestGRPCCellRegistrarLayer01_A1_FieldTypeLock verifies that
+// GRPCServiceSpec.Register is an untyped any (Kind==Interface, Name=="").
+func TestGRPCCellRegistrarLayer01_A1_FieldTypeLock(t *testing.T) {
+	t.Parallel()
+
+	rt := reflect.TypeOf(cell.GRPCServiceSpec{})
+
+	field, ok := rt.FieldByName("Register")
+	require.True(t, ok, "GRPCServiceSpec must have a Register field")
+
+	fieldType := field.Type
+	assert.Equal(t, reflect.Interface, fieldType.Kind(),
+		"GRPCServiceSpec.Register must be an interface type (i.e. any / interface{})")
+	assert.Equal(t, "", fieldType.Name(),
+		"GRPCServiceSpec.Register must be the unnamed empty interface (any); "+
+			"a named interface would import grpc or another non-kernel type")
+}
+
+// TestGRPCCellRegistrarLayer_A1_NegativeControl is the negative-control test:
+// a struct with a concretely-typed Register field (func()) triggers a violation,
+// confirming the positive test is not vacuously true.
+func TestGRPCCellRegistrarLayer_A1_NegativeControl(t *testing.T) {
+	t.Parallel()
+
+	// counterType has a Register field typed as func() — a concrete type,
+	// NOT an empty interface. The test asserts that such a type would FAIL
+	// the A1 check, proving the check is live.
+	type counterType struct {
+		Register func()
+	}
+
+	rt := reflect.TypeOf(counterType{})
+	field, ok := rt.FieldByName("Register")
+	require.True(t, ok, "negative-control struct must have Register")
+
+	fieldType := field.Type
+	violations := 0
+	if fieldType.Kind() != reflect.Interface {
+		violations++
+	}
+	if fieldType.Name() != "" {
+		violations++
+	}
+	assert.GreaterOrEqual(t, violations, 1,
+		"negative-control: concrete func() Register field must produce ≥1 violation "+
+			"(proves the A1 check is not vacuously true)")
+}


### PR DESCRIPTION
## Summary

PR-7 (⚡ convergence point) of the gRPC transport epic (#1099): adds the cell-facing gRPC service
registration seam where the adapter slice (PR-3/4/5) and codegen slice (PR-6) meet.

- Cells declare a service in `Init` via `reg.GRPCService(spec)` — **Form B**: a
  `func(grpc.ServiceRegistrar)` callback held as `any` (the cell calls the generated
  `pb.RegisterXxxServer`), symmetric with HTTP `RouteGroup.Register func(mux) error` and the
  go-zero `RegisterFn` idiom.
- Bootstrap drains `RegistrySnapshot.GRPCServices` in **phase7b** (after bind, before Serve) and
  routes each to its gRPC listener by `spec.Listener` ref (new leading `ref` on `WithGRPCListener`)
  — replacing the PR-5 manual-registration stopgap, which could never serve cells (a cell's intent
  only exists after `Init` runs inside `bootstrap.Run`).
- `runtime/grpc.ServiceRegistrar` exposes a **single public path** `Register(spec)` +
  `CellIDForMethod`; an unexported `cellScopedRegistrar` intercepts the callback's
  `RegisterService` to capture `/{svc}/{method} → cellID` attribution (foundation for PR-9).
- Layering preserved: `kernel/ ⊥ grpc` (Register is `any`); `runtime/bootstrap ⊥ grpc/adapters`
  (narrow `cell.GRPCServiceRegistrar` interface). Fail-fast on dup-ref / undeclared-ref /
  CellID-mismatch / dup-ServiceName / bad-callback-type.

Framework-only (no examples/cmd wiring; no interceptor↔attribution wiring — that's PR-9; no
streaming — PR-10). Net diff ~1.3k lines incl. tests (≤2000 budget).

## Refs

- Closes #1150 — parent epic #1099; plan `docs/plans/specs/202605262300-048-grpc-adapter/plan.md` PR-7
- Permanent-ceiling won't-do tracker: #1582 (`GRPC-CELL-REGISTRAR-LAYER-01` seal infeasible —
  #851/#893/#1282 family)
- ref: zeromicro/go-zero zrpc/internal/rpcserver.go — `RegisterFn` (Form B precedent)
- ref: go-kratos/kratos transport/grpc/server.go — `pb.RegisterXxxServer`
- ref: grpc/grpc-go server.go — `RegisterService` before `Serve` + dup `ServiceName` fatal
- ref: uber-go/fx lifecycle.go — declare → drain → start

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./kernel/cell/... ./runtime/grpc/... ./adapters/grpc/... ./runtime/bootstrap/... ./tools/archtest/` 本地通过
- [x] `golangci-lint run ./...` — 0 issues
- [x] archtest `GRPC-CELL-REGISTRAR-LAYER-01` (A1 reflect field-lock + negative control)
- [x] registrar bufconn round-trip; bad-callback-type panic; dup-`ServiceName` panic; dup-`ContractID` recorder error; `CellIDForMethod` (unary + stream)
- [x] bootstrap drain happy-path + undeclared-ref / dup-ref / CellID-mismatch fail-fast
- TDD: RED `0242b58c` → GREEN `fd086623` → docs `c9c6babb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
