### PR TITLE
fix(grpc): drain 日志记实际 bound addr + AllowInsecure 非 loopback 启动告警 [#1584 follow-up]

### DIFF
--- a/adapters/grpc/config.go
+++ b/adapters/grpc/config.go
@@ -40,6 +40,10 @@ type TLSConfig struct {
 	// the explicit opt-in: plaintext is impossible unless the operator sets this
 	// flag (Config.validate V5 rejects the zero value). A loopback-only check
 	// would break the sidecar topology and is intentionally omitted.
+	//
+	// Serving plaintext on a non-loopback address emits a startup slog.Warn (once
+	// per Serve) flagging the posture — observability, not a gate. This is
+	// expected in the sidecar topology; see warnIfInsecureNonLoopback (server.go).
 	AllowInsecure bool
 
 	// CertPEM is the PEM-encoded server leaf certificate. Required for TLS/mTLS.

--- a/adapters/grpc/insecure_warn_test.go
+++ b/adapters/grpc/insecure_warn_test.go
@@ -1,0 +1,68 @@
+package grpc
+
+// insecure_warn_test.go — TDD coverage for the AllowInsecure non-loopback
+// startup warning (GAP-1 follow-up B2). Mirrors the HTTP OPS-07 warning
+// (runtime/bootstrap/bootstrap_phase7.go): serving plaintext on a non-loopback
+// address is a legitimate mesh-sidecar posture (see TLSConfig.AllowInsecure
+// doc), so this is an observability Warn, not a fail-closed gate. The check
+// lives adapter-side because only the adapter knows its own TLSConfig and the
+// resolved listener address (bootstrap holds no adapters/grpc dependency).
+
+import (
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+)
+
+// fakeNonTCPAddr is a net.Addr that is NOT *net.TCPAddr (e.g. a bufconn address),
+// proving the warning is skipped when the bound socket is not a TCP listener.
+type fakeNonTCPAddr struct{}
+
+func (fakeNonTCPAddr) Network() string { return "bufconn" }
+func (fakeNonTCPAddr) String() string  { return "bufnet" }
+
+func TestWarnIfInsecureNonLoopback(t *testing.T) {
+	const warnMsgSubstr = "non-loopback"
+
+	cases := []struct {
+		name          string
+		allowInsecure bool
+		addr          net.Addr
+		wantWarn      bool
+		wantWildcard  bool
+	}{
+		{"insecure + non-loopback IPv4 warns", true, &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 9000}, true, false},
+		{"insecure + IPv4 wildcard warns + wildcard_bind", true, &net.TCPAddr{IP: net.IPv4zero, Port: 9000}, true, true},
+		{"insecure + IPv6 unspecified warns + wildcard_bind", true, &net.TCPAddr{IP: net.IPv6unspecified, Port: 9000}, true, true},
+		{"insecure + loopback IPv4 no warn", true, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9000}, false, false},
+		{"insecure + loopback IPv6 no warn", true, &net.TCPAddr{IP: net.IPv6loopback, Port: 9000}, false, false},
+		{"insecure + non-TCP addr no warn", true, fakeNonTCPAddr{}, false, false},
+		{"TLS + non-loopback no warn", false, &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 9000}, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := sloghelper.NewSyncBuffer()
+			original := slog.Default()
+			slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+			defer slog.SetDefault(original)
+
+			warnIfInsecureNonLoopback(tc.allowInsecure, tc.addr)
+
+			entry := sloghelper.FindLogEntry(buf.String(), warnMsgSubstr)
+			if !tc.wantWarn {
+				assert.Nil(t, entry, "no warning expected for this configuration")
+				return
+			}
+			require.NotNil(t, entry, "expected an insecure non-loopback warning")
+			assert.Equal(t, "WARN", entry["level"])
+			assert.Equal(t, tc.addr.String(), entry["addr"])
+			assert.Equal(t, tc.wantWildcard, entry["wildcard_bind"])
+		})
+	}
+}

--- a/adapters/grpc/insecure_warn_test.go
+++ b/adapters/grpc/insecure_warn_test.go
@@ -26,6 +26,18 @@ type fakeNonTCPAddr struct{}
 func (fakeNonTCPAddr) Network() string { return "bufconn" }
 func (fakeNonTCPAddr) String() string  { return "bufnet" }
 
+// installCaptureLogger swaps the process slog default for a JSON handler over a
+// concurrency-safe buffer, restoring the original on cleanup (t.Cleanup, not a
+// bare defer, so the restore survives a t.FailNow in the subtest body).
+func installCaptureLogger(t *testing.T) *sloghelper.SyncBuffer {
+	t.Helper()
+	buf := sloghelper.NewSyncBuffer()
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
 func TestWarnIfInsecureNonLoopback(t *testing.T) {
 	const warnMsgSubstr = "non-loopback"
 
@@ -41,16 +53,17 @@ func TestWarnIfInsecureNonLoopback(t *testing.T) {
 		{"insecure + IPv6 unspecified warns + wildcard_bind", true, &net.TCPAddr{IP: net.IPv6unspecified, Port: 9000}, true, true},
 		{"insecure + loopback IPv4 no warn", true, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9000}, false, false},
 		{"insecure + loopback IPv6 no warn", true, &net.TCPAddr{IP: net.IPv6loopback, Port: 9000}, false, false},
+		// IPv4-mapped IPv6 loopback: net.IP.IsLoopback() resolves via To4(), so
+		// ::ffff:127.0.0.1 is correctly treated as loopback (no warn). Locks the
+		// behavior a reviewer flagged as a potential false positive.
+		{"insecure + IPv4-mapped loopback no warn", true, &net.TCPAddr{IP: net.ParseIP("::ffff:127.0.0.1"), Port: 9000}, false, false},
 		{"insecure + non-TCP addr no warn", true, fakeNonTCPAddr{}, false, false},
 		{"TLS + non-loopback no warn", false, &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 9000}, false, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			buf := sloghelper.NewSyncBuffer()
-			original := slog.Default()
-			slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
-			defer slog.SetDefault(original)
+			buf := installCaptureLogger(t)
 
 			warnIfInsecureNonLoopback(tc.allowInsecure, tc.addr)
 

--- a/adapters/grpc/serve_addr_log_test.go
+++ b/adapters/grpc/serve_addr_log_test.go
@@ -1,0 +1,59 @@
+package grpc_test
+
+// serve_addr_log_test.go — regression coverage for the adapter serve-path
+// address logging (F8 symmetric fix). serveAddr (the Worker self-bind path) and
+// serve() previously logged cfg.Addr, which is ":0" for an ephemeral port; both
+// now log the resolved lis.Addr(), mirroring the bootstrap boundGRPC.boundAddr()
+// funnel.
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adaptersgrpc "github.com/ghbvf/gocell/adapters/grpc"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+)
+
+// TestServeAddr_LogsBoundAddr drives the Worker self-bind path with Addr ":0"
+// and asserts the "server listening" log records the resolved ephemeral port,
+// not ":0".
+func TestServeAddr_LogsBoundAddr(t *testing.T) {
+	buf := sloghelper.NewSyncBuffer()
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	srv, err := adaptersgrpc.New(adaptersgrpc.Config{
+		Addr: "127.0.0.1:0",
+		TLS:  adaptersgrpc.TLSConfig{AllowInsecure: true},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.Worker().Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return sloghelper.FindLogEntry(buf.String(), "server listening") != nil
+	}, 2*time.Second, 10*time.Millisecond, "expected a 'server listening' log line")
+
+	entry := sloghelper.FindLogEntry(buf.String(), "server listening")
+	require.NotNil(t, entry)
+	addr, _ := entry["addr"].(string)
+	assert.NotEqual(t, "127.0.0.1:0", addr, "must log the resolved port, not :0")
+	assert.True(t, strings.HasPrefix(addr, "127.0.0.1:"), "unexpected addr: %q", addr)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Worker.Start did not return after ctx cancel")
+	}
+}

--- a/adapters/grpc/serve_addr_log_test.go
+++ b/adapters/grpc/serve_addr_log_test.go
@@ -18,6 +18,7 @@ import (
 
 	adaptersgrpc "github.com/ghbvf/gocell/adapters/grpc"
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 // TestServeAddr_LogsBoundAddr drives the Worker self-bind path with Addr ":0"
@@ -42,7 +43,7 @@ func TestServeAddr_LogsBoundAddr(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return sloghelper.FindLogEntry(buf.String(), "server listening") != nil
-	}, 2*time.Second, 10*time.Millisecond, "expected a 'server listening' log line")
+	}, testtime.D2s, testtime.MediumPoll, "expected a 'server listening' log line")
 
 	entry := sloghelper.FindLogEntry(buf.String(), "server listening")
 	require.NotNil(t, entry)
@@ -53,7 +54,7 @@ func TestServeAddr_LogsBoundAddr(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(testtime.D5s):
 		t.Fatal("Worker.Start did not return after ctx cancel")
 	}
 }

--- a/adapters/grpc/server.go
+++ b/adapters/grpc/server.go
@@ -194,6 +194,8 @@ func (s *Server) serveAddr(ctx context.Context) error {
 // Serve returns (normal or error) or ctx is canceled. On ctx cancellation a
 // graceful drain is attempted within cfg.ShutdownTimeout.
 func (s *Server) serve(ctx context.Context, lis net.Listener) error {
+	warnIfInsecureNonLoopback(s.cfg.TLS.AllowInsecure, lis.Addr())
+
 	go func() {
 		err := s.grpcServer.Serve(lis)
 		s.serveErr = err
@@ -237,6 +239,29 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 		}
 		return ctx.Err()
 	}
+}
+
+// warnIfInsecureNonLoopback logs a startup Warn when the server serves plaintext
+// (AllowInsecure) on a non-loopback address. Plaintext on a non-loopback bind
+// (e.g. 0.0.0.0) is a legitimate mesh-sidecar posture (see TLSConfig.AllowInsecure),
+// so this is observability — not a fail-closed gate — mirroring the HTTP listener
+// OPS-07 warning (runtime/bootstrap/bootstrap_phase7.go). It lives adapter-side
+// because only the adapter knows its own TLSConfig and the resolved listener
+// address (runtime/bootstrap holds no adapters/grpc dependency). Non-TCP
+// listeners (e.g. bufconn in tests) and loopback binds are silent; wildcard_bind
+// flags a 0.0.0.0 / :: bind (the highest-exposure case).
+func warnIfInsecureNonLoopback(allowInsecure bool, addr net.Addr) {
+	if !allowInsecure {
+		return
+	}
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok || tcpAddr.IP.IsLoopback() {
+		return
+	}
+	slog.Warn("grpc: serving plaintext on a non-loopback address without TLS; "+
+		"ensure network-level isolation (e.g. a service-mesh sidecar terminating TLS)",
+		slog.String("addr", addr.String()),
+		slog.Bool("wildcard_bind", tcpAddr.IP.IsUnspecified()))
 }
 
 // gracefulStop initiates a graceful drain of in-flight RPCs bounded by ctx.

--- a/adapters/grpc/server.go
+++ b/adapters/grpc/server.go
@@ -186,7 +186,10 @@ func (s *Server) serveAddr(ctx context.Context) error {
 			"grpc: net.Listen failed", err,
 			errcode.WithInternal(errcode.InternalAttr("addr", s.cfg.Addr)))
 	}
-	slog.Info("grpc: server listening", slog.String("addr", s.cfg.Addr))
+	// Log the ACTUAL bound address, not cfg.Addr: cfg.Addr may be ":0"
+	// (ephemeral port) and never reflects the resolved port. Mirrors the
+	// bootstrap boundGRPC.boundAddr() funnel and the serve() error path below.
+	slog.Info("grpc: server listening", slog.String("addr", lis.Addr().String()))
 	return s.serve(ctx, lis)
 }
 
@@ -194,6 +197,11 @@ func (s *Server) serveAddr(ctx context.Context) error {
 // Serve returns (normal or error) or ctx is canceled. On ctx cancellation a
 // graceful drain is attempted within cfg.ShutdownTimeout.
 func (s *Server) serve(ctx context.Context, lis net.Listener) error {
+	// addr is the ACTUAL served address (lis.Addr()), used for every log/error
+	// in this function. It is correct for both serve paths: the listener-injection
+	// path (Serve, where cfg.Addr may not match the injected socket) and the
+	// self-bind path (serveAddr, where cfg.Addr may be ":0").
+	addr := lis.Addr().String()
 	warnIfInsecureNonLoopback(s.cfg.TLS.AllowInsecure, lis.Addr())
 
 	go func() {
@@ -218,11 +226,11 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 			// operators see the cause even when the returned errcode is unwrapped
 			// upstream. The raw addr stays in InternalAttr (server-side only).
 			slog.Error("grpc: Serve returned unexpectedly",
-				slog.String("addr", s.cfg.Addr),
+				slog.String("addr", addr),
 				slog.Any("error", err))
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterGRPCServe,
 				"grpc: Serve returned unexpectedly", err,
-				errcode.WithInternal(errcode.InternalAttr("addr", s.cfg.Addr)))
+				errcode.WithInternal(errcode.InternalAttr("addr", addr)))
 		}
 		return nil
 

--- a/runtime/bootstrap/grpc_serve.go
+++ b/runtime/bootstrap/grpc_serve.go
@@ -28,6 +28,17 @@ type boundGRPC struct {
 	owned bool // true when bootstrap bound the socket (not caller-injected)
 }
 
+// boundAddr returns the ACTUAL bound socket address (e.g. "127.0.0.1:54321").
+// It is the single source for logging a bound listener's address: cfg.addr may
+// be ":0" (ephemeral port) and never reflects the resolved port. Every
+// post-bind log site — serve start and drain — reads boundAddr so the logged
+// address matches what clients connect to; only the pre-bind FAILURE path (no
+// listener yet) logs cfg.addr. net.TCPListener.Addr() keeps returning the
+// cached local address after Close, so boundAddr is safe to call during drain.
+func (bd boundGRPC) boundAddr() string {
+	return bd.lis.Addr().String()
+}
+
 // phase7bStartGRPCServers binds every declared gRPC listener synchronously, then
 // starts one serve goroutine per server and wires the drain hook (s.grpcDrain)
 // and error channel (s.grpcErrCh). serveCtx is the long-lived run context; drain
@@ -53,9 +64,10 @@ func (b *Bootstrap) phase7bStartGRPCServers(serveCtx context.Context, s *phaseSt
 				slog.String("addr", gc.addr), slog.Any("error", err))
 			return fmt.Errorf("bootstrap: grpc listen %s: %w", gc.addr, err)
 		}
+		bd := boundGRPC{cfg: gc, lis: lis, owned: owned}
 		slog.Info("bootstrap: gRPC listener bound",
-			slog.String("addr", lis.Addr().String()), slog.Bool("owned", owned))
-		bounds = append(bounds, boundGRPC{cfg: gc, lis: lis, owned: owned})
+			slog.String("addr", bd.boundAddr()), slog.Bool("owned", owned))
+		bounds = append(bounds, bd)
 	}
 
 	// Drain cell GRPCServiceSpecs: AFTER binding, BEFORE grpcServeAll, so
@@ -193,7 +205,7 @@ func (b *Bootstrap) grpcServeAll(serveCtx context.Context, bounds []boundGRPC) c
 					close(grpcErrCh)
 				}
 			}()
-			addr := bd.lis.Addr().String()
+			addr := bd.boundAddr()
 			slog.Info("bootstrap: gRPC server starting", slog.String("addr", addr))
 			if err := bd.cfg.server.Serve(serveCtx, bd.lis); err != nil {
 				grpcErrCh <- fmt.Errorf("grpc %s: %w", addr, err)
@@ -212,15 +224,16 @@ func drainAllGRPCServers(parent context.Context, bounds []boundGRPC) error {
 	resultCh := make(chan error, len(bounds))
 	for _, bd := range bounds {
 		go func() {
+			addr := bd.boundAddr()
 			ctx, cancel := shutdownCtxFor(parent, bd.cfg.shutGrace)
 			defer cancel()
 			err := bd.cfg.server.Close(ctx)
 			if err != nil {
 				slog.Error("bootstrap: gRPC server drain failed",
-					slog.String("addr", bd.cfg.addr), slog.Any("error", err))
-				err = fmt.Errorf("grpc %s drain: %w", bd.cfg.addr, err)
+					slog.String("addr", addr), slog.Any("error", err))
+				err = fmt.Errorf("grpc %s drain: %w", addr, err)
 			} else {
-				slog.Info("bootstrap: gRPC server drained", slog.String("addr", bd.cfg.addr))
+				slog.Info("bootstrap: gRPC server drained", slog.String("addr", addr))
 			}
 			resultCh <- err
 		}()

--- a/runtime/bootstrap/grpc_serve_addr_test.go
+++ b/runtime/bootstrap/grpc_serve_addr_test.go
@@ -1,0 +1,108 @@
+package bootstrap
+
+// grpc_serve_addr_test.go — TDD coverage for gRPC serve/drain logging the
+// ACTUAL bound socket address (GAP-1 follow-up F8). Before the fix the drain
+// success/failure logs and the wrapped drain error all echoed cfg.addr — which
+// is ":0" for an ephemeral port — instead of the real bound port. boundGRPC
+// .boundAddr() funnels every bound-listener log through lis.Addr() so serve and
+// drain agree, eliminating the second (config-addr) source rather than patching
+// each call site.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+)
+
+// closeErrGRPCServer is a GRPCServer whose Close returns a fixed error, for the
+// drain-failure logging path. Serve/Registrar are unused by drainAllGRPCServers.
+type closeErrGRPCServer struct{ err error }
+
+func (closeErrGRPCServer) Serve(context.Context, net.Listener) error { return nil }
+func (s closeErrGRPCServer) Close(context.Context) error             { return s.err }
+func (closeErrGRPCServer) Registrar() GRPCServiceRegistrar           { return &noopGRPCServiceRegistrar{} }
+
+// installCaptureLogger swaps the process slog default for a JSON handler over a
+// concurrency-safe buffer, restoring the original on cleanup.
+func installCaptureLogger(t *testing.T) *sloghelper.SyncBuffer {
+	t.Helper()
+	buf := sloghelper.NewSyncBuffer()
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
+// bindEphemeralLoopback binds 127.0.0.1:0 and returns the listener; it skips the
+// test (not fails) when the sandbox forbids binding.
+func bindEphemeralLoopback(t *testing.T) net.Listener {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skip("cannot bind test listener (sandbox):", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+	return lis
+}
+
+// TestBoundGRPC_BoundAddr verifies the accessor resolves the actual bound socket
+// address (lis.Addr()), never echoing the configured ":0".
+func TestBoundGRPC_BoundAddr(t *testing.T) {
+	lis := bindEphemeralLoopback(t)
+	bd := boundGRPC{cfg: grpcListenerConfig{addr: ":0"}, lis: lis}
+
+	assert.Equal(t, lis.Addr().String(), bd.boundAddr())
+	assert.NotEqual(t, ":0", bd.boundAddr(),
+		"boundAddr must resolve the ephemeral port, not echo the configured :0")
+}
+
+// TestGRPCDrain_LogsBoundAddr asserts the drain SUCCESS log records the real
+// bound port, not the configured ":0" (F8 regression).
+func TestGRPCDrain_LogsBoundAddr(t *testing.T) {
+	buf := installCaptureLogger(t)
+	lis := bindEphemeralLoopback(t)
+	boundAddr := lis.Addr().String()
+
+	bd := boundGRPC{
+		cfg:   grpcListenerConfig{ref: cell.PrimaryListener, addr: ":0", server: stubGRPCServer{}},
+		lis:   lis,
+		owned: true,
+	}
+	require.NoError(t, drainAllGRPCServers(context.Background(), []boundGRPC{bd}))
+
+	entry := sloghelper.FindLogEntry(buf.String(), "gRPC server drained")
+	require.NotNil(t, entry, "expected a drained log line")
+	assert.Equal(t, boundAddr, entry["addr"],
+		"drain success log must record the actual bound addr, not the configured :0")
+}
+
+// TestGRPCDrain_FailureLogsBoundAddr asserts the drain FAILURE log and the
+// wrapped error both carry the bound addr, not ":0".
+func TestGRPCDrain_FailureLogsBoundAddr(t *testing.T) {
+	buf := installCaptureLogger(t)
+	lis := bindEphemeralLoopback(t)
+	boundAddr := lis.Addr().String()
+
+	bd := boundGRPC{
+		cfg:   grpcListenerConfig{ref: cell.PrimaryListener, addr: ":0", server: closeErrGRPCServer{err: errors.New("drain boom")}},
+		lis:   lis,
+		owned: true,
+	}
+	err := drainAllGRPCServers(context.Background(), []boundGRPC{bd})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), boundAddr,
+		"wrapped drain error must carry the bound addr, not :0")
+
+	entry := sloghelper.FindLogEntry(buf.String(), "gRPC server drain failed")
+	require.NotNil(t, entry, "expected a drain-failed log line")
+	assert.Equal(t, boundAddr, entry["addr"],
+		"drain failure log must record the actual bound addr, not the configured :0")
+}


### PR DESCRIPTION
## Summary

gRPC bootstrap 启停可观测/安全对齐 HTTP：drain 日志记**实际 bound addr**（F8），AllowInsecure 绑**非 loopback** 时启动 `slog.Warn`（B2）。

## Why / 背景

PR #1584（GAP-1 PR-7 [#1150]）ship 评论留了两条「OUT（需人工确认）」缺口，核实后是真实、未登记、可立即处理的小工作（其余遗留项均已完成 / 已正确登记 issue / 确认 won't-do / 确认非问题）：

- **F8** — `drainAllGRPCServers` 的成功/失败日志 + 包裹 error 用 `cfg.addr`，当 addr 为 `:0`（临时端口）时记成 `:0` 而非实际端口；而 bind/serve 路径已用 `lis.Addr()`。根因 = `boundGRPC` 同时暴露 `cfg.addr`(可为 `:0`) 与 `lis.Addr()`，调用方可选错。**根因消除版**：加 `boundGRPC.boundAddr()` accessor，bind-success/serve/drain 全部读它，「绑定后的地址」只剩一个显式入口；仅 bind **失败**日志（此时无 listener）保留 `cfg.addr`。
- **B2** — `AllowInsecure` 绑非 loopback 地址（mesh-sidecar 合法明文部署）启动**无告警**，而 HTTP 侧有 OPS-07（`bootstrap_phase7.go`）。补 `adapters/grpc.Server.serve` 内 `slog.Warn`（含 `wildcard_bind`）。**落 adapter 侧**——`runtime/bootstrap` 头部声明无 `adapters/grpc` 依赖、看不到 `AllowInsecure`，照搬 HTTP 的 bootstrap 侧告警会跨层；adapter 自身既知 `TLSConfig` 又从 `lis.Addr()` 拿地址。**Warn 而非 fail-closed**：`TLSConfig.AllowInsecure` doc 明确认可非 loopback 明文是合法 mesh-sidecar 拓扑（sidecar 终止 TLS），与 HTTP OPS-07 同性质。

`serve(ctx, lis)` 是 `Serve`（listener-injection）与 `serveAddr`（自绑）的唯一汇聚点，告警落此处单点覆盖两条服务路径。

## Refs

- Follow-up of #1584（GAP-1 PR-7 [#1150]）ship OUT findings F8 / B2；非新 issue。
- ref: HTTP OPS-07 告警形态 `runtime/bootstrap/bootstrap_phase7.go`

## Risk / 兼容性

无破坏性变更。仅日志值（`:0`→实际端口）+ 新增一条 Warn；无 wire/接口/migration 变更，无消费方需同步。新增符号 `boundGRPC.boundAddr()` / `warnIfInsecureNonLoopback` 均 unexported。属 bug-fix / 可观测性增量，按 AI-robust 章程「适用范围」不在 enforcement 治理范围，不挂 archtest（强加字符串锚点 archtest 反而是 Soft，章程禁立项）。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./runtime/bootstrap/... ./adapters/grpc/...` 通过（含 `-tags=integration`）
- [x] `golangci-lint run ./runtime/bootstrap/... ./adapters/grpc/...` 0 issues
- [x] TDD RED→GREEN：F8 drain 日志断言实际端口（捕获 slog）；B2 table-driven 覆盖 loopback / 非 loopback / wildcard / IPv6 / 非 TCP × insecure/TLS

> 注：full `go test ./...` 另现 2 条 **nightly-only** archtest 红（`CONTRACT-YAML-NO-CODEGEN-TRUE-LITERAL-01` @ `examples/iotdevice/contracts/command/.../contract.yaml`、`MESSAGE-CONST-LITERAL-01` @ `adapters/postgres/migration_set.go:106`），均**不在本 PR diff**、不在 PR-time 核心 invariant 集，系 develop 既有债，与本变更无关。
