### PR TITLE
feat(skills): fix 3.4 后置自检信号 hook —— exitplanmode 式提醒 [#1599]

### DIFF
--- a/.claude/hooks/fix-self-audit.sh
+++ b/.claude/hooks/fix-self-audit.sh
@@ -7,6 +7,8 @@
 #   消费、少自检一轮（之后恢复）——预期降级，非 bug。
 # 机制参照 exitplan-self-audit.sh（PreToolUse(ExitPlanMode) 同款 deny 回喂）；注册于 committed
 #   .claude/settings.json（团队共享，#1599 刻意选择；exitplan 在 settings.local.json 是历史差异）。
+# 两层过滤：settings.json 的 hook `if: Bash(bash *fix-self-audit.sh*)` 粗筛——只在 bash 调用本脚本时
+#   spawn（go test/ls/cat/chmod 等不触发、无误导 statusMessage）；下面的 case 精筛 emit 实参。
 # AI-robust：与 exitplan-self-audit.sh 同类的「自检提醒」hook，本质 Soft（按命令名锚定 + deny 回喂），
 #   非约束 enforcement（不 enforce 不变式），不落 ai-robust.md「Soft 严禁立项」范围；属对既有先例的复制。
 set -euo pipefail

--- a/.claude/hooks/fix-self-audit.sh
+++ b/.claude/hooks/fix-self-audit.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) hook：fix 3.4 决策后、进阶段 4 改代码前，技能发占位命令
 #   bash "$CLAUDE_PROJECT_DIR/.claude/hooks/fix-self-audit.sh" emit
-# 每次 fix 首次发该信号 → deny 并回喂自检问题，逼模型按四原则复审本次 fix 方案后重发即放行。
+# 每次 fix 首次发该信号 → deny 并回喂自检问题，提示模型按四原则复审本次 fix 方案后重发即放行。
 # 消费式 toggle：放行（重发）时删标记，故每个 /fix 都重新自检（≠ exitplan-self-audit.sh 的每会话一次）。
-# 机制参照 exitplan-self-audit.sh（PreToolUse(ExitPlanMode) 同款 deny 回喂）。
+#   已知 fail-open 降级：deny 后若中途不重发（/fix 提前中止），残留标记会被下个 /fix 的首次 emit
+#   消费、少自检一轮（之后恢复）——预期降级，非 bug。
+# 机制参照 exitplan-self-audit.sh（PreToolUse(ExitPlanMode) 同款 deny 回喂）；注册于 committed
+#   .claude/settings.json（团队共享，#1599 刻意选择；exitplan 在 settings.local.json 是历史差异）。
 # AI-robust：与 exitplan-self-audit.sh 同类的「自检提醒」hook，本质 Soft（按命令名锚定 + deny 回喂），
 #   非约束 enforcement（不 enforce 不变式），不落 ai-robust.md「Soft 严禁立项」范围；属对既有先例的复制。
 set -euo pipefail
@@ -11,13 +14,14 @@ set -euo pipefail
 # 占位命令直跑形态（技能实际执行的就是它）：无副作用、不读 stdin、成功返回
 [ "${1:-}" = "emit" ] && exit 0
 
-command -v jq >/dev/null 2>&1 || exit 0   # jq 缺失则放行，不阻塞工具调用
+# jq 缺失则放行（不阻塞工具调用）；输出 stderr 使降级可见，不进 hook 响应
+command -v jq >/dev/null 2>&1 || { echo "[fix-self-audit] jq 缺失，自检 hook 跳过" >&2; exit 0; }
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 case "$cmd" in
-  *fix-self-audit.sh*) ;;   # 命中本信号 → 走自检逻辑
-  *) exit 0 ;;              # 非本信号 → fail-open 放行（不碰无关 Bash）
+  *fix-self-audit.sh*" emit"*) ;;   # 命中本信号（脚本名 + emit 实参）→ 走自检逻辑
+  *) exit 0 ;;                       # 非本信号（含对脚本本身的 cat/chmod/grep 等）→ fail-open 放行
 esac
 
 sid=$(printf '%s' "$input" | jq -r '.session_id // "default"')

--- a/.claude/hooks/fix-self-audit.sh
+++ b/.claude/hooks/fix-self-audit.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook：fix 3.4 决策后、进阶段 4 改代码前，技能发占位命令
+#   bash "$CLAUDE_PROJECT_DIR/.claude/hooks/fix-self-audit.sh" emit
+# 每次 fix 首次发该信号 → deny 并回喂自检问题，逼模型按四原则复审本次 fix 方案后重发即放行。
+# 消费式 toggle：放行（重发）时删标记，故每个 /fix 都重新自检（≠ exitplan-self-audit.sh 的每会话一次）。
+# 机制参照 exitplan-self-audit.sh（PreToolUse(ExitPlanMode) 同款 deny 回喂）。
+# AI-robust：与 exitplan-self-audit.sh 同类的「自检提醒」hook，本质 Soft（按命令名锚定 + deny 回喂），
+#   非约束 enforcement（不 enforce 不变式），不落 ai-robust.md「Soft 严禁立项」范围；属对既有先例的复制。
+set -euo pipefail
+
+# 占位命令直跑形态（技能实际执行的就是它）：无副作用、不读 stdin、成功返回
+[ "${1:-}" = "emit" ] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0   # jq 缺失则放行，不阻塞工具调用
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+case "$cmd" in
+  *fix-self-audit.sh*) ;;   # 命中本信号 → 走自检逻辑
+  *) exit 0 ;;              # 非本信号 → fail-open 放行（不碰无关 Bash）
+esac
+
+sid=$(printf '%s' "$input" | jq -r '.session_id // "default"')
+sid=$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9-')   # 消毒：杜绝路径穿越
+[ -n "$sid" ] || sid="default"
+state="${TMPDIR:-/tmp}/claude-fix-audited-${sid}"
+
+# 待放行的重发（自检后再次发信号）→ 消费标记 + 放行；下个 /fix 又从 deny 开始
+[ -f "$state" ] && { rm -f "$state"; exit 0; }
+
+# 本次 fix 首次发信号 → deny 并回喂自检问题（先 deny 后打标记，jq 失败则标记不落盘）
+jq -nc '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: "措施符合彻底、不向后兼容 措施优雅简洁、AI HARD的原则吗"
+  }
+}'
+touch "$state"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,7 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(bash *fix-self-audit.sh*)",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/fix-self-audit.sh\"",
             "statusMessage": "fix 决策自检…"
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "skillOverrides": {
     "sonar-scan": "user-invocable-only"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/fix-self-audit.sh\"",
+            "statusMessage": "fix 决策自检…"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -184,6 +184,16 @@ Cx2 及以上问题，**先查参考实现再动手**。三层按权威性递减
 - 最后两项固定：`commit + push` + `闭合/创建 GitHub issues`
 - 创建后立即执行，不等确认
 
+### 3.6 决策自检信号（3.4 → 4.x hook 锚点）
+
+进阶段 4 改代码前，发一次决策自检信号：
+
+```
+bash "$CLAUDE_PROJECT_DIR/.claude/hooks/fix-self-audit.sh" emit
+```
+
+`PreToolUse(Bash)` hook 锚定该命令：本次 fix 首次发信号会 deny 并回喂「措施符合彻底、不向后兼容 措施优雅简洁、AI HARD的原则吗」。收到后**真正**按四原则复审本次 fix 方案（彻底 / 不向后兼容 / 优雅简洁 / AI-HARD），按需回调 3.1–3.4 决策，再重发同一命令即放行、进入阶段 4。机制同 ExitPlanMode 的 `.claude/hooks/exitplan-self-audit.sh`，但**每个 /fix 都自检**（消费式 toggle，非每会话一次）。这是自检提醒，**不是**新的 AskUserQuestion 闸门（不重复 §沟通规则）。
+
 ---
 
 ## 阶段 4: 执行修复


### PR DESCRIPTION
## Summary

fix 技能 3.4(执行决策)→4.x(执行) 之间新增「决策自检信号」hook —— 复制 `exitplan-self-audit.sh` 范式：fix 改代码前发占位命令，`PreToolUse(Bash)` hook 本次 fix 首次发信号时 deny 并回喂四原则自检问题，复审后重发即放行。

## Why / 背景

fix 3.4 后置点没有稳定信号，挂自动化只能改 skill 文本、无法用 `.claude/settings.json` hook 解耦。本 PR 把仓内成熟的 ExitPlanMode 自检 hook 范式搬到 fix（fix 不走 plan mode，改用占位 Bash 命令 + PreToolUse matcher），逼模型在动手改代码前对本次修复方案做一次四原则复审。是 #935「PR review-loop 自动化」的 fix 侧切口。

设计取舍（用户对齐）：就一个自检提醒——无 decision JSON / 无分区 gate / 无账本 / 无自动建 issue（后者会与 fix 既有「建 issue 前 AskUserQuestion」闸门冲突，明确排除）。**每个 /fix 都自检**（消费式 toggle，放行时删标记），区别于 exitplan 的每会话一次。

## Refs

Closes #1599 · Part of #935
ref: `.claude/hooks/exitplan-self-audit.sh`（PreToolUse(ExitPlanMode) deny 回喂范式）

## Risk / 兼容性

- 仅 `.claude/` harness 配置 + shell hook，无 Go 生产代码、无 wire 契约 / migration 影响。
- hook 装进 **committed** `.claude/settings.json`（非 gitignore 的 `settings.local.json`），成团队共享约定；与既有 `exitplan-self-audit.sh`（在 local）并存不冲突。
- AI-robust：与 `exitplan-self-audit.sh` 同类的「自检提醒」hook，本质 Soft（命令名锚定 + deny 回喂），非约束 enforcement（不 enforce 不变式），不落 `ai-robust.md`「Soft 严禁立项」范围——属对既有先例的复制 + 用户明确指示。
- 已知极小边角：deny 后被打断、同会话再起新 fix 时残留标记会让那一次少自检一轮（之后恢复）；nonce 化可消除，按「越简单越好」暂不做。

## Test plan

- [x] `shellcheck .claude/hooks/fix-self-audit.sh` —— 0 issues
- [x] `jq -e . .claude/settings.json` —— valid JSON
- [x] 5 行为用例手验：首次 deny + 自检问题 + 建标记 / 自检后重发放行 + 消费标记 / 下个 fix 再 deny（每次都自检）/ 无关 Bash fail-open / 直跑 `emit` exit 0 无阻塞
- [ ] N/A `go build` / `go test` / `golangci-lint`（本 PR 无 Go 改动）
