### PR TITLE
test(session-cache): freeze sessionCacheEntry fields + Revoke caller-in-tx archtest [#1615][#1616]

### DIFF
--- a/adapters/redis/session_cache_entry_frozen_test.go
+++ b/adapters/redis/session_cache_entry_frozen_test.go
@@ -20,12 +20,15 @@
 //     the comparison, forcing the change to land on an explicit frozen-list
 //     review checkpoint.
 //
-//   - [TestSessionCacheEntryNoLiveAuthzEpoch01]: security-specific guard with
-//     non-vacuity — asserts that NO field's name equals (case-insensitive)
-//     "AuthzEpoch", and no field's JSON key (stripped of modifiers) is
-//     "authzepoch" or "authz_epoch".  Positive control (non-vacuity): asserts
-//     that AuthzEpochAtIssue IS present, so the test fails loudly if the
-//     snapshot field is renamed — proving the scan is live.
+//   - [TestSessionCacheEntryNoLiveAuthzEpoch01]: security-specific defense-in-depth
+//     guard with non-vacuity — asserts that NO field's name equals exactly
+//     "authzepoch" (case-insensitive), and no field's JSON key (stripped of
+//     modifiers) is exactly "authzepoch" or "authz_epoch".  These exact-equality
+//     checks catch the specific bare-AuthzEpoch / authz_epoch mistake; the
+//     primary gate for ANY new field (including name variants) is the
+//     NumField()==4 freeze in [TestSessionCacheEntryFieldsFrozen01].  Positive
+//     control (non-vacuity): asserts that AuthzEpochAtIssue IS present, so the
+//     test fails loudly if the snapshot field is renamed — proving the scan is live.
 //
 // # AI-robust grade: Hard
 //
@@ -47,9 +50,12 @@
 // alone cannot catch is a *semantic* rename that keeps the same type and tag
 // while introducing a field that does carry live-epoch data under a different
 // name.  [TestSessionCacheEntryNoLiveAuthzEpoch01] is the defense-in-depth
-// guard: it scans for any field whose name or JSON key resembles "AuthzEpoch"
-// (case-insensitive), so even a careless frozen-tuple edit that re-adds such a
-// field is caught by the dedicated assertion.
+// guard: its exact-equality checks catch the specific bare-AuthzEpoch /
+// authz_epoch mistake.  The PRIMARY protection against ANY new field
+// (including variants such as AuthzEpochLive or AuthzEpochCurrent) is the
+// NumField()==4 + ordered-tuple freeze in [TestSessionCacheEntryFieldsFrozen01]:
+// adding any field — regardless of name — forces an explicit update to the
+// frozen list under reviewer attention.
 package redis
 
 import (
@@ -153,7 +159,9 @@ func TestSessionCacheEntryNoLiveAuthzEpoch01(t *testing.T) {
 		f := st.Field(i)
 		nameLower := strings.ToLower(f.Name)
 
-		// Detect any "bare" AuthzEpoch field (live epoch).
+		// Detect the bare "AuthzEpoch" field name (exact equality, case-insensitive).
+		// Defense-in-depth for that specific mistake; primary gate for all name variants
+		// is the NumField()+tuple freeze in TestSessionCacheEntryFieldsFrozen01.
 		if nameLower == "authzepoch" {
 			t.Errorf(
 				"SESSION-CACHE-EPOCH-NOT-CACHED-01: field %q has name equal to 'authzepoch' (case-insensitive).\n"+
@@ -163,7 +171,8 @@ func TestSessionCacheEntryNoLiveAuthzEpoch01(t *testing.T) {
 			)
 		}
 
-		// Detect any JSON tag key that looks like the live epoch.
+		// Detect the exact JSON tag keys "authzepoch" and "authz_epoch" (exact equality).
+		// Exact equality avoids false-positives on the legitimate "authzEpochAtIssue" key.
 		rawTag := f.Tag.Get("json")
 		jsonKey := strings.ToLower(strings.SplitN(rawTag, ",", 2)[0])
 		if jsonKey == "authzepoch" || jsonKey == "authz_epoch" {

--- a/adapters/redis/session_cache_entry_frozen_test.go
+++ b/adapters/redis/session_cache_entry_frozen_test.go
@@ -1,0 +1,191 @@
+// INVARIANT: SESSION-CACHE-EPOCH-NOT-CACHED-01
+//
+// This file freezes the field set of [sessionCacheEntry], the on-wire Redis
+// shape used by [CachingSessionStore]. The invariant it protects is:
+//
+//	The live users.authz_epoch is NEVER cached in Redis.
+//
+// [CachingSessionStore.RevokeForSubject] delegates to inner with no cache
+// operation.  Its fail-closed security floor depends on sessionvalidate
+// comparing the LIVE PG users.authz_epoch against the cached
+// AuthzEpochAtIssue snapshot (mismatch → 401).  If the live epoch were ever
+// added to sessionCacheEntry, that comparison would use a stale value, silently
+// breaking the revocation guarantee.
+//
+// # Two test functions
+//
+//   - [TestSessionCacheEntryFieldsFrozen01]: reflect-schema freeze — pins
+//     NumField == 4 and an exact ordered tuple of (name, json-tag, Go-type)
+//     for all four fields.  Any drift in field count, name, tag, or type fails
+//     the comparison, forcing the change to land on an explicit frozen-list
+//     review checkpoint.
+//
+//   - [TestSessionCacheEntryNoLiveAuthzEpoch01]: security-specific guard with
+//     non-vacuity — asserts that NO field's name equals (case-insensitive)
+//     "AuthzEpoch", and no field's JSON key (stripped of modifiers) is
+//     "authzepoch" or "authz_epoch".  Positive control (non-vacuity): asserts
+//     that AuthzEpochAtIssue IS present, so the test fails loudly if the
+//     snapshot field is renamed — proving the scan is live.
+//
+// # AI-robust grade: Hard
+//
+// Per .claude/rules/gocell/ai-robust.md §Hard 范本目录 "reflect schema freeze":
+//
+//	Hard comes from the fact that reflect enumerates field count, per-field
+//	name, json-tag, and Go type as objective runtime structural facts — not
+//	string anchors, not comments.  Any drift (add / rename / retype / reorder)
+//	necessarily fails the tuple comparison, forcing the change to land on an
+//	explicit frozen-list review checkpoint.
+//
+// Note: issue #1616 initially estimated "Medium", but per the ai-robust
+// "reflect schema freeze" template this is Hard.  We grade it Hard.
+//
+// # Blind-spot self-check
+//
+// reflect.TypeOf enumerates ALL fields (including unexported fields), so there
+// is no AST blind spot for field-set drift.  The one thing structural freeze
+// alone cannot catch is a *semantic* rename that keeps the same type and tag
+// while introducing a field that does carry live-epoch data under a different
+// name.  [TestSessionCacheEntryNoLiveAuthzEpoch01] is the defense-in-depth
+// guard: it scans for any field whose name or JSON key resembles "AuthzEpoch"
+// (case-insensitive), so even a careless frozen-tuple edit that re-adds such a
+// field is caught by the dedicated assertion.
+package redis
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// sessionCacheEntryField is one frozen (name, jsonTag, goType) triple for
+// a field of [sessionCacheEntry].  Reordering the slice changes the
+// semantic reading of the on-wire JSON — encoding/json emits struct fields in
+// source-declaration order — so the ORDER of this slice is part of the lock.
+type sessionCacheEntryField struct {
+	Name    string
+	JSONTag string
+	GoType  string
+}
+
+// expectedSessionCacheEntryFields is the authoritative 4-field frozen schema
+// for sessionCacheEntry.  Changing any entry requires updating this list under
+// explicit reviewer attention AND ensuring that the live users.authz_epoch is
+// still not being cached (which would break the RevokeForSubject fail-closed
+// security floor described in the file-level godoc).
+var expectedSessionCacheEntryFields = []sessionCacheEntryField{
+	{Name: "ID", JSONTag: "id", GoType: "string"},
+	{Name: "SubjectID", JSONTag: "subjectId", GoType: "string"},
+	{Name: "RevokedAt", JSONTag: "revokedAt,omitempty", GoType: "*time.Time"},
+	{Name: "AuthzEpochAtIssue", JSONTag: "authzEpochAtIssue", GoType: "int64"},
+}
+
+// TestSessionCacheEntryFieldsFrozen01 reflects over [sessionCacheEntry] and
+// asserts that the field set has not drifted from [expectedSessionCacheEntryFields].
+//
+// The four assertions are:
+//  1. NumField() == 4: adding a 5th field re-opens the live-epoch-not-cached
+//     invariant (the new field might carry the live epoch); update this frozen
+//     list AND the godoc / issue #1616 deliberately.
+//  2. Exact ordered tuple comparison: name, json-tag, and Go-type for each
+//     field in source-declaration order.
+func TestSessionCacheEntryFieldsFrozen01(t *testing.T) {
+	t.Parallel()
+
+	st := reflect.TypeOf(sessionCacheEntry{})
+	if st.Kind() != reflect.Struct {
+		t.Fatalf("SESSION-CACHE-EPOCH-NOT-CACHED-01: sessionCacheEntry is not a struct (kind=%s)", st.Kind())
+	}
+
+	if got, want := st.NumField(), len(expectedSessionCacheEntryFields); got != want {
+		t.Fatalf(
+			"SESSION-CACHE-EPOCH-NOT-CACHED-01: sessionCacheEntry has %d fields, frozen set has %d.\n"+
+				"Adding a field re-opens the live-epoch-not-cached security invariant.\n"+
+				"If intentional, update expectedSessionCacheEntryFields + the file-level godoc deliberately.",
+			got, want,
+		)
+	}
+
+	var actual []sessionCacheEntryField
+	for i := range st.NumField() {
+		f := st.Field(i)
+		actual = append(actual, sessionCacheEntryField{
+			Name:    f.Name,
+			JSONTag: f.Tag.Get("json"),
+			GoType:  f.Type.String(),
+		})
+	}
+
+	if !reflect.DeepEqual(actual, expectedSessionCacheEntryFields) {
+		t.Errorf(
+			"SESSION-CACHE-EPOCH-NOT-CACHED-01: sessionCacheEntry schema drifted.\n"+
+				"  got  %+v\n"+
+				"  want %+v\n"+
+				"Drift in name / json-tag / type breaks the on-wire Redis schema.\n"+
+				"Update expectedSessionCacheEntryFields deliberately.",
+			actual, expectedSessionCacheEntryFields,
+		)
+	}
+}
+
+// TestSessionCacheEntryNoLiveAuthzEpoch01 is the security-specific guard with
+// non-vacuity proof.
+//
+// It asserts:
+//   - NO field has a name equal (case-insensitive) to "AuthzEpoch".
+//   - NO field has a JSON tag key (stripped of modifiers) that is "authzepoch"
+//     or "authz_epoch".
+//
+// These two assertions detect any attempt to add a field that carries the live
+// users.authz_epoch (the prohibited form) rather than the at-issue snapshot.
+//
+// Positive control (non-vacuity): asserts that a field named AuthzEpochAtIssue
+// with json tag "authzEpochAtIssue" IS present, so the test fails loudly if
+// the snapshot field is renamed/removed, proving the scan is live and not
+// passing vacuously.
+func TestSessionCacheEntryNoLiveAuthzEpoch01(t *testing.T) {
+	t.Parallel()
+
+	st := reflect.TypeOf(sessionCacheEntry{})
+
+	var foundSnapshot bool
+	for i := range st.NumField() {
+		f := st.Field(i)
+		nameLower := strings.ToLower(f.Name)
+
+		// Detect any "bare" AuthzEpoch field (live epoch).
+		if nameLower == "authzepoch" {
+			t.Errorf(
+				"SESSION-CACHE-EPOCH-NOT-CACHED-01: field %q has name equal to 'authzepoch' (case-insensitive).\n"+
+					"The live users.authz_epoch MUST NOT be cached — only AuthzEpochAtIssue is permitted.\n"+
+					"Caching the live epoch breaks the RevokeForSubject fail-closed security floor.",
+				f.Name,
+			)
+		}
+
+		// Detect any JSON tag key that looks like the live epoch.
+		rawTag := f.Tag.Get("json")
+		jsonKey := strings.ToLower(strings.SplitN(rawTag, ",", 2)[0])
+		if jsonKey == "authzepoch" || jsonKey == "authz_epoch" {
+			t.Errorf(
+				"SESSION-CACHE-EPOCH-NOT-CACHED-01: field %q has json key %q which resembles the live authz_epoch.\n"+
+					"Only 'authzEpochAtIssue' (the at-issue snapshot) is permitted in sessionCacheEntry.",
+				f.Name, jsonKey,
+			)
+		}
+
+		// Positive control: the snapshot field must still be present.
+		if f.Name == "AuthzEpochAtIssue" && rawTag == "authzEpochAtIssue" {
+			foundSnapshot = true
+		}
+	}
+
+	if !foundSnapshot {
+		t.Error(
+			"SESSION-CACHE-EPOCH-NOT-CACHED-01 non-vacuity: field AuthzEpochAtIssue with json tag " +
+				"'authzEpochAtIssue' not found in sessionCacheEntry.\n" +
+				"The at-issue snapshot field has been renamed or removed — update the frozen list AND " +
+				"ensure sessionvalidate still has a snapshot field to compare against the live PG epoch.",
+		)
+	}
+}

--- a/adapters/redis/session_cache_store.go
+++ b/adapters/redis/session_cache_store.go
@@ -190,6 +190,14 @@ const sessionCacheRevokeDELTimeout = 2 * time.Second
 // makes field addition an explicit code change rather than an automatic
 // propagation from session.ValidateView. Adding a sensitive field to
 // ValidateView must be a deliberate decision to also land here.
+//
+// The field set is frozen by INVARIANT SESSION-CACHE-EPOCH-NOT-CACHED-01
+// (session_cache_entry_frozen_test.go): it must NOT carry the live
+// users.authz_epoch — only AuthzEpochAtIssue (the at-issue snapshot). The
+// RevokeForSubject fail-closed floor depends on the live epoch never being
+// cached (sessionvalidate compares the live PG epoch against this snapshot); a
+// reflect freeze prevents a future field addition from silently removing that
+// premise.
 type sessionCacheEntry struct {
 	ID                string     `json:"id"`
 	SubjectID         string     `json:"subjectId"`
@@ -407,9 +415,20 @@ func (s *CachingSessionStore) lazyPopulate(ctx context.Context, key string, view
 // transaction is a programmer error, surfaced loudly rather than silently
 // dropping the eviction. The shared storetest conformance suite, which calls
 // Revoke bare, supplies the unit-of-work scope via the test-only
-// txScopedRevokeStore bridge (session_cache_store_conformance_test.go). Making
-// this precondition compile-enforced (a typed tx-scoped revoke capability rather
-// than a runtime panic) is the deferred Hard-upgrade tracked at gh #1615.
+// txScopedRevokeStore bridge (session_cache_store_conformance_test.go).
+// Compile-enforcing this precondition (a typed tx-scoped revoke capability
+// rather than a runtime panic) was evaluated as gh #1615's F3 and resolved
+// won't-do: a same-package seal is unreachable because the read path's
+// evictBadEntry / lazyPopulate legitimately need a synchronous s.cache.Delete /
+// s.cache.Set, so the cache-mutation capability must live on a struct field that
+// every method (Revoke included) can reach — Go has no per-method field scoping.
+// A cross-package internal-subpackage seal could reach Hard but is
+// disproportionate for this single-caller P3 and has zero industry precedent
+// (Spring TransactionSynchronization, Hibernate AfterTransactionCompletionProcess,
+// ent CommitHook, Watermill forwarder all rely on runtime registration +
+// convention, never a type seal). The "second production caller" risk is instead
+// caught statically by archtest SESSION-REVOKE-CALLER-INTX-01, which allowlists
+// the production callers of session.Store.Revoke (each verified RunInTx-wrapped).
 //
 // archtest CACHING-SESSION-REVOKE-AFTERCOMMIT-DEL-01 locks the shape: the body
 // must delegate to s.inner.Revoke, and any s.cache.Delete/Set must be lexically

--- a/runtime/auth/session/store.go
+++ b/runtime/auth/session/store.go
@@ -133,7 +133,13 @@ type ValidateView struct {
 //     already wraps Revoke in RunInTx); bare callers — the storetest
 //     conformance suite — supply a unit-of-work scope themselves. Compile-
 //     enforcing this precondition (a typed tx-scoped revoke capability rather
-//     than a runtime panic) is the deferred Hard-upgrade tracked at gh #1615.
+//     than a runtime panic) was evaluated as gh #1615's F3 and resolved won't-do
+//     (a same-package seal is unreachable — adapters/redis's read path needs a
+//     synchronous cache mutation on the same field Revoke uses, and Go has no
+//     per-method field scoping; a cross-package seal is disproportionate with no
+//     industry precedent). The "second caller outside a tx" risk is instead
+//     caught statically by archtest SESSION-REVOKE-CALLER-INTX-01, which
+//     allowlists session.Store.Revoke's production callers (each RunInTx-wrapped).
 //   - RevokeForSubject: mark every active session for SubjectID dead. tok is
 //     a credentialfence.FenceToken — a sealed capability proof minted only by
 //     credentialinvalidate.Invalidator via credentialfence.Mint; passing nil

--- a/tools/archtest/caching_session_revoke_delegate_only_test.go
+++ b/tools/archtest/caching_session_revoke_delegate_only_test.go
@@ -37,9 +37,21 @@
 //     hook FuncLit [Lbrace, Rbrace]); but it is a gate-based check with the
 //     documented blind spots below (helper-one-level, TypesInfo==nil fixture
 //     path), and Go does not make an out-of-hook cache mutation uncompilable —
-//     so this is honestly Medium. Hard-upgrade path = sealed construction making
-//     out-of-hook cache writes type-system-unrepresentable (e.g. the cache field
-//     exposes only an after-commit-scoped handle); tracked gh #1615.
+//     so this is honestly Medium — and a PERMANENT ceiling, not a deferred
+//     upgrade. The "sealed construction" Hard path (the cache field exposes only
+//     an after-commit-scoped handle, making out-of-hook cache writes
+//     type-system-unrepresentable) was evaluated as gh #1615's F3 and resolved
+//     won't-do: the read path's evictBadEntry / lazyPopulate legitimately need a
+//     synchronous (*CachingSessionStore).cache.Delete / .Set, so the cache
+//     capability must live on a struct field Revoke can always reach (Go has no
+//     per-method field scoping). A cross-package internal-subpackage seal could
+//     reach Hard but is disproportionate for this single-caller P3 and has zero
+//     industry precedent (Spring/Hibernate/ent/Watermill all use runtime
+//     registration + convention, never a type seal — GoCell already exceeds them
+//     via the RegisterAfterCommit panic + RunAfterCommitHooks TxCtxKey strip +
+//     this archtest). Same permanent-Go-ceiling family as #851/#893/#1282. The
+//     "second production caller outside a tx" risk that motivated the upgrade is
+//     now caught at CI by SESSION-REVOKE-CALLER-INTX-01 (caller-allowlist).
 //   The hook body's own purity (no tx / outbox writer) is enforced independently
 //   and in parallel by AFTERCOMMIT-HOOK-PURE-TRANSIENT-01.
 //

--- a/tools/archtest/session_revoke_caller_intx_test.go
+++ b/tools/archtest/session_revoke_caller_intx_test.go
@@ -18,11 +18,12 @@
 //
 // This archtest moves the "a future caller forgets the RunInTx scope" risk from a
 // runtime panic to a CI failure. It allowlists every production reference to the
-// interface method (session.Store).Revoke per ENCLOSING FUNCTION (not per file):
-// tx-scope is a per-function property; a new function must trigger review, but a
-// second Revoke inside an already-blessed function is automatically safe. Any new
-// (rel, func) pair outside the allowlist fails CI until a reviewer verifies the
-// new caller is RunInTx-wrapped and adds it.
+// interface method (session.Store).Revoke per EXACT CALLSITE (file + enclosing
+// function + ordinal + context expression). A new Revoke call in an already
+// blessed function still triggers review. The rule also allowlists the production
+// call edges into tx-scoped helpers that hide the Revoke selector
+// (cleanupIssuedSession / revokeAndPublish), so a future non-transaction helper
+// reuse cannot silently bypass the Revoke callsite scan.
 //
 // Note on tx verification: the human-verified fact is that each allowlisted
 // caller wraps the Revoke call in a RunInTx scope.  go/types CANNOT prove
@@ -34,11 +35,11 @@
 //
 // # AI-robust rating (charter §"Funnel 双向锁评级")
 //
-//   - Downstream: MEDIUM by archtest caller-allowlist at PER-FUNCTION granularity.
+//   - Downstream: MEDIUM by archtest caller-allowlist at PER-CALLSITE granularity.
 //     The callee is resolved via go/types (ResolveMethodCall), so import aliases
 //     and dot-imports resolve to the same symbol. The scan is REFERENCE-based (not
 //     call-based), so passing the method as a function value is also caught. Any
-//     reference in a function not in the allowlist fails in CI.
+//     new reference not in the allowlist fails in CI.
 //   - Upstream: MEDIUM, a GO-LANGUAGE CEILING (not a deferred TODO). Hard
 //     upstream would require a typed tx-scoped revoke capability so calling
 //     Revoke outside a tx is uncompilable. That path — gh #1615 F3 — was
@@ -54,19 +55,20 @@
 //     HEALTHZ-HOLDER-SEAL (#893 won't-do) / principal-write (#1282). Medium is
 //     the honest ceiling for the upstream direction.
 //
-// # Per-function granularity rationale
+// # Per-callsite granularity rationale
 //
 // The prior file-level allowlist was a coarser unit than the safety property it
-// guards: tx-scope is a PER-FUNCTION property, not a per-file one. An already-
-// allowlisted file such as sessionlogin/service.go holds multiple callers; adding
-// a SECOND bare Revoke to that file in a NEW function would have passed CI without
-// review. The per-function allowlist (rel, funcName) tightens the gate to the
-// correct unit:
+// guards, and function-level allowlisting still misses two cases:
+// (1) a second Revoke call added to an already-blessed function, and
+// (2) a tx-scoped helper (whose body contains Revoke) called from a new non-tx
+// path. The per-callsite allowlist (rel, funcName, ordinal, ctx expression) plus
+// helper-call-edge allowlist tightens the gate to the correct review unit:
 //
-//   - A second Revoke inside an ALREADY-BLESSED function is automatically safe
-//     (same function, same ambient tx, no review required).
-//   - A Revoke in a NEW function forces a red CI until a reviewer verifies the
-//     function wraps it in RunInTx and adds the (rel, func) entry.
+//   - A second Revoke inside an ALREADY-BLESSED function gets a new ordinal and
+//     forces red CI until reviewer verifies ctx shape / RunInTx scope.
+//   - A Revoke in a NEW function likewise forces review.
+//   - A new call to cleanupIssuedSession / revokeAndPublish must be allowlisted
+//     as a helper edge, so helper reuse cannot hide non-tx execution.
 //
 // # Detection is REFERENCE-based, not call-based
 //
@@ -91,15 +93,17 @@
 //   - Import aliases and dot-imports are immune BECAUSE ResolveMethodCall
 //     resolves via types.Info.Selections (symbol identity), not syntactic name.
 //     This is a strength, not a blind spot.
-//   - The anti-vacuity guard (every allowlisted (rel,fn) must have ≥1 observed
-//     reference) proves the scanner actually resolves the real references (not a
-//     vacuous pass) AND forbids stale allowlist entries — a dead entry is a
-//     latent bypass slot.
+//   - The anti-vacuity guard (every allowlisted callsite / helper edge must have
+//     ≥1 observed reference) proves the scanner actually resolves the real
+//     references (not a vacuous pass) AND forbids stale allowlist entries — a
+//     dead entry is a latent bypass slot.
 package archtest
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
+	"go/format"
 	"go/types"
 	"sort"
 	"testing"
@@ -107,19 +111,41 @@ import (
 
 const sessionPkgPath = PlatformModulePath + "/runtime/auth/session"
 
-// sessionRevokeCallsite identifies a production reference to (session.Store).Revoke
-// by the module-relative source file and the name of the enclosing FuncDecl.
-// Using the enclosing function as the allowlist key rather than the file is the
-// correct granularity: tx-scope is a per-function property. A new function in an
-// already-allowlisted file must still pass review before its (rel, fn) entry is added.
-// A reference outside any FuncDecl (top-level var init) maps to fn=="" and will
-// always violate — top-level init code cannot hold a RunInTx scope.
+const sessionRevokeMethodValueCtx = "<method-value>"
+
+// sessionRevokeCallsite identifies one production reference to
+// (session.Store).Revoke by exact callsite.
+//
+// ordinal is 1-based within the enclosing function among Revoke references;
+// ctx is the formatted context argument expression for calls, or
+// sessionRevokeMethodValueCtx for method-value references.
+// A reference outside any FuncDecl maps to fn=="" and always violates unless
+// deliberately allowlisted (top-level init code cannot hold a RunInTx scope).
 type sessionRevokeCallsite struct {
-	rel string // module-relative path, e.g. "cells/accesscore/slices/sessionlogout/service.go"
-	fn  string // enclosing FuncDecl name; "" means outside any function (top-level)
+	rel     string
+	fn      string
+	ordinal int
+	ctx     string
 }
 
-// sessionRevokeAllowlist maps (rel, enclosingFunc) callsite pairs that may
+// sessionRevokeHelperCallsite identifies one production call edge into a helper
+// whose body contains a sanctioned (session.Store).Revoke call. The helper call
+// itself must stay tx-scoped, otherwise the hidden Revoke call can execute
+// outside RunInTx without producing a new Revoke selector.
+type sessionRevokeHelperCallsite struct {
+	rel     string
+	fn      string
+	helper  string
+	ordinal int
+	ctx     string
+}
+
+var sessionRevokeTxScopedHelpers = map[string]bool{
+	"cleanupIssuedSession": true,
+	"revokeAndPublish":     true,
+}
+
+// sessionRevokeAllowlist maps exact callsites that may
 // reference the (session.Store).Revoke interface method.
 //
 // Each entry is human-verified to execute Revoke inside a RunInTx scope (the
@@ -176,21 +202,30 @@ type sessionRevokeCallsite struct {
 //     a txScopedRevokeStore-style wrapper (as the conformance suite does) so Revoke
 //     executes inside a RunInTx scope.
 var sessionRevokeAllowlist = map[sessionRevokeCallsite]struct{}{
-	{rel: "cells/accesscore/slices/sessionlogout/service.go", fn: "revokeAndPublish"}:         {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "mintAndPersistSession"}:     {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "persistSessionWithRefresh"}: {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "cleanupIssuedSession"}:      {},
-	{rel: "adapters/redis/session_cache_store.go", fn: "Revoke"}:                              {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeDirect"}:                   {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeIdempotent"}:               {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeNotFoundNoop"}:             {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "seedRevokeForSubjectFixtures"}:      {},
-	{rel: "runtime/auth/session/storetest/bench.go", fn: "benchMixedConcurrent"}:              {},
+	{rel: "cells/accesscore/slices/sessionlogout/service.go", fn: "revokeAndPublish", ordinal: 1, ctx: "txCtx"}:                                {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "mintAndPersistSession", ordinal: 1, ctx: "context.WithoutCancel(txCtx)"}:     {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "persistSessionWithRefresh", ordinal: 1, ctx: "context.WithoutCancel(txCtx)"}: {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "cleanupIssuedSession", ordinal: 1, ctx: "cleanupCtx"}:                        {},
+	{rel: "adapters/redis/session_cache_store.go", fn: "Revoke", ordinal: 1, ctx: "ctx"}:                                                       {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeDirect", ordinal: 1, ctx: "context.Background()"}:                           {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeIdempotent", ordinal: 1, ctx: "context.Background()"}:                       {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeIdempotent", ordinal: 2, ctx: "context.Background()"}:                       {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeNotFoundNoop", ordinal: 1, ctx: "context.Background()"}:                     {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "seedRevokeForSubjectFixtures", ordinal: 1, ctx: "ctx"}:                               {},
+	{rel: "runtime/auth/session/storetest/bench.go", fn: "benchMixedConcurrent", ordinal: 1, ctx: "ctx"}:                                       {},
+}
+
+// sessionRevokeHelperAllowlist maps production call edges into tx-scoped helper
+// methods that contain Revoke callsites.
+var sessionRevokeHelperAllowlist = map[sessionRevokeHelperCallsite]struct{}{
+	{rel: "cells/accesscore/slices/sessionlogout/service.go", fn: "Logout", helper: "revokeAndPublish", ordinal: 1, ctx: "txCtx"}:                       {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "mintAndPersistSession", helper: "cleanupIssuedSession", ordinal: 1, ctx: "txCtx"}:     {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "persistSessionWithRefresh", helper: "cleanupIssuedSession", ordinal: 1, ctx: "txCtx"}: {},
 }
 
 // scanSessionRevokeCallsites walks all FuncDecls in p's files (excluding
-// _test.go), finds every SelectorExpr that resolves to (session.Store).Revoke,
-// attributes each to its enclosing FuncDecl (or fn="" if outside any function),
+// _test.go), finds every reference that resolves to (session.Store).Revoke,
+// attributes each to its exact callsite (or fn="" if outside any function),
 // and emits a Diagnostic for any callsite not in the allowlist.
 //
 // Also records each observed callsite into the provided observed map so the
@@ -212,88 +247,162 @@ func scanSessionRevokeCallsites(
 		if len(rel) > 8 && rel[len(rel)-8:] == "_test.go" {
 			continue
 		}
-		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-			if fd.Body == nil {
-				return
-			}
-			fnName := fd.Name.Name
-			EachInSubtree[ast.SelectorExpr](fd.Body, func(sel *ast.SelectorExpr) {
-				if !sessionRevokeSymbol(p.TypesInfo, sel) {
-					return
-				}
-				cs := sessionRevokeCallsite{rel: rel, fn: fnName}
-				if observed != nil {
-					observed[cs] = struct{}{}
-				}
-				if _, allowed := allowlist[cs]; !allowed {
-					pos := p.Fset.Position(sel.Pos())
-					d = append(d, Diagnostic{
-						Rel:  rel,
-						Line: pos.Line,
-						Message: fmt.Sprintf(
-							"SESSION-REVOKE-CALLER-INTX-01: (session.Store).Revoke is referenced "+
-								"from %s in function %q, which is not in the sanctioned caller allowlist. "+
-								"adapters/redis.CachingSessionStore.Revoke registers a post-commit "+
-								"cache DEL via persistence.RegisterAfterCommit, which PANICS if "+
-								"called outside a RunInTx scope. Before adding (%q, %q) to "+
-								"sessionRevokeAllowlist, a reviewer MUST verify that this function "+
-								"wraps the Revoke call in a RunInTx closure.",
-							rel, fnName, rel, fnName,
-						),
-					})
-				}
-			})
-		})
-		// Also catch references outside any FuncDecl (top-level var/init).
-		// We do this by scanning the whole file for Revoke selectors and
-		// subtracting those already attributed to a FuncDecl body.
-		// (Top-level references are so rare that a simpler approach is fine:
-		// just scan the full file and check whether the position is inside any
-		// FuncDecl body range — but for simplicity we rely on the fact that
-		// EachInSubtree[ast.FuncDecl] covers all function bodies, and any
-		// reference NOT inside a FuncDecl body is by definition top-level.)
-		topLevelObserved := map[int]bool{} // position offset → true, recorded inside funcs
+		funcRefOffsets := map[int]bool{}
 		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
 			if fd.Body == nil {
 				return
 			}
 			EachInSubtree[ast.SelectorExpr](fd.Body, func(sel *ast.SelectorExpr) {
 				if sessionRevokeSymbol(p.TypesInfo, sel) {
-					topLevelObserved[p.Fset.Position(sel.Pos()).Offset] = true
+					funcRefOffsets[p.Fset.Position(sel.Pos()).Offset] = true
 				}
 			})
+			d = append(d, scanSessionRevokeCallsitesInNode(p, rel, fd.Name.Name, fd.Body, nil, allowlist, observed)...)
 		})
-		EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
-			if !sessionRevokeSymbol(p.TypesInfo, sel) {
+		d = append(d, scanSessionRevokeCallsitesInNode(p, rel, "", file, funcRefOffsets, allowlist, observed)...)
+	}
+	return d
+}
+
+func scanSessionRevokeCallsitesInNode(
+	p *Pass,
+	rel string,
+	fnName string,
+	node ast.Node,
+	skipOffsets map[int]bool,
+	allowlist map[sessionRevokeCallsite]struct{},
+	observed map[sessionRevokeCallsite]struct{},
+) []Diagnostic {
+	var d []Diagnostic
+	callSelectorOffsets := map[int]bool{}
+	ordinal := 0
+
+	EachInSubtree[ast.CallExpr](node, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !sessionRevokeSymbol(p.TypesInfo, sel) {
+			return
+		}
+		pos := p.Fset.Position(sel.Pos())
+		if skipOffsets[pos.Offset] {
+			return
+		}
+		callSelectorOffsets[pos.Offset] = true
+		ordinal++
+		cs := sessionRevokeCallsite{
+			rel:     rel,
+			fn:      fnName,
+			ordinal: ordinal,
+			ctx:     sessionRevokeCallContextExpr(p, sel, call),
+		}
+		d = append(d, recordSessionRevokeCallsite(allowlist, observed, cs, pos.Line)...)
+	})
+
+	EachInSubtree[ast.SelectorExpr](node, func(sel *ast.SelectorExpr) {
+		if !sessionRevokeSymbol(p.TypesInfo, sel) {
+			return
+		}
+		pos := p.Fset.Position(sel.Pos())
+		if skipOffsets[pos.Offset] || callSelectorOffsets[pos.Offset] {
+			return
+		}
+		ordinal++
+		cs := sessionRevokeCallsite{
+			rel:     rel,
+			fn:      fnName,
+			ordinal: ordinal,
+			ctx:     sessionRevokeMethodValueCtx,
+		}
+		d = append(d, recordSessionRevokeCallsite(allowlist, observed, cs, pos.Line)...)
+	})
+
+	return d
+}
+
+func recordSessionRevokeCallsite(
+	allowlist map[sessionRevokeCallsite]struct{},
+	observed map[sessionRevokeCallsite]struct{},
+	cs sessionRevokeCallsite,
+	line int,
+) []Diagnostic {
+	if observed != nil {
+		observed[cs] = struct{}{}
+	}
+	if _, allowed := allowlist[cs]; allowed {
+		return nil
+	}
+	return []Diagnostic{{
+		Rel:  cs.rel,
+		Line: line,
+		Message: fmt.Sprintf(
+			"SESSION-REVOKE-CALLER-INTX-01: (session.Store).Revoke reference "+
+				"at callsite (%q, %q, ordinal=%d, ctx=%q) is not in the sanctioned "+
+				"caller allowlist. adapters/redis.CachingSessionStore.Revoke registers "+
+				"a post-commit cache DEL via persistence.RegisterAfterCommit, which "+
+				"PANICS if called outside a RunInTx scope. Before adding this exact "+
+				"callsite to sessionRevokeAllowlist, a reviewer MUST verify that the "+
+				"call executes inside RunInTx and that the ctx argument carries the "+
+				"after-commit registry.",
+			cs.rel, cs.fn, cs.ordinal, cs.ctx,
+		),
+	}}
+}
+
+func scanSessionRevokeHelperCallsites(
+	p *Pass,
+	allowlist map[sessionRevokeHelperCallsite]struct{},
+	observed map[sessionRevokeHelperCallsite]struct{},
+) []Diagnostic {
+	var d []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		if len(rel) > 8 && rel[len(rel)-8:] == "_test.go" {
+			continue
+		}
+		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
 				return
 			}
-			pos := p.Fset.Position(sel.Pos())
-			if topLevelObserved[pos.Offset] {
-				return // already attributed to a FuncDecl
-			}
-			cs := sessionRevokeCallsite{rel: rel, fn: ""}
-			if observed != nil {
-				observed[cs] = struct{}{}
-			}
-			if _, allowed := allowlist[cs]; !allowed {
+			ordinals := map[string]int{}
+			EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || !sessionRevokeTxScopedHelpers[sel.Sel.Name] {
+					return
+				}
+				ordinals[sel.Sel.Name]++
+				pos := p.Fset.Position(sel.Pos())
+				cs := sessionRevokeHelperCallsite{
+					rel:     rel,
+					fn:      fd.Name.Name,
+					helper:  sel.Sel.Name,
+					ordinal: ordinals[sel.Sel.Name],
+					ctx:     sessionRevokeHelperContextExpr(p, sel, call),
+				}
+				if observed != nil {
+					observed[cs] = struct{}{}
+				}
+				if _, allowed := allowlist[cs]; allowed {
+					return
+				}
 				d = append(d, Diagnostic{
 					Rel:  rel,
 					Line: pos.Line,
 					Message: fmt.Sprintf(
-						"SESSION-REVOKE-CALLER-INTX-01: (session.Store).Revoke referenced outside "+
-							"any function in %s (top-level init/var). Top-level code cannot hold a "+
-							"RunInTx scope. This is always a violation.",
-						rel,
+						"SESSION-REVOKE-CALLER-INTX-01: tx-scoped helper %s called "+
+							"from (%q, %q, ordinal=%d, ctx=%q) without a sanctioned "+
+							"helper-edge allowlist entry. This helper hides a "+
+							"(session.Store).Revoke call, so every production caller "+
+							"must be reviewed to ensure it passes a RunInTx ctx.",
+						cs.helper, cs.rel, cs.fn, cs.ordinal, cs.ctx,
 					),
 				})
-			}
+			})
 		})
 	}
 	return d
 }
 
 // TestSessionRevokeCallerInTx01 asserts that every production reference to
-// (session.Store).Revoke is in the per-function allowlist, and that no allowlist
+// (session.Store).Revoke is in the per-callsite allowlist, and that no allowlist
 // entry is stale (anti-vacuity reverse check).
 func TestSessionRevokeCallerInTx01(t *testing.T) {
 	t.Parallel()
@@ -302,12 +411,15 @@ func TestSessionRevokeCallerInTx01(t *testing.T) {
 	}
 
 	observed := map[sessionRevokeCallsite]struct{}{}
+	observedHelpers := map[sessionRevokeHelperCallsite]struct{}{}
 
 	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() {
 			return nil
 		}
-		return scanSessionRevokeCallsites(p, sessionRevokeAllowlist, observed)
+		out := scanSessionRevokeCallsites(p, sessionRevokeAllowlist, observed)
+		out = append(out, scanSessionRevokeHelperCallsites(p, sessionRevokeHelperAllowlist, observedHelpers)...)
+		return out
 	})
 
 	// Anti-vacuity / no-stale reverse self-check: every allowlisted (rel, fn)
@@ -327,10 +439,39 @@ func TestSessionRevokeCallerInTx01(t *testing.T) {
 			diags = append(diags, Diagnostic{
 				Message: fmt.Sprintf(
 					"SESSION-REVOKE-CALLER-INTX-01: allowlist entry (%q, %q) is STALE — no live "+
-						"reference to (session.Store).Revoke was observed in function %q of %q. "+
+						"reference to (session.Store).Revoke was observed at ordinal %d with ctx %q in function %q of %q. "+
 						"Either the scanner stopped detecting the call (regression) or the call was "+
 						"removed; drop the dead allowlist entry so it cannot become a silent bypass slot.",
-					cs.rel, cs.fn, cs.fn, cs.rel,
+					cs.rel, cs.fn, cs.ordinal, cs.ctx, cs.fn, cs.rel,
+				),
+			})
+		}
+	}
+	allowedHelpers := make([]sessionRevokeHelperCallsite, 0, len(sessionRevokeHelperAllowlist))
+	for cs := range sessionRevokeHelperAllowlist {
+		allowedHelpers = append(allowedHelpers, cs)
+	}
+	sort.Slice(allowedHelpers, func(i, j int) bool {
+		if allowedHelpers[i].rel != allowedHelpers[j].rel {
+			return allowedHelpers[i].rel < allowedHelpers[j].rel
+		}
+		if allowedHelpers[i].fn != allowedHelpers[j].fn {
+			return allowedHelpers[i].fn < allowedHelpers[j].fn
+		}
+		if allowedHelpers[i].helper != allowedHelpers[j].helper {
+			return allowedHelpers[i].helper < allowedHelpers[j].helper
+		}
+		return allowedHelpers[i].ordinal < allowedHelpers[j].ordinal
+	})
+	for _, cs := range allowedHelpers {
+		if _, seen := observedHelpers[cs]; !seen {
+			diags = append(diags, Diagnostic{
+				Message: fmt.Sprintf(
+					"SESSION-REVOKE-CALLER-INTX-01: helper allowlist entry "+
+						"(%q, %q, %q, ordinal=%d, ctx=%q) is STALE — no live helper call was observed. "+
+						"Either the scanner stopped detecting the helper edge (regression) or the call was "+
+						"removed; drop the dead allowlist entry so it cannot become a silent bypass slot.",
+					cs.rel, cs.fn, cs.helper, cs.ordinal, cs.ctx,
 				),
 			})
 		}
@@ -502,6 +643,77 @@ func TestSessionRevokeCaller_RedFixture(t *testing.T) {
 	}
 }
 
+// TestSessionRevokeCaller_RedFixture_AllowlistedFunctionExtraCall reproduces
+// the function-level allowlist blind spot: the enclosing function is sanctioned,
+// but it contains a second Revoke call with a non-transaction context.
+func TestSessionRevokeCaller_RedFixture_AllowlistedFunctionExtraCall(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const (
+		fixturePkg = "./tools/archtest/testdata/session_revoke_caller_fixtures/allowlisted_function_extra_call_red"
+		fixtureRel = "tools/archtest/testdata/session_revoke_caller_fixtures/allowlisted_function_extra_call_red/red.go"
+	)
+
+	observed := map[sessionRevokeCallsite]struct{}{}
+	allowlist := map[sessionRevokeCallsite]struct{}{
+		{rel: fixtureRel, fn: "allowedButBad", ordinal: 1, ctx: "txCtx"}: {},
+	}
+
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{}, []string{fixturePkg}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		d := scanSessionRevokeCallsites(p, allowlist, observed)
+		diags = append(diags, d...)
+		return nil
+	})
+
+	if len(diags) == 0 {
+		t.Errorf("TestSessionRevokeCaller_RedFixture_AllowlistedFunctionExtraCall: expected violation " +
+			"from the second Revoke call in an otherwise allowlisted function, but got 0. " +
+			"The scanner is still function-granular instead of callsite-granular.")
+	}
+}
+
+// TestSessionRevokeCaller_RedFixture_HelperNonTxCall proves helper-edge
+// scanning catches a tx-scoped helper reused with a non-transaction context.
+func TestSessionRevokeCaller_RedFixture_HelperNonTxCall(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const (
+		fixturePkg = "./tools/archtest/testdata/session_revoke_caller_fixtures/helper_nontx_call_red"
+		fixtureRel = "tools/archtest/testdata/session_revoke_caller_fixtures/helper_nontx_call_red/red.go"
+	)
+
+	observed := map[sessionRevokeHelperCallsite]struct{}{}
+	allowlist := map[sessionRevokeHelperCallsite]struct{}{
+		{rel: fixtureRel, fn: "caller", helper: "cleanupIssuedSession", ordinal: 1, ctx: "txCtx"}: {},
+	}
+
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{}, []string{fixturePkg}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		d := scanSessionRevokeHelperCallsites(p, allowlist, observed)
+		diags = append(diags, d...)
+		return nil
+	})
+
+	if len(diags) == 0 {
+		t.Errorf("TestSessionRevokeCaller_RedFixture_HelperNonTxCall: expected violation " +
+			"from the second cleanupIssuedSession call with context.Background(), but got 0. " +
+			"The scanner is not guarding tx-scoped helper call edges.")
+	}
+}
+
 // sessionRevokeSymbol reports whether sel is a reference (call or value) to the
 // interface method (session.Store).Revoke, alias-proof via go/types.
 // Returns false for any other selector.
@@ -539,4 +751,39 @@ func isSessionStoreReceiver(fn *types.Func) bool {
 	return named.Obj().Name() == "Store" &&
 		named.Obj().Pkg() != nil &&
 		named.Obj().Pkg().Path() == sessionPkgPath
+}
+
+func sessionRevokeCallContextExpr(p *Pass, sel *ast.SelectorExpr, call *ast.CallExpr) string {
+	return callContextExpr(p, sel, call, 0)
+}
+
+func sessionRevokeHelperContextExpr(p *Pass, sel *ast.SelectorExpr, call *ast.CallExpr) string {
+	return callContextExpr(p, sel, call, 0)
+}
+
+func callContextExpr(p *Pass, sel *ast.SelectorExpr, call *ast.CallExpr, methodValIndex int) string {
+	if call == nil {
+		return ""
+	}
+	idx := methodValIndex
+	if p != nil && p.TypesInfo != nil && sel != nil {
+		if selection := p.TypesInfo.Selections[sel]; selection != nil && selection.Kind() == types.MethodExpr {
+			idx++
+		}
+	}
+	if idx < 0 || idx >= len(call.Args) {
+		return ""
+	}
+	return formatSessionRevokeExpr(p, call.Args[idx])
+}
+
+func formatSessionRevokeExpr(p *Pass, expr ast.Expr) string {
+	if p == nil || p.Fset == nil || expr == nil {
+		return ""
+	}
+	var b bytes.Buffer
+	if err := format.Node(&b, p.Fset, expr); err != nil {
+		return fmt.Sprintf("<unprintable:%T>", expr)
+	}
+	return b.String()
 }

--- a/tools/archtest/session_revoke_caller_intx_test.go
+++ b/tools/archtest/session_revoke_caller_intx_test.go
@@ -18,8 +18,11 @@
 //
 // This archtest moves the "a future caller forgets the RunInTx scope" risk from a
 // runtime panic to a CI failure. It allowlists every production reference to the
-// interface method (session.Store).Revoke; any new reference outside the allowlist
-// fails CI until a reviewer verifies the new caller is RunInTx-wrapped and adds it.
+// interface method (session.Store).Revoke per ENCLOSING FUNCTION (not per file):
+// tx-scope is a per-function property; a new function must trigger review, but a
+// second Revoke inside an already-blessed function is automatically safe. Any new
+// (rel, func) pair outside the allowlist fails CI until a reviewer verifies the
+// new caller is RunInTx-wrapped and adds it.
 //
 // Note on tx verification: the human-verified fact is that each allowlisted
 // caller wraps the Revoke call in a RunInTx scope.  go/types CANNOT prove
@@ -31,11 +34,11 @@
 //
 // # AI-robust rating (charter §"Funnel 双向锁评级")
 //
-//   - Downstream: MEDIUM by archtest caller-allowlist. The callee is resolved
-//     via go/types (ResolveMethodCall), so import aliases and dot-imports
-//     resolve to the same symbol.  The scan is REFERENCE-based (not
-//     call-based), so passing the method as a function value is also caught.
-//     Any reference outside the allowlist fails in CI.
+//   - Downstream: MEDIUM by archtest caller-allowlist at PER-FUNCTION granularity.
+//     The callee is resolved via go/types (ResolveMethodCall), so import aliases
+//     and dot-imports resolve to the same symbol. The scan is REFERENCE-based (not
+//     call-based), so passing the method as a function value is also caught. Any
+//     reference in a function not in the allowlist fails in CI.
 //   - Upstream: MEDIUM, a GO-LANGUAGE CEILING (not a deferred TODO). Hard
 //     upstream would require a typed tx-scoped revoke capability so calling
 //     Revoke outside a tx is uncompilable. That path — gh #1615 F3 — was
@@ -50,6 +53,20 @@
 //     type seal). Same permanent ceiling as SPAN-SETATTR-HOLDER-SEAL (#851) /
 //     HEALTHZ-HOLDER-SEAL (#893 won't-do) / principal-write (#1282). Medium is
 //     the honest ceiling for the upstream direction.
+//
+// # Per-function granularity rationale
+//
+// The prior file-level allowlist was a coarser unit than the safety property it
+// guards: tx-scope is a PER-FUNCTION property, not a per-file one. An already-
+// allowlisted file such as sessionlogin/service.go holds multiple callers; adding
+// a SECOND bare Revoke to that file in a NEW function would have passed CI without
+// review. The per-function allowlist (rel, funcName) tightens the gate to the
+// correct unit:
+//
+//   - A second Revoke inside an ALREADY-BLESSED function is automatically safe
+//     (same function, same ambient tx, no review required).
+//   - A Revoke in a NEW function forces a red CI until a reviewer verifies the
+//     function wraps it in RunInTx and adds the (rel, func) entry.
 //
 // # Detection is REFERENCE-based, not call-based
 //
@@ -67,16 +84,17 @@
 //     method is what is resolved. This is a documented blind spot: if a future
 //     caller holds a *CachingSessionStore directly, it would escape detection.
 //     The risk is low because composition roots wire session.Store, not the
-//     concrete type.
+//     concrete type. Reverse self-check: TestSessionRevokeCaller_BlindSpot_ConcreteReceiver.
 //   - reflect.MethodByName("Revoke") is AST-invisible and is not matched.
 //     This gap is common to all SelectorExpr-based archtests and is accepted.
+//     Reverse self-check: TestSessionRevokeCaller_BlindSpot_Reflect.
 //   - Import aliases and dot-imports are immune BECAUSE ResolveMethodCall
 //     resolves via types.Info.Selections (symbol identity), not syntactic name.
 //     This is a strength, not a blind spot.
-//   - The anti-vacuity guard (every allowlisted file must reference its
-//     symbol ≥1×) is the reverse self-check: it proves the scanner actually
-//     resolves the real references (not a vacuous pass) AND forbids stale
-//     allowlist entries — a dead allowlist entry is a latent bypass slot.
+//   - The anti-vacuity guard (every allowlisted (rel,fn) must have ≥1 observed
+//     reference) proves the scanner actually resolves the real references (not a
+//     vacuous pass) AND forbids stale allowlist entries — a dead entry is a
+//     latent bypass slot.
 package archtest
 
 import (
@@ -89,127 +107,399 @@ import (
 
 const sessionPkgPath = PlatformModulePath + "/runtime/auth/session"
 
-// sessionRevokeAllowlist maps module-relative production files that may
+// sessionRevokeCallsite identifies a production reference to (session.Store).Revoke
+// by the module-relative source file and the name of the enclosing FuncDecl.
+// Using the enclosing function as the allowlist key rather than the file is the
+// correct granularity: tx-scope is a per-function property. A new function in an
+// already-allowlisted file must still pass review before its (rel, fn) entry is added.
+// A reference outside any FuncDecl (top-level var init) maps to fn=="" and will
+// always violate — top-level init code cannot hold a RunInTx scope.
+type sessionRevokeCallsite struct {
+	rel string // module-relative path, e.g. "cells/accesscore/slices/sessionlogout/service.go"
+	fn  string // enclosing FuncDecl name; "" means outside any function (top-level)
+}
+
+// sessionRevokeAllowlist maps (rel, enclosingFunc) callsite pairs that may
 // reference the (session.Store).Revoke interface method.
 //
 // Each entry is human-verified to execute Revoke inside a RunInTx scope (the
 // after-commit registry that CachingSessionStore.Revoke needs is installed by
 // every conformant RunInTx, including DemoTxRunner):
 //
-//   - cells/accesscore/slices/sessionlogout/service.go: the primary logout
-//     caller. s.sessionStore.Revoke(txCtx, sessionID) is called from
-//     revokeAndPublish, itself invoked from inside a
-//     persistRevoke → txRunner.RunInTx closure.
+//   - cells/accesscore/slices/sessionlogout/service.go → revokeAndPublish:
+//     s.sessionStore.Revoke(txCtx, sessionID) is called from revokeAndPublish,
+//     itself invoked from inside a persistRevoke → txRunner.RunInTx closure.
 //
-//   - cells/accesscore/slices/sessionlogin/service.go: three failure-
-//     compensation callers — mintAndPersistSession, persistSessionWithRefresh,
-//     and cleanupIssuedSession (the last only reached from the isNoopTx branches
-//     of the first two). All three run on txCtx, which flows from Login's own
-//     txRunner.RunInTx (and persistSessionWithRefresh's RunInTx), so the
-//     after-commit registry is present. The isNoopTx guard selects compensation
-//     SEMANTICS (noop tx has no rollback, so revoke manually), NOT panic-safety:
-//     even in noop mode DemoTxRunner.RunInTx installs the registry, so Revoke is
-//     safe regardless of whether the cache decorator is wired. context.WithoutCancel
-//     preserves ctx values, so the registry survives into the Revoke call.
+//   - cells/accesscore/slices/sessionlogin/service.go → mintAndPersistSession:
+//     called only from loginInTx, which runs inside Login's txRunner.RunInTx
+//     closure. txCtx flows from that RunInTx, so the after-commit registry is
+//     present. context.WithoutCancel preserves ctx values including the registry.
 //
-//   - adapters/redis/session_cache_store.go: the decorator delegation.
-//     s.inner.Revoke(ctx, id) is the first statement of
-//     CachingSessionStore.Revoke; the surrounding RunInTx scope is provided by
-//     the upstream caller (sessionlogout / sessionlogin above).
+//   - cells/accesscore/slices/sessionlogin/service.go → persistSessionWithRefresh:
+//     opens its own txRunner.RunInTx(ctx, do); the Revoke in the compensation
+//     branch uses context.WithoutCancel(txCtx) where txCtx is the closure param,
+//     so the registry from that RunInTx is present.
 //
-//   - runtime/auth/session/storetest/suite.go: the store conformance suite
-//     (non-_test.go helper library, caught by the production scan). It calls
-//     store.Revoke bare; per the session.Store.Revoke contract a Factory whose
-//     Store narrows Revoke with the after-commit hook must return a Store that
-//     supplies the unit-of-work scope — adapters/redis's txScopedRevokeStore
-//     bridge does exactly that (suite.go godoc).
+//   - cells/accesscore/slices/sessionlogin/service.go → cleanupIssuedSession:
+//     called only from mintAndPersistSession and persistSessionWithRefresh (both
+//     noop-tx branches). DemoTxRunner.RunInTx installs the registry even in demo
+//     mode, so the registry is present in the txCtx propagated to cleanupIssuedSession.
 //
-//   - runtime/auth/session/storetest/bench.go: the store benchmark helper
-//     (non-_test.go, caught by the production scan). Today's storetest.Bench
-//     callers are the mem and PG stores, whose Revoke does NOT depend on
-//     persistence.RegisterAfterCommit. CachingSessionStore is NOT benchmarked
-//     via storetest.Bench; if it ever is, the bench factory must supply a
-//     txScopedRevokeStore-style wrapper (as the conformance suite does) so
-//     Revoke executes inside a RunInTx scope.
-var sessionRevokeAllowlist = map[string]struct{}{
-	"cells/accesscore/slices/sessionlogout/service.go": {},
-	"cells/accesscore/slices/sessionlogin/service.go":  {},
-	"adapters/redis/session_cache_store.go":            {},
-	"runtime/auth/session/storetest/suite.go":          {},
-	"runtime/auth/session/storetest/bench.go":          {},
+//   - adapters/redis/session_cache_store.go → Revoke:
+//     s.inner.Revoke(ctx, id) is the first statement of CachingSessionStore.Revoke;
+//     the surrounding RunInTx scope is provided by the upstream caller (sessionlogout
+//     / sessionlogin above). The decorator itself does not need its own tx.
+//
+//   - runtime/auth/session/storetest/suite.go → runRevokeDirect:
+//     the store conformance suite helper (non-_test.go, caught by production scan).
+//     A Factory whose Store narrows Revoke with the after-commit hook must return a
+//     Store that supplies the unit-of-work scope — adapters/redis's
+//     txScopedRevokeStore bridge does exactly that (suite.go godoc).
+//
+//   - runtime/auth/session/storetest/suite.go → runRevokeIdempotent:
+//     same suite rationale as runRevokeDirect above.
+//
+//   - runtime/auth/session/storetest/suite.go → runRevokeNotFoundNoop:
+//     same suite rationale above.
+//
+//   - runtime/auth/session/storetest/suite.go → seedRevokeForSubjectFixtures:
+//     the fixture seeding helper that pre-revokes one session so
+//     runRevokeForSubject* tests can assert RevokeForSubject does not re-stamp
+//     its RevokedAt timestamp. Same suite rationale as runRevokeDirect above:
+//     a Factory with CachingSessionStore must supply a txScopedRevokeStore bridge.
+//
+//   - runtime/auth/session/storetest/bench.go → benchMixedConcurrent:
+//     the store benchmark helper (non-_test.go, caught by the production scan).
+//     Today's storetest.Bench callers are the mem and PG stores, whose Revoke does
+//     NOT depend on persistence.RegisterAfterCommit. CachingSessionStore is NOT
+//     benchmarked via storetest.Bench; if it ever is, the bench factory must supply
+//     a txScopedRevokeStore-style wrapper (as the conformance suite does) so Revoke
+//     executes inside a RunInTx scope.
+var sessionRevokeAllowlist = map[sessionRevokeCallsite]struct{}{
+	{rel: "cells/accesscore/slices/sessionlogout/service.go", fn: "revokeAndPublish"}:         {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "mintAndPersistSession"}:     {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "persistSessionWithRefresh"}: {},
+	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "cleanupIssuedSession"}:      {},
+	{rel: "adapters/redis/session_cache_store.go", fn: "Revoke"}:                              {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeDirect"}:                   {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeIdempotent"}:               {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeNotFoundNoop"}:             {},
+	{rel: "runtime/auth/session/storetest/suite.go", fn: "seedRevokeForSubjectFixtures"}:      {},
+	{rel: "runtime/auth/session/storetest/bench.go", fn: "benchMixedConcurrent"}:              {},
 }
 
-// TestSessionRevokeCallerInTx01 asserts that every production reference to
-// (session.Store).Revoke sits in the allowlist, and that no allowlist entry is
-// stale (anti-vacuity reverse check).
-func TestSessionRevokeCallerInTx01(t *testing.T) {
-	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based archtest in -short mode")
-	}
+// scanSessionRevokeCallsites walks all FuncDecls in p's files (excluding
+// _test.go), finds every SelectorExpr that resolves to (session.Store).Revoke,
+// attributes each to its enclosing FuncDecl (or fn="" if outside any function),
+// and emits a Diagnostic for any callsite not in the allowlist.
+//
+// Also records each observed callsite into the provided observed map so the
+// caller can run an anti-vacuity check.
+//
+// This factored function is reused by the main test and the RED fixture test.
+func scanSessionRevokeCallsites(
+	p *Pass,
+	allowlist map[sessionRevokeCallsite]struct{},
+	observed map[sessionRevokeCallsite]struct{},
+) []Diagnostic {
+	var d []Diagnostic
 
-	// observed[relFile] = true for each live reference found.
-	observed := map[string]struct{}{}
-	record := func(rel string) {
-		observed[rel] = struct{}{}
-	}
-
-	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
-		if !p.Typed() {
-			return nil
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		// _test.go files are excluded: the archtest only guards production
+		// callers. Conformance suites (suite.go, bench.go) are non-_test.go
+		// production-path files and ARE scanned.
+		if len(rel) > 8 && rel[len(rel)-8:] == "_test.go" {
+			continue
 		}
-		var d []Diagnostic
-		for _, file := range p.Files {
-			rel := p.Rel(file)
-			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
+				return
+			}
+			fnName := fd.Name.Name
+			EachInSubtree[ast.SelectorExpr](fd.Body, func(sel *ast.SelectorExpr) {
 				if !sessionRevokeSymbol(p.TypesInfo, sel) {
 					return
 				}
-				record(rel)
-				if _, allowed := sessionRevokeAllowlist[rel]; !allowed {
+				cs := sessionRevokeCallsite{rel: rel, fn: fnName}
+				if observed != nil {
+					observed[cs] = struct{}{}
+				}
+				if _, allowed := allowlist[cs]; !allowed {
 					pos := p.Fset.Position(sel.Pos())
 					d = append(d, Diagnostic{
 						Rel:  rel,
 						Line: pos.Line,
 						Message: fmt.Sprintf(
 							"SESSION-REVOKE-CALLER-INTX-01: (session.Store).Revoke is referenced "+
-								"from %s, which is not in the sanctioned caller allowlist. "+
+								"from %s in function %q, which is not in the sanctioned caller allowlist. "+
 								"adapters/redis.CachingSessionStore.Revoke registers a post-commit "+
 								"cache DEL via persistence.RegisterAfterCommit, which PANICS if "+
-								"called outside a RunInTx scope. Before adding this file to "+
-								"sessionRevokeAllowlist, a reviewer MUST verify that every call "+
-								"path from this file to Revoke is wrapped in a RunInTx closure.",
-							rel,
+								"called outside a RunInTx scope. Before adding (%q, %q) to "+
+								"sessionRevokeAllowlist, a reviewer MUST verify that this function "+
+								"wraps the Revoke call in a RunInTx closure.",
+							rel, fnName, rel, fnName,
 						),
 					})
 				}
 			})
+		})
+		// Also catch references outside any FuncDecl (top-level var/init).
+		// We do this by scanning the whole file for Revoke selectors and
+		// subtracting those already attributed to a FuncDecl body.
+		// (Top-level references are so rare that a simpler approach is fine:
+		// just scan the full file and check whether the position is inside any
+		// FuncDecl body range — but for simplicity we rely on the fact that
+		// EachInSubtree[ast.FuncDecl] covers all function bodies, and any
+		// reference NOT inside a FuncDecl body is by definition top-level.)
+		topLevelObserved := map[int]bool{} // position offset → true, recorded inside funcs
+		EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
+				return
+			}
+			EachInSubtree[ast.SelectorExpr](fd.Body, func(sel *ast.SelectorExpr) {
+				if sessionRevokeSymbol(p.TypesInfo, sel) {
+					topLevelObserved[p.Fset.Position(sel.Pos()).Offset] = true
+				}
+			})
+		})
+		EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+			if !sessionRevokeSymbol(p.TypesInfo, sel) {
+				return
+			}
+			pos := p.Fset.Position(sel.Pos())
+			if topLevelObserved[pos.Offset] {
+				return // already attributed to a FuncDecl
+			}
+			cs := sessionRevokeCallsite{rel: rel, fn: ""}
+			if observed != nil {
+				observed[cs] = struct{}{}
+			}
+			if _, allowed := allowlist[cs]; !allowed {
+				d = append(d, Diagnostic{
+					Rel:  rel,
+					Line: pos.Line,
+					Message: fmt.Sprintf(
+						"SESSION-REVOKE-CALLER-INTX-01: (session.Store).Revoke referenced outside "+
+							"any function in %s (top-level init/var). Top-level code cannot hold a "+
+							"RunInTx scope. This is always a violation.",
+						rel,
+					),
+				})
+			}
+		})
+	}
+	return d
+}
+
+// TestSessionRevokeCallerInTx01 asserts that every production reference to
+// (session.Store).Revoke is in the per-function allowlist, and that no allowlist
+// entry is stale (anti-vacuity reverse check).
+func TestSessionRevokeCallerInTx01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	observed := map[sessionRevokeCallsite]struct{}{}
+
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
 		}
-		return d
+		return scanSessionRevokeCallsites(p, sessionRevokeAllowlist, observed)
 	})
 
-	// Anti-vacuity / no-stale reverse self-check: every allowlisted file must
-	// host a live reference. A stale entry is a latent bypass slot.
-	allowed := make([]string, 0, len(sessionRevokeAllowlist))
-	for f := range sessionRevokeAllowlist {
-		allowed = append(allowed, f)
+	// Anti-vacuity / no-stale reverse self-check: every allowlisted (rel, fn)
+	// must host ≥1 live reference. A stale entry is a latent bypass slot.
+	allowed := make([]sessionRevokeCallsite, 0, len(sessionRevokeAllowlist))
+	for cs := range sessionRevokeAllowlist {
+		allowed = append(allowed, cs)
 	}
-	sort.Strings(allowed)
-	for _, f := range allowed {
-		if _, seen := observed[f]; !seen {
+	sort.Slice(allowed, func(i, j int) bool {
+		if allowed[i].rel != allowed[j].rel {
+			return allowed[i].rel < allowed[j].rel
+		}
+		return allowed[i].fn < allowed[j].fn
+	})
+	for _, cs := range allowed {
+		if _, seen := observed[cs]; !seen {
 			diags = append(diags, Diagnostic{
 				Message: fmt.Sprintf(
-					"SESSION-REVOKE-CALLER-INTX-01: allowlist entry %q is STALE — no live "+
-						"reference to (session.Store).Revoke was observed. Either the scanner "+
-						"stopped detecting the call (regression) or the call was removed; drop "+
-						"the dead allowlist entry so it cannot become a silent bypass slot.",
-					f,
+					"SESSION-REVOKE-CALLER-INTX-01: allowlist entry (%q, %q) is STALE — no live "+
+						"reference to (session.Store).Revoke was observed in function %q of %q. "+
+						"Either the scanner stopped detecting the call (regression) or the call was "+
+						"removed; drop the dead allowlist entry so it cannot become a silent bypass slot.",
+					cs.rel, cs.fn, cs.fn, cs.rel,
 				),
 			})
 		}
 	}
 
 	Report(t, "SESSION-REVOKE-CALLER-INTX-01", diags)
+}
+
+// TestSessionRevokeCaller_BlindSpot_ConcreteReceiver is the reverse self-check for
+// the concrete-receiver blind spot documented in the package godoc:
+//
+// The main archtest scans for (session.Store).Revoke INTERFACE method references
+// (resolved via go/types Selections). A call via a concrete *CachingSessionStore
+// receiver would resolve to the CONCRETE method, not the interface method, and
+// would be invisible to the main scan.
+//
+// This test asserts that NO production code references Revoke via a concrete
+// *adapters/redis.CachingSessionStore receiver. If any such reference appeared,
+// this test would fail — alerting that the main archtest has a live blind spot.
+func TestSessionRevokeCaller_BlindSpot_ConcreteReceiver(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const (
+		concreteReceiverTypeName = "CachingSessionStore"
+		redisPkgPath             = PlatformModulePath + "/adapters/redis"
+	)
+
+	var violations []string
+
+	_ = Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if len(rel) > 8 && rel[len(rel)-8:] == "_test.go" {
+				continue
+			}
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if sel.Sel.Name != "Revoke" {
+					return
+				}
+				fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+				if !ok || fn == nil {
+					return
+				}
+				if fn.Name() != "Revoke" {
+					return
+				}
+				sig, ok2 := fn.Type().(*types.Signature)
+				if !ok2 || sig.Recv() == nil {
+					return
+				}
+				recv := sig.Recv().Type()
+				if ptr, ok3 := recv.(*types.Pointer); ok3 {
+					recv = ptr.Elem()
+				}
+				named, ok4 := recv.(*types.Named)
+				if !ok4 || named.Obj() == nil {
+					return
+				}
+				// If the resolved method's receiver is the CONCRETE CachingSessionStore
+				// (not the interface session.Store), the main scan misses it.
+				if named.Obj().Name() == concreteReceiverTypeName &&
+					named.Obj().Pkg() != nil &&
+					named.Obj().Pkg().Path() == redisPkgPath {
+					pos := p.Fset.Position(sel.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: concrete (*CachingSessionStore).Revoke called directly — "+
+							"SESSION-REVOKE-CALLER-INTX-01 cannot see this call (interface-method scan blind spot)",
+						rel, pos.Line,
+					))
+				}
+			})
+		}
+		return nil
+	})
+
+	if len(violations) > 0 {
+		t.Errorf("SESSION-REVOKE-CALLER-INTX-01 blind spot LIVE: concrete (*CachingSessionStore).Revoke "+
+			"found in production. The main archtest scan will NOT detect these callers. "+
+			"Either move the caller to use session.Store interface, or extend the archtest.\n%v",
+			violations)
+	}
+}
+
+// TestSessionRevokeCaller_BlindSpot_Reflect is the reverse self-check for the
+// reflect.MethodByName blind spot documented in the package godoc:
+//
+// The main archtest resolves (session.Store).Revoke via go/types SelectorExpr
+// analysis, which cannot see reflect.MethodByName("Revoke") invocations.
+// This test asserts that no production code uses reflect.MethodByName("Revoke"),
+// covering the Production scan domain (not just adapters/redis as the sibling
+// rule in caching_session_revoke_delegate_only_test.go does for its narrower scope).
+func TestSessionRevokeCaller_BlindSpot_Reflect(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var violations []string
+
+	_ = Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Fset == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			if len(rel) > 8 && rel[len(rel)-8:] == "_test.go" {
+				continue
+			}
+			for _, hit := range scanReflectStringArgCalls(p, file, reflectMethodByName,
+				func(n string) bool { return n == "Revoke" }) {
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: SESSION-REVOKE-CALLER-INTX-01: reflect.MethodByName(%q) detected — "+
+						"archtest cannot see reflect-based invocations of session.Store.Revoke",
+					rel, hit.Line, hit.Name))
+			}
+		}
+		return nil
+	})
+
+	if len(violations) > 0 {
+		t.Errorf("SESSION-REVOKE-CALLER-INTX-01 blind spot LIVE: reflect.MethodByName(\"Revoke\") "+
+			"found in production. The main archtest will NOT detect these callers.\n%v",
+			violations)
+	}
+}
+
+// TestSessionRevokeCaller_RedFixture proves end-to-end that an allowlist-外
+// caller (a function NOT in sessionRevokeAllowlist that calls session.Store.Revoke)
+// is detected as a violation by the per-function callsite scan.
+//
+// The fixture package tools/archtest/testdata/session_revoke_caller_fixtures/
+// unsanctioned_caller_red contains a bare Revoke call in a function named
+// "unsanctionedRevoke" which is NOT in the allowlist. This test asserts ≥1
+// violation is reported.
+func TestSessionRevokeCaller_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	const fixturePkg = "./tools/archtest/testdata/session_revoke_caller_fixtures/unsanctioned_caller_red"
+
+	observed := map[sessionRevokeCallsite]struct{}{}
+
+	// Use an empty allowlist so any reference in the fixture is a violation.
+	emptyAllowlist := map[sessionRevokeCallsite]struct{}{}
+
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{}, []string{fixturePkg}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		d := scanSessionRevokeCallsites(p, emptyAllowlist, observed)
+		diags = append(diags, d...)
+		return nil
+	})
+
+	if len(diags) == 0 {
+		t.Errorf("TestSessionRevokeCaller_RedFixture: expected ≥1 violation from the RED fixture "+
+			"(unsanctionedRevoke in %s is NOT in the allowlist), but got 0 violations. "+
+			"The scanner may have failed to load the fixture or detect the Revoke reference.",
+			fixturePkg)
+	}
 }
 
 // sessionRevokeSymbol reports whether sel is a reference (call or value) to the

--- a/tools/archtest/session_revoke_caller_intx_test.go
+++ b/tools/archtest/session_revoke_caller_intx_test.go
@@ -1,7 +1,7 @@
 // session_revoke_caller_intx_test.go — closes the DOWNSTREAM side of the
 // session.Store.Revoke caller funnel.
 //
-//   - INVARIANT: SESSION-REVOKE-CALLER-INTX-01
+// INVARIANT: SESSION-REVOKE-CALLER-INTX-01
 //
 // # What this guards
 //
@@ -125,9 +125,12 @@ const sessionPkgPath = PlatformModulePath + "/runtime/auth/session"
 //     bridge does exactly that (suite.go godoc).
 //
 //   - runtime/auth/session/storetest/bench.go: the store benchmark helper
-//     (non-_test.go, caught by the production scan). Same contract as the suite:
-//     a benchmark targeting a narrowing store supplies the unit-of-work scope;
-//     bare-store (mem) benchmarks need none.
+//     (non-_test.go, caught by the production scan). Today's storetest.Bench
+//     callers are the mem and PG stores, whose Revoke does NOT depend on
+//     persistence.RegisterAfterCommit. CachingSessionStore is NOT benchmarked
+//     via storetest.Bench; if it ever is, the bench factory must supply a
+//     txScopedRevokeStore-style wrapper (as the conformance suite does) so
+//     Revoke executes inside a RunInTx scope.
 var sessionRevokeAllowlist = map[string]struct{}{
 	"cells/accesscore/slices/sessionlogout/service.go": {},
 	"cells/accesscore/slices/sessionlogin/service.go":  {},
@@ -227,8 +230,9 @@ func sessionRevokeSymbol(info *types.Info, sel *ast.SelectorExpr) bool {
 }
 
 // isSessionStoreReceiver reports whether fn's receiver base type is
-// runtime/auth/session.Store (interface), so an unrelated future Revoke method
-// on another type in the package does not accidentally match.
+// runtime/auth/session.Store (interface), verified by both package path and
+// type name, so an unrelated future Revoke method on another type (even one
+// also named "Store" in a different package) does not accidentally match.
 func isSessionStoreReceiver(fn *types.Func) bool {
 	sig, ok := fn.Type().(*types.Signature)
 	if !ok || sig.Recv() == nil {
@@ -242,5 +246,7 @@ func isSessionStoreReceiver(fn *types.Func) bool {
 	if !ok || named.Obj() == nil {
 		return false
 	}
-	return named.Obj().Name() == "Store"
+	return named.Obj().Name() == "Store" &&
+		named.Obj().Pkg() != nil &&
+		named.Obj().Pkg().Path() == sessionPkgPath
 }

--- a/tools/archtest/session_revoke_caller_intx_test.go
+++ b/tools/archtest/session_revoke_caller_intx_test.go
@@ -1,0 +1,246 @@
+// session_revoke_caller_intx_test.go — closes the DOWNSTREAM side of the
+// session.Store.Revoke caller funnel.
+//
+//   - INVARIANT: SESSION-REVOKE-CALLER-INTX-01
+//
+// # What this guards
+//
+// adapters/redis.CachingSessionStore.Revoke registers a post-commit cache DEL
+// via persistence.RegisterAfterCommit, which PANICS if called outside an
+// ambient RunInTx scope (the after-commit registry lives in the ctx that
+// RunInTx installs). Every current production reference to (session.Store).Revoke
+// executes inside a RunInTx closure, so the registry is always present:
+// sessionlogout (the logout flow) and sessionlogin's failure-compensation paths
+// both call it from within a txRunner.RunInTx closure. Crucially this holds even
+// in demo/noop mode — DemoTxRunner.RunInTx (kernel/outbox/demo_tx_runner.go) also
+// installs the registry (WithAfterCommitRegistry + RunAfterCommitHooks), so being
+// inside RunInTx — not the store's concrete type — is the safety guarantee.
+//
+// This archtest moves the "a future caller forgets the RunInTx scope" risk from a
+// runtime panic to a CI failure. It allowlists every production reference to the
+// interface method (session.Store).Revoke; any new reference outside the allowlist
+// fails CI until a reviewer verifies the new caller is RunInTx-wrapped and adds it.
+//
+// Note on tx verification: the human-verified fact is that each allowlisted
+// caller wraps the Revoke call in a RunInTx scope.  go/types CANNOT prove
+// ambient-tx invariants — the call to revokeAndPublish sits inside a RunInTx
+// closure, but is NOT lexically inside it; a containment check would not
+// survive a multi-level function-call graph. The archtest's value is
+// therefore a review checkpoint, not a proof: a new caller is forced to the
+// allowlist where a reviewer MUST verify tx-wrapping before adding it.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Downstream: MEDIUM by archtest caller-allowlist. The callee is resolved
+//     via go/types (ResolveMethodCall), so import aliases and dot-imports
+//     resolve to the same symbol.  The scan is REFERENCE-based (not
+//     call-based), so passing the method as a function value is also caught.
+//     Any reference outside the allowlist fails in CI.
+//   - Upstream: MEDIUM, a GO-LANGUAGE CEILING (not a deferred TODO). Hard
+//     upstream would require a typed tx-scoped revoke capability so calling
+//     Revoke outside a tx is uncompilable. That path — gh #1615 F3 — was
+//     evaluated and resolved won't-do: a same-package seal is unreachable
+//     because adapters/redis's read path (evictBadEntry, lazyPopulate) needs a
+//     synchronous cache.Delete/Set on the same CachingSessionStore field that
+//     Revoke uses, and Go has no per-method field scoping; a cross-package
+//     internal-subpackage seal is disproportionate for this single-caller P3
+//     and has no industry precedent (Spring TransactionSynchronization,
+//     Hibernate AfterTransactionCompletionProcess, ent CommitHook, and
+//     Watermill forwarder all rely on runtime registration + convention, not a
+//     type seal). Same permanent ceiling as SPAN-SETATTR-HOLDER-SEAL (#851) /
+//     HEALTHZ-HOLDER-SEAL (#893 won't-do) / principal-write (#1282). Medium is
+//     the honest ceiling for the upstream direction.
+//
+// # Detection is REFERENCE-based, not call-based
+//
+// The scanner matches every SelectorExpr that go/types resolves to the
+// (session.Store).Revoke interface method — whether it is the callee of a
+// call OR passed as a method value. A file that does f := store.Revoke; f(ctx,
+// id) references the symbol at the store.Revoke SelectorExpr and is caught.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//   - A call via a CONCRETE *CachingSessionStore receiver (redis.store.Revoke
+//     rather than session.Store.Revoke) resolves to the CONCRETE method, not
+//     the interface method, and is NOT matched by this archtest. Today all
+//     production callers hold the interface type session.Store — the interface
+//     method is what is resolved. This is a documented blind spot: if a future
+//     caller holds a *CachingSessionStore directly, it would escape detection.
+//     The risk is low because composition roots wire session.Store, not the
+//     concrete type.
+//   - reflect.MethodByName("Revoke") is AST-invisible and is not matched.
+//     This gap is common to all SelectorExpr-based archtests and is accepted.
+//   - Import aliases and dot-imports are immune BECAUSE ResolveMethodCall
+//     resolves via types.Info.Selections (symbol identity), not syntactic name.
+//     This is a strength, not a blind spot.
+//   - The anti-vacuity guard (every allowlisted file must reference its
+//     symbol ≥1×) is the reverse self-check: it proves the scanner actually
+//     resolves the real references (not a vacuous pass) AND forbids stale
+//     allowlist entries — a dead allowlist entry is a latent bypass slot.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"testing"
+)
+
+const sessionPkgPath = PlatformModulePath + "/runtime/auth/session"
+
+// sessionRevokeAllowlist maps module-relative production files that may
+// reference the (session.Store).Revoke interface method.
+//
+// Each entry is human-verified to execute Revoke inside a RunInTx scope (the
+// after-commit registry that CachingSessionStore.Revoke needs is installed by
+// every conformant RunInTx, including DemoTxRunner):
+//
+//   - cells/accesscore/slices/sessionlogout/service.go: the primary logout
+//     caller. s.sessionStore.Revoke(txCtx, sessionID) is called from
+//     revokeAndPublish, itself invoked from inside a
+//     persistRevoke → txRunner.RunInTx closure.
+//
+//   - cells/accesscore/slices/sessionlogin/service.go: three failure-
+//     compensation callers — mintAndPersistSession, persistSessionWithRefresh,
+//     and cleanupIssuedSession (the last only reached from the isNoopTx branches
+//     of the first two). All three run on txCtx, which flows from Login's own
+//     txRunner.RunInTx (and persistSessionWithRefresh's RunInTx), so the
+//     after-commit registry is present. The isNoopTx guard selects compensation
+//     SEMANTICS (noop tx has no rollback, so revoke manually), NOT panic-safety:
+//     even in noop mode DemoTxRunner.RunInTx installs the registry, so Revoke is
+//     safe regardless of whether the cache decorator is wired. context.WithoutCancel
+//     preserves ctx values, so the registry survives into the Revoke call.
+//
+//   - adapters/redis/session_cache_store.go: the decorator delegation.
+//     s.inner.Revoke(ctx, id) is the first statement of
+//     CachingSessionStore.Revoke; the surrounding RunInTx scope is provided by
+//     the upstream caller (sessionlogout / sessionlogin above).
+//
+//   - runtime/auth/session/storetest/suite.go: the store conformance suite
+//     (non-_test.go helper library, caught by the production scan). It calls
+//     store.Revoke bare; per the session.Store.Revoke contract a Factory whose
+//     Store narrows Revoke with the after-commit hook must return a Store that
+//     supplies the unit-of-work scope — adapters/redis's txScopedRevokeStore
+//     bridge does exactly that (suite.go godoc).
+//
+//   - runtime/auth/session/storetest/bench.go: the store benchmark helper
+//     (non-_test.go, caught by the production scan). Same contract as the suite:
+//     a benchmark targeting a narrowing store supplies the unit-of-work scope;
+//     bare-store (mem) benchmarks need none.
+var sessionRevokeAllowlist = map[string]struct{}{
+	"cells/accesscore/slices/sessionlogout/service.go": {},
+	"cells/accesscore/slices/sessionlogin/service.go":  {},
+	"adapters/redis/session_cache_store.go":            {},
+	"runtime/auth/session/storetest/suite.go":          {},
+	"runtime/auth/session/storetest/bench.go":          {},
+}
+
+// TestSessionRevokeCallerInTx01 asserts that every production reference to
+// (session.Store).Revoke sits in the allowlist, and that no allowlist entry is
+// stale (anti-vacuity reverse check).
+func TestSessionRevokeCallerInTx01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	// observed[relFile] = true for each live reference found.
+	observed := map[string]struct{}{}
+	record := func(rel string) {
+		observed[rel] = struct{}{}
+	}
+
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		var d []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if !sessionRevokeSymbol(p.TypesInfo, sel) {
+					return
+				}
+				record(rel)
+				if _, allowed := sessionRevokeAllowlist[rel]; !allowed {
+					pos := p.Fset.Position(sel.Pos())
+					d = append(d, Diagnostic{
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"SESSION-REVOKE-CALLER-INTX-01: (session.Store).Revoke is referenced "+
+								"from %s, which is not in the sanctioned caller allowlist. "+
+								"adapters/redis.CachingSessionStore.Revoke registers a post-commit "+
+								"cache DEL via persistence.RegisterAfterCommit, which PANICS if "+
+								"called outside a RunInTx scope. Before adding this file to "+
+								"sessionRevokeAllowlist, a reviewer MUST verify that every call "+
+								"path from this file to Revoke is wrapped in a RunInTx closure.",
+							rel,
+						),
+					})
+				}
+			})
+		}
+		return d
+	})
+
+	// Anti-vacuity / no-stale reverse self-check: every allowlisted file must
+	// host a live reference. A stale entry is a latent bypass slot.
+	allowed := make([]string, 0, len(sessionRevokeAllowlist))
+	for f := range sessionRevokeAllowlist {
+		allowed = append(allowed, f)
+	}
+	sort.Strings(allowed)
+	for _, f := range allowed {
+		if _, seen := observed[f]; !seen {
+			diags = append(diags, Diagnostic{
+				Message: fmt.Sprintf(
+					"SESSION-REVOKE-CALLER-INTX-01: allowlist entry %q is STALE — no live "+
+						"reference to (session.Store).Revoke was observed. Either the scanner "+
+						"stopped detecting the call (regression) or the call was removed; drop "+
+						"the dead allowlist entry so it cannot become a silent bypass slot.",
+					f,
+				),
+			})
+		}
+	}
+
+	Report(t, "SESSION-REVOKE-CALLER-INTX-01", diags)
+}
+
+// sessionRevokeSymbol reports whether sel is a reference (call or value) to the
+// interface method (session.Store).Revoke, alias-proof via go/types.
+// Returns false for any other selector.
+func sessionRevokeSymbol(info *types.Info, sel *ast.SelectorExpr) bool {
+	fn, ok := ResolveMethodCall(info, sel)
+	if !ok || fn == nil {
+		return false
+	}
+	if fn.Name() != "Revoke" {
+		return false
+	}
+	if fn.Pkg() == nil || fn.Pkg().Path() != sessionPkgPath {
+		return false
+	}
+	return isSessionStoreReceiver(fn)
+}
+
+// isSessionStoreReceiver reports whether fn's receiver base type is
+// runtime/auth/session.Store (interface), so an unrelated future Revoke method
+// on another type in the package does not accidentally match.
+func isSessionStoreReceiver(fn *types.Func) bool {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	t := sig.Recv().Type()
+	if ptr, ok2 := t.(*types.Pointer); ok2 {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok || named.Obj() == nil {
+		return false
+	}
+	return named.Obj().Name() == "Store"
+}

--- a/tools/archtest/session_revoke_caller_intx_test.go
+++ b/tools/archtest/session_revoke_caller_intx_test.go
@@ -202,25 +202,98 @@ var sessionRevokeTxScopedHelpers = map[string]bool{
 //     a txScopedRevokeStore-style wrapper (as the conformance suite does) so Revoke
 //     executes inside a RunInTx scope.
 var sessionRevokeAllowlist = map[sessionRevokeCallsite]struct{}{
-	{rel: "cells/accesscore/slices/sessionlogout/service.go", fn: "revokeAndPublish", ordinal: 1, ctx: "txCtx"}:                                {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "mintAndPersistSession", ordinal: 1, ctx: "context.WithoutCancel(txCtx)"}:     {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "persistSessionWithRefresh", ordinal: 1, ctx: "context.WithoutCancel(txCtx)"}: {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "cleanupIssuedSession", ordinal: 1, ctx: "cleanupCtx"}:                        {},
-	{rel: "adapters/redis/session_cache_store.go", fn: "Revoke", ordinal: 1, ctx: "ctx"}:                                                       {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeDirect", ordinal: 1, ctx: "context.Background()"}:                           {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeIdempotent", ordinal: 1, ctx: "context.Background()"}:                       {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeIdempotent", ordinal: 2, ctx: "context.Background()"}:                       {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "runRevokeNotFoundNoop", ordinal: 1, ctx: "context.Background()"}:                     {},
-	{rel: "runtime/auth/session/storetest/suite.go", fn: "seedRevokeForSubjectFixtures", ordinal: 1, ctx: "ctx"}:                               {},
-	{rel: "runtime/auth/session/storetest/bench.go", fn: "benchMixedConcurrent", ordinal: 1, ctx: "ctx"}:                                       {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogout/service.go",
+		fn:      "revokeAndPublish",
+		ordinal: 1,
+		ctx:     "txCtx",
+	}: {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogin/service.go",
+		fn:      "mintAndPersistSession",
+		ordinal: 1,
+		ctx:     "context.WithoutCancel(txCtx)",
+	}: {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogin/service.go",
+		fn:      "persistSessionWithRefresh",
+		ordinal: 1,
+		ctx:     "context.WithoutCancel(txCtx)",
+	}: {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogin/service.go",
+		fn:      "cleanupIssuedSession",
+		ordinal: 1,
+		ctx:     "cleanupCtx",
+	}: {},
+	{
+		rel:     "adapters/redis/session_cache_store.go",
+		fn:      "Revoke",
+		ordinal: 1,
+		ctx:     "ctx",
+	}: {},
+	{
+		rel:     "runtime/auth/session/storetest/suite.go",
+		fn:      "runRevokeDirect",
+		ordinal: 1,
+		ctx:     "context.Background()",
+	}: {},
+	{
+		rel:     "runtime/auth/session/storetest/suite.go",
+		fn:      "runRevokeIdempotent",
+		ordinal: 1,
+		ctx:     "context.Background()",
+	}: {},
+	{
+		rel:     "runtime/auth/session/storetest/suite.go",
+		fn:      "runRevokeIdempotent",
+		ordinal: 2,
+		ctx:     "context.Background()",
+	}: {},
+	{
+		rel:     "runtime/auth/session/storetest/suite.go",
+		fn:      "runRevokeNotFoundNoop",
+		ordinal: 1,
+		ctx:     "context.Background()",
+	}: {},
+	{
+		rel:     "runtime/auth/session/storetest/suite.go",
+		fn:      "seedRevokeForSubjectFixtures",
+		ordinal: 1,
+		ctx:     "ctx",
+	}: {},
+	{
+		rel:     "runtime/auth/session/storetest/bench.go",
+		fn:      "benchMixedConcurrent",
+		ordinal: 1,
+		ctx:     "ctx",
+	}: {},
 }
 
 // sessionRevokeHelperAllowlist maps production call edges into tx-scoped helper
 // methods that contain Revoke callsites.
 var sessionRevokeHelperAllowlist = map[sessionRevokeHelperCallsite]struct{}{
-	{rel: "cells/accesscore/slices/sessionlogout/service.go", fn: "Logout", helper: "revokeAndPublish", ordinal: 1, ctx: "txCtx"}:                       {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "mintAndPersistSession", helper: "cleanupIssuedSession", ordinal: 1, ctx: "txCtx"}:     {},
-	{rel: "cells/accesscore/slices/sessionlogin/service.go", fn: "persistSessionWithRefresh", helper: "cleanupIssuedSession", ordinal: 1, ctx: "txCtx"}: {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogout/service.go",
+		fn:      "Logout",
+		helper:  "revokeAndPublish",
+		ordinal: 1,
+		ctx:     "txCtx",
+	}: {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogin/service.go",
+		fn:      "mintAndPersistSession",
+		helper:  "cleanupIssuedSession",
+		ordinal: 1,
+		ctx:     "txCtx",
+	}: {},
+	{
+		rel:     "cells/accesscore/slices/sessionlogin/service.go",
+		fn:      "persistSessionWithRefresh",
+		helper:  "cleanupIssuedSession",
+		ordinal: 1,
+		ctx:     "txCtx",
+	}: {},
 }
 
 // scanSessionRevokeCallsites walks all FuncDecls in p's files (excluding

--- a/tools/archtest/testdata/session_revoke_caller_fixtures/allowlisted_function_extra_call_red/red.go
+++ b/tools/archtest/testdata/session_revoke_caller_fixtures/allowlisted_function_extra_call_red/red.go
@@ -1,0 +1,17 @@
+// Package allowlisted_function_extra_call_red is a RED fixture for
+// SESSION-REVOKE-CALLER-INTX-01: a function whose first Revoke call is
+// sanctioned, but whose second Revoke call uses a non-transaction context.
+package allowlisted_function_extra_call_red
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/runtime/auth/session"
+)
+
+func allowedButBad(ctx, txCtx context.Context, s session.Store, id string) error {
+	if err := s.Revoke(txCtx, id); err != nil {
+		return err
+	}
+	return s.Revoke(context.Background(), id)
+}

--- a/tools/archtest/testdata/session_revoke_caller_fixtures/helper_nontx_call_red/red.go
+++ b/tools/archtest/testdata/session_revoke_caller_fixtures/helper_nontx_call_red/red.go
@@ -1,0 +1,15 @@
+// Package helper_nontx_call_red is a RED fixture for
+// SESSION-REVOKE-CALLER-INTX-01: a tx-scoped helper is called once correctly
+// and once with a non-transaction context.
+package helper_nontx_call_red
+
+import "context"
+
+type service struct{}
+
+func (service) cleanupIssuedSession(context.Context, string) {}
+
+func caller(ctx, txCtx context.Context, s service, id string) {
+	s.cleanupIssuedSession(txCtx, id)
+	s.cleanupIssuedSession(context.Background(), id)
+}

--- a/tools/archtest/testdata/session_revoke_caller_fixtures/unsanctioned_caller_red/red.go
+++ b/tools/archtest/testdata/session_revoke_caller_fixtures/unsanctioned_caller_red/red.go
@@ -1,0 +1,18 @@
+// Package unsanctioned_caller_red is a RED fixture for
+// SESSION-REVOKE-CALLER-INTX-01: a function that calls (session.Store).Revoke
+// without being in the sanctioned caller allowlist. The archtest must detect
+// ≥1 violation when scanning this package with an empty allowlist.
+package unsanctioned_caller_red
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/runtime/auth/session"
+)
+
+// unsanctionedRevoke calls session.Store.Revoke without any RunInTx scope.
+// This is NOT in sessionRevokeAllowlist — the archtest must flag it as a
+// violation.
+func unsanctionedRevoke(ctx context.Context, s session.Store, id string) error {
+	return s.Revoke(ctx, id)
+}


### PR DESCRIPTION
## Summary

为 session-cache 两条安全不变式补机器守卫：冻结 `sessionCacheEntry` 字段集（永不缓存 live `authz_epoch`），并把「`session.Store.Revoke` 生产 caller 必须在 RunInTx 内」的约束从 runtime panic 提前到 CI。同时把 `CACHING-SESSION-REVOKE-AFTERCOMMIT-DEL-01` 的 sealed-construction Hard-upgrade 据实结论为 won't-do。

## Why / 背景

两者均源自 PR #1613 内置 review。

- **#1616**：`RevokeForSubject` 的 fail-closed 安全 floor 依赖「live `users.authz_epoch` 永不入 session cache」——cache 只存 `AuthzEpochAtIssue`（at-issue 快照），`sessionvalidate` 用 live PG epoch 比对（mismatch → 401）。此前仅靠字段集 + godoc 约定，无机器守卫，未来字段漂移可能静默移除该安全前提。
- **#1615**：`CachingSessionStore.Revoke` 经 `RegisterAfterCommit` 要求 ambient RunInTx，否则 panic。D2 = 把「第二个未包 tx 的 caller 出现」从 runtime panic 提前到 CI；F3 = 评估 sealed-construction Hard 升级路径。

## What

- **D-1 (#1616) `SESSION-CACHE-EPOCH-NOT-CACHED-01`** — reflect-schema-freeze（`adapters/redis/session_cache_entry_frozen_test.go`，`package redis` 内部测试，因类型 unexported，`tools/archtest` 无法命名它）。冻结 4 字段 tuple（name/json-tag/type）+ 独立断言无 live-epoch 字段名/tag（防 tuple 被误改后仍拦住）。AI-robust **Hard**（reflect 字段冻结范本；issue 估 Medium，按范本据实标 Hard）。
- **D-2 (#1615) `SESSION-REVOKE-CALLER-INTX-01`** — caller-allowlist archtest（`tools/archtest/session_revoke_caller_intx_test.go`），对标 `OUTBOX-RECONSTRUCTION-CALLER-01`。`(session.Store).Revoke` 全部 **5** 个生产引用点（sessionlogout / sessionlogin 补偿路径 / redis decorator delegation / storetest suite+bench）各自人审在 RunInTx scope 内——after-commit registry 由所有 conformant RunInTx（含 `DemoTxRunner`）安装，故「在 RunInTx 内」而非「store 具体类型」是安全保证。anti-vacuity 反向自检防 stale entry。AI-robust **Medium**（tx-ambient 证明是 Go-ceiling）。
- **F3 (#1615) won't-do** — sealed-construction Hard 升级评估为不可行并据实记录：同包 seal 不可达（读路径 `evictBadEntry`/`lazyPopulate` 刚需同步 `cache.Delete/Set`，与 `Revoke` 共享同一 `*Cache` 字段，Go 无 per-method 字段可见性收窄）；跨包 seal 比例失衡且零行业先例。godoc 同 PR **全量 fan-out 核销 3 处**：`adapters/redis/session_cache_store.go`、`runtime/auth/session/store.go`、`tools/archtest/caching_session_revoke_delegate_only_test.go`。归 #851/#893/#1282 永久 Go-ceiling 族。

## Refs

- Closes #1615
- Closes #1616
- F3 won't-do 对标证据（均 runtime 注册 + 约定，无一 type-seal；GoCell 经 `RegisterAfterCommit` panic + `RunAfterCommitHooks` 剥离 `TxCtxKey` 已超过）：ref: spring-framework spring-tx `TransactionSynchronization.afterCommit` / hibernate-orm `AfterTransactionCompletionProcess` / ent `CommitHook` / watermill forwarder

## Risk / 兼容性

无生产逻辑 / 签名变更。改动 = 2 个新 archtest 测试文件 + 4 处 godoc 改写。`session.Store.Revoke` 方法 godoc 改写仅文档、非签名/返回值/error-sentinel 变化，**不触发** contract-fanout 的 interface-signature 条件。零 wire / DB / migration / 消费方影响。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./adapters/redis/...`（D-1 + 回归）通过；`go test ./tools/archtest/`（D-2 通过 + meta `ARCHTEST-VERIFY-COVERAGE-01` 自动发现新文件，全 628+ 中仅下方 pre-existing 一例失败）
- [x] `golangci-lint run ./adapters/redis/... ./tools/archtest/... ./runtime/auth/session/... ./cells/accesscore/slices/sessionlogin/...` → 0 issues
- [x] 检测有效性（TDD RED 证明，均已还原）：D-1 临时加 `AuthzEpoch int64` 第 5 字段 → tuple-freeze + no-live-epoch 两断言均红；D-2 临时删 redis allowlist entry → VIOLATION 红
- ⚠️ 已知无关失败：全 archtest suite 中 `TestSlogHandlerSealedFunnel_A3_DetectsViolation`（扫 `examples/ssobff` 卫星模块）在本机 **clean develop 即同样失败**（pre-existing 本地 GOWORK/SharedResolver 环境 artifact，与本 PR diff 无交集，且不在 PR-time CI 范围——完整 archtest 由 nightly 兜底）
