### PR TITLE
feat(idempotency): seal HTTP idempotency key into typed IdempotencyKey funnel — β Hard 升级 [#1610]

### DIFF
--- a/adapters/redis/http_idempotency.go
+++ b/adapters/redis/http_idempotency.go
@@ -28,7 +28,9 @@ var _ idemhttp.Store = (*HTTPIdempotencyStore)(nil)
 //
 //   - <store-ns>:<req-ns>:{key}:lease — SET NX with leaseTTL, value = random token. Indicates "processing".
 //   - <store-ns>:<req-ns>:{key}:resp  — SET with doneTTL, value = MarshalRecordedResponse blob. Indicates "completed".
-//   - <store-ns>:<req-ns>:{key}:fp    — SET with leaseTTL while processing; Record extends it to doneTTL. Value = body fingerprint; flags same-key/different-body reuse.
+//   - <store-ns>:<req-ns>:{key}:fp    — SET with leaseTTL while
+//     processing; Record extends it to doneTTL. Value = body fingerprint;
+//     flags same-key/different-body reuse.
 //
 // The key prefix has two segments, both OUTSIDE the hashtag:
 //

--- a/adapters/redis/http_idempotency.go
+++ b/adapters/redis/http_idempotency.go
@@ -133,23 +133,30 @@ func (s *HTTPIdempotencyStore) ReadyCheck(ctx context.Context) error {
 // ARGV[1] = token
 // ARGV[2] = leaseTTL (milliseconds — PX precision)
 // ARGV[3] = fingerprint (hex sha256 of request body)
-// ARGV[4] = fpTTL (milliseconds — max(leaseTTL, doneTTL) to keep fp alongside resp)
+// ARGV[4] = fpTTL (milliseconds — leaseTTL; Record extends it to doneTTL)
 //
 // Returns:
 //
-//	{1}            = ClaimAcquired (lease set successfully; fp stored at KEYS[3])
+//	{1}            = ClaimAcquired (lease set successfully; fp stored at KEYS[3] with lease TTL)
 //	{0}            = ClaimBusy    (lease already held; fp matches or fp absent)
 //	{2,blob}       = ClaimDone    (resp key exists; blob = stored response; fp matches or fp absent)
 //	{3,fp_stored}  = FingerprintMismatch (fp key differs from ARGV[3]; fp_stored = the
 //	                 stored fingerprint blob, carried back for the per-field diff)
 const claimRespScript = `
 local fp_stored = redis.call('GET', KEYS[3])
-if fp_stored ~= false and ARGV[3] ~= "" and fp_stored ~= ARGV[3] then
-  return {3, fp_stored}
-end
 local resp = redis.call('GET', KEYS[1])
 if resp ~= false then
+  if fp_stored ~= false and ARGV[3] ~= "" and fp_stored ~= ARGV[3] then
+    return {3, fp_stored}
+  end
   return {2, resp}
+end
+local lease = redis.call('GET', KEYS[2])
+if lease ~= false then
+  if fp_stored ~= false and ARGV[3] ~= "" and fp_stored ~= ARGV[3] then
+    return {3, fp_stored}
+  end
+  return {0}
 end
 local ok = redis.call('SET', KEYS[2], ARGV[1], 'NX', 'PX', ARGV[2])
 if ok then
@@ -162,7 +169,7 @@ return {0}
 `
 
 // recordScript: atomic Record (token-guarded). KEYS[1] is the lease-key.
-// On success the fp key is preserved (SET with doneTTL) so that future
+// On success the fp key is extended to doneTTL so that future
 // replay Claim calls can still validate the fingerprint. On Release the fp key
 // is deleted with the lease because there is no response to protect.
 //
@@ -257,10 +264,10 @@ func (s *HTTPIdempotencyStore) Claim(
 	leaseKey := KeyNamespace(scopedNS).applyHashtag(key, "lease")
 	fpKey := KeyNamespace(scopedNS).applyHashtag(key, "fp")
 	leaseMs := max(leaseTTL.Milliseconds(), 1)
-	// fpTTL = max(leaseTTL, doneTTL) so the fp key outlasts the lease but
-	// expires alongside the response key. Use doneTTL (24h default) as an upper
-	// bound; leaseTTL is at most 5 min so doneTTL dominates in practice.
-	fpMs := max(idempotency.DefaultTTL.Milliseconds(), leaseMs)
+	// fpTTL follows the in-flight lease. If the handler never records a response
+	// and the lease expires, the old fingerprint must expire with it so a later
+	// retry is a fresh acquisition. Record extends the fp key to doneTTL.
+	fpMs := leaseMs
 
 	res, err := s.rdb.Eval(ctx, claimRespScript, []string{respKey, leaseKey, fpKey}, token, leaseMs, fingerprint, fpMs).Result()
 	if err != nil {

--- a/adapters/redis/http_idempotency.go
+++ b/adapters/redis/http_idempotency.go
@@ -205,27 +205,28 @@ return 0
 `
 
 // Claim implements idemhttp.Store. It attempts to acquire a processing lease
-// for the given ns+key pair.
+// for the given sealed key k.
 //
 // The Redis keys are derived as:
 //
 //	<store-ns>:<ns>:{<key>}:lease  and  …:resp  and  …:fp
 //
 // where <store-ns> is the construction-time KeyNamespace (s.ns, owner
-// dimension) and <ns> is the Claim ns parameter. In the standard Middleware,
-// ns is the caller TenantID (or "_notenant" when absent); the interface
-// contract accepts any non-empty, brace-free string. <key> is the composed
-// idempotency key. Both prefix segments sit outside the hashtag so Redis
-// Cluster CRC16 only hashes {<key>}.
+// dimension), <ns> = k.Namespace() (the caller TenantID, or "_notenant" when
+// absent), and <key> = k.Key() (the composed idempotency key). Both prefix
+// segments sit outside the hashtag so Redis Cluster CRC16 only hashes {<key>}.
 //
-// Both ns and key must be non-empty and free of '{'/'}' characters so the
-// Redis Cluster hashtag boundary is unambiguous.
+// Both k.Namespace() and k.Key() must be non-empty and free of '{'/'}' so the
+// Redis Cluster hashtag boundary is unambiguous — a Redis-Cluster-specific
+// constraint validated here, deliberately NOT folded into the store-agnostic
+// DeriveKey (MemStore has no such constraint).
 //
 // fingerprint is hex(sha256(body)). If a previous Claim stored a different
 // fingerprint for the same key, ErrFingerprintMismatch is returned.
 func (s *HTTPIdempotencyStore) Claim(
-	ctx context.Context, ns, key, fingerprint string, leaseTTL time.Duration,
+	ctx context.Context, k idemhttp.IdempotencyKey, fingerprint string, leaseTTL time.Duration,
 ) (idempotency.ClaimState, *idemhttp.RecordedResponse, idemhttp.Receipt, error) {
+	ns, key := k.Namespace(), k.Key()
 	if ns == "" || strings.ContainsAny(ns, "{}") {
 		return 0, nil, nil, errcode.New(errcode.KindInternal, ErrAdapterRedisSet,
 			"redis: http idempotency ns must be non-empty and free of curly-brace characters",

--- a/adapters/redis/http_idempotency.go
+++ b/adapters/redis/http_idempotency.go
@@ -28,7 +28,7 @@ var _ idemhttp.Store = (*HTTPIdempotencyStore)(nil)
 //
 //   - <store-ns>:<req-ns>:{key}:lease — SET NX with leaseTTL, value = random token. Indicates "processing".
 //   - <store-ns>:<req-ns>:{key}:resp  — SET with doneTTL, value = MarshalRecordedResponse blob. Indicates "completed".
-//   - <store-ns>:<req-ns>:{key}:fp    — SET with max(leaseTTL,doneTTL), value = body fingerprint; flags same-key/different-body reuse.
+//   - <store-ns>:<req-ns>:{key}:fp    — SET with leaseTTL while processing; Record extends it to doneTTL. Value = body fingerprint; flags same-key/different-body reuse.
 //
 // The key prefix has two segments, both OUTSIDE the hashtag:
 //
@@ -45,10 +45,12 @@ var _ idemhttp.Store = (*HTTPIdempotencyStore)(nil)
 // segments sit outside the hashtag, so slot colocality is preserved regardless
 // of either namespace value.
 //
-// Claim checks fp first (FingerprintMismatch if the stored fp differs), then
-// resp (ClaimDone+replay), then attempts lease (ClaimAcquired — storing fp — or
-// ClaimBusy). Record sets resp + preserves fp + deletes lease. Release deletes
-// lease + fp (token-guarded); there is no response to protect.
+// Claim compares fp only while resp or lease is active. With resp present it
+// returns ClaimDone+replay after validating fp; with lease present it returns
+// ClaimBusy after validating fp; when neither exists it acquires lease and
+// stores fp for the leaseTTL. Record sets resp + extends fp to doneTTL + deletes
+// lease. Release deletes lease + fp (token-guarded); there is no response to
+// protect.
 type HTTPIdempotencyStore struct {
 	rdb cmdable
 	ns  KeyNamespace

--- a/adapters/redis/http_idempotency_assembly_scope_test.go
+++ b/adapters/redis/http_idempotency_assembly_scope_test.go
@@ -73,7 +73,7 @@ func TestIntegration_HTTPIdempotencyStore_AssemblyScope_CrossPodReplay(t *testin
 	key := "asm-replay\x00POST\x00/api/v1/orders\x00" + t.Name()
 
 	// Pod A acquires and records.
-	stateA, _, receiptA, err := podA.Claim(ctx, asmReqNS, key, asmFP, testtime.D5min)
+	stateA, _, receiptA, err := podA.Claim(ctx, httpKey(asmReqNS, key), asmFP, testtime.D5min)
 	require.NoError(t, err, "pod-A Claim")
 	require.Equal(t, idempotency.ClaimAcquired, stateA, "pod-A must acquire a fresh key")
 
@@ -82,7 +82,7 @@ func TestIntegration_HTTPIdempotencyStore_AssemblyScope_CrossPodReplay(t *testin
 	require.NoError(t, receiptA.Record(ctx, &resp, testtime.CtxLong), "pod-A Record")
 
 	// Pod B (different store instance) replays the same (ns,key,fp).
-	stateB, recB, _, err := podB.Claim(ctx, asmReqNS, key, asmFP, testtime.D5min)
+	stateB, recB, _, err := podB.Claim(ctx, httpKey(asmReqNS, key), asmFP, testtime.D5min)
 	require.NoError(t, err, "pod-B Claim")
 	require.Equal(t, idempotency.ClaimDone, stateB,
 		"pod-B must replay (ClaimDone) a key pod-A recorded — assembly-wide dedup")
@@ -103,12 +103,12 @@ func TestIntegration_HTTPIdempotencyStore_AssemblyScope_CrossPodBusy(t *testing.
 	ctx := context.Background()
 	key := "asm-busy\x00PUT\x00/api/v1/payments\x00" + t.Name()
 
-	stateA, _, _, err := podA.Claim(ctx, asmReqNS, key, asmFP, testtime.D5min)
+	stateA, _, _, err := podA.Claim(ctx, httpKey(asmReqNS, key), asmFP, testtime.D5min)
 	require.NoError(t, err, "pod-A Claim")
 	require.Equal(t, idempotency.ClaimAcquired, stateA, "pod-A must acquire")
 
 	// Pod B sees the in-flight lease held by pod A.
-	stateB, _, _, err := podB.Claim(ctx, asmReqNS, key, asmFP, testtime.D5min)
+	stateB, _, _, err := podB.Claim(ctx, httpKey(asmReqNS, key), asmFP, testtime.D5min)
 	require.NoError(t, err, "pod-B Claim")
 	require.Equal(t, idempotency.ClaimBusy, stateB,
 		"pod-B must observe pod-A's in-flight lease (ClaimBusy) — cross-pod concurrency lock")
@@ -124,14 +124,14 @@ func TestIntegration_HTTPIdempotencyStore_AssemblyScope_CrossPodFingerprintMisma
 	ctx := context.Background()
 	key := "asm-fp\x00POST\x00/api/v1/orders\x00" + t.Name()
 
-	stateA, _, receiptA, err := podA.Claim(ctx, asmReqNS, key, asmFP, testtime.D5min)
+	stateA, _, receiptA, err := podA.Claim(ctx, httpKey(asmReqNS, key), asmFP, testtime.D5min)
 	require.NoError(t, err, "pod-A Claim")
 	require.Equal(t, idempotency.ClaimAcquired, stateA, "pod-A must acquire")
 	resp := idempotencytest.BuildRecordedResponse(t, 200, []byte(`{"ok":true}`))
 	require.NoError(t, receiptA.Record(ctx, &resp, testtime.CtxLong), "pod-A Record")
 
 	// Pod B replays the same key with a different body fingerprint → mismatch.
-	_, _, _, err = podB.Claim(ctx, asmReqNS, key, asmFPAlt, testtime.D5min)
+	_, _, _, err = podB.Claim(ctx, httpKey(asmReqNS, key), asmFPAlt, testtime.D5min)
 	require.Error(t, err, "pod-B Claim with mismatched fingerprint must error")
 	require.True(t, errors.Is(err, idemhttp.ErrFingerprintMismatch),
 		"cross-pod fingerprint mismatch must surface ErrFingerprintMismatch; got %v", err)

--- a/adapters/redis/http_idempotency_cluster_real_test.go
+++ b/adapters/redis/http_idempotency_cluster_real_test.go
@@ -54,7 +54,7 @@ func TestClusterIntegration_HTTPIdempotencyStore_NoCrossSlot(t *testing.T) {
 	}
 	for _, k := range keys {
 		t.Run(k, func(t *testing.T) {
-			state, _, receipt, err := store.Claim(ctx, reqNS, k, clusterHTTPFP, testtime.D5min)
+			state, _, receipt, err := store.Claim(ctx, httpKey(reqNS, k), clusterHTTPFP, testtime.D5min)
 			require.NoError(t, err, "Claim must not return CROSSSLOT")
 			require.Equal(t, idempotency.ClaimAcquired, state)
 
@@ -63,7 +63,7 @@ func TestClusterIntegration_HTTPIdempotencyStore_NoCrossSlot(t *testing.T) {
 				"Record must not return CROSSSLOT")
 
 			// Re-Claim returns ClaimDone now that the resp key is set.
-			state2, rec2, _, err := store.Claim(ctx, reqNS, k, clusterHTTPFP, testtime.D5min)
+			state2, rec2, _, err := store.Claim(ctx, httpKey(reqNS, k), clusterHTTPFP, testtime.D5min)
 			require.NoError(t, err, "re-Claim must not return CROSSSLOT")
 			require.Equal(t, idempotency.ClaimDone, state2)
 			require.NotNil(t, rec2, "replay response must be non-nil")

--- a/adapters/redis/http_idempotency_cluster_slot_test.go
+++ b/adapters/redis/http_idempotency_cluster_slot_test.go
@@ -46,7 +46,7 @@ func httpIdempotencyStoreKeys(storeNS KeyNamespace, reqNS, key string) (resp, le
 
 // TestHTTPIdempotency_HashtagKeysShareSlot asserts the resp/lease/fp keys for a
 // given request colocate on one Redis Cluster slot. Sample business keys mirror
-// the real buildNamespaceKey output shape (subject\x00method\x00path\x00header),
+// the real DeriveKey output shape (subject\x00method\x00path\x00header),
 // and the request-namespace varies (tenant id vs the "_notenant" sentinel). The
 // "_runtime" store namespace mirrors cmd/corebundle's httpIdempotencyStoreNamespace
 // (the assembly-wide owner namespace, ADR 202606051000-1449).

--- a/adapters/redis/http_idempotency_decode_test.go
+++ b/adapters/redis/http_idempotency_decode_test.go
@@ -149,7 +149,7 @@ func TestHTTPIdempotencyStore_Claim_EmptyNS(t *testing.T) {
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, newHTTPClaimerMock())
 	ctx := context.Background()
 
-	state, rec, receipt, err := s.Claim(ctx, "", "somekey", "", idempotency.DefaultLeaseTTL)
+	state, rec, receipt, err := s.Claim(ctx, idemhttp.IdempotencyKey{}, "", idempotency.DefaultLeaseTTL)
 
 	require.Error(t, err)
 	assert.Zero(t, state)
@@ -165,7 +165,7 @@ func TestHTTPIdempotencyStore_Claim_NSWithBraces(t *testing.T) {
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, newHTTPClaimerMock())
 	ctx := context.Background()
 
-	state, rec, receipt, err := s.Claim(ctx, "bad{ns}", "somekey", "", idempotency.DefaultLeaseTTL)
+	state, rec, receipt, err := s.Claim(ctx, httpKey("bad{ns}", "somekey"), "", idempotency.DefaultLeaseTTL)
 
 	require.Error(t, err)
 	assert.Zero(t, state)
@@ -173,28 +173,19 @@ func TestHTTPIdempotencyStore_Claim_NSWithBraces(t *testing.T) {
 	assert.Nil(t, receipt)
 }
 
-// TestHTTPIdempotencyStore_Claim_EmptyKey covers the "key must be non-empty" branch.
-func TestHTTPIdempotencyStore_Claim_EmptyKey(t *testing.T) {
-	s := mustNewHTTPIdempotencyStoreFromCmdable(t, newHTTPClaimerMock())
-	ctx := context.Background()
-
-	state, rec, receipt, err := s.Claim(ctx, "goodns", "", "", idempotency.DefaultLeaseTTL)
-
-	require.Error(t, err)
-	assert.Zero(t, state)
-	assert.Nil(t, rec)
-	assert.Nil(t, receipt)
-	var ec *errcode.Error
-	require.ErrorAs(t, err, &ec)
-	assert.Equal(t, ErrAdapterRedisSet, ec.Code)
-}
+// NOTE: there is no Claim_EmptyKey test. With the sealed IdempotencyKey, a
+// "non-empty ns + empty key" input is structurally unconstructible: DeriveKey
+// always yields a key of ≥3 bytes, and the only empty sealed key is the zero
+// value (covered by Claim_EmptyNS, which trips the empty-ns guard first). The
+// adapter's empty-key guard remains as defense-in-depth but is unreachable from
+// a sealed key.
 
 // TestHTTPIdempotencyStore_Claim_KeyWithBraces covers the "key contains curly braces" branch.
 func TestHTTPIdempotencyStore_Claim_KeyWithBraces(t *testing.T) {
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, newHTTPClaimerMock())
 	ctx := context.Background()
 
-	state, rec, receipt, err := s.Claim(ctx, "goodns", "bad{key}", "", idempotency.DefaultLeaseTTL)
+	state, rec, receipt, err := s.Claim(ctx, httpKey("goodns", "bad{key}"), "", idempotency.DefaultLeaseTTL)
 
 	require.Error(t, err)
 	assert.Zero(t, state)
@@ -208,7 +199,7 @@ func TestHTTPIdempotencyStore_Claim_ZeroLeaseTTLClamped(t *testing.T) {
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, newHTTPClaimerMock())
 	ctx := context.Background()
 
-	state, _, _, err := s.Claim(ctx, "testns", "key:ttlclamp", "", 0)
+	state, _, _, err := s.Claim(ctx, httpKey("testns", "key:ttlclamp"), "", 0)
 
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimAcquired, state)
@@ -228,13 +219,13 @@ func TestNoopHTTPReceipt_RecordReturnsErrNoClaimLease(t *testing.T) {
 
 	// Pre-set the lease to simulate another consumer holding it.
 	mock.mu.Lock()
-	mock.store["ownerns:testns:{key:noop:001}:lease"] = mockEntry{
+	mock.store["ownerns:testns:{key:noop:001\x00\x00\x00}:lease"] = mockEntry{
 		value: "other-token",
 	}
 	mock.mu.Unlock()
 
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
-	state, _, receipt, err := s.Claim(ctx, "testns", "key:noop:001", "", idempotency.DefaultLeaseTTL)
+	state, _, receipt, err := s.Claim(ctx, httpKey("testns", "key:noop:001"), "", idempotency.DefaultLeaseTTL)
 	require.NoError(t, err)
 	require.Equal(t, idempotency.ClaimBusy, state)
 	require.NotNil(t, receipt)
@@ -259,13 +250,13 @@ func TestNoopHTTPReceipt_ReleaseReturnsErrNoClaimLease(t *testing.T) {
 
 	// Pre-set the lease to simulate another consumer.
 	mock.mu.Lock()
-	mock.store["ownerns:testns:{key:noop:002}:lease"] = mockEntry{
+	mock.store["ownerns:testns:{key:noop:002\x00\x00\x00}:lease"] = mockEntry{
 		value: "other-token",
 	}
 	mock.mu.Unlock()
 
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
-	state, _, receipt, err := s.Claim(ctx, "testns", "key:noop:002", "", idempotency.DefaultLeaseTTL)
+	state, _, receipt, err := s.Claim(ctx, httpKey("testns", "key:noop:002"), "", idempotency.DefaultLeaseTTL)
 	require.NoError(t, err)
 	require.Equal(t, idempotency.ClaimBusy, state)
 	require.NotNil(t, receipt)
@@ -284,7 +275,7 @@ func TestNoopHTTPReceipt_ViaClaimDone_RecordAndRelease(t *testing.T) {
 	s := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 
 	// First: acquire and record a response so the second claim is ClaimDone.
-	_, _, firstReceipt, err := s.Claim(ctx, "testns", "key:noop:003", "", idempotency.DefaultLeaseTTL)
+	_, _, firstReceipt, err := s.Claim(ctx, httpKey("testns", "key:noop:003"), "", idempotency.DefaultLeaseTTL)
 	require.NoError(t, err)
 
 	raw := []byte(`{"status":200,"body":"dGVzdA==","header":{},"recordedAt":"2024-01-01T00:00:00Z"}`)
@@ -293,7 +284,7 @@ func TestNoopHTTPReceipt_ViaClaimDone_RecordAndRelease(t *testing.T) {
 	require.NoError(t, firstReceipt.Record(ctx, &rec, idempotency.DefaultTTL))
 
 	// Second claim returns ClaimDone with a noopHTTPReceipt.
-	state, _, noopR, err2 := s.Claim(ctx, "testns", "key:noop:003", "", idempotency.DefaultLeaseTTL)
+	state, _, noopR, err2 := s.Claim(ctx, httpKey("testns", "key:noop:003"), "", idempotency.DefaultLeaseTTL)
 	require.NoError(t, err2)
 	require.Equal(t, idempotency.ClaimDone, state)
 	require.NotNil(t, noopR)

--- a/adapters/redis/http_idempotency_decode_test.go
+++ b/adapters/redis/http_idempotency_decode_test.go
@@ -174,11 +174,12 @@ func TestHTTPIdempotencyStore_Claim_NSWithBraces(t *testing.T) {
 }
 
 // NOTE: there is no Claim_EmptyKey test. With the sealed IdempotencyKey, a
-// "non-empty ns + empty key" input is structurally unconstructible: DeriveKey
-// always yields a key of ≥3 bytes, and the only empty sealed key is the zero
-// value (covered by Claim_EmptyNS, which trips the empty-ns guard first). The
-// adapter's empty-key guard remains as defense-in-depth but is unreachable from
-// a sealed key.
+// "non-empty ns + empty key" input is structurally unconstructible: a key
+// produced by DeriveKey is always ≥3 bytes (3 NUL separators), so key==""
+// is unreachable via DeriveKey. The only empty sealed key is the zero value
+// IdempotencyKey{}, which has an empty ns too and is caught by the empty-ns
+// guard first (see Claim_EmptyNS). The adapter's empty-key guard remains as
+// defense-in-depth but is unreachable from a properly constructed sealed key.
 
 // TestHTTPIdempotencyStore_Claim_KeyWithBraces covers the "key contains curly braces" branch.
 func TestHTTPIdempotencyStore_Claim_KeyWithBraces(t *testing.T) {

--- a/adapters/redis/http_idempotency_test.go
+++ b/adapters/redis/http_idempotency_test.go
@@ -16,6 +16,16 @@ import (
 	idemhttp "github.com/ghbvf/gocell/runtime/http/idempotency"
 )
 
+// httpKey builds an idemhttp.IdempotencyKey for HTTPIdempotencyStore tests from
+// an (ns, key) pair via the real DeriveKey (external packages cannot construct
+// the sealed type any other way). It maps ns→tenant and key→subject; the other
+// tuple slots are empty, so Namespace()==ns and Key()==key+"\x00\x00\x00"
+// (distinct per `key`, brace-free unless ns/key carry braces — which the
+// brace-rejection tests rely on).
+func httpKey(ns, key string) idemhttp.IdempotencyKey {
+	return idemhttp.DeriveKey(ns, key, "", "", "")
+}
+
 // =============================================================================
 // Constructor tests
 // =============================================================================
@@ -66,7 +76,7 @@ func TestHTTPIdempotencyStore_Claim_Acquired(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	state, rec, receipt, err := store.Claim(ctx, "testns", "key:001", "", testtime.D5min)
+	state, rec, receipt, err := store.Claim(ctx, httpKey("testns", "key:001"), "", testtime.D5min)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimAcquired, state)
 	assert.Nil(t, rec, "acquired should have nil RecordedResponse")
@@ -74,7 +84,7 @@ func TestHTTPIdempotencyStore_Claim_Acquired(t *testing.T) {
 
 	// Verify lease key is present.
 	mock.mu.Lock()
-	_, hasLease := mock.store["ownerns:testns:{key:001}:lease"]
+	_, hasLease := mock.store["ownerns:testns:{key:001\x00\x00\x00}:lease"]
 	mock.mu.Unlock()
 	assert.True(t, hasLease, "lease key should exist after Claim Acquired")
 }
@@ -89,7 +99,7 @@ func TestHTTPIdempotencyStore_Record_ThenClaim_Done(t *testing.T) {
 	ctx := context.Background()
 
 	// First claim acquires the lease.
-	state, _, receipt, err := store.Claim(ctx, "testns", "key:002", "", testtime.D5min)
+	state, _, receipt, err := store.Claim(ctx, httpKey("testns", "key:002"), "", testtime.D5min)
 	require.NoError(t, err)
 	require.Equal(t, idempotency.ClaimAcquired, state)
 	require.NotNil(t, receipt)
@@ -103,14 +113,14 @@ func TestHTTPIdempotencyStore_Record_ThenClaim_Done(t *testing.T) {
 
 	// Verify resp key is now present, lease key is gone.
 	mock.mu.Lock()
-	_, hasLease := mock.store["ownerns:testns:{key:002}:lease"]
-	_, hasResp := mock.store["ownerns:testns:{key:002}:resp"]
+	_, hasLease := mock.store["ownerns:testns:{key:002\x00\x00\x00}:lease"]
+	_, hasResp := mock.store["ownerns:testns:{key:002\x00\x00\x00}:resp"]
 	mock.mu.Unlock()
 	assert.False(t, hasLease, "lease key should be deleted after Record")
 	assert.True(t, hasResp, "resp key should exist after Record")
 
 	// Second claim returns Done with the replayed response.
-	state2, rec2, _, err2 := store.Claim(ctx, "testns", "key:002", "", testtime.D5min)
+	state2, rec2, _, err2 := store.Claim(ctx, httpKey("testns", "key:002"), "", testtime.D5min)
 	require.NoError(t, err2)
 	assert.Equal(t, idempotency.ClaimDone, state2)
 	require.NotNil(t, rec2, "ClaimDone should return the recorded response")
@@ -128,14 +138,14 @@ func TestHTTPIdempotencyStore_Claim_Busy(t *testing.T) {
 
 	// Pre-set the lease to simulate another consumer.
 	mock.mu.Lock()
-	mock.store["ownerns:testns:{key:003}:lease"] = mockEntry{
+	mock.store["ownerns:testns:{key:003\x00\x00\x00}:lease"] = mockEntry{
 		value:  "other-token",
 		expiry: time.Now().Add(testtime.D5min),
 	}
 	mock.mu.Unlock()
 
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
-	state, rec, _, err := store.Claim(ctx, "testns", "key:003", "", testtime.D5min)
+	state, rec, _, err := store.Claim(ctx, httpKey("testns", "key:003"), "", testtime.D5min)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimBusy, state)
 	assert.Nil(t, rec, "ClaimBusy should have nil RecordedResponse")
@@ -150,7 +160,7 @@ func TestHTTPIdempotencyStore_Release(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	state, _, receipt, err := store.Claim(ctx, "testns", "key:004", "", testtime.D5min)
+	state, _, receipt, err := store.Claim(ctx, httpKey("testns", "key:004"), "", testtime.D5min)
 	require.NoError(t, err)
 	require.Equal(t, idempotency.ClaimAcquired, state)
 
@@ -158,8 +168,8 @@ func TestHTTPIdempotencyStore_Release(t *testing.T) {
 	require.NoError(t, err)
 
 	mock.mu.Lock()
-	_, hasLease := mock.store["ownerns:testns:{key:004}:lease"]
-	_, hasResp := mock.store["ownerns:testns:{key:004}:resp"]
+	_, hasLease := mock.store["ownerns:testns:{key:004\x00\x00\x00}:lease"]
+	_, hasResp := mock.store["ownerns:testns:{key:004\x00\x00\x00}:resp"]
 	mock.mu.Unlock()
 	assert.False(t, hasLease, "lease key should be deleted after Release")
 	assert.False(t, hasResp, "resp key should NOT exist after Release")
@@ -174,13 +184,13 @@ func TestHTTPIdempotencyStore_Record_StaleToken(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	state, _, receipt, err := store.Claim(ctx, "testns", "key:005", "", testtime.D5min)
+	state, _, receipt, err := store.Claim(ctx, httpKey("testns", "key:005"), "", testtime.D5min)
 	require.NoError(t, err)
 	require.Equal(t, idempotency.ClaimAcquired, state)
 
 	// Simulate lease expiry by deleting the lease key.
 	mock.mu.Lock()
-	delete(mock.store, "ownerns:testns:{key:005}:lease")
+	delete(mock.store, "ownerns:testns:{key:005\x00\x00\x00}:lease")
 	mock.mu.Unlock()
 
 	resp := buildTestRecordedResponse(t)
@@ -198,13 +208,13 @@ func TestHTTPIdempotencyStore_Release_StaleToken(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	state, _, receipt, err := store.Claim(ctx, "testns", "key:006", "", testtime.D5min)
+	state, _, receipt, err := store.Claim(ctx, httpKey("testns", "key:006"), "", testtime.D5min)
 	require.NoError(t, err)
 	require.Equal(t, idempotency.ClaimAcquired, state)
 
 	// Simulate lease expiry.
 	mock.mu.Lock()
-	delete(mock.store, "ownerns:testns:{key:006}:lease")
+	delete(mock.store, "ownerns:testns:{key:006\x00\x00\x00}:lease")
 	mock.mu.Unlock()
 
 	err = receipt.Release(ctx)
@@ -221,7 +231,7 @@ func TestHTTPIdempotencyStore_DoubleRecord_Idempotent(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	_, _, receipt, err := store.Claim(ctx, "testns", "key:007", "", testtime.D5min)
+	_, _, receipt, err := store.Claim(ctx, httpKey("testns", "key:007"), "", testtime.D5min)
 	require.NoError(t, err)
 
 	resp := buildTestRecordedResponse(t)
@@ -234,7 +244,7 @@ func TestHTTPIdempotencyStore_DoubleRelease_Idempotent(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	_, _, receipt, err := store.Claim(ctx, "testns", "key:008", "", testtime.D5min)
+	_, _, receipt, err := store.Claim(ctx, httpKey("testns", "key:008"), "", testtime.D5min)
 	require.NoError(t, err)
 
 	require.NoError(t, receipt.Release(ctx))
@@ -251,7 +261,7 @@ func TestHTTPIdempotencyStore_Claim_EvalError(t *testing.T) {
 	store := mustNewHTTPIdempotencyStoreFromCmdable(t, mock)
 	ctx := context.Background()
 
-	state, rec, receipt, err := store.Claim(ctx, "testns", "key:009", "", testtime.D5min)
+	state, rec, receipt, err := store.Claim(ctx, httpKey("testns", "key:009"), "", testtime.D5min)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_ADAPTER_REDIS_SET")
 	assert.Equal(t, idempotency.ClaimState(0), state)
@@ -286,7 +296,7 @@ func TestNewHTTPIdempotencyStore_ViaClientConstructor(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	state, _, _, err := store.Claim(ctx, "testns", "key:client:001", "", testtime.D5min)
+	state, _, _, err := store.Claim(ctx, httpKey("testns", "key:client:001"), "", testtime.D5min)
 	require.NoError(t, err)
 	assert.Equal(t, idempotency.ClaimAcquired, state)
 }

--- a/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
+++ b/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
@@ -157,7 +157,7 @@ lease 机制本身已防止重复处理：`ClaimBusy` 时 Claim 不成功，hand
 
 - `<ns>:{<key>}:lease` — `SET NX PX <leaseTTL>`，值为随机 token（UUID fencing）。表示"处理中"。
 - `<ns>:{<key>}:resp` — `SET PX <doneTTL>`，值为 `MarshalRecordedResponse` blob。表示"已完成"。
-- `<ns>:{<key>}:fp` — `SET PX max(<leaseTTL>,<doneTTL>)`，值为请求 body fingerprint。用于同 key／不同 body 的复用检测，生命周期与 resp 对齐（done 后仍存活以便后续 replay 校验指纹）。
+- `<ns>:{<key>}:fp` — Claim 获得 lease 时 `SET PX <leaseTTL>`，值为请求 body fingerprint；Record 成功后延长为 `doneTTL`，Release 删除。用于 active lease 或 done resp 下同 key／不同 body 的复用检测；abandoned lease 过期后不再保留 stale fingerprint。
 
 三个 key 共享 Redis Cluster hashtag `{<key>}`（hashtag 仅含业务 key，namespace 前缀在
 hashtag 外），保证 lease + resp + fp 落在同一 slot，使 `EVAL` multi-key 在 Cluster 模式下

--- a/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
+++ b/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
@@ -178,7 +178,7 @@ Claim）→ 返回 0，抛出 permanent error（不重试）。
 `NewHTTPIdempotencyStore` 在构造期调用 `ns.Validate()` + nil client 检查，满足
 `REDIS-KEY-NAMESPACE-01` archtest 约束（构造器 body 顶部强制 `ns.Validate()`）。
 
-注意：`HTTPIdempotencyStore.Claim` 中 `ns` 参数（来自 Middleware 的 `buildNamespaceKey`
+注意：`HTTPIdempotencyStore.Claim` 中 `ns` 参数（来自 Middleware 的 `DeriveKey`
 输出，值为 tenantID 或 `_notenant`）作为 Redis key namespace 的**运行时部分**，与构造器
 注入的 `KeyNamespace`（标识 adapter owner，如 `"http-idempotency"`）是两个正交概念——
 `KeyNamespace` 在 `REDIS-KEY-NAMESPACE-01` archtest 的 `ns.Validate()` 守卫下；Claim 的
@@ -368,7 +368,7 @@ Implementations:
                                             Store.Claim now takes fingerprint string)
   [x] runtime/http/idempotency/recorded_response.go (sealed RecordedResponse + Marshal/Unmarshal)
   [x] runtime/http/idempotency/middleware.go (Middleware + shouldIntercept + extractIdentity
-                                             + buildNamespaceKey (method+path in key)
+                                             + DeriveKey (method+path in key)
                                              + readBodyFingerprint + WithExemptMatcher
                                              + recordOrRelease + shouldRecord)
   [x] runtime/http/idempotency/buffer_writer.go (bufferingWriter — response capture)

--- a/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
+++ b/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
@@ -178,12 +178,12 @@ Claim）→ 返回 0，抛出 permanent error（不重试）。
 `NewHTTPIdempotencyStore` 在构造期调用 `ns.Validate()` + nil client 检查，满足
 `REDIS-KEY-NAMESPACE-01` archtest 约束（构造器 body 顶部强制 `ns.Validate()`）。
 
-注意：`HTTPIdempotencyStore.Claim` 中 `ns` 参数（来自 Middleware 的 `DeriveKey`
-输出，值为 tenantID 或 `_notenant`）作为 Redis key namespace 的**运行时部分**，与构造器
+注意：`HTTPIdempotencyStore.Claim` 中的 sealed `IdempotencyKey`（来自 Middleware 的
+`DeriveKey` 输出；`k.Namespace()` 为 tenantID 或 `_notenant`）作为 Redis key namespace 的**运行时部分**，与构造器
 注入的 `KeyNamespace`（标识 adapter owner，如 `"http-idempotency"`）是两个正交概念——
 `KeyNamespace` 在 `REDIS-KEY-NAMESPACE-01` archtest 的 `ns.Validate()` 守卫下；Claim 的
-`ns` 参数由 Middleware 生成，不走同一 funnel，但代码中对 `"{}` 字符做了额外 runtime
-guard（避免破坏 hashtag 边界）。
+request namespace 来自 sealed key，由 Middleware 生成，不走同一 funnel，但代码中对 `{` / `}` 字符做了额外 runtime
+guard（避免破坏 hashtag 边界）。`k.Key()` 是 Redis hash-tag payload，确保 resp/lease/fp 三键同槽。
 
 ### 9. 作用域范围
 
@@ -398,7 +398,7 @@ Dependent contracts (governance scan): none — middleware 是 framework 横切�
 
 以下内容在本 PR 范围之外，按 `feedback_pr_scope_carveouts_must_backlog` 规则同步登记 backlog：
 
-- **full-assembly 幂等命名空间** — ✅ **已实现**（gh #1449）：`_runtime` 定调为 assembly-wide 命名空间 + 两道结构闸（`HTTP-IDEMPOTENCY-STORE-STATELESS-FROZEN-01` Hard / `HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01` Medium）+ 三层证明测试，见 §9 Amendment + ADR `202606051000-1449`。
+- **full-assembly 幂等命名空间** — ✅ **已实现**（gh #1449）：`_runtime` 定调为 assembly-wide 命名空间 + 两道结构闸（`HTTP-IDEMPOTENCY-STORE-STATELESS-FROZEN-01` Hard / `HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01` 分轴：downstream Hard、upstream-external Hard、upstream-in-package + require-isolation-tuple Medium）+ 三层证明测试，见 §9 Amendment + ADR `202606051000-1449`。
 - **cross-cell 跨 cell 同槽幂等**（gh #1610，blocked-by #1044）：同一 idempotency-key 在不同 cell/listener 间共享同一去重槽，需 HTTP `Idempotency-Key` ↔ `command_id` 映射桥（ADR-1044 §5 演进路径 ⑤）+ 新的共享 KeyNamespace 治理决策。
 - **request-payload fingerprinting + 422 + per-field diff** — ✅ **已实现**（gh #1450）：`Store.Claim` 接收 canonical fingerprint blob；同一 key + 不同 body → **422** `ERR_IDEMPOTENCY_KEY_REUSED`，响应 details 列出差异的顶层字段名（Stripe 式 per-field diff，只回字段名/不回值）。详见文末 §"Amendment 2026-06-04"。gh #1450 关闭。
 - **production wiring** — ✅ **已实现**（gh #1469）：`cmd/corebundle` 在 `shared.Redis != nil` 时默认接通 `bootstrap.WithIdempotencyStore(redis.NewHTTPIdempotencyStore(client, "_runtime"))`（`buildHTTPIdempotencyStore` + `defaultRuntimeOptions`）。HARD 前置三件套（codegen 入口 + 3 凭据路由豁免 + fail-closed 守卫）同 PR 落地，见 §"敏感 body route 豁免（✅ 已收口，gh #1469）"。bootstrap e2e replay + exempt-never-recorded 测试覆盖。

--- a/docs/architecture/202606051000-1449-adr-http-idempotency-assembly-scope-namespace.md
+++ b/docs/architecture/202606051000-1449-adr-http-idempotency-assembly-scope-namespace.md
@@ -22,7 +22,7 @@
 **探索发现（本 ADR 的事实基础）**：full-assembly 的运行时机制其实**已经就绪**——
 
 1. `cmd/corebundle` 用 `_runtime`（非 pod-specific）`KeyNamespace` 构造唯一一个 `HTTPIdempotencyStore`，经 `bootstrap.WithIdempotencyStore` → `b.routerOpts` → `phases_http.go` 的 per-listener 循环 append 给**每个** listener router，故 store 已跨 listener 共享。
-2. `runtime/http/idempotency.buildNamespaceKey` 把身份元组编码为 `ns = tenantID（或 "_notenant"）`、`key = subject \x00 method \x00 path \x00 Idempotency-Key`——**不含 pod / cell / listener / instance 维度**。
+2. `runtime/http/idempotency.DeriveKey` 把身份元组编码为 `ns = tenantID（或 "_notenant"）`、`key = subject \x00 method \x00 path \x00 Idempotency-Key`——**不含 pod / cell / listener / instance 维度**。
 3. `HTTPIdempotencyStore` 仅持 `{rdb cmdable, ns KeyNamespace}`，**无内存回放态**（Claim/Record/Release 全态在 Redis）。
 4. Redis Cluster + 多 pod 拓扑（`loadRedisConfigFromEnv` / `Topology.RequiresDistributedReplay`）已接线；三个 Redis key（resp/lease/fp）已用 hashtag `{<key>}` 做 Cluster slot colocation。
 

--- a/docs/architecture/202606051000-1449-adr-http-idempotency-assembly-scope-namespace.md
+++ b/docs/architecture/202606051000-1449-adr-http-idempotency-assembly-scope-namespace.md
@@ -49,7 +49,7 @@ HTTP 幂等 store 的 owner `KeyNamespace` 定为 `_runtime`，语义是**整个
 | # | 事实 | 载体 |
 |---|------|------|
 | a | 命名空间无 pod 维度（`_runtime` 对所有 pod 相同） | `cmd/corebundle.httpIdempotencyStoreNamespace` |
-| b | 请求 key 无节点身份（pod/cell/listener/instance 不入 key） | `buildNamespaceKey`，由闸 β 守 |
+| b | 请求 key 无节点身份（pod/cell/listener/instance 不入 key） | sealed `IdempotencyKey` / `DeriveKey`，由闸 β 守 |
 | c | store 无内存回放态（全态在 Redis ⟹ 任意 pod 见同一态） | `HTTPIdempotencyStore{rdb,ns}`，由闸 α 守 |
 | d | 所有 pod 共享同一 Redis 后端（多 pod 强制 Redis） | `Topology.RequiresDistributedReplay` + `loadRedisConfigFromEnv` |
 
@@ -76,10 +76,10 @@ a/d 是 wiring/config（留本 ADR + review 守，强行 archtest 化属过度�
 | ID | 不变式 | 载体（範本） | 评级 |
 |----|--------|-------------|------|
 | `HTTP-IDEMPOTENCY-STORE-STATELESS-FROZEN-01`（α） | store 无内存回放态（事实 c） | reflect-freeze `adapters/redis.HTTPIdempotencyStore` 字段元组 `{rdb cmdable, ns KeyNamespace}`（reflect schema freeze） | **Hard** |
-| `HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01`（β） | 请求 key 无节点身份（事实 b） | AST signature-freeze `runtime/http/idempotency.buildNamespaceKey` 形参集 `(*auth.Principal, string, string, string)` + body 自由标识符闭包（仅 `p.{TenantID,Subject}` + 形参 + `noTenantSentinel`，无调用） | **Medium** |
+| `HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01`（β） | 请求 key 无节点身份（事实 b） | sealed typed `IdempotencyKey` 构造器 funnel：reflect 字段冻结 `{ns,key}` 未导出 string + go/types `DeriveKey` 唯一 producer + Unmarshal/Scan ban + `Store.Claim` 形参类型 = `IdempotencyKey`；require-isolation-tuple 由 `DeriveKey` 体 AST taint walk 守 | **node-agnostic：Hard 下游 + Hard 上游-external + Medium 上游-in-package；require-isolation：Medium（#1650）** |
 
 - 两道闸的完整盲区清单 + 反向自检活在 `tools/archtest/http_idempotency_assembly_scope_test.go` 的 package godoc（ai-robust 单源约定）。
-- 闸 β 的 **Hard 升级路径** = 把 key 派生收口成 sealed typed `IdempotencyKey` 构造器 funnel（type-system Hard 上下游），与 cross-cell 工作一并完成，跟踪于 **#1610**。β 维持 Medium 是 Go 在「证明某未来 node-identity 形参的缺席」上的天花板，同 #851/#893/#1282 family。
+- 闸 β 已由 **#1610 funnel slice** 从 Medium AST **升级为 sealed typed `IdempotencyKey` 构造器 funnel**（详见 §Amendment 2026-06-06）。**node-agnostic / ban-external-source 现为 Hard**：下游 = `Store.Claim` 收 `IdempotencyKey`，裸 `(ns,key)` 串在 store 边界编译不可表达；上游-external = `IdempotencyKey{ns,key}` 未导出字段，包外不可 mint key（无法把 node-id 塞入）。**upstream-in-package 维持 Medium**——包内字面量 / 第二 producer 编译器不拦，reflect 字段冻结 + go/types sole-producer 扫描兜底（同 CellLabel / holder-seal #893 的 Hard 下游 + Medium 上游-in-package 分轴）。**require-isolation-tuple 维持 Medium**——Go 无法表达「`DeriveKey` 体消费全部 5 个隔离维度」，且 5 个同型 string 参可在唯一 callsite 转置；`DeriveKey` 体 taint walk 兜底，**won't-do 天花板跟踪 gh #1650**（同 #851/#893/#1282/#1552 family；**非** typestate-builder 可升级——builder 只锁「全部 setter 被调用」，positional 参已给该保证，不锁 body-flow）。cross-cell 同槽（key↔command_id 桥）仍 **out-of-scope，跟踪 #1610**（blocked-by #1044），与本 funnel 正交。
 - 事实 a/d（共享 store / `_runtime` 命名空间 / 多 pod 强制 Redis）= wiring/config，**不立 archtest**：对单个 `_runtime` const 做字符串锁是 Soft（ai-robust 禁立项），强行 Hard 化属过度（违优雅简洁）；由本 ADR + review 守。
 
 三层行为测试（沿用既有 Redis 测试 idiom）：
@@ -103,11 +103,11 @@ ADR-1043 威胁矩阵全部 ✅ 行在 assembly scope 下**不退化**（key 隔
 | 跨 pod 回放越权（A pod 录的响应被 B pod 回放给他人） | key 仍含 `subject + tenant`；跨 pod 共享的是**同一认证主体本人**先前在授权下已执行操作的已录响应，跨主体回放结构上不可能（同 ADR-1043「回放跳过授权再校验」by-design 行）。多 pod 不放宽隔离，只共享去重域 | ✅ (by-design) |
 | 跨 pod 指纹绕过（B pod 用不同 body 劫持 A pod 录的 key） | 指纹 blob 在 Redis（共享底物），任意 pod Claim 同 key 异 fp → `ErrFingerprintMismatch` → 422；A 层集成测试 `CrossPodFingerprintMismatch` 覆盖 | ✅ |
 | Cluster CROSSSLOT（多 KEY EVAL 跨 slot 失败 → 幂等静默失效） | 三键共 hashtag `{<key>}` colocate；B 层单元静态守 + C 层真 cluster 守 | ✅ |
-| 节点身份污染 key（未来改动把 pod/cell id 拼进 key → 破坏跨 pod 去重） | 闸 β（`HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01`）+ 闸 α（无内存态）结构拦截 | ✅ |
+| 节点身份污染 key（未来改动把 pod/cell id 拼进 key → 破坏跨 pod 去重） | 闸 β（sealed `IdempotencyKey`：包外无法 mint key / 无法把 node-id 塞入；`Store.Claim` 收 sealed 类型）+ 闸 α（无内存态）结构拦截；#1610 funnel slice 后 node-agnostic 轴由 Medium AST **升级为 type-system Hard** | ✅（Hard 强化） |
 | 单租户→多租户迁移 namespace 碰撞（`_notenant` 期录的 key 在分配 tenant UUID 后被误回放） | 结构性无碰撞——request-ns 前缀 `_notenant:…` 与任何 `<uuid>:…` 字节不相等，是不同 Redis key；旧 `_notenant` key 在 24h `done` TTL 内自然过期，无需主动清理 | ✅ (结构性) |
 | 日志 `tenant_id` 明文（replay/busy/mismatch 路径 slog 携带 `tenant_id=ns`） | by-design——对齐 outbox observability 规范「actor/subject/tenant opaque 明文」；`tenant_id` 非密钥（opaque UUID 或 `_notenant`），`pkg/redaction.IsSensitiveKey` 刻意不含 `tenant_id`；assembly scope 未改变该日志面 | ✅ (by-design，不变) |
 
-无 ✅ → ⚠️/❌ 退化格子。
+无 ✅ → ⚠️/❌ 退化格子（#1610 funnel slice amendment 仅强化「节点身份污染 key」格 Medium→Hard，无退化）。
 
 ---
 
@@ -128,7 +128,7 @@ ADR-1043 威胁矩阵全部 ✅ 行在 assembly scope 下**不退化**（key 隔
 **Negative / 已知限制**：
 
 - cross-cell（跨 cell 同槽）仍未交付，blocked on #1044 命令桥（#1610）。
-- 闸 β 维持 Medium（AST），Hard 升级（sealed key funnel）延期至 #1610。
+- 闸 β 的 node-agnostic 轴已由 #1610 funnel slice 升级为 sealed `IdempotencyKey` type-system Hard（下游 + 上游-external）；upstream-in-package + require-isolation-tuple 维持 Medium（Go 天花板，won't-do gh #1650）。
 - legacy-form 示例 assembly（todoorder / iotdevice / orderfulfillment）未接通 HTTP 幂等 store（见 §覆盖范围）。**消费者风险**：以这些示例为模板构建自定义 assembly 时，需手动参照 `cmd/corebundle.buildHTTPIdempotencyStore` + `bootstrap.WithIdempotencyStore` 接线，否则幂等中间件**静默 skip**（未注入 store → router 无 store → Middleware 不安装），生产缺去重保护而无报错。
 
 ---
@@ -149,7 +149,7 @@ Change: 治理定调 _runtime=assembly-wide + 两道结构闸 + 三层证明测�
 Gates:
   [x] tools/archtest/http_idempotency_assembly_scope_test.go
       - HTTP-IDEMPOTENCY-STORE-STATELESS-FROZEN-01 (α, reflect freeze, + reverse self-check)
-      - HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 (β, AST freeze, + reverse self-check)
+      - HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 (β, sealed IdempotencyKey funnel: reflect freeze + go/types sole-producer + Store.Claim param + DeriveKey taint walk; + reverse self-checks) [#1610 funnel slice]
 Tests:
   [x] adapters/redis/http_idempotency_cluster_slot_test.go        (B, no tag)
   [x] adapters/redis/http_idempotency_assembly_scope_test.go      (A, //go:build integration)
@@ -166,3 +166,22 @@ Repro:
   go test -tags=integration ./adapters/redis/ -run 'AssemblyScope'   (needs Docker; CI integration job)
 Out-of-scope: cross-cell (idempotency-key ↔ command_id) → #1610 (blocked-by #1044)
 ```
+
+---
+
+## Amendment 2026-06-06 — #1610 funnel slice（闸 β Medium AST → sealed `IdempotencyKey` Hard）
+
+#1610 的核心交付（cross-cell 同槽 = idempotency-key ↔ command_id 桥）被 #1044（Command Bus dispatcher + outbox 桥）**硬阻塞**——`command_id` 在 develop 不存在，无法在 #1610 内造。本次只交付 #1610「彻底」方向中**独立可交付**的一块：把 key 派生收口成 sealed typed `IdempotencyKey` 构造器 funnel（原 §Enforcement 注列为闸 β 的 Hard 升级路径）。**因此本次 PR `Refs #1610`（partial，非 Closes）——cross-cell 核心仍 open，blocked-by #1044。**
+
+**改动**（零 wire 改动；签名内部演化）：
+
+- 新 sealed 类型 `runtime/http/idempotency.IdempotencyKey{ns,key}`（未导出字段）+ 唯一构造器 `DeriveKey(tenantID, subject, method, path, idemKey string)` + 取值器 `Namespace()/Key()`。删 `buildNamespaceKey`（自由函数）。
+- `Store.Claim` 形参 `(ns, key string)` → `(k IdempotencyKey)`；`MemStore` / `adapters/redis.HTTPIdempotencyStore` / middleware callsite / conformance / 单元 + 集成测试同步。
+- `DeriveKey` 改收**扁平 string**（非 `*auth.Principal`）：5 个隔离维度即字面签名，消除原 `*auth.Principal` selector/alias AST 盲区（`Principal.TenantID` 本就是 `string`）。
+- Redis 适配器 brace/空守卫保留（Redis-Cluster hashtag 约束，store-specific，**不**折入 store-agnostic `DeriveKey`）。
+
+**评级重评**（诚实、非 flat Hard）：node-agnostic / ban-external-source = **Hard 下游**（typed `Store.Claim` sink）+ **Hard 上游-external**（未导出字段 sealed construction）+ **Medium 上游-in-package**（reflect 字段冻结 + go/types sole-producer 兜底，同 #893）；require-isolation-tuple = **Medium**（`DeriveKey` 体 taint walk；Go 无法 type-Hard「体消费全部 5 参」+ 同型参可转置；won't-do 天花板 **gh #1650**，非 typestate-builder 可升级）。
+
+**威胁矩阵重评**：「节点身份污染 key」格 Medium→Hard 强化，无 ✅→⚠️/❌ 退化（见 §威胁矩阵）。
+
+**演进缺口**：cross-cell 落地（#1044 桥就绪后）将新增兄弟构造器（如 `DeriveCommandKey`）产出同一 sealed `IdempotencyKey`——funnel 基建是耐久层，届时只需把新构造器加入 β archtest 的 sole-producer allowlist。设计真值源仍为本 ADR + ai-robust 章程；funnel 符号清单 + 完整盲区清单活在 `tools/archtest/http_idempotency_assembly_scope_test.go` package godoc。

--- a/docs/ops/redis-cluster-deployment.md
+++ b/docs/ops/redis-cluster-deployment.md
@@ -112,7 +112,7 @@ It holds because the replay key carries no per-node identity:
   `httpIdempotencyStoreNamespace`), which is **not** pod- or cell-specific.
 - The per-request key is `(tenantID | "_notenant") · subject · method · path ·
   Idempotency-Key` — derived only from request + principal data, never from the
-  serving pod / listener / cell (`runtime/http/idempotency.buildNamespaceKey`).
+  serving pod / listener / cell (`runtime/http/idempotency.DeriveKey`).
 - The `HTTPIdempotencyStore` holds no in-memory replay state — all
   Claim/Record/Release state lives in Redis — so any pod's store instance sees
   the same state.

--- a/runtime/bootstrap/idempotency_e2e_test.go
+++ b/runtime/bootstrap/idempotency_e2e_test.go
@@ -57,10 +57,10 @@ func newIdemSpyStore(clk clock.Clock) *idemSpyStore {
 }
 
 func (s *idemSpyStore) Claim(
-	ctx context.Context, ns, key, fingerprint string, leaseTTL time.Duration,
+	ctx context.Context, k idemhttp.IdempotencyKey, fingerprint string, leaseTTL time.Duration,
 ) (idempotency.ClaimState, *idemhttp.RecordedResponse, idemhttp.Receipt, error) {
-	s.claimKeys = append(s.claimKeys, ns+":"+key)
-	return s.inner.Claim(ctx, ns, key, fingerprint, leaseTTL)
+	s.claimKeys = append(s.claimKeys, k.Namespace()+":"+k.Key())
+	return s.inner.Claim(ctx, k, fingerprint, leaseTTL)
 }
 
 // claimKeyContains returns true if any recorded Claim call's composite key
@@ -88,7 +88,7 @@ var errStoreUnavailable = errors.New("store: simulated outage")
 type idemAlwaysErrorStore struct{}
 
 func (s *idemAlwaysErrorStore) Claim(
-	_ context.Context, _, _, _ string, _ time.Duration,
+	_ context.Context, _ idemhttp.IdempotencyKey, _ string, _ time.Duration,
 ) (idempotency.ClaimState, *idemhttp.RecordedResponse, idemhttp.Receipt, error) {
 	return 0, nil, nil, errStoreUnavailable
 }

--- a/runtime/http/idempotency/idempotencytest/conformance.go
+++ b/runtime/http/idempotency/idempotencytest/conformance.go
@@ -44,12 +44,18 @@ type Factory func(t *testing.T) (store idemhttp.Store, adv TimeAdvancer, cleanup
 
 // Package-level constants extracted per coding-standards duplication rules.
 const (
-	conformNS     = "conf-ns"
-	conformKey    = "conf-key-001"
-	conformAltNS  = "conf-alt-ns"
-	conformAltKey = "conf-alt-key-001"
-	shortLeaseTTL = 50 * time.Millisecond
-	shortDoneTTL  = 50 * time.Millisecond
+	// DeriveKey inputs for the conformance keys (assembled into IdempotencyKey
+	// vars below). The Main/AltNS/AltKey trio is chosen so AltNS differs from Main
+	// ONLY in namespace and AltKey ONLY in key — see conformKeyMain below.
+	conformTenant    = "conf-tenant"
+	conformTenantAlt = "conf-tenant-alt"
+	conformSubject   = "conf-subject"
+	conformMethod    = "POST"
+	conformPath      = "/conf"
+	conformIdem      = "conf-idem-001"
+	conformIdemAlt   = "conf-idem-alt-001"
+	shortLeaseTTL    = 50 * time.Millisecond
+	shortDoneTTL     = 50 * time.Millisecond
 	// conformLeaseTTL is a normal-length lease TTL used in conformance cases
 	// that do not exercise TTL expiry.
 	conformLeaseTTL = 30 * time.Second
@@ -62,6 +68,21 @@ const (
 	conformFP = "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222"
 	// conformFPAlt is a different fingerprint used to trigger mismatch cases.
 	conformFPAlt = "bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222cccc3333"
+)
+
+// conformKeyMain / conformKeyAltNS / conformKeyAltKey are the sealed keys the
+// suite claims, built via the real DeriveKey. There is NO test-only backdoor
+// constructor — package idempotencytest is external to idempotency, so it cannot
+// build an IdempotencyKey literal, and the sole-constructor freeze in
+// HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 forbids adding one (precedent:
+// BuildRecordedResponse routes through the real UnmarshalRecordedResponse). The
+// trio is chosen so DifferentNamespaceKey_AreIndependent still proves
+// independence: AltNS differs from Main ONLY in namespace (different tenant,
+// identical key bytes); AltKey differs ONLY in key (same tenant, different idemKey).
+var (
+	conformKeyMain   = idemhttp.DeriveKey(conformTenant, conformSubject, conformMethod, conformPath, conformIdem)
+	conformKeyAltNS  = idemhttp.DeriveKey(conformTenantAlt, conformSubject, conformMethod, conformPath, conformIdem)
+	conformKeyAltKey = idemhttp.DeriveKey(conformTenant, conformSubject, conformMethod, conformPath, conformIdemAlt)
 )
 
 // RunConformanceSuite runs the full Store conformance suite against the
@@ -104,7 +125,7 @@ func conformFirstClaimAcquired(t *testing.T, factory Factory) {
 	store, _, cleanup := factory(t)
 	defer cleanup()
 
-	state, rec, receipt, err := store.Claim(context.Background(), conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, rec, receipt, err := store.Claim(context.Background(), conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil {
 		t.Fatalf("Claim: unexpected error: %v", err)
 	}
@@ -130,7 +151,7 @@ func conformClaimDoneAfterRecord(t *testing.T, factory Factory) {
 	defer cleanup()
 
 	ctx := context.Background()
-	state, _, receipt, err := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
 	}
@@ -143,7 +164,7 @@ func conformClaimDoneAfterRecord(t *testing.T, factory Factory) {
 	}
 
 	// Second Claim must return ClaimDone with the stored response.
-	state2, rec2, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state2, rec2, _, err2 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("second Claim: unexpected error: %v", err2)
 	}
@@ -176,12 +197,12 @@ func conformClaimBusyWhileLeaseHeld(t *testing.T, factory Factory) {
 	defer cleanup()
 
 	ctx := context.Background()
-	state, _, _, err := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, _, _, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("first Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
 	}
 
-	state2, rec2, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state2, rec2, _, err2 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("second Claim: unexpected error: %v", err2)
 	}
@@ -201,7 +222,7 @@ func conformReleaseAllowsReClaim(t *testing.T, factory Factory) {
 	defer cleanup()
 
 	ctx := context.Background()
-	state, _, receipt, err := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
 	}
@@ -210,7 +231,7 @@ func conformReleaseAllowsReClaim(t *testing.T, factory Factory) {
 		t.Fatalf("Release: %v", err)
 	}
 
-	state2, _, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state2, _, _, err2 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("re-Claim after Release: unexpected error: %v", err2)
 	}
@@ -227,7 +248,7 @@ func conformLeaseTTLExpiry(t *testing.T, factory Factory) {
 	defer cleanup()
 
 	ctx := context.Background()
-	state, _, _, err := store.Claim(ctx, conformNS, conformKey, conformFP, shortLeaseTTL)
+	state, _, _, err := store.Claim(ctx, conformKeyMain, conformFP, shortLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
 	}
@@ -235,7 +256,7 @@ func conformLeaseTTLExpiry(t *testing.T, factory Factory) {
 	// Advance past the lease TTL so it expires.
 	adv.AdvancePast(shortLeaseTTL)
 
-	state2, _, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state2, _, _, err2 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("re-Claim after TTL expiry: unexpected error: %v", err2)
 	}
@@ -255,7 +276,7 @@ func conformStaleTokenRecord(t *testing.T, factory Factory) {
 	ctx := context.Background()
 
 	// Acquire lease A with a short TTL.
-	stateA, _, receiptA, err := store.Claim(ctx, conformNS, conformKey, conformFP, shortLeaseTTL)
+	stateA, _, receiptA, err := store.Claim(ctx, conformKeyMain, conformFP, shortLeaseTTL)
 	if err != nil || stateA != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (A): state=%v err=%v", stateA, err)
 	}
@@ -264,7 +285,7 @@ func conformStaleTokenRecord(t *testing.T, factory Factory) {
 	adv.AdvancePast(shortLeaseTTL)
 
 	// Acquire lease B (new owner).
-	stateB, _, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	stateB, _, _, err2 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err2 != nil || stateB != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (B): state=%v err=%v", stateB, err2)
 	}
@@ -287,13 +308,13 @@ func conformDifferentNsKeyIndependent(t *testing.T, factory Factory) {
 	ctx := context.Background()
 
 	// Claim under ns1.
-	state1, _, _, err1 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state1, _, _, err1 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err1 != nil || state1 != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (ns1): state=%v err=%v", state1, err1)
 	}
 
 	// Claim under ns2 (different namespace, same key) must be independent.
-	state2, _, _, err2 := store.Claim(ctx, conformAltNS, conformKey, conformFP, conformLeaseTTL)
+	state2, _, _, err2 := store.Claim(ctx, conformKeyAltNS, conformFP, conformLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("Claim (ns2): unexpected error: %v", err2)
 	}
@@ -302,7 +323,7 @@ func conformDifferentNsKeyIndependent(t *testing.T, factory Factory) {
 	}
 
 	// Claim under ns1 with a different key must also be independent.
-	state3, _, _, err3 := store.Claim(ctx, conformNS, conformAltKey, conformFP, conformLeaseTTL)
+	state3, _, _, err3 := store.Claim(ctx, conformKeyAltKey, conformFP, conformLeaseTTL)
 	if err3 != nil {
 		t.Fatalf("Claim (ns1, altKey): unexpected error: %v", err3)
 	}
@@ -325,7 +346,7 @@ func conformDoneTTLExpiry(t *testing.T, factory Factory) {
 	ctx := context.Background()
 
 	// Claim and record with a very short done TTL.
-	state, _, receipt, err := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
 	}
@@ -336,7 +357,7 @@ func conformDoneTTLExpiry(t *testing.T, factory Factory) {
 	}
 
 	// Verify it is in ClaimDone state immediately after Record.
-	statePre, recPre, _, errPre := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	statePre, recPre, _, errPre := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if errPre != nil {
 		t.Fatalf("pre-expiry Claim: unexpected error: %v", errPre)
 	}
@@ -351,7 +372,7 @@ func conformDoneTTLExpiry(t *testing.T, factory Factory) {
 	adv.AdvancePast(shortDoneTTL)
 
 	// After expiry the key must be re-claimable as ClaimAcquired.
-	statePost, _, _, errPost := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	statePost, _, _, errPost := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if errPost != nil {
 		t.Fatalf("post-expiry Claim: unexpected error: %v", errPost)
 	}
@@ -375,7 +396,7 @@ func conformStaleTokenRelease(t *testing.T, factory Factory) {
 	ctx := context.Background()
 
 	// Acquire lease A with a short TTL.
-	stateA, _, receiptA, err := store.Claim(ctx, conformNS, conformKey, conformFP, shortLeaseTTL)
+	stateA, _, receiptA, err := store.Claim(ctx, conformKeyMain, conformFP, shortLeaseTTL)
 	if err != nil || stateA != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (A): state=%v err=%v", stateA, err)
 	}
@@ -384,7 +405,7 @@ func conformStaleTokenRelease(t *testing.T, factory Factory) {
 	adv.AdvancePast(shortLeaseTTL)
 
 	// Acquire lease B (new owner, long TTL).
-	stateB, _, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	stateB, _, _, err2 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err2 != nil || stateB != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (B): state=%v err=%v", stateB, err2)
 	}
@@ -395,7 +416,7 @@ func conformStaleTokenRelease(t *testing.T, factory Factory) {
 	_ = receiptA.Release(ctx) // error is tolerated; the key assertion is below.
 
 	// A third Claim must return ClaimBusy because B's lease is still held.
-	stateC, _, _, err3 := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	stateC, _, _, err3 := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err3 != nil {
 		t.Fatalf("third Claim: unexpected error: %v", err3)
 	}
@@ -416,7 +437,7 @@ func conformFingerprintMismatchDone(t *testing.T, factory Factory) {
 	ctx := context.Background()
 
 	// Acquire and record with fingerprint A.
-	state, _, receipt, err := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (fp=A): state=%v err=%v", state, err)
 	}
@@ -426,7 +447,7 @@ func conformFingerprintMismatchDone(t *testing.T, factory Factory) {
 	}
 
 	// Second Claim with a different fingerprint must return ErrFingerprintMismatch.
-	_, _, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFPAlt, conformLeaseTTL)
+	_, _, _, err2 := store.Claim(ctx, conformKeyMain, conformFPAlt, conformLeaseTTL)
 	if err2 == nil {
 		t.Fatal("Claim with mismatched fingerprint (Done state) must return an error, got nil")
 	}
@@ -463,14 +484,14 @@ func conformFingerprintMismatchBusy(t *testing.T, factory Factory) {
 	ctx := context.Background()
 
 	// Acquire lease with fingerprint A (do NOT record — leave busy).
-	state, _, _, err := store.Claim(ctx, conformNS, conformKey, conformFP, conformLeaseTTL)
+	state, _, _, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("Claim (fp=A): state=%v err=%v", state, err)
 	}
 
 	// Second Claim with a different fingerprint must return ErrFingerprintMismatch
 	// (not ClaimBusy).
-	_, _, _, err2 := store.Claim(ctx, conformNS, conformKey, conformFPAlt, conformLeaseTTL)
+	_, _, _, err2 := store.Claim(ctx, conformKeyMain, conformFPAlt, conformLeaseTTL)
 	if err2 == nil {
 		t.Fatal("Claim with mismatched fingerprint (Busy state) must return an error, got nil")
 	}

--- a/runtime/http/idempotency/idempotencytest/conformance.go
+++ b/runtime/http/idempotency/idempotencytest/conformance.go
@@ -99,7 +99,9 @@ func RunConformanceSuite(t *testing.T, factory Factory) {
 		{"ClaimDone_AfterRecord", conformClaimDoneAfterRecord},
 		{"ClaimBusy_WhileLeaseHeld", conformClaimBusyWhileLeaseHeld},
 		{"Release_AllowsReClaim", conformReleaseAllowsReClaim},
+		{"InvalidZeroKey_ReturnsError", conformInvalidZeroKeyReturnsError},
 		{"LeaseTTLExpiry_AllowsReClaim", conformLeaseTTLExpiry},
+		{"LeaseTTLExpiry_DifferentFingerprint_AllowsReClaim", conformLeaseTTLExpiryDifferentFingerprint},
 		{"StaleToken_RecordReturnsError", conformStaleTokenRecord},
 		{"DifferentNamespaceKey_AreIndependent", conformDifferentNsKeyIndependent},
 		{"DoneTTLExpiry_AllowsReClaim", conformDoneTTLExpiry},
@@ -240,6 +242,31 @@ func conformReleaseAllowsReClaim(t *testing.T, factory Factory) {
 	}
 }
 
+// conformInvalidZeroKeyReturnsError verifies that the externally-expressible
+// zero value of the sealed IdempotencyKey fails closed. A populated key cannot
+// be constructed outside package idempotency, but the zero value always can; all
+// Store implementations must reject it consistently instead of collapsing it
+// into a shared empty bucket.
+func conformInvalidZeroKeyReturnsError(t *testing.T, factory Factory) {
+	t.Helper()
+	store, _, cleanup := factory(t)
+	defer cleanup()
+
+	state, rec, receipt, err := store.Claim(context.Background(), idemhttp.IdempotencyKey{}, conformFP, conformLeaseTTL)
+	if err == nil {
+		t.Fatal("Claim with zero IdempotencyKey must fail closed, got nil error")
+	}
+	if state != 0 {
+		t.Errorf("state = %v, want zero on invalid key", state)
+	}
+	if rec != nil {
+		t.Error("recorded response must be nil on invalid key")
+	}
+	if receipt != nil {
+		t.Error("receipt must be nil on invalid key")
+	}
+}
+
 // conformLeaseTTLExpiry verifies that after a short lease TTL expires, the
 // same (ns, key) can be re-claimed as ClaimAcquired.
 func conformLeaseTTLExpiry(t *testing.T, factory Factory) {
@@ -262,6 +289,38 @@ func conformLeaseTTLExpiry(t *testing.T, factory Factory) {
 	}
 	if state2 != idempotency.ClaimAcquired {
 		t.Errorf("re-Claim after TTL expiry: state = %v, want ClaimAcquired (lease should have expired)", state2)
+	}
+}
+
+// conformLeaseTTLExpiryDifferentFingerprint verifies that an unfinished lease
+// does not keep binding the key to its old fingerprint after the lease expires.
+// Once there is no active lease and no recorded response, a retry with the same
+// idempotency key but a different body fingerprint is a fresh acquisition.
+func conformLeaseTTLExpiryDifferentFingerprint(t *testing.T, factory Factory) {
+	t.Helper()
+	store, adv, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	state, _, _, err := store.Claim(ctx, conformKeyMain, conformFP, shortLeaseTTL)
+	if err != nil || state != idempotency.ClaimAcquired {
+		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
+	}
+
+	adv.AdvancePast(shortLeaseTTL)
+
+	state2, rec2, receipt2, err2 := store.Claim(ctx, conformKeyMain, conformFPAlt, conformLeaseTTL)
+	if err2 != nil {
+		t.Fatalf("re-Claim with different fingerprint after TTL expiry: unexpected error: %v", err2)
+	}
+	if state2 != idempotency.ClaimAcquired {
+		t.Errorf("re-Claim with different fingerprint state = %v, want ClaimAcquired", state2)
+	}
+	if rec2 != nil {
+		t.Error("ClaimAcquired after lease expiry must not return a recorded response")
+	}
+	if receipt2 == nil {
+		t.Error("ClaimAcquired after lease expiry must return a receipt")
 	}
 }
 

--- a/runtime/http/idempotency/key.go
+++ b/runtime/http/idempotency/key.go
@@ -45,9 +45,10 @@ type IdempotencyKey struct {
 }
 
 // Namespace returns the idempotency namespace that scopes keys to a tenant (or
-// noTenantSentinel when the principal carries no tenant). A cluster-aware store
-// uses it as the Redis hash-tag so all keys for one tenant colocate on a single
-// slot.
+// noTenantSentinel when the principal carries no tenant). Redis-backed stores
+// use it as the tenant prefix segment outside the hash-tag; the per-request
+// Key() value is the hash-tag payload that colocates lease/response/fingerprint
+// keys on one cluster slot.
 func (k IdempotencyKey) Namespace() string { return k.ns }
 
 // Key returns the per-request key within the namespace.

--- a/runtime/http/idempotency/key.go
+++ b/runtime/http/idempotency/key.go
@@ -1,0 +1,96 @@
+package idempotency
+
+// IdempotencyKey is the sealed (namespace, key) pair that scopes one HTTP
+// idempotency record. Its fields are unexported, so a populated
+// IdempotencyKey{...} literal cannot be constructed outside this package — the
+// ONLY producer is DeriveKey. Stores read it through Namespace()/Key().
+//
+// # Why sealed (the node-agnostic invariant, #1449/#1610)
+//
+// The framework HTTP idempotency replay store is assembly-wide: every pod in an
+// assembly sharing one Redis deduplicates the same logical request. That rests
+// on the (ns,key) carrying NO per-pod / per-listener / per-cell dimension — it
+// is derived ONLY from request + principal data. Sealing the type makes that
+// structural, on two axes (AI-robust grading, frozen by archtest
+// HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01; governance真值源 = ADR
+// docs/architecture/202606051000-1449-adr-http-idempotency-assembly-scope-namespace.md):
+//
+//   - node-agnostic / ban-external-source — Hard, both directions:
+//     upstream-external Hard (unexported fields ⇒ no other package can mint a key
+//     and splice in node-local state — "sealed construction") + downstream Hard
+//     (Store.Claim takes IdempotencyKey, so a raw (ns,key) string pair is
+//     inexpressible at the store boundary). NOTE: upstream is Hard only against
+//     OTHER packages; an in-package populated literal or a second in-package
+//     producer is NOT a compile error — the archtest sole-producer freeze is the
+//     Medium backstop there (same split as metrics.CellLabel / holder-seal #893).
+//   - require-isolation-tuple (DeriveKey's body must FLOW all five dimensions
+//     into the key) — Medium, genuine Go ceiling: Go cannot express "a body
+//     consumes all its inputs", and the five same-type string params could be
+//     transposed at the (single, reviewed) callsite. The β archtest's AST taint
+//     walk is the Medium backstop. Won't-do ceiling tracked at gh #1650 (same
+//     family as #851/#893/#1282/#1552).
+//
+// # Forward compatibility (cross-cell, #1610 / blocked-by #1044)
+//
+// Routing one logical command to a single dedup slot ACROSS cells (the cross-cell
+// half of #1610) needs an Idempotency-Key ↔ command_id bridge that does not yet
+// exist (deferred to #1044's Command Bus). When it lands, a sibling constructor
+// (e.g. DeriveCommandKey) will produce this SAME sealed IdempotencyKey from
+// (tenant, subject, command_id) — the sealed type + Store.Claim funnel are the
+// durable infra and need no change; only the archtest sole-producer allowlist
+// gains the new constructor.
+type IdempotencyKey struct {
+	ns  string
+	key string
+}
+
+// Namespace returns the idempotency namespace that scopes keys to a tenant (or
+// noTenantSentinel when the principal carries no tenant). A cluster-aware store
+// uses it as the Redis hash-tag so all keys for one tenant colocate on a single
+// slot.
+func (k IdempotencyKey) Namespace() string { return k.ns }
+
+// Key returns the per-request key within the namespace.
+func (k IdempotencyKey) Key() string { return k.key }
+
+// noTenantSentinel is the namespace substituted when the authenticated principal
+// carries no tenant (e.g. a service principal: callerCellID is not a tenant).
+const noTenantSentinel = "_notenant"
+
+// DeriveKey is the SOLE constructor of an IdempotencyKey. It encodes the
+// isolation tuple (tenantID, subject, method, path, idemKey) into the
+// (namespace, key) pair stores expect:
+//
+//	ns  = tenantID, or noTenantSentinel when empty.
+//	key = subject + "\x00" + method + "\x00" + path + "\x00" + idemKey
+//
+// Including method+path means the same Idempotency-Key header value is
+// independent per endpoint — POST /orders and POST /payments with the same header
+// are separate records (aligned with Stripe's idempotency design and the IETF
+// idempotency-key draft §3). The NUL (\x00) separator cannot appear in HTTP
+// header values (RFC 7230 §3.2.6 limits field-value to VCHAR/obs-text, excluding
+// NUL), so subject="alic",rest="e:x" never collides with subject="alice",rest="x"
+// — a colon separator would.
+//
+// Assembly-scope (node-agnostic) invariant: the result is derived ONLY from its
+// parameters — there is no pod/listener/cell input and no call that could read
+// node-local state. That is what makes the replay domain assembly-wide. Do NOT
+// add a node/listener/cell parameter (a 6th param is the node-id injection vector
+// the β archtest signature freeze rejects). All five params MUST flow into the
+// result; dropping one silently collapses cross-tenant / cross-user /
+// cross-endpoint isolation (the Medium taint-walk backstop, gh #1650).
+//
+// DeriveKey is error-free: brace/empty rejection for Redis-cluster hash-tags is a
+// store-specific concern handled by the Redis adapter on Claim, NOT folded here
+// (MemStore has no such constraint — over-coupling the store-agnostic key to
+// Redis would be wrong).
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	ns := tenantID
+	if ns == "" {
+		ns = noTenantSentinel
+	}
+	return IdempotencyKey{
+		ns:  ns,
+		key: subject + "\x00" + method + "\x00" + path + "\x00" + idemKey,
+	}
+}

--- a/runtime/http/idempotency/mem_store.go
+++ b/runtime/http/idempotency/mem_store.go
@@ -53,11 +53,11 @@ func NewMemStore(clk clock.Clock) *MemStore {
 }
 
 // Claim implements Store.
-func (ms *MemStore) Claim(ctx context.Context, ns, key, fingerprint string, leaseTTL time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error) { //nolint:lll // Store.Claim signature mirrors the interface; cannot shorten without breaking the interface contract
+func (ms *MemStore) Claim(ctx context.Context, k IdempotencyKey, fingerprint string, leaseTTL time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error) { //nolint:lll // Store.Claim signature mirrors the interface; cannot shorten without breaking the interface contract
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	composed := ns + "\x00" + key
+	composed := k.Namespace() + "\x00" + k.Key()
 	now := ms.clk.Now()
 
 	if e, ok := ms.entries[composed]; ok {

--- a/runtime/http/idempotency/mem_store.go
+++ b/runtime/http/idempotency/mem_store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/idempotency"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // MemStore is an in-process Store implementation backed by a mutex-guarded map.
@@ -54,6 +55,10 @@ func NewMemStore(clk clock.Clock) *MemStore {
 
 // Claim implements Store.
 func (ms *MemStore) Claim(ctx context.Context, k IdempotencyKey, fingerprint string, leaseTTL time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error) { //nolint:lll // Store.Claim signature mirrors the interface; cannot shorten without breaking the interface contract
+	if k.Namespace() == "" || k.Key() == "" {
+		return 0, nil, nil, errcode.Assertion("idempotency.MemStore: IdempotencyKey namespace and key must be non-empty")
+	}
+
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 

--- a/runtime/http/idempotency/mem_store_test.go
+++ b/runtime/http/idempotency/mem_store_test.go
@@ -25,6 +25,14 @@ const (
 	testPastDoneTTL = 2 * time.Hour
 )
 
+// memKey builds an IdempotencyKey directly from an (ns, key) pair for in-package
+// store unit tests that exercise MemStore's own keyspace handling. In-package
+// construction via the unexported fields is permitted — the sealed-construction
+// gate (HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01) is a package-EXTERNAL guarantee
+// (same principle as the RecordedResponse sealed test). External packages
+// (conformance, adapters/redis) must build keys via DeriveKey instead.
+func memKey(ns, key string) IdempotencyKey { return IdempotencyKey{ns: ns, key: key} }
+
 func newTestRecordedResponse(t *testing.T) *RecordedResponse {
 	t.Helper()
 	clk := clockmock.New(time.Now())
@@ -36,7 +44,7 @@ func TestMemStore_FirstClaim_Acquired(t *testing.T) {
 	clk := clockmock.New(time.Now())
 	ms := NewMemStore(clk)
 
-	state, rec, receipt, err := ms.Claim(context.Background(), "tenant1", "user1:idem-key-1", "", idempotency.DefaultLeaseTTL)
+	state, rec, receipt, err := ms.Claim(context.Background(), memKey("tenant1", "user1:idem-key-1"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,7 +64,7 @@ func TestMemStore_RecordThenClaimDone(t *testing.T) {
 	ms := NewMemStore(clk)
 
 	ctx := context.Background()
-	state, _, receipt, err := ms.Claim(ctx, "tenant1", "user1:key2", "", idempotency.DefaultLeaseTTL)
+	state, _, receipt, err := ms.Claim(ctx, memKey("tenant1", "user1:key2"), "", idempotency.DefaultLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("first claim failed: state=%v err=%v", state, err)
 	}
@@ -67,7 +75,7 @@ func TestMemStore_RecordThenClaimDone(t *testing.T) {
 	}
 
 	// Second claim should return ClaimDone with the stored response.
-	state2, rec2, _, err2 := ms.Claim(ctx, "tenant1", "user1:key2", "", idempotency.DefaultLeaseTTL)
+	state2, rec2, _, err2 := ms.Claim(ctx, memKey("tenant1", "user1:key2"), "", idempotency.DefaultLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("second claim error: %v", err2)
 	}
@@ -88,13 +96,13 @@ func TestMemStore_ConcurrentLease_Busy(t *testing.T) {
 
 	ctx := context.Background()
 	// Acquire lease for the key.
-	state, _, _, err := ms.Claim(ctx, "tenant1", "user1:key3", "", idempotency.DefaultLeaseTTL)
+	state, _, _, err := ms.Claim(ctx, memKey("tenant1", "user1:key3"), "", idempotency.DefaultLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
 		t.Fatalf("first claim: %v %v", state, err)
 	}
 
 	// Another claim for the same key should be Busy.
-	state2, _, _, err2 := ms.Claim(ctx, "tenant1", "user1:key3", "", idempotency.DefaultLeaseTTL)
+	state2, _, _, err2 := ms.Claim(ctx, memKey("tenant1", "user1:key3"), "", idempotency.DefaultLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("second claim error: %v", err2)
 	}
@@ -108,7 +116,7 @@ func TestMemStore_Release_Reopens(t *testing.T) {
 	ms := NewMemStore(clk)
 
 	ctx := context.Background()
-	_, _, receipt, err := ms.Claim(ctx, "t1", "u1:key4", "", idempotency.DefaultLeaseTTL)
+	_, _, receipt, err := ms.Claim(ctx, memKey("t1", "u1:key4"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -118,7 +126,7 @@ func TestMemStore_Release_Reopens(t *testing.T) {
 	}
 
 	// After release, the key should be re-claimable.
-	state2, _, _, err2 := ms.Claim(ctx, "t1", "u1:key4", "", idempotency.DefaultLeaseTTL)
+	state2, _, _, err2 := ms.Claim(ctx, memKey("t1", "u1:key4"), "", idempotency.DefaultLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("re-claim error: %v", err2)
 	}
@@ -133,7 +141,7 @@ func TestMemStore_LeaseTTLExpiry(t *testing.T) {
 	ms := NewMemStore(clk)
 
 	ctx := context.Background()
-	_, _, _, err := ms.Claim(ctx, "t1", "u1:key5", "", idempotency.DefaultLeaseTTL)
+	_, _, _, err := ms.Claim(ctx, memKey("t1", "u1:key5"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -142,7 +150,7 @@ func TestMemStore_LeaseTTLExpiry(t *testing.T) {
 	clk.Advance(testPastLeaseTTL)
 
 	// Key should now be re-claimable.
-	state2, _, _, err2 := ms.Claim(ctx, "t1", "u1:key5", "", idempotency.DefaultLeaseTTL)
+	state2, _, _, err2 := ms.Claim(ctx, memKey("t1", "u1:key5"), "", idempotency.DefaultLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("re-claim after expiry: %v", err2)
 	}
@@ -157,7 +165,7 @@ func TestMemStore_DoneTTLExpiry(t *testing.T) {
 	ms := NewMemStore(clk)
 
 	ctx := context.Background()
-	_, _, receipt, err := ms.Claim(ctx, "t1", "u1:key6", "", idempotency.DefaultLeaseTTL)
+	_, _, receipt, err := ms.Claim(ctx, memKey("t1", "u1:key6"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -171,7 +179,7 @@ func TestMemStore_DoneTTLExpiry(t *testing.T) {
 	clk.Advance(testPastDoneTTL)
 
 	// Key should be re-claimable.
-	state2, rec2, _, err2 := ms.Claim(ctx, "t1", "u1:key6", "", idempotency.DefaultLeaseTTL)
+	state2, rec2, _, err2 := ms.Claim(ctx, memKey("t1", "u1:key6"), "", idempotency.DefaultLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("re-claim after done expiry: %v", err2)
 	}
@@ -188,7 +196,7 @@ func TestMemStore_StaleTokenRecordRejected(t *testing.T) {
 	ms := NewMemStore(clk)
 
 	ctx := context.Background()
-	_, _, receipt1, err := ms.Claim(ctx, "t1", "u1:key7", "", idempotency.DefaultLeaseTTL)
+	_, _, receipt1, err := ms.Claim(ctx, memKey("t1", "u1:key7"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
@@ -199,7 +207,7 @@ func TestMemStore_StaleTokenRecordRejected(t *testing.T) {
 	}
 
 	// Re-claim the key (new lease).
-	_, _, _, _ = ms.Claim(ctx, "t1", "u1:key7", "", idempotency.DefaultLeaseTTL)
+	_, _, _, _ = ms.Claim(ctx, memKey("t1", "u1:key7"), "", idempotency.DefaultLeaseTTL)
 
 	// Try to record using the stale receipt from the first claim.
 	resp := newTestRecordedResponse(t)
@@ -217,7 +225,7 @@ func TestMemStore_DoubleReleaseIsNoOp(t *testing.T) {
 	ms := NewMemStore(clk)
 
 	ctx := context.Background()
-	_, _, receipt1, err := ms.Claim(ctx, "t1", "u1:key8", "", idempotency.DefaultLeaseTTL)
+	_, _, receipt1, err := ms.Claim(ctx, memKey("t1", "u1:key8"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
@@ -241,13 +249,13 @@ func TestMemStore_NamespaceIsolation(t *testing.T) {
 
 	ctx := context.Background()
 	// Claim in namespace "t1".
-	_, _, _, err := ms.Claim(ctx, "t1", "u1:key", "", idempotency.DefaultLeaseTTL)
+	_, _, _, err := ms.Claim(ctx, memKey("t1", "u1:key"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("claim ns=t1: %v", err)
 	}
 
 	// Same key in a different namespace must be independent.
-	state2, _, _, err2 := ms.Claim(ctx, "t2", "u1:key", "", idempotency.DefaultLeaseTTL)
+	state2, _, _, err2 := ms.Claim(ctx, memKey("t2", "u1:key"), "", idempotency.DefaultLeaseTTL)
 	if err2 != nil {
 		t.Fatalf("claim ns=t2: %v", err2)
 	}
@@ -268,7 +276,7 @@ func TestMemStore_ConcurrentClaims_OnlyOnceAcquired(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			state, _, _, _ := ms.Claim(ctx, "t1", "u1:concurrent-key", "", idempotency.DefaultLeaseTTL)
+			state, _, _, _ := ms.Claim(ctx, memKey("t1", "u1:concurrent-key"), "", idempotency.DefaultLeaseTTL)
 			results <- state
 		}()
 	}
@@ -294,10 +302,10 @@ func TestMemStore_NonAcquiredReceiptErrors(t *testing.T) {
 
 	ctx := context.Background()
 	// First claim acquires.
-	_, _, _, _ = ms.Claim(ctx, "t1", "u1:key9", "", idempotency.DefaultLeaseTTL)
+	_, _, _, _ = ms.Claim(ctx, memKey("t1", "u1:key9"), "", idempotency.DefaultLeaseTTL)
 
 	// Second claim is Busy — returns a noopReceipt.
-	_, _, busyReceipt, err := ms.Claim(ctx, "t1", "u1:key9", "", idempotency.DefaultLeaseTTL)
+	_, _, busyReceipt, err := ms.Claim(ctx, memKey("t1", "u1:key9"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}

--- a/runtime/http/idempotency/middleware.go
+++ b/runtime/http/idempotency/middleware.go
@@ -27,12 +27,6 @@ import (
 )
 
 const (
-	// noTenantSentinel is the namespace substituted when the authenticated
-	// principal carries no TenantID. Single-tenant deployments and contexts
-	// where tenancy is not yet wired produce an empty TenantID; using a
-	// named sentinel keeps the namespace non-empty and distinguishable.
-	noTenantSentinel = "_notenant"
-
 	// headerIdempotencyKey is the request header carrying the client-chosen key.
 	headerIdempotencyKey = "Idempotency-Key"
 
@@ -401,11 +395,12 @@ func handleWithIdempotency(
 	store Store,
 	cfg middlewareConfig,
 ) {
-	ns, key := buildNamespaceKey(p, r.Method, r.URL.Path, idemKey)
+	k := DeriveKey(p.TenantID, p.Subject, r.Method, r.URL.Path, idemKey)
+	ns := k.Namespace() // for slog correlation + recordOrRelease below
 	ctx := r.Context()
 	keyHash := keyShortHash(idemKey)
 
-	state, rec, receipt, err := store.Claim(ctx, ns, key, fingerprint, cfg.leaseTTL)
+	state, rec, receipt, err := store.Claim(ctx, k, fingerprint, cfg.leaseTTL)
 	if err != nil {
 		if errors.Is(err, ErrFingerprintMismatch) {
 			slog.WarnContext(ctx, "idempotency: fingerprint mismatch — key reused with different body",
@@ -437,7 +432,7 @@ func handleWithIdempotency(
 		// Replay returns this principal's own previously-recorded response WITHOUT
 		// re-running the route Policy. This is by-design and not an authz bypass:
 		// the cache key includes subject+tenant (cross-principal replay is
-		// structurally impossible — see buildNamespaceKey), and the recorded
+		// structurally impossible — see DeriveKey), and the recorded
 		// response is from an operation this same principal already performed while
 		// authorized. Re-checking authz on replay would let a previously-succeeded
 		// key later return 403, violating Idempotency-Key semantics (same key →
@@ -482,45 +477,6 @@ func extractIdentity(ctx context.Context) (*auth.Principal, bool) {
 		return nil, false
 	}
 	return p, true
-}
-
-// buildNamespaceKey encodes the isolation tuple (tenantID, method, path, subject, idemKey)
-// into the (ns, key) pair expected by Store.Claim.
-//
-// ns  = tenantID, or noTenantSentinel when empty.
-// key = subject + "\x00" + method + "\x00" + path + "\x00" + idemKey
-//
-// Including method+path in the key means the same Idempotency-Key header value
-// is independent per endpoint — e.g. POST /orders and POST /payments with the
-// same header value are stored as separate idempotency records. This is aligned
-// with Stripe's idempotency design and IETF idempotency-key draft §3.
-//
-// The NUL byte (\x00) separator prevents key-space collision: it cannot appear
-// in HTTP header values (RFC 7230 §3.2.6 limits field-value to VCHAR and obs-text,
-// neither of which includes NUL), so subject="alic",key="e:x" is always distinct
-// from subject="alice",key="x". A colon separator (:) would collide on those inputs.
-//
-// Using tenantID as the namespace means the Redis key for a cluster-aware
-// adapter would be "{<tenantID>}:<subject>\x00<method>\x00<path>\x00<idemKey>",
-// which colocates all keys for the same tenant on the same hash slot — good for
-// single-slot transactions.
-//
-// Assembly-scope (node-agnostic) invariant: the (ns, key) pair is derived ONLY
-// from request + principal data — it carries no pod / listener / cell / instance
-// dimension. That is what makes the framework idempotency replay domain
-// assembly-wide (every pod sharing one Redis deduplicates the same logical
-// request). This is frozen by archtest HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 and
-// governed by ADR docs/architecture/202606051000-1449-adr-http-idempotency-assembly-scope-namespace.md.
-// Do not add a node/listener/cell parameter here — that would make the key
-// node-specific and break assembly-wide dedup. (Routing one logical command to a
-// single dedup slot across cells is the deferred cross-cell concern, #1610.)
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = p.TenantID
-	if ns == "" {
-		ns = noTenantSentinel
-	}
-	key = p.Subject + "\x00" + method + "\x00" + path + "\x00" + idemKey
-	return
 }
 
 // replayResponse writes the stored RecordedResponse to w with the

--- a/runtime/http/idempotency/middleware.go
+++ b/runtime/http/idempotency/middleware.go
@@ -265,8 +265,9 @@ func (c middlewareConfig) observeState(ctx context.Context, state RequestState) 
 // If either is absent, or if the Principal is not a user principal, the
 // request passes through without idempotency tracking.
 //
-// Key composition: ns = tenantID (or "_notenant" when empty),
-// key = method + "\x00" + path + "\x00" + subject + "\x00" + Idempotency-Key header value.
+// Key composition (namespace, key) is derived by DeriveKey (key.go) from
+// (tenantID, subject, method, path, idemKey); see it for the exact byte layout,
+// NUL-separator rationale, and node-agnostic invariant.
 // Including method+path in the key means the same client-supplied header value
 // is independent per endpoint — a key for POST /orders does NOT collide with
 // POST /payments. (Stripe / IETF idempotency-key draft §3 aligned.)
@@ -459,7 +460,7 @@ func handleWithIdempotency(
 
 	default: // ClaimAcquired
 		cfg.observeState(ctx, StateAcquired)
-		recordOrRelease(ctx, w, r, next, clk, receipt, cfg, keyHash, ns)
+		recordOrRelease(ctx, w, r, next, clk, receipt, cfg, keyHash, ns, p.Subject)
 	}
 }
 
@@ -510,6 +511,7 @@ func recordOrRelease(
 	cfg middlewareConfig,
 	keyHash string,
 	ns string,
+	subject string,
 ) {
 	bw := newBufferingWriter(w, cfg.maxBodyBytes)
 
@@ -523,6 +525,7 @@ func recordOrRelease(
 				slog.WarnContext(ctx, "idempotency: lease release failed (will expire via TTL)",
 					"err", err,
 					"idempotency_key_hash", keyHash,
+					"subject", subject,
 					"tenant_id", ns,
 				)
 			}
@@ -540,6 +543,7 @@ func recordOrRelease(
 			slog.ErrorContext(ctx, "idempotency: receipt record failed",
 				"err", err,
 				"idempotency_key_hash", keyHash,
+				"subject", subject,
 				"tenant_id", ns,
 			)
 			// Fall through to Release via defer.
@@ -550,6 +554,7 @@ func recordOrRelease(
 		slog.WarnContext(ctx, "idempotency: response body oversized, not recorded",
 			"max_body_bytes", cfg.maxBodyBytes,
 			"idempotency_key_hash", keyHash,
+			"subject", subject,
 			"tenant_id", ns,
 		)
 		cfg.observeState(ctx, StateOversize)

--- a/runtime/http/idempotency/middleware_test.go
+++ b/runtime/http/idempotency/middleware_test.go
@@ -203,7 +203,7 @@ func TestMiddleware_409WhenLeaseInProgress(t *testing.T) {
 	ctx := context.Background()
 	// Pre-seed a lease directly via MemStore to simulate in-flight request.
 	// Key composed by Middleware: subject + "\x00" + method + "\x00" + path + "\x00" + idemKey.
-	_, _, _, err := ms.Claim(ctx, "tenant1", "user-b\x00POST\x00/\x00in-flight", "", idempotency.DefaultLeaseTTL)
+	_, _, _, err := ms.Claim(ctx, memKey("tenant1", "user-b\x00POST\x00/\x00in-flight"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("pre-seed claim: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestMiddleware_409WhenLeaseInProgress(t *testing.T) {
 // failingStore always returns an error from Claim.
 type failingStore struct{}
 
-func (failingStore) Claim(_ context.Context, _, _, _ string, _ time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error) {
+func (failingStore) Claim(_ context.Context, _ IdempotencyKey, _ string, _ time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error) { //nolint:lll // Store.Claim signature mirrors the interface; cannot shorten without breaking the interface contract
 	return idempotency.ClaimAcquired, nil, nil, errors.New("store unavailable")
 }
 
@@ -642,7 +642,7 @@ func TestMiddleware_RetryAfterReflectsLeaseTTL(t *testing.T) {
 	ctx := context.Background()
 	// Pre-seed a lease with the custom TTL to simulate in-flight request.
 	// Key composed by Middleware: subject + "\x00" + method + "\x00" + path + "\x00" + idemKey.
-	_, _, _, err := ms.Claim(ctx, "tenant1", "user-m\x00POST\x00/\x00retry-after-key", "", testLeaseTTL2m)
+	_, _, _, err := ms.Claim(ctx, memKey("tenant1", "user-m\x00POST\x00/\x00retry-after-key"), "", testLeaseTTL2m)
 	if err != nil {
 		t.Fatalf("pre-seed claim: %v", err)
 	}
@@ -921,7 +921,7 @@ func TestMiddleware_Metrics_Busy(t *testing.T) {
 
 	ctx := context.Background()
 	// Pre-seed a lease to simulate in-flight request.
-	_, _, _, err := ms.Claim(ctx, "t1", "user-busy\x00POST\x00/\x00key-busy", "", idempotency.DefaultLeaseTTL)
+	_, _, _, err := ms.Claim(ctx, memKey("t1", "user-busy\x00POST\x00/\x00key-busy"), "", idempotency.DefaultLeaseTTL)
 	if err != nil {
 		t.Fatalf("pre-seed claim: %v", err)
 	}
@@ -995,7 +995,7 @@ func TestMiddleware_Metrics_Oversize(t *testing.T) {
 type fingerprintMismatchStore struct{}
 
 func (fingerprintMismatchStore) Claim(
-	_ context.Context, _, _, _ string, _ time.Duration,
+	_ context.Context, _ IdempotencyKey, _ string, _ time.Duration,
 ) (idempotency.ClaimState, *RecordedResponse, Receipt, error) {
 	// Return the typed error wrapping the sentinel, matching the Store contract
 	// (Implementations MUST return a *FingerprintMismatchError). Stored is empty
@@ -1476,26 +1476,23 @@ func TestMiddleware_ExemptMatcher_ShortCircuitsBeforeBodyRead(t *testing.T) {
 	}
 }
 
-// TestBuildNamespaceKey_IsolationMatrix is the behavioral proof of the isolation
-// contract that the archtest HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 freezes
-// structurally: every isolation dimension (tenant, subject, method, path,
-// idemKey) must change the derived (ns, key) so two distinct logical requests
-// never share one replay record, while identical inputs reproduce the same pair
-// (assembly-wide cross-pod dedup). The archtest proves the derivation cannot
-// drop a dimension; this proves the current derivation actually separates them.
-func TestBuildNamespaceKey_IsolationMatrix(t *testing.T) {
-	user := func(tenant, subject string) *auth.Principal {
-		return &auth.Principal{Kind: auth.PrincipalUser, TenantID: tenant, Subject: subject}
-	}
+// TestDeriveKey_IsolationMatrix proves DeriveKey actually separates every
+// isolation dimension: identical inputs reproduce the (ns,key) pair (cross-pod
+// dedup), and changing any one dimension changes the pair. A regression that
+// dropped a dimension would collapse one of these; this matrix proves it does not.
+func TestDeriveKey_IsolationMatrix(t *testing.T) {
 	const (
 		tenant = "11111111-1111-1111-1111-111111111111"
 		other  = "22222222-2222-2222-2222-222222222222"
 	)
-	base := user(tenant, "alice")
-	baseNS, baseKey := buildNamespaceKey(base, "POST", "/api/v1/orders", "idem-1")
+	derive := func(tenantID, subject, method, path, idemKey string) (ns, key string) {
+		k := DeriveKey(tenantID, subject, method, path, idemKey)
+		return k.Namespace(), k.Key()
+	}
+	baseNS, baseKey := derive(tenant, "alice", "POST", "/api/v1/orders", "idem-1")
 
 	t.Run("deterministic — identical inputs reproduce the pair (cross-pod dedup)", func(t *testing.T) {
-		ns, key := buildNamespaceKey(user(tenant, "alice"), "POST", "/api/v1/orders", "idem-1")
+		ns, key := derive(tenant, "alice", "POST", "/api/v1/orders", "idem-1")
 		if ns != baseNS || key != baseKey {
 			t.Errorf("identical inputs must yield identical (ns,key): got (%q,%q) want (%q,%q)", ns, key, baseNS, baseKey)
 		}
@@ -1504,21 +1501,23 @@ func TestBuildNamespaceKey_IsolationMatrix(t *testing.T) {
 	// Each dimension, changed in isolation, must alter (ns,key).
 	cases := []struct {
 		name      string
-		p         *auth.Principal
+		tenantID  string
+		subject   string
 		method    string
 		path      string
 		idemKey   string
 		wantNSneq bool // tenant change moves the namespace; the others move the key
 	}{
-		{"tenant", user(other, "alice"), "POST", "/api/v1/orders", "idem-1", true},
-		{"subject", user(tenant, "bob"), "POST", "/api/v1/orders", "idem-1", false},
-		{"method", base, "PUT", "/api/v1/orders", "idem-1", false},
-		{"path", base, "POST", "/api/v1/payments", "idem-1", false},
-		{"idemKey", base, "POST", "/api/v1/orders", "idem-2", false},
+		{"tenant", other, "alice", "POST", "/api/v1/orders", "idem-1", true},
+		{"subject", tenant, "bob", "POST", "/api/v1/orders", "idem-1", false},
+		{"method", tenant, "alice", "PUT", "/api/v1/orders", "idem-1", false},
+		{"path", tenant, "alice", "POST", "/api/v1/payments", "idem-1", false},
+		{"idemKey", tenant, "alice", "POST", "/api/v1/orders", "idem-2", false},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run("isolated by "+tc.name, func(t *testing.T) {
-			ns, key := buildNamespaceKey(tc.p, tc.method, tc.path, tc.idemKey)
+			ns, key := derive(tc.tenantID, tc.subject, tc.method, tc.path, tc.idemKey)
 			if ns == baseNS && key == baseKey {
 				t.Errorf("changing %s must change (ns,key); both still %q/%q — isolation collapsed", tc.name, ns, key)
 			}
@@ -1529,7 +1528,7 @@ func TestBuildNamespaceKey_IsolationMatrix(t *testing.T) {
 	}
 
 	t.Run("empty tenant maps to the _notenant sentinel", func(t *testing.T) {
-		ns, _ := buildNamespaceKey(user("", "alice"), "POST", "/api/v1/orders", "idem-1")
+		ns, _ := derive("", "alice", "POST", "/api/v1/orders", "idem-1")
 		if ns != noTenantSentinel {
 			t.Errorf("empty tenant must map to %q sentinel; got %q", noTenantSentinel, ns)
 		}

--- a/runtime/http/idempotency/store.go
+++ b/runtime/http/idempotency/store.go
@@ -105,15 +105,17 @@ func FrameworkStatuses() []int {
 // return a *FingerprintMismatchError (which wraps the sentinel) so the middleware
 // can recover the stored fingerprint blob for the per-field diff.
 //
-// ns is the idempotency namespace that scopes keys to a part of the
-// application. In the standard Middleware, ns is the caller TenantID (or
-// "_notenant" when absent). key is method+"\x00"+path+"\x00"+subject+"\x00"+
-// Idempotency-Key header value. fingerprint is the opaque canonical blob produced
-// by computeFingerprint (JSON whose Body field is hex(sha256(rawBody)) and whose
+// k is the sealed (namespace, key) pair produced by DeriveKey from the request +
+// principal isolation tuple; the Store reads it via k.Namespace() (the tenant
+// scope, or "_notenant" when absent) and k.Key() (the per-request key — see
+// DeriveKey for the byte layout). A raw (ns,key) string pair cannot reach Claim —
+// that typed boundary is the downstream Hard gate of the node-agnostic invariant
+// (#1449/#1610). fingerprint is the opaque canonical blob produced by
+// computeFingerprint (JSON whose Body field is hex(sha256(rawBody)) and whose
 // Fields field maps top-level field names to per-field hashes for the diff); the
 // Store treats it as an opaque string and only compares / round-trips it.
 type Store interface {
-	Claim(ctx context.Context, ns, key, fingerprint string, leaseTTL time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error)
+	Claim(ctx context.Context, k IdempotencyKey, fingerprint string, leaseTTL time.Duration) (idempotency.ClaimState, *RecordedResponse, Receipt, error) //nolint:lll // full Claim contract signature cannot be wrapped in an interface decl
 }
 
 // Receipt is the HTTP-specific lifecycle handle for a single acquired

--- a/tools/archtest/http_idempotency_assembly_scope_test.go
+++ b/tools/archtest/http_idempotency_assembly_scope_test.go
@@ -1,7 +1,8 @@
 package archtest
 
 // http_idempotency_assembly_scope_test.go — structural gates for the
-// full-assembly HTTP idempotency scope governance decision (#1449).
+// full-assembly HTTP idempotency scope governance decision (#1449), with the
+// β gate upgraded to the sealed typed IdempotencyKey funnel (#1610 funnel slice).
 //
 //   - INVARIANT: HTTP-IDEMPOTENCY-STORE-STATELESS-FROZEN-01
 //   - INVARIANT: HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01
@@ -23,24 +24,15 @@ package archtest
 //     {rdb cmdable, ns KeyNamespace}. An added in-memory cache field would break
 //     the "any pod sees the same state" guarantee and is caught here.
 //
-//   - β HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01: the request key derivation
-//     runtime/http/idempotency.buildNamespaceKey takes ONLY
-//     (*auth.Principal, method, path, idemKey) and derives the (ns,key) pair
-//     purely from those — it has no pod/listener/cell input and makes no calls
-//     that could read node-local state. This gate is two-directional:
-//       · ban-external-source (checkBuildNamespaceKeyBody): a pod/listener/cell
-//         parameter, or a call to a node-identity source (os.Hostname, getenv, a
-//         provider), would make the key node-specific and break assembly-wide
-//         dedup — caught. ("nothing node-local may enter the key.")
-//       · require-isolation-tuple (checkBuildNamespaceKeyRequiredUse): every
-//         sanctioned isolation dimension — p.TenantID, p.Subject, and the
-//         method/path/idemKey params — MUST be consumed into (ns,key). Dropping
-//         one (e.g. hard-coding ns to a literal, or omitting method) would still
-//         satisfy ban-external-source yet silently collapse cross-tenant,
-//         cross-subject, or cross-endpoint isolation — caught. ("every isolation
-//         dimension must enter the key.")
-//     Together they pin the key to EXACTLY the isolation tuple — no less (the
-//     security property) and no more node-local (the assembly-scope property).
+//   - β HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01: the request key is a SEALED typed
+//     runtime/http/idempotency.IdempotencyKey, minted only by DeriveKey from the
+//     isolation tuple (tenantID, subject, method, path, idemKey). Sealing makes
+//     the node-agnostic property structural on two directions: no OTHER package
+//     can mint a key and splice in a pod/listener/cell id (sealed construction),
+//     and Store.Claim takes IdempotencyKey (not raw strings) so a hand-built
+//     (ns,key) pair is inexpressible at the store boundary. The require-isolation-
+//     tuple half (every dimension must FLOW into the key) stays an AST taint walk
+//     on DeriveKey (Go cannot make body-flow type-Hard).
 //
 // The A-layer cross-pod integration test
 // (adapters/redis/http_idempotency_assembly_scope_test.go) is the behavioral
@@ -50,60 +42,61 @@ package archtest
 // identical regardless of serving node. The behavioral test + these two
 // structural gates together make the full-assembly claim airtight.
 //
-// # AI-robust rating (.claude/rules/gocell/ai-robust.md)
+// # AI-robust rating (.claude/rules/gocell/ai-robust.md) — honest, NOT flat Hard
 //
 //   - α: Hard — reflect schema freeze (field count + per-field name/type/exported
 //     tuple). A field-set drift is inexpressible without a CI-visible failure.
 //     Sibling范本: PEER-IDENTITY-FIELDS-FROZEN-01 / MODULE-PROVIDE-NO-VALUE-HANDOFF-01.
-//   - β: Medium — AST signature + body form-lock (no string anchor; the param
-//     type list, the body's reference set, AND the isolation taint-flow are pinned).
-//     Both halves (ban-external-source + require-isolation-tuple) are the same
-//     Medium AST tier: Go cannot make the ABSENCE of a future node-identity
-//     parameter, nor the FLOW of every isolation input into (ns,key), type-system-Hard.
-//     The Hard upgrade path for BOTH is a single sealed typed IdempotencyKey
-//     constructor funnel (Option C in the #1449 plan, deliberately out of scope
-//     for this PR) — derived once from (tenant, subject, method, path, idemKey)
-//     so neither a dropped dimension nor an injected node-id is expressible —
-//     tracked as the cross-cell follow-up issue #1610. Same ceiling family as
-//     #851/#893/#1282.
+//   - β node-agnostic / ban-external-source — 3-axis split (sealed construction
+//     范本; same shape as CellLabel / holder-seal #893, NOT flat Hard):
+//       · downstream Hard: Store.Claim takes IdempotencyKey, so a raw (ns,key)
+//         string pair is inexpressible at the boundary (type system).
+//       · upstream-external Hard: IdempotencyKey{ns,key} fields are unexported ⇒
+//         no OTHER package can mint a key.
+//       · upstream-in-package Medium: the compiler does NOT stop an in-package
+//         populated literal or a 2nd in-package producer; the prong-1 reflect
+//         field freeze + go/types sole-producer scan are the only backstop there.
+//   - β require-isolation-tuple — Medium, genuine Go ceiling (gh #1650): Go
+//     cannot express "DeriveKey's body consumes all five params into the key",
+//     and the five same-type string params could be transposed at the (single,
+//     reviewed) callsite. The AST taint walk on DeriveKey is the Medium backstop.
+//     Same ceiling family as #851/#893/#1282/#1552. NOT typestate-upgradeable
+//     (a builder enforces presence-of-setters, which positional params already
+//     give; it does not make body-flow Hard).
 //
 // # Blind spots + reverse self-checks (ai-robust mandate)
 //
 //   - α reflect freeze blind spots (embedding / alias re-shape / wrong type /
 //     unexported drift) are each covered by checkHTTPIdemStoreShape and proven
 //     non-vacuous by TestHTTPIdempotencyStoreStatelessFrozen01_ReverseBlindSpot.
-//   - β AST freeze blind spots: (1) adding a node-identity PARAM → caught by the
-//     param-type freeze; (2) referencing a package-level node-identity source or
-//     calling os/net/runtime → caught by the body free-reference + no-call check;
-//     (3) leaking extra principal fields into the key → caught by the
-//     selector-allowlist {TenantID,Subject}; (4) a chained selector like
-//     provider.Node.ID (whose selector base x.X is itself a SelectorExpr, not the
-//     principal Ident) → caught by the "non-principal source" branch; (5) dropping
-//     an isolation dimension — hard-coding ns to a literal (drops p.TenantID),
-//     omitting p.Subject (cross-user replay), or never putting method/path/idemKey
-//     into the key (cross-endpoint collision), INCLUDING a dummy read like
-//     `_ = method` that references the input but never flows it into the key →
-//     caught by checkBuildNamespaceKeyRequiredUse, which taint-tracks each of
-//     {p.TenantID, p.Subject, method, path, idemKey} from its source to the
-//     ns/key result sink (not mere presence). Non-vacuity proven by
-//     TestHTTPIdempotencyKeyNodeAgnostic01_ReverseBlindSpot against inline
-//     malformed source (chained-selector + one missing-dimension fixture per
-//     isolation field + a dummy-read-bypass fixture). Residual (NOT caught,
-//     documented): a *type alias* of auth.Principal used as `*P` makes param[0] an
-//     *ast.Ident rather than *ast.SelectorExpr, so isPrincipalPtr returns false and
-//     the param-type freeze rejects it as "not *auth.Principal" — i.e. a false
-//     positive that forces review, not a bypass. The Hard form (sealed key
-//     constructor, #1610) removes the AST-shape dependency entirely.
-//     Known tightness (documented, intentional): the body must
-//     be call-free, so a future benign refactor introducing any call (even
-//     strings.Join) trips the gate — that is the deliberate review checkpoint for
-//     changes to key derivation, not a defect.
+//   - β prong-1 reflect freeze blind spots (extra field / exported field / rename
+//     / wrong type / embedding) → checkIdempotencyKeyShape; deserialization
+//     backdoor (UnmarshalJSON/Text/Binary/Scan — they return error, NOT
+//     IdempotencyKey, so a returns-IdempotencyKey scan never catches them, #1488
+//     F4 lesson) + builder laundering (a method returning IdempotencyKey) →
+//     checkIdempotencyKeyMethods. Both proven non-vacuous by the
+//     ReverseBlindSpot test (synthetic reflect shapes + a package-level
+//     method-bearing fixture, since Go forbids method decls inside a func).
+//   - β prong-1b/2 go/types blind spots: a 2nd package-level producer (func or
+//     function-typed var) → sole-producer diff; reverting Store.Claim to raw
+//     strings → param-type freeze; both fail loud via the visited-guard if the
+//     package path moves.
+//   - β prong-3 taint walk blind spots: a 6th DeriveKey param (node-id vector) →
+//     signature freeze; dropping any isolation dimension from the body, INCLUDING
+//     a dummy read `_ = method` that references the input but never flows it into
+//     the key → checkDeriveKeyRequiredUse (taint flow, not presence). Proven
+//     non-vacuous by inline malformed DeriveKey fixtures. Note: flat-string params
+//     remove the old *auth.Principal selector/alias blind spots entirely (no more
+//     extra-principal-field / chained-selector / type-alias residual). Known
+//     tightness: a construction form other than `return IdempotencyKey{ns:…,key:…}`
+//     trips the taint sink lookup — a deliberate review checkpoint, not a defect.
 
 import (
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -111,6 +104,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	adapterredis "github.com/ghbvf/gocell/adapters/redis"
+	"github.com/ghbvf/gocell/runtime/http/idempotency"
 )
 
 // ---------------------------------------------------------------------------
@@ -242,292 +236,355 @@ func TestHTTPIdempotencyStoreStatelessFrozen01_ReverseBlindSpot(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// β — HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 (AST signature + body freeze)
+// β — HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01 (sealed IdempotencyKey funnel)
 // ---------------------------------------------------------------------------
 
 const ruleHTTPIdemKeyNodeAgnostic01 = "HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01"
 
-// buildNamespaceKeyFnName is the frozen key-derivation function in
-// runtime/http/idempotency/middleware.go.
-const buildNamespaceKeyFnName = "buildNamespaceKey"
+const (
+	idempotencyKeyTypeName = "IdempotencyKey"
+	deriveKeyFnName        = "DeriveKey"
+	deriveKeyFile          = "key.go"
+	storeIfaceName         = "Store"
+	storeClaimMethodName   = "Claim"
+)
 
-// principalSelectorAllowlist is the set of *auth.Principal fields the key
-// derivation may read. Only tenant + subject identity may flow into the key;
-// nothing node-local exists on Principal, and adding any other selector here
-// would be a deliberate, reviewed change.
-var principalSelectorAllowlist = map[string]struct{}{"TenantID": {}, "Subject": {}}
+// deriveKeyProducerAllowed is the exhaustive set of exported package-level
+// surfaces in runtime/http/idempotency that may PRODUCE an IdempotencyKey value.
+// DeriveKey is the sole constructor; a second producer (FromStrings / a
+// function-typed var / an Unmarshal) would launder an arbitrary (ns,key) —
+// possibly carrying a node id — into a sealed key, defeating the seal. (A future
+// cross-cell DeriveCommandKey, #1610, would be added here in the same PR.)
+var deriveKeyProducerAllowed = map[string]struct{}{deriveKeyFnName: {}}
 
-// TestHTTPIdempotencyKeyNodeAgnostic01 freezes buildNamespaceKey's signature and
-// body so the idempotency key carries no per-node/listener/cell identity.
-func TestHTTPIdempotencyKeyNodeAgnostic01(t *testing.T) {
+// idempotencyKeyForbiddenMethods are deserialization entries that would let an
+// external package populate a sealed IdempotencyKey from bytes, bypassing
+// DeriveKey. They return error (not IdempotencyKey), so a returns-IdempotencyKey
+// scan never catches them — they are banned by name (#1488 F4 lesson).
+var idempotencyKeyForbiddenMethods = map[string]bool{
+	"UnmarshalJSON":   true,
+	"UnmarshalText":   true,
+	"UnmarshalBinary": true,
+	"Scan":            true,
+}
+
+// checkIdempotencyKeyShape freezes the IdempotencyKey field set to exactly two
+// unexported string fields {ns,key}. Pure so the reverse self-check can feed it
+// synthetic malformed shapes (mirrors the α detector).
+func checkIdempotencyKeyShape(dt reflect.Type) []string {
+	if dt.Kind() != reflect.Struct {
+		return []string{fmt.Sprintf("Kind = %s, want struct (sealed construction)", dt.Kind())}
+	}
+	want := map[string]struct{}{"ns": {}, "key": {}}
+	var v []string
+	if dt.NumField() != len(want) {
+		v = append(v, fmt.Sprintf(
+			"NumField = %d, want exactly %d ({ns,key}). An extra field (e.g. a pod/listener id) could "+
+				"ride node-local state into the key.", dt.NumField(), len(want)))
+	}
+	for i := 0; i < dt.NumField(); i++ {
+		f := dt.Field(i)
+		if f.Anonymous {
+			v = append(v, fmt.Sprintf("field %q is embedded (embedding can re-open external construction)", f.Name))
+			continue
+		}
+		if f.IsExported() {
+			v = append(v, fmt.Sprintf(
+				"field %q is EXPORTED — an exported field lets any package build a populated "+
+					"IdempotencyKey{...} literal and splice in a node id, breaking sealed construction.", f.Name))
+		}
+		if _, ok := want[f.Name]; !ok {
+			v = append(v, fmt.Sprintf("unexpected field %q (%s) — the frozen set is {ns,key}", f.Name, f.Type))
+			continue
+		}
+		if f.Type.Kind() != reflect.String {
+			v = append(v, fmt.Sprintf("field %q type = %s, want string", f.Name, f.Type))
+		}
+	}
+	return v
+}
+
+// checkIdempotencyKeyMethods bans deserialization backdoors and builder
+// laundering on IdempotencyKey. Pure so the reverse self-check can feed it a
+// synthetic method-bearing type (Go forbids method decls inside a func, so the
+// reverse fixture is a package-level type).
+func checkIdempotencyKeyMethods(dt reflect.Type) []string {
+	var v []string
+	pt := reflect.PointerTo(dt)
+	for i := 0; i < pt.NumMethod(); i++ {
+		m := pt.Method(i)
+		if idempotencyKeyForbiddenMethods[m.Name] {
+			v = append(v, fmt.Sprintf(
+				"%s must not declare %q — a deserialization entry lets an external package build a key "+
+					"from bytes, bypassing the sole constructor DeriveKey.", idempotencyKeyTypeName, m.Name))
+			continue
+		}
+		mt := m.Func.Type() // receiver is in[0]; method results are the outs
+		for o := 0; o < mt.NumOut(); o++ {
+			if mt.Out(o) == dt {
+				v = append(v, fmt.Sprintf(
+					"%s method %q returns a new %s (builder laundering) — DeriveKey is the sole constructor.",
+					idempotencyKeyTypeName, m.Name, idempotencyKeyTypeName))
+			}
+		}
+	}
+	return v
+}
+
+// TestHTTPIdempotencyKeyNodeAgnostic01_KeySealed freezes the sealed IdempotencyKey
+// type: exactly two unexported string fields and no deserialization/builder
+// backdoor. This is the upstream-external Hard gate of the node-agnostic
+// invariant — no other package can mint a key, so none can splice a node id in.
+func TestHTTPIdempotencyKeyNodeAgnostic01_KeySealed(t *testing.T) {
+	t.Parallel()
+	dt := reflect.TypeOf(idempotency.IdempotencyKey{})
+	violations := append(checkIdempotencyKeyShape(dt), checkIdempotencyKeyMethods(dt)...)
+	for _, vio := range violations {
+		t.Errorf("%s (key sealed): %s. If a key-shape change is intentional, update ADR "+
+			"202606051000-1449 + this freeze in the same PR.", ruleHTTPIdemKeyNodeAgnostic01, vio)
+	}
+}
+
+// TestHTTPIdempotencyKeyNodeAgnostic01_SoleProducerAndSink pins, via go/types,
+// (1) DeriveKey as the SOLE exported package-level producer of an IdempotencyKey
+// value (a second producer would launder an arbitrary key), and (2) Store.Claim's
+// post-ctx parameter as IdempotencyKey (the downstream Hard sink — a raw (ns,key)
+// string pair is inexpressible at the boundary).
+func TestHTTPIdempotencyKeyNodeAgnostic01_SoleProducerAndSink(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	visited := false
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{"./runtime/http/idempotency/..."}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != httpIdempotencyPkgPath {
+				return nil
+			}
+			visited = true
+			scope := p.Pkg.Scope()
+
+			ikObj := scope.Lookup(idempotencyKeyTypeName)
+			if ikObj == nil {
+				return []Diagnostic{{Message: ruleHTTPIdemKeyNodeAgnostic01 +
+					"/SoleProducerAndSink: type IdempotencyKey not found in " + httpIdempotencyPkgPath}}
+			}
+			ikType := ikObj.Type()
+
+			// (1) sole producer: exported package-level funcs AND function-typed
+			// vars whose signature returns IdempotencyKey must be exactly {DeriveKey}.
+			var producers []string
+			for _, name := range scope.Names() {
+				obj := scope.Lookup(name)
+				if !obj.Exported() {
+					continue
+				}
+				var sig *types.Signature
+				switch o := obj.(type) {
+				case *types.Func:
+					if s, ok := o.Type().(*types.Signature); ok && s.Recv() == nil {
+						sig = s
+					}
+				case *types.Var:
+					if s, ok := o.Type().(*types.Signature); ok {
+						sig = s
+					}
+				}
+				if sig != nil && sigReturnsType(sig, ikType) {
+					producers = append(producers, name)
+				}
+			}
+			diags = append(diags, diffHTTPIdempotencyExpectedSet(
+				"exported package-level surfaces producing IdempotencyKey",
+				deriveKeyProducerAllowed, producers)...)
+
+			// (2) Store.Claim sink: the post-ctx parameter must be IdempotencyKey.
+			diags = append(diags, checkStoreClaimParamType(scope, ikType)...)
+			return nil
+		})
+
+	if !visited {
+		diags = append(diags, Diagnostic{Message: ruleHTTPIdemKeyNodeAgnostic01 +
+			"/SoleProducerAndSink: " + httpIdempotencyPkgPath + " not scanned — the funnel freeze did not run."})
+	}
+	Report(t, ruleHTTPIdemKeyNodeAgnostic01+"/SoleProducerAndSink", diags)
+}
+
+// checkStoreClaimParamType asserts Store.Claim's parameter after ctx is exactly
+// IdempotencyKey — the typed sink that makes a raw (ns,key) string pair
+// inexpressible at the store boundary.
+func checkStoreClaimParamType(scope *types.Scope, ikType types.Type) []Diagnostic {
+	storeObj := scope.Lookup(storeIfaceName)
+	if storeObj == nil {
+		return []Diagnostic{{Message: ruleHTTPIdemKeyNodeAgnostic01 + "/SoleProducerAndSink: interface Store not found"}}
+	}
+	iface, ok := storeObj.Type().Underlying().(*types.Interface)
+	if !ok {
+		return []Diagnostic{{Message: ruleHTTPIdemKeyNodeAgnostic01 + "/SoleProducerAndSink: Store is not an interface"}}
+	}
+	for i := 0; i < iface.NumMethods(); i++ {
+		m := iface.Method(i)
+		if m.Name() != storeClaimMethodName {
+			continue
+		}
+		sig, ok := m.Type().(*types.Signature)
+		if !ok {
+			continue
+		}
+		params := sig.Params()
+		if params.Len() < 2 {
+			return []Diagnostic{{Message: fmt.Sprintf(
+				"%s/SoleProducerAndSink: Store.Claim has %d params, want (ctx, IdempotencyKey, …)",
+				ruleHTTPIdemKeyNodeAgnostic01, params.Len())}}
+		}
+		if got := params.At(1).Type(); !types.Identical(got, ikType) {
+			return []Diagnostic{{Message: fmt.Sprintf(
+				"%s/SoleProducerAndSink: Store.Claim param[1] = %s, want IdempotencyKey. Reverting to a raw "+
+					"(ns,key) string pair re-opens hand-built keys at the store boundary (the downstream Hard sink).",
+				ruleHTTPIdemKeyNodeAgnostic01, got)}}
+		}
+		return nil
+	}
+	return []Diagnostic{{Message: ruleHTTPIdemKeyNodeAgnostic01 + "/SoleProducerAndSink: Store.Claim method not found"}}
+}
+
+// TestHTTPIdempotencyKeyNodeAgnostic01_RequiredUse is the require-isolation-tuple
+// half (Medium residual, gh #1650): the sealed type makes "external code injects
+// a node id" inexpressible, but Go CANNOT make "DeriveKey's body consumes all
+// five isolation dimensions into the key" type-system-Hard. This AST taint walk on
+// DeriveKey is the Medium backstop: each of (tenantID→ns, subject/method/path/
+// idemKey→key) must FLOW (not merely be referenced) into the returned
+// IdempotencyKey literal; a dropped dimension or a `_ = method` dummy read is
+// caught. A 6th parameter (a node-id injection vector) trips the signature freeze.
+func TestHTTPIdempotencyKeyNodeAgnostic01_RequiredUse(t *testing.T) {
 	t.Parallel()
 
 	root := findModuleRoot(t)
-	path := filepath.Join(root, "runtime", "http", "idempotency", "middleware.go")
+	path := filepath.Join(root, "runtime", "http", "idempotency", deriveKeyFile)
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	file, err := parser.ParseFile(fset, path, nil, 0)
 	require.NoError(t, err, "parse %s", path)
 
-	fn, ok := findTopLevelFuncDecl(file, buildNamespaceKeyFnName)
-	require.Truef(t, ok, "%s: %s not found in middleware.go", ruleHTTPIdemKeyNodeAgnostic01, buildNamespaceKeyFnName)
+	fn, ok := findTopLevelFuncDecl(file, deriveKeyFnName)
+	require.Truef(t, ok, "%s: %s not found in %s", ruleHTTPIdemKeyNodeAgnostic01, deriveKeyFnName, deriveKeyFile)
 
-	for _, v := range checkBuildNamespaceKeySignature(fn) {
-		t.Errorf("%s (signature): %s. The key derivation must take exactly "+
-			"(*auth.Principal, method, path, idemKey string) — a pod/listener/cell parameter would make "+
-			"the idempotency key node-specific and break assembly-wide dedup. If intentional, update "+
-			"ADR 202606051000-1449 + this gate + the cross-pod test in the same PR.", ruleHTTPIdemKeyNodeAgnostic01, v)
+	for _, vio := range checkDeriveKeySignature(fn) {
+		t.Errorf("%s (signature): %s. DeriveKey must take exactly five string isolation params and return "+
+			"IdempotencyKey — a 6th param is the node-id injection vector. If intentional, update ADR "+
+			"202606051000-1449 + this gate in the same PR.", ruleHTTPIdemKeyNodeAgnostic01, vio)
 	}
-	for _, v := range checkBuildNamespaceKeyBody(fn) {
-		t.Errorf("%s (body): %s. The key must be a pure derivation of (principal tenant/subject + "+
-			"method/path/idemKey) — no calls and no references to node-local state. If intentional, "+
-			"update ADR 202606051000-1449 + this gate in the same PR.", ruleHTTPIdemKeyNodeAgnostic01, v)
-	}
-	for _, v := range checkBuildNamespaceKeyRequiredUse(fn) {
-		t.Errorf("%s (required-use): %s. The key MUST consume every isolation dimension "+
-			"(p.TenantID + p.Subject + method/path/idemKey); dropping one collapses cross-tenant, "+
-			"cross-subject, or cross-endpoint isolation while still passing the node-agnostic body check. "+
-			"If intentional, update ADR 202606051000-1449 + this gate in the same PR.", ruleHTTPIdemKeyNodeAgnostic01, v)
+	for _, vio := range checkDeriveKeyRequiredUse(fn) {
+		t.Errorf("%s (required-use): %s. Every isolation dimension MUST flow into the key (#1650 Medium "+
+			"backstop); dropping one collapses cross-tenant/-user/-endpoint isolation.", ruleHTTPIdemKeyNodeAgnostic01, vio)
 	}
 }
 
-// checkBuildNamespaceKeySignature pins the parameter list to exactly
-// (*auth.Principal, string, string, string) and the results to (string, string).
-func checkBuildNamespaceKeySignature(fn *ast.FuncDecl) []string {
-	var violations []string
+// checkDeriveKeySignature pins DeriveKey to exactly five string params and a
+// single IdempotencyKey result.
+func checkDeriveKeySignature(fn *ast.FuncDecl) []string {
+	var v []string
 	params := flattenFieldList(fn.Type.Params)
-	if len(params) != 4 {
-		violations = append(violations, fmt.Sprintf(
-			"param count = %d, want exactly 4 (*auth.Principal, method, path, idemKey string)", len(params)))
-		return violations // positional checks below assume 4
+	if len(params) != 5 {
+		v = append(v, fmt.Sprintf(
+			"param count = %d, want exactly 5 (tenantID, subject, method, path, idemKey string)", len(params)))
+		return v // positional taint resolution below assumes 5
 	}
-	if !isPrincipalPtr(params[0].typ) {
-		violations = append(violations, fmt.Sprintf(
-			"param[0] type = %s, want *auth.Principal (the only identity source allowed into the key)",
-			exprString(params[0].typ)))
-	}
-	for i := 1; i < 4; i++ {
-		if !isStringIdent(params[i].typ) {
-			violations = append(violations, fmt.Sprintf(
-				"param[%d] type = %s, want string", i, exprString(params[i].typ)))
+	for i, p := range params {
+		if !isStringIdent(p.typ) {
+			v = append(v, fmt.Sprintf("param[%d] type = %s, want string", i, exprString(p.typ)))
 		}
 	}
 	results := flattenFieldList(fn.Type.Results)
-	if len(results) != 2 {
-		violations = append(violations, fmt.Sprintf("result count = %d, want exactly 2 (ns, key string)", len(results)))
-	} else {
-		for i := 0; i < 2; i++ {
-			if !isStringIdent(results[i].typ) {
-				violations = append(violations, fmt.Sprintf("result[%d] type = %s, want string", i, exprString(results[i].typ)))
-			}
-		}
+	if len(results) != 1 {
+		v = append(v, fmt.Sprintf("result count = %d, want exactly 1 (IdempotencyKey)", len(results)))
+	} else if id, ok := results[0].typ.(*ast.Ident); !ok || id.Name != idempotencyKeyTypeName {
+		v = append(v, fmt.Sprintf("result type = %s, want IdempotencyKey", exprString(results[0].typ)))
 	}
-	return violations
-}
-
-// checkBuildNamespaceKeyBody asserts the body is a pure data derivation of its
-// sanctioned inputs, so nothing node-local can enter the key:
-//   - no function calls (no os.Hostname / getenv / node-identity provider);
-//   - every selector reads *auth.Principal via the param `p` and only its
-//     allowlisted identity fields {TenantID, Subject} — any pkg.X / other
-//     selector base is an external reference and is rejected;
-//   - every bare value identifier is either declared in the function (params,
-//     named results, locals) or the single sanctioned const noTenantSentinel —
-//     a free reference to any other package-level symbol (e.g. a process node-id
-//     var) is rejected. This is the free-identifier closure that makes the
-//     "no node-local state" claim hold without a param or a call.
-func checkBuildNamespaceKeyBody(fn *ast.FuncDecl) []string {
-	if fn.Body == nil {
-		return []string{"missing body"}
-	}
-	// Resolve the principal parameter name (param[0]); default "p".
-	principalName := "p"
-	if params := flattenFieldList(fn.Type.Params); len(params) > 0 && params[0].name != "" {
-		principalName = params[0].name
-	}
-
-	declared := collectDeclaredNames(fn)
-	// Selector field names (.Sel) are not free variables; collect them so the
-	// free-identifier pass skips them.
-	selFields := map[*ast.Ident]struct{}{}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		if sel, ok := n.(*ast.SelectorExpr); ok {
-			selFields[sel.Sel] = struct{}{}
-		}
-		return true
-	})
-
-	var violations []string
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.CallExpr:
-			violations = append(violations, fmt.Sprintf(
-				"contains a function call %q (key derivation must be call-free so no node-local state can enter the key)",
-				exprString(x.Fun)))
-		case *ast.SelectorExpr:
-			base, ok := x.X.(*ast.Ident)
-			if !ok || base.Name != principalName {
-				violations = append(violations, fmt.Sprintf(
-					"selector %s reads a non-principal source (only %s.<field> is allowed)",
-					exprString(x), principalName))
-				return true
-			}
-			if _, allowed := principalSelectorAllowlist[x.Sel.Name]; !allowed {
-				violations = append(violations, fmt.Sprintf(
-					"selector %s.%s reads a principal field outside the allowlist {TenantID, Subject}",
-					principalName, x.Sel.Name))
-			}
-		case *ast.Ident:
-			if _, isField := selFields[x]; isField {
-				return true // a selector field name, not a free variable
-			}
-			if isPredeclaredIdent(x.Name) {
-				return true
-			}
-			if _, ok := declared[x.Name]; ok {
-				return true
-			}
-			if x.Name == noTenantSentinelConst {
-				return true // the single sanctioned package-level const
-			}
-			violations = append(violations, fmt.Sprintf(
-				"free reference %q (a package-level symbol other than %s may be node-local/external state)",
-				x.Name, noTenantSentinelConst))
-		}
-		return true
-	})
-	return violations
+	return v
 }
 
 // isolationToken is a bit in the set of sanctioned isolation inputs that must
-// flow into the (ns,key) outputs.
+// flow into the returned key.
 type isolationToken uint8
 
 const (
-	tokTenant  isolationToken = 1 << iota // p.TenantID → must reach ns
-	tokSubject                            // p.Subject  → must reach key
-	tokMethod                             // method     → must reach key
-	tokPath                               // path       → must reach key
-	tokIdemKey                            // idemKey    → must reach key
+	tokTenant  isolationToken = 1 << iota // tenantID → must reach the ns field
+	tokSubject                            // subject  → must reach the key field
+	tokMethod                             // method   → must reach the key field
+	tokPath                               // path     → must reach the key field
+	tokIdemKey                            // idemKey  → must reach the key field
 )
 
-// checkBuildNamespaceKeyRequiredUse is the require-isolation-tuple half of the β
-// gate (checkBuildNamespaceKeyBody is the ban-external-source half). It asserts
-// every sanctioned isolation input actually FLOWS INTO the right output, so the
-// key cannot silently drop a dimension while still passing the node-agnostic
-// checks:
+// checkDeriveKeyRequiredUse taint-tracks each of the five params from its source
+// to the ns/key fields of the returned IdempotencyKey literal. tenantID must
+// reach the ns field; subject/method/path/idemKey must reach the key field. Flow
+// (not mere presence) is tracked so a dummy read `_ = method` does not count.
 //
-//   - p.TenantID must flow into the ns result (the tenant isolation namespace).
-//     Hard-coding ns to a literal collapses cross-tenant isolation.
-//   - p.Subject, method, path, idemKey must flow into the key result. Dropping
-//     subject collapses cross-user isolation; dropping method/path collapses
-//     cross-endpoint isolation (POST /orders and POST /payments with the same
-//     header would collide); dropping idemKey makes the header value irrelevant.
-//
-// Why FLOW and not mere presence: an earlier version only checked that each input
-// was *referenced anywhere* in the body, on the false premise that
-// ban-external-source makes "referenced" ⟺ "flows into (ns,key)". It does not —
-// a dummy read like `_ = method; key = p.Subject` references method yet never
-// puts it in the key, silently dropping endpoint isolation (PR #1614 review
-// F1-partial). So this tracks taint: a per-variable token set seeded by the
-// sources (p.TenantID/Subject selectors + method/path/idemKey params),
-// propagated through assignments + named-result returns to a fixpoint, then
-// asserted at the ns/key sinks.
-//
-// Completeness within the β grammar: ban-external-source bans calls, closures,
-// non-principal selectors, and free package symbols, so the body is necessarily
-// a flat composition of assignments + binary concatenation over exactly these
-// inputs + the noTenantSentinel const. Over THAT grammar the taint walk is
-// complete (every value path is an assignment or a concat this walk follows). If
-// the grammar widened (e.g. a call were allowed), the flow could be laundered —
-// but ban-external-source keeps it narrow. Param/result identity is resolved
-// positionally from the FuncDecl; this runs only when the 4-param/2-result
-// signature holds (the signature freeze reports the shape otherwise). Rating is
-// Medium (AST taint, same tier as β); the Hard form that makes a dropped
-// dimension inexpressible is the sealed typed key constructor funnel, #1610.
-func checkBuildNamespaceKeyRequiredUse(fn *ast.FuncDecl) []string {
+// Completeness: the body is a flat composition of assignments + binary
+// concatenation over the five params + the noTenantSentinel const (no calls,
+// closures, or foreign selectors are needed to express the derivation), so the
+// per-variable token fixpoint follows every value path. Rating is Medium (AST
+// taint); the Hard form that would make a dropped dimension inexpressible is a
+// genuine Go ceiling — see gh #1650.
+func checkDeriveKeyRequiredUse(fn *ast.FuncDecl) []string {
 	if fn.Body == nil {
 		return []string{"missing body"}
 	}
 	params := flattenFieldList(fn.Type.Params)
-	results := flattenFieldList(fn.Type.Results)
-	if len(params) != 4 || len(results) != 2 {
-		// The signature freeze reports the shape; positional source/sink
-		// resolution is undefined without it.
-		return nil
-	}
-	principalName := params[0].name
-	if principalName == "" {
-		principalName = "p"
+	if len(params) != 5 {
+		return nil // the signature freeze reports the shape
 	}
 	src := map[isolationToken]string{
-		tokMethod: params[1].name, tokPath: params[2].name, tokIdemKey: params[3].name,
+		tokTenant: params[0].name, tokSubject: params[1].name, tokMethod: params[2].name,
+		tokPath: params[3].name, tokIdemKey: params[4].name,
 	}
-	// Sink keys: the named results when named, else positional placeholders so a
-	// (hypothetical) unnamed-result form is driven purely by return expressions.
-	nsSink, keySink := results[0].name, results[1].name
-	if nsSink == "" {
-		nsSink = "$res0"
-	}
-	if keySink == "" {
-		keySink = "$res1"
+
+	// Sinks are the ns/key fields of the returned IdempotencyKey composite
+	// literal. The synthetic sink names cannot collide with Go identifiers.
+	const nsSink, keySink = "$ns", "$key"
+	nsExpr, keyExpr, found := returnedKeyFields(fn.Body)
+	if !found {
+		return []string{"DeriveKey must end by returning an IdempotencyKey{ns: …, key: …} composite literal " +
+			"(the taint sinks); a different construction form is a deliberate review checkpoint"}
 	}
 
 	taint := map[string]isolationToken{}
-	// tokensOf returns the tokens an expression carries: direct sources plus the
-	// accumulated taint of any local/result variable it references.
 	tokensOf := func(expr ast.Expr) isolationToken {
 		var bits isolationToken
 		ast.Inspect(expr, func(n ast.Node) bool {
-			switch x := n.(type) {
-			case *ast.SelectorExpr:
-				if base, ok := x.X.(*ast.Ident); ok && base.Name == principalName {
-					switch x.Sel.Name {
-					case "TenantID":
-						bits |= tokTenant
-					case "Subject":
-						bits |= tokSubject
-					}
-				}
-				return false // do not descend into the selector base ident
-			case *ast.Ident:
+			if id, ok := n.(*ast.Ident); ok {
 				for tok, name := range src {
-					if name != "" && x.Name == name {
+					if name != "" && id.Name == name {
 						bits |= tok
 					}
 				}
-				bits |= taint[x.Name]
+				bits |= taint[id.Name]
 			}
 			return true
 		})
 		return bits
 	}
 
-	// Collect assignment edges (lhsName ← rhsExpr) and return edges (resultN ←
-	// retExpr) once, then iterate to a fixpoint.
 	type edge struct {
 		sink string
 		rhs  ast.Expr
 	}
 	var edges []edge
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		switch s := n.(type) {
-		case *ast.AssignStmt:
-			if len(s.Lhs) == len(s.Rhs) {
-				for i, lhs := range s.Lhs {
-					if id, ok := lhs.(*ast.Ident); ok {
-						edges = append(edges, edge{sink: id.Name, rhs: s.Rhs[i]})
-					}
+		if as, ok := n.(*ast.AssignStmt); ok && len(as.Lhs) == len(as.Rhs) {
+			for i, lhs := range as.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok {
+					edges = append(edges, edge{sink: id.Name, rhs: as.Rhs[i]})
 				}
-			}
-		case *ast.ReturnStmt:
-			if len(s.Results) == 2 {
-				edges = append(edges,
-					edge{sink: nsSink, rhs: s.Results[0]},
-					edge{sink: keySink, rhs: s.Results[1]})
 			}
 		}
 		return true
 	})
+	edges = append(edges, edge{sink: nsSink, rhs: nsExpr}, edge{sink: keySink, rhs: keyExpr})
+
 	for changed := true; changed; {
 		changed = false
 		for _, e := range edges {
@@ -538,222 +595,210 @@ func checkBuildNamespaceKeyRequiredUse(fn *ast.FuncDecl) []string {
 		}
 	}
 
-	var violations []string
+	var v []string
 	if taint[nsSink]&tokTenant == 0 {
-		violations = append(violations, fmt.Sprintf(
-			"%s.TenantID never flows into the ns result — the tenant isolation namespace would be lost (cross-tenant replay)", principalName))
+		v = append(v, "tenantID never flows into the ns field — cross-tenant replay")
 	}
 	for _, want := range []struct {
 		tok   isolationToken
 		label string
-	}{{tokSubject, principalName + ".Subject"}, {tokMethod, "method"}, {tokPath, "path"}, {tokIdemKey, "idemKey"}} {
+	}{{tokSubject, "subject"}, {tokMethod, "method"}, {tokPath, "path"}, {tokIdemKey, "idemKey"}} {
 		if taint[keySink]&want.tok == 0 {
-			violations = append(violations, fmt.Sprintf(
-				"%s never flows into the key result — isolation dropped "+
-					"(dummy read `_ = %s` does not count)", want.label, want.label))
+			v = append(v, fmt.Sprintf(
+				"%s never flows into the key field — isolation dropped (dummy read `_ = %s` does not count)",
+				want.label, want.label))
 		}
 	}
-	return violations
+	return v
 }
 
-// noTenantSentinelConst is the only package-level identifier the key derivation
-// may reference (the empty-tenant namespace sentinel in middleware.go).
-const noTenantSentinelConst = "noTenantSentinel"
-
-// collectDeclaredNames returns the identifiers declared inside fn: parameters,
-// named results, and locals introduced by `:=`, `var`, and `range`. These are
-// the non-free identifiers the body may reference.
-//
-// Not covered (intentional — buildNamespaceKey's body is a flat assign/if/return
-// with no such constructs): type-switch guard bindings (`switch x := y.(type)`)
-// and labeled-statement labels. If a future buildNamespaceKey introduced one,
-// the binding would be flagged as a free reference (a false positive forcing
-// review), not silently allowed — fail-closed for this gate's purpose.
-func collectDeclaredNames(fn *ast.FuncDecl) map[string]struct{} {
-	declared := map[string]struct{}{}
-	for _, p := range flattenFieldList(fn.Type.Params) {
-		if p.name != "" {
-			declared[p.name] = struct{}{}
+// returnedKeyFields extracts the ns/key field value expressions from the
+// IdempotencyKey composite literal in the function's return statement.
+func returnedKeyFields(body *ast.BlockStmt) (nsExpr, keyExpr ast.Expr, found bool) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			return true
 		}
-	}
-	for _, r := range flattenFieldList(fn.Type.Results) {
-		if r.name != "" {
-			declared[r.name] = struct{}{}
+		cl, ok := ret.Results[0].(*ast.CompositeLit)
+		if !ok {
+			return true
 		}
-	}
-	if fn.Body == nil {
-		return declared
-	}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.AssignStmt:
-			if x.Tok == token.DEFINE {
-				for _, lhs := range x.Lhs {
-					if id, ok := lhs.(*ast.Ident); ok {
-						declared[id.Name] = struct{}{}
-					}
-				}
+		if id, ok := cl.Type.(*ast.Ident); !ok || id.Name != idempotencyKeyTypeName {
+			return true
+		}
+		for _, el := range cl.Elts {
+			kv, ok := el.(*ast.KeyValueExpr)
+			if !ok {
+				continue
 			}
-		case *ast.ValueSpec:
-			for _, id := range x.Names {
-				declared[id.Name] = struct{}{}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
 			}
-		case *ast.RangeStmt:
-			if id, ok := x.Key.(*ast.Ident); ok {
-				declared[id.Name] = struct{}{}
+			switch key.Name {
+			case "ns":
+				nsExpr = kv.Value
+			case "key":
+				keyExpr = kv.Value
 			}
-			if id, ok := x.Value.(*ast.Ident); ok {
-				declared[id.Name] = struct{}{}
-			}
+		}
+		if nsExpr != nil && keyExpr != nil {
+			found = true
+			return false
 		}
 		return true
 	})
-	return declared
-}
-
-// isPredeclaredIdent reports whether name is a Go predeclared identifier
-// (builtins, basic types, constants, blank). These are not free package-level
-// references for the purposes of the node-agnostic body check.
-func isPredeclaredIdent(name string) bool {
-	switch name {
-	case "_", "true", "false", "nil", "iota",
-		"bool", "byte", "rune", "string", "error", "any", "comparable",
-		"int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
-		"float32", "float64", "complex64", "complex128",
-		"len", "cap", "make", "new", "append", "copy", "delete",
-		"close", "panic", "recover", "print", "println", "min", "max", "clear":
-		return true
-	}
-	return false
+	return
 }
 
 // ---------------------------------------------------------------------------
-// β reverse self-check (non-vacuity)
+// β reverse self-checks (non-vacuity)
 // ---------------------------------------------------------------------------
+
+// ikMethodFixture is a package-level reverse-self-check fixture for the METHOD
+// detectors: a type carrying a deserialization backdoor (UnmarshalJSON) and a
+// builder-laundering method (Clone returns itself). Go forbids method
+// declarations inside a func, so it must be package-level; the field set is
+// irrelevant to checkIdempotencyKeyMethods, so it is empty.
+type ikMethodFixture struct{}
+
+func (ikMethodFixture) UnmarshalJSON([]byte) error { return nil }
+func (i ikMethodFixture) Clone() ikMethodFixture   { return i }
 
 // TestHTTPIdempotencyKeyNodeAgnostic01_ReverseBlindSpot proves the β detectors
-// flag drift: a conforming inline function yields zero violations, and each
-// malformed variant (node-identity param, external call, package-var reference,
-// extra principal field, chained selector) yields ≥1.
+// flag drift: the real type/constructor yield zero violations, and each malformed
+// variant yields ≥1.
 func TestHTTPIdempotencyKeyNodeAgnostic01_ReverseBlindSpot(t *testing.T) {
 	t.Parallel()
 
-	good := `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = p.TenantID
-	if ns == "" {
-		ns = noTenantSentinel
-	}
-	key = p.Subject + "\x00" + method + "\x00" + path + "\x00" + idemKey
-	return
-}`
-	if sv, bv, uv := runBuildKeyDetectors(t, good); len(sv) != 0 || len(bv) != 0 || len(uv) != 0 {
-		t.Errorf("%s self-test: detectors flagged the conforming form (vacuous-pass risk): sig=%v body=%v use=%v",
-			ruleHTTPIdemKeyNodeAgnostic01, sv, bv, uv)
+	// Non-vacuity: the real sealed type passes both reflect detectors.
+	realKey := reflect.TypeOf(idempotency.IdempotencyKey{})
+	if v := append(checkIdempotencyKeyShape(realKey), checkIdempotencyKeyMethods(realKey)...); len(v) != 0 {
+		t.Errorf("%s self-test: detectors flagged the real conforming IdempotencyKey (vacuous-pass risk): %v",
+			ruleHTTPIdemKeyNodeAgnostic01, v)
 	}
 
-	bad := map[string]string{ //nolint:gosec // G101 false positive: map values are Go source fixtures, not credentials
-		"node-identity-param": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey, podID string) (ns, key string) {
-	key = p.Subject + podID
-	return
-}`,
-		"external-call": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	host, _ := os.Hostname()
-	key = p.Subject + host
-	return
-}`,
-		"package-var-reference": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	key = p.Subject + processNodeID
-	return
-}`,
-		"extra-principal-field": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	key = p.Subject + p.Region
-	return
-}`,
-		"chained-selector": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	key = p.Subject + provider.Node.ID
-	return
-}`,
-		// require-isolation-tuple half: each fixture drops exactly one isolation
-		// dimension while staying call-free + node-local-free, so it passes
-		// ban-external-source and is caught only by checkBuildNamespaceKeyRequiredUse.
-		"missing-tenant": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = noTenantSentinel
-	key = p.Subject + "\x00" + method + "\x00" + path + "\x00" + idemKey
-	return
-}`,
-		"missing-subject": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = p.TenantID
-	key = method + "\x00" + path + "\x00" + idemKey
-	return
-}`,
-		"missing-method": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = p.TenantID
-	key = p.Subject + "\x00" + path + "\x00" + idemKey
-	return
-}`,
-		"missing-path": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = p.TenantID
-	key = p.Subject + "\x00" + method + "\x00" + idemKey
-	return
-}`,
-		"missing-idemkey": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	ns = p.TenantID
-	key = p.Subject + "\x00" + method + "\x00" + path
-	return
-}`,
-		// dummy-read bypass: every isolation input is *referenced* (so the old
-		// presence check passed) but method/path/idemKey only flow into the blank
-		// identifier, never into key — endpoint/header isolation is silently lost.
-		// Caught only by the flow-based required-use detector (PR #1614 F1-partial).
-		"dummy-read-bypass": `package p
-func buildNamespaceKey(p *auth.Principal, method, path, idemKey string) (ns, key string) {
-	_ = method
-	_ = path
-	_ = idemKey
-	ns = p.TenantID
-	key = p.Subject
-	return
-}`,
+	// Shape reverse fixtures (synthetic reflect types). Keyed composite literals
+	// reference each field so the `unused` linter does not flag them.
+	type wrongType struct {
+		ns  int
+		key int
 	}
-	for name, src := range bad {
-		sv, bv, uv := runBuildKeyDetectors(t, src)
-		if len(sv) == 0 && len(bv) == 0 && len(uv) == 0 {
-			t.Errorf("%s self-test: detectors passed malformed form %q (blind spot): expected ≥1 violation",
+	type extraField struct {
+		ns  string
+		key string
+		pod string // a smuggled node id
+	}
+	type renamed struct {
+		namespace string
+		k         string
+	}
+	type exported struct {
+		Ns  string // re-opens external populated-literal construction
+		key string
+	}
+	type embedded struct {
+		any
+		ns  string
+		key string
+	}
+	badShapes := map[string]reflect.Type{
+		"wrong-field-type": reflect.TypeOf(wrongType{ns: 0, key: 0}),
+		"extra-field":      reflect.TypeOf(extraField{ns: "", key: "", pod: ""}),
+		"renamed-fields":   reflect.TypeOf(renamed{namespace: "", k: ""}),
+		"exported-field":   reflect.TypeOf(exported{Ns: "", key: ""}),
+		"embedded-field":   reflect.TypeOf(embedded{any: nil, ns: "", key: ""}),
+	}
+	for name, dt := range badShapes {
+		if v := checkIdempotencyKeyShape(dt); len(v) == 0 {
+			t.Errorf("%s self-test: shape detector passed malformed %q (blind spot)", ruleHTTPIdemKeyNodeAgnostic01, name)
+		}
+	}
+
+	// Method reverse fixture: UnmarshalJSON (forbidden) + Clone (returns self).
+	if v := checkIdempotencyKeyMethods(reflect.TypeOf(ikMethodFixture{})); len(v) < 2 {
+		t.Errorf("%s self-test: method detector missed the backdoor/builder fixture (got %v)",
+			ruleHTTPIdemKeyNodeAgnostic01, v)
+	}
+
+	// Taint reverse fixtures (inline DeriveKey source). The conforming body yields
+	// zero; each malformed variant yields ≥1 from the signature freeze or taint walk.
+	if sv, uv := runDeriveKeyDetectors(t, deriveKeyGood); len(sv) != 0 || len(uv) != 0 {
+		t.Errorf("%s self-test: detectors flagged the conforming DeriveKey (vacuous-pass): sig=%v use=%v",
+			ruleHTTPIdemKeyNodeAgnostic01, sv, uv)
+	}
+	for name, src := range deriveKeyBad {
+		if sv, uv := runDeriveKeyDetectors(t, src); len(sv) == 0 && len(uv) == 0 {
+			t.Errorf("%s self-test: detectors passed malformed DeriveKey %q (blind spot)",
 				ruleHTTPIdemKeyNodeAgnostic01, name)
 		}
 	}
 }
 
-// runBuildKeyDetectors parses an inline buildNamespaceKey source and runs all
-// three β detectors against it. Each malformed fixture trips ≥1 detector: a
-// node-id param trips the signature freeze; an os.Hostname call trips the no-call
-// body rule; a bare process-node-id reference trips the free-identifier closure;
-// an extra principal field trips the selector allowlist; and a dropped isolation
-// dimension trips the required-use detector.
-func runBuildKeyDetectors(t *testing.T, src string) (sig, body, use []string) {
+const deriveKeyGood = `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	ns := tenantID
+	if ns == "" {
+		ns = noTenantSentinel
+	}
+	return IdempotencyKey{
+		ns:  ns,
+		key: subject + "\x00" + method + "\x00" + path + "\x00" + idemKey,
+	}
+}`
+
+// deriveKeyBad: each fixture drops one isolation dimension (caught by the taint
+// walk) or adds a node-id param (caught by the signature freeze). The dummy-read
+// fixture references every input but flows only subject into the key.
+var deriveKeyBad = map[string]string{ //nolint:gosec,gochecknoglobals // G101 false positive: values are Go source fixtures, not credentials
+	"node-id-param": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey, podID string) IdempotencyKey {
+	return IdempotencyKey{ns: tenantID + podID, key: subject + method + path + idemKey}
+}`,
+	"missing-tenant": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	return IdempotencyKey{ns: noTenantSentinel, key: subject + method + path + idemKey}
+}`,
+	"missing-subject": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	return IdempotencyKey{ns: tenantID, key: method + path + idemKey}
+}`,
+	"missing-method": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	return IdempotencyKey{ns: tenantID, key: subject + path + idemKey}
+}`,
+	"missing-path": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	return IdempotencyKey{ns: tenantID, key: subject + method + idemKey}
+}`,
+	"missing-idemkey": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	return IdempotencyKey{ns: tenantID, key: subject + method + path}
+}`,
+	"dummy-read-bypass": `package p
+func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
+	_ = method
+	_ = path
+	_ = idemKey
+	return IdempotencyKey{ns: tenantID, key: subject}
+}`,
+}
+
+// runDeriveKeyDetectors parses an inline DeriveKey source and runs the signature
+// freeze + the required-use taint walk against it.
+func runDeriveKeyDetectors(t *testing.T, src string) (sig, use []string) {
 	t.Helper()
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "inline.go", src, 0)
-	require.NoError(t, err, "parse inline fixture")
-	fn, ok := findTopLevelFuncDecl(f, buildNamespaceKeyFnName)
-	require.True(t, ok, "inline fixture missing buildNamespaceKey")
-	return checkBuildNamespaceKeySignature(fn), checkBuildNamespaceKeyBody(fn), checkBuildNamespaceKeyRequiredUse(fn)
+	require.NoError(t, err, "parse inline DeriveKey fixture")
+	fn, ok := findTopLevelFuncDecl(f, deriveKeyFnName)
+	require.True(t, ok, "inline fixture missing DeriveKey")
+	return checkDeriveKeySignature(fn), checkDeriveKeyRequiredUse(fn)
 }
 
 // ---------------------------------------------------------------------------
-// Shared AST helpers
+// Shared AST helpers (file-local)
 // ---------------------------------------------------------------------------
 
 // flatParam is one positional parameter/result after flattening grouped fields.
@@ -762,9 +807,9 @@ type flatParam struct {
 	typ  ast.Expr
 }
 
-// flattenFieldList expands grouped fields (e.g. `method, path, idemKey string`)
-// into one entry per positional name. Unnamed fields contribute a single entry
-// with an empty name.
+// flattenFieldList expands grouped fields (e.g. `tenantID, subject string`) into
+// one entry per positional name. Unnamed fields contribute a single entry with an
+// empty name.
 func flattenFieldList(fl *ast.FieldList) []flatParam {
 	if fl == nil {
 		return nil
@@ -785,21 +830,4 @@ func flattenFieldList(fl *ast.FieldList) []flatParam {
 func isStringIdent(e ast.Expr) bool {
 	id, ok := e.(*ast.Ident)
 	return ok && id.Name == "string"
-}
-
-// isPrincipalPtr reports whether e is `*<pkg>.Principal` (the auth.Principal
-// pointer) by matching the selector name "Principal". This handles the
-// direct-import form (`*auth.Principal`); it does NOT accept a type alias
-// (`*P` where `type P = auth.Principal`, which is an *ast.Ident, not a
-// SelectorExpr) — such a form is rejected by the param-type freeze as "not
-// *auth.Principal", a false positive that forces review rather than a bypass.
-// The Hard form (sealed key constructor, #1610) removes this AST-shape
-// dependency entirely.
-func isPrincipalPtr(e ast.Expr) bool {
-	star, ok := e.(*ast.StarExpr)
-	if !ok {
-		return false
-	}
-	sel, ok := star.X.(*ast.SelectorExpr)
-	return ok && sel.Sel.Name == "Principal"
 }

--- a/tools/archtest/http_idempotency_assembly_scope_test.go
+++ b/tools/archtest/http_idempotency_assembly_scope_test.go
@@ -78,9 +78,18 @@ package archtest
 //     ReverseBlindSpot test (synthetic reflect shapes + a package-level
 //     method-bearing fixture, since Go forbids method decls inside a func).
 //   - β prong-1b/2 go/types blind spots: a 2nd package-level producer (func or
-//     function-typed var) → sole-producer diff; reverting Store.Claim to raw
-//     strings → param-type freeze; both fail loud via the visited-guard if the
-//     package path moves.
+//     function-typed var) → sole-producer diff (scan is exported-only — an
+//     unexported package-level func/var returning IdempotencyKey is NOT caught;
+//     the upstream-external Hard construction seal via unexported fields is the
+//     backstop there); reverting Store.Claim to raw strings → param-type freeze;
+//     both fail loud via the visited-guard if the package path moves.
+//   - β prong-1b/2 method blind spot: checkIdempotencyKeyMethods only scans
+//     methods of IdempotencyKey itself (via reflect.PointerTo), and the go/types
+//     sole-producer scan skips methods (Recv != nil) — so a method on ANOTHER
+//     package type that returns IdempotencyKey (e.g. func (b keyBuilder) Build()
+//     IdempotencyKey) is caught by neither. It is bounded by the
+//     upstream-external Hard seal: such a method still cannot populate the
+//     unexported fields except via DeriveKey. Known in-package Medium blind spot.
 //   - β prong-3 taint walk blind spots: a 6th DeriveKey param (node-id vector) →
 //     signature freeze; dropping any isolation dimension from the body, INCLUDING
 //     a dummy read `_ = method` that references the input but never flows it into

--- a/tools/archtest/http_idempotency_assembly_scope_test.go
+++ b/tools/archtest/http_idempotency_assembly_scope_test.go
@@ -78,11 +78,9 @@ package archtest
 //     ReverseBlindSpot test (synthetic reflect shapes + a package-level
 //     method-bearing fixture, since Go forbids method decls inside a func).
 //   - β prong-1b/2 go/types blind spots: a 2nd package-level producer (func or
-//     function-typed var) → sole-producer diff (scan is exported-only — an
-//     unexported package-level func/var returning IdempotencyKey is NOT caught;
-//     the upstream-external Hard construction seal via unexported fields is the
-//     backstop there); reverting Store.Claim to raw strings → param-type freeze;
-//     both fail loud via the visited-guard if the package path moves.
+//     function-typed var), exported OR unexported, → sole-producer diff;
+//     reverting Store.Claim to raw strings → param-type freeze; both fail loud
+//     via the visited-guard if the package path moves.
 //   - β prong-1b/2 method blind spot: checkIdempotencyKeyMethods only scans
 //     methods of IdempotencyKey itself (via reflect.PointerTo), and the go/types
 //     sole-producer scan skips methods (Recv != nil) — so a method on ANOTHER
@@ -258,7 +256,7 @@ const (
 	storeClaimMethodName   = "Claim"
 )
 
-// deriveKeyProducerAllowed is the exhaustive set of exported package-level
+// deriveKeyProducerAllowed is the exhaustive set of package-level
 // surfaces in runtime/http/idempotency that may PRODUCE an IdempotencyKey value.
 // DeriveKey is the sole constructor; a second producer (FromStrings / a
 // function-typed var / an Unmarshal) would launder an arbitrary (ns,key) —
@@ -355,7 +353,7 @@ func TestHTTPIdempotencyKeyNodeAgnostic01_KeySealed(t *testing.T) {
 }
 
 // TestHTTPIdempotencyKeyNodeAgnostic01_SoleProducerAndSink pins, via go/types,
-// (1) DeriveKey as the SOLE exported package-level producer of an IdempotencyKey
+// (1) DeriveKey as the SOLE package-level producer of an IdempotencyKey
 // value (a second producer would launder an arbitrary key), and (2) Store.Claim's
 // post-ctx parameter as IdempotencyKey (the downstream Hard sink — a raw (ns,key)
 // string pair is inexpressible at the boundary).
@@ -383,31 +381,11 @@ func TestHTTPIdempotencyKeyNodeAgnostic01_SoleProducerAndSink(t *testing.T) {
 			}
 			ikType := ikObj.Type()
 
-			// (1) sole producer: exported package-level funcs AND function-typed
-			// vars whose signature returns IdempotencyKey must be exactly {DeriveKey}.
-			var producers []string
-			for _, name := range scope.Names() {
-				obj := scope.Lookup(name)
-				if !obj.Exported() {
-					continue
-				}
-				var sig *types.Signature
-				switch o := obj.(type) {
-				case *types.Func:
-					if s, ok := o.Type().(*types.Signature); ok && s.Recv() == nil {
-						sig = s
-					}
-				case *types.Var:
-					if s, ok := o.Type().(*types.Signature); ok {
-						sig = s
-					}
-				}
-				if sig != nil && sigReturnsType(sig, ikType) {
-					producers = append(producers, name)
-				}
-			}
+			// (1) sole producer: package-level funcs AND function-typed vars whose
+			// signature returns IdempotencyKey must be exactly {DeriveKey}.
+			producers := idempotencyKeyProducerNames(scope, ikType)
 			diags = append(diags, diffHTTPIdempotencyExpectedSet(
-				"exported package-level surfaces producing IdempotencyKey",
+				"package-level surfaces producing IdempotencyKey",
 				deriveKeyProducerAllowed, producers)...)
 
 			// (2) Store.Claim sink: the post-ctx parameter must be IdempotencyKey.
@@ -420,6 +398,30 @@ func TestHTTPIdempotencyKeyNodeAgnostic01_SoleProducerAndSink(t *testing.T) {
 			"/SoleProducerAndSink: " + httpIdempotencyPkgPath + " not scanned — the funnel freeze did not run."})
 	}
 	Report(t, ruleHTTPIdemKeyNodeAgnostic01+"/SoleProducerAndSink", diags)
+}
+
+// idempotencyKeyProducerNames returns package-level func / function-typed var
+// names whose signature returns IdempotencyKey.
+func idempotencyKeyProducerNames(scope *types.Scope, ikType types.Type) []string {
+	var producers []string
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		var sig *types.Signature
+		switch o := obj.(type) {
+		case *types.Func:
+			if s, ok := o.Type().(*types.Signature); ok && s.Recv() == nil {
+				sig = s
+			}
+		case *types.Var:
+			if s, ok := o.Type().(*types.Signature); ok {
+				sig = s
+			}
+		}
+		if sig != nil && sigReturnsType(sig, ikType) {
+			producers = append(producers, name)
+		}
+	}
+	return producers
 }
 
 // checkStoreClaimParamType asserts Store.Claim's parameter after ctx is exactly
@@ -730,6 +732,10 @@ func TestHTTPIdempotencyKeyNodeAgnostic01_ReverseBlindSpot(t *testing.T) {
 		t.Errorf("%s self-test: method detector missed the backdoor/builder fixture (got %v)",
 			ruleHTTPIdemKeyNodeAgnostic01, v)
 	}
+	if got := reverseSoleProducerFixtureNames(); !containsString(got, "hiddenProducer") {
+		t.Errorf("%s self-test: sole-producer detector missed unexported producer hiddenProducer (got %v)",
+			ruleHTTPIdemKeyNodeAgnostic01, got)
+	}
 
 	// Taint reverse fixtures (inline DeriveKey source). The conforming body yields
 	// zero; each malformed variant yields ≥1 from the signature freeze or taint walk.
@@ -743,6 +749,32 @@ func TestHTTPIdempotencyKeyNodeAgnostic01_ReverseBlindSpot(t *testing.T) {
 				ruleHTTPIdemKeyNodeAgnostic01, name)
 		}
 	}
+}
+
+// reverseSoleProducerFixtureNames builds a synthetic package scope with an
+// unexported package-level producer. The production detector must include it:
+// same-package helpers can populate IdempotencyKey's unexported fields, so
+// exported-only scanning does not prove DeriveKey is the sole producer.
+func reverseSoleProducerFixtureNames() []string {
+	pkg := types.NewPackage("example.com/reverse/idem", "idem")
+	scope := pkg.Scope()
+	ikObj := types.NewTypeName(token.NoPos, pkg, idempotencyKeyTypeName, nil)
+	ikType := types.NewNamed(ikObj, types.NewStruct(nil, nil), nil)
+	scope.Insert(ikObj)
+
+	result := types.NewTuple(types.NewVar(token.NoPos, pkg, "", ikType))
+	producerSig := types.NewSignatureType(nil, nil, nil, types.NewTuple(), result, false)
+	scope.Insert(types.NewFunc(token.NoPos, pkg, "hiddenProducer", producerSig))
+	return idempotencyKeyProducerNames(scope, ikType)
+}
+
+func containsString(vals []string, want string) bool {
+	for _, v := range vals {
+		if v == want {
+			return true
+		}
+	}
+	return false
 }
 
 const deriveKeyGood = `package p


### PR DESCRIPTION
## Summary

Seal the HTTP idempotency key derivation into a sealed typed `runtime/http/idempotency.IdempotencyKey` (unexported `{ns,key}` + sole constructor `DeriveKey`), upgrading archtest β `HTTP-IDEMPOTENCY-KEY-NODE-AGNOSTIC-01` from Medium AST to a type-system **Hard** sealed-construction funnel.

## Why / 背景

#1610 asks for cross-cell idempotency dedup, whose core (HTTP `Idempotency-Key` ↔ `command_id` bridge) is **hard-blocked by #1044** (Command Bus dispatcher + outbox 桥 — only the sync core landed; `command_id` does not exist yet). This PR delivers the issue's **"彻底" sub-direction** that *is* independently shippable: the sealed `IdempotencyKey` funnel, named verbatim in ADR-1449 §Enforcement + the β archtest godoc as β's Hard-upgrade path.

After this PR a raw `(ns,key)` string pair is **inexpressible** at the `Store.Claim` boundary, and only one in-package constructor can mint a key — closing the node-id-injection vector at the type-system level. It is forward-compatible: a future cross-cell `DeriveCommandKey` produces the same sealed type.

**Honest grading (no overselling):** node-agnostic / ban-external-source = **Hard 下游** (typed `Store.Claim` sink) + **Hard 上游-external** (unexported fields) + **Medium 上游-in-package** (reflect freeze + go/types sole-producer backstop, same split as `CellLabel`/holder-seal #893). require-isolation-tuple (DeriveKey body must FLOW all 5 dims) + same-type-arg transposition = **Medium, genuine Go ceiling** → AST taint walk backstop, won't-do **gh #1650** (family #851/#893/#1282/#1552; NOT typestate-upgradeable).

## Refs

- **Refs #1610** (PARTIAL — funnel slice only; cross-cell core stays open, blocked-by #1044)
- **Refs #1449** (ADR / archtest β lineage owner; ADR §Enforcement + 威胁矩阵 amended in-PR)
- Opens **#1650** (won't-do ceiling tracker for the require-isolation-tuple Medium residual)
- ref: stripe idempotency-key; IETF idempotency-key draft §3
- ADR: `docs/architecture/202606051000-1449-...md` §Amendment 2026-06-06

## Risk / 兼容性

- **Internal API signature change** (`Store.Claim`: `(ns,key string)` → `(k IdempotencyKey)`); pre-v1.0, no external callers — all in-repo consumers migrated in-PR. No **wire** contract change (key bytes identical: `subject\x00method\x00path\x00idemKey`, ns = tenant-or-`_notenant`).
- Redis-Cluster brace/empty guards **kept** (store-specific), deliberately not folded into the store-agnostic `DeriveKey`. The decode `EmptyKey` test was removed: "ns≠empty + key=empty" is structurally unconstructible from a sealed key (guard remains as defense-in-depth, documented).

### Implementation matrix (contract-fanout: interface signature change)

```
Contract:  runtime/http/idempotency.Store.Claim
Change:    (ctx, ns, key, fingerprint string, leaseTTL) → (ctx, k IdempotencyKey, fingerprint string, leaseTTL)
Implementations: [x] MemStore  [x] adapters/redis.HTTPIdempotencyStore
                 [x] bootstrap e2e mocks (idemSpyStore / idemAlwaysErrorStore)
Conformance test: runtime/http/idempotency/idempotencytest.RunConformanceSuite (DeriveKey-built keys; AltNS/AltKey kept distinct)
Repro:     go test ./runtime/http/idempotency/... ./runtime/bootstrap/ -run Idempotency
           go test ./tools/archtest/ -run 'HTTPIdempotencyKeyNodeAgnostic01|HTTPIdempotencyStoreStatelessFrozen01|Conformance'
           go test -tags=integration ./adapters/redis/ -run 'HTTPIdempotency|AssemblyScope'   (needs Docker; CI integration job)
Dependent contracts (governance scan): none (key bytes + wire unchanged; α store-shape freeze unaffected)
```

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过（公共签名变更，integration-tag 编译验证）
- [x] `go test ./runtime/http/idempotency/... ./runtime/bootstrap/ ./adapters/redis/` 本地通过（单元）
- [x] `go test ./tools/archtest/ -run 'HTTPIdempotencyKeyNodeAgnostic01|Conformance'` 通过（β sealed funnel: reflect freeze + go/types sole-producer + Store.Claim param + DeriveKey taint walk + 全套反向自检；whole-repo conformance enrollment 绿）
- [x] `golangci-lint run` on all touched packages — 0 issues
- [ ] Redis integration cross-pod proof — runs in CI integration job (no local Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
