### PR TITLE
refactor(outbox): HandleResult 业务面 slim + DeliveryOutcome subscriber 载体 [#663]

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -34,7 +34,7 @@ func handleEvent(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 }
 ```
 
-> **回落字面量**：`outbox.HandleResult.ProcessReason` / `SettlementObservers` 字段无法用 factory 表达，需要时直接构造 `outbox.HandleResult{...}` 字面量（典型场景：kernel internal retry plumbing、middleware-handler 协议）。`OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01` archtest 把字面量构造限定在 `kernel/outbox/result.go` / `consumer_base.go` / `outboxtest/conformance.go` 三处 allowlist；业务路径必须用 `outbox.Ack()` / `Requeue(err)` / `Reject(err)`。`HandleResult` 字段集本身由 `OUTBOX-HANDLERESULT-FIELDS-FROZEN-01` 冻结。
+> **业务面 slim + subscriber 层载体（#663）**：业务 `outbox.HandleResult` 只有 `{Disposition, Err}` 两字段，factory（`outbox.Ack()` / `Requeue(err)` / `Reject(err)`）**全覆盖**——业务 handler 既不需要也无法构造携带 `ProcessReason` / `SettlementObservers` 的字面量（type-system Hard）。这两个非业务字段迁到 subscriber 层载体 `outbox.DeliveryOutcome{Disposition, Err, ProcessReason, SettlementObservers}`（`SubscriberHandler` 的返回类型，由 `ConsumerBase.Wrap` 从业务 `HandleResult` 升格产出；`ProcessReason` 仅 kernel 设 `"retry_exhausted"`，`SettlementObservers` 由 subscriber 层 wrapper —— `wrapper.WrapSubscriber` / `obmetrics.WrapConfigEventSubscriber` —— 注入）。`OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01` archtest 把 `HandleResult{...}` 字面量构造限定在 `kernel/outbox/result.go` / `outboxtest/conformance.go`（`consumer_base.go` 现构造 `DeliveryOutcome`，已移出该 allowlist）。`HandleResult` 2 字段集由 `OUTBOX-HANDLERESULT-FIELDS-FROZEN-01` 冻结、`DeliveryOutcome` 4 字段集由 `OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01` 冻结。详见 ADR `docs/architecture/202605031900-adr-handler-vocabulary-collapse.md` §Amendment 2026-06-06。
 
 ### Disposition 语义
 

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -425,8 +425,8 @@ func itestRunDispositionCase(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = sub.Subscribe(ctx, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return result, settlement
+		_ = sub.Subscribe(ctx, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: result.Disposition, Err: result.Err}, settlement
 		})
 	}()
 	itestWaitSubscribeReady(t, sub, subscription)
@@ -617,8 +617,8 @@ func itestSessionPhase1Subscribe(t *testing.T, mkCfg func() Config, ns TopicName
 	// sub1.Subscribe runs under ctx1: canceling ctx1 both drops the autopaho
 	// manager uncleanly (broker retains session) and unblocks Subscribe.
 	go func() {
-		_ = sub1.Subscribe(ctx1, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return outbox.Ack(), nil
+		_ = sub1.Subscribe(ctx1, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		})
 	}()
 	select {
@@ -680,13 +680,13 @@ func itestSessionPhase2Subscribe(t *testing.T, mkCfg func() Config, ns TopicName
 	subCtx2, subCancel2 := context.WithCancel(ctx2)
 	defer subCancel2()
 	go func() {
-		_ = sub2.Subscribe(subCtx2, subscription, func(_ context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+		_ = sub2.Subscribe(subCtx2, subscription, func(_ context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 			if isOfflineTaggedPayload(entry.Payload()) {
 				offlineReceived.Add(1)
 			} else {
 				onlineReceived.Add(1)
 			}
-			return outbox.Ack(), nil
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		})
 	}()
 	select {
@@ -1013,8 +1013,8 @@ func TestIntegration_Subscriber_DLTCapture(t *testing.T) {
 	defer subCancel()
 	go func() {
 		_ = sub.Subscribe(subCtx, subscription,
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Reject(errors.New("permanent-test")), nil
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionReject, Err: errors.New("permanent-test")}, nil
 			})
 	}()
 	select {

--- a/adapters/mqtt/subscriber.go
+++ b/adapters/mqtt/subscriber.go
@@ -435,7 +435,7 @@ func (s *Subscriber) processDelivery(ctx context.Context, pb *paho.Publish, hand
 // dispatchDisposition routes a handler result to the broker (ack / leave-unacked)
 // and settles the idempotency receipt. Mirrors adapters/rabbitmq dispatchDisposition.
 func (s *Subscriber) dispatchDisposition(
-	ctx context.Context, pb *paho.Publish, res outbox.HandleResult,
+	ctx context.Context, pb *paho.Publish, res outbox.DeliveryOutcome,
 	settlement outbox.Settlement, entry outbox.Entry, start time.Time,
 ) {
 	switch res.Disposition {
@@ -504,7 +504,7 @@ func (s *Subscriber) dispatchDisposition(
 // expired), the message is left unacked (broker redelivers) and the claim is
 // released so another holder retries — mirroring rabbitmq dispatchAck.
 func (s *Subscriber) dispatchAck(
-	ctx context.Context, pb *paho.Publish, res outbox.HandleResult,
+	ctx context.Context, pb *paho.Publish, res outbox.DeliveryOutcome,
 	settlement outbox.Settlement, entry outbox.Entry, start time.Time,
 ) {
 	if settlement != nil {

--- a/adapters/mqtt/subscriber.go
+++ b/adapters/mqtt/subscriber.go
@@ -464,7 +464,7 @@ func (s *Subscriber) dispatchDisposition(
 		if ackErr != nil {
 			outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultAckFailed, ackErr)
 		} else {
-			outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultSuccess, nil)
+			outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.RejectSettlementResult(res), nil)
 		}
 	case outbox.DispositionRequeue:
 		// Option C (ADR-050 §6): MQTT is a transport, not a work queue. Leave the

--- a/adapters/mqtt/subscriber_dispatchack_test.go
+++ b/adapters/mqtt/subscriber_dispatchack_test.go
@@ -67,6 +67,6 @@ func dispatchAckEntry(t testing.TB, topic string) (*paho.Publish, outbox.Entry) 
 // ackHandler is a trivial SubscriberHandler that always Acks with no settlement.
 // Used by tests that exercise Subscribe/Ready lifecycle and do not assert on the
 // handler result itself.
-func ackHandler(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-	return outbox.Ack(), nil
+func ackHandler(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+	return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 }

--- a/adapters/mqtt/subscriber_test.go
+++ b/adapters/mqtt/subscriber_test.go
@@ -828,6 +828,23 @@ func TestSubscriber_NotifySettlement_FiresObservers(t *testing.T) {
 			wantResult: outbox.SettlementResultSuccess,
 		},
 		{
+			// ConsumerBase exhausts its retry budget and returns a terminal
+			// Reject tagged ProcessReason=retry_exhausted; the MQTT settle loop
+			// must classify the settlement as RetryExhausted (parity with
+			// rabbitmq + eventbus), not Success.
+			name: "reject-retry-exhausted",
+			result: func(o outbox.SettlementObserver) outbox.DeliveryOutcome {
+				return outbox.DeliveryOutcome{
+					Disposition:         outbox.DispositionReject,
+					Err:                 errors.New("retry budget exhausted"),
+					ProcessReason:       outbox.ProcessReasonRetryExhausted,
+					SettlementObservers: []outbox.SettlementObserver{o},
+				}
+			},
+			wantDisp:   outbox.DispositionReject,
+			wantResult: outbox.SettlementResultRetryExhausted,
+		},
+		{
 			name: "requeue",
 			result: func(o outbox.SettlementObserver) outbox.DeliveryOutcome {
 				return outbox.DeliveryOutcome{

--- a/adapters/mqtt/subscriber_test.go
+++ b/adapters/mqtt/subscriber_test.go
@@ -203,8 +203,8 @@ func TestSubscriber_Ready_ClosesAfterSubscribe(t *testing.T) {
 	default:
 	}
 
-	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), nil
+	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	})
 	defer cancel()
 
@@ -224,7 +224,7 @@ func TestSubscriber_DispositionMatrix(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name        string
-		result      func() outbox.HandleResult
+		result      func() outbox.DeliveryOutcome
 		wantSuccess int
 		wantReason  ConsumeFailureReason
 		wantCommit  int
@@ -233,28 +233,32 @@ func TestSubscriber_DispositionMatrix(t *testing.T) {
 	}{
 		{
 			name:        "ack",
-			result:      outbox.Ack,
+			result:      func() outbox.DeliveryOutcome { return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck} },
 			wantSuccess: 1,
 			wantCommit:  1,
 			wantRelease: 0,
 		},
 		{
-			name:        "requeue",
-			result:      func() outbox.HandleResult { return outbox.Requeue(errors.New("transient")) },
+			name: "requeue",
+			result: func() outbox.DeliveryOutcome {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+			},
 			wantReason:  consumeReasonRequeue,
 			wantRelease: 1,
 			wantDLX:     0, // Option C: Requeue leaves unacked for reconnect, no $dead
 		},
 		{
-			name:        "reject",
-			result:      func() outbox.HandleResult { return outbox.Reject(errors.New("permanent")) },
+			name: "reject",
+			result: func() outbox.DeliveryOutcome {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionReject, Err: errors.New("permanent")}
+			},
 			wantReason:  consumeReasonReject,
 			wantRelease: 1,
 			wantDLX:     1, // Reject routes the envelope to $dead before ack-as-poison
 		},
 		{
 			name:        "zero-value-disposition",
-			result:      func() outbox.HandleResult { return outbox.HandleResult{} },
+			result:      func() outbox.DeliveryOutcome { return outbox.DeliveryOutcome{} },
 			wantReason:  consumeReasonUnknownDisposition,
 			wantRelease: 1,
 			wantDLX:     0, // unknown disposition degrades to Requeue (leave unacked), no $dead
@@ -279,7 +283,7 @@ func TestSubscriber_DispositionMatrix(t *testing.T) {
 			// makes the filters disjoint so no cross-subtest delivery occurs.
 			prefix := "test/disp/" + tc.name
 			subscription := newSubscription(prefix+"/+", "disp-"+tc.name+"-"+uuid.NewString())
-			cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				called.Store(true)
 				return tc.result(), settlement
 			})
@@ -343,9 +347,9 @@ func TestSubscriber_UnmarshalFail_PoisonAcked(t *testing.T) {
 
 	var handlerCalled atomic.Bool
 	subscription := newSubscription("test/poison/+", "poison-cg-"+uuid.NewString())
-	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		handlerCalled.Store(true)
-		return outbox.Ack(), nil
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	})
 	defer cancel()
 
@@ -452,12 +456,12 @@ func TestSubscriber_CompetingConsumers_ShareDistributes(t *testing.T) {
 	var dup atomic.Int64
 
 	mkHandler := func(counter *atomic.Int64) outbox.SubscriberHandler {
-		return func(_ context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+		return func(_ context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 			counter.Add(1)
 			if _, loaded := seen.LoadOrStore(string(entry.Payload()), struct{}{}); loaded {
 				dup.Add(1)
 			}
-			return outbox.Ack(), nil
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		}
 	}
 
@@ -501,11 +505,11 @@ func TestSubscriber_StopIntake_DrainsInFlight(t *testing.T) {
 	var once sync.Once
 
 	subscription := newSubscription("test/drain/+", "drain-cg-"+uuid.NewString())
-	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		once.Do(func() { close(entered) })
 		<-release
 		completed.Store(true)
-		return outbox.Ack(), nil
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	})
 	defer cancel()
 
@@ -585,8 +589,8 @@ func TestSubscriber_Close_StopsBlockedSubscribe(t *testing.T) {
 
 	subscription := newSubscription("test/block/+", "block-cg-"+uuid.NewString())
 	subDone := make(chan error, 1)
-	ackHandler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), nil
+	ackHandler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	}
 	go func() {
 		subDone <- sub.Subscribe(context.Background(), subscription, ackHandler)
@@ -622,8 +626,8 @@ func TestSubscriber_MetricsEmission(t *testing.T) {
 
 	// First message acked (success), second is poison (failure).
 	subscription := newSubscription("test/metrics/+", "metrics-cg-"+uuid.NewString())
-	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), &recordingSettlement{}
+	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, &recordingSettlement{}
 	})
 	defer cancel()
 
@@ -673,7 +677,7 @@ func TestSubscriber_DispatchAck_AckFailsAfterCommit(t *testing.T) {
 
 	settlement := &recordingSettlement{} // commitErr nil → Commit succeeds
 	pb, entry := dispatchAckEntry(t, "test/ackfail/x")
-	sub.dispatchAck(context.Background(), pb, outbox.Ack(), settlement, entry, time.Now())
+	sub.dispatchAck(context.Background(), pb, outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, settlement, entry, time.Now())
 
 	success, failure, lastReason := coll.snapshot()
 	commit, release := settlement.counts()
@@ -698,7 +702,7 @@ func TestSubscriber_DispatchAck_CommitFails(t *testing.T) {
 
 	settlement := &recordingSettlement{commitErr: errors.New("lease expired")}
 	pb, entry := dispatchAckEntry(t, "test/commitfail/x")
-	sub.dispatchAck(context.Background(), pb, outbox.Ack(), settlement, entry, time.Now())
+	sub.dispatchAck(context.Background(), pb, outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, settlement, entry, time.Now())
 
 	success, failure, lastReason := coll.snapshot()
 	commit, release := settlement.counts()
@@ -737,10 +741,10 @@ func TestSubscriber_StopIntake_DrainTimeout(t *testing.T) {
 	t.Cleanup(func() { close(release) })
 
 	subscription := newSubscription("test/draintimeout/+", "draintimeout-cg-"+uuid.NewString())
-	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		once.Do(func() { close(entered) })
 		<-release // blocks until cleanup; keeps inflight > 0 past the drain budget
-		return outbox.Ack(), nil
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	})
 	defer cancel()
 
@@ -796,14 +800,14 @@ func TestSubscriber_NotifySettlement_FiresObservers(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name       string
-		result     func(obs outbox.SettlementObserver) outbox.HandleResult
+		result     func(obs outbox.SettlementObserver) outbox.DeliveryOutcome
 		wantDisp   outbox.Disposition
 		wantResult outbox.SettlementResult
 	}{
 		{
 			name: "ack",
-			result: func(o outbox.SettlementObserver) outbox.HandleResult {
-				return outbox.HandleResult{
+			result: func(o outbox.SettlementObserver) outbox.DeliveryOutcome {
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionAck,
 					SettlementObservers: []outbox.SettlementObserver{o},
 				}
@@ -813,8 +817,8 @@ func TestSubscriber_NotifySettlement_FiresObservers(t *testing.T) {
 		},
 		{
 			name: "reject",
-			result: func(o outbox.SettlementObserver) outbox.HandleResult {
-				return outbox.HandleResult{
+			result: func(o outbox.SettlementObserver) outbox.DeliveryOutcome {
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionReject,
 					Err:                 errors.New("permanent"),
 					SettlementObservers: []outbox.SettlementObserver{o},
@@ -825,8 +829,8 @@ func TestSubscriber_NotifySettlement_FiresObservers(t *testing.T) {
 		},
 		{
 			name: "requeue",
-			result: func(o outbox.SettlementObserver) outbox.HandleResult {
-				return outbox.HandleResult{
+			result: func(o outbox.SettlementObserver) outbox.DeliveryOutcome {
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionRequeue,
 					Err:                 errors.New("transient"),
 					SettlementObservers: []outbox.SettlementObserver{o},
@@ -860,7 +864,7 @@ func TestSubscriber_NotifySettlement_FiresObservers(t *testing.T) {
 
 			prefix := "test/notify/" + tc.name
 			subscription := newSubscription(prefix+"/+", "notify-"+tc.name+"-"+uuid.NewString())
-			cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			cancel := startSubscribe(t, sub, subscription, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				return tc.result(obs), &recordingSettlement{}
 			})
 			defer cancel()
@@ -908,14 +912,14 @@ func TestSubscriber_ConcurrentDispatch_SlowHandlerDoesNotBlock(t *testing.T) {
 	})
 
 	subscription := newSubscription("test/conc/+", "conc-cg-"+uuid.NewString())
-	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	cancel := startSubscribe(t, sub, subscription, func(_ context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		if string(entry.Payload()) == slowPayload {
 			slowEntered.Store(true)
 			<-block // block until released
 		} else {
 			fastDone.Store(true)
 		}
-		return outbox.Ack(), nil
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	})
 	defer cancel()
 

--- a/adapters/rabbitmq/entry_lift_test.go
+++ b/adapters/rabbitmq/entry_lift_test.go
@@ -14,7 +14,8 @@ import (
 // This helper replaces the deleted outbox.EntryToSubscriberHandler in test-only
 // code. Production callers use SubscriberWithMiddleware.SubscribeEntry instead.
 func entryToSubHandler(h outbox.EntryHandler) outbox.SubscriberHandler {
-	return func(ctx context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return h(ctx, entry), nil
+	return func(ctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		r := h(ctx, entry)
+		return outbox.DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}, nil
 	}
 }

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -2915,8 +2915,8 @@ func TestProcessDelivery_Ack_CommitsReceipt(t *testing.T) {
 	entry := mustNewEntry(t, "test.ack", []byte(`{}`), outbox.WithID("evt-ack-receipt"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx := context.Background()
@@ -2951,8 +2951,8 @@ func TestProcessDelivery_Reject_ReleasesReceipt(t *testing.T) {
 	entry := mustNewEntry(t, "test.reject", []byte(`{}`), outbox.WithID("evt-reject-receipt"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Reject(errors.New("permanent")), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionReject, Err: errors.New("permanent")}, receipt
 	}
 
 	ctx := context.Background()
@@ -3126,8 +3126,8 @@ func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
 	entry := mustNewEntry(t, "test.ctx", []byte(`{}`), outbox.WithID("evt-detached-ctx"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	// Use a canceled context to simulate shutdown.
@@ -3164,8 +3164,8 @@ func TestProcessDelivery_Requeue_ReleasesReceipt(t *testing.T) {
 	entry := mustNewEntry(t, "test.requeue", []byte(`{}`), outbox.WithID("evt-requeue-receipt"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Requeue(errors.New("transient")), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}, receipt
 	}
 
 	sub.wg.Add(1)
@@ -3245,8 +3245,8 @@ func TestProcessDelivery_BrokerAckFails_CommitAlreadyDone(t *testing.T) {
 	entry := mustNewEntry(t, "test.brokerfail", []byte(`{}`), outbox.WithID("evt-broker-fail"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx := context.Background()
@@ -3279,8 +3279,8 @@ func TestProcessDelivery_CommitFails_NackRequeueSuccess_ReleasesReceipt(t *testi
 	entry := mustNewEntry(t, "test.commitfail", []byte(`{}`), outbox.WithID("evt-commit-fail-release"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	sub.wg.Add(1)
@@ -3317,8 +3317,8 @@ func TestProcessDelivery_CommitFails_NackRequeueFails_ReleasesReceipt(t *testing
 	entry := mustNewEntry(t, "test.commitfail.nackfail", []byte(`{}`), outbox.WithID("evt-commit-fail-nack-fail-release"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	sub.wg.Add(1)
@@ -3520,8 +3520,8 @@ func TestProcessDelivery_Requeue_BrokerNackFails_ReleasesReceipt(t *testing.T) {
 	entry := mustNewEntry(t, "test.requeue.nackfail", []byte(`{}`), outbox.WithID("evt-requeue-nack-fail"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Requeue(errors.New("transient")), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}, receipt
 	}
 
 	sub.wg.Add(1)
@@ -3647,8 +3647,8 @@ func TestProcessDelivery_UnknownDisposition_NackWithRequeue(t *testing.T) {
 	entry := mustNewEntry(t, "test.unknown", []byte(`{}`), outbox.WithID("evt-unknown-disp"))
 	entryBytes := makeDeliveryBody(t, entry)
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.HandleResult{
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{
 			Disposition: outbox.Disposition(99),
 		}, receipt
 	}

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -835,7 +835,7 @@ func (s *Subscriber) processDelivery(
 	// adapter transport-only.
 	deliveryCtx := ctx
 
-	// SubscriberHandler returns (HandleResult, Settlement). Settlement is the
+	// SubscriberHandler returns (DeliveryOutcome, Settlement). Settlement is the
 	// idempotency commit/release handle from ConsumerBase.Wrap (nil when no
 	// idempotency state is present — ClaimDone, ClaimBusy, fail-open errors).
 	res, settlement := handler(deliveryCtx, entry)
@@ -868,7 +868,7 @@ func (s *Subscriber) dispatchDisposition(
 	ctx context.Context,
 	ch AMQPChannel,
 	tag uint64,
-	res outbox.HandleResult,
+	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
 	topic string,
 	entry outbox.Entry,
@@ -930,7 +930,7 @@ func (s *Subscriber) dispatchAck(
 	ctx context.Context,
 	ch AMQPChannel,
 	tag uint64,
-	res outbox.HandleResult,
+	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
 	topic string,
 	entry outbox.Entry,

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -878,10 +878,7 @@ func (s *Subscriber) dispatchDisposition(
 	case outbox.DispositionAck:
 		s.dispatchAck(ctx, ch, tag, res, settlement, topic, entry)
 	case outbox.DispositionReject:
-		rejectResult := outbox.SettlementResultSuccess
-		if res.ProcessReason == "retry_exhausted" {
-			rejectResult = outbox.SettlementResultRetryExhausted
-		}
+		rejectResult := outbox.RejectSettlementResult(res)
 		if nackErr := ch.Nack(tag, false, false); nackErr != nil {
 			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(reject) failed",
 				slog.String(logKeyTopic, topic),

--- a/adapters/rabbitmq/subscriber_test.go
+++ b/adapters/rabbitmq/subscriber_test.go
@@ -241,8 +241,8 @@ func TestProcessDelivery_CommitFailsAfterLeaseLost_NacksRequeue(t *testing.T) {
 
 	receipt := &mockReceipt{commitErr: errors.New("lease expired: token mismatch")}
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -299,8 +299,8 @@ func TestProcessDelivery_CommitSuccess_AcksAndDoesNotRelease(t *testing.T) {
 
 	receipt := &mockReceipt{} // commitErr = nil → success
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -433,9 +433,9 @@ func TestSubscriber_ConcurrentReceiptCommitSafety(t *testing.T) {
 	mockConn.nextCh = ch
 	mockConn.mu.Unlock()
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		receipt := &countingReceipt{counter: &commitCount}
-		return outbox.Ack(), receipt
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -791,8 +791,8 @@ func TestDispatchAck_CommitFail_NackFail(t *testing.T) {
 	commitErr := errors.New("lease expired")
 	receipt := &mockReceipt{commitErr: commitErr}
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -856,8 +856,8 @@ func TestDispatchAck_CommitFailed_ReleasesBeforeNack(t *testing.T) {
 		commitErr: errors.New("lease expired"),
 		recorder:  rec,
 	}
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -922,8 +922,8 @@ func TestDispatchAck_AckFail(t *testing.T) {
 	})
 
 	receipt := &mockReceipt{} // commitErr nil → Commit succeeds
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1147,8 +1147,8 @@ func TestReleaseReceipt_ReleaseFail(t *testing.T) {
 
 	receipt := &mockReceipt{releaseErr: errors.New("release store unavailable")}
 
-	handler := func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Reject(nil), receipt
+	handler := func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionReject}, receipt
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1209,6 +1209,16 @@ func (s *spySettlementObserver) len() int {
 	return len(s.obs)
 }
 
+// subHandlerWithObserver returns a SubscriberHandler yielding disposition d with
+// obs attached as a settlement observer. Settlement is nil: these tests drive
+// final broker settlement through the subscriber's NotifySettlement, not the
+// handler return.
+func subHandlerWithObserver(d outbox.Disposition, obs outbox.SettlementObserver) outbox.SubscriberHandler {
+	return func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: d, SettlementObservers: []outbox.SettlementObserver{obs}}, nil
+	}
+}
+
 // TestDispatchAck_AckErr_NotifiesAckFailed verifies that when ch.Ack returns an
 // error, the spy settlement observer receives AckFailed with the broker error.
 func TestDispatchAck_AckErr_NotifiesAckFailed(t *testing.T) {
@@ -1228,12 +1238,7 @@ func TestDispatchAck_AckErr_NotifiesAckFailed(t *testing.T) {
 		DLXExchange: "test.dlx",
 	})
 
-	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-		return outbox.HandleResult{
-			Disposition:         outbox.DispositionAck,
-			SettlementObservers: []outbox.SettlementObserver{spy},
-		}
-	}
+	handler := subHandlerWithObserver(outbox.DispositionAck, spy)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1243,7 +1248,7 @@ func TestDispatchAck_AckErr_NotifiesAckFailed(t *testing.T) {
 
 	subDone := make(chan error, 1)
 	go func() {
-		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
+		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, handler)
 	}()
 
 	testwait.External(t, "amqp-delivery-acked", func() bool {
@@ -1284,12 +1289,7 @@ func TestDispatchDisposition_RejectNackErr_NotifiesNackFailed(t *testing.T) {
 		DLXExchange: "test.dlx",
 	})
 
-	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-		return outbox.HandleResult{
-			Disposition:         outbox.DispositionReject,
-			SettlementObservers: []outbox.SettlementObserver{spy},
-		}
-	}
+	handler := subHandlerWithObserver(outbox.DispositionReject, spy)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1299,7 +1299,7 @@ func TestDispatchDisposition_RejectNackErr_NotifiesNackFailed(t *testing.T) {
 
 	subDone := make(chan error, 1)
 	go func() {
-		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
+		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, handler)
 	}()
 
 	testwait.External(t, "amqp-delivery-nacked", func() bool {
@@ -1342,12 +1342,7 @@ func TestDispatchDisposition_RequeueNackErr_NotifiesNackFailed(t *testing.T) {
 		DLXExchange: "test.dlx",
 	})
 
-	handler := func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-		return outbox.HandleResult{
-			Disposition:         outbox.DispositionRequeue,
-			SettlementObservers: []outbox.SettlementObserver{spy},
-		}
-	}
+	handler := subHandlerWithObserver(outbox.DispositionRequeue, spy)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1357,7 +1352,7 @@ func TestDispatchDisposition_RequeueNackErr_NotifiesNackFailed(t *testing.T) {
 
 	subDone := make(chan error, 1)
 	go func() {
-		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, entryToSubHandler(handler))
+		subDone <- sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"}, handler)
 	}()
 
 	testwait.External(t, "amqp-delivery-nacked", func() bool {

--- a/cells/accesscore/slices/configreceive/service_test.go
+++ b/cells/accesscore/slices/configreceive/service_test.go
@@ -51,11 +51,10 @@ func (c *recordingConfigEventCollector) RecordEventSettlement(_ context.Context,
 // callWithConfigEventOwner runs handler through ConfigEventMiddleware and returns
 // (disposition, err) extracted from the HandleResult.
 func callWithConfigEventOwner(
-	collector obmetrics.ConfigEventCollector,
 	entry outbox.Entry,
 	fn outbox.EntryHandler,
 ) (outbox.Disposition, error) {
-	wrapped := obmetrics.ConfigEventMiddleware(collector)(
+	wrapped := obmetrics.ConfigEventMiddleware()(
 		outbox.Subscription{Topic: entry.Topic(), ConsumerGroup: "accesscore", CellID: "accesscore", SliceID: "configreceive"},
 		fn,
 	)
@@ -313,7 +312,7 @@ func TestHandleEntryUpserted_ConfigEventMetricsOutcomes(t *testing.T) {
 			svc := NewService(slog.Default(), opts...)
 			entry := outboxtest.NewEntry(TopicConfigEntryUpserted, tt.payload)
 
-			disposition, _ := callWithConfigEventOwner(collector, entry, svc.HandleEntryUpserted)
+			disposition, _ := callWithConfigEventOwner(entry, svc.HandleEntryUpserted)
 			assert.Equal(t, tt.wantDisposition, disposition)
 			assert.Equal(t, tt.wantRecords, collector.records)
 		})
@@ -434,7 +433,7 @@ func TestHandleEntryDeleted_ConfigEventMetricsOutcomes(t *testing.T) {
 			svc := NewService(slog.Default(), WithConfigEventCollector(collector))
 			entry := outboxtest.NewEntry(TopicConfigEntryDeleted, tt.payload)
 
-			disposition, _ := callWithConfigEventOwner(collector, entry, svc.HandleEntryDeleted)
+			disposition, _ := callWithConfigEventOwner(entry, svc.HandleEntryDeleted)
 			assert.Equal(t, tt.wantDisposition, disposition)
 			assert.Equal(t, tt.wantRecords, collector.records)
 		})

--- a/cells/configcore/slices/configsubscribe/service_test.go
+++ b/cells/configcore/slices/configsubscribe/service_test.go
@@ -102,12 +102,11 @@ func (c *recordingConfigEventCollector) RecordEventSettlement(_ context.Context,
 }
 
 func callWithConfigEventOwner(
-	collector obmetrics.ConfigEventCollector,
 	entry outbox.Entry,
 	fn func(context.Context, outbox.Entry) outbox.HandleResult,
 ) outbox.HandleResult {
 	var result outbox.HandleResult
-	wrapped := obmetrics.ConfigEventMiddleware(collector)(
+	wrapped := obmetrics.ConfigEventMiddleware()(
 		outbox.Subscription{Topic: entry.Topic(), ConsumerGroup: "configcore", CellID: "configcore", SliceID: "configsubscribe"},
 		func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 			result = fn(ctx, entry)
@@ -528,7 +527,7 @@ func TestService_ConfigEventMetrics_EntryUpsertedOutcomes(t *testing.T) {
 				collector.records = nil
 			}
 
-			result := callWithConfigEventOwner(collector, tt.entry, svc.HandleEntryUpserted)
+			result := callWithConfigEventOwner(tt.entry, svc.HandleEntryUpserted)
 			if tt.wantReject {
 				assert.Equal(t, outbox.DispositionReject, result.Disposition)
 			} else {
@@ -604,7 +603,7 @@ func TestService_ConfigEventMetrics_EntryDeletedOutcomes(t *testing.T) {
 				collector.records = nil
 			}
 
-			result := callWithConfigEventOwner(collector, tt.entry, svc.HandleEntryDeleted)
+			result := callWithConfigEventOwner(tt.entry, svc.HandleEntryDeleted)
 			if tt.wantReject {
 				assert.Equal(t, outbox.DispositionReject, result.Disposition)
 			} else {

--- a/cmd/corebundle/bundle_options.go
+++ b/cmd/corebundle/bundle_options.go
@@ -56,7 +56,7 @@ func runtimeBaseOptions(
 		// conversion boundary: idempotency Claim/Commit/Release + retry live here,
 		// after the business middleware chain.
 		bootstrap.WithConsumerBase(consumerBase),
-		bootstrap.WithConsumerMiddleware(consumerMiddlewares(shared)...),
+		bootstrap.WithConsumerMiddleware(consumerMiddlewares()...),
 		bootstrap.WithConfigEventCollector(shared.ConfigEventCollector),
 		bootstrap.WithSubscriptionValidator(obmetrics.ConfigEventOwnerValidator),
 		bootstrap.WithAdapterInfo(adapterInfo),
@@ -78,14 +78,10 @@ func runtimeBaseOptions(
 	return opts
 }
 
-func consumerMiddlewares(shared *composition.SharedDeps) []outbox.SubscriptionMiddleware {
+func consumerMiddlewares() []outbox.SubscriptionMiddleware {
 	return []outbox.SubscriptionMiddleware{
-		configEventConsumerMiddleware(shared.ConfigEventCollector),
+		obmetrics.ConfigEventMiddleware(),
 	}
-}
-
-func configEventConsumerMiddleware(collector obmetrics.ConfigEventCollector) outbox.SubscriptionMiddleware {
-	return obmetrics.ConfigEventMiddleware(collector)
 }
 
 // newBootstrapFromOptions creates a bootstrap.Bootstrap from a pre-built option

--- a/cmd/corebundle/bundle_options.go
+++ b/cmd/corebundle/bundle_options.go
@@ -57,6 +57,7 @@ func runtimeBaseOptions(
 		// after the business middleware chain.
 		bootstrap.WithConsumerBase(consumerBase),
 		bootstrap.WithConsumerMiddleware(consumerMiddlewares(shared)...),
+		bootstrap.WithConfigEventCollector(shared.ConfigEventCollector),
 		bootstrap.WithSubscriptionValidator(obmetrics.ConfigEventOwnerValidator),
 		bootstrap.WithAdapterInfo(adapterInfo),
 		bootstrap.WithHealthRoutes(healthRouteOpts...),

--- a/cmd/corebundle/config_event_metrics_wiring_test.go
+++ b/cmd/corebundle/config_event_metrics_wiring_test.go
@@ -27,23 +27,45 @@ func newConfigEventEntry(t *testing.T, id string) outbox.Entry {
 	return entry
 }
 
-func TestConfigEventConsumerMiddlewareUsesSubscriptionOwnerMetadata(t *testing.T) {
+// TestConfigEventSettlement_RecordsOwnerMetadataOnAck verifies the config-event
+// settlement metric carries subscription owner metadata (cell + slice) on the
+// success path. Post-#663 the settlement observer is appended at the
+// SubscriberHandler layer by WrapConfigEventSubscriber (mirroring
+// eventrouter.contractTracingSubscriber), not by the EntryHandler-layer
+// ConfigEventMiddleware (which now only injects owner ctx).
+func TestConfigEventSettlement_RecordsOwnerMetadataOnAck(t *testing.T) {
 	collector := &recordingCoreConfigEventCollector{}
-	mw := configEventConsumerMiddleware(collector)
+	shared, _ := buildTestSharedDepsAndLocals(t)
+	shared.ConfigEventCollector = collector
+	consumerBase, err := outbox.NewConsumerBase(idempotency.NewInMemClaimer(clock.Real()), outbox.ConsumerBaseConfig{
+		RetryCount:     2,
+		RetryBaseDelay: time.Millisecond,
+	}, clock.Real())
+	require.NoError(t, err)
+
+	var capturedHandler outbox.SubscriberHandler
+	inner := &captureSubscriberHandler{onSubscribe: func(h outbox.SubscriberHandler) { capturedHandler = h }}
+
 	sub := outbox.Subscription{
-		Topic:         "event.config.entry-upserted.v1",
-		ConsumerGroup: "accesscore",
-		CellID:        "accesscore",
-		SliceID:       "configreceive",
+		Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore",
+		CellID: "accesscore", SliceID: "configreceive",
+		ContractID: "event.config.entry-upserted.v1", ContractKind: "event", ContractTransport: "memory",
 	}
-	entry := newConfigEventEntry(t, "evt-target")
-	wrapped := mw(sub, func(context.Context, outbox.Entry) outbox.HandleResult {
-		return outbox.Ack()
-	})
 
-	result := wrapped(context.Background(), entry)
-	outbox.NotifySettlement(context.Background(), result, entry, outbox.DispositionAck, outbox.SettlementResultSuccess, nil)
+	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares(shared)...)
+	require.NoError(t, err)
+	require.NoError(t, wrappedSub.SubscribeEntry(context.Background(), sub,
+		func(context.Context, outbox.Entry) outbox.HandleResult { return outbox.Ack() }))
+	require.NotNil(t, capturedHandler)
 
+	// Mirror eventrouter.contractTracingSubscriber: the settlement observer lives
+	// at the SubscriberHandler layer via WrapConfigEventSubscriber.
+	settleHandler := obmetrics.WrapConfigEventSubscriber(collector, sub, capturedHandler)
+	entry := newConfigEventEntry(t, "evt-ack")
+	result, _ := settleHandler(context.Background(), entry)
+	outbox.NotifySettlement(context.Background(), result, entry, result.Disposition, outbox.SettlementResultSuccess, nil)
+
+	assert.Equal(t, outbox.DispositionAck, result.Disposition)
 	require.Equal(t, []coreConfigEventSettlementRecord{{
 		cell: "accesscore", slice: "configreceive", disposition: "ack", result: outbox.SettlementResultSuccess,
 	}}, collector.settlementRecords)
@@ -94,7 +116,8 @@ func TestConsumerMiddlewares_ConfigEventSettlementRunsOutsideConsumerBase(t *tes
 	require.NotNil(t, capturedHandler)
 
 	entry := newConfigEventEntry(t, "evt-retry-exhausted")
-	result, _ := capturedHandler(context.Background(), entry)
+	settleHandler := obmetrics.WrapConfigEventSubscriber(collector, sub, capturedHandler)
+	result, _ := settleHandler(context.Background(), entry)
 	outbox.NotifySettlement(context.Background(), result, entry, result.Disposition, outbox.SettlementResultRetryExhausted, nil)
 
 	assert.Equal(t, 2, attempts)
@@ -132,7 +155,8 @@ func TestConsumerMiddlewares_PermanentErrorRecordedAsFinalRejectSettlement(t *te
 	require.NotNil(t, capturedHandler)
 
 	entry := newConfigEventEntry(t, "evt-permanent")
-	result, _ := capturedHandler(context.Background(), entry)
+	settleHandler := obmetrics.WrapConfigEventSubscriber(collector, sub, capturedHandler)
+	result, _ := settleHandler(context.Background(), entry)
 	outbox.NotifySettlement(context.Background(), result, entry, result.Disposition, outbox.SettlementResultSuccess, nil)
 
 	assert.Equal(t, outbox.DispositionReject, result.Disposition)

--- a/cmd/corebundle/config_event_metrics_wiring_test.go
+++ b/cmd/corebundle/config_event_metrics_wiring_test.go
@@ -52,7 +52,7 @@ func TestConfigEventSettlement_RecordsOwnerMetadataOnAck(t *testing.T) {
 		ContractID: "event.config.entry-upserted.v1", ContractKind: "event", ContractTransport: "memory",
 	}
 
-	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares(shared)...)
+	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares()...)
 	require.NoError(t, err)
 	require.NoError(t, wrappedSub.SubscribeEntry(context.Background(), sub,
 		func(context.Context, outbox.Entry) outbox.HandleResult { return outbox.Ack() }))
@@ -106,7 +106,7 @@ func TestConsumerMiddlewares_ConfigEventSettlementRunsOutsideConsumerBase(t *tes
 	}
 
 	attempts := 0
-	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares(shared)...)
+	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares()...)
 	require.NoError(t, err)
 	require.NoError(t, wrappedSub.SubscribeEntry(context.Background(), sub,
 		func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -146,7 +146,7 @@ func TestConsumerMiddlewares_PermanentErrorRecordedAsFinalRejectSettlement(t *te
 		ContractID: "event.config.entry-upserted.v1", ContractKind: "event", ContractTransport: "memory",
 	}
 
-	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares(shared)...)
+	wrappedSub, err := outbox.NewSubscriberWithMiddleware(inner, consumerBase, consumerMiddlewares()...)
 	require.NoError(t, err)
 	require.NoError(t, wrappedSub.SubscribeEntry(context.Background(), sub,
 		func(_ context.Context, _ outbox.Entry) outbox.HandleResult {

--- a/cmd/corebundle/integration_testhelpers_test.go
+++ b/cmd/corebundle/integration_testhelpers_test.go
@@ -135,8 +135,9 @@ func withCorebundleTestInternalListener(t *testing.T, ln net.Listener) bootstrap
 // code (mirroring runtime/eventbus/entry_lift_test.go::entryToSubHandler).
 // Production callers use SubscriberWithMiddleware.SubscribeEntry instead.
 func entryToSubHandler(h outbox.EntryHandler) outbox.SubscriberHandler {
-	return func(ctx context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return h(ctx, entry), nil
+	return func(ctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		r := h(ctx, entry)
+		return outbox.DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}, nil
 	}
 }
 

--- a/docs/architecture/202605031900-adr-handler-vocabulary-collapse.md
+++ b/docs/architecture/202605031900-adr-handler-vocabulary-collapse.md
@@ -149,6 +149,46 @@ that was explicitly accepted in K#03.
   deleted; `SubscriberHandler` now returns `(HandleResult, Settlement)` as
   second value; `adapters/rabbitmq` no longer imports `kernel/idempotency`.
 
+## Amendment 2026-06-06 — #663 HandleResult business-slim + DeliveryOutcome carrier
+
+[OUTBOX-HANDLERESULT-SLIM-01] splits the dual-purpose `HandleResult` into two
+types so the business handler return surface is minimal:
+
+- **Business face** — `HandleResult` is now `{Disposition, Err}` only. The
+  `EntryHandler` signature is unchanged (`func(ctx, Entry) HandleResult`); only
+  the return type is slimmer. Business handlers were already 100% factory
+  (`Ack/Requeue/Reject`) and touched neither removed field, so no cell handler
+  changed.
+- **Subscriber face** — new `DeliveryOutcome{Disposition, Err, ProcessReason,
+  SettlementObservers}` carries the kernel-internal `ProcessReason` (today only
+  `"retry_exhausted"`) plus the settlement-observer channel. `ConsumerBase.Wrap`
+  is the sole `HandleResult → DeliveryOutcome` promotion point; `retryLoop` no
+  longer threads observers through its return paths (the EntryHandler return no
+  longer carries them — the propagation plumbing is deleted outright).
+- **`SubscriberHandler` now returns `(DeliveryOutcome, Settlement)`** — this
+  supersedes the `(HandleResult, Settlement)` wording in Decision 3, Trade-off
+  Q1, and the Future-Work K#12 note above. `NotifySettlement` takes a
+  `DeliveryOutcome`.
+- **Settlement observers move to the subscriber layer**, extending Decision 3's
+  "settle is a subscriber-layer boundary, not a middleware concern" principle
+  (Watermill `handleMessage` ack/nack monopoly). The config-event settlement
+  observer is no longer appended by the EntryHandler-layer `ConfigEventMiddleware`
+  (which now only injects owner ctx for process metrics); it is appended at the
+  SubscriberHandler layer by `obmetrics.WrapConfigEventSubscriber`, applied by
+  `eventrouter.contractTracingSubscriber` next to `wrapper.WrapSubscriber`.
+
+Enforcement: `OUTBOX-HANDLERESULT-FIELDS-FROZEN-01` now freezes the 2-field
+business set; new `OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01` freezes the 4-field
+carrier. `OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01`'s allowlist drops
+`consumer_base.go` (it now constructs `DeliveryOutcome`, not `HandleResult`). No
+`DeliveryOutcome` literal-construction archtest is added: business code has no
+use for the type (it cannot return it from `EntryHandler` nor hand it to a
+subscriber), so the business-face collapse is already type-system Hard. This ADR
+carries no threat matrix, so there is no security-model row to re-evaluate.
+
+ref: ThreeDotsLabs/watermill components/metrics/handler.go — instrumentation via
+middleware/defer over the handler error, never an observer carried in the return
+
 ## References
 
 - `ref: ThreeDotsLabs/watermill message/router.go` — handler returns

--- a/examples/iotdevice/mqtt_smoke_test.go
+++ b/examples/iotdevice/mqtt_smoke_test.go
@@ -226,12 +226,12 @@ func TestMQTTSmoke_DeviceRegisterPublishesToBroker(t *testing.T) {
 	t.Cleanup(runCancel)
 	go func() {
 		_ = sub.Subscribe(runCtx, subscription,
-			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, e outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				select {
 				case received <- e:
 				default:
 				}
-				return outbox.Ack(), noopSettlement{}
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, noopSettlement{}
 			})
 	}()
 	// Deterministic channel waits — no caller-supplied wall-clock budget (issue

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -209,9 +209,11 @@ func ExponentialDelay(base, maxDelay time.Duration, attempt int) time.Duration {
 // handled by the broker via DLX (DispositionReject triggers Nack requeue=false).
 //
 // Settlement flows to the Subscriber delivery loop via the second return value
-// of SubscriberHandler: ConsumerBase.Wrap returns (HandleResult, Settlement)
+// of SubscriberHandler: ConsumerBase.Wrap returns (DeliveryOutcome, Settlement)
 // so that Commit/Release can be called after broker Ack/Nack without leaking
-// idempotency types into business code. Business handlers only return HandleResult.
+// idempotency types into business code. Business handlers only return the slim
+// HandleResult; ConsumerBase lifts it to DeliveryOutcome, injecting
+// ProcessReason (e.g. "retry_exhausted") as needed.
 //
 // Lives in kernel/outbox rather than adapters/rabbitmq because the logic is
 // broker-agnostic — it only depends on kernel/idempotency + outbox types —
@@ -320,14 +322,22 @@ func (cb *ConsumerBase) AttachObserver(o ConsumerObserver) error {
 	return nil
 }
 
-// Wrap returns an EntryHandler that wraps the given business handler with
+// deliveryFrom converts a slim HandleResult into a DeliveryOutcome. It copies
+// only the fields that business handlers can express (Disposition + Err); the
+// subscriber-layer fields (ProcessReason, SettlementObservers) start empty and
+// are filled in by ConsumerBase / subscriber-layer middleware.
+func deliveryFrom(r HandleResult) DeliveryOutcome {
+	return DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}
+}
+
+// Wrap returns a SubscriberHandler that wraps the given business handler with
 // two-phase Claim/Commit/Release idempotency and retry with exponential backoff.
 //
 // The idempotency key is constructed as "{sub.ConsumerGroup}:{entry.id}",
 // ensuring cross-cell fanout correctness: each cell's ConsumerGroup forms a
 // separate namespace so ClaimDone in one cell does not silence another.
 //
-// The Receipt is threaded through HandleResult -- ConsumerBase never calls
+// The Receipt is threaded through DeliveryOutcome -- ConsumerBase never calls
 // Commit/Release itself; that is the delivery loop's job after broker Ack/Nack.
 //
 // Fail-open (ClaimPolicyFailOpen): single Claim attempt; on error, proceed
@@ -345,7 +355,7 @@ func (cb *ConsumerBase) AttachObserver(o ConsumerObserver) error {
 //   - handler returns DispositionReject -> pass through as Reject
 //   - handler returns error with non-Ack disposition -> retry with backoff
 //   - DispositionReject (handler-explicit) -> Reject (broker routes to DLX)
-//   - retry budget exhausted -> Reject
+//   - retry budget exhausted -> Reject with ProcessReason="retry_exhausted"
 //   - ctx canceled / shutdown -> Requeue
 //
 // Wrap lifts a business EntryHandler into a SubscriberHandler that includes
@@ -361,7 +371,7 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 	topic := sub.Topic
 	consumerGroup := sub.ConsumerGroup
 	cellID := sub.CellID
-	return func(ctx context.Context, entry Entry) (HandleResult, Settlement) {
+	return func(ctx context.Context, entry Entry) (DeliveryOutcome, Settlement) {
 		idempotencyKey := fmt.Sprintf("%s:%s", consumerGroup, entry.id)
 
 		// Fail-open: single Claim attempt, proceed without idempotency on error.
@@ -387,7 +397,7 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 				slog.String(logKeyConsumerGroup, consumerGroup),
 				slog.Int("claim_retry_count", cb.config.ClaimRetryCount),
 				slog.Any("error", err))
-			return Requeue(err), nil
+			return deliveryFrom(Requeue(err)), nil
 		}
 		return cb.handleClaimState(ctx, deliveryDims{cellID: cellID, consumerGroup: consumerGroup, topic: topic}, entry, handler, state, receipt)
 	}
@@ -471,7 +481,7 @@ type deliveryDims struct {
 
 // handleClaimState dispatches on the Claim result state. Both fail-open and
 // fail-closed paths share the same ClaimDone / ClaimBusy / ClaimAcquired logic.
-// Returns (HandleResult, Settlement) so Settlement flows to the Subscriber.
+// Returns (DeliveryOutcome, Settlement) so Settlement flows to the Subscriber.
 // Settlement is nil for ClaimDone and ClaimBusy (no idempotency state to settle).
 func (cb *ConsumerBase) handleClaimState(
 	ctx context.Context,
@@ -480,14 +490,14 @@ func (cb *ConsumerBase) handleClaimState(
 	handler EntryHandler,
 	state idempotency.ClaimState,
 	receipt idempotency.Receipt,
-) (HandleResult, Settlement) {
+) (DeliveryOutcome, Settlement) {
 	cellID, consumerGroup, topic := dims.cellID, dims.consumerGroup, dims.topic
 	switch state {
 	case idempotency.ClaimDone:
 		logWithContext(ctx, slog.LevelDebug, "outbox: event already processed, skipping",
 			slog.String(logKeyEventID, entry.id),
 			slog.String(logKeyTopic, topic))
-		return Ack(), nil
+		return deliveryFrom(Ack()), nil
 	case idempotency.ClaimBusy:
 		delay := cb.config.RetryBaseDelay
 		logWithContext(ctx, slog.LevelDebug, "outbox: event being processed by another consumer, requeuing after backoff",
@@ -501,7 +511,7 @@ func (cb *ConsumerBase) handleClaimState(
 		case <-ctx.Done():
 			t.Stop()
 		}
-		return Requeue(nil), nil
+		return deliveryFrom(Requeue(nil)), nil
 	default:
 		// ClaimAcquired -- start lease-renewal goroutine before invoking handler.
 		result := cb.runWithRenewal(ctx, cellID, consumerGroup, topic, entry, handler, receipt)
@@ -509,16 +519,12 @@ func (cb *ConsumerBase) handleClaimState(
 	}
 }
 
-// requeueResult constructs a Requeue HandleResult with the given error and
-// SettlementObservers. Observers from the last handler invocation are
-// propagated so business-middleware observers are notified on ctx-cancel abort
-// and other early-exit paths.
+// requeueResult constructs a Requeue DeliveryOutcome with the given error.
 // Settlement is returned separately by the Wrap closure.
-func requeueResult(err error, observers []SettlementObserver) HandleResult {
-	return HandleResult{
-		Disposition:         DispositionRequeue,
-		Err:                 err,
-		SettlementObservers: observers,
+func requeueResult(err error) DeliveryOutcome {
+	return DeliveryOutcome{
+		Disposition: DispositionRequeue,
+		Err:         err,
 	}
 }
 
@@ -559,13 +565,8 @@ func (cb *ConsumerBase) waitBackoff(ctx context.Context, topic string, entry Ent
 }
 
 // retryLoop executes the handler with exponential backoff retries.
-// Settlement is no longer threaded through HandleResult — it is returned
-// by the Wrap closure alongside HandleResult via SubscriberHandler.
-//
-// SettlementObservers from the last handler invocation are propagated to the
-// final returned HandleResult so that business-middleware observers (e.g.
-// ConfigEventMiddleware) are notified after ConsumerBase resolves the final
-// broker disposition.
+// Settlement is returned by the Wrap closure alongside DeliveryOutcome via
+// SubscriberHandler.
 //
 // cellID is the observability owner dimension forwarded to the ConsumerObserver
 // on terminal Reject paths. It is captured from sub.CellID by Wrap and passed
@@ -577,16 +578,12 @@ func (cb *ConsumerBase) retryLoop(
 	topic string,
 	entry Entry,
 	handler EntryHandler,
-) HandleResult {
+) DeliveryOutcome {
 	var lastResult HandleResult
 	for attempt := range cb.config.RetryCount {
 		lastResult = handler(ctx, entry)
 		if lastResult.Disposition == DispositionAck {
-			return HandleResult{
-				Disposition:         DispositionAck,
-				ProcessReason:       lastResult.ProcessReason,
-				SettlementObservers: lastResult.SettlementObservers,
-			}
+			return deliveryFrom(lastResult)
 		}
 
 		if isPermanentRejection(lastResult) {
@@ -602,19 +599,14 @@ func (cb *ConsumerBase) retryLoop(
 			), func() {
 				cb.observer.ObserveReject(ctx, cellID, topic, consumerGroup, ConsumerRejectReasonHandlerReject)
 			})
-			return HandleResult{
-				Disposition:         DispositionReject,
-				Err:                 lastResult.Err,
-				ProcessReason:       lastResult.ProcessReason,
-				SettlementObservers: lastResult.SettlementObservers,
-			}
+			return deliveryFrom(lastResult)
 		}
 
 		// Transient error — backoff before retry (skipped on the final attempt).
 		if attempt < cb.config.RetryCount-1 {
 			if cb.waitBackoff(ctx, topic, entry, attempt, lastResult.Err) {
 				// Settlement.Release is called by the Subscriber after broker Nack.
-				return requeueResult(ctx.Err(), lastResult.SettlementObservers)
+				return requeueResult(ctx.Err())
 			}
 		}
 	}
@@ -623,7 +615,7 @@ func (cb *ConsumerBase) retryLoop(
 	// rather than routing to DLX. This ensures graceful shutdown does not
 	// permanently discard in-flight messages.
 	if ctx.Err() != nil {
-		return requeueResult(ctx.Err(), lastResult.SettlementObservers)
+		return requeueResult(ctx.Err())
 	}
 
 	// Exhausted all retries -- reject so broker routes to DLX.
@@ -643,11 +635,10 @@ func (cb *ConsumerBase) retryLoop(
 	), func() {
 		cb.observer.ObserveReject(ctx, cellID, topic, consumerGroup, ConsumerRejectReasonRetryExhausted)
 	})
-	return HandleResult{
-		Disposition:         DispositionReject,
-		Err:                 lastResult.Err,
-		ProcessReason:       "retry_exhausted",
-		SettlementObservers: lastResult.SettlementObservers,
+	return DeliveryOutcome{
+		Disposition:   DispositionReject,
+		Err:           lastResult.Err,
+		ProcessReason: "retry_exhausted",
 	}
 }
 
@@ -674,7 +665,7 @@ func (cb *ConsumerBase) runWithRenewal(
 	entry Entry,
 	handler EntryHandler,
 	receipt idempotency.Receipt,
-) HandleResult {
+) DeliveryOutcome {
 	interval := cb.config.LeaseRenewalInterval
 	// Skip renewal when disabled (negative) or receipt is nil.
 	if interval <= 0 || receipt == nil {
@@ -710,11 +701,10 @@ func (cb *ConsumerBase) runWithRenewal(
 		logWithContext(ctx, slog.LevelWarn, "outbox: lease lost during processing, downgrading Ack to Requeue (hard fence)",
 			slog.String(logKeyEventID, entry.id),
 			slog.String(logKeyTopic, topic))
-		return HandleResult{
-			Disposition:         DispositionRequeue,
-			Err:                 idempotency.ErrLeaseExpired,
-			ProcessReason:       result.ProcessReason,
-			SettlementObservers: result.SettlementObservers,
+		return DeliveryOutcome{
+			Disposition:   DispositionRequeue,
+			Err:           idempotency.ErrLeaseExpired,
+			ProcessReason: result.ProcessReason,
 		}
 	}
 

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -626,7 +626,7 @@ func (cb *ConsumerBase) retryLoop(
 		slog.String(logKeyTopic, topic),
 		slog.String(logKeyConsumerGroup, consumerGroup),
 		slog.Int("retry_count", cb.config.RetryCount),
-		slog.String("process_reason", "retry_exhausted"),
+		slog.String("process_reason", ProcessReasonRetryExhausted),
 		slog.Any("error", lastResult.Err))
 	observability.SafeObserve(slog.Default().With(
 		slog.String("cell", cellID),
@@ -638,7 +638,7 @@ func (cb *ConsumerBase) retryLoop(
 	return DeliveryOutcome{
 		Disposition:   DispositionReject,
 		Err:           lastResult.Err,
-		ProcessReason: "retry_exhausted",
+		ProcessReason: ProcessReasonRetryExhausted,
 	}
 }
 

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -1151,12 +1151,13 @@ func TestConsumerBase_LeaseHeld_NormalAck(t *testing.T) {
 // SettlementObservers transparency tests (Wave 4 review finding #1 + #2)
 // =============================================================================
 
-// TestConsumerBase_LeaseLostPath_PreservesSettlementObservers guards finding #1:
-// when runWithRenewal detects leaseLost and force-downgrades DispositionAck →
-// DispositionRequeue, the handler's SettlementObservers must be preserved in
-// the returned HandleResult. Previously the hard-fence code path silently
-// dropped them.
-func TestConsumerBase_LeaseLostPath_PreservesSettlementObservers(t *testing.T) {
+// TestConsumerBase_LeaseLostPath_ReturnsRequeueWithLeaseExpiredErr guards the
+// hard-fence behavior in runWithRenewal: when leaseLost is detected and
+// DispositionAck is downgraded to DispositionRequeue, the returned
+// DeliveryOutcome must carry ErrLeaseExpired. Slim HandleResult has no
+// SettlementObservers field — observer injection belongs to the SubscriberHandler
+// layer (WrapSubscriber / WrapConfigEventSubscriber), not the handler return value.
+func TestConsumerBase_LeaseLostPath_ReturnsRequeueWithLeaseExpiredErr(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	interval := testtime.D20ms
@@ -1180,43 +1181,28 @@ func TestConsumerBase_LeaseLostPath_PreservesSettlementObservers(t *testing.T) {
 	}, clock.Real())
 	require.NoError(t, err)
 
-	// Capture the observer call via SettlementObserverFunc.
-	var observerCalled bool
-	testObserver := SettlementObserverFunc(func(_ context.Context, _ SettlementObservation) {
-		observerCalled = true
-	})
-
-	// Handler ignores ctx.Done() (stale holder), returns Ack with an observer.
+	// Handler ignores ctx.Done() (stale holder), returns slim Ack.
 	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
 		// Block long enough for the renewal goroutine to fire and set leaseLost.
 		time.Sleep(renewalIntervalMultiplier5 * interval) //archtest:allow:test-sleep Renew extends TTL — polling defeats test
-		return HandleResult{
-			Disposition:         DispositionAck,
-			SettlementObservers: []SettlementObserver{testObserver},
-		}
+		return Ack()
 	})
 
 	res, _ := handler(context.Background(), Entry{id: "evt-lease-lost-observers"})
 
-	// Hard fence must downgrade to Requeue and preserve SettlementObservers.
+	// Hard fence must downgrade to Requeue and set ErrLeaseExpired.
 	assert.Equal(t, DispositionRequeue, res.Disposition,
 		"leaseLost hard fence must downgrade DispositionAck to DispositionRequeue")
-	require.Len(t, res.SettlementObservers, 1,
-		"leaseLost downgrade path must preserve handler SettlementObservers")
-
-	// Invoke observer to confirm it is functional.
-	res.SettlementObservers[0].ObserveSettlement(context.Background(), SettlementObservation{})
-	assert.True(t, observerCalled,
-		"preserved SettlementObserver must be callable after leaseLost downgrade")
+	assert.ErrorIs(t, res.Err, idempotency.ErrLeaseExpired,
+		"leaseLost downgrade path must set ErrLeaseExpired on DeliveryOutcome")
 }
 
-// TestConsumerBase_CtxCancelDuringBackoff_PreservesSettlementObservers guards
-// finding #2: when retryLoop aborts via ctx.Done() during waitBackoff, the
-// requeueResult must carry SettlementObservers from lastResult so
-// business-middleware observers (e.g. ConfigEventMiddleware) are notified on
-// graceful shutdown. Previously requeueResult had no observers parameter and
-// silently dropped them.
-func TestConsumerBase_CtxCancelDuringBackoff_PreservesSettlementObservers(t *testing.T) {
+// TestConsumerBase_CtxCancelDuringBackoff_ReturnsRequeueWithCtxErr guards the
+// ctx-cancel abort path in retryLoop: when context is canceled during backoff,
+// the returned DeliveryOutcome must have DispositionRequeue and carry ctx.Err().
+// Slim HandleResult has no SettlementObservers field — the SubscriberHandler
+// layer owns observer injection, so no observer preservation is required here.
+func TestConsumerBase_CtxCancelDuringBackoff_ReturnsRequeueWithCtxErr(t *testing.T) {
 	receipt := &fakeReceipt{}
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
@@ -1227,12 +1213,6 @@ func TestConsumerBase_CtxCancelDuringBackoff_PreservesSettlementObservers(t *tes
 	}, clock.Real())
 	require.NoError(t, err)
 
-	// Capture the observer call via SettlementObserverFunc.
-	var observerCalled bool
-	testObserver := SettlementObserverFunc(func(_ context.Context, _ SettlementObservation) {
-		observerCalled = true
-	})
-
 	// Signal channel: handler sends when first called (before backoff sleep).
 	started := make(chan struct{}, 1)
 	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"}, func(_ context.Context, _ Entry) HandleResult {
@@ -1240,11 +1220,7 @@ func TestConsumerBase_CtxCancelDuringBackoff_PreservesSettlementObservers(t *tes
 		case started <- struct{}{}:
 		default:
 		}
-		return HandleResult{
-			Disposition:         DispositionRequeue,
-			Err:                 errors.New("transient"),
-			SettlementObservers: []SettlementObserver{testObserver},
-		}
+		return Requeue(errors.New("transient"))
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1261,15 +1237,8 @@ func TestConsumerBase_CtxCancelDuringBackoff_PreservesSettlementObservers(t *tes
 	assert.Less(t, elapsed, time.Second, "ctx cancel must short-circuit retry backoff")
 	assert.Equal(t, DispositionRequeue, res.Disposition,
 		"ctx-cancel abort path must return DispositionRequeue")
-
-	// SettlementObservers from lastResult must be preserved.
-	require.Len(t, res.SettlementObservers, 1,
-		"ctx-cancel abort path must preserve lastResult.SettlementObservers")
-
-	// Invoke observer to confirm it is functional.
-	res.SettlementObservers[0].ObserveSettlement(context.Background(), SettlementObservation{})
-	assert.True(t, observerCalled,
-		"preserved SettlementObserver must be callable after ctx-cancel abort")
+	assert.ErrorIs(t, res.Err, context.Canceled,
+		"ctx-cancel abort path must carry context.Canceled as the error")
 }
 
 // =============================================================================

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -755,40 +755,60 @@ func (f SettlementObserverFunc) ObserveSettlement(ctx context.Context, obs Settl
 }
 
 // HandleResult carries the business handler's processing outcome.
-// The Subscriber inspects Disposition to decide Ack/Nack, then calls
-// Settlement.Commit or Settlement.Release (received via SubscriberHandler
-// return value) based on the broker outcome.
+// Business handlers return HandleResult via EntryHandler — it contains only
+// what the handler author decides: the disposition and an optional error.
+//
+// ProcessReason and SettlementObservers are subscriber-layer concerns and live
+// in DeliveryOutcome (the type ConsumerBase.Wrap produces). Business handlers
+// never need to set those fields; ConsumerBase injects ProcessReason (e.g.
+// "retry_exhausted") and the subscriber layer appends SettlementObservers.
 type HandleResult struct {
 	Disposition Disposition
 	Err         error // optional: logged/observed; nil for success
+}
 
-	// ProcessReason is a low-cardinality handler/process classification, such
-	// as "ack", "stale", or "permanent_error". It is not a broker outcome.
+// DeliveryOutcome is the subscriber-layer carrier produced by ConsumerBase.Wrap.
+// It extends the slim HandleResult with kernel-injected ProcessReason and
+// SettlementObservers so the subscriber (rabbitmq / eventbus / mqtt) can
+// perform post-settlement notification without any of those concerns leaking
+// into business handler code.
+//
+// Business handlers return HandleResult. ConsumerBase.Wrap lifts HandleResult
+// → DeliveryOutcome, injecting ProcessReason (e.g. "retry_exhausted") before
+// returning SubscriberHandler to the subscriber layer.
+type DeliveryOutcome struct {
+	Disposition Disposition
+	Err         error // optional: logged/observed; nil for success
+
+	// ProcessReason is a low-cardinality kernel/process classification, such
+	// as "retry_exhausted". Injected by ConsumerBase, never set by business
+	// handlers.
 	ProcessReason string
 
 	// SettlementObservers are notified by subscribers after final broker
-	// settlement. Middleware appends observers after ConsumerBase has resolved
+	// settlement. Appended by subscriber-layer middleware (e.g.
+	// WrapConfigEventSubscriber) after ConsumerBase has resolved
 	// retry/lease decisions.
 	SettlementObservers []SettlementObserver
 }
 
 // NotifySettlement emits a settlement observation to every observer attached
-// to the result. It is a no-op when no observer is present.
+// to the outcome. It is a no-op when no observer is present.
 func NotifySettlement(
-	ctx context.Context, result HandleResult, entry Entry,
+	ctx context.Context, outcome DeliveryOutcome, entry Entry,
 	disposition Disposition, settlement SettlementResult, err error,
 ) {
-	if len(result.SettlementObservers) == 0 {
+	if len(outcome.SettlementObservers) == 0 {
 		return
 	}
 	obs := SettlementObservation{
 		Entry:         entry,
 		Disposition:   disposition,
 		Result:        settlement,
-		ProcessReason: result.ProcessReason,
+		ProcessReason: outcome.ProcessReason,
 		Err:           err,
 	}
-	for _, observer := range result.SettlementObservers {
+	for _, observer := range outcome.SettlementObservers {
 		if observer == nil {
 			continue
 		}
@@ -818,6 +838,11 @@ type EntryHandler func(context.Context, Entry) HandleResult
 // Settlement.Commit before broker Ack and Settlement.Release after broker Nack
 // without any idempotency types leaking into business code.
 //
+// The return type is DeliveryOutcome (not HandleResult) because ConsumerBase.Wrap
+// injects kernel-level ProcessReason ("retry_exhausted") and subscriber-layer
+// SettlementObservers that business handlers must not set. Business handlers
+// return slim HandleResult; ConsumerBase lifts it to DeliveryOutcome.
+//
 // Settlement may be nil when ConsumerBase has no idempotency state (fail-open
 // claim error, ClaimDone, ClaimBusy short-circuit). Subscribers MUST nil-check
 // before calling Commit/Release.
@@ -830,7 +855,7 @@ type EntryHandler func(context.Context, Entry) HandleResult
 //	claim ConsumerGroupClaim) — settle handle as explicit method parameter
 //
 // ref: nats-io/nats.go jetstream/message.go Msg interface (Ack/Nak/Term)
-type SubscriberHandler func(ctx context.Context, entry Entry) (HandleResult, Settlement)
+type SubscriberHandler func(ctx context.Context, entry Entry) (DeliveryOutcome, Settlement)
 
 // ---------------------------------------------------------------------------
 // PermanentError -- error classification (domain concept)
@@ -899,7 +924,7 @@ type Subscriber interface {
 	// different groups each receive a full copy (fanout).
 	//
 	// handler is SubscriberHandler so the Subscriber can receive Settlement
-	// alongside HandleResult without idempotency types leaking into business
+	// alongside DeliveryOutcome without idempotency types leaking into business
 	// code. Callers that hold an EntryHandler and want the full business
 	// pipeline (middleware chain + ConsumerBase idempotency) should use
 	// SubscriberWithMiddleware.SubscribeEntry instead of lifting manually.
@@ -1094,7 +1119,7 @@ func (s *SubscriberWithMiddleware) SubscribeEntry(ctx context.Context, sub Subsc
 	// populated with trace/request/correlation AND actor/subject/tenant/session
 	// identity. Symmetric with NewEntry's construction-time injection; neither
 	// endpoint has a kill-switch.
-	withRestore := func(reqCtx context.Context, entry Entry) (HandleResult, Settlement) {
+	withRestore := func(reqCtx context.Context, entry Entry) (DeliveryOutcome, Settlement) {
 		reqCtx = entry.RestoreContext(reqCtx)
 		return subHandler(reqCtx, entry)
 	}

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -730,6 +730,13 @@ const (
 	SettlementResultNackFailed     SettlementResult = "nack_failed"
 )
 
+// ProcessReasonRetryExhausted marks a DeliveryOutcome whose Reject was produced
+// by ConsumerBase exhausting its retry budget (as opposed to a handler's
+// explicit Reject). It is the sole value ConsumerBase injects into
+// DeliveryOutcome.ProcessReason. Subscriber settle loops classify the final
+// SettlementResult from it via RejectSettlementResult — see that helper.
+const ProcessReasonRetryExhausted = "retry_exhausted"
+
 // SettlementObservation is emitted by subscribers after the final delivery
 // settlement action is known.
 type SettlementObservation struct {
@@ -824,6 +831,21 @@ func NotifySettlement(
 			observer.ObserveSettlement(ctx, obs)
 		}()
 	}
+}
+
+// RejectSettlementResult classifies the SettlementResult of a Reject disposition
+// from the DeliveryOutcome's ProcessReason. It is the single source every
+// subscriber settle loop (rabbitmq / mqtt / eventbus) routes its Reject branch
+// through, so retry-budget exhaustion is reported as
+// SettlementResultRetryExhausted on every transport instead of drifting per
+// adapter. A handler's explicit Reject (empty ProcessReason) stays
+// SettlementResultSuccess — the broker settlement action itself succeeded; only
+// the process outcome was a rejection.
+func RejectSettlementResult(outcome DeliveryOutcome) SettlementResult {
+	if outcome.ProcessReason == ProcessReasonRetryExhausted {
+		return SettlementResultRetryExhausted
+	}
+	return SettlementResultSuccess
 }
 
 // EntryHandler is the business handler signature. Business handlers return a

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -255,8 +255,8 @@ func TestSubscriberInterface(t *testing.T) {
 	var sub Subscriber = &mockSubscriber{}
 
 	t.Run("Subscribe returns nil on success", func(t *testing.T) {
-		handler := func(_ context.Context, _ Entry) (HandleResult, Settlement) {
-			return Ack(), nil
+		handler := func(_ context.Context, _ Entry) (DeliveryOutcome, Settlement) {
+			return DeliveryOutcome{Disposition: DispositionAck}, nil
 		}
 		err := sub.Subscribe(context.Background(), testFullSub("test.topic", "cg-test"), handler)
 		assert.NoError(t, err)
@@ -1265,7 +1265,7 @@ func TestNotifySettlement_ObserverPanic_DoesNotKillCaller(t *testing.T) {
 		spy3Called = true
 	})
 
-	result := HandleResult{
+	result := DeliveryOutcome{
 		Disposition:         DispositionAck,
 		SettlementObservers: []SettlementObserver{spy1, panicObserver, spy3},
 	}
@@ -1297,7 +1297,7 @@ func TestNotifySettlement_NoObservers_NoOp(t *testing.T) {
 		}
 	}()
 	NotifySettlement(context.Background(),
-		Ack(),
+		DeliveryOutcome{Disposition: DispositionAck},
 		Entry{id: "evt-noop", topic: "t"},
 		DispositionAck, SettlementResultSuccess, nil)
 }
@@ -1312,7 +1312,7 @@ func TestNotifySettlement_NilObserverInList_Skipped(t *testing.T) {
 	spy := SettlementObserverFunc(func(_ context.Context, _ SettlementObservation) {
 		called++
 	})
-	result := HandleResult{
+	result := DeliveryOutcome{
 		Disposition:         DispositionAck,
 		SettlementObservers: []SettlementObserver{nil, spy, nil},
 	}

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -1324,6 +1324,41 @@ func TestNotifySettlement_NilObserverInList_Skipped(t *testing.T) {
 	assert.Equal(t, 1, called, "non-nil observer must run exactly once; nil entries skipped")
 }
 
+// TestRejectSettlementResult is the single-source classification every
+// subscriber settle loop (rabbitmq / mqtt / eventbus) routes its Reject branch
+// through. A Reject carrying ProcessReason="retry_exhausted" (injected by
+// ConsumerBase on retry-budget exhaustion) must report RetryExhausted; any
+// other Reject (handler explicit reject, empty/unknown ProcessReason) reports
+// Success because the broker settlement action itself succeeded.
+func TestRejectSettlementResult(t *testing.T) {
+	tests := []struct {
+		name string
+		out  DeliveryOutcome
+		want SettlementResult
+	}{
+		{
+			name: "retry_exhausted_process_reason",
+			out:  DeliveryOutcome{Disposition: DispositionReject, ProcessReason: ProcessReasonRetryExhausted},
+			want: SettlementResultRetryExhausted,
+		},
+		{
+			name: "empty_process_reason_handler_reject",
+			out:  DeliveryOutcome{Disposition: DispositionReject},
+			want: SettlementResultSuccess,
+		},
+		{
+			name: "unknown_process_reason",
+			out:  DeliveryOutcome{Disposition: DispositionReject, ProcessReason: "something_else"},
+			want: SettlementResultSuccess,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, RejectSettlementResult(tc.out))
+		})
+	}
+}
+
 func TestDiscardPublisher_TypedNil_NoPanic(t *testing.T) {
 	// Typed nil: interface is non-nil but underlying pointer is nil.
 	// Must not panic — this is the key regression from value→pointer migration.

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -58,6 +58,14 @@ const subscribeReadyTimeout = 50 * time.Millisecond
 // rather than tweaking individual tests.
 const negativeAssertionWindow = 200 * time.Millisecond
 
+// asDelivery converts a slim HandleResult from Ack/Requeue/Reject factory
+// functions to a DeliveryOutcome for use in SubscriberHandler closures.
+// Only for use in conformance test helpers where the test author knows the
+// result comes from a factory (no ProcessReason or SettlementObservers needed).
+func asDelivery(r outbox.HandleResult) outbox.DeliveryOutcome {
+	return outbox.DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}
+}
+
 // TestPubSub runs the full conformance test suite against the given
 // Publisher/Subscriber implementation. Features control which tests are
 // executed; unsupported features are skipped with t.Skip(). Each batch is
@@ -276,7 +284,7 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 	go func() {
 		defer close(subDone)
 		_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topicA, CellID: "_outboxtest"},
-			func(_ context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				select {
 				case deliveryA <- struct{}{}:
 				default:
@@ -287,7 +295,7 @@ func testTopicIsolation(t *testing.T, _ Features, constructor PubSubConstructor)
 					closeOnceA.Do(func() { close(doneA) })
 				}
 				mu.Unlock()
-				return outbox.Ack(), nil
+				return asDelivery(outbox.Ack()), nil
 			})
 	}()
 	waitForSubscription(t, ctx, sub, topicA, "")
@@ -349,16 +357,16 @@ func testMultipleSubscribers(t *testing.T, _ Features, constructor PubSubConstru
 	sub2Spec := outbox.Subscription{Topic: topic, ConsumerGroup: broadcastCG2, CellID: broadcastCG2}
 
 	wg.Go(func() {
-		_ = sub.Subscribe(subCtx, sub1Spec, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+		_ = sub.Subscribe(subCtx, sub1Spec, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 			sub1Received.Add(1)
-			return outbox.Ack(), nil
+			return asDelivery(outbox.Ack()), nil
 		})
 	})
 
 	wg.Go(func() {
-		_ = sub.Subscribe(subCtx, sub2Spec, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+		_ = sub.Subscribe(subCtx, sub2Spec, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 			sub2Received.Add(1)
-			return outbox.Ack(), nil
+			return asDelivery(outbox.Ack()), nil
 		})
 	})
 
@@ -402,13 +410,13 @@ func testCompetingConsumers(t *testing.T, _ Features, constructor PubSubConstruc
 	for range 2 {
 		wg.Go(func() {
 			_ = sub.Subscribe(subCtx, outbox.Subscription{Topic: topic, CellID: "_outboxtest"},
-				func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+				func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 					select {
 					case delivery <- struct{}{}:
 					default:
 					}
 					totalReceived.Add(1)
-					return outbox.Ack(), nil
+					return asDelivery(outbox.Ack()), nil
 				})
 		})
 	}
@@ -577,9 +585,9 @@ func testReceiptCommittedOnAck(t *testing.T, features Features, constructor PubS
 	// Settlement is now returned as the second value from SubscriberHandler,
 	// not embedded in HandleResult. subscribeWithHandler accepts SubscriberHandler
 	// directly so the conformance test can inject a mock Settlement.
-	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		h.signalDone()
-		return outbox.Ack(), receipt
+		return asDelivery(outbox.Ack()), receipt
 	})
 
 	h.publishAndWait([]byte(`{"test":"receipt-ack"}`))
@@ -600,9 +608,9 @@ func testReceiptReleasedOnReject(t *testing.T, features Features, constructor Pu
 	h := newHarness(t, constructor)
 	receipt := NewMockReceipt()
 
-	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		h.signalDone()
-		return outbox.Reject(outbox.NewPermanentError(fmt.Errorf("bad"))), receipt
+		return asDelivery(outbox.Reject(outbox.NewPermanentError(fmt.Errorf("bad")))), receipt
 	})
 
 	h.publishAndWait([]byte(`{"test":"receipt-reject"}`))
@@ -624,13 +632,13 @@ func testReceiptReleasedOnRequeue(t *testing.T, features Features, constructor P
 	receipt := NewMockReceipt()
 	var callCount atomic.Int32
 
-	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		n := callCount.Add(1)
 		if n == 1 {
 			h.signalDone()
-			return outbox.Requeue(fmt.Errorf("transient")), receipt
+			return asDelivery(outbox.Requeue(fmt.Errorf("transient"))), receipt
 		}
-		return outbox.Ack(), nil
+		return asDelivery(outbox.Ack()), nil
 	})
 
 	h.publishAndWait([]byte(`{"test":"receipt-requeue"}`))
@@ -661,12 +669,12 @@ func testReceiptCommitFailureDoesNotAck(t *testing.T, features Features, constru
 	receipt := NewMockReceiptWithErrors(errors.New("commit fails (test)"), nil)
 
 	var deliveries atomic.Int32
-	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	h.subscribeWithHandler(func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		n := deliveries.Add(1)
 		if n == 1 {
 			h.signalDone() // wake publisher after first delivery
 		}
-		return outbox.Ack(), receipt
+		return asDelivery(outbox.Ack()), receipt
 	})
 
 	h.publishAndWait([]byte(`{"test":"commit-fail"}`))
@@ -700,8 +708,8 @@ func testSubscribeBlocksUntilCancel(t *testing.T, features Features, constructor
 	subscribeReturned := make(chan error, 1)
 	go func() {
 		err := sub.Subscribe(ctx, outbox.Subscription{Topic: TestTopic(t), CellID: "_outboxtest"},
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Ack(), nil
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return asDelivery(outbox.Ack()), nil
 			})
 		subscribeReturned <- err
 	}()
@@ -733,8 +741,8 @@ func testCloseTerminatesSubscribers(t *testing.T, _ Features, constructor PubSub
 	go func() {
 		defer close(subscribeReturned)
 		_ = sub.Subscribe(ctx, outbox.Subscription{Topic: topic, CellID: "_outboxtest"},
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Ack(), nil
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return asDelivery(outbox.Ack()), nil
 			})
 	}()
 	waitForSubscription(t, ctx, sub, topic, "")

--- a/kernel/outbox/outboxtest/helpers.go
+++ b/kernel/outbox/outboxtest/helpers.go
@@ -153,7 +153,7 @@ func CollectN(
 	t.Cleanup(cancel)
 
 	//nolint:unparam // Settlement always nil: adapter tests bypass ConsumerBase by design
-	handler := func(_ context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	handler := func(_ context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		mu.Lock()
 		collected = append(collected, entry)
 		count := len(collected)
@@ -162,7 +162,7 @@ func CollectN(
 		if count >= n {
 			closeOnce.Do(func() { close(done) })
 		}
-		return outbox.Ack(), nil
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	}
 
 	// Subscribe blocks -- run in goroutine.
@@ -236,7 +236,7 @@ func startCollecting(t *testing.T, ctx context.Context, sub outbox.Subscriber, t
 		defer close(c.subDone)
 		close(ready) // signal: goroutine is running, Subscribe call is imminent
 		err := sub.Subscribe(subCtx, outbox.Subscription{Topic: topic, CellID: "_outboxtest"},
-			func(_ context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				c.mu.Lock()
 				c.collected = append(c.collected, entry)
 				count := len(c.collected)
@@ -244,7 +244,7 @@ func startCollecting(t *testing.T, ctx context.Context, sub outbox.Subscriber, t
 				if count >= c.n {
 					c.closeOnce.Do(func() { close(c.done) })
 				}
-				return outbox.Ack(), nil
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 			})
 		if err != nil && !errors.Is(err, context.Canceled) {
 			c.t.Errorf(errSubscribeUnexpectedFmt, err)
@@ -341,7 +341,7 @@ func (h *pubSubHarness) subscribeWithHandler(handler outbox.SubscriberHandler) {
 	ctx, cancel := context.WithCancel(h.T.Context())
 	h.cancel = cancel
 	h.T.Cleanup(cancel)
-	wrapped := func(hctx context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	wrapped := func(hctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		select {
 		case h.deliveryEvents <- struct{}{}:
 		default:
@@ -375,12 +375,13 @@ func (h *pubSubHarness) subscribe(handler outbox.EntryHandler) {
 	h.cancel = cancel
 	h.T.Cleanup(cancel)
 	//nolint:unparam // Settlement always nil: adapter tests bypass ConsumerBase by design
-	wrapped := func(hctx context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+	wrapped := func(hctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 		select {
 		case h.deliveryEvents <- struct{}{}:
 		default:
 		}
-		return handler(hctx, entry), nil
+		r := handler(hctx, entry)
+		return outbox.DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}, nil
 	}
 	ready := make(chan struct{})
 	go func() {

--- a/kernel/outbox/result_test.go
+++ b/kernel/outbox/result_test.go
@@ -17,12 +17,6 @@ func TestAck(t *testing.T) {
 	if got.Err != nil {
 		t.Fatalf("Err = %v, want nil", got.Err)
 	}
-	if got.ProcessReason != "" {
-		t.Fatalf("ProcessReason = %q, want empty", got.ProcessReason)
-	}
-	if got.SettlementObservers != nil {
-		t.Fatalf("SettlementObservers = %v, want nil", got.SettlementObservers)
-	}
 }
 
 func TestRequeue(t *testing.T) {

--- a/kernel/wrapper/subscriber.go
+++ b/kernel/wrapper/subscriber.go
@@ -13,7 +13,7 @@ import (
 // WrapSubscriber wraps a SubscriberHandler with a contract delivery span whose
 // status is resolved by the final broker settlement notification. It starts one
 // span per delivery attempt, appends a SettlementObserver to the returned
-// HandleResult, and ends the span when the subscriber calls outbox.NotifySettlement.
+// DeliveryOutcome, and ends the span when the subscriber calls outbox.NotifySettlement.
 //
 // This differs from WrapConsumer: Consumer middleware only sees the business
 // HandleResult before Commit/Ack/Nack, while this wrapper observes the
@@ -48,7 +48,7 @@ func WrapSubscriber(tr Tracer, spec contractspec.ContractSpec, fn outbox.Subscri
 		{Key: "messaging.destination", Value: spec.Topic},
 	}
 
-	return func(ctx context.Context, entry outbox.Entry) (res outbox.HandleResult, settlement outbox.Settlement) {
+	return func(ctx context.Context, entry outbox.Entry) (res outbox.DeliveryOutcome, settlement outbox.Settlement) {
 		ctx = entry.Observability().RestoreToContext(ctx)
 		ctx = ctxkeys.WithContractID(ctx, spec.ID)
 		ctx, span := tr.Start(ctx, defaultEventSpanName(spec))

--- a/kernel/wrapper/subscriber_test.go
+++ b/kernel/wrapper/subscriber_test.go
@@ -23,11 +23,11 @@ func newDeliveryEntry() outbox.Entry {
 func TestWrapSubscriber_ClaimDoneSpanEndsAfterSettlement(t *testing.T) {
 	tr := &spyTracer{}
 	wrapped := mustWrapSubscriberForTest(t, tr, eventSpec(),
-		func(ctx context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+		func(ctx context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 			if got := wrapper.ContractIDFromContext(ctx); got != eventSpec().ID {
 				t.Fatalf("contract id missing from handler context: %q", got)
 			}
-			return outbox.Ack(), nil
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		})
 
 	entry := newDeliveryEntry()
@@ -54,8 +54,8 @@ func TestWrapSubscriber_ClaimDoneSpanEndsAfterSettlement(t *testing.T) {
 func TestWrapSubscriber_ClaimBusySpanRecordsRequeueSettlement(t *testing.T) {
 	tr := &spyTracer{}
 	wrapped := mustWrapSubscriberForTest(t, tr, eventSpec(),
-		func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return outbox.Requeue(nil), nil
+		func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue}, nil
 		})
 
 	entry := newDeliveryEntry()
@@ -87,10 +87,11 @@ func TestWrapSubscriber_CommitFailedUsesFinalSettlementAndPreservesObservers(t *
 	commitErr := errors.New("lease expired")
 
 	wrapped := mustWrapSubscriberForTest(t, tr, eventSpec(),
-		func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			// Literal: factory Ack() does not carry SettlementObservers; needed
-			// here to verify observer propagation through commit-failure path.
-			return outbox.HandleResult{
+		func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			// Literal: factory Ack() (slim HandleResult) does not carry
+			// SettlementObservers; needed here to verify observer propagation
+			// through commit-failure path, so construct DeliveryOutcome directly.
+			return outbox.DeliveryOutcome{
 				Disposition:         outbox.DispositionAck,
 				SettlementObservers: []outbox.SettlementObserver{existingObserver},
 			}, nil
@@ -124,7 +125,7 @@ func TestWrapSubscriber_PanicEndsSpan(t *testing.T) {
 	tr := &spyTracer{}
 	boom := errors.New("subscriber handler exploded")
 	wrapped := mustWrapSubscriberForTest(t, tr, eventSpec(),
-		func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+		func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 			panic(boom)
 		})
 
@@ -151,8 +152,8 @@ func TestWrapSubscriber_PanicEndsSpan(t *testing.T) {
 func TestWrapSubscriber_ReturnsErrorsForInvalidInputs(t *testing.T) {
 	t.Parallel()
 
-	ackHandler := func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), nil
+	ackHandler := func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	}
 
 	// Structural assertions WrapSubscriber still owns: nil fn and non-event Kind
@@ -201,8 +202,8 @@ func TestWrapSubscriber_NilTracerFallsBackToNoop(t *testing.T) {
 	t.Parallel()
 
 	wrapped := mustWrapSubscriberForTest(t, nil, eventSpec(),
-		func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return outbox.Ack(), nil
+		func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		})
 	entry := newDeliveryEntry()
 	res, settlement := wrapped(context.Background(), entry)
@@ -273,8 +274,8 @@ func TestWrapSubscriber_SettlementStatusBranches(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := &spyTracer{}
 			wrapped := mustWrapSubscriberForTest(t, tr, eventSpec(),
-				func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-					return outbox.Ack(), nil
+				func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+					return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 				})
 
 			entry := newDeliveryEntry()
@@ -298,8 +299,8 @@ func TestWrapSubscriber_SettlementStatusBranches(t *testing.T) {
 func TestWrapSubscriber_SettlementObserverEndsSpanOnce(t *testing.T) {
 	tr := &spyTracer{}
 	wrapped := mustWrapSubscriberForTest(t, tr, eventSpec(),
-		func(context.Context, outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return outbox.Ack(), nil
+		func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		})
 
 	entry := newDeliveryEntry()

--- a/runtime/bootstrap/bootstrap.go
+++ b/runtime/bootstrap/bootstrap.go
@@ -127,7 +127,8 @@ type Bootstrap struct {
 	routerReadyTimeout     time.Duration
 	routerReadyTimeoutSet  bool
 	subscriptionValidators []cell.SubscriptionValidator
-	relay                  *runtimeoutbox.Relay // optional: wired by WithRelay; nil = no relay depth metric
+	relay                  *runtimeoutbox.Relay                   // optional: wired by WithRelay; nil = no relay depth metric
+	configEventCollector   metricsmiddleware.ConfigEventCollector // optional: settlement observer injected via WrapConfigEventSubscriber
 
 	// --- lifecycle: kernel/cell Lifecycle + ManagedResource + shutdown budgets ---
 	lifecycle                Lifecycle

--- a/runtime/bootstrap/config_event_settlement_wiring_test.go
+++ b/runtime/bootstrap/config_event_settlement_wiring_test.go
@@ -21,6 +21,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -40,8 +41,6 @@ import (
 	"github.com/ghbvf/gocell/runtime/eventbus"
 	"github.com/ghbvf/gocell/runtime/http/health"
 	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
-
-	"slices"
 )
 
 // configSettlementRecord captures one RecordEventSettlement call.

--- a/runtime/bootstrap/config_event_settlement_wiring_test.go
+++ b/runtime/bootstrap/config_event_settlement_wiring_test.go
@@ -1,0 +1,189 @@
+package bootstrap
+
+// config_event_settlement_wiring_test.go — faithful wiring test for the
+// config-event settlement observer (#1684 / codex F3).
+//
+// The corebundle unit tests (cmd/corebundle/config_event_metrics_wiring_test.go)
+// install obmetrics.WrapConfigEventSubscriber by hand, so they would stay green
+// even if production stopped wiring it. This test instead drives the REAL
+// production assembly path — phase6StartEventRouter → buildEventRouter →
+// eventrouter.WithSubscriberWrapper(WrapConfigEventSubscriber) — over a real
+// in-mem eventbus, so a regression that drops the wrapper (or stops honoring
+// WithConfigEventCollector) makes the settlement record disappear and this test
+// red.
+//
+// It also exercises the retry-exhausted settlement classification end-to-end:
+// the requeue-forever handler exhausts ConsumerBase's budget, ConsumerBase
+// returns a terminal Reject tagged ProcessReason=retry_exhausted, and the
+// eventbus settle loop must classify it (via outbox.RejectSettlementResult) as
+// SettlementResultRetryExhausted rather than Success.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/assembly"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cellvocab"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/contractspec"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+	"github.com/ghbvf/gocell/runtime/http/health"
+	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
+
+	"slices"
+)
+
+// configSettlementRecord captures one RecordEventSettlement call.
+type configSettlementRecord struct {
+	cell        string
+	slice       string
+	disposition string
+	result      outbox.SettlementResult
+}
+
+// recordingConfigEventCollector is a thread-safe obmetrics.ConfigEventCollector
+// that records settlement observations for assertions. The settlement observer
+// fires on the eventbus delivery goroutine, hence the mutex.
+type recordingConfigEventCollector struct {
+	mu          sync.Mutex
+	settlements []configSettlementRecord
+}
+
+func (c *recordingConfigEventCollector) RecordEventProcess(
+	_ context.Context, _, _ string, _ obmetrics.ConfigEventProcessReason,
+) {
+}
+
+func (c *recordingConfigEventCollector) RecordEventSettlement(
+	_ context.Context, cellID, sliceID, disposition string, result outbox.SettlementResult,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.settlements = append(c.settlements, configSettlementRecord{
+		cell: cellID, slice: sliceID, disposition: disposition, result: result,
+	})
+}
+
+func (c *recordingConfigEventCollector) last() (configSettlementRecord, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.settlements) == 0 {
+		return configSettlementRecord{}, false
+	}
+	return c.settlements[len(c.settlements)-1], true
+}
+
+// configEventStubCell subscribes to a config-event topic with owner metadata
+// (CellID + SliceID) and a requeue-forever handler so ConsumerBase exhausts its
+// retry budget and emits a terminal Reject tagged retry_exhausted.
+type configEventStubCell struct {
+	*cell.BaseCell
+	spec contractspec.ContractSpec
+}
+
+func newConfigEventStubCell(topic string) *configEventStubCell {
+	return &configEventStubCell{
+		BaseCell: cell.MustNewBaseCell(&metadata.CellMeta{ID: "accesscore", Type: "core"}),
+		spec: contractspec.ContractSpec{
+			ID:        topic,
+			Kind:      cellvocab.ContractEvent,
+			Transport: "inmem",
+			Topic:     topic,
+		},
+	}
+}
+
+func (c *configEventStubCell) Init(ctx context.Context, reg cell.Registrar) error {
+	if err := c.BaseCell.Init(ctx, reg); err != nil {
+		return err
+	}
+	requeueForever := outbox.EntryHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.Requeue(errors.New("transient"))
+	})
+	return reg.Subscribe(c.spec, requeueForever, c.ID(), c.ID(),
+		cell.WithSubscriptionSliceID("configreceive"))
+}
+
+var _ cell.Cell = (*configEventStubCell)(nil)
+
+// TestPhase6_ConfigEventSettlementWrapper_RecordsRetryExhausted proves the
+// production config-event settlement observer is wired through buildEventRouter
+// and that a retry-exhausted reject is recorded as RetryExhausted (not Success).
+func TestPhase6_ConfigEventSettlementWrapper_RecordsRetryExhausted(t *testing.T) {
+	t.Parallel()
+
+	const topic = "event.config.entry-upserted.v1"
+	bus := eventbus.New(clock.Real())
+	collector := &recordingConfigEventCollector{}
+
+	asm := assembly.New(clock.Real(), assembly.Config{ID: "phase6-cfgsettle-test", DurabilityMode: outbox.DurabilityDemo})
+	t.Cleanup(asm.Shutdown)
+	require.NoError(t, asm.Register(newConfigEventStubCell(topic)))
+	require.NoError(t, asm.Start(context.Background()))
+
+	cb, err := outbox.NewConsumerBase(
+		idempotency.NewInMemClaimer(clock.Real()),
+		outbox.ConsumerBaseConfig{RetryCount: 1, RetryBaseDelay: time.Millisecond},
+		clock.Real(),
+	)
+	require.NoError(t, err)
+
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		WithPublisher(bus),
+		WithSubscriber(bus),
+		WithConsumerBase(cb),
+		WithConfigEventCollector(collector),
+		WithSubscriptionValidator(obmetrics.ConfigEventOwnerValidator),
+	)
+	b.healthAggregator = newEventsTestAggregator() // phase0 normally sets this; test bypasses phase0.
+
+	runCtx, s := newPhaseState()
+	defer s.runCancel()
+	s.asm = asm
+	s.cellSnapshots = asm.Snapshots()
+	s.sub = bus
+	s.hh = health.New(asm, newEventsTestAggregator(), clock.Real()) // phase5 normally populates this.
+
+	require.NoError(t, b.phase6StartEventRouter(runCtx, s),
+		"phase6 must start the config-event subscription")
+
+	// Publish one config event. requeue-forever handler → ConsumerBase exhausts →
+	// terminal Reject(retry_exhausted) → eventbus settle loop classifies it via
+	// outbox.RejectSettlementResult → the production-wired settlement observer
+	// records reject/retry_exhausted.
+	pub, err := outbox.NewEntry(clock.Real(), context.Background(), "config.entry-upserted", []byte("{}"),
+		outbox.WithID("cfg-evt-1"), outbox.WithTopic(topic))
+	require.NoError(t, err)
+	env, err := outbox.MarshalEnvelope(pub)
+	require.NoError(t, err)
+	require.NoError(t, bus.Publish(context.Background(), topic, env))
+
+	require.Eventually(t, func() bool {
+		rec, ok := collector.last()
+		return ok && rec.disposition == "reject" && rec.result == outbox.SettlementResultRetryExhausted
+	}, testtime.D2s, testtime.D10ms,
+		"config-event settlement observer (wired via buildEventRouter→WithSubscriberWrapper) "+
+			"must record reject/retry_exhausted")
+
+	rec, _ := collector.last()
+	assert.Equal(t, "accesscore", rec.cell, "settlement must carry the subscription owner cell")
+	assert.Equal(t, "configreceive", rec.slice, "settlement must carry the subscription owner slice")
+
+	// Release the eventrouter goroutine before the test exits (goleak TestMain).
+	for _, v := range slices.Backward(s.teardowns) {
+		_ = v.fn(context.Background())
+	}
+}

--- a/runtime/bootstrap/options_events.go
+++ b/runtime/bootstrap/options_events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
+	obmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 	runtimeoutbox "github.com/ghbvf/gocell/runtime/outbox"
 	"github.com/ghbvf/gocell/runtime/worker"
 )
@@ -154,5 +155,22 @@ func WithRelay(r *runtimeoutbox.Relay) Option {
 		}
 		b.relay = r
 		b.managedResources = append(b.managedResources, newRelayAdapter(r)) // auto-lifecycle via sole sanctioned holder
+	}
+}
+
+// WithConfigEventCollector injects a ConfigEventCollector for config-event
+// settlement observability. The collector is applied at the SubscriberHandler
+// layer via WrapConfigEventSubscriber inside buildEventRouter, so settlement
+// metrics are recorded after final broker disposition rather than inside the
+// EntryHandler.
+//
+// Nil inputs are silently ignored (cumulative builder noop pattern). When this
+// option is not called, NoopConfigEventCollector is used.
+func WithConfigEventCollector(c obmetrics.ConfigEventCollector) Option {
+	return func(b *Bootstrap) {
+		if c == nil {
+			return
+		}
+		b.configEventCollector = c
 	}
 }

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -227,8 +227,18 @@ func (b *Bootstrap) buildEventRouter(sub outbox.Subscriber) (*eventrouter.Router
 	}
 	evtRouterOpts = append(evtRouterOpts, collectorOpts...)
 
+	var tracingOpts []eventrouter.TracingSubscriberOption
+	collector := b.configEventCollector
+	if collector == nil {
+		collector = metricsmiddleware.NoopConfigEventCollector{}
+	}
+	tracingOpts = append(tracingOpts, eventrouter.WithSubscriberWrapper(
+		func(sub outbox.Subscription, next outbox.SubscriberHandler) outbox.SubscriberHandler {
+			return metricsmiddleware.WrapConfigEventSubscriber(collector, sub, next)
+		},
+	))
 	swm, err := outbox.NewSubscriberWithMiddleware(
-		eventrouter.NewContractTracingSubscriber(sub, b.wrapperTracer),
+		eventrouter.NewContractTracingSubscriber(sub, b.wrapperTracer, tracingOpts...),
 		b.consumerBase,
 		b.consumerMiddleware...,
 	)

--- a/runtime/eventbus/entry_lift_test.go
+++ b/runtime/eventbus/entry_lift_test.go
@@ -14,7 +14,8 @@ import (
 // This helper replaces the deleted outbox.EntryToSubscriberHandler in test-only
 // code. Production callers use SubscriberWithMiddleware.SubscribeEntry instead.
 func entryToSubHandler(h outbox.EntryHandler) outbox.SubscriberHandler {
-	return func(ctx context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return h(ctx, entry), nil
+	return func(ctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		r := h(ctx, entry)
+		return outbox.DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}, nil
 	}
 }

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -508,7 +508,7 @@ func (b *InMemoryEventBus) processResult(
 			slog.Any("error", res.Err),
 		)
 		b.appendDeadLetter(topic, entry, res.Err)
-		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultSuccess, nil)
+		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.RejectSettlementResult(res), nil)
 		return true, nil
 	case outbox.DispositionRequeue:
 		return b.handleRequeue(ctx, topic, entry, res, settlement, attempt, finalAttempt)

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -452,7 +452,7 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 }
 
 func (b *InMemoryEventBus) notifyRetryExhausted(
-	ctx context.Context, topic string, entry outbox.Entry, res outbox.HandleResult, err error,
+	ctx context.Context, topic string, entry outbox.Entry, res outbox.DeliveryOutcome, err error,
 ) {
 	b.appendDeadLetter(topic, entry, err)
 	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultRetryExhausted, err)
@@ -472,7 +472,7 @@ func (b *InMemoryEventBus) processResult(
 	ctx context.Context,
 	topic string,
 	entry outbox.Entry,
-	res outbox.HandleResult,
+	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
 	attempt int,
 	finalAttempt bool,
@@ -526,7 +526,7 @@ func (b *InMemoryEventBus) handleRequeue(
 	ctx context.Context,
 	topic string,
 	entry outbox.Entry,
-	res outbox.HandleResult,
+	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
 	attempt int,
 	finalAttempt bool,
@@ -554,7 +554,7 @@ func (b *InMemoryEventBus) handleInvalidDisposition(
 	ctx context.Context,
 	topic string,
 	entry outbox.Entry,
-	res outbox.HandleResult,
+	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
 	attempt int,
 	finalAttempt bool,

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -1407,6 +1407,54 @@ func TestSubscribe_RetryExhausted_NotifiesRetryExhausted(t *testing.T) {
 	assert.Equal(t, 1, bus.DeadLetterLen(), "one entry must be dead-lettered")
 }
 
+// TestSubscribe_RejectWithRetryExhaustedProcessReason_NotifiesRetryExhausted
+// covers the PRODUCTION path (distinct from the eventbus-internal retry loop
+// asserted above): ConsumerBase.Wrap exhausts its OWN retry budget in-process
+// and hands the eventbus a TERMINAL Reject already tagged
+// ProcessReason=retry_exhausted on the first delivery. The eventbus Reject
+// branch never reaches its own notifyRetryExhausted, so it must classify the
+// settlement from ProcessReason (via outbox.RejectSettlementResult) instead of
+// hard-coding Success — otherwise retry-budget exhaustion is silently observed
+// as a successful settlement on the in-mem transport.
+func TestSubscribe_RejectWithRetryExhaustedProcessReason_NotifiesRetryExhausted(t *testing.T) {
+	bus := New(clock.Real(), WithBufferSize(16))
+	defer func() { _ = bus.Close(context.Background()) }()
+
+	spy := &spySettlementObserver{}
+	rejectErr := errors.New("retry budget exhausted by ConsumerBase")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "spy.terminalreject"},
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{
+					Disposition:         outbox.DispositionReject,
+					Err:                 rejectErr,
+					ProcessReason:       outbox.ProcessReasonRetryExhausted,
+					SettlementObservers: []outbox.SettlementObserver{spy},
+				}, nil
+			})
+	}()
+
+	<-bus.Ready(outbox.Subscription{Topic: "spy.terminalreject"})
+	require.NoError(t, bus.Publish(context.Background(), "spy.terminalreject", makeSimpleEnvelope(t, "spy.terminalreject")))
+
+	testwait.External(t, "eventbus-terminal-reject-settled", func() bool {
+		last := spy.last()
+		return last.Disposition == outbox.DispositionReject &&
+			last.Result == outbox.SettlementResultRetryExhausted
+	}, busEventually10x, testtime.D10ms, "spy must receive Reject/RetryExhausted for a terminal retry-exhausted reject")
+
+	cancel()
+	<-done
+
+	last := spy.last()
+	assert.Equal(t, outbox.DispositionReject, last.Disposition)
+	assert.Equal(t, outbox.SettlementResultRetryExhausted, last.Result)
+	assert.Equal(t, 1, bus.DeadLetterLen(), "terminal reject must dead-letter exactly once")
+}
+
 func TestSubscribe_RetryExhausted_NotifiesOncePerAttempt(t *testing.T) {
 	bus := New(clock.Real(), WithBufferSize(16))
 	defer func() { _ = bus.Close(context.Background()) }()

--- a/runtime/eventbus/eventbus_test.go
+++ b/runtime/eventbus/eventbus_test.go
@@ -605,8 +605,8 @@ func TestSubscribe_ReceiptCommittedOnAck(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.ack"},
-			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Ack(), receipt
+			func(_ context.Context, e outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, receipt
 			})
 	}()
 
@@ -635,8 +635,8 @@ func TestSubscribe_ReceiptReleasedOnReject(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.reject"},
-			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Reject(errors.New("permanent")), receipt
+			func(_ context.Context, e outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionReject, Err: errors.New("permanent")}, receipt
 			})
 	}()
 
@@ -666,12 +666,12 @@ func TestSubscribe_ReceiptReleasedOnRequeue(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.requeue"},
-			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, e outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				r := &mockReceipt{}
 				receiptsMu.Lock()
 				receipts = append(receipts, r)
 				receiptsMu.Unlock()
-				return outbox.Requeue(errors.New("transient")), r
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}, r
 			})
 	}()
 
@@ -714,12 +714,12 @@ func TestSubscribe_ReceiptReleasedOnRetryExhaustion(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "receipt.exhaust"},
-			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, e outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				r := &mockReceipt{}
 				receiptsMu.Lock()
 				receipts = append(receipts, r)
 				receiptsMu.Unlock()
-				return outbox.Requeue(testErr), r
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: testErr}, r
 			})
 	}()
 
@@ -765,14 +765,14 @@ func TestSubscribe_ZeroValueDisposition_TreatedAsRequeue(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "zero.disp"},
-			func(_ context.Context, e outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, e outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				attempts.Add(1)
 				r := &mockReceipt{}
 				receiptsMu.Lock()
 				receipts = append(receipts, r)
 				receiptsMu.Unlock()
-				// Zero-value HandleResult — Disposition is 0 (invalid).
-				return outbox.HandleResult{Err: errors.New("forgot disposition")}, r
+				// Zero-value DeliveryOutcome — Disposition is 0 (invalid).
+				return outbox.DeliveryOutcome{Err: errors.New("forgot disposition")}, r
 			})
 	}()
 
@@ -1237,8 +1237,8 @@ func TestReleaseReceipt_FailedRelease_LogsError(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "release.fail"},
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Reject(errors.New("permanent handler error")), receipt
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionReject, Err: errors.New("permanent handler error")}, receipt
 			})
 	}()
 
@@ -1335,9 +1335,9 @@ func TestSubscribe_CommitFailure_NotifiesCommitFailed(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "spy.commitfail"},
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
 				attempts.Add(1)
-				return outbox.HandleResult{
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionAck,
 					SettlementObservers: []outbox.SettlementObserver{spy},
 				}, receipt
@@ -1376,13 +1376,13 @@ func TestSubscribe_RetryExhausted_NotifiesRetryExhausted(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "spy.retryexhausted"},
-			entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-				return outbox.HandleResult{
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionRequeue,
 					Err:                 transientErr,
 					SettlementObservers: []outbox.SettlementObserver{spy},
-				}
-			}))
+				}, nil
+			})
 	}()
 
 	<-bus.Ready(outbox.Subscription{Topic: "spy.retryexhausted"})
@@ -1418,13 +1418,13 @@ func TestSubscribe_RetryExhausted_NotifiesOncePerAttempt(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "spy.retryexhausted.once"},
-			entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
-				return outbox.HandleResult{
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionRequeue,
 					Err:                 transientErr,
 					SettlementObservers: []outbox.SettlementObserver{spy},
-				}
-			}))
+				}, nil
+			})
 	}()
 
 	<-bus.Ready(outbox.Subscription{Topic: "spy.retryexhausted.once"})
@@ -1465,8 +1465,8 @@ func TestSubscribe_CommitFailureRetryExhausted_NotifiesOncePerAttempt(t *testing
 	done := make(chan error, 1)
 	go func() {
 		done <- bus.Subscribe(ctx, outbox.Subscription{Topic: "spy.commitfail.exhausted"},
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.HandleResult{
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{
 					Disposition:         outbox.DispositionAck,
 					SettlementObservers: []outbox.SettlementObserver{spy},
 				}, receipt

--- a/runtime/eventrouter/contract_tracing_subscriber.go
+++ b/runtime/eventrouter/contract_tracing_subscriber.go
@@ -9,6 +9,26 @@ import (
 	"github.com/ghbvf/gocell/runtime/internal/contractbuild"
 )
 
+// SubscriberWrapperFunc is applied at Subscribe time after wrapper.WrapSubscriber.
+// It allows composition-root layers to inject per-subscription instrumentation
+// (e.g. settlement observers) at the SubscriberHandler layer without
+// requiring eventrouter to import observability packages.
+type SubscriberWrapperFunc func(sub outbox.Subscription, next outbox.SubscriberHandler) outbox.SubscriberHandler
+
+// TracingSubscriberOption configures a contractTracingSubscriber.
+type TracingSubscriberOption func(*contractTracingSubscriber)
+
+// WithSubscriberWrapper adds a SubscriberHandler-layer wrapper applied after
+// wrapper.WrapSubscriber inside Subscribe. The wrapper receives the validated
+// Subscription and the tracing-wrapped handler; it may append
+// DeliveryOutcome.SettlementObservers or perform other SubscriberHandler-layer
+// instrumentation.
+func WithSubscriberWrapper(fn SubscriberWrapperFunc) TracingSubscriberOption {
+	return func(s *contractTracingSubscriber) {
+		s.subWrapper = fn
+	}
+}
+
 // NewContractTracingSubscriber decorates an outbox.Subscriber so every
 // contract-bound delivery attempt gets one span that ends after final broker
 // settlement. It delegates lifecycle methods unchanged and wraps Subscribe
@@ -25,13 +45,18 @@ import (
 // cannot signal validation errors; callers that drive lifecycle directly
 // must call Setup first to surface validation failures (Watermill /
 // Kratos pattern: registration-time validation owned by the decorator).
-func NewContractTracingSubscriber(inner outbox.Subscriber, tr wrapper.Tracer) outbox.Subscriber {
-	return &contractTracingSubscriber{inner: inner, tracer: tr}
+func NewContractTracingSubscriber(inner outbox.Subscriber, tr wrapper.Tracer, opts ...TracingSubscriberOption) outbox.Subscriber {
+	s := &contractTracingSubscriber{inner: inner, tracer: tr}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 type contractTracingSubscriber struct {
-	inner  outbox.Subscriber
-	tracer wrapper.Tracer
+	inner      outbox.Subscriber
+	tracer     wrapper.Tracer
+	subWrapper SubscriberWrapperFunc
 }
 
 func (s *contractTracingSubscriber) Setup(ctx context.Context, sub outbox.Subscription) error {
@@ -74,6 +99,9 @@ func (s *contractTracingSubscriber) Subscribe(
 	wrapped, err := wrapper.WrapSubscriber(s.tracer, spec, handler)
 	if err != nil {
 		return fmt.Errorf("eventrouter: contract tracing subscriber: %w", err)
+	}
+	if s.subWrapper != nil {
+		wrapped = s.subWrapper(sub, wrapped)
 	}
 	return s.inner.Subscribe(ctx, sub, wrapped)
 }

--- a/runtime/eventrouter/contract_tracing_subscriber_test.go
+++ b/runtime/eventrouter/contract_tracing_subscriber_test.go
@@ -77,8 +77,8 @@ func TestNewContractTracingSubscriber_WrapsSubscribeAndDelegatesLifecycle(t *tes
 	assert.True(t, inner.stopIntakeCalled)
 
 	require.NoError(t, decorated.Subscribe(context.Background(), sub,
-		func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return outbox.Ack(), nil
+		func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		}))
 	require.NotNil(t, inner.capturedHandler)
 
@@ -110,8 +110,8 @@ func subscribeCapturingPanic(t *testing.T, decorated outbox.Subscriber, sub outb
 	func() {
 		defer func() { panicked = recover() }()
 		subscribeErr = decorated.Subscribe(context.Background(), sub,
-			func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-				return outbox.Ack(), nil
+			func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+				return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 			})
 	}()
 	return panicked, subscribeErr
@@ -224,8 +224,8 @@ func TestContractTracingSubscriber_NilInnerLifecycle(t *testing.T) {
 	}
 
 	require.Error(t, decorated.Subscribe(context.Background(), sub,
-		func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-			return outbox.Ack(), nil
+		func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 		}),
 		"Subscribe must error when inner is nil")
 
@@ -332,8 +332,8 @@ func TestContractTracingSubscriber_Subscribe_PropagatesWrapSubscriberError(t *te
 		ContractID:        "event.bad-kind.v1",
 		ContractKind:      "command", // WrapSubscriber rejects non-"event" kinds.
 		ContractTransport: "amqp",
-	}, func(_ context.Context, _ outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return outbox.Ack(), nil
+	}, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be \"event\"",

--- a/runtime/observability/metrics/config_event_collector.go
+++ b/runtime/observability/metrics/config_event_collector.go
@@ -119,16 +119,15 @@ func RecordConfigEventProcess(ctx context.Context, collector ConfigEventCollecto
 
 // ConfigEventMiddleware installs config-event owner metadata into the handler
 // context so that RecordConfigEventProcess can retrieve it inside the
-// EntryHandler. Settlement observation has been moved to the SubscriberHandler
-// layer via WrapConfigEventSubscriber; this middleware no longer appends a
-// SettlementObserver.
+// EntryHandler. Settlement observation is handled at the SubscriberHandler
+// layer by WrapConfigEventSubscriber; this middleware only injects owner ctx.
 //
 // The non-config-prefix fast path (isConfigEventSubscription == false) is
 // legitimate: non-config subscriptions and audit/command topics pass through
 // without instrumentation. Config subscriptions missing owner metadata are
 // intercepted at registration time by ConfigEventOwnerValidator and never
 // reach this middleware.
-func ConfigEventMiddleware(_ ConfigEventCollector) outbox.SubscriptionMiddleware {
+func ConfigEventMiddleware() outbox.SubscriptionMiddleware {
 	return func(sub outbox.Subscription, next outbox.EntryHandler) outbox.EntryHandler {
 		if !isConfigEventSubscription(sub) {
 			// Fast path: non-config-prefix or non-config topic — skip instrumentation.

--- a/runtime/observability/metrics/config_event_collector.go
+++ b/runtime/observability/metrics/config_event_collector.go
@@ -117,22 +117,18 @@ func RecordConfigEventProcess(ctx context.Context, collector ConfigEventCollecto
 	collector.RecordEventProcess(ctx, owner.cellID, owner.sliceID, reason)
 }
 
-// ConfigEventMiddleware installs config-event owner metadata for process
-// metrics and appends a settlement observer for final broker disposition.
+// ConfigEventMiddleware installs config-event owner metadata into the handler
+// context so that RecordConfigEventProcess can retrieve it inside the
+// EntryHandler. Settlement observation has been moved to the SubscriberHandler
+// layer via WrapConfigEventSubscriber; this middleware no longer appends a
+// SettlementObserver.
+//
 // The non-config-prefix fast path (isConfigEventSubscription == false) is
 // legitimate: non-config subscriptions and audit/command topics pass through
 // without instrumentation. Config subscriptions missing owner metadata are
 // intercepted at registration time by ConfigEventOwnerValidator and never
 // reach this middleware.
-//
-// Settlement is not visible here — it flows inside the Subscriber layer
-// (ConsumerBase.Wrap → Inner.Subscribe). Settlement observation is achieved
-// by appending a SettlementObserver to HandleResult.SettlementObservers;
-// the Subscriber layer calls NotifySettlement after final broker settlement.
-func ConfigEventMiddleware(collector ConfigEventCollector) outbox.SubscriptionMiddleware {
-	if collector == nil {
-		collector = NoopConfigEventCollector{}
-	}
+func ConfigEventMiddleware(_ ConfigEventCollector) outbox.SubscriptionMiddleware {
 	return func(sub outbox.Subscription, next outbox.EntryHandler) outbox.EntryHandler {
 		if !isConfigEventSubscription(sub) {
 			// Fast path: non-config-prefix or non-config topic — skip instrumentation.
@@ -141,13 +137,35 @@ func ConfigEventMiddleware(collector ConfigEventCollector) outbox.SubscriptionMi
 		owner := configEventOwner{cellID: sub.ObservabilityID(), sliceID: sub.SliceID}
 		return func(ctx context.Context, entry outbox.Entry) outbox.HandleResult {
 			ctx = context.WithValue(ctx, configEventOwnerContextKey{}, owner)
-			result := next(ctx, entry)
-			result.SettlementObservers = append(result.SettlementObservers, configEventSettlementObserver{
-				collector: collector,
-				owner:     owner,
-			})
-			return result
+			return next(ctx, entry)
 		}
+	}
+}
+
+// WrapConfigEventSubscriber wraps a SubscriberHandler to append a settlement
+// observer that records final broker disposition via ConfigEventCollector. This
+// is the SubscriberHandler-layer counterpart to ConfigEventMiddleware (which
+// handles the EntryHandler layer).
+//
+// Non-config subscriptions take the fast path and return next unchanged.
+// ConfigEventCollector nil is replaced with NoopConfigEventCollector.
+func WrapConfigEventSubscriber(
+	collector ConfigEventCollector, sub outbox.Subscription, next outbox.SubscriberHandler,
+) outbox.SubscriberHandler {
+	if collector == nil {
+		collector = NoopConfigEventCollector{}
+	}
+	if !isConfigEventSubscription(sub) {
+		return next
+	}
+	owner := configEventOwner{cellID: sub.ObservabilityID(), sliceID: sub.SliceID}
+	return func(ctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		out, settlement := next(ctx, entry)
+		out.SettlementObservers = append(out.SettlementObservers, configEventSettlementObserver{
+			collector: collector,
+			owner:     owner,
+		})
+		return out, settlement
 	}
 }
 

--- a/runtime/observability/metrics/config_event_collector_test.go
+++ b/runtime/observability/metrics/config_event_collector_test.go
@@ -94,24 +94,33 @@ func TestConfigEventMiddleware_RecordsProcessReasonFromSubscriptionOwner(t *test
 	require.Equal(t, []configEventProcessRecord{{
 		cell: "accesscore", slice: "configreceive", reason: obmetrics.ConfigEventProcessReasonAck,
 	}}, collector.processRecords)
-	require.Len(t, result.SettlementObservers, 1)
+	// Note: SettlementObservers is on DeliveryOutcome (SubscriberHandler layer),
+	// not on HandleResult (EntryHandler layer). ConfigEventMiddleware only injects
+	// owner ctx; settlement observer is added by WrapConfigEventSubscriber.
 }
 
-func TestConfigEventMiddleware_RecordsSettlementOnlyAfterNotification(t *testing.T) {
+// TestWrapConfigEventSubscriber_RecordsSettlementOnlyAfterNotification verifies
+// that the settlement observer added by WrapConfigEventSubscriber records the
+// metric only after NotifySettlement is called, not during handler execution.
+func TestWrapConfigEventSubscriber_RecordsSettlementOnlyAfterNotification(t *testing.T) {
 	collector := &recordingConfigEventCollector{}
-	mw := obmetrics.ConfigEventMiddleware(collector)
+	sub := outbox.Subscription{
+		Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore",
+		CellID: "accesscore", SliceID: "configreceive",
+	}
 	entry := newConfigEventEntry(t, "evt-1")
-	wrapped := mw(
-		outbox.Subscription{Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore", CellID: "accesscore", SliceID: "configreceive"},
-		func(context.Context, outbox.Entry) outbox.HandleResult {
-			return outbox.Requeue(nil)
-		},
-	)
 
-	result := wrapped(context.Background(), entry)
+	// WrapConfigEventSubscriber wraps a SubscriberHandler and appends the
+	// settlement observer to DeliveryOutcome.SettlementObservers.
+	inner := func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue}, nil
+	}
+	wrapped := obmetrics.WrapConfigEventSubscriber(collector, sub, inner)
+
+	outcome, _ := wrapped(context.Background(), entry)
 	assert.Empty(t, collector.settlementRecords)
 
-	outbox.NotifySettlement(context.Background(), result, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
+	outbox.NotifySettlement(context.Background(), outcome, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 
 	require.Equal(t, []configEventSettlementRecord{{
 		cell: "accesscore", slice: "configreceive", disposition: "requeue", result: outbox.SettlementResultSuccess,
@@ -126,13 +135,21 @@ func TestConfigEventMiddleware_SkipsSubscriptionsWithoutOwnerOrConfigTopic(t *te
 		{Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore", CellID: "accesscore"},
 		{Topic: "event.audit.appended.v1", ConsumerGroup: "auditcore", CellID: "auditcore", SliceID: "auditappend"},
 	} {
-		wrapped := mw(sub, func(ctx context.Context, _ outbox.Entry) outbox.HandleResult {
+		entry := newConfigEventEntry(t, "evt-1")
+		// EntryHandler layer (middleware): process reason must not be recorded.
+		entryHandler := mw(sub, func(ctx context.Context, _ outbox.Entry) outbox.HandleResult {
 			obmetrics.RecordConfigEventProcess(ctx, collector, obmetrics.ConfigEventProcessReasonAck)
 			return outbox.Ack()
 		})
-		entry := newConfigEventEntry(t, "evt-1")
-		result := wrapped(context.Background(), entry)
-		outbox.NotifySettlement(context.Background(), result,
+		entryHandler(context.Background(), entry)
+
+		// SubscriberHandler layer: settlement observer must not be appended for
+		// non-qualifying subscriptions (missing owner or non-config topic).
+		inner := func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			return outbox.DeliveryOutcome{Disposition: outbox.DispositionAck}, nil
+		}
+		outcome, _ := obmetrics.WrapConfigEventSubscriber(collector, sub, inner)(context.Background(), entry)
+		outbox.NotifySettlement(context.Background(), outcome,
 			entry, outbox.DispositionAck, outbox.SettlementResultSuccess, nil)
 	}
 
@@ -222,23 +239,31 @@ func TestConfigEventOwnerValidator(t *testing.T) {
 	}
 }
 
-// TestConfigEventMiddleware_RetryExhaustedSettlement verifies that when
-// NotifySettlement is called with SettlementResultRetryExhausted, the
-// settlement observer records the correct result label.
-func TestConfigEventMiddleware_RetryExhaustedSettlement(t *testing.T) {
+// TestWrapConfigEventSubscriber_RetryExhaustedSettlement verifies that when
+// NotifySettlement is called with SettlementResultRetryExhausted on a
+// WrapConfigEventSubscriber-wrapped handler, the settlement observer records
+// the correct result label.
+func TestWrapConfigEventSubscriber_RetryExhaustedSettlement(t *testing.T) {
 	t.Parallel()
 	collector := &recordingConfigEventCollector{}
-	mw := obmetrics.ConfigEventMiddleware(collector)
+	sub := outbox.Subscription{
+		Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore",
+		CellID: "accesscore", SliceID: "configreceive",
+	}
 	entry := newConfigEventEntry(t, "evt-retry-exhausted")
-	wrapped := mw(
-		outbox.Subscription{Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore", CellID: "accesscore", SliceID: "configreceive"},
-		func(context.Context, outbox.Entry) outbox.HandleResult {
-			return outbox.HandleResult{Disposition: outbox.DispositionReject, ProcessReason: "retry_exhausted"}
-		},
-	)
 
-	result := wrapped(context.Background(), entry)
-	outbox.NotifySettlement(context.Background(), result, entry, outbox.DispositionReject, outbox.SettlementResultRetryExhausted, nil)
+	// ProcessReason is carried on DeliveryOutcome (set by ConsumerBase.Wrap when
+	// retry budget is exhausted). Use it here to simulate the exhausted path.
+	inner := func(context.Context, outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		return outbox.DeliveryOutcome{
+			Disposition:   outbox.DispositionReject,
+			ProcessReason: "retry_exhausted",
+		}, nil
+	}
+	wrapped := obmetrics.WrapConfigEventSubscriber(collector, sub, inner)
+
+	outcome, _ := wrapped(context.Background(), entry)
+	outbox.NotifySettlement(context.Background(), outcome, entry, outbox.DispositionReject, outbox.SettlementResultRetryExhausted, nil)
 
 	require.Equal(t, []configEventSettlementRecord{{
 		cell: "accesscore", slice: "configreceive", disposition: "reject", result: outbox.SettlementResultRetryExhausted,

--- a/runtime/observability/metrics/config_event_collector_test.go
+++ b/runtime/observability/metrics/config_event_collector_test.go
@@ -79,7 +79,7 @@ func TestProviderConfigEventCollector_EmitsExpectedMetricsAndLabels(t *testing.T
 
 func TestConfigEventMiddleware_RecordsProcessReasonFromSubscriptionOwner(t *testing.T) {
 	collector := &recordingConfigEventCollector{}
-	mw := obmetrics.ConfigEventMiddleware(collector)
+	mw := obmetrics.ConfigEventMiddleware()
 	wrapped := mw(
 		outbox.Subscription{Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore", CellID: "accesscore", SliceID: "configreceive"},
 		func(ctx context.Context, _ outbox.Entry) outbox.HandleResult {
@@ -129,7 +129,7 @@ func TestWrapConfigEventSubscriber_RecordsSettlementOnlyAfterNotification(t *tes
 
 func TestConfigEventMiddleware_SkipsSubscriptionsWithoutOwnerOrConfigTopic(t *testing.T) {
 	collector := &recordingConfigEventCollector{}
-	mw := obmetrics.ConfigEventMiddleware(collector)
+	mw := obmetrics.ConfigEventMiddleware()
 
 	for _, sub := range []outbox.Subscription{
 		{Topic: "event.config.entry-upserted.v1", ConsumerGroup: "accesscore", CellID: "accesscore"},

--- a/tests/integration/entry_lift_test.go
+++ b/tests/integration/entry_lift_test.go
@@ -16,7 +16,8 @@ import (
 // This helper replaces the deleted outbox.EntryToSubscriberHandler in test-only
 // code. Production callers use SubscriberWithMiddleware.SubscribeEntry instead.
 func entryToSubHandler(h outbox.EntryHandler) outbox.SubscriberHandler {
-	return func(ctx context.Context, entry outbox.Entry) (outbox.HandleResult, outbox.Settlement) {
-		return h(ctx, entry), nil
+	return func(ctx context.Context, entry outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+		r := h(ctx, entry)
+		return outbox.DeliveryOutcome{Disposition: r.Disposition, Err: r.Err}, nil
 	}
 }

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -13,6 +13,9 @@
 //   - INVARIANT: OUTBOX-TOPIC-FAILOPEN-01
 //   - INVARIANT: METADATA-LIMITS-SINGLE-SOURCE-01
 //   - INVARIANT: OUTBOXTEST-CLOSE-VIA-BUDGET-01
+//   - INVARIANT: OUTBOX-HANDLERESULT-FIELDS-FROZEN-01
+//   - INVARIANT: OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01
+//   - INVARIANT: OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01
 //
 // Package archtest — outbox invariants.
 //
@@ -1504,37 +1507,39 @@ func repoRootFromTestPath(t *testing.T) string {
 // ---------------------------------------------------------------------------
 
 // handleResultAllowedFields is the verbatim field set of kernel/outbox.HandleResult.
-// Adding a fifth field requires extending this allowlist deliberately, which
-// is the moment to (a) re-read ADR 202605031900-adr-handler-vocabulary-collapse.md,
+// HandleResult is the slim business-handler return type (#663 type-split).
+// Adding a field requires extending this allowlist deliberately, which is
+// the moment to (a) re-read ADR 202605031900-adr-handler-vocabulary-collapse.md,
 // (b) decide whether the new field belongs on the EntryHandler return contract
-// or in ConsumerBase internal state, and (c) extend the Ack/Requeue/Reject
-// factories in kernel/outbox/result.go if the field can be carried by them.
+// or in DeliveryOutcome (subscriber-layer carrier), and (c) extend the
+// Ack/Requeue/Reject factories in kernel/outbox/result.go if the field can be
+// carried by them.
+//
+// ProcessReason and SettlementObservers were moved to DeliveryOutcome by the
+// #663 type-split and are guarded by OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01.
 var handleResultAllowedFields = map[string]struct{}{
-	"Disposition":         {},
-	"Err":                 {},
-	"ProcessReason":       {},
-	"SettlementObservers": {},
+	"Disposition": {},
+	"Err":         {},
 }
 
 // INVARIANT: OUTBOX-HANDLERESULT-FIELDS-FROZEN-01
 //
 // TestOutboxHandleResultFieldsFrozen enforces OUTBOX-HANDLERESULT-FIELDS-FROZEN-01:
-// kernel/outbox.HandleResult must declare exactly the four fields listed in
-// handleResultAllowedFields. The factories Ack/Requeue/Reject cover the two
-// stable axes (Disposition, Err); ProcessReason and SettlementObservers are
-// intentional fallback-literal escape hatches for kernel internal retry
-// plumbing and middleware-handler protocol (see eventbus.md "回落字面量").
+// kernel/outbox.HandleResult must declare exactly the two fields listed in
+// handleResultAllowedFields. HandleResult is the slim business-handler return
+// type (#663 type-split): Disposition and Err are the only axes a business
+// handler can express. ProcessReason and SettlementObservers now live in
+// DeliveryOutcome (subscriber-layer carrier), enforced separately by
+// OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01.
 //
 // Drift in this field set silently changes what every cell handler can/must
-// produce, so freezing the set keeps the fallback intentional.
+// produce, so freezing the set keeps the interface intentional.
 //
 // Cannot funnel: HandleResult is a kernel-owned type whose literal construction
-// is required by consumer_base.go internal plumbing — making fields unexported
-// to force factory-only access would break that intra-package construction and
-// the typed-test conformance harness. No schema/marker source can express
-// "exactly these field names" as a Go compile-time constraint without
-// regenerating the type itself, which loses hand-tuned tags and comments.
-// Archtest is the minimum-friction gate.
+// is required by result.go (factories) and the conformance harness. No schema/
+// marker source can express "exactly these field names" as a Go compile-time
+// constraint without regenerating the type itself, which loses hand-tuned tags
+// and comments. Archtest is the minimum-friction gate.
 func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 	root := findModuleRoot(t)
 	path := filepath.Join(root, "kernel", "outbox", "outbox.go")
@@ -1607,6 +1612,116 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01
+// ---------------------------------------------------------------------------
+
+// deliveryOutcomeAllowedFields is the verbatim field set of
+// kernel/outbox.DeliveryOutcome (#663 type-split).
+//
+// DeliveryOutcome is the subscriber-layer carrier (returned by SubscriberHandler,
+// consumed by NotifySettlement). Its fields are frozen to prevent silent
+// protocol drift that would break broker settlement or observability:
+//   - Disposition / Err      — ack/nack semantics (mirrors slim HandleResult)
+//   - ProcessReason          — kernel-internal tag set only by ConsumerBase
+//     on the retry_exhausted path; rabbitmq subscriber reads it for logging.
+//   - SettlementObservers    — subscriber-layer observer chain appended by
+//     WrapConfigEventSubscriber (and similar future wrappers) at the
+//     SubscriberHandler layer; NotifySettlement fans out to all observers.
+//
+// Adding or removing a field silently changes the subscriber-layer protocol.
+var deliveryOutcomeAllowedFields = map[string]struct{}{
+	"Disposition":         {},
+	"Err":                 {},
+	"ProcessReason":       {},
+	"SettlementObservers": {},
+}
+
+// INVARIANT: OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01
+//
+// TestOutboxDeliveryOutcomeFieldsFrozen enforces OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01:
+// kernel/outbox.DeliveryOutcome must declare exactly the four fields listed in
+// deliveryOutcomeAllowedFields (#663 type-split from HandleResult).
+//
+// DeliveryOutcome is the subscriber-layer carrier: ConsumerBase.Wrap lifts a
+// slim HandleResult into a DeliveryOutcome, SubscriberHandler returns it, and
+// NotifySettlement consumes it. Fields must not drift silently — adding a field
+// changes the SubscriberHandler protocol and requires deliberate review of all
+// Subscriber implementations (rabbitmq/mqtt/eventbus/wrapper).
+//
+// Hard via reflect schema freeze: any field drift triggers a tuple comparison
+// failure, forcing the change through this explicit review checkpoint. No
+// schema/marker source can express "exactly these field names" as a Go
+// compile-time constraint without regenerating the type. Archtest is the
+// minimum-friction gate at Medium enforcement level.
+func TestOutboxDeliveryOutcomeFieldsFrozen(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "kernel", "outbox", "outbox.go")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var (
+		found   bool
+		seen    = make(map[string]struct{})
+		unknown []string
+	)
+	EachInSubtree[ast.TypeSpec](f, func(ts *ast.TypeSpec) {
+		if ts.Name == nil || ts.Name.Name != "DeliveryOutcome" {
+			return
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok || st.Fields == nil {
+			return
+		}
+		found = true
+		for _, field := range st.Fields.List {
+			if len(field.Names) == 0 {
+				line := fset.Position(field.Type.Pos()).Line
+				unknown = append(unknown, fmt.Sprintf("kernel/outbox/outbox.go:%d: <embedded field>", line))
+				continue
+			}
+			for _, name := range field.Names {
+				seen[name.Name] = struct{}{}
+				if _, ok := deliveryOutcomeAllowedFields[name.Name]; !ok {
+					line := fset.Position(name.Pos()).Line
+					unknown = append(unknown, fmt.Sprintf("kernel/outbox/outbox.go:%d: %s", line, name.Name))
+				}
+			}
+		}
+	})
+
+	if !found {
+		t.Fatalf("DeliveryOutcome struct definition not found in kernel/outbox/outbox.go " +
+			"— if the type was relocated to another file in package outbox, update " +
+			"this test's hardcoded path along with the move")
+	}
+
+	var missing []string
+	for k := range deliveryOutcomeAllowedFields {
+		if _, ok := seen[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+
+	sort.Strings(unknown)
+	sort.Strings(missing)
+	for _, u := range unknown {
+		t.Errorf("OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01: %s — field not in allowlist; "+
+			"to add a field, update deliveryOutcomeAllowedFields and review "+
+			"ADR 202605031900-adr-handler-vocabulary-collapse.md plus all "+
+			"Subscriber implementations (rabbitmq/mqtt/eventbus/wrapper)", u)
+	}
+	for _, m := range missing {
+		t.Errorf("OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01: required field %s missing from "+
+			"kernel/outbox.DeliveryOutcome — removing a field changes the SubscriberHandler "+
+			"protocol; review ADR 202605031900 and update deliveryOutcomeAllowedFields "+
+			"deliberately if the removal is intentional", m)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01
 // ---------------------------------------------------------------------------
 
@@ -1615,13 +1730,15 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 // production file must use the Ack/Requeue/Reject factories from
 // kernel/outbox/result.go.
 //
-// Why these three:
-//   - kernel/outbox/result.go         — defines the factories themselves.
-//   - kernel/outbox/consumer_base.go  — kernel internal retry/settle plumbing
-//     constructs HandleResult with ProcessReason / SettlementObservers, which
-//     the factories do not expose (see eventbus.md "回落字面量").
-//   - kernel/outbox/outboxtest/conformance.go — shared conformance harness;
+// Why these two (post #663 type-split):
+//   - kernel/outbox/result.go                  — defines the factories themselves.
+//   - kernel/outbox/outboxtest/conformance.go  — shared conformance harness;
 //     non-_test.go by package convention but used only from test binaries.
+//
+// kernel/outbox/consumer_base.go was removed from this allowlist by the #663
+// type-split: consumer_base.go now constructs DeliveryOutcome (not HandleResult)
+// for its internal retry/settle plumbing. DeliveryOutcome literals are governed
+// by the separate OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01 archtest.
 //
 // Adding a new entry requires the justification to live **next to the map
 // entry below as a Go comment** (not in the file being scanned, since that
@@ -1631,7 +1748,6 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 // deliberately.
 var handleResultLiteralAllowlist = map[string]struct{}{
 	"kernel/outbox/result.go":                 {},
-	"kernel/outbox/consumer_base.go":          {},
 	"kernel/outbox/outboxtest/conformance.go": {},
 }
 

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1648,11 +1648,14 @@ var deliveryOutcomeAllowedFields = map[string]struct{}{
 // changes the SubscriberHandler protocol and requires deliberate review of all
 // Subscriber implementations (rabbitmq/mqtt/eventbus/wrapper).
 //
-// Hard via reflect schema freeze: any field drift triggers a tuple comparison
-// failure, forcing the change through this explicit review checkpoint. No
-// schema/marker source can express "exactly these field names" as a Go
-// compile-time constraint without regenerating the type. Archtest is the
-// minimum-friction gate at Medium enforcement level.
+// Grading: Medium (AST field-NAME freeze). The scan parses outbox.go and
+// compares DeliveryOutcome's declared field names against the allowlist —
+// add/remove/rename of a field fails the comparison and forces the change
+// through this explicit review checkpoint. Blind spot: a field TYPE change
+// (e.g. Err error -> Err string) is NOT caught, since only names are checked.
+// Hard-upgrade path: reflect-based enumeration (field count + name + type
+// identity), the same ceiling as the sibling OUTBOX-HANDLERESULT-FIELDS-FROZEN-01;
+// kept name-only here so the two sibling freezes stay structurally identical.
 func TestOutboxDeliveryOutcomeFieldsFrozen(t *testing.T) {
 	root := findModuleRoot(t)
 	path := filepath.Join(root, "kernel", "outbox", "outbox.go")

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1779,12 +1779,14 @@ var handleResultLiteralAllowlist = map[string]struct{}{
 //  2. Bare `HandleResult{...}` when the file's package itself is the
 //     kernel/outbox package (covers any future kernel/outbox/*.go file).
 //
-// Cannot funnel: ProcessReason and SettlementObservers are runtime-determined
-// fields populated by handler code paths and middleware, with no schema /
-// marker source from which a literal-vs-factory choice can be derived. Type
-// system cannot express "callers in cells/ must use these three function
-// names" without unexporting HandleResult itself, which would break the
-// kernel-internal literal construction the allowlist exists to permit.
+// Cannot funnel to the type system: expressing "callers in cells/ must use
+// these three function names" requires unexporting HandleResult, which would
+// break the kernel-internal literal construction the allowlist exists to permit
+// (the result.go factories + the conformance harness). Post-#663 HandleResult
+// is the slim {Disposition, Err}; the kernel-injected ProcessReason and the
+// subscriber-layer SettlementObservers moved to DeliveryOutcome, so the factory
+// trio (Ack/Requeue/Reject) fully covers every business HandleResult value —
+// there is no field a business literal could carry that a factory cannot.
 // Archtest enforces the path discipline that no other layer can.
 //
 // Closes PR445-FU-PACKAGEALIASES-TYPE-AWARE-01 for this rule.
@@ -1814,8 +1816,10 @@ func TestOutboxHandleResultFactoryPreferred(t *testing.T) {
 	for _, v := range violations {
 		t.Errorf("OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01: %s — use outbox.Ack() / "+
 			"outbox.Requeue(err) / outbox.Reject(err) instead of constructing the "+
-			"struct literal; if you genuinely need ProcessReason or SettlementObservers, "+
-			"extend handleResultLiteralAllowlist with a code-comment justification", v)
+			"HandleResult{...} struct literal; the slim HandleResult{Disposition, Err} is "+
+			"fully covered by these factories (ProcessReason / SettlementObservers now live "+
+			"on DeliveryOutcome, not HandleResult). Literal construction is reserved for the "+
+			"kernel-internal sites in handleResultLiteralAllowlist", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

把双用途的 `outbox.HandleResult` 拆分为业务面 slim 类型 `{Disposition, Err}` + subscriber 层载体 `DeliveryOutcome{Disposition, Err, ProcessReason, SettlementObservers}`，达成业务 handler 返回面最小化。

## Why / 背景

`outbox.HandleResult` 同时充当业务 handler 返回类型与 subscriber 层 settle 载体；`ProcessReason`（仅 kernel 设 `"retry_exhausted"`）与 `SettlementObservers`（middleware→subscriber settle 观测通道）对业务面是噪声。#663 [OUTBOX-HANDLERESULT-SLIM-01] 把这两字段迁到 subscriber 层 `DeliveryOutcome`，业务 `HandleResult` 收为 `{Disposition, Err}`，factory（`Ack/Requeue/Reject`）全覆盖、业务面收敛达成 type-system Hard。

对标 Watermill：业务 handler 返回值只携带 ack/nack 意图；settle 后 instrumentation 由 subscriber 层 wrapper 在 settle 点注入（`components/metrics/handler.go` 的 defer 模式），不在返回值携带 observer 回调。`ConsumerBase` ≈ Watermill `handleMessage`（唯一 ack/nack 决策点）。

关键改动：
- `SubscriberHandler` 返回 `(DeliveryOutcome, Settlement)`；`NotifySettlement` 收 `DeliveryOutcome`；`ConsumerBase.Wrap` 是唯一 `HandleResult → DeliveryOutcome` 升格点。
- `retryLoop` 不再透传 observers（业务返回值已无此字段），plumbing 整段删除。
- settle observer 从 EntryHandler 层 `ConfigEventMiddleware`（现仅注入 owner ctx 供 process 指标）重定位到 subscriber 层 `obmetrics.WrapConfigEventSubscriber`，经 `eventrouter.WithSubscriberWrapper` + `bootstrap.WithConfigEventCollector` 接线。
- archtest：`HandleResult` 2 字段 FROZEN；新增 `OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01` 冻结 4 字段；`FACTORY-PREFERRED` allowlist 移除 `consumer_base.go`。

> 注：#663 是 trigger-gated backlog，三条触发条件均未满足；本 PR 经用户显式 override trigger 后实施（决策留痕见 issue + plan）。

## Refs

- Closes #663
- ADR `docs/architecture/202605031900-adr-handler-vocabulary-collapse.md` §Amendment 2026-06-06（反转 SubscriberHandler 签名 + 记录类型拆分）
- `ref: ThreeDotsLabs/watermill message/router.go@master`（HandlerFunc / handleMessage ack-nack 分离）
- `ref: ThreeDotsLabs/watermill components/metrics/handler.go@master`（middleware-based instrumentation）
- `ref: IBM/sarama consumer_group.go@main`（error-only return / session.MarkMessage settle）
- `ref: nats-io/nats.go js.go@main`（msg.Ack/Nak as message methods）

## Risk / 兼容性

- 破坏性：kernel 内部类型签名变更（`SubscriberHandler` / `NotifySettlement` / `ConsumerBase.Wrap` 等），无 wire 契约影响（`DeliveryOutcome` 永不过 wire/broker，是进程内 subscriber 层载体）。
- 消费方已全部同步更新（见下 implementation matrix）。**业务 cells/examples 零改动**——本就 100% factory、不读这两字段。
- 无向后兼容 shim / 双路径；单原子 PR。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./...` 本地通过（仅余 pre-existing/环境项：`adapters/rabbitmq` 的 `TestNewConnection_ConnectTimeout_Blackhole` 网络 flake + 全 archtest 套件经 bare `go test` 的 satellite-module 加载失败，均不在 PR CI gate 且不在本 diff）
- [x] `golangci-lint run ./<changed>/...` 0 issues
- [x] PR-gate archtest invariants（`hack/verify-archtest-invariants.sh`）通过
- [x] kernel/outbox 覆盖率 95.9%（≥90%）

## Implementation matrix（contract-fanout：Go interface 签名变更）

```
Contract: outbox.SubscriberHandler 返回 (HandleResult, Settlement) → (DeliveryOutcome, Settlement)
          + outbox.NotifySettlement 首值参 HandleResult → DeliveryOutcome
Change:   业务面 HandleResult slim 为 {Disposition, Err}；ProcessReason/SettlementObservers 迁 DeliveryOutcome
Implementations (Subscriber.Subscribe 消费方):
  [x] runtime/eventbus (in-mem)        — settle loop 类型迁移
  [x] adapters/rabbitmq                — settle loop + res.ProcessReason 检查
  [x] adapters/mqtt                    — settle loop 类型迁移
  [x] kernel/wrapper.WrapSubscriber    — span observer 注入闭包
  [x] runtime/eventrouter.contractTracingSubscriber — + WrapConfigEventSubscriber 接线
Conformance test: kernel/outbox/outboxtest/conformance.go（SubscriberHandler 闭包迁 DeliveryOutcome）
Repro:
  go test ./kernel/outbox/... -cover
  go test ./tools/archtest/ -run 'FieldsFrozen|FactoryPreferred|DeliveryOutcome'
  go test -tags='integration mqtt_tls pg e2e' -run=xNONEx ./...   # 全 build-tag 编译
Dependent contracts (governance scan): none（无 contract.yaml / wire schema 变更）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
