### PR TITLE
refactor(archtest): 迁 Saga 规则族 → module-path-agnostic CellRule [#1634]

### DIFF
--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -372,16 +372,6 @@ func typeHasResetAt(t types.Type) bool {
 	return isTimeTimeType(param)
 }
 
-// isTimeDurationType reports whether t is time.Duration.
-func isTimeDurationType(t types.Type) bool {
-	named, ok := t.(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj.Pkg() != nil && obj.Pkg().Path() == "time" && obj.Name() == "Duration"
-}
-
 // isTimeTimeType reports whether t is time.Time.
 func isTimeTimeType(t types.Type) bool {
 	named, ok := t.(*types.Named)

--- a/tools/archtest/external.go
+++ b/tools/archtest/external.go
@@ -115,6 +115,8 @@ type ConfigForExternalCell struct {
 // GoCell platform (they reason about how the consumer uses platform APIs like
 // errcode / panicregister, not about GoCell's own internal package layout).
 //
+// Registered saga rule: SAGA-STEP-COMPENSATE-PURE-01 (CheckSagaStepCompensatePure).
+//
 // This is the GoCell analog of the []*analysis.Analyzer slice handed to
 // multichecker.Main: a flat, registry-free list. The set grows as more rules
 // are migrated from their legacy _test.go form into importable CellRules (M3

--- a/tools/archtest/external.go
+++ b/tools/archtest/external.go
@@ -147,6 +147,36 @@ type ConfigForExternalCell struct {
 //     → vacuous-green there. Migrated for the unified PlatformModulePath
 //     parameterization + fork-safety only; enforced in GoCell via
 //     TestScaffoldListenerMarkerTypedConst.
+//   - SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 (CheckSagaCoordinatorNoHeartbeatLoop):
+//     reasons about GoCell-internal runtime/saga layout (or conformance enrollment)
+//     → vacuous/false-red in an external module.
+//   - SAGA-EXECUTOR-RAND-INJECTED-01 (CheckSagaExecutorRandInjected): reasons about
+//     GoCell-internal runtime/saga layout (or conformance enrollment) → vacuous/
+//     false-red in an external module.
+//   - SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01 (CheckSagaJournalConformanceEnrollment):
+//     reasons about GoCell-internal runtime/saga layout (or conformance enrollment)
+//     → vacuous/false-red in an external module.
+//   - SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01 (CheckSagaGlobalReaderConformanceEnrollment):
+//     reasons about GoCell-internal runtime/saga layout (or conformance enrollment)
+//     → vacuous/false-red in an external module.
+//   - SAGA-JOURNAL-HOLDER-SEAL-01 (CheckSagaJournalHolderSeal): reasons about
+//     GoCell-internal runtime/saga layout (or conformance enrollment) → vacuous/
+//     false-red in an external module.
+//   - SAGA-DRIVE-BEHIND-LEADER-GATE-01 (CheckSagaDriveBehindLeaderGate): reasons
+//     about GoCell-internal runtime/saga layout (or conformance enrollment) →
+//     vacuous/false-red in an external module.
+//   - SAGA-STEP-RUN-OUTSIDE-TX-01 (CheckSagaStepRunOutsideTx): reasons about
+//     GoCell-internal runtime/saga layout (or conformance enrollment) → vacuous/
+//     false-red in an external module.
+//   - SAGA-CONSTRUCTOR-NIL-GUARD-01 (CheckSagaConstructorNilGuard): reasons about
+//     GoCell-internal runtime/saga layout (or conformance enrollment) → vacuous/
+//     false-red in an external module.
+//   - SAGA-SLOG-INSTANCE-FIELDS-CALLER-01 (CheckSagaSlogInstanceFieldsCaller):
+//     reasons about GoCell-internal runtime/saga layout (or conformance enrollment)
+//     → vacuous/false-red in an external module.
+//   - SAGA-METRIC-LABEL-VALUES-FROZEN-01 (CheckSagaMetricLabelValuesFrozen):
+//     reasons about GoCell-internal runtime/saga layout (or conformance enrollment)
+//     → vacuous/false-red in an external module.
 //
 // An external consumer gets the rules migrated so far plus any cfg.ExtraRules
 // they add. The set expands as additional portable rules land in #1302.
@@ -161,6 +191,7 @@ func StandardCellRules() []*CellRule {
 		// sanctioned planDerivedArtifact site (no such site in an external repo →
 		// pure ban). Cell-applicable; Hard downstream (types.Info caller-allowlist).
 		{ID: ruleScaffoldDerivedForceOverwrite01, Run: CheckScaffoldDerivedForceOverwrite},
+		{ID: sagaCompensatePureRuleID, Run: CheckSagaStepCompensatePure},
 	}
 }
 

--- a/tools/archtest/external_test.go
+++ b/tools/archtest/external_test.go
@@ -56,6 +56,7 @@ func TestStandardCellRulesComposition(t *testing.T) {
 		ruleMessageConstLiteral01:           true,
 		ruleExportedErrorNew01:              true,
 		ruleScaffoldDerivedForceOverwrite01: true,
+		sagaCompensatePureRuleID:            true,
 	}
 	for id := range seen {
 		if !wantRuleIDs[id] {

--- a/tools/archtest/healthcheck_verify_runtime_test.go
+++ b/tools/archtest/healthcheck_verify_runtime_test.go
@@ -146,28 +146,6 @@ esac
 `
 }
 
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}
-
 func indent(s string) string {
 	if s == "" {
 		return "  <empty>"

--- a/tools/archtest/healthcheck_verify_runtime_test.go
+++ b/tools/archtest/healthcheck_verify_runtime_test.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -117,7 +118,7 @@ func TestHealthcheckVerifyRuntime01(t *testing.T) {
 			if !ok {
 				wantDesc := "non-zero"
 				if tc.wantExit != -1 {
-					wantDesc = itoa(tc.wantExit)
+					wantDesc = strconv.Itoa(tc.wantExit)
 				}
 				t.Fatalf("HEALTHCHECK-VERIFY-CLEANUP-AND-WAIT-TIMEOUT-01 (E/%s): "+
 					"got exit %d, want %s.\nWhy: %s\nScript output:\n%s",
@@ -139,7 +140,7 @@ func buildDockerStub(upExit int) string {
 # Test stub for docker — used by TestHealthcheckVerifyRuntime01.
 echo "[docker-stub] $*" >&2
 case "$2" in
-  up)   exit ` + itoa(upExit) + ` ;;
+  up)   exit ` + strconv.Itoa(upExit) + ` ;;
   down) exit 1 ;;
   *)    exit 0 ;;
 esac

--- a/tools/archtest/outbox_reserved_metadata_keys_frozen_test.go
+++ b/tools/archtest/outbox_reserved_metadata_keys_frozen_test.go
@@ -59,7 +59,6 @@ package archtest
 
 import (
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -164,11 +163,4 @@ func reservedKeysDiff(got, want []string) string {
 	slices.Sort(missing)
 	return "  extra (in production, not in golden):   " + sliceOrNone(extra) + "\n" +
 		"  missing (in golden, not in production): " + sliceOrNone(missing)
-}
-
-func sliceOrNone(s []string) string {
-	if len(s) == 0 {
-		return "(none)"
-	}
-	return "[" + strings.Join(s, ", ") + "]"
 }

--- a/tools/archtest/saga_invariants.go
+++ b/tools/archtest/saga_invariants.go
@@ -31,11 +31,17 @@ package archtest
 //
 //	SAGA-STEP-COMPENSATE-PURE-01 via CheckSagaStepCompensatePure.
 //
-// The other ten Check* are importable but intentionally NOT registered because
-// they constrain GoCell's OWN runtime/saga internals (Coordinator, executor,
-// sagalog, journal, etc.) — an external Cell module that merely uses the saga
-// engine would have zero runtime/saga/ production files and would see vacuous-
-// green or false-red results for those rules.
+// The other ten Check* are importable but intentionally NOT registered, and are
+// GoCell-internal dogfood helpers — NOT a consumer API. They constrain GoCell's
+// OWN runtime/saga internals (Coordinator, executor, sagalog, journal, etc.):
+// each IGNORES cfg (the scan scope is a hardcoded GoCell path such as
+// ./runtime/saga/... or ./kernel/saga/journal/..., never the consumer's module),
+// so an external Cell module that merely uses the saga engine sees vacuous-green
+// or false-red results. Do NOT register them in StandardCellRules or pass them
+// via ConfigForExternalCell.ExtraRules — only CheckSagaStepCompensatePure is a
+// portable consumer rule (it alone honors the cfg.BuildTags consumer-scan
+// contract). This single godoc is the authoritative internal/portable boundary;
+// per-func docs defer to it rather than repeating the caveat ten times.
 //
 // Two rules remain in saga_invariants_test.go (no importable Check*):
 //
@@ -521,16 +527,28 @@ func sagaStepRunFixturePattern(fix string) (dir, pattern string) {
 }
 
 // CheckSagaStepCompensatePure is the importable, registered form of
-// SAGA-STEP-COMPENSATE-PURE-01. It scans the running module's production code
-// (with cfg.BuildTags) for CompensateFunc bodies that call forbidden persistent
-// interfaces (outbox.Writer, outbox.Emitter, persistence.TxRunner, *sql.Tx,
-// pgx.Tx). This rule applies to any Cell that uses the saga engine and assigns
-// CompensateFunc values.
+// SAGA-STEP-COMPENSATE-PURE-01. It scans the running module's production code and
+// enforces the COMPLETE invariant (not just the direct forbidden-call scan), so
+// an external Cell repo gets the same escape-hatch guards GoCell dogfoods:
+//
+//   - A1: CompensateFunc bodies must not call forbidden persistent interfaces
+//     (outbox.Writer, outbox.Emitter, persistence.TxRunner, *sql.Tx, pgx.Tx).
+//   - B1: a CompensateFunc literal body must not exceed sagaMaxCompensateStmts
+//     top-level statements (long bodies can hide helper-indirected side effects).
+//   - B2: no reflect MethodByName dispatch inside a CompensateFunc body.
+//   - B3: a CompensateFunc value must not be passed as a function argument
+//     (outside the sanctioned safeRunCompensate transport funnel).
+//
+// Consumer-scan contract (matches the other registered CellRules, e.g. errcode):
+// it scans the consumer's DEFAULT build config first, then re-scans with
+// cfg.BuildTags when non-empty, de-duplicating by (Rel, Line, Message). This
+// catches a violation behind a //go:build tag without false-red on tag-only
+// files, and a false-green on default-build files that a hardcoded foreign tag
+// union would miss. GoCell's dogfood passes FlatNonDefaultTags() as cfg.BuildTags.
 //
 // Registered in [StandardCellRules].
 func CheckSagaStepCompensatePure(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
-	var all []Diagnostic
 	scan := func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
@@ -542,24 +560,106 @@ func CheckSagaStepCompensatePure(t *testing.T, cfg ConfigForExternalCell) []Diag
 			if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
 				continue
 			}
-			out = append(out, scanCompensatePure(p, file, ifaces, funcDecls)...)
+			out = append(out, scanCompensatePure(p, file, ifaces, funcDecls)...) // A1
+			out = append(out, scanCompensateBodyCount(p, file)...)               // B1
+			out = append(out, scanCompensateMethodByName(p, file, funcDecls)...) // B2
+			out = append(out, scanCompensateFuncArg(p, file)...)                 // B3
 		}
 		return out
 	}
-	all = append(all, Run(t, Production(TypedOpts{Tags: FlatNonDefaultTags()}), scan)...)
-	if len(cfg.BuildTags) > 0 {
-		seen := map[string]bool{}
-		for _, d := range all {
-			seen[d.Rel+":"+strconv.Itoa(d.Line)] = true
+	var all []Diagnostic
+	seen := map[string]bool{}
+	add := func(ds []Diagnostic) {
+		for _, d := range ds {
+			key := d.Rel + ":" + strconv.Itoa(d.Line) + ":" + d.Message
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			all = append(all, d)
 		}
-		extra := Run(t, Production(TypedOpts{Tags: cfg.BuildTags}), scan)
-		for _, d := range extra {
-			if !seen[d.Rel+":"+strconv.Itoa(d.Line)] {
-				all = append(all, d)
+	}
+	add(Run(t, Production(TypedOpts{}), scan))
+	if len(cfg.BuildTags) > 0 {
+		add(Run(t, Production(TypedOpts{Tags: cfg.BuildTags}), scan))
+	}
+	return all
+}
+
+// scanCompensateMethodByName flags reflect MethodByName calls inside
+// CompensateFunc bodies — the B2 blind spot (reflection dispatch bypasses the
+// banned-receiver check). Caller filters _test.go. Shared by
+// CheckSagaStepCompensatePure and the B2 reverse self-test (single source).
+// compensateAssignmentBody resolves a CompensateFunc assignment (func literal or
+// named func) to its function body, or nil when unresolvable.
+func compensateAssignmentBody(p *Pass, a compensateFuncAssignment, funcDecls map[*types.Func]*ast.FuncDecl) *ast.BlockStmt {
+	switch {
+	case a.Lit != nil:
+		return a.Lit.Body
+	case a.NamedIdent != nil:
+		if obj, ok := p.TypesInfo.ObjectOf(a.NamedIdent).(*types.Func); ok {
+			if fd, ok2 := funcDecls[obj]; ok2 {
+				return fd.Body
 			}
 		}
 	}
-	return all
+	return nil
+}
+
+func scanCompensateMethodByName(p *Pass, file *ast.File, funcDecls map[*types.Func]*ast.FuncDecl) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	rel := p.Rel(file)
+	var out []Diagnostic
+	for _, a := range collectCompensateAssignments(p, file) {
+		body := compensateAssignmentBody(p, a, funcDecls)
+		if body == nil {
+			continue
+		}
+		EachInSubtree[ast.SelectorExpr](body, func(sel *ast.SelectorExpr) {
+			if sel.Sel.Name == "MethodByName" {
+				out = append(out, sagaDiag(p, sel, rel,
+					sagaCompensatePureRuleID+"-B2 (blind-spot guard): "+
+						"MethodByName call inside a CompensateFunc body; "+
+						"reflection-based dispatch is a B2 blind spot — "+
+						"call-graph upgrade tracked in gh issue #1182"))
+			}
+		})
+	}
+	return out
+}
+
+// scanCompensateFuncArg flags a CompensateFunc value passed as a function
+// argument outside the sanctioned safeRunCompensate transport funnel — the B3
+// blind spot. Caller filters _test.go. Shared by CheckSagaStepCompensatePure and
+// the B3 reverse self-test (single source).
+func scanCompensateFuncArg(p *Pass, file *ast.File) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	const sanctionedCallee = "safeRunCompensate"
+	rel := p.Rel(file)
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == sanctionedCallee {
+			return
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == sanctionedCallee {
+			return
+		}
+		for _, arg := range call.Args {
+			if typ := p.TypesInfo.TypeOf(arg); typ != nil && isCompensateFuncType(typ) {
+				out = append(out, sagaDiag(p, arg, rel,
+					sagaCompensatePureRuleID+"-B3 (blind-spot guard): "+
+						"CompensateFunc value passed as a function argument outside "+
+						"the safeRunCompensate transport funnel; "+
+						"B3 bodies are not scanned — use the typed-slot assignment forms "+
+						"(forms 1–5) until call-graph support lands (gh issue #1182)"))
+			}
+		}
+	})
+	return out
 }
 
 // ─── SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 helpers ──────────────────────────

--- a/tools/archtest/saga_invariants.go
+++ b/tools/archtest/saga_invariants.go
@@ -44,6 +44,10 @@ package archtest
 //   - SAGA-INVARIANTS-FILE-CONSOLIDATED-01: a meta-rule about where saga INVARIANT
 //     comments live in tools/archtest/ — GoCell-specific directory structure.
 //
+// For each importable Check* targeting GoCell-internal packages, a companion
+// Test*_CheckDogfood runs the aggregate Check* on GoCell production and asserts
+// zero diagnostics, proving the imported surface is reachable.
+//
 // Platform-symbol paths are anchored to [PlatformModulePath]. See external.go.
 
 import (
@@ -65,17 +69,13 @@ import (
 // ─── Platform-path consts (all derived from PlatformModulePath) ─────────────
 
 const (
-	// sagaPkgPath is the kernel/saga package path. Merges the two formerly
-	// separate consts sagaPkgPath (line 154) and ksagaPkgPath (line 3974).
+	// sagaPkgPath is the kernel/saga package path. Merges the formerly
+	// separate consts sagaPkgPath and ksagaPkgPath.
 	sagaPkgPath = PlatformModulePath + "/kernel/saga"
 
-	// sagaJournalPkg is the kernel/saga/journal package path. Merges
-	// sagaJournalIfacePkg (line 1443) and journalInterfacePkgPath (line 2336).
+	// sagaJournalPkg is the kernel/saga/journal package path. Consolidates
+	// the formerly separate journalInterfacePkgPath const.
 	sagaJournalPkg = PlatformModulePath + "/kernel/saga/journal"
-
-	// sagaJournalIfacePkg is a backward-compat alias for sagaJournalPkg,
-	// retained so test-side code that still uses the old name compiles.
-	sagaJournalIfacePkg = sagaJournalPkg
 
 	// sagaConformancePkg is the sagajournaltest package path.
 	sagaConformancePkg = PlatformModulePath + "/kernel/saga/sagajournaltest"
@@ -488,7 +488,7 @@ func scanCompensateBodyCount(p *Pass, file *ast.File) []Diagnostic {
 		if n > sagaMaxCompensateStmts {
 			out = append(out, sagaDiag(p, a.Lit, rel,
 				sagaCompensatePureRuleID+"-B1: CompensateFunc body has too many statements ("+
-					itoa(n)+">"+itoa(sagaMaxCompensateStmts)+"); "+
+					strconv.Itoa(n)+">"+strconv.Itoa(sagaMaxCompensateStmts)+"); "+
 					"pure-reverse compensates must be short — extract logic to a named helper "+
 					"and call it from Compensate (B1 blind-spot discipline)"))
 		}
@@ -550,11 +550,11 @@ func CheckSagaStepCompensatePure(t *testing.T, cfg ConfigForExternalCell) []Diag
 	if len(cfg.BuildTags) > 0 {
 		seen := map[string]bool{}
 		for _, d := range all {
-			seen[d.Rel+":"+itoa(d.Line)] = true
+			seen[d.Rel+":"+strconv.Itoa(d.Line)] = true
 		}
 		extra := Run(t, Production(TypedOpts{Tags: cfg.BuildTags}), scan)
 		for _, d := range extra {
-			if !seen[d.Rel+":"+itoa(d.Line)] {
+			if !seen[d.Rel+":"+strconv.Itoa(d.Line)] {
 				all = append(all, d)
 			}
 		}
@@ -1372,16 +1372,12 @@ func CheckSagaJournalHolderSeal(t *testing.T, cfg ConfigForExternalCell) []Diagn
 			if strings.HasSuffix(rel, "_test.go") || !strings.HasPrefix(rel, "runtime/saga/") {
 				continue
 			}
-			EachInSubtree[ast.StructType](file, func(st *ast.StructType) {
-				// Find the enclosing type declaration name.
-				// We walk upward from the StructType, which requires finding
-				// the GenDecl/TypeSpec parent. Since we only need the struct
-				// name for the diagnostic message, we do best-effort via
-				// TypesInfo: find any TypeSpec that is a parent via file walk.
-				holderName := sagaStructHolderName(p.TypesInfo, file, st)
-				if st.Fields == nil {
+			EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok || st.Fields == nil {
 					return
 				}
+				holderName := ts.Name.Name
 				for _, field := range st.Fields.List {
 					if d, ok := journalFieldSealDiag(p, rel, holderName, field); ok {
 						out = append(out, d)
@@ -1395,28 +1391,6 @@ func CheckSagaJournalHolderSeal(t *testing.T, cfg ConfigForExternalCell) []Diagn
 		return nil
 	})
 	return out
-}
-
-// sagaStructHolderName returns the declared type name of the struct that
-// contains st, or "unknown" if not found. It iterates TypesInfo.Defs to find
-// a TypeName whose declared type's underlying is st.
-func sagaStructHolderName(_ *types.Info, file *ast.File, st *ast.StructType) string {
-	// Walk GenDecl/TypeSpec in the file to find the enclosing TypeSpec.
-	var name string
-	EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
-		if name != "" {
-			return
-		}
-		structLit, ok := ts.Type.(*ast.StructType)
-		if !ok || structLit != st {
-			return
-		}
-		name = ts.Name.Name
-	})
-	if name == "" {
-		return "unknown"
-	}
-	return name
 }
 
 // ─── SAGA-DRIVE-BEHIND-LEADER-GATE-01 helpers ────────────────────────────────
@@ -1993,7 +1967,7 @@ func CheckSagaConstructorNilGuard(t *testing.T, cfg ConfigForExternalCell) []Dia
 	t.Helper()
 	_ = cfg
 	var out []Diagnostic
-	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/...", "./runtime/saga/executor/..."}), func(p *Pass) []Diagnostic {
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil || p.Pkg == nil {
 			return nil
 		}
@@ -2077,6 +2051,8 @@ func scanSagaSlogInstanceFieldsFile(p *Pass, file *ast.File) []Diagnostic {
 
 // scanSagaSlogAttrLiteralsFile flags every log/slog.Attr composite literal
 // (keyed or unkeyed) carrying a guarded identity key.
+// Callers are responsible for _test.go filtering; fixture tests intentionally
+// do not filter so they can prove the detector fires on synthetic red code.
 func scanSagaSlogAttrLiteralsFile(p *Pass, file *ast.File) []Diagnostic {
 	rel := filepath.ToSlash(p.Rel(file))
 	var ds []Diagnostic
@@ -2154,7 +2130,12 @@ func sagaGuardedKeyFromExpr(info *types.Info, expr ast.Expr) (string, bool) {
 }
 
 // CheckSagaSlogInstanceFieldsCaller is the importable form of
-// SAGA-SLOG-INSTANCE-FIELDS-CALLER-01.
+// SAGA-SLOG-INSTANCE-FIELDS-CALLER-01. It runs both sub-checks:
+//   - A1: guarded keys (instance_id, lease_id) must only appear inside the
+//     sagalog.InstanceFields carrier body (scanSagaSlogInstanceFieldsFile).
+//   - B4: slog.Attr composite literals with guarded keys are banned outside the
+//     carrier body (scanSagaSlogAttrLiteralsFile).
+//
 // Not registered in StandardCellRules.
 func CheckSagaSlogInstanceFieldsCaller(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
@@ -2169,6 +2150,7 @@ func CheckSagaSlogInstanceFieldsCaller(t *testing.T, cfg ConfigForExternalCell) 
 				continue
 			}
 			out = append(out, scanSagaSlogInstanceFieldsFile(p, file)...)
+			out = append(out, scanSagaSlogAttrLiteralsFile(p, file)...)
 		}
 		return nil
 	})
@@ -2429,7 +2411,12 @@ func scanSagaEnumLabelAll(p *Pass) []Diagnostic {
 }
 
 // CheckSagaMetricLabelValuesFrozen is the importable form of
-// SAGA-METRIC-LABEL-VALUES-FROZEN-01.
+// SAGA-METRIC-LABEL-VALUES-FROZEN-01. It covers the A2 callsite/assignment
+// guard only: it enforces that no production code reaches a metric label via an
+// inline literal or a raw string(reason) conversion. The A1 enum-value-set-
+// frozen check (enumerating declared consts vs the sagaLabelEnumWant golden) is
+// GoCell-internal (golden-bound via sagaLabelEnumWant) and intentionally stays
+// in TestSagaMetricLabelValuesFrozen01, not exported.
 // Not registered in StandardCellRules.
 func CheckSagaMetricLabelValuesFrozen(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()

--- a/tools/archtest/saga_invariants.go
+++ b/tools/archtest/saga_invariants.go
@@ -1,0 +1,2443 @@
+package archtest
+
+// saga_invariants.go — importable saga-theme rule logic (#1634 M3-PR4).
+//
+// This is the non-test companion to saga_invariants_test.go. It holds the
+// detector logic for the saga-theme archtest rules so that rule functions can
+// be compiled and called by an external Cell repository. Go never compiles a
+// dependency's _test.go, so any rule an external repo must run cannot live in
+// a _test.go.
+//
+// Two distinct layers — importable surface vs registered subset — do NOT
+// coincide; do not conflate them:
+//
+// Importable Check* functions (all rules that do not constrain GoCell-internal
+// source layout):
+//
+//	CheckSagaStepCompensatePure — SAGA-STEP-COMPENSATE-PURE-01
+//	CheckSagaCoordinatorNoHeartbeatLoop — SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01
+//	CheckSagaExecutorRandInjected — SAGA-EXECUTOR-RAND-INJECTED-01
+//	CheckSagaJournalConformanceEnrollment — SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01
+//	CheckSagaGlobalReaderConformanceEnrollment — SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01
+//	CheckSagaJournalHolderSeal — SAGA-JOURNAL-HOLDER-SEAL-01
+//	CheckSagaDriveBehindLeaderGate — SAGA-DRIVE-BEHIND-LEADER-GATE-01
+//	CheckSagaStepRunOutsideTx — SAGA-STEP-RUN-OUTSIDE-TX-01
+//	CheckSagaConstructorNilGuard — SAGA-CONSTRUCTOR-NIL-GUARD-01
+//	CheckSagaMetricLabelValuesFrozen — SAGA-METRIC-LABEL-VALUES-FROZEN-01
+//	CheckSagaSlogInstanceFieldsCaller — SAGA-SLOG-INSTANCE-FIELDS-CALLER-01
+//
+// Registered in StandardCellRules (portable subset — rules that apply to any
+// Cell using the saga engine):
+//
+//	SAGA-STEP-COMPENSATE-PURE-01 via CheckSagaStepCompensatePure.
+//
+// The other ten Check* are importable but intentionally NOT registered because
+// they constrain GoCell's OWN runtime/saga internals (Coordinator, executor,
+// sagalog, journal, etc.) — an external Cell module that merely uses the saga
+// engine would have zero runtime/saga/ production files and would see vacuous-
+// green or false-red results for those rules.
+//
+// Two rules remain in saga_invariants_test.go (no importable Check*):
+//
+//   - SAGA-STATUS-FANOUT-COVERAGE-01: relies on sagacoveragegen + golden files
+//     in the GoCell source tree — meaningless outside the monorepo.
+//   - SAGA-INVARIANTS-FILE-CONSOLIDATED-01: a meta-rule about where saga INVARIANT
+//     comments live in tools/archtest/ — GoCell-specific directory structure.
+//
+// Platform-symbol paths are anchored to [PlatformModulePath]. See external.go.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/internal/prodscan"
+	"github.com/ghbvf/gocell/tools/typesutil"
+)
+
+// ─── Platform-path consts (all derived from PlatformModulePath) ─────────────
+
+const (
+	// sagaPkgPath is the kernel/saga package path. Merges the two formerly
+	// separate consts sagaPkgPath (line 154) and ksagaPkgPath (line 3974).
+	sagaPkgPath = PlatformModulePath + "/kernel/saga"
+
+	// sagaJournalPkg is the kernel/saga/journal package path. Merges
+	// sagaJournalIfacePkg (line 1443) and journalInterfacePkgPath (line 2336).
+	sagaJournalPkg = PlatformModulePath + "/kernel/saga/journal"
+
+	// sagaJournalIfacePkg is a backward-compat alias for sagaJournalPkg,
+	// retained so test-side code that still uses the old name compiles.
+	sagaJournalIfacePkg = sagaJournalPkg
+
+	// sagaConformancePkg is the sagajournaltest package path.
+	sagaConformancePkg = PlatformModulePath + "/kernel/saga/sagajournaltest"
+
+	// sagalogPkgPath is the runtime/saga/internal/sagalog package path.
+	sagalogPkgPath = PlatformModulePath + "/runtime/saga/internal/sagalog"
+
+	// sagaRuntimePkg is the runtime/saga package path.
+	sagaRuntimePkg = PlatformModulePath + "/runtime/saga"
+
+	// sagaRuntimeExecutorPkg is the runtime/saga/executor package path.
+	// Note: sagaExecutorPkg (already used for SAGA-METRIC-LABEL-VALUES-FROZEN-01)
+	// and sagaRuntimeExecutorPkg are the same path; they are unified here.
+	sagaRuntimeExecutorPkg = PlatformModulePath + "/runtime/saga/executor"
+
+	// sagaOutboxPkg is the kernel/outbox package path.
+	sagaOutboxPkg = PlatformModulePath + "/kernel/outbox"
+
+	// sagaPersistencePkg is the kernel/persistence package path.
+	sagaPersistencePkg = PlatformModulePath + "/kernel/persistence"
+
+	// sagaValidationPkg is the pkg/validation package path.
+	sagaValidationPkg = PlatformModulePath + "/pkg/validation"
+
+	// sagaClockPkg is the kernel/clock package path.
+	sagaClockPkg = PlatformModulePath + "/kernel/clock"
+)
+
+// ─── Rule IDs and string constants (moved from saga_invariants_test.go) ──────
+
+const (
+	// SAGA-STEP-COMPENSATE-PURE-01.
+	sagaCompensatePureRuleID = "SAGA-STEP-COMPENSATE-PURE-01"
+	sagaCompensateFuncName   = "CompensateFunc"
+	sagaCompensateFieldName  = "Compensate"
+	sagaFixturesDir          = "saga_compensate_pure_fixtures"
+	sagaMaxCompensateStmts   = 10
+
+	// SAGA-CONSTRUCTOR-NIL-GUARD-01.
+	sagaConstructorNilGuardRuleID = "SAGA-CONSTRUCTOR-NIL-GUARD-01"
+	sagaConstructorFixturesDir    = "saga_constructor_nilguard_fixtures"
+
+	// SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01.
+	sagaCoordinatorNoHeartbeatLoopRule = "SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01"
+	heartbeatMethodName                = "Heartbeat"
+	heartbeaterIdutilPkgName           = "idutil"
+	heartbeaterSafeIDType              = "SafeID"
+
+	// SAGA-EXECUTOR-RAND-INJECTED-01.
+	sagaRandInjectedRuleID = "SAGA-EXECUTOR-RAND-INJECTED-01"
+	executorPkgPrefix      = "runtime/saga/executor/"
+	randV1PkgPath          = "math/rand"
+	randV2PkgPath          = "math/rand/v2"
+
+	// SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01.
+	sagaJournalIfaceName    = "Journal"
+	sagaConformanceFuncName = "RunConformanceSuite"
+
+	// SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01.
+	sagaGlobalReaderIfaceName       = "GlobalReader"
+	sagaGlobalReaderConformanceFunc = "RunGlobalReaderConformance"
+
+	// SAGA-JOURNAL-HOLDER-SEAL-01.
+	journalInterfaceTypeName     = "Journal"
+	heartbeaterInterfaceTypeName = "Heartbeater"
+	journalCoreInterfaceTypeName = "JournalCore"
+	allowedSagaJournalHolder     = "Coordinator"
+	sagaJournalHolderSealRule    = "SAGA-JOURNAL-HOLDER-SEAL-01"
+
+	// SAGA-DRIVE-BEHIND-LEADER-GATE-01.
+	sagaLeaderGateRule        = "SAGA-DRIVE-BEHIND-LEADER-GATE-01"
+	sagaLeaderGateFixturesDir = "saga_leader_gate_fixtures"
+	driveOneMethodName        = "driveOne"
+	acquireLeadMethodName     = "acquireLead"
+	tickOnceFuncName          = "tickOnce"
+
+	// SAGA-STEP-RUN-OUTSIDE-TX-01.
+	sagaStepRunOutsideTxRule = "SAGA-STEP-RUN-OUTSIDE-TX-01"
+	sagaStepRunFixturesDir   = "saga_step_run_outside_tx_fixtures"
+	safeRunFuncName          = "safeRun"
+	runInTxMethodName        = "RunInTx"
+	sagaRuntimePkgPrefix     = "runtime/saga/"
+	stepFuncTypeName         = "StepFunc"
+
+	// SAGA-SLOG-INSTANCE-FIELDS-CALLER-01.
+	sagaSlogInstanceFieldsRule               = "SAGA-SLOG-INSTANCE-FIELDS-CALLER-01"
+	sagaInstanceFieldsFuncName               = "InstanceFields"
+	sagaSlogPkgPath                          = "log/slog"
+	sagaSlogAttrTypeName                     = "Attr"
+	violSagaSlogInstanceFieldsOutsideCarrier = sagaSlogInstanceFieldsRule + ": " +
+		`a log/slog Attr constructor with key "instance_id"|"lease_id" outside ` +
+		"sagalog.InstanceFields — route every per-instance saga log through " +
+		"sagalog.InstanceFields so lease_id is structurally guaranteed (#1266)"
+
+	// sagaExecutorPkg aliases sagaRuntimeExecutorPkg for metric-label helpers.
+	sagaExecutorPkg = sagaRuntimeExecutorPkg
+)
+
+// randAllowedConstructors is the set of (pkgPath.funcName) keys that are
+// permitted package-level rand calls (constructors, not global state reads).
+var randAllowedConstructors = map[string]bool{
+	randV2PkgPath + ".New":        true,
+	randV2PkgPath + ".NewPCG":     true,
+	randV2PkgPath + ".NewChaCha8": true,
+	randV1PkgPath + ".New":        true,
+	randV1PkgPath + ".NewSource":  true,
+}
+
+// sagaInstanceFieldsGuardedKeys is the set of slog key strings that must be
+// built via sagalog.InstanceFields (not raw slog.String / slog.Attr literals).
+var sagaInstanceFieldsGuardedKeys = map[string]struct{}{
+	"instance_id": {},
+	"lease_id":    {},
+}
+
+// sagaLabelEnumWant is the golden value-set for each frozen executor label
+// enum type (SAGA-METRIC-LABEL-VALUES-FROZEN-01 A1).
+var sagaLabelEnumWant = map[string][]string{
+	"HeartbeatFailureReason": {"infra_error", "stale_lease"},
+	"TickResult":             {"claimed", "empty", "error"},
+	"DriveResult":            {"ok", "error"},
+	"LeaderSkipReason":       {"contended", "ctx_canceled", "backend_error"},
+}
+
+// sagaBannedReceiverKeys maps "<pkgpath>.<TypeName>" → display label for
+// concrete banned types (matched after one pointer deref for *sql.Tx).
+// Moved from saga_invariants_test.go with bare literals replaced.
+var sagaBannedReceiverKeys = map[string]string{
+	"database/sql.Tx":            "*sql.Tx",
+	"github.com/jackc/pgx/v5.Tx": "pgx.Tx",
+	sagaOutboxPkg + ".Writer":    "outbox.Writer",
+	sagaOutboxPkg + ".Emitter":   "outbox.Emitter",
+}
+
+// sagaBannedIfaceSpecs lists the (pkgPath, typeName, label) tuples for
+// interface types that CompensateFunc bodies must not call methods on.
+// Moved from saga_invariants_test.go with bare literals replaced.
+var sagaBannedIfaceSpecs = []struct{ path, name, label string }{
+	{"github.com/jackc/pgx/v5", "Tx", "pgx.Tx"},
+	{sagaOutboxPkg, "Writer", "outbox.Writer"},
+	{sagaOutboxPkg, "Emitter", "outbox.Emitter"},
+	{sagaPersistencePkg, "TxRunner", "persistence.TxRunner"},
+}
+
+// sagaConstructorScopePackages is the set of packages scanned for
+// SAGA-CONSTRUCTOR-NIL-GUARD-01.
+var sagaConstructorScopePackages = map[string]bool{
+	sagaRuntimePkg:         true,
+	sagaRuntimeExecutorPkg: true,
+}
+
+// sagaGuardKey is a (pkgPath, funcName) pair for a sanctioned nil-guard call.
+type sagaGuardKey struct{ pkg, name string }
+
+// sagaGuardFuncKeys is the set of (pkgPath, funcName) pairs that constitute an
+// accepted nil-guard call for a constructor parameter.
+var sagaGuardFuncKeys = []sagaGuardKey{
+	{sagaValidationPkg, "IsNilInterface"},
+	{sagaClockPkg, "MustHaveClock"},
+}
+
+// ─── SAGA-STEP-COMPENSATE-PURE-01 helpers ────────────────────────────────────
+
+// sagaResolveBannedReceivers resolves the banned interface receiver types from
+// pkg's transitive import closure, once per Pass.
+func sagaResolveBannedReceivers(pkg *types.Package) []bannedReceiver {
+	var out []bannedReceiver
+	for _, b := range sagaBannedIfaceSpecs {
+		if iface := lookupInterface(pkg, b.path, b.name); iface != nil {
+			out = append(out, bannedReceiver{label: b.label, iface: iface})
+		}
+	}
+	return out
+}
+
+// sagaBannedReceiverLabel reports the display label when sel.X's static type
+// is a banned receiver. It checks:
+//  1. Exact concrete match (deref one pointer level for *sql.Tx).
+//  2. Implements a banned interface (types.Implements).
+func sagaBannedReceiverLabel(info *types.Info, sel *ast.SelectorExpr, ifaces []bannedReceiver) (string, bool) {
+	t := info.TypeOf(sel.X)
+	if t == nil {
+		return "", false
+	}
+	nt := t
+	if ptr, isPtr := nt.(*types.Pointer); isPtr {
+		nt = ptr.Elem()
+	}
+	if named, isNamed := nt.(*types.Named); isNamed && named.Obj() != nil && named.Obj().Pkg() != nil {
+		key := named.Obj().Pkg().Path() + "." + named.Obj().Name()
+		if label, ok := sagaBannedReceiverKeys[key]; ok {
+			return label, true
+		}
+	}
+	for _, b := range ifaces {
+		if implementsBannedIface(t, b.iface) {
+			return b.label, true
+		}
+	}
+	return "", false
+}
+
+// isCompensateFuncType reports whether typ is exactly kernel/saga.CompensateFunc.
+func isCompensateFuncType(typ types.Type) bool {
+	named, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == sagaPkgPath &&
+		obj.Name() == sagaCompensateFuncName
+}
+
+// compensateFuncAssignment holds a scanned assignment: either a func literal
+// body (for direct scan) or an ident reference to a named function (for
+// declared-func scan). Exactly one of Lit / NamedIdent is non-nil.
+type compensateFuncAssignment struct {
+	Lit        *ast.FuncLit
+	NamedIdent *ast.Ident
+}
+
+// collectCompensateAssignments walks the AST of file and returns every
+// assignment to a kernel/saga.CompensateFunc-typed slot, covering:
+//
+//  1. var c saga.CompensateFunc = <expr>    (ValueSpec)
+//  2. c = <expr> where c is CompensateFunc (AssignStmt)
+//  3. saga.Step{Compensate: <expr>}         (CompositeLit KV)
+//
+// <expr> is either a FuncLit (returned in Lit) or an Ident referencing a
+// named function (returned in NamedIdent).
+func collectCompensateAssignments(p *Pass, file *ast.File) []compensateFuncAssignment { //nolint:gocognit,lll // archtest AST scanner: three assignment forms (ValueSpec/AssignStmt/CompositeLit) each need distinct handling
+	info := p.TypesInfo
+	var out []compensateFuncAssignment
+
+	// var c saga.CompensateFunc = <expr>
+	EachInSubtree[ast.ValueSpec](file, func(node *ast.ValueSpec) {
+		typ := info.TypeOf(node.Type)
+		if typ == nil || !isCompensateFuncType(typ) {
+			return
+		}
+		for _, val := range node.Values {
+			out = append(out, classifyExpr(val))
+		}
+	})
+
+	// c = <expr> where c is CompensateFunc
+	EachInSubtree[ast.AssignStmt](file, func(node *ast.AssignStmt) {
+		for i, lhs := range node.Lhs {
+			if i >= len(node.Rhs) {
+				break
+			}
+			lhsType := info.TypeOf(lhs)
+			if lhsType == nil || !isCompensateFuncType(lhsType) {
+				continue
+			}
+			out = append(out, classifyExpr(node.Rhs[i]))
+		}
+	})
+
+	// saga.Step{Compensate: <expr>}
+	EachInSubtree[ast.CompositeLit](file, func(node *ast.CompositeLit) {
+		EachInChildren[ast.KeyValueExpr](node, func(kv *ast.KeyValueExpr) {
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != sagaCompensateFieldName {
+				return
+			}
+			if !compensateKVFieldIsCompensateFunc(info, node) {
+				return
+			}
+			out = append(out, classifyExpr(kv.Value))
+		})
+	})
+
+	return out
+}
+
+// compensateKVFieldIsCompensateFunc verifies that the struct type of the
+// CompositeLit node has a field named sagaCompensateFieldName whose declared
+// type is kernel/saga.CompensateFunc.
+func compensateKVFieldIsCompensateFunc(info *types.Info, node *ast.CompositeLit) bool {
+	structType := info.TypeOf(node)
+	if structType == nil {
+		return false
+	}
+	st := structType
+	if ptr, ok := st.(*types.Pointer); ok {
+		st = ptr.Elem()
+	}
+	var underlying types.Type
+	if named, ok := st.(*types.Named); ok {
+		underlying = named.Underlying()
+	} else {
+		underlying = st.Underlying()
+	}
+	s, ok := underlying.(*types.Struct)
+	if !ok {
+		return false
+	}
+	for fi := 0; fi < s.NumFields(); fi++ {
+		f := s.Field(fi)
+		if f.Name() == sagaCompensateFieldName && isCompensateFuncType(f.Type()) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyExpr returns a compensateFuncAssignment for expr: either a FuncLit
+// or a named-function Ident.
+func classifyExpr(expr ast.Expr) compensateFuncAssignment {
+	switch e := expr.(type) {
+	case *ast.FuncLit:
+		return compensateFuncAssignment{Lit: e}
+	case *ast.Ident:
+		return compensateFuncAssignment{NamedIdent: e}
+	}
+	return compensateFuncAssignment{}
+}
+
+// sagaFuncDeclsByObject collects all top-level FuncDecls in the Pass (across
+// all files) keyed by the types.Func pointer (via info.ObjectOf).
+func sagaFuncDeclsByObject(p *Pass) map[*types.Func]*ast.FuncDecl {
+	out := make(map[*types.Func]*ast.FuncDecl)
+	for _, f := range p.Files {
+		EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+			if fd.Body == nil {
+				return
+			}
+			obj, ok := p.TypesInfo.Defs[fd.Name].(*types.Func)
+			if !ok {
+				return
+			}
+			out[obj] = fd
+		})
+	}
+	return out
+}
+
+// countStmts counts the top-level statements in a BlockStmt.
+func countStmts(body *ast.BlockStmt) int {
+	if body == nil {
+		return 0
+	}
+	return len(body.List)
+}
+
+// sagaDiag constructs a Diagnostic for a saga rule.
+func sagaDiag(p *Pass, node ast.Node, rel, msg string) Diagnostic {
+	return Diagnostic{Rel: rel, Line: p.Fset.Position(node.Pos()).Line, Message: msg}
+}
+
+// scanBodyForForbiddenCalls scans a BlockStmt for calls to banned receivers.
+func scanBodyForForbiddenCalls(p *Pass, body *ast.BlockStmt, rel string, ifaces []bannedReceiver) []Diagnostic {
+	info := p.TypesInfo
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+		sel, isSel := call.Fun.(*ast.SelectorExpr)
+		if !isSel {
+			return
+		}
+		if label, banned := sagaBannedReceiverLabel(info, sel, ifaces); banned {
+			out = append(out, sagaDiag(p, sel, rel,
+				sagaCompensatePureRuleID+"-A1: CompensateFunc body must be pure-reverse; "+
+					"it calls a method on "+label+
+					" (Compensate runs in app domain only — the Coordinator owns the tx layer)"))
+		}
+	})
+	return out
+}
+
+// scanCompensatePure implements A1 over one file: collect every CompensateFunc
+// assignment (literal or named func) and check the body for forbidden calls.
+func scanCompensatePure(p *Pass, file *ast.File, ifaces []bannedReceiver, funcDecls map[*types.Func]*ast.FuncDecl) []Diagnostic {
+	rel := p.Rel(file)
+	var out []Diagnostic
+
+	assignments := collectCompensateAssignments(p, file)
+	for _, a := range assignments {
+		switch {
+		case a.Lit != nil:
+			out = append(out, scanBodyForForbiddenCalls(p, a.Lit.Body, rel, ifaces)...)
+		case a.NamedIdent != nil:
+			obj, ok := p.TypesInfo.ObjectOf(a.NamedIdent).(*types.Func)
+			if !ok {
+				continue
+			}
+			fd, ok := funcDecls[obj]
+			if !ok {
+				continue
+			}
+			out = append(out, scanBodyForForbiddenCalls(p, fd.Body, rel, ifaces)...)
+		}
+	}
+	return out
+}
+
+// scanCompensateBodyCount implements B1 over one file: every CompensateFunc
+// literal must have <= sagaMaxCompensateStmts top-level statements.
+func scanCompensateBodyCount(p *Pass, file *ast.File) []Diagnostic {
+	rel := p.Rel(file)
+	var out []Diagnostic
+
+	assignments := collectCompensateAssignments(p, file)
+	for _, a := range assignments {
+		if a.Lit == nil {
+			continue
+		}
+		n := countStmts(a.Lit.Body)
+		if n > sagaMaxCompensateStmts {
+			out = append(out, sagaDiag(p, a.Lit, rel,
+				sagaCompensatePureRuleID+"-B1: CompensateFunc body has too many statements ("+
+					itoa(n)+">"+itoa(sagaMaxCompensateStmts)+"); "+
+					"pure-reverse compensates must be short — extract logic to a named helper "+
+					"and call it from Compensate (B1 blind-spot discipline)"))
+		}
+	}
+	return out
+}
+
+// sagaCompensateFixturePattern returns the relative directory and module-path
+// pattern for a named compensate-pure fixture sub-directory.
+// Used by Test* functions that drive fixture-based detector self-tests.
+func sagaCompensateFixturePattern(fix string) (dir, pattern string) {
+	return filepath.Join("tools", "archtest", "testdata", sagaFixturesDir, fix),
+		"./tools/archtest/testdata/" + sagaFixturesDir + "/" + fix
+}
+
+// sagaLeaderGateFixturePattern returns the relative directory and module-path
+// pattern for a named leader-gate fixture sub-directory.
+// Used by Test* functions that drive fixture-based detector self-tests.
+func sagaLeaderGateFixturePattern(fix string) (dir, pattern string) {
+	return filepath.Join("tools", "archtest", "testdata", sagaLeaderGateFixturesDir, fix),
+		"./tools/archtest/testdata/" + sagaLeaderGateFixturesDir + "/" + fix
+}
+
+// sagaStepRunFixturePattern returns the relative directory and module-path
+// pattern for a named step-run-outside-tx fixture sub-directory.
+// Used by Test* functions that drive fixture-based detector self-tests.
+func sagaStepRunFixturePattern(fix string) (dir, pattern string) {
+	return filepath.Join("tools", "archtest", "testdata", sagaStepRunFixturesDir, fix),
+		"./tools/archtest/testdata/" + sagaStepRunFixturesDir + "/" + fix
+}
+
+// CheckSagaStepCompensatePure is the importable, registered form of
+// SAGA-STEP-COMPENSATE-PURE-01. It scans the running module's production code
+// (with cfg.BuildTags) for CompensateFunc bodies that call forbidden persistent
+// interfaces (outbox.Writer, outbox.Emitter, persistence.TxRunner, *sql.Tx,
+// pgx.Tx). This rule applies to any Cell that uses the saga engine and assigns
+// CompensateFunc values.
+//
+// Registered in [StandardCellRules].
+func CheckSagaStepCompensatePure(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	var all []Diagnostic
+	scan := func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		ifaces := sagaResolveBannedReceivers(p.Pkg)
+		funcDecls := sagaFuncDeclsByObject(p)
+		var out []Diagnostic
+		for _, file := range p.Files {
+			if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
+				continue
+			}
+			out = append(out, scanCompensatePure(p, file, ifaces, funcDecls)...)
+		}
+		return out
+	}
+	all = append(all, Run(t, Production(TypedOpts{Tags: FlatNonDefaultTags()}), scan)...)
+	if len(cfg.BuildTags) > 0 {
+		seen := map[string]bool{}
+		for _, d := range all {
+			seen[d.Rel+":"+itoa(d.Line)] = true
+		}
+		extra := Run(t, Production(TypedOpts{Tags: cfg.BuildTags}), scan)
+		for _, d := range extra {
+			if !seen[d.Rel+":"+itoa(d.Line)] {
+				all = append(all, d)
+			}
+		}
+	}
+	return all
+}
+
+// ─── SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 helpers ──────────────────────────
+
+// scanHeartbeatSelectors walks every SelectorExpr whose Sel.Name == "Heartbeat"
+// (both inside CallExpr and as a method value) and emits a diagnostic when the
+// receiver implements the Heartbeater-shape signature.
+func scanHeartbeatSelectors(p *Pass, file *ast.File, rel string) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if sel.Sel == nil || sel.Sel.Name != heartbeatMethodName {
+			return
+		}
+		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
+		if !ok || fn == nil {
+			return
+		}
+		if !methodIsHeartbeaterShape(fn) {
+			return
+		}
+		pos := p.Fset.Position(sel.Pos())
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: pos.Line,
+			Message: fmt.Sprintf(
+				"%s: forbidden reference to a Heartbeater-shape .Heartbeat method in runtime/saga; "+
+					"per-step lease maintenance is funneled through runtime/saga/executor "+
+					"(Executor.Execute / Executor.RunWithHeartbeat). If you need a "+
+					"non-step heartbeat (e.g. extending lease across an outer operation), "+
+					"call Executor.RunWithHeartbeat — do NOT re-introduce a centralized "+
+					"heartbeat goroutine.",
+				sagaCoordinatorNoHeartbeatLoopRule,
+			),
+		})
+	})
+	return out
+}
+
+// methodIsHeartbeaterShape reports whether fn has the Heartbeater-shape signature.
+func methodIsHeartbeaterShape(fn *types.Func) bool {
+	if fn == nil {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || fn.Name() != heartbeatMethodName {
+		return false
+	}
+	return signatureMatchesHeartbeaterShape(sig)
+}
+
+// signatureMatchesHeartbeaterShape validates the Heartbeat parameter/result shape.
+func signatureMatchesHeartbeaterShape(sig *types.Signature) bool {
+	params := sig.Params()
+	results := sig.Results()
+	if params.Len() != 4 || results.Len() != 2 {
+		return false
+	}
+	// param[0]: context.Context
+	if !isContextType(params.At(0).Type()) {
+		return false
+	}
+	// param[1], param[2]: idutil.SafeID
+	if !typeIsNamed(params.At(1).Type(), heartbeaterIdutilPkgName, heartbeaterSafeIDType) {
+		return false
+	}
+	if !typeIsNamed(params.At(2).Type(), heartbeaterIdutilPkgName, heartbeaterSafeIDType) {
+		return false
+	}
+	// param[3]: time.Duration
+	if !isTimeDurationType(params.At(3).Type()) {
+		return false
+	}
+	// results: (bool, error)
+	boolType := types.Typ[types.Bool]
+	if !types.Identical(results.At(0).Type(), boolType) {
+		return false
+	}
+	errIface, ok := results.At(1).Type().Underlying().(*types.Interface)
+	return ok && errIface.NumMethods() == 1 && errIface.Method(0).Name() == "Error"
+}
+
+// typeIsNamed reports whether t resolves to a named type whose enclosing
+// package's import-path *suffix* equals pkgSuffix and whose declared name
+// equals typeName.
+func typeIsNamed(t types.Type, pkgSuffix, typeName string) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Name() != typeName {
+		return false
+	}
+	pkg := obj.Pkg()
+	if pkg == nil {
+		return false
+	}
+	return pkg.Path() == pkgSuffix || strings.HasSuffix(pkg.Path(), "/"+pkgSuffix)
+}
+
+// CheckSagaCoordinatorNoHeartbeatLoop is the importable form of
+// SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01. It scans runtime/saga/ production
+// files (excluding runtime/saga/executor/) for any .Heartbeat SelectorExpr
+// whose receiver implements the Heartbeater-shape signature.
+// Not registered in StandardCellRules (targets GoCell's own runtime/saga).
+func CheckSagaCoordinatorNoHeartbeatLoop(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := filepath.ToSlash(p.Rel(file))
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			if !strings.HasPrefix(rel, "runtime/saga/") {
+				continue
+			}
+			if strings.HasPrefix(rel, "runtime/saga/executor/") {
+				continue
+			}
+			out = append(out, scanHeartbeatSelectors(p, file, rel)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// ─── SAGA-EXECUTOR-RAND-INJECTED-01 helpers ──────────────────────────────────
+
+// isRandGlobalForbidden reports whether fn is a package-level function in
+// math/rand or math/rand/v2 that is NOT in the allowed constructor set.
+func isRandGlobalForbidden(fn *types.Func) bool {
+	if fn == nil || fn.Pkg() == nil {
+		return false
+	}
+	pkgPath := fn.Pkg().Path()
+	if pkgPath != randV1PkgPath && pkgPath != randV2PkgPath {
+		return false
+	}
+	if sig, _ := fn.Type().(*types.Signature); sig != nil && sig.Recv() != nil {
+		return false
+	}
+	key := pkgPath + "." + fn.Name()
+	return !randAllowedConstructors[key]
+}
+
+// scanRandGlobalCalls walks file's AST and returns diagnostics for every
+// call to a forbidden package-level global rand function.
+func scanRandGlobalCalls(p *Pass, file *ast.File) []Diagnostic {
+	rel := p.Rel(file)
+	info := p.TypesInfo
+	var out []Diagnostic
+	seen := map[string]bool{}
+
+	record := func(node ast.Node, fnName, pkgPath string) {
+		line := p.Fset.Position(node.Pos()).Line
+		key := fmt.Sprintf("%s:%d:%s.%s", rel, line, pkgPath, fnName)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: line,
+			Message: fmt.Sprintf(
+				sagaRandInjectedRuleID+": %s.%s — "+
+					"must use an injected *rand.Rand source (rand.New(rand.NewPCG(...))) "+
+					"instead of the package-level global; "+
+					"global rand is not injectable and makes jitter non-deterministic in tests",
+				pkgPath, fnName,
+			),
+		})
+	}
+
+	EachInSubtree[ast.SelectorExpr](file, func(e *ast.SelectorExpr) {
+		fn, ok := info.ObjectOf(e.Sel).(*types.Func)
+		if !ok || !isRandGlobalForbidden(fn) {
+			return
+		}
+		record(e, fn.Name(), fn.Pkg().Path())
+	})
+
+	EachInSubtree[ast.Ident](file, func(e *ast.Ident) {
+		fn, ok := info.ObjectOf(e).(*types.Func)
+		if !ok || !isRandGlobalForbidden(fn) {
+			return
+		}
+		record(e, fn.Name(), fn.Pkg().Path())
+	})
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Rel != out[j].Rel {
+			return out[i].Rel < out[j].Rel
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out
+}
+
+// isExecutorProductionFile reports whether rel is a production .go file
+// under runtime/saga/executor/ (not _test.go).
+func isExecutorProductionFile(rel string) bool {
+	return strings.HasPrefix(rel, executorPkgPrefix) && !strings.HasSuffix(rel, "_test.go")
+}
+
+// CheckSagaExecutorRandInjected is the importable form of
+// SAGA-EXECUTOR-RAND-INJECTED-01. It scans runtime/saga/executor/ production
+// files for package-level global rand calls.
+// Not registered in StandardCellRules (targets GoCell's own runtime/saga/executor).
+func CheckSagaExecutorRandInjected(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/executor/..."}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := filepath.ToSlash(p.Rel(file))
+			if !isExecutorProductionFile(rel) {
+				continue
+			}
+			out = append(out, scanRandGlobalCalls(p, file)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// ─── SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01 helpers ─────────────────────────
+
+// collectSagaJournalImpls collects concrete types in pkg that implement iface,
+// populating implSet ("pkg/path.TypeName" → true) and implPkgSet (pkg path → true).
+func collectSagaJournalImpls(pkg *types.Package, iface *types.Interface, implSet, implPkgSet map[string]bool) { //nolint:gocognit,lll // archtest: value/pointer receivers + alias forms via typesutil.ImplementsInterface enumeration
+	if pkg == nil {
+		return
+	}
+	scope := pkg.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if obj == nil {
+			continue
+		}
+		if _, isTypeName := obj.(*types.TypeName); !isTypeName {
+			continue
+		}
+		t := obj.Type()
+		// typesutil.ImplementsInterface checks value-or-pointer receivers (the
+		// sanctioned funnel for go/types.Implements; TYPESUTIL-IMPLEMENTS-FUNNEL-01).
+		if typesutil.ImplementsInterface(t, iface) {
+			if named, ok := t.(*types.Named); ok {
+				if named.Underlying() != nil {
+					if _, isIface := named.Underlying().(*types.Interface); !isIface {
+						key := pkg.Path() + "." + name
+						implSet[key] = true
+						implPkgSet[pkg.Path()] = true
+					}
+				}
+			}
+		}
+	}
+}
+
+// factoryConstructedImpls returns the impl keys ("pkg/path.TypeName") constructed
+// inside the factory argument (call.Args[1]) of a conformance call. Resolves three
+// factory forms: an inline FuncLit, a named-func Ident (its FuncDecl in the package),
+// and a local var bound to a FuncLit. Any other form resolves to no body and credits
+// nothing — fail-closed: an unrecognized factory shape flags its impl as UNENROLLED
+// (CI-visible) rather than silently crediting it.
+func factoryConstructedImpls(call *ast.CallExpr, info *types.Info, files []*ast.File, implSet map[string]bool) []string {
+	if len(call.Args) < 2 {
+		return nil
+	}
+	body := factoryBody(call.Args[1], info, files)
+	if body == nil {
+		return nil
+	}
+	var out []string
+	EachInSubtree[ast.CallExpr](body, func(c *ast.CallExpr) {
+		out = append(out, extractEnrolledImpls(c, info, implSet)...)
+	})
+	return out
+}
+
+// extractEnrolledImpls inspects a CallExpr's callee signature and returns
+// implKey strings ("pkg/path.TypeName") for every concrete Journal impl that
+// the call constructs (return values whose underlying named type is in
+// implSet). Pointer wrappers (*T) are unwrapped. Cross-package type identity
+// is irrelevant — we compare by string keys, so the iface-pass and test-pass
+// loads do not need to share *types.Named instances.
+//
+// This is the impl-level upgrade of the prior package-level enrollment: a
+// test file is now only credited with enrolling impl X if it actually
+// constructs X — package co-location is no longer enough.
+func extractEnrolledImpls(call *ast.CallExpr, info *types.Info, implSet map[string]bool) []string {
+	if info == nil {
+		return nil
+	}
+	calleeType := info.TypeOf(call.Fun)
+	if calleeType == nil {
+		return nil
+	}
+	sig, ok := calleeType.Underlying().(*types.Signature)
+	if !ok {
+		return nil
+	}
+	var out []string
+	results := sig.Results()
+	for i := 0; i < results.Len(); i++ {
+		rt := results.At(i).Type()
+		if ptr, isPtr := rt.(*types.Pointer); isPtr {
+			rt = ptr.Elem()
+		}
+		named, ok := rt.(*types.Named)
+		if !ok {
+			continue
+		}
+		obj := named.Obj()
+		if obj == nil || obj.Pkg() == nil {
+			continue
+		}
+		key := obj.Pkg().Path() + "." + obj.Name()
+		if implSet[key] {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// creditEnrollmentsFromFactory credits conformance enrollment for impls
+// constructed in the factory argument of a RunConformanceSuite /
+// RunGlobalReaderConformance call.
+func creditEnrollmentsFromFactory(
+	info *types.Info,
+	files []*ast.File,
+	file *ast.File,
+	conformanceFuncName string,
+	implSet, enrolledImpls map[string]bool,
+) {
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
+		if !ok || pkgPath != sagaConformancePkg || name != conformanceFuncName {
+			return
+		}
+		for _, key := range factoryConstructedImpls(call, info, files, implSet) {
+			enrolledImpls[key] = true
+		}
+	})
+}
+
+// factoryBody resolves a conformance factory argument to the function body that
+// constructs the impl: a direct FuncLit, a named-func Ident (its FuncDecl), or a
+// local var Ident bound to a FuncLit (`factory := func(){…}`). Returns nil for
+// any other form.
+func factoryBody(arg ast.Expr, info *types.Info, files []*ast.File) *ast.BlockStmt {
+	switch a := arg.(type) {
+	case *ast.FuncLit:
+		return a.Body
+	case *ast.Ident:
+		obj := info.ObjectOf(a)
+		if obj == nil {
+			return nil
+		}
+		switch obj.(type) {
+		case *types.Func:
+			if fd := findFuncDeclFor(info, files, obj); fd != nil {
+				return fd.Body
+			}
+		case *types.Var:
+			if fl := findVarFuncLit(info, files, obj); fl != nil {
+				return fl.Body
+			}
+		}
+	}
+	return nil
+}
+
+// findFuncDeclFor finds the FuncDecl in files whose name identifier defines obj.
+func findFuncDeclFor(info *types.Info, files []*ast.File, obj types.Object) *ast.FuncDecl {
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			if info.Defs[fd.Name] == obj {
+				return fd
+			}
+		}
+	}
+	return nil
+}
+
+// findVarFuncLit finds the FuncLit a local var (obj) is bound to via
+// `v := func(){…}` or `var v = func(){…}`.
+func findVarFuncLit(info *types.Info, files []*ast.File, obj types.Object) *ast.FuncLit { //nolint:gocognit,lll // archtest AST scanner: handles AssignStmt (:=) and ValueSpec (var) forms with early-exit across multiple files
+	for _, f := range files {
+		var found *ast.FuncLit
+		// Short variable declarations: f := func(){...}
+		EachInSubtree[ast.AssignStmt](f, func(s *ast.AssignStmt) {
+			if found != nil || len(s.Lhs) != 1 || len(s.Rhs) != 1 {
+				return
+			}
+			if id, ok := s.Lhs[0].(*ast.Ident); ok && info.Defs[id] == obj {
+				if fl, ok := s.Rhs[0].(*ast.FuncLit); ok {
+					found = fl
+				}
+			}
+		})
+		if found != nil {
+			return found
+		}
+		// Package-level or block-level var declarations: var f = func(){...}
+		EachInSubtree[ast.ValueSpec](f, func(vs *ast.ValueSpec) {
+			if found != nil {
+				return
+			}
+			for i, name := range vs.Names {
+				if info.Defs[name] == obj && i < len(vs.Values) {
+					if fl, ok := vs.Values[i].(*ast.FuncLit); ok {
+						found = fl
+					}
+				}
+			}
+		})
+		if found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// CheckSagaJournalConformanceEnrollment is the importable form of
+// SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01. It scans the running module for
+// concrete journal.Journal implementations that lack a conformance suite call.
+// Not registered in StandardCellRules (targets GoCell-internal journal impls).
+func CheckSagaJournalConformanceEnrollment(t *testing.T, cfg ConfigForExternalCell) []Diagnostic { //nolint:gocognit,funlen,lll // archtest: mirrors GlobalReader enrollment; journal.Journal target; parallel structure intentional
+	t.Helper()
+	_ = cfg
+
+	root := findModuleRoot(t)
+	prodPatterns := prodscan.Patterns(root)
+	ifacePatterns := append([]string{"./kernel/saga/journal/..."}, prodPatterns...)
+
+	var iface *types.Interface
+	var implPkgs []*types.Package
+
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == sagaJournalPkg {
+				if obj := p.Pkg.Scope().Lookup(sagaJournalIfaceName); obj != nil {
+					if named, ok := obj.Type().(*types.Named); ok {
+						if i, ok := named.Underlying().(*types.Interface); ok {
+							iface = i.Complete()
+						}
+					}
+				}
+			}
+			implPkgs = append(implPkgs, p.Pkg)
+			return nil
+		})
+
+	if iface == nil {
+		return []Diagnostic{{
+			Rel:     "kernel/saga/journal",
+			Line:    0,
+			Message: "SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01: failed to resolve journal.Journal interface; check import path " + sagaJournalPkg,
+		}}
+	}
+
+	implSet := make(map[string]bool)
+	implPkgSet := make(map[string]bool)
+	for _, pkg := range implPkgs {
+		if pkg != nil {
+			collectSagaJournalImpls(pkg, iface, implSet, implPkgSet)
+		}
+	}
+
+	enrolledImpls := make(map[string]bool)
+	_ = Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, prodscan.Patterns(root)),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				if !strings.HasSuffix(p.Rel(f), "_test.go") {
+					continue
+				}
+				creditEnrollmentsFromFactory(p.TypesInfo, p.Files, f,
+					sagaConformanceFuncName, implSet, enrolledImpls)
+			}
+			return nil
+		})
+
+	var diags []Diagnostic
+	for implKey := range implSet {
+		if enrolledImpls[implKey] {
+			continue
+		}
+		dotIdx := strings.LastIndex(implKey, ".")
+		if dotIdx < 0 {
+			continue
+		}
+		pkgPath := implKey[:dotIdx]
+		diags = append(diags, Diagnostic{
+			Rel:  implKey,
+			Line: 0,
+			Message: fmt.Sprintf(
+				"archtest: kernel/saga/journal.Journal impl %q not enrolled "+
+					"(SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01). "+
+					"Add a _test.go in package %s (or its external _test) that "+
+					"both calls sagajournaltest.RunConformanceSuite(t, factory) "+
+					"and constructs the impl inside the factory.",
+				implKey, pkgPath,
+			),
+		})
+	}
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	return diags
+}
+
+// CheckSagaGlobalReaderConformanceEnrollment is the importable form of
+// SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01.
+// Not registered in StandardCellRules.
+func CheckSagaGlobalReaderConformanceEnrollment(t *testing.T, cfg ConfigForExternalCell) []Diagnostic { //nolint:gocognit,funlen,lll // archtest: mirrors Journal enrollment; journal.GlobalReader target; parallel structure intentional
+	t.Helper()
+	_ = cfg
+
+	root := findModuleRoot(t)
+	prodPatterns := prodscan.Patterns(root)
+	ifacePatterns := append([]string{"./kernel/saga/journal/..."}, prodPatterns...)
+
+	var iface *types.Interface
+	var implPkgs []*types.Package
+
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == sagaJournalPkg {
+				if obj := p.Pkg.Scope().Lookup(sagaGlobalReaderIfaceName); obj != nil {
+					if named, ok := obj.Type().(*types.Named); ok {
+						if i, ok := named.Underlying().(*types.Interface); ok {
+							iface = i.Complete()
+						}
+					}
+				}
+			}
+			implPkgs = append(implPkgs, p.Pkg)
+			return nil
+		})
+
+	if iface == nil {
+		return []Diagnostic{{
+			Rel:  "kernel/saga/journal",
+			Line: 0,
+			Message: "SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01: failed to resolve journal.GlobalReader interface; " +
+				"check import path " + sagaJournalPkg,
+		}}
+	}
+
+	implSet := make(map[string]bool)
+	implPkgSet := make(map[string]bool)
+	for _, pkg := range implPkgs {
+		if pkg != nil {
+			collectSagaJournalImpls(pkg, iface, implSet, implPkgSet)
+		}
+	}
+
+	enrolledImpls := make(map[string]bool)
+	_ = Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, prodscan.Patterns(root)),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				if !strings.HasSuffix(p.Rel(f), "_test.go") {
+					continue
+				}
+				creditEnrollmentsFromFactory(p.TypesInfo, p.Files, f,
+					sagaGlobalReaderConformanceFunc, implSet, enrolledImpls)
+			}
+			return nil
+		})
+
+	var diags []Diagnostic
+	for implKey := range implSet {
+		if enrolledImpls[implKey] {
+			continue
+		}
+		dotIdx := strings.LastIndex(implKey, ".")
+		if dotIdx < 0 {
+			continue
+		}
+		pkgPath := implKey[:dotIdx]
+		diags = append(diags, Diagnostic{
+			Rel:  implKey,
+			Line: 0,
+			Message: fmt.Sprintf(
+				"archtest: kernel/saga/journal.GlobalReader impl %q not enrolled "+
+					"(SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01). "+
+					"Add a _test.go in package %s (or its external _test) that "+
+					"both calls sagajournaltest.RunGlobalReaderConformance(t, factory) "+
+					"and constructs the impl inside the factory.",
+				implKey, pkgPath,
+			),
+		})
+	}
+	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	return diags
+}
+
+// ─── SAGA-JOURNAL-HOLDER-SEAL-01 helpers ─────────────────────────────────────
+
+// journalFieldKind classifies a struct field's resolved type against the three
+// journal-package interfaces this seal cares about.
+type journalFieldKind int
+
+const (
+	journalFieldNone        journalFieldKind = iota // not a journal-package interface
+	journalFieldFull                                // journal.Journal (Heartbeat-bearing)
+	journalFieldHeartbeater                         // journal.Heartbeater (Heartbeat-bearing)
+	journalFieldCore                                // journal.JournalCore (Heartbeat-free)
+)
+
+// classifyJournalFieldType resolves expr via info.Types to a known
+// journal-package interface, returning its kind.
+func classifyJournalFieldType(info *types.Info, expr ast.Expr) journalFieldKind {
+	if info == nil {
+		return journalFieldNone
+	}
+	tv, ok := info.Types[expr]
+	if !ok {
+		return journalFieldNone
+	}
+	return classifyResolvedJournalType(tv.Type)
+}
+
+// classifyResolvedJournalType maps a resolved types.Type to a journalFieldKind.
+func classifyResolvedJournalType(t types.Type) journalFieldKind {
+	if t == nil {
+		return journalFieldNone
+	}
+	// Collapse a top-level alias (`type J = journal.JournalCore`) before the
+	// pointer probe, then again after unwrapping a pointer (`*J`, or
+	// `type J = *journal.JournalCore`), so every alias⇄pointer ordering resolves.
+	t = types.Unalias(t)
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(ptr.Elem())
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return journalFieldNone
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != sagaJournalPkg {
+		return journalFieldNone
+	}
+	switch obj.Name() {
+	case journalInterfaceTypeName:
+		return journalFieldFull
+	case heartbeaterInterfaceTypeName:
+		return journalFieldHeartbeater
+	case journalCoreInterfaceTypeName:
+		return journalFieldCore
+	}
+	return journalFieldNone
+}
+
+// journalFieldSealDiag emits a diagnostic when a struct field in runtime/saga
+// holds a forbidden journal type.
+func journalFieldSealDiag(p *Pass, rel, holderName string, field *ast.Field) (Diagnostic, bool) {
+	kind := classifyJournalFieldType(p.TypesInfo, field.Type)
+	if kind == journalFieldNone {
+		return Diagnostic{}, false
+	}
+	msg := journalFieldSealMessage(kind, holderName)
+	if msg == "" {
+		return Diagnostic{}, false
+	}
+	return sagaDiag(p, field, rel, msg), true
+}
+
+// journalFieldSealMessage returns the diagnostic message for a forbidden
+// journal field, or "" if the field is explicitly allowed.
+func journalFieldSealMessage(kind journalFieldKind, holderName string) string {
+	switch kind {
+	case journalFieldFull:
+		return sagaJournalHolderSealRule + "-rule1: runtime/saga struct " + holderName +
+			" holds journal.Journal (Heartbeat-bearing); " +
+			"only journal.JournalCore may be persisted as a field in runtime/saga " +
+			"(Coordinator.journal was narrowed from Journal to JournalCore in #1209 to " +
+			"make a centralized heartbeat loop compile-impossible)"
+	case journalFieldHeartbeater:
+		return sagaJournalHolderSealRule + "-rule1: runtime/saga struct " + holderName +
+			" holds journal.Heartbeater (Heartbeat-bearing); " +
+			"same restriction as journal.Journal — only JournalCore may be persisted"
+	case journalFieldCore:
+		if holderName == allowedSagaJournalHolder {
+			return "" // allowed: Coordinator.journal is journal.JournalCore
+		}
+		return sagaJournalHolderSealRule + "-rule2: runtime/saga struct " + holderName +
+			" holds journal.JournalCore; only " + allowedSagaJournalHolder +
+			" may hold a JournalCore field — other structs must not persist it"
+	}
+	return ""
+}
+
+// heartbeatFuncFieldDiag emits a diagnostic when a struct field in runtime/saga
+// has a heartbeat-shaped func signature.
+func heartbeatFuncFieldDiag(p *Pass, rel, holderName string, field *ast.Field) (Diagnostic, bool) {
+	if p.TypesInfo == nil {
+		return Diagnostic{}, false
+	}
+	tv, ok := p.TypesInfo.Types[field.Type]
+	if !ok {
+		return Diagnostic{}, false
+	}
+	// A field typed as a named func type (e.g. `type HBFunc func(...)`) surfaces
+	// as *types.Named in go/types; its Underlying() is the *types.Signature.
+	// An alias (`type HBFunc = func(...)`) surfaces as *types.Alias in Go 1.23+,
+	// so we must Unalias before probing. Then strip a pointer if present.
+	ft := types.Unalias(tv.Type)
+	if ptr, ok2 := ft.(*types.Pointer); ok2 {
+		ft = types.Unalias(ptr.Elem())
+	}
+	sig, ok := ft.Underlying().(*types.Signature)
+	if !ok {
+		return Diagnostic{}, false
+	}
+	if !signatureMatchesHeartbeaterShape(sig) {
+		return Diagnostic{}, false
+	}
+	return sagaDiag(p, field, rel,
+			sagaJournalHolderSealRule+"-rule3: runtime/saga struct "+holderName+
+				" has a heartbeat-shaped func field "+
+				"(func(ctx, instanceID, leaseID SafeID, dur time.Duration) (bool, error)); "+
+				"this is a potential bypass path for the heartbeat loop ban "+
+				"(see SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01; SAGA-JOURNAL-HOLDER-SEAL-01 rule 3 medium guard)"),
+		true
+}
+
+// journalPackageLocalNames collects the set of local names that any import in
+// file uses for the journal package (sagaJournalPkg).
+func journalPackageLocalNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range file.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || p != sagaJournalPkg {
+			continue
+		}
+		if imp.Name != nil {
+			names[imp.Name.Name] = true
+		} else {
+			names["journal"] = true
+		}
+	}
+	return names
+}
+
+// journalInterfaceAliasName returns the aliased name if ts is a type alias to
+// one of the three journal interfaces, using journalLocalNames for resolution.
+// journalInterfaceAliasName reports the journal interface name aliased by ts if
+// ts is `type X = <localName>.{Journal,JournalCore,Heartbeater}` where localName
+// is any local binding of the journal package (journalLocalNames), else
+// ("", false). Resolving via journalLocalNames rather than a hardcoded "journal"
+// closes the import-alias evasion: `import sagajournal "…/journal"` followed by
+// `type X = sagajournal.JournalCore` is now flagged.
+func journalInterfaceAliasName(ts *ast.TypeSpec, journalLocalNames map[string]bool) (string, bool) {
+	// An alias has a valid Assign token.
+	if !ts.Assign.IsValid() {
+		return "", false
+	}
+	sel, ok := ts.Type.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	xIdent, ok := sel.X.(*ast.Ident)
+	if !ok || !journalLocalNames[xIdent.Name] {
+		return "", false
+	}
+	switch sel.Sel.Name {
+	case journalInterfaceTypeName, journalCoreInterfaceTypeName, heartbeaterInterfaceTypeName:
+		return sel.Sel.Name, true
+	}
+	return "", false
+}
+
+// CheckSagaJournalHolderSeal is the importable form of
+// SAGA-JOURNAL-HOLDER-SEAL-01.
+// Not registered in StandardCellRules.
+func CheckSagaJournalHolderSeal(t *testing.T, cfg ConfigForExternalCell) []Diagnostic { //nolint:gocognit,lll // archtest: three sub-rules (Journal/Heartbeater, JournalCore holder, heartbeat func field) require separate branches
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := filepath.ToSlash(p.Rel(file))
+			if strings.HasSuffix(rel, "_test.go") || !strings.HasPrefix(rel, "runtime/saga/") {
+				continue
+			}
+			EachInSubtree[ast.StructType](file, func(st *ast.StructType) {
+				// Find the enclosing type declaration name.
+				// We walk upward from the StructType, which requires finding
+				// the GenDecl/TypeSpec parent. Since we only need the struct
+				// name for the diagnostic message, we do best-effort via
+				// TypesInfo: find any TypeSpec that is a parent via file walk.
+				holderName := sagaStructHolderName(p.TypesInfo, file, st)
+				if st.Fields == nil {
+					return
+				}
+				for _, field := range st.Fields.List {
+					if d, ok := journalFieldSealDiag(p, rel, holderName, field); ok {
+						out = append(out, d)
+					}
+					if d, ok := heartbeatFuncFieldDiag(p, rel, holderName, field); ok {
+						out = append(out, d)
+					}
+				}
+			})
+		}
+		return nil
+	})
+	return out
+}
+
+// sagaStructHolderName returns the declared type name of the struct that
+// contains st, or "unknown" if not found. It iterates TypesInfo.Defs to find
+// a TypeName whose declared type's underlying is st.
+func sagaStructHolderName(_ *types.Info, file *ast.File, st *ast.StructType) string {
+	// Walk GenDecl/TypeSpec in the file to find the enclosing TypeSpec.
+	var name string
+	EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+		if name != "" {
+			return
+		}
+		structLit, ok := ts.Type.(*ast.StructType)
+		if !ok || structLit != st {
+			return
+		}
+		name = ts.Name.Name
+	})
+	if name == "" {
+		return "unknown"
+	}
+	return name
+}
+
+// ─── SAGA-DRIVE-BEHIND-LEADER-GATE-01 helpers ────────────────────────────────
+
+// callIsMethodNamed reports whether call.Fun is a SelectorExpr or Ident with
+// the given method name.
+func callIsMethodNamed(call *ast.CallExpr, name string) bool {
+	switch f := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return f.Sel != nil && f.Sel.Name == name
+	case *ast.Ident:
+		return f.Name == name
+	}
+	return false
+}
+
+// checkLeaderGateA1 asserts driveOne calls only appear in tickOnce bodies.
+func checkLeaderGateA1(p *Pass, file *ast.File) []Diagnostic {
+	rel := filepath.ToSlash(p.Rel(file))
+	var out []Diagnostic
+	EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+		if fd.Name == nil || fd.Body == nil {
+			return
+		}
+		if fd.Name.Name == tickOnceFuncName {
+			return // allowed
+		}
+		EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
+			if callIsMethodNamed(call, driveOneMethodName) {
+				out = append(out, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(call.Pos()).Line,
+					Message: sagaLeaderGateRule + "-A1: driveOne CallExpr outside tickOnce body — " +
+						"driveOne must only be called from tickOnce so the leader-elect gate guards every drive",
+				})
+			}
+		})
+	})
+	return out
+}
+
+// checkLeaderGateA2 asserts tickOnce calls acquireLead.
+func checkLeaderGateA2(p *Pass, file *ast.File) []Diagnostic {
+	rel := filepath.ToSlash(p.Rel(file))
+	var out []Diagnostic
+	EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+		if fd.Name == nil || fd.Body == nil || fd.Name.Name != tickOnceFuncName {
+			return
+		}
+		if !bodyCallsMethodNamed(fd.Body, acquireLeadMethodName) {
+			out = append(out, Diagnostic{
+				Rel:     rel,
+				Line:    p.Fset.Position(fd.Pos()).Line,
+				Message: sagaLeaderGateRule + "-A2: tickOnce body does not call acquireLead — the sole driveOne caller must pass the leader-elect gate",
+			})
+		}
+	})
+	return out
+}
+
+// checkLeaderGateA3 asserts the lead result from acquireLead gates driveOne.
+func checkLeaderGateA3(p *Pass, file *ast.File) []Diagnostic {
+	rel := filepath.ToSlash(p.Rel(file))
+	var out []Diagnostic
+	EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+		if fd.Name == nil || fd.Body == nil || fd.Name.Name != tickOnceFuncName {
+			return
+		}
+		leadVar, ok := acquireLeadResultVar(fd.Body)
+		if !ok {
+			return // no acquireLead result captured — A2 will report
+		}
+		if !leadGatesDrive(fd.Body, leadVar) {
+			out = append(out, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(fd.Pos()).Line,
+				Message: sagaLeaderGateRule + "-A3: tickOnce calls acquireLead but its lead result does not gate driveOne — " +
+					"the gate verdict must guard the drive (e.g. `if !lead { continue }`)",
+			})
+		}
+	})
+	return out
+}
+
+// bodyCallsMethodNamed reports whether the body contains a direct call to name.
+func bodyCallsMethodNamed(body *ast.BlockStmt, name string) bool {
+	found := false
+	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
+		if !found && callIsMethodNamed(call, name) {
+			found = true
+		}
+	})
+	return found
+}
+
+// acquireLeadResultVar finds the assignment whose RHS is `<expr>.acquireLead(...)`
+// and returns the identifier bound to the last LHS element (the lead bool). ok is
+// false when acquireLead is not assigned to a tuple of at least 2 elements or the
+// lead slot is blank (`_`) — a discarded verdict cannot gate the drive.
+//
+// acquireLead currently returns 3 values (release, orphan, lead); the last LHS
+// element is always the bool gate regardless of tuple arity, so arity ≥ 2 is
+// accepted. Fixtures using the historical 2-return form also pass.
+func acquireLeadResultVar(body *ast.BlockStmt) (name string, ok bool) {
+	as, found := FindFirstInSubtree[ast.AssignStmt](body, func(as *ast.AssignStmt) bool {
+		if len(as.Rhs) != 1 || len(as.Lhs) < 2 {
+			return false
+		}
+		call, isCall := as.Rhs[0].(*ast.CallExpr)
+		if !isCall || !callIsMethodNamed(call, acquireLeadMethodName) {
+			return false
+		}
+		last := as.Lhs[len(as.Lhs)-1]
+		id, isID := last.(*ast.Ident)
+		return isID && id.Name != "_"
+	})
+	if !found {
+		return "", false
+	}
+	last := as.Lhs[len(as.Lhs)-1]
+	id := last.(*ast.Ident)
+	return id.Name, true
+}
+
+// leadGatesDrive reports whether some IfStmt in body has a condition referencing
+// leadVar and a body that either early-exits (BranchStmt/ReturnStmt) or contains
+// a driveOne call — the two sanctioned gate shapes.
+func leadGatesDrive(body *ast.BlockStmt, leadVar string) bool {
+	_, ok := FindFirstInSubtree[ast.IfStmt](body, func(ifs *ast.IfStmt) bool {
+		if ifs.Cond == nil || !condReferences(ifs.Cond, leadVar) {
+			return false
+		}
+		return ifBodyEarlyExits(ifs.Body) || bodyCallsMethodNamed(ifs.Body, driveOneMethodName)
+	})
+	return ok
+}
+
+// condReferences reports whether expr contains an identifier named want.
+func condReferences(expr ast.Expr, want string) bool {
+	_, ok := FindFirstInSubtree[ast.Ident](expr, func(id *ast.Ident) bool {
+		return id.Name == want
+	})
+	return ok
+}
+
+// ifBodyEarlyExits reports whether body contains a continue/break/return that
+// skips the rest of the claim-loop iteration before driveOne runs.
+func ifBodyEarlyExits(body *ast.BlockStmt) bool {
+	exits := false
+	EachInSubtree[ast.BranchStmt](body, func(*ast.BranchStmt) { exits = true })
+	if exits {
+		return true
+	}
+	EachInSubtree[ast.ReturnStmt](body, func(*ast.ReturnStmt) { exits = true })
+	return exits
+}
+
+// CheckSagaDriveBehindLeaderGate is the importable form of
+// SAGA-DRIVE-BEHIND-LEADER-GATE-01.
+// Not registered in StandardCellRules.
+func CheckSagaDriveBehindLeaderGate(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
+		for _, file := range p.Files {
+			rel := filepath.ToSlash(p.Rel(file))
+			if strings.HasSuffix(rel, "_test.go") || !strings.HasPrefix(rel, "runtime/saga/") {
+				continue
+			}
+			out = append(out, checkLeaderGateA1(p, file)...)
+			out = append(out, checkLeaderGateA2(p, file)...)
+			out = append(out, checkLeaderGateA3(p, file)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// ─── SAGA-STEP-RUN-OUTSIDE-TX-01 helpers ─────────────────────────────────────
+
+// sagaLocalName returns the local identifier used to import kernel/saga in
+// file, or "saga" if the package is imported without an alias. Uses
+// strconv.Unquote to compare against the derived path constant (no quoted
+// literal in non-test code).
+func sagaLocalName(file *ast.File) string {
+	for _, imp := range file.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || p != sagaPkgPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		return "saga"
+	}
+	return ""
+}
+
+// isRuntimeSagaProductionFile reports whether rel is a production .go file
+// under runtime/saga/ (not _test.go, not runtime/saga/executor/).
+func isRuntimeSagaProductionFile(rel string) bool {
+	return strings.HasPrefix(rel, "runtime/saga/") &&
+		!strings.HasSuffix(rel, "_test.go")
+}
+
+// checkA1StepFuncCallsites implements SAGA-STEP-RUN-OUTSIDE-TX-01 A1: every
+// kernel/saga.StepFunc call must only appear in safeRun function bodies.
+func checkA1StepFuncCallsites(p *Pass, file *ast.File) []Diagnostic {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	rel := filepath.ToSlash(p.Rel(file))
+	sagaStepFuncType := resolveSagaStepFuncType(p.Pkg)
+	if sagaStepFuncType == nil {
+		return nil
+	}
+
+	// Collect safeRun body ranges.
+	safeRunRanges := collectFuncBodyRanges(file, safeRunFuncName)
+
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if !calleeIsSagaStepFunc(p.TypesInfo, call, sagaStepFuncType) {
+			return
+		}
+		if posInRanges(call.Pos(), safeRunRanges) {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: p.Fset.Position(call.Pos()).Line,
+			Message: sagaStepRunOutsideTxRule + "-A1: saga.StepFunc CallExpr outside safeRun body — " +
+				"StepFunc must only be invoked from safeRun (user step code outside DB tx invariant)",
+		})
+	})
+	return out
+}
+
+// resolveSagaStepFuncType resolves the kernel/saga.StepFunc named type from
+// pkg's transitive imports.
+func resolveSagaStepFuncType(pkg *types.Package) *types.Named {
+	if pkg == nil {
+		return nil
+	}
+	sagaPkg := findImportedPkg(pkg, sagaPkgPath)
+	if sagaPkg == nil {
+		return nil
+	}
+	obj := sagaPkg.Scope().Lookup(stepFuncTypeName)
+	if obj == nil {
+		return nil
+	}
+	named, ok := obj.Type().(*types.Named)
+	if !ok {
+		return nil
+	}
+	return named
+}
+
+// findImportedPkg traverses the import graph of root to find the package at path.
+func findImportedPkg(root *types.Package, path string) *types.Package {
+	if root == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var dfs func(*types.Package) *types.Package
+	dfs = func(pkg *types.Package) *types.Package {
+		if pkg == nil || seen[pkg.Path()] {
+			return nil
+		}
+		seen[pkg.Path()] = true
+		if pkg.Path() == path {
+			return pkg
+		}
+		for _, imp := range pkg.Imports() {
+			if found := dfs(imp); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+	return dfs(root)
+}
+
+// calleeIsSagaStepFunc reports whether call's callee resolves to a value of
+// type kernel/saga.StepFunc (i.e. a call expression like step.Run(ctx, state)).
+func calleeIsSagaStepFunc(info *types.Info, call *ast.CallExpr, sagaStepFuncType *types.Named) bool {
+	if sagaStepFuncType == nil {
+		return false
+	}
+	tv, ok := info.Types[call.Fun]
+	if !ok {
+		return false
+	}
+	named, ok := tv.Type.(*types.Named)
+	if !ok {
+		return false
+	}
+	return named == sagaStepFuncType
+}
+
+// checkA2SafeRunNotInRunInTx implements A2: safeRun must not be called inside
+// a TxRunner.RunInTx closure body.
+func checkA2SafeRunNotInRunInTx(p *Pass, file *ast.File) []Diagnostic {
+	rel := filepath.ToSlash(p.Rel(file))
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(outerCall *ast.CallExpr) {
+		if !callIsRunInTx(outerCall) {
+			return
+		}
+		// Find the closure argument (last arg that is a FuncLit).
+		var closure *ast.FuncLit
+		for i := len(outerCall.Args) - 1; i >= 0; i-- {
+			if fl, ok := outerCall.Args[i].(*ast.FuncLit); ok {
+				closure = fl
+				break
+			}
+		}
+		if closure == nil {
+			return
+		}
+		EachInSubtree[ast.CallExpr](closure.Body, func(inner *ast.CallExpr) {
+			if callIsSafeRun(inner) {
+				out = append(out, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(inner.Pos()).Line,
+					Message: sagaStepRunOutsideTxRule + "-A2: safeRun() called inside RunInTx closure body — " +
+						"user step code would run with a DB transaction held open",
+				})
+			}
+		})
+	})
+	return out
+}
+
+// callIsRunInTx reports whether call is a RunInTx call.
+func callIsRunInTx(call *ast.CallExpr) bool {
+	switch f := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return f.Sel != nil && f.Sel.Name == runInTxMethodName
+	case *ast.Ident:
+		return f.Name == runInTxMethodName
+	}
+	return false
+}
+
+// callIsSafeRun reports whether call is a safeRun call.
+func callIsSafeRun(call *ast.CallExpr) bool {
+	switch f := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return f.Sel != nil && f.Sel.Name == safeRunFuncName
+	case *ast.Ident:
+		return f.Name == safeRunFuncName
+	}
+	return false
+}
+
+// checkB1NoStepFuncAlias implements B1: no production file in runtime/saga/
+// may declare a type alias for kernel/saga.StepFunc.
+func checkB1NoStepFuncAlias(p *Pass, file *ast.File) []Diagnostic {
+	local := sagaLocalName(file)
+	if local == "" {
+		return nil
+	}
+	rel := filepath.ToSlash(p.Rel(file))
+	var out []Diagnostic
+	EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
+		if !ts.Assign.IsValid() {
+			return // not an alias
+		}
+		sel, ok := ts.Type.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		xIdent, ok := sel.X.(*ast.Ident)
+		if !ok || xIdent.Name != local || sel.Sel.Name != stepFuncTypeName {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: p.Fset.Position(ts.Pos()).Line,
+			Message: sagaStepRunOutsideTxRule + "-B1: type alias for kernel/saga.StepFunc in runtime/saga; " +
+				"aliasing StepFunc could allow calls to escape the safeRun gate (B1 blind spot)",
+		})
+	})
+	return out
+}
+
+// CheckSagaStepRunOutsideTx is the importable form of
+// SAGA-STEP-RUN-OUTSIDE-TX-01.
+// Not registered in StandardCellRules.
+func CheckSagaStepRunOutsideTx(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			rel := filepath.ToSlash(p.Rel(file))
+			if !isRuntimeSagaProductionFile(rel) {
+				continue
+			}
+			out = append(out, checkA1StepFuncCallsites(p, file)...)
+			out = append(out, checkA2SafeRunNotInRunInTx(p, file)...)
+			out = append(out, checkB1NoStepFuncAlias(p, file)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// ─── SAGA-CONSTRUCTOR-NIL-GUARD-01 helpers ────────────────────────────────────
+
+// scanConstructorNilGuards scans p for top-level New* functions that accept
+// non-variadic interface parameters lacking a guard call.
+func scanConstructorNilGuards(p *Pass) []Diagnostic { //nolint:gocognit,cyclop,funlen,lll // archtest: enumerates constructor params, resolves interface types, cross-checks guard callsites; inherent to SAGA-CONSTRUCTOR-NIL-GUARD-01
+	if p.TypesInfo == nil {
+		return nil
+	}
+	var out []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || fd.Body == nil {
+				return
+			}
+			if !strings.HasPrefix(fd.Name.Name, "New") {
+				return
+			}
+			if fd.Type.Params == nil {
+				return
+			}
+			type ifaceParam struct {
+				obj      types.Object
+				typeExpr ast.Expr
+				name     string
+				typStr   string
+			}
+			var ifaces []ifaceParam
+			for _, field := range fd.Type.Params.List {
+				if _, isEllipsis := field.Type.(*ast.Ellipsis); isEllipsis {
+					continue
+				}
+				typ := p.TypesInfo.TypeOf(field.Type)
+				if typ == nil {
+					continue
+				}
+				if _, isIface := typ.Underlying().(*types.Interface); !isIface {
+					continue
+				}
+				if len(field.Names) == 0 {
+					out = append(out, sagaDiag(p, field.Type, rel,
+						sagaConstructorNilGuardRuleID+": constructor "+fd.Name.Name+
+							" has an unnamed interface parameter (type "+sagaShortType(typ)+
+							") that cannot be nil-guarded; give it a name and add "+
+							"validation.IsNilInterface(<param>) (or clock.MustHaveClock)"))
+					continue
+				}
+				for _, name := range field.Names {
+					obj := p.TypesInfo.Defs[name]
+					if name.Name == "_" || obj == nil {
+						out = append(out, sagaDiag(p, name, rel,
+							sagaConstructorNilGuardRuleID+": constructor "+fd.Name.Name+
+								" has a blank-identifier interface parameter (type "+sagaShortType(typ)+
+								") that cannot be nil-guarded; give it a name and add "+
+								"validation.IsNilInterface(<param>) (or clock.MustHaveClock)"))
+						continue
+					}
+					ifaces = append(ifaces, ifaceParam{
+						obj:      obj,
+						typeExpr: field.Type,
+						name:     name.Name,
+						typStr:   sagaShortType(typ),
+					})
+				}
+			}
+			if len(ifaces) == 0 {
+				return
+			}
+			for _, ip := range ifaces {
+				_, guarded := FindFirstInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) bool {
+					if !sagaIsGuardCall(p, call) {
+						return false
+					}
+					if len(call.Args) == 0 {
+						return false
+					}
+					firstArg, ok2 := ast.Unparen(call.Args[0]).(*ast.Ident)
+					if !ok2 {
+						return false
+					}
+					return p.TypesInfo.ObjectOf(firstArg) == ip.obj
+				})
+				if !guarded {
+					out = append(out, sagaDiag(p, fd.Name, rel,
+						sagaConstructorNilGuardRuleID+": constructor "+fd.Name.Name+
+							" has interface parameter "+ip.name+" (type "+ip.typStr+
+							") without a guard call (IsNilInterface or clock.MustHaveClock); "+
+							"add validation.IsNilInterface("+ip.name+") or clock.MustHaveClock("+ip.name+", ...)"))
+				}
+			}
+		})
+	}
+	return out
+}
+
+// sagaIsGuardCall reports whether call resolves to a sanctioned nil-guard
+// function (validation.IsNilInterface or clock.MustHaveClock).
+func sagaIsGuardCall(p *Pass, call *ast.CallExpr) bool {
+	var calleeFunc *types.Func
+	switch fun := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		if f, ok := p.TypesInfo.ObjectOf(fun.Sel).(*types.Func); ok {
+			calleeFunc = f
+		}
+	case *ast.Ident:
+		if f, ok := p.TypesInfo.ObjectOf(fun).(*types.Func); ok {
+			calleeFunc = f
+		}
+	}
+	if calleeFunc == nil || calleeFunc.Pkg() == nil {
+		return false
+	}
+	for _, gk := range sagaGuardFuncKeys {
+		if calleeFunc.Pkg().Path() == gk.pkg && calleeFunc.Name() == gk.name {
+			return true
+		}
+	}
+	return false
+}
+
+// sagaShortType renders t as package.TypeName (short package name).
+func sagaShortType(t types.Type) string {
+	return types.TypeString(t, func(p *types.Package) string { return p.Name() })
+}
+
+// sagaConstructorIfaceParamObjs returns the set of named, non-variadic
+// interface parameter objects of a New* constructor.
+func sagaConstructorIfaceParamObjs(p *Pass, fd *ast.FuncDecl) map[types.Object]bool {
+	out := map[types.Object]bool{}
+	if fd.Type.Params == nil {
+		return out
+	}
+	for _, field := range fd.Type.Params.List {
+		if _, isEllipsis := field.Type.(*ast.Ellipsis); isEllipsis {
+			continue
+		}
+		typ := p.TypesInfo.TypeOf(field.Type)
+		if typ == nil {
+			continue
+		}
+		if _, isIface := typ.Underlying().(*types.Interface); !isIface {
+			continue
+		}
+		for _, name := range field.Names {
+			if obj := p.TypesInfo.Defs[name]; obj != nil {
+				out[obj] = true
+			}
+		}
+	}
+	return out
+}
+
+// CheckSagaConstructorNilGuard is the importable form of
+// SAGA-CONSTRUCTOR-NIL-GUARD-01.
+// Not registered in StandardCellRules.
+func CheckSagaConstructorNilGuard(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/...", "./runtime/saga/executor/..."}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil || p.Pkg == nil {
+			return nil
+		}
+		if !sagaConstructorScopePackages[p.Pkg.Path()] {
+			return nil
+		}
+		out = append(out, scanConstructorNilGuards(p)...)
+		return nil
+	})
+	return out
+}
+
+// ─── SAGA-SLOG-INSTANCE-FIELDS-CALLER-01 helpers ────────────────────────────
+
+// sagaSlogAttrCtorGuardedKey reports whether call is a log/slog package-level
+// Attr constructor whose first argument is one of the guarded identity keys.
+func sagaSlogAttrCtorGuardedKey(info *types.Info, call *ast.CallExpr) (string, bool) {
+	if info == nil || len(call.Args) < 1 {
+		return "", false
+	}
+	pkgPath, _, ok := ResolvePackageRef(info, call.Fun)
+	if !ok || pkgPath != sagaSlogPkgPath {
+		return "", false
+	}
+	if !sagaCalleeReturnsSlogAttr(info, call.Fun) {
+		return "", false
+	}
+	key, ok := EvaluateConstString(info, call.Args[0])
+	if !ok {
+		return "", false
+	}
+	if _, guarded := sagaInstanceFieldsGuardedKeys[key]; !guarded {
+		return "", false
+	}
+	return key, true
+}
+
+// sagaCalleeReturnsSlogAttr reports whether fun resolves to a function whose
+// single result is log/slog.Attr.
+func sagaCalleeReturnsSlogAttr(info *types.Info, fun ast.Expr) bool {
+	tv, ok := info.Types[fun]
+	if !ok {
+		return false
+	}
+	sig, ok := tv.Type.(*types.Signature)
+	if !ok || sig.Results().Len() != 1 {
+		return false
+	}
+	named, ok := sig.Results().At(0).Type().(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == sagaSlogAttrTypeName &&
+		obj.Pkg() != nil && obj.Pkg().Path() == sagaSlogPkgPath
+}
+
+// scanSagaSlogInstanceFieldsFile is the A1 core: flag every log/slog Attr
+// constructor call carrying a guarded identity key outside an InstanceFields body.
+func scanSagaSlogInstanceFieldsFile(p *Pass, file *ast.File) []Diagnostic {
+	rel := filepath.ToSlash(p.Rel(file))
+	carrierRanges := collectFuncBodyRanges(file, sagaInstanceFieldsFuncName)
+	var ds []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		key, ok := sagaSlogAttrCtorGuardedKey(p.TypesInfo, call)
+		if !ok {
+			return
+		}
+		if posInRanges(call.Pos(), carrierRanges) {
+			return
+		}
+		pos := p.Fset.Position(call.Pos())
+		ds = append(ds, Diagnostic{
+			Rel:     rel,
+			Line:    pos.Line,
+			Message: violSagaSlogInstanceFieldsOutsideCarrier + ` (key="` + key + `")`,
+		})
+	})
+	return ds
+}
+
+// scanSagaSlogAttrLiteralsFile flags every log/slog.Attr composite literal
+// (keyed or unkeyed) carrying a guarded identity key.
+func scanSagaSlogAttrLiteralsFile(p *Pass, file *ast.File) []Diagnostic {
+	rel := filepath.ToSlash(p.Rel(file))
+	var ds []Diagnostic
+	EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
+		key, ok := sagaSlogAttrLiteralGuardedKey(p.TypesInfo, cl)
+		if !ok {
+			return
+		}
+		pos := p.Fset.Position(cl.Pos())
+		ds = append(ds, Diagnostic{
+			Rel:  rel,
+			Line: pos.Line,
+			Message: sagaSlogInstanceFieldsRule + ": slog.Attr{…} literal with key \"" + key +
+				"\" — build identity attrs via sagalog.InstanceFields, not a raw slog.Attr literal (#1266)",
+		})
+	})
+	return ds
+}
+
+// sagaSlogAttrLiteralGuardedKey reports whether cl is a log/slog.Attr
+// composite literal whose Key field is one of the guarded identity keys.
+func sagaSlogAttrLiteralGuardedKey(info *types.Info, cl *ast.CompositeLit) (string, bool) { //nolint:gocognit,lll // archtest: handles slog.Attr keyed/keyless forms and resolves type identity for guarded identity keys
+	if info == nil {
+		return "", false
+	}
+	named, ok := info.TypeOf(cl).(*types.Named)
+	if !ok {
+		return "", false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Name() != sagaSlogAttrTypeName || obj.Pkg() == nil || obj.Pkg().Path() != sagaSlogPkgPath {
+		return "", false
+	}
+	if len(cl.Elts) == 0 {
+		return "", false
+	}
+	// Keyed form.
+	if _, isKV := cl.Elts[0].(*ast.KeyValueExpr); isKV {
+		var foundKey string
+		var foundOK bool
+		EachInSubtree[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) {
+			if foundOK {
+				return
+			}
+			ident, isIdent := kv.Key.(*ast.Ident)
+			if !isIdent || ident.Name != "Key" {
+				return
+			}
+			k, guarded := sagaGuardedKeyFromExpr(info, kv.Value)
+			if guarded {
+				foundKey = k
+				foundOK = true
+			}
+		})
+		if foundOK {
+			return foundKey, true
+		}
+		return "", false
+	}
+	// Unkeyed (positional) form.
+	return sagaGuardedKeyFromExpr(info, cl.Elts[0])
+}
+
+// sagaGuardedKeyFromExpr evaluates expr to a const string and returns it when
+// it is one of the guarded identity keys.
+func sagaGuardedKeyFromExpr(info *types.Info, expr ast.Expr) (string, bool) {
+	key, ok := EvaluateConstString(info, expr)
+	if !ok {
+		return "", false
+	}
+	if _, guarded := sagaInstanceFieldsGuardedKeys[key]; guarded {
+		return key, true
+	}
+	return "", false
+}
+
+// CheckSagaSlogInstanceFieldsCaller is the importable form of
+// SAGA-SLOG-INSTANCE-FIELDS-CALLER-01.
+// Not registered in StandardCellRules.
+func CheckSagaSlogInstanceFieldsCaller(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var out []Diagnostic
+	Run(t, Typed(TypedOpts{}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
+		if p.TypesInfo == nil {
+			return nil
+		}
+		for _, file := range p.Files {
+			if !isRuntimeSagaProductionFile(filepath.ToSlash(p.Rel(file))) {
+				continue
+			}
+			out = append(out, scanSagaSlogInstanceFieldsFile(p, file)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// ─── SAGA-METRIC-LABEL-VALUES-FROZEN-01 helpers ──────────────────────────────
+
+// sagaEnumTypeName returns the enum type name if t is one of the frozen
+// executor label-enum named types, else "".
+func sagaEnumTypeName(t types.Type) string {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return ""
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != sagaExecutorPkg {
+		return ""
+	}
+	if _, frozen := sagaLabelEnumWant[obj.Name()]; frozen {
+		return obj.Name()
+	}
+	return ""
+}
+
+// collectSagaEnumConsts enumerates, per frozen enum type, the string constant
+// values declared in the executor package.
+func collectSagaEnumConsts(p *Pass) map[string][]string {
+	if p.Pkg == nil {
+		return nil
+	}
+	got := make(map[string][]string)
+	scope := p.Pkg.Scope()
+	for _, name := range scope.Names() {
+		c, ok := scope.Lookup(name).(*types.Const)
+		if !ok {
+			continue
+		}
+		typeName := sagaEnumTypeName(c.Type())
+		if typeName == "" {
+			continue
+		}
+		got[typeName] = append(got[typeName], strings.Trim(c.Val().ExactString(), `"`))
+	}
+	return got
+}
+
+// sagaValueSetDiff returns "" when got and want hold the same set, else a
+// human-readable description.
+func sagaValueSetDiff(got, want []string) string {
+	gs, ws := slices.Clone(got), slices.Clone(want)
+	slices.Sort(gs)
+	slices.Sort(ws)
+	if slices.Equal(gs, ws) {
+		return ""
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, k := range want {
+		wantSet[k] = struct{}{}
+	}
+	gotSet := make(map[string]struct{}, len(got))
+	var extra, missing []string
+	for _, k := range got {
+		gotSet[k] = struct{}{}
+		if _, ok := wantSet[k]; !ok {
+			extra = append(extra, k)
+		}
+	}
+	for _, k := range want {
+		if _, ok := gotSet[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	slices.Sort(extra)
+	slices.Sort(missing)
+	return "  extra:   " + sliceOrNone(extra) + "\n  missing: " + sliceOrNone(missing)
+}
+
+// isSagaEnumConversion reports whether call is a type conversion to one of the
+// frozen executor label enums.
+func isSagaEnumConversion(info *types.Info, call *ast.CallExpr) bool {
+	var sel *ast.Ident
+	switch f := call.Fun.(type) {
+	case *ast.Ident:
+		sel = f
+	case *ast.SelectorExpr:
+		sel = f.Sel
+	default:
+		return false
+	}
+	tn, ok := info.ObjectOf(sel).(*types.TypeName)
+	if !ok {
+		return false
+	}
+	return sagaEnumTypeName(tn.Type()) != ""
+}
+
+// isSagaDeclaredConstRef reports whether arg is a bare reference to a const
+// declared in the runtime/saga/executor package AND typed as one of the frozen
+// executor label enums.
+func isSagaDeclaredConstRef(info *types.Info, arg ast.Expr) bool {
+	var obj types.Object
+	switch e := arg.(type) {
+	case *ast.Ident:
+		obj = info.ObjectOf(e)
+	case *ast.SelectorExpr:
+		obj = info.ObjectOf(e.Sel)
+	default:
+		return false
+	}
+	c, ok := obj.(*types.Const)
+	if !ok {
+		return false
+	}
+	if c.Pkg() == nil || c.Pkg().Path() != sagaExecutorPkg {
+		return false
+	}
+	return sagaEnumTypeName(c.Type()) != ""
+}
+
+// sagaEnumConstViolation reports whether expr is an inline enum-typed constant
+// that is NOT a valid frozen executor declared-const reference.
+func sagaEnumConstViolation(info *types.Info, expr ast.Expr) string {
+	tv, ok := info.Types[expr]
+	if !ok || tv.Value == nil {
+		return ""
+	}
+	typeName := sagaEnumTypeName(tv.Type)
+	if typeName == "" {
+		return ""
+	}
+	if isSagaDeclaredConstRef(info, expr) {
+		return ""
+	}
+	return typeName
+}
+
+// scanSagaEnumLabelCallsites flags any CallExpr argument whose go/types type is
+// a frozen executor label-enum AND is a compile-time constant that is not a
+// valid frozen executor declared-const reference.
+func scanSagaEnumLabelCallsites(p *Pass) []Diagnostic {
+	info := p.TypesInfo
+	if info == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if isSagaEnumConversion(info, call) {
+				return
+			}
+			for _, arg := range call.Args {
+				typeName := sagaEnumConstViolation(info, arg)
+				if typeName == "" {
+					continue
+				}
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(arg.Pos()).Line,
+					Message: "inline constant of saga label enum " + typeName +
+						" reaches a metric label — pass a declared executor." + typeName +
+						" const (or a classify() result), not a string literal or " +
+						typeName + "(...) conversion (SAGA-METRIC-LABEL-VALUES-FROZEN-01 callsite guard)",
+				})
+			}
+		})
+	}
+	return diags
+}
+
+// scanSagaEnumLabelAssignments flags variable declarations/assignments whose
+// LHS has a frozen executor label-enum type and RHS is an inline constant.
+func scanSagaEnumLabelAssignments(p *Pass) []Diagnostic { //nolint:gocognit,cyclop,lll // archtest: handles AssignStmt/ValueSpec/ReturnStmt for four executor enum types; inherent to SAGA-METRIC-LABEL-VALUES-FROZEN-01 A2
+	info := p.TypesInfo
+	if info == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		if strings.HasSuffix(p.Rel(file), "_test.go") {
+			continue
+		}
+		rel := p.Rel(file)
+		EachInSubtree[ast.GenDecl](file, func(gd *ast.GenDecl) {
+			if gd.Tok != token.VAR {
+				return
+			}
+			EachInChildren[ast.ValueSpec](gd, func(vs *ast.ValueSpec) {
+				for i, val := range vs.Values {
+					if i >= len(vs.Names) {
+						continue
+					}
+					lhsTV, ok := info.Types[vs.Names[i]]
+					if !ok {
+						if vs.Type == nil {
+							continue
+						}
+						lhsTV, ok = info.Types[vs.Type]
+						if !ok {
+							continue
+						}
+					}
+					if sagaEnumTypeName(lhsTV.Type) == "" {
+						continue
+					}
+					typeName := sagaEnumConstViolation(info, val)
+					if typeName == "" {
+						continue
+					}
+					diags = append(diags, Diagnostic{
+						Rel:  rel,
+						Line: p.Fset.Position(val.Pos()).Line,
+						Message: "variable of saga label enum " + typeName +
+							" initialized from an inline constant — use a declared executor." +
+							typeName + " const or a classify() result to avoid laundering " +
+							"an arbitrary value into the frozen set (SAGA-METRIC-LABEL-VALUES-FROZEN-01 assignment guard)",
+					})
+				}
+			})
+		})
+		EachInSubtree[ast.AssignStmt](file, func(as *ast.AssignStmt) {
+			for i, rhs := range as.Rhs {
+				if i >= len(as.Lhs) {
+					continue
+				}
+				lhsTV, ok := info.Types[as.Lhs[i]]
+				if !ok {
+					continue
+				}
+				if sagaEnumTypeName(lhsTV.Type) == "" {
+					continue
+				}
+				typeName := sagaEnumConstViolation(info, rhs)
+				if typeName == "" {
+					continue
+				}
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: p.Fset.Position(rhs.Pos()).Line,
+					Message: "variable of saga label enum " + typeName +
+						" assigned from an inline constant — use a declared executor." +
+						typeName + " const or a classify() result to avoid laundering " +
+						"an arbitrary value into the frozen set (SAGA-METRIC-LABEL-VALUES-FROZEN-01 assignment guard)",
+				})
+			}
+		})
+	}
+	return diags
+}
+
+// scanSagaEnumLabelAll runs both callsite and assignment guards on one Pass.
+func scanSagaEnumLabelAll(p *Pass) []Diagnostic {
+	return append(scanSagaEnumLabelCallsites(p), scanSagaEnumLabelAssignments(p)...)
+}
+
+// CheckSagaMetricLabelValuesFrozen is the importable form of
+// SAGA-METRIC-LABEL-VALUES-FROZEN-01.
+// Not registered in StandardCellRules.
+func CheckSagaMetricLabelValuesFrozen(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	_ = cfg
+	var all []Diagnostic
+	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		all = append(all, scanSagaEnumLabelAll(p)...)
+		return nil
+	})
+	return all
+}

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -48,7 +48,6 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -57,10 +56,8 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/saga"
 	"github.com/ghbvf/gocell/kernel/saga/journal"
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 	"github.com/ghbvf/gocell/tools/codegen/sagacoveragegen"
 	"github.com/ghbvf/gocell/tools/internal/prodscan"
-	"github.com/ghbvf/gocell/tools/typesutil"
 )
 
 // ============================================================================
@@ -149,329 +146,13 @@ import (
 // ref: tools/archtest/aftercommit_pure_transient_test.go (sibling purity pattern).
 // ref: .claude/rules/gocell/ai-robust.md §"typed marker funnel for unbounded ops".
 
-const (
-	sagaCompensatePureRuleID      = "SAGA-STEP-COMPENSATE-PURE-01"
-	sagaPkgPath                   = "github.com/ghbvf/gocell/kernel/saga"
-	sagaCompensateFuncName        = "CompensateFunc"
-	sagaCompensateFieldName       = "Compensate"
-	sagaFixturesDir               = "saga_compensate_pure_fixtures"
-	sagaMaxCompensateStmts        = 10
-	sagaConstructorNilGuardRuleID = "SAGA-CONSTRUCTOR-NIL-GUARD-01"
-	sagaConstructorFixturesDir    = "saga_constructor_nilguard_fixtures"
-)
-
-// sagaBannedReceiverKeys maps "<pkgpath>.<TypeName>" → display label for
-// concrete banned types (matched after one pointer deref for *sql.Tx).
-var sagaBannedReceiverKeys = map[string]string{
-	"database/sql.Tx":                               "*sql.Tx",
-	"github.com/jackc/pgx/v5.Tx":                    "pgx.Tx",
-	"github.com/ghbvf/gocell/kernel/outbox.Writer":  "outbox.Writer",
-	"github.com/ghbvf/gocell/kernel/outbox.Emitter": "outbox.Emitter",
-}
-
-// sagaBannedIfaceSpecs lists the (pkgPath, typeName, label) tuples for
-// interface types that CompensateFunc bodies must not call methods on.
-var sagaBannedIfaceSpecs = []struct{ path, name, label string }{
-	{"github.com/jackc/pgx/v5", "Tx", "pgx.Tx"},
-	{"github.com/ghbvf/gocell/kernel/outbox", "Writer", "outbox.Writer"},
-	{"github.com/ghbvf/gocell/kernel/outbox", "Emitter", "outbox.Emitter"},
-	{"github.com/ghbvf/gocell/kernel/persistence", "TxRunner", "persistence.TxRunner"},
-}
-
-// sagaResolveBannedReceivers resolves the banned interface receiver types from
-// pkg's transitive import closure, once per Pass.
-func sagaResolveBannedReceivers(pkg *types.Package) []bannedReceiver {
-	var out []bannedReceiver
-	for _, b := range sagaBannedIfaceSpecs {
-		if iface := lookupInterface(pkg, b.path, b.name); iface != nil {
-			out = append(out, bannedReceiver{label: b.label, iface: iface})
-		}
-	}
-	return out
-}
-
-// sagaBannedReceiverLabel reports the display label when sel.X's static type
-// is a banned receiver. It checks:
-//  1. Exact concrete match (deref one pointer level for *sql.Tx).
-//  2. Implements a banned interface (types.Implements).
-func sagaBannedReceiverLabel(info *types.Info, sel *ast.SelectorExpr, ifaces []bannedReceiver) (string, bool) {
-	t := info.TypeOf(sel.X)
-	if t == nil {
-		return "", false
-	}
-	// 1. Exact concrete match (deref one pointer level for *sql.Tx / *pgx.Tx).
-	nt := t
-	if ptr, isPtr := nt.(*types.Pointer); isPtr {
-		nt = ptr.Elem()
-	}
-	if named, isNamed := nt.(*types.Named); isNamed && named.Obj() != nil && named.Obj().Pkg() != nil {
-		key := named.Obj().Pkg().Path() + "." + named.Obj().Name()
-		if label, ok := sagaBannedReceiverKeys[key]; ok {
-			return label, true
-		}
-	}
-	// 2. Implements a banned interface (value or pointer receiver).
-	for _, b := range ifaces {
-		if implementsBannedIface(t, b.iface) {
-			return b.label, true
-		}
-	}
-	return "", false
-}
-
-// isCompensateFuncType reports whether typ is exactly kernel/saga.CompensateFunc.
-func isCompensateFuncType(typ types.Type) bool {
-	named, ok := typ.(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj != nil && obj.Pkg() != nil &&
-		obj.Pkg().Path() == sagaPkgPath &&
-		obj.Name() == sagaCompensateFuncName
-}
-
-// compensateFuncAssignment holds a scanned assignment: either a func literal
-// body (for direct scan) or an ident reference to a named function (for
-// declared-func scan). Exactly one of Lit / NamedIdent is non-nil.
-type compensateFuncAssignment struct {
-	Lit        *ast.FuncLit
-	NamedIdent *ast.Ident
-}
-
-// collectCompensateAssignments walks the AST of file and returns every
-// assignment to a kernel/saga.CompensateFunc-typed slot, covering:
-//
-//  1. var c saga.CompensateFunc = <expr>    (ValueSpec)
-//  2. c = <expr> where c is CompensateFunc (AssignStmt)
-//  3. saga.Step{Compensate: <expr>}         (CompositeLit KV)
-//
-// <expr> is either a FuncLit (returned in Lit) or an Ident referencing a
-// named function (returned in NamedIdent).
-func collectCompensateAssignments(p *Pass, file *ast.File) []compensateFuncAssignment {
-	info := p.TypesInfo
-	var out []compensateFuncAssignment
-
-	// var c saga.CompensateFunc = <expr>
-	scanner.EachInSubtree[ast.ValueSpec](file, func(node *ast.ValueSpec) {
-		typ := info.TypeOf(node.Type)
-		if typ == nil || !isCompensateFuncType(typ) {
-			return
-		}
-		for _, val := range node.Values {
-			out = append(out, classifyExpr(val))
-		}
-	})
-
-	// c = <expr> where c is CompensateFunc
-	scanner.EachInSubtree[ast.AssignStmt](file, func(node *ast.AssignStmt) {
-		for i, lhs := range node.Lhs {
-			if i >= len(node.Rhs) {
-				break
-			}
-			lhsType := info.TypeOf(lhs)
-			if lhsType == nil || !isCompensateFuncType(lhsType) {
-				continue
-			}
-			out = append(out, classifyExpr(node.Rhs[i]))
-		}
-	})
-
-	// saga.Step{Compensate: <expr>}
-	scanner.EachInSubtree[ast.CompositeLit](file, func(node *ast.CompositeLit) {
-		scanner.EachInChildren[ast.KeyValueExpr](node, func(kv *ast.KeyValueExpr) {
-			key, ok := kv.Key.(*ast.Ident)
-			if !ok || key.Name != sagaCompensateFieldName {
-				return
-			}
-			// Verify the field's declared type is CompensateFunc via struct
-			// field lookup (TypeOf on a CompositeLit KV value may return the
-			// underlying func signature, not the named alias).
-			if !compensateKVFieldIsCompensateFunc(info, node) {
-				return
-			}
-			out = append(out, classifyExpr(kv.Value))
-		})
-	})
-
-	return out
-}
-
-// compensateKVFieldIsCompensateFunc verifies that the struct type of the
-// CompositeLit node has a field named sagaCompensateFieldName whose declared
-// type is kernel/saga.CompensateFunc. This is the reliable path for CompositeLit
-// KV values where TypeOf(kv.Value) may return the underlying func signature.
-func compensateKVFieldIsCompensateFunc(info *types.Info, node *ast.CompositeLit) bool {
-	structType := info.TypeOf(node)
-	if structType == nil {
-		return false
-	}
-	st := structType
-	if ptr, ok := st.(*types.Pointer); ok {
-		st = ptr.Elem()
-	}
-	var underlying types.Type
-	if named, ok := st.(*types.Named); ok {
-		underlying = named.Underlying()
-	} else {
-		underlying = st.Underlying()
-	}
-	s, ok := underlying.(*types.Struct)
-	if !ok {
-		return false
-	}
-	for fi := 0; fi < s.NumFields(); fi++ {
-		f := s.Field(fi)
-		if f.Name() == sagaCompensateFieldName && isCompensateFuncType(f.Type()) {
-			return true
-		}
-	}
-	return false
-}
-
-// classifyExpr returns a compensateFuncAssignment for expr: either a FuncLit
-// or a named-function Ident.
-func classifyExpr(expr ast.Expr) compensateFuncAssignment {
-	switch e := expr.(type) {
-	case *ast.FuncLit:
-		return compensateFuncAssignment{Lit: e}
-	case *ast.Ident:
-		return compensateFuncAssignment{NamedIdent: e}
-	}
-	return compensateFuncAssignment{}
-}
-
-// sagaFuncDeclsByObject collects all top-level FuncDecls in the Pass (across
-// all files) keyed by the types.Func pointer (via info.ObjectOf). This is
-// used to resolve named CompensateFunc assignments to their declaration bodies.
-func sagaFuncDeclsByObject(p *Pass) map[*types.Func]*ast.FuncDecl {
-	out := make(map[*types.Func]*ast.FuncDecl)
-	for _, f := range p.Files {
-		EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
-			if fd.Body == nil {
-				return
-			}
-			obj, ok := p.TypesInfo.Defs[fd.Name].(*types.Func)
-			if !ok {
-				return
-			}
-			out[obj] = fd
-		})
-	}
-	return out
-}
-
-// countStmts counts the top-level statements in a BlockStmt.
-func countStmts(body *ast.BlockStmt) int {
-	if body == nil {
-		return 0
-	}
-	return len(body.List)
-}
-
-func sagaDiag(p *Pass, node ast.Node, rel, msg string) Diagnostic {
-	return Diagnostic{Rel: rel, Line: p.Fset.Position(node.Pos()).Line, Message: msg}
-}
-
-// scanBodyForForbiddenCalls scans a BlockStmt for calls to banned receivers
-// and returns diagnostics.
-func scanBodyForForbiddenCalls(p *Pass, body *ast.BlockStmt, rel string, ifaces []bannedReceiver) []Diagnostic {
-	info := p.TypesInfo
-	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
-		sel, isSel := call.Fun.(*ast.SelectorExpr)
-		if !isSel {
-			return
-		}
-		if label, banned := sagaBannedReceiverLabel(info, sel, ifaces); banned {
-			out = append(out, sagaDiag(p, sel, rel,
-				sagaCompensatePureRuleID+"-A1: CompensateFunc body must be pure-reverse; "+
-					"it calls a method on "+label+
-					" (Compensate runs in app domain only — the Coordinator owns the tx layer)"))
-		}
-	})
-	return out
-}
-
-// scanCompensatePure implements A1 over one file: collect every CompensateFunc
-// assignment (literal or named func) and check the body for forbidden calls.
-func scanCompensatePure(p *Pass, file *ast.File, ifaces []bannedReceiver, funcDecls map[*types.Func]*ast.FuncDecl) []Diagnostic {
-	rel := p.Rel(file)
-	var out []Diagnostic
-
-	assignments := collectCompensateAssignments(p, file)
-	for _, a := range assignments {
-		switch {
-		case a.Lit != nil:
-			// Direct function literal: scan its body.
-			out = append(out, scanBodyForForbiddenCalls(p, a.Lit.Body, rel, ifaces)...)
-
-		case a.NamedIdent != nil:
-			// Named function: resolve to FuncDecl and scan its body.
-			obj, ok := p.TypesInfo.ObjectOf(a.NamedIdent).(*types.Func)
-			if !ok {
-				continue
-			}
-			fd, ok := funcDecls[obj]
-			if !ok {
-				continue
-			}
-			out = append(out, scanBodyForForbiddenCalls(p, fd.Body, rel, ifaces)...)
-		}
-	}
-	return out
-}
-
-// scanCompensateBodyCount implements B1 over one file: every CompensateFunc
-// literal must have <= sagaMaxCompensateStmts top-level statements.
-func scanCompensateBodyCount(p *Pass, file *ast.File) []Diagnostic {
-	rel := p.Rel(file)
-	var out []Diagnostic
-
-	assignments := collectCompensateAssignments(p, file)
-	for _, a := range assignments {
-		if a.Lit == nil {
-			continue // only applies to inline literals
-		}
-		n := countStmts(a.Lit.Body)
-		if n > sagaMaxCompensateStmts {
-			out = append(out, sagaDiag(p, a.Lit, rel,
-				sagaCompensatePureRuleID+"-B1: CompensateFunc body has too many statements ("+
-					itoa(n)+">"+itoa(sagaMaxCompensateStmts)+"); "+
-					"pure-reverse compensates must be short — extract logic to a named helper "+
-					"and call it from Compensate (B1 blind-spot discipline)"))
-		}
-	}
-	return out
-}
-
-func sagaCompensateFixturePattern(fix string) (dir, pattern string) {
-	return filepath.Join("tools", "archtest", "testdata", sagaFixturesDir, fix),
-		"./tools/archtest/testdata/" + sagaFixturesDir + "/" + fix
-}
-
 // TestSagaStepCompensatePure_A1_NoForbiddenCallsInCompensateBody asserts no
 // production CompensateFunc slot (literal or named func) calls a banned receiver
 // method. In PR-06 there are zero CompensateFunc assignments in production, so
 // this fires 0 diagnostics; it guards future Compensate authors.
 func TestSagaStepCompensatePure_A1_NoForbiddenCallsInCompensateBody(t *testing.T) {
 	t.Parallel()
-	diags := Run(t, Production(TypedOpts{Tags: FlatNonDefaultTags()}), func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		ifaces := sagaResolveBannedReceivers(p.Pkg)
-		funcDecls := sagaFuncDeclsByObject(p)
-		var out []Diagnostic
-		for _, file := range p.Files {
-			if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
-				continue
-			}
-			out = append(out, scanCompensatePure(p, file, ifaces, funcDecls)...)
-		}
-		return out
-	})
-
+	diags := CheckSagaStepCompensatePure(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, sagaCompensatePureRuleID+"-A1", diags)
 }
 
@@ -795,12 +476,6 @@ func TestSagaStepCompensatePure_Detector_RedAssignFuncLitFixture(t *testing.T) {
 // §"Funnel 双向锁评级", the Hard interface-field seal needs no gh-tracked upgrade;
 // the Medium func-field + downstream residuals are deliberate, not Soft carryovers.
 
-// sagaCoordinatorNoHeartbeatLoopRule is the rule ID for diagnostics.
-const sagaCoordinatorNoHeartbeatLoopRule = "SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01"
-
-// heartbeatMethodName is the forbidden method name on journal.Journal.
-const heartbeatMethodName = "Heartbeat"
-
 // TestSagaCoordinatorNoHeartbeatLoop_A1_NoJournalHeartbeatCallInRuntimeSaga
 // fails if any production (non-test) file under runtime/saga/ — excluding
 // the runtime/saga/executor/ subpackage — references a Heartbeat method
@@ -826,165 +501,8 @@ const heartbeatMethodName = "Heartbeat"
 // via Ident, bypassing a SelectorExpr-only check.
 func TestSagaCoordinatorNoHeartbeatLoop_A1_NoJournalHeartbeatCallInRuntimeSaga(t *testing.T) {
 	t.Parallel()
-
-	diags := Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		var out []Diagnostic
-		for _, file := range p.Files {
-			rel := filepath.ToSlash(p.Rel(file))
-			if strings.HasSuffix(rel, "_test.go") {
-				continue
-			}
-
-			if !strings.HasPrefix(rel, "runtime/saga/") {
-				continue
-			}
-			if strings.HasPrefix(rel, "runtime/saga/executor/") {
-				continue
-			}
-
-			out = append(out, scanHeartbeatSelectors(p, file, rel)...)
-		}
-		return out
-	})
-
+	diags := CheckSagaCoordinatorNoHeartbeatLoop(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, sagaCoordinatorNoHeartbeatLoopRule+"-A1", diags)
-}
-
-// scanHeartbeatSelectors walks every SelectorExpr whose Sel.Name == "Heartbeat"
-// (both inside CallExpr and as a method value) and emits a diagnostic when the
-// receiver implements the Heartbeater-shape signature.
-func scanHeartbeatSelectors(p *Pass, file *ast.File, rel string) []Diagnostic {
-	var out []Diagnostic
-	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
-		if sel.Sel == nil || sel.Sel.Name != heartbeatMethodName {
-			return
-		}
-		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
-		if !ok || fn == nil {
-			return
-		}
-		if !methodIsHeartbeaterShape(fn) {
-			return
-		}
-		pos := p.Fset.Position(sel.Pos())
-		out = append(out, Diagnostic{
-			Rel:  rel,
-			Line: pos.Line,
-			Message: fmt.Sprintf(
-				"%s: forbidden reference to a Heartbeater-shape .Heartbeat method in runtime/saga; "+
-					"per-step lease maintenance is funneled through runtime/saga/executor "+
-					"(Executor.Execute / Executor.RunWithHeartbeat). If you need a "+
-					"non-step heartbeat (e.g. extending lease across an outer operation), "+
-					"call Executor.RunWithHeartbeat — do NOT re-introduce a centralized "+
-					"heartbeat goroutine.",
-				sagaCoordinatorNoHeartbeatLoopRule,
-			),
-		})
-	})
-	return out
-}
-
-// methodIsHeartbeaterShape reports whether fn (a method func object) has the
-// signature `Heartbeat(ctx context.Context, instanceID, leaseID idutil.SafeID,
-// leaseDuration time.Duration) (bool, error)`. The shape check is structural
-// — it does not require the receiver to be kernel/saga/journal.Journal so
-// new interfaces / local helpers that duplicate the shape are also caught
-// (#1181 F13).
-//
-// Shape constants:
-//
-//	params: 4 ⇒ context.Context, idutil.SafeID, idutil.SafeID, time.Duration
-//	results: 2 ⇒ bool, error
-//
-// Receiver type is not inspected; only the parameter and result types matter.
-func methodIsHeartbeaterShape(fn *types.Func) bool {
-	if fn == nil {
-		return false
-	}
-	sig, ok := fn.Type().(*types.Signature)
-	if !ok || sig.Recv() == nil {
-		return false // nil signature, or not a method
-	}
-	return signatureMatchesHeartbeaterShape(sig)
-}
-
-// signatureMatchesHeartbeaterShape reports whether sig has the parameter and
-// result types of journal.Heartbeater.Heartbeat, independent of whether sig is
-// a method (has a receiver) or a bare func type:
-//
-//	(ctx context.Context, instanceID, leaseID idutil.SafeID, leaseDuration time.Duration) (bool, error)
-//
-// It backs two scans in this package: the .Heartbeat method-call scan
-// (SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 A1, via methodIsHeartbeaterShape) and
-// the heartbeat-shaped func-FIELD scan (SAGA-JOURNAL-HOLDER-SEAL-01, where a
-// persisted func value of this shape is the func-value equivalent of holding a
-// journal.Heartbeater field).
-func signatureMatchesHeartbeaterShape(sig *types.Signature) bool {
-	if sig == nil {
-		return false
-	}
-	params := sig.Params()
-	if params.Len() != 4 {
-		return false
-	}
-	results := sig.Results()
-	if results.Len() != 2 {
-		return false
-	}
-	if !typeIsNamed(params.At(0).Type(), "context", "Context") {
-		return false
-	}
-	if !typeIsNamed(params.At(1).Type(), heartbeaterIdutilPkgName, heartbeaterSafeIDType) {
-		return false
-	}
-	if !typeIsNamed(params.At(2).Type(), heartbeaterIdutilPkgName, heartbeaterSafeIDType) {
-		return false
-	}
-	if !typeIsNamed(params.At(3).Type(), "time", "Duration") {
-		return false
-	}
-	if b, ok := results.At(0).Type().(*types.Basic); !ok || b.Kind() != types.Bool {
-		return false
-	}
-	if named, ok := results.At(1).Type().(*types.Named); !ok ||
-		named.Obj() == nil || named.Obj().Name() != "error" {
-		return false
-	}
-	return true
-}
-
-// heartbeaterIdutilPkgName / heartbeaterSafeIDType carry the package-suffix
-// and type-name used by Heartbeater-shape param-1 + param-2
-// (instanceID, leaseID idutil.SafeID). Names are package-prefixed to avoid
-// colliding with safeid_funnel_test.go's constants of the same intent.
-const (
-	heartbeaterIdutilPkgName = "idutil"
-	heartbeaterSafeIDType    = "SafeID"
-)
-
-// typeIsNamed reports whether t resolves to a named type whose enclosing
-// package's import-path *suffix* equals pkgSuffix and whose declared name
-// equals typeName. Suffix matching is used because callers refer to
-// idutil.SafeID via the local name even when the package is at a long path.
-func typeIsNamed(t types.Type, pkgSuffix, typeName string) bool {
-	named, ok := t.(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	if obj == nil || obj.Name() != typeName {
-		return false
-	}
-	pkg := obj.Pkg()
-	if pkg == nil {
-		// "error" lives in the universe scope (Pkg == nil); caller handles
-		// that case directly without typeIsNamed.
-		return false
-	}
-	return pkg.Path() == pkgSuffix || strings.HasSuffix(pkg.Path(), "/"+pkgSuffix)
 }
 
 // TestSagaCoordinatorNoHeartbeatLoop_B1_ExecutorSubpkgCallsitesAllowed is the
@@ -1151,112 +669,6 @@ func TestSagaCoordinatorNoHeartbeatLoop_B1_ExecutorSubpkgCallsitesAllowed(t *tes
 //
 // ref: .claude/rules/gocell/ai-robust.md §"typed marker funnel for unbounded ops".
 
-const (
-	sagaRandInjectedRuleID = "SAGA-EXECUTOR-RAND-INJECTED-01"
-	// executorPkgPrefix is the module-relative path prefix for the
-	// runtime/saga/executor package (production .go files, not _test.go).
-	executorPkgPrefix = "runtime/saga/executor/"
-)
-
-// randV1PkgPath and randV2PkgPath are the canonical import paths for the two
-// math/rand package versions. Both are checked so v1 usage is also caught.
-const (
-	randV1PkgPath = "math/rand"
-	randV2PkgPath = "math/rand/v2"
-)
-
-// randAllowedConstructors is the set of function names that ARE permitted as
-// package-level calls (they construct a source, not use the global source).
-// Keyed by (pkgPath, funcName).
-var randAllowedConstructors = map[string]bool{
-	randV2PkgPath + ".New":        true,
-	randV2PkgPath + ".NewPCG":     true,
-	randV2PkgPath + ".NewChaCha8": true,
-	randV1PkgPath + ".New":        true,
-	randV1PkgPath + ".NewSource":  true,
-}
-
-// isRandGlobalForbidden reports whether fn is a package-level function in
-// math/rand or math/rand/v2 that is NOT in the allowed constructor set.
-func isRandGlobalForbidden(fn *types.Func) bool {
-	if fn == nil || fn.Pkg() == nil {
-		return false
-	}
-	pkgPath := fn.Pkg().Path()
-	if pkgPath != randV1PkgPath && pkgPath != randV2PkgPath {
-		return false
-	}
-	// Must be a package-level function (nil receiver), not a method.
-	if sig, _ := fn.Type().(*types.Signature); sig != nil && sig.Recv() != nil {
-		return false
-	}
-	key := pkgPath + "." + fn.Name()
-	return !randAllowedConstructors[key]
-}
-
-// scanRandGlobalCalls walks file's AST and returns diagnostics for every
-// call to a forbidden package-level global rand function. Detection is
-// type-driven via info.ObjectOf — covers both qualified form (rand.Int64N)
-// and dot-import form (Int64N after `import . "math/rand/v2"`).
-func scanRandGlobalCalls(p *Pass, file *ast.File) []Diagnostic {
-	rel := p.Rel(file)
-	info := p.TypesInfo
-	var out []Diagnostic
-	seen := map[string]bool{}
-
-	record := func(node ast.Node, fnName, pkgPath string) {
-		line := p.Fset.Position(node.Pos()).Line
-		key := fmt.Sprintf("%s:%d:%s.%s", rel, line, pkgPath, fnName)
-		if seen[key] {
-			return
-		}
-		seen[key] = true
-		out = append(out, Diagnostic{
-			Rel:  rel,
-			Line: line,
-			Message: fmt.Sprintf(
-				sagaRandInjectedRuleID+": %s.%s — "+
-					"must use an injected *rand.Rand source (rand.New(rand.NewPCG(...))) "+
-					"instead of the package-level global; "+
-					"global rand is not injectable and makes jitter non-deterministic in tests",
-				pkgPath, fnName,
-			),
-		})
-	}
-
-	// Qualified form: rand.Int64N(...)
-	EachInSubtree[ast.SelectorExpr](file, func(e *ast.SelectorExpr) {
-		fn, ok := info.ObjectOf(e.Sel).(*types.Func)
-		if !ok || !isRandGlobalForbidden(fn) {
-			return
-		}
-		record(e, fn.Name(), fn.Pkg().Path())
-	})
-
-	// Dot-import form: Int64N(...) — bare Ident, no SelectorExpr.
-	EachInSubtree[ast.Ident](file, func(e *ast.Ident) {
-		fn, ok := info.ObjectOf(e).(*types.Func)
-		if !ok || !isRandGlobalForbidden(fn) {
-			return
-		}
-		record(e, fn.Name(), fn.Pkg().Path())
-	})
-
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Rel != out[j].Rel {
-			return out[i].Rel < out[j].Rel
-		}
-		return out[i].Line < out[j].Line
-	})
-	return out
-}
-
-// isExecutorProductionFile reports whether rel is a production .go file
-// under runtime/saga/executor/ (not _test.go).
-func isExecutorProductionFile(rel string) bool {
-	return strings.HasPrefix(rel, executorPkgPrefix) && !strings.HasSuffix(rel, "_test.go")
-}
-
 // sagaExecutorRandFixturePattern returns the (relDir, pattern) pair for the
 // given fixture case under saga_executor_rand_injected_fixtures.
 func sagaExecutorRandFixturePattern(fix string) (dir, pattern string) {
@@ -1276,21 +688,7 @@ func sagaExecutorRandFixturePattern(fix string) (dir, pattern string) {
 //   - B2: dot-import — handled via ast.Ident walk (reverse self-test below).
 func TestSagaExecutorRandInjected_A1_NoGlobalRandInExecutor(t *testing.T) {
 	t.Parallel()
-	diags := Run(t, Production(TypedOpts{Tags: FlatNonDefaultTags()}), func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		var out []Diagnostic
-		for _, file := range p.Files {
-			rel := filepath.ToSlash(p.Rel(file))
-			if !isExecutorProductionFile(rel) {
-				continue
-			}
-			out = append(out, scanRandGlobalCalls(p, file)...)
-		}
-		return out
-	})
-
+	diags := CheckSagaExecutorRandInjected(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, sagaRandInjectedRuleID+"-A1", diags)
 }
 
@@ -1439,13 +837,6 @@ func TestSagaExecutorRandInjected_Detector_RedDotImportRandFixture(t *testing.T)
 // ref: tools/archtest/user_repo_conformance_enrollment_test.go (USERREPO-CONFORMANCE-ENROLLMENT-01)
 // ref: docs/plans/202605230231-046-saga-l3-workflow-implementation-plan.md §PR-04
 
-const (
-	sagaJournalIfacePkg     = "github.com/ghbvf/gocell/kernel/saga/journal"
-	sagaJournalIfaceName    = "Journal"
-	sagaConformancePkg      = "github.com/ghbvf/gocell/kernel/saga/sagajournaltest"
-	sagaConformanceFuncName = "RunConformanceSuite"
-)
-
 // TestSagaJournalConformanceEnrollment enforces SAGA-JOURNAL-CONFORMANCE-
 // ENROLLMENT-01: every concrete type implementing kernel/saga/journal.Journal
 // in the production tree must have a sagajournaltest.RunConformanceSuite call
@@ -1453,110 +844,7 @@ const (
 // variant).
 func TestSagaJournalConformanceEnrollment(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based archtest in -short mode")
-	}
-
-	root := findModuleRoot(t)
-
-	// ─── Step 1: resolve journal.Journal interface ──────────────────────────
-	//
-	// The iface and the impl types MUST come from the same packages.Load
-	// invocation so that types.Implements uses pointer-identical *types.Named
-	// descriptors (cross-load comparisons are always false).
-	prodPatterns := prodscan.Patterns(root)
-	ifacePatterns := append([]string{"./kernel/saga/journal/..."}, prodPatterns...)
-
-	var iface *types.Interface
-	var implPkgs []*types.Package
-
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			if p.Pkg.Path() == sagaJournalIfacePkg {
-				if obj := p.Pkg.Scope().Lookup(sagaJournalIfaceName); obj != nil {
-					if named, ok := obj.Type().(*types.Named); ok {
-						if i, ok := named.Underlying().(*types.Interface); ok {
-							iface = i.Complete()
-						}
-					}
-				}
-			}
-			implPkgs = append(implPkgs, p.Pkg)
-			return nil
-		})
-
-	require.NotNil(t, iface,
-		"SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01: failed to resolve journal.Journal interface; "+
-			"check import path %s", sagaJournalIfacePkg)
-
-	// ─── Step 2: collect all concrete implementations ───────────────────────
-	implSet := make(map[string]bool)    // "pkg/path.TypeName" → true
-	implPkgSet := make(map[string]bool) // pkg path → true
-	for _, pkg := range implPkgs {
-		if pkg == nil {
-			continue
-		}
-		collectSagaJournalImpls(pkg, iface, implSet, implPkgSet)
-	}
-
-	require.NotEmpty(t, implSet,
-		"SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01: zero Journal implementations collected — "+
-			"likely a type-universe regression (iface and impls must share one packages.Load). "+
-			"Expect at least journal.MemJournal and saga.PGJournal.")
-
-	// ─── Step 3: scan test corpus for RunConformanceSuite call sites with
-	// impl-level enrollment. A test file is credited with enrolling impl X
-	// only if (a) it contains a sagajournaltest.RunConformanceSuite call AND
-	// (b) it constructs X (constructor call whose return type unwraps to X).
-	// Package co-location is no longer enough — closes the gap where two
-	// impls in one package could share a single conformance call.
-	enrolledImpls := make(map[string]bool)
-
-	testPatterns := prodscan.Patterns(root)
-	_ = Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, testPatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			for _, f := range p.Files {
-				if !strings.HasSuffix(p.Rel(f), "_test.go") {
-					continue
-				}
-				creditEnrollmentsFromFactory(p.TypesInfo, p.Files, f,
-					sagaConformancePkg, sagaConformanceFuncName, implSet, enrolledImpls)
-			}
-			return nil
-		})
-
-	// ─── Step 4: flag unenrolled implementations ─────────────────────────────
-	var diags []Diagnostic
-	for implKey := range implSet {
-		if enrolledImpls[implKey] {
-			continue
-		}
-		dotIdx := strings.LastIndex(implKey, ".")
-		if dotIdx < 0 {
-			continue
-		}
-		pkgPath := implKey[:dotIdx]
-		diags = append(diags, Diagnostic{
-			Rel:  implKey,
-			Line: 0,
-			Message: fmt.Sprintf(
-				"archtest: kernel/saga/journal.Journal impl %q not enrolled "+
-					"(SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01). "+
-					"Add a _test.go in package %s (or its external _test) that "+
-					"both calls sagajournaltest.RunConformanceSuite(t, factory) "+
-					"AND constructs %s inside the factory closure (impl-level "+
-					"enrollment).",
-				implKey, pkgPath, implKey,
-			),
-		})
-	}
-	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	diags := CheckSagaJournalConformanceEnrollment(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, "SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01", diags)
 }
 
@@ -1655,7 +943,8 @@ func TestSagaJournalConformanceEnrollment_ReverseBlindSpot_NoReflectImpl(t *test
 			if strings.HasPrefix(rel, "kernel/saga/journal/") ||
 				strings.HasPrefix(rel, "kernel/saga/sagajournaltest/") ||
 				strings.HasPrefix(rel, "adapters/postgres/saga/") ||
-				strings.HasPrefix(rel, "runtime/saga/") {
+				strings.HasPrefix(rel, "runtime/saga/") ||
+				strings.HasPrefix(rel, "tools/archtest/") {
 				continue
 			}
 			EachInSubtree[ast.BasicLit](f, func(lit *ast.BasicLit) {
@@ -1745,11 +1034,6 @@ func TestSagaJournalConformanceEnrollment_ReverseBlindSpot_NoReflectImpl(t *test
 // ref: SAGA-JOURNAL-CONFORMANCE-ENROLLMENT-01 (sibling rule, same mechanism)
 // ref: docs/architecture/202606051200-1609-adr-saga-journal-projection-source.md §6
 
-const (
-	sagaGlobalReaderIfaceName       = "GlobalReader"
-	sagaGlobalReaderConformanceFunc = "RunGlobalReaderConformance"
-)
-
 // TestSagaGlobalReaderConformanceEnrollment enforces
 // SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01: every concrete type implementing
 // kernel/saga/journal.GlobalReader in the production tree must have a
@@ -1757,101 +1041,7 @@ const (
 // package that also constructs the impl.
 func TestSagaGlobalReaderConformanceEnrollment(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based archtest in -short mode")
-	}
-
-	root := findModuleRoot(t)
-
-	// ─── Step 1: resolve journal.GlobalReader interface ─────────────────────
-	prodPatterns := prodscan.Patterns(root)
-	ifacePatterns := append([]string{"./kernel/saga/journal/..."}, prodPatterns...)
-
-	var iface *types.Interface
-	var implPkgs []*types.Package
-
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			if p.Pkg.Path() == sagaJournalIfacePkg {
-				if obj := p.Pkg.Scope().Lookup(sagaGlobalReaderIfaceName); obj != nil {
-					if named, ok := obj.Type().(*types.Named); ok {
-						if i, ok := named.Underlying().(*types.Interface); ok {
-							iface = i.Complete()
-						}
-					}
-				}
-			}
-			implPkgs = append(implPkgs, p.Pkg)
-			return nil
-		})
-
-	require.NotNil(t, iface,
-		"SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01: failed to resolve journal.GlobalReader interface; "+
-			"check import path %s", sagaJournalIfacePkg)
-
-	// ─── Step 2: collect all concrete implementations ───────────────────────
-	implSet := make(map[string]bool)
-	implPkgSet := make(map[string]bool)
-	for _, pkg := range implPkgs {
-		if pkg == nil {
-			continue
-		}
-		collectSagaJournalImpls(pkg, iface, implSet, implPkgSet)
-	}
-
-	require.NotEmpty(t, implSet,
-		"SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01: zero GlobalReader implementations collected — "+
-			"likely a type-universe regression (iface and impls must share one packages.Load). "+
-			"Expect at least journal.MemJournal.")
-
-	// ─── Step 3: scan test corpus for RunGlobalReaderConformance call sites
-	// with impl-level enrollment (constructs the impl AND calls the suite). ──
-	enrolledImpls := make(map[string]bool)
-	testPatterns := prodscan.Patterns(root)
-	_ = Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, testPatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			for _, f := range p.Files {
-				if !strings.HasSuffix(p.Rel(f), "_test.go") {
-					continue
-				}
-				creditEnrollmentsFromFactory(p.TypesInfo, p.Files, f,
-					sagaConformancePkg, sagaGlobalReaderConformanceFunc, implSet, enrolledImpls)
-			}
-			return nil
-		})
-
-	// ─── Step 4: flag unenrolled implementations ────────────────────────────
-	var diags []Diagnostic
-	for implKey := range implSet {
-		if enrolledImpls[implKey] {
-			continue
-		}
-		dotIdx := strings.LastIndex(implKey, ".")
-		if dotIdx < 0 {
-			continue
-		}
-		pkgPath := implKey[:dotIdx]
-		diags = append(diags, Diagnostic{
-			Rel:  implKey,
-			Line: 0,
-			Message: fmt.Sprintf(
-				"archtest: kernel/saga/journal.GlobalReader impl %q not enrolled "+
-					"(SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01). "+
-					"Add a _test.go in package %s (or its external _test) that "+
-					"both calls sagajournaltest.RunGlobalReaderConformance(t, factory) "+
-					"AND constructs %s inside the factory closure (impl-level "+
-					"enrollment).",
-				implKey, pkgPath, implKey,
-			),
-		})
-	}
-	sort.Slice(diags, func(i, j int) bool { return diags[i].Rel < diags[j].Rel })
+	diags := CheckSagaGlobalReaderConformanceEnrollment(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, "SAGA-GLOBALREADER-CONFORMANCE-ENROLL-01", diags)
 }
 
@@ -1949,7 +1139,8 @@ func TestSagaGlobalReaderConformanceEnrollment_ReverseBlindSpot_NoReflectImpl(t 
 			if strings.HasPrefix(rel, "kernel/saga/journal/") ||
 				strings.HasPrefix(rel, "kernel/saga/sagajournaltest/") ||
 				strings.HasPrefix(rel, "adapters/postgres/saga/") ||
-				strings.HasPrefix(rel, "runtime/saga/") {
+				strings.HasPrefix(rel, "runtime/saga/") ||
+				strings.HasPrefix(rel, "tools/archtest/") {
 				continue
 			}
 			EachInSubtree[ast.BasicLit](f, func(lit *ast.BasicLit) {
@@ -1977,162 +1168,6 @@ func TestSagaGlobalReaderConformanceEnrollment_ReverseBlindSpot_NoReflectImpl(t 
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
-
-// collectSagaJournalImpls adds to implSet all concrete types in pkg (exported
-// AND unexported) that implement Journal (value or pointer receiver).
-// Interface types are skipped. Unexported impls must also enroll — a package-
-// private fake/wrapper that satisfies the interface still risks behavior
-// drift if not exercised by the conformance suite.
-func collectSagaJournalImpls(pkg *types.Package, iface *types.Interface, implSet, implPkgSet map[string]bool) {
-	for _, name := range pkg.Scope().Names() {
-		obj, ok := pkg.Scope().Lookup(name).(*types.TypeName)
-		if !ok {
-			continue
-		}
-		t := obj.Type()
-		if _, isIface := t.Underlying().(*types.Interface); isIface {
-			continue
-		}
-		if typesutil.ImplementsInterface(t, iface) {
-			key := pkg.Path() + "." + name
-			implSet[key] = true
-			implPkgSet[pkg.Path()] = true
-		}
-	}
-}
-
-// extractEnrolledImpls inspects a CallExpr's callee signature and returns
-// implKey strings ("pkg/path.TypeName") for every concrete Journal impl that
-// the call constructs (return values whose underlying named type is in
-// implSet). Pointer wrappers (*T) are unwrapped. Cross-package type identity
-// is irrelevant — we compare by string keys, so the iface-pass and test-pass
-// loads do not need to share *types.Named instances.
-//
-// This is the impl-level upgrade of the prior package-level enrollment: a
-// test file is now only credited with enrolling impl X if it actually
-// constructs X — package co-location is no longer enough.
-func extractEnrolledImpls(call *ast.CallExpr, info *types.Info, implSet map[string]bool) []string {
-	if info == nil {
-		return nil
-	}
-	calleeType := info.TypeOf(call.Fun)
-	if calleeType == nil {
-		return nil
-	}
-	sig, ok := calleeType.(*types.Signature)
-	if !ok {
-		return nil
-	}
-	var out []string
-	results := sig.Results()
-	for i := 0; i < results.Len(); i++ {
-		rt := results.At(i).Type()
-		if ptr, isPtr := rt.(*types.Pointer); isPtr {
-			rt = ptr.Elem()
-		}
-		named, ok := rt.(*types.Named)
-		if !ok {
-			continue
-		}
-		obj := named.Obj()
-		if obj == nil || obj.Pkg() == nil {
-			continue
-		}
-		key := obj.Pkg().Path() + "." + obj.Name()
-		if implSet[key] {
-			out = append(out, key)
-		}
-	}
-	return out
-}
-
-// creditEnrollmentsFromFactory walks file for calls to confPkg.confFunc(t, factory)
-// and credits ONLY the impls the FACTORY argument constructs (call.Args[1]),
-// binding enrollment to the factory actually passed rather than to any
-// constructor elsewhere in the file. Shared by the Journal and GlobalReader
-// enrollment rules (#1641 review F1 — closes the file-level false-credit gap
-// where an unrelated NewXxx() in a conformance-calling file falsely credited Xxx).
-func creditEnrollmentsFromFactory(
-	info *types.Info, files []*ast.File, file *ast.File,
-	confPkg, confFunc string, implSet, enrolled map[string]bool,
-) {
-	if info == nil {
-		return
-	}
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
-		if !ok || pkgPath != confPkg || name != confFunc {
-			return
-		}
-		for _, implKey := range factoryConstructedImpls(call, info, files, implSet) {
-			enrolled[implKey] = true
-		}
-	})
-}
-
-// factoryConstructedImpls returns the impl keys constructed inside the factory
-// argument (call.Args[1]) of a conformance call. Resolves three factory forms:
-// an inline FuncLit, a named-func Ident (its FuncDecl in the package), and a
-// local var bound to a FuncLit. Any other form resolves to no body and credits
-// nothing — fail-closed: an unrecognized factory shape flags its impl as
-// UNENROLLED (CI-visible) rather than silently crediting it.
-func factoryConstructedImpls(call *ast.CallExpr, info *types.Info, files []*ast.File, implSet map[string]bool) []string {
-	if len(call.Args) < 2 {
-		return nil
-	}
-	body := factoryBody(call.Args[1], info, files)
-	if body == nil {
-		return nil
-	}
-	var out []string
-	EachInSubtree[ast.CallExpr](body, func(c *ast.CallExpr) {
-		out = append(out, extractEnrolledImpls(c, info, implSet)...)
-	})
-	return out
-}
-
-// factoryBody resolves a conformance factory argument to the function body that
-// constructs the impl: a direct FuncLit, a named-func Ident (its FuncDecl), or a
-// local var Ident bound to a FuncLit (`factory := func(){…}`). Returns nil for
-// any other form.
-func factoryBody(arg ast.Expr, info *types.Info, files []*ast.File) *ast.BlockStmt {
-	switch a := arg.(type) {
-	case *ast.FuncLit:
-		return a.Body
-	case *ast.Ident:
-		obj := info.ObjectOf(a)
-		if obj == nil {
-			return nil
-		}
-		switch obj.(type) {
-		case *types.Func:
-			if fd := findFuncDeclFor(info, files, obj); fd != nil {
-				return fd.Body
-			}
-		case *types.Var:
-			if fl := findVarFuncLit(info, files, obj); fl != nil {
-				return fl.Body
-			}
-		}
-	}
-	return nil
-}
-
-// findFuncDeclFor finds the FuncDecl in files whose name identifier defines obj.
-func findFuncDeclFor(info *types.Info, files []*ast.File, obj types.Object) *ast.FuncDecl {
-	for _, f := range files {
-		for _, decl := range f.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Body == nil {
-				continue
-			}
-			if info.Defs[fd.Name] == obj {
-				return fd
-			}
-		}
-	}
-	return nil
-}
 
 // TestSagaEnrollment_FactoryBinding_RED is the reverse self-test for the
 // factory-bound enrollment credit (#1641 review F1). It type-checks a synthetic
@@ -2198,43 +1233,6 @@ func useUnrelated() { _ = NewImpl(); run(0, emptyFactory) }
 	// — this is the file-level false-credit gap the factory binding closes.
 	assert.Empty(t, got["useUnrelated"],
 		"unrelated NewImpl() outside the factory must not credit p.Impl (false-credit gap)")
-}
-
-// findVarFuncLit finds the FuncLit a local var (obj) is bound to via
-// `v := func(){…}` or `var v = func(){…}`.
-func findVarFuncLit(info *types.Info, files []*ast.File, obj types.Object) *ast.FuncLit {
-	for _, f := range files {
-		var found *ast.FuncLit
-		EachInSubtree[ast.AssignStmt](f, func(s *ast.AssignStmt) {
-			if found != nil || len(s.Lhs) != 1 || len(s.Rhs) != 1 {
-				return
-			}
-			if id, ok := s.Lhs[0].(*ast.Ident); ok && info.Defs[id] == obj {
-				if fl, ok := s.Rhs[0].(*ast.FuncLit); ok {
-					found = fl
-				}
-			}
-		})
-		if found != nil {
-			return found
-		}
-		EachInSubtree[ast.ValueSpec](f, func(s *ast.ValueSpec) {
-			if found != nil {
-				return
-			}
-			for i, name := range s.Names {
-				if info.Defs[name] == obj && i < len(s.Values) {
-					if fl, ok := s.Values[i].(*ast.FuncLit); ok {
-						found = fl
-					}
-				}
-			}
-		})
-		if found != nil {
-			return found
-		}
-	}
-	return nil
 }
 
 // ============================================================================
@@ -2329,178 +1327,6 @@ func findVarFuncLit(info *types.Info, files []*ast.File, obj types.Object) *ast.
 //     still resolves any field that actually uses such an alias). B1 only scans
 //     non-test files in runtime/saga; test files may alias freely.
 
-// journalInterfacePkgPath is the canonical import path of the package that
-// declares the Journal / JournalCore / Heartbeater interfaces. Hardcoded rather
-// than derived from go.mod because it is load-bearing: a rename of this package
-// path would be a contract break requiring a deliberate update here.
-const journalInterfacePkgPath = "github.com/ghbvf/gocell/kernel/saga/journal"
-
-// journalInterfaceTypeName / heartbeaterInterfaceTypeName name the two
-// Heartbeat-bearing interfaces that may not be persisted as a field anywhere in
-// runtime/saga production code (rule 1).
-const (
-	journalInterfaceTypeName     = "Journal"
-	heartbeaterInterfaceTypeName = "Heartbeater"
-)
-
-// journalCoreInterfaceTypeName names the Heartbeat-free core interface that only
-// the Coordinator may hold as a field (rule 2).
-const journalCoreInterfaceTypeName = "JournalCore"
-
-// allowedSagaJournalHolder is the single struct in runtime/saga permitted to
-// hold a journal.JournalCore field.
-const allowedSagaJournalHolder = "Coordinator"
-
-// sagaJournalHolderSealRule is the rule ID prefixed to every diagnostic message.
-const sagaJournalHolderSealRule = "SAGA-JOURNAL-HOLDER-SEAL-01"
-
-// journalFieldKind classifies a struct field's resolved type against the three
-// journal-package interfaces this seal cares about.
-type journalFieldKind int
-
-const (
-	journalFieldNone        journalFieldKind = iota // not a journal-package interface
-	journalFieldFull                                // journal.Journal (Heartbeat-bearing)
-	journalFieldHeartbeater                         // journal.Heartbeater (Heartbeat-bearing)
-	journalFieldCore                                // journal.JournalCore (Heartbeat-free)
-)
-
-// classifyJournalFieldType resolves the field expression via go/types and
-// classifies it. Returns journalFieldNone when TypesInfo is nil or the type is
-// not one of the three journal-package interfaces.
-func classifyJournalFieldType(info *types.Info, expr ast.Expr) journalFieldKind {
-	if info == nil {
-		return journalFieldNone
-	}
-	tv, ok := info.Types[expr]
-	if !ok {
-		return journalFieldNone
-	}
-	return classifyResolvedJournalType(tv.Type)
-}
-
-// classifyResolvedJournalType checks whether t (possibly wrapped in one pointer
-// or resolved through a type alias) is journal.Journal, journal.Heartbeater, or
-// journal.JournalCore.
-//
-// On Go 1.23+ (gotypesalias=1, the default — this module is on go 1.25), a type
-// alias materializes as *types.Alias, NOT transparently as the aliased
-// *types.Named. A bare t.(*types.Named) assertion therefore MISSES alias-typed
-// fields (a field of `type J = journal.JournalCore` resolves to *types.Alias and
-// the assertion fails). types.Unalias collapses an alias to its underlying type
-// so the Obj().Pkg().Path()/Name() check below is canonical regardless of how
-// many alias / pointer layers wrap the field type (go/types.Unalias expands a
-// type to the one it denotes after resolving package-level aliases).
-func classifyResolvedJournalType(t types.Type) journalFieldKind {
-	if t == nil {
-		return journalFieldNone
-	}
-	// Collapse a top-level alias (`type J = journal.JournalCore`) before the
-	// pointer probe, then again after unwrapping a pointer (`*J`, or
-	// `type J = *journal.JournalCore`), so every alias⇄pointer ordering resolves.
-	t = types.Unalias(t)
-	if ptr, ok := t.(*types.Pointer); ok {
-		t = types.Unalias(ptr.Elem())
-	}
-	named, ok := t.(*types.Named)
-	if !ok {
-		return journalFieldNone
-	}
-	obj := named.Obj()
-	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != journalInterfacePkgPath {
-		return journalFieldNone
-	}
-	switch obj.Name() {
-	case journalInterfaceTypeName:
-		return journalFieldFull
-	case heartbeaterInterfaceTypeName:
-		return journalFieldHeartbeater
-	case journalCoreInterfaceTypeName:
-		return journalFieldCore
-	}
-	return journalFieldNone
-}
-
-// journalFieldSealDiag applies the two seal rules to a single struct field and
-// returns a diagnostic when violated.
-func journalFieldSealDiag(p *Pass, rel, holderName string, field *ast.Field) (Diagnostic, bool) {
-	kind := classifyJournalFieldType(p.TypesInfo, field.Type)
-	if kind == journalFieldNone {
-		return Diagnostic{}, false
-	}
-	// Rule 2: JournalCore is allowed, but only on the Coordinator.
-	if kind == journalFieldCore && holderName == allowedSagaJournalHolder {
-		return Diagnostic{}, false
-	}
-	pos := p.Fset.Position(field.Pos())
-	return Diagnostic{Rel: rel, Line: pos.Line, Message: journalFieldSealMessage(kind, holderName)}, true
-}
-
-// journalFieldSealMessage renders the diagnostic text for a violating field.
-func journalFieldSealMessage(kind journalFieldKind, holderName string) string {
-	if kind == journalFieldCore {
-		return fmt.Sprintf(
-			"%s: struct %q holds a journal.JournalCore field; only %q may hold it",
-			sagaJournalHolderSealRule, holderName, allowedSagaJournalHolder,
-		)
-	}
-	// journalFieldFull / journalFieldHeartbeater — a Heartbeat-bearing field.
-	return fmt.Sprintf(
-		"%s: struct %q holds a Heartbeat-bearing journal interface field "+
-			"(journal.Journal or journal.Heartbeater); no struct in runtime/saga may "+
-			"persist a Heartbeat-capable field — hold journal.JournalCore instead. The "+
-			"full Journal exists transiently only as the NewCoordinator parameter handed "+
-			"to executor.NewExecutor (the sanctioned per-step heartbeat funnel).",
-		sagaJournalHolderSealRule, holderName,
-	)
-}
-
-// heartbeatFuncFieldDiag (rule 3) flags a struct field whose type is a func —
-// anonymous, named, aliased, or pointer-to-func — matching the Heartbeater
-// signature shape. Persisting such a callable is the func-value equivalent of
-// holding a journal.Heartbeater field: a centralized heartbeat loop can be
-// reconstructed from a heartbeat func passed into the constructor from OUTSIDE
-// runtime/saga, where the `.Heartbeat` selector is beyond
-// SAGA-COORDINATOR-NO-HEARTBEAT-LOOP-01 A1's scope. Closing the field-
-// persistence path here blocks the loop (a loop needs a persisted callable; a
-// bare constructor closure capturing the param is the irreducible residual, same
-// class as that archtest's NewCoordinator pass-through window). No struct in
-// runtime/saga — Coordinator included — may persist a heartbeat-shaped func.
-func heartbeatFuncFieldDiag(p *Pass, rel, holderName string, field *ast.Field) (Diagnostic, bool) {
-	if p.TypesInfo == nil {
-		return Diagnostic{}, false
-	}
-	tv, ok := p.TypesInfo.Types[field.Type]
-	if !ok {
-		return Diagnostic{}, false
-	}
-	// Collapse alias + one pointer level (mirrors classifyResolvedJournalType),
-	// then require the underlying type to be a func signature of the heartbeat
-	// shape. Interface fields (Underlying = *types.Interface) never match here —
-	// they are journal-package interfaces handled by classifyJournalFieldType.
-	t := types.Unalias(tv.Type)
-	if ptr, ok := t.(*types.Pointer); ok {
-		t = types.Unalias(ptr.Elem())
-	}
-	sig, ok := t.Underlying().(*types.Signature)
-	if !ok || !signatureMatchesHeartbeaterShape(sig) {
-		return Diagnostic{}, false
-	}
-	pos := p.Fset.Position(field.Pos())
-	return Diagnostic{
-		Rel:  rel,
-		Line: pos.Line,
-		Message: fmt.Sprintf(
-			"%s: struct %q holds a Heartbeater-shaped func field "+
-				"(func(context.Context, idutil.SafeID, idutil.SafeID, time.Duration) (bool, error)); "+
-				"no struct in runtime/saga may persist a Heartbeat-capable callable (interface OR func) "+
-				"— a persisted heartbeat func reconstructs the centralized-loop anti-pattern from a value "+
-				"passed in from outside runtime/saga. Funnel per-step heartbeat through executor.",
-			sagaJournalHolderSealRule, holderName,
-		),
-	}, true
-}
-
 // TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal scans runtime/saga
 // production source for struct fields whose resolved type is a journal-package
 // interface, applying both seal rules (see package godoc):
@@ -2550,56 +1376,11 @@ func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 	Report(t, sagaJournalHolderSealRule+"-A1", diags)
 }
 
-// journalPackageLocalNames returns the set of local identifiers in file bound
-// to the journal interface package (journalInterfacePkgPath): the default
-// package name for a plain import, plus any explicit import alias
-// (`import sagajournal "…/journal"`). Blank (`_`) and dot (`.`) imports are not
-// usable as a `pkg.Type` selector base and are excluded — a dot-imported
-// `type X = JournalCore` is a bare-Ident form (no SelectorExpr) noted as a
-// residual in the package godoc.
-func journalPackageLocalNames(file *ast.File) map[string]bool {
-	names := map[string]bool{}
-	for _, imp := range file.Imports {
-		p, err := strconv.Unquote(imp.Path.Value)
-		if err != nil || p != journalInterfacePkgPath {
-			continue
-		}
-		switch {
-		case imp.Name == nil:
-			names[path.Base(journalInterfacePkgPath)] = true // default name: "journal"
-		case imp.Name.Name == "_" || imp.Name.Name == ".":
-			// not usable as a selector base; skip
-		default:
-			names[imp.Name.Name] = true
-		}
-	}
-	return names
-}
-
-// journalInterfaceAliasName reports the journal interface name aliased by ts if
-// ts is `type X = <localName>.{Journal,JournalCore,Heartbeater}` where localName
-// is any local binding of the journal package (journalLocalNames), else
-// ("", false). Resolving via journalLocalNames rather than a hardcoded "journal"
-// closes the import-alias evasion: `import sagajournal "…/journal"` followed by
-// `type X = sagajournal.JournalCore` is now flagged.
-func journalInterfaceAliasName(ts *ast.TypeSpec, journalLocalNames map[string]bool) (string, bool) {
-	// An alias has a valid Assign token.
-	if !ts.Assign.IsValid() {
-		return "", false
-	}
-	sel, ok := ts.Type.(*ast.SelectorExpr)
-	if !ok {
-		return "", false
-	}
-	id, ok := sel.X.(*ast.Ident)
-	if !ok || !journalLocalNames[id.Name] {
-		return "", false
-	}
-	switch sel.Sel.Name {
-	case journalInterfaceTypeName, journalCoreInterfaceTypeName, heartbeaterInterfaceTypeName:
-		return sel.Sel.Name, true
-	}
-	return "", false
+// TestSagaJournalHolderSeal_CheckDogfood exercises the aggregate CheckSagaJournalHolderSeal
+// on GoCell production (must yield 0 diags), verifying the importable Check* surface.
+func TestSagaJournalHolderSeal_CheckDogfood(t *testing.T) {
+	t.Parallel()
+	Report(t, sagaJournalHolderSealRule, CheckSagaJournalHolderSeal(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga ensures production
@@ -2938,44 +1719,6 @@ func TestSagaJournalHolderSeal_A1_HeartbeatFuncFieldFlagged(t *testing.T) {
 // ref: SAGA-STEP-RUN-OUTSIDE-TX-01 section (callsite-discipline pattern)
 // ref: .claude/rules/gocell/ai-robust.md §"Funnel 双向锁评级"
 
-const sagaLeaderGateRule = "SAGA-DRIVE-BEHIND-LEADER-GATE-01"
-
-// driveOneMethodName is the Coordinator step-drive method gated by leader-elect.
-const driveOneMethodName = "driveOne"
-
-// acquireLeadMethodName is the leader-elect gate method tickOnce must call.
-const acquireLeadMethodName = "acquireLead"
-
-// tickOnceFuncName is the single sanctioned driveOne caller.
-const tickOnceFuncName = "tickOnce"
-
-// sagaLeaderGateFixturesDir is the testdata directory for red fixtures.
-const sagaLeaderGateFixturesDir = "saga_leader_gate_fixtures"
-
-const (
-	violSagaLeaderA1DriveOutsideTick = "SAGA-DRIVE-BEHIND-LEADER-GATE-01-A1: " +
-		"driveOne CallExpr outside tickOnce body — " +
-		"driveOne must only be called from tickOnce so the leader-elect gate guards every drive"
-
-	violSagaLeaderA2TickMissingGate = "SAGA-DRIVE-BEHIND-LEADER-GATE-01-A2: " +
-		"tickOnce body does not call acquireLead — " +
-		"the sole driveOne caller must pass the leader-elect gate"
-
-	violSagaLeaderA3LeadIgnored = "SAGA-DRIVE-BEHIND-LEADER-GATE-01-A3: " +
-		"tickOnce calls acquireLead but its lead result does not gate driveOne — " +
-		"the gate verdict must guard the drive (e.g. `if !lead { continue }`)"
-)
-
-// callIsMethodNamed reports whether call is `<expr>.<name>(...)` — selector
-// method name matched syntactically (pure AST, no types).
-func callIsMethodNamed(call *ast.CallExpr, name string) bool {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok || sel.Sel == nil {
-		return false
-	}
-	return sel.Sel.Name == name
-}
-
 // --- A1: driveOne only inside tickOnce ---
 
 // TestSagaLeaderGate_A1_DriveOneOnlyInTickOnce asserts every `.driveOne(`
@@ -2999,28 +1742,6 @@ func TestSagaLeaderGate_A1_DriveOneOnlyInTickOnce(t *testing.T) {
 	Report(t, sagaLeaderGateRule+"-A1", diags)
 }
 
-// checkLeaderGateA1 emits a diagnostic for every driveOne callsite in file that
-// is not within the tickOnce body range.
-func checkLeaderGateA1(p *Pass, file *ast.File) []Diagnostic {
-	tickRanges := collectFuncBodyRanges(file, tickOnceFuncName)
-	var ds []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		if !callIsMethodNamed(call, driveOneMethodName) {
-			return
-		}
-		if posInRanges(call.Pos(), tickRanges) {
-			return
-		}
-		pos := p.Fset.Position(call.Pos())
-		ds = append(ds, Diagnostic{
-			Rel:     filepath.ToSlash(p.Rel(file)),
-			Line:    pos.Line,
-			Message: violSagaLeaderA1DriveOutsideTick,
-		})
-	})
-	return ds
-}
-
 // --- A2: tickOnce must call acquireLead ---
 
 // TestSagaLeaderGate_A2_TickOnceCallsAcquireLead asserts each tickOnce function
@@ -3042,29 +1763,6 @@ func TestSagaLeaderGate_A2_TickOnceCallsAcquireLead(t *testing.T) {
 	})
 
 	Report(t, sagaLeaderGateRule+"-A2", diags)
-}
-
-// checkLeaderGateA2 emits a diagnostic for any tickOnce FuncDecl whose body
-// does not contain a call to acquireLead.
-func checkLeaderGateA2(p *Pass, file *ast.File) []Diagnostic {
-	var ds []Diagnostic
-	EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-		if fd.Name == nil || fd.Name.Name != tickOnceFuncName || fd.Body == nil {
-			return
-		}
-		if _, ok := FindFirstInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) bool {
-			return callIsMethodNamed(call, acquireLeadMethodName)
-		}); ok {
-			return
-		}
-		pos := p.Fset.Position(fd.Pos())
-		ds = append(ds, Diagnostic{
-			Rel:     filepath.ToSlash(p.Rel(file)),
-			Line:    pos.Line,
-			Message: violSagaLeaderA2TickMissingGate,
-		})
-	})
-	return ds
 }
 
 // --- A3: acquireLead's lead result must gate driveOne ---
@@ -3093,117 +1791,14 @@ func TestSagaLeaderGate_A3_LeadGatesDriveOne(t *testing.T) {
 	Report(t, sagaLeaderGateRule+"-A3", diags)
 }
 
-// checkLeaderGateA3 emits a diagnostic for any tickOnce that calls driveOne and
-// acquireLead but does not let the acquireLead boolean result (lead) gate the
-// drive. "Gate" is approximated structurally: there must be an IfStmt in
-// tickOnce whose condition references the lead variable and whose body either
-// early-exits the claim loop (a BranchStmt / ReturnStmt — the `if !lead {
-// continue }` shape) or directly encloses a driveOne call (the `if lead { …
-// driveOne … }` shape). A blank/missing lead binding is an immediate violation
-// (a discarded verdict cannot gate anything).
-func checkLeaderGateA3(p *Pass, file *ast.File) []Diagnostic {
-	var ds []Diagnostic
-	EachInSubtree[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-		if fd.Name == nil || fd.Name.Name != tickOnceFuncName || fd.Body == nil {
-			return
-		}
-		// If this tickOnce never drives, A3 is vacuous (A1 governs drive sites).
-		if !bodyCallsMethodNamed(fd.Body, driveOneMethodName) {
-			return
-		}
-		leadVar, ok := acquireLeadResultVar(fd.Body)
-		if !ok || !leadGatesDrive(fd.Body, leadVar) {
-			pos := p.Fset.Position(fd.Pos())
-			ds = append(ds, Diagnostic{
-				Rel:     filepath.ToSlash(p.Rel(file)),
-				Line:    pos.Line,
-				Message: violSagaLeaderA3LeadIgnored,
-			})
-		}
-	})
-	return ds
-}
-
-// bodyCallsMethodNamed reports whether body contains a `<expr>.<name>(...)` call.
-func bodyCallsMethodNamed(body *ast.BlockStmt, name string) bool {
-	found := false
-	EachInSubtree[ast.CallExpr](body, func(call *ast.CallExpr) {
-		if callIsMethodNamed(call, name) {
-			found = true
-		}
-	})
-	return found
-}
-
-// acquireLeadResultVar finds the assignment whose RHS is `<expr>.acquireLead(...)`
-// and returns the identifier bound to the last LHS element (the lead bool). ok is
-// false when acquireLead is not assigned to a tuple of at least 2 elements or the
-// lead slot is blank (`_`) — a discarded verdict cannot gate the drive.
-//
-// acquireLead currently returns 3 values (release, orphan, lead); the last LHS
-// element is always the bool gate regardless of tuple arity, so arity ≥ 2 is
-// accepted. Fixtures using the historical 2-return form also pass.
-func acquireLeadResultVar(body *ast.BlockStmt) (name string, ok bool) {
-	as, found := FindFirstInSubtree[ast.AssignStmt](body, func(as *ast.AssignStmt) bool {
-		if len(as.Rhs) != 1 || len(as.Lhs) < 2 {
-			return false
-		}
-		call, isCall := as.Rhs[0].(*ast.CallExpr)
-		if !isCall || !callIsMethodNamed(call, acquireLeadMethodName) {
-			return false
-		}
-		last := as.Lhs[len(as.Lhs)-1]
-		id, isID := last.(*ast.Ident)
-		return isID && id.Name != "_"
-	})
-	if !found {
-		return "", false
-	}
-	last := as.Lhs[len(as.Lhs)-1]
-	id := last.(*ast.Ident)
-	return id.Name, true
-}
-
-// leadGatesDrive reports whether some IfStmt in body has a condition referencing
-// leadVar and a body that either early-exits (BranchStmt/ReturnStmt) or contains
-// a driveOne call — the two sanctioned gate shapes.
-func leadGatesDrive(body *ast.BlockStmt, leadVar string) bool {
-	_, ok := FindFirstInSubtree[ast.IfStmt](body, func(ifs *ast.IfStmt) bool {
-		if ifs.Cond == nil || !condReferences(ifs.Cond, leadVar) {
-			return false
-		}
-		return ifBodyEarlyExits(ifs.Body) || bodyCallsMethodNamed(ifs.Body, driveOneMethodName)
-	})
-	return ok
-}
-
-// condReferences reports whether expr contains an identifier named want.
-func condReferences(expr ast.Expr, want string) bool {
-	_, ok := FindFirstInSubtree[ast.Ident](expr, func(id *ast.Ident) bool {
-		return id.Name == want
-	})
-	return ok
-}
-
-// ifBodyEarlyExits reports whether body contains a continue/break/return that
-// skips the rest of the claim-loop iteration before driveOne runs.
-func ifBodyEarlyExits(body *ast.BlockStmt) bool {
-	exits := false
-	EachInSubtree[ast.BranchStmt](body, func(*ast.BranchStmt) { exits = true })
-	if exits {
-		return true
-	}
-	EachInSubtree[ast.ReturnStmt](body, func(*ast.ReturnStmt) { exits = true })
-	return exits
+// TestSagaLeaderGate_CheckDogfood exercises the aggregate CheckSagaDriveBehindLeaderGate
+// on GoCell production (must yield 0 diags), verifying the importable Check* surface.
+func TestSagaLeaderGate_CheckDogfood(t *testing.T) {
+	t.Parallel()
+	Report(t, sagaLeaderGateRule, CheckSagaDriveBehindLeaderGate(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // --- reverse self-tests (red fixtures) ---
-
-// sagaLeaderGateFixturePattern returns (relDir, pattern) for a fixture case.
-func sagaLeaderGateFixturePattern(fix string) (dir, pattern string) {
-	return filepath.Join("tools", "archtest", "testdata", sagaLeaderGateFixturesDir, fix),
-		"./tools/archtest/testdata/" + sagaLeaderGateFixturesDir + "/" + fix
-}
 
 // TestSagaLeaderGate_Detector_RedDriveOutsideTick proves A1 fires when driveOne
 // is called from a function other than tickOnce.
@@ -3370,8 +1965,8 @@ func TestSagaLeaderGate_Detector_RedTickIgnoresLead(t *testing.T) {
 // ref: .claude/rules/gocell/contract-fanout.md (the fanout obligation this guards)
 
 const (
-	sfcStatusPkgPath  = "github.com/ghbvf/gocell/kernel/saga"
-	sfcJournalPkgPath = "github.com/ghbvf/gocell/kernel/saga/journal"
+	sfcStatusPkgPath  = PlatformModulePath + "/kernel/saga"
+	sfcJournalPkgPath = PlatformModulePath + "/kernel/saga/journal"
 	sfcStatusTypeName = "Status"
 	sfcKindTypeName   = "EventKind"
 	sfcReadyzDocRel   = "docs/ops/readyz.md"
@@ -3950,48 +2545,6 @@ func TestSagaCoverageDiagnosticLocations(t *testing.T) {
 // ref: tools/archtest/aftercommit_pure_transient_test.go (parent-node negative)
 // ref: .claude/rules/gocell/ai-robust.md §"Hard 范本目录" "typed marker funnel"
 
-// --- Rule constants ---
-
-const sagaStepRunOutsideTxRule = "SAGA-STEP-RUN-OUTSIDE-TX-01"
-
-// safeRunFuncName is the single sanctioned StepFunc invoker inside coordinator.go.
-const safeRunFuncName = "safeRun"
-
-// runInTxMethodName is the method on TxRunner whose closure body must not
-// contain a safeRun call.
-const runInTxMethodName = "RunInTx"
-
-// sagaRuntimePkgPrefix is the prefix for all production runtime/saga/ files
-// enforced by A1, A2, and B1. Both test-file exclusion (_test.go suffix) and
-// this prefix guard are applied together.
-const sagaRuntimePkgPrefix = "runtime/saga/"
-
-// sagaStepRunFixturesDir is the testdata directory for SAGA-STEP-RUN-OUTSIDE-TX-01
-// red/green fixtures.
-const sagaStepRunFixturesDir = "saga_step_run_outside_tx_fixtures"
-
-// ksagaPkgPath is the import path of kernel/saga, where StepFunc is declared.
-const ksagaPkgPath = "github.com/ghbvf/gocell/kernel/saga"
-
-// stepFuncTypeName is the declared type in ksagaPkgPath.
-const stepFuncTypeName = "StepFunc"
-
-// --- Violation messages ---
-
-const (
-	violSagaA1StepFuncOutsideSafeRun = "SAGA-STEP-RUN-OUTSIDE-TX-01-A1: " +
-		"saga.StepFunc CallExpr outside safeRun body — " +
-		"StepFunc must only be invoked from safeRun (user step code outside DB tx invariant)"
-
-	violSagaA2SafeRunInsideRunInTx = "SAGA-STEP-RUN-OUTSIDE-TX-01-A2: " +
-		"safeRun() called inside RunInTx closure body — " +
-		"user step code would run with a DB transaction held open"
-
-	violSagaB1StepFuncAlias = "SAGA-STEP-RUN-OUTSIDE-TX-01-B1 (blind-spot): " +
-		"type alias of kernel/saga.StepFunc found in runtime/saga/ — " +
-		"A1 type check would miss StepFunc invocations via this alias"
-)
-
 // --- A1: StepFunc callsite uniqueness (typed) ---
 
 // TestSagaStepRunOutsideTx_A1_StepFuncCallsiteUniqueness asserts that every
@@ -4031,103 +2584,6 @@ func TestSagaStepRunOutsideTx_A1_StepFuncCallsiteUniqueness(t *testing.T) {
 	Report(t, sagaStepRunOutsideTxRule+"-A1", diags)
 }
 
-// checkA1StepFuncCallsites emits A1 diagnostics for coordinator.go:
-// every CallExpr whose callee type is saga.StepFunc must be inside safeRun.
-func checkA1StepFuncCallsites(p *Pass, file *ast.File) []Diagnostic {
-	// Resolve the saga.StepFunc named type from the package's import closure.
-	stepFuncType := resolveSagaStepFuncType(p.Pkg)
-	if stepFuncType == nil {
-		// Package doesn't import kernel/saga — nothing to check.
-		return nil
-	}
-
-	// Collect the body Pos/End range of safeRun.
-	safeRunRanges := collectFuncBodyRanges(file, safeRunFuncName)
-
-	var ds []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		if !calleeIsSagaStepFunc(p.TypesInfo, call, stepFuncType) {
-			return
-		}
-		if posInRanges(call.Pos(), safeRunRanges) {
-			return
-		}
-		pos := p.Fset.Position(call.Pos())
-		ds = append(ds, Diagnostic{
-			Rel:     filepath.ToSlash(p.Rel(file)),
-			Line:    pos.Line,
-			Message: violSagaA1StepFuncOutsideSafeRun,
-		})
-	})
-	return ds
-}
-
-// resolveSagaStepFuncType walks the import closure of pkg to find the
-// kernel/saga package and returns the named type for StepFunc. Returns nil
-// when the package is not imported.
-func resolveSagaStepFuncType(pkg *types.Package) *types.Named {
-	if pkg == nil {
-		return nil
-	}
-	sagaPkg := findImportedPkg(pkg, ksagaPkgPath)
-	if sagaPkg == nil {
-		return nil
-	}
-	obj := sagaPkg.Scope().Lookup(stepFuncTypeName)
-	if obj == nil {
-		return nil
-	}
-	named, _ := obj.Type().(*types.Named)
-	return named
-}
-
-// findImportedPkg does a BFS over pkg's transitive import closure to find the
-// package with the given path. Returns nil if not found.
-func findImportedPkg(root *types.Package, path string) *types.Package {
-	seen := make(map[string]bool)
-	var walk func(*types.Package) *types.Package
-	walk = func(p *types.Package) *types.Package {
-		if p.Path() == path {
-			return p
-		}
-		if seen[p.Path()] {
-			return nil
-		}
-		seen[p.Path()] = true
-		for _, imp := range p.Imports() {
-			if found := walk(imp); found != nil {
-				return found
-			}
-		}
-		return nil
-	}
-	return walk(root)
-}
-
-// calleeIsSagaStepFunc reports whether the callee of call has the same
-// underlying type as sagaStepFuncType. Handles both the exact named type and
-// its underlying function signature.
-func calleeIsSagaStepFunc(info *types.Info, call *ast.CallExpr, sagaStepFuncType *types.Named) bool {
-	if info == nil || sagaStepFuncType == nil {
-		return false
-	}
-	tv, ok := info.Types[call.Fun]
-	if !ok {
-		return false
-	}
-	t := tv.Type
-	if t == nil {
-		return false
-	}
-	// Direct named-type match (exact ksaga.StepFunc).
-	if named, isNamed := t.(*types.Named); isNamed {
-		return named == sagaStepFuncType
-	}
-	// Underlying signature match: a callee can be typed as the underlying func
-	// signature without the named wrapper (e.g. after a type conversion).
-	return types.Identical(t, sagaStepFuncType.Underlying())
-}
-
 // --- A2: safeRun not inside RunInTx closure (pure AST) ---
 
 // TestSagaStepRunOutsideTx_A2_SafeRunNotInsideRunInTxClosure asserts that no
@@ -4163,53 +2619,11 @@ func TestSagaStepRunOutsideTx_A2_SafeRunNotInsideRunInTxClosure(t *testing.T) {
 	Report(t, sagaStepRunOutsideTxRule+"-A2", diags)
 }
 
-// checkA2SafeRunNotInRunInTx walks the file for RunInTx calls and asserts
-// their closure bodies do not contain a direct call to safeRun.
-func checkA2SafeRunNotInRunInTx(p *Pass, file *ast.File) []Diagnostic {
-	var ds []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(outer *ast.CallExpr) {
-		if !callIsRunInTx(outer) {
-			return
-		}
-		// Args[1] must be the closure literal (the tx callback).
-		if len(outer.Args) < 2 {
-			return
-		}
-		lit, isLit := outer.Args[1].(*ast.FuncLit)
-		if !isLit || lit.Body == nil {
-			return
-		}
-		// Scan inside the closure body for any direct call to safeRun.
-		EachInSubtree[ast.CallExpr](lit.Body, func(inner *ast.CallExpr) {
-			if !callIsSafeRun(inner) {
-				return
-			}
-			pos := p.Fset.Position(inner.Pos())
-			ds = append(ds, Diagnostic{
-				Rel:     filepath.ToSlash(p.Rel(file)),
-				Line:    pos.Line,
-				Message: violSagaA2SafeRunInsideRunInTx,
-			})
-		})
-	})
-	return ds
-}
-
-// callIsRunInTx reports whether call is `<expr>.RunInTx(...)` — the method
-// name matched syntactically.
-func callIsRunInTx(call *ast.CallExpr) bool {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok || sel.Sel == nil {
-		return false
-	}
-	return sel.Sel.Name == runInTxMethodName
-}
-
-// callIsSafeRun reports whether call is a direct (unqualified) call to the
-// identifier "safeRun" — the only form that driveOne uses.
-func callIsSafeRun(call *ast.CallExpr) bool {
-	id, ok := call.Fun.(*ast.Ident)
-	return ok && id.Name == safeRunFuncName
+// TestSagaStepRunOutsideTx_CheckDogfood exercises the aggregate CheckSagaStepRunOutsideTx
+// on GoCell production (must yield 0 diags), verifying the importable Check* surface.
+func TestSagaStepRunOutsideTx_CheckDogfood(t *testing.T) {
+	t.Parallel()
+	Report(t, sagaStepRunOutsideTxRule, CheckSagaStepRunOutsideTx(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // --- B1: No StepFunc alias in runtime/saga (pure AST, reverse self-test) ---
@@ -4258,74 +2672,6 @@ func TestSagaStepRunOutsideTx_BlindSpot_B1_NoStepFuncAlias(t *testing.T) {
 	})
 
 	Report(t, sagaStepRunOutsideTxRule+"-B1", diags)
-}
-
-// checkB1NoStepFuncAlias scans file for any TypeSpec that aliases or redefines
-// ksaga.StepFunc using the file's local import name for kernel/saga.
-func checkB1NoStepFuncAlias(p *Pass, file *ast.File) []Diagnostic {
-	ksagaLocal := sagaLocalName(file)
-	if ksagaLocal == "" {
-		// File doesn't import kernel/saga at all — no alias possible.
-		return nil
-	}
-	var ds []Diagnostic
-	EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
-		if ts.Name == nil || ts.Type == nil {
-			return
-		}
-		sel, ok := ts.Type.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		x, ok := sel.X.(*ast.Ident)
-		if !ok || x.Name != ksagaLocal {
-			return
-		}
-		if sel.Sel == nil || sel.Sel.Name != stepFuncTypeName {
-			return
-		}
-		pos := p.Fset.Position(ts.Pos())
-		ds = append(ds, Diagnostic{
-			Rel:     filepath.ToSlash(p.Rel(file)),
-			Line:    pos.Line,
-			Message: violSagaB1StepFuncAlias,
-		})
-	})
-	return ds
-}
-
-// sagaLocalName returns the local identifier used in file to refer to the
-// kernel/saga package (default "saga" for an unnamed import; alias otherwise).
-// Returns "" when the file does not import kernel/saga at all.
-func sagaLocalName(file *ast.File) string {
-	const sagaImportPath = `"github.com/ghbvf/gocell/kernel/saga"`
-	for _, imp := range file.Imports {
-		if imp.Path == nil || imp.Path.Value != sagaImportPath {
-			continue
-		}
-		if imp.Name != nil {
-			return imp.Name.Name
-		}
-		// Default local name is the last path segment.
-		return "saga"
-	}
-	return ""
-}
-
-// isRuntimeSagaProductionFile reports whether rel is a production .go file
-// under runtime/saga/ (i.e., has the sagaRuntimePkgPrefix prefix and does not
-// end with _test.go). Used by A1 and A2 to scope the rule to the full
-// runtime/saga/ package, not just coordinator.go.
-func isRuntimeSagaProductionFile(rel string) bool {
-	return strings.HasPrefix(rel, sagaRuntimePkgPrefix) && !strings.HasSuffix(rel, "_test.go")
-}
-
-// sagaStepRunFixturePattern returns the (relDir, pattern) pair for the given
-// fixture case under sagaStepRunFixturesDir. Mirrors the helper pattern used
-// by the saga compensate pure test.
-func sagaStepRunFixturePattern(fix string) (dir, pattern string) {
-	return filepath.Join("tools", "archtest", "testdata", sagaStepRunFixturesDir, fix),
-		"./tools/archtest/testdata/" + sagaStepRunFixturesDir + "/" + fix
 }
 
 // TestSagaStepRunOutsideTx_Detector_RedExtraFileFixture proves that A1 fires
@@ -4464,207 +2810,6 @@ func sagaConstructorNilGuardFixturePattern(fix string) (dir, pattern string) {
 		"./tools/archtest/testdata/" + sagaConstructorFixturesDir + "/" + fix
 }
 
-// sagaConstructorScopePackages is the set of production package paths scanned
-// by SAGA-CONSTRUCTOR-NIL-GUARD-01.
-var sagaConstructorScopePackages = map[string]bool{
-	"github.com/ghbvf/gocell/runtime/saga":          true,
-	"github.com/ghbvf/gocell/runtime/saga/executor": true,
-}
-
-// sagaGuardFuncKeys is the set of (pkgPath, funcName) pairs that constitute an
-// accepted nil-guard call for a constructor parameter.
-type sagaGuardKey struct{ pkg, name string }
-
-var sagaGuardFuncKeys = []sagaGuardKey{
-	{"github.com/ghbvf/gocell/pkg/validation", "IsNilInterface"},
-	{"github.com/ghbvf/gocell/kernel/clock", "MustHaveClock"},
-}
-
-// scanConstructorNilGuards scans p for top-level New* functions that accept
-// non-variadic interface parameters lacking a guard call. It is a pure function
-// (no *testing.T dependency) so it can be shared between the production scan
-// and the fixture-based reverse test.
-//
-// Detection algorithm:
-//  1. Walk p.Files for top-level FuncDecl (no Recv) whose name starts with "New"
-//     and has a non-nil Body.
-//  2. For each non-variadic parameter: resolve its type via
-//     p.TypesInfo.TypeOf(fieldType). If the Underlying() is an interface, the
-//     parameter is a required interface dep that needs a guard.
-//  3. For each such parameter, collect its types.Object via
-//     p.TypesInfo.Defs[paramIdent].
-//  4. Walk the Body for CallExpr whose callee resolves (via
-//     p.TypesInfo.ObjectOf) to a types.Func in sagaGuardFuncKeys, and whose
-//     first argument's ObjectOf equals the parameter object.
-//  5. If no matching guard call is found, emit a diagnostic.
-func scanConstructorNilGuards(p *Pass) []Diagnostic {
-	if p.TypesInfo == nil {
-		return nil
-	}
-	var out []Diagnostic
-	for _, file := range p.Files {
-		if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
-			continue
-		}
-		rel := p.Rel(file)
-		EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-			if fd.Recv != nil || fd.Body == nil {
-				return
-			}
-			if !strings.HasPrefix(fd.Name.Name, "New") {
-				return
-			}
-			if fd.Type.Params == nil {
-				return
-			}
-			// Collect interface parameters and their types.Object.
-			type ifaceParam struct {
-				obj      types.Object
-				typeExpr ast.Expr
-				name     string
-				typStr   string
-			}
-			var ifaces []ifaceParam
-			for _, field := range fd.Type.Params.List {
-				if _, isEllipsis := field.Type.(*ast.Ellipsis); isEllipsis {
-					// variadic — skip
-					continue
-				}
-				typ := p.TypesInfo.TypeOf(field.Type)
-				if typ == nil {
-					continue
-				}
-				if _, isIface := typ.Underlying().(*types.Interface); !isIface {
-					continue
-				}
-				// An unnamed interface parameter (e.g. `func New(journal.Journal)`)
-				// has no identifier to reference, so it can never be nil-guarded —
-				// flag it directly rather than silently skipping (closes the
-				// anonymous-param bypass; the param loop below requires a name).
-				if len(field.Names) == 0 {
-					out = append(out, sagaDiag(p, field.Type, rel,
-						sagaConstructorNilGuardRuleID+": constructor "+fd.Name.Name+
-							" has an unnamed interface parameter (type "+sagaShortType(typ)+
-							") that cannot be nil-guarded; give it a name and add "+
-							"validation.IsNilInterface(<param>) (or clock.MustHaveClock)"))
-					continue
-				}
-				for _, name := range field.Names {
-					obj := p.TypesInfo.Defs[name]
-					// A blank-identifier interface param (`_ journal.Journal`) has
-					// no object to bind a guard to — also a bypass; flag it.
-					if name.Name == "_" || obj == nil {
-						out = append(out, sagaDiag(p, name, rel,
-							sagaConstructorNilGuardRuleID+": constructor "+fd.Name.Name+
-								" has a blank-identifier interface parameter (type "+sagaShortType(typ)+
-								") that cannot be nil-guarded; give it a name and add "+
-								"validation.IsNilInterface(<param>) (or clock.MustHaveClock)"))
-						continue
-					}
-					ifaces = append(ifaces, ifaceParam{
-						obj:      obj,
-						typeExpr: field.Type,
-						name:     name.Name,
-						typStr:   sagaShortType(typ),
-					})
-				}
-			}
-			if len(ifaces) == 0 {
-				return
-			}
-			// For each interface param, check if a guard call referencing it exists
-			// in the body.
-			for _, ip := range ifaces {
-				_, guarded := FindFirstInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) bool {
-					if !sagaIsGuardCall(p, call) {
-						return false
-					}
-					// Check first argument is the parameter object. ast.Unparen
-					// strips redundant parens so IsNilInterface((dep)) is still
-					// recognized as a guard (closes the parenthesized-arg bypass).
-					if len(call.Args) == 0 {
-						return false
-					}
-					firstArg, ok2 := ast.Unparen(call.Args[0]).(*ast.Ident)
-					if !ok2 {
-						return false
-					}
-					return p.TypesInfo.ObjectOf(firstArg) == ip.obj
-				})
-				if !guarded {
-					out = append(out, sagaDiag(p, fd.Name, rel,
-						sagaConstructorNilGuardRuleID+": constructor "+fd.Name.Name+
-							" has interface parameter "+ip.name+" (type "+ip.typStr+
-							") without a guard call (IsNilInterface or clock.MustHaveClock); "+
-							"add validation.IsNilInterface("+ip.name+") or clock.MustHaveClock("+ip.name+", ...)"))
-				}
-			}
-		})
-	}
-	return out
-}
-
-// sagaIsGuardCall reports whether call resolves (via go/types) to a sanctioned
-// nil-guard function — validation.IsNilInterface or clock.MustHaveClock. Shared
-// by scanConstructorNilGuards and the B1 reverse self-test so both key on the
-// same callee identity (not a string name match).
-func sagaIsGuardCall(p *Pass, call *ast.CallExpr) bool {
-	var calleeFunc *types.Func
-	switch fun := call.Fun.(type) {
-	case *ast.SelectorExpr:
-		if f, ok := p.TypesInfo.ObjectOf(fun.Sel).(*types.Func); ok {
-			calleeFunc = f
-		}
-	case *ast.Ident:
-		if f, ok := p.TypesInfo.ObjectOf(fun).(*types.Func); ok {
-			calleeFunc = f
-		}
-	}
-	if calleeFunc == nil || calleeFunc.Pkg() == nil {
-		return false
-	}
-	for _, gk := range sagaGuardFuncKeys {
-		if calleeFunc.Pkg().Path() == gk.pkg && calleeFunc.Name() == gk.name {
-			return true
-		}
-	}
-	return false
-}
-
-// sagaShortType renders t as package.TypeName (short package name, no full
-// import path) to keep diagnostics readable in CI logs.
-func sagaShortType(t types.Type) string {
-	return types.TypeString(t, func(p *types.Package) string { return p.Name() })
-}
-
-// sagaConstructorIfaceParamObjs returns the set of named, non-variadic interface
-// parameter objects of a New* constructor — the params scanConstructorNilGuards
-// requires a guard for. Used by the B2 reverse self-test.
-func sagaConstructorIfaceParamObjs(p *Pass, fd *ast.FuncDecl) map[types.Object]bool {
-	out := map[types.Object]bool{}
-	if fd.Type.Params == nil {
-		return out
-	}
-	for _, field := range fd.Type.Params.List {
-		if _, isEllipsis := field.Type.(*ast.Ellipsis); isEllipsis {
-			continue
-		}
-		typ := p.TypesInfo.TypeOf(field.Type)
-		if typ == nil {
-			continue
-		}
-		if _, isIface := typ.Underlying().(*types.Interface); !isIface {
-			continue
-		}
-		for _, name := range field.Names {
-			if obj := p.TypesInfo.Defs[name]; obj != nil {
-				out[obj] = true
-			}
-		}
-	}
-	return out
-}
-
 // TestSagaConstructorNilGuard_NoUnguardedInterfaceParam asserts that every
 // top-level New* constructor in the runtime/saga and runtime/saga/executor
 // packages guards every non-variadic interface parameter with either
@@ -4679,13 +2824,7 @@ func sagaConstructorIfaceParamObjs(p *Pass, fd *ast.FuncDecl) map[types.Object]b
 //   - B2: guard called on a reassigned alias of the parameter variable
 func TestSagaConstructorNilGuard_NoUnguardedInterfaceParam(t *testing.T) {
 	t.Parallel()
-	diags := Run(t, Production(TypedOpts{Tags: FlatNonDefaultTags()}), func(p *Pass) []Diagnostic {
-		if p.Pkg == nil || !sagaConstructorScopePackages[p.Pkg.Path()] {
-			return nil
-		}
-		return scanConstructorNilGuards(p)
-	})
-
+	diags := CheckSagaConstructorNilGuard(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, sagaConstructorNilGuardRuleID, diags)
 }
 
@@ -4855,110 +2994,6 @@ func TestSagaConstructorNilGuard_BlindSpot_B2_NoParamReassignment(t *testing.T) 
 // A1, golden-asserting the diagnostic fires — so a regression in the detector
 // (sagaSlogAttrCtorGuardedKey / posInRanges) is caught, not silently masked by
 // production's current zero violations.
-const sagaSlogInstanceFieldsRule = "SAGA-SLOG-INSTANCE-FIELDS-CALLER-01"
-
-const (
-	sagaInstanceFieldsFuncName = "InstanceFields"
-	sagaSlogPkgPath            = "log/slog"
-	sagaSlogAttrTypeName       = "Attr"
-	sagalogPkgPath             = "github.com/ghbvf/gocell/runtime/saga/internal/sagalog"
-)
-
-// sagaInstanceFieldsGuardedKeys are the per-instance identity attrs that may
-// only be emitted from inside the sagalog.InstanceFields carrier.
-var sagaInstanceFieldsGuardedKeys = map[string]struct{}{
-	"instance_id": {},
-	"lease_id":    {},
-}
-
-const violSagaSlogInstanceFieldsOutsideCarrier = sagaSlogInstanceFieldsRule + ": " +
-	`a log/slog Attr constructor with key "instance_id"|"lease_id" outside ` +
-	"sagalog.InstanceFields — route every per-instance saga log through " +
-	"sagalog.InstanceFields so lease_id is structurally guaranteed (#1266)"
-
-// sagaSlogAttrCtorGuardedKey reports whether call is a log/slog package-level
-// Attr constructor — slog.String / Int / Int64 / Uint64 / Float64 / Bool /
-// Time / Duration / Any / Group / GroupAttrs and any future key-first
-// constructor — whose first argument is one of the guarded identity keys,
-// returning the matched key.
-//
-// It does NOT hardcode the constructor name set: it accepts any call whose
-// callee resolves into package log/slog AND whose signature returns a single
-// log/slog.Attr result (sagaCalleeReturnsSlogAttr). All such log/slog
-// constructors are key-first, so the first arg is the attr key. This keeps the
-// funnel's coverage face aligned with the full log/slog Attr API face (#1266
-// review C1/F1) — a new ctor added to log/slog is covered automatically.
-// Callee resolution is via go/types, so a log/slog import alias does not evade.
-func sagaSlogAttrCtorGuardedKey(info *types.Info, call *ast.CallExpr) (string, bool) {
-	if info == nil || len(call.Args) < 1 {
-		return "", false
-	}
-	pkgPath, _, ok := ResolvePackageRef(info, call.Fun)
-	if !ok || pkgPath != sagaSlogPkgPath {
-		return "", false
-	}
-	if !sagaCalleeReturnsSlogAttr(info, call.Fun) {
-		return "", false
-	}
-	key, ok := EvaluateConstString(info, call.Args[0])
-	if !ok {
-		return "", false
-	}
-	if _, guarded := sagaInstanceFieldsGuardedKeys[key]; !guarded {
-		return "", false
-	}
-	return key, true
-}
-
-// sagaCalleeReturnsSlogAttr reports whether fun (a CallExpr.Fun) resolves to a
-// function whose single result is log/slog.Attr — i.e. an Attr constructor.
-// Used to identify the full key-first constructor family (String/Int/Any/
-// Group/…) by signature rather than by an enumerated name set.
-func sagaCalleeReturnsSlogAttr(info *types.Info, fun ast.Expr) bool {
-	tv, ok := info.Types[fun]
-	if !ok {
-		return false
-	}
-	sig, ok := tv.Type.(*types.Signature)
-	if !ok || sig.Results().Len() != 1 {
-		return false
-	}
-	named, ok := sig.Results().At(0).Type().(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj != nil && obj.Name() == sagaSlogAttrTypeName &&
-		obj.Pkg() != nil && obj.Pkg().Path() == sagaSlogPkgPath
-}
-
-// scanSagaSlogInstanceFieldsFile is the A1 core: flag every log/slog Attr
-// constructor call carrying a guarded identity key (instance_id|lease_id) in
-// file that is NOT inside an InstanceFields body. Shared by A1 (production
-// scan, with the isRuntimeSagaProductionFile filter applied by the caller) and
-// the RED-fixture detector self-test (no production filter).
-func scanSagaSlogInstanceFieldsFile(p *Pass, file *ast.File) []Diagnostic {
-	rel := filepath.ToSlash(p.Rel(file))
-	carrierRanges := collectFuncBodyRanges(file, sagaInstanceFieldsFuncName)
-	var ds []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		key, ok := sagaSlogAttrCtorGuardedKey(p.TypesInfo, call)
-		if !ok {
-			return
-		}
-		if posInRanges(call.Pos(), carrierRanges) {
-			return
-		}
-		pos := p.Fset.Position(call.Pos())
-		ds = append(ds, Diagnostic{
-			Rel:     rel,
-			Line:    pos.Line,
-			Message: violSagaSlogInstanceFieldsOutsideCarrier + ` (key="` + key + `")`,
-		})
-	})
-	return ds
-}
-
 // TestSagaSlogInstanceFieldsCaller_A1_GuardedKeysOnlyInCarrier is the upstream
 // caller-allowlist: a log/slog Attr constructor carrying a guarded key
 // (instance_id|lease_id) may appear only inside the sagalog.InstanceFields body
@@ -4980,6 +3015,14 @@ func TestSagaSlogInstanceFieldsCaller_A1_GuardedKeysOnlyInCarrier(t *testing.T) 
 	})
 
 	Report(t, sagaSlogInstanceFieldsRule+"-A1", diags)
+}
+
+// TestSagaSlogInstanceFieldsCaller_CheckDogfood exercises the aggregate
+// CheckSagaSlogInstanceFieldsCaller on GoCell production (must yield 0 diags),
+// verifying the importable Check* surface.
+func TestSagaSlogInstanceFieldsCaller_CheckDogfood(t *testing.T) {
+	t.Parallel()
+	Report(t, sagaSlogInstanceFieldsRule, CheckSagaSlogInstanceFieldsCaller(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // sagaSlogInstanceFieldsFixturePattern returns the (relDir, load-pattern) pair
@@ -5063,36 +3106,6 @@ func TestSagaSlogInstanceFieldsCaller_B3_CarrierNameUniqueInRuntimeSaga(t *testi
 	}
 }
 
-// TestSagaSlogInstanceFieldsCaller_B4_NoIdentityAttrStructLiterals closes the
-// detectable half of the "identity attr built indirectly" blind spot: a
-// slog.Attr composite literal carrying a guarded key — keyed
-// (slog.Attr{Key: "instance_id", …}) OR unkeyed (slog.Attr{"instance_id", …}) —
-// would carry an identity key without an Attr-constructor CallExpr for A1 to
-// see. Assert none exists in runtime/saga/ production. (The pre-bound-variable
-// form is a documented residual — runtime/saga uses the carrier by convention.)
-// scanSagaSlogAttrLiteralsFile flags every log/slog.Attr composite literal
-// (keyed or unkeyed) carrying a guarded identity key. Shared by B4 (production
-// scan, with the isRuntimeSagaProductionFile filter applied by the caller) and
-// the RED-fixture self-test.
-func scanSagaSlogAttrLiteralsFile(p *Pass, file *ast.File) []Diagnostic {
-	rel := filepath.ToSlash(p.Rel(file))
-	var ds []Diagnostic
-	EachInSubtree[ast.CompositeLit](file, func(cl *ast.CompositeLit) {
-		key, ok := sagaSlogAttrLiteralGuardedKey(p.TypesInfo, cl)
-		if !ok {
-			return
-		}
-		pos := p.Fset.Position(cl.Pos())
-		ds = append(ds, Diagnostic{
-			Rel:  rel,
-			Line: pos.Line,
-			Message: sagaSlogInstanceFieldsRule + ": slog.Attr{…} literal with key \"" + key +
-				"\" — build identity attrs via sagalog.InstanceFields, not a raw slog.Attr literal (#1266)",
-		})
-	})
-	return ds
-}
-
 func TestSagaSlogInstanceFieldsCaller_B4_NoIdentityAttrStructLiterals(t *testing.T) {
 	t.Parallel()
 	diags := Run(t, Typed(TypedOpts{}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
@@ -5110,60 +3123,6 @@ func TestSagaSlogInstanceFieldsCaller_B4_NoIdentityAttrStructLiterals(t *testing
 	})
 
 	Report(t, sagaSlogInstanceFieldsRule+"-B4", diags)
-}
-
-// sagaSlogAttrLiteralGuardedKey reports whether cl is a log/slog.Attr composite
-// literal whose Key field is one of the guarded identity keys, returning the
-// key. Handles BOTH literal forms (#1266 review C1/F2):
-//   - keyed:    slog.Attr{Key: "instance_id", Value: …}
-//   - unkeyed:  slog.Attr{"instance_id", …}   (Key is the first struct field)
-func sagaSlogAttrLiteralGuardedKey(info *types.Info, cl *ast.CompositeLit) (string, bool) {
-	if info == nil {
-		return "", false
-	}
-	named, ok := info.TypeOf(cl).(*types.Named)
-	if !ok {
-		return "", false
-	}
-	obj := named.Obj()
-	if obj == nil || obj.Name() != sagaSlogAttrTypeName || obj.Pkg() == nil || obj.Pkg().Path() != sagaSlogPkgPath {
-		return "", false
-	}
-	if len(cl.Elts) == 0 {
-		return "", false
-	}
-	// Keyed form: a field is given as `Key: <expr>`. Find the first `Key:` field
-	// whose value is a guarded key via the typed find-first funnel — no
-	// caller-held found/done sentinel (SCANNER-FRAMEWORK-USAGE-02).
-	if _, isKV := cl.Elts[0].(*ast.KeyValueExpr); isKV {
-		kv, ok := scanner.FindFirstChild[ast.KeyValueExpr](cl, func(kv *ast.KeyValueExpr) bool {
-			ident, isIdent := kv.Key.(*ast.Ident)
-			if !isIdent || ident.Name != "Key" {
-				return false
-			}
-			_, guarded := sagaGuardedKeyFromExpr(info, kv.Value)
-			return guarded
-		})
-		if !ok {
-			return "", false
-		}
-		return sagaGuardedKeyFromExpr(info, kv.Value)
-	}
-	// Unkeyed (positional) form: slog.Attr's first field is Key (string).
-	return sagaGuardedKeyFromExpr(info, cl.Elts[0])
-}
-
-// sagaGuardedKeyFromExpr evaluates expr to a const string and returns it when
-// it is one of the guarded identity keys.
-func sagaGuardedKeyFromExpr(info *types.Info, expr ast.Expr) (string, bool) {
-	key, ok := EvaluateConstString(info, expr)
-	if !ok {
-		return "", false
-	}
-	if _, guarded := sagaInstanceFieldsGuardedKeys[key]; guarded {
-		return key, true
-	}
-	return "", false
 }
 
 // TestSagaSlogInstanceFieldsCaller_B1_CarrierEmitsBothGuardedKeys closes the
@@ -5570,91 +3529,6 @@ func TestSagaInvariantsConsolidated_REDFixture(t *testing.T) {
 // non-constant arg and is not flagged. Reverse self-check:
 // TestSagaMetricLabelValuesFrozen01_NegativeControl + the callsite fixtures.
 
-const sagaExecutorPkg = PlatformModulePath + "/runtime/saga/executor"
-
-// sagaLabelEnumWant maps each frozen executor label-enum type name to its
-// frozen string value set. Updating any entry requires a simultaneous update to:
-// (1) the enum consts in runtime/saga/executor/observer.go, (2) the classifier
-// feeding it (classifyLeaderSkip / driveResult mapping / tick branches in
-// runtime/saga), (3) dashboards/alerts in docs/ops/alerting-rules.md, and (4)
-// any saga metric label doc契约.
-var sagaLabelEnumWant = map[string][]string{
-	"HeartbeatFailureReason": {"infra_error", "stale_lease"},
-	"TickResult":             {"claimed", "empty", "error"},
-	"DriveResult":            {"ok", "error"},
-	"LeaderSkipReason":       {"contended", "ctx_canceled", "backend_error"},
-}
-
-// sagaEnumTypeName returns the enum type name if t is one of the frozen executor
-// label-enum named types, else "".
-func sagaEnumTypeName(t types.Type) string {
-	named, ok := t.(*types.Named)
-	if !ok {
-		return ""
-	}
-	obj := named.Obj()
-	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != sagaExecutorPkg {
-		return ""
-	}
-	if _, frozen := sagaLabelEnumWant[obj.Name()]; frozen {
-		return obj.Name()
-	}
-	return ""
-}
-
-// collectSagaEnumConsts enumerates, per frozen enum type, the string constant
-// values declared in the executor package (p must be that package Pass).
-func collectSagaEnumConsts(p *Pass) map[string][]string {
-	if p.Pkg == nil {
-		return nil
-	}
-	got := make(map[string][]string)
-	scope := p.Pkg.Scope()
-	for _, name := range scope.Names() {
-		c, ok := scope.Lookup(name).(*types.Const)
-		if !ok {
-			continue
-		}
-		typeName := sagaEnumTypeName(c.Type())
-		if typeName == "" {
-			continue
-		}
-		got[typeName] = append(got[typeName], strings.Trim(c.Val().ExactString(), `"`))
-	}
-	return got
-}
-
-// sagaValueSetDiff returns "" when got and want hold the same set
-// (order-insensitive), else a human-readable extra/missing description.
-func sagaValueSetDiff(got, want []string) string {
-	gs, ws := slices.Clone(got), slices.Clone(want)
-	slices.Sort(gs)
-	slices.Sort(ws)
-	if slices.Equal(gs, ws) {
-		return ""
-	}
-	wantSet := make(map[string]struct{}, len(want))
-	for _, k := range want {
-		wantSet[k] = struct{}{}
-	}
-	gotSet := make(map[string]struct{}, len(got))
-	var extra, missing []string
-	for _, k := range got {
-		gotSet[k] = struct{}{}
-		if _, ok := wantSet[k]; !ok {
-			extra = append(extra, k)
-		}
-	}
-	for _, k := range want {
-		if _, ok := gotSet[k]; !ok {
-			missing = append(missing, k)
-		}
-	}
-	slices.Sort(extra)
-	slices.Sort(missing)
-	return "  extra:   " + sliceOrNone(extra) + "\n  missing: " + sliceOrNone(missing)
-}
-
 // TestSagaMetricLabelValuesFrozen01 freezes each executor label-enum's const
 // value set against the independent hardcoded want-set.
 func TestSagaMetricLabelValuesFrozen01(t *testing.T) {
@@ -5690,225 +3564,14 @@ func TestSagaMetricLabelValuesFrozen01(t *testing.T) {
 	}
 }
 
-// isSagaEnumConversion reports whether call is a type conversion to one of the
-// frozen executor label enums (e.g. executor.LeaderSkipReason("x")). The
-// conversion's operand is itself recorded by go/types with the enum type, so
-// scanning it would double-flag; we skip the operands here and let the parent
-// call flag the conversion expression once (as its argument).
-func isSagaEnumConversion(info *types.Info, call *ast.CallExpr) bool {
-	var sel *ast.Ident
-	switch f := call.Fun.(type) {
-	case *ast.Ident:
-		sel = f
-	case *ast.SelectorExpr:
-		sel = f.Sel
-	default:
-		return false
-	}
-	tn, ok := info.ObjectOf(sel).(*types.TypeName)
-	if !ok {
-		return false
-	}
-	return sagaEnumTypeName(tn.Type()) != ""
-}
-
-// isSagaDeclaredConstRef reports whether arg is a bare reference to a const
-// declared in the runtime/saga/executor package AND typed as one of the frozen
-// executor label enums.  A const of an enum type declared in any other package
-// (e.g. `const myReason executor.LeaderSkipReason = "rogue"`) is NOT a valid
-// frozen reference and must be flagged (F1 fix).
-func isSagaDeclaredConstRef(info *types.Info, arg ast.Expr) bool {
-	var obj types.Object
-	switch e := arg.(type) {
-	case *ast.Ident:
-		obj = info.ObjectOf(e)
-	case *ast.SelectorExpr:
-		obj = info.ObjectOf(e.Sel)
-	default:
-		return false
-	}
-	c, ok := obj.(*types.Const)
-	if !ok {
-		return false
-	}
-	// The const must be declared in the executor package (not laundered in from
-	// another package) AND must be of one of the frozen enum types.
-	if c.Pkg() == nil || c.Pkg().Path() != sagaExecutorPkg {
-		return false
-	}
-	return sagaEnumTypeName(c.Type()) != ""
-}
-
-// sagaEnumConstViolation reports whether expr is an inline enum-typed constant
-// that is NOT a valid frozen executor declared-const reference.  Returns the
-// enum type name if it is a violation, "" otherwise.  Used by both the callsite
-// guard and the assignment guard to share detection logic.
-func sagaEnumConstViolation(info *types.Info, expr ast.Expr) string {
-	tv, ok := info.Types[expr]
-	if !ok || tv.Value == nil {
-		return "" // non-constant (var, func call) — allowed
-	}
-	typeName := sagaEnumTypeName(tv.Type)
-	if typeName == "" {
-		return "" // not a frozen enum type
-	}
-	if isSagaDeclaredConstRef(info, expr) {
-		return "" // valid frozen executor const reference
-	}
-	return typeName
-}
-
-// scanSagaEnumLabelCallsites flags any CallExpr argument whose go/types type is a
-// frozen executor label-enum AND is a compile-time constant that is not a valid
-// frozen executor declared-const reference (an inline string literal, a T("x")
-// conversion, or a const declared outside runtime/saga/executor).
-func scanSagaEnumLabelCallsites(p *Pass) []Diagnostic {
-	info := p.TypesInfo
-	if info == nil {
-		return nil
-	}
-	var diags []Diagnostic
-	for _, file := range p.Files {
-		if strings.HasSuffix(p.Rel(file), "_test.go") {
-			continue
-		}
-		rel := p.Rel(file)
-		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-			if isSagaEnumConversion(info, call) {
-				return // operand handled by the parent call that receives the conversion
-			}
-			for _, arg := range call.Args {
-				typeName := sagaEnumConstViolation(info, arg)
-				if typeName == "" {
-					continue // allowed: non-constant, not an enum, or valid frozen executor const
-				}
-				diags = append(diags, Diagnostic{
-					Rel:  rel,
-					Line: p.Fset.Position(arg.Pos()).Line,
-					Message: "inline constant of saga label enum " + typeName +
-						" reaches a metric label — pass a declared executor." + typeName +
-						" const (or a classify() result), not a string literal or " +
-						typeName + "(...) conversion (SAGA-METRIC-LABEL-VALUES-FROZEN-01 callsite guard)",
-				})
-			}
-		})
-	}
-	return diags
-}
-
-// scanSagaEnumLabelAssignments flags any variable declaration or assignment
-// whose LHS has a frozen executor label-enum type and whose RHS is an inline
-// constant that is NOT a valid frozen executor declared-const reference.  This
-// catches the F2 variable-relay bypass: `var x LeaderSkipReason = "typo"` has
-// tv.Value==nil at the callsite (it is a var), so the callsite guard cannot see
-// the violation; we flag it at the assignment site instead.
-func scanSagaEnumLabelAssignments(p *Pass) []Diagnostic {
-	info := p.TypesInfo
-	if info == nil {
-		return nil
-	}
-	var diags []Diagnostic
-	for _, file := range p.Files {
-		if strings.HasSuffix(p.Rel(file), "_test.go") {
-			continue
-		}
-		rel := p.Rel(file)
-		// Walk var declarations only. const GenDecls are EXCLUDED: the executor
-		// package's own enum const block (`const TickClaimed TickResult = "claimed"`
-		// …) IS the frozen-set source of truth — those declarations are enumerated
-		// by collectSagaEnumConsts and value-frozen by A1, so flagging them here
-		// would be a false positive on the canonical definitions. Only `var`
-		// laundering (`var x EnumType = "typo"`) is a bypass of the callsite guard.
-		EachInSubtree[ast.GenDecl](file, func(gd *ast.GenDecl) {
-			if gd.Tok != token.VAR {
-				return
-			}
-			scanner.EachInChildren[ast.ValueSpec](gd, func(vs *ast.ValueSpec) {
-				for i, val := range vs.Values {
-					// Determine the type of the LHS.  For `var x EnumType = expr`,
-					// the type is recorded on the Ident in vs.Names[i].
-					if i >= len(vs.Names) {
-						continue
-					}
-					lhsTV, ok := info.Types[vs.Names[i]]
-					if !ok {
-						// Fallback: check the spec-level type expression if present.
-						if vs.Type == nil {
-							continue
-						}
-						lhsTV, ok = info.Types[vs.Type]
-						if !ok {
-							continue
-						}
-					}
-					if sagaEnumTypeName(lhsTV.Type) == "" {
-						continue // LHS is not a frozen enum type
-					}
-					typeName := sagaEnumConstViolation(info, val)
-					if typeName == "" {
-						continue // RHS is non-constant or a valid frozen executor const
-					}
-					diags = append(diags, Diagnostic{
-						Rel:  rel,
-						Line: p.Fset.Position(val.Pos()).Line,
-						Message: "variable of saga label enum " + typeName +
-							" initialized from an inline constant — use a declared executor." +
-							typeName + " const or a classify() result to avoid laundering " +
-							"an arbitrary value into the frozen set (SAGA-METRIC-LABEL-VALUES-FROZEN-01 assignment guard)",
-					})
-				}
-			})
-		})
-		// Walk AssignStmt nodes (x = expr or x := expr).
-		EachInSubtree[ast.AssignStmt](file, func(as *ast.AssignStmt) {
-			for i, rhs := range as.Rhs {
-				if i >= len(as.Lhs) {
-					continue
-				}
-				lhsTV, ok := info.Types[as.Lhs[i]]
-				if !ok {
-					continue
-				}
-				if sagaEnumTypeName(lhsTV.Type) == "" {
-					continue // LHS is not a frozen enum type
-				}
-				typeName := sagaEnumConstViolation(info, rhs)
-				if typeName == "" {
-					continue
-				}
-				diags = append(diags, Diagnostic{
-					Rel:  rel,
-					Line: p.Fset.Position(rhs.Pos()).Line,
-					Message: "variable of saga label enum " + typeName +
-						" assigned from an inline constant — use a declared executor." +
-						typeName + " const or a classify() result to avoid laundering " +
-						"an arbitrary value into the frozen set (SAGA-METRIC-LABEL-VALUES-FROZEN-01 assignment guard)",
-				})
-			}
-		})
-	}
-	return diags
-}
-
-// scanSagaEnumLabelAll runs both the callsite guard and the assignment guard on
-// a single Pass and merges the diagnostics.  Used by the production baseline and
-// by combined fixture tests.
-func scanSagaEnumLabelAll(p *Pass) []Diagnostic {
-	return append(scanSagaEnumLabelCallsites(p), scanSagaEnumLabelAssignments(p)...)
-}
-
 // TestSagaMetricLabelValuesFrozen01_CallsiteGuard is the production GREEN
 // baseline: every saga label enum value reaching a callsite or assigned to a
 // variable is a frozen executor declared const or a non-constant expression
 // (classifyLeaderSkip output / direct executor.Tick* const).
 func TestSagaMetricLabelValuesFrozen01_CallsiteGuard(t *testing.T) {
 	t.Parallel()
-	var allDiags []Diagnostic
-	Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
-		allDiags = append(allDiags, scanSagaEnumLabelAll(p)...)
-		return nil
-	})
-	Report(t, "SAGA-METRIC-LABEL-VALUES-FROZEN-01", allDiags)
+	diags := CheckSagaMetricLabelValuesFrozen(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
+	Report(t, "SAGA-METRIC-LABEL-VALUES-FROZEN-01", diags)
 }
 
 // TestSagaMetricLabelValuesFrozen01_NegativeControl proves the freeze comparison

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -146,14 +146,16 @@ import (
 // ref: tools/archtest/aftercommit_pure_transient_test.go (sibling purity pattern).
 // ref: .claude/rules/gocell/ai-robust.md §"typed marker funnel for unbounded ops".
 
-// TestSagaStepCompensatePure_A1_NoForbiddenCallsInCompensateBody asserts no
-// production CompensateFunc slot (literal or named func) calls a banned receiver
-// method. In PR-06 there are zero CompensateFunc assignments in production, so
-// this fires 0 diagnostics; it guards future Compensate authors.
-func TestSagaStepCompensatePure_A1_NoForbiddenCallsInCompensateBody(t *testing.T) {
+// TestSagaStepCompensatePure_CheckDogfood exercises the aggregate registered
+// CellRule CheckSagaStepCompensatePure (A1 forbidden-calls + B1 body-count + B2
+// MethodByName + B3 CompensateFunc-arg, over the consumer-scan contract) against
+// GoCell production — proving the importable surface is reachable and clean (0
+// diagnostics; there are zero CompensateFunc assignments in production today).
+// The focused A1/B1/B2/B3 detectors keep their own granular tests + RED fixtures.
+func TestSagaStepCompensatePure_CheckDogfood(t *testing.T) {
 	t.Parallel()
-	diags := CheckSagaStepCompensatePure(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
-	Report(t, sagaCompensatePureRuleID+"-A1", diags)
+	Report(t, sagaCompensatePureRuleID,
+		CheckSagaStepCompensatePure(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // TestSagaStepCompensatePure_BlindSpot_B1_BodyStatementCount asserts no
@@ -198,33 +200,7 @@ func TestSagaStepCompensatePure_BlindSpot_B2_NoMethodByNameInCompensateBodies(t 
 			if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
 				continue
 			}
-			assignments := collectCompensateAssignments(p, file)
-			rel := p.Rel(file)
-			for _, a := range assignments {
-				var body *ast.BlockStmt
-				switch {
-				case a.Lit != nil:
-					body = a.Lit.Body
-				case a.NamedIdent != nil:
-					if obj, ok := p.TypesInfo.ObjectOf(a.NamedIdent).(*types.Func); ok {
-						if fd, ok2 := funcDecls[obj]; ok2 {
-							body = fd.Body
-						}
-					}
-				}
-				if body == nil {
-					continue
-				}
-				EachInSubtree[ast.SelectorExpr](body, func(sel *ast.SelectorExpr) {
-					if sel.Sel.Name == "MethodByName" {
-						out = append(out, sagaDiag(p, sel, rel,
-							sagaCompensatePureRuleID+"-B2 (blind-spot guard): "+
-								"MethodByName call inside a CompensateFunc body; "+
-								"reflection-based dispatch is a B2 blind spot — "+
-								"call-graph upgrade tracked in gh issue #1182"))
-					}
-				})
-			}
+			out = append(out, scanCompensateMethodByName(p, file, funcDecls)...)
 		}
 		return out
 	})
@@ -246,36 +222,16 @@ func TestSagaStepCompensatePure_BlindSpot_B2_NoMethodByNameInCompensateBodies(t 
 // forbidden.
 func TestSagaStepCompensatePure_BlindSpot_B3_NoCompensateFuncPassedAsArgument(t *testing.T) {
 	t.Parallel()
-	// The one sanctioned call site: executor passes step.Compensate to safeRunCompensate.
-	const sanctionedCallee = "safeRunCompensate"
 	diags := Run(t, Production(TypedOpts{Tags: FlatNonDefaultTags()}), func(p *Pass) []Diagnostic {
 		if p.TypesInfo == nil {
 			return nil
 		}
 		var out []Diagnostic
 		for _, file := range p.Files {
-			rel := filepath.ToSlash(p.Rel(file))
-			if strings.HasSuffix(rel, "_test.go") {
+			if strings.HasSuffix(filepath.ToSlash(p.Rel(file)), "_test.go") {
 				continue
 			}
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == sanctionedCallee {
-					return
-				}
-				if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == sanctionedCallee {
-					return
-				}
-				for _, arg := range call.Args {
-					if typ := p.TypesInfo.TypeOf(arg); typ != nil && isCompensateFuncType(typ) {
-						out = append(out, sagaDiag(p, arg, p.Rel(file),
-							sagaCompensatePureRuleID+"-B3 (blind-spot guard): "+
-								"CompensateFunc value passed as a function argument outside "+
-								"the safeRunCompensate transport funnel; "+
-								"B3 bodies are not scanned — use the typed-slot assignment forms "+
-								"(forms 1–5) until call-graph support lands (gh issue #1182)"))
-					}
-				}
-			})
+			out = append(out, scanCompensateFuncArg(p, file)...)
 		}
 		return out
 	})

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -870,7 +870,7 @@ func TestSagaJournalConformanceEnrollment_REDFixture(t *testing.T) {
 			if p.Pkg == nil {
 				return nil
 			}
-			if p.Pkg.Path() == sagaJournalIfacePkg {
+			if p.Pkg.Path() == sagaJournalPkg {
 				if obj := p.Pkg.Scope().Lookup(sagaJournalIfaceName); obj != nil {
 					if named, ok := obj.Type().(*types.Named); ok {
 						if i, ok := named.Underlying().(*types.Interface); ok {
@@ -1065,7 +1065,7 @@ func TestSagaGlobalReaderConformanceEnrollment_REDFixture(t *testing.T) {
 			if p.Pkg == nil {
 				return nil
 			}
-			if p.Pkg.Path() == sagaJournalIfacePkg {
+			if p.Pkg.Path() == sagaJournalPkg {
 				if obj := p.Pkg.Scope().Lookup(sagaGlobalReaderIfaceName); obj != nil {
 					if named, ok := obj.Type().(*types.Named); ok {
 						if i, ok := named.Underlying().(*types.Interface); ok {
@@ -1338,49 +1338,8 @@ func useUnrelated() { _ = NewImpl(); run(0, emptyFactory) }
 // other selector named "JournalCore" without type information.
 func TestSagaJournalHolderSeal_A1_OnlyCoordinatorHoldsJournal(t *testing.T) {
 	t.Parallel()
-
-	diags := Run(t, Typed(TypedOpts{Tests: false}, []string{"./runtime/saga/..."}), func(p *Pass) []Diagnostic {
-		if p.TypesInfo == nil {
-			return nil
-		}
-		var out []Diagnostic
-		for _, file := range p.Files {
-			rel := filepath.ToSlash(p.Rel(file))
-			if strings.HasSuffix(rel, "_test.go") {
-				continue
-			}
-			if !strings.HasPrefix(rel, "runtime/saga/") {
-				continue
-			}
-
-			EachInSubtree[ast.TypeSpec](file, func(ts *ast.TypeSpec) {
-				st, ok := ts.Type.(*ast.StructType)
-				if !ok || st.Fields == nil {
-					return
-				}
-				holderName := ts.Name.Name
-				for _, field := range st.Fields.List {
-					if d, ok := journalFieldSealDiag(p, rel, holderName, field); ok {
-						out = append(out, d)
-						continue
-					}
-					if d, ok := heartbeatFuncFieldDiag(p, rel, holderName, field); ok {
-						out = append(out, d)
-					}
-				}
-			})
-		}
-		return out
-	})
-
+	diags := CheckSagaJournalHolderSeal(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()})
 	Report(t, sagaJournalHolderSealRule+"-A1", diags)
-}
-
-// TestSagaJournalHolderSeal_CheckDogfood exercises the aggregate CheckSagaJournalHolderSeal
-// on GoCell production (must yield 0 diags), verifying the importable Check* surface.
-func TestSagaJournalHolderSeal_CheckDogfood(t *testing.T) {
-	t.Parallel()
-	Report(t, sagaJournalHolderSealRule, CheckSagaJournalHolderSeal(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
 // TestSagaJournalHolderSeal_BlindSpot_B1_NoAliasInRuntimeSaga ensures production
@@ -2722,9 +2681,8 @@ func TestSagaStepRunOutsideTx_Detector_RedSafeRunInRunInTxFixture(t *testing.T) 
 	AssertGolden(t, filepath.Join(root, relDir, "diag.golden"), diags)
 }
 
-// posInRanges (package-level, defined in span_record_error_redact_test.go) and
-// collectFuncBodyRanges (defined in span_setattr_redact_test.go) are reused
-// directly — both are visible within the archtest package.
+// posInRanges and collectFuncBodyRanges are defined in shared_helpers.go and
+// reused directly — both are visible within the archtest package.
 
 // ============================================================================
 // SAGA-CONSTRUCTOR-NIL-GUARD-01   (type-aware, Medium)

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -3172,8 +3172,12 @@ const sagaConsolidatedFile = "saga_invariants_test.go"
 // sagaConsolidatedFileMinIDs is the floor for the non-vacuous guard: the
 // consolidated file must declare at least this many SAGA-* IDs, else a
 // rename/empty/scan-regression would let TestSagaInvariantsConsolidated pass
-// vacuously. 3 is the structural floor (well below the actual 9 declared today).
-const sagaConsolidatedFileMinIDs = 3
+// vacuously. Derived from knownSagaInvariantIDs (the full saga theme set) so the
+// floor tightens automatically as rules are added; the B1 oracle
+// (TestSagaInvariantsConsolidated_BlindSpot_KnownIDsPresent) is the stronger
+// per-ID check, this is the count backstop. (var, not const: len of a slice is
+// not a constant expression.)
+var sagaConsolidatedFileMinIDs = len(knownSagaInvariantIDs)
 
 // sagaThemePrefix is the theme key the consolidation guard scans for: a saga
 // INVARIANT is any anchor whose parsed ID carries this prefix (the SAGA- family

--- a/tools/archtest/shared_helpers.go
+++ b/tools/archtest/shared_helpers.go
@@ -1,0 +1,104 @@
+package archtest
+
+// shared_helpers.go — small utility functions used by both non-test rule
+// implementations (saga_invariants.go, etc.) and _test.go files.
+//
+// Functions that are needed in a non-test .go file cannot be defined only in
+// a _test.go file (Go never compiles _test.go when the package is imported).
+// This file holds the subset of helpers that crossed the boundary.
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+)
+
+// itoa converts n to its decimal string representation without importing
+// strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// sliceOrNone renders s as "[a, b, c]" or "(none)" when empty.
+func sliceOrNone(s []string) string {
+	if len(s) == 0 {
+		return "(none)"
+	}
+	return "[" + strings.Join(s, ", ") + "]"
+}
+
+// collectFuncBodyRanges returns (Lbrace, Rbrace) token.Pos pairs for every
+// FuncDecl whose name is in allowedNames. Used to check whether a node's Pos
+// falls inside a sanctioned function body (see posInRanges).
+func collectFuncBodyRanges(file *ast.File, allowedNames ...string) []token.Pos {
+	allowed := make(map[string]struct{}, len(allowedNames))
+	for _, n := range allowedNames {
+		allowed[n] = struct{}{}
+	}
+	var ranges []token.Pos
+	EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+		if fn.Body == nil || fn.Name == nil {
+			return
+		}
+		if _, ok := allowed[fn.Name.Name]; !ok {
+			return
+		}
+		ranges = append(ranges, fn.Body.Lbrace, fn.Body.Rbrace)
+	})
+	return ranges
+}
+
+// posInRanges reports whether p falls within any (Lbrace, Rbrace) pair in
+// ranges (as produced by collectFuncBodyRanges).
+func posInRanges(p token.Pos, ranges []token.Pos) bool {
+	for i := 0; i+1 < len(ranges); i += 2 {
+		if p >= ranges[i] && p <= ranges[i+1] {
+			return true
+		}
+	}
+	return false
+}
+
+// isContextType reports whether t is context.Context.
+func isContextType(t types.Type) bool {
+	iface, ok := t.Underlying().(*types.Interface)
+	if !ok {
+		return false
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	_ = iface
+	return named.Obj() != nil && named.Obj().Name() == "Context" &&
+		named.Obj().Pkg() != nil && named.Obj().Pkg().Path() == "context"
+}
+
+// isTimeDurationType reports whether t is time.Duration.
+func isTimeDurationType(t types.Type) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	return named.Obj() != nil && named.Obj().Name() == "Duration" &&
+		named.Obj().Pkg() != nil && named.Obj().Pkg().Path() == "time"
+}

--- a/tools/archtest/shared_helpers.go
+++ b/tools/archtest/shared_helpers.go
@@ -14,30 +14,6 @@ import (
 	"strings"
 )
 
-// itoa converts n to its decimal string representation without importing
-// strconv.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}
-
 // sliceOrNone renders s as "[a, b, c]" or "(none)" when empty.
 func sliceOrNone(s []string) string {
 	if len(s) == 0 {
@@ -80,15 +56,13 @@ func posInRanges(p token.Pos, ranges []token.Pos) bool {
 
 // isContextType reports whether t is context.Context.
 func isContextType(t types.Type) bool {
-	iface, ok := t.Underlying().(*types.Interface)
-	if !ok {
+	if _, ok := t.Underlying().(*types.Interface); !ok {
 		return false
 	}
 	named, ok := t.(*types.Named)
 	if !ok {
 		return false
 	}
-	_ = iface
 	return named.Obj() != nil && named.Obj().Name() == "Context" &&
 		named.Obj().Pkg() != nil && named.Obj().Pkg().Path() == "context"
 }

--- a/tools/archtest/span_record_error_seal_test.go
+++ b/tools/archtest/span_record_error_seal_test.go
@@ -103,17 +103,6 @@ func redactionLocalName(file *ast.File) string {
 	return ""
 }
 
-// posInRanges reports whether p is inside any of the flat [start,end] pairs
-// in ranges. Pairs are flat: even indices are start, odd are end positions.
-func posInRanges(p token.Pos, ranges []token.Pos) bool {
-	for i := 0; i+1 < len(ranges); i += 2 {
-		if p >= ranges[i] && p <= ranges[i+1] {
-			return true
-		}
-	}
-	return false
-}
-
 // recordErrorSinkFile is the module-relative path to the adapter file whose
 // otelSpan.RecordError body is the single sanctioned funnel for all
 // oteltrace.Span.RecordError calls in adapters/otel.

--- a/tools/archtest/span_setattr_redact_test.go
+++ b/tools/archtest/span_setattr_redact_test.go
@@ -73,7 +73,6 @@ package archtest
 
 import (
 	"go/ast"
-	"go/token"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -185,27 +184,6 @@ func selectorMatches(sel *ast.SelectorExpr, xName, selName string) bool {
 		return false
 	}
 	return x.Name == xName
-}
-
-// collectFuncBodyRanges returns the body Pos/End pairs of every FuncDecl in
-// file whose Name matches one of allowedNames. Pairs are flat: even indices
-// are start positions, odd indices are end positions.
-func collectFuncBodyRanges(file *ast.File, allowedNames ...string) []token.Pos {
-	allowed := make(map[string]struct{}, len(allowedNames))
-	for _, n := range allowedNames {
-		allowed[n] = struct{}{}
-	}
-	var ranges []token.Pos
-	EachInSubtree[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
-		if fn.Body == nil || fn.Name == nil {
-			return
-		}
-		if _, ok := allowed[fn.Name.Name]; !ok {
-			return
-		}
-		ranges = append(ranges, fn.Body.Lbrace, fn.Body.Rbrace)
-	})
-	return ranges
 }
 
 // onlyReturn returns the single *ast.ReturnStmt at depth-1 of fn.Body.

--- a/tools/archtest/tenant_repo_param_funnel_test.go
+++ b/tools/archtest/tenant_repo_param_funnel_test.go
@@ -179,16 +179,6 @@ func isTenantIDType(t types.Type) bool {
 	return obj.Pkg() != nil && obj.Pkg().Path() == tenantPkgPath && obj.Name() == "TenantID"
 }
 
-// isContextType reports whether t is context.Context (interface).
-func isContextType(t types.Type) bool {
-	named, ok := t.(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj.Pkg() != nil && obj.Pkg().Path() == "context" && obj.Name() == "Context"
-}
-
 // tenantIDAtPosition1 asserts the typed positional contract for tenant-scoped
 // repo methods:
 //

--- a/tools/archtest/testdata/module_path_funnel.baseline
+++ b/tools/archtest/testdata/module_path_funnel.baseline
@@ -59,7 +59,6 @@ tools/archtest/required_dep_nil_guard_test.go
 tools/archtest/reverse_coverage_invariants_test.go
 tools/archtest/rmq_invariants_test.go
 tools/archtest/safeid_funnel_test.go
-tools/archtest/saga_invariants_test.go
 tools/archtest/security_defaults_test.go
 tools/archtest/seed_role_iface_test.go
 tools/archtest/serviceowned_handler_owner_check_test.go


### PR DESCRIPTION
## Summary

M3 PR-4: migrate the 13 `SAGA-*` archtest invariants out of the 5968-line `saga_invariants_test.go` into an importable, module-path-agnostic CellRule form, and ratchet the `ARCHTEST-MODULE-PATH-FUNNEL-01` baseline down by one line.

## Why / 背景

`saga_invariants_test.go` hardcoded the platform module path (`github.com/ghbvf/gocell/...`) in rule logic and kept that logic in a `_test.go` — so an external Cell repo could neither import the rules nor run them fork-safely (Go never compiles a dependency's `_test.go`). This is the highest-split-risk batch of the #1302 M3 sweep (giant consolidated file, constrained by `SAGA-INVARIANTS-FILE-CONSOLIDATED-01`). Following the recipe established in #1084 PR-1 / the errcode family (`a8bb9df92`).

What changed:
- **New `saga_invariants.go`** — 11 importable `Check*` funcs (bucket-1 `COMPENSATE-PURE` + bucket-2 ×10) + their scanner/helper logic; every platform-symbol path derived from `PlatformModulePath`. `SAGA-STEP-COMPENSATE-PURE-01` registered in `StandardCellRules()`; the 10 internal-layout / conformance-enrollment rules stay importable-but-unregistered (vacuous/false-red externally), documented in the `StandardCellRules` godoc.
- **`saga_invariants_test.go`** dogfoods the same `Check*` (single source): single-part detectors call `Check*` directly; multi-part rules keep their granular `An/Bn` tests + add an aggregate `_CheckDogfood`. All `// INVARIANT: SAGA-*` anchors + `Test*` stay here. `SAGA-STATUS-FANOUT-COVERAGE-01` + `SAGA-INVARIANTS-FILE-CONSOLIDATED-01` (golden/meta-bound, like errcode `PREFIX-OWNERSHIP`/`CARVEOUT`) stay test-only, literals derived in place.
- **New `shared_helpers.go`** — helpers the non-test `Check*` need but that previously lived only in `*_test.go` (`posInRanges`, `collectFuncBodyRanges`, `isContextType`, `isTimeDurationType`, `itoa`, `sliceOrNone`) relocated from span/clock/tenant/healthcheck/outbox test files — single source, no duplication.
- **baseline** — drop the `saga_invariants_test.go` line (ratchet-down).

AI-robust ratings preserved: detection logic **moved, not rewritten**; drivers/scopes kept exactly; `collectSagaJournalImpls` keeps the `typesutil.ImplementsInterface` funnel (`TYPESUTIL-IMPLEMENTS-FUNNEL-01`), not raw `go/types.Implements`. Behavior zero-change is proven by the existing saga tests + RED fixtures staying GREEN and the baseline ratchet flipping to GREEN.

## Refs

Closes #1634
ref: tools/archtest/errcode_invariants.go (migration recipe, #1302 / a8bb9df92)

## Risk / 兼容性

- **Test-infra only** — no production code touched; all changes under `tools/archtest/`. No contract / wire / DB / errcode changes (contract-fanout not triggered).
- **Larger blast radius than a single file**: relocating shared helpers into `shared_helpers.go` touches 5 unrelated rule test files (clock/healthcheck/tenant/span×2/outbox). This is the recipe's no-duplication consequence; all affected rules' tests pass.
- API surface grows: 11 new exported `CheckSaga*` funcs + `StandardCellRules()` gains `SAGA-STEP-COMPENSATE-PURE-01`.
- Pre-existing develop archtest violations (e.g. `kernel/webhook → kernel/observability` DAG, a bare `require.Eventually` in `adapters/grpc`) surface when running the full `go test ./tools/archtest/` in one process; they are **unrelated to this PR** (identical on the clean base) and out of scope. PR-time CI runs the 4 core invariants + governance, not the full suite.

## Test plan

- [x] `go build ./tools/archtest/...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./tools/archtest/` — saga + `TestArchtestModulePathFunnel` (ratchet GREEN) + `TestRunStandardCellRules`/`TestStandardCellRulesComposition` + the 5 touched rules + scaffold all pass; rebased onto current develop and re-verified
- [x] `golangci-lint run ./tools/archtest/...` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
