### PR TITLE
refactor(webhook): funnel 加固 — sealed SignedHeaders + HMAC FullName/A4 + loopback guard [#1492][#1493][#1243][#1378]

### DIFF
--- a/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
+++ b/docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md
@@ -209,14 +209,18 @@ enum suitable for a future `{reason}` metric label —
 `errors.As(err, &ec) && ec.Code == ErrWebhookSSRFBlocked` at the
 `Transport`/`CheckRedirect` error boundary.
 
-**`WithAllowLoopback` production guard.** The option is dev/CI-only and guarded
-today only by godoc (a Soft constraint). PR-5's wiring layer (corebundle /
-assembly) must not pass it; a Medium archtest banning `WithAllowLoopback`
-references in non-`_test.go` production files should land with PR-5 once there is
-a production callsite to guard (tracked: gh #1378). The upstream
-holder-axis Hard-ization remains a won't-do permanent ceiling (#1375); PR-5 adds
-the dispatcher-specific `Dispatcher.client` typed-field lock as the practical
-upstream tightening.
+**`WithAllowLoopback` production guard.** The option is dev/CI-only.
+**Amendment 2026-06-07 (#1378):** the prior Soft godoc-only constraint is now a
+**Medium archtest** `WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01` — any reference to
+`webhook.WithAllowLoopback` in a non-`_test.go` production file fails CI (today
+vacuous green: every caller is a kernel/webhook same-package test). The wiring
+layer (corebundle / assembly) must not pass it. The stronger Hard form —
+unexporting to `withAllowLoopback` so an external reference is a Go compile error
+(achievable today, all callers being same-package tests) — is deliberately
+deferred to preserve the dev escape hatch / future cross-package integration
+tests, tracked at gh #1730 and named in the archtest godoc per the AI-robust
+§Funnel 双向锁评级 requirement. The SSRF holder-axis Hard-ization (the dispatcher
+egress holder) remains the separate won't-do permanent ceiling #1375.
 
 ## References
 

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -129,23 +129,30 @@ HMAC-SHA256, and the `v1,<base64>` token format are identical to the signer
 implementation (`kernel/webhook/signer.go`) and are Svix/standard-webhooks
 aligned; only the header names are GoCell's deliberate choice.
 
-The sole writer of these headers in the codebase is `(webhook.Headers).Apply`
-(`kernel/webhook/webhook.go`), locked downstream by archtest
-`WEBHOOK-SIGNER-FUNNEL-01`. No callsite may call `Header.Set` on these header
-name constants directly.
+The sole writer of these headers in the codebase is
+`(webhook.SignedHeaders).Apply` (`kernel/webhook/webhook.go`), locked downstream
+by archtest `WEBHOOK-SIGNER-FUNNEL-01/A1`. No callsite may call `Header.Set` on
+these header name constants directly.
 
 > **Amendment 2026-06-02 (review #1455).** F9: the `WEBHOOK-SIGNER-FUNNEL-01`
 > scan scope used exact package-path matching, which silently excluded the
 > `runtime/webhook/dispatch` subpackage (the consumer layer that actually calls
-> `Headers.Apply`). The scope is now subtree-matched (`base` or `base+"/"`), so
-> the dispatch subpackage and any future subpackage are covered. F5 (open
-> hardening): `webhook.Headers` is still a public struct with exported fields, so
-> a caller could construct `Headers{Signature: …}.Apply(h)` outside `Signer.Sign`
-> — the funnel locks the *header write site*, not *Headers provenance*. Severity
-> is low (a forged `Headers` carries an invalid HMAC the receiver rejects; no
-> secret is exposed). Closing the gap via sealed construction (unexported fields,
-> only `Signer.Sign` produces `Headers`) is tracked as a backlog item, not done
-> in PR-5.
+> `SignedHeaders.Apply`). The scope is now subtree-matched (`base` or `base+"/"`),
+> so the dispatch subpackage and any future subpackage are covered.
+>
+> **Amendment 2026-06-07 (#1492 — provenance gap CLOSED).** F5 (the open hardening
+> noted in the 2026-06-02 amendment) is **resolved**. Previously `Apply` lived on
+> the public `webhook.Headers` struct with exported fields, so a caller could
+> construct `Headers{Signature: …}.Apply(h)` outside `Signer.Sign` — the funnel
+> locked only the *write site*, not *provenance*. #1492 split the type: the inbound
+> parse DTO stays `webhook.Headers` (untrusted by design — a forged inbound Headers
+> just fails `Verify`), while the OUTBOUND value `Apply` writes is the new sealed
+> `webhook.SignedHeaders` (unexported fields, no exported constructor, produced
+> only by `Signer.Sign` — sealed construction). Outside-package literal forge is
+> now a Go compile error; the field set is reflect-frozen by
+> `WEBHOOK-SIGNER-FUNNEL-01/A2`. **Upstream is now Hard (external)**; the only
+> residual is the package-internal holder axis (a same-package `SignedHeaders{…}`
+> literal), the permanent Go ceiling shared with #851/#893/#1282/#1375.
 
 ### D5 — Schedule is the canonical default seam; per-attempt wall-clock delays and RetryCount are NOT yet wired (explicit boundary + tracked follow-up)
 

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -140,19 +140,25 @@ these header name constants directly.
 > `SignedHeaders.Apply`). The scope is now subtree-matched (`base` or `base+"/"`),
 > so the dispatch subpackage and any future subpackage are covered.
 >
-> **Amendment 2026-06-07 (#1492 — provenance gap CLOSED).** F5 (the open hardening
-> noted in the 2026-06-02 amendment) is **resolved**. Previously `Apply` lived on
-> the public `webhook.Headers` struct with exported fields, so a caller could
-> construct `Headers{Signature: …}.Apply(h)` outside `Signer.Sign` — the funnel
-> locked only the *write site*, not *provenance*. #1492 split the type: the inbound
-> parse DTO stays `webhook.Headers` (untrusted by design — a forged inbound Headers
-> just fails `Verify`), while the OUTBOUND value `Apply` writes is the new sealed
-> `webhook.SignedHeaders` (unexported fields, no exported constructor, produced
-> only by `Signer.Sign` — sealed construction). Outside-package literal forge is
-> now a Go compile error; the field set is reflect-frozen by
-> `WEBHOOK-SIGNER-FUNNEL-01/A2`. **Upstream is now Hard (external)**; the only
-> residual is the package-internal holder axis (a same-package `SignedHeaders{…}`
-> literal), the permanent Go ceiling shared with #851/#893/#1282/#1375.
+> **Amendment 2026-06-07 (#1492 + #1733 F1 — provenance gap CLOSED).** F5 (the open
+> hardening noted in the 2026-06-02 amendment) is **resolved**. Previously `Apply`
+> lived on the public `webhook.Headers` struct with exported fields, so a caller
+> could construct `Headers{Signature: …}.Apply(h)` outside `Signer.Sign` — the
+> funnel locked only the *write site*, not *provenance*. #1492 split the type: the
+> inbound parse DTO stays `webhook.Headers` (untrusted by design — a forged inbound
+> Headers just fails `Verify`), while the OUTBOUND value `Apply` writes is the
+> sealed `webhook.SignedHeaders`. A POPULATED outside-package literal
+> (`SignedHeaders{signature: …}`) is a Go compile error (unexported fields), but
+> unexported fields alone do NOT stop a ZERO-value construction
+> (`var h webhook.SignedHeaders`) — the residual gap **review #1733 F1** caught
+> (the original "closed" claim was itself an overclaim). The closure is an
+> unexported `valid` provenance flag that ONLY `Signer.Sign` sets, with `Apply`
+> fail-closing (writing nothing) when `valid==false`; external code can set neither
+> a populated literal nor `valid`, so only a Sign-produced SignedHeaders writes to
+> the wire. The field set (incl. `valid`) is reflect-frozen by
+> `WEBHOOK-SIGNER-FUNNEL-01/A2`. **Upstream is now genuinely Hard (external)**; the
+> only residual is the package-internal holder axis (`SignedHeaders{valid: true}`
+> in-package), the permanent Go ceiling shared with #851/#893/#1282/#1375.
 
 ### D5 — Schedule is the canonical default seam; per-attempt wall-clock delays and RetryCount are NOT yet wired (explicit boundary + tracked follow-up)
 

--- a/examples/webhookdemo/README.md
+++ b/examples/webhookdemo/README.md
@@ -76,10 +76,10 @@ sourceID, err := webhook.NewSourceID("demosource")          // handle err
 src, err := webhook.NewSource(sourceID, secret)             // handle err
 signer, err := webhook.NewHMACSigner(src)                   // handle err
 did, err := webhook.NewDeliveryID("delivery-1")             // handle err
-headers, err := signer.Sign(body, time.Now(), did)         // handle err
-req.Header.Set("Webhook-Delivery-Id", string(headers.DeliveryID))
-req.Header.Set("Webhook-Timestamp", headers.Timestamp)
-req.Header.Set("Webhook-Signature", headers.Signature)
+signed, err := signer.Sign(body, time.Now(), did)          // handle err — returns webhook.SignedHeaders
+req.Header.Set("Webhook-Delivery-Id", string(signed.DeliveryID())) // read-only accessors
+req.Header.Set("Webhook-Timestamp", signed.Timestamp())
+req.Header.Set("Webhook-Signature", signed.Signature())
 ```
 
 > The demo seeds a single hardcoded source secret in `run.go` for convenience.

--- a/examples/webhookdemo/webhook_e2e_test.go
+++ b/examples/webhookdemo/webhook_e2e_test.go
@@ -19,10 +19,10 @@ import (
 // Contract-declared inbound path + signature header names
 // (contracts/webhook/demo/events/v1/contract.yaml). The receiver reads the
 // signature from THESE contract-declared header names, so the test sets them
-// explicitly rather than using kwh.Headers.Apply, which writes the fixed
-// outbound (signer-side) header constants kwh.HeaderID/HeaderTimestamp/
-// HeaderSignature — a different set from a contract's inbound header names in
-// the general case.
+// explicitly (via the SignedHeaders read-only accessors) rather than using
+// kwh.SignedHeaders.Apply, which writes the fixed outbound (signer-side) header
+// constants kwh.HeaderID/HeaderTimestamp/HeaderSignature — a different set from a
+// contract's inbound header names in the general case.
 const (
 	e2ePath       = "/api/webhooks/demo/events"
 	hdrDeliveryID = "Webhook-Delivery-Id"
@@ -110,9 +110,9 @@ func TestWebhookdemoE2E(t *testing.T) {
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodPost, webhookURL+e2ePath, bytes.NewReader(payload))
 		require.NoError(t, err)
-		req.Header.Set(hdrDeliveryID, string(headers.DeliveryID))
-		req.Header.Set(hdrTimestamp, headers.Timestamp)
-		req.Header.Set(hdrSignature, headers.Signature)
+		req.Header.Set(hdrDeliveryID, string(headers.DeliveryID()))
+		req.Header.Set(hdrTimestamp, headers.Timestamp())
+		req.Header.Set(hdrSignature, headers.Signature())
 		return req
 	}
 	newSignedReq := func(t *testing.T, deliveryID string) *http.Request {

--- a/kernel/webhook/dispatcher.go
+++ b/kernel/webhook/dispatcher.go
@@ -226,7 +226,7 @@ func (d *Dispatcher) prepare(ctx context.Context, entry outbox.Entry) (*http.Req
 		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
 			"webhook dispatcher: outbox entry id is not a valid delivery id", err))
 	}
-	headers, err := d.signer.Sign(payload, d.clk.Now(), deliveryID)
+	signed, err := d.signer.Sign(payload, d.clk.Now(), deliveryID)
 	if err != nil {
 		return nil, outbox.Reject(errcode.Wrap(errcode.KindInvalid, errcode.ErrWebhookPermanentFailure,
 			"webhook dispatcher: signing failed", err))
@@ -238,7 +238,7 @@ func (d *Dispatcher) prepare(ctx context.Context, entry outbox.Entry) (*http.Req
 			"webhook dispatcher: build request failed", err))
 	}
 	req.Header.Set("Content-Type", "application/json")
-	headers.Apply(req.Header) // SOLE sanctioned signature-header writer.
+	signed.Apply(req.Header) // SOLE sanctioned signature-header writer.
 	return req, outbox.Ack()
 }
 

--- a/kernel/webhook/dispatcher_test.go
+++ b/kernel/webhook/dispatcher_test.go
@@ -257,8 +257,8 @@ func TestDispatcher_Handle_StatusMapping_408Requeue(t *testing.T) {
 // It implements sealed() because this file is package webhook (white-box).
 type errSigner struct{}
 
-func (errSigner) Sign(_ []byte, _ time.Time, _ DeliveryID) (Headers, error) {
-	return Headers{}, errors.New("inject signer error")
+func (errSigner) Sign(_ []byte, _ time.Time, _ DeliveryID) (SignedHeaders, error) {
+	return SignedHeaders{}, errors.New("inject signer error")
 }
 func (errSigner) sealed() {}
 

--- a/kernel/webhook/doc.go
+++ b/kernel/webhook/doc.go
@@ -23,12 +23,18 @@
 //     with no getter, and [Source.LogValue] redacts it, so a webhook secret
 //     can never reach slog/spans by accident — see the secret-leak defenses
 //     below.
-//   - [Headers] — the wire signature headers (delivery id, timestamp,
-//     signature) produced by a [Signer] and consumed by a [Verifier].
+//   - [Headers] — the INBOUND signature-header DTO (delivery id, timestamp,
+//     signature) that a [Verifier] consumes; the receiver builds it from raw
+//     request headers (untrusted input), so its fields are exported.
+//   - [SignedHeaders] — the OUTBOUND, provenance-sealed counterpart that
+//     [Signer.Sign] produces and [SignedHeaders.Apply] writes to the wire. Its
+//     fields are unexported, incl. a `valid` provenance flag only Sign sets, and
+//     Apply fail-closes on a zero value — so only a Sign-produced value reaches
+//     the wire (WEBHOOK-SIGNER-FUNNEL-01 upstream Hard external; #1492 + #1733 F1).
 //   - [Signer] / [Verifier] — sealed interfaces (unexported sealed() marker)
 //     so package-external implementations are a compile error. The sole
 //     in-package implementations are the HMAC-SHA256 signer/verifier built by
-//     [NewHMACSigner] / [NewHMACVerifier].
+//     [NewHMACSigner] / [NewHMACVerifier]; [Signer.Sign] returns a [SignedHeaders].
 //   - [SourceStore] / [SourceRegistry] — secret lookup interface + in-memory
 //     implementation (externally replaceable; persistent stores are a
 //     follow-up).
@@ -50,21 +56,24 @@
 //
 // Enforced by tools/archtest/webhook_hmac_funnel_test.go. Ratings:
 //
-//   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite —
-//     computeMAC in signer.go. Any other hmac.New in this package fails CI.
-//     This also closes the package-internal upstream blind spot: any new struct
-//     that wants to sign MUST call hmac.New, which is allowlisted to signer.go.
+//   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite (by go/types
+//     FullName) — computeMAC. Any other hmac.New in this package fails CI.
 //   - A2 (downstream Hard): signature comparison may only use crypto/hmac.Equal
 //     or crypto/subtle.ConstantTimeCompare; bytes.Equal / == over signature
 //     bytes fails CI (constant-time invariant as an AST lock, not a flaky
 //     timing test).
 //   - A3 (upstream Hard external / Medium internal): [Signer] / [Verifier]
 //     carry an unexported sealed() marker, so external implementations are a
-//     compile error (Hard). Package-internal new holders are not blocked by
-//     sealing (Medium) — covered transitively by A1. The explicit Hard-ization
-//     of the internal axis (unexported method-set interface + private
-//     construction, per the SPAN-SETATTR-HOLDER-SEAL precedent) is tracked in
-//     gh issue #1243; this godoc names it per ai-robust.md §Funnel 双向锁评级.
+//     compile error (Hard external). Package-internal new holders are NOT blocked
+//     by sealing, and A1 does NOT transitively cover them (A1 locks only
+//     crypto/hmac.New, not reuse of the package-level computeMAC helper) — that
+//     internal axis is covered by A4. True type-system Hard for it is a permanent
+//     Go ceiling (same family as #851/#893/#1282/#1375), tracked won't-do at gh
+//     #1243.
+//   - A4 (Medium, internal axis; #1243): every USE of the package-internal
+//     computeMAC symbol (direct/parenthesized call or function-value capture) must
+//     have an enclosing func ∈ {hmacSigner.Sign, hmacVerifier.Verify} — the actual
+//     enforcement of "only the sanctioned signer/verifier may compute a MAC".
 //
 // # Secret-leak defenses (Source.Secret)
 //

--- a/kernel/webhook/signer.go
+++ b/kernel/webhook/signer.go
@@ -71,6 +71,7 @@ func (s *hmacSigner) Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (
 		deliveryID: deliveryID,
 		timestamp:  timestamp,
 		signature:  signature,
+		valid:      true, // provenance flag — only Sign sets it; Apply fail-closes on false.
 	}, nil
 }
 

--- a/kernel/webhook/signer.go
+++ b/kernel/webhook/signer.go
@@ -22,15 +22,15 @@ const (
 	signedContentSep = "."
 )
 
-// Signer produces signature [Headers] for an outbound webhook delivery. The
+// Signer produces a sealed [SignedHeaders] for an outbound webhook delivery. The
 // interface is sealed (unexported sealed() marker): the sole implementation is
 // the HMAC-SHA256 signer from [NewHMACSigner], so package-external types cannot
 // satisfy Signer (WEBHOOK-HMAC-FUNNEL-01/A3 upstream).
 type Signer interface {
-	// Sign computes the signature headers for payload at time ts under
+	// Sign computes the sealed signature headers for payload at time ts under
 	// deliveryID. ts is supplied by the caller (the dispatcher passes its
 	// clock's Now) so the signer holds no clock.
-	Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (Headers, error)
+	Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (SignedHeaders, error)
 	sealed()
 }
 
@@ -60,17 +60,17 @@ func (s *hmacSigner) LogValue() slog.Value {
 	return slog.GroupValue(slog.Any("source", s.source))
 }
 
-func (s *hmacSigner) Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (Headers, error) {
+func (s *hmacSigner) Sign(payload []byte, ts time.Time, deliveryID DeliveryID) (SignedHeaders, error) {
 	if err := deliveryID.Validate(); err != nil {
-		return Headers{}, err
+		return SignedHeaders{}, err
 	}
 	timestamp := strconv.FormatInt(ts.Unix(), 10)
 	mac := computeMAC(s.source.secret, deliveryID, timestamp, payload)
 	signature := signatureSchemeV1 + signatureSchemeSep + base64.StdEncoding.EncodeToString(mac)
-	return Headers{
-		DeliveryID: deliveryID,
-		Timestamp:  timestamp,
-		Signature:  signature,
+	return SignedHeaders{
+		deliveryID: deliveryID,
+		timestamp:  timestamp,
+		signature:  signature,
 	}, nil
 }
 

--- a/kernel/webhook/signer_test.go
+++ b/kernel/webhook/signer_test.go
@@ -49,12 +49,13 @@ func TestSign_MatchesSvixGoldenVector(t *testing.T) {
 
 	tsInt, err := strconv.ParseInt(v.Timestamp, 10, 64)
 	require.NoError(t, err)
-	headers, err := signer.Sign([]byte(v.Payload), time.Unix(tsInt, 0), MustDeliveryID(v.DeliveryID))
+	signed, err := signer.Sign([]byte(v.Payload), time.Unix(tsInt, 0), MustDeliveryID(v.DeliveryID))
 	require.NoError(t, err)
 
-	assert.Equal(t, v.Signature, headers.Signature)
-	assert.Equal(t, v.Timestamp, headers.Timestamp)
-	assert.Equal(t, DeliveryID(v.DeliveryID), headers.DeliveryID)
+	// Same-package test: read SignedHeaders' unexported fields directly.
+	assert.Equal(t, v.Signature, signed.signature)
+	assert.Equal(t, v.Timestamp, signed.timestamp)
+	assert.Equal(t, DeliveryID(v.DeliveryID), signed.deliveryID)
 }
 
 // TestSign_SignerVerifierRoundTrip signs then verifies with the same source.
@@ -67,16 +68,19 @@ func TestSign_SignerVerifierRoundTrip(t *testing.T) {
 
 	ts := time.Unix(1700000000, 0)
 	body := []byte(`{"hello":"world"}`)
-	headers, err := signer.Sign(body, ts, MustDeliveryID("evt_rt"))
+	signed, err := signer.Sign(body, ts, MustDeliveryID("evt_rt"))
 	require.NoError(t, err)
 
 	// Signature must be a well-formed v1 token decoding to 32 MAC bytes.
-	require.True(t, len(headers.Signature) > 3 && headers.Signature[:3] == "v1,")
-	raw, err := base64.StdEncoding.DecodeString(headers.Signature[3:])
+	require.True(t, len(signed.signature) > 3 && signed.signature[:3] == "v1,")
+	raw, err := base64.StdEncoding.DecodeString(signed.signature[3:])
 	require.NoError(t, err)
 	assert.Len(t, raw, 32)
 
 	verifier, err := NewHMACVerifier(clockmockAt(ts))
 	require.NoError(t, err)
-	assert.NoError(t, verifier.Verify(body, headers, src))
+	// Bridge sealed outbound SignedHeaders → inbound Headers (same-package: read
+	// unexported fields) to feed Verify, mirroring the receiver's wire reconstruction.
+	inbound := Headers{DeliveryID: signed.deliveryID, Timestamp: signed.timestamp, Signature: signed.signature}
+	assert.NoError(t, verifier.Verify(body, inbound, src))
 }

--- a/kernel/webhook/ssrf.go
+++ b/kernel/webhook/ssrf.go
@@ -56,6 +56,13 @@ type SafeOption func(*SafePolicy)
 // targets. It is for dev / CI only (e.g. testcontainers) and must never be set
 // in production. It exempts ONLY loopback — every other private/reserved range
 // stays blocked, on both the DialContext and ValidateTargetURL paths.
+//
+// "Must never be set in production" is enforced by the Medium archtest
+// WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01 (#1378): any reference in a non-_test.go
+// production file is a CI failure. The stronger Hard form — unexporting this to
+// `withAllowLoopback` so an external reference is a compile error — is tracked at
+// gh #1730 (deferred to preserve the dev escape hatch / future cross-package
+// integration tests).
 func WithAllowLoopback() SafeOption {
 	return func(p *SafePolicy) { p.allowLoopback = true }
 }

--- a/kernel/webhook/verifier_test.go
+++ b/kernel/webhook/verifier_test.go
@@ -76,8 +76,9 @@ func TestNewHMACVerifier_Options(t *testing.T) {
 		require.NoError(t, err)
 		signer, err := NewHMACSigner(src)
 		require.NoError(t, err)
-		headers, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
+		signed, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
 		require.NoError(t, err)
+		headers := signedToInbound(signed)
 
 		verifier, err := NewHMACVerifier(clockmockAt(base.Add(tenMinutes)), WithTolerance(oneHourTolerance))
 		require.NoError(t, err)
@@ -92,8 +93,9 @@ func TestVerify_Errors(t *testing.T) {
 	require.NoError(t, err)
 	signer, err := NewHMACSigner(src)
 	require.NoError(t, err)
-	good, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
+	signed, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
 	require.NoError(t, err)
+	good := signedToInbound(signed)
 
 	cases := []struct {
 		name     string
@@ -219,8 +221,9 @@ func TestVerify_AcceptsAtExactTolerance(t *testing.T) {
 	require.NoError(t, err)
 	signer, err := NewHMACSigner(src)
 	require.NoError(t, err)
-	good, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
+	signed, err := signer.Sign([]byte("body"), base, MustDeliveryID("d1"))
 	require.NoError(t, err)
+	good := signedToInbound(signed)
 
 	// Clock is exactly fiveMinutes after signing — skew == tolerance, must pass.
 	verifier, err := NewHMACVerifier(clockmockAt(base.Add(fiveMinutes)))

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -215,15 +215,26 @@ type Headers struct {
 
 // SignedHeaders is the provenance-sealed OUTBOUND signature-header set: the value
 // [Signer.Sign] produces and [SignedHeaders.Apply] writes onto an outbound
-// request. Its fields are unexported and there is no exported constructor, so a
-// package-external caller cannot build one — the only SignedHeaders that can reach
-// the wire via Apply is one produced by the sealed [Signer.Sign]
-// (WEBHOOK-SIGNER-FUNNEL-01 upstream Hard, sealed construction; #1492). This is
-// the outbound counterpart to the inbound [Headers] parse DTO.
+// request. All fields are unexported, INCLUDING a `valid` provenance flag that
+// only [Signer.Sign] sets. A package-external caller can neither build a populated
+// literal (unexported fields) nor set `valid` on a zero value, so it cannot obtain
+// a valid SignedHeaders; [SignedHeaders.Apply] fail-closes (writes nothing) on a
+// zero value. Hence the only SignedHeaders that can write to the wire is one
+// produced by the sealed [Signer.Sign] = WEBHOOK-SIGNER-FUNNEL-01 upstream Hard
+// (external; #1492, valid-token closure of the zero-value-construction gap found
+// in review #1733 F1 — unexported fields alone do NOT stop `var h SignedHeaders`).
+// The in-package `SignedHeaders{valid: true}` literal remains the permanent Go
+// ceiling (same family as #851/#893/#1282/#1375). This is the outbound counterpart
+// to the inbound [Headers] parse DTO.
 type SignedHeaders struct {
 	deliveryID DeliveryID
 	timestamp  string
 	signature  string
+	// valid is the provenance flag — only Signer.Sign sets it true. A zero-value
+	// SignedHeaders (the only form a package-external caller can construct) has
+	// valid==false, and Apply fail-closes on it, so a non-Sign-produced value can
+	// never write signature headers to the wire.
+	valid bool
 }
 
 // DeliveryID returns the signed delivery identifier. These accessors expose the
@@ -263,14 +274,21 @@ const (
 // arbitrary value, and the archtest locks every Header.Set of these constants to
 // this method body. That makes the *write site* uniform.
 //
-// Provenance is now type-system closed (#1492): [SignedHeaders] has unexported
-// fields and no exported constructor, and only [Signer.Sign] produces one (sealed
-// construction, WEBHOOK-SIGNER-FUNNEL-01/A2 reflect freeze). So the value Apply
-// writes always originated from the sealed signer — no package-external caller can
-// hand-build a SignedHeaders to feed the wire. The package-internal holder axis (a
-// same-package literal) remains the permanent Go ceiling shared with
-// #851/#893/#1282/#1375.
+// Provenance is type-system closed (#1492 + review #1733 F1): Apply fail-closes on
+// a zero-value SignedHeaders (valid==false) — the ONLY form a package-external
+// caller can construct, since the fields (including `valid`) are unexported. Only
+// [Signer.Sign] sets valid==true, so the value Apply writes always originated from
+// the sealed signer; no external zero-value nor hand-built value can write
+// signature headers to the wire (WEBHOOK-SIGNER-FUNNEL-01/A2 reflect freeze locks
+// the field set incl. `valid`). The in-package `SignedHeaders{valid: true}` literal
+// remains the permanent Go ceiling shared with #851/#893/#1282/#1375.
 func (h SignedHeaders) Apply(header http.Header) {
+	if !h.valid {
+		// Fail-closed: a zero-value / non-Sign-produced SignedHeaders writes no
+		// signature headers; the receiver then rejects the delivery (observable),
+		// rather than letting an empty-signature delivery reach the wire.
+		return
+	}
 	header.Set(HeaderID, string(h.deliveryID))
 	header.Set(HeaderTimestamp, h.timestamp)
 	header.Set(HeaderSignature, h.signature)

--- a/kernel/webhook/webhook.go
+++ b/kernel/webhook/webhook.go
@@ -198,14 +198,45 @@ var (
 	_ fmt.GoStringer = Source{}
 )
 
-// Headers is the set of signature headers a [Signer] produces and a [Verifier]
-// consumes. Timestamp is unix seconds as a decimal string; Signature is one or
-// more space-separated "v1,<base64>" tokens.
+// Headers is the INBOUND signature-header DTO that a [Verifier] consumes. The
+// receiver constructs it from the raw request headers (untrusted input), so its
+// fields are exported by design — a forged Headers simply fails [Verifier.Verify].
+// The OUTBOUND, provenance-sealed counterpart written to the wire is
+// [SignedHeaders] (produced only by [Signer.Sign]); the two are deliberately
+// distinct types so the wire-write path cannot be fed a hand-built value (#1492).
+//
+// Timestamp is unix seconds as a decimal string; Signature is one or more
+// space-separated "v1,<base64>" tokens.
 type Headers struct {
 	DeliveryID DeliveryID
 	Timestamp  string
 	Signature  string
 }
+
+// SignedHeaders is the provenance-sealed OUTBOUND signature-header set: the value
+// [Signer.Sign] produces and [SignedHeaders.Apply] writes onto an outbound
+// request. Its fields are unexported and there is no exported constructor, so a
+// package-external caller cannot build one — the only SignedHeaders that can reach
+// the wire via Apply is one produced by the sealed [Signer.Sign]
+// (WEBHOOK-SIGNER-FUNNEL-01 upstream Hard, sealed construction; #1492). This is
+// the outbound counterpart to the inbound [Headers] parse DTO.
+type SignedHeaders struct {
+	deliveryID DeliveryID
+	timestamp  string
+	signature  string
+}
+
+// DeliveryID returns the signed delivery identifier. These accessors expose the
+// values for read-only inspection (logging, test wire reconstruction); the values
+// travel on the wire in plaintext, so reading them is not a secret leak. The seal
+// is on *construction* (only [Signer.Sign] produces a SignedHeaders), not reading.
+func (h SignedHeaders) DeliveryID() DeliveryID { return h.deliveryID }
+
+// Timestamp returns the signed unix-seconds timestamp string.
+func (h SignedHeaders) Timestamp() string { return h.timestamp }
+
+// Signature returns the signed "v1,<base64>" signature token(s).
+func (h SignedHeaders) Signature() string { return h.signature }
 
 // Outbound signature header names. GoCell signs outbound webhooks under the
 // vendor-neutral standard-webhooks header names (webhook-id / webhook-timestamp
@@ -227,20 +258,20 @@ const (
 // HeaderSignature) onto an outbound request's http.Header.
 //
 // It is the SOLE sanctioned writer of these header-name constants
-// (WEBHOOK-SIGNER-FUNNEL-01 downstream funnel): the dispatcher MUST call
-// headers.Apply(req.Header) rather than Header.Set a signature header from an
+// (WEBHOOK-SIGNER-FUNNEL-01/A1 downstream funnel): the dispatcher MUST call
+// signed.Apply(req.Header) rather than Header.Set a signature header from an
 // arbitrary value, and the archtest locks every Header.Set of these constants to
 // this method body. That makes the *write site* uniform.
 //
-// It does NOT guarantee Headers *provenance*. Headers is a public struct with
-// exported fields — it is also the inbound DTO that [Verifier.Verify] consumes,
-// constructed by the receiver from request headers — so a caller could build a
-// Headers literal and call Apply with a value that did not come from
-// [Signer.Sign]. Such a forged value carries an invalid HMAC the receiver
-// rejects (low severity); sealing provenance via a dedicated sealed outbound
-// type is tracked at gh #1492.
-func (h Headers) Apply(header http.Header) {
-	header.Set(HeaderID, string(h.DeliveryID))
-	header.Set(HeaderTimestamp, h.Timestamp)
-	header.Set(HeaderSignature, h.Signature)
+// Provenance is now type-system closed (#1492): [SignedHeaders] has unexported
+// fields and no exported constructor, and only [Signer.Sign] produces one (sealed
+// construction, WEBHOOK-SIGNER-FUNNEL-01/A2 reflect freeze). So the value Apply
+// writes always originated from the sealed signer — no package-external caller can
+// hand-build a SignedHeaders to feed the wire. The package-internal holder axis (a
+// same-package literal) remains the permanent Go ceiling shared with
+// #851/#893/#1282/#1375.
+func (h SignedHeaders) Apply(header http.Header) {
+	header.Set(HeaderID, string(h.deliveryID))
+	header.Set(HeaderTimestamp, h.timestamp)
+	header.Set(HeaderSignature, h.signature)
 }

--- a/kernel/webhook/webhook_helpers_test.go
+++ b/kernel/webhook/webhook_helpers_test.go
@@ -30,3 +30,11 @@ func MustDeliveryID(s string) DeliveryID {
 	}
 	return id
 }
+
+// signedToInbound bridges a sealed [SignedHeaders] (the outbound Sign output,
+// #1492) to the inbound [Headers] DTO that [Verifier.Verify] consumes. White-box
+// (same-package) so it reads SignedHeaders' unexported fields directly, mirroring
+// the wire reconstruction a real receiver performs from request headers.
+func signedToInbound(s SignedHeaders) Headers {
+	return Headers{DeliveryID: s.deliveryID, Timestamp: s.timestamp, Signature: s.signature}
+}

--- a/kernel/webhook/webhook_test.go
+++ b/kernel/webhook/webhook_test.go
@@ -162,7 +162,8 @@ func TestNewSource(t *testing.T) {
 		}
 		after, err := signer.Sign([]byte("body"), ts, MustDeliveryID("d1"))
 		require.NoError(t, err)
-		assert.Equal(t, before.Signature, after.Signature)
+		// Same-package: compare SignedHeaders' unexported signature field.
+		assert.Equal(t, before.signature, after.signature)
 	})
 }
 

--- a/kernel/webhook/webhook_test.go
+++ b/kernel/webhook/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,6 +18,33 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
+
+// TestSignedHeaders_ZeroValueApply_FailClosed is the #1733 F1 reverse self-check:
+// a zero-value SignedHeaders (the only form a package-external caller can
+// construct — unexported fields incl. `valid`) must write NO signature headers via
+// Apply (valid-token fail-close), while a Sign-produced one (valid==true) does.
+// This proves the provenance closure is the `valid` flag, not a no-op Apply.
+func TestSignedHeaders_ZeroValueApply_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	var zero SignedHeaders // valid == false — mirrors external `var h webhook.SignedHeaders`
+	zeroHdr := http.Header{}
+	zero.Apply(zeroHdr)
+	assert.Empty(t, zeroHdr.Get(HeaderID), "zero-value Apply must not write webhook-id")
+	assert.Empty(t, zeroHdr.Get(HeaderTimestamp), "zero-value Apply must not write webhook-timestamp")
+	assert.Empty(t, zeroHdr.Get(HeaderSignature), "zero-value Apply must not write webhook-signature")
+
+	src, err := NewSource(MustSourceID("s"), minSecret())
+	require.NoError(t, err)
+	signer, err := NewHMACSigner(src)
+	require.NoError(t, err)
+	signed, err := signer.Sign([]byte("b"), time.Unix(1700000000, 0), MustDeliveryID("d1"))
+	require.NoError(t, err)
+	signedHdr := http.Header{}
+	signed.Apply(signedHdr)
+	assert.NotEmpty(t, signedHdr.Get(HeaderSignature),
+		"Sign-produced (valid) Apply must write the signature header — guard is the valid flag, not a blanket no-op")
+}
 
 // redactionMask is the literal a redacted secret renders as (pkg/redaction.Mask).
 const redactionMask = "<REDACTED>"

--- a/kernel/webhook/webhooktest/conformance.go
+++ b/kernel/webhook/webhooktest/conformance.go
@@ -21,6 +21,7 @@ package webhooktest
 import (
 	"bytes"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -30,10 +31,12 @@ import (
 )
 
 // inboundFromSigned converts a sealed outbound [webhook.SignedHeaders] (the Sign
-// output, #1492) into the inbound [webhook.Headers] DTO that [webhook.Verifier.Verify]
-// consumes, mirroring how a real receiver reconstructs the headers off the wire.
-// It reads via the public read-only accessors (the seal is on construction, not
-// reading).
+// output, #1492) into the inbound [webhook.Headers] DTO that
+// [webhook.Verifier.Verify] consumes, using the public read-only accessors (the
+// seal is on construction, not reading). This is a unit-level bridge that does
+// NOT go through the HTTP wire path; the dedicated apply_wire_roundtrip
+// conformance case ([runApplyWireRoundTrip]) exercises [webhook.SignedHeaders.Apply]
+// → http.Header → parse end-to-end.
 func inboundFromSigned(s webhook.SignedHeaders) webhook.Headers {
 	return webhook.Headers{
 		DeliveryID: s.DeliveryID(),
@@ -106,8 +109,9 @@ func RunSignerVerifierConformance(
 
 	signed, err := signer.Sign(basePayload, base, deliveryID)
 	mustNoError(t, err, "signer.Sign")
-	// Bridge the sealed outbound SignedHeaders to the inbound Headers DTO via the
-	// real wire round-trip (Apply → http.Header → parse); see inboundFromSigned.
+	// goodHeaders is the inbound DTO derived from the signed output via the
+	// read-only accessors (see inboundFromSigned). The dedicated apply_wire_roundtrip
+	// case below is the one that exercises the real Apply → http.Header → parse path.
 	goodHeaders := inboundFromSigned(signed)
 
 	// verifierAt builds a Verifier pinned to ts.
@@ -119,6 +123,7 @@ func RunSignerVerifierConformance(
 	}
 
 	runRoundTrip(t, src, basePayload, goodHeaders, base, verifierAt)
+	runApplyWireRoundTrip(t, src, basePayload, signed, base, verifierAt)
 	runTamperBody(t, src, basePayload, goodHeaders, base, verifierAt)
 	runTamperSignature(t, src, basePayload, goodHeaders, base, verifierAt)
 	runTamperTimestampExpired(t, src, basePayload, goodHeaders, base, verifierAt)
@@ -126,6 +131,7 @@ func RunSignerVerifierConformance(
 	runMultiTokenSecondMatches(t, src, basePayload, goodHeaders, base, deliveryID, newSigner, verifierAt)
 	runTimestampOutsideWindow(t, src, basePayload, goodHeaders, base, verifierAt)
 	runEmptySecretSourceRejected(t, newSigner)
+	runEmptySecretSourceRejectedByVerifier(t, basePayload, goodHeaders, base, verifierAt)
 	runNoMatchingToken(t, src, basePayload, goodHeaders, base, verifierAt)
 }
 
@@ -140,6 +146,38 @@ func runRoundTrip(
 		v := verifierAt(t, base)
 		requireNoError(t, v.Verify(payload, headers, src),
 			"sign→verify must succeed with matching body/headers/source")
+	})
+}
+
+// runApplyWireRoundTrip is the ONLY conformance case that exercises the real
+// outbound write path [webhook.SignedHeaders.Apply] → http.Header → read-back by
+// the three header-name constants → verify. The other cases bridge via accessors
+// ([inboundFromSigned]), so this case is what catches an Apply field-mapping swap
+// (e.g. writing the signature under HeaderID) or an Apply ↔ accessor divergence.
+func runApplyWireRoundTrip(
+	t *testing.T, src webhook.Source, payload []byte,
+	signed webhook.SignedHeaders, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("apply_wire_roundtrip", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		signed.Apply(h)
+		// Apply must map each field to its sanctioned header name and agree with
+		// the read-only accessors.
+		requireEqual(t, string(signed.DeliveryID()), h.Get(webhook.HeaderID), "Apply HeaderID")
+		requireEqual(t, signed.Timestamp(), h.Get(webhook.HeaderTimestamp), "Apply HeaderTimestamp")
+		requireEqual(t, signed.Signature(), h.Get(webhook.HeaderSignature), "Apply HeaderSignature")
+		// Reconstruct the inbound Headers off the wire and verify end-to-end.
+		inbound := webhook.Headers{
+			DeliveryID: webhook.DeliveryID(h.Get(webhook.HeaderID)),
+			Timestamp:  h.Get(webhook.HeaderTimestamp),
+			Signature:  h.Get(webhook.HeaderSignature),
+		}
+		v := verifierAt(t, base)
+		requireNoError(t, v.Verify(payload, inbound, src),
+			"sign→Apply→wire→verify round-trip must succeed")
 	})
 }
 
@@ -257,6 +295,23 @@ func runEmptySecretSourceRejected(
 	})
 }
 
+// runEmptySecretSourceRejectedByVerifier is the verifier-side sibling of
+// runEmptySecretSourceRejected: Verify must independently reject a zero-value
+// (empty-secret) Source, not rely on the signer guard. Without this case, a
+// dropped verifier-side empty-secret guard would pass conformance.
+func runEmptySecretSourceRejectedByVerifier(
+	t *testing.T, payload []byte, headers webhook.Headers, base time.Time,
+	verifierAt func(*testing.T, time.Time) webhook.Verifier,
+) {
+	t.Helper()
+	t.Run("empty_secret_source_rejected_by_verifier", func(t *testing.T) {
+		t.Parallel()
+		v := verifierAt(t, base)
+		err := v.Verify(payload, headers, webhook.Source{})
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+}
+
 func runNoMatchingToken(
 	t *testing.T, src webhook.Source, payload []byte,
 	headers webhook.Headers, base time.Time,
@@ -313,6 +368,14 @@ func requireNoError(t *testing.T, err error, msg string) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("%s: unexpected error: %v", msg, err)
+	}
+}
+
+// requireEqual fails the test immediately if got != want (string equality).
+func requireEqual(t *testing.T, want, got, context string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s: got %q, want %q", context, got, want)
 	}
 }
 

--- a/kernel/webhook/webhooktest/conformance.go
+++ b/kernel/webhook/webhooktest/conformance.go
@@ -29,6 +29,19 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+// inboundFromSigned converts a sealed outbound [webhook.SignedHeaders] (the Sign
+// output, #1492) into the inbound [webhook.Headers] DTO that [webhook.Verifier.Verify]
+// consumes, mirroring how a real receiver reconstructs the headers off the wire.
+// It reads via the public read-only accessors (the seal is on construction, not
+// reading).
+func inboundFromSigned(s webhook.SignedHeaders) webhook.Headers {
+	return webhook.Headers{
+		DeliveryID: s.DeliveryID(),
+		Timestamp:  s.Timestamp(),
+		Signature:  s.Signature(),
+	}
+}
+
 const (
 	conformanceMinSecretLen = 24
 
@@ -91,8 +104,11 @@ func RunSignerVerifierConformance(
 	deliveryID, err := webhook.NewDeliveryID("conf-del-01")
 	mustNoError(t, err, "NewDeliveryID")
 
-	goodHeaders, err := signer.Sign(basePayload, base, deliveryID)
+	signed, err := signer.Sign(basePayload, base, deliveryID)
 	mustNoError(t, err, "signer.Sign")
+	// Bridge the sealed outbound SignedHeaders to the inbound Headers DTO via the
+	// real wire round-trip (Apply → http.Header → parse); see inboundFromSigned.
+	goodHeaders := inboundFromSigned(signed)
 
 	// verifierAt builds a Verifier pinned to ts.
 	verifierAt := func(t *testing.T, ts time.Time) webhook.Verifier {
@@ -274,9 +290,9 @@ func buildAltHeaders(
 	mustNoError(t, err, "NewSource alt")
 	signer2, err := newSigner(src2)
 	mustNoError(t, err, "newSigner alt")
-	h, err := signer2.Sign(payload, ts, deliveryID)
+	signed, err := signer2.Sign(payload, ts, deliveryID)
 	mustNoError(t, err, "Sign alt")
-	return h
+	return inboundFromSigned(signed)
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/bootstrap/phases_webhook_test.go
+++ b/runtime/bootstrap/phases_webhook_test.go
@@ -355,15 +355,15 @@ func TestPhase5DrainWebhookReceivers_EndToEnd(t *testing.T) {
 
 	buildReq := func(signature string) *http.Request {
 		req := httptest.NewRequest(http.MethodPost, whTestPathPattern, bytes.NewReader(body))
-		req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-		req.Header.Set("X-Timestamp", headers.Timestamp)
+		req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+		req.Header.Set("X-Timestamp", headers.Timestamp())
 		req.Header.Set("X-Signature", signature)
 		return req
 	}
 
 	t.Run("valid_hmac_returns_200", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		rtr.Handler().ServeHTTP(rec, buildReq(headers.Signature))
+		rtr.Handler().ServeHTTP(rec, buildReq(headers.Signature()))
 		assert.Equal(t, http.StatusOK, rec.Code,
 			"valid HMAC at %s must return 200 (no double-prefix, handler reached)", whTestPathPattern)
 	})
@@ -421,9 +421,9 @@ func TestPhase5_WebhookListener_IsolatedFromPrimary(t *testing.T) {
 	require.NoError(t, err, "Sign")
 	newReq := func() *http.Request {
 		req := httptest.NewRequest(http.MethodPost, whTestPathPattern, bytes.NewReader(body))
-		req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-		req.Header.Set("X-Timestamp", headers.Timestamp)
-		req.Header.Set("X-Signature", headers.Signature)
+		req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+		req.Header.Set("X-Timestamp", headers.Timestamp())
+		req.Header.Set("X-Signature", headers.Signature())
 		return req
 	}
 

--- a/runtime/webhook/receiver_integration_test.go
+++ b/runtime/webhook/receiver_integration_test.go
@@ -121,9 +121,9 @@ func sendSignedRequest(t *testing.T, srv *httptest.Server, signer kwh.Signer, bo
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
-	req.Header.Set("X-Signature", headers.Signature)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
+	req.Header.Set("X-Signature", headers.Signature())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -209,7 +209,7 @@ func TestIntegration_MissingHeader_Returns400(t *testing.T) {
 	headers, _ := signer.Sign(body, fixedNow, did)
 
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
 	// Intentionally omit X-Timestamp and X-Signature.
 
 	resp, err := http.DefaultClient.Do(req)
@@ -232,8 +232,8 @@ func TestIntegration_BadSignature_Returns401(t *testing.T) {
 	headers, _ := signer.Sign(body, fixedNow, did)
 
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
 	req.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=") // forged
 
 	resp, err := http.DefaultClient.Do(req)
@@ -252,7 +252,7 @@ func TestIntegration_StatusCodeCoverage(t *testing.T) {
 	tests := []struct {
 		name       string
 		deliveryID string
-		mutate     func(*http.Request, kwh.Headers)
+		mutate     func(*http.Request)
 		wantStatus int
 	}{
 		{
@@ -263,7 +263,7 @@ func TestIntegration_StatusCodeCoverage(t *testing.T) {
 		{
 			name:       "missing signature header -> 400",
 			deliveryID: "cov-400",
-			mutate: func(r *http.Request, _ kwh.Headers) {
+			mutate: func(r *http.Request) {
 				r.Header.Del("X-Signature")
 			},
 			wantStatus: http.StatusBadRequest,
@@ -271,7 +271,7 @@ func TestIntegration_StatusCodeCoverage(t *testing.T) {
 		{
 			name:       "invalid signature -> 401",
 			deliveryID: "cov-401",
-			mutate: func(r *http.Request, _ kwh.Headers) {
+			mutate: func(r *http.Request) {
 				r.Header.Set("X-Signature", "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 			},
 			wantStatus: http.StatusUnauthorized,
@@ -287,11 +287,11 @@ func TestIntegration_StatusCodeCoverage(t *testing.T) {
 			headers, _ := signer.Sign(body, fixedNow, did)
 
 			req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
-			req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-			req.Header.Set("X-Timestamp", headers.Timestamp)
-			req.Header.Set("X-Signature", headers.Signature)
+			req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+			req.Header.Set("X-Timestamp", headers.Timestamp())
+			req.Header.Set("X-Signature", headers.Signature())
 			if tt.mutate != nil {
-				tt.mutate(req, headers)
+				tt.mutate(req)
 			}
 
 			resp, err := http.DefaultClient.Do(req)
@@ -392,9 +392,9 @@ func TestIntegration_TimestampExpired_Returns401(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
-	req.Header.Set("X-Signature", headers.Signature)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
+	req.Header.Set("X-Signature", headers.Signature())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -445,9 +445,9 @@ func TestIntegration_ConcurrentDelivery_Returns409(t *testing.T) {
 	headers, _ := signer.Sign(body, fixedNow, did)
 
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+testPathPattern, bytes.NewReader(body))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
-	req.Header.Set("X-Signature", headers.Signature)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
+	req.Header.Set("X-Signature", headers.Signature())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/runtime/webhook/receiver_test.go
+++ b/runtime/webhook/receiver_test.go
@@ -92,9 +92,9 @@ func signedRequest(t *testing.T, body []byte, deliveryID string) *http.Request {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(body))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
-	req.Header.Set("X-Signature", headers.Signature)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
+	req.Header.Set("X-Signature", headers.Signature())
 	return req
 }
 
@@ -428,9 +428,9 @@ func TestReceiver_TimestampExpired_Returns401(t *testing.T) {
 	headers, _ := signer.Sign(body, fixedNow, did)
 
 	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(body))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
-	req.Header.Set("X-Signature", headers.Signature)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
+	req.Header.Set("X-Signature", headers.Signature())
 
 	// Verifier clock is testReplaySkew ahead → outside ±300s window.
 	laterClk := clockmock.New(fixedNow.Add(testReplaySkew))
@@ -476,9 +476,9 @@ func TestReceiver_BodyExceedsLimitViaMaxBytesReader(t *testing.T) {
 	headers, _ := signer.Sign(bigBody, fixedNow, did)
 
 	req := httptest.NewRequest(http.MethodPost, testPathPattern, bytes.NewReader(bigBody))
-	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID))
-	req.Header.Set("X-Timestamp", headers.Timestamp)
-	req.Header.Set("X-Signature", headers.Signature)
+	req.Header.Set("X-Delivery-Id", string(headers.DeliveryID()))
+	req.Header.Set("X-Timestamp", headers.Timestamp())
+	req.Header.Set("X-Signature", headers.Signature())
 	// Don't set Content-Length above limit — let MaxBytesReader detect it.
 	req.ContentLength = int64(len(bigBody)) // correct but above limit
 

--- a/tools/archtest/testdata/webhook_allow_loopback_violate/go.mod
+++ b/tools/archtest/testdata/webhook_allow_loopback_violate/go.mod
@@ -1,0 +1,7 @@
+module fixturetest/webhook_allow_loopback_violate
+
+go 1.25.11
+
+replace github.com/ghbvf/gocell => ../../../..
+
+require github.com/ghbvf/gocell v0.0.0

--- a/tools/archtest/testdata/webhook_allow_loopback_violate/violation.go
+++ b/tools/archtest/testdata/webhook_allow_loopback_violate/violation.go
@@ -1,0 +1,15 @@
+// Package webhook_allow_loopback_violate is a synthetic violation fixture for
+// the WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01 archtest. This is a production (non-
+// _test.go) file that references webhook.WithAllowLoopback, which the rule bans
+// outside _test.go — the reverse self-test asserts the scan fires here.
+//
+// DO NOT use this package in production code.
+package webhook_allow_loopback_violate
+
+import "github.com/ghbvf/gocell/kernel/webhook"
+
+// buildLeakyPolicy is a production-file callsite of WithAllowLoopback — the very
+// thing WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01 forbids outside _test.go.
+func buildLeakyPolicy() *webhook.SafePolicy {
+	return webhook.NewSafePolicy(webhook.WithAllowLoopback()) // VIOLATION
+}

--- a/tools/archtest/testdata/webhook_signer_violate/violations.go
+++ b/tools/archtest/testdata/webhook_signer_violate/violations.go
@@ -38,3 +38,11 @@ func forgeIDHeader(h http.Header) {
 func forgeTimestampHeader(h http.Header) {
 	h.Set(headerTimestamp, "0") // VIOLATION: const that evaluates to "webhook-timestamp"
 }
+
+// forgeViaMethodValue captures (net/http.Header).Set as a METHOD VALUE then calls
+// it with a signature-header key — the bypass scanSignerHeaderSetMethodValue must
+// catch (the direct-call key scan cannot see the key at the capture site).
+func forgeViaMethodValue(h http.Header) {
+	set := h.Set                     // VIOLATION: Header.Set captured as a method value
+	set("webhook-signature", "v1,x") // key not visible at the capture site
+}

--- a/tools/archtest/webhook_allow_loopback_prod_ban_test.go
+++ b/tools/archtest/webhook_allow_loopback_prod_ban_test.go
@@ -12,10 +12,13 @@
 //   - Rule (downstream Medium): scan ALL production (non-_test.go, non-generated)
 //     Go files in the module for any reference to kernel/webhook.WithAllowLoopback.
 //     Any such reference is a violation — the option may only appear in _test.go.
-//     Detection: EachInSubtree[SelectorExpr] + ResolvePackageRef(sel) ==
-//     (kernel/webhook, "WithAllowLoopback"). ResolvePackageRef is type-resolved,
-//     so an import alias (e.g. `kwh "…/kernel/webhook"; kwh.WithAllowLoopback`)
-//     cannot bypass it. Today's inventory: 0 production references → vacuous green
+//     Detection: EachInSubtree[Ident] + info.Uses[id].(*types.Func).FullName() ==
+//     "…/kernel/webhook.WithAllowLoopback". Resolving via go/types info.Uses
+//     catches EVERY reference form — qualified (webhook.WithAllowLoopback),
+//     aliased (kwh.WithAllowLoopback), AND dot-import (bare WithAllowLoopback) —
+//     because all three resolve the reference ident to the same *types.Func; the
+//     function *declaration* ident lives in info.Defs, so ssrf.go's definition
+//     never false-fires. Today's inventory: 0 production references → vacuous green
 //     (every caller is a kernel/webhook same-package test).
 //
 // AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
@@ -37,13 +40,11 @@
 //	B-rule — rule-logic regression: testdata/webhook_allow_loopback_violate is a
 //	  standalone-module production (.go) file that calls webhook.WithAllowLoopback;
 //	  TestWebhookAllowLoopbackProdBan_ReverseFixture asserts the scan fires on it.
-//	B-dotimport — a production file that dot-imports kernel/webhook
-//	  (import . "…/kernel/webhook") and calls bare WithAllowLoopback() would be a
-//	  bare *ast.Ident, not a SelectorExpr, so the SelectorExpr walk misses it (same
-//	  bounded precedent as WEBHOOK-SSRF-GUARD-01/A3). Bounded response: no
-//	  production file dot-imports kernel/webhook (a dot-import of a non-dot-import
-//	  package is itself a lint/style violation), so this vector is not realistic;
-//	  documented here so a future reviewer knows the scan is SelectorExpr-scoped.
+//	(No dot-import blind spot: the info.Uses Ident-walk resolves bare dot-import
+//	  idents to the same *types.Func as qualified/aliased selectors, so all import
+//	  forms are covered. The sibling WEBHOOK-SSRF-GUARD-01/A3 still uses a
+//	  SelectorExpr-only scan with that documented gap; adopting this Ident-walk
+//	  there is a separate, out-of-this-PR cleanup.)
 //
 // ref: docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md §Consequences
 // ref: tools/archtest/webhook_ssrf_guard_test.go (production callsite-scan template)
@@ -63,18 +64,26 @@ import (
 // webhookAllowLoopbackFunc is the banned exported function name in kernel/webhook.
 const webhookAllowLoopbackFunc = "WithAllowLoopback"
 
+// webhookAllowLoopbackFullName is the go/types FullName of the banned function.
+// Matching info.Uses against this FullName catches every reference form
+// (qualified / aliased / dot-import) because all resolve to the same *types.Func.
+const webhookAllowLoopbackFullName = webhookPkgPath + "." + webhookAllowLoopbackFunc
+
 // scanWebhookAllowLoopback implements the rule: any reference to
-// kernel/webhook.WithAllowLoopback in a production file is a violation.
+// kernel/webhook.WithAllowLoopback in a production file is a violation. It walks
+// every identifier and matches info.Uses to the banned func's go/types FullName,
+// so qualified/aliased/dot-import references are all caught; the func declaration
+// (info.Defs, not info.Uses) is not flagged.
 func scanWebhookAllowLoopback(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
-	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
-		pkgPath, name, ok := ResolvePackageRef(info, sel)
-		if !ok || pkgPath != webhookPkgPath || name != webhookAllowLoopbackFunc {
+	EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+		fn, ok := info.Uses[id].(*types.Func)
+		if !ok || fn.FullName() != webhookAllowLoopbackFullName {
 			return
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
-			Line: fset.Position(sel.Pos()).Line,
+			Line: fset.Position(id.Pos()).Line,
 			Message: "webhook.WithAllowLoopback referenced in production code; it is dev/CI-only " +
 				"and must appear only in _test.go (WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01)",
 		})

--- a/tools/archtest/webhook_allow_loopback_prod_ban_test.go
+++ b/tools/archtest/webhook_allow_loopback_prod_ban_test.go
@@ -1,0 +1,147 @@
+// INVARIANT: WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01
+//
+// WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01 — webhook.WithAllowLoopback is dev/CI-only.
+//
+// webhook.WithAllowLoopback() (kernel/webhook/ssrf.go, #1159 / KERNEL-WEBHOOK-01
+// PR-4) is a SafeOption that exempts loopback (127.0.0.0/8, ::1) from the
+// outbound SSRF blocklist — for testcontainers / local test servers only. Setting
+// it in production would let loopback egress through with NO error. Before #1378
+// this was a Soft godoc-only constraint ("must never be set in production"); this
+// rule upgrades it to a Medium archtest.
+//
+//   - Rule (downstream Medium): scan ALL production (non-_test.go, non-generated)
+//     Go files in the module for any reference to kernel/webhook.WithAllowLoopback.
+//     Any such reference is a violation — the option may only appear in _test.go.
+//     Detection: EachInSubtree[SelectorExpr] + ResolvePackageRef(sel) ==
+//     (kernel/webhook, "WithAllowLoopback"). ResolvePackageRef is type-resolved,
+//     so an import alias (e.g. `kwh "…/kernel/webhook"; kwh.WithAllowLoopback`)
+//     cannot bypass it. Today's inventory: 0 production references → vacuous green
+//     (every caller is a kernel/webhook same-package test).
+//
+// AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
+//
+//	下游 Medium — archtest callsite ban, type-resolved (alias-safe). Form is a
+//	  reference-presence scan, not a compile-time guarantee.
+//	上游 Hard ACHIEVABLE but deferred → tracked gh #1730 (named here per charter
+//	  §Funnel 双向锁评级: a Medium funnel whose Hard upgrade is achievable MUST
+//	  track it in an issue and name the number here). All WithAllowLoopback callers
+//	  today are kernel/webhook same-package tests, so unexporting it to
+//	  `withAllowLoopback` would make any external (cmd/examples/runtime) reference a
+//	  Go compile error = Hard upstream (mirrors the same-file `withResolver`
+//	  test-only seam). #1378 deliberately keeps it EXPORTED to preserve the dev
+//	  escape hatch and a path for future cross-package integration tests; #1730
+//	  flips it to unexported (and retires this archtest) once that need is resolved.
+//
+// Blind spots (ai-robust 强制反向自检):
+//
+//	B-rule — rule-logic regression: testdata/webhook_allow_loopback_violate is a
+//	  standalone-module production (.go) file that calls webhook.WithAllowLoopback;
+//	  TestWebhookAllowLoopbackProdBan_ReverseFixture asserts the scan fires on it.
+//	B-dotimport — a production file that dot-imports kernel/webhook
+//	  (import . "…/kernel/webhook") and calls bare WithAllowLoopback() would be a
+//	  bare *ast.Ident, not a SelectorExpr, so the SelectorExpr walk misses it (same
+//	  bounded precedent as WEBHOOK-SSRF-GUARD-01/A3). Bounded response: no
+//	  production file dot-imports kernel/webhook (a dot-import of a non-dot-import
+//	  package is itself a lint/style violation), so this vector is not realistic;
+//	  documented here so a future reviewer knows the scan is SelectorExpr-scoped.
+//
+// ref: docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md §Consequences
+// ref: tools/archtest/webhook_ssrf_guard_test.go (production callsite-scan template)
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// webhookAllowLoopbackFunc is the banned exported function name in kernel/webhook.
+const webhookAllowLoopbackFunc = "WithAllowLoopback"
+
+// scanWebhookAllowLoopback implements the rule: any reference to
+// kernel/webhook.WithAllowLoopback in a production file is a violation.
+func scanWebhookAllowLoopback(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		pkgPath, name, ok := ResolvePackageRef(info, sel)
+		if !ok || pkgPath != webhookPkgPath || name != webhookAllowLoopbackFunc {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(sel.Pos()).Line,
+			Message: "webhook.WithAllowLoopback referenced in production code; it is dev/CI-only " +
+				"and must appear only in _test.go (WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01)",
+		})
+	})
+	return out
+}
+
+// TestWebhookAllowLoopbackProdBan is the primary scan: no production
+// (non-_test.go, non-generated) file in the module may reference
+// kernel/webhook.WithAllowLoopback.
+func TestWebhookAllowLoopbackProdBan(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	diags := Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil {
+			return nil
+		}
+		var out []Diagnostic
+		for _, f := range p.Files {
+			if p.IsGenerated(f) {
+				continue
+			}
+			rel := p.Rel(f)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			out = append(out, scanWebhookAllowLoopback(p.Fset, f, rel, p.TypesInfo)...)
+		}
+		return out
+	})
+
+	Report(t, "WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01", diags)
+}
+
+// TestWebhookAllowLoopbackProdBan_ReverseFixture loads the synthetic violation
+// fixture and asserts the scan fires — guards against the rule logic silently
+// regressing to a vacuous pass (the production scan is vacuously green today
+// because there are zero references).
+func TestWebhookAllowLoopbackProdBan_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	fixtureDir := filepath.Join(root, "tools", "archtest", "testdata", "webhook_allow_loopback_violate")
+
+	var diags []Diagnostic
+	_ = Run(t, StandaloneModule(fixtureDir, TypedOpts{Tests: false}, []string{"./..."}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				diags = append(diags, scanWebhookAllowLoopback(p.Fset, f, rel, p.TypesInfo)...)
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, len(diags), 1,
+		"reverse fixture: expected ≥1 diagnostic for the production WithAllowLoopback callsite "+
+			"in testdata/webhook_allow_loopback_violate — the rule must fire, else it is vacuous")
+}

--- a/tools/archtest/webhook_hmac_funnel.go
+++ b/tools/archtest/webhook_hmac_funnel.go
@@ -5,13 +5,13 @@
 // WEBHOOK-HMAC-FUNNEL-01 — kernel/webhook HMAC signing funnel (KERNEL-WEBHOOK-01).
 //
 //   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite in the
-//     kernel/webhook package — the computeMAC function in signer.go. The check is
-//     FUNCTION-level, not file-level: an hmac.New in any other function (even
-//     inside signer.go) fails. This also closes the package-internal upstream
-//     blind spot: any new struct that wants to sign MUST call hmac.New, which is
-//     allowlisted to computeMAC, so an unsealed internal holder cannot produce a
-//     signature undetected. Detection: ResolvePackageRef(callee) == crypto/hmac.New
-//     AND (file basename != signer.go OR enclosing func != computeMAC).
+//     kernel/webhook package — the computeMAC function. The check is
+//     FUNCTION-IDENTITY level via go/types FullName (file-independent; #1493): an
+//     hmac.New whose enclosing func FullName != computeMAC's fails, and a
+//     same-named function in another package cannot inherit the allowance
+//     (mirrors WEBHOOK-SSRF-GUARD-01/A2). Detection: ResolvePackageRef(callee) ==
+//     crypto/hmac.New AND ResolveEnclosingFunc(call).FullName() !=
+//     hmacSanctionedComputeMACFunc.
 //   - A2 (downstream Hard): signature comparison must use crypto/hmac.Equal or
 //     crypto/subtle.ConstantTimeCompare. The non-constant-time comparison callees
 //     bytes.Equal / bytes.Compare / slices.Equal / reflect.DeepEqual are banned in
@@ -19,12 +19,24 @@
 //     a flaky timing test. Detection: ResolvePackageRef(callee) ∈ the banned set.
 //   - A3 (upstream Hard external / Medium internal): the Signer and Verifier
 //     interfaces each carry an unexported sealed() marker method, so
-//     package-external implementations are a compile error (Hard). Package-internal
-//     new holders are not blocked by sealing (Medium) — covered transitively by
-//     A1. Explicit Hard-ization of the internal axis (unexported method-set
-//     interface + private construction, per the SPAN-SETATTR-HOLDER-SEAL #851
-//     precedent) is tracked in gh #1243. Detection: the Signer/Verifier interface
-//     type decls must contain an unexported method.
+//     package-external implementations are a compile error (Hard external).
+//     Package-internal new holders are NOT blocked by sealing — and contrary to a
+//     prior overclaim, A1 does NOT transitively cover them: A1 locks only
+//     crypto/hmac.New, not reuse of the package-level computeMAC helper, so a
+//     rogue in-package struct could call computeMAC and produce a valid signature
+//     without its own hmac.New. That internal axis is instead covered by A4
+//     (computeMAC caller-allowlist, Medium). True type-system Hard for the
+//     internal axis is a PERMANENT Go ceiling (in-package code can always declare
+//     sealed(), read Source.secret, and call computeMAC) — same family as #851 /
+//     #893 / #1282 / #1375; #1243 is relabeled won't-do and named here as that
+//     ceiling's tracker. Detection: the Signer/Verifier interface type decls must
+//     contain an unexported method.
+//   - A4 (Medium, internal axis; #1243): every call to the package-internal
+//     computeMAC helper must have an enclosing func whose go/types FullName ∈
+//     {hmacSigner.Sign, hmacVerifier.Verify}. This is the actual enforcement of
+//     "only the sanctioned signer/verifier may compute a MAC", closing the A3
+//     internal axis at Medium (Hard is the permanent ceiling above). Detection:
+//     info.Uses callee FullName == computeMAC's AND enclosing FullName ∉ allowlist.
 //
 // Blind spots (ai-robust 强制反向自检; each has a reverse self-test in the _test.go):
 //
@@ -33,6 +45,11 @@
 //	  outside signer.go and inside signer.go in a non-computeMAC func) and the
 //	  banned comparison callees; TestWebhookHMACFunnel_ReverseFixture asserts A1/A2
 //	  fire on each form.
+//	B-A4 — rule-logic regression (computeMAC is unexported, so no standalone-module
+//	  RED fixture can call it): TestWebhookHMACFunnel_ComputeMACCallerAntiVacuity
+//	  re-runs the A4 scan over real production with an EMPTY allowlist and asserts it
+//	  fires on the ≥2 real computeMAC callers (Sign + Verify) — proving the scan
+//	  detects computeMAC calls and the allowlist is what suppresses them (non-vacuous).
 //	B6 — Source.Secret leak: slog of the raw unexported secret field would leak
 //	  it (Source.LogValue + slog.LogValuer covers slog.Any of a whole Source, but
 //	  not slog of src.secret directly). scanWebhookSecretSlog covers BOTH the
@@ -84,14 +101,37 @@ const webhookPkgPath = PlatformModulePath + "/kernel/webhook"
 const (
 	webhookPkgPattern  = "./kernel/webhook/..."
 	signerFileBasename = "signer.go"
-	computeMACFuncName = "computeMAC"
 	hmacPkgPath        = "crypto/hmac"
 	slogPkgPath        = "log/slog"
+
+	// hmacSanctionedComputeMACFunc is the go/types FullName of the ONE function
+	// allowed to call crypto/hmac.New: the free func computeMAC in signer.go.
+	// FullName encodes the package path, so a same-named function in another
+	// package cannot inherit the A1 allowance (mirrors WEBHOOK-SSRF-GUARD-01/A2's
+	// ssrfSanctionedDialFunc; #1493). computeMAC is package-unique, so the check is
+	// file-independent — computeMAC may move files freely. It also doubles as the
+	// callee identity for the A4 caller-allowlist scan (computeMAC's own FullName).
+	hmacSanctionedComputeMACFunc = PlatformModulePath + "/kernel/webhook.computeMAC"
+
+	// hmacSanctionedSignFunc / hmacSanctionedVerifyFunc are the go/types FullNames
+	// of the ONLY two functions permitted to call computeMAC (A4 caller-allowlist).
+	hmacSanctionedSignFunc   = "(*" + PlatformModulePath + "/kernel/webhook.hmacSigner).Sign"
+	hmacSanctionedVerifyFunc = "(*" + PlatformModulePath + "/kernel/webhook.hmacVerifier).Verify"
 )
 
 // webhookSealedInterfaces are the interface type names in kernel/webhook that
 // must carry an unexported sealed() marker (A3).
 var webhookSealedInterfaces = map[string]bool{"Signer": true, "Verifier": true}
+
+// computeMACCallerAllowlist is the set of go/types FullNames permitted to call
+// the package-internal computeMAC helper (A4). Any other in-package caller could
+// compute a valid MAC and thereby forge a signature WITHOUT an hmac.New callsite
+// of its own — A1 only locks hmac.New, not computeMAC reuse, so A4 is the actual
+// enforcement of "only the sanctioned signer/verifier may produce a MAC".
+var computeMACCallerAllowlist = map[string]bool{
+	hmacSanctionedSignFunc:   true,
+	hmacSanctionedVerifyFunc: true,
+}
 
 // nonConstTimeCompareCallees is the A2 banned set: package-qualified callees
 // that compare bytes/values in non-constant time. Signature comparison must use
@@ -103,26 +143,59 @@ var nonConstTimeCompareCallees = map[[2]string]bool{
 	{"reflect", "DeepEqual"}: true,
 }
 
-// scanWebhookHMACNew implements A1: crypto/hmac.New may be called only inside
-// the computeMAC function of signer.go (function-level, not merely file-level).
+// scanWebhookHMACNew implements A1: crypto/hmac.New may be called only inside the
+// computeMAC function (function-identity level via go/types FullName, file-
+// independent; #1493). The allowance is bound to computeMAC's FullName, not its
+// bare name, so a same-named function in another package cannot inherit it.
 func scanWebhookHMACNew(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
-	inSignerFile := filepath.Base(filepath.ToSlash(rel)) == signerFileBasename
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
 		pkgPath, name, ok := ResolvePackageRef(info, call.Fun)
 		if !ok || pkgPath != hmacPkgPath || name != "New" {
 			return
 		}
-		if inSignerFile {
-			if fn, ok := ResolveEnclosingFunc(info, file, call); ok && fn != nil && fn.Name() == computeMACFuncName {
-				return
-			}
+		if fn, ok := ResolveEnclosingFunc(info, file, call); ok && fn != nil &&
+			fn.FullName() == hmacSanctionedComputeMACFunc {
+			return
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
 			Line: fset.Position(call.Pos()).Line,
-			Message: "crypto/hmac.New called outside computeMAC (signer.go); " +
+			Message: "crypto/hmac.New called outside computeMAC; " +
 				"all HMAC computation must funnel through computeMAC (WEBHOOK-HMAC-FUNNEL-01/A1)",
+		})
+	})
+	return out
+}
+
+// scanWebhookComputeMACCallers implements A4: every call to the package-internal
+// computeMAC helper must have an enclosing func whose go/types FullName is in
+// allowlist. computeMAC is called as a bare same-package ident; the callee is
+// resolved via info.Uses and matched on FullName so a same-named func elsewhere
+// is not mistaken for it. Passing allowlist as a parameter lets the anti-vacuity
+// self-test re-run with an empty allowlist to prove the scan actually detects the
+// real callers.
+func scanWebhookComputeMACCallers(
+	fset *token.FileSet, file *ast.File, rel string, info *types.Info, allowlist map[string]bool,
+) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return
+		}
+		fnObj, ok := info.Uses[ident].(*types.Func)
+		if !ok || fnObj.FullName() != hmacSanctionedComputeMACFunc {
+			return
+		}
+		if enc, ok := ResolveEnclosingFunc(info, file, call); ok && enc != nil && allowlist[enc.FullName()] {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(call.Pos()).Line,
+			Message: "computeMAC called outside the sanctioned signer/verifier; MAC computation " +
+				"must funnel through hmacSigner.Sign / hmacVerifier.Verify (WEBHOOK-HMAC-FUNNEL-01/A4)",
 		})
 	})
 	return out
@@ -236,12 +309,20 @@ func collectWebhookSealedMarkers(fset *token.FileSet, file *ast.File, rel string
 	return found
 }
 
-// scanWebhookPkg runs the A1/A2/B6 file-level scans and sealed-marker
+// webhookScanAccum collects the per-rule diagnostic slices threaded through
+// scanWebhookPkg, keeping that helper's signature within lint limits while it
+// fans the file scans (A1/A2/A4/B6) plus sealed-marker collection.
+type webhookScanAccum struct {
+	a1, a2, a4, b6 *[]Diagnostic
+	sealed         map[string]webhookSealInfo
+}
+
+// scanWebhookPkg runs the A1/A2/A4/B6 file-level scans and sealed-marker
 // collection over all non-test production files in the webhook package pass.
 // Extracted from CheckWebhookHMACFunnel to keep the Check func within
 // gocognit ≤15. It returns a package-anchor rel (preferring signer.go) used to
 // locate the A3 "interface not found" diagnostic, which has no decl to point at.
-func scanWebhookPkg(p *Pass, a1, a2, b6 *[]Diagnostic, sealed map[string]webhookSealInfo) string {
+func scanWebhookPkg(p *Pass, acc webhookScanAccum) string {
 	var pkgRel string
 	for _, f := range p.Files {
 		rel := p.Rel(f)
@@ -251,18 +332,19 @@ func scanWebhookPkg(p *Pass, a1, a2, b6 *[]Diagnostic, sealed map[string]webhook
 		if pkgRel == "" || filepath.Base(filepath.ToSlash(rel)) == signerFileBasename {
 			pkgRel = rel
 		}
-		*a1 = append(*a1, scanWebhookHMACNew(p.Fset, f, rel, p.TypesInfo)...)
-		*a2 = append(*a2, scanWebhookBytesEqual(p.Fset, f, rel, p.TypesInfo)...)
-		*b6 = append(*b6, scanWebhookSecretSlog(p.Fset, f, rel, p.TypesInfo)...)
+		*acc.a1 = append(*acc.a1, scanWebhookHMACNew(p.Fset, f, rel, p.TypesInfo)...)
+		*acc.a2 = append(*acc.a2, scanWebhookBytesEqual(p.Fset, f, rel, p.TypesInfo)...)
+		*acc.a4 = append(*acc.a4, scanWebhookComputeMACCallers(p.Fset, f, rel, p.TypesInfo, computeMACCallerAllowlist)...)
+		*acc.b6 = append(*acc.b6, scanWebhookSecretSlog(p.Fset, f, rel, p.TypesInfo)...)
 		for name, info := range collectWebhookSealedMarkers(p.Fset, f, rel) {
-			sealed[name] = info
+			acc.sealed[name] = info
 		}
 	}
 	return pkgRel
 }
 
 // CheckWebhookHMACFunnel runs the WEBHOOK-HMAC-FUNNEL-01 production scan
-// (A1/A2/A3/B6) and returns all diagnostics.
+// (A1/A2/A3/A4/B6) and returns all diagnostics.
 //
 // cfg is unused: kernel/webhook has no build-tagged production files, so a
 // single default-config scan is complete.
@@ -276,7 +358,7 @@ func scanWebhookPkg(p *Pass, a1, a2, b6 *[]Diagnostic, sealed map[string]webhook
 func CheckWebhookHMACFunnel(t *testing.T, _ ConfigForExternalCell) []Diagnostic {
 	t.Helper()
 
-	var a1, a2, b6 []Diagnostic
+	var a1, a2, a4, b6 []Diagnostic
 	sealed := map[string]webhookSealInfo{}
 	var pkgRel string
 
@@ -285,13 +367,14 @@ func CheckWebhookHMACFunnel(t *testing.T, _ ConfigForExternalCell) []Diagnostic 
 			if p.Pkg == nil || p.Pkg.Path() != webhookPkgPath {
 				return nil
 			}
-			pkgRel = scanWebhookPkg(p, &a1, &a2, &b6, sealed)
+			pkgRel = scanWebhookPkg(p, webhookScanAccum{a1: &a1, a2: &a2, a4: &a4, b6: &b6, sealed: sealed})
 			return nil
 		})
 
 	var all []Diagnostic
 	all = append(all, a1...)
 	all = append(all, a2...)
+	all = append(all, a4...)
 	all = append(all, b6...)
 	all = append(all, checkWebhookSealedMarkers(sealed, pkgRel)...)
 	return all

--- a/tools/archtest/webhook_hmac_funnel.go
+++ b/tools/archtest/webhook_hmac_funnel.go
@@ -31,12 +31,15 @@
 //     #893 / #1282 / #1375; #1243 is relabeled won't-do and named here as that
 //     ceiling's tracker. Detection: the Signer/Verifier interface type decls must
 //     contain an unexported method.
-//   - A4 (Medium, internal axis; #1243): every call to the package-internal
-//     computeMAC helper must have an enclosing func whose go/types FullName ∈
-//     {hmacSigner.Sign, hmacVerifier.Verify}. This is the actual enforcement of
-//     "only the sanctioned signer/verifier may compute a MAC", closing the A3
-//     internal axis at Medium (Hard is the permanent ceiling above). Detection:
-//     info.Uses callee FullName == computeMAC's AND enclosing FullName ∉ allowlist.
+//   - A4 (Medium, internal axis; #1243): every USE of the package-internal
+//     computeMAC symbol — direct call, parenthesized call, OR function-value
+//     capture (`macFn := computeMAC`; the bypass review #1733 F4 flagged) — must
+//     have an enclosing func whose go/types FullName ∈ {hmacSigner.Sign,
+//     hmacVerifier.Verify}. This is the actual enforcement of "only the sanctioned
+//     signer/verifier may compute a MAC", closing the A3 internal axis at Medium
+//     (Hard is the permanent ceiling above). Detection: walk every ident, match
+//     info.Uses FullName == computeMAC's, require enclosing FullName ∈ allowlist
+//     (the computeMAC definition is in info.Defs, not info.Uses, so it never fires).
 //
 // Blind spots (ai-robust 强制反向自检; each has a reverse self-test in the _test.go):
 //
@@ -168,34 +171,34 @@ func scanWebhookHMACNew(fset *token.FileSet, file *ast.File, rel string, info *t
 	return out
 }
 
-// scanWebhookComputeMACCallers implements A4: every call to the package-internal
-// computeMAC helper must have an enclosing func whose go/types FullName is in
-// allowlist. computeMAC is called as a bare same-package ident; the callee is
-// resolved via info.Uses and matched on FullName so a same-named func elsewhere
-// is not mistaken for it. Passing allowlist as a parameter lets the anti-vacuity
-// self-test re-run with an empty allowlist to prove the scan actually detects the
-// real callers.
+// scanWebhookComputeMACCallers implements A4: every USE of the package-internal
+// computeMAC symbol must have an enclosing func whose go/types FullName is in
+// allowlist. It walks every identifier and matches info.Uses to computeMAC's
+// FullName, so ALL use forms are covered — direct call `computeMAC(...)`,
+// parenthesized `(computeMAC)(...)`, and function-value capture
+// `macFn := computeMAC` (the bypass review #1733 F4 flagged); the older
+// call.Fun.(*ast.Ident) form only caught direct calls. The computeMAC *definition*
+// ident lives in info.Defs (not info.Uses), so signer.go's declaration never
+// false-fires. Passing allowlist as a parameter lets the anti-vacuity self-test
+// re-run with an empty allowlist to prove the scan detects the real uses.
 func scanWebhookComputeMACCallers(
 	fset *token.FileSet, file *ast.File, rel string, info *types.Info, allowlist map[string]bool,
 ) []Diagnostic {
 	var out []Diagnostic
-	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		ident, ok := call.Fun.(*ast.Ident)
-		if !ok {
-			return
-		}
-		fnObj, ok := info.Uses[ident].(*types.Func)
+	EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+		fnObj, ok := info.Uses[id].(*types.Func)
 		if !ok || fnObj.FullName() != hmacSanctionedComputeMACFunc {
 			return
 		}
-		if enc, ok := ResolveEnclosingFunc(info, file, call); ok && enc != nil && allowlist[enc.FullName()] {
+		if enc, ok := ResolveEnclosingFunc(info, file, id); ok && enc != nil && allowlist[enc.FullName()] {
 			return
 		}
 		out = append(out, Diagnostic{
 			Rel:  rel,
-			Line: fset.Position(call.Pos()).Line,
-			Message: "computeMAC called outside the sanctioned signer/verifier; MAC computation " +
-				"must funnel through hmacSigner.Sign / hmacVerifier.Verify (WEBHOOK-HMAC-FUNNEL-01/A4)",
+			Line: fset.Position(id.Pos()).Line,
+			Message: "computeMAC used outside the sanctioned signer/verifier (direct call, " +
+				"parenthesized call, or function-value capture); MAC computation must funnel " +
+				"through hmacSigner.Sign / hmacVerifier.Verify (WEBHOOK-HMAC-FUNNEL-01/A4)",
 		})
 	})
 	return out

--- a/tools/archtest/webhook_hmac_funnel_test.go
+++ b/tools/archtest/webhook_hmac_funnel_test.go
@@ -27,12 +27,14 @@
 //     same family as #851 / #893 / #1282 / #1375; #1243 is relabeled won't-do and
 //     named here as that ceiling's tracker. Detection: the Signer/Verifier
 //     interface type decls must contain an unexported method.
-//   - A4 (Medium, internal axis; #1243): every call to the package-internal
-//     computeMAC helper must have an enclosing func whose go/types FullName ∈
-//     {hmacSigner.Sign, hmacVerifier.Verify}. This is the actual enforcement of
-//     "only the sanctioned signer/verifier may compute a MAC", closing the A3
-//     internal axis at Medium. Detection: info.Uses callee FullName == computeMAC's
-//     AND enclosing FullName ∉ allowlist.
+//   - A4 (Medium, internal axis; #1243): every USE of the package-internal
+//     computeMAC symbol — direct call, parenthesized call, OR function-value
+//     capture (`macFn := computeMAC`; bypass review #1733 F4) — must have an
+//     enclosing func whose go/types FullName ∈ {hmacSigner.Sign,
+//     hmacVerifier.Verify}. This is the actual enforcement of "only the sanctioned
+//     signer/verifier may compute a MAC", closing the A3 internal axis at Medium.
+//     Detection: walk every ident, match info.Uses FullName == computeMAC's,
+//     require enclosing FullName ∈ allowlist (definition is in info.Defs).
 //
 // Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
 //

--- a/tools/archtest/webhook_hmac_funnel_test.go
+++ b/tools/archtest/webhook_hmac_funnel_test.go
@@ -3,13 +3,13 @@
 // WEBHOOK-HMAC-FUNNEL-01 — kernel/webhook HMAC signing funnel (KERNEL-WEBHOOK-01).
 //
 //   - A1 (downstream Hard): crypto/hmac.New has exactly one callsite in the
-//     kernel/webhook package — the computeMAC function in signer.go. The check is
-//     FUNCTION-level, not file-level: an hmac.New in any other function (even
-//     inside signer.go) fails. This also closes the package-internal upstream
-//     blind spot: any new struct that wants to sign MUST call hmac.New, which is
-//     allowlisted to computeMAC, so an unsealed internal holder cannot produce a
-//     signature undetected. Detection: ResolvePackageRef(callee) == crypto/hmac.New
-//     AND (file basename != signer.go OR enclosing func != computeMAC).
+//     kernel/webhook package — the computeMAC function. The check is
+//     FUNCTION-IDENTITY level via go/types FullName (file-independent; #1493): an
+//     hmac.New whose enclosing func FullName != computeMAC's fails, and a
+//     same-named function in another package cannot inherit the allowance
+//     (mirrors WEBHOOK-SSRF-GUARD-01/A2). Detection: ResolvePackageRef(callee) ==
+//     crypto/hmac.New AND ResolveEnclosingFunc(call).FullName() !=
+//     hmacSanctionedComputeMACFunc.
 //   - A2 (downstream Hard): signature comparison must use crypto/hmac.Equal or
 //     crypto/subtle.ConstantTimeCompare. The non-constant-time comparison callees
 //     bytes.Equal / bytes.Compare / slices.Equal / reflect.DeepEqual are banned in
@@ -17,12 +17,22 @@
 //     a flaky timing test. Detection: ResolvePackageRef(callee) ∈ the banned set.
 //   - A3 (upstream Hard external / Medium internal): the Signer and Verifier
 //     interfaces each carry an unexported sealed() marker method, so
-//     package-external implementations are a compile error (Hard). Package-internal
-//     new holders are not blocked by sealing (Medium) — covered transitively by
-//     A1. Explicit Hard-ization of the internal axis (unexported method-set
-//     interface + private construction, per the SPAN-SETATTR-HOLDER-SEAL #851
-//     precedent) is tracked in gh #1243. Detection: the Signer/Verifier interface
-//     type decls must contain an unexported method.
+//     package-external implementations are a compile error (Hard external).
+//     Package-internal new holders are NOT blocked by sealing — and contrary to a
+//     prior overclaim, A1 does NOT transitively cover them: A1 locks only
+//     crypto/hmac.New, not reuse of the package-level computeMAC helper. That
+//     internal axis is covered by A4 (computeMAC caller-allowlist, Medium). True
+//     type-system Hard for the internal axis is a PERMANENT Go ceiling (in-package
+//     code can always declare sealed(), read Source.secret, and call computeMAC) —
+//     same family as #851 / #893 / #1282 / #1375; #1243 is relabeled won't-do and
+//     named here as that ceiling's tracker. Detection: the Signer/Verifier
+//     interface type decls must contain an unexported method.
+//   - A4 (Medium, internal axis; #1243): every call to the package-internal
+//     computeMAC helper must have an enclosing func whose go/types FullName ∈
+//     {hmacSigner.Sign, hmacVerifier.Verify}. This is the actual enforcement of
+//     "only the sanctioned signer/verifier may compute a MAC", closing the A3
+//     internal axis at Medium. Detection: info.Uses callee FullName == computeMAC's
+//     AND enclosing FullName ∉ allowlist.
 //
 // Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
 //
@@ -31,6 +41,10 @@
 //	  outside signer.go and inside signer.go in a non-computeMAC func) and the
 //	  banned comparison callees; TestWebhookHMACFunnel_ReverseFixture asserts A1/A2
 //	  fire on each form.
+//	B-A4 — rule-logic regression (computeMAC is unexported, so no standalone-module
+//	  RED fixture can call it): TestWebhookHMACFunnel_ComputeMACCallerAntiVacuity
+//	  re-runs the A4 scan over real production with an EMPTY allowlist and asserts it
+//	  fires on the ≥2 real computeMAC callers (Sign + Verify).
 //	B6 — Source.Secret leak: slog of the raw unexported secret field would leak
 //	  it (Source.LogValue + slog.LogValuer covers slog.Any of a whole Source, but
 //	  not slog of src.secret directly). scanWebhookSecretSlog covers BOTH the
@@ -168,4 +182,42 @@ func TestWebhookHMACFunnel_SealedMarkerDiagnosticsLocated(t *testing.T) {
 		"Signer":   {hasUnexported: false, rel: "kernel/webhook/signer.go", line: 12},
 		"Verifier": {hasUnexported: false, rel: "kernel/webhook/verifier.go", line: 8},
 	}, "kernel/webhook/signer.go"))
+}
+
+// TestWebhookHMACFunnel_ComputeMACCallerAntiVacuity is the B-A4 self-check.
+// computeMAC is unexported, so a standalone-module RED fixture cannot call it;
+// instead this re-runs the A4 scan over REAL production with an EMPTY allowlist
+// and asserts it fires on the actual computeMAC callers (≥2: hmacSigner.Sign +
+// hmacVerifier.Verify). That proves the scan genuinely detects computeMAC calls
+// and that the real allowlist (not a vacuous scan) is what makes production GREEN.
+func TestWebhookHMACFunnel_ComputeMACCallerAntiVacuity(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var fired []Diagnostic
+	_ = Run(t, Typed(TypedOpts{Tests: false}, []string{webhookPkgPattern}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != webhookPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				// Empty allowlist → every computeMAC caller is a violation.
+				fired = append(fired, scanWebhookComputeMACCallers(p.Fset, f, rel, p.TypesInfo, map[string]bool{})...)
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, len(fired), 2,
+		"A4 anti-vacuity: empty allowlist must fire on ≥2 real computeMAC callers "+
+			"(hmacSigner.Sign + hmacVerifier.Verify); got %d — scan may be vacuous", len(fired))
+	for i, d := range fired {
+		assert.NotEmpty(t, d.Rel, "A4 anti-vacuity: diagnostic[%d] has empty Rel (not clickable)", i)
+		assert.Greater(t, d.Line, 0, "A4 anti-vacuity: diagnostic[%d] Line = %d, want > 0", i, d.Line)
+	}
 }

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -4,10 +4,11 @@
 //
 // The three outbound webhook signature headers (webhook-id / webhook-timestamp
 // / webhook-signature) define GoCell's outbound identity protocol. This rule is
-// a CLOSED double-lock funnel (#1492): [(SignedHeaders).Apply] is the SOLE write
-// site for these header names (A1, downstream), and [SignedHeaders] — the value
-// Apply writes — is sealed-construction so only [Signer.Sign] can produce one
-// (A2, upstream Hard external).
+// a CLOSED double-lock funnel (#1492 + #1733 F1): [(SignedHeaders).Apply] is the
+// SOLE write site for these header names (A1, downstream), and [SignedHeaders] —
+// the value Apply writes — is sealed-construction + a `valid` provenance flag so
+// only [Signer.Sign] can produce a wire-writable one; Apply fail-closes on a
+// zero value (A2, upstream Hard external).
 //
 //   - A1 (downstream Hard): scan production (non-_test.go) files in
 //     kernel/webhook/... and runtime/webhook/... for any
@@ -19,16 +20,24 @@
 //     to confirm the callee is net/http.Header.Set (alias-safe),
 //     EvaluateConstString to fold the key argument across const refs and raw
 //     literals, and ResolveEnclosingFunc to bind the allowance to a go/types
-//     FullName identity (file- and name-independent).
-//   - A2 (upstream Hard external, sealed construction + reflect freeze):
-//     [SignedHeaders] has UNEXPORTED fields and no exported constructor, so an
-//     outside-package literal forge (webhook.SignedHeaders{signature: …}) is a
-//     Go compile error; only the sealed [Signer.Sign] produces a SignedHeaders.
-//     The reflect schema freeze (NumField + per-field name/type/unexported)
-//     locks the field set against in-package drift — exporting a field would
-//     re-open the forge vector; rename/reorder/add/remove breaks the Apply
-//     contract. Detection: reflect.TypeOf(webhook.SignedHeaders{}) vs the frozen
-//     tuple (TestWebhookSignerFunnel_SignedHeadersSealedFields).
+//     FullName identity (file- and name-independent). Plus (review #1733 F2):
+//     a (net/http.Header).Set captured as a METHOD VALUE — `set := h.Set;
+//     set("webhook-signature", v)` — is banned outright in the scanned tree
+//     (scanSignerHeaderSetMethodValue), because the eventual key is not visible at
+//     the capture site; the only sanctioned signature-header write is a direct
+//     (SignedHeaders).Apply call.
+//   - A2 (upstream Hard external, sealed construction + valid-token + reflect
+//     freeze): [SignedHeaders] has UNEXPORTED fields, so an outside-package
+//     POPULATED literal forge (webhook.SignedHeaders{signature: …}) is a Go
+//     compile error. Unexported fields alone do NOT stop a ZERO-value construction
+//     (`var h webhook.SignedHeaders`; review #1733 F1), so the type carries an
+//     unexported `valid` provenance flag that ONLY [Signer.Sign] sets, and
+//     [SignedHeaders.Apply] fail-closes (writes nothing) on a zero value — thus
+//     only a Sign-produced SignedHeaders can write to the wire. The reflect schema
+//     freeze (NumField + per-field name/type/unexported, INCL. `valid`) locks the
+//     field set against in-package drift — exporting any field (esp. `valid`)
+//     re-opens the forge vector. Detection: reflect.TypeOf(webhook.SignedHeaders{})
+//     vs the frozen tuple (TestWebhookSignerFunnel_SignedHeadersSealedFields).
 //
 // AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
 //
@@ -37,18 +46,21 @@
 //	  is ineffective. EvaluateConstString folds across const definitions.
 //	  ResolveEnclosingFunc binds the allowance to a go/types FullName — a
 //	  stray func that merely shares the name "Apply" cannot inherit it.
-//	上游 Hard (external) — CLOSED by #1492. Before #1492, Apply lived on the
-//	  public [Headers] struct with EXPORTED fields (also the inbound Verify DTO),
-//	  so any caller could hand-build a `webhook.Headers{Signature: …}` literal and
-//	  Apply it — provenance was open. #1492 split the type: the inbound parse DTO
-//	  stays [Headers] (untrusted by design — a forged inbound Headers just fails
-//	  Verify), while the OUTBOUND value Apply writes is the sealed [SignedHeaders]
-//	  (unexported fields, produced only by [Signer.Sign] — "sealed construction"
-//	  范本). Outside-package construction is now a Go compile error; A2's reflect
-//	  freeze guards in-package field drift. So the value reaching the wire via
-//	  Apply provably originated from the sealed signer. (Read-only accessors on
-//	  SignedHeaders do not weaken this — the seal is on construction, and the
-//	  values travel on the wire in plaintext anyway.)
+//	上游 Hard (external) — CLOSED by #1492 + valid-token (#1733 F1). Before #1492,
+//	  Apply lived on the public [Headers] struct with EXPORTED fields, so any caller
+//	  could hand-build a `webhook.Headers{Signature: …}` literal and Apply it. #1492
+//	  split the type: the inbound parse DTO stays [Headers] (untrusted by design — a
+//	  forged inbound Headers just fails Verify), while the OUTBOUND value Apply
+//	  writes is the sealed [SignedHeaders]. Unexported fields stop a POPULATED
+//	  outside-package literal (compile error) but NOT a ZERO-value construction
+//	  (`var h webhook.SignedHeaders`) — the overclaim review #1733 F1 caught. The
+//	  closure is the unexported `valid` provenance flag: only [Signer.Sign] sets it,
+//	  and Apply fail-closes (writes nothing) when valid==false, so an external
+//	  zero-value Apply writes no signature headers. External code can set neither a
+//	  populated literal nor `valid`, so only a Sign-produced SignedHeaders reaches
+//	  the wire. A2's reflect freeze locks the field set (incl. `valid`) against
+//	  in-package drift. (Read-only accessors don't weaken this — the seal is on
+//	  construction; values travel on the wire in plaintext.)
 //	上游 (package-internal holder axis) — permanent Go ceiling. A same-package
 //	  SignedHeaders{…} literal (Go allows in-package access to unexported fields)
 //	  is not compile-prevented; the A1 scan catches a stray in-package Header.Set
@@ -73,9 +85,13 @@
 // Blind spots (ai-robust 强制反向自检; each has a reverse self-test below):
 //
 //	B-A1 — rule-logic regression: testdata/webhook_signer_violate exercises
-//	  Header.Set with a raw string literal key and with a const key that
-//	  evaluates to each of the three header names;
+//	  Header.Set with a raw string literal key, a const key per header name, AND
+//	  a method-value capture (`set := h.Set`, #1733 F2);
 //	  TestWebhookSignerFunnel_ReverseFixture asserts A1 fires on each form.
+//	B-methodvalue — CLOSED (#1733 F2): a (net/http.Header).Set method-value capture
+//	  is now caught by scanSignerHeaderSetMethodValue. The remaining uncovered form
+//	  is reflection (reflect.Value.Call on Header.Set) — the permanent AST-scan
+//	  ceiling, same as the B3 raw-write below; not realistically reachable.
 //	B3 — fmt.Fprintf raw-write bypass: code that writes the header via
 //	  fmt.Fprintf(w, "webhook-signature: %s\r\n", val) on a raw net.Conn or
 //	  bufio.Writer cannot be caught by the Set-callee scan (no CallExpr with a
@@ -128,43 +144,42 @@ var webhookSignatureHeaders = map[string]bool{
 	"webhook-signature": true,
 }
 
-// scanSignerHeaderSet implements A1: http.Header.Set calls whose key evaluates
-// to one of the three signature-header names must be enclosed by
-// signerSanctionedApplyFunc. Any other enclosing function (including the
+// isNetHTTPHeaderSetSelector reports whether sel resolves to the
+// (net/http.Header).Set method — type-resolved (alias-safe), confirming both the
+// method (Set in net/http) and the receiver type (net/http.Header). Shared by the
+// direct-call scan (A1) and the method-value-capture scan (A1, review #1733 F2).
+func isNetHTTPHeaderSetSelector(info *types.Info, sel *ast.SelectorExpr) bool {
+	fn, ok := ResolveMethodCall(info, sel)
+	if !ok || fn == nil || fn.Pkg() == nil ||
+		fn.Pkg().Path() != httpPkgPath || fn.Name() != "Set" {
+		return false
+	}
+	recvType := info.TypeOf(sel.X)
+	if recvType == nil {
+		return false
+	}
+	if ptr, ok := recvType.(*types.Pointer); ok {
+		recvType = ptr.Elem()
+	}
+	named, ok := recvType.(*types.Named)
+	if !ok {
+		return false
+	}
+	return named.Obj() != nil && named.Obj().Pkg() != nil &&
+		named.Obj().Pkg().Path() == httpPkgPath && named.Obj().Name() == "Header"
+}
+
+// scanSignerHeaderSet implements A1 (direct call): (net/http.Header).Set calls
+// whose key evaluates to one of the three signature-header names must be enclosed
+// by signerSanctionedApplyFunc. Any other enclosing function (including the
 // package-level init or a FuncLit) is a violation.
 func scanSignerHeaderSet(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
 	var out []Diagnostic
 	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-		// Confirm the callee is (net/http.Header).Set — type-resolved, so import
-		// aliases cannot bypass.
 		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
+		if !ok || !isNetHTTPHeaderSetSelector(info, sel) {
 			return
 		}
-		fn, ok := ResolveMethodCall(info, sel)
-		if !ok || fn == nil || fn.Pkg() == nil ||
-			fn.Pkg().Path() != httpPkgPath || fn.Name() != "Set" {
-			return
-		}
-		// Confirm the receiver type is net/http.Header (not some other type
-		// that also has a Set method).
-		recvType := info.TypeOf(sel.X)
-		if recvType == nil {
-			return
-		}
-		// Unwrap pointer if needed.
-		if ptr, ok := recvType.(*types.Pointer); ok {
-			recvType = ptr.Elem()
-		}
-		named, ok := recvType.(*types.Named)
-		if !ok {
-			return
-		}
-		if named.Obj() == nil || named.Obj().Pkg() == nil ||
-			named.Obj().Pkg().Path() != httpPkgPath || named.Obj().Name() != "Header" {
-			return
-		}
-
 		// Call is confirmed to be (net/http.Header).Set. Evaluate the key arg.
 		if len(call.Args) < 1 {
 			return
@@ -173,7 +188,6 @@ func scanSignerHeaderSet(fset *token.FileSet, file *ast.File, rel string, info *
 		if !ok || !webhookSignatureHeaders[keyVal] {
 			return
 		}
-
 		// Key matches a signature header. Check the enclosing function.
 		enc, ok := ResolveEnclosingFunc(info, file, call)
 		if ok && enc != nil && enc.FullName() == signerSanctionedApplyFunc {
@@ -185,6 +199,38 @@ func scanSignerHeaderSet(fset *token.FileSet, file *ast.File, rel string, info *
 			Message: "http.Header.Set with key \"" + keyVal + "\" called outside " +
 				"(SignedHeaders).Apply; signature headers must only be written by " +
 				"SignedHeaders.Apply (WEBHOOK-SIGNER-FUNNEL-01/A1)",
+		})
+	})
+	return out
+}
+
+// scanSignerHeaderSetMethodValue implements A1's method-value closure (review
+// #1733 F2): (net/http.Header).Set captured as a METHOD VALUE rather than called
+// directly — e.g. `set := req.Header.Set; set("webhook-signature", v)` — bypasses
+// the direct-call key check, because the eventual key is not visible at the capture
+// site. There is no legitimate reason to capture Header.Set in kernel/webhook or
+// runtime/webhook (the sole signature-header writer is the direct calls inside
+// (SignedHeaders).Apply), so ANY such capture is a violation. Detection: a
+// SelectorExpr resolving to (net/http.Header).Set that is NOT a direct call callee.
+func scanSignerHeaderSetMethodValue(fset *token.FileSet, file *ast.File, rel string, info *types.Info) []Diagnostic {
+	var out []Diagnostic
+	// SelectorExprs that ARE direct call callees are handled by scanSignerHeaderSet.
+	directCallee := map[*ast.SelectorExpr]bool{}
+	EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			directCallee[sel] = true
+		}
+	})
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+		if directCallee[sel] || !isNetHTTPHeaderSetSelector(info, sel) {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(sel.Pos()).Line,
+			Message: "net/http.Header.Set captured as a method value (not a direct call); " +
+				"signature-header writes must be direct (SignedHeaders).Apply calls so the key " +
+				"is verifiable (WEBHOOK-SIGNER-FUNNEL-01/A1)",
 		})
 	})
 	return out
@@ -232,6 +278,7 @@ func TestWebhookSignerFunnel(t *testing.T) {
 					continue
 				}
 				a1 = append(a1, scanSignerHeaderSet(p.Fset, f, rel, p.TypesInfo)...)
+				a1 = append(a1, scanSignerHeaderSetMethodValue(p.Fset, f, rel, p.TypesInfo)...)
 			}
 			return nil
 		})
@@ -245,13 +292,14 @@ func TestWebhookSignerFunnel(t *testing.T) {
 //
 // The fixture covers:
 //
-//   - raw string literal key "webhook-signature"
-//   - const key whose value is "webhook-signature"
-//   - const key whose value is "webhook-id"
-//   - const key whose value is "webhook-timestamp"
+//   - raw string literal key "webhook-signature" (direct call)
+//   - const key whose value is "webhook-signature" (direct call)
+//   - const key whose value is "webhook-id" (direct call)
+//   - const key whose value is "webhook-timestamp" (direct call)
+//   - a (net/http.Header).Set method-value capture `set := h.Set` (#1733 F2)
 //
-// so that dropping any one of the three header names from webhookSignatureHeaders
-// causes this test to fail.
+// so that dropping any one of the three header names from webhookSignatureHeaders,
+// or the method-value branch, causes this test to fail.
 func TestWebhookSignerFunnel_ReverseFixture(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -273,21 +321,23 @@ func TestWebhookSignerFunnel_ReverseFixture(t *testing.T) {
 					continue
 				}
 				a1 = append(a1, scanSignerHeaderSet(p.Fset, f, rel, p.TypesInfo)...)
+				a1 = append(a1, scanSignerHeaderSetMethodValue(p.Fset, f, rel, p.TypesInfo)...)
 			}
 			return nil
 		})
 
-	// The fixture has exactly 4 violations:
-	//   - 1 raw string literal key "webhook-signature"
-	//   - 3 const-keyed calls, one per header name (webhook-id / webhook-timestamp
+	// The fixture has exactly 5 violations:
+	//   - 1 raw string literal key "webhook-signature" (direct call, scanSignerHeaderSet)
+	//   - 3 const-keyed direct calls, one per header name (webhook-id / webhook-timestamp
 	//     / webhook-signature)
-	// Asserting ≥4 ensures that dropping ANY single fixture violation (e.g. removing
-	// one const form or one header name from webhookSignatureHeaders) causes this
-	// self-test to fail immediately, rather than passing on the remaining 3.
-	const webhookSignerFixtureMinViolations = 4
+	//   - 1 method-value capture `set := h.Set` (scanSignerHeaderSetMethodValue, #1733 F2)
+	// Asserting ≥5 ensures that dropping ANY single fixture violation (e.g. removing
+	// one const form, one header name, or the method-value branch) causes this
+	// self-test to fail immediately, rather than passing on the remaining ones.
+	const webhookSignerFixtureMinViolations = 5
 	assert.GreaterOrEqual(t, len(a1), webhookSignerFixtureMinViolations,
-		"A1 reverse fixture: expected ≥4 diagnostics (1 raw literal + 3 const refs, "+
-			"one per header name webhook-id / webhook-timestamp / webhook-signature)")
+		"A1 reverse fixture: expected ≥5 diagnostics (1 raw literal + 3 const refs + "+
+			"1 method-value capture)")
 }
 
 // ---- A2: SignedHeaders sealed-construction reflect freeze (#1492) ----
@@ -309,10 +359,15 @@ type frozenSignedHeadersField struct {
 
 // frozenSignedHeadersFields is the expected exact field tuple for
 // webhook.SignedHeaders (in Go struct declaration order). All MUST be unexported.
+// `valid` is the provenance flag (#1733 F1): only Signer.Sign sets it, and Apply
+// fail-closes on a zero value, so an external zero-value SignedHeaders cannot
+// write to the wire. It MUST stay unexported (an exported `Valid` would let an
+// external caller forge a valid value).
 var frozenSignedHeadersFields = []frozenSignedHeadersField{
 	{name: "deliveryID", typeName: "webhook.DeliveryID", exported: false},
 	{name: "timestamp", typeName: "string", exported: false},
 	{name: "signature", typeName: "string", exported: false},
+	{name: "valid", typeName: "bool", exported: false},
 }
 
 // TestWebhookSignerFunnel_SignedHeadersSealedFields is the A2 primary guard: it

--- a/tools/archtest/webhook_signer_funnel_test.go
+++ b/tools/archtest/webhook_signer_funnel_test.go
@@ -3,28 +3,32 @@
 // WEBHOOK-SIGNER-FUNNEL-01 — kernel/webhook signature-header write funnel.
 //
 // The three outbound webhook signature headers (webhook-id / webhook-timestamp
-// / webhook-signature) define GoCell's outbound identity protocol. This rule
-// makes [(Headers).Apply] the SOLE write site for these header names, so no code
-// can emit a signature header by calling http.Header.Set with one of the three
-// strings directly. (Provenance — guaranteeing the written value actually came
-// from a sealed [Signer.Sign] rather than a hand-built Headers literal — is a
-// separate, NOT-yet-closed axis; see the rating below and gh #1492.)
-//
-// This rule locks every http.Header.Set call whose key argument evaluates to
-// one of the three header-name constant values to the sole sanctioned body:
-// [(Headers).Apply] in kernel/webhook/webhook.go.
+// / webhook-signature) define GoCell's outbound identity protocol. This rule is
+// a CLOSED double-lock funnel (#1492): [(SignedHeaders).Apply] is the SOLE write
+// site for these header names (A1, downstream), and [SignedHeaders] — the value
+// Apply writes — is sealed-construction so only [Signer.Sign] can produce one
+// (A2, upstream Hard external).
 //
 //   - A1 (downstream Hard): scan production (non-_test.go) files in
 //     kernel/webhook/... and runtime/webhook/... for any
 //     (net/http.Header).Set call whose key argument evaluates (via
 //     EvaluateConstString) to one of the three header-name strings
 //     ("webhook-id" / "webhook-timestamp" / "webhook-signature"). Any such
-//     call whose enclosing function is NOT [signerSanctionedApplyFunc] is a
-//     violation. Detection uses ResolveMethodCall to confirm the callee is
-//     net/http.Header.Set (alias-safe), EvaluateConstString to fold the key
-//     argument across const refs and raw literals, and ResolveEnclosingFunc to
-//     bind the allowance to a go/types FullName identity (file- and
-//     name-independent).
+//     call whose enclosing function is NOT [signerSanctionedApplyFunc]
+//     ((SignedHeaders).Apply) is a violation. Detection uses ResolveMethodCall
+//     to confirm the callee is net/http.Header.Set (alias-safe),
+//     EvaluateConstString to fold the key argument across const refs and raw
+//     literals, and ResolveEnclosingFunc to bind the allowance to a go/types
+//     FullName identity (file- and name-independent).
+//   - A2 (upstream Hard external, sealed construction + reflect freeze):
+//     [SignedHeaders] has UNEXPORTED fields and no exported constructor, so an
+//     outside-package literal forge (webhook.SignedHeaders{signature: …}) is a
+//     Go compile error; only the sealed [Signer.Sign] produces a SignedHeaders.
+//     The reflect schema freeze (NumField + per-field name/type/unexported)
+//     locks the field set against in-package drift — exporting a field would
+//     re-open the forge vector; rename/reorder/add/remove breaks the Apply
+//     contract. Detection: reflect.TypeOf(webhook.SignedHeaders{}) vs the frozen
+//     tuple (TestWebhookSignerFunnel_SignedHeadersSealedFields).
 //
 // AI-robust rating (Funnel 双向锁评级, per .claude/rules/gocell/ai-robust.md):
 //
@@ -33,30 +37,25 @@
 //	  is ineffective. EvaluateConstString folds across const definitions.
 //	  ResolveEnclosingFunc binds the allowance to a go/types FullName — a
 //	  stray func that merely shares the name "Apply" cannot inherit it.
-//	上游 (provenance) — NOT closed (low-severity provenance gap; risk analysis
-//	  below). This is a Hard-downstream + open-upstream funnel, NOT a closed
-//	  double-lock. [Headers] is a PUBLIC struct with
-//	  EXPORTED fields and is ALSO the inbound DTO consumed by [Verifier.Verify]
-//	  (the receiver constructs a Headers from request headers), so a caller CAN
-//	  build a `webhook.Headers{Signature: …}` literal and call Apply with a value
-//	  that never came from a sealed [Signer.Sign]. The sealed Signer interface
-//	  (unexported sealed() marker, WEBHOOK-HMAC-FUNNEL-01/A3) prevents external
-//	  *Signer implementations*, but it does NOT prevent external *Headers
-//	  construction* — a struct literal needs no constructor. So this funnel
-//	  guarantees only uniform *where* the signature headers are written (A1
-//	  downstream Hard), NOT the *provenance* of the written value. A forged
-//	  Headers carries an invalid HMAC the receiver rejects, so the gap is
-//	  low-severity, not an exploitable forgery.
-//	  Closing it requires splitting Headers into a sealed outbound type (only
-//	  [Signer.Sign] produces it, only Apply consumes it) separate from the
-//	  inbound parse DTO — a real type change tracked at gh #1492. Per
-//	  .claude/rules/gocell/ai-robust.md Funnel 双向锁评级, a Hard-downstream +
-//	  open-upstream funnel must track the upstream Hard-化 in an issue and name
-//	  it here (#1492). The package-internal holder axis (a same-package struct
-//	  that holds a Headers field, caught by the A1 scan at CI not compile time)
-//	  is the same permanent ceiling as SPAN-SETATTR-HOLDER-SEAL (#851) /
-//	  HEALTHZ-HOLDER-SEAL (#893) / WEBHOOK-SSRF-GUARD-01 (#1375); #1492 subsumes
-//	  it for this funnel.
+//	上游 Hard (external) — CLOSED by #1492. Before #1492, Apply lived on the
+//	  public [Headers] struct with EXPORTED fields (also the inbound Verify DTO),
+//	  so any caller could hand-build a `webhook.Headers{Signature: …}` literal and
+//	  Apply it — provenance was open. #1492 split the type: the inbound parse DTO
+//	  stays [Headers] (untrusted by design — a forged inbound Headers just fails
+//	  Verify), while the OUTBOUND value Apply writes is the sealed [SignedHeaders]
+//	  (unexported fields, produced only by [Signer.Sign] — "sealed construction"
+//	  范本). Outside-package construction is now a Go compile error; A2's reflect
+//	  freeze guards in-package field drift. So the value reaching the wire via
+//	  Apply provably originated from the sealed signer. (Read-only accessors on
+//	  SignedHeaders do not weaken this — the seal is on construction, and the
+//	  values travel on the wire in plaintext anyway.)
+//	上游 (package-internal holder axis) — permanent Go ceiling. A same-package
+//	  SignedHeaders{…} literal (Go allows in-package access to unexported fields)
+//	  is not compile-prevented; the A1 scan catches a stray in-package Header.Set
+//	  at CI, not compile time. Same permanent ceiling as SPAN-SETATTR-HOLDER-SEAL
+//	  (#851) / HEALTHZ-HOLDER-SEAL (#893) / outbox principal-write (#1282) /
+//	  WEBHOOK-SSRF-GUARD-01 (#1375); Go cannot express "only Signer.Sign may build
+//	  it in-package", so no separate Hard-upgrade issue.
 //
 // Note: WEBHOOK-SIGNED-STRING-FORM-01 (signed-string "{deliveryID}.{timestamp}
 // .{body}" form) is NOT a new archtest here. It is already locked by:
@@ -96,29 +95,33 @@ import (
 	"go/token"
 	"go/types"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/webhook"
 )
 
 const (
 	// signerSanctionedApplyFunc is the go/types canonical FullName of the ONE
 	// function allowed to call Header.Set with a webhook signature-header key.
-	// Headers has a value receiver, so FullName does NOT have a leading "*".
+	// SignedHeaders has a value receiver, so FullName does NOT have a leading "*".
 	// Binding the A1 allowance to this type-resolved identity means a stray func
 	// that merely shares the name "Apply" cannot inherit it, and the method can
 	// move files freely without updating this const. A rename of the method flips
 	// every violation to caught (fail-closed), forcing the author to update here.
-	signerSanctionedApplyFunc = "(" + PlatformModulePath + "/kernel/webhook.Headers).Apply"
+	signerSanctionedApplyFunc = "(" + PlatformModulePath + "/kernel/webhook.SignedHeaders).Apply"
 
 	httpPkgPath = "net/http"
 )
 
 // webhookSignatureHeaders is the set of header-name string VALUES that are
-// locked to (Headers).Apply. The scan evaluates the key argument to a string
-// constant (EvaluateConstString) and checks membership here — covering both
-// raw string literals and const references from any package.
+// locked to (SignedHeaders).Apply. The scan evaluates the key argument to a
+// string constant (EvaluateConstString) and checks membership here — covering
+// both raw string literals and const references from any package.
 var webhookSignatureHeaders = map[string]bool{
 	"webhook-id":        true,
 	"webhook-timestamp": true,
@@ -180,8 +183,8 @@ func scanSignerHeaderSet(fset *token.FileSet, file *ast.File, rel string, info *
 			Rel:  rel,
 			Line: fset.Position(call.Pos()).Line,
 			Message: "http.Header.Set with key \"" + keyVal + "\" called outside " +
-				"(Headers).Apply; signature headers must only be written by " +
-				"Headers.Apply (WEBHOOK-SIGNER-FUNNEL-01/A1)",
+				"(SignedHeaders).Apply; signature headers must only be written by " +
+				"SignedHeaders.Apply (WEBHOOK-SIGNER-FUNNEL-01/A1)",
 		})
 	})
 	return out
@@ -212,7 +215,7 @@ func TestWebhookSignerFunnel(t *testing.T) {
 			// INCLUDING subpackages. Exact-match previously excluded
 			// runtime/webhook/dispatch — the ./runtime/webhook/... pattern loads
 			// it, but the filter dropped it — so a bare Header.Set of a signature
-			// header in the dispatcher consumer layer (where Headers.Apply is
+			// header in the dispatcher consumer layer (where SignedHeaders.Apply is
 			// actually called) would have slipped past the funnel. Subtree-match
 			// (exact base or base+"/") also auto-covers any future subpackage.
 			pkgPath := p.Pkg.Path()
@@ -285,4 +288,91 @@ func TestWebhookSignerFunnel_ReverseFixture(t *testing.T) {
 	assert.GreaterOrEqual(t, len(a1), webhookSignerFixtureMinViolations,
 		"A1 reverse fixture: expected ≥4 diagnostics (1 raw literal + 3 const refs, "+
 			"one per header name webhook-id / webhook-timestamp / webhook-signature)")
+}
+
+// ---- A2: SignedHeaders sealed-construction reflect freeze (#1492) ----
+//
+// "reflect schema freeze" Hard 范本 (ai-robust.md): reflect.Type.NumField /
+// StructField.PkgPath / StructField.Type are objective structural facts, so any
+// drift (export a field / rename / reorder / add / remove) trips a tuple mismatch
+// and forces the change onto this explicit checkpoint. The upstream-Hard-external
+// guarantee of WEBHOOK-SIGNER-FUNNEL-01 rests on SignedHeaders' fields staying
+// UNEXPORTED — an exported field would re-open `webhook.SignedHeaders{signature:…}`
+// outside-package literal forge (the very gap #1492 closed).
+
+// frozenSignedHeadersField is the expected frozen shape of one SignedHeaders field.
+type frozenSignedHeadersField struct {
+	name     string
+	typeName string // reflect.Type.String()
+	exported bool   // PkgPath == "" → exported
+}
+
+// frozenSignedHeadersFields is the expected exact field tuple for
+// webhook.SignedHeaders (in Go struct declaration order). All MUST be unexported.
+var frozenSignedHeadersFields = []frozenSignedHeadersField{
+	{name: "deliveryID", typeName: "webhook.DeliveryID", exported: false},
+	{name: "timestamp", typeName: "string", exported: false},
+	{name: "signature", typeName: "string", exported: false},
+}
+
+// TestWebhookSignerFunnel_SignedHeadersSealedFields is the A2 primary guard: it
+// freezes the field set of webhook.SignedHeaders and asserts every field is
+// unexported (sealed construction; outside-package literal forge = compile error).
+func TestWebhookSignerFunnel_SignedHeadersSealedFields(t *testing.T) {
+	t.Parallel()
+
+	st := reflect.TypeOf(webhook.SignedHeaders{})
+	require.Equal(t, reflect.Struct, st.Kind(), "webhook.SignedHeaders must be a struct")
+
+	// Axis 1: exact field count.
+	require.Equal(t, len(frozenSignedHeadersFields), st.NumField(),
+		"WEBHOOK-SIGNER-FUNNEL-01/A2: SignedHeaders NumField = %d, want %d "+
+			"(adding a field may re-open the sealed-construction forge vector; removing one "+
+			"breaks the Apply contract; update frozenSignedHeadersFields + webhook.go together)",
+		st.NumField(), len(frozenSignedHeadersFields))
+
+	for i, want := range frozenSignedHeadersFields {
+		sf := st.Field(i)
+		assert.Equal(t, want.name, sf.Name,
+			"WEBHOOK-SIGNER-FUNNEL-01/A2: SignedHeaders field[%d] name = %q, want %q", i, sf.Name, want.name)
+		assert.Equal(t, want.typeName, sf.Type.String(),
+			"WEBHOOK-SIGNER-FUNNEL-01/A2: SignedHeaders.%s type = %q, want %q", sf.Name, sf.Type.String(), want.typeName)
+		exported := sf.PkgPath == ""
+		assert.Equal(t, want.exported, exported,
+			"WEBHOOK-SIGNER-FUNNEL-01/A2: SignedHeaders.%s exported = %v, want %v "+
+				"(an exported field allows `webhook.SignedHeaders{%s:…}` outside kernel/webhook — "+
+				"re-opening the forge vector #1492 closed; re-seal by lowercasing)",
+			sf.Name, exported, want.exported, sf.Name)
+	}
+}
+
+// TestWebhookSignerFunnel_SignedHeadersAntiVacuity guards against the freeze
+// trivially passing on a wrong/empty type load.
+func TestWebhookSignerFunnel_SignedHeadersAntiVacuity(t *testing.T) {
+	t.Parallel()
+
+	st := reflect.TypeOf(webhook.SignedHeaders{})
+	assert.Equal(t, "SignedHeaders", st.Name(),
+		"A2 anti-vacuity: loaded type name = %q, want SignedHeaders", st.Name())
+	assert.True(t, strings.HasSuffix(st.PkgPath(), "kernel/webhook"),
+		"A2 anti-vacuity: package path %q must end with kernel/webhook", st.PkgPath())
+	assert.Greater(t, st.NumField(), 0, "A2 anti-vacuity: SignedHeaders has no fields — wrong type loaded?")
+}
+
+// TestWebhookSignerFunnel_SignedHeadersRedFixture is the reverse self-check: a
+// look-alike struct with an EXPORTED field must be detected by the same
+// PkgPath=="" visibility check, proving the freeze is not vacuous.
+func TestWebhookSignerFunnel_SignedHeadersRedFixture(t *testing.T) {
+	t.Parallel()
+
+	type brokenSignedHeaders struct {
+		Signature  string             // EXPORTED — must be detected as a violation
+		deliveryID webhook.DeliveryID //nolint:unused // mimics the unexported shape
+		timestamp  string             //nolint:unused // mimics the unexported shape
+	}
+	bt := reflect.TypeOf(brokenSignedHeaders{})
+	exportedDetected := bt.Field(0).PkgPath == ""
+	assert.True(t, exportedDetected,
+		"RED fixture self-check: exported Signature field must be detected (PkgPath empty); "+
+			"if this fails the A2 visibility check would miss real violations")
 }


### PR DESCRIPTION
## Summary

`kernel/webhook` 签名/SSRF funnel 加固，一次落地四个 backlog enforcement 条目：把 webhook 出站签名头的 provenance 升到上游 Hard external（sealed construction），收紧 HMAC funnel 的两条 archtest 精度/覆盖，并把 `WithAllowLoopback` 的生产禁用从 Soft godoc 升级为 Medium archtest。

## Why / 背景

四条 issue 同属 webhook funnel 加固、共享 archtest 文件（issue 自身注明「可与 #1243 同批」），合并为一个 PR：

- **#1492**（P2 debt）：`Apply` 原在 public `Headers`（导出字段）上，外部可 `webhook.Headers{Signature:"forged"}.Apply()` 绕过 `Signer.Sign` → `WEBHOOK-SIGNER-FUNNEL-01` 的 "provenance" 是 overclaim。拆出 sealed `SignedHeaders`（unexported 字段、仅 `Signer.Sign` 产出、仅 `Apply` 消费、附只读 accessors）作出站类型；`Headers` 留作入站 untrusted DTO（`Verify` 消费，forge 即校验失败）。外部字面量伪造现为**编译错误** = 上游 Hard external，新增 `A2` reflect field-freeze 防包内字段漂移。
- **#1493**（P2 debt）：`A1` 用 `fn.Name()` 比 computeMAC，存在同名-异包旁路；改 `fn.FullName()` 精确解析（对齐 `WEBHOOK-SSRF-GUARD-01/A2`），删冗余 `inSignerFile` 文件耦合。
- **#1243**（P3 feat）：原 A3 godoc 称「A1 transitively covers internal」是 overclaim——A1 只锁 `hmac.New`，不锁 `computeMAC` 复用，rogue 包内 struct 可调 `computeMAC` 产有效签名。新增 `A4` computeMAC caller-allowlist（Medium）锁到 `hmacSigner.Sign`/`hmacVerifier.Verify`。**Hard 化（让包内 holder 轴编译期不可表达）经追踪确认为永久 Go 天花板**（同 #851/#893/#1282/#1375 族）→ #1243 relabel won't-do，作该轴 ceiling tracker。
- **#1378**（P3 backlog）：`WithAllowLoopback` 是 dev/CI-only，原仅 godoc（Soft）。新增 `WEBHOOK-ALLOW-LOOPBACK-PROD-BAN-01` 禁非 `_test.go` 生产引用（今日 0 引用 = vacuous green）+ RED fixture。Hard 形态（unexport，今日所有调用方都是同包测试）刻意推迟以保留 dev escape hatch，tracker **#1730**（已开，godoc 点名）。

## Refs

- Closes #1492, Closes #1493, Closes #1378
- Refs #1243（Hard 不可达 = 永久 Go 天花板；交付 Medium A4 为可达上限，建议 relabel won't-do 作 tracker）
- Refs #1730（#1378 的 Hard-化 tracker，新开）
- ADR `docs/architecture/202606012052-1160-adr-webhook-retry-default.md` §D4（回写 provenance gap CLOSED）
- ADR `docs/architecture/202605312300-1159-adr-webhook-ssrf-policy.md` §Consequences（WithAllowLoopback guard Soft→Medium）
- ref: standard-webhooks/standard-webhooks spec/standard-webhooks.md

## Risk / 兼容性

- **`Signer.Sign` 接口方法返回类型变更** `(Headers, error)` → `(SignedHeaders, error)`，`Headers.Apply` 方法移到 `SignedHeaders`。仓内唯一生产消费方 = `kernel/webhook` dispatcher + 各测试，已全部更新；无外部消费方（pre-v1.0，CLAUDE.md「不考虑向后兼容」）。无 shim/双路径。
- **无 wire / DB / contract.yaml 变更**：signed-string 形态、HMAC-SHA256、`v1,<base64>` token、header 名常量全部不变（`TestSign_MatchesSvixGoldenVector` byte-exact 守）。入站 `Headers` DTO + `Verify` + `Delivery.Headers` + `runtime/webhook/receiver` 不变。
- 纯 enforcement 改动（#1493/#1243/#1378）无运行时行为变更。

### Implementation matrix（contract-fanout：`Signer.Sign` 接口签名变更）

```
Contract: kernel/webhook.Signer.Sign(payload, ts, deliveryID) -> (SignedHeaders, error)
Change: 返回类型 Headers -> sealed SignedHeaders（出站 provenance 封闭）
Implementations: [x] hmacSigner (prod)  [x] errSigner (dispatcher_test stub)
Conformance: webhooktest.RunSignerVerifierConformance（经 Apply→wire 往返桥接到 inbound Headers）
Repro: go test ./kernel/webhook/... ./runtime/webhook/... ./runtime/bootstrap/...
       go test ./tools/archtest/ -run 'Webhook'
Dependent contracts (governance scan): none（Go 接口，无 wire contract.yaml；docs 载体 = ADR 1160 §D4 + 接口 godoc，已同步）
```

## Test plan

- [x] `go build ./...` 本地通过（+ examples/webhookdemo 卫星模块）
- [x] `go test ./kernel/webhook/... ./runtime/webhook/... ./runtime/bootstrap/...` 通过；`examples/webhookdemo` 通过
- [x] `go test ./tools/archtest/ -run 'Webhook'` 通过（含 A2 reflect-freeze / A4 anti-vacuity / loopback RED fixture）
- [x] `go vet -tags integration ./runtime/webhook/...` 通过
- [x] `golangci-lint run` 0 issues（changed 包 + webhookdemo）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
