### PR TITLE
feat(ci): 自动化 tag/release 流水线 — 手动 stable + 每日 develop snapshot [#1724]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
   verify:
     name: Resolve version & build smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       prerelease: ${{ steps.resolve.outputs.prerelease }}
@@ -50,13 +51,17 @@ jobs:
     steps:
       - name: Validate branch
         # schedule runs on the default branch (develop); dispatch must too.
+        # Context values go through env, never interpolated into the shell, to
+        # avoid script injection from a crafted ref name.
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.ref_name }}" != "develop" ]; then
-            echo "::error::Release must run on develop (got '${{ github.ref_name }}')."
+          if [ "$REF_NAME" != "develop" ]; then
+            echo "::error::Release must run on develop (got '$REF_NAME')."
             exit 1
           fi
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: develop
           fetch-depth: 0 # full history + tags for version resolution
@@ -83,6 +88,8 @@ jobs:
               echo "::error::tag $tag already exists."
               exit 1
             fi
+            # Monotonic: the new tag must sort strictly after the latest stable.
+            # Equality is already excluded by the duplicate-tag check above.
             if [ -n "$latest_stable" ]; then
               newest="$(printf '%s\n%s\n' "$latest_stable" "$tag" | sort -V | tail -n1)"
               if [ "$newest" != "$tag" ]; then
@@ -99,9 +106,12 @@ jobs:
             base="${latest_stable#v}"
             base="${base:-0.0.1}"
             last_daily="$(git tag -l 'v*-develop.*' --sort=-creatordate | head -n1 || true)"
+            # ^{commit} peels the annotated tag to its commit so the comparison
+            # is unambiguously commit-to-commit.
             if [ -n "$last_daily" ] \
-              && [ "$(git rev-list -n1 "$last_daily")" = "$(git rev-parse HEAD)" ]; then
-              echo "No new commits on develop since $last_daily — skipping snapshot."
+              && [ "$(git rev-parse "$last_daily^{commit}")" = "$(git rev-parse HEAD)" ]; then
+              echo "No new commits on develop since $last_daily — skipping snapshot." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
               echo "skip=true" >>"$GITHUB_OUTPUT"
               exit 0
             fi
@@ -132,6 +142,7 @@ jobs:
     needs: verify
     if: needs.verify.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # push annotated tag + create/delete GitHub Release
     env:
@@ -139,7 +150,7 @@ jobs:
       TAG: ${{ needs.verify.outputs.tag }}
       PRERELEASE: ${{ needs.verify.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: develop
           fetch-depth: 0 # full history for annotated tag, --generate-notes, prune
@@ -160,12 +171,26 @@ jobs:
           if [ "$PRERELEASE" = "true" ]; then
             args+=(--prerelease)
           fi
-          gh release create "$TAG" "${args[@]}"
+          # Retry: the freshly pushed tag may not be API-visible immediately,
+          # which makes --verify-tag fail transiently and leaves an orphan tag.
+          for attempt in 1 2 3; do
+            if gh release create "$TAG" "${args[@]}"; then
+              exit 0
+            fi
+            echo "::warning::gh release create attempt $attempt failed; retrying in 10s."
+            sleep 10
+          done
+          echo "::error::gh release create failed for $TAG after 3 attempts (tag is pushed; create the release manually)."
+          exit 1
 
       - name: Prune old daily snapshots
         if: needs.verify.outputs.prerelease == 'true'
         run: |
           set -euo pipefail
+          if ! printf '%s' "$DAILY_RETENTION" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::DAILY_RETENTION must be a positive integer (got '$DAILY_RETENTION')."
+            exit 1
+          fi
           # Keep the most recent DAILY_RETENTION snapshots (today's included);
           # delete older release+tag pairs together via --cleanup-tag.
           git tag -l 'v*-develop.*' --sort=-creatordate \
@@ -174,5 +199,6 @@ jobs:
                 [ -n "$old" ] || continue
                 echo "Pruning old snapshot $old"
                 gh release delete "$old" --cleanup-tag --yes \
-                  || git push origin --delete "$old" || true
+                  || git push origin --delete "$old" \
+                  || echo "::warning::failed to prune snapshot $old."
               done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,178 @@
+name: Release
+
+# Tag / release pipeline for GoCell (issue #1724).
+#
+# Two paths, one mechanism:
+#   * workflow_dispatch — an operator cuts a STABLE release by typing the
+#     version (e.g. 0.0.2). Tag vX.Y.Z, full release (becomes "Latest").
+#   * schedule (daily) — automatic develop SNAPSHOT. Version is
+#     v<base>-develop.<UTC timestamp>, where <base> is the latest stable
+#     version (default 0.0.1). Marked prerelease (never "Latest"), skipped
+#     when develop HEAD is unchanged since the last snapshot, and pruned to
+#     the most recent DAILY_RETENTION snapshots.
+#
+# The tag is the single source of truth for the version; no version constant is
+# embedded in binaries and CHANGELOG.md is maintained by hand.
+#
+# Version strings follow SemVer 2.0.0. The snapshot timestamp is encoded as a
+# single ISO-basic pre-release identifier (e.g. 20260607T021500Z) so it is NOT
+# a numeric identifier — the "no leading zeros" rule (semver.org §9) would
+# reject a dotted form like `…-develop.021500`.
+# ref: nodejs nightly (vX-nightly<date>), dotnet (-preview.<date>) tag schemes.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'STABLE release version WITHOUT the v prefix, e.g. 0.0.2. Numeric X.Y.Z, strictly greater than the latest stable tag.'
+        type: string
+        required: true
+  schedule:
+    - cron: '0 2 * * *' # daily develop snapshot, 02:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  DAILY_RETENTION: '14' # keep this many most-recent daily snapshots; older are pruned
+
+jobs:
+  verify:
+    name: Resolve version & build smoke
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
+      skip: ${{ steps.resolve.outputs.skip }}
+    steps:
+      - name: Validate branch
+        # schedule runs on the default branch (develop); dispatch must too.
+        run: |
+          if [ "${{ github.ref_name }}" != "develop" ]; then
+            echo "::error::Release must run on develop (got '${{ github.ref_name }}')."
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+          fetch-depth: 0 # full history + tags for version resolution
+          fetch-tags: true
+
+      - name: Resolve version
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          latest_stable="$(git tag -l 'v[0-9]*' --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            ver="$INPUT_VERSION"
+            if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::version must be numeric X.Y.Z without a leading v (got '$ver')."
+              exit 1
+            fi
+            tag="v$ver"
+            if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              echo "::error::tag $tag already exists."
+              exit 1
+            fi
+            if [ -n "$latest_stable" ]; then
+              newest="$(printf '%s\n%s\n' "$latest_stable" "$tag" | sort -V | tail -n1)"
+              if [ "$newest" != "$tag" ]; then
+                echo "::error::version $tag must be greater than the latest stable release $latest_stable."
+                exit 1
+              fi
+            fi
+            {
+              echo "tag=$tag"
+              echo "prerelease=false"
+              echo "skip=false"
+            } >>"$GITHUB_OUTPUT"
+          else
+            base="${latest_stable#v}"
+            base="${base:-0.0.1}"
+            last_daily="$(git tag -l 'v*-develop.*' --sort=-creatordate | head -n1 || true)"
+            if [ -n "$last_daily" ] \
+              && [ "$(git rev-list -n1 "$last_daily")" = "$(git rev-parse HEAD)" ]; then
+              echo "No new commits on develop since $last_daily — skipping snapshot."
+              echo "skip=true" >>"$GITHUB_OUTPUT"
+              exit 0
+            fi
+            ts="$(date -u +%Y%m%dT%H%M%SZ)"
+            {
+              echo "tag=v${base}-develop.${ts}"
+              echo "prerelease=true"
+              echo "skip=false"
+            } >>"$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        if: steps.resolve.outputs.skip != 'true'
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Build smoke (compile all modules)
+        if: steps.resolve.outputs.skip != 'true'
+        run: make check-build
+
+      - name: Unit smoke (kernel, docker-free)
+        if: steps.resolve.outputs.skip != 'true'
+        run: go test ./kernel/... -count=1
+
+  release:
+    name: Tag & GitHub Release
+    needs: verify
+    if: needs.verify.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push annotated tag + create/delete GitHub Release
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ needs.verify.outputs.tag }}
+      PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+          fetch-depth: 0 # full history for annotated tag, --generate-notes, prune
+          fetch-tags: true
+
+      - name: Create annotated tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        run: |
+          set -euo pipefail
+          args=(--title "$TAG" --verify-tag --generate-notes)
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$TAG" "${args[@]}"
+
+      - name: Prune old daily snapshots
+        if: needs.verify.outputs.prerelease == 'true'
+        run: |
+          set -euo pipefail
+          # Keep the most recent DAILY_RETENTION snapshots (today's included);
+          # delete older release+tag pairs together via --cleanup-tag.
+          git tag -l 'v*-develop.*' --sort=-creatordate \
+            | tail -n +"$((DAILY_RETENTION + 1))" \
+            | while IFS= read -r old; do
+                [ -n "$old" ] || continue
+                echo "Pruning old snapshot $old"
+                gh release delete "$old" --cleanup-tag --yes \
+                  || git push origin --delete "$old" || true
+              done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
       prerelease: ${{ steps.resolve.outputs.prerelease }}
       skip: ${{ steps.resolve.outputs.skip }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      tag_exists: ${{ steps.resolve.outputs.tag_exists }}
     steps:
       - name: Validate branch
         # schedule runs on the default branch (develop); dispatch must too.
@@ -72,25 +74,40 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          head_sha="$(git rev-parse HEAD)"
+          # SemVer 2.0.0: numeric identifiers carry no leading zeros.
+          num='(0|[1-9][0-9]*)'
           latest_stable="$(git tag -l 'v[0-9]*' --sort=-v:refname \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
+            | grep -E "^v${num}\.${num}\.${num}$" | head -n1 || true)"
+          tag_exists=false
 
           if [ "$EVENT" = "workflow_dispatch" ]; then
             ver="$INPUT_VERSION"
-            if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "::error::version must be numeric X.Y.Z without a leading v (got '$ver')."
+            if ! printf '%s' "$ver" | grep -Eq "^${num}\.${num}\.${num}$"; then
+              echo "::error::version must be SemVer X.Y.Z with no leading zeros or leading v (got '$ver')."
               exit 1
             fi
             tag="v$ver"
             if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-              echo "::error::tag $tag already exists."
-              exit 1
-            fi
-            # Monotonic: the new tag must sort strictly after the latest stable.
-            # Equality is already excluded by the duplicate-tag check above.
-            if [ -n "$latest_stable" ]; then
+              # Tag exists: resumable only if it points at the verified commit and
+              # its release is missing (recovering a prior half-finished run).
+              existing_sha="$(git rev-parse "$tag^{commit}")"
+              if [ "$existing_sha" != "$head_sha" ]; then
+                echo "::error::tag $tag exists at $existing_sha, not the current develop HEAD $head_sha."
+                exit 1
+              fi
+              if gh release view "$tag" >/dev/null 2>&1; then
+                echo "::error::release $tag already exists (nothing to do)."
+                exit 1
+              fi
+              echo "::warning::tag $tag exists without a release — resuming to create it." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              tag_exists=true
+            elif [ -n "$latest_stable" ]; then
+              # New tag: enforce strictly-increasing version vs the latest stable.
               newest="$(printf '%s\n%s\n' "$latest_stable" "$tag" | sort -V | tail -n1)"
               if [ "$newest" != "$tag" ]; then
                 echo "::error::version $tag must be greater than the latest stable release $latest_stable."
@@ -100,16 +117,14 @@ jobs:
             {
               echo "tag=$tag"
               echo "prerelease=false"
-              echo "skip=false"
             } >>"$GITHUB_OUTPUT"
           else
             base="${latest_stable#v}"
             base="${base:-0.0.1}"
             last_daily="$(git tag -l 'v*-develop.*' --sort=-creatordate | head -n1 || true)"
-            # ^{commit} peels the annotated tag to its commit so the comparison
-            # is unambiguously commit-to-commit.
+            # ^{commit} peels the annotated tag to its commit for a commit-to-commit compare.
             if [ -n "$last_daily" ] \
-              && [ "$(git rev-parse "$last_daily^{commit}")" = "$(git rev-parse HEAD)" ]; then
+              && [ "$(git rev-parse "$last_daily^{commit}")" = "$head_sha" ]; then
               echo "No new commits on develop since $last_daily — skipping snapshot." \
                 | tee -a "$GITHUB_STEP_SUMMARY"
               echo "skip=true" >>"$GITHUB_OUTPUT"
@@ -119,9 +134,13 @@ jobs:
             {
               echo "tag=v${base}-develop.${ts}"
               echo "prerelease=true"
-              echo "skip=false"
             } >>"$GITHUB_OUTPUT"
           fi
+          {
+            echo "skip=false"
+            echo "sha=$head_sha"
+            echo "tag_exists=$tag_exists"
+          } >>"$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.resolve.outputs.skip != 'true'
@@ -149,16 +168,22 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       TAG: ${{ needs.verify.outputs.tag }}
       PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+      SHA: ${{ needs.verify.outputs.sha }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: develop
+          ref: ${{ needs.verify.outputs.sha }} # pin to the exact commit verify smoke-tested
           fetch-depth: 0 # full history for annotated tag, --generate-notes, prune
           fetch-tags: true
 
       - name: Create annotated tag
+        if: needs.verify.outputs.tag_exists != 'true' # skip when resuming an existing tag
         run: |
           set -euo pipefail
+          if [ "$(git rev-parse HEAD)" != "$SHA" ]; then
+            echo "::error::checked-out HEAD $(git rev-parse HEAD) != verified SHA $SHA."
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
@@ -180,7 +205,7 @@ jobs:
             echo "::warning::gh release create attempt $attempt failed; retrying in 10s."
             sleep 10
           done
-          echo "::error::gh release create failed for $TAG after 3 attempts (tag is pushed; create the release manually)."
+          echo "::error::gh release create failed for $TAG after 3 attempts (tag is pushed; re-run this workflow to resume, or create the release manually)."
           exit 1
 
       - name: Prune old daily snapshots


### PR DESCRIPTION
## Summary

新增 `.github/workflows/release.yml`——一条 tag/release 流水线，两条触发线共用打 tag / 出 release 机制：**手动 stable 发布**（`workflow_dispatch` 手填版本号）+ **每日 develop snapshot**（`schedule`，自动算版本）。

## Why / 背景

GoCell 此前无任何语义版本 tag（仅 backup tag）、无 GitHub Release、无发布流水线，打 tag/出 release 全靠手动。本 PR 落地 v0.1 自用发布就绪 epic（W2 核心）的发布自动化。

**范围扩展说明**：issue #1724 原文只要求 `workflow_dispatch` 手动发布；实施沟通中扩展为「手动 stable + 每日自动 develop snapshot」（同一 workflow 文件、共用机制）。建议同步更新 issue 描述。

两条线：

| 线 | 触发 | 版本 | 标记 |
|----|------|------|------|
| **stable** | `workflow_dispatch` 手填 `0.0.2` | `v0.0.2` | full release（抢 Latest）；校验 分支=develop / format / 防重 / 单调 四闸门全 fail-closed |
| **daily** | `schedule` 02:00 UTC | `v<base>-develop.<ISO时间戳>Z`，base=最新 stable 或默认 `0.0.1` | **prerelease**（不抢 Latest）+ 无新提交跳过 + 只留最近 `DAILY_RETENTION`(=14) 个 |

设计要点：
- **tag 即版本单一真源**——不嵌二进制版本，CHANGELOG 人工维护。
- **SemVer 合规**：snapshot 时间戳用 ISO-basic 含字母形式（`20260607T021500Z`）规避 §9 纯数字 identifier 前导零禁令（`…develop.021500` 非法）。
- **两 job 最小权限**：`verify`（`contents: read`）解析版本 + build smoke（`make check-build` + kernel 单元 smoke，docker-free）→ `release`（`contents: write`）打注释 tag + `gh release create`。
- 对齐现有 CI 约定：actions commit-hash 钉死、`go-version-file: go.mod`、`concurrency: release`。

## Refs

Closes #1724
ref: nodejs nightly (`vX-nightly<date>`) / dotnet (`-preview.<date>`) tag schemes；semver.org §9（pre-release 纯数字 identifier 禁前导零）

## Risk / 兼容性

- **新增 workflow，无 Go 代码变更**，对现有运行时/契约零影响。
- tag push（`refs/tags/*`）不匹配任何现有 `on: push: branches:` 过滤器 → 不会误触发其它 CI。
- `schedule` 在默认分支 develop HEAD 运行（已确认默认分支 = develop）。
- **已知 ops caveat**：tag push 成功但 `gh release create` 瞬态失败 → 重跑撞防重 gate 留「有 tag 无 release」；stable 路径手动补救（`gh release create <tag> --verify-tag --generate-notes`），daily 路径次日新时间戳自然绕过。不造恢复双路径（守 spec + 简洁）。
- **端到端 dry-run 需 merge 后人工验收**（会创建真实 tag/release，不在 PR 内自动执行）。

## Test plan

- [x] `actionlint .github/workflows/release.yml`（v1.7.12，内嵌 shellcheck 校验 run 块）0 issues
- [x] YAML parse sanity 通过
- [x] gate 命令 sanity：`go test ./kernel/... -count=1` docker-free 全绿
- [ ] `go build ./...`（无 Go 改动，N/A）
- [ ] `golangci-lint run ./...`（无 Go 改动，N/A）
