### PR TITLE
feat(command): command-entry request-schema value-validation funnel (async untrusted boundary) [#1588]

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -208,9 +208,9 @@ relay 消费时按 **routing-topic** 在 composition-root 注入的 dispatcher-m
 否则照常发 broker。判别器 = dispatcher-map 成员资格（`command.*.v1` 命名空间 + 闭合 map
 天然隔离事件 topic），**不改 sealed `outbox.Entry`、不带 metadata 标记**。命令 settle 复用事件
 writeBack：成功 `MarkPublished` = 命令已消费；失败分两类——生成 `DispatchAsync` 的**确定性框架错误**
-（reg nil / routing-topic ≠ DispatchID / decode 失败 / no-handler / wrong-type）经 `kout.NewPermanentError`
-标记 → relay 直接 `MarkDead`（不耗重试预算，错配 entry fail-closed）；**handler 业务 error** 透传 → `MarkRetry`
-至耗尽（#1673 F3；值校验失败分类随 #1588）。生成 `DispatchAsync` 体首做 trust-boundary 自检
+（reg nil / routing-topic ≠ DispatchID / **request-schema 值校验失败** / decode 失败 / no-handler / wrong-type）经 `kout.NewPermanentError`
+标记 → relay 直接 `MarkDead`（不耗重试预算，错配 / 非法 entry fail-closed）；**handler 业务 error** 透传 → `MarkRetry`
+至耗尽（#1673 F3 + #1588）。生成 `DispatchAsync` 体首做 trust-boundary 自检
 `entry.RoutingTopic() == string(DispatchID)`，错配 entry 不被错 handler 消费。
 
 composition root 注入（dispatch 值**必须**是生成 `DispatchAsync` 直接符号——archtest
@@ -224,11 +224,17 @@ relay.WithCommandDispatch(reg, map[command.CommandID]command.AsyncDispatchFunc{
 })
 ```
 
-`DispatchAsync` 不执行 schema 值约束（typed struct 即结构契约）；untrusted-payload 值校验
-funnel = #1588。真实 binary producer 接线（devicecell 异步 enqueue）随后续 PR 落地。设计单源 =
+`DispatchAsync` **在 topic-guard 后、unmarshal 前对 `entry.Payload()`（入站 wire JSON bytes）跑
+`runtime/schemavalidate.Validator.Validate` 强制 request schema 值约束**（minLength/maxLength/required/
+additionalProperties/...全 schema 语义；#1588）——这是 HTTP request-body 校验的不可信边界对位物。违例 →
+`kout.NewPermanentError` → relay `MarkDead`。复用 HTTP 同源 byte-validator（核心抽中性包 `runtime/schemavalidate`，
+HTTP 与 command 生成包共用）；honor D4——async bytes 校验零 marshal round-trip（round-trip 仅在校验 **sync** typed
+输入时出现，sync `Dispatch` 仍刻意不校验 = 第一方可信边界，ADR §D8）。command 无 `HasBody` gate，D6 保证恒有 request
+schemaRef，故 `command.tmpl` 无条件 emit validator（无「command 无校验」逃逸路径）。真实 binary producer 接线
+（devicecell 异步 enqueue）随后续 PR（#1698）落地。设计单源 =
 ADR `docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md` §5 ④ +
-§Amendment 2026-06-06；funnel 双向锁 = `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`（上游 Hard）+
-`COMMAND-ASYNC-DISPATCH-CALLER-01`（下游 Hard）。
+§Amendment 2026-06-06 / 2026-06-08；funnel 双向锁 = `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`（上游 Hard，golden 锁
+含值校验 emit）+ `COMMAND-ASYNC-DISPATCH-CALLER-01`（下游 Hard）——值校验骑既有 funnel，无新增 enforcement 机制。
 
 ## Projection ↔ ConsumerBase 装配（composition root）
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -209,7 +209,7 @@ linters:
             - github.com/go-chi/chi
             - github.com/golang-jwt/jwt
             - github.com/google/uuid
-            - github.com/santhosh-tekuri/jsonschema  # runtime/http/schemavalidate body validator
+            - github.com/santhosh-tekuri/jsonschema  # runtime/schemavalidate body validator (HTTP + async command shared)
             - github.com/stretchr/testify  # storetest/ test-helper packages
             - go.opentelemetry.io/contrib
             - go.opentelemetry.io/otel

--- a/cmd/gocell/app/testdata/scaffold_golden/goldcell/generated/contracts/http/goldcell/example/v1/handler_gen.go.golden
+++ b/cmd/gocell/app/testdata/scaffold_golden/goldcell/generated/contracts/http/goldcell/example/v1/handler_gen.go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Example(r.Context(), req)

--- a/cmd/gocell/go.mod
+++ b/cmd/gocell/go.mod
@@ -12,7 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	golang.org/x/mod v0.36.0 // indirect

--- a/cmd/gocell/go.sum
+++ b/cmd/gocell/go.sum
@@ -6,8 +6,6 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
+++ b/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
@@ -63,7 +63,7 @@ PR-1 同步核心是 W3 的第一片。`Registry` map signature 与生成码 fun
 
 - **④ async outbox 桥（#1667，已落地——见 §Amendment 2026-06-06）**：codegen 派生单态 `DispatchAsync(ctx, reg, entry)`（从 `entry.Payload()` JSON unmarshal 回 typed `*Request` → `LookupHandler` → 复用同一 `Handler`，丢弃 `*Response` 回 `error`）；relay 按 routing-topic 在 composition-root 注入的 dispatcher-map 中匹配 command → 在进程内触发 `DispatchAsync`，否则发 broker。JSON marshal 在 outbox 边界发生（D4 同步 type-assert 路径不变）。**判别器 = routing-topic + dispatcher-map 成员，未改 sealed `Entry` wire envelope、未引入 metadata 约定 → 未触发 contract-fanout 5 载体**（原文「携带 command kind——触及 sealed Entry wire envelope 或 topic 约定，触发 contract-fanout」+「relay 消费按 command id LookupHandler」实现为：command entry 即 `eventType = command id` 的普通 entry，`LookupHandler` 留在生成 `DispatchAsync` 体内、relay 不直接调）。
 - **⑤ idempotency 桥（#1669，子 issue）**：HTTP Idempotency-Key ↔ command_id 映射（复用 `runtime/http/idempotency` Claimer 两阶段）。**映射原语半已落地（#1669 PR-A）**：`runtime/http/idempotency` sealed funnel 扩第二构造器 `DeriveCommandKey(tenant, subject, command_id)`——纯编译期形态，产同一 sealed `IdempotencyKey`、流同一 `Store.Claim` sink（详见 ADR-1449 §Amendment 2026-06-07）；#1610 cross-cell 同槽路由消费它。**Claimer-wrap 消费半延期**（`kernel/idempotency.Claimer` 两阶段包裹 relay 命令分发 + 三态生命周期）——今日 0 个生产 `WithCommandDispatch` 调用点，且 sealed-key→Claimer string-key 扁平化 + per-instance 身份承载有真实设计缺口，须随真实 devicecell 异步 command producer 落地（与下一项「真实 binary async producer 接线」绑定 → **#1698**，避免给无 producer 的 consumer 接 dead wiring）。本项**不改 §4 评级矩阵**（funnel 正交：映射原语在 `runtime/http/idempotency` funnel，与 command dispatch/register funnel 不相交），无 ✅→⚠️/❌ 降格。
-- **command-entry 值校验 funnel（#1588，Blocked-by ④）**：`DispatchAsync` 只做 typed JSON unmarshal（typed struct 即结构契约），不执行 schema 值约束（minLength/required/…）；untrusted-payload 值校验在此不可信 async 边界落地（Amendment 2026-06-04 已点名归属）。
+- ~~**command-entry 值校验 funnel（#1588，Blocked-by ④）**：`DispatchAsync` 只做 typed JSON unmarshal，不执行 schema 值约束~~ **已交付（#1588，见 §Amendment 2026-06-08）**：`DispatchAsync` 在 topic-guard 之后、unmarshal 之前对 `entry.Payload()`（已是 wire JSON bytes）跑 `runtime/schemavalidate.Validator.Validate` 强制 request schema 值约束（minLength/maxLength/required/additionalProperties），违例 → `kout.NewPermanentError` → relay `MarkDead`。复用 HTTP 同源 validator（抽中性包 `runtime/schemavalidate`）；honor D4——async bytes 校验非 marshal round-trip（round-trip 仅在校验 sync typed 输入时出现，sync `Dispatch` 不变）。
 - ~~**command consistencyLevel governance（#1044 子 issue）**：PR-1 不锁 level~~ **已交付（#1668，双层）**：`COMMAND-CONTRACT-CONSISTENCY-LEVEL-01` 下界约束 `consistencyLevel ≥ L1`，仅拒 `L0`（命令跨本地边界至少需 L1 LocalTx 原子性，L0 LocalOnly 结构上不适用）。**双层**（同 PROJECTION-CONSISTENCY-01 单 ID 双层范式）：Hard = `types.tmpl` 编译期 `const _ = uint(cellvocab.<level> - cellvocab.L1)` 对 codegen:true 命令契约 uint 下溢拦 L0；Medium = governance rule 兜底 codegen:false + in-memory fixture。下界（非 exact-lock）使现有 active L4 `devicecommand` 契约全部通过、零误伤。详见 §Amendment 2026-06-06（#1668）。
 - **真实 binary async producer 接线（#1044 子 issue，gh backlog，Blocked-by ④）**：④ 交付机制 + relay-level E2E（mem outbox store 绑生成 `enqueue.DispatchAsync` 扮演 composition root）；devicecell 异步 enqueue 命令 + iotdevice durable-mode relay `WithCommandDispatch` 接线随真实 producer 落地（给无 producer 的 consumer 接 binary wiring = dead wiring，故 defer）。
 
@@ -103,13 +103,15 @@ amend 时须回到 §4 矩阵逐行重评（ai-robust.md ADR amendment 必查）
 2. **sync in-process `Dispatch`（D4）刻意不执行 request value-validation**。三条理由：
    - **typed-struct 即契约**：调用方传入 typed `*Request`，Go 类型系统已强制字段*类型*；`additionalProperties:false` 在 typed struct 上**结构性不可违反**（无法塞未知字段）。剩余未执行约束仅 string 长度 / `required` presence。
    - **可信边界**：sync `Dispatch` 的调用方是 **in-process 第一方 Go 代码**（派发 cell），非不可信 wire 输入。JSON-schema 值约束是 untrusted-JSON 的 wire 卫生规则；在 in-process typed 调用上重复执行是对编程错误的 defense-in-depth，非安全/正确性边界。
-   - **D4 = 零序列化 fast-path**：HTTP 的 `runtime/http/schemavalidate.Validator.Validate(ctx, body []byte)` 是 **JSON-bytes 校验器**；复用它必须先把 typed `*Request` marshal 回 JSON——正是 D4 拒绝的 round-trip。在 sync 路径强加 marshal+validate 直接违背 D4 的 in-process 惯用，故**不**复用 HTTP validator。
+   - **D4 = 零序列化 fast-path**：`schemavalidate.Validator.Validate(ctx, body []byte)` 是 **JSON-bytes 校验器**；在 **sync** 路径复用它必须先把 typed `*Request` marshal 回 JSON——正是 D4 拒绝的 round-trip，故 sync `Dispatch` **不**复用 validator。**注意此论据只约束 sync 路径**：async `DispatchAsync` 的输入 `entry.Payload()` 本就是入站 JSON bytes，对它直接 `Validate` 不产生任何 marshal round-trip，故 async 边界复用同一 validator 与 D4 不矛盾（见 §Amendment 2026-06-08）。
 
-3. **value-validation 归属不可信 command-entry 边界**（= §5 演进路径的 ④/⑤）：HTTP→command（handler 在入 cell 前已校验 untrusted JSON）、async outbox→command（D4 已注明 JSON marshal 在 outbox 边界发生）。这些边界落地时，request schema 的值约束在**该处**执行——schemaRef 因此最终*被*执行，只是不在 in-process fast-path 上冗余重检。command-entry validation funnel 设计与 ④ async 共同落地，跟踪为 **#1044 子 issue**（`Discovered via /fix #1578 F5`）。
+3. **value-validation 归属不可信 command-entry 边界**（= §5 演进路径的 ④/⑤）：HTTP→command（handler 在入 cell 前已校验 untrusted JSON）、async outbox→command（D4 已注明 JSON marshal 在 outbox 边界发生）。这些边界落地时，request schema 的值约束在**该处**执行——schemaRef 因此最终*被*执行，只是不在 in-process fast-path 上冗余重检。command-entry validation funnel 设计与 ④ async 共同落地，跟踪为 **#1588**（`Discovered via /fix #1578 F5`）——**async outbox→command 边界已交付（见 §Amendment 2026-06-08）**；HTTP→command 边界今日无 wiring，落地时复用 HTTP handler 既有 validator（sync `Dispatch` 前已校验 untrusted body）。
 
 **§4 评级矩阵逐行重评（ai-robust.md ADR amendment 必查）**：本 amendment **不改 §4 任一格**。§4 双向锁矩阵约束的是 *dispatch/register funnel*（typed Handler/Register/Dispatch 仅由 codegen 派生 + raw `RegisterHandler`/`LookupHandler` 调用方收口），与 *request value-validation* 正交——后者既不放宽前者的上游/下游 Hard，也不新增伪造面。D4（golden 锁 sync 形态）、D6（codegen fail-closed 上游 Hard + governance Medium）评级不变；无 ✅→⚠️/❌ 降格，无需补偿措施。
 
-**为何不 silent defer（非 lazy）**：真实 blocker = 正确实现（typed-struct 级约束 IR，不 JSON round-trip）是一个**全新 codegen 机制**（须自带 AI-robust 评级 + archtest + golden），且其唯一真实消费点是不可信 command-entry 边界——与 ④ async 共同设计才有正确 altitude；廉价实现（JSON round-trip）违背 D4。故 funnel 设计随 ④ 落地，本 PR 以 §D8 显式收口设计边界。
+**为何不 silent defer（非 lazy）**：真实 blocker = 值校验的唯一真实消费点是不可信 command-entry 边界，须与 ④ async（JSON 真正跨不可信边界处）共同设计才有正确 altitude。本 PR 以 §D8 显式收口设计边界，funnel 随 ④ 落地。
+
+> **修订（Amendment 2026-06-08，#1588 落地后回填）**：本段原把「typed-struct 级约束 IR（不 round-trip）」称为「正确实现」、把复用 byte-validator 称为「廉价实现违背 D4」。该判断基于「校验须覆盖 sync 路径、对 sync typed 输入 marshal 即 round-trip」的隐含前提，对**最终裁决（值校验只在 async 不可信边界、sync 不校验）不成立**：async 边界 `entry.Payload()` 已是入站 JSON bytes，复用 `schemavalidate` byte-validator 零 round-trip、honor D4，且全 schema 覆盖。#1588 因此采纳 byte-validator 复用（option b），typed-struct IR（option a）评估后因覆盖不全（仅 len/required，无 nested/pattern/enum）+ 需另起全新 archtest+golden 机制而**否决**。值校验落生成 `DispatchAsync` 体内、由既有 `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01` golden 锁，无新 enforcement 机制。详见 §Amendment 2026-06-08。
 
 ---
 
@@ -186,3 +188,31 @@ empty / 非法 level 不由本规则报——由 `FMT-03`（contract consistency
 **F4（可观测维度）不在本轮**：命令 dispatch 与 broker publish 共享 `published` stat/metric 的 sink 维度区分，因今日 0 命令 producer（dead observability，sink 维度命名需真实流量决定），完整并入 **#1674**（已含 F4/F5/F6）随真实 producer 接线统一落地。
 
 **eventbus.md「Relay 命令分发」节**同步重写 settle 语义（原「失败 `MarkRetry`」）。
+
+---
+
+## Amendment 2026-06-08（#1588：command-entry request-schema 值校验 funnel — async 不可信边界落地）
+
+**触发**：§5 演进路径「command-entry 值校验 funnel（#1588，Blocked-by ④）」落地（触发条件 = ④ #1667 已落）。按 ai-robust.md「ADR amendment 必查」逐行重评 §4 + 重写矛盾原文（§D8 reason #3 加 sync-scope 澄清、§5 标 delivered、Amendment 2026-06-04「为何不 silent defer」段就地修订——见各处 §Amendment 2026-06-08 回填）。
+
+**D11：async `DispatchAsync` 在不可信边界跑 byte-validator；sync `Dispatch` 不变（D4/§D8 保持）**。生成 `DispatchAsync` 在 topic-guard 之后、`json.Unmarshal` 之前，对 `entry.Payload()`（已是入站 wire JSON bytes）调 `runtime/schemavalidate.Validator.Validate`，强制 request schema 值约束（`minLength`/`maxLength`/`required`/`additionalProperties`/`pattern`/...全 schema 语义）。这是 HTTP request-body 校验的不可信边界对位物——**与 sync 路径正交**：sync `Dispatch` 的输入是 in-process 第一方 typed `*Request`，仍刻意不校验（§D8 可信边界 + D4 零序列化）。**honor D4**：async 输入本就是 JSON bytes，对它 `Validate` 零 marshal round-trip（§D8 reason #3「round-trip 违背 D4」只约束「校验 sync typed 输入」，对 async bytes 不成立）。
+
+**D12：机制 = 复用既有 byte-validator + 抽中性包，非全新 codegen IR**。
+
+1. **包抽取**：`runtime/http/schemavalidate` 的 transport-neutral 核心（`Validator`/`NewValidator`/`Validate`/safe-message helper）迁到 `runtime/schemavalidate`；HTTP-专用 `WriteValidationError` 删除（generated HTTP handler 改调既有 `httputil.WriteError`——`Validate` 恒返回 `*errcode.Error(ErrValidationFailed)`，`WriteError` 经 `errors.As` 渲染为 400，原 `WriteValidationError` 的 non-errcode→400 fallback 是 dead code）。HTTP handler 与 command 生成包共用同一中性 validator，命令包不再 import `runtime/http/*`。
+2. **codegen embed**：`contractgen.embedRequestSchema`（HTTP+command 共享 helper）read→`bundleSchemaRefs`→`json.Compact`→`NewValidator` 编译期 fail-fast，存 `spec.RequestSchemaJSON`。command **无条件** embed（D6 保证 request schemaRef 恒存在；不套 HTTP 的 `HasBody` gate），`command.tmpl` 恒 emit 包级 `requestSchemaJSON` + `requestValidator` + `DispatchAsync` 的 `Validate` 调用——**无「command 无校验」逃逸路径**。
+3. **settle 分类**：schema 违例确定性、不可重试 → 生成码以 `kout.NewPermanentError` wrap → relay `handleFailedEntry` → `MarkDead`（与既有 decode-failure / topic-mismatch 同 permanent 类，#1673 F3 机制复用，零新增）。回答 issue「值校验失败分类随 #1588」。
+
+**拒绝**：typed-struct 级约束 codegen IR（option a）——覆盖不全（仅 len/required，无 nested/pattern/enum/format）+ 须另起全新 archtest+golden 机制；byte-validator 复用（option b）覆盖全 schema 且零新机制，胜出。**拒绝**：在 sync `Dispatch` 内 marshal→validate（§D8 已记否决，违 D4）。
+
+**§4 评级矩阵逐行重评（无格降级）**：值校验落生成 `DispatchAsync` 体内，与 dispatch/register funnel **正交**，**不新增 enforcement 机制**（骑既有 funnel）：
+
+- `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`：✅ **不变**（上游 Hard / 下游 Medium）。golden 字节锁随 `DispatchAsync` 的 `Validate` 调用 + 包级 `requestSchemaJSON`/`requestValidator` emit 更新；validate 调用经 golden regen-diff 锁定，模板单源外不可手写、不可静默删——这是值校验「不可绕过」的上游 Hard 来源（无须新 archtest）。
+- `COMMAND-DISPATCH-REGISTER-CALLER-01`：✅ **不变**（上游 Medium / 下游 Hard）。
+- `COMMAND-ASYNC-DISPATCH-CALLER-01`：✅ **不变**（上游 Medium / 下游 Hard）。relay 仍只调生成 `DispatchAsync`（下游 Hard），故「值校验必经过」由「async 命令必过生成 DispatchAsync」继承。
+
+**无 ✅→⚠️/❌ 降格，无补偿措施**：D11/D12 未改 `Entry` wire envelope、未新增 errcode（复用 `ErrValidationFailed`）/ Kind / schema / migration / interface 签名——**未触发 contract-fanout 5 载体**（包抽取是内部 refactor，generated 重生由 `generatedverify` 守）。anti-vacuity：render test 锁 `Validate` 调用 emit + E2E（`examples/iotdevice`）锁运行期 valid-过 / invalid-拦-permanent / relay-dead-letter。
+
+enforcement 索引（§7）**无新增**——值校验由 §4 既有三 funnel 覆盖；`runtime/schemavalidate` 为运行时 validator 载体（非 enforcement 机制）。
+
+**范围（显式，非 silent defer）**：HTTP→command 不在本 PR（仓内无 HTTP→command wiring；真落地时复用 HTTP handler 既有 validator，结构上已覆盖）。真实 binary async producer 接线 = #1698（正交）。

--- a/examples/iotdevice/commandbus_roundtrip_test.go
+++ b/examples/iotdevice/commandbus_roundtrip_test.go
@@ -158,6 +158,17 @@ func newCommandEntry(t *testing.T, req enqueue.Request) kout.Entry {
 	return entry
 }
 
+// newRawCommandEntry builds a command entry from raw JSON bytes — needed for the
+// #1588 value-validation cases that can't be expressed via a typed enqueue.Request
+// (missing required field, additionalProperties), which json.Marshal of the struct
+// would never produce.
+func newRawCommandEntry(t *testing.T, rawJSON string) kout.Entry {
+	t.Helper()
+	entry, err := kout.NewEntry(clock.Real(), context.Background(), string(enqueue.DispatchID), []byte(rawJSON))
+	require.NoError(t, err)
+	return entry
+}
+
 // TestCommandBus_Enqueue_DispatchAsyncRoundTrip drives the REAL generated
 // enqueue.DispatchAsync: it decodes the entry payload into *Request and invokes
 // the registered Handler — the async sibling of the sync Dispatch round-trip.
@@ -177,14 +188,16 @@ func TestCommandBus_Enqueue_DispatchAsyncRoundTrip(t *testing.T) {
 }
 
 // TestCommandBus_Enqueue_DispatchAsyncHandlerError verifies the handler error is
-// returned (the relay routes it to MarkRetry).
+// returned (the relay routes it to MarkRetry). The payload is schema-VALID
+// (DeviceID + Payload present) so it passes the #1588 value funnel and reaches
+// the handler — the handler's own error is what propagates, not a validation error.
 func TestCommandBus_Enqueue_DispatchAsyncHandlerError(t *testing.T) {
 	t.Parallel()
 	reg := command.NewRegistry()
 	sentinel := errors.New("downstream failure")
 	require.NoError(t, enqueue.Register(reg, &fakeEnqueueHandler{retErr: sentinel}))
 
-	err := enqueue.DispatchAsync(context.Background(), reg, newCommandEntry(t, enqueue.Request{Payload: "x"}))
+	err := enqueue.DispatchAsync(context.Background(), reg, newCommandEntry(t, enqueue.Request{DeviceID: "d1", Payload: "x"}))
 	assert.ErrorIs(t, err, sentinel)
 }
 
@@ -202,11 +215,51 @@ func TestCommandBus_Enqueue_DispatchAsyncBadPayload(t *testing.T) {
 	assert.False(t, h.called, "handler must not run on a malformed payload")
 }
 
+// TestCommandBus_Enqueue_DispatchAsyncValueValidation is the #1588 value funnel:
+// a payload that decodes fine into *Request but violates the request schema's
+// value constraints (required / minLength / additionalProperties) is rejected
+// with ErrValidationFailed BEFORE the handler runs, and the error is PERMANENT
+// (kout.PermanentError) so the relay dead-letters it instead of burning retries.
+// This is the untrusted-boundary counterpart to HTTP body validation; the sync
+// Dispatch path stays unvalidated (first-party typed boundary, ADR §D8).
+func TestCommandBus_Enqueue_DispatchAsyncValueValidation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		rawJSON string
+	}{
+		{"missing required payload", `{"deviceId":"d1"}`},
+		{"missing required deviceId", `{"payload":"x"}`},
+		{"empty deviceId violates minLength", `{"deviceId":"","payload":"x"}`},
+		{"empty payload violates minLength", `{"deviceId":"d1","payload":""}`},
+		{"additionalProperties rejected", `{"deviceId":"d1","payload":"x","bogus":"y"}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reg := command.NewRegistry()
+			h := &fakeEnqueueHandler{}
+			require.NoError(t, enqueue.Register(reg, h))
+
+			err := enqueue.DispatchAsync(context.Background(), reg, newRawCommandEntry(t, tc.rawJSON))
+
+			errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+			assert.False(t, h.called, "handler must not run on a schema-invalid payload")
+			var pe *kout.PermanentError
+			assert.True(t, errors.As(err, &pe),
+				"value-validation failure must be permanent (relay → MarkDead, not retry)")
+		})
+	}
+}
+
 // TestCommandBus_Enqueue_DispatchAsyncNoHandler verifies the no-handler branch.
+// Payload is schema-VALID so it clears the value funnel and reaches the
+// LookupHandler check (which is where the no-handler error originates).
 func TestCommandBus_Enqueue_DispatchAsyncNoHandler(t *testing.T) {
 	t.Parallel()
 	reg := command.NewRegistry()
-	err := enqueue.DispatchAsync(context.Background(), reg, newCommandEntry(t, enqueue.Request{Payload: "x"}))
+	err := enqueue.DispatchAsync(context.Background(), reg, newCommandEntry(t, enqueue.Request{DeviceID: "d1", Payload: "x"}))
 	errcodetest.AssertCode(t, err, errcode.ErrCommandNotFound)
 	var ec *errcode.Error
 	if errors.As(err, &ec) {
@@ -214,10 +267,12 @@ func TestCommandBus_Enqueue_DispatchAsyncNoHandler(t *testing.T) {
 	}
 }
 
-// TestCommandBus_Enqueue_DispatchAsyncNilRegistry verifies the nil-registry guard.
+// TestCommandBus_Enqueue_DispatchAsyncNilRegistry verifies the nil-registry guard
+// fires first (before the value funnel). Payload is valid so the asserted error
+// is unambiguously the nil-registry one, not a schema violation.
 func TestCommandBus_Enqueue_DispatchAsyncNilRegistry(t *testing.T) {
 	t.Parallel()
-	err := enqueue.DispatchAsync(context.Background(), nil, newCommandEntry(t, enqueue.Request{Payload: "x"}))
+	err := enqueue.DispatchAsync(context.Background(), nil, newCommandEntry(t, enqueue.Request{DeviceID: "d1", Payload: "x"}))
 	errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
 }
 
@@ -250,4 +305,36 @@ func TestCommandBus_Enqueue_AsyncRelayEndToEnd(t *testing.T) {
 		return len(rows) == 1 && rows[0].Status == kout.StatePublished
 	}), "command entry must settle to published after in-process dispatch")
 	assert.True(t, h.called, "the registered enqueue handler must be invoked via the relay")
+}
+
+// TestCommandBus_Enqueue_AsyncRelayValueValidationDeadLetters is the end-to-end
+// proof of the #1588 settle classification: a schema-invalid command entry, once
+// claimed by the relay and dispatched to the REAL generated enqueue.DispatchAsync,
+// fails the value funnel with a PERMANENT error, so the relay routes it straight
+// to MarkDead (StateDead) — not MarkRetry, not published, and the handler never
+// runs. Mirrors AsyncRelayEndToEnd but with an invalid payload + dead terminal.
+func TestCommandBus_Enqueue_AsyncRelayValueValidationDeadLetters(t *testing.T) {
+	t.Parallel()
+	reg := command.NewRegistry()
+	h := &fakeEnqueueHandler{}
+	require.NoError(t, enqueue.Register(reg, h))
+
+	store := outboxtest.NewFakeStore()
+	// Missing required "payload" — decodes into *Request but violates the schema.
+	store.Seed(outbox.ClaimedEntry{Entry: newRawCommandEntry(t, `{"deviceId":"d1"}`)})
+
+	relay := outbox.NewRelay(clock.Real(), store, &kout.DiscardPublisher{},
+		outbox.RelayConfig{PollInterval: 5 * time.Millisecond}.WithDefaults())
+	relay.WithCommandDispatch(reg, map[command.CommandID]command.AsyncDispatchFunc{
+		enqueue.DispatchID: enqueue.DispatchAsync,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() { _ = relay.Start(ctx) }()
+
+	require.NoError(t, store.WaitFor(ctx, func(rows []outboxtest.FakeRow) bool {
+		return len(rows) == 1 && rows[0].Status == kout.StateDead
+	}), "schema-invalid command entry must dead-letter (permanent), not retry or publish")
+	assert.False(t, h.called, "the handler must never run for a schema-invalid payload")
 }

--- a/examples/iotdevice/commandbus_roundtrip_test.go
+++ b/examples/iotdevice/commandbus_roundtrip_test.go
@@ -54,6 +54,10 @@ func TestCommandBus_Enqueue_RegisterDispatchRoundTrip(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
+	// DeviceID (a schema-required field) is intentionally omitted: sync Dispatch
+	// is a first-party trusted boundary and does NOT run schema value-validation
+	// (ADR 202606040550-1044 §D8). Only the async DispatchAsync path validates the
+	// untrusted payload (#1588). Adding DeviceID here would obscure that contract.
 	req := &enqueue.Request{CommandType: "reboot", Payload: "now"}
 	resp, err := enqueue.Dispatch(context.Background(), reg, req)
 	if err != nil {

--- a/generated/contracts/command/devicecommand/enqueue/v1/command_gen.go
+++ b/generated/contracts/command/devicecommand/enqueue/v1/command_gen.go
@@ -10,8 +10,10 @@ import (
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/idutil"
+	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/command"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 // DispatchID is the command.Registry key for command.devicecommand.enqueue.v1.
@@ -60,8 +62,9 @@ func Register(reg *command.Registry, h Handler) error {
 // values at runtime: Go enforces field types, additionalProperties:false is
 // structurally unviolatable on a typed struct, and the caller is first-party
 // in-process code. JSON-schema value-validation belongs at the untrusted
-// command-entry boundaries (HTTP→command, async outbox→command), tracked as a
-// #1044 sub-issue.
+// command-entry boundaries: async outbox→command is validated in DispatchAsync
+// (the #1588 value funnel, ADR §Amendment 2026-06-08); HTTP→command (when wired)
+// validates the request body in the generated HTTP handler before calling Dispatch.
 //
 // Returns KindInvalid / ErrValidationFailed when reg or req is nil (miswiring /
 // caller bug — surfaced as a structured error rather than a nil-pointer panic).
@@ -92,6 +95,29 @@ func Dispatch(ctx context.Context, reg *command.Registry, req *Request) (*Respon
 	return h.HandleEnqueue(ctx, req)
 }
 
+// requestSchemaJSON is the contract request schema ($ref-bundled, compacted),
+// embedded for the async command-entry value funnel (#1588). A command always
+// declares a request schemaRef (D6), so unlike HTTP this is emitted
+// unconditionally — there is no codegen path to a command without a validator.
+var requestSchemaJSON = []byte("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"command.devicecommand.enqueue.v1.request\",\"type\":\"object\",\"properties\":{\"deviceId\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256},\"commandType\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":64},\"payload\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":4096}},\"required\":[\"deviceId\",\"payload\"],\"additionalProperties\":false}")
+
+// requestValidator validates the untrusted outbox entry payload in DispatchAsync
+// before decode+handle. Compiled once at init; the schema was already
+// compile-checked at codegen time (contractgen embedRequestSchema → NewValidator),
+// so newRequestValidator never panics in production — the panic is a codegen
+// invariant assertion mirroring handler.tmpl NewHandler.
+var requestValidator = newRequestValidator()
+
+func newRequestValidator() schemavalidate.Validator {
+	v, err := schemavalidate.NewValidator(requestSchemaJSON)
+	if err != nil {
+		panic(panicregister.Approved("command-request-schema-compile-failed",
+			errcode.Assertion("generated command command.devicecommand.enqueue.v1: request schema compile failed: %v "+
+				"(codegen invariant violation; regenerate via gocell generate contract --all)", err)))
+	}
+	return v
+}
+
 // Compile-assert that DispatchAsync matches the generic async-dispatch signature
 // the outbox relay routes command entries to (command.Relay-side
 // WithCommandDispatch). archtest COMMAND-ASYNC-DISPATCH-CALLER-01 locks the
@@ -117,22 +143,25 @@ var _ command.AsyncDispatchFunc = DispatchAsync
 // returned for the relay to settle (ack) or retry the entry.
 //
 // Request value-constraints declared in the contract request schema
-// (minLength/maxLength/required) are NOT validated here — the typed
-// *Request is the structural contract; untrusted-payload
-// value validation at the async command-entry boundary is the command-entry
-// validation funnel tracked as #1588 (ADR §5 / Amendment 2026-06-04).
+// (minLength/maxLength/required/additionalProperties) ARE validated here against
+// the untrusted entry payload via requestValidator, before decode+handle — the
+// async command-entry value funnel (#1588, ADR §Amendment 2026-06-08). This is
+// the untrusted-boundary counterpart to HTTP request-body validation; the
+// synchronous Dispatch path stays unvalidated as a first-party typed boundary
+// (§D8). entry.Payload() is already the inbound JSON, so validating it adds no
+// marshal round-trip — D4 (sync zero-serialization fast-path) is preserved.
 //
 // # Settle classification (relay)
 //
 // Deterministic framework errors — reg nil, routing-topic ≠ DispatchID (a
-// mis-wired dispatcher map), payload decode failure, no handler registered, or a
-// wrong-typed registered value — are wrapped with kout.NewPermanentError. None
-// can recover by retry, so the relay's handleFailedEntry routes them straight to
-// MarkDead instead of burning the retry budget (ADR §Amendment 2026-06-06 r2).
-// The handler's own business error is returned UNWRAPPED: it is transient by
-// default (relay → MarkRetry until the attempt budget is exhausted); a handler
-// that knows a failure is unrecoverable can itself return a kout.PermanentError.
-// Untrusted-payload value-validation classification stays deferred to #1588.
+// mis-wired dispatcher map), request-schema value-validation failure, payload
+// decode failure, no handler registered, or a wrong-typed registered value — are
+// wrapped with kout.NewPermanentError. None can recover by retry, so the relay's
+// handleFailedEntry routes them straight to MarkDead instead of burning the retry
+// budget (ADR §Amendment 2026-06-06 r2 / 2026-06-08). The handler's own business
+// error is returned UNWRAPPED: it is transient by default (relay → MarkRetry
+// until the attempt budget is exhausted); a handler that knows a failure is
+// unrecoverable can itself return a kout.PermanentError.
 func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry) error {
 	if reg == nil {
 		return kout.NewPermanentError(errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
@@ -146,6 +175,14 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 	if entry.RoutingTopic() != string(DispatchID) {
 		return kout.NewPermanentError(errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"command.devicecommand.enqueue.v1 dispatch async: entry routing topic does not match DispatchID"))
+	}
+	// Value funnel (#1588): validate the untrusted wire payload against the request
+	// schema's value constraints (minLength/maxLength/required/additionalProperties)
+	// before decode+handle. A schema violation is deterministic and unrecoverable,
+	// so it is wrapped permanent → relay MarkDead (same class as the decode failure
+	// below). Validate returns an oracle-safe *errcode.Error (ErrValidationFailed).
+	if err := requestValidator.Validate(ctx, entry.Payload()); err != nil {
+		return kout.NewPermanentError(err)
 	}
 	var req Request
 	if err := json.Unmarshal(entry.Payload(), &req); err != nil {

--- a/generated/contracts/http/auth/login/v1/handler_gen.go
+++ b/generated/contracts/http/auth/login/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -84,7 +84,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	req.XTenantID = r.Header.Get("X-Tenant-ID")

--- a/generated/contracts/http/auth/refresh/v1/handler_gen.go
+++ b/generated/contracts/http/auth/refresh/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -84,7 +84,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Refresh(r.Context(), req)

--- a/generated/contracts/http/auth/role/assign/v1/handler_gen.go
+++ b/generated/contracts/http/auth/role/assign/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -91,7 +91,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Assign(r.Context(), req)

--- a/generated/contracts/http/auth/role/revoke/v1/handler_gen.go
+++ b/generated/contracts/http/auth/role/revoke/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -91,7 +91,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Revoke(r.Context(), req)

--- a/generated/contracts/http/auth/setup/admin/v1/handler_gen.go
+++ b/generated/contracts/http/auth/setup/admin/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -99,7 +99,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	req.XTenantID = r.Header.Get("X-Tenant-ID")

--- a/generated/contracts/http/auth/user/change-password/v1/handler_gen.go
+++ b/generated/contracts/http/auth/user/change-password/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -99,7 +99,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.ChangePassword(r.Context(), req)

--- a/generated/contracts/http/auth/user/create/v1/handler_gen.go
+++ b/generated/contracts/http/auth/user/create/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Create(r.Context(), req)

--- a/generated/contracts/http/auth/user/lock/v1/handler_gen.go
+++ b/generated/contracts/http/auth/user/lock/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -97,7 +97,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Lock(r.Context(), req)

--- a/generated/contracts/http/auth/user/patch/v1/handler_gen.go
+++ b/generated/contracts/http/auth/user/patch/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -97,7 +97,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Patch(r.Context(), req)

--- a/generated/contracts/http/auth/user/unlock/v1/handler_gen.go
+++ b/generated/contracts/http/auth/user/unlock/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -97,7 +97,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Unlock(r.Context(), req)

--- a/generated/contracts/http/auth/user/update/v1/handler_gen.go
+++ b/generated/contracts/http/auth/user/update/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -97,7 +97,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Update(r.Context(), req)

--- a/generated/contracts/http/config/flags/create/v1/handler_gen.go
+++ b/generated/contracts/http/config/flags/create/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Create(r.Context(), req)

--- a/generated/contracts/http/config/flags/evaluate/v1/handler_gen.go
+++ b/generated/contracts/http/config/flags/evaluate/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Evaluate(r.Context(), req)

--- a/generated/contracts/http/config/flags/toggle/v1/handler_gen.go
+++ b/generated/contracts/http/config/flags/toggle/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Toggle(r.Context(), req)

--- a/generated/contracts/http/config/flags/update/v1/handler_gen.go
+++ b/generated/contracts/http/config/flags/update/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Update(r.Context(), req)

--- a/generated/contracts/http/config/rollback/v1/handler_gen.go
+++ b/generated/contracts/http/config/rollback/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Rollback(r.Context(), req)

--- a/generated/contracts/http/config/update/v1/handler_gen.go
+++ b/generated/contracts/http/config/update/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Update(r.Context(), req)

--- a/generated/contracts/http/config/write/v1/handler_gen.go
+++ b/generated/contracts/http/config/write/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Write(r.Context(), req)

--- a/generated/contracts/http/device/command/ack/v1/handler_gen.go
+++ b/generated/contracts/http/device/command/ack/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -122,7 +122,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Ack(r.Context(), req)

--- a/generated/contracts/http/device/command/enqueue/v1/handler_gen.go
+++ b/generated/contracts/http/device/command/enqueue/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Enqueue(r.Context(), req)

--- a/generated/contracts/http/device/command/extend-lease/v1/handler_gen.go
+++ b/generated/contracts/http/device/command/extend-lease/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -122,7 +122,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.ExtendLease(r.Context(), req)

--- a/generated/contracts/http/device/register/v1/handler_gen.go
+++ b/generated/contracts/http/device/register/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -83,7 +83,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Register(r.Context(), req)

--- a/generated/contracts/http/order/confirm/v1/handler_gen.go
+++ b/generated/contracts/http/order/confirm/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -106,7 +106,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Confirm(r.Context(), req)

--- a/generated/contracts/http/order/create/v1/handler_gen.go
+++ b/generated/contracts/http/order/create/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Create(r.Context(), req)

--- a/generated/contracts/http/orderfulfillment/placeorder/v1/handler_gen.go
+++ b/generated/contracts/http/orderfulfillment/placeorder/v1/handler_gen.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -83,7 +83,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Placeorder(r.Context(), req)

--- a/runtime/schemavalidate/validator.go
+++ b/runtime/schemavalidate/validator.go
@@ -41,8 +41,19 @@ import (
 type Validator interface {
 	// Validate validates body against the compiled schema.
 	// Returns nil on success. Returns *errcode.Error (code=ErrValidationFailed)
-	// on schema violation. Error messages contain field names but never
-	// expose schema internals (lengths, ranges, regex patterns).
+	// on schema violation.
+	//
+	// Error shape: the offending field path is carried in the "detail"
+	// PublicDetail (oracle-safe — field name only, never the constraint value:
+	// lengths, ranges, regex patterns). The Message is a fixed const literal
+	// ("request body validation failed"). Because (*errcode.Error).Error() renders
+	// only [Code] + Message (+ Cause), NOT Details, a caller that logs err.Error()
+	// — e.g. the outbox relay storing last_error via SanitizeError — never leaks
+	// the field name. The field path reaches clients only via the wire-serialized
+	// details array (4xx), not server-side error strings.
+	//
+	// ctx is accepted for API stability and future cancellation/deadline support;
+	// the default implementation does not use it (validation is CPU-bound, in-memory).
 	Validate(ctx context.Context, body []byte) error
 }
 

--- a/runtime/schemavalidate/validator.go
+++ b/runtime/schemavalidate/validator.go
@@ -1,10 +1,25 @@
-// Package schemavalidate provides JSON Schema validation for generated HTTP handlers.
+// Package schemavalidate provides transport-neutral JSON Schema validation for
+// generated code at untrusted wire boundaries.
 //
 // It loads a JSON Schema (draft 2020-12) from raw bytes, compiles it once at
-// handler construction time, and validates request bodies on every request.
-// Validation errors are mapped to errcode.ErrValidationFailed and written
-// via httputil.WriteError. Error messages expose field names but never expose
-// schema-internal details (lengths, ranges, patterns) to prevent oracle attacks.
+// construction time, and validates payloads on every call. Validation errors are
+// mapped to errcode.ErrValidationFailed. Error messages expose field names but
+// never expose schema-internal details (lengths, ranges, patterns) to prevent
+// oracle attacks.
+//
+// Both transports embed and reuse this validator at their untrusted ingress:
+//   - HTTP handlers (generated/contracts/http/**): validate the request body
+//     bytes before entering the cell (handler.tmpl).
+//   - Async command dispatch (generated/contracts/command/**): validate the
+//     outbox entry payload bytes inside DispatchAsync before unmarshal+handle
+//     (command.tmpl, #1588). The sync in-process Dispatch deliberately does NOT
+//     validate — it is a first-party typed boundary (ADR 202606040550-1044 §D8).
+//
+// HTTP response writing for a validation error is the caller's concern:
+// generated HTTP handlers pass the returned *errcode.Error straight to
+// httputil.WriteError (KindInvalid → 400); this package stays response-writer
+// free so non-HTTP consumers (command dispatch) can reuse it without pulling in
+// net/http.
 //
 // ref: santhosh-tekuri/jsonschema/v6 (already in go.mod via contracttest)
 // ref: deepmap/oapi-codegen security examples (request validation patterns)
@@ -15,13 +30,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
-	"github.com/ghbvf/gocell/pkg/httputil"
 )
 
 // Validator validates a JSON payload against a compiled JSON Schema.
@@ -56,17 +69,6 @@ func NewValidator(schemaJSON []byte) (Validator, error) {
 	}
 
 	return &validator{schema: schema}, nil
-}
-
-// WriteValidationError writes an HTTP 400 response with the error from Validate.
-// If err is not an *errcode.Error it is wrapped as ErrValidationFailed.
-func WriteValidationError(ctx context.Context, w http.ResponseWriter, err error) {
-	var ec *errcode.Error
-	if !errors.As(err, &ec) {
-		ec = errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "request validation failed",
-			errcode.WithInternal(errcode.InternalAttr("_", err.Error())))
-	}
-	httputil.WriteError(ctx, w, ec)
 }
 
 // validator is the concrete implementation backed by santhosh-tekuri/jsonschema/v6.

--- a/runtime/schemavalidate/validator_test.go
+++ b/runtime/schemavalidate/validator_test.go
@@ -3,6 +3,7 @@ package schemavalidate
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -74,12 +75,20 @@ func TestValidator_MinLength(t *testing.T) {
 	if containsLengthOracle(ec.Message) {
 		t.Errorf("message exposes schema internals (oracle): %q", ec.Message)
 	}
-	// Field name must appear in the detail attribute (not the const Message).
+	// Field name must appear in the detail attribute (not the const Message),
+	// and the detail value is the real oracle vector (the const Message can never
+	// carry constraint values) — it too must not leak the length.
 	detailAttr, found := ec.FindAttr("detail")
 	if !found {
 		t.Errorf("expected 'detail' attribute in error details, got none")
-	} else if v, _ := detailAttr.Value().(string); !containsFieldName(v, "name") {
-		t.Errorf("detail should contain field name 'name', got: %q", detailAttr.Value())
+	} else {
+		v, _ := detailAttr.Value().(string)
+		if !containsFieldName(v, "name") {
+			t.Errorf("detail should contain field name 'name', got: %q", v)
+		}
+		if containsLengthOracle(v) {
+			t.Errorf("detail exposes schema internals (oracle): %q", v)
+		}
 	}
 }
 
@@ -106,6 +115,11 @@ func TestValidator_MaxLength(t *testing.T) {
 	}
 	if containsLengthOracle(ec.Message) {
 		t.Errorf("message exposes oracle: %q", ec.Message)
+	}
+	if d, found := ec.FindAttr("detail"); found {
+		if v, _ := d.Value().(string); containsLengthOracle(v) {
+			t.Errorf("detail exposes oracle: %q", v)
+		}
 	}
 }
 
@@ -153,9 +167,14 @@ func TestValidator_PatternRegex(t *testing.T) {
 	if ec.Code != errcode.ErrValidationFailed {
 		t.Errorf("code = %q, want ErrValidationFailed", ec.Code)
 	}
-	// Must not expose the regex pattern.
+	// Must not expose the regex pattern — in the const Message or the detail value.
 	if containsPatternOracle(ec.Message) {
 		t.Errorf("message exposes pattern oracle: %q", ec.Message)
+	}
+	if d, found := ec.FindAttr("detail"); found {
+		if v, _ := d.Value().(string); containsPatternOracle(v) {
+			t.Errorf("detail exposes pattern oracle: %q", v)
+		}
 	}
 }
 
@@ -181,6 +200,20 @@ func TestValidator_RequiredMissing(t *testing.T) {
 	}
 	if ec.Code != errcode.ErrValidationFailed {
 		t.Errorf("code = %q, want ErrValidationFailed", ec.Code)
+	}
+	// Detail contract for a `required` violation: the JSON Schema `required`
+	// keyword fails at the *parent object* instance location (empty path at the
+	// top level), so the safe message collapses to a generic "invalid" rather
+	// than enumerating the missing field name. This is intentional — declining to
+	// name the missing field avoids a property-enumeration oracle (a client can
+	// already see which field it omitted). Assert it explicitly so the behavior
+	// can't silently drift into leaking field names.
+	d, found := ec.FindAttr("detail")
+	if !found {
+		t.Fatalf("expected 'detail' attribute, got none")
+	}
+	if v, _ := d.Value().(string); v != "invalid" {
+		t.Errorf("required-missing detail = %q, want generic %q (no field enumeration)", v, "invalid")
 	}
 }
 
@@ -289,9 +322,8 @@ func containsLengthOracle(s string) bool {
 		"minLength", "maxLength", "must be at least", "must be at most",
 		"must be longer", "must be shorter", "characters",
 	}
-	lower := s
 	for _, kw := range oracleKeywords {
-		if contains(lower, kw) {
+		if contains(s, kw) {
 			return true
 		}
 	}
@@ -314,40 +346,7 @@ func containsFieldName(s, fieldName string) bool {
 	return contains(s, fieldName)
 }
 
-// contains is a case-insensitive substring check.
+// contains is a case-insensitive substring check (stdlib-backed).
 func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
-		indexCI(s, sub) >= 0)
-}
-
-func indexCI(s, sub string) int {
-	ls, lsub := len(s), len(sub)
-	if lsub == 0 {
-		return 0
-	}
-	for i := 0; i <= ls-lsub; i++ {
-		if equalCI(s[i:i+lsub], sub) {
-			return i
-		}
-	}
-	return -1
-}
-
-func equalCI(a, b string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		ac, bc := a[i], b[i]
-		if ac >= 'A' && ac <= 'Z' {
-			ac += 32
-		}
-		if bc >= 'A' && bc <= 'Z' {
-			bc += 32
-		}
-		if ac != bc {
-			return false
-		}
-	}
-	return true
+	return strings.Contains(strings.ToLower(s), strings.ToLower(sub))
 }

--- a/runtime/schemavalidate/validator_test.go
+++ b/runtime/schemavalidate/validator_test.go
@@ -3,8 +3,6 @@ package schemavalidate
 import (
 	"context"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -32,6 +30,22 @@ func TestValidator_HappyPath(t *testing.T) {
 
 	if err := v.Validate(context.Background(), []byte(`{"name":"alice"}`)); err != nil {
 		t.Errorf("expected no error for valid input, got: %v", err)
+	}
+}
+
+func TestValidator_InvalidJSONBody(t *testing.T) {
+	v := schemaForTest(t, `{"type": "object"}`)
+
+	err := v.Validate(context.Background(), []byte("not json"))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON body, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != errcode.ErrValidationFailed {
+		t.Errorf("code = %q, want ErrValidationFailed", ec.Code)
 	}
 }
 
@@ -264,26 +278,6 @@ func TestValidator_ErrorTypeIsErrcode(t *testing.T) {
 	}
 	if ec.Code != errcode.ErrValidationFailed {
 		t.Errorf("Code = %q, want ErrValidationFailed", ec.Code)
-	}
-}
-
-func TestWriteValidationError_WritesHTTP400(t *testing.T) {
-	err := errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "name: invalid")
-	w := httptest.NewRecorder()
-	WriteValidationError(context.Background(), w, err)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("HTTP status = %d, want 400", w.Code)
-	}
-}
-
-func TestWriteValidationError_WrapsPlainError(t *testing.T) {
-	plainErr := errors.New("something went wrong")
-	w := httptest.NewRecorder()
-	WriteValidationError(context.Background(), w, plainErr)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("HTTP status = %d, want 400", w.Code)
 	}
 }
 

--- a/tools/codegen/contractgen/builder.go
+++ b/tools/codegen/contractgen/builder.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/kernel/saga"
 	"github.com/ghbvf/gocell/pkg/contractpath"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 // buildContractSpec projects a single contract.yaml + its schemaRefs into a
@@ -206,32 +206,52 @@ func buildHTTPSpec(spec *ContractGenSpec, rootDir string, contract *metadata.Con
 	// ref: oapi-codegen — request validator emitted only for operations with
 	// a requestBody.
 	if contract.SchemaRefs.Request != "" && endpointSpec.HasBody {
-		reqPath := filepath.Join(rootDir, contractDir, contract.SchemaRefs.Request)
-		schemaBytes, err := os.ReadFile(reqPath) //nolint:gosec // schema path resolved from contract.yaml metadata
+		embedded, err := embedRequestSchema(contract.ID, rootDir, contractDir, contract.SchemaRefs.Request)
 		if err != nil {
-			return fmt.Errorf("contractgen build: %q read request schema for embed: %w", contract.ID, err)
+			return err
 		}
-		// Resolve external $ref entries so the embedded schema is self-contained.
-		// schemavalidate.NewValidator (santhosh-tekuri, base URI "mem:///") has no
-		// external loader; an unresolved $ref would fail to compile at codegen time.
-		bundled, err := bundleSchemaRefs(rootDir, reqPath, schemaBytes)
-		if err != nil {
-			return fmt.Errorf("contractgen build: %q bundle request schema $ref: %w", contract.ID, err)
-		}
-		// Compact to a single line: eliminates newlines so the schema can be
-		// safely embedded in the generated file as a Go interpreted string literal.
-		var compacted bytes.Buffer
-		if err := json.Compact(&compacted, bundled); err != nil {
-			return fmt.Errorf("contractgen build: %q compact request schema: %w", contract.ID, err)
-		}
-		// Validate schema compiles before embedding — fail-fast at codegen time
-		// rather than at runtime. ref: oapi-codegen pkg/codegen/templates/strict.
-		if _, vErr := schemavalidate.NewValidator(compacted.Bytes()); vErr != nil {
-			return fmt.Errorf("contractgen build: %q request schema fails to compile: %w", contract.ID, vErr)
-		}
-		spec.RequestSchemaJSON = compacted.String()
+		spec.RequestSchemaJSON = embedded
 	}
 	return nil
+}
+
+// embedRequestSchema reads, $ref-bundles, compacts, and compile-checks the
+// request schema at contractDir/ref, returning the single-line JSON to embed in
+// generated code for runtime schemavalidate.Validator construction. The
+// compile-check fails codegen early (rather than at runtime) when the schema is
+// malformed.
+//
+// Shared by HTTP handlers (handler.tmpl) and async command dispatch
+// (command.tmpl, #1588) — both validate untrusted wire bytes at ingress against
+// the embedded schema. Single source so the bundle/compact/compile-check
+// sequence stays identical across both transports.
+//
+//   - bundleSchemaRefs inlines external $ref so the embedded schema is
+//     self-contained: schemavalidate.NewValidator (santhosh-tekuri, base URI
+//     "mem:///") has no external loader; an unresolved $ref would fail to compile.
+//   - json.Compact eliminates newlines so the schema embeds safely as a Go
+//     interpreted string literal.
+//   - the NewValidator compile-check is the codegen-time fail-fast.
+//
+// ref: oapi-codegen — request validator emitted from the operation's requestBody schema.
+func embedRequestSchema(contractID, rootDir, contractDir, ref string) (string, error) {
+	reqPath := filepath.Join(rootDir, contractDir, ref)
+	schemaBytes, err := os.ReadFile(reqPath) //nolint:gosec // schema path resolved from contract.yaml metadata
+	if err != nil {
+		return "", fmt.Errorf("contractgen build: %q read request schema for embed: %w", contractID, err)
+	}
+	bundled, err := bundleSchemaRefs(rootDir, reqPath, schemaBytes)
+	if err != nil {
+		return "", fmt.Errorf("contractgen build: %q bundle request schema $ref: %w", contractID, err)
+	}
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, bundled); err != nil {
+		return "", fmt.Errorf("contractgen build: %q compact request schema: %w", contractID, err)
+	}
+	if _, vErr := schemavalidate.NewValidator(compacted.Bytes()); vErr != nil {
+		return "", fmt.Errorf("contractgen build: %q request schema fails to compile: %w", contractID, vErr)
+	}
+	return compacted.String(), nil
 }
 
 // buildHTTPDTOs loads request/response schemas, converts them to DTOSpecs, and
@@ -765,6 +785,20 @@ func buildCommandSpec(spec *ContractGenSpec, rootDir string, contract *metadata.
 		return err
 	}
 	spec.DTOs = dtos
+
+	// Embed the request schema for runtime value-validation at the untrusted
+	// async command-entry boundary (#1588). Unlike HTTP (gated on endpoint
+	// HasBody), a command ALWAYS carries a request payload and D6 mandates a
+	// non-empty request schemaRef (checked above), so the embed is unconditional
+	// — there is no "command without a request validator" path. command.tmpl
+	// emits requestValidator + its DispatchAsync Validate call unconditionally;
+	// the golden byte-lock pins them so the value funnel cannot be silently
+	// dropped (ADR 202606040550-1044 §Amendment 2026-06-08).
+	embedded, err := embedRequestSchema(contract.ID, rootDir, contractDir, reqRef)
+	if err != nil {
+		return err
+	}
+	spec.RequestSchemaJSON = embedded
 
 	domainLast := domainLastSegment(contract.ID)
 	spec.Command = &CommandSpec{

--- a/tools/codegen/contractgen/command_builder_test.go
+++ b/tools/codegen/contractgen/command_builder_test.go
@@ -8,6 +8,7 @@ package contractgen
 // see TestBuildCommandSpec_NoSchemaRefs / _MissingRequestSchemaRef / _MissingResponseSchemaRef.
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -104,6 +105,71 @@ func TestBuildCommandSpec_FullSpec(t *testing.T) {
 			names = append(names, d.Name)
 		}
 		t.Errorf("spec.DTOs missing 'Response'; got: %v", names)
+	}
+
+	// #1588: a command always embeds its request schema for the async-entry
+	// value funnel (unlike HTTP, which gates on HasBody). It must be non-empty,
+	// single-line compacted, and carry the schema's properties.
+	if spec.RequestSchemaJSON == "" {
+		t.Fatal("spec.RequestSchemaJSON must be non-empty for a command (D6 mandates request schemaRef)")
+	}
+	if strings.Contains(spec.RequestSchemaJSON, "\n") {
+		t.Errorf("spec.RequestSchemaJSON must be single-line compacted; got newline: %q", spec.RequestSchemaJSON)
+	}
+	if !strings.Contains(spec.RequestSchemaJSON, `"deviceId"`) {
+		t.Errorf("spec.RequestSchemaJSON must carry the request schema properties; got: %q", spec.RequestSchemaJSON)
+	}
+}
+
+// TestEmbedRequestSchema_Valid verifies the shared embed helper reads, bundles,
+// compacts, and compile-checks a valid request schema into single-line JSON
+// (the #1588 / HTTP-shared embedRequestSchema funnel).
+func TestEmbedRequestSchema_Valid(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const schema = `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"properties": { "deviceId": { "type": "string", "minLength": 1 } },
+		"required": ["deviceId"],
+		"additionalProperties": false
+	}`
+	if err := os.WriteFile(filepath.Join(root, "request.schema.json"), []byte(schema), 0o600); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	got, err := embedRequestSchema("command.test.do.v1", root, "", "request.schema.json")
+	if err != nil {
+		t.Fatalf("embedRequestSchema(valid): %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty embedded schema")
+	}
+	if strings.ContainsAny(got, "\n\t") {
+		t.Errorf("embedded schema must be compacted single-line; got: %q", got)
+	}
+	if !strings.Contains(got, `"deviceId"`) || !strings.Contains(got, `"minLength":1`) {
+		t.Errorf("embedded schema lost constraints; got: %q", got)
+	}
+}
+
+// TestEmbedRequestSchema_InvalidSchema verifies the codegen-time compile-check
+// fails fast on a schema that does not compile (the AI-HARD fail-fast: a command
+// can never half-generate around a broken value funnel). `type` must be a string
+// or array of strings; a number violates the draft 2020-12 meta-schema.
+func TestEmbedRequestSchema_InvalidSchema(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "request.schema.json"), []byte(`{"type": 123}`), 0o600); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	_, err := embedRequestSchema("command.test.do.v1", root, "", "request.schema.json")
+	if err == nil {
+		t.Fatal("expected compile error for an uncompilable request schema, got nil")
+	}
+	if !strings.Contains(err.Error(), "fails to compile") {
+		t.Errorf("error must cite the compile-check; got: %v", err)
 	}
 }
 

--- a/tools/codegen/contractgen/command_render_test.go
+++ b/tools/codegen/contractgen/command_render_test.go
@@ -124,6 +124,13 @@ func TestRender_Command_ContainsKeySymbols(t *testing.T) {
 		{"Dispatch func", "func Dispatch(ctx context.Context, reg *command.Registry, req *Request) (*Response, error)"},
 		{"AsyncDispatchFunc assert", "var _ command.AsyncDispatchFunc = DispatchAsync"},
 		{"DispatchAsync func", "func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry) error"},
+		// #1588 value funnel: unconditional request-schema embed + validator +
+		// the DispatchAsync Validate call (the async command-entry value check).
+		{"requestSchemaJSON embed", "var requestSchemaJSON = []byte("},
+		{"requestValidator var", "var requestValidator = newRequestValidator()"},
+		{"newRequestValidator helper", "func newRequestValidator() schemavalidate.Validator"},
+		{"DispatchAsync value-validate call", "requestValidator.Validate(ctx, entry.Payload())"},
+		{"schemavalidate import", `"github.com/ghbvf/gocell/runtime/schemavalidate"`},
 		{"KindInvalid", "errcode.KindInvalid"},
 		{"KindNotFound", "errcode.KindNotFound"},
 		{"KindInternal", "errcode.KindInternal"},

--- a/tools/codegen/contractgen/refbundle_test.go
+++ b/tools/codegen/contractgen/refbundle_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 // TestBundleSchemaRefs tests the bundleSchemaRefs function which resolves external

--- a/tools/codegen/contractgen/spec.go
+++ b/tools/codegen/contractgen/spec.go
@@ -61,11 +61,16 @@ type ContractGenSpec struct {
 	// (No grpc field: kind=grpc emits zero contractgen artifacts since #1688 —
 	// buf's generated pb.<Svc>Server is the sole server contract.)
 	// RequestSchemaJSON is the raw JSON content of the request schema file,
-	// compacted to a single line (no extra whitespace).
-	// Non-empty only when Kind=="http" and the contract declares schemaRefs.request.
-	// The generated handler embeds this as a Go string literal to compile the
+	// $ref-bundled and compacted to a single line (no extra whitespace).
+	// Set by embedRequestSchema for two kinds:
+	//   - Kind=="http" with a body (POST/PUT/PATCH declaring schemaRefs.request)
+	//     — handler.tmpl embeds it to validate the request body at HTTP ingress.
+	//   - Kind=="command" — ALWAYS set (D6 mandates schemaRefs.request; a command
+	//     always carries a payload), so command.tmpl unconditionally embeds it to
+	//     validate the untrusted outbox entry payload inside DispatchAsync (#1588).
+	// The generated code embeds this as a Go string literal to compile the
 	// validator at construction time — no runtime file I/O, no embed.FS.
-	// Empty string means no schema validation is emitted.
+	// Empty string means no schema validation is emitted (no-body HTTP endpoints).
 	RequestSchemaJSON string
 
 	// PanicReasonPolicyNil is the kebab-case reason literal passed to

--- a/tools/codegen/contractgen/templates/command.tmpl
+++ b/tools/codegen/contractgen/templates/command.tmpl
@@ -9,8 +9,10 @@ import (
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/idutil"
+	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/command"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 // DispatchID is the command.Registry key for {{.ContractID}}.
@@ -59,8 +61,9 @@ func Register(reg *command.Registry, h Handler) error {
 // values at runtime: Go enforces field types, additionalProperties:false is
 // structurally unviolatable on a typed struct, and the caller is first-party
 // in-process code. JSON-schema value-validation belongs at the untrusted
-// command-entry boundaries (HTTP→command, async outbox→command), tracked as a
-// #1044 sub-issue.
+// command-entry boundaries: async outbox→command is validated in DispatchAsync
+// (the #1588 value funnel, ADR §Amendment 2026-06-08); HTTP→command (when wired)
+// validates the request body in the generated HTTP handler before calling Dispatch.
 //
 // Returns KindInvalid / ErrValidationFailed when reg or req is nil (miswiring /
 // caller bug — surfaced as a structured error rather than a nil-pointer panic).
@@ -91,6 +94,29 @@ func Dispatch(ctx context.Context, reg *command.Registry, req *{{.Command.Reques
 	return h.{{.Command.HandlerMethod}}(ctx, req)
 }
 
+// requestSchemaJSON is the contract request schema ($ref-bundled, compacted),
+// embedded for the async command-entry value funnel (#1588). A command always
+// declares a request schemaRef (D6), so unlike HTTP this is emitted
+// unconditionally — there is no codegen path to a command without a validator.
+var requestSchemaJSON = []byte({{quoteGoString .RequestSchemaJSON}})
+
+// requestValidator validates the untrusted outbox entry payload in DispatchAsync
+// before decode+handle. Compiled once at init; the schema was already
+// compile-checked at codegen time (contractgen embedRequestSchema → NewValidator),
+// so newRequestValidator never panics in production — the panic is a codegen
+// invariant assertion mirroring handler.tmpl NewHandler.
+var requestValidator = newRequestValidator()
+
+func newRequestValidator() schemavalidate.Validator {
+	v, err := schemavalidate.NewValidator(requestSchemaJSON)
+	if err != nil {
+		panic(panicregister.Approved("command-request-schema-compile-failed",
+			errcode.Assertion("generated command {{.ContractID}}: request schema compile failed: %v "+
+				"(codegen invariant violation; regenerate via gocell generate contract --all)", err)))
+	}
+	return v
+}
+
 // Compile-assert that DispatchAsync matches the generic async-dispatch signature
 // the outbox relay routes command entries to (command.Relay-side
 // WithCommandDispatch). archtest COMMAND-ASYNC-DISPATCH-CALLER-01 locks the
@@ -116,22 +142,25 @@ var _ command.AsyncDispatchFunc = DispatchAsync
 // returned for the relay to settle (ack) or retry the entry.
 //
 // Request value-constraints declared in the contract request schema
-// (minLength/maxLength/required) are NOT validated here — the typed
-// *{{.Command.RequestGoType}} is the structural contract; untrusted-payload
-// value validation at the async command-entry boundary is the command-entry
-// validation funnel tracked as #1588 (ADR §5 / Amendment 2026-06-04).
+// (minLength/maxLength/required/additionalProperties) ARE validated here against
+// the untrusted entry payload via requestValidator, before decode+handle — the
+// async command-entry value funnel (#1588, ADR §Amendment 2026-06-08). This is
+// the untrusted-boundary counterpart to HTTP request-body validation; the
+// synchronous Dispatch path stays unvalidated as a first-party typed boundary
+// (§D8). entry.Payload() is already the inbound JSON, so validating it adds no
+// marshal round-trip — D4 (sync zero-serialization fast-path) is preserved.
 //
 // # Settle classification (relay)
 //
 // Deterministic framework errors — reg nil, routing-topic ≠ DispatchID (a
-// mis-wired dispatcher map), payload decode failure, no handler registered, or a
-// wrong-typed registered value — are wrapped with kout.NewPermanentError. None
-// can recover by retry, so the relay's handleFailedEntry routes them straight to
-// MarkDead instead of burning the retry budget (ADR §Amendment 2026-06-06 r2).
-// The handler's own business error is returned UNWRAPPED: it is transient by
-// default (relay → MarkRetry until the attempt budget is exhausted); a handler
-// that knows a failure is unrecoverable can itself return a kout.PermanentError.
-// Untrusted-payload value-validation classification stays deferred to #1588.
+// mis-wired dispatcher map), request-schema value-validation failure, payload
+// decode failure, no handler registered, or a wrong-typed registered value — are
+// wrapped with kout.NewPermanentError. None can recover by retry, so the relay's
+// handleFailedEntry routes them straight to MarkDead instead of burning the retry
+// budget (ADR §Amendment 2026-06-06 r2 / 2026-06-08). The handler's own business
+// error is returned UNWRAPPED: it is transient by default (relay → MarkRetry
+// until the attempt budget is exhausted); a handler that knows a failure is
+// unrecoverable can itself return a kout.PermanentError.
 func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry) error {
 	if reg == nil {
 		return kout.NewPermanentError(errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
@@ -145,6 +174,14 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 	if entry.RoutingTopic() != string(DispatchID) {
 		return kout.NewPermanentError(errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"{{.Command.DispatchID}} dispatch async: entry routing topic does not match DispatchID"))
+	}
+	// Value funnel (#1588): validate the untrusted wire payload against the request
+	// schema's value constraints (minLength/maxLength/required/additionalProperties)
+	// before decode+handle. A schema violation is deterministic and unrecoverable,
+	// so it is wrapped permanent → relay MarkDead (same class as the decode failure
+	// below). Validate returns an oracle-safe *errcode.Error (ErrValidationFailed).
+	if err := requestValidator.Validate(ctx, entry.Payload()); err != nil {
+		return kout.NewPermanentError(err)
 	}
 	var req {{.Command.RequestGoType}}
 	if err := json.Unmarshal(entry.Payload(), &req); err != nil {

--- a/tools/codegen/contractgen/templates/handler.tmpl
+++ b/tools/codegen/contractgen/templates/handler.tmpl
@@ -142,7 +142,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
 {{- if .RequestSchemaJSON}}
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 {{- end}}
 )
 
@@ -370,7 +370,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 {{- end}}

--- a/tools/codegen/contractgen/testdata/golden/http_order_create_v1_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/http_order_create_v1_handler_gen_go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Create(r.Context(), req)

--- a/tools/codegen/contractgen/testdata/golden/synth_command_command_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_command_command_gen_go.golden
@@ -10,8 +10,10 @@ import (
 	kout "github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/idutil"
+	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/command"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 // DispatchID is the command.Registry key for command.synth.do.v1.
@@ -60,8 +62,9 @@ func Register(reg *command.Registry, h Handler) error {
 // values at runtime: Go enforces field types, additionalProperties:false is
 // structurally unviolatable on a typed struct, and the caller is first-party
 // in-process code. JSON-schema value-validation belongs at the untrusted
-// command-entry boundaries (HTTP→command, async outbox→command), tracked as a
-// #1044 sub-issue.
+// command-entry boundaries: async outbox→command is validated in DispatchAsync
+// (the #1588 value funnel, ADR §Amendment 2026-06-08); HTTP→command (when wired)
+// validates the request body in the generated HTTP handler before calling Dispatch.
 //
 // Returns KindInvalid / ErrValidationFailed when reg or req is nil (miswiring /
 // caller bug — surfaced as a structured error rather than a nil-pointer panic).
@@ -92,6 +95,29 @@ func Dispatch(ctx context.Context, reg *command.Registry, req *Request) (*Respon
 	return h.HandleDo(ctx, req)
 }
 
+// requestSchemaJSON is the contract request schema ($ref-bundled, compacted),
+// embedded for the async command-entry value funnel (#1588). A command always
+// declares a request schemaRef (D6), so unlike HTTP this is emitted
+// unconditionally — there is no codegen path to a command without a validator.
+var requestSchemaJSON = []byte("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"command.synth.do.v1.request\",\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"deviceId\":{\"type\":\"string\",\"format\":\"uuid\"},\"payload\":{\"type\":\"string\"}},\"required\":[\"deviceId\"]}")
+
+// requestValidator validates the untrusted outbox entry payload in DispatchAsync
+// before decode+handle. Compiled once at init; the schema was already
+// compile-checked at codegen time (contractgen embedRequestSchema → NewValidator),
+// so newRequestValidator never panics in production — the panic is a codegen
+// invariant assertion mirroring handler.tmpl NewHandler.
+var requestValidator = newRequestValidator()
+
+func newRequestValidator() schemavalidate.Validator {
+	v, err := schemavalidate.NewValidator(requestSchemaJSON)
+	if err != nil {
+		panic(panicregister.Approved("command-request-schema-compile-failed",
+			errcode.Assertion("generated command command.synth.do.v1: request schema compile failed: %v "+
+				"(codegen invariant violation; regenerate via gocell generate contract --all)", err)))
+	}
+	return v
+}
+
 // Compile-assert that DispatchAsync matches the generic async-dispatch signature
 // the outbox relay routes command entries to (command.Relay-side
 // WithCommandDispatch). archtest COMMAND-ASYNC-DISPATCH-CALLER-01 locks the
@@ -117,22 +143,25 @@ var _ command.AsyncDispatchFunc = DispatchAsync
 // returned for the relay to settle (ack) or retry the entry.
 //
 // Request value-constraints declared in the contract request schema
-// (minLength/maxLength/required) are NOT validated here — the typed
-// *Request is the structural contract; untrusted-payload
-// value validation at the async command-entry boundary is the command-entry
-// validation funnel tracked as #1588 (ADR §5 / Amendment 2026-06-04).
+// (minLength/maxLength/required/additionalProperties) ARE validated here against
+// the untrusted entry payload via requestValidator, before decode+handle — the
+// async command-entry value funnel (#1588, ADR §Amendment 2026-06-08). This is
+// the untrusted-boundary counterpart to HTTP request-body validation; the
+// synchronous Dispatch path stays unvalidated as a first-party typed boundary
+// (§D8). entry.Payload() is already the inbound JSON, so validating it adds no
+// marshal round-trip — D4 (sync zero-serialization fast-path) is preserved.
 //
 // # Settle classification (relay)
 //
 // Deterministic framework errors — reg nil, routing-topic ≠ DispatchID (a
-// mis-wired dispatcher map), payload decode failure, no handler registered, or a
-// wrong-typed registered value — are wrapped with kout.NewPermanentError. None
-// can recover by retry, so the relay's handleFailedEntry routes them straight to
-// MarkDead instead of burning the retry budget (ADR §Amendment 2026-06-06 r2).
-// The handler's own business error is returned UNWRAPPED: it is transient by
-// default (relay → MarkRetry until the attempt budget is exhausted); a handler
-// that knows a failure is unrecoverable can itself return a kout.PermanentError.
-// Untrusted-payload value-validation classification stays deferred to #1588.
+// mis-wired dispatcher map), request-schema value-validation failure, payload
+// decode failure, no handler registered, or a wrong-typed registered value — are
+// wrapped with kout.NewPermanentError. None can recover by retry, so the relay's
+// handleFailedEntry routes them straight to MarkDead instead of burning the retry
+// budget (ADR §Amendment 2026-06-06 r2 / 2026-06-08). The handler's own business
+// error is returned UNWRAPPED: it is transient by default (relay → MarkRetry
+// until the attempt budget is exhausted); a handler that knows a failure is
+// unrecoverable can itself return a kout.PermanentError.
 func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry) error {
 	if reg == nil {
 		return kout.NewPermanentError(errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
@@ -146,6 +175,14 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 	if entry.RoutingTopic() != string(DispatchID) {
 		return kout.NewPermanentError(errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"command.synth.do.v1 dispatch async: entry routing topic does not match DispatchID"))
+	}
+	// Value funnel (#1588): validate the untrusted wire payload against the request
+	// schema's value constraints (minLength/maxLength/required/additionalProperties)
+	// before decode+handle. A schema violation is deterministic and unrecoverable,
+	// so it is wrapped permanent → relay MarkDead (same class as the decode failure
+	// below). Validate returns an oracle-safe *errcode.Error (ErrValidationFailed).
+	if err := requestValidator.Validate(ctx, entry.Payload()); err != nil {
+		return kout.NewPermanentError(err)
 	}
 	var req Request
 	if err := json.Unmarshal(entry.Payload(), &req); err != nil {

--- a/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_bootstrap_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_bootstrap_handler_gen_go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -99,7 +99,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Bootstrap(r.Context(), req)

--- a/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_idempotencyexempt_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_idempotencyexempt_handler_gen_go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -92,7 +92,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Idempotencyexempt(r.Context(), req)

--- a/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_passwordresetexempt_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_passwordresetexempt_handler_gen_go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -91,7 +91,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Passwordresetexempt(r.Context(), req)

--- a/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_public_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_auth_modes_public_handler_gen_go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -83,7 +83,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Public(r.Context(), req)

--- a/tools/codegen/contractgen/testdata/golden/synth_http_minimal_handler_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_http_minimal_handler_gen_go.golden
@@ -15,7 +15,7 @@ import (
 	"github.com/ghbvf/gocell/pkg/httputil"
 	"github.com/ghbvf/gocell/pkg/panicregister"
 	"github.com/ghbvf/gocell/runtime/auth"
-	"github.com/ghbvf/gocell/runtime/http/schemavalidate"
+	"github.com/ghbvf/gocell/runtime/schemavalidate"
 )
 
 var contractSpec = contractspec.ContractSpec{
@@ -90,7 +90,9 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	// schemavalidate.NewValidator failure (codegen invariant), so the field
 	// is only reachable here when validator construction succeeded.
 	if err := h.requestValidator.Validate(r.Context(), bodyBytes); err != nil {
-		schemavalidate.WriteValidationError(r.Context(), w, err)
+		// Validate always returns *errcode.Error (ErrValidationFailed → 400);
+		// httputil.WriteError renders it via errors.As → writeErrcodeError.
+		httputil.WriteError(r.Context(), w, err)
 		return
 	}
 	resp, err := h.svc.Ping(r.Context(), req)


### PR DESCRIPTION
## Summary

在 async command-entry 不可信边界落地 request-schema 值校验 funnel：生成的 `DispatchAsync` 现对 `entry.Payload()`（入站 wire JSON bytes）强制 schema 值约束（minLength/maxLength/required/additionalProperties），违例 → permanent → relay `MarkDead`。

## Why / 背景

W3 Command Bus 同步核心（#1578）+ async 桥（#1667）落地后，`DispatchAsync` 从不可信 payload unmarshal 回 typed `*Request` 直调 handler，**不执行**任何 schema 值约束（#1578 round-2 codex F5 / Cx3 显式延后）。本 PR 在该不可信边界执行值校验，是 HTTP request-body 校验的对位物。**honor D4**：async 输入本就是 JSON bytes，校验零 marshal round-trip；sync `Dispatch` 仍刻意不校验（第一方可信边界，ADR §D8）。

裁决（与用户对齐）：复用既有 byte-validator（option b），而非新建 typed-struct 约束 IR（option a，覆盖不全 + 须另起全新 archtest/golden 机制，否决）。值校验落生成 `DispatchAsync` 体内、骑既有 `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01` golden 锁——**无新增 enforcement 机制**。

主要改动：
- `runtime/http/schemavalidate` 核心抽到 transport-neutral `runtime/schemavalidate`；`WriteValidationError` 删除（generated HTTP handler 改调既有 `httputil.WriteError`——`Validate` 恒返回 `*errcode.Error`，原 fallback 是 dead code）。25 个 HTTP handler 重生引用中性包。
- `contractgen.embedRequestSchema`（HTTP+command 共享 helper）；command **无条件** embed request schema（D6 保证 schemaRef 恒存在，无 `HasBody` gate），`command.tmpl` emit `requestSchemaJSON` + 包级 `requestValidator` + `DispatchAsync` 的 `Validate` 调用。
- 值校验失败分类 = permanent（确定性不可重试，复用 #1673 F3 settle 机制）。

## Refs

- Closes #1588（Refs #1044 W3 Command Bus epic）
- ADR `docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md` §Amendment 2026-06-08（+ §112 重写、§D8 澄清、§5 标 delivered、§4 矩阵逐行重评无降格）
- `.claude/rules/gocell/eventbus.md`「Relay 命令分发」节同步
- ref: oapi-codegen request-body validation；santhosh-tekuri/jsonschema/v6

## Risk / 兼容性

- **无 wire/schema/errcode/migration 变化**——未触发 contract-fanout 5 载体（复用 `ErrValidationFailed`；`runtime/http/schemavalidate` → `runtime/schemavalidate` 是内部 refactor，generated 重生由 `generatedverify` 守）。无外部调用方（pre-v1.0）。
- 行为变化：async 命令 entry 若 payload 违反 request schema，现 fail-closed dead-letter（此前静默放行进 handler）。sync `Dispatch` 不变。
- HTTP→command 边界不在本 PR（仓内无 wiring；真落地时复用 HTTP handler 既有 validator）。真实 binary async producer 接线 = #1698（正交）。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./runtime/schemavalidate/... ./tools/codegen/contractgen/... ./examples/iotdevice/...` 通过（新增 value-validation 5 子例 + relay dead-letter E2E；既有 TDD 红→绿）
- [x] `go test ./tools/generatedverify/...` 通过（生成物 == 重生，无 drift）
- [x] `go run ./cmd/gocell validate` 0 error
- [x] `golangci-lint run ./...`（改动包）0 issues
- [x] command/panic/errcode archtests 通过（4 个 develop-pre-existing nightly archtest 失败与本 PR 无关，已在 clean develop 复现）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
