### PR TITLE
fix(governance): reduce TOPO-05 lint complexity

### DIFF
--- a/kernel/governance/rules_topo.go
+++ b/kernel/governance/rules_topo.go
@@ -202,9 +202,19 @@ func (v *Validator) checkContractProviderLevel(
 // the exception: the owner cell is listed as the provider/receiver endpoint, but
 // its implementing role is webhook-receive and may be a pure L0 receiver.
 func (v *Validator) validateTOPO05() []ValidationResult {
-	var results []ValidationResult
+	l0Cells := v.buildL0CellSet()
+	if len(l0Cells) == 0 {
+		return nil
+	}
 
-	// Build set of L0 cells.
+	var results []ValidationResult
+	for _, ct := range v.project.Contracts {
+		results = append(results, v.validateTOPO05Contract(ct, l0Cells)...)
+	}
+	return results
+}
+
+func (v *Validator) buildL0CellSet() map[string]bool {
 	l0Cells := make(map[string]bool)
 	for _, c := range v.project.Cells {
 		level, err := cellvocab.ParseLevel(c.ConsistencyLevel)
@@ -215,34 +225,50 @@ func (v *Validator) validateTOPO05() []ValidationResult {
 			l0Cells[c.ID] = true
 		}
 	}
-	if len(l0Cells) == 0 {
-		return nil
-	}
+	return l0Cells
+}
 
-	for _, ct := range v.project.Contracts {
-		provider := contractProvider(ct)
-		if l0Cells[provider] && !v.inboundWebhookL0Receiver(ct, provider) {
-			results = append(results, v.newError(
-				codeTOPO05, IssueForbidden,
-				contractFile(ct),
-				"endpoints",
-				fmt.Sprintf("L0 cell %q must not appear as provider in contract %q", provider, ct.ID),
-				"remove this cell from the contract endpoints or change the contract kind",
-			))
-		}
-		for _, consumer := range contractConsumers(ct) {
-			if l0Cells[consumer] && !v.inboundWebhookL0Receiver(ct, consumer) {
-				results = append(results, v.newError(
-					codeTOPO05, IssueForbidden,
-					contractFile(ct),
-					"endpoints",
-					fmt.Sprintf("L0 cell %q must not appear as consumer in contract %q", consumer, ct.ID),
-					"remove this cell from the contract endpoints",
-				))
-			}
+func (v *Validator) validateTOPO05Contract(ct *metadata.ContractMeta, l0Cells map[string]bool) []ValidationResult {
+	var results []ValidationResult
+
+	provider := contractProvider(ct)
+	if v.isForbiddenL0Endpoint(ct, provider, l0Cells) {
+		results = append(results, v.newTOPO05ProviderError(ct, provider))
+	}
+	for _, consumer := range contractConsumers(ct) {
+		if v.isForbiddenL0Endpoint(ct, consumer, l0Cells) {
+			results = append(results, v.newTOPO05ConsumerError(ct, consumer))
 		}
 	}
 	return results
+}
+
+func (v *Validator) isForbiddenL0Endpoint(
+	ct *metadata.ContractMeta,
+	cellID string,
+	l0Cells map[string]bool,
+) bool {
+	return l0Cells[cellID] && !v.inboundWebhookL0Receiver(ct, cellID)
+}
+
+func (v *Validator) newTOPO05ProviderError(ct *metadata.ContractMeta, provider string) ValidationResult {
+	return v.newError(
+		codeTOPO05, IssueForbidden,
+		contractFile(ct),
+		"endpoints",
+		fmt.Sprintf("L0 cell %q must not appear as provider in contract %q", provider, ct.ID),
+		"remove this cell from the contract endpoints or change the contract kind",
+	)
+}
+
+func (v *Validator) newTOPO05ConsumerError(ct *metadata.ContractMeta, consumer string) ValidationResult {
+	return v.newError(
+		codeTOPO05, IssueForbidden,
+		contractFile(ct),
+		"endpoints",
+		fmt.Sprintf("L0 cell %q must not appear as consumer in contract %q", consumer, ct.ID),
+		"remove this cell from the contract endpoints",
+	)
 }
 
 // inboundWebhookL0Receiver reports whether an L0 owner cell is the legitimate

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -982,6 +982,23 @@ func TestTOPO05(t *testing.T) {
 			},
 			wantCount: 1,
 		},
+		{
+			name: "same L0 cell as provider and consumer reports both endpoints",
+			setup: func(pm *metadata.ProjectMeta) {
+				pm.Contracts["http.crypto.loop.v1"] = &metadata.ContractMeta{
+					ID:               "http.crypto.loop.v1",
+					Kind:             "http",
+					OwnerCell:        metadatatest.CellIDAccessCore,
+					ConsistencyLevel: "L0",
+					Lifecycle:        "active",
+					Endpoints: metadata.EndpointsMeta{
+						Server:  metadatatest.CellIDSharedCrypto,
+						Clients: []string{metadatatest.CellIDSharedCrypto},
+					},
+				}
+			},
+			wantCount: 2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Refactor TOPO-05 governance validation so the push CI `golangci-lint` gocognit gate passes.

## Why / 背景

Latest `develop` push CI failed on run https://github.com/ghbvf/gocell/actions/runs/27127584460/job/80060063239:

`kernel/governance/rules_topo.go:204:1: cognitive complexity 16 of func (*Validator).validateTOPO05 is high (> 15) (gocognit)`

The rule behavior is unchanged: L0 cells are still forbidden in provider/consumer endpoints, and inbound webhook receive remains the exception.

## Refs

CI: https://github.com/ghbvf/gocell/actions/runs/27127584460/job/80060063239

ref: none, small internal refactor of existing governance rule.

## Risk / 兼容性

无 wire/API/migration impact. The change only splits existing TOPO-05 logic into smaller helpers and adds a regression test for reporting both provider and consumer endpoint violations on one contract.

During triage, the latest scheduled `archtest-nightly` run on `develop` was also inspected: https://github.com/ghbvf/gocell/actions/runs/27163966887. That was separate from the linked push CI job. This PR's `make verify` check passed on GitHub.

## Test plan

- [x] `go test ./kernel/governance -run TestTOPO05 -count=1`
- [x] `golangci-lint run ./kernel/...`
- [x] `go build ./...`
- [x] `go test ./kernel/...`
- [x] `golangci-lint run ./...`
- [ ] `go test ./...` full local run: fails in `tools/archtest` when running the complete archtest package directly, including missing `contractRootBases` entries for `examples/demo/contracts` and `examples/webhookdemo/contracts`; PR `make verify` passed on GitHub.
