### PR TITLE
refactor(sonar): resolve code smells

### DIFF
--- a/adapters/grpc/server_integration_test.go
+++ b/adapters/grpc/server_integration_test.go
@@ -720,70 +720,80 @@ func streamerServiceDesc(started chan<- struct{}) grpc.ServiceDesc {
 			{
 				StreamName:    "ServerStream",
 				ServerStreams: true,
-				Handler: func(_ any, ss grpc.ServerStream) error {
-					if err := ss.RecvMsg(healthReq()); err != nil {
-						return err
-					}
-					for i := 0; i < 3; i++ {
-						if err := ss.Context().Err(); err != nil {
-							return err
-						}
-						if err := ss.SendMsg(healthResp()); err != nil {
-							return err
-						}
-					}
-					return nil
-				},
+				Handler:       serverStreamHandler,
 			},
 			{
 				StreamName:    "ClientStream",
 				ClientStreams: true,
-				Handler: func(_ any, ss grpc.ServerStream) error {
-					for {
-						if err := ss.RecvMsg(healthReq()); err != nil {
-							if errors.Is(err, io.EOF) {
-								break
-							}
-							return err
-						}
-					}
-					return ss.SendMsg(healthResp())
-				},
+				Handler:       clientStreamHandler,
 			},
 			{
 				StreamName:    "Bidi",
 				ServerStreams: true,
 				ClientStreams: true,
-				Handler: func(_ any, ss grpc.ServerStream) error {
-					for {
-						if err := ss.RecvMsg(healthReq()); err != nil {
-							if errors.Is(err, io.EOF) {
-								return nil
-							}
-							return err
-						}
-						if err := ss.SendMsg(healthResp()); err != nil {
-							return err
-						}
-					}
-				},
+				Handler:       bidiStreamHandler,
 			},
 			{
 				StreamName:    "BlockStream",
 				ServerStreams: true,
-				Handler: func(_ any, ss grpc.ServerStream) error {
-					if err := ss.RecvMsg(healthReq()); err != nil {
-						return err
-					}
-					if err := ss.SendMsg(healthResp()); err != nil {
-						return err
-					}
-					close(started)
-					<-ss.Context().Done() // block until the drain cancels the stream ctx
-					return ss.Context().Err()
-				},
+				Handler:       blockingStreamHandler(started),
 			},
 		},
+	}
+}
+
+func serverStreamHandler(_ any, ss grpc.ServerStream) error {
+	if err := ss.RecvMsg(healthReq()); err != nil {
+		return err
+	}
+	for i := 0; i < 3; i++ {
+		if err := ss.Context().Err(); err != nil {
+			return err
+		}
+		if err := ss.SendMsg(healthResp()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func clientStreamHandler(_ any, ss grpc.ServerStream) error {
+	for {
+		if err := ss.RecvMsg(healthReq()); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+	}
+	return ss.SendMsg(healthResp())
+}
+
+func bidiStreamHandler(_ any, ss grpc.ServerStream) error {
+	for {
+		if err := ss.RecvMsg(healthReq()); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		if err := ss.SendMsg(healthResp()); err != nil {
+			return err
+		}
+	}
+}
+
+func blockingStreamHandler(started chan<- struct{}) grpc.StreamHandler {
+	return func(_ any, ss grpc.ServerStream) error {
+		if err := ss.RecvMsg(healthReq()); err != nil {
+			return err
+		}
+		if err := ss.SendMsg(healthResp()); err != nil {
+			return err
+		}
+		close(started)
+		<-ss.Context().Done() // block until the drain cancels the stream ctx
+		return ss.Context().Err()
 	}
 }
 

--- a/adapters/postgres/migrations/044_outbox_entries_principal.sql
+++ b/adapters/postgres/migrations/044_outbox_entries_principal.sql
@@ -3,8 +3,12 @@
 --
 -- Runbook (DESTRUCTIVE FORWARD — operator steps required before `goose up`):
 --   1. Stop all producer traffic, then drain the relay. The drain is complete
---      when there are ZERO undelivered rows according to a direct status count
---      over outbox_entries (all rows whose status is not published).
+--      when this direct status count returns ZERO undelivered rows:
+--
+--          SELECT count(*) AS undelivered
+--          FROM outbox_entries
+--          WHERE status <> 'published';
+--
 --      Do NOT use CountPending / outbox_pending_depth as the drain signal: that
 --      query counts only status='pending' rows whose backoff has elapsed
 --      (next_retry_at <= now()), so it EXCLUDES rows still in retry backoff and

--- a/adapters/postgres/migrations/044_outbox_entries_principal.sql
+++ b/adapters/postgres/migrations/044_outbox_entries_principal.sql
@@ -3,8 +3,8 @@
 --
 -- Runbook (DESTRUCTIVE FORWARD — operator steps required before `goose up`):
 --   1. Stop all producer traffic, then drain the relay. The drain is complete
---      when there are ZERO undelivered rows:
---          SELECT count(*) FROM outbox_entries WHERE status <> 'published';   -- must be 0
+--      when there are ZERO undelivered rows according to a direct status count
+--      over outbox_entries (all rows whose status is not published).
 --      Do NOT use CountPending / outbox_pending_depth as the drain signal: that
 --      query counts only status='pending' rows whose backoff has elapsed
 --      (next_retry_at <= now()), so it EXCLUDES rows still in retry backoff and

--- a/adapters/postgres/migrations/053_accesscore_tenant_rls_force.sql
+++ b/adapters/postgres/migrations/053_accesscore_tenant_rls_force.sql
@@ -28,7 +28,7 @@
 --   USING / WITH CHECK (tenant_id = NULLIF(current_setting('app.tenant_id', true), ''))
 --   current_setting(..., true) = missing_ok → NULL when the GUC was never set
 --   (probes / migrations / any path that did not run SET LOCAL); NULLIF(...,'')
---   maps the empty-string GUC to NULL; tenant_id = NULL is never true → 0 rows
+--   maps the empty-string GUC to NULL; equality against that NULL is never true → 0 rows
 --   visible AND 0 rows insertable (fail-closed). The tenant_id columns are TEXT
 --   (migration 050) and the GUC value is a Validate()-canonical lowercase UUID
 --   string, so TEXT=TEXT compare is exact and index-friendly (idx_users_tenant_id_id

--- a/adapters/postgres/migrator.go
+++ b/adapters/postgres/migrator.go
@@ -128,7 +128,9 @@ func AllowForwardRebuild(migrationNumber int64, reason string) (ForwardRebuildPe
 	return forwardRebuildPermit{migrationNumber: migrationNumber, reason: reason}, nil
 }
 
-func (forwardRebuildPermit) forwardRebuildPermit() {}
+func (forwardRebuildPermit) forwardRebuildPermit() {
+	// Marker method only: the unexported method seals ForwardRebuildPermit.
+}
 
 // MigrationNumber returns the migration version this permit authorizes.
 func (p forwardRebuildPermit) MigrationNumber() int64 { return p.migrationNumber }

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ghbvf/gocell/pkg/migration"
 )
 
+const gotWantQuotedFmt = "got %q want %q"
+
 // Tables owned by the adapters/postgres migration set (in migration order).
 // Append here when a new table is introduced by a migration file so that
 // schema_guard documentation stays in sync with the embedded SQL.
@@ -1028,7 +1030,7 @@ func checkRLSPolicyShape(r expectedRLS, policies []rlsPolicyRow) error {
 	if p.name != r.Policy {
 		return errcode.New(errcode.KindInternal, ErrAdapterPGSchemaShape,
 			"schema_guard: row-security policy has unexpected name",
-			rlsPolicyShapeDetails(r, fmt.Sprintf("got %q want %q", p.name, r.Policy))...)
+			rlsPolicyShapeDetails(r, fmt.Sprintf(gotWantQuotedFmt, p.name, r.Policy))...)
 	}
 	if !strings.EqualFold(p.permissive, "PERMISSIVE") {
 		return errcode.New(errcode.KindInternal, ErrAdapterPGSchemaShape,
@@ -1221,7 +1223,7 @@ func verifyColumns(ctx context.Context, pool *Pool) error {
 					errcode.PublicString("table", ec.Table),
 					errcode.PublicString("column", ec.Column),
 				),
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("got %q want %q", gotType, ec.Type))),
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(gotWantQuotedFmt, gotType, ec.Type))),
 			)
 		}
 		if gotNotNull != ec.NotNull {
@@ -1286,7 +1288,7 @@ func verifyDefaults(ctx context.Context, pool *Pool) error {
 					errcode.PublicString("table", ed.Table),
 					errcode.PublicString("column", ed.Column),
 				),
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("got %q want %q", gotDefault, ed.Default))),
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(gotWantQuotedFmt, gotDefault, ed.Default))),
 			)
 		}
 	}

--- a/adapters/redis/session_cache_store.go
+++ b/adapters/redis/session_cache_store.go
@@ -171,10 +171,21 @@ type cacheMetricsRecorder interface {
 // recorder) must still function — these no-ops carry that decision.
 type nopCacheMetrics struct{}
 
-func (nopCacheMetrics) RecordHit(context.Context)            {}
-func (nopCacheMetrics) RecordMiss(context.Context)           {}
-func (nopCacheMetrics) RecordError(context.Context)          {}
-func (nopCacheMetrics) RecordRevokeDelError(context.Context) {}
+func (nopCacheMetrics) RecordHit(context.Context) {
+	// Metrics are optional; nil collectors intentionally record nothing.
+}
+
+func (nopCacheMetrics) RecordMiss(context.Context) {
+	// Metrics are optional; nil collectors intentionally record nothing.
+}
+
+func (nopCacheMetrics) RecordError(context.Context) {
+	// Metrics are optional; nil collectors intentionally record nothing.
+}
+
+func (nopCacheMetrics) RecordRevokeDelError(context.Context) {
+	// Metrics are optional; nil collectors intentionally record nothing.
+}
 
 // sessionCacheKey is the per-id key prefix written under the Cache's
 // KeyNamespace. Final Redis key = "<namespace>:session:<sessionID>".

--- a/cells/accesscore/internal/adapters/postgres/role_repo.go
+++ b/cells/accesscore/internal/adapters/postgres/role_repo.go
@@ -27,6 +27,8 @@ import (
 // Compile-time assertion: PGRoleRepo implements ports.RoleRepository.
 var _ ports.RoleRepository = (*PGRoleRepo)(nil)
 
+const msgRoleInvalidTenant = "role_repo: invalid tenant"
+
 // PGRoleRepo is the cell-private PostgreSQL implementation of ports.RoleRepository.
 // It reads/writes the `roles` and `role_assignments` tables (migration 019).
 type PGRoleRepo struct {
@@ -172,7 +174,7 @@ WHERE ra.tenant_id = $1 AND ra.role_id = 'admin' AND u.status = 'active'`
 // here; any error is a genuine infra failure, classified as ErrInternal.
 func (r *PGRoleRepo) Create(ctx context.Context, t tenant.TenantID, role *domain.Role) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	permJSON, err := json.Marshal(role.Permissions)
 	if err != nil {
@@ -195,7 +197,7 @@ func (r *PGRoleRepo) Create(ctx context.Context, t tenant.TenantID, role *domain
 // GetByID fetches a role by composite (tenant_id, id) key. Returns ErrAuthRoleNotFound when absent.
 func (r *PGRoleRepo) GetByID(ctx context.Context, t tenant.TenantID, id string) (*domain.Role, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	row := r.db.QueryRow(ctx, selectRoleByIDSQL, string(t), id)
 	role, err := scanRole(row)
@@ -214,7 +216,7 @@ func (r *PGRoleRepo) GetByID(ctx context.Context, t tenant.TenantID, id string) 
 // Returns an empty slice when the user has no roles (mirrors mem behavior).
 func (r *PGRoleRepo) GetByUserID(ctx context.Context, t tenant.TenantID, userID string) ([]*domain.Role, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	rows, err := r.db.Query(ctx, selectRolesByUserIDSQL, string(t), userID)
 	if err != nil {
@@ -251,7 +253,7 @@ func fkConstraintName(err error) string {
 // exist (FK on user_id). Fallback for unknown FK violations returns ErrAuthRoleNotFound.
 func (r *PGRoleRepo) AssignToUser(ctx context.Context, t tenant.TenantID, userID, roleID string) (bool, error) {
 	if err := t.Validate(); err != nil {
-		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	tag, err := r.db.Exec(
 		ctx, insertAssignmentSQL,
@@ -300,7 +302,7 @@ func (r *PGRoleRepo) AssignToUser(ctx context.Context, t tenant.TenantID, userID
 // the operator with a usable account rather than an unusable system.
 func (r *PGRoleRepo) RemoveFromUser(ctx context.Context, t tenant.TenantID, userID, roleID string) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	_, err := r.db.Exec(ctx, deleteAssignmentSQL, string(t), userID, roleID)
 	if err != nil {
@@ -340,7 +342,7 @@ func (r *PGRoleRepo) RemoveFromUser(ctx context.Context, t tenant.TenantID, user
 //     handlers match a single business invariant.
 func (r *PGRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, t tenant.TenantID, userID, roleID string) (bool, error) {
 	if err := t.Validate(); err != nil {
-		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if roleID != auth.RoleAdmin {
 		// Non-admin role: plain DELETE, no last-holder check. Trigger
@@ -396,7 +398,7 @@ func (r *PGRoleRepo) RemoveFromUserIfNotLast(ctx context.Context, t tenant.Tenan
 // see CountEffectiveAdmins.
 func (r *PGRoleRepo) CountByRole(ctx context.Context, t tenant.TenantID, roleID string) (int, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	var count int
 	row := r.db.QueryRow(ctx, countByRoleSQL, string(t), roleID)
@@ -425,7 +427,7 @@ func (r *PGRoleRepo) CountByRole(ctx context.Context, t tenant.TenantID, roleID 
 // the advisory-lock CTE rather than relaxing this contract.
 func (r *PGRoleRepo) CountEffectiveAdmins(ctx context.Context, t tenant.TenantID) (int, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	tx, ok := ctx.Value(persistence.TxCtxKey).(pgx.Tx)
 	if !ok || tx == nil {
@@ -458,7 +460,7 @@ SELECT EXISTS (
 // for fast-path semantics. Pool-driven (no tx required, no advisory lock).
 func (r *PGRoleRepo) EffectiveAdminExists(ctx context.Context, t tenant.TenantID) (bool, error) {
 	if err := t.Validate(); err != nil {
-		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	var exists bool
 	row := r.db.QueryRow(ctx, effectiveAdminExistsSQL, string(t))

--- a/cells/accesscore/internal/adapters/postgres/user_repo.go
+++ b/cells/accesscore/internal/adapters/postgres/user_repo.go
@@ -26,6 +26,8 @@ import (
 // Compile-time assertion: PGUserRepo implements ports.UserRepository.
 var _ ports.UserRepository = (*PGUserRepo)(nil)
 
+const msgUserInvalidTenant = "user_repo: invalid tenant"
+
 // PGUserRepo is the cell-private PostgreSQL implementation of ports.UserRepository.
 // It reads/writes the `users` table (migration 017).
 //
@@ -233,7 +235,7 @@ func validateFailedLoginCount(userID string, count int) (int32, error) {
 // constraint violation (username or email already taken within the tenant).
 func (r *PGUserRepo) Create(ctx context.Context, t tenant.TenantID, user *domain.User) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	_, err := r.db.Exec(
 		ctx, insertUserSQL,
@@ -265,7 +267,7 @@ func (r *PGUserRepo) Create(ctx context.Context, t tenant.TenantID, user *domain
 // both cases produce pgx.ErrNoRows from `WHERE id=$1 AND tenant_id=$2`.
 func (r *PGUserRepo) GetByIDInTenant(ctx context.Context, t tenant.TenantID, id string) (*domain.User, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	row := r.db.QueryRow(ctx, selectUserByIDInTenantSQL, id, string(t))
 	u, err := scanUser(row)
@@ -287,7 +289,7 @@ func (r *PGUserRepo) GetByIDInTenant(ctx context.Context, t tenant.TenantID, id 
 // GetByUsername fetches a user by (tenant_id, username). Returns ErrAuthUserNotFound when absent.
 func (r *PGUserRepo) GetByUsername(ctx context.Context, t tenant.TenantID, username string) (*domain.User, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	row := r.db.QueryRow(ctx, selectUserByUsernameSQL, string(t), username)
 	u, err := scanUser(row)
@@ -333,7 +335,7 @@ func (r *PGUserRepo) getForUpdateBy(
 		return nil, err
 	}
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	var (
 		sqlStr   string
@@ -415,7 +417,7 @@ func (r *PGUserRepo) UpdateProfile(
 	now time.Time,
 ) (*domain.User, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	// pgx binds *string (PG TEXT) directly; *domain.NonEmpty is type-renamed
 	// string but pgx's reflect path treats it as plain text. We convert to
@@ -463,7 +465,7 @@ func (r *PGUserRepo) UpdateLockState(
 	now time.Time,
 ) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	// updateLockStateSQL: $1=id, $2=status, $3=now, $4=tenant_id
 	tag, err := r.db.Exec(ctx, updateLockStateSQL, userID, string(status), now, string(t))
@@ -493,7 +495,7 @@ func (r *PGUserRepo) UpdatePasswordResetFlag(
 	now time.Time,
 ) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	// updatePasswordResetFlagSQL: $1=id, $2=required, $3=now, $4=tenant_id
 	tag, err := r.db.Exec(ctx, updatePasswordResetFlagSQL, userID, required, now, string(t))
@@ -516,7 +518,7 @@ func (r *PGUserRepo) UpdatePasswordResetFlag(
 // layer caught the violation.
 func (r *PGUserRepo) Delete(ctx context.Context, t tenant.TenantID, id string) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	// deleteUserSQL: $1=tenant_id, $2=id
 	tag, err := r.db.Exec(ctx, deleteUserSQL, string(t), id)
@@ -547,7 +549,7 @@ func (r *PGUserRepo) Delete(ctx context.Context, t tenant.TenantID, id string) e
 // before the caller's surrounding atomic sequence completes.
 func (r *PGUserRepo) BumpAuthzEpoch(ctx context.Context, t tenant.TenantID, userID string, tok credentialfence.FenceToken) (int64, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	credentialfence.MustHave(tok, "ports.UserRepository.BumpAuthzEpoch")
 	if err := assertAmbientTx(ctx); err != nil {
@@ -659,7 +661,7 @@ func scanUser(row pgx.Row) (*domain.User, error) {
 // the password-change path (UpdatePassword); they are NOT mutated here.
 func (r *PGUserRepo) UpdateLockoutFields(ctx context.Context, t tenant.TenantID, user *domain.User) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	count32, err := validateFailedLoginCount(user.ID, user.FailedLoginCount())
 	if err != nil {
@@ -702,7 +704,7 @@ func (r *PGUserRepo) UpdatePassword(
 	expectedPV int64,
 ) (int64, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	now := r.clock.Now()
 	var newPV int64

--- a/cells/accesscore/internal/mem/policy_repo.go
+++ b/cells/accesscore/internal/mem/policy_repo.go
@@ -12,6 +12,8 @@ import (
 
 var _ ports.PolicyRepository = (*PolicyRepository)(nil)
 
+const msgPolicyInvalidTenant = "policy_repo: invalid tenant"
+
 // PolicyRepository is the in-memory implementation of ports.PolicyRepository.
 //
 // Unlike RoleRepository, PolicyRepository owns its own mutex and its own
@@ -46,7 +48,7 @@ func NewPolicyRepository() *PolicyRepository {
 // violation.
 func (r *PolicyRepository) Save(ctx context.Context, t tenant.TenantID, p *abac.Policy) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "policy_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgPolicyInvalidTenant, err)
 	}
 	if p == nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "policy_repo: policy must not be nil")
@@ -74,7 +76,7 @@ func (r *PolicyRepository) Save(ctx context.Context, t tenant.TenantID, p *abac.
 // when the policy does not exist.
 func (r *PolicyRepository) GetByID(ctx context.Context, t tenant.TenantID, id string) (*abac.Policy, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "policy_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgPolicyInvalidTenant, err)
 	}
 
 	r.mu.RLock()
@@ -95,7 +97,7 @@ func (r *PolicyRepository) GetByID(ctx context.Context, t tenant.TenantID, id st
 // defensive clone.
 func (r *PolicyRepository) ListByTenant(ctx context.Context, t tenant.TenantID) ([]*abac.Policy, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "policy_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgPolicyInvalidTenant, err)
 	}
 
 	r.mu.RLock()
@@ -115,7 +117,7 @@ func (r *PolicyRepository) ListByTenant(ctx context.Context, t tenant.TenantID) 
 // KindNotFound when the policy does not exist in t.
 func (r *PolicyRepository) Delete(ctx context.Context, t tenant.TenantID, id string) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "policy_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgPolicyInvalidTenant, err)
 	}
 
 	r.mu.Lock()

--- a/cells/accesscore/internal/mem/policy_repo_test.go
+++ b/cells/accesscore/internal/mem/policy_repo_test.go
@@ -327,69 +327,81 @@ func TestPolicyRepository_ConcurrentSaveGet(t *testing.T) {
 	repo := mem.NewPolicyRepository()
 	ctx := context.Background()
 
-	var (
-		wg         sync.WaitGroup
-		mu         sync.Mutex
-		saveErrs   []error
-		getErrs    []error
-		listErrs   []error
-		deleteErrs []error
-	)
+	var wg sync.WaitGroup
+	errs := &concurrentPolicyErrors{}
 	const goroutines = 20
 
 	for i := range goroutines {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			policyID := "policy-concurrent"
-			p := makeTestPolicy(policyID, testTenant1)
-
-			if err := repo.Save(ctx, testTenant1, p); err != nil {
-				mu.Lock()
-				saveErrs = append(saveErrs, err)
-				mu.Unlock()
-			}
-			if _, err := repo.GetByID(ctx, testTenant1, policyID); err != nil {
-				// Not-found is acceptable when a concurrent Delete races ahead
-				var ec *errcode.Error
-				if !errors.As(err, &ec) || ec.Kind != errcode.KindNotFound {
-					mu.Lock()
-					getErrs = append(getErrs, err)
-					mu.Unlock()
-				}
-			}
-			if _, err := repo.ListByTenant(ctx, testTenant1); err != nil {
-				mu.Lock()
-				listErrs = append(listErrs, err)
-				mu.Unlock()
-			}
-			// Interleave Delete on even goroutines to exercise concurrent write paths
-			if idx%2 == 0 {
-				if err := repo.Delete(ctx, testTenant1, policyID); err != nil {
-					// Not-found is acceptable when another goroutine already deleted it
-					var ec *errcode.Error
-					if !errors.As(err, &ec) || ec.Kind != errcode.KindNotFound {
-						mu.Lock()
-						deleteErrs = append(deleteErrs, err)
-						mu.Unlock()
-					}
-				}
-			}
+			runConcurrentPolicyOperation(ctx, repo, idx, errs)
 		}(i)
 	}
 	wg.Wait()
 
 	// No unexpected infrastructure errors from any operation
-	if len(saveErrs) > 0 {
-		t.Errorf("concurrent Save() produced %d unexpected error(s): first=%v", len(saveErrs), saveErrs[0])
+	errs.assertEmpty(t)
+}
+
+type concurrentPolicyErrors struct {
+	mu         sync.Mutex
+	saveErrs   []error
+	getErrs    []error
+	listErrs   []error
+	deleteErrs []error
+}
+
+func (e *concurrentPolicyErrors) addSave(err error)   { e.add(&e.saveErrs, err) }
+func (e *concurrentPolicyErrors) addGet(err error)    { e.add(&e.getErrs, err) }
+func (e *concurrentPolicyErrors) addList(err error)   { e.add(&e.listErrs, err) }
+func (e *concurrentPolicyErrors) addDelete(err error) { e.add(&e.deleteErrs, err) }
+
+func (e *concurrentPolicyErrors) add(dst *[]error, err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	*dst = append(*dst, err)
+}
+
+func (e *concurrentPolicyErrors) assertEmpty(t *testing.T) {
+	t.Helper()
+
+	if len(e.saveErrs) > 0 {
+		t.Errorf("concurrent Save() produced %d unexpected error(s): first=%v", len(e.saveErrs), e.saveErrs[0])
 	}
-	if len(getErrs) > 0 {
-		t.Errorf("concurrent GetByID() produced %d unexpected error(s): first=%v", len(getErrs), getErrs[0])
+	if len(e.getErrs) > 0 {
+		t.Errorf("concurrent GetByID() produced %d unexpected error(s): first=%v", len(e.getErrs), e.getErrs[0])
 	}
-	if len(listErrs) > 0 {
-		t.Errorf("concurrent ListByTenant() produced %d unexpected error(s): first=%v", len(listErrs), listErrs[0])
+	if len(e.listErrs) > 0 {
+		t.Errorf("concurrent ListByTenant() produced %d unexpected error(s): first=%v", len(e.listErrs), e.listErrs[0])
 	}
-	if len(deleteErrs) > 0 {
-		t.Errorf("concurrent Delete() produced %d unexpected error(s): first=%v", len(deleteErrs), deleteErrs[0])
+	if len(e.deleteErrs) > 0 {
+		t.Errorf("concurrent Delete() produced %d unexpected error(s): first=%v", len(e.deleteErrs), e.deleteErrs[0])
 	}
+}
+
+func runConcurrentPolicyOperation(ctx context.Context, repo *mem.PolicyRepository, idx int, errs *concurrentPolicyErrors) {
+	policyID := "policy-concurrent"
+	p := makeTestPolicy(policyID, testTenant1)
+
+	if err := repo.Save(ctx, testTenant1, p); err != nil {
+		errs.addSave(err)
+	}
+	if _, err := repo.GetByID(ctx, testTenant1, policyID); err != nil && !isNotFoundError(err) {
+		errs.addGet(err)
+	}
+	if _, err := repo.ListByTenant(ctx, testTenant1); err != nil {
+		errs.addList(err)
+	}
+	// Interleave Delete on even goroutines to exercise concurrent write paths.
+	if idx%2 == 0 {
+		if err := repo.Delete(ctx, testTenant1, policyID); err != nil && !isNotFoundError(err) {
+			errs.addDelete(err)
+		}
+	}
+}
+
+func isNotFoundError(err error) bool {
+	var ec *errcode.Error
+	return errors.As(err, &ec) && ec.Kind == errcode.KindNotFound
 }

--- a/cells/accesscore/internal/mem/role_repo.go
+++ b/cells/accesscore/internal/mem/role_repo.go
@@ -15,6 +15,8 @@ import (
 
 var _ ports.RoleRepository = (*RoleRepository)(nil)
 
+const msgRoleInvalidTenant = "role_repo: invalid tenant"
+
 // RoleRepository is the in-memory implementation of ports.RoleRepository.
 // It is always vended by Store.RoleRepository() so the shared mutex covers
 // any cross-repo invariant — most importantly, CountEffectiveAdmins and the
@@ -60,7 +62,7 @@ func (r *RoleRepository) SeedUserRoleAssignment(t tenant.TenantID, userID, roleI
 // a RunInTx closure; see the lock contract on UserRepository.
 func (r *RoleRepository) Create(ctx context.Context, t tenant.TenantID, role *domain.Role) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -79,7 +81,7 @@ func (r *RoleRepository) Create(ctx context.Context, t tenant.TenantID, role *do
 // UserRepository.
 func (r *RoleRepository) GetByID(ctx context.Context, t tenant.TenantID, id string) (*domain.Role, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -102,7 +104,7 @@ func (r *RoleRepository) GetByID(ctx context.Context, t tenant.TenantID, id stri
 // UserRepository.
 func (r *RoleRepository) GetByUserID(ctx context.Context, t tenant.TenantID, userID string) ([]*domain.Role, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -135,7 +137,7 @@ func (r *RoleRepository) GetByUserID(ctx context.Context, t tenant.TenantID, use
 // Agent A. Returns ErrAuthUserNotFound when the user does not exist in t.
 func (r *RoleRepository) AssignToUser(ctx context.Context, t tenant.TenantID, userID, roleID string) (bool, error) {
 	if err := t.Validate(); err != nil {
-		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -173,7 +175,7 @@ func (r *RoleRepository) AssignToUser(ctx context.Context, t tenant.TenantID, us
 // Safe to call both inside and outside a RunInTx closure.
 func (r *RoleRepository) RemoveFromUser(ctx context.Context, t tenant.TenantID, userID, roleID string) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -192,7 +194,7 @@ func (r *RoleRepository) RemoveFromUser(ctx context.Context, t tenant.TenantID, 
 // admins. Mirrors the PG removeIfNotLastSQL per-tenant CTE semantics (#1337 PR-2).
 func (r *RoleRepository) RemoveFromUserIfNotLast(ctx context.Context, t tenant.TenantID, userID, roleID string) (bool, error) {
 	if err := t.Validate(); err != nil {
-		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -258,7 +260,7 @@ func (r *RoleRepository) rolesByUserSnapshot(ctx context.Context, t tenant.Tenan
 	// map with a bad key. Closes the mem/PG drift the PG path already guards via
 	// its GetByUserID delegation (review F4).
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -311,7 +313,7 @@ func roleFieldValue(r *domain.Role, field string) any {
 // see CountEffectiveAdmins.
 func (r *RoleRepository) CountByRole(ctx context.Context, t tenant.TenantID, roleID string) (int, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -332,7 +334,7 @@ func (r *RoleRepository) CountByRole(ctx context.Context, t tenant.TenantID, rol
 // domain.EffectiveAdminCounter sealed interface (S4.0 invariant counter).
 func (r *RoleRepository) CountEffectiveAdmins(ctx context.Context, t tenant.TenantID) (int, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -359,7 +361,7 @@ func (r *RoleRepository) CountEffectiveAdmins(ctx context.Context, t tenant.Tena
 // for fast-path semantics. Returns true on the first match within the tenant.
 func (r *RoleRepository) EffectiveAdminExists(ctx context.Context, t tenant.TenantID) (bool, error) {
 	if err := t.Validate(); err != nil {
-		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "role_repo: invalid tenant", err)
+		return false, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgRoleInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()

--- a/cells/accesscore/internal/mem/user_repo.go
+++ b/cells/accesscore/internal/mem/user_repo.go
@@ -18,9 +18,10 @@ import (
 var _ ports.UserRepository = (*UserRepository)(nil)
 
 const (
-	msgUserNotFound   = "user not found"
-	errMsgUsernameFmt = "username=%q"
-	errMsgIDFmt       = "id=%q"
+	msgUserNotFound      = "user not found"
+	msgUserInvalidTenant = "user_repo: invalid tenant"
+	errMsgUsernameFmt    = "username=%q"
+	errMsgIDFmt          = "id=%q"
 )
 
 // UserRepository is the in-memory implementation of ports.UserRepository.
@@ -51,7 +52,7 @@ type UserRepository struct {
 // outside a RunInTx closure; see UserRepository lock contract.
 func (r *UserRepository) Create(ctx context.Context, t tenant.TenantID, user *domain.User) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -106,7 +107,7 @@ func checkProfileUniqueLocked(tByName, tByEmail map[string]*domain.User, userID,
 // collapsing both cases to prevent cross-tenant existence enumeration.
 func (r *UserRepository) GetByIDInTenant(ctx context.Context, t tenant.TenantID, id string) (*domain.User, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -126,7 +127,7 @@ func (r *UserRepository) GetByIDInTenant(ctx context.Context, t tenant.TenantID,
 // Safe to call both inside and outside a RunInTx closure.
 func (r *UserRepository) GetByUsername(ctx context.Context, t tenant.TenantID, username string) (*domain.User, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -170,7 +171,7 @@ func (r *UserRepository) UpdateProfile(
 	now time.Time,
 ) (*domain.User, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -245,7 +246,7 @@ func (r *UserRepository) UpdateLockState(
 	now time.Time,
 ) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -318,7 +319,7 @@ func (r *UserRepository) UpdatePasswordResetFlag(
 	now time.Time,
 ) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -450,7 +451,7 @@ func (r *UserRepository) UpdatePassword(
 	expectedPV int64,
 ) (int64, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -510,7 +511,7 @@ func (r *UserRepository) BumpAuthzEpoch(
 	ctx context.Context, t tenant.TenantID, userID string, tok credentialfence.FenceToken,
 ) (int64, error) {
 	if err := t.Validate(); err != nil {
-		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return 0, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	credentialfence.MustHave(tok, "ports.UserRepository.BumpAuthzEpoch")
 	if !r.store.inLiveTx(ctx) {
@@ -557,7 +558,7 @@ func (r *UserRepository) BumpAuthzEpoch(
 // within the tenant. Safe to call both inside and outside a RunInTx closure.
 func (r *UserRepository) UpdateLockoutFields(ctx context.Context, t tenant.TenantID, user *domain.User) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()
@@ -584,7 +585,7 @@ func (r *UserRepository) UpdateLockoutFields(ctx context.Context, t tenant.Tenan
 // both inside and outside a RunInTx closure.
 func (r *UserRepository) Delete(ctx context.Context, t tenant.TenantID, id string) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "user_repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgUserInvalidTenant, err)
 	}
 	if !r.store.inLiveTx(ctx) {
 		r.store.mu.Lock()

--- a/cells/accesscore/internal/ports/conformance/conformance.go
+++ b/cells/accesscore/internal/ports/conformance/conformance.go
@@ -37,6 +37,10 @@ import (
 // reuse — kept in this file).
 const concurrencyDeadlineBudget = 30 * time.Second
 
+// conformanceBcryptFixtureHash is a syntactically valid bcrypt-shaped string
+// used only as a repository conformance placeholder.
+const conformanceBcryptFixtureHash = "$2a$12$conformancefakehash"
+
 // quickGracePeriod is the small wall-time used to differentiate "immediately
 // returned" from "blocked on lock" in conformGetByIDForUpdateLockContention.
 // 50ms is large enough to avoid scheduler-noise false positives on typical CI
@@ -260,11 +264,11 @@ func seedActiveInTenant(
 ) *domain.User {
 	t.Helper()
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	u, err := domain.ReconstituteUser(domain.ReconstituteUserParams{ //nolint:gosec // test helper, not real credentials
+	u, err := domain.ReconstituteUser(domain.ReconstituteUserParams{
 		ID:           id,
 		Username:     username,
 		Email:        username + exampleEmailDomain,
-		PasswordHash: "$2a$12$conformancefakehash",
+		PasswordHash: conformanceBcryptFixtureHash,
 		Status:       domain.StatusActive,
 		Source:       domain.UserSourceIdentity,
 		AuthzEpoch:   1,
@@ -722,11 +726,11 @@ func conformCrossTenantWriteProbes(t *testing.T, repo ports.UserRepository, id, 
 	}
 	// UpdateLockoutFields cross-tenant: build a minimal domain.User with the seeded id.
 	crossTenantUser, reconErr := domain.ReconstituteUser(
-		domain.ReconstituteUserParams{ //nolint:gosec // G101: test constant, not real credentials
+		domain.ReconstituteUserParams{
 			ID:           id,
 			Username:     username,
 			Email:        username + exampleEmailDomain,
-			PasswordHash: "$2a$12$conformancefakehash",
+			PasswordHash: conformanceBcryptFixtureHash,
 			Status:       domain.StatusActive,
 			Source:       domain.UserSourceIdentity,
 			AuthzEpoch:   1,
@@ -908,7 +912,7 @@ func conformUpdateLockoutFieldsNotFound(t *testing.T, factory UserRepoFactory) e
 	now := time.Now().UTC()
 	// fakeHash is a syntactically valid bcrypt string used only as a test
 	// placeholder; it is not a real credential.
-	const fakeHash = "$2a$12$conformancefakehash"
+	fakeHash := conformanceBcryptFixtureHash
 	ghost, err := domain.ReconstituteUser(domain.ReconstituteUserParams{
 		ID:           phantom,
 		Username:     "ghost_" + phantom,
@@ -1494,11 +1498,11 @@ func conformUserInvalidTenantRejected(t *testing.T, factory UserRepoFactory, fea
 	}
 
 	// UpdateLockoutFields cross-tenant: build a minimal domain.User to call it.
-	ghost, err := domain.ReconstituteUser(domain.ReconstituteUserParams{ //nolint:gosec // test helper
+	ghost, err := domain.ReconstituteUser(domain.ReconstituteUserParams{
 		ID:           uuid.NewString(),
 		Username:     "invalid_tenant_ghost",
 		Email:        "invalid_tenant_ghost" + exampleEmailDomain,
-		PasswordHash: "$2a$12$conformancefakehash",
+		PasswordHash: conformanceBcryptFixtureHash,
 		Status:       domain.StatusActive,
 		Source:       domain.UserSourceIdentity,
 		AuthzEpoch:   1,

--- a/cells/accesscore/internal/ports/conformance/policy_conformance.go
+++ b/cells/accesscore/internal/ports/conformance/policy_conformance.go
@@ -14,6 +14,12 @@ import (
 	"github.com/ghbvf/gocell/pkg/tenant"
 )
 
+const (
+	msgPolicySaveUnexpected         = "Save() unexpected error: %v"
+	msgPolicyGetByIDUnexpected      = "GetByID() unexpected error: %v"
+	msgPolicyListByTenantUnexpected = "ListByTenant() unexpected error: %v"
+)
+
 // PolicyRepoFactory constructs a fresh ports.PolicyRepository for use in a
 // single conformance sub-test. The factory must return a zero-state (empty)
 // repository; state accumulated across calls is a test error. No TxRunner is
@@ -123,11 +129,11 @@ func conformPolicySaveAndGetByID(t *testing.T, factory PolicyRepoFactory) {
 	p := conformTestPolicy("pol-1", testTenantID)
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 	got, err := repo.GetByID(ctx, testTenantID, "pol-1")
 	if err != nil {
-		t.Fatalf("GetByID() unexpected error: %v", err)
+		t.Fatalf(msgPolicyGetByIDUnexpected, err)
 	}
 	if got.ID != p.ID {
 		t.Errorf("GetByID().ID = %q, want %q", got.ID, p.ID)
@@ -157,7 +163,7 @@ func conformPolicyListByTenantEmpty(t *testing.T, factory PolicyRepoFactory) {
 
 	list, err := repo.ListByTenant(ctx, testTenantID)
 	if err != nil {
-		t.Fatalf("ListByTenant() unexpected error: %v", err)
+		t.Fatalf(msgPolicyListByTenantUnexpected, err)
 	}
 	if list == nil {
 		t.Error("ListByTenant() returned nil slice, want non-nil empty slice")
@@ -182,7 +188,7 @@ func conformPolicyListByTenant(t *testing.T, factory PolicyRepoFactory) {
 
 	list, err := repo.ListByTenant(ctx, testTenantID)
 	if err != nil {
-		t.Fatalf("ListByTenant() unexpected error: %v", err)
+		t.Fatalf(msgPolicyListByTenantUnexpected, err)
 	}
 	if len(list) != 2 {
 		t.Errorf("ListByTenant() returned %d items, want 2", len(list))
@@ -196,7 +202,7 @@ func conformPolicyDeleteSucceeds(t *testing.T, factory PolicyRepoFactory) {
 	p := conformTestPolicy("pol-1", testTenantID)
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 	if err := repo.Delete(ctx, testTenantID, "pol-1"); err != nil {
 		t.Fatalf("Delete() unexpected error: %v", err)
@@ -228,7 +234,7 @@ func conformPolicyCrossTenantIsolation(t *testing.T, factory PolicyRepoFactory) 
 	p := conformTestPolicy("pol-1", testTenantID)
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 
 	// Other tenant must not see tenant 1's policy.
@@ -262,11 +268,11 @@ func conformPolicyCloneGetByIDIsIndependent(t *testing.T, factory PolicyRepoFact
 	p := conformTestPolicy("pol-1", testTenantID)
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 	got, err := repo.GetByID(ctx, testTenantID, "pol-1")
 	if err != nil {
-		t.Fatalf("GetByID() unexpected error: %v", err)
+		t.Fatalf(msgPolicyGetByIDUnexpected, err)
 	}
 
 	// Mutate the returned clone.
@@ -299,11 +305,11 @@ func conformPolicyCloneListByTenantIsIndependent(t *testing.T, factory PolicyRep
 	p := conformTestPolicy("pol-1", testTenantID)
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 	list, err := repo.ListByTenant(ctx, testTenantID)
 	if err != nil {
-		t.Fatalf("ListByTenant() unexpected error: %v", err)
+		t.Fatalf(msgPolicyListByTenantUnexpected, err)
 	}
 	if len(list) == 0 {
 		t.Fatal("ListByTenant() returned empty list, want 1 item")
@@ -333,11 +339,11 @@ func conformPolicyCloneFieldMaskIsIndependent(t *testing.T, factory PolicyRepoFa
 	p := conformTestPolicyWithFieldMask("pol-1", testTenantID)
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 	got, err := repo.GetByID(ctx, testTenantID, "pol-1")
 	if err != nil {
-		t.Fatalf("GetByID() unexpected error: %v", err)
+		t.Fatalf(msgPolicyGetByIDUnexpected, err)
 	}
 	if len(got.Rules[0].Obligations.FieldMask.Fields) == 0 {
 		t.Fatal("GetByID() returned policy with no FieldMask.Fields; test fixture requires non-empty FieldMask")
@@ -499,7 +505,7 @@ func conformPolicySaveInputCloneIsIndependent(t *testing.T, factory PolicyRepoFa
 	origField := p.Rules[0].Obligations.FieldMask.Fields[0]
 
 	if err := repo.Save(ctx, testTenantID, p); err != nil {
-		t.Fatalf("Save() unexpected error: %v", err)
+		t.Fatalf(msgPolicySaveUnexpected, err)
 	}
 
 	// Mutate the ORIGINAL p after Save.
@@ -510,7 +516,7 @@ func conformPolicySaveInputCloneIsIndependent(t *testing.T, factory PolicyRepoFa
 	// GetByID must reflect the at-Save snapshot, not the mutations.
 	got, err := repo.GetByID(ctx, testTenantID, "pol-clone-input")
 	if err != nil {
-		t.Fatalf("GetByID() unexpected error: %v", err)
+		t.Fatalf(msgPolicyGetByIDUnexpected, err)
 	}
 	if got.Name != origName {
 		t.Errorf("GetByID(): Name = %q, want %q (mutation of original leaked into store)", got.Name, origName)
@@ -529,7 +535,7 @@ func conformPolicySaveInputCloneIsIndependent(t *testing.T, factory PolicyRepoFa
 	// ListByTenant must also reflect the at-Save snapshot.
 	list, err := repo.ListByTenant(ctx, testTenantID)
 	if err != nil {
-		t.Fatalf("ListByTenant() unexpected error: %v", err)
+		t.Fatalf(msgPolicyListByTenantUnexpected, err)
 	}
 	if len(list) == 0 {
 		t.Fatal("ListByTenant() returned empty list, want 1 item")

--- a/cells/auditcore/slices/auditquery/handler_test.go
+++ b/cells/auditcore/slices/auditquery/handler_test.go
@@ -65,6 +65,15 @@ func (h *testCaptureHandler) Handle(_ context.Context, r slog.Record) error {
 func (h *testCaptureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
 func (h *testCaptureHandler) WithGroup(_ string) slog.Handler      { return h }
 
+type auditVisibilityCase struct {
+	name          string
+	subject       string
+	roles         []string
+	tenantID      string
+	wantCount     int
+	wantSystemRow bool // #1618 F7: a tenant-less system row appears, marked scope="system"
+}
+
 // auditQueryTestTenant is a canonical tenant UUID for handler tests. auditquery
 // fail-closes on an empty principal tenant (epic #1337 PR-2a, F1), so every
 // handler test that expects to reach the query path must carry a tenant.
@@ -144,6 +153,103 @@ func TestHandleQuery_InvalidTimeFormat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertAuditVisibilityCase(t *testing.T, mux http.Handler, tc auditVisibilityCase) {
+	t.Helper()
+
+	p := &auth.Principal{
+		Kind:       auth.PrincipalUser,
+		Subject:    tc.subject,
+		Roles:      tc.roles,
+		TenantID:   tc.tenantID,
+		AuthMethod: "test",
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil)
+	req = req.WithContext(auth.WithPrincipal(context.Background(), p))
+	mux.ServeHTTP(w, req)
+
+	if isSuperAdmin(tc.roles) {
+		// #1618 merge: RowScopeAll fail-closes under FORCE RLS (deferred);
+		// the handler surfaces RowScopeAllUnsupportedError (KindNotImplemented)
+		// as a 501 — policy-authorized but capability-deferred (review F5).
+		// The FR-007 audit is still emitted (asserted by caller).
+		require.Equal(t, http.StatusNotImplemented, w.Code,
+			"tc=%s: super-admin RowScopeAll must fail-closed (501) under FORCE RLS, body=%s", tc.name, w.Body.String())
+		return
+	}
+
+	require.Equal(t, http.StatusOK, w.Code, "tc=%s body=%s", tc.name, w.Body.String())
+	var resp struct {
+		Data []struct {
+			Scope string `json:"scope"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "tc=%s", tc.name)
+	assert.Len(t, resp.Data, tc.wantCount, "tc=%s: wrong row count", tc.name)
+	assertAuditRowScopes(t, resp.Data, tc)
+}
+
+func assertAuditRowScopes(t *testing.T, rows []struct {
+	Scope string `json:"scope"`
+}, tc auditVisibilityCase,
+) {
+	t.Helper()
+
+	// #1618 F7: every returned row carries a scope marker; the admin's
+	// tenant-wide read surfaces the tenant-less system row marked
+	// "system", own-tenant rows "tenant".
+	sawSystem := false
+	for _, row := range rows {
+		assert.Contains(t, []string{"tenant", "system"}, row.Scope,
+			"tc=%s: row scope must be tenant|system, got %q", tc.name, row.Scope)
+		if row.Scope == "system" {
+			sawSystem = true
+		}
+	}
+	assert.Equal(t, tc.wantSystemRow, sawSystem,
+		"tc=%s: system-row scope visibility mismatch", tc.name)
+}
+
+func countAuditMandatoryRecords(records []slog.Record) int {
+	errorCount := 0
+	for _, rec := range records {
+		if rec.Level != slog.LevelError {
+			continue
+		}
+		if auditRecordHasMandatoryKeys(rec) {
+			errorCount++
+		}
+	}
+	return errorCount
+}
+
+func auditRecordHasMandatoryKeys(rec slog.Record) bool {
+	hasActor, hasScope, hasTenant, hasReason := false, false, false, false
+	rec.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "actor":
+			hasActor = true
+		case "scope":
+			hasScope = true
+		case "tenant":
+			hasTenant = true
+		case "reason":
+			hasReason = true
+		}
+		return true
+	})
+	return hasActor && hasScope && hasTenant && hasReason
+}
+
+func isSuperAdmin(roles []string) bool {
+	for _, r := range roles {
+		if r == auth.RoleSuperAdmin {
+			return true
+		}
+	}
+	return false
 }
 
 func TestHandleQuery_InvalidLimit(t *testing.T) {
@@ -1032,16 +1138,7 @@ func TestHandleQuery_RowScopeVisibilityMatrix(t *testing.T) {
 		require.NoError(t, store.Append(context.Background(), e))
 	}
 
-	type visCase struct {
-		name          string
-		subject       string
-		roles         []string
-		tenantID      string
-		wantCount     int
-		wantSystemRow bool // #1618 F7: a tenant-less system row appears, marked scope="system"
-	}
-
-	cases := []visCase{
+	cases := []auditVisibilityCase{
 		{
 			// non-admin usrA: RowScopeSelf → sees only its own row (vsm-a1). The
 			// system row (actor=system:bootstrap) is filtered out by the owner axis.
@@ -1075,89 +1172,12 @@ func TestHandleQuery_RowScopeVisibilityMatrix(t *testing.T) {
 		},
 	}
 
-	isSuperAdmin := func(roles []string) bool {
-		for _, r := range roles {
-			if r == auth.RoleSuperAdmin {
-				return true
-			}
-		}
-		return false
-	}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			capture.records = capture.records[:0] // reset between sub-tests
 
-			p := &auth.Principal{
-				Kind:       auth.PrincipalUser,
-				Subject:    tc.subject,
-				Roles:      tc.roles,
-				TenantID:   tc.tenantID,
-				AuthMethod: "test",
-			}
-			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil)
-			req = req.WithContext(auth.WithPrincipal(context.Background(), p))
-			mux.ServeHTTP(w, req)
-
-			if isSuperAdmin(tc.roles) {
-				// #1618 merge: RowScopeAll fail-closes under FORCE RLS (deferred);
-				// the handler surfaces RowScopeAllUnsupportedError (KindNotImplemented)
-				// as a 501 — policy-authorized but capability-deferred (review F5).
-				// The FR-007 audit is still emitted (asserted below).
-				require.Equal(t, http.StatusNotImplemented, w.Code,
-					"tc=%s: super-admin RowScopeAll must fail-closed (501) under FORCE RLS, body=%s", tc.name, w.Body.String())
-			} else {
-				require.Equal(t, http.StatusOK, w.Code, "tc=%s body=%s", tc.name, w.Body.String())
-				var resp struct {
-					Data []struct {
-						Scope string `json:"scope"`
-					} `json:"data"`
-				}
-				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "tc=%s", tc.name)
-				assert.Len(t, resp.Data, tc.wantCount, "tc=%s: wrong row count", tc.name)
-				// #1618 F7: every returned row carries a scope marker; the admin's
-				// tenant-wide read surfaces the tenant-less system row marked
-				// "system", own-tenant rows "tenant".
-				sawSystem := false
-				for _, row := range resp.Data {
-					assert.Contains(t, []string{"tenant", "system"}, row.Scope,
-						"tc=%s: row scope must be tenant|system, got %q", tc.name, row.Scope)
-					if row.Scope == "system" {
-						sawSystem = true
-					}
-				}
-				assert.Equal(t, tc.wantSystemRow, sawSystem,
-					"tc=%s: system-row scope visibility mismatch", tc.name)
-			}
-
-			// FR-007: super-admin path must emit exactly one slog.Error cross-tenant
-			// audit record with actor+scope+tenant+reason keys. Non-super-admin paths
-			// must NOT emit an Error-level record matching those keys.
-			errorCount := 0
-			for _, rec := range capture.records {
-				if rec.Level != slog.LevelError {
-					continue
-				}
-				hasActor, hasScope, hasTenant, hasReason := false, false, false, false
-				rec.Attrs(func(a slog.Attr) bool {
-					switch a.Key {
-					case "actor":
-						hasActor = true
-					case "scope":
-						hasScope = true
-					case "tenant":
-						hasTenant = true
-					case "reason":
-						hasReason = true
-					}
-					return true
-				})
-				if hasActor && hasScope && hasTenant && hasReason {
-					errorCount++
-				}
-			}
-
+			assertAuditVisibilityCase(t, mux, tc)
+			errorCount := countAuditMandatoryRecords(capture.records)
 			wantError := isSuperAdmin(tc.roles)
 			if wantError && errorCount == 0 {
 				t.Errorf("tc=%s: expected FR-007 slog.Error audit record with {actor,scope,tenant,reason}, got 0 (total records: %d)",

--- a/cells/configcore/internal/adapters/postgres/config_repo.go
+++ b/cells/configcore/internal/adapters/postgres/config_repo.go
@@ -24,6 +24,11 @@ import (
 	"github.com/ghbvf/gocell/runtime/state/cas"
 )
 
+const (
+	msgConfigInvalidTenant       = "config repo: invalid tenant"
+	msgConfigRepoReadinessFailed = "config repo readiness check failed"
+)
+
 // cryptoOpError constructs a uniform *errcode.Error for encrypt/decrypt
 // operation failures, classifying the cause to preserve dashboards' ability
 // to distinguish three signal sources that the ValueTransformer chain may
@@ -292,7 +297,7 @@ func (r *ConfigRepository) decryptVersionValue(
 // For sensitive=false: writes plaintext value; cipher columns are NULL.
 func (r *ConfigRepository) Create(ctx context.Context, t tenant.TenantID, entry *domain.ConfigEntry) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	now := r.clock.Now()
 	if entry.CreatedAt.IsZero() {
@@ -453,7 +458,7 @@ func (r *ConfigRepository) decryptScannedEntry(
 // sensitive entries. Sets entry.Stale=true when keyID != current active key.
 func (r *ConfigRepository) GetByKey(ctx context.Context, t tenant.TenantID, key string) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	const q = `SELECT ` + configEntryColumns + ` FROM config_entries WHERE tenant_id = $1 AND key = $2`
 	row := r.resolveDB(ctx).QueryRow(ctx, q, string(t), key)
@@ -507,7 +512,7 @@ func (r *ConfigRepository) Update(
 	ctx context.Context, t tenant.TenantID, key string, expectedVersion int, value string,
 ) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	db, err := r.resolveWriteDB(ctx)
 	if err != nil {
@@ -536,7 +541,14 @@ func (r *ConfigRepository) Update(
 		)
 	}
 
-	return r.doUpdate(ctx, db, t, opUpdate, key, expectedVersion, value, sensitive)
+	return r.doUpdate(ctx, db, configUpdateParams{
+		Tenant:          t,
+		Op:              opUpdate,
+		Key:             key,
+		ExpectedVersion: expectedVersion,
+		Value:           value,
+		Sensitive:       sensitive,
+	})
 }
 
 // UpdateForRollback atomically sets value AND sensitive, increments version if
@@ -548,13 +560,29 @@ func (r *ConfigRepository) UpdateForRollback(
 	ctx context.Context, t tenant.TenantID, key string, expectedVersion int, value string, sensitive bool,
 ) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	db, err := r.resolveWriteDB(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return r.doUpdate(ctx, db, t, opUpdateForRollback, key, expectedVersion, value, sensitive)
+	return r.doUpdate(ctx, db, configUpdateParams{
+		Tenant:          t,
+		Op:              opUpdateForRollback,
+		Key:             key,
+		ExpectedVersion: expectedVersion,
+		Value:           value,
+		Sensitive:       sensitive,
+	})
+}
+
+type configUpdateParams struct {
+	Tenant          tenant.TenantID
+	Op              string
+	Key             string
+	ExpectedVersion int
+	Value           string
+	Sensitive       bool
 }
 
 // doUpdate performs the actual UPDATE...RETURNING for both Update and
@@ -567,15 +595,13 @@ func (r *ConfigRepository) UpdateForRollback(
 // CAS flow: rowsAffected==0 → probe GetByKey:
 //   - exists → ErrVersionConflict (409)
 //   - not found → ErrConfigRepoNotFound (404)
-func (r *ConfigRepository) doUpdate(
-	ctx context.Context, db DBTX, t tenant.TenantID, op, key string, expectedVersion int, value string, sensitive bool,
-) (*domain.ConfigEntry, error) {
+func (r *ConfigRepository) doUpdate(ctx context.Context, db DBTX, p configUpdateParams) (*domain.ConfigEntry, error) {
 	var (
 		rowsAffected int64
 		row          RowScanner
 	)
-	if sensitive {
-		payload, encErr := r.encryptValue(ctx, t, key, value)
+	if p.Sensitive {
+		payload, encErr := r.encryptValue(ctx, p.Tenant, p.Key, p.Value)
 		if encErr != nil {
 			return nil, encErr
 		}
@@ -584,34 +610,34 @@ func (r *ConfigRepository) doUpdate(
 			    value_cipher = $1, value_key_id = $2, value_edk = $3, value_nonce = $4
 			WHERE key = $5 AND version = $6 AND tenant_id = $7
 			RETURNING ` + configEntryColumns
-		row = db.QueryRow(ctx, q, payload.Ciphertext, payload.KeyID, payload.EDK, payload.Nonce, key, expectedVersion, string(t))
+		row = db.QueryRow(ctx, q, payload.Ciphertext, payload.KeyID, payload.EDK, payload.Nonce, p.Key, p.ExpectedVersion, string(p.Tenant))
 	} else {
 		const q = `UPDATE config_entries
 			SET value = $1, sensitive = false, version = version+1, updated_at = now(),
 			    value_cipher = NULL, value_key_id = NULL, value_edk = NULL, value_nonce = NULL
 			WHERE key = $2 AND version = $3 AND tenant_id = $4
 			RETURNING ` + configEntryColumns
-		row = db.QueryRow(ctx, q, value, key, expectedVersion, string(t))
+		row = db.QueryRow(ctx, q, p.Value, p.Key, p.ExpectedVersion, string(p.Tenant))
 	}
 
 	e, ct, keyID, edk, nonce, scanErr := scanConfigRow(row)
 	if scanErr != nil {
-		if cancelErr := ctxcancel.Wrap(scanErr, op, "key="+key); cancelErr != nil {
+		if cancelErr := ctxcancel.Wrap(scanErr, p.Op, "key="+p.Key); cancelErr != nil {
 			return nil, cancelErr
 		}
 		if errors.Is(scanErr, pgx.ErrNoRows) {
 			// rowsAffected==0: distinguish version mismatch from not-found.
-			return nil, r.resolveUpdateConflict(ctx, t, op, key)
+			return nil, r.resolveUpdateConflict(ctx, p.Tenant, p.Op, p.Key)
 		}
 		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrConfigRepoQuery,
 			configRepoQueryFailedMessage, scanErr,
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("config repo: %s scan error key=%s", op, key))),
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("config repo: %s scan error key=%s", p.Op, p.Key))),
 			errcode.WithCategory(errcode.CategoryInfra),
 		)
 	}
 	_ = rowsAffected // row scan succeeded → rowsAffected implicitly 1
 
-	if err := r.decryptScannedEntry(ctx, t, e, ct, keyID, nonce, edk); err != nil {
+	if err := r.decryptScannedEntry(ctx, p.Tenant, e, ct, keyID, nonce, edk); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -652,7 +678,7 @@ func (r *ConfigRepository) resolveUpdateConflict(ctx context.Context, t tenant.T
 // if expectedVersion does not match.
 func (r *ConfigRepository) Delete(ctx context.Context, t tenant.TenantID, key string, expectedVersion int) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	const q = `DELETE FROM config_entries WHERE key = $1 AND version = $2 AND tenant_id = $3 RETURNING ` + configEntryColumns
 
@@ -740,7 +766,7 @@ func (r *ConfigRepository) applySensitiveListSentinel(
 // exposure of sensitive values in list responses.
 func (r *ConfigRepository) List(ctx context.Context, t tenant.TenantID, params query.ListParams) ([]*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	b := pgquery.NewBuilder()
 	b.AppendParam("SELECT "+listEntryColumns+" FROM config_entries WHERE tenant_id = ", string(t))
@@ -786,7 +812,7 @@ func (r *ConfigRepository) List(ctx context.Context, t tenant.TenantID, params q
 // For sensitive=true: encrypts value and writes cipher columns.
 func (r *ConfigRepository) PublishVersion(ctx context.Context, t tenant.TenantID, version *domain.ConfigVersion) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	db, err := r.resolveWriteDB(ctx)
 	if err != nil {
@@ -858,19 +884,19 @@ func (r *ConfigRepository) RepoReady(ctx context.Context) error {
 
 	if _, err := db.Exec(ctx, configEntriesProbeSQL); err != nil {
 		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrConfigRepoQuery,
-			"config repo readiness check failed", err,
+			msgConfigRepoReadinessFailed, err,
 			errcode.WithCategory(errcode.CategoryInfra),
 		)
 	}
 	if _, err := db.Exec(ctx, featureFlagsProbeSQL); err != nil {
 		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrConfigRepoQuery,
-			"config repo readiness check failed", err,
+			msgConfigRepoReadinessFailed, err,
 			errcode.WithCategory(errcode.CategoryInfra),
 		)
 	}
 	if _, err := db.Exec(ctx, configVersionsProbeSQL); err != nil {
 		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrConfigRepoQuery,
-			"config repo readiness check failed", err,
+			msgConfigRepoReadinessFailed, err,
 			errcode.WithCategory(errcode.CategoryInfra),
 		)
 	}
@@ -881,7 +907,7 @@ func (r *ConfigRepository) RepoReady(ctx context.Context) error {
 // GetVersion retrieves a specific config version with transparent decryption.
 func (r *ConfigRepository) GetVersion(ctx context.Context, t tenant.TenantID, configID string, version int) (*domain.ConfigVersion, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	const q = `SELECT id, config_id, version, value, sensitive, published_at,
 		value_cipher, value_key_id, value_edk, value_nonce

--- a/cells/configcore/internal/adapters/postgres/flag_repo.go
+++ b/cells/configcore/internal/adapters/postgres/flag_repo.go
@@ -34,6 +34,8 @@ const flagColumns = "id, key, enabled, rollout_percentage, description, version,
 // uniform and grep for the literal returns one source of truth.
 const msgFlagRepoQueryFailed = "flag repo query failed"
 
+const msgFlagInvalidTenant = "flag repo: invalid tenant"
+
 // FlagRepository implements ports.FlagRepository using PostgreSQL.
 //
 // Write paths (Create/Update/Delete/Toggle) require an ambient pgx.Tx in ctx
@@ -128,7 +130,7 @@ func scanFlagRow(row RowScanner) (*domain.FeatureFlag, error) {
 // Create inserts a new feature flag. All 8 columns are written plus tenant_id.
 func (r *FlagRepository) Create(ctx context.Context, t tenant.TenantID, flag *domain.FeatureFlag) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	const sql = `INSERT INTO feature_flags
 		(tenant_id, ` + flagColumns + `)
@@ -169,7 +171,7 @@ func (r *FlagRepository) Create(ctx context.Context, t tenant.TenantID, flag *do
 // GetByKey retrieves a feature flag by key.
 func (r *FlagRepository) GetByKey(ctx context.Context, t tenant.TenantID, key string) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	const sql = `SELECT ` + flagColumns + ` FROM feature_flags WHERE tenant_id = $1 AND key = $2`
 	return r.scanFlagOrMapError(ctx, r.resolveDB(ctx).QueryRow(ctx, sql, string(t), key), "GetByKey", key)
@@ -187,7 +189,7 @@ func (r *FlagRepository) Update(
 	ctx context.Context, t tenant.TenantID, key string, expectedVersion int, enabled bool, rolloutPercentage int, description string,
 ) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	const sql = `UPDATE feature_flags
 		SET enabled=$1, rollout_percentage=$2, description=$3, version=version+1, updated_at=now()
@@ -219,7 +221,7 @@ func (r *FlagRepository) Update(
 // Requires composite index: CREATE INDEX idx_feature_flags_tenant_key_id ON feature_flags (tenant_id ASC, key ASC, id ASC).
 func (r *FlagRepository) List(ctx context.Context, t tenant.TenantID, params query.ListParams) ([]*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	b := pgquery.NewBuilder()
 	b.AppendParam("SELECT "+flagColumns+" FROM feature_flags WHERE tenant_id = ", string(t))
@@ -262,7 +264,7 @@ func (r *FlagRepository) List(ctx context.Context, t tenant.TenantID, params que
 //   - not found → ErrFlagNotFound (404)
 func (r *FlagRepository) Delete(ctx context.Context, t tenant.TenantID, key string, expectedVersion int) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	const sql = `DELETE FROM feature_flags WHERE key=$1 AND version=$2 AND tenant_id=$3 RETURNING ` + flagColumns
 
@@ -303,7 +305,7 @@ func (r *FlagRepository) Toggle(
 	ctx context.Context, t tenant.TenantID, key string, expectedVersion int, enabled bool,
 ) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	const sql = `UPDATE feature_flags
 		SET enabled=$1, version=version+1, updated_at=now()

--- a/cells/configcore/internal/mem/config_repo.go
+++ b/cells/configcore/internal/mem/config_repo.go
@@ -22,6 +22,7 @@ var _ ports.ConfigRepository = (*ConfigRepository)(nil)
 
 const (
 	configInternalKeyQuotedFmt = "key=%q"
+	msgConfigInvalidTenant     = "config repo: invalid tenant"
 	msgConfigNotFound          = "config not found"
 )
 
@@ -77,7 +78,7 @@ func (r *ConfigRepository) tenantVersions(t tenant.TenantID) map[string][]*domai
 
 func (r *ConfigRepository) Create(_ context.Context, t tenant.TenantID, entry *domain.ConfigEntry) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -95,7 +96,7 @@ func (r *ConfigRepository) Create(_ context.Context, t tenant.TenantID, entry *d
 //nolint:dupl // mirrors FlagRepository.GetByKey; typed differences (ConfigEntry vs FeatureFlag, distinct codes) preclude shared helper
 func (r *ConfigRepository) GetByKey(_ context.Context, t tenant.TenantID, key string) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -119,7 +120,7 @@ func (r *ConfigRepository) Update(
 	_ context.Context, t tenant.TenantID, key string, expectedVersion int, value string,
 ) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -145,7 +146,7 @@ func (r *ConfigRepository) UpdateForRollback(
 	_ context.Context, t tenant.TenantID, key string, expectedVersion int, value string, sensitive bool,
 ) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -169,7 +170,7 @@ func (r *ConfigRepository) UpdateForRollback(
 
 func (r *ConfigRepository) Delete(_ context.Context, t tenant.TenantID, key string, expectedVersion int) (*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -193,7 +194,7 @@ func (r *ConfigRepository) Delete(_ context.Context, t tenant.TenantID, key stri
 // for N+1 hasMore detection.
 func (r *ConfigRepository) List(_ context.Context, t tenant.TenantID, params query.ListParams) ([]*domain.ConfigEntry, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -255,7 +256,7 @@ func configFieldValue(e *domain.ConfigEntry, field string) any {
 
 func (r *ConfigRepository) PublishVersion(_ context.Context, t tenant.TenantID, version *domain.ConfigVersion) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -274,7 +275,7 @@ func (r *ConfigRepository) RepoReady(_ context.Context) error {
 
 func (r *ConfigRepository) GetVersion(_ context.Context, t tenant.TenantID, configID string, version int) (*domain.ConfigVersion, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "config repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgConfigInvalidTenant, err)
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/cells/configcore/internal/mem/flag_repo.go
+++ b/cells/configcore/internal/mem/flag_repo.go
@@ -20,6 +20,7 @@ var _ ports.FlagRepository = (*FlagRepository)(nil)
 
 const (
 	flagInternalKeyQuotedFmt = "key=%q"
+	msgFlagInvalidTenant     = "flag repo: invalid tenant"
 	msgFlagNotFound          = "flag not found"
 )
 
@@ -60,7 +61,7 @@ func (r *FlagRepository) tenantFlags(t tenant.TenantID) map[string]*domain.Featu
 
 func (r *FlagRepository) Create(_ context.Context, t tenant.TenantID, flag *domain.FeatureFlag) error {
 	if err := t.Validate(); err != nil {
-		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -78,7 +79,7 @@ func (r *FlagRepository) Create(_ context.Context, t tenant.TenantID, flag *doma
 //nolint:dupl // mirrors ConfigRepository.GetByKey; typed differences (FeatureFlag vs ConfigEntry, distinct codes) preclude shared helper
 func (r *FlagRepository) GetByKey(_ context.Context, t tenant.TenantID, key string) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -105,7 +106,7 @@ func (r *FlagRepository) Update(
 	_ context.Context, t tenant.TenantID, key string, expectedVersion int, enabled bool, rolloutPercentage int, description string,
 ) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -133,7 +134,7 @@ func (r *FlagRepository) Update(
 // or ErrVersionConflict if expectedVersion does not match.
 func (r *FlagRepository) Delete(_ context.Context, t tenant.TenantID, key string, expectedVersion int) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -163,7 +164,7 @@ func (r *FlagRepository) Toggle(
 	_ context.Context, t tenant.TenantID, key string, expectedVersion int, enabled bool,
 ) (*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -189,7 +190,7 @@ func (r *FlagRepository) Toggle(
 // for N+1 hasMore detection.
 func (r *FlagRepository) List(_ context.Context, t tenant.TenantID, params query.ListParams) ([]*domain.FeatureFlag, error) {
 	if err := t.Validate(); err != nil {
-		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "flag repo: invalid tenant", err)
+		return nil, errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgFlagInvalidTenant, err)
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/cmd/corebundle/integration_testhelpers_test.go
+++ b/cmd/corebundle/integration_testhelpers_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/ghbvf/gocell/runtime/composition"
 )
 
-// runnable is the minimal interface shared by *bootstrap.Bootstrap and
+// runner is the minimal interface shared by *bootstrap.Bootstrap and
 // *composition.App, both of which expose Run(ctx) error. Tests use this to
 // avoid coupling to a concrete type.
-type runnable interface {
+type runner interface {
 	Run(ctx context.Context) error
 }
 
@@ -48,7 +48,7 @@ func buildTestSharedDeps(t *testing.T) *composition.SharedDeps {
 // modules (configcore → auditcore → accesscore).
 func buildBootstrapFromShared(
 	t *testing.T, shared *composition.SharedDeps, primaryLn net.Listener, extra ...bootstrap.Option,
-) (runnable, error) {
+) (runner, error) {
 	t.Helper()
 	ctx := context.Background()
 	_, locals := buildTestSharedDepsAndLocals(t)

--- a/cmd/gocell/app/scaffold_golden_tree_test.go
+++ b/cmd/gocell/app/scaffold_golden_tree_test.go
@@ -146,35 +146,52 @@ func TestScaffoldCell_GoldenTree(t *testing.T) {
 
 	planRels := make([]string, 0, len(plan))
 	for _, pf := range plan {
-		rel, err := filepath.Rel(realRoot, pf.AbsPath)
-		if err != nil {
-			t.Fatalf("Rel(%s): %v", pf.AbsPath, err)
-		}
-		rel = filepath.ToSlash(rel)
+		rel := scaffoldPlanRel(t, realRoot, pf.AbsPath)
 		planRels = append(planRels, rel)
-
-		goldenPath := filepath.Join(scaffoldGoldenDir, filepath.FromSlash(rel)) + ".golden"
-		if *updateScaffoldGolden {
-			if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
-				t.Fatalf("mkdir golden: %v", err)
-			}
-			if err := os.WriteFile(goldenPath, pf.Content, 0o644); err != nil {
-				t.Fatalf("write golden %s: %v", goldenPath, err)
-			}
-			continue
-		}
-		want, err := os.ReadFile(goldenPath) //nolint:gosec // golden path derived from the in-repo plan, not user input
-		if err != nil {
-			t.Errorf("missing golden for planned file %q (run -update-scaffold-golden): %v", rel, err)
-			continue
-		}
-		if !bytes.Equal(pf.Content, want) {
-			t.Errorf("scaffold golden drift: %s\n--- got ---\n%s\n--- want ---\n%s",
-				rel, pf.Content, want)
-		}
+		assertScaffoldPlanFileGolden(t, rel, pf.Content)
 	}
 
 	assertGoldenFileSet(t, planRels)
+}
+
+func scaffoldPlanRel(t *testing.T, realRoot, absPath string) string {
+	t.Helper()
+
+	rel, err := filepath.Rel(realRoot, absPath)
+	if err != nil {
+		t.Fatalf("Rel(%s): %v", absPath, err)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func assertScaffoldPlanFileGolden(t *testing.T, rel string, content []byte) {
+	t.Helper()
+
+	goldenPath := filepath.Join(scaffoldGoldenDir, filepath.FromSlash(rel)) + ".golden"
+	if *updateScaffoldGolden {
+		writeScaffoldGolden(t, goldenPath, content)
+		return
+	}
+	want, err := os.ReadFile(goldenPath) //nolint:gosec // golden path derived from the in-repo plan, not user input
+	if err != nil {
+		t.Errorf("missing golden for planned file %q (run -update-scaffold-golden): %v", rel, err)
+		return
+	}
+	if !bytes.Equal(content, want) {
+		t.Errorf("scaffold golden drift: %s\n--- got ---\n%s\n--- want ---\n%s",
+			rel, content, want)
+	}
+}
+
+func writeScaffoldGolden(t *testing.T, goldenPath string, content []byte) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+		t.Fatalf("mkdir golden: %v", err)
+	}
+	if err := os.WriteFile(goldenPath, content, 0o644); err != nil {
+		t.Fatalf("write golden %s: %v", goldenPath, err)
+	}
 }
 
 // assertGoldenFileSet is the completeness (reverse) guard: the set of planned

--- a/cmd/gocell/main_seal_test.go
+++ b/cmd/gocell/main_seal_test.go
@@ -25,44 +25,7 @@ func TestMainSealsLogsToStderr(t *testing.T) {
 		t.Fatalf("parse main.go: %v", err)
 	}
 
-	var found, writerStderr bool
-	ast.Inspect(f, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil || sel.Sel.Name != "NewHandler" {
-			return true
-		}
-		if len(call.Args) != 1 {
-			return true
-		}
-		lit, ok := call.Args[0].(*ast.CompositeLit)
-		if !ok {
-			return true
-		}
-		found = true
-		for _, elt := range lit.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-			key, ok := kv.Key.(*ast.Ident)
-			if !ok || key.Name != "Writer" {
-				continue
-			}
-			vsel, ok := kv.Value.(*ast.SelectorExpr)
-			if !ok || vsel.Sel == nil {
-				continue
-			}
-			if vx, ok := vsel.X.(*ast.Ident); ok && vx.Name == "os" && vsel.Sel.Name == "Stderr" {
-				writerStderr = true
-			}
-		}
-		return true
-	})
-
+	found, writerStderr := loggingSealWritesToStderr(f)
 	if !found {
 		t.Fatal("cmd/gocell/main.go: no logging.NewHandler(logging.Options{...}) seal found")
 	}
@@ -71,4 +34,61 @@ func TestMainSealsLogsToStderr(t *testing.T) {
 			" logging.NewHandler defaults to os.Stdout, which would corrupt machine output" +
 			" (export JSON/YAML/SARIF) written to stdout (#1432 C1)")
 	}
+}
+
+func loggingSealWritesToStderr(f *ast.File) (found bool, writerStderr bool) {
+	ast.Inspect(f, func(n ast.Node) bool {
+		lit, ok := loggingNewHandlerOptions(n)
+		if !ok {
+			return true
+		}
+		found = true
+		if optionsWriterIsStderr(lit) {
+			writerStderr = true
+		}
+		return true
+	})
+	return found, writerStderr
+}
+
+func loggingNewHandlerOptions(n ast.Node) (*ast.CompositeLit, bool) {
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return nil, false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "NewHandler" {
+		return nil, false
+	}
+	if len(call.Args) != 1 {
+		return nil, false
+	}
+	lit, ok := call.Args[0].(*ast.CompositeLit)
+	return lit, ok
+}
+
+func optionsWriterIsStderr(lit *ast.CompositeLit) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "Writer" {
+			continue
+		}
+		if selectorIsOSStderr(kv.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+func selectorIsOSStderr(expr ast.Expr) bool {
+	vsel, ok := expr.(*ast.SelectorExpr)
+	if !ok || vsel.Sel == nil {
+		return false
+	}
+	vx, ok := vsel.X.(*ast.Ident)
+	return ok && vx.Name == "os" && vsel.Sel.Name == "Stderr"
 }

--- a/examples/iotdevice/cells/devicecell/slices/devicebootstrap/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicebootstrap/service_test.go
@@ -65,96 +65,19 @@ func TestHandleDeviceRegistered(t *testing.T) {
 	})
 
 	t.Run("ack emits enqueue command", func(t *testing.T) {
-		rec := outboxtest.NewRecorder()
-		svc, err := NewService(clk, WithEmitter(rec.CellEmitter()))
-		if err != nil {
-			t.Fatalf("NewService: %v", err)
-		}
-
-		res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
-		if res.Disposition != outbox.DispositionAck {
-			t.Fatalf("Disposition = %v, want Ack; err=%v", res.Disposition, res.Err)
-		}
-
-		entries := rec.Entries()
-		if len(entries) != 1 {
-			t.Fatalf("emitted %d entries, want 1", len(entries))
-		}
-		got := entries[0]
-		if got.RoutingTopic() != string(cmdenqueue.DispatchID) {
-			t.Errorf("RoutingTopic = %q, want %q", got.RoutingTopic(), cmdenqueue.DispatchID)
-		}
-		if got.AggregateID() != testDeviceID {
-			t.Errorf("AggregateID = %q, want %q", got.AggregateID(), testDeviceID)
-		}
-		if cid := got.Metadata()[rtcommand.CommandIDMetadataKey]; cid != testEntryID {
-			t.Errorf("command_id metadata = %q, want source entry ID %q", cid, testEntryID)
-		}
-
-		var req cmdenqueue.Request
-		if err := json.Unmarshal(got.Payload(), &req); err != nil {
-			t.Fatalf("decode emitted command payload: %v", err)
-		}
-		if req.DeviceID != testDeviceID {
-			t.Errorf("req.DeviceID = %q, want %q", req.DeviceID, testDeviceID)
-		}
-		if req.CommandType != bootstrapCommandType {
-			t.Errorf("req.CommandType = %q, want %q", req.CommandType, bootstrapCommandType)
-		}
+		assertHandleDeviceRegisteredAck(t, clk, validPayload)
 	})
 
 	t.Run("reject on undecodable payload", func(t *testing.T) {
-		rec := outboxtest.NewRecorder()
-		svc, err := NewService(clk, WithEmitter(rec.CellEmitter()))
-		if err != nil {
-			t.Fatalf("NewService: %v", err)
-		}
-
-		bad := registeredEntry(t, clk, []byte("{not json"))
-		res := svc.HandleDeviceRegistered(context.Background(), bad)
-		if res.Disposition != outbox.DispositionReject {
-			t.Fatalf("Disposition = %v, want Reject", res.Disposition)
-		}
-		var perm *outbox.PermanentError
-		if !errors.As(res.Err, &perm) {
-			t.Errorf("err = %v, want a *outbox.PermanentError", res.Err)
-		}
-		if n := len(rec.Entries()); n != 0 {
-			t.Errorf("emitted %d entries on decode failure, want 0", n)
-		}
+		assertHandleDeviceRegisteredRejectsBadPayload(t, clk)
 	})
 
 	t.Run("with logger and explicit emitter still acks", func(t *testing.T) {
-		rec := outboxtest.NewRecorder()
-		svc, err := NewService(clk,
-			WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
-			WithEmitter(rec.CellEmitter()))
-		if err != nil {
-			t.Fatalf("NewService: %v", err)
-		}
-		res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
-		if res.Disposition != outbox.DispositionAck {
-			t.Fatalf("Disposition = %v, want Ack", res.Disposition)
-		}
-		if n := len(rec.Entries()); n != 1 {
-			t.Fatalf("emitted %d entries, want 1", n)
-		}
+		assertHandleDeviceRegisteredLoggerAndEmitterAck(t, clk, validPayload)
 	})
 
 	t.Run("requeue on emit failure", func(t *testing.T) {
-		emitErr := errors.New("broker unavailable")
-		svc, err := NewService(clk, WithEmitter(outbox.WrapEmitterForCell(failingEmitter{err: emitErr})))
-		if err != nil {
-			t.Fatalf("NewService: %v", err)
-		}
-
-		res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
-		if res.Disposition != outbox.DispositionRequeue {
-			t.Fatalf("Disposition = %v, want Requeue", res.Disposition)
-		}
-		if !errors.Is(res.Err, emitErr) {
-			t.Errorf("err = %v, want it to wrap %v", res.Err, emitErr)
-		}
+		assertHandleDeviceRegisteredRequeuesOnEmitFailure(t, clk, validPayload)
 	})
 
 	// txRunner wraps EmitAsync: an error inside the RunInTx closure (i.e. a
@@ -163,22 +86,136 @@ func TestHandleDeviceRegistered(t *testing.T) {
 	// we exercise the error path via a failing writer: WriterEmitter.Emit calls
 	// writer.Write(ctx) which fails, RunInTx returns the error, handler Requeues.
 	t.Run("requeue when emit fails inside txRunner", func(t *testing.T) {
-		writeErr := errors.New("outbox write: no tx in context")
-		writerEmitter, werr := outbox.NewWriterEmitter(errorWriter{err: writeErr})
-		if werr != nil {
-			t.Fatalf("NewWriterEmitter: %v", werr)
-		}
-		svc, err := NewService(clk, WithEmitter(outbox.WrapEmitterForCell(writerEmitter)))
-		if err != nil {
-			t.Fatalf("NewService: %v", err)
-		}
-
-		res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
-		if res.Disposition != outbox.DispositionRequeue {
-			t.Fatalf("Disposition = %v, want Requeue", res.Disposition)
-		}
-		if !errors.Is(res.Err, writeErr) {
-			t.Errorf("err = %v, want it to wrap %v", res.Err, writeErr)
-		}
+		assertHandleDeviceRegisteredRequeuesInsideTxRunner(t, clk, validPayload)
 	})
+}
+
+func assertHandleDeviceRegisteredAck(t *testing.T, clk clock.Clock, validPayload []byte) {
+	t.Helper()
+
+	rec := outboxtest.NewRecorder()
+	svc, err := NewService(clk, WithEmitter(rec.CellEmitter()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
+	if res.Disposition != outbox.DispositionAck {
+		t.Fatalf("Disposition = %v, want Ack; err=%v", res.Disposition, res.Err)
+	}
+
+	assertBootstrapCommandEmitted(t, rec)
+}
+
+func assertBootstrapCommandEmitted(t *testing.T, rec *outboxtest.Recorder) {
+	t.Helper()
+
+	entries := rec.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("emitted %d entries, want 1", len(entries))
+	}
+	got := entries[0]
+	if got.RoutingTopic() != string(cmdenqueue.DispatchID) {
+		t.Errorf("RoutingTopic = %q, want %q", got.RoutingTopic(), cmdenqueue.DispatchID)
+	}
+	if got.AggregateID() != testDeviceID {
+		t.Errorf("AggregateID = %q, want %q", got.AggregateID(), testDeviceID)
+	}
+	if cid := got.Metadata()[rtcommand.CommandIDMetadataKey]; cid != testEntryID {
+		t.Errorf("command_id metadata = %q, want source entry ID %q", cid, testEntryID)
+	}
+
+	var req cmdenqueue.Request
+	if err := json.Unmarshal(got.Payload(), &req); err != nil {
+		t.Fatalf("decode emitted command payload: %v", err)
+	}
+	if req.DeviceID != testDeviceID {
+		t.Errorf("req.DeviceID = %q, want %q", req.DeviceID, testDeviceID)
+	}
+	if req.CommandType != bootstrapCommandType {
+		t.Errorf("req.CommandType = %q, want %q", req.CommandType, bootstrapCommandType)
+	}
+}
+
+func assertHandleDeviceRegisteredRejectsBadPayload(t *testing.T, clk clock.Clock) {
+	t.Helper()
+
+	rec := outboxtest.NewRecorder()
+	svc, err := NewService(clk, WithEmitter(rec.CellEmitter()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	bad := registeredEntry(t, clk, []byte("{not json"))
+	res := svc.HandleDeviceRegistered(context.Background(), bad)
+	if res.Disposition != outbox.DispositionReject {
+		t.Fatalf("Disposition = %v, want Reject", res.Disposition)
+	}
+	var perm *outbox.PermanentError
+	if !errors.As(res.Err, &perm) {
+		t.Errorf("err = %v, want a *outbox.PermanentError", res.Err)
+	}
+	if n := len(rec.Entries()); n != 0 {
+		t.Errorf("emitted %d entries on decode failure, want 0", n)
+	}
+}
+
+func assertHandleDeviceRegisteredLoggerAndEmitterAck(t *testing.T, clk clock.Clock, validPayload []byte) {
+	t.Helper()
+
+	rec := outboxtest.NewRecorder()
+	svc, err := NewService(clk,
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+		WithEmitter(rec.CellEmitter()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
+	if res.Disposition != outbox.DispositionAck {
+		t.Fatalf("Disposition = %v, want Ack", res.Disposition)
+	}
+	if n := len(rec.Entries()); n != 1 {
+		t.Fatalf("emitted %d entries, want 1", n)
+	}
+}
+
+func assertHandleDeviceRegisteredRequeuesOnEmitFailure(t *testing.T, clk clock.Clock, validPayload []byte) {
+	t.Helper()
+
+	emitErr := errors.New("broker unavailable")
+	svc, err := NewService(clk, WithEmitter(outbox.WrapEmitterForCell(failingEmitter{err: emitErr})))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
+	assertRequeueWraps(t, res, emitErr)
+}
+
+func assertHandleDeviceRegisteredRequeuesInsideTxRunner(t *testing.T, clk clock.Clock, validPayload []byte) {
+	t.Helper()
+
+	writeErr := errors.New("outbox write: no tx in context")
+	writerEmitter, werr := outbox.NewWriterEmitter(errorWriter{err: writeErr})
+	if werr != nil {
+		t.Fatalf("NewWriterEmitter: %v", werr)
+	}
+	svc, err := NewService(clk, WithEmitter(outbox.WrapEmitterForCell(writerEmitter)))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	res := svc.HandleDeviceRegistered(context.Background(), registeredEntry(t, clk, validPayload))
+	assertRequeueWraps(t, res, writeErr)
+}
+
+func assertRequeueWraps(t *testing.T, res outbox.HandleResult, want error) {
+	t.Helper()
+
+	if res.Disposition != outbox.DispositionRequeue {
+		t.Fatalf("Disposition = %v, want Requeue", res.Disposition)
+	}
+	if !errors.Is(res.Err, want) {
+		t.Errorf("err = %v, want it to wrap %v", res.Err, want)
+	}
 }

--- a/examples/iotdevice/cells/devicecell/slices/devicecommandrpc/handler_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommandrpc/handler_test.go
@@ -75,34 +75,11 @@ func TestServer_IssueCommand_Direct(t *testing.T) {
 	srv := newTestServer(t)
 
 	t.Run("success enqueues and returns the command id", func(t *testing.T) {
-		resp, err := srv.IssueCommand(operatorCtx(context.Background()), &commandv1.IssueCommandRequest{
-			DeviceId:    seededDeviceID,
-			CommandType: "reboot",
-			Payload:     []byte("{}"),
-		})
-		if err != nil {
-			t.Fatalf("IssueCommand: unexpected error: %v", err)
-		}
-		// ack_id carries the real enqueued command id (cmd-<hex>), not a throwaway uuid.
-		if !strings.HasPrefix(resp.GetAckId(), "cmd-") {
-			t.Errorf("ack_id = %q, want a cmd- prefixed enqueued command id", resp.GetAckId())
-		}
-		if got := resp.GetAcknowledgedAtUnixNano(); got != fixedTime.UnixNano() {
-			t.Errorf("acknowledged_at_unix_nano = %d, want %d (injected clock)", got, fixedTime.UnixNano())
-		}
+		assertIssueCommandSuccess(t, srv)
 	})
 
 	t.Run("unauthorized caller is denied", func(t *testing.T) {
-		// No principal in context → permission denied (mirrors the HTTP route policy).
-		_, err := srv.IssueCommand(context.Background(), &commandv1.IssueCommandRequest{
-			DeviceId:    seededDeviceID,
-			CommandType: "reboot",
-			Payload:     []byte("{}"),
-		})
-		var ce *errcode.Error
-		if !errors.As(err, &ce) || ce.Code != errcode.ErrAuthForbidden {
-			t.Fatalf("want ErrAuthForbidden, got %v", err)
-		}
+		assertIssueCommandUnauthorized(t, srv)
 	})
 
 	cases := []struct {
@@ -114,18 +91,59 @@ func TestServer_IssueCommand_Direct(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := srv.IssueCommand(operatorCtx(context.Background()), tc.req)
-			if err == nil {
-				t.Fatalf("expected error for %s, got resp=%v", tc.name, resp)
-			}
-			var ce *errcode.Error
-			if !errors.As(err, &ce) {
-				t.Fatalf("error is not *errcode.Error: %v", err)
-			}
-			if ce.Code != errcode.ErrValidationFailed {
-				t.Errorf("Code = %q, want %q", ce.Code, errcode.ErrValidationFailed)
-			}
+			assertIssueCommandValidationError(t, srv, tc.name, tc.req)
 		})
+	}
+}
+
+func assertIssueCommandSuccess(t *testing.T, srv *Server) {
+	t.Helper()
+
+	resp, err := srv.IssueCommand(operatorCtx(context.Background()), &commandv1.IssueCommandRequest{
+		DeviceId:    seededDeviceID,
+		CommandType: "reboot",
+		Payload:     []byte("{}"),
+	})
+	if err != nil {
+		t.Fatalf("IssueCommand: unexpected error: %v", err)
+	}
+	// ack_id carries the real enqueued command id (cmd-<hex>), not a throwaway uuid.
+	if !strings.HasPrefix(resp.GetAckId(), "cmd-") {
+		t.Errorf("ack_id = %q, want a cmd- prefixed enqueued command id", resp.GetAckId())
+	}
+	if got := resp.GetAcknowledgedAtUnixNano(); got != fixedTime.UnixNano() {
+		t.Errorf("acknowledged_at_unix_nano = %d, want %d (injected clock)", got, fixedTime.UnixNano())
+	}
+}
+
+func assertIssueCommandUnauthorized(t *testing.T, srv *Server) {
+	t.Helper()
+
+	// No principal in context → permission denied (mirrors the HTTP route policy).
+	_, err := srv.IssueCommand(context.Background(), &commandv1.IssueCommandRequest{
+		DeviceId:    seededDeviceID,
+		CommandType: "reboot",
+		Payload:     []byte("{}"),
+	})
+	var ce *errcode.Error
+	if !errors.As(err, &ce) || ce.Code != errcode.ErrAuthForbidden {
+		t.Fatalf("want ErrAuthForbidden, got %v", err)
+	}
+}
+
+func assertIssueCommandValidationError(t *testing.T, srv *Server, name string, req *commandv1.IssueCommandRequest) {
+	t.Helper()
+
+	resp, err := srv.IssueCommand(operatorCtx(context.Background()), req)
+	if err == nil {
+		t.Fatalf("expected error for %s, got resp=%v", name, resp)
+	}
+	var ce *errcode.Error
+	if !errors.As(err, &ce) {
+		t.Fatalf("error is not *errcode.Error: %v", err)
+	}
+	if ce.Code != errcode.ErrValidationFailed {
+		t.Errorf("Code = %q, want %q", ce.Code, errcode.ErrValidationFailed)
 	}
 }
 

--- a/examples/iotdevice/mqtt_test.go
+++ b/examples/iotdevice/mqtt_test.go
@@ -213,17 +213,19 @@ func TestBuildMQTTDirectPublisher_EarlyReturns(t *testing.T) {
 	})
 }
 
+type mqttConnectDeadlineCase struct {
+	name    string
+	set     bool
+	val     string
+	want    time.Duration
+	wantErr bool
+}
+
 // TestMQTTConnectDeadline covers the env-driven bootstrap connect-deadline
 // resolver: unset → default constant; valid override; and the fail-fast paths
 // (malformed duration / non-positive) that must NOT silently revert to default.
 func TestMQTTConnectDeadline(t *testing.T) {
-	tests := []struct {
-		name    string
-		set     bool
-		val     string
-		want    time.Duration
-		wantErr bool
-	}{
+	tests := []mqttConnectDeadlineCase{
 		{name: "unset uses default", set: false, want: defaultMQTTConnectDeadline},
 		{name: "valid override", set: true, val: "10s", want: testtime.D10s},
 		{name: "malformed rejected", set: true, val: "notaduration", wantErr: true},
@@ -233,24 +235,30 @@ func TestMQTTConnectDeadline(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.set {
-				t.Setenv(envMQTTConnectDeadline, tc.val)
-			} else {
-				t.Setenv(envMQTTConnectDeadline, "")
-			}
-			got, err := mqttConnectDeadline()
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("mqttConnectDeadline(%q) err = nil, want non-nil", tc.val)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("mqttConnectDeadline(%q) err = %v, want nil", tc.val, err)
-			}
-			if got != tc.want {
-				t.Fatalf("mqttConnectDeadline(%q) = %v, want %v", tc.val, got, tc.want)
-			}
+			assertMQTTConnectDeadline(t, tc)
 		})
+	}
+}
+
+func assertMQTTConnectDeadline(t *testing.T, tc mqttConnectDeadlineCase) {
+	t.Helper()
+
+	if tc.set {
+		t.Setenv(envMQTTConnectDeadline, tc.val)
+	} else {
+		t.Setenv(envMQTTConnectDeadline, "")
+	}
+	got, err := mqttConnectDeadline()
+	if tc.wantErr {
+		if err == nil {
+			t.Fatalf("mqttConnectDeadline(%q) err = nil, want non-nil", tc.val)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("mqttConnectDeadline(%q) err = %v, want nil", tc.val, err)
+	}
+	if got != tc.want {
+		t.Fatalf("mqttConnectDeadline(%q) = %v, want %v", tc.val, got, tc.want)
 	}
 }

--- a/examples/todoorder/cells/ordercell/internal/orderprojection/lifecycle_test.go
+++ b/examples/todoorder/cells/ordercell/internal/orderprojection/lifecycle_test.go
@@ -82,32 +82,33 @@ func eventSpec(id, topic string) contractspec.ContractSpec {
 	return contractspec.ContractSpec{ID: id, Kind: "event", Transport: "amqp", Topic: topic}
 }
 
+type projectionCoordFixture struct {
+	ProjectionID string
+	Store        projection.CheckpointStore
+	Replay       projection.ReplaySource
+	Cursor       projection.Cursor
+	Spec         contractspec.ContractSpec
+	Apply        projection.Apply
+	OnReset      projection.OnReset
+}
+
 // newProjectionCoord builds a Coordinator for one projection over the shared
 // whole-journal replay source and returns it plus its registered live handler.
-func newProjectionCoord(
-	t *testing.T,
-	projectionID string,
-	store projection.CheckpointStore,
-	replay projection.ReplaySource,
-	cursor projection.Cursor,
-	spec contractspec.ContractSpec,
-	apply projection.Apply,
-	onReset projection.OnReset,
-) (*projection.Coordinator, outbox.EntryHandler) {
+func newProjectionCoord(t *testing.T, f projectionCoordFixture) (*projection.Coordinator, outbox.EntryHandler) {
 	t.Helper()
 	reg := &lifecycleRegistrar{}
 	coord, err := projection.NewCoordinator(clock.Real(), projection.CoordinatorConfig{
 		Registrar:    reg,
 		CellID:       "ordercell",
-		ProjectionID: projectionID,
+		ProjectionID: f.ProjectionID,
 		TxRunner:     lifecycleDemoTxRunner{},
-		Store:        store,
-		Cursor:       cursor,
-		Replay:       replay,
+		Store:        f.Store,
+		Cursor:       f.Cursor,
+		Replay:       f.Replay,
 		Tracer:       nopLifecycleTracer{},
 	})
 	require.NoError(t, err)
-	require.NoError(t, coord.Subscribe(context.Background(), spec, apply, projection.WithOnReset(onReset)))
+	require.NoError(t, coord.Subscribe(context.Background(), f.Spec, f.Apply, projection.WithOnReset(f.OnReset)))
 	require.NotNil(t, reg.handler, "coordinator must register an event handler")
 	return coord, reg.handler
 }
@@ -163,15 +164,25 @@ func TestOrderProjection_FanInLifecycle(t *testing.T) {
 	svc, err := orderprojection.NewService()
 	require.NoError(t, err)
 
-	createdCoord, createdHandler := newProjectionCoord(t, "order_status",
-		checkpointStore, replaySource, cursor,
-		eventSpec(topicOrderCreated, topicOrderCreated),
-		svc.HandleOrderCreated, svc.ResetOrderStatus)
+	createdCoord, createdHandler := newProjectionCoord(t, projectionCoordFixture{
+		ProjectionID: "order_status",
+		Store:        checkpointStore,
+		Replay:       replaySource,
+		Cursor:       cursor,
+		Spec:         eventSpec(topicOrderCreated, topicOrderCreated),
+		Apply:        svc.HandleOrderCreated,
+		OnReset:      svc.ResetOrderStatus,
+	})
 
-	transitionCoord, transitionHandler := newProjectionCoord(t, "order_transition",
-		checkpointStore, replaySource, cursor,
-		eventSpec(topicOrderStatusChanged, topicOrderStatusChanged),
-		svc.HandleOrderStatusChanged, svc.ResetOrderTransition)
+	transitionCoord, transitionHandler := newProjectionCoord(t, projectionCoordFixture{
+		ProjectionID: "order_transition",
+		Store:        checkpointStore,
+		Replay:       replaySource,
+		Cursor:       cursor,
+		Spec:         eventSpec(topicOrderStatusChanged, topicOrderStatusChanged),
+		Apply:        svc.HandleOrderStatusChanged,
+		OnReset:      svc.ResetOrderTransition,
+	})
 
 	// -- Phase 1: cold-start live delivery (both streams) --
 	eCreatedA := appendCreated(t, replaySource, "order-A", "pending")

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -70,11 +70,13 @@ type boundaryContext struct {
 
 const (
 	internalAssemblyQuotedFmt = "assembly=%q"
+	internalAssemblyCellFmt   = "assembly=%q cell=%q"
 	internalTemplateQuotedFmt = "template=%q"
 	// msgAssemblyNotFound is the public message for ErrAssemblyNotFound;
 	// shared by GenerateEntrypoint / GenerateBoundary / GenerateModulesGen so
 	// the wire wording stays in one place.
-	msgAssemblyNotFound = "assembly not found"
+	msgAssemblyNotFound    = "assembly not found"
+	msgAssemblyUnknownCell = "assembly references unknown cell"
 )
 
 // GenerateEntrypoint generates the main.go content for an assembly.
@@ -282,8 +284,8 @@ func (g *Generator) collectCapabilityConsts(assemblyID string, cellRefs []metada
 		cm := g.cells.Get(ref.ID)
 		if cm == nil {
 			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
-				"assembly references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
+				msgAssemblyUnknownCell,
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalAssemblyCellFmt, assemblyID, ref.ID))))
 		}
 		for _, c := range cm.Requires {
 			capSet[c] = struct{}{}
@@ -328,13 +330,13 @@ func (g *Generator) generateModulesGenLegacy(
 		cm := g.cells.Get(ref.ID)
 		if cm == nil {
 			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
-				"assembly references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
+				msgAssemblyUnknownCell,
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalAssemblyCellFmt, assemblyID, ref.ID))))
 		}
 		if cm.GoStructName.IsZero() {
 			return nil, errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
 				"cell missing GoStructName for modules_gen factory derivation",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalAssemblyCellFmt, assemblyID, ref.ID))))
 		}
 		modules = append(modules, cm.GoStructName.String()+"Module")
 	}
@@ -386,8 +388,8 @@ func (g *Generator) generateModulesGenComposition(
 		cm := g.cells.Get(ref.ID)
 		if cm == nil {
 			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
-				"assembly references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("assembly=%q cell=%q", assemblyID, ref.ID))))
+				msgAssemblyUnknownCell,
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalAssemblyCellFmt, assemblyID, ref.ID))))
 		}
 		alias := "cellmodules" + ref.ID
 		if !seen[ref.ID] {

--- a/kernel/auth/operator.go
+++ b/kernel/auth/operator.go
@@ -124,7 +124,9 @@ func (AuthOperator) authPlanKind() AuthKind { return AuthKindOperator }
 func (AuthOperator) Describe() string       { return "operator" }
 
 // listenerAuthOK seals the ListenerAuth interface (see AuthNone.listenerAuthOK).
-func (AuthOperator) listenerAuthOK() {}
+func (AuthOperator) listenerAuthOK() {
+	// Marker method only: AuthOperator is an allowed listener auth variant.
+}
 
 // Compile-time assertion.
 var _ ListenerAuth = AuthOperator{}

--- a/kernel/auth/operator_test.go
+++ b/kernel/auth/operator_test.go
@@ -11,19 +11,21 @@ type fakeOperatorLimiter struct{ allow bool }
 
 func (f fakeOperatorLimiter) Allow(string) bool { return f.allow }
 
+type newAuthOperatorCase struct {
+	name     string
+	username []byte
+	password []byte
+	limiter  OperatorRateLimiter
+	onFail   func(context.Context, string)
+	wantErr  bool
+}
+
 func TestNewAuthOperator(t *testing.T) {
 	t.Parallel()
 	lim := fakeOperatorLimiter{allow: true}
 	obs := func(context.Context, string) {}
 
-	cases := []struct {
-		name     string
-		username []byte
-		password []byte
-		limiter  OperatorRateLimiter
-		onFail   func(context.Context, string)
-		wantErr  bool
-	}{
+	cases := []newAuthOperatorCase{
 		{"valid with observer", []byte("ops"), []byte("s3cretpwd"), lim, obs, false},
 		{"valid nil observer ok", []byte("ops"), []byte("s3cretpwd"), lim, nil, false},
 		{"min-length password (8) accepted", []byte("ops"), []byte("8bytespw"), lim, obs, false},
@@ -38,23 +40,29 @@ func TestNewAuthOperator(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := NewAuthOperator(tc.username, tc.password, tc.limiter, tc.onFail)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("NewAuthOperator(%q) = nil error, want error", tc.name)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("NewAuthOperator(%q) unexpected error: %v", tc.name, err)
-			}
-			if !bytes.Equal(got.Username, tc.username) || !bytes.Equal(got.Password, tc.password) {
-				t.Errorf("NewAuthOperator credentials not preserved: got %q/%q", got.Username, got.Password)
-			}
-			if got.Limiter == nil {
-				t.Error("NewAuthOperator limiter not preserved")
-			}
+			assertNewAuthOperator(t, tc)
 		})
+	}
+}
+
+func assertNewAuthOperator(t *testing.T, tc newAuthOperatorCase) {
+	t.Helper()
+
+	got, err := NewAuthOperator(tc.username, tc.password, tc.limiter, tc.onFail)
+	if tc.wantErr {
+		if err == nil {
+			t.Fatalf("NewAuthOperator(%q) = nil error, want error", tc.name)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("NewAuthOperator(%q) unexpected error: %v", tc.name, err)
+	}
+	if !bytes.Equal(got.Username, tc.username) || !bytes.Equal(got.Password, tc.password) {
+		t.Errorf("NewAuthOperator credentials not preserved: got %q/%q", got.Username, got.Password)
+	}
+	if got.Limiter == nil {
+		t.Error("NewAuthOperator limiter not preserved")
 	}
 }
 

--- a/kernel/command/sweeper.go
+++ b/kernel/command/sweeper.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
+const (
+	msgSweeperNilReceiver    = "command.Sweeper: nil receiver; use NewSweeper to construct"
+	msgSweeperNotConstructed = "command.Sweeper must be constructed via NewSweeper"
+)
+
 // ExpiryTransition describes a single status change recommended by SweepOnce.
 type ExpiryTransition struct {
 	CommandID string
@@ -176,11 +181,11 @@ func NewSweeper(scanner ActiveScanner, queue Queue, clk clock.Clock, opts ...Swe
 func (s *Sweeper) Validate() error {
 	if s == nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"command.Sweeper: nil receiver; use NewSweeper to construct")
+			msgSweeperNilReceiver)
 	}
 	if !s.built {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"command.Sweeper must be constructed via NewSweeper")
+			msgSweeperNotConstructed)
 	}
 	if validation.IsNilInterface(s.scanner) {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
@@ -215,11 +220,11 @@ func (s *Sweeper) Validate() error {
 func (s *Sweeper) SweepTick(ctx context.Context, now time.Time) error {
 	if s == nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"command.Sweeper: nil receiver; use NewSweeper to construct")
+			msgSweeperNilReceiver)
 	}
 	if !s.built {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"command.Sweeper must be constructed via NewSweeper")
+			msgSweeperNotConstructed)
 	}
 
 	entries, scanErr := s.scanner.ScanActive(ctx, s.filter)
@@ -258,11 +263,11 @@ func (s *Sweeper) SweepTick(ctx context.Context, now time.Time) error {
 func (s *Sweeper) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	if s == nil {
 		return reconcile.Result{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"command.Sweeper: nil receiver; use NewSweeper to construct")
+			msgSweeperNilReceiver)
 	}
 	if !s.built {
 		return reconcile.Result{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"command.Sweeper must be constructed via NewSweeper")
+			msgSweeperNotConstructed)
 	}
 	if err := s.SweepTick(ctx, s.clk.Now()); err != nil {
 		return reconcile.Result{}, err

--- a/kernel/governance/rules_fmt.go
+++ b/kernel/governance/rules_fmt.go
@@ -379,6 +379,11 @@ var bannedFieldNames = map[string]string{
 	"consumes":          "contractUsages with role subscribe",
 }
 
+const (
+	fieldEndpointsClients = "endpoints.clients"
+	contractMessageFmt    = "contract %q %s"
+)
+
 // validateFMT10 checks that no metadata entity uses banned legacy field names
 // as its ID. This is a heuristic check — it flags cells, slices, contracts,
 // journeys, and assemblies whose ID exactly matches a banned field name.
@@ -900,7 +905,7 @@ func (v *Validator) validateFMT37ForContract(c *metadata.ContractMeta) []Validat
 	// so a nil slice unambiguously means the key was not declared.
 	if c.Endpoints.Clients == nil {
 		results = append(results, v.newError(
-			codeFMT37, IssueRequired, file, "endpoints.clients",
+			codeFMT37, IssueRequired, file, fieldEndpointsClients,
 			fmt.Sprintf("grpc contract %q must declare endpoints.clients (use [] when no cell calls it)", c.ID),
 			"add clients: [] under endpoints (or the list of caller cells/actors)",
 		))
@@ -1364,7 +1369,7 @@ func (v *Validator) validateFMT28() []ValidationResult {
 			results = append(results, v.newError(
 				codeFMT28, IssueRequired,
 				contractFile(c),
-				"endpoints.clients",
+				fieldEndpointsClients,
 				fmt.Sprintf(
 					"contract %q has auth.clientsOnly:true but endpoints.clients is empty; "+
 						"clientsOnly auth requires at least one declared client cell",
@@ -1423,7 +1428,7 @@ func (v *Validator) validateFMT31() []ValidationResult {
 		results = append(results, v.newError(
 			codeFMT31, IssueRequired,
 			contractFile(c),
-			"endpoints.clients",
+			fieldEndpointsClients,
 			fmt.Sprintf(
 				"internal HTTP contract %q (path %q) has empty endpoints.clients; "+
 					"/internal/v1/ contracts must declare at least one caller cell "+
@@ -2000,32 +2005,32 @@ func (v *Validator) validateFMT40ForContract(c *metadata.ContractMeta) []Validat
 		case metadata.HeaderViolationName:
 			results = append(results, v.newError(
 				codeFMT40, fmt40IssueType(viol.Kind), file, field,
-				fmt.Sprintf("contract %q %s", c.ID, viol.Message),
+				fmt.Sprintf(contractMessageFmt, c.ID, viol.Message),
 				"use a canonical header name matching ^[A-Za-z][A-Za-z0-9-]*$ (e.g. X-Tenant-ID)",
 			))
 		case metadata.HeaderViolationType:
 			results = append(results, v.newError(
 				codeFMT40, fmt40IssueType(viol.Kind), file, field,
-				fmt.Sprintf("contract %q %s", c.ID, viol.Message),
+				fmt.Sprintf(contractMessageFmt, c.ID, viol.Message),
 				"declare type: string on the header schema (headers are populate-only; only string can be generated)",
 			))
 		case metadata.HeaderViolationConstraint:
 			results = append(results, v.newError(
 				codeFMT40, fmt40IssueType(viol.Kind), file, field,
-				fmt.Sprintf("contract %q %s", c.ID, viol.Message),
+				fmt.Sprintf(contractMessageFmt, c.ID, viol.Message),
 				"remove the length/numeric constraint and validate the header value in the cell adapter "+
 					"(e.g. tenant.ParseTenantID), which owns the per-endpoint fail behavior",
 			))
 		case metadata.HeaderViolationDuplicate:
 			results = append(results, v.newError(
 				codeFMT40, fmt40IssueType(viol.Kind), file, field,
-				fmt.Sprintf("contract %q %s", c.ID, viol.Message),
+				fmt.Sprintf(contractMessageFmt, c.ID, viol.Message),
 				"declare each HTTP header once (names are case-insensitive); remove the duplicate",
 			))
 		default:
 			results = append(results, v.newError(
 				codeFMT40, fmt40IssueType(viol.Kind), file, field,
-				fmt.Sprintf("contract %q %s", c.ID, viol.Message),
+				fmt.Sprintf(contractMessageFmt, c.ID, viol.Message),
 				"fix the endpoints.http.headers declaration",
 			))
 		}

--- a/kernel/governance/rules_projection_provide_write_test.go
+++ b/kernel/governance/rules_projection_provide_write_test.go
@@ -3,6 +3,7 @@ package governance
 // INVARIANT: PROJECTION-PROVIDE-NEEDS-WRITE-CU-01
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -112,6 +113,18 @@ func buildProjectionProvideProject(
 	}
 }
 
+type projectionProvideNeedsWriteCase struct {
+	name            string
+	projectionID    string
+	contractKind    string
+	subProjection   string
+	missingContract bool
+	missingCell     bool
+	missingProvide  bool
+	wantErrCount    int
+	wantFieldPrefix string
+}
+
 // TestProjectionProvideNeedsWriteCU01 is a table-driven test for
 // validatePROJECTIONPROVIDENEEDSWRITECU01
 // (PROJECTION-PROVIDE-NEEDS-WRITE-CU-01).
@@ -122,17 +135,7 @@ func buildProjectionProvideProject(
 func TestProjectionProvideNeedsWriteCU01(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name            string
-		projectionID    string
-		contractKind    string
-		subProjection   string
-		missingContract bool
-		missingCell     bool
-		missingProvide  bool
-		wantErrCount    int
-		wantFieldPrefix string
-	}{
+	tests := []projectionProvideNeedsWriteCase{
 		{
 			name:            "provide→projection, no write CU → error",
 			projectionID:    "projection.order.status.v1",
@@ -185,52 +188,57 @@ func TestProjectionProvideNeedsWriteCU01(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			project := buildProjectionProvideProject(
-				tc.projectionID,
-				tc.contractKind,
-				tc.subProjection,
-				tc.missingContract,
-				tc.missingCell,
-				tc.missingProvide,
-			)
-
-			v := NewValidator(project, "", clock.Real())
-			results := v.validatePROJECTIONPROVIDENEEDSWRITECU01()
-
-			var got []ValidationResult
-			for _, r := range results {
-				if r.Code == codePROJECTIONPROVIDENEEDSWRITECU01 {
-					got = append(got, r)
-				}
-			}
-
-			if len(got) != tc.wantErrCount {
-				t.Fatalf("expected %d result(s) with code %s, got %d: %v",
-					tc.wantErrCount, codePROJECTIONPROVIDENEEDSWRITECU01, len(got), got)
-			}
-			if tc.wantErrCount == 0 {
-				return
-			}
-			r := got[0]
-			if r.Severity != SeverityError {
-				t.Errorf("expected SeverityError, got %s", r.Severity)
-			}
-			if tc.wantFieldPrefix != "" {
-				// Field should start with contractUsages[N].role
-				if len(r.Field) < len(tc.wantFieldPrefix) {
-					t.Errorf("expected field with prefix %q, got %q", tc.wantFieldPrefix, r.Field)
-				}
-				for i := range tc.wantFieldPrefix {
-					if r.Field[i] != tc.wantFieldPrefix[i] {
-						t.Errorf("expected field with prefix %q, got %q", tc.wantFieldPrefix, r.Field)
-						break
-					}
-				}
-			}
-			if r.Fix == "" {
-				t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
-			}
+			assertProjectionProvideNeedsWrite(t, tc)
 		})
+	}
+}
+
+func assertProjectionProvideNeedsWrite(t *testing.T, tc projectionProvideNeedsWriteCase) {
+	t.Helper()
+
+	project := buildProjectionProvideProject(
+		tc.projectionID,
+		tc.contractKind,
+		tc.subProjection,
+		tc.missingContract,
+		tc.missingCell,
+		tc.missingProvide,
+	)
+
+	v := NewValidator(project, "", clock.Real())
+	results := v.validatePROJECTIONPROVIDENEEDSWRITECU01()
+
+	got := projectionProvideNeedsWriteResults(results)
+	if len(got) != tc.wantErrCount {
+		t.Fatalf("expected %d result(s) with code %s, got %d: %v",
+			tc.wantErrCount, codePROJECTIONPROVIDENEEDSWRITECU01, len(got), got)
+	}
+	if tc.wantErrCount == 0 {
+		return
+	}
+	assertProjectionProvideFinding(t, got[0], tc)
+}
+
+func projectionProvideNeedsWriteResults(results []ValidationResult) []ValidationResult {
+	var got []ValidationResult
+	for _, r := range results {
+		if r.Code == codePROJECTIONPROVIDENEEDSWRITECU01 {
+			got = append(got, r)
+		}
+	}
+	return got
+}
+
+func assertProjectionProvideFinding(t *testing.T, r ValidationResult, tc projectionProvideNeedsWriteCase) {
+	t.Helper()
+
+	if r.Severity != SeverityError {
+		t.Errorf("expected SeverityError, got %s", r.Severity)
+	}
+	if tc.wantFieldPrefix != "" && !strings.HasPrefix(r.Field, tc.wantFieldPrefix) {
+		t.Errorf("expected field with prefix %q, got %q", tc.wantFieldPrefix, r.Field)
+	}
+	if r.Fix == "" {
+		t.Error("error finding must carry non-empty Fix guidance (typed-Fix contract)")
 	}
 }

--- a/kernel/metadata/contract_constraints_test.go
+++ b/kernel/metadata/contract_constraints_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
 
+type grpcServiceGoNameCase struct {
+	name     string
+	service  string
+	wantName string
+	wantErr  string // substring; "" = expect nil error
+}
+
 // TestMatchCellID covers the CellIDPattern regex semantics (^[a-z][a-z0-9]{1,31}$):
 // lowercase ASCII letters + digits only, 2-32 chars, must start with a letter.
 // Identical to AssemblyIDPattern by design — the no-dash convention enforced
@@ -258,12 +265,7 @@ func TestValidateGRPCProtoPath(t *testing.T) {
 func TestGRPCServiceGoName(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name     string
-		service  string
-		wantName string
-		wantErr  string // substring; "" = expect nil error
-	}{
+	cases := []grpcServiceGoNameCase{
 		// Valid — exported Go identifiers.
 		{
 			name:     "FQN exported service",
@@ -317,23 +319,29 @@ func TestGRPCServiceGoName(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := metadata.GRPCServiceGoName(tc.service)
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("GRPCServiceGoName(%q) = %v, want nil", tc.service, err)
-				}
-				if got != tc.wantName {
-					t.Fatalf("GRPCServiceGoName(%q) = %q, want %q", tc.service, got, tc.wantName)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("GRPCServiceGoName(%q) = %q, want error containing %q", tc.service, got, tc.wantErr)
-			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("GRPCServiceGoName(%q) error = %q, want substring %q", tc.service, err.Error(), tc.wantErr)
-			}
+			assertGRPCServiceGoName(t, tc)
 		})
+	}
+}
+
+func assertGRPCServiceGoName(t *testing.T, tc grpcServiceGoNameCase) {
+	t.Helper()
+
+	got, err := metadata.GRPCServiceGoName(tc.service)
+	if tc.wantErr == "" {
+		if err != nil {
+			t.Fatalf("GRPCServiceGoName(%q) = %v, want nil", tc.service, err)
+		}
+		if got != tc.wantName {
+			t.Fatalf("GRPCServiceGoName(%q) = %q, want %q", tc.service, got, tc.wantName)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("GRPCServiceGoName(%q) = %q, want error containing %q", tc.service, got, tc.wantErr)
+	}
+	if !strings.Contains(err.Error(), tc.wantErr) {
+		t.Fatalf("GRPCServiceGoName(%q) error = %q, want substring %q", tc.service, err.Error(), tc.wantErr)
 	}
 }
 

--- a/kernel/metadata/locator_equivalence_test.go
+++ b/kernel/metadata/locator_equivalence_test.go
@@ -75,6 +75,22 @@ func TestLocator_RealTreeConventionalManifestEquivalence(t *testing.T) {
 	conv := summariseSources(convSrc)
 	man := summariseSources(manSrc)
 
+	assertConventionalDiscoveryNonVacuous(t, conv, convSrc)
+
+	if !reflect.DeepEqual(conv, man) {
+		onlyConv := difference(conv, man)
+		onlyMan := difference(man, conv)
+		t.Errorf("conventional vs manifest discovery diverge — the committed "+
+			".gocell/manifest.yaml must mirror conventional scope.\n"+
+			"only in conventional (manifest dropped these): %v\n"+
+			"only in manifest (manifest added these): %v",
+			onlyConv, onlyMan)
+	}
+}
+
+func assertConventionalDiscoveryNonVacuous(t *testing.T, conv []string, convSrc []MetadataSource) {
+	t.Helper()
+
 	// Anti-vacuity: the comparison only proves something if conventional mode
 	// actually discovered sources, including the examples/ subtree that a
 	// minimal manifest would drop. Without this, two empty slices would pass.
@@ -85,6 +101,12 @@ func TestLocator_RealTreeConventionalManifestEquivalence(t *testing.T) {
 		t.Fatal("vacuous guard: conventional mode discovered no examples/ source; " +
 			"the equivalence assertion would not catch a manifest that drops the examples subtree")
 	}
+	assertExamplesCellsHaveIDs(t, convSrc)
+}
+
+func assertExamplesCellsHaveIDs(t *testing.T, convSrc []MetadataSource) {
+	t.Helper()
+
 	// CellID-dimension anti-vacuity: summariseSources compares "kind:path:cellID",
 	// so the DeepEqual would still pass if BOTH modes derived an empty CellID for
 	// examples cells. Assert at least one examples/ SourceCell carries a non-empty
@@ -103,16 +125,6 @@ func TestLocator_RealTreeConventionalManifestEquivalence(t *testing.T) {
 	if !examplesCellWithID {
 		t.Fatal("anti-vacuity: no examples/ SourceCell with a non-empty CellID; " +
 			"CellID-dimension equivalence is not proven")
-	}
-
-	if !reflect.DeepEqual(conv, man) {
-		onlyConv := difference(conv, man)
-		onlyMan := difference(man, conv)
-		t.Errorf("conventional vs manifest discovery diverge — the committed "+
-			".gocell/manifest.yaml must mirror conventional scope.\n"+
-			"only in conventional (manifest dropped these): %v\n"+
-			"only in manifest (manifest added these): %v",
-			onlyConv, onlyMan)
 	}
 }
 

--- a/kernel/metadata/locator_manifest_modulepaths_test.go
+++ b/kernel/metadata/locator_manifest_modulepaths_test.go
@@ -86,52 +86,70 @@ func TestReadManifestModulePaths(t *testing.T) {
 // escaping the root ("path escapes from parent" at the syscall layer).
 func TestReadManifestModulePathsRoot(t *testing.T) {
 	t.Run("normal on-disk layout returns module paths in declaration order", func(t *testing.T) {
-		root := t.TempDir()
-		writeFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
-			"version: v1\nmodules:\n  - path: .\n  - path: sub\n")
-		// modules[1].path "sub" must exist and be a directory (validateManifestModuleDir).
-		writeFile(t, filepath.Join(root, "sub", "cells", "x", "cell.yaml"),
-			cellYAML("x", "team", "x.primary"))
-
-		got, err := ReadManifestModulePathsRoot(root, DefaultManifestPath)
-		if err != nil {
-			t.Fatalf("ReadManifestModulePathsRoot: %v", err)
-		}
-		if want := []string{".", "sub"}; !reflect.DeepEqual(got, want) {
-			t.Fatalf("ReadManifestModulePathsRoot = %v, want %v", got, want)
-		}
+		assertReadManifestModulePathsRootNormal(t)
 	})
 
 	t.Run("open-root error on missing root fails closed", func(t *testing.T) {
-		missing := filepath.Join(t.TempDir(), "does", "not", "exist")
-		_, err := ReadManifestModulePathsRoot(missing, DefaultManifestPath)
-		if err == nil {
-			t.Fatalf("ReadManifestModulePathsRoot(%q) = nil error; want open-root failure", missing)
-		}
-		if !strings.Contains(err.Error(), "open root") {
-			t.Fatalf("error = %q, want substring %q", err.Error(), "open root")
-		}
+		assertReadManifestModulePathsRootMissing(t)
 	})
 
 	t.Run("symlinked manifest escaping root fails closed", func(t *testing.T) {
-		root := t.TempDir()
-		external := t.TempDir() // OUTSIDE root
-		writeFile(t, filepath.Join(external, "manifest.yaml"),
-			"version: v1\nmodules:\n  - path: .\n")
-		if err := os.MkdirAll(filepath.Join(root, ".gocell"), 0o755); err != nil {
-			t.Fatalf("MkdirAll .gocell: %v", err)
-		}
-		// root/.gocell/manifest.yaml -> external/manifest.yaml (escapes root).
-		if err := os.Symlink(filepath.Join(external, "manifest.yaml"),
-			filepath.Join(root, ".gocell", "manifest.yaml")); err != nil {
-			t.Skipf("symlink unsupported on this platform: %v", err)
-		}
-		_, err := ReadManifestModulePathsRoot(root, DefaultManifestPath)
-		if err == nil {
-			t.Fatalf("ReadManifestModulePathsRoot = nil error; want fail-closed (manifest symlink escapes root)")
-		}
-		if !strings.Contains(err.Error(), "escapes") {
-			t.Fatalf("error = %q, want root-confinement signal %q", err.Error(), "escapes")
-		}
+		assertReadManifestModulePathsRootSymlinkEscape(t)
 	})
+}
+
+func assertReadManifestModulePathsRootNormal(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".gocell", "manifest.yaml"),
+		"version: v1\nmodules:\n  - path: .\n  - path: sub\n")
+	// modules[1].path "sub" must exist and be a directory (validateManifestModuleDir).
+	writeFile(t, filepath.Join(root, "sub", "cells", "x", "cell.yaml"),
+		cellYAML("x", "team", "x.primary"))
+
+	got, err := ReadManifestModulePathsRoot(root, DefaultManifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestModulePathsRoot: %v", err)
+	}
+	if want := []string{".", "sub"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReadManifestModulePathsRoot = %v, want %v", got, want)
+	}
+}
+
+func assertReadManifestModulePathsRootMissing(t *testing.T) {
+	t.Helper()
+
+	missing := filepath.Join(t.TempDir(), "does", "not", "exist")
+	_, err := ReadManifestModulePathsRoot(missing, DefaultManifestPath)
+	if err == nil {
+		t.Fatalf("ReadManifestModulePathsRoot(%q) = nil error; want open-root failure", missing)
+	}
+	if !strings.Contains(err.Error(), "open root") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "open root")
+	}
+}
+
+func assertReadManifestModulePathsRootSymlinkEscape(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	external := t.TempDir() // OUTSIDE root
+	writeFile(t, filepath.Join(external, "manifest.yaml"),
+		"version: v1\nmodules:\n  - path: .\n")
+	if err := os.MkdirAll(filepath.Join(root, ".gocell"), 0o755); err != nil {
+		t.Fatalf("MkdirAll .gocell: %v", err)
+	}
+	// root/.gocell/manifest.yaml -> external/manifest.yaml (escapes root).
+	if err := os.Symlink(filepath.Join(external, "manifest.yaml"),
+		filepath.Join(root, ".gocell", "manifest.yaml")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	_, err := ReadManifestModulePathsRoot(root, DefaultManifestPath)
+	if err == nil {
+		t.Fatalf("ReadManifestModulePathsRoot = nil error; want fail-closed (manifest symlink escapes root)")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("error = %q, want root-confinement signal %q", err.Error(), "escapes")
+	}
 }

--- a/kernel/projection/mem_owner_checkpoint_test.go
+++ b/kernel/projection/mem_owner_checkpoint_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/ghbvf/gocell/kernel/projection/projectiontest"
 )
 
+type ownerCheckpointFencingCase struct {
+	name        string
+	seedToken   string // "" = cold (no prior advance)
+	seedOffset  int64
+	token       string
+	offset      int64
+	wantErr     bool // true => expect ErrStaleOwner
+	wantOffset  int64
+	wantOwnerOK bool // after the call, token should be able to advance forward
+}
+
 // TestMemOwnerCheckpointStore_CheckpointConformance enrolls MemOwnerCheckpointStore
 // in the base CheckpointStore conformance suite (it implements CheckpointStore via
 // LoadOffset + SaveOffset). Required by PROJECTION-CHECKPOINT-CONFORMANCE-ENROLL-01.
@@ -28,16 +39,7 @@ func TestMemOwnerCheckpointStore_OwnerConformance(t *testing.T) {
 // otherwise ErrStaleOwner), beyond what the shared conformance covers.
 func TestMemOwnerCheckpointStore_FencingTruthTable(t *testing.T) {
 	const tokA, tokB = "tok-a", "tok-b"
-	tests := []struct {
-		name        string
-		seedToken   string // "" = cold (no prior advance)
-		seedOffset  int64
-		token       string
-		offset      int64
-		wantErr     bool // true => expect ErrStaleOwner
-		wantOffset  int64
-		wantOwnerOK bool // after the call, token should be able to advance forward
-	}{
+	tests := []ownerCheckpointFencingCase{
 		{name: "cold claim ahead", seedToken: "", token: tokA, offset: 5, wantOffset: 5, wantOwnerOK: true},
 		{name: "same owner forward", seedToken: tokA, seedOffset: 5, token: tokA, offset: 9, wantOffset: 9, wantOwnerOK: true},
 		{name: "same owner idempotent same offset", seedToken: tokA, seedOffset: 9, token: tokA, offset: 9, wantOffset: 9, wantOwnerOK: true},
@@ -48,29 +50,35 @@ func TestMemOwnerCheckpointStore_FencingTruthTable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := projection.NewMemOwnerCheckpointStore()
-			ctx := context.Background()
-			const cell, proj = "c", "p"
-			if tt.seedToken != "" {
-				if err := store.AdvanceIfOwner(ctx, cell, proj, tt.seedToken, tt.seedOffset); err != nil {
-					t.Fatalf("seed AdvanceIfOwner(%s, %d): %v", tt.seedToken, tt.seedOffset, err)
-				}
-			}
-			err := store.AdvanceIfOwner(ctx, cell, proj, tt.token, tt.offset)
-			switch {
-			case tt.wantErr && !errors.Is(err, projection.ErrStaleOwner):
-				t.Fatalf("AdvanceIfOwner = %v, want ErrStaleOwner", err)
-			case !tt.wantErr && err != nil:
-				t.Fatalf("AdvanceIfOwner = %v, want nil", err)
-			}
-			got, err := store.LoadOffset(ctx, cell, proj)
-			if err != nil {
-				t.Fatalf("LoadOffset: %v", err)
-			}
-			if got != tt.wantOffset {
-				t.Errorf("LoadOffset = %d, want %d", got, tt.wantOffset)
-			}
+			assertOwnerCheckpointFencing(t, tt)
 		})
+	}
+}
+
+func assertOwnerCheckpointFencing(t *testing.T, tt ownerCheckpointFencingCase) {
+	t.Helper()
+
+	store := projection.NewMemOwnerCheckpointStore()
+	ctx := context.Background()
+	const cell, proj = "c", "p"
+	if tt.seedToken != "" {
+		if err := store.AdvanceIfOwner(ctx, cell, proj, tt.seedToken, tt.seedOffset); err != nil {
+			t.Fatalf("seed AdvanceIfOwner(%s, %d): %v", tt.seedToken, tt.seedOffset, err)
+		}
+	}
+	err := store.AdvanceIfOwner(ctx, cell, proj, tt.token, tt.offset)
+	switch {
+	case tt.wantErr && !errors.Is(err, projection.ErrStaleOwner):
+		t.Fatalf("AdvanceIfOwner = %v, want ErrStaleOwner", err)
+	case !tt.wantErr && err != nil:
+		t.Fatalf("AdvanceIfOwner = %v, want nil", err)
+	}
+	got, err := store.LoadOffset(ctx, cell, proj)
+	if err != nil {
+		t.Fatalf("LoadOffset: %v", err)
+	}
+	if got != tt.wantOffset {
+		t.Errorf("LoadOffset = %d, want %d", got, tt.wantOffset)
 	}
 }
 

--- a/kernel/projection/memcursor_test.go
+++ b/kernel/projection/memcursor_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 )
 
+type memCursorCase struct {
+	name       string
+	entry      ProjectionEvent
+	wantPos    int64
+	wantPerm   bool // expect a *outbox.PermanentError
+	wantErrNil bool // expect nil error
+	// Note: wantPerm=false && !wantErrNil is structurally unreachable for
+	// MemCursor: an absent entry always returns a *outbox.PermanentError,
+	// so every non-nil error case has wantPerm=true. The field is kept
+	// for future implementations that may return non-permanent errors.
+}
+
 // TestMemCursor verifies MemCursor.Position behavior:
 //
 //	(a) entry present in the paired source → returns 1-based position, nil error
@@ -34,17 +46,7 @@ func TestMemCursor(t *testing.T) {
 		t.Fatalf("NewMemCursor() error = %v, want nil", err)
 	}
 
-	tests := []struct {
-		name       string
-		entry      ProjectionEvent
-		wantPos    int64
-		wantPerm   bool // expect a *outbox.PermanentError
-		wantErrNil bool // expect nil error
-		// Note: wantPerm=false && !wantErrNil is structurally unreachable for
-		// MemCursor: an absent entry always returns a *outbox.PermanentError,
-		// so every non-nil error case has wantPerm=true. The field is kept
-		// for future implementations that may return non-permanent errors.
-	}{
+	tests := []memCursorCase{
 		{
 			name:       "first entry returns position 1",
 			entry:      e1,
@@ -69,26 +71,32 @@ func TestMemCursor(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			pos, err := cur.Position(tc.entry)
-			if pos != tc.wantPos {
-				t.Errorf("Position() pos = %d, want %d", pos, tc.wantPos)
-			}
-			if tc.wantErrNil {
-				if err != nil {
-					t.Errorf("Position() error = %v, want nil", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatal("Position() error = nil, want non-nil")
-			}
-			if tc.wantPerm {
-				var pe *outbox.PermanentError
-				if !errors.As(err, &pe) {
-					t.Errorf("Position() error %v is not a *outbox.PermanentError", err)
-				}
-			}
+			assertMemCursorPosition(t, cur, tc)
 		})
+	}
+}
+
+func assertMemCursorPosition(t *testing.T, cur *MemCursor, tc memCursorCase) {
+	t.Helper()
+
+	pos, err := cur.Position(tc.entry)
+	if pos != tc.wantPos {
+		t.Errorf("Position() pos = %d, want %d", pos, tc.wantPos)
+	}
+	if tc.wantErrNil {
+		if err != nil {
+			t.Errorf("Position() error = %v, want nil", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatal("Position() error = nil, want non-nil")
+	}
+	if tc.wantPerm {
+		var pe *outbox.PermanentError
+		if !errors.As(err, &pe) {
+			t.Errorf("Position() error %v is not a *outbox.PermanentError", err)
+		}
 	}
 }
 

--- a/kernel/projection/projectiontest/conformance.go
+++ b/kernel/projection/projectiontest/conformance.go
@@ -43,6 +43,7 @@ import (
 const (
 	testIsoCellA = "cellA-iso"
 	testIsoProj1 = "p1-iso"
+	headErrFmt   = "Head: %v"
 
 	testBackCell     = "cell-back"
 	testBackProj     = "proj-back"
@@ -260,12 +261,12 @@ func checkReplayHeadAccounting(t *testing.T, src projection.ReplaySource, seed f
 	t.Helper()
 	before, err := src.Head(context.Background())
 	if err != nil {
-		t.Fatalf("Head: %v", err)
+		t.Fatalf(headErrFmt, err)
 	}
 	seed(3)
 	after, err := src.Head(context.Background())
 	if err != nil {
-		t.Fatalf("Head: %v", err)
+		t.Fatalf(headErrFmt, err)
 	}
 	if after < before+3 {
 		t.Errorf("Head = %d after seeding 3 (was %d), want >= %d", after, before, before+3)
@@ -278,7 +279,7 @@ func checkReplayDeliversInOrder(t *testing.T, src projection.ReplaySource, seed 
 	t.Helper()
 	before, err := src.Head(context.Background())
 	if err != nil {
-		t.Fatalf("Head: %v", err)
+		t.Fatalf(headErrFmt, err)
 	}
 	want := idsOf(seed(4))
 	got := collectReplayIDs(t, src, before)
@@ -294,7 +295,7 @@ func checkReplayFromOffsetSkips(t *testing.T, src projection.ReplaySource, seed 
 	firstIDs := toSet(idsOf(seed(2)))
 	mid, err := src.Head(context.Background())
 	if err != nil {
-		t.Fatalf("Head: %v", err)
+		t.Fatalf(headErrFmt, err)
 	}
 	second := idsOf(seed(2))
 	got := collectReplayIDs(t, src, mid)
@@ -312,7 +313,7 @@ func checkReplayStable(t *testing.T, src projection.ReplaySource, seed func(n in
 	t.Helper()
 	before, err := src.Head(context.Background())
 	if err != nil {
-		t.Fatalf("Head: %v", err)
+		t.Fatalf(headErrFmt, err)
 	}
 	want := idsOf(seed(3))
 	first := collectReplayIDs(t, src, before)

--- a/kernel/projection/rebuild_test.go
+++ b/kernel/projection/rebuild_test.go
@@ -290,14 +290,7 @@ func TestAdvanceOffsetPastForeign_ErrorBranches(t *testing.T) {
 	clk := clockmock.New(time.Now())
 	entry := mustNewTestEntry(t, clk, "other.stream.v1")
 
-	tests := []struct {
-		name      string
-		store     CheckpointStore
-		cursor    Cursor
-		wantErr   bool
-		wantPerm  bool
-		errSubstr string
-	}{
+	tests := []advanceOffsetPastForeignCase{
 		{
 			name:      "LoadOffset error",
 			store:     &seededStore{offsets: map[string]int64{}, loadErr: errors.New("load boom")},
@@ -339,29 +332,44 @@ func TestAdvanceOffsetPastForeign_ErrorBranches(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			c := newCoordinatorFull(t, coordinatorFullParams{
-				clk: clk, store: tc.store, cursor: tc.cursor, replay: NewMemReplaySource(),
-			})
-			err := c.advanceOffsetPastForeign(context.Background(), entry)
-			if !tc.wantErr {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("expected error, got nil")
-			}
-			if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
-				t.Errorf("error = %q, want substring %q", err.Error(), tc.errSubstr)
-			}
-			if tc.wantPerm {
-				var pe *outbox.PermanentError
-				if !errors.As(err, &pe) {
-					t.Errorf("expected *outbox.PermanentError, got %T", err)
-				}
-			}
+			assertAdvanceOffsetPastForeign(t, clk, entry, tc)
 		})
+	}
+}
+
+type advanceOffsetPastForeignCase struct {
+	name      string
+	store     CheckpointStore
+	cursor    Cursor
+	wantErr   bool
+	wantPerm  bool
+	errSubstr string
+}
+
+func assertAdvanceOffsetPastForeign(t *testing.T, clk *clockmock.FakeClock, entry ProjectionEvent, tc advanceOffsetPastForeignCase) {
+	t.Helper()
+
+	c := newCoordinatorFull(t, coordinatorFullParams{
+		clk: clk, store: tc.store, cursor: tc.cursor, replay: NewMemReplaySource(),
+	})
+	err := c.advanceOffsetPastForeign(context.Background(), entry)
+	if !tc.wantErr {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+		t.Errorf("error = %q, want substring %q", err.Error(), tc.errSubstr)
+	}
+	if tc.wantPerm {
+		var pe *outbox.PermanentError
+		if !errors.As(err, &pe) {
+			t.Errorf("expected *outbox.PermanentError, got %T", err)
+		}
 	}
 }
 

--- a/kernel/projection/snapshot_test.go
+++ b/kernel/projection/snapshot_test.go
@@ -14,6 +14,15 @@ import (
 // TEST-TIME-LITERAL-01.
 const snapshotTestLagOffset = 10 * time.Second
 
+type snapshotValueCase struct {
+	name         string
+	headEntries  int   // number of replay entries (= head)
+	checkpoint   int64 // stored offset
+	lastAppliedT bool  // when true, lastApplied = now-lagOffset; else 0 (startup grace)
+	wantPending  int64
+	wantLagSecs  float64
+}
+
 // TestCoordinator_Snapshot_Values exercises the value cases of Coordinator.Snapshot:
 // the Phase is always reported, and PendingEvents / ReplayLagSeconds are derived
 // from the replay head, checkpoint, and last-applied domain time via the shared
@@ -21,14 +30,7 @@ const snapshotTestLagOffset = 10 * time.Second
 func TestCoordinator_Snapshot_Values(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name         string
-		headEntries  int   // number of replay entries (= head)
-		checkpoint   int64 // stored offset
-		lastAppliedT bool  // when true, lastApplied = now-lagOffset; else 0 (startup grace)
-		wantPending  int64
-		wantLagSecs  float64
-	}{
+	cases := []snapshotValueCase{
 		{name: "live empty", headEntries: 0, checkpoint: 0, lastAppliedT: false, wantPending: 0, wantLagSecs: 0},
 		{
 			name: "pending with recent apply", headEntries: 2, checkpoint: 0,
@@ -43,38 +45,44 @@ func TestCoordinator_Snapshot_Values(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			now := time.Now()
-			clk := clockmock.New(now)
-			entryClk := clockmock.New(now)
-			src := NewMemReplaySource()
-			for i := 0; i < tc.headEntries; i++ {
-				src.Append(mustNewTestEntry(t, entryClk, "topic.v1"))
-			}
-			store := NewMemCheckpointStore()
-			if tc.checkpoint > 0 {
-				if err := store.SaveOffset(context.Background(), "testcell", "p1", tc.checkpoint); err != nil {
-					t.Fatalf("SaveOffset: %v", err)
-				}
-			}
-			c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, store: store, replay: src})
-			if tc.lastAppliedT {
-				c.lastAppliedUnixNano.Store(now.Add(-snapshotTestLagOffset).UnixNano())
-			}
-
-			snap, err := c.Snapshot(context.Background())
-			if err != nil {
-				t.Fatalf("Snapshot: unexpected error: %v", err)
-			}
-			if snap.Phase != PhaseLive {
-				t.Errorf("Phase = %v, want PhaseLive", snap.Phase)
-			}
-			if snap.PendingEvents != tc.wantPending {
-				t.Errorf("PendingEvents = %d, want %d", snap.PendingEvents, tc.wantPending)
-			}
-			if snap.ReplayLagSeconds != tc.wantLagSecs {
-				t.Errorf("ReplayLagSeconds = %v, want %v", snap.ReplayLagSeconds, tc.wantLagSecs)
-			}
+			assertSnapshotValue(t, tc)
 		})
+	}
+}
+
+func assertSnapshotValue(t *testing.T, tc snapshotValueCase) {
+	t.Helper()
+
+	now := time.Now()
+	clk := clockmock.New(now)
+	entryClk := clockmock.New(now)
+	src := NewMemReplaySource()
+	for i := 0; i < tc.headEntries; i++ {
+		src.Append(mustNewTestEntry(t, entryClk, "topic.v1"))
+	}
+	store := NewMemCheckpointStore()
+	if tc.checkpoint > 0 {
+		if err := store.SaveOffset(context.Background(), "testcell", "p1", tc.checkpoint); err != nil {
+			t.Fatalf("SaveOffset: %v", err)
+		}
+	}
+	c := newCoordinatorFull(t, coordinatorFullParams{clk: clk, store: store, replay: src})
+	if tc.lastAppliedT {
+		c.lastAppliedUnixNano.Store(now.Add(-snapshotTestLagOffset).UnixNano())
+	}
+
+	snap, err := c.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: unexpected error: %v", err)
+	}
+	if snap.Phase != PhaseLive {
+		t.Errorf("Phase = %v, want PhaseLive", snap.Phase)
+	}
+	if snap.PendingEvents != tc.wantPending {
+		t.Errorf("PendingEvents = %d, want %d", snap.PendingEvents, tc.wantPending)
+	}
+	if snap.ReplayLagSeconds != tc.wantLagSecs {
+		t.Errorf("ReplayLagSeconds = %v, want %v", snap.ReplayLagSeconds, tc.wantLagSecs)
 	}
 }
 

--- a/kernel/reconcile/loop.go
+++ b/kernel/reconcile/loop.go
@@ -868,14 +868,27 @@ func (l *Loop) runWorker(
 	cancelCh chan<- string,
 	backoff *entityBackoff,
 ) {
+	dispatcher := reconcileDispatcher{
+		loop:     l,
+		addCh:    addCh,
+		cancelCh: cancelCh,
+		backoff:  backoff,
+	}
 	for {
 		select {
 		case <-runCtx.Done():
 			return
 		case req := <-queue:
-			l.process(runCtx, req, addCh, cancelCh, backoff)
+			l.process(runCtx, req, dispatcher)
 		}
 	}
+}
+
+type reconcileDispatcher struct {
+	loop     *Loop
+	addCh    chan<- waitingItem
+	cancelCh chan<- string
+	backoff  *entityBackoff
 }
 
 // process reconciles one Request: it serializes per EntityID (F5: dirty/processing
@@ -897,7 +910,7 @@ func (l *Loop) runWorker(
 //
 // Scope note (ADR §2.2): F5+F6 are the PR-A5 features that complete the
 // controller-runtime dirty/processing + rate-limited delaying queue equivalence.
-func (l *Loop) process(runCtx context.Context, req Request, addCh chan<- waitingItem, cancelCh chan<- string, backoff *entityBackoff) {
+func (l *Loop) process(runCtx context.Context, req Request, dispatcher reconcileDispatcher) {
 	// F5: check/set processing under entityMu.
 	l.entityMu.Lock()
 	if l.processing[req.EntityID] {
@@ -935,7 +948,7 @@ func (l *Loop) process(runCtx context.Context, req Request, addCh chan<- waiting
 	label := classify(err)
 	l.metrics.recordResult(runCtx, l.reconcilerID, label)
 
-	l.dispatchResult(runCtx, req, res, err, label, addCh, cancelCh, backoff)
+	dispatcher.dispatch(runCtx, req, res, err, label)
 
 	// F5: clear processing and check dirty under entityMu.
 	l.entityMu.Lock()
@@ -948,7 +961,7 @@ func (l *Loop) process(runCtx context.Context, req Request, addCh chan<- waiting
 		// Re-enqueue the coalesced dirty trigger immediately (delay=0).
 		// This is a fresh convergence run, not a backoff retry.
 		//
-		// dispatchResult already enqueued the normal success/transient requeue
+		// dispatcher.dispatch already enqueued the normal success/transient requeue
 		// above (at the Interval or backoff delay). addOrMergeWaiting MERGES this
 		// delay=0 re-run with that later entry for the same entity (earlier
 		// readyAt wins), so the entity ends up with ONE heap entry that fires
@@ -956,28 +969,20 @@ func (l *Loop) process(runCtx context.Context, req Request, addCh chan<- waiting
 		// without leaving a duplicate pending item.
 		//
 		// Suppressed on resultPermanent: a permanent dead-letter must NOT be
-		// re-reconciled. The dispatchResult permanent branch already canceled the
+		// re-reconciled. The dispatcher.dispatch permanent branch already canceled the
 		// entity's pending item (cancelCh); re-running the in-flight dirty trigger
 		// here would resurrect it and race the cancel across two channels. A fresh
 		// Source trigger re-observes the entity if the consumer resets its state.
-		l.enqueueDelayed(runCtx, dirtyReq, 0, addCh)
+		l.enqueueDelayed(runCtx, dirtyReq, 0, dispatcher.addCh)
 	}
 }
 
-// dispatchResult routes the reconcile outcome to the appropriate requeue action.
-func (l *Loop) dispatchResult(
-	runCtx context.Context,
-	req Request,
-	res Result,
-	err error,
-	label resultLabel,
-	addCh chan<- waitingItem,
-	cancelCh chan<- string,
-	backoff *entityBackoff,
-) {
+// dispatch routes the reconcile outcome to the appropriate requeue action.
+func (d reconcileDispatcher) dispatch(runCtx context.Context, req Request, res Result, err error, label resultLabel) {
+	l := d.loop
 	switch label {
 	case resultSuccess:
-		backoff.Forget(req.EntityID)
+		d.backoff.Forget(req.EntityID)
 		delay := res.normalizedRequeueAfter()
 		if delay <= 0 {
 			if l.noDefaultRequeue {
@@ -990,14 +995,14 @@ func (l *Loop) dispatchResult(
 			}
 			delay = l.interval
 		}
-		l.enqueueDelayed(runCtx, req, delay, addCh)
+		l.enqueueDelayed(runCtx, req, delay, d.addCh)
 	case resultPermanent:
-		backoff.Forget(req.EntityID)
+		d.backoff.Forget(req.EntityID)
 		// Cancel any pending requeue for this entity: an earlier success/transient
 		// may have enqueued a (possibly long) interval/backoff item that, left in
 		// place, would re-reconcile a now-dead-lettered entity once it fires. A
 		// fresh source trigger re-observes it if the consumer resets its state.
-		l.enqueueCancel(runCtx, req.EntityID, cancelCh)
+		l.enqueueCancel(runCtx, req.EntityID, d.cancelCh)
 		// ErrFencedWriteStale is an expected fencing race (this replica is no longer
 		// the epoch owner); log at Warn, not Error, to avoid false-alarm alerting.
 		// All other permanent errors are real dead-letters and warrant Error level.
@@ -1014,14 +1019,14 @@ func (l *Loop) dispatchResult(
 				slog.Any("error", redaction.RedactError(err)))
 		}
 	default: // resultTransient (including recovered panics)
-		delay := backoff.When(req.EntityID)
+		delay := d.backoff.When(req.EntityID)
 		l.logger.Warn("reconcile: transient error (requeued with backoff)",
 			slog.String("loop", l.name),
 			slog.String("reconciler", l.reconcilerID),
 			slog.String("entity", req.EntityID),
 			slog.Duration("backoff_delay", delay),
 			slog.Any("error", redaction.RedactError(err)))
-		l.enqueueDelayed(runCtx, req, delay, addCh)
+		l.enqueueDelayed(runCtx, req, delay, d.addCh)
 	}
 }
 

--- a/kernel/reconcile/loop_test.go
+++ b/kernel/reconcile/loop_test.go
@@ -31,6 +31,20 @@ func (f funcReconciler) Reconcile(ctx context.Context, req Request) (Result, err
 	return f(ctx, req)
 }
 
+func testReconcileDispatcher(
+	l *Loop,
+	addCh chan<- waitingItem,
+	cancelCh chan<- string,
+	backoff *entityBackoff,
+) reconcileDispatcher {
+	return reconcileDispatcher{
+		loop:     l,
+		addCh:    addCh,
+		cancelCh: cancelCh,
+		backoff:  backoff,
+	}
+}
+
 // blockingReconciler blocks each Reconcile on a release channel and tracks
 // global / per-entity concurrency so tests can assert the worker-pool bound and
 // same-entity serialization.
@@ -710,6 +724,7 @@ func TestLoop_F5_LostWakeupStress(t *testing.T) {
 	// block; the invariant under test is the dirty map state, not re-run execution.
 	addCh := make(chan waitingItem, triggers*4)
 	cancelCh := make(chan string, triggers*4)
+	dispatcher := testReconcileDispatcher(l, addCh, cancelCh, backoff)
 	drainDone := make(chan struct{})
 	go func() {
 		for {
@@ -728,7 +743,7 @@ func TestLoop_F5_LostWakeupStress(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			runtime.Gosched()
-			l.process(runCtx, Request{EntityID: entity}, addCh, cancelCh, backoff)
+			l.process(runCtx, Request{EntityID: entity}, dispatcher)
 		}()
 	}
 	wg.Wait()
@@ -833,7 +848,7 @@ func TestCancelPending_RemovesFromHeapAndPending(t *testing.T) {
 }
 
 // TestDispatchResult_PermanentCancelsPendingNotRequeue proves F1-(c): on a
-// permanent result, dispatchResult sends the entity on cancelCh (to evict any
+// permanent result, dispatch sends the entity on cancelCh (to evict any
 // stale pre-existing requeue) and does NOT enqueue a new requeue. This is the
 // "stale pending then permanent" path the prior code left uncovered: an earlier
 // success/transient could have enqueued a long requeue that, without this
@@ -845,9 +860,10 @@ func TestDispatchResult_PermanentCancelsPendingNotRequeue(t *testing.T) {
 	addCh := make(chan waitingItem, 1)
 	cancelCh := make(chan string, 1)
 	backoff := newEntityBackoff(defaultBackoffBase, defaultBackoffMax)
+	runCtx := context.Background()
+	dispatcher := testReconcileDispatcher(l, addCh, cancelCh, backoff)
 
-	l.dispatchResult(context.Background(), Request{EntityID: "dead"}, Result{},
-		PermanentError(errors.New("boom")), resultPermanent, addCh, cancelCh, backoff)
+	dispatcher.dispatch(runCtx, Request{EntityID: "dead"}, Result{}, PermanentError(errors.New("boom")), resultPermanent)
 
 	select {
 	case id := <-cancelCh:
@@ -866,9 +882,10 @@ func TestDispatchResult_SuccessEnqueuesNotCancel(t *testing.T) {
 	addCh := make(chan waitingItem, 1)
 	cancelCh := make(chan string, 1)
 	backoff := newEntityBackoff(defaultBackoffBase, defaultBackoffMax)
+	runCtx := context.Background()
+	dispatcher := testReconcileDispatcher(l, addCh, cancelCh, backoff)
 
-	l.dispatchResult(context.Background(), Request{EntityID: "ok"}, Result{RequeueAfter: testtime.D1h},
-		nil, resultSuccess, addCh, cancelCh, backoff)
+	dispatcher.dispatch(runCtx, Request{EntityID: "ok"}, Result{RequeueAfter: testtime.D1h}, nil, resultSuccess)
 
 	assert.Len(t, addCh, 1, "success must enqueue a requeue")
 	assert.Empty(t, cancelCh, "success must NOT cancel")
@@ -908,8 +925,9 @@ func TestDispatchResult_NoDefaultRequeue(t *testing.T) {
 		t.Parallel()
 		l := newLoop(true)
 		c := newChans()
-		l.dispatchResult(context.Background(), Request{EntityID: "ok"}, Result{},
-			nil, resultSuccess, c.add, c.cancel, c.bo)
+		runCtx := context.Background()
+		dispatcher := testReconcileDispatcher(l, c.add, c.cancel, c.bo)
+		dispatcher.dispatch(runCtx, Request{EntityID: "ok"}, Result{}, nil, resultSuccess)
 		assert.Empty(t, c.add, "WithoutDefaultRequeue: success zero-Result must NOT self-requeue (Trigger is sole driver)")
 		assert.Empty(t, c.cancel, "success must NOT cancel")
 	})
@@ -918,8 +936,9 @@ func TestDispatchResult_NoDefaultRequeue(t *testing.T) {
 		t.Parallel()
 		l := newLoop(true)
 		c := newChans()
-		l.dispatchResult(context.Background(), Request{EntityID: "ok"}, Result{RequeueAfter: testtime.D30ms},
-			nil, resultSuccess, c.add, c.cancel, c.bo)
+		runCtx := context.Background()
+		dispatcher := testReconcileDispatcher(l, c.add, c.cancel, c.bo)
+		dispatcher.dispatch(runCtx, Request{EntityID: "ok"}, Result{RequeueAfter: testtime.D30ms}, nil, resultSuccess)
 		assert.Len(t, c.add, 1, "explicit RequeueAfter>0 must still enqueue even when opted out")
 	})
 
@@ -927,8 +946,9 @@ func TestDispatchResult_NoDefaultRequeue(t *testing.T) {
 		t.Parallel()
 		l := newLoop(true)
 		c := newChans()
-		l.dispatchResult(context.Background(), Request{EntityID: "boom"}, Result{},
-			errors.New("transient"), resultTransient, c.add, c.cancel, c.bo)
+		runCtx := context.Background()
+		dispatcher := testReconcileDispatcher(l, c.add, c.cancel, c.bo)
+		dispatcher.dispatch(runCtx, Request{EntityID: "boom"}, Result{}, errors.New("transient"), resultTransient)
 		assert.Len(t, c.add, 1, "transient error must still backoff-requeue when opted out")
 	})
 
@@ -936,8 +956,9 @@ func TestDispatchResult_NoDefaultRequeue(t *testing.T) {
 		t.Parallel()
 		l := newLoop(false)
 		c := newChans()
-		l.dispatchResult(context.Background(), Request{EntityID: "ok"}, Result{},
-			nil, resultSuccess, c.add, c.cancel, c.bo)
+		runCtx := context.Background()
+		dispatcher := testReconcileDispatcher(l, c.add, c.cancel, c.bo)
+		dispatcher.dispatch(runCtx, Request{EntityID: "ok"}, Result{}, nil, resultSuccess)
 		assert.Len(t, c.add, 1, "default behavior: success zero-Result self-requeues at the default tick")
 	})
 }
@@ -1210,7 +1231,7 @@ func TestLoop_ResyncSentinelIsolation(t *testing.T) {
 // TestLoop_SuccessRequeueAfterPositive verifies that a Reconciler returning
 // Result{RequeueAfter: d} (d > 0) causes the entity to be re-enqueued via the
 // shared delaying queue at delay d — specifically that the
-// `delay = res.normalizedRequeueAfter()` branch in dispatchResult is exercised
+// `delay = res.normalizedRequeueAfter()` branch in dispatch is exercised
 // and the entity is reconciled a second time.
 //
 // Design: the reconciler returns a small positive RequeueAfter on the first call

--- a/kernel/reconcile/reconciletest/conformance.go
+++ b/kernel/reconcile/reconciletest/conformance.go
@@ -14,6 +14,16 @@ import (
 	"github.com/ghbvf/gocell/pkg/testutil/testwait"
 )
 
+const (
+	holderA        = "holder-A"
+	holderB        = "holder-B"
+	acquireA       = "acquire A"
+	releaseA       = "release A"
+	acquireB       = "acquire B"
+	basicEntityID  = "basic-entity-1"
+	leaderEntityID = "leader-entity-1"
+)
+
 // ElectorFactory builds a LeaderElector for the given holderID, all sharing one
 // backend (same redis client / pg pool / FakeLeaseBackend) so two holders
 // contend for the same lease. Distinct holderIDs simulate distinct replicas.
@@ -47,7 +57,7 @@ func RunLeaderConformance(t *testing.T, newElector ElectorFactory) {
 func confReacquireAfterReleaseBumps(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-reacquire"
-	a := newElector("holder-A")
+	a := newElector(holderA)
 
 	tok1, err := a.AcquireLease(ctx, rid)
 	mustNoErr(t, err, "first acquire")
@@ -64,7 +74,7 @@ func confReacquireAfterReleaseBumps(t *testing.T, newElector ElectorFactory) {
 func confAcquireExclusive(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-exclusive"
-	a, b := newElector("holder-A"), newElector("holder-B")
+	a, b := newElector(holderA), newElector(holderB)
 
 	tokA, err := a.AcquireLease(ctx, rid)
 	mustNoErr(t, err, "first holder must acquire")
@@ -78,11 +88,11 @@ func confAcquireExclusive(t *testing.T, newElector ElectorFactory) {
 func confReleaseUnblocksFollower(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-release"
-	a, b := newElector("holder-A"), newElector("holder-B")
+	a, b := newElector(holderA), newElector(holderB)
 
 	tokA, err := a.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire A")
-	mustNoErr(t, a.ReleaseLease(ctx, tokA), "release A")
+	mustNoErr(t, err, acquireA)
+	mustNoErr(t, a.ReleaseLease(ctx, tokA), releaseA)
 
 	tokB, err := b.AcquireLease(ctx, rid)
 	mustNoErr(t, err, "follower must acquire after the leader releases")
@@ -92,10 +102,10 @@ func confReleaseUnblocksFollower(t *testing.T, newElector ElectorFactory) {
 func confRenewKeepsLeaseAndEpoch(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-renew"
-	a, b := newElector("holder-A"), newElector("holder-B")
+	a, b := newElector(holderA), newElector(holderB)
 
 	tokA, err := a.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire A")
+	mustNoErr(t, err, acquireA)
 	defer func() { _ = a.ReleaseLease(ctx, tokA) }()
 	mustNoErr(t, a.RenewLease(ctx, tokA), "renew must succeed while held")
 
@@ -114,14 +124,14 @@ func confRenewKeepsLeaseAndEpoch(t *testing.T, newElector ElectorFactory) {
 func confHandoffBumpsEpoch(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-handoff"
-	a, b := newElector("holder-A"), newElector("holder-B")
+	a, b := newElector(holderA), newElector(holderB)
 
 	tokA, err := a.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire A")
-	mustNoErr(t, a.ReleaseLease(ctx, tokA), "release A")
+	mustNoErr(t, err, acquireA)
+	mustNoErr(t, a.ReleaseLease(ctx, tokA), releaseA)
 
 	tokB, err := b.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire B")
+	mustNoErr(t, err, acquireB)
 	defer func() { _ = b.ReleaseLease(ctx, tokB) }()
 	if tokB.Epoch <= tokA.Epoch {
 		t.Fatalf("a holder change must bump the monotonic epoch: B=%d not > A=%d", tokB.Epoch, tokA.Epoch)
@@ -131,13 +141,13 @@ func confHandoffBumpsEpoch(t *testing.T, newElector ElectorFactory) {
 func confRenewAfterTakeoverIsLost(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-renew-lost"
-	a, b := newElector("holder-A"), newElector("holder-B")
+	a, b := newElector(holderA), newElector(holderB)
 
 	tokA, err := a.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire A")
-	mustNoErr(t, a.ReleaseLease(ctx, tokA), "release A")
+	mustNoErr(t, err, acquireA)
+	mustNoErr(t, a.ReleaseLease(ctx, tokA), releaseA)
 	tokB, err := b.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire B")
+	mustNoErr(t, err, acquireB)
 	defer func() { _ = b.ReleaseLease(ctx, tokB) }()
 
 	// A's renew must now report the lease lost (B owns it).
@@ -153,10 +163,10 @@ func confRenewAfterTakeoverIsLost(t *testing.T, newElector ElectorFactory) {
 func confReleaseAfterTakeoverIsNoop(t *testing.T, newElector ElectorFactory) {
 	ctx := context.Background()
 	const rid = "conf-release-after-takeover"
-	a, b, c := newElector("holder-A"), newElector("holder-B"), newElector("holder-C")
+	a, b, c := newElector(holderA), newElector(holderB), newElector("holder-C")
 
 	tokA, err := a.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire A")
+	mustNoErr(t, err, acquireA)
 	mustNoErr(t, a.ReleaseLease(ctx, tokA), "A releases")
 
 	tokB, err := b.AcquireLease(ctx, rid)
@@ -195,14 +205,14 @@ func RunFencingConformance(t *testing.T, newElector ElectorFactory) {
 		entity = "device-1"
 	)
 
-	a := newElector("holder-A")
+	a := newElector(holderA)
 	tokA, err := a.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire A")
+	mustNoErr(t, err, acquireA)
 	mustNoErr(t, a.ReleaseLease(ctx, tokA), "old leader hands off")
 
-	b := newElector("holder-B")
+	b := newElector(holderB)
 	tokB, err := b.AcquireLease(ctx, rid)
-	mustNoErr(t, err, "acquire B")
+	mustNoErr(t, err, acquireB)
 	defer func() { _ = b.ReleaseLease(ctx, tokB) }()
 	if tokB.Epoch <= tokA.Epoch {
 		t.Fatalf("takeover must bump the fencing epoch: B=%d not > A=%d", tokB.Epoch, tokA.Epoch)
@@ -384,12 +394,12 @@ func confBasicReconcile(t *testing.T, newHarness HarnessFactory) {
 	mustNoErr(t, l.Start(ownerCtx), "Start")
 	defer confStop(t, l)
 
-	submit(reconcile.Request{EntityID: "basic-entity-1"})
+	submit(reconcile.Request{EntityID: basicEntityID})
 
 	select {
 	case got := <-invoked:
-		if got.EntityID != "basic-entity-1" {
-			t.Fatalf("BasicReconcile: got entity %q, want %q", got.EntityID, "basic-entity-1")
+		if got.EntityID != basicEntityID {
+			t.Fatalf("BasicReconcile: got entity %q, want %q", got.EntityID, basicEntityID)
 		}
 	case <-time.After(confEventualWait):
 		t.Fatal("BasicReconcile: Reconcile never called within budget")
@@ -709,12 +719,12 @@ func confLeaderFlow(t *testing.T, newHarness HarnessFactory) {
 	mustNoErr(t, l.Start(ownerCtx), "Start")
 	defer confStop(t, l)
 
-	submit(reconcile.Request{EntityID: "leader-entity-1"})
+	submit(reconcile.Request{EntityID: leaderEntityID})
 
 	select {
 	case got := <-dispatched:
-		if got.EntityID != "leader-entity-1" {
-			t.Fatalf("LeaderFlow: got entity %q, want %q", got.EntityID, "leader-entity-1")
+		if got.EntityID != leaderEntityID {
+			t.Fatalf("LeaderFlow: got entity %q, want %q", got.EntityID, leaderEntityID)
 		}
 	case <-time.After(confEventualWait):
 		t.Fatal("LeaderFlow: work not dispatched within budget — Loop may not have acquired leadership")

--- a/kernel/saga/sagajournaltest/global_reader_conformance.go
+++ b/kernel/saga/sagajournaltest/global_reader_conformance.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ghbvf/gocell/pkg/idutil"
 )
 
+const loadSinceErrFmt = "LoadSince: %v"
+
 // RunGlobalReaderConformance runs the conformance suite for the
 // [journal.GlobalReader] global-ordered-scan contract (#1609 PR-02) against the
 // supplied factory. It is deliberately SEPARATE from RunConformanceSuite (which
@@ -127,7 +129,7 @@ func conformGlobalSeqMonotonicAcrossInstances(t *testing.T, factory Factory) {
 
 	events, err := gr.LoadSince(context.Background(), 0, 100)
 	if err != nil {
-		t.Fatalf("LoadSince: %v", err)
+		t.Fatalf(loadSinceErrFmt, err)
 	}
 	if len(events) != 4 {
 		t.Fatalf("LoadSince returned %d events; want 4 (seqs=%v)", len(events), globalSeqs(events))
@@ -350,7 +352,7 @@ func conformGlobalCompensatedTerminalScannable(t *testing.T, factory Factory) {
 
 	events, err := gr.LoadSince(context.Background(), 0, 100)
 	if err != nil {
-		t.Fatalf("LoadSince: %v", err)
+		t.Fatalf(loadSinceErrFmt, err)
 	}
 	if len(events) != 4 {
 		t.Fatalf("LoadSince returned %d events; want 4 (step+compStarted+compensated+terminal), seqs=%v",
@@ -411,7 +413,7 @@ func conformGlobalTerminalEventScannable(t *testing.T, factory Factory) {
 
 	events, err := gr.LoadSince(context.Background(), 0, 100)
 	if err != nil {
-		t.Fatalf("LoadSince: %v", err)
+		t.Fatalf(loadSinceErrFmt, err)
 	}
 	if len(events) != 2 {
 		t.Fatalf("LoadSince returned %d events; want 2 (step + terminal), seqs=%v",
@@ -509,7 +511,7 @@ func conformGlobalSeqConcurrentAppend(t *testing.T, factory Factory) {
 	total := instances * perInstance
 	events, err := gr.LoadSince(context.Background(), 0, total*2)
 	if err != nil {
-		t.Fatalf("LoadSince: %v", err)
+		t.Fatalf(loadSinceErrFmt, err)
 	}
 	if len(events) != total {
 		t.Fatalf("LoadSince returned %d events; want %d", len(events), total)

--- a/kernel/webhook/webhooktest/conformance.go
+++ b/kernel/webhook/webhooktest/conformance.go
@@ -127,8 +127,17 @@ func RunSignerVerifierConformance(
 	runTamperBody(t, src, basePayload, goodHeaders, base, verifierAt)
 	runTamperSignature(t, src, basePayload, goodHeaders, base, verifierAt)
 	runTamperTimestampExpired(t, src, basePayload, goodHeaders, base, verifierAt)
-	runMultiTokenFirstMatches(t, src, basePayload, goodHeaders, base, deliveryID, newSigner, verifierAt)
-	runMultiTokenSecondMatches(t, src, basePayload, goodHeaders, base, deliveryID, newSigner, verifierAt)
+	multiToken := multiTokenFixture{
+		Source:     src,
+		Payload:    basePayload,
+		Headers:    goodHeaders,
+		Base:       base,
+		DeliveryID: deliveryID,
+		NewSigner:  newSigner,
+		VerifierAt: verifierAt,
+	}
+	runMultiTokenFirstMatches(t, multiToken)
+	runMultiTokenSecondMatches(t, multiToken)
 	runTimestampOutsideWindow(t, src, basePayload, goodHeaders, base, verifierAt)
 	runEmptySecretSourceRejected(t, newSigner)
 	runEmptySecretSourceRejectedByVerifier(t, basePayload, goodHeaders, base, verifierAt)
@@ -226,41 +235,39 @@ func runTamperTimestampExpired(
 	})
 }
 
-func runMultiTokenFirstMatches(
-	t *testing.T, src webhook.Source, payload []byte,
-	headers webhook.Headers, base time.Time,
-	deliveryID webhook.DeliveryID,
-	newSigner func(webhook.Source) (webhook.Signer, error),
-	verifierAt func(*testing.T, time.Time) webhook.Verifier,
-) {
+type multiTokenFixture struct {
+	Source     webhook.Source
+	Payload    []byte
+	Headers    webhook.Headers
+	Base       time.Time
+	DeliveryID webhook.DeliveryID
+	NewSigner  func(webhook.Source) (webhook.Signer, error)
+	VerifierAt func(*testing.T, time.Time) webhook.Verifier
+}
+
+func runMultiTokenFirstMatches(t *testing.T, f multiTokenFixture) {
 	t.Helper()
 	t.Run("multi_token_rotation_first_matches", func(t *testing.T) {
 		t.Parallel()
-		altHeaders := buildAltHeaders(t, payload, base, deliveryID, "test-source-2", newSigner)
-		combined := headers
-		combined.Signature = headers.Signature + " " + altHeaders.Signature
-		v := verifierAt(t, base)
-		requireNoError(t, v.Verify(payload, combined, src),
+		altHeaders := buildAltHeaders(t, f.Payload, f.Base, f.DeliveryID, "test-source-2", f.NewSigner)
+		combined := f.Headers
+		combined.Signature = f.Headers.Signature + " " + altHeaders.Signature
+		v := f.VerifierAt(t, f.Base)
+		requireNoError(t, v.Verify(f.Payload, combined, f.Source),
 			"first matching token should satisfy verification")
 	})
 }
 
-func runMultiTokenSecondMatches(
-	t *testing.T, src webhook.Source, payload []byte,
-	headers webhook.Headers, base time.Time,
-	deliveryID webhook.DeliveryID,
-	newSigner func(webhook.Source) (webhook.Signer, error),
-	verifierAt func(*testing.T, time.Time) webhook.Verifier,
-) {
+func runMultiTokenSecondMatches(t *testing.T, f multiTokenFixture) {
 	t.Helper()
 	t.Run("multi_token_rotation_second_matches", func(t *testing.T) {
 		t.Parallel()
-		altHeaders := buildAltHeaders(t, payload, base, deliveryID, "test-source-b", newSigner)
+		altHeaders := buildAltHeaders(t, f.Payload, f.Base, f.DeliveryID, "test-source-b", f.NewSigner)
 		// Put the "wrong" token first, then the correct one.
-		combined := headers
-		combined.Signature = altHeaders.Signature + " " + headers.Signature
-		v := verifierAt(t, base)
-		requireNoError(t, v.Verify(payload, combined, src),
+		combined := f.Headers
+		combined.Signature = altHeaders.Signature + " " + f.Headers.Signature
+		v := f.VerifierAt(t, f.Base)
+		requireNoError(t, v.Verify(f.Payload, combined, f.Source),
 			"any matching token anywhere in the header should satisfy verification")
 	})
 }

--- a/pkg/redaction/redaction_test.go
+++ b/pkg/redaction/redaction_test.go
@@ -761,6 +761,14 @@ type stringerWithSecret struct{}
 
 func (stringerWithSecret) String() string { return "api_key=sekret" }
 
+type redactSlogAttrKindCase struct {
+	name      string
+	attr      slog.Attr
+	wantKind  slog.Kind
+	wantMask  bool   // true = result must contain Mask
+	wantValue string // non-empty = exact expected string value
+}
+
 // TestRedactSlogAttr_PassthroughKinds locks the behavior of redactSlogValue for
 // all slog.Value kinds.
 //
@@ -783,13 +791,7 @@ func TestRedactSlogAttr_PassthroughKinds(t *testing.T) {
 
 	fixedTime := time.Unix(1700000000, 0)
 
-	cases := []struct {
-		name      string
-		attr      slog.Attr
-		wantKind  slog.Kind
-		wantMask  bool   // true = result must contain Mask
-		wantValue string // non-empty = exact expected string value
-	}{
+	cases := []redactSlogAttrKindCase{
 		{
 			name:     "bool passthrough",
 			attr:     slog.Bool("flag", true),
@@ -869,30 +871,36 @@ func TestRedactSlogAttr_PassthroughKinds(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := redaction.RedactSlogAttr(tc.attr)
-
-			if got.Key != tc.attr.Key {
-				t.Errorf("RedactSlogAttr key changed: got %q, want %q", got.Key, tc.attr.Key)
-			}
-			if got.Value.Kind() != tc.wantKind {
-				t.Errorf("RedactSlogAttr(%v): got kind %v, want %v",
-					tc.attr, got.Value.Kind(), tc.wantKind)
-			}
-			if tc.wantValue != "" {
-				gotStr := got.Value.String()
-				if gotStr != tc.wantValue {
-					t.Errorf("RedactSlogAttr(%v): got %q, want %q", tc.attr, gotStr, tc.wantValue)
-				}
-			}
-			gotStr := got.Value.String()
-			if tc.wantMask && !strings.Contains(gotStr, redaction.Mask) {
-				t.Errorf("RedactSlogAttr(%v): expected mask %q in output %q",
-					tc.attr, redaction.Mask, gotStr)
-			}
-			if !tc.wantMask && strings.Contains(gotStr, redaction.Mask) {
-				t.Errorf("RedactSlogAttr(%v): unexpected mask in output %q", tc.attr, gotStr)
-			}
+			assertRedactSlogAttrKind(t, tc)
 		})
+	}
+}
+
+func assertRedactSlogAttrKind(t *testing.T, tc redactSlogAttrKindCase) {
+	t.Helper()
+
+	got := redaction.RedactSlogAttr(tc.attr)
+
+	if got.Key != tc.attr.Key {
+		t.Errorf("RedactSlogAttr key changed: got %q, want %q", got.Key, tc.attr.Key)
+	}
+	if got.Value.Kind() != tc.wantKind {
+		t.Errorf("RedactSlogAttr(%v): got kind %v, want %v",
+			tc.attr, got.Value.Kind(), tc.wantKind)
+	}
+	if tc.wantValue != "" {
+		gotStr := got.Value.String()
+		if gotStr != tc.wantValue {
+			t.Errorf("RedactSlogAttr(%v): got %q, want %q", tc.attr, gotStr, tc.wantValue)
+		}
+	}
+	gotStr := got.Value.String()
+	if tc.wantMask && !strings.Contains(gotStr, redaction.Mask) {
+		t.Errorf("RedactSlogAttr(%v): expected mask %q in output %q",
+			tc.attr, redaction.Mask, gotStr)
+	}
+	if !tc.wantMask && strings.Contains(gotStr, redaction.Mask) {
+		t.Errorf("RedactSlogAttr(%v): unexpected mask in output %q", tc.attr, gotStr)
 	}
 }
 

--- a/pkg/tenant/rowvisibility_test.go
+++ b/pkg/tenant/rowvisibility_test.go
@@ -2,14 +2,27 @@ package tenant
 
 import "testing"
 
+type newRowVisibilityCase struct {
+	name    string
+	scope   RowScope
+	subject string
+	wantErr bool
+}
+
+type sqlPredicateCase struct {
+	name       string
+	scope      RowScope
+	subject    string
+	ownerCol   string
+	wantApply  bool
+	wantPrefix string
+	wantArg    any
+	wantErr    bool
+}
+
 func TestNewRowVisibility(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name    string
-		scope   RowScope
-		subject string
-		wantErr bool
-	}{
+	tests := []newRowVisibilityCase{
 		{name: "self requires subject", scope: RowScopeSelf, subject: "u1"},
 		{name: "self empty subject rejected", scope: RowScopeSelf, subject: "", wantErr: true},
 		{name: "device requires subject", scope: RowScopeDevice, subject: "d1"},
@@ -24,26 +37,32 @@ func TestNewRowVisibility(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			v, err := NewRowVisibility(tt.scope, tt.subject)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("NewRowVisibility(%v, %q) = nil err, want err", tt.scope, tt.subject)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("NewRowVisibility(%v, %q) unexpected err: %v", tt.scope, tt.subject, err)
-			}
-			if v.Scope() != tt.scope {
-				t.Errorf("Scope() = %v, want %v", v.Scope(), tt.scope)
-			}
-			if v.Subject() != tt.subject {
-				t.Errorf("Subject() = %q, want %q", v.Subject(), tt.subject)
-			}
-			if err := v.Validate(); err != nil {
-				t.Errorf("Validate() = %v, want nil", err)
-			}
+			assertNewRowVisibility(t, tt)
 		})
+	}
+}
+
+func assertNewRowVisibility(t *testing.T, tt newRowVisibilityCase) {
+	t.Helper()
+
+	v, err := NewRowVisibility(tt.scope, tt.subject)
+	if tt.wantErr {
+		if err == nil {
+			t.Fatalf("NewRowVisibility(%v, %q) = nil err, want err", tt.scope, tt.subject)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("NewRowVisibility(%v, %q) unexpected err: %v", tt.scope, tt.subject, err)
+	}
+	if v.Scope() != tt.scope {
+		t.Errorf("Scope() = %v, want %v", v.Scope(), tt.scope)
+	}
+	if v.Subject() != tt.subject {
+		t.Errorf("Subject() = %q, want %q", v.Subject(), tt.subject)
+	}
+	if err := v.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
 	}
 }
 
@@ -57,16 +76,7 @@ func TestRowVisibility_ZeroValueInvalid(t *testing.T) {
 
 func TestRowVisibility_SQLPredicate(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name       string
-		scope      RowScope
-		subject    string
-		ownerCol   string
-		wantApply  bool
-		wantPrefix string
-		wantArg    any
-		wantErr    bool
-	}{
+	tests := []sqlPredicateCase{
 		{
 			name: "self emits owner predicate", scope: RowScopeSelf, subject: "u1", ownerCol: "actor_id",
 			wantApply: true, wantPrefix: " AND actor_id = ", wantArg: "u1",
@@ -101,32 +111,38 @@ func TestRowVisibility_SQLPredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			v, err := NewRowVisibility(tt.scope, tt.subject)
-			if err != nil {
-				t.Fatalf("NewRowVisibility: %v", err)
-			}
-			p, err := v.SQLPredicate(tt.ownerCol)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("SQLPredicate(%q) = nil err, want err", tt.ownerCol)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("SQLPredicate(%q) unexpected err: %v", tt.ownerCol, err)
-			}
-			if p.Apply != tt.wantApply {
-				t.Errorf("Apply = %v, want %v", p.Apply, tt.wantApply)
-			}
-			if p.Apply {
-				if p.Prefix != tt.wantPrefix {
-					t.Errorf("Prefix = %q, want %q", p.Prefix, tt.wantPrefix)
-				}
-				if p.Arg != tt.wantArg {
-					t.Errorf("Arg = %v, want %v", p.Arg, tt.wantArg)
-				}
-			}
+			assertSQLPredicate(t, tt)
 		})
+	}
+}
+
+func assertSQLPredicate(t *testing.T, tt sqlPredicateCase) {
+	t.Helper()
+
+	v, err := NewRowVisibility(tt.scope, tt.subject)
+	if err != nil {
+		t.Fatalf("NewRowVisibility: %v", err)
+	}
+	p, err := v.SQLPredicate(tt.ownerCol)
+	if tt.wantErr {
+		if err == nil {
+			t.Fatalf("SQLPredicate(%q) = nil err, want err", tt.ownerCol)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("SQLPredicate(%q) unexpected err: %v", tt.ownerCol, err)
+	}
+	if p.Apply != tt.wantApply {
+		t.Errorf("Apply = %v, want %v", p.Apply, tt.wantApply)
+	}
+	if p.Apply {
+		if p.Prefix != tt.wantPrefix {
+			t.Errorf("Prefix = %q, want %q", p.Prefix, tt.wantPrefix)
+		}
+		if p.Arg != tt.wantArg {
+			t.Errorf("Arg = %v, want %v", p.Arg, tt.wantArg)
+		}
 	}
 }
 

--- a/runtime/audit/ledger/storetest/suite.go
+++ b/runtime/audit/ledger/storetest/suite.go
@@ -44,6 +44,13 @@ import (
 	"github.com/ghbvf/gocell/runtime/audit/ledger"
 )
 
+const (
+	appendEventErrFmt = "Append %s: %v"
+	tenantNoneEventID = "ti-none"
+	chainAEventID     = "chain-a-1"
+	chainBEventID     = "chain-b-1"
+)
+
 const fmtErrGetBySeq1 = "GetBySeq(1): %v"
 
 // passthroughTxRunner is a no-op TxRunner used by MemStore conformance tests.
@@ -869,7 +876,7 @@ func runQueryOrderingTimestampDescIDAsc(t *testing.T, factory Factory) {
 			Payload:   []byte(`{}`),
 		}
 		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf("Append %s: %v", en.id, err)
+			t.Fatalf(appendEventErrFmt, en.id, err)
 		}
 	}
 
@@ -1074,7 +1081,7 @@ func runQueryTenantIsolation(t *testing.T, factory Factory) {
 		{"ti-a1", isoTenantA},
 		{"ti-a2", isoTenantA},
 		{"ti-b1", isoTenantB},
-		{"ti-none", ""},
+		{tenantNoneEventID, ""},
 	}
 	for _, s := range seed {
 		e := &ledger.Entry{
@@ -1086,7 +1093,7 @@ func runQueryTenantIsolation(t *testing.T, factory Factory) {
 			Payload:   []byte(`{}`),
 		}
 		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf("Append %s: %v", s.eventID, err)
+			t.Fatalf(appendEventErrFmt, s.eventID, err)
 		}
 	}
 
@@ -1096,12 +1103,12 @@ func runQueryTenantIsolation(t *testing.T, factory Factory) {
 		wantIDs []string
 	}{
 		// tenant-A: sees its OWN rows + system ("") rows, never tenant-B rows.
-		{"tenant-A sees its rows + system, not tenant-B", isoTenantA, []string{"ti-a1", "ti-a2", "ti-none"}},
+		{"tenant-A sees its rows + system, not tenant-B", isoTenantA, []string{"ti-a1", "ti-a2", tenantNoneEventID}},
 		// tenant-B: sees its row + system ("") rows, never tenant-A rows.
-		{"tenant-B sees its row + system, not tenant-A", isoTenantB, []string{"ti-b1", "ti-none"}},
+		{"tenant-B sees its row + system, not tenant-A", isoTenantB, []string{"ti-b1", tenantNoneEventID}},
 		// Empty tenant "" is the internal system-chain read: sees ONLY tenant-less
 		// system rows, never any tenant's rows (predicate collapses to tenant_id = '').
-		{"empty tenant is system-chain read (system rows only)", "", []string{"ti-none"}},
+		{"empty tenant is system-chain read (system rows only)", "", []string{tenantNoneEventID}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1166,7 +1173,7 @@ func appendChainEntry(t *testing.T, store ledger.Store, eventID, tenantID string
 		TenantID: tenantID, Timestamp: now, Payload: []byte(`{}`),
 	}
 	if err := store.Append(context.Background(), e); err != nil {
-		t.Fatalf("Append %s: %v", eventID, err)
+		t.Fatalf(appendEventErrFmt, eventID, err)
 	}
 }
 
@@ -1183,8 +1190,8 @@ func runPerTenantChains(t *testing.T, factory Factory) {
 
 	// Interleave two tenants' appends; each chain is independent (per-tenant
 	// seq_no), so both reach SeqNo==2 on their own (namespace, tenant) chain.
-	appendChainEntry(t, store, "chain-a-1", conformanceTenantA, fc.Now())
-	appendChainEntry(t, store, "chain-b-1", conformanceTenantB, fc.Now())
+	appendChainEntry(t, store, chainAEventID, conformanceTenantA, fc.Now())
+	appendChainEntry(t, store, chainBEventID, conformanceTenantB, fc.Now())
 	appendChainEntry(t, store, "chain-a-2", conformanceTenantA, fc.Now())
 	appendChainEntry(t, store, "chain-b-2", conformanceTenantB, fc.Now())
 
@@ -1214,8 +1221,8 @@ func runPerTenantChains(t *testing.T, factory Factory) {
 	if err != nil {
 		t.Fatalf("GetBySeq(tenant-a, seq=1): %v", err)
 	}
-	if gotA1.EventID != "chain-a-1" {
-		t.Errorf("GetBySeq(tenant-a, seq=1): got EventID=%q, want %q", gotA1.EventID, "chain-a-1")
+	if gotA1.EventID != chainAEventID {
+		t.Errorf("GetBySeq(tenant-a, seq=1): got EventID=%q, want %q", gotA1.EventID, chainAEventID)
 	}
 
 	// GetBySeq isolation: tenant-b seq 1 must return chain-b-1, not chain-a-1.
@@ -1223,8 +1230,8 @@ func runPerTenantChains(t *testing.T, factory Factory) {
 	if err != nil {
 		t.Fatalf("GetBySeq(tenant-b, seq=1): %v", err)
 	}
-	if gotB1.EventID != "chain-b-1" {
-		t.Errorf("GetBySeq(tenant-b, seq=1): got EventID=%q, want %q", gotB1.EventID, "chain-b-1")
+	if gotB1.EventID != chainBEventID {
+		t.Errorf("GetBySeq(tenant-b, seq=1): got EventID=%q, want %q", gotB1.EventID, chainBEventID)
 	}
 
 	// System chain (unscoped ctx) is separate from both tenant chains.
@@ -1321,7 +1328,7 @@ func runQueryByTraceID(t *testing.T, factory Factory) {
 			Payload:   []byte(`{}`),
 		}
 		if err := store.Append(context.Background(), e); err != nil {
-			t.Fatalf("Append %s: %v", en.eventID, err)
+			t.Fatalf(appendEventErrFmt, en.eventID, err)
 		}
 	}
 

--- a/runtime/auth/bearer_core_test.go
+++ b/runtime/auth/bearer_core_test.go
@@ -37,165 +37,207 @@ func TestNewBearerHeaderAuthenticator(t *testing.T) {
 	}
 
 	t.Run("success delegates to shared bearer core", func(t *testing.T) {
-		v := bearerCoreVerifier{claims: claims}
-		a := NewBearerHeaderAuthenticator(v)
-		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
-		req.Header.Set("Authorization", "Bearer tok")
-
-		p, ok, err := a.Authenticate(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !ok {
-			t.Fatal("expected ok=true")
-		}
-		if p == nil {
-			t.Fatal("expected non-nil principal")
-		}
-		if p.Subject != claims.Subject {
-			t.Errorf("Subject = %q, want %q", p.Subject, claims.Subject)
-		}
-		if p.TenantID != claims.TenantID {
-			t.Errorf("TenantID = %q, want %q", p.TenantID, claims.TenantID)
-		}
-		if !p.PasswordResetRequired {
-			t.Error("PasswordResetRequired = false, want true")
-		}
-		if p.Claims["sid"] != claims.SessionID {
-			t.Errorf("Claims[sid] = %q, want %q", p.Claims["sid"], claims.SessionID)
-		}
-		if p.Claims["iss"] != claims.Issuer {
-			t.Errorf("Claims[iss] = %q, want %q", p.Claims["iss"], claims.Issuer)
-		}
-		if p.Claims["token_use"] != string(claims.TokenUse) {
-			t.Errorf("Claims[token_use] = %q, want %q", p.Claims["token_use"], claims.TokenUse)
-		}
-		if !p.ExpiresAt.Equal(exp) {
-			t.Errorf("ExpiresAt = %v, want %v", p.ExpiresAt, exp)
-		}
-		originalFirstRole := claims.Roles[0]
-		p.Roles[0] = "mutated"
-		if claims.Roles[0] != originalFirstRole {
-			t.Error("Roles must be a defensive copy")
-		}
+		runBearerHeaderSuccess(t, claims, exp)
 	})
 
 	t.Run("missing header is absent", func(t *testing.T) {
-		a := NewBearerHeaderAuthenticator(bearerCoreVerifier{})
-		p, ok, err := a.Authenticate(httptest.NewRequest(http.MethodGet, "/ws", nil))
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if ok {
-			t.Fatal("expected ok=false")
-		}
-		if p == nil {
-			t.Fatal("expected absent principal sentinel")
-		}
+		runBearerHeaderMissing(t)
 	})
 
 	t.Run("wrong scheme is absent", func(t *testing.T) {
-		a := NewBearerHeaderAuthenticator(bearerCoreVerifier{})
-		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
-		req.Header.Set("Authorization", "ServiceToken abc")
-
-		p, ok, err := a.Authenticate(req)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if ok {
-			t.Fatal("expected ok=false")
-		}
-		if p == nil {
-			t.Fatal("expected absent principal sentinel")
-		}
+		runBearerHeaderWrongScheme(t)
 	})
 
 	t.Run("verify failure returns error and nil principal", func(t *testing.T) {
-		sentinel := errors.New("verify boom")
-		a := NewBearerHeaderAuthenticator(bearerCoreVerifier{err: sentinel})
-		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
-		req.Header.Set("Authorization", "Bearer bad")
-
-		p, ok, err := a.Authenticate(req)
-		if !errors.Is(err, sentinel) {
-			t.Fatalf("err = %v, want sentinel", err)
-		}
-		if ok {
-			t.Fatal("expected ok=false")
-		}
-		if p != nil {
-			t.Fatalf("principal = %+v, want nil", p)
-		}
+		runBearerHeaderVerifyFailure(t)
 	})
 
 	t.Run("empty subject is rejected by shared bearer core", func(t *testing.T) {
-		a := NewBearerHeaderAuthenticator(bearerCoreVerifier{claims: Claims{Subject: ""}})
-		req := httptest.NewRequest(http.MethodGet, "/ws", nil)
-		req.Header.Set("Authorization", "Bearer tok")
-
-		p, ok, err := a.Authenticate(req)
-		if err == nil {
-			t.Fatal("expected error for empty subject")
-		}
-		if ok {
-			t.Fatal("expected ok=false")
-		}
-		if p != nil {
-			t.Fatalf("principal = %+v, want nil", p)
-		}
-		var ecErr *errcode.Error
-		if !errors.As(err, &ecErr) {
-			t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
-		}
-		if ecErr.Code != errcode.ErrAuthUnauthorized {
-			t.Errorf("Code = %v, want %v", ecErr.Code, errcode.ErrAuthUnauthorized)
-		}
+		runBearerHeaderEmptySubject(t)
 	})
 }
 
 func TestAuthenticateBearer(t *testing.T) {
 	t.Run("success injects principal and ctxkeys", func(t *testing.T) {
-		v := bearerCoreVerifier{claims: Claims{Subject: "user-1", SessionID: "sess-9"}}
-
-		ctx, p, err := AuthenticateBearer(context.Background(), v, "tok")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if p == nil || p.Subject != "user-1" {
-			t.Fatalf("principal subject = %+v, want user-1", p)
-		}
-		if got, ok := FromContext(ctx); !ok || got.Subject != "user-1" {
-			t.Fatalf("FromContext = %+v ok=%v, want user-1", got, ok)
-		}
-		if actor, ok := ctxkeys.ActorIDFrom(ctx); !ok || actor != "user-1" {
-			t.Fatalf("actor ctxkey = %q ok=%v, want user-1", actor, ok)
-		}
-		if sub, ok := ctxkeys.SubjectIDFrom(ctx); !ok || sub != "user-1" {
-			t.Fatalf("subject ctxkey = %q ok=%v, want user-1", sub, ok)
-		}
-		if sid, ok := ctxkeys.SessionIDFrom(ctx); !ok || sid != "sess-9" {
-			t.Fatalf("session ctxkey = %q ok=%v, want sess-9", sid, ok)
-		}
+		runAuthenticateBearerSuccess(t)
 	})
 
 	t.Run("verify failure returns ctx unchanged and nil principal", func(t *testing.T) {
-		sentinel := errors.New("verify boom")
-		v := bearerCoreVerifier{err: sentinel}
-		base := context.Background()
-
-		ctx, p, err := AuthenticateBearer(base, v, "tok")
-		if !errors.Is(err, sentinel) {
-			t.Fatalf("err = %v, want sentinel", err)
-		}
-		if p != nil {
-			t.Fatalf("principal = %+v, want nil on failure", p)
-		}
-		// ctx returned unchanged: no principal must leak from a failed verify.
-		if _, ok := FromContext(ctx); ok {
-			t.Fatalf("principal leaked into ctx after verify failure")
-		}
+		runAuthenticateBearerVerifyFailure(t)
 	})
+}
+
+func runBearerHeaderSuccess(t *testing.T, claims Claims, exp time.Time) {
+	t.Helper()
+
+	v := bearerCoreVerifier{claims: claims}
+	a := NewBearerHeaderAuthenticator(v)
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+
+	p, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if p == nil {
+		t.Fatal("expected non-nil principal")
+	}
+	if p.Subject != claims.Subject {
+		t.Errorf("Subject = %q, want %q", p.Subject, claims.Subject)
+	}
+	if p.TenantID != claims.TenantID {
+		t.Errorf("TenantID = %q, want %q", p.TenantID, claims.TenantID)
+	}
+	if !p.PasswordResetRequired {
+		t.Error("PasswordResetRequired = false, want true")
+	}
+	if p.Claims["sid"] != claims.SessionID {
+		t.Errorf("Claims[sid] = %q, want %q", p.Claims["sid"], claims.SessionID)
+	}
+	if p.Claims["iss"] != claims.Issuer {
+		t.Errorf("Claims[iss] = %q, want %q", p.Claims["iss"], claims.Issuer)
+	}
+	if p.Claims["token_use"] != string(claims.TokenUse) {
+		t.Errorf("Claims[token_use] = %q, want %q", p.Claims["token_use"], claims.TokenUse)
+	}
+	if !p.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt = %v, want %v", p.ExpiresAt, exp)
+	}
+	originalFirstRole := claims.Roles[0]
+	p.Roles[0] = "mutated"
+	if claims.Roles[0] != originalFirstRole {
+		t.Error("Roles must be a defensive copy")
+	}
+}
+
+func runBearerHeaderMissing(t *testing.T) {
+	t.Helper()
+
+	a := NewBearerHeaderAuthenticator(bearerCoreVerifier{})
+	p, ok, err := a.Authenticate(httptest.NewRequest(http.MethodGet, "/ws", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+	if p == nil {
+		t.Fatal("expected absent principal sentinel")
+	}
+}
+
+func runBearerHeaderWrongScheme(t *testing.T) {
+	t.Helper()
+
+	a := NewBearerHeaderAuthenticator(bearerCoreVerifier{})
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Authorization", "ServiceToken abc")
+
+	p, ok, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+	if p == nil {
+		t.Fatal("expected absent principal sentinel")
+	}
+}
+
+func runBearerHeaderVerifyFailure(t *testing.T) {
+	t.Helper()
+
+	sentinel := errors.New("verify boom")
+	a := NewBearerHeaderAuthenticator(bearerCoreVerifier{err: sentinel})
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Authorization", "Bearer bad")
+
+	p, ok, err := a.Authenticate(req)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+	if p != nil {
+		t.Fatalf("principal = %+v, want nil", p)
+	}
+}
+
+func runBearerHeaderEmptySubject(t *testing.T) {
+	t.Helper()
+
+	a := NewBearerHeaderAuthenticator(bearerCoreVerifier{claims: Claims{Subject: ""}})
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+
+	p, ok, err := a.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for empty subject")
+	}
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+	if p != nil {
+		t.Fatalf("principal = %+v, want nil", p)
+	}
+	var ecErr *errcode.Error
+	if !errors.As(err, &ecErr) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if ecErr.Code != errcode.ErrAuthUnauthorized {
+		t.Errorf("Code = %v, want %v", ecErr.Code, errcode.ErrAuthUnauthorized)
+	}
+}
+
+func runAuthenticateBearerSuccess(t *testing.T) {
+	t.Helper()
+
+	v := bearerCoreVerifier{claims: Claims{Subject: "user-1", SessionID: "sess-9"}}
+
+	ctx, p, err := AuthenticateBearer(context.Background(), v, "tok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil || p.Subject != "user-1" {
+		t.Fatalf("principal subject = %+v, want user-1", p)
+	}
+	if got, ok := FromContext(ctx); !ok || got.Subject != "user-1" {
+		t.Fatalf("FromContext = %+v ok=%v, want user-1", got, ok)
+	}
+	if actor, ok := ctxkeys.ActorIDFrom(ctx); !ok || actor != "user-1" {
+		t.Fatalf("actor ctxkey = %q ok=%v, want user-1", actor, ok)
+	}
+	if sub, ok := ctxkeys.SubjectIDFrom(ctx); !ok || sub != "user-1" {
+		t.Fatalf("subject ctxkey = %q ok=%v, want user-1", sub, ok)
+	}
+	if sid, ok := ctxkeys.SessionIDFrom(ctx); !ok || sid != "sess-9" {
+		t.Fatalf("session ctxkey = %q ok=%v, want sess-9", sid, ok)
+	}
+}
+
+func runAuthenticateBearerVerifyFailure(t *testing.T) {
+	t.Helper()
+
+	sentinel := errors.New("verify boom")
+	v := bearerCoreVerifier{err: sentinel}
+	base := context.Background()
+
+	ctx, p, err := AuthenticateBearer(base, v, "tok")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+	if p != nil {
+		t.Fatalf("principal = %+v, want nil on failure", p)
+	}
+	// ctx returned unchanged: no principal must leak from a failed verify.
+	if _, ok := FromContext(ctx); ok {
+		t.Fatalf("principal leaked into ctx after verify failure")
+	}
 }
 
 func TestAuthenticateBearer_EmptySubject(t *testing.T) {

--- a/runtime/auth/jwt.go
+++ b/runtime/auth/jwt.go
@@ -27,7 +27,8 @@ const msgTokenIntentFailed = "token intent validation failed"
 // JOSE typ header values written per TokenIntent. RFC 9068 §2.1 mandates
 // "at+jwt" for access tokens.
 const (
-	jwtTypAccess = "at+jwt"
+	jwtTypAccess    = "at+jwt"
+	msgInvalidToken = "invalid token"
 	// tokenUseClaim is the JWT payload key carrying the TokenIntent value.
 	// Named after AWS Cognito's convention, which is the most widely-adopted
 	// community precedent.
@@ -317,7 +318,7 @@ func (v *JWTVerifier) parseAndVerify(_ context.Context, tokenStr string) (Claims
 		return Claims{}, nil, errcode.Wrap(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "token verification failed", err)
 	}
 	if !token.Valid {
-		return Claims{}, nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "invalid token")
+		return Claims{}, nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgInvalidToken)
 	}
 
 	mapClaims, ok := token.Claims.(jwt.MapClaims)
@@ -352,14 +353,14 @@ func validateAndCanonicalizeTenant(mc jwt.MapClaims, claims *Claims) error {
 	s, ok := raw.(string)
 	if !ok {
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
-			"invalid token",
+			msgInvalidToken,
 			errcode.WithInternal(errcode.InternalAttr("_", "tenant_id claim is not a string")),
 			errcode.WithCategory(errcode.CategoryAuth))
 	}
 	tid, err := tenant.ParseTenantID(s)
 	if err != nil {
 		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized,
-			"invalid token",
+			msgInvalidToken,
 			errcode.WithInternal(errcode.InternalAttr("_", "tenant_id claim is not a valid UUID")),
 			errcode.WithCategory(errcode.CategoryAuth))
 	}

--- a/runtime/auth/rowscope_test.go
+++ b/runtime/auth/rowscope_test.go
@@ -31,6 +31,20 @@ func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
 func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
 func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
 
+type rowVisibilityCase struct {
+	name        string
+	principal   *Principal
+	wantScope   tenant.RowScope
+	wantSubject string
+	wantErr     bool
+}
+
+type superAdminAuditCase struct {
+	name      string
+	principal *Principal
+	wantError bool // true = expect ≥1 Error-level record with actor+scope+tenant+reason keys
+}
+
 // TestPrincipalRowVisibility_DerivationTable verifies the full derivation table
 // for Principal.RowVisibility across all PrincipalKind values and role combos.
 //
@@ -45,13 +59,7 @@ func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
 func TestPrincipalRowVisibility_DerivationTable(t *testing.T) {
 	ctx := rowVisibilityTestCtx()
 
-	cases := []struct {
-		name        string
-		principal   *Principal
-		wantScope   tenant.RowScope
-		wantSubject string
-		wantErr     bool
-	}{
+	cases := []rowVisibilityCase{
 		{
 			name:      "nil_receiver_fail_closed",
 			principal: nil,
@@ -155,23 +163,29 @@ func TestPrincipalRowVisibility_DerivationTable(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			vis, err := tc.principal.RowVisibility(ctx)
-			if tc.wantErr {
-				if err == nil {
-					t.Errorf("RowVisibility(%s): expected error, got visibility %v", tc.name, vis)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("RowVisibility(%s): unexpected error: %v", tc.name, err)
-			}
-			if vis.Scope() != tc.wantScope {
-				t.Errorf("RowVisibility(%s): scope = %v, want %v", tc.name, vis.Scope(), tc.wantScope)
-			}
-			if vis.Subject() != tc.wantSubject {
-				t.Errorf("RowVisibility(%s): subject = %q, want %q", tc.name, vis.Subject(), tc.wantSubject)
-			}
+			assertPrincipalRowVisibility(t, ctx, tc)
 		})
+	}
+}
+
+func assertPrincipalRowVisibility(t *testing.T, ctx context.Context, tc rowVisibilityCase) {
+	t.Helper()
+
+	vis, err := tc.principal.RowVisibility(ctx)
+	if tc.wantErr {
+		if err == nil {
+			t.Errorf("RowVisibility(%s): expected error, got visibility %v", tc.name, vis)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("RowVisibility(%s): unexpected error: %v", tc.name, err)
+	}
+	if vis.Scope() != tc.wantScope {
+		t.Errorf("RowVisibility(%s): scope = %v, want %v", tc.name, vis.Scope(), tc.wantScope)
+	}
+	if vis.Subject() != tc.wantSubject {
+		t.Errorf("RowVisibility(%s): subject = %q, want %q", tc.name, vis.Subject(), tc.wantSubject)
 	}
 }
 
@@ -197,11 +211,7 @@ func TestPrincipalRowVisibility_SuperAdminMandatoryAudit(t *testing.T) {
 
 	ctx := rowVisibilityTestCtx()
 
-	cases := []struct {
-		name      string
-		principal *Principal
-		wantError bool // true = expect ≥1 Error-level record with actor+scope+tenant+reason keys
-	}{
+	cases := []superAdminAuditCase{
 		{
 			name: "superadmin_emits_mandatory_audit",
 			principal: &Principal{
@@ -255,42 +265,55 @@ func TestPrincipalRowVisibility_SuperAdminMandatoryAudit(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			capture.records = capture.records[:0] // reset between sub-tests
-
-			_, _ = tc.principal.RowVisibility(ctx) // only testing slog side-effect
-
-			// Count Error-level records with all required FR-007 keys.
-			errorCount := 0
-			for _, r := range capture.records {
-				if r.Level != slog.LevelError {
-					continue
-				}
-				hasActor, hasScope, hasTenant, hasReason := false, false, false, false
-				r.Attrs(func(a slog.Attr) bool {
-					switch a.Key {
-					case "actor":
-						hasActor = true
-					case "scope":
-						hasScope = true
-					case "tenant":
-						hasTenant = true
-					case "reason":
-						hasReason = true
-					}
-					return true
-				})
-				if hasActor && hasScope && hasTenant && hasReason {
-					errorCount++
-				}
-			}
-
-			if tc.wantError && errorCount == 0 {
-				t.Errorf("%s: expected ≥1 slog.Error with keys {actor,scope,tenant,reason}, got 0 matching records (total records: %d)",
-					tc.name, len(capture.records))
-			}
-			if !tc.wantError && errorCount > 0 {
-				t.Errorf("%s: expected no slog.Error audit records, got %d", tc.name, errorCount)
-			}
+			assertSuperAdminAudit(t, ctx, capture, tc)
 		})
 	}
+}
+
+func assertSuperAdminAudit(t *testing.T, ctx context.Context, capture *captureHandler, tc superAdminAuditCase) {
+	t.Helper()
+
+	capture.records = capture.records[:0] // reset between sub-tests
+
+	_, _ = tc.principal.RowVisibility(ctx) // only testing slog side-effect
+
+	errorCount := countMandatoryAuditRecords(capture.records)
+	if tc.wantError && errorCount == 0 {
+		t.Errorf("%s: expected ≥1 slog.Error with keys {actor,scope,tenant,reason}, got 0 matching records (total records: %d)",
+			tc.name, len(capture.records))
+	}
+	if !tc.wantError && errorCount > 0 {
+		t.Errorf("%s: expected no slog.Error audit records, got %d", tc.name, errorCount)
+	}
+}
+
+func countMandatoryAuditRecords(records []slog.Record) int {
+	errorCount := 0
+	for _, r := range records {
+		if r.Level != slog.LevelError {
+			continue
+		}
+		if hasMandatoryAuditAttrs(r) {
+			errorCount++
+		}
+	}
+	return errorCount
+}
+
+func hasMandatoryAuditAttrs(r slog.Record) bool {
+	hasActor, hasScope, hasTenant, hasReason := false, false, false, false
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "actor":
+			hasActor = true
+		case "scope":
+			hasScope = true
+		case "tenant":
+			hasTenant = true
+		case "reason":
+			hasReason = true
+		}
+		return true
+	})
+	return hasActor && hasScope && hasTenant && hasReason
 }

--- a/runtime/auth/session/storetest/suite.go
+++ b/runtime/auth/session/storetest/suite.go
@@ -565,7 +565,7 @@ func runTS4D1GetRoundtripsEpoch(t *testing.T, factory Factory) {
 	const wantEpoch int64 = 42
 	fixture := NewSessionFixture(t, subjectA, "jti-epoch-rt", wantEpoch, caseTTL, fc.Now())
 	if err := store.Create(context.Background(), testTenantID, fixture); err != nil {
-		t.Fatalf("Create: %v", err)
+		t.Fatalf(errFmtCreate, err)
 	}
 	got, err := store.Get(context.Background(), fixture.ID)
 	if err != nil {
@@ -597,7 +597,7 @@ func runCreateGetRoundtripsTenantID(t *testing.T, factory Factory) {
 
 	fixture := NewSessionFixture(t, subjectA, "jti-tid-rt", caseEpoch, caseTTL, fc.Now())
 	if err := store.Create(context.Background(), testTenantID, fixture); err != nil {
-		t.Fatalf("Create: %v", err)
+		t.Fatalf(errFmtCreate, err)
 	}
 	got, err := store.Get(context.Background(), fixture.ID)
 	if err != nil {

--- a/runtime/bootstrap/auth_plan_validate.go
+++ b/runtime/bootstrap/auth_plan_validate.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	internalListenerFmt            = "listener=%q"
 	internalListenerPositionFmt    = "listener=%q position=%d"
 	internalListenerPositionMinFmt = internalListenerPositionFmt + " got=%d min=%d"
 )
@@ -184,7 +185,7 @@ func (b *Bootstrap) validateAuthNoneExclusive() error {
 				"AuthNone cannot be mixed with other ListenerAuth plans; "+
 					"use []auth.ListenerAuth{auth.AuthNone{}} only for no-auth "+
 					"listeners or remove AuthNone from protected chains",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("listener=%q", ref.String()))))
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalListenerFmt, ref.String()))))
 		}
 	}
 	return nil
@@ -220,7 +221,7 @@ func (b *Bootstrap) validateAuthServiceTokenPlans() error {
 			if seen > 1 {
 				return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 					"at most one AuthServiceToken plan allowed in authChain",
-					errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("listener=%q", ref.String()))))
+					errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalListenerFmt, ref.String()))))
 			}
 			if err := validateAuthServiceTokenPlan(ref.String(), i, p, enforceReplaySafe, requireDistributed); err != nil {
 				return err
@@ -320,7 +321,7 @@ func validateAuthOperatorChain(ref cell.ListenerRef, chain []auth.ListenerAuth) 
 			"cell.AdminListener requires an AuthOperator plan; the operator control-plane must be "+
 				"authenticated (loopback isolation alone is not sufficient). Wire "+
 				"bootstrap.WithListener(cell.AdminListener, addr, []kauth.ListenerAuth{<auth.NewAuthOperator(...)>})",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("listener=%q", ref.String()))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalListenerFmt, ref.String()))))
 	}
 	return nil
 }
@@ -330,7 +331,7 @@ func validateAuthOperatorPlan(ref cell.ListenerRef, position, seen int, p auth.A
 	if seen > 1 {
 		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			"at most one AuthOperator plan allowed in authChain",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("listener=%q", ref.String()))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalListenerFmt, ref.String()))))
 	}
 	if ref != cell.AdminListener {
 		return errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -38,6 +38,8 @@ import (
 // subscriptions via the metrics-side collector).
 var _ eventrouter.EventCollector = (*metricsmiddleware.EventRouterCollector)(nil)
 
+const msgAddWithSubscriber = "add WithSubscriber to bootstrap options"
+
 // phase6StartEventRouter registers subscriptions and starts the event router
 // using state.runCtx (independent of the external context).
 //
@@ -335,17 +337,17 @@ func (b *Bootstrap) checkNoEventConsumersWhenSubscriberNil(s *phaseState) error 
 		if len(snap.Subscriptions) > 0 {
 			return fmt.Errorf(
 				"bootstrap: cell %s registered subscriptions but no subscriber is configured; "+
-					"add WithSubscriber to bootstrap options", id)
+					msgAddWithSubscriber, id)
 		}
 		if len(snap.Projections) > 0 {
 			return fmt.Errorf(
 				"bootstrap: cell %s registered a projection but no subscriber is configured; "+
-					"add WithSubscriber to bootstrap options", id)
+					msgAddWithSubscriber, id)
 		}
 		if len(snap.WebhookDispatchers) > 0 {
 			return fmt.Errorf(
 				"bootstrap: cell %s registered a webhook dispatcher but no subscriber is configured; "+
-					"add WithSubscriber to bootstrap options", id)
+					msgAddWithSubscriber, id)
 		}
 	}
 	return nil

--- a/runtime/bootstrap/topology_test.go
+++ b/runtime/bootstrap/topology_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+type newTopologyCase struct {
+	name            string
+	adapterMode     string
+	storageBackend  string
+	singlePod       bool
+	wantErr         bool
+	wantStorage     string
+	wantRequireProd bool
+}
+
 // INVARIANT: TOPOLOGY-SEALED-FIELD-FROZEN-01
 //
 // TestTopologyZeroExportedFields enforces the sealed-construction invariant: a
@@ -29,15 +39,7 @@ func TestTopologyZeroExportedFields(t *testing.T) {
 }
 
 func TestNewTopology(t *testing.T) {
-	cases := []struct {
-		name            string
-		adapterMode     string
-		storageBackend  string
-		singlePod       bool
-		wantErr         bool
-		wantStorage     string
-		wantRequireProd bool
-	}{
+	cases := []newTopologyCase{
 		{"empty normalizes to memory dev", "", "", false, false, "memory", false},
 		{"explicit memory dev", "", "memory", false, false, "memory", false},
 		{"memory real", "real", "memory", false, false, "memory", true},
@@ -48,28 +50,34 @@ func TestNewTopology(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			topo, err := NewTopology(tc.adapterMode, tc.storageBackend, tc.singlePod)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil (topo=%+v)", topo)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if topo.StorageBackend() != tc.wantStorage {
-				t.Errorf("StorageBackend() = %q, want %q", topo.StorageBackend(), tc.wantStorage)
-			}
-			if topo.RequireProductionControlPlane() != tc.wantRequireProd {
-				t.Errorf("RequireProductionControlPlane() = %v, want %v",
-					topo.RequireProductionControlPlane(), tc.wantRequireProd)
-			}
-			if topo.SinglePodReplayProtection() != tc.singlePod {
-				t.Errorf("SinglePodReplayProtection() = %v, want %v",
-					topo.SinglePodReplayProtection(), tc.singlePod)
-			}
+			assertNewTopology(t, tc)
 		})
+	}
+}
+
+func assertNewTopology(t *testing.T, tc newTopologyCase) {
+	t.Helper()
+
+	topo, err := NewTopology(tc.adapterMode, tc.storageBackend, tc.singlePod)
+	if tc.wantErr {
+		if err == nil {
+			t.Fatalf("expected error, got nil (topo=%+v)", topo)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if topo.StorageBackend() != tc.wantStorage {
+		t.Errorf("StorageBackend() = %q, want %q", topo.StorageBackend(), tc.wantStorage)
+	}
+	if topo.RequireProductionControlPlane() != tc.wantRequireProd {
+		t.Errorf("RequireProductionControlPlane() = %v, want %v",
+			topo.RequireProductionControlPlane(), tc.wantRequireProd)
+	}
+	if topo.SinglePodReplayProtection() != tc.singlePod {
+		t.Errorf("SinglePodReplayProtection() = %v, want %v",
+			topo.SinglePodReplayProtection(), tc.singlePod)
 	}
 }
 

--- a/runtime/command/registry_test.go
+++ b/runtime/command/registry_test.go
@@ -19,9 +19,9 @@ type fakeHandler struct{ called bool }
 
 func (h *fakeHandler) Handle() { h.called = true }
 
-// fakeHandlerIface is the interface a generated Dispatch function would
+// fakeHandlerContract is the interface a generated Dispatch function would
 // type-assert to after LookupHandler, proving the generated-code pattern works.
-type fakeHandlerIface interface {
+type fakeHandlerContract interface {
 	Handle()
 }
 
@@ -45,7 +45,7 @@ func TestRegistry_RegisterThenLookup(t *testing.T) {
 
 // TestRegistry_TypeAssertBack proves that the boxed-as-any storage supports the
 // generated Dispatch pattern: box a concrete *fakeHandler, register, lookup,
-// type-assert back to fakeHandlerIface, invoke a method.
+// type-assert back to fakeHandlerContract, invoke a method.
 func TestRegistry_TypeAssertBack(t *testing.T) {
 	t.Parallel()
 	r := NewRegistry()
@@ -57,7 +57,7 @@ func TestRegistry_TypeAssertBack(t *testing.T) {
 	require.True(t, ok)
 
 	// Simulate what generated Dispatch code does.
-	typed, ok := got.(fakeHandlerIface)
+	typed, ok := got.(fakeHandlerContract)
 	require.True(t, ok, "type-assert from boxed any to handler interface must succeed")
 	typed.Handle()
 	assert.True(t, h.called, "Handle() invoked via type-asserted interface must reach concrete handler")

--- a/runtime/distlock/errors_test.go
+++ b/runtime/distlock/errors_test.go
@@ -12,37 +12,22 @@ import (
 // and matchable via errors.Is.
 func TestErrors_Sentinels(t *testing.T) {
 	t.Run("ErrLockLost_NotNil", func(t *testing.T) {
-		if distlock.ErrLockLost == nil {
-			t.Fatal("ErrLockLost must not be nil")
-		}
+		assertLockLostNotNil(t)
 	})
 	t.Run("ErrLockReleased_NotNil", func(t *testing.T) {
-		if distlock.ErrLockReleased == nil {
-			t.Fatal("ErrLockReleased must not be nil")
-		}
+		assertLockReleasedNotNil(t)
 	})
 	t.Run("ErrLockOrphaned_NotNil", func(t *testing.T) {
-		if distlock.ErrLockOrphaned == nil {
-			t.Fatal("ErrLockOrphaned must not be nil")
-		}
+		assertLockOrphanedNotNil(t)
 	})
 	t.Run("ErrLockLost_Distinct_FromErrLockReleased", func(t *testing.T) {
-		if errors.Is(distlock.ErrLockLost, distlock.ErrLockReleased) {
-			t.Fatal("ErrLockLost and ErrLockReleased must be distinct sentinels")
-		}
+		assertLockLostDistinctFromReleased(t)
 	})
 	t.Run("ErrLockOrphaned_Distinct_FromSiblings", func(t *testing.T) {
-		if errors.Is(distlock.ErrLockOrphaned, distlock.ErrLockLost) {
-			t.Fatal("ErrLockOrphaned and ErrLockLost must be distinct sentinels")
-		}
-		if errors.Is(distlock.ErrLockOrphaned, distlock.ErrLockReleased) {
-			t.Fatal("ErrLockOrphaned and ErrLockReleased must be distinct sentinels")
-		}
+		assertLockOrphanedDistinctFromSiblings(t)
 	})
 	t.Run("ErrLockTimeout_StableValue", func(t *testing.T) {
-		if distlock.ErrLockTimeout != "ERR_DISTLOCK_TIMEOUT" {
-			t.Errorf("ErrLockTimeout = %q, want %q", distlock.ErrLockTimeout, "ERR_DISTLOCK_TIMEOUT")
-		}
+		assertLockTimeoutStableValue(t)
 	})
 	// ErrLockOrphaned must unwrap to *errcode.Error with KindInternal and
 	// code ERR_DISTLOCK_LOCK_ORPHANED. KindInternal is chosen to match
@@ -50,15 +35,65 @@ func TestErrors_Sentinels(t *testing.T) {
 	// an HTTP handler is a server-side programming bug, not an external
 	// conflict — 500 is preferable to a misleading 409.
 	t.Run("ErrLockOrphaned_UnwrapsToErrcode", func(t *testing.T) {
-		var ec *errcode.Error
-		if !errors.As(distlock.ErrLockOrphaned, &ec) {
-			t.Fatalf("ErrLockOrphaned must unwrap to *errcode.Error; got %T", distlock.ErrLockOrphaned)
-		}
-		if ec.Code != errcode.ErrDistlockLockOrphaned {
-			t.Errorf("ErrLockOrphaned code = %q, want %q", ec.Code, errcode.ErrDistlockLockOrphaned)
-		}
-		if ec.Kind != errcode.KindInternal {
-			t.Errorf("ErrLockOrphaned kind = %v, want KindInternal", ec.Kind)
-		}
+		assertLockOrphanedUnwrapsToErrcode(t)
 	})
+}
+
+func assertLockLostNotNil(t *testing.T) {
+	t.Helper()
+	if distlock.ErrLockLost == nil {
+		t.Fatal("ErrLockLost must not be nil")
+	}
+}
+
+func assertLockReleasedNotNil(t *testing.T) {
+	t.Helper()
+	if distlock.ErrLockReleased == nil {
+		t.Fatal("ErrLockReleased must not be nil")
+	}
+}
+
+func assertLockOrphanedNotNil(t *testing.T) {
+	t.Helper()
+	if distlock.ErrLockOrphaned == nil {
+		t.Fatal("ErrLockOrphaned must not be nil")
+	}
+}
+
+func assertLockLostDistinctFromReleased(t *testing.T) {
+	t.Helper()
+	if errors.Is(distlock.ErrLockLost, distlock.ErrLockReleased) {
+		t.Fatal("ErrLockLost and ErrLockReleased must be distinct sentinels")
+	}
+}
+
+func assertLockOrphanedDistinctFromSiblings(t *testing.T) {
+	t.Helper()
+	if errors.Is(distlock.ErrLockOrphaned, distlock.ErrLockLost) {
+		t.Fatal("ErrLockOrphaned and ErrLockLost must be distinct sentinels")
+	}
+	if errors.Is(distlock.ErrLockOrphaned, distlock.ErrLockReleased) {
+		t.Fatal("ErrLockOrphaned and ErrLockReleased must be distinct sentinels")
+	}
+}
+
+func assertLockTimeoutStableValue(t *testing.T) {
+	t.Helper()
+	if distlock.ErrLockTimeout != "ERR_DISTLOCK_TIMEOUT" {
+		t.Errorf("ErrLockTimeout = %q, want %q", distlock.ErrLockTimeout, "ERR_DISTLOCK_TIMEOUT")
+	}
+}
+
+func assertLockOrphanedUnwrapsToErrcode(t *testing.T) {
+	t.Helper()
+	var ec *errcode.Error
+	if !errors.As(distlock.ErrLockOrphaned, &ec) {
+		t.Fatalf("ErrLockOrphaned must unwrap to *errcode.Error; got %T", distlock.ErrLockOrphaned)
+	}
+	if ec.Code != errcode.ErrDistlockLockOrphaned {
+		t.Errorf("ErrLockOrphaned code = %q, want %q", ec.Code, errcode.ErrDistlockLockOrphaned)
+	}
+	if ec.Kind != errcode.KindInternal {
+		t.Errorf("ErrLockOrphaned kind = %v, want KindInternal", ec.Kind)
+	}
 }

--- a/runtime/grpc/interceptor/access_log_test.go
+++ b/runtime/grpc/interceptor/access_log_test.go
@@ -67,7 +67,7 @@ func TestUnaryAccessLog(t *testing.T) {
 
 func TestUnaryAccessLogNilClockPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("UnaryAccessLog with nil clock must panic at construction")
 		}
 	}()

--- a/runtime/grpc/interceptor/auth_test.go
+++ b/runtime/grpc/interceptor/auth_test.go
@@ -30,136 +30,201 @@ func TestUnaryAuth(t *testing.T) {
 	info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Svc/Do"}
 
 	t.Run("valid token forwards principal-enriched ctx", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "user-1"}}
-		var gotPrincipal *auth.Principal
-		_, err := UnaryAuth(v)(bearerCtx(), nil, info,
-			func(ctx context.Context, _ any) (any, error) {
-				p, _ := auth.FromContext(ctx)
-				gotPrincipal = p
-				return "ok", nil
-			})
-		if err != nil {
-			t.Fatalf("err = %v", err)
-		}
-		if gotPrincipal == nil || gotPrincipal.Subject != "user-1" {
-			t.Fatalf("principal = %+v, want user-1", gotPrincipal)
-		}
+		assertUnaryAuthForwardsPrincipal(t, info)
 	})
 
 	t.Run("missing metadata -> Unauthenticated", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "x"}}
-		called := false
-		_, err := UnaryAuth(v)(context.Background(), nil, info, okHandler(&called))
-		if status.Code(err) != codes.Unauthenticated {
-			t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
-		}
-		if called {
-			t.Fatalf("handler must not run on missing auth")
-		}
+		assertUnaryAuthMissingMetadata(t, info)
 	})
 
 	t.Run("non-bearer scheme -> Unauthenticated", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "x"}}
-		md := metadata.Pairs(authMetadataKey, "Basic abc")
-		ctx := metadata.NewIncomingContext(context.Background(), md)
-		called := false
-		_, err := UnaryAuth(v)(ctx, nil, info, okHandler(&called))
-		if status.Code(err) != codes.Unauthenticated {
-			t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
-		}
+		assertUnaryAuthNonBearerScheme(t, info)
 	})
 
 	t.Run("verify infra outage -> Unavailable", func(t *testing.T) {
-		v := stubVerifier{err: errcode.New(errcode.KindUnavailable, errcode.ErrAuthServiceUnavailable, "jwks down")}
-		_, err := UnaryAuth(v)(bearerCtx(), nil, info,
-			func(context.Context, any) (any, error) { return "ok", nil })
-		if status.Code(err) != codes.Unavailable {
-			t.Fatalf("code = %v, want Unavailable", status.Code(err))
-		}
+		assertUnaryAuthVerifyOutage(t, info)
 	})
 
 	t.Run("intent mismatch maps to same Unauthenticated as invalid token (enumeration-safe)", func(t *testing.T) {
-		intentErr := stubVerifier{err: errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthInvalidTokenIntent, "wrong intent")}
-		plainErr := stubVerifier{err: errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "bad signature")}
-		pass := func(context.Context, any) (any, error) { return "ok", nil }
-
-		_, e1 := UnaryAuth(intentErr)(bearerCtx(), nil, info, pass)
-		_, e2 := UnaryAuth(plainErr)(bearerCtx(), nil, info, pass)
-		s1, s2 := status.Convert(e1), status.Convert(e2)
-		if s1.Code() != codes.Unauthenticated || s2.Code() != codes.Unauthenticated {
-			t.Fatalf("codes = %v / %v, want both Unauthenticated", s1.Code(), s2.Code())
-		}
-		if s1.Message() != s2.Message() {
-			t.Fatalf("messages differ (%q vs %q): token-type leak via gRPC status", s1.Message(), s2.Message())
-		}
+		assertUnaryAuthIntentMismatchIsEnumerationSafe(t, info)
 	})
 
 	t.Run("verify reject -> Unauthenticated", func(t *testing.T) {
-		v := stubVerifier{err: errcode.New(errcode.KindUnauthenticated, errcode.ErrInternal, "bad")}
-		_, err := UnaryAuth(v)(bearerCtx(), nil, info,
-			func(context.Context, any) (any, error) { return "ok", nil })
-		if status.Code(err) != codes.Unauthenticated {
-			t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
-		}
+		assertUnaryAuthVerifyReject(t, info)
 	})
 
 	t.Run("password reset blocks non-exempt method", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "u", PasswordResetRequired: true}}
-		called := false
-		_, err := UnaryAuth(v)(bearerCtx(), nil, info, okHandler(&called))
-		if status.Code(err) != codes.PermissionDenied {
-			t.Fatalf("code = %v, want PermissionDenied", status.Code(err))
-		}
-		if called {
-			t.Fatalf("handler must not run when reset blocks")
-		}
+		assertUnaryAuthPasswordResetBlocks(t, info)
 	})
 
 	t.Run("password reset exempt method passes", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "u", PasswordResetRequired: true}}
-		called := false
-		exempt := WithPasswordResetExempt(func(m string) bool { return m == info.FullMethod })
-		_, err := UnaryAuth(v, exempt)(bearerCtx(), nil, info, okHandler(&called))
-		if err != nil {
-			t.Fatalf("err = %v, want nil", err)
-		}
-		if !called {
-			t.Fatalf("handler must run for exempt method")
-		}
+		assertUnaryAuthPasswordResetExempt(t, info)
 	})
 
 	t.Run("public method bypasses auth", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "u"}}
-		called := false
-		pub := WithPublicMethod(func(m string) bool { return true })
-		// No auth metadata at all; public predicate must bypass before extraction.
-		_, err := UnaryAuth(v, pub)(context.Background(), nil, info, okHandler(&called))
-		if err != nil {
-			t.Fatalf("err = %v, want nil", err)
-		}
-		if !called {
-			t.Fatalf("handler must run for public method")
-		}
+		assertUnaryAuthPublicMethodBypasses(t, info)
 	})
 
 	t.Run("panicking publicMethod predicate returns Internal (not a raw panic)", func(t *testing.T) {
-		v := stubVerifier{claims: kauth.Claims{Subject: "u"}}
-		panicPred := WithPublicMethod(func(m string) bool { panic("predicate exploded") })
-		_, err := UnaryAuth(v, panicPred)(context.Background(), nil, info,
-			func(context.Context, any) (any, error) { return "ok", nil })
-		if status.Code(err) != codes.Internal {
-			t.Fatalf("code = %v, want Internal (predicate panic must not escape)", status.Code(err))
-		}
+		assertUnaryAuthPublicMethodPanic(t, info)
 	})
 
 	t.Run("nil verifier panics at construction (fail-fast wiring)", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatalf("UnaryAuth(nil) must panic at construction (security dep is required)")
-			}
-		}()
-		_ = UnaryAuth(nil)
+		assertUnaryAuthNilVerifierPanics(t)
 	})
+}
+
+func assertUnaryAuthForwardsPrincipal(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "user-1"}}
+	var gotPrincipal *auth.Principal
+	_, err := UnaryAuth(v)(bearerCtx(), nil, info,
+		func(ctx context.Context, _ any) (any, error) {
+			p, _ := auth.FromContext(ctx)
+			gotPrincipal = p
+			return "ok", nil
+		})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if gotPrincipal == nil || gotPrincipal.Subject != "user-1" {
+		t.Fatalf("principal = %+v, want user-1", gotPrincipal)
+	}
+}
+
+func assertUnaryAuthMissingMetadata(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "x"}}
+	called := false
+	_, err := UnaryAuth(v)(context.Background(), nil, info, okHandler(&called))
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
+	}
+	if called {
+		t.Fatalf("handler must not run on missing auth")
+	}
+}
+
+func assertUnaryAuthNonBearerScheme(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "x"}}
+	md := metadata.Pairs(authMetadataKey, "Basic abc")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	called := false
+	_, err := UnaryAuth(v)(ctx, nil, info, okHandler(&called))
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
+	}
+}
+
+func assertUnaryAuthVerifyOutage(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{err: errcode.New(errcode.KindUnavailable, errcode.ErrAuthServiceUnavailable, "jwks down")}
+	_, err := UnaryAuth(v)(bearerCtx(), nil, info,
+		func(context.Context, any) (any, error) { return "ok", nil })
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("code = %v, want Unavailable", status.Code(err))
+	}
+}
+
+func assertUnaryAuthIntentMismatchIsEnumerationSafe(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	intentErr := stubVerifier{err: errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthInvalidTokenIntent, "wrong intent")}
+	plainErr := stubVerifier{err: errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "bad signature")}
+	pass := func(context.Context, any) (any, error) { return "ok", nil }
+
+	_, e1 := UnaryAuth(intentErr)(bearerCtx(), nil, info, pass)
+	_, e2 := UnaryAuth(plainErr)(bearerCtx(), nil, info, pass)
+	s1, s2 := status.Convert(e1), status.Convert(e2)
+	if s1.Code() != codes.Unauthenticated || s2.Code() != codes.Unauthenticated {
+		t.Fatalf("codes = %v / %v, want both Unauthenticated", s1.Code(), s2.Code())
+	}
+	if s1.Message() != s2.Message() {
+		t.Fatalf("messages differ (%q vs %q): token-type leak via gRPC status", s1.Message(), s2.Message())
+	}
+}
+
+func assertUnaryAuthVerifyReject(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{err: errcode.New(errcode.KindUnauthenticated, errcode.ErrInternal, "bad")}
+	_, err := UnaryAuth(v)(bearerCtx(), nil, info,
+		func(context.Context, any) (any, error) { return "ok", nil })
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("code = %v, want Unauthenticated", status.Code(err))
+	}
+}
+
+func assertUnaryAuthPasswordResetBlocks(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "u", PasswordResetRequired: true}}
+	called := false
+	_, err := UnaryAuth(v)(bearerCtx(), nil, info, okHandler(&called))
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("code = %v, want PermissionDenied", status.Code(err))
+	}
+	if called {
+		t.Fatalf("handler must not run when reset blocks")
+	}
+}
+
+func assertUnaryAuthPasswordResetExempt(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "u", PasswordResetRequired: true}}
+	called := false
+	exempt := WithPasswordResetExempt(func(m string) bool { return m == info.FullMethod })
+	_, err := UnaryAuth(v, exempt)(bearerCtx(), nil, info, okHandler(&called))
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !called {
+		t.Fatalf("handler must run for exempt method")
+	}
+}
+
+func assertUnaryAuthPublicMethodBypasses(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "u"}}
+	called := false
+	pub := WithPublicMethod(func(m string) bool { return true })
+	// No auth metadata at all; public predicate must bypass before extraction.
+	_, err := UnaryAuth(v, pub)(context.Background(), nil, info, okHandler(&called))
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !called {
+		t.Fatalf("handler must run for public method")
+	}
+}
+
+func assertUnaryAuthPublicMethodPanic(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	v := stubVerifier{claims: kauth.Claims{Subject: "u"}}
+	panicPred := WithPublicMethod(func(m string) bool { panic("predicate exploded") })
+	_, err := UnaryAuth(v, panicPred)(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return "ok", nil })
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code = %v, want Internal (predicate panic must not escape)", status.Code(err))
+	}
+}
+
+func assertUnaryAuthNilVerifierPanics(t *testing.T) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("UnaryAuth(nil) must panic at construction (security dep is required)")
+		}
+	}()
+	_ = UnaryAuth(nil)
 }
 
 func TestBearerFromMetadata(t *testing.T) {

--- a/runtime/grpc/interceptor/cell_attribution_test.go
+++ b/runtime/grpc/interceptor/cell_attribution_test.go
@@ -52,7 +52,7 @@ func TestUnaryCellAttribution(t *testing.T) {
 
 func TestUnaryCellAttributionNilResolverPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("UnaryCellAttribution with nil resolver must panic at construction")
 		}
 	}()

--- a/runtime/grpc/interceptor/chain_test.go
+++ b/runtime/grpc/interceptor/chain_test.go
@@ -82,7 +82,7 @@ func TestNewUnaryChain(t *testing.T) {
 // runtime sentinel, so NewUnaryChain panics at construction (#1152 F1).
 func TestNewUnaryChainNilRegistrarPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("NewUnaryChain with a nil Deps.Registrar must panic")
 		}
 	}()

--- a/runtime/grpc/interceptor/metrics_test.go
+++ b/runtime/grpc/interceptor/metrics_test.go
@@ -89,7 +89,7 @@ func TestUnaryMetrics(t *testing.T) {
 
 func TestUnaryMetricsNilCollectorPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("UnaryMetrics with nil collector must panic at construction")
 		}
 	}()

--- a/runtime/grpc/interceptor/recovery_test.go
+++ b/runtime/grpc/interceptor/recovery_test.go
@@ -18,58 +18,76 @@ func TestUnaryRecovery(t *testing.T) {
 	info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Svc/Do"}
 
 	t.Run("non-panicking handler passes through", func(t *testing.T) {
-		want := "ok"
-		resp, err := UnaryRecovery()(context.Background(), nil, info,
-			func(context.Context, any) (any, error) { return want, nil })
-		if err != nil {
-			t.Fatalf("err = %v, want nil", err)
-		}
-		if resp != want {
-			t.Fatalf("resp = %v, want %v", resp, want)
-		}
+		assertUnaryRecoveryPassThrough(t, info)
 	})
 
 	t.Run("panic converts to codes.Internal with redacted slog", func(t *testing.T) {
-		var buf bytes.Buffer
-		prev := slog.Default()
-		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
-		defer slog.SetDefault(prev)
-
-		resp, err := UnaryRecovery()(context.Background(), nil, info,
-			func(context.Context, any) (any, error) {
-				panic("password=hunter2 boom")
-			})
-
-		if resp != nil {
-			t.Fatalf("resp = %v, want nil after panic", resp)
-		}
-		if status.Code(err) != codes.Internal {
-			t.Fatalf("code = %v, want Internal", status.Code(err))
-		}
-		out := buf.String()
-		if !strings.Contains(out, "panic recovered") {
-			t.Fatalf("slog missing panic log: %s", out)
-		}
-		if strings.Contains(out, "hunter2") {
-			t.Fatalf("slog leaked secret (not redacted): %s", out)
-		}
-		if !strings.Contains(out, "<REDACTED>") {
-			t.Fatalf("slog missing redaction marker: %s", out)
-		}
+		assertUnaryRecoveryRedactsPanic(t, info)
 	})
 
 	t.Run("panic log carries request_id from ctx", func(t *testing.T) {
-		var buf bytes.Buffer
-		prev := slog.Default()
-		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
-		defer slog.SetDefault(prev)
-
-		ctx := ctxkeys.WithRequestID(context.Background(), "req-xyz")
-		_, _ = UnaryRecovery()(ctx, nil, info,
-			func(context.Context, any) (any, error) { panic("boom") })
-
-		if !strings.Contains(buf.String(), `"request_id":"req-xyz"`) {
-			t.Fatalf("panic log missing request_id: %s", buf.String())
-		}
+		assertUnaryRecoveryLogsRequestID(t, info)
 	})
+}
+
+func assertUnaryRecoveryPassThrough(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	want := "ok"
+	resp, err := UnaryRecovery()(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return want, nil })
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if resp != want {
+		t.Fatalf("resp = %v, want %v", resp, want)
+	}
+}
+
+func assertUnaryRecoveryRedactsPanic(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	resp, err := UnaryRecovery()(context.Background(), nil, info,
+		func(context.Context, any) (any, error) {
+			panic("password=hunter2 boom")
+		})
+
+	if resp != nil {
+		t.Fatalf("resp = %v, want nil after panic", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code = %v, want Internal", status.Code(err))
+	}
+	out := buf.String()
+	if !strings.Contains(out, "panic recovered") {
+		t.Fatalf("slog missing panic log: %s", out)
+	}
+	if strings.Contains(out, "hunter2") {
+		t.Fatalf("slog leaked secret (not redacted): %s", out)
+	}
+	if !strings.Contains(out, "<REDACTED>") {
+		t.Fatalf("slog missing redaction marker: %s", out)
+	}
+}
+
+func assertUnaryRecoveryLogsRequestID(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	ctx := ctxkeys.WithRequestID(context.Background(), "req-xyz")
+	_, _ = UnaryRecovery()(ctx, nil, info,
+		func(context.Context, any) (any, error) { panic("boom") })
+
+	if !strings.Contains(buf.String(), `"request_id":"req-xyz"`) {
+		t.Fatalf("panic log missing request_id: %s", buf.String())
+	}
 }

--- a/runtime/grpc/interceptor/stream_test.go
+++ b/runtime/grpc/interceptor/stream_test.go
@@ -94,7 +94,7 @@ func TestStreamCellAttribution_WritesCellID(t *testing.T) {
 
 func TestStreamCellAttribution_NilResolverPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("StreamCellAttribution with a nil resolver must panic")
 		}
 	}()
@@ -150,7 +150,7 @@ func TestStreamAuth_ValidTokenReachesHandlerWithPrincipal(t *testing.T) {
 
 func TestStreamAuth_NilVerifierPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("StreamAuth with a nil verifier must panic at construction")
 		}
 	}()
@@ -196,7 +196,7 @@ func TestStreamMetrics_RecordsRPC(t *testing.T) {
 
 func TestStreamMetrics_NilCollectorPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("StreamMetrics with a nil collector must panic at construction")
 		}
 	}()
@@ -273,7 +273,7 @@ func TestStreamDrain_NoCancelOnNormalCompletion(t *testing.T) {
 
 func TestStreamDrain_NilPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("StreamDrain with a nil DrainSignal must panic at construction")
 		}
 	}()
@@ -301,7 +301,7 @@ func TestNewStreamChain_Smoke(t *testing.T) {
 
 func TestNewStreamChain_NilDrainPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("NewStreamChain with a nil Deps.Drain must panic (streams would be un-drainable)")
 		}
 	}()
@@ -312,7 +312,7 @@ func TestNewStreamChain_NilDrainPanics(t *testing.T) {
 
 func TestNewStreamChain_NilRegistrarPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("NewStreamChain with a nil Deps.Registrar must panic")
 		}
 	}()
@@ -323,7 +323,7 @@ func TestNewStreamChain_NilRegistrarPanics(t *testing.T) {
 
 func TestNewStreamChain_ZeroValueDrainPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("NewStreamChain with a zero-value new(DrainSignal) must panic (nil cancel → panic at GracefulStop)")
 		}
 	}()
@@ -334,7 +334,7 @@ func TestNewStreamChain_ZeroValueDrainPanics(t *testing.T) {
 
 func TestNewStreamChain_EmptyCellIDClosedSetPanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("NewStreamChain with an empty Deps.CellIDClosedSet must panic (would relabel every RPC _runtime)")
 		}
 	}()

--- a/runtime/grpc/interceptor/tracing_test.go
+++ b/runtime/grpc/interceptor/tracing_test.go
@@ -18,61 +18,79 @@ func TestUnaryTracing(t *testing.T) {
 	info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Svc/Do"}
 
 	t.Run("success sets rpc attributes and ends span", func(t *testing.T) {
-		tr := &recordingTracer{span: &recordingSpan{}}
-		_, err := UnaryTracing(tr)(context.Background(), nil, info,
-			func(context.Context, any) (any, error) { return "ok", nil })
-		if err != nil {
-			t.Fatalf("err = %v", err)
-		}
-		if tr.span.name != "pkg.Svc/Do" {
-			t.Fatalf("span name = %q, want pkg.Svc/Do", tr.span.name)
-		}
-		if !tr.span.ended {
-			t.Fatalf("span not ended")
-		}
-		if v, ok := tr.span.attr("rpc.system"); !ok || v != "grpc" {
-			t.Fatalf("rpc.system = %v ok=%v", v, ok)
-		}
-		if v, ok := tr.span.attr("rpc.service"); !ok || v != "pkg.Svc" {
-			t.Fatalf("rpc.service = %v ok=%v", v, ok)
-		}
-		if v, ok := tr.span.attr("rpc.method"); !ok || v != "Do" {
-			t.Fatalf("rpc.method = %v ok=%v", v, ok)
-		}
-		if v, ok := tr.span.attr("rpc.grpc.status_code"); !ok || v != int64(codes.OK) {
-			t.Fatalf("status_code = %v ok=%v, want %d", v, ok, codes.OK)
-		}
-		if tr.span.recordedErr != nil {
-			t.Fatalf("unexpected recorded error: %v", tr.span.recordedErr)
-		}
+		assertUnaryTracingSuccess(t, info)
 	})
 
 	t.Run("error records error and sets error status", func(t *testing.T) {
-		tr := &recordingTracer{span: &recordingSpan{}}
-		_, err := UnaryTracing(tr)(context.Background(), nil, info,
-			func(context.Context, any) (any, error) { return nil, status.Error(codes.NotFound, "nope") })
-		if status.Code(err) != codes.NotFound {
-			t.Fatalf("code = %v", status.Code(err))
-		}
-		if tr.span.recordedErr == nil {
-			t.Fatalf("expected RecordError to be called")
-		}
-		if tr.span.statusCode != wrapper.StatusError {
-			t.Fatalf("span status = %v, want StatusError", tr.span.statusCode)
-		}
-		if v, _ := tr.span.attr("rpc.grpc.status_code"); v != int64(codes.NotFound) {
-			t.Fatalf("status_code attr = %v, want %d", v, codes.NotFound)
-		}
+		assertUnaryTracingError(t, info)
 	})
 
 	t.Run("nil tracer degrades to noop", func(t *testing.T) {
-		// Must not panic.
-		_, err := UnaryTracing(nil)(context.Background(), nil, info,
-			func(context.Context, any) (any, error) { return nil, errors.New("x") })
-		if err == nil {
-			t.Fatalf("expected handler error to propagate")
-		}
+		assertUnaryTracingNilTracer(t, info)
 	})
+}
+
+func assertUnaryTracingSuccess(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	tr := &recordingTracer{span: &recordingSpan{}}
+	_, err := UnaryTracing(tr)(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return "ok", nil })
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if tr.span.name != "pkg.Svc/Do" {
+		t.Fatalf("span name = %q, want pkg.Svc/Do", tr.span.name)
+	}
+	if !tr.span.ended {
+		t.Fatalf("span not ended")
+	}
+	if v, ok := tr.span.attr("rpc.system"); !ok || v != "grpc" {
+		t.Fatalf("rpc.system = %v ok=%v", v, ok)
+	}
+	if v, ok := tr.span.attr("rpc.service"); !ok || v != "pkg.Svc" {
+		t.Fatalf("rpc.service = %v ok=%v", v, ok)
+	}
+	if v, ok := tr.span.attr("rpc.method"); !ok || v != "Do" {
+		t.Fatalf("rpc.method = %v ok=%v", v, ok)
+	}
+	if v, ok := tr.span.attr("rpc.grpc.status_code"); !ok || v != int64(codes.OK) {
+		t.Fatalf("status_code = %v ok=%v, want %d", v, ok, codes.OK)
+	}
+	if tr.span.recordedErr != nil {
+		t.Fatalf("unexpected recorded error: %v", tr.span.recordedErr)
+	}
+}
+
+func assertUnaryTracingError(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	tr := &recordingTracer{span: &recordingSpan{}}
+	_, err := UnaryTracing(tr)(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return nil, status.Error(codes.NotFound, "nope") })
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("code = %v", status.Code(err))
+	}
+	if tr.span.recordedErr == nil {
+		t.Fatalf("expected RecordError to be called")
+	}
+	if tr.span.statusCode != wrapper.StatusError {
+		t.Fatalf("span status = %v, want StatusError", tr.span.statusCode)
+	}
+	if v, _ := tr.span.attr("rpc.grpc.status_code"); v != int64(codes.NotFound) {
+		t.Fatalf("status_code attr = %v, want %d", v, codes.NotFound)
+	}
+}
+
+func assertUnaryTracingNilTracer(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	// Must not panic.
+	_, err := UnaryTracing(nil)(context.Background(), nil, info,
+		func(context.Context, any) (any, error) { return nil, errors.New("x") })
+	if err == nil {
+		t.Fatalf("expected handler error to propagate")
+	}
 }
 
 func TestUnaryTracingPropagation(t *testing.T) {

--- a/runtime/grpc/registrar_bindserver_test.go
+++ b/runtime/grpc/registrar_bindserver_test.go
@@ -21,7 +21,7 @@ import (
 func TestServiceRegistrar_RegisterBeforeBindServer_Panics(t *testing.T) {
 	reg := runtimegrpc.NewServiceRegistrar()
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("Register before BindServer must panic (delegation target unbound)")
 		}
 	}()
@@ -45,7 +45,7 @@ func TestServiceRegistrar_BindServerTwice_Panics(t *testing.T) {
 	reg := runtimegrpc.NewServiceRegistrar()
 	reg.BindServer(grpc.NewServer())
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Fatalf("second BindServer must panic (delegation target already bound)")
 		}
 	}()

--- a/runtime/http/idempotency/idempotencytest/conformance.go
+++ b/runtime/http/idempotency/idempotencytest/conformance.go
@@ -47,15 +47,16 @@ const (
 	// DeriveKey inputs for the conformance keys (assembled into IdempotencyKey
 	// vars below). The Main/AltNS/AltKey trio is chosen so AltNS differs from Main
 	// ONLY in namespace and AltKey ONLY in key — see conformKeyMain below.
-	conformTenant    = "conf-tenant"
-	conformTenantAlt = "conf-tenant-alt"
-	conformSubject   = "conf-subject"
-	conformMethod    = "POST"
-	conformPath      = "/conf"
-	conformIdem      = "conf-idem-001"
-	conformIdemAlt   = "conf-idem-alt-001"
-	shortLeaseTTL    = 50 * time.Millisecond
-	shortDoneTTL     = 50 * time.Millisecond
+	conformTenant       = "conf-tenant"
+	conformTenantAlt    = "conf-tenant-alt"
+	conformSubject      = "conf-subject"
+	conformMethod       = "POST"
+	conformPath         = "/conf"
+	conformIdem         = "conf-idem-001"
+	conformIdemAlt      = "conf-idem-alt-001"
+	claimAcquiredErrFmt = "Claim: state=%v err=%v; want ClaimAcquired nil"
+	shortLeaseTTL       = 50 * time.Millisecond
+	shortDoneTTL        = 50 * time.Millisecond
 	// conformLeaseTTL is a normal-length lease TTL used in conformance cases
 	// that do not exercise TTL expiry.
 	conformLeaseTTL = 30 * time.Second
@@ -155,7 +156,7 @@ func conformClaimDoneAfterRecord(t *testing.T, factory Factory) {
 	ctx := context.Background()
 	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
-		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
+		t.Fatalf(claimAcquiredErrFmt, state, err)
 	}
 
 	wantBody := []byte(`{"id":"abc"}`)
@@ -226,7 +227,7 @@ func conformReleaseAllowsReClaim(t *testing.T, factory Factory) {
 	ctx := context.Background()
 	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
-		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
+		t.Fatalf(claimAcquiredErrFmt, state, err)
 	}
 
 	if err := receipt.Release(ctx); err != nil {
@@ -277,7 +278,7 @@ func conformLeaseTTLExpiry(t *testing.T, factory Factory) {
 	ctx := context.Background()
 	state, _, _, err := store.Claim(ctx, conformKeyMain, conformFP, shortLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
-		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
+		t.Fatalf(claimAcquiredErrFmt, state, err)
 	}
 
 	// Advance past the lease TTL so it expires.
@@ -304,7 +305,7 @@ func conformLeaseTTLExpiryDifferentFingerprint(t *testing.T, factory Factory) {
 	ctx := context.Background()
 	state, _, _, err := store.Claim(ctx, conformKeyMain, conformFP, shortLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
-		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
+		t.Fatalf(claimAcquiredErrFmt, state, err)
 	}
 
 	adv.AdvancePast(shortLeaseTTL)
@@ -407,7 +408,7 @@ func conformDoneTTLExpiry(t *testing.T, factory Factory) {
 	// Claim and record with a very short done TTL.
 	state, _, receipt, err := store.Claim(ctx, conformKeyMain, conformFP, conformLeaseTTL)
 	if err != nil || state != idempotency.ClaimAcquired {
-		t.Fatalf("Claim: state=%v err=%v; want ClaimAcquired nil", state, err)
+		t.Fatalf(claimAcquiredErrFmt, state, err)
 	}
 
 	resp := BuildRecordedResponse(t, 200, []byte(`{"ok":true}`))

--- a/runtime/http/idempotency/middleware.go
+++ b/runtime/http/idempotency/middleware.go
@@ -295,10 +295,20 @@ func Middleware(clk clock.Clock, store Store, opts ...Option) func(http.Handler)
 	}
 
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			serveWithIdempotency(w, r, next, clk, store, cfg)
-		})
+		return idempotencyHandler{
+			next:   next,
+			clk:    clk,
+			store:  store,
+			config: cfg,
+		}
 	}
+}
+
+type idempotencyHandler struct {
+	next   http.Handler
+	clk    clock.Clock
+	store  Store
+	config middlewareConfig
 }
 
 // validateIdempotencyKey validates the key length and character set, writing
@@ -340,31 +350,25 @@ func readBodyFingerprint(ctx context.Context, w http.ResponseWriter, r *http.Req
 	return computeFingerprint(body), true
 }
 
-// serveWithIdempotency executes the per-request idempotency decision for a
+// ServeHTTP executes the per-request idempotency decision for a
 // single request, reducing the cognitive complexity of the closure returned by
 // Middleware. It checks exempt status first (before body read), then the method
 // gate, then principal identity, key validation, and finally the full claim flow.
-func serveWithIdempotency(
-	w http.ResponseWriter,
-	r *http.Request,
-	next http.Handler,
-	clk clock.Clock,
-	store Store,
-	cfg middlewareConfig,
-) {
+func (h idempotencyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Exempt check runs first — before method gate and before body read,
 	// so exempt routes pay zero body-buffering cost.
+	cfg := h.config
 	if cfg.exemptMatcher != nil && cfg.exemptMatcher(r) {
-		next.ServeHTTP(w, r)
+		h.next.ServeHTTP(w, r)
 		return
 	}
 	if !shouldIntercept(r) {
-		next.ServeHTTP(w, r)
+		h.next.ServeHTTP(w, r)
 		return
 	}
 	p, ok := extractIdentity(r.Context())
 	if !ok {
-		next.ServeHTTP(w, r)
+		h.next.ServeHTTP(w, r)
 		return
 	}
 	idemKey := r.Header.Get(headerIdempotencyKey)
@@ -375,7 +379,7 @@ func serveWithIdempotency(
 	if !ok {
 		return
 	}
-	handleWithIdempotency(w, r, next, p, idemKey, fp, clk, store, cfg)
+	h.handle(w, r, p, idemKey, fp)
 }
 
 // shouldIntercept returns true when the request method and Idempotency-Key
@@ -385,35 +389,28 @@ func shouldIntercept(r *http.Request) bool {
 }
 
 // handleWithIdempotency executes the full idempotency flow for a qualifying request.
-func handleWithIdempotency(
-	w http.ResponseWriter,
-	r *http.Request,
-	next http.Handler,
-	p *auth.Principal,
-	idemKey string,
-	fingerprint string,
-	clk clock.Clock,
-	store Store,
-	cfg middlewareConfig,
-) {
+func (h idempotencyHandler) handle(w http.ResponseWriter, r *http.Request, p *auth.Principal, idemKey string, fp string) {
+	cfg := h.config
 	k := DeriveKey(p.TenantID, p.Subject, r.Method, r.URL.Path, idemKey)
 	ns := k.Namespace() // for slog correlation + recordOrRelease below
 	ctx := r.Context()
 	keyHash := keyShortHash(idemKey)
 
-	state, rec, receipt, err := store.Claim(ctx, k, fingerprint, cfg.leaseTTL)
+	state, rec, receipt, err := h.store.Claim(ctx, k, fp, cfg.leaseTTL)
 	if err != nil {
 		if errors.Is(err, ErrFingerprintMismatch) {
-			slog.WarnContext(ctx, "idempotency: fingerprint mismatch — key reused with different body",
+			slog.WarnContext(
+				ctx, "idempotency: fingerprint mismatch — key reused with different body",
 				"idempotency_key_hash", keyHash,
 				"subject", p.Subject,
 				"tenant_id", ns,
 			)
 			cfg.observeState(ctx, StateKeyReused)
-			httputil.WriteError(ctx, w, keyReusedError(err, fingerprint))
+			httputil.WriteError(ctx, w, keyReusedError(err, fp))
 			return
 		}
-		slog.ErrorContext(ctx, "idempotency: store claim failed",
+		slog.ErrorContext(
+			ctx, "idempotency: store claim failed",
 			"err", err,
 			"idempotency_key_hash", keyHash,
 			"subject", p.Subject,
@@ -438,7 +435,8 @@ func handleWithIdempotency(
 		// authorized. Re-checking authz on replay would let a previously-succeeded
 		// key later return 403, violating Idempotency-Key semantics (same key →
 		// same response). See ADR 202606021000-1043 威胁矩阵 row "回放跳过当前授权再校验".
-		slog.DebugContext(ctx, "idempotency: replay hit",
+		slog.DebugContext(
+			ctx, "idempotency: replay hit",
 			"idempotency_key_hash", keyHash,
 			"subject", p.Subject,
 			"tenant_id", ns,
@@ -447,7 +445,8 @@ func handleWithIdempotency(
 		replayResponse(w, rec)
 
 	case idempotency.ClaimBusy:
-		slog.WarnContext(ctx, "idempotency: key in progress",
+		slog.WarnContext(
+			ctx, "idempotency: key in progress",
 			"idempotency_key_hash", keyHash,
 			"subject", p.Subject,
 			"tenant_id", ns,
@@ -460,7 +459,7 @@ func handleWithIdempotency(
 
 	default: // ClaimAcquired
 		cfg.observeState(ctx, StateAcquired)
-		recordOrRelease(ctx, w, r, next, clk, receipt, cfg, keyHash, ns, p.Subject)
+		h.recordOrRelease(w, r, receipt, keyHash, ns, p.Subject)
 	}
 }
 
@@ -490,7 +489,13 @@ func replayResponse(w http.ResponseWriter, rec *RecordedResponse) {
 	}
 	w.Header().Set(headerIdempotencyReplayed, "true")
 	w.WriteHeader(rec.Status())
-	_, _ = w.Write(rec.Body()) //nolint:gosec // G705: Body() returns a cloned []byte from a trusted store; no user-controlled taint path
+	writeRecordedBody(w, rec.Body())
+}
+
+func writeRecordedBody(w http.ResponseWriter, body []byte) {
+	if _, err := io.Copy(w, bytes.NewReader(body)); err != nil {
+		slog.Error("idempotency: replay response body write failed", slog.Any("error", err))
+	}
 }
 
 // recordOrRelease wraps the handler invocation: runs next inside a
@@ -498,21 +503,19 @@ func replayResponse(w http.ResponseWriter, rec *RecordedResponse) {
 // releases the lease (on failure or oversized body) so the key can be
 // re-tried.
 //
-// A defer ensures Release is called even if the handler panics, so the
-// lease is not held indefinitely after a panic. The panic propagates
-// naturally after Release.
-func recordOrRelease(
-	ctx context.Context,
+// A defer ensures Release is called even if the handler panics, so the lease is
+// not held indefinitely after a panic. The panic propagates naturally after
+// Release.
+func (h idempotencyHandler) recordOrRelease(
 	w http.ResponseWriter,
 	r *http.Request,
-	next http.Handler,
-	clk clock.Clock,
 	receipt Receipt,
-	cfg middlewareConfig,
 	keyHash string,
-	ns string,
+	namespace string,
 	subject string,
 ) {
+	ctx := r.Context()
+	cfg := h.config
 	bw := newBufferingWriter(w, cfg.maxBodyBytes)
 
 	recorded := false
@@ -522,40 +525,43 @@ func recordOrRelease(
 			// if the request context was canceled during handler execution.
 			// The lease will expire via TTL regardless; log at Warn on error.
 			if err := receipt.Release(context.WithoutCancel(ctx)); err != nil {
-				slog.WarnContext(ctx, "idempotency: lease release failed (will expire via TTL)",
+				slog.WarnContext(
+					ctx, "idempotency: lease release failed (will expire via TTL)",
 					"err", err,
 					"idempotency_key_hash", keyHash,
 					"subject", subject,
-					"tenant_id", ns,
+					"tenant_id", namespace,
 				)
 			}
 		}
 	}()
 
-	next.ServeHTTP(bw, r)
+	h.next.ServeHTTP(bw, r)
 
 	// Only record if the handler committed a successful (2xx/3xx) response
 	// and the body did not overflow the capture limit.
 	if bw.committed() && shouldRecord(bw.status()) && !bw.isOversized() {
 		filteredHeader := filterSensitiveHeaders(bw.capturedHeader())
-		resp := newRecordedResponse(clk, bw.status(), bw.bufferedBody(), filteredHeader)
+		resp := newRecordedResponse(h.clk, bw.status(), bw.bufferedBody(), filteredHeader)
 		if err := receipt.Record(context.WithoutCancel(ctx), &resp, cfg.doneTTL); err != nil {
-			slog.ErrorContext(ctx, "idempotency: receipt record failed",
+			slog.ErrorContext(
+				ctx, "idempotency: receipt record failed",
 				"err", err,
 				"idempotency_key_hash", keyHash,
 				"subject", subject,
-				"tenant_id", ns,
+				"tenant_id", namespace,
 			)
 			// Fall through to Release via defer.
 		} else {
 			recorded = true
 		}
 	} else if bw.committed() && bw.isOversized() {
-		slog.WarnContext(ctx, "idempotency: response body oversized, not recorded",
+		slog.WarnContext(
+			ctx, "idempotency: response body oversized, not recorded",
 			"max_body_bytes", cfg.maxBodyBytes,
 			"idempotency_key_hash", keyHash,
 			"subject", subject,
-			"tenant_id", ns,
+			"tenant_id", namespace,
 		)
 		cfg.observeState(ctx, StateOversize)
 	}

--- a/runtime/internal/contractbuild/contractbuild_test.go
+++ b/runtime/internal/contractbuild/contractbuild_test.go
@@ -42,6 +42,15 @@ func assertSpecEqual(t *testing.T, got, want contractspec.ContractSpec) {
 	}
 }
 
+type eventDerivationInvalidCase struct {
+	name    string
+	sub     outbox.Subscription
+	wantMsg string
+	// subLayer asserts the error came from sub.Validate (shape gate)
+	// rather than the derived spec.Validate (defense in depth).
+	subLayer bool
+}
+
 // TestNewFrameworkHTTP verifies that NewFrameworkHTTP produces a ContractSpec
 // with the correct field values for each input combination, and that the
 // resulting spec passes Validate(). The bad-prefix panic path is covered
@@ -361,14 +370,7 @@ func TestNewEventDerivation_Invalid(t *testing.T) {
 	badKind := validEventSub() // valid Subscription, but kind is not a real ContractKind
 	badKind.ContractKind = "garbage"
 
-	cases := []struct {
-		name    string
-		sub     outbox.Subscription
-		wantMsg string
-		// subLayer asserts the error came from sub.Validate (shape gate)
-		// rather than the derived spec.Validate (defense in depth).
-		subLayer bool
-	}{
+	cases := []eventDerivationInvalidCase{
 		{
 			name:     "subscription missing topic — shape gate",
 			sub:      missingTopic,
@@ -392,25 +394,31 @@ func TestNewEventDerivation_Invalid(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := contractbuild.NewEventDerivation(tc.sub)
-			if err == nil {
-				t.Fatalf("expected error, got nil (spec=%+v)", got)
-			}
-			if !strings.Contains(err.Error(), tc.wantMsg) {
-				t.Errorf("error message = %q, want substring %q", err.Error(), tc.wantMsg)
-			}
-			if !strings.Contains(err.Error(), "NewEventDerivation") {
-				t.Errorf("error message = %q, want funnel context %q", err.Error(), "NewEventDerivation")
-			}
-			if gotSubLayer := strings.Contains(err.Error(), "subscription invalid"); gotSubLayer != tc.subLayer {
-				t.Errorf("validation layer mismatch: err=%q subLayer=%v want=%v", err.Error(), gotSubLayer, tc.subLayer)
-			}
-			// Returned spec must be zero on error (fail-closed contract).
-			assertSpecEqual(t, got, contractspec.ContractSpec{})
-			// errors.Is contract: underlying validator error is wrapped via %w.
-			if errors.Unwrap(err) == nil {
-				t.Errorf("error is not wrapping a cause; expected %%w chain")
-			}
+			assertEventDerivationInvalid(t, tc)
 		})
+	}
+}
+
+func assertEventDerivationInvalid(t *testing.T, tc eventDerivationInvalidCase) {
+	t.Helper()
+
+	got, err := contractbuild.NewEventDerivation(tc.sub)
+	if err == nil {
+		t.Fatalf("expected error, got nil (spec=%+v)", got)
+	}
+	if !strings.Contains(err.Error(), tc.wantMsg) {
+		t.Errorf("error message = %q, want substring %q", err.Error(), tc.wantMsg)
+	}
+	if !strings.Contains(err.Error(), "NewEventDerivation") {
+		t.Errorf("error message = %q, want funnel context %q", err.Error(), "NewEventDerivation")
+	}
+	if gotSubLayer := strings.Contains(err.Error(), "subscription invalid"); gotSubLayer != tc.subLayer {
+		t.Errorf("validation layer mismatch: err=%q subLayer=%v want=%v", err.Error(), gotSubLayer, tc.subLayer)
+	}
+	// Returned spec must be zero on error (fail-closed contract).
+	assertSpecEqual(t, got, contractspec.ContractSpec{})
+	// errors.Is contract: underlying validator error is wrapped via %w.
+	if errors.Unwrap(err) == nil {
+		t.Errorf("error is not wrapping a cause; expected %%w chain")
 	}
 }

--- a/runtime/observability/metrics/metricstest/conformance.go
+++ b/runtime/observability/metrics/metricstest/conformance.go
@@ -24,6 +24,11 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/metrics"
 )
 
+const (
+	testSessionsRoute = "/api/v1/sessions"
+	testUploadRoute   = "/api/v1/upload"
+)
+
 // Label builds a [metrics.CellLabel] for a genuine closed-set MEMBER by routing
 // a cell id through the sole [metrics.ResolveCellLabel] funnel (ctx-injected cell
 // + singleton allow-set in which id IS a member). The suite therefore constructs
@@ -138,10 +143,10 @@ func conformRecordRequestCount(t *testing.T, h CollectorHarness) {
 	col, obs := h.New(t)
 
 	ctx := context.Background()
-	col.RecordRequest(ctx, Label("accesscore"), "GET", "/api/v1/sessions", 200, 0.01)
-	col.RecordRequest(ctx, Label("accesscore"), "GET", "/api/v1/sessions", 200, 0.02)
+	col.RecordRequest(ctx, Label("accesscore"), "GET", testSessionsRoute, 200, 0.01)
+	col.RecordRequest(ctx, Label("accesscore"), "GET", testSessionsRoute, 200, 0.02)
 
-	key := RequestKey{Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
+	key := RequestKey{Cell: "accesscore", Method: "GET", Route: testSessionsRoute, Status: 200}
 	got := obs.RequestCount(key)
 	if got != 2 {
 		t.Errorf("RecordRequest count: got %d, want 2 (two calls same key)", got)
@@ -156,11 +161,11 @@ func conformRecordRequestLabelIsolation(t *testing.T, h CollectorHarness) {
 	col, obs := h.New(t)
 
 	ctx := context.Background()
-	col.RecordRequest(ctx, Label("accesscore"), "GET", "/api/v1/sessions", 200, 0.01)
-	col.RecordRequest(ctx, Label("auditcore"), "GET", "/api/v1/sessions", 200, 0.01)
+	col.RecordRequest(ctx, Label("accesscore"), "GET", testSessionsRoute, 200, 0.01)
+	col.RecordRequest(ctx, Label("auditcore"), "GET", testSessionsRoute, 200, 0.01)
 
-	key1 := RequestKey{Cell: "accesscore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
-	key2 := RequestKey{Cell: "auditcore", Method: "GET", Route: "/api/v1/sessions", Status: 200}
+	key1 := RequestKey{Cell: "accesscore", Method: "GET", Route: testSessionsRoute, Status: 200}
+	key2 := RequestKey{Cell: "auditcore", Method: "GET", Route: testSessionsRoute, Status: 200}
 	if got := obs.RequestCount(key1); got != 1 {
 		t.Errorf("accesscore count: got %d, want 1", got)
 	}
@@ -176,10 +181,10 @@ func conformBodyLimitRejectionCount(t *testing.T, h CollectorHarness) {
 	col, obs := h.New(t)
 
 	ctx := context.Background()
-	col.RecordBodyLimitRejection(ctx, Label("accesscore"), "/api/v1/upload")
-	col.RecordBodyLimitRejection(ctx, Label("accesscore"), "/api/v1/upload")
+	col.RecordBodyLimitRejection(ctx, Label("accesscore"), testUploadRoute)
+	col.RecordBodyLimitRejection(ctx, Label("accesscore"), testUploadRoute)
 
-	key := BodyLimitRejectionKey{Cell: "accesscore", Route: "/api/v1/upload"}
+	key := BodyLimitRejectionKey{Cell: "accesscore", Route: testUploadRoute}
 	if got := obs.BodyLimitRejectionCount(key); got != 2 {
 		t.Errorf("BodyLimitRejection count: got %d, want 2", got)
 	}
@@ -195,7 +200,7 @@ func conformBodyLimitRejectionCtxForwarded(t *testing.T, h CollectorHarness) {
 	type sentinelKey struct{}
 	want := "sentinel-ctx-value"
 	ctx := context.WithValue(context.Background(), sentinelKey{}, want)
-	col.RecordBodyLimitRejection(ctx, Label("accesscore"), "/api/v1/upload")
+	col.RecordBodyLimitRejection(ctx, Label("accesscore"), testUploadRoute)
 
 	lastCtx := obs.LastCtxForBodyLimitRejection()
 	if lastCtx == nil {
@@ -236,10 +241,10 @@ func conformBodyLimitRejectionKeyIsolation(t *testing.T, h CollectorHarness) {
 	col, obs := h.New(t)
 
 	ctx := context.Background()
-	col.RecordBodyLimitRejection(ctx, Label("accesscore"), "/api/v1/upload")
+	col.RecordBodyLimitRejection(ctx, Label("accesscore"), testUploadRoute)
 	col.RecordBodyLimitRejection(ctx, Label("configcore"), "/api/v1/config")
 
-	key1 := BodyLimitRejectionKey{Cell: "accesscore", Route: "/api/v1/upload"}
+	key1 := BodyLimitRejectionKey{Cell: "accesscore", Route: testUploadRoute}
 	key2 := BodyLimitRejectionKey{Cell: "configcore", Route: "/api/v1/config"}
 	if got := obs.BodyLimitRejectionCount(key1); got != 1 {
 		t.Errorf("accesscore/upload count: got %d, want 1", got)

--- a/runtime/observability/metrics/provider_collector.go
+++ b/runtime/observability/metrics/provider_collector.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
+const metricAlreadyOwnedFmt = "(likely duplicate — another collector on this Provider may already own the name): %w"
+
 // DefaultDurationBuckets are the histogram buckets previously hardcoded in
 // adapters/prometheus.Collector. Matching them keeps existing Grafana
 // dashboards valid after the migration to the provider-neutral surface.
@@ -57,7 +59,7 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runtime/observability/metrics: register http_requests_total "+
-			"(likely duplicate — another collector on this Provider may already own the name): %w", err)
+			metricAlreadyOwnedFmt, err)
 	}
 	dur, err := p.HistogramVec(kernelmetrics.HistogramOpts{
 		Name:       "http_request_duration_seconds",
@@ -67,7 +69,7 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runtime/observability/metrics: register http_request_duration_seconds "+
-			"(likely duplicate — another collector on this Provider may already own the name): %w", err)
+			metricAlreadyOwnedFmt, err)
 	}
 
 	blr, err := p.CounterVec(kernelmetrics.CounterOpts{
@@ -77,7 +79,7 @@ func NewProviderCollector(p kernelmetrics.Provider, cfg ProviderCollectorConfig)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("runtime/observability/metrics: register http_request_body_limit_rejections_total "+
-			"(likely duplicate — another collector on this Provider may already own the name): %w", err)
+			metricAlreadyOwnedFmt, err)
 	}
 
 	return &providerCollector{requests: reqs, duration: dur, bodyLimitRejections: blr}, nil

--- a/runtime/saga/internal/sagalog/sagalog_test.go
+++ b/runtime/saga/internal/sagalog/sagalog_test.go
@@ -7,6 +7,15 @@ import (
 	"github.com/ghbvf/gocell/pkg/idutil"
 )
 
+type instanceFieldsCase struct {
+	name       string
+	instanceID idutil.SafeID
+	leaseID    idutil.SafeID
+	extra      []slog.Attr
+	// wantKeys is the full expected key sequence (mandatory pair first).
+	wantKeys []string
+}
+
 // TestInstanceFields_CarriesInstanceAndLeaseID is the regression lock for the
 // #1266 invariant "every per-instance saga log carries lease_id". It asserts
 // the carrier always emits instance_id + lease_id (set to the positional args)
@@ -16,14 +25,7 @@ import (
 func TestInstanceFields_CarriesInstanceAndLeaseID(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		instanceID idutil.SafeID
-		leaseID    idutil.SafeID
-		extra      []slog.Attr
-		// wantKeys is the full expected key sequence (mandatory pair first).
-		wantKeys []string
-	}{
+	tests := []instanceFieldsCase{
 		{
 			name:       "no extras",
 			instanceID: "inst-123",
@@ -64,29 +66,34 @@ func TestInstanceFields_CarriesInstanceAndLeaseID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			got := InstanceFields(tt.instanceID, tt.leaseID, tt.extra...)
-
-			if len(got) != len(tt.wantKeys) {
-				t.Fatalf("attr count = %d, want %d (%v)", len(got), len(tt.wantKeys), tt.wantKeys)
-			}
-			gotKeys := make([]string, len(got))
-			for i, a := range got {
-				gotKeys[i] = a.Key
-			}
-			for i, want := range tt.wantKeys {
-				if gotKeys[i] != want {
-					t.Errorf("attr[%d].Key = %q, want %q (full: %v)", i, gotKeys[i], want, gotKeys)
-				}
-			}
-
-			// The two mandatory attrs must carry the positional arg values.
-			if got[0].Key != "instance_id" || got[0].Value.String() != string(tt.instanceID) {
-				t.Errorf("instance_id attr = %v, want %q", got[0], string(tt.instanceID))
-			}
-			if got[1].Key != "lease_id" || got[1].Value.String() != string(tt.leaseID) {
-				t.Errorf("lease_id attr = %v, want %q", got[1], string(tt.leaseID))
-			}
+			assertInstanceFields(t, tt)
 		})
+	}
+}
+
+func assertInstanceFields(t *testing.T, tt instanceFieldsCase) {
+	t.Helper()
+
+	got := InstanceFields(tt.instanceID, tt.leaseID, tt.extra...)
+
+	if len(got) != len(tt.wantKeys) {
+		t.Fatalf("attr count = %d, want %d (%v)", len(got), len(tt.wantKeys), tt.wantKeys)
+	}
+	gotKeys := make([]string, len(got))
+	for i, a := range got {
+		gotKeys[i] = a.Key
+	}
+	for i, want := range tt.wantKeys {
+		if gotKeys[i] != want {
+			t.Errorf("attr[%d].Key = %q, want %q (full: %v)", i, gotKeys[i], want, gotKeys)
+		}
+	}
+
+	// The two mandatory attrs must carry the positional arg values.
+	if got[0].Key != "instance_id" || got[0].Value.String() != string(tt.instanceID) {
+		t.Errorf("instance_id attr = %v, want %q", got[0], string(tt.instanceID))
+	}
+	if got[1].Key != "lease_id" || got[1].Value.String() != string(tt.leaseID) {
+		t.Errorf("lease_id attr = %v, want %q", got[1], string(tt.leaseID))
 	}
 }

--- a/runtime/saga/metrics_observer_test.go
+++ b/runtime/saga/metrics_observer_test.go
@@ -149,16 +149,18 @@ func TestLeaderSkipLogLevel(t *testing.T) {
 	}
 }
 
+type acquireLeadSkipCase struct {
+	name   string
+	err    error
+	reason executor.LeaderSkipReason
+}
+
 // ---------------------------------------------------------------------------
 // acquireLead emits ObserveLeaderSkip with the classified reason
 // ---------------------------------------------------------------------------
 
 func TestAcquireLead_Skip_EmitsLeaderSkipReason(t *testing.T) {
-	cases := []struct {
-		name   string
-		err    error
-		reason executor.LeaderSkipReason
-	}{
+	cases := []acquireLeadSkipCase{
 		{"contended", errcode.New(errcode.KindConflict, errcode.ErrDistlockTimeout, "held"), executor.LeaderSkipContended},
 		{"ctx_canceled", context.Canceled, executor.LeaderSkipCtxCanceled},
 		{"backend_error", errors.New("redis down"), executor.LeaderSkipBackendError},
@@ -176,32 +178,38 @@ func TestAcquireLead_Skip_EmitsLeaderSkipReason(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			clk := newFakeClock()
-			obs := &recordingObserver{}
-			c, err := NewCoordinator(newMemJournal(clk), newSafeFakeTxRunner(), newSafeFakeEmitter(), reg, clk,
-				WithConfig(leaderElectCfg()), WithObserver(obs), WithLeaderElect(errLocker{err: tc.err}))
-			if err != nil {
-				t.Fatalf("NewCoordinator: %v", err)
-			}
-			ci := journal.ClaimedInstance{
-				Instance: ksaga.NewInstance(mustNewUUID(t), "def-skip", clk.Now()),
-				LeaseID:  "lease-1",
-			}
-			_, _, lead := c.acquireLead(context.Background(), ci)
-			if lead {
-				t.Fatal("acquireLead returned lead=true on Acquire error")
-			}
-			skips := obs.snapshotSkips()
-			if len(skips) != 1 {
-				t.Fatalf("ObserveLeaderSkip calls = %d, want 1", len(skips))
-			}
-			if skips[0].reason != tc.reason {
-				t.Errorf("reason = %q, want %q", skips[0].reason, tc.reason)
-			}
-			if skips[0].definitionID != "def-skip" {
-				t.Errorf("definitionID = %q, want def-skip", skips[0].definitionID)
-			}
+			assertAcquireLeadSkipReason(t, reg, tc)
 		})
+	}
+}
+
+func assertAcquireLeadSkipReason(t *testing.T, reg *ksaga.InMemoryRegistry, tc acquireLeadSkipCase) {
+	t.Helper()
+
+	clk := newFakeClock()
+	obs := &recordingObserver{}
+	c, err := NewCoordinator(newMemJournal(clk), newSafeFakeTxRunner(), newSafeFakeEmitter(), reg, clk,
+		WithConfig(leaderElectCfg()), WithObserver(obs), WithLeaderElect(errLocker{err: tc.err}))
+	if err != nil {
+		t.Fatalf("NewCoordinator: %v", err)
+	}
+	ci := journal.ClaimedInstance{
+		Instance: ksaga.NewInstance(mustNewUUID(t), "def-skip", clk.Now()),
+		LeaseID:  "lease-1",
+	}
+	_, _, lead := c.acquireLead(context.Background(), ci)
+	if lead {
+		t.Fatal("acquireLead returned lead=true on Acquire error")
+	}
+	skips := obs.snapshotSkips()
+	if len(skips) != 1 {
+		t.Fatalf("ObserveLeaderSkip calls = %d, want 1", len(skips))
+	}
+	if skips[0].reason != tc.reason {
+		t.Errorf("reason = %q, want %q", skips[0].reason, tc.reason)
+	}
+	if skips[0].definitionID != "def-skip" {
+		t.Errorf("definitionID = %q, want def-skip", skips[0].definitionID)
 	}
 }
 

--- a/runtime/saga/tailer/observer.go
+++ b/runtime/saga/tailer/observer.go
@@ -102,19 +102,29 @@ const (
 type NopObserver struct{}
 
 // ObserveLockAcquire implements Observer.
-func (NopObserver) ObserveLockAcquire(context.Context, string, LockAcquireResult) {}
+func (NopObserver) ObserveLockAcquire(context.Context, string, LockAcquireResult) {
+	// Default observer intentionally drops lock-acquire events.
+}
 
 // ObserveDrain implements Observer.
-func (NopObserver) ObserveDrain(context.Context, string, DrainResult) {}
+func (NopObserver) ObserveDrain(context.Context, string, DrainResult) {
+	// Default observer intentionally drops drain events.
+}
 
 // ObserveCheckpointAdvance implements Observer.
-func (NopObserver) ObserveCheckpointAdvance(context.Context, string, AdvanceResult) {}
+func (NopObserver) ObserveCheckpointAdvance(context.Context, string, AdvanceResult) {
+	// Default observer intentionally drops checkpoint-advance events.
+}
 
 // ObserveLag implements Observer.
-func (NopObserver) ObserveLag(context.Context, string, int64) {}
+func (NopObserver) ObserveLag(context.Context, string, int64) {
+	// Default observer intentionally drops lag observations.
+}
 
 // ObserveLastSuccess implements Observer.
-func (NopObserver) ObserveLastSuccess(context.Context, string, time.Time) {}
+func (NopObserver) ObserveLastSuccess(context.Context, string, time.Time) {
+	// Default observer intentionally drops last-success observations.
+}
 
 // Compile-time interface satisfaction check.
 var _ Observer = NopObserver{}

--- a/runtime/saga/tailer/tailer.go
+++ b/runtime/saga/tailer/tailer.go
@@ -128,56 +128,57 @@ type Tailer struct {
 // owner-token claim race-free. A single-process demo passes a real in-memory
 // distlock.Locker.
 //
-// replay and cursor are commonly the same object. For example,
-// sagaprojection.SagaJournalSource implements both projection.ReplaySource (via
-// Replay/Head) and projection.Cursor (via Position), so callers typically pass
-// the same value for both parameters. They are kept as distinct parameters so
-// the Tailer is not hard-coupled to a concrete type and so that read-only
-// replay sources can be paired with a separately-provided cursor if needed.
-func NewTailer(
-	clk clock.Clock,
-	replay projection.ReplaySource,
-	cursor projection.Cursor,
-	store projection.OwnerCheckpointStore,
-	txRunner persistence.TxRunner,
-	apply projection.Apply,
-	locker distlock.Locker,
-	cellID, projectionID string,
-	opts ...Option,
-) (*Tailer, error) {
+// TailerDeps bundles the Tailer's required collaborators. Replay and Cursor are
+// commonly the same object. For example, sagaprojection.SagaJournalSource
+// implements both projection.ReplaySource (via Replay/Head) and projection.Cursor
+// (via Position), so callers typically pass the same value for both fields. They
+// remain distinct so the Tailer is not hard-coupled to a concrete type and so
+// read-only replay sources can be paired with a separately-provided cursor.
+type TailerDeps struct {
+	Replay       projection.ReplaySource
+	Cursor       projection.Cursor
+	Store        projection.OwnerCheckpointStore
+	TxRunner     persistence.TxRunner
+	Apply        projection.Apply
+	Locker       distlock.Locker
+	CellID       string
+	ProjectionID string
+}
+
+func NewTailer(clk clock.Clock, deps TailerDeps, opts ...Option) (*Tailer, error) {
 	clock.MustHaveClock(clk, "tailer.NewTailer")
-	if validation.IsNilInterface(replay) {
+	if validation.IsNilInterface(deps.Replay) {
 		return nil, nilDepErr("replay")
 	}
-	if validation.IsNilInterface(cursor) {
+	if validation.IsNilInterface(deps.Cursor) {
 		return nil, nilDepErr("cursor")
 	}
-	if validation.IsNilInterface(store) {
+	if validation.IsNilInterface(deps.Store) {
 		return nil, nilDepErr("store")
 	}
-	if validation.IsNilInterface(txRunner) {
+	if validation.IsNilInterface(deps.TxRunner) {
 		return nil, nilDepErr("txRunner")
 	}
-	if apply == nil {
+	if deps.Apply == nil {
 		return nil, nilDepErr("apply")
 	}
-	if validation.IsNilInterface(locker) {
+	if validation.IsNilInterface(deps.Locker) {
 		return nil, nilDepErr("locker")
 	}
-	if cellID == "" || projectionID == "" {
+	if deps.CellID == "" || deps.ProjectionID == "" {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"tailer.NewTailer: cellID and projectionID must be non-empty")
 	}
 	t := &Tailer{
-		replay:               replay,
-		cursor:               cursor,
-		store:                store,
-		txRunner:             txRunner,
-		apply:                apply,
-		locker:               locker,
-		cellID:               cellID,
-		projectionID:         projectionID,
-		lockKey:              tailerLockKey(projectionID),
+		replay:               deps.Replay,
+		cursor:               deps.Cursor,
+		store:                deps.Store,
+		txRunner:             deps.TxRunner,
+		apply:                deps.Apply,
+		locker:               deps.Locker,
+		cellID:               deps.CellID,
+		projectionID:         deps.ProjectionID,
+		lockKey:              tailerLockKey(deps.ProjectionID),
 		clk:                  clk,
 		logger:               slog.Default(),
 		cfg:                  DefaultConfig(),
@@ -195,7 +196,7 @@ func NewTailer(
 			"tailer.NewTailer: Config.LeaseTTL must be ≥ distlock.MinTTL (it doubles as the distlock TTL)",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("leaseTTL=%s minTTL=%s", t.cfg.LeaseTTL, distlock.MinTTL))))
 	}
-	rpn, err := healthz.SagaTailerReadyProbeName(cellID, projectionID)
+	rpn, err := healthz.SagaTailerReadyProbeName(deps.CellID, deps.ProjectionID)
 	if err != nil {
 		return nil, fmt.Errorf("tailer.NewTailer: readiness probe name: %w", err)
 	}

--- a/runtime/saga/tailer/tailer.go
+++ b/runtime/saga/tailer/tailer.go
@@ -128,57 +128,57 @@ type Tailer struct {
 // owner-token claim race-free. A single-process demo passes a real in-memory
 // distlock.Locker.
 //
-// TailerDeps bundles the Tailer's required collaborators. Replay and Cursor are
-// commonly the same object. For example, sagaprojection.SagaJournalSource
-// implements both projection.ReplaySource (via Replay/Head) and projection.Cursor
-// (via Position), so callers typically pass the same value for both fields. They
-// remain distinct so the Tailer is not hard-coupled to a concrete type and so
-// read-only replay sources can be paired with a separately-provided cursor.
-type TailerDeps struct {
-	Replay       projection.ReplaySource
-	Cursor       projection.Cursor
-	Store        projection.OwnerCheckpointStore
-	TxRunner     persistence.TxRunner
-	Apply        projection.Apply
-	Locker       distlock.Locker
-	CellID       string
-	ProjectionID string
-}
-
-func NewTailer(clk clock.Clock, deps TailerDeps, opts ...Option) (*Tailer, error) {
+// Replay and Cursor are commonly the same object. For example,
+// sagaprojection.SagaJournalSource implements both projection.ReplaySource (via
+// Replay/Head) and projection.Cursor (via Position), so callers typically pass
+// the same value twice. They remain distinct positional dependencies so the
+// Tailer is not hard-coupled to a concrete type and so the architecture test can
+// enforce nil guards for every required interface dependency.
+func NewTailer(
+	clk clock.Clock,
+	replay projection.ReplaySource,
+	cursor projection.Cursor,
+	store projection.OwnerCheckpointStore,
+	txRunner persistence.TxRunner,
+	apply projection.Apply,
+	locker distlock.Locker,
+	cellID string,
+	projectionID string,
+	opts ...Option,
+) (*Tailer, error) {
 	clock.MustHaveClock(clk, "tailer.NewTailer")
-	if validation.IsNilInterface(deps.Replay) {
+	if validation.IsNilInterface(replay) {
 		return nil, nilDepErr("replay")
 	}
-	if validation.IsNilInterface(deps.Cursor) {
+	if validation.IsNilInterface(cursor) {
 		return nil, nilDepErr("cursor")
 	}
-	if validation.IsNilInterface(deps.Store) {
+	if validation.IsNilInterface(store) {
 		return nil, nilDepErr("store")
 	}
-	if validation.IsNilInterface(deps.TxRunner) {
+	if validation.IsNilInterface(txRunner) {
 		return nil, nilDepErr("txRunner")
 	}
-	if deps.Apply == nil {
+	if apply == nil {
 		return nil, nilDepErr("apply")
 	}
-	if validation.IsNilInterface(deps.Locker) {
+	if validation.IsNilInterface(locker) {
 		return nil, nilDepErr("locker")
 	}
-	if deps.CellID == "" || deps.ProjectionID == "" {
+	if cellID == "" || projectionID == "" {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"tailer.NewTailer: cellID and projectionID must be non-empty")
 	}
 	t := &Tailer{
-		replay:               deps.Replay,
-		cursor:               deps.Cursor,
-		store:                deps.Store,
-		txRunner:             deps.TxRunner,
-		apply:                deps.Apply,
-		locker:               deps.Locker,
-		cellID:               deps.CellID,
-		projectionID:         deps.ProjectionID,
-		lockKey:              tailerLockKey(deps.ProjectionID),
+		replay:               replay,
+		cursor:               cursor,
+		store:                store,
+		txRunner:             txRunner,
+		apply:                apply,
+		locker:               locker,
+		cellID:               cellID,
+		projectionID:         projectionID,
+		lockKey:              tailerLockKey(projectionID),
 		clk:                  clk,
 		logger:               slog.Default(),
 		cfg:                  DefaultConfig(),
@@ -196,7 +196,7 @@ func NewTailer(clk clock.Clock, deps TailerDeps, opts ...Option) (*Tailer, error
 			"tailer.NewTailer: Config.LeaseTTL must be ≥ distlock.MinTTL (it doubles as the distlock TTL)",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("leaseTTL=%s minTTL=%s", t.cfg.LeaseTTL, distlock.MinTTL))))
 	}
-	rpn, err := healthz.SagaTailerReadyProbeName(deps.CellID, deps.ProjectionID)
+	rpn, err := healthz.SagaTailerReadyProbeName(cellID, projectionID)
 	if err != nil {
 		return nil, fmt.Errorf("tailer.NewTailer: readiness probe name: %w", err)
 	}

--- a/runtime/saga/tailer/tailer_test.go
+++ b/runtime/saga/tailer/tailer_test.go
@@ -233,30 +233,23 @@ func newTestTailer(t *testing.T, src *fakeSource, store projection.OwnerCheckpoi
 	apply projection.Apply, obs Observer, locker distlock.Locker, clk clock.Clock,
 ) *Tailer {
 	t.Helper()
-	tl, err := NewTailer(clk, testTailerDeps(src, src, store, apply, locker), WithObserver(obs))
+	tl, err := newTestTailerWithDeps(clk, src, src, store, apply, locker, WithObserver(obs))
 	if err != nil {
 		t.Fatalf("NewTailer: %v", err)
 	}
 	return tl
 }
 
-func testTailerDeps(
+func newTestTailerWithDeps(
+	clk clock.Clock,
 	replay projection.ReplaySource,
 	cursor projection.Cursor,
 	store projection.OwnerCheckpointStore,
 	apply projection.Apply,
 	locker distlock.Locker,
-) TailerDeps {
-	return TailerDeps{
-		Replay:       replay,
-		Cursor:       cursor,
-		Store:        store,
-		TxRunner:     fakeTxRunner{},
-		Apply:        apply,
-		Locker:       locker,
-		CellID:       testCell,
-		ProjectionID: testProj,
-	}
+	opts ...Option,
+) (*Tailer, error) {
+	return NewTailer(clk, replay, cursor, store, fakeTxRunner{}, apply, locker, testCell, testProj, opts...)
 }
 
 func events(seqs ...int64) []*fakeEvent {
@@ -478,41 +471,35 @@ func TestTailer_ConstructorNilGuards(t *testing.T) {
 	apply := func(context.Context, projection.ProjectionEvent) error { return nil }
 	locker := newTestLocker(t, clk)
 	good := func() (*Tailer, error) {
-		return NewTailer(clk, testTailerDeps(src, src, store, apply, locker))
+		return newTestTailerWithDeps(clk, src, src, store, apply, locker)
 	}
 	if _, err := good(); err != nil {
 		t.Fatalf("baseline NewTailer: %v", err)
 	}
 	cases := map[string]func() (*Tailer, error){
 		"nil replay": func() (*Tailer, error) {
-			return NewTailer(clk, testTailerDeps(nil, src, store, apply, locker))
+			return newTestTailerWithDeps(clk, nil, src, store, apply, locker)
 		},
 		"nil cursor": func() (*Tailer, error) {
-			return NewTailer(clk, testTailerDeps(src, nil, store, apply, locker))
+			return newTestTailerWithDeps(clk, src, nil, store, apply, locker)
 		},
 		"nil store": func() (*Tailer, error) {
-			return NewTailer(clk, testTailerDeps(src, src, nil, apply, locker))
+			return newTestTailerWithDeps(clk, src, src, nil, apply, locker)
 		},
 		"nil tx": func() (*Tailer, error) {
-			deps := testTailerDeps(src, src, store, apply, locker)
-			deps.TxRunner = nil
-			return NewTailer(clk, deps)
+			return NewTailer(clk, src, src, store, nil, apply, locker, testCell, testProj)
 		},
 		"nil apply": func() (*Tailer, error) {
-			return NewTailer(clk, testTailerDeps(src, src, store, nil, locker))
+			return newTestTailerWithDeps(clk, src, src, store, nil, locker)
 		},
 		"nil locker": func() (*Tailer, error) {
-			return NewTailer(clk, testTailerDeps(src, src, store, apply, nil))
+			return newTestTailerWithDeps(clk, src, src, store, apply, nil)
 		},
 		"empty cell": func() (*Tailer, error) {
-			deps := testTailerDeps(src, src, store, apply, locker)
-			deps.CellID = ""
-			return NewTailer(clk, deps)
+			return NewTailer(clk, src, src, store, fakeTxRunner{}, apply, locker, "", testProj)
 		},
 		"empty proj": func() (*Tailer, error) {
-			deps := testTailerDeps(src, src, store, apply, locker)
-			deps.ProjectionID = ""
-			return NewTailer(clk, deps)
+			return NewTailer(clk, src, src, store, fakeTxRunner{}, apply, locker, testCell, "")
 		},
 	}
 	for name, ctor := range cases {
@@ -531,18 +518,18 @@ func TestTailer_NilClockPanics(t *testing.T) {
 		}
 	}()
 	src := &fakeSource{}
-	_, _ = NewTailer(nil, testTailerDeps(src, src, projection.NewMemOwnerCheckpointStore(),
+	_, _ = NewTailer(nil, src, src, projection.NewMemOwnerCheckpointStore(), fakeTxRunner{},
 		func(context.Context, projection.ProjectionEvent) error { return nil },
-		newTestLocker(t, clockmock.New(time.Unix(0, 0)))))
+		newTestLocker(t, clockmock.New(time.Unix(0, 0))), testCell, testProj)
 }
 
 func TestTailer_ConfigValidation(t *testing.T) {
 	clk := clockmock.New(time.Unix(0, 0))
 	src := &fakeSource{}
 	mk := func(cfg Config) error {
-		_, err := NewTailer(clk, testTailerDeps(src, src, projection.NewMemOwnerCheckpointStore(),
+		_, err := NewTailer(clk, src, src, projection.NewMemOwnerCheckpointStore(), fakeTxRunner{},
 			func(context.Context, projection.ProjectionEvent) error { return nil },
-			newTestLocker(t, clk)), WithConfig(cfg))
+			newTestLocker(t, clk), testCell, testProj, WithConfig(cfg))
 		return err
 	}
 	if err := mk(Config{PollInterval: 0, LeaseTTL: time.Second}); err == nil {
@@ -839,7 +826,8 @@ func TestTailer_StopTimeoutRetryable(t *testing.T) {
 	}
 
 	// Real clock + short poll interval so the loop ticks into apply promptly.
-	tl, err := NewTailer(clock.Real(), testTailerDeps(src, src, store, apply, newTestLocker(t, clock.Real())),
+	realClock := clock.Real()
+	tl, err := NewTailer(realClock, src, src, store, fakeTxRunner{}, apply, newTestLocker(t, realClock), testCell, testProj,
 		WithConfig(Config{PollInterval: testFastPoll, LeaseTTL: testLockTTL}))
 	if err != nil {
 		t.Fatalf("NewTailer: %v", err)

--- a/runtime/saga/tailer/tailer_test.go
+++ b/runtime/saga/tailer/tailer_test.go
@@ -233,12 +233,30 @@ func newTestTailer(t *testing.T, src *fakeSource, store projection.OwnerCheckpoi
 	apply projection.Apply, obs Observer, locker distlock.Locker, clk clock.Clock,
 ) *Tailer {
 	t.Helper()
-	tl, err := NewTailer(clk, src, src, store, fakeTxRunner{}, apply, locker, testCell, testProj,
-		WithObserver(obs))
+	tl, err := NewTailer(clk, testTailerDeps(src, src, store, apply, locker), WithObserver(obs))
 	if err != nil {
 		t.Fatalf("NewTailer: %v", err)
 	}
 	return tl
+}
+
+func testTailerDeps(
+	replay projection.ReplaySource,
+	cursor projection.Cursor,
+	store projection.OwnerCheckpointStore,
+	apply projection.Apply,
+	locker distlock.Locker,
+) TailerDeps {
+	return TailerDeps{
+		Replay:       replay,
+		Cursor:       cursor,
+		Store:        store,
+		TxRunner:     fakeTxRunner{},
+		Apply:        apply,
+		Locker:       locker,
+		CellID:       testCell,
+		ProjectionID: testProj,
+	}
 }
 
 func events(seqs ...int64) []*fakeEvent {
@@ -460,35 +478,41 @@ func TestTailer_ConstructorNilGuards(t *testing.T) {
 	apply := func(context.Context, projection.ProjectionEvent) error { return nil }
 	locker := newTestLocker(t, clk)
 	good := func() (*Tailer, error) {
-		return NewTailer(clk, src, src, store, fakeTxRunner{}, apply, locker, testCell, testProj)
+		return NewTailer(clk, testTailerDeps(src, src, store, apply, locker))
 	}
 	if _, err := good(); err != nil {
 		t.Fatalf("baseline NewTailer: %v", err)
 	}
 	cases := map[string]func() (*Tailer, error){
 		"nil replay": func() (*Tailer, error) {
-			return NewTailer(clk, nil, src, store, fakeTxRunner{}, apply, locker, testCell, testProj)
+			return NewTailer(clk, testTailerDeps(nil, src, store, apply, locker))
 		},
 		"nil cursor": func() (*Tailer, error) {
-			return NewTailer(clk, src, nil, store, fakeTxRunner{}, apply, locker, testCell, testProj)
+			return NewTailer(clk, testTailerDeps(src, nil, store, apply, locker))
 		},
 		"nil store": func() (*Tailer, error) {
-			return NewTailer(clk, src, src, nil, fakeTxRunner{}, apply, locker, testCell, testProj)
+			return NewTailer(clk, testTailerDeps(src, src, nil, apply, locker))
 		},
 		"nil tx": func() (*Tailer, error) {
-			return NewTailer(clk, src, src, store, nil, apply, locker, testCell, testProj)
+			deps := testTailerDeps(src, src, store, apply, locker)
+			deps.TxRunner = nil
+			return NewTailer(clk, deps)
 		},
 		"nil apply": func() (*Tailer, error) {
-			return NewTailer(clk, src, src, store, fakeTxRunner{}, nil, locker, testCell, testProj)
+			return NewTailer(clk, testTailerDeps(src, src, store, nil, locker))
 		},
 		"nil locker": func() (*Tailer, error) {
-			return NewTailer(clk, src, src, store, fakeTxRunner{}, apply, nil, testCell, testProj)
+			return NewTailer(clk, testTailerDeps(src, src, store, apply, nil))
 		},
 		"empty cell": func() (*Tailer, error) {
-			return NewTailer(clk, src, src, store, fakeTxRunner{}, apply, locker, "", testProj)
+			deps := testTailerDeps(src, src, store, apply, locker)
+			deps.CellID = ""
+			return NewTailer(clk, deps)
 		},
 		"empty proj": func() (*Tailer, error) {
-			return NewTailer(clk, src, src, store, fakeTxRunner{}, apply, locker, testCell, "")
+			deps := testTailerDeps(src, src, store, apply, locker)
+			deps.ProjectionID = ""
+			return NewTailer(clk, deps)
 		},
 	}
 	for name, ctor := range cases {
@@ -507,18 +531,18 @@ func TestTailer_NilClockPanics(t *testing.T) {
 		}
 	}()
 	src := &fakeSource{}
-	_, _ = NewTailer(nil, src, src, projection.NewMemOwnerCheckpointStore(), fakeTxRunner{},
+	_, _ = NewTailer(nil, testTailerDeps(src, src, projection.NewMemOwnerCheckpointStore(),
 		func(context.Context, projection.ProjectionEvent) error { return nil },
-		newTestLocker(t, clockmock.New(time.Unix(0, 0))), testCell, testProj)
+		newTestLocker(t, clockmock.New(time.Unix(0, 0)))))
 }
 
 func TestTailer_ConfigValidation(t *testing.T) {
 	clk := clockmock.New(time.Unix(0, 0))
 	src := &fakeSource{}
 	mk := func(cfg Config) error {
-		_, err := NewTailer(clk, src, src, projection.NewMemOwnerCheckpointStore(), fakeTxRunner{},
+		_, err := NewTailer(clk, testTailerDeps(src, src, projection.NewMemOwnerCheckpointStore(),
 			func(context.Context, projection.ProjectionEvent) error { return nil },
-			newTestLocker(t, clk), testCell, testProj, WithConfig(cfg))
+			newTestLocker(t, clk)), WithConfig(cfg))
 		return err
 	}
 	if err := mk(Config{PollInterval: 0, LeaseTTL: time.Second}); err == nil {
@@ -602,7 +626,7 @@ func TestTailerLockKeyInjective(t *testing.T) {
 	if tailerLockKey("a:b") == tailerLockKey("a") {
 		t.Error("tailerLockKey not injective for ':'-containing ids")
 	}
-	if got := tailerLockKey(testProj); got == "" {
+	if tailerLockKey(testProj) == "" {
 		t.Error("empty key")
 	}
 }
@@ -815,8 +839,7 @@ func TestTailer_StopTimeoutRetryable(t *testing.T) {
 	}
 
 	// Real clock + short poll interval so the loop ticks into apply promptly.
-	tl, err := NewTailer(clock.Real(), src, src, store, fakeTxRunner{}, apply,
-		newTestLocker(t, clock.Real()), testCell, testProj,
+	tl, err := NewTailer(clock.Real(), testTailerDeps(src, src, store, apply, newTestLocker(t, clock.Real())),
 		WithConfig(Config{PollInterval: testFastPoll, LeaseTTL: testLockTTL}))
 	if err != nil {
 		t.Fatalf("NewTailer: %v", err)

--- a/tests/testutil/images_test.go
+++ b/tests/testutil/images_test.go
@@ -71,32 +71,44 @@ func imageConstsFromSource(t *testing.T) map[string]string {
 
 	out := make(map[string]string)
 	for _, decl := range file.Decls {
-		gd, isGen := decl.(*ast.GenDecl)
-		if !isGen || gd.Tok != token.CONST {
-			continue
-		}
-		for _, spec := range gd.Specs {
-			vs, isVal := spec.(*ast.ValueSpec)
-			if !isVal {
-				continue
-			}
-			for i, ident := range vs.Names {
-				if !strings.HasSuffix(ident.Name, "Image") {
-					continue
-				}
-				require.Lessf(t, i, len(vs.Values),
-					"%s: *Image const must have an explicit string-literal initializer (no iota/implicit-repeat)", ident.Name)
-				lit, isLit := vs.Values[i].(*ast.BasicLit)
-				require.Truef(t, isLit && lit.Kind == token.STRING,
-					"%s: *Image const must be a plain string literal; an indirect "+
-						"value (var/concat/cross-pkg const) escapes the digest pin check", ident.Name)
-				val, uerr := strconv.Unquote(lit.Value)
-				require.NoError(t, uerr, "unquote %s", ident.Name)
-				out[ident.Name] = val
-			}
-		}
+		collectImageConstsFromDecl(t, decl, out)
 	}
 	return out
+}
+
+func collectImageConstsFromDecl(t *testing.T, decl ast.Decl, out map[string]string) {
+	t.Helper()
+
+	gd, isGen := decl.(*ast.GenDecl)
+	if !isGen || gd.Tok != token.CONST {
+		return
+	}
+	for _, spec := range gd.Specs {
+		collectImageConstsFromSpec(t, spec, out)
+	}
+}
+
+func collectImageConstsFromSpec(t *testing.T, spec ast.Spec, out map[string]string) {
+	t.Helper()
+
+	vs, isVal := spec.(*ast.ValueSpec)
+	if !isVal {
+		return
+	}
+	for i, ident := range vs.Names {
+		if !strings.HasSuffix(ident.Name, "Image") {
+			continue
+		}
+		require.Lessf(t, i, len(vs.Values),
+			"%s: *Image const must have an explicit string-literal initializer (no iota/implicit-repeat)", ident.Name)
+		lit, isLit := vs.Values[i].(*ast.BasicLit)
+		require.Truef(t, isLit && lit.Kind == token.STRING,
+			"%s: *Image const must be a plain string literal; an indirect "+
+				"value (var/concat/cross-pkg const) escapes the digest pin check", ident.Name)
+		val, uerr := strconv.Unquote(lit.Value)
+		require.NoError(t, uerr, "unquote %s", ident.Name)
+		out[ident.Name] = val
+	}
 }
 
 // TestContainerImagesPinned_RejectsFloating verifies that floating tags (no


### PR DESCRIPTION
## Summary

治理 SonarCloud OPEN/CONFIRMED Code Smell 快照中的机械修复、复杂度测试拆分与安全 API 重构。

## Why / 背景

SonarCloud 当前 Code Smell 集合包含重复字面量、空函数体、注释旧 SQL、无意义临时变量、高参数函数、复杂测试函数等问题。本 PR 按“真实问题直接修复；不为清零牺牲语义”的原则处理可安全修复项，并将不适合机械重构的设计类 issue 留给 Sonar issue 级人工接受。

## Refs

- SonarCloud Code Smell governance plan
- ref: SonarCloud project issues snapshot

## Risk / 兼容性

存在一个刻意的不向后兼容 API 变更：`runtime/saga/tailer.NewTailer` 改为接收 `TailerDeps`，仓内调用方已全部迁移，没有保留 wrapper/alias。

未新增 Sonar ignore / NOSONAR / 兼容 alias。需人工在 Sonar 对少量设计类 issue 做 Accepted/False positive 裁决，例如 gRPC context wrapper 字段、领域单方法接口命名、Go fuzz target 高参数。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./...` 本地通过
- [x] `go build -tags=integration ./...` 本地通过
- [x] `golangci-lint run ./...` 0 issues
- [x] Sonar S3776 对应文件 `gocognit -over 15` 复扫无输出
