### PR TITLE
fix(archtest): restore clock workspace scan scope

### DIFF
--- a/tools/archtest/clock_invariants.go
+++ b/tools/archtest/clock_invariants.go
@@ -42,7 +42,6 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/tools/internal/fileroles"
-	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 // ---------------------------------------------------------------------------
@@ -171,17 +170,14 @@ func clockMatchedKernelClockReal(info *types.Info, ident *ast.Ident) bool {
 }
 
 // CheckKernelClockLeafFallback runs KERNEL-CLOCK-LEAF-FALLBACK-01 against the
-// running module and returns its diagnostics. Does not call t.Errorf —
+// go.work workspace production scope and returns its diagnostics. Does not call t.Errorf —
 // callers funnel diagnostics through Report.
 //
 // Not registered in StandardCellRules: see file godoc.
 func CheckKernelClockLeafFallback(t *testing.T, _ ConfigForExternalCell) []Diagnostic {
 	t.Helper()
 
-	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
-
-	return Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, patterns),
+	return Run(t, Production(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			var d []Diagnostic
 			for _, f := range p.Files {
@@ -218,8 +214,8 @@ func CheckKernelClockLeafFallback(t *testing.T, _ ConfigForExternalCell) []Diagn
 //
 // # Not registered in StandardCellRules
 //
-// Scan scope is the entire GoCell module (prodscan.PatternsExtended); there is
-// no ConfigForExternalCell consumer-extension for the exempt paths
+// Scan scope is the go.work workspace production scope; there is no
+// ConfigForExternalCell consumer-extension for the exempt paths
 // (clockResetRelativeExemptPaths) -> would be vacuous-green in an external repo.
 
 // clockResetRelativeExemptPaths lists path prefixes exempt from the gate.
@@ -358,7 +354,7 @@ func clockIsTimeTimeType(t types.Type) bool {
 }
 
 // CheckKernelClockResetRelativeProd runs KERNEL-CLOCK-RESET-RELATIVE-PROD-01
-// against the running module and returns its diagnostics. Does not call
+// against the go.work workspace production scope and returns its diagnostics. Does not call
 // t.Errorf — callers funnel diagnostics through Report.
 //
 // Not registered in StandardCellRules: see file godoc.
@@ -368,10 +364,7 @@ func CheckKernelClockResetRelativeProd(t *testing.T, _ ConfigForExternalCell) []
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
-
-	return Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, patterns),
+	return Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			var d []Diagnostic
 			for _, f := range p.Files {
@@ -422,8 +415,8 @@ func CheckKernelClockResetRelativeProd(t *testing.T, _ ConfigForExternalCell) []
 //
 // # Not registered in StandardCellRules
 //
-// Scan scope is the entire GoCell module plus composition-root carve-outs
-// (clockControlPlaneCarveOut) that are gocell-hardcoded with no
+// Scan scope is the go.work workspace production scope plus composition-root
+// carve-outs (clockControlPlaneCarveOut) that are gocell-hardcoded with no
 // ConfigForExternalCell consumer-extension -> vacuous-green in an external repo.
 
 // clockAllowedRealClockPaths lists the paths whose files may legitimately
@@ -711,19 +704,16 @@ func scanProdClockInjectionAST(fset *token.FileSet, file *ast.File, rel string, 
 	return out
 }
 
-// CheckProdClockInjection runs PROD-CLOCK-INJECTION-01 against the running
-// module and returns its diagnostics. Does not call t.Errorf — callers funnel
-// diagnostics through Report.
+// CheckProdClockInjection runs PROD-CLOCK-INJECTION-01 against the go.work
+// workspace production scope and returns its diagnostics. Does not call t.Errorf
+// — callers funnel diagnostics through Report.
 //
 // Not registered in StandardCellRules: see file godoc.
 func CheckProdClockInjection(t *testing.T, _ ConfigForExternalCell) []Diagnostic {
 	t.Helper()
 	// Intentionally not honoring testing.Short — see original TestProdClockInjection.
 
-	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
-
-	return Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, patterns),
+	return Run(t, Production(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			var d []Diagnostic
 			for _, f := range p.Files {
@@ -775,8 +765,8 @@ func CheckProdClockInjection(t *testing.T, _ ConfigForExternalCell) []Diagnostic
 //
 // # Not registered in StandardCellRules
 //
-// Scan scope is the entire GoCell module; carve-outs are gocell-hardcoded
-// (composition-root naming convention) with no ConfigForExternalCell
+// Scan scope is the go.work workspace production scope; carve-outs are
+// gocell-hardcoded (composition-root naming convention) with no ConfigForExternalCell
 // consumer-extension -> vacuous-green in an external repo.
 
 // clockIsMustHaveClockCall reports whether call is a call to
@@ -1138,7 +1128,7 @@ func scanClockPositionalInjectionAST(fset *token.FileSet, file *ast.File, rel st
 }
 
 // CheckClockPositionalInjection runs CLOCK-POSITIONAL-INJECTION-01 against the
-// running module and returns its diagnostics. Does not call t.Errorf — callers
+// go.work workspace production scope and returns its diagnostics. Does not call t.Errorf — callers
 // funnel diagnostics through Report.
 //
 // Not registered in StandardCellRules: see file godoc.
@@ -1148,10 +1138,7 @@ func CheckClockPositionalInjection(t *testing.T, _ ConfigForExternalCell) []Diag
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
-
-	return Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, patterns),
+	return Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			var d []Diagnostic
 			for _, f := range p.Files {

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -15,6 +15,9 @@
 package archtest
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"path/filepath"
 	"testing"
 )
@@ -159,6 +162,82 @@ func TestProdClockInjection(t *testing.T) {
 func TestClockPositionalInjection(t *testing.T) {
 	t.Parallel()
 	Report(t, "CLOCK-POSITIONAL-INJECTION-01", CheckClockPositionalInjection(t, ConfigForExternalCell{}))
+}
+
+func TestClockWorkspaceScopeIncludesSatellites(t *testing.T) {
+	t.Parallel()
+
+	required := map[string]bool{
+		"cmd/gocell/main.go":      false,
+		"cmd/gocell/app/check.go": false,
+		"cmd/corebundle/main.go":  false,
+	}
+
+	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := filepath.ToSlash(p.Rel(f))
+			if _, ok := required[rel]; ok {
+				required[rel] = true
+			}
+		}
+		return nil
+	})
+
+	for rel, seen := range required {
+		if !seen {
+			t.Errorf("clock workspace production scope did not visit %s; satellite module coverage would be vacuous", rel)
+		}
+	}
+}
+
+func TestClockChecksDoNotUseProdscanPatternsExtended(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "tools", "archtest", "clock_invariants.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse clock_invariants.go: %v", err)
+	}
+
+	checks := map[string]bool{
+		"CheckKernelClockLeafFallback":      false,
+		"CheckKernelClockResetRelativeProd": false,
+		"CheckProdClockInjection":           false,
+		"CheckClockPositionalInjection":     false,
+	}
+
+	EachInChildren[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+		if fn.Name == nil || fn.Body == nil {
+			return
+		}
+		if _, ok := checks[fn.Name.Name]; !ok {
+			return
+		}
+		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+			switch fun := call.Fun.(type) {
+			case *ast.Ident:
+				if fun.Name == "Production" {
+					checks[fn.Name.Name] = true
+				}
+				if fun.Name == "Typed" {
+					t.Errorf("%s must use Production scope, not Typed", fn.Name.Name)
+				}
+			case *ast.SelectorExpr:
+				if ident, ok := fun.X.(*ast.Ident); ok &&
+					ident.Name == "prodscan" && fun.Sel.Name == "PatternsExtended" {
+					t.Errorf("%s must not call prodscan.PatternsExtended; it drops go.work satellite modules", fn.Name.Name)
+				}
+			}
+		})
+	})
+
+	for name, sawProduction := range checks {
+		if !sawProduction {
+			t.Errorf("%s must call Production(...) so clock invariants scan go.work satellite modules", name)
+		}
+	}
 }
 
 // runClockPositionalInjectionFixtureScan loads the fixture package at fixtureDir


### PR DESCRIPTION
## Summary

Restore clock archtest coverage for go.work satellite modules by moving the four clock invariant checks from root-module `Typed(prodscan.PatternsExtended(...))` scans to the workspace-aware `Production(...)` scan scope.

## Why / 背景

#1653 tracks a silent coverage loss after `cmd/gocell` became a go.work satellite module. `./cmd/...` under the root-module typed scan no longer reaches `cmd/gocell`, so clock invariants could pass without checking the CLI module. `slog_handler` A3 was already restored on `develop` by #1799; this PR covers the remaining clock invariant gap.

## Refs

Closes #1653

ref: golang.org/x/tools/go/analysis analysis.go Pass driver model

## Risk / 兼容性

No public API, CLI, schema, or generated artifact changes. Risk is limited to archtest scan scope: the clock checks now include go.work production modules that were previously skipped.

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./修改的包/...` 本地通过（涉及逻辑变更时）
- [x] `golangci-lint run ./...` 0 issues
- [x] `go test ./tools/archtest -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockResetRelativeProd|TestClockPositionalInjection|TestClock.*Scope|TestClock.*Prodscan)' -count=1 -timeout 5m`
- [x] `bash hack/verify-archtest-invariants.sh`
- [x] `go test ./tools/archtest -count=1 -timeout 10m`
- [x] `go test ./...`
