### PR TITLE
feat(devicecell): enqueue cert renewal commands

### DIFF
--- a/adapters/postgres/migrations/056_devices_cert_renewal.sql
+++ b/adapters/postgres/migrations/056_devices_cert_renewal.sql
@@ -1,0 +1,25 @@
+-- Migration 056: device certificate renewal state for iotdevice devicecell.
+--
+-- Supports issue #1757: a devicecell reconcile loop scans certificates nearing
+-- expiry and emits an idempotent async rotate-cert command keyed by
+-- (device_id, cert_epoch). The state lives on devices because cert epoch and
+-- expiry are properties of the device aggregate, not the command queue.
+
+-- +goose Up
+ALTER TABLE devices
+    ADD COLUMN IF NOT EXISTS cert_epoch BIGINT NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS cert_expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '90 days');
+
+ALTER TABLE devices
+    ADD CONSTRAINT devices_cert_epoch_positive CHECK (cert_epoch >= 1);
+
+CREATE INDEX IF NOT EXISTS idx_devices_cert_expires_at
+    ON devices (cert_expires_at, id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_devices_cert_expires_at;
+
+ALTER TABLE devices
+    DROP CONSTRAINT IF EXISTS devices_cert_epoch_positive,
+    DROP COLUMN IF EXISTS cert_expires_at,
+    DROP COLUMN IF EXISTS cert_epoch;

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -65,6 +65,8 @@ const gotWantQuotedFmt = "got %q want %q"
 //                                   the 12-field canonical-JSON HMAC chain.
 //   - devices            (029)  examples/iotdevice devicecell PG repo (B2.B)
 //                                 + devices_status_chk CHECK (status IN online/offline)
+//                                 + cert_epoch / cert_expires_at (056) for
+//                                   devicecell cert-renewal reconcile
 //   - commands           (030)  examples/iotdevice command queue PG adapter (B2.B)
 //                                 + commands.device_id FK → devices(id) ON DELETE RESTRICT
 //                                 + commands_status_chk, commands_attempt_chk
@@ -592,6 +594,8 @@ var expectedColumns = []expectedColumn{
 	{Table: "devices", Column: "name", Type: "text", NotNull: true},
 	{Table: "devices", Column: "status", Type: "text", NotNull: true},
 	{Table: "devices", Column: "last_seen", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "devices", Column: "cert_epoch", Type: "bigint", NotNull: true},
+	{Table: "devices", Column: "cert_expires_at", Type: pgTypeTSTZ, NotNull: true},
 	// commands (030_commands.sql) — kernel/command.Queue PG adapter (B2.B).
 	{Table: "commands", Column: "id", Type: "text", NotNull: true},
 	{Table: "commands", Column: "device_id", Type: "text", NotNull: true},
@@ -695,6 +699,11 @@ var expectedDefaults = []expectedDefault{
 	// adds users_password_version_non_negative CHECK >= 0). A dropped default would
 	// cause every new-user Create to fail at write time.
 	{Table: "users", Column: "password_version", Default: "0"},
+	// devices.cert_epoch / cert_expires_at (056) — raw SQL fixtures and
+	// migrations that seed devices omit cert state, so the DB default is
+	// load-bearing for the new certificate-renewal invariant.
+	{Table: "devices", Column: "cert_epoch", Default: "1"},
+	{Table: "devices", Column: "cert_expires_at", Default: "(now() + '90 days'::interval)"},
 }
 
 // expectedIndexes covers both unique and non-unique indexes across S3F tables.
@@ -751,6 +760,7 @@ var expectedIndexes = []expectedIndex{
 	// filter. See audit_ledger_store.Query.
 	// devices / commands (029, 030, 031) — B2.B.
 	{Table: "devices", Name: "idx_devices_status", Unique: false, Columns: []string{"status"}},
+	{Table: "devices", Name: "idx_devices_cert_expires_at", Unique: false, Columns: []string{"cert_expires_at", "id"}},
 	// 030_commands.sql partial indexes — Columns lists only key columns, not WHERE predicate columns
 	{Table: "commands", Name: "idx_commands_pending_fifo", Unique: false, Columns: []string{"device_id", "created_at"}},
 	{Table: "commands", Name: "idx_commands_active_lease", Unique: false, Columns: []string{"lease_expiry"}},
@@ -1161,6 +1171,7 @@ var expectedChecks = []expectedCheck{
 	{Table: "refresh_tokens", Name: "refresh_tokens_authz_epoch_at_issue_positive"},
 	// devices / commands (029, 030) — B2.B.
 	{Table: "devices", Name: "devices_status_chk"},
+	{Table: "devices", Name: "devices_cert_epoch_positive"},
 	{Table: "commands", Name: "commands_status_chk"},
 	{Table: "commands", Name: "commands_attempt_chk"},
 	// audit_entries hash-format guard (020_audit_ledger.sql + 043_audit_entries_v2.sql

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -93,9 +93,11 @@ func TestExpectedVersion_FromEmbedFS(t *testing.T) {
 	// for the sessions tenant carrier (EPIC #1337 PR-3b, #1617);
 	// 055 rebuilds audit_entries per-(namespace, tenant) (DROP+CREATE — UNIQUE(namespace,
 	// tenant_id, seq_no)) + FORCE RLS with the OR tenant_id='' system-rows policy
-	// (EPIC #1337 #1618).
-	assert.Equal(t, int64(55), v,
-		"expected version should be exactly 55 (current migration max — 055_audit_entries_per_tenant_rls)")
+	// (EPIC #1337 #1618);
+	// 056 adds devices.cert_epoch / cert_expires_at for devicecell certificate
+	// renewal reconcile (#1757).
+	assert.Equal(t, int64(56), v,
+		"expected version should be exactly 56 (current migration max — 056_devices_cert_renewal)")
 }
 
 func TestExpectedVersion_SyntheticFS(t *testing.T) {
@@ -356,6 +358,29 @@ func containsCheck(table, name string) bool {
 	return false
 }
 
+// containsDefault returns true when expectedDefaults contains an entry with the
+// given table, column, and default expression.
+func containsDefault(table, column, def string) bool {
+	for _, d := range expectedDefaults {
+		if d.Table == table && d.Column == column && d.Default == def {
+			return true
+		}
+	}
+	return false
+}
+
+// containsIndex returns true when expectedIndexes contains an entry with the
+// given table, index name, uniqueness, and key columns.
+func containsIndex(table, name string, unique bool, columns []string) bool {
+	for _, idx := range expectedIndexes {
+		if idx.Table == table && idx.Name == name &&
+			idx.Unique == unique && slices.Equal(idx.Columns, columns) {
+			return true
+		}
+	}
+	return false
+}
+
 // TestVerifyExpectedShape_RequiresAuthzEpochPositiveChecks verifies that all
 // three CHECK constraints added by migration 028 are declared in expectedChecks.
 // Each constraint enforces authz_epoch > 0 at the DB level as a hard invariant
@@ -428,6 +453,36 @@ func TestVerifyExpectedShape_RequiresLockoutCountPositiveCheck(t *testing.T) {
 		containsCheck("users", "users_failed_login_count_positive"),
 		"expectedChecks must include users.users_failed_login_count_positive "+
 			"(migration 032 auto-lockout counter non-negativity)",
+	)
+}
+
+// TestVerifyExpectedShape_RequiresDeviceCertRenewalShape verifies that
+// migration 056's certificate renewal columns and storage-level invariants are
+// declared in the schema guard registry.
+func TestVerifyExpectedShape_RequiresDeviceCertRenewalShape(t *testing.T) {
+	for _, tc := range []struct {
+		column string
+		def    string
+	}{
+		{column: "cert_epoch", def: "1"},
+		{column: "cert_expires_at", def: "(now() + '90 days'::interval)"},
+	} {
+		tc := tc
+		t.Run("devices/"+tc.column, func(t *testing.T) {
+			assert.True(t, containsColumn("devices", tc.column),
+				"expectedColumns must include devices.%s (migration 056 cert renewal)", tc.column)
+			assert.True(t, containsDefault("devices", tc.column, tc.def),
+				"expectedDefaults must include devices.%s default %s (migration 056 cert renewal)",
+				tc.column, tc.def)
+		})
+	}
+	assert.True(t,
+		containsCheck("devices", "devices_cert_epoch_positive"),
+		"expectedChecks must include devices.devices_cert_epoch_positive (migration 056 cert renewal)",
+	)
+	assert.True(t,
+		containsIndex("devices", "idx_devices_cert_expires_at", false, []string{"cert_expires_at", "id"}),
+		"expectedIndexes must include devices.idx_devices_cert_expires_at (migration 056 cert renewal)",
 	)
 }
 

--- a/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
+++ b/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
@@ -66,7 +66,7 @@ PR-1 同步核心是 W3 的第一片。`Registry` map signature 与生成码 fun
 - **⑤ idempotency 桥（#1669 映射半 + #1698 消费半，已落地）**：HTTP Idempotency-Key ↔ command_id 映射（复用 `runtime/http/idempotency` 派生 key + `kernel/idempotency.Claimer` 两阶段）。**映射原语半已落地（#1669 PR-A）**：`runtime/http/idempotency` sealed funnel 扩第二构造器 `DeriveCommandKey(tenant, subject, command_id)`——纯编译期形态，产同一 sealed `IdempotencyKey`、流同一 `Store.Claim` sink（详见 ADR-1449 §Amendment 2026-06-07）；#1610 cross-cell 同槽路由消费它。**Claimer-wrap 消费半已落地（#1698 PR-B，见 §Amendment 2026-06-08）**：`kernel/idempotency.Claimer` 两阶段包裹 relay 命令分发 + 三态生命周期；sealed-key→Claimer string-key 经新增 `IdempotencyKey.Flat()` 扁平化（node-agnostic）；per-instance 身份经 `outbox.Entry` 的 `AggregateID(subject)` + business-metadata（command_id）承载，随真实 devicecell 异步 command producer 一并落地。**§4 评级矩阵新增「命令幂等身份双向锁 funnel」行（见 §Amendment 2026-06-08）**，无 ✅→⚠️/❌ 降格。
 - ~~**command-entry 值校验 funnel（#1588，Blocked-by ④）**：`DispatchAsync` 只做 typed JSON unmarshal，不执行 schema 值约束~~ **已交付（#1588，见 §Amendment 2026-06-08）**：`DispatchAsync` 在 topic-guard 之后、unmarshal 之前对 `entry.Payload()`（已是 wire JSON bytes）跑 `runtime/schemavalidate.Validator.Validate` 强制 request schema 值约束（minLength/maxLength/required/additionalProperties），违例 → `kout.NewPermanentError` → relay `MarkDead`。复用 HTTP 同源 validator（抽中性包 `runtime/schemavalidate`）；honor D4——async bytes 校验非 marshal round-trip（round-trip 仅在校验 sync typed 输入时出现，sync `Dispatch` 不变）。
 - ~~**command consistencyLevel governance（#1044 子 issue）**：PR-1 不锁 level~~ **已交付（#1668，双层）**：`COMMAND-CONTRACT-CONSISTENCY-LEVEL-01` 下界约束 `consistencyLevel ≥ L1`，仅拒 `L0`（命令跨本地边界至少需 L1 LocalTx 原子性，L0 LocalOnly 结构上不适用）。**双层**（同 PROJECTION-CONSISTENCY-01 单 ID 双层范式）：Hard = `types.tmpl` 编译期 `const _ = uint(cellvocab.<level> - cellvocab.L1)` 对 codegen:true 命令契约 uint 下溢拦 L0；Medium = governance rule 兜底 codegen:false + in-memory fixture。下界（非 exact-lock）使现有 active L4 `devicecommand` 契约全部通过、零误伤。详见 §Amendment 2026-06-06（#1668）。
-- **真实 binary async producer 接线（#1698 PR-B，已落地——见 §Amendment 2026-06-08）**：archetype ① **事件反应式**——`examples/iotdevice/cells/devicecell/slices/devicebootstrap` 订阅 `event.device-registered.v1` → handler 经 `command.EmitAsync` emit `command.devicecommand.enqueue.v1`（包进 `CellTxManager.RunInTx`，durable PG outbox writer 要 tx）；`examples/iotdevice/run.go` demo + durable 两模式都接命令-relay 子系统（首个生产 `WithCommandDispatch` callsite）。其余 producer archetype（② #1757 同步 HTTP→command、③ #1758 saga step→command）仍复用本 wrap，随各自 PR 落地。
+- **真实 binary async producer 接线（#1698 PR-B，已落地——见 §Amendment 2026-06-08）**：archetype ① **事件反应式**——`examples/iotdevice/cells/devicecell/slices/devicebootstrap` 订阅 `event.device-registered.v1` → handler 经 `command.EmitAsync` emit `command.devicecommand.enqueue.v1`（包进 `CellTxManager.RunInTx`，durable PG outbox writer 要 tx）；`examples/iotdevice/run.go` demo + durable 两模式都接命令-relay 子系统（首个生产 `WithCommandDispatch` callsite）。archetype ② **level-based reconcile** 已随 #1757 落地：devicecell 证书续期 reconciler 周期扫描 near-expiry cert state，经同一 `command.EmitAsync` + relay Claimer funnel 发 `rotate-cert` enqueue（见 §Amendment 2026-06-10）。其余 producer archetype（③ #1758 saga step→command）仍复用本 wrap，随各自 PR 落地。
 
 amend 时须回到 §4 矩阵逐行重评（ai-robust.md ADR amendment 必查）：见 §Amendment 2026-06-06。
 
@@ -250,3 +250,26 @@ empty / 非法 level 不由本规则报——由 `FMT-03`（contract consistency
 enforcement 索引（§7）**无新增**——值校验由 §4 既有三 funnel 覆盖；`runtime/schemavalidate` 为运行时 validator 载体（非 enforcement 机制）。
 
 **范围（显式，非 silent defer）**：HTTP→command 不在本 PR（仓内无 HTTP→command wiring；真落地时复用 HTTP handler 既有 validator，结构上已覆盖）。真实 binary async producer 接线 = #1698（正交）。
+
+---
+
+## Amendment 2026-06-10 — archetype ② level-based reconcile async producer 落地（#1757）
+
+**触发**：#1757 将 devicecell 证书续期从隐含状态推进为 level-based reconcile producer：周期观察 `Device.CertExpiresAt` / `CertEpoch`，对 near-expiry 当前 epoch 发出异步 `rotate-cert` 设备命令。按 ai-robust.md「ADR amendment 必查」重评 §4。
+
+**交付**：
+
+1. **建模与存储**：`domain.Device` 破坏式增加 `CertEpoch` / `CertExpiresAt`，`DeviceRepository` 增加 `ListCertificateRenewalCandidates(ctx, expiresBefore)`；mem / PG repo 同步实现。PG migration 056 增加列、`devices_cert_epoch_positive` CHECK、`idx_devices_cert_expires_at`，并进 `schema_guard` columns/default/check/index 注册与静态 membership 测试。
+2. **producer archetype ②：level-based reconcile**：devicecell 增加 `devicecert.renewal` lifecycle hook，基于 `kernel/reconcile.Loop` 每 tick 扫描 `now+7d` 前过期证书。该 producer 不依赖一次性 event，符合 controller-runtime level-based reconcile 语义。
+3. **复用现有 command async funnel**：reconciler 只调用 `command.EmitAsync(ctx, clk, emitter, cmdenqueue.DispatchID, deviceID, deterministicCommandID, req)`；`req` 仍是既有 `command.devicecommand.enqueue.v1`，`CommandType="rotate-cert"`。不新增 rotate-cert command 契约、不新增 dispatcher、不新增 funnel。
+4. **幂等身份**：`commandID = f(deviceID, certEpoch)`，同一设备同一证书 epoch 跨 tick 派生相同 Claimer key；payload 为 full context JSON（`deviceId` / `certEpoch` / `certExpiresAt` / `requestedAt`）。本 PR 不实现设备续期 ack 后 epoch 推进，epoch 推进属于后续设备完成续期语义。
+5. **端到端覆盖**：单测锁定 outbox topic / aggregate / command-id metadata / payload；E2E 锁定两次 tick 只 enqueue 一条 `rotate-cert` 且设备可 dequeue。
+
+**§4 评级矩阵逐行重评（无格降级）**：
+
+- `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`：**不变**（上游 Hard / 下游 Medium）。#1757 不新增 typed command contract，也不手写 `Handler/Register/Dispatch/DispatchAsync` look-alike；仍复用生成的 `enqueue.DispatchID` / `DispatchAsync`。
+- `COMMAND-DISPATCH-REGISTER-CALLER-01`：**不变**（上游 Medium / 下游 Hard）。reconcile producer 不直接调用 `RegisterHandler` / `LookupHandler`。
+- `COMMAND-ASYNC-DISPATCH-CALLER-01`：**不变**（上游 Medium / 下游 Hard）。生产 dispatch 仍走既有 `WithCommandDispatch(reg, {enqueue.DispatchID: enqueue.DispatchAsync}, claimer)` 3-arg 形态；#1757 未新增 callsite 形态。
+- `COMMAND-ASYNC-EMIT-FUNNEL-01`：**不变**（上游 Medium / 下游 Hard）。新增 producer 通过 sanctioned `command.EmitAsync` 出口构造 command-topic entry，subject / commandID 为必填位置参；无 funnel 外 `kout.NewEntry` / `Emit` 构造 command-topic entry。
+
+**无 contract-fanout / 无降级**：没有新增 `contract.yaml` command、没有修改 `kernel/outbox.Entry` wire envelope、没有新增 errcode / schemaRef / generated handler；PG schema 变更只服务 devicecell repository state，并由 migration 056 + schema_guard 守护。§4 所有既有 invariant 无 ✅→⚠️/❌ 降格，无补偿措施缺口。

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/devicecert"
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/devicecmd"
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
 	dto "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/dto"
@@ -163,9 +164,11 @@ type DeviceCell struct {
 	cursorCodec        *query.CursorCodec
 	logger             *slog.Logger
 	metricsProvider    metrics.Provider
+	reconcileMetrics   *reconcile.Metrics
 	commandQueue       commandQueueStore
 	commandRegistry    *commandruntime.Registry // required; sync command-bus handler registry (#1580)
 	commandSweeper     *reconcile.Loop          // device-command expiry sweep, driven on a TickerTrigger cadence
+	certRenewalLoop    *reconcile.Loop          // device certificate renewal sweep, driven on a TickerTrigger cadence
 	clk                clock.Clock              // injected from reg.Config during initInternal
 
 	// +slice:route:slice=deviceregister,subPath=/api/v1/devices
@@ -359,6 +362,9 @@ func (c *DeviceCell) initSlices(durabilityMode outbox.DurabilityMode) error {
 				"writerEmitter is an outbox.WriterEmitter over the mode's outbox Writer "+
 				"(demo: outboxtest.FakeStore; durable: adapterpg.NewOutboxWriter(clk))")
 	}
+	if c.bootstrapTxManager == nil {
+		c.bootstrapTxManager = outbox.DemoCellTxManager()
+	}
 	bootstrapSvc, err := devicebootstrap.NewService(
 		c.clk,
 		devicebootstrap.WithEmitter(c.bootstrapEmitter),
@@ -442,6 +448,9 @@ func (c *DeviceCell) initSlices(durabilityMode outbox.DurabilityMode) error {
 	if err := c.buildCommandSweeper(cmdQueue); err != nil {
 		return err
 	}
+	if err := c.buildCertRenewalLoop(); err != nil {
+		return err
+	}
 	c.AddSlice(cell.MustNewBaseSliceFromMeta(devicecommand.SliceMetadata()))
 	c.AddSlice(cell.MustNewBaseSliceFromMeta(devicecommandinternal.SliceMetadata()))
 
@@ -476,6 +485,8 @@ func (c *DeviceCell) initSlices(durabilityMode outbox.DurabilityMode) error {
 // sweep would run ~twice per cycle.)
 const commandSweepInterval = 30 * time.Second
 
+const certRenewalInterval = 30 * time.Second
+
 // buildCommandSweeper constructs the device-command expiry reconcile.Loop. The
 // kernel Sweeper implements reconcile.Reconciler; a TickerTrigger off the cell's
 // business clock (c.clk) drives a resync-all pulse every commandSweepInterval,
@@ -501,11 +512,9 @@ func (c *DeviceCell) buildCommandSweeper(cmdQueue commandQueueStore) error {
 		WithName("devicecommand.sweeper").
 		WithReconcilerID("devicecommand_sweeper"). // label-safe: [a-z0-9_], no dots
 		WithoutDefaultRequeue()                    // ticker is the sole periodic source
-	if c.metricsProvider != nil {
-		m, err := reconcile.RegisterMetrics(c.metricsProvider)
-		if err != nil {
-			return fmt.Errorf("device-command reconcile metrics: %w", err)
-		}
+	if m, ok, err := c.sharedReconcileMetrics(); err != nil {
+		return fmt.Errorf("device-command reconcile metrics: %w", err)
+	} else if ok {
 		b = b.WithMetrics(m)
 	}
 	loop, err := b.Build()
@@ -516,7 +525,51 @@ func (c *DeviceCell) buildCommandSweeper(cmdQueue commandQueueStore) error {
 	return nil
 }
 
-// registerHealthAndLifecycle registers health probes and the sweeper lifecycle hook.
+func (c *DeviceCell) buildCertRenewalLoop() error {
+	rec, err := devicecert.NewReconciler(
+		c.clk,
+		c.deviceRepo,
+		c.bootstrapEmitter,
+		c.bootstrapTxManager,
+		devicecert.WithLogger(c.logger),
+	)
+	if err != nil {
+		return fmt.Errorf("device-cert renewal reconciler: %w", err)
+	}
+	b := reconcile.New(rec).
+		WithTrigger(reconcile.TickerTrigger(c.clk, certRenewalInterval)).
+		WithName("devicecert.renewal").
+		WithReconcilerID("devicecert_renewal").
+		WithoutDefaultRequeue()
+	if m, ok, err := c.sharedReconcileMetrics(); err != nil {
+		return fmt.Errorf("device-cert reconcile metrics: %w", err)
+	} else if ok {
+		b = b.WithMetrics(m)
+	}
+	loop, err := b.Build()
+	if err != nil {
+		return fmt.Errorf("device-cert reconcile loop: %w", err)
+	}
+	c.certRenewalLoop = loop
+	return nil
+}
+
+func (c *DeviceCell) sharedReconcileMetrics() (reconcile.Metrics, bool, error) {
+	if c.metricsProvider == nil {
+		return reconcile.Metrics{}, false, nil
+	}
+	if c.reconcileMetrics != nil {
+		return *c.reconcileMetrics, true, nil
+	}
+	m, err := reconcile.RegisterMetrics(c.metricsProvider)
+	if err != nil {
+		return reconcile.Metrics{}, false, err
+	}
+	c.reconcileMetrics = &m
+	return m, true, nil
+}
+
+// registerHealthAndLifecycle registers health probes and reconcile lifecycle hooks.
 func (c *DeviceCell) registerHealthAndLifecycle(reg cell.Registrar) error {
 	if err := cell.RegisterEmitterHealthProbes(reg, c.emitter); err != nil {
 		return err
@@ -538,6 +591,11 @@ func (c *DeviceCell) registerHealthAndLifecycle(reg cell.Registrar) error {
 		Name:    "devicecommand.sweeper",
 		OnStart: c.commandSweeper.Start,
 		OnStop:  c.commandSweeper.Stop,
+	})
+	reg.Lifecycle(cell.LifecycleHook{
+		Name:    "devicecert.renewal",
+		OnStart: c.certRenewalLoop.Start,
+		OnStop:  c.certRenewalLoop.Stop,
 	})
 	return nil
 }

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -487,17 +487,24 @@ func TestDeviceCell_Probes_WithDirectEmitter(t *testing.T) {
 }
 
 // TestDeviceCell_LifecycleHookRegistered verifies that Init registers the
-// command sweeper lifecycle hook via reg.Lifecycle.
+// reconcile lifecycle hooks via reg.Lifecycle.
 func TestDeviceCell_LifecycleHookRegistered(t *testing.T) {
 	c := newTestCell()
 	rec := cell.NewRegistryRecorder(make(map[string]any), outbox.DurabilityDemo)
 	require.NoError(t, c.Init(context.Background(), rec))
 	snap := rec.Snapshot()
 
-	require.Len(t, snap.LifecycleHooks, 1, "Init must register exactly one lifecycle hook (command sweeper)")
-	assert.Equal(t, "devicecommand.sweeper", snap.LifecycleHooks[0].Name)
-	assert.NotNil(t, snap.LifecycleHooks[0].OnStart)
-	assert.NotNil(t, snap.LifecycleHooks[0].OnStop)
+	require.Len(t, snap.LifecycleHooks, 2, "Init must register command and cert reconcile lifecycle hooks")
+	got := map[string]cell.LifecycleHook{}
+	for _, hook := range snap.LifecycleHooks {
+		got[hook.Name] = hook
+	}
+	for _, name := range []string{"devicecommand.sweeper", "devicecert.renewal"} {
+		hook, ok := got[name]
+		require.True(t, ok, "missing lifecycle hook %s", name)
+		assert.NotNil(t, hook.OnStart)
+		assert.NotNil(t, hook.OnStop)
+	}
 }
 
 // TestDeviceCell_CommandSweeper_MetricsBranches verifies that Init (and

--- a/examples/iotdevice/cells/devicecell/cert_renewal_command_e2e_test.go
+++ b/examples/iotdevice/cells/devicecell/cert_renewal_command_e2e_test.go
@@ -1,0 +1,117 @@
+package devicecell
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/devicecert"
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/mem"
+	cmdenqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
+	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	kcommand "github.com/ghbvf/gocell/kernel/command"
+	"github.com/ghbvf/gocell/kernel/command/commandtest"
+	"github.com/ghbvf/gocell/kernel/idempotency"
+	kout "github.com/ghbvf/gocell/kernel/outbox"
+	commandruntime "github.com/ghbvf/gocell/runtime/command"
+	"github.com/ghbvf/gocell/runtime/eventbus"
+	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
+	"github.com/ghbvf/gocell/runtime/outbox/outboxtest"
+)
+
+func TestDeviceCell_CertRenewal_ReconcileToAsyncEnqueueDedupAndDequeue(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	fc := clockmock.New(base)
+	repo := mem.NewDeviceRepository()
+	require.NoError(t, repo.Create(ctx, &domain.Device{
+		ID:            "dev-cert",
+		Name:          "cert-sensor",
+		Status:        "online",
+		LastSeen:      base,
+		CertEpoch:     5,
+		CertExpiresAt: base.Add(devicecert.RenewalThreshold).Add(-time.Hour),
+	}))
+
+	store := outboxtest.NewFakeStore()
+	writerEmitter, err := kout.NewWriterEmitter(store)
+	require.NoError(t, err)
+	reg := commandruntime.NewRegistry()
+	queue := commandtest.NewInMemQueue()
+	queue.Now = fc.Now
+	cell := NewDeviceCell(
+		fc,
+		WithDeviceRepository(repo),
+		WithDirectPublisher(kout.WrapPublisherForCell(eventbus.New(clock.Real()))),
+		WithBootstrapEmitter(kout.WrapEmitterForCell(writerEmitter)),
+		WithCommandRegistry(reg),
+	)
+	cell.RegisterCommandQueue(queue)
+	rec := newTestRec()
+	require.NoError(t, cell.Init(ctx, rec))
+
+	relay := outboxruntime.NewRelay(clock.Real(), store, &kout.DiscardPublisher{},
+		outboxruntime.RelayConfig{PollInterval: 5 * time.Millisecond, BaseRetryDelay: 5 * time.Millisecond}.WithDefaults())
+	relay.WithCommandDispatch(reg, map[commandruntime.CommandID]commandruntime.AsyncDispatchFunc{
+		cmdenqueue.DispatchID: cmdenqueue.DispatchAsync,
+	}, idempotency.NewInMemClaimer(clock.Real()))
+	relayCtx, cancelRelay := context.WithCancel(ctx)
+	defer cancelRelay()
+	go func() { _ = relay.Start(relayCtx) }()
+
+	stop := startNamedLifecycleHook(t, rec, "devicecert.renewal", ctx)
+	defer func() { require.NoError(t, stop(context.Background())) }()
+
+	fc.Advance(certRenewalInterval)
+	fc.Advance(certRenewalInterval)
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 3*time.Second)
+	defer cancelWait()
+	require.NoError(t, store.WaitFor(waitCtx, func(rows []outboxtest.FakeRow) bool {
+		return len(rows) == 2 &&
+			rows[0].Status == kout.StatePublished &&
+			rows[1].Status == kout.StatePublished
+	}), "both repeated cert-renewal command entries must settle to published")
+
+	rows := store.Snapshot()
+	key0, ok0 := commandruntime.ClaimKeyFromEntry(rows[0].Entry)
+	key1, ok1 := commandruntime.ClaimKeyFromEntry(rows[1].Entry)
+	require.True(t, ok0)
+	require.True(t, ok1)
+	assert.Equal(t, key0, key1, "same device cert epoch must dedupe across ticks")
+
+	got, err := queue.Dequeue(ctx, "dev-cert", 10, kcommand.DefaultLeaseDuration)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "relay Claimer must allow exactly one queued rotate-cert command")
+	assert.Equal(t, devicecert.CommandTypeRotateCert, got[0].CommandType)
+
+	var payload struct {
+		DeviceID  string `json:"deviceId"`
+		CertEpoch int64  `json:"certEpoch"`
+	}
+	require.NoError(t, json.Unmarshal(got[0].Payload, &payload))
+	assert.Equal(t, "dev-cert", payload.DeviceID)
+	assert.Equal(t, int64(5), payload.CertEpoch)
+}
+
+func startNamedLifecycleHook(
+	t *testing.T, rec *cell.RegistryRecorder, name string, ctx context.Context,
+) func(context.Context) error {
+	t.Helper()
+	for _, hook := range rec.Snapshot().LifecycleHooks {
+		if hook.Name != name {
+			continue
+		}
+		require.NoError(t, hook.OnStart(ctx), "start lifecycle hook %s", name)
+		return hook.OnStop
+	}
+	t.Fatalf("lifecycle hook %q not registered", name)
+	return nil
+}

--- a/examples/iotdevice/cells/devicecell/command_sweep_behavior_test.go
+++ b/examples/iotdevice/cells/devicecell/command_sweep_behavior_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
 	kcommand "github.com/ghbvf/gocell/kernel/command"
@@ -85,10 +86,20 @@ func startSweeperHook(t *testing.T, c *DeviceCell, ctx context.Context) func(con
 	rec := newTestRec()
 	require.NoError(t, c.Init(context.Background(), rec))
 	snap := rec.Snapshot()
-	require.Len(t, snap.LifecycleHooks, 1, "expect one lifecycle hook (sweeper)")
-	hook := snap.LifecycleHooks[0]
+	hook := lifecycleHookByName(t, snap.LifecycleHooks, "devicecommand.sweeper")
 	require.NoError(t, hook.OnStart(ctx), "OnStart must start the loop without error")
 	return hook.OnStop
+}
+
+func lifecycleHookByName(t *testing.T, hooks []cell.LifecycleHook, name string) cell.LifecycleHook {
+	t.Helper()
+	for _, hook := range hooks {
+		if hook.Name == name {
+			return hook
+		}
+	}
+	t.Fatalf("lifecycle hook %q not registered", name)
+	return cell.LifecycleHook{}
 }
 
 // TestDeviceCell_CommandSweep_ExpiresOverdueCommand pins the end-to-end expiry

--- a/examples/iotdevice/cells/devicecell/internal/adapters/postgres/device_repo.go
+++ b/examples/iotdevice/cells/devicecell/internal/adapters/postgres/device_repo.go
@@ -69,13 +69,19 @@ func NewPGDeviceRepository(pool *pgxpool.Pool, txRunner persistence.TxRunner, cl
 
 const (
 	insertDeviceSQL = `
-INSERT INTO devices (id, name, status, last_seen)
-VALUES ($1, $2, $3, $4)`
+INSERT INTO devices (id, name, status, last_seen, cert_epoch, cert_expires_at)
+VALUES ($1, $2, $3, $4, $5, $6)`
 
 	selectDeviceByIDSQL = `
-SELECT id, name, status, last_seen
+SELECT id, name, status, last_seen, cert_epoch, cert_expires_at
 FROM devices
 WHERE id = $1`
+
+	selectCertificateRenewalCandidatesSQL = `
+SELECT id, cert_epoch, cert_expires_at
+FROM devices
+WHERE cert_expires_at <= $1
+ORDER BY cert_expires_at ASC, id ASC`
 )
 
 // Create inserts a new device row. Returns ErrConflict on unique constraint violation.
@@ -85,6 +91,8 @@ func (r *PGDeviceRepository) Create(ctx context.Context, device *domain.Device) 
 		device.Name,
 		device.Status,
 		device.LastSeen,
+		device.CertEpoch,
+		device.CertExpiresAt,
 	)
 	if err != nil {
 		if pgquery.IsUniqueViolation(err) {
@@ -170,7 +178,7 @@ func buildListQuery(params query.ListParams) (string, []any, error) {
 
 	if len(params.CursorValues) == 0 {
 		// First page: no keyset predicate.
-		sqlStr := "SELECT id, name, status, last_seen FROM devices ORDER BY " + orderBy + " LIMIT $1"
+		sqlStr := "SELECT id, name, status, last_seen, cert_epoch, cert_expires_at FROM devices ORDER BY " + orderBy + " LIMIT $1"
 		return sqlStr, []any{params.FetchLimit()}, nil
 	}
 
@@ -212,7 +220,7 @@ func buildListQuery(params query.ListParams) (string, []any, error) {
 	limitPlaceholder := fmt.Sprintf("$%d", len(params.Sort)+1)
 
 	sqlStr := fmt.Sprintf(
-		"SELECT id, name, status, last_seen FROM devices WHERE (%s) %s (%s) ORDER BY %s LIMIT %s",
+		"SELECT id, name, status, last_seen, cert_epoch, cert_expires_at FROM devices WHERE (%s) %s (%s) ORDER BY %s LIMIT %s",
 		strings.Join(colNames, ", "),
 		op,
 		strings.Join(placeholders, ", "),
@@ -256,12 +264,42 @@ func trustedDeviceColumn(name string) string {
 	}
 }
 
+// ListCertificateRenewalCandidates returns devices whose cert expires at or
+// before expiresBefore. The stable order keeps reconcile tests and command
+// emission deterministic.
+func (r *PGDeviceRepository) ListCertificateRenewalCandidates(
+	ctx context.Context, expiresBefore time.Time,
+) ([]domain.CertificateRenewalCandidate, error) {
+	rows, err := r.db.Query(ctx, selectCertificateRenewalCandidatesSQL, expiresBefore)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"device_repo: list certificate renewal candidates", err)
+	}
+	defer rows.Close()
+
+	var out []domain.CertificateRenewalCandidate
+	for rows.Next() {
+		var c domain.CertificateRenewalCandidate
+		if err := rows.Scan(&c.DeviceID, &c.CertEpoch, &c.CertExpiresAt); err != nil {
+			return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+				"device_repo: scan certificate renewal candidate", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrInternal,
+			"device_repo: list certificate renewal candidates rows", err)
+	}
+	return out, nil
+}
+
 // scanDevice scans a pgx.Row into a domain.Device.
 func scanDevice(row pgx.Row) (*domain.Device, error) {
 	var d domain.Device
 	var status string
 	var lastSeen time.Time
-	err := row.Scan(&d.ID, &d.Name, &status, &lastSeen)
+	var certExpiresAt time.Time
+	err := row.Scan(&d.ID, &d.Name, &status, &lastSeen, &d.CertEpoch, &certExpiresAt)
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +311,7 @@ func scanDevice(row pgx.Row) (*domain.Device, error) {
 	}
 	d.Status = status
 	d.LastSeen = lastSeen
+	d.CertExpiresAt = certExpiresAt
 	return &d, nil
 }
 
@@ -281,7 +320,8 @@ func scanDeviceFromRows(rows pgx.Rows) (*domain.Device, error) {
 	var d domain.Device
 	var status string
 	var lastSeen time.Time
-	err := rows.Scan(&d.ID, &d.Name, &status, &lastSeen)
+	var certExpiresAt time.Time
+	err := rows.Scan(&d.ID, &d.Name, &status, &lastSeen, &d.CertEpoch, &certExpiresAt)
 	if err != nil {
 		return nil, err
 	}
@@ -293,6 +333,7 @@ func scanDeviceFromRows(rows pgx.Rows) (*domain.Device, error) {
 	}
 	d.Status = status
 	d.LastSeen = lastSeen
+	d.CertExpiresAt = certExpiresAt
 	return &d, nil
 }
 

--- a/examples/iotdevice/cells/devicecell/internal/devicecert/reconciler.go
+++ b/examples/iotdevice/cells/devicecell/internal/devicecert/reconciler.go
@@ -1,0 +1,156 @@
+// Package devicecert turns near-expiry device certificate state into
+// idempotent async rotate-cert commands.
+package devicecert
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	cmdenqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/kernel/reconcile"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/validation"
+	"github.com/ghbvf/gocell/runtime/command"
+
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
+)
+
+const (
+	CommandTypeRotateCert = "rotate-cert"
+	RenewalThreshold      = 7 * 24 * time.Hour
+)
+
+// DeviceRepository is the certificate renewal subset of domain.DeviceRepository.
+type DeviceRepository interface {
+	ListCertificateRenewalCandidates(ctx context.Context, expiresBefore time.Time) ([]domain.CertificateRenewalCandidate, error)
+}
+
+// Reconciler scans near-expiry device certs and emits rotate-cert enqueue
+// commands through the existing command.devicecommand.enqueue.v1 async path.
+type Reconciler struct {
+	repo     DeviceRepository
+	emitter  outbox.CellEmitter
+	txRunner persistence.CellTxManager
+	clk      clock.Clock
+	logger   *slog.Logger
+}
+
+type Option func(*Reconciler)
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(r *Reconciler) {
+		if logger != nil {
+			r.logger = logger
+		}
+	}
+}
+
+func NewReconciler(
+	clk clock.Clock,
+	repo DeviceRepository,
+	emitter outbox.CellEmitter,
+	txRunner persistence.CellTxManager,
+	opts ...Option,
+) (*Reconciler, error) {
+	clock.MustHaveClock(clk, "devicecert.NewReconciler")
+	r := &Reconciler{
+		repo:     repo,
+		emitter:  emitter,
+		txRunner: txRunner,
+		clk:      clk,
+		logger:   slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *Reconciler) Validate() error {
+	if r == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"devicecert: reconciler is nil")
+	}
+	if validation.IsNilInterface(r.repo) {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"devicecert: device repository is required")
+	}
+	if validation.IsNilInterface(r.emitter) {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"devicecert: command emitter is required")
+	}
+	if validation.IsNilInterface(r.txRunner) {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"devicecert: tx manager is required")
+	}
+	return nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	now := r.clk.Now()
+	candidates, err := r.repo.ListCertificateRenewalCandidates(ctx, now.Add(RenewalThreshold))
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("devicecert: scan renewal candidates: %w", err)
+	}
+	for _, c := range candidates {
+		if err := r.emitRotateCert(ctx, now, c); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) emitRotateCert(
+	ctx context.Context, requestedAt time.Time, c domain.CertificateRenewalCandidate,
+) error {
+	payload, err := json.Marshal(rotateCertPayload{
+		DeviceID:      c.DeviceID,
+		CertEpoch:     c.CertEpoch,
+		CertExpiresAt: c.CertExpiresAt,
+		RequestedAt:   requestedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("devicecert: marshal rotate-cert payload: %w", err)
+	}
+	req := cmdenqueue.Request{
+		DeviceID:    c.DeviceID,
+		CommandType: CommandTypeRotateCert,
+		Payload:     string(payload),
+	}
+	commandID := RenewalCommandID(c.DeviceID, c.CertEpoch)
+	if err := r.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
+		return command.EmitAsync(txCtx, r.clk, r.emitter, cmdenqueue.DispatchID, c.DeviceID, commandID, req)
+	}); err != nil {
+		return fmt.Errorf("devicecert: emit rotate-cert command: %w", err)
+	}
+	r.logger.Info("devicecert: emitted rotate-cert command",
+		slog.String("device_id", c.DeviceID),
+		slog.Int64("cert_epoch", c.CertEpoch),
+		slog.String("command_id", commandID))
+	return nil
+}
+
+// RenewalCommandID deterministically maps one device certificate epoch to one
+// async command instance, so repeated reconcile ticks hit the same Claimer key.
+func RenewalCommandID(deviceID string, certEpoch int64) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s:%d", deviceID, certEpoch)))
+	return "cert-renewal-" + hex.EncodeToString(sum[:16])
+}
+
+type rotateCertPayload struct {
+	DeviceID      string    `json:"deviceId"`
+	CertEpoch     int64     `json:"certEpoch"`
+	CertExpiresAt time.Time `json:"certExpiresAt"`
+	RequestedAt   time.Time `json:"requestedAt"`
+}

--- a/examples/iotdevice/cells/devicecell/internal/devicecert/reconciler_test.go
+++ b/examples/iotdevice/cells/devicecell/internal/devicecert/reconciler_test.go
@@ -1,0 +1,98 @@
+package devicecert
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
+	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/mem"
+	cmdenqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	kout "github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/outbox/outboxtest"
+	"github.com/ghbvf/gocell/kernel/reconcile"
+	rtcommand "github.com/ghbvf/gocell/runtime/command"
+)
+
+var certTestBase = time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+func TestReconciler_EmitsRotateCertCommandForNearExpiryDevice(t *testing.T) {
+	ctx := context.Background()
+	repo := mem.NewDeviceRepository()
+	require.NoError(t, repo.Create(ctx, &domain.Device{
+		ID:            "dev-near",
+		Name:          "near",
+		Status:        "online",
+		LastSeen:      certTestBase,
+		CertEpoch:     7,
+		CertExpiresAt: certTestBase.Add(RenewalThreshold).Add(-time.Hour),
+	}))
+	require.NoError(t, repo.Create(ctx, &domain.Device{
+		ID:            "dev-later",
+		Name:          "later",
+		Status:        "online",
+		LastSeen:      certTestBase,
+		CertEpoch:     8,
+		CertExpiresAt: certTestBase.Add(RenewalThreshold).Add(time.Hour),
+	}))
+	recorder := outboxtest.NewRecorder()
+	r, err := NewReconciler(clockmock.New(certTestBase), repo, recorder.CellEmitter(), kout.DemoCellTxManager())
+	require.NoError(t, err)
+
+	res, err := r.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+
+	entries := recorder.Entries()
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	assert.Equal(t, string(cmdenqueue.DispatchID), entry.RoutingTopic())
+	assert.Equal(t, "dev-near", entry.AggregateID())
+	assert.Equal(t, RenewalCommandID("dev-near", 7), entry.Metadata()[rtcommand.CommandIDMetadataKey])
+
+	var req cmdenqueue.Request
+	require.NoError(t, json.Unmarshal(entry.Payload(), &req))
+	assert.Equal(t, "dev-near", req.DeviceID)
+	assert.Equal(t, CommandTypeRotateCert, req.CommandType)
+
+	var payload rotateCertPayload
+	require.NoError(t, json.Unmarshal([]byte(req.Payload), &payload))
+	assert.Equal(t, "dev-near", payload.DeviceID)
+	assert.Equal(t, int64(7), payload.CertEpoch)
+	assert.Equal(t, certTestBase, payload.RequestedAt)
+}
+
+func TestReconciler_RepeatedTickDerivesSameClaimKeyForSameEpoch(t *testing.T) {
+	ctx := context.Background()
+	repo := mem.NewDeviceRepository()
+	require.NoError(t, repo.Create(ctx, &domain.Device{
+		ID:            "dev-repeat",
+		Name:          "repeat",
+		Status:        "online",
+		LastSeen:      certTestBase,
+		CertEpoch:     3,
+		CertExpiresAt: certTestBase.Add(RenewalThreshold).Add(-time.Hour),
+	}))
+	recorder := outboxtest.NewRecorder()
+	r, err := NewReconciler(clockmock.New(certTestBase), repo, recorder.CellEmitter(), kout.DemoCellTxManager())
+	require.NoError(t, err)
+
+	_, err = r.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, reconcile.Request{})
+	require.NoError(t, err)
+
+	entries := recorder.Entries()
+	require.Len(t, entries, 2)
+	key0, ok0 := rtcommand.ClaimKeyFromEntry(entries[0])
+	key1, ok1 := rtcommand.ClaimKeyFromEntry(entries[1])
+	require.True(t, ok0)
+	require.True(t, ok1)
+	assert.Equal(t, key0, key1)
+	assert.NotEqual(t, entries[0].ID(), entries[1].ID())
+}

--- a/examples/iotdevice/cells/devicecell/internal/domain/conformance/conformance.go
+++ b/examples/iotdevice/cells/devicecell/internal/domain/conformance/conformance.go
@@ -53,6 +53,9 @@ func RunDeviceRepoConformance(t *testing.T, factory DeviceRepoFactory, features 
 	t.Run("List/SortByNameASC", func(t *testing.T) { runListSortName(t, factory, features) })
 	t.Run("List/Pagination", func(t *testing.T) { runListPagination(t, factory, features) })
 	t.Run("List/SecondPage", func(t *testing.T) { runListSecondPage(t, factory, features) })
+	t.Run("CertRenewalCandidates/NearExpiryOnly", func(t *testing.T) {
+		runCertRenewalCandidatesNearExpiry(t, factory, features)
+	})
 }
 
 func inTx(t *testing.T, ctx context.Context, txRunner persistence.TxRunner, features Features, fn func(ctx context.Context) error) error {
@@ -76,6 +79,17 @@ func createDevice(
 		return repo.Create(c, d)
 	}); err != nil {
 		t.Fatalf("createDevice %q: %v", d.ID, err)
+	}
+}
+
+func device(id, name string, now time.Time) *domain.Device {
+	return &domain.Device{
+		ID:            id,
+		Name:          name,
+		Status:        "online",
+		LastSeen:      now,
+		CertEpoch:     domain.DefaultCertEpoch,
+		CertExpiresAt: now.Add(domain.DefaultCertTTL),
 	}
 }
 
@@ -107,7 +121,7 @@ func runCreateHappy(t *testing.T, factory DeviceRepoFactory, features Features) 
 	defer cleanup()
 	ctx := context.Background()
 
-	d := &domain.Device{ID: "dev-1", Name: "Edge-01", Status: "online", LastSeen: now()}
+	d := device("dev-1", "Edge-01", now())
 	createDevice(t, ctx, repo, tx, features, d)
 
 	got, err := repo.GetByID(ctx, "dev-1")
@@ -117,6 +131,9 @@ func runCreateHappy(t *testing.T, factory DeviceRepoFactory, features Features) 
 	if got.ID != "dev-1" || got.Name != "Edge-01" || got.Status != "online" {
 		t.Fatalf("unexpected device: %+v", got)
 	}
+	if got.CertEpoch != domain.DefaultCertEpoch || got.CertExpiresAt.IsZero() {
+		t.Fatalf("unexpected cert state: %+v", got)
+	}
 }
 
 func runCreateDuplicate(t *testing.T, factory DeviceRepoFactory, features Features) {
@@ -125,11 +142,12 @@ func runCreateDuplicate(t *testing.T, factory DeviceRepoFactory, features Featur
 	defer cleanup()
 	ctx := context.Background()
 
-	d := &domain.Device{ID: "dup", Name: "first", Status: "online", LastSeen: now()}
+	nowTime := now()
+	d := device("dup", "first", nowTime)
 	createDevice(t, ctx, repo, tx, features, d)
 
 	err := inTx(t, ctx, tx, features, func(c context.Context) error {
-		return repo.Create(c, &domain.Device{ID: "dup", Name: "second", Status: "online", LastSeen: now()})
+		return repo.Create(c, device("dup", "second", nowTime))
 	})
 	requireErrCode(t, err, errcode.ErrConflict)
 }
@@ -144,7 +162,7 @@ func runGetByIDHappy(t *testing.T, factory DeviceRepoFactory, features Features)
 	defer cleanup()
 	ctx := context.Background()
 
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "g-1", Name: "n", Status: "online", LastSeen: now()})
+	createDevice(t, ctx, repo, tx, features, device("g-1", "n", now()))
 	got, err := repo.GetByID(ctx, "g-1")
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
@@ -193,9 +211,10 @@ func runListSortName(t *testing.T, factory DeviceRepoFactory, features Features)
 	defer cleanup()
 	ctx := context.Background()
 
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "id-1", Name: "Charlie", Status: "online", LastSeen: now()})
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "id-2", Name: "Alpha", Status: "online", LastSeen: now()})
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "id-3", Name: "Bravo", Status: "online", LastSeen: now()})
+	nowTime := now()
+	createDevice(t, ctx, repo, tx, features, device("id-1", "Charlie", nowTime))
+	createDevice(t, ctx, repo, tx, features, device("id-2", "Alpha", nowTime))
+	createDevice(t, ctx, repo, tx, features, device("id-3", "Bravo", nowTime))
 
 	params := query.ListParams{
 		Limit: 20,
@@ -219,9 +238,10 @@ func runListPagination(t *testing.T, factory DeviceRepoFactory, features Feature
 	defer cleanup()
 	ctx := context.Background()
 
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "p-1", Name: "A", Status: "online", LastSeen: now()})
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "p-2", Name: "B", Status: "online", LastSeen: now()})
-	createDevice(t, ctx, repo, tx, features, &domain.Device{ID: "p-3", Name: "C", Status: "online", LastSeen: now()})
+	nowTime := now()
+	createDevice(t, ctx, repo, tx, features, device("p-1", "A", nowTime))
+	createDevice(t, ctx, repo, tx, features, device("p-2", "B", nowTime))
+	createDevice(t, ctx, repo, tx, features, device("p-3", "C", nowTime))
 
 	// Repo returns FetchLimit() = Limit+1 rows so the service can detect HasMore.
 	params := query.ListParams{
@@ -263,9 +283,7 @@ func runListSecondPage(t *testing.T, factory DeviceRepoFactory, features Feature
 		{"kp-1", "A"}, {"kp-2", "B"}, {"kp-3", "C"}, {"kp-4", "D"}, {"kp-5", "E"},
 	}
 	for _, s := range seeds {
-		createDevice(t, ctx, repo, tx, features, &domain.Device{
-			ID: s.id, Name: s.name, Status: "online", LastSeen: now(),
-		})
+		createDevice(t, ctx, repo, tx, features, device(s.id, s.name, now()))
 	}
 
 	// Page 1: no cursor.
@@ -308,5 +326,46 @@ func runListSecondPage(t *testing.T, factory DeviceRepoFactory, features Feature
 	}
 	if p3[0].Name != "E" {
 		t.Fatalf("page3: expected [E], got [%s]", p3[0].Name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Certificate renewal candidates
+// ---------------------------------------------------------------------------
+
+func runCertRenewalCandidatesNearExpiry(t *testing.T, factory DeviceRepoFactory, features Features) {
+	t.Helper()
+	repo, tx, now, cleanup := factory(t)
+	defer cleanup()
+	ctx := context.Background()
+	base := now()
+	cutoff := base.Add(7 * 24 * time.Hour)
+
+	near := device("cert-a", "near", base)
+	near.CertEpoch = 2
+	near.CertExpiresAt = cutoff.Add(-time.Hour)
+	atCutoff := device("cert-b", "edge", base)
+	atCutoff.CertEpoch = 3
+	atCutoff.CertExpiresAt = cutoff
+	later := device("cert-c", "later", base)
+	later.CertEpoch = 4
+	later.CertExpiresAt = cutoff.Add(time.Hour)
+
+	createDevice(t, ctx, repo, tx, features, later)
+	createDevice(t, ctx, repo, tx, features, atCutoff)
+	createDevice(t, ctx, repo, tx, features, near)
+
+	got, err := repo.ListCertificateRenewalCandidates(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("ListCertificateRenewalCandidates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 renewal candidates, got %d: %+v", len(got), got)
+	}
+	if got[0].DeviceID != "cert-a" || got[0].CertEpoch != 2 {
+		t.Fatalf("candidate[0] = %+v, want cert-a epoch 2", got[0])
+	}
+	if got[1].DeviceID != "cert-b" || got[1].CertEpoch != 3 {
+		t.Fatalf("candidate[1] = %+v, want cert-b epoch 3", got[1])
 	}
 }

--- a/examples/iotdevice/cells/devicecell/internal/domain/device.go
+++ b/examples/iotdevice/cells/devicecell/internal/domain/device.go
@@ -8,12 +8,27 @@ import (
 	"github.com/ghbvf/gocell/pkg/query"
 )
 
+const (
+	DefaultCertEpoch = int64(1)
+	DefaultCertTTL   = 90 * 24 * time.Hour
+)
+
 // Device represents an IoT device aggregate.
 type Device struct {
-	ID       string
-	Name     string
-	Status   string // online, offline
-	LastSeen time.Time
+	ID            string
+	Name          string
+	Status        string // online, offline
+	LastSeen      time.Time
+	CertEpoch     int64
+	CertExpiresAt time.Time
+}
+
+// CertificateRenewalCandidate is the minimal snapshot the cert-renewal
+// reconciler needs to derive an idempotent rotate-cert command.
+type CertificateRenewalCandidate struct {
+	DeviceID      string
+	CertEpoch     int64
+	CertExpiresAt time.Time
 }
 
 // DeviceRepository abstracts device persistence.
@@ -22,6 +37,7 @@ type DeviceRepository interface {
 	GetByID(ctx context.Context, id string) (*Device, error)
 	// List returns a paginated list of devices sorted by name ASC, id ASC.
 	List(ctx context.Context, params query.ListParams) ([]*Device, error)
+	ListCertificateRenewalCandidates(ctx context.Context, expiresBefore time.Time) ([]CertificateRenewalCandidate, error)
 	// RepoReady verifies the devices table is reachable and readable.
 	// Used by the cell-level readiness probe registered as "devicecell_repo_ready".
 	RepoReady(ctx context.Context) error

--- a/examples/iotdevice/cells/devicecell/internal/mem/repository.go
+++ b/examples/iotdevice/cells/devicecell/internal/mem/repository.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/internal/domain"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -73,6 +74,39 @@ func (r *DeviceRepository) List(_ context.Context, params query.ListParams) ([]*
 		return nil, fmt.Errorf("device-repo: list: %w", err)
 	}
 	return result, nil
+}
+
+// ListCertificateRenewalCandidates returns devices whose current cert expires
+// before or exactly at expiresBefore, ordered by cert expiry then device id.
+func (r *DeviceRepository) ListCertificateRenewalCandidates(
+	_ context.Context, expiresBefore time.Time,
+) ([]domain.CertificateRenewalCandidate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]domain.CertificateRenewalCandidate, 0)
+	for _, d := range r.devices {
+		if d.CertExpiresAt.IsZero() || d.CertExpiresAt.After(expiresBefore) {
+			continue
+		}
+		out = append(out, domain.CertificateRenewalCandidate{
+			DeviceID:      d.ID,
+			CertEpoch:     d.CertEpoch,
+			CertExpiresAt: d.CertExpiresAt,
+		})
+	}
+	compare := func(a, b domain.CertificateRenewalCandidate) int {
+		if c := a.CertExpiresAt.Compare(b.CertExpiresAt); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.DeviceID, b.DeviceID)
+	}
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && compare(out[j], out[j-1]) < 0; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out, nil
 }
 
 // RepoReady always returns nil for the in-memory store (no external dependency).

--- a/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/deviceregister/service.go
@@ -98,11 +98,14 @@ func (s *Service) registerInternal(ctx context.Context, name string) (*domain.De
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "device name must not be empty")
 	}
 
+	now := s.clock.Now()
 	device := &domain.Device{
-		ID:       "dev" + "-" + uuid.NewString(),
-		Name:     name,
-		Status:   "online",
-		LastSeen: s.clock.Now(),
+		ID:            "dev" + "-" + uuid.NewString(),
+		Name:          name,
+		Status:        "online",
+		LastSeen:      now,
+		CertEpoch:     domain.DefaultCertEpoch,
+		CertExpiresAt: now.Add(domain.DefaultCertTTL),
 	}
 
 	if err := s.repo.Create(ctx, device); err != nil {

--- a/examples/iotdevice/cells/devicecell/sweeper_lifecycle_test.go
+++ b/examples/iotdevice/cells/devicecell/sweeper_lifecycle_test.go
@@ -27,8 +27,8 @@ const sweeperOnStartReturnTimeout = 2 * time.Second
 // reconcile.Loop is wired into the cell as a lifecycle hook whose OnStart is
 // invoked safely (no panic) and whose OnStop is idempotent + nil-safe. This is
 // the devicecell-level integration of the kernel Sweeper → reconcile.Reconciler
-// migration: Init builds exactly one lifecycle hook named "devicecommand.sweeper"
-// backed by Loop.Start / Loop.Stop, and the worker exits cleanly on ctx cancel.
+// migration: Init builds a lifecycle hook named "devicecommand.sweeper" backed
+// by Loop.Start / Loop.Stop, and the worker exits cleanly on ctx cancel.
 //
 // The historical regression this guards (PR 441 F2): a Sweeper constructed
 // without a clock would panic at clock.MustHaveClock inside the lifecycle
@@ -40,9 +40,7 @@ func TestDeviceCell_CommandSweeperLoop_OnStartClean(t *testing.T) {
 	rec := newTestRec()
 	require.NoError(t, c.Init(context.Background(), rec))
 	snap := rec.Snapshot()
-	require.Len(t, snap.LifecycleHooks, 1, "expect one lifecycle hook (sweeper)")
-	hook := snap.LifecycleHooks[0]
-	require.Equal(t, "devicecommand.sweeper", hook.Name)
+	hook := lifecycleHookByName(t, snap.LifecycleHooks, "devicecommand.sweeper")
 	require.NotNil(t, hook.OnStart)
 	require.NotNil(t, hook.OnStop)
 


### PR DESCRIPTION
## Summary

devicecell now scans near-expiry device certificates and enqueues idempotent async `rotate-cert` device commands through the existing command async funnel.

## Why / 背景

Issue #1757 needs certificate renewal to be level-based instead of relying on a one-shot event. The implementation models certificate epoch/expiry on `domain.Device`, persists it in mem/PG repos, and wires a `devicecert.renewal` reconcile loop that emits `command.devicecommand.enqueue.v1` via `command.EmitAsync`.

## Refs

Closes #1757

ref: Watermill `components/cqrs/command_processor.go`
ref: controller-runtime `pkg/reconcile/reconcile.go`
ref: client-go `util/workqueue/default_rate_limiters.go`

## Risk / 兼容性

Breaking model/repository/schema change: `domain.Device` and `DeviceRepository` now include certificate state and renewal candidate scanning. PG migration 056 adds `devices.cert_epoch`, `devices.cert_expires_at`, a positive-epoch CHECK, and an expiry scan index. No new command contract, no rotate-cert generated handler, and no outbox wire-envelope change.

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./examples/iotdevice/cells/devicecell/...`
- [x] `go test ./examples/iotdevice/... ./runtime/command/... ./runtime/outbox/...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` 0 issues

Docker daemon is not running locally, so testcontainer-backed PG conformance was not separately rerun beyond the normal skipped integration behavior.
