### PR TITLE
refactor(pm): Cx 评级载体改用 cx-X label（弃用 Estimate 字段）

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -262,7 +262,7 @@ push 后按 `issues` B5 ① 验无文件冲突；通过后**立即**进步骤 3�
 
 - **修完** → 贴 fix 评论（命令 + **回显 comment URL/id** 见 `issues` B4；用 `<!-- pm:fix -->` 模板：findings triage + 修复结果 + 遗留 IN_SCOPE，无损写入（约定见 `pr-comment.md`：每条带 `file:line` + 详表入 `<details>`），OUT_OF_SCOPE 仅一行指针（`🚦 OUT_OF_SCOPE（详见本 PR 的 pm:oos 评论）`），含 footer）。**追加机器块**（贴评论前，接口见 `pr-comment.md` §机器块）：`bash hack/automation/pr-meta.sh emit-block --kind=fix --pr=<PR#> --findings='<计数 json>'`（phase/verdict/round 全派生），输出单行追加到 `pm:fix` body 末尾，再走 `issues` B4 贴。再 `gh pr edit` 切 `pr-status/needs-check-fix`（移除 `pr-status/needs-fix`；待 `/pr-review --check` 验证；**fix 不再直接到 ready**）——check-side 执行器从此刻可立即开始，无需等待 CI。
 - **OOS findings → 独立 pm:oos 评论**（仅当有 OUT_OF_SCOPE findings 时，紧接在 pm:fix 之后贴）：用 `<!-- pm:oos -->` 模板，每条 OOS finding 完整无损记录（字段映射见 `pr-comment.md` / `backlog.md`，不得一句话带过）。**追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=oos --pr=<PR#> --oos='{"items":[…]}'`，输出追加到 pm:oos body 末尾，再走 `issues` B4 贴。
-- **未修 / 待办 finding**（非 OOS 的 Cx3+/RELATED deferred）→ §沟通规则闸门输出 `gh issue create` 建议命令（确认后跑，留 open；label = `backlog` + `pri-pX` + `area-XX` + `type-XX`；body 按 `backlog.md` 顶部字段映射**无损**填充，不得一句话带过；条件延后型加 `flag-cond` + Trigger，派生注明 `Discovered via /fix #<original>`）。
+- **未修 / 待办 finding**（非 OOS 的 Cx3+/RELATED deferred）→ §沟通规则闸门输出 `gh issue create` 建议命令（确认后跑，留 open；label = `backlog` + `pri-pX` + `area-XX` + `type-XX` + `cx-X`（可选，从 finding `[…Cx…]` tag 提取）；body 按 `backlog.md` 顶部字段映射**无损**填充，不得一句话带过；条件延后型加 `flag-cond` + Trigger，派生注明 `Discovered via /fix #<original>`）。
 
 Priority：review finding 用原 `[P0-P3]`；`/fix` 派生默认 `pri-p2`；`pri-p0` 仅 incident（线上故障/数据完整性/CVE），停下 AskUserQuestion 确认。建 issue 必须显式 `--label pri-pX`。
 

--- a/.claude/skills/issues/SKILL.md
+++ b/.claude/skills/issues/SKILL.md
@@ -53,7 +53,7 @@ allowed-tools: [Read, Grep, Bash, Agent, AskUserQuestion]
    - `wave(v) = 1` 若 v 无 OPEN blocker；
    - `wave(v) = 1 + max(wave(b) for b in OPEN blockers(v))` 否则。
 5. **有界 cap = Wave 4**：`wave(v) > 4` 的节点标记 **超窗**——不落 Project Wave 字段（A3 清空/不写）。Project Wave 只有 1-4 四档。
-6. **wave 内排序 = 对每个 Wave 内任务并行分析，确认实施顺序**：跨 wave 顺序已由依赖锁定；wave 内无硬 `Blocked-by`，顺序是自由度。对每个 Wave（成员 ≥2）**并行**派 `Agent(Explore)` 分析其中每个任务的 scope / 触碰文件 / 产出↔消费 / 风险，主 agent 汇总后定该 wave 实施顺序：**基础性产出**（被同 wave 他者隐式消费）先 → **同文件任务相邻**防写冲突 → 默认 `pri`(p0>p1>p2>p3) → `Cx`(小先) → issue#。单任务 wave 跳过分析。
+6. **wave 内排序 = 对每个 Wave 内任务并行分析，确认实施顺序**：跨 wave 顺序已由依赖锁定；wave 内无硬 `Blocked-by`，顺序是自由度。对每个 Wave（成员 ≥2）**并行**派 `Agent(Explore)` 分析其中每个任务的 scope / 触碰文件 / 产出↔消费 / 风险，主 agent 汇总后定该 wave 实施顺序：**基础性产出**（被同 wave 他者隐式消费）先 → **同文件任务相邻**防写冲突 → 默认 `pri`(p0>p1>p2>p3) → `Cx`(小先，由 `cx-X` label 提供、REST 可查) → issue#。单任务 wave 跳过分析。
 7. 输出每个 OPEN 子任务的 `(wave, wave 内序)` 或「超窗」。
 
 呈现给用户的 dry-run 表（只列 OPEN；超窗与已完成单列）：
@@ -130,16 +130,17 @@ C
 
 ```bash
 gh issue create \
-  --label backlog --label pri-p2 --label area-eventing --label type-bug \
+  --label backlog --label pri-p2 --label area-eventing --label type-bug [--label cx-2] \
   --title "[<ID>] <简短标题>" --body-file <填好的 backlog.md>
 # body 骨架单源 = .github/project-template/backlog.md（现状 / 修复方向 / Files / Trigger / Source）——本技能不复制其结构
 ```
 
-> **由 review/fix finding（OUT_OF_SCOPE / 派生）成文时**：body 按 `backlog.md` 顶部的字段映射**无损**填充，不得一句话带过——否则后续无法据此修复。
+> **由 review/fix finding（OUT_OF_SCOPE / 派生）成文时**：body 按 `backlog.md` 顶部的字段映射**无损**填充，不得一句话带过——否则后续无法据此修复；并从 finding 的 `[…Cx…]` tag 取 `--label cx-X` 一并贴。
 
 - **area-XX**（1 个，8 选）：见 `.github/project-template/PROJECT.md` §2.1。
 - **type-XX**（1 个，8 选）：见 §2.2。
 - **pri-pX**：评级 rubric 见 `.github/project-template/PROJECT.md` §3。`/fix` 派生默认 `pri-p2`；`pri-p0` 仅 incident-driven，停下 AskUserQuestion 确认。
+- **cx-X**（可选）：复杂度 rubric 见 `.github/project-template/PROJECT.md` §3.2 / §2.6。能定级则贴；finding 派生从 `[…Cx…]` tag 取。
 - **flag-cond**（可选）：条件延后型加此 label + body 写 `## Trigger`。
 
 > P0 红线不得默认贴。area/type 漏贴时用 `gh issue edit <N> --add-label area-X --add-label type-X` 补。

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -291,7 +291,7 @@ PR #<N> 含 Cx2 findings，不自动修复（决策 3：Cx1 proven 后再开放 
 
 backlog issue draft（Cx2 follow-up）:
 gh issue create \
-  --label backlog --label pri-p2 --label area-<XX> --label type-fu \
+  --label backlog --label pri-p2 --label area-<XX> --label type-fu --label cx-2 \
   --title "[#<N>] Cx2 finding follow-up: <简述>" \
   --body-file <填好的 .github/project-template/backlog.md>
 ```

--- a/.github/project-template/PROJECT.md
+++ b/.github/project-template/PROJECT.md
@@ -168,6 +168,9 @@ gh issue list --label backlog --label area-eventing --state open
 # 按类型
 gh issue list --label backlog --label type-bug --state open
 
+# 按复杂度（cx 迁 label 后经 REST 可查）
+gh issue list --label backlog --label cx-3 --state open
+
 # epic
 gh issue list --label epic --state open
 

--- a/.github/project-template/PROJECT.md
+++ b/.github/project-template/PROJECT.md
@@ -12,15 +12,15 @@
 | 维度 | 载体 | 写入方 |
 |------|------|--------|
 | 条目内容 / 状态描述 | GitHub Issue body | 人 / 自动化 |
-| 领域 / 类型 / 优先级 | Issue label（area / type / pri） | CLI 显式 `--label` |
-| 进度状态 / 复杂度 / wave | Project v2 字段（Status / Estimate / Wave） | Project UI / 自动化 |
+| 领域 / 类型 / 优先级 / 复杂度 | Issue label（area / type / pri / cx） | CLI 显式 `--label` |
+| 进度状态 / wave | Project v2 字段（Status / Wave） | Project UI / 自动化 |
 | 父子关系 | GitHub 原生 sub-issue | 人 / 自动化 |
 
 > 本仓 issue/PR 全程经 `gh` CLI / 技能创建，body 读 `.github/project-template/` 下对应模版（`--body-file`）。
 
-**新建 backlog**：`gh issue create --label backlog --label pri-pX --label area-XX --label type-XX --title "[<ID>] ..." --body-file <填好的 backlog.md>`。pri/area/type 必须显式贴（取值见 §2/§3）。
+**新建 backlog**：`gh issue create --label backlog --label pri-pX --label area-XX --label type-XX [--label cx-X] --title "[<ID>] ..." --body-file <填好的 backlog.md>`。pri/area/type 必须显式贴；cx 可选（能定级则贴，取值见 §2.6/§3.2）。
 
-**新建 epic**：`gh issue create --label epic --label backlog --label pri-pX --label area-XX --title "[EPIC] ..." --body-file <填好的 epic.md>`；子任务用 GitHub 原生 sub-issue 关联。
+**新建 epic**：`gh issue create --label epic --label backlog --label pri-pX --label area-XX --title "[EPIC] ..." --body-file <填好的 epic.md>`；子任务用 GitHub 原生 sub-issue 关联。epic 不贴 cx（跨多 PR、无单一 diff）。
 
 ---
 
@@ -46,7 +46,7 @@
 
 ### 2.3 pri-XX（优先级，1 个，CLI 显式贴）
 
-`pri-p0` / `pri-p1` / `pri-p2` / `pri-p3`（语义见 §3 rubric）。建 issue 时必须显式 `--label pri-pX`。
+`pri-p0` / `pri-p1` / `pri-p2` / `pri-p3`（语义见 §3 rubric）。建 issue 时必须显式 `--label pri-pX`。复杂度 label（cx）见 §2.6。
 
 ### 2.4 工具 / 标记 label
 
@@ -68,6 +68,10 @@
 | | `pr-review/changes-requested` | review 提出需改项 |
 
 流转见 §5。PR 始终恰好一个 `pr-status/*`，pr-review 轴 `approved` XOR `changes-requested`（切一侧必清同轴对侧）。`/fix` 不能直接到 `ready`——必过 `/pr-review --check` 验证（fix 不能自证完成）。`needs-review-again` 仅用于 ship 首次交接；review 出 changes-requested 后始终切 `needs-fix`（5-state）。
+
+### 2.6 cx-XX（复杂度，1 个，可选 CLI 贴）
+
+`cx-1` / `cx-2` / `cx-3` / `cx-4`（语义见 §3.2 rubric）。与 pri 同为评级两轴之一、载体对称（都是 label），但 cx **可选**：建 issue / 评级时能定级则贴 `--label cx-X`，不强制；review/fix finding 派生的 issue 从 finding 的 `[…Cx…]` tag 自动带上对应 cx。epic 不贴（跨多 PR、无单一 diff）。
 
 ---
 
@@ -101,7 +105,7 @@
 | **Cx3** | 跨包 5–15 文件 | 需 archtest typed / typeseval | 接口扩字段 + 多实现同步、funnel 双向锁、ADR amendment |
 | **Cx4** | ≥15 文件 / ≥3 领域 | 跨包 type info + reflect/codegen | 接口 ctx 透传、cell 接口重构、codegen 链路改造 |
 
-> Cx 映射 Project v2 Estimate 字段（Cx1–Cx4）。Cx5+ 必须拆为多 item / 多 wave。
+> Cx 由 `cx-1`..`cx-4` label 承载（§2.6）。Cx5+ 必须拆为多 item / 多 wave。
 
 ---
 
@@ -110,13 +114,12 @@
 | 字段 | 类型 | 取值 | 写入方 |
 |------|------|------|--------|
 | **Status** | single-select | Backlog / Ready / In progress / In review / Done | 人（Project 内置 workflow + 手动） |
-| **Estimate** | single-select | Cx1 / Cx2 / Cx3 / Cx4 | 人 / 评级时 |
 | **Wave** | single-select | Wave 1 / 2 / 3 / 4（**仅 4 档**） | 自动化（epic OPEN 子任务**滚动**排序：已完成不动、未完成重排 Wave 1-4、超窗 >W4 不入字段。算法见 `issues` Part A） |
 | **Parent issue** | built-in | 自动派生（原生 sub-issue） | GitHub |
 | **Sub-issues progress** | built-in | 自动派生（子 issue close 比例） | GitHub |
 
-> Priority 不是 Project 字段，是 `pri-pX` label（单源）。已删字段：Iteration（原 daily-planner 每日调度，技能已退役）、
-> legacy Size（XS-XL，被 Estimate 取代）。
+> Priority 不是 Project 字段，是 `pri-pX` label（单源）；复杂度（Cx）同理改用 `cx-X` label（§2.6）。已删字段：Iteration（原 daily-planner 每日调度，技能已退役）、
+> Size（XS-XL）、Estimate（原承载 Cx1-Cx4，已改 `cx-X` label）。
 
 ---
 
@@ -173,4 +176,4 @@ gh pr view <N> --json reviews,comments
 gh api repos/{owner}/{repo}/pulls/<N>/comments --jq length   # 探 inline review comments，>0 才一并读取
 ```
 
-> label 维度（area/type/pri）经 REST 可查；Status/Estimate/Wave 仅 Project UI 可见（REST token 缺 `project` scope）。
+> label 维度（area/type/pri/cx）经 REST 可查；Status/Wave 仅 Project UI 可见（REST token 缺 `project` scope）。cx 改 label 后，wave 内 Cx tiebreaker 不再依赖 Project UI。

--- a/.github/project-template/README.md
+++ b/.github/project-template/README.md
@@ -22,7 +22,7 @@
 ## 用法
 
 ```bash
-gh issue create --label backlog --label pri-pX --label area-XX --label type-XX \
+gh issue create --label backlog --label pri-pX --label area-XX --label type-XX [--label cx-X] \
   --title "[<ID>] ..." --body-file <填好的 backlog.md>
 gh pr create --title "..." --body-file <填好的 pull_request_template.md>
 gh pr comment <N> --body-file <填好的 pr-comment.md 模板>

--- a/.github/project-template/pr-comment.md
+++ b/.github/project-template/pr-comment.md
@@ -157,7 +157,7 @@
 - 三级方案种子：最小 <…> / 彻底 <…> / 重构 <…>
 - 影响范围：直接 <…> / 间接 <…> / 同类 <Grep N 处>
 - Files：`other/pkg/z.go:64` `other/pkg/w.go:30`
-- → 建 issue 草稿（确认后跑）：`gh issue create --label backlog --label pri-p2 --label area-XX --label type-XX --title "[<ID>] <标题>" --body-file <backlog.md：现状←证据+根因+影响 / 修复方向←方案种子 / Files←上行 / Source←PR #<N> F3>`
+- → 建 issue 草稿（确认后跑）：`gh issue create --label backlog --label pri-p2 --label area-XX --label type-XX --label cx-2 --title "[<ID>] <标题>" --body-file <backlog.md：现状←证据+根因+影响 / 修复方向←方案种子 / Files←上行 / Source←PR #<N> F3>`（cx 从 finding `[…Cx…]` tag 取，此例 F3=Cx2）
 
 ---
 🤖 PR #<N> · Generated with <Claude Code|Codex> · branch <head 分支> · worktree <路径|—> · session <会话id|—>


### PR DESCRIPTION
## Summary

Cx 复杂度评级载体从 Project v2 #3 的 `Estimate` single-select 字段迁到 `cx-1`..`cx-4` GitHub label——与 pri 载体对称、REST 可查、可在 `gh issue create` 时原子贴。

## Why / 背景

Cx 原活在 Project UI 字段，要在 `gh issue create` 之外单独走一步 UI 设置 → 覆盖率长期偏低（原子创建命令只贴 area/type/pri label，Cx 在另一载体、创建时不落事后没人补）。而 P 与 Cx 是同一 rubric 两轴，却载体不对称（P 是 label、Cx 是字段；历史上 Estimate 继承自已弃用的 legacy Size 字段，并非深思熟虑的 label-vs-field 决策）。本 PR 把 Cx 迁回 label 收口：创建时可原子贴、REST 可查（wave 内 Cx tiebreaker 不再依赖 Project UI）、与 pri 对称。

## Refs

Closes #1728

## Risk / 兼容性

- 文档单源切换，**无 Go 代码 / wire 契约改动**（4 文件均 markdown）。
- 不向后兼容、不留软回退：直接切到 cx-X，无 deprecation 别名 / 无双写；§4 把 Estimate 并入「已删字段」墓碑（与 Iteration/Size 对称）。
- GitHub 侧副作用（非 diff）：已建 `cx-1`..`cx-4` label（绿色递进 `c2e0c6→1a6e3a`，描述指向 §3.2）。
- **需用户人工收尾**（gh api 对 project v2 字段受限）：存量 issue 重评贴 cx + 删除 Project `Estimate` 字段；文档已按「Estimate 字段已删」终态收口，用户手动同步 GitHub 侧。
- cx 为**可选** label（非强制贴），epic 豁免（跨多 PR 无单一 diff）。

## Test plan

- [x] 无 Go 改动 → `go build` / `go test` / `golangci-lint` 不适用（diff 仅 4 个 markdown）
- [x] 零残留：`grep -rn Estimate .github .claude` 仅 §4 墓碑条目，无活载体引用；自动化 `grep -wiE estimate` = 0
- [x] §2.6 用 append 不 renumber，§2.5 被 `pr-meta.v1.json`/`router.sh`/`codex README`/`issues SKILL` 引用均未 desync
- [x] 内置 6 维 review（1 reviewer，diff<200）：1 finding（§6 缺 cx 查询示例，P2/Cx1）已自动修
