### PR TITLE
fix(grpc): contain auth-stage panic with single recoverGRPCPanic guard (#1790)

### DIFF
--- a/runtime/grpc/interceptor/auth.go
+++ b/runtime/grpc/interceptor/auth.go
@@ -3,7 +3,6 @@ package interceptor
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/panicregister"
-	"github.com/ghbvf/gocell/pkg/redaction"
 	"github.com/ghbvf/gocell/pkg/validation"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -95,12 +93,25 @@ func UnaryAuth(verifier auth.IntentTokenVerifier, opts ...AuthOption) grpc.Unary
 // status error (the context is returned unchanged on the failure paths). The
 // caller forwards the returned context to the handler (wrapping the stream for
 // the streaming path).
-func authorize(ctx context.Context, cfg authConfig, verifier auth.IntentTokenVerifier, fullMethod string) (context.Context, error) {
-	isPublic, err := callPredicate(ctx, cfg.publicMethod, fullMethod)
-	if err != nil {
-		return ctx, err
-	}
-	if isPublic {
+//
+// The whole auth stage runs OUTSIDE UnaryRecovery/StreamRecovery (Recovery wraps
+// only the handler), so authorize installs ONE stage-level panic guard reusing the
+// shared recoverGRPCPanic core (#1790): any panic from a predicate, the bearer
+// verifier, or metadata parsing is collapsed into codes.Internal and logged
+// (redacted) instead of escaping the chain unobserved by the outer Metrics/Tracing
+// interceptors. This is the single chokepoint — no per-callsite guard can be
+// forgotten — so the inner helpers (callPredicate) stay panic-naive.
+func authorize(
+	ctx context.Context, cfg authConfig, verifier auth.IntentTokenVerifier, fullMethod string,
+) (resultCtx context.Context, err error) {
+	resultCtx = ctx
+	defer func() {
+		if v := recover(); v != nil {
+			resultCtx, err = ctx, recoverGRPCPanic(ctx, fullMethod, v)
+		}
+	}()
+
+	if callPredicate(cfg.publicMethod, fullMethod) {
 		return ctx, nil
 	}
 
@@ -109,44 +120,28 @@ func authorize(ctx context.Context, cfg authConfig, verifier auth.IntentTokenVer
 		return ctx, status.Error(codes.Unauthenticated, "missing or invalid authorization metadata")
 	}
 
-	ctx, p, err := auth.AuthenticateBearer(ctx, verifier, token)
-	if err != nil {
-		return ctx, authErrorToStatus(err)
+	authCtx, p, verr := auth.AuthenticateBearer(ctx, verifier, token)
+	if verr != nil {
+		return ctx, authErrorToStatus(verr)
 	}
 
-	exempt, err := callPredicate(ctx, cfg.passwordResetExempt, fullMethod)
-	if err != nil {
-		return ctx, err
-	}
-	if auth.PasswordResetBlocked(p, exempt) {
+	if auth.PasswordResetBlocked(p, callPredicate(cfg.passwordResetExempt, fullMethod)) {
 		return ctx, status.Error(codes.PermissionDenied, "password reset required before accessing this method")
 	}
 
-	return ctx, nil
+	return authCtx, nil
 }
 
 // callPredicate invokes an externally-supplied auth predicate (public-method /
-// password-reset-exempt) and converts any panic into a codes.Internal status.
-// The Auth interceptor runs OUTSIDE UnaryRecovery (Recovery wraps only the
-// handler), so without this guard a panicking predicate would escape the chain
-// unobserved by the outer Metrics/Tracing interceptors and surface as an opaque
-// transport error rather than a clean codes.Internal. A nil predicate reports
-// false (the fail-closed default).
-func callPredicate(ctx context.Context, pred func(string) bool, method string) (result bool, err error) {
+// password-reset-exempt), reporting false for a nil predicate (the fail-closed
+// default). A panicking predicate needs no local recover here: authorize's
+// stage-level guard (the auth stage runs outside Recovery) collapses it into
+// codes.Internal, so this stays a pure dispatch.
+func callPredicate(pred func(string) bool, method string) bool {
 	if pred == nil {
-		return false, nil
+		return false
 	}
-	defer func() {
-		if v := recover(); v != nil {
-			slog.ErrorContext(ctx, "grpc auth predicate panicked",
-				slog.String("method", method),
-				slog.Any("panic", redaction.RedactAny(v)),
-			)
-			result = false
-			err = status.Error(codes.Internal, "internal server error")
-		}
-	}()
-	return pred(method), nil
+	return pred(method)
 }
 
 // bearerFromMetadata extracts the bearer token from the lowercase

--- a/runtime/grpc/interceptor/auth.go
+++ b/runtime/grpc/interceptor/auth.go
@@ -100,14 +100,16 @@ func UnaryAuth(verifier auth.IntentTokenVerifier, opts ...AuthOption) grpc.Unary
 // verifier, or metadata parsing is collapsed into codes.Internal and logged
 // (redacted) instead of escaping the chain unobserved by the outer Metrics/Tracing
 // interceptors. This is the single chokepoint — no per-callsite guard can be
-// forgotten — so the inner helpers (callPredicate) stay panic-naive.
+// forgotten — so the inner helpers (callPredicate) stay panic-naive. The named
+// returns exist solely so the deferred guard can rewrite the result on the panic
+// path; the normal paths all return explicitly.
 func authorize(
 	ctx context.Context, cfg authConfig, verifier auth.IntentTokenVerifier, fullMethod string,
 ) (resultCtx context.Context, err error) {
 	resultCtx = ctx
 	defer func() {
 		if v := recover(); v != nil {
-			resultCtx, err = ctx, recoverGRPCPanic(ctx, fullMethod, v)
+			resultCtx, err = ctx, recoverGRPCPanic(ctx, "auth", fullMethod, v)
 		}
 	}()
 

--- a/runtime/grpc/interceptor/auth_test.go
+++ b/runtime/grpc/interceptor/auth_test.go
@@ -1,7 +1,10 @@
 package interceptor
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -224,6 +227,11 @@ func assertUnaryAuthPublicMethodPanic(t *testing.T, info *grpc.UnaryServerInfo) 
 func assertUnaryAuthVerifierPanic(t *testing.T, info *grpc.UnaryServerInfo) {
 	t.Helper()
 
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
 	called := false
 	_, err := UnaryAuth(panicVerifier{val: "verifier exploded"})(bearerCtx(), nil, info, okHandler(&called))
 	if status.Code(err) != codes.Internal {
@@ -231,6 +239,11 @@ func assertUnaryAuthVerifierPanic(t *testing.T, info *grpc.UnaryServerInfo) {
 	}
 	if called {
 		t.Fatalf("handler must not run when the verifier panics")
+	}
+	// stage=auth lets operators distinguish an auth-stage panic (e.g. a verifier
+	// defect) from a business handler panic without parsing the stack.
+	if !strings.Contains(buf.String(), `"stage":"auth"`) {
+		t.Fatalf("auth-stage panic log must carry stage=auth: %s", buf.String())
 	}
 }
 

--- a/runtime/grpc/interceptor/auth_test.go
+++ b/runtime/grpc/interceptor/auth_test.go
@@ -69,6 +69,10 @@ func TestUnaryAuth(t *testing.T) {
 		assertUnaryAuthPublicMethodPanic(t, info)
 	})
 
+	t.Run("panicking verifier returns Internal (panic must not escape Recovery-less auth stage)", func(t *testing.T) {
+		assertUnaryAuthVerifierPanic(t, info)
+	})
+
 	t.Run("nil verifier panics at construction (fail-fast wiring)", func(t *testing.T) {
 		assertUnaryAuthNilVerifierPanics(t)
 	})
@@ -214,6 +218,19 @@ func assertUnaryAuthPublicMethodPanic(t *testing.T, info *grpc.UnaryServerInfo) 
 		func(context.Context, any) (any, error) { return "ok", nil })
 	if status.Code(err) != codes.Internal {
 		t.Fatalf("code = %v, want Internal (predicate panic must not escape)", status.Code(err))
+	}
+}
+
+func assertUnaryAuthVerifierPanic(t *testing.T, info *grpc.UnaryServerInfo) {
+	t.Helper()
+
+	called := false
+	_, err := UnaryAuth(panicVerifier{val: "verifier exploded"})(bearerCtx(), nil, info, okHandler(&called))
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("code = %v, want Internal (verifier panic must not escape the Recovery-less auth stage)", status.Code(err))
+	}
+	if called {
+		t.Fatalf("handler must not run when the verifier panics")
 	}
 }
 

--- a/runtime/grpc/interceptor/helpers_test.go
+++ b/runtime/grpc/interceptor/helpers_test.go
@@ -50,3 +50,12 @@ type stubVerifier struct {
 func (v stubVerifier) VerifyIntent(_ context.Context, _ string, _ kauth.TokenIntent) (kauth.Claims, error) {
 	return v.claims, v.err
 }
+
+// panicVerifier panics inside VerifyIntent to exercise authorize's stage-level
+// panic guard: the Auth interceptor runs OUTSIDE Recovery, so a verifier that
+// panics must be collapsed into codes.Internal rather than escaping the chain.
+type panicVerifier struct{ val any }
+
+func (v panicVerifier) VerifyIntent(context.Context, string, kauth.TokenIntent) (kauth.Claims, error) {
+	panic(v.val)
+}

--- a/runtime/grpc/interceptor/recovery.go
+++ b/runtime/grpc/interceptor/recovery.go
@@ -26,7 +26,7 @@ func UnaryRecovery() grpc.UnaryServerInterceptor {
 		defer func() {
 			if v := recover(); v != nil {
 				resp = nil
-				err = recoverGRPCPanic(ctx, info.FullMethod, v)
+				err = recoverGRPCPanic(ctx, "handler", info.FullMethod, v)
 			}
 		}()
 		return handler(ctx, req)
@@ -34,11 +34,14 @@ func UnaryRecovery() grpc.UnaryServerInterceptor {
 }
 
 // recoverGRPCPanic is the transport-shape-agnostic panic-collapse core shared by
-// UnaryRecovery and StreamRecovery (PR-10 #1153): it logs the redacted panic
-// value plus stack and returns the codes.Internal status the interceptor hands
-// back to the client. It never re-panics, so it is outside the PANIC-REGISTERED-01
-// funnel (same as the unary path).
-func recoverGRPCPanic(ctx context.Context, fullMethod string, recovered any) error {
+// UnaryRecovery / StreamRecovery (the handler stage, PR-10 #1153) and authorize
+// (the auth stage, #1790): it logs the redacted panic value plus stack and returns
+// the codes.Internal status the interceptor hands back to the client. It never
+// re-panics, so it is outside the PANIC-REGISTERED-01 funnel (same as the unary
+// path). stage ("handler" / "auth") is logged so operators can tell a business
+// handler panic from an auth-stage panic (e.g. a verifier defect) — they carry
+// different severity — without parsing the stack.
+func recoverGRPCPanic(ctx context.Context, stage, fullMethod string, recovered any) error {
 	stack := string(debug.Stack())
 	// Sanitize the panic payload before logging — a raw value may carry
 	// credentials or connection strings. RedactAny is the sanctioned funnel for
@@ -46,6 +49,7 @@ func recoverGRPCPanic(ctx context.Context, fullMethod string, recovered any) err
 	attrs := []any{
 		slog.Any("panic", redaction.RedactAny(recovered)),
 		slog.String("stack", stack),
+		slog.String("stage", stage),
 		slog.String("method", fullMethod),
 	}
 	if reqID, ok := ctxkeys.RequestIDFrom(ctx); ok {

--- a/runtime/grpc/interceptor/recovery_test.go
+++ b/runtime/grpc/interceptor/recovery_test.go
@@ -67,6 +67,9 @@ func assertUnaryRecoveryRedactsPanic(t *testing.T, info *grpc.UnaryServerInfo) {
 	if !strings.Contains(out, "panic recovered") {
 		t.Fatalf("slog missing panic log: %s", out)
 	}
+	if !strings.Contains(out, `"stage":"handler"`) {
+		t.Fatalf("handler panic log must carry stage=handler (operator distinguishability): %s", out)
+	}
 	if strings.Contains(out, "hunter2") {
 		t.Fatalf("slog leaked secret (not redacted): %s", out)
 	}

--- a/runtime/grpc/interceptor/stream.go
+++ b/runtime/grpc/interceptor/stream.go
@@ -173,7 +173,7 @@ func StreamRecovery() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
 		defer func() {
 			if v := recover(); v != nil {
-				err = recoverGRPCPanic(ss.Context(), info.FullMethod, v)
+				err = recoverGRPCPanic(ss.Context(), "handler", info.FullMethod, v)
 			}
 		}()
 		return handler(srv, ss)

--- a/runtime/grpc/interceptor/stream_test.go
+++ b/runtime/grpc/interceptor/stream_test.go
@@ -157,6 +157,22 @@ func TestStreamAuth_NilVerifierPanics(t *testing.T) {
 	_ = StreamAuth(nil)
 }
 
+func TestStreamAuth_VerifierPanicReturnsInternal(t *testing.T) {
+	// bearerCtx() carries a valid bearer token so authorize reaches the verifier;
+	// the panicking verifier must be collapsed into codes.Internal by authorize's
+	// stage-level guard — the streaming Auth interceptor also runs outside Recovery.
+	handlerReached := false
+	handler := func(any, grpc.ServerStream) error { handlerReached = true; return nil }
+	ss := &fakeServerStream{ctx: bearerCtx()}
+	err := StreamAuth(panicVerifier{val: "verifier exploded"})(nil, ss, streamInfo(), handler)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("StreamAuth verifier panic must return Internal, got %v", status.Code(err))
+	}
+	if handlerReached {
+		t.Fatalf("handler must not be reached when the verifier panics")
+	}
+}
+
 func TestStreamAccessLog_LogsWithoutBreakingStream(t *testing.T) {
 	// StreamAccessLog logs once at stream close and must pass the handler result
 	// through unchanged (success + error paths). The slog line itself is sink-


### PR DESCRIPTION
## Summary

gRPC auth 阶段装单个 stage-level panic 守卫（复用 `recoverGRPCPanic`），verifier / predicate panic 不再越过 Recovery 逃出 interceptor chain。

## Why / 背景

gRPC Auth interceptor 在链中位于 `Recovery` **之外**（Recovery 是 innermost，只包 handler）。`authorize` 直接调 `auth.AuthenticateBearer`，若 verifier panic 会越过 Recovery 逃出整条链，外层 Metrics/Tracing 的 cleanup 无法按预期完成，panic 以不透明 transport error 而非干净的 `codes.Internal` 暴露给客户端（PR #1777 finding F13）。

根因是结构性的：**整个 auth 阶段都在 Recovery 之外**，而既有缓解只守住了 predicate callsite（`callPredicate`），verifier（及未来 `authorize` 内任何新增调用）仍裸奔。本 PR 不在单一 callsite 补丁，而在 `authorize` 装 **一个** stage-level 守卫，复用 Unary/StreamRecovery 已在用的共享 `recoverGRPCPanic` 核 —— 单一 chokepoint，任何 per-callsite 守卫都不会被遗忘。`callPredicate` 自带的 recover 随之删除（退化为纯 dispatch），`log/slog` + `pkg/redaction` import 从 `auth.go` 移除。因 `UnaryAuth` 与 `StreamAuth` 共享 `authorize`，一处守卫覆盖两条 transport。

不做（issue 明确排除）：不把 `Recovery` 包整条链 —— 当前 gRPC status-as-return 设计下 Recovery innermost 是刻意选择，本 PR 仅在 auth 阶段加 localized recover，不移动 Recovery。

**AI-robust 评级**：Medium（runtime guard 单 chokepoint）。panic containment 是 runtime 属性，Go 无法用 type/compile/golden 表达「此路径不会 panic」→ Hard 不可达；章程禁止把 bug 修复包装成 archtest，故不新增治理机制。

## Refs

Closes #1790
ref: reuses `runtime/grpc/interceptor.recoverGRPCPanic` (recovery.go)

## Risk / 兼容性

无破坏性变更。无 wire 契约 / migration / 消费方影响。唯二可观测变化均为改进：(1) 此前越过 Recovery 逃逸的 verifier panic 现收敛为干净 `codes.Internal`；(2) predicate panic 日志从 `"grpc auth predicate panicked"` 改为共享核的 `"panic recovered"`（额外带 stack + request_id），wire 结果不变。

## Test plan

- [x] `go build ./...` 本地通过（含 `-tags=integration`）
- [x] `go test ./runtime/grpc/interceptor/...` 本地通过（unary + stream verifier-panic 新测 + 既有 predicate-panic 测试全绿）
- [x] `golangci-lint run ./runtime/grpc/interceptor/...` 0 issues（v2.11.4，与 CI 同版本）
