### PR TITLE
docs(reconcile): kernel/reconcile 单源规则 + L4 引用 + ADR/对标收口 (#1171)

### DIFF
--- a/.claude/rules/gocell/reconcile.md
+++ b/.claude/rules/gocell/reconcile.md
@@ -1,7 +1,7 @@
 # Reconcile 控制环规则
 
 本文件只保留当前行为约束。完整 invariant 清单、符号、盲区写在
-`kernel/reconcile/doc.go` §Enforced invariants、`tools/archtest/reconcile_invariants_test.go`
+`kernel/reconcile/doc.go` §Enforced invariants、`tools/archtest/reconcile*_test.go`
 和 reconcile ADR 中。
 
 ## 适用范围
@@ -47,7 +47,6 @@ L3 最终一致可用 projection / saga；reconcile 用于 L4 跨不可靠边界
 ## 参考
 
 - ADR：`docs/architecture/202605291600-661-adr-kernel-reconcile-design.md`
-- 权威 godoc：`kernel/reconcile/doc.go`
-- Invariants：`RECONCILE-*` 族（fields/interface/trigger/leader frozen、builder/fenced-write/leader-impl
-  funnel、requeue-caller、result-label frozen）完整清单与盲区见 `kernel/reconcile/doc.go`
-  §Enforced invariants 与 `tools/archtest/reconcile_invariants_test.go`。
+- 权威 godoc：`kernel/reconcile/doc.go` §Enforced invariants
+- Invariants：`RECONCILE-*` 族完整清单、符号与盲区以 `tools/archtest/reconcile*_test.go`
+  （4 文件，可执行真源）与 `kernel/reconcile/doc.go` §Enforced invariants 为准；规则文件不另维护清单。

--- a/.claude/rules/gocell/reconcile.md
+++ b/.claude/rules/gocell/reconcile.md
@@ -1,0 +1,52 @@
+# Reconcile 控制环规则
+
+本文件只保留当前行为约束。完整 invariant 清单、符号、盲区写在
+`kernel/reconcile/doc.go` §Enforced invariants、`tools/archtest/reconcile_invariants_test.go`
+和 reconcile ADR 中。
+
+## 适用范围
+
+reconcile 是 L4 desired-state 收敛控制环：周期观察一个 cell **自己 OWN** 的非终态实体
+（设备命令、证书行、trust score），把每个驱动趋向 desired。收敛权属于消费 cell——框架只
+提供 Loop harness，cell 在 `Reconcile` 内对自己的实体表行使写权。
+
+reconcile **不是业务编排器**（那是 saga），**不是 CQRS 读模型构建器**（那是 projection
+harness）。三者正交，边界见下。
+
+## Reconciler 实现要点
+
+- 签名 `Reconcile(ctx, Request) (Result, error)`，方法集冻结。
+- 零值 `Request{}`（空 EntityID）是 resync pulse——「re-observe 你拥有的全部」，fan out 到每个
+  实体；ticker 每 interval 再发，早退的 sweep 下个 tick 被重驱动（level-triggered，不丢）。
+- transient error → Loop 退避重试（per-entity 指数退避）。
+- `PermanentError` / `IsPermanent` 只是不可重试分类，**不**自动把重试改成放弃下一步逻辑。
+- `Result.RequeueAfter` 表达健康态稍后复检；result label 值集冻结，recovered panic 映射 transient。
+
+## Builder 强制
+
+`reconcile.New(r).With*().Build()` 是**唯一**公开构造入口；Loop config 字段全部 unexported，
+`Build()` 强制要求一个 Trigger。消费方禁止裸构造 Loop，禁止旁路 Builder 注入调度逻辑。
+
+## Leader-elect
+
+- nil `LeaderElector` = 单进程模式（always leader，Epoch 0，无 fencing）。
+- wire 后整环 leader-gated：仅 lease holder dispatch；丢 lease 取消 lease-scoped ctx 中断在途 Reconcile。
+- **leader ≠ fencing**：跨副本正确性靠单调 `LeaseToken.Epoch` 注入 `FencedWriter`（写路径 CAS）+
+  消费方幂等，绝不靠 lease 本身。
+- `LeaderElector` 实现只允许在 `adapters/{redis,postgres}` + `reconciletest` fake；adapter
+  选型 Redis vs PG 按部署形态决定。
+
+## 与 saga / projection 边界
+
+- **saga**：边沿触发、有限步前向编排 + 补偿，跑完即终态（对标 Temporal）。
+- **reconcile**：水平触发、desired↔actual 无限收敛环（对标 controller-runtime）。
+- **projection**：CQRS 读模型构建，事件驱动重放投影。
+
+L3 最终一致可用 projection / saga；reconcile 用于 L4 跨不可靠边界（设备 / 证书）的主动收敛。
+
+## 参考
+
+- ADR：`docs/architecture/202605291600-661-adr-kernel-reconcile-design.md`
+- 权威 godoc：`kernel/reconcile/doc.go`
+- Invariants：`tools/archtest/reconcile_invariants_test.go`（`RECONCILE-*`，含 BUILDER-FUNNEL /
+  FENCED-WRITE-FUNNEL / 各 FROZEN 族）

--- a/.claude/rules/gocell/reconcile.md
+++ b/.claude/rules/gocell/reconcile.md
@@ -48,5 +48,6 @@ L3 最终一致可用 projection / saga；reconcile 用于 L4 跨不可靠边界
 
 - ADR：`docs/architecture/202605291600-661-adr-kernel-reconcile-design.md`
 - 权威 godoc：`kernel/reconcile/doc.go`
-- Invariants：`tools/archtest/reconcile_invariants_test.go`（`RECONCILE-*`，含 BUILDER-FUNNEL /
-  FENCED-WRITE-FUNNEL / 各 FROZEN 族）
+- Invariants：`RECONCILE-*` 族（fields/interface/trigger/leader frozen、builder/fenced-write/leader-impl
+  funnel、requeue-caller、result-label frozen）完整清单与盲区见 `kernel/reconcile/doc.go`
+  §Enforced invariants 与 `tools/archtest/reconcile_invariants_test.go`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ actors.yaml   — 外部 Actor 注册（参与 contract 但不属于 Cell 模型
 | L1 LocalTx | 单 cell 本地事务 | session 创建、审计写入 |
 | L2 OutboxFact | 本地事务 + outbox 发布 | session.created 事件、config.entry-upserted 事件 |
 | L3 WorkflowEventual | 跨 cell 最终一致 | 查询投影、CQRS、Saga |
-| L4 DeviceLatent | 设备长延迟闭环 | 命令回执、证书续期 |
+| L4 DeviceLatent | 设备长延迟闭环 | 命令回执、证书续期、状态收敛 |
 
 ## Go 编码规范
 

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -531,7 +531,7 @@ K=N 静态 enumerate 的目的。
 
 | 维度 | 评估 |
 |---|---|
-| per-shard RSS / OOM 包络 | develop archtest 顶层 Test 函数现共 **1223**（D1 discovery 快照、非真值源；已含 reconcile 族 27 个，非本 PR 新增）；reconcile 占 ~2.2%，K=24 下 ≈ 51 函数/shard、reconcile 贡献 ≈ +1.1。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，该族不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
+| per-shard RSS / OOM 包络 | reconcile 族 27 个顶层 Test 函数（见上；`grep -hc '^func TestReconcile' tools/archtest/reconcile*_test.go`，随 epic 冻结、增删须过 review）在 develop archtest 全池中占低个位数百分比，且该占比随全仓 archtest 增长只稀释不放大——K=24 下每 shard ≈ +1 函数。**本 ADR 不固化任何全池绝对计数**：池大小以 D1 discovery（`go test -tags archtest -list '^Test' ./tools/archtest`）实时为真源，写死的总数会随无关 PR 漂移（line 535 同理拒绝 true-up 历史 296/32）。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，该族不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
 | §决策 行的绝对计数（"296 函数"/"per-shard 32"）| 为历史 macOS baseline，早被 line 29 声明为「方向性论点权威、不以绝对数为真值源」；本 PR **不** true-up 该历史数（其漂移源自全仓 archtest 4× 增长，非 reconcile，超出本 PR 范围）。|
 | 一致性守卫 | `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` / `ARCHTEST-LEAF-BUILD-TAG-01` 不受影响；reconcile 测试文件已带 `//go:build archtest` leaf tag（同 D3 范式），编译级排除 bare `go test` 自动覆盖。|
 

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -511,3 +511,27 @@ Go 生态「重型套件排出默认 `go test`」标准只有 build tag（编译
 | §D6 single-owner 原则（nightly + verify-archtest.sh 为唯一 owner） | ⚠️ 补强 | 原则不变；本 amendment 把它从「靠 VERIFY_SKIP 约定」升级为「靠 build tag 编译级 + ARCHTEST-LEAF-BUILD-TAG-01 守卫」机器强制 |
 | §D6 `VERIFY_SKIP=archtest` env | ✅ 保留 | 仍 skip 专用 `verify-archtest.sh` gate（避免 governance lane 跑 K=1 全量）；与 build tag 互补，非冗余 |
 | build-test `_dynamic_archtest_excluded` grep | ⚠️ 职责收窄 | 见 D4：执行排除 → coverage-scope 排除 |
+
+---
+
+## §Amendment 2026-06-10 (PR-A10 #1171, KERNEL-RECONCILE-01 收口) — reconcile invariant 族纳入 archtest 池
+
+epic #661（`kernel/reconcile` L4 收敛控制环）落地后，`tools/archtest/reconcile_*_test.go` 4 个文件新增
+**27 个顶层 Test 函数**（`RECONCILE-*` 族：interface/Request/Result/Trigger/LeaderElector frozen、
+BUILDER-FUNNEL、FENCED-WRITE-FUNNEL、RESULT-LABEL-VALUES-FROZEN、REQUEUE-ENQUEUE-CALLER、
+LEADER-IMPL-FUNNEL、goleak TestMain funnel）。
+
+**无 matrix / 脚本编辑**：D1 的 discovery（`go test -list '^Test' ./tools/archtest` modulo `SHARD_COUNT`）
+按设计自动吸收这 27 个函数，无需任何 CI 配置改动——这正是 D1 动态分片相对旧 K=N 静态 enumerate 的目的。
+本 amendment 仅做威胁矩阵再评，不改决策。
+
+### 威胁矩阵再评（per ai-robust.md §"ADR amendment 落地必查"）
+
+| 维度 | 评估 |
+|---|---|
+| per-shard RSS / OOM 包络 | archtest 顶层 Test 函数当前共 **1226**，reconcile 族 27 个占 ~2.2%；K=24 下每 shard ≈ 51 函数，reconcile 增量 ≈ +1.1 函数/shard。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，27 个新函数不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
+| §决策 行的绝对计数（"296 函数"/"per-shard 32"）| 为历史 macOS baseline，早被 line 29 声明为「方向性论点权威、不以绝对数为真值源」；本 PR **不** true-up 该历史数（其漂移源自全仓 archtest 4× 增长，非 reconcile，超出本 PR 范围）。|
+| 一致性守卫 | `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` / `ARCHTEST-LEAF-BUILD-TAG-01` 不受影响；reconcile 测试文件已带 `//go:build archtest` leaf tag（同 D3 范式），编译级排除 bare `go test` 自动覆盖。|
+
+> 关联 ADR2 `202605170000-...`：reconcile.Loop 共用的 control-plane clock carve-out 已由其 §Amendment
+> 2026-06-06（#1169）就地重写，本 PR 不重复 amend（避免双真值源）。

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -531,7 +531,7 @@ K=N 静态 enumerate 的目的。
 
 | 维度 | 评估 |
 |---|---|
-| per-shard RSS / OOM 包络 | develop archtest 顶层 Test 函数现共 **1226**（已含 reconcile 族 27 个，非本 PR 新增）；reconcile 占 ~2.2%，K=24 下 ≈ 51 函数/shard、reconcile 贡献 ≈ +1.1。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，该族不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
+| per-shard RSS / OOM 包络 | develop archtest 顶层 Test 函数现共 **1223**（D1 discovery 快照、非真值源；已含 reconcile 族 27 个，非本 PR 新增）；reconcile 占 ~2.2%，K=24 下 ≈ 51 函数/shard、reconcile 贡献 ≈ +1.1。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，该族不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
 | §决策 行的绝对计数（"296 函数"/"per-shard 32"）| 为历史 macOS baseline，早被 line 29 声明为「方向性论点权威、不以绝对数为真值源」；本 PR **不** true-up 该历史数（其漂移源自全仓 archtest 4× 增长，非 reconcile，超出本 PR 范围）。|
 | 一致性守卫 | `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` / `ARCHTEST-LEAF-BUILD-TAG-01` 不受影响；reconcile 测试文件已带 `//go:build archtest` leaf tag（同 D3 范式），编译级排除 bare `go test` 自动覆盖。|
 

--- a/docs/architecture/202605120000-adr-archtest-process-isolation.md
+++ b/docs/architecture/202605120000-adr-archtest-process-isolation.md
@@ -516,20 +516,22 @@ Go 生态「重型套件排出默认 `go test`」标准只有 build tag（编译
 
 ## §Amendment 2026-06-10 (PR-A10 #1171, KERNEL-RECONCILE-01 收口) — reconcile invariant 族纳入 archtest 池
 
-epic #661（`kernel/reconcile` L4 收敛控制环）落地后，`tools/archtest/reconcile_*_test.go` 4 个文件新增
-**27 个顶层 Test 函数**（`RECONCILE-*` 族：interface/Request/Result/Trigger/LeaderElector frozen、
+epic #661（`kernel/reconcile` L4 收敛控制环）的 archtest 守卫 `tools/archtest/reconcile_*_test.go`
+（4 文件、**27 个顶层 Test 函数**：interface/Request/Result/Trigger/LeaderElector frozen、
 BUILDER-FUNNEL、FENCED-WRITE-FUNNEL、RESULT-LABEL-VALUES-FROZEN、REQUEUE-ENQUEUE-CALLER、
-LEADER-IMPL-FUNNEL、goleak TestMain funnel）。
+LEADER-IMPL-FUNNEL、goleak TestMain funnel）随 PR-A2…A7 已 merge，早已在 develop archtest 池内。
+本收口 PR（A10）**纯文档、不新增任何 archtest 函数**；本 §Amendment 在 epic 关闭时回溯记录该 invariant
+族的 CI 足迹并再评威胁矩阵，不改决策。
 
 **无 matrix / 脚本编辑**：D1 的 discovery（`go test -list '^Test' ./tools/archtest` modulo `SHARD_COUNT`）
-按设计自动吸收这 27 个函数，无需任何 CI 配置改动——这正是 D1 动态分片相对旧 K=N 静态 enumerate 的目的。
-本 amendment 仅做威胁矩阵再评，不改决策。
+按设计自动吸收这 27 个函数（A2…A7 落地时即生效），无需任何 CI 配置改动——这正是 D1 动态分片相对旧
+K=N 静态 enumerate 的目的。
 
 ### 威胁矩阵再评（per ai-robust.md §"ADR amendment 落地必查"）
 
 | 维度 | 评估 |
 |---|---|
-| per-shard RSS / OOM 包络 | archtest 顶层 Test 函数当前共 **1226**，reconcile 族 27 个占 ~2.2%；K=24 下每 shard ≈ 51 函数，reconcile 增量 ≈ +1.1 函数/shard。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，27 个新函数不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
+| per-shard RSS / OOM 包络 | develop archtest 顶层 Test 函数现共 **1226**（已含 reconcile 族 27 个，非本 PR 新增）；reconcile 占 ~2.2%，K=24 下 ≈ 51 函数/shard、reconcile 贡献 ≈ +1.1。OOM 触发源是 `typeseval.SharedResolver` 的 type-graph 累加，该族不引入新对标语义类别，per-shard RSS 仍落在 §决策 中 K=24 < GHA 7GB 的方向性包络内。|
 | §决策 行的绝对计数（"296 函数"/"per-shard 32"）| 为历史 macOS baseline，早被 line 29 声明为「方向性论点权威、不以绝对数为真值源」；本 PR **不** true-up 该历史数（其漂移源自全仓 archtest 4× 增长，非 reconcile，超出本 PR 范围）。|
 | 一致性守卫 | `ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01` / `ARCHTEST-LEAF-BUILD-TAG-01` 不受影响；reconcile 测试文件已带 `//go:build archtest` leaf tag（同 D3 范式），编译级排除 bare `go test` 自动覆盖。|
 

--- a/docs/references/framework-comparison.md
+++ b/docs/references/framework-comparison.md
@@ -84,9 +84,12 @@ goal:      outbox 模式 + 幂等消费，不是直接 publish
 
 ```
 primary:   kubernetes-sigs/controller-runtime → pkg/reconcile/reconcile.go（Reconciler 接口、Request/Result）
-secondary: kubernetes/client-go               → tools/leaderelection/（leader election + LeaseToken fencing）
+secondary: kubernetes/client-go               → tools/leaderelection/（leader election lease/renew 模型）
 goal:      比 controller-runtime 更窄——单 opaque EntityID、无 Informer/CRD watch、无 Requeue bool/Priority；
            仅 cell 治理 / 设备收敛（L4），业务编排归 saga、CQRS 读模型归 projection
+deviations:
+  - leader ≠ fencing：client-go leaderelection 不保证 fencing；跨副本写正确性是 GoCell 自有补强——
+    单调 LeaseToken.Epoch 注入 FencedWriter（写路径 CAS）+ 消费方幂等，绝不靠 lease 本身
 ```
 
 ### pkg/errcode/ — 错误模型

--- a/docs/references/framework-comparison.md
+++ b/docs/references/framework-comparison.md
@@ -12,6 +12,7 @@
 | [go-micro](https://github.com/micro/go-micro) | 23K | Apache 2.0 | Config 热更新、服务注册、Auth 模块、PubSub |
 | [Watermill](https://github.com/ThreeDotsLabs/watermill) | 6K | MIT | 事件驱动 Pub/Sub、多后端 adapter、CQRS |
 | [Kubernetes](https://github.com/kubernetes/kubernetes) | 110K | Apache 2.0 | Cell/Slice 声明模型、生命周期、校验链、编排 |
+| [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) | 3K | Apache 2.0 | L4 控制环：Reconciler 接口、level-triggered 收敛、RequeueAfter、leader election |
 
 ## 按 GoCell 模块的参考映射
 
@@ -77,6 +78,15 @@ goal:      configcore Cell 通过 outbox 事件推送变更，不是轮询
 primary:   ThreeDotsLabs/watermill → message/（Message 统一模型、Publisher/Subscriber 接口）
 secondary: micro/go-micro          → events/（Event 模型、Store/Stream 抽象）
 goal:      outbox 模式 + 幂等消费，不是直接 publish
+```
+
+### kernel/reconcile/ — L4 desired-state 收敛控制环
+
+```
+primary:   kubernetes-sigs/controller-runtime → pkg/reconcile/reconcile.go（Reconciler 接口、Request/Result）
+secondary: kubernetes/client-go               → tools/leaderelection/（leader election + LeaseToken fencing）
+goal:      比 controller-runtime 更窄——单 opaque EntityID、无 Informer/CRD watch、无 Requeue bool/Priority；
+           仅 cell 治理 / 设备收敛（L4），业务编排归 saga、CQRS 读模型归 projection
 ```
 
 ### pkg/errcode/ — 错误模型

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -140,6 +140,16 @@
 //     sites are pinned to loop.go / fenced.go.
 //   - RECONCILE-LEADER-IMPL-FUNNEL-01 (PR-A6): LeaderElector is implemented only
 //     in adapters/{redis,postgres} + the reconciletest fake (layering hygiene).
+//   - RECONCILE-BUILDER-FUNNEL-01 (PR-A7): reconcile.Loop config fields are
+//     private — no composite literal of reconcile.Loop (incl. the zero-value
+//     Loop{}) compiles outside this package, so a consumer cannot bypass the
+//     Builder's metric / leader / backoff wiring. Retires the transitional
+//     RECONCILE-LOOP-CONSTRUCTION-ALLOWLIST-01.
+//   - RECONCILE-GOLEAK-TESTMAIN-FUNNEL-01 (#1604): all goroutine-leak checks in
+//     the kernel/reconcile test binaries funnel through a single package-level
+//     goleak.VerifyTestMain, banning the per-test VerifyNone(IgnoreCurrent())
+//     idiom that flakes under -race (the Trigger / watchDrain tails drain
+//     asynchronously on ctx cancel).
 //
 // Leader election (PR-A6) is whole-loop: when a LeaderElector is wired only the
 // lease holder dispatches Reconcile; a lost lease cancels the lease-scoped ctx to


### PR DESCRIPTION
## Summary

PR-A10：为已落地的 `kernel/reconcile`（L4 desired-state 收敛控制环）补单源治理规则文件，并把 reconcile 接入章程 / 对标索引，收口 epic #661。

## Why / 背景

`kernel/reconcile/`（Reconciler/Loop/Trigger/Backoff/Leader/Builder + 11 类 archtest invariant + 权威 `doc.go`）经 PR-A1…A9 已全部 merge，但缺一份给 AI co-author 的 prompt-context 单源规则。本 PR 是 #661 的文档收口（B8）。

按用户收紧的两点（均被机器规则佐证）：
- **reconcile.md 保持简洁**：仓库 rule 文件 25–78 行（同类 `saga.md`=35），`AGENT-RULES-GOVERNANCE-01` 强制 ≤220 行/16KB；本文件 52 行、2828 字节、零 history marker，通过该门。
- **CLAUDE.md 只加一个词到 L4**：L4 场景列加「状态收敛」。**不**按 spec T48 在 AI-robust 段加链接——仓库无「CLAUDE.md↔rule 链接」检查，rule 靠 `.claude/rules/gocell` 目录扫描可达（`saga.md` 即未被引用却一等的先例）。

## Refs

- Closes #1171
- Closes #661（`KERNEL-RECONCILE-01` epic 收口；前置门已核：A1–A9 全 merge + controller-runtime 接口快照未漂移）
- ADR：`docs/architecture/202605291600-661-adr-kernel-reconcile-design.md`
- ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
- ref: kubernetes/client-go tools/leaderelection

### 实施矩阵（PR-A10 T46–T49）

| 任务 | 载体 | 处理 |
|------|------|------|
| T46 | `.claude/rules/gocell/reconcile.md` | 新建，52 行 pointer-heavy，过 `AGENT-RULES-GOVERNANCE-01` |
| T47 | ADR `...process-isolation.md` | 加 §Amendment：reconcile 27 函数经 D1 动态发现入 24-shard 矩阵 + 威胁矩阵再评 |
| T47 | ADR `...control-plane-decouple.md` | **不改**：reconcile clock carve-out 已由 #1169 §Amendment 2026-06-06 就地覆盖（避免双真值源） |
| T48 | `CLAUDE.md` | L4 行场景列 +「状态收敛」（仅此一处） |
| T49 | `docs/references/framework-comparison.md` | 对标框架表加 controller-runtime 行 + `kernel/reconcile` 映射块 |

> **不编辑 `...-661-...-tasks.md`**：该文件是 frozen 设计（flag-cond），T01–T49 全部未勾选（A1–A9 已 merge 也未勾），从未用 checkbox 跟踪——收口靠 `Closes #1171` + 关闭 #661，不破坏 frozen 一致性。

## Risk / 兼容性

无。纯文档新增/追加，零 `.go` 改动，无 wire / 契约 / migration 影响，无消费方需同步。`Closes #661` 前已核 A1–A9 全 merge + controller-runtime 接口快照（`Reconcile(ctx,Request)(Result,error)` 不变；GoCell 仍正确地 drop namespace/Requeue bool/Priority）未漂移。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test -tags archtest -run TestAgentRulesGovernance ./tools/archtest/` 0 diagnostic（reconcile.md 过治理门）
- [x] 引用 ADR 路径的 archtest（shard-count / clock）通过；二者仅 `// ref:` 引用、不解析我改的 prose
- [x] `golangci-lint run ./...` — N/A（零 `.go` 改动，git diff 确认）
