### PR TITLE
feat(webhook): honor Svix per-attempt retry delays via broker-native delayed re-delivery (#1458)

### DIFF
--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -364,6 +364,119 @@ func TestIntegration_ConsumerBaseRetry(t *testing.T) {
 	_ = sub.Close(context.Background())
 }
 
+// TestIntegration_WebhookDelaySchedule_RoutesToDLQAfterExhaustion verifies the
+// broker-native delayed re-delivery path end to end against a real broker
+// (#1458, F3): an always-Requeue handler is redelivered through the TTL+DLX delay
+// tiers per the schedule and, once the attempt count exceeds the schedule length,
+// is Nack(requeue=false)'d to the queue's real DLX — where this test consumes it
+// and verifies the entry survived intact. The shared conformance suite asserts
+// the per-attempt delivery count; this test closes the gap that a count-only
+// assertion would pass even if the exhausted message were silently dropped
+// (DLX binding/routing fault) instead of dead-lettered.
+func TestIntegration_WebhookDelaySchedule_RoutesToDLQAfterExhaustion(t *testing.T) {
+	conn, cleanup := startRabbitMQ(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := NewPublisher(clock.Real(), conn)
+
+	const (
+		topic       = "test.webhookdelay.e2e"
+		dlxExchange = "test.webhookdelay.e2e.dlx"
+		dlxQueue    = "test.webhookdelay.e2e.dlq"
+		mainQueue   = "test.webhookdelay.e2e.main"
+	)
+	// Two short tiers: deliver → delay.0 → delay.1 → exhaust → real DLX. Tiny
+	// TTLs keep the test fast while still exercising the real broker TTL→DLX hop
+	// (and the F1 publisher-confirm + F6 x-death provenance on the live path).
+	schedule := []time.Duration{testtime.D200ms, testtime.D200ms}
+	wantHandlerCalls := int32(len(schedule) + 1) // immediate attempt + one per tier
+
+	// --- Set up the real DLX where exhausted messages land ---
+	rawCh, err := conn.AcquireChannel()
+	require.NoError(t, err)
+	require.NoError(t, rawCh.ExchangeDeclare(dlxExchange, "direct", true, false, false, false, nil), "declare DLX exchange")
+	_, err = rawCh.QueueDeclare(dlxQueue, true, false, false, false, nil)
+	require.NoError(t, err, "declare DLQ queue")
+	require.NoError(t, rawCh.QueueBind(dlxQueue, "", dlxExchange, false, nil), "bind DLQ to DLX exchange")
+	conn.ReleaseChannel(rawCh)
+
+	// Broker-delay subscriptions run ConsumerBase in single-attempt pass-through,
+	// so the transport — not the in-process retry budget — owns the schedule.
+	cb, cbErr := outbox.NewConsumerBase(
+		&noopClaimer{},
+		outbox.ConsumerBaseConfig{RetryCount: 2, RetryBaseDelay: testtime.MediumPoll, IdempotencyTTL: time.Hour},
+		clock.Real(),
+	)
+	require.NoError(t, cbErr)
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{
+		QueueName:     mainQueue,
+		PrefetchCount: 1,
+		DLXExchange:   dlxExchange,
+	})
+
+	subscription := outbox.Subscription{
+		Topic:               topic,
+		ConsumerGroup:       "test-webhookdelay-e2e",
+		CellID:              "test-webhookdelay-e2e",
+		BrokerDelaySchedule: schedule,
+	}
+
+	var callCount atomic.Int32
+	subCtx, subCancel := context.WithTimeout(ctx, testtime.CtxLong)
+	defer subCancel()
+
+	wrappedHandler := cb.Wrap(subscription, func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		callCount.Add(1)
+		return outbox.Requeue(assert.AnError)
+	})
+
+	subErrCh := make(chan error, 1)
+	go func() {
+		subErrCh <- sub.Subscribe(subCtx, subscription, wrappedHandler)
+	}()
+
+	waitForSubscriberReady(t, conn, mainQueue, subErrCh, testtime.EventuallyLong)
+
+	entry := mustNewEntry(t, "test.webhookdelay.transient", []byte(`{"delay":"e2e"}`),
+		outbox.WithID("evt-webhookdelay-e2e-001"), outbox.WithCreatedAt(time.Now().UTC()))
+	payload, err := outbox.MarshalEnvelope(entry)
+	require.NoError(t, err)
+	require.NoError(t, pub.Publish(ctx, topic, payload), "publish should succeed")
+
+	// --- Consume the real DLX and verify the exhausted entry arrived intact ---
+	dlxCh, err := conn.AcquireChannel()
+	require.NoError(t, err)
+	defer conn.ReleaseChannel(dlxCh)
+	dlxMsgs, err := dlxCh.Consume(dlxQueue, "webhookdelay-dlx-consumer", true, false, false, false, nil)
+	require.NoError(t, err, "consume from DLQ")
+
+	var dlEntry outbox.Entry
+	testwait.External(t, "amqp-webhookdelay-dlq", func() bool {
+		select {
+		case msg := <-dlxMsgs:
+			decoded, decodeErr := outbox.UnmarshalEnvelope("", msg.Body)
+			if decodeErr != nil {
+				return false
+			}
+			dlEntry = decoded
+			return true
+		default:
+			return false
+		}
+	}, testtime.D15s, testtime.D200ms,
+		"exhausted webhook must reach the DLQ — handler called %d times", callCount.Load())
+
+	assert.Equal(t, "evt-webhookdelay-e2e-001", dlEntry.ID(), "dead-lettered entry ID should match")
+	assert.JSONEq(t, `{"delay":"e2e"}`, string(dlEntry.Payload()))
+	assert.GreaterOrEqual(t, callCount.Load(), wantHandlerCalls,
+		"handler must run once per scheduled attempt (immediate + one per tier) before exhaustion")
+
+	subCancel()
+	_ = sub.Close(context.Background())
+}
+
 // TestIntegration_ConnectionRecovery verifies that the Connection automatically
 // reconnects after the broker forcibly closes all client connections.
 //

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -2935,7 +2935,7 @@ func TestProcessDelivery_Ack_CommitsReceipt(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 1,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	ch.mu.Lock()
 	assert.True(t, ch.ackCalled)
@@ -2971,7 +2971,7 @@ func TestProcessDelivery_Reject_ReleasesReceipt(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 2,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled)
@@ -3009,7 +3009,7 @@ func TestProcessDelivery_NilReceipt_NoPanic(t *testing.T) {
 		sub.processDelivery(ctx, ch, amqp.Delivery{
 			DeliveryTag: 3,
 			Body:        entryBytes,
-		}, "test.topic", nil, handler)
+		}, "test.topic", "", nil, handler)
 	})
 }
 
@@ -3061,7 +3061,7 @@ func TestProcessDelivery_PassesThroughContextWithoutRestore(t *testing.T) {
 	sub.processDelivery(parentCtx, ch, amqp.Delivery{
 		DeliveryTag: 5,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	// Subscriber should NOT restore obs metadata (middleware's job).
 	assert.Empty(t, observed["request_id"], "subscriber should not restore request_id")
@@ -3114,7 +3114,7 @@ func TestProcessDelivery_DoesNotRestoreObservabilityContext(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 6,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	assert.Empty(t, capturedRequestID,
 		"processDelivery should NOT restore request_id — that is middleware's job")
@@ -3149,7 +3149,7 @@ func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 4,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	// Receipt should still be committed because processDelivery uses
 	// context.WithoutCancel for Receipt operations. The parent ctx is
@@ -3183,7 +3183,7 @@ func TestProcessDelivery_Requeue_ReleasesReceipt(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 10,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled)
@@ -3265,7 +3265,7 @@ func TestProcessDelivery_BrokerAckFails_CommitAlreadyDone(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 5,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	receipt.mu.Lock()
 	// With Commit→Ack ordering, Commit is called before Ack.
@@ -3298,7 +3298,7 @@ func TestProcessDelivery_CommitFails_NackRequeueSuccess_ReleasesReceipt(t *testi
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 41,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	ch.mu.Lock()
 	assert.False(t, ch.ackCalled, "Commit failure must not Ack")
@@ -3336,7 +3336,7 @@ func TestProcessDelivery_CommitFails_NackRequeueFails_ReleasesReceipt(t *testing
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 42,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	ch.mu.Lock()
 	assert.False(t, ch.ackCalled, "Commit failure must not Ack even if Nack fails")
@@ -3505,7 +3505,7 @@ func TestProcessDelivery_HandlerError_Logged(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 20,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	// Ack should still be called (error does not affect disposition).
 	ch.mu.Lock()
@@ -3539,7 +3539,7 @@ func TestProcessDelivery_Requeue_BrokerNackFails_ReleasesReceipt(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 30,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	// Nack was attempted (requeue=true) but failed.
 	ch.mu.Lock()
@@ -3668,7 +3668,7 @@ func TestProcessDelivery_UnknownDisposition_NackWithRequeue(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 42,
 		Body:        entryBytes,
-	}, "test.topic", nil, handler)
+	}, "test.topic", "", nil, handler)
 
 	// Unknown disposition should Nack with requeue=true.
 	ch.mu.Lock()

--- a/adapters/rabbitmq/rabbitmq_test.go
+++ b/adapters/rabbitmq/rabbitmq_test.go
@@ -108,6 +108,13 @@ func (r *callOrderRecorder) snapshot() []string {
 	return out
 }
 
+// queueBindDetail records all fields of a QueueBind call for precise assertion.
+type queueBindDetail struct {
+	queue    string
+	key      string
+	exchange string
+}
+
 // --- Mock AMQP Channel ---
 
 type mockChannel struct {
@@ -121,6 +128,7 @@ type mockChannel struct {
 	publishCalled     bool
 	publishedMessages []amqp.Publishing
 	publishExchange   string
+	publishRoutingKey string
 	publishErr        error
 
 	consumeDeliveries chan amqp.Delivery
@@ -151,6 +159,7 @@ type mockChannel struct {
 	queueDeclareArgs   []amqp.Table
 	queueDeclareErr    error
 	queueBindings      []string
+	queueBindDetails   []queueBindDetail
 	queueBindErr       error
 
 	notifyPublishCh chan amqp.Confirmation
@@ -189,6 +198,7 @@ func (m *mockChannel) Publish(exchange, key string, mandatory, immediate bool, m
 	defer m.mu.Unlock()
 	m.publishCalled = true
 	m.publishExchange = exchange
+	m.publishRoutingKey = key
 	m.publishedMessages = append(m.publishedMessages, msg)
 	return m.publishErr
 }
@@ -300,6 +310,7 @@ func (m *mockChannel) QueueBind(name, key, exchange string, noWait bool, args am
 		return m.queueBindErr
 	}
 	m.queueBindings = append(m.queueBindings, name+"->"+exchange)
+	m.queueBindDetails = append(m.queueBindDetails, queueBindDetail{queue: name, key: key, exchange: exchange})
 	return nil
 }
 
@@ -2046,7 +2057,7 @@ func TestSubscriber_SubscribeOnce_AcquireChannelFails(t *testing.T) {
 	})
 
 	// subscribeOnce should return an error (channel acquisition failure).
-	err = sub.subscribeOnce(context.Background(), "test.topic", "test-queue",
+	err = sub.subscribeOnce(context.Background(), "test.topic", "test-queue", nil,
 		entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 			return outbox.Ack()
 		}))
@@ -2924,7 +2935,7 @@ func TestProcessDelivery_Ack_CommitsReceipt(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 1,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	ch.mu.Lock()
 	assert.True(t, ch.ackCalled)
@@ -2960,7 +2971,7 @@ func TestProcessDelivery_Reject_ReleasesReceipt(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 2,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled)
@@ -2998,7 +3009,7 @@ func TestProcessDelivery_NilReceipt_NoPanic(t *testing.T) {
 		sub.processDelivery(ctx, ch, amqp.Delivery{
 			DeliveryTag: 3,
 			Body:        entryBytes,
-		}, "test.topic", handler)
+		}, "test.topic", nil, handler)
 	})
 }
 
@@ -3050,7 +3061,7 @@ func TestProcessDelivery_PassesThroughContextWithoutRestore(t *testing.T) {
 	sub.processDelivery(parentCtx, ch, amqp.Delivery{
 		DeliveryTag: 5,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	// Subscriber should NOT restore obs metadata (middleware's job).
 	assert.Empty(t, observed["request_id"], "subscriber should not restore request_id")
@@ -3103,7 +3114,7 @@ func TestProcessDelivery_DoesNotRestoreObservabilityContext(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 6,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	assert.Empty(t, capturedRequestID,
 		"processDelivery should NOT restore request_id — that is middleware's job")
@@ -3138,7 +3149,7 @@ func TestProcessDelivery_Receipt_UsesDetachedCtx(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 4,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	// Receipt should still be committed because processDelivery uses
 	// context.WithoutCancel for Receipt operations. The parent ctx is
@@ -3172,7 +3183,7 @@ func TestProcessDelivery_Requeue_ReleasesReceipt(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 10,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	ch.mu.Lock()
 	assert.True(t, ch.nackCalled)
@@ -3254,7 +3265,7 @@ func TestProcessDelivery_BrokerAckFails_CommitAlreadyDone(t *testing.T) {
 	sub.processDelivery(ctx, ch, amqp.Delivery{
 		DeliveryTag: 5,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	receipt.mu.Lock()
 	// With Commit→Ack ordering, Commit is called before Ack.
@@ -3287,7 +3298,7 @@ func TestProcessDelivery_CommitFails_NackRequeueSuccess_ReleasesReceipt(t *testi
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 41,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	ch.mu.Lock()
 	assert.False(t, ch.ackCalled, "Commit failure must not Ack")
@@ -3325,7 +3336,7 @@ func TestProcessDelivery_CommitFails_NackRequeueFails_ReleasesReceipt(t *testing
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 42,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	ch.mu.Lock()
 	assert.False(t, ch.ackCalled, "Commit failure must not Ack even if Nack fails")
@@ -3494,7 +3505,7 @@ func TestProcessDelivery_HandlerError_Logged(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 20,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	// Ack should still be called (error does not affect disposition).
 	ch.mu.Lock()
@@ -3528,7 +3539,7 @@ func TestProcessDelivery_Requeue_BrokerNackFails_ReleasesReceipt(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 30,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	// Nack was attempted (requeue=true) but failed.
 	ch.mu.Lock()
@@ -3657,7 +3668,7 @@ func TestProcessDelivery_UnknownDisposition_NackWithRequeue(t *testing.T) {
 	sub.processDelivery(context.Background(), ch, amqp.Delivery{
 		DeliveryTag: 42,
 		Body:        entryBytes,
-	}, "test.topic", handler)
+	}, "test.topic", nil, handler)
 
 	// Unknown disposition should Nack with requeue=true.
 	ch.mu.Lock()

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -65,6 +66,50 @@ func readWebhookAttempt(h amqp.Table) int {
 	default:
 		return 1
 	}
+}
+
+// isBrokerDeathHeader reports whether k is a RabbitMQ broker-injected dead-letter
+// bookkeeping header (x-death and its x-first-death-* / x-original-* siblings).
+// These accumulate on every dead-letter hop and must not be copied forward when
+// republishing to a delay tier.
+func isBrokerDeathHeader(k string) bool {
+	return k == "x-death" ||
+		strings.HasPrefix(k, "x-first-death-") ||
+		strings.HasPrefix(k, "x-original-")
+}
+
+// deliveryFromDelayTier reports whether the broker attests, via an x-death
+// "expired" record, that this delivery re-entered the dispatch exchange by
+// expiring (TTL) out of one of queueName's own delay tier queues
+// ("<queueName>.delay.<i>"). Only such deliveries carry a trustworthy
+// x-webhook-attempt counter; a message published straight to the dispatch
+// exchange has no expired-from-delay-tier x-death entry (see dispatchDelayedRequeue
+// for why the attempt header is gated on this).
+//
+// x-death is an AMQP array of tables (one per dead-letter event); the relevant
+// entry has reason="expired" and queue="<queueName>.delay.<i>".
+func deliveryFromDelayTier(headers amqp.Table, queueName string) bool {
+	raw, ok := headers["x-death"]
+	if !ok {
+		return false
+	}
+	deaths, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	delayPrefix := queueName + ".delay."
+	for _, d := range deaths {
+		t, ok := d.(amqp.Table)
+		if !ok {
+			continue
+		}
+		reason, _ := t["reason"].(string)
+		q, _ := t["queue"].(string)
+		if reason == "expired" && strings.HasPrefix(q, delayPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -380,11 +425,15 @@ func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName strin
 		if _, err := ch.QueueDeclare(tierQueue, true, false, false, false, tierArgs); err != nil {
 			// AMQP 406 PRECONDITION_FAILED is returned when the queue already
 			// exists with different arguments (e.g. a changed x-message-ttl from
-			// a new BrokerDelaySchedule). To apply the new schedule, delete the
-			// existing tier queues ("<queue>.delay.<i>") and restart the consumer.
+			// a new BrokerDelaySchedule). Changing the schedule requires the
+			// drain-before-delete runbook — a non-empty tier queue holds webhooks
+			// still waiting out their retry interval, so deleting it blindly drops
+			// pending retries.
 			return fmt.Errorf("rabbitmq: declare delay tier queue %d (%s): %w"+
-				" (hint: AMQP 406 PRECONDITION_FAILED means the queue exists with"+
-				" a different x-message-ttl; delete %s and retry)", i, tierQueue, err, tierQueue)
+				" (hint: AMQP 406 PRECONDITION_FAILED means the queue exists with a"+
+				" different x-message-ttl; to change the schedule follow the"+
+				" drain-before-delete runbook in"+
+				" docs/ops/rabbitmq-webhook-delay-topology.md)", i, tierQueue, err)
 		}
 		if err := ch.QueueBind(tierQueue, strconv.Itoa(i), delayExchange, false, nil); err != nil {
 			return fmt.Errorf("rabbitmq: bind delay tier queue %d: %w", i, err)
@@ -1064,7 +1113,19 @@ func (s *Subscriber) dispatchDelayedRequeue(
 ) {
 	tag := delivery.DeliveryTag
 	eventID := dp.entry.ID()
-	attempt := readWebhookAttempt(delivery.Headers)
+	// F6: only trust the x-webhook-attempt header on deliveries the broker
+	// attests came from this queue's own delay tier (x-death "expired"
+	// provenance). A message published straight to the dispatch exchange — a
+	// fresh first attempt, or a forged direct publish — carries no such record,
+	// so its attempt header is ignored and the delivery is treated as attempt 1.
+	// This fail-closed gate keeps the retry budget out of reach of producers
+	// that can publish to the dispatch exchange but cannot forge a broker
+	// x-death entry: a forged high attempt no longer forces a premature DLX, and
+	// a forged low attempt cannot extend retries beyond the schedule length.
+	attempt := 1
+	if deliveryFromDelayTier(delivery.Headers, queueName) {
+		attempt = readWebhookAttempt(delivery.Headers)
+	}
 
 	if attempt > len(schedule) {
 		// Retry budget exhausted: route to the real DLX (Nack without requeue).
@@ -1106,9 +1167,13 @@ func (s *Subscriber) exhaustDelayBudget(
 }
 
 // republishToDelayTier publishes the delivery body to the delay tier queue for
-// the given attempt, Acks the original delivery, and releases (not commits) the
-// settlement so the redelivered message can re-enter the Claim/Commit cycle.
-// On publish failure it falls back to Nack(requeue=true) to avoid message loss.
+// the given attempt with broker publisher confirmation, then Acks the original
+// delivery and releases (not commits) the settlement so the redelivered message
+// can re-enter the Claim/Commit cycle. The original is Acked only after the
+// broker confirms the delay-tier publish (F1) — otherwise the consume→publish→
+// ack ownership transfer would lose the webhook on a broker/channel drop between
+// publish and ack. On a publish/confirm failure it fails closed to the real DLX
+// (see failClosedDelayPublish) instead of hot-looping an immediate requeue.
 //
 // queueName is the canonical queue name threaded from subscribeOnce; it is used
 // to build <queueName>.delay so the exchange always matches the one declared by
@@ -1126,16 +1191,13 @@ func (s *Subscriber) republishToDelayTier(
 	delayExchange := queueName + ".delay"
 	routingKey := strconv.Itoa(attempt - 1)
 
-	// Copy headers, skipping RabbitMQ broker system headers that accumulate
-	// across dead-letter cycles and must not be propagated to the delay tier.
-	// x-death and x-first-death-* / x-original-* are injected by the broker
-	// and grow unboundedly on each dead-letter hop; carrying them forward
-	// pollutes headers on redelivery and can confuse broker routing.
-	// x-webhook-attempt and all business headers are preserved.
+	// Copy headers, skipping RabbitMQ broker system headers (x-death,
+	// x-first-death-*, x-original-*) that the broker injects and grows on each
+	// dead-letter hop; carrying them forward pollutes redelivery and can confuse
+	// routing. x-webhook-attempt and all business headers are preserved.
 	headers := make(amqp.Table, len(delivery.Headers)+1)
 	for k, v := range delivery.Headers {
-		if k == "x-death" || len(k) >= len("x-first-death-") && k[:len("x-first-death-")] == "x-first-death-" ||
-			len(k) >= len("x-original-") && k[:len("x-original-")] == "x-original-" {
+		if isBrokerDeathHeader(k) {
 			continue
 		}
 		headers[k] = v
@@ -1155,35 +1217,16 @@ func (s *Subscriber) republishToDelayTier(
 		ContentType:  delivery.ContentType,
 	}
 
-	publishErr := ch.PublishWithContext(ctx, delayExchange, routingKey, false, false, pub)
-	if publishErr != nil {
-		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: republish to delay tier failed, falling back to nack(requeue)",
-			slog.String(logKeyTopic, dp.topic),
-			slog.String(logKeyEventID, eventID),
-			slog.Int("attempt", attempt),
-			slog.Any("error", publishErr))
-		if nackErr := ch.Nack(tag, false, true); nackErr != nil {
-			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) fallback failed",
-				slog.String(logKeyTopic, dp.topic),
-				slog.String(logKeyEventID, eventID),
-				slog.Any("error", nackErr))
-			// Both publish and nack fallback failed: settlement result is NackFailed.
-			releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_publish_failed")
-			outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, publishErr)
-			return
-		}
-		// Nack fallback succeeded: delivery was requeued immediately and bypassed
-		// the delay schedule. Log at Warn so ops can detect unexpected scheduling gaps.
-		slog.LogAttrs(ctx, slog.LevelWarn, "rabbitmq: delay publish failed; delivery requeued immediately, bypassing delay schedule",
-			slog.String(logKeyTopic, dp.topic),
-			slog.String(logKeyEventID, eventID),
-			slog.Int("attempt", attempt))
-		releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_publish_failed")
-		outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
+	// F1: publish to the delay tier with broker confirmation BEFORE acking the
+	// original. The delay round-trip is a consume→publish→ack ownership transfer;
+	// acking before the broker durably holds the republished copy risks losing
+	// the webhook on a broker/channel drop between publish and ack.
+	if publishErr := s.confirmPublishToDelay(ctx, delayExchange, routingKey, pub); publishErr != nil {
+		s.failClosedDelayPublish(ctx, ch, tag, attempt, publishErr, dp)
 		return
 	}
 
-	// Ack the original delivery — the delay queue now owns this message.
+	// Ack the original delivery — the delay queue now durably owns this message.
 	if ackErr := ch.Ack(tag, false); ackErr != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: ack(delay) failed",
 			slog.String(logKeyTopic, dp.topic),
@@ -1198,6 +1241,85 @@ func (s *Subscriber) republishToDelayTier(
 	// must re-enter the Claim path when it exits the delay tier.
 	releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_requeue")
 	outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
+}
+
+// confirmPublishToDelay publishes pub to the delay exchange on a dedicated
+// ephemeral channel in confirm mode and blocks until the broker durably
+// confirms receipt (or the confirm times out / the channel drops). Returning
+// nil means the broker accepted the message into the delay tier; only then may
+// the caller Ack the original delivery.
+//
+// A dedicated ephemeral channel is acquired per publish (closed on return)
+// rather than reusing the long-lived consumer channel: putting the consumer
+// channel into confirm mode would let a full NotifyPublish listener block the
+// connection reader and deadlock every channel on the connection. This mirrors
+// the Publisher's ephemeral-channel-per-publish strategy (see publisher.go);
+// webhook retries are low-frequency, so the per-retry channel cost is negligible.
+func (s *Subscriber) confirmPublishToDelay(ctx context.Context, exchange, routingKey string, pub amqp.Publishing) error {
+	ch, err := s.conn.AcquireChannel()
+	if err != nil {
+		return fmt.Errorf("rabbitmq: acquire delay publish channel: %w", err)
+	}
+	defer s.conn.CloseEphemeralChannel(ch)
+
+	if err := ch.Confirm(false); err != nil {
+		return fmt.Errorf("rabbitmq: enable confirm mode for delay publish: %w", err)
+	}
+	confirmCh := ch.NotifyPublish(make(chan amqp.Confirmation, 1))
+	if err := ch.PublishWithContext(ctx, exchange, routingKey, false, false, pub); err != nil {
+		return fmt.Errorf("rabbitmq: publish to delay tier: %w", err)
+	}
+
+	confirmTimer := s.clock.NewTimerAt(s.clock.Now().Add(s.conn.config.ConfirmTimeout))
+	defer confirmTimer.Stop()
+	select {
+	case confirm, ok := <-confirmCh:
+		if !ok {
+			return fmt.Errorf("rabbitmq: delay publish confirm channel closed before broker confirmation")
+		}
+		if !confirm.Ack {
+			return fmt.Errorf("rabbitmq: broker nacked delay publish")
+		}
+		return nil
+	case <-confirmTimer.C():
+		return fmt.Errorf("rabbitmq: delay publish confirm timed out after %s", s.conn.config.ConfirmTimeout)
+	case <-ctx.Done():
+		return fmt.Errorf("rabbitmq: delay publish canceled: %w", ctx.Err())
+	}
+}
+
+// failClosedDelayPublish handles a delay-tier publish/confirm failure by routing
+// the original delivery to the queue's real DLX via Nack(requeue=false). It does
+// NOT immediately requeue (Nack(requeue=true)): an immediate requeue redelivers
+// the SAME message with the SAME, un-advanced x-webhook-attempt, so a persistent
+// delay-infra fault would hot-loop forever without ever exhausting the retry
+// budget. Routing to the DLX is fail-closed — the webhook lands in the
+// dead-letter queue where ops can inspect/replay it, and the retry cycle ends.
+func (s *Subscriber) failClosedDelayPublish(
+	ctx context.Context,
+	ch AMQPChannel,
+	tag uint64,
+	attempt int,
+	publishErr error,
+	dp delayDispatchCtx,
+) {
+	eventID := dp.entry.ID()
+	slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: delay publish failed, routing to DLX (fail-closed)",
+		slog.String(logKeyTopic, dp.topic),
+		slog.String(logKeyEventID, eventID),
+		slog.Int("attempt", attempt),
+		slog.Any("error", publishErr))
+	if nackErr := ch.Nack(tag, false, false); nackErr != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(fail-closed) failed",
+			slog.String(logKeyTopic, dp.topic),
+			slog.String(logKeyEventID, eventID),
+			slog.Any("error", nackErr))
+		releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_publish_failed")
+		outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionReject, outbox.SettlementResultNackFailed, nackErr)
+		return
+	}
+	releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_publish_failed")
+	outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionReject, outbox.SettlementResultSuccess, nil)
 }
 
 // dispatchAck handles the Commit→Ack path for DispositionAck.

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -421,6 +421,14 @@ func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName strin
 		tierArgs := amqp.Table{
 			"x-message-ttl":          d.Milliseconds(), // int64 of milliseconds; TTL fires expiry to re-enter dispatch fanout
 			"x-dead-letter-exchange": topic,
+			// Reset the routing key on TTL-expiry dead-letter back to the canonical
+			// empty key. The republish put the message on this tier with routing
+			// key = tier index ("0"/"1"/…); without this reset that index would
+			// ride along when the message later exhausts and the main queue
+			// dead-letters it to the real DLX, so a direct DLX bound on "" would
+			// silently never receive the exhausted webhook. The dispatch exchange
+			// is fanout, so re-entry routing is unaffected by the key.
+			"x-dead-letter-routing-key": "",
 		}
 		if _, err := ch.QueueDeclare(tierQueue, true, false, false, false, tierArgs); err != nil {
 			// AMQP 406 PRECONDITION_FAILED is returned when the queue already

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"log/slog"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,43 @@ var errSubscriptionLost = errors.New("rabbitmq: subscription lost")
 // Aligned with AMQP 0-9-1 shortstr limit (255 octets) to ensure the ID
 // can be safely embedded in AMQP message headers without truncation.
 const maxEntryIDLength = 255
+
+// headerWebhookAttempt is the AMQP message header key used to track the
+// current delivery attempt number for webhook retry delay tiers.
+// Value is int32. Absent / zero / negative / malformed → treated as attempt 1.
+const headerWebhookAttempt = "x-webhook-attempt"
+
+// readWebhookAttempt reads the attempt counter from an AMQP message header
+// table. Returns 1 when the key is absent, zero, negative, or of an
+// unrecognized type — i.e., the first delivery is always attempt 1.
+func readWebhookAttempt(h amqp.Table) int {
+	if h == nil {
+		return 1
+	}
+	v, ok := h[headerWebhookAttempt]
+	if !ok {
+		return 1
+	}
+	switch n := v.(type) {
+	case int32:
+		if n <= 0 {
+			return 1
+		}
+		return int(n)
+	case int64:
+		if n <= 0 {
+			return 1
+		}
+		return int(n)
+	case int:
+		if n <= 0 {
+			return 1
+		}
+		return n
+	default:
+		return 1
+	}
+}
 
 const (
 	// defaultRMQReconnectWaitTimeout is the graceful-shutdown wait budget when
@@ -261,10 +299,16 @@ func (s *Subscriber) resolveQueueName(topic, consumerGroup string) string {
 // declareTopology declares the exchange, DLX, queue, and binding on the given
 // channel. All operations are idempotent — safe to call multiple times.
 //
+// When schedule is non-empty the function additionally declares a "direct"
+// delay exchange (<queueName>.delay) and one TTL+DLX queue per tier. On TTL
+// expiry the broker re-routes the message back to the dispatch exchange (topic)
+// so it re-enters the main consumer queue. No additional topology is declared
+// when schedule is empty — non-delayed subscriptions are regression-protected.
+//
 // Precondition: s.config.DLXExchange must be non-empty. Both call sites
 // (Subscribe, Setup) validate this, but the guard here prevents accidental
 // misuse from future code paths.
-func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string) error {
+func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string, schedule []time.Duration) error {
 	if s.config.DLXExchange == "" {
 		return fmt.Errorf("rabbitmq: declareTopology: DLXExchange must not be empty")
 	}
@@ -298,6 +342,48 @@ func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string) er
 		return fmt.Errorf("rabbitmq: bind queue: %w", err)
 	}
 
+	// Declare delay topology when the subscription carries a retry schedule.
+	// Non-delayed subscriptions declare nothing extra (regression-protected).
+	if len(schedule) > 0 {
+		if err := s.declareDelayTopology(ch, topic, queueName, schedule); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// declareDelayTopology declares the delay exchange and per-tier queues for
+// broker-side webhook retry delays (TTL+DLX pure AMQP pattern). Called only
+// when BrokerDelaySchedule is non-empty. All operations are idempotent.
+//
+// Topology per tier i:
+//   - Queue: <queueName>.delay.<i>
+//   - x-message-ttl: schedule[i] in milliseconds (int64)
+//   - x-dead-letter-exchange: topic (the dispatch fanout exchange)
+//   - Bound to delay exchange with routing key strconv.Itoa(i)
+//
+// On TTL expiry the broker dead-letters the message back to topic (the fanout),
+// which re-enqueues it into the main consumer queue for the next handler attempt.
+func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName string, schedule []time.Duration) error {
+	delayExchange := queueName + ".delay"
+	if err := ch.ExchangeDeclare(delayExchange, "direct", true, false, false, false, nil); err != nil {
+		return fmt.Errorf("rabbitmq: declare delay exchange: %w", err)
+	}
+
+	for i, d := range schedule {
+		tierQueue := fmt.Sprintf("%s.delay.%d", queueName, i)
+		tierArgs := amqp.Table{
+			"x-message-ttl":          d.Milliseconds(), // int64 of milliseconds; TTL fires expiry to re-enter dispatch fanout
+			"x-dead-letter-exchange": topic,
+		}
+		if _, err := ch.QueueDeclare(tierQueue, true, false, false, false, tierArgs); err != nil {
+			return fmt.Errorf("rabbitmq: declare delay tier queue %d: %w", i, err)
+		}
+		if err := ch.QueueBind(tierQueue, strconv.Itoa(i), delayExchange, false, nil); err != nil {
+			return fmt.Errorf("rabbitmq: bind delay tier queue %d: %w", i, err)
+		}
+	}
 	return nil
 }
 
@@ -320,7 +406,7 @@ func (s *Subscriber) Setup(ctx context.Context, sub outbox.Subscription) error {
 	defer s.conn.ReleaseChannel(ch)
 
 	queueName := s.resolveQueueName(sub.Topic, sub.ConsumerGroup)
-	return s.declareTopology(ch, sub.Topic, queueName)
+	return s.declareTopology(ch, sub.Topic, queueName, sub.BrokerDelaySchedule)
 }
 
 // Ready implements outbox.Subscriber. RabbitMQ topology is declared synchronously
@@ -372,9 +458,10 @@ func (s *Subscriber) Subscribe(ctx context.Context, sub outbox.Subscription, han
 	}()
 
 	queueName := s.resolveQueueName(topic, consumerGroup)
+	schedule := sub.BrokerDelaySchedule
 
 	for {
-		err := s.subscribeOnce(subCtx, topic, queueName, handler)
+		err := s.subscribeOnce(subCtx, topic, queueName, schedule, handler)
 		if err == nil {
 			return nil // Clean exit: ctx canceled or subscriber closed.
 		}
@@ -450,6 +537,7 @@ func (s *Subscriber) awaitReconnect(ctx context.Context, topic, queueName string
 func (s *Subscriber) subscribeOnce(
 	ctx context.Context,
 	topic, queueName string,
+	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) error {
 	ch, err := s.conn.AcquireChannel()
@@ -478,7 +566,7 @@ func (s *Subscriber) subscribeOnce(
 	}
 
 	// Declare topology (exchange, DLX, queue, binding) — idempotent.
-	if err := s.declareTopology(ch, topic, queueName); err != nil {
+	if err := s.declareTopology(ch, topic, queueName, schedule); err != nil {
 		return setupErr("rabbitmq: declare topology", err, func() error {
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterAMQPSubscribe, "rabbitmq: declare topology failed", err)
 		})
@@ -517,7 +605,7 @@ func (s *Subscriber) subscribeOnce(
 		slog.String("consumer", consumerTag),
 		slog.Int("prefetch", s.config.PrefetchCount))
 
-	loopErr := s.consumeLoop(ctx, run, deliveries, topic, handler)
+	loopErr := s.consumeLoop(ctx, run, deliveries, topic, schedule, handler)
 
 	// A19 fix: wait for all in-flight processDelivery goroutines of THIS run
 	// before closing the AMQP channel. This prevents Ack/Nack calls on a
@@ -617,6 +705,7 @@ func (s *Subscriber) consumeLoop(
 	run *subscriptionRun,
 	deliveries <-chan amqp.Delivery,
 	topic string,
+	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) error {
 	ch := run.ch
@@ -636,7 +725,7 @@ func (s *Subscriber) consumeLoop(
 			slog.Info("rabbitmq: intake stopped, entering drain mode",
 				slog.String(logKeyTopic, topic))
 			drainCtx := context.WithoutCancel(ctx)
-			return s.drainRemaining(drainCtx, run, deliveries, topic, handler)
+			return s.drainRemaining(drainCtx, run, deliveries, topic, schedule, handler)
 		default:
 		}
 
@@ -645,7 +734,7 @@ func (s *Subscriber) consumeLoop(
 			slog.Info("rabbitmq: intake stopped, entering drain mode",
 				slog.String(logKeyTopic, topic))
 			drainCtx := context.WithoutCancel(ctx)
-			return s.drainRemaining(drainCtx, run, deliveries, topic, handler)
+			return s.drainRemaining(drainCtx, run, deliveries, topic, schedule, handler)
 
 		case <-ctx.Done():
 			slog.Info("rabbitmq: subscriber context canceled",
@@ -669,7 +758,7 @@ func (s *Subscriber) consumeLoop(
 			go func(d amqp.Delivery) {
 				defer s.wg.Done()
 				defer run.markDeliveryDone()
-				s.processDelivery(ctx, ch, d, topic, handler)
+				s.processDelivery(ctx, ch, d, topic, schedule, handler)
 			}(delivery)
 		}
 	}
@@ -721,6 +810,7 @@ func (s *Subscriber) drainRemaining(
 	run *subscriptionRun,
 	deliveries <-chan amqp.Delivery,
 	topic string,
+	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) error {
 	ch := run.ch
@@ -740,7 +830,7 @@ func (s *Subscriber) drainRemaining(
 			go func(d amqp.Delivery) {
 				defer s.wg.Done()
 				defer run.markDeliveryDone()
-				s.processDelivery(ctx, ch, d, topic, handler)
+				s.processDelivery(ctx, ch, d, topic, schedule, handler)
 			}(d)
 		case <-timer.C():
 			slog.Warn("rabbitmq: drain deadline reached, broker did not acknowledge basic.cancel",
@@ -784,6 +874,7 @@ func (s *Subscriber) processDelivery(
 	ch AMQPChannel,
 	delivery amqp.Delivery,
 	topic string,
+	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) {
 	entry, err := unmarshalDelivery(delivery.Body)
@@ -849,7 +940,7 @@ func (s *Subscriber) processDelivery(
 			slog.Any("error", res.Err))
 	}
 
-	s.dispatchDisposition(deliveryCtx, ch, delivery.DeliveryTag, res, settlement, topic, entry)
+	s.dispatchDisposition(deliveryCtx, ch, delivery, schedule, res, settlement, topic, entry)
 }
 
 // dispatchDisposition executes the broker-level disposition and settles the
@@ -864,15 +955,22 @@ func (s *Subscriber) processDelivery(
 //
 // DispositionReject/Requeue: broker Nack first, then Release the receipt so
 // DLQ replay or redelivery can re-enter the Claim/Commit cycle cleanly.
+//
+// DispositionRequeue with non-empty schedule: uses TTL+DLX delay tiers instead
+// of immediate Nack(requeue=true). The delivery is republished to the per-tier
+// delay queue; the original message is Acked. Settlement is Released (not
+// Committed) so the redelivered message can re-enter the Claim/Commit cycle.
 func (s *Subscriber) dispatchDisposition(
 	ctx context.Context,
 	ch AMQPChannel,
-	tag uint64,
+	delivery amqp.Delivery,
+	schedule []time.Duration,
 	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
 	topic string,
 	entry outbox.Entry,
 ) {
+	tag := delivery.DeliveryTag
 	eventID := entry.ID()
 	switch res.Disposition {
 	case outbox.DispositionAck:
@@ -891,6 +989,11 @@ func (s *Subscriber) dispatchDisposition(
 		releaseSettlement(ctx, settlement, topic, eventID, "reject")
 		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, rejectResult, nil)
 	case outbox.DispositionRequeue:
+		if len(schedule) > 0 {
+			s.dispatchDelayedRequeue(ctx, ch, delivery, schedule, res, settlement, topic, entry)
+			return
+		}
+		// Non-delayed requeue: immediate Nack+requeue (unchanged).
 		if nackErr := ch.Nack(tag, false, true); nackErr != nil {
 			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) failed",
 				slog.String(logKeyTopic, topic),
@@ -919,6 +1022,154 @@ func (s *Subscriber) dispatchDisposition(
 		releaseSettlement(ctx, settlement, topic, eventID, "unknown")
 		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 	}
+}
+
+// dispatchDelayedRequeue handles DispositionRequeue when BrokerDelaySchedule is
+// non-empty. It routes the message through a TTL+DLX delay tier queue instead
+// of immediate requeue. Cognitive complexity kept low by delegating the two
+// outcome branches to named helpers.
+func (s *Subscriber) dispatchDelayedRequeue(
+	ctx context.Context,
+	ch AMQPChannel,
+	delivery amqp.Delivery,
+	schedule []time.Duration,
+	res outbox.DeliveryOutcome,
+	settlement outbox.Settlement,
+	topic string,
+	entry outbox.Entry,
+) {
+	tag := delivery.DeliveryTag
+	eventID := entry.ID()
+	queueName := resolveQueueNameFromTopic(delivery, topic)
+	attempt := readWebhookAttempt(delivery.Headers)
+
+	if attempt > len(schedule) {
+		// Retry budget exhausted: route to the real DLX (Nack without requeue).
+		s.exhaustDelayBudget(ctx, ch, tag, res, settlement, topic, eventID, entry)
+		return
+	}
+
+	// Republish to the delay tier for this attempt.
+	s.republishToDelayTier(ctx, ch, delivery, queueName, attempt, res, settlement, topic, eventID, entry)
+}
+
+// resolveQueueNameFromTopic derives the queue name from the delivery's
+// ConsumerTag. The consumer tag is formatted as "cg-<queueName>-<topic>".
+// When the format does not match we fall back to the topic. This is used
+// exclusively to construct the delay exchange name on the consume path.
+func resolveQueueNameFromTopic(delivery amqp.Delivery, topic string) string {
+	// Consumer tag format: "cg-<queueName>-<topic>" (see subscribeOnce).
+	// Strip "cg-" prefix and "-<topic>" suffix to recover queueName.
+	prefix := "cg-"
+	suffix := "-" + topic
+	tag := delivery.ConsumerTag
+	if len(tag) > len(prefix)+len(suffix) &&
+		tag[:len(prefix)] == prefix &&
+		tag[len(tag)-len(suffix):] == suffix {
+		return tag[len(prefix) : len(tag)-len(suffix)]
+	}
+	return topic
+}
+
+// exhaustDelayBudget handles the retry-budget-exhausted path: Nack(requeue=false)
+// routes to the queue's real DLX, then releases the settlement.
+func (s *Subscriber) exhaustDelayBudget(
+	ctx context.Context,
+	ch AMQPChannel,
+	tag uint64,
+	res outbox.DeliveryOutcome,
+	settlement outbox.Settlement,
+	topic, eventID string,
+	entry outbox.Entry,
+) {
+	slog.LogAttrs(ctx, slog.LevelWarn, "rabbitmq: webhook retry budget exhausted, routing to DLX",
+		slog.String(logKeyTopic, topic),
+		slog.String(logKeyEventID, eventID))
+	if nackErr := ch.Nack(tag, false, false); nackErr != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(exhaust) failed",
+			slog.String(logKeyTopic, topic),
+			slog.String(logKeyEventID, eventID),
+			slog.Any("error", nackErr))
+		releaseSettlement(ctx, settlement, topic, eventID, "exhaust")
+		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultNackFailed, nackErr)
+		return
+	}
+	releaseSettlement(ctx, settlement, topic, eventID, "exhaust")
+	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultRetryExhausted, nil)
+}
+
+// republishToDelayTier publishes the delivery body to the delay tier queue for
+// the given attempt, Acks the original delivery, and releases (not commits) the
+// settlement so the redelivered message can re-enter the Claim/Commit cycle.
+// On publish failure it falls back to Nack(requeue=true) to avoid message loss.
+func (s *Subscriber) republishToDelayTier(
+	ctx context.Context,
+	ch AMQPChannel,
+	delivery amqp.Delivery,
+	queueName string,
+	attempt int,
+	res outbox.DeliveryOutcome,
+	settlement outbox.Settlement,
+	topic, eventID string,
+	entry outbox.Entry,
+) {
+	tag := delivery.DeliveryTag
+	delayExchange := queueName + ".delay"
+	routingKey := strconv.Itoa(attempt - 1)
+
+	// Copy headers and set next attempt number.
+	// attempt is bounded by len(schedule) which is a small slice in practice,
+	// so the int32 conversion is safe. Use explicit bounds to satisfy gosec G115.
+	headers := make(amqp.Table, len(delivery.Headers)+1)
+	for k, v := range delivery.Headers {
+		headers[k] = v
+	}
+	nextAttempt := attempt + 1
+	if nextAttempt > 1<<30 { // defensive cap well within int32 range
+		nextAttempt = 1 << 30
+	}
+	headers[headerWebhookAttempt] = int32(nextAttempt)
+
+	pub := amqp.Publishing{
+		Headers:      headers,
+		Body:         delivery.Body,
+		DeliveryMode: amqp.Persistent,
+		ContentType:  delivery.ContentType,
+	}
+
+	publishErr := ch.PublishWithContext(ctx, delayExchange, routingKey, false, false, pub)
+	if publishErr != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: republish to delay tier failed, falling back to nack(requeue)",
+			slog.String(logKeyTopic, topic),
+			slog.String(logKeyEventID, eventID),
+			slog.Int("attempt", attempt),
+			slog.Any("error", publishErr))
+		if nackErr := ch.Nack(tag, false, true); nackErr != nil {
+			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) fallback failed",
+				slog.String(logKeyTopic, topic),
+				slog.String(logKeyEventID, eventID),
+				slog.Any("error", nackErr))
+		}
+		releaseSettlement(ctx, settlement, topic, eventID, "delay_publish_failed")
+		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, publishErr)
+		return
+	}
+
+	// Ack the original delivery — the delay queue now owns this message.
+	if ackErr := ch.Ack(tag, false); ackErr != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: ack(delay) failed",
+			slog.String(logKeyTopic, topic),
+			slog.String(logKeyEventID, eventID),
+			slog.Any("error", ackErr))
+		releaseSettlement(ctx, settlement, topic, eventID, "delay_ack_failed")
+		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, ackErr)
+		return
+	}
+
+	// Release (not Commit) — the redelivered message has the same entry.ID and
+	// must re-enter the Claim path when it exits the delay tier.
+	releaseSettlement(ctx, settlement, topic, eventID, "delay_requeue")
+	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 }
 
 // dispatchAck handles the Commit→Ack path for DispositionAck.

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -378,7 +378,13 @@ func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName strin
 			"x-dead-letter-exchange": topic,
 		}
 		if _, err := ch.QueueDeclare(tierQueue, true, false, false, false, tierArgs); err != nil {
-			return fmt.Errorf("rabbitmq: declare delay tier queue %d: %w", i, err)
+			// AMQP 406 PRECONDITION_FAILED is returned when the queue already
+			// exists with different arguments (e.g. a changed x-message-ttl from
+			// a new BrokerDelaySchedule). To apply the new schedule, delete the
+			// existing tier queues ("<queue>.delay.<i>") and restart the consumer.
+			return fmt.Errorf("rabbitmq: declare delay tier queue %d (%s): %w"+
+				" (hint: AMQP 406 PRECONDITION_FAILED means the queue exists with"+
+				" a different x-message-ttl; delete %s and retry)", i, tierQueue, err, tierQueue)
 		}
 		if err := ch.QueueBind(tierQueue, strconv.Itoa(i), delayExchange, false, nil); err != nil {
 			return fmt.Errorf("rabbitmq: bind delay tier queue %d: %w", i, err)
@@ -605,7 +611,7 @@ func (s *Subscriber) subscribeOnce(
 		slog.String("consumer", consumerTag),
 		slog.Int("prefetch", s.config.PrefetchCount))
 
-	loopErr := s.consumeLoop(ctx, run, deliveries, topic, schedule, handler)
+	loopErr := s.consumeLoop(ctx, run, deliveries, topic, queueName, schedule, handler)
 
 	// A19 fix: wait for all in-flight processDelivery goroutines of THIS run
 	// before closing the AMQP channel. This prevents Ack/Nack calls on a
@@ -704,7 +710,7 @@ func (s *Subscriber) consumeLoop(
 	ctx context.Context,
 	run *subscriptionRun,
 	deliveries <-chan amqp.Delivery,
-	topic string,
+	topic, queueName string,
 	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) error {
@@ -725,7 +731,7 @@ func (s *Subscriber) consumeLoop(
 			slog.Info("rabbitmq: intake stopped, entering drain mode",
 				slog.String(logKeyTopic, topic))
 			drainCtx := context.WithoutCancel(ctx)
-			return s.drainRemaining(drainCtx, run, deliveries, topic, schedule, handler)
+			return s.drainRemaining(drainCtx, run, deliveries, topic, queueName, schedule, handler)
 		default:
 		}
 
@@ -734,7 +740,7 @@ func (s *Subscriber) consumeLoop(
 			slog.Info("rabbitmq: intake stopped, entering drain mode",
 				slog.String(logKeyTopic, topic))
 			drainCtx := context.WithoutCancel(ctx)
-			return s.drainRemaining(drainCtx, run, deliveries, topic, schedule, handler)
+			return s.drainRemaining(drainCtx, run, deliveries, topic, queueName, schedule, handler)
 
 		case <-ctx.Done():
 			slog.Info("rabbitmq: subscriber context canceled",
@@ -758,7 +764,7 @@ func (s *Subscriber) consumeLoop(
 			go func(d amqp.Delivery) {
 				defer s.wg.Done()
 				defer run.markDeliveryDone()
-				s.processDelivery(ctx, ch, d, topic, schedule, handler)
+				s.processDelivery(ctx, ch, d, topic, queueName, schedule, handler)
 			}(delivery)
 		}
 	}
@@ -809,7 +815,7 @@ func (s *Subscriber) drainRemaining(
 	ctx context.Context,
 	run *subscriptionRun,
 	deliveries <-chan amqp.Delivery,
-	topic string,
+	topic, queueName string,
 	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) error {
@@ -830,7 +836,7 @@ func (s *Subscriber) drainRemaining(
 			go func(d amqp.Delivery) {
 				defer s.wg.Done()
 				defer run.markDeliveryDone()
-				s.processDelivery(ctx, ch, d, topic, schedule, handler)
+				s.processDelivery(ctx, ch, d, topic, queueName, schedule, handler)
 			}(d)
 		case <-timer.C():
 			slog.Warn("rabbitmq: drain deadline reached, broker did not acknowledge basic.cancel",
@@ -873,7 +879,7 @@ func (s *Subscriber) processDelivery(
 	ctx context.Context,
 	ch AMQPChannel,
 	delivery amqp.Delivery,
-	topic string,
+	topic, queueName string,
 	schedule []time.Duration,
 	handler outbox.SubscriberHandler,
 ) {
@@ -940,7 +946,7 @@ func (s *Subscriber) processDelivery(
 			slog.Any("error", res.Err))
 	}
 
-	s.dispatchDisposition(deliveryCtx, ch, delivery, schedule, res, settlement, topic, entry)
+	s.dispatchDisposition(deliveryCtx, ch, delivery, queueName, schedule, res, settlement, topic, entry)
 }
 
 // dispatchDisposition executes the broker-level disposition and settles the
@@ -964,6 +970,7 @@ func (s *Subscriber) dispatchDisposition(
 	ctx context.Context,
 	ch AMQPChannel,
 	delivery amqp.Delivery,
+	queueName string,
 	schedule []time.Duration,
 	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
@@ -990,7 +997,8 @@ func (s *Subscriber) dispatchDisposition(
 		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, rejectResult, nil)
 	case outbox.DispositionRequeue:
 		if len(schedule) > 0 {
-			s.dispatchDelayedRequeue(ctx, ch, delivery, schedule, res, settlement, topic, entry)
+			dp := delayDispatchCtx{res: res, settlement: settlement, topic: topic, entry: entry}
+			s.dispatchDelayedRequeue(ctx, ch, delivery, queueName, schedule, dp)
 			return
 		}
 		// Non-delayed requeue: immediate Nack+requeue (unchanged).
@@ -1024,106 +1032,116 @@ func (s *Subscriber) dispatchDisposition(
 	}
 }
 
+// delayDispatchCtx bundles the settlement-tracking parameters threaded through
+// the delayed-requeue dispatch chain (dispatchDelayedRequeue →
+// republishToDelayTier / exhaustDelayBudget). Bundled to keep those helpers
+// under the 7-parameter threshold.
+type delayDispatchCtx struct {
+	res        outbox.DeliveryOutcome
+	settlement outbox.Settlement
+	topic      string
+	entry      outbox.Entry
+}
+
 // dispatchDelayedRequeue handles DispositionRequeue when BrokerDelaySchedule is
 // non-empty. It routes the message through a TTL+DLX delay tier queue instead
 // of immediate requeue. Cognitive complexity kept low by delegating the two
 // outcome branches to named helpers.
+//
+// queueName is threaded from subscribeOnce via the consume chain
+// (subscribeOnce → consumeLoop → drainRemaining → processDelivery →
+// dispatchDisposition → dispatchDelayedRequeue → republishToDelayTier).
+// It is used to build the delay exchange name (<queueName>.delay) so that
+// the publish always targets the exchange declared by declareDelayTopology,
+// regardless of ConsumerTag truncation or topic-substring ambiguity.
 func (s *Subscriber) dispatchDelayedRequeue(
 	ctx context.Context,
 	ch AMQPChannel,
 	delivery amqp.Delivery,
+	queueName string,
 	schedule []time.Duration,
-	res outbox.DeliveryOutcome,
-	settlement outbox.Settlement,
-	topic string,
-	entry outbox.Entry,
+	dp delayDispatchCtx,
 ) {
 	tag := delivery.DeliveryTag
-	eventID := entry.ID()
-	queueName := resolveQueueNameFromTopic(delivery, topic)
+	eventID := dp.entry.ID()
 	attempt := readWebhookAttempt(delivery.Headers)
 
 	if attempt > len(schedule) {
 		// Retry budget exhausted: route to the real DLX (Nack without requeue).
-		s.exhaustDelayBudget(ctx, ch, tag, res, settlement, topic, eventID, entry)
+		s.exhaustDelayBudget(ctx, ch, tag, eventID, dp)
 		return
 	}
 
 	// Republish to the delay tier for this attempt.
-	s.republishToDelayTier(ctx, ch, delivery, queueName, attempt, res, settlement, topic, eventID, entry)
-}
-
-// resolveQueueNameFromTopic derives the queue name from the delivery's
-// ConsumerTag. The consumer tag is formatted as "cg-<queueName>-<topic>".
-// When the format does not match we fall back to the topic. This is used
-// exclusively to construct the delay exchange name on the consume path.
-func resolveQueueNameFromTopic(delivery amqp.Delivery, topic string) string {
-	// Consumer tag format: "cg-<queueName>-<topic>" (see subscribeOnce).
-	// Strip "cg-" prefix and "-<topic>" suffix to recover queueName.
-	prefix := "cg-"
-	suffix := "-" + topic
-	tag := delivery.ConsumerTag
-	if len(tag) > len(prefix)+len(suffix) &&
-		tag[:len(prefix)] == prefix &&
-		tag[len(tag)-len(suffix):] == suffix {
-		return tag[len(prefix) : len(tag)-len(suffix)]
-	}
-	return topic
+	s.republishToDelayTier(ctx, ch, delivery, queueName, attempt, dp)
 }
 
 // exhaustDelayBudget handles the retry-budget-exhausted path: Nack(requeue=false)
 // routes to the queue's real DLX, then releases the settlement.
+// Log level is Error (not Warn) because routing to DLX is correctness-affecting:
+// the message is permanently removed from the retry cycle.
+// Mirrors consumer_base.go:648 which also logs Error on retry-exhausted → DLX.
 func (s *Subscriber) exhaustDelayBudget(
 	ctx context.Context,
 	ch AMQPChannel,
 	tag uint64,
-	res outbox.DeliveryOutcome,
-	settlement outbox.Settlement,
-	topic, eventID string,
-	entry outbox.Entry,
+	eventID string,
+	dp delayDispatchCtx,
 ) {
-	slog.LogAttrs(ctx, slog.LevelWarn, "rabbitmq: webhook retry budget exhausted, routing to DLX",
-		slog.String(logKeyTopic, topic),
-		slog.String(logKeyEventID, eventID))
+	slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: webhook retry budget exhausted, routing to DLX",
+		slog.String(logKeyTopic, dp.topic),
+		slog.String(logKeyEventID, eventID),
+		slog.String("process_reason", outbox.ProcessReasonRetryExhausted))
 	if nackErr := ch.Nack(tag, false, false); nackErr != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(exhaust) failed",
-			slog.String(logKeyTopic, topic),
+			slog.String(logKeyTopic, dp.topic),
 			slog.String(logKeyEventID, eventID),
 			slog.Any("error", nackErr))
-		releaseSettlement(ctx, settlement, topic, eventID, "exhaust")
-		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultNackFailed, nackErr)
+		releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "exhaust")
+		outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionReject, outbox.SettlementResultNackFailed, nackErr)
 		return
 	}
-	releaseSettlement(ctx, settlement, topic, eventID, "exhaust")
-	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.SettlementResultRetryExhausted, nil)
+	releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "exhaust")
+	outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionReject, outbox.SettlementResultRetryExhausted, nil)
 }
 
 // republishToDelayTier publishes the delivery body to the delay tier queue for
 // the given attempt, Acks the original delivery, and releases (not commits) the
 // settlement so the redelivered message can re-enter the Claim/Commit cycle.
 // On publish failure it falls back to Nack(requeue=true) to avoid message loss.
+//
+// queueName is the canonical queue name threaded from subscribeOnce; it is used
+// to build <queueName>.delay so the exchange always matches the one declared by
+// declareDelayTopology regardless of ConsumerTag truncation.
 func (s *Subscriber) republishToDelayTier(
 	ctx context.Context,
 	ch AMQPChannel,
 	delivery amqp.Delivery,
 	queueName string,
 	attempt int,
-	res outbox.DeliveryOutcome,
-	settlement outbox.Settlement,
-	topic, eventID string,
-	entry outbox.Entry,
+	dp delayDispatchCtx,
 ) {
 	tag := delivery.DeliveryTag
+	eventID := dp.entry.ID()
 	delayExchange := queueName + ".delay"
 	routingKey := strconv.Itoa(attempt - 1)
 
-	// Copy headers and set next attempt number.
-	// attempt is bounded by len(schedule) which is a small slice in practice,
-	// so the int32 conversion is safe. Use explicit bounds to satisfy gosec G115.
+	// Copy headers, skipping RabbitMQ broker system headers that accumulate
+	// across dead-letter cycles and must not be propagated to the delay tier.
+	// x-death and x-first-death-* / x-original-* are injected by the broker
+	// and grow unboundedly on each dead-letter hop; carrying them forward
+	// pollutes headers on redelivery and can confuse broker routing.
+	// x-webhook-attempt and all business headers are preserved.
 	headers := make(amqp.Table, len(delivery.Headers)+1)
 	for k, v := range delivery.Headers {
+		if k == "x-death" || len(k) >= len("x-first-death-") && k[:len("x-first-death-")] == "x-first-death-" ||
+			len(k) >= len("x-original-") && k[:len("x-original-")] == "x-original-" {
+			continue
+		}
 		headers[k] = v
 	}
+	// attempt is bounded by len(schedule) which is a small slice in practice,
+	// so the int32 conversion is safe. Use explicit bounds to satisfy gosec G115.
 	nextAttempt := attempt + 1
 	if nextAttempt > 1<<30 { // defensive cap well within int32 range
 		nextAttempt = 1 << 30
@@ -1140,36 +1158,46 @@ func (s *Subscriber) republishToDelayTier(
 	publishErr := ch.PublishWithContext(ctx, delayExchange, routingKey, false, false, pub)
 	if publishErr != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: republish to delay tier failed, falling back to nack(requeue)",
-			slog.String(logKeyTopic, topic),
+			slog.String(logKeyTopic, dp.topic),
 			slog.String(logKeyEventID, eventID),
 			slog.Int("attempt", attempt),
 			slog.Any("error", publishErr))
 		if nackErr := ch.Nack(tag, false, true); nackErr != nil {
 			slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: nack(requeue) fallback failed",
-				slog.String(logKeyTopic, topic),
+				slog.String(logKeyTopic, dp.topic),
 				slog.String(logKeyEventID, eventID),
 				slog.Any("error", nackErr))
+			// Both publish and nack fallback failed: settlement result is NackFailed.
+			releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_publish_failed")
+			outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, publishErr)
+			return
 		}
-		releaseSettlement(ctx, settlement, topic, eventID, "delay_publish_failed")
-		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, publishErr)
+		// Nack fallback succeeded: delivery was requeued immediately and bypassed
+		// the delay schedule. Log at Warn so ops can detect unexpected scheduling gaps.
+		slog.LogAttrs(ctx, slog.LevelWarn, "rabbitmq: delay publish failed; delivery requeued immediately, bypassing delay schedule",
+			slog.String(logKeyTopic, dp.topic),
+			slog.String(logKeyEventID, eventID),
+			slog.Int("attempt", attempt))
+		releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_publish_failed")
+		outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 		return
 	}
 
 	// Ack the original delivery — the delay queue now owns this message.
 	if ackErr := ch.Ack(tag, false); ackErr != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "rabbitmq: ack(delay) failed",
-			slog.String(logKeyTopic, topic),
+			slog.String(logKeyTopic, dp.topic),
 			slog.String(logKeyEventID, eventID),
 			slog.Any("error", ackErr))
-		releaseSettlement(ctx, settlement, topic, eventID, "delay_ack_failed")
-		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, ackErr)
+		releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_ack_failed")
+		outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultNackFailed, ackErr)
 		return
 	}
 
 	// Release (not Commit) — the redelivered message has the same entry.ID and
 	// must re-enter the Claim path when it exits the delay tier.
-	releaseSettlement(ctx, settlement, topic, eventID, "delay_requeue")
-	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
+	releaseSettlement(ctx, dp.settlement, dp.topic, eventID, "delay_requeue")
+	outbox.NotifySettlement(ctx, dp.res, dp.entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 }
 
 // dispatchAck handles the Commit→Ack path for DispositionAck.

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -92,6 +92,75 @@ func TestReadWebhookAttempt(t *testing.T) {
 }
 
 // =============================================================================
+// deliveryFromDelayTier (x-death provenance) tests
+// =============================================================================
+
+func TestDeliveryFromDelayTier(t *testing.T) {
+	const queueName = "myqueue"
+	tests := []struct {
+		name    string
+		headers amqp.Table
+		want    bool
+	}{
+		{name: "nil headers", headers: nil, want: false},
+		{name: "no x-death", headers: amqp.Table{headerWebhookAttempt: int32(2)}, want: false},
+		{
+			name: "expired from own delay tier",
+			headers: amqp.Table{"x-death": []any{
+				amqp.Table{"reason": "expired", "queue": "myqueue.delay.0"},
+			}},
+			want: true,
+		},
+		{
+			name: "expired from a later own delay tier",
+			headers: amqp.Table{"x-death": []any{
+				amqp.Table{"reason": "expired", "queue": "myqueue.delay.5"},
+			}},
+			want: true,
+		},
+		{
+			name: "rejected (not expired) from delay tier is not provenance",
+			headers: amqp.Table{"x-death": []any{
+				amqp.Table{"reason": "rejected", "queue": "myqueue.delay.0"},
+			}},
+			want: false,
+		},
+		{
+			name: "expired from a different queue is not provenance",
+			headers: amqp.Table{"x-death": []any{
+				amqp.Table{"reason": "expired", "queue": "otherqueue.delay.0"},
+			}},
+			want: false,
+		},
+		{
+			name: "expired from the main queue (not a delay tier) is not provenance",
+			headers: amqp.Table{"x-death": []any{
+				amqp.Table{"reason": "expired", "queue": "myqueue"},
+			}},
+			want: false,
+		},
+		{
+			name:    "x-death wrong type is not provenance",
+			headers: amqp.Table{"x-death": "not-an-array"},
+			want:    false,
+		},
+		{
+			name: "multiple deaths, one matching",
+			headers: amqp.Table{"x-death": []any{
+				amqp.Table{"reason": "rejected", "queue": "myqueue"},
+				amqp.Table{"reason": "expired", "queue": "myqueue.delay.2"},
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, deliveryFromDelayTier(tt.headers, queueName))
+		})
+	}
+}
+
+// =============================================================================
 // declareTopology — delay topology tests
 // =============================================================================
 
@@ -208,6 +277,11 @@ func makeDispatchTestSetup(t *testing.T) (*Subscriber, *mockChannel, amqp.Delive
 	t.Helper()
 	conn, mockConn := newTestConnection(t)
 	ch := newMockChannel()
+	// F1: the delay-tier republish runs on an ephemeral confirm-mode channel
+	// acquired from the connection (mockConn.nextCh). Auto-confirm publishes so
+	// the happy-path republish completes; failure paths set ch.publishErr (publish
+	// send fails) or autoConfirmation.Ack=false (broker nacks) explicitly.
+	ch.autoConfirmation = &amqp.Confirmation{Ack: true, DeliveryTag: 1}
 	mockConn.nextCh = ch
 
 	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{
@@ -227,6 +301,20 @@ func makeDispatchTestSetup(t *testing.T) (*Subscriber, *mockChannel, amqp.Delive
 	}
 
 	return sub, ch, delivery, entry
+}
+
+// delayTierHeaders builds the header table a delivery carries after it has
+// expired (TTL) out of "myqueue.delay.<i>" and been dead-lettered back to the
+// dispatch exchange: the x-webhook-attempt counter plus the broker x-death
+// "expired" provenance that dispatchDelayedRequeue requires before trusting the
+// attempt counter (F6). Without this provenance the attempt header is ignored.
+func delayTierHeaders(attempt int32) amqp.Table {
+	return amqp.Table{
+		headerWebhookAttempt: attempt,
+		"x-death": []any{
+			amqp.Table{"reason": "expired", "queue": "myqueue.delay.0"},
+		},
+	}
 }
 
 // TestDispatchDisposition_DelayedRequeue_Attempt1_PublishesAndAcks verifies that
@@ -273,8 +361,9 @@ func TestDispatchDisposition_DelayedRequeue_Attempt1_PublishesAndAcks(t *testing
 func TestDispatchDisposition_DelayedRequeue_BudgetExhausted(t *testing.T) {
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
 
-	// Set attempt = 3 > len(schedule)=2 to trigger exhaustion.
-	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(3)}
+	// Set attempt = 3 > len(schedule)=2 to trigger exhaustion. Carry delay-tier
+	// provenance so the attempt counter is trusted (F6).
+	delivery.Headers = delayTierHeaders(3)
 
 	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
@@ -297,10 +386,13 @@ func TestDispatchDisposition_DelayedRequeue_BudgetExhausted(t *testing.T) {
 	_ = notifyCount // used only for assertion above
 }
 
-// TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack verifies
-// that when PublishWithContext returns an error, the subscriber falls back to
-// Nack(tag, false, true) so the message is not lost.
-func TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack(t *testing.T) {
+// TestDispatchDisposition_DelayedRequeue_PublishError_FailsClosedToDLX verifies
+// that when the delay-tier publish fails, the subscriber fails closed via
+// Nack(tag, false, false) — routing to the real DLX — instead of an immediate
+// Nack(tag, false, true). An immediate requeue would redeliver the same message
+// with the same, un-advanced x-webhook-attempt, hot-looping forever on a
+// persistent delay-infra fault (F5).
+func TestDispatchDisposition_DelayedRequeue_PublishError_FailsClosedToDLX(t *testing.T) {
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
 	ch.publishErr = errors.New("channel closed")
 
@@ -312,12 +404,65 @@ func TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack(t *testing
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
 
-	// Fallback: Nack(tag, false, true) — do not lose the message.
-	assert.True(t, ch.nackCalled, "fallback Nack must be called on publish error")
-	assert.True(t, ch.nackRequeue, "fallback Nack must use requeue=true to avoid message loss")
+	// Fail closed: Nack(tag, false, false) routes to the real DLX.
+	assert.True(t, ch.nackCalled, "publish failure must Nack to fail closed")
+	assert.False(t, ch.nackRequeue,
+		"fail-closed Nack must use requeue=false (route to DLX, not hot-loop an immediate requeue)")
 
 	// Ack must NOT be called (publish failed before original Ack).
 	assert.False(t, ch.ackCalled, "Ack must NOT be called when publish fails")
+}
+
+// TestDispatchDisposition_DelayedRequeue_BrokerNack_FailsClosedToDLX verifies
+// that when the broker NACKs the delay-tier publish (confirm.Ack == false), the
+// subscriber fails closed to the DLX and does NOT Ack the original delivery —
+// the broker never durably accepted the republished copy, so acking would lose
+// the webhook (F1).
+func TestDispatchDisposition_DelayedRequeue_BrokerNack_FailsClosedToDLX(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+	// Broker rejects the publish: confirm arrives with Ack == false.
+	ch.autoConfirmation = &amqp.Confirmation{Ack: false, DeliveryTag: 1}
+
+	schedule := []time.Duration{testtime.D200ms}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	assert.True(t, ch.publishCalled, "publish must be attempted")
+	assert.True(t, ch.nackCalled, "broker nack must fail closed via Nack")
+	assert.False(t, ch.nackRequeue, "fail-closed Nack must use requeue=false (route to DLX)")
+	assert.False(t, ch.ackCalled,
+		"original delivery must NOT be Acked when the broker did not confirm the delay publish")
+}
+
+// TestDispatchDisposition_DelayedRequeue_ForgedAttemptWithoutProvenance_TreatedAsAttempt1
+// verifies F6: an x-webhook-attempt header on a delivery that lacks broker
+// x-death "expired from delay tier" provenance is NOT trusted. A forged high
+// attempt (here 99, well past the schedule) must NOT force a premature DLX; the
+// delivery is treated as attempt 1 and republished to tier 0.
+func TestDispatchDisposition_DelayedRequeue_ForgedAttemptWithoutProvenance_TreatedAsAttempt1(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+	// Forged attempt header, but NO x-death delay-tier provenance.
+	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(99)}
+
+	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Treated as attempt 1: republished to tier 0, NOT exhausted to DLX.
+	assert.True(t, ch.publishCalled, "forged attempt must be ignored and the delivery republished, not exhausted")
+	assert.Equal(t, "0", ch.publishRoutingKey, "untrusted attempt must default to attempt 1 (routing key \"0\")")
+	assert.True(t, ch.ackCalled, "original delivery must be Acked after successful republish")
+	require.Len(t, ch.publishedMessages, 1)
+	assert.Equal(t, int32(2), ch.publishedMessages[0].Headers[headerWebhookAttempt],
+		"x-webhook-attempt must advance from the trusted base of 1 to 2")
 }
 
 // TestDispatchDisposition_NonDelayed_Requeue_Unchanged verifies that an empty
@@ -343,7 +488,7 @@ func TestDispatchDisposition_NonDelayed_Requeue_Unchanged(t *testing.T) {
 // for attempt=2, routing key "1" is used (tier index = attempt-1).
 func TestDispatchDisposition_DelayedRequeue_Attempt2_PublishesRK1(t *testing.T) {
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
-	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(2)}
+	delivery.Headers = delayTierHeaders(2)
 
 	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
@@ -369,7 +514,8 @@ func TestDispatchDisposition_DelayedRequeue_AttemptEqLen_RepublishesLastTier(t *
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
 
 	// attempt = len(schedule) = 2: boundary — must republish, not exhaust.
-	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(2)}
+	// Carry delay-tier provenance so the attempt counter is trusted (F6).
+	delivery.Headers = delayTierHeaders(2)
 
 	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
@@ -485,6 +631,10 @@ func TestSubscribe_NoDelaySchedule_NoDelayTopology(t *testing.T) {
 func TestSubscribe_DelayedSchedule_RequeueRoutesToDelayTier(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 	ch := newMockChannel()
+	// F1: the delay-tier republish runs on a confirm-mode channel acquired from
+	// the connection (same mock channel here); auto-confirm so the republish and
+	// subsequent Ack of the original delivery complete.
+	ch.autoConfirmation = &amqp.Confirmation{Ack: true, DeliveryTag: 1}
 	mockConn.mu.Lock()
 	mockConn.nextCh = ch
 	mockConn.mu.Unlock()

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -222,8 +222,6 @@ func makeDispatchTestSetup(t *testing.T) (*Subscriber, *mockChannel, amqp.Delive
 		DeliveryTag: 99,
 		Body:        body,
 		ContentType: "application/json",
-		// ConsumerTag matches the format "cg-<queue>-<topic>" so resolveQueueNameFromTopic
-		// can derive "myqueue" from it.
 		ConsumerTag: "cg-myqueue-test.topic",
 		Headers:     amqp.Table{},
 	}
@@ -243,7 +241,7 @@ func TestDispatchDisposition_DelayedRequeue_Attempt1_PublishesAndAcks(t *testing
 	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
-	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
 
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
@@ -283,7 +281,7 @@ func TestDispatchDisposition_DelayedRequeue_BudgetExhausted(t *testing.T) {
 
 	notifyCount := 0
 	// We can't inject a settlement observer here; we just assert the broker call.
-	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
 
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
@@ -309,7 +307,7 @@ func TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack(t *testing
 	schedule := []time.Duration{200 * time.Millisecond}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
-	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
 
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
@@ -330,7 +328,7 @@ func TestDispatchDisposition_NonDelayed_Requeue_Unchanged(t *testing.T) {
 	// Empty schedule: non-delayed path.
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
-	sub.dispatchDisposition(context.Background(), ch, delivery, nil, res, nil, "test.topic", entry)
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", nil, res, nil, "test.topic", entry)
 
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
@@ -350,7 +348,7 @@ func TestDispatchDisposition_DelayedRequeue_Attempt2_PublishesRK1(t *testing.T) 
 	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
-	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
 
 	ch.mu.Lock()
 	defer ch.mu.Unlock()
@@ -360,6 +358,45 @@ func TestDispatchDisposition_DelayedRequeue_Attempt2_PublishesRK1(t *testing.T) 
 
 	pub := ch.publishedMessages[0]
 	assert.Equal(t, int32(3), pub.Headers[headerWebhookAttempt], "x-webhook-attempt must be 3")
+}
+
+// TestDispatchDisposition_DelayedRequeue_AttemptEqLen_RepublishesLastTier verifies
+// the boundary case where attempt == len(schedule) (e.g. schedule length 2,
+// attempt=2). This is NOT exhaustion — exhaustion only fires when attempt >
+// len(schedule). The message must be republished to the LAST tier (routing key
+// strconv.Itoa(len-1) = "1" for a 2-tier schedule) and Acked normally.
+func TestDispatchDisposition_DelayedRequeue_AttemptEqLen_RepublishesLastTier(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+
+	// attempt = len(schedule) = 2: boundary — must republish, not exhaust.
+	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(2)}
+
+	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Must publish to last tier (routing key = strconv.Itoa(len-1) = "1").
+	assert.True(t, ch.publishCalled, "must republish to last tier when attempt == len(schedule)")
+	assert.Equal(t, "1", ch.publishRoutingKey, "routing key must be \"1\" (last tier) for attempt == len(schedule)")
+	assert.Equal(t, "myqueue.delay", ch.publishExchange, "must target delay exchange")
+
+	// Must NOT nack with requeue=false (that would exhaust the budget).
+	if ch.nackCalled {
+		assert.True(t, ch.nackRequeue,
+			"if Nack was called it must be requeue=true (not DLX exhaust path)")
+	}
+
+	// Original delivery must be Acked.
+	assert.True(t, ch.ackCalled, "original delivery must be Acked on successful republish")
+
+	// x-webhook-attempt header must be incremented to 3.
+	require.Len(t, ch.publishedMessages, 1)
+	assert.Equal(t, int32(3), ch.publishedMessages[0].Headers[headerWebhookAttempt],
+		"x-webhook-attempt must be incremented to attempt+1")
 }
 
 // =============================================================================

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -216,9 +216,11 @@ func TestDeclareTopology_WithDelaySchedule_DeclaresDelayTiers(t *testing.T) {
 
 	assert.Equal(t, int64(200), tier0Args["x-message-ttl"], "tier 0 x-message-ttl must be 200ms as int64")
 	assert.Equal(t, topic, tier0Args["x-dead-letter-exchange"], "tier 0 x-dead-letter-exchange must point to dispatch exchange")
+	assert.Equal(t, "", tier0Args["x-dead-letter-routing-key"], "tier 0 must reset routing key to canonical empty")
 
 	assert.Equal(t, int64(500), tier1Args["x-message-ttl"], "tier 1 x-message-ttl must be 500ms as int64")
 	assert.Equal(t, topic, tier1Args["x-dead-letter-exchange"], "tier 1 x-dead-letter-exchange must point to dispatch exchange")
+	assert.Equal(t, "", tier1Args["x-dead-letter-routing-key"], "tier 1 must reset routing key to canonical empty")
 
 	// Bindings: tier 0 bound with routing key "0", tier 1 with "1".
 	var tier0Detail, tier1Detail *queueBindDetail

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -102,7 +102,7 @@ func TestDeclareTopology_WithDelaySchedule_DeclaresDelayTiers(t *testing.T) {
 
 	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{DLXExchange: "test.dlx"})
 
-	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	topic := "session.created"
 	queueName := "cg-1.session.created"
 
@@ -238,7 +238,7 @@ func makeDispatchTestSetup(t *testing.T) (*Subscriber, *mockChannel, amqp.Delive
 func TestDispatchDisposition_DelayedRequeue_Attempt1_PublishesAndAcks(t *testing.T) {
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
 
-	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
 	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
@@ -276,7 +276,7 @@ func TestDispatchDisposition_DelayedRequeue_BudgetExhausted(t *testing.T) {
 	// Set attempt = 3 > len(schedule)=2 to trigger exhaustion.
 	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(3)}
 
-	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
 	notifyCount := 0
@@ -304,7 +304,7 @@ func TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack(t *testing
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
 	ch.publishErr = errors.New("channel closed")
 
-	schedule := []time.Duration{200 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
 	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
@@ -345,7 +345,7 @@ func TestDispatchDisposition_DelayedRequeue_Attempt2_PublishesRK1(t *testing.T) 
 	sub, ch, delivery, entry := makeDispatchTestSetup(t)
 	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(2)}
 
-	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
 	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
@@ -371,7 +371,7 @@ func TestDispatchDisposition_DelayedRequeue_AttemptEqLen_RepublishesLastTier(t *
 	// attempt = len(schedule) = 2: boundary — must republish, not exhaust.
 	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(2)}
 
-	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms, testtime.D500ms}
 	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
 
 	sub.dispatchDisposition(context.Background(), ch, delivery, "myqueue", schedule, res, nil, "test.topic", entry)
@@ -421,7 +421,7 @@ func TestSubscribe_DelayedSchedule_ThreadedThroughTopology(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately so Subscribe exits after topology declaration.
 
-	schedule := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond}
+	schedule := []time.Duration{testtime.D100ms, testtime.D300ms}
 	subscription := outbox.Subscription{
 		Topic:               "test.topic",
 		CellID:              "test-cell",
@@ -508,7 +508,7 @@ func TestSubscribe_DelayedSchedule_RequeueRoutesToDelayTier(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	schedule := []time.Duration{200 * time.Millisecond}
+	schedule := []time.Duration{testtime.D200ms}
 	subscription := outbox.Subscription{
 		Topic:               "test.topic",
 		CellID:              "test-cell",

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -1,0 +1,512 @@
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/pkg/testutil/testwait"
+)
+
+// =============================================================================
+// readWebhookAttempt tests
+// =============================================================================
+
+func TestReadWebhookAttempt(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers amqp.Table
+		want    int
+	}{
+		{
+			name:    "nil header returns 1",
+			headers: nil,
+			want:    1,
+		},
+		{
+			name:    "absent key returns 1",
+			headers: amqp.Table{"other": "value"},
+			want:    1,
+		},
+		{
+			name:    "int32 value 3 returns 3",
+			headers: amqp.Table{headerWebhookAttempt: int32(3)},
+			want:    3,
+		},
+		{
+			name:    "int64 value 2 returns 2",
+			headers: amqp.Table{headerWebhookAttempt: int64(2)},
+			want:    2,
+		},
+		{
+			name:    "int value 5 returns 5",
+			headers: amqp.Table{headerWebhookAttempt: int(5)},
+			want:    5,
+		},
+		{
+			name:    "int32 zero returns 1",
+			headers: amqp.Table{headerWebhookAttempt: int32(0)},
+			want:    1,
+		},
+		{
+			name:    "int32 negative returns 1",
+			headers: amqp.Table{headerWebhookAttempt: int32(-5)},
+			want:    1,
+		},
+		{
+			name:    "int64 zero returns 1",
+			headers: amqp.Table{headerWebhookAttempt: int64(0)},
+			want:    1,
+		},
+		{
+			name:    "int zero returns 1",
+			headers: amqp.Table{headerWebhookAttempt: int(0)},
+			want:    1,
+		},
+		{
+			name:    "string value returns 1 (unrecognized type)",
+			headers: amqp.Table{headerWebhookAttempt: "bad"},
+			want:    1,
+		},
+		{
+			name:    "float64 value returns 1 (unrecognized type)",
+			headers: amqp.Table{headerWebhookAttempt: float64(3.0)},
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := readWebhookAttempt(tt.headers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// =============================================================================
+// declareTopology — delay topology tests
+// =============================================================================
+
+func TestDeclareTopology_WithDelaySchedule_DeclaresDelayTiers(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	topic := "session.created"
+	queueName := "cg-1.session.created"
+
+	err := sub.declareTopology(ch, topic, queueName, schedule)
+	require.NoError(t, err)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Regular topology: main exchange, DLX exchange.
+	assert.Contains(t, ch.exchangesDeclared, topic, "main fanout exchange must be declared")
+	assert.Contains(t, ch.exchangesDeclared, "test.dlx", "DLX exchange must be declared")
+
+	// Delay exchange.
+	delayExchange := queueName + ".delay"
+	assert.Contains(t, ch.exchangesDeclared, delayExchange, "delay exchange must be declared")
+
+	// Main queue.
+	assert.Contains(t, ch.queuesDeclared, queueName, "main queue must be declared")
+
+	// Tier 0 queue.
+	tier0 := queueName + ".delay.0"
+	assert.Contains(t, ch.queuesDeclared, tier0, "tier 0 delay queue must be declared")
+
+	// Tier 1 queue.
+	tier1 := queueName + ".delay.1"
+	assert.Contains(t, ch.queuesDeclared, tier1, "tier 1 delay queue must be declared")
+
+	// Assert x-message-ttl values (must be int64 of milliseconds) and
+	// x-dead-letter-exchange pointing back to the dispatch fanout topic.
+	var tier0Args, tier1Args amqp.Table
+	for i, q := range ch.queuesDeclared {
+		switch q {
+		case tier0:
+			tier0Args = ch.queueDeclareArgs[i]
+		case tier1:
+			tier1Args = ch.queueDeclareArgs[i]
+		}
+	}
+	require.NotNil(t, tier0Args, "tier 0 queue args must be recorded")
+	require.NotNil(t, tier1Args, "tier 1 queue args must be recorded")
+
+	assert.Equal(t, int64(200), tier0Args["x-message-ttl"], "tier 0 x-message-ttl must be 200ms as int64")
+	assert.Equal(t, topic, tier0Args["x-dead-letter-exchange"], "tier 0 x-dead-letter-exchange must point to dispatch exchange")
+
+	assert.Equal(t, int64(500), tier1Args["x-message-ttl"], "tier 1 x-message-ttl must be 500ms as int64")
+	assert.Equal(t, topic, tier1Args["x-dead-letter-exchange"], "tier 1 x-dead-letter-exchange must point to dispatch exchange")
+
+	// Bindings: tier 0 bound with routing key "0", tier 1 with "1".
+	var tier0Detail, tier1Detail *queueBindDetail
+	for i, d := range ch.queueBindDetails {
+		switch d.queue {
+		case tier0:
+			dc := ch.queueBindDetails[i]
+			tier0Detail = &dc
+		case tier1:
+			dc := ch.queueBindDetails[i]
+			tier1Detail = &dc
+		}
+	}
+	require.NotNil(t, tier0Detail, "tier 0 binding must be recorded")
+	require.NotNil(t, tier1Detail, "tier 1 binding must be recorded")
+
+	assert.Equal(t, "0", tier0Detail.key, "tier 0 routing key must be \"0\"")
+	assert.Equal(t, delayExchange, tier0Detail.exchange, "tier 0 must bind to delay exchange")
+
+	assert.Equal(t, "1", tier1Detail.key, "tier 1 routing key must be \"1\"")
+	assert.Equal(t, delayExchange, tier1Detail.exchange, "tier 1 must bind to delay exchange")
+}
+
+func TestDeclareTopology_EmptySchedule_NoDeLlayTopology(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	// Empty schedule: no delay topology should be declared.
+	err := sub.declareTopology(ch, "my.topic", "my-queue", nil)
+	require.NoError(t, err)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Only main exchange + DLX exchange — no delay exchange.
+	assert.NotContains(t, ch.exchangesDeclared, "my-queue.delay",
+		"delay exchange must NOT be declared for empty schedule")
+
+	// Only main queue — no tier queues.
+	for _, q := range ch.queuesDeclared {
+		assert.NotContains(t, q, ".delay.", "delay tier queues must NOT be declared for empty schedule")
+	}
+}
+
+// =============================================================================
+// dispatchDisposition — delayed Requeue branch tests
+// =============================================================================
+
+// makeDispatchTestSetup builds the minimal scaffold for dispatchDisposition
+// unit tests: a real Subscriber (with a mock conn), a mock channel, and a
+// pre-baked outbox.Entry + delivery.
+func makeDispatchTestSetup(t *testing.T) (*Subscriber, *mockChannel, amqp.Delivery, outbox.Entry) {
+	t.Helper()
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.nextCh = ch
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{
+		QueueName:   "myqueue",
+		DLXExchange: "test.dlx",
+	})
+
+	entry := mustNewEntry(t, "test.event", []byte(`{"x":1}`), outbox.WithID("evt-delay-001"))
+	body := makeDeliveryBody(t, entry)
+
+	delivery := amqp.Delivery{
+		DeliveryTag: 99,
+		Body:        body,
+		ContentType: "application/json",
+		// ConsumerTag matches the format "cg-<queue>-<topic>" so resolveQueueNameFromTopic
+		// can derive "myqueue" from it.
+		ConsumerTag: "cg-myqueue-test.topic",
+		Headers:     amqp.Table{},
+	}
+
+	return sub, ch, delivery, entry
+}
+
+// TestDispatchDisposition_DelayedRequeue_Attempt1_PublishesAndAcks verifies that
+// for attempt=1 with a 2-tier schedule:
+//   - exactly one PublishWithContext to "<q>.delay" with routing key "0"
+//   - header x-webhook-attempt set to 2
+//   - Ack(tag) called on the original delivery
+//   - no Nack(tag,false,true) called
+func TestDispatchDisposition_DelayedRequeue_Attempt1_PublishesAndAcks(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+
+	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Exactly one publish to the delay exchange with routing key "0".
+	assert.True(t, ch.publishCalled, "PublishWithContext must be called")
+	assert.Len(t, ch.publishedMessages, 1, "exactly one message must be published")
+	assert.Equal(t, "myqueue.delay", ch.publishExchange, "must publish to the delay exchange")
+	assert.Equal(t, "0", ch.publishRoutingKey, "must use routing key \"0\" for attempt 1")
+
+	// Header x-webhook-attempt must be set to 2 (attempt+1).
+	pub := ch.publishedMessages[0]
+	require.NotNil(t, pub.Headers)
+	assert.Equal(t, int32(2), pub.Headers[headerWebhookAttempt], "x-webhook-attempt must be 2")
+	assert.Equal(t, amqp.Persistent, pub.DeliveryMode, "delivery mode must be persistent")
+	assert.Equal(t, "application/json", pub.ContentType, "content type must be preserved")
+
+	// Original delivery must be Acked.
+	assert.True(t, ch.ackCalled, "original delivery must be Acked")
+	assert.Equal(t, uint64(99), ch.ackTag, "Ack must use the original delivery tag")
+
+	// Must NOT Nack(requeue=true).
+	assert.False(t, ch.nackCalled, "Nack must NOT be called on successful delay publish")
+}
+
+// TestDispatchDisposition_DelayedRequeue_BudgetExhausted verifies that when
+// attempt > len(schedule), Nack(false,false) is issued (routes to real DLX)
+// and the settlement result is RetryExhausted.
+func TestDispatchDisposition_DelayedRequeue_BudgetExhausted(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+
+	// Set attempt = 3 > len(schedule)=2 to trigger exhaustion.
+	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(3)}
+
+	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	notifyCount := 0
+	// We can't inject a settlement observer here; we just assert the broker call.
+	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Nack(false,false) routes to real DLX.
+	assert.True(t, ch.nackCalled, "Nack must be called on budget exhaustion")
+	assert.False(t, ch.nackRequeue, "Nack must use requeue=false to route to real DLX")
+	assert.Equal(t, uint64(99), ch.nackTag)
+
+	// Must NOT publish to delay exchange.
+	assert.False(t, ch.publishCalled, "PublishWithContext must NOT be called on exhaustion")
+
+	_ = notifyCount // used only for assertion above
+}
+
+// TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack verifies
+// that when PublishWithContext returns an error, the subscriber falls back to
+// Nack(tag, false, true) so the message is not lost.
+func TestDispatchDisposition_DelayedRequeue_PublishError_FallbackNack(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+	ch.publishErr = errors.New("channel closed")
+
+	schedule := []time.Duration{200 * time.Millisecond}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Fallback: Nack(tag, false, true) — do not lose the message.
+	assert.True(t, ch.nackCalled, "fallback Nack must be called on publish error")
+	assert.True(t, ch.nackRequeue, "fallback Nack must use requeue=true to avoid message loss")
+
+	// Ack must NOT be called (publish failed before original Ack).
+	assert.False(t, ch.ackCalled, "Ack must NOT be called when publish fails")
+}
+
+// TestDispatchDisposition_NonDelayed_Requeue_Unchanged verifies that an empty
+// schedule leaves the Requeue branch unchanged (Nack(false,true)).
+func TestDispatchDisposition_NonDelayed_Requeue_Unchanged(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+
+	// Empty schedule: non-delayed path.
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, nil, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	assert.True(t, ch.nackCalled, "non-delayed Requeue must Nack")
+	assert.True(t, ch.nackRequeue, "non-delayed Requeue must use requeue=true")
+	assert.False(t, ch.publishCalled, "non-delayed Requeue must NOT publish")
+	assert.False(t, ch.ackCalled, "non-delayed Requeue must NOT Ack")
+}
+
+// TestDispatchDisposition_DelayedRequeue_Attempt2_PublishesRK1 verifies that
+// for attempt=2, routing key "1" is used (tier index = attempt-1).
+func TestDispatchDisposition_DelayedRequeue_Attempt2_PublishesRK1(t *testing.T) {
+	sub, ch, delivery, entry := makeDispatchTestSetup(t)
+	delivery.Headers = amqp.Table{headerWebhookAttempt: int32(2)}
+
+	schedule := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	res := outbox.DeliveryOutcome{Disposition: outbox.DispositionRequeue, Err: errors.New("transient")}
+
+	sub.dispatchDisposition(context.Background(), ch, delivery, schedule, res, nil, "test.topic", entry)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	assert.True(t, ch.publishCalled)
+	assert.Equal(t, "1", ch.publishRoutingKey, "attempt 2 must use routing key \"1\"")
+
+	pub := ch.publishedMessages[0]
+	assert.Equal(t, int32(3), pub.Headers[headerWebhookAttempt], "x-webhook-attempt must be 3")
+}
+
+// =============================================================================
+// Subscribe integration: delay schedule threaded end-to-end
+// =============================================================================
+
+// TestSubscribe_DelayedSchedule_ThreadedThroughTopology verifies that when
+// BrokerDelaySchedule is set on the Subscription, the delay topology is
+// declared (delay exchange and tier queues visible on the mock channel).
+func TestSubscribe_DelayedSchedule_ThreadedThroughTopology(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{
+		QueueName:   "myqueue",
+		DLXExchange: "test.dlx",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately so Subscribe exits after topology declaration.
+
+	schedule := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond}
+	subscription := outbox.Subscription{
+		Topic:               "test.topic",
+		CellID:              "test-cell",
+		BrokerDelaySchedule: schedule,
+	}
+
+	err := sub.Subscribe(ctx, subscription,
+		entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+			return outbox.Ack()
+		}))
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	assert.Contains(t, ch.exchangesDeclared, "myqueue.delay",
+		"delay exchange must be declared when schedule is non-empty")
+	assert.Contains(t, ch.queuesDeclared, "myqueue.delay.0",
+		"tier 0 delay queue must be declared")
+	assert.Contains(t, ch.queuesDeclared, "myqueue.delay.1",
+		"tier 1 delay queue must be declared")
+}
+
+// TestSubscribe_NoDelaySchedule_NoDelayTopology verifies that without a
+// BrokerDelaySchedule the delay exchange and tier queues are NOT declared.
+func TestSubscribe_NoDelaySchedule_NoDelayTopology(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{
+		QueueName:   "myqueue",
+		DLXExchange: "test.dlx",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sub.Subscribe(ctx, outbox.Subscription{Topic: "test.topic", CellID: "test-cell"},
+		entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+			return outbox.Ack()
+		}))
+	assert.NoError(t, err)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	assert.NotContains(t, ch.exchangesDeclared, "myqueue.delay",
+		"delay exchange must NOT be declared when schedule is empty")
+	for _, q := range ch.queuesDeclared {
+		assert.NotContains(t, q, ".delay.", "delay tier queues must NOT be declared for empty schedule")
+	}
+}
+
+// TestSubscribe_DelayedSchedule_RequeueRoutesToDelayTier is a higher-level test
+// that delivers a message, returns DispositionRequeue with a delay schedule, and
+// asserts that PublishWithContext is called on the mock channel (routing to the
+// delay tier) rather than Nack(requeue=true).
+func TestSubscribe_DelayedSchedule_RequeueRoutesToDelayTier(t *testing.T) {
+	conn, mockConn := newTestConnection(t)
+	ch := newMockChannel()
+	mockConn.mu.Lock()
+	mockConn.nextCh = ch
+	mockConn.mu.Unlock()
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{
+		QueueName:   "myqueue",
+		DLXExchange: "test.dlx",
+	})
+
+	entry := mustNewEntry(t, "test.event", []byte(`{}`), outbox.WithID("evt-delay-e2e"))
+	entryBytes := makeDeliveryBody(t, entry)
+
+	ch.consumeDeliveries <- amqp.Delivery{
+		DeliveryTag: 7,
+		Body:        entryBytes,
+		ContentType: "application/json",
+		ConsumerTag: "cg-myqueue-test.topic",
+		Headers:     amqp.Table{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	schedule := []time.Duration{200 * time.Millisecond}
+	subscription := outbox.Subscription{
+		Topic:               "test.topic",
+		CellID:              "test-cell",
+		BrokerDelaySchedule: schedule,
+	}
+
+	subDone := make(chan error, 1)
+	go func() {
+		subDone <- sub.Subscribe(ctx, subscription,
+			entryToSubHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+				return outbox.Requeue(errors.New("transient"))
+			}))
+	}()
+
+	// Wait until a publish or nack is recorded.
+	testwait.External(t, "amqp-delay-publish", func() bool {
+		ch.mu.Lock()
+		defer ch.mu.Unlock()
+		return ch.publishCalled || ch.nackCalled
+	}, testtime.D2s, testtime.FastPoll, "neither publish nor nack was called in time")
+
+	cancel()
+	assert.NoError(t, <-subDone)
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	// Must have published to the delay exchange, not Nacked with requeue.
+	assert.True(t, ch.publishCalled, "must publish to delay tier for delayed Requeue")
+	assert.Equal(t, "myqueue.delay", ch.publishExchange, "must target the delay exchange")
+	assert.Equal(t, "0", ch.publishRoutingKey, "routing key must be \"0\" for attempt 1")
+	assert.True(t, ch.ackCalled, "original delivery must be Acked after successful publish")
+
+	// Nack(requeue=true) must NOT be called.
+	if ch.nackCalled {
+		assert.False(t, ch.nackRequeue, "if Nack was called it must NOT be requeue=true (only DLX nack is acceptable)")
+	}
+}

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -48,14 +48,17 @@ a custom `RetrySchedule` via a future `WithSchedule` option (not in PR-5 scope).
 `RetrySchedule.MaxRetries()` returns 7 (the retry count excluding the initial
 attempt); `RetrySchedule.Attempts()` returns 8 (the total delivery count).
 
-**PR-5 ships `DefaultSvixSchedule` as a tested primitive and the documented
-seam for the broker-delay follow-up. PR-5 does NOT wire per-attempt delays or
-a per-dispatcher RetryCount at runtime**: `Dispatcher` has no schedule field,
-`runtime/webhook/dispatch.BuildConsumers` never sets `ConsumerBaseConfig.RetryCount`,
-and the global `kernel/outbox.ConsumerBase` cannot accept a per-dispatcher
-count. The dispatch consumer rides the shared ConsumerBase (default exponential
-backoff, capped 30 s). `RetrySchedule.DelayFor` is the seam the follow-up
-(gh #1458) will consume.
+PR-5 shipped `DefaultSvixSchedule` as a tested primitive and the documented
+seam. The per-attempt wall-clock delays **are now honoured at runtime** (#1458):
+the webhook-dispatch bootstrap drain copies `DefaultSvixSchedule().Delays()` onto
+`outbox.Subscription.BrokerDelaySchedule`, and the Subscriber applies
+broker-native delayed re-delivery. `RetrySchedule.DelayFor`/`Delays()` are the
+seams the wiring consumes. See §D5 for the mechanism and threat re-evaluation.
+
+> **Historical note (pre-#1458):** PR-5 itself did NOT wire the delays — the
+> dispatch consumer rode the shared `kernel/outbox.ConsumerBase` whose in-process
+> exponential backoff is capped at 30 s and is lost on restart. That gap was
+> deliberate and tracked at #1458, now closed (§D5).
 
 ### D2 — HTTP status code → `outbox.HandleResult` mapping (standard-webhooks aligned)
 

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -178,12 +178,20 @@ so adapters never import `kernel/webhook`):
 - **rabbitmq (TTL+DLX delay-tier queues)**: on a transient `Requeue` for a
   delayed subscription, the subscriber republishes the delivery to a per-tier
   queue `{queue}.delay.{i}` (`x-message-ttl = schedule[i]`, no consumer) that
-  dead-letters back to the dispatch exchange on expiry. The attempt counter
-  rides the `x-webhook-attempt` AMQP header; once `attempt > len(schedule)` the
-  entry is `Nack(requeue=false)` → DLX. Delays are held in **durable queues**, so
-  the ~40 h envelope survives process and broker-node restarts (unlike the
-  community `x-delayed-message` plugin, which holds delayed messages in node
-  memory — explicitly rejected).
+  dead-letters back to the dispatch exchange on expiry. The republish uses
+  **publisher confirms** on a dedicated ephemeral channel and Acks the original
+  delivery only after the broker confirms the delay-tier copy, so the
+  consume→publish→ack ownership transfer is not lost on a channel/broker drop
+  (#1828 F1); a delay-publish failure **fails closed to the real DLX** rather
+  than hot-looping an immediate requeue that never advances the attempt (#1828
+  F5). The attempt counter rides the `x-webhook-attempt` AMQP header — trusted
+  only on deliveries the broker attests expired from this queue's own `.delay.`
+  tier (`x-death` provenance), never on a header that could be forged by a direct
+  publish (#1828 F6); once `attempt > len(schedule)` the entry is
+  `Nack(requeue=false)` → DLX. Delays are held in **durable queues**, so the
+  ~40 h envelope survives process and broker-node restarts (unlike the community
+  `x-delayed-message` plugin, which holds delayed messages in node memory —
+  explicitly rejected).
 - **in-memory bus**: `handleWithRetry` uses `len(schedule)+1` deliveries as the
   budget and waits `schedule[attempt]` via the injected clock between attempts;
   exhaustion routes to the dead-letter slice.
@@ -201,15 +209,32 @@ so adapters never import `kernel/webhook`):
   `BrokerDelaySchedule` fails CI rather than silently degrading to immediate
   retry. The new `Subscription` field is locked by `SUBSCRIPTION-FIELDS-FROZEN-01`.
 
-**Threat / safety re-evaluation.** The 30 s ConsumerBase ceiling no longer
-applies to webhook dispatch; the full ~40 h Svix envelope is realized.
-At-least-once delivery is unchanged: the delay round-trip **releases (does not
-commit)** the idempotency receipt, so the redelivered same-`entry.ID` message
-re-claims and the handler re-runs — downstream handlers must remain idempotent
-(already required). No new wire field or PII surface is introduced;
-`x-webhook-attempt` is internal broker metadata, never part of the signed
-payload. `RetrySchedule.DelayFor` / `Delays()` remain the single source of the
-tier values.
+**Threat / safety re-evaluation (re-amended 2026-06-11, #1828 review).** The 30 s
+ConsumerBase ceiling no longer applies to webhook dispatch; the full ~40 h Svix
+envelope is realized.
+
+At-least-once across the **application** boundary holds: the delay round-trip
+**releases (does not commit)** the idempotency receipt and the delay-tier
+republish is publisher-confirmed (#1828 F1), so the redelivered same-`entry.ID`
+message re-claims and the handler re-runs — downstream handlers must remain
+idempotent (already required).
+
+One residual gap is **not** closed here and supersedes the earlier blanket
+"at-least-once delivery is unchanged" claim: the per-tier delay queues are
+RabbitMQ **classic** queues, and the broker-internal TTL→dead-letter republish
+on a classic queue is best-effort (the internal hop is not publisher-confirmed).
+On a **single-node** broker this is reliable; on a **multi-node cluster** a node
+failure *during* that internal republish can drop one scheduled retry. The next
+business event or a manual replay recovers it (handlers are idempotent), so the
+delay hop is **at-least-once on single-node and best-effort under clustering** —
+not unconditionally at-least-once. Closing the cluster gap requires quorum queues
+with at-least-once dead-lettering, a separate infrastructure decision tracked at
+**#1835** (#1828 F2).
+
+No new wire field or PII surface is introduced; `x-webhook-attempt` is internal
+broker metadata, never part of the signed payload, and is provenance-gated
+against forgery (#1828 F6). `RetrySchedule.DelayFor` / `Delays()` remain the
+single source of the tier values.
 
 ---
 

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -160,46 +160,71 @@ these header name constants directly.
 > only residual is the package-internal holder axis (`SignedHeaders{valid: true}`
 > in-package), the permanent Go ceiling shared with #851/#893/#1282/#1375.
 
-### D5 — Schedule is the canonical default seam; per-attempt wall-clock delays and RetryCount are NOT yet wired (explicit boundary + tracked follow-up)
+### D5 — Per-attempt wall-clock delays via broker-native delayed re-delivery (amended 2026-06-10, #1458)
 
-This is the most important honesty section of this ADR.
+> **Amendment (2026-06-10, #1458): the PR-5 gap described at the end of this
+> section is now CLOSED.** Webhook dispatch honours the full Svix per-attempt
+> schedule on **both** `outbox.Subscriber` implementations — no broker plugin,
+> durable across restarts on rabbitmq.
 
-**PR-5 does NOT wire per-attempt delays or a per-dispatcher RetryCount at
-runtime.** Specifically:
+**Mechanism.** `outbox.Subscription.BrokerDelaySchedule []time.Duration` is the
+transport-neutral carrier (sourced from `DefaultSvixSchedule().Delays()` by the
+webhook-dispatch bootstrap drain via `cell.WithSubscriptionBrokerDelaySchedule`,
+so adapters never import `kernel/webhook`):
 
-- `Dispatcher` has no schedule field.
-- `runtime/webhook/dispatch.BuildConsumers` never sets
-  `ConsumerBaseConfig.RetryCount` from the schedule.
-- The global `kernel/outbox.ConsumerBase` cannot accept a per-dispatcher retry
-  count; the dispatch consumer rides the shared ConsumerBase with its default
-  exponential backoff capped at 30 s.
+- **rabbitmq (TTL+DLX delay-tier queues)**: on a transient `Requeue` for a
+  delayed subscription, the subscriber republishes the delivery to a per-tier
+  queue `{queue}.delay.{i}` (`x-message-ttl = schedule[i]`, no consumer) that
+  dead-letters back to the dispatch exchange on expiry. The attempt counter
+  rides the `x-webhook-attempt` AMQP header; once `attempt > len(schedule)` the
+  entry is `Nack(requeue=false)` → DLX. Delays are held in **durable queues**, so
+  the ~40 h envelope survives process and broker-node restarts (unlike the
+  community `x-delayed-message` plugin, which holds delayed messages in node
+  memory — explicitly rejected).
+- **in-memory bus**: `handleWithRetry` uses `len(schedule)+1` deliveries as the
+  budget and waits `schedule[attempt]` via the injected clock between attempts;
+  exhaustion routes to the dead-letter slice.
+- **`ConsumerBase`**: a subscription carrying `BrokerDelaySchedule` runs in
+  single-attempt pass-through mode (`brokerDelayPassthrough`). The handler's
+  verdict (Ack/Requeue/Reject) is returned verbatim and the transport owns the
+  retry budget, the per-attempt delay, and the final DLX routing. ConsumerBase
+  must NOT stack its own exponential backoff nor convert the transient `Requeue`
+  into a retry-exhausted `Reject` — doing so would dead-letter the entry on the
+  first failure and bypass the schedule.
+- **Cross-transport guard**: the shared `outboxtest`
+  `DelayedRedeliveryHonorsSchedule` conformance feature is mandatory for every
+  requeue-supporting Subscriber (it passes a custom short schedule and asserts
+  the exact delivery count + cumulative delay), so a transport that ignored
+  `BrokerDelaySchedule` fails CI rather than silently degrading to immediate
+  retry. The new `Subscription` field is locked by `SUBSCRIPTION-FIELDS-FROZEN-01`.
 
-The exact per-attempt wall-clock delays (5 s → 5 min → 30 min → 2 h → 5 h →
-10 h → 10 h, totalling approximately 40 h) are therefore **NOT honoured at
-runtime**. Honouring the full Svix timeline requires broker-level delayed
-re-delivery (e.g. RabbitMQ `x-delayed-message`, a delayed queue, or a
-scheduler) that GoCell does not yet wire for the dispatch consumer.
+**Threat / safety re-evaluation.** The 30 s ConsumerBase ceiling no longer
+applies to webhook dispatch; the full ~40 h Svix envelope is realized.
+At-least-once delivery is unchanged: the delay round-trip **releases (does not
+commit)** the idempotency receipt, so the redelivered same-`entry.ID` message
+re-claims and the handler re-runs — downstream handlers must remain idempotent
+(already required). No new wire field or PII surface is introduced;
+`x-webhook-attempt` is internal broker metadata, never part of the signed
+payload. `RetrySchedule.DelayFor` / `Delays()` remain the single source of the
+tier values.
 
-This gap is **deliberate and explicitly tracked**, not silent. `DefaultSvixSchedule`
-is retained as the canonical default because honouring the full Svix timeline
-is a real future need: `RetrySchedule.DelayFor(n int)` is exactly the per-retry
-delay seam the broker-delay wiring will consume. Removing the schedule now and
-re-adding it later would be churn with no benefit.
+---
 
-The follow-up work — broker-delay long-schedule wiring for the dispatch consumer
-(extend `ConsumerBase` per-attempt delay, or replace with a delay-aware relay
-that calls `DelayFor(attemptNumber)`) — is tracked at **gh #1458**.
-
-The `RetrySchedule` godoc (`kernel/webhook/retry.go`) also states this gap
-explicitly.
+**Historical context (PR-5).** PR-5 shipped `DefaultSvixSchedule` as the
+canonical default and `RetrySchedule.DelayFor`/`Delays()` as the documented
+seam, but did **not** wire per-attempt delays at runtime: the dispatch consumer
+rode the shared `kernel/outbox.ConsumerBase` whose in-process exponential
+backoff is capped at 30 s and cannot hold a 10 h delay across restarts. That
+gap was deliberate and tracked at #1458 — now resolved by the mechanism above.
 
 ## Consequences
 
-- **Runtime dispatch consumer** (`runtime/webhook/dispatch`) rides the shared
-  `ConsumerBase` with its default exponential back-off (capped at 30 s per
-  retry interval). PR-5 does NOT set a per-dispatcher `ConsumerBaseConfig.RetryCount`
-  from the schedule — `DefaultSvixSchedule` is the canonical default and the
-  seam for the broker-delay follow-up (gh #1458), not yet runtime-honored.
+- **Runtime dispatch consumer** (`runtime/webhook/dispatch`) sources
+  `DefaultSvixSchedule().Delays()` onto `outbox.Subscription.BrokerDelaySchedule`;
+  the Subscriber honours the per-attempt schedule via broker-native delayed
+  re-delivery (#1458, see D5). `ConsumerBase` runs delayed subscriptions in
+  single-attempt pass-through mode, so its 30 s backoff ceiling does not apply to
+  webhook dispatch.
 - **Permanent failures** (amended 2026-06-02) are now only: SSRF-blocked target,
   a selector that signals `ErrWebhookPermanentFailure` (no subscription
   configured), signing failure, delivery-id derivation failure, and URL
@@ -209,19 +234,18 @@ explicitly.
   no longer permanent** — they are retried (review #1455 F3).
 - **Transient failures** — every non-2xx delivery response (3xx/4xx/5xx) and all
   non-SSRF transport errors (DNS resolution failure, timeout, connection
-  refused) — trigger `ConsumerBase` retry with default backoff; on budget
-  exhaustion they are escalated to Reject → DLX. A generic target-selector error
-  is also transient (review #1455 F2): a store/config hiccup retries rather than
-  dead-lettering.
+  refused) — are retried on the Svix per-attempt schedule (#1458); on budget
+  exhaustion (`attempt > len(schedule)`) they are escalated to Reject → DLX. A
+  generic target-selector error is also transient (review #1455 F2): a
+  store/config hiccup retries rather than dead-lettering.
 - **Wire protocol**: receivers that verify GoCell outbound webhooks must use the
   `webhook-id` / `webhook-timestamp` / `webhook-signature` header names, not
   `svix-*`. GoCell's example receiver (`kernel/webhook.Verifier`) already uses
   these names.
-- **Broker-delay gap (tracked gh #1458)**: until the follow-up lands, deliveries
-  exhaust their retry budget faster than the 40 h Svix envelope because
-  ConsumerBase back-off is capped at 30 s per interval rather than honouring
-  the schedule's 2 h / 5 h / 10 h steps. `RetrySchedule.DelayFor` is the seam
-  that follow-up will consume.
+- **Broker-delay (resolved, gh #1458)**: deliveries now honour the full ~40 h
+  Svix envelope (5 s → 5 min → 30 min → 2 h → 5 h → 10 h → 10 h) via TTL+DLX
+  delay-tier queues (rabbitmq) and the clock-timed schedule (in-memory bus),
+  durable across restarts. See D5 for the mechanism and threat re-evaluation.
 
 ## References
 

--- a/docs/ops/rabbitmq-webhook-delay-topology.md
+++ b/docs/ops/rabbitmq-webhook-delay-topology.md
@@ -53,12 +53,25 @@ The tier `x-message-ttl` values are baked into the queue declaration. RabbitMQ d
 **not** allow redeclaring an existing queue with different arguments, so changing the
 schedule (today fixed at `DefaultSvixSchedule`) and redeploying will fail
 `QueueDeclare` with **406 PRECONDITION_FAILED** — a non-recoverable error that stops
-the affected webhook-dispatch subscription. To apply a new schedule:
+the affected webhook-dispatch subscription.
 
-1. Stop the dispatcher (or the whole service).
-2. Delete the old tier queues: `rabbitmqctl delete_queue Q.delay.0 … Q.delay.N`
-   (and `Q.delay` exchange if the tier count changed).
-3. Redeploy — the subscriber re-declares the queues with the new TTLs.
+> ⚠️ A non-empty `*.delay.<i>` queue holds **webhooks still waiting out their retry
+> interval** (see "Identifying these queues"), not garbage. Deleting it drops those
+> pending retries on the floor — the webhook is never re-attempted. **Drain before
+> you delete.**
 
-The subscriber surfaces a hint in the `declare delay tier queue` error message when
-it hits 406.
+To apply a new schedule **without losing in-flight retries**:
+
+1. Stop the dispatcher (or the whole service) so no new messages enter the tiers.
+2. For every old tier queue, confirm depth is **0**:
+   `rabbitmqctl list_queues name messages | grep '\.delay\.'`.
+   If any tier is non-empty, drain it first — shovel/republish the waiting messages
+   to the dispatch exchange `X` (an immediate re-attempt) or to the real DLX for
+   manual handling — and re-check until every tier reads 0.
+3. Only once every tier reads 0, delete the old tier queues:
+   `rabbitmqctl delete_queue Q.delay.0 … Q.delay.N` (and the `Q.delay` exchange if
+   the tier count changed).
+4. Redeploy — the subscriber re-declares the queues with the new TTLs.
+
+The subscriber surfaces a 406 hint in the `declare delay tier queue` error message
+that points back to this runbook.

--- a/docs/ops/rabbitmq-webhook-delay-topology.md
+++ b/docs/ops/rabbitmq-webhook-delay-topology.md
@@ -32,6 +32,26 @@ back to `X` → `Q` and is re-consumed. The attempt counter rides the
 payload). Once the attempt exceeds the schedule length the entry is
 `Nack(requeue=false)` → the queue's **real DLX**.
 
+## Reliability (classic-queue caveat)
+
+The subscriber republishes to a delay tier with **publisher confirms** and Acks
+the original delivery only after the broker confirms the copy, so the
+application-side hop does not lose messages on a channel/broker drop. The delay
+queues are **classic** queues, however, and RabbitMQ's broker-internal
+TTL→dead-letter republish on a classic queue is **best-effort** (the internal hop
+is not publisher-confirmed):
+
+- **Single-node broker** — reliable; the durable queue holds the message until TTL
+  expiry and the internal dead-letter re-enters the dispatch queue.
+- **Multi-node cluster** — a node failure *during* the internal TTL→DLX republish
+  can drop that one scheduled retry. The next business event or a manual replay
+  recovers it (webhook handlers are idempotent), so a missed retry is degraded —
+  not corrupting — behaviour.
+
+Upgrading the delay tiers to **quorum queues with at-least-once dead-lettering**
+to close the cluster gap is tracked at **#1835**. Until then, treat clustered
+webhook retry as at-least-once-best-effort on the internal hop.
+
 ## Identifying these queues
 
 - Name pattern: `*.delay` (exchange) and `*.delay.<tier-index>` (queues), where the

--- a/docs/ops/rabbitmq-webhook-delay-topology.md
+++ b/docs/ops/rabbitmq-webhook-delay-topology.md
@@ -1,0 +1,64 @@
+# RabbitMQ webhook delay-tier topology (ops)
+
+Webhook dispatch honours the Svix per-attempt retry schedule (5s/5min/30min/2h/5h/10h/10h)
+via broker-native delayed re-delivery (#1458, ADR `202606012052-1160-adr-webhook-retry-default.md`
+§D5). Operators will see **extra RabbitMQ queues and an exchange per webhook-dispatch
+subscription** — this doc explains them.
+
+## Topology
+
+For a webhook-dispatch subscription whose dispatch queue is `Q` (derived from
+`{consumerGroup}` + topic) bound to dispatch exchange `X` (the contract-ID topic):
+
+```
+X (fanout, dispatch) ──► Q (dispatch queue; x-dead-letter-exchange = real DLX)
+                          └─ consumer: webhook dispatcher (signs + POSTs)
+
+Q.delay (direct, the delay exchange)
+  ├─ rk "0" ─► Q.delay.0   x-message-ttl = 5s,    no consumer, x-dead-letter-exchange = X
+  ├─ rk "1" ─► Q.delay.1   x-message-ttl = 5min,  …
+  ├─ rk "2" ─► Q.delay.2   x-message-ttl = 30min
+  ├─ rk "3" ─► Q.delay.3   x-message-ttl = 2h
+  ├─ rk "4" ─► Q.delay.4   x-message-ttl = 5h
+  ├─ rk "5" ─► Q.delay.5   x-message-ttl = 10h
+  └─ rk "6" ─► Q.delay.6   x-message-ttl = 10h
+```
+
+All `Q.delay*` queues are **durable** (the ~40h envelope survives broker/process
+restart — no `x-delayed-message` plugin is used). On the Nth POST failure the
+subscriber republishes to `Q.delay.{N-1}`; on TTL expiry the message dead-letters
+back to `X` → `Q` and is re-consumed. The attempt counter rides the
+`x-webhook-attempt` AMQP header (broker-internal; never part of the signed HTTP
+payload). Once the attempt exceeds the schedule length the entry is
+`Nack(requeue=false)` → the queue's **real DLX**.
+
+## Identifying these queues
+
+- Name pattern: `*.delay` (exchange) and `*.delay.<tier-index>` (queues), where the
+  prefix matches the dispatch queue name.
+- A delay-tier queue has **no consumer** and a non-zero `x-message-ttl`; messages
+  sit there until TTL expiry, so a non-empty `*.delay.*` queue is normal (deliveries
+  waiting out their retry interval), **not** a stuck consumer.
+
+## Monitoring
+
+- Sustained growth of `*.delay.6` (the 10h tail) or messages landing in the real DLX
+  indicates an endpoint that is persistently failing — inspect the DLX and the
+  `webhook_deliveries_total{result="..."}` metric.
+- The delay queues are bounded per subscription (one queue per schedule tier).
+
+## Changing the schedule (PRECONDITION_FAILED / 406)
+
+The tier `x-message-ttl` values are baked into the queue declaration. RabbitMQ does
+**not** allow redeclaring an existing queue with different arguments, so changing the
+schedule (today fixed at `DefaultSvixSchedule`) and redeploying will fail
+`QueueDeclare` with **406 PRECONDITION_FAILED** — a non-recoverable error that stops
+the affected webhook-dispatch subscription. To apply a new schedule:
+
+1. Stop the dispatcher (or the whole service).
+2. Delete the old tier queues: `rabbitmqctl delete_queue Q.delay.0 … Q.delay.N`
+   (and `Q.delay` exchange if the tier count changed).
+3. Redeploy — the subscriber re-declares the queues with the new TTLs.
+
+The subscriber surfaces a hint in the `declare delay tier queue` error message when
+it hits 406.

--- a/kernel/cell/registry.go
+++ b/kernel/cell/registry.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/cellvocab"
@@ -464,9 +465,13 @@ func WithSubscriptionSliceID(sliceID string) SubscriptionOption {
 // WithSubscriptionBrokerDelaySchedule opts the subscription into broker-native
 // delayed re-delivery with the given per-attempt wait schedule (#1458). Empty or
 // nil is a no-op (immediate-requeue behavior is preserved).
+//
+// The slice is cloned so a caller that mutates its backing array after
+// registration cannot retroactively alter the runtime delay topology (the
+// recorded SubscriptionRequest owns an independent copy).
 func WithSubscriptionBrokerDelaySchedule(delays []time.Duration) SubscriptionOption {
 	return func(r *SubscriptionRequest) {
-		r.BrokerDelaySchedule = delays
+		r.BrokerDelaySchedule = slices.Clone(delays)
 	}
 }
 

--- a/kernel/cell/registry.go
+++ b/kernel/cell/registry.go
@@ -443,6 +443,12 @@ type SubscriptionRequest struct {
 	// ref: ThreeDotsLabs/watermill router.AddHandler handlerName / NATS subscription metadata.
 	// ref: ADR docs/architecture/202605111000-adr-subscription-cellid-mandatory.md
 	CellID string
+
+	// BrokerDelaySchedule opts the subscription into broker-native delayed
+	// re-delivery (#1458). It flows through to outbox.Subscription.BrokerDelaySchedule;
+	// see that field for semantics. Empty for ordinary event subscriptions;
+	// the webhook-dispatch drain sets it to DefaultSvixSchedule().Delays().
+	BrokerDelaySchedule []time.Duration
 }
 
 // SubscriptionOption mutates a SubscriptionRequest to attach optional metadata.
@@ -452,6 +458,15 @@ type SubscriptionOption func(*SubscriptionRequest)
 func WithSubscriptionSliceID(sliceID string) SubscriptionOption {
 	return func(r *SubscriptionRequest) {
 		r.SliceID = sliceID
+	}
+}
+
+// WithSubscriptionBrokerDelaySchedule opts the subscription into broker-native
+// delayed re-delivery with the given per-attempt wait schedule (#1458). Empty or
+// nil is a no-op (immediate-requeue behavior is preserved).
+func WithSubscriptionBrokerDelaySchedule(delays []time.Duration) SubscriptionOption {
+	return func(r *SubscriptionRequest) {
+		r.BrokerDelaySchedule = delays
 	}
 }
 

--- a/kernel/cell/registry_test.go
+++ b/kernel/cell/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,6 +290,32 @@ func TestRegistry_Subscribe_HappyPath_AppendsToSnapshot(t *testing.T) {
 	assert.Equal(t, "ordercell", snap.Subscriptions[0].CellID)
 	assert.Equal(t, "order-slice", snap.Subscriptions[0].SliceID)
 	assert.NotNil(t, snap.Subscriptions[0].Handler)
+}
+
+// ---------------------------------------------------------------------------
+// TestWithSubscriptionBrokerDelaySchedule_ClonesInput (F8)
+// ---------------------------------------------------------------------------
+
+func TestWithSubscriptionBrokerDelaySchedule_ClonesInput(t *testing.T) {
+	rec := NewRegistryRecorder(nil, outbox.DurabilityDurable)
+
+	delays := []time.Duration{time.Second, 5 * time.Second}
+	spec := testRegistrySpec("order.placed")
+	err := rec.Subscribe(spec, noopHandler, "cg-order", "ordercell",
+		WithSubscriptionBrokerDelaySchedule(delays))
+	require.NoError(t, err)
+
+	// Mutating the caller's backing array after registration must NOT alter the
+	// recorded subscription — the option clones its input so the runtime delay
+	// topology cannot be retroactively rewritten.
+	delays[0] = 99 * time.Hour
+
+	snap := rec.Snapshot()
+	require.Len(t, snap.Subscriptions, 1)
+	got := snap.Subscriptions[0].BrokerDelaySchedule
+	require.Len(t, got, 2)
+	assert.Equal(t, time.Second, got[0], "post-registration caller mutation must not leak into the recorded schedule")
+	assert.Equal(t, 5*time.Second, got[1])
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/cell/registry_test.go
+++ b/kernel/cell/registry_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/webhook"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 // TestAuthRouteMeta_ListenerAffinity pins the path-prefix predicates that the
@@ -299,7 +300,7 @@ func TestRegistry_Subscribe_HappyPath_AppendsToSnapshot(t *testing.T) {
 func TestWithSubscriptionBrokerDelaySchedule_ClonesInput(t *testing.T) {
 	rec := NewRegistryRecorder(nil, outbox.DurabilityDurable)
 
-	delays := []time.Duration{time.Second, 5 * time.Second}
+	delays := []time.Duration{testtime.D1s, testtime.D5s}
 	spec := testRegistrySpec("order.placed")
 	err := rec.Subscribe(spec, noopHandler, "cg-order", "ordercell",
 		WithSubscriptionBrokerDelaySchedule(delays))
@@ -308,14 +309,14 @@ func TestWithSubscriptionBrokerDelaySchedule_ClonesInput(t *testing.T) {
 	// Mutating the caller's backing array after registration must NOT alter the
 	// recorded subscription — the option clones its input so the runtime delay
 	// topology cannot be retroactively rewritten.
-	delays[0] = 99 * time.Hour
+	delays[0] = testtime.D24h
 
 	snap := rec.Snapshot()
 	require.Len(t, snap.Subscriptions, 1)
 	got := snap.Subscriptions[0].BrokerDelaySchedule
 	require.Len(t, got, 2)
-	assert.Equal(t, time.Second, got[0], "post-registration caller mutation must not leak into the recorded schedule")
-	assert.Equal(t, 5*time.Second, got[1])
+	assert.Equal(t, testtime.D1s, got[0], "post-registration caller mutation must not leak into the recorded schedule")
+	assert.Equal(t, testtime.D5s, got[1])
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -371,6 +371,8 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 	topic := sub.Topic
 	consumerGroup := sub.ConsumerGroup
 	cellID := sub.CellID
+	passthrough := cb.brokerDelayPassthrough(sub)
+	dims := deliveryDims{cellID: cellID, consumerGroup: consumerGroup, topic: topic}
 	return func(ctx context.Context, entry Entry) (DeliveryOutcome, Settlement) {
 		idempotencyKey := fmt.Sprintf("%s:%s", consumerGroup, entry.id)
 
@@ -383,9 +385,9 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 					slog.String(logKeyTopic, topic),
 					slog.String(logKeyConsumerGroup, consumerGroup),
 					slog.Any("error", err))
-				return cb.retryLoop(ctx, cellID, consumerGroup, topic, entry, handler), nil
+				return cb.retryLoop(ctx, cellID, consumerGroup, topic, entry, handler, passthrough), nil
 			}
-			return cb.handleClaimState(ctx, deliveryDims{cellID: cellID, consumerGroup: consumerGroup, topic: topic}, entry, handler, state, receipt)
+			return cb.handleClaimState(ctx, dims, entry, handler, state, receipt, passthrough)
 		}
 
 		// Fail-closed: claimWithRetry handles all attempts with backoff + jitter.
@@ -399,8 +401,20 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 				slog.Any("error", err))
 			return deliveryFrom(Requeue(err)), nil
 		}
-		return cb.handleClaimState(ctx, deliveryDims{cellID: cellID, consumerGroup: consumerGroup, topic: topic}, entry, handler, state, receipt)
+		return cb.handleClaimState(ctx, dims, entry, handler, state, receipt, passthrough)
 	}
+}
+
+// brokerDelayPassthrough reports whether the subscription delegates retry timing
+// to a broker/in-memory delay schedule (#1458). When true, ConsumerBase runs the
+// handler exactly once and returns its verdict verbatim — it must NOT run its own
+// in-process retry loop, and crucially must NOT convert a transient Requeue into
+// the retry-exhausted Reject, because the transport (rabbitmq TTL+DLX delay
+// tiers / in-memory schedule) owns the per-attempt delay, the retry budget, and
+// the final DLX routing. Stacking ConsumerBase's exhaustion logic here would
+// dead-letter the entry on the first failure and bypass the delay schedule.
+func (cb *ConsumerBase) brokerDelayPassthrough(sub Subscription) bool {
+	return len(sub.BrokerDelaySchedule) > 0
 }
 
 // claimWithRetry attempts Claimer.Claim up to ClaimRetryCount times with
@@ -490,8 +504,9 @@ func (cb *ConsumerBase) handleClaimState(
 	handler EntryHandler,
 	state idempotency.ClaimState,
 	receipt idempotency.Receipt,
+	passthrough bool,
 ) (DeliveryOutcome, Settlement) {
-	cellID, consumerGroup, topic := dims.cellID, dims.consumerGroup, dims.topic
+	topic := dims.topic
 	switch state {
 	case idempotency.ClaimDone:
 		logWithContext(ctx, slog.LevelDebug, "outbox: event already processed, skipping",
@@ -514,7 +529,7 @@ func (cb *ConsumerBase) handleClaimState(
 		return deliveryFrom(Requeue(nil)), nil
 	default:
 		// ClaimAcquired -- start lease-renewal goroutine before invoking handler.
-		result := cb.runWithRenewal(ctx, cellID, consumerGroup, topic, entry, handler, receipt)
+		result := cb.runWithRenewal(ctx, dims, entry, handler, receipt, passthrough)
 		return result, receipt
 	}
 }
@@ -578,7 +593,16 @@ func (cb *ConsumerBase) retryLoop(
 	topic string,
 	entry Entry,
 	handler EntryHandler,
+	passthrough bool,
 ) DeliveryOutcome {
+	if passthrough {
+		// Broker-delay subscriptions (#1458): the transport owns retry timing,
+		// the retry budget, and DLX routing, so run the handler exactly once and
+		// return its verdict verbatim. Crucially this skips the retry-exhausted
+		// → Reject conversion below: a transient Requeue must reach the subscriber
+		// as a Requeue so it can apply the per-attempt delay, not be dead-lettered.
+		return deliveryFrom(handler(ctx, entry))
+	}
 	var lastResult HandleResult
 	for attempt := range cb.config.RetryCount {
 		lastResult = handler(ctx, entry)
@@ -659,17 +683,16 @@ func (cb *ConsumerBase) retryLoop(
 // Cognitive complexity is kept ≤15 by delegating the ticker loop to leaseRenewalLoop.
 func (cb *ConsumerBase) runWithRenewal(
 	ctx context.Context,
-	cellID string,
-	consumerGroup string,
-	topic string,
+	dims deliveryDims,
 	entry Entry,
 	handler EntryHandler,
 	receipt idempotency.Receipt,
+	passthrough bool,
 ) DeliveryOutcome {
 	interval := cb.config.LeaseRenewalInterval
 	// Skip renewal when disabled (negative) or receipt is nil.
 	if interval <= 0 || receipt == nil {
-		return cb.retryLoop(ctx, cellID, consumerGroup, topic, entry, handler)
+		return cb.retryLoop(ctx, dims.cellID, dims.consumerGroup, dims.topic, entry, handler, passthrough)
 	}
 
 	var leaseLost atomic.Bool
@@ -680,13 +703,13 @@ func (cb *ConsumerBase) runWithRenewal(
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		cb.leaseRenewalLoop(renewCtx, topic, entry, receipt, interval, func() {
+		cb.leaseRenewalLoop(renewCtx, dims.topic, entry, receipt, interval, func() {
 			leaseLost.Store(true)
 			cancelRenew()
 		})
 	}()
 
-	result := cb.retryLoop(renewCtx, cellID, consumerGroup, topic, entry, handler)
+	result := cb.retryLoop(renewCtx, dims.cellID, dims.consumerGroup, dims.topic, entry, handler, passthrough)
 
 	// Signal the renewal goroutine to stop and wait for it.
 	cancelRenew()
@@ -700,7 +723,7 @@ func (cb *ConsumerBase) runWithRenewal(
 	if leaseLost.Load() && result.Disposition == DispositionAck {
 		logWithContext(ctx, slog.LevelWarn, "outbox: lease lost during processing, downgrading Ack to Requeue (hard fence)",
 			slog.String(logKeyEventID, entry.id),
-			slog.String(logKeyTopic, topic))
+			slog.String(logKeyTopic, dims.topic))
 		return DeliveryOutcome{
 			Disposition:   DispositionRequeue,
 			Err:           idempotency.ErrLeaseExpired,

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -504,6 +504,54 @@ func TestConsumerBase_Wrap_ExplicitReject_NoRetry(t *testing.T) {
 	assert.Same(t, receipt, settlement)
 }
 
+// TestConsumerBase_Wrap_BrokerDelaySchedule_PassesThroughVerbatim locks the
+// #1458 invariant: a subscription carrying a BrokerDelaySchedule delegates retry
+// timing/budget/DLX to the transport, so ConsumerBase runs the handler EXACTLY
+// ONCE and returns its verdict verbatim — even with RetryCount=3. Crucially a
+// transient Requeue must NOT be converted into the retry-exhausted Reject (which
+// would dead-letter the entry on the first failure and bypass the delay
+// schedule); it must reach the subscriber as a Requeue so the broker/in-memory
+// schedule can apply the per-attempt delay.
+func TestConsumerBase_Wrap_BrokerDelaySchedule_PassesThroughVerbatim(t *testing.T) {
+	tests := []struct {
+		name   string
+		result HandleResult
+		want   Disposition
+	}{
+		{"requeue passes through, not exhaustion-reject", Requeue(errors.New("transient")), DispositionRequeue},
+		{"ack passes through", Ack(), DispositionAck},
+		{"reject passes through", Reject(errors.New("permanent")), DispositionReject},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receipt := &fakeReceipt{}
+			claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+			cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+				RetryCount:     3,
+				RetryBaseDelay: time.Millisecond,
+			}, clock.Real())
+			require.NoError(t, err)
+
+			attempts := 0
+			sub := Subscription{
+				Topic:               "topic",
+				ConsumerGroup:       "cg",
+				BrokerDelaySchedule: []time.Duration{time.Second, time.Minute},
+			}
+			handler := cb.Wrap(sub, func(_ context.Context, _ Entry) HandleResult {
+				attempts++
+				return tt.result
+			})
+
+			res, settlement := handler(context.Background(), Entry{id: "evt-broker-delay"})
+			assert.Equal(t, 1, attempts, "broker-delay sub must invoke the handler exactly once (transport owns retries)")
+			assert.Equal(t, tt.want, res.Disposition)
+			assert.Same(t, receipt, settlement)
+		})
+	}
+}
+
 // TestConsumerBase_Wrap_WrappedPermanentErrorInRequeue_NotEscalated locks the
 // Q2 decision (029 #03 ADR Decision 4): when a handler returns Requeue with a
 // PermanentError-wrapped Err, ConsumerBase MUST keep the Disposition as

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -560,6 +560,15 @@ func testZeroValueDisposition(t *testing.T, features Features, constructor PubSu
 	h.teardown()
 }
 
+// deadLetterInspector is an optional capability a Subscriber may implement to let
+// conformance assert that a retry-exhausted entry actually reached the
+// dead-letter store. The in-memory bus implements it (DeadLetterLen); transports
+// whose DLQ is only observable by consuming it (rabbitmq) leave it unimplemented
+// and verify the same property in a dedicated broker integration test.
+type deadLetterInspector interface {
+	DeadLetterLen() int
+}
+
 // testDelayedRedeliveryHonorsSchedule verifies that a subscription carrying a
 // BrokerDelaySchedule (#1458) redelivers a transient failure on the per-attempt
 // schedule and stops after the schedule is exhausted (routing to DLX /
@@ -630,6 +639,18 @@ func testDelayedRedeliveryHonorsSchedule(t *testing.T, features Features, constr
 	case <-delivered:
 		t.Fatalf("broker-delay: received more than %d deliveries — retry budget not bounded by the schedule", wantDeliveries)
 	case <-time.After(negativeAssertionWindow):
+	}
+
+	// The exhausted entry must land in dead-letter, not silently vanish. A
+	// delivery-count assertion alone would pass even if the final
+	// Nack(requeue=false) dropped the message because of a DLX binding/routing
+	// fault. Transports that expose their dead-letter store (the in-memory bus
+	// via DeadLetterLen) are checked here; transports whose DLQ is only observable
+	// by consuming it (rabbitmq) verify this in a dedicated broker integration test.
+	if dli, ok := sub.(deadLetterInspector); ok {
+		assertEventually(t, func() bool { return dli.DeadLetterLen() >= 1 },
+			defaultTimeout, subscribeReadyTimeout,
+			"broker-delay: exhausted entry must be routed to dead-letter, not dropped")
 	}
 
 	cancel()

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -65,6 +65,13 @@ const negativeAssertionWindow = 200 * time.Millisecond
 // per-tier queue TTL).
 const delayedTier = 60 * time.Millisecond
 
+// delayedMinSpan is the lower bound on the cumulative span across the delayed
+// attempts in testDelayedRedeliveryHonorsSchedule (#1458) — at least two tiers'
+// worth of real wait. A no-delay implementation would deliver all attempts
+// near-instantly and fall below this floor. (Package-level const per
+// TEST-TIME-LITERAL-01: no inline duration arithmetic in the test body.)
+const delayedMinSpan = 2 * delayedTier
+
 // asDelivery converts a slim HandleResult from Ack/Requeue/Reject factory
 // functions to a DeliveryOutcome for use in SubscriberHandler closures.
 // Only for use in conformance test helpers where the test author knows the
@@ -634,12 +641,11 @@ func testDelayedRedeliveryHonorsSchedule(t *testing.T, features Features, constr
 	defer mu.Unlock()
 	assertLen(t, len(stamps), wantDeliveries,
 		"broker-delay: handler must be invoked exactly once per scheduled attempt")
-	// Delays were actually applied: the span across attempts is at least a
-	// generous fraction of the schedule sum (a no-delay impl delivers near-instantly).
+	// Delays were actually applied: the span across attempts clears the
+	// delayedMinSpan floor (a no-delay impl delivers near-instantly).
 	span := stamps[len(stamps)-1].Sub(stamps[0])
-	minSpan := (delayedTier * time.Duration(len(tiers))) * 2 / 3
-	assertTrue(t, span >= minSpan,
-		fmt.Sprintf("broker-delay: attempts spanned %s, expected >= %s (schedule delays not applied)", span, minSpan))
+	assertTrue(t, span >= delayedMinSpan,
+		fmt.Sprintf("broker-delay: attempts spanned %s, expected >= %s (schedule delays not applied)", span, delayedMinSpan))
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/outbox/outboxtest/conformance.go
+++ b/kernel/outbox/outboxtest/conformance.go
@@ -58,6 +58,13 @@ const subscribeReadyTimeout = 50 * time.Millisecond
 // rather than tweaking individual tests.
 const negativeAssertionWindow = 200 * time.Millisecond
 
+// delayedTier is the per-attempt wait used by testDelayedRedeliveryHonorsSchedule
+// (#1458). Short enough for a fast test, long enough that the cumulative span
+// across attempts is an unambiguous signal that the per-attempt schedule delays
+// were applied — on both the in-memory bus (clock-timed) and rabbitmq (real
+// per-tier queue TTL).
+const delayedTier = 60 * time.Millisecond
+
 // asDelivery converts a slim HandleResult from Ack/Requeue/Reject factory
 // functions to a DeliveryOutcome for use in SubscriberHandler closures.
 // Only for use in conformance test helpers where the test author knows the
@@ -131,6 +138,9 @@ func RunBatch2Disposition(t *testing.T, features Features, constructor PubSubCon
 	})
 	t.Run("ZeroValueDisposition", func(t *testing.T) {
 		testZeroValueDisposition(t, features, constructor)
+	})
+	t.Run("DelayedRedeliveryHonorsSchedule", func(t *testing.T) {
+		testDelayedRedeliveryHonorsSchedule(t, features, constructor)
 	})
 }
 
@@ -541,6 +551,95 @@ func testZeroValueDisposition(t *testing.T, features Features, constructor PubSu
 	assertTrue(t, callCount.Load() >= 2,
 		"zero-value Disposition should be treated as requeue (safe degradation)")
 	h.teardown()
+}
+
+// testDelayedRedeliveryHonorsSchedule verifies that a subscription carrying a
+// BrokerDelaySchedule (#1458) redelivers a transient failure on the per-attempt
+// schedule and stops after the schedule is exhausted (routing to DLX /
+// dead-letter), instead of using the transport's built-in backoff + retry
+// budget. It is the cross-transport guard that keeps rabbitmq (TTL+DLX
+// delay-tier queues) and the in-memory bus (clock-timed schedule) honoring the
+// same Svix timeline: a transport that ignored BrokerDelaySchedule would deliver
+// a different number of times (its own budget — or, for a bare broker requeue,
+// unbounded) and fail the exact-count assertion. Mandatory for every
+// requeue-supporting transport (no opt-out flag).
+func testDelayedRedeliveryHonorsSchedule(t *testing.T, features Features, constructor PubSubConstructor) {
+	if !features.SupportsRequeue {
+		t.Skip("implementation does not support requeue")
+	}
+
+	pub, sub := constructor(t)
+	ctx := t.Context()
+	topic := TestTopic(t)
+
+	// 3 tiers → 4 deliveries (the immediate attempt + one retry per tier); then
+	// the budget is exhausted and the entry routes to DLX/dead-letter (no further
+	// delivery). 4 differs from the transports' built-in retry budgets, so a
+	// transport that ignored BrokerDelaySchedule fails the exact-count assertion.
+	tiers := []time.Duration{delayedTier, delayedTier, delayedTier}
+	wantDeliveries := len(tiers) + 1
+
+	var (
+		mu        sync.Mutex
+		stamps    []time.Time
+		delivered = make(chan struct{}, deliveryEventsBuffer)
+	)
+
+	subCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	subDone := make(chan struct{})
+	go func() {
+		defer close(subDone)
+		_ = sub.Subscribe(subCtx, outbox.Subscription{
+			Topic:               topic,
+			ConsumerGroup:       conformanceCG,
+			CellID:              conformanceCG,
+			BrokerDelaySchedule: tiers,
+		}, func(_ context.Context, _ outbox.Entry) (outbox.DeliveryOutcome, outbox.Settlement) {
+			mu.Lock()
+			stamps = append(stamps, time.Now())
+			mu.Unlock()
+			select {
+			case delivered <- struct{}{}:
+			default:
+			}
+			return asDelivery(outbox.Requeue(fmt.Errorf("always transient"))), nil
+		})
+	}()
+	waitForSubscription(t, ctx, sub, topic, conformanceCG)
+
+	assertNoError(t, pub.Publish(ctx, topic, wrapV1Envelope(t, topic, []byte(`{"test":"broker-delay"}`))))
+
+	for i := range wantDeliveries {
+		select {
+		case <-delivered:
+		case <-time.After(defaultTimeout):
+			t.Fatalf("broker-delay: delivery %d of %d did not arrive within %s", i+1, wantDeliveries, defaultTimeout)
+		}
+	}
+	// Budget is bounded by the schedule: no delivery beyond wantDeliveries.
+	select {
+	case <-delivered:
+		t.Fatalf("broker-delay: received more than %d deliveries — retry budget not bounded by the schedule", wantDeliveries)
+	case <-time.After(negativeAssertionWindow):
+	}
+
+	cancel()
+	if err := awaitWithBudget(fmt.Sprintf("delayedRedelivery-join(topic=%q)", topic), subDone, defaultTimeout); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertLen(t, len(stamps), wantDeliveries,
+		"broker-delay: handler must be invoked exactly once per scheduled attempt")
+	// Delays were actually applied: the span across attempts is at least a
+	// generous fraction of the schedule sum (a no-delay impl delivers near-instantly).
+	span := stamps[len(stamps)-1].Sub(stamps[0])
+	minSpan := (delayedTier * time.Duration(len(tiers))) * 2 / 3
+	assertTrue(t, span >= minSpan,
+		fmt.Sprintf("broker-delay: attempts spanned %s, expected >= %s (schedule delays not applied)", span, minSpan))
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/outbox/subscription.go
+++ b/kernel/outbox/subscription.go
@@ -1,6 +1,10 @@
 package outbox
 
-import "github.com/ghbvf/gocell/pkg/errcode"
+import (
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
 
 // Subscription describes the full identity of a single subscription intent.
 // It is the first-class object passed through the middleware chain, ensuring
@@ -48,6 +52,20 @@ type Subscription struct {
 	ContractID        string
 	ContractKind      string
 	ContractTransport string
+
+	// BrokerDelaySchedule, when non-empty, opts this subscription into
+	// broker-native delayed re-delivery (#1458): delays[i] is the wait before
+	// retry i+1. A transient failure (DispositionRequeue) is redelivered after
+	// delays[attempt-1] — rabbitmq via a per-tier TTL+DLX delay queue, the
+	// in-memory bus via a clock-timed wait — and routed to DLX/dead-letter once
+	// the attempt count exceeds len(delays). Empty (the zero value, and the case
+	// for every non-webhook subscription) preserves the existing
+	// immediate-requeue behavior. Carried as transport-neutral []time.Duration
+	// (sourced from kernel/webhook.DefaultSvixSchedule().Delays()) so adapters
+	// need not import kernel/webhook. Honored by every Subscriber implementation
+	// — enforced by the shared outboxtest DelayedRedelivery conformance feature,
+	// not by an opt-in capability flag.
+	BrokerDelaySchedule []time.Duration
 }
 
 // Validate returns an error when required fields are missing.

--- a/kernel/outbox/subscription.go
+++ b/kernel/outbox/subscription.go
@@ -93,6 +93,16 @@ func (s Subscription) Validate() error {
 	if s.ContractTransport == "" {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed, "outbox: subscription ContractTransport must not be empty")
 	}
+	// A non-empty BrokerDelaySchedule must carry only positive durations: each
+	// entry becomes a broker delay (rabbitmq writes d.Milliseconds() into
+	// x-message-ttl, the in-memory bus waits d), so a zero or negative tier would
+	// silently collapse the retry interval. Fail fast rather than mis-deliver.
+	for _, d := range s.BrokerDelaySchedule {
+		if d <= 0 {
+			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"outbox: subscription BrokerDelaySchedule entries must be positive durations")
+		}
+	}
 	return nil
 }
 

--- a/kernel/outbox/subscription_test.go
+++ b/kernel/outbox/subscription_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/testutil/testtime"
 )
 
 func TestSubscription_Validate(t *testing.T) {
@@ -65,19 +67,19 @@ func TestSubscription_Validate(t *testing.T) {
 		},
 		{
 			name:        "brokerDelaySchedule with zero duration",
-			mutate:      func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{time.Second, 0} },
+			mutate:      func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{testtime.D1s, 0} },
 			wantErr:     true,
 			errContains: "BrokerDelaySchedule",
 		},
 		{
 			name:        "brokerDelaySchedule with negative duration",
-			mutate:      func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{-time.Second} },
+			mutate:      func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{-testtime.D1s} },
 			wantErr:     true,
 			errContains: "BrokerDelaySchedule",
 		},
 		{
 			name:    "brokerDelaySchedule all positive",
-			mutate:  func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{time.Second, 5 * time.Second} },
+			mutate:  func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{testtime.D1s, testtime.D5s} },
 			wantErr: false,
 		},
 		{

--- a/kernel/outbox/subscription_test.go
+++ b/kernel/outbox/subscription_test.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +62,23 @@ func TestSubscription_Validate(t *testing.T) {
 			mutate:      func(s *Subscription) { s.ContractTransport = "" },
 			wantErr:     true,
 			errContains: "ContractTransport",
+		},
+		{
+			name:        "brokerDelaySchedule with zero duration",
+			mutate:      func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{time.Second, 0} },
+			wantErr:     true,
+			errContains: "BrokerDelaySchedule",
+		},
+		{
+			name:        "brokerDelaySchedule with negative duration",
+			mutate:      func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{-time.Second} },
+			wantErr:     true,
+			errContains: "BrokerDelaySchedule",
+		},
+		{
+			name:    "brokerDelaySchedule all positive",
+			mutate:  func(s *Subscription) { s.BrokerDelaySchedule = []time.Duration{time.Second, 5 * time.Second} },
+			wantErr: false,
 		},
 		{
 			name:    "valid",

--- a/kernel/webhook/retry.go
+++ b/kernel/webhook/retry.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/outbox"
@@ -13,13 +14,12 @@ import (
 // wait before retry i+1. The schedule is value-immutable: DefaultSvixSchedule
 // returns a fresh copy and there is no setter.
 //
-// PR-5 ships DefaultSvixSchedule as the canonical default and the seam for the
-// broker-delay follow-up (gh #1458). PR-5 does NOT wire per-attempt delays or a
-// per-dispatcher RetryCount at runtime: the dispatch consumer rides the shared
-// ConsumerBase (default exponential backoff, capped 30 s). Honoring the full
-// Svix timeline (up to ~40 h) needs broker-delay support; DelayFor is the seam
-// the follow-up will consume. The schedule is retained because that follow-up is
-// a real future need, not a dead abstraction.
+// DefaultSvixSchedule is the canonical default. The per-attempt wall-clock
+// delays ARE honored at runtime (gh #1458): the webhook-dispatch bootstrap
+// drain copies Delays() onto outbox.Subscription.BrokerDelaySchedule, and the
+// Subscriber applies broker-native delayed re-delivery (rabbitmq TTL+DLX
+// delay-tier queues / in-memory clock-timed schedule), durable across restarts.
+// DelayFor is the single-tier lookup; Delays is the bulk seam the wiring consumes.
 //
 // See docs/architecture/202606012052-1160-adr-webhook-retry-default.md §D5.
 type RetrySchedule struct {
@@ -68,6 +68,13 @@ func (s RetrySchedule) DelayFor(n int) (delay time.Duration, ok bool) {
 	}
 	return s.delays[n-1], true
 }
+
+// Delays returns a copy of the retry-delay tiers, in retry order (delays[i] is
+// the wait before retry i+1). It is the bulk-read seam the broker-delay wiring
+// (#1458) consumes to build per-tier delay queues / schedule-driven redelivery;
+// DelayFor remains the single-tier lookup. The slice is cloned so callers cannot
+// mutate the schedule's internal state.
+func (s RetrySchedule) Delays() []time.Duration { return slices.Clone(s.delays) }
 
 // Classify maps an outbound delivery outcome to an outbox.Disposition per the
 // webhook retry-default ADR (standard-webhooks / Svix aligned). Exactly one of

--- a/kernel/webhook/retry.go
+++ b/kernel/webhook/retry.go
@@ -73,7 +73,8 @@ func (s RetrySchedule) DelayFor(n int) (delay time.Duration, ok bool) {
 // the wait before retry i+1). It is the bulk-read seam the broker-delay wiring
 // (#1458) consumes to build per-tier delay queues / schedule-driven redelivery;
 // DelayFor remains the single-tier lookup. The slice is cloned so callers cannot
-// mutate the schedule's internal state.
+// mutate the schedule's internal state — call it once at wiring time (e.g. in
+// the dispatch consumer builder), not on the per-delivery hot path.
 func (s RetrySchedule) Delays() []time.Duration { return slices.Clone(s.delays) }
 
 // Classify maps an outbound delivery outcome to an outbox.Disposition per the

--- a/kernel/webhook/retry_test.go
+++ b/kernel/webhook/retry_test.go
@@ -64,6 +64,25 @@ func TestRetrySchedule_DelayFor_OutOfRange(t *testing.T) {
 	}
 }
 
+// TestRetrySchedule_Delays verifies the bulk-read accessor consumed by the
+// #1458 broker-delay wiring returns the full tier list in retry order and a
+// defensive copy (mutating the result must not affect the schedule).
+func TestRetrySchedule_Delays(t *testing.T) {
+	t.Parallel()
+	s := DefaultSvixSchedule()
+	want := []time.Duration{
+		goldenSvixDelay1, goldenSvixDelay2, goldenSvixDelay3, goldenSvixDelay4,
+		goldenSvixDelay5, goldenSvixDelay6, goldenSvixDelay7,
+	}
+	got := s.Delays()
+	assert.Equal(t, want, got, "Delays() must return the canonical tiers in retry order")
+
+	// Mutating the returned slice must not corrupt the schedule's internal state.
+	got[0] = time.Nanosecond
+	again := s.Delays()
+	assert.Equal(t, want, again, "Delays() must return a defensive copy")
+}
+
 func TestClassify(t *testing.T) {
 	t.Parallel()
 	ssrf := errcode.New(errcode.KindPermissionDenied, errcode.ErrWebhookSSRFBlocked, "blocked")

--- a/runtime/bootstrap/phases_dispatch_test.go
+++ b/runtime/bootstrap/phases_dispatch_test.go
@@ -264,3 +264,36 @@ func TestDrainWebhookDispatchers_HappyPath_RegistersHandler(t *testing.T) {
 	assert.Equal(t, 1, evtRouter.HandlerCount(),
 		"one dispatcher must register exactly one handler on the event router")
 }
+
+// TestDrainWebhookDispatchers_HappyPath_LocksSvixSchedule verifies the full
+// schedule funnel end-to-end (F10): the webhook dispatcher's BrokerDelaySchedule
+// reaches the final outbox.Subscription registered on the event router, equal to
+// the canonical Svix timeline. A capturing SubscriptionValidator observes the
+// candidate subscription the router builds from BuildConsumers →
+// WithSubscriptionBrokerDelaySchedule → eventrouter. HandlerCount alone could not
+// catch a regression that drops the schedule between the consumer and the router.
+func TestDrainWebhookDispatchers_HappyPath_LocksSvixSchedule(t *testing.T) {
+	t.Parallel()
+	dc := newWebhookDispatchCell()
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	clk := clockmock.New(whFixedNow)
+	b := New(clk, WithConsumerBase(newTestConsumerBase(t)))
+	b.webhookSourceStore = whTestStore(t)
+
+	evtRouter := newDispatchEvtRouter(t, b)
+
+	var captured outbox.Subscription
+	var count int
+	evtRouter.AddSubscriptionValidator(func(sub outbox.Subscription) error {
+		captured = sub
+		count++
+		return nil
+	})
+
+	err := b.drainWebhookDispatchers(s, evtRouter)
+	require.NoError(t, err, "happy path must not error")
+	require.Equal(t, 1, count, "exactly one webhook dispatch subscription must be registered")
+	assert.Equal(t, kwh.DefaultSvixSchedule().Delays(), captured.BrokerDelaySchedule,
+		"webhook dispatch subscription must carry the full Svix retry schedule end-to-end")
+}

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -275,19 +275,38 @@ func (b *Bootstrap) drainCellSubscriptions(s *phaseState, evtRouter *eventrouter
 			continue
 		}
 		for _, sub := range snap.Subscriptions {
-			if sub.CellID != id {
-				return fmt.Errorf("bootstrap: cell %s subscription drift: declared CellID=%q but snapshot owner=%q"+
-					" (codegen should inject cellID from cell metadata; check cellgen + contractgen templates)",
-					id, sub.CellID, id)
-			}
-			var opts []cell.SubscriptionOption
-			if sub.SliceID != "" {
-				opts = append(opts, cell.WithSubscriptionSliceID(sub.SliceID))
-			}
-			if err := evtRouter.AddContractHandler(sub.Spec, sub.Handler, sub.ConsumerGroup, sub.CellID, opts...); err != nil {
-				return fmt.Errorf("bootstrap: cell %s subscription setup failed: %w", id, err)
+			if err := registerCellSubscription(evtRouter, id, sub); err != nil {
+				return err
 			}
 		}
+	}
+	return nil
+}
+
+// registerCellSubscription registers one cell snapshot subscription onto the
+// router. It cross-checks CellID against the snapshot owner (fail-fast on drift —
+// see drainCellSubscriptions) and forwards optional per-subscription metadata:
+// the slice owner and, for opted-in subscriptions, the broker-delay schedule.
+func registerCellSubscription(evtRouter *eventrouter.Router, id string, sub cell.SubscriptionRequest) error {
+	if sub.CellID != id {
+		return fmt.Errorf("bootstrap: cell %s subscription drift: declared CellID=%q but snapshot owner=%q"+
+			" (codegen should inject cellID from cell metadata; check cellgen + contractgen templates)",
+			id, sub.CellID, id)
+	}
+	var opts []cell.SubscriptionOption
+	if sub.SliceID != "" {
+		opts = append(opts, cell.WithSubscriptionSliceID(sub.SliceID))
+	}
+	// F7: forward an opted-in broker-delay schedule so a non-webhook cell
+	// subscription that requested broker-native delayed re-delivery actually
+	// carries it onto outbox.Subscription — without this the option would be
+	// silently dropped (only the webhook-dispatch drain forwarded it, see
+	// drainWebhookDispatchers).
+	if len(sub.BrokerDelaySchedule) > 0 {
+		opts = append(opts, cell.WithSubscriptionBrokerDelaySchedule(sub.BrokerDelaySchedule))
+	}
+	if err := evtRouter.AddContractHandler(sub.Spec, sub.Handler, sub.ConsumerGroup, sub.CellID, opts...); err != nil {
+		return fmt.Errorf("bootstrap: cell %s subscription setup failed: %w", id, err)
 	}
 	return nil
 }

--- a/runtime/bootstrap/phases_events.go
+++ b/runtime/bootstrap/phases_events.go
@@ -180,7 +180,10 @@ func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventroute
 		return fmt.Errorf("bootstrap: build webhook dispatch consumers: %w", err)
 	}
 	for _, c := range consumers {
-		if err := evtRouter.AddContractHandler(c.Spec, c.Handler, c.ConsumerGroup, c.CellID); err != nil {
+		// #1458: carry the Svix per-attempt retry schedule onto the subscription
+		// so the subscriber honors broker-native delayed re-delivery.
+		if err := evtRouter.AddContractHandler(c.Spec, c.Handler, c.ConsumerGroup, c.CellID,
+			cell.WithSubscriptionBrokerDelaySchedule(c.BrokerDelaySchedule)); err != nil {
 			return fmt.Errorf("bootstrap: webhook dispatch setup failed for contract %q: %w", c.Spec.ID, err)
 		}
 	}

--- a/runtime/bootstrap/phases_events_test.go
+++ b/runtime/bootstrap/phases_events_test.go
@@ -251,6 +251,75 @@ func TestPhase6_DrainCellSubscriptions_DriftedCellID_ReturnsError(t *testing.T) 
 		"error must identify the drift failure mode")
 }
 
+// TestDrainCellSubscriptions_ForwardsBrokerDelaySchedule verifies F7: a
+// non-webhook cell subscription that opted into broker-native delayed
+// re-delivery actually carries its BrokerDelaySchedule onto the final
+// outbox.Subscription registered on the router. Before the fix, only the
+// webhook-dispatch drain forwarded the schedule, so a cell using
+// reg.Subscribe(..., WithSubscriptionBrokerDelaySchedule(...)) would have the
+// option silently dropped. A capturing SubscriptionValidator observes the
+// candidate subscription the router builds.
+func TestDrainCellSubscriptions_ForwardsBrokerDelaySchedule(t *testing.T) {
+	t.Parallel()
+
+	bus := eventbus.New(clock.Real())
+	asm := assembly.New(clock.Real(), assembly.Config{ID: "phase6-delay-forward-test", DurabilityMode: outbox.DurabilityDemo})
+	t.Cleanup(asm.Shutdown)
+	require.NoError(t, asm.Register(newStubEventCell("event.delay.forward.v1")))
+	require.NoError(t, asm.Start(context.Background()))
+
+	b := New(
+		clock.Real(),
+		WithAssembly(asm),
+		WithPublisher(bus),
+		WithSubscriber(bus),
+		WithConsumerBase(newTestConsumerBase(t)),
+	)
+
+	evtRouter, err := b.buildEventRouter(bus)
+	require.NoError(t, err)
+
+	var captured outbox.Subscription
+	var count int
+	evtRouter.AddSubscriptionValidator(func(sub outbox.Subscription) error {
+		captured = sub
+		count++
+		return nil
+	})
+
+	schedule := []time.Duration{time.Second, 5 * time.Second}
+	noopH := outbox.EntryHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
+		return outbox.Ack()
+	})
+
+	_, s := newPhaseState()
+	defer s.runCancel()
+	s.asm = asm
+	s.cellSnapshots = map[string]cell.RegistrySnapshot{
+		"stub": {
+			Subscriptions: []cell.SubscriptionRequest{
+				{
+					Spec: contractspec.ContractSpec{
+						ID:        "event.delay.forward.v1",
+						Kind:      cellvocab.ContractEvent,
+						Transport: "inmem",
+						Topic:     "event.delay.forward.v1",
+					},
+					Handler:             noopH,
+					ConsumerGroup:       "stub-cg",
+					CellID:              "stub",
+					BrokerDelaySchedule: schedule,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, b.drainCellSubscriptions(s, evtRouter))
+	require.Equal(t, 1, count, "exactly one cell subscription must be drained")
+	assert.Equal(t, schedule, captured.BrokerDelaySchedule,
+		"drainCellSubscriptions must forward the cell subscription's BrokerDelaySchedule onto outbox.Subscription")
+}
+
 func TestPhase6_SubscriptionsWithSubscriberButNoConsumerBase_FailsFast(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/bootstrap/phases_events_test.go
+++ b/runtime/bootstrap/phases_events_test.go
@@ -287,7 +287,7 @@ func TestDrainCellSubscriptions_ForwardsBrokerDelaySchedule(t *testing.T) {
 		return nil
 	})
 
-	schedule := []time.Duration{time.Second, 5 * time.Second}
+	schedule := []time.Duration{testtime.D1s, testtime.D5s}
 	noopH := outbox.EntryHandler(func(_ context.Context, _ outbox.Entry) outbox.HandleResult {
 		return outbox.Ack()
 	})

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -464,14 +464,21 @@ func (b *InMemoryEventBus) handleWithRetry(
 		// Wait the per-attempt delay — the schedule tier for #1458 broker-delay
 		// subscriptions, else exponential backoff — then retry, or abort on ctx
 		// cancellation. Logged here, the single site that knows the actual wait,
-		// so retry_delay is accurate for both retry modes.
+		// so retry_delay is accurate for both retry modes. The error attr is
+		// omitted when nil (e.g. a zero-value/invalid disposition carries no Err —
+		// handleInvalidDisposition already logged the cause at Error level) so the
+		// field never reads as a spurious "error=<nil>".
 		delay := nextAttemptDelay(schedule, attempt)
-		slog.Warn("eventbus: delivery failed, retrying after delay",
+		retryAttrs := []slog.Attr{
 			slog.String("topic", topic),
 			slog.String("entry_id", entry.ID()),
 			slog.Int("attempt", attempt+1),
 			slog.Duration("retry_delay", delay),
-			slog.Any("error", res.Err))
+		}
+		if res.Err != nil {
+			retryAttrs = append(retryAttrs, slog.Any("error", res.Err))
+		}
+		slog.LogAttrs(ctx, slog.LevelWarn, "eventbus: delivery failed, retrying after delay", retryAttrs...)
 		if !awaitDelay(ctx, b.clk, delay) {
 			return
 		}

--- a/runtime/eventbus/eventbus.go
+++ b/runtime/eventbus/eventbus.go
@@ -287,7 +287,7 @@ func (b *InMemoryEventBus) Subscribe(ctx context.Context, sub outbox.Subscriptio
 			if !ok {
 				return nil
 			}
-			b.handleWithRetry(subCtx, topic, entry, handler)
+			b.handleWithRetry(subCtx, sub.BrokerDelaySchedule, topic, entry, handler)
 		}
 	}
 }
@@ -432,10 +432,27 @@ func (b *InMemoryEventBus) removeSub(topic, consumerGroup string, target *subscr
 	}
 }
 
-func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, entry outbox.Entry, handler outbox.SubscriberHandler) {
-	for attempt := range maxRetries {
+// handleWithRetry drives the per-delivery retry loop. For ordinary
+// subscriptions the budget is maxRetries with exponential backoff. For
+// broker-delay subscriptions (#1458, non-empty schedule) the budget is
+// len(schedule)+1 deliveries (the immediate attempt plus one retry per tier)
+// and the inter-attempt wait is the per-tier schedule delay — mirroring the
+// rabbitmq TTL+DLX tier walk so both transports honor the Svix timeline
+// identically (enforced by the shared outboxtest DelayedRedelivery feature).
+func (b *InMemoryEventBus) handleWithRetry(
+	ctx context.Context,
+	schedule []time.Duration,
+	topic string,
+	entry outbox.Entry,
+	handler outbox.SubscriberHandler,
+) {
+	budget := maxRetries
+	if len(schedule) > 0 {
+		budget = len(schedule) + 1
+	}
+	for attempt := range budget {
 		res, settlement := handler(ctx, entry)
-		finalAttempt := attempt == maxRetries-1
+		finalAttempt := attempt == budget-1
 		done, err := b.processResult(ctx, topic, entry, res, settlement, attempt, finalAttempt)
 		if done {
 			return
@@ -444,11 +461,32 @@ func (b *InMemoryEventBus) handleWithRetry(ctx context.Context, topic string, en
 			b.notifyRetryExhausted(ctx, topic, entry, res, err)
 			return
 		}
-		// Wait for retry delay or ctx cancellation.
-		if !awaitRetry(ctx, b.clk, res.Disposition, attempt) {
+		// Wait the per-attempt delay — the schedule tier for #1458 broker-delay
+		// subscriptions, else exponential backoff — then retry, or abort on ctx
+		// cancellation. Logged here, the single site that knows the actual wait,
+		// so retry_delay is accurate for both retry modes.
+		delay := nextAttemptDelay(schedule, attempt)
+		slog.Warn("eventbus: delivery failed, retrying after delay",
+			slog.String("topic", topic),
+			slog.String("entry_id", entry.ID()),
+			slog.Int("attempt", attempt+1),
+			slog.Duration("retry_delay", delay),
+			slog.Any("error", res.Err))
+		if !awaitDelay(ctx, b.clk, delay) {
 			return
 		}
 	}
+}
+
+// nextAttemptDelay returns the wait before the next delivery attempt: the
+// per-tier schedule delay for broker-delay subscriptions (#1458), else
+// exponential backoff. schedule[attempt] is in range because handleWithRetry
+// only waits when attempt < len(schedule).
+func nextAttemptDelay(schedule []time.Duration, attempt int) time.Duration {
+	if len(schedule) > 0 {
+		return schedule[attempt]
+	}
+	return retryDelay(attempt)
 }
 
 func (b *InMemoryEventBus) notifyRetryExhausted(
@@ -511,13 +549,15 @@ func (b *InMemoryEventBus) processResult(
 		outbox.NotifySettlement(ctx, res, entry, outbox.DispositionReject, outbox.RejectSettlementResult(res), nil)
 		return true, nil
 	case outbox.DispositionRequeue:
-		return b.handleRequeue(ctx, topic, entry, res, settlement, attempt, finalAttempt)
+		return b.handleRequeue(ctx, topic, entry, res, settlement, finalAttempt)
 	default:
 		return b.handleInvalidDisposition(ctx, topic, entry, res, settlement, attempt, finalAttempt)
 	}
 }
 
-// handleRequeue processes DispositionRequeue: schedule retry with backoff.
+// handleRequeue processes DispositionRequeue: release the receipt and signal a
+// non-final retry (the wait + retry log happen in handleWithRetry, the single
+// site that knows the actual per-attempt delay — backoff or #1458 schedule tier).
 // PermanentError 不再短路 — 与 ConsumerBase 029 #03 ADR Decision 4 对齐：
 // PermanentError 仅作分类标签（用于 logging/metrics），handler 必须显式返回
 // DispositionReject 才会立刻路由 DLX；Requeue 一律走 retry budget，预算耗尽
@@ -528,7 +568,6 @@ func (b *InMemoryEventBus) handleRequeue(
 	entry outbox.Entry,
 	res outbox.DeliveryOutcome,
 	settlement outbox.Settlement,
-	attempt int,
 	finalAttempt bool,
 ) (done bool, lastErr error) {
 	if settlement != nil {
@@ -537,13 +576,6 @@ func (b *InMemoryEventBus) handleRequeue(
 	if finalAttempt {
 		return false, res.Err
 	}
-	delay := retryDelay(attempt)
-	slog.Warn("eventbus: handler requested requeue, retrying",
-		slog.String("topic", topic),
-		slog.Int("attempt", attempt+1),
-		slog.Any("error", res.Err),
-		slog.Duration("retry_delay", delay),
-	)
 	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 	return false, res.Err
 }
@@ -573,7 +605,6 @@ func (b *InMemoryEventBus) handleInvalidDisposition(
 		)
 		return false, res.Err
 	}
-	delay := retryDelay(attempt)
 	slog.Error("eventbus: invalid disposition, treating as requeue",
 		slog.String("topic", topic),
 		slog.String("entry_id", entry.ID()),
@@ -581,7 +612,6 @@ func (b *InMemoryEventBus) handleInvalidDisposition(
 		slog.String("event_type", entry.EventType()),
 		slog.String("disposition", res.Disposition.String()),
 		slog.Int("attempt", attempt+1),
-		slog.Duration("retry_delay", delay),
 	)
 	outbox.NotifySettlement(ctx, res, entry, outbox.DispositionRequeue, outbox.SettlementResultSuccess, nil)
 	return false, res.Err
@@ -596,10 +626,10 @@ func retryDelay(attempt int) time.Duration {
 	return base + jitter
 }
 
-// awaitRetry sleeps for the retry delay then returns true, or returns false
-// if ctx is canceled. For invalid disposition, uses the same delay logic.
-func awaitRetry(ctx context.Context, clk clock.Clock, _ outbox.Disposition, attempt int) bool {
-	delay := retryDelay(attempt)
+// awaitDelay sleeps for the given delay then returns true, or returns false if
+// ctx is canceled. Used for both exponential backoff (retryDelay) and the
+// #1458 broker-delay schedule path (see nextAttemptDelay).
+func awaitDelay(ctx context.Context, clk clock.Clock, delay time.Duration) bool {
 	t := clk.NewTimerAt(clk.Now().Add(delay))
 	defer t.Stop()
 	select {

--- a/runtime/eventrouter/router.go
+++ b/runtime/eventrouter/router.go
@@ -113,12 +113,13 @@ func WithEventRouterCollector(c EventCollector) Option {
 }
 
 type handlerConfig struct {
-	topic         string
-	handler       outbox.EntryHandler
-	consumerGroup string
-	cellID        string // cellID is the observability owner; must be provided by caller — no fallback to consumerGroup (K#07).
-	sliceID       string
-	contract      contractspec.ContractSpec
+	topic               string
+	handler             outbox.EntryHandler
+	consumerGroup       string
+	cellID              string // cellID is the observability owner; must be provided by caller — no fallback to consumerGroup (K#07).
+	sliceID             string
+	contract            contractspec.ContractSpec
+	brokerDelaySchedule []time.Duration // #1458: per-attempt webhook retry delays (empty for ordinary subscriptions).
 }
 
 // Router manages event subscription lifecycle. It is populated from
@@ -242,10 +243,11 @@ func (r *Router) AddContractHandler(
 	// Validators run outside the lock to avoid holding the subscription store
 	// during potentially slow or user-provided checks.
 	candidateSub := outbox.Subscription{
-		Topic:         spec.Topic,
-		ConsumerGroup: consumerGroup,
-		CellID:        ownerCellID,
-		SliceID:       req.SliceID,
+		Topic:               spec.Topic,
+		ConsumerGroup:       consumerGroup,
+		CellID:              ownerCellID,
+		SliceID:             req.SliceID,
+		BrokerDelaySchedule: req.BrokerDelaySchedule,
 	}
 	r.mu.Lock()
 	currentValidators := make([]cell.SubscriptionValidator, len(r.validators))
@@ -268,12 +270,13 @@ func (r *Router) AddContractHandler(
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.handlers = append(r.handlers, handlerConfig{
-		topic:         spec.Topic,
-		handler:       handler,
-		consumerGroup: consumerGroup,
-		cellID:        ownerCellID,
-		sliceID:       req.SliceID,
-		contract:      spec,
+		topic:               spec.Topic,
+		handler:             handler,
+		consumerGroup:       consumerGroup,
+		cellID:              ownerCellID,
+		sliceID:             req.SliceID,
+		contract:            spec,
+		brokerDelaySchedule: req.BrokerDelaySchedule,
 	})
 	return nil
 }
@@ -589,10 +592,11 @@ func (r *Router) awaitAllReady(ctx context.Context, handlers []handlerConfig) <-
 
 func (h handlerConfig) subscription() outbox.Subscription {
 	sub := outbox.Subscription{
-		Topic:         h.topic,
-		ConsumerGroup: h.consumerGroup,
-		CellID:        h.cellID,
-		SliceID:       h.sliceID,
+		Topic:               h.topic,
+		ConsumerGroup:       h.consumerGroup,
+		CellID:              h.cellID,
+		SliceID:             h.sliceID,
+		BrokerDelaySchedule: h.brokerDelaySchedule,
 	}
 	if h.contract.ID != "" {
 		sub.ContractID = h.contract.ID

--- a/runtime/webhook/dispatch/dispatch.go
+++ b/runtime/webhook/dispatch/dispatch.go
@@ -38,6 +38,7 @@ package dispatch
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -63,6 +64,10 @@ type Consumer struct {
 	// observability owner.
 	ConsumerGroup string
 	CellID        string
+	// BrokerDelaySchedule is the Svix per-attempt retry timeline
+	// (DefaultSvixSchedule().Delays()) the bootstrap drain copies onto the
+	// outbox.Subscription so the broker honors per-attempt delays (#1458).
+	BrokerDelaySchedule []time.Duration
 }
 
 // Validate checks that all required Consumer fields are populated. buildConsumer
@@ -177,10 +182,11 @@ func buildConsumer(
 		return Consumer{}, err
 	}
 	c := Consumer{
-		Spec:          cs,
-		Handler:       dispatcher.Handle,
-		ConsumerGroup: spec.CellID,
-		CellID:        spec.CellID,
+		Spec:                cs,
+		Handler:             dispatcher.Handle,
+		ConsumerGroup:       spec.CellID,
+		CellID:              spec.CellID,
+		BrokerDelaySchedule: kwh.DefaultSvixSchedule().Delays(),
 	}
 	if err := c.Validate(); err != nil {
 		return Consumer{}, err

--- a/runtime/webhook/dispatch/dispatch_test.go
+++ b/runtime/webhook/dispatch/dispatch_test.go
@@ -64,6 +64,10 @@ func TestBuildConsumers_HappyPath(t *testing.T) {
 	assert.Equal(t, "ordercore", c.ConsumerGroup)
 	assert.Equal(t, "ordercore", c.CellID)
 	require.NotNil(t, c.Handler)
+	// #1458: the dispatcher carries the canonical Svix per-attempt retry schedule
+	// so bootstrap can wire broker-native delayed re-delivery onto the subscription.
+	assert.Equal(t, kwh.DefaultSvixSchedule().Delays(), c.BrokerDelaySchedule,
+		"webhook dispatch must source the canonical Svix retry schedule")
 	// Synthesized spec must pass the contractspec event validator (what
 	// eventrouter.AddContractHandler enforces).
 	require.NoError(t, c.Spec.Validate())

--- a/tools/archtest/subscription_invariants_test.go
+++ b/tools/archtest/subscription_invariants_test.go
@@ -166,7 +166,7 @@ func collectSubscriptionFieldViolations(f *ast.File, fset *token.FileSet, label 
 }
 
 // TestSubscriptionFieldsFrozen enforces SUBSCRIPTION-FIELDS-FROZEN-01:
-// kernel/outbox.Subscription must declare exactly the seven fields listed in
+// kernel/outbox.Subscription must declare exactly the eight fields listed in
 // subscriptionAllowedFields. Drift in this field set silently changes what
 // every cell handler can/must produce on a Subscription literal AND what
 // codegen (contractgen + cellgen) must inject; freezing the set keeps the

--- a/tools/archtest/subscription_invariants_test.go
+++ b/tools/archtest/subscription_invariants_test.go
@@ -96,19 +96,28 @@ func parseSubscriptionFixtureSrc(t *testing.T, src string) (*ast.File, *token.Fi
 // ---------------------------------------------------------------------------
 
 // subscriptionAllowedFields is the verbatim field set of kernel/outbox.Subscription.
-// Adding an eighth field requires extending this allowlist deliberately, which
-// is the moment to (a) decide whether the field belongs on the cross-middleware
+// Adding a field requires extending this allowlist deliberately, which is the
+// moment to (a) decide whether the field belongs on the cross-middleware
 // Subscription identity or on SubscriptionRequest/handlerConfig (eventrouter
 // internal), (b) re-read ADR 202605111000-adr-subscription-cellid-mandatory.md
 // (W2 of K#07), and (c) confirm whether codegen/cellgen must inject the value.
+//
+// BrokerDelaySchedule (#1458) belongs on the cross-middleware Subscription
+// because the Subscriber (the consume-side adapter) is what honors the
+// per-attempt delay. Unlike CellID/SliceID it is NOT codegen-injected on
+// reg.Subscribe: it is wiring-injected by the webhook-dispatch bootstrap drain
+// (runtime/bootstrap/phases_events.go) via cell.WithSubscriptionBrokerDelaySchedule,
+// so contractgen/cellgen templates intentionally do not set it (the zero value —
+// nil — is correct for every codegen-registered cell subscription).
 var subscriptionAllowedFields = map[string]struct{}{
-	"Topic":             {},
-	"ConsumerGroup":     {},
-	"CellID":            {},
-	"SliceID":           {},
-	"ContractID":        {},
-	"ContractKind":      {},
-	"ContractTransport": {},
+	"Topic":               {},
+	"ConsumerGroup":       {},
+	"CellID":              {},
+	"SliceID":             {},
+	"ContractID":          {},
+	"ContractKind":        {},
+	"ContractTransport":   {},
+	"BrokerDelaySchedule": {},
 }
 
 // collectSubscriptionFieldViolations walks an AST for a struct named
@@ -212,16 +221,17 @@ func TestSubscriptionFieldsFrozen_DetectorFixtures(t *testing.T) {
 		wantMissing bool
 	}{
 		{
-			name: "green_exact_seven",
+			name: "green_exact_allowlist",
 			src: `package fixture
 type Subscription struct {
-	Topic             string
-	ConsumerGroup     string
-	CellID            string
-	SliceID           string
-	ContractID        string
-	ContractKind      string
-	ContractTransport string
+	Topic               string
+	ConsumerGroup       string
+	CellID              string
+	SliceID             string
+	ContractID          string
+	ContractKind        string
+	ContractTransport   string
+	BrokerDelaySchedule []time.Duration
 }`,
 			wantFound: true,
 		},
@@ -229,14 +239,15 @@ type Subscription struct {
 			name: "red_extra_field",
 			src: `package fixture
 type Subscription struct {
-	Topic             string
-	ConsumerGroup     string
-	CellID            string
-	SliceID           string
-	ContractID        string
-	ContractKind      string
-	ContractTransport string
-	Extra             string
+	Topic               string
+	ConsumerGroup       string
+	CellID              string
+	SliceID             string
+	ContractID          string
+	ContractKind        string
+	ContractTransport   string
+	BrokerDelaySchedule []time.Duration
+	Extra               string
 }`,
 			wantFound:   true,
 			wantUnknown: true,
@@ -245,12 +256,13 @@ type Subscription struct {
 			name: "red_missing_cellid",
 			src: `package fixture
 type Subscription struct {
-	Topic             string
-	ConsumerGroup     string
-	SliceID           string
-	ContractID        string
-	ContractKind      string
-	ContractTransport string
+	Topic               string
+	ConsumerGroup       string
+	SliceID             string
+	ContractID          string
+	ContractKind        string
+	ContractTransport   string
+	BrokerDelaySchedule []time.Duration
 }`,
 			wantFound:   true,
 			wantMissing: true,
@@ -259,13 +271,14 @@ type Subscription struct {
 			name: "red_embedded_field",
 			src: `package fixture
 type Subscription struct {
-	Topic             string
-	ConsumerGroup     string
-	CellID            string
-	SliceID           string
-	ContractID        string
-	ContractKind      string
-	ContractTransport string
+	Topic               string
+	ConsumerGroup       string
+	CellID              string
+	SliceID             string
+	ContractID          string
+	ContractKind        string
+	ContractTransport   string
+	BrokerDelaySchedule []time.Duration
 	EmbeddedBase
 }`,
 			wantFound:   true,


### PR DESCRIPTION
## Summary

Honor the Svix per-attempt webhook retry schedule (5s/5min/30min/2h/5h/10h/10h) at runtime on **both** `outbox.Subscriber` implementations via broker-native delayed re-delivery — closing the ADR #1160 §D5 gap.

## Why / 背景

PR-5 (#1455) shipped `kernel/webhook.DefaultSvixSchedule` + the `RetrySchedule.DelayFor` seam, but ADR #1160 §D5 deferred wiring the wall-clock delays: the dispatch consumer rode the shared `kernel/outbox.ConsumerBase`, whose in-process exponential backoff is **capped at 30s** and is a sleeping goroutine — it cannot hold a 10h delay nor survive a process restart. The **default** transport (`InMemoryEventBus`) had the same root-cause bug (in-process backoff, not the schedule). This PR honors the full ~40h envelope, durable across restarts, with **no broker plugin**.

**What changed, by layer:**
- `kernel/outbox`: new transport-neutral `Subscription.BrokerDelaySchedule []time.Duration`. `ConsumerBase` runs delayed subs in **single-attempt pass-through** mode (`brokerDelayPassthrough`) — the transport owns retry budget + per-attempt delay + DLX, so a transient `Requeue` is returned verbatim and is **not** converted into the retry-exhausted `Reject` (which would dead-letter on the first failure and bypass the schedule).
- `adapters/rabbitmq`: TTL+DLX **delay-tier queues** (`{queue}.delay.{i}`, `x-message-ttl`=tier, dead-letter back to the dispatch exchange). Attempt count rides the `x-webhook-attempt` header; `attempt > len(schedule)` → `Nack(false,false)` → DLX. Delays held in **durable queues** (survive restart) — the community `x-delayed-message` plugin was rejected (node-memory, lossy).
- `runtime/eventbus`: clock-timed schedule (budget `len(schedule)+1`, wait `schedule[attempt]`); retry-delay logging moved to the single site that knows the actual wait (was inaccurate for the new path).
- wiring: `RetrySchedule.Delays()` → `dispatch.Consumer` → `cell.WithSubscriptionBrokerDelaySchedule` → eventrouter → `outbox.Subscription`.

## Refs

- Closes #1458
- ADR `docs/architecture/202606012052-1160-adr-webhook-retry-default.md` §D5 amended (gap closed + threat re-evaluation)
- ref: getconvoy.io / standard-webhooks sender retry (TTL+DLX delay-tier pattern)
- Follow-up (out of scope, separate PR): #1541 dispatcher circuit-breaker full state machine

## Risk / 兼容性

- **No wire / contract / generated-code change** — the retry schedule is not part of any wire contract; `x-webhook-attempt` is internal broker metadata, never in the signed payload.
- `Subscription.BrokerDelaySchedule` is **additive** (zero value = today's immediate-requeue behavior for every non-webhook subscription); locked by the Hard `SUBSCRIPTION-FIELDS-FROZEN-01` reflect/AST freeze.
- At-least-once delivery unchanged: the delay round-trip **releases (not commits)** the idempotency receipt, so the redelivered same-`entry.ID` message re-claims and the handler re-runs — handlers must remain idempotent (already required).
- **AI-robustness**: cross-transport behavior enforced by the shared `outboxtest` `DelayedRedeliveryHonorsSchedule` conformance feature (mandatory for every requeue-supporting Subscriber — a transport that ignored the schedule fails CI rather than silently degrading). Field surface is Hard (frozen golden); cross-transport behavior is Medium (conformance — the correct ceiling, since "the broker actually waits N hours" is not compile-expressible). Zero Soft mechanisms.

## Test plan

- [x] `go build ./...` 本地通过 (+ `go build -tags=integration ./...`, `go vet -tags=integration ./adapters/rabbitmq/...`)
- [x] `go test ./...` 本地通过（含新增 `DelayedRedeliveryHonorsSchedule` 对 in-memory 总线的验证、ConsumerBase pass-through 回归、`SUBSCRIPTION-FIELDS-FROZEN-01` + detector fixtures）
- [x] `golangci-lint run ./<changed pkgs>/...` 0 issues
- [ ] rabbitmq integration conformance (TTL+DLX tier walk) — runs in CI `integration-test` job (testcontainers/docker; not runnable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
