### PR TITLE
feat(tooling): close Cx labeling loop for backlog issues (#1832)

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -262,7 +262,7 @@ push 后按 `issues` B5 ① 验无文件冲突；通过后**立即**进步骤 3�
 
 - **修完** → 贴 fix 评论（命令 + **回显 comment URL/id** 见 `issues` B4；用 `<!-- pm:fix -->` 模板：findings triage + 修复结果 + 遗留 IN_SCOPE，无损写入（约定见 `pr-comment.md`：每条带 `file:line` + 详表入 `<details>`），OUT_OF_SCOPE 仅一行指针（`🚦 OUT_OF_SCOPE（详见本 PR 的 pm:oos 评论）`），含 footer）。**追加机器块**（贴评论前，接口见 `pr-comment.md` §机器块）：`bash hack/automation/pr-meta.sh emit-block --kind=fix --pr=<PR#> --findings='<计数 json>'`（phase/verdict/round 全派生），输出单行追加到 `pm:fix` body 末尾，再走 `issues` B4 贴。再 `gh pr edit` 切 `pr-status/needs-check-fix`（移除 `pr-status/needs-fix`；待 `/pr-review --check` 验证；**fix 不再直接到 ready**）——check-side 执行器从此刻可立即开始，无需等待 CI。
 - **OOS findings → 独立 pm:oos 评论**（仅当有 OUT_OF_SCOPE findings 时，紧接在 pm:fix 之后贴）：用 `<!-- pm:oos -->` 模板，每条 OOS finding 完整无损记录（字段映射见 `pr-comment.md` / `backlog.md`，不得一句话带过）。**追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=oos --pr=<PR#> --oos='{"items":[…]}'`，输出追加到 pm:oos body 末尾，再走 `issues` B4 贴。
-- **未修 / 待办 finding**（非 OOS 的 Cx3+/RELATED deferred）→ §沟通规则闸门输出 `gh issue create` 建议命令（确认后跑，留 open；label = `backlog` + `pri-pX` + `area-XX` + `type-XX` + `cx-X`（可选，从 finding `[…Cx…]` tag 提取）；body 按 `backlog.md` 顶部字段映射**无损**填充，不得一句话带过；条件延后型加 `flag-cond` + Trigger，派生注明 `Discovered via /fix #<original>`）。
+- **未修 / 待办 finding**（非 OOS 的 Cx3+/RELATED deferred）→ §沟通规则闸门输出 `gh issue create` 建议命令（确认后跑，留 open；label = `backlog` + `pri-pX` + `area-XX` + `type-XX` + `cx-X`（必填，从 finding `[…Cx…]` tag 提取——四轴齐全，建单单源命令见 `issues` B1）；body 按 `backlog.md` 顶部字段映射**无损**填充，不得一句话带过；条件延后型加 `flag-cond` + Trigger，派生注明 `Discovered via /fix #<original>`）。
 
 Priority：review finding 用原 `[P0-P3]`；`/fix` 派生默认 `pri-p2`；`pri-p0` 仅 incident（线上故障/数据完整性/CVE），停下 AskUserQuestion 确认。建 issue 必须显式 `--label pri-pX`。
 

--- a/.claude/skills/issues/SKILL.md
+++ b/.claude/skills/issues/SKILL.md
@@ -126,11 +126,13 @@ C
 
 ## B1. 新建 backlog issue
 
-三维 label 齐全（area + type + pri）+ `backlog`，全部 CLI 显式贴（必须显式 `--label pri-pX`）：
+四轴 label 齐全（area + type + pri + cx）+ `backlog`，全部 CLI 显式贴（pri/cx 必填，cx 无 unknown sentinel）：
 
 ```bash
+# 建单前强制门：校验 area/type/pri/cx 四轴完整（exit 0 才执行 create；下游 selftest-locked，见 PROJECT.md §2.6）
+bash hack/automation/issue-labels.sh validate --labels "backlog,pri-p2,area-eventing,type-bug,cx-2"
 gh issue create \
-  --label backlog --label pri-p2 --label area-eventing --label type-bug [--label cx-2] \
+  --label backlog --label pri-p2 --label area-eventing --label type-bug --label cx-2 \
   --title "[<ID>] <简短标题>" --body-file <填好的 backlog.md>
 # body 骨架单源 = .github/project-template/backlog.md（现状 / 修复方向 / Files / Trigger / Source）——本技能不复制其结构
 ```
@@ -140,10 +142,10 @@ gh issue create \
 - **area-XX**（1 个，8 选）：见 `.github/project-template/PROJECT.md` §2.1。
 - **type-XX**（1 个，8 选）：见 §2.2。
 - **pri-pX**：评级 rubric 见 `.github/project-template/PROJECT.md` §3。`/fix` 派生默认 `pri-p2`；`pri-p0` 仅 incident-driven，停下 AskUserQuestion 确认。
-- **cx-X**（可选）：复杂度 rubric 见 `.github/project-template/PROJECT.md` §3.2 / §2.6。能定级则贴；finding 派生从 `[…Cx…]` tag 取。
+- **cx-X**（必填）：复杂度 rubric 见 `.github/project-template/PROJECT.md` §3.2 / §2.6。建单前必须定级并显式 `--label cx-X`（与 pri 对称，无 unknown sentinel——定不到级也要就近取一档）；finding 派生从 `[…Cx…]` tag 取。epic 例外（不贴 cx）。
 - **flag-cond**（可选）：条件延后型加此 label + body 写 `## Trigger`。
 
-> P0 红线不得默认贴。area/type 漏贴时用 `gh issue edit <N> --add-label area-X --add-label type-X` 补。
+> P0 红线不得默认贴。area/type/cx 漏贴时用 `gh issue edit <N> --add-label area-X --add-label type-X --add-label cx-X` 补；建单前 `issue-labels.sh validate` 强制门正常会先拦截，此为绕过门（raw gh / web UI）后的补救。
 
 ## B2. 编辑 label / 关闭 issue
 

--- a/.github/project-template/PROJECT.md
+++ b/.github/project-template/PROJECT.md
@@ -18,7 +18,7 @@
 
 > 本仓 issue/PR 全程经 `gh` CLI / 技能创建，body 读 `.github/project-template/` 下对应模版（`--body-file`）。
 
-**新建 backlog**：`gh issue create --label backlog --label pri-pX --label area-XX --label type-XX [--label cx-X] --title "[<ID>] ..." --body-file <填好的 backlog.md>`。pri/area/type 必须显式贴；cx 可选（能定级则贴，取值见 §2.6/§3.2）。
+**新建 backlog**：`gh issue create --label backlog --label pri-pX --label area-XX --label type-XX --label cx-X --title "[<ID>] ..." --body-file <填好的 backlog.md>`。area/type/pri/cx 四轴必须显式贴（cx 取值见 §2.6/§3.2，无 unknown sentinel）；建单前先经 `hack/automation/issue-labels.sh validate` 校验完整性（`issues` B1 强制门）。
 
 **新建 epic**：`gh issue create --label epic --label backlog --label pri-pX --label area-XX --title "[EPIC] ..." --body-file <填好的 epic.md>`；子任务用 GitHub 原生 sub-issue 关联。epic 不贴 cx（跨多 PR、无单一 diff）。
 
@@ -69,9 +69,9 @@
 
 流转见 §5。PR 始终恰好一个 `pr-status/*`，pr-review 轴 `approved` XOR `changes-requested`（切一侧必清同轴对侧）。`/fix` 不能直接到 `ready`——必过 `/pr-review --check` 验证（fix 不能自证完成）。`needs-review-again` 仅用于 ship 首次交接；review 出 changes-requested 后始终切 `needs-fix`（5-state）。
 
-### 2.6 cx-XX（复杂度，1 个，可选 CLI 贴）
+### 2.6 cx-XX（复杂度，1 个，必填 CLI 贴）
 
-`cx-1` / `cx-2` / `cx-3` / `cx-4`（语义见 §3.2 rubric）。与 pri 同为评级两轴之一、载体对称（都是 label），但 cx **可选**：建 issue / 评级时能定级则贴 `--label cx-X`，不强制；review/fix finding 派生的 issue 从 finding 的 `[…Cx…]` tag 自动带上对应 cx。epic 不贴（跨多 PR、无单一 diff）。
+`cx-1` / `cx-2` / `cx-3` / `cx-4`（语义见 §3.2 rubric）。与 pri 同为评级两轴之一、载体对称（都是 label），cx **必填**：建 issue 时必须定级并显式 `--label cx-X`（与 pri 对称，无 unknown sentinel——定不到级也要在 §3.2 rubric 里就近取一档）；review/fix finding 派生的 issue 从 finding 的 `[…Cx…]` tag 自动带上对应 cx。epic 不贴（跨多 PR、无单一 diff）。非 epic backlog issue 的 area/type/pri/cx 完整性由 `hack/automation/issue-labels.sh validate` 守卫（`issues` B1 建单前强制门 + `make verify` 经 `verify-automation-selftest.sh` selftest 回归）。
 
 ---
 

--- a/.github/project-template/README.md
+++ b/.github/project-template/README.md
@@ -22,8 +22,8 @@
 ## 用法
 
 ```bash
-gh issue create --label backlog --label pri-pX --label area-XX --label type-XX [--label cx-X] \
-  --title "[<ID>] ..." --body-file <填好的 backlog.md>
+gh issue create --label backlog --label pri-pX --label area-XX --label type-XX --label cx-X \
+  --title "[<ID>] ..." --body-file <填好的 backlog.md>   # area/type/pri/cx 四轴必填，见 PROJECT.md §2.6
 gh pr create --title "..." --body-file <填好的 pull_request_template.md>
 gh pr comment <N> --body-file <填好的 pr-comment.md 模板>
 ```

--- a/.github/project-template/backlog.md
+++ b/.github/project-template/backlog.md
@@ -1,6 +1,6 @@
 <!--
 Backlog issue body 模版 — 经 `gh issue create --body-file <填好的本文件>` 创建。
-labels（`backlog` + `area-XX` + `type-XX` + `pri-pX`）与 title `[<ID>] <简短标题>` 由建 issue 的一方用 `--label` / `--title` 显式给；取值见 PROJECT.md §2/§3。
+labels（`backlog` + `area-XX` + `type-XX` + `pri-pX` + `cx-X`）与 title `[<ID>] <简短标题>` 由建 issue 的一方用 `--label` / `--title` 显式给（非 epic backlog 四轴齐全，cx 必填、无 unknown sentinel）；取值见 PROJECT.md §2/§3。
 
 由 review/fix finding（OUT_OF_SCOPE / 派生）成文时，**无损映射**自 finding 详表（`pr-comment.md` 的 `<details>`），不得一句话带过：
   现状     ← 证据代码片段 + 三维根因（代码/架构/历史）+ 影响范围（直接/间接/同类 Grep N 处）

--- a/hack/automation/issue-labels.sh
+++ b/hack/automation/issue-labels.sh
@@ -61,11 +61,17 @@ _require_one() {
 # _validate_labels CSV -> 0 ok | 2 violation. Prints violations to stderr.
 #
 # Axis membership: pri/cx use value-exact regexes (pri-p0..p3, cx-1..cx-4) — these
-# axes have small fixed value sets and exactness is load-bearing: it rejects
-# cx-unknown (deliberately unsupported, #1832) and out-of-range typos. area/type use
-# prefix-count: their value sets (PROJECT.md §2.1/§2.2, 8 each) are validated by
-# GitHub label existence + the enum docs, not duplicated here — this guard checks
-# COMPLETENESS (exactly-one per axis), not value membership.
+# axes have small, mathematically-fixed value sets, so value-exactness is drift-free
+# and load-bearing: it rejects cx-unknown (deliberately unsupported, #1832) and
+# out-of-range typos. Because the count is valid-only, an invalid same-axis extra
+# (cx-1 + cx-unknown, pri-p2 + pri-p10) would slip past a valid-count check — so we
+# also require any-count == valid-count for pri/cx (#1838 F1).
+# area/type use prefix-count (completeness, exactly-one): an extra area/type label is
+# caught for free as a count≥2 conflict; a lone invalid value is hard-backstopped by
+# GitHub label existence (gh create rejects an undefined label) + PROJECT.md
+# §2.1/§2.2. The 8-value enums are NOT duplicated here — doing so would add a
+# doc↔code drift surface (a new Soft coupling). A single-source machine-readable axes
+# declaration is the proper path if inline value-validation is ever wanted.
 _validate_labels() {
     local labels
     labels="$(_normalize "$1")"
@@ -73,10 +79,11 @@ _validate_labels() {
     # Out of scope: only backlog issues are governed.
     printf '%s\n' "${labels}" | grep -qx 'backlog' || return 0
 
-    local area type pri cx cx_any is_epic
+    local area type pri pri_any cx cx_any is_epic
     area="$(_count '^area-' "${labels}")"
     type="$(_count '^type-' "${labels}")"
     pri="$(_count '^pri-p[0-3]$' "${labels}")"
+    pri_any="$(_count '^pri-' "${labels}")"
     cx="$(_count '^cx-[1-4]$' "${labels}")"
     cx_any="$(_count '^cx-' "${labels}")"
     is_epic="$(_count '^epic$' "${labels}")"
@@ -84,6 +91,10 @@ _validate_labels() {
     local rc=0
     _require_one 'area' "${area}" || rc=1
     _require_one 'pri (pri-p0..p3)' "${pri}" || rc=1
+    # Value-locked axes: a valid value can coexist with an invalid same-axis label
+    # (pri-p2+pri-p10, cx-1+cx-unknown) that the valid-only count ignores — reject
+    # via any==valid. pri applies to epic + non-epic alike.
+    [[ "${pri_any}" -le "${pri}" ]] || { echo "  - invalid pri-* label present (only pri-p0..p3)" >&2; rc=1; }
     if [[ "${is_epic}" -gt 0 ]]; then
         # epic 不贴 cx; type not required for epic (epic create cmd omits it).
         # cx_any (not cx) so a cx-unknown / typo on an epic is also rejected.
@@ -94,6 +105,7 @@ _validate_labels() {
     else
         _require_one 'type' "${type}" || rc=1
         _require_one 'cx (cx-1..cx-4)' "${cx}" || rc=1
+        [[ "${cx_any}" -le "${cx}" ]] || { echo "  - invalid cx-* label present (only cx-1..cx-4; cx-unknown unsupported, #1832)" >&2; rc=1; }
     fi
 
     if [[ "${rc}" -ne 0 ]]; then
@@ -173,6 +185,10 @@ cmd_selftest() {
     _expect "pri-invalid"   2 --labels "backlog,area-tooling,type-debt,pri-p10,cx-1"
     # epic carrying cx-unknown still rejected (epic forbid uses cx_any, not cx-1..4)
     _expect "epic-cx-unknown" 2 --labels "epic,backlog,area-tooling,pri-p2,cx-unknown"
+    # valid value + invalid same-axis extra must be rejected (#1838 F1, Codex review)
+    _expect "cx1-plus-unknown" 2 --labels "backlog,area-tooling,type-debt,pri-p2,cx-1,cx-unknown"
+    _expect "cx1-plus-cx5"     2 --labels "backlog,area-tooling,type-debt,pri-p2,cx-1,cx-5"
+    _expect "pri2-plus-pri10"  2 --labels "backlog,area-tooling,type-debt,pri-p2,pri-p10,cx-1"
     # usage errors: missing flag value / no flag at all -> 64
     _expect "labels-no-value" 64 --labels
     _expect "issue-no-value"  64 --issue

--- a/hack/automation/issue-labels.sh
+++ b/hack/automation/issue-labels.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# issue-labels.sh — guard backlog-issue label completeness (#1832).
+#
+# Closes the Cx labeling loop. A non-epic backlog issue must carry exactly one
+# each of area-* / type-* / pri-* / cx-* — cx is now MANDATORY, symmetric to pri
+# (PROJECT.md §2.6). An epic backlog issue requires area-*/pri-* and must NOT
+# carry any cx-* (epic 不贴 cx — PROJECT.md :23). Non-backlog issues are out of
+# scope (return ok).
+#
+# INVARIANT: non-epic backlog ⇒ exactly-one {area,type,pri,cx}; epic ⇒
+# exactly-one {area,pri} ∧ zero cx. Enforcement is a skill-side pre-create gate
+# (issues B1 runs `validate --labels` and only `gh issue create`s on exit 0).
+# Funnel strength: downstream logic Hard (single decision point, selftest-locked);
+# upstream callsite weak-Medium (skill-routed; a raw `gh` / web-UI create bypasses
+# it). True Hard (违反不可表达) is structurally unreachable — GitHub issue labels
+# are external mutable state no repo-side mechanism can constrain. The unconditional
+# `on: issues` CI backstop (true Medium ceiling) is a deliberate future-hardening
+# path, not built here.
+#
+# Usage:
+#   issue-labels.sh validate --labels "<csv>"   pure offline validator
+#   issue-labels.sh validate --issue <N>        validate a live issue (needs gh)
+#   issue-labels.sh selftest                    offline red/green regression
+# Exit: 0 ok | 1 gh/IO error | 2 validation violation | 64 usage error
+#
+# ref: hack/automation/pr-meta.sh — subcommand dispatch + embedded selftest shape.
+
+set -euo pipefail
+
+# ---- core -------------------------------------------------------------------
+
+# _normalize CSV -> newline-separated, trimmed, blank-stripped label list.
+_normalize() {
+    printf '%s' "$1" \
+        | tr ',' '\n' \
+        | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+        | grep -v '^[[:space:]]*$' || true
+}
+
+# _count REGEX LABELS -> number of labels matching REGEX (anchored by caller).
+_count() {
+    printf '%s\n' "$2" | grep -cE "$1" || true
+}
+
+# _require_one NAME COUNT -> 0 ok; prints + returns 1 on missing/conflict.
+_require_one() {
+    local name="$1" count="$2"
+    if [[ "${count}" -eq 0 ]]; then
+        echo "  - missing ${name} label (exactly 1 required)" >&2
+        return 1
+    fi
+    if [[ "${count}" -gt 1 ]]; then
+        echo "  - conflict: ${count} ${name} labels (exactly 1 required)" >&2
+        return 1
+    fi
+    return 0
+}
+
+# _validate_labels CSV -> 0 ok | 2 violation. Prints violations to stderr.
+_validate_labels() {
+    local labels
+    labels="$(_normalize "$1")"
+
+    # Out of scope: only backlog issues are governed.
+    printf '%s\n' "${labels}" | grep -qx 'backlog' || return 0
+
+    local area type pri cx is_epic
+    area="$(_count '^area-' "${labels}")"
+    type="$(_count '^type-' "${labels}")"
+    pri="$(_count '^pri-p[0-9]+$' "${labels}")"
+    cx="$(_count '^cx-[1-4]$' "${labels}")"
+    is_epic="$(_count '^epic$' "${labels}")"
+
+    local rc=0
+    _require_one area "${area}" || rc=1
+    _require_one pri "${pri}" || rc=1
+    if [[ "${is_epic}" -gt 0 ]]; then
+        # epic 不贴 cx; type not required for epic (epic create cmd omits it).
+        if [[ "${cx}" -gt 0 ]]; then
+            echo "  - epic must not carry cx-* (epic 不贴 cx)" >&2
+            rc=1
+        fi
+    else
+        _require_one type "${type}" || rc=1
+        _require_one cx "${cx}" || rc=1
+    fi
+
+    if [[ "${rc}" -ne 0 ]]; then
+        echo "issue-labels: backlog label set incomplete: $1" >&2
+        return 2
+    fi
+    return 0
+}
+
+# ---- subcommands ------------------------------------------------------------
+
+cmd_validate() {
+    local labels="" issue="" have_labels=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --labels)   labels="${2:-}"; have_labels=1; shift 2 ;;
+            --labels=*) labels="${1#*=}"; have_labels=1; shift ;;
+            --issue)    issue="${2:-}"; shift 2 ;;
+            --issue=*)  issue="${1#*=}"; shift ;;
+            *) echo "issue-labels validate: unknown flag '$1'" >&2; return 64 ;;
+        esac
+    done
+
+    if [[ -n "${issue}" ]]; then
+        command -v gh >/dev/null 2>&1 || { echo "issue-labels: gh not found" >&2; return 1; }
+        labels="$(gh issue view "${issue}" --json labels -q '[.labels[].name] | join(",")' 2>/dev/null)" \
+            || { echo "issue-labels: gh issue view ${issue} failed" >&2; return 1; }
+    elif [[ "${have_labels}" -eq 0 ]]; then
+        echo "issue-labels validate: --labels or --issue required" >&2
+        return 64
+    fi
+
+    local rc=0
+    _validate_labels "${labels}" || rc=$?
+    return "${rc}"
+}
+
+cmd_selftest() {
+    local pass=0 fail=0
+    _expect() {  # NAME WANT_RC -- validate-args...
+        local name="$1" want="$2"; shift 2
+        local got=0
+        cmd_validate "$@" >/dev/null 2>&1 || got=$?
+        if [[ "${got}" -eq "${want}" ]]; then
+            echo "PASS [${name}]"; pass=$((pass + 1))
+        else
+            echo "FAIL [${name}]: want rc=${want} got rc=${got}"; fail=$((fail + 1))
+        fi
+    }
+
+    # non-epic backlog, all four axes present -> ok
+    _expect "complete"      0 --labels "backlog,area-tooling,type-debt,pri-p2,cx-1"
+    # the #1829/#1830 case: cx omitted -> violation
+    _expect "missing-cx"    2 --labels "backlog,area-tooling,type-debt,pri-p2"
+    _expect "missing-pri"   2 --labels "backlog,area-tooling,type-debt,cx-1"
+    _expect "missing-area"  2 --labels "backlog,type-debt,pri-p2,cx-1"
+    _expect "missing-type"  2 --labels "backlog,area-tooling,pri-p2,cx-1"
+    # two cx labels -> conflict
+    _expect "double-cx"     2 --labels "backlog,area-tooling,type-debt,pri-p2,cx-1,cx-2"
+    # epic backlog: area+pri, no cx, no type required -> ok
+    _expect "epic-ok"       0 --labels "epic,backlog,area-tooling,pri-p2"
+    # epic must not carry cx
+    _expect "epic-with-cx"  2 --labels "epic,backlog,area-tooling,pri-p2,cx-1"
+    # not a backlog issue -> out of scope, ok
+    _expect "non-backlog"   0 --labels "area-tooling,type-debt,pri-p2"
+    # tolerates whitespace + orthogonal flag labels
+    _expect "ws-and-flag"   0 --labels "backlog, area-tooling , type-debt, pri-p2, cx-3, flag-cond"
+
+    echo "issue-labels selftest: ${pass} passed, ${fail} failed"
+    [[ "${fail}" -eq 0 ]]
+}
+
+usage() {
+    cat >&2 <<'EOF'
+usage: issue-labels.sh <validate|selftest> [args]
+  validate --labels "<csv>"   validate an explicit label set (offline)
+  validate --issue <N>        validate a live issue's labels (needs gh)
+  selftest                    run offline red/green regression
+exit codes: 0 ok | 1 gh/IO error | 2 validation violation | 64 usage error
+EOF
+}
+
+main() {
+    local sub="${1:-}"
+    if [[ $# -gt 0 ]]; then shift; fi
+    case "${sub}" in
+        validate) cmd_validate "$@" ;;
+        selftest) cmd_selftest "$@" ;;
+        -h|--help|help) usage; exit 0 ;;
+        "") usage; exit 64 ;;
+        *) echo "issue-labels: unknown subcommand '${sub}'" >&2; usage; exit 64 ;;
+    esac
+}
+
+main "$@"

--- a/hack/automation/issue-labels.sh
+++ b/hack/automation/issue-labels.sh
@@ -10,12 +10,14 @@
 # INVARIANT: non-epic backlog ⇒ exactly-one {area,type,pri,cx}; epic ⇒
 # exactly-one {area,pri} ∧ zero cx. Enforcement is a skill-side pre-create gate
 # (issues B1 runs `validate --labels` and only `gh issue create`s on exit 0).
-# Funnel strength: downstream logic Hard (single decision point, selftest-locked);
-# upstream callsite weak-Medium (skill-routed; a raw `gh` / web-UI create bypasses
-# it). True Hard (违反不可表达) is structurally unreachable — GitHub issue labels
-# are external mutable state no repo-side mechanism can constrain. The unconditional
-# `on: issues` CI backstop (true Medium ceiling) is a deliberate future-hardening
-# path, not built here.
+# Funnel strength (honest, per .claude/rules/gocell/ai-robust.md): overall Medium.
+# Downstream logic Medium (single decision point; selftest is the golden gate, run
+# in CI via make verify — not compile-time un-expressible, so not Hard). Upstream
+# callsite weak-Medium (skill-routed; a raw `gh` / web-UI create bypasses it). True
+# Hard (违反不可表达) is structurally unreachable — GitHub issue labels are external
+# mutable state no repo-side mechanism can constrain. The unconditional `on: issues`
+# CI backstop (the strong-Medium ceiling) is a deliberate future-hardening path,
+# not built here.
 #
 # Usage:
 #   issue-labels.sh validate --labels "<csv>"   pure offline validator
@@ -57,6 +59,13 @@ _require_one() {
 }
 
 # _validate_labels CSV -> 0 ok | 2 violation. Prints violations to stderr.
+#
+# Axis membership: pri/cx use value-exact regexes (pri-p0..p3, cx-1..cx-4) — these
+# axes have small fixed value sets and exactness is load-bearing: it rejects
+# cx-unknown (deliberately unsupported, #1832) and out-of-range typos. area/type use
+# prefix-count: their value sets (PROJECT.md §2.1/§2.2, 8 each) are validated by
+# GitHub label existence + the enum docs, not duplicated here — this guard checks
+# COMPLETENESS (exactly-one per axis), not value membership.
 _validate_labels() {
     local labels
     labels="$(_normalize "$1")"
@@ -64,25 +73,27 @@ _validate_labels() {
     # Out of scope: only backlog issues are governed.
     printf '%s\n' "${labels}" | grep -qx 'backlog' || return 0
 
-    local area type pri cx is_epic
+    local area type pri cx cx_any is_epic
     area="$(_count '^area-' "${labels}")"
     type="$(_count '^type-' "${labels}")"
-    pri="$(_count '^pri-p[0-9]+$' "${labels}")"
+    pri="$(_count '^pri-p[0-3]$' "${labels}")"
     cx="$(_count '^cx-[1-4]$' "${labels}")"
+    cx_any="$(_count '^cx-' "${labels}")"
     is_epic="$(_count '^epic$' "${labels}")"
 
     local rc=0
-    _require_one area "${area}" || rc=1
-    _require_one pri "${pri}" || rc=1
+    _require_one 'area' "${area}" || rc=1
+    _require_one 'pri (pri-p0..p3)' "${pri}" || rc=1
     if [[ "${is_epic}" -gt 0 ]]; then
         # epic 不贴 cx; type not required for epic (epic create cmd omits it).
-        if [[ "${cx}" -gt 0 ]]; then
+        # cx_any (not cx) so a cx-unknown / typo on an epic is also rejected.
+        if [[ "${cx_any}" -gt 0 ]]; then
             echo "  - epic must not carry cx-* (epic 不贴 cx)" >&2
             rc=1
         fi
     else
-        _require_one type "${type}" || rc=1
-        _require_one cx "${cx}" || rc=1
+        _require_one 'type' "${type}" || rc=1
+        _require_one 'cx (cx-1..cx-4)' "${cx}" || rc=1
     fi
 
     if [[ "${rc}" -ne 0 ]]; then
@@ -98,9 +109,11 @@ cmd_validate() {
     local labels="" issue="" have_labels=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --labels)   labels="${2:-}"; have_labels=1; shift 2 ;;
+            --labels)   [[ $# -ge 2 ]] || { echo "issue-labels validate: --labels requires a value" >&2; return 64; }
+                        labels="$2"; have_labels=1; shift 2 ;;
             --labels=*) labels="${1#*=}"; have_labels=1; shift ;;
-            --issue)    issue="${2:-}"; shift 2 ;;
+            --issue)    [[ $# -ge 2 ]] || { echo "issue-labels validate: --issue requires a value" >&2; return 64; }
+                        issue="$2"; shift 2 ;;
             --issue=*)  issue="${1#*=}"; shift ;;
             *) echo "issue-labels validate: unknown flag '$1'" >&2; return 64 ;;
         esac
@@ -150,6 +163,20 @@ cmd_selftest() {
     _expect "non-backlog"   0 --labels "area-tooling,type-debt,pri-p2"
     # tolerates whitespace + orthogonal flag labels
     _expect "ws-and-flag"   0 --labels "backlog, area-tooling , type-debt, pri-p2, cx-3, flag-cond"
+    # empty set -> out of scope (no backlog) — locks _normalize / out-of-scope path
+    _expect "empty-labels"  0 --labels ""
+    # cx-unknown is deliberately unsupported (#1832): not a valid cx -> violation
+    _expect "cx-unknown"    2 --labels "backlog,area-tooling,type-debt,pri-p2,cx-unknown"
+    # out-of-range cx (Cx5+ must be split, §3.2) is not a valid cx -> violation
+    _expect "cx-out-of-range" 2 --labels "backlog,area-tooling,type-debt,pri-p2,cx-5"
+    # invalid pri value (only pri-p0..p3) -> violation
+    _expect "pri-invalid"   2 --labels "backlog,area-tooling,type-debt,pri-p10,cx-1"
+    # epic carrying cx-unknown still rejected (epic forbid uses cx_any, not cx-1..4)
+    _expect "epic-cx-unknown" 2 --labels "epic,backlog,area-tooling,pri-p2,cx-unknown"
+    # usage errors: missing flag value / no flag at all -> 64
+    _expect "labels-no-value" 64 --labels
+    _expect "issue-no-value"  64 --issue
+    _expect "no-flag"       64
 
     echo "issue-labels selftest: ${pass} passed, ${fail} failed"
     [[ "${fail}" -eq 0 ]]

--- a/hack/verify-automation-selftest.sh
+++ b/hack/verify-automation-selftest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# verify-automation-selftest.sh — gate the gocell-pr-meta:v1 protocol helper
-# and the codex-pr-router decision logic.
+# verify-automation-selftest.sh — gate the gocell-pr-meta:v1 protocol helper,
+# the codex-pr-router decision logic, and the issue-labels backlog guard.
 # Discovered automatically by make verify (find hack -maxdepth 1 -name 'verify-*.sh').
 #
 # ref: kubernetes/kubernetes hack/verify-shellcheck.sh — script shape.
@@ -8,3 +8,4 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 bash "${REPO_ROOT}/hack/automation/pr-meta.sh" selftest
 bash "${REPO_ROOT}/hack/automation/codex-pr-router/router-selftest.sh"
+bash "${REPO_ROOT}/hack/automation/issue-labels.sh" selftest


### PR DESCRIPTION
## Summary

Make `cx-1..cx-4` **mandatory** for non-epic backlog issues (symmetric to `pri`, no `cx-unknown` sentinel) and back it with a machine guard + selftest — closing the Cx-labeling loop in backlog issue creation.

## Why / 背景

`PROJECT.md` defined `cx-*` but the `issues` skill B1 and `PROJECT.md` only forced `backlog + area + type + pri` — **cx was optional** ("能定级则贴"). An AI could silently ship a backlog issue with no Cx (happened on #1829 / #1830). The root cause: enforcement was *advisory skill text that relies on the AI remembering to tag cx* — the exact surface that already failed. This PR makes cx mandatory and adds a validator + selftest so the omission is machine-caught.

Decisions (with owner this session):
- **Drop `cx-unknown`** — Cx is always one of `cx-1..cx-4`, symmetric to `pri`.
- **Machine guard + selftest**, enforced as a **mandatory skill-side pre-create gate** in `issues` B1.
- **No `on: issues` CI workflow** — the unconditional CI-event backstop is deliberately deferred to keep scope tight.

## Refs

Closes #1832. Supersedes #1833.
ref: hack/automation/pr-meta.sh (subcommand dispatch + embedded selftest shape)

## Risk / 兼容性

- **No Go / wire / contract change** — process tooling + docs only. `go build`/`go test`/`golangci-lint` are N/A; the gate is shellcheck + selftest.
- **Behavior change**: `issues` B1 now gates `gh issue create` on `issue-labels.sh validate` exit 0; non-epic backlog issues now require a `cx-*` label.
- Existing OPEN backlog issues lacking cx will fail `validate --issue` — guard working as intended, not a compat break (an existing-debt sweep is run as part of verification; violators are reported for follow-up tagging).

### AI-robust grade (honest — `.claude/rules/gocell/ai-robust.md`)

- **True Hard (违反不可表达) is structurally unreachable**: GitHub issue labels are external mutable state; no repo-side type/codegen/golden/field-freeze can make "a backlog issue missing cx" un-representable.
- **Chosen = skill-routed Medium**: downstream validator logic Medium (single decision point; selftest is the golden gate, CI-run via `make verify` — not compile-time un-expressible, so not Hard); upstream callsite weak-Medium (`issues` B1 gate; a raw `gh` / web-UI create bypasses it). Same skill→helper grade as the existing `pr-meta.sh emit-block` pattern.
- The unconditional `on: issues` CI backstop (true Medium ceiling) is noted as the future hardening path, deliberately not built here (owner decision).

## Implementation matrix (Cx-label rule fanout — not a contract/wire change)

| 变更 | PROJECT.md | backlog.md | issues B1 | fix deferred path | guard + test |
|------|-----------|-----------|-----------|-------------------|--------------|
| cx optional→mandatory | §2.6 + :21 ✓ | header ✓ | template + pre-create gate + bullet + 漏贴补救 ✓ | deferred-finding line ✓ | `issue-labels.sh` + 10-case selftest + `verify-automation-selftest.sh` ✓ |

## Test plan

- [x] `bash hack/automation/issue-labels.sh selftest` — 10/10 PASS (TDD red→green: stub RED 6 fails → impl GREEN)
- [x] `bash hack/verify-automation-selftest.sh` — green (pr-meta + router + issue-labels), exit 0
- [x] `shellcheck hack/automation/issue-labels.sh hack/verify-automation-selftest.sh` — clean
- [x] `validate --issue 1832` → PASS; `validate --labels "backlog,area-tooling,type-debt,pri-p2"` → rc=2 (missing cx)
- [ ] `go build` / `go test` / `golangci-lint` — **N/A** (no Go change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
