### PR TITLE
feat(projection): sealed ResourceProjection + FieldMask PEP framework (#1349)

### DIFF
--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -113,6 +113,16 @@ const (
 	ErrAuthRoleDuplicate  Code = "ERR_AUTH_ROLE_DUPLICATE"
 	ErrAuthPolicyNotFound Code = "ERR_AUTH_POLICY_NOT_FOUND"
 	ErrAuthInvalidInput   Code = "ERR_AUTH_INVALID_INPUT"
+	// ErrAuthObligationUnenforceable signals that a PEP (policy enforcement
+	// point) was handed a mandatory authorization obligation it cannot
+	// discharge — e.g. a column FieldMask naming a nested (dotted) path the
+	// top-level masker does not traverse. Per XACML, a PEP that cannot fulfill a
+	// mandatory obligation MUST NOT permit the access, so the enforcement point
+	// fails closed. Constructed with KindInternal → HTTP 500: this is a PEP /
+	// policy-authoring misconfiguration, not a client error, and is distinct
+	// from generic ERR_INTERNAL so operator dashboards can alert on
+	// un-dischargeable obligations separately from arbitrary 500s.
+	ErrAuthObligationUnenforceable Code = "ERR_AUTH_OBLIGATION_UNENFORCEABLE"
 	// ErrAuthUserNotActive signals the user's status is not 'active' (i.e.,
 	// locked or suspended). Authentication surfaces (login / refresh /
 	// validate) reject any non-active user fail-closed: a suspended user

--- a/pkg/projection/doc.go
+++ b/pkg/projection/doc.go
@@ -24,9 +24,11 @@
 // Masking is top-level only; an un-dischargeable (dotted/nested) obligation
 // fails closed rather than leaking an un-masked column (see requireEnforceable).
 //
-// The masked sentinel is HTML-escaped by encoding/json on the wire (the bytes
-// are "<REDACTED>", not the literal "<REDACTED>"); consumers matching
-// the sentinel in a JSON body must decode first or compare the escaped form.
+// On the wire the masked sentinel is HTML-escaped by encoding/json: the JSON
+// bytes are \u003cREDACTED\u003e, not a literal <REDACTED>. A consumer
+// matching the masked value in a raw JSON body must compare that
+// \u003cREDACTED\u003e escaped form (or json-decode first, which restores the
+// literal <REDACTED>).
 //
 // # Immutability contract
 //

--- a/pkg/projection/doc.go
+++ b/pkg/projection/doc.go
@@ -1,0 +1,51 @@
+// Package projection is the PEP-side (policy enforcement point) column-masking
+// framework for the GoCell data-permission model. It provides ResourceProjection,
+// the sealed carrier for a column-masked resource view, and the NewProjection /
+// NewProjectionList funnel that is the only way to build one.
+//
+// # PDP vs PEP split
+//
+// The authorization vocabulary in pkg/authz is the PDP (decision) output:
+// authz.FieldMask is an open obligation that merely names the columns to mask —
+// the names are inert strings carrying no runtime security. This package is the
+// PEP that discharges that obligation. It imports authz.FieldMask rather than
+// redefining it (the obligation lives with the Decision it travels in;
+// see docs/plans/specs/1220-tenancy-abac-dataperm/research.md §1.1).
+//
+//	authz.FieldMask (PDP obligation)  →  NewProjection  →  ResourceProjection (PEP-enforced view)
+//
+// # Masking semantics
+//
+// A masked column's value is replaced by redaction.Mask ("<REDACTED>"); the
+// column stays present. The visible field set is therefore invariant under
+// masking, and an empty FieldMask is the identity projection. This avoids the
+// MVP→masking response-shape churn the obligation model is designed to prevent:
+// a Decision carrying FieldMask{} projects identically to no obligation at all.
+// Masking is top-level only; an un-dischargeable (dotted/nested) obligation
+// fails closed rather than leaking an un-masked column (see requireEnforceable).
+//
+// # Seal (RESOURCE-PROJECTION-SEALED-01)
+//
+// ResourceProjection's single field is unexported, so an external populated
+// literal does not compile — the same sealed-construction pattern as
+// errcode.PublicDetail, outbox.Entry, and authz.Decision. A handler whose
+// response type is a ResourceProjection cannot hand back a raw, un-masked map:
+// the only ResourceProjection it can obtain comes from the constructors, which
+// always apply the mask.
+//
+// The AI-robust rating is an honestly-split funnel:
+//
+//   - Upstream (type-system Hard): unexported field ⇒ no external populated
+//     literal; reflect field-freeze guards a regression that re-exports it.
+//   - Downstream (go/types Hard): the sole-reconstruction-surface check pins the
+//     only exported producers to {NewProjection, NewProjectionList}, so no second
+//     forge path can be added inside this package without tripping the archtest.
+//
+// SCOPE — what this package does NOT yet enforce. PR-11 ships the unforgeable
+// carrier only. Forcing production read handlers to actually return a
+// ResourceProjection built from the request's Decision.Obligations().FieldMask —
+// the downstream callsite lock — lands in PR-12 (#1350), when real handlers
+// adopt it. Until then this package is a safe building block, not active column
+// protection: do not read RESOURCE-PROJECTION-SEALED-01 as "column leakage is
+// already closed".
+package projection

--- a/pkg/projection/doc.go
+++ b/pkg/projection/doc.go
@@ -24,6 +24,18 @@
 // Masking is top-level only; an un-dischargeable (dotted/nested) obligation
 // fails closed rather than leaking an un-masked column (see requireEnforceable).
 //
+// The masked sentinel is HTML-escaped by encoding/json on the wire (the bytes
+// are "<REDACTED>", not the literal "<REDACTED>"); consumers matching
+// the sentinel in a JSON body must decode first or compare the escaped form.
+//
+// # Immutability contract
+//
+// Construction never mutates the caller's input. A masked column's value is
+// REPLACED (by the sentinel), so masked data is never aliased — there is no
+// leak path through a shared reference. Un-masked values, however, share their
+// reference with the caller's map (they are meant to be visible), so the caller
+// MUST NOT mutate the input map after construction if a stable snapshot matters.
+//
 // # Seal (RESOURCE-PROJECTION-SEALED-01)
 //
 // ResourceProjection's single field is unexported, so an external populated

--- a/pkg/projection/projection.go
+++ b/pkg/projection/projection.go
@@ -73,13 +73,15 @@ func NewProjectionList(mask authz.FieldMask, rows []map[string]any) ([]ResourceP
 // nested path the masker does not traverse. Silently leaving such a column
 // un-masked would be a fail-OPEN leak, so — per XACML's "a PEP that cannot
 // discharge a mandatory obligation MUST NOT permit the access" — we fail closed
-// with a 500 instead of serving an un-masked view. The offending column is
-// recorded as a server-only internal detail (never on the wire). Nested-path
-// masking is deferred until a real nested obligation exists (PR-9/PR-12).
+// instead of serving an un-masked view. The dedicated
+// ErrAuthObligationUnenforceable code (KindInternal → 500) lets operators alert
+// on un-dischargeable obligations distinctly from arbitrary 500s; the offending
+// column is recorded as a server-only internal detail (never on the wire).
+// Nested-path masking is deferred until a real nested obligation exists (PR-9/PR-12).
 func requireEnforceable(mask authz.FieldMask) error {
 	for _, f := range mask.Fields {
 		if strings.ContainsRune(f, '.') {
-			return errcode.New(errcode.KindInternal, errcode.ErrInternal,
+			return errcode.New(errcode.KindInternal, errcode.ErrAuthObligationUnenforceable,
 				"projection: PEP cannot discharge nested field-mask obligation",
 				errcode.WithInternal(errcode.InternalAttr("column", f)))
 		}

--- a/pkg/projection/projection.go
+++ b/pkg/projection/projection.go
@@ -1,0 +1,107 @@
+package projection
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/ghbvf/gocell/pkg/authz"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// ResourceProjection is the sealed, column-masked view of a resource that a PEP
+// (policy enforcement point) may serialize to the wire. Its only field is
+// unexported, so a populated literal `projection.ResourceProjection{data: ...}`
+// outside this package does not compile — the sole way to obtain a populated
+// value is NewProjection / NewProjectionList, which apply the FieldMask
+// obligation. A handler therefore cannot fabricate an un-masked ("full") view;
+// see package doc and RESOURCE-PROJECTION-SEALED-01 for the funnel proof.
+//
+// The zero value marshals to JSON null (it carries no forged data) — the only
+// literal expressible outside the package is harmless.
+type ResourceProjection struct {
+	data map[string]any
+}
+
+// NewProjection builds the sealed, masked view of a single resource. It first
+// validates the obligation (authz.FieldMask.Validate — canonical keys, no
+// duplicates), then refuses obligations this PEP cannot discharge
+// (requireEnforceable — fail-closed), then applies the mask onto a private copy
+// of data. An empty FieldMask yields the identity projection (every value
+// visible), keeping the response field set stable.
+func NewProjection(mask authz.FieldMask, data map[string]any) (ResourceProjection, error) {
+	if err := mask.Validate(); err != nil {
+		return ResourceProjection{}, err
+	}
+	if err := requireEnforceable(mask); err != nil {
+		return ResourceProjection{}, err
+	}
+	return ResourceProjection{data: applyMask(mask, data)}, nil
+}
+
+// NewProjectionList builds the sealed, masked view of every row under one mask.
+// The mask is validated once (an invalid or un-enforceable obligation fails the
+// whole call before any row is projected — fail-closed); each row is then masked
+// onto its own private copy. A nil/empty rows slice yields an empty result.
+func NewProjectionList(mask authz.FieldMask, rows []map[string]any) ([]ResourceProjection, error) {
+	if err := mask.Validate(); err != nil {
+		return nil, err
+	}
+	if err := requireEnforceable(mask); err != nil {
+		return nil, err
+	}
+	out := make([]ResourceProjection, len(rows))
+	for i, row := range rows {
+		out[i] = ResourceProjection{data: applyMask(mask, row)}
+	}
+	return out, nil
+}
+
+// requireEnforceable rejects obligations this PEP cannot discharge. PR-11 only
+// implements top-level (flat) column masking; a dotted field name denotes a
+// nested path the masker does not traverse. Silently leaving such a column
+// un-masked would be a fail-OPEN leak, so — per XACML's "a PEP that cannot
+// discharge a mandatory obligation MUST NOT permit the access" — we fail closed
+// with a 500 instead of serving an un-masked view. The offending column is
+// recorded as a server-only internal detail (never on the wire). Nested-path
+// masking is deferred until a real nested obligation exists (PR-9/PR-12).
+func requireEnforceable(mask authz.FieldMask) error {
+	for _, f := range mask.Fields {
+		if strings.ContainsRune(f, '.') {
+			return errcode.New(errcode.KindInternal, errcode.ErrInternal,
+				"projection: PEP cannot discharge nested field-mask obligation",
+				errcode.WithInternal(errcode.InternalAttr("column", f)))
+		}
+	}
+	return nil
+}
+
+// applyMask returns a shallow copy of data in which every masked column present
+// in data has its value replaced by redaction.Mask. The copy is defensive: the
+// caller's map (and any nested object it holds) is never mutated. A shallow copy
+// suffices because a masked key's entire value is replaced — no sub-field of a
+// masked object can leak — while an un-masked key is meant to stay visible, so
+// sharing its reference is intentional. A masked column absent from data is a
+// no-op (the key is not materialized).
+func applyMask(mask authz.FieldMask, data map[string]any) map[string]any {
+	out := make(map[string]any, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+	for _, f := range mask.Fields {
+		if _, ok := out[f]; ok {
+			out[f] = redaction.Mask
+		}
+	}
+	return out
+}
+
+// MarshalJSON renders the masked view. The zero value (data == nil) marshals to
+// JSON null so an externally-expressible empty literal carries no data. Note the
+// redaction.Mask sentinel is HTML-escaped by encoding/json like any string value.
+func (p ResourceProjection) MarshalJSON() ([]byte, error) {
+	if p.data == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(p.data)
+}

--- a/pkg/projection/projection.go
+++ b/pkg/projection/projection.go
@@ -27,8 +27,19 @@ type ResourceProjection struct {
 // validates the obligation (authz.FieldMask.Validate — canonical keys, no
 // duplicates), then refuses obligations this PEP cannot discharge
 // (requireEnforceable — fail-closed), then applies the mask onto a private copy
-// of data. An empty FieldMask yields the identity projection (every value
-// visible), keeping the response field set stable.
+// of data.
+//
+// The mask is expected to come from Decision.Obligations().FieldMask. An empty
+// FieldMask is valid and yields the identity projection (every value visible,
+// response field set stable) — passing an empty mask where a populated one was
+// intended therefore returns the FULL view silently; supplying the right mask is
+// the caller's responsibility (locked at the handler callsite in PR-12).
+//
+// Error kinds let the handler map status codes: a validation failure carries
+// KindInvalid (→ 400, client-correctable bad mask); an un-dischargeable
+// obligation carries KindInternal (→ 500, a PEP misconfiguration, not user
+// error). A nil data map projects to an empty JSON object ("{}"), distinct from
+// the zero-value ResourceProjection which marshals to null.
 func NewProjection(mask authz.FieldMask, data map[string]any) (ResourceProjection, error) {
 	if err := mask.Validate(); err != nil {
 		return ResourceProjection{}, err

--- a/pkg/projection/projection_test.go
+++ b/pkg/projection/projection_test.go
@@ -185,7 +185,9 @@ func TestNewProjectionList(t *testing.T) {
 
 // TestResourceProjection_ZeroValueInert documents the seal's blind spot: a
 // zero-value ResourceProjection{} (the only literal expressible outside this
-// package) carries no forged data — it marshals to JSON null.
+// package) carries no forged data — it marshals to JSON null. A constructed
+// projection over a nil data map, by contrast, marshals to an empty object "{}"
+// — the two empty forms are deliberately distinguishable.
 func TestResourceProjection_ZeroValueInert(t *testing.T) {
 	t.Parallel()
 
@@ -195,5 +197,38 @@ func TestResourceProjection_ZeroValueInert(t *testing.T) {
 	}
 	if string(b) != "null" {
 		t.Errorf("zero ResourceProjection marshaled to %s, want null", b)
+	}
+
+	p, err := NewProjection(authz.FieldMask{Fields: []string{"email"}}, nil)
+	if err != nil {
+		t.Fatalf("NewProjection(mask, nil): %v", err)
+	}
+	nb, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("MarshalJSON nil-data projection: %v", err)
+	}
+	if string(nb) != "{}" {
+		t.Errorf("constructed projection over nil data marshaled to %s, want {}", nb)
+	}
+}
+
+// TestNewProjectionList_NilRow proves a nil row element is projected to an empty
+// object ("{}") rather than panicking or producing a null element.
+func TestNewProjectionList_NilRow(t *testing.T) {
+	t.Parallel()
+
+	got, err := NewProjectionList(authz.FieldMask{Fields: []string{"email"}}, []map[string]any{nil})
+	if err != nil {
+		t.Fatalf("NewProjectionList with nil row: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	b, err := json.Marshal(got[0])
+	if err != nil {
+		t.Fatalf("MarshalJSON nil row: %v", err)
+	}
+	if string(b) != "{}" {
+		t.Errorf("nil row marshaled to %s, want {}", b)
 	}
 }

--- a/pkg/projection/projection_test.go
+++ b/pkg/projection/projection_test.go
@@ -1,0 +1,199 @@
+package projection
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/authz"
+	"github.com/ghbvf/gocell/pkg/redaction"
+)
+
+// marshalExpected encodes want with the same encoder ResourceProjection.MarshalJSON
+// uses (stdlib json.Marshal, which HTML-escapes "<"/">" in the redaction.Mask
+// sentinel and sorts map keys). Comparing against this keeps the test honest
+// about the on-wire bytes instead of hand-writing escaped literals.
+func marshalExpected(t *testing.T, want map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal expected: %v", err)
+	}
+	return b
+}
+
+func TestNewProjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mask    authz.FieldMask
+		data    map[string]any
+		want    map[string]any // expected visible view (post-mask); nil ⇒ expect error
+		wantErr bool
+	}{
+		{
+			name: "identity projection / empty mask keeps every value",
+			mask: authz.FieldMask{},
+			data: map[string]any{"id": "u1", "email": "a@b.c", "age": 30},
+			want: map[string]any{"id": "u1", "email": "a@b.c", "age": 30},
+		},
+		{
+			name: "single column masked, field set unchanged",
+			mask: authz.FieldMask{Fields: []string{"email"}},
+			data: map[string]any{"id": "u1", "email": "a@b.c", "age": 30},
+			want: map[string]any{"id": "u1", "email": redaction.Mask, "age": 30},
+		},
+		{
+			name: "multiple columns masked",
+			mask: authz.FieldMask{Fields: []string{"email", "age"}},
+			data: map[string]any{"id": "u1", "email": "a@b.c", "age": 30},
+			want: map[string]any{"id": "u1", "email": redaction.Mask, "age": redaction.Mask},
+		},
+		{
+			name: "masked column absent in row is a no-op (no key materialized)",
+			mask: authz.FieldMask{Fields: []string{"ssn"}},
+			data: map[string]any{"id": "u1", "email": "a@b.c"},
+			want: map[string]any{"id": "u1", "email": "a@b.c"},
+		},
+		{
+			name: "nested value under a masked key is replaced wholesale (no sub-field leak)",
+			mask: authz.FieldMask{Fields: []string{"profile"}},
+			data: map[string]any{"id": "u1", "profile": map[string]any{"ssn": "secret"}},
+			want: map[string]any{"id": "u1", "profile": redaction.Mask},
+		},
+		{
+			name:    "non-canonical mask key fails (authz.FieldMask.Validate)",
+			mask:    authz.FieldMask{Fields: []string{" email"}},
+			data:    map[string]any{"email": "a@b.c"},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate mask column fails (authz.FieldMask.Validate)",
+			mask:    authz.FieldMask{Fields: []string{"email", "email"}},
+			data:    map[string]any{"email": "a@b.c"},
+			wantErr: true,
+		},
+		{
+			name:    "dotted mask field fails closed (PEP cannot discharge nested obligation)",
+			mask:    authz.FieldMask{Fields: []string{"profile.ssn"}},
+			data:    map[string]any{"profile": map[string]any{"ssn": "secret"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewProjection(tc.mask, tc.data)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NewProjection(%v) = nil error, want error", tc.mask)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewProjection(%v) unexpected error: %v", tc.mask, err)
+			}
+			gotJSON, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("MarshalJSON: %v", err)
+			}
+			if want := marshalExpected(t, tc.want); !bytes.Equal(gotJSON, want) {
+				t.Errorf("projected view = %s, want %s", gotJSON, want)
+			}
+		})
+	}
+}
+
+// TestNewProjection_DefensiveCopy proves the caller's input map (and the nested
+// object under a masked key) is never mutated by masking — masking operates on a
+// private copy, so a caller that retains the raw map still sees the raw values.
+func TestNewProjection_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	nested := map[string]any{"ssn": "secret"}
+	data := map[string]any{"id": "u1", "email": "a@b.c", "profile": nested}
+
+	if _, err := NewProjection(authz.FieldMask{Fields: []string{"email", "profile"}}, data); err != nil {
+		t.Fatalf("NewProjection: %v", err)
+	}
+
+	if data["email"] != "a@b.c" {
+		t.Errorf("input map mutated: email = %v, want a@b.c", data["email"])
+	}
+	if data["profile"].(map[string]any)["ssn"] != "secret" {
+		t.Errorf("input nested map mutated: profile.ssn = %v, want secret", nested["ssn"])
+	}
+}
+
+func TestNewProjectionList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("masks every row independently", func(t *testing.T) {
+		t.Parallel()
+		rows := []map[string]any{
+			{"id": "u1", "email": "a@b.c"},
+			{"id": "u2", "email": "d@e.f"},
+		}
+		got, err := NewProjectionList(authz.FieldMask{Fields: []string{"email"}}, rows)
+		if err != nil {
+			t.Fatalf("NewProjectionList: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		for i, p := range got {
+			b, err := json.Marshal(p)
+			if err != nil {
+				t.Fatalf("row %d MarshalJSON: %v", i, err)
+			}
+			want := marshalExpected(t, map[string]any{"id": rows[i]["id"], "email": redaction.Mask})
+			if !bytes.Equal(b, want) {
+				t.Errorf("row %d = %s, want %s", i, b, want)
+			}
+		}
+	})
+
+	t.Run("empty rows yields empty slice", func(t *testing.T) {
+		t.Parallel()
+		got, err := NewProjectionList(authz.FieldMask{Fields: []string{"email"}}, nil)
+		if err != nil {
+			t.Fatalf("NewProjectionList: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("invalid mask fails the whole call before any row", func(t *testing.T) {
+		t.Parallel()
+		rows := []map[string]any{{"email": "a@b.c"}}
+		if _, err := NewProjectionList(authz.FieldMask{Fields: []string{"email", "email"}}, rows); err == nil {
+			t.Error("NewProjectionList accepted a duplicate-column mask, want error")
+		}
+	})
+
+	t.Run("dotted mask field fails closed", func(t *testing.T) {
+		t.Parallel()
+		rows := []map[string]any{{"profile": map[string]any{"ssn": "x"}}}
+		if _, err := NewProjectionList(authz.FieldMask{Fields: []string{"profile.ssn"}}, rows); err == nil {
+			t.Error("NewProjectionList accepted a dotted mask, want fail-closed error")
+		}
+	})
+}
+
+// TestResourceProjection_ZeroValueInert documents the seal's blind spot: a
+// zero-value ResourceProjection{} (the only literal expressible outside this
+// package) carries no forged data — it marshals to JSON null.
+func TestResourceProjection_ZeroValueInert(t *testing.T) {
+	t.Parallel()
+
+	b, err := json.Marshal(ResourceProjection{})
+	if err != nil {
+		t.Fatalf("MarshalJSON zero value: %v", err)
+	}
+	if string(b) != "null" {
+		t.Errorf("zero ResourceProjection marshaled to %s, want null", b)
+	}
+}

--- a/pkg/projection/projection_test.go
+++ b/pkg/projection/projection_test.go
@@ -3,9 +3,11 @@ package projection
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/ghbvf/gocell/pkg/authz"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/redaction"
 )
 
@@ -103,6 +105,29 @@ func TestNewProjection(t *testing.T) {
 				t.Errorf("projected view = %s, want %s", gotJSON, want)
 			}
 		})
+	}
+}
+
+// TestNewProjection_DottedMaskFailClosedCode pins that an un-dischargeable
+// (dotted) obligation fails closed with the dedicated KindInternal
+// ErrAuthObligationUnenforceable code — so operators can alert on it distinctly
+// from arbitrary 500s, and so the masker never serves an un-masked column.
+func TestNewProjection_DottedMaskFailClosedCode(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewProjection(authz.FieldMask{Fields: []string{"profile.ssn"}}, map[string]any{"profile": "x"})
+	if err == nil {
+		t.Fatal("NewProjection accepted a dotted mask, want fail-closed error")
+	}
+	var ce *errcode.Error
+	if !errors.As(err, &ce) {
+		t.Fatalf("error is not *errcode.Error: %v", err)
+	}
+	if ce.Code != errcode.ErrAuthObligationUnenforceable {
+		t.Errorf("code = %s, want %s", ce.Code, errcode.ErrAuthObligationUnenforceable)
+	}
+	if ce.Kind != errcode.KindInternal {
+		t.Errorf("kind = %v, want KindInternal (fail-closed 500)", ce.Kind)
 	}
 }
 

--- a/tools/archtest/resource_projection_sealed_test.go
+++ b/tools/archtest/resource_projection_sealed_test.go
@@ -20,10 +20,13 @@
 //     gate; AllFieldsUnexported is the REVERSE self-check that pins this property
 //     so a future PR re-exporting the field fails at PR/nightly time instead of
 //     silently re-opening literal construction.
-//   - Hard (downstream / go/types): SoleReconstructionSurface pins the COMPLETE
-//     set of exported producers to {NewProjection, NewProjectionList}, so no
-//     second forge path (a new exported func returning the type) can be added
-//     inside pkg/projection without tripping this archtest.
+//   - Hard (downstream / go/types): SoleReconstructionSurface scans the exported
+//     producer surface — package-level FUNCS and exported TYPES' exported METHODS
+//     (value / pointer / slice / pointer-slice return forms) — and pins it to
+//     {NewProjection, NewProjectionList} with an empty method-mirror set, so no
+//     second forge path (a new exported func OR method returning the type) can be
+//     added inside pkg/projection without tripping this archtest. Mirrors the
+//     func+method scan in outbox_entry_sealed_construction_test.go.
 //
 // SCOPE — what this seal does NOT cover. PR-11 ships the unforgeable carrier
 // only. It does NOT force production read handlers to actually return a
@@ -103,17 +106,31 @@ func TestResourceProjectionSealed01_WireSurfacePresent(t *testing.T) {
 // sets of exported package-level functions in pkg/projection that may RETURN a
 // ResourceProjection (the single-resource funnel) or a []ResourceProjection (the
 // list funnel). Both always discharge the FieldMask obligation.
+// resourceProjectionMirrorTypes is the exhaustive set of exported TYPES whose
+// exported methods may yield a ResourceProjection — currently EMPTY: no type has
+// a producer method (MarshalJSON returns []byte), so the sealed view can only
+// come from the two funcs above. A new type method returning the sealed type
+// trips the mirror diff.
 var (
 	resourceProjectionScalarFuncs = map[string]struct{}{"NewProjection": {}}
 	resourceProjectionSliceFuncs  = map[string]struct{}{"NewProjectionList": {}}
+	resourceProjectionMirrorTypes = map[string]struct{}{}
 )
 
 // TestResourceProjectionSealed01_SoleReconstructionSurface pins the COMPLETE set
-// of exported funcs in pkg/projection that can yield a ResourceProjection (value
-// or pointer) or a []ResourceProjection. The composite-literal seal only blocks
-// `projection.ResourceProjection{...}`; a new exported func returning the type
-// would be a fresh forge path that skips masking and that the literal seal does
-// not cover. This go/types reverse self-check fails when either set drifts.
+// of exported producer surfaces in pkg/projection that can yield a
+// ResourceProjection. It scans both exported package-level FUNCS and exported
+// TYPES' exported METHODS, in value / pointer / slice / pointer-slice return
+// forms (mirroring outbox_entry_sealed_construction_test.go). The
+// composite-literal seal only blocks `projection.ResourceProjection{...}`; a new
+// exported func OR method returning the type would be a fresh forge path that
+// skips masking and that the literal seal does not cover. This go/types reverse
+// self-check fails when any of the three expected sets drifts (funcs→scalar,
+// funcs→slice, types-with-producer-method).
+//
+// Residual blind spot (accepted): exotic container returns (map[K]T, chan T,
+// fixed arrays) are not scanned — they are not realistic producer surfaces for a
+// sealed view type. Extend the scan here if such a surface is ever introduced.
 func TestResourceProjectionSealed01_SoleReconstructionSurface(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -133,34 +150,53 @@ func TestResourceProjectionSealed01_SoleReconstructionSurface(t *testing.T) {
 				return []Diagnostic{{Message: "RESOURCE-PROJECTION-SEALED-01/SoleReconstructionSurface: ResourceProjection not found"}}
 			}
 			projType := obj.Type()
-			sliceType := types.NewSlice(projType)
 
-			var scalarFuncs, sliceFuncs []string
+			var scalarFuncs, sliceFuncs, mirrorTypes []string
 			for _, name := range scope.Names() {
 				o := scope.Lookup(name)
 				if !o.Exported() {
 					continue
 				}
-				fn, ok := o.(*types.Func)
-				if !ok {
-					continue
-				}
-				sig, ok := fn.Type().(*types.Signature)
-				if !ok {
-					continue
-				}
-				if sigReturnsType(sig, projType) {
-					scalarFuncs = append(scalarFuncs, name)
-				}
-				if sigReturnsSlice(sig, sliceType) {
-					sliceFuncs = append(sliceFuncs, name)
+				switch obj := o.(type) {
+				case *types.Func:
+					sig, ok := obj.Type().(*types.Signature)
+					if !ok {
+						continue
+					}
+					if sigReturnsType(sig, projType) {
+						scalarFuncs = append(scalarFuncs, name)
+					}
+					if sigReturnsSliceOf(sig, projType) {
+						sliceFuncs = append(sliceFuncs, name)
+					}
+				case *types.TypeName:
+					named, ok := obj.Type().(*types.Named)
+					if !ok {
+						continue
+					}
+					for i := 0; i < named.NumMethods(); i++ {
+						m := named.Method(i)
+						if !m.Exported() {
+							continue
+						}
+						sig, ok := m.Type().(*types.Signature)
+						if !ok {
+							continue
+						}
+						if sigReturnsType(sig, projType) || sigReturnsSliceOf(sig, projType) {
+							mirrorTypes = append(mirrorTypes, name)
+							break
+						}
+					}
 				}
 			}
 
 			diags = append(diags, diffResourceProjectionSurface(
 				"exported funcs returning ResourceProjection", resourceProjectionScalarFuncs, scalarFuncs)...)
 			diags = append(diags, diffResourceProjectionSurface(
-				"exported funcs returning []ResourceProjection", resourceProjectionSliceFuncs, sliceFuncs)...)
+				"exported funcs returning []ResourceProjection (or []*ResourceProjection)", resourceProjectionSliceFuncs, sliceFuncs)...)
+			diags = append(diags, diffResourceProjectionSurface(
+				"exported types with a method returning ResourceProjection", resourceProjectionMirrorTypes, mirrorTypes)...)
 			return nil
 		})
 
@@ -183,12 +219,16 @@ func TestResourceProjectionSealed01_ZeroLiteralInert(t *testing.T) {
 	}
 }
 
-// sigReturnsSlice reports whether sig has any result identical to want (a slice
-// type). Complements the shared sigReturnsType, which covers value/pointer forms.
-func sigReturnsSlice(sig *types.Signature, want types.Type) bool {
+// sigReturnsSliceOf reports whether sig has any result identical to []elem or
+// []*elem. Complements the shared sigReturnsType (value/pointer forms), closing
+// the slice-of-pointer producer blind spot.
+func sigReturnsSliceOf(sig *types.Signature, elem types.Type) bool {
+	sliceVal := types.NewSlice(elem)
+	slicePtr := types.NewSlice(types.NewPointer(elem))
 	res := sig.Results()
 	for i := 0; i < res.Len(); i++ {
-		if types.Identical(res.At(i).Type(), want) {
+		rt := res.At(i).Type()
+		if types.Identical(rt, sliceVal) || types.Identical(rt, slicePtr) {
 			return true
 		}
 	}

--- a/tools/archtest/resource_projection_sealed_test.go
+++ b/tools/archtest/resource_projection_sealed_test.go
@@ -1,0 +1,239 @@
+//go:build archtest
+
+// INVARIANT: RESOURCE-PROJECTION-SEALED-01
+//
+// This file owns ONE invariant: pkg/projection.ResourceProjection is sealed
+// construction — its single field is unexported, so a populated composite
+// literal `projection.ResourceProjection{data: ...}` outside package
+// pkg/projection does not compile. That compile-time impossibility is the Hard
+// upstream gate: the only way to obtain a populated ResourceProjection is the
+// NewProjection / NewProjectionList funnel, which always discharges the
+// authz.FieldMask obligation. A read handler therefore cannot fabricate an
+// un-masked ("full") view by struct literal — column masking cannot be bypassed
+// by forging the carrier.
+//
+// AI-robust rating (per .claude/rules/gocell/ai-robust.md §Hard 范本目录
+// "sealed construction" + "reflect schema freeze"):
+//
+//   - Hard (upstream / type-system): the ResourceProjection field is unexported
+//     ⇒ an external populated literal is a compile error. The Go compiler is the
+//     gate; AllFieldsUnexported is the REVERSE self-check that pins this property
+//     so a future PR re-exporting the field fails at PR/nightly time instead of
+//     silently re-opening literal construction.
+//   - Hard (downstream / go/types): SoleReconstructionSurface pins the COMPLETE
+//     set of exported producers to {NewProjection, NewProjectionList}, so no
+//     second forge path (a new exported func returning the type) can be added
+//     inside pkg/projection without tripping this archtest.
+//
+// SCOPE — what this seal does NOT cover. PR-11 ships the unforgeable carrier
+// only. It does NOT force production read handlers to actually return a
+// ResourceProjection built from the request's Decision.Obligations().FieldMask —
+// that downstream callsite lock lands in PR-12 (#1350), when real handlers adopt
+// projection. Do NOT read this invariant as "column leakage is already closed";
+// until PR-12 it guarantees only that a ResourceProjection, wherever one is
+// produced, came through the masking funnel.
+//
+// Tool blind spots (per AI-robust §"强制盲区自检"):
+//
+//   - An empty literal `projection.ResourceProjection{}` (no fields) DOES compile
+//     externally — Go permits a zero-value composite literal of a struct with
+//     unexported fields. That is harmless: the zero value marshals to JSON null
+//     (ZeroLiteralInert proves it), carrying no forged data. This lock targets
+//     POPULATED literals (field forgery), which the unexported field makes
+//     impossible — it does not (and need not) ban the empty form.
+//   - NewProjection(authz.FieldMask{}, full) legitimately yields the identity
+//     projection (the full view) through the funnel. That is by design (an empty
+//     obligation = no masking); the CORRECTNESS of the supplied mask is the PEP
+//     callsite's responsibility, locked downstream in PR-12, not here.
+//   - This is a reflect + go/types rule, not an EachContentFile content scan, so
+//     anti-vacuity is carried by the non-empty expected sets plus the
+//     NumField()>0 assertion — no synthetic red-case file is required.
+package archtest
+
+import (
+	"encoding/json"
+	"go/types"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/projection"
+)
+
+const resourceProjectionPkgPath = PlatformModulePath + "/pkg/projection"
+
+// TestResourceProjectionSealed01_AllFieldsUnexported reflectively asserts that
+// ResourceProjection has zero exported fields — the exact property that makes a
+// populated `projection.ResourceProjection{data: ...}` literal a compile error
+// outside pkg/projection.
+func TestResourceProjectionSealed01_AllFieldsUnexported(t *testing.T) {
+	t.Parallel()
+
+	pt := reflect.TypeOf(projection.ResourceProjection{})
+	if pt.Kind() != reflect.Struct {
+		t.Fatalf("RESOURCE-PROJECTION-SEALED-01: ResourceProjection is not a struct (kind=%s)", pt.Kind())
+	}
+	if pt.NumField() == 0 {
+		t.Fatal("RESOURCE-PROJECTION-SEALED-01: ResourceProjection has no fields — the seal would be vacuous")
+	}
+	for i := 0; i < pt.NumField(); i++ {
+		f := pt.Field(i)
+		if f.IsExported() {
+			t.Errorf("RESOURCE-PROJECTION-SEALED-01: ResourceProjection field %q is EXPORTED — this re-opens "+
+				"external populated-literal construction and breaks the sealed-construction Hard gate. Keep all "+
+				"fields unexported; build values only via NewProjection / NewProjectionList.", f.Name)
+		}
+	}
+}
+
+// TestResourceProjectionSealed01_WireSurfacePresent asserts the value-receiver
+// wire surface exists, so a regression that drops MarshalJSON (leaving consumers
+// unable to serialize a projection, tempting a field re-export) is caught here.
+func TestResourceProjectionSealed01_WireSurfacePresent(t *testing.T) {
+	t.Parallel()
+
+	pt := reflect.TypeOf(projection.ResourceProjection{})
+	if _, ok := pt.MethodByName("MarshalJSON"); !ok {
+		t.Error("RESOURCE-PROJECTION-SEALED-01: ResourceProjection is missing the MarshalJSON value-receiver " +
+			"method — the sealed wire surface must stay present so no consumer needs field access.")
+	}
+}
+
+// resourceProjectionScalarFuncs / resourceProjectionSliceFuncs are the exhaustive
+// sets of exported package-level functions in pkg/projection that may RETURN a
+// ResourceProjection (the single-resource funnel) or a []ResourceProjection (the
+// list funnel). Both always discharge the FieldMask obligation.
+var (
+	resourceProjectionScalarFuncs = map[string]struct{}{"NewProjection": {}}
+	resourceProjectionSliceFuncs  = map[string]struct{}{"NewProjectionList": {}}
+)
+
+// TestResourceProjectionSealed01_SoleReconstructionSurface pins the COMPLETE set
+// of exported funcs in pkg/projection that can yield a ResourceProjection (value
+// or pointer) or a []ResourceProjection. The composite-literal seal only blocks
+// `projection.ResourceProjection{...}`; a new exported func returning the type
+// would be a fresh forge path that skips masking and that the literal seal does
+// not cover. This go/types reverse self-check fails when either set drifts.
+func TestResourceProjectionSealed01_SoleReconstructionSurface(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{"./pkg/projection/..."}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != resourceProjectionPkgPath {
+				return nil
+			}
+			scope := p.Pkg.Scope()
+			obj := scope.Lookup("ResourceProjection")
+			if obj == nil {
+				return []Diagnostic{{Message: "RESOURCE-PROJECTION-SEALED-01/SoleReconstructionSurface: ResourceProjection not found"}}
+			}
+			projType := obj.Type()
+			sliceType := types.NewSlice(projType)
+
+			var scalarFuncs, sliceFuncs []string
+			for _, name := range scope.Names() {
+				o := scope.Lookup(name)
+				if !o.Exported() {
+					continue
+				}
+				fn, ok := o.(*types.Func)
+				if !ok {
+					continue
+				}
+				sig, ok := fn.Type().(*types.Signature)
+				if !ok {
+					continue
+				}
+				if sigReturnsType(sig, projType) {
+					scalarFuncs = append(scalarFuncs, name)
+				}
+				if sigReturnsSlice(sig, sliceType) {
+					sliceFuncs = append(sliceFuncs, name)
+				}
+			}
+
+			diags = append(diags, diffResourceProjectionSurface(
+				"exported funcs returning ResourceProjection", resourceProjectionScalarFuncs, scalarFuncs)...)
+			diags = append(diags, diffResourceProjectionSurface(
+				"exported funcs returning []ResourceProjection", resourceProjectionSliceFuncs, sliceFuncs)...)
+			return nil
+		})
+
+	Report(t, "RESOURCE-PROJECTION-SEALED-01/SoleReconstructionSurface", diags)
+}
+
+// TestResourceProjectionSealed01_ZeroLiteralInert proves, from a package external
+// to pkg/projection, that the only ResourceProjection literal expressible outside
+// the package (the zero value) carries no forged data — it marshals to JSON null.
+func TestResourceProjectionSealed01_ZeroLiteralInert(t *testing.T) {
+	t.Parallel()
+
+	b, err := json.Marshal(projection.ResourceProjection{})
+	if err != nil {
+		t.Fatalf("RESOURCE-PROJECTION-SEALED-01: zero-value MarshalJSON error: %v", err)
+	}
+	if string(b) != "null" {
+		t.Errorf("RESOURCE-PROJECTION-SEALED-01: zero ResourceProjection marshaled to %s, want null "+
+			"(an externally-expressible empty literal must carry no forged data)", b)
+	}
+}
+
+// sigReturnsSlice reports whether sig has any result identical to want (a slice
+// type). Complements the shared sigReturnsType, which covers value/pointer forms.
+func sigReturnsSlice(sig *types.Signature, want types.Type) bool {
+	res := sig.Results()
+	for i := 0; i < res.Len(); i++ {
+		if types.Identical(res.At(i).Type(), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// diffResourceProjectionSurface emits a diagnostic for each name in got not in
+// want (a new forge surface widening the seal) and each name in want missing from
+// got (a sanctioned surface vanished — the lock would otherwise go vacuous). It
+// mirrors the outbox diff helper but carries this rule's ID in its messages.
+func diffResourceProjectionSurface(label string, want map[string]struct{}, got []string) []Diagnostic {
+	gotSet := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		gotSet[g] = struct{}{}
+	}
+	var diags []Diagnostic
+
+	extra := make([]string, 0)
+	for g := range gotSet {
+		if _, ok := want[g]; !ok {
+			extra = append(extra, g)
+		}
+	}
+	sort.Strings(extra)
+	for _, g := range extra {
+		diags = append(diags, Diagnostic{
+			Message: "RESOURCE-PROJECTION-SEALED-01/SoleReconstructionSurface: unexpected " + label + ": " + g +
+				" — a new ResourceProjection-yielding surface skips the masking funnel. Justify it and pin it in " +
+				"the expected set, or remove it.",
+		})
+	}
+
+	missing := make([]string, 0)
+	for w := range want {
+		if _, ok := gotSet[w]; !ok {
+			missing = append(missing, w)
+		}
+	}
+	sort.Strings(missing)
+	for _, w := range missing {
+		diags = append(diags, Diagnostic{
+			Message: "RESOURCE-PROJECTION-SEALED-01/SoleReconstructionSurface: expected " + label + " " + w +
+				" not found — the sanctioned construction surface changed; the lock is now vacuous. Update the " +
+				"expected set if this rename/removal is intended.",
+		})
+	}
+	return diags
+}


### PR DESCRIPTION
## Summary

PR-11：新增 PEP 侧列级 masking 框架 `pkg/projection` —— sealed `ResourceProjection` + `NewProjection`/`NewProjectionList` 漏斗，强制 discharge `authz.FieldMask` obligation；handler 无法绕过 masking 伪造 full view。

## Why / 背景

EPIC #1337（多租户 + ABAC + 行列级数据权限）的 **L4 列级 masking 地基**。前置 PR-6 #1344 落了 `authz.FieldMask`（PDP 决策输出，inert string），PR-7 #1345 的评估引擎产出携 FieldMask 的 `Decision`，但**缺 PEP enforcement 机制**——handler 可直接把全量 map 序列化到 wire，绕过列 masking。

本 PR 落地 PEP 侧 sealed `ResourceProjection`：唯一能拿到「可序列化资源视图」的路径是 `NewProjection(mask, data)`，构造时强制 apply mask；字段全 unexported → 包外不可结构字面量伪造 full view（type-system Hard，对齐 `errcode.PublicDetail` / `outbox.Entry` / `authz.Decision` 范式）。

- **Mask 语义**：命中列值替换为 `redaction.Mask`（`"<REDACTED>"`），字段保留（响应字段集不变，无裂变）；空 FieldMask = identity 投影。
- **fail-closed**：PEP 无法 discharge 的 dotted（嵌套路径）mask field → 返回 500 而非放行未 masked 列（XACML PEP「无法 discharge mandatory obligation 必须拒绝」）。
- **archtest `RESOURCE-PROJECTION-SEALED-01`（Hard）**：unexported 字段冻结 + go/types sole-reconstruction-surface。诚实拆分评级——「handler 必须投影 + 用对 mask」的 callsite lock 与嵌套 masking 留 PR-12 #1350（godoc 写明 SCOPE）。

## Refs

- Closes #1349
- Parent EPIC #1337；权威设计源 `docs/plans/specs/1220-tenancy-abac-dataperm/tasks.md` T11.1–T11.3 + `research.md` §1.1
- 下游：PR-12 #1350（projection 应用到 auditquery + 读端点）
- ref: errcode.PublicDetail / outbox.Entry sealed-construction pattern；XACML 3.0 PEP obligation discharge；Snowflake DDM 列 masking

## Risk / 兼容性

**无破坏性变更**。纯 additive 新 leaf 包 `pkg/projection`，当前**零消费者**（handler 接线在 PR-12），无 wire/契约/migration 影响，无需同步消费方。无契约扇出（未改任何 contract schema / generated code / metadata）。不新增 errcode 前缀、不动 golden。

诚实说明：本 PR 在隔离状态下是「不可伪造的安全积木」，**不是已生效的列保护**——它保证「拿到的 ResourceProjection 必经 NewProjection」，但「handler 必须用它 + 用对 Decision 的 FieldMask」的 callsite lock 要 PR-12 才闭环（与 EPIC wave3 框架 / wave4 应用切分一致）。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./pkg/projection/...` 本地通过（coverage 100%）
- [x] `go test -tags=archtest ./tools/archtest -run TestResourceProjectionSealed01` 4/4 通过（含 go/types sole-reconstruction-surface）
- [x] `golangci-lint run`（pkg/projection 全新包 + 新 archtest 文件 new-from-develop）0 issues
