### PR TITLE
fix(rabbitmq): quorum at-least-once dead-lettering for webhook delay tiers [#1835]

### DIFF
--- a/adapters/rabbitmq/integration_test.go
+++ b/adapters/rabbitmq/integration_test.go
@@ -423,6 +423,14 @@ func TestIntegration_WebhookDelaySchedule_RoutesToDLQAfterExhaustion(t *testing.
 		BrokerDelaySchedule: schedule,
 	}
 
+	// Explicit broker-accept gate (#1835): Setup declares the full topology
+	// synchronously, so a real broker that rejected the quorum delay tiers'
+	// at-least-once + reject-publish arg combo fails HERE with a clear error
+	// instead of surfacing as a downstream subscriber-ready timeout. Idempotent
+	// with the re-declare inside Subscribe below.
+	require.NoError(t, sub.Setup(ctx, subscription),
+		"broker must accept the quorum at-least-once delay-tier topology")
+
 	var callCount atomic.Int32
 	subCtx, subCancel := context.WithTimeout(ctx, testtime.CtxLong)
 	defer subCancel()

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -403,13 +403,22 @@ func (s *Subscriber) declareTopology(ch AMQPChannel, topic, queueName string, sc
 // when BrokerDelaySchedule is non-empty. All operations are idempotent.
 //
 // Topology per tier i:
-//   - Queue: <queueName>.delay.<i>
+//   - Queue: <queueName>.delay.<i> (quorum, at-least-once dead-lettering)
 //   - x-message-ttl: schedule[i] in milliseconds (int64)
 //   - x-dead-letter-exchange: topic (the dispatch fanout exchange)
 //   - Bound to delay exchange with routing key strconv.Itoa(i)
 //
 // On TTL expiry the broker dead-letters the message back to topic (the fanout),
 // which re-enqueues it into the main consumer queue for the next handler attempt.
+//
+// The tiers are quorum queues with x-dead-letter-strategy=at-least-once (#1835):
+// classic queues republish on the internal TTL→dead-letter hop WITHOUT publisher
+// confirms, so a cluster node failure mid-hop can drop a scheduled retry. Quorum
+// at-least-once dead-lettering confirms that internal hop, closing the cluster
+// gap. x-overflow=reject-publish is a hard precondition — at-least-once silently
+// degrades to at-most-once under the default drop-head overflow (the broker
+// raises no error), so it must stay set (ref: rabbitmq docs/dlx + quorum-queues;
+// ref: Particular/NServiceBus.RabbitMQ DelayInfrastructure.cs).
 func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName string, schedule []time.Duration) error {
 	delayExchange := queueName + ".delay"
 	if err := ch.ExchangeDeclare(delayExchange, "direct", true, false, false, false, nil); err != nil {
@@ -419,6 +428,9 @@ func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName strin
 	for i, d := range schedule {
 		tierQueue := fmt.Sprintf("%s.delay.%d", queueName, i)
 		tierArgs := amqp.Table{
+			// Quorum queue so the broker-internal TTL→dead-letter republish can be
+			// publisher-confirmed (classic queues cannot); see func godoc / #1835.
+			"x-queue-type":           "quorum",
 			"x-message-ttl":          d.Milliseconds(), // int64 of milliseconds; TTL fires expiry to re-enter dispatch fanout
 			"x-dead-letter-exchange": topic,
 			// Reset the routing key on TTL-expiry dead-letter back to the canonical
@@ -429,17 +441,26 @@ func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName strin
 			// silently never receive the exhausted webhook. The dispatch exchange
 			// is fanout, so re-entry routing is unaffected by the key.
 			"x-dead-letter-routing-key": "",
+			// at-least-once dead-lettering turns publisher confirms on for the
+			// internal TTL→DLX hop. reject-publish is mandatory: under the default
+			// drop-head overflow the strategy SILENTLY falls back to at-most-once
+			// (no broker error), re-opening the cluster gap #1835 closes. Do not
+			// remove either; the unit test pins both as the regression guard.
+			"x-dead-letter-strategy": "at-least-once",
+			"x-overflow":             "reject-publish",
 		}
 		if _, err := ch.QueueDeclare(tierQueue, true, false, false, false, tierArgs); err != nil {
 			// AMQP 406 PRECONDITION_FAILED is returned when the queue already
-			// exists with different arguments (e.g. a changed x-message-ttl from
-			// a new BrokerDelaySchedule). Changing the schedule requires the
+			// exists with different arguments — either a changed x-message-ttl from
+			// a new BrokerDelaySchedule, or a pre-#1835 classic queue whose
+			// x-queue-type now differs (quorum). Both require the same
 			// drain-before-delete runbook — a non-empty tier queue holds webhooks
 			// still waiting out their retry interval, so deleting it blindly drops
 			// pending retries.
 			return fmt.Errorf("rabbitmq: declare delay tier queue %d (%s): %w"+
-				" (hint: AMQP 406 PRECONDITION_FAILED means the queue exists with a"+
-				" different x-message-ttl; to change the schedule follow the"+
+				" (hint: AMQP 406 PRECONDITION_FAILED means the queue exists with"+
+				" different args — a changed x-message-ttl or a pre-#1835 classic"+
+				" queue being upgraded to quorum; either way follow the"+
 				" drain-before-delete runbook in"+
 				" docs/ops/rabbitmq-webhook-delay-topology.md)", i, tierQueue, err)
 		}

--- a/adapters/rabbitmq/subscriber.go
+++ b/adapters/rabbitmq/subscriber.go
@@ -450,19 +450,26 @@ func (s *Subscriber) declareDelayTopology(ch AMQPChannel, topic, queueName strin
 			"x-overflow":             "reject-publish",
 		}
 		if _, err := ch.QueueDeclare(tierQueue, true, false, false, false, tierArgs); err != nil {
-			// AMQP 406 PRECONDITION_FAILED is returned when the queue already
-			// exists with different arguments — either a changed x-message-ttl from
-			// a new BrokerDelaySchedule, or a pre-#1835 classic queue whose
-			// x-queue-type now differs (quorum). Both require the same
-			// drain-before-delete runbook — a non-empty tier queue holds webhooks
-			// still waiting out their retry interval, so deleting it blindly drops
-			// pending retries.
+			// A QueueDeclare failure here has two distinct operator causes, and the
+			// hint must surface both so an old-broker failure is not misrouted to the
+			// drain runbook (#1858 F2):
+			//   1. The queue already EXISTS with different arguments — a changed
+			//      x-message-ttl from a new BrokerDelaySchedule, or a pre-#1835
+			//      classic queue whose x-queue-type now differs (quorum). This is a
+			//      406 PRECONDITION_FAILED, resolved by the drain-before-delete
+			//      runbook (a non-empty tier queue holds webhooks still waiting out
+			//      their retry interval, so deleting it blindly drops pending retries).
+			//   2. A FRESH declare the broker cannot satisfy — RabbitMQ older than
+			//      3.10 or the quorum_queue/stream_queue feature flags disabled — so
+			//      the quorum + at-least-once declaration is rejected or cannot apply.
+			//      Resolved by verifying the broker prerequisite, NOT by draining.
 			return fmt.Errorf("rabbitmq: declare delay tier queue %d (%s): %w"+
-				" (hint: AMQP 406 PRECONDITION_FAILED means the queue exists with"+
-				" different args — a changed x-message-ttl or a pre-#1835 classic"+
-				" queue being upgraded to quorum; either way follow the"+
-				" drain-before-delete runbook in"+
-				" docs/ops/rabbitmq-webhook-delay-topology.md)", i, tierQueue, err)
+				" (hint: two causes — (1) the queue already exists with different args"+
+				" (a changed x-message-ttl, or a pre-#1835 classic queue upgrading to"+
+				" quorum): follow the drain-before-delete runbook in"+
+				" docs/ops/rabbitmq-webhook-delay-topology.md; (2) a fresh declare the"+
+				" broker cannot satisfy: verify RabbitMQ >= 3.10 and the"+
+				" quorum_queue/stream_queue feature flags are enabled)", i, tierQueue, err)
 		}
 		if err := ch.QueueBind(tierQueue, strconv.Itoa(i), delayExchange, false, nil); err != nil {
 			return fmt.Errorf("rabbitmq: bind delay tier queue %d: %w", i, err)

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -288,6 +288,11 @@ func TestDeclareDelayTopology_TierQueueDeclareFailure_WrapsRunbookHint(t *testin
 	assert.Contains(t, err.Error(), "quorum", "hint must mention the classic→quorum upgrade case")
 	assert.Contains(t, err.Error(), "drain-before-delete runbook", "hint must point operators at the runbook")
 	assert.ErrorContains(t, err, "PRECONDITION_FAILED", "underlying broker error must be wrapped, not swallowed")
+	// #1858 F2 (codex): the hint must surface BOTH 406 recovery paths, not just the
+	// existing-queue migration one — a fresh declare can also fail because the broker
+	// is too old / the quorum feature flags are off.
+	assert.Contains(t, err.Error(), "3.10", "hint must surface the RabbitMQ >=3.10 broker-prerequisite recovery path")
+	assert.Contains(t, err.Error(), "feature flag", "hint must mention the quorum_queue/stream_queue feature-flag prerequisite")
 }
 
 func TestDeclareTopology_EmptySchedule_NoDelayTopology(t *testing.T) {

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -265,7 +265,7 @@ func assertQuorumAtLeastOnce(t *testing.T, args amqp.Table, tier string) {
 		"%s must set reject-publish overflow; drop-head silently degrades at-least-once to at-most-once", tier)
 }
 
-func TestDeclareTopology_EmptySchedule_NoDeLlayTopology(t *testing.T) {
+func TestDeclareTopology_EmptySchedule_NoDelayTopology(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 	ch := newMockChannel()
 	mockConn.nextCh = ch

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -217,10 +217,12 @@ func TestDeclareTopology_WithDelaySchedule_DeclaresDelayTiers(t *testing.T) {
 	assert.Equal(t, int64(200), tier0Args["x-message-ttl"], "tier 0 x-message-ttl must be 200ms as int64")
 	assert.Equal(t, topic, tier0Args["x-dead-letter-exchange"], "tier 0 x-dead-letter-exchange must point to dispatch exchange")
 	assert.Equal(t, "", tier0Args["x-dead-letter-routing-key"], "tier 0 must reset routing key to canonical empty")
+	assertQuorumAtLeastOnce(t, tier0Args, "tier 0")
 
 	assert.Equal(t, int64(500), tier1Args["x-message-ttl"], "tier 1 x-message-ttl must be 500ms as int64")
 	assert.Equal(t, topic, tier1Args["x-dead-letter-exchange"], "tier 1 x-dead-letter-exchange must point to dispatch exchange")
 	assert.Equal(t, "", tier1Args["x-dead-letter-routing-key"], "tier 1 must reset routing key to canonical empty")
+	assertQuorumAtLeastOnce(t, tier1Args, "tier 1")
 
 	// Bindings: tier 0 bound with routing key "0", tier 1 with "1".
 	var tier0Detail, tier1Detail *queueBindDetail
@@ -242,6 +244,25 @@ func TestDeclareTopology_WithDelaySchedule_DeclaresDelayTiers(t *testing.T) {
 
 	assert.Equal(t, "1", tier1Detail.key, "tier 1 routing key must be \"1\"")
 	assert.Equal(t, delayExchange, tier1Detail.exchange, "tier 1 must bind to delay exchange")
+}
+
+// assertQuorumAtLeastOnce pins the three arguments that make a delay tier's
+// broker-internal TTL→dead-letter republish at-least-once (#1835): a quorum
+// queue with the at-least-once dead-letter strategy. This is the Medium guard
+// for the change — the assertions fail in CI if a future edit drops any of them.
+//
+// x-overflow=reject-publish is the highest-risk one: RabbitMQ silently falls
+// back to at-most-once dead-lettering if the overflow strategy is the default
+// drop-head (the broker raises NO error), so removing it would re-open the
+// cluster gap with no other signal. The unit assertion is the signal.
+func assertQuorumAtLeastOnce(t *testing.T, args amqp.Table, tier string) {
+	t.Helper()
+	assert.Equal(t, "quorum", args["x-queue-type"],
+		"%s must be a quorum queue (classic internal dead-letter republish is not at-least-once)", tier)
+	assert.Equal(t, "at-least-once", args["x-dead-letter-strategy"],
+		"%s must use at-least-once dead-lettering so the TTL→DLX hop is publisher-confirmed", tier)
+	assert.Equal(t, "reject-publish", args["x-overflow"],
+		"%s must set reject-publish overflow; drop-head silently degrades at-least-once to at-most-once", tier)
 }
 
 func TestDeclareTopology_EmptySchedule_NoDeLlayTopology(t *testing.T) {

--- a/adapters/rabbitmq/subscriber_webhook_delay_test.go
+++ b/adapters/rabbitmq/subscriber_webhook_delay_test.go
@@ -265,6 +265,31 @@ func assertQuorumAtLeastOnce(t *testing.T, args amqp.Table, tier string) {
 		"%s must set reject-publish overflow; drop-head silently degrades at-least-once to at-most-once", tier)
 }
 
+// TestDeclareDelayTopology_TierQueueDeclareFailure_WrapsRunbookHint covers the
+// 406 PRECONDITION_FAILED branch of declareDelayTopology: when a tier
+// QueueDeclare fails — e.g. a pre-#1835 classic tier queue whose x-queue-type now
+// differs from the quorum declaration — the returned error must name the failing
+// tier, mention the classic→quorum case, point at the drain-before-delete runbook,
+// and wrap (not swallow) the underlying broker error so an operator can recover.
+func TestDeclareDelayTopology_TierQueueDeclareFailure_WrapsRunbookHint(t *testing.T) {
+	conn, _ := newTestConnection(t)
+	ch := newMockChannel()
+	// Simulate the broker rejecting the quorum redeclare over an existing classic
+	// tier queue (the classic→quorum 406 migration path).
+	ch.queueDeclareErr = errors.New("PRECONDITION_FAILED - inequivalent arg 'x-queue-type'")
+
+	sub := NewSubscriber(clock.Real(), conn, SubscriberConfig{DLXExchange: "test.dlx"})
+
+	err := sub.declareDelayTopology(ch, "session.created", "cg-1.session.created",
+		[]time.Duration{testtime.D200ms})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declare delay tier queue 0", "error must name the failing tier index")
+	assert.Contains(t, err.Error(), "quorum", "hint must mention the classic→quorum upgrade case")
+	assert.Contains(t, err.Error(), "drain-before-delete runbook", "hint must point operators at the runbook")
+	assert.ErrorContains(t, err, "PRECONDITION_FAILED", "underlying broker error must be wrapped, not swallowed")
+}
+
 func TestDeclareTopology_EmptySchedule_NoDelayTopology(t *testing.T) {
 	conn, mockConn := newTestConnection(t)
 	ch := newMockChannel()

--- a/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
+++ b/docs/architecture/202606012052-1160-adr-webhook-retry-default.md
@@ -188,10 +188,12 @@ so adapters never import `kernel/webhook`):
   only on deliveries the broker attests expired from this queue's own `.delay.`
   tier (`x-death` provenance), never on a header that could be forged by a direct
   publish (#1828 F6); once `attempt > len(schedule)` the entry is
-  `Nack(requeue=false)` → DLX. Delays are held in **durable queues**, so the
-  ~40 h envelope survives process and broker-node restarts (unlike the community
-  `x-delayed-message` plugin, which holds delayed messages in node memory —
-  explicitly rejected).
+  `Nack(requeue=false)` → DLX. Delays are held in **durable quorum queues with
+  at-least-once dead-lettering** (#1835), so the ~40 h envelope survives process
+  and broker-node restarts AND the broker-internal TTL→dead-letter hop is
+  publisher-confirmed on a cluster (unlike the community `x-delayed-message`
+  plugin, which holds delayed messages in node memory — explicitly rejected). See
+  the threat re-evaluation below for the precise at-least-once boundary.
 - **in-memory bus**: `handleWithRetry` uses `len(schedule)+1` deliveries as the
   budget and waits `schedule[attempt]` via the injected clock between attempts;
   exhaustion routes to the dead-letter slice.
@@ -209,9 +211,9 @@ so adapters never import `kernel/webhook`):
   `BrokerDelaySchedule` fails CI rather than silently degrading to immediate
   retry. The new `Subscription` field is locked by `SUBSCRIPTION-FIELDS-FROZEN-01`.
 
-**Threat / safety re-evaluation (re-amended 2026-06-11, #1828 review).** The 30 s
-ConsumerBase ceiling no longer applies to webhook dispatch; the full ~40 h Svix
-envelope is realized.
+**Threat / safety re-evaluation (re-amended 2026-06-11, #1828 review; #1835 quorum
+closure).** The 30 s ConsumerBase ceiling no longer applies to webhook dispatch;
+the full ~40 h Svix envelope is realized.
 
 At-least-once across the **application** boundary holds: the delay round-trip
 **releases (does not commit)** the idempotency receipt and the delay-tier
@@ -219,17 +221,28 @@ republish is publisher-confirmed (#1828 F1), so the redelivered same-`entry.ID`
 message re-claims and the handler re-runs — downstream handlers must remain
 idempotent (already required).
 
-One residual gap is **not** closed here and supersedes the earlier blanket
-"at-least-once delivery is unchanged" claim: the per-tier delay queues are
-RabbitMQ **classic** queues, and the broker-internal TTL→dead-letter republish
-on a classic queue is best-effort (the internal hop is not publisher-confirmed).
-On a **single-node** broker this is reliable; on a **multi-node cluster** a node
-failure *during* that internal republish can drop one scheduled retry. The next
-business event or a manual replay recovers it (handlers are idempotent), so the
-delay hop is **at-least-once on single-node and best-effort under clustering** —
-not unconditionally at-least-once. Closing the cluster gap requires quorum queues
-with at-least-once dead-lettering, a separate infrastructure decision tracked at
-**#1835** (#1828 F2).
+The cluster gap previously tracked at #1835 is now **closed** (re-amended
+2026-06-11, #1835). The per-tier delay queues are RabbitMQ **quorum** queues with
+`x-dead-letter-strategy=at-least-once` (and the mandatory `x-overflow=reject-publish`
+— under the default `drop-head` overflow the strategy silently degrades to
+at-most-once with no broker error). The broker-internal TTL→dead-letter republish
+— best-effort on a classic queue, droppable by a node failure mid-hop on a
+multi-node cluster — is now publisher-confirmed by the source quorum queue
+(at-least-once dead-lettering retains the message until that internal confirm
+arrives). The scheduled **TTL→re-dispatch** retry hops are therefore at-least-once
+on single-node **and** clustered deployments. Existing classic `.delay.` queues
+need a one-time drain-before-recreate on first deploy (406 PRECONDITION_FAILED);
+see `docs/ops/rabbitmq-webhook-delay-topology.md`.
+
+One narrower hop stays best-effort **by design** and must not be over-claimed: the
+*terminal* `attempt > len(schedule)` exhaustion `Nack(requeue=false)` → real-DLX
+routing leaves the **main consumer queue** (classic), whose own dead-letter hop is
+not publisher-confirmed. A message reaching it has already exhausted all ~40 h /
+7 scheduled attempts; losing that terminal routing on a node failure is recoverable
+by manual replay (handlers idempotent) and is out of scope for #1835, which names
+only the scheduled delay-tier hop. Quorum-ifying the main queue is an independent
+decision — `declareTopology` is shared by every non-webhook subscription — and is
+not pursued here.
 
 No new wire field or PII surface is introduced; `x-webhook-attempt` is internal
 broker metadata, never part of the signed payload, and is provenance-gated

--- a/docs/ops/rabbitmq-webhook-delay-topology.md
+++ b/docs/ops/rabbitmq-webhook-delay-topology.md
@@ -5,6 +5,12 @@ via broker-native delayed re-delivery (#1458, ADR `202606012052-1160-adr-webhook
 §D5). Operators will see **extra RabbitMQ queues and an exchange per webhook-dispatch
 subscription** — this doc explains them.
 
+> **Broker requirement: RabbitMQ ≥ 3.10.** The delay tiers use the
+> `x-dead-letter-strategy=at-least-once` queue argument, a quorum-queue feature
+> introduced in 3.10 (the `quorum_queue` + `stream_queue` feature flags must be
+> enabled — both are on by default from 3.12). On an older broker `QueueDeclare`
+> fails with 406 PRECONDITION_FAILED.
+
 ## Topology
 
 For a webhook-dispatch subscription whose dispatch queue is `Q` (derived from

--- a/docs/ops/rabbitmq-webhook-delay-topology.md
+++ b/docs/ops/rabbitmq-webhook-delay-topology.md
@@ -14,7 +14,7 @@ For a webhook-dispatch subscription whose dispatch queue is `Q` (derived from
 X (fanout, dispatch) ──► Q (dispatch queue; x-dead-letter-exchange = real DLX)
                           └─ consumer: webhook dispatcher (signs + POSTs)
 
-Q.delay (direct, the delay exchange)
+Q.delay (direct, the delay exchange)        [all Q.delay.* are quorum, at-least-once DLX]
   ├─ rk "0" ─► Q.delay.0   x-message-ttl = 5s,    no consumer, x-dead-letter-exchange = X
   ├─ rk "1" ─► Q.delay.1   x-message-ttl = 5min,  …
   ├─ rk "2" ─► Q.delay.2   x-message-ttl = 30min
@@ -24,33 +24,50 @@ Q.delay (direct, the delay exchange)
   └─ rk "6" ─► Q.delay.6   x-message-ttl = 10h
 ```
 
-All `Q.delay*` queues are **durable** (the ~40h envelope survives broker/process
-restart — no `x-delayed-message` plugin is used). On the Nth POST failure the
+All `Q.delay*` queues are **durable quorum** queues with at-least-once
+dead-lettering (#1835) — the ~40h envelope survives broker/process restart and the
+internal TTL→DLX hop is publisher-confirmed on a cluster; no `x-delayed-message`
+plugin is used. On the Nth POST failure the
 subscriber republishes to `Q.delay.{N-1}`; on TTL expiry the message dead-letters
 back to `X` → `Q` and is re-consumed. The attempt counter rides the
 `x-webhook-attempt` AMQP header (broker-internal; never part of the signed HTTP
 payload). Once the attempt exceeds the schedule length the entry is
 `Nack(requeue=false)` → the queue's **real DLX**.
 
-## Reliability (classic-queue caveat)
+## Reliability
 
-The subscriber republishes to a delay tier with **publisher confirms** and Acks
-the original delivery only after the broker confirms the copy, so the
-application-side hop does not lose messages on a channel/broker drop. The delay
-queues are **classic** queues, however, and RabbitMQ's broker-internal
-TTL→dead-letter republish on a classic queue is **best-effort** (the internal hop
-is not publisher-confirmed):
+A delivery moves through the retry cycle in two hops, each with its own guarantee:
 
-- **Single-node broker** — reliable; the durable queue holds the message until TTL
-  expiry and the internal dead-letter re-enters the dispatch queue.
-- **Multi-node cluster** — a node failure *during* the internal TTL→DLX republish
-  can drop that one scheduled retry. The next business event or a manual replay
-  recovers it (webhook handlers are idempotent), so a missed retry is degraded —
-  not corrupting — behaviour.
+1. **app → delay-tier republish** — the subscriber republishes to a delay tier
+   with **publisher confirms** and Acks the original delivery only after the broker
+   confirms the copy, so this hop does not lose messages on a channel/broker drop.
+2. **broker-internal TTL → dead-letter re-dispatch** — the delay queues are
+   **quorum** queues declared with `x-dead-letter-strategy=at-least-once` (and the
+   mandatory `x-overflow=reject-publish`), so the broker's internal TTL-expiry
+   republish back to the dispatch exchange is **publisher-confirmed by the source
+   queue**: the quorum queue retains the message until the internal confirm
+   arrives. This closes the multi-node-cluster gap classic queues left open (a node
+   failure mid-hop could drop one scheduled retry). #1835.
 
-Upgrading the delay tiers to **quorum queues with at-least-once dead-lettering**
-to close the cluster gap is tracked at **#1835**. Until then, treat clustered
-webhook retry as at-least-once-best-effort on the internal hop.
+Both scheduled-retry hops are therefore **at-least-once on single-node and
+clustered** deployments.
+
+> **One terminal hop stays best-effort by design — do not over-read the guarantee.**
+> Once a delivery exhausts the schedule (`attempt > len(schedule)`) it is
+> `Nack(requeue=false)`'d to the **real DLX** from the **main consumer queue** `Q`,
+> which is a **classic** queue — that final dead-letter hop is not
+> publisher-confirmed. A message reaching it has already failed all ~40h / 7
+> attempts; a node failure on this terminal routing is recoverable by manual replay
+> (handlers are idempotent). Only the **scheduled delay-tier** hops are
+> at-least-once; "the whole webhook retry chain is at-least-once" is **not** a
+> correct reading. Quorum-ifying `Q` (shared by every non-webhook subscription) was
+> deliberately out of scope for #1835.
+
+> ⚠️ **Policy caveat.** Do **not** apply a `max-length` policy with the default
+> `drop-head` overflow to the `*.delay.*` queues: at-least-once dead-lettering
+> **silently degrades to at-most-once** under `drop-head` (the broker raises no
+> error). The queues are declared with `reject-publish`; any operator policy that
+> touches them must preserve it.
 
 ## Identifying these queues
 
@@ -67,13 +84,25 @@ webhook retry as at-least-once-best-effort on the internal hop.
   `webhook_deliveries_total{result="..."}` metric.
 - The delay queues are bounded per subscription (one queue per schedule tier).
 
+## One-time classic → quorum migration (#1835)
+
+Deployments created **before #1835** have **classic** `*.delay.*` queues. The first
+deploy that carries the quorum declaration cannot change an existing queue's type in
+place, so `QueueDeclare` fails with **406 PRECONDITION_FAILED** (`x-queue-type`
+differs) and stops the affected webhook-dispatch subscription — the same failure mode
+as a schedule change. Apply the **drain-before-recreate** procedure below once per
+environment; afterwards the tiers are quorum and no further migration is needed.
+Fresh deployments declare quorum tiers from the start and skip this entirely.
+
 ## Changing the schedule (PRECONDITION_FAILED / 406)
 
-The tier `x-message-ttl` values are baked into the queue declaration. RabbitMQ does
-**not** allow redeclaring an existing queue with different arguments, so changing the
-schedule (today fixed at `DefaultSvixSchedule`) and redeploying will fail
+The tier `x-message-ttl` values (and `x-queue-type`) are baked into the queue
+declaration. RabbitMQ does **not** allow redeclaring an existing queue with different
+arguments, so changing the schedule (today fixed at `DefaultSvixSchedule`) **or
+upgrading a pre-#1835 classic tier to quorum** and redeploying will fail
 `QueueDeclare` with **406 PRECONDITION_FAILED** — a non-recoverable error that stops
-the affected webhook-dispatch subscription.
+the affected webhook-dispatch subscription. The drain-before-recreate steps below
+cover both cases.
 
 > ⚠️ A non-empty `*.delay.<i>` queue holds **webhooks still waiting out their retry
 > interval** (see "Identifying these queues"), not garbage. Deleting it drops those

--- a/docs/ops/rabbitmq-webhook-delay-topology.md
+++ b/docs/ops/rabbitmq-webhook-delay-topology.md
@@ -8,8 +8,11 @@ subscription** — this doc explains them.
 > **Broker requirement: RabbitMQ ≥ 3.10.** The delay tiers use the
 > `x-dead-letter-strategy=at-least-once` queue argument, a quorum-queue feature
 > introduced in 3.10 (the `quorum_queue` + `stream_queue` feature flags must be
-> enabled — both are on by default from 3.12). On an older broker `QueueDeclare`
-> fails with 406 PRECONDITION_FAILED.
+> enabled — both are on by default from 3.12). A broker that does not meet this
+> prerequisite **rejects the quorum/at-least-once declaration (or, for some
+> version/arg combinations, fails to apply it)** — so a `QueueDeclare` failure on a
+> *fresh* deploy points at the broker version / feature flags, not at a queue-arg
+> mismatch (see the two recovery paths under "Changing the schedule" below).
 
 ## Topology
 
@@ -109,6 +112,14 @@ upgrading a pre-#1835 classic tier to quorum** and redeploying will fail
 `QueueDeclare` with **406 PRECONDITION_FAILED** — a non-recoverable error that stops
 the affected webhook-dispatch subscription. The drain-before-recreate steps below
 cover both cases.
+
+> **Two declare-failure causes — only one is a drain.** The steps below apply when an
+> **existing** queue has different args (schedule change, or classic→quorum upgrade).
+> If a **fresh** declare fails instead (no prior `*.delay.*` queue), the cause is the
+> broker prerequisite — RabbitMQ < 3.10 or disabled `quorum_queue`/`stream_queue`
+> feature flags (see "Broker requirement" at the top) — and draining does nothing; fix
+> the broker, then redeploy. The runtime `declare delay tier queue` error spells out
+> both recovery paths.
 
 > ⚠️ A non-empty `*.delay.<i>` queue holds **webhooks still waiting out their retry
 > interval** (see "Identifying these queues"), not garbage. Deleting it drops those


### PR DESCRIPTION
## Summary

Webhook 重试延迟层升级为 RabbitMQ **quorum queue + at-least-once dead-lettering**，关闭 classic 队列内部 TTL→DLX republish 在多节点 cluster 下可能丢一次已排程重试的缺口。

## Why / 背景

- classic 延迟层的 **broker 内部 TTL→dead-letter republish 不打 publisher confirm**（官方 DLX 文档：clustered DLX 非 at-least-once）。多节点 cluster 节点故障 mid-hop 可丢一次已排程重试。
- #1828 F1 已闭合 **app→broker** 跳（republish 改 confirm-mode，confirm 后才 Ack 原投递）；#1828 F2 把残余的 **broker 内部跳**挂账到本 issue。ADR §D5 / ops 文档此前已诚实降级为「单节点 at-least-once / cluster best-effort」。
- 本 PR 把延迟层声明为 `x-queue-type=quorum` + `x-dead-letter-strategy=at-least-once`（+ 强制 `x-overflow=reject-publish`）：**at-least-once dead-lettering 是源队列属性**，源 quorum 队列在内部 confirm 收到前保留消息 → **scheduled TTL→re-dispatch 跳在 cluster 下也 at-least-once**。
- 同步重评 ADR §D5 安全模型（AI-robust 章程要求 ADR amendment 同改安全模型），**精确限定**新承诺，不反向过度声称（终态 exhaustion→DLX 跳仍 classic best-effort，by-design 保留 caveat）。

## Refs

- Closes #1835
- ADR `docs/architecture/202606012052-1160-adr-webhook-retry-default.md` §D5（threat/safety re-eval, #1835 quorum closure）
- ops `docs/ops/rabbitmq-webhook-delay-topology.md`（Reliability 重写 + classic→quorum 一次性迁移 runbook + drop-head policy caveat）
- ref: rabbitmq/rabbitmq-server docs/dlx + quorum-queues（at-least-once dead-lettering，3.10+；源队列保留至内部 publisher confirm）
- ref: Particular/NServiceBus.RabbitMQ DelayInfrastructure.cs（逐字先例：delay-level 队列 quorum + at-least-once + reject-publish，主接收队列独立轴）

## Risk / 兼容性

- **一次性 migration**：既有 pre-#1835 classic `*.delay.*` 队列首次部署报 **406 PRECONDITION_FAILED**（`x-queue-type` 不可原地改）。需 drain-before-recreate（复用既有 runbook，ops 文档已补「classic→quorum 一次性迁移」节）。新部署直接声明 quorum，无需迁移。
- **fail-fast，无软回退**：406 直接冒泡停订阅，不回退 classic（符合单上下文无向后兼容原则）。
- **无 wire / contract 变更**：队列参数是 broker topology，非 wire contract；无 generated / governance 改动。
- **范围边界（显式 non-goal）**：只改延迟层；主队列「重试耗尽→真 DLX」终态跳仍 classic best-effort（#1835 未点名；`declareTopology` 为全订阅共用，quorum 化主队列是独立决策）。
- **隐坑（已闭环守卫）**：运维勿给 `*.delay.*` 加 `drop-head` max-length policy → at-least-once **静默退化 at-most-once**（broker 不报错）；已在 ops 文档 + 代码注释 + 单测三处钉死 `reject-publish`。

### Implementation matrix（contract-fanout）

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| delay tier → quorum + at-least-once dead-lettering | 无（broker topology，非 wire） | 无 | 无 | 单测（钉死 3 参数）+ 集成（broker-accept + e2e） | ADR §D5 + ops |

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./adapters/rabbitmq/...` 单测通过（新增三 quorum 参数断言：x-queue-type / x-dead-letter-strategy / x-overflow，含 silent-degrade WHY 注释）
- [x] `golangci-lint run ./...` 0 issues（v2.11.4，与 pinned 一致）
- [x] 集成测试 real RabbitMQ 3.12.14：新增 `Setup` broker-accept gate 通过（broker 接受 quorum+at-least-once+reject-publish 组合）+ 端到端 TTL→delay→exhaust→DLX 通过
- 盲区（显式）：真·多节点 node-failure 期间 at-least-once 无法单测/集成验证（需 cluster + 故障注入），由 RabbitMQ quorum at-least-once 实现本身保证；ADR/ops 已标注

🤖 Generated with [Claude Code](https://claude.com/claude-code)
