### PR TITLE
fix(examples): iotdevice internal listener loopback + listener/setup 文档 [#1831 PR-6]

### DIFF
--- a/.claude/rules/gocell/api-versioning.md
+++ b/.claude/rules/gocell/api-versioning.md
@@ -43,4 +43,5 @@ bootstrap admin 路径形状由单一谓词 `metadata.IsBootstrapPath`
 `auth.bootstrap:true` 出现在匹配该谓词的路径上，缺 cell 段的 `/api/v1/setup/admin` 被
 fail-closed 拒绝。破坏式 wire 变更照常走所属 Cell 的版本目录升级，与上文规则一致。
 
-参考 ADR：`202605061600`（bootstrap admin boundary）、`202606021200`（pre-auth tenant header）。
+参考 ADR：`docs/architecture/202605061600-adr-bootstrap-admin-boundary.md`、
+`docs/architecture/202606021200-1160-adr-pre-auth-tenant-header-contract.md`。

--- a/.claude/rules/gocell/api-versioning.md
+++ b/.claude/rules/gocell/api-versioning.md
@@ -23,3 +23,24 @@ GoCell 当前 pre-GA，不保留旧 Go API shim。HTTP / event / command wire co
 - contract.yaml 声明鉴权和 caller
 - path、schema、handler、generated code 同步
 - 破坏式 wire 变更新增版本
+
+## Setup / bootstrap 路径
+
+没有顶级 `/api/v1/setup/` 命名空间。首启动引导端点和所有业务端点一样挂在所属 Cell 的版本化
+前缀下，遵循同一 `/api/v{N}/{cell}/...` 约定：
+
+- bootstrap admin：`/api/v{N}/{cell}/setup/admin`（如 `/api/v1/access/setup/admin`）
+- setup status：`/api/v{N}/{cell}/setup/status`
+
+「setup」的特殊性在鉴权与生命周期，不在路径位置：
+
+- 鉴权用 `auth.bootstrap:true`（HTTP Basic + 环境凭据），不是 JWT/RBAC。
+- admin 创建后端点返回 410 Gone（一次性引导边界）。
+- pre-auth 阶段经 `X-Tenant-ID` header 解析租户（此时还没有 JWT claim）。
+
+bootstrap admin 路径形状由单一谓词 `metadata.IsBootstrapPath`
+（`^/api/v\d+/[^/]+/setup/admin$`，强制带 cell 段）锁定；治理规则 `FMT-28` 只允许
+`auth.bootstrap:true` 出现在匹配该谓词的路径上，缺 cell 段的 `/api/v1/setup/admin` 被
+fail-closed 拒绝。破坏式 wire 变更照常走所属 Cell 的版本目录升级，与上文规则一致。
+
+参考 ADR：`202605061600`（bootstrap admin boundary）、`202606021200`（pre-auth tenant header）。

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export GOCELL_TODOORDER_SERVICE_SECRET="$(openssl rand -base64 32)"
 # reads $GOCELL_JWT_PRIVATE_KEY/$GOCELL_JWT_ISSUER/$GOCELL_JWT_AUDIENCE from env
 export TODOORDER_TOKEN="$(go run ./examples/todoorder/localtoken)"
 
-# Step 4 — start the server (primary :8082, internal :9082, health 127.0.0.1:9092)
+# Step 4 — start the server (primary :8082, internal 127.0.0.1:9082, health 127.0.0.1:9092)
 go run ./examples/todoorder &
 
 # Step 5 — wait for readiness (/healthz and /readyz live on the health listener)

--- a/examples/corebundlestarter/run.go
+++ b/examples/corebundlestarter/run.go
@@ -56,6 +56,8 @@ const devAccessTokenTTL = 15 * time.Minute
 
 // starterPrimaryAddr / InternalAddr / HealthAddr are the default listener
 // bind addresses.  Pick non-default ports to avoid conflicts with corebundle.
+// Only the primary listener is all-interfaces; the internal cell→cell control
+// plane binds loopback per docs/ops/listener-topology.md.
 const (
 	starterPrimaryAddr  = ":8088"
 	starterInternalAddr = "127.0.0.1:9088"

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -66,7 +66,7 @@ export IOT_ADMIN_TOKEN="$(go run ./examples/iotdevice/localtoken)"
 go run ./examples/iotdevice
 ```
 
-The server starts with primary listener on `:8083` (API), internal listener on `:9083` (control-plane), and health listener on `127.0.0.1:9093` (`/healthz` `/readyz` `/metrics`).
+The server starts with primary listener on `:8083` (API), internal listener on `127.0.0.1:9083` (loopback control-plane), and health listener on `127.0.0.1:9093` (`/healthz` `/readyz` `/metrics`).
 `IOT_ADMIN_TOKEN` is a real RS256 access token signed by the local key above.
 The helper defaults to the roles needed by the walkthrough; override with
 `go run ./examples/iotdevice/localtoken -roles admin,role:operator,role:device`.

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -230,8 +230,12 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	opts := []bootstrap.Option{
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
+		// PrimaryListener stays all-interfaces (:8083) so remote IoT devices can
+		// reach it over the network. InternalListener is the cell→cell control
+		// plane (/internal/v1/*) and binds loopback per docs/ops/listener-topology.md;
+		// a real deployment sets a VPC-only addr + NetworkPolicy instead.
 		bootstrap.WithListener(cell.PrimaryListener, ":8083", []auth.ListenerAuth{jwtPlan}),
-		bootstrap.WithListener(cell.InternalListener, ":9083", internalAuthChain),
+		bootstrap.WithListener(cell.InternalListener, "127.0.0.1:9083", internalAuthChain),
 		// #673: a dedicated HealthListener is mandatory — /healthz, /readyz,
 		// /metrics no longer fall back onto the primary listener.
 		bootstrap.WithListener(cell.HealthListener, "127.0.0.1:9093", []auth.ListenerAuth{auth.AuthNone{}}),

--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -308,6 +308,9 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 		// LIFO close: relay registered last → stopped first; relay must stop before pool closes.
 		bootstrap.WithRelay(relayWorker),
 		listenerOption(cell.PrimaryListener, cfg.primary, []kauth.ListenerAuth{primaryAuth}),
+		// internal defaults to loopback (see defaultSSOBFFAppConfig); the cell→cell
+		// control plane is never all-interfaces. Override GOCELL_SSOBFF_INTERNAL_ADDR
+		// + add a NetworkPolicy for a VPC deployment (docs/ops/listener-topology.md).
 		listenerOption(cell.InternalListener, cfg.internal, internalAuthChain),
 		listenerOption(cell.HealthListener, cfg.health, []kauth.ListenerAuth{kauth.AuthNone{}}),
 		bootstrap.WithHealthRoutes(healthRouteOptions()...),

--- a/examples/todoorder/README.md
+++ b/examples/todoorder/README.md
@@ -56,7 +56,7 @@ export TODOORDER_TOKEN="$(go run ./examples/todoorder/localtoken)"
 go run ./examples/todoorder
 ```
 
-The server starts with primary listener on `:8082` (API), internal listener on `:9082` (control-plane), and health listener on `127.0.0.1:9092` (`/healthz` `/readyz` `/metrics`).
+The server starts with primary listener on `:8082` (API), internal listener on `127.0.0.1:9082` (loopback control-plane), and health listener on `127.0.0.1:9092` (`/healthz` `/readyz` `/metrics`).
 `TODOORDER_TOKEN` is a real RS256 access token signed by the local key above.
 
 ## Docker Mode


### PR DESCRIPTION
## Summary

Epic #1831 PR-6（HTTP / listener / API 文档小修）：把 iotdevice 的 InternalListener 绑到 loopback、为所有双 addr example 补 rationale 注释、并在 api-versioning 规则中明文记录 setup 路径命名空间策略。

## Why / 背景

- **#1107**（type-bug）：`examples/iotdevice/run.go` 把 InternalListener 绑 `:9083`（全网卡），而 cell→cell 控制面（`/internal/v1/*`）按 `docs/ops/listener-topology.md` 应走 loopback/VPC-only，其余 example 也都如此。改为 `127.0.0.1:9083`（primary `:8083` 保持全网卡供远程 IoT 设备连入）。
- **#627**（type-doc）：双 addr example（primary 全网卡 + internal loopback）缺解释注释。为 iotdevice / corebundlestarter / ssobff 补上 rationale 注释（todoorder 早已有），统一闭合 `EXAMPLE-INTERNAL-LISTENER-COMMENT-01`。代码中不存在 `WithHTTPInternalDisable` option，故走「加注释」路径。
- **#621**（type-doc）：`SETUP-PATH-NAMESPACE-POLICY-01` 未明文。记录现状——**没有**顶级 `/api/v1/setup/` 命名空间，setup 端点挂所属 Cell 前缀（`/api/v{N}/{cell}/setup/admin|status`），形状由 `metadata.IsBootstrapPath`（`^/api/v\d+/[^/]+/setup/admin$`）+ 治理规则 `FMT-28` 锁定；特殊性在鉴权（`auth.bootstrap`）+ 生命周期（410 Gone），不在路径位置。

**范围排除（显式 carve-out）**：

- **#634**（flag-cond）**排除**，保持 deferred。其 trigger 是「第二个 handler 引入 ops-diagnostics 通道 d」，今天**未触发**——只有 readyz-verbose 使用 `redactedErrorMsg` typed-funnel 形态；recovery panic dump / outbox last_error / auditquery payload 三个候选都只调用普通 redaction 函数，均未实现 typed-wrapper + archtest funnel。现在补 ADR funnel-matrix 行会是空/超前的，且违反 ADR `202605171200` §5 自身的「伴随新 handler 落地时才追加矩阵行」分阶段协议。#634 已是 OPEN backlog item，无需新建（已留评论确认 deferred）。
- iotdevice 的 internal-loopback **系统性机器守卫**（fail-fast 非 loopback internal bind）不在本 Cx1 PR 范围，由既有 backlog `BOOTSTRAP-INTERNAL-LOCAL-ONLY-FAIL-FAST-01` 跟踪（`listener-topology.md` 已记录该缺口）。本 PR 只改违例值 + 注释（bug 修复 + 文档，非新治理机制）。

## Refs

- Closes #1107
- Closes #627
- Closes #621
- Refs epic #1831（PR-6 分组）
- #634 排除：trigger 未触发，保持 deferred（非本 PR 关闭）
- ref ADR `202605061600`（bootstrap admin boundary）、`202606021200`（pre-auth tenant header）、`202605171200`（readyz verbose four-channel redaction §5）

## Risk / 兼容性

无破坏性变更。改动面 = ① 一个 example demo 的 internal listener 绑定值（`:9083` → `127.0.0.1:9083`）+ 注释；② 两个 example 的注释；③ 一个 example README 的地址说明；④ 一份协作规则文档新增一节。**无 contract / schema / generated code / wire 契约变更**，contract-fanout 矩阵 N/A。examples 为 demo、无外部调用方（CLAUDE.md）。

## Test plan

- [x] `go build ./...` 本地通过（iotdevice / ssobff / corebundlestarter 各 module）
- [x] `go test ./...` 本地通过（三个受影响 example module 全绿）
- [x] `golangci-lint run ./...` 0 issues（三个 module）
