### PR TITLE
feat(release): synchronized multi-module tagging for external go get [#1843]

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -206,15 +206,17 @@ jobs:
             [ "$dir" != "." ] || continue
             echo "+++ golangci-lint in module: $dir"
             # The tools module's archtest leaf is gated behind `//go:build archtest`
-            # (ARCHTEST-LEAF-BUILD-TAG-01); without the tag golangci-lint skips
-            # those ~288 *_test.go files and their lint coverage silently drops.
-            # Lint tools under the tag so the heavy suite's source stays covered —
-            # the same cross-tag lane idea as `go vet -tags=e2e` below. Other
-            # satellites carry no archtest-gated files, so the flag stays empty.
+            # (ARCHTEST-LEAF-BUILD-TAG-01) and the release smoke behind
+            # `//go:build releasesmoke` (RELEASE-EXTERNAL-GET-01); without the tags
+            # golangci-lint skips those *_test.go files and their lint coverage
+            # silently drops. Lint tools under both tags so the heavy suite + the
+            # smoke source stay covered — the same cross-tag lane idea as
+            # `go vet -tags=e2e` below. Other satellites carry no tag-gated files,
+            # so the flag stays empty.
             build_tags=""
             # gocell::modules::dirs yields `tools` (go work edit -json DiskPath);
             # ${dir#./} tolerates `./tools` too if the path ever gains a leading ./.
-            [ "${dir#./}" = "tools" ] && build_tags="--build-tags=archtest"
+            [ "${dir#./}" = "tools" ] && build_tags="--build-tags=archtest,releasesmoke"
             (
               cd "$dir"
               # shellcheck disable=SC2086 # LINT_ARGS + build_tags are intentionally split into CLI flags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,12 @@ jobs:
             | tail -n +"$((DAILY_RETENTION + 1))" \
             | while IFS= read -r old; do
                 [ -n "$old" ] || continue
+                # Defense-in-depth: only delete tags that match the snapshot shape
+                # exactly, so a glob surprise never deletes a real release tag.
+                printf '%s' "$old" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+-develop\.' || {
+                  echo "::warning::skipping prune of unexpected tag '$old' (not a develop snapshot)."
+                  continue
+                }
                 echo "Pruning old snapshot $old"
                 gh release delete "$old" --cleanup-tag --yes \
                   || git push origin --delete "$old" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,9 @@ jobs:
     permissions:
       contents: write # push annotated tag + create/delete GitHub Release
     env:
-      GH_TOKEN: ${{ github.token }}
+      # GH_TOKEN (write-scope) is deliberately NOT set at job level — it is scoped
+      # per-step to only the `gh release` API steps, so the repo-code steps
+      # (modrelease `go run`, git tag/push via checkout creds) never see it.
       TAG: ${{ needs.verify.outputs.tag }}
       PRERELEASE: ${{ needs.verify.outputs.prerelease }}
       SHA: ${{ needs.verify.outputs.sha }}
@@ -177,20 +179,19 @@ jobs:
           fetch-tags: true
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        # Stable releases run the modrelease tool (bump + tag-path derivation);
-        # snapshots are root-only git operations and need no Go.
-        if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
+        # Stable (fresh OR resume) runs the modrelease tool (bump / tag-path
+        # derivation / resume tag-set validation); snapshots are root-only git ops.
+        if: needs.verify.outputs.prerelease != 'true'
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Pin internal requires & commit (stable only)
         # Synchronized multi-module release (#1843): pin every publishable LIBRARY
-        # module's internal requires v0.0.0 -> vX.Y.Z (keeping replace) on a commit
-        # pushed to develop — the single tag target for root and all satellites.
-        # develop thereafter carries the released version (replace still resolves
-        # locally under GOWORK=off, so verify-workspace stays green; filesystem
-        # replace needs no go.sum, so go.sum is untouched). Snapshots skip this.
+        # module's internal requires v0.0.0 -> vX.Y.Z (keeping replace) on a local
+        # commit — the single tag target for root and all satellites. It is NEITHER
+        # pushed NOR tagged here: the pinned tree is first re-verified (next step),
+        # so the released commit is never an unverified tree (F1). Snapshots skip.
         if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
         run: |
           set -euo pipefail
@@ -206,17 +207,23 @@ jobs:
               | tee -a "$GITHUB_STEP_SUMMARY"
           else
             git commit -am "release($TAG): pin internal module requires"
-            # A non-fast-forward push means develop advanced since verify (often a
-            # prior pin commit in this same release). Surface a clear ::error:: +
-            # summary: the operator must RE-DISPATCH from the new develop HEAD, not
-            # "Re-run jobs" (re-run replays the stale verified SHA). Also requires
-            # branch protection to permit the github-actions bot to push to develop.
-            if ! git push origin "HEAD:develop"; then
-              echo "::error::push to develop rejected (non-fast-forward, or bot lacks branch-protection write). develop has advanced since verify resolved SHA=$SHA — RE-DISPATCH this workflow from the new develop HEAD (do NOT 'Re-run jobs', which replays the stale SHA)." \
-                | tee -a "$GITHUB_STEP_SUMMARY"
-              exit 1
-            fi
           fi
+
+      - name: Verify pinned tree (stable only)
+        # The verify job ran the build gates on the PRE-pin develop SHA. Re-run the
+        # release-consistency gates on the actual pin commit so the tagged tree is
+        # the verified tree, not just the pre-pin one (F1). Runs before any push or
+        # tag, so a failure leaves develop unadvanced and no tag minted. Skips when
+        # the pin was a no-op (HEAD == SHA, already verified).
+        if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse HEAD)" = "$SHA" ]; then
+            echo "pin was a no-op (HEAD == verified SHA) — skipping re-verify."
+            exit 0
+          fi
+          make check-build
+          bash hack/verify-workspace.sh
 
       - name: Tag modules
         # Root always tags at HEAD. Stable additionally tags every publishable
@@ -225,11 +232,12 @@ jobs:
         # contain the root tag, and is pushed --atomic so a partial set never
         # lands. Snapshots tag root only.
         #
-        # Resume invariant: the verify job's tag_exists check inspects only the
-        # ROOT tag. Correctness of resuming a half-finished stable release relies
-        # on this --atomic push — root + satellites land all-or-nothing, so the
-        # root tag's presence faithfully reflects the whole set. If --atomic is
-        # ever dropped, the resume guard must be extended to check satellites too.
+        # Resume: the verify job's tag_exists check inspects only the ROOT tag.
+        # The --atomic push makes root + satellites land all-or-nothing, so the root
+        # tag normally reflects the whole set — but on a stable resume the next step
+        # ("Validate satellite tag set") additionally proves every satellite tag
+        # exists and peels to the same commit, fail-closed (F3), rather than
+        # trusting the atomic invariant alone.
         if: needs.verify.outputs.tag_exists != 'true'
         run: |
           set -euo pipefail
@@ -254,12 +262,50 @@ jobs:
             echo "### Release $TAG — tagging ${#tags[@]} modules"
             printf -- '- %s\n' "${tags[@]}"
           } >>"$GITHUB_STEP_SUMMARY"
+          # Push the now-verified pin commit to develop (only if one was created).
+          # A non-fast-forward push means develop advanced since verify (often a
+          # prior pin commit in this same release): the operator must RE-DISPATCH
+          # from the new develop HEAD, not "Re-run jobs" (re-run replays the stale
+          # SHA). Requires branch protection to permit the github-actions bot push.
+          if [ "$(git rev-parse HEAD)" != "$SHA" ]; then
+            if ! git push origin "HEAD:develop"; then
+              echo "::error::push to develop rejected (non-fast-forward, or bot lacks branch-protection write). develop has advanced since verify resolved SHA=$SHA — RE-DISPATCH this workflow from the new develop HEAD (do NOT 'Re-run jobs', which replays the stale SHA)." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+          fi
           for tag in "${tags[@]}"; do
             git tag -a "$tag" -m "Release $tag"
           done
           git push origin --atomic "${tags[@]}"
 
+      - name: Validate satellite tag set (stable resume)
+        # On resume the root tag exists but the GitHub Release is missing. tag_exists
+        # is set off the ROOT tag only, so before creating the release prove the FULL
+        # synchronized set is present and consistent: every derived tag must exist
+        # and peel to the same commit as the root tag, else fail closed (F3). This
+        # catches a prior run that tagged root but lost the satellite --atomic push.
+        if: needs.verify.outputs.tag_exists == 'true' && needs.verify.outputs.prerelease != 'true'
+        run: |
+          set -euo pipefail
+          root_commit="$(git rev-parse "$TAG^{commit}")"
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          [ "${#tags[@]}" -ge 2 ] || { echo "::error::derived tag set too small (${#tags[@]})."; exit 1; }
+          missing=0
+          for tag in "${tags[@]}"; do
+            if ! c="$(git rev-parse -q --verify "refs/tags/$tag^{commit}" 2>/dev/null)"; then
+              echo "::error::resume: satellite tag '$tag' is missing (root tagged but satellite set incomplete)."
+              missing=1
+            elif [ "$c" != "$root_commit" ]; then
+              echo "::error::resume: tag '$tag' points at $c, not the root tag commit $root_commit."
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || { echo "::error::resume aborted: satellite tag set incomplete/inconsistent — delete the partial tags and re-dispatch." | tee -a "$GITHUB_STEP_SUMMARY"; exit 1; }
+
       - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }} # write-scope token scoped to the gh API step only (F5)
         run: |
           set -euo pipefail
           args=(--title "$TAG" --verify-tag --generate-notes)
@@ -280,6 +326,8 @@ jobs:
 
       - name: Prune old daily snapshots
         if: needs.verify.outputs.prerelease == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }} # write-scope token scoped to the gh API step only (F5)
         run: |
           set -euo pipefail
           if ! printf '%s' "$DAILY_RETENTION" | grep -Eq '^[1-9][0-9]*$'; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,22 @@ jobs:
           fetch-depth: 0 # full history for annotated tag, --generate-notes, prune
           fetch-tags: true
 
-      - name: Create annotated tag
-        if: needs.verify.outputs.tag_exists != 'true' # skip when resuming an existing tag
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        # Stable releases run the modrelease tool (bump + tag-path derivation);
+        # snapshots are root-only git operations and need no Go.
+        if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Pin internal requires & commit (stable only)
+        # Synchronized multi-module release (#1843): pin every publishable LIBRARY
+        # module's internal requires v0.0.0 -> vX.Y.Z (keeping replace) on a commit
+        # pushed to develop — the single tag target for root and all satellites.
+        # develop thereafter carries the released version (replace still resolves
+        # locally under GOWORK=off, so verify-workspace stays green; filesystem
+        # replace needs no go.sum, so go.sum is untouched). Snapshots skip this.
+        if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
         run: |
           set -euo pipefail
           if [ "$(git rev-parse HEAD)" != "$SHA" ]; then
@@ -186,8 +200,47 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
+          go run ./tools/modrelease/cmd --version "$TAG"
+          if git diff --quiet; then
+            echo "::warning::modrelease pinned no requires (already at $TAG?) — tagging $SHA as-is." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            git commit -am "release($TAG): pin internal module requires"
+            # Non-fast-forward (develop advanced since verify) fails the push;
+            # re-run the workflow to release the new HEAD. Requires branch
+            # protection to permit the github-actions bot to push to develop.
+            git push origin "HEAD:develop"
+          fi
+
+      - name: Tag modules
+        # Root always tags at HEAD. Stable additionally tags every publishable
+        # satellite <reldir>/vX.Y.Z at the same (pin) commit; the tag set is
+        # derived from the same publishable enumeration as the golden guard, must
+        # contain the root tag, and is pushed --atomic so a partial set never
+        # lands. Snapshots tag root only.
+        if: needs.verify.outputs.tag_exists != 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ "$PRERELEASE" = "true" ]; then
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+            exit 0
+          fi
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          if [ "${#tags[@]}" -lt 2 ]; then
+            echo "::error::expected root + satellite tags from modrelease, got ${#tags[@]}."
+            exit 1
+          fi
+          case " ${tags[*]} " in
+            *" $TAG "*) ;;
+            *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
+          esac
+          for tag in "${tags[@]}"; do
+            git tag -a "$tag" -m "Release $tag"
+          done
+          git push origin --atomic "${tags[@]}"
 
       - name: Create GitHub Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,10 +206,16 @@ jobs:
               | tee -a "$GITHUB_STEP_SUMMARY"
           else
             git commit -am "release($TAG): pin internal module requires"
-            # Non-fast-forward (develop advanced since verify) fails the push;
-            # re-run the workflow to release the new HEAD. Requires branch
-            # protection to permit the github-actions bot to push to develop.
-            git push origin "HEAD:develop"
+            # A non-fast-forward push means develop advanced since verify (often a
+            # prior pin commit in this same release). Surface a clear ::error:: +
+            # summary: the operator must RE-DISPATCH from the new develop HEAD, not
+            # "Re-run jobs" (re-run replays the stale verified SHA). Also requires
+            # branch protection to permit the github-actions bot to push to develop.
+            if ! git push origin "HEAD:develop"; then
+              echo "::error::push to develop rejected (non-fast-forward, or bot lacks branch-protection write). develop has advanced since verify resolved SHA=$SHA — RE-DISPATCH this workflow from the new develop HEAD (do NOT 'Re-run jobs', which replays the stale SHA)." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
           fi
 
       - name: Tag modules
@@ -218,6 +224,12 @@ jobs:
         # derived from the same publishable enumeration as the golden guard, must
         # contain the root tag, and is pushed --atomic so a partial set never
         # lands. Snapshots tag root only.
+        #
+        # Resume invariant: the verify job's tag_exists check inspects only the
+        # ROOT tag. Correctness of resuming a half-finished stable release relies
+        # on this --atomic push — root + satellites land all-or-nothing, so the
+        # root tag's presence faithfully reflects the whole set. If --atomic is
+        # ever dropped, the resume guard must be extended to check satellites too.
         if: needs.verify.outputs.tag_exists != 'true'
         run: |
           set -euo pipefail
@@ -237,6 +249,11 @@ jobs:
             *" $TAG "*) ;;
             *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
           esac
+          # Operator-visible preview of the exact set about to be pushed.
+          {
+            echo "### Release $TAG — tagging ${#tags[@]} modules"
+            printf -- '- %s\n' "${tags[@]}"
+          } >>"$GITHUB_STEP_SUMMARY"
           for tag in "${tags[@]}"; do
             git tag -a "$tag" -m "Release $tag"
           done

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -837,6 +837,17 @@ linters:
         linters:
           - gosec
         text: "G70(2|3)"
+      # tools/modrelease rewrites the repo's own go.mod files during release and
+      # tools/releasesmoke stages go.mods + builds a module proxy under
+      # t.TempDir(); both write to developer-owned / test-temp trees, so gosec
+      # G703 (path-traversal taint that survives filepath.Clean) is a false
+      # positive — the same trusted-tooling context as tools/metricschema above.
+      # G304 (variable ReadFile) and G306 (WriteFile mode) are fixed at the call
+      # site (filepath.Clean / 0o600); only the un-clearable G703 is waived here.
+      - path: ^tools/(modrelease|releasesmoke)/
+        linters:
+          - gosec
+        text: "G703"
       # rbacassign/service.go: Assign/Revoke are intentionally mirror-image
       # public APIs (per-action audit trail). Source comment documents the
       # decision; dupl flags the duplication structurally.

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,10 @@ update-modrelease-golden:
 	go test ./tools/modrelease -run TestPublishableModuleSet01 -update -count=1
 
 # release-smoke runs the external-consumer go-get/build smoke for the
-# synchronized multi-module release (RELEASE-EXTERNAL-GET-01). Network-free and
-# Docker-free; also wired as the `nightly`-bucket hack/verify-release-smoke.sh.
+# synchronized multi-module release (RELEASE-EXTERNAL-GET-01). Network-free at
+# test execution, Docker-free. This is a convenience shortcut; the CI gate
+# hack/verify-release-smoke.sh (workspace bucket) additionally enforces the
+# anti-vacuity / build-tag-presence guards a bare `go test` does not.
 release-smoke:
 	go test -tags=releasesmoke -count=1 ./tools/releasesmoke/...
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build check-build test fmt verify validate generate proto-lint proto-gen cover clean \
-        install-hooks update-archtest-golden \
+        install-hooks update-archtest-golden update-modrelease-golden release-smoke \
         up down \
         local-up local-down \
         test-integration \
@@ -119,6 +119,18 @@ fmt:
 # to internal/ subpackages would fail with "flag provided but not defined: -update".
 update-archtest-golden:
 	go test -tags=archtest ./tools/archtest -update -count=1
+
+# update-modrelease-golden regenerates testdata/publishable.golden, the
+# byte-frozen derived publishable module set (PUBLISHABLE-MODULE-SET-01). Run
+# after intentionally adding/removing a go.work member or changing IsPublishable.
+update-modrelease-golden:
+	go test ./tools/modrelease -run TestPublishableModuleSet01 -update -count=1
+
+# release-smoke runs the external-consumer go-get/build smoke for the
+# synchronized multi-module release (RELEASE-EXTERNAL-GET-01). Network-free and
+# Docker-free; also wired as the `nightly`-bucket hack/verify-release-smoke.sh.
+release-smoke:
+	go test -tags=releasesmoke -count=1 ./tools/releasesmoke/...
 
 # verify discovers and runs every hack/verify-*.sh in deterministic order,
 # accumulating failures. Single entry point for static governance gates

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -15,7 +15,7 @@
   go install ./cmd/gocell
   ```
 
-  The framework itself is a public module; `go get github.com/ghbvf/gocell@v0.1.0` works without GOPRIVATE. However, `go install github.com/ghbvf/gocell/cmd/gocell@vX.Y.Z` is not yet available — `cmd/gocell` is a satellite module (its `go.mod` contains a local `replace` directive, and the release pipeline only tags the root, not the `cmd/gocell/vX.Y.Z` sub-module tag), which prevents `go install pkg@version` from working. A stable standalone CLI installation path is planned for a future release.
+  The framework itself is a public module; `go get github.com/ghbvf/gocell@v0.1.0` works without GOPRIVATE, and as of #1843 every **library** satellite (`adapters/*`, `corecells`, `cellmodules`, `tools`) is tagged per module at the synchronized version, so `go get github.com/ghbvf/gocell/adapters/postgres@vX.Y.Z` resolves too (see §6). However, `go install github.com/ghbvf/gocell/cmd/gocell@vX.Y.Z` is still **not** available — `cmd/gocell` is a `go install` binary, and `go install pkg@version` is rejected outright when the target module's `go.mod` contains the local `replace` directive it needs for monorepo development. #1843 deliberately excludes the `cmd/*` modules for exactly this reason; making the CLI installable at a version needs release-time replace-strip, tracked as **#1088**. Install from source (above) for now.
 
 ## Steps
 
@@ -25,6 +25,8 @@
 mkdir -p ~/work/acme-payment-cell && cd ~/work/acme-payment-cell
 go mod init github.com/acme/payment-cell
 go get github.com/ghbvf/gocell@v0.1.0   # pin a stable tag (@develop = prerelease snapshot)
+# any library satellite you import (adapters/*, corecells, cellmodules, tools) is
+# tagged at the SAME version — e.g. go get github.com/ghbvf/gocell/adapters/postgres@v0.1.0
 ```
 
 ### 2. Place the Manifest File
@@ -180,7 +182,7 @@ builder := composition.New(cellIDs...).
 
 **Execution bridge**: `composition.Build()` itself does **not** run migrations (the schema must be in place before cells start, and `runtime/` must not depend on `adapters/`). In the composition root (which can import both layers), drain the registered migration set into `adapters/postgres.MigrationSet` and apply it **before** `Build` — `NewMigrationSetWithPlatform` places the platform namespace first (platform-first ordering guarantees: external cell migrations can FK platform tables):
 
-> **Note (per-adapter module split, #1558)**: `adapters/postgres` — like every `adapters/*` — is now a **separate satellite module** (`github.com/ghbvf/gocell/adapters/postgres`), no longer part of the root `github.com/ghbvf/gocell` module. The release pipeline currently tags only the root (`@v0.1.0`), not per-adapter tags (`adapters/postgres/vX.Y.Z`) — the same limitation already noted above for `go install .../cmd/gocell@vX.Y.Z`. Consequently `go get github.com/ghbvf/gocell@v0.1.0` does **not** pull `adapters/postgres`, and `go get github.com/ghbvf/gocell/adapters/postgres@<version>` cannot resolve yet. Until per-adapter release tags exist, an external composition root that needs this PG migration bridge must consume the adapter via a Go workspace / local `replace` (Workspace Mode, §5 above). Per-adapter release tagging is planned for a future release (tracked under the #1558 adapter-split epic).
+> **Note (per-adapter module split #1558 / external publishing #1843)**: `adapters/postgres` — like every `adapters/*` — is a **separate satellite module** (`github.com/ghbvf/gocell/adapters/postgres`), no longer part of the root `github.com/ghbvf/gocell` module. As of #1843 the release pipeline tags every library satellite per module (`adapters/postgres/vX.Y.Z`), **synchronized to the same `vX.Y.Z` as the root** — so `go get github.com/ghbvf/gocell/adapters/postgres@vX.Y.Z` now resolves directly. **Pin it at the same `vX.Y.Z` you use for the core `go get github.com/ghbvf/gocell@vX.Y.Z`** (the synchronized-release contract holds every gocell module at one version). Note that `go get github.com/ghbvf/gocell@vX.Y.Z` alone does **not** pull `adapters/postgres` — it is a distinct module; add it explicitly. The Go workspace / local `replace` route (Workspace Mode, §5 above) remains available as a dev-time convenience but is no longer required for consumption.
 
 ```go
 set, err := adapterpg.NewMigrationSetWithPlatform() // seeds "platform" first

--- a/docs/guides/cell-external-repo-quickstart.md
+++ b/docs/guides/cell-external-repo-quickstart.md
@@ -15,7 +15,7 @@
   go install ./cmd/gocell
   ```
 
-  The framework itself is a public module; `go get github.com/ghbvf/gocell@v0.1.0` works without GOPRIVATE, and as of #1843 every **library** satellite (`adapters/*`, `corecells`, `cellmodules`, `tools`) is tagged per module at the synchronized version, so `go get github.com/ghbvf/gocell/adapters/postgres@vX.Y.Z` resolves too (see §6). However, `go install github.com/ghbvf/gocell/cmd/gocell@vX.Y.Z` is still **not** available — `cmd/gocell` is a `go install` binary, and `go install pkg@version` is rejected outright when the target module's `go.mod` contains the local `replace` directive it needs for monorepo development. #1843 deliberately excludes the `cmd/*` modules for exactly this reason; making the CLI installable at a version needs release-time replace-strip, tracked as **#1088**. Install from source (above) for now.
+  The framework itself is a public module; `go get github.com/ghbvf/gocell@v0.1.0` works without GOPRIVATE. #1843 adds per-module release tags for every **library** satellite (`adapters/*`, `corecells`, `cellmodules`; `tools` is published for toolchain consumers such as external `archtest` users, not business Cells), synchronized to the same `vX.Y.Z` as the root — so `go get github.com/ghbvf/gocell/adapters/postgres@vX.Y.Z` resolves (see §6). These satellite tags exist **from the first stable release that ships #1843 onward** (the root-only `v0.1.0` predates it and has no satellite tags). `go install github.com/ghbvf/gocell/cmd/gocell@vX.Y.Z` is still **not** available — `cmd/gocell` is a `go install` binary, and `go install pkg@version` is rejected outright when the target module's `go.mod` carries the local `replace` directive it needs for monorepo development. #1843 deliberately excludes the `cmd/*` modules for exactly this reason; making the CLI installable at a version needs release-time replace-strip, tracked as **#1088**. Install from source (above) for now.
 
 ## Steps
 
@@ -24,9 +24,12 @@
 ```bash
 mkdir -p ~/work/acme-payment-cell && cd ~/work/acme-payment-cell
 go mod init github.com/acme/payment-cell
-go get github.com/ghbvf/gocell@v0.1.0   # pin a stable tag (@develop = prerelease snapshot)
-# any library satellite you import (adapters/*, corecells, cellmodules, tools) is
-# tagged at the SAME version — e.g. go get github.com/ghbvf/gocell/adapters/postgres@v0.1.0
+go get github.com/ghbvf/gocell@vX.Y.Z   # pin a stable tag (see Releases; @develop = prerelease snapshot)
+# Synchronized-version contract: pin every library satellite you import at the
+# SAME vX.Y.Z as the core, in one command — Go MVS otherwise resolves a satellite's
+# internal require to a different version and the gocell module graph won't line up:
+go get github.com/ghbvf/gocell@vX.Y.Z github.com/ghbvf/gocell/adapters/postgres@vX.Y.Z
+go list -m all | grep ghbvf/gocell   # verify every gocell module sits at vX.Y.Z
 ```
 
 ### 2. Place the Manifest File

--- a/hack/verify-release-smoke.sh
+++ b/hack/verify-release-smoke.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# verify-bucket: nightly
+# verify-bucket: workspace
 # verify-release-smoke runs the external-consumer smoke for the synchronized
 # multi-module release (#1843, RELEASE-EXTERNAL-GET-01): it publishes the
 # release-bumped library modules to a hermetic local file GOPROXY and proves an
 # external consumer can `go get` + `go build` against them, with the full internal
 # graph resolving to the published version.
 #
-# Bucketed nightly (not a PR bucket): the test spawns nested `go get`/`go build`
-# subprocesses, mirroring verify-archtest.sh's placement, to keep the PR hot path
-# fast. It is network-free (internal-deps-only proxy projections + a fresh
-# per-test GOMODCACHE) and Docker-free.
+# Bucketed `workspace` (a PR bucket, alongside verify-workspace.sh's module-graph
+# checks): the test is fast and self-contained — it spawns nested `go get`/`go
+# build` over an internal-deps-only file proxy with a fresh per-test GOMODCACHE,
+# so the TEST EXECUTION is network-free and Docker-free. (The `go test` COMPILE
+# step still needs the standard module cache for golang.org/x/mod + tools/gomodutil
+# — present in CI's go.sum-keyed cache and on any workstation that ran the build.)
+# NOTE: do NOT move this to the reserved `nightly` bucket — that bucket is excluded
+# from the PR matrix and run only by archtest-nightly.yml's verify-archtest step,
+# so a `nightly` gate here would never execute (governance.yml derives the matrix).
 
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 readonly PKG="./tools/releasesmoke"
+readonly PKG_DIR="tools/releasesmoke"
 readonly TIMEOUT="${TIMEOUT:-5m}"
 
-# Anti-vacuity: the smoke is build-tagged `releasesmoke`; a dropped tag or moved
-# file would silently run zero tests. Fail closed if discovery finds none.
+# Build-tag self-check: the smoke is gated behind `//go:build releasesmoke`, and
+# .github/workflows/_build-lint.yml lints tools under `--build-tags=…,releasesmoke`
+# so the tagged source stays covered. If the tag were dropped from the source, that
+# lint flag would silently cover nothing — fail closed here so the desync surfaces.
+if ! grep -rlE '^//go:build releasesmoke' "$PKG_DIR" >/dev/null 2>&1; then
+  echo "ERROR: no file under $PKG_DIR carries '//go:build releasesmoke' — the tag was" >&2
+  echo "       dropped, so the _build-lint.yml '--build-tags=…,releasesmoke' flag is dead." >&2
+  exit 1
+fi
+
+# Anti-vacuity: a moved/renamed file would silently run zero tests. Fail closed if
+# discovery finds none.
 TESTS=$(go test -tags=releasesmoke -list '^Test' "$PKG" 2>/dev/null | grep -E '^Test' || true)
 TOTAL=$(printf '%s\n' "$TESTS" | grep -c '^Test' || true)
 if [ "${TOTAL:-0}" -lt 1 ]; then

--- a/hack/verify-release-smoke.sh
+++ b/hack/verify-release-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# verify-bucket: nightly
+# verify-release-smoke runs the external-consumer smoke for the synchronized
+# multi-module release (#1843, RELEASE-EXTERNAL-GET-01): it publishes the
+# release-bumped library modules to a hermetic local file GOPROXY and proves an
+# external consumer can `go get` + `go build` against them, with the full internal
+# graph resolving to the published version.
+#
+# Bucketed nightly (not a PR bucket): the test spawns nested `go get`/`go build`
+# subprocesses, mirroring verify-archtest.sh's placement, to keep the PR hot path
+# fast. It is network-free (internal-deps-only proxy projections + a fresh
+# per-test GOMODCACHE) and Docker-free.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+readonly PKG="./tools/releasesmoke"
+readonly TIMEOUT="${TIMEOUT:-5m}"
+
+# Anti-vacuity: the smoke is build-tagged `releasesmoke`; a dropped tag or moved
+# file would silently run zero tests. Fail closed if discovery finds none.
+TESTS=$(go test -tags=releasesmoke -list '^Test' "$PKG" 2>/dev/null | grep -E '^Test' || true)
+TOTAL=$(printf '%s\n' "$TESTS" | grep -c '^Test' || true)
+if [ "${TOTAL:-0}" -lt 1 ]; then
+  echo "ERROR: no releasesmoke Test* functions discovered in $PKG (build-tag drift?)" >&2
+  echo "       discovery: go test -tags=releasesmoke -list '^Test' $PKG" >&2
+  exit 1
+fi
+
+echo "verify-release-smoke: running $TOTAL test(s) in $PKG"
+go test -tags=releasesmoke -count=1 -timeout "$TIMEOUT" "$PKG"
+echo "verify-release-smoke: PASS ($TOTAL tests)"

--- a/tools/archtest/internal/typeseval/buildtags.go
+++ b/tools/archtest/internal/typeseval/buildtags.go
@@ -40,6 +40,12 @@ func KnownNonDefaultTags() [][]string {
 		// rule files (TEST-TIME-LITERAL / TEST-SLEEP-DISCIPLINE / MODULE-PATH-FUNNEL
 		// etc. apply to them), exactly as they did before the suite was tagged.
 		{"archtest"},
+		// releasesmoke gates the single external-consumer release smoke
+		// (tools/releasesmoke/external_get_smoke_test.go, RELEASE-EXTERNAL-GET-01,
+		// #1843), kept off the bare `go test ./...` path because it spawns nested
+		// `go get`/`go build`. Like archtest above (and unlike archtest_fixture), it
+		// gates a REAL test file the meta-scanners should still see.
+		{"releasesmoke"},
 		// archtest_fixture is deliberately ABSENT (#944): the fixture build tag
 		// is NOT a generic production tag and must never enter this union, or a
 		// business Run(t, Typed(TypedOpts{Tags: FlatNonDefaultTags()}, ...)) scan

--- a/tools/modrelease/cmd/main.go
+++ b/tools/modrelease/cmd/main.go
@@ -1,0 +1,97 @@
+// Command modrelease drives the synchronized multi-module release transform for
+// the GoCell workspace. With --version it rewrites every publishable library
+// module's internal require versions in place (keeping replace); with
+// --print-tag-paths it emits the per-module git tags (one per line) for the
+// release workflow's tag loop; with --dry-run it previews the set and tags
+// without writing. It is invoked by .github/workflows/release.yml.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/ghbvf/gocell/tools/modrelease"
+	"github.com/ghbvf/gocell/tools/workspace"
+)
+
+func main() {
+	// workspace.Modules' manifest cross-check logs INFO per member via the
+	// default slog logger; quiet it so --print-tag-paths stdout stays clean and
+	// the release-workflow log isn't flooded.
+	slog.SetLogLoggerLevel(slog.LevelWarn)
+	if err := run(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "modrelease:", err)
+		os.Exit(1)
+	}
+}
+
+// p writes a line to stdout (the machine-readable output channel, e.g.
+// --print-tag-paths). A failed stdout write is unactionable in a CLI, so the
+// error is intentionally discarded.
+func p(format string, a ...any) { _, _ = fmt.Fprintf(os.Stdout, format, a...) }
+
+func run() error {
+	version := flag.String("version", "", "release version tag, e.g. v1.2.3 (required)")
+	printTags := flag.Bool("print-tag-paths", false, "print per-module git tags (one per line) instead of bumping")
+	dryRun := flag.Bool("dry-run", false, "preview the publishable set and tags without writing go.mod files")
+	flag.Parse()
+
+	if *version == "" {
+		return fmt.Errorf("--version is required (e.g. --version v1.2.3)")
+	}
+	root, err := workspace.WorkspaceRoot()
+	if err != nil {
+		return err
+	}
+
+	if *printTags {
+		tags, err := modrelease.TagPaths(root, *version)
+		if err != nil {
+			return err
+		}
+		for _, t := range tags {
+			p("%s\n", t)
+		}
+		return nil
+	}
+
+	if *dryRun {
+		return preview(root, *version)
+	}
+
+	results, err := modrelease.BumpTree(root, *version)
+	if err != nil {
+		return err
+	}
+	bumped := 0
+	for _, res := range results {
+		if len(res.Requires) > 0 {
+			bumped++
+			p("bumped %s: %v -> %s\n", res.Dir, res.Requires, *version)
+		}
+	}
+	p("modrelease: bumped internal requires in %d/%d publishable modules to %s\n", bumped, len(results), *version)
+	return nil
+}
+
+func preview(root, version string) error {
+	mods, err := modrelease.PublishableModules(root)
+	if err != nil {
+		return err
+	}
+	tags, err := modrelease.TagPaths(root, version)
+	if err != nil {
+		return err
+	}
+	p("modrelease --dry-run: %d publishable modules would bump internal requires to %s\n", len(mods), version)
+	for _, m := range mods {
+		p("  %s (%s)\n", m.Dir, m.ImportPath)
+	}
+	p("would create %d tags:\n", len(tags))
+	for _, t := range tags {
+		p("  %s\n", t)
+	}
+	return nil
+}

--- a/tools/modrelease/cmd/main.go
+++ b/tools/modrelease/cmd/main.go
@@ -17,10 +17,6 @@ import (
 )
 
 func main() {
-	// workspace.Modules' manifest cross-check logs INFO per member via the
-	// default slog logger; quiet it so --print-tag-paths stdout stays clean and
-	// the release-workflow log isn't flooded.
-	slog.SetLogLoggerLevel(slog.LevelWarn)
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "modrelease:", err)
 		os.Exit(1)
@@ -47,6 +43,10 @@ func run() error {
 	}
 
 	if *printTags {
+		// Only --print-tag-paths feeds stdout to a shell `mapfile`; quiet the
+		// workspace manifest cross-check's per-member INFO so the release-workflow
+		// log isn't flooded. --version / --dry-run keep INFO for operator diagnosis.
+		slog.SetLogLoggerLevel(slog.LevelWarn)
 		tags, err := modrelease.TagPaths(root, *version)
 		if err != nil {
 			return err

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -119,23 +119,40 @@ func PublishableModules(root string) ([]workspace.Module, error) {
 // by the following \s+, so a sibling namespace like github.com/ghbvf/gocellxyz
 // cannot false-match.
 //
-// Out of scope: a BLOCK-form `exclude (` / `retract (` whose inner line carries an
-// internal path (no keyword on that line) WOULD match and be rewritten. This is
-// acceptable — excluding or retracting one's own sibling module is nonsensical and
-// no GoCell go.mod contains it. require blocks are the only multi-line form the
-// bump targets; single-line exclude/retract is keyword-anchored and safe (covered
-// by a test). This sealed assumption is documented rather than guarded because the
-// red case cannot occur in a well-formed monorepo go.mod.
+// A BLOCK-form `exclude (` / `retract (` whose inner line carries an internal path
+// (no keyword on that line) would otherwise match this regex; [bumpModuleRE] guards
+// it with a small block-context state machine that skips lines inside those blocks
+// (see [blockOpens]). require blocks are the only multi-line form the bump targets;
+// single-line exclude/retract is keyword-anchored and never matches. Both forms are
+// covered by tests.
 func internalRequireRE(prefix string) *regexp.Regexp {
 	return regexp.MustCompile(
 		`^(\s*(?:require\s+)?)(` + regexp.QuoteMeta(prefix) + `(?:/\S+)?)(\s+)(v\S+)(.*)$`,
 	)
 }
 
-// validReleaseVersion checks version is a canonical semver tag (e.g. "v1.2.3").
+// blockOpens reports whether trimmed (a whitespace-trimmed line) opens a go.mod
+// directive block for keyword — i.e. `<keyword> (`, tolerating inner whitespace.
+func blockOpens(trimmed []byte, keyword string) bool {
+	if !bytes.HasPrefix(trimmed, []byte(keyword)) {
+		return false
+	}
+	rest := bytes.TrimLeft(trimmed[len(keyword):], " \t")
+	return string(rest) == "("
+}
+
+// validReleaseVersion checks version is a canonical semver tag (e.g. "v1.2.3")
+// whose major is v0 or v1. A v2+ major requires the module path to end in /vN
+// (Go semantic import versioning), which no gocell module carries yet — so a v2
+// release would mint unresolvable adapters/postgres/v2.0.0-style tags. Reject it
+// until that path migration lands. ref: https://go.dev/blog/v2-go-modules
 func validReleaseVersion(version string) error {
 	if !semver.IsValid(version) || semver.Canonical(version) != version {
 		return fmt.Errorf("modrelease: version %q is not a canonical semver tag (want e.g. v1.2.3)", version)
+	}
+	if m := semver.Major(version); m != "v0" && m != "v1" {
+		return fmt.Errorf("modrelease: version %q has major %s; gocell modules have no /vN path suffix, "+
+			"so v2+ tags would be unresolvable (Go semantic import versioning) — migrate module paths to /vN first", version, m)
 	}
 	return nil
 }
@@ -161,31 +178,61 @@ func bumpModuleRE(dir string, re *regexp.Regexp, version string) (Result, error)
 	if err != nil {
 		return Result{}, fmt.Errorf("modrelease: read go.mod: %w", err)
 	}
-
-	lines := bytes.Split(data, []byte("\n"))
-	var requires []string
-	for i, line := range lines {
-		m := re.FindSubmatch(line)
-		if m == nil {
-			continue
-		}
-		path, oldVer := string(m[2]), string(m[4])
-		if oldVer == version {
-			continue // idempotent
-		}
-		requires = append(requires, path)
-		lines[i] = []byte(string(m[1]) + path + string(m[3]) + version + string(m[5]))
-	}
+	out, requires := rewriteRequires(data, re, version)
 	if len(requires) == 0 {
 		return Result{Dir: dir}, nil // no write: nothing internal to bump
 	}
 	// 0o600: BumpModule only rewrites EXISTING go.mod files, so the mode arg is
 	// inert (os.WriteFile preserves an existing file's permissions); 0o600
 	// satisfies gosec G306 without altering the real go.mod mode.
-	if err := os.WriteFile(p, bytes.Join(lines, []byte("\n")), 0o600); err != nil {
+	if err := os.WriteFile(p, out, 0o600); err != nil {
 		return Result{}, fmt.Errorf("modrelease: write go.mod: %w", err)
 	}
 	return Result{Dir: dir, Requires: requires}, nil
+}
+
+// rewriteRequires returns go.mod bytes with every internal require version bumped
+// to version (and the list of bumped paths). Lines inside an `exclude (` /
+// `retract (` block are skipped — an internal-path line there carries a version
+// and would otherwise match and corrupt the directive; require blocks ARE
+// rewritten (that is the bump target). Single-line exclude/retract is
+// keyword-anchored and never matches, so only the block form needs the guard.
+func rewriteRequires(data []byte, re *regexp.Regexp, version string) ([]byte, []string) {
+	lines := bytes.Split(data, []byte("\n"))
+	var requires []string
+	inExcludeRetract := false
+	for i, line := range lines {
+		trimmed := bytes.TrimSpace(line)
+		switch {
+		case blockOpens(trimmed, "exclude") || blockOpens(trimmed, "retract"):
+			inExcludeRetract = true
+		case inExcludeRetract:
+			if string(trimmed) == ")" {
+				inExcludeRetract = false
+			}
+		default:
+			if newLine, path := bumpRequireLine(line, re, version); path != "" {
+				lines[i] = newLine
+				requires = append(requires, path)
+			}
+		}
+	}
+	return bytes.Join(lines, []byte("\n")), requires
+}
+
+// bumpRequireLine rewrites a single internal require line's version to version,
+// returning the new line and the matched module path. It returns ("", path="")
+// when line is not an internal require or is already at version (idempotent).
+func bumpRequireLine(line []byte, re *regexp.Regexp, version string) ([]byte, string) {
+	m := re.FindSubmatch(line)
+	if m == nil {
+		return nil, ""
+	}
+	path, oldVer := string(m[2]), string(m[4])
+	if oldVer == version {
+		return nil, "" // idempotent
+	}
+	return []byte(string(m[1]) + path + string(m[3]) + version + string(m[5])), path
 }
 
 // BumpTree rewrites the internal require versions of every publishable module

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -113,14 +113,31 @@ func PublishableModules(root string) ([]workspace.Module, error) {
 //	4: the current version token (vX.Y.Z, pseudo, or v0.0.0)
 //	5: the remainder of the line (e.g. " // indirect")
 //
-// `replace` and `module` lines never match: they begin with their own keyword,
-// so neither the optional `require ` nor the bare path can anchor at line start.
-// The (?:/\S+)? after the quoted prefix is bounded by the following \s+, so a
-// sibling namespace like github.com/ghbvf/gocellxyz cannot false-match.
+// `module`, single-line `replace`/`exclude`/`retract` lines never match: they
+// begin with their own keyword, so neither the optional `require ` nor the bare
+// path can anchor at line start. The (?:/\S+)? after the quoted prefix is bounded
+// by the following \s+, so a sibling namespace like github.com/ghbvf/gocellxyz
+// cannot false-match.
+//
+// Out of scope: a BLOCK-form `exclude (` / `retract (` whose inner line carries an
+// internal path (no keyword on that line) WOULD match and be rewritten. This is
+// acceptable — excluding or retracting one's own sibling module is nonsensical and
+// no GoCell go.mod contains it. require blocks are the only multi-line form the
+// bump targets; single-line exclude/retract is keyword-anchored and safe (covered
+// by a test). This sealed assumption is documented rather than guarded because the
+// red case cannot occur in a well-formed monorepo go.mod.
 func internalRequireRE(prefix string) *regexp.Regexp {
 	return regexp.MustCompile(
 		`^(\s*(?:require\s+)?)(` + regexp.QuoteMeta(prefix) + `(?:/\S+)?)(\s+)(v\S+)(.*)$`,
 	)
+}
+
+// validReleaseVersion checks version is a canonical semver tag (e.g. "v1.2.3").
+func validReleaseVersion(version string) error {
+	if !semver.IsValid(version) || semver.Canonical(version) != version {
+		return fmt.Errorf("modrelease: version %q is not a canonical semver tag (want e.g. v1.2.3)", version)
+	}
+	return nil
 }
 
 // BumpModule rewrites every internal require version in dir/go.mod (a require
@@ -130,16 +147,21 @@ func internalRequireRE(prefix string) *regexp.Regexp {
 // writes the file only when at least one require changed. version must be a valid
 // canonical semver tag (e.g. "v1.2.3").
 func BumpModule(dir, prefix, version string) (Result, error) {
-	if !semver.IsValid(version) || semver.Canonical(version) != version {
-		return Result{}, fmt.Errorf("modrelease: version %q is not a canonical semver tag (want e.g. v1.2.3)", version)
+	if err := validReleaseVersion(version); err != nil {
+		return Result{}, err
 	}
+	return bumpModuleRE(dir, internalRequireRE(prefix), version)
+}
+
+// bumpModuleRE is the core rewrite, taking a precompiled matcher so BumpTree
+// compiles the prefix regexp once across all modules rather than per module.
+func bumpModuleRE(dir string, re *regexp.Regexp, version string) (Result, error) {
 	p := filepath.Clean(filepath.Join(dir, "go.mod"))
 	data, err := os.ReadFile(p)
 	if err != nil {
 		return Result{}, fmt.Errorf("modrelease: read go.mod: %w", err)
 	}
 
-	re := internalRequireRE(prefix)
 	lines := bytes.Split(data, []byte("\n"))
 	var requires []string
 	for i, line := range lines {
@@ -171,6 +193,9 @@ func BumpModule(dir, prefix, version string) (Result, error) {
 // root/go.mod (never a hardcoded literal). Returns one Result per publishable
 // module, in go.work order.
 func BumpTree(root, version string) ([]Result, error) {
+	if err := validReleaseVersion(version); err != nil {
+		return nil, err
+	}
 	prefix, err := gomodutil.ReadModulePath(root)
 	if err != nil {
 		return nil, fmt.Errorf("modrelease: read root module path: %w", err)
@@ -179,9 +204,10 @@ func BumpTree(root, version string) ([]Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	re := internalRequireRE(prefix)
 	results := make([]Result, 0, len(mods))
 	for _, m := range mods {
-		res, err := BumpModule(filepath.Join(root, m.Dir), prefix, version)
+		res, err := bumpModuleRE(filepath.Join(root, m.Dir), re, version)
 		if err != nil {
 			return nil, fmt.Errorf("modrelease: bump %q: %w", m.Dir, err)
 		}
@@ -206,8 +232,8 @@ func tagPathFor(reldir, version string) string {
 // go.work order: root → "vX.Y.Z", satellites → "<reldir>/vX.Y.Z". The release
 // workflow tags exactly these refs at the bump commit.
 func TagPaths(root, version string) ([]string, error) {
-	if !semver.IsValid(version) || semver.Canonical(version) != version {
-		return nil, fmt.Errorf("modrelease: version %q is not a canonical semver tag (want e.g. v1.2.3)", version)
+	if err := validReleaseVersion(version); err != nil {
+		return nil, err
 	}
 	mods, err := PublishableModules(root)
 	if err != nil {

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -1,0 +1,221 @@
+// Package modrelease is the synchronized multi-module release tool for the
+// GoCell workspace. It rewrites the internal `require` versions of every
+// publishable LIBRARY module to a single release version and derives the
+// per-module git tag set, so satellites become externally consumable via
+// `go get <module>@vX.Y.Z`.
+//
+// # Why
+//
+// Each satellite go.mod declares its intra-repo dependencies as
+// `require github.com/ghbvf/gocell[/path] v0.0.0` + a local
+// `replace … => ../relative`. `v0.0.0` is an unpublished placeholder: an external
+// consumer's `go get github.com/ghbvf/gocell/adapters/postgres@<tag>` cannot
+// resolve it. The release rewrites every internal require to the real release
+// version (v0.0.0 / pseudo / a prior real version → vX.Y.Z) and tags each module
+// `<reldir>/vX.Y.Z`.
+//
+// # Keep replace (NOT stripped)
+//
+// The local `replace` directives are LEFT UNTOUCHED, matching the
+// OpenTelemetry-Go published shape (ref: open-telemetry/opentelemetry-go
+// exporters/otlp/otlptrace/go.mod@exporters/otlp/otlptrace/v1.24.0 — replace kept
+// at the release tag). Go IGNORES a dependency module's replace directives, so a
+// published library carrying `replace … => ../local` is harmless to consumers
+// (they resolve the bumped `require … vX.Y.Z` from the sibling's own tag), while
+// the same replace keeps `GOWORK=off go list -m all` (hack/verify-workspace.sh)
+// resolving unpublished siblings on the develop branch. The version-only rewrite
+// (ref: open-telemetry/opentelemetry-go-build-tools multimod replaceModVersion)
+// touches require versions only; replace lines carry no version and are never
+// matched.
+//
+// # Scope: library modules only
+//
+// The publishable set is every go.work member EXCEPT examples/*, tests/*, and
+// cmd/* (see [IsPublishable]). cmd/* are `go install` binaries / deployment
+// artifacts: `go install pkg@version` is rejected outright when the installed
+// module's go.mod contains a replace directive, so making them go-install-able
+// would require release-time replace-strip + a separate tagged-tree shape that
+// conflicts with the develop GOWORK=off verify — a distinct, harder problem
+// tracked in #1088 (see tools/archtest/root_module_no_replace_test.go godoc).
+package modrelease
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/ghbvf/gocell/tools/gomodutil"
+	"github.com/ghbvf/gocell/tools/workspace"
+)
+
+// Result reports the require-version rewrites a single [BumpModule] applied.
+type Result struct {
+	// Dir is the module directory as passed to BumpModule (or the go.work
+	// use-dir when produced by BumpTree).
+	Dir string
+	// Requires lists the internal module paths whose require version was
+	// rewritten, in file order. Empty when the module was already at the target
+	// version or carries no internal require.
+	Requires []string
+}
+
+// IsPublishable reports whether the workspace member at reldir (a go.work `use`
+// directory, filepath.Clean'd, "." for the root module) belongs to the
+// externally-published LIBRARY set.
+//
+// Deny predicate: examples/* and tests/* are leaf consumers; cmd/* are
+// `go install` binaries / deployment artifacts whose go-install-at-version path
+// conflicts with the kept replace directives (#1088). Everything else publishes
+// by default — a new adapters/foo is publishable (fail-toward-publish), a new
+// cmd/foo binary is excluded (fail-toward-exclude-binary). This predicate is the
+// single source of the allow/deny rule; the set itself is DERIVED from go.work
+// (see [PublishableModules]), never a hand-maintained list.
+func IsPublishable(reldir string) bool {
+	slash := filepath.ToSlash(filepath.Clean(reldir))
+	for _, deny := range [...]string{"examples", "tests", "cmd"} {
+		if slash == deny || strings.HasPrefix(slash, deny+"/") {
+			return false
+		}
+	}
+	return true
+}
+
+// PublishableModules returns the publishable subset of the workspace rooted at
+// root, in go.work `use` order. It is the single source shared by the release
+// tagger, the golden drift guard, and the external smoke test: the set is
+// workspace.Modules(root) filtered by [IsPublishable], so it can never drift from
+// the go.work the toolchain actually compiles.
+func PublishableModules(root string) ([]workspace.Module, error) {
+	mods, err := workspace.Modules(root)
+	if err != nil {
+		return nil, fmt.Errorf("modrelease: enumerate workspace: %w", err)
+	}
+	out := make([]workspace.Module, 0, len(mods))
+	for _, m := range mods {
+		if IsPublishable(m.Dir) {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+// internalRequireRE builds the per-line matcher for an internal require whose
+// module path is rooted at prefix. Capture groups:
+//
+//	1: leading whitespace + optional `require ` keyword (single-line form)
+//	2: the internal module path (prefix, optionally with a /subpath)
+//	3: whitespace between path and version
+//	4: the current version token (vX.Y.Z, pseudo, or v0.0.0)
+//	5: the remainder of the line (e.g. " // indirect")
+//
+// `replace` and `module` lines never match: they begin with their own keyword,
+// so neither the optional `require ` nor the bare path can anchor at line start.
+// The (?:/\S+)? after the quoted prefix is bounded by the following \s+, so a
+// sibling namespace like github.com/ghbvf/gocellxyz cannot false-match.
+func internalRequireRE(prefix string) *regexp.Regexp {
+	return regexp.MustCompile(
+		`^(\s*(?:require\s+)?)(` + regexp.QuoteMeta(prefix) + `(?:/\S+)?)(\s+)(v\S+)(.*)$`,
+	)
+}
+
+// BumpModule rewrites every internal require version in dir/go.mod (a require
+// whose module path is prefix or under prefix/) to version, preserving replace
+// directives, `// indirect` markers, external requires, the module line, and all
+// other bytes. It is idempotent (a require already at version is left as-is) and
+// writes the file only when at least one require changed. version must be a valid
+// canonical semver tag (e.g. "v1.2.3").
+func BumpModule(dir, prefix, version string) (Result, error) {
+	if !semver.IsValid(version) || semver.Canonical(version) != version {
+		return Result{}, fmt.Errorf("modrelease: version %q is not a canonical semver tag (want e.g. v1.2.3)", version)
+	}
+	p := filepath.Clean(filepath.Join(dir, "go.mod"))
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return Result{}, fmt.Errorf("modrelease: read go.mod: %w", err)
+	}
+
+	re := internalRequireRE(prefix)
+	lines := bytes.Split(data, []byte("\n"))
+	var requires []string
+	for i, line := range lines {
+		m := re.FindSubmatch(line)
+		if m == nil {
+			continue
+		}
+		path, oldVer := string(m[2]), string(m[4])
+		if oldVer == version {
+			continue // idempotent
+		}
+		requires = append(requires, path)
+		lines[i] = []byte(string(m[1]) + path + string(m[3]) + version + string(m[5]))
+	}
+	if len(requires) == 0 {
+		return Result{Dir: dir}, nil // no write: nothing internal to bump
+	}
+	// 0o600: BumpModule only rewrites EXISTING go.mod files, so the mode arg is
+	// inert (os.WriteFile preserves an existing file's permissions); 0o600
+	// satisfies gosec G306 without altering the real go.mod mode.
+	if err := os.WriteFile(p, bytes.Join(lines, []byte("\n")), 0o600); err != nil {
+		return Result{}, fmt.Errorf("modrelease: write go.mod: %w", err)
+	}
+	return Result{Dir: dir, Requires: requires}, nil
+}
+
+// BumpTree rewrites the internal require versions of every publishable module
+// under root to version, in place. The platform module prefix is read from
+// root/go.mod (never a hardcoded literal). Returns one Result per publishable
+// module, in go.work order.
+func BumpTree(root, version string) ([]Result, error) {
+	prefix, err := gomodutil.ReadModulePath(root)
+	if err != nil {
+		return nil, fmt.Errorf("modrelease: read root module path: %w", err)
+	}
+	mods, err := PublishableModules(root)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]Result, 0, len(mods))
+	for _, m := range mods {
+		res, err := BumpModule(filepath.Join(root, m.Dir), prefix, version)
+		if err != nil {
+			return nil, fmt.Errorf("modrelease: bump %q: %w", m.Dir, err)
+		}
+		res.Dir = m.Dir
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+// tagPathFor maps a workspace use-dir to its synchronized git tag: the root
+// module ("." ) tags as the bare version (vX.Y.Z); a satellite at reldir tags as
+// "<reldir>/vX.Y.Z" (Go's submodule tag convention).
+func tagPathFor(reldir, version string) string {
+	slash := filepath.ToSlash(filepath.Clean(reldir))
+	if slash == "." {
+		return version
+	}
+	return slash + "/" + version
+}
+
+// TagPaths returns the git tag for every publishable module at version, in
+// go.work order: root → "vX.Y.Z", satellites → "<reldir>/vX.Y.Z". The release
+// workflow tags exactly these refs at the bump commit.
+func TagPaths(root, version string) ([]string, error) {
+	if !semver.IsValid(version) || semver.Canonical(version) != version {
+		return nil, fmt.Errorf("modrelease: version %q is not a canonical semver tag (want e.g. v1.2.3)", version)
+	}
+	mods, err := PublishableModules(root)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(mods))
+	for _, m := range mods {
+		out = append(out, tagPathFor(m.Dir, version))
+	}
+	return out, nil
+}

--- a/tools/modrelease/modrelease_test.go
+++ b/tools/modrelease/modrelease_test.go
@@ -103,6 +103,24 @@ func TestBumpModule(t *testing.T) {
 			wantRequires: []string{"github.com/ghbvf/gocell/adapters/s3"},
 		},
 		{
+			name: "block-form exclude/retract with internal path untouched, require bumped",
+			in: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/s3 v0.0.0\n\n" +
+				"exclude (\n" +
+				"\tgithub.com/ghbvf/gocell v0.0.0\n" +
+				"\tgithub.com/ghbvf/gocell/adapters/redis v0.0.0\n" +
+				")\n\n" +
+				"retract (\n\tv0.0.1\n)\n",
+			want: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/s3 v1.2.3\n\n" +
+				"exclude (\n" +
+				"\tgithub.com/ghbvf/gocell v0.0.0\n" +
+				"\tgithub.com/ghbvf/gocell/adapters/redis v0.0.0\n" +
+				")\n\n" +
+				"retract (\n\tv0.0.1\n)\n",
+			wantRequires: []string{"github.com/ghbvf/gocell/adapters/s3"},
+		},
+		{
 			name: "sibling-namespace false-match guard (gocellxyz must NOT match)",
 			in: "module gocell.example/x\n\ngo 1.25\n\n" +
 				"require github.com/ghbvf/gocellxyz/foo v0.4.0\n" +
@@ -227,9 +245,11 @@ func TestBumpTree(t *testing.T) {
 // the real workspace.
 func TestTagPaths(t *testing.T) {
 	root := workspaceRootForTest(t)
-	for _, bad := range []string{"1.2.3", "v1.2", "v1.2.3-rc1+meta", ""} {
+	// Non-canonical and v2+ (Go semantic import versioning: no /vN module path)
+	// must all be rejected.
+	for _, bad := range []string{"1.2.3", "v1.2", "v1.2.3-rc1+meta", "", "v2.0.0", "v3.1.4"} {
 		if _, err := TagPaths(root, bad); err == nil {
-			t.Errorf("TagPaths must reject non-canonical version %q", bad)
+			t.Errorf("TagPaths must reject version %q", bad)
 		}
 	}
 	tags, err := TagPaths(root, testVersion)

--- a/tools/modrelease/modrelease_test.go
+++ b/tools/modrelease/modrelease_test.go
@@ -3,6 +3,7 @@ package modrelease
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -90,6 +91,18 @@ func TestBumpModule(t *testing.T) {
 			wantRequires: nil,
 		},
 		{
+			name: "single-line exclude/retract keyword-anchored: untouched, require bumped",
+			in: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/s3 v0.0.0\n" +
+				"exclude github.com/ghbvf/gocell v0.0.0\n" +
+				"retract v0.0.1\n",
+			want: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/s3 v1.2.3\n" +
+				"exclude github.com/ghbvf/gocell v0.0.0\n" +
+				"retract v0.0.1\n",
+			wantRequires: []string{"github.com/ghbvf/gocell/adapters/s3"},
+		},
+		{
 			name: "sibling-namespace false-match guard (gocellxyz must NOT match)",
 			in: "module gocell.example/x\n\ngo 1.25\n\n" +
 				"require github.com/ghbvf/gocellxyz/foo v0.4.0\n" +
@@ -148,6 +161,108 @@ func TestIsPublishable(t *testing.T) {
 			t.Errorf("IsPublishable(%q) = %v, want %v", tt.dir, got, tt.want)
 		}
 	}
+}
+
+// TestBumpTree exercises the actual release entry: it bumps every PUBLISHABLE
+// member of a synthetic workspace (root + adapters), leaves a denied member
+// (examples/*) untouched, preserves replace, and stamps Result.Dir.
+func TestBumpTree(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module github.com/ghbvf/gocell\n\ngo 1.25\n")
+	write("go.work", "go 1.25\n\nuse (\n\t.\n\t./adapters/a\n\t./adapters/b\n\t./examples/demo\n)\n")
+	write("adapters/a/go.mod", "module github.com/ghbvf/gocell/adapters/a\n\ngo 1.25\n\n"+
+		"require github.com/ghbvf/gocell v0.0.0\n\nreplace github.com/ghbvf/gocell => ../../\n")
+	write("adapters/b/go.mod", "module github.com/ghbvf/gocell/adapters/b\n\ngo 1.25\n\n"+
+		"require (\n\tgithub.com/ghbvf/gocell v0.0.0\n\tgithub.com/ghbvf/gocell/adapters/a v0.0.0\n)\n")
+	write("examples/demo/go.mod", "module github.com/ghbvf/gocell/examples/demo\n\ngo 1.25\n\n"+
+		"require github.com/ghbvf/gocell v0.0.0\n")
+
+	results, err := BumpTree(root, testVersion)
+	if err != nil {
+		t.Fatalf("BumpTree: %v", err)
+	}
+	// Publishable = root + adapters/a + adapters/b (examples/demo denied).
+	if len(results) != 3 {
+		t.Fatalf("want 3 publishable results, got %d: %+v", len(results), results)
+	}
+	for _, r := range results {
+		if r.Dir == "" {
+			t.Errorf("Result.Dir not stamped: %+v", r)
+		}
+	}
+	a := mustRead(t, filepath.Join(root, "adapters", "a", "go.mod"))
+	if !strings.Contains(a, "require github.com/ghbvf/gocell v1.2.3") {
+		t.Errorf("adapters/a require not bumped:\n%s", a)
+	}
+	if !strings.Contains(a, "replace github.com/ghbvf/gocell => ../../") {
+		t.Errorf("adapters/a replace must be preserved:\n%s", a)
+	}
+	b := mustRead(t, filepath.Join(root, "adapters", "b", "go.mod"))
+	if strings.Contains(b, "v0.0.0") {
+		t.Errorf("adapters/b still has v0.0.0 (both internal requires must bump):\n%s", b)
+	}
+	// Denied member is left as-is.
+	demo := mustRead(t, filepath.Join(root, "examples", "demo", "go.mod"))
+	if !strings.Contains(demo, "v0.0.0") {
+		t.Errorf("examples/demo is denied and must be untouched, got:\n%s", demo)
+	}
+
+	// Invalid version rejected before touching the tree.
+	if _, err := BumpTree(root, "1.2.3"); err == nil {
+		t.Error("BumpTree must reject a non-canonical version")
+	}
+}
+
+// TestTagPaths covers version validation + the root/satellite tag shapes against
+// the real workspace.
+func TestTagPaths(t *testing.T) {
+	root := workspaceRootForTest(t)
+	for _, bad := range []string{"1.2.3", "v1.2", "v1.2.3-rc1+meta", ""} {
+		if _, err := TagPaths(root, bad); err == nil {
+			t.Errorf("TagPaths must reject non-canonical version %q", bad)
+		}
+	}
+	tags, err := TagPaths(root, testVersion)
+	if err != nil {
+		t.Fatalf("TagPaths: %v", err)
+	}
+	if len(tags) < 2 {
+		t.Fatalf("want >=2 tags, got %d", len(tags))
+	}
+	if tags[0] != testVersion {
+		t.Errorf("root tag = %q, want bare %q", tags[0], testVersion)
+	}
+	if !containsString(tags, "adapters/postgres/"+testVersion) {
+		t.Errorf("satellite tag adapters/postgres/%s missing from %v", testVersion, tags)
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func containsString(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestTagPathsShape(t *testing.T) {

--- a/tools/modrelease/modrelease_test.go
+++ b/tools/modrelease/modrelease_test.go
@@ -1,0 +1,181 @@
+package modrelease
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	testPrefix  = "github.com/ghbvf/gocell"
+	testVersion = "v1.2.3"
+)
+
+// TestBumpModule is the byte-level golden for the require-version rewrite. Each
+// `want` MUST preserve replace directives, `// indirect` markers, external
+// requires, the module line, and all surrounding bytes — only internal require
+// versions change. This is the Hard load-bearing guard on "do NOT strip replace"
+// (OTel-canonical published shape): a future edit that drops a replace line, or
+// rewrites an external require, fails byte-diff here.
+func TestBumpModule(t *testing.T) {
+	tests := []struct {
+		name         string
+		in           string
+		want         string
+		wantRequires []string
+	}{
+		{
+			name: "block v0.0.0 + pseudo + indirect, replace+external+module untouched",
+			in: "module github.com/ghbvf/gocell/adapters/postgres\n\ngo 1.25.11\n\n" +
+				"require (\n" +
+				"\tgithub.com/ghbvf/gocell v0.0.0\n" +
+				"\tgithub.com/ghbvf/gocell/adapters/adapterutil v0.0.0\n" +
+				"\tgithub.com/google/uuid v1.6.0\n" +
+				")\n\n" +
+				"require github.com/ghbvf/gocell/corecells v0.0.0-00010101000000-000000000000 // indirect\n\n" +
+				"replace github.com/ghbvf/gocell => ../../\n\n" +
+				"replace github.com/ghbvf/gocell/adapters/adapterutil => ../adapterutil\n",
+			want: "module github.com/ghbvf/gocell/adapters/postgres\n\ngo 1.25.11\n\n" +
+				"require (\n" +
+				"\tgithub.com/ghbvf/gocell v1.2.3\n" +
+				"\tgithub.com/ghbvf/gocell/adapters/adapterutil v1.2.3\n" +
+				"\tgithub.com/google/uuid v1.6.0\n" +
+				")\n\n" +
+				"require github.com/ghbvf/gocell/corecells v1.2.3 // indirect\n\n" +
+				"replace github.com/ghbvf/gocell => ../../\n\n" +
+				"replace github.com/ghbvf/gocell/adapters/adapterutil => ../adapterutil\n",
+			wantRequires: []string{
+				"github.com/ghbvf/gocell",
+				"github.com/ghbvf/gocell/adapters/adapterutil",
+				"github.com/ghbvf/gocell/corecells",
+			},
+		},
+		{
+			name: "single-line require form, with and without indirect",
+			in: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/tools v0.0.0\n" +
+				"require github.com/ghbvf/gocell v0.0.0 // indirect\n\n" +
+				"replace github.com/ghbvf/gocell/tools => ./tools\n",
+			want: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/tools v1.2.3\n" +
+				"require github.com/ghbvf/gocell v1.2.3 // indirect\n\n" +
+				"replace github.com/ghbvf/gocell/tools => ./tools\n",
+			wantRequires: []string{
+				"github.com/ghbvf/gocell/tools",
+				"github.com/ghbvf/gocell",
+			},
+		},
+		{
+			name: "steady real->real bump (not just v0.0.0)",
+			in: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/redis v1.1.0\n",
+			want: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/redis v1.2.3\n",
+			wantRequires: []string{"github.com/ghbvf/gocell/adapters/redis"},
+		},
+		{
+			name: "idempotent: already at target -> no change, no requires",
+			in: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/redis v1.2.3\n",
+			want: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocell/adapters/redis v1.2.3\n",
+			wantRequires: nil,
+		},
+		{
+			name: "no internal requires (root-like): unchanged",
+			in: "module github.com/ghbvf/gocell\n\ngo 1.25.11\n\n" +
+				"require (\n\tgithub.com/google/uuid v1.6.0\n\tgopkg.in/yaml.v3 v3.0.1\n)\n",
+			want: "module github.com/ghbvf/gocell\n\ngo 1.25.11\n\n" +
+				"require (\n\tgithub.com/google/uuid v1.6.0\n\tgopkg.in/yaml.v3 v3.0.1\n)\n",
+			wantRequires: nil,
+		},
+		{
+			name: "sibling-namespace false-match guard (gocellxyz must NOT match)",
+			in: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocellxyz/foo v0.4.0\n" +
+				"require github.com/ghbvf/gocell/adapters/s3 v0.0.0\n",
+			want: "module gocell.example/x\n\ngo 1.25\n\n" +
+				"require github.com/ghbvf/gocellxyz/foo v0.4.0\n" +
+				"require github.com/ghbvf/gocell/adapters/s3 v1.2.3\n",
+			wantRequires: []string{"github.com/ghbvf/gocell/adapters/s3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			modPath := filepath.Clean(filepath.Join(dir, "go.mod"))
+			if err := os.WriteFile(modPath, []byte(tt.in), 0o644); err != nil {
+				t.Fatalf("write go.mod: %v", err)
+			}
+			res, err := BumpModule(dir, testPrefix, testVersion)
+			if err != nil {
+				t.Fatalf("BumpModule: %v", err)
+			}
+			got, err := os.ReadFile(modPath)
+			if err != nil {
+				t.Fatalf("read go.mod: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("go.mod bytes mismatch\n--- got ---\n%s\n--- want ---\n%s", got, tt.want)
+			}
+			if !equalStrings(res.Requires, tt.wantRequires) {
+				t.Errorf("Result.Requires = %v, want %v", res.Requires, tt.wantRequires)
+			}
+		})
+	}
+}
+
+func TestIsPublishable(t *testing.T) {
+	tests := []struct {
+		dir  string
+		want bool
+	}{
+		{".", true},
+		{"adapters/postgres", true},
+		{"adapters/adapterutil", true},
+		{"corecells", true},
+		{"cellmodules", true},
+		{"tools", true},
+		{"examples/demo", false},
+		{"examples/ssobff", false},
+		{"tests/integration", false},
+		{"tests/testutil/pgshare", false},
+		{"cmd/gocell", false},
+		{"cmd/corebundle", false},
+	}
+	for _, tt := range tests {
+		if got := IsPublishable(tt.dir); got != tt.want {
+			t.Errorf("IsPublishable(%q) = %v, want %v", tt.dir, got, tt.want)
+		}
+	}
+}
+
+func TestTagPathsShape(t *testing.T) {
+	// Root maps to a bare version tag; satellites to <dir>/<version>.
+	mods := []struct {
+		dir  string
+		want string
+	}{
+		{".", "v1.2.3"},
+		{"adapters/postgres", "adapters/postgres/v1.2.3"},
+		{"tools", "tools/v1.2.3"},
+	}
+	for _, m := range mods {
+		got := tagPathFor(m.dir, testVersion)
+		if got != m.want {
+			t.Errorf("tagPathFor(%q) = %q, want %q", m.dir, got, m.want)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/modrelease/publishable_golden_test.go
+++ b/tools/modrelease/publishable_golden_test.go
@@ -1,0 +1,172 @@
+package modrelease
+
+// INVARIANT: PUBLISHABLE-MODULE-SET-01
+//
+// The externally-published module set is DERIVED from go.work minus the
+// examples/ + tests/ + cmd/ deny predicate ([IsPublishable]) and byte-locked into
+// testdata/publishable.golden. This is a codegen-funnel+golden guard (ai-robust
+// §载体 #1, Hard): adding an adapter to go.work, renaming a member, or changing
+// the deny predicate shifts the derived set, the golden goes stale, and CI fails
+// on the byte diff — the drift cannot be silent. Regenerate intentionally with
+// `make update-modrelease-golden`.
+//
+// # Grading: Hard (golden byte-freeze of a derived set)
+//
+// The SET is derived from go.work (the single source the toolchain compiles), and
+// the OUTPUT bytes are frozen; any drift in either the source (go.work) or the
+// rule (IsPublishable) surfaces as a byte diff. This is stronger than a runtime
+// equality assertion (Medium) because the expected output is a checked-in
+// artifact a human must consciously regenerate.
+//
+// # Anti-vacuity + synthetic red case (ai-robust §archtest 文件命名)
+//
+//   - Anti-vacuity: TestPublishableModuleSet01 asserts len >= 2 and that the root
+//     module (Dir ".") is present, so a mis-resolved / empty set cannot pass green.
+//   - Synthetic red case: TestPublishableModuleSet01_DenyPredicate feeds a fixture
+//     go.work containing synthetic examples/foo, tests/bar, and cmd/baz members and
+//     asserts the deny predicate drops exactly those three while keeping the
+//     non-leaf members — proving the filter is not a vacuous always-true pass.
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/workspace"
+)
+
+const publishableModuleSetRule = "PUBLISHABLE-MODULE-SET-01"
+
+// updateGolden regenerates testdata/publishable.golden (via `make
+// update-modrelease-golden`). Test-scope only; modrelease is not imported as a
+// dependency, so this flag cannot collide with a consumer's own -update.
+var updateGolden = flag.Bool("update", false, "regenerate testdata/publishable.golden")
+
+// goldenTagPathRE matches a well-formed synchronized tag: a bare version for the
+// root, or "<reldir>/vX.Y.Z" for a satellite. Rejects "..", absolute paths.
+var goldenTagPathRE = regexp.MustCompile(`^(v\d+\.\d+\.\d+|[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*/v\d+\.\d+\.\d+)$`)
+
+func TestPublishableModuleSet01(t *testing.T) {
+	root := workspaceRootForTest(t)
+
+	mods, err := PublishableModules(root)
+	if err != nil {
+		t.Fatalf("%s: PublishableModules: %v", publishableModuleSetRule, err)
+	}
+
+	// Anti-vacuity: a real workspace has the root + many satellites; an empty or
+	// root-only result means the enumeration mis-resolved.
+	if len(mods) < 2 {
+		t.Fatalf("%s: anti-vacuity failed: derived %d publishable modules, want >= 2", publishableModuleSetRule, len(mods))
+	}
+	var hasRoot bool
+	for _, m := range mods {
+		if filepath.ToSlash(filepath.Clean(m.Dir)) == "." {
+			hasRoot = true
+		}
+		// Tag-path well-formedness: every member maps to a valid synchronized tag.
+		tag := tagPathFor(m.Dir, "v1.2.3")
+		if !goldenTagPathRE.MatchString(tag) {
+			t.Errorf("%s: module %q yields malformed tag %q", publishableModuleSetRule, m.Dir, tag)
+		}
+	}
+	if !hasRoot {
+		t.Fatalf("%s: anti-vacuity failed: root module (Dir \".\") absent from publishable set", publishableModuleSetRule)
+	}
+
+	got := renderPublishable(mods)
+	goldenPath := filepath.Clean(filepath.Join("testdata", "publishable.golden"))
+	if *updateGolden {
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("%s: write golden: %v", publishableModuleSetRule, err)
+		}
+		t.Logf("%s: wrote %s (%d modules)", publishableModuleSetRule, goldenPath, len(mods))
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("%s: read golden (run `make update-modrelease-golden`): %v", publishableModuleSetRule, err)
+	}
+	if got != string(want) {
+		t.Errorf("%s: publishable module set drifted from testdata/publishable.golden.\n"+
+			"A go.work member was added/removed/renamed, or IsPublishable changed. If intentional, run "+
+			"`make update-modrelease-golden`.\n--- got ---\n%s\n--- want ---\n%s",
+			publishableModuleSetRule, got, want)
+	}
+}
+
+// TestPublishableModuleSet01_DenyPredicate is the synthetic red case: a fixture
+// workspace whose go.work declares examples/foo, tests/bar, and cmd/baz alongside
+// real-shaped library members. The deny predicate MUST drop exactly the three
+// leaf/binary members; if it returned them (or filtered everything), the main
+// green assertion would be vacuous.
+func TestPublishableModuleSet01_DenyPredicate(t *testing.T) {
+	root := workspaceRootForTest(t)
+	fixture := filepath.Join(root, "tools", "modrelease", "testdata", "publishable_set_fixture")
+
+	mods, err := PublishableModules(fixture)
+	if err != nil {
+		t.Fatalf("%s: PublishableModules(fixture): %v", publishableModuleSetRule, err)
+	}
+	got := make(map[string]bool, len(mods))
+	for _, m := range mods {
+		got[filepath.ToSlash(filepath.Clean(m.Dir))] = true
+	}
+	wantKept := []string{".", "adapters/keep", "corecells"}
+	for _, d := range wantKept {
+		if !got[d] {
+			t.Errorf("%s: deny predicate wrongly dropped publishable member %q", publishableModuleSetRule, d)
+		}
+	}
+	wantDropped := []string{"examples/foo", "tests/bar", "cmd/baz"}
+	for _, d := range wantDropped {
+		if got[d] {
+			t.Errorf("%s: deny predicate failed to drop non-publishable member %q (filter is vacuous)", publishableModuleSetRule, d)
+		}
+	}
+	if len(mods) != len(wantKept) {
+		t.Errorf("%s: fixture yielded %d publishable modules %v, want exactly %v",
+			publishableModuleSetRule, len(mods), keys(got), wantKept)
+	}
+}
+
+func renderPublishable(mods []workspace.Module) string {
+	var b strings.Builder
+	b.WriteString("# Publishable module set — DERIVED from go.work minus examples/ + tests/ + cmd/.\n")
+	b.WriteString("# Regenerate intentionally: make update-modrelease-golden\n")
+	b.WriteString("# <reldir>\\t<import-path>\n")
+	for _, m := range mods {
+		fmt.Fprintf(&b, "%s\t%s\n", filepath.ToSlash(filepath.Clean(m.Dir)), m.ImportPath)
+	}
+	return b.String()
+}
+
+func workspaceRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.work")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("workspaceRootForTest: no go.work found walking up from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tools/modrelease/testdata/publishable.golden
+++ b/tools/modrelease/testdata/publishable.golden
@@ -1,0 +1,21 @@
+# Publishable module set — DERIVED from go.work minus examples/ + tests/ + cmd/.
+# Regenerate intentionally: make update-modrelease-golden
+# <reldir>\t<import-path>
+.	github.com/ghbvf/gocell
+adapters/adapterutil	github.com/ghbvf/gocell/adapters/adapterutil
+adapters/circuitbreaker	github.com/ghbvf/gocell/adapters/circuitbreaker
+adapters/grpc	github.com/ghbvf/gocell/adapters/grpc
+adapters/mqtt	github.com/ghbvf/gocell/adapters/mqtt
+adapters/oidc	github.com/ghbvf/gocell/adapters/oidc
+adapters/otel	github.com/ghbvf/gocell/adapters/otel
+adapters/postgres	github.com/ghbvf/gocell/adapters/postgres
+adapters/prometheus	github.com/ghbvf/gocell/adapters/prometheus
+adapters/rabbitmq	github.com/ghbvf/gocell/adapters/rabbitmq
+adapters/ratelimit	github.com/ghbvf/gocell/adapters/ratelimit
+adapters/redis	github.com/ghbvf/gocell/adapters/redis
+adapters/s3	github.com/ghbvf/gocell/adapters/s3
+adapters/vault	github.com/ghbvf/gocell/adapters/vault
+adapters/websocket	github.com/ghbvf/gocell/adapters/websocket
+cellmodules	github.com/ghbvf/gocell/cellmodules
+corecells	github.com/ghbvf/gocell/corecells
+tools	github.com/ghbvf/gocell/tools

--- a/tools/modrelease/testdata/publishable_set_fixture/adapters/keep/go.mod
+++ b/tools/modrelease/testdata/publishable_set_fixture/adapters/keep/go.mod
@@ -1,0 +1,3 @@
+module example.com/fix/adapters/keep
+
+go 1.25

--- a/tools/modrelease/testdata/publishable_set_fixture/cmd/baz/go.mod
+++ b/tools/modrelease/testdata/publishable_set_fixture/cmd/baz/go.mod
@@ -1,0 +1,3 @@
+module example.com/fix/cmd/baz
+
+go 1.25

--- a/tools/modrelease/testdata/publishable_set_fixture/corecells/go.mod
+++ b/tools/modrelease/testdata/publishable_set_fixture/corecells/go.mod
@@ -1,0 +1,3 @@
+module example.com/fix/corecells
+
+go 1.25

--- a/tools/modrelease/testdata/publishable_set_fixture/examples/foo/go.mod
+++ b/tools/modrelease/testdata/publishable_set_fixture/examples/foo/go.mod
@@ -1,0 +1,3 @@
+module example.com/fix/examples/foo
+
+go 1.25

--- a/tools/modrelease/testdata/publishable_set_fixture/go.mod
+++ b/tools/modrelease/testdata/publishable_set_fixture/go.mod
@@ -1,0 +1,3 @@
+module example.com/fix
+
+go 1.25

--- a/tools/modrelease/testdata/publishable_set_fixture/go.work
+++ b/tools/modrelease/testdata/publishable_set_fixture/go.work
@@ -1,0 +1,10 @@
+go 1.25
+
+use (
+	.
+	./adapters/keep
+	./corecells
+	./examples/foo
+	./tests/bar
+	./cmd/baz
+)

--- a/tools/modrelease/testdata/publishable_set_fixture/tests/bar/go.mod
+++ b/tools/modrelease/testdata/publishable_set_fixture/tests/bar/go.mod
@@ -1,0 +1,3 @@
+module example.com/fix/tests/bar
+
+go 1.25

--- a/tools/releasesmoke/doc.go
+++ b/tools/releasesmoke/doc.go
@@ -1,0 +1,55 @@
+// Package releasesmoke holds the external-consumer smoke test for the
+// synchronized multi-module release (#1843). The test body is build-tagged
+// `releasesmoke` (see external_get_smoke_test.go); this file keeps the package
+// non-empty so `go build ./...` and `go vet ./...` do not trip over a
+// constraint-only directory.
+//
+// INVARIANT: RELEASE-EXTERNAL-GET-01
+//
+// Proves an EXTERNAL consumer can `go get github.com/ghbvf/gocell/<satellite>@vX.Y.Z`
+// and `go list -m all` against the release-BUMPED library go.mods, via a hermetic
+// local file GOPROXY — no real git tag, no network. This is the machine-checked
+// successor to the "external-consumer smoke, run once by hand" deferral named in
+// ROOT-MODULE-NO-REPLACE-01's godoc (#1767).
+//
+// # How it stays hermetic, and why keeping replace is correct
+//
+// The proxy serves an INTERNAL-DEPS-ONLY PROJECTION of each module: external
+// requires are stripped and the stub package blank-imports the module's internal
+// siblings. So a consumer that imports the probe traverses the real internal
+// graph (postgres → gocell, adapterutil) under a fresh per-test GOMODCACHE — no
+// network, no warm cache, no external universe. The published go.mod still
+// carries its local `replace … => ../..` (OTel-canonical shape); Go ignores a
+// dependency module's replace, so the consumer resolves the BUMPED `require …
+// vX.Y.Z` from each sibling's proxy version (replace inert). The transitive
+// assertion (gocell AND adapterutil resolve to the synthetic version, none at
+// v0.0.0, none via `=>`) is the anti-vacuity teeth.
+//
+// # Synthetic red case (ai-robust §archtest 文件命名)
+//
+// TestExternalGet_IncompleteSet_Fails publishes every module EXCEPT one internal
+// sibling (gocell) — the real #1842/#1843 failure mode "a satellite with no
+// per-module tag" — and asserts the consumer build FAILS to resolve the missing
+// sibling. This proves the green path depends on the COMPLETE synchronized
+// published set, not a vacuous pass.
+//
+// Note on the bump vs. publishing: once every module IS published at one version,
+// Go's MVS leniently upgrades any stale `v0.0.0` lower bound to the available
+// version, so an unbumped-but-published proxy is NOT a single-version
+// discriminator — the bump's value is compatible CROSS-version pinning (the
+// published go.mod declaring the tested-compatible sibling version), which is
+// byte-locked separately by modrelease's BumpModule golden. This smoke proves the
+// publish→resolve half end-to-end; the rewrite-correctness half is the golden.
+//
+// # Grading: Medium (correct ceiling, not Soft)
+//
+// "external resolution works" is only checkable by running the real go toolchain
+// against the real bumped+projected artifacts — an execution guard, inherently
+// not Hard-expressible (a go.mod is data, not a type). It is far above Soft (no
+// comment/checklist; it executes the toolchain). No cheap Hard-upgrade exists, so
+// none is opened. Faithfulness gaps it does NOT cover (network-inherent): VCS
+// tag→version mapping, GOSUMDB interop, pseudo-versions, v2+ major suffix, and the
+// external (non-gocell) dependency closure — the tag-name shape is covered
+// separately by PUBLISHABLE-MODULE-SET-01's tag-path assertion; the rest stay the
+// "run once by hand on the real tag" residual.
+package releasesmoke

--- a/tools/releasesmoke/external_get_smoke_test.go
+++ b/tools/releasesmoke/external_get_smoke_test.go
@@ -103,6 +103,39 @@ func TestExternalGet_IncompleteSet_Fails(t *testing.T) {
 	}
 }
 
+// TestExternalGet_AllPublishable_Build extends the probe-only green path to EVERY
+// publishable module: a consumer that imports each one in turn must compile
+// against the bumped publish, deepening into that module's own internal closure.
+// This proves the synchronized release makes the WHOLE set externally consumable,
+// not just the postgres probe (the detailed go get / go list assertions stay on
+// the probe in TestExternalGet_Bumped_Resolves).
+func TestExternalGet_AllPublishable_Build(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping all-module external build smoke in -short mode")
+	}
+	goBin := mustGo(t)
+	root := repoRoot(t)
+	proxy := buildProxy(t, root, synthVersion)
+	env := offlineEnv(t, proxy)
+
+	mods, err := modrelease.PublishableModules(root)
+	if err != nil {
+		t.Fatalf("PublishableModules: %v", err)
+	}
+	if len(mods) < 10 {
+		t.Fatalf("anti-vacuity: only %d publishable modules enumerated", len(mods))
+	}
+	for _, m := range mods {
+		t.Run(m.ImportPath, func(t *testing.T) {
+			consumer := newConsumerRequiring(t, m.ImportPath, synthVersion)
+			if out, err := run(goBin, consumer, env, "build", "./..."); err != nil {
+				t.Fatalf("RELEASE-EXTERNAL-GET-01: external build against published %s@%s failed:\n%s",
+					m.ImportPath, synthVersion, out)
+			}
+		})
+	}
+}
+
 // buildProxy publishes every publishable module at version into a fresh file
 // GOPROXY directory and returns its path. When bump is true each module's go.mod
 // is release-bumped first; otherwise the as-committed go.mod (with v0.0.0) is used.

--- a/tools/releasesmoke/external_get_smoke_test.go
+++ b/tools/releasesmoke/external_get_smoke_test.go
@@ -1,0 +1,413 @@
+//go:build releasesmoke
+
+// INVARIANT: RELEASE-EXTERNAL-GET-01 (see doc.go for the full statement, grading,
+// synthetic red case, and faithfulness gaps).
+
+package releasesmoke_test
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+
+	"github.com/ghbvf/gocell/tools/gomodutil"
+	"github.com/ghbvf/gocell/tools/modrelease"
+)
+
+const (
+	// synthVersion is never produced by a real git tag, so it cannot be masked by
+	// a stale entry in the warm module cache. Major v0 keeps it valid for the
+	// suffix-less module paths (a vN>=2 would require a /vN path suffix).
+	synthVersion = "v0.99.99"
+	// probe is the satellite an external consumer fetches; its transitive internal
+	// closure (gocell, adapterutil) is the anti-vacuity surface.
+	probe       = "github.com/ghbvf/gocell/adapters/postgres"
+	probeCore   = "github.com/ghbvf/gocell"
+	probeAdpUtl = "github.com/ghbvf/gocell/adapters/adapterutil"
+)
+
+// TestExternalGet_Bumped_Resolves is the green path: publish every library module
+// at synthVersion with its release-BUMPED go.mod to a hermetic file GOPROXY, then
+// an external consumer `go get`s the probe and `go list -m all` resolves the probe
+// AND its transitive internal requires to synthVersion — proving the bumped
+// require versions are externally consumable even though the published go.mod
+// still carries its (ignored) local replace.
+func TestExternalGet_Bumped_Resolves(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping external go get smoke in -short mode (spawns go get/build, ~10-40s)")
+	}
+	goBin := mustGo(t)
+	root := repoRoot(t)
+	proxy := buildProxy(t, root, synthVersion)
+	env := offlineEnv(t, proxy)
+
+	// (1) The issue's literal command resolves against the bumped publish.
+	runOK(t, goBin, newConsumer(t), env, "get", probe+"@"+synthVersion)
+
+	// (2) A consumer that IMPORTS the probe compiles against it, deepening into
+	// the probe's internal requires (gocell, adapterutil) and resolving the whole
+	// internal graph to the published synthVersion — the real `go build` path.
+	consumer := newConsumerRequiring(t, probe, synthVersion)
+	runOK(t, goBin, consumer, env, "build", "./...")
+
+	out := runOK(t, goBin, consumer, env, "list", "-m", "all")
+	assertResolved(t, out, probe, synthVersion)
+	assertResolved(t, out, probeCore, synthVersion)
+	assertResolved(t, out, probeAdpUtl, synthVersion)
+	// No internal (github.com/ghbvf/gocell…) module sits at v0.0.0 — the bump
+	// rewrote them all (the projected proxy carries no external pseudo-versions).
+	assertNoInternalV000(t, out)
+	// The published go.mods carry replace, but Go must ignore a dependency's
+	// replace: no internal module may resolve via a replacement (=>).
+	assertNoInternalReplace(t, out)
+}
+
+// TestExternalGet_IncompleteSet_Fails is the synthetic red case (the real #1843
+// failure mode): one internal sibling of the probe — the root module gocell — is
+// left UNPUBLISHED, exactly as #1842 reported a satellite with "no per-module
+// tag". Compiling a consumer that imports the probe must then FAIL to resolve the
+// missing sibling, proving the green path's success genuinely depends on the
+// COMPLETE synchronized published set rather than passing vacuously.
+//
+// (Once every module IS published, Go's MVS leniently upgrades any stale v0.0.0
+// lower bound to the available version, so an unbumped-but-published proxy is not
+// a discriminator on a single version — the bump's value is compatible
+// cross-version pinning, byte-locked separately by modrelease's golden.)
+func TestExternalGet_IncompleteSet_Fails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping external go get smoke in -short mode")
+	}
+	goBin := mustGo(t)
+	root := repoRoot(t)
+	// Publish everything EXCEPT the probe's core sibling — an incomplete set.
+	proxy := buildProxy(t, root, synthVersion, probeCore)
+	env := offlineEnv(t, proxy)
+
+	consumer := newConsumerRequiring(t, probe, synthVersion)
+	out, err := run(goBin, consumer, env, "build", "./...")
+	if err == nil {
+		t.Fatalf("RELEASE-EXTERNAL-GET-01: consumer built against an INCOMPLETE published set "+
+			"(missing %s) — the green path is vacuous.\n%s", probeCore, out)
+	}
+	// The failure must name the missing internal sibling, not something incidental.
+	if !strings.Contains(out, probeCore) {
+		t.Fatalf("RELEASE-EXTERNAL-GET-01: build failed but not on the missing sibling %s — unexpected cause:\n%s", probeCore, out)
+	}
+}
+
+// buildProxy publishes every publishable module at version into a fresh file
+// GOPROXY directory and returns its path. When bump is true each module's go.mod
+// is release-bumped first; otherwise the as-committed go.mod (with v0.0.0) is used.
+//
+// Each published module is an INTERNAL-DEPS-ONLY PROJECTION of the real module:
+// external requires are stripped and the package is a stub that blank-imports the
+// module's internal siblings (the github.com/ghbvf/gocell… requires). This keeps
+// the smoke hermetic — building a consumer that imports the probe traverses the
+// real INTERNAL dependency graph (postgres → gocell, adapterutil), forcing
+// version resolution of exactly the modules the bump rewrites, without dragging
+// in the root module's external universe. The local replace is PRESERVED to prove
+// Go ignores a dependency's replace (the OTel-canonical shape).
+func buildProxy(t *testing.T, root, version string, omit ...string) string {
+	t.Helper()
+	prefix, err := gomodutil.ReadModulePath(root)
+	if err != nil {
+		t.Fatalf("read root module path: %v", err)
+	}
+	mods, err := modrelease.PublishableModules(root)
+	if err != nil {
+		t.Fatalf("PublishableModules: %v", err)
+	}
+	omitted := make(map[string]bool, len(omit))
+	for _, o := range omit {
+		omitted[o] = true
+	}
+	proxy := t.TempDir()
+	for _, m := range mods {
+		if omitted[m.ImportPath] {
+			continue // simulate an incomplete published set (a sibling left untagged)
+		}
+		goMod := stageGoMod(t, filepath.Join(root, m.Dir), prefix, version)
+		projected, internalImports := internalProjection(t, goMod, prefix)
+		writeProxyModule(t, proxy, m.ImportPath, version, projected, internalImports)
+	}
+	return proxy
+}
+
+// internalProjection drops every external require from goMod (keeping the module
+// line, go directive, internal github.com/ghbvf/gocell… requires, and all replace
+// directives) and returns the projected go.mod plus the internal require paths
+// (the siblings the stub package must import to force their resolution).
+func internalProjection(t *testing.T, goMod []byte, prefix string) ([]byte, []string) {
+	t.Helper()
+	mf, err := modfile.Parse("go.mod", goMod, nil)
+	if err != nil {
+		t.Fatalf("parse go.mod for projection: %v", err)
+	}
+	var internalImports []string
+	var drop []string
+	for _, r := range mf.Require {
+		if r.Mod.Path == prefix || strings.HasPrefix(r.Mod.Path, prefix+"/") {
+			internalImports = append(internalImports, r.Mod.Path)
+		} else {
+			drop = append(drop, r.Mod.Path)
+		}
+	}
+	for _, p := range drop {
+		_ = mf.DropRequire(p)
+	}
+	mf.Cleanup()
+	out, err := mf.Format()
+	if err != nil {
+		t.Fatalf("format projected go.mod: %v", err)
+	}
+	return out, internalImports
+}
+
+// stageGoMod copies modDir/go.mod into a temp dir, release-bumps it, and returns
+// the resulting bytes (the published .mod / zip go.mod).
+func stageGoMod(t *testing.T, modDir, prefix, version string) []byte {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Clean(filepath.Join(modDir, "go.mod")))
+	if err != nil {
+		t.Fatalf("read %s/go.mod: %v", modDir, err)
+	}
+	stage := t.TempDir()
+	if err := os.WriteFile(filepath.Clean(filepath.Join(stage, "go.mod")), src, 0o644); err != nil {
+		t.Fatalf("stage go.mod: %v", err)
+	}
+	if _, err := modrelease.BumpModule(stage, prefix, version); err != nil {
+		t.Fatalf("BumpModule(%s): %v", modDir, err)
+	}
+	out, err := os.ReadFile(filepath.Clean(filepath.Join(stage, "go.mod")))
+	if err != nil {
+		t.Fatalf("read staged go.mod: %v", err)
+	}
+	return out
+}
+
+// writeProxyModule writes the GOPROXY file layout (.info/.mod/.zip/list) for one
+// module at version. The .mod is the projected go.mod; the .zip carries that
+// go.mod plus a stub package that blank-imports internalImports (the module's
+// internal siblings) so building it forces their resolution.
+func writeProxyModule(t *testing.T, proxyRoot, importPath, version string, goMod []byte, internalImports []string) {
+	t.Helper()
+	esc, err := module.EscapePath(importPath)
+	if err != nil {
+		t.Fatalf("escape %s: %v", importPath, err)
+	}
+	dir := filepath.Join(proxyRoot, filepath.FromSlash(esc), "@v")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir proxy dir: %v", err)
+	}
+	write := func(name string, data []byte) {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write(version+".info", []byte(fmt.Sprintf(`{"Version":%q,"Time":"2000-01-01T00:00:00Z"}`, version)))
+	write(version+".mod", goMod)
+	write("list", []byte(version+"\n"))
+	writeModuleZip(t, filepath.Join(dir, version+".zip"), importPath, version, goMod, internalImports)
+}
+
+func writeModuleZip(t *testing.T, zipPath, importPath, version string, goMod []byte, internalImports []string) {
+	t.Helper()
+	f, err := os.Create(zipPath) //nolint:gosec // G304: zipPath is under t.TempDir()
+	if err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	prefix := importPath + "@" + version + "/"
+	add := func(name string, data []byte) {
+		w, err := zw.Create(prefix + name)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", name, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("zip write %s: %v", name, err)
+		}
+	}
+	add("go.mod", goMod)
+	add("doc.go", []byte(stubPackage(importPath, internalImports)))
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+}
+
+// stubPackage renders a minimal compilable package for importPath that
+// blank-imports its internal siblings, so building it traverses the internal
+// dependency graph (forcing version resolution) without importing anything
+// external.
+func stubPackage(importPath string, internalImports []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "package %s\n", pkgName(importPath))
+	if len(internalImports) > 0 {
+		b.WriteString("\nimport (\n")
+		for _, imp := range internalImports {
+			fmt.Fprintf(&b, "\t_ %q\n", imp)
+		}
+		b.WriteString(")\n")
+	}
+	return b.String()
+}
+
+// pkgName derives a valid package identifier from a module path's last segment.
+func pkgName(importPath string) string {
+	seg := path.Base(importPath)
+	var b strings.Builder
+	for _, r := range seg {
+		if r == '_' || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || ('0' <= r && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "lib"
+	}
+	return b.String()
+}
+
+// newConsumer creates a throwaway external module that depends on nothing yet.
+func newConsumer(t *testing.T) string {
+	t.Helper()
+	return writeConsumer(t, "module smoke.example/consumer\n\ngo 1.25\n")
+}
+
+// newConsumerRequiring creates a throwaway external module that directly requires
+// AND imports modPath@version. The blank import forces Go (under the default
+// pruned graph) to treat the probe as providing-an-imported-package and deepen
+// into ITS internal requires (gocell, adapterutil), fetching their .mod —
+// performing real build-list MVS resolution rather than `go get`'s lenient
+// upgrade. The probe's published stub imports nothing, so deepening stops there:
+// the root module's external universe is never loaded.
+func newConsumerRequiring(t *testing.T, modPath, version string) string {
+	t.Helper()
+	dir := writeConsumer(t, fmt.Sprintf(
+		"module smoke.example/consumer\n\ngo 1.25\n\nrequire %s %s\n", modPath, version))
+	use := fmt.Sprintf("package consumer\n\nimport _ %q\n", modPath)
+	if err := os.WriteFile(filepath.Join(dir, "use.go"), []byte(use), 0o644); err != nil {
+		t.Fatalf("write consumer use.go: %v", err)
+	}
+	return dir
+}
+
+func writeConsumer(t *testing.T, goMod string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write consumer go.mod: %v", err)
+	}
+	return dir
+}
+
+// offlineEnv resolves every module from the file proxy and nothing else: because
+// the proxy serves internal-deps-only projections, a consumer's build closure is
+// entirely internal modules, so a FRESH per-test GOMODCACHE keeps the test fully
+// hermetic — no warm cache, no network — and prevents one test's published
+// version from masking another's omission. GOWORK=off stops the repo's go.work
+// from absorbing the consumer and bypassing the proxy; GOTOOLCHAIN=local prevents
+// a toolchain download.
+func offlineEnv(t *testing.T, proxy string) []string {
+	t.Helper()
+	return append(os.Environ(),
+		"GOPROXY=file://"+filepath.ToSlash(proxy),
+		"GOMODCACHE="+filepath.Join(t.TempDir(), "modcache"),
+		"GOSUMDB=off",
+		// -modcacherw keeps the per-test module cache writable so t.TempDir()
+		// cleanup can remove it (Go otherwise extracts read-only files).
+		"GOFLAGS=-mod=mod -modcacherw",
+		"GOWORK=off",
+		"GOTOOLCHAIN=local",
+	)
+}
+
+func mustGo(t *testing.T) string {
+	t.Helper()
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not in PATH; external get smoke skipped")
+	}
+	return goBin
+}
+
+func run(goBin, dir string, env []string, args ...string) (string, error) {
+	cmd := exec.Command(goBin, args...) //nolint:gosec // G204: const args; cwd is t.TempDir()
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func runOK(t *testing.T, goBin, dir string, env []string, args ...string) string {
+	t.Helper()
+	out, err := run(goBin, dir, env, args...)
+	if err != nil {
+		t.Fatalf("go %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+func assertResolved(t *testing.T, listOut, modPath, version string) {
+	t.Helper()
+	want := modPath + " " + version
+	for _, line := range strings.Split(listOut, "\n") {
+		if strings.TrimSpace(line) == want {
+			return
+		}
+	}
+	t.Errorf("RELEASE-EXTERNAL-GET-01: `go list -m all` did not resolve %q to %q:\n%s", modPath, version, listOut)
+}
+
+const internalPrefix = "github.com/ghbvf/gocell"
+
+// assertNoInternalV000 fails if any internal (github.com/ghbvf/gocell…) module
+// resolves to exactly v0.0.0. It ignores external pseudo-versions of the form
+// v0.0.0-<timestamp>-<hash> by comparing the version field exactly.
+func assertNoInternalV000(t *testing.T, listOut string) {
+	t.Helper()
+	for _, line := range strings.Split(listOut, "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 && strings.HasPrefix(f[0], internalPrefix) && f[1] == "v0.0.0" {
+			t.Errorf("RELEASE-EXTERNAL-GET-01: internal module %q resolved to v0.0.0 (require not bumped):\n%s", f[0], listOut)
+			return
+		}
+	}
+}
+
+// assertNoInternalReplace fails if any internal module resolves via a replacement
+// (=>), which would mean a dependency's local replace leaked into resolution.
+func assertNoInternalReplace(t *testing.T, listOut string) {
+	t.Helper()
+	for _, line := range strings.Split(listOut, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), internalPrefix) && strings.Contains(line, "=>") {
+			t.Errorf("RELEASE-EXTERNAL-GET-01: internal module resolved via replacement (=>) — dependency replace leaked:\n%s", line)
+			return
+		}
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.work")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repoRoot: no go.work found walking up from %s", dir)
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary

发布 18 个 **库** module（root + 14 adapters + corecells + cellmodules + tools）供外部 `go get <module>@vX.Y.Z` 消费——对标 OpenTelemetry-Go / Prometheus 的同步多 module 发布。

## Why / 背景

#1558 把 `adapters/*` 拆成独立 module，内部依赖写成 `require gocell v0.0.0` + 本地 `replace`。`v0.0.0` 泄漏进可发布 module graph：外部 `go get adapters/postgres@<tag>` 失败（`unknown revision v0.0.0`，且无 per-module tag）。#1842 修了内部一致性 + 文档 caveat；本 PR 交付剩余的**外部发布能力**（issue F1/F2）。

发布时 `modrelease` 把每个 satellite 的内部 require `v0.0.0 → vX.Y.Z`（**保留 replace**——Go 忽略依赖模块的 replace，OTel 一致；filesystem replace 不进 go.sum，develop `GOWORK=off` verify 仍绿），落在 develop 一个 commit 上；`release.yml` 给 root + 每个 satellite 打 `<reldir>/vX.Y.Z` tag（同步版本）。

**cmd/gocell + cmd/corebundle 排除**：`go install pkg@version` 对含 replace 的模块直接拒绝，而 develop 又需要 replace，二者矛盾——需发布期 replace-strip + 独立 release-commit 形态，是更难的独立问题，留 **#1088**（`root_module_no_replace_test.go` godoc 已记此 deferral）。

### Implementation matrix

| 变更 | 工具/契约 | generated | tests | docs |
|------|-----------|-----------|-------|------|
| 内部 require 版本改写（保留 replace） | `tools/modrelease` (multimod `replaceModVersion` 对标) | — | `modrelease_test.go`（byte golden：幂等/伪版本/稳态/replace 保留/false-match） | — |
| 发布集派生 + 漂移守卫 | `IsPublishable` deny `examples/+tests/+cmd/`；go.work 派生 | `testdata/publishable.golden`（Hard 字节锁） | `publishable_golden_test.go` + negative-control fixture | — |
| 外部消费验证 | file-proxy 外部 smoke | — | `releasesmoke`（go get/build@tag + incomplete-set 红） | doc.go INVARIANT |
| per-module 打 tag | `release.yml` stable-only bump+commit+atomic tag | — | （workflow，手跑验证）| — |
| 外部消费文档 | — | — | — | `cell-external-repo-quickstart.md` §18/§6/§1 |

## Refs

Closes #1843 · Refs #1842 #1558 #1088

- ref: open-telemetry/opentelemetry-go-build-tools multimod/internal/shared/tools.go（`replaceModVersion`）
- ref: open-telemetry/opentelemetry-go exporters/otlp/otlptrace/go.mod@exporters/otlp/otlptrace/v1.24.0（release tag 保留 replace）
- ref: prometheus/prometheus go.work

## Risk / 兼容性

- **release.yml 不能在 PR 实跑**（仅 dispatch/schedule on develop）→ 重逻辑全在可单测的 `modrelease` + file-proxy smoke；workflow 只做薄编排，留 `--dry-run`。**首次稳定发布需 maintainer 手跑一次并核 18 个 tag**（PR 合并后）。
- **develop 直推**：稳定发布会把 pin commit push 到 develop（OTel prerelease 模型）。若 develop 有 branch protection 禁 bot 直推，需放行 github-actions bot 或改 auto-merge PR（workflow 注释已标）。
- **bootstrap 混合态**：develop 在首次发布前仍带 `v0.0.0`，之后携带真实版本号（本地 replace 仍覆盖编译）。
- **forbidden 扇出**：无 wire 契约变更；纯发布元数据。
- **smoke 忠实度缺口**（doc.go 诚实记录，非 gap）：file proxy 不覆盖 VCS tag→version 映射 / GOSUMDB / 伪版本 / v2+ major suffix / 外部依赖闭包——tag 名 shape 由 PUBLISHABLE-MODULE-SET-01 守，其余留「真 tag 手跑一次」。

## Test plan

- [x] `make check-build`（全 18+ module 编译）通过
- [x] `bash hack/verify-workspace.sh` 通过（保留 replace 后 `GOWORK=off go list -m all` 仍绿）
- [x] `go test ./tools/modrelease/...` 通过（bump golden + Hard 发布集 golden + deny 红）
- [x] `make release-smoke`（`go test -tags=releasesmoke`）通过（外部 go get/build@tag 解析；incomplete-set 红）
- [x] `golangci-lint run`（tools，`--build-tags=archtest,releasesmoke`）0 issues + `verify-gofumpt.sh` 绿
- [x] `go build -tags=integration ./...`（root / tools / tests/integration）通过
- [x] `release.yml --dry-run` 打印 18 个 tag 名核对；workflow YAML parse 通过
- [ ] 首次稳定发布手跑一次、记 evidence（PR 合并后，maintainer）
