### PR TITLE
refactor(observability): epic #1831 PR-1 — logging 小修 (grpc addr / no_tenant / event attr / ConsumerBase logger)

### DIFF
--- a/adapters/grpc/server.go
+++ b/adapters/grpc/server.go
@@ -209,6 +209,13 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 	addr := lis.Addr().String()
 	warnIfInsecureNonLoopback(s.cfg.TLS.AllowInsecure, lis.Addr())
 
+	// srvLog carries the resolved bound addr on every serve-lifecycle log line
+	// (started / serve-returned / force-stopped) so the field never drifts as new
+	// lifecycle logs are added here (#1791). gracefulStop's drain log lives in a
+	// separate method where addr is out of scope and is server-wide, not
+	// addr-specific, so it stays on the package logger.
+	srvLog := slog.Default().With(slog.String("addr", addr))
+
 	go func() {
 		err := s.grpcServer.Serve(lis)
 		s.serveErr = err
@@ -216,7 +223,7 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 	}()
 
 	s.serving.Store(true)
-	slog.Info("grpc: server started serving")
+	srvLog.Info("grpc: server started serving")
 
 	select {
 	case <-s.serveDone:
@@ -230,8 +237,7 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 			// with structured context, mirroring the net.Listen failure path, so
 			// operators see the cause even when the returned errcode is unwrapped
 			// upstream. The raw addr stays in InternalAttr (server-side only).
-			slog.Error("grpc: Serve returned unexpectedly",
-				slog.String("addr", addr),
+			srvLog.Error("grpc: Serve returned unexpectedly",
 				slog.Any("error", err))
 			return errcode.Wrap(errcode.KindInternal, ErrAdapterGRPCServe,
 				"grpc: Serve returned unexpectedly", err,
@@ -247,7 +253,7 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.cfg.ShutdownTimeout)
 		defer cancel()
 		if err := s.gracefulStop(shutdownCtx); err != nil {
-			slog.Warn("grpc: graceful stop exceeded shutdown budget; server force-stopped",
+			srvLog.Warn("grpc: graceful stop exceeded shutdown budget; server force-stopped",
 				slog.Any("error", err))
 		}
 		return ctx.Err()

--- a/cellmodules/accesscore/module.go
+++ b/cellmodules/accesscore/module.go
@@ -436,14 +436,12 @@ func newBootstrapAuthObserver(
 		// payload — no plaintext IP leaves this closure (#1488).
 		ipHash := redaction.HashIP(salt, ip)
 		logger.ErrorContext(ctx, "bootstrap_auth_failed",
-			slog.String("event", "bootstrap_auth_failed"),
 			slog.String("namespace", "bootstrap"),
 			slog.String("reason", reason),
 			slog.String("client_ip_hash", ipHash.String()))
 		c := cellPtr.Load()
 		if c == nil {
 			logger.ErrorContext(ctx, "bootstrap_audit_append_failed",
-				slog.String("event", "bootstrap_audit_append_failed"),
 				slog.String("namespace", "bootstrap"),
 				slog.String("auth_reason", reason),
 				slog.String("failure", "cell not yet initialized"),
@@ -454,7 +452,6 @@ func newBootstrapAuthObserver(
 		defer cancel()
 		if err := c.RecordBootstrapAuthFail(appendCtx, reason, ipHash); err != nil {
 			logger.ErrorContext(ctx, "bootstrap_audit_append_failed",
-				slog.String("event", "bootstrap_audit_append_failed"),
 				slog.String("namespace", "bootstrap"),
 				slog.String("auth_reason", reason),
 				slog.String("client_ip_hash", ipHash.String()),

--- a/corecells/accesscore/slices/configreceive/service_test.go
+++ b/corecells/accesscore/slices/configreceive/service_test.go
@@ -379,6 +379,72 @@ func TestHandleEntryUpserted_WithConfigGetter_ForwardsRealTenant(t *testing.T) {
 	assert.Equal(t, wantTenant, stub.calledWithTenant, "GetEntry must receive the real tenant from context")
 }
 
+// TestHandleEntryUpserted_NoTenant_FailClosed_RegressionGuard is a table-driven
+// regression guard for the fail-closed no-tenant behavior described by the
+// ConfigEventProcessReasonNoTenant const comment. It fires immediately (behavior
+// is already correct) and must stay green to prevent comment/behavior drift.
+//
+// Invariant: when tenant.FromContext fails on a context reaching HandleEntryUpserted
+// while a ConfigGetter is wired, the service MUST:
+//  1. Return DispositionReject (routes to DLQ, NOT Ack or Requeue).
+//  2. Wrap the error as PermanentError (retrying cannot supply a missing tenant).
+//  3. Record ConfigEventProcessReasonNoTenant on the collector.
+//
+// This test exercises multiple "no tenant" entry points to guard all paths through
+// the condition (bare context, principal-only context without tenant claim).
+func TestHandleEntryUpserted_NoTenant_FailClosed_RegressionGuard(t *testing.T) {
+	validPayload := []byte(`{"key":"jwt.ttl","version":1,"actorId":"adm-1"}`)
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{
+			name: "bare background context — no tenant installed",
+			ctx:  context.Background(),
+		},
+		{
+			name: "auth context without tenant claim",
+			// auth.TestContext provides a principal but no tenant ID in ctxkeys.
+			ctx: auth.TestContext("acc", []string{"user"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := &recordingConfigEventCollector{}
+			stub := &stubConfigGetter{
+				entry: ports.ConfigEntry{Key: "jwt.ttl", Value: "30m", Version: 1},
+			}
+			svc := NewService(slog.Default(),
+				WithConfigGetter(stub),
+				WithConfigEventCollector(collector),
+			)
+
+			entry := outboxtest.NewEntry(TopicConfigEntryUpserted, validPayload)
+			// Run through ConfigEventMiddleware so the metric owner context is installed,
+			// matching the real deployment path.
+			disposition, err := callWithConfigEventOwner(tt.ctx, entry, svc.HandleEntryUpserted)
+
+			// 1. Must route to DLQ, never Ack or Requeue.
+			assert.Equal(t, outbox.DispositionReject, disposition,
+				"no-tenant event must be Rejected to DLQ (fail-closed)")
+			// 2. Error must be permanent — retrying cannot supply a missing tenant.
+			require.Error(t, err)
+			var permErr *outbox.PermanentError
+			assert.True(t, errors.As(err, &permErr),
+				"no-tenant Reject must wrap PermanentError (DLQ, not retry-eligible)")
+			// 3. Metric reason must be NoTenant — keeps const comment honest.
+			require.Len(t, collector.records, 1)
+			assert.Equal(t, obmetrics.ConfigEventProcessReasonNoTenant, collector.records[0].reason,
+				"metric reason must be ConfigEventProcessReasonNoTenant, not Ack or any other reason")
+			// 4. GetEntry must NOT be called — fail-closed before reaching the getter.
+			assert.Empty(t, stub.calledWith,
+				"ConfigGetter.GetEntry must not be called when no tenant in context")
+		})
+	}
+}
+
 // TestHandleEntryUpserted_WithConfigGetter_NoTenant_RejectsToDLQ asserts that
 // when no tenant is present in the context (bare context.Background()), the
 // service fail-closes: it does NOT call the ConfigGetter and Rejects the event

--- a/docs/architecture/202605031900-adr-handler-vocabulary-collapse.md
+++ b/docs/architecture/202605031900-adr-handler-vocabulary-collapse.md
@@ -160,11 +160,16 @@ types so the business handler return surface is minimal:
   (`Ack/Requeue/Reject`) and touched neither removed field, so no cell handler
   changed.
 - **Subscriber face** — new `DeliveryOutcome{Disposition, Err, ProcessReason,
-  SettlementObservers}` carries the kernel-internal `ProcessReason` (today only
-  `"retry_exhausted"`) plus the settlement-observer channel. `ConsumerBase.Wrap`
-  is the sole `HandleResult → DeliveryOutcome` promotion point; `retryLoop` no
-  longer threads observers through its return paths (the EntryHandler return no
-  longer carries them — the propagation plumbing is deleted outright).
+  SettlementObservers, Logger}` carries the kernel-internal `ProcessReason`
+  (today only `"retry_exhausted"`) plus the settlement-observer channel.
+  `ConsumerBase.Wrap` is the sole `HandleResult → DeliveryOutcome` promotion
+  point; `retryLoop` no longer threads observers through its return paths (the
+  EntryHandler return no longer carries them — the propagation plumbing is
+  deleted outright). `Logger` (added #716) is the settle-loop sink:
+  `ConsumerBase.Wrap` stamps the consumer's configured logger onto every outcome
+  so `NotifySettlement`'s observer-panic line routes to the same sink as the rest
+  of the pipeline (nil → `slog.Default()`); read only by `NotifySettlement`, so
+  the subscriber implementations pass the outcome through unchanged.
 - **`SubscriberHandler` now returns `(DeliveryOutcome, Settlement)`** — this
   supersedes the `(HandleResult, Settlement)` wording in Decision 3, Trade-off
   Q1, and the Future-Work K#12 note above. `NotifySettlement` takes a
@@ -178,8 +183,8 @@ types so the business handler return surface is minimal:
   `eventrouter.contractTracingSubscriber` next to `wrapper.WrapSubscriber`.
 
 Enforcement: `OUTBOX-HANDLERESULT-FIELDS-FROZEN-01` now freezes the 2-field
-business set; new `OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01` freezes the 4-field
-carrier. `OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01`'s allowlist drops
+business set; new `OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01` freezes the 5-field
+carrier (`Logger` added #716, reviewed through that guard). `OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01`'s allowlist drops
 `consumer_base.go` (it now constructs `DeliveryOutcome`, not `HandleResult`). No
 `DeliveryOutcome` literal-construction archtest is added: business code has no
 use for the type (it cannot return it from `EntryHandler` nor hand it to a

--- a/docs/architecture/202605061600-adr-bootstrap-admin-boundary.md
+++ b/docs/architecture/202605061600-adr-bootstrap-admin-boundary.md
@@ -96,7 +96,7 @@ brute-force 防护：per-IP token-bucket limiter（5 req/min sustained, burst 10
 
 ## Out of Scope / backlog 登记
 
-- **BOOTSTRAP-AUDIT-CHAIN-WIRING-01**：`access_module.go` 当前注入 `bootstrapAuthFailLogger(slog.Default())`，写 `event=bootstrap_auth_failed` + `reason` + `client_ip` 到 slog；触发条件：accesscore audit chain 跨 cell 注入路径打通后将 hook 升级为 audit chain writer，扩展零成本
+- **BOOTSTRAP-AUDIT-CHAIN-WIRING-01**：`cellmodules/accesscore/module.go`（+ `examples/ssobff/app.go`）当前注入 `BootstrapAuthFailObserver`，以 slog message `bootstrap_auth_failed` + 字段 `namespace`/`reason`/`client_ip_hash` 写日志（`client_ip` 已按 #1488 经 `redaction.HashIP` 单向哈希；冗余 `event` attr 已于 #1008 删除）；触发条件：accesscore audit chain 跨 cell 注入路径打通后将 hook 升级为 audit chain writer，扩展零成本
 - **BOOTSTRAP-RATELIMIT-DISTRIBUTED-01**：per-replica in-memory bucket；multi-pod 拓扑约束已删除，分布式 rate limiter 仍是合理后续
 - K8s etcd 加密 / Secret RBAC 最小化（运维责任域，不涉及 GoCell 代码）
 

--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -348,7 +348,6 @@ func newSSOBFFAuthFailObserver(logger *slog.Logger, acPtr **accesscore.AccessCor
 		ip, _ := ctxkeys.RealIPFrom(ctx)
 		ipHash := redaction.HashIP(salt, ip)
 		logger.ErrorContext(ctx, "bootstrap_auth_failed",
-			slog.String("event", "bootstrap_auth_failed"),
 			slog.String("namespace", "bootstrap"),
 			slog.String("reason", reason),
 			slog.String("client_ip_hash", ipHash.String()))
@@ -356,7 +355,6 @@ func newSSOBFFAuthFailObserver(logger *slog.Logger, acPtr **accesscore.AccessCor
 			// Symmetric with cellmodules/accesscore: surface the cell-not-ready
 			// path so it is not a silent observability hole during debugging.
 			logger.ErrorContext(ctx, "bootstrap_audit_append_failed",
-				slog.String("event", "bootstrap_audit_append_failed"),
 				slog.String("namespace", "bootstrap"),
 				slog.String("auth_reason", reason),
 				slog.String("failure", "cell not yet initialized"),
@@ -367,7 +365,6 @@ func newSSOBFFAuthFailObserver(logger *slog.Logger, acPtr **accesscore.AccessCor
 		defer cancel()
 		if err := (*acPtr).RecordBootstrapAuthFail(appendCtx, reason, ipHash); err != nil {
 			logger.ErrorContext(ctx, "bootstrap_audit_append_failed",
-				slog.String("event", "bootstrap_audit_append_failed"),
 				slog.String("namespace", "bootstrap"),
 				slog.String("auth_reason", reason),
 				slog.String("client_ip_hash", ipHash.String()),

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -133,6 +133,13 @@ type ConsumerBaseConfig struct {
 	// LeaseTTL/3 so the lease is renewed well before it expires.
 	// Set to a negative value to disable lease renewal entirely.
 	LeaseRenewalInterval time.Duration
+
+	// Logger is the structured logger for all ConsumerBase log output (claim,
+	// retry, DLX-reject and observer-panic lines). Nil defaults to slog.Default()
+	// in SetDefaults, so production callers need not set it. Tests inject a
+	// buffer-backed logger here to capture output without mutating the global
+	// slog default (slog.SetDefault races with t.Parallel() siblings).
+	Logger *slog.Logger
 }
 
 // SetDefaults populates zero-valued fields with safe defaults. Called
@@ -163,6 +170,9 @@ func (c *ConsumerBaseConfig) SetDefaults() {
 	}
 	if c.LeaseRenewalInterval == 0 {
 		c.LeaseRenewalInterval = c.LeaseTTL / leaseRenewalDivisor
+	}
+	if c.Logger == nil {
+		c.Logger = slog.Default()
 	}
 }
 
@@ -234,6 +244,11 @@ type ConsumerBase struct {
 	config  ConsumerBaseConfig
 	clk     clock.Clock
 
+	// logger is the resolved structured logger (config.Logger after SetDefaults,
+	// never nil). Every ConsumerBase log line and the observer-panic SafeObserve
+	// logger derive from it, so a test-injected logger captures all output.
+	logger *slog.Logger
+
 	// observer receives notifications on terminal Reject paths. Initialized to
 	// NopConsumerObserver{} by NewConsumerBase so it is never nil. Replaced at
 	// most once via AttachObserver; observerAttached tracks whether a non-Nop
@@ -259,12 +274,13 @@ func (cb *ConsumerBase) IsConstructed() bool {
 	return cb != nil && cb.built
 }
 
-// logWithContext delegates to slog.LogAttrs with the given context, ensuring
-// any ContextHandler extracts observability fields (request_id, correlation_id,
-// trace_id) restored by SubscriberWithMiddleware.SubscribeEntry on the consumer
-// path (built-in outermost wrapper, no separate middleware to install).
-func logWithContext(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
-	slog.LogAttrs(ctx, level, msg, attrs...)
+// logWithContext delegates to the injected logger's LogAttrs with the given
+// context, ensuring any ContextHandler extracts observability fields
+// (request_id, correlation_id, trace_id) restored by
+// SubscriberWithMiddleware.SubscribeEntry on the consumer path (built-in
+// outermost wrapper, no separate middleware to install).
+func (cb *ConsumerBase) logWithContext(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
+	cb.logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
 // NewConsumerBase creates a ConsumerBase using the two-phase Claimer interface.
@@ -288,6 +304,7 @@ func NewConsumerBase(claimer idempotency.Claimer, config ConsumerBaseConfig, clk
 		claimer:  claimer,
 		config:   config,
 		clk:      clk,
+		logger:   config.Logger, // non-nil: SetDefaults fell back to slog.Default()
 		observer: NopConsumerObserver{},
 		built:    true,
 	}, nil
@@ -380,7 +397,7 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 		if cb.config.ClaimPolicy == ClaimPolicyFailOpen {
 			state, receipt, err := cb.claimer.Claim(ctx, idempotencyKey, cb.config.LeaseTTL, cb.config.IdempotencyTTL)
 			if err != nil {
-				logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, proceeding without receipt (fail-open)",
+				cb.logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, proceeding without receipt (fail-open)",
 					slog.String(logKeyEventID, entry.id),
 					slog.String(logKeyTopic, topic),
 					slog.String(logKeyConsumerGroup, consumerGroup),
@@ -393,7 +410,7 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 		// Fail-closed: claimWithRetry handles all attempts with backoff + jitter.
 		state, receipt, err := cb.claimWithRetry(ctx, topic, entry, idempotencyKey, consumerGroup)
 		if err != nil {
-			logWithContext(ctx, slog.LevelError, "outbox: idempotency claim exhausted, requeuing (fail-closed)",
+			cb.logWithContext(ctx, slog.LevelError, "outbox: idempotency claim exhausted, requeuing (fail-closed)",
 				slog.String(logKeyEventID, entry.id),
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyConsumerGroup, consumerGroup),
@@ -460,7 +477,7 @@ func (cb *ConsumerBase) claimWithRetry(
 				jitter = time.Duration(cryptoRandInt64N(int64(base/backoffJitterDivisor) + 1))
 			}
 			delay := min(base+jitter, cb.config.MaxRetryDelay)
-			logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, retrying locally",
+			cb.logWithContext(ctx, slog.LevelWarn, "outbox: idempotency claim failed, retrying locally",
 				slog.String(logKeyEventID, entry.id),
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyConsumerGroup, consumerGroup),
@@ -509,13 +526,13 @@ func (cb *ConsumerBase) handleClaimState(
 	topic := dims.topic
 	switch state {
 	case idempotency.ClaimDone:
-		logWithContext(ctx, slog.LevelDebug, "outbox: event already processed, skipping",
+		cb.logWithContext(ctx, slog.LevelDebug, "outbox: event already processed, skipping",
 			slog.String(logKeyEventID, entry.id),
 			slog.String(logKeyTopic, topic))
 		return deliveryFrom(Ack()), nil
 	case idempotency.ClaimBusy:
 		delay := cb.config.RetryBaseDelay
-		logWithContext(ctx, slog.LevelDebug, "outbox: event being processed by another consumer, requeuing after backoff",
+		cb.logWithContext(ctx, slog.LevelDebug, "outbox: event being processed by another consumer, requeuing after backoff",
 			slog.String(logKeyEventID, entry.id),
 			slog.String(logKeyTopic, topic),
 			slog.Duration("backoff", delay))
@@ -560,7 +577,7 @@ func (cb *ConsumerBase) waitBackoff(ctx context.Context, topic string, entry Ent
 		return true
 	}
 	delay := ExponentialDelay(cb.config.RetryBaseDelay, cb.config.MaxRetryDelay, attempt)
-	logWithContext(ctx, slog.LevelWarn, "outbox: transient error, retrying",
+	cb.logWithContext(ctx, slog.LevelWarn, "outbox: transient error, retrying",
 		slog.String(logKeyEventID, entry.id),
 		slog.String(logKeyTopic, topic),
 		slog.Int("attempt", attempt+1),
@@ -611,12 +628,12 @@ func (cb *ConsumerBase) retryLoop(
 		}
 
 		if isPermanentRejection(lastResult) {
-			logWithContext(ctx, slog.LevelError, "outbox: handler rejected entry, routing to DLX",
+			cb.logWithContext(ctx, slog.LevelError, "outbox: handler rejected entry, routing to DLX",
 				slog.String(logKeyEventID, entry.id),
 				slog.String(logKeyTopic, topic),
 				slog.String(logKeyConsumerGroup, consumerGroup),
 				slog.Any("error", lastResult.Err))
-			observability.SafeObserve(slog.Default().With(
+			observability.SafeObserve(cb.logger.With(
 				slog.String("cell", cellID),
 				slog.String("topic", topic),
 				slog.String("consumer_group", consumerGroup),
@@ -645,7 +662,7 @@ func (cb *ConsumerBase) retryLoop(
 	// Exhausted all retries -- reject so broker routes to DLX.
 	// Upgraded from LevelWarn to LevelError: retry-exhausted routes to DLX
 	// (correctness-affecting) per observability.md §slog 日志级别.
-	logWithContext(ctx, slog.LevelError, "outbox: retry budget exhausted, rejecting to DLX",
+	cb.logWithContext(ctx, slog.LevelError, "outbox: retry budget exhausted, rejecting to DLX",
 		slog.String(logKeyEventID, entry.id),
 		slog.String(logKeyTopic, topic),
 		slog.String(logKeyConsumerGroup, consumerGroup),
@@ -721,7 +738,7 @@ func (cb *ConsumerBase) runWithRenewal(
 	// Settlement (receipt) is returned by handleClaimState alongside this result;
 	// Subscriber will call Settlement.Release on Requeue disposition.
 	if leaseLost.Load() && result.Disposition == DispositionAck {
-		logWithContext(ctx, slog.LevelWarn, "outbox: lease lost during processing, downgrading Ack to Requeue (hard fence)",
+		cb.logWithContext(ctx, slog.LevelWarn, "outbox: lease lost during processing, downgrading Ack to Requeue (hard fence)",
 			slog.String(logKeyEventID, entry.id),
 			slog.String(logKeyTopic, dims.topic))
 		return DeliveryOutcome{
@@ -757,13 +774,13 @@ func (cb *ConsumerBase) leaseRenewalLoop(
 			extendCtx := context.WithoutCancel(ctx)
 			if err := receipt.Extend(extendCtx, cb.config.LeaseTTL); err != nil {
 				if errors.Is(err, idempotency.ErrLeaseExpired) {
-					logWithContext(ctx, slog.LevelError, "outbox: lease lost during processing, canceling handler",
+					cb.logWithContext(ctx, slog.LevelError, "outbox: lease lost during processing, canceling handler",
 						slog.String(logKeyEventID, entry.id),
 						slog.String(logKeyTopic, topic))
 					onLeaseLost()
 					return
 				}
-				logWithContext(ctx, slog.LevelWarn, "outbox: lease extend failed (transient), will retry",
+				cb.logWithContext(ctx, slog.LevelWarn, "outbox: lease extend failed (transient), will retry",
 					slog.String(logKeyEventID, entry.id),
 					slog.String(logKeyTopic, topic),
 					slog.Any("error", err))

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -394,7 +394,13 @@ func (cb *ConsumerBase) Wrap(sub Subscription, handler EntryHandler) SubscriberH
 	cellID := sub.CellID
 	passthrough := cb.brokerDelayPassthrough(sub)
 	dims := deliveryDims{cellID: cellID, consumerGroup: consumerGroup, topic: topic}
-	return func(ctx context.Context, entry Entry) (DeliveryOutcome, Settlement) {
+	return func(ctx context.Context, entry Entry) (out DeliveryOutcome, _ Settlement) {
+		// Single funnel: stamp the consumer's configured logger onto whatever
+		// outcome the dispatch below produces, so the subscriber settle loop's
+		// NotifySettlement routes its observer-panic line to the same sink as the
+		// rest of this consumer's pipeline. cb.logger is always non-nil
+		// (SetDefaults pins slog.Default()); see DeliveryOutcome.Logger (#716/#1871 F2).
+		defer func() { out.Logger = cb.logger }()
 		idempotencyKey := fmt.Sprintf("%s:%s", consumerGroup, entry.id)
 
 		// Fail-open: single Claim attempt, proceed without idempotency on error.

--- a/kernel/outbox/consumer_base.go
+++ b/kernel/outbox/consumer_base.go
@@ -139,6 +139,10 @@ type ConsumerBaseConfig struct {
 	// in SetDefaults, so production callers need not set it. Tests inject a
 	// buffer-backed logger here to capture output without mutating the global
 	// slog default (slog.SetDefault races with t.Parallel() siblings).
+	//
+	// ConsumerBase takes the logger as a config field (not a WithLogger option
+	// like DirectEmitter) because SetDefaults resolves the nil fallback once at
+	// construction.
 	Logger *slog.Logger
 }
 
@@ -669,7 +673,7 @@ func (cb *ConsumerBase) retryLoop(
 		slog.Int("retry_count", cb.config.RetryCount),
 		slog.String("process_reason", ProcessReasonRetryExhausted),
 		slog.Any("error", lastResult.Err))
-	observability.SafeObserve(slog.Default().With(
+	observability.SafeObserve(cb.logger.With(
 		slog.String("cell", cellID),
 		slog.String("topic", topic),
 		slog.String("consumer_group", consumerGroup),

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -1614,6 +1614,46 @@ func TestConsumerBase_ObserveReject_PanicingObserver_DoesNotEscape(t *testing.T)
 		"expected a log line mentioning observer panic, but found none in captured slog output")
 }
 
+// TestConsumerBase_RetryExhausted_PanicingObserver_LogsViaInjectedLogger guards
+// the SECOND SafeObserve site — the retry-exhausted reject path. The
+// handler-reject panic test above only exercises the first site; this one pins
+// that the retry-exhausted SafeObserve logger also derives from the injected
+// cb.logger (it previously used slog.Default(), so its recovered-panic log
+// escaped buffer capture under injection). Fails RED if that site regresses
+// back to slog.Default().
+func TestConsumerBase_RetryExhausted_PanicingObserver_LogsViaInjectedLogger(t *testing.T) {
+	t.Parallel()
+	logger, buf := newCapturingLogger()
+
+	receipt := &fakeReceipt{}
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
+
+	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
+		RetryCount:           1,
+		RetryBaseDelay:       time.Millisecond,
+		LeaseRenewalInterval: disableLeaseRenewal,
+		Logger:               logger,
+	}, clock.Real())
+	require.NoError(t, err)
+	require.NoError(t, cb.AttachObserver(&panicingObserver{}))
+
+	sub := Subscription{Topic: "event.test.v1", ConsumerGroup: "cg-test", CellID: "testcell"}
+	handler := cb.Wrap(sub, func(_ context.Context, _ Entry) HandleResult {
+		return Requeue(errors.New("always fail")) // exhausts RetryCount → retry-exhausted reject
+	})
+
+	require.NotPanics(t, func() {
+		_, _ = handler(context.Background(), Entry{id: "evt-retry-exhausted-panic"})
+	}, "panic from ObserveReject on the retry-exhausted path must NOT escape the Wrap handler")
+
+	// SafeObserve logs the recovered panic via the logger it is given. Asserting
+	// the exact "observability hook panic" message proves it reached the INJECTED
+	// buffer (cb.logger), not slog.Default(); a loose substring match would not
+	// discriminate the two SafeObserve loggers.
+	assert.Contains(t, buf.String(), "observability hook panic",
+		"retry-exhausted observer-panic log must be captured via the injected logger (cb.logger), not slog.Default()")
+}
+
 // panicingObserver is a ConsumerObserver that always panics in ObserveReject,
 // used to verify panic isolation in ConsumerBase.Wrap.
 type panicingObserver struct{}

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -370,6 +370,46 @@ func TestNilConsumerBase_IsConstructed_False(t *testing.T) {
 
 // --- Wrap: happy paths -----------------------------------------------------
 
+// TestConsumerBase_Wrap_ThreadsInjectedLoggerOntoOutcome pins #1871 F2: every
+// outcome ConsumerBase.Wrap produces must carry the consumer's configured
+// logger (ConsumerBaseConfig.Logger) so the subscriber settle loop's
+// NotifySettlement routes its observer-panic line to the SAME sink as the rest
+// of the consumer pipeline — not the global slog.Default(). Before the Wrap
+// funnel set out.Logger, deliveryFrom returned a nil-Logger outcome and the
+// settle-panic line escaped to slog.Default(), defeating the injection.
+func TestConsumerBase_Wrap_ThreadsInjectedLoggerOntoOutcome(t *testing.T) {
+	t.Parallel()
+
+	logger, logBuf := newCapturingLogger()
+	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: &fakeReceipt{}}
+	cb, err := NewConsumerBase(
+		claimer,
+		ConsumerBaseConfig{Logger: logger, LeaseRenewalInterval: disableLeaseRenewal},
+		clock.Real(),
+	)
+	require.NoError(t, err)
+
+	handler := cb.Wrap(Subscription{Topic: "topic", ConsumerGroup: "cg"},
+		func(_ context.Context, _ Entry) HandleResult { return Ack() })
+	out, _ := handler(context.Background(), Entry{id: "evt-logger"})
+
+	// Root cause: the produced outcome must carry the injected logger.
+	require.Same(t, logger, out.Logger,
+		"Wrap must thread cb.logger onto every produced DeliveryOutcome (#1871 F2)")
+
+	// End-to-end: a panicking SettlementObserver (appended by subscriber-layer
+	// middleware) must log to the injected buffer, not slog.Default().
+	out.SettlementObservers = []SettlementObserver{
+		SettlementObserverFunc(func(_ context.Context, _ SettlementObservation) {
+			panic("settlement observer panicked intentionally")
+		}),
+	}
+	NotifySettlement(context.Background(), out, Entry{id: "evt-logger", topic: "topic"},
+		DispositionAck, SettlementResultSuccess, nil)
+	assert.Contains(t, logBuf.String(), "settlement observer panicked",
+		"injected logger must capture the settlement observer-panic line")
+}
+
 func TestConsumerBase_Wrap_ClaimAcquired_Ack_ThreadsReceipt(t *testing.T) {
 	receipt := &fakeReceipt{}
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}

--- a/kernel/outbox/consumer_base_test.go
+++ b/kernel/outbox/consumer_base_test.go
@@ -1293,16 +1293,15 @@ func TestConsumerBase_CtxCancelDuringBackoff_ReturnsRequeueWithCtxErr(t *testing
 // ConsumerObserver wiring tests (W2: wire ConsumerObserver into ConsumerBase)
 // =============================================================================
 
-// captureDefaultSlogForConsumerBase replaces the global slog default with a
-// JSON handler writing to a buffer; the original logger is restored via
-// t.Cleanup. Callers must NOT call t.Parallel() when using this helper.
-func captureDefaultSlogForConsumerBase(t *testing.T) *bytes.Buffer {
-	t.Helper()
+// newCapturingLogger returns a slog.Logger writing JSON to the returned buffer
+// for per-test log capture. Injected via ConsumerBaseConfig.Logger (and
+// DeliveryOutcome.Logger for settlement) so tests never mutate the global slog
+// default — that mutation races with t.Parallel() siblings in this package.
+// Tests using it ARE parallel-safe.
+func newCapturingLogger() (*slog.Logger, *bytes.Buffer) {
 	var buf bytes.Buffer
-	orig := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(orig) })
-	return &buf
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return logger, &buf
 }
 
 // logLevelFromBuf scans JSON log lines in buf for the first entry whose "msg"
@@ -1476,8 +1475,8 @@ func TestConsumerBase_AttachObserver_NilObserver_ReturnsError(t *testing.T) {
 // retry-budget-exhausted log entry is emitted at ERROR level (upgraded from
 // WARN per observability.md: DLX-routed reject is correctness-affecting).
 func TestConsumerBase_RetryExhausted_LogLevelError(t *testing.T) {
-	// Do NOT call t.Parallel(): this test mutates the global slog default logger.
-	buf := captureDefaultSlogForConsumerBase(t)
+	t.Parallel()
+	logger, buf := newCapturingLogger()
 
 	receipt := &fakeReceipt{}
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
@@ -1486,6 +1485,7 @@ func TestConsumerBase_RetryExhausted_LogLevelError(t *testing.T) {
 		RetryCount:           1,
 		RetryBaseDelay:       time.Millisecond,
 		LeaseRenewalInterval: disableLeaseRenewal,
+		Logger:               logger,
 	}, clock.Real())
 	require.NoError(t, err)
 
@@ -1579,13 +1579,15 @@ func TestConsumerBase_RetryExhausted_NoObserveReject_OnCtxCancel(t *testing.T) {
 // RED: consumer_base.go calls cb.observer.ObserveReject(...) without a
 // panic-recovery wrapper, so the panic currently escapes.
 func TestConsumerBase_ObserveReject_PanicingObserver_DoesNotEscape(t *testing.T) {
-	buf := captureDefaultSlogForConsumerBase(t)
+	t.Parallel()
+	logger, buf := newCapturingLogger()
 
 	receipt := &fakeReceipt{}
 	claimer := &fakeClaimer{state: idempotency.ClaimAcquired, receipt: receipt}
 
 	cb, err := NewConsumerBase(claimer, ConsumerBaseConfig{
 		LeaseRenewalInterval: disableLeaseRenewal,
+		Logger:               logger,
 	}, clock.Real())
 	require.NoError(t, err)
 	require.NoError(t, cb.AttachObserver(&panicingObserver{}))
@@ -1601,7 +1603,6 @@ func TestConsumerBase_ObserveReject_PanicingObserver_DoesNotEscape(t *testing.T)
 	}, "panic from ConsumerObserver.ObserveReject must NOT escape the Wrap handler")
 
 	// A WARN or ERROR log line must be emitted to record the recovered panic.
-	_ = buf // accessed by logLevelFromBuf when the log sentinel is checked
 	found := false
 	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
 		if bytes.Contains(line, []byte("observer")) || bytes.Contains(line, []byte("panic")) {

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -800,9 +800,10 @@ type DeliveryOutcome struct {
 
 	// Logger is the structured logger NotifySettlement uses for the
 	// observer-panic line. Optional: nil falls back to slog.Default() (current
-	// production behavior). Tests set it to capture the settlement-panic log
-	// without mutating the global slog default (slog.SetDefault races with
-	// t.Parallel() siblings).
+	// production behavior). Outcomes produced by ConsumerBase.Wrap leave this nil
+	// — production routes settlement-panic logs to slog.Default(); tests that
+	// capture those logs set it directly on the outcome, avoiding the global
+	// slog.SetDefault mutation (which races with t.Parallel() siblings).
 	Logger *slog.Logger
 }
 

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -799,11 +799,14 @@ type DeliveryOutcome struct {
 	SettlementObservers []SettlementObserver
 
 	// Logger is the structured logger NotifySettlement uses for the
-	// observer-panic line. Optional: nil falls back to slog.Default() (current
-	// production behavior). Outcomes produced by ConsumerBase.Wrap leave this nil
-	// — production routes settlement-panic logs to slog.Default(); tests that
-	// capture those logs set it directly on the outcome, avoiding the global
-	// slog.SetDefault mutation (which races with t.Parallel() siblings).
+	// observer-panic line. ConsumerBase.Wrap threads the consumer's configured
+	// logger (ConsumerBaseConfig.Logger, itself defaulting to slog.Default())
+	// onto every outcome it produces, so the whole delivery pipeline — internal
+	// logs, ConsumerObserver panics, and settlement observer panics — routes to
+	// one sink. nil falls back to slog.Default(): the no-observer hot path and
+	// directly-constructed literals (tests) may leave it unset; a test capturing
+	// settle logs sets it on the literal to avoid the global slog.SetDefault
+	// mutation (which races with t.Parallel() siblings).
 	Logger *slog.Logger
 }
 

--- a/kernel/outbox/outbox.go
+++ b/kernel/outbox/outbox.go
@@ -797,6 +797,13 @@ type DeliveryOutcome struct {
 	// WrapConfigEventSubscriber) after ConsumerBase has resolved
 	// retry/lease decisions.
 	SettlementObservers []SettlementObserver
+
+	// Logger is the structured logger NotifySettlement uses for the
+	// observer-panic line. Optional: nil falls back to slog.Default() (current
+	// production behavior). Tests set it to capture the settlement-panic log
+	// without mutating the global slog default (slog.SetDefault races with
+	// t.Parallel() siblings).
+	Logger *slog.Logger
 }
 
 // NotifySettlement emits a settlement observation to every observer attached
@@ -807,6 +814,10 @@ func NotifySettlement(
 ) {
 	if len(outcome.SettlementObservers) == 0 {
 		return
+	}
+	logger := outcome.Logger
+	if logger == nil {
+		logger = slog.Default()
 	}
 	obs := SettlementObservation{
 		Entry:         entry,
@@ -822,7 +833,7 @@ func NotifySettlement(
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.LogAttrs(ctx, slog.LevelError, "outbox: settlement observer panicked",
+					logger.LogAttrs(ctx, slog.LevelError, "outbox: settlement observer panicked",
 						slog.String("topic", entry.topic),
 						slog.String("entry_id", entry.id),
 						slog.Any("panic", redaction.RedactAny(r)))

--- a/kernel/outbox/outbox_test.go
+++ b/kernel/outbox/outbox_test.go
@@ -1240,18 +1240,12 @@ func TestSubscriberWithMiddleware_StopIntake_InnerNotStopper(t *testing.T) {
 //
 // ref: Finding 3 — observer panic isolation (PR #334 L4 review)
 func TestNotifySettlement_ObserverPanic_DoesNotKillCaller(t *testing.T) {
-	// Do NOT call t.Parallel(): this test mutates the global slog default logger
-	// and must not race with other tests that also call slog.SetDefault.
+	t.Parallel()
 
-	// Save the original default logger and restore it after the test so that
-	// parallel or sequential sibling tests see the expected global state.
-	originalLogger := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(originalLogger) })
-
-	// Capture slog output to verify the panic is logged.
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	slog.SetDefault(logger)
+	// Capture slog output via per-call injection (DeliveryOutcome.Logger) so the
+	// test never mutates the global slog default — that mutation races with
+	// t.Parallel() siblings in this package.
+	logger, logBuf := newCapturingLogger()
 
 	var spy1Called, spy3Called bool
 
@@ -1267,6 +1261,7 @@ func TestNotifySettlement_ObserverPanic_DoesNotKillCaller(t *testing.T) {
 
 	result := DeliveryOutcome{
 		Disposition:         DispositionAck,
+		Logger:              logger,
 		SettlementObservers: []SettlementObserver{spy1, panicObserver, spy3},
 	}
 	entry := Entry{id: "test-panic-entry", topic: "event.test.v1"}

--- a/runtime/observability/metrics/config_event_collector.go
+++ b/runtime/observability/metrics/config_event_collector.go
@@ -19,8 +19,10 @@ const (
 	ConfigEventProcessReasonStale          ConfigEventProcessReason = "stale"
 	ConfigEventProcessReasonPermanentError ConfigEventProcessReason = "permanent_error"
 	// ConfigEventProcessReasonNoTenant is recorded when tenant.FromContext returns
-	// an error (no tenant in consumer context). The event is Ack-ed as
-	// retrying cannot supply a tenant that was absent at delivery time.
+	// an error (no tenant in consumer context). The event is Rejected to the DLQ
+	// (fail-closed): an event reaching the consumer without a tenant envelope is a
+	// pipeline-integrity violation, not a retriable condition — retrying cannot
+	// supply a tenant that was absent at delivery time.
 	ConfigEventProcessReasonNoTenant ConfigEventProcessReason = "no_tenant"
 	// ConfigEventProcessReasonTransient is recorded when the config getter
 	// returns a transient (non-permanent, non-404) error so the entry is

--- a/tools/archtest/outbox_invariants_test.go
+++ b/tools/archtest/outbox_invariants_test.go
@@ -1337,6 +1337,12 @@ func TestOutboxHandleResultFieldsFrozen(t *testing.T) {
 //   - SettlementObservers    — subscriber-layer observer chain appended by
 //     WrapConfigEventSubscriber (and similar future wrappers) at the
 //     SubscriberHandler layer; NotifySettlement fans out to all observers.
+//   - Logger                 — the settle-loop logger NotifySettlement uses for
+//     the observer-panic line; ConsumerBase.Wrap threads the consumer's
+//     configured logger onto every outcome so the whole delivery pipeline logs
+//     to one sink. Read only by NotifySettlement (nil → slog.Default()), so the
+//     subscriber implementations (rabbitmq/mqtt/eventbus) need no change — they
+//     pass the outcome through unmodified (#716/#1871).
 //
 // Adding or removing a field silently changes the subscriber-layer protocol.
 var deliveryOutcomeAllowedFields = map[string]struct{}{
@@ -1344,13 +1350,14 @@ var deliveryOutcomeAllowedFields = map[string]struct{}{
 	"Err":                 {},
 	"ProcessReason":       {},
 	"SettlementObservers": {},
+	"Logger":              {},
 }
 
 // INVARIANT: OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01
 //
 // TestOutboxDeliveryOutcomeFieldsFrozen enforces OUTBOX-DELIVERYOUTCOME-FIELDS-FROZEN-01:
-// kernel/outbox.DeliveryOutcome must declare exactly the four fields listed in
-// deliveryOutcomeAllowedFields (#663 type-split from HandleResult).
+// kernel/outbox.DeliveryOutcome must declare exactly the fields listed in
+// deliveryOutcomeAllowedFields (#663 type-split from HandleResult; Logger added #716).
 //
 // DeliveryOutcome is the subscriber-layer carrier: ConsumerBase.Wrap lifts a
 // slim HandleResult into a DeliveryOutcome, SubscriberHandler returns it, and


### PR DESCRIPTION
## Summary

Epic #1831 **PR-1 = observability / logging 小修**：清理 4 个 Cx1 尾项 —— grpc 启动日志补 addr、no_tenant metric 注释纠偏、bootstrap 重复 `event` attr 去重、ConsumerBase 注入 logger 摆脱测试 `slog.SetDefault`。

## Why / 背景

Epic #1831 把 OPEN 的 `cx-1` backlog 聚合成低冲突 PR 批次清理。本 PR 落地其中 observability/logging 组。各项均为既有 PR review 的 follow-up / 技术债尾项，互不重叠、文件互斥。

实施期复核发现 issue 文字与 develop 现状偏离，逐条按真值落地（非照搬 issue）：
- **#1791**：否决「只加一行 addr」（Soft 点修），改在 `serve()` 预绑 `srvLog := slog.Default().With("addr", addr)`，started/serve-error/force-stop 三条 lifecycle 日志统一走它，结构性防字段漂移。
- **#1719**：注释纠偏（Ack→fail-closed Reject/DLQ；真值在 `corecells/.../configreceive`，非 issue 写的 `cells/`），并加表驱动回归守护把注释 Hard 化为 CI 守护。
- **#1008**：原文件 `runtime/audit/bootstrap_observer.go` 在 develop 已不存在（cellmodules rename 后内联）；重复 `event` attr 现落 `cellmodules/accesscore/module.go` + `examples/ssobff/app.go` 两处，均删（确认无告警/测试 key 在该 attr）。
- **#716**：`ConsumerBase` 无 logger 字段、全走 `slog.Default()`；测试用全局 `slog.SetDefault` 捕获日志，与同包 `t.Parallel()` 兄弟有 stomp 风险。注入 `ConsumerBaseConfig.Logger` + `DeliveryOutcome.Logger`（均可选，nil→`slog.Default()`），3 个测试改注入式并恢复 `t.Parallel()`。settlement 路径复用既有 `outcome` thread，避开 `NotifySettlement` ~45 callsite 签名改。

## Refs

Closes #1791, Closes #1719, Closes #1008, Closes #716

ref: grpc-go server.go — Serve lifecycle logging

实施期拆出（已更新各自 issue body 重判，**不在本 PR**）：
- **#880**：issue「仅 test fixture 用」前提证伪 —— `Provider.Unregister` 有 ~13 处生产调用，OTel 下全 silent no-op（latent bug）；重判 Cx2~Cx3，需先定 OTel deregistration 策略。
- **#1101**：范围比「A2 措辞」大 —— 同一 #1034 事件还 retire 了 `HEALTHZ-TYPED-REGISTER-01`/`reg.Healthz()`，需重写两个 load-bearing 治理 ADR 的 ~12-15 处 funnel 叙述 + 威胁矩阵重评；重判 Cx3，独立 doc PR 处理。

## Risk / 兼容性

无 contract / wire / event 契约变更 —— 契约扇出矩阵 **N/A**。

- #716：`ConsumerBaseConfig` 与 `DeliveryOutcome` 新增**可选** `Logger *slog.Logger` 字段（nil → `slog.Default()` via SetDefaults / NotifySettlement fallback）。所有现有 caller（6 个 ConsumerBase 构造点 + 全部 NotifySettlement callsite，含 mqtt/rabbitmq/eventbus）均为 keyed literal 或传 `res` 变量，编译与行为不变；已实测 root + adapters/mqtt + adapters/rabbitmq + cellmodules + corecells + examples/ssobff 全绿。
- #1008：删除冗余 `event` slog attr 属可观测 wire 形态收窄，但已确认无 `docs/ops/alerting-rules.md` 告警或测试 key 在该 attr（msg 仍携带 event 名）。
- 其余为注释 / 日志字段 / 测试，无行为变更。

## Test plan

- [x] `go build ./...` 本地通过（root + 全部受影响子模块）
- [x] `go test ./修改的包/...` 本地通过（kernel/outbox `-race`、runtime/eventbus、kernel/wrapper、adapters/grpc、cellmodules/accesscore、corecells/.../configreceive、examples/ssobff）
- [x] `golangci-lint run`（受影响包）0 issues
