### PR TITLE
refactor(mqtt): seal routeDeadLetter drop in dlxoutcome.Outcome — MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 封闭 sealed-construction funnel (Medium) [#1440]

### DIFF
--- a/adapters/mqtt/deadletter.go
+++ b/adapters/mqtt/deadletter.go
@@ -3,13 +3,14 @@ package mqtt
 import (
 	"context"
 	"log/slog"
+
+	"github.com/ghbvf/gocell/adapters/mqtt/internal/dlxoutcome"
 )
 
 // routeDeadLetter publishes a permanently-rejected or undecodable (poison)
 // message to the app-level dead-letter sink "$dead/<originalTopic>" for ops
-// audit, then records the dead-letter metric. MQTT has no broker-native
-// dead-letter exchange (unlike AMQP's DLX), so this is the adapter's equivalent
-// of rabbitmq's Nack(requeue=false) → DLX.
+// audit. MQTT has no broker-native dead-letter exchange (unlike AMQP's DLX), so
+// this is the adapter's equivalent of rabbitmq's Nack(requeue=false) → DLX.
 //
 // originalTopic is the topic the message was delivered on:
 //   - Reject path: entry.Topic() (the decoded envelope topic);
@@ -19,17 +20,27 @@ import (
 // It is called BEFORE the poison ack (ackPoison), so the $dead capture happens
 // before redelivery is stopped.
 //
+// Every exit returns a [dlxoutcome.Outcome]: the metric is recorded by the
+// returning constructor, never inline. [dlxoutcome.Dropped] records the alertable
+// mqtt_dlx_failed_total; [dlxoutcome.Captured] records mqtt_dlx_total. Because the
+// function is typed to return an Outcome and only those two constructors produce
+// one, a drop path that forgets the metric cannot compile (gh #1440 / archtest
+// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01). The caller discards the Outcome — its job is
+// to force every exit through a recording constructor, not to carry state.
+//
 // Fail-closed on every error: if the topic cannot be minted (out-of-namespace /
-// wildcard poison topic) or the $dead publish fails, routeDeadLetter logs at
-// Error, increments mqtt_dlx_failed_total (the alertable "dead-letter sink
-// unhealthy" signal), and returns WITHOUT recording a successful capture — the
-// caller still ack-as-poisons the message so a dead-letter failure can never
-// block intake. This fail-closed-and-drop mirrors Kafka Connect's
-// DeadLetterQueueReporter (KIP-298): the original is dropped, but the failure is
-// a distinct, alertable metric — NOT leave-unacked, which on MQTT would
-// reconnect-redeliver and reintroduce the head-of-line stall Option C
-// (ADR-050 §6) avoids. mqtt_dlx_total counts only messages actually captured.
-func (s *Subscriber) routeDeadLetter(ctx context.Context, originalTopic string, payload []byte, reason ConsumeFailureReason) {
+// wildcard poison topic) or the $dead publish fails, routeDeadLetter logs at Error
+// and Dropped() increments mqtt_dlx_failed_total (the alertable "dead-letter sink
+// unhealthy" signal) WITHOUT recording a successful capture — the caller still
+// ack-as-poisons the message so a dead-letter failure can never block intake. This
+// fail-closed-and-drop mirrors Kafka Connect's DeadLetterQueueReporter (KIP-298):
+// the original is dropped, but the failure is a distinct, alertable metric — NOT
+// leave-unacked, which on MQTT would reconnect-redeliver and reintroduce the
+// head-of-line stall Option C (ADR-050 §6) avoids. mqtt_dlx_total counts only
+// messages actually captured.
+func (s *Subscriber) routeDeadLetter(
+	ctx context.Context, originalTopic string, payload []byte, reason ConsumeFailureReason,
+) dlxoutcome.Outcome { //nolint:unparam // gh #1440: Outcome forces each exit through a recording constructor; callers discard it.
 	dlt, err := s.ns.MintDeadLetter(originalTopic)
 	if err != nil {
 		// safeErrForLog: the mint error (errcode) embeds the untrusted originalTopic
@@ -40,8 +51,7 @@ func (s *Subscriber) routeDeadLetter(ctx context.Context, originalTopic string, 
 			slog.String(logKeyTopic, safeTopicForLog(originalTopic)),
 			slog.String("reason", string(reason)),
 			slog.String("error", safeErrForLog(err)))
-		s.collector.RecordDeadLetterFailure(ctx, reason)
-		return
+		return dlxoutcome.Dropped(ctx, s.collector, reason)
 	}
 
 	// Bound the publish and use WithoutCancel so the dead-letter capture
@@ -57,14 +67,13 @@ func (s *Subscriber) routeDeadLetter(ctx context.Context, originalTopic string, 
 			slog.String(logKeyDLXTopic, safeTopicForLog(dlt.String())),
 			slog.String("reason", string(reason)),
 			slog.Any("error", redactErr(pubErr)))
-		s.collector.RecordDeadLetterFailure(ctx, reason)
-		return
+		return dlxoutcome.Dropped(ctx, s.collector, reason)
 	}
 
-	s.collector.RecordDeadLetter(ctx, reason)
 	slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: routed message to dead-letter sink",
 		slog.String(logKeyClientID, s.conn.cfg.clientID.String()),
 		slog.String(logKeyTopic, safeTopicForLog(originalTopic)),
 		slog.String(logKeyDLXTopic, safeTopicForLog(dlt.String())),
 		slog.String("reason", string(reason)))
+	return dlxoutcome.Captured(ctx, s.collector, reason)
 }

--- a/adapters/mqtt/deadletter.go
+++ b/adapters/mqtt/deadletter.go
@@ -22,11 +22,14 @@ import (
 //
 // Every exit returns a [dlxoutcome.Outcome]: the metric is recorded by the
 // returning constructor, never inline. [dlxoutcome.Dropped] records the alertable
-// mqtt_dlx_failed_total; [dlxoutcome.Captured] records mqtt_dlx_total. Because the
-// function is typed to return an Outcome and only those two constructors produce
-// one, a drop path that forgets the metric cannot compile (gh #1440 / archtest
-// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01). The caller discards the Outcome — its job is
-// to force every exit through a recording constructor, not to carry state.
+// mqtt_dlx_failed_total; [dlxoutcome.Captured] records mqtt_dlx_total. The return
+// type is a FLOOR — every exit must return some Outcome — and the archtest funnel
+// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 (H2 no-forge + H4 sole-producer + H3a records)
+// makes that Outcome come from a recording path, so a drop branch that forgets the
+// metric is caught (machine-guarded Medium, not a compile error — a stateless token
+// is forgeable as a zero value; see gh #1440 / gh #1873 F1). The caller discards the
+// Outcome — its job is to force every exit through a recording constructor, not to
+// carry state.
 //
 // Fail-closed on every error: if the topic cannot be minted (out-of-namespace /
 // wildcard poison topic) or the $dead publish fails, routeDeadLetter logs at Error

--- a/adapters/mqtt/deadletter.go
+++ b/adapters/mqtt/deadletter.go
@@ -40,7 +40,7 @@ import (
 // messages actually captured.
 func (s *Subscriber) routeDeadLetter(
 	ctx context.Context, originalTopic string, payload []byte, reason ConsumeFailureReason,
-) dlxoutcome.Outcome { //nolint:unparam // gh #1440: Outcome forces each exit through a recording constructor; callers discard it.
+) dlxoutcome.Outcome { //nolint:unparam // R2-approved: gh #1440 — Outcome is a compile-forcing token; callers discard it.
 	dlt, err := s.ns.MintDeadLetter(originalTopic)
 	if err != nil {
 		// safeErrForLog: the mint error (errcode) embeds the untrusted originalTopic

--- a/adapters/mqtt/internal/dlxoutcome/dlxoutcome.go
+++ b/adapters/mqtt/internal/dlxoutcome/dlxoutcome.go
@@ -1,0 +1,56 @@
+// Package dlxoutcome seals the dead-letter routing outcome so the alertable
+// failure metric is structurally inseparable from a $dead drop.
+//
+// (*mqtt.Subscriber).routeDeadLetter is typed to return an [Outcome]. The only
+// way to obtain one is [Dropped] (which records the alertable
+// RecordDeadLetterFailure signal) or [Captured] (which records the RecordDeadLetter
+// success signal). Because Go forces every exit path of a value-returning function
+// to return that value, a new drop branch that forgets the metric cannot produce an
+// Outcome to return — it does not compile. "Every exit records a metric" is thus a
+// compile-time property, not an archtest one. (Hard upgrade of archtest
+// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01, gh #1440.)
+//
+// The residual hole — the empty literal dlxoutcome.Outcome{} and a zero
+// `var o Outcome` are still constructible from package mqtt — is irreducible in Go
+// (there is no "no zero value" type modifier) and is closed by the H2 shape-guard
+// in that archtest.
+//
+// NOTE: the generic type parameter R is load-bearing. It lets the constructors
+// record via the caller's collector WITHOUT importing adapters/mqtt — which would
+// be an import cycle (mqtt imports this package). Do NOT replace R with a concrete
+// mqtt.ConsumeFailureReason; it would not compile.
+package dlxoutcome
+
+import "context"
+
+// Outcome is an opaque, unforgeable proof token that a dead-letter routing
+// decision recorded its outcome metric. Its sole field is a blank field of an
+// unexported type, so package mqtt cannot name it in a literal; the only producers
+// are [Dropped] and [Captured] below, each of which records a metric. The token
+// carries no payload — the drop-vs-capture distinction is the recorded metric
+// (asserted by dlxoutcome_test.go and adapters/mqtt deadletter_test.go), not state
+// on the token. Its only job is to be a mandatory return type that forces every
+// exit of routeDeadLetter through a recording constructor.
+type Outcome struct{ _ recordedToken }
+
+type recordedToken struct{}
+
+// Dropped records the alertable dead-letter FAILURE signal (mqtt_dlx_failed_total)
+// for a $dead drop and returns the proof token. Use it on every drop exit.
+func Dropped[R any](ctx context.Context, rec interface {
+	RecordDeadLetterFailure(context.Context, R)
+}, reason R,
+) Outcome {
+	rec.RecordDeadLetterFailure(ctx, reason)
+	return Outcome{}
+}
+
+// Captured records the dead-letter SUCCESS signal (mqtt_dlx_total) for a message
+// actually captured in $dead and returns the proof token. Use it on the success exit.
+func Captured[R any](ctx context.Context, rec interface {
+	RecordDeadLetter(context.Context, R)
+}, reason R,
+) Outcome {
+	rec.RecordDeadLetter(ctx, reason)
+	return Outcome{}
+}

--- a/adapters/mqtt/internal/dlxoutcome/dlxoutcome.go
+++ b/adapters/mqtt/internal/dlxoutcome/dlxoutcome.go
@@ -23,8 +23,8 @@
 // The irreducible residual — a zero Outcome pulled from an open-ended set of
 // extraction sites (array/map element, reflect.Zero, an IIFE) — is what keeps this
 // Medium: Go has no "no zero value" type modifier and the forge surface is
-// open-ended, so no archtest can bound it. The three ENUMERABLE forge forms (empty
-// literal, zero var, new) ARE closed, by H2.
+// open-ended, so no archtest can bound it. The ENUMERABLE forge forms (empty
+// literal, zero var, new — each alias-aware via types.Unalias) ARE closed, by H2.
 //
 // NOTE: the generic type parameter R is load-bearing. It lets the constructors
 // record via the caller's collector WITHOUT importing adapters/mqtt — which would

--- a/adapters/mqtt/internal/dlxoutcome/dlxoutcome.go
+++ b/adapters/mqtt/internal/dlxoutcome/dlxoutcome.go
@@ -1,19 +1,30 @@
 // Package dlxoutcome seals the dead-letter routing outcome so the alertable
-// failure metric is structurally inseparable from a $dead drop.
+// failure metric is bound to a $dead drop via a sealed-construction funnel.
 //
-// (*mqtt.Subscriber).routeDeadLetter is typed to return an [Outcome]. The only
-// way to obtain one is [Dropped] (which records the alertable
-// RecordDeadLetterFailure signal) or [Captured] (which records the RecordDeadLetter
-// success signal). Because Go forces every exit path of a value-returning function
-// to return that value, a new drop branch that forgets the metric cannot produce an
-// Outcome to return — it does not compile. "Every exit records a metric" is thus a
-// compile-time property, not an archtest one. (Hard upgrade of archtest
-// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01, gh #1440.)
+// (*mqtt.Subscriber).routeDeadLetter is typed to return an [Outcome]. The type
+// system contributes a FLOOR: every exit must return SOME Outcome value (a bare
+// `return` is a compile error). The two sanctioned producers are [Dropped] (records
+// the alertable RecordDeadLetterFailure signal) and [Captured] (records the
+// RecordDeadLetter success signal). But the floor alone does NOT force the metric:
+// a stateless proof token has a zero value that is always constructible
+// (Outcome{}, var o, *new(Outcome), …), so a drop branch could forge one and still
+// compile. That gap is closed by the archtest funnel, NOT the compiler: H2 forbids
+// package mqtt forging an Outcome (composite-lit / zero-var / new), H4 forbids this
+// package gaining a third, non-recording producer, H3a checks Dropped/Captured
+// actually record. Floor + funnel ⇒ every Outcome routeDeadLetter returns came from
+// a recording path.
 //
-// The residual hole — the empty literal dlxoutcome.Outcome{} and a zero
-// `var o Outcome` are still constructible from package mqtt — is irreducible in Go
-// (there is no "no zero value" type modifier) and is closed by the H2 shape-guard
-// in that archtest.
+// This is graded Medium (the closure is archtest), NOT Hard: genuine type-system
+// Hard is unreachable for a stateless token — it would require proving a side effect
+// happened, but Go can only prove a value was produced, and a zero value carries no
+// such proof. See the MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 archtest godoc §grading and
+// ADR-048 §Amendment 2026-06-11 (gh #1440 / gh #1873 F1).
+//
+// The irreducible residual — a zero Outcome pulled from an open-ended set of
+// extraction sites (array/map element, reflect.Zero, an IIFE) — is what keeps this
+// Medium: Go has no "no zero value" type modifier and the forge surface is
+// open-ended, so no archtest can bound it. The three ENUMERABLE forge forms (empty
+// literal, zero var, new) ARE closed, by H2.
 //
 // NOTE: the generic type parameter R is load-bearing. It lets the constructors
 // record via the caller's collector WITHOUT importing adapters/mqtt — which would
@@ -23,14 +34,19 @@ package dlxoutcome
 
 import "context"
 
-// Outcome is an opaque, unforgeable proof token that a dead-letter routing
-// decision recorded its outcome metric. Its sole field is a blank field of an
-// unexported type, so package mqtt cannot name it in a literal; the only producers
-// are [Dropped] and [Captured] below, each of which records a metric. The token
-// carries no payload — the drop-vs-capture distinction is the recorded metric
-// (asserted by dlxoutcome_test.go and adapters/mqtt deadletter_test.go), not state
-// on the token. Its only job is to be a mandatory return type that forces every
-// exit of routeDeadLetter through a recording constructor.
+// Outcome is an opaque proof token that a dead-letter routing decision went
+// through a recording constructor. Its sole field is a blank field of an unexported
+// type, so package mqtt cannot construct a CONTENTFUL Outcome — but the EMPTY value
+// (Outcome{}, *new(Outcome), …) is still constructible (Go has no "no zero value"
+// type modifier), so the token is NOT unforgeable at the type level: forging from
+// mqtt is blocked by the H2 archtest, and adding a non-recording producer here is
+// blocked by H4. The two sanctioned producers are [Dropped] and [Captured] below,
+// each of which records a metric. The token carries no payload — the drop-vs-capture
+// distinction is the recorded metric (asserted by dlxoutcome_test.go and
+// adapters/mqtt deadletter_test.go), not state on the token. Its job is to be a
+// mandatory return type whose FLOOR forces every exit of routeDeadLetter to return
+// some Outcome; the funnel (H2/H4/H3a) forces that Outcome to come from a recording
+// constructor.
 type Outcome struct{ _ recordedToken }
 
 type recordedToken struct{}

--- a/adapters/mqtt/internal/dlxoutcome/dlxoutcome_test.go
+++ b/adapters/mqtt/internal/dlxoutcome/dlxoutcome_test.go
@@ -1,0 +1,68 @@
+package dlxoutcome
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeRecorder records the dead-letter signal calls. It uses string reasons
+// (R=string) to prove the generic constructors work on a plain string type —
+// mirroring adapters/mqtt.ConsumeFailureReason, whose underlying kind is string —
+// without importing the (internal) mqtt package.
+type fakeRecorder struct {
+	failures []string
+	captures []string
+}
+
+func (r *fakeRecorder) RecordDeadLetterFailure(_ context.Context, reason string) {
+	r.failures = append(r.failures, reason)
+}
+
+func (r *fakeRecorder) RecordDeadLetter(_ context.Context, reason string) {
+	r.captures = append(r.captures, reason)
+}
+
+// TestDropped_RecordsFailureOnly asserts Dropped records exactly the alertable
+// failure signal (RecordDeadLetterFailure) with the given reason and never the
+// success signal — the drop is observable, never silently miscounted as captured.
+func TestDropped_RecordsFailureOnly(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []string{"unmarshal", "reject"} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+			rec := &fakeRecorder{}
+			_ = Dropped(context.Background(), rec, reason)
+			if got := len(rec.failures); got != 1 {
+				t.Fatalf("Dropped: failure count = %d, want 1", got)
+			}
+			if rec.failures[0] != reason {
+				t.Fatalf("Dropped: failure reason = %q, want %q", rec.failures[0], reason)
+			}
+			if got := len(rec.captures); got != 0 {
+				t.Fatalf("Dropped: capture count = %d, want 0 (a drop must not be credited as captured)", got)
+			}
+		})
+	}
+}
+
+// TestCaptured_RecordsSuccessOnly asserts Captured records exactly the success
+// signal (RecordDeadLetter) with the given reason and never the failure signal.
+func TestCaptured_RecordsSuccessOnly(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []string{"unmarshal", "reject"} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+			rec := &fakeRecorder{}
+			_ = Captured(context.Background(), rec, reason)
+			if got := len(rec.captures); got != 1 {
+				t.Fatalf("Captured: capture count = %d, want 1", got)
+			}
+			if rec.captures[0] != reason {
+				t.Fatalf("Captured: capture reason = %q, want %q", rec.captures[0], reason)
+			}
+			if got := len(rec.failures); got != 0 {
+				t.Fatalf("Captured: failure count = %d, want 0", got)
+			}
+		})
+	}
+}

--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -190,7 +190,7 @@ ref: `adapters/rabbitmq/publisher.go` — `NewPublisher(*Publisher)` + `clock.Mu
 | shared-sub `$share` group 伪冒窃取他人消息 | `consumerGroup` 在 `MintFilter` 时由 GoCell wiring 注入（内部，非用户输入）；sealed `subscribableFilter` 包外不可构造；broker ACL 提供纵深防御 | ✅ PR-3（非用户可控）|
 | clientId 接管循环（两实例同 stable clientId 互相 DISCONNECT 0x8E） | `onServerDisconnect` 解码并 slog-Warn 0x8E；`ClientID` sealed `{cellID}-{role}-{uuid}` 降低偶发碰撞；operator 不得为两实例配置相同 stable clientId | ⚠️ operator-config concern（见 §Amendment 2026-05-29）|
 | Reject 消息堆积在 DLT topic | `$dead/<originalTopic>` via sealed `TopicNamespace.MintDeadLetter` funnel + 指标 `mqtt_dlx_total`；Reject（含 ConsumerBase retry_exhausted 转换的 Reject）与 unmarshal poison 均在 PUBACK-as-poison 前路由 | ✅ PR-4 |
-| `$dead` publish **本身失败**（topic unmintable / broker publish error / broker PUBACK reason ≥ 0x80）→ 消息被 ack-as-poison 丢弃，未落 $dead | **已接受的 fail-closed 取舍**（§Amendment 2026-06-02 — #1356，含 OSS 实测证据矩阵）：失败时 log-Error + 递增独立可告警指标 `mqtt_dlx_failed_total{cell,reason}` + 仍 PUBACK（drop）。**不** leave-unacked——MQTT 仅重连重投，会重新引入 Option C（ADR-050 §6）规避的 HoL stall，且对永久 Reject 为审计发布无限重投语义错误。镜像 Kafka Connect `DeadLetterQueueReporter`（KIP-298 `deadletterqueue-produce-failures` 与 `total-record-errors` 分离）。该 alertable 信号的 **no-silent-exit 轴现由类型系统 Hard 强制**（§Amendment 2026-06-11 — #1440）：routeDeadLetter 返回封印 `dlxoutcome.Outcome`，唯二产出者 `Dropped`/`Captured` 各记一指标，故新 drop 分支漏记 metric **编译不过**；drop→failure 语义匹配（review F1）+ 空字面量残留仍由 `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 降级后的 shape-guard（H2/H3b）守（Medium，非类型强制）。**字面 no-loss 在 transport 层不可达**，重定位到 consumer-cell 事务层（deferred，见 §Amendment 2026-06-02）。瞬态丢失靠 `mqtt_dlx_failed_total > 0` 告警捕获；有界进程内重投 deferred（#1334，数据驱动，非臆测） | ✅ PR-4 / #1356 |
+| `$dead` publish **本身失败**（topic unmintable / broker publish error / broker PUBACK reason ≥ 0x80）→ 消息被 ack-as-poison 丢弃，未落 $dead | **已接受的 fail-closed 取舍**（§Amendment 2026-06-02 — #1356，含 OSS 实测证据矩阵）：失败时 log-Error + 递增独立可告警指标 `mqtt_dlx_failed_total{cell,reason}` + 仍 PUBACK（drop）。**不** leave-unacked——MQTT 仅重连重投，会重新引入 Option C（ADR-050 §6）规避的 HoL stall，且对永久 Reject 为审计发布无限重投语义错误。镜像 Kafka Connect `DeadLetterQueueReporter`（KIP-298 `deadletterqueue-produce-failures` 与 `total-record-errors` 分离）。该 alertable 信号的 **no-silent-exit 轴由 sealed-construction archtest funnel 守**（§Amendment 2026-06-11 — #1440 / #1873 F1）：routeDeadLetter 返回封印 `dlxoutcome.Outcome`（类型系统 floor：必返回某 Outcome），funnel H1 签名 + H2 禁 mqtt 伪造[字面量/零值/new] + H4 dlxoutcome 唯一生产者 + H3a 构造器必记，使返回的 Outcome 必经记指标路径。**评级 Medium（archtest），非类型系统 Hard**——Outcome 是无 state 纯 token，零值恒可伪造，漏记 metric 的退出**仍能编译**（由 H2/H4 拦截，非编译器）；字面 Hard 对 stateless token 在 Go 不可达。drop→failure 语义匹配（review F1）由 H3b 聚合计数 + 行为测试守。**字面 no-loss 在 transport 层不可达**，重定位到 consumer-cell 事务层（deferred，见 §Amendment 2026-06-02）。瞬态丢失靠 `mqtt_dlx_failed_total > 0` 告警捕获；有界进程内重投 deferred（#1334，数据驱动，非臆测） | ✅ PR-4 / #1356 |
 | mTLS 证书过期 | bootstrap fail-fast（x509 handshake fail）；cert rotation 通过 Vault PKI；nightly TLS 测试 `integration_tls_test.go` + `.github/workflows/mqtt-tls-nightly.yml` 已落地 | ✅ PR-4 |
 
 ---
@@ -647,7 +647,7 @@ Matrix additions (no regressions):
 3. **no-loss 重定位（deferred）**：字面 no-loss（"绝不丢"）需要持久化底座。GoCell 的持久化底座是**消费 cell 的本地事务**——消费 cell 在永久失败时应在本地 tx 落一条持久 dead-letter 行再 `Reject`（即 Spring offset 重读 / Watermill clean-Nack 在 GoCell 的等价物），或桥接到 AMQP/Kafka（ADR-050 Option C 同款建议）。当前 develop **无 MQTT-consuming cell**（iotdevice 为 publish-only），故无 enforcement 对象；该 enforcement 在真实消费 cell 出现时落地，登记于 backlog **#1435**（带机制，不写投机指南——Soft 严禁立项，见 ai-robust.md）。
    > **面向未来 MQTT-consuming cell 开发者**：MQTT adapter **不**提供与 AMQP broker-native DLX 等同的 no-loss 保证。消费 MQTT 的 cell 若需 no-loss，**必须**在本地事务里落 dead-letter 记录再 `Reject`——否则 poison 消息在 `$dead` 失败路径上会被 fail-closed 丢弃（仅 `mqtt_dlx_failed_total` 告警可见）。这不是 adapter bug，是 transport 层的结构性边界。
 4. **有界进程内重试**：deferred（#1334，数据驱动，无 OSS 传输层先例）。
-5. **archtest Hard 化**：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 从 Medium 升 Hard（drop 决策收口为 typed sink helper）——**已落地**（§Amendment 2026-06-11 — #1440：no-silent-exit 轴升 Hard，F1/空字面量残留留 Medium shape-guard）。
+5. **archtest 强化**：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 的 no-silent-exit 轴由单控制流扫描升级为 **sealed-construction funnel + 类型 floor**（drop 决策收口为封印 `dlxoutcome.Outcome`）——**已落地**（§Amendment 2026-06-11 — #1440 / #1873 F1）。**仍是 Medium**：closure 是 archtest（H1/H2/H4/H3a），stateless token 的字面类型系统 Hard 在 Go 不可达；强化在于从启发式控制流扫描换成封闭的生产者/消费者 funnel。
 
 ### §3 威胁矩阵逐行重评（ai-robust「ADR amendment 落地必查」）
 
@@ -767,33 +767,38 @@ NewConfig / 字段集 / 默认值 / A1 freeze want-set 的权威定义活在 `ad
 
 ---
 
-## Amendment 2026-06-11 — #1440 sealed dlxoutcome.Outcome（MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 no-silent-exit Medium → Hard）
+## Amendment 2026-06-11 — #1440 sealed dlxoutcome.Outcome（MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 no-silent-exit：单控制流扫描 → 封闭 sealed-construction funnel，仍 Medium）
+
+> **#1873 review F1 更正**：本 amendment 原文（初版）声称把 no-silent-exit 轴升「类型系统 Hard」。该表述是 overclaim：`Outcome` 是无 state 的纯 proof token，其零值恒可伪造（`Outcome{}` / `*new(Outcome)` / `var o`），漏记 metric 的退出**仍能编译**，由 archtest 拦截而非编译器。按 ai-robust 载体表，archtest typed scan = **Medium**。下文已按 F1 更正为诚实分级。
 
 ### 触发
 
-§Amendment 2026-06-02 item 5 carryover：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01`（#1356 落地）此前是 Medium——AST 控制流扫描断言 `routeDeadLetter` 每个 `return`（drop 退出）前置 `RecordDeadLetterFailure`。Medium 根因：Go 类型系统无法表达「每个退出必记 metric」，只能 archtest 守。本 amendment（#1440）把 drop 决策收口为 typed sink helper，将 no-silent-exit 轴升 Hard。
+§Amendment 2026-06-02 item 5 carryover：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01`（#1356 落地）此前是 Medium——AST 控制流扫描断言 `routeDeadLetter` 每个 `return`（drop 退出）前置 `RecordDeadLetterFailure`，是启发式（metric 上移到祖先块会假阳性）。Medium 根因：Go 类型系统无法表达「每个退出必记 metric」（那是**副作用**断言，类型系统只能证明「产生了一个 Outcome 值」），只能 archtest 守。本 amendment（#1440）把 drop 决策收口为封印 token，将载体从单控制流扫描换成封闭的 sealed-construction funnel——**强度提升但仍 Medium**。
 
 ### 决策
 
-1. 新增 internal 包 `adapters/mqtt/internal/dlxoutcome`：封印 proof-token `Outcome`（唯一字段是不可导出类型的 blank field），唯二产出者 `Dropped[R](ctx, rec, reason)`（记 `RecordDeadLetterFailure`）/ `Captured[R](ctx, rec, reason)`（记 `RecordDeadLetter`）。泛型 `R` **承重**——让构造器经调用方 collector 记录而**不** import mqtt（否则 import cycle）；godoc 写明此理由防后人「简化」成环。
-2. `routeDeadLetter` retype `... ) dlxoutcome.Outcome`：每个 drop 分支 `return dlxoutcome.Dropped(...)`、成功 fall-through `return dlxoutcome.Captured(...)`，三处 inline `s.collector.Record*` 下沉进构造器。新 drop 分支若漏 metric 无 Outcome 可返回 → **编译错**。行为逐字不变（同两指标发射），4 个 `deadletter_test.go` 测试不改即过；callers 以裸语句丢弃返回的 Outcome（`//nolint:unparam`：Outcome 是编译强制 token，设计上被丢弃）。
-3. archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 降为 shape-guard：H1 签名守卫（routeDeadLetter 必返回 `dlxoutcome.Outcome`，捕获改回 void 回退）/ H2 禁 mqtt 铸 Outcome 字面量+零值 `var`（含空字面量，配 `dlxoutcomeredfixture` synthetic red）/ H3a 构造器必记对应指标（防掏成 no-op）/ H3b F1 聚合计数（`Captured` callsite==1、`Dropped`≥1）。
+1. 新增 internal 包 `adapters/mqtt/internal/dlxoutcome`：封印 proof-token `Outcome`（唯一字段是不可导出类型的 blank field），唯二 sanctioned 产出者 `Dropped[R](ctx, rec, reason)`（记 `RecordDeadLetterFailure`）/ `Captured[R](ctx, rec, reason)`（记 `RecordDeadLetter`）。泛型 `R` **承重**——让构造器经调用方 collector 记录而**不** import mqtt（否则 import cycle）；godoc 写明此理由防后人「简化」成环。
+2. `routeDeadLetter` retype `... ) dlxoutcome.Outcome`：每个 drop 分支 `return dlxoutcome.Dropped(...)`、成功 fall-through `return dlxoutcome.Captured(...)`，三处 inline `s.collector.Record*` 下沉进构造器。类型系统提供 **floor**——每个退出必返回某 Outcome（裸 `return` 编译错）；但 floor **不**强制 metric：新 drop 分支可伪造零值 Outcome 并仍编译，由下方 funnel（H2/H4）拦截。行为逐字不变（同两指标发射），4 个 `deadletter_test.go` 测试不改即过；callers 以裸语句丢弃返回的 Outcome（`//nolint:unparam`：Outcome 是 floor 强制 token，设计上被丢弃）。
+3. archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` = sealed-construction funnel：**H1** 签名守卫（routeDeadLetter 必返回 `dlxoutcome.Outcome`，捕获改回 void 回退）/ **H2** 禁 mqtt 伪造 Outcome（composite literal + 零值 `var` + `*new(T)`，含空字面量，配 `dlxoutcomeredfixture` synthetic red 三 forge）/ **H4** dlxoutcome 唯一生产者守卫（返回 Outcome 的函数名 ⊆ {Dropped, Captured}，配 red fixture 三个越权生产者）/ **H3a** 构造器必记对应指标（防掏成 no-op）/ **H3b** F1 聚合计数（`Captured` callsite==1、`Dropped`≥1）。H1 floor + H2/H4/H3a 闭合「返回的 Outcome 必经记指标路径」。
 
-### AI-robust 诚实分级（不 overclaim）
+### AI-robust 诚实分级（按 #1873 F1 更正）
 
-- **Hard（类型系统）**：no-silent-exit——新 drop 退出漏 metric 编译不过。最高严重度失败模式（整条 $dead drop 静默丢失）升 Hard。
-- **Medium 残留①（shape-guard）**：空字面量 `dlxoutcome.Outcome{}` / 零值 `var o Outcome` 仍可在 mqtt 内构造——Go 不可消除（无「无零值」修饰符，同 `internal/topicns` token 天花板），由 H2 守。
-- **Medium 残留②（F1 语义）**：类型系统强制「记某指标」但**不**强制「记对的指标」（不知哪个 return 是 drop）。drop 误用 Captured = 假成功计数（review F1）。由 H3b 聚合计数 + `deadletter_test.go` 行为测试守。
-- **严禁**表述为「drop→failure 指标由类型系统强制」——该轴仍 Medium。
+整条 no-silent-exit 轴 = **Medium**（sealed-construction funnel + 类型 floor）。载体是 archtest（H2/H4/H3a），按 ai-robust 表即 Medium，**非 Hard**。
+
+- **类型 floor（Hard 子性质，H1）**：routeDeadLetter 必返回某 Outcome——裸 `return` / 改回 void 编译错（H1 捕获）。抬高门槛（静默 drop 必须主动伪造零值），但**不**单独强制 metric。
+- **funnel completion（Medium，H2 + H4 + H3a）**：H2 禁 mqtt 伪造 Outcome（字面量/零值/new 三 enumerable 形态）；H4 禁 dlxoutcome 增非记录生产者；H3a 验构造器确实记指标。三者合闭 floor 留下的「Outcome 来自记指标路径」缺口。
+- **F1 语义（Medium，H3b + 行为测试）**：floor 强制「记某指标」但**不**强制「记对的指标」。drop 误用 Captured = 假成功计数（review F1）。由 H3b 聚合计数 + `deadletter_test.go` 守。
+- **不可达 Hard 的根因 / 不可消除天花板**：`Outcome` 无 state，零值恒可构造（Go 无「无零值」修饰符）；开放集零值提取（数组/map 元素、`reflect.Zero`、IIFE）非 enumerable AST 形态，无 archtest 可穷举——这正是它停在 Medium。对比真 Hard 的 `ClientID`/`internal/topicns`：那些密封**有内容的** unexported 字段，包外构造有内容值编译错；Outcome 没有可密封的 state。
+- **严禁**表述为「漏记 metric 编译不过」或「类型系统 Hard 强制 no-silent-exit」——#1873 F1 更正点。
 
 ### §3 威胁矩阵逐行重评（ai-robust「ADR amendment 落地必查」）
 
-本 amendment 是 **Medium→Hard 改善**，无任一格子 ✅→⚠️/❌ 回退：
+本 amendment 是 **Medium 内强化**（载体从启发式控制流扫描换成封闭 funnel），无任一格子 ✅→⚠️/❌ 回退，**也不是** Medium→Hard 升级：
 
-- line 193（`$dead` publish 本身失败）：缓解从「archtest 控制流守 drop 必记 metric（Medium）」**重写**为「sealed `dlxoutcome.Outcome` 类型系统强制 no-silent-exit（Hard）+ shape-guard 守 F1/空字面量残留（Medium）」。no-silent-exit 轴 Medium→Hard 上升；F1 轴维持 Medium（载体从控制流扫描换成聚合计数 + 行为测试，强度不降）；空字面量为不可消除天花板（已写入 archtest godoc，非新缺口）。状态 ✅ 强化，无降级。
+- line 193（`$dead` publish 本身失败）：缓解从「archtest 控制流守 drop 必记 metric（Medium，启发式）」**重写**为「sealed-construction funnel（H1 floor + H2/H4/H3a，Medium）+ H3b 守 F1」。no-silent-exit 轴**仍 Medium**，强度提升（封闭生产者/消费者 funnel > 单控制流扫描，且消除控制流扫描的祖先块假阳性）；零值/开放集为不可消除天花板（已写入 archtest godoc，非新缺口）。状态 ✅ 强化，无降级、无 Hard 升级。
 - 其余安全行：本 amendment 不触及，状态不变。
-- **矩阵净变化**：1 行的 no-silent-exit 轴从 Medium 缓解升级到 Hard 缓解；无降级。
+- **矩阵净变化**：1 行的 no-silent-exit 轴载体强化（Medium→Medium），无评级跃迁，无降级。
 
 ### 单源
 
-`Outcome` / `Dropped` / `Captured` 的封印机制 + H1/H2/H3a/H3b 符号与盲区清单活在 `adapters/mqtt/internal/dlxoutcome/dlxoutcome.go` package godoc + `tools/archtest/mqtt_dlx_failure_signal_funnel_test.go` package godoc；本节只记决策与对账。
+`Outcome` / `Dropped` / `Captured` 的封印机制 + H1/H2/H4/H3a/H3b 符号与盲区清单（含「为何 Medium 非 Hard」「开放集天花板」）活在 `adapters/mqtt/internal/dlxoutcome/dlxoutcome.go` package godoc + `tools/archtest/mqtt_dlx_failure_signal_funnel_test.go` package godoc；本节只记决策与对账。ref: #1873 review F1。

--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -190,7 +190,7 @@ ref: `adapters/rabbitmq/publisher.go` — `NewPublisher(*Publisher)` + `clock.Mu
 | shared-sub `$share` group 伪冒窃取他人消息 | `consumerGroup` 在 `MintFilter` 时由 GoCell wiring 注入（内部，非用户输入）；sealed `subscribableFilter` 包外不可构造；broker ACL 提供纵深防御 | ✅ PR-3（非用户可控）|
 | clientId 接管循环（两实例同 stable clientId 互相 DISCONNECT 0x8E） | `onServerDisconnect` 解码并 slog-Warn 0x8E；`ClientID` sealed `{cellID}-{role}-{uuid}` 降低偶发碰撞；operator 不得为两实例配置相同 stable clientId | ⚠️ operator-config concern（见 §Amendment 2026-05-29）|
 | Reject 消息堆积在 DLT topic | `$dead/<originalTopic>` via sealed `TopicNamespace.MintDeadLetter` funnel + 指标 `mqtt_dlx_total`；Reject（含 ConsumerBase retry_exhausted 转换的 Reject）与 unmarshal poison 均在 PUBACK-as-poison 前路由 | ✅ PR-4 |
-| `$dead` publish **本身失败**（topic unmintable / broker publish error / broker PUBACK reason ≥ 0x80）→ 消息被 ack-as-poison 丢弃，未落 $dead | **已接受的 fail-closed 取舍**（§Amendment 2026-06-02 — #1356，含 OSS 实测证据矩阵）：失败时 log-Error + 递增独立可告警指标 `mqtt_dlx_failed_total{cell,reason}` + 仍 PUBACK（drop）。**不** leave-unacked——MQTT 仅重连重投，会重新引入 Option C（ADR-050 §6）规避的 HoL stall，且对永久 Reject 为审计发布无限重投语义错误。镜像 Kafka Connect `DeadLetterQueueReporter`（KIP-298 `deadletterqueue-produce-failures` 与 `total-record-errors` 分离）。该 alertable 信号现由 archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 机器守卫（routeDeadLetter 每个退出路径必记 dead-letter outcome，drop 不可静默化）。**字面 no-loss 在 transport 层不可达**，重定位到 consumer-cell 事务层（deferred，见 §Amendment 2026-06-02）。瞬态丢失靠 `mqtt_dlx_failed_total > 0` 告警捕获；有界进程内重投 deferred（#1334，数据驱动，非臆测） | ✅ PR-4 / #1356 |
+| `$dead` publish **本身失败**（topic unmintable / broker publish error / broker PUBACK reason ≥ 0x80）→ 消息被 ack-as-poison 丢弃，未落 $dead | **已接受的 fail-closed 取舍**（§Amendment 2026-06-02 — #1356，含 OSS 实测证据矩阵）：失败时 log-Error + 递增独立可告警指标 `mqtt_dlx_failed_total{cell,reason}` + 仍 PUBACK（drop）。**不** leave-unacked——MQTT 仅重连重投，会重新引入 Option C（ADR-050 §6）规避的 HoL stall，且对永久 Reject 为审计发布无限重投语义错误。镜像 Kafka Connect `DeadLetterQueueReporter`（KIP-298 `deadletterqueue-produce-failures` 与 `total-record-errors` 分离）。该 alertable 信号的 **no-silent-exit 轴现由类型系统 Hard 强制**（§Amendment 2026-06-11 — #1440）：routeDeadLetter 返回封印 `dlxoutcome.Outcome`，唯二产出者 `Dropped`/`Captured` 各记一指标，故新 drop 分支漏记 metric **编译不过**；drop→failure 语义匹配（review F1）+ 空字面量残留仍由 `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 降级后的 shape-guard（H2/H3b）守（Medium，非类型强制）。**字面 no-loss 在 transport 层不可达**，重定位到 consumer-cell 事务层（deferred，见 §Amendment 2026-06-02）。瞬态丢失靠 `mqtt_dlx_failed_total > 0` 告警捕获；有界进程内重投 deferred（#1334，数据驱动，非臆测） | ✅ PR-4 / #1356 |
 | mTLS 证书过期 | bootstrap fail-fast（x509 handshake fail）；cert rotation 通过 Vault PKI；nightly TLS 测试 `integration_tls_test.go` + `.github/workflows/mqtt-tls-nightly.yml` 已落地 | ✅ PR-4 |
 
 ---
@@ -647,7 +647,7 @@ Matrix additions (no regressions):
 3. **no-loss 重定位（deferred）**：字面 no-loss（"绝不丢"）需要持久化底座。GoCell 的持久化底座是**消费 cell 的本地事务**——消费 cell 在永久失败时应在本地 tx 落一条持久 dead-letter 行再 `Reject`（即 Spring offset 重读 / Watermill clean-Nack 在 GoCell 的等价物），或桥接到 AMQP/Kafka（ADR-050 Option C 同款建议）。当前 develop **无 MQTT-consuming cell**（iotdevice 为 publish-only），故无 enforcement 对象；该 enforcement 在真实消费 cell 出现时落地，登记于 backlog **#1435**（带机制，不写投机指南——Soft 严禁立项，见 ai-robust.md）。
    > **面向未来 MQTT-consuming cell 开发者**：MQTT adapter **不**提供与 AMQP broker-native DLX 等同的 no-loss 保证。消费 MQTT 的 cell 若需 no-loss，**必须**在本地事务里落 dead-letter 记录再 `Reject`——否则 poison 消息在 `$dead` 失败路径上会被 fail-closed 丢弃（仅 `mqtt_dlx_failed_total` 告警可见）。这不是 adapter bug，是 transport 层的结构性边界。
 4. **有界进程内重试**：deferred（#1334，数据驱动，无 OSS 传输层先例）。
-5. **archtest Hard 化**：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 从 Medium 升 Hard（drop 决策收口为 typed sink helper）deferred（#1440）。
+5. **archtest Hard 化**：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 从 Medium 升 Hard（drop 决策收口为 typed sink helper）——**已落地**（§Amendment 2026-06-11 — #1440：no-silent-exit 轴升 Hard，F1/空字面量残留留 Medium shape-guard）。
 
 ### §3 威胁矩阵逐行重评（ai-robust「ADR amendment 落地必查」）
 
@@ -764,3 +764,36 @@ PR #1227 review C1 F1 carryover：`Config` round-1 仅有 form-lock（`MQTT-CONF
 ### 单源
 
 NewConfig / 字段集 / 默认值 / A1 freeze want-set 的权威定义活在 `adapters/mqtt/config.go` + `tools/archtest/mqtt_funnel_test.go::wantMQTTConfigFields`；本节只记决策与对账。
+
+---
+
+## Amendment 2026-06-11 — #1440 sealed dlxoutcome.Outcome（MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 no-silent-exit Medium → Hard）
+
+### 触发
+
+§Amendment 2026-06-02 item 5 carryover：`MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01`（#1356 落地）此前是 Medium——AST 控制流扫描断言 `routeDeadLetter` 每个 `return`（drop 退出）前置 `RecordDeadLetterFailure`。Medium 根因：Go 类型系统无法表达「每个退出必记 metric」，只能 archtest 守。本 amendment（#1440）把 drop 决策收口为 typed sink helper，将 no-silent-exit 轴升 Hard。
+
+### 决策
+
+1. 新增 internal 包 `adapters/mqtt/internal/dlxoutcome`：封印 proof-token `Outcome`（唯一字段是不可导出类型的 blank field），唯二产出者 `Dropped[R](ctx, rec, reason)`（记 `RecordDeadLetterFailure`）/ `Captured[R](ctx, rec, reason)`（记 `RecordDeadLetter`）。泛型 `R` **承重**——让构造器经调用方 collector 记录而**不** import mqtt（否则 import cycle）；godoc 写明此理由防后人「简化」成环。
+2. `routeDeadLetter` retype `... ) dlxoutcome.Outcome`：每个 drop 分支 `return dlxoutcome.Dropped(...)`、成功 fall-through `return dlxoutcome.Captured(...)`，三处 inline `s.collector.Record*` 下沉进构造器。新 drop 分支若漏 metric 无 Outcome 可返回 → **编译错**。行为逐字不变（同两指标发射），4 个 `deadletter_test.go` 测试不改即过；callers 以裸语句丢弃返回的 Outcome（`//nolint:unparam`：Outcome 是编译强制 token，设计上被丢弃）。
+3. archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 降为 shape-guard：H1 签名守卫（routeDeadLetter 必返回 `dlxoutcome.Outcome`，捕获改回 void 回退）/ H2 禁 mqtt 铸 Outcome 字面量+零值 `var`（含空字面量，配 `dlxoutcomeredfixture` synthetic red）/ H3a 构造器必记对应指标（防掏成 no-op）/ H3b F1 聚合计数（`Captured` callsite==1、`Dropped`≥1）。
+
+### AI-robust 诚实分级（不 overclaim）
+
+- **Hard（类型系统）**：no-silent-exit——新 drop 退出漏 metric 编译不过。最高严重度失败模式（整条 $dead drop 静默丢失）升 Hard。
+- **Medium 残留①（shape-guard）**：空字面量 `dlxoutcome.Outcome{}` / 零值 `var o Outcome` 仍可在 mqtt 内构造——Go 不可消除（无「无零值」修饰符，同 `internal/topicns` token 天花板），由 H2 守。
+- **Medium 残留②（F1 语义）**：类型系统强制「记某指标」但**不**强制「记对的指标」（不知哪个 return 是 drop）。drop 误用 Captured = 假成功计数（review F1）。由 H3b 聚合计数 + `deadletter_test.go` 行为测试守。
+- **严禁**表述为「drop→failure 指标由类型系统强制」——该轴仍 Medium。
+
+### §3 威胁矩阵逐行重评（ai-robust「ADR amendment 落地必查」）
+
+本 amendment 是 **Medium→Hard 改善**，无任一格子 ✅→⚠️/❌ 回退：
+
+- line 193（`$dead` publish 本身失败）：缓解从「archtest 控制流守 drop 必记 metric（Medium）」**重写**为「sealed `dlxoutcome.Outcome` 类型系统强制 no-silent-exit（Hard）+ shape-guard 守 F1/空字面量残留（Medium）」。no-silent-exit 轴 Medium→Hard 上升；F1 轴维持 Medium（载体从控制流扫描换成聚合计数 + 行为测试，强度不降）；空字面量为不可消除天花板（已写入 archtest godoc，非新缺口）。状态 ✅ 强化，无降级。
+- 其余安全行：本 amendment 不触及，状态不变。
+- **矩阵净变化**：1 行的 no-silent-exit 轴从 Medium 缓解升级到 Hard 缓解；无降级。
+
+### 单源
+
+`Outcome` / `Dropped` / `Captured` 的封印机制 + H1/H2/H3a/H3b 符号与盲区清单活在 `adapters/mqtt/internal/dlxoutcome/dlxoutcome.go` package godoc + `tools/archtest/mqtt_dlx_failure_signal_funnel_test.go` package godoc；本节只记决策与对账。

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -186,8 +186,11 @@ no-loss（leave-unacked 会复活 Option C 的 HoL stall，ADR-050 §1），因�
 消息**确实丢失**——`mqtt_dlx_failed_total > 0` 是运维必须介入的信号，**不是**可容忍的
 降级。RTO 内未恢复死信管道（broker / ACL / topic 配置）即意味着永久消息丢失。
 
-> 该信号"每个 drop 路径必记"由 archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 机器守卫，
-> 不会被代码改动静默移除。真正的 no-loss 保证应由消费 cell 在本地事务捕获 poison 消息
+> 该信号"每个 drop 路径必记"的 no-silent-exit 轴由**类型系统 Hard** 强制（`routeDeadLetter`
+> 返回封印 `dlxoutcome.Outcome`，唯一来源是记指标的构造器 `Dropped`/`Captured`，漏记编译不过——
+> 见 ADR-048 §Amendment 2026-06-11 / #1440）；drop→failure 语义匹配 + 空字面量残留由 archtest
+> `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 降级后的 shape-guard 守。两者均不会被代码改动静默移除。
+> 真正的 no-loss 保证应由消费 cell 在本地事务捕获 poison 消息
 > 实现（重定位，deferred — 见 ADR-048 §Amendment 2026-06-02）。
 >
 > ⚠ **前提:信号仅在 wire 了 provider-backed `SubscriberCollector` 后才发射。**

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -186,10 +186,13 @@ no-loss（leave-unacked 会复活 Option C 的 HoL stall，ADR-050 §1），因�
 消息**确实丢失**——`mqtt_dlx_failed_total > 0` 是运维必须介入的信号，**不是**可容忍的
 降级。RTO 内未恢复死信管道（broker / ACL / topic 配置）即意味着永久消息丢失。
 
-> 该信号"每个 drop 路径必记"的 no-silent-exit 轴由**类型系统 Hard** 强制（`routeDeadLetter`
-> 返回封印 `dlxoutcome.Outcome`，唯一来源是记指标的构造器 `Dropped`/`Captured`，漏记编译不过——
-> 见 ADR-048 §Amendment 2026-06-11 / #1440）；drop→failure 语义匹配 + 空字面量残留由 archtest
-> `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 降级后的 shape-guard 守。两者均不会被代码改动静默移除。
+> 该信号"每个 drop 路径必记"的 no-silent-exit 轴由 **sealed-construction archtest funnel**
+> `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 守（H1 签名 floor + H2 禁 mqtt 伪造[字面量/零值/new] +
+> H4 dlxoutcome 唯一生产者 + H3a 构造器必记），配类型系统 **floor**——`routeDeadLetter` 必返回封印
+> `dlxoutcome.Outcome`，但 Outcome 是无 state 的纯 token，零值可伪造（`Outcome{}`/`*new(...)`），
+> **漏记 metric 的退出仍能编译**，由 H2/H4 archtest 拦截而非编译器。**评级 Medium（archtest），非类型系统 Hard**
+> ——stateless token 的字面 Hard 在 Go 不可达（见 ADR-048 §Amendment 2026-06-11 / #1440 / #1873 F1）。
+> drop→failure 语义匹配（review F1）由 H3b 聚合计数 + 行为测试守。funnel + floor 均不会被代码改动静默移除。
 > 真正的 no-loss 保证应由消费 cell 在本地事务捕获 poison 消息
 > 实现（重定位，deferred — 见 ADR-048 §Amendment 2026-06-02）。
 >

--- a/tools/archtest/internal/dlxoutcomeredfixture/fixture.go
+++ b/tools/archtest/internal/dlxoutcomeredfixture/fixture.go
@@ -1,11 +1,15 @@
 //go:build archtest_fixture
 
 // Package dlxoutcomeredfixture is the red fixture for
-// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2's scanner-fires self-check. It declares a
-// REPLICA of adapters/mqtt/internal/dlxoutcome.Outcome (an exported struct with
-// only a blank/unexported field — the sealed-proof-token shape) and plants the
-// two forge forms H2 must detect: an empty composite literal and a zero-value
-// `var` declaration.
+// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01's H2 and H4 scanner-fires self-checks. It
+// declares a REPLICA of adapters/mqtt/internal/dlxoutcome.Outcome (an exported
+// struct with only a blank/unexported field — the sealed-proof-token shape) and
+// plants the three zero-value forge forms H2 must detect: an empty composite
+// literal, a zero-value `var` declaration, and a `*new(T)` allocation.
+//
+// The same three planted functions double as H4 (sole-producer) red samples:
+// each returns the replica Outcome but is NOT named Dropped/Captured, so the H4
+// producer-allowlist scan must flag all of them as non-sanctioned producers.
 //
 // Why a replica and not the real dlxoutcome.Outcome: dlxoutcome lives under
 // adapters/mqtt/internal, and Go's internal-package rule forbids this tools-module
@@ -21,7 +25,7 @@
 //
 // ref: tools/archtest/mqtt_dlx_failure_signal_funnel_test.go TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture
 // ref: tools/archtest/internal/mqttredfixture/fixture.go (replica-fixture precedent)
-// ref: gh #1440 — MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 Hard upgrade
+// ref: gh #1440 — MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 sealed-construction funnel (Medium, gh #1873 F1)
 package dlxoutcomeredfixture
 
 // FixtureOutcome is a sealed-shape replica of dlxoutcome.Outcome: an exported
@@ -48,4 +52,14 @@ func archtestForgedOutcomeLiteral() FixtureOutcome {
 func archtestForgedOutcomeVar() FixtureOutcome {
 	var o FixtureOutcome
 	return o
+}
+
+// archtestForgedOutcomeNew plants the `*new(T)` allocation forge — a zero Outcome
+// produced by the builtin new, with neither a composite literal nor a typed
+// zero-var, so a composite-lit/var-only scan misses it. This is the third form H2
+// closes (gh #1873 review F1: new(T) is detectable, not an irreducible residual).
+//
+//nolint:unused // referenced exclusively by the archtest scanner via AST loading.
+func archtestForgedOutcomeNew() FixtureOutcome {
+	return *new(FixtureOutcome)
 }

--- a/tools/archtest/internal/dlxoutcomeredfixture/fixture.go
+++ b/tools/archtest/internal/dlxoutcomeredfixture/fixture.go
@@ -4,12 +4,15 @@
 // MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01's H2 and H4 scanner-fires self-checks. It
 // declares a REPLICA of adapters/mqtt/internal/dlxoutcome.Outcome (an exported
 // struct with only a blank/unexported field — the sealed-proof-token shape) and
-// plants the three zero-value forge forms H2 must detect: an empty composite
-// literal, a zero-value `var` declaration, and a `*new(T)` allocation.
+// plants the four forge forms H2 must detect: an empty composite literal, a
+// zero-value `var` declaration, a `*new(T)` allocation, and an alias-typed
+// construction (Go 1.23+ surfaces a type alias as *types.Alias, so the scanner
+// must types.Unalias before the *types.Named assertion — gh #1873 review F1 r2).
 //
-// The same three planted functions double as H4 (sole-producer) red samples:
-// each returns the replica Outcome but is NOT named Dropped/Captured, so the H4
-// producer-allowlist scan must flag all of them as non-sanctioned producers.
+// The same four planted functions double as H4 (sole-producer) red samples: each
+// returns the replica Outcome (the alias one returns the alias) but is NOT named
+// Dropped/Captured, so the H4 producer-allowlist scan must flag all of them as
+// non-sanctioned producers.
 //
 // Why a replica and not the real dlxoutcome.Outcome: dlxoutcome lives under
 // adapters/mqtt/internal, and Go's internal-package rule forbids this tools-module
@@ -62,4 +65,21 @@ func archtestForgedOutcomeVar() FixtureOutcome {
 //nolint:unused // referenced exclusively by the archtest scanner via AST loading.
 func archtestForgedOutcomeNew() FixtureOutcome {
 	return *new(FixtureOutcome)
+}
+
+// FixtureOutcomeAlias is a type alias of FixtureOutcome. Under Go 1.23+
+// (gotypesalias=1, the default) an alias surfaces as *types.Alias, NOT
+// *types.Named — so a scanner asserting *types.Named WITHOUT types.Unalias misses
+// an alias-typed forge/producer. Same Unalias requirement as reconcile_invariants
+// isReconcileLoopType (gh #1873 review F1 round-2).
+type FixtureOutcomeAlias = FixtureOutcome
+
+// archtestForgedOutcomeAlias exercises BOTH alias-aware paths from one function:
+// its body `FixtureOutcomeAlias{}` is an alias composite-literal (H2 must Unalias
+// to flag it) AND its result type is the alias (H4 must Unalias to recognize it as
+// a non-sanctioned producer). A scanner that skips types.Unalias detects neither.
+//
+//nolint:unused // referenced exclusively by the archtest scanner via AST loading.
+func archtestForgedOutcomeAlias() FixtureOutcomeAlias {
+	return FixtureOutcomeAlias{}
 }

--- a/tools/archtest/internal/dlxoutcomeredfixture/fixture.go
+++ b/tools/archtest/internal/dlxoutcomeredfixture/fixture.go
@@ -1,0 +1,51 @@
+//go:build archtest_fixture
+
+// Package dlxoutcomeredfixture is the red fixture for
+// MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2's scanner-fires self-check. It declares a
+// REPLICA of adapters/mqtt/internal/dlxoutcome.Outcome (an exported struct with
+// only a blank/unexported field — the sealed-proof-token shape) and plants the
+// two forge forms H2 must detect: an empty composite literal and a zero-value
+// `var` declaration.
+//
+// Why a replica and not the real dlxoutcome.Outcome: dlxoutcome lives under
+// adapters/mqtt/internal, and Go's internal-package rule forbids this tools-module
+// package from importing it. The replica lets the H2 scanner exercise the same
+// go/types composite-literal / var type-resolution path it runs over production —
+// which is the structural invariant H2 relies on. (Same replica rationale as
+// internal/mqttredfixture, whose real type is unexported-field-sealed.)
+//
+// Why not in-package (adapters/mqtt itself): the path-scoped allowlist guard
+// (#944) rejects the archtest_fixture tag in production paths because a production
+// file silently skipped by the default-tag scan is a fail-open vector. The
+// internal/ subtree here is the sanctioned home.
+//
+// ref: tools/archtest/mqtt_dlx_failure_signal_funnel_test.go TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture
+// ref: tools/archtest/internal/mqttredfixture/fixture.go (replica-fixture precedent)
+// ref: gh #1440 — MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01 Hard upgrade
+package dlxoutcomeredfixture
+
+// FixtureOutcome is a sealed-shape replica of dlxoutcome.Outcome: an exported
+// struct whose only field is a blank field of an unexported type. The H2 scanner
+// resolves composite-literal and var types by (package, name), so this replica
+// drives the identical resolution path as the real Outcome.
+type FixtureOutcome struct{ _ recordedToken }
+
+type recordedToken struct{}
+
+// archtestForgedOutcomeLiteral plants the empty composite-literal forge. The H2
+// scanner must report it — no consumer may mint an Outcome without going through a
+// recording constructor.
+//
+//nolint:unused // referenced exclusively by the archtest scanner via AST loading.
+func archtestForgedOutcomeLiteral() FixtureOutcome {
+	return FixtureOutcome{}
+}
+
+// archtestForgedOutcomeVar plants the zero-value `var` forge — invisible to a
+// composite-literal-only scan, which is exactly the second form H2 closes.
+//
+//nolint:unused // referenced exclusively by the archtest scanner via AST loading.
+func archtestForgedOutcomeVar() FixtureOutcome {
+	var o FixtureOutcome
+	return o
+}

--- a/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
+++ b/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
@@ -5,95 +5,69 @@
 // mqtt_dlx_failure_signal_funnel_test.go — the alertable dead-letter outcome
 // signal in (*Subscriber).routeDeadLetter can never be silently dropped.
 //
-// # Why this exists (gh #1356)
+// # Why this exists (gh #1356, hardened gh #1440)
 //
 // MQTT has no broker-native dead-letter exchange, so adapters/mqtt routes a
 // permanently-rejected / poison message to the app-level sink "$dead/<topic>".
 // When that $dead publish ITSELF fails (topic unmintable / broker publish error)
-// the message is acked-as-poison and dropped from the processing flow — a
-// deliberate fail-closed-and-drop (Kafka Connect KIP-298 model), because the
-// only no-loss alternative on MQTT (leave-unacked → reconnect-redeliver) would
-// reintroduce the paho strict-PUBACK-ordering head-of-line stall that ADR-050 §6
-// (Option C) avoids, and would infinitely re-loop a permanent Reject.
+// the message is acked-as-poison and dropped — a deliberate fail-closed-and-drop
+// (Kafka Connect KIP-298 model). Because the message IS dropped on $dead failure,
+// the ONLY operator-recovery hook is the alertable metric mqtt_dlx_failed_total
+// (RecordDeadLetterFailure). If a future edit removed that metric call from a drop
+// path, the drop would become silent and unrecoverable.
 //
-// Because the message IS dropped on $dead failure, the ONLY operator-recovery
-// hook is the alertable metric mqtt_dlx_failed_total (RecordDeadLetterFailure).
-// If a future edit removed that metric call from any drop path, the drop would
-// become silent and unrecoverable. This invariant makes that recovery signal a
-// machine-enforced contract: every exit path of routeDeadLetter MUST record a
-// dead-letter outcome — RecordDeadLetter on the success path, or
-// RecordDeadLetterFailure on every drop path. No silent exit.
+// # The mechanism (Hard, gh #1440)
 //
-// This is the enforceable spine of the #1356 resolution: literal no-loss is
-// unreachable at the MQTT transport layer (proven against Watermill / Spring
-// Kafka / Kafka Connect / autopaho — all achieve no-loss via a durable substrate
-// MQTT lacks), so the adapter contract is fail-closed-drop + alertable signal,
-// and THAT signal is what we lock here. True no-loss is relocated to the
-// consumer-cell transaction layer (deferred; see ADR-048 §threat-matrix amend).
+// routeDeadLetter does NOT record the metric inline. It RETURNS a sealed
+// dlxoutcome.Outcome whose only producers are dlxoutcome.Dropped (records the
+// alertable RecordDeadLetterFailure) and dlxoutcome.Captured (records the success
+// RecordDeadLetter). Because routeDeadLetter is typed to return Outcome, Go forces
+// every exit path to `return` one — and the only non-forged way to obtain one runs
+// a metric. A new drop branch that forgets the metric cannot produce an Outcome to
+// return → COMPILE ERROR. "Every exit records a metric" is therefore type-enforced,
+// not archtest-enforced. (This relocates the #1356 enforce spine from a same-block
+// control-flow scan to the Go type system.)
 //
-// # The invariant (A1)
+// # AI-robust grading (honest, per .claude/rules/gocell/ai-robust.md)
 //
-// In (*Subscriber).routeDeadLetter every *ast.ReturnStmt must be preceded —
-// within the statement list of its directly-enclosing *ast.BlockStmt — by a call
-// resolving to SubscriberCollector.RecordDeadLetterFailure (the alertable DROP
-// signal). routeDeadLetter is a void method whose success path falls through the
-// end (no ReturnStmt), so every explicit return IS a drop/failure exit and must
-// carry the failure signal. The success metric (RecordDeadLetter) deliberately
-// does NOT satisfy A1: crediting a drop return with the success signal would
-// record a dropped message as captured — silent message loss with a false
-// success count (review F1). A return with no preceding failure signal → diagnostic.
+//   - Hard (type system): no-silent-exit. A new routeDeadLetter exit cannot omit
+//     the metric without failing to compile (no Outcome to return). This is the
+//     highest-severity failure mode (an entire $dead drop going silent) and is what
+//     #1440 hardens. H1 pins the return type so a refactor back to a void
+//     routeDeadLetter (which removes the compile pressure) is caught.
+//   - Medium residual ① (shape guard, H2): the empty composite literal
+//     `dlxoutcome.Outcome{}` and a zero `var o dlxoutcome.Outcome` are still
+//     constructible from package mqtt — irreducible in Go (no "no zero value"
+//     modifier; same ceiling as internal/topicns sealed tokens). H2 bans both forms
+//     in mqtt production files.
+//   - Medium residual ② (F1 semantic, H3b): the type system forces SOME outcome
+//     metric per exit but cannot force the CORRECT one (it does not know which
+//     return is a drop). A drop branch wrongly using Captured would record a false
+//     success (review F1). H3b pins the `Captured` callsite count == 1 (the single
+//     success fall-through) and `Dropped` >= 1; a single-branch swap trips it. The
+//     per-path failure/success correctness is also covered behaviorally by
+//     deadletter_test.go.
 //
-// Covered form: metric-call-then-return in the SAME block (the idiom in
-// deadletter.go). A refactor that hoists the metric to an ancestor block before
-// the if is reported (fail-closed: keep the signal adjacent to the return). That
-// is a false-positive on a valid-but-unusual shape, NOT a missed bypass: the only
-// way to PASS is to have a metric call before the return in its block, so a
-// genuine silent drop (return with no metric anywhere) is always caught.
+// This is NOT a "drop -> failure metric is type-enforced" claim — that part stays
+// Medium (H3b + behavioral tests). The ADR must not overclaim.
 //
-// # AI-robust grading (per .claude/rules/gocell/ai-robust.md)
+// # Blind-spot inventory (per ai-robust.md 强制盲区自检)
 //
-// Medium. This is a single-axis structural invariant (a function-body
-// control-shape guard), NOT a funnel — there is no caller-allowlist downstream /
-// sealed-interface upstream split, so the §Funnel 双向锁评级 two-column format
-// does not apply. The detector is type-aware: callee identity is resolved via
-// go/types (ResolveMethodCall → *types.Func.FullName), so an import alias or a
-// same-named method on a different type does not match. Enforcement is
-// archtest-bound (Go cannot make "every exit records a metric" unrepresentable),
-// hence Medium not Hard.
-//
-// Hard-upgrade path: collapse the drop decision into a single typed sink helper
-// (e.g. routeDeadLetter returns a typed Outcome that the caller must record, or a
-// `func dropPoison(ctx, reason)` that wraps log+metric+return so the metric is
-// structurally inseparable from the drop). Then the metric call becomes
-// unrepresentable to omit. Tracked at gh #1440 (recorded in this package godoc
-// per ai-robust.md §Funnel 双向锁评级 "点名 issue 号").
-//
-// # Blind-spot inventory (per ai-robust.md §载体决策原则 强制盲区自检)
-//
-// The A1 scanner matches a metric call only as an *ast.ExprStmt wrapping a
-// *ast.CallExpr with a *ast.SelectorExpr callee. AST forms outside that coverage,
-// each with a reverse self-check below:
-//
-//   - B1 method-value: `f := s.collector.RecordDeadLetterFailure; f(ctx, r)` —
-//     the call site `f(...)` has no SelectorExpr callee, so A1 would not credit
-//     it. B1 asserts no method-value of RecordDeadLetter / RecordDeadLetterFailure
-//     is taken (non-call SelectorExpr) inside routeDeadLetter.
-//   - B2 defer: `defer s.collector.RecordDeadLetterFailure(ctx, r)` is a
-//     *ast.DeferStmt, not the *ast.ExprStmt A1 matches, so A1 would flag the
-//     return as silent (false-positive) — and a reader could "fix" it by moving
-//     the real signal into a defer, making the same-block scan blind. B2 asserts
-//     no defer of either signal method inside routeDeadLetter; the signal must be
-//     a direct same-block ExprStmt before the return so A1 can verify it.
-//   - Non-vacuity: A1NonVacuous asserts ≥2 ReturnStmt are seen and
-//     SignalsPresent asserts ≥1 RecordDeadLetter and ≥1 RecordDeadLetterFailure
-//     callsite resolve inside routeDeadLetter — so an empty/broken scan (wrong
-//     FullName, types resolution down) cannot vacuously pass.
+//   - empty-literal / zero-var forge → H2 (composite-lit + ValueSpec scan over mqtt
+//     production files). Proven non-vacuous by the dlxoutcomeredfixture synthetic
+//     red case, which uses a sealed-shape REPLICA (a real-type fixture is impossible:
+//     dlxoutcome is an internal package the tools module cannot import — same replica
+//     rationale as internal/mqttredfixture).
+//   - constructor gutted to a no-op → H3a (Dropped calls RecordDeadLetterFailure,
+//     Captured calls RecordDeadLetter; a metric-less constructor would defeat the
+//     seal while still compiling).
+//   - drop credited as success (F1) → H3b + deadletter_test.go behavioral tests.
 //
 // ref: gh #1356 — MQTT DLT no-loss (this invariant is the resolution's enforce spine)
-// ref: gh #1334 — bounded $dead retry (deferred, data-driven; out of scope here)
-// ref: ADR docs/architecture/202605281200-048-adr-mqtt-adapter.md §threat matrix ($dead publish failure row)
+// ref: gh #1440 — Hard upgrade (drop decision收口为 sealed dlxoutcome.Outcome)
+// ref: ADR docs/architecture/202605281200-048-adr-mqtt-adapter.md §threat matrix + Amendment 2026-06-11
 // ref: ADR docs/architecture/202605301200-050-adr-mqtt-requeue-semantics.md §6 (HoL / Option C)
-// ref: ai-robust.md §AI-robust 三档分级 (Medium structural invariant)
+// ref: ai-robust.md §Hard 范本 sealed construction
 package archtest
 
 import (
@@ -108,35 +82,36 @@ import (
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
-// routeDeadLetterFuncName is the method whose exit paths must each record a
-// dead-letter outcome metric. routeDeadLetterFullName is its go/types FullName,
-// used for exact identity (not a suffix) so a same-named method on a Subscriber
-// type in another package cannot satisfy the match.
+// mqttDLXOutcomePkgPath is the internal sub-package that owns the sealed
+// dlxoutcome.Outcome proof token + its recording constructors (gh #1440).
+const mqttDLXOutcomePkgPath = mqttPkgPath + "/internal/dlxoutcome"
+
+// dlxOutcomeRedFixturePkgPath is the archtest_fixture-gated red fixture proving
+// the H2 forbidden-construction scanner fires (sealed-shape replica).
+const dlxOutcomeRedFixturePkgPath = PlatformModulePath + "/tools/archtest/internal/dlxoutcomeredfixture"
+
+// routeDeadLetterFuncName / routeDeadLetterFullName identify the method whose
+// signature (H1) and constructor balance (H3b) are pinned. FullName gives exact
+// identity so a same-named method on a Subscriber in another package cannot match.
 const (
 	routeDeadLetterFuncName = "routeDeadLetter"
 	routeDeadLetterFullName = "(*github.com/ghbvf/gocell/adapters/mqtt.Subscriber).routeDeadLetter"
 )
 
-// SubscriberCollector method FullName()s resolved via ResolveMethodCall. These
-// are the two dead-letter outcome signals; RecordDeadLetterFailure is the
-// alertable drop signal (mqtt_dlx_failed_total), RecordDeadLetter the success
-// signal (mqtt_dlx_total).
+// dlxoutcome symbol names. Dropped/Captured are the sole sanctioned Outcome
+// producers; Outcome is the sealed return type. recordDLX* are the
+// SubscriberCollector method names the constructors must call (H3a).
 const (
-	recordDLXFailureFullName = "(github.com/ghbvf/gocell/adapters/mqtt.SubscriberCollector).RecordDeadLetterFailure"
-	recordDLXSuccessFullName = "(github.com/ghbvf/gocell/adapters/mqtt.SubscriberCollector).RecordDeadLetter"
+	dlxOutcomeTypeName     = "Outcome"
+	dlxDroppedFuncName     = "Dropped"
+	dlxCapturedFuncName    = "Captured"
+	recordDLXFailureMethod = "RecordDeadLetterFailure"
+	recordDLXSuccessMethod = "RecordDeadLetter"
 )
 
-// dlxSignalMethodNames is the selector-name set used by the B1 method-value
-// blind-spot scan (name-level reverse self-check; defense-in-depth).
-var dlxSignalMethodNames = map[string]bool{
-	"RecordDeadLetter":        true,
-	"RecordDeadLetterFailure": true,
-}
-
 // findRouteDeadLetter returns the FuncDecl of (*Subscriber).routeDeadLetter in
-// the given production file, or nil. Identity is confirmed via go/types: the
-// resolved object's FullName must be the routeDeadLetter method on *Subscriber,
-// so a same-named free function elsewhere does not match.
+// the given production file, or nil. Identity is confirmed via go/types so a
+// same-named free function elsewhere does not match.
 func findRouteDeadLetter(p *Pass, f *ast.File) *ast.FuncDecl {
 	var result *ast.FuncDecl
 	scanner.EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
@@ -149,13 +124,10 @@ func findRouteDeadLetter(p *Pass, f *ast.File) *ast.FuncDecl {
 		if fd.Recv == nil || len(fd.Recv.List) == 0 {
 			return
 		}
-		obj := p.TypesInfo.Defs[fd.Name]
-		fn, ok := obj.(*types.Func)
+		fn, ok := p.TypesInfo.Defs[fd.Name].(*types.Func)
 		if !ok {
 			return
 		}
-		// Exact FullName match (not HasSuffix): a same-named routeDeadLetter on a
-		// Subscriber type in any OTHER package would otherwise satisfy a suffix.
 		if fn.FullName() == routeDeadLetterFullName {
 			result = fd
 		}
@@ -163,122 +135,12 @@ func findRouteDeadLetter(p *Pass, f *ast.File) *ast.FuncDecl {
 	return result
 }
 
-// dlxStmtIsFailureSignal reports whether stmt is `<recv>.RecordDeadLetterFailure(...)`
-// resolving (via go/types) to the SubscriberCollector method — i.e., the alertable
-// DROP signal. It deliberately does NOT accept RecordDeadLetter (the success
-// signal): in routeDeadLetter every explicit return is a drop/failure exit (the
-// success path falls through the end with no return), so a return credited by the
-// SUCCESS metric would record a dropped message as captured — the exact silent-loss
-// regression this invariant exists to forbid (review F1).
-func dlxStmtIsFailureSignal(info *types.Info, stmt ast.Stmt) bool {
-	es, ok := stmt.(*ast.ExprStmt)
-	if !ok {
-		return false
-	}
-	call, ok := es.X.(*ast.CallExpr)
-	if !ok {
-		return false
-	}
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return false
-	}
-	fn, ok := ResolveMethodCall(info, sel)
-	if !ok || fn == nil {
-		return false
-	}
-	return fn.FullName() == recordDLXFailureFullName
-}
-
-// blockReturnPrecededByFailureSignal reports whether some statement preceding
-// ret in the SAME block (by source position) is a dead-letter FAILURE signal.
-// Extracted from the EachInChildren callback so the callback carries no
-// found/done sentinel flag (SCANNER-FRAMEWORK-USAGE-02). The scan is a raw
-// position-bounded range over block.List (no type assertion), not an Each*
-// walker, so it is outside both SCANNER-FRAMEWORK-USAGE sub-rules.
-func blockReturnPrecededByFailureSignal(info *types.Info, block *ast.BlockStmt, ret *ast.ReturnStmt) bool {
-	for _, prev := range block.List {
-		if prev.Pos() >= ret.Pos() {
-			break
-		}
-		if dlxStmtIsFailureSignal(info, prev) {
-			return true
-		}
-	}
-	return false
-}
-
-// scanRouteDeadLetterReturns walks every BlockStmt in routeDeadLetter and, for
-// each ReturnStmt, checks that some earlier statement in the SAME block is a
-// dead-letter outcome metric. Returns diagnostics for silent returns plus the
-// total ReturnStmt count (for the non-vacuous companion).
-func scanRouteDeadLetterReturns(p *Pass, f *ast.File, fd *ast.FuncDecl) ([]Diagnostic, int) {
-	var diags []Diagnostic
-	var returnCount int
-	// EachInSubtree[BlockStmt] visits every block at any depth (matches the old
-	// ast.Inspect walk); EachInChildren[ReturnStmt] is depth-1 — correct because
-	// a ReturnStmt is always a direct child of its enclosing block, which is the
-	// "same block" the preceding-signal check requires.
-	scanner.EachInSubtree[ast.BlockStmt](fd.Body, func(block *ast.BlockStmt) {
-		scanner.EachInChildren[ast.ReturnStmt](block, func(ret *ast.ReturnStmt) {
-			returnCount++
-			// A return preceded (same block) by a failure-signal statement is
-			// compliant; skip it. The preceding-statement scan lives in a helper
-			// so this callback holds no found/done sentinel flag
-			// (SCANNER-FRAMEWORK-USAGE-02).
-			if blockReturnPrecededByFailureSignal(p.TypesInfo, block, ret) {
-				return
-			}
-			pos := p.Fset.Position(ret.Pos())
-			rel := p.Rel(f)
-			diags = append(diags, Diagnostic{
-				Rel:  rel,
-				Line: pos.Line,
-				Message: fmt.Sprintf(
-					"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/A1: return in routeDeadLetter at %s:%d "+
-						"is not preceded (same block) by RecordDeadLetterFailure — a $dead drop path "+
-						"must record the alertable FAILURE signal (RecordDeadLetter success metric does "+
-						"NOT count: crediting a drop as captured is silent message loss)",
-					rel, pos.Line,
-				),
-			})
-		})
-	})
-	return diags, returnCount
-}
-
-// countRouteDeadLetterSignals returns the number of resolved RecordDeadLetter
-// and RecordDeadLetterFailure callsites inside routeDeadLetter.
-func countRouteDeadLetterSignals(p *Pass, fd *ast.FuncDecl) (success, failure int) {
-	EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		fn, ok := ResolveMethodCall(p.TypesInfo, sel)
-		if !ok || fn == nil {
-			return
-		}
-		switch fn.FullName() {
-		case recordDLXSuccessFullName:
-			success++
-		case recordDLXFailureFullName:
-			failure++
-		}
-	})
-	return success, failure
-}
-
 // withRouteDeadLetter loads the adapters/mqtt production package and invokes fn
-// with the routeDeadLetter FuncDecl (and its file/Pass). It fails the test if
-// routeDeadLetter is not found, so a rename cannot silently disable the rule.
+// with the routeDeadLetter FuncDecl. It fails the test if routeDeadLetter is not
+// found, so a rename cannot silently disable the rule.
 func withRouteDeadLetter(t *testing.T, fn func(p *Pass, f *ast.File, fd *ast.FuncDecl)) {
 	t.Helper()
 	found := false
-	// FlatNonDefaultTags excludes the integration tag: adapters/mqtt production
-	// files (deadletter.go etc.) carry no special build constraint, so the
-	// default+flat tag set loads routeDeadLetter. If it ever moves behind a tag,
-	// the found==false assertion below fails loudly (rule cannot go vacuous).
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		[]string{mqttPkgPath}),
 		func(p *Pass) []Diagnostic {
@@ -298,129 +160,257 @@ func withRouteDeadLetter(t *testing.T, fn func(p *Pass, f *ast.File, fd *ast.Fun
 			}
 			return nil
 		})
-
 	assert.True(t, found,
 		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01: (*Subscriber).routeDeadLetter not found in adapters/mqtt "+
 			"production AST — the rule target was renamed/removed; update this archtest")
 }
 
-// ─── A1: every routeDeadLetter return records a dead-letter outcome ───────────
+// ─── H1: routeDeadLetter returns the sealed dlxoutcome.Outcome ────────────────
 
-func TestMQTTDLXFailureSignalFunnel_A1_NoSilentReturn(t *testing.T) {
-	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based archtest in -short mode")
-	}
-	withRouteDeadLetter(t, func(p *Pass, f *ast.File, fd *ast.FuncDecl) {
-		diags, _ := scanRouteDeadLetterReturns(p, f, fd)
-		assert.Empty(t, diags,
-			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/A1: routeDeadLetter has a return path with no "+
-				"preceding dead-letter outcome metric (silent $dead drop)")
-	})
-}
-
-func TestMQTTDLXFailureSignalFunnel_A1_NonVacuous(t *testing.T) {
-	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based archtest in -short mode")
-	}
-	withRouteDeadLetter(t, func(p *Pass, f *ast.File, fd *ast.FuncDecl) {
-		_, returnCount := scanRouteDeadLetterReturns(p, f, fd)
-		assert.GreaterOrEqual(t, returnCount, 2,
-			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/A1: scanner found <2 returns in routeDeadLetter — "+
-				"there are two drop branches (mint failure + publish failure); the AST walk may be broken")
-	})
-}
-
-// ─── A2: both outcome signals are wired (non-vacuous resolution) ──────────────
-
-func TestMQTTDLXFailureSignalFunnel_A2_SignalsPresent(t *testing.T) {
+func TestMQTTDLXFailureSignalFunnel_H1_ReturnsSealedOutcome(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 	withRouteDeadLetter(t, func(p *Pass, _ *ast.File, fd *ast.FuncDecl) {
-		success, failure := countRouteDeadLetterSignals(p, fd)
-		assert.GreaterOrEqual(t, failure, 1,
-			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/A2: no resolved RecordDeadLetterFailure callsite in "+
-				"routeDeadLetter — the alertable drop signal is missing or the FullName drifted")
-		assert.GreaterOrEqual(t, success, 1,
-			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/A2: no resolved RecordDeadLetter callsite in "+
-				"routeDeadLetter — the success signal is missing or the FullName drifted")
+		fn, ok := p.TypesInfo.Defs[fd.Name].(*types.Func)
+		if !assert.True(t, ok, "routeDeadLetter has no *types.Func definition") {
+			return
+		}
+		sig, ok := fn.Type().(*types.Signature)
+		if !assert.True(t, ok, "routeDeadLetter is not a *types.Signature") {
+			return
+		}
+		if !assert.Equal(t, 1, sig.Results().Len(),
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H1: routeDeadLetter must return exactly one value "+
+				"(dlxoutcome.Outcome) — a void routeDeadLetter removes the compile pressure that makes "+
+				"the metric structurally inseparable from the drop (gh #1440)") {
+			return
+		}
+		named, ok := sig.Results().At(0).Type().(*types.Named)
+		if !assert.True(t, ok, "routeDeadLetter result is not a named type") {
+			return
+		}
+		obj := named.Obj()
+		assert.True(t,
+			obj.Pkg() != nil && obj.Pkg().Path() == mqttDLXOutcomePkgPath && obj.Name() == dlxOutcomeTypeName,
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H1: routeDeadLetter must return %s.%s, got %s",
+			mqttDLXOutcomePkgPath, dlxOutcomeTypeName, named.String())
 	})
 }
 
-// ─── B1: method-value blind-spot reverse self-check ──────────────────────────
+// ─── H2: no mqtt code forges a dlxoutcome.Outcome ─────────────────────────────
 
-func TestMQTTDLXFailureSignalFunnel_B1_NoMethodValue(t *testing.T) {
+// dlxIsOutcomeType reports whether expr's resolved type is (pkgPath, typeName).
+func dlxIsOutcomeType(info *types.Info, expr ast.Expr, pkgPath, typeName string) bool {
+	if expr == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	if !ok {
+		return false
+	}
+	named, ok := tv.Type.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Pkg() != nil && obj.Pkg().Path() == pkgPath && obj.Name() == typeName
+}
+
+// scanForbiddenOutcomeConstruction flags every in-package construction of the
+// sealed (pkgPath, typeName) Outcome token in file: a composite literal of ANY
+// shape (INCLUDING the empty `Outcome{}` — unlike scanSealedCompositeLitConstruction
+// which exempts empty literals) and a zero-value `var o Outcome` declaration. In
+// the dead-letter funnel NO consumer may mint an Outcome; the only sanctioned
+// producers are dlxoutcome.Dropped/Captured (which record a metric) and they live
+// in the dlxoutcome package itself (not scanned here). This closes the irreducible
+// empty-literal forge the type system cannot forbid (residual Medium per the godoc).
+func scanForbiddenOutcomeConstruction(p *Pass, f *ast.File, rel, pkgPath, typeName string) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.CompositeLit](f, func(lit *ast.CompositeLit) {
+		if !dlxIsOutcomeType(p.TypesInfo, lit.Type, pkgPath, typeName) {
+			return
+		}
+		pos := p.Fset.Position(lit.Pos())
+		out = append(out, Diagnostic{Rel: rel, Line: pos.Line, Message: fmt.Sprintf(
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: %s composite literal at %s:%d — no mqtt code may "+
+				"mint a dlxoutcome.Outcome; obtain it only from dlxoutcome.Dropped/Captured (which "+
+				"record the alertable metric)", typeName, rel, pos.Line)})
+	})
+	EachInSubtree[ast.ValueSpec](f, func(vs *ast.ValueSpec) {
+		if vs.Type == nil || len(vs.Values) > 0 {
+			return
+		}
+		if !dlxIsOutcomeType(p.TypesInfo, vs.Type, pkgPath, typeName) {
+			return
+		}
+		pos := p.Fset.Position(vs.Pos())
+		out = append(out, Diagnostic{Rel: rel, Line: pos.Line, Message: fmt.Sprintf(
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: zero-value `var %s` at %s:%d — a forged Outcome "+
+				"bypasses the recording constructors; obtain it only from dlxoutcome.Dropped/Captured",
+			typeName, rel, pos.Line)})
+	})
+	return out
+}
+
+func TestMQTTDLXFailureSignalFunnel_H2_NoOutcomeForgeInMQTT(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
-	withRouteDeadLetter(t, func(p *Pass, f *ast.File, fd *ast.FuncDecl) {
-		// Collect SelectorExprs used as a call callee (allowed); any OTHER
-		// SelectorExpr selecting a dlx signal method is a method-value escape.
-		callFun := map[*ast.SelectorExpr]bool{}
-		EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
-			if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-				callFun[sel] = true
+	seen := false
+	diags := Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttPkgPath}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
+				return nil
 			}
-		})
-		var diags []Diagnostic
-		EachInSubtree[ast.SelectorExpr](fd.Body, func(sel *ast.SelectorExpr) {
-			if sel.Sel == nil || !dlxSignalMethodNames[sel.Sel.Name] || callFun[sel] {
-				return
+			seen = true
+			var out []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				out = append(out, scanForbiddenOutcomeConstruction(p, f, rel, mqttDLXOutcomePkgPath, dlxOutcomeTypeName)...)
 			}
-			pos := p.Fset.Position(sel.Pos())
-			rel := p.Rel(f)
-			diags = append(diags, Diagnostic{
-				Rel:  rel,
-				Line: pos.Line,
-				Message: fmt.Sprintf(
-					"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/B1: dead-letter signal method %q taken as a "+
-						"method-value at %s:%d — A1 cannot credit an indirect call; call it directly",
-					sel.Sel.Name, rel, pos.Line,
-				),
-			})
+			return out
 		})
-		assert.Empty(t, diags,
-			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/B1: dead-letter signal method taken as a method-value")
-	})
+	assert.True(t, seen, "MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: adapters/mqtt production package not loaded")
+	assert.Empty(t, diags,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: mqtt forges a dlxoutcome.Outcome — see diagnostics")
 }
 
-// ─── B2: defer blind-spot reverse self-check ─────────────────────────────────
-
-// TestMQTTDLXFailureSignalFunnel_B2_NoDeferSignal asserts no dead-letter signal
-// method is invoked via `defer` inside routeDeadLetter. A1 only credits a
-// same-block *ast.ExprStmt before the return; a defer (*ast.DeferStmt) would both
-// (a) make A1 false-positive a return it actually covers, and (b) let a reader
-// relocate the real signal out of A1's same-block view. Banning defer keeps the
-// signal a direct, A1-verifiable same-block statement.
-func TestMQTTDLXFailureSignalFunnel_B2_NoDeferSignal(t *testing.T) {
+// TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture proves the H2 scanner
+// is non-vacuous: it MUST report the planted forge in the sealed-shape replica
+// fixture. Without this, a silently-broken type-resolution path would let H2 pass
+// vacuously (production has no forge).
+func TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
-	withRouteDeadLetter(t, func(p *Pass, f *ast.File, fd *ast.FuncDecl) {
-		var diags []Diagnostic
-		EachInSubtree[ast.DeferStmt](fd.Body, func(d *ast.DeferStmt) {
-			sel, ok := d.Call.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel == nil || !dlxSignalMethodNames[sel.Sel.Name] {
-				return
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{dlxOutcomeRedFixturePkgPath}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != dlxOutcomeRedFixturePkgPath {
+				return nil
 			}
-			pos := p.Fset.Position(d.Pos())
-			rel := p.Rel(f)
-			diags = append(diags, Diagnostic{
-				Rel:  rel,
-				Line: pos.Line,
-				Message: fmt.Sprintf(
-					"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/B2: dead-letter signal method %q invoked via defer "+
-						"at %s:%d — A1 verifies a direct same-block ExprStmt before the return; call it directly",
-					sel.Sel.Name, rel, pos.Line,
-				),
-			})
+			var out []Diagnostic
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				if strings.HasSuffix(rel, "_test.go") {
+					continue
+				}
+				out = append(out, scanForbiddenOutcomeConstruction(p, f, rel, dlxOutcomeRedFixturePkgPath, "FixtureOutcome")...)
+			}
+			return out
 		})
-		assert.Empty(t, diags,
-			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/B2: dead-letter signal method invoked via defer in routeDeadLetter")
+	assert.NotEmpty(t, diags,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on the dlxoutcomeredfixture forge — "+
+			"if empty, the composite-lit/var type-resolution path is silently broken")
+}
+
+// ─── H3a: the dlxoutcome constructors actually record (inseparability spine) ──
+
+// dlxConstructorCallsMethod reports whether fd's body contains a call whose
+// selector name is method. The receiver is the anonymous-interface `rec` param,
+// so its FullName() is not a stable mqtt name — a name-level match is the
+// deliberate (documented) choice, safe because the dlxoutcome package's only
+// selector calls are these two collector methods.
+func dlxConstructorCallsMethod(fd *ast.FuncDecl, method string) bool {
+	found := false
+	EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel != nil && sel.Sel.Name == method {
+			found = true
+		}
+	})
+	return found
+}
+
+func TestMQTTDLXFailureSignalFunnel_H3a_ConstructorsRecord(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	seen := false
+	var foundDropped, foundCaptured, droppedRecords, capturedRecords bool
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttDLXOutcomePkgPath}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttDLXOutcomePkgPath {
+				return nil
+			}
+			seen = true
+			for _, f := range p.Files {
+				if strings.HasSuffix(p.Rel(f), "_test.go") {
+					continue
+				}
+				scanner.EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+					if fd.Body == nil || fd.Name == nil {
+						return
+					}
+					switch fd.Name.Name {
+					case dlxDroppedFuncName:
+						foundDropped = true
+						droppedRecords = dlxConstructorCallsMethod(fd, recordDLXFailureMethod)
+					case dlxCapturedFuncName:
+						foundCaptured = true
+						capturedRecords = dlxConstructorCallsMethod(fd, recordDLXSuccessMethod)
+					}
+				})
+			}
+			return nil
+		})
+	assert.True(t, seen,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3a: %s package not loaded — gh #1440 mechanism missing", mqttDLXOutcomePkgPath)
+	assert.True(t, foundDropped, "MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3a: dlxoutcome.Dropped not found")
+	assert.True(t, foundCaptured, "MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3a: dlxoutcome.Captured not found")
+	assert.True(t, droppedRecords,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3a: dlxoutcome.Dropped must call RecordDeadLetterFailure "+
+			"(a no-op constructor would defeat the seal while still compiling)")
+	assert.True(t, capturedRecords,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3a: dlxoutcome.Captured must call RecordDeadLetter")
+}
+
+// ─── H3b: F1 semantic balance — one success exit, ≥1 drop exit ────────────────
+
+// dlxCountConstructorCalls counts dlxoutcome.Captured and dlxoutcome.Dropped
+// callsites inside fd. They are package-level funcs, so the callee is resolved
+// via Uses (not ResolveMethodCall, which is for value-receiver method calls).
+func dlxCountConstructorCalls(p *Pass, fd *ast.FuncDecl) (captured, dropped int) {
+	EachInSubtree[ast.CallExpr](fd.Body, func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil {
+			return
+		}
+		obj, ok := p.TypesInfo.Uses[sel.Sel].(*types.Func)
+		if !ok || obj.Pkg() == nil || obj.Pkg().Path() != mqttDLXOutcomePkgPath {
+			return
+		}
+		switch obj.Name() {
+		case dlxCapturedFuncName:
+			captured++
+		case dlxDroppedFuncName:
+			dropped++
+		}
+	})
+	return captured, dropped
+}
+
+func TestMQTTDLXFailureSignalFunnel_H3b_OutcomeConstructorBalance(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	withRouteDeadLetter(t, func(p *Pass, _ *ast.File, fd *ast.FuncDecl) {
+		captured, dropped := dlxCountConstructorCalls(p, fd)
+		assert.Equal(t, 1, captured,
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3b: routeDeadLetter must have exactly one "+
+				"dlxoutcome.Captured callsite (the single success fall-through) — a drop branch wrongly "+
+				"credited as success (review F1) makes this 2; a success path wrongly dropped makes it 0")
+		assert.GreaterOrEqual(t, dropped, 1,
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3b: routeDeadLetter must have ≥1 dlxoutcome.Dropped "+
+				"callsite (the alertable failure exits)")
 	})
 }

--- a/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
+++ b/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
@@ -58,9 +58,17 @@
 //     red case, which uses a sealed-shape REPLICA (a real-type fixture is impossible:
 //     dlxoutcome is an internal package the tools module cannot import — same replica
 //     rationale as internal/mqttredfixture).
+//   - new(T) allocation forge → `*new(dlxoutcome.Outcome)` / `var o = *new(...)` produce a
+//     zero Outcome with neither a composite literal nor a typed zero-var, so H2 does not
+//     see them. Irreducible in Go (same ceiling as the empty literal) and equally vacuous;
+//     accepted residual, flagged so it is not mistaken for covered (not a closed hole).
 //   - constructor gutted to a no-op → H3a (Dropped calls RecordDeadLetterFailure,
 //     Captured calls RecordDeadLetter; a metric-less constructor would defeat the
 //     seal while still compiling).
+//   - H3a name-level match → H3a matches the recording call by selector NAME (rec is an
+//     anonymous interface, so FullName is not a stable mqtt symbol). A future homonymous
+//     method in the (tiny) dlxoutcome package would yield a false-POSITIVE (over-credit),
+//     never a false-negative; H3b + behavioral tests stay valid regardless.
 //   - drop credited as success (F1) → H3b + deadletter_test.go behavioral tests.
 //
 // ref: gh #1356 — MQTT DLT no-loss (this invariant is the resolution's enforce spine)
@@ -162,7 +170,8 @@ func withRouteDeadLetter(t *testing.T, fn func(p *Pass, f *ast.File, fd *ast.Fun
 		})
 	assert.True(t, found,
 		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01: (*Subscriber).routeDeadLetter not found in adapters/mqtt "+
-			"production AST — the rule target was renamed/removed; update this archtest")
+			"production AST — the rule target was renamed/removed; update routeDeadLetterFuncName + "+
+			"routeDeadLetterFullName in this file")
 }
 
 // ─── H1: routeDeadLetter returns the sealed dlxoutcome.Outcome ────────────────
@@ -306,9 +315,12 @@ func TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture(t *testing.T) {
 			}
 			return out
 		})
-	assert.NotEmpty(t, diags,
-		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on the dlxoutcomeredfixture forge — "+
-			"if empty, the composite-lit/var type-resolution path is silently broken")
+	// The fixture plants BOTH forge forms (empty composite literal + zero-value var),
+	// so require ≥2 diagnostics: if only one fires, one of the two scan paths
+	// (CompositeLit vs ValueSpec) is silently broken.
+	assert.GreaterOrEqual(t, len(diags), 2,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on BOTH dlxoutcomeredfixture forge forms "+
+			"(empty composite literal + zero-value var); <2 means a composite-lit/var type-resolution path is silently broken")
 }
 
 // ─── H3a: the dlxoutcome constructors actually record (inseparability spine) ──

--- a/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
+++ b/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
@@ -16,52 +16,66 @@
 // (RecordDeadLetterFailure). If a future edit removed that metric call from a drop
 // path, the drop would become silent and unrecoverable.
 //
-// # The mechanism (Hard, gh #1440)
+// # The mechanism (sealed-construction funnel + type floor, gh #1440)
 //
 // routeDeadLetter does NOT record the metric inline. It RETURNS a sealed
-// dlxoutcome.Outcome whose only producers are dlxoutcome.Dropped (records the
-// alertable RecordDeadLetterFailure) and dlxoutcome.Captured (records the success
-// RecordDeadLetter). Because routeDeadLetter is typed to return Outcome, Go forces
-// every exit path to `return` one — and the only non-forged way to obtain one runs
-// a metric. A new drop branch that forgets the metric cannot produce an Outcome to
-// return → COMPILE ERROR. "Every exit records a metric" is therefore type-enforced,
-// not archtest-enforced. (This relocates the #1356 enforce spine from a same-block
-// control-flow scan to the Go type system.)
+// dlxoutcome.Outcome whose only sanctioned producers are dlxoutcome.Dropped
+// (records the alertable RecordDeadLetterFailure) and dlxoutcome.Captured (records
+// the success RecordDeadLetter). The type system contributes a FLOOR: because
+// routeDeadLetter is typed to return Outcome, every exit must `return` SOME Outcome
+// value — a bare `return` is a compile error. But the type system stops there: it
+// does NOT prove the returned Outcome came from a recording path. A stateless proof
+// token has a zero value that is always constructible (Outcome{}, var o, *new(T), …),
+// so a drop branch CAN forget the metric and still compile by forging a zero value.
+// What closes that gap is the archtest funnel: H2 forbids mqtt forging an Outcome
+// (composite-lit / zero-var / new), H4 forbids dlxoutcome gaining a non-recording
+// producer, H3a checks the two constructors actually record. Floor (H1) + funnel
+// (H2/H4/H3a) ⇒ every Outcome routeDeadLetter returns came from a recording
+// constructor. This is a stronger, sealed-construction form of the #1356 enforce
+// spine — but the closure is archtest, hence Medium (§grading), NOT the literal
+// "metric omission is a compile error" the type system cannot deliver.
 //
 // # AI-robust grading (honest, per .claude/rules/gocell/ai-robust.md)
 //
-//   - Hard (type system): no-silent-exit. A new routeDeadLetter exit cannot omit
-//     the metric without failing to compile (no Outcome to return). This is the
-//     highest-severity failure mode (an entire $dead drop going silent) and is what
-//     #1440 hardens. H1 pins the return type so a refactor back to a void
-//     routeDeadLetter (which removes the compile pressure) is caught.
-//   - Medium residual ① (shape guard, H2): the empty composite literal
-//     `dlxoutcome.Outcome{}` and a zero `var o dlxoutcome.Outcome` are still
-//     constructible from package mqtt — irreducible in Go (no "no zero value"
-//     modifier; same ceiling as internal/topicns sealed tokens). H2 bans both forms
-//     in mqtt production files.
-//   - Medium residual ② (F1 semantic, H3b): the type system forces SOME outcome
-//     metric per exit but cannot force the CORRECT one (it does not know which
-//     return is a drop). A drop branch wrongly using Captured would record a false
-//     success (review F1). H3b pins the `Captured` callsite count == 1 (the single
-//     success fall-through) and `Dropped` >= 1; a single-branch swap trips it. The
-//     per-path failure/success correctness is also covered behaviorally by
+// Medium — a sealed-construction funnel with a type-system floor. Per the
+// ai-robust carrier table, archtest typed scan = Medium; the closure of this
+// invariant is archtest (H2/H4/H3a), so the whole no-silent-exit axis is Medium,
+// NOT Hard. Genuine type-system Hard is unreachable here: it would require proving
+// a SIDE EFFECT (the metric was recorded) happened on every exit, but Go can only
+// prove a VALUE of type Outcome was produced — and a stateless token's zero value
+// is always constructible (no "no zero value" modifier), so the value carries no
+// proof of the side effect. Contrast genuinely-Hard sealed construction
+// (mqtt.ClientID, internal/topicns): those seal a MEANINGFUL unexported field, so a
+// contentful value is package-external compile-gated. Outcome has no state to seal.
+//
+//   - Type floor (Hard sub-property, H1): routeDeadLetter must return an Outcome —
+//     a bare `return` / a refactor back to a void routeDeadLetter is a compile error
+//     caught by H1. This raises the bar (a silent drop must actively FORGE a zero
+//     value) but does not by itself enforce the metric.
+//   - Completion (Medium, H2 + H4 + H3a): H2 forbids mqtt forging an Outcome
+//     (composite-lit / zero-var / new); H4 forbids dlxoutcome gaining a non-recording
+//     producer; H3a checks Dropped/Captured actually record. Together these close the
+//     "the Outcome came from a recording path" gap the type floor leaves open.
+//   - F1 semantic (Medium, H3b + behavioral): the floor forces SOME outcome per exit
+//     but not the CORRECT one. A drop branch wrongly using Captured records a false
+//     success (review F1). H3b pins the Captured callsite count == 1 (single success
+//     fall-through) and Dropped >= 1; per-path correctness is also covered by
 //     deadletter_test.go.
 //
-// This is NOT a "drop -> failure metric is type-enforced" claim — that part stays
-// Medium (H3b + behavioral tests). The ADR must not overclaim.
+// The ADR / ops / dlxoutcome godoc must NOT claim "metric omission is a compile
+// error" or "type-system Hard" — that is the overclaim corrected in gh #1873 F1.
 //
 // # Blind-spot inventory (per ai-robust.md 强制盲区自检)
 //
-//   - empty-literal / zero-var forge → H2 (composite-lit + ValueSpec scan over mqtt
-//     production files). Proven non-vacuous by the dlxoutcomeredfixture synthetic
-//     red case, which uses a sealed-shape REPLICA (a real-type fixture is impossible:
+//   - composite-lit / zero-var / new(T) forge in mqtt → H2 (CompositeLit + ValueSpec +
+//     new-builtin scan over mqtt production files). All three are enumerable AST forms.
+//     Proven non-vacuous by the dlxoutcomeredfixture synthetic red case (three planted
+//     forges), which uses a sealed-shape REPLICA (a real-type fixture is impossible:
 //     dlxoutcome is an internal package the tools module cannot import — same replica
 //     rationale as internal/mqttredfixture).
-//   - new(T) allocation forge → `*new(dlxoutcome.Outcome)` / `var o = *new(...)` produce a
-//     zero Outcome with neither a composite literal nor a typed zero-var, so H2 does not
-//     see them. Irreducible in Go (same ceiling as the empty literal) and equally vacuous;
-//     accepted residual, flagged so it is not mistaken for covered (not a closed hole).
+//   - non-recording third producer in dlxoutcome → H4 (sole-producer allowlist =
+//     {Dropped, Captured}). Proven non-vacuous by the same red fixture, whose three
+//     planted functions return the replica Outcome but are not Dropped/Captured.
 //   - constructor gutted to a no-op → H3a (Dropped calls RecordDeadLetterFailure,
 //     Captured calls RecordDeadLetter; a metric-less constructor would defeat the
 //     seal while still compiling).
@@ -70,12 +84,19 @@
 //     method in the (tiny) dlxoutcome package would yield a false-POSITIVE (over-credit),
 //     never a false-negative; H3b + behavioral tests stay valid regardless.
 //   - drop credited as success (F1) → H3b + deadletter_test.go behavioral tests.
+//   - ACCEPTED RESIDUAL (the Medium ceiling, gh #1873 F1): open-set zero-value
+//     extraction — a zero Outcome pulled from an array/map element, reflect.Zero, or an
+//     IIFE — is not an enumerable AST forge form, so neither H2 nor any archtest can
+//     bound it. This is precisely why no-silent-exit is Medium, not Hard: the type
+//     system cannot forbid zero values and the forge surface is open-ended. Flagged so
+//     it is not mistaken for a closed hole.
 //
 // ref: gh #1356 — MQTT DLT no-loss (this invariant is the resolution's enforce spine)
-// ref: gh #1440 — Hard upgrade (drop decision收口为 sealed dlxoutcome.Outcome)
+// ref: gh #1440 — sealed dlxoutcome.Outcome funnel (drop decision 收口为 sealed token)
+// ref: gh #1873 — F1: no-silent-exit is Medium (funnel), not Hard; new(T) + sole-producer closed
 // ref: ADR docs/architecture/202605281200-048-adr-mqtt-adapter.md §threat matrix + Amendment 2026-06-11
 // ref: ADR docs/architecture/202605301200-050-adr-mqtt-requeue-semantics.md §6 (HoL / Option C)
-// ref: ai-robust.md §Hard 范本 sealed construction
+// ref: ai-robust.md §Hard 范本 sealed construction (pattern followed; graded Medium — stateless token)
 package archtest
 
 import (
@@ -228,13 +249,20 @@ func dlxIsOutcomeType(info *types.Info, expr ast.Expr, pkgPath, typeName string)
 }
 
 // scanForbiddenOutcomeConstruction flags every in-package construction of the
-// sealed (pkgPath, typeName) Outcome token in file: a composite literal of ANY
-// shape (INCLUDING the empty `Outcome{}` — unlike scanSealedCompositeLitConstruction
-// which exempts empty literals) and a zero-value `var o Outcome` declaration. In
-// the dead-letter funnel NO consumer may mint an Outcome; the only sanctioned
-// producers are dlxoutcome.Dropped/Captured (which record a metric) and they live
-// in the dlxoutcome package itself (not scanned here). This closes the irreducible
-// empty-literal forge the type system cannot forbid (residual Medium per the godoc).
+// sealed (pkgPath, typeName) Outcome token in file via the three enumerable
+// zero-value forge forms: a composite literal of ANY shape (INCLUDING the empty
+// `Outcome{}` — unlike scanSealedCompositeLitConstruction which exempts empty
+// literals), a zero-value `var o Outcome` declaration, and a `*new(Outcome)`
+// allocation. In the dead-letter funnel NO consumer may mint an Outcome; the only
+// sanctioned producers are dlxoutcome.Dropped/Captured (which record a metric) and
+// they live in the dlxoutcome package itself (locked by H4, not scanned here).
+//
+// These three are the enumerable forge forms; the genuinely-irreducible residual
+// (open-set zero-value extraction: array/map element, reflect.Zero, an IIFE) is
+// what keeps the no-silent-exit axis Medium, not Hard (see the package godoc
+// §grading). The type floor only forces routeDeadLetter to return SOME Outcome;
+// that it came from a recording path is closed by this scan (H2) + the
+// sole-producer guard (H4), both archtest.
 func scanForbiddenOutcomeConstruction(p *Pass, f *ast.File, rel, pkgPath, typeName string) []Diagnostic {
 	var out []Diagnostic
 	EachInSubtree[ast.CompositeLit](f, func(lit *ast.CompositeLit) {
@@ -257,6 +285,25 @@ func scanForbiddenOutcomeConstruction(p *Pass, f *ast.File, rel, pkgPath, typeNa
 		pos := p.Fset.Position(vs.Pos())
 		out = append(out, Diagnostic{Rel: rel, Line: pos.Line, Message: fmt.Sprintf(
 			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: zero-value `var %s` at %s:%d — a forged Outcome "+
+				"bypasses the recording constructors; obtain it only from dlxoutcome.Dropped/Captured",
+			typeName, rel, pos.Line)})
+	})
+	// new(Outcome) / *new(Outcome): the builtin new has no package object in
+	// TypesInfo.Uses, so identify it by name — no user-defined func may be named
+	// `new` in Go (same pattern as reconcile.Loop's new(T) guard,
+	// reconcile_invariants_test.go). Closes the new(T) forge (gh #1873 review F1):
+	// it is enumerable, not an irreducible residual.
+	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || id.Name != "new" || len(call.Args) != 1 {
+			return
+		}
+		if !dlxIsOutcomeType(p.TypesInfo, call.Args[0], pkgPath, typeName) {
+			return
+		}
+		pos := p.Fset.Position(call.Pos())
+		out = append(out, Diagnostic{Rel: rel, Line: pos.Line, Message: fmt.Sprintf(
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: new(%s) at %s:%d — a forged zero Outcome "+
 				"bypasses the recording constructors; obtain it only from dlxoutcome.Dropped/Captured",
 			typeName, rel, pos.Line)})
 	})
@@ -315,12 +362,12 @@ func TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture(t *testing.T) {
 			}
 			return out
 		})
-	// The fixture plants BOTH forge forms (empty composite literal + zero-value var),
-	// so require ≥2 diagnostics: if only one fires, one of the two scan paths
-	// (CompositeLit vs ValueSpec) is silently broken.
-	assert.GreaterOrEqual(t, len(diags), 2,
-		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on BOTH dlxoutcomeredfixture forge forms "+
-			"(empty composite literal + zero-value var); <2 means a composite-lit/var type-resolution path is silently broken")
+	// The fixture plants ALL THREE forge forms (empty composite literal + zero-value
+	// var + *new(T) allocation), so require ≥3 diagnostics: if fewer fire, one of the
+	// three scan paths (CompositeLit / ValueSpec / new-builtin) is silently broken.
+	assert.GreaterOrEqual(t, len(diags), 3,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on ALL THREE dlxoutcomeredfixture forge forms "+
+			"(empty composite literal + zero-value var + *new(T)); <3 means a composite-lit/var/new type-resolution path is silently broken")
 }
 
 // ─── H3a: the dlxoutcome constructors actually record (inseparability spine) ──
@@ -425,4 +472,139 @@ func TestMQTTDLXFailureSignalFunnel_H3b_OutcomeConstructorBalance(t *testing.T) 
 			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H3b: routeDeadLetter must have ≥1 dlxoutcome.Dropped "+
 				"callsite (the alertable failure exits)")
 	})
+}
+
+// ─── H4: dlxoutcome's ONLY Outcome producers are Dropped/Captured ─────────────
+//
+// H2 forbids mqtt from FORGING an Outcome; H4 closes the upstream side of the
+// funnel — it forbids the dlxoutcome package from gaining a THIRD producer (e.g.
+// `func Silent() Outcome { return Outcome{} }`) that returns an Outcome without
+// recording a metric. Without H4, H2 (downstream) + H3b (aggregate count) would
+// pass while a silent drop routed through such a producer (gh #1873 review F1,
+// "没闭合上游唯一生产者"). Together H1+H2+H4+H3a mean every Outcome mqtt returns came
+// from a recording constructor — the closed funnel that makes no-silent-exit a
+// Medium machine-guarded property (the type system only forces returning SOME
+// Outcome; see the package godoc §grading).
+
+// dlxSanctionedProducers is the allowlist of dlxoutcome functions permitted to
+// return an Outcome. Both record a metric (H3a), so confining production to this
+// set is what makes "any Outcome was minted by a recording path" hold.
+func dlxSanctionedProducers() map[string]bool {
+	return map[string]bool{dlxDroppedFuncName: true, dlxCapturedFuncName: true}
+}
+
+// funcResultIsOutcome reports whether fd's signature returns the sealed
+// (pkgPath, typeName) Outcome in any result position. Generic constructors
+// (Dropped[R]/Captured[R]) still have a concrete Outcome result, so the type-param
+// does not affect the match.
+func funcResultIsOutcome(info *types.Info, fd *ast.FuncDecl, pkgPath, typeName string) bool {
+	if fd.Name == nil {
+		return false
+	}
+	fn, ok := info.Defs[fd.Name].(*types.Func)
+	if !ok {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	res := sig.Results()
+	for i := 0; i < res.Len(); i++ {
+		named, ok := res.At(i).Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		obj := named.Obj()
+		if obj.Pkg() != nil && obj.Pkg().Path() == pkgPath && obj.Name() == typeName {
+			return true
+		}
+	}
+	return false
+}
+
+// scanOutcomeProducers walks the top-level functions of p's loaded package and
+// returns (diags, found): a diagnostic for every function whose result type is the
+// sealed (pkgPath, typeName) Outcome but whose name is NOT in allowed, and found =
+// the names of ALL Outcome producers (for the non-vacuity assertion).
+func scanOutcomeProducers(p *Pass, pkgPath, typeName string, allowed map[string]bool) (diags []Diagnostic, found []string) {
+	for _, f := range p.Files {
+		rel := p.Rel(f)
+		if strings.HasSuffix(rel, "_test.go") {
+			continue
+		}
+		scanner.EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+			if !funcResultIsOutcome(p.TypesInfo, fd, pkgPath, typeName) {
+				return
+			}
+			found = append(found, fd.Name.Name)
+			if allowed[fd.Name.Name] {
+				return
+			}
+			pos := p.Fset.Position(fd.Pos())
+			diags = append(diags, Diagnostic{Rel: rel, Line: pos.Line, Message: fmt.Sprintf(
+				"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: %s returns %s but is not a sanctioned producer "+
+					"(Dropped/Captured) at %s:%d — a non-recording producer mints an Outcome without the "+
+					"alertable metric; the sole producers of %s must record a dead-letter outcome",
+				fd.Name.Name, typeName, rel, pos.Line, typeName)})
+		})
+	}
+	return diags, found
+}
+
+func TestMQTTDLXFailureSignalFunnel_H4_SoleProducers(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	seen := false
+	var diags []Diagnostic
+	var found []string
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
+		[]string{mqttDLXOutcomePkgPath}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttDLXOutcomePkgPath {
+				return nil
+			}
+			seen = true
+			diags, found = scanOutcomeProducers(p, mqttDLXOutcomePkgPath, dlxOutcomeTypeName, dlxSanctionedProducers())
+			return nil
+		})
+	assert.True(t, seen,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: %s package not loaded — gh #1440 mechanism missing", mqttDLXOutcomePkgPath)
+	assert.Empty(t, diags,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: dlxoutcome has a non-sanctioned Outcome producer — only "+
+			"Dropped/Captured (which record a metric) may return Outcome; a third producer reopens silent drop")
+	// Non-vacuity: both sanctioned producers must be present, else the result-type
+	// resolution is silently broken and H4 would pass on an empty producer set.
+	assert.Subset(t, found, []string{dlxDroppedFuncName, dlxCapturedFuncName},
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: expected Dropped+Captured among Outcome producers; "+
+			"missing one means the producer scan is broken")
+}
+
+// TestMQTTDLXFailureSignalFunnel_H4_ScannerFiresOnRedFixture proves the H4 producer
+// scan is non-vacuous: the replica fixture declares three Outcome producers
+// (archtestForgedOutcome{Literal,Var,New}), none named Dropped/Captured, so the
+// allowlist scan MUST flag all three.
+func TestMQTTDLXFailureSignalFunnel_H4_ScannerFiresOnRedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	var diags []Diagnostic
+	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{dlxOutcomeRedFixturePkgPath}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != dlxOutcomeRedFixturePkgPath {
+				return nil
+			}
+			diags, _ = scanOutcomeProducers(p, dlxOutcomeRedFixturePkgPath, "FixtureOutcome", dlxSanctionedProducers())
+			return nil
+		})
+	assert.GreaterOrEqual(t, len(diags), 3,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: scanner must flag all three non-sanctioned producers in "+
+			"dlxoutcomeredfixture; <3 means the result-type producer scan is silently broken")
+	for _, d := range diags {
+		assert.True(t, strings.HasSuffix(d.Rel, "fixture.go"),
+			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: diagnostic not from the red fixture file: %s", d.Rel)
+	}
 }

--- a/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
+++ b/tools/archtest/mqtt_dlx_failure_signal_funnel_test.go
@@ -68,14 +68,18 @@
 // # Blind-spot inventory (per ai-robust.md 强制盲区自检)
 //
 //   - composite-lit / zero-var / new(T) forge in mqtt → H2 (CompositeLit + ValueSpec +
-//     new-builtin scan over mqtt production files). All three are enumerable AST forms.
-//     Proven non-vacuous by the dlxoutcomeredfixture synthetic red case (three planted
-//     forges), which uses a sealed-shape REPLICA (a real-type fixture is impossible:
-//     dlxoutcome is an internal package the tools module cannot import — same replica
-//     rationale as internal/mqttredfixture).
+//     new-builtin scan over mqtt production files). All enumerable AST forms, and each
+//     is alias-aware: H2 resolves the type via dlxNamedUnaliased (types.Unalias), so a
+//     `type A = dlxoutcome.Outcome; A{}` / `new(A)` forge is caught too (gh #1873 r2).
+//     Proven non-vacuous by the dlxoutcomeredfixture synthetic red case (four planted
+//     forges incl. an alias literal), which uses a sealed-shape REPLICA (a real-type
+//     fixture is impossible: dlxoutcome is an internal package the tools module cannot
+//     import — same replica rationale as internal/mqttredfixture).
 //   - non-recording third producer in dlxoutcome → H4 (sole-producer allowlist =
-//     {Dropped, Captured}). Proven non-vacuous by the same red fixture, whose three
-//     planted functions return the replica Outcome but are not Dropped/Captured.
+//     {Dropped, Captured}), alias-aware via dlxNamedUnaliased so `func Silent() A`
+//     (A = Outcome alias) is recognized as a producer. Proven non-vacuous by the same
+//     red fixture, whose four planted functions return the replica Outcome (one via the
+//     alias) but are not Dropped/Captured.
 //   - constructor gutted to a no-op → H3a (Dropped calls RecordDeadLetterFailure,
 //     Captured calls RecordDeadLetter; a metric-less constructor would defeat the
 //     seal while still compiling).
@@ -217,7 +221,7 @@ func TestMQTTDLXFailureSignalFunnel_H1_ReturnsSealedOutcome(t *testing.T) {
 				"the metric structurally inseparable from the drop (gh #1440)") {
 			return
 		}
-		named, ok := sig.Results().At(0).Type().(*types.Named)
+		named, ok := dlxNamedUnaliased(sig.Results().At(0).Type())
 		if !assert.True(t, ok, "routeDeadLetter result is not a named type") {
 			return
 		}
@@ -231,7 +235,20 @@ func TestMQTTDLXFailureSignalFunnel_H1_ReturnsSealedOutcome(t *testing.T) {
 
 // ─── H2: no mqtt code forges a dlxoutcome.Outcome ─────────────────────────────
 
-// dlxIsOutcomeType reports whether expr's resolved type is (pkgPath, typeName).
+// dlxNamedUnaliased unwraps a type alias and returns the underlying *types.Named.
+// types.Unalias is REQUIRED because under Go 1.23+ (gotypesalias=1, the default) a
+// `type A = dlxoutcome.Outcome` denotes a *types.Alias, not a *types.Named — so a
+// bare .(*types.Named) assertion would let an alias-typed forge/producer
+// (`A{}` / `new(A)` / `func() A`) slip past H1/H2/H4 (gh #1873 review F1 r2; same
+// requirement as reconcile_invariants isReconcileLoopType). No-op when t is already
+// a *types.Named.
+func dlxNamedUnaliased(t types.Type) (*types.Named, bool) {
+	named, ok := types.Unalias(t).(*types.Named)
+	return named, ok
+}
+
+// dlxIsOutcomeType reports whether expr's resolved type (alias-unwrapped) is
+// (pkgPath, typeName).
 func dlxIsOutcomeType(info *types.Info, expr ast.Expr, pkgPath, typeName string) bool {
 	if expr == nil {
 		return false
@@ -240,7 +257,7 @@ func dlxIsOutcomeType(info *types.Info, expr ast.Expr, pkgPath, typeName string)
 	if !ok {
 		return false
 	}
-	named, ok := tv.Type.(*types.Named)
+	named, ok := dlxNamedUnaliased(tv.Type)
 	if !ok {
 		return false
 	}
@@ -253,9 +270,12 @@ func dlxIsOutcomeType(info *types.Info, expr ast.Expr, pkgPath, typeName string)
 // zero-value forge forms: a composite literal of ANY shape (INCLUDING the empty
 // `Outcome{}` — unlike scanSealedCompositeLitConstruction which exempts empty
 // literals), a zero-value `var o Outcome` declaration, and a `*new(Outcome)`
-// allocation. In the dead-letter funnel NO consumer may mint an Outcome; the only
-// sanctioned producers are dlxoutcome.Dropped/Captured (which record a metric) and
-// they live in the dlxoutcome package itself (locked by H4, not scanned here).
+// allocation. All three resolve the type through dlxNamedUnaliased (types.Unalias),
+// so an alias-typed forge (`type A = Outcome; A{}` / `new(A)`) is caught as well
+// (gh #1873 review F1 r2). In the dead-letter funnel NO consumer may mint an Outcome;
+// the only sanctioned producers are dlxoutcome.Dropped/Captured (which record a
+// metric) and they live in the dlxoutcome package itself (locked by H4, not scanned
+// here).
 //
 // These three are the enumerable forge forms; the genuinely-irreducible residual
 // (open-set zero-value extraction: array/map element, reflect.Zero, an IIFE) is
@@ -362,12 +382,15 @@ func TestMQTTDLXFailureSignalFunnel_H2_ScannerFiresOnRedFixture(t *testing.T) {
 			}
 			return out
 		})
-	// The fixture plants ALL THREE forge forms (empty composite literal + zero-value
-	// var + *new(T) allocation), so require ≥3 diagnostics: if fewer fire, one of the
-	// three scan paths (CompositeLit / ValueSpec / new-builtin) is silently broken.
-	assert.GreaterOrEqual(t, len(diags), 3,
-		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on ALL THREE dlxoutcomeredfixture forge forms "+
-			"(empty composite literal + zero-value var + *new(T)); <3 means a composite-lit/var/new type-resolution path is silently broken")
+	// The fixture plants ALL FOUR forge forms (empty composite literal + zero-value
+	// var + *new(T) + an alias-typed composite literal), so require ≥4 diagnostics:
+	// if fewer fire, one of the four scan paths (CompositeLit / ValueSpec / new-builtin
+	// / types.Unalias) is silently broken. The 4th specifically requires types.Unalias
+	// in dlxIsOutcomeType (gh #1873 review F1 r2): without it the alias forge is missed.
+	assert.GreaterOrEqual(t, len(diags), 4,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H2: scanner must fire on ALL FOUR dlxoutcomeredfixture forge forms "+
+			"(empty composite literal + zero-value var + *new(T) + alias literal); <4 means a "+
+			"composite-lit/var/new/unalias type-resolution path is silently broken")
 }
 
 // ─── H3a: the dlxoutcome constructors actually record (inseparability spine) ──
@@ -511,7 +534,7 @@ func funcResultIsOutcome(info *types.Info, fd *ast.FuncDecl, pkgPath, typeName s
 	}
 	res := sig.Results()
 	for i := 0; i < res.Len(); i++ {
-		named, ok := res.At(i).Type().(*types.Named)
+		named, ok := dlxNamedUnaliased(res.At(i).Type())
 		if !ok {
 			continue
 		}
@@ -600,9 +623,10 @@ func TestMQTTDLXFailureSignalFunnel_H4_ScannerFiresOnRedFixture(t *testing.T) {
 			diags, _ = scanOutcomeProducers(p, dlxOutcomeRedFixturePkgPath, "FixtureOutcome", dlxSanctionedProducers())
 			return nil
 		})
-	assert.GreaterOrEqual(t, len(diags), 3,
-		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: scanner must flag all three non-sanctioned producers in "+
-			"dlxoutcomeredfixture; <3 means the result-type producer scan is silently broken")
+	assert.GreaterOrEqual(t, len(diags), 4,
+		"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: scanner must flag all four non-sanctioned producers in "+
+			"dlxoutcomeredfixture (incl. the alias-return producer); <4 means the result-type producer "+
+			"scan is silently broken — the alias one needs types.Unalias (gh #1873 review F1 r2)")
 	for _, d := range diags {
 		assert.True(t, strings.HasSuffix(d.Rel, "fixture.go"),
 			"MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01/H4: diagnostic not from the red fixture file: %s", d.Rel)


### PR DESCRIPTION
## Summary

把 `routeDeadLetter` 的 drop 决策收口为封印 `dlxoutcome.Outcome`，将 archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01` 的 **no-silent-exit 轴从 Medium 升为类型系统 Hard**（漏记死信指标编译不过）。

## Why / 背景

MQTT 无 broker 原生 DLX，`$dead` 发布失败时消息被 ack-as-poison 丢弃，唯一运维补救钩子是可告警指标 `mqtt_dlx_failed_total`。原 archtest 用 AST 控制流扫描守「每个 drop 退出必记该指标」，但 Go 类型系统无法表达此约束，故只能是 Medium。#1440 要求把 drop 决策收口为 typed sink helper，使「漏记 metric」在编译/构造层不可表达。

**机制**：新增 internal 包 `adapters/mqtt/internal/dlxoutcome`，封印 proof-token `Outcome`，唯二产出者 `Dropped`（记 `RecordDeadLetterFailure`）/ `Captured`（记 `RecordDeadLetter`）。`routeDeadLetter` retype 为返回 `Outcome`——新 drop 分支不返回 Outcome 即**编译错**，且唯一非伪造来源是记指标的构造器。泛型 `R` 承重（避免 `dlxoutcome → mqtt` import cycle）。

**诚实分级（不 overclaim）**：
- **Hard（类型系统）**：no-silent-exit——整条死信静默丢失这一最高严重度失败模式。
- **Medium 残留①**：空字面量 `Outcome{}` / 零值 `var` 仍可构造（Go 不可消除，同 `internal/topicns` 天花板），由降级后的 shape-guard **H2** 守。
- **Medium 残留②（F1）**：drop→failure 语义匹配（类型系统无法强制「记对的指标」）由 **H3b** 聚合计数 + 行为测试守。
- ADR/godoc **不**表述为「drop→failure 由类型系统强制」。

archtest 降为 shape-guard：**H1** 签名守卫 / **H2** 禁 mqtt 铸 Outcome 字面量+零值 var（含空字面量，配 `dlxoutcomeredfixture` synthetic red）/ **H3a** 构造器必记指标 / **H3b** F1 聚合计数。

## Refs

- Closes #1440
- EPIC #1138；前序 #1356（MQTT DLT no-loss enforce spine）
- ref: kernel/outbox/result.go（HandleResult sealed construction 范本）
- ADR：docs/architecture/202605281200-048-adr-mqtt-adapter.md §Amendment 2026-06-11（含 §3 威胁矩阵逐行重评，无 ✅→⚠️/❌ 回归）

## Risk / 兼容性

- **无 wire 契约影响**：纯 adapters/mqtt 内部 Go 重构，不动 contract / HTTP / event topic / metric 名 / metric reason 集 → **无契约扇出**。
- **行为逐字不变**：同两指标（`mqtt_dlx_total` / `mqtt_dlx_failed_total`）按原条件发射；4 个 `deadletter_test.go` 测试不改即过。
- 兄弟 archtest `MQTT-METRIC-LABEL-VALUES-FROZEN-01` 不受影响（扫描限 mqtt 包，构造器下沉到 dlxoutcome 不触发）。
- `routeDeadLetter` 返回的 Outcome 被调用方按设计丢弃（`//nolint:unparam`，理由内联：Outcome 是编译强制 token）。
- **残留天花板**（非缺口，已写入 archtest godoc）：空字面量 `dlxoutcome.Outcome{}` Go 不可消除，由 H2 shape-guard 守。

## Test plan

- [x] `go build ./...` 本地通过（adapters/mqtt + tools）
- [x] `go test ./...` 本地通过（mqtt：新 `dlxoutcome` 100% 覆盖 + 既有 4 个 `deadletter_test`）
- [x] `golangci-lint run ./...` 0 issues（mqtt 模块）
- [x] archtest `MQTT-DLX-FAILURE-SIGNAL-FUNNEL-01`（H1/H2/H3a/H3b + synthetic red fixture）全绿；sibling `MQTT-METRIC-LABEL-VALUES-FROZEN-01` + meta-rules（SCANNER-FRAMEWORK-USAGE-01/02、PASS-FUNNEL、buildtags classifier）全绿
- [x] 已 merge `origin/develop`（+2 commits）后复跑全部 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
