### PR TITLE
refactor(mqtt): pre-existing hygiene debt — ctx-aware logs / testwait poll / dedup buckets / 4-branch error msgs [#1338]

### DIFF
--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -395,7 +395,7 @@ func (c *Connection) onConnectionUp(_ *autopaho.ConnectionManager, _ *paho.Conna
 		c.collector.RecordReconnect(context.Background())
 	}
 	slog.Info("mqtt: connection established",
-		slog.String("client_id", c.cfg.clientID.String()),
+		slog.String(logKeyClientID, c.cfg.clientID.String()),
 		slog.Bool("reconnect", isReconnect))
 
 	// Re-arm all registered subscriptions. autopaho does not replay SUBSCRIBE
@@ -425,7 +425,7 @@ func (c *Connection) resubscribeAll() {
 		// reused so deliveries continue to route to the same handler.
 		if reason, err := c.sendSubscribe(context.Background(), route.filter, route.qos, route.subID); err != nil {
 			slog.Warn("mqtt: resubscribe after reconnect failed; will retry on next reconnect",
-				slog.String("client_id", c.cfg.clientID.String()),
+				slog.String(logKeyClientID, c.cfg.clientID.String()),
 				slog.String("filter", route.filter.String()),
 				slog.Any("error", redactErr(err)))
 			c.collector.RecordSubscribeFailure(context.Background(), reason)
@@ -455,11 +455,11 @@ func (c *Connection) onConnectionDown() bool {
 		// Graceful-shutdown lifecycle event — Info per observability.md (not Debug,
 		// which is off in production and would hide the orderly-stop confirmation).
 		slog.Info("mqtt: connection down after close; stopping retry",
-			slog.String("client_id", c.cfg.clientID.String()))
+			slog.String(logKeyClientID, c.cfg.clientID.String()))
 		return false
 	}
 	slog.Info("mqtt: connection lost; autopaho will reconnect",
-		slog.String("client_id", c.cfg.clientID.String()))
+		slog.String(logKeyClientID, c.cfg.clientID.String()))
 	return true
 }
 
@@ -479,7 +479,7 @@ func (c *Connection) onConnectError(err error) {
 		permErr := errcode.New(errcode.KindInternal, code,
 			"mqtt: connection rejected (fail-fast)", buildConnackOpts(err)...)
 		slog.Error("mqtt: bootstrap-fatal connect error",
-			slog.String("client_id", c.cfg.clientID.String()),
+			slog.String(logKeyClientID, c.cfg.clientID.String()),
 			slog.String("errcode", string(code)),
 			slog.Any("error", redacted))
 		c.recordPermanentLocked(permErr)
@@ -489,7 +489,7 @@ func (c *Connection) onConnectError(err error) {
 		permErr := errcode.New(errcode.KindInternal, code,
 			"mqtt: connection rejected (permanent; retrying until operator fix)", buildConnackOpts(err)...)
 		slog.Warn("mqtt: permanent connect error; will retry until operator fixes",
-			slog.String("client_id", c.cfg.clientID.String()),
+			slog.String(logKeyClientID, c.cfg.clientID.String()),
 			slog.String("errcode", string(code)),
 			slog.Any("error", redacted))
 		c.recordPermanentLocked(permErr)
@@ -504,7 +504,7 @@ func (c *Connection) onConnectError(err error) {
 		}
 		c.mu.Unlock()
 		slog.Warn("mqtt: transient connect error; autopaho will retry",
-			slog.String("client_id", c.cfg.clientID.String()),
+			slog.String(logKeyClientID, c.cfg.clientID.String()),
 			slog.Any("error", redacted))
 	}
 }
@@ -568,7 +568,7 @@ func errClosed() error {
 // codes with different meanings.
 func (c *Connection) onServerDisconnect(d *paho.Disconnect) {
 	slog.Warn("mqtt: server requested disconnect",
-		slog.String("client_id", c.cfg.clientID.String()),
+		slog.String(logKeyClientID, c.cfg.clientID.String()),
 		slog.Int("reason_code", int(d.ReasonCode)),
 		slog.String("reason_name", disconnectReasonName(d.ReasonCode)))
 }
@@ -650,8 +650,8 @@ func (c *Connection) onPublishReceived(pr paho.PublishReceived) (bool, error) {
 		// closed: log and do NOT dispatch / ack (leave unacked for redelivery)
 		// rather than guess a route and risk cross-consumer-group misdelivery.
 		slog.Error("mqtt: received PUBLISH without subscription identifier; dropping (fail-closed)",
-			slog.String("client_id", c.cfg.clientID.String()),
-			slog.String("topic", safeTopicForLog(pb.Topic)))
+			slog.String(logKeyClientID, c.cfg.clientID.String()),
+			slog.String(logKeyTopic, safeTopicForLog(pb.Topic)))
 		return false, nil
 	}
 	for _, route := range snapshot {
@@ -663,9 +663,9 @@ func (c *Connection) onPublishReceived(pr paho.PublishReceived) (bool, error) {
 	// Sub-id with no matching route: the route was concurrently deregistered
 	// (cancel / close) between delivery and dispatch. Drop (do not ack).
 	slog.Warn("mqtt: received PUBLISH with unknown subscription identifier; route deregistered",
-		slog.String("client_id", c.cfg.clientID.String()),
+		slog.String(logKeyClientID, c.cfg.clientID.String()),
 		slog.Int("subscription_id", subID),
-		slog.String("topic", safeTopicForLog(pb.Topic)))
+		slog.String(logKeyTopic, safeTopicForLog(pb.Topic)))
 	return false, nil
 }
 
@@ -796,7 +796,7 @@ func (c *Connection) Subscribe(ctx context.Context, f topicns.SubscribableFilter
 				Topics: []string{f.String()},
 			}); unsubErr != nil {
 				slog.LogAttrs(unsubCtx, slog.LevelWarn, "mqtt: unsubscribe on cancel failed",
-					slog.String("client_id", c.cfg.clientID.String()),
+					slog.String(logKeyClientID, c.cfg.clientID.String()),
 					slog.String("filter", f.String()),
 					slog.Any("error", redactErr(unsubErr)))
 			}
@@ -940,7 +940,7 @@ func (c *Connection) unsubscribeAll(ctx context.Context) {
 	}
 	if _, err := c.cm.Unsubscribe(ctx, &paho.Unsubscribe{Topics: filters}); err != nil {
 		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: unsubscribe-all on close failed",
-			slog.String("client_id", c.cfg.clientID.String()),
+			slog.String(logKeyClientID, c.cfg.clientID.String()),
 			slog.Any("error", redactErr(err)))
 	}
 }

--- a/adapters/mqtt/connection.go
+++ b/adapters/mqtt/connection.go
@@ -795,7 +795,7 @@ func (c *Connection) Subscribe(ctx context.Context, f topicns.SubscribableFilter
 			if _, unsubErr := c.cm.Unsubscribe(unsubCtx, &paho.Unsubscribe{
 				Topics: []string{f.String()},
 			}); unsubErr != nil {
-				slog.Warn("mqtt: unsubscribe on cancel failed",
+				slog.LogAttrs(unsubCtx, slog.LevelWarn, "mqtt: unsubscribe on cancel failed",
 					slog.String("client_id", c.cfg.clientID.String()),
 					slog.String("filter", f.String()),
 					slog.Any("error", redactErr(unsubErr)))
@@ -939,7 +939,7 @@ func (c *Connection) unsubscribeAll(ctx context.Context) {
 		return
 	}
 	if _, err := c.cm.Unsubscribe(ctx, &paho.Unsubscribe{Topics: filters}); err != nil {
-		slog.Warn("mqtt: unsubscribe-all on close failed",
+		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: unsubscribe-all on close failed",
 			slog.String("client_id", c.cfg.clientID.String()),
 			slog.Any("error", redactErr(err)))
 	}

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -468,15 +468,11 @@ func itestPollDispositionSettlement(
 	wantRelease int,
 ) {
 	t.Helper()
-	deadline := time.Now().Add(testtime.D10s)
-	for time.Now().Before(deadline) {
+	testwait.External(t, "mqtt-disposition-settled", func() bool {
 		s, f, _ := coll.snapshot()
 		_, rel := settlement.counts()
-		if s >= wantSuccess && rel >= wantRelease && (wantReason == "" || f >= 1) {
-			break
-		}
-		time.Sleep(testtime.D10ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
-	}
+		return s >= wantSuccess && rel >= wantRelease && (wantReason == "" || f >= 1)
+	}, testtime.D10s, testtime.D10ms)
 }
 
 // itestAssertDispositionCounts reads the final snapshot from coll and settlement
@@ -789,19 +785,11 @@ func TestIntegration_Subscriber_ClientIDConflict(t *testing.T) {
 	// a HARD assertion: conn1 MUST be observed non-healthy within the window. It
 	// is NOT skipped — a broker that never evicts the first session is a real
 	// regression this test exists to catch.
-	observedUnhealthy := false
-	deadline := time.Now().Add(testtime.D10s)
-	for time.Now().Before(deadline) {
-		if conn1.Health(context.Background()) != nil {
-			observedUnhealthy = true
-			break
-		}
-		time.Sleep(testtime.D50ms) //archtest:allow:test-sleep poll-loop: wait for broker session-takeover disconnect
-	}
-	if !observedUnhealthy {
-		t.Fatalf("conn1 never transitioned to unhealthy after a same-clientId reconnect; " +
+	testwait.External(t, "mqtt-session-takeover-disconnect", func() bool {
+		return conn1.Health(context.Background()) != nil
+	}, testtime.D10s, testtime.D50ms,
+		"conn1 never transitioned to unhealthy after a same-clientId reconnect; "+
 			"MQTT v5 session takeover (DISCONNECT 0x8E) did not occur — broker eviction is broken")
-	}
 }
 
 // startDedicatedMosquittoContainer starts an eclipse-mosquitto container for
@@ -1037,19 +1025,17 @@ func TestIntegration_Subscriber_DLTCapture(t *testing.T) {
 	itestPublish(t, conn, originalTopic, envelope)
 
 	// Poll until the DLT watcher receives the message or timeout.
-	deadline := time.Now().Add(testtime.D15s)
-	for time.Now().Before(deadline) {
+	testwait.External(t, "mqtt-broker-delivery", func() bool {
 		select {
 		case <-cap.gotCh:
-			goto assertDLT
+			return true
 		default:
+			return false
 		}
-		time.Sleep(testtime.D50ms) //archtest:allow:test-sleep poll-loop: real broker delivery latency
-	}
-	t.Fatal("dlt capture: DLT watcher did not receive a message within 15s; " +
-		"routeDeadLetter may be broken or $dead/<topic> is not being published")
+	}, testtime.D15s, testtime.D50ms,
+		"dlt capture: DLT watcher did not receive a message within 15s; "+
+			"routeDeadLetter may be broken or $dead/<topic> is not being published")
 
-assertDLT:
 	gotTopic, gotPayload := cap.snapshot()
 	if gotTopic != expectedDLTTopic {
 		t.Errorf("DLT topic = %q, want %q", gotTopic, expectedDLTTopic)

--- a/adapters/mqtt/integration_test.go
+++ b/adapters/mqtt/integration_test.go
@@ -472,7 +472,32 @@ func itestPollDispositionSettlement(
 		s, f, _ := coll.snapshot()
 		_, rel := settlement.counts()
 		return s >= wantSuccess && rel >= wantRelease && (wantReason == "" || f >= 1)
-	}, testtime.D10s, testtime.D10ms)
+	}, testtime.D10s, testtime.D10ms,
+		dispositionDiag{coll, settlement, wantSuccess, wantReason, wantRelease})
+}
+
+// dispositionDiag renders the live disposition counters at format time (not at
+// call time, which would capture the pre-poll zero state). It is passed as the
+// testwait.External msgAndArg so a poll timeout's Fatalf carries the
+// actual-vs-wanted counters. Without it the diagnostics are lost: External
+// Fatals on timeout, aborting the test before itestAssertDispositionCounts
+// (which prints the per-counter diffs) can run.
+type dispositionDiag struct {
+	coll        *recordingSubCollector
+	settlement  *recordingSettlement
+	wantSuccess int
+	wantReason  ConsumeFailureReason
+	wantRelease int
+}
+
+func (d dispositionDiag) String() string {
+	success, failure, reason := d.coll.snapshot()
+	commit, release := d.settlement.counts()
+	return fmt.Sprintf(
+		"actual success=%d failure=%d reason=%q commit=%d release=%d; "+
+			"want success=%d release=%d reason=%q",
+		success, failure, reason, commit, release,
+		d.wantSuccess, d.wantRelease, d.wantReason)
 }
 
 // itestAssertDispositionCounts reads the final snapshot from coll and settlement

--- a/adapters/mqtt/internal/topicns/topicns.go
+++ b/adapters/mqtt/internal/topicns/topicns.go
@@ -39,8 +39,10 @@ const (
 const (
 	maxNamespaceLen = 128
 
-	msgInvalidNamespace = "mqtt topic namespace: must be non-empty, no leading/trailing slash, " +
-		"no wildcards, each level ^[a-z0-9_-]+$, max 128 chars"
+	msgInvalidNamespaceLength   = "mqtt topic namespace: must be non-empty and at most 128 chars"
+	msgInvalidNamespaceSlash    = "mqtt topic namespace: must not have a leading or trailing slash"
+	msgInvalidNamespaceWildcard = "mqtt topic namespace: must not contain MQTT wildcards (+ or #)"
+	msgInvalidNamespaceLevel    = "mqtt topic namespace: each level must match ^[a-z0-9_-]+$"
 	msgTopicOutsideNamespace    = "mqtt topic is outside the declared namespace"
 	msgSubscribeOutsideNS       = "mqtt subscribe filter head is outside the declared namespace"
 	msgInvalidWildcardPlacement = "mqtt subscribe filter has invalid wildcard placement (# must be at end, each level must be a lone token)"
@@ -87,21 +89,21 @@ func Parse(ns string) (Namespace, error) {
 	if len(ns) == 0 || len(ns) > maxNamespaceLen {
 		return Namespace{}, errcode.New(
 			errcode.KindInvalid, ErrInvalidNamespace,
-			msgInvalidNamespace,
+			msgInvalidNamespaceLength,
 			errcode.WithDetails(errcode.PublicString(detailKeyNamespace, ns)),
 		)
 	}
 	if strings.HasPrefix(ns, "/") || strings.HasSuffix(ns, "/") {
 		return Namespace{}, errcode.New(
 			errcode.KindInvalid, ErrInvalidNamespace,
-			msgInvalidNamespace,
+			msgInvalidNamespaceSlash,
 			errcode.WithDetails(errcode.PublicString(detailKeyNamespace, ns)),
 		)
 	}
 	if strings.ContainsAny(ns, "+#") {
 		return Namespace{}, errcode.New(
 			errcode.KindInvalid, ErrInvalidNamespace,
-			msgInvalidNamespace,
+			msgInvalidNamespaceWildcard,
 			errcode.WithDetails(errcode.PublicString(detailKeyNamespace, ns)),
 		)
 	}
@@ -110,7 +112,7 @@ func Parse(ns string) (Namespace, error) {
 		if !isValidNSLevel(lvl) {
 			return Namespace{}, errcode.New(
 				errcode.KindInvalid, ErrInvalidNamespace,
-				msgInvalidNamespace,
+				msgInvalidNamespaceLevel,
 				errcode.WithDetails(errcode.PublicString(detailKeyNamespace, ns)),
 			)
 		}

--- a/adapters/mqtt/internal/topicns/topicns.go
+++ b/adapters/mqtt/internal/topicns/topicns.go
@@ -39,6 +39,9 @@ const (
 const (
 	maxNamespaceLen = 128
 
+	// The "128" literal below must stay in sync with maxNamespaceLen above. errcode
+	// messages are required to be const literals (MESSAGE-CONST-LITERAL-01), so the
+	// constant cannot be interpolated into the string.
 	msgInvalidNamespaceLength   = "mqtt topic namespace: must be non-empty and at most 128 chars"
 	msgInvalidNamespaceSlash    = "mqtt topic namespace: must not have a leading or trailing slash"
 	msgInvalidNamespaceWildcard = "mqtt topic namespace: must not contain MQTT wildcards (+ or #)"

--- a/adapters/mqtt/internal/topicns/topicns_test.go
+++ b/adapters/mqtt/internal/topicns/topicns_test.go
@@ -752,6 +752,81 @@ func TestNamespace_MintFilter_InvalidGroup(t *testing.T) {
 	}
 }
 
+// TestParse_InvalidNamespace_DistinctMessages asserts that each of the four
+// invalid-namespace branches returns its own distinct error message.
+// This is the TDD red test: before the const split, all four branches return
+// the same msgInvalidNamespace value, so wantMsg assertions will fail for the
+// three non-length branches (they will all carry the combined message).
+func TestParse_InvalidNamespace_DistinctMessages(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		ns      string
+		wantMsg string
+	}{
+		{
+			name:    "empty-triggers-length-message",
+			ns:      "",
+			wantMsg: "mqtt topic namespace: must be non-empty and at most 128 chars",
+		},
+		{
+			name:    "too-long-triggers-length-message",
+			ns:      strings.Repeat("a", 129),
+			wantMsg: "mqtt topic namespace: must be non-empty and at most 128 chars",
+		},
+		{
+			name:    "leading-slash-triggers-slash-message",
+			ns:      "/foo",
+			wantMsg: "mqtt topic namespace: must not have a leading or trailing slash",
+		},
+		{
+			name:    "trailing-slash-triggers-slash-message",
+			ns:      "foo/",
+			wantMsg: "mqtt topic namespace: must not have a leading or trailing slash",
+		},
+		{
+			name:    "plus-wildcard-triggers-wildcard-message",
+			ns:      "foo/+",
+			wantMsg: "mqtt topic namespace: must not contain MQTT wildcards (+ or #)",
+		},
+		{
+			name:    "hash-wildcard-triggers-wildcard-message",
+			ns:      "a/#",
+			wantMsg: "mqtt topic namespace: must not contain MQTT wildcards (+ or #)",
+		},
+		{
+			name:    "uppercase-triggers-level-charset-message",
+			ns:      "FOO",
+			wantMsg: "mqtt topic namespace: each level must match ^[a-z0-9_-]+$",
+		},
+		{
+			name:    "mixed-case-triggers-level-charset-message",
+			ns:      "foo/Bar",
+			wantMsg: "mqtt topic namespace: each level must match ^[a-z0-9_-]+$",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse(tc.ns)
+			if err == nil {
+				t.Fatalf("Parse(%q) expected error, got nil", tc.ns)
+			}
+			var ec *errcode.Error
+			if !errors.As(err, &ec) {
+				t.Fatalf("Parse(%q) error is not *errcode.Error: %T", tc.ns, err)
+			}
+			if ec.Code != ErrInvalidNamespace {
+				t.Errorf("Parse(%q) code = %s, want %s", tc.ns, ec.Code, ErrInvalidNamespace)
+			}
+			if ec.Message != tc.wantMsg {
+				t.Errorf("Parse(%q) message = %q, want %q", tc.ns, ec.Message, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestNamespace_SubscribeOK_BareWildcardOutsideNamespace verifies that bare
 // wildcard filters "#" and "+/x" are rejected with ErrTopicOutsideNamespace
 // when the namespace is "ns" — the filter head is empty (before the first "/")

--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -227,10 +227,12 @@ type providerPublisherCollector struct {
 
 var _ PublisherCollector = (*providerPublisherCollector)(nil)
 
-// ackDurationBuckets covers MQTT publish ack round-trip times from 1 ms to
-// 10 s, matching a standard Prometheus default-ish bucket set oriented to
-// network-latency distributions.
-var ackDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+// mqttDurationBuckets is the shared network-latency-oriented histogram bucket
+// bounds used by both the publish-ack round-trip histogram
+// (mqtt_publish_ack_duration_seconds) and the consume handler+commit histogram
+// (mqtt_consume_duration_seconds). Covers 1 ms to 10 s; observations outside
+// this range fall into the +Inf bucket.
+var mqttDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
 
 // NewProviderPublisherCollector registers 3 metrics on p and returns a
 // PublisherCollector bound to cellID. cellID becomes the "cell" label value.
@@ -289,7 +291,7 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		Help: "End-to-end MQTT publish ack round-trip duration in seconds, from Publish() call to broker PUBACK. " +
 			"Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. " + helpCellLabel,
 		LabelNames: []string{"cell"},
-		Buckets:    ackDurationBuckets,
+		Buckets:    mqttDurationBuckets,
 	})
 	if err != nil {
 		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
@@ -447,10 +449,6 @@ type providerSubscriberCollector struct {
 
 var _ SubscriberCollector = (*providerSubscriberCollector)(nil)
 
-// consumeDurationBuckets covers MQTT consume handler+commit times from 1 ms to
-// 10 s, reusing the publish ack bucket choice (network-latency-oriented set).
-var consumeDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
-
 // Subscriber metric definitions (data; registered in registration order by
 // NewProviderSubscriberCollector). Extracted to package level to keep the
 // constructor's registration loop short.
@@ -489,7 +487,7 @@ var (
 			"Buckets cover 1 ms to 10 s; values outside this range fall into the +Inf bucket. " +
 			helpCellLabel,
 		LabelNames: []string{"cell"},
-		Buckets:    consumeDurationBuckets,
+		Buckets:    mqttDurationBuckets,
 	}
 	subConsumeInflightOpts = metrics.GaugeOpts{
 		Name: "mqtt_consume_inflight",

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -168,8 +168,8 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 	// is a concern for the target sink.
 	if resp != nil && resp.ReasonCode == 0x10 {
 		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: publish succeeded with no matching subscribers",
-			slog.String("client_id", p.conn.cfg.clientID.String()),
-			slog.String("topic", t.String()))
+			slog.String(logKeyClientID, p.conn.cfg.clientID.String()),
+			slog.String(logKeyTopic, t.String()))
 	}
 	p.collector.RecordPublishSuccess(ctx, p.clk.Since(start))
 	return nil

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -167,7 +167,7 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 	// identifiers in IoT deployments — configure slog handler redaction if that
 	// is a concern for the target sink.
 	if resp != nil && resp.ReasonCode == 0x10 {
-		slog.Warn("mqtt: publish succeeded with no matching subscribers",
+		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: publish succeeded with no matching subscribers",
 			slog.String("client_id", p.conn.cfg.clientID.String()),
 			slog.String("topic", t.String()))
 	}

--- a/adapters/mqtt/publisher.go
+++ b/adapters/mqtt/publisher.go
@@ -163,13 +163,17 @@ func (p *Publisher) Publish(ctx context.Context, topic string, payload []byte) e
 	// via the error branch above — handlePublishError classifies them. 0x10 is
 	// informational: counted as success with an operator warning.
 	//
-	// topic is the operator's actionable field here; it may carry device/tenant
-	// identifiers in IoT deployments — configure slog handler redaction if that
-	// is a concern for the target sink.
+	// The topic is the caller-supplied publish target: Mint/PublishOK enforce the
+	// namespace prefix and reject wildcards, but do NOT strip control characters
+	// or key=value secrets from the suffix levels. Route it through
+	// safeTopicForLog so a CR/LF or `token=` embedded in the topic cannot forge
+	// log lines (CWE-117) — the same output boundary the broker-delivered topic
+	// logs already use. PII in topic levels (device/tenant ids) is orthogonal and
+	// stays a slog-sink redaction concern.
 	if resp != nil && resp.ReasonCode == 0x10 {
 		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: publish succeeded with no matching subscribers",
 			slog.String(logKeyClientID, p.conn.cfg.clientID.String()),
-			slog.String(logKeyTopic, t.String()))
+			slog.String(logKeyTopic, safeTopicForLog(t.String())))
 	}
 	p.collector.RecordPublishSuccess(ctx, p.clk.Since(start))
 	return nil

--- a/adapters/mqtt/redact.go
+++ b/adapters/mqtt/redact.go
@@ -14,13 +14,15 @@ import (
 // topic; capping bounds log-line size independent of the redaction pass.
 const maxTopicLogLen = 256
 
-// safeTopicForLog sanitizes a broker-delivered (untrusted) MQTT topic before it
-// is logged. pb.Topic is wire bytes the broker forwards verbatim; unlike
-// entry.Topic (which UnmarshalEnvelope validates via idutil.SafeID), the raw
-// topic on the intake-stop drop / unmarshal-poison / ackPoison paths is never
-// validated. Logging it directly is a CWE-117 log-injection sink: a CR/LF or
-// ANSI escape embedded in the topic could forge log lines or corrupt terminal
-// output.
+// safeTopicForLog sanitizes an untrusted MQTT topic before it is logged. Two
+// source categories are untrusted: (1) broker-delivered topics — pb.Topic is
+// wire bytes the broker forwards verbatim; unlike entry.Topic (which
+// UnmarshalEnvelope validates via idutil.SafeID), the raw topic on the
+// intake-stop drop / unmarshal-poison / ackPoison paths is never validated — and
+// (2) caller-supplied publish targets, which Mint/PublishOK check only for
+// namespace prefix and wildcards, not for control characters or secrets. Logging
+// either directly is a CWE-117 log-injection sink: a CR/LF or ANSI escape
+// embedded in the topic could forge log lines or corrupt terminal output.
 //
 // Two-layer fail-closed (mirrors the redact.go redactConnectURL compose):
 //  1. strip control characters (CR, LF, tab, ANSI ESC, other non-printables) so

--- a/adapters/mqtt/subscriber.go
+++ b/adapters/mqtt/subscriber.go
@@ -463,6 +463,11 @@ func (s *Subscriber) dispatchDisposition(
 		// the message to another instance that then re-claims a freed claim (mirrors
 		// rabbitmq's Nack-before-release). routeDeadLetter's broker round-trip would
 		// otherwise widen that window.
+		// res.Err is logged bare (no redactErr): runtime/observability/logging's
+		// contextHandler redacts every slog attr at the sink (process-global
+		// barrier), and a domain handler error is not a broker secret. Mirrors the
+		// rabbitmq canonical (adapters/rabbitmq/subscriber.go). Call-site redact
+		// stays reserved for broker errors that also feed spans / persisted last_error.
 		slog.LogAttrs(ctx, slog.LevelError, "mqtt: handler rejected entry, routing to $dead then acking poison",
 			slog.String(logKeyClientID, s.conn.cfg.clientID.String()),
 			slog.String(logKeyTopic, entry.Topic()),
@@ -488,6 +493,8 @@ func (s *Subscriber) dispatchDisposition(
 		// idempotency backend down / claim contention), where reconnect-redelivery
 		// is the correct behavior. There is deliberately no app-level re-dispatch
 		// loop and no $dead routing on Requeue (those would be Option A).
+		// res.Err logged bare — see the reject-path note above (domain error scrubbed
+		// at the slog sink, not a broker secret).
 		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: handler requeued entry, leaving unacked for reconnect redelivery (degraded-state signal)",
 			slog.String(logKeyClientID, s.conn.cfg.clientID.String()),
 			slog.String(logKeyTopic, entry.Topic()),

--- a/adapters/mqtt/subscriber.go
+++ b/adapters/mqtt/subscriber.go
@@ -358,7 +358,7 @@ func (s *Subscriber) makeReceive(subCtx context.Context, handler outbox.Subscrib
 			// Intake stopped: do not process or ack. Leaving the message unacked
 			// lets the broker redeliver after session resume / reconnect.
 			s.adjustInflight(ctx, -1)
-			s.logIntakeStoppedDrop(pb)
+			s.logIntakeStoppedDrop(ctx, pb)
 			return
 		default:
 		}
@@ -371,7 +371,7 @@ func (s *Subscriber) makeReceive(subCtx context.Context, handler outbox.Subscrib
 		case s.workerSem <- struct{}{}:
 		case <-s.stopIntakeCh:
 			s.adjustInflight(ctx, -1)
-			s.logIntakeStoppedDrop(pb)
+			s.logIntakeStoppedDrop(ctx, pb)
 			return
 		}
 		// Prefer the connection-supplied ctx (subscription-scoped); fall back to
@@ -400,8 +400,8 @@ func (s *Subscriber) adjustInflight(ctx context.Context, delta int64) {
 
 // logIntakeStoppedDrop records that a delivery was dropped (left unacked for
 // broker redelivery) because StopIntake has fired.
-func (s *Subscriber) logIntakeStoppedDrop(pb *paho.Publish) {
-	slog.Info("mqtt: intake stopped, dropping delivery for redelivery",
+func (s *Subscriber) logIntakeStoppedDrop(ctx context.Context, pb *paho.Publish) {
+	slog.LogAttrs(ctx, slog.LevelInfo, "mqtt: intake stopped, dropping delivery for redelivery",
 		slog.String(logKeyClientID, s.conn.cfg.clientID.String()),
 		slog.String(logKeyTopic, safeTopicForLog(pb.Topic)))
 }
@@ -618,7 +618,7 @@ func (s *Subscriber) StopIntake(ctx context.Context) error {
 			}
 		case <-drainTimer.C():
 			pollTimer.Stop()
-			slog.Warn("mqtt: StopIntake drain timeout, returning fail-closed",
+			slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: StopIntake drain timeout, returning fail-closed",
 				slog.String(logKeyClientID, s.conn.cfg.clientID.String()),
 				slog.Duration("budget", s.config.StopIntakeDrainTimeout),
 				slog.Int64("residual", s.inflight.Load()))
@@ -657,7 +657,7 @@ func (s *Subscriber) cancelWithBudget(ctx context.Context, cancel func()) {
 	select {
 	case <-done:
 	case <-callCtx.Done():
-		slog.Warn("mqtt: route cancel during StopIntake exceeded per-call budget or ctx canceled",
+		slog.LogAttrs(ctx, slog.LevelWarn, "mqtt: route cancel during StopIntake exceeded per-call budget or ctx canceled",
 			slog.String(logKeyClientID, s.conn.cfg.clientID.String()),
 			slog.Any("error", callCtx.Err()))
 	}


### PR DESCRIPTION
## Summary

清理 MQTT adapter 在 PR-1/2/3 遗留的 5 项 hygiene 债（#1142 review round 3 triage 的 PREEXISTING 集群），并连同同文件、同模式的干净同胞一起修。

## Why / 背景

这批 finding 在 #1142(PR-4) review 第三轮被发现，全部是 PR-1/2/3 的既存问题，与 PR-4 无关，当时为保 PR-4 范围干净单独 track 到 #1338。本 PR 一次性闭环，避免同类 anti-pattern 在仓库里反复被再扫。

落地内容（按 finding）：

| Finding | 改动 | 文件 |
|---------|------|------|
| **F35** | `ParseTopicNamespace` 的 length/slash/wildcard/level-charset 4 个分支原本都返回同一 `msgInvalidNamespace`，拆成 4 个 const-literal message（error code/Kind/WithDetails 不变，调试可区分） | `internal/topicns/topicns.go(+_test)` |
| **F21** | `ackDurationBuckets` 与 `consumeDurationBuckets` 是完全相同的 12 值 `[]float64`，合并为单一 `mqttDurationBuckets`（共享 bucket bounds，metric 名不变） | `metrics.go` |
| **F19** | 6 处 ctx 在手却用裸 `slog.Info/Warn` 的日志改走 `slog.LogAttrs(ctx, ...)` 补齐 trace 关联。issue 原列 1 处（`logIntakeStoppedDrop`），逐站核实后补回 `subscriber.go`(StopIntake/cancelWithBudget)、`connection.go`(Subscribe cancel 闭包用现成的 `unsubCtx`、unsubscribeAll)、`publisher.go`(Publish)。autopaho 固定签名回调（无 ctx）保持 bare | `subscriber.go` `connection.go` `publisher.go` |
| **F18** | 3 处 `time.Sleep` 轮询循环改 `testwait.External`，移除 `//archtest:allow:test-sleep` 注释。issue 原列 1 处（:478），扫出 :799/:1047 同模式一并转。wall-clock 心跳(:152)/teardown-settle(:645) 非轮询，保留 | `integration_test.go` |
| **F2** | **不改代码（won't-fix + rationale）**：domain handler error 裸 `slog.Any("error", res.Err)` 无需走 redactErr——`runtime/observability/logging` 是进程级 redaction barrier，每条 slog attr 在 sink 端已统一脱敏（其 godoc 明示 call-site redactErr 仅 defense-in-depth）；domain error 非 broker 秘密；rabbitmq canonical(`subscriber.go:1003`)同样 bare。加 redactErr 冗余且与 rabbitmq 分歧 | — |

## Refs

Closes #1338
ref: #1142 review round 3 triage（PREEXISTING cluster）

## Risk / 兼容性

无破坏性变更。无 wire / event / command 契约改动——F35 只改 error **message 文本**，error code（`ErrInvalidNamespace`）与 Kind 不变，非 wire 契约（不触发 API 版本升级）；F21 只合并 Go 变量，Prometheus metric 名与 bucket 边界值不变；F19/F18 行为不变（仅补 ctx 关联 / 测试等待惯用法）。`TEST-SLEEP-DISCIPLINE-01` 是 scan-unannotated guard，删 sleep+注释干净无 golden 漂移；`MESSAGE-CONST-LITERAL-01` 由 4 个新 const literal 满足。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./...` 本地通过（unit: `adapters/mqtt` + `internal/topicns`）
- [x] `golangci-lint run` 0 issues（CI-equivalent，mqtt 模块无 build tag）
- [x] 3 个转换后的集成测试对真实 Mosquitto（testcontainers）通过：`Disposition3State` / `ClientIDConflict`(会话接管) / `DLTCapture`
