### PR TITLE
refactor(fspath): extract isWithinRoot to pkg/fspath, delete metadata/governance duplicates [#1255]

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -988,7 +988,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: Vet (cross-platform unit subset)
-        run: go vet ./runtime/shutdown/... ./runtime/config/... ./pkg/fspath/... ./pkg/pathsafe/...
+        run: go vet ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/fspath/... ./pkg/pathsafe/...
         shell: bash
 
       - name: Cross-platform unit smoke
@@ -996,9 +996,9 @@ jobs:
         # Enable -race on macOS to maximise race-detector coverage.
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            go test -race -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./pkg/fspath/... ./pkg/pathsafe/...
+            go test -race -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/fspath/... ./pkg/pathsafe/...
           else
-            go test -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./pkg/fspath/... ./pkg/pathsafe/...
+            go test -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/fspath/... ./pkg/pathsafe/...
           fi
         shell: bash
 

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -988,7 +988,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: Vet (cross-platform unit subset)
-        run: go vet ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/pathsafe/...
+        run: go vet ./runtime/shutdown/... ./runtime/config/... ./pkg/fspath/... ./pkg/pathsafe/...
         shell: bash
 
       - name: Cross-platform unit smoke
@@ -996,9 +996,9 @@ jobs:
         # Enable -race on macOS to maximise race-detector coverage.
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            go test -race -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/pathsafe/...
+            go test -race -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./pkg/fspath/... ./pkg/pathsafe/...
           else
-            go test -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./kernel/governance/... ./pkg/pathsafe/...
+            go test -count=1 -timeout 5m ./runtime/shutdown/... ./runtime/config/... ./pkg/fspath/... ./pkg/pathsafe/...
           fi
         shell: bash
 

--- a/cmd/corebundle/bundle_devtools.go
+++ b/cmd/corebundle/bundle_devtools.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock"
-	"github.com/ghbvf/gocell/kernel/governance"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/fspath"
 	"github.com/ghbvf/gocell/runtime/bootstrap"
 	"github.com/ghbvf/gocell/runtime/composition"
 	"github.com/ghbvf/gocell/tools/wiresummary"
@@ -48,7 +48,7 @@ func devtoolsOption(shared *composition.SharedDeps) bootstrap.Option {
 			slog.Any("error", err))
 		return bootstrap.WithDevtoolsCatalog(nil, "", nil)
 	}
-	if !governance.IsWithinRoot(cwd, absRoot) {
+	if !fspath.IsWithinRoot(cwd, absRoot) {
 		slog.Warn("devtools: GOCELL_PROJECT_ROOT escapes working tree; catalog endpoint disabled",
 			slog.String("root", root),
 			slog.String("absRoot", absRoot),

--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -574,9 +574,9 @@ func TestPrintTargetList(t *testing.T) {
 }
 
 // TestIsWithinRoot / TestEvalExistingPrefix previously lived here as a copy
-// of kernel/governance's tests. Now that cmd/gocell/app delegates to the
-// exported governance.IsWithinRoot / EvalExistingPrefix, coverage lives in
-// kernel/governance/validate_test.go — no duplication here.
+// of kernel/governance's tests. Coverage now lives in pkg/fspath
+// (github.com/ghbvf/gocell/pkg/fspath, see pkg/fspath/fspath_test.go) — no
+// duplication here.
 
 // TestPrintResult and the file:line:col / scope rendering tests previously
 // lived here as direct callers of printResult. They moved to

--- a/docs/architecture/202605241700-adr-contracts-shared-cas-mixin-funnel.md
+++ b/docs/architecture/202605241700-adr-contracts-shared-cas-mixin-funnel.md
@@ -34,7 +34,7 @@ S6 PR 给 6 个 configcore 写接口加 CAS（compare-and-swap）守卫字段
 - **runtime 校验 embed**：`builder.go` embed 路径原先读 raw bytes 不解析 `$ref`，外部 `$ref` 会让
   `schemavalidate.NewValidator`（santhosh-tekuri，`mem:///` base，无 loader）在 codegen 期编译失败。
   **新增 `bundleSchemaRefs`**（`refbundle.go`）：compact 前递归内联 `$ref`、剥离 document-meta
-  （`$schema`/`$id`/`title`）、`governance.IsWithinRoot` 路径守护、无 `$ref` 文件原样透传（golden 不变）。
+  （`$schema`/`$id`/`title`）、`fspath.IsWithinRoot` 路径守护、无 `$ref` 文件原样透传（golden 不变）。
   生成的 embed 自包含、无 `$ref`，runtime 无需文件系统 loader。
 
 ### 载体 2 — DELETE query param（contract.yaml `$ref`，解析期回填）
@@ -62,7 +62,7 @@ governance FMT-25 `inlineCrossFileSchemaRefs`（新，否则 `scanSchemaForInput
 
 1. root-guard：拒绝绝对路径 `$ref` + `IsWithinRoot`/`fs.ValidPath`/allow-list 守护（三者择一，按所在层的 IO）。
 
-**守护基线对齐说明**：三个生产解析者（contractgen DTO/embed bundler、metadata paramRef、governance FMT-25）的守护基线 = **词法 root 限制**（`governance.IsWithinRoot` 或 `os.DirFS(root)` + `fs.ValidPath`，两者等价，均拒绝逃出仓库根）。这是 build/validate 期对**仓库受控**文件的读取，无运行时攻击者输入，root 限制足够。`tests/contracttest` 额外做 symlink 解析 + `contracts/shared/` allow-list，是测试侧的更严防御（非生产强制要求）；三个生产解析者不强制对齐到该层级（symlink 逃逸需提交恶意 symlink，code review 必现，近零真实风险）。若未来引入运行时用户可控的 `$ref`，再统一升级为 symlink-resolved + allow-list。
+**守护基线对齐说明**：三个生产解析者（contractgen DTO/embed bundler、metadata paramRef、governance FMT-25）的守护基线 = **词法 root 限制**（`fspath.IsWithinRoot` 或 `os.DirFS(root)` + `fs.ValidPath`，两者等价，均拒绝逃出仓库根）。这是 build/validate 期对**仓库受控**文件的读取，无运行时攻击者输入，root 限制足够。`tests/contracttest` 额外做 symlink 解析 + `contracts/shared/` allow-list，是测试侧的更严防御（非生产强制要求）；三个生产解析者不强制对齐到该层级（symlink 逃逸需提交恶意 symlink，code review 必现，近零真实风险）。若未来引入运行时用户可控的 `$ref`，再统一升级为 symlink-resolved + allow-list。
 2. 拒绝 `http(s)://` 绝对 URL。
 3. cycle guard（visited set，DFS-scoped）。
 4. missing-file 错误包成本层的领域错误类型（不要裸 `*os.PathError` 泄漏给上层误判），点名缺失的是 `$ref` target 而非引用者。

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -162,7 +162,8 @@ parallel with the Linux `build-test` job.
 - `runtime/config` — symlink pivot detection; symlink tests are skipped on Windows via
   `t.Skip("symlink requires SeCreateSymbolicLinkPrivilege on Windows")` so the Windows runner
   passes cleanly while macOS validates the full symlink path.
-- `kernel/governance` — `IsWithinRoot` symlink escape test; same Windows skip applies.
+- `pkg/fspath` — `IsWithinRoot` / `EvalExistingPrefix` symlink-escape + missing-leaf tests;
+  same Windows skip applies (the shared root-containment predicate lives here, #1255).
 - `pkg/pathsafe` — cross-platform path containment / symlink-escape checks.
 
 **Coverage:** the `os-smoke` job does NOT upload a coverage profile and does NOT contribute to

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -150,6 +150,7 @@ go test -count=1 -timeout 5m \
   ./runtime/shutdown/... \
   ./runtime/config/... \
   ./kernel/governance/... \
+  ./pkg/fspath/... \
   ./pkg/pathsafe/...
 ```
 
@@ -162,6 +163,11 @@ parallel with the Linux `build-test` job.
 - `runtime/config` — symlink pivot detection; symlink tests are skipped on Windows via
   `t.Skip("symlink requires SeCreateSymbolicLinkPrivilege on Windows")` so the Windows runner
   passes cleanly while macOS validates the full symlink path.
+- `kernel/governance` — contract `$ref` resolution holds OS-divergent absolute-path detection
+  (`isAbsoluteSchemaRef`: `path.IsAbs` ORed with `filepath.IsAbs(filepath.FromSlash(...))`, since
+  `filepath.IsAbs("/etc/passwd")` is `false` on Windows). The `absolute_path_ref_rejected` test is
+  the Windows-only guard that a leading-slash `$ref` is still rejected on windows-latest. This is
+  why governance stays in the matrix even after `IsWithinRoot` moved to `pkg/fspath` (#1255).
 - `pkg/fspath` — `IsWithinRoot` / `EvalExistingPrefix` symlink-escape + missing-leaf tests;
   same Windows skip applies (the shared root-containment predicate lives here, #1255).
 - `pkg/pathsafe` — cross-platform path containment / symlink-escape checks.

--- a/kernel/governance/helpers.go
+++ b/kernel/governance/helpers.go
@@ -2,7 +2,6 @@ package governance
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -200,56 +199,6 @@ func repositoryRoot(root string) string {
 		return root
 	}
 	return absRoot
-}
-
-// IsWithinRoot checks that target resolves to a path inside root.
-// Both sides are normalized to absolute paths, and symlinks are resolved
-// when possible, to prevent both relative-path and symlink-based bypasses.
-//
-// Exported so cmd/gocell and other callers share a single implementation
-// rather than carrying a duplicate with a hand-maintained `// SYNC:` note.
-//
-// kernel/metadata.isWithinRoot is a forced duplicate (layering forbids
-// kernel/metadata importing kernel/governance); keep both in sync until the
-// shared-helper extraction tracked in #1255 lands.
-func IsWithinRoot(root, target string) bool {
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return false
-	}
-	absTarget, err := filepath.Abs(target)
-	if err != nil {
-		return false
-	}
-	// Resolve symlinks on root (which should exist).
-	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
-		absRoot = resolved
-	}
-	// For target: resolve symlinks if possible. If the target doesn't exist
-	// (common — we're checking *whether* a file exists), resolve the longest
-	// existing ancestor to handle platforms where intermediate dirs are
-	// symlinks (e.g., macOS /tmp → /private/tmp).
-	if resolved, err := filepath.EvalSymlinks(absTarget); err == nil {
-		absTarget = resolved
-	} else {
-		absTarget = EvalExistingPrefix(absTarget)
-	}
-	cleanRoot := absRoot + string(os.PathSeparator)
-	return strings.HasPrefix(absTarget, cleanRoot) || absTarget == absRoot
-}
-
-// EvalExistingPrefix resolves symlinks on the longest existing ancestor of p,
-// then appends the non-existent suffix. This handles platforms where
-// intermediate directories are symlinks (e.g., macOS /tmp → /private/tmp).
-func EvalExistingPrefix(p string) string {
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
-		return resolved
-	}
-	parent := filepath.Dir(p)
-	if parent == p {
-		return p // filesystem root, stop recursion
-	}
-	return filepath.Join(EvalExistingPrefix(parent), filepath.Base(p))
 }
 
 // --- actor helpers ---

--- a/kernel/governance/rules_http.go
+++ b/kernel/governance/rules_http.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/metadata"
 	"github.com/ghbvf/gocell/pkg/contractpath"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 const (
@@ -380,7 +381,7 @@ func safeJoinUnderRoot(root string, segments ...string) (string, bool) {
 		}
 	}
 	full := filepath.Join(append([]string{root}, segments...)...)
-	if !IsWithinRoot(root, full) {
+	if !fspath.IsWithinRoot(root, full) {
 		return "", false
 	}
 	return full, true
@@ -392,7 +393,8 @@ func safeJoinUnderRoot(root string, segments ...string) (string, bool) {
 //
 // Scoped to rules_http.go (CH-04/05 message redaction). Promote to helpers.go
 // if a third rule needs it — it is deliberately separate from the security-
-// oriented IsWithinRoot/repositoryRoot helpers there.
+// oriented helpers there (IsWithinRoot now lives in pkg/fspath;
+// repositoryRoot lives in helpers.go).
 func relToRoot(root, p string) string {
 	if root != "" {
 		if rel, err := filepath.Rel(root, p); err == nil && !strings.HasPrefix(rel, "..") {

--- a/kernel/governance/rules_misc_advisory.go
+++ b/kernel/governance/rules_misc_advisory.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/ghbvf/gocell/kernel/cellvocab"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 // =============================================================================
@@ -754,7 +755,7 @@ func (v *Validator) walkDocNamingInclude(include string, exclude []string, seen 
 	// Don't walk a tree rooted outside the project (addDocNamingTarget would
 	// reject each escaping file anyway, but skipping the walk avoids
 	// enumerating directories outside the root).
-	if !IsWithinRoot(v.root, baseAbs) {
+	if !fspath.IsWithinRoot(v.root, baseAbs) {
 		return nil
 	}
 	info, statErr := os.Stat(baseAbs)
@@ -798,7 +799,7 @@ func (v *Validator) globDocNamingInclude(include string, exclude []string, seen 
 		// Defense-in-depth symmetric with walkDocNamingInclude: skip matches
 		// outside the root before addDocNamingTarget (which also guards). A glob
 		// pattern containing `..` can match parent-dir entries.
-		if !IsWithinRoot(v.root, match) {
+		if !fspath.IsWithinRoot(v.root, match) {
 			continue
 		}
 		v.addDocNamingTarget(match, exclude, seen)
@@ -811,7 +812,7 @@ func (v *Validator) addDocNamingTarget(abs string, exclude []string, seen map[st
 	// escape the project root (a hostile naming-guard.yaml could otherwise read
 	// arbitrary files on the CI worker via `include: ../../...`). Mirrors the
 	// IsWithinRoot guard already used by resolveCrossFileSchemaRef and rules_ref.go.
-	if !IsWithinRoot(v.root, abs) {
+	if !fspath.IsWithinRoot(v.root, abs) {
 		return
 	}
 	info, err := os.Stat(abs)

--- a/kernel/governance/rules_misc_strict.go
+++ b/kernel/governance/rules_misc_strict.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 // =============================================================================
@@ -896,7 +897,7 @@ func resolveCrossFileSchemaRef(ref, dir, projectRoot string, seen map[string]boo
 		return nil, &schemaWalkError{path: ref, msg: fmt.Sprintf("cross-file $ref %q must be relative", ref)}
 	}
 	targetAbs := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ref)))
-	if projectRoot != "" && !IsWithinRoot(projectRoot, targetAbs) {
+	if projectRoot != "" && !fspath.IsWithinRoot(projectRoot, targetAbs) {
 		return nil, &schemaWalkError{path: ref, msg: fmt.Sprintf("cross-file $ref %q escapes project root", ref)}
 	}
 	if seen[targetAbs] {

--- a/kernel/governance/rules_ref.go
+++ b/kernel/governance/rules_ref.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 const fieldBuildEntrypoint = "build.entrypoint"
@@ -217,7 +218,7 @@ func (v *Validator) validateREF11() []ValidationResult {
 		// The entrypoint path is relative to the repository root (parent of go.mod directory).
 		repoRoot := repositoryRoot(v.root)
 		fullPath := filepath.Join(repoRoot, a.Build.Entrypoint)
-		if !IsWithinRoot(repoRoot, fullPath) {
+		if !fspath.IsWithinRoot(repoRoot, fullPath) {
 			results = append(results, v.newError(
 				codeREF11, IssueInvalid,
 				assemblyFile(a),
@@ -320,7 +321,7 @@ func (v *Validator) validateREF16() []ValidationResult {
 	for _, a := range v.project.Assemblies {
 		generatedDir := metadata.AssemblyGeneratedDir(a)
 		boundaryPath := filepath.Join(v.root, filepath.FromSlash(generatedDir), "boundary.yaml")
-		if !IsWithinRoot(v.root, boundaryPath) {
+		if !fspath.IsWithinRoot(v.root, boundaryPath) {
 			results = append(results, v.newError(
 				codeREF16, IssueInvalid,
 				assemblyFile(a),

--- a/kernel/governance/validate_test.go
+++ b/kernel/governance/validate_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -3705,62 +3704,6 @@ func TestActorExists(t *testing.T) {
 	assert.True(t, val.actorExists("accesscore"), "cell should be a known actor")
 	assert.True(t, val.actorExists(metadatatest.CellIDEdgeBFF), "external actor should be known")
 	assert.False(t, val.actorExists("nonexistent"), "unknown ID should not exist")
-}
-
-// --- S1: IsWithinRoot path traversal guard ---
-
-func TestIsWithinRoot(t *testing.T) {
-	tests := []struct {
-		name   string
-		root   string
-		target string
-		want   bool
-	}{
-		{"inside root", "/project/src", "/project/src/cmd/main.go", true},
-		{"equals root", "/project/src", "/project/src", true},
-		{"escapes root", "/project/src", "/project/etc/passwd", false},
-		{"dot-dot escapes", "/project/src", "/project/src/../etc/passwd", false},
-		{"different tree", "/project/src", "/other/place", false},
-	}
-	// Also test relative paths (P1 fix: IsWithinRoot must handle relative root).
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	tests = append(tests, struct {
-		name   string
-		root   string
-		target string
-		want   bool
-	}{
-		"relative root dot",
-		".",
-		filepath.Join(cwd, "assemblies", "corebundle", "generated", "boundary.yaml"),
-		true,
-	})
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := IsWithinRoot(tt.root, tt.target)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestIsWithinRoot_Symlink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink requires SeCreateSymbolicLinkPrivilege on Windows")
-	}
-	root := t.TempDir()
-	outside := t.TempDir()
-
-	// Create a file outside root.
-	outsideFile := filepath.Join(outside, "secret.yaml")
-	require.NoError(t, os.WriteFile(outsideFile, []byte("x"), 0o644))
-
-	// Create a symlink inside root pointing outside.
-	symlink := filepath.Join(root, "escape")
-	require.NoError(t, os.Symlink(outside, symlink))
-
-	target := filepath.Join(symlink, "secret.yaml")
-	assert.False(t, IsWithinRoot(root, target), "symlink target outside root should be rejected")
 }
 
 // --- S1: REF-11 path traversal ---

--- a/kernel/metadata/schema_refs.go
+++ b/kernel/metadata/schema_refs.go
@@ -2,10 +2,11 @@ package metadata
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 // SchemaRefScope describes the filesystem boundary used to resolve a schema ref.
@@ -137,7 +138,7 @@ func ResolveContractSchemaRef(projectRoot string, c *ContractMeta, ref ContractS
 	if ref.Scope == SchemaRefScopeProjectRoot {
 		bounds = rootAbs
 	}
-	if !isWithinRoot(bounds, target) {
+	if !fspath.IsWithinRoot(bounds, target) {
 		return ResolvedSchemaRef{}, &SchemaRefError{Field: ref.Field, Ref: ref.Ref, Kind: "path escapes project root or " + string(ref.Scope)}
 	}
 	rel, err := filepath.Rel(rootAbs, target)
@@ -174,41 +175,4 @@ func sortedStringKeys(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
-}
-
-// isWithinRoot mirrors kernel/governance.IsWithinRoot. The duplication is
-// forced by layering (kernel/metadata cannot import kernel/governance); keep
-// the two in sync. Extracting a shared helper is tracked in #1255.
-func isWithinRoot(root, target string) bool {
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return false
-	}
-	absTarget, err := filepath.Abs(target)
-	if err != nil {
-		return false
-	}
-	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
-		absRoot = resolved
-	} else {
-		absRoot = evalExistingPrefix(absRoot)
-	}
-	if resolved, err := filepath.EvalSymlinks(absTarget); err == nil {
-		absTarget = resolved
-	} else {
-		absTarget = evalExistingPrefix(absTarget)
-	}
-	prefix := absRoot + string(os.PathSeparator)
-	return absTarget == absRoot || strings.HasPrefix(absTarget, prefix)
-}
-
-func evalExistingPrefix(path string) string {
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return resolved
-	}
-	parent := filepath.Dir(path)
-	if parent == path {
-		return path
-	}
-	return filepath.Join(evalExistingPrefix(parent), filepath.Base(path))
 }

--- a/kernel/metadata/schema_refs_test.go
+++ b/kernel/metadata/schema_refs_test.go
@@ -176,7 +176,6 @@ func TestResolveContractSchemaRefScopes(t *testing.T) {
 
 func TestResolveContractSchemaRefRejectsEscapes(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(root, "..", "outside.schema.json")
 	c := &ContractMeta{ID: "http.auth.login.v1", Dir: "contracts/http/auth/login/v1"}
 
 	_, err := ResolveContractSchemaRef(root, c, ContractSchemaRef{
@@ -186,7 +185,6 @@ func TestResolveContractSchemaRefRejectsEscapes(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path escapes")
-	assert.False(t, isWithinRoot(root, outside))
 }
 
 func TestResolveContractSchemaRefRejectsSymlinkEscape(t *testing.T) {
@@ -234,11 +232,6 @@ func TestResolveContractSchemaRefsSkipsEmptyAndStopsOnError(t *testing.T) {
 	_, err = ResolveContractSchemaRefs(root, c)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "schemaRefs.response")
-}
-
-func TestIsWithinRootHandlesMissingLeaf(t *testing.T) {
-	root := t.TempDir()
-	assert.True(t, isWithinRoot(root, filepath.Join(root, "missing", "schema.json")))
 }
 
 func ensureTestFile(path string) error {

--- a/pkg/fspath/fspath.go
+++ b/pkg/fspath/fspath.go
@@ -1,0 +1,82 @@
+// Package fspath holds the single, symlink-aware root-containment predicate
+// shared across the codebase: IsWithinRoot reports whether a target path
+// resolves inside a root, and EvalExistingPrefix resolves the longest existing
+// ancestor of a not-yet-existing path.
+//
+// # Single source
+//
+// This is the SOLE implementation. Both kernel/metadata (schema ref resolution)
+// and kernel/governance (REF-11/REF-12 path-traversal rules, generated-artifact
+// lookup) depend on it, as do cmd/ and tools/codegen. It lives under pkg/ —
+// rather than in either kernel package — because kernel/metadata cannot import
+// kernel/governance: the kernel-internal import DAG forbids it (metadata's
+// allowlist is {cellvocab}; enforced by archtest KERNEL-INTERNAL-DAG-01). pkg/
+// depends only on the standard library, so it is the one place both kernel
+// layers may reach. Extracting it here is what eliminated the previous
+// hand-synced duplicate pair (the old `// SYNC:` notes, #1255).
+//
+// This package comment is clarifying documentation, not an enforcement
+// mechanism: the import ban that makes a shared home necessary is held by
+// KERNEL-INTERNAL-DAG-01, not by this note.
+//
+// # Boundary
+//
+// Not a substitute for pkg/pathsafe.ContainPath: that helper takes a relative
+// target under a pre-resolved root and walks parent symlinks as part of the
+// scaffold/codegen write TOCTOU funnel. fspath is a read-only predicate over a
+// (root, target) pair where both sides are absolutized internally; it makes no
+// write-safety guarantee.
+package fspath
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IsWithinRoot reports whether target resolves to a path inside root.
+//
+// Both sides are absolutized and symlink-resolved before comparison, defeating
+// both relative-path and symlink-based escapes. When a side cannot be resolved
+// by filepath.EvalSymlinks (the common case where target does not exist yet, or
+// a non-existent root), the longest existing ancestor is resolved via
+// EvalExistingPrefix and the missing suffix appended — so a not-yet-created
+// file under root is still reported as within root, while a symlink that
+// redirects outside root is rejected.
+func IsWithinRoot(root, target string) bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = resolved
+	} else {
+		absRoot = EvalExistingPrefix(absRoot)
+	}
+	if resolved, err := filepath.EvalSymlinks(absTarget); err == nil {
+		absTarget = resolved
+	} else {
+		absTarget = EvalExistingPrefix(absTarget)
+	}
+	prefix := absRoot + string(os.PathSeparator)
+	return absTarget == absRoot || strings.HasPrefix(absTarget, prefix)
+}
+
+// EvalExistingPrefix resolves symlinks on the longest existing ancestor of p,
+// then re-appends the non-existent suffix. This handles platforms where
+// intermediate directories are symlinks (e.g., macOS /tmp → /private/tmp) for
+// paths whose leaf does not exist yet.
+func EvalExistingPrefix(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	parent := filepath.Dir(p)
+	if parent == p {
+		return p // filesystem root, stop recursion
+	}
+	return filepath.Join(EvalExistingPrefix(parent), filepath.Base(p))
+}

--- a/pkg/fspath/fspath.go
+++ b/pkg/fspath/fspath.go
@@ -9,11 +9,11 @@
 // and kernel/governance (REF-11/REF-12 path-traversal rules, generated-artifact
 // lookup) depend on it, as do cmd/ and tools/codegen. It lives under pkg/ —
 // rather than in either kernel package — because kernel/metadata cannot import
-// kernel/governance: the kernel-internal import DAG forbids it (metadata's
-// allowlist is {cellvocab}; enforced by archtest KERNEL-INTERNAL-DAG-01). pkg/
-// depends only on the standard library, so it is the one place both kernel
-// layers may reach. Extracting it here is what eliminated the previous
-// hand-synced duplicate pair (the old `// SYNC:` notes, #1255).
+// kernel/governance: the kernel-internal import DAG forbids it (enforced by
+// archtest KERNEL-INTERNAL-DAG-01). pkg/ depends only on the standard library,
+// so it is the one place both kernel layers may reach. Extracting it here is
+// what eliminated the previous hand-synced duplicate pair (the old `// SYNC:`
+// notes, #1255).
 //
 // This package comment is clarifying documentation, not an enforcement
 // mechanism: the import ban that makes a shared home necessary is held by

--- a/pkg/fspath/fspath_test.go
+++ b/pkg/fspath/fspath_test.go
@@ -1,0 +1,121 @@
+package fspath_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ghbvf/gocell/pkg/fspath"
+)
+
+func TestIsWithinRoot(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		root   string
+		target string
+		want   bool
+	}{
+		{"inside root", "/project/src", "/project/src/cmd/main.go", true},
+		{"equals root", "/project/src", "/project/src", true},
+		{"escapes root", "/project/src", "/project/etc/passwd", false},
+		{"dot-dot escapes", "/project/src", "/project/src/../etc/passwd", false},
+		{"different tree", "/project/src", "/other/place", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fspath.IsWithinRoot(tt.root, tt.target); got != tt.want {
+				t.Errorf("IsWithinRoot(%q, %q) = %v, want %v", tt.root, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsWithinRootRelativeRoot covers a relative root ("."): IsWithinRoot must
+// absolutize both sides before comparing. The target is constructed under the
+// current working directory so it is genuinely contained.
+func TestIsWithinRootRelativeRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	target := filepath.Join(cwd, "nested", "artifact.yaml")
+	if !fspath.IsWithinRoot(".", target) {
+		t.Errorf("IsWithinRoot(%q, %q) = false, want true (relative root must absolutize)", ".", target)
+	}
+}
+
+// TestIsWithinRootMissingLeaf: a not-yet-existing leaf under an existing root is
+// still within root — the longest existing ancestor resolves and the missing
+// suffix is appended. This is the common "checking whether a file exists" path.
+func TestIsWithinRootMissingLeaf(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "missing", "schema.json")
+	if !fspath.IsWithinRoot(root, target) {
+		t.Errorf("IsWithinRoot(%q, %q) = false, want true (missing leaf under root)", root, target)
+	}
+}
+
+// TestIsWithinRootSymlinkEscape: a symlink inside root that points outside root
+// must be rejected — symlink resolution defeats the prefix check.
+func TestIsWithinRootSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink requires SeCreateSymbolicLinkPrivilege on Windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	outsideFile := filepath.Join(outside, "secret.yaml")
+	if err := os.WriteFile(outsideFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	symlink := filepath.Join(root, "escape")
+	if err := os.Symlink(outside, symlink); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	target := filepath.Join(symlink, "secret.yaml")
+	if fspath.IsWithinRoot(root, target) {
+		t.Errorf("IsWithinRoot(%q, %q) = true, want false (symlink target outside root)", root, target)
+	}
+}
+
+// TestEvalExistingPrefixResolvesAncestorSymlink: for a non-existent path whose
+// parent is a symlink, EvalExistingPrefix resolves the existing-ancestor symlink
+// and appends the missing suffix.
+func TestEvalExistingPrefixResolvesAncestorSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink requires SeCreateSymbolicLinkPrivilege on Windows")
+	}
+	realDir := t.TempDir()
+	linkParent := t.TempDir()
+	link := filepath.Join(linkParent, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	resolvedReal, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(realDir): %v", err)
+	}
+	got := fspath.EvalExistingPrefix(filepath.Join(link, "missing.json"))
+	want := filepath.Join(resolvedReal, "missing.json")
+	if got != want {
+		t.Errorf("EvalExistingPrefix = %q, want %q (ancestor symlink should resolve)", got, want)
+	}
+}
+
+// TestEvalExistingPrefixExistingPath: a path that fully exists resolves through
+// EvalSymlinks.
+func TestEvalExistingPrefixExistingPath(t *testing.T) {
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if got := fspath.EvalExistingPrefix(dir); got != resolved {
+		t.Errorf("EvalExistingPrefix(%q) = %q, want %q", dir, got, resolved)
+	}
+}

--- a/tools/codegen/contractgen/jsonschema.go
+++ b/tools/codegen/contractgen/jsonschema.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghbvf/gocell/kernel/governance"
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 // Schema represents the minimal subset of JSON Schema draft 2020-12 used by contractgen.
@@ -393,7 +393,7 @@ func resolveRef(
 	targetAbs := filepath.Clean(filepath.Join(filepath.Dir(currentFile), ref))
 
 	// B.1: path-traversal guard — resolved target must remain within rootDir.
-	if rootDir != "" && !governance.IsWithinRoot(rootDir, targetAbs) {
+	if rootDir != "" && !fspath.IsWithinRoot(rootDir, targetAbs) {
 		return nil, fmt.Errorf("contractgen/jsonschema: $ref %q at %s resolves to %s which is outside root %s", ref, loc, targetAbs, rootDir)
 	}
 

--- a/tools/codegen/contractgen/refbundle.go
+++ b/tools/codegen/contractgen/refbundle.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghbvf/gocell/kernel/governance"
+	"github.com/ghbvf/gocell/pkg/fspath"
 )
 
 // bundleSchemaRefs resolves all external $ref entries in raw (a JSON Schema file
@@ -128,7 +128,7 @@ func loadAndStripRef(rootDir, currentFile, refStr string, visited map[string]str
 
 	targetAbs := filepath.Clean(filepath.Join(filepath.Dir(currentFile), refStr))
 
-	if !governance.IsWithinRoot(rootDir, targetAbs) {
+	if !fspath.IsWithinRoot(rootDir, targetAbs) {
 		return nil, fmt.Errorf(
 			"refbundle: $ref %q in %s resolves to %s which is outside root %s",
 			refStr, currentFile, targetAbs, rootDir)

--- a/tools/codegen/writer.go
+++ b/tools/codegen/writer.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/ghbvf/gocell/kernel/governance"
+	"github.com/ghbvf/gocell/pkg/fspath"
 	"github.com/ghbvf/gocell/pkg/pathsafe"
 )
 
@@ -43,7 +44,7 @@ type WriteOptions struct {
 	Path string
 	// Content is the bytes to compare against / write to the target.
 	Content []byte
-	// RepoRoot gates Path through governance.IsWithinRoot to reject path
+	// RepoRoot gates Path through fspath.IsWithinRoot to reject path
 	// traversal. Must be non-empty (the output of pathsafe.ResolveRoot);
 	// Write returns an error immediately if RepoRoot is empty.
 	RepoRoot string
@@ -75,7 +76,7 @@ type WriteResult struct {
 
 // Write persists Content to opts.Path with two safety guards:
 //
-//  1. opts.Path must be inside opts.RepoRoot (governance.IsWithinRoot);
+//  1. opts.Path must be inside opts.RepoRoot (fspath.IsWithinRoot);
 //     opts.RepoRoot must be non-empty — Write returns an error otherwise.
 //     Out-of-root writes are refused.
 //  2. If opts.Path already exists on disk, its first bytes must match
@@ -93,7 +94,7 @@ func Write(opts WriteOptions) (WriteResult, error) {
 	if opts.RepoRoot == "" {
 		return res, fmt.Errorf("codegen write: RepoRoot is required")
 	}
-	if !governance.IsWithinRoot(opts.RepoRoot, opts.Path) {
+	if !fspath.IsWithinRoot(opts.RepoRoot, opts.Path) {
 		return res, fmt.Errorf("codegen write: path escapes RepoRoot: %s", opts.Path)
 	}
 

--- a/tools/generatedverify/generatedverify.go
+++ b/tools/generatedverify/generatedverify.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/assembly"
 	"github.com/ghbvf/gocell/kernel/governance"
 	"github.com/ghbvf/gocell/kernel/metadata"
+	"github.com/ghbvf/gocell/pkg/fspath"
 	"github.com/ghbvf/gocell/tools/codegen/cellgen"
 	"github.com/ghbvf/gocell/tools/codegen/contractgen"
 	"github.com/ghbvf/gocell/tools/codegen/requireddepsgen"
@@ -474,7 +475,7 @@ func validateArtifactPaths(root string, artifacts []Artifact) error {
 			return fmt.Errorf("%s for assembly %q must be repo-relative: %s",
 				artifact.Kind, artifact.AssemblyID, artifact.Path)
 		}
-		if !governance.IsWithinRoot(root, absPath(root, artifact.Path)) {
+		if !fspath.IsWithinRoot(root, absPath(root, artifact.Path)) {
 			return fmt.Errorf("%s for assembly %q escapes project root: %s",
 				artifact.Kind, artifact.AssemblyID, artifact.Path)
 		}


### PR DESCRIPTION
## Summary

把 `kernel/metadata.isWithinRoot` 与 `kernel/governance.IsWithinRoot` 两份功能相同的 symlink-aware 路径包含判定抽取为单一 `pkg/fspath` 实现，删除两份副本与手工 `// SYNC:` 同步注释。

## Why / 背景

两处是同一个 root-containment 谓词的拷贝，被 kernel-internal import DAG 逼开（`kernel/metadata` 不能 import `kernel/governance`），只能靠 godoc `// SYNC:` 手工同步——这是 AI-robust 章程里的 **Soft** 约束（依赖人记住），正是要消除的形态。`pkg/` 只依赖 stdlib 且 `kernel/*` 可依赖 `pkg/`，是双方唯一共同可依赖的合规落点，故把单一实现提到 `pkg/fspath`。

合并时统一到更健壮的 metadata 变体（`evalExistingPrefix` 对 root 和 target 都兜底）——对现有全部测试用例**行为不变**：root 存在时 `EvalSymlinks` 成功两者等价；root 不存在时逐级解析最长存在祖先后原样重建，对字面路径输出不变。

净效果：**移除一个 Soft 约束、不引入任何新 Soft 约束**。结构性根因（metadata ⊄ governance）继续由既有 `KERNEL-INTERNAL-DAG-01`（Medium，闭集 allowlist + drift 检查）静态守住，本次 allowlist 零改动。

## Refs

- Closes #1255
- ref: 无新框架对标（纯内部去重，沿用 `pkg/pathsafe` / `pkg/contractpath` 单职责工具包范式）
- 结构守卫：`KERNEL-INTERNAL-DAG-01`（`tools/archtest/kernel_internal_dag_test.go`）

## Risk / 兼容性

- 删除 exported `governance.IsWithinRoot` / `EvalExistingPrefix` 与 metadata 私有副本，**不留 re-export wrapper / 别名 / 双路径**（pre-GA，无外部调用方；repo 内 7 个调用点已全部迁移：governance 规则 ×6、`cmd/corebundle`、`tools/codegen` ×3、`tools/generatedverify`）。
- 无 wire / contract / schema / 迁移影响——纯 Go 函数搬家，行为等价。

## Test plan

- [x] `go build ./...` 本地通过（含 `go build -tags=integration ./...`，删 exported 签名属公共签名变更）
- [x] `go test ./...` 本地通过（exit 0，134 ok / 0 fail；含 `pkg/fspath` 表驱动 85% 覆盖、governance REF-11/REF-12、metadata symlink-escape 集成测试，行为等价已验证）
- [x] `golangci-lint run` 0 issues（v2.11.4，pinned 一致）
- [x] `KERNEL-INTERNAL-DAG-01` archtest 绿（allowlist 零改动）；full archtest 套件相对 develop 基线**零回归**（15 个 pre-existing harness-artifact 失败，按名逐条相同）
