### PR TITLE
feat(auth): X-Tenant-ID 纳入 service-token 签名材料 (SignedHeaders) [#1717]

### DIFF
--- a/cmd/corebundle/auth_integration_test.go
+++ b/cmd/corebundle/auth_integration_test.go
@@ -469,7 +469,7 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 		body := strings.NewReader(fmt.Sprintf(`{"userId":%q,"roleId":"nonexistent","tenantId":%q}`, seedUserID, testTenantID))
 		// Spec: 4-part token — callerCell="accesscore" is the identity claim.
 		token := auth.GenerateServiceToken(ring, "accesscore",
-			http.MethodPost, "/internal/v1/access/roles/assign", "", time.Now())
+			http.MethodPost, "/internal/v1/access/roles/assign", "", "", time.Now())
 		require.NotEmpty(t, token)
 
 		req, err := http.NewRequest(http.MethodPost,
@@ -495,7 +495,7 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 		body := strings.NewReader(fmt.Sprintf(`{"userId":%q,"roleId":"nonexistent","tenantId":%q}`, seedUserID, testTenantID))
 		// Spec: 4-part token — callerCell="accesscore".
 		token := auth.GenerateServiceToken(ring, "accesscore",
-			http.MethodPost, "/internal/v1/access/roles/revoke", "", time.Now())
+			http.MethodPost, "/internal/v1/access/roles/revoke", "", "", time.Now())
 		require.NotEmpty(t, token)
 
 		req, err := http.NewRequest(http.MethodPost,
@@ -522,7 +522,7 @@ func TestAuthWiring_InternalGuard_RequiresServiceToken(t *testing.T) {
 	t.Run("internal_replay_same_nonce_401", func(t *testing.T) {
 		// Spec: 4-part token — callerCell="accesscore".
 		token := auth.GenerateServiceToken(ring, "accesscore",
-			http.MethodPost, "/internal/v1/access/roles/revoke", "", time.Now())
+			http.MethodPost, "/internal/v1/access/roles/revoke", "", "", time.Now())
 		require.NotEmpty(t, token)
 
 		doReq := func() (int, string) {

--- a/cmd/corebundle/controlplane_guard_test.go
+++ b/cmd/corebundle/controlplane_guard_test.go
@@ -130,6 +130,6 @@ func TestBuildInternalHMACRing_ValidSecret_RingUsable(t *testing.T) {
 	require.NotNil(t, ring, "ring must be installed when secret is present")
 
 	// Verify ring works by generating a service token (non-empty result = usable ring).
-	token := auth.GenerateServiceToken(ring, "accesscore", "GET", "/internal/v1/access/roles", "", time.Now())
+	token := auth.GenerateServiceToken(ring, "accesscore", "GET", "/internal/v1/access/roles", "", "", time.Now())
 	assert.NotEmpty(t, token, "ring must produce valid service tokens")
 }

--- a/cmd/corebundle/setup_pg_integration_test.go
+++ b/cmd/corebundle/setup_pg_integration_test.go
@@ -1145,7 +1145,7 @@ func TestS4b_RbacRevoke_SameTxAtomicity(t *testing.T) {
 
 	// 3. Assign "editor" role via internal listener.
 	assignBody, _ := json.Marshal(map[string]string{"userId": userID, "roleId": "editor", "tenantId": testTenantID})
-	assignToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/assign", "", time.Now())
+	assignToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/assign", "", "", time.Now())
 	assignReq, _ := http.NewRequest(http.MethodPost, h.internalBase+"/internal/v1/access/roles/assign",
 		bytes.NewReader(assignBody))
 	assignReq.Header.Set("Authorization", "ServiceToken "+assignToken)
@@ -1168,7 +1168,7 @@ func TestS4b_RbacRevoke_SameTxAtomicity(t *testing.T) {
 
 	// 4. Revoke "editor" role → outbox write fails → tx rollback → 500.
 	revokeBody, _ := json.Marshal(map[string]string{"userId": userID, "roleId": "editor", "tenantId": testTenantID})
-	revokeToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/revoke", "", time.Now())
+	revokeToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/revoke", "", "", time.Now())
 	revokeReq, _ := http.NewRequest(http.MethodPost, h.internalBase+"/internal/v1/access/roles/revoke",
 		bytes.NewReader(revokeBody))
 	revokeReq.Header.Set("Authorization", "ServiceToken "+revokeToken)
@@ -1225,7 +1225,7 @@ func TestS4b_RoleChangeConsumer_NoRedundantRevoke(t *testing.T) {
 
 	// Assign "editor" role so revoke has something to act on.
 	assignBody, _ := json.Marshal(map[string]string{"userId": userID, "roleId": "editor", "tenantId": testTenantID})
-	assignToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/assign", "", time.Now())
+	assignToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/assign", "", "", time.Now())
 	assignReq, _ := http.NewRequest(http.MethodPost, h.internalBase+"/internal/v1/access/roles/assign",
 		bytes.NewReader(assignBody))
 	assignReq.Header.Set("Authorization", "ServiceToken "+assignToken)
@@ -1245,7 +1245,7 @@ func TestS4b_RoleChangeConsumer_NoRedundantRevoke(t *testing.T) {
 
 	// Revoke the role — funnel runs once: epoch bumped 1→2.
 	revokeBody, _ := json.Marshal(map[string]string{"userId": userID, "roleId": "editor", "tenantId": testTenantID})
-	revokeToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/revoke", "", time.Now())
+	revokeToken := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, "/internal/v1/access/roles/revoke", "", "", time.Now())
 	revokeReq, _ := http.NewRequest(http.MethodPost, h.internalBase+"/internal/v1/access/roles/revoke",
 		bytes.NewReader(revokeBody))
 	revokeReq.Header.Set("Authorization", "ServiceToken "+revokeToken)

--- a/corecells/accesscore/internal/adapters/http/configclient.go
+++ b/corecells/accesscore/internal/adapters/http/configclient.go
@@ -24,10 +24,6 @@ const (
 	defaultConfigClientHTTPTimeout = 5 * time.Second
 
 	internalKeyQuotedFmt = "key=%q"
-
-	// headerTenantID is the request header that carries the caller's tenant for
-	// configcore's RLS-scoped GET /internal/v1/config/{key}.
-	headerTenantID = "X-Tenant-ID"
 )
 
 // configEntryDataResponse mirrors the {data: {...}} envelope returned by
@@ -94,13 +90,16 @@ func (c *HTTPConfigGetter) GetEntry(ctx context.Context, t tenant.TenantID, key 
 	}
 
 	// Sign the request with a service token so the InternalListener middleware accepts it.
-	// callerCell="accesscore" mirrors contract.yaml endpoints.clients[0].
-	token := auth.GenerateServiceToken(c.ring, "accesscore", http.MethodGet, path, "", c.clock.Now())
+	// callerCell="accesscore" mirrors contract.yaml endpoints.clients[0]. The tenant
+	// assertion is bound into the token MAC (signed X-Tenant-ID header) and set on the
+	// wire from the SAME string, so a tampered/injected/stripped header fails verify.
+	tid := t.String()
+	token := auth.GenerateServiceToken(c.ring, "accesscore", http.MethodGet, path, "", tid, c.clock.Now())
 	if token == "" {
 		return ports.ConfigEntry{}, errcode.New(errcode.KindInternal, errcode.ErrInternal, "configclient: service token generation failed")
 	}
 	req.Header.Set("Authorization", "ServiceToken "+token)
-	req.Header.Set(headerTenantID, t.String())
+	req.Header.Set(auth.HeaderTenantID, tid)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/corecells/accesscore/internal/adapters/http/configclient.go
+++ b/corecells/accesscore/internal/adapters/http/configclient.go
@@ -90,16 +90,15 @@ func (c *HTTPConfigGetter) GetEntry(ctx context.Context, t tenant.TenantID, key 
 	}
 
 	// Sign the request with a service token so the InternalListener middleware accepts it.
-	// callerCell="accesscore" mirrors contract.yaml endpoints.clients[0]. The tenant
-	// assertion is bound into the token MAC (signed X-Tenant-ID header) and set on the
-	// wire from the SAME string, so a tampered/injected/stripped header fails verify.
-	tid := t.String()
-	token := auth.GenerateServiceToken(c.ring, "accesscore", http.MethodGet, path, "", tid, c.clock.Now())
+	// callerCell="accesscore" mirrors contract.yaml endpoints.clients[0]. The tenant t is
+	// bound into the token MAC (signed X-Tenant-ID) and set on the wire as the same
+	// canonical t.String(), so a tampered/injected/stripped header fails verification.
+	token := auth.GenerateServiceToken(c.ring, "accesscore", http.MethodGet, path, "", t, c.clock.Now())
 	if token == "" {
 		return ports.ConfigEntry{}, errcode.New(errcode.KindInternal, errcode.ErrInternal, "configclient: service token generation failed")
 	}
 	req.Header.Set("Authorization", "ServiceToken "+token)
-	req.Header.Set(auth.HeaderTenantID, tid)
+	req.Header.Set(auth.HeaderTenantID, t.String())
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/corecells/accesscore/internal/adapters/http/configclient_test.go
+++ b/corecells/accesscore/internal/adapters/http/configclient_test.go
@@ -248,3 +248,91 @@ func TestHTTPConfigGetter_GetEntry_TenantIDForwarded(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, tid2.String(), receivedTenant, "X-Tenant-ID must update with each call")
 }
+
+// configEntryHandler returns an http.Handler that answers the internal config
+// GET with a fixed 200 {data:...} envelope. It is the downstream handler the
+// service-token middleware guards in the passthrough tests below.
+func configEntryHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"key": "app.name", "value": "gocell", "sensitive": false, "version": 3,
+			},
+		})
+	})
+}
+
+// TestHTTPConfigGetter_GetEntry_MiddlewareVerified drives the production
+// GetEntry call site through the real auth.ServiceTokenMiddleware (same ring +
+// replay-safe nonce store), proving the signed service token and the X-Tenant-ID
+// wire header this PR binds into the MAC actually pass verification end to end —
+// not just that the headers are non-empty. The middleware reconstructs the MAC
+// from the live X-Tenant-ID header (#1717 SignedHeaders binding); a 200 here
+// means signed tenant == wire tenant survives the full verify path.
+func TestHTTPConfigGetter_GetEntry_MiddlewareVerified(t *testing.T) {
+	ring := newTestRing(t)
+	ns, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL, clock.Real())
+	require.NoError(t, err)
+
+	guarded := auth.ServiceTokenMiddleware(ring, clock.Real(),
+		auth.WithServiceTokenNonceStore(ns))(configEntryHandler())
+	srv := httptest.NewServer(guarded)
+	defer srv.Close()
+
+	client := NewHTTPConfigGetterWithHTTPClient(srv.URL, ring, srv.Client(), clock.Real())
+	entry, err := client.GetEntry(context.Background(), testTenant, "app.name")
+	require.NoError(t, err, "signed token + matching X-Tenant-ID must pass middleware verification")
+	assert.Equal(t, "app.name", entry.Key)
+	assert.Equal(t, "gocell", entry.Value)
+	assert.Equal(t, 3, entry.Version)
+}
+
+// tamperTenantTransport rewrites the X-Tenant-ID header after GetEntry has signed
+// the request, simulating a wire-level man-in-the-middle altering the tenant
+// assertion while leaving the (already computed) Authorization MAC untouched.
+type tamperTenantTransport struct {
+	inner  http.RoundTripper
+	tenant string
+}
+
+func (tt tamperTenantTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(auth.HeaderTenantID, tt.tenant)
+	return tt.inner.RoundTrip(req)
+}
+
+// TestHTTPConfigGetter_GetEntry_TamperedTenantHeaderRejected is the negative leg
+// of the binding proof at the production call site: when the on-the-wire
+// X-Tenant-ID diverges from the value GetEntry signed (testTenant), the MAC the
+// middleware reconstructs no longer matches, so verification fails with 401 —
+// which GetEntry maps to the permanent errcode.ErrAuthUnauthorized (consumers
+// Reject, never Requeue). The guarded handler must never be reached.
+func TestHTTPConfigGetter_GetEntry_TamperedTenantHeaderRejected(t *testing.T) {
+	ring := newTestRing(t)
+	ns, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL, clock.Real())
+	require.NoError(t, err)
+
+	var handlerReached bool
+	guarded := auth.ServiceTokenMiddleware(ring, clock.Real(),
+		auth.WithServiceTokenNonceStore(ns))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerReached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(guarded)
+	defer srv.Close()
+
+	// Tamper the wire tenant to a different canonical UUID than the signed one.
+	tamper := mustParseTenant("99999999-9999-4999-8999-999999999999")
+	tampered := &http.Client{Transport: tamperTenantTransport{inner: http.DefaultTransport, tenant: tamper.String()}}
+
+	client := NewHTTPConfigGetterWithHTTPClient(srv.URL, ring, tampered, clock.Real())
+	_, err = client.GetEntry(context.Background(), testTenant, "app.name")
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec, "wire-tampered tenant must surface a typed errcode")
+	assert.Equal(t, errcode.ErrAuthUnauthorized, ec.Code,
+		"tampered X-Tenant-ID must break the MAC binding → 401 → permanent auth error")
+	assert.False(t, handlerReached, "middleware must reject before the guarded handler runs")
+}

--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -273,7 +273,7 @@ func walkthroughServiceToken(t *testing.T, secret, method, rawURL string) string
 	ring, err := auth.NewHMACKeyRing([]byte(secret), nil)
 	require.NoError(t, err)
 	// Spec: 4-part token — callerCell="accesscore" (ssobff is the accesscore BFF).
-	return auth.GenerateServiceToken(ring, "accesscore", method, parsed.Path, parsed.RawQuery, time.Now())
+	return auth.GenerateServiceToken(ring, "accesscore", method, parsed.Path, parsed.RawQuery, "", time.Now())
 }
 
 // TestWalkthrough exercises the complete ssobff API walkthrough.

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -95,7 +95,7 @@ func jwtClaimsToPrincipal(c Claims) *Principal {
 }
 
 // NewServiceTokenAuthenticator returns an Authenticator that validates HMAC
-// service tokens (Authorization: ServiceToken <ts>:<nonce>:<mac>).
+// service tokens (Authorization: ServiceToken <ts>:<nonce>:<callerCell>:<mac>).
 //
 // Returns an error when:
 //   - ring is nil or a typed-nil interface;

--- a/runtime/auth/authenticator.go
+++ b/runtime/auth/authenticator.go
@@ -212,7 +212,10 @@ func verifyServiceTokenPayload(ring kauth.HMACKeyring, payload string, cfg servi
 		return "", err
 	}
 
-	message := buildServiceTokenMessage(r.Method, r.URL.Path, r.URL.RawQuery, tsStr, nonce, callerCell)
+	// Fold the live X-Tenant-ID header into the MAC material (sign/verify share
+	// buildServiceTokenMessage). A tampered, injected, or stripped tenant header
+	// reconstructs a different message and fails verifyServiceTokenMAC below.
+	message := buildServiceTokenMessage(r.Method, r.URL.Path, r.URL.RawQuery, tsStr, nonce, callerCell, r.Header.Get(HeaderTenantID))
 
 	providedMAC, err := hex.DecodeString(sigHex)
 	if err != nil {

--- a/runtime/auth/authenticator_test.go
+++ b/runtime/auth/authenticator_test.go
@@ -280,7 +280,7 @@ func TestServiceTokenAuthenticator_InvalidMAC_Error(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	// Construct a token with wrong HMAC. Do not replace with a fixed suffix:
 	// the generated MAC is random and may already end with that value.
-	goodToken := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
+	goodToken := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", now)
 	parts := strings.Split(goodToken, ":")
 	if len(parts) != 4 {
 		t.Fatalf("expected generated service token to have 4 parts, got %d: %q", len(parts), goodToken)
@@ -313,7 +313,7 @@ func TestServiceTokenAuthenticator_Expired_Error(t *testing.T) {
 	now := time.Now()
 	oldTime := now.Add(authnDNeg6min)
 	// Token is signed for 6 minutes ago — exceeds ServiceTokenMaxAge.
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", oldTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", oldTime)
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
@@ -341,7 +341,7 @@ func TestServiceTokenAuthenticator_NonceReplay_Error(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServiceTokenAuthenticator: %v", err)
 	}
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", now)
 
 	// First use — must succeed.
 	req1 := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
@@ -378,7 +378,7 @@ func TestServiceTokenAuthenticator_Success_PrincipalShape(t *testing.T) {
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
 
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", now)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 
@@ -448,7 +448,7 @@ func TestServiceTokenAuthenticator_FutureTimestamp_Error(t *testing.T) {
 	now := time.Now()
 	// Token is signed just beyond the explicit future-skew window.
 	futureTime := now.Add(ServiceTokenClockSkew + time.Second)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", futureTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", futureTime)
 
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
@@ -471,7 +471,7 @@ func TestServiceTokenAuthenticator_FarFutureTimestampOverflow_Error(t *testing.T
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Unix(1_700_000_000, 0)
 	farFuture := time.Unix(math.MaxInt64/2, 0)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", farFuture)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", farFuture)
 
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
@@ -494,7 +494,7 @@ func TestServiceTokenAuthenticator_FutureTimestampWithinSkew_Accepted(t *testing
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
 	futureTime := now.Add(ServiceTokenClockSkew)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", futureTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", futureTime)
 
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
@@ -523,7 +523,7 @@ func TestNewServiceTokenAuthenticator_PrincipalCallerCell(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
 	// Spec: 4-part signature: GenerateServiceToken(ring, callerCell, method, path, query, ts)
-	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", "", now)
 
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))
@@ -559,7 +559,7 @@ func TestServiceTokenAuthenticator_PastTimestampAtMaxAge_Error(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
 	oldTime := now.Add(-ServiceTokenMaxAge)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", oldTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", oldTime)
 
 	a := mustNewServiceTokenAuthenticator(t, ring, clockmock.New(now),
 		WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)))

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -80,6 +80,20 @@ const ServiceTokenNonceTTL = ServiceTokenMaxAge + ServiceTokenClockSkew
 // runtime/auth namespace; the source of truth lives in kernel/cell.
 const MinHMACKeyBytes = kauth.MinHMACKeyBytes
 
+// HeaderTenantID is the canonical HTTP header carrying the caller's tenant
+// assertion on internal service-token requests, and the single signed header in
+// the service-token MAC material. buildServiceTokenMessage folds its value into
+// the HMAC unconditionally and verifyServiceTokenPayload reconstructs the same
+// value from r.Header.Get(HeaderTenantID), so tampering with, injecting, or
+// stripping the header changes the MAC input and fails verification
+// (defense-in-depth, AWS SigV4 SignedHeaders style).
+//
+// INVARIANT: X-Tenant-ID is unconditionally part of the service-token MAC
+// material; sign and verify share buildServiceTokenMessage. Dropping or altering
+// the tenant segment breaks the golden + tamper/inject/strip negative tests in
+// servicetoken_tenant_sign_test.go.
+const HeaderTenantID = "X-Tenant-ID"
+
 // serviceTokenConfig holds per-middleware options.
 type serviceTokenConfig struct {
 	clk        clock.Clock
@@ -478,14 +492,20 @@ func verifyServiceTokenMAC(ring kauth.HMACKeyring, message string, providedMAC [
 
 // buildServiceTokenMessage constructs the canonical HMAC message for the
 // 4-part token format. The query string is canonicalized (keys sorted) and
-// appended to the path when non-empty. callerCell is included as the final
-// segment so tampering with the caller identity invalidates the MAC.
-func buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell string) string {
+// appended to the path when non-empty. callerCell is included as a segment so
+// tampering with the caller identity invalidates the MAC. tenantID (the
+// X-Tenant-ID signed header) is unconditionally folded as the final
+// "x-tenant-id=<value>" segment — empty for requests that assert no tenant — so
+// tampering with, injecting, or stripping the header invalidates the MAC. The
+// label is lowercased canonical form (SigV4-style signed header). This function
+// is the single source for the MAC message; sign and verify must both call it.
+func buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell, tenantID string) string {
 	cq := canonicalQuery(rawQuery)
+	tenantSeg := " x-tenant-id=" + tenantID
 	if cq != "" {
-		return fmt.Sprintf("%s %s?%s %s %s %s", method, path, cq, tsStr, nonce, callerCell)
+		return fmt.Sprintf("%s %s?%s %s %s %s", method, path, cq, tsStr, nonce, callerCell) + tenantSeg
 	}
-	return fmt.Sprintf("%s %s %s %s %s", method, path, tsStr, nonce, callerCell)
+	return fmt.Sprintf("%s %s %s %s %s", method, path, tsStr, nonce, callerCell) + tenantSeg
 }
 
 // canonicalQuery returns a deterministic encoding of rawQuery with keys sorted.
@@ -503,16 +523,22 @@ func canonicalQuery(rawQuery string) string {
 }
 
 // GenerateServiceToken creates a service token for the given callerCell, method,
-// path, optional rawQuery, and timestamp using the current secret from the key ring.
-// The token format is "{timestamp}:{nonce}:{callerCell}:{hex_hmac}" where nonce is
-// 16 cryptographically random bytes, hex-encoded. It returns an empty string if:
+// path, optional rawQuery, tenantID, and timestamp using the current secret from
+// the key ring. The token format is "{timestamp}:{nonce}:{callerCell}:{hex_hmac}"
+// where nonce is 16 cryptographically random bytes, hex-encoded. It returns an
+// empty string if:
 //   - ring is nil
 //   - callerCell is empty (mandatory — identifies the originating cell)
 //   - callerCell contains ':' (would corrupt the 4-part token structure)
 //
 // rawQuery is canonicalized separately from path so the HMAC message remains stable
 // across query parameter ordering. Pass "" when the request has no query parameters.
-func GenerateServiceToken(ring *HMACKeyRing, callerCell, method, path, rawQuery string, ts time.Time) string {
+//
+// tenantID is the X-Tenant-ID signed-header value folded into the MAC so the
+// tenant assertion is integrity-bound to the caller credential. Pass "" when the
+// request asserts no tenant; callers that forward X-Tenant-ID MUST pass the same
+// string they set on the header (see HeaderTenantID).
+func GenerateServiceToken(ring *HMACKeyRing, callerCell, method, path, rawQuery, tenantID string, ts time.Time) string {
 	if ring == nil {
 		return ""
 	}
@@ -532,7 +558,7 @@ func GenerateServiceToken(ring *HMACKeyRing, callerCell, method, path, rawQuery 
 	}
 	nonce := hex.EncodeToString(nonceBytes)
 
-	message := buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell)
+	message := buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell, tenantID)
 	mac := hmac.New(sha256.New, ring.Current())
 	_, _ = mac.Write([]byte(message))
 	return tsStr + ":" + nonce + ":" + callerCell + ":" + hex.EncodeToString(mac.Sum(nil))

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/httputil"
+	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/pkg/validation"
 )
 
@@ -499,6 +500,13 @@ func verifyServiceTokenMAC(ring kauth.HMACKeyring, message string, providedMAC [
 // tampering with, injecting, or stripping the header invalidates the MAC. The
 // label is lowercased canonical form (SigV4-style signed header). This function
 // is the single source for the MAC message; sign and verify must both call it.
+//
+// SECURITY: segments are space-delimited and the tenant segment is appended
+// last, so no segment may contain a space. callerCell is validated against
+// ^[a-z][a-z0-9]+$ before this is called, and tenantID is either "" or a
+// canonical UUID (sign side passes the typed tenant.TenantID; verify side folds
+// the raw X-Tenant-ID header, where any space/garbage simply yields a
+// non-matching MAC). The trailing "x-tenant-id=" segment is thus unambiguous.
 func buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell, tenantID string) string {
 	cq := canonicalQuery(rawQuery)
 	tenantSeg := " x-tenant-id=" + tenantID
@@ -534,11 +542,13 @@ func canonicalQuery(rawQuery string) string {
 // rawQuery is canonicalized separately from path so the HMAC message remains stable
 // across query parameter ordering. Pass "" when the request has no query parameters.
 //
-// tenantID is the X-Tenant-ID signed-header value folded into the MAC so the
-// tenant assertion is integrity-bound to the caller credential. Pass "" when the
-// request asserts no tenant; callers that forward X-Tenant-ID MUST pass the same
-// string they set on the header (see HeaderTenantID).
-func GenerateServiceToken(ring *HMACKeyRing, callerCell, method, path, rawQuery, tenantID string, ts time.Time) string {
+// tenantID is the X-Tenant-ID assertion folded into the MAC so the tenant is
+// integrity-bound to the caller credential. It is a typed tenant.TenantID (not a
+// raw string) so the signed value is always the canonical form that
+// tenant.TenantID.String() emits — the same value callers set on the X-Tenant-ID
+// header. Pass the zero value (tenant.TenantID("")) when the request asserts no
+// tenant; the MAC then binds an empty tenant segment (see HeaderTenantID).
+func GenerateServiceToken(ring *HMACKeyRing, callerCell, method, path, rawQuery string, tenantID tenant.TenantID, ts time.Time) string {
 	if ring == nil {
 		return ""
 	}
@@ -558,7 +568,7 @@ func GenerateServiceToken(ring *HMACKeyRing, callerCell, method, path, rawQuery,
 	}
 	nonce := hex.EncodeToString(nonceBytes)
 
-	message := buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell, tenantID)
+	message := buildServiceTokenMessage(method, path, rawQuery, tsStr, nonce, callerCell, tenantID.String())
 	mac := hmac.New(sha256.New, ring.Current())
 	_, _ = mac.Write([]byte(message))
 	return tsStr + ":" + nonce + ":" + callerCell + ":" + hex.EncodeToString(mac.Sum(nil))

--- a/runtime/auth/servicetoken.go
+++ b/runtime/auth/servicetoken.go
@@ -211,12 +211,18 @@ func LoadHMACKeyRingFromEnv() (*HMACKeyRing, error) {
 }
 
 // ServiceTokenMiddleware validates requests using HMAC-SHA256 service tokens.
-// The token is expected in the Authorization header as:
+// The token is expected in the Authorization header as the 4-part payload:
 //
-//	ServiceToken {unix_timestamp}:{nonce}:{hex_hmac}
+//	ServiceToken {unix_timestamp}:{nonce}:{callerCell}:{hex_hmac}
 //
 // The HMAC is computed over
-// "{method} {path}[?{canonicalQuery}] {timestamp} {nonce}".
+// "{method} {path}[?{canonicalQuery}] {timestamp} {nonce} {callerCell} x-tenant-id=<value>"
+// — i.e. the caller cell is a MAC segment, and the X-Tenant-ID signed header is
+// folded unconditionally as the trailing "x-tenant-id=<value>" segment (empty for
+// no-tenant requests). buildServiceTokenMessage is the single source for this
+// material; sign (GenerateServiceToken) and verify (verifyServiceTokenPayload)
+// both call it, so tampering with the caller identity or the tenant header
+// invalidates the MAC (see HeaderTenantID).
 //
 // Verification tries each secret in the key ring in order (current, then
 // previous). Tokens older than 5 minutes (exclusive boundary) are rejected.

--- a/runtime/auth/servicetoken_tenant_sign_test.go
+++ b/runtime/auth/servicetoken_tenant_sign_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/pkg/tenant"
 )
 
 // Canonical tenant UUIDs (lowercase, dashed) mirroring what tenant.TenantID.String()
@@ -33,9 +34,9 @@ func TestServiceTokenMiddleware_TenantHeaderBinding(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		signTenant string // value passed to GenerateServiceToken (folded into MAC)
-		setHeader  bool   // whether the request carries an X-Tenant-ID header
-		wireHeader string // header value when setHeader is true
+		signTenant tenant.TenantID // value bound into the MAC by GenerateServiceToken
+		setHeader  bool            // whether the request carries an X-Tenant-ID header
+		wireHeader string          // header value when setHeader is true
 		wantStatus int
 		wantCalled bool
 	}{
@@ -168,6 +169,15 @@ func TestBuildServiceTokenMessage_TenantSegment_Golden(t *testing.T) {
 			callerCell: "accesscore",
 			tenantID:   tenantSignA,
 			want:       "GET /api?a=1&b=2 1700000000 abcdef0123456789abcdef0123456789 accesscore x-tenant-id=11111111-1111-4111-8111-111111111111",
+		},
+		{
+			name:       "no tenant, with query",
+			method:     http.MethodGet,
+			path:       "/api",
+			rawQuery:   "b=2&a=1",
+			callerCell: "accesscore",
+			tenantID:   "",
+			want:       "GET /api?a=1&b=2 1700000000 abcdef0123456789abcdef0123456789 accesscore x-tenant-id=",
 		},
 	}
 

--- a/runtime/auth/servicetoken_tenant_sign_test.go
+++ b/runtime/auth/servicetoken_tenant_sign_test.go
@@ -1,0 +1,180 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+)
+
+// Canonical tenant UUIDs (lowercase, dashed) mirroring what tenant.TenantID.String()
+// emits on the wire. The MAC binding folds the raw header value, so these double as
+// the signed tenant and the wire header value in the table below.
+const (
+	tenantSignA = "11111111-1111-4111-8111-111111111111"
+	tenantSignB = "22222222-2222-4222-8222-222222222222"
+)
+
+// TestServiceTokenMiddleware_TenantHeaderBinding exercises the four-state closure
+// of binding X-Tenant-ID into the service-token MAC (#1717):
+//   - the signed tenant and the live wire header agree → 200;
+//   - any divergence (tamper / inject / strip) → MAC mismatch → 401.
+//
+// Spec: buildServiceTokenMessage unconditionally folds the X-Tenant-ID value
+// (empty for no-tenant tokens). verifyServiceTokenPayload reconstructs it from
+// r.Header.Get(HeaderTenantID); a different reconstructed value fails the MAC.
+func TestServiceTokenMiddleware_TenantHeaderBinding(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		name       string
+		signTenant string // value passed to GenerateServiceToken (folded into MAC)
+		setHeader  bool   // whether the request carries an X-Tenant-ID header
+		wireHeader string // header value when setHeader is true
+		wantStatus int
+		wantCalled bool
+	}{
+		{
+			name:       "matching tenant accepted",
+			signTenant: tenantSignA,
+			setHeader:  true,
+			wireHeader: tenantSignA,
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		{
+			name:       "no tenant, no header accepted",
+			signTenant: "",
+			setHeader:  false,
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		{
+			name:       "no tenant, empty header accepted",
+			signTenant: "",
+			setHeader:  true,
+			wireHeader: "",
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		{
+			name:       "tampered tenant rejected",
+			signTenant: tenantSignA,
+			setHeader:  true,
+			wireHeader: tenantSignB,
+			wantStatus: http.StatusUnauthorized,
+			wantCalled: false,
+		},
+		{
+			name:       "injected tenant rejected",
+			signTenant: "",
+			setHeader:  true,
+			wireHeader: tenantSignB,
+			wantStatus: http.StatusUnauthorized,
+			wantCalled: false,
+		},
+		{
+			name:       "stripped tenant rejected",
+			signTenant: tenantSignA,
+			setHeader:  false,
+			wantStatus: http.StatusUnauthorized,
+			wantCalled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ring := mustTestRing(t, testHMACKey, "")
+
+			token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", tc.signTenant, now)
+			require.NotEmpty(t, token, "token generation must succeed")
+
+			var called bool
+			handler := ServiceTokenMiddleware(
+				ring, clockmock.New(now),
+				WithServiceTokenNonceStore(mustNewInMemoryNonceStore(t)),
+			)(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					called = true
+					w.WriteHeader(http.StatusOK)
+				}),
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
+			req.Header.Set("Authorization", "ServiceToken "+token)
+			if tc.setHeader {
+				req.Header.Set(HeaderTenantID, tc.wireHeader)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code, "status code")
+			assert.Equal(t, tc.wantCalled, called, "handler invocation")
+		})
+	}
+}
+
+// TestBuildServiceTokenMessage_TenantSegment_Golden freezes the canonical MAC
+// message format including the unconditional x-tenant-id segment. Any drift in
+// the MAC material (dropping, renaming, reordering the tenant segment) shows up
+// as a byte-level diff here — the static-guard leg of the #1717 closure.
+//
+// INVARIANT: X-Tenant-ID is unconditionally part of the service-token MAC
+// material; the segment is the lowercased canonical "x-tenant-id=<value>".
+func TestBuildServiceTokenMessage_TenantSegment_Golden(t *testing.T) {
+	const (
+		ts    = "1700000000"
+		nonce = "abcdef0123456789abcdef0123456789"
+	)
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		rawQuery   string
+		callerCell string
+		tenantID   string
+		want       string
+	}{
+		{
+			name:       "with tenant, no query",
+			method:     http.MethodGet,
+			path:       "/internal/v1/resource",
+			rawQuery:   "",
+			callerCell: "accesscore",
+			tenantID:   tenantSignA,
+			want: "GET /internal/v1/resource 1700000000 abcdef0123456789abcdef0123456789 accesscore " +
+				"x-tenant-id=11111111-1111-4111-8111-111111111111",
+		},
+		{
+			name:       "no tenant, no query",
+			method:     http.MethodGet,
+			path:       "/internal/v1/resource",
+			rawQuery:   "",
+			callerCell: "accesscore",
+			tenantID:   "",
+			want:       "GET /internal/v1/resource 1700000000 abcdef0123456789abcdef0123456789 accesscore x-tenant-id=",
+		},
+		{
+			name:       "with tenant and canonicalized query",
+			method:     http.MethodGet,
+			path:       "/api",
+			rawQuery:   "b=2&a=1",
+			callerCell: "accesscore",
+			tenantID:   tenantSignA,
+			want:       "GET /api?a=1&b=2 1700000000 abcdef0123456789abcdef0123456789 accesscore x-tenant-id=11111111-1111-4111-8111-111111111111",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildServiceTokenMessage(tc.method, tc.path, tc.rawQuery, ts, nonce, tc.callerCell, tc.tenantID)
+			assert.Equal(t, tc.want, got, "canonical MAC message must match golden")
+		})
+	}
+}

--- a/runtime/auth/servicetoken_test.go
+++ b/runtime/auth/servicetoken_test.go
@@ -90,7 +90,7 @@ func TestHMACKeyRing_Current_ReturnsCopy(t *testing.T) {
 func TestHMACKeyRing_SignWithCurrent(t *testing.T) {
 	ring := mustTestRing(t, testHMACKeyNew, testHMACKeyOld)
 	now := time.Now()
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", "", now)
 
 	singleRing := mustTestRing(t, testHMACKeyNew, "")
 	handler := mustTestServiceHandler(t, singleRing, clockmock.New(now))
@@ -107,7 +107,7 @@ func TestHMACKeyRing_VerifyWithPrevious(t *testing.T) {
 	now := time.Now()
 
 	oldRing := mustTestRing(t, testHMACKeyOld, "")
-	token := GenerateServiceToken(oldRing, "gocell", http.MethodGet, "/api", "", now)
+	token := GenerateServiceToken(oldRing, "gocell", http.MethodGet, "/api", "", "", now)
 
 	newRing := mustTestRing(t, testHMACKeyNew, testHMACKeyOld)
 	handler := mustTestServiceHandler(t, newRing, clockmock.New(now))
@@ -124,7 +124,7 @@ func TestHMACKeyRing_RejectUnknownSecret(t *testing.T) {
 	now := time.Now()
 
 	unknownRing := mustTestRing(t, testHMACKeyUnk, "")
-	token := GenerateServiceToken(unknownRing, "gocell", http.MethodGet, "/api", "", now)
+	token := GenerateServiceToken(unknownRing, "gocell", http.MethodGet, "/api", "", "", now)
 
 	ring := mustTestRing(t, testHMACKeyNew, testHMACKeyOld)
 	handler := mustTestServiceHandlerFatal(t, ring, clockmock.New(now))
@@ -141,7 +141,7 @@ func TestHMACKeyRing_SingleSecretMode(t *testing.T) {
 	now := time.Now()
 
 	ring := mustTestRing(t, testHMACKeyOne, "")
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", "", now)
 	handler := mustTestServiceHandler(t, ring, clockmock.New(now))
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -156,7 +156,7 @@ func TestHMACKeyRing_SameSecretBothPositions(t *testing.T) {
 	now := time.Now()
 
 	ring := mustTestRing(t, testHMACKeySam, testHMACKeySam)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", "", now)
 	handler := mustTestServiceHandler(t, ring, clockmock.New(now))
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -193,7 +193,7 @@ func TestNewHMACKeyRing_ShortPreviousFails(t *testing.T) {
 }
 
 func TestGenerateServiceToken_NilRing(t *testing.T) {
-	token := GenerateServiceToken(nil, "gocell", "GET", "/api", "", time.Now())
+	token := GenerateServiceToken(nil, "gocell", "GET", "/api", "", "", time.Now())
 	assert.Empty(t, token)
 }
 
@@ -247,7 +247,7 @@ func TestLoadHMACKeyRingFromEnv_MissingCurrentFails(t *testing.T) {
 func TestServiceTokenMiddleware_ValidToken(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", "", now)
 	handler := mustTestServiceHandler(t, ring, clockmock.New(now))
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
@@ -298,7 +298,7 @@ func TestServiceTokenMiddleware_DifferentPath(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
 
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/other", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/other", "", "", now)
 	handler := mustTestServiceHandlerFatal(t, ring, clockmock.New(now))
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
@@ -363,7 +363,7 @@ func TestServiceTokenMiddleware_ExpiredTimestamp(t *testing.T) {
 	handler := mustTestServiceHandlerFatal(t, ring, clockmock.New(now))
 
 	oldTime := now.Add(svcTokenDNeg6min)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", oldTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", "", oldTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -378,7 +378,7 @@ func TestServiceTokenMiddleware_ExactBoundary_Rejected(t *testing.T) {
 	handler := mustTestServiceHandlerFatal(t, ring, clockmock.New(now))
 
 	boundaryTime := now.Add(-ServiceTokenMaxAge)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", boundaryTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", "", boundaryTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -393,7 +393,7 @@ func TestServiceTokenMiddleware_JustWithinWindow(t *testing.T) {
 	handler := mustTestServiceHandler(t, ring, clockmock.New(now))
 
 	recentTime := now.Add(svcTokenDNeg4min59s)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", recentTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", "", recentTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -408,7 +408,7 @@ func TestServiceTokenMiddleware_FutureTimestamp_Rejected(t *testing.T) {
 	handler := mustTestServiceHandlerFatal(t, ring, clockmock.New(now))
 
 	futureTime := now.Add(svcTokenD6min)
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", futureTime)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/health", "", "", futureTime)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/health", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -440,8 +440,8 @@ func TestGenerateServiceToken_Deterministic(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	ts := time.Unix(1700000000, 0)
 
-	t1 := GenerateServiceToken(ring, "accesscore", http.MethodPost, "/api", "", ts)
-	t2 := GenerateServiceToken(ring, "accesscore", http.MethodPost, "/api", "", ts)
+	t1 := GenerateServiceToken(ring, "accesscore", http.MethodPost, "/api", "", "", ts)
+	t2 := GenerateServiceToken(ring, "accesscore", http.MethodPost, "/api", "", "", ts)
 
 	parts1 := strings.SplitN(t1, ":", 4)
 	parts2 := strings.SplitN(t2, ":", 4)
@@ -455,7 +455,7 @@ func TestGenerateServiceToken_Deterministic(t *testing.T) {
 	assert.NotEqual(t, parts1[1], parts2[1], "nonces must differ between calls")
 
 	// Different method produces a different HMAC (nonces also differ).
-	t3 := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/api", "", ts)
+	t3 := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/api", "", "", ts)
 	assert.NotEqual(t, t1, t3)
 }
 
@@ -463,7 +463,7 @@ func TestGenerateServiceToken_IncludesNonce(t *testing.T) {
 	// Spec: 4-part format {ts}:{nonce}:{caller_cell}:{hex_hmac}
 	ring := mustTestRing(t, testHMACKey, "")
 	ts := time.Unix(1700000000, 0)
-	token := GenerateServiceToken(ring, "configcore", http.MethodGet, "/api", "", ts)
+	token := GenerateServiceToken(ring, "configcore", http.MethodGet, "/api", "", "", ts)
 
 	parts := strings.SplitN(token, ":", 4)
 	require.Len(t, parts, 4, "token must have 4 colon-separated parts: {ts}:{nonce}:{caller_cell}:{hex_hmac}")
@@ -477,8 +477,8 @@ func TestGenerateServiceToken_NonceUniqueness(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	ts := time.Unix(1700000000, 0)
 
-	t1 := GenerateServiceToken(ring, "auditcore", http.MethodGet, "/api", "", ts)
-	t2 := GenerateServiceToken(ring, "auditcore", http.MethodGet, "/api", "", ts)
+	t1 := GenerateServiceToken(ring, "auditcore", http.MethodGet, "/api", "", "", ts)
+	t2 := GenerateServiceToken(ring, "auditcore", http.MethodGet, "/api", "", "", ts)
 
 	parts1 := strings.SplitN(t1, ":", 4)
 	parts2 := strings.SplitN(t2, ":", 4)
@@ -501,7 +501,7 @@ func TestServiceTokenMiddleware_WithNonceStore_ReplayRejected(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api/v1/resource", "", "", now)
 
 	// First use — accepted.
 	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
@@ -530,8 +530,8 @@ func TestServiceTokenMiddleware_WithNonceStore_UniqueTokensAccepted(t *testing.T
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token1 := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api/v1/resource", "", now)
-	token2 := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api/v1/resource", "", now)
+	token1 := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api/v1/resource", "", "", now)
+	token2 := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api/v1/resource", "", "", now)
 
 	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/resource", nil)
 	req1.Header.Set("Authorization", "ServiceToken "+token1)
@@ -558,7 +558,7 @@ func TestServiceTokenMiddleware_DefaultNoNonceStore_ReturnsErrorMiddleware(t *te
 		t.Fatal("handler must not be called when NonceStore is missing")
 	}))
 
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", now)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -582,7 +582,7 @@ func TestServiceTokenMiddleware_NoopNonceStoreSupplied_ReturnsErrorMiddleware(t 
 		t.Fatal("handler must not be called when NonceStore is Noop")
 	}))
 
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", now)
 	req := httptest.NewRequest(http.MethodGet, "/internal/v1/resource", nil)
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	rec := httptest.NewRecorder()
@@ -722,7 +722,7 @@ func TestServiceTokenMiddleware_WithMetrics_NoPanic(t *testing.T) {
 
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "", "", now)
 
 	handler := ServiceTokenMiddleware(
 		ring, clockmock.New(now),
@@ -751,7 +751,7 @@ func TestServiceTokenMiddleware_QueryBoundInSignature(t *testing.T) {
 	now := time.Now()
 
 	// Sign with query=foo=bar
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "foo=bar", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/api", "foo=bar", "", now)
 	handler := mustTestServiceHandler(t, ring, clockmock.New(now))
 
 	// Same path+query should succeed.
@@ -777,7 +777,7 @@ func TestServiceTokenMiddleware_QueryBoundInSignature(t *testing.T) {
 func TestServiceTokenMiddleware_InjectsServicePrincipal(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
-	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "gocell", http.MethodGet, "/internal/v1/resource", "", "", now)
 
 	var gotPrincipal *Principal
 	handler := ServiceTokenMiddleware(
@@ -819,7 +819,7 @@ func TestServiceTokenMiddleware_InjectsServicePrincipal(t *testing.T) {
 func TestServiceTokenMiddleware_InjectsPrincipalCtxKeys(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
-	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", "", now)
 
 	var gotActor, gotSubject, gotSession, gotTenant string
 	var actorOK, subjectOK, sessionOK, tenantOK bool
@@ -969,7 +969,7 @@ func TestServiceTokenMiddleware_CallerCellPropagated(t *testing.T) {
 	ring := mustTestRing(t, testHMACKey, "")
 	now := time.Now()
 	// Spec: 4-part signature with explicit callerCell
-	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", "", now)
 
 	var gotPrincipal *Principal
 	handler := ServiceTokenMiddleware(
@@ -1006,7 +1006,7 @@ func TestServiceTokenMiddleware_TamperedCallerCell_Rejected(t *testing.T) {
 	now := time.Now()
 
 	// Sign with "accesscore" as caller_cell.
-	goodToken := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", now)
+	goodToken := GenerateServiceToken(ring, "accesscore", http.MethodGet, "/internal/v1/resource", "", "", now)
 
 	// Tamper: replace the caller_cell segment (parts[2]) with "configcore".
 	parts := strings.SplitN(goodToken, ":", 4)
@@ -1042,7 +1042,7 @@ func TestServiceTokenMiddleware_CallerCellWithColon_Rejected(t *testing.T) {
 	now := time.Now()
 
 	// Spec: GenerateServiceToken must return "" when callerCell contains ':'
-	token := GenerateServiceToken(ring, "bad:cell", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "bad:cell", http.MethodGet, "/internal/v1/resource", "", "", now)
 	assert.Empty(t, token,
 		"GenerateServiceToken must return empty string when callerCell contains ':'")
 }
@@ -1056,7 +1056,7 @@ func TestServiceTokenMiddleware_EmptyCallerCell_Rejected(t *testing.T) {
 	now := time.Now()
 
 	// Spec: GenerateServiceToken must return "" when callerCell is empty.
-	token := GenerateServiceToken(ring, "", http.MethodGet, "/internal/v1/resource", "", now)
+	token := GenerateServiceToken(ring, "", http.MethodGet, "/internal/v1/resource", "", "", now)
 	assert.Empty(t, token,
 		"GenerateServiceToken must return empty string when callerCell is empty")
 }

--- a/runtime/bootstrap/dual_listener_test.go
+++ b/runtime/bootstrap/dual_listener_test.go
@@ -141,7 +141,7 @@ func getWithServiceToken(t *testing.T, rawURL string, ring *auth.HMACKeyRing) *h
 	require.NoError(t, err)
 	// Spec: 4-part token — callerCell="accesscore" (bootstrap integration tests use accesscore as caller).
 	req.Header.Set("Authorization", "ServiceToken "+
-		auth.GenerateServiceToken(ring, "accesscore", http.MethodGet, parsed.Path, parsed.RawQuery, time.Now()))
+		auth.GenerateServiceToken(ring, "accesscore", http.MethodGet, parsed.Path, parsed.RawQuery, "", time.Now()))
 	resp, err := testHTTPClient.Do(req)
 	require.NoError(t, err)
 	return resp

--- a/tests/integration/internal_rpc_caller_cell_test.go
+++ b/tests/integration/internal_rpc_caller_cell_test.go
@@ -285,8 +285,9 @@ func TestInternalRPC_AccessCoreCallsConfigRead_GuardPassed_404KeyNotFound(t *tes
 	// Real (non-reserved) tenant UUID, bound into the token MAC (#1717) AND sent
 	// on the wire as X-Tenant-ID. The MAC binding requires the signed tenant and
 	// the header to agree; a valid matching tenant lets the request pass the guard
-	// and reach the key lookup (which 404s — the key is not seeded).
-	tenantID := "00000000-0000-0000-0000-000000000001"
+	// and reach the key lookup (which 404s — the key is not seeded). Untyped const
+	// so it is assignable to both the tenant.TenantID sign param and the string header.
+	const tenantID = "00000000-0000-0000-0000-000000000001"
 	token := auth.GenerateServiceToken(app.ring, "accesscore",
 		http.MethodGet, "/internal/v1/config/no-such-key", "", tenantID, time.Now())
 	require.NotEmpty(t, token, "token generation must succeed for a valid callerCell")

--- a/tests/integration/internal_rpc_caller_cell_test.go
+++ b/tests/integration/internal_rpc_caller_cell_test.go
@@ -282,17 +282,20 @@ func startCallerCellApp(t *testing.T) *callerCellApp {
 func TestInternalRPC_AccessCoreCallsConfigRead_GuardPassed_404KeyNotFound(t *testing.T) {
 	app := startCallerCellApp(t)
 
+	// Real (non-reserved) tenant UUID, bound into the token MAC (#1717) AND sent
+	// on the wire as X-Tenant-ID. The MAC binding requires the signed tenant and
+	// the header to agree; a valid matching tenant lets the request pass the guard
+	// and reach the key lookup (which 404s — the key is not seeded).
+	tenantID := "00000000-0000-0000-0000-000000000001"
 	token := auth.GenerateServiceToken(app.ring, "accesscore",
-		http.MethodGet, "/internal/v1/config/no-such-key", "", time.Now())
+		http.MethodGet, "/internal/v1/config/no-such-key", "", tenantID, time.Now())
 	require.NotEmpty(t, token, "token generation must succeed for a valid callerCell")
 
 	req, err := http.NewRequest(http.MethodGet,
 		fmt.Sprintf("http://%s/internal/v1/config/no-such-key", app.internalAddr), nil)
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "ServiceToken "+token)
-	// Real (non-reserved) tenant UUID so the X-Tenant-ID parse passes and the
-	// request reaches the key lookup (which 404s — the key is not seeded).
-	req.Header.Set("X-Tenant-ID", "00000000-0000-0000-0000-000000000001")
+	req.Header.Set("X-Tenant-ID", tenantID)
 
 	resp, err := callerCellHTTPClient.Do(req)
 	require.NoError(t, err)
@@ -311,7 +314,7 @@ func TestInternalRPC_ConfigCoreCallsConfigRead_Denied_403(t *testing.T) {
 	app := startCallerCellApp(t)
 
 	token := auth.GenerateServiceToken(app.ring, "configcore",
-		http.MethodGet, "/internal/v1/config/any-key", "", time.Now())
+		http.MethodGet, "/internal/v1/config/any-key", "", "", time.Now())
 	require.NotEmpty(t, token)
 
 	req, err := http.NewRequest(http.MethodGet,
@@ -339,7 +342,7 @@ func TestInternalRPC_WrongEndpointForCaller_403(t *testing.T) {
 	// auditcore is a valid cell ID and passes HMAC + format checks,
 	// but it is not in the configread contract.clients allowlist.
 	token := auth.GenerateServiceToken(app.ring, "auditcore",
-		http.MethodGet, "/internal/v1/config/any-key", "", time.Now())
+		http.MethodGet, "/internal/v1/config/any-key", "", "", time.Now())
 	require.NotEmpty(t, token)
 
 	req, err := http.NewRequest(http.MethodGet,
@@ -402,7 +405,7 @@ func TestInternalRPC_TamperedCallerCellRejected(t *testing.T) {
 
 	// Generate a legitimate token for "accesscore".
 	original := auth.GenerateServiceToken(app.ring, "accesscore",
-		http.MethodGet, "/internal/v1/config/any-key", "", time.Now())
+		http.MethodGet, "/internal/v1/config/any-key", "", "", time.Now())
 	require.NotEmpty(t, original)
 
 	// Token format: ts:nonce:callerCell:mac — 4 colon-separated segments.
@@ -427,6 +430,38 @@ func TestInternalRPC_TamperedCallerCellRejected(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
 		"tampered callerCell segment invalidates the HMAC; ServiceTokenMiddleware must return 401")
+}
+
+// TestInternalRPC_TamperedTenantHeaderRejected verifies that X-Tenant-ID is bound
+// into the service-token MAC (#1717): a token signed binding tenant A whose wire
+// X-Tenant-ID header is swapped to tenant B fails MAC verification → 401, before
+// the handler or RequireCallerCell run. This closes the gap where a holder of a
+// valid service token could tamper the tenant assertion to read another tenant's
+// config tier. End-to-end analog of the unit coverage in
+// runtime/auth/servicetoken_tenant_sign_test.go.
+func TestInternalRPC_TamperedTenantHeaderRejected(t *testing.T) {
+	app := startCallerCellApp(t)
+
+	// Sign the token binding tenant A.
+	const signedTenant = "00000000-0000-0000-0000-000000000001"
+	token := auth.GenerateServiceToken(app.ring, "accesscore",
+		http.MethodGet, "/internal/v1/config/any-key", "", signedTenant, time.Now())
+	require.NotEmpty(t, token)
+
+	req, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("http://%s/internal/v1/config/any-key", app.internalAddr), nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "ServiceToken "+token)
+	// Tamper: present a DIFFERENT tenant on the wire than the one bound in the MAC.
+	req.Header.Set("X-Tenant-ID", "00000000-0000-0000-0000-000000000002")
+
+	resp, err := callerCellHTTPClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"tampered X-Tenant-ID is covered by the token MAC; ServiceTokenMiddleware must return 401")
+	assertErrCode(t, resp, "ERR_AUTH_UNAUTHORIZED")
 }
 
 // assertErrCode reads the response body and asserts that the JSON error

--- a/tests/integration/l2atomicity/helpers_test.go
+++ b/tests/integration/l2atomicity/helpers_test.go
@@ -543,7 +543,7 @@ func assignRole(t *testing.T, h *l2Harness, userID, roleID string) {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"userId": userID, "roleId": roleID, "tenantId": l2TestTenantID})
 	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost,
-		internalPathRolesAssign, "", time.Now())
+		internalPathRolesAssign, "", "", time.Now())
 	req, _ := http.NewRequest(http.MethodPost, h.internalBase+internalPathRolesAssign,
 		bytes.NewReader(body))
 	req.Header.Set("Authorization", "ServiceToken "+token)
@@ -563,7 +563,7 @@ func revokeRole(t *testing.T, h *l2Harness, userID, roleID string) {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"userId": userID, "roleId": roleID, "tenantId": l2TestTenantID})
 	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost,
-		internalPathRolesRevoke, "", time.Now())
+		internalPathRolesRevoke, "", "", time.Now())
 	req, _ := http.NewRequest(http.MethodPost, h.internalBase+internalPathRolesRevoke,
 		bytes.NewReader(body))
 	req.Header.Set("Authorization", "ServiceToken "+token)

--- a/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
+++ b/tests/integration/l2atomicity/rbacassign_atomicity_failureproof_e2e_test.go
@@ -112,7 +112,7 @@ func postRoleEndpoint(t *testing.T, h *l2Harness, action, userID, roleID string)
 	default:
 		t.Fatalf("postRoleEndpoint: unknown action %q (expected \"assign\" or \"revoke\")", action)
 	}
-	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, path, "", time.Now())
+	token := auth.GenerateServiceToken(h.ring, "accesscore", http.MethodPost, path, "", "", time.Now())
 	req, _ := http.NewRequest(http.MethodPost, h.internalBase+path, bytes.NewReader(body))
 	req.Header.Set("Authorization", "ServiceToken "+token)
 	req.Header.Set("Content-Type", "application/json")

--- a/tools/archtest/svctoken_caller_cell.go
+++ b/tools/archtest/svctoken_caller_cell.go
@@ -137,8 +137,8 @@ func collectGenerateServiceTokenDiagsFromFile(
 // SVCTOKEN-CALLER-CELL-REQUIRED-01. It returns (diag, true) when call resolves
 // to auth.GenerateServiceToken AND its callerCell argument (index 1) is missing
 // / non-literal / empty / pattern-malformed / unknown; otherwise (zero, false)
-// for unrelated or valid calls. The 4-part signature is
-// GenerateServiceToken(ring, callerCell, method, path, query, ts).
+// for unrelated or valid calls. callerCell remains argument index 1; the
+// signature is GenerateServiceToken(ring, callerCell, method, path, query, tenantID, ts).
 func generateServiceTokenCallDiag(p *Pass, call *ast.CallExpr, rel string, knownCells map[string]bool) (Diagnostic, bool) {
 	path, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
 	if !ok || path != authRuntimeImportPath || name != "GenerateServiceToken" {

--- a/tools/archtest/svctoken_caller_cell.go
+++ b/tools/archtest/svctoken_caller_cell.go
@@ -139,6 +139,9 @@ func collectGenerateServiceTokenDiagsFromFile(
 // / non-literal / empty / pattern-malformed / unknown; otherwise (zero, false)
 // for unrelated or valid calls. callerCell remains argument index 1; the
 // signature is GenerateServiceToken(ring, callerCell, method, path, query, tenantID, ts).
+// Only callerCell (index 1) is guarded here; tenantID (index 5) needs no archtest
+// because it is a typed tenant.TenantID (the type system constrains it to canonical
+// tenant values), not a raw string.
 func generateServiceTokenCallDiag(p *Pass, call *ast.CallExpr, rel string, knownCells map[string]bool) (Diagnostic, bool) {
 	path, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
 	if !ok || path != authRuntimeImportPath || name != "GenerateServiceToken" {

--- a/tools/archtest/svctoken_caller_cell.go
+++ b/tools/archtest/svctoken_caller_cell.go
@@ -139,9 +139,26 @@ func collectGenerateServiceTokenDiagsFromFile(
 // / non-literal / empty / pattern-malformed / unknown; otherwise (zero, false)
 // for unrelated or valid calls. callerCell remains argument index 1; the
 // signature is GenerateServiceToken(ring, callerCell, method, path, query, tenantID, ts).
-// Only callerCell (index 1) is guarded here; tenantID (index 5) needs no archtest
-// because it is a typed tenant.TenantID (the type system constrains it to canonical
-// tenant values), not a raw string.
+//
+// Scope: only callerCell (index 1) is statically guarded here. tenantID (index 5)
+// is deliberately NOT archtest-guarded — and the typed tenant.TenantID parameter
+// must not be mistaken for a Hard guard of its value. tenant.TenantID is
+// `type TenantID string` (pkg/tenant/tenant_id.go) with String() returning the raw
+// value, so tenant.TenantID("") and conversions of arbitrary strings remain
+// expressible; the type buys call-site ergonomics (no accidental bare-string
+// arg), not canonicality. Two reasons no static rule is added:
+//   - There is no static path→tenant-requirement mapping, so a scanner cannot
+//     decide which GenerateServiceToken call sites must sign a NON-EMPTY tenant.
+//   - The tenant value is already closed at runtime, not statically:
+//     (a) integrity is Hard — X-Tenant-ID is folded into the MAC unconditionally
+//     (buildServiceTokenMessage), so tamper/inject/strip → MAC mismatch → 401,
+//     structurally unforgeable; (b) non-emptiness for tenant-scoped internal paths
+//     is Medium runtime fail-closed — configcore's handler ParseTenantID rejects
+//     absent/malformed/nil-UUID X-Tenant-ID with 400.
+//
+// Adding a Soft archtest here (or a Medium one guarding the single existing
+// tenant-scoped caller) would duplicate that runtime closure without raising the
+// bar, so the runtime fail-closed is the deliberate carrier.
 func generateServiceTokenCallDiag(p *Pass, call *ast.CallExpr, rel string, knownCells map[string]bool) (Diagnostic, bool) {
 	path, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
 	if !ok || path != authRuntimeImportPath || name != "GenerateServiceToken" {


### PR DESCRIPTION
## Summary

把 `X-Tenant-ID` 折进 service-token HMAC 签名材料，使隔离边界 tenant 断言与 caller 凭据完整性绑定——篡改/注入/剥离该 header 即 MAC 失配 → 401。

## Why / 背景

PR #1712（#1577）让 `configreadinternal`（`GET /internal/v1/config/{key}`）由 caller 经 `X-Tenant-ID` header 透传真 tenant。但该 header **没进入 service-token 的 HMAC 材料**：签名侧 `buildServiceTokenMessage` 只含 method/path/query/ts/nonce/callerCell；调用侧 `configclient` 签完 token 后**另行** `req.Header.Set("X-Tenant-ID", …)`，tenant 断言旁挂在签名之外。

**根因**：tenant assertion 是隔离边界数据，却没和 service-token 完整性绑定。持有有效（未过期、未重放）service token 的链路可篡改 `X-Tenant-ID`，读取另一租户的 config tier。loopback 隔离 + nonce 防重放是兜底，但隔离边界 header **应当**进入受信完整性通道（defense-in-depth，对标 AWS SigV4 `SignedHeaders` / K8s impersonation header 鉴权）。

**做法**（Option 1 最小绑定）：
- `buildServiceTokenMessage` **无条件**追加 `x-tenant-id=<value>` 段（空租户=空值），sign/verify 共用此唯一 message builder；`verifyServiceTokenPayload` 从实时 `r.Header.Get(X-Tenant-ID)` 重建同值。四态闭环：匹配/无租户 → 200；篡改/注入/剥离 → 401。
- `GenerateServiceToken` 增显式 `tenantID` 位置参（callerCell 仍 arg-index 1，`SVCTOKEN-CALLER-CELL-REQUIRED-01` 不受影响），强制每个 call site 声明 tenant。
- `configclient` 同源 `tid` 喂 sign + header，消除「签后旁挂」不对称。

**AI-robust 守卫三件套**：golden 冻结 MAC message 格式（`TestBuildServiceTokenMessage_TenantSegment_Golden`，drift 字节级暴露）+ `servicetoken.go` `INVARIANT:` godoc + 篡改/注入/剥离负测（单元）+ `TamperedTenantHeader` e2e。主守卫 = MAC 本身（Hard，篡改但 token 有效结构上不可表达）。anti-vacuity：已实测 neuter 绑定后 tamper+golden 测试转红。

**Option 3（mTLS/SPIFFE）单独成 epic**：调研确认 mTLS 只认证 peer，**不**绑定 app 层 tenant header（Istio/Linkerd/SPIFFE 一致），无法单独闭环此威胁，终态仍需本绑定。已 file follow-up epic（见下）。

## Refs

Closes #1717
ref: aws-sigv4 signed-headers（SignedHeaders 把指定 header 折入 canonical request → HMAC）

## Risk / 兼容性

- **wire 契约不变**：`X-Tenant-ID` 仍在 `contract.yaml` 声明、仍由 generated handler 注入 `req.XTenantID`、handler 仍读它；auth scheme 名（`ServiceToken`）不变。**仅** runtime MAC 材料（HMAC 输入字节）变 —— contract / generated / handler 不动，无版本目录升级。
- **破坏旧 MAC**：放弃「空租户 MAC 字节一致」软回退；旧格式 token 验签失败（pre-GA、token 5 分钟即逝、无外部调用方，无代价）。
- **blast radius**：`GenerateServiceToken` 签名变 → 1 production caller（configclient）+ ~47 test call site 机械加 `""`（无租户场景）。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过（main / corecells / cmd/corebundle / tests/integration / examples/ssobff 五模块）
- [x] `go test ./...` 本地通过（main 133 ok + corecells 61 ok）
- [x] 新单元测试：四态绑定 + golden（含 anti-vacuity red-demo）
- [x] e2e：`TestInternalRPC_TamperedTenantHeaderRejected` + 既有 caller-cell 测试全绿（in-process app）
- [x] archtest `SVCTOKEN-CALLER-CELL-REQUIRED-01` 绿
- [x] `golangci-lint run`（changed pkgs 0 issues；`--new-from-rev=origin/develop` 0 new issues）
