### PR TITLE
feat(tenancy): TENANT-RLS-READ-CALLER-01 — freeze accesscore RLS-read caller surface [#1690]

### DIFF
--- a/tools/archtest/internal/rlsreadfixture/fixture.go
+++ b/tools/archtest/internal/rlsreadfixture/fixture.go
@@ -19,19 +19,36 @@ package rlsreadfixture
 
 import "context"
 
-// UserRepository is a local stand-in mirroring the shape of accesscore's
-// ports.UserRepository: a READ method (in the detector's read-method set) and a
-// WRITE method (excluded). The detector keys on the receiver interface name plus
-// the method name, so this local interface exercises the same resolution path.
+// UserRepository and RoleRepository are local stand-ins mirroring the SHAPE of
+// accesscore's two ports interfaces: each has a READ method (in the detector's
+// read-method set); UserRepository also has a WRITE method (excluded). Both
+// interfaces are declared so the fixture proves the detector's receiver-binding
+// resolves BOTH interface types — a regression that only broke resolution for
+// the second interface would otherwise slip through a single-interface fixture.
+//
+// Parameter types deliberately use string, not tenant.TenantID: the fixture
+// cannot import corecells/accesscore/internal (Go internal-package visibility),
+// and the detector keys on the receiver interface name + method name, NOT on
+// parameter types — so this divergence is intentional and inert.
 type UserRepository interface {
 	GetByIDInTenant(ctx context.Context, t, id string) (any, error) // READ — must flag
 	Create(ctx context.Context, t string, u any) error              // WRITE — must NOT flag
 }
 
-// badUnscopedRead references the read method from this non-allowlisted file. The
-// detector MUST report this reference.
+type RoleRepository interface {
+	CountEffectiveAdmins(ctx context.Context, t string) (int, error) // READ — must flag
+}
+
+// badUnscopedRead references a UserRepository read method from this
+// non-allowlisted file. The detector MUST report this reference.
 func badUnscopedRead(ctx context.Context, r UserRepository) {
 	_, _ = r.GetByIDInTenant(ctx, "t", "id")
+}
+
+// badUnscopedRoleRead references a RoleRepository read method, proving the
+// receiver-binding resolves the SECOND interface type too. MUST be reported.
+func badUnscopedRoleRead(ctx context.Context, r RoleRepository) {
+	_, _ = r.CountEffectiveAdmins(ctx, "t")
 }
 
 // writeOutsideScope references a write method; the read-method-set filter MUST

--- a/tools/archtest/internal/rlsreadfixture/fixture.go
+++ b/tools/archtest/internal/rlsreadfixture/fixture.go
@@ -1,0 +1,41 @@
+//go:build archtest_fixture
+
+// Package rlsreadfixture is an archtest RED fixture for TENANT-RLS-READ-CALLER-01.
+//
+// The production rule resolves references to accesscore's
+// ports.UserRepository / ports.RoleRepository RLS-table READ methods via
+// go/types (info.Uses → *types.Func, receiver-bound) and asserts each sits in a
+// caller allowlist. Those interfaces live in corecells/accesscore/internal/ports
+// — an internal package tools/archtest cannot import — so this fixture declares
+// its OWN stand-in UserRepository interface, and the fixture test runs the SAME
+// detector core targeted at THIS package. It proves the detector actually fires
+// on a genuine read reference (resolution + receiver-binding + read-method-set),
+// and that a WRITE reference does NOT trip it. A 0 result means the detector
+// regressed and a new unscoped RLS read could slip in unnoticed.
+//
+// (Build-tag gated behind archtest_fixture so it stays out of normal / Production
+// builds and is loaded only by the Fixture() RunScope.)
+package rlsreadfixture
+
+import "context"
+
+// UserRepository is a local stand-in mirroring the shape of accesscore's
+// ports.UserRepository: a READ method (in the detector's read-method set) and a
+// WRITE method (excluded). The detector keys on the receiver interface name plus
+// the method name, so this local interface exercises the same resolution path.
+type UserRepository interface {
+	GetByIDInTenant(ctx context.Context, t, id string) (any, error) // READ — must flag
+	Create(ctx context.Context, t string, u any) error              // WRITE — must NOT flag
+}
+
+// badUnscopedRead references the read method from this non-allowlisted file. The
+// detector MUST report this reference.
+func badUnscopedRead(ctx context.Context, r UserRepository) {
+	_, _ = r.GetByIDInTenant(ctx, "t", "id")
+}
+
+// writeOutsideScope references a write method; the read-method-set filter MUST
+// exclude it (no diagnostic), proving the rule does not over-match writes.
+func writeOutsideScope(ctx context.Context, r UserRepository) {
+	_ = r.Create(ctx, "t", nil)
+}

--- a/tools/archtest/tenant_rls_read_caller_test.go
+++ b/tools/archtest/tenant_rls_read_caller_test.go
@@ -1,0 +1,283 @@
+//go:build archtest
+
+// tenant_rls_read_caller_test.go — closes the READ side of the accesscore
+// tenant-scope boundary (#1690), the future-drift counterpart to the scope-WRITE
+// funnels.
+//
+//   - INVARIANT: TENANT-RLS-READ-CALLER-01
+//
+// # What this guards
+//
+// accesscore has three Postgres tables under FORCE ROW LEVEL SECURITY (users /
+// roles / role_assignments, migration 053). A production read of any of them MUST
+// run inside a transaction that wrote the app.tenant_id GUC (via scopedtx.Do /
+// scopedtx.ApplyScope / a post-auth txRunner.RunInTx whose ctxkeys fallback sets
+// the GUC) — a bare-pool read sees an UNSET GUC → tenant_id = NULL predicate →
+// fail-closed 0 rows under the restricted app-serving pool (#1676). PR #1678
+// finding F1 fixed the three sites that had drifted out of a scoped tx; today
+// there are 0 residual sites. This rule is the FUTURE-DRIFT guard: it freezes the
+// set of files that may reference an accesscore RLS-table read method, so a NEW
+// reader fails CI until it is consciously reviewed (and, by that review, confirmed
+// to run inside a scoped tx) and added to the allowlist with rationale.
+//
+// The scope-WRITE side is already funnel-locked (TENANT-TXSCOPE-WRITE-CALLER-01
+// pins tenant.WithScope; TENANT-APPLYSCOPE-WRITE-CALLER-01 pins the mid-tx GUC
+// write). This rule closes the symmetric read side with the same caller-allowlist
+// mechanism.
+//
+// # Why a caller-allowlist, not a lexical body-gate
+//
+// accesscore reads pervasively run inside MULTI-LEVEL named *Tx helpers that
+// receive the tx-context as a parameter, e.g. identitymanage:
+//
+//	RunInTx(ctx, func(txCtx){ return s.applyUserUpdateTx(ctx, txCtx, …) })
+//	  → applyUserUpdateTx → guardUpdateStatusDemotion → checkLastAdminRemoval
+//	  → s.lastAdminRoleRepo.GetByUserID(ctx, …)   // 4 frames below the wrapper
+//
+// A lexical "read is inside a scopedtx.Do/RunInTx closure body" gate would either
+// false-positive on these helper-borne reads or require a fragile, drift-prone
+// enrollment of every *Tx helper — the Soft pattern the AI-robust charter bans.
+// The caller-allowlist is indirection-immune: it records WHICH FILE references a
+// read method, regardless of nesting depth. (The compile-time-Hard alternative —
+// a sealed ScopedCtx capability making an unscoped read unrepresentable — was
+// assessed and deferred: it adds ZERO confidentiality over this guard because the
+// runtime RLS fail-closed backstop catches an unscoped read in BOTH designs, while
+// costing a cx-4 signature fan-out plus an un-typeable use-after-tx hole. See the
+// follow-up issue.)
+//
+// # Detection + anti-vacuity
+//
+// Use-based (info.Uses → *types.Func), receiver-bound to ports.UserRepository /
+// ports.RoleRepository (methodRecvTypeName). The receiver binding is what
+// excludes the same-named collisions: policymanage's PolicyRepository.GetByID,
+// the identitymanage *Service.GetByID handler method, and the mem/postgres
+// concrete-repo self-calls (a different receiver type / package) all resolve to a
+// non-matching owner and are skipped. The read-method set excludes WRITE methods
+// (Create / Update* / Delete / Assign* …), which hit the same RLS tables but
+// always run inside RunInTx already (writes are inherently transactional). The
+// anti-vacuity reverse check requires every allowlist entry to reference a read
+// method live, so a scanner regression or a removed reader (which would make the
+// freeze vacuously pass) fails CI. The RED fixture (internal/rlsreadfixture,
+// TestTenantRLSReadCaller01_FixtureCatchesRead) proves the detector fires on a
+// genuine read reference and not on a write.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级") — MEDIUM
+//
+//   - Downstream (who may reference an RLS read method): MEDIUM. The file
+//     allowlist + use-based resolution catch every import form (a method call
+//     carries no package qualifier; the method binds to the receiver type).
+//   - Upstream (can an RLS read happen WITHOUT referencing these methods): the
+//     repo interface methods are the sole sanctioned read path for these tables;
+//     raw SQL bypassing the repo is out of this rule's scope (the pgexec executor
+//     is separately sealed).
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//   - File granularity: a SECOND unscoped read added inside an ALREADY-allowlisted
+//     file is not caught (same limit as the sibling write-side guards). The runtime
+//     RLS fail-closed (0 rows, adapters/postgres/tx_manager.go tenantScopeForTx /
+//     setLocalTenant) is the correctness backstop.
+//   - A read assembled by reflection or through an erased (non-ports) receiver does
+//     not resolve to a ports interface — the same limit as every identifier-
+//     resolution funnel in this suite.
+//   - Raw SQL against users / roles / role_assignments outside the repo methods is
+//     invisible here.
+//   - A read reached only through a narrow domain facade interface (e.g.
+//     domain.EffectiveAdminCounter.CountEffectiveAdmins, which RoleRepository
+//     satisfies structurally) is referenced by the facade type, not ports, so it is
+//     not matched — that is why internal/domain/admin.go is not in the allowlist.
+//     Those facades are sealed and their sole production caller chain
+//     (identitymanage.checkLastAdminRemoval) is already inside a scoped tx.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// accesscorePortsPkg (the package owning the UserRepository / RoleRepository
+// interfaces whose READ methods touch the RLS tables) is declared in
+// tenant_repo_param_funnel_test.go (same package) and reused here.
+
+const (
+	userRepositoryTypeName = "UserRepository"
+	roleRepositoryTypeName = "RoleRepository"
+)
+
+// rlsReadMethodsByIface maps each RLS-reading repo interface to its READ method
+// set. WRITE methods are deliberately excluded (see godoc §Detection). This set
+// IS the protected-operation definition; the anti-vacuity check pins the
+// load-bearing entries live so it cannot silently drift.
+var rlsReadMethodsByIface = map[string]map[string]struct{}{
+	userRepositoryTypeName: {
+		"GetByIDInTenant":        {},
+		"GetByUsername":          {},
+		"GetByIDForUpdate":       {},
+		"GetByUsernameForUpdate": {},
+	},
+	roleRepositoryTypeName: {
+		"GetByID":              {},
+		"GetByUserID":          {},
+		"CountByRole":          {},
+		"CountEffectiveAdmins": {},
+		"EffectiveAdminExists": {},
+		"ListByUserID":         {},
+	},
+}
+
+// rlsReadCallerAllowlist: the files that legitimately reference an accesscore
+// RLS-table read method (production slices, internal helpers, and the test-support
+// conformance / fixture packages that exercise the repos). A NEW entry must be
+// added consciously, after confirming the read runs inside a tenant-scoped tx.
+var rlsReadCallerAllowlist = map[string]struct{}{
+	"corecells/accesscore/slices/sessionlogin/service.go":            {},
+	"corecells/accesscore/slices/sessionrefresh/service.go":          {},
+	"corecells/accesscore/slices/sessionvalidate/service.go":         {},
+	"corecells/accesscore/slices/rbacassign/service.go":              {},
+	"corecells/accesscore/slices/rbaccheck/service.go":               {},
+	"corecells/accesscore/slices/identitymanage/service.go":          {},
+	"corecells/accesscore/internal/adminprovision/provisioner.go":    {},
+	"corecells/accesscore/internal/sessionmint/sessionmint.go":       {},
+	"corecells/accesscore/accesscoretest/fixture.go":                 {},
+	"corecells/accesscore/internal/ports/conformance/conformance.go": {},
+}
+
+// rlsReadRef is one resolved reference to an RLS-table read method.
+type rlsReadRef struct {
+	rel    string
+	line   int
+	iface  string
+	method string
+}
+
+// collectRLSReadRefs returns every reference, in p, to a read method (per
+// ifaceReads) owned by an interface in portsPkg. Resolution is use-based
+// (info.Uses) and receiver-bound (methodRecvTypeName), so it is invariant to
+// import alias and matches both calls and method-value references. Parameterized
+// by portsPkg/ifaceReads so the production scan and the RED fixture share one
+// detector core.
+func collectRLSReadRefs(p *Pass, portsPkg string, ifaceReads map[string]map[string]struct{}) []rlsReadRef {
+	if p.TypesInfo == nil {
+		return nil
+	}
+	var out []rlsReadRef
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+			fn, ok := p.TypesInfo.Uses[id].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != portsPkg {
+				return
+			}
+			reads, ok := ifaceReads[methodRecvTypeName(fn)]
+			if !ok {
+				return
+			}
+			if _, isRead := reads[fn.Name()]; !isRead {
+				return
+			}
+			out = append(out, rlsReadRef{
+				rel:    rel,
+				line:   p.Fset.Position(id.Pos()).Line,
+				iface:  methodRecvTypeName(fn),
+				method: fn.Name(),
+			})
+		})
+	}
+	return out
+}
+
+// TestTenantRLSReadCaller01 asserts every production reference to an accesscore
+// RLS-table read method sits in rlsReadCallerAllowlist, and that every allowlist
+// entry is live (anti-vacuity).
+func TestTenantRLSReadCaller01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	observed := map[string]struct{}{}
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		var d []Diagnostic
+		for _, ref := range collectRLSReadRefs(p, accesscorePortsPkg, rlsReadMethodsByIface) {
+			observed[ref.rel] = struct{}{}
+			if _, allowed := rlsReadCallerAllowlist[ref.rel]; !allowed {
+				d = append(d, Diagnostic{
+					Rel:  ref.rel,
+					Line: ref.line,
+					Message: fmt.Sprintf(
+						"TENANT-RLS-READ-CALLER-01: %s.%s (a read of an RLS-protected table: users/roles/"+
+							"role_assignments, FORCE ROW LEVEL SECURITY migration 053) is referenced from %s, which is "+
+							"not a sanctioned RLS reader. The read MUST run inside a tenant-scoped tx (scopedtx.Do / "+
+							"scopedtx.ApplyScope / a post-auth RunInTx whose ctxkeys fallback writes app.tenant_id); a "+
+							"bare-pool read fail-closes to 0 rows under the restricted app-serving pool (#1676). If this "+
+							"IS a new sanctioned reader, confirm it runs inside a scoped tx and add %s to "+
+							"rlsReadCallerAllowlist with rationale.",
+						ref.iface, ref.method, ref.rel, ref.rel,
+					),
+				})
+			}
+		}
+		return d
+	})
+
+	// Anti-vacuity / no-stale reverse self-check: every allowlist entry must
+	// reference a read method live, else a scanner regression or a removed reader
+	// would make the freeze vacuously pass.
+	for f := range rlsReadCallerAllowlist {
+		if _, seen := observed[f]; !seen {
+			diags = append(diags, Diagnostic{
+				Message: fmt.Sprintf(
+					"TENANT-RLS-READ-CALLER-01: allowlist entry %q is STALE — no live accesscore RLS read-method "+
+						"reference observed. Either the scanner regressed or the reader was removed; drop the dead "+
+						"allowlist entry so it cannot become a silent bypass slot.",
+					f,
+				),
+			})
+		}
+	}
+
+	Report(t, "TENANT-RLS-READ-CALLER-01", diags)
+}
+
+// TestTenantRLSReadCaller01_FixtureCatchesRead is the reverse self-check: the RED
+// fixture references a read method on a stand-in repository interface from a
+// non-allowlisted file. The detector core (run against the fixture package) must
+// resolve and flag exactly that ONE read reference — and must NOT flag the
+// fixture's write reference. A 0 result means the detector regressed (lost the
+// receiver binding or the read-method-set filter) and a new unscoped RLS read
+// could be added unnoticed.
+func TestTenantRLSReadCaller01_FixtureCatchesRead(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+
+	fixturePkg := modPath + "/tools/archtest/internal/rlsreadfixture"
+	pattern := "./tools/archtest/internal/rlsreadfixture/..."
+	fixtureReads := map[string]map[string]struct{}{
+		userRepositoryTypeName: {"GetByIDInTenant": {}},
+	}
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{pattern}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != fixturePkg {
+			return nil
+		}
+		var d []Diagnostic
+		for _, ref := range collectRLSReadRefs(p, fixturePkg, fixtureReads) {
+			d = append(d, Diagnostic{Rel: ref.rel, Line: ref.line, Message: ref.iface + "." + ref.method + " reference"})
+		}
+		return d
+	})
+	for _, dd := range diags {
+		t.Log(dd.Message)
+	}
+	require.Len(t, diags, 1,
+		"the detector must resolve the one out-of-allowlist UserRepository read reference and exclude the write; "+
+			"a 0 result means it regressed and an unscoped RLS read could be added unnoticed")
+}

--- a/tools/archtest/tenant_rls_read_caller_test.go
+++ b/tools/archtest/tenant_rls_read_caller_test.go
@@ -16,9 +16,12 @@
 // fail-closed 0 rows under the restricted app-serving pool (#1676). PR #1678
 // finding F1 fixed the three sites that had drifted out of a scoped tx; today
 // there are 0 residual sites. This rule is the FUTURE-DRIFT guard: it freezes the
-// set of files that may reference an accesscore RLS-table read method, so a NEW
-// reader fails CI until it is consciously reviewed (and, by that review, confirmed
-// to run inside a scoped tx) and added to the allowlist with rationale.
+// set of files that may reference an accesscore RLS-table read method DIRECTLY, so
+// a new such reference fails CI until it is consciously reviewed (and, by that
+// review, confirmed to run inside a scoped tx) and added to the allowlist with
+// rationale. A read reached only THROUGH A FACADE METHOD (which references the
+// facade type, not a ports read method) is NOT caught here — see §"Tool blind
+// spots"; the runtime RLS fail-closed (0 rows) is the correctness backstop for it.
 //
 // The scope-WRITE side is already funnel-locked (TENANT-TXSCOPE-WRITE-CALLER-01
 // pins tenant.WithScope; TENANT-APPLYSCOPE-WRITE-CALLER-01 pins the mid-tx GUC
@@ -52,12 +55,17 @@
 // excludes the same-named collisions: policymanage's PolicyRepository.GetByID,
 // the identitymanage *Service.GetByID handler method, and the mem/postgres
 // concrete-repo self-calls (a different receiver type / package) all resolve to a
-// non-matching owner and are skipped. The read-method set excludes WRITE methods
-// (Create / Update* / Delete / Assign* …), which hit the same RLS tables but
-// always run inside RunInTx already (writes are inherently transactional). The
-// anti-vacuity reverse check requires every allowlist entry to reference a read
-// method live, so a scanner regression or a removed reader (which would make the
-// freeze vacuously pass) fails CI. The RED fixture (internal/rlsreadfixture,
+// non-matching owner and are skipped. The protected read set is DERIVED, not
+// hand-listed: it is the live interface method set MINUS the WRITE methods
+// (rlsWriteMethodsByIface — Create / Update* / Delete / Assign* …), which hit the
+// same RLS tables but always run inside RunInTx already (writes are inherently
+// transactional). Deriving from the interface makes read COMPLETENESS structural
+// — a new RLS read method is protected by default, and the classification guard
+// (TestTenantRLSReadCaller01_ReadMethodClassification) fails CI if a new method
+// escapes both sets, a write entry goes stale, or the interface starts embedding.
+// The anti-vacuity reverse check requires every allowlist entry to reference a
+// read method live, so a scanner regression or a removed reader (which would make
+// the freeze vacuously pass) fails CI. The RED fixture (internal/rlsreadfixture,
 // TestTenantRLSReadCaller01_FixtureCatchesRead) proves the detector fires on a
 // genuine read reference and not on a write.
 //
@@ -100,6 +108,18 @@
 //     CURRENT-STATE snapshot, NOT an invariant this rule guards: a new unscoped
 //     caller of an RLS-reading facade method would not be caught here (the runtime
 //     RLS fail-closed backstop still applies).
+//   - The SAME facade limit applies to adminprovision.Provisioner.Status / Ensure,
+//     which wrap roleRepo.EffectiveAdminExists / CountByRole: provisioner.go IS in
+//     the allowlist (it references the ports read methods directly), but the
+//     Provisioner's callers reference Provisioner.Status / Ensure — not a ports read
+//     method — so a NEW unscoped caller of those facade methods is not caught here.
+//     Today the sole production caller (slices/setup/service.go Status / CreateAdmin,
+//     a pre-auth path with no JWT tenant fallback) wraps every call in scopedtx.Do
+//     — again a CURRENT-STATE snapshot, not an invariant this rule guards. The
+//     principled static closure for BOTH facade cases is the sealed ScopedCtx
+//     capability deferred to #1893 (it would make an unscoped read uncompilable
+//     through ANY path, facade or direct); until then the runtime RLS fail-closed
+//     backstop is the correctness boundary.
 //
 // # CI bucket
 //
@@ -127,25 +147,94 @@ const (
 	roleRepositoryTypeName = "RoleRepository"
 )
 
-// rlsReadMethodsByIface maps each RLS-reading repo interface to its READ method
-// set. WRITE methods are deliberately excluded (see godoc §Detection). This set
-// IS the protected-operation definition; the anti-vacuity check pins the
-// load-bearing entries live so it cannot silently drift.
-var rlsReadMethodsByIface = map[string]map[string]struct{}{
+// rlsRepoIfaces are the accesscore ports interfaces whose EVERY method touches an
+// RLS-protected table (users / roles / role_assignments). Because there is no
+// third category — each method is either a read or a write of those tables — the
+// protected READ set is DERIVED as (live interface method set − writes), not
+// hand-listed. That makes read completeness STRUCTURAL: a method newly added to
+// one of these interfaces is, by default, a protected read this rule catches —
+// closing the gap where a hand-list could silently omit a new RLS read method
+// (the anti-vacuity check only proves listed reads still have a live caller, not
+// that the list is complete).
+var rlsRepoIfaces = []string{userRepositoryTypeName, roleRepositoryTypeName}
+
+// rlsWriteMethodsByIface is the SOLE hand-maintained classification: the WRITE
+// methods on each rlsRepoIface. Writes hit the same RLS tables but are inherently
+// transactional (always issued inside RunInTx), so the read-side caller-allowlist
+// does not freeze them. deriveRLSReadMethods subtracts this set from the live
+// interface method set to obtain the protected read set; the classification guard
+// (TestTenantRLSReadCaller01_ReadMethodClassification) fails CI if an entry here
+// is not a live interface method (typo / stale) or if the interface embeds a
+// sub-interface (which would hide promoted methods from the AST scan). A NEW write
+// method must be added here, else it is (mis)derived as a protected read and flags
+// at its call sites — fail-closed toward protection, by design.
+var rlsWriteMethodsByIface = map[string]map[string]struct{}{
 	userRepositoryTypeName: {
-		"GetByIDInTenant":        {},
-		"GetByUsername":          {},
-		"GetByIDForUpdate":       {},
-		"GetByUsernameForUpdate": {},
+		"Create":                  {},
+		"Delete":                  {},
+		"UpdateProfile":           {},
+		"UpdateLockState":         {},
+		"UpdatePasswordResetFlag": {},
+		"UpdatePassword":          {},
+		"BumpAuthzEpoch":          {},
+		"UpdateLockoutFields":     {},
 	},
 	roleRepositoryTypeName: {
-		"GetByID":              {},
-		"GetByUserID":          {},
-		"CountByRole":          {},
-		"CountEffectiveAdmins": {},
-		"EffectiveAdminExists": {},
-		"ListByUserID":         {},
+		"Create":                  {},
+		"AssignToUser":            {},
+		"RemoveFromUser":          {},
+		"RemoveFromUserIfNotLast": {},
 	},
+}
+
+// deriveRLSReadMethods loads the live rlsRepoIface method sets (AST) and returns
+// (iface → read-method set) = full − rlsWriteMethodsByIface[iface]. It fails t on
+// any classification drift: an interface that embeds a sub-interface (promoted
+// methods would escape the AST scan), a write-exclusion entry that is not a live
+// interface method (typo / stale — would shrink the write set and misclassify a
+// real write as a read), or an interface whose derived read set is empty (the
+// whole interface classified as writes — almost certainly a mistake that would
+// make the rule vacuous for it). This is the completeness half the anti-vacuity
+// check cannot give: anti-vacuity proves every observed read has a live caller;
+// this pins the read SET to the interface fact.
+func deriveRLSReadMethods(t *testing.T, root string) map[string]map[string]struct{} {
+	t.Helper()
+	const portsDirRel = "corecells/accesscore/internal/ports"
+	reads := make(map[string]map[string]struct{}, len(rlsRepoIfaces))
+	for _, ifaceName := range rlsRepoIfaces {
+		iface := loadInterfaceType(t, root, portsDirRel, ifaceName)
+		if iface == nil {
+			t.Fatalf("TENANT-RLS-READ-CALLER-01: %s not found in %s", ifaceName, portsDirRel)
+		}
+		if embedded := embeddedTypeNames(iface); len(embedded) > 0 {
+			t.Errorf("TENANT-RLS-READ-CALLER-01: %s must not embed sub-interfaces "+
+				"(promoted methods would escape the read-method derivation); got %v", ifaceName, embedded)
+		}
+		methods := directMethodNames(iface)
+		methodSet := make(map[string]struct{}, len(methods))
+		for _, m := range methods {
+			methodSet[m] = struct{}{}
+		}
+		writes := rlsWriteMethodsByIface[ifaceName]
+		for w := range writes {
+			if _, ok := methodSet[w]; !ok {
+				t.Errorf("TENANT-RLS-READ-CALLER-01: write-exclusion %q is not a method of %s "+
+					"(typo or stale entry); fix rlsWriteMethodsByIface", w, ifaceName)
+			}
+		}
+		read := make(map[string]struct{}, len(methods))
+		for _, m := range methods {
+			if _, isWrite := writes[m]; !isWrite {
+				read[m] = struct{}{}
+			}
+		}
+		if len(read) == 0 {
+			t.Errorf("TENANT-RLS-READ-CALLER-01: derived read set for %s is empty "+
+				"(every method classified as a write); the rule would be vacuous for this interface", ifaceName)
+		}
+		reads[ifaceName] = read
+	}
+	return reads
 }
 
 // rlsReadCallerAllowlist: the files that legitimately reference an accesscore
@@ -220,6 +309,12 @@ func TestTenantRLSReadCaller01(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
+	// Derive the protected read set from the live interface fact (completeness is
+	// structural, not a hand-list). The derivation's classification assertions are
+	// also exercised standalone by TestTenantRLSReadCaller01_ReadMethodClassification
+	// (AST-only, runs even in -short).
+	rlsReadMethodsByIface := deriveRLSReadMethods(t, findModuleRoot(t))
+
 	observed := map[string]struct{}{}
 	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() {
@@ -271,13 +366,26 @@ func TestTenantRLSReadCaller01(t *testing.T) {
 	Report(t, "TENANT-RLS-READ-CALLER-01", diags)
 }
 
+// TestTenantRLSReadCaller01_ReadMethodClassification pins the read/write
+// classification to the LIVE interface fact (AST-only, so it runs even in -short
+// mode, unlike the packages.Load production scan above). It is the completeness
+// guard: adding a method to UserRepository / RoleRepository without listing it as
+// a write in rlsWriteMethodsByIface makes it a derived protected read; a stale or
+// misspelled write entry, an emptied read set, or a newly embedded sub-interface
+// fails here. deriveRLSReadMethods carries the assertions.
+func TestTenantRLSReadCaller01_ReadMethodClassification(t *testing.T) {
+	t.Parallel()
+	_ = deriveRLSReadMethods(t, findModuleRoot(t))
+}
+
 // TestTenantRLSReadCaller01_FixtureCatchesRead is the reverse self-check: the RED
-// fixture references a read method on a stand-in repository interface from a
-// non-allowlisted file. The detector core (run against the fixture package) must
-// resolve and flag exactly that ONE read reference — and must NOT flag the
-// fixture's write reference. A 0 result means the detector regressed (lost the
-// receiver binding or the read-method-set filter) and a new unscoped RLS read
-// could be added unnoticed.
+// fixture references a read method on EACH of two stand-in repository interfaces
+// (UserRepository + RoleRepository) from a non-allowlisted file. The detector core
+// (run against the fixture package) must resolve and flag exactly those TWO read
+// references — one per interface, proving the receiver binding resolves both — and
+// must NOT flag the fixture's write reference. A wrong count means the detector
+// regressed (lost the receiver binding or the read-method-set filter) and a new
+// unscoped RLS read could be added unnoticed.
 func TestTenantRLSReadCaller01_FixtureCatchesRead(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/tools/archtest/tenant_rls_read_caller_test.go
+++ b/tools/archtest/tenant_rls_read_caller_test.go
@@ -63,13 +63,22 @@
 //
 // # AI-robust rating (charter §"Funnel 双向锁评级") — MEDIUM
 //
-//   - Downstream (who may reference an RLS read method): MEDIUM. The file
-//     allowlist + use-based resolution catch every import form (a method call
-//     carries no package qualifier; the method binds to the receiver type).
-//   - Upstream (can an RLS read happen WITHOUT referencing these methods): the
-//     repo interface methods are the sole sanctioned read path for these tables;
-//     raw SQL bypassing the repo is out of this rule's scope (the pgexec executor
-//     is separately sealed).
+// Overall MEDIUM: a new unscoped read is expressible and COMPILES; the CI
+// archtest is the enforcement — the same tier as the sibling scope-WRITE guards
+// (a caller-allowlist, not a compile-time seal). The two axes:
+//
+//   - Downstream (detection robustness): alias-proof. Resolution is use-based
+//     (info.Uses → *types.Func) + receiver-bound, so no import form (qualified /
+//     alias / dot-import) and no same-name collision evades it. This matches what
+//     the sibling guards label "HARD" on this axis — but it is robust DETECTION,
+//     not a compile-time Hard tier: a non-allowlisted reference still compiles,
+//     which is exactly what keeps the rule Medium.
+//   - Upstream (can an RLS read happen WITHOUT referencing these methods):
+//     MEDIUM. The ports repo interface methods are the sole sanctioned read path
+//     for these tables, and repo reads route through the sealed ambient-tx
+//     PGExecutor (PG-REPO-AMBIENT-TX-01), so a repo read honors the scoped tx.
+//     Raw SQL issued OUTSIDE the repo methods is NOT covered by this rule (a
+//     separate concern; no claim is made here that it is sealed).
 //
 // # Tool blind spots (charter §"强制盲区自检")
 //
@@ -86,8 +95,18 @@
 //     domain.EffectiveAdminCounter.CountEffectiveAdmins, which RoleRepository
 //     satisfies structurally) is referenced by the facade type, not ports, so it is
 //     not matched — that is why internal/domain/admin.go is not in the allowlist.
-//     Those facades are sealed and their sole production caller chain
-//     (identitymanage.checkLastAdminRemoval) is already inside a scoped tx.
+//     Today the sole such facade's production caller chain
+//     (identitymanage.checkLastAdminRemoval) runs inside a scoped tx, but that is a
+//     CURRENT-STATE snapshot, NOT an invariant this rule guards: a new unscoped
+//     caller of an RLS-reading facade method would not be caught here (the runtime
+//     RLS fail-closed backstop still applies).
+//
+// # CI bucket
+//
+// Discovered + run by `gocell verify archtest` (whole-module packages.Load);
+// routed to the NIGHTLY bucket, NOT the PR-time archtest-invariants gate (per the
+// budget reasoning in hack/verify-archtest-invariants.sh). So a read-caller drift
+// is caught at the next nightly run, not on the introducing PR.
 package archtest
 
 import (
@@ -101,7 +120,7 @@ import (
 
 // accesscorePortsPkg (the package owning the UserRepository / RoleRepository
 // interfaces whose READ methods touch the RLS tables) is declared in
-// tenant_repo_param_funnel_test.go (same package) and reused here.
+// tenant_repo_param_funnel_test.go:104 (same package const) and reused here.
 
 const (
 	userRepositoryTypeName = "UserRepository"
@@ -134,14 +153,16 @@ var rlsReadMethodsByIface = map[string]map[string]struct{}{
 // conformance / fixture packages that exercise the repos). A NEW entry must be
 // added consciously, after confirming the read runs inside a tenant-scoped tx.
 var rlsReadCallerAllowlist = map[string]struct{}{
-	"corecells/accesscore/slices/sessionlogin/service.go":            {},
-	"corecells/accesscore/slices/sessionrefresh/service.go":          {},
-	"corecells/accesscore/slices/sessionvalidate/service.go":         {},
-	"corecells/accesscore/slices/rbacassign/service.go":              {},
-	"corecells/accesscore/slices/rbaccheck/service.go":               {},
-	"corecells/accesscore/slices/identitymanage/service.go":          {},
-	"corecells/accesscore/internal/adminprovision/provisioner.go":    {},
-	"corecells/accesscore/internal/sessionmint/sessionmint.go":       {},
+	"corecells/accesscore/slices/sessionlogin/service.go":         {},
+	"corecells/accesscore/slices/sessionrefresh/service.go":       {},
+	"corecells/accesscore/slices/sessionvalidate/service.go":      {},
+	"corecells/accesscore/slices/rbacassign/service.go":           {},
+	"corecells/accesscore/slices/rbaccheck/service.go":            {},
+	"corecells/accesscore/slices/identitymanage/service.go":       {},
+	"corecells/accesscore/internal/adminprovision/provisioner.go": {},
+	"corecells/accesscore/internal/sessionmint/sessionmint.go":    {},
+	// test-support readers (no scoped-tx obligation — they exercise the repos in
+	// tests, not on a production request path):
 	"corecells/accesscore/accesscoretest/fixture.go":                 {},
 	"corecells/accesscore/internal/ports/conformance/conformance.go": {},
 }
@@ -201,21 +222,25 @@ func TestTenantRLSReadCaller01(t *testing.T) {
 
 	observed := map[string]struct{}{}
 	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil // detection is type-dependent (info.Uses); skip AST-only passes.
+		}
 		var d []Diagnostic
 		for _, ref := range collectRLSReadRefs(p, accesscorePortsPkg, rlsReadMethodsByIface) {
 			observed[ref.rel] = struct{}{}
 			if _, allowed := rlsReadCallerAllowlist[ref.rel]; !allowed {
+				// Message carries no ruleID prefix — Report prepends it (avoids a
+				// double "TENANT-RLS-READ-CALLER-01:" in the output).
 				d = append(d, Diagnostic{
 					Rel:  ref.rel,
 					Line: ref.line,
 					Message: fmt.Sprintf(
-						"TENANT-RLS-READ-CALLER-01: %s.%s (a read of an RLS-protected table: users/roles/"+
-							"role_assignments, FORCE ROW LEVEL SECURITY migration 053) is referenced from %s, which is "+
-							"not a sanctioned RLS reader. The read MUST run inside a tenant-scoped tx (scopedtx.Do / "+
-							"scopedtx.ApplyScope / a post-auth RunInTx whose ctxkeys fallback writes app.tenant_id); a "+
-							"bare-pool read fail-closes to 0 rows under the restricted app-serving pool (#1676). If this "+
-							"IS a new sanctioned reader, confirm it runs inside a scoped tx and add %s to "+
-							"rlsReadCallerAllowlist with rationale.",
+						"%s.%s (a read of an RLS-protected table: users/roles/role_assignments, FORCE ROW LEVEL "+
+							"SECURITY migration 053) is referenced from %s, which is not a sanctioned RLS reader. The "+
+							"read MUST run inside a tenant-scoped tx (scopedtx.Do / scopedtx.ApplyScope / a post-auth "+
+							"RunInTx whose ctxkeys fallback writes app.tenant_id); a bare-pool read fail-closes to 0 rows "+
+							"under the restricted app-serving pool (#1676). If this IS a new sanctioned reader, confirm it "+
+							"runs inside a scoped tx and add %s to rlsReadCallerAllowlist with rationale.",
 						ref.iface, ref.method, ref.rel, ref.rel,
 					),
 				})
@@ -229,11 +254,14 @@ func TestTenantRLSReadCaller01(t *testing.T) {
 	// would make the freeze vacuously pass.
 	for f := range rlsReadCallerAllowlist {
 		if _, seen := observed[f]; !seen {
+			// Rel = the stale entry itself, so the diagnostic points at the file to
+			// drop; Message carries no ruleID prefix (Report prepends it).
 			diags = append(diags, Diagnostic{
+				Rel: f,
 				Message: fmt.Sprintf(
-					"TENANT-RLS-READ-CALLER-01: allowlist entry %q is STALE — no live accesscore RLS read-method "+
-						"reference observed. Either the scanner regressed or the reader was removed; drop the dead "+
-						"allowlist entry so it cannot become a silent bypass slot.",
+					"allowlist entry %q is STALE — no live accesscore RLS read-method reference observed. Either "+
+						"the scanner regressed or the reader was removed; drop the dead allowlist entry so it cannot "+
+						"become a silent bypass slot.",
 					f,
 				),
 			})
@@ -263,6 +291,7 @@ func TestTenantRLSReadCaller01_FixtureCatchesRead(t *testing.T) {
 	pattern := "./tools/archtest/internal/rlsreadfixture/..."
 	fixtureReads := map[string]map[string]struct{}{
 		userRepositoryTypeName: {"GetByIDInTenant": {}},
+		roleRepositoryTypeName: {"CountEffectiveAdmins": {}},
 	}
 	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{pattern}), func(p *Pass) []Diagnostic {
 		if p.Pkg == nil || p.Pkg.Path() != fixturePkg {
@@ -277,7 +306,8 @@ func TestTenantRLSReadCaller01_FixtureCatchesRead(t *testing.T) {
 	for _, dd := range diags {
 		t.Log(dd.Message)
 	}
-	require.Len(t, diags, 1,
-		"the detector must resolve the one out-of-allowlist UserRepository read reference and exclude the write; "+
-			"a 0 result means it regressed and an unscoped RLS read could be added unnoticed")
+	require.Len(t, diags, 2,
+		"the detector must resolve BOTH out-of-allowlist read references (UserRepository + RoleRepository) and "+
+			"exclude the write; a wrong count means receiver-binding or the read-method-set filter regressed and an "+
+			"unscoped RLS read could be added unnoticed")
 }


### PR DESCRIPTION
## Summary

新增 archtest `TENANT-RLS-READ-CALLER-01`（Medium）：冻结「哪些文件可引用 accesscore RLS 表（users/roles/role_assignments，FORCE RLS migration 053）的 ports 读方法」，作为读侧 future-drift 守卫。

## Why / 背景

PR #1678 finding F1 修复了 3 处 accesscore 对 RLS 表的生产读漏在 tenant-scoped tx 之外（裸 pool 读 → 未设 `app.tenant_id` GUC → `tenant_id = NULL` → fail-closed 0 行）。F1 已清全部已知站点（0 残留），但**读侧无机器守**——未来新增读站点可能再漏。scope-**写**侧已 funnel 锁死（`TENANT-TXSCOPE-WRITE-CALLER-01` / `TENANT-APPLYSCOPE-WRITE-CALLER-01`）；本 PR 用同一 caller-allowlist 机制补齐对称的读侧。

**为何 caller-allowlist 而非 lexical body-gate**：accesscore 读普遍落在多层 `*Tx` 命名 helper（接收 tx-ctx 作参数，如 `identitymanage`：`RunInTx → applyUserUpdateTx → guardUpdateStatusDemotion → checkLastAdminRemoval → GetByUserID`，读在 wrapper 下 4 帧）。lexical「读在 scope 闭包体内」要么误报要么需脆弱的多层 helper enrollment（章程禁止的 Soft）。caller-allowlist 对 indirection 免疫——只记录「哪个文件引用读方法」，与嵌套深度无关。

**为何 Medium 而非 Hard**：探索设计后裁定，compile-time-Hard 的 sealed `ScopedCtx` capability 相对本 Medium 守卫**机密性收益为 0**（unscoped 读在两种方案都被 runtime RLS fail-closed 兜底为 0 行），代价却是 cx-4 签名扇出 + 不可类型化的 use-after-tx 漏洞——故 Hard 升级路径登记为 follow-up issue（见 Refs）。

## Refs

Closes #1690

Follow-up（Hard 升级路径，本 PR 不做）: sealed `ScopedCtx` capability — 见本 PR 评论引用的 follow-up issue。

## Risk / 兼容性

无。纯新增 archtest 守卫（`//go:build archtest` 测试文件 + `//go:build archtest_fixture` RED fixture），不改任何生产签名/wire 契约/migration。产线扫描即时通过（0 残留站点全部落在 allowlist 内）。

## Test plan

- [x] `go build ./...`（tools 模块默认 tag）本地通过
- [x] `gocell verify archtest --rule=TENANT-RLS-READ-CALLER-01` 本地绿（production scan 0 finding + anti-vacuity + RED fixture catches read/excludes write，两 test 均 pass 非 skip）
- [x] `golangci-lint run --build-tags=archtest ./archtest/` 0 issues（fixture 在默认 tag 下被 build constraint 排除，与 sibling applyscopefixture 同范式）
