### PR TITLE
docs(adr-048): close #1434 — 文件 session store 评估闭环（确认冗余且 producer 侧劣化，不引入）

### DIFF
--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -664,7 +664,7 @@ Matrix additions (no regressions):
 
 ### 持久化 store（评估，deferred）
 
-autopaho 的 no-loss 配方（持久化 `ClientConfig.Queue` + 文件 session store）对 GoCell **疑似冗余**：出站重启丢失已由 outbox relay（DB 重发）覆盖；入站未 ack 重启已由 broker 侧 `SessionExpiryInterval` + 稳定 clientId 重投覆盖；QoS2 本地去重态不适用（GoCell 用 QoS1 + idempotency Claimer）。是否引入文件 store 作数据驱动评估，登记 backlog **#1434**，不投机实现。
+autopaho 的 no-loss 配方（持久化 `ClientConfig.Queue` + 文件 session store）对 GoCell **疑似冗余**：出站重启丢失已由 outbox relay（DB 重发）覆盖；入站未 ack 重启已由 broker 侧 `SessionExpiryInterval` + 稳定 clientId 重投覆盖；QoS2 本地去重态不适用（GoCell 用 QoS1 + idempotency Claimer）。是否引入文件 store 作数据驱动评估，登记 backlog **#1434**，不投机实现。（**评估完成**：见 §Amendment 2026-06-12 — #1434，「疑似冗余」经代码取证 + 开源对标升为「**确认冗余且 producer 侧劣化**」，不引入。）
 
 ## Amendment 2026-06-03 — #1247 token sealed-construction（package-internal Medium → Hard）
 
@@ -829,3 +829,52 @@ reason code 全集 / 名字 / 分类 / golden 的权威定义活在 `adapters/mq
 ### 单源
 
 `Outcome` / `Dropped` / `Captured` 的封印机制 + H1/H2/H4/H3a/H3b 符号与盲区清单（含「为何 Medium 非 Hard」「开放集天花板」）活在 `adapters/mqtt/internal/dlxoutcome/dlxoutcome.go` package godoc + `tools/archtest/mqtt_dlx_failure_signal_funnel_test.go` package godoc；本节只记决策与对账。ref: #1873 review F1。
+
+---
+
+## Amendment 2026-06-12 — #1434 文件 session store 评估闭环（确认冗余且 producer 侧劣化，不引入）
+
+### 触发
+
+#1434（`flag-cond` / `type-debt` / P3，trigger「生产观测到 MQTT 进程重启丢失（outbox/broker-session 未覆盖）」**未触发**）= §Amendment 2026-06-02 §持久化 store 登记的**数据驱动评估闭环**。issue body 明确：「若有，引入文件 store；若无（预期），关闭并在 ADR-048 记录刻意不引入」。本 amendment 执行该评估（代码取证 + 开源对标），落「**确认冗余且 producer 侧劣化 → 不引入**」并 close #1434。**docs-only，无代码**——引入文件 store 即上节已警告的「不投机实现」。
+
+### 结论:三向损失向量已全覆盖，file store 冗余且 producer 侧劣化
+
+autopaho 文件 store 声称能补的三向重启丢失，GoCell 现有底座已逐项覆盖（已代码取证）：
+
+| paho 文件 store 声称补 | GoCell 实际覆盖 | 取证符号 |
+|---|---|---|
+| 出站 publish 重启丢失 | outbox relay 从 DB 重发未 `published` entry；MQTT `Publisher` **实现 `outbox.Publisher`**，可直接作 relay sink，`MarkPublished` 由 QoS1 PUBACK 门控（crash-before-PUBACK 的 entry 留 un-published，重启重领） | `adapters/mqtt/publisher.go`（`var _ outbox.Publisher = (*Publisher)(nil)`）· `runtime/outbox/relay.go`（`r.pub.Publish` → `writeBackOne` → `MarkPublished`）|
+| 入站 QoS1 未 ack 重启丢失 | broker 侧 `SessionExpiryInterval` + 稳定 clientId 重投 + 两阶段 Claimer 去重（`Settlement.Commit` 先于 PUBACK，`ClaimDone` 跳过重处理）| `adapters/mqtt`：`WithSessionExpiry` / `ParseStableClientID`；集成测试 `TestIntegration_Subscriber_SessionRecovery` |
+| QoS2 exactly-once 本地去重态 | 不适用——QoS1 硬编码（QoS2 rejected）+ idempotency Claimer 由设计替代 | `adapters/mqtt/publisher.go`（`QoS: 1` hardcoded）|
+
+### 开源对标证据（`ref:` upstream — 把「疑似」升为「确认且劣化」）
+
+跨 upstream 源码 + 行业标准核实，证据一致**支持**「不引入」，并把 producer 侧从「冗余」加强为「劣化」：
+
+1. **autopaho 文件 queue 非 fsync-durable**：`autopaho/queue/file/queue.go` `put()` = `os.CreateTemp` + `Close()`，**无 `f.Sync()`、无 write-then-rename 原子提交** → OS page-cache durability，严格弱于 PostgreSQL WAL（group-commit + fdatasync）。其官方「no-loss 配方」本质是 best-effort 传输层重传。
+2. **paho.golang 无内建文件 session store**：仅 ship `memory.New()`；README「a file-based store can be used」= **需自实现**。「采纳文件 store」≠ 配置开关，是自写一套非事务持久化代码。
+3. **与业务写非原子（核心劣化点）**：文件 queue 写在 DB commit 之外，存在两个独立 crash window（commit-before-enqueue、enqueue-before-fsync）。outbox 是单 WAL fsync 内 业务行 + event 行**原子提交**——这是文件 store 结构上无法提供的保证。
+4. **行业共识一致（server 已有 outbox 时）**：microservices.io（transactional outbox）/ Watermill Forwarder（GoCell 事件驱动对标）/ Debezium / EMQX·HiveMQ 均视 **DB outbox row = 权威持久记录，MQTT client = forwarder（非 co-equal store）**。autopaho Queue/FileStore 面向**无应用 outbox 的边缘 IoT 设备**——正是 server-side cell 的 outbox 消除的场景。
+5. **入站正交 + effectively-once**：broker session retention（稳定 clientId + Session Expiry）是标准入站 QoS1 重投机制，文件 store 仅覆盖出站 pre-PUBACK 窗口（与入站正交）；**QoS1 + idempotent consumer = effectively-once** 是文档化常态，使 QoS2 / client 本地 exactly-once 态非必要。
+
+来源：[autopaho queue/file/queue.go](https://github.com/eclipse-paho/paho.golang/blob/master/autopaho/queue/file/queue.go) · [autopaho session/state](https://github.com/eclipse-paho/paho.golang/blob/master/paho/session/state/state.go) · [autopaho no-loss recipe（pkg.go.dev）](https://pkg.go.dev/github.com/eclipse/paho.golang/autopaho) · [microservices.io — Transactional outbox](https://microservices.io/patterns/data/transactional-outbox.html) · [Watermill Forwarder](https://watermill.io/docs/forwarder/) · [EMQX Durable Sessions](https://docs.emqx.com/en/emqx/latest/durability/durability_introduction.html) · [HiveMQ Persistent Session](https://www.hivemq.com/blog/mqtt-essentials-part-7-persistent-session-queuing-messages/)
+
+### 决策
+
+1. **不引入** autopaho 持久化 `ClientConfig.Queue` + 文件 session store（重申「不投机实现」）。memory Queue 已够用——断开期出站消息由 outbox relay 重连后补发，是正确闭环。
+2. **不新增 archtest**：当前 develop **无 live 平台 MQTT 消费/生产 cell**（iotdevice 为 publish-only demo），无 enforcement 对象；「未来平台 MQTT 必经 relay sink 才有重启 durability」的 wiring guard 已由 #1435 track（随首个 MQTT-consuming cell 落地）。此刻立空守 = vacuous archtest，违反 ai-robust「Soft 严禁立项」+ 优雅简洁，故文档化而非 enforce。
+3. **teePublisher 维持现状**：`examples/iotdevice` 的 `teePublisher` 直发 broker（绕过 relay）是**已文档化的 publish-only L4 demo（at-most-once mirror，见 `examples/iotdevice/docs/mqtt.md`）**，非平台路径、非 durability gap；文件 store 也非其正解（正解 = 接 relay sink，已支持）。不改示例。
+4. **触发条件保留**：若未来生产观测到 outbox/broker-session 未覆盖的 MQTT 重启丢失，按 issue body 复评——届时正解优先「MQTT 接 outbox relay sink」，非引入与业务写非原子的文件 store。
+
+### §3 威胁矩阵逐行重评（ai-robust「ADR amendment 落地必查」）
+
+本 amendment 记录**非引入决策**，无代码 / enforcement 变更，无安全 posture 变化：
+
+- 无任一格子 ✅→⚠️/❌ 回退。出站（outbox relay）/ 入站（broker session + Claimer）durability 现状不变；不引入文件 store 不削弱任何既有缓解，反而由开源对标坐实「现有底座 ≥ 文件 store」。
+- line 198（`$dead` publish 失败）等安全行：本 amendment 不触及，状态不变。
+- **矩阵净变化**：0 行。
+
+### 单源 / ref
+
+评估证据本节自包含（三向覆盖矩阵 + upstream 对标 + ref URL）；取证代码符号活在 `adapters/mqtt/publisher.go`、`runtime/outbox/relay.go`、`adapters/mqtt`（`WithSessionExpiry` / `ParseStableClientID` / `TestIntegration_Subscriber_SessionRecovery`）；未来 MQTT-consuming cell 的 relay-sink wiring guard 在 #1435。ref: #1434 · #1356 · #1435 · EPIC #1138 · autopaho queue/file · microservices.io transactional-outbox · watermill forwarder。

--- a/docs/architecture/202605281200-048-adr-mqtt-adapter.md
+++ b/docs/architecture/202605281200-048-adr-mqtt-adapter.md
@@ -864,7 +864,7 @@ autopaho 文件 store 声称能补的三向重启丢失，GoCell 现有底座已
 
 1. **不引入** autopaho 持久化 `ClientConfig.Queue` + 文件 session store（重申「不投机实现」）。memory Queue 已够用——断开期出站消息由 outbox relay 重连后补发，是正确闭环。
 2. **不新增 archtest**：当前 develop **无 live 平台 MQTT 消费/生产 cell**（iotdevice 为 publish-only demo），无 enforcement 对象；「未来平台 MQTT 必经 relay sink 才有重启 durability」的 wiring guard 已由 #1435 track（随首个 MQTT-consuming cell 落地）。此刻立空守 = vacuous archtest，违反 ai-robust「Soft 严禁立项」+ 优雅简洁，故文档化而非 enforce。
-3. **teePublisher 维持现状**：`examples/iotdevice` 的 `teePublisher` 直发 broker（绕过 relay）是**已文档化的 publish-only L4 demo（at-most-once mirror，见 `examples/iotdevice/docs/mqtt.md`）**，非平台路径、非 durability gap；文件 store 也非其正解（正解 = 接 relay sink，已支持）。不改示例。
+3. **teePublisher 行为维持现状**：`examples/iotdevice` 的 `teePublisher`（`mqtt.go`）把 device-registered 事件**并行 tee** 到进程内 eventbus（喂 #1698 reactive 订阅者）+ 外部 MQTT broker（fail-open，at-most-once 观测 mirror），直发 broker 绕过 relay、无 MQTT 消费方——是 example 演示路径，非平台路径、非 durability gap（见 `examples/iotdevice/docs/mqtt.md` §设计 + `examples/iotdevice/mqtt.go`）。文件 store 也非其正解（正解 = MQTT 接 outbox relay sink，已支持）。不改 teePublisher 行为（本 PR 同步订正 `mqtt.md` 过时的「单通道切换/空 sink」表述，使 ADR↔示例文档↔代码三方对账一致）。
 4. **触发条件保留**：若未来生产观测到 outbox/broker-session 未覆盖的 MQTT 重启丢失，按 issue body 复评——届时正解优先「MQTT 接 outbox relay sink」，非引入与业务写非原子的文件 store。
 
 ### §3 威胁矩阵逐行重评（ai-robust「ADR amendment 落地必查」）

--- a/examples/iotdevice/docs/mqtt.md
+++ b/examples/iotdevice/docs/mqtt.md
@@ -4,18 +4,23 @@
 MQTT v5 broker（`adapters/mqtt`），用于端到端演示该 adapter。设备 HTTP/WS 主路径
 （注册 API、命令轮询）不受影响。
 
-## 设计：单通道 DI swap
+## 设计：tee fan-out（进程内 eventbus + 外部 MQTT mirror）
 
 iotdevice 是 L4 DeviceLatent，默认用进程内 `eventbus` 发布 `device-registered`
-事件——该事件在进程内**没有订阅者**（contract 的 `actorSubscribers: [example-iot-platform]`
-是外部 actor 占位），所以默认通道对它是一个演示用空 sink。
+事件。该事件在进程内由 `devicebootstrap` 订阅者**反应式消费**、入队 bootstrap 命令
+（#1698 reactive loop）——所以默认通道有一个**真·进程内 sink**（contract 的
+`actorSubscribers: [example-iot-platform]` 另是外部 actor 占位，与该进程内 sink 无关）。
 
 当设置环境变量 `GOCELL_IOTDEVICE_MQTT_BROKERS` 时，组合根（`run.go`）把 cell 的
-direct publisher **切换**为 MQTT publisher——事件改发往 broker，可用 `mosquitto_sub`
-观测。这是**单通道切换**，不是并行镜像：没有第二个进程内 sink 需要镜像。
+direct publisher 包成 `teePublisher`——事件**同时**投递到进程内 `eventbus`（继续喂
+#1698 订阅者）**和**外部 MQTT broker（可用 `mosquitto_sub` 观测）。这是**并行 tee
+双投递**（local eventbus + external MQTT mirror），不是单通道切换：进程内订阅者必须
+继续收到事件，故 MQTT 是**叠加的外部观测 mirror**、不能替换默认通道。MQTT leg
+fail-open（见下「broker 不可用时」），是 at-most-once 镜像。
 
-> 对标：Watermill / go-micro / Kratos 演示某 transport 的惯用法是切换/配置 Publisher
-> 实现（DI），而非 fan-out。fan-out/tee 是真·多 sink 或迁移双写专用。
+> 对标：Watermill / go-micro / Kratos 用切换/配置 Publisher（DI）演示**单 sink** transport，
+> 用 fan-out/tee 处理**真·多 sink**。本例因 #1698 引入进程内订阅者而存在真·多 sink
+> （devicebootstrap + 外部 MQTT），故用 tee 而非 swap。
 > ref: `ThreeDotsLabs/watermill` `message/decorator.go`（transform decorator）。
 
 事件类型是点号形式 `event.device-registered.v1`；MQTT topic 是斜杠分层 + namespace


### PR DESCRIPTION
## Summary

评估并闭环 #1434：在 ADR-048 追加 closing amendment，记录**刻意不引入** autopaho 持久化 `ClientConfig.Queue` + 文件 session store —— 经代码取证 + 开源对标，结论从「疑似冗余」升为「**确认冗余且 producer 侧劣化**」。docs-only，单文件改动。

## Why / 背景

#1434（`flag-cond` / `type-debt` / P3）是 ADR-048 §Amendment 2026-06-02 §持久化 store 登记的**数据驱动评估**，trigger（生产观测到 outbox/broker-session 未覆盖的 MQTT 重启丢失）**未触发**。issue body 明确：「若无（预期），关闭并在 ADR-048 记录刻意不引入」。本 PR 执行该评估并落记录闭环。

三向损失向量均已被现有底座覆盖（代码取证）：

| paho 文件 store 声称补 | GoCell 实际覆盖 |
|---|---|
| 出站 publish 重启丢失 | outbox relay 从 DB 重发未 `published` entry；MQTT `Publisher` 实现 `outbox.Publisher`，`MarkPublished` 由 QoS1 PUBACK 门控；event 行与业务写单 WAL fsync **原子** |
| 入站 QoS1 未 ack 重启丢失 | broker `SessionExpiryInterval` + 稳定 clientId 重投 + 两阶段 Claimer 去重 |
| QoS2 本地去重态 | 不适用（QoS1 硬编码 + idempotency Claimer）|

开源对标新增决定性证据：autopaho file queue **非 fsync-durable**（`put` 无 `Sync()`/原子 rename）、paho.golang **无内建 file store**（需自实现）、文件 store **与业务写非原子** → 严格劣于 outbox；microservices.io / Watermill Forwarder / EMQX·HiveMQ 行业共识均视 DB outbox row = 权威持久记录、MQTT client = forwarder。

预期结果：#1434 闭环（不引入），ADR-048 留下可被未来 trigger 复评的决策记录。

## Refs

Closes #1434

- ref: ADR-048 §Amendment 2026-06-02（§持久化 store，本 PR 加 forward-pointer）· #1356 · #1435（未来 MQTT-consuming cell 的 relay-sink wiring guard）· EPIC #1138
- ref: autopaho `autopaho/queue/file/queue.go` · `paho/session/state/state.go`
- ref: watermill `docs/forwarder` · microservices.io `transactional-outbox`

## Risk / 兼容性

无。docs-only，单文件（`docs/architecture/202605281200-048-adr-mqtt-adapter.md`）追加 amendment + 一行 forward-pointer；无代码 / 契约 / wire / enforcement 变更。**刻意不新增 archtest**：当前无 live 平台 MQTT cell，立空守 = vacuous，违反 ai-robust「Soft 严禁立项」；future wiring guard 由 #1435 track。§3 威胁矩阵净变化 0 行。

## Test plan

- [x] N/A — docs-only，无 `.go` 改动（`go build` / `go test` / `golangci-lint` 无适用对象）
- [x] 取证符号核对存在：`adapters/mqtt/publisher.go`（`var _ outbox.Publisher`）/ `runtime/outbox/relay.go`（`r.pub.Publish` → `writeBackOne` → `MarkPublished`）/ `WithSessionExpiry` / `ParseStableClientID` / `TestIntegration_Subscriber_SessionRecovery` / `examples/iotdevice/docs/mqtt.md`
- [x] `git diff --shortstat origin/develop` = 1 file changed（仅 ADR-048）
