### PR TITLE
docs(devicecert): PR-1 — 设备证书框架化 ADR + 路线图修订 + speckit 规格 [#1895]

### DIFF
--- a/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
+++ b/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
@@ -75,8 +75,11 @@ lifecycle、EST 前端、生产 device 主体。
 
 ### D5 — MDM/ZT 前期工作 = 4 中立契约 + 设备主体签发器（部分提前 #1051/#1052）
 
-- 定义 `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1`——路线图
-  唯一允许提前的 MDM/ZT 前期项（#1052「可提前子项」）。`deviceidentity` 是证书/身份之家。
+- 定义 4 个中立设备契约（domain：deviceidentity / devicestate / devicecompliance / remotecommand）——
+  路线图唯一允许提前的 MDM/ZT 前期项（#1052「可提前子项」）。`deviceidentity` 是证书/身份之家。
+  目录按仓库单源 `{kind}/{domain-path}/{version}/` 落 **kind-qualified** 路径（`contracts/http/deviceidentity/.../v1`、
+  `contracts/event/deviceidentity/.../v1`、`contracts/command/{deviceidentity/rotate,remotecommand}/v1` 等，详见 spec FR-013）；
+  「4 个契约」是 domain 简写，非目录真源。
 - 落地 #1811（生产 device / super-admin 主体签发器）——证书底座硬前置。
 - **不建** `mdm/` / `zerotrust/` module 骨架；winmdm `pkicell` 的**框架级 PKI 原语下移 core**，
   winmdm 触发（2027 Q1）后只需建 WSTEP/SCEP 协议前端 + caworkflow，不再自建 PKI 原语。
@@ -91,6 +94,7 @@ lifecycle、EST 前端、生产 device 主体。
 | 跨副本重复签发 | 复用 `RECONCILE-FENCED-WRITE-FUNNEL-01`（`LeaseToken.Epoch` 写路径 CAS）+ 队列 active-uniqueness | Hard |
 | 吊销与续期竞态（吊销正在续期的证书） | epoch 单调 CAS（fencing）保证终态一致；`certlifecycle` 状态机 revoke 转换串行化 | Hard（复用 fencing）/ Medium（状态机测试） |
 | 多租户证书 reconcile 串租户 | reconcile system identity 清空 tenant（#1821）；scan + 命令 key + 签发请求自带 tenant 维度 | Medium |
+| 跨租户吊销（凭裸 serial 吊销他租户证书） | `Revoke`/`RevocationList`/`Tidy` 带 `CertScope`（tenant+issuer+device）typed 位置参，与签发同源；漏传编译错（`CERT-REVOKE-SCOPED-01`）；跨租户/issuer fail-closed | 上游 Hard（typed scope 漏传编译错）/ 下游 Medium（fail-closed 测试） |
 | EST 注册鉴权绕过 | `EST-ENROLL-AUTH-BOUNDARY-01`（enroll=bootstrap/设备凭证；reenroll=现证书 mTLS；缺则 fail-closed） | Medium |
 | 续期惊群 | jitter 续期窗口（k8s 70-90% 寿命模型） | —（工程） |
 | device PII（serial/subject/device_id 入日志/wire） | 复用 `pkg/redaction`（#1695）；审计前 hash/redact | Medium |
@@ -103,7 +107,9 @@ lifecycle、EST 前端、生产 device 主体。
   开箱可用；`Authorize`/`Sign` 分离 + 私钥边界对齐业界最佳实践。
 - **代价**：推翻一条已锁定决策（#995）+ 修订 4 份路线图文档（见下）；新增 2 个 runtime 包 +
   1 个 adapter module + 4 个契约 + iotdevice 破坏式迁移（`rotate-cert` 字符串→真契约，无 shim）。
-- **真值源**：`docs/plans/specs/1895-device-identity-cert-framework/`（spec/plan/tasks/research）。
+- **实施规格 / 设计分解 / 后续 PR 输入**：`docs/plans/specs/1895-device-identity-cert-framework/`
+  （spec/plan/tasks/research）。**项目状态 / 优先级 / wave / 父子关系的唯一真源是 GitHub Issues #1895 + Project**
+  （PROJECT.md / agent-instruction-surfaces 单源）；speckit 目录只承载实施规格内容，不承载项目管理状态。
 
 ## 路线图修订（本 ADR 同改动落地，冲突段落重写——AI-robust §审查）
 
@@ -111,14 +117,16 @@ lifecycle、EST 前端、生产 device 主体。
 |---|---|---|
 | #995（issue） | 全文 | 收口结论=进框架（评论 + PR-11 关闭）；推翻「不在框架 / 消费方自建」 |
 | `202604301030-winmdm-prd-on-gocell.md` | §2 pkicell（line 72）+ §10 module 归属 | pkicell 框架级 PKI 原语下移 core；winmdm 仅留 WSTEP/SCEP 前端 + caworkflow |
-| `202604300900-gocell-as-platform-foundation.md` | §3 pkicell 映射（191/206）+ §4 mtlscert | PKI 底座=框架 `runtime/certsigning`+`adapters/softca`；pkicell/mtlscert 为消费方 |
-| `202604300950-plan-d-...md` | §10 阶段 0 | 加注：设备证书框架底座落 core（runtime/adapters/contracts），**不**建 mdm/，与「禁止预建 mdm/」一致 |
+| `202604300900-gocell-as-platform-foundation.md` | §3 pkicell 映射（M6 / cell 表 / Stage1 / M1）+ §3 P0 callout + §4 mtlscert | inline 重写：PKI 底座=框架 `runtime/certsigning`+`adapters/softca`+EST；pkicell/mtlscert 为消费方；**`rotation` slice 退役**；v1.0 P0 由「pkicell WSTEP」**替换为「框架证书底座（certsigning/softca/EST）」**，winmdm WSTEP/SCEP 前端归 2027 Stage 2 |
+| `202604300950-plan-d-...md` | §10 阶段 0 + §3.1 树（pkicell 内部CA）+ §9 PKIIssuer + PR A1.4 | 加注 + inline：设备证书框架底座落 core（runtime/adapters/contracts），**不**建 mdm/，与「禁止预建 mdm/」一致；pkicell 去 `rotation`/内部CA，改消费框架 |
+| `202604301030-winmdm-prd-on-gocell.md` | §2 pkicell（line 80）+ §10 module + §3 链路 + §7 mTLS | pkicell 框架级 PKI 原语下移 core；winmdm 仅留 WSTEP/SCEP 前端 + caworkflow；`rotation` 退役；CA 私钥归 softca |
 | `202604300800-final-form-capability-overview.md` | §3.7 运行时能力清单 | final-form 增列「设备身份与证书底座」（`runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` + EST）能力条目 |
 | #1051 / #1052（issue） | 锚点 | 评论：框架 PKI 原语 + 4 中立契约提前；其余项仍门控 2027/2029 |
 
-> 与 gocell-platform §3「P0 阻塞项」callout「pkicell WSTEP 作为 v1.0 P0」**一致**——本 ADR 把该
-> P0 的 PKI 原语部分明确为框架交付（WSTEP 协议前端仍 winmdm），同时消解 #995「不在框架」与该
-> P0 callout 的张力。
+> **v1.0 P0 重定义**：路线图原把「pkicell WSTEP 支持」列为 v1.0 P0（同文 §3.7 时间估算却把 pkicell
+> 排到 Stage 1 / 2027 Q1，本身不自洽）。本 ADR **替换**该 P0 为「框架证书底座（`runtime/certsigning` +
+> `adapters/softca` + EST）」——这是真正属于 core v1.0 的能力；winmdm 的 WSTEP/SCEP 协议前端归 2027
+> Stage 2，不塞进 core v1.0 P0。一并消解 #995「不在框架」与原 P0 callout 的张力。
 
 ## 参考
 

--- a/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
+++ b/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
@@ -1,0 +1,125 @@
+# ADR: 设备身份与证书框架化决议（device-cert pivot）
+
+- Status: Accepted
+- Date: 2026-06-12
+- Issue: #1895 (EPIC), #1897 (PR-1, US6 / FR-018); 收口 #995; 部分提前 #1051 / #1052
+- Scope: 本 ADR 锁定「设备证书成为框架的一部分」的范围决策 + 层放置 + 威胁矩阵，
+  并修订 4 份已锁定路线图文档的冲突段落。各 PR 的实现级 invariant 符号 / 评级证明
+  写入其 archtest godoc；跨层威胁矩阵复检由 PR-11（#1907）收尾，本 ADR 是其单源。
+
+## Context
+
+`docs/plans/product-roadmap/`（2026-04-30 锁定）把设备证书 / PKI 定位为**消费方自建**：
+#995 明文「X.509 证书管理…**当前不在框架内**——定位为消费方（winmdm）在 `cells/cert-core`
+自建或集成 step-ca / Vault PKI」，框架最多给 hook 接口；winmdm `pkicell`
+（slices `wstep/scep/caworkflow/rotation`）落在 `mdm` module，门控 v1.0 GA / 2027 Q1（#1051）；
+zerotrust 门控 2029 Q1（#1052）。
+
+三个事实促成转向（2026-06）：
+
+1. **多租户已大幅推进**（epic #1337 PR-1..12 落地）。设备主体模型 `principalKind=device` /
+   `RowScope=device` 就位（`runtime/auth/rowscope.go`），但 develop **无生产 authn 铸造
+   `PrincipalDevice`**（rowscope.go 自述 "type-foundation entries, no production issuer"）——#1811。
+2. **「设备证书」今天是时间戳，不是 PKI**。repo 中**零** CA / CSR / CRL / 签名 / 私钥代码；
+   唯一「证书」= devices 行 `cert_epoch` + `cert_expires_at` 两列 + 一个发 `rotate-cert`
+   字符串命令的 stateless reconciler（`examples/iotdevice/.../devicecertrenewal`）。
+3. **路线图自身存在张力**：gocell-platform §3.7（line 271）已把「pkicell WSTEP 支持」列为
+   **GoCell v1.0 P0 前置**——与 #995「不在框架」立场矛盾。本 ADR 消解该张力。
+
+开源对标（SPIFFE/SPIRE + cert-manager + step-ca，三家一致）：**控制面（生命周期 reconcile +
+请求模型 + 续期调度）属框架；签名私钥在 adapter（`crypto.Signer` 永不出边界）；协议前端在
+消费方边缘；`Authorize`（能否拿证书）与 `Sign`（CSR→证书）是两个接口**。GoCell 已有其中
+4 个接缝（`kernel/reconcile` / `runtime/command` / PDP / `RowScope`），缺真实 Signer、泛化
+lifecycle、EST 前端、生产 device 主体。
+
+## Decisions
+
+### D1 — 设备证书进框架（推翻 #995「不在框架」）
+
+设备证书全生命周期的**通用控制面**提升为框架能力，结束「每个 MDM 消费方各自重造」。
+#995 的触发条件（「WinMDM 或设备管理产品线正式启动，需框架级 PKI；或 ≥2 消费方需证书管理」）
+由本决策按 fiat 满足（MDM + ZT 双消费方 + 设备身份框架化诉求）。#995 收口结论 = **进框架**。
+
+### D2 — 深度 = 底座 + 内置软 CA + EST 前端（不做完整 PKI corecell）
+
+- **框架拥有**：`runtime/certsigning`（`Signer` / `Authorizer` / `RevocationStore` 接口 +
+  `CertRequest` / `IssuedCert` sealed 类型）、`runtime/certlifecycle`（泛化 iotdevice 种子的
+  `reconcile.Reconciler`）、`runtime/http/est`（EST RFC 7030 注册前端）、`adapters/softca`
+  （内置软 CA，标准库 `crypto/x509`，**无外部 CA 依赖即可用**）。
+- **留 adapter**：真实 CA 后端 step-ca / Vault PKI（本轮只留接口位，后续 PR）。
+- **留消费方**：Windows 专属 XCEP / WSTEP / SCEP / MS-MDE 协议前端（winmdm）；ZT 的
+  mTLS / SPIFFE Workload-API 边缘。
+- **不做**：`certcore` 平台 corecell（证书底座是 primitive 不是平台 Cell；强行做 corecell
+  与 #995「cells/cert-core」消费方语义 + winmdm `pkicell` 落点都冲突）。
+
+### D3 — 层放置：runtime + adapters + contracts，全落 core，不入 kernel、不建 module
+
+- 证书底座入 **`runtime/`**（需 `crypto/x509` + 在 reconcile/command 之上 wiring；kernel 只依赖
+  stdlib+pkg，不入 kernel）。对标既有范式：`kernel/reconcile` 定义 `LeaderElector` 接口、
+  `adapters/{redis,postgres}` 实现——本 epic：`runtime/certsigning` 定义 `Signer`、
+  `adapters/softca` 实现。
+- 证书生命周期**复用** `kernel/reconcile.Loop`（leader-elect / `LeaseToken.Epoch` fencing /
+  system-identity），**不新造控制环**。
+- 中立契约入 `contracts/`；设备主体签发器入 `runtime/auth`。
+- **全部落 core 顶层 module**，不建 `mdm/` / `zerotrust/`（守 plan-D §10）。
+
+### D4 — `Authorize` 与 `Sign` 分离；私钥永不出 adapter；`Sign` 唯一签发入口
+
+- `Authorizer.AuthorizeEnroll(ctx, EnrollmentClaim) (SignConstraints, error)` 与
+  `Signer.Sign(ctx, CertRequest) (IssuedCert, error)` 是**两个接口**（对标 step-ca
+  `AuthorizeSign` vs `Authority.Sign`）。授权**复用既有 PDP**，不新建决策引擎。
+- 签名私钥（`crypto.Signer`）**永不进 kernel/runtime**，只在 adapter 内（SPIRE KeyManager 范式）。
+- `Signer.Sign` 是包外铸造设备证书的**唯一入口**（sealed funnel）；`CertRequest` / `IssuedCert`
+  sealed 构造（包外不可字面量伪造证书材料）。
+
+### D5 — MDM/ZT 前期工作 = 4 中立契约 + 设备主体签发器（部分提前 #1051/#1052）
+
+- 定义 `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1`——路线图
+  唯一允许提前的 MDM/ZT 前期项（#1052「可提前子项」）。`deviceidentity` 是证书/身份之家。
+- 落地 #1811（生产 device / super-admin 主体签发器）——证书底座硬前置。
+- **不建** `mdm/` / `zerotrust/` module 骨架；winmdm `pkicell` 的**框架级 PKI 原语下移 core**，
+  winmdm 触发（2027 Q1）后只需建 WSTEP/SCEP 协议前端 + caworkflow，不再自建 PKI 原语。
+
+## 威胁矩阵（PR-11 复检单源）
+
+| 威胁 | 缓解 | 评级 |
+|---|---|---|
+| 包外伪造证书值 / 绕过签发 | `CERT-VALUE-SEALED-CONSTRUCTION-01` + `CERT-SIGN-FUNNEL-01`（Sign 唯一入口） | Hard |
+| 私钥泄漏到 kernel/runtime | `CERT-PRIVATE-KEY-CUSTODY-01`（archtest 扫 certsigning 边界外无 PrivateKey 字段；私钥只在 adapter 的 `crypto.Signer`） | Hard/Medium |
+| 授权漏洞放大为越权签发 | `Authorize` / `Sign` 分离；`AuthorizeEnroll` 复用 PDP；nil grant fail-closed；SignConstraints 由 Signer 强制 | Medium |
+| 跨副本重复签发 | 复用 `RECONCILE-FENCED-WRITE-FUNNEL-01`（`LeaseToken.Epoch` 写路径 CAS）+ 队列 active-uniqueness | Hard |
+| 多租户证书 reconcile 串租户 | reconcile system identity 清空 tenant（#1821）；scan + 命令 key + 签发请求自带 tenant 维度 | Medium |
+| EST 注册鉴权绕过 | `EST-ENROLL-AUTH-BOUNDARY-01`（enroll=bootstrap/设备凭证；reenroll=现证书 mTLS；缺则 fail-closed） | Medium |
+| 续期惊群 | jitter 续期窗口（k8s 70-90% 寿命模型） | —（工程） |
+| device PII（serial/subject/device_id 入日志/wire） | 复用 `pkg/redaction`（#1695）；审计前 hash/redact | Medium |
+
+每条 enforcement 与其实现**同 PR 闭环**（静态守卫 + 反向自检 + godoc/ADR）；无 Soft（AI-robust §分级）。
+
+## Consequences
+
+- **正向**：设备证书一次性框架化，winmdm / ZT / iotdevice 共享同一底座；内置 softca 使能力
+  开箱可用；`Authorize`/`Sign` 分离 + 私钥边界对齐业界最佳实践。
+- **代价**：推翻一条已锁定决策（#995）+ 修订 4 份路线图文档（见下）；新增 2 个 runtime 包 +
+  1 个 adapter module + 4 个契约 + iotdevice 破坏式迁移（`rotate-cert` 字符串→真契约，无 shim）。
+- **真值源**：`docs/plans/specs/1895-device-identity-cert-framework/`（spec/plan/tasks/research）。
+
+## 路线图修订（本 ADR 同改动落地，冲突段落重写——AI-robust §审查）
+
+| 文档 | 段落 | 修订 |
+|---|---|---|
+| #995（issue） | 全文 | 收口结论=进框架（评论 + PR-11 关闭）；推翻「不在框架 / 消费方自建」 |
+| `202604301030-winmdm-prd-on-gocell.md` | §2 pkicell（line 72）+ §10 module 归属 | pkicell 框架级 PKI 原语下移 core；winmdm 仅留 WSTEP/SCEP 前端 + caworkflow |
+| `202604300900-gocell-as-platform-foundation.md` | §3 pkicell 映射（191/206）+ §4 mtlscert | PKI 底座=框架 `runtime/certsigning`+`adapters/softca`；pkicell/mtlscert 为消费方 |
+| `202604300950-plan-d-...md` | §10 阶段 0 | 加注：设备证书框架底座落 core（runtime/adapters/contracts），**不**建 mdm/，与「禁止预建 mdm/」一致 |
+| `202604300800-final-form-capability-overview.md` | §3.7 + Tier B | final-form 增列 `runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` 能力 |
+| #1051 / #1052（issue） | 锚点 | 评论：框架 PKI 原语 + 4 中立契约提前；其余项仍门控 2027/2029 |
+
+> 与 §3.7（line 271）「pkicell WSTEP 作为 v1.0 P0」**一致**——本 ADR 把该 P0 的 PKI 原语部分
+> 明确为框架交付（WSTEP 协议前端仍 winmdm），消解 #995 与 §3.7 的张力。
+
+## 参考
+
+- 对标：SPIFFE/SPIRE `pkg/server/ca/ca.go` + keymanager plugin；cert-manager Issuer/CertificateRequest；
+  smallstep/certificates `authority/{tls,provisioner}`；Vault PKI；k8s kubelet `certificate.Manager`；IETF RFC 7030（EST）。
+- 内部：`kernel/reconcile/doc.go`、`runtime/command`、`docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md`、
+  `docs/architecture/202606101200-1821-adr-reconcile-system-producer-identity.md`、`.claude/rules/gocell/tenancy.md`。

--- a/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
+++ b/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
@@ -23,8 +23,9 @@ zerotrust 门控 2029 Q1（#1052）。
 2. **「设备证书」今天是时间戳，不是 PKI**。repo 中**零** CA / CSR / CRL / 签名 / 私钥代码；
    唯一「证书」= devices 行 `cert_epoch` + `cert_expires_at` 两列 + 一个发 `rotate-cert`
    字符串命令的 stateless reconciler（`examples/iotdevice/.../devicecertrenewal`）。
-3. **路线图自身存在张力**：gocell-platform §3.7（line 271）已把「pkicell WSTEP 支持」列为
-   **GoCell v1.0 P0 前置**——与 #995「不在框架」立场矛盾。本 ADR 消解该张力。
+3. **路线图自身存在张力**：gocell-platform §3「P0 阻塞项（GoCell v1.0 前置）」callout 已把
+   「pkicell WSTEP 支持」列为 **v1.0 P0 前置**（同文 §3.7 时间估算却把 pkicell 排到 Stage 1 /
+   2027 Q1，本身已不自洽）——且与 #995「不在框架」立场矛盾。本 ADR 消解该张力。
 
 开源对标（SPIFFE/SPIRE + cert-manager + step-ca，三家一致）：**控制面（生命周期 reconcile +
 请求模型 + 续期调度）属框架；签名私钥在 adapter（`crypto.Signer` 永不出边界）；协议前端在
@@ -84,10 +85,11 @@ lifecycle、EST 前端、生产 device 主体。
 
 | 威胁 | 缓解 | 评级 |
 |---|---|---|
-| 包外伪造证书值 / 绕过签发 | `CERT-VALUE-SEALED-CONSTRUCTION-01` + `CERT-SIGN-FUNNEL-01`（Sign 唯一入口） | Hard |
-| 私钥泄漏到 kernel/runtime | `CERT-PRIVATE-KEY-CUSTODY-01`（archtest 扫 certsigning 边界外无 PrivateKey 字段；私钥只在 adapter 的 `crypto.Signer`） | Hard/Medium |
+| 包外伪造证书值 / 绕过签发 | `CERT-VALUE-SEALED-CONSTRUCTION-01`（sealed 构造）+ `CERT-SIGN-FUNNEL-01`（Sign 唯一入口） | 上游 Hard（sealed 值构造）/ 下游 Medium（archtest 扫单一 Sign callsite） |
+| 私钥泄漏到 kernel/runtime | `CERT-PRIVATE-KEY-CUSTODY-01`（私钥只在 adapter 的 `crypto.Signer`） | 上游 Hard（`Signer` 接口不暴露 key getter）/ 下游 Medium（archtest 扫 certsigning 边界外无 PrivateKey 字段） |
 | 授权漏洞放大为越权签发 | `Authorize` / `Sign` 分离；`AuthorizeEnroll` 复用 PDP；nil grant fail-closed；SignConstraints 由 Signer 强制 | Medium |
 | 跨副本重复签发 | 复用 `RECONCILE-FENCED-WRITE-FUNNEL-01`（`LeaseToken.Epoch` 写路径 CAS）+ 队列 active-uniqueness | Hard |
+| 吊销与续期竞态（吊销正在续期的证书） | epoch 单调 CAS（fencing）保证终态一致；`certlifecycle` 状态机 revoke 转换串行化 | Hard（复用 fencing）/ Medium（状态机测试） |
 | 多租户证书 reconcile 串租户 | reconcile system identity 清空 tenant（#1821）；scan + 命令 key + 签发请求自带 tenant 维度 | Medium |
 | EST 注册鉴权绕过 | `EST-ENROLL-AUTH-BOUNDARY-01`（enroll=bootstrap/设备凭证；reenroll=现证书 mTLS；缺则 fail-closed） | Medium |
 | 续期惊群 | jitter 续期窗口（k8s 70-90% 寿命模型） | —（工程） |
@@ -111,11 +113,12 @@ lifecycle、EST 前端、生产 device 主体。
 | `202604301030-winmdm-prd-on-gocell.md` | §2 pkicell（line 72）+ §10 module 归属 | pkicell 框架级 PKI 原语下移 core；winmdm 仅留 WSTEP/SCEP 前端 + caworkflow |
 | `202604300900-gocell-as-platform-foundation.md` | §3 pkicell 映射（191/206）+ §4 mtlscert | PKI 底座=框架 `runtime/certsigning`+`adapters/softca`；pkicell/mtlscert 为消费方 |
 | `202604300950-plan-d-...md` | §10 阶段 0 | 加注：设备证书框架底座落 core（runtime/adapters/contracts），**不**建 mdm/，与「禁止预建 mdm/」一致 |
-| `202604300800-final-form-capability-overview.md` | §3.7 + Tier B | final-form 增列 `runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` 能力 |
+| `202604300800-final-form-capability-overview.md` | §3.7 运行时能力清单 | final-form 增列「设备身份与证书底座」（`runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` + EST）能力条目 |
 | #1051 / #1052（issue） | 锚点 | 评论：框架 PKI 原语 + 4 中立契约提前；其余项仍门控 2027/2029 |
 
-> 与 §3.7（line 271）「pkicell WSTEP 作为 v1.0 P0」**一致**——本 ADR 把该 P0 的 PKI 原语部分
-> 明确为框架交付（WSTEP 协议前端仍 winmdm），消解 #995 与 §3.7 的张力。
+> 与 gocell-platform §3「P0 阻塞项」callout「pkicell WSTEP 作为 v1.0 P0」**一致**——本 ADR 把该
+> P0 的 PKI 原语部分明确为框架交付（WSTEP 协议前端仍 winmdm），同时消解 #995「不在框架」与该
+> P0 callout 的张力。
 
 ## 参考
 

--- a/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
+++ b/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
@@ -95,7 +95,7 @@ lifecycle、EST 前端、生产 device 主体。
 | 吊销与续期竞态（吊销正在续期的证书） | epoch 单调 CAS（fencing）保证终态一致；`certlifecycle` 状态机 revoke 转换串行化 | Hard（复用 fencing）/ Medium（状态机测试） |
 | 多租户证书 reconcile 串租户 | reconcile system identity 清空 tenant（#1821）；scan + 命令 key + 签发请求自带 tenant 维度 | Medium |
 | 跨租户吊销（凭裸 serial 吊销他租户证书） | `Revoke`/`RevocationList`/`Tidy` 带 `CertScope`（tenant+issuer+device）typed 位置参，与签发同源；漏传编译错（`CERT-REVOKE-SCOPED-01`）；跨租户/issuer fail-closed | 上游 Hard（typed scope 漏传编译错）/ 下游 Medium（fail-closed 测试） |
-| EST 注册鉴权绕过 | `EST-ENROLL-AUTH-BOUNDARY-01`（enroll=bootstrap/设备凭证；reenroll=现证书 mTLS；缺则 fail-closed） | Medium |
+| EST 注册鉴权绕过 | `EST-ENROLL-AUTH-BOUNDARY-01`（enroll=专用 enrollment-credential/device-token，**不复用** setup `auth.bootstrap:true`；reenroll=现证书 mTLS；EST 挂版本化 cell 路径，缺则 fail-closed） | Medium |
 | 续期惊群 | jitter 续期窗口（k8s 70-90% 寿命模型） | —（工程） |
 | device PII（serial/subject/device_id 入日志/wire） | 复用 `pkg/redaction`（#1695）；审计前 hash/redact | Medium |
 

--- a/docs/plans/engineering-baseline/202604300800-final-form-capability-overview.md
+++ b/docs/plans/engineering-baseline/202604300800-final-form-capability-overview.md
@@ -234,7 +234,8 @@ deployTemplate:
 - **Config 热更新**：fsnotify + ConfigMap symlink pivot 检测，无需重启
 - **健康检查**：`/livez` + `/readyz`，cell 注册的所有 health checker 聚合，readyz 翻转 → drain
 - **可观测性**：OTel trace + slog 结构化日志 + Prometheus 指标，metrics-schema.yaml 守护 label cardinality
-- **认证**：JWT 签发 + 验证 + key rotation
+- **认证**：JWT 签发 + 验证 + key rotation；生产 `PrincipalDevice` / super-admin 主体签发（#1811）
+- **设备身份与证书底座**（#1895/ADR-1895）：`runtime/certsigning`（Signer/Authorizer/RevocationStore 接口 + sealed CertRequest/IssuedCert，私钥不出 adapter）+ `runtime/certlifecycle`（复用 kernel/reconcile 的签发/续期/吊销状态机）+ `adapters/softca`（内置软 CA，开箱可用）+ 框架级 EST(RFC 7030) 注册前端。对标 SPIFFE/cert-manager/step-ca。
 - **持久化**：Postgres + advisory lock migration（goose），Redis cache，S3 blob
 - **强结构化守护**：archtest LAYER（11 条规则）+ boundary.yaml fingerprint diff gate
 

--- a/docs/plans/product-roadmap/202604300900-gocell-as-platform-foundation.md
+++ b/docs/plans/product-roadmap/202604300900-gocell-as-platform-foundation.md
@@ -3,6 +3,12 @@
 > 日期：2026-04-30
 > 状态：产品视角探索文档（与 `../engineering-baseline/` 框架视角解耦）
 > 受众：(a) 评估 GoCell 是否适合做 MDM / 零信任平台底座的产品决策者；(b) 想理解 GoCell 库形态能拼出什么应用的工程师；(c) 评估 Tier C 解耦边界的 framework 维护者
+> **修订（#1895 / ADR-1895，2026-06-12）**：设备证书 / PKI 底座**提升为框架能力**并提前落地
+> （`runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` + EST 前端 + 4 中立设备契约 +
+> 生产 device 主体签发器）。§3 `pkicell`（M6）/ §4 `mtlscert` / `pkicell` 均改为**消费**框架底座，
+> 不自建 CA/CSR/CRL/签发/续期原语；推翻 #995「PKI 不在框架」。详见
+> `docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md`。
+>
 > 关联：
 > - `../engineering-baseline/202604300600-radical-lightweight-revision.md`（核心 10 落点 E1-E10）
 > - `../engineering-baseline/202604300700-extension-leverages.md`（Tier B 25 个独立包清单）
@@ -188,7 +194,7 @@ E14 完成后 GoCell 暴露 25 个独立可用包，按典型场景拼装可覆�
 | M3 基础状态采集 | adapters/postgres | mdmcell.device + agentcell.device（基础硬件，**遥测时序延后**） |
 | M4 远程控制 | kernel/idempotency + outbox | mdmcell.command（状态机）+ auditcore.approvalflow（24h 审批） |
 | M5 应用分发 | adapters/s3（**已有，复用**） | appcatalog（catalog/signing/scriptlib/s3dispatch） |
-| M6 证书管理 | runtime/crypto | pkicell（wstep/scep/caworkflow/rotation） |
+| M6 证书管理 | **框架底座** `runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` + EST 前端（#1895/ADR-1895，下移 core） | pkicell（wstep/scep/caworkflow——**消费**框架底座，仅留 Windows 协议前端） |
 | M7 合规审计 | auditcore | + approvalflow slice |
 | M8 RBAC | accesscore | rbaccell（rolemgmt/permcheck/datascope）+ accesscore.{jwtlifecycle, ssooidc} |
 | 设备生命周期 | — | devicelifecycle（基于 unified_device_id 的 5 状态机） |

--- a/docs/plans/product-roadmap/202604300900-gocell-as-platform-foundation.md
+++ b/docs/plans/product-roadmap/202604300900-gocell-as-platform-foundation.md
@@ -299,7 +299,7 @@ E14 完成后 GoCell 暴露 25 个独立可用包，按典型场景拼装可覆�
 | Z1 IAP | accesscore（JWT/session）+ deviceidentity（设备身份） | iapgateway cell（请求拦截 + 三因素验证：身份/设备/上下文）|
 | Z2 Continuous verify | accesscore + outbox | sessionpolicy cell（按策略触发重验证）+ trustscore cell（连续评估） |
 | Z3 Least privilege + JIT | accesscore + L1 LocalTx + rbaccell（winmdm 阶段已建） | jitgrant cell（短期凭证签发 + workflow 审批）+ policycell（已在 winmdm 阶段建） |
-| Z4 Microsegmentation | runtime/auth + pkicell（winmdm 阶段已建） | service-mesh adapter（Istio / Linkerd）+ mtlscert cell（与 pkicell 集成） |
+| Z4 Microsegmentation | runtime/auth + **框架证书底座**（`runtime/certsigning`+`adapters/softca`，#1895/ADR-1895；不再依赖 winmdm pkicell 自建 PKI） | service-mesh adapter（Istio / Linkerd）+ mtlscert cell（**消费**框架 `certsigning.Signer` 签发 mTLS 证书） |
 | Z5 Device trust | mdmcell + agentcell + devicelifecycle（winmdm 阶段已建） | trustscore cell（聚合设备合规度 + 用户行为评分）|
 | Z6 Behavioral analytics | adapters/postgres + metrics + outbox | eventcorrelation cell（流式聚合）+ ML adapter（外部推理服务） |
 
@@ -309,7 +309,7 @@ E14 完成后 GoCell 暴露 25 个独立可用包，按典型场景拼装可覆�
 2. **sessionpolicy**（L1 LocalTx）—— 会话策略评估
 3. **trustscore**（L3 WorkflowEventual）—— 设备 + 用户连续信任度评估
 4. **jitgrant**（L1 LocalTx）—— JIT 短期凭证签发
-5. **mtlscert**（L2 OutboxFact）—— 服务间 mTLS 证书
+5. **mtlscert**（L2 OutboxFact）—— 服务间 mTLS 证书（**消费**框架 `runtime/certsigning`，不自建 CA；#1895/ADR-1895）
 6. **eventcorrelation**（L3 WorkflowEventual）—— 行为事件流式聚合
 7. **anomalydetection**（L3 WorkflowEventual）—— 异常识别（接入外部 ML）
 8. **compliancereporting**（L1 LocalTx）—— 合规报告 + 仪表盘

--- a/docs/plans/product-roadmap/202604300900-gocell-as-platform-foundation.md
+++ b/docs/plans/product-roadmap/202604300900-gocell-as-platform-foundation.md
@@ -181,7 +181,7 @@ E14 完成后 GoCell 暴露 25 个独立可用包，按典型场景拼装可覆�
 | M3 | 状态采集 | DevDetail CSP + Agent 基础硬件 | **遥测 / SMART / 时序聚合（延后）** |
 | M4 | 远程控制 | Wipe / Lock / Reboot + 状态机 + 24h 审批 | **WebSocket 实时 / 远程桌面 / 远程 CLI（延后）** |
 | M5 | 应用分发 | MSI/MSIX/EXE/ZIP/PowerShell + S3 直连 + 断点续传 + 包签名 | **P2P 分发（延后，> 1W 设备规模启动）** |
-| M6 | 证书管理 | 内部 CA + WSTEP / SCEP + 证书轮换 + 4 类证书生命周期 | HSM / KeyVault 集成 |
+| M6 | 证书管理 | 框架证书底座（`runtime/certsigning`+`certlifecycle`+`adapters/softca`+EST，#1895）+ winmdm WSTEP/SCEP 前端 + 4 类证书生命周期 | HSM / KeyVault adapter |
 | M7 | 合规审计 | 完整 actor/target/before/after + 高危操作审批链 | tamper-evident 存储 / SIEM 集成 |
 | M8 | RBAC | 5 角色 + 数据范围 + 自建用户 + SSO（OIDC）| Azure AD（Phase 2 可选 IdP） |
 
@@ -209,7 +209,7 @@ E14 完成后 GoCell 暴露 25 个独立可用包，按典型场景拼装可覆�
 | 1 | `accesscore` | 已有扩展 | L1 | + jwtlifecycle / ssooidc |
 | 2 | `auditcore` | 已有扩展 | L2 | + approvalflow |
 | 3 | `rbaccell` | 新建 | L1 | rolemgmt / permcheck / datascope |
-| 4 | `pkicell` | 新建 | L1 | wstep / scep / caworkflow / rotation |
+| 4 | `pkicell` | 新建 | L1 | wstep / scep / caworkflow（消费框架 certsigning/certlifecycle，rotation 退役；#1895） |
 | 5 | `deviceidentity` | 新建 | L1 | resolve / bind / lookup（**替代旧 Reconciliation Worker**）|
 | 6 | `mdmcell` | 新建 | L1+L2+L4 | enroll / device / command |
 | 7 | `agentcell` | 新建 | L1+L2+L4 | enroll / device / checkin / taskdispatch |
@@ -267,14 +267,14 @@ E14 完成后 GoCell 暴露 25 个独立可用包，按典型场景拼装可覆�
 
 | 阶段 | 时长 | 内容 |
 |---|---|---|
-| **Phase 0**：GoCell v1.0 + P0 5 项 | 6 个月（2026 Q2-Q4） | E1-E10 + E14 + 方案 D 切换 + Windows MDM 协议 + WSTEP + JWT 完整 + 熔断 |
-| **Stage 1**：基础设施（accesscore/auditcore/rbaccell/pkicell/deviceidentity） | 2 个月（2027 Q1） | wmcore 跑通 + RBAC 5 角色 + 审批流 + 内部 CA 链路 |
+| **Phase 0**：GoCell v1.0 + P0 5 项 | 6 个月（2026 Q2-Q4） | E1-E10 + E14 + 方案 D 切换 + Windows MDM 协议 + 框架证书底座（#1895） + JWT 完整 + 熔断 |
+| **Stage 1**：基础设施（accesscore/auditcore/rbaccell/pkicell/deviceidentity） | 2 个月（2027 Q1） | wmcore 跑通 + RBAC 5 角色 + 审批流 + WSTEP/SCEP 链路（消费框架 certsigning，不自建 CA；#1895） |
 | **Stage 2**：MDM 通道（mdmcell + windows adapter） | 3 个月（2027 Q2-Q3） | WSTEP 注册 + DevDetail 采集 + Wipe/Lock/Reboot 命令下发 |
 | **Stage 3**：Agent 通道（agentcell） | 3 个月（2027 Q3-Q4） | MSI 签名校验 + 基础采集 + 15min checkin + 任务派发 |
 | **Stage 4**：上层应用（groupengine + policycell + appcatalog + devicelifecycle）| 3 个月（2027 Q4-2028 Q1） | 分组 + 策略路由 + 软件分发（S3）+ 设备墓碑 |
 | **总计** | **17 个月**（含 Phase 0）/ **11 个月**（仅 winmdm Stage 1-4） | winmdm v1 GA 2028 Q1 |
 
-> **P0 阻塞项**（GoCell v1.0 前置）：方案 D 多 module 切换 / `adapters/mdmprotocol/windows` / pkicell WSTEP 支持 / `accesscore.jwtlifecycle` / `runtime/circuitbreaker` / RBAC 提前到 Stage 1。
+> **P0 阻塞项**（GoCell v1.0 前置）：方案 D 多 module 切换 / `adapters/mdmprotocol/windows` / **框架证书底座（`runtime/certsigning`+`adapters/softca`+EST，#1895；非 winmdm WSTEP 前端）** / `accesscore.jwtlifecycle` / `runtime/circuitbreaker` / RBAC 提前到 Stage 1。winmdm WSTEP/SCEP 协议前端归 2027 Stage 2，不入 core v1.0 P0。
 > **P2 优化项**（明确延后）：WNS / WebRTC / P2P / TimescaleDB / WebSocket / BitLocker 密钥托管 / 补丁管理 / OOBE。
 
 ---
@@ -398,8 +398,8 @@ Phase 0 GoCell v1.0     winmdm Stage 1-4                    winmdm v1 GA + Phase
 
 | 里程碑 | 标志 | 估时 |
 |---|---|---|
-| **M0 GoCell v1.0** | E1-E10 + E14 全部完成；25 包 SemVer 锁定；方案 D 多 module 切换 + Windows MDM 协议 + WSTEP + JWT 完整 + 熔断 5 项 P0 就绪 | 2026 Q4 |
-| **M1 winmdm Stage 1** | wmcore assembly 跑通：accesscore + auditcore + rbaccell + pkicell + deviceidentity；RBAC 5 角色 + 24h 审批流；CA + WSTEP/SCEP 链路 | 2027 Q1 末 |
+| **M0 GoCell v1.0** | E1-E10 + E14 全部完成；25 包 SemVer 锁定；方案 D 多 module 切换 + Windows MDM 协议 + 框架证书底座（#1895） + JWT 完整 + 熔断 5 项 P0 就绪 | 2026 Q4 |
+| **M1 winmdm Stage 1** | wmcore assembly 跑通：accesscore + auditcore + rbaccell + pkicell + deviceidentity；RBAC 5 角色 + 24h 审批流；WSTEP/SCEP 链路（消费框架 certsigning，不自建 CA；#1895） | 2027 Q1 末 |
 | **M2 winmdm Stage 2** | wmmdm assembly：mdmcell（enroll + device + command）；100 台 Win10/11 真机注册 + Wipe/Lock/Reboot 通过 | 2027 Q3 中 |
 | **M3 winmdm Stage 3** | wmagent assembly：agentcell（enroll + device + checkin + taskdispatch）；MSI 签名校验 + 短轮询 + 任务派发 | 2027 Q4 中 |
 | **M4 winmdm v1 GA** | 11 cell + 6 assembly + 1 winmdmall；策略 + 分组 + 软件分发（S3）+ 设备墓碑；5W 设备压测 | 2028 Q1 |
@@ -411,7 +411,7 @@ Phase 0 GoCell v1.0     winmdm Stage 1-4                    winmdm v1 GA + Phase
 
 | 风险 | 严重度 | 缓解 |
 |---|---|---|
-| **GoCell v1.0 延期** | 高 | E1-E10 是 12-16 周固定承诺；P0 5 项（方案 D / Windows 协议 / WSTEP / JWT / 熔断）必须就绪 |
+| **GoCell v1.0 延期** | 高 | E1-E10 是 12-16 周固定承诺；P0 5 项（方案 D / Windows 协议 / 框架证书底座 #1895 / JWT / 熔断）必须就绪 |
 | **WSTEP 证书链复杂度** | 高 | 旧 winmdm Spike-03 单独立项；2026 Q4 v1.0 前置必跑通；先做 Windows 协议（Apple/Android 取消）|
 | **wmcore 单点故障** | 中-高 | 3 副本 HA + JWKS 客户端缓存 + 异步审计 outbox + 熔断器（runtime/circuitbreaker P0 必备）|
 | **零信任合规审计要求** | 中-高 | FedRAMP / SOC2 等审计要求会拖 6-12 个月；从 winmdm Stage 1 起就走 archtest + auditcore.approvalflow 完整路径，不要后期补 |
@@ -432,7 +432,7 @@ Phase 0 GoCell v1.0     winmdm Stage 1-4                    winmdm v1 GA + Phase
 
 ### 5.5 推荐策略
 
-**短期（2026 Q2-Q4）**：GoCell v1.0 + P0 5 项（方案 D / Windows 协议 / WSTEP / JWT / 熔断）；examples/ 加 winmdmsmoke 作为多 assembly 示例。
+**短期（2026 Q2-Q4）**：GoCell v1.0 + P0 5 项（方案 D / Windows 协议 / 框架证书底座 #1895 / JWT / 熔断）；examples/ 加 winmdmsmoke 作为多 assembly 示例。
 
 **中期（2027 Q1-2028 Q1）**：winmdm Stage 1-4 串行落地，11 cell + 6 assembly + 1 winmdmall；M4 GA 时 5W 设备压测通过。
 

--- a/docs/plans/product-roadmap/202604300950-plan-d-go-workspace-multimodule-migration.md
+++ b/docs/plans/product-roadmap/202604300950-plan-d-go-workspace-multimodule-migration.md
@@ -722,6 +722,8 @@ jobs:
 **禁止动作**：不要预先创建 mdm/ 或 zerotrust/ 空目录；不要预先建 go.work；不要预先做 module 拆分。
 
 > **注（#1554, 2026-06）**：`use .` workspace 地基已由 #1554 前置落地（committed `go.work` + `.gocell/manifest.yaml` + CI 遍历扩展点），与本节不矛盾——本节「不要预先建 go.work」针对的是**真正的 mdm/ 多 module 拆分 + 外部 module 版本选择**，那部分仍按 A1.1 在 Phase 1 落地。`use .` 单 module 形态对依赖解析行为与无 go.work 完全等价，仅为 Phase 1 预设扩展点。
+>
+> **注（#1895 / ADR-1895, 2026-06-12）**：**设备身份与证书框架底座**（`runtime/certsigning` + `runtime/certlifecycle` + `adapters/softca` + `runtime/http/est` + 4 中立设备契约 + 生产 device 主体签发器）在 v1.0 前提前落地，**全部落 core 顶层**（runtime / adapters / contracts），**不**建 `mdm/` / `zerotrust/`——与本节「禁止预建 mdm/」**一致**（core 是业务无关 framework，证书底座是通用原语）。§9 表「业务领域 kernel `mdm/kernel/pki.PKIIssuer` 不应在 core 出现」据此修订：**通用证书签发接口 `runtime/certsigning.Signer` 属 core framework**；`mdm/kernel/pki` 仅在 winmdm 触发后承载 Windows 协议特定扩展（WSTEP/SCEP 解码），不重造签发原语。详见 ADR-1895。
 
 ### 阶段 1：MDM 启动（2027 Q1）
 

--- a/docs/plans/product-roadmap/202604300950-plan-d-go-workspace-multimodule-migration.md
+++ b/docs/plans/product-roadmap/202604300950-plan-d-go-workspace-multimodule-migration.md
@@ -86,7 +86,7 @@ github.com/ghbvf/gocell/                      单仓库（全开源 Apache 2.0�
 │   │                                                     timeseries/timescaledb
 │   ├── cells/                                  **依赖 mdm/kernel 接口，不直接 import adapters**
 │   │   ├── rbaccell/                           （L1）角色权限管理
-│   │   ├── pkicell/                            （L1）内部 CA + WSTEP/SCEP + 证书轮换
+│   │   ├── pkicell/                            （L1）WSTEP/SCEP 前端（消费 core certsigning/certlifecycle，不自建 CA/轮换；#1895）
 │   │   ├── deviceidentity/                     （L1）SMBIOS 哈希 → unified_device_id（替代旧 Reconciliation Worker）
 │   │   ├── mdmcell/                            （L1+L2+L4）enroll / device / command 三 slice
 │   │   ├── agentcell/                          （L1+L2+L4）enroll / device / checkin / taskdispatch 四 slice
@@ -205,7 +205,7 @@ mdm / zerotrust **复用 core 分层模式**（kernel + runtime + adapters + cel
 |---|---|---|---|
 | **framework kernel**（不可复制）| 仅在 core | `cell.Cell` interface / metadata parser / assembly / outbox 接口 / idempotency 等 GoCell 框架契约 | mdm/zerotrust 直接 import core，**禁止复制** |
 | **framework runtime**（不可复制）| 仅在 core | `bootstrap` 10-phase / `eventrouter` / `auth` / `http/router` 等 framework 运行时 | 同上 |
-| **业务 kernel**（每个应用 module 自有）| `mdm/kernel/` / `zerotrust/kernel/` | mdm 业务领域抽象接口（如 `mdm/kernel/protocol.MDMProtocolHandler` / `mdm/kernel/pki.PKIIssuer`）| **必须有**，否则 cells 会直接 import adapters 违反 CLAUDE.md |
+| **业务 kernel**（每个应用 module 自有）| `mdm/kernel/` / `zerotrust/kernel/` | mdm 业务领域抽象接口（如 `mdm/kernel/protocol.MDMProtocolHandler`；**通用证书签发 `Signer` 已属 core `runtime/certsigning`，#1895——`mdm/kernel/pki` 仅承载 winmdm 协议特定扩展，不重造签发原语**）| **必须有**，否则 cells 会直接 import adapters 违反 CLAUDE.md |
 | **业务 runtime**（可选）| `mdm/runtime/` | mdm 特有运行时编排（如 mdm 协议 dispatcher）| 按需 |
 
 **依赖方向**（每个 module 内部，与 core 一致）：
@@ -775,7 +775,7 @@ jobs:
 **Stage 1 - 基础设施（2027 Q1）**：
 - PR A1.2：rbaccell（rolemgmt / permcheck / datascope）+ wmcore assembly 骨架
 - PR A1.3：accesscore.{jwtlifecycle, ssooidc} 扩 slice（在 core 内，不在 mdm）+ auditcore.approvalflow 扩 slice
-- PR A1.4：pkicell（wstep / scep / caworkflow / rotation）+ adapters/mdmprotocol/windows 骨架
+- PR A1.4：pkicell（wstep / scep / caworkflow——消费 core certsigning/certlifecycle，rotation 退役 #1895）+ adapters/mdmprotocol/windows 骨架
 - PR A1.5：deviceidentity（resolve / bind / lookup）+ unified_devices 表
 
 **Stage 2 - MDM 通道（2027 Q2-Q3）**：

--- a/docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md
+++ b/docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md
@@ -77,7 +77,7 @@
 | 1 | `accesscore` | 已有扩展 | L1 LocalTx | ✅ GoCell 内置 | + `jwtlifecycle` + `ssooidc` | `users`, `sessions`, `idp_config` |
 | 2 | `auditcore` | 已有扩展 | L2 OutboxFact | ✅ GoCell 内置 | + `approvalflow` | `audit_logs`, `approval_chain` |
 | 3 | `rbaccell` | 新建 | L1 LocalTx | — | `rolemgmt` / `permcheck` / `datascope` | `roles`, `permissions`, `user_roles`, `data_scopes` |
-| 4 | `pkicell` | 新建 | L1 LocalTx | — | `wstep` / `scep` / `caworkflow` / `rotation` | `ca_certs`, `device_certs`, `cert_issued` |
+| 4 | `pkicell` | 新建 | L1 LocalTx | — | `wstep` / `scep` / `caworkflow`（**消费**框架 `runtime/certsigning`+`certlifecycle`，不自建 CA/CSR/CRL/签发/续期——`rotation` 退役，#1895/ADR-1895） | `device_certs`, `cert_issued`（CA 私钥归 `adapters/softca`，不在本 cell） |
 | 5 | `deviceidentity` | 新建 | L1 LocalTx | — | `resolve` / `bind` / `lookup` | `unified_devices(id, smbios_uuid, serial_number, mdm_device_id, agent_device_id)` |
 | 6 | `mdmcell` | 新建 | L1+L2+L4 | — | `enroll` / `device` / `command` | `mdm_devices`, `mdm_enrollments`, `syncml_sessions`, `mdm_commands` |
 | 7 | `agentcell` | 新建 | L1+L2+L4 | — | `enroll` / `device` / `checkin` / `taskdispatch` | `agent_devices`, `agent_checkins`, `agent_tasks` |
@@ -396,7 +396,7 @@ DoD：
 
 | 维度 | 方案 |
 |---|---|
-| MDM 通信 | TLS 1.2+ + mTLS 双向（pkicell 签发） |
+| MDM 通信 | TLS 1.2+ + mTLS 双向（经框架 `runtime/certsigning` 签发，pkicell 仅 WSTEP 前端；#1895） |
 | Agent 通信 | TLS 1.2+ + Agent JWT |
 | 字段加密 | BitLocker Recovery Key AES-256-GCM；用户 PII AES-256 字段级 |
 | JWT | RS256 + access 1h + refresh 7d/30d + 轮换 + 黑名单 + DPAPI |

--- a/docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md
+++ b/docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md
@@ -187,7 +187,7 @@ DoD：
 - SSO 对接 OIDC（Keycloak/Casdoor 互通测试）
 - RBAC 5 角色（Super Admin / MDM Admin / 安全管理员 / Help Desk / Auditor）
 - 审批流（24h 超时 + 紧急越权 + 审计告警）
-- 内部 CA + WSTEP/SCEP 证书签发链路（Spike-03 出清）
+- WSTEP/SCEP 证书签发链路（消费框架 `runtime/certsigning`+`certlifecycle`，不自建 CA；Spike-03 出清；#1895）
 - `wmcore` assembly 可独立启动 + 健康检查
 
 ### Stage 2：MDM 通道（2027 Q2-Q3，~3 个月）
@@ -432,7 +432,7 @@ GoCell v1.0 + P0 5 项     Stage 1 基础设施           Stage 2 MDM    Stage 3
 
 | 里程碑 | 标志 | 时间 |
 |---|---|---|
-| **M0**：GoCell v1.0 + P0 就绪 | core/方案D + Windows MDM 协议 + WSTEP + JWT 完整 + 熔断 | 2026 Q4 |
+| **M0**：GoCell v1.0 + P0 就绪 | core/方案D + Windows MDM 协议 + 框架证书底座（#1895） + JWT 完整 + 熔断 | 2026 Q4 |
 | **M1**：winmdm Stage 1 完成 | wmcore 单 assembly 跑通 + RBAC + 审批流 | 2027 Q1 末 |
 | **M2**：winmdm Stage 2 完成 | wmmdm assembly + 设备注册 + 远程命令 | 2027 Q3 中 |
 | **M3**：winmdm Stage 3 完成 | wmagent assembly + 心跳 + 任务派发 | 2027 Q4 中 |

--- a/docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md
+++ b/docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md
@@ -8,6 +8,14 @@
 > - `202604300930-repository-structure-decision.md`（已选方案 D 全开源 MIT）
 > - 旧版本：`/Users/shengming/Documents/winmdm/winmdm-mvp-v3/docs/products/prd-v6.md` v6.0（已废弃）
 
+> **修订（#1895 / ADR-1895，2026-06-12）**：设备证书的**框架级 PKI 原语下移 core**
+> （`runtime/certsigning` 接口 + `runtime/certlifecycle` reconciler + `adapters/softca` +
+> 框架级 EST 前端）。`pkicell`（§2.1 / §10）的 `wstep`/`scep`/`caworkflow` 仍是 winmdm
+> 消费方 Cell（落 `mdm` module，2027 Q1），但**不再自建 CA/CSR/CRL/签发/续期原语**——
+> 改为消费框架 `certsigning.Signer` + `certlifecycle`，只保留 Windows 专属协议前端
+> （XCEP/WSTEP/SCEP/MS-MDE 解码）+ caworkflow（审批集成）。详见
+> `docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md`。
+
 ---
 
 ## §0 与 v6.0 的差异（核心说明）

--- a/docs/plans/specs/1895-device-identity-cert-framework/plan.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: 设备身份与证书框架化 + MDM/ZT 前期地基
+
+**Branch**: `1895-device-identity-cert-framework` | **Date**: 2026-06-12 | **Spec**: [spec.md](./spec.md) | **Epic**: #1895
+
+## Summary
+
+把设备证书从 iotdevice 示例提升为框架能力：在 `runtime/` 加证书签发底座（`Signer`/`Authorizer`/`RevocationStore` 接口 + sealed 请求模型 + `certlifecycle` reconciler），在 `adapters/softca` 加内置软 CA，在 `runtime/http` 加 EST 前端；同步落地 MDM/ZT 前期地基（4 个中立设备契约 + 生产设备主体签发器 #1811）；并以一份 ADR 收口 #995 + 修订已锁定路线图。技术路线对标 SPIFFE/SPIRE + cert-manager + step-ca：控制面属框架、签名私钥在 adapter、协议前端在边缘、`Authorize` 与 `Sign` 分离。**最大复用既有 `kernel/reconcile` + `runtime/command` + PDP，不新造控制环。**
+
+## Technical Context
+
+**Language/Version**: Go 1.24（go.work 多 module：core 顶层 + per-adapter module）
+**Primary Dependencies**: 标准库 `crypto/x509`·`crypto/ecdsa`·`encoding/pem`·`crypto/tls`；既有 `kernel/reconcile`·`runtime/command`·`runtime/auth`·`pkg/tenant`·`pkg/errcode`·`kernel/clock`。**不引入**外部 PKI 库（softca 用标准库；step-ca/Vault 留后续 adapter）。
+**Storage**: PostgreSQL（device_certs / ca_certs / cert_revocations 表 + RLS）；softca CA key 经 adapter 托管（dev：内存/文件；后续：KMS/HSM adapter）。
+**Testing**: table-driven 单测（kernel/runtime ≥90% / 其余 ≥80%）；契约级测试；testcontainers 集成（softca 签发 + EST 往返 + certlifecycle reconcile）；archtest 反向自检。
+**Target Platform**: Linux server（core module）。
+**Project Type**: 框架底座（library）+ 平台契约 + 示例迁移。
+**Performance Goals**: 单次 softca 签发 p95 < 10ms（无网络）；certlifecycle resync sweep 有界（按 cutoff 范围扫描，不全表）。
+**Constraints**: 私钥永不出 adapter；`Sign` 唯一签发入口；reconcile 多租户须自带 tenant 维度（system identity 清空 tenant）；EST 鉴权 fail-closed。
+**Scale/Scope**: ~11 PR / ~14,100 行；新增 2 个 runtime 包 + 1 个 adapter module + 4 个契约 + 1 个 auth 签发器 + iotdevice 迁移 + 2 ADR。
+
+## Constitution Check
+
+*GATE：Phase 0 前必过；Phase 1 设计后复检。*
+
+| 宪法约束 | 本 epic 落点 | 通过 |
+|---|---|---|
+| 分层依赖（kernel 不依赖 runtime/adapters） | 证书底座放 `runtime/`（需 crypto/x509 + reconcile/command 上层 wiring），**不**入 kernel；softca 入 adapters 实现 runtime 接口 | ✅ |
+| Cell 只经 contract 通信 | 4 中立契约定义跨边界 wire；证书事实经 outbox L2 事件 | ✅ |
+| 一致性等级 | certlifecycle = L4（设备长延迟闭环，同 devicecertrenewal）；cert-issued 事件 = L2；EST enroll = L2（本地 tx + outbox） | ✅ |
+| 错误用 errcode；无导出 `Err* =` | 新 cert 错误走 errcode；新增 `ERR_CERT_` 前缀须注册 + golden（ERRCODE-PREFIX-OWNERSHIP-01） | ✅ |
+| 认知复杂度 ≤15 / 覆盖率 | 每 PR TDD；reconciler 状态机切小函数 | ✅ |
+| AI-robust 新机制 ≥ Medium | cert sealed 构造 + 单一 Sign funnel（Hard）；lifecycle fencing（Hard，复用既有）；EST 鉴权边界 / Authorizer-Signer 分离（Medium archtest）；**无 Soft** | ✅ |
+| 引入约束同 PR 闭环 | 每 PR 自带守卫 + 反向自检 + godoc/ADR（不甩 backlog） | ✅ |
+| id no-dash | `softca`/`certsigning`/`certlifecycle`/`deviceidentity` 全 concat | ✅ |
+| 契约扇出闭环 | PR-3/4/9 出 implementation matrix（contract/generated/cell-slice/tests/docs） | ✅ |
+
+**无违规需 Complexity Tracking。**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+docs/plans/specs/1895-device-identity-cert-framework/
+├── plan.md          # 本文件
+├── research.md      # 探索结论（OSS 对标 + 现状 + issue 收口）
+├── spec.md          # 功能规格（US1-US6 / FR / SC）
+└── tasks.md         # PR 分解 + 依赖波次
+```
+
+### Source Code (repository root)
+
+```text
+runtime/
+├── certsigning/                 # PR-5：接口 + sealed 类型 + funnel
+│   ├── signer.go                #   Signer / TrustBundle
+│   ├── authorizer.go            #   Authorizer / EnrollmentClaim / SignConstraints（独立于 Signer）
+│   ├── request.go               #   CertRequest / IssuedCert sealed（unexported + 唯一构造器）
+│   ├── revocation.go            #   RevocationStore
+│   └── doc.go                   #   §Enforced invariants（CERT-SIGN-FUNNEL / CERT-VALUE-SEALED）
+├── certlifecycle/               # PR-7：生命周期 reconciler（复用 kernel/reconcile）
+│   ├── reconciler.go            #   reconcile.Reconciler 实现；状态机；jitter 续期
+│   ├── repository.go            #   DeviceCertRepository 接口（scan near-expiry / persist）
+│   └── doc.go
+└── http/est/                    # PR-8：EST(RFC 7030) 前端
+    ├── handler.go               #   /cacerts /simpleenroll /simplereenroll
+    └── doc.go
+
+adapters/softca/                 # PR-6：内置软 CA（per-adapter go module）
+├── go.mod
+├── signer.go                    #   实现 certsigning.Signer（crypto.Signer 托管，私钥不出）
+├── revocation.go                #   实现 RevocationStore（CRL）
+└── ca.go                        #   CA 层级 + key 托管接口（dev mem/file；KMS 留后续）
+
+runtime/auth/                    # PR-2：设备主体签发器（#1811）
+├── deviceprincipal.go           #   生产 PrincipalDevice / super-admin 铸造
+└── (扩 principal.go / rowscope.go wiring)
+
+contracts/                       # PR-3/4：4 中立设备契约
+├── http/deviceidentity/{enroll,renew,revoke,status}/v1/
+├── event/deviceidentity/{cert-issued,cert-revoked}/v1/
+├── command/deviceidentity/rotate/v1/      # PR-9：rotate-cert 真契约
+├── {devicestate,devicecompliance}/v1/
+└── command/remotecommand/v1/
+
+examples/iotdevice/              # PR-9：迁移到框架证书底座
+└── cells/devicecell/...         #   deviceregister 经 Signer；certlifecycle 替代字符串命令；#654 RBAC
+
+cellmodules/ + bootstrap         # PR-10：composition wiring + WithCertSigner/WithCertLifecycle + readyz
+docs/architecture/               # PR-1 路线图修订 ADR；PR-11 跨层 ADR
+```
+
+**Structure Decision**：证书底座入 **`runtime/`** 而非 kernel（需 `crypto/x509` + 在 reconcile/command 之上 wiring，kernel 只依赖 stdlib+pkg），对标 `kernel/reconcile` 定义接口、`adapters/{redis,postgres}` 实现 `LeaderElector` 的既有范式——本 epic：`runtime/certsigning` 定义 `Signer`、`adapters/softca` 实现。证书生命周期**复用** `kernel/reconcile.Loop`，不在 kernel 加 cert 概念。中立契约入 `contracts/`（平台跨 Cell 边界）。设备主体签发器入 `runtime/auth`（authn 边界）。**不**新建 corecell（证书底座是 primitive 不是平台 Cell；winmdm 的 `pkicell` 仍是未来 mdm module 的消费方 Cell，本 epic 只下移其依赖的框架原语）。
+
+## Complexity Tracking
+
+> 无宪法违规需 justify。唯一需记录的张力：**路线图修订**——本 epic 推翻 #995「PKI 不在框架」+ winmdm PRD pkicell 落点（mdm module）+ #1051/#1052 门控日期。处置：PR-1 出 ADR 显式修订 4 份路线图文档 + 重评威胁矩阵；不静默改、不留冲突段落（遵循 AI-robust §审查「ADR amendment 同步重评」+ memory「先沟通再落文档」——范围已与用户对齐）。

--- a/docs/plans/specs/1895-device-identity-cert-framework/plan.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/plan.md
@@ -16,7 +16,7 @@
 **Project Type**: 框架底座（library）+ 平台契约 + 示例迁移。
 **Performance Goals**: 单次 softca 签发 p95 < 10ms（无网络）；certlifecycle resync sweep 有界（按 cutoff 范围扫描，不全表）。
 **Constraints**: 私钥永不出 adapter；`Sign` 唯一签发入口；reconcile 多租户须自带 tenant 维度（system identity 清空 tenant）；EST 鉴权 fail-closed。
-**Scale/Scope**: ~11 PR / ~14,100 行；新增 2 个 runtime 包 + 1 个 adapter module + 4 个契约 + 1 个 auth 签发器 + iotdevice 迁移 + 2 ADR。
+**Scale/Scope**: ~11 PR / ~15,100 行；新增 3 个 runtime 包（certsigning/certlifecycle/http·est）+ 1 个 adapter module（softca）+ 4 个契约 + 1 个 auth 签发器 + iotdevice 迁移 + 2 ADR。
 
 ## Constitution Check
 

--- a/docs/plans/specs/1895-device-identity-cert-framework/research.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/research.md
@@ -1,0 +1,79 @@
+# Research: 设备身份与证书框架化（探索结论）
+
+**Date**: 2026-06-12 · **Epic**: #1895 · 来源：ship 探索阶段（2 个 explorer agent：OSS 对标 + 现状/issue 收口）。
+
+## 0. 决策摘要（已与用户对齐）
+
+| 维度 | 决策 |
+|---|---|
+| 证书深度 | 底座 + 内置软 CA + EST 前端 |
+| 前期范围 | 4 中立契约 + 设备身份签发器（#1811） |
+| epic 结构 | 1 合并 epic + 路线图 ADR；每 PR ≤2000 行 |
+
+## 1. 现状真相（current-state）
+
+- **零 PKI 代码**：repo 中无 CA / CSR / CRL / 签名 / 私钥生成。所有 `crypto/x509` 命中 = TLS 传输层消费已编码 PEM（`runtime/http/tlsutil/server.go`）或 `_test.go` 自签链（grpc/mqtt/mtls）。
+- **今天的「证书」** = devices 行 `cert_epoch`(int64, ≥1) + `cert_expires_at`(timestamp) 两列（migration 056/057/062）。`deviceregister/service.go` 注册时 stamp `now+90d`（仅时间戳，无证书材料）。
+- **续期** = `examples/iotdevice/.../devicecertrenewal` stateless reconciler，扫 `cert_expires_at<=now+Threshold` 发 `CommandType="rotate-cert"` 字符串（载于 `command.devicecommand.enqueue.v1`，payload `{epoch,notAfter}`）。正确性（至多一活跃 rotate）由**队列 active-uniqueness**owned（#1820），非 producer state。
+- **可复用框架原语（成熟）**：
+  - `kernel/reconcile`：`Reconciler{Reconcile(ctx,Request)(Result,error)}`（冻结）、Builder 唯一构造、TickerTrigger resync-all、leader-elect + `LeaseToken.Epoch` fencing + `FencedWriter`、system identity 清空 tenant（#1821）。
+  - `runtime/command`：`EmitAsync[T]`（位置参 subject+commandID）、`WithActiveUniqueness(deadline)`、Claimer dedup key（tenant 来自 entry principal envelope）。
+  - `runtime/auth`：service-token HMAC，`X-Tenant-ID` 折入签名材料（#1717）；mTLS 传输层（`tlsutil` + `middleware/mtls` + `ctxkeys.PeerIdentity` 冻结）。
+  - `pkg/tenant`：`RowVisibility` sealed，`PrincipalDevice→RowScope=device`（`runtime/auth/rowscope.go`）。
+- **关键缺口**：develop **无生产 authn 铸造 `PrincipalDevice`/super-admin**（rowscope.go:19-22 明示「type-foundation entries, no production issuer」）= **#1811，证书底座硬前置**。
+
+## 2. OSS 对标（SPIFFE/SPIRE + cert-manager + step-ca 一致结论）
+
+8 个普适接缝，三家画同一条线：
+
+| 接缝 | 归属 | Go 形状 | CP/DP |
+|---|---|---|---|
+| Signer/Issuer（CSR→证书） | 框架定义接口，adapter 实现 | `Sign(ctx,CSR,opts)(Chain,error)` over `crypto.Signer` | DP（adapter CA） |
+| 请求/证书模型 | 框架 | 协议无关 CertRequest + IssuedCert | CP |
+| 生命周期状态机 | 框架 | requested→issued→active→nearExpiry→renewing→{revoked\|expired} | CP（reconcile） |
+| 续期 reconcile | 框架 | 周期扫 notAfter 入队续期（level-triggered，jitter 70-90% 寿命） | CP（= GoCell 既有 reconcile） |
+| 吊销/CRL/OCSP | adapter | `Revoke(serial,reason)` + `RevocationList` + `Tidy` | DP |
+| 注册协议 adapter | 消费方边缘 | EST/SCEP/ACME/XCEP 终结 wire → 内部 CertRequest | edge |
+| 证明/身份绑定 | 框架 | `Authorize(claim)(grant,error)`——**与 Sign 分离** | CP（GoCell 既有 PDP） |
+| 私钥托管 | adapter | `crypto.Signer`，**私钥永不跨边界** | DP |
+
+**三条承重洞见**：①签名≠授权（step-ca `AuthorizeSign` vs `Authority.Sign`；cert-manager `Check` vs `Sign`；SPIRE 证明 vs `ServerCA`）→ GoCell 必须 `Authorize`/`Sign` 两接口。②私钥永不跨框架边界（SPIRE `KeyManager.SignData`，key 留 plugin）= Go `crypto.Signer`。③请求对象协议无关（cert-manager `CertificateRequestObject` 抽象 CR + CSR）；EST/SCEP/ACME/XCEP 都归约为「PKCS#10 in / PKCS#7 out」（RFC 7030 §4）。
+
+**层放置**：每家都把「生命周期+请求模型+续期调度」放框架、「签名私钥」放 adapter、「wire 协议」放边缘。GoCell 已有其中 4 个接缝（reconcile/command/PDP/RowScope），缺的是 ①真实 Signer ②泛化的 lifecycle reconciler ③EST 前端 ④生产 device 主体。
+
+`ref:` spiffe/spire `pkg/server/ca/ca.go`·keymanager/upstreamauthority proto；cert-manager `pkg/apis/certmanager/v1/types_{issuer,certificaterequest}.go`·issuer-lib `controllers/signer`；smallstep/certificates `authority/{tls.go,provisioner/provisioner.go}`；hashicorp/vault `api-docs/secret/pki`；kubernetes `client-go/util/certificate/certificate_manager.go`（jitter 70-90%）；IETF RFC 7030（EST）；MS-XCEP/MS-WSTEP。
+
+## 3. 推荐接口签名（GoCell 风格）
+
+```go
+// runtime/certsigning — Authorize 与 Sign 分离；私钥在 adapter。
+type Signer interface {
+    Sign(ctx context.Context, req CertRequest) (IssuedCert, error)
+    TrustBundle(ctx context.Context) (roots [][]byte, err error)
+}
+type Authorizer interface { // 独立于 Signer，复用 PDP；nil grant=deny
+    AuthorizeEnroll(ctx context.Context, claim EnrollmentClaim) (SignConstraints, error)
+}
+type RevocationStore interface {
+    Revoke(ctx context.Context, serial string, reason RevocationReason) error
+    RevocationList(ctx context.Context) (crlDER []byte, err error)
+    Tidy(ctx context.Context, before time.Time) (purged int, err error)
+}
+// CertRequest/IssuedCert sealed（unexported + 唯一构造器；typed tenant+deviceID）
+```
+`certlifecycle.Reconciler` 实现冻结的 `reconcile.Reconciler`，`clock.Clock` 位置参 + `MustHaveClock`，复用 `kernel/reconcile.Loop` + `runtime/command`，不新造控制环。EST 前端在 `runtime/http/est` 终结 PKCS#10/PKCS#7，调用框架 `Signer`。
+
+## 4. issue 收口 / 路线图冲突
+
+- **收口** #995（X.509 框架化评估）：结论=进框架（推翻「不在框架 / 消费方自建」）。
+- **关闭** #1811（设备主体签发器，硬前置）、#654（DEVICE-ENQUEUE-RBAC）。
+- **部分提前** #1051（pkicell 框架底座下移 core；winmdm 仅留 WSTEP/SCEP 前端）、#1052（4 中立契约——路线图唯一允许提前项）。
+- **关联** #1870（cert terminal-feedback，PR-7 续期主路径）、#1890（mTLS/SPIFFE service identity，邻接独立，softca 后续可复用）、#822/#1845/#1695/#1591（设备主体硬化）。
+- **路线图冲突**（PR-1 ADR 修订）：#995「不在框架」立场、winmdm PRD pkicell 落点（mdm module）、plan-D §10「v1.0 前不建 mdm/」、#1051/#1052 门控日期、final-form 未列 PKI。**部分支持**：路线图自身把「pkicell WSTEP」列为 v1.0 P0（gocell-platform §3.7 line 271），与本提前一致。
+
+## 5. 治理要求
+
+- AI-robust：cert sealed 构造 + 单一 `Sign` funnel（Hard）；lifecycle fencing 复用 reconcile（Hard）；EST 鉴权边界 / Authorize-Sign 分离（Medium archtest）。**无 Soft**。
+- 每条约束**同 PR 闭环**（静态守卫 + 反向自检 + godoc/ADR）。
+- 契约扇出（PR-3/4/9）出 implementation matrix；破坏式 wire 走新版本目录。
+- id no-dash（softca/certsigning/certlifecycle/deviceidentity）；私钥不出 adapter（`CERT-PRIVATE-KEY-CUSTODY-01`）。

--- a/docs/plans/specs/1895-device-identity-cert-framework/research.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/research.md
@@ -32,7 +32,7 @@
 | 请求/证书模型 | 框架 | 协议无关 CertRequest + IssuedCert | CP |
 | 生命周期状态机 | 框架 | requested→issued→active→nearExpiry→renewing→{revoked\|expired} | CP（reconcile） |
 | 续期 reconcile | 框架 | 周期扫 notAfter 入队续期（level-triggered，jitter 70-90% 寿命） | CP（= GoCell 既有 reconcile） |
-| 吊销/CRL/OCSP | adapter | `Revoke(serial,reason)` + `RevocationList` + `Tidy` | DP |
+| 吊销/CRL/OCSP | adapter | `Revoke(scope,serial,reason)` + `RevocationList(scope)` + `Tidy` | DP |
 | 注册协议 adapter | 消费方边缘 | EST/SCEP/ACME/XCEP 终结 wire → 内部 CertRequest | edge |
 | 证明/身份绑定 | 框架 | `Authorize(claim)(grant,error)`——**与 Sign 分离** | CP（GoCell 既有 PDP） |
 | 私钥托管 | adapter | `crypto.Signer`，**私钥永不跨边界** | DP |
@@ -54,12 +54,12 @@ type Signer interface {
 type Authorizer interface { // 独立于 Signer，复用 PDP；nil grant=deny
     AuthorizeEnroll(ctx context.Context, claim EnrollmentClaim) (SignConstraints, error)
 }
-type RevocationStore interface {
-    Revoke(ctx context.Context, serial string, reason RevocationReason) error
-    RevocationList(ctx context.Context) (crlDER []byte, err error)
-    Tidy(ctx context.Context, before time.Time) (purged int, err error)
+type RevocationStore interface { // CertScope = {tenant,issuer,device}，与 Sign 同源隔离；漏传编译错（Hard）
+    Revoke(ctx context.Context, scope CertScope, serial string, reason RevocationReason) error
+    RevocationList(ctx context.Context, scope CertScope) (crlDER []byte, err error)
+    Tidy(ctx context.Context, scope CertScope, before time.Time) (purged int, err error)
 }
-// CertRequest/IssuedCert sealed（unexported + 唯一构造器；typed tenant+deviceID）
+// CertScope/CertRequest/IssuedCert sealed（unexported + 唯一构造器；typed tenant+issuer+device，非裸 string/serial）
 ```
 `certlifecycle.Reconciler` 实现冻结的 `reconcile.Reconciler`，`clock.Clock` 位置参 + `MustHaveClock`，复用 `kernel/reconcile.Loop` + `runtime/command`，不新造控制环。EST 前端在 `runtime/http/est` 终结 PKCS#10/PKCS#7，调用框架 `Signer`。
 

--- a/docs/plans/specs/1895-device-identity-cert-framework/research.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/research.md
@@ -69,7 +69,7 @@ type RevocationStore interface {
 - **关闭** #1811（设备主体签发器，硬前置）、#654（DEVICE-ENQUEUE-RBAC）。
 - **部分提前** #1051（pkicell 框架底座下移 core；winmdm 仅留 WSTEP/SCEP 前端）、#1052（4 中立契约——路线图唯一允许提前项）。
 - **关联** #1870（cert terminal-feedback，PR-7 续期主路径）、#1890（mTLS/SPIFFE service identity，邻接独立，softca 后续可复用）、#822/#1845/#1695/#1591（设备主体硬化）。
-- **路线图冲突**（PR-1 ADR 修订）：#995「不在框架」立场、winmdm PRD pkicell 落点（mdm module）、plan-D §10「v1.0 前不建 mdm/」、#1051/#1052 门控日期、final-form 未列 PKI。**部分支持**：路线图自身把「pkicell WSTEP」列为 v1.0 P0（gocell-platform §3.7 line 271），与本提前一致。
+- **路线图冲突**（PR-1 ADR 修订）：#995「不在框架」立场、winmdm PRD pkicell 落点（mdm module）、plan-D §10「v1.0 前不建 mdm/」、#1051/#1052 门控日期、final-form 未列 PKI。**部分支持**：路线图自身把「pkicell WSTEP」列为 v1.0 P0（gocell-platform §3「P0 阻塞项」callout），与本提前一致。
 
 ## 5. 治理要求
 

--- a/docs/plans/specs/1895-device-identity-cert-framework/spec.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/spec.md
@@ -1,0 +1,202 @@
+# Feature Specification: 设备身份与证书框架化 + MDM/ZT 前期地基
+
+**Feature Branch**: `1895-device-identity-cert-framework`
+**Epic**: #1895
+**Created**: 2026-06-12
+**Status**: Draft
+**Input**: 把设备证书从 iotdevice 示例提升为框架能力（底座 + 内置软 CA + EST 前端）；落地 MDM/ZT 前期工作（4 个中立设备契约 + 生产级设备主体签发器）。收口 #995，部分提前 #1051/#1052，修订已锁定路线图。
+
+## 设计基线（探索结论摘要）
+
+**现状真相**：repo 中**零** CA / CSR / CRL / 签名 / 私钥代码。今天的「设备证书」= devices 行上 `cert_epoch`(int64) + `cert_expires_at`(timestamp) 两列，一个 stateless reconciler 扫近期过期并发 `CommandType="rotate-cert"` 字符串命令（`examples/iotdevice/.../devicecertrenewal`）。所有 `crypto/x509` 命中均为 TLS 传输层消费已编码 PEM 或 `_test.go` 自签链。
+
+**开源一致结论**（SPIFFE/SPIRE + cert-manager + step-ca）：成熟证书身份平台都画同一条线——
+
+> **控制面（生命周期 reconcile + 请求模型 + 续期调度）属框架；签名私钥在 adapter（`crypto.Signer` 永不出边界）；协议前端在消费方边缘。`Authorize`（能否拿证书）与 `Sign`（CSR→证书）是两个接口。**
+
+| 接缝 | GoCell 落点 | 默认 fail |
+|---|---|---|
+| Signer（CSR→证书） | `runtime/certsigning` 接口，`adapters/softca` 实现（私钥在 adapter） | fail-closed（签发失败不降级） |
+| Authorize（设备能否拿证书） | 复用既有 PDP（`auth.RequirePermission` / authorizationdecide），独立于 Sign | fail-closed（缺授权 deny） |
+| CertLifecycle（状态机 + 续期） | `runtime/certlifecycle`，复用 `kernel/reconcile.Loop`（leader/fencing/system-identity） | level-triggered；transient 退避 |
+| Revocation/CRL | `runtime/certsigning.RevocationStore`，PG/softca 实现 | fail-closed |
+| 设备身份绑定 | 生产 `PrincipalDevice` 签发器（#1811）；证书即设备凭证的统一路径 | service/anonymous fail-closed |
+| 中立设备信号 | `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1` | 契约边界 |
+| 协议前端 | 框架内 EST(RFC 7030)；XCEP/WSTEP/SCEP 留 winmdm 消费方 | 鉴权边界 fail-closed |
+
+**核心安全不变式**：私钥永不进 kernel/runtime（只持 `crypto.Signer` 句柄，SPIRE KeyManager 范式）；`Sign` 是包外铸造设备证书的唯一入口（sealed funnel）；`Authorize` 与 `Sign` 分离——证书签发授权漏洞不得放大为越权签发。
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 设备拥有可信框架身份 (Priority: P1) 🎯 MVP
+
+设备主体经生产级签发器获得真实 `PrincipalDevice`（含 tenant + 设备 subject），从而沿请求链派生 `RowScope=device`，并成为后续证书签发的被授权主体。今天 `runtime/auth/rowscope.go` 的派生规则已就位，但 develop **无任何生产 authn 铸造 `PrincipalDevice`/super-admin**（#1811）——US1 补齐这一硬前置。
+
+**Why this priority**：地基。证书签发、行级隔离、设备态势评估全部以「可信设备主体」为前提；没有它，证书底座只能跑测试桩。
+
+**Independent Test**：用设备凭证通道认证 → ctx 得 `principalKind=device` + 设备 subject + tenant；查命令队列只返回 `device_id=self` 行；缺设备凭证 / service-token 冒充 → fail-closed。
+
+**Acceptance Scenarios**：
+1. **Given** 设备出示有效设备凭证，**When** 进入业务端点，**Then** ctx Principal 为 `PrincipalDevice`，subject=设备 ID，tenant 来自凭证。
+2. **Given** super-admin 凭证，**When** 跨租户运维端点，**Then** 派生 `RowScope=all` 且强制审计（复用 ROWSCOPEALL-AUDIT-FUNNEL-01）。
+3. **Given** service-token 冒充设备，**When** 解析主体，**Then** 不得派生 `PrincipalDevice`（service ≠ device，概念隔离）。
+4. **Given** 设备主体，**When** 查命令/证书列表，**Then** 仅 `device_id=self`（`RowScope=device`）。
+
+---
+
+### User Story 2 - 框架级证书签发底座 (Priority: P1) 🎯 MVP
+
+框架能为设备签发 / 续期 / 吊销 X.509 证书，CA 后端可插拔，消费方零重建。内置 `adapters/softca`（`crypto.Signer` 托管 CA）使能力**无外部依赖即可用**；证书生命周期由复用 `kernel/reconcile` 的 `certlifecycle` reconciler 驱动（把 iotdevice 种子从「发字符串命令」泛化为「真实签发状态机」）。
+
+**Why this priority**：这是「设备证书成为框架的一部分」的本体。P1 与 US1 并列——没有真实签发，设备身份只是时间戳。
+
+**Independent Test**：构造一个近期过期设备证书 → certlifecycle 触发 → `Authorizer` 放行 → `Signer.Sign(CSR)` 返回证书链 → 持久化 epoch+1/notAfter → 发 `cert-issued` L2 事实；吊销 → CRL 含该 serial；签名失败 / 缺授权 → 不签发（fail-closed），不损坏现有证书。
+
+**Acceptance Scenarios**：
+1. **Given** 设备证书 `notAfter` 进入续期窗口，**When** certlifecycle reconcile，**Then** 经 `Authorizer` 放行后 `Signer.Sign` 签发新证书，epoch 单调 +1，持久化 notAfter，发 `deviceidentity.cert-issued.v1`。
+2. **Given** `Signer`（softca）不可用，**When** reconcile，**Then** transient 退避重试，**不**损坏既有证书状态（level-triggered）。
+3. **Given** `Authorizer` deny，**When** 续期，**Then** 不签发（fail-closed），记审计。
+4. **Given** 吊销请求，**When** `RevocationStore.Revoke(serial)`，**Then** `RevocationList` 含该 serial，发 `cert-revoked.v1`。
+5. **Given** 开发者试图在 adapter 外构造证书值或绕过 `Sign`，**When** 编译/archtest，**Then** 失败（sealed 构造 + 单一签发 funnel）。
+6. **Given** 多副本部署，**When** 两副本同时 reconcile 同设备，**Then** `LeaseToken.Epoch` fencing + 队列 active-uniqueness 保证至多一次有效签发。
+
+---
+
+### User Story 3 - 设备经 EST 开箱自助注册/续期证书 (Priority: P2)
+
+框架提供 EST(RFC 7030) 注册前端：`/cacerts`（取信任根）、`/simpleenroll`（首次注册 PKCS#10 CSR → PKCS#7 证书）、`/simplereenroll`（凭现证书续期）。设备无需消费方实现协议即可自助拿证书；Windows 专属 XCEP/WSTEP/SCEP 仍留 winmdm。
+
+**Why this priority**：P2，依赖 US2 的 `Signer`/`Authorizer`。EST 是「batteries-included」的开箱注册路径（用户决策含 EST 前端）。
+
+**Independent Test**：设备 POST CSR 到 `/simpleenroll`（bootstrap 或设备主体鉴权）→ 得证书链；`/simplereenroll` 用现证书 TLS-client-auth 续期；未授权 / 畸形 CSR → 4xx fail-closed；`/cacerts` 返回 softca 信任根。
+
+**Acceptance Scenarios**：
+1. **Given** 合法 bootstrap/设备鉴权 + 合法 PKCS#10，**When** POST `/simpleenroll`，**Then** 返回 PKCS#7 证书链，状态 200。
+2. **Given** 已有证书设备，**When** `/simplereenroll`（mTLS client-auth），**Then** 续期新证书，旧证书可吊销。
+3. **Given** 缺/错鉴权，**When** enroll，**Then** 401/403（fail-closed），经 `Authorizer`。
+4. **Given** 畸形 / 越权 SAN 的 CSR，**When** enroll，**Then** 4xx，签名约束（SignConstraints）拒绝。
+5. **Given** 任意客户端，**When** GET `/cacerts`，**Then** 返回 softca 信任根（PKCS#7）。
+
+---
+
+### User Story 4 - 中立设备信号契约 (Priority: P2)
+
+定义 4 个中立设备契约 `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1`，使 MDM / ZT 能消费**任意** device provider（winmdm / Intune / Jamf / 自建），而非硬绑单一实现。`deviceidentity` 是证书 / 身份之家；`remotecommand` 泛化既有 `command.devicecommand.enqueue.v1`。
+
+**Why this priority**：P2，路线图唯一允许提前的 MDM/ZT 前期项（#1052 可提前子项）。契约形状提前冻结，避免 2029 重写。
+
+**Independent Test**：每个契约有 contract.yaml + schema + generated code + governance；契约级测试覆盖正常 schema / 参数错误 / 鉴权边界；契约扇出闭环（5 载体同步）。
+
+**Acceptance Scenarios**：
+1. **Given** `deviceidentity/v1` 契约，**When** codegen，**Then** 生成 handler/client/types，registration glue 派生自 slice.yaml `contractUsages`。
+2. **Given** 任一中立契约破坏式 wire 变更，**When** 提交，**Then** 走新版本目录（不偷改旧版本语义）。
+3. **Given** `remotecommand/v1`，**When** 与既有 devicecommand enqueue 比对，**Then** 字段形状对齐可承接（PR-9 迁移）。
+
+---
+
+### User Story 5 - iotdevice 迁移示范（端到端证明接缝） (Priority: P2)
+
+把 `examples/iotdevice/devicecell` 从 bare-string `rotate-cert` 切到框架证书底座：用 `deviceidentity` 契约 + `certlifecycle` reconciler + `softca` 签发真实证书；把 `rotate-cert` 字符串提升为真契约 `command.deviceidentity.rotate.v1`；补设备粒度 enqueue 鉴权（#654）。
+
+**Why this priority**：P2，依赖 US2/US4。示例迁移是框架能力的端到端验证（消费方视角），也是 winmdm/ZT 的参考实现。
+
+**Independent Test**：iotdevice 设备注册 → 签发真实证书（softca）→ 近期过期 → certlifecycle 续期 → 新证书生效；`rotate-cert` 走真契约；非授权设备 enqueue 命令被拒。
+
+**Acceptance Scenarios**：
+1. **Given** iotdevice 注册设备，**When** deviceregister，**Then** 经 `Signer` 签发真实初始证书（非仅时间戳），持久化证书 + epoch。
+2. **Given** 迁移后，**When** 扫描续期，**Then** 经 `certlifecycle` 真实签发，`command.deviceidentity.rotate.v1` 取代字符串命令。
+3. **Given** 设备 A 试图 enqueue 设备 B 的命令，**When** Enqueue，**Then** 设备粒度授权拒绝（#654）。
+
+---
+
+### User Story 6 - 治理闭环 + 路线图修订 (Priority: P3)
+
+把上述 enforcement 按 AI-robust 三档固化：cert sealed 构造 + 单一 `Sign` funnel（Hard）、lifecycle fencing 复用 reconcile（Hard）、EST 鉴权边界（Medium archtest）、Authorizer/Signer 分离（Medium）。出**路线图修订 ADR**：收口 #995（结论：进框架）、修订 winmdm PRD pkicell 落点（mdm→core 注记）、plan-D §10 例外、final-form 增列 PKI 能力、更新 #1051/#1052 锚点。
+
+**Why this priority**：P3，随各层增量补；但每条 enforcement 守卫与其实现**同 PR 闭环**。本故事收口跨层 ADR + 路线图一致性 + 威胁矩阵重评。
+
+**Independent Test**：`make verify`（含 archtest）全绿；每条新 invariant 有反向自检；路线图 4 份文档与本 epic 一致（无残留「PKI 不在框架」表述）。
+
+---
+
+### Edge Cases
+
+- **私钥泄漏面**：私钥永不进 kernel/runtime；adapter 只暴露 `Sign` 操作（`crypto.Signer`）。任何让原始私钥跨 `runtime/certsigning` 边界的代码 = archtest 红。
+- **reconcile 单租户系统身份**：`kernel/reconcile` 在 system identity 下运行且**清空 tenant**（#1821）；多租户证书 reconcile 必须在 scan + 命令 key + 签发请求中**自带 tenant 维度**，不能依赖 ctx tenant。
+- **续期抖动**：续期窗口加 jitter（k8s 70–90% 寿命模型）避免整队同时续期惊群。
+- **EST bootstrap vs 续期鉴权**：首次 `/simpleenroll` 用 bootstrap/设备凭证；`/simplereenroll` 用现证书 mTLS——两条鉴权路径显式声明，不混。
+- **吊销与续期竞态**：吊销正在续期的证书 → epoch CAS（fencing）保证终态一致。
+- **决策不跨 async**：证书签发授权结论不随事件携带；跨边界只传设备 identity，消费侧重决策。
+- **device PII**：`device_id` 日志 redaction（#1695）；证书 serial / subject 写审计前按 redaction 包处理。
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**设备主体（US1，#1811）**
+- **FR-001**: 系统 MUST 提供生产级设备主体签发器，铸造 `PrincipalKind=device`（subject=设备 ID、tenant 来自可信凭证），消除「develop 无生产 PrincipalDevice 来源」现状。
+- **FR-002**: 系统 MUST 提供 super-admin 主体签发，`RowScope=all` 为显式独立路径并强制审计。
+- **FR-003**: service-token MUST NOT 派生 `PrincipalDevice`（概念隔离）；caller-cell ID ≠ device subject。
+
+**证书签发底座（US2）**
+- **FR-004**: 系统 MUST 提供 `Signer` 接口（`Sign(ctx, CertRequest) (IssuedCert, error)` + `TrustBundle`），**唯一**铸造设备证书入口；`adapters/softca` 实现，私钥（`crypto.Signer`）永不出 adapter 边界。
+- **FR-005**: 系统 MUST 提供 `Authorizer`（`AuthorizeEnroll(ctx, EnrollmentClaim) (SignConstraints, error)`），**独立于** `Signer`，复用既有 PDP；nil grant fail-closed deny；返回 SignConstraints（max TTL / 允许 SAN）由 Signer 强制。
+- **FR-006**: 系统 MUST 提供 `CertRequest`/`IssuedCert` sealed 类型（unexported 字段 + 唯一构造器），包外不可字面量伪造证书材料。
+- **FR-007**: 系统 MUST 提供 `RevocationStore`（`Revoke(serial,reason)` / `RevocationList` / `Tidy`）；吊销 fail-closed。
+- **FR-008**: 系统 MUST 提供 `certlifecycle.Reconciler`（实现冻结的 `reconcile.Reconciler`），驱动状态机 requested→issued→active→near-expiry→renewing→{rotated|revoked|expired}，**复用** `kernel/reconcile.Loop`（leader/fencing/system-identity）+ `runtime/command`（设备往返腿），不新造控制环。
+- **FR-009**: 续期窗口 MUST 经注入 `clock.Clock`（禁 `time.Now()`）+ jitter；签发 epoch 单调，跨副本经 `LeaseToken.Epoch` fencing 写路径 CAS。
+- **FR-010**: 证书签发 MUST 发 L2 事实 `deviceidentity.cert-issued.v1` / `cert-revoked.v1`（outbox），供 ZT 信任根 / 审计消费侧消费。
+
+**EST 前端（US3）**
+- **FR-011**: 系统 MUST 提供框架级 EST(RFC 7030) 端点 `/cacerts` `/simpleenroll` `/simplereenroll`，wiring `Authorizer`→`Signer`；PKCS#10 in / PKCS#7 out。
+- **FR-012**: EST 鉴权 MUST 区分 bootstrap/设备凭证（首次）与现证书 mTLS（续期）两条路径，显式声明，缺鉴权 fail-closed 4xx。
+
+**中立契约（US4）**
+- **FR-013**: 系统 MUST 定义 `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1`，含 contract.yaml（鉴权/caller/schema）+ generated code + slice 派生 registration；走契约扇出闭环。
+- **FR-014**: `deviceidentity/v1` MUST 承载证书 enroll/renew/revoke + 当前证书状态；`remotecommand/v1` MUST 承接既有 `command.devicecommand.enqueue.v1` 形状（PR-9 迁移）。
+
+**迁移（US5）**
+- **FR-015**: iotdevice MUST 迁移到框架证书底座（deviceregister 经 `Signer` 签真实初始证书；续期经 `certlifecycle`）；`rotate-cert` 字符串 MUST 提升为真契约 `command.deviceidentity.rotate.v1`。
+- **FR-016**: 设备命令 Enqueue MUST 加设备粒度授权（#654），设备不可操作他设备命令。
+
+**治理 + 路线图（US6）**
+- **FR-017**: 每条 enforcement MUST 与守卫（archtest / sealed type / governance rule）同 PR 落地，按 Hard/Medium 评级，附反向自检 + godoc/ADR。
+- **FR-018**: MUST 出路线图修订 ADR：收口 #995（进框架）、修订 winmdm PRD pkicell 落点注记、plan-D §10 例外、final-form 增列 PKI 能力、更新 #1051/#1052 锚点；冲突段落同改动重写，重评威胁矩阵。
+
+### Key Entities
+
+- **PrincipalDevice（签发）**：生产铸造的设备主体（kind=device + subject + tenant），派生 `RowScope=device`。
+- **CertRequest**：协议无关签发请求 sealed 类型（CSR + DeviceSubject + SANs + TTL + Usages）；EST/SCEP/XCEP 解码到此。
+- **IssuedCert**：签发结果 sealed 类型（证书 + 链 + serial + notAfter + epoch）。
+- **Signer**：CSR→证书的 CA 接缝（adapter，私钥不出边界）；**唯一**签发入口。
+- **Authorizer**：设备能否拿证书的决策（复用 PDP），返回 SignConstraints；独立于 Signer。
+- **RevocationStore**：吊销 + CRL + tidy。
+- **CertLifecycle.Reconciler**：复用 kernel/reconcile 的证书生命周期状态机。
+- **4 中立契约**：deviceidentity（证书之家）/ devicestate / devicecompliance / remotecommand。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 设备经生产签发器获得 `PrincipalDevice`，端到端派生 `RowScope=device`（US1 三类主体 e2e 通过）；service-token 不可冒充 device。
+- **SC-002**: 框架可经内置 softca 签发 / 续期 / 吊销真实 X.509 证书，**无外部 CA 依赖**；签名私钥不出 adapter（archtest 守卫）。
+- **SC-003**: 包外伪造证书值或绕过 `Sign` 入口**编译/archtest 失败**（sealed 构造 + 单一 funnel，Hard）；`Authorizer` 与 `Signer` 为两接口。
+- **SC-004**: 证书生命周期复用 `kernel/reconcile`（无新控制环）；多副本 fencing + 队列 active-uniqueness 保证至多一次有效签发；签发失败不损坏既有证书（fail-closed 有测试覆盖）。
+- **SC-005**: 设备经 EST `/simpleenroll` `/simplereenroll` 开箱注册/续期；缺鉴权 fail-closed。
+- **SC-006**: 4 个中立契约就位，契约级测试 + 扇出闭环全绿；破坏式变更走新版本目录。
+- **SC-007**: iotdevice 端到端经框架能力签发真实证书；`rotate-cert` 走真契约；设备粒度鉴权拒绝越权 enqueue（#654 关闭）。
+- **SC-008**: `make verify`（含 archtest）全绿；每条新 invariant 有反向自检 + AI-robust 评级登记于其 archtest godoc；路线图 4 份文档无残留「PKI 不在框架」表述（#995 收口）。
+
+## Assumptions
+
+- 内置软 CA（`adapters/softca`）足以支撑 dev/test + 小型 ZT；step-ca/Vault adapter 留接口位，后续 PR（不在本 epic）。
+- 不引入外部 PDP；证书签发授权复用 accesscore 既有 policy 引擎。
+- 不向后兼容：`rotate-cert` 字符串直接换真契约，无 shim；iotdevice 直接迁移。
+- 设备凭证通道（设备 token / 证书 mTLS）首版由 #1811 签发器提供 device token；证书 mTLS 派生 `PrincipalDevice` 为统一终态（EST `/simplereenroll` 已用 client-cert），二者本 epic 内可并存。
+- 不建 `mdm/`/`zerotrust/` module（plan-D §10）；本 epic 全部落 core（顶层 module）。
+- Windows 专属 XCEP/WSTEP/SCEP/MS-MDE 留 winmdm 消费方；本 epic 只到 EST。
+- #1890（service mTLS/SPIFFE identity）邻接但独立；softca 后续可被其复用。

--- a/docs/plans/specs/1895-device-identity-cert-framework/spec.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/spec.md
@@ -19,12 +19,12 @@
 | Signer（CSR→证书） | `runtime/certsigning` 接口，`adapters/softca` 实现（私钥在 adapter） | fail-closed（签发失败不降级） |
 | Authorize（设备能否拿证书） | 复用既有 PDP（`auth.RequirePermission` / authorizationdecide），独立于 Sign | fail-closed（缺授权 deny） |
 | CertLifecycle（状态机 + 续期） | `runtime/certlifecycle`，复用 `kernel/reconcile.Loop`（leader/fencing/system-identity） | level-triggered；transient 退避 |
-| Revocation/CRL | `runtime/certsigning.RevocationStore`，PG/softca 实现 | fail-closed |
+| Revocation/CRL | `runtime/certsigning.RevocationStore`（方法带 `CertScope` typed 位置参），PG/softca 实现 | fail-closed（跨租户/issuer 吊销/查询拒绝） |
 | 设备身份绑定 | 生产 `PrincipalDevice` 签发器（#1811）；证书即设备凭证的统一路径 | service/anonymous fail-closed |
-| 中立设备信号 | `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1` | 契约边界 |
-| 协议前端 | 框架内 EST(RFC 7030)；XCEP/WSTEP/SCEP 留 winmdm 消费方 | 鉴权边界 fail-closed |
+| 中立设备信号 | 4 个 domain 契约（deviceidentity/devicestate/devicecompliance/remotecommand），kind-qualified 落 `contracts/{http,event,command}/<domain>/.../v1`（见 FR-013） | 契约边界 |
+| 协议前端 | 框架内 EST(RFC 7030)，挂版本化 cell 路径 `/api/v{N}/deviceidentity/est/*`；XCEP/WSTEP/SCEP 留 winmdm 消费方 | 鉴权边界 fail-closed（非 setup-bootstrap） |
 
-**核心安全不变式**：私钥永不进 kernel/runtime（只持 `crypto.Signer` 句柄，SPIRE KeyManager 范式）；`Sign` 是包外铸造设备证书的唯一入口（sealed funnel）；`Authorize` 与 `Sign` 分离——证书签发授权漏洞不得放大为越权签发。
+**核心安全不变式**：私钥永不进 kernel/runtime（只持 `crypto.Signer` 句柄，SPIRE KeyManager 范式）；`Sign` 是包外铸造设备证书的唯一入口（sealed funnel）；签发与吊销共用 `CertScope` 隔离（吊销不可凭裸 serial 跨租户）；`Authorize` 与 `Sign` 分离——证书签发授权漏洞不得放大为越权签发。
 
 ---
 
@@ -58,7 +58,8 @@
 1. **Given** 设备证书 `notAfter` 进入续期窗口，**When** certlifecycle reconcile，**Then** 经 `Authorizer` 放行后 `Signer.Sign` 签发新证书，epoch 单调 +1，持久化 notAfter，发 `deviceidentity.cert-issued.v1`。
 2. **Given** `Signer`（softca）不可用，**When** reconcile，**Then** transient 退避重试，**不**损坏既有证书状态（level-triggered）。
 3. **Given** `Authorizer` deny，**When** 续期，**Then** 不签发（fail-closed），记审计。
-4. **Given** 吊销请求，**When** `RevocationStore.Revoke(serial)`，**Then** `RevocationList` 含该 serial，发 `cert-revoked.v1`。
+4. **Given** 吊销请求，**When** `RevocationStore.Revoke(CertScope, serial)`，**Then** `RevocationList(CertScope)` 含该 serial，发 `cert-revoked.v1`。
+7. **Given** tenant-A 主体持 tenant-B 证书的 serial，**When** 调 `Revoke` / `RevocationList`，**Then** fail-closed 拒绝（`CertScope` 隔离，绝不凭裸 serial 跨租户吊销/查询）。
 5. **Given** 开发者试图在 adapter 外构造证书值或绕过 `Sign`，**When** 编译/archtest，**Then** 失败（sealed 构造 + 单一签发 funnel）。
 6. **Given** 多副本部署，**When** 两副本同时 reconcile 同设备，**Then** `LeaseToken.Epoch` fencing + 队列 active-uniqueness 保证至多一次有效签发。
 
@@ -70,12 +71,12 @@
 
 **Why this priority**：P2，依赖 US2 的 `Signer`/`Authorizer`。EST 是「batteries-included」的开箱注册路径（用户决策含 EST 前端）。
 
-**Independent Test**：设备 POST CSR 到 `/simpleenroll`（bootstrap 或设备主体鉴权）→ 得证书链；`/simplereenroll` 用现证书 TLS-client-auth 续期；未授权 / 畸形 CSR → 4xx fail-closed；`/cacerts` 返回 softca 信任根。
+**Independent Test**：设备 POST CSR 到版本化 `/api/v1/deviceidentity/est/simpleenroll`（enrollment-credential / device-token 鉴权）→ 得证书链；`/.../simplereenroll` 用现证书 TLS-client-auth 续期；未授权 / 畸形 CSR → 4xx fail-closed；`/.../cacerts` 返回 softca 信任根。
 
-**Acceptance Scenarios**：
-1. **Given** 合法 bootstrap/设备鉴权 + 合法 PKCS#10，**When** POST `/simpleenroll`，**Then** 返回 PKCS#7 证书链，状态 200。
+**Acceptance Scenarios**（EST 操作挂版本化 cell 路径 `/api/v1/deviceidentity/est/*`）：
+1. **Given** 合法 enrollment-credential / device-token + 合法 PKCS#10，**When** POST `/simpleenroll`，**Then** 返回 PKCS#7 证书链，状态 200。
 2. **Given** 已有证书设备，**When** `/simplereenroll`（mTLS client-auth），**Then** 续期新证书，旧证书可吊销。
-3. **Given** 缺/错鉴权，**When** enroll，**Then** 401/403（fail-closed），经 `Authorizer`。
+3. **Given** 缺/错鉴权 **或** 用 setup `auth.bootstrap:true` 冒充，**When** enroll，**Then** 401/403（fail-closed，经 `Authorizer`；EST 非 setup-admin 路径，FMT-28 拒绝 bootstrap 凭据）。
 4. **Given** 畸形 / 越权 SAN 的 CSR，**When** enroll，**Then** 4xx，签名约束（SignConstraints）拒绝。
 5. **Given** 任意客户端，**When** GET `/cacerts`，**Then** 返回 softca 信任根（PKCS#7）。
 
@@ -83,7 +84,7 @@
 
 ### User Story 4 - 中立设备信号契约 (Priority: P2)
 
-定义 4 个中立设备契约 `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1`，使 MDM / ZT 能消费**任意** device provider（winmdm / Intune / Jamf / 自建），而非硬绑单一实现。`deviceidentity` 是证书 / 身份之家；`remotecommand` 泛化既有 `command.devicecommand.enqueue.v1`。
+定义 4 个中立设备契约（domain：deviceidentity / devicestate / devicecompliance / remotecommand，kind-qualified 落库见 FR-013），使 MDM / ZT 能消费**任意** device provider（winmdm / Intune / Jamf / 自建），而非硬绑单一实现。`deviceidentity` 是证书 / 身份之家；`remotecommand` 泛化既有 `command.devicecommand.enqueue.v1`。
 
 **Why this priority**：P2，路线图唯一允许提前的 MDM/ZT 前期项（#1052 可提前子项）。契约形状提前冻结，避免 2029 重写。
 
@@ -126,7 +127,8 @@
 - **私钥泄漏面**：私钥永不进 kernel/runtime；adapter 只暴露 `Sign` 操作（`crypto.Signer`）。任何让原始私钥跨 `runtime/certsigning` 边界的代码 = archtest 红。
 - **reconcile 单租户系统身份**：`kernel/reconcile` 在 system identity 下运行且**清空 tenant**（#1821）；多租户证书 reconcile 必须在 scan + 命令 key + 签发请求中**自带 tenant 维度**，不能依赖 ctx tenant。
 - **续期抖动**：续期窗口加 jitter（k8s 70–90% 寿命模型）避免整队同时续期惊群。
-- **EST bootstrap vs 续期鉴权**：首次 `/simpleenroll` 用 bootstrap/设备凭证；`/simplereenroll` 用现证书 mTLS——两条鉴权路径显式声明，不混。
+- **EST 落点与鉴权**：EST 操作挂所属 cell 版本化路径（`/api/v{N}/deviceidentity/est/*`），非顶级裸路径；首次 `/simpleenroll` 用专用 enrollment-credential / device-token，`/simplereenroll` 用现证书 mTLS——两条路径显式声明，不混；**不复用** setup `auth.bootstrap:true`（FMT-28 限其只在 setup/admin，EST 复用会被 fail-closed 拒绝）。
+- **跨租户吊销**：`Revoke`/`RevocationList` 带 `CertScope`（tenant+issuer+device）；tenant-A 不可凭裸 serial 吊销/查询 tenant-B 证书（与签发同源隔离，fail-closed）。
 - **吊销与续期竞态**：吊销正在续期的证书 → epoch CAS（fencing）保证终态一致。
 - **决策不跨 async**：证书签发授权结论不随事件携带；跨边界只传设备 identity，消费侧重决策。
 - **device PII**：`device_id` 日志 redaction（#1695）；证书 serial / subject 写审计前按 redaction 包处理。
@@ -146,17 +148,17 @@
 - **FR-004**: 系统 MUST 提供 `Signer` 接口（`Sign(ctx, CertRequest) (IssuedCert, error)` + `TrustBundle`），**唯一**铸造设备证书入口；`adapters/softca` 实现，私钥（`crypto.Signer`）永不出 adapter 边界。
 - **FR-005**: 系统 MUST 提供 `Authorizer`（`AuthorizeEnroll(ctx, EnrollmentClaim) (SignConstraints, error)`），**独立于** `Signer`，复用既有 PDP；nil grant fail-closed deny；返回 SignConstraints（max TTL / 允许 SAN）由 Signer 强制。
 - **FR-006**: 系统 MUST 提供 `CertRequest`/`IssuedCert` sealed 类型（unexported 字段 + 唯一构造器），包外不可字面量伪造证书材料。
-- **FR-007**: 系统 MUST 提供 `RevocationStore`（`Revoke(serial,reason)` / `RevocationList` / `Tidy`）；吊销 fail-closed。
+- **FR-007**: 系统 MUST 提供 `RevocationStore`（`Revoke(ctx, CertScope, serial, reason)` / `RevocationList(ctx, CertScope)` / `Tidy(ctx, CertScope, before)`），其中 `CertScope` 是与签发**同源**的 typed 隔离值（`{tenant, issuer, device}`，复用 `CertRequest` 的 scope 维度）。吊销与 CRL 查询 MUST 带 `CertScope` 强制 typed 位置参——**漏传为编译错**（Hard，对齐 tenant typed-param 范式）；跨租户/跨 issuer 吊销或查询 fail-closed（绝不凭裸 serial 跨隔离域操作）。
 - **FR-008**: 系统 MUST 提供 `certlifecycle.Reconciler`（实现冻结的 `reconcile.Reconciler`），驱动状态机 requested→issued→active→near-expiry→renewing→{rotated|revoked|expired}，**复用** `kernel/reconcile.Loop`（leader/fencing/system-identity）+ `runtime/command`（设备往返腿），不新造控制环。
 - **FR-009**: 续期窗口 MUST 经注入 `clock.Clock`（禁 `time.Now()`）+ jitter；签发 epoch 单调，跨副本经 `LeaseToken.Epoch` fencing 写路径 CAS。
 - **FR-010**: 证书签发 MUST 发 L2 事实 `deviceidentity.cert-issued.v1` / `cert-revoked.v1`（outbox），供 ZT 信任根 / 审计消费侧消费。
 
 **EST 前端（US3）**
-- **FR-011**: 系统 MUST 提供框架级 EST(RFC 7030) 端点 `/cacerts` `/simpleenroll` `/simplereenroll`，wiring `Authorizer`→`Signer`；PKCS#10 in / PKCS#7 out。
-- **FR-012**: EST 鉴权 MUST 区分 bootstrap/设备凭证（首次）与现证书 mTLS（续期）两条路径，显式声明，缺鉴权 fail-closed 4xx。
+- **FR-011**: 系统 MUST 提供 EST(RFC 7030) 操作 `cacerts` / `simpleenroll` / `simplereenroll`（PKCS#10 in / PKCS#7 out，wiring `Authorizer`→`Signer`），挂在所属 cell 的**版本化路径**下（`/api/v{N}/deviceidentity/est/{cacerts,simpleenroll,simplereenroll}`），**不**用顶级裸 EST 路径（对齐 api-versioning「无顶级命名空间，端点挂所属 cell 版本前缀」）。
+- **FR-012**: EST 鉴权 MUST 用**专用 enrollment-credential / device-bootstrap-token** scheme（首次 enroll）+ 现证书 mTLS client-auth（reenroll）两条显式声明路径，缺鉴权 fail-closed 4xx。**不复用** setup `auth.bootstrap:true`（FMT-28 限其只在 `^/api/v\d+/[^/]+/setup/admin$`，EST 非 setup-admin 路径，复用会被 fail-closed 拒绝）；若未来确需复用 bootstrap 凭据，MUST 先出 ADR 扩展 FMT-28（本 epic 不走此路）。
 
 **中立契约（US4）**
-- **FR-013**: 系统 MUST 定义 `contracts/{deviceidentity,devicestate,devicecompliance,remotecommand}/v1`，含 contract.yaml（鉴权/caller/schema）+ generated code + slice 派生 registration；走契约扇出闭环。
+- **FR-013**: 系统 MUST 定义 4 个中立设备契约（domain shorthand：`deviceidentity` / `devicestate` / `devicecompliance` / `remotecommand`），按仓库契约布局单源 `{kind}/{domain-path}/{version}/` 落 **kind-qualified** 路径——`contracts/http/deviceidentity/{enroll,renew,revoke,status}/v1`、`contracts/event/deviceidentity/{cert-issued,cert-revoked}/v1`、`contracts/command/deviceidentity/rotate/v1`、`contracts/http/devicestate/v1`、`contracts/http/devicecompliance/v1`、`contracts/command/remotecommand/v1`。各含 contract.yaml（鉴权/caller/schema）+ generated code + slice 派生 registration；走契约扇出闭环。「4 个中立契约」是 domain 简写，**不是**目录真源（目录必带 kind 维度）。
 - **FR-014**: `deviceidentity/v1` MUST 承载证书 enroll/renew/revoke + 当前证书状态；`remotecommand/v1` MUST 承接既有 `command.devicecommand.enqueue.v1` 形状（PR-9 迁移）。
 
 **迁移（US5）**
@@ -170,11 +172,12 @@
 ### Key Entities
 
 - **PrincipalDevice（签发）**：生产铸造的设备主体（kind=device + subject + tenant），派生 `RowScope=device`。
-- **CertRequest**：协议无关签发请求 sealed 类型（CSR + DeviceSubject + SANs + TTL + Usages）；EST/SCEP/XCEP 解码到此。
+- **CertScope**：与签发同源的 typed 隔离值（`{tenant, issuer, device}`），Sign / Revoke / RevocationList / Tidy 共用；裸 serial 不可跨隔离域操作。
+- **CertRequest**：协议无关签发请求 sealed 类型（CSR + DeviceSubject + SANs + TTL + Usages；scope 维度即 `CertScope`）；EST/SCEP/XCEP 解码到此。
 - **IssuedCert**：签发结果 sealed 类型（证书 + 链 + serial + notAfter + epoch）。
 - **Signer**：CSR→证书的 CA 接缝（adapter，私钥不出边界）；**唯一**签发入口。
 - **Authorizer**：设备能否拿证书的决策（复用 PDP），返回 SignConstraints；独立于 Signer。
-- **RevocationStore**：吊销 + CRL + tidy。
+- **RevocationStore**：吊销 + CRL + tidy，方法带 `CertScope` 强制 typed 位置参（跨租户/issuer fail-closed）。
 - **CertLifecycle.Reconciler**：复用 kernel/reconcile 的证书生命周期状态机。
 - **4 中立契约**：deviceidentity（证书之家）/ devicestate / devicecompliance / remotecommand。
 
@@ -183,10 +186,10 @@
 ### Measurable Outcomes
 
 - **SC-001**: 设备经生产签发器获得 `PrincipalDevice`，端到端派生 `RowScope=device`（US1 三类主体 e2e 通过）；service-token 不可冒充 device。
-- **SC-002**: 框架可经内置 softca 签发 / 续期 / 吊销真实 X.509 证书，**无外部 CA 依赖**；签名私钥不出 adapter（archtest 守卫）。
+- **SC-002**: 框架可经内置 softca 签发 / 续期 / 吊销真实 X.509 证书，**无外部 CA 依赖**；签名私钥不出 adapter（archtest 守卫）。吊销/CRL 查询带 `CertScope`，跨租户/issuer 吊销/查询 100% fail-closed（漏传 scope 编译失败）。
 - **SC-003**: 包外伪造证书值或绕过 `Sign` 入口**编译/archtest 失败**（sealed 构造 + 单一 funnel，Hard）；`Authorizer` 与 `Signer` 为两接口。
 - **SC-004**: 证书生命周期复用 `kernel/reconcile`（无新控制环）；多副本 fencing + 队列 active-uniqueness 保证至多一次有效签发；签发失败不损坏既有证书（fail-closed 有测试覆盖）。
-- **SC-005**: 设备经 EST `/simpleenroll` `/simplereenroll` 开箱注册/续期；缺鉴权 fail-closed。
+- **SC-005**: 设备经版本化 EST 端点（`/api/v1/deviceidentity/est/*`）开箱注册/续期；首次用 enrollment-credential、续期用现证书 mTLS；缺鉴权或 setup-bootstrap 冒充 fail-closed（FMT-28 边界）。
 - **SC-006**: 4 个中立契约就位，契约级测试 + 扇出闭环全绿；破坏式变更走新版本目录。
 - **SC-007**: iotdevice 端到端经框架能力签发真实证书；`rotate-cert` 走真契约；设备粒度鉴权拒绝越权 enqueue（#654 关闭）。
 - **SC-008**: `make verify`（含 archtest）全绿；每条新 invariant 有反向自检 + AI-robust 评级登记于其 archtest godoc；路线图 4 份文档无残留「PKI 不在框架」表述（#995 收口）。

--- a/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
@@ -1,0 +1,253 @@
+---
+description: "PR decomposition & dependency graph for 1895-device-identity-cert-framework"
+---
+
+# Tasks: 设备身份与证书框架化 + MDM/ZT 前期地基
+
+**Input**: `/docs/plans/specs/1895-device-identity-cert-framework/` plan.md + spec.md
+**Epic**: #1895
+**Tests**: TDD 强制（每个 PR 先写 `*_test.go`，FAIL→实现）；runtime/kernel ≥90%，其余 ≥80%。
+
+## 拆分原则
+
+- 每个 PR **目标净增删 ≤ 2000 行**（含测试），接受少量超限（~10%，≤2200）；显著超限（>2200）才按子任务切（`PR-Na/PR-Nb`，不重排编号）。
+- 每个 PR 自带其 enforcement 守卫（archtest / sealed type / governance rule）+ 反向自检 + godoc/ADR——**同 PR 闭环**，不甩 backlog。
+- 同一文件只属一个 PR（防写冲突）。
+- 破坏式演化（`rotate-cert` 字符串→真契约、iotdevice 迁移）直接改，无 shim；涉及契约/接口签名变更出 contract-fanout implementation matrix。
+- **私钥不出 adapter** + **`Sign` 唯一签发入口**是贯穿不变式，每个触及证书材料的 PR 必须守。
+
+---
+
+## PR 总览（11 个）
+
+| PR | 标题 | 架构层 | US | 行数估算 | 依赖 | 关闭/关联 issue |
+|----|------|--------|----|---------|------|----------------|
+| PR-1 | 路线图修订 ADR（设备证书框架化决议） | 治理/docs | US6 | ~500 | — | 关联 #995 #1051 #1052 |
+| PR-2 | 生产级设备/super-admin 主体签发器 | runtime/auth | US1 | ~1500 | — | **关闭 #1811** |
+| PR-3 | 中立契约 (a)：deviceidentity + devicestate | contracts | US4 | ~1400 | — | 关联 #1052 |
+| PR-4 | 中立契约 (b)：devicecompliance + remotecommand | contracts | US4 | ~1400 | PR-3 | 关联 #1052 |
+| PR-5 | `runtime/certsigning` 接口 + sealed 类型 + funnel | runtime | US2 | ~1500 | PR-3 | 关联 #995 |
+| PR-6 | `adapters/softca` 内置软 CA（Signer + CRL） | adapters | US2 | ~1700 | PR-5 | 关联 #995 |
+| PR-7 | `runtime/certlifecycle` 生命周期 reconciler | runtime | US2 | ~1900 ⚠ | PR-5, PR-2 | 关联 #995 #1870 |
+| PR-8 | EST(RFC 7030) 框架注册前端 | runtime/http | US3 | ~1600 | PR-5, PR-6, PR-2 | 关联 #995 |
+| PR-9 | iotdevice 迁移 + `rotate-cert` 真契约 + 设备 enqueue RBAC | examples | US5 | ~1800 | PR-4, PR-6, PR-7 | **关闭 #654**，关联 #1870 |
+| PR-10 | composition wiring + bootstrap option + readyz + docs/ops | cellmodules | US2/3 | ~1100 | PR-6,7,8,9 | 关联 #1085 |
+| PR-11 | 跨层 ADR 收口 + 扇出闭环 + 治理 invariant 汇总 | 治理 | US6 | ~700 | all | 关联 #995 |
+
+**总估算 ~14,100 行 / 11 PR**，平均 ~1280 行/PR。PR-7(~1900) 接受少量超限；实测 >2200 才切（`PR-7a` lifecycle 状态机 / `PR-7b` fencing+多租户 sweep）。
+
+---
+
+## 依赖波次（并行调度）
+
+```mermaid
+graph TD
+    PR1[PR-1 路线图ADR]
+    PR2[PR-2 设备主体签发器 #1811]
+    PR3[PR-3 契约a deviceidentity+devicestate]
+    PR4[PR-4 契约b devicecompliance+remotecommand]
+    PR5[PR-5 certsigning 接口+sealed]
+    PR6[PR-6 softca 软CA]
+    PR7[PR-7 certlifecycle reconciler]
+    PR8[PR-8 EST 前端]
+    PR9[PR-9 iotdevice 迁移]
+    PR10[PR-10 wiring+bootstrap+readyz]
+    PR11[PR-11 ADR收口+治理汇总]
+
+    PR3 --> PR4
+    PR3 --> PR5
+    PR5 --> PR6
+    PR5 --> PR7
+    PR2 --> PR7
+    PR5 --> PR8
+    PR6 --> PR8
+    PR2 --> PR8
+    PR4 --> PR9
+    PR6 --> PR9
+    PR7 --> PR9
+    PR6 --> PR10
+    PR7 --> PR10
+    PR8 --> PR10
+    PR9 --> PR10
+    PR10 --> PR11
+```
+
+| Wave | 可并行 PR | 说明 |
+|------|----------|------|
+| 1 | PR-1, PR-2, PR-3 | ADR / 设备主体 / 契约 a 互不依赖 |
+| 2 | PR-4, PR-5 | 均依赖 PR-3（契约范式/deviceidentity 形状） |
+| 3 | PR-6, PR-7 | 依赖 PR-5（接口）；PR-7 另依赖 PR-2（PrincipalDevice） |
+| 4 | PR-8, PR-9 | PR-8 依赖 5/6/2；PR-9 依赖 4/6/7 |
+| 5 | PR-10, PR-11 | wiring 后收口 |
+
+---
+
+## Phase 0：治理对齐（US6 前置部分）
+
+### PR-1 路线图修订 ADR（设备证书框架化决议）~500 行 · docs-only
+
+**Goal**：把范围决策固化为 ADR，修订 4 份已锁定路线图文档，避免「PKI 不在框架」残留语义与本 epic 冲突。
+
+- [ ] T1.1 新建 `docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md`：决议（证书进框架 / 底座+softca+EST / 4 中立契约 / 设备主体签发器）、对标依据、层放置（runtime+adapter+contracts）、威胁矩阵（私钥边界 / Sign funnel / Authorize-Sign 分离）。
+- [ ] T1.2 修订 `docs/plans/product-roadmap/202604301030-winmdm-prd-on-gocell.md`：pkicell 落点注记（框架底座下移 core，winmdm 仅留 WSTEP/SCEP 前端 + caworkflow）。
+- [ ] T1.3 修订 `202604300900-gocell-as-platform-foundation.md` §3 + `plan-d-...md` §10：plan-D §10「v1.0 前不建 mdm/」加例外注记（本 epic 全落 core，不建 module）。
+- [ ] T1.4 修订 `engineering-baseline/202604300800-final-form-capability-overview.md`：final-form 增列「设备身份与证书底座」能力。
+- [ ] T1.5 更新 #995/#1051/#1052 锚点（评论指针，不重写锚点 body——锚点 body 改由 ADR 承载）。
+
+> **enforcement**：无新静态守卫（docs）；但 ADR 是后续 PR 的威胁矩阵单源。
+
+---
+
+## Phase 1：设备主体地基（US1，硬前置）
+
+### PR-2 生产级设备/super-admin 主体签发器（#1811）~1500 行
+
+**Goal**：补齐生产 authn 铸造 `PrincipalDevice` / super-admin，消除「develop 无生产来源」。
+
+- [ ] T2.1 [TDD] `runtime/auth/deviceprincipal_test.go`：device token → PrincipalDevice（subject/tenant）；super-admin → RowScope=all + 审计；service-token 不派生 device。
+- [ ] T2.2 `runtime/auth/deviceprincipal.go`：设备主体签发器（device token 验证 → 铸造 PrincipalDevice）；wire 到 `injectPrincipalCtxKeys`；写入方同 commit 加 `CTXKEYS-PRINCIPAL-WRITE-CALLER-01` allowlist。
+- [ ] T2.3 super-admin 主体路径 + `RowScope=all` 强制审计（复用 ROWSCOPEALL-AUDIT-FUNNEL-01）。
+- [ ] T2.4 enforcement：`DEVICE-PRINCIPAL-MINT-CALLER-01`（Medium，签发器为唯一 device 主体来源）+ 反向自检；godoc §invariants。
+- [ ] T2.5 概念隔离测试：service ≠ device、callerCellID ≠ device subject。
+
+> **关闭 #1811**。证书 mTLS 派生 PrincipalDevice 为统一终态（PR-8 `/simplereenroll` client-cert 已用）；本 PR 提供 device-token 路径，二者并存。
+
+---
+
+## Phase 2：中立契约（US4）
+
+### PR-3 中立契约 (a)：deviceidentity + devicestate ~1400 行
+
+**Goal**：定义证书/身份之家 `deviceidentity/v1` + 在线态 `devicestate/v1`。
+
+- [ ] T3.1 [TDD] 契约级测试：正常 schema / 参数错误 / 鉴权边界 / path 校验。
+- [ ] T3.2 `contracts/http/deviceidentity/{enroll,renew,revoke,status}/v1/contract.yaml` + schema（PKCS#10/PKCS#7 wire 形状、证书状态）。
+- [ ] T3.3 `contracts/event/deviceidentity/{cert-issued,cert-revoked}/v1/`（L2 outbox 事实 schema）。
+- [ ] T3.4 `contracts/devicestate/v1/`（online/offline/last-seen 查询）。
+- [ ] T3.5 codegen（`gocell generate`）→ generated handler/client/types；slice.yaml `contractUsages` 派生 registration。
+- [ ] T3.6 contract-fanout implementation matrix（contract/generated/cell-slice/tests/docs）。
+
+### PR-4 中立契约 (b)：devicecompliance + remotecommand ~1400 行
+
+**Goal**：定义合规 `devicecompliance/v1`（喂 Authorize 决策的设备态势）+ 远程命令 `remotecommand/v1`（承接既有 enqueue 形状）。依赖 PR-3 的 codegen 范式 + archtest。
+
+- [ ] T4.1 [TDD] 契约级测试（同 PR-3 范式）。
+- [ ] T4.2 `contracts/devicecompliance/v1/`（BitLocker/AV/补丁/防火墙等态势属性查询）。
+- [ ] T4.3 `contracts/command/remotecommand/v1/`：字段形状对齐既有 `command.devicecommand.enqueue.v1`（PR-9 迁移目标）。
+- [ ] T4.4 codegen + slice 派生 + fanout matrix。
+- [ ] T4.5 enforcement：契约 schema reflect-freeze（DTO 字段集冻结）+ active-subscriber 警告（死契约）。
+
+---
+
+## Phase 3：证书签发底座（US2）
+
+### PR-5 `runtime/certsigning` 接口 + sealed 类型 + funnel ~1500 行
+
+**Goal**：定义 CA 接缝 + 协议无关请求模型 + 单一签发 funnel。
+
+- [ ] T5.1 [TDD] `request_test.go`：CertRequest/IssuedCert 包外不可字面量构造（sealed）；唯一构造器校验。
+- [ ] T5.2 `signer.go`：`Signer{ Sign(ctx, CertRequest)(IssuedCert,error); TrustBundle(ctx) }`。
+- [ ] T5.3 `authorizer.go`：`Authorizer{ AuthorizeEnroll(ctx, EnrollmentClaim)(SignConstraints,error) }`——**独立**于 Signer；nil grant fail-closed；SignConstraints（max TTL / 允许 SAN）。
+- [ ] T5.4 `request.go`：`CertRequest`/`IssuedCert`/`DeviceSubject`/`SubjectAltNames`/`KeyUsages` sealed（unexported + 唯一构造器，typed tenant+deviceID 非裸 string）。
+- [ ] T5.5 `revocation.go`：`RevocationStore{ Revoke; RevocationList; Tidy }`。
+- [ ] T5.6 enforcement：`CERT-VALUE-SEALED-CONSTRUCTION-01`（Hard，证书值不可伪造）+ `CERT-SIGN-FUNNEL-01`（Hard/Medium，Sign 唯一签发入口）+ 反向自检；`doc.go` §Enforced invariants。
+- [ ] T5.7 新增 `ERR_CERT_` 前缀注册 + golden（ERRCODE-PREFIX-OWNERSHIP-01）。
+
+### PR-6 `adapters/softca` 内置软 CA ~1700 行
+
+**Goal**：标准库实现 `Signer`+`RevocationStore`，私钥经 `crypto.Signer` 托管**永不出 adapter**。
+
+- [ ] T6.1 [TDD] 集成测试（testcontainers/纯内存）：签发链可验证、续期 epoch+1、吊销入 CRL、TTL clamp。
+- [ ] T6.2 `adapters/softca/go.mod`（per-adapter module，对齐 #1558 拆分）。
+- [ ] T6.3 `ca.go`：CA 层级（root + intermediate）+ key 托管接口（dev mem/file；KMS/HSM 留后续 adapter，明确 no-op 业务理由）。
+- [ ] T6.4 `signer.go`：实现 `certsigning.Signer`（`x509.CreateCertificate` + SignConstraints 强制）。
+- [ ] T6.5 `revocation.go`：实现 `RevocationStore`（`x509.CreateRevocationList` + tidy）。
+- [ ] T6.6 enforcement：`CERT-PRIVATE-KEY-CUSTODY-01`（Hard/Medium，原始私钥不跨 certsigning 边界，archtest 扫 adapter 外无 PrivateKey 字段）+ 反向自检。
+
+### PR-7 `runtime/certlifecycle` 生命周期 reconciler ~1900 行 ⚠
+
+**Goal**：把 iotdevice 种子泛化为可复用 `reconcile.Reconciler`，驱动证书生命周期状态机，复用 `kernel/reconcile.Loop` + `runtime/command`。依赖 PR-5（接口）+ PR-2（PrincipalDevice）。
+
+- [ ] T7.1 [TDD] `reconciler_test.go`：requested→issued→active→near-expiry→renewing→{rotated|revoked|expired} 转换；签名失败不损坏既有证书；fail-closed deny 不签发。
+- [ ] T7.2 [TDD] `reconciler_loop_test.go`：resync-all sweep 有界扫描；多副本 `LeaseToken.Epoch` fencing；队列 active-uniqueness 至多一次有效签发。
+- [ ] T7.3 `reconciler.go`：`reconcile.Reconciler` 实现；`clock.Clock` 位置参 + `MustHaveClock`；jitter 续期（k8s 70-90% 模型）；Authorize→Sign→persist→emit `cert-issued` L2。
+- [ ] T7.4 `repository.go`：`DeviceCertRepository`（scan near-expiry by cutoff / persist epoch+cert / mark）接口。
+- [ ] T7.5 **多租户维度**：scan + 命令 key + 签发请求自带 tenant（system identity 清空 tenant，#1821 caveat）。
+- [ ] T7.6 enforcement：复用 `RECONCILE-FENCED-WRITE-FUNNEL-01`（Hard）；新增 `CERTLIFECYCLE-SIGN-VIA-FUNNEL-01`（Medium，生命周期只经 certsigning.Signer 签发）+ 反向自检；`doc.go`。
+
+---
+
+## Phase 4：协议前端 + 消费方迁移（US3/US5）
+
+### PR-8 EST(RFC 7030) 框架注册前端 ~1600 行
+
+**Goal**：框架级 EST 端点，wiring Authorizer→Signer。依赖 PR-5/6/2。
+
+- [ ] T8.1 [TDD] handler 测试：`/simpleenroll` 200 PKCS#7、畸形/越权 CSR 4xx、缺鉴权 401/403、`/cacerts` 返回信任根。
+- [ ] T8.2 `runtime/http/est/handler.go`：`/cacerts`·`/simpleenroll`·`/simplereenroll`（PKCS#10 in / PKCS#7 out）。
+- [ ] T8.3 鉴权两路径：首次=bootstrap/设备凭证（PR-2），续期=现证书 mTLS client-auth（`runtime/http/middleware/mtls` + PeerIdentity）。
+- [ ] T8.4 EST 契约（`auth.Route` 声明 + bootstrap 豁免边界，对齐 FMT-28/bootstrap path 约定）。
+- [ ] T8.5 enforcement：`EST-ENROLL-AUTH-BOUNDARY-01`（Medium，enroll/reenroll 鉴权路径显式声明，缺则 fail-closed）+ 反向自检。
+
+### PR-9 iotdevice 迁移 + `rotate-cert` 真契约 + 设备 enqueue RBAC ~1800 行
+
+**Goal**：示例端到端切到框架证书底座，证明接缝。依赖 PR-4/6/7。
+
+- [ ] T9.1 [TDD] iotdevice 集成：注册→softca 签真实初始证书→近期过期→certlifecycle 续期→新证书生效。
+- [ ] T9.2 `deviceregister` 经 `certsigning.Signer` 签真实初始证书（替代仅 stamp `cert_expires_at`）。
+- [ ] T9.3 `devicecertrenewal` slice 退役 / 重接 `certlifecycle`（删字符串 `rotate-cert`，无 shim）。
+- [ ] T9.4 `command.deviceidentity.rotate.v1` 真契约取代 bare-string `CommandType="rotate-cert"`；fanout matrix。
+- [ ] T9.5 设备粒度 enqueue 授权（#654）：设备不可操作他设备命令（`auth.RequirePermission` + RowScope=device，无 role-literal）。
+- [ ] T9.6 迁移：devices 行证书列 + migration（cert material 持久化）；删除退役列（只增不改例外须 ADR 注记）。
+
+> **关闭 #654**；**关联 #1870**（cert terminal-feedback——续期释放主路径基础留 PR-7 时间窗 + 本 PR 真契约 terminal 态）。
+
+---
+
+## Phase 5：装配 + 收口（US2/3/US6）
+
+### PR-10 composition wiring + bootstrap option + readyz + docs/ops ~1100 行
+
+**Goal**：把证书底座装配进 composition root，对外暴露 option + readyz + 运维文档。依赖 PR-6/7/8/9。
+
+- [ ] T10.1 [TDD] bootstrap option fail-fast 测试（缺 Signer fail-fast，不静默 noop）。
+- [ ] T10.2 `bootstrap.WithCertSigner` / `WithCertLifecycle` option（强依赖 fail-fast）；cellmodules 绑定 softca↔certsigning。
+- [ ] T10.3 readyz probe：`certsigner_ready`（CA 可用性，复合 readyz）。
+- [ ] T10.4 metrics cell label（closed set）+ cert 签发/吊销/续期 metric（typed enum 入口）。
+- [ ] T10.5 docs/ops：cert 运维 runbook（CA 轮换 / CRL 发布 / 续期监控）+ quickstart。
+
+### PR-11 跨层 ADR 收口 + 扇出闭环 + 治理 invariant 汇总 ~700 行
+
+**Goal**：收口跨层 ADR、扇出、治理 invariant 汇总 + 威胁矩阵复检。依赖 all。
+
+- [ ] T11.1 跨层 ADR：证书底座完整威胁矩阵（私钥边界 / Sign funnel / Authorize-Sign 分离 / lifecycle fencing / EST 鉴权）。
+- [ ] T11.2 治理 invariant 汇总文档（CERT-* 族 ID / 评级 / 盲区写入对应 archtest godoc）。
+- [ ] T11.3 `make verify` 全绿；每条 invariant 反向自检 + anti-vacuity。
+- [ ] T11.4 复检 PR-1 ADR 威胁矩阵 vs 实现；冲突段落重写（AI-robust §审查）。
+- [ ] T11.5 收口 #995（评论结论 + 关闭）；更新 status-board / journey（如新增 J-deviceenroll）。
+
+---
+
+## Dependencies & Execution Order
+
+### 关键路径
+
+`PR-3 → PR-5 → PR-6/7 → PR-8/9 → PR-10 → PR-11`（约 5 wave）。PR-1（ADR）+ PR-2（设备主体）可与 PR-3 并行起跑。
+
+### Within Each PR
+
+- TDD：先写 `*_test.go`，FAIL→实现。
+- sealed 类型/接口 before 实现 before wiring。
+- 每 PR 守卫 + 反向自检 + godoc/ADR **同 PR 闭环**。
+
+### 风险点
+
+- **PR-7 体量**（~1900）：实测 >2200 切 `PR-7a`（状态机）/`PR-7b`（fencing+多租户 sweep），不重排编号。
+- **PR-9 破坏式迁移**：删字符串命令 + 退役列，须 fanout matrix + migration ADR 注记。
+- **私钥边界**贯穿 PR-5/6/7/8：每个触及证书材料的 PR 守 `CERT-PRIVATE-KEY-CUSTODY-01`。
+
+## Notes
+
+- 行数估算含测试；超限以实测 `git diff --shortstat origin/develop` 为准。
+- [Story] 映射：PR-1/11→US6，PR-2→US1，PR-3/4→US4，PR-5/6/7→US2，PR-8→US3，PR-9→US5，PR-10→US2/3。
+- 每 PR 经 ship→review→fix→check 流程；契约 PR 出 implementation matrix。

--- a/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
@@ -123,7 +123,7 @@ graph TD
 - [ ] T3.1 [TDD] 契约级测试：正常 schema / 参数错误 / 鉴权边界 / path 校验。
 - [ ] T3.2 `contracts/http/deviceidentity/{enroll,renew,revoke,status}/v1/contract.yaml` + schema（PKCS#10/PKCS#7 wire 形状、证书状态）。
 - [ ] T3.3 `contracts/event/deviceidentity/{cert-issued,cert-revoked}/v1/`（L2 outbox 事实 schema）。
-- [ ] T3.4 `contracts/devicestate/v1/`（online/offline/last-seen 查询）。
+- [ ] T3.4 `contracts/http/devicestate/v1/`（online/offline/last-seen 查询）。
 - [ ] T3.5 codegen（`gocell generate`）→ generated handler/client/types；slice.yaml `contractUsages` 派生 registration。
 - [ ] T3.6 contract-fanout implementation matrix（contract/generated/cell-slice/tests/docs）。
 
@@ -132,7 +132,7 @@ graph TD
 **Goal**：定义合规 `devicecompliance/v1`（喂 Authorize 决策的设备态势）+ 远程命令 `remotecommand/v1`（承接既有 enqueue 形状）。依赖 PR-3 的 codegen 范式 + archtest。
 
 - [ ] T4.1 [TDD] 契约级测试（同 PR-3 范式）。
-- [ ] T4.2 `contracts/devicecompliance/v1/`（BitLocker/AV/补丁/防火墙等态势属性查询）。
+- [ ] T4.2 `contracts/http/devicecompliance/v1/`（BitLocker/AV/补丁/防火墙等态势属性查询）。
 - [ ] T4.3 `contracts/command/remotecommand/v1/`：字段形状对齐既有 `command.devicecommand.enqueue.v1`（PR-9 迁移目标）。
 - [ ] T4.4 codegen + slice 派生 + fanout matrix。
 - [ ] T4.5 enforcement：契约 schema reflect-freeze（DTO 字段集冻结）+ active-subscriber 警告（死契约）。

--- a/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
@@ -148,9 +148,9 @@ graph TD
 - [ ] T5.1 [TDD] `request_test.go`：CertRequest/IssuedCert 包外不可字面量构造（sealed）；唯一构造器校验。
 - [ ] T5.2 `signer.go`：`Signer{ Sign(ctx, CertRequest)(IssuedCert,error); TrustBundle(ctx) }`。
 - [ ] T5.3 `authorizer.go`：`Authorizer{ AuthorizeEnroll(ctx, EnrollmentClaim)(SignConstraints,error) }`——**独立**于 Signer；nil grant fail-closed；SignConstraints（max TTL / 允许 SAN）。
-- [ ] T5.4 `request.go`：`CertRequest`/`IssuedCert`/`DeviceSubject`/`SubjectAltNames`/`KeyUsages` sealed（unexported + 唯一构造器，typed tenant+deviceID 非裸 string）。
-- [ ] T5.5 `revocation.go`：`RevocationStore{ Revoke; RevocationList; Tidy }`。
-- [ ] T5.6 enforcement：`CERT-VALUE-SEALED-CONSTRUCTION-01`（Hard，证书值不可伪造）+ `CERT-SIGN-FUNNEL-01`（funnel：上游 Hard = CertRequest/IssuedCert sealed 构造；下游 Medium = archtest 扫单一 Sign callsite）+ 反向自检；`doc.go` §Enforced invariants。
+- [ ] T5.4 `request.go`：`CertScope`（`{tenant,issuer,device}`，Sign/Revoke/List 共用）/`CertRequest`/`IssuedCert`/`DeviceSubject`/`SubjectAltNames`/`KeyUsages` sealed（unexported + 唯一构造器，typed tenant+issuer+device 非裸 string/serial）。
+- [ ] T5.5 `revocation.go`：`RevocationStore{ Revoke(ctx,CertScope,serial,reason); RevocationList(ctx,CertScope); Tidy(ctx,CertScope,before) }`——`CertScope` 强制 typed 位置参（漏传编译错 Hard）；跨租户/issuer fail-closed。
+- [ ] T5.6 enforcement：`CERT-VALUE-SEALED-CONSTRUCTION-01`（Hard，证书值不可伪造）+ `CERT-SIGN-FUNNEL-01`（funnel：上游 Hard = CertRequest/IssuedCert sealed 构造；下游 Medium = archtest 扫单一 Sign callsite）+ `CERT-REVOKE-SCOPED-01`（Hard，Revoke/RevocationList 带 `CertScope` typed 位置参，漏传编译错——对齐 tenant typed-param 范式）+ 反向自检；`doc.go` §Enforced invariants。
 - [ ] T5.7 新增 `ERR_CERT_` 前缀注册 + golden（ERRCODE-PREFIX-OWNERSHIP-01）。
 
 ### PR-6 `adapters/softca` 内置软 CA ~1700 行
@@ -181,13 +181,13 @@ graph TD
 
 ### PR-8 EST(RFC 7030) 框架注册前端 ~1600 行
 
-**Goal**：框架级 EST 端点，wiring Authorizer→Signer。依赖 PR-5/6/2。
+**Goal**：框架级 EST 端点，挂**版本化 cell 路径** `/api/v{N}/deviceidentity/est/*`，wiring Authorizer→Signer。依赖 PR-5/6/2。
 
-- [ ] T8.1 [TDD] handler 测试：`/simpleenroll` 200 PKCS#7、畸形/越权 CSR 4xx、缺鉴权 401/403、`/cacerts` 返回信任根。
-- [ ] T8.2 `runtime/http/est/handler.go`：`/cacerts`·`/simpleenroll`·`/simplereenroll`（PKCS#10 in / PKCS#7 out）。
-- [ ] T8.3 鉴权两路径：首次=bootstrap/设备凭证（PR-2），续期=现证书 mTLS client-auth（`runtime/http/middleware/mtls` + PeerIdentity）。
-- [ ] T8.4 EST 契约（`auth.Route` 声明 + bootstrap 豁免边界，对齐 FMT-28/bootstrap path 约定）。
-- [ ] T8.5 enforcement：`EST-ENROLL-AUTH-BOUNDARY-01`（Medium，enroll/reenroll 鉴权路径显式声明，缺则 fail-closed）+ 反向自检。
+- [ ] T8.1 [TDD] handler 测试：`/simpleenroll` 200 PKCS#7、畸形/越权 CSR 4xx、缺鉴权 / setup-bootstrap 冒充 401/403、`/cacerts` 返回信任根。
+- [ ] T8.2 `runtime/http/est/handler.go`：`cacerts`·`simpleenroll`·`simplereenroll`（PKCS#10 in / PKCS#7 out），挂 `/api/v{N}/deviceidentity/est/*`（**非顶级裸路径**，对齐 api-versioning「端点挂所属 cell 版本前缀」）。
+- [ ] T8.3 鉴权两路径：首次=**专用 enrollment-credential / device-token**（PR-2 设备主体，**非** setup `auth.bootstrap:true`），续期=现证书 mTLS client-auth（`runtime/http/middleware/mtls` + PeerIdentity）。
+- [ ] T8.4 EST `auth.Route` 声明：显式 enrollment-credential / mTLS scheme；**不**声明 `auth.bootstrap:true`（FMT-28 限其只在 `^/api/v\d+/[^/]+/setup/admin$`，EST 非该路径，复用 fail-closed）。
+- [ ] T8.5 enforcement：`EST-ENROLL-AUTH-BOUNDARY-01`（Medium，enroll/reenroll 鉴权路径显式声明 + 禁 setup-bootstrap 凭据复用，缺则 fail-closed）+ 反向自检。
 
 ### PR-9 iotdevice 迁移 + `rotate-cert` 真契约 + 设备 enqueue RBAC ~1800 行
 

--- a/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
@@ -34,7 +34,7 @@ description: "PR decomposition & dependency graph for 1895-device-identity-cert-
 | PR-10 | composition wiring + bootstrap option + readyz + docs/ops | cellmodules | US2/3 | ~1100 | PR-6,7,8,9 | 关联 #1085 |
 | PR-11 | 跨层 ADR 收口 + 扇出闭环 + 治理 invariant 汇总 | 治理 | US6 | ~700 | all | 关联 #995 |
 
-**总估算 ~14,100 行 / 11 PR**，平均 ~1280 行/PR。PR-7(~1900) 接受少量超限；实测 >2200 才切（`PR-7a` lifecycle 状态机 / `PR-7b` fencing+多租户 sweep）。
+**总估算 ~15,100 行 / 11 PR**，平均 ~1370 行/PR。PR-7(~1900) 接受少量超限；实测 >2200 才切（`PR-7a` lifecycle 状态机 / `PR-7b` fencing+多租户 sweep）。
 
 ---
 
@@ -150,7 +150,7 @@ graph TD
 - [ ] T5.3 `authorizer.go`：`Authorizer{ AuthorizeEnroll(ctx, EnrollmentClaim)(SignConstraints,error) }`——**独立**于 Signer；nil grant fail-closed；SignConstraints（max TTL / 允许 SAN）。
 - [ ] T5.4 `request.go`：`CertRequest`/`IssuedCert`/`DeviceSubject`/`SubjectAltNames`/`KeyUsages` sealed（unexported + 唯一构造器，typed tenant+deviceID 非裸 string）。
 - [ ] T5.5 `revocation.go`：`RevocationStore{ Revoke; RevocationList; Tidy }`。
-- [ ] T5.6 enforcement：`CERT-VALUE-SEALED-CONSTRUCTION-01`（Hard，证书值不可伪造）+ `CERT-SIGN-FUNNEL-01`（Hard/Medium，Sign 唯一签发入口）+ 反向自检；`doc.go` §Enforced invariants。
+- [ ] T5.6 enforcement：`CERT-VALUE-SEALED-CONSTRUCTION-01`（Hard，证书值不可伪造）+ `CERT-SIGN-FUNNEL-01`（funnel：上游 Hard = CertRequest/IssuedCert sealed 构造；下游 Medium = archtest 扫单一 Sign callsite）+ 反向自检；`doc.go` §Enforced invariants。
 - [ ] T5.7 新增 `ERR_CERT_` 前缀注册 + golden（ERRCODE-PREFIX-OWNERSHIP-01）。
 
 ### PR-6 `adapters/softca` 内置软 CA ~1700 行
@@ -162,7 +162,7 @@ graph TD
 - [ ] T6.3 `ca.go`：CA 层级（root + intermediate）+ key 托管接口（dev mem/file；KMS/HSM 留后续 adapter，明确 no-op 业务理由）。
 - [ ] T6.4 `signer.go`：实现 `certsigning.Signer`（`x509.CreateCertificate` + SignConstraints 强制）。
 - [ ] T6.5 `revocation.go`：实现 `RevocationStore`（`x509.CreateRevocationList` + tidy）。
-- [ ] T6.6 enforcement：`CERT-PRIVATE-KEY-CUSTODY-01`（Hard/Medium，原始私钥不跨 certsigning 边界，archtest 扫 adapter 外无 PrivateKey 字段）+ 反向自检。
+- [ ] T6.6 enforcement：`CERT-PRIVATE-KEY-CUSTODY-01`（custody：上游 Hard = `Signer` 接口不暴露 key getter；下游 Medium = archtest 扫 certsigning 边界外无 PrivateKey 字段）+ 反向自检。
 
 ### PR-7 `runtime/certlifecycle` 生命周期 reconciler ~1900 行 ⚠
 


### PR DESCRIPTION
## Summary

EPIC #1895 PR-1（治理/docs）：落地「设备证书成为框架的一部分」的**路线图修订 ADR** + 4 份已锁定路线图文档的冲突段落重写 + speckit 规格四件套（spec/plan/tasks/research）。纯文档，~775 行。

## Why / 背景

设备证书今天只存在于 `examples/iotdevice`（扫 `cert_expires_at` 发 `rotate-cert` 字符串命令，**零 PKI 代码**）。已锁定路线图（2026-04-30）把 PKI 定位为消费方自建（#995「不在框架」/ winmdm `pkicell` 落 `mdm` module / 门控 2027 Q1）。本轮决策**转向**：设备证书提升为框架能力（底座 + 内置软 CA + EST 前端），MDM/ZT 展开前期工作（4 中立契约 + 设备主体签发器 #1811）。该转向**推翻已锁定决策**，故先以 ADR 显式修订路线图、重评威胁矩阵，不静默改（AI-robust §审查 + 「先沟通再落文档」）。

本 PR 同时把 ship→speckit 探索/分析产物（spec/plan/tasks/research）随 epic 落库，作为后续 10 个 PR 的真值源。

## Refs

- EPIC #1895；本 PR Closes #1897
- 收口 #995（X.509 框架化评估 → 结论进框架）；部分提前 #1051 / #1052（4 中立契约 + PKI 原语下移 core）；硬前置 #1811（PR-2 落地）
- 新增 ADR：`docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md`
- 修订：winmdm PRD / gocell-as-platform §3·§4 / plan-d §10 / final-form overview §3.7
- speckit 规格：`docs/plans/specs/1895-device-identity-cert-framework/`（spec/plan/tasks/research）
- 对标：SPIFFE/SPIRE · cert-manager · smallstep step-ca · IETF RFC 7030（EST）

## Risk / 兼容性

- **无代码 / wire 变更**（docs-only）。
- 推翻一条已锁定路线图决策（#995）+ 修订 4 份路线图文档冲突段落——已在 ADR 威胁矩阵表逐条记录修订点；与 gocell-platform §3.7「pkicell WSTEP 作为 v1.0 P0」**一致**（消解 #995 张力）。
- plan-d §10「禁止预建 mdm/」**不违反**——证书底座全落 core（runtime/adapters/contracts）。

## Test plan

- [x] docs-only，无 Go 变更（`go build` / `go test` / `golangci-lint` N/A）
- [x] ADR 文件名符合 `yyyyMMddHHmm-编号-...` 约定（`202606121500-1895-adr-...`）
- [x] 无 ADR 索引 / 中央 registry 需同步（已核查）
- [x] 4 处路线图修订均加 `#1895/ADR-1895` 指针，冲突段落同改动重写
