### PR TITLE
refactor(tenancy): LoginInput/CreateAdminInput.TenantID typed tenant.TenantID; parse 上移 handler [#1545]

### DIFF
--- a/contracts/http/auth/login/v1/contract.yaml
+++ b/contracts/http/auth/login/v1/contract.yaml
@@ -33,10 +33,11 @@ endpoints:
     headers:
       # X-Tenant-ID carries the pre-login tenant scope (no JWT exists yet).
       # Populate-only at codegen → merged into the generated Request field; the
-      # sessionlogin Service then applies a two-stage check (ADR 1160; the
-      # per-endpoint fail behavior is adapter/service-owned, not a codegen gate):
-      #   - absent header (empty value) → 400 ERR_AUTH_LOGIN_INVALID_INPUT
-      #     (RequireNotEmpty): a malformed request, not a tenant-existence probe.
+      # sessionlogin LoginAdapter (handler) then applies a two-stage check before
+      # delegating to Service.Login, which receives a canonical typed
+      # tenant.TenantID and trusts it (ADR 1160; adapter-owned fail, not a codegen gate):
+      #   - absent header (empty value) → 400 ERR_AUTH_LOGIN_INVALID_INPUT:
+      #     a malformed request, not a tenant-existence probe.
       #   - present but non-canonical UUID → 401 (ErrAuthLoginFailed), the same
       #     opaque shape as wrong-password, to prevent tenant enumeration.
       X-Tenant-ID:

--- a/contracts/http/auth/setup/admin/v1/contract.yaml
+++ b/contracts/http/auth/setup/admin/v1/contract.yaml
@@ -16,10 +16,10 @@ endpoints:
     headers:
       # X-Tenant-ID carries the pre-bootstrap tenant scope (no JWT yet).
       # Populate-only at codegen → merged into the generated Request field; the
-      # setup admin adapter passes it to CreateAdminInput.TenantID, whose
-      # service-layer tenant.ParseTenantID validation rejects a missing/malformed
-      # value with 400 ERR_AUTH_IDENTITY_INVALID_INPUT (ADR 1160 — adapter-owned
-      # fail, not a codegen gate).
+      # setup admin AdminAdapter (handler) parses it via tenant.ParseTenantID and
+      # rejects a missing/malformed value with 400 ERR_AUTH_IDENTITY_INVALID_INPUT
+      # (ADR 1160 — adapter-owned fail, not a codegen gate); Service.CreateAdmin
+      # receives a canonical typed CreateAdminInput.TenantID and trusts it.
       X-Tenant-ID:
         type: string
         format: uuid

--- a/corecells/accesscore/slices/identitymanage/changepassword_e2e_test.go
+++ b/corecells/accesscore/slices/identitymanage/changepassword_e2e_test.go
@@ -264,7 +264,7 @@ func TestChangePassword_FullFlow(t *testing.T) {
 	loginPair, err := f.loginSvc.Login(context.Background(), sessionlogin.LoginInput{
 		Username: "e2e-admin",
 		Password: bootstrapPassword,
-		TenantID: string(e2eTestTenantID),
+		TenantID: e2eTestTenantID,
 	})
 	require.NoError(t, err)
 	assert.True(t, loginPair.PasswordResetRequired,

--- a/corecells/accesscore/slices/sessionlogin/handler.go
+++ b/corecells/accesscore/slices/sessionlogin/handler.go
@@ -41,6 +41,8 @@ func (a LoginAdapter) Login(ctx context.Context, req *logingen.Request) (loginge
 	}
 	tid, perr := tenant.ParseTenantID(req.XTenantID)
 	if perr != nil {
+		// errMsgInvalidCredentials is defined in service.go (same package); reused here so the
+		// malformed-tenant 401 is byte-identical to the wrong-password 401 (non-enumerable, ADR 1160).
 		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthLoginFailed, errMsgInvalidCredentials,
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("invalid tenantId: %v", perr))))
 	}

--- a/corecells/accesscore/slices/sessionlogin/handler.go
+++ b/corecells/accesscore/slices/sessionlogin/handler.go
@@ -2,6 +2,7 @@ package sessionlogin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -9,8 +10,14 @@ import (
 	"github.com/ghbvf/gocell/corecells/accesscore/internal/httpcookie"
 	logingen "github.com/ghbvf/gocell/generated/contracts/http/auth/login/v1"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/runtime/http/cellmw"
 )
+
+// errMsgTenantIDRequired is the error message for a missing (empty) X-Tenant-ID
+// header on the login endpoint. Must be a const literal (MESSAGE-CONST-LITERAL-01).
+const errMsgTenantIDRequired = "tenantId is required"
 
 // LoginAdapter implements logingen.Service for http.auth.login.v1.
 // It adapts the slice-internal Service (Login takes LoginInput) to the
@@ -21,19 +28,26 @@ type LoginAdapter struct{ S *Service }
 
 // Login implements logingen.Service. The generated handler validates and decodes
 // username+password from the request body and populates req.XTenantID from the
-// X-Tenant-ID header (populate-only — no codegen gate). The tenant header drives
-// a two-stage validation inside Service.Login:
+// X-Tenant-ID header (populate-only — no codegen gate). Two-stage tenant
+// validation runs in this adapter before delegating to Service.Login:
 //
-//   - Absent header (empty string): validation.RequireNotEmpty rejects with 400
-//     (ErrAuthLoginInvalidInput) before any authentication work is attempted.
-//   - Present but malformed UUID: tenant.ParseTenantID rejects with a uniform 401
-//     (ErrAuthLoginFailed), the same shape as wrong-password, to prevent tenant
-//     enumeration (ADR 1160).
+//   - Absent header (empty string): returns 400 ErrAuthLoginInvalidInput.
+//   - Present but malformed UUID: tenant.ParseTenantID fails → returns 401
+//     ErrAuthLoginFailed, the same shape as wrong-password (non-enumerable,
+//     ADR 1160).
 func (a LoginAdapter) Login(ctx context.Context, req *logingen.Request) (logingen.LoginResponseObject, error) {
+	if req.XTenantID == "" {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrAuthLoginInvalidInput, errMsgTenantIDRequired)
+	}
+	tid, perr := tenant.ParseTenantID(req.XTenantID)
+	if perr != nil {
+		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthLoginFailed, errMsgInvalidCredentials,
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("invalid tenantId: %v", perr))))
+	}
 	pair, err := a.S.Login(ctx, LoginInput{
 		Username: req.Username,
 		Password: req.Password,
-		TenantID: req.XTenantID,
+		TenantID: tid,
 	})
 	if err != nil {
 		return nil, err

--- a/corecells/accesscore/slices/sessionlogin/handler_test.go
+++ b/corecells/accesscore/slices/sessionlogin/handler_test.go
@@ -280,6 +280,21 @@ func TestHandler_Login_SetsRefreshCookie(t *testing.T) {
 	assert.Equal(t, int(testCookieTTL.Seconds()), rtCookie.MaxAge, "cookie MaxAge must match cookieTTL arg")
 }
 
+// TestHandler_Login_MalformedTenant_Returns401 locks in the moved two-stage
+// tenant validation: a present-but-malformed X-Tenant-ID (not a canonical UUID)
+// must return 401 ErrAuthLoginFailed (non-enumerable, ADR 1160), not 400.
+func TestHandler_Login_MalformedTenant_Returns401(t *testing.T) {
+	h := setup(t)
+	body := `{"username":"alice","password":"correct-pass"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, loginPath, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "not-a-uuid")
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assertValidationError(t, w.Body.Bytes(), "ERR_AUTH_LOGIN_FAILED")
+}
+
 // TestHandler_Login_NoCookieOn401 asserts that a failed login (401) does NOT
 // emit a __Host-gocell_rt cookie — a 4xx must neither mint nor clear the cookie.
 func TestHandler_Login_NoCookieOn401(t *testing.T) {

--- a/corecells/accesscore/slices/sessionlogin/handler_test.go
+++ b/corecells/accesscore/slices/sessionlogin/handler_test.go
@@ -182,8 +182,9 @@ func TestHandleLogin(t *testing.T) {
 }
 
 // TestHandler_Login_MissingTenantHeader verifies that a request without the
-// X-Tenant-ID header returns 400 (the service treats an empty tenantId as
-// ErrAuthLoginInvalidInput via RequireNotEmpty).
+// X-Tenant-ID header returns 400 ErrAuthLoginInvalidInput. The HANDLER
+// short-circuits before the service when the X-Tenant-ID header is absent,
+// returning 400 without ever delegating to Service.Login.
 func TestHandler_Login_MissingTenantHeader(t *testing.T) {
 	h := setup(t)
 	body := `{"username":"alice","password":"correct-pass"}`
@@ -200,13 +201,23 @@ func TestHandler_Login_MissingTenantHeader(t *testing.T) {
 // expected error code (from the generated handler's schema validation).
 func assertValidationError(t *testing.T, body []byte, wantCode string) {
 	t.Helper()
+	code, _ := extractErrorCodeAndMessage(t, body)
+	assert.Equal(t, wantCode, code)
+}
+
+// extractErrorCodeAndMessage parses the {"error":{"code":"...","message":"..."}}
+// wire envelope and returns (code, message). Used by non-enumeration tests to
+// assert byte-identical shapes across different 401 paths (ADR 1160).
+func extractErrorCodeAndMessage(t *testing.T, body []byte) (code, message string) {
+	t.Helper()
 	var resp struct {
 		Error struct {
-			Code string `json:"code"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
 		} `json:"error"`
 	}
 	require.NoError(t, json.Unmarshal(body, &resp))
-	assert.Equal(t, wantCode, resp.Error.Code)
+	return resp.Error.Code, resp.Error.Message
 }
 
 // TestHandler_Login_BlankUsername verifies that submitting an empty username
@@ -283,16 +294,40 @@ func TestHandler_Login_SetsRefreshCookie(t *testing.T) {
 // TestHandler_Login_MalformedTenant_Returns401 locks in the moved two-stage
 // tenant validation: a present-but-malformed X-Tenant-ID (not a canonical UUID)
 // must return 401 ErrAuthLoginFailed (non-enumerable, ADR 1160), not 400.
+//
+// Non-enumeration invariant (ADR 1160): the malformed-tenant 401 response body
+// must be IDENTICAL to the wrong-password 401 so an attacker cannot distinguish
+// the two cases. This test asserts both responses share the same error.code AND
+// error.message (byte-identical shape).
 func TestHandler_Login_MalformedTenant_Returns401(t *testing.T) {
 	h := setup(t)
-	body := `{"username":"alice","password":"correct-pass"}`
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, loginPath, strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Tenant-ID", "not-a-uuid")
-	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assertValidationError(t, w.Body.Bytes(), "ERR_AUTH_LOGIN_FAILED")
+
+	// Malformed-tenant 401: present but not a valid UUID.
+	malformedBody := `{"username":"alice","password":"correct-pass"}`
+	wMalformed := httptest.NewRecorder()
+	reqMalformed := httptest.NewRequest(http.MethodPost, loginPath, strings.NewReader(malformedBody))
+	reqMalformed.Header.Set("Content-Type", "application/json")
+	reqMalformed.Header.Set("X-Tenant-ID", "not-a-uuid")
+	h.ServeHTTP(wMalformed, reqMalformed)
+	assert.Equal(t, http.StatusUnauthorized, wMalformed.Code)
+	malformedCode, malformedMsg := extractErrorCodeAndMessage(t, wMalformed.Body.Bytes())
+	assert.Equal(t, "ERR_AUTH_LOGIN_FAILED", malformedCode)
+
+	// Wrong-password 401: valid tenant, correct username, wrong password.
+	wrongPwBody := `{"username":"alice","password":"wrong-password"}`
+	wWrongPw := httptest.NewRecorder()
+	reqWrongPw := httptest.NewRequest(http.MethodPost, loginPath, strings.NewReader(wrongPwBody))
+	reqWrongPw.Header.Set("Content-Type", "application/json")
+	reqWrongPw.Header.Set("X-Tenant-ID", testTenantIDStr)
+	h.ServeHTTP(wWrongPw, reqWrongPw)
+	assert.Equal(t, http.StatusUnauthorized, wWrongPw.Code)
+	wrongPwCode, wrongPwMsg := extractErrorCodeAndMessage(t, wWrongPw.Body.Bytes())
+
+	// Non-enumeration: both 401 paths must produce identical error.code and error.message.
+	assert.Equal(t, wrongPwCode, malformedCode,
+		"non-enumeration (ADR 1160): malformed-tenant 401 and wrong-password 401 must have identical error.code")
+	assert.Equal(t, wrongPwMsg, malformedMsg,
+		"non-enumeration (ADR 1160): malformed-tenant 401 and wrong-password 401 must have identical error.message")
 }
 
 // TestHandler_Login_NoCookieOn401 asserts that a failed login (401) does NOT

--- a/corecells/accesscore/slices/sessionlogin/intent_test.go
+++ b/corecells/accesscore/slices/sessionlogin/intent_test.go
@@ -20,7 +20,7 @@ func TestService_Login_IssuesDistinctIntents(t *testing.T) {
 	svc, userRepo := newTestService(t)
 	seedUser(userRepo, "alice", "s3cret!")
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "alice", Password: "s3cret!"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "alice", Password: "s3cret!"})
 	require.NoError(t, err)
 	require.NotNil(t, pair)
 

--- a/corecells/accesscore/slices/sessionlogin/outbox_test.go
+++ b/corecells/accesscore/slices/sessionlogin/outbox_test.go
@@ -122,7 +122,7 @@ func TestService_WithEmitter(t *testing.T) {
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
 	seedUserDirect(userRepo, "alice", string(hash))
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "alice", Password: string(testCredential)})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "alice", Password: string(testCredential)})
 	require.NoError(t, err)
 
 	require.Len(t, ow.entries, 1)
@@ -139,7 +139,7 @@ func TestService_WithTxManager(t *testing.T) {
 	hash, _ := bcrypt.GenerateFromPassword(testCredential, bcrypt.MinCost)
 	seedUserDirect(userRepo, "bob", string(hash))
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "bob", Password: string(testCredential)})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "bob", Password: string(testCredential)})
 	require.NoError(t, err)
 	// PR-3b: Login now uses two RunInTx calls per attempt:
 	//   tx[0] = pre-bcrypt read-tx (GetByUsername, RLS requires GUC)
@@ -185,7 +185,7 @@ func TestPersistSessionWithRefresh_DurableTx_EmitFails_NoExplicitCleanup(t *test
 	seedUserDirect(userRepo, "durable-emit-fail", string(hash))
 
 	_, err := svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr, Username: "durable-emit-fail", Password: string(testCredential),
+		TenantID: testTenantID, Username: "durable-emit-fail", Password: string(testCredential),
 	})
 	require.Error(t, err, "emit failure must propagate as an error")
 
@@ -215,7 +215,7 @@ func TestPersistSessionWithRefresh_NoopTxRunner_EmitFails_CleanupRuns(t *testing
 	seedUserDirect(userRepo, "noop-emit-fail", string(hash))
 
 	_, err := svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr, Username: "noop-emit-fail", Password: string(testCredential),
+		TenantID: testTenantID, Username: "noop-emit-fail", Password: string(testCredential),
 	})
 	require.Error(t, err, "emit failure must propagate as an error")
 

--- a/corecells/accesscore/slices/sessionlogin/security_test.go
+++ b/corecells/accesscore/slices/sessionlogin/security_test.go
@@ -109,15 +109,15 @@ func TestLogin_ErrorPathUniformity(t *testing.T) {
 	}{
 		{
 			name:  "missing user",
-			input: LoginInput{TenantID: testTenantIDStr, Username: "ghost-no-exist", Password: "any-pass"},
+			input: LoginInput{TenantID: testTenantID, Username: "ghost-no-exist", Password: "any-pass"},
 		},
 		{
 			name:  "bad password",
-			input: LoginInput{TenantID: testTenantIDStr, Username: "active-uniform", Password: "wrong-pass"},
+			input: LoginInput{TenantID: testTenantID, Username: "active-uniform", Password: "wrong-pass"},
 		},
 		{
 			name:  "inactive (locked) user",
-			input: LoginInput{TenantID: testTenantIDStr, Username: "locked-uniform", Password: "correct-pass"},
+			input: LoginInput{TenantID: testTenantID, Username: "locked-uniform", Password: "correct-pass"},
 		},
 	}
 
@@ -166,7 +166,7 @@ func TestLogin_InactivePath_BcryptExecuted(t *testing.T) {
 	seedInactiveUser(t, userRepo, "locked-bcrypt-spy", "some-pass", domain.StatusLocked)
 
 	_, err := svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "locked-bcrypt-spy",
 		Password: "some-pass",
 	})
@@ -190,7 +190,7 @@ func TestLogin_MissingUser_BcryptExecuted(t *testing.T) {
 	svc, _ := newTestServiceWithComparer(t, cmp)
 
 	_, err := svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "no-such-user",
 		Password: "any-pass",
 	})
@@ -214,7 +214,7 @@ func TestLogin_InactivePath_NoPublic403(t *testing.T) {
 	seedInactiveUser(t, userRepo, "suspended-403-check", "pass", domain.StatusSuspended)
 
 	_, err := svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "suspended-403-check",
 		Password: "pass",
 	})
@@ -282,7 +282,7 @@ func TestLogin_InactiveInTx_NoPublic403(t *testing.T) {
 	)
 
 	_, loginErr := svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "race-active",
 		Password: "correct",
 	})

--- a/corecells/accesscore/slices/sessionlogin/service.go
+++ b/corecells/accesscore/slices/sessionlogin/service.go
@@ -213,11 +213,11 @@ type LoginInput struct {
 	Username string
 	Password string
 	// TenantID is required for pre-auth user lookup (GetByUsername is
-	// tenant-scoped). Parsed from the HTTP request X-Tenant-ID header by the
-	// handler and validated via tenant.ParseTenantID before constructing this
-	// struct (no JWT exists pre-login, so the header is the only source — see
-	// ADR 1160).
-	TenantID string
+	// tenant-scoped). The handler parses the X-Tenant-ID header via
+	// tenant.ParseTenantID and passes a guaranteed-canonical typed value; the
+	// service no longer re-parses. No JWT exists pre-login, so the header is
+	// the only source (ADR 1160).
+	TenantID tenant.TenantID
 }
 
 // Login authenticates a user and returns a JWT token pair.
@@ -252,26 +252,11 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (dto.TokenPair, e
 		errcode.ErrAuthLoginInvalidInput,
 		validation.F("username", input.Username),
 		validation.F("password", input.Password),
-		validation.F("tenantId", input.TenantID),
 	); err != nil {
 		return dto.TokenPair{}, err
 	}
 
-	// Parse and validate the tenant before any DB access. Fail-closed: a
-	// present-but-malformed tenantId returns 401 (ErrAuthLoginFailed) — the same
-	// error as an invalid credential. This is intentional non-enumerable posture:
-	// callers must not be able to distinguish a valid-but-wrong tenant from a
-	// malformed tenant string, preventing cross-tenant tenant ID enumeration. The
-	// setup handler (setup/handler.go, CreateAdmin) uses the same non-enumerable
-	// design for the same reason. Missing tenantId was already rejected above as
-	// 400 (RequireNotEmpty); only a non-empty but syntactically invalid UUID reaches
-	// this branch.
-	tid, parseErr := tenant.ParseTenantID(input.TenantID)
-	if parseErr != nil {
-		return dto.TokenPair{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthLoginFailed,
-			errMsgInvalidCredentials,
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("invalid tenantId: %v", parseErr))))
-	}
+	tid := input.TenantID
 
 	// Authenticate the password outside the tx (bcrypt is CPU-bound and must
 	// not hold a DB transaction open during the hash comparison). We re-fetch

--- a/corecells/accesscore/slices/sessionlogin/service_test.go
+++ b/corecells/accesscore/slices/sessionlogin/service_test.go
@@ -126,7 +126,7 @@ func TestNewService_IssuerDefaultAudienceWrittenToTokens(t *testing.T) {
 	verifier, err := auth.NewJWTVerifier(testKeySet, clock.Real(), auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "aud-user", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "aud-user", Password: "pass123"})
 	require.NoError(t, err)
 
 	// The access token must carry the audience from the issuer's configured default.
@@ -312,19 +312,19 @@ func TestService_Login(t *testing.T) {
 		{
 			name:    "valid login",
 			setup:   func(r *mem.UserRepository) { seedUser(r, "alice", "pass123") },
-			input:   LoginInput{TenantID: testTenantIDStr, Username: "alice", Password: "pass123"},
+			input:   LoginInput{TenantID: testTenantID, Username: "alice", Password: "pass123"},
 			wantErr: false,
 		},
 		{
 			name:    "wrong password",
 			setup:   func(r *mem.UserRepository) { seedUser(r, "bob", "correct") },
-			input:   LoginInput{TenantID: testTenantIDStr, Username: "bob", Password: "wrong"},
+			input:   LoginInput{TenantID: testTenantID, Username: "bob", Password: "wrong"},
 			wantErr: true,
 		},
 		{
 			name:    "non-existent user",
 			setup:   func(_ *mem.UserRepository) {},
-			input:   LoginInput{TenantID: testTenantIDStr, Username: "ghost", Password: "pass"},
+			input:   LoginInput{TenantID: testTenantID, Username: "ghost", Password: "pass"},
 			wantErr: true,
 		},
 		{
@@ -340,7 +340,7 @@ func TestService_Login(t *testing.T) {
 				u, _ := r.GetByUsername(context.Background(), testTenantID, "locked")
 				_ = r.UpdateLockState(context.Background(), testTenantID, u.ID, domain.StatusLocked, time.Now())
 			},
-			input:   LoginInput{TenantID: testTenantIDStr, Username: "locked", Password: "pass"},
+			input:   LoginInput{TenantID: testTenantID, Username: "locked", Password: "pass"},
 			wantErr: true,
 		},
 	}
@@ -380,7 +380,7 @@ func TestService_Login_DemoMode_ExplicitCleanup_NoOrphanSession(t *testing.T) {
 		WithSessionTTL(time.Hour))
 	seedUser(userRepo, "refresh-down", "pass123")
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "refresh-down", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "refresh-down", Password: "pass123"})
 	require.Error(t, err)
 	assert.Empty(t, pair.AccessToken)
 	var ec *errcode.Error
@@ -403,7 +403,7 @@ func TestService_Login_TokensContainSessionID(t *testing.T) {
 	verifier, err := auth.NewJWTVerifier(testKeySet, clock.Real(), auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "sid-user", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "sid-user", Password: "pass123"})
 	require.NoError(t, err)
 
 	// Access token must contain sid.
@@ -435,7 +435,7 @@ func TestLogin_PasswordResetRequiredFlagPropagated(t *testing.T) {
 	user.SetPasswordResetRequired(true, time.Now())
 	_ = userRepo.Create(context.Background(), testTenantID, user)
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "reset-user", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "reset-user", Password: "pass123"})
 	require.NoError(t, err)
 
 	// TokenPair flag must be true.
@@ -453,7 +453,7 @@ func TestLogin_NoResetWhenFlagFalse(t *testing.T) {
 	svc, userRepo := newTestService(t)
 	seedUser(userRepo, "normal-user", "pass123")
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "normal-user", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "normal-user", Password: "pass123"})
 	require.NoError(t, err)
 
 	assert.False(t, pair.PasswordResetRequired, "TokenPair.PasswordResetRequired must be false for normal user")
@@ -547,12 +547,12 @@ func TestService_Login_BlankFieldsRejected(t *testing.T) {
 	}{
 		{
 			name:        "blank username rejected",
-			input:       LoginInput{TenantID: testTenantIDStr, Username: "", Password: "p"},
+			input:       LoginInput{TenantID: testTenantID, Username: "", Password: "p"},
 			wantMessage: "username",
 		},
 		{
 			name:        "blank password rejected",
-			input:       LoginInput{TenantID: testTenantIDStr, Username: "u", Password: ""},
+			input:       LoginInput{TenantID: testTenantID, Username: "u", Password: ""},
 			wantMessage: "password",
 		},
 	}
@@ -633,7 +633,7 @@ func TestService_Login_RoleFetchFailure_AbortsLogin(t *testing.T) {
 		testIssuer, slog.Default(), WithEmitter(outbox.WrapEmitterForCell(emitter)), WithTxManager(persistence.WrapForCell(&stubTxRunner{})),
 		WithSessionTTL(time.Hour))
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "role-outage", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "role-outage", Password: "pass123"})
 	require.Error(t, err, "Login must fail when role fetch fails")
 	assert.Empty(t, pair.AccessToken, "no token on failure")
 
@@ -701,7 +701,7 @@ func TestService_Login_PublishError_DoesNotFailLogin(t *testing.T) {
 		slog.Default(), WithEmitter(outbox.WrapEmitterForCell(emitter)), WithTxManager(persistence.WrapForCell(&stubTxRunner{})),
 		WithSessionTTL(time.Hour))
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "pub-err", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "pub-err", Password: "pass123"})
 	require.NoError(t, err, "publish failure in demo mode should not fail login")
 	assert.NotEmpty(t, pair.AccessToken)
 }
@@ -746,7 +746,7 @@ func TestPersistSessionWithRefresh_DurableTx_RefreshIssueFails_NoExplicitCleanup
 		WithTxManager(persistence.WrapForCell(tx)), WithSessionTTL(time.Hour))
 	seedUser(userRepo, "durable-refresh-fail", "pass123")
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "durable-refresh-fail", Password: "pass123"})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "durable-refresh-fail", Password: "pass123"})
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -781,7 +781,7 @@ func TestCleanupIssuedSession_Revoke_IdempotentOnAbsent(t *testing.T) {
 	seedUser(userRepo, "cleanup-not-found", "pass123")
 
 	// Should not panic or return an unexpected error — the original refresh issue error propagates.
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "cleanup-not-found", Password: "pass123"})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "cleanup-not-found", Password: "pass123"})
 	require.Error(t, err)
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
@@ -801,10 +801,8 @@ func TestLogin_EmptyCredentials_AuthErrorCode(t *testing.T) {
 		name  string
 		input LoginInput
 	}{
-		{"empty_password", LoginInput{TenantID: testTenantIDStr, Username: "user@example.com", Password: ""}},
-		{"empty_email", LoginInput{TenantID: testTenantIDStr, Username: "", Password: "secret"}},
-		// U14 (#1337 PR-2a review): blank tenantId must also yield ErrAuthLoginInvalidInput.
-		{"blank_tenant_id", LoginInput{TenantID: "", Username: "user@example.com", Password: "secret"}},
+		{"empty_password", LoginInput{TenantID: testTenantID, Username: "user@example.com", Password: ""}},
+		{"empty_email", LoginInput{TenantID: testTenantID, Username: "", Password: "secret"}},
 	}
 
 	for _, tc := range cases {
@@ -840,7 +838,7 @@ func TestLogin_AccessJWT_NoAuthzEpochClaim(t *testing.T) {
 	verifier, err := auth.NewJWTVerifier(testKeySet, clock.Real(), auth.WithExpectedAudiences("gocell"))
 	require.NoError(t, err)
 
-	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "epoch-user", Password: "pass123"})
+	pair, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "epoch-user", Password: "pass123"})
 	require.NoError(t, err)
 
 	claims, err := verifier.VerifyIntent(context.Background(), pair.AccessToken, kauth.TokenIntentAccess)
@@ -861,8 +859,8 @@ func TestLogin_NoLengthOracle(t *testing.T) {
 		name  string
 		input LoginInput
 	}{
-		{"empty_password", LoginInput{TenantID: testTenantIDStr, Username: "user@example.com", Password: ""}},
-		{"empty_email", LoginInput{TenantID: testTenantIDStr, Username: "", Password: "secret"}},
+		{"empty_password", LoginInput{TenantID: testTenantID, Username: "user@example.com", Password: ""}},
+		{"empty_email", LoginInput{TenantID: testTenantID, Username: "", Password: "secret"}},
 	}
 
 	for _, tc := range cases {
@@ -992,7 +990,7 @@ func TestLogin_PasswordVersionRace_OldPasswordRejected(t *testing.T) {
 			)
 
 			pair, loginErr := svc.Login(context.Background(), LoginInput{
-				TenantID: testTenantIDStr,
+				TenantID: testTenantID,
 				Username: "race-user",
 				Password: "old-pass",
 			})
@@ -1063,7 +1061,7 @@ func TestLoginInTx_InfraError_NotCollapsedTo401(t *testing.T) {
 		WithSessionTTL(time.Hour),
 	)
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "r3-user", Password: "pass123"})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "r3-user", Password: "pass123"})
 	require.Error(t, err, "infra error must propagate, not silently succeed")
 
 	var ec *errcode.Error
@@ -1102,7 +1100,7 @@ func TestLoginInTx_NotFound_CollapsedTo401(t *testing.T) {
 		WithSessionTTL(time.Hour),
 	)
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "r3-notfound", Password: "pass123"})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "r3-notfound", Password: "pass123"})
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -1140,7 +1138,7 @@ func TestLoginInTx_UnavailableError_NotCollapsedTo401(t *testing.T) {
 		WithSessionTTL(time.Hour),
 	)
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "r3-unavail", Password: "pass123"})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "r3-unavail", Password: "pass123"})
 	require.Error(t, err)
 
 	var ec *errcode.Error
@@ -1170,7 +1168,7 @@ func TestService_Login_ConsecutiveFailures_TriggersAutoLock(t *testing.T) {
 
 	// 5 consecutive wrong-password logins. Each must return ErrAuthLoginFailed.
 	for i := range failuresNeeded {
-		_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: username, Password: wrongPass})
+		_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: username, Password: wrongPass})
 		require.Error(t, err, "attempt %d: expected error", i+1)
 		var ec *errcode.Error
 		require.ErrorAs(t, err, &ec, "attempt %d: expected errcode.Error", i+1)
@@ -1186,7 +1184,7 @@ func TestService_Login_ConsecutiveFailures_TriggersAutoLock(t *testing.T) {
 
 	// A 6th attempt with the CORRECT password must still return ErrAuthLoginFailed
 	// because the lockout TTL has not elapsed.
-	_, err = svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: username, Password: correctPass})
+	_, err = svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: username, Password: correctPass})
 	require.Error(t, err, "locked user must be rejected even with correct password")
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
@@ -1349,7 +1347,7 @@ func loginWithThresholdLockoutSetup(
 func TestLogin_WrongPassword_CounterPersistsAcrossTx(t *testing.T) {
 	svc, userRepo, tx, uid := loginWithThresholdLockoutSetup(t, "rollback-bob", "correct", domain.StatusActive)
 
-	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "rollback-bob", Password: "wrong"})
+	_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "rollback-bob", Password: "wrong"})
 	require.Error(t, err, "wrong-password must return error to caller")
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
@@ -1381,7 +1379,7 @@ func TestLogin_ThresholdReached_AccountLocks(t *testing.T) {
 	svc, userRepo, tx, uid := loginWithThresholdLockoutSetup(t, "lockchain-eve", password, domain.StatusActive)
 
 	for i := 0; i < accountlockout.Threshold; i++ {
-		_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "lockchain-eve", Password: "wrong"})
+		_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "lockchain-eve", Password: "wrong"})
 		require.Error(t, err, "attempt %d: wrong password rejected", i+1)
 	}
 
@@ -1418,7 +1416,7 @@ func TestLogin_SuspendedUser_DoesNotIncrementCounter(t *testing.T) {
 	// suspended user. None of them should advance the counter or change
 	// the status: a suspended user is not a candidate for auto-lock.
 	for i := 0; i < accountlockout.Threshold+2; i++ {
-		_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantIDStr, Username: "suspended-alice", Password: "wrong"})
+		_, err := svc.Login(context.Background(), LoginInput{TenantID: testTenantID, Username: "suspended-alice", Password: "wrong"})
 		require.Error(t, err, "attempt %d: suspended user rejected", i+1)
 	}
 
@@ -1574,7 +1572,7 @@ func TestLogin_PreBcryptRead_IsRLSScoped(t *testing.T) {
 	seedUser(inner, "rls-test-user", "pass123")
 
 	_, _ = svc.Login(context.Background(), LoginInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "rls-test-user",
 		Password: "pass123",
 	})

--- a/corecells/accesscore/slices/sessionlogin/service_test.go
+++ b/corecells/accesscore/slices/sessionlogin/service_test.go
@@ -1545,6 +1545,33 @@ func (r *scopeCapturingUserRepo) UpdateLockoutFields(ctx context.Context, t tena
 	return r.inner.UpdateLockoutFields(ctx, t, user)
 }
 
+// TestLogin_ZeroTenantID_FailsClosed locks the fail-closed safety net for
+// direct (non-handler) callers of Service.Login. An empty typed TenantID
+// (zero value) must cause Login to fail — it cannot result in a successful
+// authentication — even if a caller somehow bypasses the handler's
+// tenant-parse step. The repo's Validate() backstop ensures that an empty
+// tenant cannot reach a successful user lookup, funneling the empty-tenant
+// path into the same unified 401 ErrAuthLoginFailed returned for wrong
+// passwords (防枚举).
+func TestLogin_ZeroTenantID_FailsClosed(t *testing.T) {
+	svc, userRepo := newTestService(t)
+	seedUser(userRepo, "alice", "correct-pass")
+
+	_, err := svc.Login(context.Background(), LoginInput{
+		TenantID: "", // zero value — bypasses handler parse
+		Username: "alice",
+		Password: "correct-pass",
+	})
+	require.Error(t, err,
+		"zero TenantID must fail closed; successful login must be impossible")
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	// The empty tenant fails the repo RLS-scoped lookup (t.Validate() backstop),
+	// which is treated as a user-not-found credential failure → ErrAuthLoginFailed.
+	assert.Equal(t, errcode.ErrAuthLoginFailed, ec.Code,
+		"zero TenantID must produce ErrAuthLoginFailed (repo Validate backstop, 防枚举)")
+}
+
 // TestLogin_PreBcryptRead_IsRLSScoped (Site 1, PR-3b) asserts that the
 // pre-bcrypt GetByUsername call runs inside a scopedtx.Do, so that
 // tenant.ScopeFromContext is set on the context when the users table is

--- a/corecells/accesscore/slices/setup/contract_test.go
+++ b/corecells/accesscore/slices/setup/contract_test.go
@@ -256,7 +256,7 @@ func TestEventUserCreatedV1Publish_FromSetup(t *testing.T) {
 	svc := newService(t, sharedStore.UserRepository(), sharedStore.RoleRepository(), w)
 
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: "00000000-0000-0000-0000-000000000001",
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",

--- a/corecells/accesscore/slices/setup/handler.go
+++ b/corecells/accesscore/slices/setup/handler.go
@@ -2,12 +2,14 @@ package setup
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	adminGen "github.com/ghbvf/gocell/generated/contracts/http/auth/setup/admin/v1"
 	statusGen "github.com/ghbvf/gocell/generated/contracts/http/auth/setup/status/v1"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
 	"github.com/ghbvf/gocell/pkg/authz"
+	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/projection"
 	"github.com/ghbvf/gocell/pkg/tenant"
 )
@@ -53,12 +55,19 @@ type AdminAdapter struct{ S *Service }
 
 // Admin implements adminGen.Service. The generated handler validates and decodes
 // username+email+password from the request body and populates req.XTenantID from
-// the X-Tenant-ID header. A missing/malformed tenant fails closed inside
-// Service.CreateAdmin (tenant.ParseTenantID on CreateAdminInput.TenantID) to a
-// 400 ERR_AUTH_IDENTITY_INVALID_INPUT (ADR 1160).
+// the X-Tenant-ID header. Tenant parse and 400 mapping live here: an empty or
+// malformed X-Tenant-ID header causes tenant.ParseTenantID to fail, which this
+// adapter maps to 400 ERR_AUTH_IDENTITY_INVALID_INPUT (ADR 1160). The typed
+// tenant.TenantID is then passed to Service.CreateAdmin, which trusts it.
 func (a AdminAdapter) Admin(ctx context.Context, req *adminGen.Request) (adminGen.AdminResponseObject, error) {
+	tid, perr := tenant.ParseTenantID(req.XTenantID)
+	if perr != nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrAuthIdentityInvalidInput,
+			"tenantId is required and must be a valid UUID",
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("invalid tenantId: %v", perr))))
+	}
 	out, err := a.S.CreateAdmin(ctx, CreateAdminInput{
-		TenantID: req.XTenantID,
+		TenantID: tid,
 		Username: req.Username,
 		Email:    req.Email,
 		Password: req.Password,

--- a/corecells/accesscore/slices/setup/handler.go
+++ b/corecells/accesscore/slices/setup/handler.go
@@ -50,6 +50,11 @@ func toStatusProjection(hasAdmin bool) (statusGen.StatusResponseObject, error) {
 	return statusGen.Status200JSONResponse{Data: data}, nil
 }
 
+// errMsgTenantIDRequired is the error message for a missing or malformed
+// X-Tenant-ID header on the setup admin endpoint.
+// Must be a const literal (MESSAGE-CONST-LITERAL-01).
+const errMsgTenantIDRequired = "tenantId is required and must be a valid UUID"
+
 // AdminAdapter implements adminGen.Service for http.auth.setup.admin.v1.
 type AdminAdapter struct{ S *Service }
 
@@ -63,7 +68,7 @@ func (a AdminAdapter) Admin(ctx context.Context, req *adminGen.Request) (adminGe
 	tid, perr := tenant.ParseTenantID(req.XTenantID)
 	if perr != nil {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrAuthIdentityInvalidInput,
-			"tenantId is required and must be a valid UUID",
+			errMsgTenantIDRequired,
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("invalid tenantId: %v", perr))))
 	}
 	out, err := a.S.CreateAdmin(ctx, CreateAdminInput{

--- a/corecells/accesscore/slices/setup/handler_test.go
+++ b/corecells/accesscore/slices/setup/handler_test.go
@@ -389,7 +389,7 @@ func TestHandler_Status_NoTenantHeader_ReturnsFalse(t *testing.T) {
 // TestHandler_CreateAdmin_NoTenantHeader_Returns400 verifies the ADR 1160
 // fail-closed design for the admin-creation endpoint: an absent X-Tenant-ID
 // header causes an empty XTenantID in the Request DTO, which
-// validateCreateAdminInput rejects with 400 (RequireNotEmpty on tenantId)
+// AdminAdapter.Admin rejects with 400 (tenant.ParseTenantID fails on empty string)
 // before any bcrypt or DB work is attempted.
 func TestHandler_CreateAdmin_NoTenantHeader_Returns400(t *testing.T) {
 	h := newHandlerFresh(t)
@@ -404,5 +404,25 @@ func TestHandler_CreateAdmin_NoTenantHeader_Returns400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code,
 		"admin endpoint must return 400 when X-Tenant-ID header is absent (ADR 1160 fail-closed)")
 	assert.Contains(t, w.Body.String(), "ERR_AUTH_IDENTITY_INVALID_INPUT",
-		"error code must indicate invalid input (empty tenantId via RequireNotEmpty)")
+		"error code must indicate invalid input (empty tenantId via tenant.ParseTenantID)")
+}
+
+// TestHandler_CreateAdmin_MalformedTenant_Returns400 verifies that a
+// syntactically invalid X-Tenant-ID header (not a UUID) is rejected with 400
+// ERR_AUTH_IDENTITY_INVALID_INPUT. The parse now happens in AdminAdapter.Admin
+// before any service call, so malformed tenants are caught at the handler layer.
+func TestHandler_CreateAdmin_MalformedTenant_Returns400(t *testing.T) {
+	h := newHandlerFresh(t)
+	body := `{"username":"root","email":"root@local","password":"SecretPass!23"}`
+	req := httptest.NewRequest(http.MethodPost, setupAdminPath, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "not-a-uuid")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"admin endpoint must return 400 when X-Tenant-ID is not a valid UUID")
+	assert.Contains(t, w.Body.String(), "ERR_AUTH_IDENTITY_INVALID_INPUT",
+		"error code must indicate invalid input (malformed tenantId)")
 }

--- a/corecells/accesscore/slices/setup/service.go
+++ b/corecells/accesscore/slices/setup/service.go
@@ -173,10 +173,11 @@ func (s *Service) Status(ctx context.Context, t tenant.TenantID) (StatusOutput, 
 }
 
 // CreateAdminInput holds the operator-supplied first-admin fields.
-// TenantID is the tenant for which the admin is being provisioned; it must be
-// a canonical UUID and is required (bootstrap must designate a specific tenant).
+// TenantID is the tenant for which the admin is being provisioned; the handler
+// layer parses and validates the tenant header before constructing this struct,
+// so service.CreateAdmin receives a canonical typed value and trusts it.
 type CreateAdminInput struct {
-	TenantID string
+	TenantID tenant.TenantID
 	Username string
 	Email    string
 	Password string
@@ -219,13 +220,9 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 		return nil, err
 	}
 
-	// Parse the tenant ID before any expensive operations.
-	tid, err := tenant.ParseTenantID(in.TenantID)
-	if err != nil {
-		return nil, errcode.New(errcode.KindInvalid, errcode.ErrAuthIdentityInvalidInput,
-			"tenantId is required and must be a valid UUID",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("invalid tenantId: %v", err))))
-	}
+	// tid is already a canonical tenant.TenantID; the handler layer parsed and
+	// validated the X-Tenant-ID header before constructing CreateAdminInput.
+	tid := in.TenantID
 
 	// Fast-path: if admin already exists for this tenant, return 410 without
 	// touching bcrypt. This keeps anonymous floods in O(1) roundtrip. The check
@@ -283,7 +280,6 @@ func (s *Service) CreateAdmin(ctx context.Context, in CreateAdminInput) (*Create
 func validateCreateAdminInput(in CreateAdminInput) error {
 	if err := validation.RequireNotEmpty(
 		errcode.ErrAuthIdentityInvalidInput,
-		validation.F("tenantId", in.TenantID),
 		validation.F("username", in.Username),
 		validation.F("email", in.Email),
 		validation.F("password", in.Password),

--- a/corecells/accesscore/slices/setup/service_test.go
+++ b/corecells/accesscore/slices/setup/service_test.go
@@ -752,6 +752,40 @@ func TestService_CreateAdmin_AlreadyExists_DetailsContainOnlyNextAction(t *testi
 		"loginEndpoint key was retired by PR-A42 — keep details minimal")
 }
 
+// TestCreateAdmin_ZeroTenantID_FailsClosed locks the fail-closed safety net for
+// direct (non-handler) callers of Service.CreateAdmin. An empty typed TenantID
+// (zero value) must cause CreateAdmin to fail — it cannot result in a successful
+// admin creation — even if a caller somehow bypasses the handler's tenant-parse
+// step. The repo's tenant.TenantID Validate() backstop (called by
+// provisioner.EffectiveAdminExists inside scopedtx.Do) rejects the empty tenant
+// with ErrValidationFailed before any user write can proceed. This documents the
+// exact fail-closed error so future callers cannot accidentally soften it.
+func TestCreateAdmin_ZeroTenantID_FailsClosed(t *testing.T) {
+	store := mem.NewStore(clock.Real())
+	svc := newService(t, store.UserRepository(), store.RoleRepository(), nil)
+
+	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
+		TenantID: "", // zero value — bypasses handler parse
+		Username: "u",
+		Email:    "e@x",
+		Password: "SecretPass!23",
+	})
+	require.Error(t, err,
+		"zero TenantID must fail closed; successful admin creation must be impossible")
+	assert.Nil(t, out)
+	// The empty tenant is rejected by the tenant.TenantID Validate() backstop
+	// inside the provisioner's EffectiveAdminExists call, which surfaces as a
+	// wrapped ErrValidationFailed. The exact chain is:
+	//   setup: status: adminprovision: effective-admin-exists: [ERR_VALIDATION_FAILED] ...
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec,
+		"zero TenantID must produce an errcode.Error (repo Validate backstop)")
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code,
+		"zero TenantID must produce ErrValidationFailed from tenant.TenantID Validate backstop")
+	assert.Contains(t, err.Error(), "TenantID required",
+		"error must mention TenantID required so the cause is unambiguous")
+}
+
 // --- helpers --------------------------------------------------------------
 
 func seedAdmin(t *testing.T, userRepo ports.UserRepository, roleRepo ports.RoleRepository) {

--- a/corecells/accesscore/slices/setup/service_test.go
+++ b/corecells/accesscore/slices/setup/service_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 // testTenantIDStr is the string form of the canonical test tenant UUID, used
-// in CreateAdminInput.TenantID (which is a string, not tenant.TenantID).
+// when setting HTTP headers (X-Tenant-ID) in handler tests.
 const testTenantIDStr = "00000000-0000-0000-0000-000000000001"
 
 type noopTxRunner struct{}
@@ -220,7 +220,7 @@ func TestService_CreateAdmin_FreshSystem_Creates_EmitsEvent(t *testing.T) {
 	svc := newService(t, userRepo, roleRepo, w)
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -267,7 +267,7 @@ func TestService_CreateAdmin_WithSetupLock_AcquiresInsideTxBeforeEmit(t *testing
 	)
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -290,7 +290,7 @@ func TestService_CreateAdmin_SetupLockFailure_ShortCircuitsNoSideEffects(t *test
 	svc := newService(t, userRepo, roleRepo, w, setup.WithSetupLock(lock))
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -328,7 +328,7 @@ func TestService_CreateAdmin_NilSetupLockOptionIgnored_PriorLockWins(t *testing.
 	svc := newService(t, userRepo, roleRepo, w, setup.WithSetupLock(nil))
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -377,7 +377,7 @@ func TestService_CreateAdmin_AlreadyExists_Returns410_NoEmit(t *testing.T) {
 	svc := newService(t, userRepo, roleRepo, w)
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -397,9 +397,9 @@ func TestService_CreateAdmin_BlankField_Returns400(t *testing.T) {
 		name string
 		in   setup.CreateAdminInput
 	}{
-		{"blank username", setup.CreateAdminInput{TenantID: testTenantIDStr, Username: "", Email: "e@x", Password: "p"}},
-		{"blank email", setup.CreateAdminInput{TenantID: testTenantIDStr, Username: "u", Email: "", Password: "p"}},
-		{"blank password", setup.CreateAdminInput{TenantID: testTenantIDStr, Username: "u", Email: "e@x", Password: ""}},
+		{"blank username", setup.CreateAdminInput{TenantID: testTenantID, Username: "", Email: "e@x", Password: "p"}},
+		{"blank email", setup.CreateAdminInput{TenantID: testTenantID, Username: "u", Email: "", Password: "p"}},
+		{"blank password", setup.CreateAdminInput{TenantID: testTenantID, Username: "u", Email: "e@x", Password: ""}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -427,7 +427,7 @@ func TestService_CreateAdmin_PasswordLengthOutOfRange_Returns400(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-				TenantID: testTenantIDStr,
+				TenantID: testTenantID,
 				Username: "root",
 				Email:    "root@local",
 				Password: tc.password,
@@ -450,12 +450,12 @@ func TestService_CreateAdmin_FieldLengthOutOfRange_Returns400(t *testing.T) {
 		{
 			name: "username too long",
 			in: setup.CreateAdminInput{
-				TenantID: testTenantIDStr, Username: strings.Repeat("u", 129), Email: "root@local", Password: "SecretPass!23",
+				TenantID: testTenantID, Username: strings.Repeat("u", 129), Email: "root@local", Password: "SecretPass!23",
 			},
 		},
 		{
 			name: "email too long",
-			in:   setup.CreateAdminInput{TenantID: testTenantIDStr, Username: "root", Email: strings.Repeat("e", 257), Password: "SecretPass!23"},
+			in:   setup.CreateAdminInput{TenantID: testTenantID, Username: "root", Email: strings.Repeat("e", 257), Password: "SecretPass!23"},
 		},
 	}
 	for _, tc := range tests {
@@ -477,7 +477,7 @@ func TestService_CreateAdmin_EmitterFailure_Propagates(t *testing.T) {
 	svc := newService(t, userRepo, roleRepo, w)
 
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -494,7 +494,7 @@ func TestService_CreateAdmin_ProvisionerInfraError_Propagates(t *testing.T) {
 	svc := newService(t, userRepo, roleRepo, nil)
 
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -586,7 +586,7 @@ func TestService_CreateAdmin_Concurrent_StoreTxRunner_ExactlyOneAdmin(t *testing
 			defer done.Done()
 			start.Wait()
 			out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-				TenantID: testTenantIDStr,
+				TenantID: testTenantID,
 				Username: "root" + strconv.Itoa(i),
 				Email:    "root" + strconv.Itoa(i) + "@local",
 				Password: "SecretPass!23",
@@ -638,7 +638,7 @@ func TestService_CreateAdmin_AlreadyExists_DoesNotHashPassword(t *testing.T) {
 
 	start := time.Now()
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -668,7 +668,7 @@ func TestService_CreateAdmin_DuplicateUsername_Returns409WithoutTakeover(t *test
 	svc := newService(t, userRepo, roleRepo, &stubWriter{})
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -698,12 +698,12 @@ func TestService_CreateAdmin_ControlCharInField_Returns400(t *testing.T) {
 		in   setup.CreateAdminInput
 	}{
 		{"newline in email", setup.CreateAdminInput{
-			TenantID: testTenantIDStr, Username: "root", Email: "root@local\n", Password: "SecretPass!23",
+			TenantID: testTenantID, Username: "root", Email: "root@local\n", Password: "SecretPass!23",
 		}},
 		{"tab in username", setup.CreateAdminInput{
-			TenantID: testTenantIDStr, Username: "ro\tot", Email: "root@local", Password: "SecretPass!23",
+			TenantID: testTenantID, Username: "ro\tot", Email: "root@local", Password: "SecretPass!23",
 		}},
-		{"cr in email", setup.CreateAdminInput{TenantID: testTenantIDStr, Username: "root", Email: "root\r@local", Password: "SecretPass!23"}},
+		{"cr in email", setup.CreateAdminInput{TenantID: testTenantID, Username: "root", Email: "root\r@local", Password: "SecretPass!23"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -729,7 +729,7 @@ func TestService_CreateAdmin_AlreadyExists_DetailsContainOnlyNextAction(t *testi
 	svc := newService(t, userRepo, roleRepo, &stubWriter{})
 
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -848,7 +848,7 @@ func TestService_CreateAdmin_AlreadyProvisioned_410_OperatorEnvSetIsExpected(t *
 	svc := newService(t, userRepo, roleRepo, w)
 
 	out, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "newadmin",
 		Email:    "newadmin@local",
 		Password: "SecretPass!23",
@@ -880,7 +880,7 @@ func TestService_CreateAdmin_IsRLSScoped(t *testing.T) {
 	)
 
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr,
+		TenantID: testTenantID,
 		Username: "root",
 		Email:    "root@local",
 		Password: "SecretPass!23",
@@ -1015,7 +1015,7 @@ func TestService_CreateAdmin_FastPathStatus_IsRLSScoped(t *testing.T) {
 	// Fresh store has no admin → the fast-path EffectiveAdminExists check runs
 	// (and so does the in-tx Ensure check); assertAllScoped proves BOTH are scoped.
 	_, err := svc.CreateAdmin(context.Background(), setup.CreateAdminInput{
-		TenantID: testTenantIDStr, Username: "root", Email: "root@local", Password: "SecretPass!23",
+		TenantID: testTenantID, Username: "root", Email: "root@local", Password: "SecretPass!23",
 	})
 	require.NoError(t, err)
 	roleCap.assertAllScoped(t, testTenantID)


### PR DESCRIPTION
## Summary

把 `sessionlogin.LoginInput` / `setup.CreateAdminInput` 的 `TenantID` 从裸 `string` 改为 `tenant.TenantID`，`tenant.ParseTenantID` 从 service 上移到 handler，service 去掉重复 parse。

## Why / 背景

源自 PR #1481（epic #1337 多租户 PR-2a #1340）6-reviewer review 的 finding U6。PR-2a 已在 **repo 接口层**达成「漏传 tenant = 编译错」的 typed 保证（`tenant.TenantID` 作为 repo 方法 param[1]，`TENANT-REPO-PARAM-FUNNEL-01` 守卫），但两个 **pre-auth input DTO**（登录前/建管理员前直接喂 repo 路径、此刻还没有 JWT/Principal）仍是裸 `string`，typed 值止步于 repo 边界。

本 PR 把 typed **值**推到 input 边界：字段 typed + `ParseTenantID` 上移 handler（参数绑定本就是 handler 职责，DDD 分层）+ service 去重复 parse、直接信任。预期结果：tenant 在 handler 边界一次性解析为 canonical typed 值，wire 行为逐字保持。

**范围裁定**：`runtime/auth.Principal.TenantID` 按 ADR-1042 **保持 string**——ctx/wire principal 类型统一 string/SafeID（`ctxkeys` string、`outbox.PrincipalMetadata.TenantID` 冻结 `idutil.SafeID`），与 K8s `user.Info` / Spring / .NET `ClaimsPrincipal` / OIDC 主流一致；typed Principal 净转换 +5 换 -1、收益边际，issue 作者亦划为另一个 epic。

> 措辞精确性：struct 字段 typed ≠ repo 位置参 typed（字段会零值化，「漏传=编译错」无法搬到 DTO）。typed 字段真正给的是**防误塞**（裸 string 不能进 tenant 槽，编译期挡）；canonicality fail-closed 兜底仍由既有 repo `t.Validate()` + handler `ParseTenantID` 承载。本 PR **不新增 enforcement 机制**（无新 archtest/funnel）。

## Refs

- Closes #1545
- epic #1337 / PR-2a #1340 / 源 PR #1481
- `ref: kubernetes user.go`（`k8s.io/apiserver/pkg/authentication/user` —— auth principal 全 string，typed 值对象放 domain 层；本 PR 即该模式：input DTO typed、wire principal 保持 string）

## Risk / 兼容性

- **无 wire 契约变更**：HTTP 错误语义逐字保持，已有 handler 级测试 + 新增畸形-tenant 测试锁定：
  - login：空 X-Tenant-ID → **400** `ERR_AUTH_LOGIN_INVALID_INPUT`；畸形 → **401** `ERR_AUTH_LOGIN_FAILED`（反枚举，ADR 1160）
  - setup：空/畸形 → **400** `ERR_AUTH_IDENTITY_INVALID_INPUT`
  - status fail-soft（HasAdmin:false）**不变**
- **行为变化登记**（仅非 wire 的直调 service 调用方，实际只有测试）：删除 service 层 `RequireNotEmpty(tenantId)` 后，直接给 service 传空/畸形 typed tenant 的错误码从 `ErrAuthLogin*` 变为 repo 的 `ErrValidationFailed`；wire 路径（handler 唯一生产调用方）不受影响。
- repo 签名 / `Principal.TenantID` / archtest 面均**不动**；无 migration、无 contract/generated/订阅变更、无版本升级。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...`（whole module）本地通过
- [x] `go test ./...` 全量单测 **0 失败** + 集成测试 `identitymanage`（testcontainers Postgres）通过（114s）
- [x] `golangci-lint run ./...` **0 issues**
- [x] archtest tenant/principal/message-const 族 **PASS**（唯一失败 `TestErrcodeMessageConstLiteral` → `tools/codegen/cellgen/builder.go:885` 系 **pre-existing**，base `develop` 同样失败、非本 PR 文件、PR-time 不 gate）
