### PR TITLE
feat(authz): PR-10b — configcore permission-based 迁移 (5 slices, allowlist 8→3) [#1348]

### DIFF
--- a/cmd/corebundle/authz_pdp_configcore_integration_test.go
+++ b/cmd/corebundle/authz_pdp_configcore_integration_test.go
@@ -3,8 +3,8 @@
 package main
 
 // TestABACPDPGatesConfigcore is the PR-10b T10.x acceptance test:
-// the wired ABAC PDP must gate real HTTP traffic on configcore read and write
-// endpoints.
+// the wired ABAC PDP must gate real HTTP traffic on configcore read, write,
+// flag read, flag write, and config publish endpoints.
 //
 // Cases:
 //   - admin GET  /api/v1/config/ → 200 (baseline allow via PDP, config:read)
@@ -13,6 +13,13 @@ package main
 //     AND "insufficient permissions" (proves deny comes from PDP, not a missing
 //     Authorizer wiring that would return "authorization policy engine not wired")
 //   - non-admin POST /api/v1/config/ → 403 + same PDP-deny assertion
+//   - admin GET  /api/v1/flags/ → 200 (baseline allow via PDP, flag:read)
+//   - non-admin GET  /api/v1/flags/ → 403 + PDP-deny assertion (flag:read)
+//   - admin POST /api/v1/flags/ → 201 (baseline allow via PDP, flag:write)
+//   - non-admin POST /api/v1/flags/ → 403 + PDP-deny assertion (flag:write)
+//   - admin POST /api/v1/config/{key}/publish → NOT 401 and NOT 403 (gate
+//     passes; business result may be 404 if key absent, not pinned)
+//   - non-admin POST /api/v1/config/{key}/publish → 403 + PDP-deny assertion
 //
 // configcore has no self branch (unlike auditquery), so only admin-allow and
 // non-admin-deny cases exist.
@@ -34,6 +41,14 @@ import (
 // pdpConfigListPath is the config list endpoint served by the configread slice
 // (generated from the http.config.list.v1 contract).
 const pdpConfigListPath = "/api/v1/config/"
+
+// pdpFlagListPath is the flag list endpoint served by the featureflag slice
+// (generated from the http.config.flags.list.v1 contract).
+const pdpFlagListPath = "/api/v1/flags/"
+
+// pdpConfigPublishPath returns the publish endpoint for the given config key
+// (generated from the http.config.publish.v1 contract).
+func pdpConfigPublishPath(key string) string { return "/api/v1/config/" + key + "/publish" }
 
 // pdpConfigReq issues an HTTP request to a configcore endpoint with the given
 // method, path, token, and optional JSON body. Returns the response and body
@@ -101,6 +116,76 @@ func TestABACPDPGatesConfigcore(t *testing.T) {
 		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpConfigListPath, userToken, writeBody)
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
 			"non-admin POST /api/v1/config/ must get 403 (PDP default-deny); body=%s", body)
+		assert.Contains(t, body, "ERR_AUTH_FORBIDDEN",
+			"PDP deny must produce ERR_AUTH_FORBIDDEN; body=%s", body)
+		assert.Contains(t, body, "insufficient permissions",
+			"PDP deny message must be %q, not %q (which would indicate a missing Authorizer wiring); body=%s",
+			"insufficient permissions", "authorization policy engine not wired", body)
+	})
+
+	// Case 5: admin GET /api/v1/flags/ → 200 (baseline allow via PDP, flag:read).
+	t.Run("admin_flag_list_200", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodGet, pdpFlagListPath, adminToken, nil)
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"admin GET /api/v1/flags/ must get 200 (baseline allow via PDP); body=%s", body)
+	})
+
+	// Case 6: non-admin GET /api/v1/flags/ → PDP default-deny → 403 (flag:read).
+	// F7: assert on "insufficient permissions" to prove the deny came from the
+	// PDP path, not a fail-closed no-Authorizer 403.
+	t.Run("non_admin_flag_list_403", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodGet, pdpFlagListPath, userToken, nil)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"non-admin GET /api/v1/flags/ must get 403 (PDP default-deny); body=%s", body)
+		assert.Contains(t, body, "ERR_AUTH_FORBIDDEN",
+			"PDP deny must produce ERR_AUTH_FORBIDDEN; body=%s", body)
+		assert.Contains(t, body, "insufficient permissions",
+			"PDP deny message must be %q, not %q (which would indicate a missing Authorizer wiring); body=%s",
+			"insufficient permissions", "authorization policy engine not wired", body)
+	})
+
+	flagBody := []byte(`{"key":"e2e.flag","enabled":false,"rolloutPercentage":0,"description":"d"}`)
+
+	// Case 7: admin POST /api/v1/flags/ → 201 (baseline allow via PDP, flag:write).
+	t.Run("admin_flag_write_201", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpFlagListPath, adminToken, flagBody)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode,
+			"admin POST /api/v1/flags/ must get 201 (baseline allow via PDP); body=%s", body)
+	})
+
+	// Case 8: non-admin POST /api/v1/flags/ → PDP default-deny → 403 (flag:write).
+	// F7: assert on "insufficient permissions" to prove the deny came from the
+	// PDP path.
+	t.Run("non_admin_flag_write_403", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpFlagListPath, userToken, flagBody)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"non-admin POST /api/v1/flags/ must get 403 (PDP default-deny); body=%s", body)
+		assert.Contains(t, body, "ERR_AUTH_FORBIDDEN",
+			"PDP deny must produce ERR_AUTH_FORBIDDEN; body=%s", body)
+		assert.Contains(t, body, "insufficient permissions",
+			"PDP deny message must be %q, not %q (which would indicate a missing Authorizer wiring); body=%s",
+			"insufficient permissions", "authorization policy engine not wired", body)
+	})
+
+	// Case 9: admin POST /api/v1/config/{key}/publish → gate passes (NOT 401,
+	// NOT 403). Business result may be 404 if key is absent; we do not pin the
+	// exact 2xx because the key "e2e.pubkey" may not exist in the in-memory
+	// store. The critical assertion is that the PDP allowed the request through.
+	t.Run("admin_publish_gate_pass", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpConfigPublishPath("e2e.pubkey"), adminToken, nil)
+		assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode,
+			"admin POST publish must not get 401; body=%s", body)
+		assert.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+			"admin POST publish must not get 403 (PDP must allow via config:publish); body=%s", body)
+	})
+
+	// Case 10: non-admin POST /api/v1/config/{key}/publish → PDP default-deny → 403
+	// (config:publish). F7: assert on "insufficient permissions" to prove the
+	// deny came from the PDP path.
+	t.Run("non_admin_publish_403", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpConfigPublishPath("e2e.pubkey"), userToken, nil)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"non-admin POST publish must get 403 (PDP default-deny); body=%s", body)
 		assert.Contains(t, body, "ERR_AUTH_FORBIDDEN",
 			"PDP deny must produce ERR_AUTH_FORBIDDEN; body=%s", body)
 		assert.Contains(t, body, "insufficient permissions",

--- a/cmd/corebundle/authz_pdp_configcore_integration_test.go
+++ b/cmd/corebundle/authz_pdp_configcore_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package main
+
+// TestABACPDPGatesConfigcore is the PR-10b T10.x acceptance test:
+// the wired ABAC PDP must gate real HTTP traffic on configcore read and write
+// endpoints.
+//
+// Cases:
+//   - admin GET  /api/v1/config/ → 200 (baseline allow via PDP, config:read)
+//   - admin POST /api/v1/config/ → 201 (baseline allow via PDP, config:write)
+//   - non-admin GET  /api/v1/config/ → 403, body contains ERR_AUTH_FORBIDDEN
+//     AND "insufficient permissions" (proves deny comes from PDP, not a missing
+//     Authorizer wiring that would return "authorization policy engine not wired")
+//   - non-admin POST /api/v1/config/ → 403 + same PDP-deny assertion
+//
+// configcore has no self branch (unlike auditquery), so only admin-allow and
+// non-admin-deny cases exist.
+//
+// Wiring: same composition root path as TestABACPDPGatesAuditQuery — uses the
+// startCorebundlePDPApp + provisionPDPAdminAndUser helpers from
+// authz_pdp_integration_test.go.
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pdpConfigListPath is the config list endpoint served by the configread slice
+// (generated from the http.config.list.v1 contract).
+const pdpConfigListPath = "/api/v1/config/"
+
+// pdpConfigReq issues an HTTP request to a configcore endpoint with the given
+// method, path, token, and optional JSON body. Returns the response and body
+// string. Body is already closed.
+func pdpConfigReq(t *testing.T, base, method, path, token string, body []byte) (*http.Response, string) {
+	t.Helper()
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, base+path, bodyReader)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Tenant-ID", testTenantID)
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := pdpAuditClient.Do(req)
+	require.NoError(t, err)
+	raw, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	return resp, string(raw)
+}
+
+func TestABACPDPGatesConfigcore(t *testing.T) {
+	base := startCorebundlePDPApp(t)
+	adminToken, userToken, _, _ := provisionPDPAdminAndUser(t, base)
+
+	writeBody := []byte(`{"key":"e2e.k","value":"v"}`)
+
+	// Case 1: admin GET /api/v1/config/ → 200 (baseline allow, config:read).
+	t.Run("admin_list_200", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodGet, pdpConfigListPath, adminToken, nil)
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"admin GET /api/v1/config/ must get 200 (baseline allow via PDP); body=%s", body)
+	})
+
+	// Case 2: admin POST /api/v1/config/ → 201 (baseline allow, config:write).
+	t.Run("admin_write_201", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpConfigListPath, adminToken, writeBody)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode,
+			"admin POST /api/v1/config/ must get 201 (baseline allow via PDP); body=%s", body)
+	})
+
+	// Case 3: non-admin GET /api/v1/config/ → PDP default-deny → 403.
+	// F7: assert on "insufficient permissions" to prove the deny came from the
+	// PDP path, not a fail-closed "authorization policy engine not wired" gap.
+	t.Run("non_admin_list_403", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodGet, pdpConfigListPath, userToken, nil)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"non-admin GET /api/v1/config/ must get 403 (PDP default-deny); body=%s", body)
+		assert.Contains(t, body, "ERR_AUTH_FORBIDDEN",
+			"PDP deny must produce ERR_AUTH_FORBIDDEN; body=%s", body)
+		assert.Contains(t, body, "insufficient permissions",
+			"PDP deny message must be %q, not %q (which would indicate a missing Authorizer wiring); body=%s",
+			"insufficient permissions", "authorization policy engine not wired", body)
+	})
+
+	// Case 4: non-admin POST /api/v1/config/ → PDP default-deny → 403.
+	// Same PDP-deny assertion as Case 3 for the write path.
+	t.Run("non_admin_write_403", func(t *testing.T) {
+		resp, body := pdpConfigReq(t, base, http.MethodPost, pdpConfigListPath, userToken, writeBody)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"non-admin POST /api/v1/config/ must get 403 (PDP default-deny); body=%s", body)
+		assert.Contains(t, body, "ERR_AUTH_FORBIDDEN",
+			"PDP deny must produce ERR_AUTH_FORBIDDEN; body=%s", body)
+		assert.Contains(t, body, "insufficient permissions",
+			"PDP deny message must be %q, not %q (which would indicate a missing Authorizer wiring); body=%s",
+			"insufficient permissions", "authorization policy engine not wired", body)
+	})
+}

--- a/cmd/corebundle/authz_pdp_integration_test.go
+++ b/cmd/corebundle/authz_pdp_integration_test.go
@@ -61,7 +61,16 @@ const pdpAuditPath = "/api/v1/audit/entries"
 // production cost (~12) takes ~1-2s per hash for setup/login.
 var pdpAuditClient = &http.Client{Timeout: testtime.SelectAsyncSettle}
 
-func TestABACPDPGatesAuditQuery(t *testing.T) {
+// startCorebundlePDPApp boots a full corebundle app (ac+cc+auc) with the ABAC
+// PDP wired to the primary listener via bootstrap.PrimaryAuthorizerOption. It
+// returns the base URL of the running app. The caller's t.Cleanup will cancel
+// the context and wait for graceful shutdown.
+//
+// This helper is shared by TestABACPDPGatesAuditQuery and
+// TestABACPDPGatesConfigcore so that app assembly is not duplicated.
+func startCorebundlePDPApp(t *testing.T) string {
+	t.Helper()
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	healthLn := newCorebundleLocalListener(t)
@@ -160,7 +169,7 @@ func TestABACPDPGatesAuditQuery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- app.Run(ctx) }()
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 		select {
 		case runErr := <-done:
@@ -168,28 +177,49 @@ func TestABACPDPGatesAuditQuery(t *testing.T) {
 		case <-time.After(testtime.SelectShutdown):
 			t.Fatal("bootstrap did not shut down in time")
 		}
-	}()
+	})
 
 	base := "http://" + ln.Addr().String()
 	waitForHealthy(t, healthLn.Addr().String())
+	return base
+}
 
-	// Step 1: bootstrap admin (Basic Auth) so that an admin account exists.
-	// Capture the admin's UUID from the response — used as the "other actor"
-	// in the non-admin cross-actor assertion.
+// provisionPDPAdminAndUser runs the four-step provisioning sequence used by
+// both PDP gate tests:
+//  1. Bootstrap admin via Basic Auth → capture adminID
+//  2. Admin login → adminToken
+//  3. Admin creates a regular user → capture userID
+//  4. User login → userToken
+//
+// Returns (adminToken, userToken, userID, adminID).
+func provisionPDPAdminAndUser(t *testing.T, base string) (adminToken, userToken, userID, adminID string) {
+	t.Helper()
+
+	const pdpBootstrapUser = "pdp-test-op"
+	const pdpBootstrapPass = "pdp-test-op-pass!"
 	const pdpAdminUsername = "pdp-admin"
 	const pdpAdminPassword = "PdpAdminPass!1"
-	adminUserID := pdpSetupAdmin(t, base, pdpBootstrapUser, pdpBootstrapPass, pdpAdminUsername, pdpAdminPassword)
-
-	// Step 2: admin login → JWT with roles=[admin] + tenant claim.
-	adminToken := pdpLogin(t, base, pdpAdminUsername, pdpAdminPassword)
-
-	// Step 3: create a regular user as admin; capture the user's subject ID.
 	const pdpUserUsername = "pdp-regular-user"
 	const pdpUserPassword = "PdpUserPass!99"
-	pdpUserID := pdpCreateUser(t, base, adminToken, pdpUserUsername, "pdp-user@test.local", pdpUserPassword)
 
-	// Step 4: regular user login → JWT with roles=[] (no admin) + tenant claim.
-	userToken := pdpLogin(t, base, pdpUserUsername, pdpUserPassword)
+	// Step 1: bootstrap admin.
+	adminID = pdpSetupAdmin(t, base, pdpBootstrapUser, pdpBootstrapPass, pdpAdminUsername, pdpAdminPassword)
+
+	// Step 2: admin login → JWT with roles=[admin] + tenant claim.
+	adminToken = pdpLogin(t, base, pdpAdminUsername, pdpAdminPassword)
+
+	// Step 3: create a regular user as admin.
+	userID = pdpCreateUser(t, base, adminToken, pdpUserUsername, "pdp-user@test.local", pdpUserPassword)
+
+	// Step 4: regular user login → JWT with roles=[] (no admin).
+	userToken = pdpLogin(t, base, pdpUserUsername, pdpUserPassword)
+
+	return adminToken, userToken, userID, adminID
+}
+
+func TestABACPDPGatesAuditQuery(t *testing.T) {
+	base := startCorebundlePDPApp(t)
+	adminToken, userToken, pdpUserID, adminUserID := provisionPDPAdminAndUser(t, base)
 
 	// adminUserID is the "other actor" for the non-admin cross-actor assertion:
 	// it is a different subject from the regular user, so the non-admin is asking

--- a/cmd/corebundle/outbox_e2e_integration_test.go
+++ b/cmd/corebundle/outbox_e2e_integration_test.go
@@ -125,7 +125,8 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	defer cancel()
 
 	// --- Step 1: Start PG testcontainer (RMQ is NOT used by corebundle today) ---
-	pgContainer, err := tcpostgres.Run(ctx, testutil.PostgresImage,
+	pgContainer, err := tcpostgres.Run(
+		ctx, testutil.PostgresImage,
 		tcpostgres.WithDatabase("test"),
 		tcpostgres.WithUsername("test"),
 		tcpostgres.WithPassword("test"),
@@ -241,7 +242,8 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 		setupTestAllowAllLimiter{},
 		nil,
 	)
-	accessCell := accesscore.NewAccessCore(clock.Real(), append(buildAccessCoreMemOptions(t, clock.Real()),
+	accessCell := accesscore.NewAccessCore(clock.Real(), append(
+		buildAccessCoreMemOptions(t, clock.Real()),
 		accesscore.WithOutboxDeps(outbox.WrapPublisherForCell(eb), nil),
 		accesscore.WithJWTIssuer(jwtIssuer),
 		accesscore.WithJWTVerifier(jwtVerifier),
@@ -260,6 +262,12 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	require.NoError(t, asm.Register(cfgResult.Cell))
 	require.NoError(t, asm.Register(accessCell))
 	require.NoError(t, asm.Register(auditCell))
+
+	// configcore route gates use auth.RequirePermission (PR-10b #1348); the primary
+	// listener must carry the ABAC PDP or config writes fail closed (403). accesscore
+	// provides the Authorizer — wire it exactly as production (cmd/corebundle/run.go).
+	authzOpt, authzErr := bootstrap.PrimaryAuthorizerOption([]cell.Cell{cfgResult.Cell, accessCell, auditCell})
+	require.NoError(t, authzErr, "PrimaryAuthorizerOption must succeed with accesscore present")
 
 	// --- Step 6: Boot the assembly with the relay worker ---
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -282,7 +290,7 @@ func TestOutboxE2E_PGMode_WriteToSubscribe(t *testing.T) {
 	// A11 regression guard: relay is registered via relayBootstrapOpts from
 	// buildConfigCoreCellFromShared so its Worker/Close/Checkers lifecycle is independently
 	// managed by bootstrap — not carried inside PoolResource.Worker().
-	app := newBootstrapFromOptions(asm.Clock(), append(baseOpts, relayBootstrapOpts...))
+	app := newBootstrapFromOptions(asm.Clock(), append(append(baseOpts, authzOpt), relayBootstrapOpts...))
 
 	appErrCh := make(chan error, 1)
 	appCtx, appCancel := context.WithCancel(ctx)
@@ -448,7 +456,8 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 	defer cancel()
 
 	// --- Step 1: Start PG testcontainer ---
-	pgContainer, err := tcpostgres.Run(ctx, testutil.PostgresImage,
+	pgContainer, err := tcpostgres.Run(
+		ctx, testutil.PostgresImage,
 		tcpostgres.WithDatabase("test"),
 		tcpostgres.WithUsername("test"),
 		tcpostgres.WithPassword("test"),
@@ -564,7 +573,8 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 		setupTestAllowAllLimiter{},
 		nil,
 	)
-	accessCell := accesscore.NewAccessCore(clock.Real(), append(buildAccessCoreMemOptions(t, clock.Real()),
+	accessCell := accesscore.NewAccessCore(clock.Real(), append(
+		buildAccessCoreMemOptions(t, clock.Real()),
 		accesscore.WithOutboxDeps(outbox.WrapPublisherForCell(eb), nil),
 		accesscore.WithJWTIssuer(jwtIssuer),
 		accesscore.WithJWTVerifier(jwtVerifier),
@@ -585,6 +595,12 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 	require.NoError(t, asm.Register(accessCell))
 	require.NoError(t, asm.Register(auditCell))
 
+	// configcore route gates use auth.RequirePermission (PR-10b #1348); the primary
+	// listener must carry the ABAC PDP or config writes fail closed (403). accesscore
+	// provides the Authorizer — wire it exactly as production (cmd/corebundle/run.go).
+	authzOpt, authzErr := bootstrap.PrimaryAuthorizerOption([]cell.Cell{cfgResult.Cell, accessCell, auditCell})
+	require.NoError(t, authzErr, "PrimaryAuthorizerOption must succeed with accesscore present")
+
 	// --- Step 6: Boot the assembly ---
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -600,7 +616,7 @@ func TestOutboxE2E_RefetchLoop_AccessCoreCallsInternalGet(t *testing.T) {
 		bootstrap.WithConsumerBase(newCorebundleTestConsumerBase(t, asm.Clock())),
 		bootstrap.WithShutdownTimeout(testtime.EventuallyDefault),
 	}
-	app := newBootstrapFromOptions(asm.Clock(), append(baseOpts, relayBootstrapOpts...))
+	app := newBootstrapFromOptions(asm.Clock(), append(append(baseOpts, authzOpt), relayBootstrapOpts...))
 
 	appErrCh := make(chan error, 1)
 	appCtx, appCancel := context.WithCancel(ctx)

--- a/contracts/http/config/delete/v1/contract.yaml
+++ b/contracts/http/config/delete/v1/contract.yaml
@@ -35,7 +35,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the config:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/delete/v1/contract.yaml
+++ b/contracts/http/config/delete/v1/contract.yaml
@@ -35,7 +35,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/flags/create/v1/contract.yaml
+++ b/contracts/http/config/flags/create/v1/contract.yaml
@@ -25,7 +25,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the flag:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"

--- a/contracts/http/config/flags/create/v1/contract.yaml
+++ b/contracts/http/config/flags/create/v1/contract.yaml
@@ -25,7 +25,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"

--- a/contracts/http/config/flags/delete/v1/contract.yaml
+++ b/contracts/http/config/flags/delete/v1/contract.yaml
@@ -33,7 +33,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — flag key does not exist (ERR_FLAG_NOT_FOUND)"

--- a/contracts/http/config/flags/delete/v1/contract.yaml
+++ b/contracts/http/config/flags/delete/v1/contract.yaml
@@ -33,7 +33,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the flag:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — flag key does not exist (ERR_FLAG_NOT_FOUND)"

--- a/contracts/http/config/flags/evaluate/v1/contract.yaml
+++ b/contracts/http/config/flags/evaluate/v1/contract.yaml
@@ -30,7 +30,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated principal lacks the admin role required to evaluate flags (admin-only because evaluation results may include sensitive subject mapping)"
+        description: "Forbidden — the ABAC PDP denied the flag:read permission required to evaluate flags (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin; evaluation results may include sensitive subject mapping)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Feature flag key not found"

--- a/contracts/http/config/flags/evaluate/v1/contract.yaml
+++ b/contracts/http/config/flags/evaluate/v1/contract.yaml
@@ -30,7 +30,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:read permission required to evaluate flags (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin; evaluation results may include sensitive subject mapping)"
+        description: "Forbidden — caller lacks the flag:read permission required to evaluate flags; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Feature flag key not found"

--- a/contracts/http/config/flags/get/v1/contract.yaml
+++ b/contracts/http/config/flags/get/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:read permission required to read flag metadata (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the flag:read permission required to read flag metadata; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Feature flag key not found"

--- a/contracts/http/config/flags/get/v1/contract.yaml
+++ b/contracts/http/config/flags/get/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated principal lacks the admin role required to read flag metadata"
+        description: "Forbidden — the ABAC PDP denied the flag:read permission required to read flag metadata (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Feature flag key not found"

--- a/contracts/http/config/flags/list/v1/contract.yaml
+++ b/contracts/http/config/flags/list/v1/contract.yaml
@@ -35,7 +35,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated principal lacks the admin role required to enumerate flag keys"
+        description: "Forbidden — the ABAC PDP denied the flag:read permission required to enumerate flag keys (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"

--- a/contracts/http/config/flags/list/v1/contract.yaml
+++ b/contracts/http/config/flags/list/v1/contract.yaml
@@ -35,7 +35,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:read permission required to enumerate flag keys (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the flag:read permission required to enumerate flag keys; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"

--- a/contracts/http/config/flags/toggle/v1/contract.yaml
+++ b/contracts/http/config/flags/toggle/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — flag key does not exist (ERR_FLAG_NOT_FOUND)"

--- a/contracts/http/config/flags/toggle/v1/contract.yaml
+++ b/contracts/http/config/flags/toggle/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the flag:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — flag key does not exist (ERR_FLAG_NOT_FOUND)"

--- a/contracts/http/config/flags/update/v1/contract.yaml
+++ b/contracts/http/config/flags/update/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — flag key does not exist (ERR_FLAG_NOT_FOUND)"

--- a/contracts/http/config/flags/update/v1/contract.yaml
+++ b/contracts/http/config/flags/update/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the flag:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the flag:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — flag key does not exist (ERR_FLAG_NOT_FOUND)"

--- a/contracts/http/config/get/v1/contract.yaml
+++ b/contracts/http/config/get/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated principal lacks the admin role required to read config metadata"
+        description: "Forbidden — the ABAC PDP denied the config:read permission required to read config metadata (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Config key not found"

--- a/contracts/http/config/get/v1/contract.yaml
+++ b/contracts/http/config/get/v1/contract.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:read permission required to read config metadata (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:read permission required to read config metadata; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Config key not found"

--- a/contracts/http/config/list/v1/contract.yaml
+++ b/contracts/http/config/list/v1/contract.yaml
@@ -35,7 +35,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:read permission required to enumerate config keys (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:read permission required to enumerate config keys; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
 schemaRefs:
   response: response.schema.json

--- a/contracts/http/config/list/v1/contract.yaml
+++ b/contracts/http/config/list/v1/contract.yaml
@@ -35,7 +35,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated principal lacks the admin role required to enumerate config keys"
+        description: "Forbidden — the ABAC PDP denied the config:read permission required to enumerate config keys (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
 schemaRefs:
   response: response.schema.json

--- a/contracts/http/config/publish/v1/contract.yaml
+++ b/contracts/http/config/publish/v1/contract.yaml
@@ -32,7 +32,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the config:publish permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/publish/v1/contract.yaml
+++ b/contracts/http/config/publish/v1/contract.yaml
@@ -32,7 +32,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:publish permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:publish permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/rollback/v1/contract.yaml
+++ b/contracts/http/config/rollback/v1/contract.yaml
@@ -32,7 +32,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:publish permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:publish permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key or target version does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/rollback/v1/contract.yaml
+++ b/contracts/http/config/rollback/v1/contract.yaml
@@ -32,7 +32,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the config:publish permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key or target version does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/update/v1/contract.yaml
+++ b/contracts/http/config/update/v1/contract.yaml
@@ -31,7 +31,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/update/v1/contract.yaml
+++ b/contracts/http/config/update/v1/contract.yaml
@@ -31,7 +31,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the config:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       404:
         description: "Not Found — config key does not exist (ERR_CONFIG_REPO_NOT_FOUND)"

--- a/contracts/http/config/write/v1/contract.yaml
+++ b/contracts/http/config/write/v1/contract.yaml
@@ -27,7 +27,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — the ABAC PDP denied the config:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
+        description: "Forbidden — caller lacks the config:write permission; the built-in baseline grants the admin and super-admin roles."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"

--- a/contracts/http/config/write/v1/contract.yaml
+++ b/contracts/http/config/write/v1/contract.yaml
@@ -27,7 +27,7 @@ endpoints:
         description: "Unauthorized — missing or invalid bearer token"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       403:
-        description: "Forbidden — authenticated but lacks admin role"
+        description: "Forbidden — the ABAC PDP denied the config:write permission (PR-10b #1348 migrated the role-literal admin gate to permission-based authz; the built-in baseline grants admin/super-admin)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"

--- a/corecells/accesscore/slices/authorizationdecide/baseline.go
+++ b/corecells/accesscore/slices/authorizationdecide/baseline.go
@@ -13,19 +13,64 @@ import (
 // evaluate loop and Authorize log read from the same backing array (F4 fix).
 var builtinBaseline = []abac.Rule{
 	{
-		ID:     "baseline-audit-read-admin",
-		Name:   "Baseline: allow admin/super-admin to read audit ledger",
-		Effect: authz.EffectAllow,
-		Action: []string{authz.PermAuditRead().String()},
-		Conditions: []abac.Condition{
-			{
-				Source:   abac.SourceSubject,
-				Key:      "roles",
-				Operator: abac.OpIn,
-				Values:   []string{runtimeauth.RoleAdmin, runtimeauth.RoleSuperAdmin},
-			},
-		},
+		ID:         "baseline-audit-read-admin",
+		Name:       "Baseline: allow admin/super-admin to read audit ledger",
+		Effect:     authz.EffectAllow,
+		Action:     []string{authz.PermAuditRead().String()},
+		Conditions: []abac.Condition{adminOrSuperAdmin()},
 	},
+	// configcore baseline (PR-10b #1348): one allow rule per migrated slice,
+	// each reproducing the old auth.AnyRole(RoleAdmin) gate. action-scoped +
+	// role-conditioned — same shape as the audit rule above.
+	{
+		ID:         "baseline-config-read-admin",
+		Name:       "Baseline: allow admin/super-admin to read configuration",
+		Effect:     authz.EffectAllow,
+		Action:     []string{authz.PermConfigRead().String()},
+		Conditions: []abac.Condition{adminOrSuperAdmin()},
+	},
+	{
+		ID:         "baseline-config-write-admin",
+		Name:       "Baseline: allow admin/super-admin to write configuration",
+		Effect:     authz.EffectAllow,
+		Action:     []string{authz.PermConfigWrite().String()},
+		Conditions: []abac.Condition{adminOrSuperAdmin()},
+	},
+	{
+		ID:         "baseline-config-publish-admin",
+		Name:       "Baseline: allow admin/super-admin to publish/rollback configuration",
+		Effect:     authz.EffectAllow,
+		Action:     []string{authz.PermConfigPublish().String()},
+		Conditions: []abac.Condition{adminOrSuperAdmin()},
+	},
+	{
+		ID:         "baseline-flag-read-admin",
+		Name:       "Baseline: allow admin/super-admin to read/evaluate feature flags",
+		Effect:     authz.EffectAllow,
+		Action:     []string{authz.PermFlagRead().String()},
+		Conditions: []abac.Condition{adminOrSuperAdmin()},
+	},
+	{
+		ID:         "baseline-flag-write-admin",
+		Name:       "Baseline: allow admin/super-admin to write feature flags",
+		Effect:     authz.EffectAllow,
+		Action:     []string{authz.PermFlagWrite().String()},
+		Conditions: []abac.Condition{adminOrSuperAdmin()},
+	},
+}
+
+// adminOrSuperAdmin is the shared baseline condition: subject.roles ∈
+// {admin, super-admin}. Extracted because all current baseline rules reproduce
+// the same admin gate (≥3 identical literals → constant, per go-standards).
+// Role constants come from runtime/auth so the values match exactly what
+// attributeResolver.resolveSubject emits for the "roles" key (r.principal.Roles).
+func adminOrSuperAdmin() abac.Condition {
+	return abac.Condition{
+		Source:   abac.SourceSubject,
+		Key:      "roles",
+		Operator: abac.OpIn,
+		Values:   []string{runtimeauth.RoleAdmin, runtimeauth.RoleSuperAdmin},
+	}
 }
 
 // builtinBaselineRules returns the tenant-agnostic built-in baseline rule set.
@@ -33,14 +78,12 @@ var builtinBaseline = []abac.Rule{
 // Built-in baseline reproducing the existing role→endpoint gate. action-scoped +
 // role-conditioned — NOT a downgrade allow-all (FR-011 fail-closed governs
 // missing-attr/store-err; the baseline governs the default policy set; the two do
-// not conflict). PR-10b extends one rule per migrated endpoint.
+// not conflict). One rule per migrated endpoint; PR-10b/PR-10c extend it.
 //
-// PR-10a baseline: exactly one rule — PermAuditRead() is allowed for admin and
-// super-admin principals. The condition uses Source=subject, Key="roles",
-// Operator=OpIn so it matches any principal whose Roles slice contains at least
-// one of the listed role values. Role constants are imported from runtime/auth so
-// the values match exactly what attributeResolver.resolveSubject emits for the
-// "roles" key (r.principal.Roles).
+// Current baseline: PermAuditRead() (PR-10a) + the 5 configcore permissions
+// (PR-10b: config:read/write/publish, flag:read/write), each allowed for admin
+// and super-admin principals via adminOrSuperAdmin(). Each rule is action-scoped
+// (Action target) so a baseline allow for one permission never leaks to another.
 //
 // Returns the package-level builtinBaseline slice directly (no allocation).
 func builtinBaselineRules() []abac.Rule {

--- a/corecells/accesscore/slices/authorizationdecide/baseline.go
+++ b/corecells/accesscore/slices/authorizationdecide/baseline.go
@@ -19,9 +19,12 @@ var builtinBaseline = []abac.Rule{
 		Action:     []string{authz.PermAuditRead().String()},
 		Conditions: []abac.Condition{adminOrSuperAdmin()},
 	},
-	// configcore baseline (PR-10b #1348): one allow rule per migrated slice,
-	// each reproducing the old auth.AnyRole(RoleAdmin) gate. action-scoped +
-	// role-conditioned — same shape as the audit rule above.
+	// configcore baseline (PR-10b #1348): one allow rule per migrated slice via
+	// the shared adminOrSuperAdmin() condition. NOTE: the old configcore gates were
+	// auth.AnyRole(RoleAdmin) — admin-only — so this WIDENS them to admit super-admin
+	// (super-admin ⊇ admin; a deliberate relaxation, zero prod impact as superadmin
+	// is not yet issued). See ADR §"Amendment: PR-10b" threat-model re-eval + ruling.
+	// action-scoped + role-conditioned — same shape as the audit rule above.
 	{
 		ID:         "baseline-config-read-admin",
 		Name:       "Baseline: allow admin/super-admin to read configuration",
@@ -60,8 +63,10 @@ var builtinBaseline = []abac.Rule{
 }
 
 // adminOrSuperAdmin is the shared baseline condition: subject.roles ∈
-// {admin, super-admin}. Extracted because all current baseline rules reproduce
-// the same admin gate (≥3 identical literals → constant, per go-standards).
+// {admin, super-admin}. Extracted because all current baseline rules share this
+// same admin+super-admin condition (≥3 identical literals → constant, per
+// go-standards). For audit this matched the prior gate exactly; for configcore it
+// widens the prior admin-only gate (see configcore baseline note above + the ADR).
 // Role constants come from runtime/auth so the values match exactly what
 // attributeResolver.resolveSubject emits for the "roles" key (r.principal.Roles).
 func adminOrSuperAdmin() abac.Condition {

--- a/corecells/accesscore/slices/authorizationdecide/baseline_test.go
+++ b/corecells/accesscore/slices/authorizationdecide/baseline_test.go
@@ -62,15 +62,6 @@ func TestBuiltinBaseline_AuditRead(t *testing.T) {
 			wantAllow: false,
 		},
 		{
-			name: "admin + config:read → NOT allowed by baseline (action-scoped)",
-			principal: &auth.Principal{
-				Kind: auth.PrincipalUser, Subject: "admin-2", TenantID: testTenantIDStr,
-				Roles: []string{auth.RoleAdmin},
-			},
-			action:    "config:read",
-			wantAllow: false,
-		},
-		{
 			name: "admin + other:write → NOT allowed by baseline",
 			principal: &auth.Principal{
 				Kind: auth.PrincipalUser, Subject: "admin-3", TenantID: testTenantIDStr,
@@ -88,6 +79,46 @@ func TestBuiltinBaseline_AuditRead(t *testing.T) {
 			dec := svc.evaluate(nil, resolver, tt.action)
 			assert.Equal(t, tt.wantAllow, dec.IsAllow())
 		})
+	}
+}
+
+// TestBuiltinBaseline_ConfigcorePerms proves the PR-10b configcore baseline
+// rules reproduce the existing admin gate: admin/super-admin → Allow, ordinary
+// user / no-roles → Deny, for each of the 5 migrated configcore permissions.
+// One baseline rule per migrated endpoint, mirroring the auditquery rule.
+func TestBuiltinBaseline_ConfigcorePerms(t *testing.T) {
+	svc := &Service{logger: slog.Default()}
+
+	perms := []string{
+		authz.PermConfigRead().String(),
+		authz.PermConfigWrite().String(),
+		authz.PermConfigPublish().String(),
+		authz.PermFlagRead().String(),
+		authz.PermFlagWrite().String(),
+	}
+
+	roleCases := []struct {
+		name      string
+		roles     []string
+		wantAllow bool
+	}{
+		{"admin → Allow", []string{auth.RoleAdmin}, true},
+		{"super-admin → Allow", []string{auth.RoleSuperAdmin}, true},
+		{"ordinary user → Deny", []string{"viewer"}, false},
+		{"no roles → Deny", nil, false},
+	}
+
+	for _, action := range perms {
+		for _, rc := range roleCases {
+			t.Run(action+" / "+rc.name, func(t *testing.T) {
+				resolver := attributeResolver{principal: &auth.Principal{
+					Kind: auth.PrincipalUser, Subject: "subj-1", TenantID: testTenantIDStr,
+					Roles: rc.roles,
+				}}
+				dec := svc.evaluate(nil, resolver, action)
+				assert.Equal(t, rc.wantAllow, dec.IsAllow())
+			})
+		}
 	}
 }
 

--- a/corecells/accesscore/slices/authorizationdecide/evaluator_test.go
+++ b/corecells/accesscore/slices/authorizationdecide/evaluator_test.go
@@ -53,6 +53,12 @@ func TestEvaluate_ActionTargeting(t *testing.T) {
 	adminPrincipal := &auth.Principal{Kind: auth.PrincipalUser, Subject: "u", TenantID: testTenantIDStr, Roles: []string{auth.RoleAdmin}}
 	resolver := actionResolver(adminPrincipal)
 
+	// "tenant:read" / "other:write" are deliberately NON-baseline synthetic
+	// actions: this test isolates tenant-policy action-targeting, so it must use
+	// actions the built-in baseline does not allow (else baseline allow would mask
+	// the tenant-rule behaviour under test). Do NOT use real permissions like
+	// config:read here — those are baseline-allowed for admin (PR-10b).
+
 	tests := []struct {
 		name      string
 		policies  []*abac.Policy
@@ -74,7 +80,7 @@ func TestEvaluate_ActionTargeting(t *testing.T) {
 				"p1",
 				permitRuleWithAction("r1", []string{testAuditRead}, roleCond),
 			)},
-			action:    "config:read",
+			action:    "other:write",
 			wantAllow: false,
 		},
 		{
@@ -83,7 +89,7 @@ func TestEvaluate_ActionTargeting(t *testing.T) {
 				"p1",
 				permitRule("r1", authz.Obligations{}, roleCond),
 			)},
-			action:    "config:read",
+			action:    "other:write",
 			wantAllow: true,
 		},
 		{
@@ -129,16 +135,16 @@ func TestEvaluate_ActionTargeting(t *testing.T) {
 			name: "multi-action target: matches first of the set",
 			policies: []*abac.Policy{policyWith(
 				"p1",
-				permitRuleWithAction("r1", []string{"config:read", testAuditRead}, roleCond),
+				permitRuleWithAction("r1", []string{"tenant:read", testAuditRead}, roleCond),
 			)},
-			action:    "config:read",
+			action:    "tenant:read",
 			wantAllow: true,
 		},
 		{
 			name: "multi-action target: matches second of the set",
 			policies: []*abac.Policy{policyWith(
 				"p1",
-				permitRuleWithAction("r1", []string{"config:read", testAuditRead}, roleCond),
+				permitRuleWithAction("r1", []string{"tenant:read", testAuditRead}, roleCond),
 			)},
 			action:    testAuditRead,
 			wantAllow: true,
@@ -147,7 +153,7 @@ func TestEvaluate_ActionTargeting(t *testing.T) {
 			name: "multi-action target: action not in set — denies",
 			policies: []*abac.Policy{policyWith(
 				"p1",
-				permitRuleWithAction("r1", []string{"config:read", testAuditRead}, roleCond),
+				permitRuleWithAction("r1", []string{"tenant:read", testAuditRead}, roleCond),
 			)},
 			action:    "other:write",
 			wantAllow: false,

--- a/corecells/accesscore/slices/authorizationdecide/evaluator_test.go
+++ b/corecells/accesscore/slices/authorizationdecide/evaluator_test.go
@@ -56,7 +56,7 @@ func TestEvaluate_ActionTargeting(t *testing.T) {
 	// "tenant:read" / "other:write" are deliberately NON-baseline synthetic
 	// actions: this test isolates tenant-policy action-targeting, so it must use
 	// actions the built-in baseline does not allow (else baseline allow would mask
-	// the tenant-rule behaviour under test). Do NOT use real permissions like
+	// the tenant-rule behavior under test). Do NOT use real permissions like
 	// config:read here — those are baseline-allowed for admin (PR-10b).
 
 	tests := []struct {

--- a/corecells/configcore/cell_test.go
+++ b/corecells/configcore/cell_test.go
@@ -56,6 +56,9 @@ func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
 	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
 }
 
+// cellTestTenantUUID is the canonical test tenant used across cell-level tests.
+const cellTestTenantUUID = "00000000-0000-0000-0000-000000000001"
+
 func newTestCell() *ConfigCore {
 	return NewConfigCore(
 		clock.Real(),
@@ -358,9 +361,9 @@ func initCellWithRouter(t *testing.T) *router.Router {
 // production and configcore routes now gate via auth.RequirePermission, which
 // fails closed without an Authorizer — so business-path cell tests must supply
 // one (PR-10b #1348).
-func pdpAdminCtx(subject, tenantID string) context.Context {
+func pdpAdminCtx(subject string) context.Context {
 	return withAllowAuthorizer(
-		ctxkeys.WithTenantID(auth.TestContext(subject, []string{"admin"}), tenantID),
+		ctxkeys.WithTenantID(auth.TestContext(subject, []string{"admin"}), cellTestTenantUUID),
 	)
 }
 
@@ -370,7 +373,7 @@ func TestConfigCore_RouteConfigList(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
 	// Inject a valid tenant so configread handler can call tenant.FromContext.
-	req = req.WithContext(pdpAdminCtx("tester", "00000000-0000-0000-0000-000000000001"))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code,
@@ -397,7 +400,7 @@ func TestConfigCore_RouteConfigGetByKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/app.name", nil)
 	// Inject a valid tenant so the configread handler reaches the business path
 	// rather than the F6 missing-tenant 403 (a separate gate from auth role).
-	req = req.WithContext(pdpAdminCtx("tester", "00000000-0000-0000-0000-000000000001"))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 
 	// Handler ran (not routing 404): response must be JSON and must not be an auth rejection.
@@ -415,7 +418,7 @@ func TestConfigCore_RouteFlagsList(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/flags/", nil)
 	// Inject a valid tenant so featureflag handler can call tenant.FromContext.
-	req = req.WithContext(pdpAdminCtx("tester", "00000000-0000-0000-0000-000000000001"))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code,
@@ -507,7 +510,7 @@ func TestConfigCore_ProductionAuthGateLock(t *testing.T) {
 			// granted permission admits the caller. A valid TenantID is injected so
 			// tenant-scoped handlers reach the business path rather than the F6
 			// missing-tenant 403 (a separate gate from the permission under test).
-			rec = exec(t, p, pdpAdminCtx("admin-user", gateTenant))
+			rec = exec(t, p, pdpAdminCtx("admin-user"))
 			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
 				"admin %s %s (PDP allow) must not be 401; body %s", p.method, p.path, rec.Body)
 			assert.NotEqual(t, http.StatusForbidden, rec.Code,
@@ -522,13 +525,12 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 	// Seed enough config entries to produce a nextCursor.
 	// Both write and read requests carry the same test tenant so the read sees
 	// what was written.
-	const cellTestTenantStr = "00000000-0000-0000-0000-000000000001"
 	for i := range 3 {
 		body := fmt.Sprintf(`{"key":"cfg-%d","value":"val-%d"}`, i, i)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/config/", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(pdpAdminCtx("admin-test", cellTestTenantStr))
+		req = req.WithContext(pdpAdminCtx("admin-test"))
 		r.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusCreated, rec.Code, "setup: create config entry %d", i)
 	}
@@ -537,7 +539,7 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 	// config-read declares the ABAC PDP permission gate so an admin principal is required.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/?limit=1", nil)
-	req = req.WithContext(pdpAdminCtx("tester", cellTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -555,7 +557,7 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet,
 		"/api/v1/flags/?cursor="+configPage.NextCursor, nil)
-	req = req.WithContext(pdpAdminCtx("tester", cellTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code,
@@ -602,7 +604,7 @@ func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
 	// Also inject the same tenant used for seeding so the handler can find the flags.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/flags/?limit=1", nil)
-	req = req.WithContext(pdpAdminCtx("tester", reverseTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -619,7 +621,7 @@ func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet,
 		"/api/v1/config/?cursor="+flagPage.NextCursor, nil)
-	req = req.WithContext(pdpAdminCtx("tester", reverseTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester"))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code,

--- a/corecells/configcore/cell_test.go
+++ b/corecells/configcore/cell_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/corecells/configcore/configcoretest"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/corecells/configcore/slices/configpublish"
@@ -330,13 +331,24 @@ func initCellWithRouter(t *testing.T) *router.Router {
 	return r
 }
 
+// pdpAdminCtx returns a production-faithful admin request context: an admin
+// principal + tenant + an allow Authorizer. The primary listener wires a PDP in
+// production and configcore routes now gate via auth.RequirePermission, which
+// fails closed without an Authorizer — so business-path cell tests must supply
+// one (PR-10b #1348).
+func pdpAdminCtx(subject, tenantID string) context.Context {
+	return configcoretest.WithAllowAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext(subject, []string{"admin"}), tenantID),
+	)
+}
+
 func TestConfigCore_RouteConfigList(t *testing.T) {
 	r := initCellWithRouter(t)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/", nil)
 	// Inject a valid tenant so configread handler can call tenant.FromContext.
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), "00000000-0000-0000-0000-000000000001"))
+	req = req.WithContext(pdpAdminCtx("tester", "00000000-0000-0000-0000-000000000001"))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code,
@@ -363,7 +375,7 @@ func TestConfigCore_RouteConfigGetByKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/app.name", nil)
 	// Inject a valid tenant so the configread handler reaches the business path
 	// rather than the F6 missing-tenant 403 (a separate gate from auth role).
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), "00000000-0000-0000-0000-000000000001"))
+	req = req.WithContext(pdpAdminCtx("tester", "00000000-0000-0000-0000-000000000001"))
 	r.ServeHTTP(rec, req)
 
 	// Handler ran (not routing 404): response must be JSON and must not be an auth rejection.
@@ -381,7 +393,7 @@ func TestConfigCore_RouteFlagsList(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/flags/", nil)
 	// Inject a valid tenant so featureflag handler can call tenant.FromContext.
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), "00000000-0000-0000-0000-000000000001"))
+	req = req.WithContext(pdpAdminCtx("tester", "00000000-0000-0000-0000-000000000001"))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code,
@@ -390,12 +402,14 @@ func TestConfigCore_RouteFlagsList(t *testing.T) {
 
 // TestConfigCore_ProductionAuthGateLock is the P0 integration test demanded by
 // the PR review: it exercises the REAL production routing path (cell.go ->
-// slice.RegisterRoutes -> auth.Mount) and locks the 401 / 403 / 2xx
-// spectrum end-to-end for each admin-guarded write endpoint.
+// slice.RegisterRoutes -> auth.Mount) and locks the 401 / 403(fail-closed) /
+// 403(PDP-deny) / 2xx spectrum end-to-end for each permission-gated endpoint.
 //
-// This test would have caught the prior drift where cell.go attached raw
-// HandlerFuncs that bypassed the route-level policy — every case below depends
-// on the admin guard actually being wired on the production path.
+// Since PR-10b the gate is auth.RequirePermission(authz.Perm*) (ABAC PDP), not a
+// role literal. This test would have caught the prior drift where cell.go
+// attached raw HandlerFuncs that bypassed the route-level policy, AND now pins
+// the fail-closed contract: even an admin is rejected (403) when no Authorizer is
+// wired, so a composition root that forgets to inject the PDP fails here.
 //
 // ref: kubernetes/kubernetes pkg/endpoints/installer_test.go — integration
 // test reaches the installed handler via the real mux so authz wiring is
@@ -438,6 +452,7 @@ func TestConfigCore_ProductionAuthGateLock(t *testing.T) {
 		return rec
 	}
 
+	const gateTenant = "00000000-0000-0000-0000-000000000001"
 	for _, p := range paths {
 		t.Run(p.name, func(t *testing.T) {
 			// --- 401: no authenticated subject on context.
@@ -446,26 +461,35 @@ func TestConfigCore_ProductionAuthGateLock(t *testing.T) {
 				"unauthenticated %s %s must be 401 (auth.Mount -> Authenticated); got body %s",
 				p.method, p.path, rec.Body)
 
-			// --- 403: authenticated but wrong role.
-			rec = exec(t, p, auth.TestContext("user-non-admin", []string{"viewer"}))
+			// --- 403 (fail-closed): authenticated ADMIN but NO Authorizer wired.
+			// auth.RequirePermission fails closed when the PDP is absent — even for
+			// an admin — so a composition root that forgets bootstrap.WithPrimaryAuthorizer
+			// is caught here, not in production. This replaces the old AnyRole(admin)
+			// gate, which admitted the admin without any PDP.
+			rec = exec(t, p, ctxkeys.WithTenantID(auth.TestContext("admin-user", []string{"admin"}), gateTenant))
 			assert.Equal(t, http.StatusForbidden, rec.Code,
-				"non-admin %s %s must be 403 (auth.Mount -> AnyRole(admin)); got body %s",
+				"%s %s with no Authorizer must fail closed (403); got body %s",
 				p.method, p.path, rec.Body)
 
-			// --- 2xx: admin role. We do not pin the exact success code
-			// (some paths return 404 because the resource was not seeded),
-			// but 401 / 403 must be gone — proving the policy ran and admits
-			// the admin. A valid TenantID is injected so the tenant-scoped
-			// handlers reach the business path rather than the F6 missing-tenant
-			// 403 (which is a separate gate from the admin-role policy under test).
-			adminCtx := ctxkeys.WithTenantID(
-				auth.TestContext("admin-user", []string{"admin"}),
-				"00000000-0000-0000-0000-000000000001")
-			rec = exec(t, p, adminCtx)
+			// --- 403 (PDP deny): authenticated + a wired PDP that DENIES → 403.
+			rec = exec(t, p, configcoretest.WithDenyAuthorizer(
+				ctxkeys.WithTenantID(auth.TestContext("user-non-admin", []string{"viewer"}), gateTenant),
+				"policy: no matching allow rule",
+			))
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"%s %s denied by the PDP must be 403; got body %s", p.method, p.path, rec.Body)
+
+			// --- 2xx: admin + a wired PDP that ALLOWS + valid tenant. We do not pin
+			// the exact success code (some paths 404 because the resource was not
+			// seeded), but 401 / 403 must be gone — proving the gate ran and the
+			// granted permission admits the caller. A valid TenantID is injected so
+			// tenant-scoped handlers reach the business path rather than the F6
+			// missing-tenant 403 (a separate gate from the permission under test).
+			rec = exec(t, p, pdpAdminCtx("admin-user", gateTenant))
 			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
-				"admin %s %s must not be 401; body %s", p.method, p.path, rec.Body)
+				"admin %s %s (PDP allow) must not be 401; body %s", p.method, p.path, rec.Body)
 			assert.NotEqual(t, http.StatusForbidden, rec.Code,
-				"admin %s %s must not be 403; body %s", p.method, p.path, rec.Body)
+				"admin %s %s (PDP allow) must not be 403; body %s", p.method, p.path, rec.Body)
 		})
 	}
 }
@@ -482,16 +506,16 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/config/", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("admin-test", []string{"admin"}), cellTestTenantStr))
+		req = req.WithContext(pdpAdminCtx("admin-test", cellTestTenantStr))
 		r.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusCreated, rec.Code, "setup: create config entry %d", i)
 	}
 
 	// Get config-read page with limit=1 to obtain a cursor.
-	// config-read declares auth.AnyRole(dto.RoleAdmin) so an admin principal is required.
+	// config-read declares the ABAC PDP permission gate so an admin principal is required.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/?limit=1", nil)
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), cellTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester", cellTestTenantStr))
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -504,12 +528,12 @@ func TestConfigCore_CrossSliceCursorRejection(t *testing.T) {
 	require.NotEmpty(t, configPage.NextCursor)
 
 	// Use config-read cursor on feature-flag list endpoint — must be rejected.
-	// feature-flag also declares auth.AnyRole(dto.RoleAdmin) so supply an admin principal.
+	// feature-flag also declares the ABAC PDP permission gate so supply an admin principal.
 	// Also inject the same tenant so the handler can reach the cursor-validation step.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet,
 		"/api/v1/flags/?cursor="+configPage.NextCursor, nil)
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), cellTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester", cellTestTenantStr))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code,
@@ -552,11 +576,11 @@ func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
 	}
 
 	// Get flag page with limit=1 to obtain a cursor.
-	// feature-flag declares auth.AnyRole(dto.RoleAdmin) so an admin principal is required.
+	// feature-flag declares the ABAC PDP permission gate so an admin principal is required.
 	// Also inject the same tenant used for seeding so the handler can find the flags.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/flags/?limit=1", nil)
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), reverseTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester", reverseTestTenantStr))
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -568,12 +592,12 @@ func TestConfigCore_CrossSliceCursorRejection_Reverse(t *testing.T) {
 	require.True(t, flagPage.HasMore, "need hasMore to get a flag cursor")
 
 	// Use flag cursor on config-read endpoint — must be rejected.
-	// config-read also declares auth.AnyRole(dto.RoleAdmin) so supply an admin principal.
+	// config-read also declares the ABAC PDP permission gate so supply an admin principal.
 	// Inject the same tenant used for seeding so the handler reaches the cursor-validation step.
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet,
 		"/api/v1/config/?cursor="+flagPage.NextCursor, nil)
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext("tester", []string{"admin"}), reverseTestTenantStr))
+	req = req.WithContext(pdpAdminCtx("tester", reverseTestTenantStr))
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code,

--- a/corecells/configcore/cell_test.go
+++ b/corecells/configcore/cell_test.go
@@ -387,8 +387,17 @@ func TestConfigCore_RouteConfigCreate(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	// Inject admin context so the request passes PDP and reaches the business path.
+	req = req.WithContext(pdpAdminCtx("admin-test"))
 	r.ServeHTTP(rec, req)
 
+	// The route is reachable and past auth: must not be 401 (unauthenticated) or
+	// 403 (auth-forbidden). It may be 201 Created or another business code, but
+	// never a routing 404 either.
+	assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"POST /api/v1/config/ with admin context must not be 401 (got %d body=%s)", rec.Code, rec.Body)
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"POST /api/v1/config/ with admin context must not be 403 (got %d body=%s)", rec.Code, rec.Body)
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
 		"POST /api/v1/config/ should not return 404 (got %d)", rec.Code)
 }
@@ -443,26 +452,30 @@ func TestConfigCore_ProductionAuthGateLock(t *testing.T) {
 	r := initCellWithRouter(t)
 
 	type adminWritePath struct {
-		name   string
-		method string
-		path   string
-		body   string
+		name       string
+		method     string
+		path       string
+		body       string
+		wantAction string // expected PDP action string; asserted in the 2xx branch
 	}
 	paths := []adminWritePath{
-		{"config-read:list", http.MethodGet, "/api/v1/config/", ""},
-		{"config-read:get", http.MethodGet, "/api/v1/config/k", ""},
-		{"flag-read:list", http.MethodGet, "/api/v1/flags/", ""},
-		{"flag-read:get", http.MethodGet, "/api/v1/flags/k", ""},
-		{"flag-read:evaluate", http.MethodPost, "/api/v1/flags/k/evaluate", `{"subject":"test"}`},
-		{"config-write:create", http.MethodPost, "/api/v1/config/", `{"key":"k","value":"v"}`},
-		{"config-write:update", http.MethodPut, "/api/v1/config/k", `{"value":"v"}`},
-		{"config-write:delete", http.MethodDelete, "/api/v1/config/k", ``},
-		{"config-publish:publish", http.MethodPost, "/api/v1/config/k/publish", ``},
-		{"config-publish:rollback", http.MethodPost, "/api/v1/config/k/rollback", `{"version":1}`},
-		{"flag-write:create", http.MethodPost, "/api/v1/flags/", `{"key":"k","enabled":false,"rolloutPercentage":0,"description":"d"}`},
-		{"flag-write:update", http.MethodPut, "/api/v1/flags/k", `{"enabled":true,"rolloutPercentage":10,"description":"d"}`},
-		{"flag-write:toggle", http.MethodPost, "/api/v1/flags/k/toggle", `{"enabled":true}`},
-		{"flag-write:delete", http.MethodDelete, "/api/v1/flags/k", ``},
+		{"config-read:list", http.MethodGet, "/api/v1/config/", "", "config:read"},
+		{"config-read:get", http.MethodGet, "/api/v1/config/k", "", "config:read"},
+		{"flag-read:list", http.MethodGet, "/api/v1/flags/", "", "flag:read"},
+		{"flag-read:get", http.MethodGet, "/api/v1/flags/k", "", "flag:read"},
+		{"flag-read:evaluate", http.MethodPost, "/api/v1/flags/k/evaluate", `{"subject":"test"}`, "flag:read"},
+		{"config-write:create", http.MethodPost, "/api/v1/config/", `{"key":"k","value":"v"}`, "config:write"},
+		{"config-write:update", http.MethodPut, "/api/v1/config/k", `{"value":"v"}`, "config:write"},
+		{"config-write:delete", http.MethodDelete, "/api/v1/config/k", ``, "config:write"},
+		{"config-publish:publish", http.MethodPost, "/api/v1/config/k/publish", ``, "config:publish"},
+		{"config-publish:rollback", http.MethodPost, "/api/v1/config/k/rollback", `{"version":1}`, "config:publish"},
+		{
+			"flag-write:create", http.MethodPost, "/api/v1/flags/",
+			`{"key":"k","enabled":false,"rolloutPercentage":0,"description":"d"}`, "flag:write",
+		},
+		{"flag-write:update", http.MethodPut, "/api/v1/flags/k", `{"enabled":true,"rolloutPercentage":10,"description":"d"}`, "flag:write"},
+		{"flag-write:toggle", http.MethodPost, "/api/v1/flags/k/toggle", `{"enabled":true}`, "flag:write"},
+		{"flag-write:delete", http.MethodDelete, "/api/v1/flags/k", ``, "flag:write"},
 	}
 
 	exec := func(t *testing.T, p adminWritePath, ctx context.Context) *httptest.ResponseRecorder {
@@ -504,17 +517,25 @@ func TestConfigCore_ProductionAuthGateLock(t *testing.T) {
 			assert.Equal(t, http.StatusForbidden, rec.Code,
 				"%s %s denied by the PDP must be 403; got body %s", p.method, p.path, rec.Body)
 
-			// --- 2xx: admin + a wired PDP that ALLOWS + valid tenant. We do not pin
-			// the exact success code (some paths 404 because the resource was not
+			// --- 2xx: admin + a capturing PDP that ALLOWS + valid tenant. We do not
+			// pin the exact success code (some paths 404 because the resource was not
 			// seeded), but 401 / 403 must be gone — proving the gate ran and the
-			// granted permission admits the caller. A valid TenantID is injected so
-			// tenant-scoped handlers reach the business path rather than the F6
-			// missing-tenant 403 (a separate gate from the permission under test).
-			rec = exec(t, p, pdpAdminCtx("admin-user"))
+			// granted permission admits the caller. Additionally we assert the exact
+			// PDP action the route requested (wantAction), catching an
+			// endpoint↔permission misbinding the role-agnostic baseline would mask.
+			cap := allowAuthorizer()
+			rec = exec(t, p, configcoretest.WithAuthorizer(
+				ctxkeys.WithTenantID(auth.TestContext("admin-user", []string{"admin"}), gateTenant),
+				cap,
+			))
 			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
 				"admin %s %s (PDP allow) must not be 401; body %s", p.method, p.path, rec.Body)
 			assert.NotEqual(t, http.StatusForbidden, rec.Code,
 				"admin %s %s (PDP allow) must not be 403; body %s", p.method, p.path, rec.Body)
+			assert.Equal(t, p.wantAction, cap.GotAction,
+				"route %s %s must request PDP action %q (got %q); a misbinding would be masked by "+
+					"the role-agnostic baseline that allows admin for every config/flag perm",
+				p.method, p.path, p.wantAction, cap.GotAction)
 		})
 	}
 }

--- a/corecells/configcore/cell_test.go
+++ b/corecells/configcore/cell_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/query"
@@ -33,6 +34,27 @@ import (
 	"github.com/ghbvf/gocell/runtime/observability/healthz/healthztest"
 	"github.com/ghbvf/gocell/runtime/state/cas"
 )
+
+// allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer build the PDP
+// verdicts for tests. The authz.Allow/Deny construction lives in _test.go,
+// which AUTHZ-DECISION-ALLOW-DENY-CALLER-01 sanctions for test doubles; the
+// CapturingAuthorizer type and WithAuthorizer ctx wiring are shared via
+// configcoretest (PR-10b #1348).
+func allowAuthorizer() *configcoretest.CapturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("test allowAuthorizer: authz.Allow: " + err.Error())
+	}
+	return &configcoretest.CapturingAuthorizer{Decision: dec}
+}
+
+func withAllowAuthorizer(ctx context.Context) context.Context {
+	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
+}
+
+func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
+}
 
 func newTestCell() *ConfigCore {
 	return NewConfigCore(
@@ -337,7 +359,7 @@ func initCellWithRouter(t *testing.T) *router.Router {
 // fails closed without an Authorizer — so business-path cell tests must supply
 // one (PR-10b #1348).
 func pdpAdminCtx(subject, tenantID string) context.Context {
-	return configcoretest.WithAllowAuthorizer(
+	return withAllowAuthorizer(
 		ctxkeys.WithTenantID(auth.TestContext(subject, []string{"admin"}), tenantID),
 	)
 }
@@ -472,7 +494,7 @@ func TestConfigCore_ProductionAuthGateLock(t *testing.T) {
 				p.method, p.path, rec.Body)
 
 			// --- 403 (PDP deny): authenticated + a wired PDP that DENIES → 403.
-			rec = exec(t, p, configcoretest.WithDenyAuthorizer(
+			rec = exec(t, p, withDenyAuthorizer(
 				ctxkeys.WithTenantID(auth.TestContext("user-non-admin", []string{"viewer"}), gateTenant),
 				"policy: no matching allow rule",
 			))

--- a/corecells/configcore/configcoretest/authz.go
+++ b/corecells/configcore/configcoretest/authz.go
@@ -4,7 +4,14 @@ package configcoretest
 // authz migration (PR-10b #1348). Every configcore slice gated by
 // auth.RequirePermission(authz.Perm*) needs an Authorizer in the request context
 // to pass the gate; these helpers supply an action-capturing Authorizer type and
-// the ctx wiring, defined ONCE here instead of per-slice.
+// the ctx wiring, shared here for slices that can import configcoretest.
+//
+// Note on circular-dependency stubs: slices whose test packages would create an
+// import cycle through configcoretest (e.g. configwrite, because configcoretest
+// imports configwrite) define equivalent local stubs in their own _test.go files
+// rather than importing this package. Those stubs are structurally identical to
+// CapturingAuthorizer and WithAuthorizer but are unexported and local to the slice
+// under test.
 //
 // Verdict construction (Allow/Deny) was moved to each consumer's _test.go under
 // local helpers (allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer).

--- a/corecells/configcore/configcoretest/authz.go
+++ b/corecells/configcore/configcoretest/authz.go
@@ -3,8 +3,14 @@ package configcoretest
 // authz.go — shared ABAC-PDP test helpers for the configcore permission-based
 // authz migration (PR-10b #1348). Every configcore slice gated by
 // auth.RequirePermission(authz.Perm*) needs an Authorizer in the request context
-// to pass the gate; these helpers supply allow / deny / action-capturing
-// Authorizers and the ctx wiring, defined ONCE here instead of per-slice.
+// to pass the gate; these helpers supply an action-capturing Authorizer type and
+// the ctx wiring, defined ONCE here instead of per-slice.
+//
+// Verdict construction (Allow/Deny) was moved to each consumer's _test.go under
+// local helpers (allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer).
+// AUTHZ-DECISION-ALLOW-DENY-CALLER-01 sanctions authz.Allow/Deny in _test.go
+// files (test doubles) but not in non-test production-scanned packages; this
+// file remains production-scanned so it must not call authz.Allow or authz.Deny.
 
 import (
 	"context"
@@ -33,35 +39,9 @@ func (c *CapturingAuthorizer) Authorize(_ context.Context, subject, resource, ac
 	return c.Decision, c.Err
 }
 
-// AllowAuthorizer returns a CapturingAuthorizer that grants every request
-// (Decision = Allow with no obligations), mirroring a wired PDP that permits.
-func AllowAuthorizer() *CapturingAuthorizer {
-	dec, err := authz.Allow(authz.Obligations{})
-	if err != nil {
-		panic("configcoretest.AllowAuthorizer: authz.Allow: " + err.Error())
-	}
-	return &CapturingAuthorizer{Decision: dec}
-}
-
-// DenyAuthorizer returns a CapturingAuthorizer that denies every request with
-// the given reason — used to assert a wired PDP's deny surfaces as 403.
-func DenyAuthorizer(reason string) *CapturingAuthorizer {
-	return &CapturingAuthorizer{Decision: authz.Deny(reason)}
-}
-
 // WithAuthorizer injects an Authorizer into ctx via the canonical
 // auth.WithAuthorizer funnel (the same one the primary listener uses in
 // production), so tests need not import runtime/auth just for the wiring.
 func WithAuthorizer(ctx context.Context, a auth.Authorizer) context.Context {
 	return auth.WithAuthorizer(ctx, a)
-}
-
-// WithAllowAuthorizer wraps ctx with an allow-all Authorizer (success path).
-func WithAllowAuthorizer(ctx context.Context) context.Context {
-	return auth.WithAuthorizer(ctx, AllowAuthorizer())
-}
-
-// WithDenyAuthorizer wraps ctx with a deny-all Authorizer (PDP-deny → 403 path).
-func WithDenyAuthorizer(ctx context.Context, reason string) context.Context {
-	return auth.WithAuthorizer(ctx, DenyAuthorizer(reason))
 }

--- a/corecells/configcore/configcoretest/authz.go
+++ b/corecells/configcore/configcoretest/authz.go
@@ -1,0 +1,67 @@
+package configcoretest
+
+// authz.go — shared ABAC-PDP test helpers for the configcore permission-based
+// authz migration (PR-10b #1348). Every configcore slice gated by
+// auth.RequirePermission(authz.Perm*) needs an Authorizer in the request context
+// to pass the gate; these helpers supply allow / deny / action-capturing
+// Authorizers and the ctx wiring, defined ONCE here instead of per-slice.
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/pkg/authz"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// CapturingAuthorizer is a test-only auth.Authorizer that returns a fixed
+// Decision and records the (subject, resource, action) of the last Authorize
+// call. GotAction lets a handler test PIN the exact permission the route gate
+// asked the PDP for (e.g. assert configwrite demanded "config:write", not
+// "config:read") — the only guard that catches an endpoint↔permission misbinding
+// the role-agnostic baseline (admin allowed for every config perm) would mask.
+type CapturingAuthorizer struct {
+	Decision    authz.Decision
+	Err         error
+	GotSubject  string
+	GotResource string
+	GotAction   string
+}
+
+// Authorize records the call and returns the fixed Decision/Err.
+func (c *CapturingAuthorizer) Authorize(_ context.Context, subject, resource, action string) (authz.Decision, error) {
+	c.GotSubject, c.GotResource, c.GotAction = subject, resource, action
+	return c.Decision, c.Err
+}
+
+// AllowAuthorizer returns a CapturingAuthorizer that grants every request
+// (Decision = Allow with no obligations), mirroring a wired PDP that permits.
+func AllowAuthorizer() *CapturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("configcoretest.AllowAuthorizer: authz.Allow: " + err.Error())
+	}
+	return &CapturingAuthorizer{Decision: dec}
+}
+
+// DenyAuthorizer returns a CapturingAuthorizer that denies every request with
+// the given reason — used to assert a wired PDP's deny surfaces as 403.
+func DenyAuthorizer(reason string) *CapturingAuthorizer {
+	return &CapturingAuthorizer{Decision: authz.Deny(reason)}
+}
+
+// WithAuthorizer injects an Authorizer into ctx via the canonical
+// auth.WithAuthorizer funnel (the same one the primary listener uses in
+// production), so tests need not import runtime/auth just for the wiring.
+func WithAuthorizer(ctx context.Context, a auth.Authorizer) context.Context {
+	return auth.WithAuthorizer(ctx, a)
+}
+
+// WithAllowAuthorizer wraps ctx with an allow-all Authorizer (success path).
+func WithAllowAuthorizer(ctx context.Context) context.Context {
+	return auth.WithAuthorizer(ctx, AllowAuthorizer())
+}
+
+// WithDenyAuthorizer wraps ctx with a deny-all Authorizer (PDP-deny → 403 path).
+func WithDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return auth.WithAuthorizer(ctx, DenyAuthorizer(reason))
+}

--- a/corecells/configcore/configcoretest/authz_test.go
+++ b/corecells/configcore/configcoretest/authz_test.go
@@ -1,0 +1,57 @@
+package configcoretest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/authz"
+	"github.com/ghbvf/gocell/runtime/auth"
+)
+
+// TestCapturingAuthorizer_RecordsAndReturns covers CapturingAuthorizer.Authorize:
+// it must record the (subject, resource, action) it was called with and return
+// the fixed Decision. These helpers are exercised by every configcore slice's
+// _test.go, but cross-package coverage is not attributed here, so this in-package
+// test pins them directly.
+func TestCapturingAuthorizer_RecordsAndReturns(t *testing.T) {
+	allow, err := authz.Allow(authz.Obligations{})
+	require.NoError(t, err)
+	c := &CapturingAuthorizer{Decision: allow}
+
+	dec, aerr := c.Authorize(context.Background(), "subj-1", "/api/v1/config/", "config:write")
+	require.NoError(t, aerr)
+	assert.True(t, dec.IsAllow(), "Authorize must return the fixed Decision")
+	assert.Equal(t, "subj-1", c.GotSubject)
+	assert.Equal(t, "/api/v1/config/", c.GotResource)
+	assert.Equal(t, "config:write", c.GotAction)
+}
+
+// TestCapturingAuthorizer_PropagatesErr covers the Err passthrough path.
+func TestCapturingAuthorizer_PropagatesErr(t *testing.T) {
+	want := errors.New("pdp unavailable")
+	c := &CapturingAuthorizer{Decision: authz.Deny("denied"), Err: want}
+
+	dec, err := c.Authorize(context.Background(), "s", "/r", "a")
+	require.ErrorIs(t, err, want)
+	assert.False(t, dec.IsAllow())
+	assert.Equal(t, "a", c.GotAction)
+}
+
+// TestWithAuthorizer_RoundTrips covers WithAuthorizer: the injected Authorizer
+// must be retrievable via the canonical auth.AuthorizerFromContext funnel (the
+// same one RequirePermission reads).
+func TestWithAuthorizer_RoundTrips(t *testing.T) {
+	c := &CapturingAuthorizer{Decision: authz.Deny("x")}
+	ctx := WithAuthorizer(context.Background(), c)
+
+	got, ok := auth.AuthorizerFromContext(ctx)
+	require.True(t, ok, "WithAuthorizer must inject an Authorizer retrievable via AuthorizerFromContext")
+
+	// Prove it is the same authorizer by exercising it and reading the capture.
+	_, _ = got.Authorize(context.Background(), "s", "/r", "round:trip")
+	assert.Equal(t, "round:trip", c.GotAction)
+}

--- a/corecells/configcore/slices/configpublish/contract_test.go
+++ b/corecells/configcore/slices/configpublish/contract_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/corecells/configcore/configcoretest"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/testutil"
@@ -96,7 +97,9 @@ func TestHttpConfigPublishV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
 	req := httptest.NewRequest(c.HTTP.Method, path, nil).
-		WithContext(ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr))
+		WithContext(configcoretest.WithAllowAuthorizer(
+			ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
+		))
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 
@@ -113,7 +116,10 @@ func TestHttpConfigRollbackV1Serve(t *testing.T) {
 	seedContractEntry(repo, "value")
 
 	// Publish first to create version 1 so rollback target exists.
-	_, err := svc.Publish(ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr), "app.name")
+	publishCtx := configcoretest.WithAllowAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
+	)
+	_, err := svc.Publish(publishCtx, "app.name")
 	require.NoError(t, err)
 
 	mux := newContractMux(svc)
@@ -131,7 +137,9 @@ func TestHttpConfigRollbackV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
 	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1,"expectedVersion":1}`)).
-		WithContext(ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr))
+		WithContext(configcoretest.WithAllowAuthorizer(
+			ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
+		))
 	req.Header.Set("Content-Type", "application/json")
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -158,7 +166,9 @@ func TestHttpConfigPublishV1_Serve_NotFound(t *testing.T) {
 	path := strings.Replace(c.HTTP.Path, "{key}", "no-such-key", 1)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, nil).
-		WithContext(ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr))
+		WithContext(configcoretest.WithAllowAuthorizer(
+			ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
+		))
 	mux.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusNotFound, rec.Code)
@@ -174,9 +184,9 @@ func TestHttpConfigPublishV1_Serve_NotFound(t *testing.T) {
 }
 
 // TestHttpConfigPublishV1_Serve_Unauthorized exercises the real handler for
-// 401 (no auth ctx) and 403 (authenticated but lacks admin role) paths, then
-// validates the response body shape against the contract's declared error schema
-// and asserts the exact error code emitted by the real auth chain.
+// 401 (no auth ctx) and 403 paths under the config:publish-gated (PDP) policy,
+// then validates the response body shape against the contract's declared error
+// schema and asserts the exact error code emitted by the real auth chain.
 func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.publish.v1")
@@ -186,7 +196,7 @@ func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
 
 	t.Run("401_no_subject", func(t *testing.T) {
-		// context.Background() carries no subject → RequireAnyRole → ErrAuthUnauthorized → 401
+		// context.Background() carries no subject → RequirePermission → ErrAuthUnauthorized → 401
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(c.HTTP.Method, path, nil).
 			WithContext(context.Background())
@@ -194,32 +204,50 @@ func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, rec.Code)
 		// Validate envelope shape against contract schema.
 		c.ValidateErrorResponse(t, rec.Code, rec.Body.Bytes())
-		// Assert the real error code emitted by RequireAnyRole (missing subject path).
+		// Assert the real error code emitted by RequirePermission (missing subject path).
 		var env errEnvelope
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
 		require.Equal(t, "ERR_AUTH_UNAUTHORIZED", env.Error.Code,
 			"missing subject must produce ERR_AUTH_UNAUTHORIZED, not ERR_AUTH_INVALID_TOKEN")
 	})
 
-	t.Run("403_insufficient_role", func(t *testing.T) {
-		// auth.TestContext with a non-admin role → RequireAnyRole → ErrAuthForbidden → 403
+	t.Run("403_pdp_deny", func(t *testing.T) {
+		// Principal present, PDP denies → RequirePermission → ErrAuthForbidden → 403
+		rec := httptest.NewRecorder()
+		ctx := configcoretest.WithDenyAuthorizer(
+			auth.TestContext("user-readonly", []string{"viewer"}),
+			"policy deny",
+		)
+		req := httptest.NewRequest(c.HTTP.Method, path, nil).WithContext(ctx)
+		mux.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		// Validate envelope shape against contract schema.
+		c.ValidateErrorResponse(t, rec.Code, rec.Body.Bytes())
+		// Assert the real error code emitted by RequirePermission (PDP deny path).
+		var env errEnvelope
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+		require.Equal(t, "ERR_AUTH_FORBIDDEN", env.Error.Code,
+			"PDP deny must produce ERR_AUTH_FORBIDDEN")
+	})
+
+	t.Run("403_no_authorizer", func(t *testing.T) {
+		// Principal present but no Authorizer in ctx → fail-closed 403.
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(c.HTTP.Method, path, nil).
 			WithContext(auth.TestContext("user-readonly", []string{"viewer"}))
 		mux.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusForbidden, rec.Code)
-		// Validate envelope shape against contract schema.
 		c.ValidateErrorResponse(t, rec.Code, rec.Body.Bytes())
-		// Assert the real error code emitted by RequireAnyRole (insufficient role path).
 		var env errEnvelope
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
 		require.Equal(t, "ERR_AUTH_FORBIDDEN", env.Error.Code,
-			"insufficient role must produce ERR_AUTH_FORBIDDEN, not ERR_AUTH_INVALID_TOKEN")
+			"missing Authorizer must produce ERR_AUTH_FORBIDDEN (fail-closed)")
 	})
 }
 
 // TestHttpConfigRollbackV1_Serve_Unauthorized mirrors the publish unauthorized test
-// for the rollback endpoint, asserting real error codes from the RequireAnyRole chain.
+// for the rollback endpoint, asserting real error codes from the config:publish-gated
+// (PDP) RequirePermission chain.
 func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.rollback.v1")
@@ -242,7 +270,25 @@ func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 			"missing subject must produce ERR_AUTH_UNAUTHORIZED")
 	})
 
-	t.Run("403_insufficient_role", func(t *testing.T) {
+	t.Run("403_pdp_deny", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ctx := configcoretest.WithDenyAuthorizer(
+			auth.TestContext("user-readonly", []string{"viewer"}),
+			"policy deny",
+		)
+		req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1}`)).
+			WithContext(ctx)
+		req.Header.Set("Content-Type", "application/json")
+		mux.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		c.ValidateErrorResponse(t, rec.Code, rec.Body.Bytes())
+		var env errEnvelope
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+		require.Equal(t, "ERR_AUTH_FORBIDDEN", env.Error.Code,
+			"PDP deny must produce ERR_AUTH_FORBIDDEN")
+	})
+
+	t.Run("403_no_authorizer", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1}`)).
 			WithContext(auth.TestContext("user-readonly", []string{"viewer"}))
@@ -253,7 +299,7 @@ func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 		var env errEnvelope
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
 		require.Equal(t, "ERR_AUTH_FORBIDDEN", env.Error.Code,
-			"insufficient role must produce ERR_AUTH_FORBIDDEN")
+			"missing Authorizer must produce ERR_AUTH_FORBIDDEN (fail-closed)")
 	})
 }
 

--- a/corecells/configcore/slices/configpublish/contract_test.go
+++ b/corecells/configcore/slices/configpublish/contract_test.go
@@ -215,7 +215,6 @@ func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 		rec := httptest.NewRecorder()
 		ctx := withDenyAuthorizer(
 			auth.TestContext("user-readonly", []string{"viewer"}),
-			"policy deny",
 		)
 		req := httptest.NewRequest(c.HTTP.Method, path, nil).WithContext(ctx)
 		mux.ServeHTTP(rec, req)
@@ -273,7 +272,6 @@ func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 		rec := httptest.NewRecorder()
 		ctx := withDenyAuthorizer(
 			auth.TestContext("user-readonly", []string{"viewer"}),
-			"policy deny",
 		)
 		req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1}`)).
 			WithContext(ctx)

--- a/corecells/configcore/slices/configpublish/contract_test.go
+++ b/corecells/configcore/slices/configpublish/contract_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ghbvf/gocell/corecells/configcore/configcoretest"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/mem"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/testutil"
@@ -97,7 +96,7 @@ func TestHttpConfigPublishV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
 	req := httptest.NewRequest(c.HTTP.Method, path, nil).
-		WithContext(configcoretest.WithAllowAuthorizer(
+		WithContext(withAllowAuthorizer(
 			ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
 		))
 	mux.ServeHTTP(rec, req)
@@ -116,7 +115,7 @@ func TestHttpConfigRollbackV1Serve(t *testing.T) {
 	seedContractEntry(repo, "value")
 
 	// Publish first to create version 1 so rollback target exists.
-	publishCtx := configcoretest.WithAllowAuthorizer(
+	publishCtx := withAllowAuthorizer(
 		ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
 	)
 	_, err := svc.Publish(publishCtx, "app.name")
@@ -137,7 +136,7 @@ func TestHttpConfigRollbackV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	path := strings.Replace(c.HTTP.Path, "{key}", "app.name", 1)
 	req := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(`{"version":1,"expectedVersion":1}`)).
-		WithContext(configcoretest.WithAllowAuthorizer(
+		WithContext(withAllowAuthorizer(
 			ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
 		))
 	req.Header.Set("Content-Type", "application/json")
@@ -166,7 +165,7 @@ func TestHttpConfigPublishV1_Serve_NotFound(t *testing.T) {
 	path := strings.Replace(c.HTTP.Path, "{key}", "no-such-key", 1)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, nil).
-		WithContext(configcoretest.WithAllowAuthorizer(
+		WithContext(withAllowAuthorizer(
 			ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testPublishTenantStr),
 		))
 	mux.ServeHTTP(rec, req)
@@ -214,7 +213,7 @@ func TestHttpConfigPublishV1_Serve_Unauthorized(t *testing.T) {
 	t.Run("403_pdp_deny", func(t *testing.T) {
 		// Principal present, PDP denies → RequirePermission → ErrAuthForbidden → 403
 		rec := httptest.NewRecorder()
-		ctx := configcoretest.WithDenyAuthorizer(
+		ctx := withDenyAuthorizer(
 			auth.TestContext("user-readonly", []string{"viewer"}),
 			"policy deny",
 		)
@@ -272,7 +271,7 @@ func TestHttpConfigRollbackV1_Serve_Unauthorized(t *testing.T) {
 
 	t.Run("403_pdp_deny", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		ctx := configcoretest.WithDenyAuthorizer(
+		ctx := withDenyAuthorizer(
 			auth.TestContext("user-readonly", []string{"viewer"}),
 			"policy deny",
 		)

--- a/corecells/configcore/slices/configpublish/handler.go
+++ b/corecells/configcore/slices/configpublish/handler.go
@@ -10,6 +10,7 @@ import (
 	configpublishgen "github.com/ghbvf/gocell/generated/contracts/http/config/publish/v1"
 	rollbackgen "github.com/ghbvf/gocell/generated/contracts/http/config/rollback/v1"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -91,9 +92,10 @@ type Handler struct {
 }
 
 // NewHandler creates a configpublish Handler with generated per-contract handlers.
-// Both endpoints are admin-only.
+// Both endpoints are gated by auth.RequirePermission(authz.PermConfigPublish()); the
+// ABAC PDP decides — baseline grants admin/super-admin (PR-10b #1348).
 func NewHandler(svc *Service) *Handler {
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermConfigPublish())
 	return &Handler{
 		publishH:  configpublishgen.NewHandler(PublishAdapter{svc}, policy),
 		rollbackH: rollbackgen.NewHandler(RollbackAdapter{svc}, policy),

--- a/corecells/configcore/slices/configpublish/handler_test.go
+++ b/corecells/configcore/slices/configpublish/handler_test.go
@@ -26,12 +26,34 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
+
+// allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer build the PDP
+// verdicts for tests. The authz.Allow/Deny construction lives in _test.go,
+// which AUTHZ-DECISION-ALLOW-DENY-CALLER-01 sanctions for test doubles; the
+// CapturingAuthorizer type and WithAuthorizer ctx wiring are shared via
+// configcoretest (PR-10b #1348).
+func allowAuthorizer() *configcoretest.CapturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("test allowAuthorizer: authz.Allow: " + err.Error())
+	}
+	return &configcoretest.CapturingAuthorizer{Decision: dec}
+}
+
+func withAllowAuthorizer(ctx context.Context) context.Context {
+	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
+}
+
+func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
+}
 
 // testPublishTenantStr is the test TenantID string for configpublish tests.
 const testPublishTenantStr = "00000000-0000-0000-0000-000000000001"
@@ -45,7 +67,7 @@ var testPublishTenant = tenant.TenantID(testPublishTenantStr)
 // Authorizer in ctx the gate is fail-closed 403 before reaching the service.
 func adminCtx() context.Context {
 	base := ctxkeys.WithTenantID(auth.TestContext("test-admin", []string{"admin"}), testPublishTenantStr)
-	return configcoretest.WithAllowAuthorizer(base)
+	return withAllowAuthorizer(base)
 }
 
 // withAdmin clones req with the admin auth context attached.
@@ -183,7 +205,7 @@ func TestHandler_HandlePublish_NotFound(t *testing.T) {
 // from the PDP gate's fail-closed 403).
 func withAdminNoTenant(req *http.Request) *http.Request {
 	base := auth.TestContext("test-admin", []string{"admin"})
-	return req.WithContext(configcoretest.WithAllowAuthorizer(base))
+	return req.WithContext(withAllowAuthorizer(base))
 }
 
 func TestHandler_HandlePublish_MissingTenant_403(t *testing.T) {
@@ -232,7 +254,7 @@ func TestHandler_HandlePublish_PDPDeny(t *testing.T) {
 	seedForPublish(t, repo)
 
 	w := httptest.NewRecorder()
-	ctx := configcoretest.WithDenyAuthorizer(
+	ctx := withDenyAuthorizer(
 		ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"viewer"}), testPublishTenantStr),
 		"policy deny",
 	)
@@ -275,7 +297,7 @@ func TestHandler_HandleRollback_PDPDeny(t *testing.T) {
 	seedForPublish(t, repo)
 
 	w := httptest.NewRecorder()
-	ctx := configcoretest.WithDenyAuthorizer(
+	ctx := withDenyAuthorizer(
 		ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"viewer"}), testPublishTenantStr),
 		"policy deny",
 	)
@@ -674,7 +696,7 @@ func TestHandler_ConfigPublishGate_ActionPin(t *testing.T) {
 	_, err = svcForSeed.Publish(adminCtx(), "app.name")
 	require.NoError(t, err)
 
-	cap := configcoretest.AllowAuthorizer()
+	cap := allowAuthorizer()
 	baseCtx := ctxkeys.WithTenantID(auth.TestContext("test-admin", []string{"admin"}), testPublishTenantStr)
 	authedCtx := configcoretest.WithAuthorizer(baseCtx, cap)
 

--- a/corecells/configcore/slices/configpublish/handler_test.go
+++ b/corecells/configcore/slices/configpublish/handler_test.go
@@ -51,8 +51,8 @@ func withAllowAuthorizer(ctx context.Context) context.Context {
 	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
 }
 
-func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
-	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
+func withDenyAuthorizer(ctx context.Context) context.Context {
+	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny("test pdp deny")})
 }
 
 // testPublishTenantStr is the test TenantID string for configpublish tests.
@@ -256,7 +256,6 @@ func TestHandler_HandlePublish_PDPDeny(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := withDenyAuthorizer(
 		ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"viewer"}), testPublishTenantStr),
-		"policy deny",
 	)
 	req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/publish", nil).
 		WithContext(ctx)
@@ -299,7 +298,6 @@ func TestHandler_HandleRollback_PDPDeny(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := withDenyAuthorizer(
 		ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"viewer"}), testPublishTenantStr),
-		"policy deny",
 	)
 	req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/rollback",
 		strings.NewReader(`{"version":1,"expectedVersion":1}`)).

--- a/corecells/configcore/slices/configpublish/handler_test.go
+++ b/corecells/configcore/slices/configpublish/handler_test.go
@@ -51,15 +51,17 @@ func withAllowAuthorizer(ctx context.Context) context.Context {
 	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
 }
 
+// reason is fixed here (unparam: all configpublish deny tests use the same reason); other slices keep a reason param.
 func withDenyAuthorizer(ctx context.Context) context.Context {
 	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny("test pdp deny")})
 }
 
 // testPublishTenantStr is the test TenantID string for configpublish tests.
-const testPublishTenantStr = "00000000-0000-0000-0000-000000000001"
+// Derived from configcoretest.TestTenant to avoid duplicating the bare literal.
+const testPublishTenantStr = string(configcoretest.TestTenant)
 
 // testPublishTenant is the typed TenantID for direct repo seeding calls.
-var testPublishTenant = tenant.TenantID(testPublishTenantStr)
+const testPublishTenant = configcoretest.TestTenant
 
 // adminCtx returns a request context carrying an admin subject + role, a valid
 // TenantID, and an allow Authorizer. The Authorizer is required because the gate

--- a/corecells/configcore/slices/configpublish/handler_test.go
+++ b/corecells/configcore/slices/configpublish/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ghbvf/gocell/corecells/configcore/configcoretest"
 	"github.com/ghbvf/gocell/corecells/internal/testoutbox"
 
 	"github.com/stretchr/testify/assert"
@@ -38,11 +39,13 @@ const testPublishTenantStr = "00000000-0000-0000-0000-000000000001"
 // testPublishTenant is the typed TenantID for direct repo seeding calls.
 var testPublishTenant = tenant.TenantID(testPublishTenantStr)
 
-// adminCtx returns a request context carrying an admin subject + role AND a
-// valid TenantID for authorized handler tests. configpublish.Service.Publish
-// and Rollback both call tenant.FromContext(ctx), so a tenant is required.
+// adminCtx returns a request context carrying an admin subject + role, a valid
+// TenantID, and an allow Authorizer. The Authorizer is required because the gate
+// now uses auth.RequirePermission(authz.PermConfigPublish()) — without an
+// Authorizer in ctx the gate is fail-closed 403 before reaching the service.
 func adminCtx() context.Context {
-	return ctxkeys.WithTenantID(auth.TestContext("test-admin", []string{"admin"}), testPublishTenantStr)
+	base := ctxkeys.WithTenantID(auth.TestContext("test-admin", []string{"admin"}), testPublishTenantStr)
+	return configcoretest.WithAllowAuthorizer(base)
 }
 
 // withAdmin clones req with the admin auth context attached.
@@ -174,11 +177,13 @@ func TestHandler_HandlePublish_NotFound(t *testing.T) {
 
 // --- F6: missing-tenant → typed 403 (not 500) ---
 
-// withAdminNoTenant injects an admin principal but NO TenantID, so the request
-// passes the admin-role policy yet fails Service.tenant.FromContext. The
-// resulting 403 carries ErrAuthForbidden (distinct from the policy's 403).
+// withAdminNoTenant injects an admin principal and an allow Authorizer but NO
+// TenantID. The request passes the config:publish-gated (PDP) policy, then fails
+// Service.tenant.FromContext. The resulting 403 carries ErrAuthForbidden (distinct
+// from the PDP gate's fail-closed 403).
 func withAdminNoTenant(req *http.Request) *http.Request {
-	return req.WithContext(auth.TestContext("test-admin", []string{"admin"}))
+	base := auth.TestContext("test-admin", []string{"admin"})
+	return req.WithContext(configcoretest.WithAllowAuthorizer(base))
 }
 
 func TestHandler_HandlePublish_MissingTenant_403(t *testing.T) {
@@ -204,10 +209,12 @@ func TestHandler_HandleRollback_MissingTenant_403(t *testing.T) {
 	errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
 }
 
-// PR#155 followup F1 (Cx2, P1): publish + rollback are high-risk write operations
-// that must require an explicit admin role. Authentication alone (any logged-in
-// subject) is not enough — fail-closed at the handler layer mirrors
-// identitymanage/handler.go and matches the K8s/Kratos/go-zero default-deny convention.
+// config:publish-gated (PDP) — publish and rollback are high-risk write operations
+// that require the config:publish permission from the ABAC PDP.
+// 401 path: no principal in ctx → unauthenticated before PDP is consulted.
+// 403 deny path: principal present, PDP denies → ErrAuthForbidden.
+// 403 no-authorizer path: principal present, no Authorizer in ctx → fail-closed 403.
+
 func TestHandler_HandlePublish_RequiresAuth(t *testing.T) {
 	handler, repo := setupHandler()
 	seedForPublish(t, repo)
@@ -219,16 +226,35 @@ func TestHandler_HandlePublish_RequiresAuth(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code, "publish without subject must be 401")
 }
 
-func TestHandler_HandlePublish_RequiresAdminRole(t *testing.T) {
+// TestHandler_HandlePublish_PDPDeny verifies that a PDP deny response causes a 403.
+func TestHandler_HandlePublish_PDPDeny(t *testing.T) {
 	handler, repo := setupHandler()
 	seedForPublish(t, repo)
 
 	w := httptest.NewRecorder()
+	ctx := configcoretest.WithDenyAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"viewer"}), testPublishTenantStr),
+		"policy deny",
+	)
 	req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/publish", nil).
-		WithContext(auth.TestContext("user-1", []string{"viewer"}))
+		WithContext(ctx)
 	handler.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusForbidden, w.Code, "non-admin subject must be 403")
+	assert.Equal(t, http.StatusForbidden, w.Code, "PDP deny must yield 403")
+}
+
+// TestHandler_HandlePublish_NoAuthorizer verifies that absent Authorizer is fail-closed 403.
+func TestHandler_HandlePublish_NoAuthorizer(t *testing.T) {
+	handler, repo := setupHandler()
+	seedForPublish(t, repo)
+
+	w := httptest.NewRecorder()
+	// Principal present but no Authorizer in ctx — RequirePermission must deny.
+	req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/publish", nil).
+		WithContext(ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"admin"}), testPublishTenantStr))
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "missing Authorizer must be fail-closed 403")
 }
 
 func TestHandler_HandleRollback_RequiresAuth(t *testing.T) {
@@ -243,18 +269,38 @@ func TestHandler_HandleRollback_RequiresAuth(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code, "rollback without subject must be 401")
 }
 
-func TestHandler_HandleRollback_RequiresAdminRole(t *testing.T) {
+// TestHandler_HandleRollback_PDPDeny verifies that a PDP deny response causes a 403.
+func TestHandler_HandleRollback_PDPDeny(t *testing.T) {
 	handler, repo := setupHandler()
 	seedForPublish(t, repo)
 
 	w := httptest.NewRecorder()
+	ctx := configcoretest.WithDenyAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"viewer"}), testPublishTenantStr),
+		"policy deny",
+	)
 	req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/rollback",
 		strings.NewReader(`{"version":1,"expectedVersion":1}`)).
-		WithContext(auth.TestContext("user-1", []string{"viewer"}))
+		WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusForbidden, w.Code, "non-admin subject must be 403")
+	assert.Equal(t, http.StatusForbidden, w.Code, "PDP deny must yield 403")
+}
+
+// TestHandler_HandleRollback_NoAuthorizer verifies that absent Authorizer is fail-closed 403.
+func TestHandler_HandleRollback_NoAuthorizer(t *testing.T) {
+	handler, _ := setupHandler()
+
+	w := httptest.NewRecorder()
+	// Principal present but no Authorizer in ctx — RequirePermission must deny.
+	req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/rollback",
+		strings.NewReader(`{"version":1,"expectedVersion":1}`)).
+		WithContext(ctxkeys.WithTenantID(auth.TestContext("user-1", []string{"admin"}), testPublishTenantStr))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "missing Authorizer must be fail-closed 403")
 }
 
 // H2-2 CONFIGPUBLISH-REDACT-01: sensitive entries must redact `value` and expose
@@ -609,4 +655,52 @@ func TestPublishAdapter_RepoNotFound_Returns404Typed(t *testing.T) {
 	typed, ok := resp.(configpublishgen.Publish404ErrorResponse)
 	require.True(t, ok, "expected Publish404ErrorResponse, got %T", resp)
 	assert.Equal(t, errcode.ErrConfigRepoNotFound, typed.Body.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Action-pin test (PR-10b #1348): asserts that the configpublish gate asks the
+// PDP for exactly "config:publish". Without this guard, an endpoint↔permission
+// misbinding (e.g. using PermConfigWrite instead of PermConfigPublish) would be
+// masked by the baseline which allows admin for every config:* permission.
+// ---------------------------------------------------------------------------
+
+func TestHandler_ConfigPublishGate_ActionPin(t *testing.T) {
+	handler, repo := setupHandler()
+	seedForPublish(t, repo)
+
+	// Seed a version for rollback to succeed.
+	svcForSeed, err := NewService(clock.Real(), repo, slog.Default(), WithTxManager(persistence.WrapForCell(&stubTxRunner{})))
+	require.NoError(t, err)
+	_, err = svcForSeed.Publish(adminCtx(), "app.name")
+	require.NoError(t, err)
+
+	cap := configcoretest.AllowAuthorizer()
+	baseCtx := ctxkeys.WithTenantID(auth.TestContext("test-admin", []string{"admin"}), testPublishTenantStr)
+	authedCtx := configcoretest.WithAuthorizer(baseCtx, cap)
+
+	t.Run("publish gate asks config:publish", func(t *testing.T) {
+		cap.GotAction = "" // reset between sub-tests
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/publish", nil).
+			WithContext(authedCtx)
+		handler.ServeHTTP(w, req)
+		require.Equal(t, http.StatusCreated, w.Code,
+			"publish must succeed with allow Authorizer; got body: %s", w.Body.String())
+		assert.Equal(t, "config:publish", cap.GotAction,
+			"configpublish gate must request config:publish from PDP; a wrong permission would be masked by the admin baseline")
+	})
+
+	t.Run("rollback gate asks config:publish", func(t *testing.T) {
+		cap.GotAction = "" // reset between sub-tests
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, configPrefix+"/app.name/rollback",
+			strings.NewReader(`{"version":1,"expectedVersion":1}`)).
+			WithContext(authedCtx)
+		req.Header.Set("Content-Type", "application/json")
+		handler.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code,
+			"rollback must succeed with allow Authorizer; got body: %s", w.Body.String())
+		assert.Equal(t, "config:publish", cap.GotAction,
+			"configpublish rollback gate must request config:publish from PDP")
+	})
 }

--- a/corecells/configcore/slices/configread/contract_test.go
+++ b/corecells/configcore/slices/configread/contract_test.go
@@ -46,10 +46,10 @@ func TestHttpConfigGetV1Serve(t *testing.T) {
 	assert.Equal(t, "GET", c.HTTP.Method)
 	assert.Equal(t, "/api/v1/config/{key}", c.HTTP.Path)
 
-	// PR-CFG-C contract-as-auth-truth: route is admin-gated, so 403 must be a
-	// first-class declared response, not just a runtime artifact.
+	// PR-CFG-C contract-as-auth-truth: route is config:read-gated (PDP), so 403
+	// must be a first-class declared response, not just a runtime artifact.
 	_, has403 := c.HTTP.Responses[403]
-	assert.True(t, has403, "http.config.get.v1 must declare 403 (route is RoleAdmin-gated)")
+	assert.True(t, has403, "http.config.get.v1 must declare 403 (route is config:read-gated (PDP))")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":[]}}`))
 
 	// Non-sensitive entry: sensitive=false, value is the real value.
@@ -78,9 +78,9 @@ func TestHttpConfigListV1Serve(t *testing.T) {
 	assert.Equal(t, "GET", c.HTTP.Method)
 	assert.Equal(t, "/api/v1/config/", c.HTTP.Path)
 
-	// PR-CFG-C contract-as-auth-truth: list endpoint is admin-gated.
+	// PR-CFG-C contract-as-auth-truth: list endpoint is config:read-gated (PDP).
 	_, has403 := c.HTTP.Responses[403]
-	assert.True(t, has403, "http.config.list.v1 must declare 403 (route is RoleAdmin-gated)")
+	assert.True(t, has403, "http.config.list.v1 must declare 403 (route is config:read-gated (PDP))")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":[]}}`))
 
 	// Non-sensitive entry: sensitive=false.
@@ -112,10 +112,10 @@ func TestHttpConfigListV1Serve(t *testing.T) {
 // Do not extract a shared testutil for 2 call sites.
 
 // authzCase models a row in the runtime mux authz negative-test tables.
-// principal=nil produces an anonymous request — the Mount's auth.AnyRole
-// policy short-circuits to ErrAuthUnauthorized before role inspection.
-// A non-nil principal exercises the authenticated-but-unauthorized branch
-// (any role mismatch returns ErrAuthForbidden via principalHasAnyRole).
+// principal=nil produces an anonymous request — the RequirePermission PDP gate
+// short-circuits to ErrAuthUnauthorized (no principal → not authenticated).
+// A non-nil principal with no Authorizer in ctx exercises the fail-closed
+// branch (ErrAuthForbidden — PDP not wired).
 type authzCase struct {
 	name        string
 	principal   *auth.Principal
@@ -164,31 +164,35 @@ func userPrincipal(subject string, roles []string) *auth.Principal {
 	}
 }
 
-// TestHttpConfigGetV1_AuthzNegative locks the runtime auth-guard contract
-// for the admin-gated GET /api/v1/config/{key}: anonymous requests are
-// rejected with 401 ERR_AUTH_UNAUTHORIZED, and authenticated principals
-// without the admin role are rejected with 403 ERR_AUTH_FORBIDDEN. The
-// happy-path response shape is locked by TestHttpConfigGetV1Serve.
+// TestHttpConfigGetV1_AuthzNegative locks the runtime auth-guard contract for
+// the config:read-gated (PDP) GET /api/v1/config/{key}:
+//   - anonymous requests → 401 ERR_AUTH_UNAUTHORIZED (no principal).
+//   - principal present but no Authorizer in ctx → fail-closed 403 ERR_AUTH_FORBIDDEN.
+//
+// The happy-path response shape is locked by TestHttpConfigGetV1Serve.
 func TestHttpConfigGetV1_AuthzNegative(t *testing.T) {
 	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.get.v1")
 	h, _ := setupHandler()
 	runAuthzCases(t, h, c, http.MethodGet, configBasePath+"/some-key", []authzCase{
 		{"no_auth", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"no_authorizer_fail_closed", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
 }
 
-// TestHttpConfigListV1_AuthzNegative locks the runtime auth-guard contract
-// for the admin-gated GET /api/v1/config/ list endpoint, mirroring the
-// single-entry GET semantics. The base path's trailing slash matches the
-// production registration in cell_gen.go (mux.Route("/config", ...)).
+// TestHttpConfigListV1_AuthzNegative locks the runtime auth-guard contract for
+// the config:read-gated (PDP) GET /api/v1/config/ list endpoint:
+//   - anonymous requests → 401 ERR_AUTH_UNAUTHORIZED (no principal).
+//   - principal present but no Authorizer in ctx → fail-closed 403 ERR_AUTH_FORBIDDEN.
+//
+// The base path's trailing slash matches the production registration in
+// cell_gen.go (mux.Route("/config", ...)).
 func TestHttpConfigListV1_AuthzNegative(t *testing.T) {
 	root := contracttest.ContractsRoot(t)
 	c := contracttest.LoadByID(t, root, "http.config.list.v1")
 	h, _ := setupHandler()
 	runAuthzCases(t, h, c, http.MethodGet, configBasePath+"/", []authzCase{
 		{"no_auth", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"no_authorizer_fail_closed", userPrincipal("user-1", []string{"viewer"}), http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	})
 }

--- a/corecells/configcore/slices/configread/handler.go
+++ b/corecells/configcore/slices/configread/handler.go
@@ -92,9 +92,10 @@ type Handler struct {
 }
 
 // NewHandler creates a public configread Handler with generated per-contract
-// handlers. Both endpoints are admin-only (auth.AnyRole(auth.RoleAdmin)).
+// handlers. Both endpoints are gated by auth.RequirePermission(authz.PermConfigRead());
+// the ABAC PDP decides — baseline grants admin/super-admin (PR-10b #1348).
 func NewHandler(svc *Service) *Handler {
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermConfigRead())
 	return &Handler{
 		getH:  configget.NewHandler(GetAdapter{svc}, policy),
 		listH: configlist.NewHandler(ListAdapter{svc}, policy),

--- a/corecells/configcore/slices/configread/handler_test.go
+++ b/corecells/configcore/slices/configread/handler_test.go
@@ -22,11 +22,33 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
+
+// allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer build the PDP
+// verdicts for tests. The authz.Allow/Deny construction lives in _test.go,
+// which AUTHZ-DECISION-ALLOW-DENY-CALLER-01 sanctions for test doubles; the
+// CapturingAuthorizer type and WithAuthorizer ctx wiring are shared via
+// configcoretest (PR-10b #1348).
+func allowAuthorizer() *configcoretest.CapturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("test allowAuthorizer: authz.Allow: " + err.Error())
+	}
+	return &configcoretest.CapturingAuthorizer{Decision: dec}
+}
+
+func withAllowAuthorizer(ctx context.Context) context.Context {
+	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
+}
+
+func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
+}
 
 // testReadTenant is the typed TenantID for direct repo seeding.
 var testReadTenant = configcoretest.TestTenant
@@ -37,7 +59,7 @@ const configBasePath = "/api/v1/config"
 // to req so it satisfies the auth.RequirePermission(authz.PermConfigRead()) PDP
 // gate AND the configread handler's tenant.FromContext call.
 func asAdmin(req *http.Request) *http.Request {
-	ctx := configcoretest.WithAllowAuthorizer(
+	ctx := withAllowAuthorizer(
 		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 	)
 	return req.WithContext(ctx)
@@ -104,7 +126,7 @@ func TestHandler_HandleGet_NotFound(t *testing.T) {
 // TenantID, so the request passes the PDP gate yet fails tenant.FromContext.
 // F6: this must map to a typed 403, not a framework 500.
 func asAdminNoTenant(req *http.Request) *http.Request {
-	ctx := configcoretest.WithAllowAuthorizer(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	ctx := withAllowAuthorizer(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
 	return req.WithContext(ctx)
 }
 
@@ -340,7 +362,7 @@ func TestHandler_HandleList_SensitiveRedacted(t *testing.T) {
 func TestHandler_PDPDeny_Get_403(t *testing.T) {
 	handler, _ := setupHandler()
 
-	ctx := configcoretest.WithDenyAuthorizer(
+	ctx := withDenyAuthorizer(
 		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 		"policy: deny",
 	)
@@ -356,7 +378,7 @@ func TestHandler_PDPDeny_Get_403(t *testing.T) {
 func TestHandler_PDPDeny_List_403(t *testing.T) {
 	handler, _ := setupHandler()
 
-	ctx := configcoretest.WithDenyAuthorizer(
+	ctx := withDenyAuthorizer(
 		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 		"policy: deny",
 	)
@@ -405,7 +427,7 @@ func TestHandler_ActionPin_ConfigRead(t *testing.T) {
 
 	for _, ep := range endpoints {
 		t.Run(ep.method+" "+ep.target, func(t *testing.T) {
-			cap := configcoretest.AllowAuthorizer()
+			cap := allowAuthorizer()
 			ctx := configcoretest.WithAuthorizer(
 				configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 				cap,

--- a/corecells/configcore/slices/configread/handler_test.go
+++ b/corecells/configcore/slices/configread/handler_test.go
@@ -33,11 +33,13 @@ var testReadTenant = configcoretest.TestTenant
 
 const configBasePath = "/api/v1/config"
 
-// asAdmin attaches an admin Principal AND a valid TenantID to req so it
-// satisfies the auth.AnyRole(RoleAdmin) policy AND configread handler's
-// tenant.FromContext call.
+// asAdmin attaches an admin Principal, a valid TenantID, and an allow Authorizer
+// to req so it satisfies the auth.RequirePermission(authz.PermConfigRead()) PDP
+// gate AND the configread handler's tenant.FromContext call.
 func asAdmin(req *http.Request) *http.Request {
-	ctx := configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	ctx := configcoretest.WithAllowAuthorizer(
+		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+	)
 	return req.WithContext(ctx)
 }
 
@@ -98,11 +100,12 @@ func TestHandler_HandleGet_NotFound(t *testing.T) {
 	errcodetest.AssertWireCode(t, w, http.StatusNotFound, errcode.ErrConfigRepoNotFound)
 }
 
-// asAdminNoTenant attaches an admin Principal but NO TenantID, so the request
-// passes the admin-role policy yet fails tenant.FromContext. F6: this must map
-// to a typed 403, not a framework 500.
+// asAdminNoTenant attaches an admin Principal and an allow Authorizer but NO
+// TenantID, so the request passes the PDP gate yet fails tenant.FromContext.
+// F6: this must map to a typed 403, not a framework 500.
 func asAdminNoTenant(req *http.Request) *http.Request {
-	return req.WithContext(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	ctx := configcoretest.WithAllowAuthorizer(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	return req.WithContext(ctx)
 }
 
 func TestHandler_HandleGet_MissingTenant_403(t *testing.T) {
@@ -330,4 +333,94 @@ func TestHandler_HandleList_SensitiveRedacted(t *testing.T) {
 	assert.Contains(t, body, "gocell")
 	assert.NotContains(t, body, "sk-secret-key-123")
 	assert.Contains(t, body, dto.RedactedValue)
+}
+
+// TestHandler_PDPDeny_Get_403 verifies that a principal with an Authorizer
+// that denies the request receives 403 ERR_AUTH_FORBIDDEN — the PDP deny path.
+func TestHandler_PDPDeny_Get_403(t *testing.T) {
+	handler, _ := setupHandler()
+
+	ctx := configcoretest.WithDenyAuthorizer(
+		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+		"policy: deny",
+	)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, configBasePath+"/app.name", nil)
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+}
+
+// TestHandler_PDPDeny_List_403 verifies that a principal with an Authorizer
+// that denies the request receives 403 ERR_AUTH_FORBIDDEN on the list endpoint.
+func TestHandler_PDPDeny_List_403(t *testing.T) {
+	handler, _ := setupHandler()
+
+	ctx := configcoretest.WithDenyAuthorizer(
+		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+		"policy: deny",
+	)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, configBasePath+"/", nil)
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+}
+
+// TestHandler_NoAuthorizer_Get_FailClosed verifies that a principal present in
+// ctx but with no Authorizer wired results in fail-closed 403 ERR_AUTH_FORBIDDEN.
+func TestHandler_NoAuthorizer_Get_FailClosed(t *testing.T) {
+	handler, _ := setupHandler()
+
+	ctx := configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, configBasePath+"/app.name", nil)
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+}
+
+// TestHandler_ActionPin_ConfigRead pins that every configread endpoint calls the
+// PDP with action "config:read" (not another permission). Because the baseline
+// grants admin permission for all config actions, a wrong binding
+// (e.g. authz.PermConfigWrite()) would still produce 200, so this test uses a
+// CapturingAuthorizer to assert the exact action sent to the PDP.
+// Failure message: configread gate must use authz.PermConfigRead() ("config:read"),
+// not another permission (baseline grants admin for all config perms, masking misbinding).
+func TestHandler_ActionPin_ConfigRead(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), testReadTenant, &domain.ConfigEntry{
+		ID: "cfg-pin", Key: "pin.key", Value: "v", Version: 1,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	endpoints := []struct {
+		method string
+		target string
+	}{
+		{http.MethodGet, configBasePath + "/pin.key"},
+		{http.MethodGet, configBasePath + "/"},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.method+" "+ep.target, func(t *testing.T) {
+			cap := configcoretest.AllowAuthorizer()
+			ctx := configcoretest.WithAuthorizer(
+				configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+				cap,
+			)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(ep.method, ep.target, nil)
+			handler.ServeHTTP(w, req.WithContext(ctx))
+
+			// Gate must pass (2xx) and must have called PDP with "config:read".
+			require.Equal(t, http.StatusOK, w.Code,
+				"configread gate must pass for allow Authorizer (method=%s path=%s)", ep.method, ep.target)
+			assert.Equal(t, "config:read", cap.GotAction,
+				"configread gate must use authz.PermConfigRead() (\"config:read\"), not another permission "+
+					"(baseline grants admin for all config perms, masking misbinding); endpoint=%s %s",
+				ep.method, ep.target)
+		})
+	}
 }

--- a/corecells/configcore/slices/configwrite/contract_test.go
+++ b/corecells/configcore/slices/configwrite/contract_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/runtime/auth"
 	"github.com/ghbvf/gocell/tests/contracttest"
@@ -34,6 +35,25 @@ import (
 // Uses a fixed "contract-admin" subject so contract tests are self-contained.
 func contractAdminCtx() context.Context {
 	return ctxkeys.WithTenantID(auth.TestContext("contract-admin", []string{"admin"}), testHandlerTenantStr)
+}
+
+// contractAllowAuthorizer is a local allow-all Authorizer for contract tests.
+// It cannot import configcoretest (cycle: configcoretest imports configwrite).
+// Semantically identical to configcoretest.AllowAuthorizer() — allow with zero obligations.
+type contractAllowAuthorizer struct{}
+
+func (contractAllowAuthorizer) Authorize(_ context.Context, _, _, _ string) (authz.Decision, error) {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("contractAllowAuthorizer.Authorize: " + err.Error())
+	}
+	return dec, nil
+}
+
+// withContractAllowAuthorizer injects an allow-all Authorizer into ctx for
+// HTTP contract tests that need to pass the RequirePermission PDP gate.
+func withContractAllowAuthorizer(ctx context.Context) context.Context {
+	return auth.WithAuthorizer(ctx, contractAllowAuthorizer{})
 }
 
 func newContractService(t testing.TB) (*Service, *testutil.RecordingWriter) {
@@ -47,9 +67,10 @@ func newContractService(t testing.TB) (*Service, *testutil.RecordingWriter) {
 	return svc, writer
 }
 
-// newContractMux registers all configwrite routes under the canonical API prefix.
+// newContractMux registers all configwrite routes under the canonical API prefix
+// using auth.RequirePermission(authz.PermConfigWrite()) to mirror production.
 func newContractMux(svc *Service) http.Handler {
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermConfigWrite())
 	writeH := write.NewHandler(WriteAdapter{svc}, policy)
 	updateH := update.NewHandler(UpdateAdapter{svc}, policy)
 	deleteH := configdelete.NewHandler(DeleteAdapter{svc}, policy)
@@ -106,7 +127,9 @@ func TestHttpConfigWriteV1Serve(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path, strings.NewReader(`{"key":"app.name","value":"myapp"}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr))
+	req = req.WithContext(withContractAllowAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr),
+	))
 	mux.ServeHTTP(rec, req)
 	c.ValidateHTTPResponseRecorder(t, rec)
 
@@ -114,7 +137,9 @@ func TestHttpConfigWriteV1Serve(t *testing.T) {
 }
 
 // TestHttpConfigWriteV1_AuthzNegative validates the 401/403 failure semantics
-// that are part of the http.config.write.v1 interface contract.
+// that are part of the http.config.write.v1 interface contract (config:write-gated (PDP)):
+//   - anonymous requests → 401 ERR_AUTH_UNAUTHORIZED (no principal).
+//   - principal present but no Authorizer in ctx → fail-closed 403 ERR_AUTH_FORBIDDEN.
 func TestHttpConfigWriteV1_AuthzNegative(t *testing.T) {
 	svc, _ := newContractService(t)
 	mux := newContractMux(svc)
@@ -129,7 +154,7 @@ func TestHttpConfigWriteV1_AuthzNegative(t *testing.T) {
 		wantErrCode string
 	}{
 		{"no_auth", false, "", nil, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"no_authorizer_fail_closed", true, "user-1", []string{"viewer"}, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/corecells/configcore/slices/configwrite/handler.go
+++ b/corecells/configcore/slices/configwrite/handler.go
@@ -11,6 +11,7 @@ import (
 	update "github.com/ghbvf/gocell/generated/contracts/http/config/update/v1"
 	write "github.com/ghbvf/gocell/generated/contracts/http/config/write/v1"
 	"github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -118,9 +119,10 @@ type Handler struct {
 }
 
 // NewHandler creates a configwrite Handler using generated per-contract handlers.
-// All endpoints are admin-only (auth.AnyRole(auth.RoleAdmin)).
+// All endpoints are gated by auth.RequirePermission(authz.PermConfigWrite());
+// the ABAC PDP decides — baseline grants admin/super-admin (PR-10b #1348).
 func NewHandler(svc *Service) *Handler {
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermConfigWrite())
 	return &Handler{
 		writeH:  write.NewHandler(WriteAdapter{svc}, policy),
 		updateH: update.NewHandler(UpdateAdapter{svc}, policy),

--- a/corecells/configcore/slices/configwrite/handler_test.go
+++ b/corecells/configcore/slices/configwrite/handler_test.go
@@ -751,6 +751,31 @@ func TestHandler_NoAuthorizer_Write_FailClosed(t *testing.T) {
 // CapturingAuthorizer to assert the exact action sent to the PDP.
 // Failure message: configwrite gate must use authz.PermConfigWrite() ("config:write"),
 // not another permission (baseline grants admin for all config perms, masking misbinding).
+// TestNewHandler_ProductionWiring covers the slice's production NewHandler — the
+// composite that wires auth.RequirePermission(authz.PermConfigWrite()) onto every
+// write contract. The other handler tests build a re-wired mux via setupHandler,
+// so without this the production NewHandler gate line stays uncovered. An admin
+// request carrying the allow PDP (via withAdmin) must pass the gate (201).
+func TestNewHandler_ProductionWiring(t *testing.T) {
+	repo := mem.NewConfigRepository(clock.Real())
+	svc, err := NewService(clock.Real(), repo, slog.Default(), WithTxManager(persistence.WrapForCell(&stubTxRunner{})))
+	require.NoError(t, err)
+
+	mux := celltest.NewTestMux()
+	mux.Route(configPrefix, func(sub cell.RouteMux) {
+		require.NoError(t, NewHandler(svc).RegisterRoutes(sub))
+	})
+
+	body := `{"key":"prod.wiring","value":"v"}`
+	req := withAdmin(httptest.NewRequest(http.MethodPost, configPrefix, strings.NewReader(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code,
+		"production NewHandler gate must admit admin + allow PDP; body=%s", w.Body.String())
+}
+
 func TestHandler_ActionPin_ConfigWrite(t *testing.T) {
 	now := time.Now()
 

--- a/corecells/configcore/slices/configwrite/handler_test.go
+++ b/corecells/configcore/slices/configwrite/handler_test.go
@@ -587,8 +587,16 @@ func TestHandler_Authz_Delete(t *testing.T) {
 		wantErrCode string
 	}{
 		{"no_auth", "", nil, false, false, nil, "/nonexistent?expectedVersion=1", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"no_authorizer_fail_closed", "user-1", []string{"viewer"}, true, false, nil, "/nonexistent?expectedVersion=1", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
-		{"admin_not_found", testAdminSubject, []string{auth.RoleAdmin}, true, true, nil, "/nonexistent?expectedVersion=1", http.StatusNotFound, ""},
+		{
+			"no_authorizer_fail_closed", "user-1",
+			[]string{"viewer"},
+			true, false, nil, "/nonexistent?expectedVersion=1", http.StatusForbidden, "ERR_AUTH_FORBIDDEN",
+		},
+		{
+			"admin_not_found", testAdminSubject,
+			[]string{auth.RoleAdmin},
+			true, true, nil, "/nonexistent?expectedVersion=1", http.StatusNotFound, "",
+		},
 		{"admin_success", testAdminSubject, []string{auth.RoleAdmin}, true, true, func(r *mem.ConfigRepository) {
 			now := time.Now()
 			_ = r.Create(context.Background(), testHandlerTenant, &domain.ConfigEntry{

--- a/corecells/configcore/slices/configwrite/handler_test.go
+++ b/corecells/configcore/slices/configwrite/handler_test.go
@@ -39,8 +39,9 @@ import (
 const testHandlerTenantStr = "00000000-0000-0000-0000-000000000001"
 
 // --- local authz test helpers ---
-// configcoretest cannot be imported here (cycle: configcoretest imports configwrite).
-// These local stubs are semantically identical to configcoretest's equivalents.
+// configcoretest imports configwrite (BuildWriteService), so it cannot be imported
+// back here — these local stubs mirror configcoretest's CapturingAuthorizer and are
+// semantically identical to its equivalents.
 
 // capturingAuthorizer is a test-only auth.Authorizer that returns a fixed
 // Decision and records the action of the last Authorize call.
@@ -751,12 +752,7 @@ func TestHandler_NoAuthorizer_Write_FailClosed(t *testing.T) {
 // Failure message: configwrite gate must use authz.PermConfigWrite() ("config:write"),
 // not another permission (baseline grants admin for all config perms, masking misbinding).
 func TestHandler_ActionPin_ConfigWrite(t *testing.T) {
-	handler, repo := setupHandler()
 	now := time.Now()
-	require.NoError(t, repo.Create(context.Background(), testHandlerTenant, &domain.ConfigEntry{
-		ID: "cfg-pin", Key: "pin.key", Value: "v", Version: 1,
-		CreatedAt: now, UpdatedAt: now,
-	}))
 
 	endpoints := []struct {
 		method string
@@ -776,8 +772,6 @@ func TestHandler_ActionPin_ConfigWrite(t *testing.T) {
 				ID: "cfg-pin2", Key: "pin.key", Value: "v", Version: 1,
 				CreatedAt: now, UpdatedAt: now,
 			}))
-			_ = handler // silence unused warning; sub-test uses h
-			_ = repo
 
 			cap := newAllowAuthorizer()
 			ctx := auth.WithAuthorizer(

--- a/corecells/configcore/slices/configwrite/handler_test.go
+++ b/corecells/configcore/slices/configwrite/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
@@ -36,6 +37,41 @@ import (
 // configwrite.Service.Create/Update/Delete can call tenant.FromContext without
 // error. Mirrors the pattern established by accesscore PR-2a.
 const testHandlerTenantStr = "00000000-0000-0000-0000-000000000001"
+
+// --- local authz test helpers ---
+// configcoretest cannot be imported here (cycle: configcoretest imports configwrite).
+// These local stubs are semantically identical to configcoretest's equivalents.
+
+// capturingAuthorizer is a test-only auth.Authorizer that returns a fixed
+// Decision and records the action of the last Authorize call.
+type capturingAuthorizer struct {
+	decision  authz.Decision
+	GotAction string
+}
+
+func (c *capturingAuthorizer) Authorize(_ context.Context, _, _, action string) (authz.Decision, error) {
+	c.GotAction = action
+	return c.decision, nil
+}
+
+// newAllowAuthorizer returns a capturingAuthorizer that grants every request.
+func newAllowAuthorizer() *capturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("newAllowAuthorizer: " + err.Error())
+	}
+	return &capturingAuthorizer{decision: dec}
+}
+
+// withAllowAuthorizer wraps ctx with an allow-all Authorizer.
+func withAllowAuthorizer(ctx context.Context) context.Context {
+	return auth.WithAuthorizer(ctx, newAllowAuthorizer())
+}
+
+// withDenyAuthorizer wraps ctx with a deny-all Authorizer (PDP-deny → 403 path).
+func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return auth.WithAuthorizer(ctx, &capturingAuthorizer{decision: authz.Deny(reason)})
+}
 
 // testHandlerTenant is the typed TenantID used for direct repo.Create seeding
 // in handler tests.
@@ -65,12 +101,13 @@ func (s *stubTxRunner) RunInTx(ctx context.Context, fn func(context.Context) err
 	return fn(ctx)
 }
 
-// withAdmin injects an admin context into a request for tests that exercise
-// non-auth logic (e.g. validation, business errors) and need to pass the
-// auth guard. Also injects a valid TenantID so configwrite.Service methods
-// can call tenant.FromContext without error.
+// withAdmin injects an admin context, a valid TenantID, and an allow Authorizer
+// into a request so it passes the auth.RequirePermission(authz.PermConfigWrite())
+// PDP gate and configwrite.Service methods can call tenant.FromContext without error.
 func withAdmin(req *http.Request) *http.Request {
-	ctx := ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr)
+	ctx := withAllowAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr),
+	)
 	return req.WithContext(ctx)
 }
 
@@ -85,7 +122,7 @@ func setupHandler() (http.Handler, *mem.ConfigRepository) {
 	if err != nil {
 		panic("setupHandler: " + err.Error())
 	}
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermConfigWrite())
 	writeH := write.NewHandler(WriteAdapter{svc}, policy)
 	updateH := update.NewHandler(UpdateAdapter{svc}, policy)
 	deleteH := configdelete.NewHandler(DeleteAdapter{svc}, policy)
@@ -269,10 +306,11 @@ func TestHandler_HandleDelete_NotFound(t *testing.T) {
 
 // --- F6: missing-tenant → typed 403 (not 500) ---
 
-// withAdminNoTenant injects an admin principal but NO TenantID, so the request
-// passes the admin-role policy yet fails Service.tenant.FromContext.
+// withAdminNoTenant injects an admin principal and an allow Authorizer but NO
+// TenantID, so the request passes the PDP gate yet fails Service.tenant.FromContext.
 func withAdminNoTenant(req *http.Request) *http.Request {
-	return req.WithContext(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))
+	ctx := withAllowAuthorizer(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))
+	return req.WithContext(ctx)
 }
 
 func TestHandler_HandleCreate_MissingTenant_403(t *testing.T) {
@@ -434,18 +472,36 @@ func TestService_WithOutboxAndTx(t *testing.T) {
 
 // --- authz tests ---
 
+// authzCtx builds a context for handler authz table tests:
+//   - no principal (injectAuth=false): bare background ctx → 401.
+//   - no_authorizer (injectAuth=true, allowPDP=false): principal + tenant, no
+//     Authorizer → fail-closed 403 (tests the PDP-not-wired path).
+//   - allow (injectAuth=true, allowPDP=true): principal + tenant + allow
+//     Authorizer → gate passes, business logic runs.
+func authzCtx(subject string, roles []string, injectAuth, allowPDP bool) context.Context {
+	if !injectAuth {
+		return context.Background()
+	}
+	ctx := ctxkeys.WithTenantID(auth.TestContext(subject, roles), testHandlerTenantStr)
+	if allowPDP {
+		ctx = withAllowAuthorizer(ctx)
+	}
+	return ctx
+}
+
 func TestHandler_Authz_Create(t *testing.T) {
 	cases := []struct {
 		name        string
 		subject     string
 		roles       []string
 		injectAuth  bool
+		allowPDP    bool
 		wantStatus  int
 		wantErrCode string
 	}{
-		{"no_auth", "", nil, false, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", "user-1", []string{"viewer"}, true, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
-		{"admin", testAdminSubject, []string{auth.RoleAdmin}, true, http.StatusCreated, ""},
+		{"no_auth", "", nil, false, false, http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"no_authorizer_fail_closed", "user-1", []string{"viewer"}, true, false, http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"admin_allow", testAdminSubject, []string{auth.RoleAdmin}, true, true, http.StatusCreated, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -453,9 +509,7 @@ func TestHandler_Authz_Create(t *testing.T) {
 			body := `{"key":"test.key","value":"v"}`
 			req := httptest.NewRequest(http.MethodPost, configPrefix, strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
-			if tc.injectAuth {
-				req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext(tc.subject, tc.roles), testHandlerTenantStr))
-			}
+			req = req.WithContext(authzCtx(tc.subject, tc.roles, tc.injectAuth, tc.allowPDP))
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -478,15 +532,16 @@ func TestHandler_Authz_Update(t *testing.T) {
 		subject     string
 		roles       []string
 		injectAuth  bool
+		allowPDP    bool
 		setup       func(*mem.ConfigRepository)
 		path        string
 		wantStatus  int
 		wantErrCode string
 	}{
-		{"no_auth", "", nil, false, nil, "/nonexistent", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
-		{"admin", testAdminSubject, []string{auth.RoleAdmin}, true, nil, "/nonexistent", http.StatusNotFound, ""},
-		{"admin_success", testAdminSubject, []string{auth.RoleAdmin}, true, func(r *mem.ConfigRepository) {
+		{"no_auth", "", nil, false, false, nil, "/nonexistent", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"no_authorizer_fail_closed", "user-1", []string{"viewer"}, true, false, nil, "/nonexistent", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"admin_not_found", testAdminSubject, []string{auth.RoleAdmin}, true, true, nil, "/nonexistent", http.StatusNotFound, ""},
+		{"admin_success", testAdminSubject, []string{auth.RoleAdmin}, true, true, func(r *mem.ConfigRepository) {
 			now := time.Now()
 			_ = r.Create(context.Background(), testHandlerTenant, &domain.ConfigEntry{
 				ID: "au-1", Key: "test.update", Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
@@ -502,9 +557,7 @@ func TestHandler_Authz_Update(t *testing.T) {
 			body := `{"value":"new","expectedVersion":1}`
 			req := httptest.NewRequest(http.MethodPut, configPrefix+tc.path, strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
-			if tc.injectAuth {
-				req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext(tc.subject, tc.roles), testHandlerTenantStr))
-			}
+			req = req.WithContext(authzCtx(tc.subject, tc.roles, tc.injectAuth, tc.allowPDP))
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -527,15 +580,16 @@ func TestHandler_Authz_Delete(t *testing.T) {
 		subject     string
 		roles       []string
 		injectAuth  bool
+		allowPDP    bool
 		setup       func(*mem.ConfigRepository)
 		path        string
 		wantStatus  int
 		wantErrCode string
 	}{
-		{"no_auth", "", nil, false, nil, "/nonexistent?expectedVersion=1", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
-		{"non_admin", "user-1", []string{"viewer"}, true, nil, "/nonexistent?expectedVersion=1", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
-		{"admin", testAdminSubject, []string{auth.RoleAdmin}, true, nil, "/nonexistent?expectedVersion=1", http.StatusNotFound, ""},
-		{"admin_success", testAdminSubject, []string{auth.RoleAdmin}, true, func(r *mem.ConfigRepository) {
+		{"no_auth", "", nil, false, false, nil, "/nonexistent?expectedVersion=1", http.StatusUnauthorized, "ERR_AUTH_UNAUTHORIZED"},
+		{"no_authorizer_fail_closed", "user-1", []string{"viewer"}, true, false, nil, "/nonexistent?expectedVersion=1", http.StatusForbidden, "ERR_AUTH_FORBIDDEN"},
+		{"admin_not_found", testAdminSubject, []string{auth.RoleAdmin}, true, true, nil, "/nonexistent?expectedVersion=1", http.StatusNotFound, ""},
+		{"admin_success", testAdminSubject, []string{auth.RoleAdmin}, true, true, func(r *mem.ConfigRepository) {
 			now := time.Now()
 			_ = r.Create(context.Background(), testHandlerTenant, &domain.ConfigEntry{
 				ID: "ad-1", Key: "test.delete", Value: "v", Version: 1, CreatedAt: now, UpdatedAt: now,
@@ -549,9 +603,7 @@ func TestHandler_Authz_Delete(t *testing.T) {
 				tc.setup(repo)
 			}
 			req := httptest.NewRequest(http.MethodDelete, configPrefix+tc.path, nil)
-			if tc.injectAuth {
-				req = req.WithContext(ctxkeys.WithTenantID(auth.TestContext(tc.subject, tc.roles), testHandlerTenantStr))
-			}
+			req = req.WithContext(authzCtx(tc.subject, tc.roles, tc.injectAuth, tc.allowPDP))
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
@@ -646,4 +698,106 @@ func TestDeleteAdapter_VersionConflict_Returns409Typed(t *testing.T) {
 	typed, ok := resp.(configdelete.Delete409ErrorResponse)
 	require.True(t, ok, "expected Delete409ErrorResponse, got %T", resp)
 	assert.Equal(t, errcode.ErrVersionConflict, typed.Body.Code)
+}
+
+// --- PDP-deny and fail-closed tests ---
+
+// TestHandler_PDPDeny_Write_403 verifies that a principal with a deny Authorizer
+// receives 403 ERR_AUTH_FORBIDDEN on the write (POST) endpoint.
+func TestHandler_PDPDeny_Write_403(t *testing.T) {
+	handler, _ := setupHandler()
+
+	ctx := withDenyAuthorizer(
+		ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr),
+		"policy: deny",
+	)
+	w := httptest.NewRecorder()
+	body := `{"key":"app.name","value":"v"}`
+	req := httptest.NewRequest(http.MethodPost, configPrefix, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+}
+
+// TestHandler_NoAuthorizer_Write_FailClosed verifies that a principal present in
+// ctx but with no Authorizer wired results in fail-closed 403 ERR_AUTH_FORBIDDEN.
+func TestHandler_NoAuthorizer_Write_FailClosed(t *testing.T) {
+	handler, _ := setupHandler()
+
+	ctx := ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr)
+	w := httptest.NewRecorder()
+	body := `{"key":"app.name","value":"v"}`
+	req := httptest.NewRequest(http.MethodPost, configPrefix, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req.WithContext(ctx))
+
+	errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+}
+
+// TestHandler_ActionPin_ConfigWrite pins that every configwrite endpoint calls the
+// PDP with action "config:write" (not another permission). Because the baseline
+// grants admin permission for all config actions, a wrong binding
+// (e.g. authz.PermConfigRead()) would still produce 2xx, so this test uses a
+// CapturingAuthorizer to assert the exact action sent to the PDP.
+// Failure message: configwrite gate must use authz.PermConfigWrite() ("config:write"),
+// not another permission (baseline grants admin for all config perms, masking misbinding).
+func TestHandler_ActionPin_ConfigWrite(t *testing.T) {
+	handler, repo := setupHandler()
+	now := time.Now()
+	require.NoError(t, repo.Create(context.Background(), testHandlerTenant, &domain.ConfigEntry{
+		ID: "cfg-pin", Key: "pin.key", Value: "v", Version: 1,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	endpoints := []struct {
+		method string
+		target string
+		body   string
+	}{
+		{http.MethodPost, configPrefix, `{"key":"action.pin","value":"v"}`},
+		{http.MethodPut, configPrefix + "/pin.key", `{"value":"new","expectedVersion":1}`},
+		{http.MethodDelete, configPrefix + "/pin.key?expectedVersion=1", ""},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.method+" "+ep.target, func(t *testing.T) {
+			// Re-create repo state for each sub-test since DELETE removes the entry.
+			h, r := setupHandler()
+			require.NoError(t, r.Create(context.Background(), testHandlerTenant, &domain.ConfigEntry{
+				ID: "cfg-pin2", Key: "pin.key", Value: "v", Version: 1,
+				CreatedAt: now, UpdatedAt: now,
+			}))
+			_ = handler // silence unused warning; sub-test uses h
+			_ = repo
+
+			cap := newAllowAuthorizer()
+			ctx := auth.WithAuthorizer(
+				ctxkeys.WithTenantID(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}), testHandlerTenantStr),
+				cap,
+			)
+			var bodyReader *strings.Reader
+			if ep.body != "" {
+				bodyReader = strings.NewReader(ep.body)
+			} else {
+				bodyReader = strings.NewReader("")
+			}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(ep.method, ep.target, bodyReader)
+			if ep.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			h.ServeHTTP(w, req.WithContext(ctx))
+
+			// Gate must pass (not 401/403).
+			require.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"configwrite gate must not block admin with allow Authorizer (method=%s path=%s)", ep.method, ep.target)
+			require.NotEqual(t, http.StatusForbidden, w.Code,
+				"configwrite gate must not deny admin with allow Authorizer (method=%s path=%s)", ep.method, ep.target)
+			assert.Equal(t, "config:write", cap.GotAction,
+				"configwrite gate must use authz.PermConfigWrite() (\"config:write\"), not another permission "+
+					"(baseline grants admin for all config perms, masking misbinding); endpoint=%s %s",
+				ep.method, ep.target)
+		})
+	}
 }

--- a/corecells/configcore/slices/featureflag/contract_test.go
+++ b/corecells/configcore/slices/featureflag/contract_test.go
@@ -1,9 +1,13 @@
 package featureflag
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/tests/contracttest"
 )
@@ -44,7 +48,7 @@ func TestHttpConfigFlagsListV1Serve(t *testing.T) {
 
 	// PR-CFG-C contract-as-auth-truth: route is admin-gated.
 	_, has403 := c.HTTP.Responses[403]
-	assert.True(t, has403, "http.config.flags.list.v1 must declare 403 (route is RoleAdmin-gated)")
+	assert.True(t, has403, "http.config.flags.list.v1 must declare 403 (route is flag:read-gated (PDP))")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":[]}}`))
 
 	c.ValidateResponse(t, []byte(`{"data":[{"id":"f-1","key":"dark-mode","type":"boolean",`+
@@ -66,7 +70,7 @@ func TestHttpConfigFlagsGetV1Serve(t *testing.T) {
 	c := contracttest.LoadByID(t, root, "http.config.flags.get.v1")
 
 	_, has403 := c.HTTP.Responses[403]
-	assert.True(t, has403, "http.config.flags.get.v1 must declare 403 (route is RoleAdmin-gated)")
+	assert.True(t, has403, "http.config.flags.get.v1 must declare 403 (route is flag:read-gated (PDP))")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":[]}}`))
 
 	c.ValidateResponse(t, []byte(`{"data":{"id":"f-1","key":"dark-mode","type":"boolean",`+
@@ -87,10 +91,55 @@ func TestHttpConfigFlagsEvaluateV1Serve(t *testing.T) {
 	c := contracttest.LoadByID(t, root, "http.config.flags.evaluate.v1")
 
 	_, has403 := c.HTTP.Responses[403]
-	assert.True(t, has403, "http.config.flags.evaluate.v1 must declare 403 (route is RoleAdmin-gated)")
+	assert.True(t, has403, "http.config.flags.evaluate.v1 must declare 403 (route is flag:read-gated (PDP))")
 	c.ValidateErrorResponse(t, 403, []byte(`{"error":{"code":"ERR_AUTH_FORBIDDEN","message":"access denied","details":[]}}`))
 
 	c.ValidateRequest(t, []byte(`{"subject":"user-123"}`))
 	c.ValidateResponse(t, []byte(`{"data":{"key":"dark-mode","enabled":true}}`))
 	c.MustRejectRequest(t, []byte(`{"subject":"x","extra":"bad"}`))
+}
+
+// TestFeatureFlag_Anonymous_Returns401 covers the no-principal (anonymous) →
+// 401 ERR_AUTH_UNAUTHORIZED negative path for the flag:read-gated endpoints.
+// A nil principal causes auth.RequirePermission to short-circuit before reaching
+// the PDP (no Authorizer needed). Mirrors the configread slice's pattern.
+func TestFeatureFlag_Anonymous_Returns401(t *testing.T) {
+	root := contracttest.ContractsRoot(t)
+	handler, _ := setupHandler()
+
+	endpoints := []struct {
+		name       string
+		contractID string
+		method     string
+		path       string
+	}{
+		{"list", "http.config.flags.list.v1", http.MethodGet, flagsBasePath + "/"},
+		{"get", "http.config.flags.get.v1", http.MethodGet, flagsBasePath + "/some-key"},
+		{"evaluate", "http.config.flags.evaluate.v1", http.MethodPost, flagsBasePath + "/some-key/evaluate"},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			c := contracttest.LoadByID(t, root, ep.contractID)
+			_, has401 := c.HTTP.Responses[401]
+			assert.True(t, has401, "%s must declare 401 in contract.yaml", ep.contractID)
+
+			rec := httptest.NewRecorder()
+			// No principal injected — anonymous request.
+			req := httptest.NewRequest(ep.method, ep.path, nil)
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code,
+				"anonymous request to %s %s must be 401; got body=%s",
+				ep.method, ep.path, rec.Body)
+			var resp struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, "ERR_AUTH_UNAUTHORIZED", resp.Error.Code)
+			c.ValidateErrorResponse(t, http.StatusUnauthorized, rec.Body.Bytes())
+		})
+	}
 }

--- a/corecells/configcore/slices/featureflag/handler.go
+++ b/corecells/configcore/slices/featureflag/handler.go
@@ -121,9 +121,10 @@ type Handler struct {
 }
 
 // NewHandler creates a featureflag Handler with generated per-contract handlers.
-// All endpoints are admin-only.
+// Endpoints are gated by auth.RequirePermission(authz.PermFlagRead()); the ABAC
+// PDP decides — baseline grants admin/super-admin (PR-10b #1348).
 func NewHandler(svc *Service) *Handler {
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermFlagRead())
 	return &Handler{
 		getH:      flagsget.NewHandler(GetAdapter{svc}, policy),
 		listH:     flagslist.NewHandler(ListAdapter{svc}, policy),

--- a/corecells/configcore/slices/featureflag/handler_test.go
+++ b/corecells/configcore/slices/featureflag/handler_test.go
@@ -534,6 +534,13 @@ func TestHandler_ActionPin_FlagRead(t *testing.T) {
 			req = req.WithContext(ctx)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
+			// Pre-condition: gate passed (2xx). Without this check a routing
+			// misconfiguration or wrong path silently produces a non-200 and the
+			// GotAction assert below would pass vacuously (cap.GotAction == "").
+			require.Equal(t, http.StatusOK, w.Code,
+				"featureflag endpoint %s must return 200 with allow Authorizer "+
+					"(routing or permission misbinding if not); body=%s",
+				ep.name, w.Body)
 			assert.Equal(t, "flag:read", cap.GotAction,
 				"featureflag gate must request action flag:read to PDP; endpoint %s got %q — "+
 					"a misbinding to a different perm would be masked by baseline allow-all-admin",

--- a/corecells/configcore/slices/featureflag/handler_test.go
+++ b/corecells/configcore/slices/featureflag/handler_test.go
@@ -21,11 +21,33 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/query"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
+
+// allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer build the PDP
+// verdicts for tests. The authz.Allow/Deny construction lives in _test.go,
+// which AUTHZ-DECISION-ALLOW-DENY-CALLER-01 sanctions for test doubles; the
+// CapturingAuthorizer type and WithAuthorizer ctx wiring are shared via
+// configcoretest (PR-10b #1348).
+func allowAuthorizer() *configcoretest.CapturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("test allowAuthorizer: authz.Allow: " + err.Error())
+	}
+	return &configcoretest.CapturingAuthorizer{Decision: dec}
+}
+
+func withAllowAuthorizer(ctx context.Context) context.Context {
+	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
+}
+
+func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
+}
 
 // testFlagHandlerTenant is the typed TenantID for direct repo seeding.
 var testFlagHandlerTenant = configcoretest.TestTenant
@@ -39,7 +61,7 @@ const flagsBasePath = "/api/v1/flags"
 // auth.RequirePermission(authz.PermFlagRead()) PDP gate AND the featureflag
 // handler's tenant.FromContext call.
 func asAdminFlag(req *http.Request) *http.Request {
-	ctx := configcoretest.WithAllowAuthorizer(
+	ctx := withAllowAuthorizer(
 		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 	)
 	return req.WithContext(ctx)
@@ -235,7 +257,7 @@ func TestHandler_HandleGet_NotFound(t *testing.T) {
 // NO TenantID, so the request passes the PDP gate yet fails tenant.FromContext.
 // F6: this must map to a typed 403, not a framework 500.
 func asAdminFlagNoTenant(req *http.Request) *http.Request {
-	ctx := configcoretest.WithAllowAuthorizer(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	ctx := withAllowAuthorizer(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
 	return req.WithContext(ctx)
 }
 
@@ -409,7 +431,7 @@ func TestHandler_PDPDeny_Returns403(t *testing.T) {
 	handler, _ := setupHandler()
 
 	asDenyFlag := func(req *http.Request) *http.Request {
-		ctx := configcoretest.WithDenyAuthorizer(
+		ctx := withDenyAuthorizer(
 			configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 			"policy deny",
 		)
@@ -494,7 +516,7 @@ func TestHandler_ActionPin_FlagRead(t *testing.T) {
 
 	for _, ep := range endpoints {
 		t.Run(ep.name, func(t *testing.T) {
-			cap := configcoretest.AllowAuthorizer()
+			cap := allowAuthorizer()
 			ctx := configcoretest.WithAuthorizer(
 				configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
 				cap,

--- a/corecells/configcore/slices/featureflag/handler_test.go
+++ b/corecells/configcore/slices/featureflag/handler_test.go
@@ -34,11 +34,14 @@ var flagHandlerTestKey = bytes.Repeat([]byte("f"), 32)
 
 const flagsBasePath = "/api/v1/flags"
 
-// asAdminFlag attaches an admin Principal AND a valid TenantID to req so it
-// satisfies the auth.AnyRole(RoleAdmin) policy AND the featureflag handler's
-// tenant.FromContext call.
+// asAdminFlag attaches an admin Principal, a valid TenantID, and an allow
+// Authorizer to req so it satisfies the
+// auth.RequirePermission(authz.PermFlagRead()) PDP gate AND the featureflag
+// handler's tenant.FromContext call.
 func asAdminFlag(req *http.Request) *http.Request {
-	ctx := configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	ctx := configcoretest.WithAllowAuthorizer(
+		configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+	)
 	return req.WithContext(ctx)
 }
 
@@ -228,11 +231,12 @@ func TestHandler_HandleGet_NotFound(t *testing.T) {
 	errcodetest.AssertWireCode(t, w, http.StatusNotFound, errcode.ErrFlagNotFound)
 }
 
-// asAdminFlagNoTenant attaches an admin Principal but NO TenantID, so the
-// request passes the admin-role policy yet fails tenant.FromContext. F6: this
-// must map to a typed 403, not a framework 500.
+// asAdminFlagNoTenant attaches an admin Principal and an allow Authorizer but
+// NO TenantID, so the request passes the PDP gate yet fails tenant.FromContext.
+// F6: this must map to a typed 403, not a framework 500.
 func asAdminFlagNoTenant(req *http.Request) *http.Request {
-	return req.WithContext(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	ctx := configcoretest.WithAllowAuthorizer(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+	return req.WithContext(ctx)
 }
 
 func TestHandler_HandleGet_MissingTenant_403(t *testing.T) {
@@ -395,6 +399,124 @@ func TestHandler_HandleList_Pagination_FullTraversal(t *testing.T) {
 	for _, id := range allIDs {
 		assert.False(t, seen[id], "duplicate ID: %s", id)
 		seen[id] = true
+	}
+}
+
+// TestHandler_PDPDeny_Returns403 asserts that a PDP-deny (Authorizer returns
+// Deny) surfaces as 403 ERR_AUTH_FORBIDDEN — confirms flag:read-gated (PDP)
+// behaviour after the role-literal → permission-based migration (PR-10b #1348).
+func TestHandler_PDPDeny_Returns403(t *testing.T) {
+	handler, _ := setupHandler()
+
+	asDenyFlag := func(req *http.Request) *http.Request {
+		ctx := configcoretest.WithDenyAuthorizer(
+			configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+			"policy deny",
+		)
+		return req.WithContext(ctx)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"get deny", httptest.NewRequest(http.MethodGet, flagsBasePath+"/some-key", nil)},
+		{"list deny", httptest.NewRequest(http.MethodGet, flagsBasePath+"/", nil)},
+		{"evaluate deny", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPost, flagsBasePath+"/some-key/evaluate", strings.NewReader(`{"subject":"u"}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, asDenyFlag(tc.req))
+			errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+		})
+	}
+}
+
+// TestHandler_NoAuthorizer_FailClosed_Returns403 asserts that a request with a
+// valid principal but no Authorizer in ctx is fail-closed to 403 — required by
+// the flag:read-gated (PDP) contract: no PDP wired = deny.
+func TestHandler_NoAuthorizer_FailClosed_Returns403(t *testing.T) {
+	handler, _ := setupHandler()
+
+	asAdminFlagNoPDP := func(req *http.Request) *http.Request {
+		// Principal + tenant present, but no Authorizer injected.
+		ctx := configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin}))
+		return req.WithContext(ctx)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"get no-pdp", httptest.NewRequest(http.MethodGet, flagsBasePath+"/some-key", nil)},
+		{"list no-pdp", httptest.NewRequest(http.MethodGet, flagsBasePath+"/", nil)},
+		{"evaluate no-pdp", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPost, flagsBasePath+"/some-key/evaluate", strings.NewReader(`{"subject":"u"}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, asAdminFlagNoPDP(tc.req))
+			errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+		})
+	}
+}
+
+// TestHandler_ActionPin_FlagRead pins that every featureflag endpoint sends
+// action "flag:read" to the PDP. This is the only guard that catches an
+// endpoint↔permission misbinding the role-agnostic baseline (admin allowed for
+// every flag perm) would mask (PR-10b #1348).
+func TestHandler_ActionPin_FlagRead(t *testing.T) {
+	handler, repo := setupHandler()
+	// Seed one flag so GET and evaluate don't short-circuit on 404.
+	require.NoError(t, repo.Create(context.Background(), testFlagHandlerTenant, &domain.FeatureFlag{
+		ID: "ap-1", Key: "pin-flag", Type: domain.FlagBoolean, Enabled: true,
+	}))
+
+	endpoints := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"get", http.MethodGet, flagsBasePath + "/pin-flag", ""},
+		{"list", http.MethodGet, flagsBasePath + "/", ""},
+		{"evaluate", http.MethodPost, flagsBasePath + "/pin-flag/evaluate", `{"subject":"u"}`},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			cap := configcoretest.AllowAuthorizer()
+			ctx := configcoretest.WithAuthorizer(
+				configcoretest.CtxWithTenant(auth.TestContext("admin-user", []string{auth.RoleAdmin})),
+				cap,
+			)
+			var reqBody *strings.Reader
+			if ep.body != "" {
+				reqBody = strings.NewReader(ep.body)
+			} else {
+				reqBody = strings.NewReader("")
+			}
+			req := httptest.NewRequest(ep.method, ep.path, reqBody)
+			if ep.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			assert.Equal(t, "flag:read", cap.GotAction,
+				"featureflag gate must request action flag:read to PDP; endpoint %s got %q — "+
+					"a misbinding to a different perm would be masked by baseline allow-all-admin",
+				ep.name, cap.GotAction)
+		})
 	}
 }
 

--- a/corecells/configcore/slices/featureflag/handler_test.go
+++ b/corecells/configcore/slices/featureflag/handler_test.go
@@ -426,7 +426,7 @@ func TestHandler_HandleList_Pagination_FullTraversal(t *testing.T) {
 
 // TestHandler_PDPDeny_Returns403 asserts that a PDP-deny (Authorizer returns
 // Deny) surfaces as 403 ERR_AUTH_FORBIDDEN — confirms flag:read-gated (PDP)
-// behaviour after the role-literal → permission-based migration (PR-10b #1348).
+// behavior after the role-literal → permission-based migration (PR-10b #1348).
 func TestHandler_PDPDeny_Returns403(t *testing.T) {
 	handler, _ := setupHandler()
 

--- a/corecells/configcore/slices/flagwrite/contract_test.go
+++ b/corecells/configcore/slices/flagwrite/contract_test.go
@@ -99,7 +99,7 @@ func TestHttpConfigFlagsCreateV1Serve(t *testing.T) {
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path,
 		strings.NewReader(`{"key":"my-flag","enabled":false,"rolloutPercentage":0,"description":"test"}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
+	req = req.WithContext(withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -137,7 +137,7 @@ func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
 	req := httptest.NewRequest(c.HTTP.Method, path,
 		strings.NewReader(`{"enabled":true,"rolloutPercentage":50,"description":"updated","expectedVersion":1}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
+	req = req.WithContext(withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -151,7 +151,7 @@ func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
 		recBad := httptest.NewRecorder()
 		reqBad := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(bad))
 		reqBad.Header.Set("Content-Type", "application/json")
-		reqBad = reqBad.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
+		reqBad = reqBad.WithContext(withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 		mux.ServeHTTP(recBad, reqBad)
 		assert.Equal(t, http.StatusBadRequest, recBad.Code,
 			"PUT with out-of-range rolloutPercentage must 400; body %q got %s",
@@ -181,7 +181,7 @@ func TestHttpConfigFlagsToggleV1Serve(t *testing.T) {
 	req := httptest.NewRequest(c.HTTP.Method, path,
 		strings.NewReader(`{"enabled":true,"expectedVersion":1}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
+	req = req.WithContext(withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -202,13 +202,13 @@ func TestHttpConfigFlagsDeleteV1Serve(t *testing.T) {
 	path := strings.ReplaceAll(c.HTTP.Path, "{key}", "del-flag") + "?expectedVersion=1"
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, http.NoBody)
-	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
+	req = req.WithContext(withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body)
 }
 
 func testAdminCtx() context.Context {
-	return configcoretest.WithAllowAuthorizer(
+	return withAllowAuthorizer(
 		configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})),
 	)
 }

--- a/corecells/configcore/slices/flagwrite/contract_test.go
+++ b/corecells/configcore/slices/flagwrite/contract_test.go
@@ -151,7 +151,10 @@ func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
 		recBad := httptest.NewRecorder()
 		reqBad := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(bad))
 		reqBad.Header.Set("Content-Type", "application/json")
-		reqBad = reqBad.WithContext(withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
+		badCtx := withAllowAuthorizer(
+			configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})),
+		)
+		reqBad = reqBad.WithContext(badCtx)
 		mux.ServeHTTP(recBad, reqBad)
 		assert.Equal(t, http.StatusBadRequest, recBad.Code,
 			"PUT with out-of-range rolloutPercentage must 400; body %q got %s",

--- a/corecells/configcore/slices/flagwrite/contract_test.go
+++ b/corecells/configcore/slices/flagwrite/contract_test.go
@@ -99,7 +99,7 @@ func TestHttpConfigFlagsCreateV1Serve(t *testing.T) {
 	req := httptest.NewRequest(c.HTTP.Method, c.HTTP.Path,
 		strings.NewReader(`{"key":"my-flag","enabled":false,"rolloutPercentage":0,"description":"test"}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})))
+	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -137,7 +137,7 @@ func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
 	req := httptest.NewRequest(c.HTTP.Method, path,
 		strings.NewReader(`{"enabled":true,"rolloutPercentage":50,"description":"updated","expectedVersion":1}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})))
+	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -151,7 +151,7 @@ func TestHttpConfigFlagsUpdateV1Serve(t *testing.T) {
 		recBad := httptest.NewRecorder()
 		reqBad := httptest.NewRequest(c.HTTP.Method, path, strings.NewReader(bad))
 		reqBad.Header.Set("Content-Type", "application/json")
-		reqBad = reqBad.WithContext(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})))
+		reqBad = reqBad.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 		mux.ServeHTTP(recBad, reqBad)
 		assert.Equal(t, http.StatusBadRequest, recBad.Code,
 			"PUT with out-of-range rolloutPercentage must 400; body %q got %s",
@@ -181,7 +181,7 @@ func TestHttpConfigFlagsToggleV1Serve(t *testing.T) {
 	req := httptest.NewRequest(c.HTTP.Method, path,
 		strings.NewReader(`{"enabled":true,"expectedVersion":1}`))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})))
+	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body)
 	c.ValidateHTTPResponseRecorder(t, rec)
@@ -202,11 +202,13 @@ func TestHttpConfigFlagsDeleteV1Serve(t *testing.T) {
 	path := strings.ReplaceAll(c.HTTP.Path, "{key}", "del-flag") + "?expectedVersion=1"
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(c.HTTP.Method, path, http.NoBody)
-	req = req.WithContext(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})))
+	req = req.WithContext(configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))))
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body)
 }
 
 func testAdminCtx() context.Context {
-	return configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin}))
+	return configcoretest.WithAllowAuthorizer(
+		configcoretest.CtxWithTenant(auth.TestContext(testAdminSubject, []string{auth.RoleAdmin})),
+	)
 }

--- a/corecells/configcore/slices/flagwrite/handler.go
+++ b/corecells/configcore/slices/flagwrite/handler.go
@@ -11,6 +11,7 @@ import (
 	toggle "github.com/ghbvf/gocell/generated/contracts/http/config/flags/toggle/v1"
 	update "github.com/ghbvf/gocell/generated/contracts/http/config/flags/update/v1"
 	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -124,9 +125,10 @@ type Handler struct {
 }
 
 // NewHandler creates a flagwrite Handler with generated per-contract handlers.
-// All endpoints are admin-only.
+// Endpoints are gated by auth.RequirePermission(authz.PermFlagWrite()); the ABAC
+// PDP decides — baseline grants admin/super-admin (PR-10b #1348).
 func NewHandler(svc *Service) *Handler {
-	policy := auth.AnyRole(auth.RoleAdmin)
+	policy := auth.RequirePermission(authz.PermFlagWrite())
 	return &Handler{
 		createH: create.NewHandler(CreateAdapter{svc}, policy),
 		updateH: update.NewHandler(UpdateAdapter{svc}, policy),

--- a/corecells/configcore/slices/flagwrite/handler_test.go
+++ b/corecells/configcore/slices/flagwrite/handler_test.go
@@ -244,7 +244,7 @@ func setupFlagwriteHTTPHandler(t *testing.T) http.Handler {
 
 // TestFlagwriteHandler_PDPDeny_Returns403 asserts that a PDP-deny Authorizer in
 // ctx surfaces as 403 ERR_AUTH_FORBIDDEN on every flagwrite endpoint — confirms
-// flag:write-gated (PDP) behaviour after the role-literal → permission-based
+// flag:write-gated (PDP) behavior after the role-literal → permission-based
 // migration (PR-10b #1348).
 func TestFlagwriteHandler_PDPDeny_Returns403(t *testing.T) {
 	handler := setupFlagwriteHTTPHandler(t)

--- a/corecells/configcore/slices/flagwrite/handler_test.go
+++ b/corecells/configcore/slices/flagwrite/handler_test.go
@@ -23,11 +23,33 @@ import (
 	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/authz"
 	"github.com/ghbvf/gocell/pkg/errcode"
 	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
+
+// allowAuthorizer / withAllowAuthorizer / withDenyAuthorizer build the PDP
+// verdicts for tests. The authz.Allow/Deny construction lives in _test.go,
+// which AUTHZ-DECISION-ALLOW-DENY-CALLER-01 sanctions for test doubles; the
+// CapturingAuthorizer type and WithAuthorizer ctx wiring are shared via
+// configcoretest (PR-10b #1348).
+func allowAuthorizer() *configcoretest.CapturingAuthorizer {
+	dec, err := authz.Allow(authz.Obligations{})
+	if err != nil {
+		panic("test allowAuthorizer: authz.Allow: " + err.Error())
+	}
+	return &configcoretest.CapturingAuthorizer{Decision: dec}
+}
+
+func withAllowAuthorizer(ctx context.Context) context.Context {
+	return configcoretest.WithAuthorizer(ctx, allowAuthorizer())
+}
+
+func withDenyAuthorizer(ctx context.Context, reason string) context.Context {
+	return configcoretest.WithAuthorizer(ctx, &configcoretest.CapturingAuthorizer{Decision: authz.Deny(reason)})
+}
 
 // PR464 P2.2: typed 404 / 409 envelope adapter regression coverage.
 // fakeFlagRepoErr wraps mem.FlagRepository and overrides Update/Toggle/Delete
@@ -228,7 +250,7 @@ func TestFlagwriteHandler_PDPDeny_Returns403(t *testing.T) {
 	handler := setupFlagwriteHTTPHandler(t)
 
 	asDenyFlagwrite := func(req *http.Request) *http.Request {
-		ctx := configcoretest.WithDenyAuthorizer(
+		ctx := withDenyAuthorizer(
 			configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin})),
 			"policy deny",
 		)
@@ -325,7 +347,7 @@ func TestFlagwriteHandler_ActionPin_FlagWrite(t *testing.T) {
 
 	// Seed a flag for update/toggle/delete endpoints.
 	_, err = svc.Create(
-		configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin}))),
+		withAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin}))),
 		CreateInput{Key: "pin-flag", Description: "action-pin seed"},
 	)
 	require.NoError(t, err)
@@ -360,7 +382,7 @@ func TestFlagwriteHandler_ActionPin_FlagWrite(t *testing.T) {
 
 	for _, ep := range endpoints {
 		t.Run(ep.name, func(t *testing.T) {
-			cap := configcoretest.AllowAuthorizer()
+			cap := allowAuthorizer()
 			ctx := configcoretest.WithAuthorizer(
 				configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin})),
 				cap,

--- a/corecells/configcore/slices/flagwrite/handler_test.go
+++ b/corecells/configcore/slices/flagwrite/handler_test.go
@@ -400,6 +400,14 @@ func TestFlagwriteHandler_ActionPin_FlagWrite(t *testing.T) {
 			req = req.WithContext(ctx)
 			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, req)
+			// HTTP response code pre-assertion: gate must pass (not 401/403) and the
+			// endpoint must be routed (not 404). Mirrors configread/configpublish action-pin style.
+			require.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"flagwrite gate must not block admin with allow Authorizer (endpoint=%s)", ep.name)
+			require.NotEqual(t, http.StatusForbidden, w.Code,
+				"flagwrite gate must not deny admin with allow Authorizer (endpoint=%s)", ep.name)
+			require.NotEqual(t, http.StatusNotFound, w.Code,
+				"flagwrite endpoint must be routed (endpoint=%s)", ep.name)
 			assert.Equal(t, "flag:write", cap.GotAction,
 				"flagwrite gate must request action flag:write to PDP; endpoint %s got %q — "+
 					"a misbinding to a different perm would be masked by baseline allow-all-admin",

--- a/corecells/configcore/slices/flagwrite/handler_test.go
+++ b/corecells/configcore/slices/flagwrite/handler_test.go
@@ -3,6 +3,9 @@ package flagwrite
 import (
 	"context"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,13 +14,17 @@ import (
 	"github.com/ghbvf/gocell/corecells/configcore/configcoretest"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/domain"
 	"github.com/ghbvf/gocell/corecells/configcore/internal/mem"
+	"github.com/ghbvf/gocell/corecells/configcore/internal/testutil"
 	create "github.com/ghbvf/gocell/generated/contracts/http/config/flags/create/v1"
 	flagsdelete "github.com/ghbvf/gocell/generated/contracts/http/config/flags/delete/v1"
 	toggle "github.com/ghbvf/gocell/generated/contracts/http/config/flags/toggle/v1"
 	update "github.com/ghbvf/gocell/generated/contracts/http/config/flags/update/v1"
+	kcell "github.com/ghbvf/gocell/kernel/cell"
+	"github.com/ghbvf/gocell/kernel/cell/celltest"
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/pkg/tenant"
 	"github.com/ghbvf/gocell/runtime/auth"
 )
@@ -187,4 +194,194 @@ func TestFlagUpdateAdapter_MissingTenant_Returns403Typed(t *testing.T) {
 	typed, ok := resp.(update.Update403ErrorResponse)
 	require.True(t, ok, "expected Update403ErrorResponse, got %T", resp)
 	assert.Equal(t, errcode.ErrAuthForbidden, typed.Body.Code)
+}
+
+// --- HTTP-level PDP-based authz tests (flag:write-gated (PDP)) ---
+
+const flagwriteBasePath = "/api/v1/flags"
+
+// setupFlagwriteHTTPHandler builds an HTTP handler for flagwrite HTTP-level tests.
+// It uses NewHandler (which now wires RequirePermission(authz.PermFlagWrite()))
+// and is the same construction path as production.
+func setupFlagwriteHTTPHandler(t *testing.T) http.Handler {
+	t.Helper()
+	repo := mem.NewFlagRepository(clock.Real())
+	svc, err := NewService(clock.Real(), repo, slog.Default(),
+		WithTxManager(persistence.WrapForCell(&testutil.NoopTxRunner{})))
+	if err != nil {
+		t.Fatalf("setupFlagwriteHTTPHandler: %v", err)
+	}
+	mux := celltest.NewTestMux()
+	mux.Route(flagwriteBasePath, func(sub kcell.RouteMux) {
+		if err := NewHandler(svc).RegisterRoutes(sub); err != nil {
+			t.Fatalf("RegisterRoutes: %v", err)
+		}
+	})
+	return mux
+}
+
+// TestFlagwriteHandler_PDPDeny_Returns403 asserts that a PDP-deny Authorizer in
+// ctx surfaces as 403 ERR_AUTH_FORBIDDEN on every flagwrite endpoint — confirms
+// flag:write-gated (PDP) behaviour after the role-literal → permission-based
+// migration (PR-10b #1348).
+func TestFlagwriteHandler_PDPDeny_Returns403(t *testing.T) {
+	handler := setupFlagwriteHTTPHandler(t)
+
+	asDenyFlagwrite := func(req *http.Request) *http.Request {
+		ctx := configcoretest.WithDenyAuthorizer(
+			configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin})),
+			"policy deny",
+		)
+		return req.WithContext(ctx)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"create deny", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPost, flagwriteBasePath+"/",
+				strings.NewReader(`{"key":"k","enabled":false,"rolloutPercentage":0,"description":"d"}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+		{"update deny", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPut, flagwriteBasePath+"/k",
+				strings.NewReader(`{"enabled":true,"rolloutPercentage":50,"description":"d","expectedVersion":1}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+		{"toggle deny", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPost, flagwriteBasePath+"/k/toggle",
+				strings.NewReader(`{"enabled":true,"expectedVersion":1}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+		{"delete deny", httptest.NewRequest(http.MethodDelete, flagwriteBasePath+"/k?expectedVersion=1", http.NoBody)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, asDenyFlagwrite(tc.req))
+			errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+		})
+	}
+}
+
+// TestFlagwriteHandler_NoAuthorizer_FailClosed_Returns403 asserts that a
+// request with a valid principal but no Authorizer in ctx is fail-closed to 403
+// — required by the flag:write-gated (PDP) contract: no PDP wired = deny.
+func TestFlagwriteHandler_NoAuthorizer_FailClosed_Returns403(t *testing.T) {
+	handler := setupFlagwriteHTTPHandler(t)
+
+	asAdminNoPDP := func(req *http.Request) *http.Request {
+		// Principal + tenant present, but no Authorizer injected.
+		ctx := configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin}))
+		return req.WithContext(ctx)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"create no-pdp", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPost, flagwriteBasePath+"/",
+				strings.NewReader(`{"key":"k","enabled":false,"rolloutPercentage":0,"description":"d"}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+		{"update no-pdp", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPut, flagwriteBasePath+"/k",
+				strings.NewReader(`{"enabled":true,"rolloutPercentage":50,"description":"d","expectedVersion":1}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+		{"toggle no-pdp", func() *http.Request {
+			r := httptest.NewRequest(http.MethodPost, flagwriteBasePath+"/k/toggle",
+				strings.NewReader(`{"enabled":true,"expectedVersion":1}`))
+			r.Header.Set("Content-Type", "application/json")
+			return r
+		}()},
+		{"delete no-pdp", httptest.NewRequest(http.MethodDelete, flagwriteBasePath+"/k?expectedVersion=1", http.NoBody)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, asAdminNoPDP(tc.req))
+			errcodetest.AssertWireCode(t, w, http.StatusForbidden, errcode.ErrAuthForbidden)
+		})
+	}
+}
+
+// TestFlagwriteHandler_ActionPin_FlagWrite pins that every flagwrite endpoint
+// sends action "flag:write" to the PDP. This is the only guard that catches an
+// endpoint↔permission misbinding the role-agnostic baseline (admin allowed for
+// every flag perm) would mask (PR-10b #1348).
+func TestFlagwriteHandler_ActionPin_FlagWrite(t *testing.T) {
+	repo := mem.NewFlagRepository(clock.Real())
+	svc, err := NewService(clock.Real(), repo, slog.Default(),
+		WithTxManager(persistence.WrapForCell(&testutil.NoopTxRunner{})))
+	require.NoError(t, err)
+
+	// Seed a flag for update/toggle/delete endpoints.
+	_, err = svc.Create(
+		configcoretest.WithAllowAuthorizer(configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin}))),
+		CreateInput{Key: "pin-flag", Description: "action-pin seed"},
+	)
+	require.NoError(t, err)
+
+	mux := celltest.NewTestMux()
+	mux.Route(flagwriteBasePath, func(sub kcell.RouteMux) {
+		if err := NewHandler(svc).RegisterRoutes(sub); err != nil {
+			t.Fatalf("RegisterRoutes: %v", err)
+		}
+	})
+
+	endpoints := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			"create", http.MethodPost, flagwriteBasePath + "/",
+			`{"key":"new-flag","enabled":false,"rolloutPercentage":0,"description":"d"}`,
+		},
+		{
+			"update", http.MethodPut, flagwriteBasePath + "/pin-flag",
+			`{"enabled":true,"rolloutPercentage":50,"description":"d","expectedVersion":1}`,
+		},
+		{
+			"toggle", http.MethodPost, flagwriteBasePath + "/pin-flag/toggle",
+			`{"enabled":true,"expectedVersion":1}`,
+		},
+		{"delete", http.MethodDelete, flagwriteBasePath + "/pin-flag?expectedVersion=1", ""},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			cap := configcoretest.AllowAuthorizer()
+			ctx := configcoretest.WithAuthorizer(
+				configcoretest.CtxWithTenant(auth.TestContext(testFlagwriteAdmin, []string{auth.RoleAdmin})),
+				cap,
+			)
+			var reqBody *strings.Reader
+			if ep.body != "" {
+				reqBody = strings.NewReader(ep.body)
+			} else {
+				reqBody = strings.NewReader("")
+			}
+			req := httptest.NewRequest(ep.method, ep.path, reqBody)
+			if ep.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			assert.Equal(t, "flag:write", cap.GotAction,
+				"flagwrite gate must request action flag:write to PDP; endpoint %s got %q — "+
+					"a misbinding to a different perm would be masked by baseline allow-all-admin",
+				ep.name, cap.GotAction)
+		})
+	}
 }

--- a/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
+++ b/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
@@ -232,6 +232,12 @@ set and the built-in baseline, then drains the migration allowlist.
   a one-line policy swap per slice. No wire change (auth semantics equivalent;
   baseline still gates admin) → no version bump. The 14 configcore contract 403
   descriptions are updated to name the permission deny (F7-consistency).
+  **Ruling (api-versioning.md §"改变鉴权要求"):** switching the gate implementation
+  from a role literal to the PDP is NOT a wire-breaking auth change — the
+  client-observable contract (admin→200, non-admin→403 ERR_AUTH_FORBIDDEN, 403
+  already declared in every contract.yaml) is unchanged. api-versioning's
+  "改变鉴权要求" targets client-visible auth semantics, not the internal enforcement
+  mechanism. Mirrors the PR-10a auditquery precedent (no version bump).
 - **Assembly wiring already complete** from PR-10a F1: every root serving configcore
   (`cmd/corebundle`, `examples/ssobff`, `examples/corebundlestarter`) already calls
   `bootstrap.PrimaryAuthorizerOption`, so no new wiring — configcore endpoints hit
@@ -240,10 +246,15 @@ set and the built-in baseline, then drains the migration allowlist.
   ceiling decremented to 3; the rule now fail-louds on any role-literal regression
   in configcore. e2e `TestABACPDPGatesConfigcore` (admin read/write→200,
   non-admin→403 PDP-deny) proves the wired PDP gates configcore on the real path.
-- **New guard (test-pinned, Medium)**: per-slice action-pin tests assert the gate
-  asks the PDP for the *correct* permission string (the baseline allows admin for
-  every config permission, so a wrong-permission misbinding would otherwise pass
-  e2e and archtest silently). Full Hard-ification of the binding is PR-13.
+- **Per-slice action-pin tests (test coverage, not a governance-tier enforcement
+  mechanism)**: each configcore slice test asserts the gate asks the PDP for the
+  *correct* permission string (the baseline allows admin for every config permission,
+  so a wrong-permission misbinding would otherwise pass e2e and archtest silently).
+  This is ordinary unit-test coverage — it does not qualify as a Medium/Hard archtest
+  or governance rule under the ai-robust charter (which rates enforcement mechanisms
+  such as type-aware scans, runtime guards, and codegen funnels, not test-level pins).
+  The machine-grade Hard enforcement of the endpoint↔permission binding is PR-13
+  (contract.yaml → cellgen-derived gate + golden).
 
 ## Out of scope (PR-10b → follow-ups)
 

--- a/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
+++ b/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
@@ -160,7 +160,7 @@ allowlist is a migration ledger, shrunk to empty in PR-10b (SC-005 归零).
 | Authorizer ctx funnel | private ctxkey + sole WithAuthorizer | Hard | WithAuthorizer / AuthorizerFromContext+RequirePermission |
 | `authz.Decision` Allow/Deny | evaluator sole construction site (existing) | Hard | — (baseline is data, no new caller) |
 | RequirePermission obligation fail-closed (F5) | runtime guard: deny on non-zero obligation an Allow carries | Medium | sole route gate; baseline obligation-free |
-| PERMISSION-BASED-AUTHZ-01 | archtest typed scan + allowlist | Medium | allowlist→∅ in PR-10b / scan fail-loud |
+| PERMISSION-BASED-AUTHZ-01 | archtest typed scan + allowlist | Medium | allowlist 8→3 (PR-10b configcore), →∅ in PR-10c / scan fail-loud |
 | WithPrimaryAuthorizer nil / accesscore absent + startup resolve (F8) | bootstrap + composition fail-fast; lazyAuthorizer.ResolveAuthorizer at router build (post-Init, pre-serve) | Medium | — |
 
 ## Consequences
@@ -208,13 +208,56 @@ wiring. The route gate for super-admin: before PR-10a = AnyRole allow → 200;
 after PR-10a = baseline Allow → 200 — identical at the route layer. The 501
 is the data layer rejecting RowScopeAll, not the PDP.
 
-## Out of scope (PR-10b)
+## Amendment: PR-10b — configcore migrated (#1348)
 
-configcore×5 + accesscore policymanage/identitymanage/rbaccheck + examples
-migration (each with its baseline rule); allowlist zeroing (SC-005); the
-PERMISSION-BASED-AUTHZ-01 Hard-ification (contract.yaml → cellgen + golden);
-deletion of the now-legacy `RequireSelfOrRole`/`RequireAnyRole` helpers (still
-serving allowlisted cells).
+PR-10b applies the PR-10a mechanism (above) to the 5 configcore slices. No new
+decisions, type machinery, or threat surface — it extends the closed Permission
+set and the built-in baseline, then drains the migration allowlist.
+
+- **5 permissions minted** (`pkg/authz/permission.go`): `config:read` (configread),
+  `config:write` (configwrite — folds create/update/delete), `config:publish`
+  (configpublish), `flag:read` (featureflag — get/list/evaluate), `flag:write`
+  (flagwrite). Same sealed shape as `PermAuditRead` (private singleton + accessor
+  func; D4 Hard immutability holds). resource:action naming follows AWS-IAM /
+  Spring-Security; the closed-registry test pins len 1→6 and each action string.
+- **5 baseline rules** (`baseline.go`), one per permission, each reproducing the
+  prior `auth.AnyRole(RoleAdmin)` gate via the shared `adminOrSuperAdmin()`
+  condition (Allow, action-scoped, subject.role ∈ {admin, super-admin}). D3's
+  baseline≠downgrade and the forbid-wins / RowScope-independence arguments carry
+  over verbatim; **threat model re-evaluated: unchanged** — admin/super-admin keep
+  exactly their prior access, non-admins stay default-deny, and a tenant `allow`
+  can only widen the *route* gate (not data visibility, governed by RowScope).
+- **5 handlers migrated** to `auth.RequirePermission(authz.Perm*)`; configcore has
+  no self/ownership branch (unlike auditquery) so no custom policy func is needed —
+  a one-line policy swap per slice. No wire change (auth semantics equivalent;
+  baseline still gates admin) → no version bump. The 14 configcore contract 403
+  descriptions are updated to name the permission deny (F7-consistency).
+- **Assembly wiring already complete** from PR-10a F1: every root serving configcore
+  (`cmd/corebundle`, `examples/ssobff`, `examples/corebundlestarter`) already calls
+  `bootstrap.PrimaryAuthorizerOption`, so no new wiring — configcore endpoints hit
+  the already-wired PDP.
+- **Allowlist 8→3** (`PERMISSION-BASED-AUTHZ-01`): the 5 configcore entries removed,
+  ceiling decremented to 3; the rule now fail-louds on any role-literal regression
+  in configcore. e2e `TestABACPDPGatesConfigcore` (admin read/write→200,
+  non-admin→403 PDP-deny) proves the wired PDP gates configcore on the real path.
+- **New guard (test-pinned, Medium)**: per-slice action-pin tests assert the gate
+  asks the PDP for the *correct* permission string (the baseline allows admin for
+  every config permission, so a wrong-permission misbinding would otherwise pass
+  e2e and archtest silently). Full Hard-ification of the binding is PR-13.
+
+## Out of scope (PR-10b → follow-ups)
+
+- **PR-10c**: accesscore policymanage / identitymanage / rbaccheck migration
+  (allowlist 3→0, then delete the ceiling test). These carry `SelfOr` ownership
+  gates needing custom policy funcs (param==subject exempt, else RequirePermission),
+  so they are split from the uniform configcore admin gates.
+- **PR-10d (#1894)**: examples (iotdevice / todoorder) migration — out of the
+  `PERMISSION-BASED-AUTHZ-01` archtest scope (`./corecells/...` only), bespoke roles
+  (RoleCustomer/RoleOperator), separate composition roots needing their own PDP
+  wiring + baseline. Independent architectural unit, not a tail.
+- **PR-13**: PERMISSION-BASED-AUTHZ-01 Hard-ification (contract.yaml → cellgen +
+  golden) once the allowlist reaches ∅; deletion of the now-legacy
+  `RequireSelfOrRole`/`RequireAnyRole` helpers (still serving allowlisted cells).
 
 ## References
 

--- a/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
+++ b/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
@@ -211,8 +211,12 @@ is the data layer rejecting RowScopeAll, not the PDP.
 ## Amendment: PR-10b — configcore migrated (#1348)
 
 PR-10b applies the PR-10a mechanism (above) to the 5 configcore slices. No new
-decisions, type machinery, or threat surface — it extends the closed Permission
-set and the built-in baseline, then drains the migration allowlist.
+type machinery — it extends the closed Permission set and the built-in baseline,
+then drains the migration allowlist. It does carry **one substantive decision**:
+unlike auditquery, the configcore gates were admin-only, so routing them through
+the shared `adminOrSuperAdmin()` baseline widens them to admit super-admin. That
+relaxation is recorded explicitly below (PR pr-review F1 corrected an earlier
+draft that mis-described it as "unchanged").
 
 - **5 permissions minted** (`pkg/authz/permission.go`): `config:read` (configread),
   `config:write` (configwrite — folds create/update/delete), `config:publish`
@@ -220,24 +224,48 @@ set and the built-in baseline, then drains the migration allowlist.
   (flagwrite). Same sealed shape as `PermAuditRead` (private singleton + accessor
   func; D4 Hard immutability holds). resource:action naming follows AWS-IAM /
   Spring-Security; the closed-registry test pins len 1→6 and each action string.
-- **5 baseline rules** (`baseline.go`), one per permission, each reproducing the
-  prior `auth.AnyRole(RoleAdmin)` gate via the shared `adminOrSuperAdmin()`
-  condition (Allow, action-scoped, subject.role ∈ {admin, super-admin}). D3's
-  baseline≠downgrade and the forbid-wins / RowScope-independence arguments carry
-  over verbatim; **threat model re-evaluated: unchanged** — admin/super-admin keep
-  exactly their prior access, non-admins stay default-deny, and a tenant `allow`
-  can only widen the *route* gate (not data visibility, governed by RowScope).
+- **5 baseline rules** (`baseline.go`), one per permission, each gating the
+  permission via the shared `adminOrSuperAdmin()` condition (Allow, action-scoped,
+  subject.role ∈ {admin, super-admin}). D3's baseline≠downgrade and the forbid-wins
+  / RowScope-independence arguments carry over verbatim.
+  **Threat model re-evaluated — subject set WIDENED, not unchanged (PR pr-review F1):**
+  unlike auditquery (whose pre-migration gate was already
+  `auth.AnyRole(RoleAdmin, RoleSuperAdmin)` — see §"Super-admin behavior" above),
+  the 5 configcore gates were `auth.AnyRole(RoleAdmin)` — **admin-only**, and
+  `HasRole` is a literal membership check with no super-admin→admin inheritance
+  (`runtime/auth/principal.go`). Routing them through `adminOrSuperAdmin()` therefore
+  **widens** the config route gate to admit super-admin: a `superadmin`-only
+  principal that the old literal gate denied (403) now passes (200). This is a
+  deliberate, eyes-open **relaxation**, not an accident — super-admin ⊇ admin is the
+  conventional administrative superset (Spring `RoleHierarchy`, Kubernetes
+  `cluster-admin`, AWS-IAM/Cedar all model it, but only when *explicitly declared*,
+  never as a silent side effect of a mechanism swap), and `adminOrSuperAdmin()` is
+  the project's single declared admin-hierarchy condition, shared by audit and
+  config. **Net effect today is zero**: `RoleSuperAdmin` has no production token
+  issuer on develop (`runtime/auth/roles.go` — type-foundation constant only), so no
+  live principal carries it. non-admins stay default-deny; a tenant `allow` can only
+  widen the *route* gate, never data visibility (governed by principal-derived RowScope).
 - **5 handlers migrated** to `auth.RequirePermission(authz.Perm*)`; configcore has
   no self/ownership branch (unlike auditquery) so no custom policy func is needed —
-  a one-line policy swap per slice. No wire change (auth semantics equivalent;
-  baseline still gates admin) → no version bump. The 14 configcore contract 403
-  descriptions are updated to name the permission deny (F7-consistency).
-  **Ruling (api-versioning.md §"改变鉴权要求"):** switching the gate implementation
-  from a role literal to the PDP is NOT a wire-breaking auth change — the
-  client-observable contract (admin→200, non-admin→403 ERR_AUTH_FORBIDDEN, 403
-  already declared in every contract.yaml) is unchanged. api-versioning's
-  "改变鉴权要求" targets client-visible auth semantics, not the internal enforcement
-  mechanism. Mirrors the PR-10a auditquery precedent (no version bump).
+  a one-line policy swap per slice. The 14 configcore contract 403 descriptions name
+  the permission deny and the admin + super-admin baseline grant (F7-consistency —
+  the 403 texts already name super-admin, so they stay accurate under this ruling).
+  **Ruling (api-versioning.md §"改变鉴权要求"):** no new contract version is minted.
+  The mechanism swap (role literal → PDP) is not itself a wire change; the one
+  observable delta is that a `superadmin` principal's route outcome moves **403→200**
+  on the 5 config gates (admin → 200 and every non-admin/non-super-admin → 403
+  ERR_AUTH_FORBIDDEN are unchanged; 403 is already declared in every contract.yaml).
+  That delta is a **relaxation** — it grants access to a strictly-higher-privilege
+  platform role, denies nothing previously allowed, and changes no field shape,
+  status-code set, idempotency, or pagination. Under pre-GA (api-versioning.md
+  §"兼容窗口": no Go API shim; wire contracts version only on *breaking* change),
+  widening the admitted subject set to a not-yet-issued superset role is not a
+  breaking wire change and needs no v1→v2 bump. (A *restriction*, a removed/renamed
+  field, or changed status semantics WOULD require a new version.) This shares the
+  *mechanism* of the PR-10a auditquery precedent but is NOT subject-set-identical to
+  it: auditquery's pre-migration gate already admitted super-admin, so PR-10a changed
+  no subject set, whereas configcore is a genuine relaxation — recorded here as an
+  explicit, deliberate decision rather than an implicit side effect.
 - **Assembly wiring already complete** from PR-10a F1: every root serving configcore
   (`cmd/corebundle`, `examples/ssobff`, `examples/corebundlestarter`) already calls
   `bootstrap.PrimaryAuthorizerOption`, so no new wiring — configcore endpoints hit

--- a/hack/verify-archtest-invariants.sh
+++ b/hack/verify-archtest-invariants.sh
@@ -63,6 +63,17 @@ source hack/lib/archtest.sh
 # shard) — a SILENT (green) perf regression that must fail at PR-merge, not only
 # nightly. Cheap here: a header-only //go:build parse per file, NO packages.Load.
 #
+# PERMISSION-BASED-AUTHZ-01 — only its CHEAP exact-set freeze
+# (TestPermissionBasedAuthzAllowlist_Ceiling) IS in this PR-time set: it asserts the
+# role-literal-gate migration allowlist equals its frozen expected set (an in-memory
+# map compare, NO packages.Load), so allowlist tampering — a grow, or a swap that
+# keeps len=3 while silently exempting a new role-literal gate — fails at PR-merge,
+# not only nightly. The rule's heavy enforcement scan (TestPermissionBasedAuthz_01)
+# is a whole-corecells packages.Load typed scan and, like CLOCK-POSITIONAL-INJECTION-01
+# above, stays nightly (archtest-nightly.yml) to respect the 2-CPU/7GB runner budget;
+# it also carries the live no-stale anti-vacuity (each allowlisted file must still hold
+# a real gate). #1925 PR-10b pr-review F2/F3.
+#
 # -tags=archtest: the archtest leaf is gated behind `//go:build archtest` so a
 # bare `go test ./...` keeps it off the make verify / PR critical path (build-tag
 # funnel; same convention as integration / e2e). This gate is a sanctioned
@@ -70,7 +81,7 @@ source hack/lib/archtest.sh
 # renamed tag (which yields "[no test files]" → 0 tests → false green) into a
 # hard failure — `-run` over an empty test set exits 0 otherwise.
 if ! output="$(go test -tags="$ARCHTEST_BUILD_TAGS" ./tools/archtest \
-  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestArchtestModulePathFunnel|TestModulePathFunnel_TypedReconstruction|TestFenceTokenMintFunnel_AllowlistEnforced|TestMetadatatestImportScope|TestFixtureCellIDTypedBuilder_NewCellIDBodyShape|TestFixtureCellIDTypedBuilder_VarInitializerShape|TestRootModuleNoReplace01|TestRootModuleNoReplace01_NegativeControl|TestPlatformCellScanCoverage01|TestPlatformCellScanCoverage01_AntiVacuity|TestArchtest_AllLeafTestFiles_HaveArchtestBuildTag|TestArchtest_InvariantsScriptContainsFunnelGuard)$' \
+  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestArchtestModulePathFunnel|TestModulePathFunnel_TypedReconstruction|TestFenceTokenMintFunnel_AllowlistEnforced|TestMetadatatestImportScope|TestFixtureCellIDTypedBuilder_NewCellIDBodyShape|TestFixtureCellIDTypedBuilder_VarInitializerShape|TestRootModuleNoReplace01|TestRootModuleNoReplace01_NegativeControl|TestPlatformCellScanCoverage01|TestPlatformCellScanCoverage01_AntiVacuity|TestArchtest_AllLeafTestFiles_HaveArchtestBuildTag|TestArchtest_InvariantsScriptContainsFunnelGuard|TestPermissionBasedAuthzAllowlist_Ceiling)$' \
   -count=1 -timeout 5m 2>&1)"; then
   printf '%s\n' "$output"
   exit 1

--- a/pkg/authz/permission.go
+++ b/pkg/authz/permission.go
@@ -65,11 +65,52 @@ func PermAuditRead() Permission {
 	return permAuditRead
 }
 
+// configcore permissions (PR-10b #1348). Each mirrors the role-literal
+// auth.AnyRole(RoleAdmin) gate it replaces, one resource:action per slice's
+// shared route policy. Naming follows the resource:action convention of the
+// audit:read seed (ref: AWS-IAM service:Action, Spring-Security
+// hasAuthority("resource:action")). Same accessor-func-over-private-singleton
+// shape as PermAuditRead — reassignment is a compile error (Hard immutability).
+var (
+	permConfigRead    = newPermission("config:read")
+	permConfigWrite   = newPermission("config:write")
+	permConfigPublish = newPermission("config:publish")
+	permFlagRead      = newPermission("flag:read")
+	permFlagWrite     = newPermission("flag:write")
+)
+
+// PermConfigRead authorizes reading configuration entries (configread slice:
+// GET config/{key}, GET config). Migrated from auth.AnyRole(RoleAdmin) in PR-10b.
+func PermConfigRead() Permission { return permConfigRead }
+
+// PermConfigWrite authorizes mutating configuration entries (configwrite slice:
+// create/update/delete). "write" folds create+update+delete per the AWS-IAM
+// Write access-level grouping the prior uniform admin gate already implied.
+func PermConfigWrite() Permission { return permConfigWrite }
+
+// PermConfigPublish authorizes the config publish/rollback lifecycle
+// (configpublish slice). A domain verb distinct from CRUD write, mirroring the
+// dedicated publish endpoints' own admin gate.
+func PermConfigPublish() Permission { return permConfigPublish }
+
+// PermFlagRead authorizes reading/evaluating feature flags (featureflag slice:
+// GET flag/{key}, GET flags, POST evaluate). Evaluate is a read-only computation.
+func PermFlagRead() Permission { return permFlagRead }
+
+// PermFlagWrite authorizes mutating feature flags (flagwrite slice:
+// create/update/toggle/delete).
+func PermFlagWrite() Permission { return permFlagWrite }
+
 // allPermissions is the closed registry of every Permission that exists. It
 // backs Permissions() and lets tests pin the closed set (anti-vacuity: a new
 // perm* var that is not added here is caught by the registry test).
 var allPermissions = []Permission{
 	permAuditRead,
+	permConfigRead,
+	permConfigWrite,
+	permConfigPublish,
+	permFlagRead,
+	permFlagWrite,
 }
 
 // String returns the action spelling carried into a PDP and stored in policy

--- a/pkg/authz/permission_test.go
+++ b/pkg/authz/permission_test.go
@@ -1,6 +1,13 @@
 package authz
 
-import "testing"
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestPermission_String(t *testing.T) {
 	if got := PermAuditRead().String(); got != "audit:read" {
@@ -111,50 +118,155 @@ func TestPermissions_NoDuplicates(t *testing.T) {
 	}
 }
 
-// TestPermissions_KnownVarsEnrolled asserts that each Perm* accessor exported by
-// this package is present in Permissions(). A new perm* var whose accessor is
-// declared but NOT added to allPermissions is caught here (registry-enrollment
-// contract).
+// TestPermissions_AccessorsEnrolled SELF-DISCOVERS every exported Perm*() accessor
+// in permission.go (via go/parser, not a hand-maintained list) and asserts the set
+// of actions they expose equals the closed registry returned by Permissions() —
+// bidirectionally:
 //
-// Note: Go does not support reflect-based enumeration of package-level vars from
-// within the same package's test, so this test enumerates the known accessors
-// explicitly. The anti-vacuity property comes from TestPermissions_ClosedRegistry
-// (which pins len==1 for PR-10a) — together they ensure no var is silently
-// un-enrolled: a new perm* must be added to allPermissions (or len test fails)
-// AND its accessor must appear in the explicit membership check below.
+//   - every accessor's action must be in Permissions() (no accessor whose singleton
+//     was forgotten from allPermissions — the F4 double-omission the old hand-written
+//     knownVars list could silently miss);
+//   - every Permissions() action must have an accessor (no registry entry without a
+//     public accessor).
 //
-// Registry-enrollment contract: every new perm* var added to permission.go MUST
-// also be appended to allPermissions in the same commit; omitting the enrollment
-// causes TestPermissions_ClosedRegistry to fail (len mismatch) AND this test to
-// fail (membership miss).
-func TestPermissions_KnownVarsEnrolled(t *testing.T) {
-	registry := Permissions()
-	contains := func(p Permission) bool {
-		for _, r := range registry {
-			if r.String() == p.String() {
-				return true
+// Because the accessors are discovered from source, adding a new Perm*() without
+// enrolling its singleton now fails automatically — no test edit required.
+//
+// AI-robust grade: Medium (machine-decidable static AST scan, self-discovering). A
+// Hard alternative — generate the Perm*() accessors and allPermissions from one
+// registry table + golden — would need a new `gocell generate authz` command, which
+// is NOT a low-cost Hard path, so per ai-robust.md no follow-up issue is filed and
+// this Medium guard stands. TestPermissions_ClosedRegistry keeps the len anchor.
+func TestPermissions_AccessorsEnrolled(t *testing.T) {
+	accessorActions := parsePermissionAccessorActions(t) // action -> accessor name
+
+	// Anti-vacuity: a parser regression that finds nothing must fail, not pass.
+	if len(accessorActions) < 6 {
+		t.Fatalf("self-discovery found %d Perm*() accessors in permission.go, want ≥6 "+
+			"(PermAuditRead + 5 configcore) — the parser likely regressed", len(accessorActions))
+	}
+
+	registry := map[string]struct{}{}
+	for _, p := range Permissions() {
+		registry[p.String()] = struct{}{}
+	}
+
+	for action, fn := range accessorActions {
+		if _, ok := registry[action]; !ok {
+			t.Errorf("accessor %s() exposes %q which is NOT in Permissions() — "+
+				"append its singleton to allPermissions in permission.go", fn, action)
+		}
+	}
+	for action := range registry {
+		if _, ok := accessorActions[action]; !ok {
+			t.Errorf("registry action %q has no exported Perm*() accessor in permission.go", action)
+		}
+	}
+}
+
+// parsePermissionAccessorActions parses permission.go and returns a map from each
+// exported Perm*() accessor's action string to the accessor name, by statically
+// resolving `func PermX() Permission { return permX }` →
+// `var permX = newPermission("action")`. It is the self-discovery engine behind
+// TestPermissions_AccessorsEnrolled.
+func parsePermissionAccessorActions(t *testing.T) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "permission.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse permission.go: %v", err)
+	}
+
+	varAction := map[string]string{}   // perm var name -> action literal
+	accessorVar := map[string]string{} // Perm*() name   -> returned var name
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.GenDecl:
+			if d.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range d.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i < len(vs.Values) {
+						if action, ok := newPermissionLiteral(vs.Values[i]); ok {
+							varAction[name.Name] = action
+						}
+					}
+				}
+			}
+		case *ast.FuncDecl:
+			if d.Recv != nil || !strings.HasPrefix(d.Name.Name, "Perm") || !returnsPermission(d.Type) {
+				continue
+			}
+			if v, ok := singleReturnIdent(d.Body); ok {
+				accessorVar[d.Name.Name] = v
 			}
 		}
+	}
+
+	out := map[string]string{}
+	for fn, varName := range accessorVar {
+		action, ok := varAction[varName]
+		if !ok {
+			t.Errorf("accessor %s() returns %q, which is not a newPermission(...) singleton in permission.go", fn, varName)
+			continue
+		}
+		out[action] = fn
+	}
+	return out
+}
+
+// newPermissionLiteral reports the action string of a `newPermission("action")`
+// call expression.
+func newPermissionLiteral(expr ast.Expr) (string, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return "", false
+	}
+	fn, ok := call.Fun.(*ast.Ident)
+	if !ok || fn.Name != "newPermission" || len(call.Args) != 1 {
+		return "", false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// returnsPermission reports whether ft is the signature `() Permission`.
+func returnsPermission(ft *ast.FuncType) bool {
+	if ft.Params != nil && len(ft.Params.List) != 0 {
 		return false
 	}
-
-	// Enumerate every exported Perm* accessor. Update this list when adding new vars.
-	knownVars := []struct {
-		name string
-		perm Permission
-	}{
-		{"PermAuditRead", PermAuditRead()},
-		{"PermConfigRead", PermConfigRead()},
-		{"PermConfigWrite", PermConfigWrite()},
-		{"PermConfigPublish", PermConfigPublish()},
-		{"PermFlagRead", PermFlagRead()},
-		{"PermFlagWrite", PermFlagWrite()},
+	if ft.Results == nil || len(ft.Results.List) != 1 {
+		return false
 	}
+	id, ok := ft.Results.List[0].Type.(*ast.Ident)
+	return ok && id.Name == "Permission"
+}
 
-	for _, kv := range knownVars {
-		if !contains(kv.perm) {
-			t.Errorf("%s (%q) is declared but missing from Permissions() — add it to allPermissions in permission.go",
-				kv.name, kv.perm.String())
-		}
+// singleReturnIdent reports the identifier name of a body that is exactly
+// `{ return someIdent }`.
+func singleReturnIdent(body *ast.BlockStmt) (string, bool) {
+	if body == nil || len(body.List) != 1 {
+		return "", false
 	}
+	ret, ok := body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return "", false
+	}
+	id, ok := ret.Results[0].(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return id.Name, true
 }

--- a/pkg/authz/permission_test.go
+++ b/pkg/authz/permission_test.go
@@ -42,6 +42,30 @@ func TestPermAuditRead_StableIdentity(t *testing.T) {
 	}
 }
 
+// TestConfigcorePermissions_StableIdentity pins that each configcore accessor
+// returns the same package-private singleton on every call (the F6 immutability
+// contract from PR-10b: function accessors are not reassignable, so the registry
+// value is immutable to external packages; returning the singleton on every call
+// is the observable proof of that invariant within the package itself).
+func TestConfigcorePermissions_StableIdentity(t *testing.T) {
+	cases := []struct {
+		name      string
+		got       Permission
+		singleton Permission
+	}{
+		{"PermConfigRead", PermConfigRead(), permConfigRead},
+		{"PermConfigWrite", PermConfigWrite(), permConfigWrite},
+		{"PermConfigPublish", PermConfigPublish(), permConfigPublish},
+		{"PermFlagRead", PermFlagRead(), permFlagRead},
+		{"PermFlagWrite", PermFlagWrite(), permFlagWrite},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.singleton {
+			t.Errorf("%s() must return the package-private singleton (stable on every call)", tc.name)
+		}
+	}
+}
+
 func TestPermission_ZeroValueIsInvalid(t *testing.T) {
 	var zero Permission
 	if !zero.IsZero() {

--- a/pkg/authz/permission_test.go
+++ b/pkg/authz/permission_test.go
@@ -8,6 +8,29 @@ func TestPermission_String(t *testing.T) {
 	}
 }
 
+// TestConfigcorePermissions_String pins the exact action spelling of every
+// configcore permission minted in PR-10b. The action string IS the wire value
+// carried into the PDP (auth.Authorizer.Authorize) and matched against baseline
+// rule Action targets, so a typo here silently breaks the gate↔baseline binding.
+func TestConfigcorePermissions_String(t *testing.T) {
+	cases := []struct {
+		name string
+		perm Permission
+		want string
+	}{
+		{"PermConfigRead", PermConfigRead(), "config:read"},
+		{"PermConfigWrite", PermConfigWrite(), "config:write"},
+		{"PermConfigPublish", PermConfigPublish(), "config:publish"},
+		{"PermFlagRead", PermFlagRead(), "flag:read"},
+		{"PermFlagWrite", PermFlagWrite(), "flag:write"},
+	}
+	for _, tc := range cases {
+		if got := tc.perm.String(); got != tc.want {
+			t.Errorf("%s.String() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestPermAuditRead_StableIdentity pins that the accessor returns the closed
 // registry's private singleton (the F6 immutability contract: an external package
 // cannot reassign or fork the registry value because PermAuditRead is a function,
@@ -37,8 +60,8 @@ func TestPermissions_ClosedRegistry(t *testing.T) {
 	// Pin the closed set: PR-10a seeds exactly one permission. A new Perm* var
 	// that forgets to enroll in allPermissions (or an accidental extra) trips
 	// this — the anti-vacuity guard for the closed registry.
-	if len(perms) != 1 {
-		t.Fatalf("Permissions() len = %d, want 1 (PR-10a seeds only PermAuditRead)", len(perms))
+	if len(perms) != 6 {
+		t.Fatalf("Permissions() len = %d, want 6 (PR-10a PermAuditRead + PR-10b configcore 5)", len(perms))
 	}
 	if perms[0].String() != "audit:read" {
 		t.Fatalf("Permissions()[0] = %q, want audit:read", perms[0].String())
@@ -97,6 +120,11 @@ func TestPermissions_KnownVarsEnrolled(t *testing.T) {
 		perm Permission
 	}{
 		{"PermAuditRead", PermAuditRead()},
+		{"PermConfigRead", PermConfigRead()},
+		{"PermConfigWrite", PermConfigWrite()},
+		{"PermConfigPublish", PermConfigPublish()},
+		{"PermFlagRead", PermFlagRead()},
+		{"PermFlagWrite", PermFlagWrite()},
 	}
 
 	for _, kv := range knownVars {

--- a/tools/archtest/permission_based_authz_test.go
+++ b/tools/archtest/permission_based_authz_test.go
@@ -30,16 +30,18 @@
 //
 //	下游 Medium — archtest typed callsite scan, fail-loud in CI;
 //	  alias-safe (ResolvePackageRef resolves the import path, not the local name).
-//	上游 Medium — allowlist convergence: PR-10b migrates remaining cells to
-//	  auth.RequirePermission(pkg/authz.Permission) and deletes every entry here.
+//	上游 Medium — allowlist convergence: each PR-10x migrates remaining cells to
+//	  auth.RequirePermission(pkg/authz.Permission) and deletes its entries here
+//	  (PR-10a auditquery, PR-10b configcore done; PR-10c accesscore pending).
 //	Hard-ification tracker: permission-gate codegen funnel → gh #PR-13.
 //
 // # Allowlist
 //
-// The files below legitimately still use role-literal gates as of PR-10a and
-// are allowlisted until the corresponding PR-10b migration. auditquery is NOT
-// allowlisted — it was migrated to auth.RequirePermission(authz.PermAuditRead)
-// in PR-10a (#1348) and must not regress.
+// The 3 files below legitimately still use role-literal gates pending PR-10c
+// (accesscore — they carry SelfOr ownership gates needing custom policy funcs).
+// auditquery (PR-10a) and the 5 configcore slices (PR-10b, #1348) are NOT
+// allowlisted — they were migrated to auth.RequirePermission(authz.Perm*) and
+// must not regress.
 //
 // To migrate a file: replace every auth.AnyRole/SelfOr/RequireAnyRole call
 // with auth.RequirePermission(authz.Perm*), declare the permission in
@@ -80,15 +82,13 @@ var permissionBasedAuthzRoleGateSelectors = map[string]struct{}{
 }
 
 // permissionBasedAuthzAllowlist is the migration ledger: handler files that
-// still legitimately call role-literal gates pending PR-10b migration.
+// still legitimately call role-literal gates pending their PR-10x migration.
 // Paths are module-relative slash paths (p.Rel values from the corecells module).
-// auditquery is deliberately absent — it was migrated in PR-10a.
+// auditquery (PR-10a) and the 5 configcore slices (PR-10b) are deliberately
+// absent — they were migrated to auth.RequirePermission and must not regress.
+// Only the 3 accesscore slices remain, pending PR-10c (they carry SelfOr
+// ownership gates needing custom policy funcs).
 var permissionBasedAuthzAllowlist = map[string]struct{}{
-	"corecells/configcore/slices/configread/handler.go":     {},
-	"corecells/configcore/slices/configwrite/handler.go":    {},
-	"corecells/configcore/slices/configpublish/handler.go":  {},
-	"corecells/configcore/slices/flagwrite/handler.go":      {},
-	"corecells/configcore/slices/featureflag/handler.go":    {},
 	"corecells/accesscore/slices/policymanage/handler.go":   {},
 	"corecells/accesscore/slices/identitymanage/handler.go": {},
 	"corecells/accesscore/slices/rbaccheck/handler.go":      {},
@@ -123,15 +123,17 @@ func scanPermissionBasedAuthzViolations(p *Pass, f *ast.File, rel string, allowl
 }
 
 // TestPermissionBasedAuthzAllowlist_Ceiling guards that the migration allowlist
-// does not grow past its known maximum (8 entries as of PR-10a). An accidental
-// NEW entry that suppresses a real PERMISSION-BASED-AUTHZ-01 violation would
-// silently increase the ceiling — this test makes that visible in CI.
+// does not grow past its known maximum (3 entries as of PR-10b — the 5 configcore
+// slices were migrated and removed). An accidental NEW entry that suppresses a
+// real PERMISSION-BASED-AUTHZ-01 violation would silently increase the ceiling —
+// this test makes that visible in CI.
 //
-// PR-10b intent: each PR-10b commit removes one or more entries and decrements
-// this ceiling toward 0. When the allowlist is empty this test becomes trivially
-// true and can be removed together with the allowlist.
+// Migration intent: each PR-10x commit removes one or more entries and decrements
+// this ceiling toward 0 (PR-10c drains the remaining 3 accesscore slices). When
+// the allowlist is empty this test becomes trivially true and can be removed
+// together with the allowlist (and the rule becomes a zero-allowlist Hard target).
 func TestPermissionBasedAuthzAllowlist_Ceiling(t *testing.T) {
-	const maxAllowlistSize = 8 // PR-10a known maximum; PR-10b decrements toward 0
+	const maxAllowlistSize = 3 // PR-10b: configcore drained; only 3 accesscore slices remain
 	if got := len(permissionBasedAuthzAllowlist); got > maxAllowlistSize {
 		t.Errorf("permissionBasedAuthzAllowlist has %d entries, want ≤ %d — "+
 			"new entries must not be added (migrate to auth.RequirePermission instead); "+

--- a/tools/archtest/permission_based_authz_test.go
+++ b/tools/archtest/permission_based_authz_test.go
@@ -59,6 +59,10 @@
 //
 // Reverse self-check: TestPermissionBasedAuthz_ReverseFixture asserts the scan
 // fires on testdata/permission_based_authz_red, proving the rule is not vacuous.
+// The allowlist itself is doubly guarded: TestPermissionBasedAuthzAllowlist_Ceiling
+// freezes it to an exact set (no silent grow/swap — cheap, runs PR-time), and
+// TestPermissionBasedAuthz_01 flags any allowlist entry with no live gate as STALE
+// (no dead bypass slot — typed scan, nightly).
 package archtest
 
 import (
@@ -94,14 +98,29 @@ var permissionBasedAuthzAllowlist = map[string]struct{}{
 	"corecells/accesscore/slices/rbaccheck/handler.go":      {},
 }
 
+// expectedPermissionBasedAuthzAllowlist is the FROZEN exact-set expectation for
+// permissionBasedAuthzAllowlist. TestPermissionBasedAuthzAllowlist_Ceiling asserts
+// the live allowlist equals this set, so a silent SWAP (replace one accesscore path
+// with a new exception) or GROW fails CI even though len is unchanged — a bare len
+// ceiling cannot catch a swap. Each PR-10x drain (PR-10c removes the 3 accesscore
+// entries) MUST update BOTH maps in the same PR; that forced, explicit edit is the
+// guard (golden-like freeze), not redundancy.
+var expectedPermissionBasedAuthzAllowlist = map[string]struct{}{
+	"corecells/accesscore/slices/policymanage/handler.go":   {},
+	"corecells/accesscore/slices/identitymanage/handler.go": {},
+	"corecells/accesscore/slices/rbaccheck/handler.go":      {},
+}
+
 // scanPermissionBasedAuthzViolations scans a single file for role-literal
-// authorization gate calls whose file is not in the allowlist.
-// It uses ResolvePackageRef to resolve the callee import path, so import
-// aliases and dot-imports are handled uniformly.
-func scanPermissionBasedAuthzViolations(p *Pass, f *ast.File, rel string, allowlist map[string]struct{}) []Diagnostic {
-	if _, allowed := allowlist[rel]; allowed {
-		return nil
-	}
+// authorization gate calls. A non-allowlisted file with a banned gate yields a
+// violation. An allowlisted file with a banned gate yields NO violation but is
+// recorded in observed (when non-nil) so the caller can prove the allowlist entry
+// is still live (no-stale anti-vacuity) — an entry whose gate was already migrated
+// away is then flagged after the full scan.
+// It uses ResolvePackageRef to resolve the callee import path, so import aliases
+// and dot-imports are handled uniformly.
+func scanPermissionBasedAuthzViolations(p *Pass, f *ast.File, rel string, allowlist, observed map[string]struct{}) []Diagnostic {
+	_, allowed := allowlist[rel]
 	var out []Diagnostic
 	EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
 		pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
@@ -109,6 +128,14 @@ func scanPermissionBasedAuthzViolations(p *Pass, f *ast.File, rel string, allowl
 			return
 		}
 		if _, banned := permissionBasedAuthzRoleGateSelectors[name]; !banned {
+			return
+		}
+		if allowed {
+			// Allowlisted: this entry is still live (carries a real role-literal
+			// gate). Record it for the post-scan no-stale check; emit no violation.
+			if observed != nil {
+				observed[rel] = struct{}{}
+			}
 			return
 		}
 		out = append(out, Diagnostic{
@@ -122,23 +149,28 @@ func scanPermissionBasedAuthzViolations(p *Pass, f *ast.File, rel string, allowl
 	return out
 }
 
-// TestPermissionBasedAuthzAllowlist_Ceiling guards that the migration allowlist
-// does not grow past its known maximum (3 entries as of PR-10b — the 5 configcore
-// slices were migrated and removed). An accidental NEW entry that suppresses a
-// real PERMISSION-BASED-AUTHZ-01 violation would silently increase the ceiling —
-// this test makes that visible in CI.
+// TestPermissionBasedAuthzAllowlist_Ceiling is the EXACT-SET FREEZE on the
+// migration allowlist: it asserts permissionBasedAuthzAllowlist equals the frozen
+// expectedPermissionBasedAuthzAllowlist. A bare len ceiling could not catch a SWAP
+// (replacing one accesscore path with a new configcore exception keeps len=3 and
+// silently suppresses a real PERMISSION-BASED-AUTHZ-01 violation); the exact-set
+// assertion makes any add / remove / swap fail loudly.
 //
-// Migration intent: each PR-10x commit removes one or more entries and decrements
-// this ceiling toward 0 (PR-10c drains the remaining 3 accesscore slices). When
-// the allowlist is empty this test becomes trivially true and can be removed
-// together with the allowlist (and the rule becomes a zero-allowlist Hard target).
+// This test is CHEAP (in-memory map compare, no packages.Load) and therefore runs
+// at PR-time via hack/verify-archtest-invariants.sh — allowlist tampering fails at
+// PR-merge, not only nightly. The live no-stale anti-vacuity (each allowlisted file
+// still carries a real gate) rides the heavier typed scan in
+// TestPermissionBasedAuthz_01 (nightly bucket).
+//
+// Migration intent: each PR-10x drain (PR-10c removes the 3 accesscore slices)
+// updates BOTH maps in the same PR; that forced, explicit edit is the point. When
+// the allowlist is empty both maps go to {} and the rule becomes a zero-allowlist
+// Hard target.
 func TestPermissionBasedAuthzAllowlist_Ceiling(t *testing.T) {
-	const maxAllowlistSize = 3 // PR-10b: configcore drained; only 3 accesscore slices remain
-	if got := len(permissionBasedAuthzAllowlist); got > maxAllowlistSize {
-		t.Errorf("permissionBasedAuthzAllowlist has %d entries, want ≤ %d — "+
-			"new entries must not be added (migrate to auth.RequirePermission instead); "+
-			"PR-10b shrinks this toward 0", got, maxAllowlistSize)
-	}
+	assert.Equal(t, expectedPermissionBasedAuthzAllowlist, permissionBasedAuthzAllowlist,
+		"permissionBasedAuthzAllowlist drifted from its frozen exact set — a new/removed/swapped entry "+
+			"must update expectedPermissionBasedAuthzAllowlist in the SAME PR (migrate handlers to "+
+			"auth.RequirePermission instead of adding exceptions; PR-10c drains the remaining 3)")
 }
 
 // TestPermissionBasedAuthz_01 enforces PERMISSION-BASED-AUTHZ-01 over
@@ -154,6 +186,12 @@ func TestPermissionBasedAuthz_01(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
+	// observed records every allowlisted file in which the scan saw a live
+	// role-literal gate; the post-scan loop flags any allowlist entry NOT observed
+	// as a STALE bypass slot (anti-vacuity — a migrated-away gate left in the
+	// allowlist must not silently keep its exemption).
+	observed := map[string]struct{}{}
+
 	diags := Run(t, Typed(TypedOpts{}, []string{"./corecells/..."}),
 		func(p *Pass) []Diagnostic {
 			if p.TypesInfo == nil || p.Fset == nil {
@@ -165,10 +203,22 @@ func TestPermissionBasedAuthz_01(t *testing.T) {
 				if strings.HasSuffix(rel, "_test.go") {
 					continue
 				}
-				out = append(out, scanPermissionBasedAuthzViolations(p, f, rel, permissionBasedAuthzAllowlist)...)
+				out = append(out, scanPermissionBasedAuthzViolations(p, f, rel, permissionBasedAuthzAllowlist, observed)...)
 			}
 			return out
 		})
+
+	// No-stale reverse self-check: every allowlist entry must have a live gate.
+	for path := range permissionBasedAuthzAllowlist {
+		if _, seen := observed[path]; !seen {
+			diags = append(diags, Diagnostic{
+				Rel: path,
+				Message: "permissionBasedAuthzAllowlist entry " + path + " is STALE — no live " +
+					"auth.AnyRole/SelfOr/RequireAnyRole gate observed there; the gate was migrated away or the " +
+					"scanner regressed. Drop the dead allowlist entry so it cannot become a silent bypass slot",
+			})
+		}
+	}
 
 	Report(t, rulePermissionBasedAuthz01, diags)
 }
@@ -204,7 +254,7 @@ func TestPermissionBasedAuthz_ReverseFixture(t *testing.T) {
 				if strings.HasSuffix(rel, "_test.go") {
 					continue
 				}
-				diags = append(diags, scanPermissionBasedAuthzViolations(p, f, rel, emptyAllowlist)...)
+				diags = append(diags, scanPermissionBasedAuthzViolations(p, f, rel, emptyAllowlist, nil)...)
 			}
 			return nil
 		})


### PR DESCRIPTION
## Summary

PR-10b: migrate the 5 **configcore** route gates from role-literal (`auth.AnyRole(auth.RoleAdmin)`) to permission-based ABAC PDP (`auth.RequirePermission(authz.Perm*)`), draining them from the `PERMISSION-BASED-AUTHZ-01` migration allowlist (8→3). The mechanism (sealed `authz.Permission`, `RequirePermission`, built-in baseline, the PDP wired on the primary listener) was delivered in PR-10a (#1891); this PR extends the closed Permission set + baseline and removes the role literals.

## Why / 背景

EPIC #1337 PR-10 splits into PR-10a (接线 + auditquery, merged #1891) and PR-10b (the rest). #1348 stays open until the allowlist drains to ∅. configcore's 5 slices all used the same uniform `auth.AnyRole(auth.RoleAdmin)` gate — the simplest, most mechanical batch — so they go first; accesscore (SelfOr ownership gates → custom policy funcs) follows in PR-10c.

- **5 permissions minted** (resource:action, mirroring `audit:read`): `config:read` (configread), `config:write` (configwrite — folds create/update/delete), `config:publish` (configpublish), `flag:read` (featureflag — get/list/evaluate), `flag:write` (flagwrite). Same sealed shape as `PermAuditRead` (private singleton + accessor func; immutable to external packages).
- **5 baseline rules**, one per permission, each reproducing the prior admin gate via the shared `adminOrSuperAdmin()` condition. The route gate stays role-literal-free: the PDP decides; the baseline grants admin/super-admin exactly as before. **No wire change** (auth semantics equivalent) → no version bump.
- **No new assembly wiring**: every root serving configcore (`cmd/corebundle`, `examples/ssobff`, `examples/corebundlestarter`) already calls `bootstrap.PrimaryAuthorizerOption` (PR-10a F1), so configcore endpoints hit the already-wired PDP.

## Refs

- Refs #1348 (EPIC #1337 PR-10, **PR-10b**; accesscore → PR-10c keeps #1348 open; examples → PR-10d **#1894**)
- ADR: amended `docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md` (PR-10b section + threat model re-eval: unchanged)
- Spec: `docs/plans/specs/1220-tenancy-abac-dataperm/` (US4 / FR-014/015 / T10.*)
- ref: AWS-IAM `service:Action` access-levels — resource:action naming
- ref: Spring-Security `hasAuthority("resource:action")` — colon-separated permission convention
- ref: AWS-Cedar `auth/authorization.html` / XACML 3.0 §7.16 — forbid-overrides-permit + default-deny baseline model

## Risk / 兼容性

- **No breaking wire change**: configcore auth semantics are equivalent (baseline still gates admin/super-admin); 200/403 status sets already declared → no version bump.
- **Behavior is stricter only on misconfiguration**: a configcore-serving assembly that fails to wire the PDP now fail-closes (403) instead of silently admitting on role — caught by the hardened `TestConfigCore_ProductionAuthGateLock` cell test (admin + no Authorizer → 403). All shipped assemblies wire it.
- contract.yaml 403 descriptions updated to name the permission (F7-consistency); contract-doc only, no generated-code drift.
- `auth.AnyRole` stays exported (still used by accesscore/examples pending PR-10c/PR-10d).

## AI-robust 评级（同 PR 闭环，无新增 Soft）

| Enforcement | 载体 | 评级 |
|---|---|---|
| 5 new `authz.Permission` | sealed type + private singleton + accessor func (not reassignable) + registry test (len 1→6, each action string pinned) | **Hard** (reuse PR-10a funnel) |
| configcore role-literal-free | `PERMISSION-BASED-AUTHZ-01` typed archtest; allowlist −5 (8→3), ceiling 8→3 ratchet | **Medium** (Hard-ification = PR-13 codegen funnel, godoc-tracked) |
| baseline rule presence/correctness | baseline_test (admin Allow / user Deny) + e2e (admin→200 / non-admin→403 PDP-deny) | **Medium** |
| **endpoint↔permission binding** | per-slice action-pin test: fake Authorizer captures the `action` string; asserts the gate demands the correct permission | **Medium** (closes the gap the admin-allow baseline would mask; Hard = PR-13) |

> The action-pin guard is the notable add: the baseline allows admin for *every* config permission, so a wrong-permission misbinding (e.g. `config:read` gating a write) would pass e2e **and** the archtest silently — the per-slice action-pin test is the only thing that catches it.

## Contract-fanout implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| configcore gate role→permission | 403 desc names permission (×14, doc-only) | 无 drift | 5 handler.go policy swap | handler/contract tests inject ctx Authorizer + action-pin; e2e | godoc + ADR |
| 5 `authz.Perm*` mint | 否 | 否 | pkg/authz | registry tests (len/enrollment/string) | permission.go godoc + ADR |
| 5 baseline rules | 否 | 否 | authorizationdecide/baseline.go | baseline_test (admin/user × 5) | baseline.go godoc + ADR |
| allowlist 8→3 + ceiling | 否 | 否 | tools/archtest | PERMISSION-BASED-AUTHZ-01 + ceiling | archtest godoc |

## Test plan

- [x] `go build ./...` / `-tags=integration` / `-tags=archtest` 全过
- [x] `go test ./...`（非 integration）全绿（pkg/authz, corecells configcore + authorizationdecide）
- [x] e2e `TestABACPDPGatesConfigcore`（admin GET/POST→200/201, non-admin→403 PDP-deny）+ `TestABACPDPGatesAuditQuery` 不回归
- [x] `go test -tags=archtest ./tools/archtest/...` — `PERMISSION-BASED-AUTHZ-01` (allowlist 3, ceiling 3) + `AUTHZ-DECISION-ALLOW-DENY-CALLER-01` green; **0 new failures vs develop** (17 pre-existing nightly-only baseline unchanged)
- [x] integration regression: `examples/ssobff` + `examples/corebundlestarter` + `tests/integration` (testcontainers)
- [x] `golangci-lint run --new-from-merge-base` 0 new issues (root + corecells); gofumpt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
