### PR TITLE
docs(saga): add godoc Example for NewCoordinator + NewExecutor wiring [#1214]

### DIFF
--- a/runtime/saga/example_test.go
+++ b/runtime/saga/example_test.go
@@ -1,0 +1,142 @@
+package saga_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	ksaga "github.com/ghbvf/gocell/kernel/saga"
+	"github.com/ghbvf/gocell/kernel/saga/journal"
+	"github.com/ghbvf/gocell/kernel/wrapper"
+	"github.com/ghbvf/gocell/pkg/idutil"
+	obsmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
+	"github.com/ghbvf/gocell/runtime/saga"
+)
+
+// exampleTxRunner is a minimal in-memory persistence.TxRunner sufficient to run
+// the example against journal.MemJournal. The Coordinator persists each step
+// (Append + MarkTerminal) inside RunInTx and registers a post-commit dispatcher
+// kick via persistence.RegisterAfterCommit, so a TxRunner MUST install the
+// after-commit registry and drain it on success — a bare fn(ctx) is not enough.
+//
+// Production wiring passes a real, transactional runner (adapters/postgres.TxManager);
+// this in-memory runner exists only to keep the example self-contained.
+type exampleTxRunner struct{}
+
+func (exampleTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	ctx, installed := persistence.WithAfterCommitRegistry(ctx)
+	mark := persistence.AfterCommitMark(ctx)
+	if err := fn(ctx); err != nil {
+		persistence.TruncateAfterCommitTo(ctx, mark)
+		return err
+	}
+	if installed {
+		persistence.RunAfterCommitHooks(ctx)
+	}
+	return nil
+}
+
+// ExampleNewCoordinator shows the minimal single-package wiring for a saga
+// Coordinator and drives one instance to a terminal state.
+//
+// Since #1181/#1210 the Coordinator builds its own *executor.Executor
+// internally (using the supplied journal as the heartbeater so claim and
+// heartbeat are same-source by construction). A consumer therefore learns only
+// this one package: WithObserver / WithConfig / WithTracer configure both the
+// coordinator and the step layer through a single call site. There is no
+// saga.WithExecutor or executor.WithObserver at the call site.
+func ExampleNewCoordinator() {
+	clk := clock.Real()
+
+	// 1. In-memory journal — the append-only event log the Coordinator drives.
+	j, err := journal.NewMemJournal(clk)
+	if err != nil {
+		panic(err)
+	}
+
+	// 2. The saga definition: one forward step that "charges a card".
+	def := &ksaga.Definition{
+		ID: "payment_saga",
+		Steps: []ksaga.Step{{
+			Name: "charge_card",
+			Run: func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) {
+				return []byte(`{"charged":true}`), nil
+			},
+		}},
+		Timeout: 30 * time.Second,
+	}
+	reg, err := ksaga.NewInMemoryRegistry(def)
+	if err != nil {
+		panic(err)
+	}
+
+	// 3. The observability sink: SagaCollector implements executor.Observer and
+	//    receives both step-level and coordinator-level events. NopProvider
+	//    records nothing but still validates the metric label sets.
+	collector, err := obsmetrics.NewSagaCollector(kernelmetrics.NopProvider{}, "examplecell")
+	if err != nil {
+		panic(err)
+	}
+
+	// 4. Config: start from DefaultConfig (WithConfig rejects zero-value fields,
+	//    so always derive from it) and shorten the poll interval so the tick
+	//    loop claims the enqueued instance promptly.
+	cfg := saga.DefaultConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+
+	// 5. Build the Coordinator. One WithObserver / WithTracer reaches both the
+	//    coordinator and the internally-constructed Executor.
+	coord, err := saga.NewCoordinator(j, exampleTxRunner{}, outbox.NewNoopEmitter(), reg, clk,
+		saga.WithObserver(collector),
+		saga.WithConfig(cfg),
+		saga.WithTracer(wrapper.NoopTracer{}),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// 6. Run the control loop, enqueue one instance, and wait for it to finish.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = coord.Start(ctx) }()
+	<-coord.Ready()
+
+	inst := ksaga.NewInstance("payment_inst_1", "payment_saga", clk.Now())
+	if err := j.Enqueue(ctx, inst); err != nil {
+		panic(err)
+	}
+
+	final := waitTerminal(ctx, j, inst.ID)
+
+	if err := coord.Stop(context.Background()); err != nil {
+		panic(err)
+	}
+	fmt.Println(final)
+	// Output:
+	// saga_succeeded
+}
+
+// waitTerminal tails an instance's event log — the journal.Reader "status-query"
+// pattern (fold Load) — until a terminal event is recorded, returning its kind.
+// It panics after a generous deadline so a stuck example fails loudly instead of
+// hanging.
+func waitTerminal(ctx context.Context, r journal.Reader, id idutil.SafeID) journal.EventKind {
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		events, err := r.Load(ctx, id)
+		if err != nil {
+			panic(err)
+		}
+		if n := len(events); n > 0 && events[n-1].Kind.IsTerminal() {
+			return events[n-1].Kind
+		}
+		if time.Now().After(deadline) {
+			panic("saga did not reach a terminal state in time")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/runtime/saga/example_test.go
+++ b/runtime/saga/example_test.go
@@ -3,6 +3,7 @@ package saga_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock"
@@ -12,9 +13,18 @@ import (
 	ksaga "github.com/ghbvf/gocell/kernel/saga"
 	"github.com/ghbvf/gocell/kernel/saga/journal"
 	"github.com/ghbvf/gocell/kernel/wrapper"
-	"github.com/ghbvf/gocell/pkg/idutil"
 	obsmetrics "github.com/ghbvf/gocell/runtime/observability/metrics"
 	"github.com/ghbvf/gocell/runtime/saga"
+)
+
+// Test-time Duration values live in a package-level const block
+// (TEST-TIME-LITERAL-01), never inline at the call site.
+const (
+	// examplePollInterval shortens the Coordinator's claim cadence so the example
+	// drives its single instance promptly (DefaultConfig uses 200ms).
+	examplePollInterval = 5 * time.Millisecond
+	// exampleSagaTimeout is the overall saga deadline (the Expired ceiling).
+	exampleSagaTimeout = 30 * time.Second
 )
 
 // exampleTxRunner is a minimal in-memory persistence.TxRunner sufficient to run
@@ -59,16 +69,22 @@ func ExampleNewCoordinator() {
 		panic(err)
 	}
 
-	// 2. The saga definition: one forward step that "charges a card".
+	// 2. The saga definition: one forward step that "charges a card". It closes
+	//    stepRan when it runs, letting the example observe forward progress
+	//    without polling (Run executes once on the success path; sync.Once keeps
+	//    the close safe if a copy-paste adaptation ever retries).
+	stepRan := make(chan struct{})
+	var once sync.Once
 	def := &ksaga.Definition{
 		ID: "payment_saga",
 		Steps: []ksaga.Step{{
 			Name: "charge_card",
 			Run: func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) {
+				once.Do(func() { close(stepRan) })
 				return []byte(`{"charged":true}`), nil
 			},
 		}},
-		Timeout: 30 * time.Second,
+		Timeout: exampleSagaTimeout,
 	}
 	reg, err := ksaga.NewInMemoryRegistry(def)
 	if err != nil {
@@ -87,7 +103,7 @@ func ExampleNewCoordinator() {
 	//    so always derive from it) and shorten the poll interval so the tick
 	//    loop claims the enqueued instance promptly.
 	cfg := saga.DefaultConfig()
-	cfg.PollInterval = 5 * time.Millisecond
+	cfg.PollInterval = examplePollInterval
 
 	// 5. Build the Coordinator. One WithObserver / WithTracer reaches both the
 	//    coordinator and the internally-constructed Executor.
@@ -100,7 +116,7 @@ func ExampleNewCoordinator() {
 		panic(err)
 	}
 
-	// 6. Run the control loop, enqueue one instance, and wait for it to finish.
+	// 6. Run the control loop and enqueue one instance.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = coord.Start(ctx) }()
@@ -111,37 +127,23 @@ func ExampleNewCoordinator() {
 		panic(err)
 	}
 
-	final := waitTerminal(ctx, j, inst.ID)
-
-	// Stop drains in-flight work within the supplied budget; context.Background()
-	// suffices for an example, but production should pass a deadline-bounded ctx.
+	// 7. Wait for the step to run, then Stop. Stop drains the in-flight drive —
+	//    including the terminal MarkTerminal write — before it returns, so the
+	//    journal deterministically holds the terminal event afterward, with no
+	//    polling. context.Background() gives Stop an unbounded drain budget;
+	//    production should pass a deadline-bounded ctx.
+	<-stepRan
 	if err := coord.Stop(context.Background()); err != nil {
 		panic(err)
 	}
-	fmt.Println(final)
+
+	// 8. Read the terminal state back via the journal.Reader (Load) — the same
+	//    read path a status-query slice would use.
+	events, err := j.Load(context.Background(), inst.ID)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(events[len(events)-1].Kind)
 	// Output:
 	// saga_succeeded
-}
-
-// waitTerminal tails an instance's event log — the journal.Reader "status-query"
-// pattern (fold Load) — until a terminal event is recorded, returning its kind.
-// It uses the wall clock deliberately (not a clock.Clock): it only observes the
-// Coordinator, which already runs on clock.Real(), so no fake clock is warranted.
-// An Example has no *testing.T, so it panics after a generous real-time deadline
-// to fail loudly instead of hanging.
-func waitTerminal(ctx context.Context, r journal.Reader, id idutil.SafeID) journal.EventKind {
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		events, err := r.Load(ctx, id)
-		if err != nil {
-			panic(err)
-		}
-		if n := len(events); n > 0 && events[n-1].Kind.IsTerminal() {
-			return events[n-1].Kind
-		}
-		if time.Now().After(deadline) {
-			panic("saga did not reach a terminal state in time")
-		}
-		time.Sleep(time.Millisecond)
-	}
 }

--- a/runtime/saga/example_test.go
+++ b/runtime/saga/example_test.go
@@ -23,8 +23,9 @@ import (
 // kick via persistence.RegisterAfterCommit, so a TxRunner MUST install the
 // after-commit registry and drain it on success — a bare fn(ctx) is not enough.
 //
-// Production wiring passes a real, transactional runner (adapters/postgres.TxManager);
-// this in-memory runner exists only to keep the example self-contained.
+// Production wiring passes a real, transactional runner (adapters/postgres.TxManager)
+// that also confines all DB access to fn's ctx; this in-memory runner exists only to
+// keep the example self-contained (it has no connection to misuse).
 type exampleTxRunner struct{}
 
 func (exampleTxRunner) RunInTx(ctx context.Context, fn func(context.Context) error) error {
@@ -112,6 +113,8 @@ func ExampleNewCoordinator() {
 
 	final := waitTerminal(ctx, j, inst.ID)
 
+	// Stop drains in-flight work within the supplied budget; context.Background()
+	// suffices for an example, but production should pass a deadline-bounded ctx.
 	if err := coord.Stop(context.Background()); err != nil {
 		panic(err)
 	}
@@ -122,8 +125,10 @@ func ExampleNewCoordinator() {
 
 // waitTerminal tails an instance's event log — the journal.Reader "status-query"
 // pattern (fold Load) — until a terminal event is recorded, returning its kind.
-// It panics after a generous deadline so a stuck example fails loudly instead of
-// hanging.
+// It uses the wall clock deliberately (not a clock.Clock): it only observes the
+// Coordinator, which already runs on clock.Real(), so no fake clock is warranted.
+// An Example has no *testing.T, so it panics after a generous real-time deadline
+// to fail loudly instead of hanging.
 func waitTerminal(ctx context.Context, r journal.Reader, id idutil.SafeID) journal.EventKind {
 	deadline := time.Now().Add(2 * time.Second)
 	for {

--- a/runtime/saga/example_test.go
+++ b/runtime/saga/example_test.go
@@ -25,7 +25,31 @@ const (
 	examplePollInterval = 5 * time.Millisecond
 	// exampleSagaTimeout is the overall saga deadline (the Expired ceiling).
 	exampleSagaTimeout = 30 * time.Second
+	// exampleWaitBudget bounds every asynchronous lifecycle wait (Ready, the
+	// step running, Stop's drain). A regression — Start exiting early, the tick
+	// loop never claiming, or the step never running — then fails this Example
+	// locally within the budget instead of hanging until the whole package's
+	// `go test` deadline. It runs on the wall clock deliberately: the Coordinator
+	// below is wired to clock.Real(), so a fake clock would never advance these
+	// real-time waits.
+	exampleWaitBudget = 10 * time.Second
 )
+
+// awaitExample blocks until ch is signaled, but panics if the coordinator's
+// Start goroutine exits first (surfacing its error) or the wait budget elapses.
+// An Example has no *testing.T, so a labeled panic is the only way to turn a
+// regression into a local failure instead of a low-signal whole-package
+// `go test` timeout. It lives outside ExampleNewCoordinator so each wait reads
+// as a single self-documenting line in the godoc-rendered body.
+func awaitExample(what string, ch <-chan struct{}, startErr <-chan error) {
+	select {
+	case <-ch:
+	case err := <-startErr:
+		panic(fmt.Errorf("saga example: coordinator Start exited before %s: %w", what, err))
+	case <-time.After(exampleWaitBudget):
+		panic("saga example: timed out waiting for " + what)
+	}
+}
 
 // exampleTxRunner is a minimal in-memory persistence.TxRunner sufficient to run
 // the example against journal.MemJournal. The Coordinator persists each step
@@ -116,11 +140,14 @@ func ExampleNewCoordinator() {
 		panic(err)
 	}
 
-	// 6. Run the control loop and enqueue one instance.
+	// 6. Run the control loop and enqueue one instance. Start's return is
+	//    captured in a buffered channel (not discarded with `_ =`) so a Start
+	//    failure surfaces and the goroutine's exit is observable.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go func() { _ = coord.Start(ctx) }()
-	<-coord.Ready()
+	startErr := make(chan error, 1)
+	go func() { startErr <- coord.Start(ctx) }()
+	awaitExample("coordinator ready", coord.Ready(), startErr)
 
 	inst := ksaga.NewInstance("payment_inst_1", "payment_saga", clk.Now())
 	if err := j.Enqueue(ctx, inst); err != nil {
@@ -130,10 +157,18 @@ func ExampleNewCoordinator() {
 	// 7. Wait for the step to run, then Stop. Stop drains the in-flight drive —
 	//    including the terminal MarkTerminal write — before it returns, so the
 	//    journal deterministically holds the terminal event afterward, with no
-	//    polling. context.Background() gives Stop an unbounded drain budget;
-	//    production should pass a deadline-bounded ctx.
-	<-stepRan
-	if err := coord.Stop(context.Background()); err != nil {
+	//    polling. Stop is given a deadline-bounded context (the drain budget):
+	//    production should do the same so a wedged step cannot make shutdown hang.
+	awaitExample("charge_card step to run", stepRan, startErr)
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), exampleWaitBudget)
+	defer stopCancel()
+	if err := coord.Stop(stopCtx); err != nil {
+		panic(err)
+	}
+
+	// Stop cancels the Coordinator's internal context, so Start has unwound by
+	// now; confirm its goroutine exited without error.
+	if err := <-startErr; err != nil {
 		panic(err)
 	}
 

--- a/runtime/saga/executor/example_test.go
+++ b/runtime/saga/executor/example_test.go
@@ -33,6 +33,8 @@ func ExampleNewExecutor() {
 
 	exec, err := executor.NewExecutor(exampleHeartbeater{}, clk,
 		executor.WithObserver(executor.NopObserver{}),
+		// Both durations equal the package defaults (DefaultHeartbeatInterval /
+		// DefaultLeaseDuration); passed explicitly only to illustrate the options.
 		executor.WithHeartbeatInterval(10*time.Second),
 		executor.WithLeaseDuration(30*time.Second),
 	)
@@ -48,6 +50,9 @@ func ExampleNewExecutor() {
 	}
 	inst := ksaga.NewInstance("payment_inst_1", "payment_saga", clk.Now())
 
+	// In production leaseID is the CAS fencing token from journal.ClaimPending's
+	// ci.LeaseID, not a hand-picked string; "lease_1" works here only because
+	// exampleHeartbeater always reports the lease as still held.
 	res := exec.Execute(context.Background(), &inst, "lease_1", step, ksaga.RetryPolicy{}, nil)
 	fmt.Println(res.Outcome)
 	// Output:

--- a/runtime/saga/executor/example_test.go
+++ b/runtime/saga/executor/example_test.go
@@ -1,0 +1,55 @@
+package executor_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	ksaga "github.com/ghbvf/gocell/kernel/saga"
+	"github.com/ghbvf/gocell/pkg/idutil"
+	"github.com/ghbvf/gocell/runtime/saga/executor"
+)
+
+// exampleHeartbeater is a minimal executor.Heartbeater for the example: it
+// always reports the lease as still held. A production Heartbeater renews the
+// lease against the saga journal — any journal.Journal satisfies the interface
+// structurally, which is why the Coordinator can pass its own journal in.
+type exampleHeartbeater struct{}
+
+func (exampleHeartbeater) Heartbeat(_ context.Context, _, _ idutil.SafeID, _ time.Duration) (bool, error) {
+	return true, nil
+}
+
+// ExampleNewExecutor shows the lower-level Executor used standalone. Most
+// consumers do NOT build an Executor directly — saga.NewCoordinator constructs
+// one internally (see ExampleNewCoordinator). This example documents the
+// advanced path for code that drives a single step itself: NewExecutor takes a
+// Heartbeater plus a clock, and WithObserver / WithHeartbeatInterval /
+// WithLeaseDuration tune it. Execute runs one step with retry/heartbeat and
+// returns a Result classifying the outcome.
+func ExampleNewExecutor() {
+	clk := clock.Real()
+
+	exec, err := executor.NewExecutor(exampleHeartbeater{}, clk,
+		executor.WithObserver(executor.NopObserver{}),
+		executor.WithHeartbeatInterval(10*time.Second),
+		executor.WithLeaseDuration(30*time.Second),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	step := ksaga.Step{
+		Name: "charge_card",
+		Run: func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) {
+			return []byte(`{"charged":true}`), nil
+		},
+	}
+	inst := ksaga.NewInstance("payment_inst_1", "payment_saga", clk.Now())
+
+	res := exec.Execute(context.Background(), &inst, "lease_1", step, ksaga.RetryPolicy{}, nil)
+	fmt.Println(res.Outcome)
+	// Output:
+	// Succeeded
+}

--- a/runtime/saga/executor/example_test.go
+++ b/runtime/saga/executor/example_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/ghbvf/gocell/runtime/saga/executor"
 )
 
+// Test-time Duration values live in a package-level const block
+// (TEST-TIME-LITERAL-01), never inline at the call site. Both equal the
+// executor package defaults (DefaultHeartbeatInterval / DefaultLeaseDuration);
+// passed explicitly only to illustrate the options.
+const (
+	exampleHeartbeatInterval = 10 * time.Second
+	exampleLeaseDuration     = 30 * time.Second
+)
+
 // exampleHeartbeater is a minimal executor.Heartbeater for the example: it
 // always reports the lease as still held. A production Heartbeater renews the
 // lease against the saga journal — any journal.Journal satisfies the interface
@@ -33,10 +42,8 @@ func ExampleNewExecutor() {
 
 	exec, err := executor.NewExecutor(exampleHeartbeater{}, clk,
 		executor.WithObserver(executor.NopObserver{}),
-		// Both durations equal the package defaults (DefaultHeartbeatInterval /
-		// DefaultLeaseDuration); passed explicitly only to illustrate the options.
-		executor.WithHeartbeatInterval(10*time.Second),
-		executor.WithLeaseDuration(30*time.Second),
+		executor.WithHeartbeatInterval(exampleHeartbeatInterval),
+		executor.WithLeaseDuration(exampleLeaseDuration),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary

为 `saga.NewCoordinator` + `saga.WithObserver(SagaCollector)` 接线新增可在 pkg.go.dev 渲染的 godoc `Example`：coordinator 端到端驱动一个实例到终态 + executor 独立用法。纯文档，无新增公开 API。

## Why / 背景

PR #1210（#1181）把 saga 注入链收敛为**单包**接线：`saga.NewCoordinator` 内部自建 `*executor.Executor`（用 Coordinator 自己的 journal 作 Heartbeater，claim/heartbeat 同源），消费者只需学一处 `WithObserver` / `WithConfig` / `WithTracer`。但此前唯一的接线演示埋在集成测试 harness scaffolding（未导出 fake + `testtime` 时钟推进）里，pkg.go.dev/godoc 完全不可见。

本 PR 用真正的 `func Example…()`（带 `// Output:`，`go test` 实跑、pkg.go.dev 自动渲染）公开最小可用接线——这也是「文档由机器校验、不靠人记得更新」的载体选择：接线 API 漂移则 build 红，行为漂移则 `// Output:` 不匹配。

- `ExampleNewCoordinator`：仅用导出 API 接齐 journal / txRunner / emitter / registry / clock / collector / tracer，`NewCoordinator(WithObserver/WithConfig/WithTracer)` → `Start`/`Ready`/`Stop`，enqueue 一个实例并 tail 事件日志直到终态（打印 `saga_succeeded`）。
- `ExampleNewExecutor`：示范 executor 独立（低层）用法 `NewExecutor(heartbeater, clk, WithObserver/WithHeartbeatInterval/WithLeaseDuration)` + 一次 `Execute`（打印 `Succeeded`）。

## Refs

- Closes #1214
- ref: PR #1210 review (DX F6)
- 顺手修正：issue #1214 / #1215 body 沿用的 stale 名 `NewSagaStepCollector` 实际为 `NewSagaCollector`（type `SagaCollector` 已扩为同时采 coordinator 级 tick/drive/leader-skip 指标）。示例用真实名，且「示例能编译」即守卫此修正。

## Risk / 兼容性

无。纯新增两个 `_test.go`（`runtime/saga/example_test.go`、`runtime/saga/executor/example_test.go`），零生产代码、零导出 API 变更。inline `exampleTxRunner`（after-commit 合规，~12 行）/ `exampleHeartbeater` 仅存在于 `_test.go`，不触发 TxRunner-conformance 类 archtest（仅扫生产码）。未耦合 PR-09(#967)，独立可 ship。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./runtime/saga/...` 本地通过（含两个 Example，`// Output:` 匹配）
- [x] `golangci-lint run ./runtime/saga/...` 0 issues
- [x] `go build -tags=integration ./...` 通过
- [x] saga archtests（`go test -tags=archtest ./tools/archtest -run Saga`）通过
