### PR TITLE
feat(webhook): 持久化加密 source secret 存储（dedicated global store）[#1540]

### DIFF
--- a/adapters/postgres/migrations/063_create_webhook_sources.sql
+++ b/adapters/postgres/migrations/063_create_webhook_sources.sql
@@ -1,0 +1,65 @@
+-- Migration 063: create the global `webhook_sources` table — durable, encrypted
+-- store for webhook source HMAC secrets (KERNEL-WEBHOOK-01 follow-up, issue #1540).
+-- Until now the kernel webhook.SourceRegistry was in-memory only (eager-registered
+-- at startup, immutable at runtime; secrets hardcoded at the composition root).
+-- This adds the PG-backed persistence behind the same kernel webhook.SourceStore
+-- seam: the composition root (cellmodules/webhooksource) loads every row at boot,
+-- decrypts each secret through the sealed kernel funnel, and serves them from a
+-- SourceRegistry snapshot.
+--
+-- Global, NOT tenant-scoped: the kernel SourceStore.Lookup(id) carries no tenant,
+-- so webhook sources are platform-global identities (a sender such as "github" or
+-- "stripe" is one source for the whole deployment). The source_id alone is the
+-- primary key. There is therefore NO tenant_id column and NO row-level security —
+-- the same posture as the global outbox_entries relay table (001). Cross-tenant
+-- secret leakage is structurally impossible because there is no tenant dimension.
+--
+-- Encryption shape (NO plaintext column): unlike config_entries (which keeps a
+-- `value` TEXT column for non-sensitive entries), every webhook source secret is
+-- encrypted, so this table has NO plaintext column at all — value_cipher is
+-- NOT NULL. A plaintext secret is structurally unrepresentable at rest: there is
+-- nowhere to put one. The cipher tuple mirrors config_entries' envelope columns
+-- (010): value_cipher (AES-GCM ciphertext), value_key_id (KEK version that wrapped
+-- the DEK), value_edk (wrapped data key), value_nonce (per-encryption AEAD nonce).
+-- value_edk / value_nonce are nullable because they are provider-specific (a
+-- backend that embeds the nonce in the ciphertext returns none); value_cipher and
+-- value_key_id are always present for an encrypted row. The encrypt-time AAD binds
+-- each ciphertext to its source_id (kernel webhook.sourceAAD), so a ciphertext
+-- cannot be transplanted across rows or into config_entries' AAD domain.
+--
+-- Access pattern: the loader full-loads every row at boot (LoadAll); writes are
+-- per-source Upsert/Delete at provisioning time. The PRIMARY KEY (source_id)
+-- covers every path, so NO secondary index is added (a brand-new, small table
+-- with a covering PK needs none).
+--
+-- Non-destructive DDL (CREATE TABLE webhook_sources introduces a new relation,
+-- drops nothing, rewrites no row): NO `+gocell forward-rebuild` annotation and NO
+-- Go destructive permit. The Down section is a true reversible rollback (it drops
+-- the table this migration introduced; no pre-existing data is touched).
+--
+-- [F-B11] DEPLOYMENT REQUIREMENT (provisioning, not enforced by this migration):
+-- the application PG role MUST be granted read/write on webhook_sources. Same
+-- grant model as the other global table outbox_entries.
+--
+-- ref: adapters/postgres/migrations/010_add_config_value_cipher.sql (envelope columns)
+-- ref: adapters/postgres/migrations/001_create_outbox_entries.sql (global, no tenant/RLS)
+-- ref: docs/architecture/...-1540-adr-webhook-source-persistence.md
+
+-- +goose Up
+
+CREATE TABLE webhook_sources (
+    source_id    TEXT                     NOT NULL,
+    value_cipher BYTEA                    NOT NULL,
+    value_key_id VARCHAR(128)             NOT NULL,
+    value_edk    BYTEA,
+    value_nonce  BYTEA,
+    created_at   timestamptz              NOT NULL DEFAULT now(),
+    updated_at   timestamptz              NOT NULL DEFAULT now(),
+    PRIMARY KEY (source_id)
+);
+
+-- +goose Down
+-- Reversible: 063 INTRODUCES the table, so DROP TABLE removes it (and its encrypted
+-- rows) atomically. No pre-existing data is affected. Re-seeding the secrets is the
+-- operator's responsibility after a forward re-apply.
+DROP TABLE IF EXISTS webhook_sources;

--- a/adapters/postgres/migrations/063_create_webhook_sources.sql
+++ b/adapters/postgres/migrations/063_create_webhook_sources.sql
@@ -39,7 +39,10 @@
 --
 -- [F-B11] DEPLOYMENT REQUIREMENT (provisioning, not enforced by this migration):
 -- the application PG role MUST be granted read/write on webhook_sources. Same
--- grant model as the other global table outbox_entries.
+-- grant model as the other global table outbox_entries. The startup LoadAll call
+-- in cellmodules/webhooksource.LoadSourceStore serves as an implicit permission
+-- smoke-test: a missing GRANT surfaces as a fail-fast startup error, not a latent
+-- runtime fault.
 --
 -- ref: adapters/postgres/migrations/010_add_config_value_cipher.sql (envelope columns)
 -- ref: adapters/postgres/migrations/001_create_outbox_entries.sql (global, no tenant/RLS)

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -680,6 +680,20 @@ var expectedColumns = []expectedColumn{
 	{Table: "reconcile_leases", Column: "epoch", Type: "bigint", NotNull: true},
 	{Table: "reconcile_leases", Column: "acquired_at", Type: pgTypeTSTZ, NotNull: true},
 	{Table: "reconcile_leases", Column: "expires_at", Type: pgTypeTSTZ, NotNull: true},
+	// webhook_sources (063_create_webhook_sources.sql) — global, encrypted store
+	// for webhook source HMAC secrets (#1540). NO tenant_id / NO RLS (the kernel
+	// SourceStore.Lookup carries no tenant). NO plaintext column: value_cipher is
+	// NOT NULL, so a webhook secret is structurally unrepresentable at rest in
+	// plaintext (the schema-shape half of the encryption-at-rest guarantee). The
+	// envelope columns mirror config_entries (010); value_edk / value_nonce are
+	// nullable (provider-specific — a backend may embed the nonce in the ciphertext).
+	{Table: "webhook_sources", Column: "source_id", Type: "text", NotNull: true},
+	{Table: "webhook_sources", Column: "value_cipher", Type: "bytea", NotNull: true},
+	{Table: "webhook_sources", Column: "value_key_id", Type: "character varying(128)", NotNull: true},
+	{Table: "webhook_sources", Column: "value_edk", Type: "bytea", NotNull: false},
+	{Table: "webhook_sources", Column: "value_nonce", Type: "bytea", NotNull: false},
+	{Table: "webhook_sources", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "webhook_sources", Column: "updated_at", Type: pgTypeTSTZ, NotNull: true},
 }
 
 // forbiddenColumns are legacy columns that must NOT exist after migration.

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -88,6 +88,9 @@ const gotWantQuotedFmt = "got %q want %q"
 //                                 + global_seq BIGINT GENERATED ALWAYS AS IDENTITY PK
 //                                 + idx_projection_events_id UNIQUE(id) (idempotency / cursor key)
 //                                 + JSONB payload/metadata/observability/principal
+//   - webhook_sources    (063)  global encrypted webhook HMAC secret store (#1540);
+//                                 PK(source_id); NO tenant_id / NO RLS (SourceStore.Lookup
+//                                 carries no tenant); NO plaintext column (value_cipher NOT NULL).
 //
 // Drift between this comment and verifyChecks/verifyIndexes/... registries is
 // caught by archtest SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE-01.
@@ -744,6 +747,9 @@ var expectedPKs = []expectedPK{
 	{Table: "config_versions", Columns: []string{"id"}},
 	// feature_flags (051_configcore_tenant_id.sql): PK on id.
 	{Table: "feature_flags", Columns: []string{"id"}},
+	// webhook_sources (063_create_webhook_sources.sql): PK on source_id (global,
+	// no tenant — one source identity per deployment).
+	{Table: "webhook_sources", Columns: []string{"source_id"}},
 }
 
 // expectedDefaults is the load-bearing column-default registry. Only defaults a

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -293,6 +293,9 @@ func VerifyExpectedShape(ctx context.Context, pool *Pool) error {
 	if err := verifyForbiddenColumns(ctx, pool); err != nil {
 		return err
 	}
+	if err := verifyFrozenColumnSets(ctx, pool); err != nil {
+		return err
+	}
 	if err := verifyPrimaryKeys(ctx, pool); err != nil {
 		return err
 	}
@@ -698,6 +701,13 @@ var expectedColumns = []expectedColumn{
 	{Table: "webhook_sources", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
 	{Table: "webhook_sources", Column: "updated_at", Type: pgTypeTSTZ, NotNull: true},
 }
+
+// frozenColumnTables lists tables for which the schema guard enforces an
+// exact-column-set check: any column NOT in expectedColumns for that table is
+// rejected. This catches out-of-band additions (e.g. a plaintext `value`
+// column on webhook_sources) that the positive-existence check in verifyColumns
+// cannot detect.
+var frozenColumnTables = []string{"webhook_sources"}
 
 // forbiddenColumns are legacy columns that must NOT exist after migration.
 var forbiddenColumns = []requiredColumn{
@@ -1401,6 +1411,89 @@ func verifyForbiddenColumns(ctx context.Context, pool *Pool) error {
 					errcode.PublicString("column", r.column),
 				),
 			)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Dimension helper: frozen column sets
+// ---------------------------------------------------------------------------
+
+// frozenExpectedColumns returns the set of column names registered in
+// expectedColumns for the given table. It is the single source of truth —
+// callers must not re-list columns.
+func frozenExpectedColumns(table string) map[string]bool {
+	set := make(map[string]bool)
+	for _, ec := range expectedColumns {
+		if ec.Table == table {
+			set[ec.Column] = true
+		}
+	}
+	return set
+}
+
+// queryLiveColumns returns all non-system, non-dropped column names for the
+// given table in the current schema. Mirrors the WHERE predicate used by
+// verifyColumns so test-schema parallelism is scoped correctly.
+func queryLiveColumns(ctx context.Context, pool *Pool, table string) ([]string, error) {
+	const q = `
+	SELECT a.attname
+	  FROM pg_attribute a
+	  JOIN pg_class c ON c.oid = a.attrelid
+	  JOIN pg_namespace n ON n.oid = c.relnamespace
+	 WHERE n.nspname = current_schema()
+	   AND c.relname = $1
+	   AND a.attnum > 0
+	   AND NOT a.attisdropped`
+
+	rows, err := pool.inner.Query(ctx, q, table)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery,
+			"schema_guard: query live columns for frozen-set check", err)
+	}
+	defer rows.Close()
+
+	var cols []string
+	for rows.Next() {
+		var col string
+		if scanErr := rows.Scan(&col); scanErr != nil {
+			return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery,
+				"schema_guard: scan column name for frozen-set check", scanErr)
+		}
+		cols = append(cols, col)
+	}
+	if rows.Err() != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery,
+			"schema_guard: iterate columns for frozen-set check", rows.Err())
+	}
+	return cols, nil
+}
+
+// verifyFrozenColumnSets enforces an exact-column-set constraint on tables
+// listed in frozenColumnTables. Any column present in the live schema but
+// absent from expectedColumns is rejected with ErrAdapterPGSchemaShape.
+// This catches out-of-band column additions that verifyColumns (positive-only)
+// cannot detect — e.g., a plaintext `value` column added to webhook_sources.
+func verifyFrozenColumnSets(ctx context.Context, pool *Pool) error {
+	for _, table := range frozenColumnTables {
+		expected := frozenExpectedColumns(table)
+		live, err := queryLiveColumns(ctx, pool, table)
+		if err != nil {
+			return err
+		}
+		for _, col := range live {
+			if !expected[col] {
+				return errcode.New(
+					errcode.KindInternal, ErrAdapterPGSchemaShape,
+					"schema_guard: unexpected column on frozen table",
+					errcode.WithDetails(
+						errcode.PublicString("dimension", "frozen_column_set"),
+						errcode.PublicString("table", table),
+						errcode.PublicString("column", col),
+					),
+				)
+			}
 		}
 	}
 	return nil

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -104,8 +104,10 @@ func TestExpectedVersion_FromEmbedFS(t *testing.T) {
 	// 061 replaces the permanent idempotency key index with a state-aware active-uniqueness
 	// partial index on commands (status IN 1,2,3) for retry-release semantics (#1820).
 	// 062 drops devices.renewal_requested_epoch (stateless cert-renewal producer, #1820).
-	assert.Equal(t, int64(62), v,
-		"expected version should be exactly 62 (current migration max — 062_drop_devices_renewal_requested_epoch)")
+	// 063 creates the global webhook_sources table (encrypted webhook source secret store,
+	// NO tenant/RLS, NO plaintext column) for the persistent SourceStore backing (#1540).
+	assert.Equal(t, int64(63), v,
+		"expected version should be exactly 63 (current migration max — 063_create_webhook_sources)")
 }
 
 func TestExpectedVersion_SyntheticFS(t *testing.T) {

--- a/adapters/postgres/webhook_source_repo.go
+++ b/adapters/postgres/webhook_source_repo.go
@@ -9,6 +9,7 @@ import (
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	kwh "github.com/ghbvf/gocell/kernel/webhook"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	runtimecrypto "github.com/ghbvf/gocell/runtime/crypto"
 	runtimewebhook "github.com/ghbvf/gocell/runtime/webhook"
 )
 
@@ -58,15 +59,23 @@ var _ runtimewebhook.SourceRepo = (*WebhookSourceRepository)(nil)
 // NewWebhookSourceRepository wraps pool in the sealed pgexec funnel and binds the
 // value transformer used to seal/unseal secrets.
 //
-// transformer is validated first and must be non-nil: persisting a webhook secret
-// without encryption is a security fault, and the table has no plaintext column
-// to fall back to, so there is no NoopTransformer path here (contrast configcore,
-// which permits Noop for non-sensitive entries). pool must also be non-nil.
+// transformer is validated first: nil is rejected (no plaintext fallback), and
+// [runtimecrypto.NoopTransformer] is rejected by a concrete-type guard — passing
+// the passthrough transformer would persist webhook source secrets in plaintext,
+// which the table schema structurally prevents (no plaintext column). This
+// rejection is now ENFORCED by a runtime guard, not merely narrated (contrast
+// configcore, which permits Noop for non-sensitive entries). pool must also be
+// non-nil.
 func NewWebhookSourceRepository(pool *pgxpool.Pool, transformer kcrypto.ValueTransformer) (*WebhookSourceRepository, error) {
 	if transformer == nil {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"postgres.NewWebhookSourceRepository: value transformer must not be nil "+
 				"(webhook source secrets are never persisted in plaintext)")
+	}
+	if _, ok := transformer.(runtimecrypto.NoopTransformer); ok {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"postgres.NewWebhookSourceRepository: NoopTransformer (passthrough) would persist "+
+				"webhook source secrets in plaintext")
 	}
 	if pool == nil {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
@@ -109,7 +118,9 @@ func (r *WebhookSourceRepository) LoadAll(ctx context.Context) ([]kwh.Source, er
 		}
 		id, err := kwh.NewSourceID(sourceID)
 		if err != nil {
-			return nil, err
+			return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGSchemaShape,
+				"postgres: persisted webhook source_id violates kernel id shape", err,
+				errcode.WithInternal(errcode.InternalAttr("_", "webhook source load-all")))
 		}
 		src, err := kwh.NewSourceFromCiphertext(ctx, r.transformer, id, cipher, keyID, nonce, edk)
 		if err != nil {

--- a/adapters/postgres/webhook_source_repo.go
+++ b/adapters/postgres/webhook_source_repo.go
@@ -1,0 +1,132 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ghbvf/gocell/adapters/postgres/internal/pgexec"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	runtimewebhook "github.com/ghbvf/gocell/runtime/webhook"
+)
+
+// upsertWebhookSourceSQL inserts or replaces a source's encrypted secret. The
+// table has NO plaintext column, so value_cipher (NOT NULL) is always written
+// from the sealed [kwh.Source.Encrypt] result — a plaintext secret has nowhere
+// to land at rest.
+const upsertWebhookSourceSQL = `INSERT INTO webhook_sources
+    (source_id, value_cipher, value_key_id, value_edk, value_nonce, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, now(), now())
+ON CONFLICT (source_id) DO UPDATE SET
+    value_cipher = EXCLUDED.value_cipher,
+    value_key_id = EXCLUDED.value_key_id,
+    value_edk    = EXCLUDED.value_edk,
+    value_nonce  = EXCLUDED.value_nonce,
+    updated_at   = now()`
+
+// selectAllWebhookSourcesSQL reads every persisted cipher tuple for the boot-time
+// load. Webhook sources are a small, global set, so an unbounded full scan is the
+// intended access pattern (no pagination).
+const selectAllWebhookSourcesSQL = `SELECT source_id, value_cipher, value_key_id, value_edk, value_nonce
+FROM webhook_sources`
+
+// deleteWebhookSourceSQL removes one source by id. A no-op delete (unknown id)
+// affects zero rows and is not an error.
+const deleteWebhookSourceSQL = `DELETE FROM webhook_sources WHERE source_id = $1`
+
+// WebhookSourceRepository is the PostgreSQL [runtimewebhook.SourceRepo] backing
+// for persistent webhook source secrets (#1540). It holds the sealed pgexec
+// funnel (never a raw *pgxpool.Pool — PG-REPO-AMBIENT-TX-01) and the
+// [kcrypto.ValueTransformer] that seals/unseals each secret.
+//
+// The repository never handles a plaintext secret: Upsert seals through
+// [kwh.Source.Encrypt] and writes only the resulting ciphertext columns; LoadAll
+// reads the ciphertext columns and reconstructs sealed [kwh.Source] values via
+// [kwh.NewSourceFromCiphertext]. The AAD binding each ciphertext to its source id
+// is computed inside the kernel funnel, so this adapter cannot transplant a
+// ciphertext across sources or weaken the binding.
+type WebhookSourceRepository struct {
+	db          pgexec.PGExecutor
+	transformer kcrypto.ValueTransformer
+}
+
+// compile-time interface check.
+var _ runtimewebhook.SourceRepo = (*WebhookSourceRepository)(nil)
+
+// NewWebhookSourceRepository wraps pool in the sealed pgexec funnel and binds the
+// value transformer used to seal/unseal secrets.
+//
+// transformer is validated first and must be non-nil: persisting a webhook secret
+// without encryption is a security fault, and the table has no plaintext column
+// to fall back to, so there is no NoopTransformer path here (contrast configcore,
+// which permits Noop for non-sensitive entries). pool must also be non-nil.
+func NewWebhookSourceRepository(pool *pgxpool.Pool, transformer kcrypto.ValueTransformer) (*WebhookSourceRepository, error) {
+	if transformer == nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"postgres.NewWebhookSourceRepository: value transformer must not be nil "+
+				"(webhook source secrets are never persisted in plaintext)")
+	}
+	if pool == nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"postgres.NewWebhookSourceRepository: pool must not be nil")
+	}
+	return &WebhookSourceRepository{db: pgexec.New(pool), transformer: transformer}, nil
+}
+
+// Upsert implements [runtimewebhook.SourceRepo].
+func (r *WebhookSourceRepository) Upsert(ctx context.Context, src kwh.Source) error {
+	res, err := src.Encrypt(ctx, r.transformer)
+	if err != nil {
+		return err // already an *errcode.Error from the kernel funnel
+	}
+	if _, err := r.db.Exec(ctx, upsertWebhookSourceSQL,
+		string(src.ID()), res.Ciphertext, res.KeyID, res.EDK, res.Nonce); err != nil {
+		return classifyPGError(err, ErrAdapterPGQuery, "webhook source upsert")
+	}
+	return nil
+}
+
+// LoadAll implements [runtimewebhook.SourceRepo].
+func (r *WebhookSourceRepository) LoadAll(ctx context.Context) ([]kwh.Source, error) {
+	rows, err := r.db.Query(ctx, selectAllWebhookSourcesSQL)
+	if err != nil {
+		return nil, classifyPGError(err, ErrAdapterPGQuery, "webhook source load-all")
+	}
+	defer rows.Close()
+
+	sources := make([]kwh.Source, 0)
+	for rows.Next() {
+		var (
+			sourceID    string
+			cipher, edk []byte
+			nonce       []byte
+			keyID       string
+		)
+		if err := rows.Scan(&sourceID, &cipher, &keyID, &edk, &nonce); err != nil {
+			return nil, classifyPGError(err, ErrAdapterPGQuery, "webhook source scan")
+		}
+		id, err := kwh.NewSourceID(sourceID)
+		if err != nil {
+			return nil, err
+		}
+		src, err := kwh.NewSourceFromCiphertext(ctx, r.transformer, id, cipher, keyID, nonce, edk)
+		if err != nil {
+			return nil, err // fail-closed: a source whose secret cannot be recovered aborts the load
+		}
+		sources = append(sources, src)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, classifyPGError(err, ErrAdapterPGQuery, "webhook source rows")
+	}
+	return sources, nil
+}
+
+// Delete implements [runtimewebhook.SourceRepo].
+func (r *WebhookSourceRepository) Delete(ctx context.Context, id kwh.SourceID) error {
+	if _, err := r.db.Exec(ctx, deleteWebhookSourceSQL, string(id)); err != nil {
+		return classifyPGError(err, ErrAdapterPGQuery, "webhook source delete")
+	}
+	return nil
+}

--- a/adapters/postgres/webhook_source_repo.go
+++ b/adapters/postgres/webhook_source_repo.go
@@ -62,17 +62,21 @@ var _ runtimewebhook.SourceRepo = (*WebhookSourceRepository)(nil)
 // transformer is validated first: nil is rejected (no plaintext fallback), and
 // [runtimecrypto.NoopTransformer] is rejected by a concrete-type guard — passing
 // the passthrough transformer would persist webhook source secrets in plaintext,
-// which the table schema structurally prevents (no plaintext column). This
-// rejection is now ENFORCED by a runtime guard, not merely narrated (contrast
-// configcore, which permits Noop for non-sensitive entries). pool must also be
-// non-nil.
+// which the table schema structurally prevents (no plaintext column). Both the
+// value form ([runtimecrypto.NoopTransformer]) and the pointer form
+// (*[runtimecrypto.NoopTransformer]) are rejected: NoopTransformer's methods have
+// value receivers, so *NoopTransformer also satisfies [kcrypto.ValueTransformer]
+// and a value-only guard would let the pointer slip through. This rejection is
+// ENFORCED by a runtime guard, not merely narrated (contrast configcore, which
+// permits Noop for non-sensitive entries). pool must also be non-nil.
 func NewWebhookSourceRepository(pool *pgxpool.Pool, transformer kcrypto.ValueTransformer) (*WebhookSourceRepository, error) {
 	if transformer == nil {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"postgres.NewWebhookSourceRepository: value transformer must not be nil "+
 				"(webhook source secrets are never persisted in plaintext)")
 	}
-	if _, ok := transformer.(runtimecrypto.NoopTransformer); ok {
+	switch transformer.(type) {
+	case runtimecrypto.NoopTransformer, *runtimecrypto.NoopTransformer:
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"postgres.NewWebhookSourceRepository: NoopTransformer (passthrough) would persist "+
 				"webhook source secrets in plaintext")

--- a/adapters/postgres/webhook_source_repo_integration_test.go
+++ b/adapters/postgres/webhook_source_repo_integration_test.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -180,4 +181,65 @@ func mustSourceID(t *testing.T, id string) kwh.SourceID {
 	sid, err := kwh.NewSourceID(id)
 	require.NoError(t, err)
 	return sid
+}
+
+// TestVerifyExpectedShape_FrozenColumnSet_WebhookSources verifies that adding
+// an unexpected column to webhook_sources causes VerifyExpectedShape to return
+// ErrAdapterPGSchemaShape. The extra column is dropped after the assertion so
+// the per-test database is left in a clean state for pool reuse.
+func TestVerifyExpectedShape_FrozenColumnSet_WebhookSources(t *testing.T) {
+	ctx := context.Background()
+	pool := migratedPool(t)
+
+	// Inject an unexpected column (simulates an out-of-band DDL that would
+	// allow persisting a plaintext secret — the exact threat the frozen-set
+	// check guards against).
+	_, err := pool.DB().Exec(ctx, `ALTER TABLE webhook_sources ADD COLUMN value bytea`)
+	require.NoError(t, err, "ADD COLUMN must succeed (superuser in testcontainer)")
+
+	t.Cleanup(func() {
+		_, _ = pool.DB().Exec(ctx, `ALTER TABLE webhook_sources DROP COLUMN IF EXISTS value`)
+	})
+
+	err = VerifyExpectedShape(ctx, pool)
+	require.Error(t, err, "VerifyExpectedShape must reject an unexpected column on webhook_sources")
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec), "error must be *errcode.Error")
+	assert.Equal(t, ErrAdapterPGSchemaShape, ec.Code, "error code must be ErrAdapterPGSchemaShape")
+	assert.Contains(t, ec.Message, "unexpected column on frozen table",
+		"message must describe the frozen-set fault")
+}
+
+// TestWebhookSourceRepository_LoadAll_CorruptSourceID verifies that a persisted
+// row with an invalid source_id (e.g. uppercase, violating the kernel shape
+// rule) causes LoadAll to return ErrAdapterPGSchemaShape (adapter data-shape
+// error), not the kernel's ErrWebhookConfigInvalid (which would look like a
+// caller config error rather than DB corruption).
+func TestWebhookSourceRepository_LoadAll_CorruptSourceID(t *testing.T) {
+	ctx := context.Background()
+	repo, vt, pool := webhookSourceFixture(t)
+
+	// Build a valid cipher envelope to satisfy NOT NULL column constraints,
+	// then insert it under an invalid source_id (uppercase violates
+	// ^[a-z][a-z0-9_-]*$ enforced by kwh.NewSourceID).
+	gh := mustWebhookSource(t, "github", "github-webhook-shared-secret-01")
+	res, err := gh.Encrypt(ctx, vt)
+	require.NoError(t, err)
+
+	_, err = pool.DB().Exec(ctx, upsertWebhookSourceSQL,
+		"GITHUB", res.Ciphertext, res.KeyID, res.EDK, res.Nonce)
+	require.NoError(t, err, "direct INSERT with invalid source_id must succeed at DB level")
+
+	t.Cleanup(func() {
+		_, _ = pool.DB().Exec(ctx, `DELETE FROM webhook_sources WHERE source_id = 'GITHUB'`)
+	})
+
+	_, err = repo.LoadAll(ctx)
+	require.Error(t, err, "LoadAll must fail when a persisted source_id violates kernel shape")
+
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec), "error must be *errcode.Error")
+	assert.Equal(t, ErrAdapterPGSchemaShape, ec.Code,
+		"corrupt persisted source_id must surface as ErrAdapterPGSchemaShape (DB corruption), not ErrWebhookConfigInvalid (caller error)")
 }

--- a/adapters/postgres/webhook_source_repo_integration_test.go
+++ b/adapters/postgres/webhook_source_repo_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/crypto"
+)
+
+// webhookSourceFixture builds a WebhookSourceRepository over a fresh per-test
+// database (cloned from the migrated template, so webhook_sources exists) backed
+// by a real local-aes ValueTransformer. The same transformer is returned so a
+// test can hand-craft a cipher tuple and exercise the AAD binding end-to-end with
+// real AES-GCM. The raw *pgxpool.Pool is returned for direct row insertion.
+func webhookSourceFixture(t *testing.T) (*WebhookSourceRepository, kcrypto.ValueTransformer, *Pool) {
+	t.Helper()
+	kp, err := crypto.NewLocalAESKeyProviderFromKeys(strings.Repeat("ab", 32), "")
+	require.NoError(t, err)
+	vt := crypto.NewValueTransformer(kp)
+	pool := migratedPool(t)
+	repo, err := NewWebhookSourceRepository(pool.DB(), vt)
+	require.NoError(t, err)
+	return repo, vt, pool
+}
+
+func mustWebhookSource(t *testing.T, id, secret string) kwh.Source {
+	t.Helper()
+	sid, err := kwh.NewSourceID(id)
+	require.NoError(t, err)
+	src, err := kwh.NewSource(sid, []byte(secret))
+	require.NoError(t, err)
+	return src
+}
+
+func findSource(sources []kwh.Source, id string) (kwh.Source, bool) {
+	for _, s := range sources {
+		if string(s.ID()) == id {
+			return s, true
+		}
+	}
+	return kwh.Source{}, false
+}
+
+// assertSameSecret proves two Sources carry the same secret without reading the
+// (unexported, getter-less) secret field: identical (payload, ts, deliveryID)
+// inputs produce identical HMAC signatures iff the signing secrets are equal.
+func assertSameSecret(t *testing.T, want, got kwh.Source) {
+	t.Helper()
+	did, err := kwh.NewDeliveryID("delivery-1")
+	require.NoError(t, err)
+	ts := time.Unix(1700000000, 0)
+	payload := []byte("the-webhook-payload-body")
+
+	wSigner, err := kwh.NewHMACSigner(want)
+	require.NoError(t, err)
+	wHeaders, err := wSigner.Sign(payload, ts, did)
+	require.NoError(t, err)
+
+	gSigner, err := kwh.NewHMACSigner(got)
+	require.NoError(t, err)
+	gHeaders, err := gSigner.Sign(payload, ts, did)
+	require.NoError(t, err)
+
+	assert.Equal(t, wHeaders, gHeaders, "decrypted secret must match the original")
+}
+
+func TestWebhookSourceRepository_Roundtrip(t *testing.T) {
+	ctx := context.Background()
+	repo, _, _ := webhookSourceFixture(t)
+
+	src := mustWebhookSource(t, "github", "github-webhook-shared-secret-01")
+	require.NoError(t, repo.Upsert(ctx, src))
+
+	loaded, err := repo.LoadAll(ctx)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	got, ok := findSource(loaded, "github")
+	require.True(t, ok)
+	assert.Equal(t, src.ID(), got.ID())
+	assertSameSecret(t, src, got)
+}
+
+func TestWebhookSourceRepository_UpsertReplacesSecret(t *testing.T) {
+	ctx := context.Background()
+	repo, _, _ := webhookSourceFixture(t)
+
+	require.NoError(t, repo.Upsert(ctx, mustWebhookSource(t, "github", "old-secret-rotated-away-0001")))
+	rotated := mustWebhookSource(t, "github", "new-secret-after-rotation-0002")
+	require.NoError(t, repo.Upsert(ctx, rotated))
+
+	loaded, err := repo.LoadAll(ctx)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1, "upsert under the same id must replace, not duplicate")
+	got, ok := findSource(loaded, "github")
+	require.True(t, ok)
+	assertSameSecret(t, rotated, got)
+}
+
+func TestWebhookSourceRepository_Delete(t *testing.T) {
+	ctx := context.Background()
+	repo, _, _ := webhookSourceFixture(t)
+
+	require.NoError(t, repo.Upsert(ctx, mustWebhookSource(t, "github", "github-webhook-shared-secret-01")))
+	require.NoError(t, repo.Delete(ctx, mustSourceID(t, "github")))
+
+	loaded, err := repo.LoadAll(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+
+	// Deleting an absent source is idempotent (no error, no rows).
+	require.NoError(t, repo.Delete(ctx, mustSourceID(t, "stripe")))
+}
+
+func TestWebhookSourceRepository_MultiSourcePersist(t *testing.T) {
+	ctx := context.Background()
+	repo, _, _ := webhookSourceFixture(t)
+
+	gh := mustWebhookSource(t, "github", "github-webhook-shared-secret-01")
+	st := mustWebhookSource(t, "stripe", "stripe-webhook-shared-secret-02")
+	require.NoError(t, repo.Upsert(ctx, gh))
+	require.NoError(t, repo.Upsert(ctx, st))
+
+	loaded, err := repo.LoadAll(ctx)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	gotGH, ok := findSource(loaded, "github")
+	require.True(t, ok)
+	assertSameSecret(t, gh, gotGH)
+	gotST, ok := findSource(loaded, "stripe")
+	require.True(t, ok)
+	assertSameSecret(t, st, gotST)
+}
+
+func TestWebhookSourceRepository_EmptyLoadAll(t *testing.T) {
+	ctx := context.Background()
+	repo, _, _ := webhookSourceFixture(t)
+
+	loaded, err := repo.LoadAll(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, loaded)
+	assert.Empty(t, loaded)
+}
+
+// TestWebhookSourceRepository_AADTransplantRejected proves the AAD binding holds
+// against real AES-GCM: a ciphertext encrypted for "github" but stored under
+// source_id "stripe" fails the tag check on load (the loader recomputes the AAD
+// from "stripe"), so LoadAll fails closed rather than serving the wrong secret.
+func TestWebhookSourceRepository_AADTransplantRejected(t *testing.T) {
+	ctx := context.Background()
+	repo, vt, pool := webhookSourceFixture(t)
+
+	// Seal a secret bound to "github".
+	gh := mustWebhookSource(t, "github", "github-webhook-shared-secret-01")
+	res, err := gh.Encrypt(ctx, vt)
+	require.NoError(t, err)
+
+	// Plant that ciphertext under a DIFFERENT source id (transplant attack).
+	_, err = pool.DB().Exec(ctx, upsertWebhookSourceSQL,
+		"stripe", res.Ciphertext, res.KeyID, res.EDK, res.Nonce)
+	require.NoError(t, err)
+
+	_, err = repo.LoadAll(ctx)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrWebhookSecretCryptoFailed, ec.Code)
+}
+
+func mustSourceID(t *testing.T, id string) kwh.SourceID {
+	t.Helper()
+	sid, err := kwh.NewSourceID(id)
+	require.NoError(t, err)
+	return sid
+}

--- a/adapters/postgres/webhook_source_repo_test.go
+++ b/adapters/postgres/webhook_source_repo_test.go
@@ -9,6 +9,7 @@ import (
 
 	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	runtimecrypto "github.com/ghbvf/gocell/runtime/crypto"
 )
 
 // webhookStubTransformer is a non-nil ValueTransformer for the constructor-guard
@@ -24,14 +25,26 @@ func (webhookStubTransformer) Decrypt(context.Context, []byte, string, []byte, [
 }
 
 // TestNewWebhookSourceRepository_Guards covers the fail-closed constructor:
-// a nil transformer is rejected first (no plaintext-at-rest path), and a nil pool
-// is rejected. Both fire before any SQL, so no database is required.
+// a nil transformer is rejected first (no plaintext-at-rest path), a
+// NoopTransformer (non-nil but passthrough) is rejected as it would persist
+// secrets in plaintext, and a nil pool is rejected. All guards fire before any
+// SQL, so no database is required.
 func TestNewWebhookSourceRepository_Guards(t *testing.T) {
 	t.Run("nil transformer rejected (no plaintext fallback)", func(t *testing.T) {
 		repo, err := NewWebhookSourceRepository(nil, nil)
 		assert.Nil(t, repo)
 		var ec *errcode.Error
 		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+		assert.Contains(t, ec.Message, "plaintext")
+	})
+
+	t.Run("NoopTransformer rejected (plaintext passthrough not allowed)", func(t *testing.T) {
+		repo, err := NewWebhookSourceRepository(nil, runtimecrypto.NoopTransformer{})
+		assert.Nil(t, repo)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, errcode.KindInvalid, ec.Kind)
 		assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
 		assert.Contains(t, ec.Message, "plaintext")
 	})

--- a/adapters/postgres/webhook_source_repo_test.go
+++ b/adapters/postgres/webhook_source_repo_test.go
@@ -1,0 +1,46 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// webhookStubTransformer is a non-nil ValueTransformer for the constructor-guard
+// tests (which never reach a SQL call, so the bodies are unused).
+type webhookStubTransformer struct{}
+
+func (webhookStubTransformer) Encrypt(context.Context, []byte, []byte) (kcrypto.EncryptResult, error) {
+	return kcrypto.EncryptResult{}, nil
+}
+
+func (webhookStubTransformer) Decrypt(context.Context, []byte, string, []byte, []byte, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+// TestNewWebhookSourceRepository_Guards covers the fail-closed constructor:
+// a nil transformer is rejected first (no plaintext-at-rest path), and a nil pool
+// is rejected. Both fire before any SQL, so no database is required.
+func TestNewWebhookSourceRepository_Guards(t *testing.T) {
+	t.Run("nil transformer rejected (no plaintext fallback)", func(t *testing.T) {
+		repo, err := NewWebhookSourceRepository(nil, nil)
+		assert.Nil(t, repo)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+		assert.Contains(t, ec.Message, "plaintext")
+	})
+
+	t.Run("nil pool rejected", func(t *testing.T) {
+		repo, err := NewWebhookSourceRepository(nil, webhookStubTransformer{})
+		assert.Nil(t, repo)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+	})
+}

--- a/adapters/postgres/webhook_source_repo_test.go
+++ b/adapters/postgres/webhook_source_repo_test.go
@@ -39,15 +39,24 @@ func TestNewWebhookSourceRepository_Guards(t *testing.T) {
 		assert.Contains(t, ec.Message, "plaintext")
 	})
 
-	t.Run("NoopTransformer rejected (plaintext passthrough not allowed)", func(t *testing.T) {
-		repo, err := NewWebhookSourceRepository(nil, runtimecrypto.NoopTransformer{})
-		assert.Nil(t, repo)
-		var ec *errcode.Error
-		require.ErrorAs(t, err, &ec)
-		assert.Equal(t, errcode.KindInvalid, ec.Kind)
-		assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
-		assert.Contains(t, ec.Message, "plaintext")
-	})
+	// NoopTransformer's methods have value receivers, so both the value form and
+	// the *NoopTransformer pointer form satisfy ValueTransformer — both must be
+	// rejected or a passthrough could persist secrets in plaintext.
+	noopForms := map[string]runtimecrypto.ValueTransformer{
+		"value":   runtimecrypto.NoopTransformer{},
+		"pointer": &runtimecrypto.NoopTransformer{},
+	}
+	for form, vt := range noopForms {
+		t.Run("NoopTransformer ("+form+") rejected (plaintext passthrough not allowed)", func(t *testing.T) {
+			repo, err := NewWebhookSourceRepository(nil, vt)
+			assert.Nil(t, repo)
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.KindInvalid, ec.Kind)
+			assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+			assert.Contains(t, ec.Message, "plaintext")
+		})
+	}
 
 	t.Run("nil pool rejected", func(t *testing.T) {
 		repo, err := NewWebhookSourceRepository(nil, webhookStubTransformer{})

--- a/cellmodules/cellsecrets/env.go
+++ b/cellmodules/cellsecrets/env.go
@@ -32,11 +32,12 @@ func LoadConfigCoreKeyProvider() (providerName, masterKey, prevMasterKey string)
 }
 
 // LoadWebhookSourceKeyProvider reads the KeyProvider configuration for the
-// persistent, encrypted webhook source secret store (#1540):
+// persistent, encrypted webhook source secret store (#1540). See
+// cellmodules/webhooksource.buildKeyProviderFromName for provider semantics:
 //
-//	GOCELL_WEBHOOK_KEY_PROVIDER
-//	GOCELL_WEBHOOK_MASTER_KEY
-//	GOCELL_WEBHOOK_MASTER_KEY_PREVIOUS
+//	GOCELL_WEBHOOK_KEY_PROVIDER        (required in postgres mode: "local-aes" | "vault-transit")
+//	GOCELL_WEBHOOK_MASTER_KEY          (required for local-aes; ignored for vault-transit)
+//	GOCELL_WEBHOOK_MASTER_KEY_PREVIOUS (optional rotation key; local-aes only)
 func LoadWebhookSourceKeyProvider() (providerName, masterKey, prevMasterKey string) {
 	return os.Getenv("GOCELL_WEBHOOK_KEY_PROVIDER"),
 		os.Getenv("GOCELL_WEBHOOK_MASTER_KEY"),

--- a/cellmodules/cellsecrets/env.go
+++ b/cellmodules/cellsecrets/env.go
@@ -30,3 +30,15 @@ func LoadConfigCoreKeyProvider() (providerName, masterKey, prevMasterKey string)
 		os.Getenv("GOCELL_CONFIGCORE_MASTER_KEY"),
 		os.Getenv("GOCELL_CONFIGCORE_MASTER_KEY_PREVIOUS")
 }
+
+// LoadWebhookSourceKeyProvider reads the KeyProvider configuration for the
+// persistent, encrypted webhook source secret store (#1540):
+//
+//	GOCELL_WEBHOOK_KEY_PROVIDER
+//	GOCELL_WEBHOOK_MASTER_KEY
+//	GOCELL_WEBHOOK_MASTER_KEY_PREVIOUS
+func LoadWebhookSourceKeyProvider() (providerName, masterKey, prevMasterKey string) {
+	return os.Getenv("GOCELL_WEBHOOK_KEY_PROVIDER"),
+		os.Getenv("GOCELL_WEBHOOK_MASTER_KEY"),
+		os.Getenv("GOCELL_WEBHOOK_MASTER_KEY_PREVIOUS")
+}

--- a/cellmodules/webhooksource/key_provider.go
+++ b/cellmodules/webhooksource/key_provider.go
@@ -1,0 +1,98 @@
+package webhooksource
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	adaptervault "github.com/ghbvf/gocell/adapters/vault"
+	"github.com/ghbvf/gocell/cellmodules/cellsecrets"
+	"github.com/ghbvf/gocell/kernel/clock"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/crypto"
+)
+
+// Key-provider enum values for GOCELL_WEBHOOK_KEY_PROVIDER. Single source of truth
+// for the switch dispatch and the slog provider label.
+const (
+	providerLocalAES     = "local-aes"
+	providerVaultTransit = "vault-transit"
+)
+
+// buildKeyProviderFromName is the adapter-aware key-provider factory for the
+// webhook source secret encryption key (#1540). It deliberately mirrors
+// cellmodules/configcore's buildKeyProviderFromName rather than sharing it: there
+// are only two consumers (configcore + webhook), and the go-standards "重复三次
+// 才抽" guideline defers extraction until a third appears. Both consumers reuse
+// the same underlying primitives (runtime/crypto local-aes, adapters/vault
+// transit, cellsecrets demo-key rejection); only the env-var namespace differs.
+//
+// Unlike configcore, an empty provider is always an error here: the loader only
+// calls this in postgres-storage mode (memory/demo deployments use the in-memory
+// kwh.SourceRegistry directly), where persisting an unencrypted secret is never
+// acceptable.
+//
+// The vault-transit branch reuses the SAME vault transit metric names as
+// configcore; the kernel MetricsProvider returns the already-registered
+// collectors on a duplicate name (prometheus AlreadyRegisteredError reuse), so a
+// deployment running both configcore and webhook on vault-transit does not fail.
+func buildKeyProviderFromName(
+	adapterMode, providerName, masterKey, prevMasterKey string,
+	clk clock.Clock,
+	metricsProvider metrics.Provider,
+) (kcrypto.KeyProvider, error) {
+	switch providerName {
+	case providerLocalAES:
+		return buildLocalAESKeyProvider(adapterMode, masterKey, prevMasterKey)
+	case providerVaultTransit:
+		return buildVaultTransitKeyProvider(adapterMode, clk, metricsProvider)
+	case "":
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"webhooksource: GOCELL_WEBHOOK_KEY_PROVIDER must be set for the persistent "+
+				"webhook source store (known values: \"local-aes\" for dev/CI, "+
+				"\"vault-transit\" for production)")
+	default:
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"unknown GOCELL_WEBHOOK_KEY_PROVIDER; known values: \"local-aes\", \"vault-transit\"",
+			errcode.WithDetails(errcode.PublicString("provider", providerName)))
+	}
+}
+
+// buildLocalAESKeyProvider constructs the local-aes KeyProvider, rejecting
+// well-known demo keys in real adapter mode.
+func buildLocalAESKeyProvider(adapterMode, masterKey, prevMasterKey string) (kcrypto.KeyProvider, error) {
+	lowerMK := []byte(strings.ToLower(masterKey))
+	if err := cellsecrets.RejectDemoKey(adapterMode, "GOCELL_WEBHOOK_MASTER_KEY", lowerMK); err != nil {
+		return nil, err
+	}
+	if prevMasterKey != "" {
+		lowerPrev := []byte(strings.ToLower(prevMasterKey))
+		if err := cellsecrets.RejectDemoKey(adapterMode, "GOCELL_WEBHOOK_MASTER_KEY_PREVIOUS", lowerPrev); err != nil {
+			return nil, err
+		}
+	}
+	kp, err := crypto.NewLocalAESKeyProviderFromKeys(masterKey, prevMasterKey)
+	if err != nil {
+		return nil, fmt.Errorf("webhooksource local-aes key provider: %w", err)
+	}
+	slog.Info("webhooksource: key provider initialized", slog.String("provider", providerLocalAES))
+	return kp, nil
+}
+
+// buildVaultTransitKeyProvider constructs the vault-transit KeyProvider from env.
+func buildVaultTransitKeyProvider(
+	adapterMode string, clk clock.Clock, metricsProvider metrics.Provider,
+) (kcrypto.KeyProvider, error) {
+	m, err := adaptervault.NewTransitMetrics(metricsProvider)
+	if err != nil {
+		return nil, fmt.Errorf("webhooksource vault-transit metrics: %w", err)
+	}
+	kp, err := adaptervault.NewTransitKeyProviderFromEnv(cellsecrets.IsRealMode(adapterMode), clk, m)
+	if err != nil {
+		return nil, fmt.Errorf("webhooksource vault-transit key provider: %w", err)
+	}
+	slog.Info("webhooksource: key provider initialized", slog.String("provider", providerVaultTransit))
+	return kp, nil
+}

--- a/cellmodules/webhooksource/key_provider.go
+++ b/cellmodules/webhooksource/key_provider.go
@@ -29,10 +29,11 @@ const (
 // the same underlying primitives (runtime/crypto local-aes, adapters/vault
 // transit, cellsecrets demo-key rejection); only the env-var namespace differs.
 //
-// Unlike configcore, an empty provider is always an error here: the loader only
-// calls this in postgres-storage mode (memory/demo deployments use the in-memory
-// kwh.SourceRegistry directly), where persisting an unencrypted secret is never
-// acceptable.
+// Unlike configcore's counterpart, this function takes no storageBackend
+// argument: the loader only calls it in postgres-storage mode (memory/demo
+// deployments use the in-memory kwh.SourceRegistry directly), so there is no
+// NoopTransformer path and an empty provider is ALWAYS an error here — persisting
+// an unencrypted webhook secret is never acceptable.
 //
 // The vault-transit branch reuses the SAME vault transit metric names as
 // configcore; the kernel MetricsProvider returns the already-registered

--- a/cellmodules/webhooksource/key_provider_test.go
+++ b/cellmodules/webhooksource/key_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/cellmodules/cellsecrets"
 	"github.com/ghbvf/gocell/kernel/clock"
 	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -41,4 +42,25 @@ func TestBuildKeyProviderFromName_UnknownProviderRejected(t *testing.T) {
 	var ec *errcode.Error
 	require.ErrorAs(t, err, &ec)
 	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+}
+
+// TestBuildKeyProviderFromName_LocalAESRealModeRejectsDemoKey verifies the
+// real-mode demo-key guard fires for the webhook master key (a well-known demo
+// key must not encrypt production secrets).
+func TestBuildKeyProviderFromName_LocalAESRealModeRejectsDemoKey(t *testing.T) {
+	demo := cellsecrets.WellKnownDemoKeys()[0]
+	kp, err := buildKeyProviderFromName(cellsecrets.RealAdapterMode, providerLocalAES, demo, "", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, kp)
+	require.Error(t, err)
+}
+
+// TestBuildKeyProviderFromName_VaultTransitFailsWithoutEnv verifies the
+// vault-transit branch fails closed when Vault is not configured (missing
+// VAULT_ADDR fails fast in all modes), rather than hanging on a connect attempt.
+func TestBuildKeyProviderFromName_VaultTransitFailsWithoutEnv(t *testing.T) {
+	t.Setenv("VAULT_ADDR", "")
+	t.Setenv("VAULT_AUTH_METHOD", "")
+	kp, err := buildKeyProviderFromName("memory", providerVaultTransit, "", "", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, kp)
+	require.Error(t, err)
 }

--- a/cellmodules/webhooksource/key_provider_test.go
+++ b/cellmodules/webhooksource/key_provider_test.go
@@ -1,0 +1,44 @@
+package webhooksource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// validLocalAESKey is a 64-char hex string decoding to 32 bytes.
+var validLocalAESKey = strings.Repeat("ab", 32)
+
+func TestBuildKeyProviderFromName_LocalAES(t *testing.T) {
+	kp, err := buildKeyProviderFromName("memory", providerLocalAES, validLocalAESKey, "", clock.Real(), kernelmetrics.NopProvider{})
+	require.NoError(t, err)
+	assert.NotNil(t, kp)
+}
+
+func TestBuildKeyProviderFromName_LocalAESEmptyKeyFailsClosed(t *testing.T) {
+	kp, err := buildKeyProviderFromName("memory", providerLocalAES, "", "", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, kp)
+	require.Error(t, err)
+}
+
+func TestBuildKeyProviderFromName_EmptyProviderRejected(t *testing.T) {
+	kp, err := buildKeyProviderFromName("memory", "", "", "", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, kp)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+}
+
+func TestBuildKeyProviderFromName_UnknownProviderRejected(t *testing.T) {
+	kp, err := buildKeyProviderFromName("memory", "aws-kms", "", "", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, kp)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+}

--- a/cellmodules/webhooksource/loader.go
+++ b/cellmodules/webhooksource/loader.go
@@ -1,0 +1,90 @@
+// Package webhooksource is the composition-root loader for the persistent,
+// encrypted webhook source secret store (#1540). It reads every webhook source
+// row from postgres at boot, decrypts each secret through the sealed kernel
+// funnel, and returns a kwh.SourceRegistry snapshot ready to inject via
+// bootstrap.WithWebhookSourceStore — so the runtime Lookup hot path stays a pure
+// in-memory read, immutable until the next restart (matching the
+// eager-register-at-startup contract of the in-memory default).
+//
+// This is a composition-root-layer package: it may import adapters/, cellmodules/
+// cellsecrets, and runtime/. It must NOT be imported by cells/, runtime/, or
+// adapters/. It is NOT a composition.CellModule (webhook is not a cell); it is a
+// loader the assembly's composition root calls when it wires webhook receivers /
+// dispatchers against a persistent store.
+//
+// ref: cellmodules/configcore (sibling composition module; key-provider pattern)
+package webhooksource
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/cellmodules/cellsecrets"
+	"github.com/ghbvf/gocell/kernel/clock"
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/kernel/observability/metrics"
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/composition"
+	"github.com/ghbvf/gocell/runtime/crypto"
+)
+
+// LoadSourceStore builds the persistent webhook [kwh.SourceStore] from postgres.
+// It builds the value transformer from env, opens the shared PG pool, loads and
+// decrypts every persisted source, and returns a populated [kwh.SourceRegistry]
+// snapshot.
+//
+// Fail-closed: the persistent store requires postgres storage AND a configured
+// key provider (GOCELL_WEBHOOK_KEY_PROVIDER) — webhook secrets are never persisted
+// in plaintext. Dev / demo single-process deployments that do not persist secrets
+// build an in-memory [kwh.NewSourceRegistry] directly instead of calling this.
+func LoadSourceStore(ctx context.Context, shared *composition.SharedDeps) (kwh.SourceStore, error) {
+	vt, err := buildValueTransformer(
+		shared.Topology.StorageBackend(), shared.Topology.AdapterMode(),
+		shared.Clock, shared.MetricsProvider)
+	if err != nil {
+		return nil, err
+	}
+	pool, err := cellsecrets.PgxPoolFromProvider(shared.PG)
+	if err != nil {
+		return nil, fmt.Errorf("webhooksource: resolve pg pool: %w", err)
+	}
+	repo, err := adapterpg.NewWebhookSourceRepository(pool, vt)
+	if err != nil {
+		return nil, err
+	}
+	sources, err := repo.LoadAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("webhooksource: load sources: %w", err)
+	}
+	registry := kwh.NewSourceRegistry()
+	for _, src := range sources {
+		if err := registry.Register(src); err != nil {
+			return nil, fmt.Errorf("webhooksource: register source %q: %w", src.ID(), err)
+		}
+	}
+	slog.Info("webhooksource: loaded persistent webhook sources", slog.Int("count", len(sources)))
+	return registry, nil
+}
+
+// buildValueTransformer gates persistence on postgres storage and builds the
+// envelope-encryption transformer from the GOCELL_WEBHOOK_* key-provider env. It
+// is split from [LoadSourceStore] so the storage gate and key-provider wiring are
+// unit-testable from primitives, without constructing a full SharedDeps / pool.
+func buildValueTransformer(
+	storageBackend, adapterMode string, clk clock.Clock, metricsProvider metrics.Provider,
+) (kcrypto.ValueTransformer, error) {
+	if storageBackend != "postgres" {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"webhooksource: persistent webhook source store requires postgres storage "+
+				"(memory/demo deployments use the in-memory kwh.SourceRegistry directly)")
+	}
+	providerName, masterKey, prevMasterKey := cellsecrets.LoadWebhookSourceKeyProvider()
+	kp, err := buildKeyProviderFromName(adapterMode, providerName, masterKey, prevMasterKey, clk, metricsProvider)
+	if err != nil {
+		return nil, fmt.Errorf("webhooksource: key provider: %w", err)
+	}
+	return crypto.NewValueTransformer(kp), nil
+}

--- a/cellmodules/webhooksource/loader.go
+++ b/cellmodules/webhooksource/loader.go
@@ -65,7 +65,8 @@ func LoadSourceStore(ctx context.Context, shared *composition.SharedDeps) (kwh.S
 			return nil, fmt.Errorf("webhooksource: register source %q: %w", src.ID(), err)
 		}
 	}
-	slog.Info("webhooksource: loaded persistent webhook sources", slog.Int("count", len(sources)))
+	slog.InfoContext(ctx, "webhooksource: loaded persistent webhook sources",
+		slog.Int("count", len(sources)), slog.String("storage", "postgres"))
 	return registry, nil
 }
 

--- a/cellmodules/webhooksource/loader_test.go
+++ b/cellmodules/webhooksource/loader_test.go
@@ -1,0 +1,58 @@
+package webhooksource
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock"
+	kernelmetrics "github.com/ghbvf/gocell/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/runtime/bootstrap"
+	"github.com/ghbvf/gocell/runtime/composition"
+)
+
+func TestBuildValueTransformer_RequiresPostgres(t *testing.T) {
+	vt, err := buildValueTransformer("memory", "memory", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, vt)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+	assert.Contains(t, ec.Message, "postgres")
+}
+
+func TestBuildValueTransformer_PostgresLocalAES(t *testing.T) {
+	t.Setenv("GOCELL_WEBHOOK_KEY_PROVIDER", "local-aes")
+	t.Setenv("GOCELL_WEBHOOK_MASTER_KEY", strings.Repeat("ab", 32))
+	vt, err := buildValueTransformer("postgres", "memory", clock.Real(), kernelmetrics.NopProvider{})
+	require.NoError(t, err)
+	assert.NotNil(t, vt)
+}
+
+func TestBuildValueTransformer_PostgresMissingProviderFailsClosed(t *testing.T) {
+	t.Setenv("GOCELL_WEBHOOK_KEY_PROVIDER", "")
+	vt, err := buildValueTransformer("postgres", "memory", clock.Real(), kernelmetrics.NopProvider{})
+	assert.Nil(t, vt)
+	require.Error(t, err)
+}
+
+// TestLoadSourceStore_RequiresPostgres exercises the public entry point's
+// fail-closed storage gate: with memory storage it returns before touching the
+// pool. A struct-literal SharedDeps is sufficient because the gate fires first.
+func TestLoadSourceStore_RequiresPostgres(t *testing.T) {
+	topo, err := bootstrap.NewTopology("", "memory", false)
+	require.NoError(t, err)
+	shared := &composition.SharedDeps{
+		Topology:        topo,
+		Clock:           clock.Real(),
+		MetricsProvider: kernelmetrics.NopProvider{},
+	}
+	store, err := LoadSourceStore(context.Background(), shared)
+	assert.Nil(t, store)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrValidationFailed, ec.Code)
+}

--- a/docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
+++ b/docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
@@ -56,13 +56,18 @@ Three constraints framed the design:
    only on the next restart (matches the issue's "运行时不可变").
 
 3. **A bidirectional sealed crypto funnel in `kernel/webhook`.** `Source.Encrypt`
-   and `NewSourceFromCiphertext` seal/unseal the secret; the plaintext bytes
-   never leave the package. The persistence repo (`runtimewebhook.SourceRepo`,
-   implemented by `adapters/postgres.WebhookSourceRepository`) deals exclusively
-   in the sealed `kwh.Source` type and ciphertext columns — never a loose
-   `[]byte` secret. The AAD that binds each ciphertext to its `source_id`
-   (`cell:webhook/source:{id}`) is computed inside the funnel from the sealed id,
-   so the repo cannot pass a wrong AAD.
+   and `NewSourceFromCiphertext` seal/unseal the secret. The plaintext is never a
+   loose returnable value outside the package — `Source` keeps its secret
+   unexported with no getter (**Hard**). It *is* observed by the caller-supplied
+   `ValueTransformer` those methods run, so "no in-process code sees the plaintext"
+   is a composition-root **trust** property (**Medium**), not a package boundary —
+   locked by `WEBHOOK-SOURCE-CRYPTO-FUNNEL-01` to the sole sanctioned caller. The
+   persistence repo (`runtimewebhook.SourceRepo`, implemented by
+   `adapters/postgres.WebhookSourceRepository`) deals exclusively in the sealed
+   `kwh.Source` type and ciphertext columns — never a loose `[]byte` secret. The
+   AAD that binds each ciphertext to its `source_id` (`cell:webhook/source:{id}`)
+   is computed inside the funnel from the sealed id, so the repo cannot pass a
+   wrong AAD.
 
 4. **Write path this PR = repo CRUD (Upsert / LoadAll / Delete) + boot loader.**
    Secrets are provisioned out-of-band (e.g. a provisioning tool calling

--- a/docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
+++ b/docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
@@ -49,7 +49,11 @@ Three constraints framed the design:
    decrypts each secret, and populates a `kwh.SourceRegistry` snapshot injected
    via `bootstrap.WithWebhookSourceStore`. The hot `Lookup` path is unchanged —
    persistence is about *where secrets come from at boot*, not runtime mutability.
-   Rotation / add = write the row + restart (matches the issue's "运行时不可变").
+   Rotation / add / **delete** = write or remove the row + restart: the loader
+   builds an immutable snapshot at boot, so a `SourceRepo.Delete` only removes the
+   persisted row and does **not** hot-revoke a source already live in the running
+   `SourceRegistry`. Every mutation — add, rotate, *and delete* — takes effect
+   only on the next restart (matches the issue's "运行时不可变").
 
 3. **A bidirectional sealed crypto funnel in `kernel/webhook`.** `Source.Encrypt`
    and `NewSourceFromCiphertext` seal/unseal the secret; the plaintext bytes
@@ -68,20 +72,26 @@ Three constraints framed the design:
 
 ## Security model (AI-robust grading)
 
-Encryption-at-rest is enforced **Hard** (violations unrepresentable), not by a
-new bespoke scan:
+Encryption-at-rest rests on schema-shape + cryptography + sealed value (Hard)
+plus two Medium machine guards. This is an honest split: PR #1929 review (C1/C2)
+corrected an earlier over-grade that called the plaintext-funnel and the
+column-set freeze Hard when neither was actually enforced.
 
 | Invariant | Carrier | Grade |
 |-----------|---------|-------|
-| A webhook secret must be encrypted at rest | `webhook_sources` has **no plaintext column** (`value_cipher BYTEA NOT NULL`, no `value`); `schema_guard.go` freezes the column set — adding a plaintext column trips `SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE-01`/shape verify | **Hard** (schema-shape freeze) |
-| Plaintext secret bytes never leave kernel/webhook | sealed `Source` + `Source.Encrypt` / `NewSourceFromCiphertext`; no API returns the raw secret, the only bytes entry is the validated minter `NewSource`; repo/composition handle only ciphertext | **Hard** (type-system funnel) |
+| A webhook secret must be encrypted at rest | `webhook_sources` has **no plaintext column** (`value_cipher BYTEA NOT NULL`); `schema_guard.verifyFrozenColumnSets` freezes the column set **exactly** — any live column not in the registered expected set fails `ErrAdapterPGSchemaShape` (a positive column check alone does NOT catch an added `value`/`secret`; the exact-set check does, with an integration red test) | **Hard** (schema-shape exact freeze) |
 | Cross-source / cross-cell ciphertext transplant rejected | AAD computed by the kernel from the sealed id (`cell:webhook/source:{id}`, distinct from configcore's domain), AES-GCM tag fails closed | **Hard** (cryptographic + unrepresentable wrong AAD) |
 | Secret never logged / to wire | existing `Source.LogValue/String/GoString` redaction + `WEBHOOK-HMAC-FUNNEL-01` | **Hard** (existing) |
-| Postgres persistence requires a transformer | loader fail-closed (nil key provider → error); no `NoopTransformer` path for webhook secrets | Medium (runtime guard) |
+| Plaintext secret is never a loose returnable value | sealed `Source` (unexported `secret`, no getter); the only bytes entry is the validated minter `NewSource`; no API returns the raw secret | **Hard** (type-system: unrepresentable as a returnable value) |
+| Encryption observes the plaintext only inside the trusted transformer | `Source.Encrypt` / `NewSourceFromCiphertext` take a **caller-supplied** `ValueTransformer`, so any holder of a `Source` could pass a capturing transformer — "no in-process code sees the plaintext" is a composition-root *trust* property, not a type-system one. The sole sanctioned caller is the persistence repo, locked by `WEBHOOK-SOURCE-CRYPTO-FUNNEL-01` (caller-allowlist); a future package wiring its own transformer trips CI | **Medium** (caller-allowlist; permanent Go ceiling — an in-process adversary can always implement the leaf `ValueTransformer` / `KeyHandle` interface, so this cannot be type-system Hard — same ceiling family as `WEBHOOK-HMAC-FUNNEL-01/A3-A4`) |
+| Postgres persistence never writes plaintext | loader fail-closed (nil key provider → error); `NewWebhookSourceRepository` **rejects** a `runtime/crypto.NoopTransformer` (passthrough), so a non-nil pass-through cannot write `value_cipher = plaintext` | **Medium** (runtime guard, enforced — previously only narrated) |
 
-No new archtest invariant is added: the three load-bearing properties are locked
-by schema-shape + type-system + cryptography (the AI-robust charter's top-priority
-carriers), which is stronger than a scan.
+Two new machine guards land with this PR: `WEBHOOK-SOURCE-CRYPTO-FUNNEL-01`
+(`tools/archtest`, the caller-allowlist on the crypto funnel, with anti-vacuity +
+RED fixture) and `schema_guard.verifyFrozenColumnSets` (exact-column-set freeze +
+integration red test). The Hard rows remain locked by schema-shape, type-system,
+and cryptography; the Medium rows are honestly graded with their enforcing guard
+named (per the AI-robust charter — Soft is never used as a new mechanism).
 
 ## Alternatives considered
 

--- a/docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
+++ b/docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
@@ -1,0 +1,114 @@
+# ADR: Webhook source secret persistence — dedicated global encrypted store
+
+- Status: Accepted
+- Date: 2026-06-12
+- Context: KERNEL-WEBHOOK-01 follow-up (#1540; PR-6 closeout #1538 carve)
+- Supersedes / amends: none (greenfield); the SourceStore seam was reserved as a
+  follow-up in `202605291200-adr-webhook-signing-algorithm.md`
+
+## Context
+
+`kernel/webhook.SourceStore.Lookup(id) (Source, bool)` is the secret-lookup seam
+the receiver (verify) and dispatcher (sign) hit on every delivery. Its only
+implementation was the in-memory `SourceRegistry` (eager-registered at startup,
+immutable at runtime); secrets were hardcoded at the composition root
+(`examples/webhookdemo`). #1540 asks for a durable, encrypted backing store so a
+production deployment does not carry HMAC secrets in code.
+
+Three constraints framed the design:
+
+1. **The seam stays as-is.** `Lookup(id)` is synchronous, has no `ctx`, no
+   `error`, and **no tenant** — it is a runtime-hot read. The issue scope is
+   "swap the implementation behind the interface", so changing the kernel
+   signature (e.g. tenant-scoping it) is out of scope. Webhook sources therefore
+   remain **platform-global** (a sender such as "github" is one source for the
+   whole deployment).
+
+2. **configcore is strictly tenant-scoped with no platform tenant.** Every
+   `configcore.ConfigRepository` method demands a real per-tenant UUID, and the
+   `SystemTenantID` sentinel was deliberately removed (`pkg/tenant/tenant_id.go`).
+   Routing global webhook secrets through configcore's entry model would mean
+   inventing a synthetic platform tenant — fighting that prior decision — plus a
+   boot-time cross-cell read.
+
+3. **The reusable, security-critical part is the crypto, not configcore's entry
+   model.** `kernel/crypto.ValueTransformer` (AES-GCM envelope) over
+   `adapters/vault.TransitKeyProvider` / local-AES, with **caller-supplied AAD**,
+   is what gives encryption-at-rest. configcore is merely one consumer of it.
+
+## Decision
+
+1. **A dedicated, global `webhook_sources` table** (migration 063), NOT a
+   configcore entry. No `tenant_id`, no RLS — the same posture as the global
+   `outbox_entries` relay. Secrets are encrypted-at-rest by reusing the SAME
+   `kernel/crypto.ValueTransformer` (vault-transit / local-aes) configcore uses;
+   no synthetic platform tenant, no cross-cell coupling.
+
+2. **Eager-load-into-snapshot, immutable at runtime.** A composition-root loader
+   (`cellmodules/webhooksource.LoadSourceStore`) reads every row at boot,
+   decrypts each secret, and populates a `kwh.SourceRegistry` snapshot injected
+   via `bootstrap.WithWebhookSourceStore`. The hot `Lookup` path is unchanged —
+   persistence is about *where secrets come from at boot*, not runtime mutability.
+   Rotation / add = write the row + restart (matches the issue's "运行时不可变").
+
+3. **A bidirectional sealed crypto funnel in `kernel/webhook`.** `Source.Encrypt`
+   and `NewSourceFromCiphertext` seal/unseal the secret; the plaintext bytes
+   never leave the package. The persistence repo (`runtimewebhook.SourceRepo`,
+   implemented by `adapters/postgres.WebhookSourceRepository`) deals exclusively
+   in the sealed `kwh.Source` type and ciphertext columns — never a loose
+   `[]byte` secret. The AAD that binds each ciphertext to its `source_id`
+   (`cell:webhook/source:{id}`) is computed inside the funnel from the sealed id,
+   so the repo cannot pass a wrong AAD.
+
+4. **Write path this PR = repo CRUD (Upsert / LoadAll / Delete) + boot loader.**
+   Secrets are provisioned out-of-band (e.g. a provisioning tool calling
+   `repo.Upsert(kwh.NewSource(...))`). A self-service HTTP admin endpoint
+   (contract + authz) is a tracked follow-up — it is a separable contract/authz
+   surface, not part of the persistence increment.
+
+## Security model (AI-robust grading)
+
+Encryption-at-rest is enforced **Hard** (violations unrepresentable), not by a
+new bespoke scan:
+
+| Invariant | Carrier | Grade |
+|-----------|---------|-------|
+| A webhook secret must be encrypted at rest | `webhook_sources` has **no plaintext column** (`value_cipher BYTEA NOT NULL`, no `value`); `schema_guard.go` freezes the column set — adding a plaintext column trips `SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE-01`/shape verify | **Hard** (schema-shape freeze) |
+| Plaintext secret bytes never leave kernel/webhook | sealed `Source` + `Source.Encrypt` / `NewSourceFromCiphertext`; no API returns the raw secret, the only bytes entry is the validated minter `NewSource`; repo/composition handle only ciphertext | **Hard** (type-system funnel) |
+| Cross-source / cross-cell ciphertext transplant rejected | AAD computed by the kernel from the sealed id (`cell:webhook/source:{id}`, distinct from configcore's domain), AES-GCM tag fails closed | **Hard** (cryptographic + unrepresentable wrong AAD) |
+| Secret never logged / to wire | existing `Source.LogValue/String/GoString` redaction + `WEBHOOK-HMAC-FUNNEL-01` | **Hard** (existing) |
+| Postgres persistence requires a transformer | loader fail-closed (nil key provider → error); no `NoopTransformer` path for webhook secrets | Medium (runtime guard) |
+
+No new archtest invariant is added: the three load-bearing properties are locked
+by schema-shape + type-system + cryptography (the AI-robust charter's top-priority
+carriers), which is stronger than a scan.
+
+## Alternatives considered
+
+- **configcore entries under a platform tenant** — max reuse, but invents a
+  synthetic platform tenant (fights the removed `SystemTenantID`) and adds a
+  boot-time cross-cell read. Rejected.
+- **Vault KV direct** — cleanest "secret manager" story, but the vault adapter is
+  Transit-only (would need a new KV client) and makes Vault a hard dependency for
+  any persistence. Rejected; vault-transit is still available as the KMS *behind*
+  the dedicated store.
+
+## Key-provider wiring
+
+`cellmodules/webhooksource` builds its key provider from `GOCELL_WEBHOOK_*` env,
+mirroring `cellmodules/configcore`'s factory rather than sharing it: there are
+only two consumers, and the go-standards "重复三次才抽" guideline defers
+extraction to a third. The vault-transit branch reuses configcore's vault metric
+names; the metrics provider returns the already-registered collectors on a
+duplicate name, so running both configcore and webhook on vault-transit is safe.
+
+## Consequences
+
+- Webhook secrets persist encrypted; a restart re-loads them — no code-resident
+  secrets in PG-backed deployments.
+- `cmd/corebundle` declares no webhook receivers today, so the loader ships as a
+  tested, public composition helper (not force-wired into corebundle) ready for a
+  webhook-serving assembly; the repo's encrypt/decrypt/AAD roundtrip is proven by
+  an integration test against real PostgreSQL + local-AES.
+- Follow-up: a self-service webhook-source admin HTTP endpoint (CRUD + authz),
+  tracked as a separate backlog issue.

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -4,6 +4,10 @@ This document lists all environment variables consumed by `cmd/corebundle` at st
 Variables without a default value are **required** in the indicated adapter mode.
 Missing required variables cause fail-fast before any assembly initialization.
 
+> **Exception:** the [webhook source secret encryption](#webhook-source-secret-encryption)
+> section is consumed by **assemblies that call `cellmodules/webhooksource.LoadSourceStore`**,
+> not by `cmd/corebundle` (which declares no webhook receivers today). It is flagged inline.
+
 ## JWT Configuration (required in all modes)
 
 | Variable | Purpose | Default | Required | Notes |
@@ -140,8 +144,15 @@ Probe `postgres_app_role_restricted_ready` verifies at runtime that the serving 
 
 Persistent, encrypted webhook source HMAC secrets (#1540). Same envelope-encryption
 backends as configcore; vault-transit reuses the shared `VAULT_*` / `GOCELL_VAULT_*`
-settings above. Required only for assemblies that persist webhook sources (postgres
-storage) — memory/demo deployments seed the in-memory `kwh.SourceRegistry` directly.
+settings above.
+
+> **Not consumed by `cmd/corebundle` today** (unlike the rest of this document).
+> These variables are read by `cellmodules/webhooksource.LoadSourceStore`, which a
+> webhook-serving **assembly** calls at boot to load the persistent encrypted
+> `SourceStore`. `cmd/corebundle` declares no webhook receivers and does not invoke
+> the loader, so setting `GOCELL_WEBHOOK_*` has no effect on the current corebundle.
+> Required only for assemblies that persist webhook sources (postgres storage) —
+> memory/demo deployments seed the in-memory `kwh.SourceRegistry` directly.
 
 | Variable | Purpose | Default | Required | Notes |
 |---|---|---|---|---|

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -136,6 +136,19 @@ Probe `postgres_app_role_restricted_ready` verifies at runtime that the serving 
 | `GOCELL_VAULT_TRANSIT_KEY` | Vault Transit key name | `gocell-config` | No | |
 | `GOCELL_VAULT_STARTUP_TIMEOUT` | Total startup I/O deadline (auth Login + optional unwrap + initial key metadata read) | `30s` | No | `time.ParseDuration` format (e.g. `45s`, `2m`). Must be positive; malformed or non-positive values fail fast. Increase for high-latency networks or wrapped-token paths that require multiple TLS round-trips. |
 
+### webhook source secret encryption
+
+Persistent, encrypted webhook source HMAC secrets (#1540). Same envelope-encryption
+backends as configcore; vault-transit reuses the shared `VAULT_*` / `GOCELL_VAULT_*`
+settings above. Required only for assemblies that persist webhook sources (postgres
+storage) — memory/demo deployments seed the in-memory `kwh.SourceRegistry` directly.
+
+| Variable | Purpose | Default | Required | Notes |
+|---|---|---|---|---|
+| `GOCELL_WEBHOOK_KEY_PROVIDER` | Selects the encryption backend for persisted webhook source secrets | — | **postgres mode (when persisting webhook sources)** | `"local-aes"` (dev/CI) or `"vault-transit"` (production). The persistent SourceStore loader fails fast if unset; there is no plaintext fallback (the `webhook_sources` table has no plaintext column). |
+| `GOCELL_WEBHOOK_MASTER_KEY` | 32-byte hex-encoded AES key for `local-aes` provider | — | When `GOCELL_WEBHOOK_KEY_PROVIDER=local-aes` | Generate: `openssl rand -hex 32`. Real mode rejects well-known demo keys. |
+| `GOCELL_WEBHOOK_MASTER_KEY_PREVIOUS` | Previous master key for key rotation | — | No | Optional; enables decryption of secrets encrypted with the prior key during the rotation window (`local-aes` only). |
+
 ### Required Vault transit policy
 
 The provider needs `read` on the key metadata, `update` on `datakey/plaintext` (the encrypt path), `update` on `decrypt`, and `update` on `rotate`. Apply this HCL at the role's policy:

--- a/kernel/webhook/doc.go
+++ b/kernel/webhook/doc.go
@@ -40,7 +40,13 @@
 //     store (adapters/postgres webhook_sources, wired by cellmodules/webhooksource)
 //     loads its secrets through the sealed crypto funnel [Source.Encrypt] /
 //     [NewSourceFromCiphertext] at boot and serves them from a SourceRegistry
-//     snapshot — the plaintext secret never leaves this package.
+//     snapshot. The repo only ever holds the sealed [Source] type and ciphertext
+//     columns — the plaintext is never a loose returnable value outside this
+//     package (Hard: sealed secret, no getter). It IS observed by the
+//     caller-supplied [kcrypto.ValueTransformer] that Encrypt/Decrypt run, so
+//     "no in-process code sees the plaintext" is a composition-root trust
+//     property (Medium), locked by WEBHOOK-SOURCE-CRYPTO-FUNNEL-01 to the sole
+//     sanctioned caller (the persistence repo) — see [Source.Encrypt].
 //
 // # Signing scheme (Svix-aligned)
 //

--- a/kernel/webhook/doc.go
+++ b/kernel/webhook/doc.go
@@ -36,8 +36,11 @@
 //     in-package implementations are the HMAC-SHA256 signer/verifier built by
 //     [NewHMACSigner] / [NewHMACVerifier]; [Signer.Sign] returns a [SignedHeaders].
 //   - [SourceStore] / [SourceRegistry] — secret lookup interface + in-memory
-//     implementation (externally replaceable; persistent stores are a
-//     follow-up).
+//     implementation (externally replaceable). A persistent encrypted backing
+//     store (adapters/postgres webhook_sources, wired by cellmodules/webhooksource)
+//     loads its secrets through the sealed crypto funnel [Source.Encrypt] /
+//     [NewSourceFromCiphertext] at boot and serves them from a SourceRegistry
+//     snapshot — the plaintext secret never leaves this package.
 //
 // # Signing scheme (Svix-aligned)
 //

--- a/kernel/webhook/sourcecrypto.go
+++ b/kernel/webhook/sourcecrypto.go
@@ -28,12 +28,19 @@ func sourceAAD(id SourceID) []byte {
 }
 
 // Encrypt seals this source's secret under vt's current key, binding the
-// ciphertext to the source id via [sourceAAD]. It is the only sanctioned path
-// to turn a webhook secret into ciphertext: the plaintext secret never leaves
-// this package — callers receive only the [kcrypto.EncryptResult] (ciphertext +
-// key metadata) to persist, never the raw bytes. Together with [Source] having
-// no secret getter, this makes a plaintext webhook secret unrepresentable
-// outside kernel/webhook and the transformer internals.
+// ciphertext to the source id via [sourceAAD]. Callers receive only the
+// [kcrypto.EncryptResult] (ciphertext + key metadata) to persist: the secret
+// never materializes as a loose returnable slice outside this package, and
+// [Source] has no secret getter. That part is Hard — a plaintext webhook secret
+// is unrepresentable as a returnable value outside kernel/webhook.
+//
+// The encryption itself runs inside the caller-supplied vt (vt.Encrypt sees
+// s.secret), so "no in-process code observes the plaintext" is NOT a type-system
+// property — it rests on vt being the trusted, composition-root-built
+// transformer. The sole sanctioned caller is the persistence repo
+// (adapters/postgres.WebhookSourceRepository), enforced at Medium by
+// WEBHOOK-SOURCE-CRYPTO-FUNNEL-01; that repo additionally rejects a passthrough
+// NoopTransformer, so a plaintext secret cannot land at rest either.
 //
 // A zero-value Source (empty secret — i.e. one not built via [NewSource]) is
 // rejected with [errcode.ErrWebhookConfigInvalid]; vt must be non-nil.
@@ -64,7 +71,10 @@ func (s Source) Encrypt(ctx context.Context, vt kcrypto.ValueTransformer) (kcryp
 // fail-closed with [errcode.ErrWebhookSecretCryptoFailed].
 //
 // vt must be non-nil. The recovered secret is still subject to [NewSource]'s
-// length floor, so a too-short decrypted secret is rejected.
+// length floor, so a too-short decrypted secret is rejected. Like
+// [Source.Encrypt], its sole sanctioned caller is the persistence repo
+// (adapters/postgres.WebhookSourceRepository), enforced by
+// WEBHOOK-SOURCE-CRYPTO-FUNNEL-01.
 func NewSourceFromCiphertext(
 	ctx context.Context, vt kcrypto.ValueTransformer,
 	id SourceID, ciphertext []byte, keyID string, nonce, edk []byte,

--- a/kernel/webhook/sourcecrypto.go
+++ b/kernel/webhook/sourcecrypto.go
@@ -1,0 +1,82 @@
+package webhook
+
+import (
+	"context"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// sourceAAD computes the Additional Authenticated Data that binds a webhook
+// source secret's ciphertext to its owning source. AES-GCM authenticates the
+// AAD, so any mismatch surfaces as a decryption (tag) failure — fail-closed.
+//
+// The "cell:webhook/source:" domain prefix is deliberately distinct from
+// configcore's "cell:configcore/..." AAD (see corecells configcore crypto), so a
+// ciphertext encrypted for a config entry can never be transplanted into a
+// webhook source row and decrypt, and vice versa. The trailing source id binds
+// the ciphertext to one source so a row cannot be moved under a different id.
+// Unlike configcore, there is no tenant segment: webhook sources are global (the
+// [SourceStore] lookup carries no tenant), so the id alone is the identity.
+//
+// The AAD is computed here — inside the package that owns the sealed secret —
+// rather than supplied by the persistence layer, so a backing store cannot pass
+// a wrong or absent AAD and weaken the binding (the domain-isolation guarantee
+// is a type-system property, not repo discipline).
+func sourceAAD(id SourceID) []byte {
+	return []byte("cell:webhook/source:" + string(id))
+}
+
+// Encrypt seals this source's secret under vt's current key, binding the
+// ciphertext to the source id via [sourceAAD]. It is the only sanctioned path
+// to turn a webhook secret into ciphertext: the plaintext secret never leaves
+// this package — callers receive only the [kcrypto.EncryptResult] (ciphertext +
+// key metadata) to persist, never the raw bytes. Together with [Source] having
+// no secret getter, this makes a plaintext webhook secret unrepresentable
+// outside kernel/webhook and the transformer internals.
+//
+// A zero-value Source (empty secret — i.e. one not built via [NewSource]) is
+// rejected with [errcode.ErrWebhookConfigInvalid]; vt must be non-nil.
+func (s Source) Encrypt(ctx context.Context, vt kcrypto.ValueTransformer) (kcrypto.EncryptResult, error) {
+	if len(s.secret) == 0 {
+		return kcrypto.EncryptResult{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: cannot encrypt a source with an empty secret")
+	}
+	if vt == nil {
+		return kcrypto.EncryptResult{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: cannot encrypt a source without a value transformer")
+	}
+	res, err := vt.Encrypt(ctx, s.secret, sourceAAD(s.id))
+	if err != nil {
+		return kcrypto.EncryptResult{}, errcode.Wrap(errcode.KindInternal,
+			errcode.ErrWebhookSecretCryptoFailed, "webhook: encrypt source secret failed", err)
+	}
+	return res, nil
+}
+
+// NewSourceFromCiphertext decrypts a persisted cipher tuple via vt and returns
+// the sealed [Source]. It is the read-path counterpart to [Source.Encrypt]: the
+// recovered plaintext is handed straight to [NewSource] and never returned to
+// the caller as raw bytes, so a persistent [SourceStore] reconstructs sources
+// without ever materializing a loose secret slice. The AAD is recomputed from id
+// (see [sourceAAD]); a tuple whose AAD does not match — e.g. a ciphertext moved
+// under a different source id — fails the AES-GCM tag check and is rejected
+// fail-closed with [errcode.ErrWebhookSecretDecryptFailed].
+//
+// vt must be non-nil. The recovered secret is still subject to [NewSource]'s
+// length floor, so a too-short decrypted secret is rejected.
+func NewSourceFromCiphertext(
+	ctx context.Context, vt kcrypto.ValueTransformer,
+	id SourceID, ciphertext []byte, keyID string, nonce, edk []byte,
+) (Source, error) {
+	if vt == nil {
+		return Source{}, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook: cannot decrypt a source without a value transformer")
+	}
+	pt, err := vt.Decrypt(ctx, ciphertext, keyID, nonce, edk, sourceAAD(id))
+	if err != nil {
+		return Source{}, errcode.Wrap(errcode.KindInternal,
+			errcode.ErrWebhookSecretCryptoFailed, "webhook: decrypt source secret failed", err)
+	}
+	return NewSource(id, pt)
+}

--- a/kernel/webhook/sourcecrypto.go
+++ b/kernel/webhook/sourcecrypto.go
@@ -61,7 +61,7 @@ func (s Source) Encrypt(ctx context.Context, vt kcrypto.ValueTransformer) (kcryp
 // without ever materializing a loose secret slice. The AAD is recomputed from id
 // (see [sourceAAD]); a tuple whose AAD does not match — e.g. a ciphertext moved
 // under a different source id — fails the AES-GCM tag check and is rejected
-// fail-closed with [errcode.ErrWebhookSecretDecryptFailed].
+// fail-closed with [errcode.ErrWebhookSecretCryptoFailed].
 //
 // vt must be non-nil. The recovered secret is still subject to [NewSource]'s
 // length floor, so a too-short decrypted secret is rejected.

--- a/kernel/webhook/sourcecrypto_test.go
+++ b/kernel/webhook/sourcecrypto_test.go
@@ -1,0 +1,148 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kcrypto "github.com/ghbvf/gocell/kernel/crypto"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// fakeVT is an AAD-binding identity transformer for funnel tests. Encrypt copies
+// the plaintext into Ciphertext and records the AAD in EDK; Decrypt fails unless
+// the caller-supplied AAD matches the recorded EDK — modeling AES-GCM's tag
+// check over the AAD without real crypto. failEncrypt / failDecrypt force the
+// error paths.
+type fakeVT struct {
+	failEncrypt bool
+	failDecrypt bool
+}
+
+func (f fakeVT) Encrypt(_ context.Context, pt, aad []byte) (kcrypto.EncryptResult, error) {
+	if f.failEncrypt {
+		return kcrypto.EncryptResult{}, errors.New("kms unavailable")
+	}
+	return kcrypto.EncryptResult{
+		Ciphertext: append([]byte(nil), pt...),
+		Nonce:      []byte("nonce"),
+		EDK:        append([]byte(nil), aad...),
+		KeyID:      "fake-v1",
+	}, nil
+}
+
+func (f fakeVT) Decrypt(_ context.Context, ct []byte, _ string, _, edk, aad []byte) ([]byte, error) {
+	if f.failDecrypt {
+		return nil, errors.New("kms unavailable")
+	}
+	// AES-GCM authenticates the AAD: a tuple whose encrypt-time AAD (recorded in
+	// edk) differs from the decrypt-time AAD fails the tag check.
+	if !bytes.Equal(edk, aad) {
+		return nil, errors.New("aad mismatch (tag check failed)")
+	}
+	return append([]byte(nil), ct...), nil
+}
+
+func mustSource(t *testing.T, id, secret string) Source {
+	t.Helper()
+	sid, err := NewSourceID(id)
+	require.NoError(t, err)
+	src, err := NewSource(sid, []byte(secret))
+	require.NoError(t, err)
+	return src
+}
+
+const testSecret = "0123456789abcdef01234567" // 24 bytes, the minimum secret length
+
+// TestSourceEncrypt_Roundtrip proves the sealed funnel preserves the secret:
+// Encrypt → NewSourceFromCiphertext yields a Source whose secret equals the
+// original, while the plaintext is only ever handed back through the sealed type.
+func TestSourceEncrypt_Roundtrip(t *testing.T) {
+	ctx := context.Background()
+	vt := fakeVT{}
+	src := mustSource(t, "github", testSecret)
+
+	res, err := src.Encrypt(ctx, vt)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-v1", res.KeyID)
+	assert.Equal(t, []byte(testSecret), res.Ciphertext)
+
+	got, err := NewSourceFromCiphertext(ctx, vt, src.ID(), res.Ciphertext, res.KeyID, res.Nonce, res.EDK)
+	require.NoError(t, err)
+	assert.Equal(t, src.ID(), got.ID())
+	// Internal-package access: the decrypted secret round-trips byte-for-byte.
+	assert.Equal(t, []byte(testSecret), got.secret)
+}
+
+// TestNewSourceFromCiphertext_AADTransplantRejected proves the AAD binds the
+// ciphertext to its source id: a tuple encrypted for "github" cannot be decrypted
+// under "stripe" (cross-source transplant), fail-closed.
+func TestNewSourceFromCiphertext_AADTransplantRejected(t *testing.T) {
+	ctx := context.Background()
+	vt := fakeVT{}
+	src := mustSource(t, "github", testSecret)
+	res, err := src.Encrypt(ctx, vt)
+	require.NoError(t, err)
+
+	other, err := NewSourceID("stripe")
+	require.NoError(t, err)
+
+	_, err = NewSourceFromCiphertext(ctx, vt, other, res.Ciphertext, res.KeyID, res.Nonce, res.EDK)
+	requireErrCode(t, err, errcode.ErrWebhookSecretCryptoFailed, errcode.KindInternal)
+}
+
+func TestSourceEncrypt_ErrorPaths(t *testing.T) {
+	ctx := context.Background()
+	src := mustSource(t, "github", testSecret)
+
+	t.Run("empty secret (zero-value Source)", func(t *testing.T) {
+		_, err := Source{}.Encrypt(ctx, fakeVT{})
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+	t.Run("nil transformer", func(t *testing.T) {
+		_, err := src.Encrypt(ctx, nil)
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+	t.Run("transformer encrypt failure", func(t *testing.T) {
+		_, err := src.Encrypt(ctx, fakeVT{failEncrypt: true})
+		requireErrCode(t, err, errcode.ErrWebhookSecretCryptoFailed, errcode.KindInternal)
+	})
+}
+
+func TestNewSourceFromCiphertext_ErrorPaths(t *testing.T) {
+	ctx := context.Background()
+	id, err := NewSourceID("github")
+	require.NoError(t, err)
+	aad := sourceAAD(id)
+
+	t.Run("nil transformer", func(t *testing.T) {
+		_, err := NewSourceFromCiphertext(ctx, nil, id, []byte(testSecret), "fake-v1", nil, aad)
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+	t.Run("transformer decrypt failure", func(t *testing.T) {
+		_, err := NewSourceFromCiphertext(ctx, fakeVT{failDecrypt: true}, id, []byte(testSecret), "fake-v1", nil, aad)
+		requireErrCode(t, err, errcode.ErrWebhookSecretCryptoFailed, errcode.KindInternal)
+	})
+	t.Run("decrypted secret below length floor", func(t *testing.T) {
+		// A valid AAD but a too-short recovered secret must be rejected by
+		// NewSource's length floor, not silently accepted.
+		_, err := NewSourceFromCiphertext(ctx, fakeVT{}, id, []byte("short"), "fake-v1", nil, aad)
+		requireErrCode(t, err, errcode.ErrWebhookConfigInvalid, errcode.KindInvalid)
+	})
+}
+
+// TestSourceAAD_DomainIsolation locks the AAD shape: the webhook domain prefix is
+// distinct from configcore's, and the id is bound in.
+func TestSourceAAD_DomainIsolation(t *testing.T) {
+	gh, err := NewSourceID("github")
+	require.NoError(t, err)
+	stripe, err := NewSourceID("stripe")
+	require.NoError(t, err)
+
+	assert.Equal(t, "cell:webhook/source:github", string(sourceAAD(gh)))
+	assert.NotEqual(t, sourceAAD(gh), sourceAAD(stripe))
+}

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -834,6 +834,14 @@ const (
 	// ErrWebhookConfigInvalid signals invalid webhook configuration (bad source
 	// ID / delivery ID / empty secret). Constructed with KindInvalid → HTTP 400.
 	ErrWebhookConfigInvalid Code = "ERR_WEBHOOK_CONFIG_INVALID"
+	// ErrWebhookSecretCryptoFailed signals that a persisted webhook source secret
+	// could not be sealed (encrypt, e.g. KMS unavailable) or unsealed (decrypt:
+	// wrong key version, AAD mismatch / ciphertext transplanted across source
+	// IDs, or a corrupt cipher tuple). Constructed with KindInternal → HTTP 500.
+	// Fail-closed: the persistent SourceStore loader refuses to start rather than
+	// serve a source whose secret cannot be recovered. First constructed in #1540
+	// (webhook source secret persistence).
+	ErrWebhookSecretCryptoFailed Code = "ERR_WEBHOOK_SECRET_CRYPTO_FAILED"
 
 	// Reconcile leader-election / epoch-fencing codes (KERNEL-RECONCILE-01 PR-A6).
 	//

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -52,9 +52,10 @@ func TestWebhookSentinelCodes(t *testing.T) {
 		{ErrWebhookPermanentFailure, "ERR_WEBHOOK_PERMANENT_FAILURE"},
 		{ErrWebhookBodyTooLarge, "ERR_WEBHOOK_BODY_TOO_LARGE"},
 		{ErrWebhookConfigInvalid, "ERR_WEBHOOK_CONFIG_INVALID"},
+		{ErrWebhookSecretCryptoFailed, "ERR_WEBHOOK_SECRET_CRYPTO_FAILED"},
 	}
-	if len(cases) != 11 {
-		t.Fatalf("expected 11 webhook sentinels, got %d", len(cases))
+	if len(cases) != 12 {
+		t.Fatalf("expected 12 webhook sentinels, got %d", len(cases))
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/runtime/webhook/sourcerepo.go
+++ b/runtime/webhook/sourcerepo.go
@@ -23,7 +23,8 @@ import (
 // each ciphertext to its source id is computed by the kernel funnel, not passed
 // across this interface, so an implementation cannot weaken the binding.
 //
-// Implemented by adapters/postgres.WebhookSourceRepository.
+// A PostgreSQL implementation lives in adapters/postgres; composition-root wiring
+// (build + LoadAll + snapshot) lives in cellmodules/webhooksource.
 type SourceRepo interface {
 	// Upsert seals src's secret and persists it under src.ID(), inserting a new
 	// row or replacing the existing one (idempotent re-seed / secret rotation).

--- a/runtime/webhook/sourcerepo.go
+++ b/runtime/webhook/sourcerepo.go
@@ -1,0 +1,39 @@
+package webhook
+
+import (
+	"context"
+
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+)
+
+// SourceRepo is the persistence seam behind a durable, encrypted webhook
+// [kwh.SourceStore]. The composition root (cellmodules/webhooksource) calls
+// [SourceRepo.LoadAll] once at boot, feeds the recovered sources into a
+// [kwh.SourceRegistry] snapshot, and injects that snapshot via
+// bootstrap.WithWebhookSourceStore — so the runtime Lookup hot path stays a pure
+// in-memory read (matching the eager-register-at-startup, immutable-at-runtime
+// contract of the in-memory default).
+//
+// The seam deals exclusively in the sealed [kwh.Source] type: Upsert takes a
+// Source (built from the operator-supplied secret via [kwh.NewSource]) and
+// LoadAll returns Sources. A raw secret []byte never crosses this interface —
+// the secret is sealed/unsealed through [kwh.Source.Encrypt] /
+// [kwh.NewSourceFromCiphertext] inside the implementation, so a backing store
+// holds only ciphertext and never a loose plaintext secret. The AAD that binds
+// each ciphertext to its source id is computed by the kernel funnel, not passed
+// across this interface, so an implementation cannot weaken the binding.
+//
+// Implemented by adapters/postgres.WebhookSourceRepository.
+type SourceRepo interface {
+	// Upsert seals src's secret and persists it under src.ID(), inserting a new
+	// row or replacing the existing one (idempotent re-seed / secret rotation).
+	Upsert(ctx context.Context, src kwh.Source) error
+
+	// LoadAll unseals and returns every persisted source. The returned order is
+	// unspecified. An empty store yields an empty (non-nil) slice, not an error.
+	LoadAll(ctx context.Context) ([]kwh.Source, error)
+
+	// Delete removes the persisted source registered under id. Deleting an id
+	// that is not present is not an error (idempotent).
+	Delete(ctx context.Context, id kwh.SourceID) error
+}

--- a/tools/archtest/internal/webhooksourcecryptofixture/fixture.go
+++ b/tools/archtest/internal/webhooksourcecryptofixture/fixture.go
@@ -1,0 +1,56 @@
+//go:build archtest_fixture
+
+// Package webhooksourcecryptofixture is the WEBHOOK-SOURCE-CRYPTO-FUNNEL-01
+// negative fixture. It calls the two sealed webhook-secret crypto entry points —
+// kwh.Source.Encrypt and kwh.NewSourceFromCiphertext — from functions that are
+// NOT the sanctioned persistence repo, exercising every use shape the rule
+// catches: direct call and function/method-value capture.
+//
+// Loaded only when the archtest_fixture build tag is set (so the production
+// Production scan never compiles it). Never imported from production code. The
+// scanner pointed at this package with the real caller-allowlist must report one
+// violation per use below:
+//
+//  1. badEncrypt          — direct call s.Encrypt(...).
+//  2. badDecrypt          — direct call kwh.NewSourceFromCiphertext(...).
+//  3. badEncryptCapture   — method-value capture m := s.Encrypt.
+//  4. badDecryptCapture   — function-value capture fn := kwh.NewSourceFromCiphertext.
+//
+// Total: 4 violations. A caller in any of these positions could supply its own
+// ValueTransformer and capture the raw secret at vt.Encrypt — exactly what the
+// caller-allowlist forecloses.
+//
+// DO NOT use this package in production code.
+package webhooksourcecryptofixture
+
+import (
+	"context"
+
+	kwh "github.com/ghbvf/gocell/kernel/webhook"
+)
+
+// badEncrypt calls Source.Encrypt outside the sanctioned repo — a caller here
+// could pass a capturing transformer and read the plaintext secret. VIOLATION.
+func badEncrypt(ctx context.Context, s kwh.Source) {
+	_, _ = s.Encrypt(ctx, nil) // VIOLATION: non-repo caller of Source.Encrypt
+}
+
+// badDecrypt calls NewSourceFromCiphertext outside the sanctioned repo.
+// VIOLATION.
+func badDecrypt(ctx context.Context) {
+	_, _ = kwh.NewSourceFromCiphertext(ctx, nil, kwh.SourceID("github"), nil, "", nil, nil) // VIOLATION
+}
+
+// badEncryptCapture captures Source.Encrypt as a method value — the function-
+// value-capture bypass form (a direct-call-only scan would miss it). VIOLATION.
+func badEncryptCapture(s kwh.Source) {
+	m := s.Encrypt // VIOLATION: method-value capture of Source.Encrypt
+	_ = m
+}
+
+// badDecryptCapture captures NewSourceFromCiphertext as a function value — the
+// function-value-capture bypass form. VIOLATION.
+func badDecryptCapture() {
+	fn := kwh.NewSourceFromCiphertext // VIOLATION: function-value capture
+	_ = fn
+}

--- a/tools/archtest/webhook_source_crypto_funnel_test.go
+++ b/tools/archtest/webhook_source_crypto_funnel_test.go
@@ -1,0 +1,257 @@
+//go:build archtest
+
+// INVARIANT: WEBHOOK-SOURCE-CRYPTO-FUNNEL-01
+//
+// webhook_source_crypto_funnel_test.go — caller-allowlist for the two sealed
+// webhook-secret crypto entry points in kernel/webhook:
+//
+//   - kwh.Source.Encrypt(ctx, vt) — seals a source secret into ciphertext.
+//   - kwh.NewSourceFromCiphertext(ctx, vt, ...) — reconstructs a sealed Source.
+//
+// # What this guards (cluster C1, PR #1929 / #1540)
+//
+// Both entry points take a CALLER-SUPPLIED kcrypto.ValueTransformer and feed the
+// raw secret through it (sourcecrypto.go: vt.Encrypt(ctx, s.secret, aad)). Any
+// package that holds a webhook.Source (e.g. from SourceStore.Lookup) could pass a
+// transformer that captures the plaintext at that hop. The plaintext therefore
+// does NOT "never leave kernel/webhook" as a type-system property — it leaves
+// through whatever ValueTransformer the caller supplies.
+//
+// This rule locks the WRITE/READ crypto sites to the single sanctioned holder of
+// the trusted, composition-root-built transformer: the persistence repo
+// adapters/postgres.WebhookSourceRepository (Upsert / LoadAll). A new caller that
+// wires its own transformer trips CI. Combined with the repo constructor
+// rejecting a passthrough NoopTransformer (F2), the cluster's "no plaintext
+// observed / no plaintext at rest" promise is enforced at Medium.
+//
+// # AI-robust rating
+//
+//   - Rating: MEDIUM (caller-allowlist archtest, type-aware go/types scan).
+//   - Downstream enforcement: walk every ident; match info.Uses *types.Func
+//     FullName against the two sealed entry points; require the enclosing func
+//     FullName ∈ webhookSourceCryptoCallerAllowlist. Covers direct call,
+//     parenthesized call, and function/method-value capture (a direct-call-only
+//     scan would miss `fn := kwh.NewSourceFromCiphertext`). The match is on
+//     go/types FullName (package-path qualified), so a same-named symbol in
+//     another package cannot inherit the allowance, and import aliases / dot-
+//     imports cannot bypass it.
+//   - Upstream: the secret field itself is sealed Hard — Source.secret is
+//     unexported with no getter, and the ONLY bytes entry is the validated minter
+//     NewSource (so the plaintext never materializes as a loose returnable slice
+//     outside kernel/webhook). What is Medium, not Hard, is "no in-process code
+//     observes the plaintext during encryption": that rests on the caller being
+//     the trusted repo with a real KMS-backed transformer, which this rule (the
+//     caller location) + F2 (the repo rejecting Noop) enforce.
+//   - Permanent ceiling: Go visibility cannot express "only adapters/postgres may
+//     call this EXPORTED method" at the type system — the method must be exported
+//     for a different module to call it at all. A type-system Hard would require
+//     the encrypt capability to be a sealed token minted only inside the trusted
+//     path, but the transformer is necessarily reached via an open interface
+//     (ValueTransformer / KeyHandle) that an in-process adversary can implement,
+//     so the boundary only moves down a level — same permanent ceiling family as
+//     WEBHOOK-HMAC-FUNNEL-01/A3-A4 (#851 / #893 / #1282 / #1375 / #1243). The
+//     archtest is the downstream Medium backstop for the realistic regression
+//     vector: a NEW caller wiring its own transformer.
+//
+// # register=no — gocell-internal-layout
+//
+// This rule references the sanctioned repo's FullName (adapters/postgres) which
+// an external Cell repo lacks, so it is NOT in StandardCellRules() and not
+// promised to run externally — dogfooded by TestWebhookSourceCryptoFunnel below.
+//
+// # Blind spots (ai-robust 强制反向自检; reverse self-tests below)
+//
+//	B1 — rule-logic regression / vacuous pass:
+//	  TestWebhookSourceCryptoFunnel_AntiVacuity re-runs the scan over REAL
+//	  production with an EMPTY allowlist and asserts it fires on the ≥2 real
+//	  callers (repo Upsert + LoadAll) — proving the scan detects the symbols and
+//	  the real allowlist is what makes production GREEN (non-vacuous).
+//	B2 — use-shape coverage: the archtest_fixture RED module
+//	  (internal/webhooksourcecryptofixture) calls both entry points via direct
+//	  call AND value-capture from a non-repo context;
+//	  TestWebhookSourceCryptoFunnel_ReverseFixture asserts every shape fires.
+//	B3 — reflect/unsafe dynamic dispatch of Source.Encrypt bypasses the ident
+//	  scan (no SelectorExpr). Not present in production today; a reflective call
+//	  to an exported method on a value with an unexported secret field is
+//	  conspicuous in review. Documented, not machine-checked (same class as the
+//	  audit-trace reflect blind spot).
+//
+// ref: tools/archtest/audit_trace_id_write_caller_test.go (exported-symbol caller-allowlist over Production)
+// ref: tools/archtest/webhook_hmac_funnel.go (A4 computeMAC caller-allowlist)
+// ref: docs/architecture/202606122050-1540-adr-webhook-source-persistence.md
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// webhookSourceCryptoRuleID is the single source for this rule's ID, used in the
+// Report call and every assertion message.
+const webhookSourceCryptoRuleID = "WEBHOOK-SOURCE-CRYPTO-FUNNEL-01"
+
+const (
+	// webhookSourceEncryptFunc / webhookNewSourceFromCiphertextFunc are the
+	// go/types FullNames of the two sealed webhook-secret crypto entry points.
+	// Source.Encrypt is a value-receiver method → "(pkg.Source).Encrypt";
+	// NewSourceFromCiphertext is a free func → "pkg.NewSourceFromCiphertext".
+	// Anchored to PlatformModulePath so a module rename updates one place.
+	webhookSourceEncryptFunc           = "(" + PlatformModulePath + "/kernel/webhook.Source).Encrypt"
+	webhookNewSourceFromCiphertextFunc = PlatformModulePath + "/kernel/webhook.NewSourceFromCiphertext"
+
+	// webhookSourceRepoUpsertFunc / webhookSourceRepoLoadAllFunc are the go/types
+	// FullNames of the ONLY two functions permitted to call the sealed entry
+	// points: the postgres persistence repo's pointer-receiver methods.
+	webhookSourceRepoUpsertFunc  = "(*" + PlatformModulePath + "/adapters/postgres.WebhookSourceRepository).Upsert"
+	webhookSourceRepoLoadAllFunc = "(*" + PlatformModulePath + "/adapters/postgres.WebhookSourceRepository).LoadAll"
+)
+
+// webhookSourceCryptoSealedFuncs is the closed set of crypto entry-point
+// FullNames this rule guards.
+var webhookSourceCryptoSealedFuncs = map[string]bool{
+	webhookSourceEncryptFunc:           true,
+	webhookNewSourceFromCiphertextFunc: true,
+}
+
+// webhookSourceCryptoCallerAllowlist is the set of go/types FullNames permitted
+// to call the sealed crypto entry points. Only the sanctioned persistence repo
+// holds the trusted composition-root transformer; any other caller could supply
+// its own and capture the raw secret.
+var webhookSourceCryptoCallerAllowlist = map[string]bool{
+	webhookSourceRepoUpsertFunc:  true,
+	webhookSourceRepoLoadAllFunc: true,
+}
+
+// scanWebhookSourceCryptoCallers reports every USE of a sealed webhook-secret
+// crypto entry point (Source.Encrypt / NewSourceFromCiphertext) whose enclosing
+// func is not in allowlist. It walks every identifier and matches info.Uses to
+// the guarded FullNames, so ALL use forms are covered — direct call,
+// parenthesized call, and function/method-value capture. The symbols' own
+// declarations live in info.Defs (not info.Uses), so kernel/webhook never
+// false-fires on its definitions. Passing allowlist as a parameter lets the
+// anti-vacuity self-test re-run with an empty allowlist.
+func scanWebhookSourceCryptoCallers(
+	fset *token.FileSet, file *ast.File, rel string, info *types.Info, allowlist map[string]bool,
+) []Diagnostic {
+	var out []Diagnostic
+	EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+		fnObj, ok := info.Uses[id].(*types.Func)
+		if !ok || !webhookSourceCryptoSealedFuncs[fnObj.FullName()] {
+			return
+		}
+		if enc, ok := ResolveEnclosingFunc(info, file, id); ok && enc != nil && allowlist[enc.FullName()] {
+			return
+		}
+		out = append(out, Diagnostic{
+			Rel:  rel,
+			Line: fset.Position(id.Pos()).Line,
+			Message: "webhook source secret crypto (" + fnObj.Name() + ") used outside the sanctioned " +
+				"persistence repo; Source.Encrypt / NewSourceFromCiphertext may be called only by " +
+				"adapters/postgres.WebhookSourceRepository (Upsert/LoadAll), so a caller cannot supply " +
+				"its own ValueTransformer and capture the raw secret (WEBHOOK-SOURCE-CRYPTO-FUNNEL-01)",
+		})
+	})
+	return out
+}
+
+// scanWebhookSourceCryptoProduction runs scanWebhookSourceCryptoCallers over all
+// non-test production packages with the given allowlist and returns the union of
+// diagnostics. Shared by the GREEN dogfood (real allowlist) and the anti-vacuity
+// self-check (empty allowlist).
+func scanWebhookSourceCryptoProduction(t *testing.T, allowlist map[string]bool) []Diagnostic {
+	t.Helper()
+	var out []Diagnostic
+	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		for _, f := range p.Files {
+			rel := p.Rel(f)
+			if strings.HasSuffix(rel, "_test.go") {
+				continue
+			}
+			out = append(out, scanWebhookSourceCryptoCallers(p.Fset, f, rel, p.TypesInfo, allowlist)...)
+		}
+		return nil
+	})
+	return out
+}
+
+// TestWebhookSourceCryptoFunnel is the GREEN dogfood: with the real caller-
+// allowlist, no production code outside the sanctioned repo calls the sealed
+// crypto entry points.
+func TestWebhookSourceCryptoFunnel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	Report(t, webhookSourceCryptoRuleID,
+		scanWebhookSourceCryptoProduction(t, webhookSourceCryptoCallerAllowlist))
+}
+
+// TestWebhookSourceCryptoFunnel_AntiVacuity is the B1 self-check: re-run the scan
+// over REAL production with an EMPTY allowlist and assert it fires on the actual
+// callers (≥2: repo Upsert calling Source.Encrypt + repo LoadAll calling
+// NewSourceFromCiphertext). This proves the scan genuinely detects the symbols
+// and that the real allowlist — not a vacuous scan — is what makes production
+// GREEN.
+func TestWebhookSourceCryptoFunnel_AntiVacuity(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	fired := scanWebhookSourceCryptoProduction(t, map[string]bool{})
+
+	assert.GreaterOrEqual(t, len(fired), 2,
+		webhookSourceCryptoRuleID+" anti-vacuity: empty allowlist must fire on ≥2 real callers "+
+			"(repo Upsert→Source.Encrypt + repo LoadAll→NewSourceFromCiphertext); got %d — scan may be vacuous",
+		len(fired))
+	for i, d := range fired {
+		assert.NotEmpty(t, d.Rel, webhookSourceCryptoRuleID+" anti-vacuity: diagnostic[%d] has empty Rel (not clickable)", i)
+		assert.Greater(t, d.Line, 0, webhookSourceCryptoRuleID+" anti-vacuity: diagnostic[%d] Line = %d, want > 0", i, d.Line)
+	}
+}
+
+// TestWebhookSourceCryptoFunnel_ReverseFixture is the B2 self-check: scan the
+// archtest_fixture RED module with the REAL allowlist and assert the scanner
+// fires on every prohibited use shape (direct call + value capture, for both
+// entry points). The fixture lives behind the archtest_fixture build tag, so the
+// production scan above never sees it; here it is loaded explicitly via Fixture.
+func TestWebhookSourceCryptoFunnel_ReverseFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var fired []Diagnostic
+	_ = Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/webhooksourcecryptofixture"}),
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			for _, f := range p.Files {
+				rel := p.Rel(f)
+				fired = append(fired,
+					scanWebhookSourceCryptoCallers(p.Fset, f, rel, p.TypesInfo, webhookSourceCryptoCallerAllowlist)...)
+			}
+			return nil
+		})
+
+	// Four prohibited uses: badEncrypt (call), badDecrypt (call),
+	// badEncryptCapture (method value), badDecryptCapture (func value).
+	assert.GreaterOrEqual(t, len(fired), 4,
+		webhookSourceCryptoRuleID+" reverse fixture: expected ≥4 diagnostics from "+
+			"webhooksourcecryptofixture (badEncrypt + badDecrypt + badEncryptCapture + "+
+			"badDecryptCapture); got %d — a missing shape means the scan regressed", len(fired))
+	for i, d := range fired {
+		assert.NotEmpty(t, d.Rel, webhookSourceCryptoRuleID+" reverse fixture: diagnostic[%d] has empty Rel", i)
+		assert.Greater(t, d.Line, 0, webhookSourceCryptoRuleID+" reverse fixture: diagnostic[%d] Line = %d, want > 0", i, d.Line)
+	}
+}


### PR DESCRIPTION
## Summary

把 webhook source secret 从 in-memory `kwh.SourceRegistry` 持久化到专用全局加密表 `webhook_sources`，复用 `kernel/crypto.ValueTransformer`（vault-transit / local-aes）信封加密，启动期 eager load 解密成 `SourceRegistry` 快照注入运行时（Lookup 热路径与 bootstrap 签名零改动）。

## Why / 背景

KERNEL-WEBHOOK-01 follow-up（#1538 PR-6 closeout carve）。此前 webhook 签名密钥只在内存、硬编码在 composition root（`examples/webhookdemo`），无法在 PG-backed 部署中安全持久化。`kwh.SourceStore` 接缝（无 ctx/error/tenant 的热路径查询）按 issue 要求**只换实现不改签名**，故 webhook source 保持平台全局；configcore 严格 tenant-scoped 且 `SystemTenantID` 哨兵已被移除，强行走 configcore 需合成 platform-tenant，遂选**专用全局加密表**只复用 crypto 原语。

**安全模型**（pr-review C1/C2 后**重评**——见 ADR §安全模型：加密落盘 / AAD 域隔离 / secret 非可返回值 为 **Hard**，crypto-funnel caller 信任 + Noop 拒绝为 **Medium**，并**新增** `WEBHOOK-SOURCE-CRYPTO-FUNNEL-01` caller-allowlist archtest + `verifyFrozenColumnSets` 精确列集守卫；原「三项 Hard / 不新增 archtest」表述已作废）：
- **加密落盘** — `webhook_sources` 无明文列（`value_cipher NOT NULL`），明文落盘 schema 层不可表达；`schema_guard.go` 冻结列集。
- **密钥不逸出 kernel** — sealed `Source`（unexported secret、无 getter，唯一 bytes 入口是校验型 minter `NewSource`）= **Hard**；`Source.Encrypt`/`NewSourceFromCiphertext` 收 caller 提供的 transformer，故「明文不被任何 in-process 代码观测」是 composition-root 信任属性 = **Medium**，由 `WEBHOOK-SOURCE-CRYPTO-FUNNEL-01`（仅 sanctioned repo 可调）+ 构造器拒 Noop 守卫；repo/composition 只碰 ciphertext。
- **AAD 域隔离** — AAD 由 kernel 从 sealed id 内部计算（`cell:webhook/source:{id}`，与 configcore 域名互斥），AES-GCM tag fail-closed；跨 source/跨 cell ciphertext 移植被拒（集成测试用真 AES-GCM 验证）。

运行时不可变（eager load at boot），轮换/删除 = 写行 + 重启。`cmd/corebundle` 现无 webhook 消费者，装载器作公开受测 composition helper 交付，集成测试证活，待 webhook-serving assembly 出现时接线。

## Refs

- Closes #1540
- ADR: `docs/architecture/202606122050-1540-adr-webhook-source-persistence.md`
- ref: kubernetes/apiserver pkg/storage/value（信封加密 + AAD 由存储层计算）
- ref: cellmodules/configcore（sibling composition module；key-provider 模式镜像）
- follow-up（独立 backlog issue）：webhook-source 自助管理 HTTP 端点（CRUD contract + authz）

## Risk / 兼容性

- **Migration 063**（`webhook_sources`，全局表，无 tenant/RLS，无明文列，新表 forward DDL；Down 为可逆 `DROP TABLE`，对标 059）。新表只增不改既有表。
- **kernel/webhook 新增导出**：`Source.Encrypt` / `NewSourceFromCiphertext`（加方法，不改既有签名）；`SourceStore` / `WithWebhookSourceStore` 签名不动 → 无 wire/契约破坏。
- **新 errcode**：`ERR_WEBHOOK_SECRET_CRYPTO_FAILED`（既有 `ERR_WEBHOOK_` 前缀下新增 whole-code，prefix golden 无需改）。
- 无契约/事件/command wire 变更（contract-fanout 仅 schema-guard + migration）。

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./kernel/webhook/... ./adapters/postgres/ ./runtime/webhook/... ./cellmodules/webhooksource/... ./pkg/errcode/...` 通过
- [x] `go test -tags=integration ./adapters/postgres/ -run TestWebhookSourceRepository`（真 PG + local-aes）：roundtrip / upsert-replace / delete / multi-source / empty / **AAD transplant 拒绝** 全绿
- [x] `go test -tags=integration ./adapters/postgres/ -run TestVerifyExpectedShape`（live DB 校验 `webhook_sources` 列形）通过
- [x] `go test -tags=archtest ./tools/archtest/`：SCHEMA-GUARD-COVERS-EVERY-OWNED-TABLE / ERRCODE-PREFIX-OWNERSHIP / PG-REPO-AMBIENT-TX / ADAPTER-ERROR-CLASSIFICATION / WEBHOOK-HMAC-FUNNEL 全绿（3 个 unrelated 既有 develop-red 失败：cellgen/builder.go、policy/delete contract、kernel/projection，均不在本 PR diff）
- [x] `golangci-lint run` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

