### PR TITLE
feat(projection): 1504-PR02 emit 期同事务双写装饰器 + APPEND/TOPIC archtest + 写路径测试 [#1769]

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -64,9 +64,10 @@ retained journal、checkpoint、tailer 的完整约束以对应 archtest godoc �
 
 outbox 派生投影的 durable journal（`projection_events`，EPIC #1504）由 emit 期同事务双写
 装饰器写入：append 收口单一 sanctioned 路径（`PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`），
-双写 topic 集从 `slice.yaml` 投影声明派生、非手写（`PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`），
-append-only 永不删（`PROJECTION-EVENT-JOURNAL-NO-DELETE-01` + DB 引擎 REVOKE）。盲区/评级/符号以对应
-archtest godoc 与 ADR `202606071600-1504` 为准。
+双写 topic 集从 `slice.yaml` 投影声明派生、非手写（`PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`）。
+append-only 当前由 serving role 的 DB 引擎 `REVOKE UPDATE, DELETE`（migration 058）保护；code-level
+no-delete archtest（`PROJECTION-EVENT-JOURNAL-NO-DELETE-01`）是 ADR PR-05 的纵深防御计划，尚未落地。
+盲区/评级/符号以对应 archtest godoc 与 ADR `202606071600-1504` 为准。
 
 ## 命名与 payload
 

--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -66,8 +66,8 @@ outbox 派生投影的 durable journal（`projection_events`，EPIC #1504）由 
 装饰器写入：append 收口单一 sanctioned 路径（`PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`），
 双写 topic 集从 `slice.yaml` 投影声明派生、非手写（`PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`）。
 append-only 当前由 serving role 的 DB 引擎 `REVOKE UPDATE, DELETE`（migration 058）保护；code-level
-no-delete archtest（`PROJECTION-EVENT-JOURNAL-NO-DELETE-01`）是 ADR PR-05 的纵深防御计划，尚未落地。
-盲区/评级/符号以对应 archtest godoc 与 ADR `202606071600-1504` 为准。
+no-delete archtest 是 ADR 规划中的纵深防御、尚未落地（ID 与排期以 ADR 为准）。盲区/评级/符号以对应
+archtest godoc 与 ADR `202606071600-1504` 为准。
 
 ## 命名与 payload
 

--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -62,6 +62,12 @@ projection consumer 必须 wire `bootstrap.WithConsumerBase`。投影事件载�
 `cellvocab.ProjectionEvent`；outbox entry 与 saga journal event 都实现该接口。
 retained journal、checkpoint、tailer 的完整约束以对应 archtest godoc 和 ADR 为准。
 
+outbox 派生投影的 durable journal（`projection_events`，EPIC #1504）由 emit 期同事务双写
+装饰器写入：append 收口单一 sanctioned 路径（`PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`），
+双写 topic 集从 `slice.yaml` 投影声明派生、非手写（`PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`），
+append-only 永不删（`PROJECTION-EVENT-JOURNAL-NO-DELETE-01` + DB 引擎 REVOKE）。盲区/评级/符号以对应
+archtest godoc 与 ADR `202606071600-1504` 为准。
+
 ## 命名与 payload
 
 - stream / topic / command key 使用稳定 dotted 名称。

--- a/adapters/postgres/journaling_outbox_writer.go
+++ b/adapters/postgres/journaling_outbox_writer.go
@@ -1,0 +1,201 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/kernel/persistence"
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// journalingOutboxWriter decorates the base OutboxWriter with an emit-time
+// same-transaction double-write into the durable projection_events journal
+// (ADR 202606071600-1504 §D4, "event-store-primary"). For every entry whose
+// RoutingTopic is a projection source, it appends a journal row inside the
+// SAME ambient business transaction (persistence.TxFromContext[pgx.Tx]) the
+// base writer already used to insert outbox_entries — so the journal row and
+// the business fact commit or roll back atomically.
+//
+// projectionTopics is the topic-filtered allowlist (D4): only events that a
+// projection will replay are journaled, bounding journal growth by construction.
+// It is injected by the composition root from the cellgen-derived projection
+// source set (generatedProjectionSourceTopics) — never hand-maintained
+// (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01).
+//
+// The decorator is wired as the assembly's sole outbox.Writer, so the WriterEmitter
+// emit funnel is unchanged and producers are untouched. The base BatchWriter
+// capability is preserved (WriteBatch below) so a batched emit path keeps its
+// multi-row insert rather than silently degrading to per-entry writes.
+//
+// ref: AxonFramework JdbcEventStore + TrackingToken — events written in the
+// business transaction as the source of truth; projections derive from them.
+type journalingOutboxWriter struct {
+	inner            *OutboxWriter
+	projectionTopics map[string]struct{}
+}
+
+// Compile-time interface checks: the decorator is an outbox.Writer and preserves
+// the wrapped *OutboxWriter's BatchWriter capability.
+var (
+	_ outbox.Writer      = (*journalingOutboxWriter)(nil)
+	_ outbox.BatchWriter = (*journalingOutboxWriter)(nil)
+)
+
+// NewJournalingOutboxWriter wraps a base OutboxWriter so projection-source events
+// are journaled in the producer's transaction. projectionTopics is the set of
+// routing topics (== projection contract ids) to journal; an empty set means the
+// decorator forwards writes unchanged (journals nothing). Exported because the
+// composition root (a different package) wires it; construction is locked to the
+// capability provider funnel (CAPABILITY-PROVIDER-FUNNEL-01).
+func NewJournalingOutboxWriter(inner *OutboxWriter, projectionTopics []string) outbox.Writer {
+	set := make(map[string]struct{}, len(projectionTopics))
+	for _, t := range projectionTopics {
+		set[t] = struct{}{}
+	}
+	return &journalingOutboxWriter{inner: inner, projectionTopics: set}
+}
+
+// Write inserts the entry into outbox_entries (base writer, ambient tx) and then,
+// if the entry's topic is a projection source, appends a journal row in the same tx.
+func (w *journalingOutboxWriter) Write(ctx context.Context, entry outbox.Entry) error {
+	if err := w.inner.Write(ctx, entry); err != nil {
+		return err
+	}
+	return w.journalProjectionSubset(ctx, []outbox.Entry{entry})
+}
+
+// WriteBatch inserts all entries via the base batch writer (preserving the
+// multi-row insert), then journals the projection-source subset.
+func (w *journalingOutboxWriter) WriteBatch(ctx context.Context, entries []outbox.Entry) error {
+	if err := w.inner.WriteBatch(ctx, entries); err != nil {
+		return err
+	}
+	return w.journalProjectionSubset(ctx, entries)
+}
+
+// journalProjectionSubset filters entries to the projection-source set and is the
+// SOLE caller of appendProjectionEvents — the single sanctioned journal-append
+// chokepoint (PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01). It returns early when no
+// entry is a projection source so non-projection writes touch only outbox_entries.
+func (w *journalingOutboxWriter) journalProjectionSubset(ctx context.Context, entries []outbox.Entry) error {
+	var subset []outbox.Entry
+	for _, e := range entries {
+		if _, ok := w.projectionTopics[e.RoutingTopic()]; ok {
+			subset = append(subset, e)
+		}
+	}
+	if len(subset) == 0 {
+		return nil
+	}
+	return w.appendProjectionEvents(ctx, subset)
+}
+
+// projectionEventCols is the column count per projection_events row (global_seq is
+// GENERATED ALWAYS and never inserted).
+const projectionEventCols = 11
+
+// projectionEventChunkSize caps rows per INSERT to stay within PostgreSQL's 65535
+// bind-parameter limit (65535/11 ≈ 5957); 5400 mirrors writeBatchChunkSize's margin.
+const projectionEventChunkSize = 5400
+
+// projectionEventInsertPrefix / projectionEventInsertConflict frame the multi-row
+// upsert. ON CONFLICT (id) DO NOTHING makes the append idempotent against
+// application-layer retries of the producer transaction.
+const projectionEventInsertPrefix = `INSERT INTO projection_events
+	(id, aggregate_id, aggregate_type, event_type, topic, payload, metadata, observability, principal, created_at, occurred_at)
+	VALUES `
+
+const projectionEventInsertConflict = ` ON CONFLICT (id) DO NOTHING`
+
+// appendProjectionEvents writes the given entries to projection_events on the
+// ambient business transaction, chunked to respect the bind-parameter limit. It is
+// unexported (PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01 upstream Hard): no package
+// outside adapters/postgres can reach a journal-append path. Entries are already
+// validated by the base writer, so this does not re-validate.
+func (w *journalingOutboxWriter) appendProjectionEvents(ctx context.Context, entries []outbox.Entry) error {
+	tx, ok := persistence.TxFromContext[pgx.Tx](ctx)
+	if !ok {
+		return errcode.New(errcode.KindInternal, ErrAdapterPGNoTx,
+			"projection journal append requires a transaction in context")
+	}
+	for offset := 0; offset < len(entries); offset += projectionEventChunkSize {
+		end := min(offset+projectionEventChunkSize, len(entries))
+		if err := appendProjectionChunk(ctx, tx, entries[offset:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// appendProjectionChunk inserts one chunk of entries via a single multi-row INSERT.
+func appendProjectionChunk(ctx context.Context, tx pgx.Tx, entries []outbox.Entry) error {
+	var sb strings.Builder
+	sb.WriteString(projectionEventInsertPrefix)
+
+	var numBuf [32]byte
+	args := make([]any, 0, len(entries)*projectionEventCols)
+	for i, e := range entries {
+		rowArgs, err := encodeProjectionEntry(e)
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		appendProjectionPlaceholders(&sb, i*projectionEventCols, &numBuf)
+		args = append(args, rowArgs...)
+	}
+	sb.WriteString(projectionEventInsertConflict)
+
+	if _, err := tx.Exec(ctx, sb.String(), args...); err != nil {
+		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery,
+			"projection journal: failed to append events", err,
+			errcode.WithDetails(errcode.PublicInt("count", len(entries))))
+	}
+	return nil
+}
+
+// encodeProjectionEntry serializes one entry into the fixed projectionEventCols
+// argument order. It reuses the outbox writer's envelope marshalers so the journal
+// row carries the same observability/principal/metadata shape as outbox_entries.
+func encodeProjectionEntry(e outbox.Entry) ([]any, error) {
+	metadata, err := json.Marshal(e.Metadata())
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGMarshal,
+			"projection journal: failed to marshal metadata", err)
+	}
+	observabilityJSON, err := marshalObservability(e.Observability())
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGMarshal,
+			"projection journal: failed to marshal observability", err)
+	}
+	principalJSON, err := marshalPrincipal(e.Principal())
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGMarshal,
+			"projection journal: failed to marshal principal", err)
+	}
+	return []any{
+		e.ID(), e.AggregateID(), e.AggregateType(), e.EventType(), e.RoutingTopic(),
+		e.Payload(), metadata, observabilityJSON, principalJSON, e.CreatedAt(), e.OccurredAt(),
+	}, nil
+}
+
+// appendProjectionPlaceholders writes a `($base+1, …, $base+projectionEventCols)`
+// tuple to sb. numBuf is a caller-supplied scratch buffer to keep integer
+// formatting allocation-free (mirrors appendBatchPlaceholders for the 11-col row).
+func appendProjectionPlaceholders(sb *strings.Builder, base int, numBuf *[32]byte) {
+	sb.WriteString("(")
+	for j := range projectionEventCols {
+		if j > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("$")
+		sb.Write(strconv.AppendInt(numBuf[:0], int64(base+j+1), 10))
+	}
+	sb.WriteString(")")
+}

--- a/adapters/postgres/journaling_outbox_writer.go
+++ b/adapters/postgres/journaling_outbox_writer.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/outbox"
 	"github.com/ghbvf/gocell/kernel/persistence"
 	"github.com/ghbvf/gocell/pkg/errcode"
+	"github.com/ghbvf/gocell/pkg/panicregister"
 )
 
 // journalingOutboxWriter decorates the base OutboxWriter with an emit-time
@@ -48,11 +50,19 @@ var (
 
 // NewJournalingOutboxWriter wraps a base OutboxWriter so projection-source events
 // are journaled in the producer's transaction. projectionTopics is the set of
-// routing topics (== projection contract ids) to journal; an empty set means the
-// decorator forwards writes unchanged (journals nothing). Exported because the
+// routing topics (== projection contract ids) to journal; a nil or empty set means
+// the decorator forwards writes unchanged (journals nothing). Exported because the
 // composition root (a different package) wires it; construction is locked to the
 // capability provider funnel (CAPABILITY-PROVIDER-FUNNEL-01).
+//
+// inner is a strong dependency: a nil inner is a composition-root programmer error
+// (NewOutboxWriter never returns nil), so it fail-fasts at construction rather than
+// deferring to a nil-deref on the first Write (Option 范式 fail-fast; mirrors
+// clock.MustHaveClock).
 func NewJournalingOutboxWriter(inner *OutboxWriter, projectionTopics []string) outbox.Writer {
+	if inner == nil {
+		panic(panicregister.Approved("journaling-outbox-writer-nil-inner", nil))
+	}
 	set := make(map[string]struct{}, len(projectionTopics))
 	for _, t := range projectionTopics {
 		set[t] = struct{}{}
@@ -92,7 +102,16 @@ func (w *journalingOutboxWriter) journalProjectionSubset(ctx context.Context, en
 	if len(subset) == 0 {
 		return nil
 	}
-	return w.appendProjectionEvents(ctx, subset)
+	if err := w.appendProjectionEvents(ctx, subset); err != nil {
+		// The append runs in the producer's business tx, so a failure rolls the
+		// whole transaction back (the business fact is discarded with the journal
+		// row — atomicity). Log at the decorator so the journal-specific failure is
+		// diagnosable rather than surfacing only as an opaque business-tx abort.
+		slog.ErrorContext(ctx, "projection journal: append failed, business transaction will roll back",
+			slog.Int("count", len(subset)), slog.Any("error", err))
+		return err
+	}
+	return nil
 }
 
 // projectionEventCols is the column count per projection_events row (global_seq is
@@ -114,9 +133,12 @@ const projectionEventInsertConflict = ` ON CONFLICT (id) DO NOTHING`
 
 // appendProjectionEvents writes the given entries to projection_events on the
 // ambient business transaction, chunked to respect the bind-parameter limit. It is
-// unexported (PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01 upstream Hard): no package
-// outside adapters/postgres can reach a journal-append path. Entries are already
-// validated by the base writer, so this does not re-validate.
+// unexported and is the SOLE site that executes an INSERT into projection_events —
+// the SQL builder it delegates to (buildProjectionInsert) is side-effect-free, so
+// the journal-write path has exactly one executing function for
+// PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01 to lock (no callable INSERT helper to
+// bypass it). No package outside adapters/postgres can reach a journal-append path.
+// Entries are already validated by the base writer, so this does not re-validate.
 func (w *journalingOutboxWriter) appendProjectionEvents(ctx context.Context, entries []outbox.Entry) error {
 	tx, ok := persistence.TxFromContext[pgx.Tx](ctx)
 	if !ok {
@@ -125,15 +147,25 @@ func (w *journalingOutboxWriter) appendProjectionEvents(ctx context.Context, ent
 	}
 	for offset := 0; offset < len(entries); offset += projectionEventChunkSize {
 		end := min(offset+projectionEventChunkSize, len(entries))
-		if err := appendProjectionChunk(ctx, tx, entries[offset:end]); err != nil {
+		query, args, err := buildProjectionInsert(entries[offset:end])
+		if err != nil {
 			return err
+		}
+		if _, err := tx.Exec(ctx, query, args...); err != nil {
+			return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery,
+				"projection journal: failed to append events", err,
+				// 5xx strips public details on the wire; count is server-log only.
+				errcode.WithInternal(errcode.InternalAttr("count", end-offset)))
 		}
 	}
 	return nil
 }
 
-// appendProjectionChunk inserts one chunk of entries via a single multi-row INSERT.
-func appendProjectionChunk(ctx context.Context, tx pgx.Tx, entries []outbox.Entry) error {
+// buildProjectionInsert renders the multi-row INSERT statement + bind args for one
+// chunk. It is PURE — no transaction, no journal side effect — so it is not a
+// journal-write path the append caller-allowlist must lock; the only INSERT
+// execution lives in appendProjectionEvents.
+func buildProjectionInsert(entries []outbox.Entry) (string, []any, error) {
 	var sb strings.Builder
 	sb.WriteString(projectionEventInsertPrefix)
 
@@ -142,7 +174,7 @@ func appendProjectionChunk(ctx context.Context, tx pgx.Tx, entries []outbox.Entr
 	for i, e := range entries {
 		rowArgs, err := encodeProjectionEntry(e)
 		if err != nil {
-			return err
+			return "", nil, err
 		}
 		if i > 0 {
 			sb.WriteString(", ")
@@ -151,13 +183,7 @@ func appendProjectionChunk(ctx context.Context, tx pgx.Tx, entries []outbox.Entr
 		args = append(args, rowArgs...)
 	}
 	sb.WriteString(projectionEventInsertConflict)
-
-	if _, err := tx.Exec(ctx, sb.String(), args...); err != nil {
-		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery,
-			"projection journal: failed to append events", err,
-			errcode.WithDetails(errcode.PublicInt("count", len(entries))))
-	}
-	return nil
+	return sb.String(), args, nil
 }
 
 // encodeProjectionEntry serializes one entry into the fixed projectionEventCols

--- a/adapters/postgres/journaling_outbox_writer_integration_test.go
+++ b/adapters/postgres/journaling_outbox_writer_integration_test.go
@@ -21,8 +21,10 @@ import (
 // invariants PR-02 must hold (ADR §9 PR-02), over BOTH Write and WriteBatch so the
 // preserved BatchWriter path is covered identically:
 //
-//   ① atomicity   — a rolled-back business tx discards BOTH the outbox_entries and
-//                    the projection_events rows.
+//   ① atomicity   — the outbox_entries and projection_events rows commit or roll back
+//                    together: a CALLER-initiated abort discards both, and a journal
+//                    append FAILURE (the second write) aborts the business tx so the
+//                    base outbox_entries row is rolled back too.
 //   ② topic-filter — only projection-source topics are journaled; non-source topics
 //                    land in outbox_entries only.
 //   ③ idempotency  — ON CONFLICT (id) DO NOTHING: re-appending the same id is a no-op,
@@ -98,6 +100,16 @@ func journalGlobalSeq(t *testing.T, pool *Pool, id string) int64 {
 	return seq
 }
 
+// breakProjectionJournal makes the projection_events append fail by dropping the table
+// on the test's isolated migrated pool, so a subsequent double-write hits an undefined
+// relation. (Mirrors the broken-pool seam in projection_event_source_integration_test.go;
+// gives the PR-03 live-resolver failure tests a reusable journal-break helper.)
+func breakProjectionJournal(t *testing.T, pool *Pool) {
+	t.Helper()
+	_, err := pool.DB().Exec(context.Background(), `DROP TABLE IF EXISTS projection_events CASCADE`)
+	require.NoError(t, err, "drop projection_events to break the journal")
+}
+
 func TestJournalingOutboxWriter_DoubleWriteAtomicity(t *testing.T) {
 	for _, m := range writeModes() {
 		t.Run(m.name, func(t *testing.T) {
@@ -118,6 +130,31 @@ func TestJournalingOutboxWriter_DoubleWriteAtomicity(t *testing.T) {
 				"outbox_entries row must be rolled back")
 			assert.Equal(t, 0, countRows(t, pool, "projection_events", e.ID()),
 				"projection_events row must be rolled back in the same business tx")
+		})
+	}
+}
+
+// TestJournalingOutboxWriter_AppendFailureRollsBackOutbox proves the SECOND-write
+// failure direction of D4 atomicity: when the base outbox insert succeeds but the
+// projection_events append then fails, the append error propagates out of Write/
+// WriteBatch and aborts the producer's business tx, so the outbox_entries row is rolled
+// back too (no orphaned business fact). DoubleWriteAtomicity only covers a CALLER-
+// initiated abort AFTER a successful double-write; this covers the writer's own failure.
+func TestJournalingOutboxWriter_AppendFailureRollsBackOutbox(t *testing.T) {
+	for _, m := range writeModes() {
+		t.Run(m.name, func(t *testing.T) {
+			w, txm, pool := newJournalingWriter(t, projTopicA)
+			ctx := context.Background()
+			breakProjectionJournal(t, pool) // the append INSERT now hits an undefined relation
+			e := newJournalEntry(t, projTopicA)
+
+			runErr := txm.RunInTx(ctx, func(txCtx context.Context) error {
+				return m.apply(t, txCtx, w, []kout.Entry{e})
+			})
+			require.Error(t, runErr, "journal append failure must propagate out of the business tx")
+
+			assert.Equal(t, 0, countRows(t, pool, "outbox_entries", e.ID()),
+				"base outbox_entries insert must roll back when the journal append fails")
 		})
 	}
 }

--- a/adapters/postgres/journaling_outbox_writer_integration_test.go
+++ b/adapters/postgres/journaling_outbox_writer_integration_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	kout "github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// The journaling decorator double-writes projection-source events into the durable
+// projection_events journal inside the producer's business transaction (ADR
+// 202606071600-1504 §D4). These integration tests exercise the three write-path
+// invariants PR-02 must hold (ADR §9 PR-02), over BOTH Write and WriteBatch so the
+// preserved BatchWriter path is covered identically:
+//
+//   ① atomicity   — a rolled-back business tx discards BOTH the outbox_entries and
+//                    the projection_events rows.
+//   ② topic-filter — only projection-source topics are journaled; non-source topics
+//                    land in outbox_entries only.
+//   ③ idempotency  — ON CONFLICT (id) DO NOTHING: re-appending the same id is a no-op,
+//                    global_seq does not advance.
+
+const (
+	projTopicA = "event.order-created.v1"
+	projTopicB = "event.order-status-changed.v1"
+	auditTopic = "event.audit.entry.created.v1" // NOT a projection source
+)
+
+// writeMode lets each invariant run identically over Write and WriteBatch.
+type writeMode struct {
+	name  string
+	apply func(t *testing.T, ctx context.Context, w kout.Writer, entries []kout.Entry) error
+}
+
+func writeModes() []writeMode {
+	return []writeMode{
+		{name: "Write", apply: func(_ *testing.T, ctx context.Context, w kout.Writer, entries []kout.Entry) error {
+			for _, e := range entries {
+				if err := w.Write(ctx, e); err != nil {
+					return err
+				}
+			}
+			return nil
+		}},
+		{name: "WriteBatch", apply: func(t *testing.T, ctx context.Context, w kout.Writer, entries []kout.Entry) error {
+			bw, ok := w.(kout.BatchWriter)
+			require.True(t, ok, "decorator must preserve the base writer's BatchWriter capability")
+			return bw.WriteBatch(ctx, entries)
+		}},
+	}
+}
+
+func newJournalingWriter(t *testing.T, topics ...string) (kout.Writer, *TxManager, *Pool) {
+	t.Helper()
+	pool := migratedPool(t)
+	base := NewOutboxWriter(clockmock.New(time.Now()))
+	return NewJournalingOutboxWriter(base, topics), NewTxManager(pool), pool
+}
+
+func newJournalEntry(t *testing.T, topic string) kout.Entry {
+	t.Helper()
+	// eventType == routing topic (no explicit WithTopic) — the decorator filters on
+	// RoutingTopic(), so the entry's eventType is what the projectionTopics set matches.
+	e, err := kout.NewEntry(clockmock.New(time.Now()), context.Background(), topic, []byte(`{"k":"v"}`))
+	require.NoError(t, err)
+	return e
+}
+
+func countRows(t *testing.T, pool *Pool, table, id string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.DB().QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM "+table+" WHERE id = $1", id).Scan(&n))
+	return n
+}
+
+func journalGlobalSeq(t *testing.T, pool *Pool, id string) int64 {
+	t.Helper()
+	var seq int64
+	require.NoError(t, pool.DB().QueryRow(context.Background(),
+		"SELECT global_seq FROM projection_events WHERE id = $1", id).Scan(&seq))
+	return seq
+}
+
+func TestJournalingOutboxWriter_DoubleWriteAtomicity(t *testing.T) {
+	for _, m := range writeModes() {
+		t.Run(m.name, func(t *testing.T) {
+			w, txm, pool := newJournalingWriter(t, projTopicA)
+			ctx := context.Background()
+			e := newJournalEntry(t, projTopicA)
+			sentinel := errors.New("force rollback")
+
+			runErr := txm.RunInTx(ctx, func(txCtx context.Context) error {
+				if err := m.apply(t, txCtx, w, []kout.Entry{e}); err != nil {
+					return err
+				}
+				return sentinel // abort: both writes must roll back together
+			})
+			require.ErrorIs(t, runErr, sentinel)
+
+			assert.Equal(t, 0, countRows(t, pool, "outbox_entries", e.ID()),
+				"outbox_entries row must be rolled back")
+			assert.Equal(t, 0, countRows(t, pool, "projection_events", e.ID()),
+				"projection_events row must be rolled back in the same business tx")
+		})
+	}
+}
+
+func TestJournalingOutboxWriter_TopicFilter(t *testing.T) {
+	for _, m := range writeModes() {
+		t.Run(m.name, func(t *testing.T) {
+			w, txm, pool := newJournalingWriter(t, projTopicA, projTopicB)
+			ctx := context.Background()
+			src1 := newJournalEntry(t, projTopicA)
+			src2 := newJournalEntry(t, projTopicB)
+			nonSrc := newJournalEntry(t, auditTopic)
+
+			require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
+				return m.apply(t, txCtx, w, []kout.Entry{src1, src2, nonSrc})
+			}))
+
+			// Every entry lands in the transient outbox regardless of topic.
+			for _, e := range []kout.Entry{src1, src2, nonSrc} {
+				assert.Equal(t, 1, countRows(t, pool, "outbox_entries", e.ID()))
+			}
+			// Only the projection-source subset lands in the durable journal.
+			assert.Equal(t, 1, countRows(t, pool, "projection_events", src1.ID()))
+			assert.Equal(t, 1, countRows(t, pool, "projection_events", src2.ID()))
+			assert.Equal(t, 0, countRows(t, pool, "projection_events", nonSrc.ID()),
+				"non-projection-source topic must not be journaled")
+		})
+	}
+}
+
+// TestJournalingOutboxWriter_OnConflictIdempotency drives the unexported append twice
+// for the same id (this test is in package postgres). A second full Write would abort
+// on the outbox_entries PK; appending directly isolates the journal's ON CONFLICT path.
+func TestJournalingOutboxWriter_OnConflictIdempotency(t *testing.T) {
+	w, txm, pool := newJournalingWriter(t, projTopicA)
+	jw := w.(*journalingOutboxWriter)
+	ctx := context.Background()
+	e := newJournalEntry(t, projTopicA)
+
+	require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
+		return jw.appendProjectionEvents(txCtx, []kout.Entry{e})
+	}))
+	firstSeq := journalGlobalSeq(t, pool, e.ID())
+
+	require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
+		return jw.appendProjectionEvents(txCtx, []kout.Entry{e}) // same id again
+	}))
+
+	assert.Equal(t, 1, countRows(t, pool, "projection_events", e.ID()),
+		"ON CONFLICT (id) DO NOTHING must keep a single journal row")
+	assert.Equal(t, firstSeq, journalGlobalSeq(t, pool, e.ID()),
+		"global_seq must not advance on a conflicting re-append")
+}

--- a/adapters/postgres/journaling_outbox_writer_integration_test.go
+++ b/adapters/postgres/journaling_outbox_writer_integration_test.go
@@ -76,6 +76,14 @@ func newJournalEntry(t *testing.T, topic string) kout.Entry {
 
 func countRows(t *testing.T, pool *Pool, table, id string) int {
 	t.Helper()
+	// table is interpolated (not bindable), so whitelist it to a closed set — the
+	// helper can never become an injection seam even if a future caller passes a
+	// dynamic value.
+	switch table {
+	case "outbox_entries", "projection_events":
+	default:
+		t.Fatalf("countRows: unexpected table %q", table)
+	}
 	var n int
 	require.NoError(t, pool.DB().QueryRow(context.Background(),
 		"SELECT COUNT(*) FROM "+table+" WHERE id = $1", id).Scan(&n))
@@ -140,26 +148,42 @@ func TestJournalingOutboxWriter_TopicFilter(t *testing.T) {
 	}
 }
 
-// TestJournalingOutboxWriter_OnConflictIdempotency drives the unexported append twice
-// for the same id (this test is in package postgres). A second full Write would abort
-// on the outbox_entries PK; appending directly isolates the journal's ON CONFLICT path.
+// TestJournalingOutboxWriter_OnConflictIdempotency drives the unexported append for
+// the same id twice (this test is in package postgres; a second full Write would
+// abort on the outbox_entries PK, so appending directly isolates the journal's ON
+// CONFLICT path). Covers both shapes the Write and WriteBatch entry points funnel
+// into: a cross-transaction application-layer retry (the ADR §D4 idempotency
+// scenario), and a duplicate id WITHIN one batched multi-row INSERT (the WriteBatch
+// path — single Write only ever passes a 1-element slice).
 func TestJournalingOutboxWriter_OnConflictIdempotency(t *testing.T) {
 	w, txm, pool := newJournalingWriter(t, projTopicA)
 	jw := w.(*journalingOutboxWriter)
 	ctx := context.Background()
-	e := newJournalEntry(t, projTopicA)
 
-	require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
-		return jw.appendProjectionEvents(txCtx, []kout.Entry{e})
-	}))
-	firstSeq := journalGlobalSeq(t, pool, e.ID())
+	t.Run("cross-tx re-append", func(t *testing.T) {
+		e := newJournalEntry(t, projTopicA)
+		require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
+			return jw.appendProjectionEvents(txCtx, []kout.Entry{e})
+		}))
+		firstSeq := journalGlobalSeq(t, pool, e.ID())
 
-	require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
-		return jw.appendProjectionEvents(txCtx, []kout.Entry{e}) // same id again
-	}))
+		require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
+			return jw.appendProjectionEvents(txCtx, []kout.Entry{e}) // same id again
+		}))
+		assert.Equal(t, 1, countRows(t, pool, "projection_events", e.ID()),
+			"ON CONFLICT (id) DO NOTHING must keep a single journal row")
+		assert.Equal(t, firstSeq, journalGlobalSeq(t, pool, e.ID()),
+			"global_seq must not advance on a conflicting re-append")
+	})
 
-	assert.Equal(t, 1, countRows(t, pool, "projection_events", e.ID()),
-		"ON CONFLICT (id) DO NOTHING must keep a single journal row")
-	assert.Equal(t, firstSeq, journalGlobalSeq(t, pool, e.ID()),
-		"global_seq must not advance on a conflicting re-append")
+	t.Run("duplicate id within one batched INSERT", func(t *testing.T) {
+		e := newJournalEntry(t, projTopicA)
+		// Two identical-id rows in a single multi-row INSERT (the WriteBatch shape):
+		// ON CONFLICT DO NOTHING must skip the second without erroring the statement.
+		require.NoError(t, txm.RunInTx(ctx, func(txCtx context.Context) error {
+			return jw.appendProjectionEvents(txCtx, []kout.Entry{e, e})
+		}))
+		assert.Equal(t, 1, countRows(t, pool, "projection_events", e.ID()),
+			"a duplicate id within one batched INSERT must yield a single journal row")
+	})
 }

--- a/adapters/postgres/journaling_outbox_writer_test.go
+++ b/adapters/postgres/journaling_outbox_writer_test.go
@@ -1,0 +1,89 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/kernel/outbox"
+)
+
+// Unit tests for the journaling decorator's DB-free paths (pure SQL builder, the
+// nil-inner fail-fast, the no-transaction error, and the append-failure log path).
+// The happy double-write paths are covered by the //go:build integration suite.
+
+func unitEntry(t *testing.T, topic string) outbox.Entry {
+	t.Helper()
+	e, err := outbox.NewEntry(clockmock.New(time.Now()), context.Background(), topic, []byte(`{"k":"v"}`))
+	require.NoError(t, err)
+	return e
+}
+
+func newUnitWriter(t *testing.T, topics ...string) *journalingOutboxWriter {
+	t.Helper()
+	w := NewJournalingOutboxWriter(NewOutboxWriter(clockmock.New(time.Now())), topics)
+	return w.(*journalingOutboxWriter)
+}
+
+func TestNewJournalingOutboxWriter_NilInnerPanics(t *testing.T) {
+	assert.Panics(t, func() { NewJournalingOutboxWriter(nil, []string{"event.x.v1"}) },
+		"a nil inner is a composition-root programmer error and must fail-fast at construction")
+}
+
+func TestWrite_InnerErrorPropagates(t *testing.T) {
+	w := newUnitWriter(t, "event.a.v1")
+	// No tx → the base writer fails before journaling; the decorator returns its
+	// error without attempting an append.
+	err := w.Write(context.Background(), unitEntry(t, "event.a.v1"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "requires a transaction")
+}
+
+func TestWriteBatch_InnerErrorPropagates(t *testing.T) {
+	w := newUnitWriter(t, "event.a.v1")
+	err := w.WriteBatch(context.Background(), []outbox.Entry{unitEntry(t, "event.a.v1")})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "requires a transaction")
+}
+
+func TestBuildProjectionInsert(t *testing.T) {
+	entries := []outbox.Entry{unitEntry(t, "event.a.v1"), unitEntry(t, "event.b.v1")}
+	query, args, err := buildProjectionInsert(entries)
+	require.NoError(t, err)
+
+	assert.Contains(t, query, "INSERT INTO projection_events")
+	assert.Contains(t, query, "ON CONFLICT (id) DO NOTHING")
+	assert.Contains(t, query, "VALUES")
+	// One placeholder tuple per entry, projectionEventCols bind args each.
+	assert.Len(t, args, len(entries)*projectionEventCols)
+}
+
+func TestAppendProjectionEvents_NoTransaction(t *testing.T) {
+	w := newUnitWriter(t, "event.a.v1")
+	// No pgx.Tx in ctx → fail-closed before any Exec.
+	err := w.appendProjectionEvents(context.Background(), []outbox.Entry{unitEntry(t, "event.a.v1")})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "requires a transaction")
+}
+
+func TestJournalProjectionSubset_EmptySubsetIsNoop(t *testing.T) {
+	w := newUnitWriter(t, "event.a.v1")
+	// Entry topic is NOT in the projection set → subset empty → returns nil without
+	// touching the (txless) ambient context.
+	err := w.journalProjectionSubset(context.Background(), []outbox.Entry{unitEntry(t, "event.other.v1")})
+	require.NoError(t, err)
+}
+
+func TestJournalProjectionSubset_AppendFailurePropagates(t *testing.T) {
+	w := newUnitWriter(t, "event.a.v1")
+	// Topic matches → subset non-empty → appendProjectionEvents runs and fails on the
+	// missing tx; journalProjectionSubset logs and propagates the error (covers the
+	// append-failure path that rolls back the business tx).
+	err := w.journalProjectionSubset(context.Background(), []outbox.Entry{unitEntry(t, "event.a.v1")})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "requires a transaction")
+}

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -13,9 +13,9 @@ import (
 
 // provisionCapabilities is the assembly's single shared-infrastructure
 // provisioning site. It is the sole sanctioned caller of the banned adapter
-// constructors (adapterpg.NewPool / NewTxManager / NewOutboxWriter,
-// adapterredis.NewClient via the factory) — CAPABILITY-PROVIDER-FUNNEL-01
-// downstream allowlist locks construction to this file.
+// constructors (adapterpg.NewPool / NewTxManager / NewOutboxWriter /
+// NewJournalingOutboxWriter, adapterredis.NewClient via the factory) —
+// CAPABILITY-PROVIDER-FUNNEL-01 downstream allowlist locks construction to this file.
 //
 // It iterates the codegen-declared generatedCapabilities() (single source:
 // the derived union of the assembly cells' cell.yaml `requires`, computed in
@@ -100,7 +100,14 @@ func provisionPostgres(ctx context.Context, shared *composition.SharedDeps, loca
 		return vErr
 	}
 	txMgr := adapterpg.NewTxManager(pool)
-	writer := adapterpg.NewOutboxWriter(shared.Clock)
+	// Wrap the base outbox writer so projection-source events are journaled to the
+	// durable projection_events table inside the producer's transaction (EPIC #1504
+	// D4). The topic set is cellgen-derived (generatedProjectionSourceTopics, I5); it
+	// is empty today (corebundle declares no outbox projections), so the decorator
+	// forwards writes unchanged until a projection is added — at which point its topic
+	// auto-enrolls on the next `gocell generate assembly`. Wiring the durable source as
+	// the projection read side lands in PR-03.
+	writer := adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(shared.Clock), generatedProjectionSourceTopics())
 	shared.PG = capability.NewPGProvider(txMgr, writer, pool.DB())
 	locals.poolMR = pool
 	return nil

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/pkg/errcode"
@@ -107,6 +108,15 @@ func provisionPostgres(ctx context.Context, shared *composition.SharedDeps, loca
 	// forwards writes unchanged until a projection is added — at which point its topic
 	// auto-enrolls on the next `gocell generate assembly`. Wiring the durable source as
 	// the projection read side lands in PR-03.
+	// Surface the wired topic-set size so operators can distinguish "journal inactive
+	// because no projections are declared" (count 0, expected today) from a wiring
+	// regression — the durable journal otherwise gives no startup signal (#1504 PR-02).
+	// The decorator's topic argument MUST stay the direct generatedProjectionSourceTopics()
+	// call (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 rejects a threaded
+	// variable, which could hide a hand-typed list); the accessor is a cheap generated
+	// slice literal, so calling it again for the count is free.
+	slog.InfoContext(ctx, "corebundle: journaling outbox writer wired",
+		slog.Int("projection_source_topic_count", len(generatedProjectionSourceTopics())))
 	writer := adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(shared.Clock), generatedProjectionSourceTopics())
 	shared.PG = capability.NewPGProvider(txMgr, writer, pool.DB())
 	locals.poolMR = pool

--- a/cmd/corebundle/modules_gen.go
+++ b/cmd/corebundle/modules_gen.go
@@ -30,3 +30,17 @@ func generatedCapabilities() []capability.Kind {
 		capability.Redis,
 	}
 }
+
+// generatedProjectionSourceTopics is the sorted set of outbox-projection contract
+// ids (== routing topics) declared across the assembly cells' slice.yaml
+// contractUsages (role: subscribe, projection set, projectionSource outbox/empty;
+// saga-journal excluded). The composition root injects it into the journaling
+// outbox writer decorator so only events a projection will replay are double-written
+// to the durable projection_events journal (EPIC #1504 D4). Derived, never
+// hand-maintained (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01); adding a
+// projection auto-enrolls its topic on the next `gocell generate assembly`, and
+// `--verify` red-flags stale output. ALWAYS emitted (nil when empty) so the
+// decorator wiring can call it unconditionally.
+func generatedProjectionSourceTopics() []string {
+	return nil
+}

--- a/docs/architecture/202606071600-1504-adr-projection-event-journal.md
+++ b/docs/architecture/202606071600-1504-adr-projection-event-journal.md
@@ -7,7 +7,7 @@
   - `docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md`（#1100 投影 harness Q1–Q5：Coordinator / CheckpointStore / ReplaySource / Cursor / Apply；本 ADR 即其 §Amendment 2026-06-03 retention-boundary 标注的 C1 设计项）
   - `docs/architecture/202606051200-1609-adr-saga-journal-projection-source.md`（saga 事件的 model-a 投影源：`GlobalReader` + `global_seq` + `cellvocab.ProjectionEvent` 载体——本 ADR 复用其已落地地基，载体不同）
 - Amends：`docs/architecture/202605261620-adr-cqrs-projection-lifecycle-harness.md` §Amendment 2026-06-03 retention-boundary 段 + §6 威胁矩阵 Row 1（同 PR 原地重写，见 §Amendment 段）；`docs/architecture/202606051200-1609-adr-saga-journal-projection-source.md` §1.2 加 back-pointer
-- 范围：EPIC #1504 的 **PR-00**（ADR）。PR-01..05 + PR-PG 见 §9 子 PR 映射；本 ADR 是该 EPIC 的设计权威源。三条新 enforcement invariant（`PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01` / `PROJECTION-EVENT-JOURNAL-NO-DELETE-01` / `PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`）**尚未落地**，随实现 PR 增量回灌 `eventbus.md` 的 Archtest Invariants 导航表。
+- 范围：EPIC #1504 的 **PR-00**（ADR）。PR-01..05 + PR-PG 见 §9 子 PR 映射；本 ADR 是该 EPIC 的设计权威源。三条新 enforcement invariant 中 `PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`（I2）+ `…-TOPIC-ALLOWLIST-DERIVED-01`（I5）**已随 PR-02（#1769）落地**（权威盲区/反向自检活在各 archtest godoc）；`PROJECTION-EVENT-JOURNAL-NO-DELETE-01`（I4 archtest 纵深）随 PR-05 落地（I4 主守卫 DB-REVOKE 已在 PR-01）。`eventbus.md` projection 段已加导航指针。
 
 > **真值边界**：本 ADR 决策以本文为准。`202605261620` §Amendment 2026-06-03 retention-boundary 段与 §6 Row 1 在同 PR 内原地重写为指向本 ADR 的指针（per `ai-robust.md` §"ADR amendment 落地必查"——原文与 amendment 不得两套真理源共存）。
 
@@ -136,24 +136,33 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_events_id ON projection_events 
 ```go
 // adapters/postgres：journaling Writer 装饰器（emit 期同事务双写）
 // projectionTopics = composition root 从 cellgen 派生的 projection-source topic 集注入。
+// 保留基础 *OutboxWriter 的 BatchWriter 能力（Write + WriteBatch），两者经单一
+// chokepoint journalProjectionSubset 收口，故 I2 caller-allowlist 唯一项即该 chokepoint。
 type journalingOutboxWriter struct {
     inner            *OutboxWriter            // 基础 outbox 写入（保持通用）
     projectionTopics map[string]struct{}      // topic-filtered（D4）
 }
 
 func (w *journalingOutboxWriter) Write(ctx context.Context, e outbox.Entry) error {
-    if err := w.inner.Write(ctx, e); err != nil {     // 写 outbox_entries（已 ambient-tx）
+    if err := w.inner.Write(ctx, e); err != nil {           // 写 outbox_entries（已 ambient-tx）
         return err
     }
-    if _, ok := w.projectionTopics[e.RoutingTopic()]; ok {
-        return w.appendProjectionEvent(ctx, e)        // 同事务、未导出（I2 forge 封口）
-    }
-    return nil
+    return w.journalProjectionSubset(ctx, []outbox.Entry{e})
 }
+
+func (w *journalingOutboxWriter) WriteBatch(ctx context.Context, es []outbox.Entry) error {
+    if err := w.inner.WriteBatch(ctx, es); err != nil {     // 保留多行 INSERT 批写
+        return err
+    }
+    return w.journalProjectionSubset(ctx, es)
+}
+
+// journalProjectionSubset：过滤 projection-source topic，是 appendProjectionEvents 的唯一调用点。
+// appendProjectionEvents 未导出、批量 INSERT ... ON CONFLICT (id) DO NOTHING（I2 forge 封口）。
 ```
 
-- `appendProjectionEvent` **未导出**：包外无任何导出 append API（source 是只读，conformance 走 seed-persists 契约）→ 写侧 forge 封口为 Hard/Hard（I2，§6）。
-- 装饰器作为 `Writer` 注入 `WriterEmitter`，复用既有 emit 漏斗——**无新 emit 路径、producer 零改动**。
+- `appendProjectionEvents` **未导出**：包外无任何导出 append API（source 是只读，conformance 走 seed-persists 契约）→ 写侧 forge 封口为 Hard/Hard（I2，§6）。批量多行 INSERT（复刻 `outbox_writer.go` 的分块），单写经 1 元素切片走同一路径。
+- 装饰器作为 `Writer` 注入 `WriterEmitter`，复用既有 emit 漏斗——**无新 emit 路径、producer 零改动**；保留 `BatchWriter` 故批写不静默退化为顺序写。
 
 ### 4.4 wiring（D5/D9，**分两步：先挂 gate 后默认化**）
 
@@ -186,10 +195,10 @@ func (w *journalingOutboxWriter) Write(ctx context.Context, e outbox.Entry) erro
 | ID（占位，落地 PR 定型） | 摘要 | 评级（双向锁分轴） |
 |---|---|---|
 | **I1 — `PROJECTION-EVENT-JOURNAL-SOURCE-CONFORMANCE-ENROLL`** | 新 source（mem + PG）入既有 `RunReplaySourceConformance`/`RunCursorConformance`——**骑现有** `PROJECTION-REPLAY-SOURCE-CONFORMANCE-ENROLL-01`/`PROJECTION-CURSOR-CONFORMANCE-ENROLL-01`，新 impl 自动纳入，无新 archtest 文件 | **Medium**（typed impl-discovery + conformance 调用扫描；Go 无法编译期要求某类型有 `_test.go`。Hard 路径 = codegen golden 枚举 impl，**共享 gh #1003**） |
-| **I2 — `PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`**（#1504 forge 防护，封写侧） | append `projection_events` 收口单一 sanctioned 写路径 | **Hard/Hard fully-closed**：上游 = append 是 `adapters/postgres` 包内**未导出**函数（**包外**调用编译不可表达）；下游 = archtest caller-allowlist 扫 `adapters/postgres` **包内所有** callsite、锁到 `decorator.Write` 唯一调用点（闭合"同包其他函数直接调 `appendProjectionEvent`"盲区——上游 unexported 只防包外，包内由下游 whole-package scan 闭环）。生产无任何导出 append API（read-only source + seed-persists conformance）。比 #851/#893/#1282 族更紧：那些 append 与 caller **跨包**、受 Go 可见性天花板限制只能 Medium 上游；本条同包，下游 archtest 可完整闭合 |
+| **I2 — `PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`**（#1504 forge 防护，封写侧） | append `projection_events` 收口单一 sanctioned 写路径 | **Hard/Hard fully-closed**：上游 = append 是 `adapters/postgres` 包内**未导出**方法 `appendProjectionEvents`（**包外**调用编译不可表达）；下游 = archtest caller-allowlist 扫 `adapters/postgres` **包内所有** callsite、锁到唯一 chokepoint `journalingOutboxWriter.journalProjectionSubset`（`Write` 与 `WriteBatch` 都经此单一收口 append——闭合"同包其他函数直接调 `appendProjectionEvents`"盲区，上游 unexported 只防包外，包内由下游 whole-package scan 闭环）。生产无任何导出 append API（read-only source + seed-persists conformance）。比 #851/#893/#1282 族更紧：那些 append 与 caller **跨包**、受 Go 可见性天花板限制只能 Medium 上游；本条同包，下游 archtest 可完整闭合 |
 | **I3 — `…-APPEND-TX-BOUND`** | ~~append 经 ambient tx 同事务~~ **不单独立项**：被 I2 + 既有 `PG-REPO-AMBIENT-TX-01` 包含——append 就在已 ambient-tx 的 `Write` 体内，同事务是结构性的，独立 archtest 冗余（最小化 enforcement 集） | —（subsumed） |
 | **I4 — `PROJECTION-EVENT-JOURNAL-NO-DELETE-01`**（D7 append-only） | serving role 不能 UPDATE/DELETE `projection_events`（主守卫）；生产代码不发 `DELETE`/`TRUNCATE` 字面量（纵深） | **Hard（DB 引擎 REVOKE，PR-01 已在位）+ Medium archtest 纵深（PR-05）**——主守卫 = migration 058 `REVOKE UPDATE, DELETE ON projection_events FROM gocell_app`，DB 引擎层不可绕（同 #1676 `gocell_app` restricted-role 范式），自 PR-01 起对 serving role 强制 append-only。下游 archtest（PR-05）SQL-literal scan 锁 `DELETE`/`TRUNCATE … projection_events` 字面量为**纵深防御**，补 DB-REVOKE 够不着的盲区：**owner/migration 上下文误删**（migration 以 table owner 跑、保留 DELETE）、动态拼接 SQL、其它 adapter 包的 raw `pgx.Exec`、包内旁路。盲区清单 + 反向自检 RED/GREEN fixture 活在落地 archtest godoc。**gate-flip 阻塞前置**（PR-04 删 gate 前 no-DELETE 守卫须在位）**已由 PR-01 DB 引擎 REVOKE 满足**；PR-05 archtest 为纵深、非阻塞前置。未来 archive 落地需在 allowlist 加 DELETE callsite（须引 archive ADR 章节号 per `contract-fanout.md`） |
-| **I5 — `PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`**（D4 topic-filter） | 双写的 topic 集从投影合约 metadata 派生（cellgen），非手写字面量列表——加投影自动纳入 journal | **Medium**（metadata 派生成员；Hard 路径 = cellgen golden 字节锁，开 gh 跟踪） |
+| **I5 — `PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01`**（D4 topic-filter） | 双写的 topic 集从投影合约 metadata 派生（cellgen），非手写字面量列表——加投影自动纳入 journal | **Hard**（双轴，PR-02 落地，原计划 Medium 已上修——见 §Amendment 2026-06-12）：上游 = `generatedProjectionSourceTopics()` 由 `kernel/assembly.GenerateModulesGen` 从 `slice.yaml contractUsages` 派生、`gocell generate assembly --verify`（`tools/generatedverify`）字节锁 `modules_gen.go`，metadata 改而未 regen 即 CI 红；派生正确性由 `TestCollectOutboxProjectionTopics` 守。下游 = 本 archtest 强制每个 `NewJournalingOutboxWriter` callsite 的 topic 实参经 go/types 解析为 `generatedProjectionSourceTopics()`（手写 `[]string{…}` 字面量、别的函数、变量均 fail-closed），闭合"在 callsite 手打绕过 golden 派生"盲区 |
 
 **I2 vs 既有 `PROJECTION-EVENT-CARRIER-TYPED-01`**：后者是**单轴 type-system Hard（API shape）**——只 gate"公开 API 不再裸收 `outbox.Entry`"，`ProjectionEvent` 全导出可实现、载体来源**不**封闭。**I2 才是 #1504 的真 forge 防护**（封*写侧*：只有 sanctioned 装饰器能把行放进 source 读的 journal），与 #1609 §5 forge 行同款 wiring-层（非 interface-构造层）保护。
 
@@ -231,7 +240,7 @@ func (w *journalingOutboxWriter) Write(ctx context.Context, e outbox.Entry) erro
 |----|------|------------|-------------|
 | **PR-00（本 PR）** | 本 ADR + `202605261620` §Amendment 2026-06-03 retention-boundary 段 + §6 Row 1 原地重写 + `202606051200-1609` §1.2 back-pointer + `eventbus.md` nav。`Refs #1504`（**不 Closes**，镜像 #1609 PR-00 不关闭 #1609） | D1–D9（设计） | 无；解锁 PR-01..05 |
 | **PR-01** | `projection_events` migration（only-add `global_seq IDENTITY` + `idx`）+ `schema_guard` 表注册 + mem source + PG source（`Position` 读 `global_seq`）+ 入既有 conformance（I1，**含新增 "Position 返回 carrier 自带 `global_seq`、无额外 DB 往返" 场景断言**——回归 #1504 根 fix，可经 mock tx / statement 计数）+ **`projection_journal_ready` readyz probe**（`RepoReady()` + `CELL-REPO-READYZ-PROBE-01` 入列 + `PROBENAME-SEALED-FUNNEL-01` typed const）+ **扩 `OUTBOX-RECONSTRUCTION-CALLER-01` allowlist +1**（`PGProjectionEventSource` 调 `EntryScan.ToEntry` 重建载体）+ **serving-role `REVOKE UPDATE, DELETE`（migration 058，DB 引擎 append-only Hard，I4 主守卫前移）+ append-only 集成回归**（`TestProjectionEvents_AppendOnly_ServingRoleRevoked`：catalog `has_table_privilege` + 连 `gocell_app` 实测 INSERT 过 / UPDATE·DELETE 返 42501） | D2/D3/D7 | 依赖 PR-00 |
-| **PR-02** | emit 期同事务双写装饰器（D4，topic-filtered）+ `PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`（I2）+ `…-TOPIC-ALLOWLIST-DERIVED-01`（I5）+ **写路径回归测试**（L2-equiv 原子性，**不甩 PR-04**）：①双写原子性——`outbox_entries` 写成功但 `appendProjectionEvent` 失败时两表同回滚；②topic-filter——非 projection-source topic 事件不入 `projection_events`；③`ON CONFLICT (id) DO NOTHING` 幂等——同 `id` 二次写 `global_seq` 不变 | D4 | 依赖 PR-01 |
+| **PR-02**（#1769，已落地） | emit 期同事务双写装饰器（D4，topic-filtered，**保留 `BatchWriter`**：`Write`+`WriteBatch` 经 `journalProjectionSubset` 收口）+ `PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01`（I2，Hard/Hard）+ `…-TOPIC-ALLOWLIST-DERIVED-01`（I5，**Hard**：cellgen `generatedProjectionSourceTopics()` golden + cap_wiring 消费 archtest）+ composition-root 接线（always-decorate，topic 集 corebundle 今为空）+ `NewJournalingOutboxWriter` 纳入 `CAPABILITY-PROVIDER-FUNNEL-01` + **写路径集成回归测试**（`//go:build integration`，覆盖 `Write`+`WriteBatch`，**不甩 PR-04**）：①双写原子性——回滚两表同回滚；②topic-filter——非 projection-source topic 不入 `projection_events`（含 mixed-batch 子集）；③`ON CONFLICT (id) DO NOTHING` 幂等——同 `id` 二次 append `global_seq` 不变 | D4 | 依赖 PR-01 |
 | **PR-03** | corebundle wiring：durable source 填 `WithProjection*` 槽但**仍挂既有 gate 下**（gate 现选 durable，posture **保持 fail-closed**）+ **删 outbox-backed source**（无双路径）+ **live-carrier resolver**（投递边界把裸 `outbox.Entry` 经 `id → global_seq` 查找包成 `JournalEvent`，§4.2）+ **live-path 回归**（裸 `outbox.Entry` 必须解析、不得 permanent-error）。**不删 gate**（移到 PR-04） | D5 | 依赖 PR-01+02；posture 不变 |
 | **PR-04** | **T-06-2 PG e2e rebuild 证明 + 删 gate（production-default）+ runbook/rollback**：testcontainers cold-start / crash-restart / full-rebuild-from-0 over `projection_events` 证 cleaned-outbox 行不再破坏 rebuild；**e2e 绿后同 PR 删 gate** → fail-closed→production-safe 安全 flip（D9）→ finalize `202605261620` compensation 重写 | D1/D9（验证 + flip） | 依赖 PR-03 **+ PR-05**（no-DELETE 须先到位）；**解锁 T-06-2** |
 | **PR-05** | `PROJECTION-EVENT-JOURNAL-NO-DELETE-01`（I4 archtest，Medium **纵深防御**）+ anti-vacuity + RED/GREEN fixture——锁 code-level `DELETE`/`TRUNCATE` 字面量，补 PR-01 DB 引擎 REVOKE 够不着的 owner/migration 上下文盲区 | D7 | 依赖 PR-01；**非删 gate 阻塞前置**（该前置已由 PR-01 DB 引擎 REVOKE 满足）；纵深守卫，宜在 PR-04 前落地但不阻塞 |
@@ -274,3 +283,35 @@ PR-01（#1825）落地时把 D7(iii) 的 **DB 引擎 serving-role REVOKE 前移�
 5. **F1 — §4.2 / §5 row 2 / §9 PR-03 补全**：补 live-carrier resolution 协议规约（裸 `outbox.Entry` 经 `id → global_seq` 在投递边界解析、包成 `JournalEvent`，落 PR-03），使「live Position 必然解析成功」的断言有规约支撑、PR-03（#1770）有显式验收项；统一 rebuild/live 载体协议。
 
 来源：Codex `pm:pr-review` PR #1825（F1 live 载体 / F2 append-only 权限，均 Cx3），经 `/fix #1825` 收口。
+
+---
+
+## §Amendment 2026-06-12（PR-02 #1769，原地重评）
+
+PR-02（#1769）落地 D4 写路径装饰器 + I2/I5 时做了两处相对 PR-00 设计的强化，per
+`ai-robust.md`「ADR amendment 落地必查——同步重评威胁矩阵/安全模型」，本段记录（§4.3 /
+§6 I2·I5 / §9 PR-02 / §0 已就地重写，本段为审计痕）：
+
+1. **I5 升 Medium→Hard（§6 I5 / §9 PR-02）**：原计划「Medium（metadata 派生成员）；Hard 路径 =
+   cellgen golden 字节锁，开 gh 跟踪」。落地时发现唯一可行派生口就是 codegen（composition-root
+   provisioning 期无运行时 metadata），而既有 `gocell generate assembly --verify`（`generatedverify`）
+   对 `modules_gen.go` 的字节锁是**免费自带**的——故 golden Hard 即得，无需另开 gh 延后。新增
+   `generatedProjectionSourceTopics()`（`GenerateModulesGen` 派生）+ cap_wiring 消费 archtest
+   （`TOPIC-ALLOWLIST-DERIVED-01`）构成双轴 Hard。**无 gh 跟踪项需关闭**（原 Hard 路径从未开
+   issue）。**威胁矩阵无行翻转**：I5 强化只收紧 D4 topic-filter 的派生闭环，不触 §5 任一行。
+2. **装饰器保留 `BatchWriter`（§4.3）**：PR-00 §4.3 草图仅示 `Write`。落地保留基础
+   `*OutboxWriter` 的 `BatchWriter`（`Write`+`WriteBatch`），二者经单一 chokepoint
+   `journalProjectionSubset` → 未导出 `appendProjectionEvents`（批量 INSERT ... ON CONFLICT）收口，
+   故 I2 caller-allowlist 唯一项 = 该 chokepoint（非裸 `Write`）。理由：装饰器是 assembly 唯一
+   outbox writer，丢弃基础类型的 `BatchWriter` 能力会让未来批量 emit 路径静默退化为顺序写——
+   保留是 `不留小尾巴`，且 chokepoint 设计使 I2 仍单入口。**威胁矩阵无行翻转**（写路径原子性行的
+   同事务双写机制不变，`WriteBatch` 同样在 ambient tx 内）。
+3. **always-decorate + 接线归属（§9 PR-02/PR-03）**：corebundle 今无 outbox 投影，
+   `generatedProjectionSourceTopics()` 派生空集；cap_wiring **无条件**包装装饰器（空集即 forward
+   原样），故装饰器在生产路径被真实行使、非死代码，且加投影即自动 journal。**「生产 provider 的
+   writer 必是 journaling 装饰器」的 Hard 守卫不在 PR-02**：该守卫只在读侧消费 journal 时才有意义
+   （PR-03 wiring / PR-04 e2e），ADR enforcement 集刻意不含（`最小化 enforcement 集`），PR-04 T-06-2
+   e2e 为下游网——登记为 **PR-03 验收项**。`NewJournalingOutboxWriter` 已纳入
+   `CAPABILITY-PROVIDER-FUNNEL-01` 禁构造集（仅 cap_wiring + tests）。
+
+来源：`/ship 1769`（内置 review 前自审：彻底/不向后兼容/优雅简洁/AI-HARD 四原则三层自查）。

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -773,26 +773,32 @@ rebuild 卡在 Replay 相。下游查询读到陈旧 read-model。
 
 durable 投影 journal `projection_events` 是 **append-only、归档能力尚 out-of-scope（ADR §D8）**，
 故从 PR-02 装饰器部署起持续增长。topic-filter（D4）已把写入面限到真会被 replay 的 projection-source
-事件，但仍须监控表大小并接入容量告警（无内置 metric——表大小由 PG 侧采集，如 postgres_exporter
-`pg_relation_size`）：
+事件，但仍须监控**总**磁盘占用（heap + 索引 + TOAST，JSONB payload 大可触发 TOAST offload，总占用可达
+heap 的数倍）并接入容量告警。表大小无内置应用 metric，由 PG 侧采集。
+
+> postgres_exporter 默认不暴露按表的 `pg_total_relation_size`——需配 custom query collector
+> （`queries.yaml`：`SELECT relname, pg_total_relation_size(relid) AS bytes FROM pg_stat_user_tables`），
+> 或用默认已暴露的行数 `pg_stat_user_tables_n_live_tup{relname="projection_events"}` 做近似告警（行数阈值
+> 按平均行宽换算）。下例假设已暴露 `pg_total_relation_size_bytes{relname=...}`。
 
 ```yaml
-# 需 postgres_exporter 暴露 pg_relation_size{relname="projection_events"}（或等价采集）
 - alert: GoCellProjectionEventsJournalGrowthHigh
-  expr: pg_relation_size{relname="projection_events"} > 5e10  # 50 GiB，按部署容量调
+  # pg_total_relation_size（含索引 idx_projection_events_id + PK btree + TOAST），非裸 heap。
+  expr: pg_total_relation_size_bytes{relname="projection_events"} > 5e10  # 50 GiB，按部署容量调
   for: 30m
   labels:
     severity: warning
   annotations:
     summary: "projection_events journal large (append-only, no archival yet)"
     description: |
-      The durable projection_events journal exceeds the capacity threshold. It is
-      append-only (ADR 202606071600-1504 §D7) with archival still out-of-scope
-      (§D8): truncation MUST stay ≥ MIN(projection_checkpoints.offset_seq) or
-      rebuildable history is lost. Treat as a capacity-planning signal — provision
-      storage, or prioritise the archival epic (D8). Do NOT manually DELETE/TRUNCATE
-      the table (serving role is REVOKEd UPDATE/DELETE; only a table-owner migration
-      could, and must honour the checkpoint floor).
+      The durable projection_events journal exceeds the capacity threshold (total
+      relation size incl. indexes + TOAST). It is append-only (ADR 202606071600-1504
+      §D7) with archival still out-of-scope (§D8): truncation MUST stay ≥
+      MIN(projection_checkpoints.offset_seq) or rebuildable history is lost. Treat as a
+      capacity-planning signal — provision storage, or prioritise the archival epic
+      (D8). Do NOT manually DELETE/TRUNCATE the table (serving role is REVOKEd
+      UPDATE/DELETE; only a table-owner migration could, and must honour the checkpoint
+      floor).
 ```
 
 运维注意（ADR §8）：首次 full rebuild 后 `projection_event_replay_lag_seconds` 快速降至 ~0 仅表示

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -769,6 +769,36 @@ rebuild 卡在 Replay 相。下游查询读到陈旧 read-model。
 确保 p95 ≥ 30min 的触发条件可测量而不塌缩入 +Inf。p95 PromQL：
 `histogram_quantile(0.95, sum(rate(gocell_projection_rebuild_duration_seconds_bucket[1h])) by (le, cell, projection))`
 
+### `projection_events` journal 增长监控（#1504 PR-02）
+
+durable 投影 journal `projection_events` 是 **append-only、归档能力尚 out-of-scope（ADR §D8）**，
+故从 PR-02 装饰器部署起持续增长。topic-filter（D4）已把写入面限到真会被 replay 的 projection-source
+事件，但仍须监控表大小并接入容量告警（无内置 metric——表大小由 PG 侧采集，如 postgres_exporter
+`pg_relation_size`）：
+
+```yaml
+# 需 postgres_exporter 暴露 pg_relation_size{relname="projection_events"}（或等价采集）
+- alert: GoCellProjectionEventsJournalGrowthHigh
+  expr: pg_relation_size{relname="projection_events"} > 5e10  # 50 GiB，按部署容量调
+  for: 30m
+  labels:
+    severity: warning
+  annotations:
+    summary: "projection_events journal large (append-only, no archival yet)"
+    description: |
+      The durable projection_events journal exceeds the capacity threshold. It is
+      append-only (ADR 202606071600-1504 §D7) with archival still out-of-scope
+      (§D8): truncation MUST stay ≥ MIN(projection_checkpoints.offset_seq) or
+      rebuildable history is lost. Treat as a capacity-planning signal — provision
+      storage, or prioritise the archival epic (D8). Do NOT manually DELETE/TRUNCATE
+      the table (serving role is REVOKEd UPDATE/DELETE; only a table-owner migration
+      could, and must honour the checkpoint floor).
+```
+
+运维注意（ADR §8）：首次 full rebuild 后 `projection_event_replay_lag_seconds` 快速降至 ~0 仅表示
+读完 journal，**不**代表历史完整（bootstrap gap：journal 仅从 PR-02 部署起 append）；数据完整性须
+经 `projection_checkpoints.offset_seq` + 业务校验确认，不能仅看 lag。
+
 ---
 
 ## Saga-Journal Tailer 可观测性（#1609 PR-04）

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -131,8 +131,9 @@ type modulesCompositionContext struct {
 	Capabilities  []string
 	// ProjectionSourceTopics is the sorted de-duplicated set of outbox-projection
 	// contract ids (== routing topics) declared across the assembly cells'
-	// slice.yaml contractUsages (role: subscribe, projection set, projectionSource
-	// outbox/empty; saga-journal excluded). The composition root injects it into the
+	// slice.yaml contractUsages (role: subscribe, projection set, EXPLICIT
+	// projectionSource: outbox; saga-journal and empty source excluded — empty fails
+	// the generation closed). The composition root injects it into the
 	// journaling outbox writer decorator so only events a projection will replay are
 	// double-written to projection_events (EPIC #1504 D4 / I5). The template ALWAYS
 	// emits generatedProjectionSourceTopics() (even when empty) so the decorator
@@ -322,22 +323,41 @@ func (g *Generator) collectCapabilityConsts(assemblyID string, cellRefs []metada
 // cellvocab.ProjectionSourceOutbox / ProjectionSourceSagaJournal, declared locally to
 // keep kernel/assembly's codegen dependencies minimal (same convention as
 // tools/codegen/cellgen). The outbox double-write topic set is a POSITIVE allowlist of
-// these — only outbox-sourced projections (empty == outbox default) flow through the
-// outbox writer; saga-journal reads the global saga_events journal, and any future
-// projectionSource value is excluded by construction rather than silently included.
+// these — only projections that declare an EXPLICIT projectionSource: outbox flow
+// through the outbox writer; saga-journal reads the global saga_events journal, and any
+// future projectionSource value is excluded by construction rather than silently
+// included. An empty source is NOT defaulted to outbox: it is a parser-invariant
+// violation and fails the generation closed (see collectOutboxProjectionTopics).
 const (
 	projectionSourceOutbox      = "outbox"
 	projectionSourceSagaJournal = "saga-journal"
+
+	// msgProjectionSourceRequiredCodegen is returned when a projection contractUsage
+	// reaches the journal-topic collector with an empty projectionSource — a
+	// parser-invariant violation (metadata.checkProjectionSourcePlacement requires an
+	// explicit source whenever projection is set). The collector fails closed rather
+	// than defaulting empty to outbox and journaling the event into the durable
+	// allowlist (a security boundary, EPIC #1504 I5).
+	msgProjectionSourceRequiredCodegen = "projection contractUsage requires an explicit projectionSource"
 )
 
 // collectOutboxProjectionTopics returns the sorted, de-duplicated set of contract
 // ids that feed outbox-sourced projections across the assembly's cells — derived
-// from slice.yaml contractUsages (role: subscribe + projection set + projectionSource
-// ∈ {"outbox",""}). Each contract id is the event's routing topic (the producer
-// emits with WithTopic == contract id, and the projection Coordinator filters on it),
-// so this set is exactly the topics the journaling decorator must double-write
-// (EPIC #1504 D4 / I5). Saga-journal projections are excluded (different source).
-func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCellRef) []string {
+// from slice.yaml contractUsages (role: subscribe + projection set + EXPLICIT
+// projectionSource: outbox). Each contract id is the event's routing topic (the
+// producer emits with WithTopic == contract id, and the projection Coordinator filters
+// on it), so this set is exactly the topics the journaling decorator must double-write
+// (EPIC #1504 D4 / I5). Saga-journal and any future explicit source are excluded by the
+// positive allowlist.
+//
+// It fails CLOSED: a projection contractUsage that reaches here with an empty
+// projectionSource is a parser-invariant violation (the parser requires an explicit
+// source whenever projection is set), so generation errors rather than fail-open-
+// defaulting empty to outbox and journaling it into the durable allowlist — the
+// allowlist bounds journal growth (a security boundary), so the generation funnel must
+// be closed even if a value reaches codegen by a non-parser path. Mirrors the
+// capabilityConstNames "guard bypassed → GenerateModulesGen fails" posture.
+func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCellRef) ([]string, error) {
 	inAssembly := make(map[string]bool, len(cellRefs))
 	for _, ref := range cellRefs {
 		inAssembly[ref.ID] = true
@@ -348,7 +368,11 @@ func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCe
 			continue
 		}
 		for _, cu := range s.ContractUsages {
-			if isOutboxProjectionUsage(cu) {
+			isOutbox, err := outboxProjectionTopic(s.ID, cu)
+			if err != nil {
+				return nil, err
+			}
+			if isOutbox {
 				topicSet[cu.Contract] = struct{}{}
 			}
 		}
@@ -358,19 +382,28 @@ func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCe
 		topics = append(topics, t)
 	}
 	sort.Strings(topics)
-	return topics
+	return topics, nil
 }
 
-// isOutboxProjectionUsage reports whether cu declares an outbox-sourced projection:
-// role subscribe + projection set + projectionSource ∈ {"outbox",""} (empty == outbox
-// default, per cellgen validateProjectionContractKind). saga-journal and any future
-// projectionSource value are excluded by this positive allowlist, so a new source
-// cannot be silently double-written to the outbox journal.
-func isOutboxProjectionUsage(cu metadata.ContractUsage) bool {
+// outboxProjectionTopic classifies cu for the outbox journal allowlist. It returns
+// (true, nil) for a projection (role subscribe + projection set) whose projectionSource
+// is EXPLICITLY outbox; (false, nil) for a non-projection or a non-outbox source
+// (saga-journal / any future explicit source — excluded by the positive allowlist); and
+// (false, err) when cu IS a projection but its projectionSource is empty. An empty
+// source is a parser-invariant violation (the parser requires an explicit source
+// whenever projection is set), so the collector fails closed rather than treating empty
+// as outbox. sliceID is threaded only for the error's diagnostic context.
+func outboxProjectionTopic(sliceID string, cu metadata.ContractUsage) (bool, error) {
 	if cu.Role != "subscribe" || cu.Projection == "" {
-		return false
+		return false, nil
 	}
-	return cu.ProjectionSource == "" || cu.ProjectionSource == projectionSourceOutbox
+	if cu.ProjectionSource == "" {
+		return false, errcode.New(errcode.KindInvalid, errcode.ErrMetadataInvalid,
+			msgProjectionSourceRequiredCodegen,
+			errcode.WithInternal(errcode.InternalAttr("_",
+				fmt.Sprintf("slice=%q contract=%q", sliceID, cu.Contract))))
+	}
+	return cu.ProjectionSource == projectionSourceOutbox, nil
 }
 
 // generateModulesGenLegacy emits the legacy local-CellModule-type form used
@@ -472,13 +505,17 @@ func (g *Generator) generateModulesGenComposition(
 	// BootstrapLedgerStore handoff was removed in #1423 (cross-cell wiring is now
 	// event-driven), so module Provide order carries no runtime dependency.
 	sort.Strings(importLines)
+	projTopics, err := g.collectOutboxProjectionTopics(asm.Cells)
+	if err != nil {
+		return nil, err
+	}
 	ctx := modulesCompositionContext{
 		AssemblyID:             assemblyID,
 		SourcePath:             asm.File,
 		Modules:                moduleCalls,
 		ModuleImports:          importLines,
 		Capabilities:           capConsts,
-		ProjectionSourceTopics: g.collectOutboxProjectionTopics(asm.Cells),
+		ProjectionSourceTopics: projTopics,
 	}
 	return g.executeTemplate("modules_gen_composition.go.tpl", ctx)
 }

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -318,12 +318,17 @@ func (g *Generator) collectCapabilityConsts(assemblyID string, cellRefs []metada
 	return capConsts, nil
 }
 
-// projectionSourceSagaJournal mirrors cellvocab.ProjectionSourceSagaJournal,
-// declared locally to keep kernel/assembly's codegen dependencies minimal (same
-// convention as tools/codegen/cellgen). Saga-journal projections read the global
-// saga_events journal, NOT the outbox, so they are excluded from the outbox
-// double-write topic set.
-const projectionSourceSagaJournal = "saga-journal"
+// projectionSourceOutbox / projectionSourceSagaJournal mirror
+// cellvocab.ProjectionSourceOutbox / ProjectionSourceSagaJournal, declared locally to
+// keep kernel/assembly's codegen dependencies minimal (same convention as
+// tools/codegen/cellgen). The outbox double-write topic set is a POSITIVE allowlist of
+// these — only outbox-sourced projections (empty == outbox default) flow through the
+// outbox writer; saga-journal reads the global saga_events journal, and any future
+// projectionSource value is excluded by construction rather than silently included.
+const (
+	projectionSourceOutbox      = "outbox"
+	projectionSourceSagaJournal = "saga-journal"
+)
 
 // collectOutboxProjectionTopics returns the sorted, de-duplicated set of contract
 // ids that feed outbox-sourced projections across the assembly's cells — derived
@@ -343,13 +348,9 @@ func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCe
 			continue
 		}
 		for _, cu := range s.ContractUsages {
-			if cu.Role != "subscribe" || cu.Projection == "" {
-				continue
+			if isOutboxProjectionUsage(cu) {
+				topicSet[cu.Contract] = struct{}{}
 			}
-			if cu.ProjectionSource == projectionSourceSagaJournal {
-				continue
-			}
-			topicSet[cu.Contract] = struct{}{}
 		}
 	}
 	var topics []string // nil when no outbox projections (corebundle today)
@@ -358,6 +359,18 @@ func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCe
 	}
 	sort.Strings(topics)
 	return topics
+}
+
+// isOutboxProjectionUsage reports whether cu declares an outbox-sourced projection:
+// role subscribe + projection set + projectionSource ∈ {"outbox",""} (empty == outbox
+// default, per cellgen validateProjectionContractKind). saga-journal and any future
+// projectionSource value are excluded by this positive allowlist, so a new source
+// cannot be silently double-written to the outbox journal.
+func isOutboxProjectionUsage(cu metadata.ContractUsage) bool {
+	if cu.Role != "subscribe" || cu.Projection == "" {
+		return false
+	}
+	return cu.ProjectionSource == "" || cu.ProjectionSource == projectionSourceOutbox
 }
 
 // generateModulesGenLegacy emits the legacy local-CellModule-type form used

--- a/kernel/assembly/generator.go
+++ b/kernel/assembly/generator.go
@@ -129,6 +129,15 @@ type modulesCompositionContext struct {
 	Modules       []string // Module call expressions, e.g. "cellmodulesconfigcore.Module()"
 	ModuleImports []string // aliased import lines, e.g. `cellmodulesconfigcore "github.com/ghbvf/gocell/cellmodules/configcore"`
 	Capabilities  []string
+	// ProjectionSourceTopics is the sorted de-duplicated set of outbox-projection
+	// contract ids (== routing topics) declared across the assembly cells'
+	// slice.yaml contractUsages (role: subscribe, projection set, projectionSource
+	// outbox/empty; saga-journal excluded). The composition root injects it into the
+	// journaling outbox writer decorator so only events a projection will replay are
+	// double-written to projection_events (EPIC #1504 D4 / I5). The template ALWAYS
+	// emits generatedProjectionSourceTopics() (even when empty) so the decorator
+	// wiring can call it unconditionally.
+	ProjectionSourceTopics []string
 }
 
 // capabilityConstNames maps cell.yaml `requires` enum values to their
@@ -309,6 +318,48 @@ func (g *Generator) collectCapabilityConsts(assemblyID string, cellRefs []metada
 	return capConsts, nil
 }
 
+// projectionSourceSagaJournal mirrors cellvocab.ProjectionSourceSagaJournal,
+// declared locally to keep kernel/assembly's codegen dependencies minimal (same
+// convention as tools/codegen/cellgen). Saga-journal projections read the global
+// saga_events journal, NOT the outbox, so they are excluded from the outbox
+// double-write topic set.
+const projectionSourceSagaJournal = "saga-journal"
+
+// collectOutboxProjectionTopics returns the sorted, de-duplicated set of contract
+// ids that feed outbox-sourced projections across the assembly's cells — derived
+// from slice.yaml contractUsages (role: subscribe + projection set + projectionSource
+// ∈ {"outbox",""}). Each contract id is the event's routing topic (the producer
+// emits with WithTopic == contract id, and the projection Coordinator filters on it),
+// so this set is exactly the topics the journaling decorator must double-write
+// (EPIC #1504 D4 / I5). Saga-journal projections are excluded (different source).
+func (g *Generator) collectOutboxProjectionTopics(cellRefs []metadata.AssemblyCellRef) []string {
+	inAssembly := make(map[string]bool, len(cellRefs))
+	for _, ref := range cellRefs {
+		inAssembly[ref.ID] = true
+	}
+	topicSet := make(map[string]struct{})
+	for _, s := range g.project.Slices {
+		if s == nil || !inAssembly[s.BelongsToCell] {
+			continue
+		}
+		for _, cu := range s.ContractUsages {
+			if cu.Role != "subscribe" || cu.Projection == "" {
+				continue
+			}
+			if cu.ProjectionSource == projectionSourceSagaJournal {
+				continue
+			}
+			topicSet[cu.Contract] = struct{}{}
+		}
+	}
+	var topics []string // nil when no outbox projections (corebundle today)
+	for t := range topicSet {
+		topics = append(topics, t)
+	}
+	sort.Strings(topics)
+	return topics
+}
+
 // generateModulesGenLegacy emits the legacy local-CellModule-type form used
 // by examples/ assemblies.
 func (g *Generator) generateModulesGenLegacy(
@@ -409,11 +460,12 @@ func (g *Generator) generateModulesGenComposition(
 	// event-driven), so module Provide order carries no runtime dependency.
 	sort.Strings(importLines)
 	ctx := modulesCompositionContext{
-		AssemblyID:    assemblyID,
-		SourcePath:    asm.File,
-		Modules:       moduleCalls,
-		ModuleImports: importLines,
-		Capabilities:  capConsts,
+		AssemblyID:             assemblyID,
+		SourcePath:             asm.File,
+		Modules:                moduleCalls,
+		ModuleImports:          importLines,
+		Capabilities:           capConsts,
+		ProjectionSourceTopics: g.collectOutboxProjectionTopics(asm.Cells),
 	}
 	return g.executeTemplate("modules_gen_composition.go.tpl", ctx)
 }

--- a/kernel/assembly/generator_projectiontopics_test.go
+++ b/kernel/assembly/generator_projectiontopics_test.go
@@ -1,0 +1,84 @@
+package assembly
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ghbvf/gocell/kernel/metadata"
+)
+
+// slice builds a SliceMeta with the given cell + contractUsages for the collector tests.
+func projSlice(cellID, sliceID string, cus ...metadata.ContractUsage) *metadata.SliceMeta {
+	return &metadata.SliceMeta{ID: sliceID, BelongsToCell: cellID, ContractUsages: cus}
+}
+
+func subscribeCU(contract, projection, source string) metadata.ContractUsage {
+	return metadata.ContractUsage{
+		Contract: contract, Role: "subscribe", Handler: "H",
+		Projection: projection, ProjectionSource: source,
+	}
+}
+
+// TestCollectOutboxProjectionTopics is the derivation anti-vacuity + exclusion proof
+// for PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01: the topic set is computed
+// from slice.yaml contractUsages, includes outbox projections (sorted, deduped), and
+// excludes saga-journal projections, non-projection CUs, and out-of-assembly cells.
+func TestCollectOutboxProjectionTopics(t *testing.T) {
+	cellA, cellB, cellOut := "acell", "bcell", "outcell"
+	tests := []struct {
+		name   string
+		slices map[string]*metadata.SliceMeta
+		cells  []metadata.AssemblyCellRef
+		want   []string
+	}{
+		{
+			name:   "no projections yields empty set (corebundle today)",
+			slices: map[string]*metadata.SliceMeta{cellA + "/s": projSlice(cellA, "s", subscribeCU("event.x.v1", "", ""))},
+			cells:  []metadata.AssemblyCellRef{{ID: cellA}},
+			want:   nil,
+		},
+		{
+			name: "outbox projections sorted + deduped; empty-source treated as outbox",
+			slices: map[string]*metadata.SliceMeta{
+				cellA + "/s1": projSlice(cellA, "s1",
+					subscribeCU("event.beta.v1", "p_beta", "outbox"),
+					subscribeCU("event.alpha.v1", "p_alpha", ""), // "" == outbox
+				),
+				cellB + "/s2": projSlice(cellB, "s2",
+					subscribeCU("event.beta.v1", "p_beta_again", "outbox"), // dup contract
+					subscribeCU("event.gamma.v1", "p_gamma", "outbox"),
+				),
+			},
+			cells: []metadata.AssemblyCellRef{{ID: cellA}, {ID: cellB}},
+			want:  []string{"event.alpha.v1", "event.beta.v1", "event.gamma.v1"},
+		},
+		{
+			name: "saga-journal projections and non-projection CUs are excluded",
+			slices: map[string]*metadata.SliceMeta{
+				cellA + "/s": projSlice(cellA, "s",
+					subscribeCU("event.out.v1", "p_out", "outbox"),
+					subscribeCU("saga.journal.v1", "p_saga", "saga-journal"), // excluded: saga source
+					subscribeCU("event.plain.v1", "", ""),                    // excluded: not a projection
+				),
+			},
+			cells: []metadata.AssemblyCellRef{{ID: cellA}},
+			want:  []string{"event.out.v1"},
+		},
+		{
+			name: "projections in cells outside the assembly are excluded",
+			slices: map[string]*metadata.SliceMeta{
+				cellA + "/s":   projSlice(cellA, "s", subscribeCU("event.in.v1", "p_in", "outbox")),
+				cellOut + "/s": projSlice(cellOut, "s", subscribeCU("event.skip.v1", "p_skip", "outbox")),
+			},
+			cells: []metadata.AssemblyCellRef{{ID: cellA}}, // cellOut not in assembly
+			want:  []string{"event.in.v1"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGenerator(&metadata.ProjectMeta{Slices: tc.slices}, "github.com/ghbvf/gocell", "")
+			assert.Equal(t, tc.want, g.collectOutboxProjectionTopics(tc.cells))
+		})
+	}
+}

--- a/kernel/assembly/generator_projectiontopics_test.go
+++ b/kernel/assembly/generator_projectiontopics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/metadata"
 )
@@ -22,15 +23,18 @@ func subscribeCU(contract, projection, source string) metadata.ContractUsage {
 
 // TestCollectOutboxProjectionTopics is the derivation anti-vacuity + exclusion proof
 // for PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01: the topic set is computed
-// from slice.yaml contractUsages, includes outbox projections (sorted, deduped), and
-// excludes saga-journal projections, non-projection CUs, and out-of-assembly cells.
+// from slice.yaml contractUsages, includes ONLY explicit-outbox projections (sorted,
+// deduped), and excludes saga-journal projections, future explicit sources,
+// non-projection CUs, and out-of-assembly cells. An empty source on a projection CU
+// fails closed (it is a parser-invariant violation, never defaulted to outbox).
 func TestCollectOutboxProjectionTopics(t *testing.T) {
 	cellA, cellB, cellOut := "acell", "bcell", "outcell"
 	tests := []struct {
-		name   string
-		slices map[string]*metadata.SliceMeta
-		cells  []metadata.AssemblyCellRef
-		want   []string
+		name    string
+		slices  map[string]*metadata.SliceMeta
+		cells   []metadata.AssemblyCellRef
+		want    []string
+		wantErr bool
 	}{
 		{
 			name:   "no projections yields empty set (corebundle today)",
@@ -39,13 +43,15 @@ func TestCollectOutboxProjectionTopics(t *testing.T) {
 			want:   nil,
 		},
 		{
-			name: "outbox projections sorted + deduped; empty-source treated as outbox",
+			name: "outbox projections sorted + deduped",
 			slices: map[string]*metadata.SliceMeta{
-				cellA + "/s1": projSlice(cellA, "s1",
+				cellA + "/s1": projSlice(
+					cellA, "s1",
 					subscribeCU("event.beta.v1", "p_beta", "outbox"),
-					subscribeCU("event.alpha.v1", "p_alpha", ""), // "" == outbox
+					subscribeCU("event.alpha.v1", "p_alpha", "outbox"),
 				),
-				cellB + "/s2": projSlice(cellB, "s2",
+				cellB + "/s2": projSlice(
+					cellB, "s2",
 					subscribeCU("event.beta.v1", "p_beta_again", "outbox"), // dup contract
 					subscribeCU("event.gamma.v1", "p_gamma", "outbox"),
 				),
@@ -56,12 +62,13 @@ func TestCollectOutboxProjectionTopics(t *testing.T) {
 		{
 			name: "saga-journal, non-projection, and unknown-source CUs are excluded",
 			slices: map[string]*metadata.SliceMeta{
-				cellA + "/s": projSlice(cellA, "s",
+				cellA + "/s": projSlice(
+					cellA, "s",
 					subscribeCU("event.out.v1", "p_out", "outbox"),
 					subscribeCU("saga.journal.v1", "p_saga", "saga-journal"), // excluded: saga source
 					subscribeCU("event.plain.v1", "", ""),                    // excluded: not a projection
-					// positive-allowlist anti-regression: a future projectionSource value
-					// must be excluded by construction, not silently journaled.
+					// positive-allowlist anti-regression: a future explicit projectionSource
+					// value must be excluded by construction, not silently journaled.
 					subscribeCU("event.future.v1", "p_future", "kinesis"),
 				),
 			},
@@ -77,11 +84,33 @@ func TestCollectOutboxProjectionTopics(t *testing.T) {
 			cells: []metadata.AssemblyCellRef{{ID: cellA}}, // cellOut not in assembly
 			want:  []string{"event.in.v1"},
 		},
+		{
+			// fail-closed: a projection CU with an EMPTY projectionSource is a
+			// parser-invariant violation (checkProjectionSourcePlacement requires an
+			// explicit source whenever projection is set). Reaching the collector means
+			// the parser was bypassed; it errors rather than fail-open-defaulting empty
+			// to outbox and journaling it into the durable allowlist.
+			name: "empty-source projection fails closed (parser bypass)",
+			slices: map[string]*metadata.SliceMeta{
+				cellA + "/s": projSlice(
+					cellA, "s",
+					subscribeCU("event.alpha.v1", "p_alpha", ""), // projection set, source empty
+				),
+			},
+			cells:   []metadata.AssemblyCellRef{{ID: cellA}},
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGenerator(&metadata.ProjectMeta{Slices: tc.slices}, "github.com/ghbvf/gocell", "")
-			assert.Equal(t, tc.want, g.collectOutboxProjectionTopics(tc.cells))
+			got, err := g.collectOutboxProjectionTopics(tc.cells)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/kernel/assembly/generator_projectiontopics_test.go
+++ b/kernel/assembly/generator_projectiontopics_test.go
@@ -54,12 +54,15 @@ func TestCollectOutboxProjectionTopics(t *testing.T) {
 			want:  []string{"event.alpha.v1", "event.beta.v1", "event.gamma.v1"},
 		},
 		{
-			name: "saga-journal projections and non-projection CUs are excluded",
+			name: "saga-journal, non-projection, and unknown-source CUs are excluded",
 			slices: map[string]*metadata.SliceMeta{
 				cellA + "/s": projSlice(cellA, "s",
 					subscribeCU("event.out.v1", "p_out", "outbox"),
 					subscribeCU("saga.journal.v1", "p_saga", "saga-journal"), // excluded: saga source
 					subscribeCU("event.plain.v1", "", ""),                    // excluded: not a projection
+					// positive-allowlist anti-regression: a future projectionSource value
+					// must be excluded by construction, not silently journaled.
+					subscribeCU("event.future.v1", "p_future", "kinesis"),
 				),
 			},
 			cells: []metadata.AssemblyCellRef{{ID: cellA}},

--- a/kernel/assembly/gentpl/modules_gen_composition.go.tpl
+++ b/kernel/assembly/gentpl/modules_gen_composition.go.tpl
@@ -35,3 +35,25 @@ func generatedCapabilities() []capability.Kind {
 	}
 }
 {{- end}}
+
+// generatedProjectionSourceTopics is the sorted set of outbox-projection contract
+// ids (== routing topics) declared across the assembly cells' slice.yaml
+// contractUsages (role: subscribe, projection set, projectionSource outbox/empty;
+// saga-journal excluded). The composition root injects it into the journaling
+// outbox writer decorator so only events a projection will replay are double-written
+// to the durable projection_events journal (EPIC #1504 D4). Derived, never
+// hand-maintained (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01); adding a
+// projection auto-enrolls its topic on the next `gocell generate assembly`, and
+// `--verify` red-flags stale output. ALWAYS emitted (nil when empty) so the
+// decorator wiring can call it unconditionally.
+func generatedProjectionSourceTopics() []string {
+{{- if .ProjectionSourceTopics}}
+	return []string{
+{{- range .ProjectionSourceTopics}}
+		{{printf "%q" .}},
+{{- end}}
+	}
+{{- else}}
+	return nil
+{{- end}}
+}

--- a/tools/archtest/capability_provider_funnel.go
+++ b/tools/archtest/capability_provider_funnel.go
@@ -17,7 +17,7 @@
 //
 // The shared-infrastructure constructors
 //
-//	adapters/postgres.NewPool / NewTxManager / NewOutboxWriter
+//	adapters/postgres.NewPool / NewTxManager / NewOutboxWriter / NewJournalingOutboxWriter
 //	adapters/redis.NewClient
 //
 // may only be invoked from the assembly's single provisioning site
@@ -107,9 +107,10 @@ const (
 // per-role derivations (NewSessionStore, NewCache, …) are intentionally absent.
 var capForbiddenCtors = map[string]map[string]struct{}{
 	capPgImportPath: {
-		"NewPool":         {},
-		"NewTxManager":    {},
-		"NewOutboxWriter": {},
+		"NewPool":                   {},
+		"NewTxManager":              {},
+		"NewOutboxWriter":           {},
+		"NewJournalingOutboxWriter": {},
 	},
 	capRedisImportPath: {
 		"NewClient": {},

--- a/tools/archtest/capability_provider_funnel_test.go
+++ b/tools/archtest/capability_provider_funnel_test.go
@@ -31,8 +31,8 @@ func TestCapabilityProviderFunnel_CompositionRootOnly(t *testing.T) {
 // It runs the same scanCapabilityProviderViolations the production Check uses
 // (single source) against the synthetic fixture packages.
 //
-// Coverage: 3 PG qualified (NewPool/NewTxManager/NewOutboxWriter) + 1 redis
-// qualified (NewClient) + 1 aliased (NewPool) + 1 dot-import (NewTxManager) = 6.
+// Coverage: 4 PG qualified (NewPool/NewTxManager/NewOutboxWriter/NewJournalingOutboxWriter)
+// + 1 redis qualified (NewClient) + 1 aliased (NewPool) + 1 dot-import (NewTxManager) = 7.
 func TestCapabilityProviderFunnel_RedFixtureDetected(t *testing.T) {
 	diags := Run(t, Fixture(
 		FixtureOpts{Tests: false},
@@ -46,9 +46,9 @@ func TestCapabilityProviderFunnel_RedFixtureDetected(t *testing.T) {
 	}
 	// Equality (not ≥) so the fixture cannot drift silently — any change to the
 	// fixture files must update this count.
-	assert.Len(t, diags, 6,
-		"fixture must yield exactly 6 CAPABILITY-PROVIDER-FUNNEL-01 hits "+
-			"(3 PG qualified + 1 redis qualified + 1 aliased + 1 dot-import); "+
+	assert.Len(t, diags, 7,
+		"fixture must yield exactly 7 CAPABILITY-PROVIDER-FUNNEL-01 hits "+
+			"(4 PG qualified + 1 redis qualified + 1 aliased + 1 dot-import); "+
 			"if the fixture changes intentionally, update the expected count")
 }
 

--- a/tools/archtest/internal/capfunnelfixture/redfixture.go
+++ b/tools/archtest/internal/capfunnelfixture/redfixture.go
@@ -27,13 +27,17 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 )
 
-// qualifiedPGCalls exercises the three banned postgres constructors in
-// qualified-import form (3 hits).
+// qualifiedPGCalls exercises the four banned postgres constructors in
+// qualified-import form (4 hits). NewJournalingOutboxWriter takes a pre-built
+// *OutboxWriter (var, not a nested constructor) so the only hit on that line is
+// the decorator constructor itself.
 func qualifiedPGCalls(ctx context.Context, clk clock.Clock) {
 	_, _ = adapterpg.NewPool(ctx, adapterpg.Config{})
 	var p *adapterpg.Pool
 	_ = adapterpg.NewTxManager(p)
 	_ = adapterpg.NewOutboxWriter(clk)
+	var w *adapterpg.OutboxWriter
+	_ = adapterpg.NewJournalingOutboxWriter(w, nil)
 }
 
 // qualifiedRedisCall exercises the banned redis client constructor in

--- a/tools/archtest/internal/projectionappendfixture/fixture.go
+++ b/tools/archtest/internal/projectionappendfixture/fixture.go
@@ -1,0 +1,32 @@
+//go:build archtest_fixture
+
+// Package projectionappendfixture is the RED fixture for
+// PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01. The real append target
+// (adapters/postgres.journalingOutboxWriter.appendProjectionEvents) is UNEXPORTED,
+// so a fixture package cannot call it — Go visibility is the upstream Hard rung.
+// To exercise the downstream whole-package caller-allowlist (closing the "another
+// same-package function calls appendProjectionEvents" blind spot), this fixture
+// reproduces the exact shape: an unexported appendProjectionEvents method with one
+// SANCTIONED chokepoint caller (journalProjectionSubset) and one UNSANCTIONED
+// bypass caller. The detector is parameterized by package path, so the test runs it
+// against this fixture's path + the fixture chokepoint allowlist and asserts it
+// fires exactly once (the bypass), proving the funnel is callsite-level, not
+// file-level.
+package projectionappendfixture
+
+import "context"
+
+type fakeJournalingWriter struct{}
+
+// appendProjectionEvents stands in for the real unexported journal append.
+func (w *fakeJournalingWriter) appendProjectionEvents(_ context.Context) error { return nil }
+
+// journalProjectionSubset is the sanctioned chokepoint (allowlisted in the test).
+func (w *fakeJournalingWriter) journalProjectionSubset(ctx context.Context) error {
+	return w.appendProjectionEvents(ctx)
+}
+
+// bypassAppend is an UNSANCTIONED same-package caller — the detector must flag it.
+func (w *fakeJournalingWriter) bypassAppend(ctx context.Context) error {
+	return w.appendProjectionEvents(ctx)
+}

--- a/tools/archtest/internal/projectiontopicfixture/fixture.go
+++ b/tools/archtest/internal/projectiontopicfixture/fixture.go
@@ -1,0 +1,17 @@
+//go:build archtest_fixture
+
+// Package projectiontopicfixture is the RED fixture for
+// PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01. It constructs the journaling
+// decorator with a HAND-TYPED []string topic literal instead of the cellgen-derived
+// generatedProjectionSourceTopics() accessor — the exact drift the invariant forbids
+// (a hand-maintained allowlist would silently diverge from slice.yaml projections).
+// The detector run against this package must flag the call.
+package projectiontopicfixture
+
+import adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+
+// handTypedTopics passes a hand-typed literal as the projection-source topic set.
+func handTypedTopics() {
+	var base *adapterpg.OutboxWriter
+	_ = adapterpg.NewJournalingOutboxWriter(base, []string{"event.hand.typed.v1"})
+}

--- a/tools/archtest/projection_event_journal_append_caller.go
+++ b/tools/archtest/projection_event_journal_append_caller.go
@@ -1,0 +1,167 @@
+package archtest
+
+// projection_event_journal_append_caller.go — importable rule body for
+// PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01 (EPIC #1504 PR-02 / ADR
+// 202606071600-1504 §6 I2). The non-test home keeps the detector compilable so the
+// _test.go companion (production dogfood + RED fixture) calls the same single
+// source — no parallel rule body.
+//
+// # What this guards
+//
+// adapters/postgres.journalingOutboxWriter.appendProjectionEvents is the SOLE write
+// path into the durable projection_events journal (the replay source for CQRS
+// projections). If any other code could append, it could forge rows the projection
+// harness will replay as truth — the #1504 "伪造 / 越界投影事件" threat. The journal
+// has no exported append API (the source is read-only; conformance seeds via raw
+// INSERT in _test.go), so this funnel locks the one internal append.
+//
+// # AI-robust rating — Hard/Hard fully-closed (charter §"Funnel 双向锁评级")
+//
+//   - Upstream Hard (Go visibility): appendProjectionEvents is UNEXPORTED, so no
+//     package outside adapters/postgres can name it — a package-external append is
+//     not expressible. This is a real seal, not a deferred TODO.
+//   - Downstream Hard (whole-package caller-allowlist): upstream visibility only
+//     bars package-EXTERNAL callers; a second function INSIDE adapters/postgres could
+//     still call appendProjectionEvents and bypass the topic filter / tx binding.
+//     This scanner resolves every reference to the method by go/types object
+//     (info.Uses → *types.Func in adapters/postgres named appendProjectionEvents),
+//     binds it to its enclosing FuncDecl identity (ResolveEnclosingFunc.FullName),
+//     and allows exactly one caller: the chokepoint journalProjectionSubset. Any
+//     other in-package caller fails CI. Together the two rungs are the
+//     "Hard/Hard fully-closed" example from ai-robust.md §6 I2 — tighter than the
+//     #851/#893/#1282 cross-package families whose append+caller straddle a package
+//     boundary and are capped at Medium upstream by Go visibility.
+//
+// # Detection is REFERENCE-based and form-invariant
+//
+// Matching is by go/types object, so qualified, same-package-bare, aliased, and
+// dot-import forms all resolve to the same *types.Func. The enclosing-caller bind
+// is what makes it callsite-level (not file-level): all the decorator methods live
+// in one file, so a file-level allowlist could not distinguish journalProjectionSubset
+// from Write / appendProjectionEvents itself.
+//
+// # Blind spots and anti-vacuity
+//
+//   - A reference whose enclosing FuncDecl cannot be resolved (package-level
+//     initializer) is a hard violation, not silently skipped.
+//   - Reflection / unsafe construction is out of scope (charter §3) — same ceiling
+//     as every identifier-resolution funnel.
+//   - The anti-vacuity reverse check requires the chokepoint allowlist entry to have
+//     ≥1 observed live reference, so a removed/renamed caller fails CI rather than
+//     leaving a dead bypass slot.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"testing"
+)
+
+// journalAppendPkg is the canonical import path of adapters/postgres, anchored to
+// PlatformModulePath so a module rename updates one place.
+const journalAppendPkg = PlatformModulePath + "/adapters/postgres"
+
+// journalAppendFunc is the unexported method name being locked.
+const journalAppendFunc = "appendProjectionEvents"
+
+// journalAppendCallerAllowlist is the set of caller identities (types.Func.FullName)
+// permitted to reference appendProjectionEvents. Exactly one: the chokepoint
+// journalProjectionSubset, through which both Write and WriteBatch funnel.
+var journalAppendCallerAllowlist = map[string]struct{}{
+	"(*" + journalAppendPkg + ".journalingOutboxWriter).journalProjectionSubset": {},
+}
+
+// CheckProjectionEventJournalAppendCaller01 runs the rule over the running module
+// and returns its diagnostics (production dogfood single source).
+func CheckProjectionEventJournalAppendCaller01(t *testing.T, _ ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	observed := map[string]struct{}{}
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		return scanJournalAppendCallers(p, journalAppendPkg, journalAppendFunc, journalAppendCallerAllowlist, observed)
+	})
+	diags = append(diags, staleJournalAppendAllowlistDiags(journalAppendCallerAllowlist, observed)...)
+	return diags
+}
+
+// scanJournalAppendCallers records the enclosing-function identity of every
+// reference to targetPkg.<targetFunc> into observed and returns a diagnostic for
+// each reference whose enclosing caller is outside allowlist. Parameterized by
+// (targetPkg, targetFunc, allowlist) so the same body drives the production scan
+// and the RED fixture (the fixture reproduces the unexported-method shape under its
+// own package path).
+func scanJournalAppendCallers(
+	p *Pass, targetPkg, targetFunc string, allowlist map[string]struct{}, observed map[string]struct{},
+) []Diagnostic {
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+			if id.Name != targetFunc {
+				return
+			}
+			fn, ok := p.TypesInfo.Uses[id].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != targetPkg {
+				return
+			}
+			line := p.Fset.Position(id.Pos()).Line
+			caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, id)
+			if !ok {
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: line,
+					Message: "PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01: " + targetFunc +
+						" is referenced outside any FuncDecl (package-level initializer) — it " +
+						"cannot be allowlisted at the callsite level. Append only from the " +
+						"journalProjectionSubset chokepoint.",
+				})
+				return
+			}
+			callerID := caller.FullName()
+			observed[callerID] = struct{}{}
+			if _, allowed := allowlist[callerID]; allowed {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: line,
+				Message: fmt.Sprintf(
+					"PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01: %s is referenced from caller %q, "+
+						"which is not the sanctioned journal-append chokepoint. The durable "+
+						"projection_events journal must have exactly one append path "+
+						"(journalingOutboxWriter.journalProjectionSubset) so no code can forge rows "+
+						"the projection harness replays as truth. If this IS a new sanctioned "+
+						"append caller, add it to journalAppendCallerAllowlist with rationale.",
+					targetFunc, callerID,
+				),
+			})
+		})
+	}
+	return diags
+}
+
+// staleJournalAppendAllowlistDiags is the anti-vacuity reverse self-check: every
+// allowlist entry must correspond to ≥1 live observed reference.
+func staleJournalAppendAllowlistDiags(allowlist, observed map[string]struct{}) []Diagnostic {
+	var diags []Diagnostic
+	for caller := range allowlist {
+		if _, seen := observed[caller]; seen {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Message: fmt.Sprintf(
+				"PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01: allowlist entry %q is STALE — no live "+
+					"reference to %s observed from that caller. Either the scanner regressed or the "+
+					"caller was removed/renamed; drop the dead entry so it cannot become a silent "+
+					"bypass slot.",
+				caller, journalAppendFunc,
+			),
+		})
+	}
+	return diags
+}

--- a/tools/archtest/projection_event_journal_append_caller.go
+++ b/tools/archtest/projection_event_journal_append_caller.go
@@ -46,6 +46,13 @@ package archtest
 //     initializer) is a hard violation, not silently skipped.
 //   - Reflection / unsafe construction is out of scope (charter §3) — same ceiling
 //     as every identifier-resolution funnel.
+//   - A raw tx.Exec("INSERT INTO projection_events …") that does not call
+//     appendProjectionEvents is not caught here — the same raw/dynamic-SQL blind spot
+//     as I4 / §D7, backstopped by the migration-058 serving-role REVOKE. Note the
+//     SQL builder appendProjectionEvents delegates to (buildProjectionInsert) is
+//     side-effect-free (it returns a string + args, runs no Exec), so there is no
+//     callable Go helper that writes the journal — the single INSERT-executing
+//     function is appendProjectionEvents, which this scan locks.
 //   - The anti-vacuity reverse check requires the chokepoint allowlist entry to have
 //     ≥1 observed live reference, so a removed/renamed caller fails CI rather than
 //     leaving a dead bypass slot.

--- a/tools/archtest/projection_event_journal_append_caller_test.go
+++ b/tools/archtest/projection_event_journal_append_caller_test.go
@@ -1,0 +1,66 @@
+//go:build archtest
+
+// INVARIANT: PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01
+//
+// This _test.go dogfoods + precision-gates the rule. The importable rule body
+// (CheckProjectionEventJournalAppendCaller01 + scanJournalAppendCallers + the full
+// package godoc) lives in the non-test companion
+// projection_event_journal_append_caller.go — single source, no parallel rule body.
+package archtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProjectionEventJournalAppendCaller01 asserts that every production reference
+// to adapters/postgres.appendProjectionEvents originates from the single sanctioned
+// chokepoint (journalProjectionSubset), and that the allowlist entry is not stale
+// (anti-vacuity reverse check). Dogfoods GoCell itself via the importable rule body.
+func TestProjectionEventJournalAppendCaller01(t *testing.T) {
+	t.Parallel()
+	Report(t, "PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01",
+		CheckProjectionEventJournalAppendCaller01(t, ConfigForExternalCell{}))
+}
+
+// projectionAppendFixturePkg is the import path of the RED fixture package.
+const projectionAppendFixturePkg = PlatformModulePath + "/tools/archtest/internal/projectionappendfixture"
+
+// projectionAppendFixtureAllowlist sanctions only the fixture's chokepoint, so the
+// fixture's bypassAppend caller is the single expected violation.
+var projectionAppendFixtureAllowlist = map[string]struct{}{
+	"(*" + projectionAppendFixturePkg + ".fakeJournalingWriter).journalProjectionSubset": {},
+}
+
+// TestProjectionEventJournalAppendCaller01_RedFixture is the negative control: the
+// detector, run against a self-contained reproduction of the unexported-append
+// shape (appendProjectionEvents cannot be called from outside adapters/postgres, so
+// the real symbol cannot be forged in a fixture), must fire EXACTLY once — on the
+// unsanctioned bypassAppend caller — proving the downstream whole-package
+// caller-allowlist closes the same-package bypass blind spot.
+func TestProjectionEventJournalAppendCaller01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var found int
+	throwaway := map[string]struct{}{}
+	_ = Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/projectionappendfixture"}),
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			found += len(scanJournalAppendCallers(
+				p, projectionAppendFixturePkg, journalAppendFunc, projectionAppendFixtureAllowlist, throwaway))
+			return nil
+		})
+	assert.Equal(t, 1, found,
+		"PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01 RED fixture self-check FAILED: expected "+
+			"exactly 1 violation (bypassAppend calls appendProjectionEvents from an "+
+			"unsanctioned same-package caller). Got %d — found<1 means the scanner missed the "+
+			"in-package method call (whole-package downstream regression); found>1 means "+
+			"over-detection. This fixture is the negative control for the Hard/Hard funnel.", found)
+}

--- a/tools/archtest/projection_event_journal_topic_allowlist_derived_test.go
+++ b/tools/archtest/projection_event_journal_topic_allowlist_derived_test.go
@@ -50,8 +50,12 @@ import (
 const (
 	journalDecoratorPkg  = PlatformModulePath + "/adapters/postgres"
 	journalDecoratorCtor = "NewJournalingOutboxWriter"
-	// journalTopicsDerivedFunc is the cellgen-derived accessor the topic argument must be.
+	// journalTopicsDerivedFunc / journalTopicsDerivedPkg pin the cellgen-derived
+	// accessor the topic argument must be — BOTH name and owning package, so a
+	// same-named function in any other package cannot satisfy the rule (mirrors the
+	// pkg-path precision of the I2 append-caller scan).
 	journalTopicsDerivedFunc = "generatedProjectionSourceTopics"
+	journalTopicsDerivedPkg  = PlatformModulePath + "/cmd/corebundle"
 )
 
 // TestProjectionEventJournalTopicAllowlistDerived01 asserts that every production
@@ -75,7 +79,10 @@ func TestProjectionEventJournalTopicAllowlistDerived01(t *testing.T) {
 		diags = append(diags, Diagnostic{
 			Message: "PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01: no production " +
 				"NewJournalingOutboxWriter call observed — the journaling decorator appears unwired, " +
-				"so the derived-topic-set rule is vacuous. Wire it in cmd/corebundle/cap_wiring.go.",
+				"so the derived-topic-set rule is vacuous. Run `gocell generate assembly` so " +
+				"generatedProjectionSourceTopics() exists in modules_gen.go, then wire it in " +
+				"cmd/corebundle/cap_wiring.go: " +
+				"adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(shared.Clock), generatedProjectionSourceTopics()).",
 		})
 	}
 	Report(t, "PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01", diags)
@@ -134,7 +141,8 @@ func isDerivedTopicsArg(info *types.Info, expr ast.Expr) bool {
 		return false
 	}
 	fn, ok := info.Uses[id].(*types.Func)
-	return ok && fn.Name() == journalTopicsDerivedFunc
+	return ok && fn.Name() == journalTopicsDerivedFunc &&
+		fn.Pkg() != nil && fn.Pkg().Path() == journalTopicsDerivedPkg
 }
 
 // TestProjectionEventJournalTopicAllowlistDerived01_RedFixture is the negative

--- a/tools/archtest/projection_event_journal_topic_allowlist_derived_test.go
+++ b/tools/archtest/projection_event_journal_topic_allowlist_derived_test.go
@@ -1,0 +1,163 @@
+//go:build archtest
+
+// INVARIANT: PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01
+//
+// PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 (EPIC #1504 PR-02 / ADR
+// 202606071600-1504 §6 I5) — the journaling outbox writer decorator's projection-
+// source topic set MUST be cellgen-derived, never a hand-typed literal.
+//
+// # What this guards
+//
+// journalingOutboxWriter double-writes only events whose topic is in projectionTopics
+// (D4 topic-filter). If the composition root passed a hand-maintained []string literal,
+// it would silently drift from the slice.yaml projection declarations — a new projection
+// would not be journaled (rebuild gap) or a removed one would linger. The set is instead
+// derived by cellgen into generatedProjectionSourceTopics() (modules_gen.go), so adding a
+// projection auto-enrolls its topic on the next `gocell generate assembly`.
+//
+// # Two-axis AI-robust rating (charter §"Funnel 双向锁评级") — Hard
+//
+//   - Upstream Hard (codegen golden): generatedProjectionSourceTopics() is emitted by
+//     kernel/assembly.GenerateModulesGen from slice.yaml contractUsages and byte-locked
+//     by `gocell generate assembly --verify` (tools/generatedverify). Stale output —
+//     metadata changed without regen — fails CI. The derivation correctness is covered by
+//     TestCollectOutboxProjectionTopics.
+//   - Downstream Hard (this archtest): every NewJournalingOutboxWriter callsite must pass
+//     the generatedProjectionSourceTopics() accessor as the topic argument — resolved by
+//     go/types object, so a composite literal, a different func, or a variable is flagged.
+//     Without this rung, the golden-locked derivation could be bypassed by hand-typing the
+//     argument at the callsite.
+//
+// # Blind spots and anti-vacuity
+//
+//   - A NewJournalingOutboxWriter call with <2 args cannot type-check, so the arg index is
+//     always safe.
+//   - The anti-vacuity guard requires ≥1 production NewJournalingOutboxWriter call to be
+//     observed, so the rule cannot silently pass if the decorator is unwired.
+//   - The RED fixture (projectiontopicfixture) is the negative control: a hand-typed []string
+//     literal must be flagged.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	journalDecoratorPkg  = PlatformModulePath + "/adapters/postgres"
+	journalDecoratorCtor = "NewJournalingOutboxWriter"
+	// journalTopicsDerivedFunc is the cellgen-derived accessor the topic argument must be.
+	journalTopicsDerivedFunc = "generatedProjectionSourceTopics"
+)
+
+// TestProjectionEventJournalTopicAllowlistDerived01 asserts that every production
+// NewJournalingOutboxWriter callsite derives its topic set from
+// generatedProjectionSourceTopics() (no hand-typed literal), and that at least one
+// such call is observed (anti-vacuity — the decorator is wired).
+func TestProjectionEventJournalTopicAllowlistDerived01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var observed int
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		return scanJournalTopicDerivation(p, &observed)
+	})
+	if observed == 0 {
+		diags = append(diags, Diagnostic{
+			Message: "PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01: no production " +
+				"NewJournalingOutboxWriter call observed — the journaling decorator appears unwired, " +
+				"so the derived-topic-set rule is vacuous. Wire it in cmd/corebundle/cap_wiring.go.",
+		})
+	}
+	Report(t, "PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01", diags)
+}
+
+// scanJournalTopicDerivation flags every NewJournalingOutboxWriter call whose topic
+// argument is not the generatedProjectionSourceTopics() accessor, and counts the
+// sanctioned calls into observed for the anti-vacuity check.
+func scanJournalTopicDerivation(p *Pass, observed *int) []Diagnostic {
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+			if !ok || pkgPath != journalDecoratorPkg || name != journalDecoratorCtor {
+				return
+			}
+			if len(call.Args) < 2 {
+				return // cannot type-check; the compiler rejects it first
+			}
+			if isDerivedTopicsArg(p.TypesInfo, call.Args[1]) {
+				*observed++
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(call.Pos()).Line,
+				Message: fmt.Sprintf(
+					"PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01: %s is constructed with a "+
+						"topic set that is not the cellgen-derived %s(). The projection-source topic "+
+						"set must be derived from slice.yaml (so adding a projection auto-enrolls its "+
+						"topic), never a hand-typed literal that silently drifts from metadata. Pass "+
+						"generatedProjectionSourceTopics() as the topic argument.",
+					journalDecoratorCtor, journalTopicsDerivedFunc,
+				),
+			})
+		})
+	}
+	return diags
+}
+
+// isDerivedTopicsArg reports whether expr is a call to the generatedProjectionSourceTopics
+// accessor (resolved by go/types object, so import shape is irrelevant).
+func isDerivedTopicsArg(info *types.Info, expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	var id *ast.Ident
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		id = fun
+	case *ast.SelectorExpr:
+		id = fun.Sel
+	default:
+		return false
+	}
+	fn, ok := info.Uses[id].(*types.Func)
+	return ok && fn.Name() == journalTopicsDerivedFunc
+}
+
+// TestProjectionEventJournalTopicAllowlistDerived01_RedFixture is the negative
+// control: the detector must fire on a hand-typed []string topic literal.
+func TestProjectionEventJournalTopicAllowlistDerived01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var throwaway int
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/projectiontopicfixture"}),
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			found += len(scanJournalTopicDerivation(p, &throwaway))
+			return nil
+		})
+	assert.Equal(t, 1, found,
+		"PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 RED fixture self-check FAILED: "+
+			"expected exactly 1 violation (handTypedTopics passes a []string literal instead of "+
+			"generatedProjectionSourceTopics()). Got %d.", found)
+}


### PR DESCRIPTION
## Summary

EPIC #1504 **PR-02**：durable 投影 journal `projection_events` 的 **emit 期同事务双写装饰器**（ADR §D4）+ 两条写侧守卫（I2 append-caller / I5 topic-derived）+ 写路径回归测试。`journalingOutboxWriter` 包住基础 `OutboxWriter`，对 projection-source topic 的事件在 producer **既有业务 tx** 内 append `projection_events`，与业务事实原子提交。

## Why / 背景

#1504 的投影 harness 原坐在 transient `outbox_entries` relay 上（被 cleanup 删行 → rebuild 不健全 / live `Position` dead-letter，即 #1504 根 bug）。PR-01（#1825）已落 durable `projection_events` 读侧（source + cursor + readyz + DB 引擎 append-only）。本 PR 补**写侧**：emit 期同事务双写（event-store-primary，对标 Axon/Marten），让 journal 行在事件投递前已提交。topic-filtered（D4）使增长有界——只 journal 真会被 replay 的事件。

> 注：corebundle 今无 outbox 投影，派生 topic 集为空 → 装饰器 always-wire 但**当前 inert**（ADR §8 bootstrap-gap，foundation-first）；加投影即自动 journal（I5）。

## Refs

- `Refs: Closes #1769`（EPIC #1504 / ADR `docs/architecture/202606071600-1504-adr-projection-event-journal.md` §D4 / §6 I2·I5 / §9 PR-02）
- 依赖 PR-01 #1825（已 merged）
- `ref: axoniq/AxonFramework JdbcEventStore + TrackingToken`（retained event store 即投影源，业务 tx 内写）

## Risk / 兼容性

- **无 wire 契约变更**：不改 contract / event payload / HTTP path；topic 集从既有 `slice.yaml contractUsages` 派生（无 schema 改动）。
- 新增 exported `adapters/postgres.NewJournalingOutboxWriter`（已纳入 `CAPABILITY-PROVIDER-FUNNEL-01` 禁构造集，仅 cap_wiring + tests）。
- always-decorate：postgres 模式每次 outbox write 多一次 map 查（空集即 forward 原样）；memory 模式无 PG writer，不受影响。
- I5 升 Medium→Hard（ADR §6 就地重评，威胁矩阵无行翻转 — 见 §Amendment 2026-06-12）。
- **PR-03 验收项（本 PR 刻意不做）**：「生产 provider 的 writer 必是 journaling 装饰器」的 Hard 守卫——该守卫只在读侧消费 journal 时才有意义（PR-03 wiring / PR-04 e2e），ADR enforcement 集刻意不含（最小化原则），PR-04 T-06-2 e2e 为下游网。

## Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| 双写装饰器（D4） | 无 | — | 无 | decorator integration（atomicity/topic-filter/idempotency，Write+WriteBatch） | ADR §4.3 as-built |
| topic 集派生（I5） | 无 | `modules_gen.go` `generatedProjectionSourceTopics()`（golden 字节锁） | 读 slice.yaml projection CU（无改） | `TestCollectOutboxProjectionTopics` + I5 archtest | ADR §6 I5、eventbus.md 指针 |
| append 收口（I2） | 无 | — | 无 | I2 archtest + RED fixture + 反向自检 | ADR §6 I2 |
| funnel allowlist | 无 | — | 无 | cap funnel RED fixture（6→7） | cap_wiring godoc |
| journal 增长运维 | 无 | — | 无 | — | alerting-rules.md |

## Test plan

- [x] `go build ./...` + `go build -tags=integration ./...` 通过
- [x] `go test ./adapters/postgres/... ./kernel/assembly/...` 通过；`gocell verify archtest --rule=PROJECTION-EVENT-JOURNAL-APPEND-CALLER-01 / -TOPIC-ALLOWLIST-DERIVED-01 / CAPABILITY-PROVIDER-FUNNEL-01` 全绿（含 RED fixture）
- [x] `go test -tags=integration github.com/ghbvf/gocell/adapters/postgres/`（testcontainers，全包 53s）通过——含三条写路径回归
- [x] `gocell generate assembly --all` 无 drift；`verify-generated`（382 files）+ `generatedverify` golden 通过
- [x] `golangci-lint run`（main + tools `--build-tags=archtest,releasesmoke`）0 issues；gofumpt clean；`gocell validate --strict` 0 errors
- [x] cheap archtest-invariants 门（ARCHTEST-LEAF-BUILD-TAG / MODULE-PATH-FUNNEL / FIXTURE-CELLID-TYPED-BUILDER …）通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
