### PR TITLE
docs(archtest): 纠正 CONFIG-NOOP-TRANSFORMER-FUNNEL-01 godoc 退役断言 [#1411]

### DIFF
--- a/tools/archtest/config_noop_transformer_funnel_test.go
+++ b/tools/archtest/config_noop_transformer_funnel_test.go
@@ -42,8 +42,18 @@ const (
 // zero-value struct elsewhere" inexpressible; this archtest is the backstop).
 // Same shape as the reconstruction / ctx-write caller-allowlist funnels.
 //
-// Hard-上游升级路径（接 gocell:"required" tag-funnel，泛化 requireddepsgen）追踪于
-// gh #1411；届时本 archtest 可退役。
+// 上游 Medium = 接受的终态，不被 nil-guard 退役：本 funnel 与 Service.validateRequired
+// 风格的 gocell:"required" nil-guard 守正交威胁，不可互替——
+//   - required nil-guard 走 validation.IsNilInterface 只抓 typed-nil；NoopTransformer{}
+//     是非 nil 具体值（IsNilInterface(NoopTransformer{}) == false），会被放行。
+//   - 本 funnel 抓「非 nil 的无加密 transformer 被 mint 到别处并接入 postgres」（明文落盘），
+//     configpg.WithValueTransformer 即此类入口；其 crypto.NoopTransformer{} 字面量被本扫描捕获。
+//
+// 故给 ConfigRepository.transformer 打 required tag 不能退役本 archtest（原 gh #1411 前提有误：
+// transformer 实为可选依赖，required-guard 与本 funnel 正交，#1411 已 close）。唯一退役路径 =
+// sealed「持久化 transformer」能力类型（结构性排除 NoopTransformer 接入 postgres，使坏状态不可
+// 构造而非仅被扫描）；该路径成本 > 收益（hole 已被本 Medium 扫描封闭），不立项，作为独立 ADR 级
+// 决策保留。本注释修正不降级任何 enforcement，威胁矩阵不变（仍 Hard 下游 / Medium 上游）。
 //
 // Blind spots (AST-only Run; documented per ai-robust §载体决策原则):
 //   - Aliased construction via a function value (e.g. `f := crypto.NoopTransformer{};`

--- a/tools/archtest/config_noop_transformer_funnel_test.go
+++ b/tools/archtest/config_noop_transformer_funnel_test.go
@@ -46,8 +46,10 @@ const (
 // 风格的 gocell:"required" nil-guard 守正交威胁，不可互替——
 //   - required nil-guard 走 validation.IsNilInterface 只抓 typed-nil；NoopTransformer{}
 //     是非 nil 具体值（IsNilInterface(NoopTransformer{}) == false），会被放行。
-//   - 本 funnel 抓「非 nil 的无加密 transformer 被 mint 到别处并接入 postgres」（明文落盘），
-//     configpg.WithValueTransformer 即此类入口；其 crypto.NoopTransformer{} 字面量被本扫描捕获。
+//   - 本 funnel 抓「非 nil 的无加密 transformer 被 mint 到别处并接入 postgres」（明文落盘）：
+//     configpg.WithValueTransformer 是这样一个非 allowlist 入口——若有人写
+//     configpg.WithValueTransformer(crypto.NoopTransformer{})，该字面量即被本扫描捕获
+//     （当前无此类调用；唯一 NoopTransformer{} 出生点是 allowlist 的 resolveValueTransformer）。
 //
 // 故给 ConfigRepository.transformer 打 required tag 不能退役本 archtest（原 gh #1411 前提有误：
 // transformer 实为可选依赖，required-guard 与本 funnel 正交，#1411 已 close）。唯一退役路径 =


### PR DESCRIPTION
## Summary

纠正 `CONFIG-NOOP-TRANSFORMER-FUNNEL-01` archtest 的 godoc：删除「#1411 接 `gocell:"required"` tag-funnel 后本 funnel 可退役」的错误断言，改为「上游 Medium = 接受的终态」显式决策。

## Why / 背景

#1411 原意：泛化 `requireddepsgen`，给 `ConfigRepository.transformer` 打 `gocell:"required"` 达双向 Hard，届时退役本 funnel。经 3 explorer + 2 Plan agent 对真实代码核实，**前提不成立**：

1. **`transformer` 是设计上的可选依赖**——`config_repo.go` 四个加解密方法（`:217/:241/:260/:283`）显式处理 `r.transformer == nil`，只在加解密**敏感值**时报错；非敏感配置走明文路径不需要 transformer。`WithValueTransformer`（`postgres/options.go:31`）可选、`WithPool` 允许不传、`examples/ssobff/app.go:621` 即真实不传。打 required tag 会否决合法「无加密」部署 + 让 4 个 nil 守卫变死代码（触发 archtest B2）。ConfigRepository **无任何无条件必填 interface 依赖**（transformer 可选 / session·db 互斥对 / clock 已 MustHaveClock 守卫 / logger 有默认）→ 无合法 tag 目标。
2. **「可退役」可证伪**——required-guard 走 `validation.IsNilInterface` 只抓 typed-nil；`NoopTransformer{}` 是非 nil 具体值（`IsNilInterface(NoopTransformer{}) == false`）被放行。本 funnel 守**正交威胁**：防非 nil 的无加密 transformer 接入 postgres（明文落盘），`configpg.WithValueTransformer` 即此类入口。退役 funnel = 重开 F3 明文持久化洞。

唯一能让本 funnel 退役的路径是 sealed「持久化 transformer」能力类型（结构性排除 NoopTransformer 接入 postgres），属独立 ADR 级设计，成本 > 收益（hole 已被本 Medium 扫描封闭），**不立项**。按 `ai-robust.md §审查要求` 同步在 godoc 重评威胁矩阵（不变）。

saga `#1317` 不同形（其 `NewCoordinator`/`NewExecutor` 依赖**真正必填**，断言正确），本 PR **不触碰**。

## Refs

Closes #1411

## Risk / 兼容性

无。纯 godoc 注释修正，无逻辑改动；测试体不变，`CONFIG-NOOP-TRANSFORMER-FUNNEL-01` 仍全绿；不降级任何 enforcement（仍 Hard 下游 / Medium 上游）。

## Test plan

- [x] `go vet -tags=archtest ./tools/archtest/` 本地通过（纯注释，build 无影响）
- [x] `go test -tags=archtest ./tools/archtest/ -run TestConfigNoopTransformerFunnel01` 绿
- [x] `golangci-lint run --build-tags=archtest ./tools/archtest/` 0 issues
