### PR TITLE
feat(archtest): GRPC-CELL-NO-CLIENT-DIAL-01 跨 cell gRPC 客户端直连禁制 + 直传=0 守卫清单 [#1961]

### DIFF
--- a/tools/archtest/doc.go
+++ b/tools/archtest/doc.go
@@ -55,9 +55,12 @@
 //	  (archtest_test.go)                          public subpackage of cell B
 //	LAYER-09 / LAYER-09T                  Medium  cell A importing cell B/events
 //	  (archtest_test.go)                          (direct / transitive)
-//	GRPC-CELL-NO-CLIENT-DIAL-01           Medium  a cell constructing a gRPC client
-//	  (grpc_cell_no_client_dial_test.go)          to dial a sibling cell in-process
-//	                                             (#1961 — closes the #1752 runtime/grpc gap)
+//	GRPC-CELL-NO-CLIENT-DIAL-01           Medium  a cell constructing OR holding a
+//	  (grpc_cell_no_client_dial_test.go)          gRPC client (dial / *grpc.ClientConn /
+//	                                             generated <Svc>Client surface) to reach
+//	                                             a sibling cell in-process — incl. the
+//	                                             inject-a-built-client escape (#1961;
+//	                                             closes the #1752 runtime/grpc gap)
 //
 // Open blind spots (NOT yet guarded — tracked, not silently dropped):
 //

--- a/tools/archtest/doc.go
+++ b/tools/archtest/doc.go
@@ -37,6 +37,36 @@
 //	            pkg/query remains limited to generic pagination, cursor,
 //	            runmode, and in-memory pagination helpers
 //
+// # In-process cross-cell Go handoff = 0 — guard inventory (epic #1423 / US8)
+//
+// US8's acceptance signal (SC-003 / FR-009) requires "进程内跨 cell Go 直传 = 0"
+// (zero in-process cross-cell Go handoff) be permanently archtest-guarded at
+// Medium+. The guards that together enforce it, organized by handoff FORM (the
+// inventory deliverable of #1961 / T071 — this is the口径 single source; per-rule
+// symbols/blind spots live in each rule's own godoc):
+//
+//	MODULE-PROVIDE-NO-VALUE-HANDOFF-01   Hard    re-opening the ModuleResult
+//	  (module_provide_signature_frozen_test.go)  value-handoff channel — a cell
+//	                                             handing sibling values back through
+//	                                             Provide (reflect field freeze)
+//	LAYER-05 / LAYER-05T                  Medium  cell A importing cell B/internal/
+//	  (archtest_test.go)                          (direct / transitive)
+//	LAYER-06 / LAYER-06T                  Medium  cell A importing a cell-owned
+//	  (archtest_test.go)                          public subpackage of cell B
+//	LAYER-09 / LAYER-09T                  Medium  cell A importing cell B/events
+//	  (archtest_test.go)                          (direct / transitive)
+//	GRPC-CELL-NO-CLIENT-DIAL-01           Medium  a cell constructing a gRPC client
+//	  (grpc_cell_no_client_dial_test.go)          to dial a sibling cell in-process
+//	                                             (#1961 — closes the #1752 runtime/grpc gap)
+//
+// Open blind spots (NOT yet guarded — tracked, not silently dropped):
+//
+//	interface{} / any pointer smuggling — a cell holding a sibling cell's concrete
+//	  value behind an `any` field/param; type erasure defeats the LAYER-05/06 import
+//	  edges and the MODULE-PROVIDE field freeze. Backlog: gh #2002 (Medium+ target).
+//	sync HTTP direct dial — a cell calling a sibling contract via a raw http.Client.
+//	  OUT OF SCOPE here: owned by US4's CellTransport funnel task, not #1961.
+//
 // # Themed invariant files & reverse-index anchors
 //
 // Beyond the LAYER-* / PGQUERY-01 rules above, this package hosts the rest of

--- a/tools/archtest/grpc_cell_no_client_dial_test.go
+++ b/tools/archtest/grpc_cell_no_client_dial_test.go
@@ -357,10 +357,4 @@ func TestGRPCCellNoClientDial01_FixtureScanRED(t *testing.T) {
 	assert.Positive(t, kinds["conn-type"], "client-conn type (*grpc.ClientConn / ClientConnInterface) must fire")
 	assert.Positive(t, kinds["generated-client"],
 		"generated client surface (New*Client ctor + <Svc>Client interface) must fire")
-	// The stub branch (generated New*Client) cannot fire from this fixture: it
-	// imports only google.golang.org/grpc, NOT the separate generated module. The
-	// stub detector branch is pinned by TestGRPCCellNoClientDial01_SyntheticDetector.
-	// Asserting zero here guards against a future fixture edit silently relying on
-	// (and masking a regression in) the unexercised stub path.
-	assert.Zero(t, kinds["stub"], "stub branch must NOT fire from this grpc-only fixture")
 }

--- a/tools/archtest/grpc_cell_no_client_dial_test.go
+++ b/tools/archtest/grpc_cell_no_client_dial_test.go
@@ -1,0 +1,314 @@
+//go:build archtest
+
+// INVARIANT: GRPC-CELL-NO-CLIENT-DIAL-01
+//
+// # GRPC-CELL-NO-CLIENT-DIAL-01 — cell production code must not construct a gRPC client (Medium)
+//
+// ## Rule
+//
+// A cell's production code MUST NOT construct or hold a gRPC client connection.
+// Concretely, no package owned by a cell (Classifier.Cell(pkg) != "") may, in a
+// non-test production file, reference any of:
+//
+//   - google.golang.org/grpc.Dial / .DialContext / .NewClient   (dial primitive)
+//   - google.golang.org/grpc.ClientConn / .ClientConnInterface   (client-conn type)
+//   - a generated gRPC client constructor New<Svc>Client whose package lives
+//     under .../generated/contracts/grpc/...                     (client stub)
+//
+// Rationale (epic #1423 / US8 — 进程内跨 cell Go 直传 = 0): cells communicate
+// only through contracts. A cell reaches an EXTERNAL system through adapters/
+// (the only layer that may dial), never directly. Therefore the only thing a
+// cell could be doing by constructing a gRPC ClientConn in-process is dialing a
+// SIBLING cell's gRPC service — the cross-cell direct connection this invariant
+// forbids. Server-side registration (naming grpc.ServiceRegistrar, calling the
+// generated Register<Svc>Server) is legitimate and explicitly NOT flagged.
+//
+// Why not depguard (the gap #1961 names): .golangci.yml cells-isolation must
+// ALLOW cells to import google.golang.org/grpc, because the cellgen-generated
+// cell_gen.go Register callback `func(r grpc.ServiceRegistrar){ ... }` names the
+// transport lib (#1601). depguard is symbol-blind at import granularity, so it
+// cannot distinguish a cell legitimately importing grpc for server registration
+// from a cell illegitimately calling grpc.NewClient to dial a sibling. This rule
+// closes that gap at callsite/symbol granularity.
+//
+// ## AI-robust rating: Medium — and why Hard is unreachable here (per ai-robust.md)
+//
+// This is a caller-allowlist constraint ("a cell must not CALL grpc.NewClient").
+// Each Hard carrier is unreachable without the already-rejected #1582 marker
+// rework (and that rework is the SERVER path, out of scope here):
+//
+//  1. type system / sealed construction — grpc.ClientConn / grpc.NewClient are a
+//     third-party package's exported API; we cannot seal their construction nor
+//     make "calling them" a compile error. Any package may import & call them. ✗
+//  2. codegen funnel + golden — a client dial is hand-written business code; it
+//     flows through no codegen seam, so there is no golden to byte-lock. ✗
+//  3. reflect field freeze — this forbids calling a function, not the shape of a
+//     struct/interface; nothing to freeze. ✗
+//  4. depguard import-deny (the closest-to-Hard depth) — a cell's only
+//     production grpc reference today is the generated cell_gen.go, so depguard
+//     could in principle deny grpc imports in a cell's non-cell_gen.go files,
+//     making `grpc.NewClient` unnameable in hand code. NOT adopted: depguard is
+//     symbol-blind (cannot separate client vs server use of the same grpc pkg),
+//     it leans on the fragile "only cell_gen.go names grpc" premise (a future
+//     generated streaming surface that names grpc in a hand handler breaks it),
+//     and it still cannot match the symbol precision needed for the generated
+//     stub / conn-injection forms.
+//
+// Conclusion: this constraint is structurally identical to
+// GRPC-SERVICE-IN-CONTRACT-01/A (who may call reg.GRPCService) and
+// SVCTOKEN-CALLER-CELL-REQUIRED-01 (who may call GenerateServiceToken). Medium
+// (typed callsite scan via ResolvePackageRef) is the reachable ceiling for the
+// "who may call a third-party exported function" carrier class; there is NO
+// low-cost Hard path. Permanent ceiling, same #1631 family as
+// GRPC-SERVICE-IN-CONTRACT-01/A — no Hard-conversion issue is filed (no cheap
+// path exists).
+//
+// ## Blind spots and reverse self-checks
+//
+//   - Vacuity: zero production cell constructs a gRPC client today (cells only
+//     register servers; the only grpc.NewClient callsites are in _test.go
+//     bufnet harnesses, excluded by Tests:false). The production scan
+//     (TestGRPCCellNoClientDial01) is therefore vacuously green — exactly like
+//     GRPC-SERVICE-IN-CONTRACT-01. Anti-vacuity is provided by the synthetic
+//     fixture (TestGRPCCellNoClientDial01_FixtureScanRED) which MUST fire, and by
+//     the pure-detector table (TestGRPCCellNoClientDial01_SyntheticDetector).
+//   - Generated-stub AST coverage: the stub branch (New<Svc>Client under
+//     /generated/contracts/grpc/) is covered only by the pure-detector table,
+//     NOT by a fixture-AST case — the generated tree is a SEPARATE go module
+//     (github.com/ghbvf/gocell/generated) that the main module deliberately does
+//     not depend on, so a main-module fixture cannot import it. The SCAN layer
+//     (SelectorExpr walk + ResolvePackageRef → pkgPath/name) is shared with the
+//     dial branch, which the fixture DOES exercise; only the detector's
+//     pkgPath-prefix/name-regex branch is fixture-uncovered, and the synthetic
+//     table pins it. dial is the chokepoint anyway (no ClientConn → no stub call
+//     unless the conn is smuggled via interface{} — see the doc.go inventory's
+//     open blind spot).
+//   - Function-value indirection (`f := grpc.NewClient; f(...)`): the bare-ident
+//     `grpc.NewClient` selector is still walked and resolved, so assigning the
+//     method value is itself flagged.
+//   - Dot-import (`import . "google.golang.org/grpc"`): bare `NewClient(...)`
+//     resolves via ResolvePackageRef's *types.Func path; additionally cells
+//     cannot dot-import per the revive dot-imports linter.
+//
+// ## Symbol inventory (forbidden client-construction symbol set)
+//
+//	google.golang.org/grpc: Dial, DialContext, NewClient        (dial)
+//	google.golang.org/grpc: ClientConn, ClientConnInterface     (conn-type)
+//	.../generated/contracts/grpc/...: ^New[A-Za-z0-9]*Client$   (stub)
+//
+// Explicitly NOT forbidden (server side / type references):
+// grpc.ServiceRegistrar, grpc.NewServer, grpc.ServiceDesc, grpc.ServerStream,
+// the generated Register<Svc>Server, the generated <Svc>Client interface type.
+//
+// ref: tools/archtest/grpc_service_in_contract_test.go (typed callsite scan + synthetic fixture template)
+// ref: tools/archtest/svctoken_caller_cell.go (ResolvePackageRef callsite identification)
+// ref: tools/archtest/internal/grpccelldialfixture/fixture.go (RED fixture)
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kerneldepgraph "github.com/ghbvf/gocell/kernel/depgraph"
+)
+
+// ruleGRPCCellNoClientDial is the archtest rule identifier.
+const ruleGRPCCellNoClientDial = "GRPC-CELL-NO-CLIENT-DIAL-01"
+
+// grpcRuntimeLibPath is the canonical import path of the gRPC transport library.
+const grpcRuntimeLibPath = "google.golang.org/grpc"
+
+// generatedGRPCContractsMarker is the path segment shared by every buf/protoc
+// generated gRPC contract package (where the typed New<Svc>Client stub
+// constructors live). It is a substring (not a prefix) so it matches regardless
+// of how the separate `generated` module's path is anchored.
+const generatedGRPCContractsMarker = "/generated/contracts/grpc/"
+
+// grpcClientCtorRe matches a generated gRPC client constructor name
+// (New<Svc>Client). Anchored so it never matches Register<Svc>Server or the
+// bare <Svc>Client interface type.
+var grpcClientCtorRe = regexp.MustCompile(`^New[A-Za-z0-9]*Client$`)
+
+// grpcCellDialFixturePkg is the archtest_fixture RED fixture package pattern.
+const grpcCellDialFixturePkg = "./tools/archtest/internal/grpccelldialfixture"
+
+// forbiddenGRPCClientRef classifies a (pkgPath, name) package-symbol reference
+// as a forbidden cross-cell gRPC client-construction symbol. It returns the
+// violation kind ("dial" / "conn-type" / "stub") and true when forbidden, or
+// ("", false) otherwise. Server-side symbols (grpc.ServiceRegistrar,
+// grpc.NewServer, the generated Register<Svc>Server) and any non-grpc symbol are
+// not forbidden. This is the pure detector core shared by the production scan
+// and the synthetic table (mirrors detectOrphanRegs in grpc_service_in_contract).
+func forbiddenGRPCClientRef(pkgPath, name string) (kind string, forbidden bool) {
+	if pkgPath == grpcRuntimeLibPath {
+		switch name {
+		case "Dial", "DialContext", "NewClient":
+			return "dial", true
+		case "ClientConn", "ClientConnInterface":
+			return "conn-type", true
+		default:
+			return "", false
+		}
+	}
+	if strings.Contains(pkgPath, generatedGRPCContractsMarker) && grpcClientCtorRe.MatchString(name) {
+		return "stub", true
+	}
+	return "", false
+}
+
+// scanGRPCClientConstruction walks one file's AST for package-symbol references
+// (selector `pkg.Name` and dot-imported bare `Name`) and emits a Diagnostic for
+// every forbidden gRPC client-construction symbol. The caller decides whether
+// the file belongs to a cell (production scan) or not (fixture scan).
+func scanGRPCClientConstruction(p *Pass, file *ast.File, rel string) []Diagnostic {
+	var diags []Diagnostic
+	emit := func(node ast.Expr) {
+		path, name, ok := ResolvePackageRef(p.TypesInfo, node)
+		if !ok {
+			return
+		}
+		kind, forbidden := forbiddenGRPCClientRef(path, name)
+		if !forbidden {
+			return
+		}
+		line := p.Fset.Position(node.Pos()).Line
+		diags = append(diags, Diagnostic{
+			Rel:  rel,
+			Line: line,
+			Message: fmt.Sprintf(
+				"%s [%s]: cell production code references %s.%s at %s:%d — a cell must not construct a "+
+					"gRPC client (dial primitive / generated New*Client stub / *grpc.ClientConn). In-process "+
+					"cross-cell calls go through contracts, not a direct gRPC dial; external gRPC reach belongs "+
+					"in adapters/, never a cell (epic #1423 US8: 进程内跨 cell Go 直传 = 0).",
+				ruleGRPCCellNoClientDial, kind, path, name, rel, line),
+		})
+	}
+	EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) { emit(sel) })
+	return diags
+}
+
+// TestGRPCCellNoClientDial01 is the production scan: every cell-owned production
+// package (Classifier.Cell != "") must be free of gRPC client construction.
+// Vacuously green today — see the godoc "Blind spots / Vacuity" note.
+func TestGRPCCellNoClientDial01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := findModuleRoot(t)
+	cls := kerneldepgraph.NewClassifier(moduleImportPaths(findWorkspaceModules(t, root)))
+
+	var diags []Diagnostic
+	_ = Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil {
+				return nil
+			}
+			if cellOf(cls, p.Pkg.Path()) == "" {
+				return nil // only cell-owned packages are in scope
+			}
+			for _, f := range p.Files {
+				diags = append(diags, scanGRPCClientConstruction(p, f, p.Rel(f))...)
+			}
+			return nil
+		})
+
+	Report(t, ruleGRPCCellNoClientDial, diags)
+}
+
+// TestGRPCCellNoClientDial01_SyntheticDetector pins the pure forbiddenGRPCClientRef
+// classifier (RED forbidden set + GREEN server-side / type-reference set),
+// proving the detector branch is reachable independent of the repo's vacuous
+// production state.
+func TestGRPCCellNoClientDial01_SyntheticDetector(t *testing.T) {
+	t.Parallel()
+
+	const genPkg = PlatformModulePath + "/generated/contracts/grpc/device/command/v1"
+
+	red := []struct {
+		pkg, name, wantKind string
+	}{
+		{grpcRuntimeLibPath, "Dial", "dial"},
+		{grpcRuntimeLibPath, "DialContext", "dial"},
+		{grpcRuntimeLibPath, "NewClient", "dial"},
+		{grpcRuntimeLibPath, "ClientConn", "conn-type"},
+		{grpcRuntimeLibPath, "ClientConnInterface", "conn-type"},
+		{genPkg, "NewDeviceCommandServiceClient", "stub"},
+		{genPkg, "NewFooClient", "stub"},
+	}
+	for _, tc := range red {
+		kind, forbidden := forbiddenGRPCClientRef(tc.pkg, tc.name)
+		assert.Truef(t, forbidden, "%s.%s must be forbidden", tc.pkg, tc.name)
+		assert.Equalf(t, tc.wantKind, kind, "%s.%s wrong kind", tc.pkg, tc.name)
+	}
+
+	green := []struct{ pkg, name string }{
+		{grpcRuntimeLibPath, "ServiceRegistrar"}, // server registration param type
+		{grpcRuntimeLibPath, "NewServer"},        // server construction, not client
+		{grpcRuntimeLibPath, "ServiceDesc"},
+		{grpcRuntimeLibPath, "ServerStream"},
+		{genPkg, "RegisterDeviceCommandServiceServer"}, // generated server registrar
+		{genPkg, "DeviceCommandServiceClient"},         // the client interface TYPE (not its New ctor)
+		{genPkg, "FooServerClient"},                    // ends in Client but no New prefix
+		{PlatformModulePath + "/runtime/grpc", "NewServiceRegistrar"}, // runtime/grpc, not the lib
+		{PlatformModulePath + "/corecells/accesscore", "NewClient"},   // a cell's own NewClient, not grpc
+	}
+	for _, tc := range green {
+		_, forbidden := forbiddenGRPCClientRef(tc.pkg, tc.name)
+		assert.Falsef(t, forbidden, "%s.%s must NOT be forbidden", tc.pkg, tc.name)
+	}
+}
+
+// TestGRPCCellNoClientDial01_FixtureScanRED runs the real scanner over the
+// archtest_fixture RED fixture and asserts it fires for the dial + conn-type
+// forms while the server-registration GREEN anchor (grpc.ServiceRegistrar) does
+// NOT fire — proving the scan layer (SelectorExpr walk + ResolvePackageRef) is
+// load-bearing and that deleting the violating lines would turn it green
+// (anti-vacuity). The production rule runs this SAME scanGRPCClientConstruction.
+func TestGRPCCellNoClientDial01_FixtureScanRED(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{grpcCellDialFixturePkg}),
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			var d []Diagnostic
+			for _, f := range p.Files {
+				d = append(d, scanGRPCClientConstruction(p, f, p.Rel(f))...)
+			}
+			return d
+		})
+
+	assert.NotEmpty(t, diags,
+		"GRPC-CELL-NO-CLIENT-DIAL-01 RED fixture must produce violations (anti-vacuity); a miss means "+
+			"the resolver or the forbidden-symbol branch regressed")
+
+	kinds := map[string]int{}
+	for _, d := range diags {
+		assert.Contains(t, d.Rel, "grpccelldialfixture",
+			"RED fixture diagnostic must point at the fixture, got %q", d.Rel)
+		assert.Contains(t, d.Message, ruleGRPCCellNoClientDial,
+			"RED fixture diagnostic must carry the rule ID")
+		for _, k := range []string{"dial", "conn-type", "stub"} {
+			if strings.Contains(d.Message, "["+k+"]") {
+				kinds[k]++
+			}
+		}
+		// The GREEN anchor names grpc.ServiceRegistrar; no forbidden ref does, so
+		// no diagnostic may ever mention it.
+		assert.NotContains(t, d.Message, "ServiceRegistrar",
+			"server registration (grpc.ServiceRegistrar) must NOT fire")
+	}
+	assert.Positive(t, kinds["dial"], "dial primitive (grpc.NewClient) must fire")
+	assert.Positive(t, kinds["conn-type"], "client-conn type (*grpc.ClientConn / ClientConnInterface) must fire")
+}

--- a/tools/archtest/grpc_cell_no_client_dial_test.go
+++ b/tools/archtest/grpc_cell_no_client_dial_test.go
@@ -261,9 +261,9 @@ func TestGRPCCellNoClientDial01_SyntheticDetector(t *testing.T) {
 		{grpcRuntimeLibPath, "NewServer"},        // server construction, not client
 		{grpcRuntimeLibPath, "ServiceDesc"},
 		{grpcRuntimeLibPath, "ServerStream"},
-		{genPkg, "RegisterDeviceCommandServiceServer"}, // generated server registrar
-		{genPkg, "DeviceCommandServiceClient"},         // the client interface TYPE (not its New ctor)
-		{genPkg, "FooServerClient"},                    // ends in Client but no New prefix
+		{genPkg, "RegisterDeviceCommandServiceServer"},                // generated server registrar
+		{genPkg, "DeviceCommandServiceClient"},                        // the client interface TYPE (not its New ctor)
+		{genPkg, "FooServerClient"},                                   // ends in Client but no New prefix
 		{PlatformModulePath + "/runtime/grpc", "NewServiceRegistrar"}, // runtime/grpc, not the lib
 		{PlatformModulePath + "/corecells/accesscore", "NewClient"},   // a cell's own NewClient, not grpc
 	}

--- a/tools/archtest/grpc_cell_no_client_dial_test.go
+++ b/tools/archtest/grpc_cell_no_client_dial_test.go
@@ -86,9 +86,11 @@
 //   - Function-value indirection (`f := grpc.NewClient; f(...)`): the bare-ident
 //     `grpc.NewClient` selector is still walked and resolved, so assigning the
 //     method value is itself flagged.
-//   - Dot-import (`import . "google.golang.org/grpc"`): bare `NewClient(...)`
-//     resolves via ResolvePackageRef's *types.Func path; additionally cells
-//     cannot dot-import per the revive dot-imports linter.
+//   - Dot-import (`import . "google.golang.org/grpc"`): bare `NewClient(...)` is
+//     NOT walked by scanGRPCClientConstruction (it walks qualified selectors
+//     only). Cells cannot dot-import (the revive dot-imports linter is the gate),
+//     so this form cannot arise in a cell — mirrors GRPC-SERVICE-IN-CONTRACT-01
+//     blind spot B3 (the linter, not the scanner, is the defense).
 //
 // ## Symbol inventory (forbidden client-construction symbol set)
 //
@@ -123,11 +125,14 @@ const ruleGRPCCellNoClientDial = "GRPC-CELL-NO-CLIENT-DIAL-01"
 // grpcRuntimeLibPath is the canonical import path of the gRPC transport library.
 const grpcRuntimeLibPath = "google.golang.org/grpc"
 
-// generatedGRPCContractsMarker is the path segment shared by every buf/protoc
-// generated gRPC contract package (where the typed New<Svc>Client stub
-// constructors live). It is a substring (not a prefix) so it matches regardless
-// of how the separate `generated` module's path is anchored.
-const generatedGRPCContractsMarker = "/generated/contracts/grpc/"
+// generatedGRPCContractsMarker anchors the buf/protoc generated gRPC contract
+// packages (where the typed New<Svc>Client stub constructors live) to the
+// platform module path, so a stray non-generated package whose import path
+// merely contains "/generated/contracts/grpc/" (e.g. a testdata tree) cannot
+// false-match. The generated tree is the separate module
+// github.com/ghbvf/gocell/generated, whose import paths are
+// <PlatformModulePath>/generated/contracts/grpc/...
+const generatedGRPCContractsMarker = PlatformModulePath + "/generated/contracts/grpc/"
 
 // grpcClientCtorRe matches a generated gRPC client constructor name
 // (New<Svc>Client). Anchored so it never matches Register<Svc>Server or the
@@ -161,10 +166,13 @@ func forbiddenGRPCClientRef(pkgPath, name string) (kind string, forbidden bool) 
 	return "", false
 }
 
-// scanGRPCClientConstruction walks one file's AST for package-symbol references
-// (selector `pkg.Name` and dot-imported bare `Name`) and emits a Diagnostic for
-// every forbidden gRPC client-construction symbol. The caller decides whether
-// the file belongs to a cell (production scan) or not (fixture scan).
+// scanGRPCClientConstruction walks one file's AST for qualified selector
+// references (`pkg.Name`) and emits a Diagnostic for every forbidden gRPC
+// client-construction symbol. The caller decides whether the file belongs to a
+// cell (production scan) or not (fixture scan). Dot-imported bare `Name` is NOT
+// walked here (selector-only) — cells cannot dot-import (revive dot-imports
+// linter is the gate), so that form is an independent linter concern, not a
+// scanner one (see the godoc blind-spots section).
 func scanGRPCClientConstruction(p *Pass, file *ast.File, rel string) []Diagnostic {
 	var diags []Diagnostic
 	emit := func(node ast.Expr) {
@@ -311,4 +319,10 @@ func TestGRPCCellNoClientDial01_FixtureScanRED(t *testing.T) {
 	}
 	assert.Positive(t, kinds["dial"], "dial primitive (grpc.NewClient) must fire")
 	assert.Positive(t, kinds["conn-type"], "client-conn type (*grpc.ClientConn / ClientConnInterface) must fire")
+	// The stub branch (generated New*Client) cannot fire from this fixture: it
+	// imports only google.golang.org/grpc, NOT the separate generated module. The
+	// stub detector branch is pinned by TestGRPCCellNoClientDial01_SyntheticDetector.
+	// Asserting zero here guards against a future fixture edit silently relying on
+	// (and masking a regression in) the unexercised stub path.
+	assert.Zero(t, kinds["stub"], "stub branch must NOT fire from this grpc-only fixture")
 }

--- a/tools/archtest/grpc_cell_no_client_dial_test.go
+++ b/tools/archtest/grpc_cell_no_client_dial_test.go
@@ -2,7 +2,7 @@
 
 // INVARIANT: GRPC-CELL-NO-CLIENT-DIAL-01
 //
-// # GRPC-CELL-NO-CLIENT-DIAL-01 — cell production code must not construct a gRPC client (Medium)
+// # GRPC-CELL-NO-CLIENT-DIAL-01 — cell production code must not construct or hold a gRPC client (Medium)
 //
 // ## Rule
 //
@@ -12,16 +12,21 @@
 //
 //   - google.golang.org/grpc.Dial / .DialContext / .NewClient   (dial primitive)
 //   - google.golang.org/grpc.ClientConn / .ClientConnInterface   (client-conn type)
-//   - a generated gRPC client constructor New<Svc>Client whose package lives
-//     under .../generated/contracts/grpc/...                     (client stub)
+//   - ANY generated gRPC CLIENT surface symbol — the New<Svc>Client constructor,
+//     the <Svc>Client interface, or the <Svc>_<Method>Client stream alias (every
+//     client-surface symbol is suffixed "Client") — in a package under
+//     <PlatformModulePath>/generated/contracts/grpc/...           (generated-client)
 //
 // Rationale (epic #1423 / US8 — 进程内跨 cell Go 直传 = 0): cells communicate
 // only through contracts. A cell reaches an EXTERNAL system through adapters/
-// (the only layer that may dial), never directly. Therefore the only thing a
-// cell could be doing by constructing a gRPC ClientConn in-process is dialing a
-// SIBLING cell's gRPC service — the cross-cell direct connection this invariant
-// forbids. Server-side registration (naming grpc.ServiceRegistrar, calling the
-// generated Register<Svc>Server) is legitimate and explicitly NOT flagged.
+// (the only layer that may dial), never directly. So a cell constructing a gRPC
+// ClientConn in-process can only be dialing a SIBLING cell. But construction is
+// not the only escape: a cell that merely HOLDS a generated <Svc>Client interface
+// (a composition root injects a built client, the cell keeps the interface and
+// calls it) reaches the sibling with no ClientConn / New*Client in sight — so the
+// whole generated client surface is forbidden, not just its constructor (#1961
+// F1). Server-side registration (grpc.ServiceRegistrar, the generated <Svc>Server
+// interface / Register<Svc>Server — suffixed "Server") is legitimate, NOT flagged.
 //
 // Why not depguard (the gap #1961 names): .golangci.yml cells-isolation must
 // ALLOW cells to import google.golang.org/grpc, because the cellgen-generated
@@ -72,17 +77,25 @@
 //     GRPC-SERVICE-IN-CONTRACT-01. Anti-vacuity is provided by the synthetic
 //     fixture (TestGRPCCellNoClientDial01_FixtureScanRED) which MUST fire, and by
 //     the pure-detector table (TestGRPCCellNoClientDial01_SyntheticDetector).
-//   - Generated-stub AST coverage: the stub branch (New<Svc>Client under
-//     /generated/contracts/grpc/) is covered only by the pure-detector table,
-//     NOT by a fixture-AST case — the generated tree is a SEPARATE go module
-//     (github.com/ghbvf/gocell/generated) that the main module deliberately does
-//     not depend on, so a main-module fixture cannot import it. The SCAN layer
-//     (SelectorExpr walk + ResolvePackageRef → pkgPath/name) is shared with the
-//     dial branch, which the fixture DOES exercise; only the detector's
-//     pkgPath-prefix/name-regex branch is fixture-uncovered, and the synthetic
-//     table pins it. dial is the chokepoint anyway (no ClientConn → no stub call
-//     unless the conn is smuggled via interface{} — see the doc.go inventory's
-//     open blind spot).
+//   - Generated client surface coverage: the constructor, the <Svc>Client
+//     interface, AND the <Svc>_<Method>Client stream alias (all suffixed
+//     "Client") have REAL fixture-AST coverage — grpccelldialfixture imports the
+//     actual generated module (tools/go.mod require+replace
+//     github.com/ghbvf/gocell/generated; archtest lives in the tools/ module,
+//     NOT the main module — an earlier draft wrongly claimed a fixture could not
+//     import it, #1961 F2) and both constructs a client and holds the interface
+//     (#1961 F1). The server surface (suffixed "Server") stays GREEN, also
+//     exercised by the fixture.
+//   - Suffix heuristic edge: a generated proto MESSAGE type named to end in
+//     "Client" would false-RED. protoc-gen-go derives message names from the
+//     .proto and never appends a Client/Server role suffix, so this cannot arise
+//     from the generated contract pipeline; noted for honesty, not separately gated.
+//   - A cell naming google.golang.org/grpc.ServerStreamingClient (the raw stream
+//     client type) directly — rather than the generated <Svc>_<Method>Client
+//     alias — is NOT flagged (the grpc-lib branch locks only Dial/NewClient/
+//     ClientConn). A cell is the SERVER side (it implements the service), so it
+//     uses ServerStreamingServer, not the client type; the generated alias path
+//     covers the realistic case.
 //   - Function-value indirection (`f := grpc.NewClient; f(...)`): the bare-ident
 //     `grpc.NewClient` selector is still walked and resolved, so assigning the
 //     method value is itself flagged.
@@ -92,15 +105,17 @@
 //     so this form cannot arise in a cell — mirrors GRPC-SERVICE-IN-CONTRACT-01
 //     blind spot B3 (the linter, not the scanner, is the defense).
 //
-// ## Symbol inventory (forbidden client-construction symbol set)
+// ## Symbol inventory (forbidden client symbol set)
 //
-//	google.golang.org/grpc: Dial, DialContext, NewClient        (dial)
-//	google.golang.org/grpc: ClientConn, ClientConnInterface     (conn-type)
-//	.../generated/contracts/grpc/...: ^New[A-Za-z0-9]*Client$   (stub)
+//	google.golang.org/grpc: Dial, DialContext, NewClient               (dial)
+//	google.golang.org/grpc: ClientConn, ClientConnInterface            (conn-type)
+//	<PlatformModulePath>/generated/contracts/grpc/...: "Client" suffix  (generated-client)
+//	  — New<Svc>Client ctor, <Svc>Client interface, <Svc>_<Method>Client stream alias
 //
-// Explicitly NOT forbidden (server side / type references):
+// Explicitly NOT forbidden (server side / message types):
 // grpc.ServiceRegistrar, grpc.NewServer, grpc.ServiceDesc, grpc.ServerStream,
-// the generated Register<Svc>Server, the generated <Svc>Client interface type.
+// the generated <Svc>Server interface, Register<Svc>Server, Unimplemented<Svc>Server,
+// Unsafe<Svc>Server, <Svc>_<Method>Server (all suffixed "Server"), message types.
 //
 // ref: tools/archtest/grpc_service_in_contract_test.go (typed callsite scan + synthetic fixture template)
 // ref: tools/archtest/svctoken_caller_cell.go (ResolvePackageRef callsite identification)
@@ -110,7 +125,6 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -125,30 +139,30 @@ const ruleGRPCCellNoClientDial = "GRPC-CELL-NO-CLIENT-DIAL-01"
 // grpcRuntimeLibPath is the canonical import path of the gRPC transport library.
 const grpcRuntimeLibPath = "google.golang.org/grpc"
 
-// generatedGRPCContractsMarker anchors the buf/protoc generated gRPC contract
-// packages (where the typed New<Svc>Client stub constructors live) to the
-// platform module path, so a stray non-generated package whose import path
-// merely contains "/generated/contracts/grpc/" (e.g. a testdata tree) cannot
-// false-match. The generated tree is the separate module
-// github.com/ghbvf/gocell/generated, whose import paths are
-// <PlatformModulePath>/generated/contracts/grpc/...
+// generatedGRPCContractsMarker is the import-path PREFIX of the buf/protoc
+// generated gRPC contract packages — the separate module
+// github.com/ghbvf/gocell/generated, anchored at <PlatformModulePath>/generated.
+// Matched by prefix (isGeneratedGRPCPkg), so a vendored/stray package whose path
+// merely contains the segment mid-string cannot false-match (#1961 F3).
 const generatedGRPCContractsMarker = PlatformModulePath + "/generated/contracts/grpc/"
-
-// grpcClientCtorRe matches a generated gRPC client constructor name
-// (New<Svc>Client). Anchored so it never matches Register<Svc>Server or the
-// bare <Svc>Client interface type.
-var grpcClientCtorRe = regexp.MustCompile(`^New[A-Za-z0-9]*Client$`)
 
 // grpcCellDialFixturePkg is the archtest_fixture RED fixture package pattern.
 const grpcCellDialFixturePkg = "./tools/archtest/internal/grpccelldialfixture"
 
+// isGeneratedGRPCPkg reports whether pkgPath is a buf/protoc generated gRPC
+// contract package, by import-path PREFIX (not a mid-string substring — #1961 F3).
+func isGeneratedGRPCPkg(pkgPath string) bool {
+	return strings.HasPrefix(pkgPath, generatedGRPCContractsMarker)
+}
+
 // forbiddenGRPCClientRef classifies a (pkgPath, name) package-symbol reference
-// as a forbidden cross-cell gRPC client-construction symbol. It returns the
-// violation kind ("dial" / "conn-type" / "stub") and true when forbidden, or
-// ("", false) otherwise. Server-side symbols (grpc.ServiceRegistrar,
-// grpc.NewServer, the generated Register<Svc>Server) and any non-grpc symbol are
-// not forbidden. This is the pure detector core shared by the production scan
-// and the synthetic table (mirrors detectOrphanRegs in grpc_service_in_contract).
+// as a forbidden cross-cell gRPC client-construction-or-surface symbol. It
+// returns the violation kind ("dial" / "conn-type" / "generated-client") and
+// true when forbidden, or ("", false) otherwise. Server-side symbols
+// (grpc.ServiceRegistrar, grpc.NewServer, the generated <Svc>Server /
+// Register<Svc>Server / Unimplemented... / Unsafe...) and any non-grpc symbol
+// are not forbidden. Pure detector core shared by the production scan and the
+// synthetic table (mirrors detectOrphanRegs in grpc_service_in_contract).
 func forbiddenGRPCClientRef(pkgPath, name string) (kind string, forbidden bool) {
 	if pkgPath == grpcRuntimeLibPath {
 		switch name {
@@ -160,8 +174,14 @@ func forbiddenGRPCClientRef(pkgPath, name string) (kind string, forbidden bool) 
 			return "", false
 		}
 	}
-	if strings.Contains(pkgPath, generatedGRPCContractsMarker) && grpcClientCtorRe.MatchString(name) {
-		return "stub", true
+	// In a generated gRPC contract package the entire CLIENT surface is suffixed
+	// "Client": the New<Svc>Client constructor, the <Svc>Client interface, AND
+	// the <Svc>_<Method>Client stream alias. A cell referencing ANY of them can
+	// hold/inject a sibling-cell transport client and call it directly — the
+	// injection-then-call escape the construction-only check missed (#1961 F1).
+	// The SERVER surface (all suffixed "Server") is legitimate registration.
+	if isGeneratedGRPCPkg(pkgPath) && strings.HasSuffix(name, "Client") {
+		return "generated-client", true
 	}
 	return "", false
 }
@@ -189,10 +209,10 @@ func scanGRPCClientConstruction(p *Pass, file *ast.File, rel string) []Diagnosti
 			Rel:  rel,
 			Line: line,
 			Message: fmt.Sprintf(
-				"%s [%s]: cell production code references %s.%s at %s:%d — a cell must not construct a "+
-					"gRPC client (dial primitive / generated New*Client stub / *grpc.ClientConn). In-process "+
-					"cross-cell calls go through contracts, not a direct gRPC dial; external gRPC reach belongs "+
-					"in adapters/, never a cell (epic #1423 US8: 进程内跨 cell Go 直传 = 0).",
+				"%s [%s]: cell production code references %s.%s at %s:%d — a cell must not construct OR hold a "+
+					"gRPC client (dial primitive / *grpc.ClientConn / generated <Svc>Client surface: interface, "+
+					"New*Client, or stream client). In-process cross-cell calls go through contracts, not a direct "+
+					"gRPC client; external gRPC reach belongs in adapters/, never a cell (epic #1423 US8: 进程内跨 cell Go 直传 = 0).",
 				ruleGRPCCellNoClientDial, kind, path, name, rel, line),
 		})
 	}
@@ -247,8 +267,13 @@ func TestGRPCCellNoClientDial01_SyntheticDetector(t *testing.T) {
 		{grpcRuntimeLibPath, "NewClient", "dial"},
 		{grpcRuntimeLibPath, "ClientConn", "conn-type"},
 		{grpcRuntimeLibPath, "ClientConnInterface", "conn-type"},
-		{genPkg, "NewDeviceCommandServiceClient", "stub"},
-		{genPkg, "NewFooClient", "stub"},
+		// generated CLIENT surface — all suffixed "Client" (#1961 F1): the
+		// constructor, the interface (the injection-then-call escape), and the
+		// stream-client alias. Referencing ANY lets a cell call a sibling cell.
+		{genPkg, "NewDeviceCommandServiceClient", "generated-client"},            // constructor
+		{genPkg, "DeviceCommandServiceClient", "generated-client"},               // interface (F1 injection path)
+		{genPkg, "DeviceCommandService_WatchCommandsClient", "generated-client"}, // stream-client alias
+		{genPkg, "NewFooClient", "generated-client"},
 	}
 	for _, tc := range red {
 		kind, forbidden := forbiddenGRPCClientRef(tc.pkg, tc.name)
@@ -261,11 +286,18 @@ func TestGRPCCellNoClientDial01_SyntheticDetector(t *testing.T) {
 		{grpcRuntimeLibPath, "NewServer"},        // server construction, not client
 		{grpcRuntimeLibPath, "ServiceDesc"},
 		{grpcRuntimeLibPath, "ServerStream"},
-		{genPkg, "RegisterDeviceCommandServiceServer"},                // generated server registrar
-		{genPkg, "DeviceCommandServiceClient"},                        // the client interface TYPE (not its New ctor)
-		{genPkg, "FooServerClient"},                                   // ends in Client but no New prefix
+		// generated SERVER surface — all suffixed "Server" → legitimate registration.
+		{genPkg, "DeviceCommandServiceServer"},                        // server interface
+		{genPkg, "RegisterDeviceCommandServiceServer"},                // server registrar
+		{genPkg, "UnimplementedDeviceCommandServiceServer"},           // forward-compat base
+		{genPkg, "UnsafeDeviceCommandServiceServer"},                  // opt-out marker
+		{genPkg, "DeviceCommandService_WatchCommandsServer"},          // stream-server alias
+		{genPkg, "IssueCommandRequest"},                               // a message type (neither Client nor Server)
 		{PlatformModulePath + "/runtime/grpc", "NewServiceRegistrar"}, // runtime/grpc, not the lib
-		{PlatformModulePath + "/corecells/accesscore", "NewClient"},   // a cell's own NewClient, not grpc
+		{PlatformModulePath + "/corecells/accesscore", "NewClient"},   // a cell's own *Client, not lib/generated
+		// #1961 F3 negative: a VENDORED generated path — the marker appears
+		// mid-string but NOT as a prefix, so HasPrefix (not Contains) must reject it.
+		{"example.com/vendor/" + PlatformModulePath + "/generated/contracts/grpc/device/command/v1", "NewDeviceCommandServiceClient"},
 	}
 	for _, tc := range green {
 		_, forbidden := forbiddenGRPCClientRef(tc.pkg, tc.name)
@@ -307,18 +339,24 @@ func TestGRPCCellNoClientDial01_FixtureScanRED(t *testing.T) {
 			"RED fixture diagnostic must point at the fixture, got %q", d.Rel)
 		assert.Contains(t, d.Message, ruleGRPCCellNoClientDial,
 			"RED fixture diagnostic must carry the rule ID")
-		for _, k := range []string{"dial", "conn-type", "stub"} {
+		for _, k := range []string{"dial", "conn-type", "generated-client"} {
 			if strings.Contains(d.Message, "["+k+"]") {
 				kinds[k]++
 			}
 		}
-		// The GREEN anchor names grpc.ServiceRegistrar; no forbidden ref does, so
-		// no diagnostic may ever mention it.
+		// GREEN anchors — neither the grpc server-registration seam
+		// (grpc.ServiceRegistrar) nor the generated SERVER surface
+		// (DeviceCommandServiceServer / RegisterDeviceCommandServiceServer) may
+		// ever appear in a diagnostic.
 		assert.NotContains(t, d.Message, "ServiceRegistrar",
-			"server registration (grpc.ServiceRegistrar) must NOT fire")
+			"grpc.ServiceRegistrar (server seam) must NOT fire")
+		assert.NotContains(t, d.Message, "ServiceServer",
+			"generated server surface (*ServiceServer / Register*ServiceServer) must NOT fire")
 	}
 	assert.Positive(t, kinds["dial"], "dial primitive (grpc.NewClient) must fire")
 	assert.Positive(t, kinds["conn-type"], "client-conn type (*grpc.ClientConn / ClientConnInterface) must fire")
+	assert.Positive(t, kinds["generated-client"],
+		"generated client surface (New*Client ctor + <Svc>Client interface) must fire")
 	// The stub branch (generated New*Client) cannot fire from this fixture: it
 	// imports only google.golang.org/grpc, NOT the separate generated module. The
 	// stub detector branch is pinned by TestGRPCCellNoClientDial01_SyntheticDetector.

--- a/tools/archtest/internal/grpccelldialfixture/fixture.go
+++ b/tools/archtest/internal/grpccelldialfixture/fixture.go
@@ -1,25 +1,32 @@
 //go:build archtest_fixture
 
 // Package grpccelldialfixture is the GRPC-CELL-NO-CLIENT-DIAL-01 negative
-// fixture. It stages the forbidden cross-cell gRPC *client*-construction forms a
-// cell must never use — the chokepoint being any construction of / reference to
-// a gRPC ClientConn, which (since a cell reaches external systems only through
-// adapters/) can only mean dialing a sibling cell in-process. It also stages a
-// legitimate server-registration GREEN anchor (naming grpc.ServiceRegistrar)
-// that must NOT fire, proving the scan distinguishes client construction from
-// server registration by SYMBOL, not by file/import (a cell legitimately imports
-// google.golang.org/grpc for the cellgen-generated Register callback — see
-// .golangci.yml cells-isolation — so an import-level ban is impossible).
+// fixture. It stages the forbidden cross-cell gRPC CLIENT forms a cell must
+// never use — both CONSTRUCTING a client (dial primitive, generated New*Client)
+// and merely HOLDING a generated <Svc>Client interface (the injection-then-call
+// escape: a composition root injects a built client, the cell keeps only the
+// interface and calls it). It also stages the legitimate server-registration
+// GREEN surface (grpc.ServiceRegistrar + the generated <Svc>Server interface +
+// Register<Svc>Server) that must NOT fire — proving the scan distinguishes the
+// client surface from the server surface by SYMBOL (suffix Client vs Server),
+// not by file/import (a cell legitimately imports both grpc and the generated
+// contract for server registration).
 //
 // Loaded only under the archtest_fixture build tag (via Run(t, Fixture(...)));
-// never imported from production code.
+// never imported from production code. It DOES import the real generated module
+// (tools/go.mod require+replace github.com/ghbvf/gocell/generated), so the
+// constructor + interface RED paths have real AST coverage (#1961 F2).
 //
 // DO NOT use this package in production code.
 package grpccelldialfixture
 
-import "google.golang.org/grpc"
+import (
+	"google.golang.org/grpc"
 
-// dialSibling constructs a gRPC client connection — the forbidden chokepoint.
+	commandv1 "github.com/ghbvf/gocell/generated/contracts/grpc/device/command/v1"
+)
+
+// dialSibling constructs a gRPC client connection — the dial chokepoint.
 // Returns *grpc.ClientConn, so it also exercises the client-conn type detection.
 func dialSibling() (*grpc.ClientConn, error) {
 	return grpc.NewClient("passthrough:///sibling-cell") // VIOLATION [dial]
@@ -31,20 +38,37 @@ type siblingProxy struct {
 	conn *grpc.ClientConn // VIOLATION [conn-type]
 }
 
-// wrapConn names grpc.ClientConnInterface — the client-conn abstraction a cell
-// would hold to invoke a sibling cell's generated stub.
+// wrapConn names grpc.ClientConnInterface — the client-conn abstraction.
 func wrapConn(cc grpc.ClientConnInterface) grpc.ClientConnInterface { // VIOLATION [conn-type]
 	return cc
 }
 
-// registerServer is the GREEN anchor: legitimate server registration names
-// grpc.ServiceRegistrar (server side) and must NOT fire.
-func registerServer(r grpc.ServiceRegistrar) { _ = r }
+// makeSiblingClient constructs a generated client stub.
+func makeSiblingClient(cc grpc.ClientConnInterface) commandv1.DeviceCommandServiceClient { // VIOLATION [generated-client]
+	return commandv1.NewDeviceCommandServiceClient(cc) // VIOLATION [generated-client]
+}
+
+// injectedClientHolder holds the generated <Svc>Client INTERFACE — the
+// injection-then-call escape (#1961 F1): the cell keeps only the interface, a
+// composition root injects a built client, the cell calls it; no ClientConn /
+// New*Client ever appears in the cell.
+type injectedClientHolder struct {
+	client commandv1.DeviceCommandServiceClient // VIOLATION [generated-client]
+}
+
+// registerServer is the GREEN anchor: the server-registration surface
+// (grpc.ServiceRegistrar + the generated <Svc>Server interface + the
+// Register<Svc>Server registrar — all suffixed "Server") must NOT fire.
+func registerServer(r grpc.ServiceRegistrar, srv commandv1.DeviceCommandServiceServer) {
+	commandv1.RegisterDeviceCommandServiceServer(r, srv)
+}
 
 // Keep the fixture symbols referenced so the package type-checks cleanly.
 var (
 	_ = dialSibling
 	_ = wrapConn
+	_ = makeSiblingClient
 	_ = registerServer
 	_ = siblingProxy{}
+	_ = injectedClientHolder{}
 )

--- a/tools/archtest/internal/grpccelldialfixture/fixture.go
+++ b/tools/archtest/internal/grpccelldialfixture/fixture.go
@@ -1,0 +1,50 @@
+//go:build archtest_fixture
+
+// Package grpccelldialfixture is the GRPC-CELL-NO-CLIENT-DIAL-01 negative
+// fixture. It stages the forbidden cross-cell gRPC *client*-construction forms a
+// cell must never use — the chokepoint being any construction of / reference to
+// a gRPC ClientConn, which (since a cell reaches external systems only through
+// adapters/) can only mean dialing a sibling cell in-process. It also stages a
+// legitimate server-registration GREEN anchor (naming grpc.ServiceRegistrar)
+// that must NOT fire, proving the scan distinguishes client construction from
+// server registration by SYMBOL, not by file/import (a cell legitimately imports
+// google.golang.org/grpc for the cellgen-generated Register callback — see
+// .golangci.yml cells-isolation — so an import-level ban is impossible).
+//
+// Loaded only under the archtest_fixture build tag (via Run(t, Fixture(...)));
+// never imported from production code.
+//
+// DO NOT use this package in production code.
+package grpccelldialfixture
+
+import "google.golang.org/grpc"
+
+// dialSibling constructs a gRPC client connection — the forbidden chokepoint.
+// Returns *grpc.ClientConn, so it also exercises the client-conn type detection.
+func dialSibling() (*grpc.ClientConn, error) {
+	return grpc.NewClient("passthrough:///sibling-cell") // VIOLATION [dial]
+}
+
+// siblingProxy holds a *grpc.ClientConn — a cell retaining a cross-cell client
+// connection as state.
+type siblingProxy struct {
+	conn *grpc.ClientConn // VIOLATION [conn-type]
+}
+
+// wrapConn names grpc.ClientConnInterface — the client-conn abstraction a cell
+// would hold to invoke a sibling cell's generated stub.
+func wrapConn(cc grpc.ClientConnInterface) grpc.ClientConnInterface { // VIOLATION [conn-type]
+	return cc
+}
+
+// registerServer is the GREEN anchor: legitimate server registration names
+// grpc.ServiceRegistrar (server side) and must NOT fire.
+func registerServer(r grpc.ServiceRegistrar) { _ = r }
+
+// Keep the fixture symbols referenced so the package type-checks cleanly.
+var (
+	_ = dialSibling
+	_ = wrapConn
+	_ = registerServer
+	_ = siblingProxy{}
+)


### PR DESCRIPTION
## Summary

新增 `GRPC-CELL-NO-CLIENT-DIAL-01`（Medium）archtest 规则——禁止 cell 生产代码构造 gRPC 客户端（dial 原语 / 生成 `New*Client` stub / `*grpc.ClientConn` 类型），封住 #1752 引入 `runtime/grpc` 后的跨 cell gRPC 直连盲区；并在 archtest package godoc 沉淀「进程内跨 cell Go 直传 = 0」守卫清单 + 盲区表（epic #1423 US8 / T071 清点）。

## Why / 背景

epic #1423 US8 验收信号要求「进程内跨 cell Go 直传 = 0」由 archtest 永久守卫（Medium+）。盲区：#1752 PR-05 引入 `runtime/grpc`（server 注册 seam）后，archtest 未覆盖 gRPC **客户端**维度。

关键：`.golangci.yml` 的 `cells-isolation` depguard **允许** cell import `google.golang.org/grpc`（cellgen 生成的 `cell_gen.go` 的 `Register: func(r grpc.ServiceRegistrar){...}` 回调命名该传输库），故 **import 级禁制不可行**——一个 cell 可合法 import grpc 做 server 注册，**同时**非法调用 `grpc.NewClient` 直拨兄弟 cell 的 gRPC 服务，depguard（symbol-blind）抓不到。本 PR 以 callsite/symbol 级 typed scan（`ResolvePackageRef`）精确区分 client 构造 vs server 注册，封住该 chokepoint。

**AI-robust 评级 Medium**：本约束属 caller-allowlist 类（禁止谁调用第三方公开函数），与 `GRPC-SERVICE-IN-CONTRACT-01/A`、`SVCTOKEN-CALLER-CELL-REQUIRED-01` 同构。Hard 不可达——四种 Hard 载体（type system / codegen golden / reflect freeze / depguard import-deny）逐一核验均不成立（论证写入规则 godoc），无低成本 Hard 化路径 → permanent ceiling（#1631 家族），不另立 Hard 化 issue。今天生产零 cell-side gRPC client（仅 server 注册 + 测试 client），规则 **vacuously green**；红来自 `archtest_fixture` synthetic 用例 + 纯 detector table + anti-vacuity 反验（破坏 detector → 红）。

**T071 清点**：守卫清单 + 盲区表落 `doc.go`；未收口盲区 `interface{}`/`any` 跨 cell 指针偷渡 → backlog #2002；sync HTTP 直拨归 US4 CellTransport（越界，doc 标注 out-of-scope）。

## Refs

Closes #1961
Backlog (T071 未收口盲区): #2002
ref: tools/archtest/grpc_service_in_contract_test.go (typed callsite scan + synthetic fixture 范本)
ref: tools/archtest/svctoken_caller_cell.go (ResolvePackageRef callsite 识别)

## Risk / 兼容性

无。纯新增 archtest 守卫 + package godoc，无 wire / 契约 / generated / 运行时影响，无 migration。规则今天 vacuous green（零生产违规）。

注：`tools/archtest` 上预存在两处**与本 PR 无关**的基线失败——`TestResourceProjectionCoverage01` / `TestContractPathQueryCoverage01`（均 `http.policy.*` contract），在 `origin/develop`（088bf4c5c）干净基线即红，非本 PR 引入、不在本 PR 范围。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test -tags=archtest ./tools/archtest/ -run GRPCCellNoClientDial`：synthetic detector + fixture scan RED + 生产 vacuous green 全 PASS；anti-vacuity 反验（破坏 detector → fixture RED 转 FAIL）
- [x] archtest 元规则（anchor 登记 / coverage / shard / build-tag）全 PASS
- [x] `golangci-lint run ./tools/archtest/...`：本 PR 文件 0 issue（CI PR 模式 `--new-from-merge-base` 0 新增）
