### PR TITLE
fix(archtest): MQTT funnel typed scan 迁 workspace-aware scope，修复 #1558 module-local 假红/假绿 [#1911]

### DIFF
--- a/tools/archtest/mqtt_funnel.go
+++ b/tools/archtest/mqtt_funnel.go
@@ -33,8 +33,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 // mqttPkgPath is the canonical import path of the mqtt adapter package —
@@ -599,10 +597,13 @@ func collectTopicNSDiags(p *Pass, a2Diags, a3Diags *[]Diagnostic) {
 // fork-safety, dogfooded via the per-rule Tests).
 func CheckMQTTClientIDNamespace(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
-	root := findModuleRoot(t)
 	var a2Diags, a3Diags []Diagnostic
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: cfg.BuildTags},
-		prodscan.PatternsExtended(root)),
+	// A3 (type-alias) scans EVERY package for re-exports of the sealed type, so this
+	// needs whole-workspace breadth — Production reaches every go.work module incl.
+	// the adapters/mqtt satellite (#1558); a module-local relative scope silently
+	// misses both the satellite's own A2 construction scan and any satellite-declared
+	// alias (#1911). Mirrors PR #1879's observability/metrics Production migration.
+	_ = Run(t, Production(TypedOpts{Tests: false, Tags: cfg.BuildTags}),
 		func(p *Pass) []Diagnostic {
 			collectClientIDDiags(p, &a2Diags, &a3Diags)
 			return nil
@@ -622,10 +623,13 @@ func CheckMQTTClientIDNamespace(t *testing.T, cfg ConfigForExternalCell) []Diagn
 // fork-safety, dogfooded via the per-rule Tests).
 func CheckMQTTTopicNamespace(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
-	root := findModuleRoot(t)
 	var a2Diags, a3Diags []Diagnostic
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: cfg.BuildTags},
-		prodscan.PatternsExtended(root)),
+	// A3 (type-alias) scans EVERY package for re-exports of the sealed type, so this
+	// needs whole-workspace breadth — Production reaches every go.work module incl.
+	// the adapters/mqtt satellite (#1558); a module-local relative scope silently
+	// misses both the satellite's own A2 construction scan and any satellite-declared
+	// alias (#1911). Mirrors PR #1879's observability/metrics Production migration.
+	_ = Run(t, Production(TypedOpts{Tests: false, Tags: cfg.BuildTags}),
 		func(p *Pass) []Diagnostic {
 			collectTopicNSDiags(p, &a2Diags, &a3Diags)
 			return nil
@@ -687,10 +691,13 @@ func collectConfigDiags(p *Pass, a2Diags *[]Diagnostic) {
 // parameterization + fork-safety, dogfooded via the per-rule Tests).
 func CheckMQTTConfigSeal(t *testing.T, cfg ConfigForExternalCell) []Diagnostic {
 	t.Helper()
-	root := findModuleRoot(t)
 	var a2Diags []Diagnostic
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: cfg.BuildTags},
-		prodscan.PatternsExtended(root)),
+	// collectConfigDiags only scans the Config-owning package (mqttPkgPath) — it has
+	// no cross-package A3 alias scan — so a single-package Typed scope suffices. The
+	// explicit absolute import path resolves the adapters/mqtt satellite across the
+	// go.work boundary (#1558/#1911), unlike a module-local relative ./... pattern
+	// that match-zeroes the satellite subtree.
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: cfg.BuildTags}, []string{mqttPkgPath}),
 		func(p *Pass) []Diagnostic {
 			collectConfigDiags(p, &a2Diags)
 			return nil

--- a/tools/archtest/mqtt_funnel_test.go
+++ b/tools/archtest/mqtt_funnel_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/adapters/mqtt"
-	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 // wantMQTTConfigFields is the frozen field set of adapters/mqtt.Config pinned by
@@ -377,12 +376,10 @@ func TestMQTTFunnel_BlindSpot_NoReflectNew(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
 	var diags []Diagnostic
 	var sawSatellite bool
 
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
-		prodscan.PatternsExtended(root)),
+	_ = Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
@@ -460,12 +457,10 @@ func TestMQTTFunnel_BlindSpot_NoUnsafePtr(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
 	var diags []Diagnostic
 	var sawSatellite bool
 
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
-		prodscan.PatternsExtended(root)),
+	_ = Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil
@@ -519,7 +514,6 @@ func TestMQTTFunnel_BlindSpot_NoUnsafePtr(t *testing.T) {
 			return nil
 		})
 
-	_ = root // used via prodscan patterns above; kept to avoid unused var error
 	assert.Empty(t, diags,
 		"MQTT funnel blind-spot B2: production code imports \"unsafe\" while referencing adapters/mqtt")
 	assert.True(t, sawSatellite,
@@ -550,8 +544,6 @@ func TestMQTTFunnel_A2ScannerFires(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
-
 	// assembleClientIDFullName is the typed FullName() of the sole allowed
 	// ClientID constructor: a package-level func in adapters/mqtt.
 	const assembleClientIDFullName = mqttPkgPath + ".assembleClientID"
@@ -564,7 +556,7 @@ func TestMQTTFunnel_A2ScannerFires(t *testing.T) {
 	var outsideCount, insideCount int
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
-		prodscan.PatternsExtended(root)),
+		[]string{mqttPkgPath}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -711,14 +703,12 @@ func TestMQTTConfigSeal_A2ScannerFires(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
-
 	const newConfigFullName = mqttPkgPath + ".NewConfig"
 
 	var outsideCount, insideCount int
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
-		prodscan.PatternsExtended(root)),
+		[]string{mqttPkgPath}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil
@@ -841,14 +831,12 @@ func TestMQTTConfigFieldWriteSeal_ScannerFires(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	root := findModuleRoot(t)
-
 	const newConfigFullName = mqttPkgPath + ".NewConfig"
 	const ruleID = "MQTT-CONFIG-SEALED-FIELD-FROZEN-01"
 	var outsideCount, seenCount int
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
-		prodscan.PatternsExtended(root)),
+		[]string{mqttPkgPath}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil || p.Pkg.Path() != mqttPkgPath {
 				return nil

--- a/tools/archtest/mqtt_funnel_test.go
+++ b/tools/archtest/mqtt_funnel_test.go
@@ -379,12 +379,20 @@ func TestMQTTFunnel_BlindSpot_NoReflectNew(t *testing.T) {
 
 	root := findModuleRoot(t)
 	var diags []Diagnostic
+	var sawSatellite bool
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
 				return nil
+			}
+			// Anti-vacuity (#1911): this blind-spot guard only means something if the
+			// scan actually reaches the satellite packages owning the sealed types.
+			// #1558 split adapters/mqtt into its own go.work module, so a module-local
+			// scope silently stops visiting it (false-green); assert we saw it below.
+			if p.Pkg.Path() == mqttPkgPath || p.Pkg.Path() == topicnsPkgPath {
+				sawSatellite = true
 			}
 			for _, f := range p.Files {
 				rel := p.Rel(f)
@@ -437,6 +445,9 @@ func TestMQTTFunnel_BlindSpot_NoReflectNew(t *testing.T) {
 
 	assert.Empty(t, diags,
 		"MQTT funnel blind-spot B1: production code calls reflect.New on mqtt sealed types")
+	assert.True(t, sawSatellite,
+		"MQTT funnel blind-spot B1 anti-vacuity: scan never visited adapters/mqtt or internal/topicns — "+
+			"the guard is vacuous for the satellite module (module-local scope after #1558)")
 }
 
 // TestMQTTFunnel_BlindSpot_NoUnsafePtr (blind-spot B2) asserts that NO
@@ -451,12 +462,19 @@ func TestMQTTFunnel_BlindSpot_NoUnsafePtr(t *testing.T) {
 
 	root := findModuleRoot(t)
 	var diags []Diagnostic
+	var sawSatellite bool
 
 	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()},
 		prodscan.PatternsExtended(root)),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {
 				return nil
+			}
+			// Anti-vacuity (#1911): the unsafe-import guard for the mqtt package itself
+			// is vacuous unless the scan reaches adapters/mqtt — #1558 made it a
+			// satellite module that a module-local scope silently skips. Assert below.
+			if p.Pkg.Path() == mqttPkgPath {
+				sawSatellite = true
 			}
 
 			importsMQTT := false
@@ -504,6 +522,9 @@ func TestMQTTFunnel_BlindSpot_NoUnsafePtr(t *testing.T) {
 	_ = root // used via prodscan patterns above; kept to avoid unused var error
 	assert.Empty(t, diags,
 		"MQTT funnel blind-spot B2: production code imports \"unsafe\" while referencing adapters/mqtt")
+	assert.True(t, sawSatellite,
+		"MQTT funnel blind-spot B2 anti-vacuity: scan never visited adapters/mqtt — "+
+			"the guard is vacuous for the satellite module (module-local scope after #1558)")
 }
 
 // TestMQTTFunnel_A2ScannerFires proves that scanMQTTCompositeLitConstruction

--- a/tools/archtest/mqtt_funnel_test.go
+++ b/tools/archtest/mqtt_funnel_test.go
@@ -379,6 +379,9 @@ func TestMQTTFunnel_BlindSpot_NoReflectNew(t *testing.T) {
 	var diags []Diagnostic
 	var sawSatellite bool
 
+	// Production (whole-workspace): reflect.New(mqtt.ClientID) can appear in ANY
+	// package, so this guard needs workspace breadth — not a single-package Typed
+	// scope. Production also reaches the adapters/mqtt satellite (#1558/#1911).
 	_ = Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.TypesInfo == nil {
@@ -460,6 +463,9 @@ func TestMQTTFunnel_BlindSpot_NoUnsafePtr(t *testing.T) {
 	var diags []Diagnostic
 	var sawSatellite bool
 
+	// Production (whole-workspace): any package importing adapters/mqtt could add an
+	// unsafe.Pointer cast, so this guard needs workspace breadth — not a single-package
+	// Typed scope. Production also reaches the adapters/mqtt satellite (#1558/#1911).
 	_ = Run(t, Production(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil {


### PR DESCRIPTION
## 现状

#1558 把 `adapters/mqtt` 拆成独立 go.work satellite module 后，MQTT funnel archtest 用 module-local `Typed(TypedOpts{…}, prodscan.PatternsExtended(root))` 扫描——其相对模式 `./adapters/...` 在 ModeModule 下 **match-zero 掉 satellite 子树**（`prodscan` godoc 明述，满覆盖是 #1590 的 ModeWorkspace 迁移），于是扫不到 `adapters/mqtt`。受影响面比 issue #1911 列的更广，分三层：

**① 生产 enforcement（`mqtt_funnel.go`，内置 reviewer 揪出，issue 未列）** — 核心 sealed-construction funnel：
| 函数 | 主产测试 | 失效 |
|---|---|---|
| `CheckMQTTClientIDNamespace` | `TestMQTTClientIDNamespace01/A2` | A2/A2b 复合字面量+字段写 enforcement 对 satellite **vacuous**（silently false-GREEN），A3 alias 漏 satellite |
| `CheckMQTTTopicNamespace` | `TestMQTTTopicNamespace01/A2` | 同上 |
| `CheckMQTTConfigSeal` | `TestMQTTConfigSealedFieldFrozen01/A2` | 同上（无 A3） |

**② 自检 ScannerFires（`mqtt_funnel_test.go`）** — 带 `≥1` anti-vacuity：
| Site | 测试 | 失效 |
|---|---|---|
| `:546/700/830` | `TestMQTTFunnel_A2ScannerFires` / `…ConfigSeal…` / `…ConfigFieldWriteSeal…` | satellite 掉出 → `insideCount/seenCount=0` → **false-RED**（可见失败，issue 复现的 3 个） |

**③ blind-spot guard（`mqtt_funnel_test.go`）** — 只 `assert.Empty`、无 anti-vacuity：
| Site | 测试 | 失效 |
|---|---|---|
| `:384/456` | `TestMQTTFunnel_BlindSpot_NoReflectNew` (B1) / `NoUnsafePtr` (B2) | satellite 掉出 → 悄悄不再扫该模块 → **silently false-GREEN**（失armed，issue 未察觉） |

复现：`go test -tags=archtest ./tools/archtest -run 'Test(MQTT|Tenant).*' -count=1` → 3 FAIL（②）。①③ 不报错但已失armed。

## 方案

按**扫描意图**区分 scope（对标 PR #1879 observability/metrics 同手法），而非一刀切：

- **单包意图**（scan func 内部 filter 单一 owning package）→ `Typed([]string{<pkg>})`：显式绝对 import path 经 go.work 跨模块解析，与 `mqtt_callsite_funnel_test.go` 10 处既有手法统一，顺带消除"加载整棵生产树再过滤"的 over-broad-load。用于 ② 3 个 ScannerFires + ① `CheckMQTTConfigSeal`（无 A3）。
- **全 workspace breadth**（须扫每个包：B1/B2 的 `reflect.New`/`unsafe`，① ClientID/TopicNS 的跨包 A3 type-alias 扫描）→ `Production(TypedOpts{…})`。用于 ③ B1/B2 + ① `CheckMQTTClientIDNamespace`/`CheckMQTTTopicNamespace`。
- **B1/B2 补 `sawSatellite` anti-vacuity**（与 ② 既有 `≥1` 同设计）：scan 必须实际访问 satellite 包，否则 guard vacuous。迁移前 RED、迁移后 GREEN → 证明 re-arm 生效且防再次静默失armed。
- 清理 `prodscan` import / `root` 变量 / `_ = root` hack（两文件已无引用）。

**AI-robust 评级**：`sawSatellite` 断言 = **Medium**（CI runtime、违反即 RED、机器可判定）；Hard 化路径 = #1590 ModeWorkspace scope 自动枚举 satellite 使"漏扫"不可表达。scope 迁移本身是**恢复**被 #1558 静默降为 vacuous 的既有 archtest 的预期强度，非新机制。

**范围裁定（非静默 carve-out）**：
- `mqtt_callsite_funnel_test.go` 10 处用显式绝对 import path、实测含 `…NonVacuous` 断言已证看到 satellite → **不改动**。
- 其余 ~25 个 `prodscan.Patterns*` 文件对 satellite 的静默覆盖缺口、以及"Check scope 回退无专测捕获"的残留耦合缺口，属系统类，由 **#1590 ModeWorkspace migration** 收口 → 不在本 PR。

## 测试

```
go test -tags=archtest ./tools/archtest -run 'Test(MQTT|Tenant).*' -count=1   # ok
golangci-lint run --build-tags=archtest ./archtest/...                        # 0 issues
```

- 主产测试 `TestMQTTClientIDNamespace01` / `TopicNamespace01` / `ConfigSealedFieldFrozen01` 全绿（real-green，非 vacuous）。
- ② 3 个 ScannerFires false-RED→GREEN；③ B1/B2 经 RED commit 证明失armed、修复后 GREEN。
- sanctioned alias `type TopicNamespace = topicns.Namespace` 经 A3 allowed-name 正确 skip，无假阳。
- ① callsite 10 测 + Tenant 全套不受影响、保持绿。

两文件 `mqtt_funnel.go` + `mqtt_funnel_test.go`。内置六维度 reviewer 首审已跑（findings 全 IN_SCOPE Cx1/Cx2，已修，无 OUT_OF_SCOPE）。

ref: tools/archtest/observability_metrics_test.go (#1879 `Production` scope 同手法)

Closes #1911