### PR TITLE
fix(reconcile): sealed LeaseTTL 让 lease 亚毫秒截断→多 leader 不可表达 [#1953]

### DIFF
--- a/adapters/postgres/reconcile_leader.go
+++ b/adapters/postgres/reconcile_leader.go
@@ -102,7 +102,11 @@ func NewReconcileElector(pool *Pool, lease reconcile.LeaseTTL) (*ReconcileElecto
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterPGConnect, "postgres reconcile elector: pool is nil")
 	}
 	if lease.IsZero() {
-		return nil, errcode.New(errcode.KindInternal, ErrAdapterPGConnect, "postgres reconcile elector: lease must be a constructed LeaseTTL")
+		// ErrCellInvalidConfig (not the connect code): a zero-value lease is a
+		// wiring mistake (forgot reconcile.NewLeaseTTL), routable separately from
+		// genuine Postgres connection failures.
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"postgres reconcile elector: lease must be a constructed LeaseTTL")
 	}
 	holderID, err := idutil.NewUUID()
 	if err != nil {

--- a/adapters/postgres/reconcile_leader.go
+++ b/adapters/postgres/reconcile_leader.go
@@ -83,31 +83,33 @@ func epochToUint64(e int64) uint64 {
 // Failover triggers on TTL expiry (a hung-but-alive leader's lease lapses and a
 // follower takes over), matching the Redis and fake electors.
 type ReconcileElector struct {
-	pool          *Pool
-	holderID      string
-	leaseDuration time.Duration
+	pool     *Pool
+	holderID string
+	lease    reconcile.LeaseTTL
 }
 
 // NewReconcileElector builds a PG leader elector. The holderID (this replica's
 // identity) is minted INTERNALLY as a fresh UUID — making accidental cross-process
 // holderID reuse (which would be treated as the same holder, defeating mutual
 // exclusion — PR-A6 review C4) impossible by construction rather than relying on a
-// caller contract. leaseDuration is the lease TTL window. Unlike the Redis elector,
-// no clock.Clock is needed — lease timestamps are computed by the DB (now()), the
-// single wall-clock authority across replicas.
-func NewReconcileElector(pool *Pool, leaseDuration time.Duration) (*ReconcileElector, error) {
+// caller contract. lease is the validated lease TTL window (a sealed
+// reconcile.LeaseTTL, so a sub-millisecond window — which would truncate to a 0ms
+// interval and break mutual exclusion — is unrepresentable). Unlike the Redis
+// elector, no clock.Clock is needed — lease timestamps are computed by the DB
+// (now()), the single wall-clock authority across replicas.
+func NewReconcileElector(pool *Pool, lease reconcile.LeaseTTL) (*ReconcileElector, error) {
 	if pool == nil {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterPGConnect, "postgres reconcile elector: pool is nil")
 	}
-	if leaseDuration <= 0 {
-		return nil, errcode.New(errcode.KindInternal, ErrAdapterPGConnect, "postgres reconcile elector: leaseDuration must be positive")
+	if lease.IsZero() {
+		return nil, errcode.New(errcode.KindInternal, ErrAdapterPGConnect, "postgres reconcile elector: lease must be a constructed LeaseTTL")
 	}
 	holderID, err := idutil.NewUUID()
 	if err != nil {
 		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterPGConnect, "postgres reconcile elector: mint holderID", err)
 	}
 	slog.Info("postgres reconcile elector: created", slog.String("holder_id", holderID))
-	return &ReconcileElector{pool: pool, holderID: holderID, leaseDuration: leaseDuration}, nil
+	return &ReconcileElector{pool: pool, holderID: holderID, lease: lease}, nil
 }
 
 // AcquireLease implements reconcile.LeaderElector via the row-TTL UPSERT CAS.
@@ -115,7 +117,7 @@ func (e *ReconcileElector) AcquireLease(ctx context.Context, reconcilerID string
 	var epoch int64
 	var acquiredAt, expiresAt time.Time
 	err := e.pool.DB().
-		QueryRow(ctx, pgReconcileAcquireSQL, reconcilerID, e.holderID, e.leaseDuration.Milliseconds()).
+		QueryRow(ctx, pgReconcileAcquireSQL, reconcilerID, e.holderID, e.lease.Milliseconds()).
 		Scan(&epoch, &acquiredAt, &expiresAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// ON CONFLICT WHERE matched no row: a live lease is held by another holder.
@@ -130,7 +132,7 @@ func (e *ReconcileElector) AcquireLease(ctx context.Context, reconcilerID string
 // RenewLease implements reconcile.LeaderElector (holder + still-live guarded). 0
 // rows ⟹ lease lapsed or taken over ⟹ ErrReconcileLeaseLost.
 func (e *ReconcileElector) RenewLease(ctx context.Context, token reconcile.LeaseToken) error {
-	tag, err := e.pool.DB().Exec(ctx, pgReconcileRenewSQL, token.ReconcilerID, e.holderID, e.leaseDuration.Milliseconds())
+	tag, err := e.pool.DB().Exec(ctx, pgReconcileRenewSQL, token.ReconcilerID, e.holderID, e.lease.Milliseconds())
 	if err != nil {
 		return errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "postgres reconcile elector: renew", err)
 	}

--- a/adapters/postgres/reconcile_leader_integration_test.go
+++ b/adapters/postgres/reconcile_leader_integration_test.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -12,9 +11,9 @@ import (
 	"github.com/ghbvf/gocell/kernel/reconcile/reconciletest"
 )
 
-// reconcilePGTestLeaseTTL is the lease duration for the PG reconcile elector
-// integration tests (TEST-TIME-LITERAL-01: literal lives in a package-level const).
-const reconcilePGTestLeaseTTL = 30 * time.Second
+// reconcilePGTestLeaseTTL + mustPGLease are declared in the untagged
+// reconcile_leader_test.go so this integration-tagged file shares them without a
+// duplicate declaration (mirrors the redis adapter's reconcileTestLeaseTTL).
 
 // TestIntegration_ReconcileElectorConformance runs the cross-implementation
 // LeaderElector + fencing conformance suites against a real PostgreSQL
@@ -26,7 +25,7 @@ func TestIntegration_ReconcileElectorConformance(t *testing.T) {
 	pool := migratedPool(t)
 
 	factory := func(string) reconcile.LeaderElector {
-		e, err := NewReconcileElector(pool, reconcilePGTestLeaseTTL)
+		e, err := NewReconcileElector(pool, mustPGLease(t))
 		require.NoError(t, err)
 		return e
 	}

--- a/adapters/postgres/reconcile_leader_integration_test.go
+++ b/adapters/postgres/reconcile_leader_integration_test.go
@@ -17,10 +17,11 @@ import (
 
 // TestIntegration_ReconcileElectorConformance runs the cross-implementation
 // LeaderElector + fencing conformance suites against a real PostgreSQL
-// (testcontainers via migratedPool), validating the session-scoped
-// pg_try_advisory_lock gate + the ON CONFLICT epoch-bump UPSERT. Each factory
-// call builds a distinct-holder elector sharing one pool, so the suites' two
-// holders contend for the same reconcile_leases row / advisory lock.
+// (testcontainers via migratedPool), validating the reconcile_leases row-TTL UPSERT
+// CAS (the ROW's expires_at TTL is the lease authority — NOT a session advisory
+// lock; ADR §4.1) + the ON CONFLICT epoch-bump. Each factory call builds a
+// distinct-holder elector sharing one pool, so the suites' two holders contend for
+// the same reconcile_leases row.
 func TestIntegration_ReconcileElectorConformance(t *testing.T) {
 	pool := migratedPool(t)
 

--- a/adapters/postgres/reconcile_leader_test.go
+++ b/adapters/postgres/reconcile_leader_test.go
@@ -1,0 +1,78 @@
+package postgres
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/kernel/reconcile"
+)
+
+// reconcilePGTestLeaseTTL is the lease duration shared by the PG reconcile elector
+// unit + integration tests (TEST-TIME-LITERAL-01: literal lives in a package-level
+// const). Declared in this untagged file so the integration-tagged file can share it
+// without a duplicate declaration (mirrors the redis adapter's reconcileTestLeaseTTL).
+const reconcilePGTestLeaseTTL = 30 * time.Second
+
+// mustPGLease builds the shared test LeaseTTL from the package-level literal const
+// (the elector now takes a validated reconcile.LeaseTTL, not a raw time.Duration —
+// sub-ms truncation is foreclosed at NewLeaseTTL, see kernel/reconcile/leasettl.go).
+func mustPGLease(t *testing.T) reconcile.LeaseTTL {
+	t.Helper()
+	l, err := reconcile.NewLeaseTTL(reconcilePGTestLeaseTTL)
+	require.NoError(t, err)
+	return l
+}
+
+// TestEpochToUint64 covers the BIGINT→uint64 epoch conversion's defensive guard:
+// reconcile_leases.epoch is monotonic and seeded at 1, so a negative value is DB
+// corruption and is clamped to 0 (a fail-safe lowest epoch the FencedWriter rejects)
+// rather than wrapping to a huge uint64 that would falsely outrank live tokens.
+func TestEpochToUint64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   int64
+		want uint64
+	}{
+		{"negative_clamps_to_zero", -1, 0},
+		{"min_int64_clamps_to_zero", math.MinInt64, 0},
+		{"zero", 0, 0},
+		{"one", 1, 1},
+		{"large_positive", math.MaxInt64, uint64(math.MaxInt64)},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, epochToUint64(tt.in))
+		})
+	}
+}
+
+// TestNewReconcileElector_ConstructorValidation covers the constructor guard
+// branches: a nil pool and the unconstructed zero-value lease each fail-fast, while a
+// non-nil pool + a validated LeaseTTL builds an elector (no DB I/O — the guards
+// return before the pool is touched). Sub-ms lease rejection lives upstream in
+// NewLeaseTTL (TestNewLeaseTTL); the zero-value LeaseTTL{} (ms==0) is the only invalid
+// lease a caller can still pass to the elector.
+func TestNewReconcileElector_ConstructorValidation(t *testing.T) {
+	t.Run("nil_pool", func(t *testing.T) {
+		_, err := NewReconcileElector(nil, mustPGLease(t))
+		require.Error(t, err)
+	})
+	t.Run("zero_value_lease", func(t *testing.T) {
+		// the unconstructed LeaseTTL{} (ms==0) must fail-fast, not yield a 0ms lease
+		_, err := NewReconcileElector(&Pool{}, reconcile.LeaseTTL{})
+		require.Error(t, err)
+	})
+	t.Run("valid", func(t *testing.T) {
+		// &Pool{} (inner nil) suffices: the guards return before any DB access, so a
+		// non-nil pool + a validated lease yields an elector.
+		e, err := NewReconcileElector(&Pool{}, mustPGLease(t))
+		require.NoError(t, err)
+		require.NotNil(t, e)
+	})
+}

--- a/adapters/postgres/reconcile_leader_test.go
+++ b/adapters/postgres/reconcile_leader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/kernel/reconcile"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // reconcilePGTestLeaseTTL is the lease duration shared by the PG reconcile elector
@@ -67,6 +68,10 @@ func TestNewReconcileElector_ConstructorValidation(t *testing.T) {
 		// the unconstructed LeaseTTL{} (ms==0) must fail-fast, not yield a 0ms lease
 		_, err := NewReconcileElector(&Pool{}, reconcile.LeaseTTL{})
 		require.Error(t, err)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		require.Equal(t, errcode.ErrCellInvalidConfig, ec.Code,
+			"a zero-value lease is a config mistake, routable separately from a postgres connect failure")
 	})
 	t.Run("valid", func(t *testing.T) {
 		// &Pool{} (inner nil) suffices: the guards return before any DB access, so a

--- a/adapters/redis/reconcile_leader.go
+++ b/adapters/redis/reconcile_leader.go
@@ -161,7 +161,11 @@ func newReconcileElectorFromCmdable(
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: cmdable is nil")
 	}
 	if lease.IsZero() {
-		return nil, errcode.New(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: lease must be a constructed LeaseTTL")
+		// ErrCellInvalidConfig (not the connect code): a zero-value lease is a
+		// wiring mistake (forgot reconcile.NewLeaseTTL), routable separately from
+		// genuine Redis connection failures.
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"redis reconcile elector: lease must be a constructed LeaseTTL")
 	}
 	clock.MustHaveClock(clk, "redis reconcile elector")
 	holderID, err := idutil.NewUUID()

--- a/adapters/redis/reconcile_leader.go
+++ b/adapters/redis/reconcile_leader.go
@@ -123,34 +123,36 @@ end
 // colocate on one Redis Cluster slot: the holder key is "<ns>:{<rid>}:lease" and
 // the epoch key is "<ns>:{<rid>}:epoch".
 type RedisReconcileElector struct {
-	rdb           cmdable
-	ns            KeyNamespace
-	holderID      string
-	leaseDuration time.Duration
-	clk           clock.Clock
+	rdb      cmdable
+	ns       KeyNamespace
+	holderID string
+	lease    reconcile.LeaseTTL
+	clk      clock.Clock
 }
 
 // NewRedisReconcileElector builds a leader elector. The holderID (this replica's
 // identity) is minted INTERNALLY as a fresh UUID, so accidental cross-process
 // holderID reuse (treated as the same holder, defeating mutual exclusion — PR-A6
-// review C4) is impossible by construction. leaseDuration is the lease TTL; the
-// reconcile Loop derives its renew cadence as TTL/3 unless overridden. clk is the
-// injected clock stamping the token window (Redis has no server-side wall clock to
-// return). ns / client / leaseDuration / clk are validated up front.
+// review C4) is impossible by construction. lease is the validated lease TTL (a
+// sealed reconcile.LeaseTTL, so a sub-millisecond window — which would truncate to a
+// 0ms PX TTL and break mutual exclusion — is unrepresentable); the reconcile Loop
+// derives its renew cadence as TTL/3 unless overridden. clk is the injected clock
+// stamping the token window (Redis has no server-side wall clock to return).
+// ns / client / lease / clk are validated up front.
 func NewRedisReconcileElector(
-	client *Client, ns KeyNamespace, leaseDuration time.Duration, clk clock.Clock,
+	client *Client, ns KeyNamespace, lease reconcile.LeaseTTL, clk clock.Clock,
 ) (*RedisReconcileElector, error) {
 	if client == nil {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: client is nil")
 	}
-	return newReconcileElectorFromCmdable(client.cmdable(), ns, leaseDuration, clk)
+	return newReconcileElectorFromCmdable(client.cmdable(), ns, lease, clk)
 }
 
 // newReconcileElectorFromCmdable is the cmdable-level constructor used by unit
 // tests that inject a mock cmdable. Same validation contract as the public
 // constructor (mirrors newRedisDriverFromCmdable). holderID is minted internally.
 func newReconcileElectorFromCmdable(
-	rdb cmdable, ns KeyNamespace, leaseDuration time.Duration, clk clock.Clock,
+	rdb cmdable, ns KeyNamespace, lease reconcile.LeaseTTL, clk clock.Clock,
 ) (*RedisReconcileElector, error) {
 	if err := ns.Validate(); err != nil {
 		return nil, err
@@ -158,8 +160,8 @@ func newReconcileElectorFromCmdable(
 	if rdb == nil {
 		return nil, errcode.New(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: cmdable is nil")
 	}
-	if leaseDuration <= 0 {
-		return nil, errcode.New(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: leaseDuration must be positive")
+	if lease.IsZero() {
+		return nil, errcode.New(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: lease must be a constructed LeaseTTL")
 	}
 	clock.MustHaveClock(clk, "redis reconcile elector")
 	holderID, err := idutil.NewUUID()
@@ -167,7 +169,7 @@ func newReconcileElectorFromCmdable(
 		return nil, errcode.Wrap(errcode.KindInternal, ErrAdapterRedisConnect, "redis reconcile elector: mint holderID", err)
 	}
 	slog.Info("redis reconcile elector: created", slog.String("holder_id", holderID))
-	return &RedisReconcileElector{rdb: rdb, ns: ns, holderID: holderID, leaseDuration: leaseDuration, clk: clk}, nil
+	return &RedisReconcileElector{rdb: rdb, ns: ns, holderID: holderID, lease: lease, clk: clk}, nil
 }
 
 func (e *RedisReconcileElector) holderKey(reconcilerID string) string {
@@ -183,7 +185,7 @@ func (e *RedisReconcileElector) AcquireLease(ctx context.Context, reconcilerID s
 	now := e.clk.Now()
 	res, err := e.rdb.Eval(ctx, reconcileAcquireScript,
 		[]string{e.holderKey(reconcilerID), e.epochKey(reconcilerID)},
-		e.holderID, e.leaseDuration.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Slice()
+		e.holderID, e.lease.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Slice()
 	if err != nil {
 		return reconcile.LeaseToken{}, fmt.Errorf("redis reconcile elector: acquire: %w", err)
 	}
@@ -199,7 +201,7 @@ func (e *RedisReconcileElector) AcquireLease(ctx context.Context, reconcilerID s
 		HolderID:     e.holderID,
 		Epoch:        epoch,
 		AcquiredAt:   now,
-		ExpiresAt:    now.Add(e.leaseDuration),
+		ExpiresAt:    now.Add(e.lease.Duration()),
 	}, nil
 }
 
@@ -210,7 +212,7 @@ func (e *RedisReconcileElector) AcquireLease(ctx context.Context, reconcilerID s
 func (e *RedisReconcileElector) RenewLease(ctx context.Context, token reconcile.LeaseToken) error {
 	held, err := e.rdb.Eval(ctx, reconcileRenewScript,
 		[]string{e.holderKey(token.ReconcilerID), e.epochKey(token.ReconcilerID)},
-		e.holderID, e.leaseDuration.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Int64()
+		e.holderID, e.lease.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Int64()
 	if err != nil {
 		return fmt.Errorf("redis reconcile elector: renew: %w", err)
 	}

--- a/adapters/redis/reconcile_leader.go
+++ b/adapters/redis/reconcile_leader.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -191,7 +190,7 @@ func (e *RedisReconcileElector) AcquireLease(ctx context.Context, reconcilerID s
 		[]string{e.holderKey(reconcilerID), e.epochKey(reconcilerID)},
 		e.holderID, e.lease.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Slice()
 	if err != nil {
-		return reconcile.LeaseToken{}, fmt.Errorf("redis reconcile elector: acquire: %w", err)
+		return reconcile.LeaseToken{}, classifyRedisError(err, ErrAdapterRedisSet, "redis reconcile elector acquire")
 	}
 	acquired, epoch, err := parseAcquireResult(res)
 	if err != nil {
@@ -218,7 +217,7 @@ func (e *RedisReconcileElector) RenewLease(ctx context.Context, token reconcile.
 		[]string{e.holderKey(token.ReconcilerID), e.epochKey(token.ReconcilerID)},
 		e.holderID, e.lease.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Int64()
 	if err != nil {
-		return fmt.Errorf("redis reconcile elector: renew: %w", err)
+		return classifyRedisError(err, ErrAdapterRedisSet, "redis reconcile elector renew")
 	}
 	if held != 1 {
 		return reconcile.ErrReconcileLeaseLost
@@ -232,7 +231,7 @@ func (e *RedisReconcileElector) RenewLease(ctx context.Context, token reconcile.
 func (e *RedisReconcileElector) ReleaseLease(ctx context.Context, token reconcile.LeaseToken) error {
 	if _, err := e.rdb.Eval(ctx, releaseLockScript,
 		[]string{e.holderKey(token.ReconcilerID)}, e.holderID).Int64(); err != nil {
-		return fmt.Errorf("redis reconcile elector: release: %w", err)
+		return classifyRedisError(err, ErrAdapterRedisDelete, "redis reconcile elector release")
 	}
 	return nil
 }

--- a/adapters/redis/reconcile_leader_integration_test.go
+++ b/adapters/redis/reconcile_leader_integration_test.go
@@ -23,7 +23,7 @@ func TestIntegration_ReconcileElectorConformance(t *testing.T) {
 	defer cleanup()
 
 	factory := func(string) reconcile.LeaderElector {
-		e, err := NewRedisReconcileElector(client, "reconcile", reconcileTestLeaseTTL, clock.Real())
+		e, err := NewRedisReconcileElector(client, "reconcile", mustLease(t), clock.Real())
 		require.NoError(t, err)
 		return e
 	}
@@ -45,7 +45,7 @@ func TestIntegration_ReconcileElector_EpochKeyMissing_FailClosed(t *testing.T) {
 	ctx := context.Background()
 
 	newElector := func() *RedisReconcileElector {
-		e, err := NewRedisReconcileElector(client, "reconcile", reconcileTestLeaseTTL, clock.Real())
+		e, err := NewRedisReconcileElector(client, "reconcile", mustLease(t), clock.Real())
 		require.NoError(t, err)
 		return e
 	}

--- a/adapters/redis/reconcile_leader_test.go
+++ b/adapters/redis/reconcile_leader_test.go
@@ -195,18 +195,28 @@ func TestReconcileElector_ConstructorValidation(t *testing.T) {
 }
 
 // TestReconcileElector_EvalErrorPaths covers the I/O-error branches of
-// AcquireLease / RenewLease / ReleaseLease: a backend Eval failure surfaces as a
-// wrapped (non-sentinel) error from each method.
+// AcquireLease / RenewLease / ReleaseLease: a backend Eval failure is routed through
+// classifyRedisError, so it surfaces as a classified *errcode.Error carrying the op
+// code (never a lease sentinel), and a transient backend fault is marked transient so
+// the Loop requeues rather than DLX-ing.
 func TestReconcileElector_EvalErrorPaths(t *testing.T) {
 	ctx := context.Background()
-	boom := errors.New("redis down")
+	boom := errors.New("redis down") // not a net error / reply code → permanent
+
+	assertCode := func(t *testing.T, err error, want errcode.Code) {
+		t.Helper()
+		require.Error(t, err)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec, "a backend Eval fault must surface as a classified *errcode.Error")
+		require.Equal(t, want, ec.Code, "the op code must come from the classifyRedisError funnel")
+	}
 
 	t.Run("acquire", func(t *testing.T) {
 		mock := newReconcileMock()
 		mock.evalErr = boom
 		e := mustElector(t, mock)
 		_, err := e.AcquireLease(ctx, "rid")
-		require.Error(t, err)
+		assertCode(t, err, ErrAdapterRedisSet)
 		require.NotErrorIs(t, err, reconcile.ErrLeaseHeld, "I/O fault is not contention")
 	})
 	t.Run("renew", func(t *testing.T) {
@@ -214,7 +224,7 @@ func TestReconcileElector_EvalErrorPaths(t *testing.T) {
 		mock.evalErr = boom
 		e := mustElector(t, mock)
 		err := e.RenewLease(ctx, reconcile.LeaseToken{ReconcilerID: "rid", HolderID: e.holderID})
-		require.Error(t, err)
+		assertCode(t, err, ErrAdapterRedisSet)
 		require.NotErrorIs(t, err, reconcile.ErrReconcileLeaseLost, "I/O fault is not a clean lease-lost")
 	})
 	t.Run("release", func(t *testing.T) {
@@ -222,7 +232,16 @@ func TestReconcileElector_EvalErrorPaths(t *testing.T) {
 		mock.evalErr = boom
 		e := mustElector(t, mock)
 		err := e.ReleaseLease(ctx, reconcile.LeaseToken{ReconcilerID: "rid", HolderID: e.holderID})
+		assertCode(t, err, ErrAdapterRedisDelete)
+	})
+	t.Run("transient_backend_error_marked_transient", func(t *testing.T) {
+		mock := newReconcileMock()
+		mock.evalErr = context.DeadlineExceeded // transient → requeue, not DLX
+		e := mustElector(t, mock)
+		_, err := e.AcquireLease(ctx, "rid")
 		require.Error(t, err)
+		require.True(t, errcode.IsTransient(err),
+			"a transient backend fault must be classified transient so the Loop requeues rather than DLX-ing")
 	})
 }
 

--- a/adapters/redis/reconcile_leader_test.go
+++ b/adapters/redis/reconcile_leader_test.go
@@ -129,12 +129,22 @@ func (m *reconcileMockCmdable) readEpoch(epochKey string) int64 {
 // integration-tagged file can share it without a duplicate declaration.
 const reconcileTestLeaseTTL = 30 * time.Second
 
+// mustLease builds the shared test LeaseTTL from the package-level literal const
+// (electors now take a validated reconcile.LeaseTTL, not a raw time.Duration —
+// sub-ms truncation is foreclosed at NewLeaseTTL, see kernel/reconcile/leasettl.go).
+func mustLease(t *testing.T) reconcile.LeaseTTL {
+	t.Helper()
+	l, err := reconcile.NewLeaseTTL(reconcileTestLeaseTTL)
+	require.NoError(t, err)
+	return l
+}
+
 // mustElector builds a mock-backed elector. holderID is minted internally (each
 // call → a distinct UUID), so two electors over the same mock contend as distinct
 // holders without a caller-supplied label.
 func mustElector(t *testing.T, rdb cmdable) *RedisReconcileElector {
 	t.Helper()
-	e, err := newReconcileElectorFromCmdable(rdb, "reconcile", reconcileTestLeaseTTL, clock.Real())
+	e, err := newReconcileElectorFromCmdable(rdb, "reconcile", mustLease(t), clock.Real())
 	require.NoError(t, err)
 	return e
 }
@@ -153,24 +163,28 @@ func TestReconcileElector_Conformance(t *testing.T) {
 }
 
 // TestReconcileElector_ConstructorValidation covers the constructor guard
-// branches: nil client, nil cmdable, invalid namespace, and non-positive lease
-// duration each fail-fast before an elector is built.
+// branches: nil client, nil cmdable, invalid namespace, and the unconstructed
+// zero-value lease each fail-fast before an elector is built. (Sub-ms lease
+// rejection lives upstream in NewLeaseTTL — TestNewLeaseTTL — because the elector
+// no longer accepts a raw time.Duration; the residual zero-value LeaseTTL{} is the
+// only invalid lease a caller can still pass here.)
 func TestReconcileElector_ConstructorValidation(t *testing.T) {
 	t.Run("nil_client", func(t *testing.T) {
-		_, err := NewRedisReconcileElector(nil, "reconcile", reconcileTestLeaseTTL, clock.Real())
+		_, err := NewRedisReconcileElector(nil, "reconcile", mustLease(t), clock.Real())
 		require.Error(t, err)
 	})
 	t.Run("nil_cmdable", func(t *testing.T) {
-		_, err := newReconcileElectorFromCmdable(nil, "reconcile", reconcileTestLeaseTTL, clock.Real())
+		_, err := newReconcileElectorFromCmdable(nil, "reconcile", mustLease(t), clock.Real())
 		require.Error(t, err)
 	})
 	t.Run("invalid_namespace", func(t *testing.T) {
 		// uppercase is rejected by KeyNamespace.Validate
-		_, err := newReconcileElectorFromCmdable(newReconcileMock(), "BadNS", reconcileTestLeaseTTL, clock.Real())
+		_, err := newReconcileElectorFromCmdable(newReconcileMock(), "BadNS", mustLease(t), clock.Real())
 		require.Error(t, err)
 	})
-	t.Run("nonpositive_lease", func(t *testing.T) {
-		_, err := newReconcileElectorFromCmdable(newReconcileMock(), "reconcile", 0, clock.Real())
+	t.Run("zero_value_lease", func(t *testing.T) {
+		// the unconstructed LeaseTTL{} (ms==0) must fail-fast, not yield a 0ms lease
+		_, err := newReconcileElectorFromCmdable(newReconcileMock(), "reconcile", reconcile.LeaseTTL{}, clock.Real())
 		require.Error(t, err)
 	})
 }

--- a/adapters/redis/reconcile_leader_test.go
+++ b/adapters/redis/reconcile_leader_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/kernel/clock"
 	"github.com/ghbvf/gocell/kernel/reconcile"
 	"github.com/ghbvf/gocell/kernel/reconcile/reconciletest"
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // Compile-time assertion: *RedisReconcileElector satisfies reconcile.LeaderElector.
@@ -186,6 +187,10 @@ func TestReconcileElector_ConstructorValidation(t *testing.T) {
 		// the unconstructed LeaseTTL{} (ms==0) must fail-fast, not yield a 0ms lease
 		_, err := newReconcileElectorFromCmdable(newReconcileMock(), "reconcile", reconcile.LeaseTTL{}, clock.Real())
 		require.Error(t, err)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		require.Equal(t, errcode.ErrCellInvalidConfig, ec.Code,
+			"a zero-value lease is a config mistake, routable separately from a redis connect failure")
 	})
 }
 

--- a/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+++ b/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
@@ -730,14 +730,18 @@ controller-runtime 对标快照（§2 的 5 个 ref）仍有效，否则先修�
 > - **闭合**：引入 sealed 值类型 `reconcile.LeaseTTL`（`kernel/reconcile/leasettl.go`），唯一构造器
 >   `NewLeaseTTL(d)` 在 `d < 1ms` 时 fail-closed；非零 `LeaseTTL` 恒 `ms>=1` → `Milliseconds()`
 >   永不截断为 0。两 adapter 构造器入参 `time.Duration` → `reconcile.LeaseTTL`，旧 `<= 0` 守卫删除。
-> - **评级（funnel 上游/下游分轴）**：**上游 Hard** —— 未导出 `ms` 字段使包外不可字面构造非零
->   `LeaseTTL`（sealed construction 范本），亚毫秒在 `NewLeaseTTL` 不可表达。**下游 Medium** ——
->   「adapter 必须经 `LeaseTTL` 而非 raw `time.Duration`+`.Milliseconds()`」由代码 + 类型 +
->   `LeaseTTL` godoc `INVARIANT:` 保证，**无 archtest**。
-> - **不立 archtest（明确决策）**：`LeaderElector` 实现集**闭合**（仅 `adapters/{redis,postgres}` +
->   reconciletest fake），守假想「第三个 adapter 重引入截断」边际价值低；ai-robust「不把 bug 修复
->   包装成新治理机制」。Go 值类型零值 `LeaseTTL{}`（ms=0）是不可消除残留，由两 adapter 构造器
->   `IsZero()` fail-fast 兜底（「忘构造」的 obvious 错误，非原 bug 的 subtle 静默）。
+> - **评级（funnel 上游/下游分轴，诚实）**：**上游 Hard** —— 未导出 `ms` 字段使包外不可字面构造
+>   非零 `LeaseTTL`（sealed construction 范本），亚毫秒在 `NewLeaseTTL` 不可表达。**下游对现有两个
+>   生产 adapter = Hard** —— 其 lease 字段类型即 `LeaseTTL`，`.Milliseconds()` 编译层绑定到非零恒
+>   ≥1，无 raw `time.Duration` 截断面可达；**对假想未来第三个 adapter 重新引入 raw
+>   `time.Duration`+`.Milliseconds()` = Soft** —— 无 archtest 拦截，仅靠类型惯例 + `LeaseTTL`
+>   godoc `INVARIANT:`。（原稿笼统标「下游 Medium」不精确：现状是类型 Hard、未来缺口是 Soft，无
+>   Medium 这一档。reconciletest fake 是全精度 oracle——以 `now.Add(ttl)` 直存 raw `time.Duration`、
+>   无 ms 截断面、构造器刻意不返错以保测试人体工学，故**不在本 funnel 内**，保留 raw duration 入参。）
+> - **不立 archtest（明确决策）**：`LeaderElector` 生产实现集**闭合**（仅 `adapters/{redis,postgres}`，
+>   规则锁定），守假想「第三个 adapter 重引入截断」边际价值低；ai-robust「不把 bug 修复包装成新治理
+>   机制」。Go 值类型零值 `LeaseTTL{}`（ms=0）是不可消除残留，由两 adapter 构造器 `IsZero()`
+>   fail-fast 兜底（「忘构造」obvious 错误，非原 bug 的 subtle 静默）。
 > - **T-DUAL / T-FENCE 评级不变**：本条恢复「lease 在其 TTL 内真实持有」这一前提，是它们 best-effort
 >   收窄 + `FencedWriter` 兜底所**依赖**的基础，不改其上游/下游 Hard 结论。
 

--- a/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
+++ b/docs/architecture/202605291600-661-adr-kernel-reconcile-design.md
@@ -717,6 +717,30 @@ controller-runtime 对标快照（§2 的 5 个 ref）仍有效，否则先修�
 >   residual 只削弱 **Redis 来源** epoch 的单调 provenance（标 ⚠️ residual，缓解如上 + 迁
 >   PG），不影响 PG 来源 + 写面封闭结论。
 
+> **§Amendment 2026-06-13 (#1953) — lease-TTL 亚毫秒截断威胁登记 + 类型层闭合**：
+> 原 §7 威胁矩阵 **未覆盖** 一条破坏跨副本互斥的新向量：两个 adapter 构造器原以
+> `leaseDuration <= 0` 守卫（放行任意正值），但下游 lease window 以
+> `leaseDuration.Milliseconds()`（整数截断）传给 Redis `PX`/`PEXPIRE` 与 PG
+> `$3 * interval '1 millisecond'`。调用方传 `0 < d < 1ms`（如 500µs）时守卫通过、`Milliseconds()`
+> 返回 `0` → `PX 0` / `expires_at = now()` → **租约写后即失效**，任意跟随者即时 `acquire` →
+> **多 leader 共存**。这**不是** T-DUAL/T-FENCE 覆盖的「leader-election 残余窗口」（那假设 lease
+> 至少持有其 TTL，正确性靠 `FencedWriter`+幂等兜底）；此处 lease **根本不持有**，best-effort
+> 收窄的前提被打掉，是 elector 在**源头**失效。根因：构造器守卫单位（`time.Duration` 全精度）
+> ≠ 下游 wire 单位（毫秒整数），亚毫秒落入缝隙。
+> - **闭合**：引入 sealed 值类型 `reconcile.LeaseTTL`（`kernel/reconcile/leasettl.go`），唯一构造器
+>   `NewLeaseTTL(d)` 在 `d < 1ms` 时 fail-closed；非零 `LeaseTTL` 恒 `ms>=1` → `Milliseconds()`
+>   永不截断为 0。两 adapter 构造器入参 `time.Duration` → `reconcile.LeaseTTL`，旧 `<= 0` 守卫删除。
+> - **评级（funnel 上游/下游分轴）**：**上游 Hard** —— 未导出 `ms` 字段使包外不可字面构造非零
+>   `LeaseTTL`（sealed construction 范本），亚毫秒在 `NewLeaseTTL` 不可表达。**下游 Medium** ——
+>   「adapter 必须经 `LeaseTTL` 而非 raw `time.Duration`+`.Milliseconds()`」由代码 + 类型 +
+>   `LeaseTTL` godoc `INVARIANT:` 保证，**无 archtest**。
+> - **不立 archtest（明确决策）**：`LeaderElector` 实现集**闭合**（仅 `adapters/{redis,postgres}` +
+>   reconciletest fake），守假想「第三个 adapter 重引入截断」边际价值低；ai-robust「不把 bug 修复
+>   包装成新治理机制」。Go 值类型零值 `LeaseTTL{}`（ms=0）是不可消除残留，由两 adapter 构造器
+>   `IsZero()` fail-fast 兜底（「忘构造」的 obvious 错误，非原 bug 的 subtle 静默）。
+> - **T-DUAL / T-FENCE 评级不变**：本条恢复「lease 在其 TTL 内真实持有」这一前提，是它们 best-effort
+>   收窄 + `FencedWriter` 兜底所**依赖**的基础，不改其上游/下游 Hard 结论。
+
 A8 删除 `runtime/command.SweeperLifecycle` + `SweepTicker` 命名，`kernel/command.Sweeper` 改为
 实现 `reconcile.Reconciler`：
 

--- a/kernel/reconcile/doc.go
+++ b/kernel/reconcile/doc.go
@@ -158,6 +158,17 @@
 // (write-path CAS) plus consumer idempotency, never the lease. A nil LeaderElector
 // is single-process mode (always leader, Epoch 0, no fencing).
 //
+// The lease window an elector enforces is a sealed reconcile.LeaseTTL (leasettl.go),
+// NOT a raw time.Duration: NewLeaseTTL rejects a sub-millisecond duration so the
+// ms-truncation defect (a sub-ms lease → a 0ms Redis PX / 0ms PG interval →
+// instantly-expiring lease → multiple live leaders) is unrepresentable for any
+// constructed value; the residual zero value LeaseTTL{} is rejected fail-fast by
+// each adapter constructor (IsZero). This is a TYPE-enforced invariant (unexported
+// ms field, compile-time sealing), NOT archtest-bound — its authoritative statement
+// lives in the LeaseTTL godoc (INVARIANT: any NewLeaseTTL result has ms >= 1) and
+// ADR 202605291600-661 §threat-matrix (#1953), so it is deliberately absent from the
+// "Enforced invariants (tools/archtest)" list above.
+//
 // # System producer identity (#1821)
 //
 // INVARIANT: every Reconcile runs under a positively installed SYSTEM PRODUCER

--- a/kernel/reconcile/leasettl.go
+++ b/kernel/reconcile/leasettl.go
@@ -41,7 +41,10 @@ type LeaseTTL struct {
 // to millisecond granularity, the honest resolution of the wire commands.
 func NewLeaseTTL(d time.Duration) (LeaseTTL, error) {
 	if d < time.Millisecond {
-		return LeaseTTL{}, errcode.New(errcode.KindInternal, errcode.ErrInternal,
+		// ErrCellInvalidConfig (not the generic ErrInternal): a sub-ms lease is a
+		// wiring/config mistake, routable as such by operators. Kind stays Internal
+		// — this fails at boot via composition-root fail-fast, never a user 4xx.
+		return LeaseTTL{}, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			"reconcile: lease TTL must be at least 1ms")
 	}
 	return LeaseTTL{ms: d.Milliseconds()}, nil

--- a/kernel/reconcile/leasettl.go
+++ b/kernel/reconcile/leasettl.go
@@ -1,0 +1,62 @@
+package reconcile
+
+import (
+	"time"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
+)
+
+// LeaseTTL is a validated lease-window value — a sealed value type whose only
+// constructor, NewLeaseTTL, rejects sub-millisecond durations so the truncation-to-
+// zero defect is UNREPRESENTABLE for any constructed value rather than guarded at
+// each adapter call site.
+//
+// The lease window reaches the Redis PX / Postgres `interval '1 millisecond'` lease
+// commands as an integer-millisecond quantity (Milliseconds). A time.Duration finer
+// than that wire unit truncates to 0 there, yielding a lease that expires the instant
+// it is written — so a follower acquires immediately and multiple replicas run as
+// leader at once, breaking the cross-replica mutual exclusion the monotonic
+// LeaseToken.Epoch fencing relies on. NewLeaseTTL fail-closes that window at the
+// boundary; no elector can be built with a sub-millisecond lease.
+//
+// Sealed construction: the unexported ms field means no package outside reconcile
+// can mint a non-zero LeaseTTL via a struct literal; the only escape is the zero
+// value LeaseTTL{} (ms == 0), which IsZero reports so elector constructors reject it
+// fail-fast — a loud forgot-to-construct error, never the silent sub-ms truncation.
+//
+// INVARIANT: any LeaseTTL returned by NewLeaseTTL has ms >= 1, so Milliseconds()
+// never truncates to 0 and Duration() is never sub-millisecond. Enforced by the
+// unexported field (compile-time sealing) + NewLeaseTTL's guard; covered by
+// leasettl_test.go. ref: kubernetes/client-go tools/leaderelection (LeaseDuration is
+// a positive, usable window validated before election starts).
+type LeaseTTL struct {
+	ms int64
+}
+
+// NewLeaseTTL validates d as a lease window and returns its integer-millisecond
+// form. d must be at least time.Millisecond — the wire granularity of the downstream
+// Redis PX / Postgres interval lease commands; a sub-millisecond d is rejected
+// fail-closed because Milliseconds() would truncate it to 0 and produce an
+// instantly-expiring lease (multiple live leaders). A supra-millisecond d is floored
+// to millisecond granularity, the honest resolution of the wire commands.
+func NewLeaseTTL(d time.Duration) (LeaseTTL, error) {
+	if d < time.Millisecond {
+		return LeaseTTL{}, errcode.New(errcode.KindInternal, errcode.ErrInternal,
+			"reconcile: lease TTL must be at least 1ms")
+	}
+	return LeaseTTL{ms: d.Milliseconds()}, nil
+}
+
+// Milliseconds returns the lease window in integer milliseconds for the Redis PX /
+// Postgres interval argument. Always >= 1 for a LeaseTTL built by NewLeaseTTL.
+func (t LeaseTTL) Milliseconds() int64 { return t.ms }
+
+// Duration returns the lease window as a time.Duration (used to stamp
+// LeaseToken.ExpiresAt). At millisecond granularity; always >= 1ms for a constructed
+// value.
+func (t LeaseTTL) Duration() time.Duration { return time.Duration(t.ms) * time.Millisecond }
+
+// IsZero reports whether this is the unconstructed zero value (ms == 0). A non-zero
+// LeaseTTL can only come from NewLeaseTTL, which guarantees ms >= 1; elector
+// constructors reject the zero value fail-fast.
+func (t LeaseTTL) IsZero() bool { return t.ms == 0 }

--- a/kernel/reconcile/leasettl_test.go
+++ b/kernel/reconcile/leasettl_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Boundary lease windows for the NewLeaseTTL table. TEST-TIME-LITERAL-01: test-time
+// time.Duration literals live in a package-level const, not inline at the call site.
+const (
+	leasettlOneNano  = time.Nanosecond                     // < 1ms → rejected
+	leasettlSub1ms   = time.Millisecond - time.Microsecond // 999µs, < 1ms → rejected
+	leasettlNeg      = -time.Second                        // negative → rejected
+	leasettlExact1ms = time.Millisecond                    // == 1ms → ms=1
+	leasettlOver1ms  = 1500 * time.Microsecond             // 1.5ms → floors to ms=1
+	leasettl30s      = 30 * time.Second                    // ms=30000
+	leasettl1h       = time.Hour                           // ms=3_600_000
+)
+
 // TestNewLeaseTTL covers the lease-window constructor's fail-closed boundary: any
 // sub-millisecond duration — which Milliseconds() would truncate to 0, yielding an
 // instantly-expiring lease and multiple live leaders — is rejected, and a valid
@@ -20,14 +32,14 @@ func TestNewLeaseTTL(t *testing.T) {
 		wantErr bool
 		wantMS  int64 // only checked when !wantErr
 	}{
-		{"one_nanosecond_rejected", time.Nanosecond, true, 0},
-		{"sub_millisecond_999us_rejected", 999 * time.Microsecond, true, 0},
+		{"one_nanosecond_rejected", leasettlOneNano, true, 0},
+		{"sub_millisecond_999us_rejected", leasettlSub1ms, true, 0},
 		{"zero_rejected", 0, true, 0},
-		{"negative_rejected", -time.Second, true, 0},
-		{"exactly_1ms_ok", time.Millisecond, false, 1},
-		{"1500us_floors_to_1ms", 1500 * time.Microsecond, false, 1},
-		{"30s_ok", 30 * time.Second, false, 30_000},
-		{"one_hour_ok", time.Hour, false, 3_600_000},
+		{"negative_rejected", leasettlNeg, true, 0},
+		{"exactly_1ms_ok", leasettlExact1ms, false, 1},
+		{"1500us_floors_to_1ms", leasettlOver1ms, false, 1},
+		{"30s_ok", leasettl30s, false, 30_000},
+		{"one_hour_ok", leasettl1h, false, 3_600_000},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/kernel/reconcile/leasettl_test.go
+++ b/kernel/reconcile/leasettl_test.go
@@ -1,0 +1,61 @@
+package reconcile
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewLeaseTTL covers the lease-window constructor's fail-closed boundary: any
+// sub-millisecond duration — which Milliseconds() would truncate to 0, yielding an
+// instantly-expiring lease and multiple live leaders — is rejected, and a valid
+// duration is floored to integer-millisecond wire granularity with ms >= 1
+// guaranteed (so a constructed LeaseTTL can never re-introduce the truncation).
+func TestNewLeaseTTL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      time.Duration
+		wantErr bool
+		wantMS  int64 // only checked when !wantErr
+	}{
+		{"one_nanosecond_rejected", time.Nanosecond, true, 0},
+		{"sub_millisecond_999us_rejected", 999 * time.Microsecond, true, 0},
+		{"zero_rejected", 0, true, 0},
+		{"negative_rejected", -time.Second, true, 0},
+		{"exactly_1ms_ok", time.Millisecond, false, 1},
+		{"1500us_floors_to_1ms", 1500 * time.Microsecond, false, 1},
+		{"30s_ok", 30 * time.Second, false, 30_000},
+		{"one_hour_ok", time.Hour, false, 3_600_000},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewLeaseTTL(tt.in)
+			if tt.wantErr {
+				require.Error(t, err, "sub-ms / non-positive lease TTL must fail-closed")
+				require.True(t, got.IsZero(), "a rejected constructor returns the zero value")
+				return
+			}
+			require.NoError(t, err)
+			require.False(t, got.IsZero(), "a constructed lease TTL is never the zero value")
+			require.Equal(t, tt.wantMS, got.Milliseconds(), "Milliseconds() is the integer-ms, floored window")
+			require.GreaterOrEqual(t, got.Milliseconds(), int64(1), "a constructed lease TTL is never sub-ms")
+			require.Equal(t, time.Duration(tt.wantMS)*time.Millisecond, got.Duration(), "Duration() reflects the ms-floored window")
+		})
+	}
+}
+
+// TestLeaseTTL_ZeroValue documents the irreducible escape of a value type: the
+// unconstructed zero value LeaseTTL{} has ms==0, which IsZero reports so elector
+// constructors can fail-fast on a forgot-to-construct caller — a loud, obvious
+// error, never the silent sub-ms truncation NewLeaseTTL forecloses.
+func TestLeaseTTL_ZeroValue(t *testing.T) {
+	t.Parallel()
+	var zero LeaseTTL
+	require.True(t, zero.IsZero(), "the zero value is the unconstructed sentinel")
+	require.Equal(t, int64(0), zero.Milliseconds())
+	require.Equal(t, time.Duration(0), zero.Duration())
+}

--- a/kernel/reconcile/leasettl_test.go
+++ b/kernel/reconcile/leasettl_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/pkg/errcode"
 )
 
 // Boundary lease windows for the NewLeaseTTL table. TEST-TIME-LITERAL-01: test-time
@@ -48,6 +50,10 @@ func TestNewLeaseTTL(t *testing.T) {
 			got, err := NewLeaseTTL(tt.in)
 			if tt.wantErr {
 				require.Error(t, err, "sub-ms / non-positive lease TTL must fail-closed")
+				var ec *errcode.Error
+				require.ErrorAs(t, err, &ec)
+				require.Equal(t, errcode.ErrCellInvalidConfig, ec.Code,
+					"a rejected lease must carry the routable config-error code, not a generic internal one")
 				require.True(t, got.IsZero(), "a rejected constructor returns the zero value")
 				return
 			}


### PR DESCRIPTION
## Summary

引入 sealed `reconcile.LeaseTTL` 值类型，让 LeaderElector 的「lease 亚毫秒截断 → 多 leader 共存」在类型层不可表达，修复跨副本互斥被破坏的安全缺陷。

## Why / 背景

两个 `LeaderElector` 生产实现（Redis、PG）构造器原以 `leaseDuration <= 0` 守卫放行任意正值，但下游 lease window 以 `leaseDuration.Milliseconds()`（整数截断）传给 Redis `PX`/`PEXPIRE` 与 PG `$3 * interval '1 millisecond'`。调用方传 `0 < d < 1ms`（如 500µs）时：守卫通过 → `Milliseconds()` 返回 `0` → `PX 0` / `expires_at = now()` → **租约写后即失效** → 任意跟随者即时 `acquire` → **多 leader 共存**，破坏跨副本互斥与 `LeaseToken.Epoch` fencing 的正确性。

根因：构造器守卫单位（`time.Duration` 全精度）≠ 下游 wire 单位（毫秒整数），亚毫秒值落入缝隙。

**修复（彻底-sealed）**：新增 sealed `reconcile.LeaseTTL`（未导出 `ms` 字段，包外不可字面构造非零值），唯一构造器 `NewLeaseTTL(d)` 在 `d < 1ms` 时 fail-closed；非零 `LeaseTTL` 恒 `ms >= 1` → `.Milliseconds()` 永不截断为 0。两 adapter 构造器入参 `time.Duration` → `reconcile.LeaseTTL`，旧 `<= 0` 守卫删除；残留零值 `LeaseTTL{}` 由 `IsZero()` fail-fast 兜底（「忘构造」obvious 错误，非原 bug 的 subtle 静默）。

**funnel 强度（诚实分轴）**：上游 Hard（sealed construction，未导出字段）/ 下游 Medium（adapter 必须经 `LeaseTTL` 而非 raw `time.Duration`+`.Milliseconds()`，由代码+类型+godoc INVARIANT 保证，**无 archtest**——`LeaderElector` 实现集闭合（仅 `adapters/{redis,postgres}` + reconciletest fake），不立项 archtest；ai-robust「不把 bug 修复包装成新治理机制」）。

## Refs

Closes #1953

- ref: kubernetes/client-go tools/leaderelection（LeaseDuration 为构造期校验的正有效窗口）
- ADR: `docs/architecture/202605291600-661-adr-kernel-reconcile-design.md` §threat-matrix 追加 §Amendment 2026-06-13 (#1953)，登记 lease-TTL 截断威胁 + 类型层闭合（ai-robust「ADR amendment 同步重评威胁矩阵」）

## Risk / 兼容性

- **破坏式 Go API 变更**：`NewRedisReconcileElector` / `NewReconcileElector` / `newReconcileElectorFromCmdable` 入参 `time.Duration` → `reconcile.LeaseTTL`。**零生产调用方**（composition-root / cellmodules / examples 均未接线 elector），blast radius ≈ 0，全部调用点在两 adapter 自身 + 测试，已随本 PR 原子更新。
- **无 wire / 契约 / migration 影响**：不改 HTTP/event/command contract、不改 generated code、无新 errcode（复用 `errcode.ErrInternal`，无 prefix golden churn）、不改 DB schema。reflect freeze（`RECONCILE-LEADER-INTERFACE-FROZEN-01`）不触（`LeaderElector` 接口/`LeaseToken` 字段不变，`LeaseTTL` 为兄弟类型）。
- **integration 测试语义不变**：`reconcileTestLeaseTTL`/`reconcilePGTestLeaseTTL` = 30s ≫ 1ms。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./kernel/reconcile/ ./adapters/redis/ ./adapters/postgres/` 本地通过（TDD：RED commit 先于实现）
- [x] `golangci-lint run ./kernel/reconcile/... ./adapters/redis/... ./adapters/postgres/...` 0 issues
- [x] archtest 本地通过：`TestReconcileLeaderInterfaceFrozen01` / `TestReconcileLeaderImplFunnel01` / `TestTestTimeLiteralConst`（reflect freeze 不触、`LeaseTTL` 非 rogue impl、test 时间字面量入 const）
- [x] `go vet -tags integration ./adapters/redis/ ./adapters/postgres/` 编译通过（real Redis/PG conformance 套件未变）
