### PR TITLE
fix(idempotency): body-read/replay 失败路径可观测性 + 503 语义统一 [#2015]

### DIFF
--- a/assemblies/corebundle/generated/metrics-schema.yaml
+++ b/assemblies/corebundle/generated/metrics-schema.yaml
@@ -288,7 +288,7 @@ metrics:
       fqName: gocell_idempotency_requests_total
       namespace: gocell
       type: counter
-      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch)). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
+      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch); body_read_failed = request body read failed before the claim, a transient/connection fault — e.g. the client aborted the upload — that maps to 503). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
       labels:
         - cell
         - state

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -981,7 +981,7 @@ sum(rate(gocell_config_event_settlement_total[5m])) by (cell, slice, disposition
 
 ## HTTP 幂等 (#1460)
 
-`idempotency_requests_total{cell,state}` 由 HTTP idempotency 中间件（`runtime/http/idempotency`）经 `obmetrics.IdempotencyCollector` 发射，bootstrap 在配置了真实 metrics `Provider` 时自动接线。`cell` 是归属 RouteGroup 的 cell（框架路径为 `_runtime`）。`state` 取值冻结为 6 个终态（archtest `IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01` 守）：
+`idempotency_requests_total{cell,state}` 由 HTTP idempotency 中间件（`runtime/http/idempotency`）经 `obmetrics.IdempotencyCollector` 发射，bootstrap 在配置了真实 metrics `Provider` 时自动接线。`cell` 是归属 RouteGroup 的 cell（框架路径为 `_runtime`）。`state` 取值冻结为 7 个终态（archtest `IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01` 守）：
 
 - `acquired`：新 claim（已处理请求分母，claim 时计，不是其余 state 之和）
 - `replayed`：缓存响应回放
@@ -989,6 +989,7 @@ sum(rate(gocell_config_event_settlement_total[5m])) by (cell, slice, disposition
 - `store_error`：Claim 路径失败 → 500
 - `oversize`：响应超限不录（`acquired` 的子事件）
 - `key_reused`：同 key 不同 body → 422（附 per-field diff 字段名；安全相关）
+- `body_read_failed`：请求 body 读取失败 → 503（claim 前的入站传输/连接故障，如客户端中止上传；区别于 `store_error` 的服务端 store 故障，持续偏高指向客户端/网络问题）
 
 > 仅当配置真实 `Provider` 且某 listener 接线了 idempotency store 时才会有时间序列；无 store 时该 metric 仅出现在 `/metrics` HELP，无序列。
 

--- a/examples/demo/generated/metrics-schema.yaml
+++ b/examples/demo/generated/metrics-schema.yaml
@@ -163,7 +163,7 @@ metrics:
       file: runtime/bootstrap/phases_http.go
     - name: idempotency_requests_total
       type: counter
-      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch)). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
+      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch); body_read_failed = request body read failed before the claim, a transient/connection fault — e.g. the client aborted the upload — that maps to 503). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
       labels:
         - cell
         - state

--- a/examples/iotdevice/generated/metrics-schema.yaml
+++ b/examples/iotdevice/generated/metrics-schema.yaml
@@ -227,7 +227,7 @@ metrics:
       file: runtime/bootstrap/phases_http.go
     - name: idempotency_requests_total
       type: counter
-      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch)). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
+      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch); body_read_failed = request body read failed before the claim, a transient/connection fault — e.g. the client aborted the upload — that maps to 503). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
       labels:
         - cell
         - state

--- a/examples/orderfulfillment/generated/metrics-schema.yaml
+++ b/examples/orderfulfillment/generated/metrics-schema.yaml
@@ -163,7 +163,7 @@ metrics:
       file: runtime/bootstrap/phases_http.go
     - name: idempotency_requests_total
       type: counter
-      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch)). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
+      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch); body_read_failed = request body read failed before the claim, a transient/connection fault — e.g. the client aborted the upload — that maps to 503). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
       labels:
         - cell
         - state

--- a/examples/todoorder/generated/metrics-schema.yaml
+++ b/examples/todoorder/generated/metrics-schema.yaml
@@ -163,7 +163,7 @@ metrics:
       file: runtime/bootstrap/phases_http.go
     - name: idempotency_requests_total
       type: counter
-      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch)). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
+      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch); body_read_failed = request body read failed before the claim, a transient/connection fault — e.g. the client aborted the upload — that maps to 503). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
       labels:
         - cell
         - state

--- a/examples/webhookdemo/generated/metrics-schema.yaml
+++ b/examples/webhookdemo/generated/metrics-schema.yaml
@@ -163,7 +163,7 @@ metrics:
       file: runtime/bootstrap/phases_http.go
     - name: idempotency_requests_total
       type: counter
-      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch)). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
+      help: Total HTTP idempotency decisions, labeled by terminal state (acquired = fresh claim processed; replayed = cached response served; busy = an in-flight lease already holds the key; store_error = Claim-path store failure (Record/Release failures are logged only, not counted here); oversize = response too large to record; key_reused = same key presented with a different request body (fingerprint mismatch); body_read_failed = request body read failed before the claim, a transient/connection fault — e.g. the client aborted the upload — that maps to 503). acquired counts every fresh claim; oversize is a sub-event of acquired. cell is the owning RouteGroup cell or _runtime for framework paths.
       labels:
         - cell
         - state

--- a/runtime/http/idempotency/failure_observability_test.go
+++ b/runtime/http/idempotency/failure_observability_test.go
@@ -1,7 +1,6 @@
 package idempotency
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/pkg/testutil/slogcapture"
 	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
 )
 
@@ -32,15 +32,16 @@ type failingBodyWriter struct {
 
 func (f *failingBodyWriter) Write(_ []byte) (int, error) { return 0, f.writeErr }
 
-// captureSlog swaps the package-level default logger for a JSON handler over buf
-// (the middleware logs via package-level slog.ErrorContext) and restores it on
-// cleanup.
-func captureSlog(t *testing.T) *bytes.Buffer {
+// captureSlog redirects the process-global default logger (the middleware logs
+// via package-level slog.ErrorContext) to a JSON buffer for the duration of t.
+// It goes through slogcapture.InstallDefault — the sole sanctioned global-default
+// redirect site (SLOG-CAPTURE-GLOBAL-FUNNEL-01) — and uses a SyncBuffer so reads stay
+// race-safe. Tests using it MUST stay serial (no t.Parallel) per InstallDefault's
+// contract: a global redirect would race parallel siblings (#1490).
+func captureSlog(t *testing.T) *sloghelper.SyncBuffer {
 	t.Helper()
-	buf := &bytes.Buffer{}
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	buf := sloghelper.NewSyncBuffer()
+	slogcapture.InstallDefault(t, slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	return buf
 }
 
@@ -53,7 +54,8 @@ func captureSlog(t *testing.T) *bytes.Buffer {
 func TestServeHTTP_BodyReadError_Returns503AndLogs(t *testing.T) {
 	clk := clockmock.New(time.Now())
 	ms := NewMemStore(clk)
-	mw := Middleware(clk, ms)
+	obs := &recordingObserver{}
+	mw := Middleware(clk, ms, WithMetrics(obs))
 	buf := captureSlog(t)
 
 	handler := mw(testHandler(200, "should-not-run"))
@@ -65,6 +67,10 @@ func TestServeHTTP_BodyReadError_Returns503AndLogs(t *testing.T) {
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503; body: %s", rr.Code, rr.Body.String())
+	}
+
+	if len(obs.states) != 1 || obs.states[0] != StateBodyReadFailed {
+		t.Errorf("metric states: got %v, want [StateBodyReadFailed]", obs.states)
 	}
 
 	var envelope struct {

--- a/runtime/http/idempotency/failure_observability_test.go
+++ b/runtime/http/idempotency/failure_observability_test.go
@@ -1,0 +1,136 @@
+package idempotency
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/pkg/testutil/sloghelper"
+)
+
+// errReader is a minimal io.Reader that always fails on Read, used to simulate a
+// network/IO error during request body reading (mirrors runtime/webhook
+// receiver_test.go).
+type errReader struct{ err error }
+
+func (e errReader) Read(_ []byte) (int, error) { return 0, e.err }
+
+// failingBodyWriter wraps a ResponseWriter but fails every Write, used to drive
+// the replay-body write-failure path. Header()/WriteHeader delegate to the
+// embedded writer so status/headers are still observable.
+type failingBodyWriter struct {
+	http.ResponseWriter
+	writeErr error
+}
+
+func (f *failingBodyWriter) Write(_ []byte) (int, error) { return 0, f.writeErr }
+
+// captureSlog swaps the package-level default logger for a JSON handler over buf
+// (the middleware logs via package-level slog.ErrorContext) and restores it on
+// cleanup.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// TestServeHTTP_BodyReadError_Returns503AndLogs covers issue #2015: a request
+// body read failure must return 503 ERR_SERVICE_UNAVAILABLE (transient, mirrors
+// the webhook receiver) instead of 500 ERR_INTERNAL, and emit a correlated slog
+// entry — previously this path had no logging at all and returned the wrong
+// (server-fault) status. The custom msgBodyReadFailed surfaces only server-side
+// (5xx strips the message to a generic "service unavailable" on the wire).
+func TestServeHTTP_BodyReadError_Returns503AndLogs(t *testing.T) {
+	clk := clockmock.New(time.Now())
+	ms := NewMemStore(clk)
+	mw := Middleware(clk, ms)
+	buf := captureSlog(t)
+
+	handler := mw(testHandler(200, "should-not-run"))
+	r := requestWithUserCtx("POST", "/orders", "body-err-key", "tenant1", "user1")
+	r.Body = io.NopCloser(errReader{err: errors.New("simulated network read error")})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if got := envelope.Error.Code; got != "ERR_SERVICE_UNAVAILABLE" {
+		t.Errorf("code = %q, want ERR_SERVICE_UNAVAILABLE (transient, not server-fault ERR_INTERNAL)", got)
+	}
+
+	entry := sloghelper.FindLogEntry(buf.String(), "idempotency: read body failed")
+	if entry == nil {
+		t.Fatalf("expected a slog entry for the body-read failure; got none.\nlog: %s", buf.String())
+	}
+	for _, field := range []string{"err", "idempotency_key_hash", "subject", "tenant_id"} {
+		if _, ok := entry[field]; !ok {
+			t.Errorf("body-read failure log missing correlation field %q; entry=%v", field, entry)
+		}
+	}
+}
+
+// TestReplay_BodyWriteError_LogsWithCorrelation covers issue #2015: when writing
+// a replayed response body fails, the log must use slog.ErrorContext and carry
+// the idempotency correlation fields — previously it used a context-less
+// slog.Error with only an "error" field.
+func TestReplay_BodyWriteError_LogsWithCorrelation(t *testing.T) {
+	clk := clockmock.New(time.Now())
+	ms := NewMemStore(clk)
+	mw := Middleware(clk, ms)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		_, _ = io.WriteString(w, `{"id":"order-1"}`)
+	})
+	handler := mw(inner)
+
+	// First request records the response.
+	r1 := requestWithUserCtx("POST", "/orders", "replay-key", "tenant1", "user1")
+	rr1 := httptest.NewRecorder()
+	handler.ServeHTTP(rr1, r1)
+	if rr1.Code != 201 {
+		t.Fatalf("first request status = %d, want 201", rr1.Code)
+	}
+
+	// Second request replays; the response body write fails.
+	buf := captureSlog(t)
+	r2 := requestWithUserCtx("POST", "/orders", "replay-key", "tenant1", "user1")
+	fw := &failingBodyWriter{ResponseWriter: httptest.NewRecorder(), writeErr: errors.New("client gone")}
+	handler.ServeHTTP(fw, r2)
+
+	if rr := fw.ResponseWriter.(*httptest.ResponseRecorder); rr.Header().Get(headerIdempotencyReplayed) != "true" {
+		t.Fatalf("expected replay (Idempotency-Replayed: true); headers=%v", rr.Header())
+	}
+
+	entry := sloghelper.FindLogEntry(buf.String(), "idempotency: replay response body write failed")
+	if entry == nil {
+		t.Fatalf("expected a slog entry for the replay-write failure; got none.\nlog: %s", buf.String())
+	}
+	for _, field := range []string{"err", "idempotency_key_hash", "subject", "tenant_id"} {
+		if _, ok := entry[field]; !ok {
+			t.Errorf("replay-write failure log missing correlation field %q; entry=%v", field, entry)
+		}
+	}
+}

--- a/runtime/http/idempotency/metrics.go
+++ b/runtime/http/idempotency/metrics.go
@@ -11,7 +11,7 @@ import "context"
 // below). The same string-typed-enum funnel is used by the saga executor
 // (executor.TickResult / DriveResult / …) and reconcile (resultLabel).
 //
-// Cardinality: the value set is a closed, registration-time enumeration (6
+// Cardinality: the value set is a closed, registration-time enumeration (7
 // values); combined with the bounded {cell} dimension the worst-case series
 // count is tiny. There is no per-request / per-key dimension — keys are
 // SHA-256 hashed for logs only and never become metric labels.
@@ -56,6 +56,14 @@ const (
 	// It is security-relevant: a sustained rate can indicate a client bug or a
 	// replay attempt.
 	StateKeyReused RequestState = "key_reused"
+
+	// StateBodyReadFailed is recorded when reading the request body fails
+	// (io.ReadAll error → 503 ErrServiceUnavailable). Unlike StateStoreError (a
+	// Claim-path store failure → 500), this is an inbound transport/connection
+	// fault — e.g. the client aborted the upload — that occurs BEFORE the claim,
+	// so it is its own state: a sustained rate points at client/network trouble,
+	// not the idempotency store. Mirrors the webhook receiver's body-read handling.
+	StateBodyReadFailed RequestState = "body_read_failed"
 )
 
 // MetricsObserver is the best-effort sink for per-request idempotency metrics.

--- a/runtime/http/idempotency/middleware.go
+++ b/runtime/http/idempotency/middleware.go
@@ -435,6 +435,10 @@ func (h idempotencyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sc := logScope{keyHash: keyShortHash(idemKey), subject: p.Subject, tenantID: k.Namespace()}
 	fp, ok := readBodyFingerprint(r.Context(), w, r, sc)
 	if !ok {
+		// readBodyFingerprint already wrote the 503 + slog; record the metric
+		// state here (it has no cfg access) so body-read failures are observable
+		// like every other failure path.
+		cfg.observeState(r.Context(), StateBodyReadFailed)
 		return
 	}
 	// Mint the sealed RequestIdentity (caller + body fingerprint + validated key) and

--- a/runtime/http/idempotency/middleware.go
+++ b/runtime/http/idempotency/middleware.go
@@ -47,6 +47,13 @@ const (
 	// Must be a const literal (MESSAGE-CONST-LITERAL-01 archtest).
 	msgStoreUnavailable = "idempotency store unavailable"
 
+	// msgBodyReadFailed is the message for a request body I/O read failure (a
+	// transient/connection-level fault, not store unavailability). Mirrors the
+	// webhook receiver's body-read handling (runtime/webhook/receiver.go); paired
+	// with KindUnavailable → HTTP 503 so clients retry rather than treat it as a
+	// server fault. Must be a const literal (MESSAGE-CONST-LITERAL-01 archtest).
+	msgBodyReadFailed = "idempotency: failed to read request body"
+
 	// msgInProgress is the client-visible message for concurrent in-flight keys.
 	// Must be a const literal (MESSAGE-CONST-LITERAL-01 archtest).
 	msgInProgress = "a request with this Idempotency-Key is already in progress"
@@ -346,15 +353,48 @@ func validateKeyValue(idemKey string) error {
 	return nil
 }
 
+// logScope bundles the idempotency correlation fields emitted on every
+// structured log along this request's flow. Assembling the (key-hash, subject,
+// tenant) triple once with named fields — at the sole construction site in
+// ServeHTTP — makes mis-ordering the three same-typed strings unexpressible and
+// keeps the attribute keys defined in exactly one place (vs. repeating the
+// triple inline at every slog call).
+type logScope struct {
+	keyHash  string
+	subject  string
+	tenantID string
+}
+
+// attrs returns the correlation key/value pairs for slog's variadic args.
+func (s logScope) attrs() []any {
+	return []any{
+		"idempotency_key_hash", s.keyHash,
+		"subject", s.subject,
+		"tenant_id", s.tenantID,
+	}
+}
+
+// attrsWith prepends call-site-specific pairs (e.g. "err", err) to the
+// correlation attrs.
+func (s logScope) attrsWith(pairs ...any) []any {
+	return append(pairs, s.attrs()...)
+}
+
 // readBodyFingerprint reads the request body, restores it for the handler,
 // and returns the hex(sha256(body)) fingerprint. Returns ("", false) on error.
-func readBodyFingerprint(ctx context.Context, w http.ResponseWriter, r *http.Request) (string, bool) {
+//
+// On read failure it emits a correlated slog entry and returns 503
+// ERR_SERVICE_UNAVAILABLE: an io.ReadAll failure is a transient/connection-level
+// fault (e.g. client aborted the upload), not a server fault — mirroring the
+// webhook receiver's body-read handling (runtime/webhook/receiver.go).
+func readBodyFingerprint(ctx context.Context, w http.ResponseWriter, r *http.Request, sc logScope) (string, bool) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		slog.ErrorContext(ctx, "idempotency: read body failed", sc.attrsWith("err", err)...)
 		httputil.WriteError(ctx, w, errcode.New(
-			errcode.KindInternal,
-			errcode.ErrInternal,
-			msgStoreUnavailable,
+			errcode.KindUnavailable,
+			errcode.ErrServiceUnavailable,
+			msgBodyReadFailed,
 		))
 		return "", false
 	}
@@ -387,7 +427,13 @@ func (h idempotencyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !validateIdempotencyKey(r.Context(), w, idemKey) {
 		return
 	}
-	fp, ok := readBodyFingerprint(r.Context(), w, r)
+	// Derive the key + correlation scope once, before the body read, so every
+	// failure path (including the body-read failure below) carries the same
+	// correlation triple. DeriveKey is a pure function of the request/principal
+	// (body-independent), so computing it here changes no behavior.
+	k := DeriveKey(p.TenantID, p.Subject, r.Method, r.URL.Path, idemKey)
+	sc := logScope{keyHash: keyShortHash(idemKey), subject: p.Subject, tenantID: k.Namespace()}
+	fp, ok := readBodyFingerprint(r.Context(), w, r, sc)
 	if !ok {
 		return
 	}
@@ -404,7 +450,7 @@ func (h idempotencyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	r = r.WithContext(WithRequestIdentity(r.Context(), id))
-	h.handle(w, r, p, idemKey, fp)
+	h.handle(w, r, k, sc, fp)
 }
 
 // shouldIntercept returns true when the request method and Idempotency-Key
@@ -413,34 +459,22 @@ func shouldIntercept(r *http.Request) bool {
 	return idempotentMethods[r.Method] && r.Header.Get(headerIdempotencyKey) != ""
 }
 
-// handleWithIdempotency executes the full idempotency flow for a qualifying request.
-func (h idempotencyHandler) handle(w http.ResponseWriter, r *http.Request, p *auth.Principal, idemKey string, fp string) {
+// handleWithIdempotency executes the full idempotency flow for a qualifying
+// request. The derived key k and correlation scope sc are minted once in
+// ServeHTTP (so the body-read failure path shares them) and threaded in here.
+func (h idempotencyHandler) handle(w http.ResponseWriter, r *http.Request, k IdempotencyKey, sc logScope, fp string) {
 	cfg := h.config
-	k := DeriveKey(p.TenantID, p.Subject, r.Method, r.URL.Path, idemKey)
-	ns := k.Namespace() // for slog correlation + recordOrRelease below
 	ctx := r.Context()
-	keyHash := keyShortHash(idemKey)
 
 	state, rec, receipt, err := h.store.Claim(ctx, k, fp, cfg.leaseTTL)
 	if err != nil {
 		if errors.Is(err, ErrFingerprintMismatch) {
-			slog.WarnContext(
-				ctx, "idempotency: fingerprint mismatch — key reused with different body",
-				"idempotency_key_hash", keyHash,
-				"subject", p.Subject,
-				"tenant_id", ns,
-			)
+			slog.WarnContext(ctx, "idempotency: fingerprint mismatch — key reused with different body", sc.attrs()...)
 			cfg.observeState(ctx, StateKeyReused)
 			httputil.WriteError(ctx, w, keyReusedError(err, fp))
 			return
 		}
-		slog.ErrorContext(
-			ctx, "idempotency: store claim failed",
-			"err", err,
-			"idempotency_key_hash", keyHash,
-			"subject", p.Subject,
-			"tenant_id", ns,
-		)
+		slog.ErrorContext(ctx, "idempotency: store claim failed", sc.attrsWith("err", err)...)
 		cfg.observeState(ctx, StateStoreError)
 		httputil.WriteError(ctx, w, errcode.New(
 			errcode.KindInternal,
@@ -460,22 +494,12 @@ func (h idempotencyHandler) handle(w http.ResponseWriter, r *http.Request, p *au
 		// authorized. Re-checking authz on replay would let a previously-succeeded
 		// key later return 403, violating Idempotency-Key semantics (same key →
 		// same response). See ADR 202606021000-1043 威胁矩阵 row "回放跳过当前授权再校验".
-		slog.DebugContext(
-			ctx, "idempotency: replay hit",
-			"idempotency_key_hash", keyHash,
-			"subject", p.Subject,
-			"tenant_id", ns,
-		)
+		slog.DebugContext(ctx, "idempotency: replay hit", sc.attrs()...)
 		cfg.observeState(ctx, StateReplayed)
-		replayResponse(w, rec)
+		replayResponse(ctx, w, rec, sc)
 
 	case idempotency.ClaimBusy:
-		slog.WarnContext(
-			ctx, "idempotency: key in progress",
-			"idempotency_key_hash", keyHash,
-			"subject", p.Subject,
-			"tenant_id", ns,
-		)
+		slog.WarnContext(ctx, "idempotency: key in progress", sc.attrs()...)
 		cfg.observeState(ctx, StateBusy)
 		// Use a small fixed hint (retryAfterHintSeconds) rather than the full
 		// leaseTTL (300 s default) so clients retry soon without a long wait.
@@ -484,7 +508,7 @@ func (h idempotencyHandler) handle(w http.ResponseWriter, r *http.Request, p *au
 
 	default: // ClaimAcquired
 		cfg.observeState(ctx, StateAcquired)
-		h.recordOrRelease(w, r, receipt, keyHash, ns, p.Subject)
+		h.recordOrRelease(w, r, receipt, sc)
 	}
 }
 
@@ -506,7 +530,7 @@ func extractIdentity(ctx context.Context) (*auth.Principal, bool) {
 
 // replayResponse writes the stored RecordedResponse to w with the
 // Idempotency-Replayed marker.
-func replayResponse(w http.ResponseWriter, rec *RecordedResponse) {
+func replayResponse(ctx context.Context, w http.ResponseWriter, rec *RecordedResponse, sc logScope) {
 	for k, vv := range rec.Header() {
 		for _, v := range vv {
 			w.Header().Add(k, v)
@@ -514,12 +538,12 @@ func replayResponse(w http.ResponseWriter, rec *RecordedResponse) {
 	}
 	w.Header().Set(headerIdempotencyReplayed, "true")
 	w.WriteHeader(rec.Status())
-	writeRecordedBody(w, rec.Body())
+	writeRecordedBody(ctx, w, rec.Body(), sc)
 }
 
-func writeRecordedBody(w http.ResponseWriter, body []byte) {
+func writeRecordedBody(ctx context.Context, w http.ResponseWriter, body []byte, sc logScope) {
 	if _, err := io.Copy(w, bytes.NewReader(body)); err != nil {
-		slog.Error("idempotency: replay response body write failed", slog.Any("error", err))
+		slog.ErrorContext(ctx, "idempotency: replay response body write failed", sc.attrsWith("err", err)...)
 	}
 }
 
@@ -535,9 +559,7 @@ func (h idempotencyHandler) recordOrRelease(
 	w http.ResponseWriter,
 	r *http.Request,
 	receipt Receipt,
-	keyHash string,
-	namespace string,
-	subject string,
+	sc logScope,
 ) {
 	ctx := r.Context()
 	cfg := h.config
@@ -550,13 +572,7 @@ func (h idempotencyHandler) recordOrRelease(
 			// if the request context was canceled during handler execution.
 			// The lease will expire via TTL regardless; log at Warn on error.
 			if err := receipt.Release(context.WithoutCancel(ctx)); err != nil {
-				slog.WarnContext(
-					ctx, "idempotency: lease release failed (will expire via TTL)",
-					"err", err,
-					"idempotency_key_hash", keyHash,
-					"subject", subject,
-					"tenant_id", namespace,
-				)
+				slog.WarnContext(ctx, "idempotency: lease release failed (will expire via TTL)", sc.attrsWith("err", err)...)
 			}
 		}
 	}()
@@ -569,25 +585,13 @@ func (h idempotencyHandler) recordOrRelease(
 		filteredHeader := filterSensitiveHeaders(bw.capturedHeader())
 		resp := newRecordedResponse(h.clk, bw.status(), bw.bufferedBody(), filteredHeader)
 		if err := receipt.Record(context.WithoutCancel(ctx), &resp, cfg.doneTTL); err != nil {
-			slog.ErrorContext(
-				ctx, "idempotency: receipt record failed",
-				"err", err,
-				"idempotency_key_hash", keyHash,
-				"subject", subject,
-				"tenant_id", namespace,
-			)
+			slog.ErrorContext(ctx, "idempotency: receipt record failed", sc.attrsWith("err", err)...)
 			// Fall through to Release via defer.
 		} else {
 			recorded = true
 		}
 	} else if bw.committed() && bw.isOversized() {
-		slog.WarnContext(
-			ctx, "idempotency: response body oversized, not recorded",
-			"max_body_bytes", cfg.maxBodyBytes,
-			"idempotency_key_hash", keyHash,
-			"subject", subject,
-			"tenant_id", namespace,
-		)
+		slog.WarnContext(ctx, "idempotency: response body oversized, not recorded", sc.attrsWith("max_body_bytes", cfg.maxBodyBytes)...)
 		cfg.observeState(ctx, StateOversize)
 	}
 }

--- a/runtime/observability/metrics/idempotency.go
+++ b/runtime/observability/metrics/idempotency.go
@@ -22,7 +22,7 @@ import (
 //     not match any registered RouteGroup. The resolution is identical to the
 //     one used by the HTTP metrics middleware for http_requests_total{cell}.
 //
-//   - {state}: terminal idempotency decision, one of the six
+//   - {state}: terminal idempotency decision, one of the seven
 //     idempotency.RequestState constants. The value set is frozen by archtest
 //     IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01 (A1 freezes the
 //     constant set; A2 forbids inline literals or RequestState("x") conversions
@@ -35,7 +35,7 @@ import (
 // response body exceeds the buffer limit emits both StateAcquired and
 // StateOversize; the ratio oversize/acquired is the uncacheable-response rate.
 //
-// Cardinality: 6 state values × bounded cell set = tiny worst-case series
+// Cardinality: 7 state values × bounded cell set = tiny worst-case series
 // count, well within the metrics provider cap of 2000. No per-request or
 // per-key dimension is exposed (keys are SHA-256 hashed for logs only).
 //
@@ -79,7 +79,9 @@ func NewIdempotencyCollector(p kernelmetrics.Provider) (*IdempotencyCollector, e
 			"store_error = Claim-path store failure " +
 			"(Record/Release failures are logged only, not counted here); " +
 			"oversize = response too large to record; " +
-			"key_reused = same key presented with a different request body (fingerprint mismatch)). " +
+			"key_reused = same key presented with a different request body (fingerprint mismatch); " +
+			"body_read_failed = request body read failed before the claim, a transient/connection " +
+			"fault — e.g. the client aborted the upload — that maps to 503). " +
 			"acquired counts every fresh claim; oversize is a sub-event of acquired. " +
 			"cell is the owning RouteGroup cell or _runtime for framework paths.",
 		LabelNames: []string{"cell", "state"},

--- a/runtime/observability/metrics/idempotency_test.go
+++ b/runtime/observability/metrics/idempotency_test.go
@@ -60,9 +60,9 @@ func TestNewIdempotencyCollector_RegistersOneCounter(t *testing.T) {
 	}
 }
 
-// TestIdempotencyCollector_ObserveRequest_AllSixStates verifies all six
+// TestIdempotencyCollector_ObserveRequest_AllStates verifies all seven
 // RequestState constants emit the correct wire-stable state label value.
-func TestIdempotencyCollector_ObserveRequest_AllSixStates(t *testing.T) {
+func TestIdempotencyCollector_ObserveRequest_AllStates(t *testing.T) {
 	cases := []struct {
 		state idemhttp.RequestState
 		want  string
@@ -73,6 +73,7 @@ func TestIdempotencyCollector_ObserveRequest_AllSixStates(t *testing.T) {
 		{idemhttp.StateStoreError, "store_error"},
 		{idemhttp.StateOversize, "oversize"},
 		{idemhttp.StateKeyReused, "key_reused"},
+		{idemhttp.StateBodyReadFailed, "body_read_failed"},
 	}
 
 	p := newSagaSpyProvider()

--- a/tools/archtest/idempotency_metric_label_frozen_test.go
+++ b/tools/archtest/idempotency_metric_label_frozen_test.go
@@ -7,10 +7,10 @@
 // the `state` label on idempotency_requests_total{cell,state} — is frozen to
 // exactly:
 //
-//	{"acquired", "replayed", "busy", "store_error", "oversize", "key_reused"}
+//	{"acquired", "replayed", "busy", "store_error", "oversize", "key_reused", "body_read_failed"}
 //
-// These are the six terminal outcomes of one HTTP idempotency decision. The set
-// is design-time bounded: runtime drift (a 7th const, a renamed value) breaks
+// These are the seven terminal outcomes of one HTTP idempotency decision. The set
+// is design-time bounded: runtime drift (an 8th const, a renamed value) breaks
 // dashboards / alerts (replay-storm, busy-rate, key-reused) without a compile
 // error. #1460 added the counter; the `cell` label inherits the assembly
 // closed-set discipline (#1093 / observability.md §HTTP Metrics cell Label) and
@@ -22,7 +22,7 @@
 //     and compare to an independent hardcoded want-set (anti-tautology,
 //     order-insensitive). Enumeration is BY TYPE identity (not name prefix), so a
 //     const renamed off the "State" mnemonic but still typed RequestState is
-//     still counted and a 7th const still fails the count assertion.
+//     still counted and an 8th const still fails the count assertion.
 //   - A2 callsite + assignment guard (DOWNSTREAM): a `type RequestState string`
 //     does NOT stop an inline literal — observeState(ctx, "typo"),
 //     RequestState("typo"), and `var s RequestState = "typo"` all compile. The
@@ -46,8 +46,8 @@
 //     for this rule shape — there is no "looks like but isn't" gap.
 //   - UPSTREAM: MEDIUM, a GO-LANGUAGE CEILING (not a deferred TODO). Go assigns
 //     an untyped literal to a defined string type, so the type system cannot
-//     seal "only these 6 RequestState values exist" from inside the package — an
-//     in-package author can add a 7th const and the compiler does not object.
+//     seal "only these 7 RequestState values exist" from inside the package — an
+//     in-package author can add an 8th const and the compiler does not object.
 //     The A1 archtest is the external frozen-witness. Hard upstream path: enroll
 //     the RequestState value set into the metricschema golden so the freeze is
 //     byte-locked at codegen time, retiring A1 here — SHARED with saga/reconcile
@@ -66,7 +66,7 @@
 //     is the reviewed convention. The funnel guarantees: IF a value flows through
 //     RequestState it is a frozen const — it does not prevent a parallel raw-map
 //     bypass.
-//   - A1 does NOT verify the middleware actually emits one of the 6 in every code
+//   - A1 does NOT verify the middleware actually emits one of the 7 in every code
 //     path (that behavioral coverage is the middleware_test recording-observer
 //     assertions), only that the const VALUE set is frozen.
 //   - Scope is the two named packages. A RequestState const declared elsewhere is
@@ -75,7 +75,7 @@
 //
 // # Reverse self-check (non-vacuous proof)
 //
-// TestIdempotencyStateLabelValuesFrozen01_NegativeControl proves a synthetic 7th
+// TestIdempotencyStateLabelValuesFrozen01_NegativeControl proves a synthetic 8th
 // value / renamed value is detected; the *_CallsiteGuard_Fixtures RED fixtures
 // (inline literal, conversion, foreign const, var relay) prove A2 fires and the
 // GREEN fixture proves it does not over-fire.
@@ -117,6 +117,7 @@ var wantIdempotencyStateValues = []string{
 	"store_error",
 	"oversize",
 	"key_reused",
+	"body_read_failed",
 }
 
 // idempotencyRequestStateType returns the runtime/http/idempotency RequestState
@@ -187,18 +188,18 @@ func TestIdempotencyStateLabelValuesFrozen01(t *testing.T) {
 		t.Fatalf("IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01: RequestState const value set in "+
 			"runtime/http/idempotency drifted from the frozen want-set.\n%s\n"+
 			"The state label value set for idempotency_requests_total is frozen to "+
-			"{acquired,replayed,busy,store_error,oversize,key_reused}. If this change is intentional, "+
+			"{acquired,replayed,busy,store_error,oversize,key_reused,body_read_failed}. If this change is intentional, "+
 			"update ALL sync points in the same PR: (1) wantIdempotencyStateValues here, "+
 			"(2) runtime/http/idempotency/metrics.go RequestState consts + middleware.go emit sites, "+
 			"(3) dashboards/alerts, (4) .claude/rules/gocell/observability.md §HTTP Idempotency state Label.", diff)
 	}
 
-	// Reverse self-check: assert exactly 6 RequestState consts exist (same count
-	// as the want-set). A 7th const would produce an extra entry AND increment
+	// Reverse self-check: assert exactly 7 RequestState consts exist (same count
+	// as the want-set). An 8th const would produce an extra entry AND increment
 	// this count.
 	if len(gotValues) != len(wantIdempotencyStateValues) {
 		t.Errorf("IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01: found %d RequestState string consts, "+
-			"want exactly %d — a 7th const was added without updating the golden; see wantIdempotencyStateValues",
+			"want exactly %d — an 8th const was added without updating the golden; see wantIdempotencyStateValues",
 			len(gotValues), len(wantIdempotencyStateValues))
 	}
 }
@@ -431,20 +432,20 @@ func TestIdempotencyStateLabelValuesFrozen01_CallsiteGuard(t *testing.T) {
 }
 
 // TestIdempotencyStateLabelValuesFrozen01_NegativeControl proves the A1
-// comparison is non-vacuous: a synthetically drifted set (a 7th value, or a
+// comparison is non-vacuous: a synthetically drifted set (an 8th value, or a
 // renamed value) MUST produce a non-empty diff.
 func TestIdempotencyStateLabelValuesFrozen01_NegativeControl(t *testing.T) {
 	t.Parallel()
 
-	// Extra value "fingerprint_pass" — a forbidden 7th label.
+	// Extra value "fingerprint_pass" — a forbidden 8th label.
 	withExtra := append(append([]string(nil), wantIdempotencyStateValues...), "fingerprint_pass")
 	if diff := resultValuesDiff(withExtra, wantIdempotencyStateValues); diff == "" {
-		t.Fatal("IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01 negative control: a set with an extra 7th " +
+		t.Fatal("IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01 negative control: a set with an extra 8th " +
 			"value produced an empty diff — the comparison is vacuous and would not catch a real drift")
 	}
 
 	// Missing value — "key_reused" renamed to "reused".
-	withMissing := []string{"acquired", "replayed", "busy", "store_error", "oversize", "reused"}
+	withMissing := []string{"acquired", "replayed", "busy", "store_error", "oversize", "reused", "body_read_failed"}
 	if diff := resultValuesDiff(withMissing, wantIdempotencyStateValues); diff == "" {
 		t.Fatal("IDEMPOTENCY-REQUESTS-STATE-LABEL-VALUES-FROZEN-01 negative control: a set with 'key_reused' " +
 			"renamed to 'reused' produced an empty diff — the comparison is vacuous")


### PR DESCRIPTION
## Summary

修复幂等中间件两条失败路径的可观测性 + 错误语义错配：`readBodyFingerprint`（body 读失败）改为 **503 `ERR_SERVICE_UNAVAILABLE`** + 关联 slog（原 500/`ERR_INTERNAL` 且无日志、复用误导性 `msgStoreUnavailable`）；`writeRecordedBody`（replay 写失败）改 `slog.ErrorContext` + 三关联字段（原无 ctx 的 `slog.Error` 缺关联）。同时引入 `logScope` 把 9 个 slog 站点的关联三元组收口为单源。

## Why / 背景

pre-existing 缺陷（PR #2014 三 reviewer 审查发现，**非 #1610 引入**）：

- `readBodyFingerprint` 的 `io.ReadAll(r.Body)` 失败路径**无任何 slog**（其余失败路径均有关联日志）→ 生产中无法定位根因；且返回 500/`KindInternal` + 复用 `msgStoreUnavailable`（"store unavailable"）→ 把 transient/连接级 body-read 故障误报为服务端 fault。`io.ReadAll` 失败通常是客户端中断上传等 transient 情况，应 503 让客户端重试 —— **对齐在仓兄弟实现 `runtime/webhook/receiver.go`**（同样 `KindUnavailable`/`ErrServiceUnavailable`/503）。
- `writeRecordedBody` 的 replay body 写失败用无 Context 的 `slog.Error` 且缺 `idempotency_key_hash`/`subject`/`tenant_id` 关联字段。

**优雅 / AI-HARD**：关联三元组原在 4 个函数签名 + 多 slog 站点以裸 positional-string 重复（三同型字符串易错序）。引入 unexported `logScope` 值类型（命名字段、`ServeHTTP` 处一次构造），9 个 slog 站点统一经 `sc.attrs()` / `sc.attrsWith()` —— 错序变为不可表达、属性键单源。`DeriveKey`（纯函数、body-independent）上移到 `ServeHTTP` 使 body-read 失败路径也携带同一关联三元组，行为不变。

`subject` 沿用明文（OIDC `sub` 不透明化名，全仓一致约定，redaction 敏感键集刻意不含）；是否全路径假名化是受 PII 触发条件 gate 的独立决策，**见 #1586 → epic，不在本 PR**。

## Refs

- Closes #2015
- 对标在仓兄弟范式：`runtime/webhook/receiver.go:281-294`（body-read IO 失败 → 503）
- 关联决策：#1586（subject 明文 vs 全路径哈希）→ 升级为 PII-trigger-gated epic（独立追踪，不在本 PR）

## Risk / 兼容性

- **wire 破坏式变更**：body-read 失败 HTTP 状态 `500 → 503`、错误码 `ERR_INTERNAL → ERR_SERVICE_UNAVAILABLE`。依据 `.claude/rules/gocell/api-versioning.md` §兼容窗口：pre-GA 窗口（至 2026-12-31）允许**原地修改 active 版本**状态码/错误码语义 —— 本变更纯 error-path、**无 schema / generated 扇出**、全部 in-repo 调用方随 PR 原子更新。语义更正确（transient → 503 retry），不是退化。
- 无 DB migration；无新增依赖；`Middleware()` 等公开 API 签名未变（仅 unexported 内部签名调整）。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./runtime/http/idempotency/...` 本地通过（覆盖率 94.5%；新增 2 失败路径测试 RED→GREEN）+ `./runtime/http/...` `./runtime/bootstrap/...` 回归通过
- [x] `golangci-lint run ./runtime/http/idempotency/` 0 issues
- [x] `MESSAGE-CONST-LITERAL-01` archtest：新增 `msgBodyReadFailed` 为 const literal，合规（该规则唯一报错在 pre-existing `tools/codegen/cellgen/builder.go:885`，非本 PR）
