### PR TITLE
docs(spec): epic 1895 回灌 #1939 framework-owned + PR-8a serving harness 拆分 [#1895]

### DIFF
--- a/docs/plans/specs/1895-device-identity-cert-framework/spec.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/spec.md
@@ -22,7 +22,7 @@
 | Revocation/CRL | `runtime/certsigning.RevocationStore`（方法带 `CertScope` typed 位置参），PG/softca 实现 | fail-closed（跨租户/issuer 吊销/查询拒绝） |
 | 设备身份绑定 | 生产 `PrincipalDevice` 签发器（#1811）；证书即设备凭证的统一路径 | service/anonymous fail-closed |
 | 中立设备信号 | 4 个 domain 契约（deviceidentity/devicestate/devicecompliance/remotecommand），kind-qualified 落 `contracts/{http,event,command}/<domain>/.../v1`（见 FR-013） | 契约边界 |
-| 协议前端 | 框架内 EST(RFC 7030)，挂版本化 cell 路径 `/api/v{N}/deviceidentity/est/*`；XCEP/WSTEP/SCEP 留 winmdm 消费方 | 鉴权边界 fail-closed（非 setup-bootstrap） |
+| 协议前端 | 框架内 EST(RFC 7030)，经 framework serving harness 挂 framework-owned domain 路径 `/api/v{N}/deviceidentity/est/*`（`deviceidentity` 是 contract domain 段，非 cell 段；deviceidentity 框架归属无 owner cell，#1939）；XCEP/WSTEP/SCEP 留 winmdm 消费方 | 鉴权边界 fail-closed（非 setup-bootstrap） |
 
 **核心安全不变式**：私钥永不进 kernel/runtime（只持 `crypto.Signer` 句柄，SPIRE KeyManager 范式）；`Sign` 是包外铸造设备证书的唯一入口（sealed funnel）；签发与吊销共用 `CertScope` 隔离（吊销不可凭裸 serial 跨租户）；`Authorize` 与 `Sign` 分离——证书签发授权漏洞不得放大为越权签发。
 
@@ -73,7 +73,7 @@
 
 **Independent Test**：设备 POST CSR 到版本化 `/api/v1/deviceidentity/est/simpleenroll`（enrollment-credential / device-token 鉴权）→ 得证书链；`/.../simplereenroll` 用现证书 TLS-client-auth 续期；未授权 / 畸形 CSR → 4xx fail-closed；`/.../cacerts` 返回 softca 信任根。
 
-**Acceptance Scenarios**（EST 操作挂版本化 cell 路径 `/api/v1/deviceidentity/est/*`）：
+**Acceptance Scenarios**（EST 操作经 framework serving harness 挂 framework-owned domain 路径 `/api/v1/deviceidentity/est/*`，`deviceidentity` 为 domain 段非 cell 段，#1939）：
 1. **Given** 合法 enrollment-credential / device-token + 合法 PKCS#10，**When** POST `/simpleenroll`，**Then** 返回 PKCS#7 证书链，状态 200。
 2. **Given** 已有证书设备，**When** `/simplereenroll`（mTLS client-auth），**Then** 续期新证书，旧证书可吊销。
 3. **Given** 缺/错鉴权 **或** 用 setup `auth.bootstrap:true` 冒充，**When** enroll，**Then** 401/403（fail-closed，经 `Authorizer`；EST 非 setup-admin 路径，FMT-28 拒绝 bootstrap 凭据）。
@@ -127,7 +127,7 @@
 - **私钥泄漏面**：私钥永不进 kernel/runtime；adapter 只暴露 `Sign` 操作（`crypto.Signer`）。任何让原始私钥跨 `runtime/certsigning` 边界的代码 = archtest 红。
 - **reconcile 单租户系统身份**：`kernel/reconcile` 在 system identity 下运行且**清空 tenant**（#1821）；多租户证书 reconcile 必须在 scan + 命令 key + 签发请求中**自带 tenant 维度**，不能依赖 ctx tenant。
 - **续期抖动**：续期窗口加 jitter（k8s 70–90% 寿命模型）避免整队同时续期惊群。
-- **EST 落点与鉴权**：EST 操作挂所属 cell 版本化路径（`/api/v{N}/deviceidentity/est/*`），非顶级裸路径；首次 `/simpleenroll` 用专用 enrollment-credential / device-token，`/simplereenroll` 用现证书 mTLS——两条路径显式声明，不混；**不复用** setup `auth.bootstrap:true`（FMT-28 限其只在 setup/admin，EST 复用会被 fail-closed 拒绝）。
+- **EST 落点与鉴权**：EST 操作经 framework serving harness（PR-8a）挂 framework-owned domain 版本化路径（`/api/v{N}/deviceidentity/est/*`，`deviceidentity` 是 domain 段非 cell 段，框架归属无 owner cell，#1939），非顶级裸路径；首次 `/simpleenroll` 用专用 enrollment-credential / device-token，`/simplereenroll` 用现证书 mTLS——两条路径显式声明，不混；**不复用** setup `auth.bootstrap:true`（FMT-28 限其只在 setup/admin，EST 复用会被 fail-closed 拒绝）。
 - **跨租户吊销**：`Revoke`/`RevocationList` 带 `CertScope`（tenant+issuer+device）；tenant-A 不可凭裸 serial 吊销/查询 tenant-B 证书（与签发同源隔离，fail-closed）。
 - **吊销与续期竞态**：吊销正在续期的证书 → epoch CAS（fencing）保证终态一致。
 - **决策不跨 async**：证书签发授权结论不随事件携带；跨边界只传设备 identity，消费侧重决策。
@@ -154,11 +154,12 @@
 - **FR-010**: 证书签发 MUST 发 L2 事实 `deviceidentity.cert-issued.v1` / `cert-revoked.v1`（outbox），供 ZT 信任根 / 审计消费侧消费。
 
 **EST 前端（US3）**
-- **FR-011**: 系统 MUST 提供 EST(RFC 7030) 操作 `cacerts` / `simpleenroll` / `simplereenroll`（PKCS#10 in / PKCS#7 out，wiring `Authorizer`→`Signer`），挂在所属 cell 的**版本化路径**下（`/api/v{N}/deviceidentity/est/{cacerts,simpleenroll,simplereenroll}`），**不**用顶级裸 EST 路径（对齐 api-versioning「无顶级命名空间，端点挂所属 cell 版本前缀」）。
+- **FR-011**: 系统 MUST 提供 EST(RFC 7030) 操作 `cacerts` / `simpleenroll` / `simplereenroll`（PKCS#10 in / PKCS#7 out，wiring `Authorizer`→`Signer`），经 framework serving harness（PR-8a）挂在 framework-owned **domain 版本化路径**下（`/api/v{N}/deviceidentity/est/{cacerts,simpleenroll,simplereenroll}`，`deviceidentity` 是 contract domain 段、非 cell 段——框架归属契约无 owner cell，#1939），**不**用顶级裸 EST 路径（对齐 api-versioning「无顶级命名空间，端点挂版本化 domain/cell 前缀」）。
 - **FR-012**: EST 鉴权 MUST 用**专用 enrollment-credential / device-bootstrap-token** scheme（首次 enroll）+ 现证书 mTLS client-auth（reenroll）两条显式声明路径，缺鉴权 fail-closed 4xx。**不复用** setup `auth.bootstrap:true`（FMT-28 限其只在 `^/api/v\d+/[^/]+/setup/admin$`，EST 非 setup-admin 路径，复用会被 fail-closed 拒绝）；若未来确需复用 bootstrap 凭据，MUST 先出 ADR 扩展 FMT-28（本 epic 不走此路）。
 
 **中立契约（US4）**
 - **FR-013**: 系统 MUST 定义 4 个中立设备契约（domain shorthand：`deviceidentity` / `devicestate` / `devicecompliance` / `remotecommand`），按仓库契约布局单源 `{kind}/{domain-path}/{version}/` 落 **kind-qualified** 路径——`contracts/http/deviceidentity/{enroll,renew,revoke,status}/v1`、`contracts/event/deviceidentity/{cert-issued,cert-revoked}/v1`、`contracts/command/deviceidentity/rotate/v1`、`contracts/http/devicestate/v1`、`contracts/http/devicecompliance/v1`、`contracts/command/remotecommand/v1`。各含 contract.yaml（鉴权/caller/schema）+ generated code + slice 派生 registration；走契约扇出闭环。「4 个中立契约」是 domain 简写，**不是**目录真源（目录必带 kind 维度）。
+- **FR-013a（归属，#1939）**: 中立 provider-agnostic 的 **http/event** 契约（`deviceidentity`、`devicestate`、`devicecompliance`）MUST 由**框架**归属（sealed `ContractOwner`，`ownerCell: _framework`，不绑单一 consumer cell——对齐 cert-manager/SPIFFE/k8s 范式）；其 active serving 经 framework serving harness（PR-8a）落地，serving wire 前 MUST `lifecycle: draft|deprecated`（fail-closed）。`remotecommand`（command kind，带 cell 内部 dispatch 语义）MUST **cell-owned**，不可框架归属。归属机制威胁矩阵见 ADR `202606130635-1939`。
 - **FR-014**: `deviceidentity/v1` MUST 承载证书 enroll/renew/revoke + 当前证书状态；`remotecommand/v1` MUST 承接既有 `command.devicecommand.enqueue.v1` 形状（PR-9 迁移）。
 
 **迁移（US5）**

--- a/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
@@ -18,23 +18,28 @@ description: "PR decomposition & dependency graph for 1895-device-identity-cert-
 
 ---
 
-## PR 总览（11 个）
+## 前置机制（Wave 1 期间衍生，已闭）
+
+- **#1939 framework-owned contract**（ADR `202606130635-1939`，PR #1945）：中立 provider-agnostic 契约由**框架**归属（sealed `ContractOwner = Cell|Framework`，`ownerCell: _framework`），不绑单一 Cell。PR-3（#1899）落地时衍生，1895-ADR D5 预埋前向引用。**后果**：7 个设备契约均 `ownerCell: _framework` + `lifecycle: draft`，有 generated handler 但无挂载点；framework HTTP serving（`contract.yaml→RouteGroup` 派生 + serving-scan 治理 + Journey）由 #1939 ADR 显式延后到 active 化 PR → **新增 PR-8a 承载**（原 PR 分解未含）。
+
+## PR 总览（12 个）
 
 | PR | 标题 | 架构层 | US | 行数估算 | 依赖 | 关闭/关联 issue |
 |----|------|--------|----|---------|------|----------------|
 | PR-1 | 路线图修订 ADR（设备证书框架化决议） | 治理/docs | US6 | ~500 | — | 关联 #995 #1051 #1052 |
 | PR-2 | 生产级设备/super-admin 主体签发器 | runtime/auth | US1 | ~1500 | — | **关闭 #1811** |
-| PR-3 | 中立契约 (a)：deviceidentity + devicestate | contracts | US4 | ~1400 | — | 关联 #1052 |
+| PR-3 | 中立契约 (a)：deviceidentity + devicestate | contracts | US4 | ~1400 | — | 关联 #1052 #1939 |
 | PR-4 | 中立契约 (b)：devicecompliance + remotecommand | contracts | US4 | ~1400 | PR-3 | 关联 #1052 |
 | PR-5 | `runtime/certsigning` 接口 + sealed 类型 + funnel | runtime | US2 | ~1500 | PR-3 | 关联 #995 |
 | PR-6 | `adapters/softca` 内置软 CA（Signer + CRL） | adapters | US2 | ~1700 | PR-5 | 关联 #995 |
 | PR-7 | `runtime/certlifecycle` 生命周期 reconciler | runtime | US2 | ~1900 ⚠ | PR-5, PR-2 | 关联 #995 #1870 |
-| PR-8 | EST(RFC 7030) 框架注册前端 | runtime/http | US3 | ~1600 | PR-5, PR-6, PR-2 | 关联 #995 |
-| PR-9 | iotdevice 迁移 + `rotate-cert` 真契约 + 设备 enqueue RBAC | examples | US5 | ~1800 | PR-4, PR-6, PR-7 | **关闭 #654**，关联 #1870 |
-| PR-10 | composition wiring + bootstrap option + readyz + docs/ops | cellmodules | US2/3 | ~1100 | PR-6,7,8,9 | 关联 #1085 |
+| PR-8a | framework HTTP serving harness + 契约 draft→active | runtime/http | US3 | ~1500 | PR-3 | 关联 #1939 #1052 |
+| PR-8b | EST(RFC 7030) 框架注册前端 | runtime/http | US3 | ~1500 | PR-5, PR-6, PR-2, PR-8a | 关联 #995 |
+| PR-9 | iotdevice 迁移 + `rotate-cert` 真契约 + 设备 enqueue RBAC | examples | US5 | ~1800 | PR-4, PR-6, PR-7, PR-8a | **关闭 #654**，关联 #1870 |
+| PR-10 | composition wiring + bootstrap option + readyz + docs/ops | cellmodules | US2/3 | ~1100 | PR-6,7,8a,8b,9 | 关联 #1085 |
 | PR-11 | 跨层 ADR 收口 + 扇出闭环 + 治理 invariant 汇总 | 治理 | US6 | ~700 | all | 关联 #995 |
 
-**总估算 ~15,100 行 / 11 PR**，平均 ~1370 行/PR。PR-7(~1900) 接受少量超限；实测 >2200 才切（`PR-7a` lifecycle 状态机 / `PR-7b` fencing+多租户 sweep）。
+**总估算 ~16,600 行 / 12 PR**，平均 ~1380 行/PR。PR-7(~1900) 接受少量超限；实测 >2200 才切（`PR-7a` lifecycle 状态机 / `PR-7b` fencing+多租户 sweep）。PR-8 拆为 PR-8a（serving harness）/ PR-8b（EST 协议前端），不重排 9-11 编号。
 
 ---
 
@@ -49,25 +54,30 @@ graph TD
     PR5[PR-5 certsigning 接口+sealed]
     PR6[PR-6 softca 软CA]
     PR7[PR-7 certlifecycle reconciler]
-    PR8[PR-8 EST 前端]
+    PR8a[PR-8a framework serving harness]
+    PR8b[PR-8b EST 前端]
     PR9[PR-9 iotdevice 迁移]
     PR10[PR-10 wiring+bootstrap+readyz]
     PR11[PR-11 ADR收口+治理汇总]
 
     PR3 --> PR4
     PR3 --> PR5
+    PR3 --> PR8a
     PR5 --> PR6
     PR5 --> PR7
     PR2 --> PR7
-    PR5 --> PR8
-    PR6 --> PR8
-    PR2 --> PR8
+    PR5 --> PR8b
+    PR6 --> PR8b
+    PR2 --> PR8b
+    PR8a --> PR8b
     PR4 --> PR9
     PR6 --> PR9
     PR7 --> PR9
+    PR8a --> PR9
     PR6 --> PR10
     PR7 --> PR10
-    PR8 --> PR10
+    PR8a --> PR10
+    PR8b --> PR10
     PR9 --> PR10
     PR10 --> PR11
 ```
@@ -75,10 +85,12 @@ graph TD
 | Wave | 可并行 PR | 说明 |
 |------|----------|------|
 | 1 | PR-1, PR-2, PR-3 | ADR / 设备主体 / 契约 a 互不依赖 |
-| 2 | PR-4, PR-5 | 均依赖 PR-3（契约范式/deviceidentity 形状） |
+| 2 | PR-4, PR-5, PR-8a | 均依赖 PR-3（契约范式/deviceidentity 形状）；PR-8a = framework serving harness（#1939 延后项） |
 | 3 | PR-6, PR-7 | 依赖 PR-5（接口）；PR-7 另依赖 PR-2（PrincipalDevice） |
-| 4 | PR-8, PR-9 | PR-8 依赖 5/6/2；PR-9 依赖 4/6/7 |
+| 4 | PR-8b, PR-9 | PR-8b 依赖 5/6/2/8a；PR-9 依赖 4/6/7/8a |
 | 5 | PR-10, PR-11 | wiring 后收口 |
+
+> 注：上表为**设计时 DAG**。Wave 1（PR-1/2/3）已全部 CLOSED，实时滚动 Wave（机器单源 = GitHub Project #3 Wave 字段）：W1 PR-5/PR-4/PR-8a · W2 PR-6/PR-7 · W3 PR-8b/PR-9 · W4 PR-10 · 超窗 PR-11。
 
 ---
 
@@ -110,7 +122,7 @@ graph TD
 - [ ] T2.4 enforcement：`DEVICE-PRINCIPAL-MINT-CALLER-01`（Medium，签发器为唯一 device 主体来源）+ 反向自检；godoc §invariants。
 - [ ] T2.5 概念隔离测试：service ≠ device、callerCellID ≠ device subject。
 
-> **关闭 #1811**。证书 mTLS 派生 PrincipalDevice 为统一终态（PR-8 `/simplereenroll` client-cert 已用）；本 PR 提供 device-token 路径，二者并存。
+> **关闭 #1811**。证书 mTLS 派生 PrincipalDevice 为统一终态（PR-8b `/simplereenroll` client-cert 已用）；本 PR 提供 device-token 路径，二者并存。实际交付额外做了 **sealed PrincipalDevice 构造 + seal-aware test helper + `principal_kind` fail-closed**——下游（PR-7/PR-8b/PR-9）铸造/测试 PrincipalDevice 必须走 sealed funnel，不裸构造。
 
 ---
 
@@ -126,6 +138,8 @@ graph TD
 - [ ] T3.4 `contracts/http/devicestate/v1/`（online/offline/last-seen 查询）。
 - [ ] T3.5 codegen（`gocell generate`）→ generated handler/client/types；slice.yaml `contractUsages` 派生 registration。
 - [ ] T3.6 contract-fanout implementation matrix（contract/generated/cell-slice/tests/docs）。
+
+> **实际交付（#1899 CLOSED，PR #2010）**：(1) 全部契约经 **#1939 framework-owned**（`ownerCell: _framework` + `lifecycle: draft`，无 cell 挂载点；serving 留 PR-8a）；(2) **status 契约收窄为 deviceId-only**——禁裸 serial / 半指定 issuer 查询，specific-cert lookup 必须经 serving 层 typed `CertScope`（isolation invariant，对齐 PR-5 CertScope）。
 
 ### PR-4 中立契约 (b)：devicecompliance + remotecommand ~1400 行
 
@@ -171,36 +185,53 @@ graph TD
 - [ ] T7.1 [TDD] `reconciler_test.go`：requested→issued→active→near-expiry→renewing→{rotated|revoked|expired} 转换；签名失败不损坏既有证书；fail-closed deny 不签发。
 - [ ] T7.2 [TDD] `reconciler_loop_test.go`：resync-all sweep 有界扫描；多副本 `LeaseToken.Epoch` fencing；队列 active-uniqueness 至多一次有效签发。
 - [ ] T7.3 `reconciler.go`：`reconcile.Reconciler` 实现；`clock.Clock` 位置参 + `MustHaveClock`；jitter 续期（k8s 70-90% 模型）；Authorize→Sign→persist→emit `cert-issued` L2。
-- [ ] T7.4 `repository.go`：`DeviceCertRepository`（scan near-expiry by cutoff / persist epoch+cert / mark）接口。
+- [ ] T7.4 `repository.go`：`DeviceCertRepository`（scan near-expiry by cutoff / persist epoch+cert / mark）接口；specific-cert 查询经 typed `CertScope`（PR-5），**非裸 serial**（status 契约已收窄 deviceId-only，#1899）。
 - [ ] T7.5 **多租户维度**：scan + 命令 key + 签发请求自带 tenant（system identity 清空 tenant，#1821 caveat）。
 - [ ] T7.6 enforcement：复用 `RECONCILE-FENCED-WRITE-FUNNEL-01`（Hard）；新增 `CERTLIFECYCLE-SIGN-VIA-FUNNEL-01`（Medium，生命周期只经 certsigning.Signer 签发）+ 反向自检；`doc.go`。
+
+> 注记：铸造/测试 PrincipalDevice 走 PR-2 的 **sealed funnel + seal-aware test helper**（#1898 实际交付），不裸构造。
 
 ---
 
 ## Phase 4：协议前端 + 消费方迁移（US3/US5）
 
-### PR-8 EST(RFC 7030) 框架注册前端 ~1600 行
+### PR-8a framework HTTP serving harness + 契约 draft→active ~1500 行
 
-**Goal**：框架级 EST 端点，挂**版本化 cell 路径** `/api/v{N}/deviceidentity/est/*`，wiring Authorizer→Signer。依赖 PR-5/6/2。
+**Goal**：落地 #1939 ADR 延后的 framework HTTP serving 基建——从 framework-owned `contract.yaml` 派生 RouteGroup + bootstrap 挂载，把悬空的 deviceidentity/devicestate draft 契约转为可 serve 的 active 框架契约。PR-8b/9/10 硬前置。依赖 PR-3。
 
-- [ ] T8.1 [TDD] handler 测试：`/simpleenroll` 200 PKCS#7、畸形/越权 CSR 4xx、缺鉴权 / setup-bootstrap 冒充 401/403、`/cacerts` 返回信任根。
-- [ ] T8.2 `runtime/http/est/handler.go`：`cacerts`·`simpleenroll`·`simplereenroll`（PKCS#10 in / PKCS#7 out），挂 `/api/v{N}/deviceidentity/est/*`（**非顶级裸路径**，对齐 api-versioning「端点挂所属 cell 版本前缀」）。
-- [ ] T8.3 鉴权两路径：首次=**专用 enrollment-credential / device-token**（PR-2 设备主体，**非** setup `auth.bootstrap:true`），续期=现证书 mTLS client-auth（`runtime/http/middleware/mtls` + PeerIdentity）。
-- [ ] T8.4 EST `auth.Route` 声明：显式 enrollment-credential / mTLS scheme；**不**声明 `auth.bootstrap:true`（FMT-28 限其只在 `^/api/v\d+/[^/]+/setup/admin$`，EST 非该路径，复用 fail-closed）。
-- [ ] T8.5 enforcement：`EST-ENROLL-AUTH-BOUNDARY-01`（Medium，enroll/reenroll 鉴权路径显式声明 + 禁 setup-bootstrap 凭据复用，缺则 fail-closed）+ 反向自检。
+- [ ] T8a.1 [TDD] `contract.yaml → RouteGroup` 派生测试；未 serve 的 active 框架契约 fail-closed（red case，anti-vacuity）；缺 Journey 引用 red case。
+- [ ] T8a.2 `runtime/internal/contractbuild`：新增「从 framework-owned `contract.yaml` 派生 `ContractSpec`」入口（区别于现字面量 `NewFrameworkHTTP`；id/method/path/schema 取自解析的 contract，与 codegen 单源）。
+- [ ] T8a.3 `runtime/bootstrap`：framework RouteGroup 挂载 framework-owned http 契约（listener + auth plan **显式声明**，in-process 不 bypass listener auth）。
+- [ ] T8a.4 扩展 `FRAMEWORK-OWNED-CONTRACT-SCOPED-01`（#1939 D3）为 **serving-scan**：放行已 serve 的 active 框架契约（DEAD-CONTRACT-01 的框架版）+ synthetic red case。
+- [ ] T8a.5 首批只读契约 `http.devicestate.v1`（+ `http.deviceidentity.status.v1`，视 cert 持久化就绪）`draft→active` + framework handler；写路径（enroll/renew/revoke/rotate）的 active 化留 PR-8b/PR-9 经本 harness 落地。
+- [ ] T8a.6 Journey coverage：转 active 的框架契约补 `JOURNEY-CONTRACT-EXISTENCE-01` 引用（如 `J-deviceidentity`）。
+
+> **enforcement**：`FRAMEWORK-OWNED-CONTRACT-SCOPED-01` serving-scan 扩展（Medium）+ 反向 red case；RouteGroup 派生口与 `contract.yaml` 单源（复用 codegen funnel）。同 PR 闭环。
+
+### PR-8b EST(RFC 7030) 框架注册前端 ~1500 行
+
+**Goal**：框架级 EST 端点，经 PR-8a framework serving harness 挂 `/api/v{N}/deviceidentity/est/*`，wiring Authorizer→Signer。依赖 PR-5/6/2/8a。
+
+- [ ] T8b.1 [TDD] handler 测试：`/simpleenroll` 200 PKCS#7、畸形/越权 CSR 4xx、缺鉴权 / setup-bootstrap 冒充 401/403、`/cacerts` 返回信任根。
+- [ ] T8b.2 `runtime/http/est/handler.go`：`cacerts`·`simpleenroll`·`simplereenroll`（PKCS#10 in / PKCS#7 out），经 PR-8a framework RouteGroup 挂 `/api/v{N}/deviceidentity/est/*`（**framework serving，非「所属 cell 前缀」**——deviceidentity 框架归属无 owner cell；path 段 deviceidentity 是 domain 非 cell）。
+- [ ] T8b.3 鉴权两路径：首次=**专用 enrollment-credential / device-token**（PR-2 设备主体；**PrincipalDevice 现为 sealed，经签发器铸造**，**非** setup `auth.bootstrap:true`），续期=现证书 mTLS client-auth（`runtime/http/middleware/mtls` + PeerIdentity）。
+- [ ] T8b.4 EST `auth.Route` 声明：显式 enrollment-credential / mTLS scheme；**不**声明 `auth.bootstrap:true`（FMT-28 限其只在 `^/api/v\d+/[^/]+/setup/admin$`，EST 非该路径，复用 fail-closed）。
+- [ ] T8b.5 写路径 deviceidentity 契约（enroll/renew）经 PR-8a harness `draft→active`（serving-scan 放行）。
+- [ ] T8b.6 enforcement：`EST-ENROLL-AUTH-BOUNDARY-01`（Medium，enroll/reenroll 鉴权路径显式声明 + 禁 setup-bootstrap 凭据复用，缺则 fail-closed）+ 反向自检。
 
 ### PR-9 iotdevice 迁移 + `rotate-cert` 真契约 + 设备 enqueue RBAC ~1800 行
 
-**Goal**：示例端到端切到框架证书底座，证明接缝。依赖 PR-4/6/7。
+**Goal**：示例端到端切到框架证书底座，证明接缝。依赖 PR-4/6/7/8a。
 
 - [ ] T9.1 [TDD] iotdevice 集成：注册→softca 签真实初始证书→近期过期→certlifecycle 续期→新证书生效。
 - [ ] T9.2 `deviceregister` 经 `certsigning.Signer` 签真实初始证书（替代仅 stamp `cert_expires_at`）。
 - [ ] T9.3 `devicecertrenewal` slice 退役 / 重接 `certlifecycle`（删字符串 `rotate-cert`，无 shim）。
-- [ ] T9.4 `command.deviceidentity.rotate.v1` 真契约取代 bare-string `CommandType="rotate-cert"`；fanout matrix。
+- [ ] T9.4 `command.deviceidentity.rotate.v1` 真契约取代 bare-string `CommandType="rotate-cert"`；fanout matrix。（command kind 带 cell 内部语义，仍 **cell-owned** 正常 serve；非 framework-owned。）
 - [ ] T9.5 设备粒度 enqueue 授权（#654）：设备不可操作他设备命令（`auth.RequirePermission` + RowScope=device，无 role-literal）。
 - [ ] T9.6 迁移：devices 行证书列 + migration（cert material 持久化）；删除退役列（只增不改例外须 ADR 注记）。
+- [ ] T9.7 cert 状态/查询走 typed `CertScope`（PR-5），不依赖裸 serial（status 契约已收窄 deviceId-only，#1899）；消费 PR-2 sealed PrincipalDevice（device-token 路径走 sealed funnel）。
 
-> **关闭 #654**；**关联 #1870**（cert terminal-feedback——续期释放主路径基础留 PR-7 时间窗 + 本 PR 真契约 terminal 态）。
+> **关闭 #654**；**关联 #1870**（cert terminal-feedback——续期释放主路径基础留 PR-7 时间窗 + 本 PR 真契约 terminal 态）。另：#1943（device 幂等 middleware bypass）forward-looking 至本 PR（device 写端点落地时一并处理）。
 
 ---
 
@@ -232,7 +263,7 @@ graph TD
 
 ### 关键路径
 
-`PR-3 → PR-5 → PR-6/7 → PR-8/9 → PR-10 → PR-11`（约 5 wave）。PR-1（ADR）+ PR-2（设备主体）可与 PR-3 并行起跑。
+`PR-3 → PR-5 → PR-6/7 → PR-8b/9 → PR-10 → PR-11`（约 5 wave）；PR-8a（serving harness）依赖 PR-3、阻塞 PR-8b/9/10，可在 Wave 2 与 PR-5 并行起跑。PR-1（ADR）+ PR-2（设备主体）可与 PR-3 并行起跑。
 
 ### Within Each PR
 
@@ -249,5 +280,5 @@ graph TD
 ## Notes
 
 - 行数估算含测试；超限以实测 `git diff --shortstat origin/develop` 为准。
-- [Story] 映射：PR-1/11→US6，PR-2→US1，PR-3/4→US4，PR-5/6/7→US2，PR-8→US3，PR-9→US5，PR-10→US2/3。
+- [Story] 映射：PR-1/11→US6，PR-2→US1，PR-3/4→US4，PR-5/6/7→US2，PR-8a/8b→US3，PR-9→US5，PR-10→US2/3。
 - 每 PR 经 ship→review→fix→check 流程；契约 PR 出 implementation matrix。

--- a/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
+++ b/docs/plans/specs/1895-device-identity-cert-framework/tasks.md
@@ -82,7 +82,7 @@ graph TD
     PR10 --> PR11
 ```
 
-| Wave | 可并行 PR | 说明 |
+| Wave（设计时，从 PR-1 起算） | 可并行 PR | 说明 |
 |------|----------|------|
 | 1 | PR-1, PR-2, PR-3 | ADR / 设备主体 / 契约 a 互不依赖 |
 | 2 | PR-4, PR-5, PR-8a | 均依赖 PR-3（契约范式/deviceidentity 形状）；PR-8a = framework serving harness（#1939 延后项） |
@@ -90,7 +90,7 @@ graph TD
 | 4 | PR-8b, PR-9 | PR-8b 依赖 5/6/2/8a；PR-9 依赖 4/6/7/8a |
 | 5 | PR-10, PR-11 | wiring 后收口 |
 
-> 注：上表为**设计时 DAG**。Wave 1（PR-1/2/3）已全部 CLOSED，实时滚动 Wave（机器单源 = GitHub Project #3 Wave 字段）：W1 PR-5/PR-4/PR-8a · W2 PR-6/PR-7 · W3 PR-8b/PR-9 · W4 PR-10 · 超窗 PR-11。
+> 注：上表为**设计时 DAG 绝对 wave**（从 PR-1 起算）。Wave 1（PR-1/2/3）已全部 CLOSED；**实时滚动 Wave**（机器单源 = GitHub Project #3 Wave 字段，仅排 OPEN 子任务，设计 Wave 2-5 → 滚动 W1-W4）：W1 PR-5/PR-4/PR-8a · W2 PR-6/PR-7 · W3 PR-8b/PR-9 · W4 PR-10 · **超窗(>W4)** PR-11（依赖 all，滚动后落 W5 超 cap，不入 Project Wave 字段）。
 
 ---
 
@@ -239,7 +239,7 @@ graph TD
 
 ### PR-10 composition wiring + bootstrap option + readyz + docs/ops ~1100 行
 
-**Goal**：把证书底座装配进 composition root，对外暴露 option + readyz + 运维文档。依赖 PR-6/7/8/9。
+**Goal**：把证书底座装配进 composition root，对外暴露 option + readyz + 运维文档。依赖 PR-6/7/8a/8b/9。
 
 - [ ] T10.1 [TDD] bootstrap option fail-fast 测试（缺 Signer fail-fast，不静默 noop）。
 - [ ] T10.2 `bootstrap.WithCertSigner` / `WithCertLifecycle` option（强依赖 fail-fast）；cellmodules 绑定 softca↔certsigning。
@@ -263,7 +263,7 @@ graph TD
 
 ### 关键路径
 
-`PR-3 → PR-5 → PR-6/7 → PR-8b/9 → PR-10 → PR-11`（约 5 wave）；PR-8a（serving harness）依赖 PR-3、阻塞 PR-8b/9/10，可在 Wave 2 与 PR-5 并行起跑。PR-1（ADR）+ PR-2（设备主体）可与 PR-3 并行起跑。
+`PR-3 → {PR-5 · PR-8a 并行} → PR-6/7 · PR-8b/9 → PR-10 → PR-11`（约 5 wave）。PR-8a（serving harness）依赖 PR-3、阻塞 PR-8b/9/10——是关键路径节点（非旁路），可在 Wave 2 与 PR-5 并行起跑。PR-1（ADR）+ PR-2（设备主体）可与 PR-3 并行起跑。
 
 ### Within Each PR
 


### PR DESCRIPTION
## 背景

Wave 1（#1897/#1898/#1899）复盘：#1899 落地时衍生了**计划外机制 #1939**（framework-owned contract，sealed `ContractOwner = Cell|Framework`，`ownerCell: _framework`）。后果——7 个设备契约均 `_framework` + `lifecycle: draft`，有 generated handler 但**无挂载点**；framework HTTP serving（`contract.yaml→RouteGroup` 派生 + serving-scan 治理 + Journey）被 #1939 ADR 显式**延后到 active 化 PR**，而原 epic 1895 PR 分解**无任何 PR 承载**这块基建。

本 PR 把该复盘结论回灌到 epic 1895 的实施规格 `tasks.md`（**仅 doc 改动**）。

## 改动（docs-only）

`docs/plans/specs/1895-device-identity-cert-framework/tasks.md`：

- 登记 **#1939** 前置机制节点
- 拆 PR-8 → **PR-8a**（framework HTTP serving harness + 契约 draft→active）/ **PR-8b**（EST 协议前端），不重排 9-11 编号
- 更新 PR 总览表（11→12 PR）/ mermaid DAG / wave 表（设计时 DAG + 实时滚动）
- 回灌实际交付注记：
  - PR-3（#1899）：framework-owned + **status 收窄 deviceId-only**（禁裸 serial 跨 scope 查询）
  - PR-2（#1898）：**sealed PrincipalDevice** 构造 + seal-aware test helper + `principal_kind` fail-closed
  - PR-7/PR-9：specific-cert 查询经 typed `CertScope`，不依赖裸 serial

## GitHub 侧（已直接经 issues 流程落地，非本 PR）

新建 **#2037**（PR-8a）、改名 #1904→PR-8b、回灌 #1901/#1903/#1905/#1906/#1943 body、Project #3 Wave 字段滚动、epic #1895 body + 评论。

## Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| spec 回灌（计划文档） | — | — | — | — | tasks.md |

> 纯计划文档同步，无代码 / 契约 / 治理改动。机制源 ADR `docs/architecture/202606130635-1939-adr-framework-owned-contract.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)