### PR TITLE
fix(contractgen): 刷新 policy types.ts golden — 补 #1977 eq_attr 漂移 [#2073]

### DIFF
--- a/generated-ts/contracts/http/policy/create/v1/types.ts
+++ b/generated-ts/contracts/http/policy/create/v1/types.ts
@@ -21,7 +21,9 @@ export interface RequestRulesItemConditionsItem {
   source: string;
   key: string;
   operator: string;
-  values: string[];
+  values?: string[];
+  rhsSource?: string;
+  rhsKey?: string;
 }
 
 export interface RequestRulesItemObligations {
@@ -56,7 +58,9 @@ export interface ResponseDataRulesItemConditionsItem {
   source: string;
   key: string;
   operator: string;
-  values: string[];
+  values?: string[];
+  rhsSource?: string;
+  rhsKey?: string;
 }
 
 export interface ResponseDataRulesItemObligations {

--- a/generated-ts/contracts/http/policy/get/v1/types.ts
+++ b/generated-ts/contracts/http/policy/get/v1/types.ts
@@ -33,7 +33,9 @@ export interface ResponseDataRulesItemConditionsItem {
   source: string;
   key: string;
   operator: string;
-  values: string[];
+  values?: string[];
+  rhsSource?: string;
+  rhsKey?: string;
 }
 
 export interface ResponseDataRulesItemObligations {

--- a/generated-ts/contracts/http/policy/list/v1/types.ts
+++ b/generated-ts/contracts/http/policy/list/v1/types.ts
@@ -36,7 +36,9 @@ export interface ResponseDataItemRulesItemConditionsItem {
   source: string;
   key: string;
   operator: string;
-  values: string[];
+  values?: string[];
+  rhsSource?: string;
+  rhsKey?: string;
 }
 
 export interface ResponseDataItemRulesItemObligations {

--- a/generated-ts/contracts/http/policy/update/v1/types.ts
+++ b/generated-ts/contracts/http/policy/update/v1/types.ts
@@ -23,7 +23,9 @@ export interface RequestRulesItemConditionsItem {
   source: string;
   key: string;
   operator: string;
-  values: string[];
+  values?: string[];
+  rhsSource?: string;
+  rhsKey?: string;
 }
 
 export interface RequestRulesItemObligations {
@@ -58,7 +60,9 @@ export interface ResponseDataRulesItemConditionsItem {
   source: string;
   key: string;
   operator: string;
-  values: string[];
+  values?: string[];
+  rhsSource?: string;
+  rhsKey?: string;
 }
 
 export interface ResponseDataRulesItemObligations {


### PR DESCRIPTION
## Summary

干净 develop 上 `gocell generate contract --all` 重生成的 4 个 policy TypeScript 契约类型与已提交 golden 不一致，纯机械刷新使 `verify generated` codegen bucket 转绿。

## Why / 背景

`origin/develop` 自身存在 generated-ts golden 漂移：4 个 policy `types.ts` 的 condition 类型缺 `eq_attr` 跨属性字段（`values` 应转 optional、新增 `rhsSource?`/`rhsKey?`）。因 PR CI 测 base 合并 ref，**#2004 之后所有 PR 的 codegen check 都红**、与 PR 自身改动无关 —— 整条 PR 合入流水线被阻塞（发现于 #2058 saga PR，未触碰任何 contracts/）。

**根因（三维）**：
- **代码层**：develop 已提交的 4 个 policy `types.ts` 与当前 `rule.schema.json` 不同步（stale golden）。
- **架构层**：#1977（`81258d2d5`）给 `contracts/http/policy/shared/v1/rule.schema.json` 加了 `eq_attr` 跨属性条件（`values` 转 optional + `rhsSource`/`rhsKey`）；#2004（`fbb1ec091`）的 TS emitter 落地时未对该已变更 schema 全量重生成 → 派生源与 golden 漂移。
- **历史层**：`81258d2d5`(#1977) → `fbb1ec091`(#2004)，emitter 晚于 schema 变更但其分支 golden 基于变更前 schema 生成。

**CI 未拦截的取证（issue 彻底方向 #2）**：codegen bucket（`_build-lint.yml` / `governance.yml`）的 `verify generated` 行为正确——它**现在就是红的**，证明守卫有效。#2004 能带漂移合入的根因是 GitHub PR merge-ref CI 不在 base 推进后自动重跑：#2004 分支上次 CI 跑时 develop 尚未含 #1977 的 schema（或 TS emitter 由 #2004 自身引入、其历史 run 未覆盖 merge 后 schema），合并后未重测即落地。系统性预防（branch protection「require branches up to date」/ merge queue）是仓库管理面配置、非代码改动，不纳入本 golden 刷新 PR。

## Refs

Closes #2073
无新对标框架（纯 golden 刷新，无设计决策）；codegen 验证工具沿用既有 `ref: kubernetes/kubernetes hack/lib/verify-generated.sh` 形态（`hack/verify-codegen-contract.sh`），本 PR 不改动该工具。

## Risk / 兼容性

无逻辑 / wire 契约变更。改动仅 4 个 `generated-ts/**/types.ts`（机器派生产物，schema 早已含 `eq_attr` 字段），TS 类型现与 `rule.schema.json` 对齐。无 migration、无消费方需同步。

## Test plan

- [x] `go run ./cmd/gocell verify generated` — 0 drift（499 files verified），由红转绿
- [x] `bash hack/verify-codegen-contract.sh`（CI sandbox 模式，HEAD）— `Generated contract DTOs OK.`
- [x] 重生成确定性确认：`generate contract --all` 仅改这 4 个文件，再次运行 byte-identical
- [N/A] `go build` / `go test` / `golangci-lint` — 本 PR 零 Go 文件改动（仅 TypeScript golden），故不适用
