### PR TITLE
fix(ci): ssobff go-redis workspace drift + PGJournal.MarkTerminal complexity [#2096 #2097]

### DIFF
--- a/adapters/postgres/saga/journal_store.go
+++ b/adapters/postgres/saga/journal_store.go
@@ -558,27 +558,8 @@ func (s *PGJournal) MarkTerminal(ctx context.Context, instanceID, leaseID idutil
 		return false, err
 	}
 
-	if _, err := tx.Exec(ctx, updateInstanceTerminal,
-		statusToInt16(finalStatus), now, string(instanceID), string(leaseID),
-	); err != nil {
-		return false, errcode.Wrap(errcode.KindInternal, kerrors.ErrAdapterPGQuery,
-			"saga journal: MarkTerminal update failed", err)
-	}
-
-	// Serialize saga_events INSERTs so global_seq order == commit order (F1).
-	// See sagaEventsGlobalAppendLockKey for the full rationale.
-	if _, err := tx.Exec(ctx, advisoryLockSQL, sagaEventsGlobalAppendLockKey); err != nil {
-		return false, errcode.Wrap(errcode.KindInternal, kerrors.ErrAdapterPGQuery,
-			"saga journal: MarkTerminal advisory lock", err)
-	}
-
-	version := row.currentVersion + 1
-	if _, err := tx.Exec(ctx, insertEvent,
-		string(instanceID), version, kindToInt16(termKind),
-		nullableStepName(""), nil, now,
-	); err != nil {
-		return false, errcode.Wrap(errcode.KindInternal, kerrors.ErrAdapterPGQuery,
-			"saga journal: MarkTerminal insert event failed", err)
+	if err := markTerminalWrites(ctx, tx, instanceID, leaseID, finalStatus, termKind, row.currentVersion+1, now); err != nil {
+		return false, err
 	}
 
 	if owned {
@@ -589,6 +570,39 @@ func (s *PGJournal) MarkTerminal(ctx context.Context, instanceID, leaseID idutil
 		committed = true
 	}
 	return true, nil
+}
+
+// markTerminalWrites performs the terminal projection update plus the
+// advisory-locked terminal event append inside the caller's tx. Split out of
+// MarkTerminal to keep that method under the cognitive-complexity budget; the
+// commit-order protocol (F1, #1630) is unchanged — sagaEventsGlobalAppendLockKey
+// is still acquired immediately before the insertEvent INSERT.
+func markTerminalWrites(
+	ctx context.Context, tx pgx.Tx, instanceID, leaseID idutil.SafeID,
+	finalStatus saga.Status, termKind journal.EventKind, version int64, now time.Time,
+) error {
+	if _, err := tx.Exec(ctx, updateInstanceTerminal,
+		statusToInt16(finalStatus), now, string(instanceID), string(leaseID),
+	); err != nil {
+		return errcode.Wrap(errcode.KindInternal, kerrors.ErrAdapterPGQuery,
+			"saga journal: MarkTerminal update failed", err)
+	}
+
+	// Serialize saga_events INSERTs so global_seq order == commit order (F1).
+	// See sagaEventsGlobalAppendLockKey for the full rationale.
+	if _, err := tx.Exec(ctx, advisoryLockSQL, sagaEventsGlobalAppendLockKey); err != nil {
+		return errcode.Wrap(errcode.KindInternal, kerrors.ErrAdapterPGQuery,
+			"saga journal: MarkTerminal advisory lock", err)
+	}
+
+	if _, err := tx.Exec(ctx, insertEvent,
+		string(instanceID), version, kindToInt16(termKind),
+		nullableStepName(""), nil, now,
+	); err != nil {
+		return errcode.Wrap(errcode.KindInternal, kerrors.ErrAdapterPGQuery,
+			"saga journal: MarkTerminal insert event failed", err)
+	}
+	return nil
 }
 
 // RepoReady probes the saga_instances relation so schema/migration drift

--- a/examples/ssobff/go.mod
+++ b/examples/ssobff/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ghbvf/gocell/adapters/rabbitmq v0.0.0 // indirect
 	github.com/ghbvf/gocell/adapters/redis v0.0.0 // indirect
 	github.com/rabbitmq/amqp091-go v1.11.0 // indirect
-	github.com/redis/go-redis/v9 v9.20.0 // indirect
+	github.com/redis/go-redis/v9 v9.20.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/examples/ssobff/go.sum
+++ b/examples/ssobff/go.sum
@@ -121,8 +121,8 @@ github.com/pressly/goose/v3 v3.27.1 h1:6uEvcprBybDmW4hcz3gYujhARhye+GoWKhEWyzD5s
 github.com/pressly/goose/v3 v3.27.1/go.mod h1:maruOxsPnIG2yHHyo8UqKWXYKFcH7Q76csUV7+7KYoM=
 github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRbEY8O8=
 github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
-github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
-github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
+github.com/redis/go-redis/v9 v9.20.1 h1:sfCU6A8P3dXbKyWes02uxA2baehGux9dZHfEKtsTB1w=
+github.com/redis/go-redis/v9 v9.20.1/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=


### PR DESCRIPTION
## Summary

修两处 develop CI 红：① examples/ssobff 在 go-redis bump (#2085) 后未随根模块同步到 v9.20.1，触发 workspace drift；② PGJournal.MarkTerminal 认知复杂度 16 (>15)，触发 satellite 模块 lint（./adapters/postgres）。两者均为独立的 CI-unblock 小修，合并为单 PR 一次评审/CI 周期闭环。

## Why / 背景

- **#2096**：`go-redis` bump 只升了根模块到 `v9.20.1`，`examples/ssobff` 仍 pin `v9.20.0`，`go work sync` 后 scaffold + workspace verify 桶报 `go: updates to go.mod needed`（GOWORK=off 加载失败）。
- **#2097**：PG saga-journal 落地后 `MarkTerminal` gocognit=16，`full-ci / build-test` 的 workspace satellite linter 在 `./adapters/postgres` 红（root golangci-lint 本身通过）。

## Refs

- Closes #2096
- Closes #2097

## Risk / 兼容性

无。#2096 纯依赖版本对齐（v9.20.0→v9.20.1，go.mod hash 不变，仅 indirect）；#2097 纯重构，语义不变——markTerminalWrites 仍在 insertEvent 前紧接获取 `sagaEventsGlobalAppendLockKey`（F1 commit-order 协议 #1630 不变），stale lease / missing instance 仍返回 `(false, nil)`。无 wire / migration / 契约影响。

## Test plan

- [x] `go build ./...` 本地通过（root + adapters/postgres satellite）
- [x] `go test ./adapters/postgres/saga/...` 本地通过；`go vet -tags=integration ./saga/...` 编译通过
- [x] `golangci-lint run ./...` 0 issues（root + adapters/postgres 均 0）
- [x] `bash hack/verify-unconditional-skip.sh` PASS（含 ssobff）
- [x] `bash hack/verify-workspace.sh` all checks passed
