### PR TITLE
test(eventing): durable iotdevice command-relay testcontainers 全链路集成测试 [#1778]

### DIFF
--- a/examples/iotdevice/command_dedup_durable_integration_test.go
+++ b/examples/iotdevice/command_dedup_durable_integration_test.go
@@ -1,0 +1,294 @@
+//go:build integration
+
+package main
+
+// command_dedup_durable_integration_test.go — the durable, real-Postgres sibling
+// of command_dedup_e2e_test.go (#1778).
+//
+// The demo E2E (TestCommandRelay_DedupOnEventRedelivery) drives the reactive
+// producer→outbox→relay→Claimer loop over an in-memory outboxtest.FakeStore,
+// which ignores the transaction context and fakes the poll/lease. That leaves
+// three properties of the DURABLE production wiring unverified end-to-end:
+// transaction atomicity (a rolled-back emit must leave NO row), real PG relay
+// polling + Claimer dedup, and real PG MarkDead fail-closed. This test anchors
+// all three against a testcontainers Postgres by exercising the SAME production
+// assembly the binary uses — buildCommandRelaySubsystem(clk, eb, reg, pool) with
+// a PG-backed pool — rather than re-wiring a replica.
+//
+// Both this file and command_dedup_e2e_test.go are package main, so under
+// `-tags=integration` they compile together and this file reuses the demo's
+// dedupEnqueueHandler / sourceEvent helpers verbatim (zero duplication).
+//
+// Single-pod note: buildCommandRelaySubsystem's durable branch refuses an
+// in-memory command Claimer unless GOCELL_IOTDEVICE_DURABLE_SINGLE_POD
+// acknowledges single-pod deployment — the iotdevice durable form IS single-pod
+// (in-memory Claimer; a PG outbox coordinates row leases across pods, but the
+// command_id Claimer does not). Cross-pod command dedup is a different
+// (replaydeps / Redis) wiring and is out of scope here.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	devicebootstrap "github.com/ghbvf/gocell/examples/iotdevice/cells/devicecell/slices/devicebootstrap"
+	enqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
+	"github.com/ghbvf/gocell/kernel/clock"
+	kout "github.com/ghbvf/gocell/kernel/outbox"
+	"github.com/ghbvf/gocell/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/pkg/migration"
+	"github.com/ghbvf/gocell/runtime/command"
+	outboxruntime "github.com/ghbvf/gocell/runtime/outbox"
+	"github.com/ghbvf/gocell/tests/testutil"
+)
+
+// durableTestTenant is a canonical tenant UUID. The durable path is driven
+// tenant-scoped (CLAUDE.md MDM-default: don't assume an implicit single tenant
+// via context.Background()), so command dedup keys are tenant-scoped and the
+// test additionally witnesses tenant propagation through the durable PG path.
+const durableTestTenant = "11111111-1111-1111-1111-111111111111"
+
+// TestCommandRelay_Durable_PG verifies the durable command-relay subsystem
+// against real Postgres. One PG testcontainer is shared across the three
+// sub-tests; each TRUNCATEs outbox_entries and builds a fresh subsystem +
+// relay, and startDurableRelay stops the relay (waiting for its loop to exit)
+// before the next sub-test runs so no lingering poller consumes the next
+// sub-test's rows. Sub-tests are sequential (no t.Parallel — they share the
+// pool and the single-pod env).
+func TestCommandRelay_Durable_PG(t *testing.T) {
+	testutil.RequireDocker(t)
+	t.Setenv(envDurableSinglePod, "true")
+
+	clk := clock.Real()
+	pool, terminate := setupDurableOutboxPG(t)
+	t.Cleanup(terminate)
+
+	// ① Core dedup happy-path on real PG, tenant-scoped.
+	t.Run("DedupOnEventRedelivery", func(t *testing.T) {
+		truncateOutbox(t, pool)
+		reg := command.NewRegistry()
+		h := &dedupEnqueueHandler{}
+		require.NoError(t, enqueue.Register(reg, h))
+
+		crs, err := buildCommandRelaySubsystem(clk, &kout.DiscardPublisher{}, reg, pool)
+		require.NoError(t, err)
+		svc, err := devicebootstrap.NewService(clk,
+			devicebootstrap.WithEmitter(crs.bootstrapEmitter),
+			devicebootstrap.WithTxManager(crs.bootstrapTxManager))
+		require.NoError(t, err)
+
+		tenantCtx := ctxkeys.WithTenantID(context.Background(), durableTestTenant)
+		src := sourceEvent(t, "d1", "evt-durable-redelivered")
+		// At-least-once redelivery: handle the SAME source event twice → two
+		// command entries carrying the SAME tenant-scoped command_id (distinct
+		// store ids), written into PG outbox inside a real device-bootstrap tx.
+		require.Equal(t, kout.DispositionAck, svc.HandleDeviceRegistered(tenantCtx, src).Disposition)
+		require.Equal(t, kout.DispositionAck, svc.HandleDeviceRegistered(tenantCtx, src).Disposition)
+
+		n, err := outboxCount(context.Background(), pool, "")
+		require.NoError(t, err)
+		require.Equal(t, 2, n, "two command entries must be written to PG outbox")
+		require.Equal(t, []string{durableTestTenant, durableTestTenant}, outboxTenants(t, pool),
+			"tenant must propagate through the durable PG path into the entry principal")
+
+		startDurableRelay(t, crs.relay)
+		require.Eventually(t, func() bool {
+			pub, perr := outboxCount(context.Background(), pool, "published")
+			return perr == nil && pub == 2
+		}, 60*time.Second, 200*time.Millisecond,
+			"both command entries must settle to published (one dispatched, one deduped)")
+
+		require.Equal(t, 1, h.calls,
+			"enqueue handler must run exactly once across the redelivered command (PG Claimer dedup)")
+	})
+
+	// ② Transaction atomicity — the property the demo FakeStore cannot witness.
+	t.Run("TxAtomicity_RollbackLeavesNoRow", func(t *testing.T) {
+		truncateOutbox(t, pool)
+		reg := command.NewRegistry()
+		crs, err := buildCommandRelaySubsystem(clk, &kout.DiscardPublisher{}, reg, pool)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		req := enqueue.Request{DeviceID: "d2", CommandType: "bootstrap", Payload: "{}"}
+		errBoom := errors.New("durable tx rollback boom")
+
+		// Rollback: the PG outbox writer writes inside the device-bootstrap tx, so
+		// a tx that emits then fails must leave NO command entry.
+		rbErr := crs.bootstrapTxManager.RunInTx(ctx, func(txCtx context.Context) error {
+			if e := command.EmitAsync(txCtx, clk, crs.bootstrapEmitter,
+				enqueue.DispatchID, "d2", "evt-rollback", req); e != nil {
+				return e
+			}
+			return errBoom
+		})
+		require.ErrorIs(t, rbErr, errBoom)
+		n, err := outboxCount(ctx, pool, "")
+		require.NoError(t, err)
+		require.Equal(t, 0, n, "rolled-back tx must leave no command entry in PG outbox")
+
+		// Commit: the same emit with a tx that succeeds → exactly one entry persists.
+		require.NoError(t, crs.bootstrapTxManager.RunInTx(ctx, func(txCtx context.Context) error {
+			return command.EmitAsync(txCtx, clk, crs.bootstrapEmitter,
+				enqueue.DispatchID, "d2", "evt-commit", req)
+		}))
+		n, err = outboxCount(ctx, pool, "")
+		require.NoError(t, err)
+		require.Equal(t, 1, n, "committed tx must persist exactly one command entry")
+	})
+
+	// ③ Fail-closed dead-letter on missing identity, settled by real PG MarkDead.
+	t.Run("FailClosedOnMissingIdentity_DeadLetter", func(t *testing.T) {
+		truncateOutbox(t, pool)
+		reg := command.NewRegistry()
+		h := &dedupEnqueueHandler{}
+		require.NoError(t, enqueue.Register(reg, h))
+
+		crs, err := buildCommandRelaySubsystem(clk, &kout.DiscardPublisher{}, reg, pool)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		// Identity-less command entry: schema-valid payload but no AggregateID and
+		// no command_id metadata → ClaimKeyFromEntry returns ok=false. EmitAsync
+		// always stamps a command_id, so seed via the raw PG writer instead.
+		payload, err := json.Marshal(enqueue.Request{DeviceID: "d1", CommandType: "reboot", Payload: "now"})
+		require.NoError(t, err)
+		bad, err := kout.NewEntry(clk, ctx, string(enqueue.DispatchID), payload)
+		require.NoError(t, err)
+		writer := adapterpg.NewOutboxWriter(clk)
+		require.NoError(t, crs.bootstrapTxManager.RunInTx(ctx, func(txCtx context.Context) error {
+			return writer.Write(txCtx, bad)
+		}))
+
+		startDurableRelay(t, crs.relay)
+		require.Eventually(t, func() bool {
+			dead, derr := outboxCount(context.Background(), pool, "dead")
+			return derr == nil && dead == 1
+		}, 30*time.Second, 200*time.Millisecond,
+			"identity-less command entry must be fail-closed dead-lettered on PG")
+		require.Equal(t, 0, h.calls, "handler must not run on an identity-less entry")
+	})
+}
+
+// setupDurableOutboxPG starts ONE PG testcontainer and applies the platform
+// migrations once for the whole test. terminate closes the pool and stops the
+// container. Mirrors setupSharedDeviceRepoPG in the sibling devicecell PG
+// conformance test — a local per-file helper, not a cross-package harness.
+func setupDurableOutboxPG(t *testing.T) (*adapterpg.Pool, func()) {
+	t.Helper()
+	// Required by archtest TestTestcontainerHelpersRequireDockerBeforeRun: the
+	// function that calls tcpostgres.Run must also call RequireDocker (idempotent
+	// — the top-level test already invoked it).
+	testutil.RequireDocker(t)
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx, testutil.PostgresImage,
+		tcpostgres.WithDatabase("test"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	require.NoError(t, err, "start postgres container")
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
+	require.NoError(t, err)
+
+	migrator, err := adapterpg.NewMigrator(pool, durableMigrationsFS(t), migration.PlatformNamespace)
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
+
+	terminate := func() {
+		if err := pool.Close(ctx); err != nil {
+			t.Logf("WARN: pool close: %v", err)
+		}
+		if err := container.Terminate(ctx); err != nil {
+			t.Logf("WARN: terminate postgres container: %v", err)
+		}
+	}
+	return pool, terminate
+}
+
+// durableMigrationsFS returns the shared adapters/postgres migration FS.
+// Mirrors the sibling devicecell PG test helper — Go _test.go files cannot be
+// imported across packages, so the accessor is duplicated.
+func durableMigrationsFS(t testing.TB) fs.FS {
+	t.Helper()
+	fsys, err := adapterpg.MigrationsFS()
+	require.NoError(t, err)
+	return fsys
+}
+
+// startDurableRelay starts the relay and, at sub-test end, cancels it and waits
+// for its run loop to exit. Waiting is correctness (not just cleanliness): the
+// pool is shared across sub-tests, so a lingering poller would consume the next
+// sub-test's outbox rows.
+func startDurableRelay(t *testing.T, relay *outboxruntime.Relay) {
+	t.Helper()
+	relayCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = relay.Start(relayCtx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+// truncateOutbox clears outbox_entries so each sub-test starts from empty.
+func truncateOutbox(t *testing.T, pool *adapterpg.Pool) {
+	t.Helper()
+	_, err := pool.DB().Exec(context.Background(), "TRUNCATE TABLE outbox_entries")
+	require.NoError(t, err, "truncate outbox_entries")
+}
+
+// outboxCount returns the number of outbox_entries rows, optionally filtered by
+// status (status == "" counts all). It returns an error rather than failing the
+// test so it is safe to call inside require.Eventually condition callbacks
+// (which run off the test goroutine).
+func outboxCount(ctx context.Context, pool *adapterpg.Pool, status string) (int, error) {
+	var (
+		n   int
+		err error
+	)
+	if status == "" {
+		err = pool.DB().QueryRow(ctx, "SELECT count(*) FROM outbox_entries").Scan(&n)
+	} else {
+		err = pool.DB().QueryRow(ctx, "SELECT count(*) FROM outbox_entries WHERE status = $1", status).Scan(&n)
+	}
+	return n, err
+}
+
+// outboxTenants returns the principal tenant id of every outbox_entries row
+// (empty string when the principal carries no tenant). Used to assert tenant
+// propagation through the durable PG path.
+func outboxTenants(t *testing.T, pool *adapterpg.Pool) []string {
+	t.Helper()
+	rows, err := pool.DB().Query(context.Background(), "SELECT principal->>'tenantId' FROM outbox_entries")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var tenant *string
+		require.NoError(t, rows.Scan(&tenant))
+		if tenant == nil {
+			out = append(out, "")
+		} else {
+			out = append(out, *tenant)
+		}
+	}
+	require.NoError(t, rows.Err())
+	return out
+}

--- a/examples/iotdevice/command_dedup_durable_integration_test.go
+++ b/examples/iotdevice/command_dedup_durable_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"sync"
 	"testing"
 	"time"
 
@@ -54,6 +55,11 @@ import (
 // via context.Background()), so command dedup keys are tenant-scoped and the
 // test additionally witnesses tenant propagation through the durable PG path.
 const durableTestTenant = "11111111-1111-1111-1111-111111111111"
+
+// durableRelayStopTimeout bounds how long a sub-test waits for the relay's run
+// loop to exit after cancel — guards against a hung Start() turning teardown
+// into a permanent test hang instead of a bounded failure.
+const durableRelayStopTimeout = 10 * time.Second
 
 // TestCommandRelay_Durable_PG verifies the durable command-relay subsystem
 // against real Postgres. One PG testcontainer is shared across the three
@@ -95,21 +101,33 @@ func TestCommandRelay_Durable_PG(t *testing.T) {
 		n, err := outboxCount(context.Background(), pool, "")
 		require.NoError(t, err)
 		require.Equal(t, 2, n, "two command entries must be written to PG outbox")
-		require.Equal(t, []string{durableTestTenant, durableTestTenant}, outboxTenants(t, pool),
-			"tenant must propagate through the durable PG path into the entry principal")
+		tenants := outboxTenants(t, pool)
+		require.Len(t, tenants, 2, "two command entries must be written to PG outbox")
+		for _, tn := range tenants {
+			require.Equal(t, durableTestTenant, tn,
+				"tenant must propagate through the durable PG path into the entry principal")
+		}
 
-		startDurableRelay(t, crs.relay)
+		stop := startDurableRelay(t, crs.relay)
 		require.Eventually(t, func() bool {
 			pub, perr := outboxCount(context.Background(), pool, "published")
 			return perr == nil && pub == 2
 		}, 60*time.Second, 200*time.Millisecond,
 			"both command entries must settle to published (one dispatched, one deduped)")
 
+		// Stop the relay (wait for its goroutine to exit) before reading h.calls:
+		// the channel-close in stop() establishes happens-before for the handler's
+		// in-memory counter, so the read needs no atomic and sees the final value.
+		stop()
 		require.Equal(t, 1, h.calls,
 			"enqueue handler must run exactly once across the redelivered command (PG Claimer dedup)")
 	})
 
 	// ② Transaction atomicity — the property the demo FakeStore cannot witness.
+	// This sub-test isolates the tx-atomicity invariant: it deliberately uses a
+	// tenantless context.Background() (tenant propagation is covered by ①) and
+	// never starts the relay — it asserts row presence/absence directly, not
+	// dispatch, so no command handler is registered either.
 	t.Run("TxAtomicity_RollbackLeavesNoRow", func(t *testing.T) {
 		truncateOutbox(t, pool)
 		reg := command.NewRegistry()
@@ -167,12 +185,14 @@ func TestCommandRelay_Durable_PG(t *testing.T) {
 			return writer.Write(txCtx, bad)
 		}))
 
-		startDurableRelay(t, crs.relay)
+		stop := startDurableRelay(t, crs.relay)
 		require.Eventually(t, func() bool {
 			dead, derr := outboxCount(context.Background(), pool, "dead")
 			return derr == nil && dead == 1
 		}, 30*time.Second, 200*time.Millisecond,
 			"identity-less command entry must be fail-closed dead-lettered on PG")
+		// Stop the relay before reading h.calls (happens-before; see ①).
+		stop()
 		require.Equal(t, 0, h.calls, "handler must not run on an identity-less entry")
 	})
 }
@@ -228,11 +248,17 @@ func durableMigrationsFS(t testing.TB) fs.FS {
 	return fsys
 }
 
-// startDurableRelay starts the relay and, at sub-test end, cancels it and waits
-// for its run loop to exit. Waiting is correctness (not just cleanliness): the
-// pool is shared across sub-tests, so a lingering poller would consume the next
-// sub-test's outbox rows.
-func startDurableRelay(t *testing.T, relay *outboxruntime.Relay) {
+// startDurableRelay starts the relay and returns an idempotent stop() that
+// cancels it and waits (bounded by durableRelayStopTimeout) for its run loop to
+// exit. stop() is also registered as a t.Cleanup, so callers that don't invoke
+// it explicitly still get teardown.
+//
+// Waiting is correctness on two fronts: (1) the pool is shared across sub-tests,
+// so a lingering poller would consume the next sub-test's outbox rows; (2)
+// calling stop() before reading the handler's in-memory counter establishes a
+// happens-before edge (channel close), so the read sees the final value without
+// an atomic.
+func startDurableRelay(t *testing.T, relay *outboxruntime.Relay) func() {
 	t.Helper()
 	relayCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -240,10 +266,19 @@ func startDurableRelay(t *testing.T, relay *outboxruntime.Relay) {
 		defer close(done)
 		_ = relay.Start(relayCtx)
 	}()
-	t.Cleanup(func() {
-		cancel()
-		<-done
-	})
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(durableRelayStopTimeout):
+				t.Errorf("relay goroutine did not exit within %s after cancel", durableRelayStopTimeout)
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return stop
 }
 
 // truncateOutbox clears outbox_entries so each sub-test starts from empty.


### PR DESCRIPTION
## Summary

durable iotdevice 命令-relay 子系统补一条贯穿真 Postgres（testcontainers）的全链路集成测试——驱动 #1698 已落地的生产 durable wiring 本身（`buildCommandRelaySubsystem` 的 PG 分支），锚住 demo in-memory FakeStore 结构性测不到的三件事。

## Why / 背景

#1698 落地了 durable 生产 wiring（`run.go::buildCommandRelaySubsystem` 在 durable 分支用真 `adapterpg.NewOutboxStore` + `NewOutboxWriter` + `WrapForCell(NewTxManager)` + `InMemClaimer` + `NewRelay/WithCommandDispatch`），但端到端只有 demo `command_dedup_e2e_test.go` 覆盖——它用 in-memory `outboxtest.FakeStore`，**忽略事务上下文、伪造 poll/lease**。于是 durable 路径的 **tx 原子性 + relay 真轮询 + Claimer 去重在真 PG 上从未端到端验证**（#1698 Q1 用户拍板 demo 全链路本 PR 落地、durable 集成测试登记 #1778）。本 PR 补这条回归锚。

本测试**直接调用真实生产装配** `buildCommandRelaySubsystem(clk, eb, reg, pool)`（传 PG-backed pool），而非复制 wiring——验证已落地的生产代码本身。三个子测试（实跑全绿，见 Test plan）：

- **DedupOnEventRedelivery**：真 PG relay 轮询 + Claimer 两阶段去重。源事件重投两次 → 同 `command_id` 两 entry → enqueue handler 恰触发一次。日志见证真实路径：`command dispatch busy, another worker holds claim` → 退避后 `command deduped (already processed)`。**MDM-default**：用显式 tenant principal（`ctxkeys.WithTenantID`，canonical UUID）驱动而非 demo 的隐式单租户 `context.Background()`，dedup 即 tenant-scoped，并附带断言 tenant 经 durable PG 路径透传到 entry principal（`outbox_entries` 无 RLS，relay 跨租户 sweep 不受阻）。
- **TxAtomicity_RollbackLeavesNoRow**：PG outbox writer 写在 device-bootstrap 事务内 → 回滚留 0 行、提交留 1 行。**这正是 demo FakeStore（忽略 tx context）结构性测不到的属性。**
- **FailClosedOnMissingIdentity_DeadLetter**：无身份 command entry（无 AggregateID / 无 command_id metadata）→ `ClaimKeyFromEntry` ok=false → 真 PG `MarkDead`，handler 不触发。

实现取舍：单文件、复用 demo helper（同 package main，integration tag 下同编）、用生产 `DefaultRelayConfig()`（A1 60s deadline 吸收默认 5s+ 退避，不为可测性 doctor 生产 config）、共享 PG 容器 + 子测试间 TRUNCATE（镜像同模块 `device_repo_conformance_integration_test.go`）。**不抽**跨包可复用 harness（YAGNI——issue「重构」档的 archetype ②/③ 尚不存在）。

## Refs

- Closes #1778
- Refs #1698（durable wiring 落地 PR）、#1044（W3 Command Bus epic）
- 镜像参考：`examples/iotdevice/cells/devicecell/internal/adapters/postgres/device_repo_conformance_integration_test.go`（同模块 testcontainers 模式）

## Risk / 兼容性

无。纯测试补充——零生产代码改动、零 go.mod 改动（`tcpostgres`/`testify`/`tests/testutil`/`adapterpg`/`pkg/migration` 已是 iotdevice 模块依赖）、零 wire/契约/migration 影响。`tcpostgres.Run` 直连经 `PG-TESTCONTAINER-FUNNEL-01` 的 `examples/iotdevice/` allowlist 放行；`setupDurableOutboxPG` 先 `RequireDocker` 再 `tcpostgres.Run`，过 `TestTestcontainerHelpersRequireDockerBeforeRun`。

> 注（非本 PR）：nightly 桶的 `PG-TESTCONTAINER-FUNNEL-01` 当前因 `corecells/accesscore/slices/policymanage/service_integration_test.go`（来自 #1844，未进 allowlist）已 RED——与本 PR 无关，属 #1347/#1844 归属。

## Test plan

- [x] `go -C examples/iotdevice build -tags=integration ./...` 通过（+ 无 tag build 通过）
- [x] `go -C examples/iotdevice test -tags=integration -run TestCommandRelay_Durable_PG ./...` 3 子测试全绿（真 PG，~16-20s）
- [x] CI-exact integration 命令（照抄 `_build-lint.yml`：`go test -tags=integration -covermode=atomic -count=1 -timeout 15m <discovered-pkgs>`）over iotdevice 模块 2 个 integration 包全绿，均 < 120s slowgate 阈值
- [x] 无 tag 全模块 `go test ./...` 全绿（demo 测试不受影响）
- [x] `golangci-lint run --build-tags=integration ./...` 我的文件 0 issues + gofmt 干净
- [x] archtest `PG-TESTCONTAINER-FUNNEL-01`（我的文件经 allowlist 放行）+ `TestTestcontainerHelpersRequireDockerBeforeRun` 通过
