### PR TITLE
fix(vault): drop stale //nolint:unparam on scrapeCounterVec [develop CI red]

### DIFF
--- a/adapters/vault/transit_metrics_test.go
+++ b/adapters/vault/transit_metrics_test.go
@@ -237,8 +237,6 @@ func scrapeGauge(t *testing.T, rec *recordingProvider, name string) float64 {
 
 // scrapeCounterVec returns the recorded value of a CounterVec sample matching the
 // given label set exactly. Fatals if the label set is not found.
-//
-//nolint:unparam // metric name parameterised for parity with scrapeCounter/scrapeGauge
 func scrapeCounterVec(t *testing.T, rec *recordingProvider, name string, labels map[string]string) float64 {
 	t.Helper()
 	v, ok := rec.value(name, labels)


### PR DESCRIPTION
## Summary

删除 `adapters/vault/transit_metrics_test.go` 中 `scrapeCounterVec` 上已失效的 `//nolint:unparam` 指令，修复 develop full-ci 红。

## Why / 背景

develop 的 `full-ci / build-test (kernel, ./kernel/..., true)`（workspace satellite linter，`only-new-issues:false`）持续红：`nolintlint` 报 `scrapeCounterVec` 的 `//nolint:unparam` 指令 unused。

该指令在 #1879（callers 当时同构）时加入，现已失效——`scrapeCounterVec` 被以**多种** `name` 值调用（`"gocell_vault_auth_login_total"`、`metric` 变量、`"test_labeled_total"`），`unparam` 不再标记该参数，故抑制是死代码。

此 satellite-lint 失败在 PR CI 上**不可见**：PR 跑 `--new-from-merge-base`（only-new-issues），跳过 diff 外的 pre-existing 问题；develop full-ci 全树 lint 才暴露（与 #2096/#2097 同一 only-new-issues 机制）。与已合并的 #2098（ssobff drift + MarkTerminal）无关——本问题在 vault，#1879 引入，独立于 #2098。

## Refs

- 无独立 issue（CI-red 直修）。诊断自 develop run 27472877339 / 27472893659 的 kernel-bucket 失败。

## Risk / 兼容性

无。纯删除一条失效的 lint 抑制指令，无行为变更，仅 test helper 的注释。

注：本地 `go run golangci-lint@v2.11.4`（darwin/arm64）会在 `transit_provider.go:59` 报一条 `gosec G706`（log injection taint）误报——该行已用 `logutil.Sanitize` 清洗。此为本地平台 gosec taint 分析的假阳性：CI（linux/amd64, Go 1.25.11）的 fresh satellite 分析对同一未改动行从未报 G706（develop full-ci 仅报本 PR 修复的 nolintlint）。本 PR 不触碰 `transit_provider.go`。

## Test plan

- [x] `go build ./...`（adapters/vault）通过
- [x] `go test ./...`（adapters/vault）通过
- [x] diff = 删除 2 行（一条 `//` 分隔 + 一条 `//nolint:unparam`）
- [x] CI satellite lint 将验证 nolintlint 已消除
