### PR TITLE
test(saga): scenario-5 多步补偿 integration tier + tailer goleak TestMain [#1949]

### DIFF
--- a/runtime/saga/integration_test.go
+++ b/runtime/saga/integration_test.go
@@ -4,22 +4,25 @@ package saga
 //   - TestIntegration_HappyPath1Step (§220 scenario 1)
 //   - TestIntegration_StepRunError (§220 scenario 2)
 //   - TestIntegration_TotalSagaTimeout (§220 scenario 4)
+//   - TestIntegration_Compensation_MultiStepReverseWalk_Compensated /
+//     _CompensationFailed (§220 scenario 5 — multi-step compensation walk)
 //   - TestIntegration_ClaimContention (§220 scenario 6)
 //   - TestIntegration_ResumeAfterRestart (§220 scenario 7)
 //   - TestIntegration_PanicRecovery (§220 scenario 8)
 //   - TestIntegration_Compensation_LeaseLost_ResumesOnReclaim (#1210 C3 — compensation-phase lease-lost recovery)
 //
-// §220 scenarios 3 (retry budget) and 5 (multi-step compensation walk)
-// are covered by white-box unit tests in coordinator_test.go and
-// executor_test.go; the integration tier focuses on cross-coordinator
-// goroutine paths.
+// §220 scenario 3 (retry budget) is covered by white-box unit tests in
+// coordinator_test.go and executor_test.go; the integration tier focuses on
+// full-lifecycle (Start/Stop + tickLoop) and cross-coordinator goroutine paths.
 //
 // Fake helpers live in testfakes_test.go (same package, test-only).
 
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1045,4 +1048,223 @@ func assertPhase3RecoveryFinal(t *testing.T, j *journal.MemJournal, instID iduti
 	if got := step1CompensateCalls.Load(); got != 1 {
 		t.Errorf("step1CompensateCalls = %d, want 1 (c1 attempted; c2 recovery skips already-attempted)", got)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — Multi-step reverse compensation walk (full Coordinator lifecycle)
+// ---------------------------------------------------------------------------
+
+// scenario5Def builds a 3-step saga that exercises the multi-step reverse
+// compensation walk through the full Coordinator tickLoop:
+//   - step1, step2: Run succeeds and each owns a Compensate handler, so both
+//     commit and become eligible for the reverse walk.
+//   - step3: Run deliberately fails. Because committed steps with Compensate
+//     handlers exist, routeOutcome routes to runCompensation (not the plain
+//     StatusFailed path). step3 itself never commits, so it stays outside the
+//     reverse walk and needs no Compensate.
+//
+// step2CompensateErr selects the terminal outcome:
+//   - nil → both compensations succeed → StatusCompensated (KindSagaCompensated)
+//   - err → step2's Compensate fails; the walk continues to step1 (best-effort)
+//     → StatusCompensationFailed (KindSagaCompensationFailed)
+func scenario5Def(defID idutil.SafeID, step2CompensateErr error) *ksaga.Definition {
+	return &ksaga.Definition{
+		ID: defID,
+		Steps: []ksaga.Step{
+			{
+				Name:       "step1",
+				Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return []byte(`{"s":1}`), nil },
+				Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return nil },
+			},
+			{
+				Name:       "step2",
+				Run:        func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) { return []byte(`{"s":2}`), nil },
+				Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error { return step2CompensateErr },
+			},
+			{
+				Name: "step3",
+				Run: func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) {
+					return nil, errors.New("step3 deliberately fails to trigger compensation")
+				},
+			},
+		},
+	}
+}
+
+// driveScenario5ToTerminal enqueues inst and drives the 3-step saga to a terminal
+// journal event through the running tickLoop: one tick per forward step, advancing
+// the clock past the 60s lease between claims so each subsequent tick can re-claim.
+// step3's tick runs the entire reverse compensation walk inside a single driveOne,
+// so the saga reaches its terminal event on that final tick.
+func driveScenario5ToTerminal(t *testing.T, h *testHarness, inst ksaga.Instance) {
+	t.Helper()
+	if err := h.j.Enqueue(context.Background(), inst); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	// step1 commits — the initial claim needs no lease expiry.
+	tickOnceAndWait(t, h.clk, func() bool {
+		evs, err := h.j.Load(context.Background(), inst.ID)
+		return err == nil && len(evs) >= 1
+	})
+
+	// step2 commits — expire step1's lease first so the next tick re-claims.
+	h.clk.Advance(testLeaseAdvance)
+	tickOnceAndWait(t, h.clk, func() bool {
+		evs, err := h.j.Load(context.Background(), inst.ID)
+		return err == nil && len(evs) >= 2
+	})
+
+	// step3 fails → reverse compensation walk → terminal, all within one driveOne.
+	h.clk.Advance(testLeaseAdvance)
+	tickOnceAndWait(t, h.clk, func() bool {
+		evs, err := h.j.Load(context.Background(), inst.ID)
+		return err == nil && len(evs) > 0 && evs[len(evs)-1].Kind.IsTerminal()
+	})
+}
+
+// scenario5JournalShape is the expected journal event sequence for a scenario-5
+// run, parameterized by the two compensation-step kinds and the terminal kind so
+// the same shape covers both the clean-rollback and compensation-failed paths.
+type scenario5JournalShape struct {
+	step2Comp journal.EventKind // KindStepCompensated or KindStepCompensationFailed (reverse walk: step2 first)
+	step1Comp journal.EventKind // KindStepCompensated (step1 always compensates cleanly here)
+	terminal  journal.EventKind // KindSagaCompensated or KindSagaCompensationFailed
+}
+
+// assertScenario5Journal verifies the full forward+compensation event sequence:
+// two forward KindStepCompleted, KindCompensationStarted, then the reverse walk
+// (step2 before step1) and the terminal kind. Version is the per-instance
+// position (1..6); StepName must match for the step-scoped kinds and be empty for
+// the saga-scoped CompensationStarted / terminal kinds.
+func assertScenario5Journal(t *testing.T, evs []journal.Event, shape scenario5JournalShape) {
+	t.Helper()
+	expected := []struct {
+		kind journal.EventKind
+		step idutil.SafeID // "" → saga-scoped (no StepName)
+		desc string
+	}{
+		{journal.KindStepCompleted, "step1", "forward step1 completed"},
+		{journal.KindStepCompleted, "step2", "forward step2 completed"},
+		{journal.KindCompensationStarted, "", "compensation started"},
+		{shape.step2Comp, "step2", "reverse walk: step2 (first)"},
+		{shape.step1Comp, "step1", "reverse walk: step1 (second)"},
+		{shape.terminal, "", "terminal"},
+	}
+	if len(evs) != len(expected) {
+		t.Fatalf("journal event count = %d, want %d; events: %v", len(evs), len(expected), evs)
+	}
+	for i, want := range expected {
+		if evs[i].Kind != want.kind {
+			t.Errorf("evs[%d].Kind = %s, want %s (%s)", i, evs[i].Kind, want.kind, want.desc)
+		}
+		if evs[i].Version != int64(i+1) {
+			t.Errorf("evs[%d].Version = %d, want %d (%s)", i, evs[i].Version, i+1, want.desc)
+		}
+		if evs[i].StepName != want.step {
+			t.Errorf("evs[%d].StepName = %q, want %q (%s)", i, evs[i].StepName, want.step, want.desc)
+		}
+	}
+	if !evs[len(evs)-1].Kind.IsTerminal() {
+		t.Errorf("last event %s is not terminal", evs[len(evs)-1].Kind)
+	}
+}
+
+// assertScenario5ForwardEmitsOnly pins the compensation-path outbox contract
+// (#1949 (c)): the reverse compensation walk emits NOTHING to the outbox. Only
+// the two committed forward steps produce step-completed events, so the emitter
+// holds exactly two entries — both on the step-completed topic, for step1 then
+// step2. A future regression that emits during compensation pushes the count
+// past two. The dispatcher Kick count is likewise 2: compensation commits use
+// txRunner.RunInTx directly and never register the AfterCommit Kick hook that
+// only commitStepInTx (forward path) installs.
+func assertScenario5ForwardEmitsOnly(t *testing.T, h *testHarness, defID idutil.SafeID) {
+	t.Helper()
+	entries := h.emitter.Snapshot()
+	if len(entries) != 2 {
+		t.Fatalf("emitter entries = %d, want 2 (forward step1+step2 only; compensation emits nothing)", len(entries))
+	}
+	wantTopic := stepCompletedTopic(defID)
+	gotSteps := make([]string, 0, len(entries))
+	for i, e := range entries {
+		// RoutingTopic() is the routing identity a consumer subscribes against
+		// (== Entry.Stream()); koutbox.Emit stamps the dotted name as eventType,
+		// so RoutingTopic falls back to it (the bare topic field is empty).
+		if e.RoutingTopic() != wantTopic {
+			t.Errorf("entry[%d].RoutingTopic = %q, want %q", i, e.RoutingTopic(), wantTopic)
+		}
+		var ev StepCompletedEvent
+		if err := json.Unmarshal(e.Payload(), &ev); err != nil {
+			t.Fatalf("entry[%d] payload unmarshal: %v", i, err)
+		}
+		gotSteps = append(gotSteps, string(ev.Step))
+	}
+	if !reflect.DeepEqual(gotSteps, []string{"step1", "step2"}) {
+		t.Errorf("emitted step-completed steps = %v, want [step1 step2]", gotSteps)
+	}
+	if got := h.disp.KickCount(); got != 2 {
+		t.Errorf("KickCount = %d, want 2 (one per forward commit; compensation path does not Kick)", got)
+	}
+}
+
+// TestIntegration_Compensation_MultiStepReverseWalk_Compensated drives a 3-step
+// saga through the full Coordinator lifecycle (Start/Stop + tickLoop): step1 and
+// step2 commit, step3's Run fails and triggers the reverse compensation walk, and
+// both compensations succeed → terminal StatusCompensated.
+//
+// This is the §220 scenario-5 integration tier — previously only covered white-box
+// in coordinator_test.go via direct driveOne calls. It exercises (a) the reverse
+// walk under the executor's RunWithHeartbeat goroutine fan-out, (b) the
+// StatusCompensated terminal end to end, and (c) the compensation-path outbox
+// contract (the walk emits nothing; only the two forward step-completed events
+// reach the emitter).
+func TestIntegration_Compensation_MultiStepReverseWalk_Compensated(t *testing.T) {
+	const defID idutil.SafeID = "scenario5compensated"
+
+	h := newTestHarness(t, scenario5Def(defID, nil))
+	cancel := startCoord(t, h.coord)
+	defer cancel()
+
+	inst := newInstance(t, defID, h.clk.Now())
+	driveScenario5ToTerminal(t, h, inst)
+
+	evs, err := h.j.Load(context.Background(), inst.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertScenario5Journal(t, evs, scenario5JournalShape{
+		step2Comp: journal.KindStepCompensated,
+		step1Comp: journal.KindStepCompensated,
+		terminal:  journal.KindSagaCompensated,
+	})
+	assertScenario5ForwardEmitsOnly(t, h, defID)
+}
+
+// TestIntegration_Compensation_MultiStepReverseWalk_CompensationFailed is the
+// §220 scenario-5 integration tier for the failed-rollback terminal: same 3-step
+// saga driven through the full tickLoop, but step2's Compensate returns an error.
+// The reverse walk records KindStepCompensationFailed for step2, continues
+// best-effort to step1 (which compensates cleanly), and terminates as
+// StatusCompensationFailed — distinct from StatusFailed (forward failure with no
+// rollback). The compensation path still emits nothing to the outbox.
+func TestIntegration_Compensation_MultiStepReverseWalk_CompensationFailed(t *testing.T) {
+	const defID idutil.SafeID = "scenario5compfailed"
+
+	h := newTestHarness(t, scenario5Def(defID, errors.New("step2 compensation deliberately fails")))
+	cancel := startCoord(t, h.coord)
+	defer cancel()
+
+	inst := newInstance(t, defID, h.clk.Now())
+	driveScenario5ToTerminal(t, h, inst)
+
+	evs, err := h.j.Load(context.Background(), inst.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertScenario5Journal(t, evs, scenario5JournalShape{
+		step2Comp: journal.KindStepCompensationFailed,
+		step1Comp: journal.KindStepCompensated,
+		terminal:  journal.KindSagaCompensationFailed,
+	})
+	assertScenario5ForwardEmitsOnly(t, h, defID)
 }

--- a/runtime/saga/integration_test.go
+++ b/runtime/saga/integration_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"reflect"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,8 +39,13 @@ import (
 
 // File-local duration consts for values not present in testtime.
 const (
-	// testLeaseAdvance is used in TestIntegration_ResumeAfterRestart to advance
-	// the clock past the 60s lease expiry so coordinator 2 can re-claim.
+	// testLeaseAdvance advances the clock past the 60s lease expiry (LeaseDuration
+	// in newTestHarness) so the next tick can re-claim. Used by
+	// TestIntegration_ResumeAfterRestart (phase 2) and also by
+	// driveScenario5ToTerminal (scenario-5 step2/step3 advances) — both need to
+	// expire a prior claim lease before the subsequent tick can acquire a new one.
+	// The value (65s) = Config.LeaseDuration(60s) + 5s grace, ensuring the lease
+	// has fully expired before the next ClaimPending call.
 	testLeaseAdvance = 65 * time.Second
 )
 
@@ -1067,7 +1072,14 @@ func assertPhase3RecoveryFinal(t *testing.T, j *journal.MemJournal, instID iduti
 //   - nil → both compensations succeed → StatusCompensated (KindSagaCompensated)
 //   - err → step2's Compensate fails; the walk continues to step1 (best-effort)
 //     → StatusCompensationFailed (KindSagaCompensationFailed)
-func scenario5Def(defID idutil.SafeID, step2CompensateErr error) *ksaga.Definition {
+//
+// step3Compensated is an observable counter for step3's Compensate handler. Even
+// though step3 has a Compensate registered, collectCommittedSteps only includes
+// steps that produced a KindStepCompleted journal event — step3 never commits
+// (its Run returns an error), so it is never added to the reverse walk and its
+// Compensate is never called. Callers can assert step3Compensated.Load() == 0
+// to lock this "uncommitted step stays outside reverse walk" invariant.
+func scenario5Def(defID idutil.SafeID, step2CompensateErr error, step3Compensated *atomic.Int64) *ksaga.Definition {
 	return &ksaga.Definition{
 		ID: defID,
 		Steps: []ksaga.Step{
@@ -1086,6 +1098,13 @@ func scenario5Def(defID idutil.SafeID, step2CompensateErr error) *ksaga.Definiti
 				Run: func(_ context.Context, _ *ksaga.Instance, _ []byte) ([]byte, error) {
 					return nil, errors.New("step3 deliberately fails to trigger compensation")
 				},
+				// step3.Compensate is intentionally registered to prove that an
+				// uncommitted step's Compensate is never invoked: collectCommittedSteps
+				// filters by KindStepCompleted, and step3 never produces one.
+				Compensate: func(_ context.Context, _ *ksaga.Instance, _ []byte) error {
+					step3Compensated.Add(1)
+					return nil
+				},
 			},
 		},
 	}
@@ -1096,6 +1115,9 @@ func scenario5Def(defID idutil.SafeID, step2CompensateErr error) *ksaga.Definiti
 // the clock past the 60s lease between claims so each subsequent tick can re-claim.
 // step3's tick runs the entire reverse compensation walk inside a single driveOne,
 // so the saga reaches its terminal event on that final tick.
+//
+// Each testLeaseAdvance call (= Config.LeaseDuration(60s) + 5s grace, see
+// newTestHarness) expires the prior claim lease so the next tick can re-claim.
 func driveScenario5ToTerminal(t *testing.T, h *testHarness, inst ksaga.Instance) {
 	t.Helper()
 	if err := h.j.Enqueue(context.Background(), inst); err != nil {
@@ -1105,14 +1127,14 @@ func driveScenario5ToTerminal(t *testing.T, h *testHarness, inst ksaga.Instance)
 	// step1 commits — the initial claim needs no lease expiry.
 	tickOnceAndWait(t, h.clk, func() bool {
 		evs, err := h.j.Load(context.Background(), inst.ID)
-		return err == nil && len(evs) >= 1
+		return err == nil && len(evs) >= 1 && evs[len(evs)-1].Kind == journal.KindStepCompleted
 	})
 
 	// step2 commits — expire step1's lease first so the next tick re-claims.
 	h.clk.Advance(testLeaseAdvance)
 	tickOnceAndWait(t, h.clk, func() bool {
 		evs, err := h.j.Load(context.Background(), inst.ID)
-		return err == nil && len(evs) >= 2
+		return err == nil && len(evs) >= 2 && evs[len(evs)-1].Kind == journal.KindStepCompleted
 	})
 
 	// step3 fails → reverse compensation walk → terminal, all within one driveOne.
@@ -1128,7 +1150,7 @@ func driveScenario5ToTerminal(t *testing.T, h *testHarness, inst ksaga.Instance)
 // the same shape covers both the clean-rollback and compensation-failed paths.
 type scenario5JournalShape struct {
 	step2Comp journal.EventKind // KindStepCompensated or KindStepCompensationFailed (reverse walk: step2 first)
-	step1Comp journal.EventKind // KindStepCompensated (step1 always compensates cleanly here)
+	step1Comp journal.EventKind // KindStepCompensated — step1.Compensate returns nil in both current tests
 	terminal  journal.EventKind // KindSagaCompensated or KindSagaCompensationFailed
 }
 
@@ -1182,7 +1204,8 @@ func assertScenario5ForwardEmitsOnly(t *testing.T, h *testHarness, defID idutil.
 	t.Helper()
 	entries := h.emitter.Snapshot()
 	if len(entries) != 2 {
-		t.Fatalf("emitter entries = %d, want 2 (forward step1+step2 only; compensation emits nothing)", len(entries))
+		t.Errorf("emitter entries = %d, want 2 (forward step1+step2 only; compensation emits nothing)", len(entries))
+		return
 	}
 	wantTopic := stepCompletedTopic(defID)
 	gotSteps := make([]string, 0, len(entries))
@@ -1199,7 +1222,7 @@ func assertScenario5ForwardEmitsOnly(t *testing.T, h *testHarness, defID idutil.
 		}
 		gotSteps = append(gotSteps, string(ev.Step))
 	}
-	if !reflect.DeepEqual(gotSteps, []string{"step1", "step2"}) {
+	if !slices.Equal(gotSteps, []string{"step1", "step2"}) {
 		t.Errorf("emitted step-completed steps = %v, want [step1 step2]", gotSteps)
 	}
 	if got := h.disp.KickCount(); got != 2 {
@@ -1221,7 +1244,8 @@ func assertScenario5ForwardEmitsOnly(t *testing.T, h *testHarness, defID idutil.
 func TestIntegration_Compensation_MultiStepReverseWalk_Compensated(t *testing.T) {
 	const defID idutil.SafeID = "scenario5compensated"
 
-	h := newTestHarness(t, scenario5Def(defID, nil))
+	var step3Compensated atomic.Int64
+	h := newTestHarness(t, scenario5Def(defID, nil, &step3Compensated))
 	cancel := startCoord(t, h.coord)
 	defer cancel()
 
@@ -1238,6 +1262,9 @@ func TestIntegration_Compensation_MultiStepReverseWalk_Compensated(t *testing.T)
 		terminal:  journal.KindSagaCompensated,
 	})
 	assertScenario5ForwardEmitsOnly(t, h, defID)
+	if got := step3Compensated.Load(); got != 0 {
+		t.Errorf("step3.Compensate called %d times, want 0 (step3 never committed → outside reverse walk)", got)
+	}
 }
 
 // TestIntegration_Compensation_MultiStepReverseWalk_CompensationFailed is the
@@ -1250,7 +1277,8 @@ func TestIntegration_Compensation_MultiStepReverseWalk_Compensated(t *testing.T)
 func TestIntegration_Compensation_MultiStepReverseWalk_CompensationFailed(t *testing.T) {
 	const defID idutil.SafeID = "scenario5compfailed"
 
-	h := newTestHarness(t, scenario5Def(defID, errors.New("step2 compensation deliberately fails")))
+	var step3Compensated atomic.Int64
+	h := newTestHarness(t, scenario5Def(defID, errors.New("step2 compensation deliberately fails"), &step3Compensated))
 	cancel := startCoord(t, h.coord)
 	defer cancel()
 
@@ -1267,4 +1295,7 @@ func TestIntegration_Compensation_MultiStepReverseWalk_CompensationFailed(t *tes
 		terminal:  journal.KindSagaCompensationFailed,
 	})
 	assertScenario5ForwardEmitsOnly(t, h, defID)
+	if got := step3Compensated.Load(); got != 0 {
+		t.Errorf("step3.Compensate called %d times, want 0 (step3 never committed → outside reverse walk)", got)
+	}
 }

--- a/runtime/saga/tailer/main_test.go
+++ b/runtime/saga/tailer/main_test.go
@@ -8,16 +8,17 @@ import (
 
 // TestMain installs a package-wide goleak guard, bringing the tailer package to
 // parity with its siblings runtime/saga (integration_test.go) and
-// runtime/saga/executor (main_test.go), which both already verify no goroutines
-// leak across the test binary.
+// runtime/saga/executor (executor/main_test.go), which both already verify no
+// goroutines leak across the test binary.
 //
 // This matters most for safeObserve (tailer.go): when an observer call exceeds
 // observerCallDeadline, safeObserve abandons the spawned observer goroutine and
 // returns — by design (Go cannot kill a goroutine). Tests such as
 // TestTailer_BlockingObserverBounded deliberately exercise that abandonment;
-// goleak.VerifyTestMain asserts every such goroutine is released before the
-// binary exits, so a regression that leaves an observer pinned indefinitely
-// surfaces as a failing test rather than silently rotting.
+// goleak.VerifyTestMain causes the test binary to exit non-zero with a goroutine
+// leak report if any such goroutine is still live when the binary exits, so a
+// regression that leaves an observer pinned indefinitely is caught at the binary
+// level rather than silently rotting.
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/runtime/saga/tailer/main_test.go
+++ b/runtime/saga/tailer/main_test.go
@@ -1,0 +1,23 @@
+package tailer
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain installs a package-wide goleak guard, bringing the tailer package to
+// parity with its siblings runtime/saga (integration_test.go) and
+// runtime/saga/executor (main_test.go), which both already verify no goroutines
+// leak across the test binary.
+//
+// This matters most for safeObserve (tailer.go): when an observer call exceeds
+// observerCallDeadline, safeObserve abandons the spawned observer goroutine and
+// returns — by design (Go cannot kill a goroutine). Tests such as
+// TestTailer_BlockingObserverBounded deliberately exercise that abandonment;
+// goleak.VerifyTestMain asserts every such goroutine is released before the
+// binary exits, so a regression that leaves an observer pinned indefinitely
+// surfaces as a failing test rather than silently rotting.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
## Summary

补 saga 两处测试缺口：scenario-5 多步逆序补偿的 **integration tier**（走完整 Coordinator `Start/Stop` + `tickLoop`），以及 `runtime/saga/tailer` 包缺失的 **goleak `TestMain`**。纯测试新增，无生产代码变更。

## Why / 背景

`#1949`（六角色 saga review 测试维度发现）指出两处缺口：

1. **scenario-5 无 integration tier**：既有覆盖只有白盒 `coordinator_test.go`（`driveOne` 直调、非完整生命周期，且只验 `StatusCompensationFailed` 一条终态）。缺 integration 级验证：(a) 逆序补偿在 executor `RunWithHeartbeat` goroutine 扇出下的行为、(b) `StatusCompensated` 与 `StatusCompensationFailed` 两条终态端到端、(c) 补偿路径的 outbox emit 契约。
2. **`tailer` 包无 goleak 守卫**：兄弟包 `runtime/saga`、`runtime/saga/executor` 都有 `goleak.VerifyTestMain`，唯独 `tailer` 没有。`tailer.safeObserve` 超时会按设计弃用 observer goroutine，`TestTailer_BlockingObserverBounded` 等用例此前无泄漏回归保护。

新增的两个 `TestIntegration_Compensation_MultiStepReverseWalk_*` 把 (c) 钉死为一条强回归守卫：**补偿路径不向 outbox emit**，emitter 恰为两条 forward step-completed 事件（topic/payload/计数 + `KickCount` 全断言）——未来若补偿路径误加 emit，计数漂移即被抓。

## Refs

- Closes #1949
- ref: Temporal compensation semantics（saga 逆序补偿对标）、controller-runtime（reconcile/saga 边界）、`go.uber.org/goleak`（goroutine 泄漏守卫）
- 既有 integration 补偿模板：`runtime/saga/integration_test.go` `TestIntegration_Compensation_LeaseLost_ResumesOnReclaim`；白盒语义参照：`coordinator_test.go` `TestRunCompensation_StepFails_ContinuesReverseFinalStatusCompensationFailed`

### 附注：#1023 已 stale，**不在本 PR**

`/ship 1023 + 1949` 原含 #1023，但核实 #1023（`testwait.External` 非 const 字面量）**已被 PR #1135 / commit `67a1262d4` 修复**——它把 `testwait.External(t, name+"-tickers-registered", …)` 改成 const 字面量 `"coordinator-tickers-registered"`。现状 `TestExternalReasonLiteral` archtest 通过、line 785 已是无关代码。#1023 单独评论关闭（指向 #1135），不进本 PR（本 PR 未修 #1023，语义诚实）。

## Risk / 兼容性

无。纯测试新增（test-only），无生产代码、wire 契约、migration 变更。文件头注释从「scenario 5 白盒覆盖」更新为「integration 覆盖」（清理误导声明）。白盒补偿测试**刻意保留**（不同 tier，删除反降覆盖）。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test ./runtime/saga/... -race -count=1` 全绿（含 tailer 新 goleak 守卫）
- [x] `go test ./runtime/saga/ -run TestIntegration_Compensation_MultiStepReverseWalk -race` 两终态全绿
- [x] `go test -tags=archtest ./tools/archtest/ -run TestExternalReasonLiteral$` 保持绿（#1023 不回归）
- [x] `golangci-lint run ./runtime/saga/...` 0 issues
