### PR TITLE
fix(releasesmoke): satellites lint unparam on buildProxy — unblock develop CI [develop CI]

### DIFF
--- a/tools/releasesmoke/external_get_smoke_test.go
+++ b/tools/releasesmoke/external_get_smoke_test.go
@@ -137,8 +137,13 @@ func TestExternalGet_AllPublishable_Build(t *testing.T) {
 }
 
 // buildProxy publishes every publishable module at version into a fresh file
-// GOPROXY directory and returns its path. When bump is true each module's go.mod
-// is release-bumped first; otherwise the as-committed go.mod (with v0.0.0) is used.
+// GOPROXY directory and returns its path. Each module's go.mod is release-bumped
+// (internal requires pinned to version) before publishing; import paths passed in
+// omit are left unpublished to simulate an incomplete tag set. Every caller passes
+// the synthetic synthVersion — there is no second publish version to exercise (an
+// unbumped/alternate version is not a discriminator; see
+// [TestExternalGet_IncompleteSet_Fails]), so version stays a named axis for parity
+// with stageGoMod / writeProxyModule (hence the nolint:unparam below).
 //
 // Each published module is an INTERNAL-DEPS-ONLY PROJECTION of the real module:
 // external requires are stripped and the package is a stub that blank-imports the
@@ -148,7 +153,7 @@ func TestExternalGet_AllPublishable_Build(t *testing.T) {
 // version resolution of exactly the modules the bump rewrites, without dragging
 // in the root module's external universe. The local replace is PRESERVED to prove
 // Go ignores a dependency's replace (the OTel-canonical shape).
-func buildProxy(t *testing.T, root, version string, omit ...string) string {
+func buildProxy(t *testing.T, root, version string, omit ...string) string { //nolint:unparam // one synthetic publish version by design
 	t.Helper()
 	prefix, err := gomodutil.ReadModulePath(root)
 	if err != nil {

--- a/tools/releasesmoke/external_get_smoke_test.go
+++ b/tools/releasesmoke/external_get_smoke_test.go
@@ -153,7 +153,7 @@ func TestExternalGet_AllPublishable_Build(t *testing.T) {
 // version resolution of exactly the modules the bump rewrites, without dragging
 // in the root module's external universe. The local replace is PRESERVED to prove
 // Go ignores a dependency's replace (the OTel-canonical shape).
-func buildProxy(t *testing.T, root, version string, omit ...string) string { //nolint:unparam // one synthetic publish version by design
+func buildProxy(t *testing.T, root, version string, omit ...string) string { //nolint:unparam // R2-approved: synthetic version by design
 	t.Helper()
 	prefix, err := gomodutil.ReadModulePath(root)
 	if err != nil {


### PR DESCRIPTION
## Summary

修复 `golangci-lint workspace satellites` 步骤里 `buildProxy` 的 `unparam` finding（`version` 形参恒为 `synthVersion`），它自 #2091 起让 **develop CI 每次 push 都红**。

## Why / 背景

develop CI 最近 21/23 次全红，且**每次都挂在同一步**：`build-test (kernel)` 的 `golangci-lint workspace satellites`。具体 finding 会轮换：

- 早期：`scrapeCounterVec` 的过期 `//nolint:unparam`（已由 `d4313c59a` 修）。
- 当前：`tools/releasesmoke/external_get_smoke_test.go:151` 的 `buildProxy - version always receives synthVersion ("v0.99.99") (unparam)`。

**根因（双重盲区）**：

1. **模式不对称**：satellites lint 在 **PR** 用 `--new-from-merge-base`（only-new-issues，只看改动行），在 **push/develop** 用 **full 模式（无过滤）**。于是 satellite 模块里任何「不在 PR 改动行上」的潜伏 finding 会顺利通过 PR CI，落到 develop 后**每次 push 都红**，直到被单独修掉 → 这就是「老是 ci 问题」的结构性来源。
2. **build-tag 不对称**：satellite 的 `tools` 用 `--build-tags=archtest,releasesmoke` 才能 lint 到 tag-gated 文件；本地默认 `golangci-lint run ./...` 不带这些 tag，所以本地也看不到。

本 PR 只修当前这条 blocker（已确认是当前全 satellite 仅剩的一条 finding，修掉即可让 develop CI 恢复绿）。结构性建议见下方 Risk。

## Refs

- 失败 run：`27485825294`、`27485868773`（均挂 satellites lint → buildProxy unparam）
- 引入点：#2091（`c40d0030b`）；同类前序：`d4313c59a`
- 对标：`unparam` 抑制范式同 `kernel/outbox/outboxtest/helpers.go:532`（test helper 形参保留为命名轴 + 带理由 nolint）

## Risk / 兼容性

无 wire / 行为变更，仅测试 helper 的注释 + 一行 `//nolint:unparam`。

**为何 nolint 而非删形参**：`version` 贯穿整条 hermetic proxy publisher（`stageGoMod`/`writeProxyModule`/`writeModuleZip` 都带它，且与 `publishInstallableBinary` 签名对齐）。删 `buildProxy` 的 `version` 会把 `synthVersion` 常量直接传给下游，**把 unparam 级联到那几个 helper**（局部实测过），更脏。本文件自身 doctrine（`TestExternalGet_IncompleteSet_Fails`）已论证「换一个版本不是 discriminator」，所以单一合成版本是有意设计 → 带理由抑制是正解。顺手修掉 `buildProxy` 过期的 "When bump is true … otherwise v0.0.0" doc（已无 `bump` 形参）。

**结构性建议（不在本 PR 范围，需决策）**：要根治「satellite 潜伏 finding 落 develop 才暴露」，可选 (a) 给 `make`/pre-push 加一个跑 satellites lint 全量（带 tag）的 target 让本地可见；(b) PR 上 satellites 也跑 full 模式（代价：所有 open PR 会被既有 satellite finding 染红，需先清零）。建议先 (a)。

## Test plan

- [x] satellites lint（CI 完全等价命令）：`(cd tools && golangci-lint run --config ../.golangci.yml --build-tags=archtest,releasesmoke ./...)` → **0 issues**
- [x] `go vet -tags=releasesmoke ./releasesmoke/...` → OK
- [x] `go build ./...`（tools 模块）→ OK
