### PR TITLE
fix(ci): correct fabricated goreleaser-action SHA pin (Dependabot red + latent release break)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
       # first and goreleaser would only fail afterwards, leaving an orphan tag.
       - name: Install goreleaser
         if: steps.resolve.outputs.skip != 'true'
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598b3a9b32eca9d83de83de9050d # v6.3.0
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: 'v2.16.0' # pinned (F6); bump via dependabot
           install-only: true
@@ -368,7 +368,7 @@ jobs:
 
       - name: Install goreleaser (stable only)
         if: needs.verify.outputs.prerelease != 'true'
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598b3a9b32eca9d83de83de9050d # v6.3.0
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: 'v2.16.0' # pinned (F6); bump via dependabot
           install-only: true


### PR DESCRIPTION
## Summary

修正 `release.yml` 里 `goreleaser/goreleaser-action` 的 **伪造 SHA pin**（上游不存在的 commit），它每周让 Dependabot 的 `github_actions` 更新红，且是一个潜伏的发布流水线断点。

## Why / 背景

两处（line 165 安装、line 371 发布）都 pin 成：

```
goreleaser/goreleaser-action@9c156ee8a17a598b3a9b32eca9d83de83de9050d # v6.3.0
```

这个 SHA **上游不存在**。真实 v6.3.0 commit 是 `9c156ee8a17a598857849441385a2041ef570552`（仅前 15 个 hex 相同，尾部被改坏 —— 注意 `83de83de` 的重复模式，典型 copy-paste / 幻觉损坏）。

**两个影响：**

1. **Dependabot 每次 `github_actions in /.` 更新都红** —— updater 能拉到 action 的 refs（HTTP 200），但无法把这个 pinned commit 映射到任何 release，于是整个 job 报 `goreleaser/goreleaser-action: unknown_error`（runs `27481509658`、`27468997556` …）。这就是 Actions 列表里那个一直红的 Dependabot job（用户两次追问的那个）。
2. **潜伏的发布断点** —— `release.yml` 真正跑发布时，`@9c156ee8…9050d` 解析不到，goreleaser 的 install/release 两步都起不来。只因 release 不常跑，这个坏 SHA 一直没被运行时暴露。

## Refs

- 失败 run：`27481509658`（job `81230001116`）、`27468997556`
- 修复依据：`git ls-remote https://github.com/goreleaser/goreleaser-action v6.3.0` → `9c156ee8a17a598857849441385a2041ef570552`

## Risk / 兼容性

无行为变更 —— 仅把坏 SHA 改成同一 `# v6.3.0` 的真实 commit。修复后 Dependabot 即可正常给出 v6.4.0 升级 PR。

**额外核查（彻底性）**：已逐一验证 `.github/workflows/` 下**所有** `action@sha # vX` pin 是否对得上其声明 tag —— `goreleaser` 是**唯一**不匹配项（`actions/checkout`、`setup-go`、`docker/*`、`golangci-lint-action`、`qodana` 等全部 ✅；`codeql-action` 用 moving `v3` major tag + subpath，正常）。

## Test plan

- [x] 坏 SHA 全仓已清零（`grep` 0 命中）
- [x] 新 SHA = 真实 v6.3.0 commit（`git ls-remote` 核对）
- [x] `release.yml` YAML 解析通过
