### PR TITLE
refactor(archtest): LISTENER-DX-A52 doc scan 收窄至 Go-syntax forms，消除 Delegated 散文误撞 [#2118]

### DIFF
--- a/tools/archtest/listener_dx_test.go
+++ b/tools/archtest/listener_dx_test.go
@@ -11,11 +11,12 @@ package archtest
 //   - owner API signatures for RouteGroup.Register and auth.Mount stay aligned;
 //   - active docs/godoc must not show old listener APIs, the deleted auth.Route
 //     Delegated surface in its Go-syntax forms (`Delegated:` / `.Delegated` /
-//     `WithDelegatedMatcher`), or the legacy single-mux route registration
-//     surface. The bare English word "delegated" is NOT forbidden — "delegated
-//     ownership" is live ABAC vocabulary (see .claude/rules/gocell/tenancy.md);
-//     only the deleted Go surface is. TestListenerDXA52DocTermFixture is the
-//     RED/GREEN anti-vacuity proof for this distinction.
+//     `WithDelegatedMatcher` / the `Delegated bool` field declaration), or the
+//     legacy single-mux route registration surface. The bare English word
+//     "delegated" is NOT forbidden — "delegated ownership" is live ABAC
+//     vocabulary (see .claude/rules/gocell/tenancy.md); only the deleted Go
+//     surface is. TestListenerDXA52DocTermFixture is the RED/GREEN anti-vacuity
+//     proof for this distinction.
 //
 // Historical provenance remains allowed in docs/plans/**,
 // docs/reviews/**, docs/archive/**, and CHANGELOG.md.
@@ -25,6 +26,7 @@ import (
 	"go/ast"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -66,11 +68,14 @@ var activeDocForbiddenTerms = []string{
 	"WithInternalListener",
 	// The deleted auth.Route Delegated surface is matched by its Go-syntax forms
 	// only: the composite-literal key (auth.Route{Delegated: ...}), a field access
-	// (route.Delegated), and the deleted helper (WithDelegatedMatcher). We
-	// deliberately do NOT forbid the bare word "Delegated": "delegated ownership"
-	// is live ABAC vocabulary (.claude/rules/gocell/tenancy.md, ADR
-	// 202606121400-1348) and a case-sensitive substring false-positives on that
-	// prose. Anti-vacuity proof: TestListenerDXA52DocTermFixture.
+	// (route.Delegated), and the deleted helper (WithDelegatedMatcher). The field
+	// *declaration* form (`Delegated bool`) needs whitespace tolerance (a single
+	// space in hand-written docs, a gofmt tab in pasted structs) so it lives in
+	// listenerDXForbiddenDocPatterns, not here. We deliberately do NOT forbid the
+	// bare word "Delegated": "delegated ownership" is live ABAC vocabulary
+	// (.claude/rules/gocell/tenancy.md, ADR 202606121400-1348) and a
+	// case-sensitive substring false-positives on that prose. Anti-vacuity proof:
+	// TestListenerDXA52DocTermFixture.
 	"Delegated:",
 	".Delegated",
 	"WithDelegatedMatcher",
@@ -454,6 +459,21 @@ var listenerDXForbiddenDocTerms = append(
 	oldRouteSurfaceDocTerms...,
 )
 
+// listenerDXForbiddenDocPatterns matches deleted-surface Go-syntax forms that a
+// fixed substring cannot capture. Currently the auth.Route.Delegated *field
+// declaration* (`Delegated bool`): its inter-token whitespace varies (a single
+// space in hand-written docs, a gofmt tab in pasted struct code), so \s+ covers
+// both, while the trailing `bool` field-type token keeps it disjoint from
+// "delegated ownership" ABAC prose. Each entry carries a probe line it MUST
+// match so TestListenerDXA52DocTermFixture's anti-vacuity loop covers patterns
+// as well as substring terms.
+var listenerDXForbiddenDocPatterns = []struct {
+	re    *regexp.Regexp
+	probe string
+}{
+	{regexp.MustCompile(`\bDelegated\s+bool\b`), "\tDelegated bool // deleted auth.Route field"},
+}
+
 func listenerDXViolation(root, path string, line int, msg string) string {
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
@@ -462,15 +482,22 @@ func listenerDXViolation(root, path string, line int, msg string) string {
 	return fmt.Sprintf("%s:%d: %s", filepath.ToSlash(rel), line, msg)
 }
 
-// listenerDXLineForbiddenTerms returns every forbidden doc/godoc term contained
-// in line. It is the single per-line matcher shared by the .md, doc.go, and
-// Go-comment scanners, so the RED/GREEN guarantees in
-// TestListenerDXA52DocTermFixture apply uniformly across all three doc surfaces.
+// listenerDXLineForbiddenTerms returns every forbidden doc/godoc token contained
+// in line — both fixed substrings (listenerDXForbiddenDocTerms) and Go-syntax
+// regexps (listenerDXForbiddenDocPatterns). It is the single per-line matcher
+// shared by the .md, doc.go, and Go-comment scanners, so the RED/GREEN
+// guarantees in TestListenerDXA52DocTermFixture apply uniformly across all three
+// doc surfaces.
 func listenerDXLineForbiddenTerms(line string) []string {
 	var hits []string
 	for _, term := range listenerDXForbiddenDocTerms {
 		if strings.Contains(line, term) {
 			hits = append(hits, term)
+		}
+	}
+	for _, pat := range listenerDXForbiddenDocPatterns {
+		if m := pat.re.FindString(line); m != "" {
+			hits = append(hits, m)
 		}
 	}
 	return hits
@@ -493,6 +520,8 @@ func TestListenerDXA52DocTermFixture(t *testing.T) {
 		{"route field access", "if route.Delegated {"},
 		{"deleted matcher helper", "auth.WithDelegatedMatcher(jwtMatcher)"},
 		{"deleted listener option", "bootstrap.WithPrimaryListener(addr)"},
+		{"field declaration (space)", "\tDelegated bool // legacy auth.Route field"},
+		{"field declaration (gofmt tab)", "\tDelegated\tbool"},
 	}
 	for _, tc := range flagged {
 		t.Run("flagged/"+tc.name, func(t *testing.T) {
@@ -531,6 +560,20 @@ func TestListenerDXA52DocTermFixture(t *testing.T) {
 			probe := "doc text mentioning " + term + " inline"
 			assert.NotEmpty(t, listenerDXLineForbiddenTerms(probe),
 				"%s: forbidden term %q is unreachable via the shared matcher", ruleListenerDXA52, term)
+		}
+	})
+
+	// Same anti-vacuity for the regexp dimension: every pattern must carry a probe
+	// it actually matches via the shared matcher, so a dropped/broken pattern (or a
+	// pattern whose probe stops matching) fails loudly instead of silently passing.
+	t.Run("every_pattern_is_live", func(t *testing.T) {
+		require.NotEmpty(t, listenerDXForbiddenDocPatterns, "%s: forbidden pattern set is empty", ruleListenerDXA52)
+		for _, pat := range listenerDXForbiddenDocPatterns {
+			require.NotNil(t, pat.re, "%s: a nil forbidden pattern would never match", ruleListenerDXA52)
+			require.NotEmpty(t, pat.probe,
+				"%s: forbidden pattern %q has no anti-vacuity probe", ruleListenerDXA52, pat.re.String())
+			assert.NotEmpty(t, listenerDXLineForbiddenTerms(pat.probe),
+				"%s: forbidden pattern %q is unreachable via the shared matcher", ruleListenerDXA52, pat.re.String())
 		}
 	})
 }

--- a/tools/archtest/listener_dx_test.go
+++ b/tools/archtest/listener_dx_test.go
@@ -452,3 +452,60 @@ func listenerDXViolation(root, path string, line int, msg string) string {
 	}
 	return fmt.Sprintf("%s:%d: %s", filepath.ToSlash(rel), line, msg)
 }
+
+// listenerDXLineForbiddenTerms returns every forbidden doc/godoc term contained
+// in line. It is the single per-line matcher shared by the .md, doc.go, and
+// Go-comment scanners, so the RED/GREEN guarantees in
+// TestListenerDXA52DocTermFixture apply uniformly across all three doc surfaces.
+func listenerDXLineForbiddenTerms(line string) []string {
+	var hits []string
+	for _, term := range listenerDXForbiddenDocTerms() {
+		if strings.Contains(line, term) {
+			hits = append(hits, term)
+		}
+	}
+	return hits
+}
+
+// TestListenerDXA52DocTermFixture is the anti-vacuity guard for the active
+// docs/godoc term scan. It proves the matcher still catches the deleted
+// auth.Route Delegated surface in its Go-syntax forms, and does NOT regress to
+// false-positiving on legitimate "delegated ownership" ABAC prose (live
+// vocabulary in .claude/rules/gocell/tenancy.md and ADR 202606121400-1348).
+// Without this fixture, narrowing the term set could silently become vacuous.
+func TestListenerDXA52DocTermFixture(t *testing.T) {
+	// Deleted listener/route surface as it would actually appear in docs or
+	// godoc example code — each MUST stay flagged.
+	flagged := []struct {
+		name string
+		line string
+	}{
+		{"route composite-literal key", "reg.Mount(auth.Route{Delegated: true})"},
+		{"route field access", "if route.Delegated {"},
+		{"deleted matcher helper", "auth.WithDelegatedMatcher(jwtMatcher)"},
+		{"deleted listener option", "bootstrap.WithPrimaryListener(addr)"},
+	}
+	for _, tc := range flagged {
+		t.Run("flagged/"+tc.name, func(t *testing.T) {
+			assert.NotEmpty(t, listenerDXLineForbiddenTerms(tc.line),
+				"%s: deleted surface %q must be flagged", ruleListenerDXA52, tc.line)
+		})
+	}
+
+	// Legitimate live vocabulary that merely contains the English word
+	// "delegated" — each MUST pass. The bare-substring guard false-positived here.
+	allowed := []struct {
+		name string
+		line string
+	}{
+		{"ADR ownership heading", "- **Delegated ownership** (MDM, future): the resource has a *separate* owner"},
+		{"lowercase abac prose", "delegated ownership (owner != id, e.g. a device) uses subject.sub == resource.owner"},
+		{"owner attribute comparison", "`subject.sub == resource.owner`, where `resource.owner` is supplied by a PIP"},
+	}
+	for _, tc := range allowed {
+		t.Run("allowed/"+tc.name, func(t *testing.T) {
+			assert.Empty(t, listenerDXLineForbiddenTerms(tc.line),
+				"%s: legitimate prose %q must not be flagged", ruleListenerDXA52, tc.line)
+		})
+	}
+}

--- a/tools/archtest/listener_dx_test.go
+++ b/tools/archtest/listener_dx_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ruleListenerDXA52 labels assertion failures with the A52 batch id. The file's
+// registered invariant is LISTENER-DX-01 (see the INVARIANT header above); both
+// ids resolve to this file via `grep -rn`.
 const ruleListenerDXA52 = "LISTENER-DX-A52"
 
 var oldListenerAPIIdents = map[string]struct{}{
@@ -441,12 +444,15 @@ func activeGoCommentTermViolationsPass(p *Pass, file *ast.File) []string {
 	return violations
 }
 
-func listenerDXForbiddenDocTerms() []string {
-	terms := make([]string, 0, len(activeDocForbiddenTerms)+len(oldRouteSurfaceDocTerms))
-	terms = append(terms, activeDocForbiddenTerms...)
-	terms = append(terms, oldRouteSurfaceDocTerms...)
-	return terms
-}
+// listenerDXForbiddenDocTerms is the single combined term set forbidden in
+// active docs/godoc: the active-doc listener/route terms plus the legacy
+// single-mux route-surface terms. Computed once at package init. Do NOT scan
+// against the two source vars directly — listenerDXLineForbiddenTerms is the
+// sole per-line entry point, so the anti-vacuity fixture covers every term.
+var listenerDXForbiddenDocTerms = append(
+	append([]string{}, activeDocForbiddenTerms...),
+	oldRouteSurfaceDocTerms...,
+)
 
 func listenerDXViolation(root, path string, line int, msg string) string {
 	rel, err := filepath.Rel(root, path)
@@ -462,7 +468,7 @@ func listenerDXViolation(root, path string, line int, msg string) string {
 // TestListenerDXA52DocTermFixture apply uniformly across all three doc surfaces.
 func listenerDXLineForbiddenTerms(line string) []string {
 	var hits []string
-	for _, term := range listenerDXForbiddenDocTerms() {
+	for _, term := range listenerDXForbiddenDocTerms {
 		if strings.Contains(line, term) {
 			hits = append(hits, term)
 		}
@@ -511,4 +517,20 @@ func TestListenerDXA52DocTermFixture(t *testing.T) {
 				"%s: legitimate prose %q must not be flagged", ruleListenerDXA52, tc.line)
 		})
 	}
+
+	// Mechanical anti-vacuity over the WHOLE term set (not just the Delegated
+	// forms above): every forbidden term must be reachable via the shared matcher,
+	// and none may be empty (an empty term matches every line). Self-maintaining —
+	// a newly added term is auto-covered, so the matcher can never silently drop a
+	// source list or admit a vacuous term.
+	t.Run("every_term_is_live", func(t *testing.T) {
+		require.NotEmpty(t, listenerDXForbiddenDocTerms, "%s: forbidden term set is empty", ruleListenerDXA52)
+		for _, term := range listenerDXForbiddenDocTerms {
+			require.NotEmpty(t, term,
+				"%s: an empty forbidden term would flag every line", ruleListenerDXA52)
+			probe := "doc text mentioning " + term + " inline"
+			assert.NotEmpty(t, listenerDXLineForbiddenTerms(probe),
+				"%s: forbidden term %q is unreachable via the shared matcher", ruleListenerDXA52, term)
+		}
+	})
 }

--- a/tools/archtest/listener_dx_test.go
+++ b/tools/archtest/listener_dx_test.go
@@ -9,8 +9,13 @@ package archtest
 //   - production Go must not reintroduce deleted listener option APIs;
 //   - production Go must not reintroduce the old auth.Route Delegated surface;
 //   - owner API signatures for RouteGroup.Register and auth.Mount stay aligned;
-//   - active docs/godoc must not show old listener APIs, Delegated examples, or
-//     the legacy single-mux route registration surface.
+//   - active docs/godoc must not show old listener APIs, the deleted auth.Route
+//     Delegated surface in its Go-syntax forms (`Delegated:` / `.Delegated` /
+//     `WithDelegatedMatcher`), or the legacy single-mux route registration
+//     surface. The bare English word "delegated" is NOT forbidden — "delegated
+//     ownership" is live ABAC vocabulary (see .claude/rules/gocell/tenancy.md);
+//     only the deleted Go surface is. TestListenerDXA52DocTermFixture is the
+//     RED/GREEN anti-vacuity proof for this distinction.
 //
 // Historical provenance remains allowed in docs/plans/**,
 // docs/reviews/**, docs/archive/**, and CHANGELOG.md.
@@ -56,7 +61,16 @@ var activeDocForbiddenTerms = []string{
 	"WithHTTPInternalAddr",
 	"WithPrimaryListener",
 	"WithInternalListener",
-	"Delegated",
+	// The deleted auth.Route Delegated surface is matched by its Go-syntax forms
+	// only: the composite-literal key (auth.Route{Delegated: ...}), a field access
+	// (route.Delegated), and the deleted helper (WithDelegatedMatcher). We
+	// deliberately do NOT forbid the bare word "Delegated": "delegated ownership"
+	// is live ABAC vocabulary (.claude/rules/gocell/tenancy.md, ADR
+	// 202606121400-1348) and a case-sensitive substring false-positives on that
+	// prose. Anti-vacuity proof: TestListenerDXA52DocTermFixture.
+	"Delegated:",
+	".Delegated",
+	"WithDelegatedMatcher",
 }
 
 var productionForbiddenSurfaceTerms = []string{
@@ -383,15 +397,11 @@ func activeDocTermViolations(t *testing.T, root, path string) []string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Clean(path))
 	require.NoError(t, err)
-	lines := strings.Split(string(data), "\n")
 	var violations []string
-	terms := listenerDXForbiddenDocTerms()
-	for i, line := range lines {
-		for _, term := range terms {
-			if strings.Contains(line, term) {
-				violations = append(violations, listenerDXViolation(root, path, i+1,
-					fmt.Sprintf("active docs/godoc contains %q", term)))
-			}
+	for i, line := range strings.Split(string(data), "\n") {
+		for _, term := range listenerDXLineForbiddenTerms(line) {
+			violations = append(violations, listenerDXViolation(root, path, i+1,
+				fmt.Sprintf("active docs/godoc contains %q", term)))
 		}
 	}
 	return violations
@@ -407,14 +417,10 @@ func activeDocTermViolationsFromFile(p *Pass, file *ast.File) []string {
 	if err != nil {
 		return []string{fmt.Sprintf("%s:0: cannot read file: %v", rel, err)}
 	}
-	lines := strings.Split(string(data), "\n")
 	var violations []string
-	terms := listenerDXForbiddenDocTerms()
-	for i, line := range lines {
-		for _, term := range terms {
-			if strings.Contains(line, term) {
-				violations = append(violations, fmt.Sprintf("%s:%d: active docs/godoc contains %q", rel, i+1, term))
-			}
+	for i, line := range strings.Split(string(data), "\n") {
+		for _, term := range listenerDXLineForbiddenTerms(line) {
+			violations = append(violations, fmt.Sprintf("%s:%d: active docs/godoc contains %q", rel, i+1, term))
 		}
 	}
 	return violations
@@ -424,14 +430,11 @@ func activeDocTermViolationsFromFile(p *Pass, file *ast.File) []string {
 // for forbidden terms. Run parses with ParseComments so file.Comments is populated.
 func activeGoCommentTermViolationsPass(p *Pass, file *ast.File) []string {
 	var violations []string
-	terms := listenerDXForbiddenDocTerms()
 	for _, group := range file.Comments {
 		for _, comment := range group.List {
-			for _, term := range terms {
-				if strings.Contains(comment.Text, term) {
-					violations = append(violations, fmt.Sprintf("%s:%d: active godoc/comment contains %q",
-						p.Rel(file), p.Fset.Position(comment.Pos()).Line, term))
-				}
+			for _, term := range listenerDXLineForbiddenTerms(comment.Text) {
+				violations = append(violations, fmt.Sprintf("%s:%d: active godoc/comment contains %q",
+					p.Rel(file), p.Fset.Position(comment.Pos()).Line, term))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

修精 `LISTENER-DX-A52` archtest 的 active-docs `Delegated` 扫描：从**裸大小写敏感子串** `"Delegated"` 收窄到只匹配被删 surface 的 **Go 语法形态**（`Delegated:` / `.Delegated` / `WithDelegatedMatcher`），消除对合法 ABAC「delegated ownership」散文的误撞，并补该 guard 此前缺失的 anti-vacuity RED/GREEN fixture。

## Why / 背景

2026-06-14 full archtest 红：`TestListenerDXA52Guard/active_docs_do_not_show_deleted_listener_surface`。

根因：guard 的 `activeDocForbiddenTerms` 含裸 `"Delegated"`，以 `strings.Contains(line, "Delegated")` 扫所有 active `.md`/Go 注释，意在阻止已删除的 `auth.Route.Delegated` listener surface 复活。但它撞上 `docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md:477` 的 ABAC「Delegated ownership」——一个**当前存活**的所有权模型（`.claude/rules/gocell/tenancy.md:65` 以小写 `delegated ownership` 记录同概念）。即 guard 把「被删 Go 标识符」与「英文单词」混为一谈。已核实生产 Go 无任何 `Delegated`，被删 surface 真实不存在于代码。

不走「ADR 小写治标」：那是迁就坏 guard 的 Soft dodge（下个大写 "Delegated" 再撞、可被 re-casing 绕）。真正根因是 guard 载体过宽。被删 surface 在文档里的忠实形态是 Go 语法 token，散文 "delegated ownership" 永不产生这些 token——故收窄到语法形态既保留 anti-regression 覆盖、又消除误撞类。

**AI-robust 评级**：doc 扫描从 **Soft**（裸英文词子串，re-casing 可绕）升级到 **Medium**（Go 语法 token，散文不可表达）。并补 ai-robust.md 要求的 synthetic RED/GREEN fixture（`TestListenerDXA52DocTermFixture`）——此 guard 此前无 anti-vacuity，收窄匹配后该 fixture 防止其退化成「保护真空」。三个 doc 扫描器（`.md` / `doc.go` / Go 注释）统一走单一 `listenerDXLineForbiddenTerms` 逐行判定，fixture 的保证覆盖全部三个面。

## Refs

- Closes #2118（issue 修复方向 #2「adjust the guard with a clear rationale」，rationale 见上）
- ADR `docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md`（ABAC 两种 ownership 模型；ADR 文本未改）
- 无外部框架对标（archtest 内部治理逻辑收窄）；无契约扇出（未触 contract/generated/cell-slice）

## Risk / 兼容性

- 无 wire / 契约 / migration 影响；纯 archtest 治理逻辑。
- ADR `1348:477` **不改动**——「Delegated ownership」本就是合法 ABAC 词汇，收窄后 guard GREEN。
- 残留同根因盲区（OOS，已登记 backlog）：`forbiddenProductionSurfaceViolationsPass` 的 prod-Go **注释**扫描对 `Delegated` 同有裸散文误撞（latent，当前 0 命中）。本 PR 不一并改两处扫描路径以控风险面。
- issue #2118 原 label `cx-1`/`type-doc` 与本修法（archtest 收窄）不符，收尾重标 `type-refactor`/`area-tooling`。

## Test plan

- [x] `go build ./...` 本地通过
- [x] `go test -tags archtest -run TestListenerDXA52 ./tools/archtest/` 本地通过（parent + 新 fixture 全 GREEN；ADR 无改动）
- [x] `go vet -tags archtest ./tools/archtest/` 通过
- [x] `golangci-lint run --build-tags archtest ./tools/archtest/` 0 issues
- [x] TDD：fixture RED commit（旧裸 `Delegated` 下 `allowed/ADR ownership heading` FAIL）→ 收窄 GREEN commit
