### PR TITLE
feat(automation): add codex PR app dispatcher

### DIFF
--- a/.codex/skills/codex-pr-dispatcher/SKILL.md
+++ b/.codex/skills/codex-pr-dispatcher/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: codex-pr-dispatcher
+description: "主动唤醒本机 Codex PR app dispatcher，立即拉取一次 GitHub PR label 信息并按 ledger 去重派发。"
+argument-hint: ""
+allowed-tools: [Bash, Read]
+disable-model-invocation: true
+---
+
+# Codex PR Dispatcher
+
+Use this skill when the user asks to immediately poll PR review labels, wake the dispatcher, or manually trigger the Codex PR app dispatcher.
+
+Run:
+
+```bash
+bash hack/automation/codex-pr-app-dispatcher/trigger.sh
+```
+
+Then confirm from the router log:
+
+```bash
+tail -30 "${GOCELL_APP_ROUTER_HOME:-$HOME/.local/gocell-pr-app-router}/logs/router.log"
+```
+
+Expected signal:
+
+```text
+active poll trigger received
+```
+
+This only wakes one `poll_once`. It must not wait for `turn/completed`, inspect Codex session results, or move PR labels directly.
+

--- a/.codex/skills/codex-pr-dispatcher/SKILL.md
+++ b/.codex/skills/codex-pr-dispatcher/SKILL.md
@@ -16,7 +16,7 @@ Run:
 bash hack/automation/codex-pr-app-dispatcher/trigger.sh
 ```
 
-Then confirm from the router log:
+Then confirm from the router log when the dispatcher runs under LaunchAgent or another supervisor that redirects stdout:
 
 ```bash
 tail -30 "${GOCELL_APP_ROUTER_HOME:-$HOME/.local/gocell-pr-app-router}/logs/router.log"
@@ -27,5 +27,7 @@ Expected signal:
 ```text
 active poll trigger received
 ```
+
+When running `router.py` directly, confirm from that terminal's stdout instead.
 
 This only wakes one `poll_once`. It must not wait for `turn/completed`, inspect Codex session results, or move PR labels directly.

--- a/.codex/skills/codex-pr-dispatcher/SKILL.md
+++ b/.codex/skills/codex-pr-dispatcher/SKILL.md
@@ -29,4 +29,3 @@ active poll trigger received
 ```
 
 This only wakes one `poll_once`. It must not wait for `turn/completed`, inspect Codex session results, or move PR labels directly.
-

--- a/.codex/skills/codex-pr-dispatcher/SKILL.md
+++ b/.codex/skills/codex-pr-dispatcher/SKILL.md
@@ -1,22 +1,35 @@
 ---
 name: codex-pr-dispatcher
-description: "主动唤醒本机 Codex PR app dispatcher，立即拉取一次 GitHub PR label 信息并按 ledger 去重派发。"
-argument-hint: ""
+description: "管理本机 Codex PR app dispatcher 监控：start/stop/status/restart/logs/trigger，或主动唤醒立即拉取一次 GitHub PR label。"
+argument-hint: "[start|stop|restart|status|logs|trigger]"
 allowed-tools: [Bash, Read]
 disable-model-invocation: true
 ---
 
 # Codex PR Dispatcher
 
-Use this skill when the user asks to immediately poll PR review labels, wake the dispatcher, or manually trigger the Codex PR app dispatcher.
+Use this skill when the user asks to start, stop, restart, inspect, tail logs, or immediately poll the Codex PR app dispatcher.
 
-Run:
+Default action is `trigger` when the user only asks to wake or poll once.
+
+Commands:
+
+```bash
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh start
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh stop
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh restart
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh status
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh logs
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh trigger
+```
+
+For backward compatibility, this also works:
 
 ```bash
 bash hack/automation/codex-pr-app-dispatcher/trigger.sh
 ```
 
-Then confirm from the router log when the dispatcher runs under LaunchAgent or another supervisor that redirects stdout:
+Confirm from the router log when the dispatcher runs under LaunchAgent or another supervisor that redirects stdout:
 
 ```bash
 tail -30 "${GOCELL_APP_ROUTER_HOME:-$HOME/.local/gocell-pr-app-router}/logs/router.log"

--- a/hack/automation/codex-pr-app-dispatcher/README.md
+++ b/hack/automation/codex-pr-app-dispatcher/README.md
@@ -77,6 +77,14 @@ That means one GitHub PR information pull every 5 minutes. A normal empty poll p
 
 The long-lived router supports an immediate poll without restarting app-server. Send `SIGUSR1` to the running router process:
 
+From Codex, use the repository skill:
+
+```text
+codex-pr-dispatcher
+```
+
+From a shell, run:
+
 ```bash
 bash hack/automation/codex-pr-app-dispatcher/trigger.sh
 ```

--- a/hack/automation/codex-pr-app-dispatcher/README.md
+++ b/hack/automation/codex-pr-app-dispatcher/README.md
@@ -1,0 +1,352 @@
+# Codex PR App Dispatcher
+
+Fire-and-forget dispatcher for GoCell PR review labels.
+
+This dispatcher watches GitHub PR labels and starts one Codex app-server turn per eligible PR. It does not manage the Codex session after `turn/start` succeeds. The project-local `pr-review` skill owns review execution, PR comments, machine blocks, and label transitions.
+
+## Scope
+
+In scope:
+
+- Poll open PRs in `ghbvf/gocell`.
+- Dispatch same-repo, non-draft, allowlisted PRs.
+- Map labels to project skill commands:
+  - `pr-status/needs-review-again` -> `pr-review <PR#>`
+  - `pr-status/needs-check-fix` -> `pr-review <PR#> --check`
+- Start Codex through `codex app-server --stdio`.
+- Wait only for `thread/start` and `turn/start` JSON-RPC responses.
+- Write a local dispatch ledger after `turn/start` returns a `turn.id`.
+
+Out of scope:
+
+- Waiting for `turn/completed`.
+- Reading or summarizing Codex session output.
+- Checking PR postconditions after review.
+- Moving labels directly from the dispatcher.
+- Retrying failed Codex work after the turn has already started.
+
+## Runtime Model
+
+Production should run the dispatcher as a long-lived process. One dispatcher process owns one long-lived `codex app-server --stdio` child. Each poll can dispatch multiple PRs in parallel through that app-server.
+
+`--once` is for smoke tests and local debugging. When `--once` exits, it closes its app-server child, so any started turn depends on whether the app-server/session runtime has already taken ownership. Production should not depend on that timing.
+
+Required environment:
+
+```bash
+export GOCELL_APP_ROUTER_AUTHORS="alice bot"
+export GOCELL_APP_ROUTER_REPO_ROOT="/Users/shengming/Documents/code/gocell"
+export GOCELL_APP_ROUTER_HOME="${HOME}/.local/gocell-pr-app-router"
+export GOCELL_APP_ROUTER_INTERVAL=120
+export GOCELL_APP_ROUTER_REPO="ghbvf/gocell"
+export CODEX_BIN="codex"
+export GH_BIN="gh"
+```
+
+Run:
+
+```bash
+python3 hack/automation/codex-pr-app-dispatcher/router.py
+```
+
+Dry run:
+
+```bash
+python3 hack/automation/codex-pr-app-dispatcher/router.py --dry-run --once
+```
+
+## Flowchart
+
+```mermaid
+flowchart TD
+    A["Long-lived router process"] --> B["Start codex app-server --stdio"]
+    B --> C["JSON-RPC initialize"]
+    C --> D["Poll GitHub labels"]
+    D --> E["List PRs with pr-status/needs-review-again"]
+    D --> F["List PRs with pr-status/needs-check-fix"]
+    E --> G["Merge candidates by PR number"]
+    F --> G
+    G --> H{"Both trigger labels on same PR?"}
+    H -- "yes" --> H1["Skip and log conflict"]
+    H -- "no" --> I{"Gate passes?"}
+    I -- "no" --> I1["Skip and log reason"]
+    I -- "yes" --> J["Acquire per-PR local lock"]
+    J --> K{"Ledger has <PR>@<headSha>:kind?"}
+    K -- "yes" --> K1["Skip duplicate"]
+    K -- "no" --> L["Re-read live PR head SHA"]
+    L --> M{"Head unchanged?"}
+    M -- "no" --> M1["Skip stale candidate"]
+    M -- "yes" --> N["thread/start"]
+    N --> O["turn/start with pr-review skill item and command text"]
+    O --> P{"turn.id returned?"}
+    P -- "no" --> P1["Log dispatch failure; do not write ledger"]
+    P -- "yes" --> Q["Append dispatch key to ledger"]
+    Q --> R["Return immediately; do not wait for turn/completed"]
+    R --> S["pr-review skill posts comments and moves labels"]
+    H1 --> T["Next poll"]
+    I1 --> T
+    K1 --> T
+    M1 --> T
+    P1 --> T
+    S --> T
+    T --> D
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Router as router.py
+    participant GH as gh/GitHub
+    participant Ledger as local ledger
+    participant App as Codex app-server
+    participant Skill as pr-review skill
+    participant PR as GitHub PR
+
+    Router->>App: start codex app-server --stdio
+    Router->>App: initialize
+    App-->>Router: initialized
+
+    loop every GOCELL_APP_ROUTER_INTERVAL
+        Router->>GH: gh pr list --label pr-status/needs-review-again
+        GH-->>Router: review candidates
+        Router->>GH: gh pr list --label pr-status/needs-check-fix
+        GH-->>Router: check candidates
+        Router->>Router: merge candidates and reject conflicts
+
+        par per eligible PR
+            Router->>Router: acquire PR lock
+            Router->>Ledger: check <PR>@<headSha>:review|check
+            alt already dispatched
+                Router-->>Router: skip
+            else new key
+                Router->>GH: gh pr view <PR> --json headRefOid
+                GH-->>Router: live head SHA
+                alt head changed
+                    Router-->>Router: skip stale candidate
+                else head stable
+                    Router->>App: thread/start
+                    App-->>Router: thread.id
+                    Router->>App: turn/start(input: skill + text command)
+                    App-->>Router: turn.id
+                    Router->>Ledger: append dispatch key
+                    Router-->>Router: release lock and stop managing session
+                    App->>Skill: execute pr-review command
+                    Skill->>PR: post pm:pr-review comment
+                    Skill->>PR: apply label transition
+                end
+            end
+        end
+    end
+```
+
+## State Machine
+
+The dispatcher state machine is intentionally smaller than the review state machine. Once a turn has started, the dispatcher records dispatch and leaves completion to Codex plus `pr-review`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Polling: interval tick
+    Polling --> NoCandidates: no trigger labels
+    NoCandidates --> Idle
+
+    Polling --> CandidateFound: PR has exactly one trigger label
+    CandidateFound --> Skipped: cross-repo / draft / author denied
+    CandidateFound --> Conflict: both trigger labels present
+    CandidateFound --> Locked: PR lock unavailable
+    CandidateFound --> Duplicate: ledger key exists
+    CandidateFound --> Stale: live head SHA changed
+    CandidateFound --> Dispatching: gates pass
+
+    Conflict --> Idle
+    Skipped --> Idle
+    Locked --> Idle
+    Duplicate --> Idle
+    Stale --> Idle
+
+    Dispatching --> DispatchFailed: app-server/thread/start/turn/start error
+    Dispatching --> Dispatched: turn.id returned
+    DispatchFailed --> Idle
+    Dispatched --> LedgerRecorded: append key
+    LedgerRecorded --> FireAndForget: router stops tracking turn
+    FireAndForget --> Idle
+```
+
+PR labels move in the review-side workflow, not in this dispatcher:
+
+```mermaid
+stateDiagram-v2
+    [*] --> NeedsReviewAgain: pr-status/needs-review-again
+    [*] --> NeedsCheckFix: pr-status/needs-check-fix
+    NeedsReviewAgain --> ReviewTurnStarted: dispatcher starts pr-review <PR#>
+    NeedsCheckFix --> CheckTurnStarted: dispatcher starts pr-review <PR#> --check
+    ReviewTurnStarted --> Ready: pr-review approves and moves labels
+    ReviewTurnStarted --> ChangesRequested: pr-review posts findings and moves labels
+    CheckTurnStarted --> Ready: pr-review --check verifies fix
+    CheckTurnStarted --> NeedsCheckFix: pr-review --check still finds blocking issues
+```
+
+## De-Dupe
+
+Ledger path:
+
+```text
+$GOCELL_APP_ROUTER_HOME/state/dispatched
+```
+
+Ledger key:
+
+```text
+<PR>@<headSha>:review
+<PR>@<headSha>:check
+```
+
+The key is written only after `turn/start` returns a `turn.id`. If the app-server request fails, no key is written and a later poll may retry.
+
+If Codex starts successfully but fails later inside the turn, the dispatcher will not know. Recovery is manual:
+
+1. Push a new commit to change the PR head SHA, or
+2. Delete the specific ledger line and let the next poll dispatch again.
+
+## Gates
+
+Per candidate:
+
+- Same-repo only.
+- Draft PRs are skipped.
+- Author must be in `GOCELL_APP_ROUTER_AUTHORS`.
+- Same poll uses a per-PR lock.
+- A PR with both trigger labels is skipped and logged as an error condition.
+- Live head SHA is checked immediately before dispatch.
+
+## App-Server Calls
+
+The dispatcher uses JSON-RPC over stdio:
+
+1. `initialize`
+2. `thread/start`
+3. `turn/start`
+
+`turn/start.input` includes both:
+
+- a skill item pointing at `.codex/skills/pr-review/SKILL.md`
+- a text item requiring the exact project command:
+  - `pr-review <PR#>`
+  - `pr-review <PR#> --check`
+
+`turn/start` must be a request with an `id`, not a notification. The dispatcher treats a missing `turn.id` as a dispatch failure and does not write the ledger.
+
+## Monitoring Options
+
+There are three levels of monitoring. They should be implemented outside the dispatcher so the dispatcher can remain fire-and-forget.
+
+### Level 1: Current Operational Monitoring
+
+Use this today:
+
+- Router process status: LaunchAgent, system service, or process supervisor.
+- Router logs:
+  - `$GOCELL_APP_ROUTER_HOME/logs/router.log`
+  - `$GOCELL_APP_ROUTER_HOME/logs/router.err.log`
+- Dispatch ledger:
+  - `$GOCELL_APP_ROUTER_HOME/state/dispatched`
+- PR truth:
+  - GitHub comments with `<!-- pm:pr-review -->`
+  - PR labels such as `pr-status/ready`, `pr-review/approved`, `pr-review/changes-requested`
+- Codex session files under `$CODEX_HOME/sessions/...` when local session inspection is needed.
+
+This proves whether dispatch happened and whether the review-side skill changed the PR, but it is not a real-time progress UI.
+
+### Level 2: Codex App Visibility
+
+For real-time viewing inside Codex App, the cleanest approach is to make app-server-created threads visible/indexed in the app's normal thread list.
+
+Required capabilities:
+
+- Persist and expose `thread.id` and `turn.id` from each dispatch.
+- Add a local index mapping:
+
+```json
+{
+  "pr": 2121,
+  "headSha": "6905af86afca004195fdb307b797b916bb652458",
+  "kind": "check",
+  "threadId": "...",
+  "turnId": "...",
+  "dispatchedAt": "2026-06-14T10:13:00Z"
+}
+```
+
+- Provide a way for the operator to open that thread in Codex App.
+- Subscribe to or read app-server/session events for progress display.
+
+The dispatcher can write the index at dispatch time, but it still should not wait for completion or mutate PR labels.
+
+### Level 3: Separate Tauri App
+
+A Tauri app is useful only if Codex App cannot expose app-server threads directly or if the team wants a dedicated operations console.
+
+Suggested architecture:
+
+```mermaid
+flowchart LR
+    Router["router.py"] --> Index["dispatch index JSONL/SQLite"]
+    Router --> Logs["router logs"]
+    Codex["Codex sessions/events"] --> Collector["session collector"]
+    GH["GitHub PR API"] --> Collector
+    Index --> Collector
+    Logs --> Collector
+    Collector --> Store["SQLite state store"]
+    Store --> Tauri["Tauri desktop UI"]
+```
+
+The Tauri app should be read-mostly:
+
+- PR number, head SHA, kind, dispatch time.
+- Thread and turn ids.
+- Current inferred phase: queued, running, commented, labels-moved, failed, stale.
+- Links to GitHub PR/comment and Codex session/thread.
+- Manual actions:
+  - delete one ledger key for redispatch
+  - open PR
+  - open local session file
+  - copy thread/turn id
+
+It should not own the review workflow. The source of truth remains GitHub PR labels/comments plus Codex session events.
+
+## Monitoring State Model
+
+If monitoring is added, use a separate monitor state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Dispatched
+    Dispatched --> Running: session has turn activity
+    Dispatched --> Unknown: no session activity found after grace period
+    Running --> Commented: pm:pr-review comment appears on PR
+    Commented --> LabelsMoved: expected label transition observed
+    Running --> Failed: session terminal error observed
+    Unknown --> NeedsOperator: no progress after timeout
+    Failed --> NeedsOperator
+    LabelsMoved --> Done
+    Done --> [*]
+```
+
+This monitor may read sessions and GitHub, but it must not be merged into `router.py` unless the fire-and-forget contract is intentionally changed.
+
+## Test
+
+Offline selftest:
+
+```bash
+bash hack/automation/codex-pr-app-dispatcher/selftest.sh
+```
+
+Syntax check:
+
+```bash
+python3 -m py_compile hack/automation/codex-pr-app-dispatcher/router.py
+```
+

--- a/hack/automation/codex-pr-app-dispatcher/README.md
+++ b/hack/automation/codex-pr-app-dispatcher/README.md
@@ -37,7 +37,8 @@ Required environment:
 export GOCELL_APP_ROUTER_AUTHORS="alice bot"
 export GOCELL_APP_ROUTER_REPO_ROOT="/Users/shengming/Documents/code/gocell"
 export GOCELL_APP_ROUTER_HOME="${HOME}/.local/gocell-pr-app-router"
-export GOCELL_APP_ROUTER_INTERVAL=120
+export GOCELL_APP_ROUTER_INTERVAL=600
+export GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS=1800
 export GOCELL_APP_ROUTER_REPO="ghbvf/gocell"
 export CODEX_BIN="codex"
 export GH_BIN="gh"
@@ -68,10 +69,33 @@ Default:
 Recommended LaunchAgent value for normal operation:
 
 ```bash
-export GOCELL_APP_ROUTER_INTERVAL=300
+export GOCELL_APP_ROUTER_INTERVAL=600
 ```
 
-That means one GitHub PR information pull every 5 minutes. A normal empty poll performs two `gh pr list` calls, one for each trigger label. It performs extra `gh pr view` calls only for candidate PRs that pass initial discovery.
+That means one GitHub PR information pull every 10 minutes. A normal empty poll performs two `gh pr list` calls, one for each trigger label. It performs extra `gh pr view` calls only for candidate PRs that pass initial discovery.
+
+## Dispatch Cooldown
+
+The router has a PR-level cooldown per dispatch kind:
+
+```bash
+export GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS=1800
+```
+
+That means the same PR cannot start the same dispatch kind again within 30 minutes:
+
+- `review`: `pr-review <PR#>`
+- `check`: `pr-review <PR#> --check`
+
+The cooldown is keyed by `(PR, kind)`, not by head SHA. If a PR gets multiple new commits within 30 minutes while it still has `pr-status/needs-review-again`, the router skips repeated `review` dispatches and logs the remaining cooldown. `check` is independent so a later fix verification is not blocked by an earlier review dispatch.
+
+Successful dispatches are appended to:
+
+```text
+$GOCELL_APP_ROUTER_HOME/state/dispatch-events.jsonl
+```
+
+Set `GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS=0` only for offline tests or manual emergency redispatch.
 
 ## Active Poll Trigger
 
@@ -304,7 +328,13 @@ This proves whether dispatch happened and whether the review-side skill changed 
 
 ### Level 2: Codex App Visibility
 
-For real-time viewing inside Codex App, the cleanest approach is to make app-server-created threads visible/indexed in the app's normal thread list.
+Current limitation: a turn started by this dispatcher is not a normal Codex App-owned live thread. The dispatcher owns its own `codex app-server --stdio` transport and stops reading after `turn/start` returns. Codex app-server streams progress notifications such as `item/agentMessage/delta`, tool progress, and `turn/completed` only to the active transport connection. Opening the persisted session in Codex App may show a snapshot, but it is not guaranteed to be a live stream.
+
+For real-time viewing inside Codex App, do not rely on opening the stdio-created session directly. Use one of these designs:
+
+1. Keep the dispatcher fire-and-forget and build a read-only monitor from session JSONL + GitHub comments/labels.
+2. Replace the dispatch transport with a long-lived remote-control/proxy client that keeps reading app-server notifications and stores them in a dispatch index.
+3. Build a small Tauri or web console that reads the dispatch index/session stream and links back to GitHub/Codex sessions.
 
 Required capabilities:
 

--- a/hack/automation/codex-pr-app-dispatcher/README.md
+++ b/hack/automation/codex-pr-app-dispatcher/README.md
@@ -55,6 +55,40 @@ Dry run:
 python3 hack/automation/codex-pr-app-dispatcher/router.py --dry-run --once
 ```
 
+## Poll Interval
+
+The router polls once immediately after startup, then sleeps for `GOCELL_APP_ROUTER_INTERVAL` seconds between polls.
+
+Default:
+
+```text
+120
+```
+
+Recommended LaunchAgent value for normal operation:
+
+```bash
+export GOCELL_APP_ROUTER_INTERVAL=300
+```
+
+That means one GitHub PR information pull every 5 minutes. A normal empty poll performs two `gh pr list` calls, one for each trigger label. It performs extra `gh pr view` calls only for candidate PRs that pass initial discovery.
+
+## Active Poll Trigger
+
+The long-lived router supports an immediate poll without restarting app-server. Send `SIGUSR1` to the running router process:
+
+```bash
+bash hack/automation/codex-pr-app-dispatcher/trigger.sh
+```
+
+On macOS LaunchAgent installations this script runs:
+
+```bash
+launchctl kill SIGUSR1 gui/$(id -u)/com.ghbvf.gocell.codex-pr-app-dispatcher
+```
+
+The signal wakes the sleep loop, runs one normal `poll_once`, and then returns to the configured interval. It does not wait for Codex turns to complete and does not manage existing sessions.
+
 ## Flowchart
 
 ```mermaid
@@ -89,6 +123,7 @@ flowchart TD
     M1 --> T
     P1 --> T
     S --> T
+    U["SIGUSR1 active trigger"] --> D
     T --> D
 ```
 
@@ -349,4 +384,3 @@ Syntax check:
 ```bash
 python3 -m py_compile hack/automation/codex-pr-app-dispatcher/router.py
 ```
-

--- a/hack/automation/codex-pr-app-dispatcher/README.md
+++ b/hack/automation/codex-pr-app-dispatcher/README.md
@@ -39,6 +39,8 @@ export GOCELL_APP_ROUTER_REPO_ROOT="/Users/shengming/Documents/code/gocell"
 export GOCELL_APP_ROUTER_HOME="${HOME}/.local/gocell-pr-app-router"
 export GOCELL_APP_ROUTER_INTERVAL=600
 export GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS=1800
+export GOCELL_APP_ROUTER_GH_TIMEOUT=30
+export GOCELL_APP_ROUTER_APP_SERVER_REQUEST_TIMEOUT=30
 export GOCELL_APP_ROUTER_REPO="ghbvf/gocell"
 export CODEX_BIN="codex"
 export GH_BIN="gh"
@@ -286,7 +288,21 @@ Per candidate:
 - Author must be in `GOCELL_APP_ROUTER_AUTHORS`.
 - Same poll uses a per-PR lock.
 - A PR with both trigger labels is skipped and logged as an error condition.
-- Live head SHA is checked immediately before dispatch.
+- Live head SHA, draft state, and trigger labels are checked immediately before dispatch.
+- If the trigger label disappeared, the PR became draft, or the opposite trigger label appeared between list and dispatch, the PR is skipped.
+
+## Runtime Recovery
+
+External calls are bounded:
+
+```bash
+export GOCELL_APP_ROUTER_GH_TIMEOUT=30
+export GOCELL_APP_ROUTER_APP_SERVER_REQUEST_TIMEOUT=30
+```
+
+If `gh` hangs or fails, only that poll/candidate fails and the daemon keeps running. If app-server closes stdin/stdout, exits, or misses the request deadline before `turn/start` succeeds, the router tears down that app-server child, waits a short backoff, starts a fresh one, and continues polling.
+
+Per-PR lock directories with a missing or malformed `pid` file are treated as stale and reclaimed.
 
 ## App-Server Calls
 
@@ -317,6 +333,7 @@ Use this today:
 - Router logs:
   - `$GOCELL_APP_ROUTER_HOME/logs/router.log`
   - `$GOCELL_APP_ROUTER_HOME/logs/router.err.log`
+  - These paths are produced by LaunchAgent or another supervisor redirecting stdout/stderr. When running `router.py` directly, use that terminal output.
 - Dispatch ledger:
   - `$GOCELL_APP_ROUTER_HOME/state/dispatched`
 - PR truth:

--- a/hack/automation/codex-pr-app-dispatcher/README.md
+++ b/hack/automation/codex-pr-app-dispatcher/README.md
@@ -58,6 +58,32 @@ Dry run:
 python3 hack/automation/codex-pr-app-dispatcher/router.py --dry-run --once
 ```
 
+## Monitor Control
+
+When installed as a macOS LaunchAgent, use the repository control script:
+
+```bash
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh start
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh stop
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh restart
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh status
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh logs
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh trigger
+```
+
+The script defaults to:
+
+```text
+~/Library/LaunchAgents/com.ghbvf.gocell.codex-pr-app-dispatcher.plist
+```
+
+Override with:
+
+```bash
+export GOCELL_APP_ROUTER_LAUNCHD_LABEL=com.ghbvf.gocell.codex-pr-app-dispatcher
+export GOCELL_APP_ROUTER_LAUNCHD_PLIST="${HOME}/Library/LaunchAgents/com.ghbvf.gocell.codex-pr-app-dispatcher.plist"
+```
+
 ## Poll Interval
 
 The router polls once immediately after startup, then sleeps for `GOCELL_APP_ROUTER_INTERVAL` seconds between polls.
@@ -112,7 +138,7 @@ codex-pr-dispatcher
 From a shell, run:
 
 ```bash
-bash hack/automation/codex-pr-app-dispatcher/trigger.sh
+bash hack/automation/codex-pr-app-dispatcher/monitor.sh trigger
 ```
 
 On macOS LaunchAgent installations this script runs:

--- a/hack/automation/codex-pr-app-dispatcher/monitor.sh
+++ b/hack/automation/codex-pr-app-dispatcher/monitor.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# monitor.sh — manage the local Codex PR app dispatcher LaunchAgent.
+
+set -euo pipefail
+
+LABEL="${GOCELL_APP_ROUTER_LAUNCHD_LABEL:-com.ghbvf.gocell.codex-pr-app-dispatcher}"
+PLIST="${GOCELL_APP_ROUTER_LAUNCHD_PLIST:-${HOME}/Library/LaunchAgents/${LABEL}.plist}"
+ROUTER_HOME="${GOCELL_APP_ROUTER_HOME:-${HOME}/.local/gocell-pr-app-router}"
+DOMAIN="gui/$(id -u)"
+SERVICE="${DOMAIN}/${LABEL}"
+
+usage() {
+    cat >&2 <<EOF
+usage: $0 <start|stop|restart|status|trigger|logs>
+
+Environment overrides:
+  GOCELL_APP_ROUTER_LAUNCHD_LABEL   default: ${LABEL}
+  GOCELL_APP_ROUTER_LAUNCHD_PLIST   default: ${PLIST}
+  GOCELL_APP_ROUTER_HOME            default: ${ROUTER_HOME}
+EOF
+}
+
+require_launchctl() {
+    if ! command -v launchctl >/dev/null 2>&1; then
+        echo "monitor: launchctl is required on this host" >&2
+        exit 1
+    fi
+}
+
+require_plist() {
+    if [[ ! -f "${PLIST}" ]]; then
+        echo "monitor: LaunchAgent plist not found: ${PLIST}" >&2
+        exit 1
+    fi
+}
+
+start() {
+    require_launchctl
+    require_plist
+    launchctl bootstrap "${DOMAIN}" "${PLIST}" 2>/dev/null || true
+    launchctl kickstart -k "${SERVICE}"
+}
+
+stop() {
+    require_launchctl
+    require_plist
+    launchctl bootout "${DOMAIN}" "${PLIST}" 2>/dev/null || true
+}
+
+status() {
+    require_launchctl
+    launchctl print "${SERVICE}"
+}
+
+trigger() {
+    require_launchctl
+    launchctl kill SIGUSR1 "${SERVICE}"
+}
+
+logs() {
+    tail -n "${GOCELL_APP_ROUTER_LOG_LINES:-80}" \
+        "${ROUTER_HOME}/logs/router.log" \
+        "${ROUTER_HOME}/logs/router.err.log"
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+    start) start ;;
+    stop) stop ;;
+    restart) stop; start ;;
+    status) status ;;
+    trigger) trigger ;;
+    logs) logs ;;
+    *) usage; exit 64 ;;
+esac

--- a/hack/automation/codex-pr-app-dispatcher/router.py
+++ b/hack/automation/codex-pr-app-dispatcher/router.py
@@ -46,6 +46,7 @@ class Config:
     codex_bin: str
     gh_bin: str
     dry_run: bool
+    pr_cooldown_seconds: int
 
     @property
     def state_dir(self) -> Path:
@@ -62,6 +63,10 @@ class Config:
     @property
     def ledger_file(self) -> Path:
         return self.state_dir / "dispatched"
+
+    @property
+    def dispatch_events_file(self) -> Path:
+        return self.state_dir / "dispatch-events.jsonl"
 
     @property
     def skill_path(self) -> Path:
@@ -165,6 +170,16 @@ def load_config(args: argparse.Namespace) -> Config:
     if interval <= 0:
         fail("GOCELL_APP_ROUTER_INTERVAL must be positive")
 
+    cooldown_raw = os.environ.get("GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS", "1800")
+    try:
+        pr_cooldown_seconds = int(cooldown_raw)
+    except ValueError as exc:
+        raise SystemExit(
+            f"router: invalid GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS={cooldown_raw!r}"
+        ) from exc
+    if pr_cooldown_seconds < 0:
+        fail("GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS must be non-negative")
+
     cfg = Config(
         repo_root=repo_root,
         router_home=router_home,
@@ -174,12 +189,14 @@ def load_config(args: argparse.Namespace) -> Config:
         codex_bin=os.environ.get("CODEX_BIN", "codex"),
         gh_bin=os.environ.get("GH_BIN", "gh"),
         dry_run=args.dry_run,
+        pr_cooldown_seconds=pr_cooldown_seconds,
     )
     for path in (cfg.state_dir, cfg.locks_dir, cfg.logs_dir):
         path.mkdir(parents=True, exist_ok=True)
     if not cfg.skill_path.exists():
         fail(f"pr-review skill not found: {cfg.skill_path}")
     cfg.ledger_file.touch(exist_ok=True)
+    cfg.dispatch_events_file.touch(exist_ok=True)
     return cfg
 
 
@@ -271,6 +288,70 @@ def ledger_contains(cfg: Config, key: str) -> bool:
 def ledger_append(cfg: Config, key: str) -> None:
     with cfg.ledger_file.open("a", encoding="utf-8") as fh:
         fh.write(key + "\n")
+
+
+def iter_dispatch_events(cfg: Config) -> list[dict[str, Any]]:
+    try:
+        lines = cfg.dispatch_events_file.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        if not line:
+            continue
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(raw, dict):
+            events.append(raw)
+    return events
+
+
+def recent_dispatch_reason(cfg: Config, cand: Candidate, now: float) -> str | None:
+    if cfg.pr_cooldown_seconds <= 0:
+        return None
+    for event in reversed(iter_dispatch_events(cfg)):
+        if int(event.get("pr", 0)) != cand.number:
+            continue
+        if str(event.get("kind", "")) != cand.kind:
+            continue
+        try:
+            dispatched_at = float(event["dispatchedAtEpoch"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        age = now - dispatched_at
+        if age < cfg.pr_cooldown_seconds:
+            remaining = int(cfg.pr_cooldown_seconds - age)
+            return (
+                f"recent {cand.kind} dispatch within cooldown "
+                f"({remaining}s remaining, thread={event.get('threadId', '-')}, "
+                f"turn={event.get('turnId', '-')})"
+            )
+        return None
+    return None
+
+
+def dispatch_event_append(
+    cfg: Config,
+    cand: Candidate,
+    thread_id: str,
+    turn_id: str,
+    dispatched_at: float,
+) -> None:
+    event = {
+        "pr": cand.number,
+        "kind": cand.kind,
+        "headSha": cand.head_sha,
+        "key": cand.key,
+        "threadId": thread_id,
+        "turnId": turn_id,
+        "dispatchedAtEpoch": dispatched_at,
+        "dispatchedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(dispatched_at)),
+    }
+    with cfg.dispatch_events_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, separators=(",", ":"), sort_keys=True) + "\n")
 
 
 def pid_alive(pid: int) -> bool:
@@ -496,6 +577,11 @@ def dispatch_one(cfg: Config, client: AppServerClient | None, cand: Candidate) -
             log(f"PR #{cand.number}: skip - {skip}")
             return False
 
+        cooldown = recent_dispatch_reason(cfg, cand, time.time())
+        if cooldown:
+            log(f"PR #{cand.number}: skip - {cooldown}")
+            return False
+
         live_head = gh_live_head(cfg, cand.number)
         if live_head != cand.head_sha:
             log(
@@ -512,7 +598,9 @@ def dispatch_one(cfg: Config, client: AppServerClient | None, cand: Candidate) -
 
         log(f"PR #{cand.number}: dispatching {cand.kind} via Codex app-server ({cand.key})")
         thread_id, turn_id = start_pr_review_turn(cfg, client, cand)
+        dispatched_at = time.time()
         ledger_append(cfg, cand.key)
+        dispatch_event_append(cfg, cand, thread_id, turn_id, dispatched_at)
         log(
             f"PR #{cand.number}: dispatched {cand.kind}; "
             f"thread={thread_id} turn={turn_id}; ledger key recorded"

--- a/hack/automation/codex-pr-app-dispatcher/router.py
+++ b/hack/automation/codex-pr-app-dispatcher/router.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Fire-and-forget Codex app-server dispatcher for GoCell PR review labels.
+
+The dispatcher owns only GitHub discovery, local de-duplication, and starting
+Codex app-server turns. It deliberately does not wait for the turn to complete:
+the project-local pr-review skill is responsible for PR comments, machine
+blocks, and label transitions.
+
+Run this as a long-lived process for real dispatching. It owns one
+`codex app-server --stdio` child; exiting the dispatcher closes that app-server.
+The `--once` flag is only for dry runs, smoke tests, and stubbed selftests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REVIEW_LABEL = "pr-status/needs-review-again"
+CHECK_LABEL = "pr-status/needs-check-fix"
+REPO_DEFAULT = "ghbvf/gocell"
+
+
+class DispatchError(Exception):
+    """A recoverable per-PR dispatch failure."""
+
+
+@dataclass(frozen=True)
+class Config:
+    repo_root: Path
+    router_home: Path
+    repo: str
+    authors: frozenset[str]
+    interval: int
+    codex_bin: str
+    gh_bin: str
+    dry_run: bool
+
+    @property
+    def state_dir(self) -> Path:
+        return self.router_home / "state"
+
+    @property
+    def locks_dir(self) -> Path:
+        return self.router_home / "locks"
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.router_home / "logs"
+
+    @property
+    def ledger_file(self) -> Path:
+        return self.state_dir / "dispatched"
+
+    @property
+    def skill_path(self) -> Path:
+        return self.repo_root / ".codex" / "skills" / "pr-review" / "SKILL.md"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    number: int
+    head_sha: str
+    head_ref: str
+    author: str
+    is_cross_repository: bool
+    is_draft: bool
+    kind: str  # review | check
+
+    @property
+    def key(self) -> str:
+        return f"{self.number}@{self.head_sha}:{self.kind}"
+
+    @property
+    def skill_command(self) -> str:
+        if self.kind == "check":
+            return f"pr-review {self.number} --check"
+        return f"pr-review {self.number}"
+
+
+def log(message: str) -> None:
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    print(f"[{ts}] {message}", flush=True)
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(f"router: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run_json(args: list[str], *, input_text: str | None = None) -> Any:
+    proc = subprocess.run(
+        args,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise DispatchError(f"{' '.join(args)} failed ({proc.returncode}): {stderr}")
+    output = proc.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise DispatchError(f"{' '.join(args)} returned invalid JSON: {exc}") from exc
+
+
+def run_text(args: list[str]) -> str:
+    proc = subprocess.run(
+        args,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise DispatchError(f"{' '.join(args)} failed ({proc.returncode}): {stderr}")
+    return proc.stdout.strip()
+
+
+def parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() == "true"
+    return bool(value)
+
+
+def load_config(args: argparse.Namespace) -> Config:
+    repo_root = Path(
+        os.environ.get("GOCELL_APP_ROUTER_REPO_ROOT", Path.cwd())
+    ).resolve()
+    router_home = Path(
+        os.environ.get(
+            "GOCELL_APP_ROUTER_HOME",
+            str(Path.home() / ".local" / "gocell-pr-app-router"),
+        )
+    ).resolve()
+    authors_raw = os.environ.get("GOCELL_APP_ROUTER_AUTHORS", "")
+    authors = frozenset(a for a in authors_raw.split() if a)
+    if not authors:
+        fail("GOCELL_APP_ROUTER_AUTHORS is required")
+
+    interval_raw = os.environ.get("GOCELL_APP_ROUTER_INTERVAL", "120")
+    try:
+        interval = int(interval_raw)
+    except ValueError as exc:
+        raise SystemExit(f"router: invalid GOCELL_APP_ROUTER_INTERVAL={interval_raw!r}") from exc
+    if interval <= 0:
+        fail("GOCELL_APP_ROUTER_INTERVAL must be positive")
+
+    cfg = Config(
+        repo_root=repo_root,
+        router_home=router_home,
+        repo=os.environ.get("GOCELL_APP_ROUTER_REPO", REPO_DEFAULT),
+        authors=authors,
+        interval=interval,
+        codex_bin=os.environ.get("CODEX_BIN", "codex"),
+        gh_bin=os.environ.get("GH_BIN", "gh"),
+        dry_run=args.dry_run,
+    )
+    for path in (cfg.state_dir, cfg.locks_dir, cfg.logs_dir):
+        path.mkdir(parents=True, exist_ok=True)
+    if not cfg.skill_path.exists():
+        fail(f"pr-review skill not found: {cfg.skill_path}")
+    cfg.ledger_file.touch(exist_ok=True)
+    return cfg
+
+
+def gh_pr_list(cfg: Config, label: str) -> list[dict[str, Any]]:
+    fields = "number,headRefName,headRefOid,author,isCrossRepository,isDraft"
+    data = run_json(
+        [
+            cfg.gh_bin,
+            "pr",
+            "list",
+            "--repo",
+            cfg.repo,
+            "--state",
+            "open",
+            "--label",
+            label,
+            "--json",
+            fields,
+        ]
+    )
+    if not isinstance(data, list):
+        raise DispatchError(f"gh pr list for {label} returned non-list JSON")
+    return data
+
+
+def gh_live_head(cfg: Config, pr: int) -> str:
+    return run_text(
+        [
+            cfg.gh_bin,
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            cfg.repo,
+            "--json",
+            "headRefOid",
+            "--jq",
+            ".headRefOid",
+        ]
+    )
+
+
+def candidate_from_json(raw: dict[str, Any], kind: str) -> Candidate:
+    author = raw.get("author") or {}
+    login = author.get("login") if isinstance(author, dict) else ""
+    return Candidate(
+        number=int(raw["number"]),
+        head_sha=str(raw["headRefOid"]),
+        head_ref=str(raw.get("headRefName", "")),
+        author=str(login or ""),
+        is_cross_repository=parse_bool(raw.get("isCrossRepository", False)),
+        is_draft=parse_bool(raw.get("isDraft", False)),
+        kind=kind,
+    )
+
+
+def discover_candidates(cfg: Config) -> list[Candidate]:
+    review_raw = gh_pr_list(cfg, REVIEW_LABEL)
+    check_raw = gh_pr_list(cfg, CHECK_LABEL)
+
+    by_pr: dict[int, Candidate] = {}
+    conflicts: set[int] = set()
+    for raw in review_raw:
+        cand = candidate_from_json(raw, "review")
+        by_pr[cand.number] = cand
+    for raw in check_raw:
+        cand = candidate_from_json(raw, "check")
+        if cand.number in by_pr:
+            conflicts.add(cand.number)
+        by_pr[cand.number] = cand
+
+    out: list[Candidate] = []
+    for cand in sorted(by_pr.values(), key=lambda c: c.number):
+        if cand.number in conflicts:
+            log(f"PR #{cand.number}: skip - both review and check trigger labels are present")
+            continue
+        out.append(cand)
+    return out
+
+
+def ledger_contains(cfg: Config, key: str) -> bool:
+    try:
+        with cfg.ledger_file.open("r", encoding="utf-8") as fh:
+            return any(line.rstrip("\n") == key for line in fh)
+    except FileNotFoundError:
+        return False
+
+
+def ledger_append(cfg: Config, key: str) -> None:
+    with cfg.ledger_file.open("a", encoding="utf-8") as fh:
+        fh.write(key + "\n")
+
+
+def pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+class PrLock:
+    def __init__(self, cfg: Config, pr: int) -> None:
+        self.path = cfg.locks_dir / f"{pr}.lock"
+        self.pid_file = self.path / "pid"
+        self.acquired = False
+
+    def __enter__(self) -> "PrLock":
+        try:
+            self.path.mkdir()
+        except FileExistsError:
+            self._reclaim_if_stale()
+            try:
+                self.path.mkdir()
+            except FileExistsError:
+                return self
+        self.pid_file.write_text(str(os.getpid()), encoding="utf-8")
+        self.acquired = True
+        return self
+
+    def _reclaim_if_stale(self) -> None:
+        try:
+            raw = self.pid_file.read_text(encoding="utf-8").strip()
+            pid = int(raw)
+        except (FileNotFoundError, ValueError):
+            return
+        if not pid_alive(pid):
+            try:
+                self.pid_file.unlink()
+                self.path.rmdir()
+            except OSError:
+                pass
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        if not self.acquired:
+            return
+        try:
+            self.pid_file.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            self.path.rmdir()
+        except OSError:
+            pass
+
+
+class AppServerClient:
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+        self.proc: subprocess.Popen[str] | None = None
+        self.reader: Any = None
+        self.writer: Any = None
+        self.next_id = 1
+        self.lock = threading.Lock()
+
+    def __enter__(self) -> "AppServerClient":
+        self.proc = subprocess.Popen(
+            [self.cfg.codex_bin, "app-server", "--stdio"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            try:
+                self.proc.stdin.close()
+            except BrokenPipeError:
+                pass
+        if self.proc.poll() is None:
+            try:
+                self.proc.wait(timeout=2)
+                return
+            except subprocess.TimeoutExpired:
+                pass
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+            self.proc.wait(timeout=2)
+
+    def request(self, method: str, params: dict[str, Any]) -> Any:
+        if self.proc is None or self.proc.stdin is None or self.proc.stdout is None:
+            raise DispatchError("app-server is not running")
+        with self.lock:
+            req_id = self.next_id
+            self.next_id += 1
+            payload = {"id": req_id, "method": method, "params": params}
+            try:
+                self.proc.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+                self.proc.stdin.flush()
+            except BrokenPipeError as exc:
+                raise DispatchError("app-server closed stdin") from exc
+
+            while True:
+                line = self.proc.stdout.readline()
+                if line == "":
+                    stderr = ""
+                    if self.proc.stderr:
+                        stderr = self.proc.stderr.read().strip()
+                    raise DispatchError(f"app-server exited before {method} response: {stderr}")
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if msg.get("id") != req_id:
+                    continue
+                if "error" in msg:
+                    raise DispatchError(f"{method} failed: {msg['error']}")
+                return msg.get("result")
+
+    def notify(self, method: str, params: dict[str, Any]) -> None:
+        if self.proc is None or self.proc.stdin is None:
+            raise DispatchError("app-server is not running")
+        with self.lock:
+            payload = {"method": method, "params": params}
+            try:
+                self.proc.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+                self.proc.stdin.flush()
+            except BrokenPipeError as exc:
+                raise DispatchError("app-server closed stdin") from exc
+
+
+def initialize_app_server(client: AppServerClient) -> None:
+    client.request(
+        "initialize",
+        {
+            "clientInfo": {
+                "name": "gocell-pr-app-dispatcher",
+                "title": "GoCell PR App Dispatcher",
+                "version": "1",
+            },
+            "capabilities": {"experimentalApi": True},
+        },
+    )
+
+
+def start_pr_review_turn(cfg: Config, client: AppServerClient, cand: Candidate) -> tuple[str, str]:
+    prompt = (
+        "Use the attached local project skill `pr-review` exactly. "
+        f"Execute `{cand.skill_command}` for repository `{cfg.repo}`. "
+        "Complete the full skill workflow, including posting the pm:pr-review "
+        "comment, appending the machine block, and actually applying the label "
+        "transition required by the skill. Do not stop at a label-transition "
+        "suggestion. Do not use the built-in Codex review command."
+    )
+    thread_params = {
+        "cwd": str(cfg.repo_root),
+        "approvalPolicy": "never",
+        "sandbox": "workspace-write",
+        "runtimeWorkspaceRoots": [str(cfg.repo_root)],
+    }
+    turn_params_base = {
+        "approvalPolicy": "never",
+        "cwd": str(cfg.repo_root),
+        "runtimeWorkspaceRoots": [str(cfg.repo_root)],
+        "sandboxPolicy": {
+            "type": "workspaceWrite",
+            "networkAccess": True,
+            "writableRoots": [str(cfg.repo_root), str(cfg.router_home)],
+        },
+        "input": [
+            {
+                "type": "skill",
+                "name": "pr-review",
+                "path": str(cfg.skill_path),
+            },
+            {
+                "type": "text",
+                "text": prompt,
+                "text_elements": [],
+            },
+        ],
+    }
+    thread_result = client.request("thread/start", thread_params)
+    thread_id = ((thread_result or {}).get("thread") or {}).get("id")
+    if not thread_id:
+        raise DispatchError("thread/start response did not include thread.id")
+    turn_params = dict(turn_params_base)
+    turn_params["threadId"] = thread_id
+    turn_result = client.request("turn/start", turn_params)
+    turn_id = ((turn_result or {}).get("turn") or {}).get("id")
+    if not turn_id:
+        raise DispatchError("turn/start response did not include turn.id")
+    return thread_id, turn_id
+
+
+def should_skip(cfg: Config, cand: Candidate) -> str | None:
+    if cand.is_cross_repository:
+        return "cross-repository PR"
+    if cand.is_draft:
+        return "draft PR"
+    if cand.author not in cfg.authors:
+        return f"author {cand.author!r} not in allowlist"
+    if ledger_contains(cfg, cand.key):
+        return f"already dispatched key {cand.key}"
+    return None
+
+
+def dispatch_one(cfg: Config, client: AppServerClient | None, cand: Candidate) -> bool:
+    with PrLock(cfg, cand.number) as lock:
+        if not lock.acquired:
+            log(f"PR #{cand.number}: skip - locked")
+            return False
+
+        skip = should_skip(cfg, cand)
+        if skip:
+            log(f"PR #{cand.number}: skip - {skip}")
+            return False
+
+        live_head = gh_live_head(cfg, cand.number)
+        if live_head != cand.head_sha:
+            log(
+                f"PR #{cand.number}: skip - head moved "
+                f"(listed={cand.head_sha[:12]} live={live_head[:12]})"
+            )
+            return False
+
+        if cfg.dry_run:
+            log(f"PR #{cand.number}: dry-run would dispatch {cand.kind} ({cand.key})")
+            return False
+        if client is None:
+            raise DispatchError("app-server client is required outside dry-run")
+
+        log(f"PR #{cand.number}: dispatching {cand.kind} via Codex app-server ({cand.key})")
+        thread_id, turn_id = start_pr_review_turn(cfg, client, cand)
+        ledger_append(cfg, cand.key)
+        log(
+            f"PR #{cand.number}: dispatched {cand.kind}; "
+            f"thread={thread_id} turn={turn_id}; ledger key recorded"
+        )
+        return True
+
+
+def poll_once(cfg: Config, client: AppServerClient | None) -> int:
+    candidates = discover_candidates(cfg)
+    if not candidates:
+        log("poll_once: no candidates")
+        return 0
+
+    dispatched = 0
+    workers = len(candidates)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(dispatch_one, cfg, client, cand): cand for cand in candidates}
+        for future in concurrent.futures.as_completed(futures):
+            cand = futures[future]
+            try:
+                if future.result():
+                    dispatched += 1
+            except Exception as exc:  # noqa: BLE001 - daemon logs per-PR failures and continues.
+                log(f"PR #{cand.number}: dispatch failed - {exc}")
+    log(f"poll_once: done candidates={len(candidates)} dispatched={dispatched}")
+    return dispatched
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="run one poll and exit; for smoke tests only when not using --dry-run",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="do not start Codex or write ledger")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    cfg = load_config(args)
+    if cfg.dry_run:
+        poll_once(cfg, None)
+        return 0
+    with AppServerClient(cfg) as client:
+        initialize_app_server(client)
+        if args.once:
+            log(
+                "--once will exit after dispatch and close app-server; "
+                "production dispatch should run without --once"
+            )
+            poll_once(cfg, client)
+            return 0
+        while True:
+            try:
+                poll_once(cfg, client)
+            except Exception as exc:  # noqa: BLE001 - daemon should keep polling.
+                log(f"poll failed - {exc}")
+            time.sleep(cfg.interval)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    raise SystemExit(main(sys.argv[1:]))

--- a/hack/automation/codex-pr-app-dispatcher/router.py
+++ b/hack/automation/codex-pr-app-dispatcher/router.py
@@ -17,6 +17,7 @@ import argparse
 import concurrent.futures
 import json
 import os
+import select
 import signal
 import subprocess
 import sys
@@ -30,10 +31,15 @@ from typing import Any
 REVIEW_LABEL = "pr-status/needs-review-again"
 CHECK_LABEL = "pr-status/needs-check-fix"
 REPO_DEFAULT = "ghbvf/gocell"
+ACTIVE_CONFIG: Config | None = None
 
 
 class DispatchError(Exception):
     """A recoverable per-PR dispatch failure."""
+
+
+class AppServerUnavailable(DispatchError):
+    """The app-server connection must be recreated before dispatch can continue."""
 
 
 @dataclass(frozen=True)
@@ -47,6 +53,8 @@ class Config:
     gh_bin: str
     dry_run: bool
     pr_cooldown_seconds: int
+    gh_timeout: int
+    app_server_request_timeout: int
 
     @property
     def state_dir(self) -> Path:
@@ -104,15 +112,30 @@ def fail(message: str, code: int = 1) -> None:
     raise SystemExit(code)
 
 
+def parse_positive_int_env(name: str, default: str) -> int:
+    raw = os.environ.get(name, default)
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"router: invalid {name}={raw!r}") from exc
+    if value <= 0:
+        fail(f"{name} must be positive")
+    return value
+
+
 def run_json(args: list[str], *, input_text: str | None = None) -> Any:
-    proc = subprocess.run(
-        args,
-        input=input_text,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            args,
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=ACTIVE_CONFIG.gh_timeout if ACTIVE_CONFIG else None,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DispatchError(f"{' '.join(args)} timed out after {exc.timeout}s") from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip()
         raise DispatchError(f"{' '.join(args)} failed ({proc.returncode}): {stderr}")
@@ -126,13 +149,17 @@ def run_json(args: list[str], *, input_text: str | None = None) -> Any:
 
 
 def run_text(args: list[str]) -> str:
-    proc = subprocess.run(
-        args,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            args,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=ACTIVE_CONFIG.gh_timeout if ACTIVE_CONFIG else None,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DispatchError(f"{' '.join(args)} timed out after {exc.timeout}s") from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip()
         raise DispatchError(f"{' '.join(args)} failed ({proc.returncode}): {stderr}")
@@ -148,6 +175,7 @@ def parse_bool(value: Any) -> bool:
 
 
 def load_config(args: argparse.Namespace) -> Config:
+    global ACTIVE_CONFIG
     repo_root = Path(
         os.environ.get("GOCELL_APP_ROUTER_REPO_ROOT", Path.cwd())
     ).resolve()
@@ -180,6 +208,11 @@ def load_config(args: argparse.Namespace) -> Config:
     if pr_cooldown_seconds < 0:
         fail("GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS must be non-negative")
 
+    gh_timeout = parse_positive_int_env("GOCELL_APP_ROUTER_GH_TIMEOUT", "30")
+    app_server_request_timeout = parse_positive_int_env(
+        "GOCELL_APP_ROUTER_APP_SERVER_REQUEST_TIMEOUT", "30"
+    )
+
     cfg = Config(
         repo_root=repo_root,
         router_home=router_home,
@@ -190,6 +223,8 @@ def load_config(args: argparse.Namespace) -> Config:
         gh_bin=os.environ.get("GH_BIN", "gh"),
         dry_run=args.dry_run,
         pr_cooldown_seconds=pr_cooldown_seconds,
+        gh_timeout=gh_timeout,
+        app_server_request_timeout=app_server_request_timeout,
     )
     for path in (cfg.state_dir, cfg.locks_dir, cfg.logs_dir):
         path.mkdir(parents=True, exist_ok=True)
@@ -197,6 +232,7 @@ def load_config(args: argparse.Namespace) -> Config:
         fail(f"pr-review skill not found: {cfg.skill_path}")
     cfg.ledger_file.touch(exist_ok=True)
     cfg.dispatch_events_file.touch(exist_ok=True)
+    ACTIVE_CONFIG = cfg
     return cfg
 
 
@@ -237,6 +273,35 @@ def gh_live_head(cfg: Config, pr: int) -> str:
             ".headRefOid",
         ]
     )
+
+
+def gh_live_pr(cfg: Config, pr: int) -> dict[str, Any]:
+    data = run_json(
+        [
+            cfg.gh_bin,
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            cfg.repo,
+            "--json",
+            "headRefOid,isDraft,labels",
+        ]
+    )
+    if not isinstance(data, dict):
+        raise DispatchError(f"gh pr view for #{pr} returned non-object JSON")
+    return data
+
+
+def live_trigger_labels(raw: dict[str, Any]) -> set[str]:
+    labels = raw.get("labels", [])
+    out: set[str] = set()
+    if not isinstance(labels, list):
+        return out
+    for label in labels:
+        if isinstance(label, dict) and isinstance(label.get("name"), str):
+            out.add(label["name"])
+    return out
 
 
 def candidate_from_json(raw: dict[str, Any], kind: str) -> Candidate:
@@ -388,13 +453,20 @@ class PrLock:
             raw = self.pid_file.read_text(encoding="utf-8").strip()
             pid = int(raw)
         except (FileNotFoundError, ValueError):
+            self._remove_stale_dir()
             return
         if not pid_alive(pid):
-            try:
-                self.pid_file.unlink()
-                self.path.rmdir()
-            except OSError:
-                pass
+            self._remove_stale_dir()
+
+    def _remove_stale_dir(self) -> None:
+        try:
+            self.pid_file.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            self.path.rmdir()
+        except OSError:
+            pass
 
     def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
         if not self.acquired:
@@ -453,8 +525,10 @@ class AppServerClient:
 
     def request(self, method: str, params: dict[str, Any]) -> Any:
         if self.proc is None or self.proc.stdin is None or self.proc.stdout is None:
-            raise DispatchError("app-server is not running")
+            raise AppServerUnavailable("app-server is not running")
         with self.lock:
+            if self.proc.poll() is not None:
+                raise AppServerUnavailable("app-server process has exited")
             req_id = self.next_id
             self.next_id += 1
             payload = {"id": req_id, "method": method, "params": params}
@@ -462,12 +536,20 @@ class AppServerClient:
                 self.proc.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
                 self.proc.stdin.flush()
             except BrokenPipeError as exc:
-                raise DispatchError("app-server closed stdin") from exc
+                raise AppServerUnavailable("app-server closed stdin") from exc
 
             while True:
+                ready, _, _ = select.select(
+                    [self.proc.stdout], [], [], self.cfg.app_server_request_timeout
+                )
+                if not ready:
+                    raise AppServerUnavailable(
+                        f"app-server did not answer {method} within "
+                        f"{self.cfg.app_server_request_timeout}s"
+                    )
                 line = self.proc.stdout.readline()
                 if line == "":
-                    raise DispatchError(f"app-server exited before {method} response")
+                    raise AppServerUnavailable(f"app-server exited before {method} response")
                 try:
                     msg = json.loads(line)
                 except json.JSONDecodeError:
@@ -480,14 +562,14 @@ class AppServerClient:
 
     def notify(self, method: str, params: dict[str, Any]) -> None:
         if self.proc is None or self.proc.stdin is None:
-            raise DispatchError("app-server is not running")
+            raise AppServerUnavailable("app-server is not running")
         with self.lock:
             payload = {"method": method, "params": params}
             try:
                 self.proc.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
                 self.proc.stdin.flush()
             except BrokenPipeError as exc:
-                raise DispatchError("app-server closed stdin") from exc
+                raise AppServerUnavailable("app-server closed stdin") from exc
 
 
 def initialize_app_server(client: AppServerClient) -> None:
@@ -566,6 +648,24 @@ def should_skip(cfg: Config, cand: Candidate) -> str | None:
     return None
 
 
+def live_gate_skip(cfg: Config, cand: Candidate) -> str | None:
+    live = gh_live_pr(cfg, cand.number)
+    live_head = str(live.get("headRefOid", ""))
+    if live_head != cand.head_sha:
+        return f"head moved (listed={cand.head_sha[:12]} live={live_head[:12]})"
+    if parse_bool(live.get("isDraft", False)):
+        return "draft PR"
+
+    labels = live_trigger_labels(live)
+    want = REVIEW_LABEL if cand.kind == "review" else CHECK_LABEL
+    other = CHECK_LABEL if cand.kind == "review" else REVIEW_LABEL
+    if want not in labels:
+        return f"trigger label {want!r} no longer present"
+    if other in labels:
+        return "both review and check trigger labels are present"
+    return None
+
+
 def dispatch_one(cfg: Config, client: AppServerClient | None, cand: Candidate) -> bool:
     with PrLock(cfg, cand.number) as lock:
         if not lock.acquired:
@@ -582,12 +682,9 @@ def dispatch_one(cfg: Config, client: AppServerClient | None, cand: Candidate) -
             log(f"PR #{cand.number}: skip - {cooldown}")
             return False
 
-        live_head = gh_live_head(cfg, cand.number)
-        if live_head != cand.head_sha:
-            log(
-                f"PR #{cand.number}: skip - head moved "
-                f"(listed={cand.head_sha[:12]} live={live_head[:12]})"
-            )
+        live_skip = live_gate_skip(cfg, cand)
+        if live_skip:
+            log(f"PR #{cand.number}: skip - {live_skip}")
             return False
 
         if cfg.dry_run:
@@ -615,6 +712,7 @@ def poll_once(cfg: Config, client: AppServerClient | None) -> int:
         return 0
 
     dispatched = 0
+    app_server_error: AppServerUnavailable | None = None
     workers = len(candidates)
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(dispatch_one, cfg, client, cand): cand for cand in candidates}
@@ -623,9 +721,14 @@ def poll_once(cfg: Config, client: AppServerClient | None) -> int:
             try:
                 if future.result():
                     dispatched += 1
+            except AppServerUnavailable as exc:
+                log(f"PR #{cand.number}: dispatch failed - {exc}")
+                app_server_error = exc
             except Exception as exc:  # noqa: BLE001 - daemon logs per-PR failures and continues.
                 log(f"PR #{cand.number}: dispatch failed - {exc}")
     log(f"poll_once: done candidates={len(candidates)} dispatched={dispatched}")
+    if app_server_error is not None:
+        raise app_server_error
     return dispatched
 
 
@@ -658,25 +761,40 @@ def main(argv: list[str]) -> int:
     if cfg.dry_run:
         poll_once(cfg, None)
         return 0
-    with AppServerClient(cfg) as client:
-        initialize_app_server(client)
-        if args.once:
+
+    while True:
+        try:
+            with AppServerClient(cfg) as client:
+                initialize_app_server(client)
+                if args.once:
+                    log(
+                        "--once will exit after dispatch and close app-server; "
+                        "production dispatch should run without --once"
+                    )
+                    poll_once(cfg, client)
+                    return 0
+                run_poll_loop(cfg, client)
+        except AppServerUnavailable as exc:
             log(
-                "--once will exit after dispatch and close app-server; "
-                "production dispatch should run without --once"
+                "app-server unavailable; restarting after short backoff "
+                f"({exc})"
             )
+            time.sleep(2)
+
+
+def run_poll_loop(cfg: Config, client: AppServerClient) -> None:
+    wake_event = threading.Event()
+    install_wake_signal(wake_event)
+    while True:
+        try:
             poll_once(cfg, client)
-            return 0
-        wake_event = threading.Event()
-        install_wake_signal(wake_event)
-        while True:
-            try:
-                poll_once(cfg, client)
-            except Exception as exc:  # noqa: BLE001 - daemon should keep polling.
-                log(f"poll failed - {exc}")
-            if wake_event.wait(cfg.interval):
-                wake_event.clear()
-                log("active poll trigger received")
+        except AppServerUnavailable:
+            raise
+        except Exception as exc:  # noqa: BLE001 - daemon should keep polling.
+            log(f"poll failed - {exc}")
+        if wake_event.wait(cfg.interval):
+            wake_event.clear()
+            log("active poll trigger received")
 
 
 if __name__ == "__main__":

--- a/hack/automation/codex-pr-app-dispatcher/router.py
+++ b/hack/automation/codex-pr-app-dispatcher/router.py
@@ -342,7 +342,7 @@ class AppServerClient:
             [self.cfg.codex_bin, "app-server", "--stdio"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=None,
             text=True,
             bufsize=1,
         )
@@ -386,10 +386,7 @@ class AppServerClient:
             while True:
                 line = self.proc.stdout.readline()
                 if line == "":
-                    stderr = ""
-                    if self.proc.stderr:
-                        stderr = self.proc.stderr.read().strip()
-                    raise DispatchError(f"app-server exited before {method} response: {stderr}")
+                    raise DispatchError(f"app-server exited before {method} response")
                 try:
                     msg = json.loads(line)
                 except json.JSONDecodeError:

--- a/hack/automation/codex-pr-app-dispatcher/router.py
+++ b/hack/automation/codex-pr-app-dispatcher/router.py
@@ -541,6 +541,18 @@ def poll_once(cfg: Config, client: AppServerClient | None) -> int:
     return dispatched
 
 
+def install_wake_signal(wake_event: threading.Event) -> None:
+    if not hasattr(signal, "SIGUSR1"):
+        log("SIGUSR1 is unavailable on this platform; active poll trigger disabled")
+        return
+
+    def _wake(_signum: int, _frame: object) -> None:
+        wake_event.set()
+
+    signal.signal(signal.SIGUSR1, _wake)
+    log("active poll trigger installed: send SIGUSR1 to wake the router")
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -567,12 +579,16 @@ def main(argv: list[str]) -> int:
             )
             poll_once(cfg, client)
             return 0
+        wake_event = threading.Event()
+        install_wake_signal(wake_event)
         while True:
             try:
                 poll_once(cfg, client)
             except Exception as exc:  # noqa: BLE001 - daemon should keep polling.
                 log(f"poll failed - {exc}")
-            time.sleep(cfg.interval)
+            if wake_event.wait(cfg.interval):
+                wake_event.clear()
+                log("active poll trigger received")
 
 
 if __name__ == "__main__":

--- a/hack/automation/codex-pr-app-dispatcher/selftest.sh
+++ b/hack/automation/codex-pr-app-dispatcher/selftest.sh
@@ -84,7 +84,25 @@ if args[:2] == ["pr", "view"]:
     pr = args[2]
     with open(oid_file, encoding="utf-8") as fh:
         oid_map = json.load(fh)
-    print(oid_map.get(pr, ""))
+    if "--jq" in args:
+        print(oid_map.get(pr, ""))
+        sys.exit(0)
+    labels = []
+    is_draft = False
+    for src, label in (
+        (review_file, "pr-status/needs-review-again"),
+        (check_file, "pr-status/needs-check-fix"),
+    ):
+        with open(src, encoding="utf-8") as fh:
+            for item in json.load(fh):
+                if str(item.get("number")) == pr:
+                    labels.append({"name": label})
+                    is_draft = bool(item.get("isDraft", False))
+    print(json.dumps({
+        "headRefOid": oid_map.get(pr, ""),
+        "isDraft": is_draft,
+        "labels": labels,
+    }))
     sys.exit(0)
 
 print("unexpected gh args: " + " ".join(args), file=sys.stderr)
@@ -145,6 +163,8 @@ run_router() {
         GOCELL_APP_ROUTER_REPO="ghbvf/gocell" \
         GOCELL_APP_ROUTER_AUTHORS="alice bot" \
         GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS="${ROUTER_COOLDOWN:-1800}" \
+        GOCELL_APP_ROUTER_GH_TIMEOUT=5 \
+        GOCELL_APP_ROUTER_APP_SERVER_REQUEST_TIMEOUT=5 \
         CODEX_BIN="${STUB_BIN}/codex" \
         GH_BIN="${STUB_BIN}/gh" \
         GH_REVIEW_LIST_FILE="${REVIEW_LIST}" \
@@ -211,6 +231,13 @@ write_json "${OID_MAP}" '{"3":"'"${OID3}"'"}'
 run_router
 rm -f "${CODEX_FAIL_FLAG}"
 assert_not_contains "S4-no-ledger-on-failure" "${ROUTER_HOME}/state/dispatched" "3@${OID3}:review"
+
+echo ""
+echo "=== Scenario 4b: pidless lock is reclaimed ==="
+mkdir -p "${ROUTER_HOME}/locks/3.lock"
+run_router
+assert_line_count "S4b-one-extra-turn" "${CALLS_LOG}" "turn/start" "4"
+assert_contains "S4b-ledger-after-lock-reclaim" "${ROUTER_HOME}/state/dispatched" "3@${OID3}:review"
 
 echo ""
 echo "=== Scenario 5: conflicting labels skip dispatch ==="

--- a/hack/automation/codex-pr-app-dispatcher/selftest.sh
+++ b/hack/automation/codex-pr-app-dispatcher/selftest.sh
@@ -144,6 +144,9 @@ run_router() {
         GOCELL_APP_ROUTER_REPO_ROOT="${REPO_ROOT}" \
         GOCELL_APP_ROUTER_REPO="ghbvf/gocell" \
         GOCELL_APP_ROUTER_AUTHORS="alice bot" \
+        GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS="${ROUTER_COOLDOWN:-1800}" \
+        CODEX_BIN="${STUB_BIN}/codex" \
+        GH_BIN="${STUB_BIN}/gh" \
         GH_REVIEW_LIST_FILE="${REVIEW_LIST}" \
         GH_CHECK_LIST_FILE="${CHECK_LIST}" \
         GH_OID_MAP_FILE="${OID_MAP}" \
@@ -175,6 +178,8 @@ assert_contains "S1-check-command" "${CALLS_LOG}" "Execute \`pr-review 2 --check
 assert_contains "S1-label-transition" "${CALLS_LOG}" "actually applying the label transition"
 assert_contains "S1-ledger-review" "${ROUTER_HOME}/state/dispatched" "1@${OID1}:review"
 assert_contains "S1-ledger-check" "${ROUTER_HOME}/state/dispatched" "2@${OID2}:check"
+assert_contains "S1-events-review" "${ROUTER_HOME}/state/dispatch-events.jsonl" "\"key\":\"1@${OID1}:review\""
+assert_contains "S1-events-check" "${ROUTER_HOME}/state/dispatch-events.jsonl" "\"key\":\"2@${OID2}:check\""
 
 echo ""
 echo "=== Scenario 2: ledger de-dupes repeated poll ==="
@@ -182,13 +187,20 @@ run_router
 assert_line_count "S2-no-extra-turns" "${CALLS_LOG}" "turn/start" "2"
 
 echo ""
-echo "=== Scenario 3: changed head allows re-dispatch ==="
+echo "=== Scenario 3: changed head within cooldown skips re-dispatch ==="
 write_json "${REVIEW_LIST}" '[{"number":1,"headRefName":"feat/a","headRefOid":"'"${OID1B}"'","author":{"login":"alice"},"isCrossRepository":false,"isDraft":false}]'
 write_json "${CHECK_LIST}" '[]'
 write_json "${OID_MAP}" '{"1":"'"${OID1B}"'"}'
 run_router
-assert_line_count "S3-one-extra-turn" "${CALLS_LOG}" "turn/start" "3"
-assert_contains "S3-ledger-new-head" "${ROUTER_HOME}/state/dispatched" "1@${OID1B}:review"
+assert_line_count "S3-no-extra-turn-cooldown" "${CALLS_LOG}" "turn/start" "2"
+assert_not_contains "S3-no-ledger-new-head" "${ROUTER_HOME}/state/dispatched" "1@${OID1B}:review"
+
+echo ""
+echo "=== Scenario 3b: changed head can re-dispatch when cooldown disabled ==="
+ROUTER_COOLDOWN=0 run_router
+unset ROUTER_COOLDOWN
+assert_line_count "S3b-one-extra-turn" "${CALLS_LOG}" "turn/start" "3"
+assert_contains "S3b-ledger-new-head" "${ROUTER_HOME}/state/dispatched" "1@${OID1B}:review"
 
 echo ""
 echo "=== Scenario 4: app-server failure does not write ledger ==="

--- a/hack/automation/codex-pr-app-dispatcher/selftest.sh
+++ b/hack/automation/codex-pr-app-dispatcher/selftest.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# selftest.sh — offline regression tests for codex-pr-app-dispatcher/router.py.
+#
+# Stubs gh and codex. No network, no real app-server, no repository mutation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROUTER="${SCRIPT_DIR}/router.py"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "PASS [$1]"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "FAIL [$1]: $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_contains() {
+    local name="$1" file="$2" needle="$3"
+    if grep -qF "${needle}" "${file}"; then
+        pass "${name}"
+    else
+        fail "${name}" "expected ${file} to contain ${needle}"
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" file="$2" needle="$3"
+    if grep -qF "${needle}" "${file}"; then
+        fail "${name}" "expected ${file} not to contain ${needle}"
+    else
+        pass "${name}"
+    fi
+}
+
+assert_line_count() {
+    local name="$1" file="$2" pattern="$3" want="$4"
+    local got
+    got="$(grep -cF "${pattern}" "${file}" || true)"
+    if [[ "${got}" == "${want}" ]]; then
+        pass "${name}"
+    else
+        fail "${name}" "want ${want} matches for ${pattern}, got ${got}"
+    fi
+}
+
+WORKDIR="$(mktemp -d)"
+STUB_BIN="${WORKDIR}/bin"
+ROUTER_HOME="${WORKDIR}/router-home"
+CALLS_LOG="${WORKDIR}/calls.log"
+REVIEW_LIST="${WORKDIR}/review.json"
+CHECK_LIST="${WORKDIR}/check.json"
+OID_MAP="${WORKDIR}/oids.json"
+CODEX_FAIL_FLAG="${WORKDIR}/codex-fail"
+
+cleanup() { rm -rf "${WORKDIR}"; }
+trap cleanup EXIT
+
+mkdir -p "${STUB_BIN}" "${ROUTER_HOME}"
+: > "${CALLS_LOG}"
+echo '[]' > "${REVIEW_LIST}"
+echo '[]' > "${CHECK_LIST}"
+echo '{}' > "${OID_MAP}"
+
+cat > "${STUB_BIN}/gh" <<'GHSTUB'
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+review_file = os.environ["GH_REVIEW_LIST_FILE"]
+check_file = os.environ["GH_CHECK_LIST_FILE"]
+oid_file = os.environ["GH_OID_MAP_FILE"]
+
+if args[:2] == ["pr", "list"]:
+    label = args[args.index("--label") + 1]
+    src = review_file if label == "pr-status/needs-review-again" else check_file
+    with open(src, encoding="utf-8") as fh:
+        sys.stdout.write(fh.read())
+    sys.exit(0)
+
+if args[:2] == ["pr", "view"]:
+    pr = args[2]
+    with open(oid_file, encoding="utf-8") as fh:
+        oid_map = json.load(fh)
+    print(oid_map.get(pr, ""))
+    sys.exit(0)
+
+print("unexpected gh args: " + " ".join(args), file=sys.stderr)
+sys.exit(2)
+GHSTUB
+chmod +x "${STUB_BIN}/gh"
+
+cat > "${STUB_BIN}/codex" <<'CODEXSTUB'
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+calls_log = os.environ["CALLS_LOG"]
+fail_flag = os.environ["CODEX_FAIL_FLAG"]
+
+def log(line):
+    with open(calls_log, "a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+if args == ["app-server", "--stdio"]:
+    log("app-server start")
+    for line in sys.stdin:
+        msg = json.loads(line)
+        method = msg.get("method")
+        if method == "thread/start" and os.path.exists(fail_flag):
+            print(json.dumps({"id": msg["id"], "error": {"code": 1, "message": "forced failure"}}), flush=True)
+            continue
+        if method == "turn/start":
+            text = ""
+            for item in msg.get("params", {}).get("input", []):
+                if item.get("type") == "text":
+                    text = item.get("text", "")
+            log("turn/start " + text)
+            if "id" not in msg:
+                continue
+        if method == "thread/start":
+            print(json.dumps({"id": msg["id"], "result": {"thread": {"id": "thread-stub"}}}), flush=True)
+        elif method == "turn/start":
+            print(json.dumps({"id": msg["id"], "result": {"turn": {"id": "turn-stub"}}}), flush=True)
+        elif method == "initialize":
+            print(json.dumps({"id": msg["id"], "result": {"codexHome": "/tmp/codex", "platformFamily": "unix", "platformOs": "macos", "userAgent": "stub"}}), flush=True)
+        else:
+            print(json.dumps({"id": msg["id"], "result": {}}), flush=True)
+    sys.exit(0)
+
+print("unexpected codex args: " + " ".join(args), file=sys.stderr)
+sys.exit(2)
+CODEXSTUB
+chmod +x "${STUB_BIN}/codex"
+
+run_router() {
+    env \
+        PATH="${STUB_BIN}:${PATH}" \
+        GOCELL_APP_ROUTER_HOME="${ROUTER_HOME}" \
+        GOCELL_APP_ROUTER_REPO_ROOT="${REPO_ROOT}" \
+        GOCELL_APP_ROUTER_REPO="ghbvf/gocell" \
+        GOCELL_APP_ROUTER_AUTHORS="alice bot" \
+        GH_REVIEW_LIST_FILE="${REVIEW_LIST}" \
+        GH_CHECK_LIST_FILE="${CHECK_LIST}" \
+        GH_OID_MAP_FILE="${OID_MAP}" \
+        CALLS_LOG="${CALLS_LOG}" \
+        CODEX_FAIL_FLAG="${CODEX_FAIL_FLAG}" \
+        python3 "${ROUTER}" --once >/tmp/codex-pr-app-dispatcher-test.out 2>&1
+}
+
+write_json() {
+    local file="$1" json="$2"
+    printf '%s\n' "${json}" > "${file}"
+}
+
+OID1="aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+OID1B="bbbb1111bbbb2222cccc3333dddd4444eeee5555"
+OID2="ffff0000aaaa1111bbbb2222cccc3333dddd4444"
+OID3="cccc0000aaaa1111bbbb2222cccc3333dddd4444"
+OID4="dddd0000aaaa1111bbbb2222cccc3333dddd4444"
+
+echo ""
+echo "=== Scenario 1: review/check dispatch and ledger ==="
+write_json "${REVIEW_LIST}" '[{"number":1,"headRefName":"feat/a","headRefOid":"'"${OID1}"'","author":{"login":"alice"},"isCrossRepository":false,"isDraft":false}]'
+write_json "${CHECK_LIST}" '[{"number":2,"headRefName":"feat/b","headRefOid":"'"${OID2}"'","author":{"login":"bot"},"isCrossRepository":false,"isDraft":false}]'
+write_json "${OID_MAP}" '{"1":"'"${OID1}"'","2":"'"${OID2}"'"}'
+run_router
+assert_line_count "S1-two-turns" "${CALLS_LOG}" "turn/start" "2"
+assert_contains "S1-review-command" "${CALLS_LOG}" "Execute \`pr-review 1\`"
+assert_contains "S1-check-command" "${CALLS_LOG}" "Execute \`pr-review 2 --check\`"
+assert_contains "S1-label-transition" "${CALLS_LOG}" "actually applying the label transition"
+assert_contains "S1-ledger-review" "${ROUTER_HOME}/state/dispatched" "1@${OID1}:review"
+assert_contains "S1-ledger-check" "${ROUTER_HOME}/state/dispatched" "2@${OID2}:check"
+
+echo ""
+echo "=== Scenario 2: ledger de-dupes repeated poll ==="
+run_router
+assert_line_count "S2-no-extra-turns" "${CALLS_LOG}" "turn/start" "2"
+
+echo ""
+echo "=== Scenario 3: changed head allows re-dispatch ==="
+write_json "${REVIEW_LIST}" '[{"number":1,"headRefName":"feat/a","headRefOid":"'"${OID1B}"'","author":{"login":"alice"},"isCrossRepository":false,"isDraft":false}]'
+write_json "${CHECK_LIST}" '[]'
+write_json "${OID_MAP}" '{"1":"'"${OID1B}"'"}'
+run_router
+assert_line_count "S3-one-extra-turn" "${CALLS_LOG}" "turn/start" "3"
+assert_contains "S3-ledger-new-head" "${ROUTER_HOME}/state/dispatched" "1@${OID1B}:review"
+
+echo ""
+echo "=== Scenario 4: app-server failure does not write ledger ==="
+touch "${CODEX_FAIL_FLAG}"
+write_json "${REVIEW_LIST}" '[{"number":3,"headRefName":"feat/c","headRefOid":"'"${OID3}"'","author":{"login":"alice"},"isCrossRepository":false,"isDraft":false}]'
+write_json "${CHECK_LIST}" '[]'
+write_json "${OID_MAP}" '{"3":"'"${OID3}"'"}'
+run_router
+rm -f "${CODEX_FAIL_FLAG}"
+assert_not_contains "S4-no-ledger-on-failure" "${ROUTER_HOME}/state/dispatched" "3@${OID3}:review"
+
+echo ""
+echo "=== Scenario 5: conflicting labels skip dispatch ==="
+write_json "${REVIEW_LIST}" '[{"number":4,"headRefName":"feat/d","headRefOid":"'"${OID4}"'","author":{"login":"alice"},"isCrossRepository":false,"isDraft":false}]'
+write_json "${CHECK_LIST}" '[{"number":4,"headRefName":"feat/d","headRefOid":"'"${OID4}"'","author":{"login":"alice"},"isCrossRepository":false,"isDraft":false}]'
+write_json "${OID_MAP}" '{"4":"'"${OID4}"'"}'
+run_router
+assert_not_contains "S5-no-ledger-conflict" "${ROUTER_HOME}/state/dispatched" "4@${OID4}:review"
+assert_not_contains "S5-no-ledger-conflict-check" "${ROUTER_HOME}/state/dispatched" "4@${OID4}:check"
+
+echo ""
+echo "codex-pr-app-dispatcher selftest: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+[[ "${FAIL_COUNT}" -eq 0 ]]

--- a/hack/automation/codex-pr-app-dispatcher/trigger.sh
+++ b/hack/automation/codex-pr-app-dispatcher/trigger.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# trigger.sh — wake the long-lived Codex PR app dispatcher for an immediate poll.
+
+set -euo pipefail
+
+LABEL="${GOCELL_APP_ROUTER_LAUNCHD_LABEL:-com.ghbvf.gocell.codex-pr-app-dispatcher}"
+
+if ! command -v launchctl >/dev/null 2>&1; then
+    echo "trigger: launchctl is required on this host" >&2
+    exit 1
+fi
+
+launchctl kill SIGUSR1 "gui/$(id -u)/${LABEL}"
+

--- a/hack/automation/codex-pr-app-dispatcher/trigger.sh
+++ b/hack/automation/codex-pr-app-dispatcher/trigger.sh
@@ -3,11 +3,6 @@
 
 set -euo pipefail
 
-LABEL="${GOCELL_APP_ROUTER_LAUNCHD_LABEL:-com.ghbvf.gocell.codex-pr-app-dispatcher}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-if ! command -v launchctl >/dev/null 2>&1; then
-    echo "trigger: launchctl is required on this host" >&2
-    exit 1
-fi
-
-launchctl kill SIGUSR1 "gui/$(id -u)/${LABEL}"
+exec "${SCRIPT_DIR}/monitor.sh" trigger

--- a/hack/automation/codex-pr-app-dispatcher/trigger.sh
+++ b/hack/automation/codex-pr-app-dispatcher/trigger.sh
@@ -11,4 +11,3 @@ if ! command -v launchctl >/dev/null 2>&1; then
 fi
 
 launchctl kill SIGUSR1 "gui/$(id -u)/${LABEL}"
-


### PR DESCRIPTION
## Summary

Add a fire-and-forget Codex app-server PR dispatcher plus offline selftests and README documentation.

## Why / 背景

The existing automation path could not use the project-local `pr-review` skill correctly through `codex exec review`. This dispatcher keeps responsibility narrow: poll GitHub PR labels, start Codex app-server turns with the local `pr-review` skill, and stop managing the session after `turn/start` returns.

The README documents the full flow, sequence, dispatcher state machine, PR label state machine, and monitoring options including Codex App visibility and a possible separate Tauri console.

## Refs

Manual request in Codex thread. No issue.

## Risk / 兼容性

No runtime Go code or product contract changes. This adds an opt-in local automation script under `hack/automation/`. The dispatcher writes only to its configured local router home and starts Codex app-server turns; PR comments and label transitions remain owned by the project `pr-review` skill.

## Test plan

- [x] `python3 -m py_compile hack/automation/codex-pr-app-dispatcher/router.py`
- [x] `bash hack/automation/codex-pr-app-dispatcher/selftest.sh`
- [x] `bash hack/verify-shellcheck.sh`
- [ ] `go build ./...` not run; change is Python/Bash documentation automation only
- [ ] `go test ./修改的包/...` not run; no Go package changed
- [ ] `golangci-lint run ./...` not run; no Go package changed
