### PR TITLE
fix(ssobff): 拆分 walkthrough readyz/业务 HTTP client 超时消除 CI flake [#2122]

### DIFF
--- a/examples/ssobff/walkthrough_test.go
+++ b/examples/ssobff/walkthrough_test.go
@@ -54,7 +54,16 @@ const (
 	ssobffTestTenantID = "00000000-0000-0000-0000-000000000001"
 )
 
-var walkthroughHTTPClient = &http.Client{Timeout: testtime.D1s}
+// walkthroughReadyClient probes /readyz with a short, fail-fast timeout so a
+// slow probe retries within waitForWalkthroughReady's EventuallyLong deadline
+// instead of blocking past it.
+var walkthroughReadyClient = &http.Client{Timeout: testtime.D1s}
+
+// walkthroughHTTPClient drives business requests. Its timeout must exceed a
+// single argon2/bcrypt password hash + DB write under CI CPU contention —
+// create-user / login deliberately run a CPU-slow KDF, so the prior 1s budget
+// flaked (#2122). D10s covers the worst-case CI hashing latency.
+var walkthroughHTTPClient = &http.Client{Timeout: testtime.D10s}
 
 type capturedLogRecords struct {
 	mu      sync.Mutex
@@ -213,7 +222,7 @@ func waitForWalkthroughReady(t *testing.T, readyzURL string, done <-chan error) 
 		case <-tick.C:
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, readyzURL, http.NoBody)
 			require.NoError(t, err)
-			resp, err := walkthroughHTTPClient.Do(req)
+			resp, err := walkthroughReadyClient.Do(req)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
## Summary

拆分 ssobff walkthrough 集成测试的单一 HTTP client 为「readyz 快失败探活」+「业务请求」两个 client，消除 1s 超时对密码哈希端点过紧导致的 `corebundle` shard CI flake。

## Why / 背景

`examples/ssobff/walkthrough_test.go` 原先用单一 `walkthroughHTTPClient`（`testtime.D1s`）同时服务两类语义不同的请求：

- **readyz 探活**（`waitForWalkthroughReady`）：本应短超时、快失败、轮询重试。
- **业务请求**（`doWalkthroughRequest`，含 `setup/admin` / `users` / `sessions/login`）：这些端点走 argon2/bcrypt，**单个同步请求内部** CPU-slow。

二者耦合在同一过紧 1s 值上。CI（PR #2121 run `27494362274` job `81265565431`, shard `corebundle`）实测 `POST .../api/v1/access/users` → `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`，并级联 alice login 期望 201 实得 401（用户未落库）。readyz 已轮询至 200 才放行 → 非启动未就绪，慢的是单请求内的哈希。

**预期结果**：readyz 探活保持快失败、业务请求获得足够覆盖单次哈希的预算，消除间歇红。

## Refs

Closes #2122

## Risk / 兼容性

无。仅改集成测试代码（`//go:build integration`），无生产代码 / 契约 / wire / schema 变更，无消费方影响。两个 client 复用现有 `testtime` 常量（`D1s` / `D10s`），满足 `TEST-TIME-LITERAL-01`。

设计取舍（已在 issue 与 plan 评估）：
- **未做跨-example 共享 testutil**：已核实仅 ssobff 走密码哈希端点（`corebundlestarter`/`iotdevice`/`orderfulfillment` 不走、`smoke_test.go` 的 `D500ms` client 只探 readyz GET），共享抽象属过度设计。
- **未做 retry/auto-wait**：失败是单个同步 CPU 哈希请求内部慢（无可轮询对象），且 `create-user` 非幂等（首次超时但服务端可能已落库 → 重试得 409），retry 会把超时 flake 变成更糟的正确性 flake。

## Test plan

- [x] `go build ./...` 本地通过（`go vet -tags integration ./examples/ssobff/...` exit 0）
- [x] `go test ./修改的包/...` 本地通过（flake 仅 CI CPU 竞争下显形；本地编译+静态检查通过，真实证据见 CI `corebundle` shard 转绿）
- [x] `golangci-lint run ./...` 0 issues（默认 lane；integration-tagged 文件的 errcheck/gosec 为 pre-existing，非本 PR 引入，且 CI 不 lint 该 lane）
