### PR TITLE
fix(release): mint bare $TAG as GitHub Release marker post-#1565 [#2134]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,18 +247,23 @@ jobs:
           bash hack/verify-workspace.sh
 
       - name: Tag modules
-        # Root always tags at HEAD. Stable additionally tags every publishable
-        # satellite <reldir>/vX.Y.Z at the same (pin) commit; the tag set is
-        # derived from the same publishable enumeration as the golden guard, must
-        # contain the root tag, and is pushed --atomic so a partial set never
-        # lands. Snapshots tag root only.
+        # Snapshots tag the bare $TAG only. Stable mints the bare $TAG as the GitHub
+        # Release MARKER tag (NOT a module tag: post-#1565 no module sits at the repo
+        # root, so modrelease's --print-tag-paths correctly emits only the per-module
+        # <reldir>/vX.Y.Z library tags — see modrelease_test.go TestTagPaths). The
+        # workflow prepends the bare marker to those library tags and pushes the
+        # whole set --atomic so a partial set never lands. This restores the pre-#1565
+        # ref topology — a bare vX.Y.Z at the release commit alongside every library
+        # tag — which `gh release create --verify-tag`, goreleaser {{.Tag}}, and the
+        # verify-job resume sentinel all resolve against (k8s/gopls convention; #2134).
+        # Guarded by RELEASE-STABLE-MARKER-TAG-01.
         #
-        # Resume: the verify job's tag_exists check inspects only the ROOT tag.
-        # The --atomic push makes root + satellites land all-or-nothing, so the root
-        # tag normally reflects the whole set — but on a stable resume the next step
-        # ("Validate satellite tag set") additionally proves every satellite tag
-        # exists and peels to the same commit, fail-closed (F3), rather than
-        # trusting the atomic invariant alone.
+        # Resume: the verify job's tag_exists check inspects only the bare MARKER tag.
+        # The --atomic push makes marker + library tags land all-or-nothing, so the
+        # marker normally reflects the whole set — but on a stable resume the next step
+        # ("Validate satellite tag set") additionally proves every library tag exists
+        # and peels to the same commit, fail-closed (F3), rather than trusting the
+        # atomic invariant alone.
         if: needs.verify.outputs.tag_exists != 'true'
         run: |
           set -euo pipefail
@@ -269,18 +274,21 @@ jobs:
             git push origin "$TAG"
             exit 0
           fi
-          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
-          if [ "${#tags[@]}" -lt 2 ]; then
-            echo "::error::expected root + satellite tags from modrelease, got ${#tags[@]}."
+          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          if [ "${#module_tags[@]}" -lt 2 ]; then
+            echo "::error::modrelease produced ${#module_tags[@]} library tag(s) for $TAG; expected the full publishable module set."
             exit 1
           fi
-          case " ${tags[*]} " in
-            *" $TAG "*) ;;
-            *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
-          esac
+          # The bare $TAG is the GitHub Release MARKER tag, prepended to the per-module
+          # library tags. modrelease never emits it (post-#1565 no module sits at the
+          # repo root; see modrelease_test.go TestTagPaths), so the workflow mints it
+          # here — restoring the pre-#1565 ref topology that `gh release create
+          # --verify-tag`, goreleaser {{.Tag}}, and the verify-job resume sentinel
+          # resolve against (#2134, RELEASE-STABLE-MARKER-TAG-01).
+          tags=("$TAG" "${module_tags[@]}")
           # Operator-visible preview of the exact set about to be pushed.
           {
-            echo "### Release $TAG — tagging ${#tags[@]} modules"
+            echo "### Release $TAG — marker tag + ${#module_tags[@]} library module tags"
             printf -- '- %s\n' "${tags[@]}"
           } >>"$GITHUB_STEP_SUMMARY"
           # Push the now-verified pin commit to develop (only if one was created).
@@ -301,28 +309,29 @@ jobs:
           git push origin --atomic "${tags[@]}"
 
       - name: Validate satellite tag set (stable resume)
-        # On resume the root tag exists but the GitHub Release is missing. tag_exists
-        # is set off the ROOT tag only, so before creating the release prove the FULL
-        # synchronized set is present and consistent: every derived tag must exist
-        # and peel to the same commit as the root tag, else fail closed (F3). This
-        # catches a prior run that tagged root but lost the satellite --atomic push.
+        # On resume the bare marker tag exists but the GitHub Release is missing.
+        # tag_exists is set off the MARKER tag only, so before creating the release
+        # prove the FULL synchronized set is present and consistent: every library tag
+        # must exist and peel to the same commit as the marker, else fail closed (F3).
+        # This catches a prior run that tagged the marker but lost the library
+        # --atomic push.
         if: needs.verify.outputs.tag_exists == 'true' && needs.verify.outputs.prerelease != 'true'
         run: |
           set -euo pipefail
-          root_commit="$(git rev-parse "$TAG^{commit}")"
-          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
-          [ "${#tags[@]}" -ge 2 ] || { echo "::error::derived tag set too small (${#tags[@]})."; exit 1; }
+          marker_commit="$(git rev-parse "$TAG^{commit}")"
+          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          [ "${#module_tags[@]}" -ge 2 ] || { echo "::error::derived library tag set too small (${#module_tags[@]})."; exit 1; }
           missing=0
-          for tag in "${tags[@]}"; do
+          for tag in "${module_tags[@]}"; do
             if ! c="$(git rev-parse -q --verify "refs/tags/$tag^{commit}" 2>/dev/null)"; then
-              echo "::error::resume: satellite tag '$tag' is missing (root tagged but satellite set incomplete)."
+              echo "::error::resume: library tag '$tag' is missing (marker tagged but library set incomplete)."
               missing=1
-            elif [ "$c" != "$root_commit" ]; then
-              echo "::error::resume: tag '$tag' points at $c, not the root tag commit $root_commit."
+            elif [ "$c" != "$marker_commit" ]; then
+              echo "::error::resume: tag '$tag' points at $c, not the marker tag commit $marker_commit."
               missing=1
             fi
           done
-          [ "$missing" -eq 0 ] || { echo "::error::resume aborted: satellite tag set incomplete/inconsistent — delete the partial tags and re-dispatch." | tee -a "$GITHUB_STEP_SUMMARY"; exit 1; }
+          [ "$missing" -eq 0 ] || { echo "::error::resume aborted: library tag set incomplete/inconsistent — delete the partial tags and re-dispatch." | tee -a "$GITHUB_STEP_SUMMARY"; exit 1; }
 
       # ── goreleaser: CLI binary + docker (stable only) ──────────────────────
       # Runs after tags are pushed so goreleaser can resolve {{.Tag}} from the
@@ -384,6 +393,11 @@ jobs:
         if: needs.verify.outputs.prerelease != 'true'
         env:
           GOWORK: "off"
+          # Pin goreleaser's {{.Tag}} to the bare marker (#2134): the marker + N
+          # library tags share the release commit, so git-describe resolution is
+          # ambiguous; an unpinned {{.Tag}} could resolve to framework/vX.Y.Z and
+          # fail the cliVersion == $TAG smoke below (and corrupt ldflags / docker tag).
+          GORELEASER_CURRENT_TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
           goreleaser build --single-target --clean
@@ -423,6 +437,9 @@ jobs:
         if: needs.verify.outputs.prerelease != 'true'
         env:
           GOWORK: "off"
+          # Pin {{.Tag}} to the bare marker (#2134): deterministic across the marker +
+          # library tags that share the release commit (see pre-publish smoke step).
+          GORELEASER_CURRENT_TAG: ${{ needs.verify.outputs.tag }}
           GITHUB_TOKEN: ${{ github.token }}
         run: goreleaser release --clean
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,6 +275,9 @@ jobs:
             exit 0
           fi
           mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          # Sanity floor only — the EXACT publishable set is Hard golden-locked by
+          # PUBLISHABLE-MODULE-SET-01 (modrelease testdata/publishable.golden). The
+          # >=2 here just catches modrelease returning empty/garbage at release time.
           if [ "${#module_tags[@]}" -lt 2 ]; then
             echo "::error::modrelease produced ${#module_tags[@]} library tag(s) for $TAG; expected the full publishable module set."
             exit 1

--- a/tools/archtest/release_stable_marker_tag_test.go
+++ b/tools/archtest/release_stable_marker_tag_test.go
@@ -1,0 +1,294 @@
+//go:build archtest
+
+// INVARIANT: RELEASE-STABLE-MARKER-TAG-01
+package archtest
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// tagModulesStepName is the release.yml step that creates + pushes the stable
+// release's git tags. The marker invariant binds to THIS step's run block.
+const tagModulesStepName = "Tag modules"
+
+// markerMintRe matches the stable push-set construction that PREPENDS the bare
+// $TAG marker to the modrelease-derived library tags:
+//
+//	tags=("$TAG" "${module_tags[@]}")
+//
+// Whitespace-tolerant inside the array literal; the leading "$TAG" element is the
+// load-bearing assertion — the bare vX.Y.Z GitHub Release marker the workflow
+// must mint ITSELF, since modrelease emits only <subdir>/vX.Y.Z library tags
+// post-#1565. Comment-stripped command lines are matched (runCommandLines), so a
+// commented example cannot satisfy the guard.
+var markerMintRe = regexp.MustCompile(`tags=\(\s*"\$TAG"`)
+
+// staleAssertionMarker is the pre-#1565 broken guard's error string: it required
+// the bare $TAG to appear in modrelease's derived tag set, which always exits 1
+// post-#1565 (modrelease correctly never emits a bare tag). Its reappearance is a
+// regression — locked out alongside the positive marker-mint assertion.
+const staleAssertionMarker = "root tag $TAG missing from derived tag set"
+
+type markerWorkflow struct {
+	Jobs map[string]markerJob `yaml:"jobs"`
+}
+
+type markerJob struct {
+	Steps []markerStep `yaml:"steps"`
+}
+
+type markerStep struct {
+	Name string `yaml:"name"`
+	Run  string `yaml:"run"`
+}
+
+// TestReleaseStableMarkerTag enforces RELEASE-STABLE-MARKER-TAG-01 across every
+// .github/workflows/*.y{a,}ml: the stable "Tag modules" step must mint the bare
+// $TAG as the GitHub Release marker tag (prepended to the modrelease-derived
+// library tag set) and must NOT carry the pre-#1565 "$TAG must be in the derived
+// set" assertion.
+//
+// Why it matters: #1565 moved the core into framework/, so the repo root holds no
+// module and modrelease's TagPaths correctly emits only <subdir>/vX.Y.Z library
+// tags — never a bare vX.Y.Z (TestTagPaths, modrelease_test.go). But the bare
+// vX.Y.Z is the repo-level RELEASE MARKER that `gh release create --verify-tag`,
+// goreleaser {{.Tag}}, and the verify-job resume sentinel (`refs/tags/$tag`) all
+// resolve against (k8s/gopls convention: bare = release marker, <subdir>/vX = the
+// go-get module tag). The pre-#1565 workflow expected modrelease to emit that bare
+// tag and asserted its presence — so every stable release dispatch exits 1 (#2134,
+// latent: pre-release / develop CI never exercises this path). The fix restores
+// the pre-#1565 git ref topology by minting the marker in the workflow; this guard
+// keeps that mint from silently regressing.
+//
+// The deeper purpose is AI-robustness against the #1565→#2134 failure CLASS:
+// release semantics living in un-CI-guarded shell that drifts when the module
+// layout changes. modrelease's library + installable tag sets are already Hard
+// golden-locked (PUBLISHABLE-MODULE-SET-01 / publishable.golden, installable.golden);
+// the bare marker was the one release ref with no CI-time guard — its only check,
+// `gh release create --verify-tag`, fires at RELEASE time, not in the PR that
+// breaks it (the same latency that let #2134 ship green through #2125). This static
+// scan pulls the marker invariant into CI.
+//
+// AI-robust grade: Medium content-scan (machine-checkable; dropping the marker
+// mint or re-adding the stale assertion is a reviewer-visible diff that fails this
+// test). Hard is reachable but not low-cost — it would require modrelease to own
+// the full stable tag set (a `--print-stable-tags` golden the workflow consumes
+// verbatim), re-merging the marker into modrelease's surface (in tension with
+// "modrelease = pure module tags") + 3 files; tracked as a backlog Hard-ization
+// issue per ai-robust.md §审查要求.
+//
+// Blind spot (disclosed): this scans the run-block TEXT, not the executed git
+// pushes — it proves the marker is constructed into the push array, not that the
+// push succeeds. Push success / tag-set atomicity is covered at release time by
+// the --atomic push + `gh release create --verify-tag` + the "Validate satellite
+// tag set (stable resume)" step. A maintainer who renames "Tag modules" or moves
+// the mint to a new step evades the anti-vacuity tally loudly (require.Positive),
+// not silently.
+//
+// ref: kubernetes/kubernetes (bare vX.Y.Z = release marker; staging modules tag
+//
+//	in their own repos) — release-tag-as-marker convention.
+//
+// ref: golang.org/x/tools gopls (submodule tags as gopls/vX.Y.Z; bare vX.Y.Z is
+//
+//	the root/release tag) — sub-directory module tag shape.
+func TestReleaseStableMarkerTag(t *testing.T) {
+	root := findModuleRoot(t)
+	// Sanctioned content-scan façade (ai-robust.md §载体选择 rule 4: YAML rules use
+	// EachContentFile), matching the sibling archtest_ci_gowork_test.go which audits
+	// the same .github/workflows/*.{yml,yaml} set.
+	scope := DirsScope(root, []string{filepath.Join(".github", "workflows")})
+	total := 0
+	EachContentFile(t, scope, []string{".yml", ".yaml"}, func(_ *testing.T, fc ContentContext) {
+		matched, verr := validateReleaseStableMarkerTag(fc.Rel, fc.Bytes)
+		require.NoError(t, verr)
+		total += matched
+	})
+
+	// Anti-vacuity: the "Tag modules" step MUST be found in at least one real
+	// workflow, or the guard silently passes on everything (step renamed/removed or
+	// the stable tagging path restructured).
+	require.Positivef(t, total,
+		"RELEASE-STABLE-MARKER-TAG-01: no %q step found in any .github/workflows/*.yml — "+
+			"step renamed/removed or the stable release tagging path was restructured; the guard "+
+			"is vacuous. release.yml must tag the stable release in a %q step.",
+		tagModulesStepName, tagModulesStepName)
+}
+
+// validateReleaseStableMarkerTag checks one workflow file. Returns the number of
+// "Tag modules" steps found (for the caller's anti-vacuity tally) and the first
+// violation, if any. A workflow with no such step returns (0, nil) — not an error.
+func validateReleaseStableMarkerTag(name string, body []byte) (int, error) {
+	var wf markerWorkflow
+	if err := yaml.NewDecoder(bytes.NewReader(body)).Decode(&wf); err != nil {
+		return 0, fmt.Errorf("RELEASE-STABLE-MARKER-TAG-01: parse %s: %w", name, err)
+	}
+	matched := 0
+	for _, jobName := range markerJobNames(wf.Jobs) {
+		for _, step := range wf.Jobs[jobName].Steps {
+			if step.Name != tagModulesStepName {
+				continue
+			}
+			matched++
+			joined := strings.Join(runCommandLines(step.Run), "\n")
+			if !markerMintRe.MatchString(joined) {
+				return matched, fmt.Errorf("RELEASE-STABLE-MARKER-TAG-01: %s job %q step %q does not "+
+					"mint the bare $TAG release marker — expected the stable push set to PREPEND it: "+
+					"`tags=(\"$TAG\" \"${module_tags[@]}\")`. modrelease emits only <subdir>/vX.Y.Z "+
+					"library tags post-#1565, so the workflow must mint the bare vX.Y.Z marker itself; "+
+					"it is what `gh release create --verify-tag`, goreleaser {{.Tag}}, and the verify-job "+
+					"resume sentinel resolve against. See #2134.", name, jobName, markerStepLabel(step))
+			}
+			if strings.Contains(joined, staleAssertionMarker) {
+				return matched, fmt.Errorf("RELEASE-STABLE-MARKER-TAG-01: %s job %q step %q still "+
+					"contains the pre-#1565 assertion %q, which fails every stable release: modrelease "+
+					"correctly never emits a bare tag, so requiring it in the derived set always exits 1. "+
+					"Remove it; the bare $TAG is minted as the Release marker instead. See #2134.",
+					name, jobName, markerStepLabel(step), staleAssertionMarker)
+			}
+		}
+	}
+	return matched, nil
+}
+
+func markerStepLabel(s markerStep) string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return "(unnamed)"
+}
+
+// markerJobNames returns job ids in deterministic order so the first reported
+// violation is stable across runs.
+func markerJobNames(m map[string]markerJob) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// --- synthetic fixtures: red (must fail) ---------------------------------
+
+// TestReleaseStableMarkerTag_RejectsMissingMarker covers the broken shapes: the
+// stable step pushes only modrelease's library tags without minting the bare $TAG
+// marker, and/or carries the pre-#1565 stale assertion.
+func TestReleaseStableMarkerTag_RejectsMissingMarker(t *testing.T) {
+	cases := map[string]string{
+		// The current (pre-fix) shape: maps modrelease's tags, asserts the bare $TAG
+		// is among them, pushes only those — no marker minted.
+		"no-marker-with-stale-assertion": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          case " ${tags[*]} " in
+            *" $TAG "*) ;;
+            *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
+          esac
+          git push origin --atomic "${tags[@]}"
+`,
+		// Marker absent even without the stale assertion: still a violation.
+		"no-marker": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          git push origin --atomic "${module_tags[@]}"
+`,
+		// Marker minted correctly BUT the stale assertion re-introduced: the
+		// regression-lock must still fire (the broken case must never reappear).
+		"marker-but-stale-assertion": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          case " ${module_tags[*]} " in
+            *" $TAG "*) ;;
+            *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
+          esac
+          tags=("$TAG" "${module_tags[@]}")
+          git push origin --atomic "${tags[@]}"
+`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			matched, err := validateReleaseStableMarkerTag("fixture.yml", []byte(body))
+			require.Error(t, err, "missing marker / stale assertion (%s) must be rejected", name)
+			require.Positive(t, matched, "fixture must be recognized as a Tag modules step")
+		})
+	}
+}
+
+// --- synthetic fixtures: green (must pass + be non-vacuous) ---------------
+
+func TestReleaseStableMarkerTag_AcceptsMintedMarker(t *testing.T) {
+	cases := map[string]string{
+		"marker-prepended": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          if [ "${#module_tags[@]}" -lt 2 ]; then exit 1; fi
+          tags=("$TAG" "${module_tags[@]}")
+          for tag in "${tags[@]}"; do git tag -a "$tag" -m "Release $tag"; done
+          git push origin --atomic "${tags[@]}"
+`,
+		// Whitespace tolerance inside the array literal.
+		"marker-prepended-spaced": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          tags=(  "$TAG" "${module_tags[@]}")
+          git push origin --atomic "${tags[@]}"
+`,
+		// Anti-vacuity / F3-class false-positive guard: a commented historical
+		// mention of the stale assertion must NOT trip the regression-lock
+		// (comment-stripping in runCommandLines binds it to actual command text).
+		"commented-stale-assertion": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          # historical note: we used to assert "root tag $TAG missing from derived tag set"
+          tags=("$TAG" "${module_tags[@]}")
+          git push origin --atomic "${tags[@]}"
+`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			matched, err := validateReleaseStableMarkerTag("fixture.yml", []byte(body))
+			require.NoError(t, err)
+			require.Positive(t, matched, "fixture must be recognized as a Tag modules step (non-vacuous)")
+		})
+	}
+}
+
+// A workflow with no "Tag modules" step must return (0, nil): the guard is
+// per-file scoped and must not over-match other workflows.
+func TestReleaseStableMarkerTag_IgnoresUnrelatedWorkflow(t *testing.T) {
+	body := `jobs:
+  build:
+    steps:
+      - name: Build
+        run: go build ./...
+`
+	matched, err := validateReleaseStableMarkerTag("ci.yml", []byte(body))
+	require.NoError(t, err, "a workflow without a Tag modules step is out of scope")
+	require.Zero(t, matched, "no Tag modules step must not match")
+}

--- a/tools/archtest/release_stable_marker_tag_test.go
+++ b/tools/archtest/release_stable_marker_tag_test.go
@@ -83,16 +83,26 @@ type markerStep struct {
 // test). Hard is reachable but not low-cost — it would require modrelease to own
 // the full stable tag set (a `--print-stable-tags` golden the workflow consumes
 // verbatim), re-merging the marker into modrelease's surface (in tension with
-// "modrelease = pure module tags") + 3 files; tracked as a backlog Hard-ization
-// issue per ai-robust.md §审查要求.
+// "modrelease = pure module tags") + 3 files; tracked as backlog Hard-ization
+// issue #2141 per ai-robust.md §审查要求.
 //
-// Blind spot (disclosed): this scans the run-block TEXT, not the executed git
-// pushes — it proves the marker is constructed into the push array, not that the
-// push succeeds. Push success / tag-set atomicity is covered at release time by
-// the --atomic push + `gh release create --verify-tag` + the "Validate satellite
-// tag set (stable resume)" step. A maintainer who renames "Tag modules" or moves
-// the mint to a new step evades the anti-vacuity tally loudly (require.Positive),
-// not silently.
+// Blind spot (disclosed):
+//   - This scans the run-block TEXT, not the executed git pushes — it proves the
+//     marker is constructed into the push array, not that the push succeeds. Push
+//     success / tag-set atomicity is covered at release time by the --atomic push +
+//     `gh release create --verify-tag` + the "Validate satellite tag set (stable
+//     resume)" step.
+//   - markerMintRe binds to the `tags=("$TAG" …)` array-literal form. A maintainer
+//     who rewrites the push set into append form (e.g. `tags+=("$TAG")`) would evade
+//     the positive match; the Hard-ization (#2141) closes this by deriving the set
+//     from modrelease + golden instead of scanning shell text.
+//   - Only the "Tag modules" step is scanned; the sibling "Validate satellite tag
+//     set (stable resume)" step (which re-derives the library tags on resume) is NOT
+//     guarded here — its correctness rides on the same modrelease source plus the
+//     release-time peel-to-marker-commit check.
+//   - A maintainer who renames "Tag modules" or moves the mint to a new step evades
+//     the positive check but trips the anti-vacuity tally loudly (require.Positive),
+//     not silently.
 //
 // ref: kubernetes/kubernetes (bare vX.Y.Z = release marker; staging modules tag
 //


### PR DESCRIPTION
## Summary

stable release workflow 自铸裸 `$TAG` 作 GitHub Release marker（#1565 后 modrelease 只产子模块 tag），并补一条 Medium archtest 把该不变式拉进 CI。

## Why / 背景

`#1565` 把根模块拆进 `framework/` 后，仓库根目录**不再有 Go 模块**，`tools/modrelease` 的 `--print-tag-paths` 正确地只产 `<subdir>/vX.Y.Z` library tag（`framework/vX`、`adapters/postgres/vX` …），**不再产裸 `vX.Y.Z`**（`modrelease_test.go:263` 已断言）。

但 `release.yml` 的 stable「Tag modules」仍把「裸 `$TAG` 必含于 modrelease 派生集」当作必备校验（`case ... *" $TAG "*`），于是**任何 stable release dispatch 必然 `exit 1`**。pre-release / develop CI 不走该路径，故 #2125 CI 仍绿（latent）。**修复前 develop 不允许切 stable release。**

根因：裸 `vX.Y.Z` 是**仓库级 GitHub Release marker**（`gh release create --verify-tag`、goreleaser `{{.Tag}}`、verify-job resume sentinel `refs/tags/$tag` 都解析它），**不是模块 tag**。#1565 前根是模块、裸 tag 二者兼任；拆模块后该语义未同步进 workflow。

**根因 CLASS**：release 语义活在**无 CI 守卫的 shell** 里、随模块布局静默漂移。modrelease 侧 library/installable tag 集已是 Hard golden，唯独裸 marker 裸奔——唯一守卫 `--verify-tag` 在**发布期**才触发、CI 期抓不到（正是 #2134 经 #2125 绿灯混过的延迟同类）。故除 workflow 修复外，补一条 Medium archtest 把 marker 不变式拉进 CI，杜绝同种漂移复发。

## 改动

| 变更 | 文件 | 说明 |
|------|------|------|
| 删「`$TAG` 必含派生集」断言 + 自铸 marker | `release.yml` Tag modules (stable) | `tags=("$TAG" "${module_tags[@]}")` 前置裸 marker，与 library tags 一起 `--atomic` push；恢复 #1565 前 ref 拓扑 |
| resume 校验术语对齐 | `release.yml` Validate satellite tag set | `root`→`marker`，逻辑不变（library tag 各 peel 到 marker commit） |
| 锁定 goreleaser `{{.Tag}}` | `release.yml` 两个 goreleaser step | `GORELEASER_CURRENT_TAG=${{ needs.verify.outputs.tag }}`：marker + N library tag 同指 release commit 时 git-describe 有歧义，显式锁定避免 `cliVersion==$TAG` smoke 失真 |
| **新增 Medium archtest** | `tools/archtest/release_stable_marker_tag_test.go` | `RELEASE-STABLE-MARKER-TAG-01`：断言 stable 步铸 marker + 旧断言已除；anti-vacuity + RED/GREEN fixtures；镜像 `archtest_ci_gowork_test.go` 范本 |
| 不改 | `tools/modrelease/*` | `TagPaths` 已正确（只产 module tag），`:263`/golden 不动 |

**AI-robust**：marker 不变式由 Soft(发布期) → **Medium(CI scan)**；library/installable 已 Hard golden；完整 release ref 集全程 CI 守卫。Hard 化路径（modrelease 自有 `--print-stable-tags` + golden）成本非低，登记 backlog（见下）。

**对标**：k8s/gopls——裸 `vX.Y.Z` = Release marker，`<subdir>/vX.Y.Z` = go-get module tag。

## Refs

- Closes #2134
- Backlog（Hard 化）：见评论登记的 issue
- ref: kubernetes/kubernetes release-tag-as-marker
- ref: golang.org/x/tools gopls submodule tag

## Risk / 兼容性

- 仅改 CI release workflow + 新增 archtest，**无 wire / 无 runtime / 无 migration 影响**。
- modrelease 行为不变，外部 consumer `go get <module>@vX.Y.Z` 不受影响（library satellite tag 照常产）。
- 预存 2 个 `ci_pinning` archtest 失败（`TestGolangCILintVersionPinnedToPatch` / `TestDependabotCoversCIAndGolangCILint`）经核实在 **origin/develop 基线即失败**，与本 PR 无关、不在范围内。

## Test plan

- [x] `go test -tags archtest ./tools/archtest/ -run TestReleaseStableMarkerTag`：RED(未修)→GREEN(修后)
- [x] `actionlint .github/workflows/release.yml` → 0 issues
- [x] `go test ./tools/modrelease/...` → 绿（`:263`/golden 不动）
- [x] `go run ./tools/modrelease/cmd --version v1.2.3 --print-tag-paths` → 19 个 `<subdir>/v1.2.3`，无裸 `v1.2.3`
- [x] `golangci-lint run --build-tags archtest ./archtest/...`（tools 模块）→ 0 issues
- [x] bash dry-run：`tags=("$TAG" "${module_tags[@]}")` → 首元 = 裸 marker
