### PR TITLE
fix(archtest): 收敛 full archtest 暴露的 3 处 adapter/runtime 漂移 [#2116]

### DIFF
--- a/corecells/accesscore/internal/adapters/postgres/policy_repo.go
+++ b/corecells/accesscore/internal/adapters/postgres/policy_repo.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/ghbvf/gocell/corecells/accesscore/internal/abac"
@@ -14,6 +13,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/persistence"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	pgquery "github.com/ghbvf/gocell/framework/pkg/pgquery"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	"github.com/ghbvf/gocell/framework/pkg/validation"
 	"github.com/ghbvf/gocell/framework/runtime/state/cas"
@@ -25,9 +25,6 @@ var _ ports.PolicyRepository = (*PGPolicyRepo)(nil)
 // msgPolicyInvalidTenant is the single-source error message shared via the
 // ports package (#6). Unexported local alias for conciseness.
 const msgPolicyInvalidTenant = ports.MsgInvalidTenant
-
-// pgConflictCode is the PostgreSQL SQLSTATE for unique-constraint violations.
-const pgConflictCode = "23505"
 
 // PGPolicyRepo is the cell-private PostgreSQL implementation of
 // ports.PolicyRepository (#1346 PR-8, #1347 PR-9). It reads/writes the
@@ -167,8 +164,7 @@ func (r *PGPolicyRepo) Create(ctx context.Context, t tenant.TenantID, p *abac.Po
 	}
 	now := r.clock.Now()
 	if _, err := r.db.Exec(ctx, insertPolicySQL, string(t), p.ID, p.Name, p.Description, rulesJSON, now); err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgConflictCode {
+		if pgquery.IsUniqueViolation(err) {
 			return nil, errcode.New(errcode.KindConflict, errcode.ErrAuthPolicyDuplicate, "policy already exists",
 				errcode.WithInternal(errcode.InternalAttr("policy_id", p.ID)))
 		}

--- a/corecells/accesscore/slices/policymanage/service_integration_test.go
+++ b/corecells/accesscore/slices/policymanage/service_integration_test.go
@@ -96,8 +96,6 @@ func TestL2Atomicity_policymanage_RollsBack(t *testing.T) {
 		"Create error must wrap the injected outbox sentinel (proves Write was invoked)")
 
 	// Policy row must NOT exist (transaction rolled back atomically).
-	_, getErr := bundle.repo.ListByTenant(context.Background(), integTestTenant)
-	require.NoError(t, getErr)
 	// ListByTenant returns empty slice when tenant has no policies; the rollback
 	// proof is that we see zero rows, not a not-found error.
 	policies, listErr := bundle.repo.ListByTenant(context.Background(), integTestTenant)

--- a/corecells/accesscore/slices/policymanage/service_integration_test.go
+++ b/corecells/accesscore/slices/policymanage/service_integration_test.go
@@ -16,13 +16,11 @@ package policymanage
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	accesspgrepo "github.com/ghbvf/gocell/corecells/accesscore/internal/adapters/postgres"
@@ -31,7 +29,6 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/kernel/persistence"
 	"github.com/ghbvf/gocell/framework/pkg/ctxkeys"
-	"github.com/ghbvf/gocell/framework/pkg/migration"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
@@ -46,57 +43,26 @@ func integAdminCtx() context.Context {
 	return ctxkeys.WithTenantID(auth.TestContext("integ-admin", []string{"admin"}), integTestTenantStr)
 }
 
-func pgIntegMigrationsFS(t testing.TB) fs.FS {
-	t.Helper()
-	fsys, err := adapterpg.MigrationsFS()
-	require.NoError(t, err)
-	return fsys
-}
-
 type policyIntegBundle struct {
 	pool  *adapterpg.Pool
 	repo  *accesspgrepo.PGPolicyRepo
 	txMgr *adapterpg.TxManager
 }
 
-// setupPolicyIntegPG starts a testcontainers PostgreSQL instance, applies all
-// migrations, and returns a PGPolicyRepo + TxManager wired on the real pool.
+// setupPolicyIntegPG clones the package-shared pre-migrated template database
+// into a fresh per-test database and returns a PGPolicyRepo + TxManager wired on
+// the real pool. Pool + per-test DB lifecycle is owned by t.Cleanup registered
+// inside sharedPG.NewPerTestPool (see testmain_integration_test.go); the shared
+// container + migration are routed through the sanctioned pgclone funnel
+// (PG-TESTCONTAINER-FUNNEL-01) rather than a per-test tcpostgres.Run.
 func setupPolicyIntegPG(t *testing.T) policyIntegBundle {
 	t.Helper()
 	globaltestutil.RequireDocker(t)
 
-	ctx := context.Background()
-	container, err := tcpostgres.Run(
-		ctx, globaltestutil.PostgresImage,
-		tcpostgres.WithDatabase("test"),
-		tcpostgres.WithUsername("test"),
-		tcpostgres.WithPassword("test"),
-		tcpostgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err, "start postgres container")
-
-	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: connStr})
-	require.NoError(t, err)
-
-	migrator, err := adapterpg.NewMigrator(pool, pgIntegMigrationsFS(t), migration.PlatformNamespace)
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up(ctx), "migrations must apply cleanly")
-
+	pool := sharedPG.NewPerTestPool(t)
 	txMgr := adapterpg.NewTxManager(pool)
 	repo, err := accesspgrepo.NewPGPolicyRepo(pool.DB(), txMgr, clock.Real())
 	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		if cerr := pool.Close(ctx); cerr != nil {
-			t.Logf("WARN: pool close: %v", cerr)
-		}
-		if cerr := container.Terminate(ctx); cerr != nil {
-			t.Logf("WARN: terminate container: %v", cerr)
-		}
-	})
 
 	return policyIntegBundle{pool: pool, repo: repo, txMgr: txMgr}
 }

--- a/corecells/accesscore/slices/policymanage/testmain_integration_test.go
+++ b/corecells/accesscore/slices/policymanage/testmain_integration_test.go
@@ -1,0 +1,25 @@
+//go:build integration
+
+package policymanage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ghbvf/gocell/adapters/postgres/pgtest"
+)
+
+// Package-shared PostgreSQL lifecycle: one container per test binary; per-test
+// isolation via `CREATE DATABASE <test> TEMPLATE <pre-migrated>` clone. The
+// template is migrated once with the full platform migration set (the same set
+// the per-test setup applied manually before #2116). See adapters/postgres/pgtest
+// for the mechanics; routing through this funnel satisfies PG-TESTCONTAINER-FUNNEL-01.
+var sharedPG = pgtest.New("gocell_policymanage_repo_test_template")
+
+// TestMain owns shared-container teardown. Runs once per test binary after all
+// tests in the package complete.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	sharedPG.Shutdown()
+	os.Exit(code)
+}

--- a/tools/archtest/outbox_subscriber_settlement_notify_test.go
+++ b/tools/archtest/outbox_subscriber_settlement_notify_test.go
@@ -69,7 +69,14 @@ func scanOutboxSubscriberSettlement(t *testing.T) (implPkgSet, notifyPkgSet map[
 	t.Helper()
 	root := findModuleRoot(t)
 	prodPatterns := prodscan.Patterns(root)
-	ifacePatterns := append([]string{"./framework/kernel/outbox/..."}, prodPatterns...)
+	// prodscan.Patterns prunes multi-member parents (adapters/ holds per-adapter
+	// go.work members post-#1565), so the terminal Subscriber impls in
+	// adapters/rabbitmq + adapters/mqtt would be invisible to this scan — leaving
+	// the rule vacuous for everything but the in-process eventbus. Hardcode the
+	// satellite parent prefix (the sanctioned opt-in: the typed loader expands it
+	// via workspace.ExpandParentPrefix, kept honest by SATELLITE-PARENT-PREFIX-SCAN-01;
+	// mirrors health_aggregation_test.go) so all three terminal packages are scanned.
+	ifacePatterns := append([]string{"./framework/kernel/outbox/...", "./adapters/..."}, prodPatterns...)
 
 	var subIface *types.Interface
 	var allPkgs []*types.Package
@@ -119,7 +126,7 @@ func scanOutboxSubscriberSettlement(t *testing.T) (implPkgSet, notifyPkgSet map[
 	require.NotEmpty(t, implSet,
 		"OUTBOX-SUBSCRIBER-SETTLEMENT-NOTIFY-01: zero outbox.Subscriber implementations collected — "+
 			"likely a type-universe regression. Expect adapters/rabbitmq.Subscriber, "+
-			"adapters/mqtt.Subscriber, runtime/eventbus.InMemoryEventBus.")
+			"adapters/mqtt.Subscriber, framework/runtime/eventbus.InMemoryEventBus.")
 	return implPkgSet, notifyPkgSet
 }
 


### PR DESCRIPTION
## Summary

修复 2026-06-14 full archtest 暴露的 adapter/runtime 集成漂移：SQLSTATE 单源、PG testcontainer funnel、outbox settlement detector 三处。

## Why / 背景

一次 full archtest (`go run ./cmd/gocell verify archtest`) 暴露 5 条漂移登记为 #2116。该 issue 在框架重构 #1565（`kernel/runtime/pkg`→`framework/` module）**之前**提交，路径多为旧路径。

逐条实跑 archtest 取 ground truth：**5 条里 2 条已被后续提交（#1565 重构 PR）顺手修好、现已 PASS**，只剩 3 条仍 FAIL。本 PR 只修这 3 条：

| # | Invariant | 实跑状态 | 本 PR |
|---|-----------|---------|------|
| 1 | `MANAGED-RESOURCE-COMPLETENESS-01` | ✅ PASS（3 类型已在 opt-out + rationale） | 不动（verified-passing） |
| 2 | `SQLSTATE-SINGLE-SOURCE-01` | ❌ FAIL | **修** |
| 3 | `SEC-FAIL-CLOSED-05` | ✅ PASS（compose 已全用 `${VAR:?msg}`） | 不动（verified-passing） |
| 4 | `PG-TESTCONTAINER-FUNNEL-01` | ❌ FAIL | **修** |
| 5 | `OUTBOX-SUBSCRIBER-SETTLEMENT-NOTIFY-01` | ❌ FAIL（仅 `_DetectorFires` guard） | **修** |

### 三处修复

- **#2 SQLSTATE-SINGLE-SOURCE-01**（生产代码）：`policy_repo.go` Create 唯一约束分支裸比对 `pgErr.Code == "23505"` 违反 SQLSTATE 单源；改走 `pgquery.IsUniqueViolation(err)`（语义 1:1 等价），删 `pgConflictCode` 常量 + `pgconn` import，镜像同包 `role_repo.go` 既有 `pgquery` 用法。
- **#4 PG-TESTCONTAINER-FUNNEL-01**（集成测试）：`policymanage` 集成测试 per-test 裸调 `tcpostgres.Run` + 手工迁移，绕过 testcontainer funnel；改用 `pgtest.NewPerTestPool`（pgclone funnel），新增 `testmain_integration_test.go` 共享模板。`pgtest.applyMigrations` 的迁移集（`MigrationsFS` + `PlatformNamespace`）与原手工路径**完全一致**，忠实重构（附带 per-test 容器→共享模板提速）。镜像 canonical 模式 `configcore/.../testmain_integration_test.go`。
- **#5 OUTBOX-SUBSCRIBER-SETTLEMENT-NOTIFY-01**（archtest，stale detector 假阳性）：`NotifySettlement` 在三个 terminal subscriber（rabbitmq 16 / mqtt 7 / eventbus 6）都在调，但 detector 用 `prodscan.Patterns` 构造扫描集，而 #1565 后 `prodscan` 刻意剪掉多成员父 `adapters/` → 只数到 eventbus 1 个包：主测 vacuously PASS、`_DetectorFires` guard（≥3）FAIL。修复 = 扫描集补 `./adapters/...`（文档化 satellite opt-in，loader 经 `workspace.ExpandParentPrefix` 展开，由 `SATELLITE-PARENT-PREFIX-SCAN-01` 守护；同 `health_aggregation_test.go:120`），**恢复 rabbitmq/mqtt 真实覆盖（加强非削弱）** + 修 `runtime/eventbus`→`framework/runtime/eventbus` stale 文案。

> **#5 诚实 caveat**：该根因是「prodscan 排除 adapters/cmd/examples 多成员父」系统性盲区的**一个实例**，prodscan godoc 自述该 satellite 覆盖已有 tracking **#2136**。本 PR 只修当前 FAIL 的这一实例（full run 仅这 5 条 FAIL，其余欠扫 detector 是 vacuous-pass 非 fail，归 #2136），不在本 PR 兜底整个 #2136。

## Refs

Closes #2116

## Risk / 兼容性

无。pre-GA、无外部 wire 消费方；#2 行为等价（语义保持替换）、#4 纯测试基建、#5 archtest 自身。无 migration / wire 契约 / 消费方影响。

## Test plan

- [x] `go build ./...` 本地通过（corecells + tools 模块）
- [x] archtest 复跑：`TestSQLStateSingleSource` / `TestPG_TESTCONTAINER_FUNNEL_01` / `TestOutboxSubscriberSettlementNotify(_DetectorFires)` 3 条 FAIL→PASS，红夹具/anti-vacuity 兄弟测试不回归
- [x] 集成 tag 实跑（Docker）：`go -C corecells test -tags=integration ./accesscore/slices/policymanage/` 全绿，含 `TestL2Atomicity_*`（经重构后的 `setupPolicyIntegPG`/pgtest funnel）
- [x] `golangci-lint run`（CI-faithful，`--new-from-merge-base=origin/develop`）0 issues：corecells（untagged + `integration` tag）、tools（`archtest,releasesmoke` tag）

### Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| #2 SQLSTATE 单源 | 无 | 无 | `policy_repo.go` | 既有 integration 覆盖 | 无 |
| #4 PG funnel | 无 | 无 | 无 | `service_integration_test.go` + 新 `testmain_integration_test.go` | 无 |
| #5 outbox detector | 无 | 无 | 无 | `outbox_subscriber_settlement_notify_test.go` | 无 |

无 contract / wire 变更，无需契约扇出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
