### PR TITLE
chore(ai-surfaces): pr-monitor/pr-review 开放模型自动调用 + CLAUDE.md 中文沟通约定

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -3,7 +3,6 @@ name: pr-monitor
 description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。由 `/loop <interval> /pr-monitor <PR#>` 简单 loop 驱动（ship/fix 收尾自动启动；每 tick 无状态，只读 label + 机器块）；human-in-loop 可随时中断。pr-status/ready 或 PR 关闭时报告终止。"
 argument-hint: "<PR#> [--mode report|auto] [--role fix|review]"
 allowed-tools: [Bash, Read, Skill, Agent]
-disable-model-invocation: true
 ---
 
 # pr-monitor — PR 状态单 tick 检查器（fix 侧）

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -3,7 +3,6 @@ name: pr-review
 description: "对指定 PR 跑自动分级六维度 review（默认）；或 --check 模式验证上一轮 findings 是否修复 + 抓回归。按 diff 净增删行数自动分配 2/3/6 reviewer agent 并行（< 200 行不派发，主 agent 自审）；主 agent 做根因聚类 + Cx 分级 + 修复分流建议，不自动 fix。"
 argument-hint: "<PR 编号> [--check]"
 allowed-tools: [Read, Glob, Grep, Bash, Agent]
-disable-model-invocation: true
 ---
 
 # GoCell PR Review — 自动分级六维度审查

--- a/.codex/skills/pr-review/SKILL.md
+++ b/.codex/skills/pr-review/SKILL.md
@@ -3,7 +3,6 @@ name: pr-review
 description: "对指定 PR 跑自动分级六维度 review（默认）；或 --check 模式验证上一轮 findings 是否修复 + 抓回归。按 diff 净增删行数自动分配 2/3/6 reviewer agent 并行（< 200 行不派发，主 agent 自审）；主 agent 做根因聚类 + Cx 分级 + 修复分流建议，不自动 fix。"
 argument-hint: "<PR 编号> [--check]"
 allowed-tools: [Read, Glob, Grep, Bash, Agent]
-disable-model-invocation: true
 ---
 
 See .claude/skills/pr-review/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Cell-native Go 工程底座。只保留稳定的开发规则和架构约束。
 
 ## 工作方式
 
+- 与用户的所有沟通默认使用中文（对话回复、方案讨论、PR / review 说明）
 - 修改前先查看 README.md 与 docs/
 - 提交信息遵循 Conventional Commits
 - 涉及功能或行为变更时，同步更新对应文档


### PR DESCRIPTION
## Summary

删除 `pr-monitor` / `pr-review` 技能 frontmatter 的 `disable-model-invocation: true`，使其可被模型自动调用；CLAUDE.md「工作方式」新增「与用户的所有沟通默认使用中文」约定。

## Why / 背景

- `pr-monitor` 的设计语义就是「ship/fix 收尾自动启动 `/loop <interval> /pr-monitor <PR#>`」自驱动循环，`disable-model-invocation: true` 与该自动化语义冲突——保留它会阻断模型按设计自动驱动 review/check 跟进。`pr-review` 同理需要可被自动派发。删除后两个技能恢复可被模型自动调用。
- 沟通语言此前未在协作说明中显式固定，新增 CLAUDE.md 约定使「中文沟通」成为成文规则，而非隐含习惯。

## Refs

- 无关联 issue（按 `/ship --L1` 直接交付）

## Risk / 兼容性

- 仅改 AI instruction surface（技能 frontmatter + CLAUDE.md），无 Go 代码 / wire 契约 / migration 影响。
- 行为变化：两个技能从「禁止模型自动调用」变为「允许模型自动调用」，符合其文档化的自驱动设计，无下游消费方受影响。
- 范围限定：仅 `pr-monitor` / `pr-review`；`speckit-*` 技能的 `disable-model-invocation` 按需求保留不动。

## Test plan

- [x] N/A — `go build ./...`：无 Go 代码变更，不受影响
- [x] N/A — `go test`：无 Go 代码变更，不受影响
- [x] N/A — `golangci-lint run ./...`：无 Go 代码变更，trivially clean
- [x] 仅 markdown frontmatter / 文档变更，diff 经人工核对（3 文件，+1/-2）
