### PR TITLE
fix(framework): 收敛 full archtest 暴露的 projection/assembly/auth API 漂移 [#2115]

### DIFF
--- a/docs/architecture/202605171800-adr-kernel-mustctor-removal.md
+++ b/docs/architecture/202605171800-adr-kernel-mustctor-removal.md
@@ -88,7 +88,21 @@ production 代码（`cmd/corebundle/secrets.go:30`）可以直接调用，且编
 - `runtime/audit/ledger/storetest/`
 - `cells/internal/testoutbox/`
 
-**D1 总结：除上述三类外，production 路径（`kernel/` `runtime/` `adapters/` `cells/`
+**(c) 子情形：无法物理隔离的 test fixture（依赖生产包的包私有状态）**
+
+少数 test fixture 必须**导出于生产包本体**——因为它依赖该包的**包私有状态**（私有 seal /
+私有 mint），而跨包 `_test.go` 调用方又够不到包私有符号，故无法迁入上述任一 test-fixture 子包。
+这类 fixture 以 `(modulePath, funcName)` 形式登记进 `allowedMustDecls` carve-out（而非靠包前缀豁免），
+其 **production caller ban 由专用 companion archtest 承载**。当前唯一实例：
+
+- `runtime/auth.MustNewTestDevicePrincipal`：伪造 sealed device principal 供跨 cell handler /
+  集成测试用，依赖未导出的 `mintDevicePrincipal` seal（PR #1898 起 `Principal.RowVisibility` 对
+  无 seal 的 device principal fail-close），无法迁包；production 调用方由
+  `NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01`（AST 全扫，更高执行高度）禁止。与
+  `runtime/auth/keystest`（可迁包的 RSA key fixture）形成对照：能隔离的迁包，依赖包私有 seal 的
+  留本体 + carve-out + companion ban。
+
+**D1 总结：除上述三类（含 (c) 子情形）外，production 路径（`kernel/` `runtime/` `adapters/` `cells/`
 `cmd/` `examples/` 非 `_test.go` 非 test 子包）禁止声明或调用 `Must*` 真构造器。**
 
 另有一处内部 validator 豁免，详见 §carve-out registry。
@@ -289,6 +303,7 @@ system 表达"function name 必须有 receiver"。
 | `pkgErrcode` | `MustValidateDetailsKinds` | assertion guard | details kind 合法性，pkg-level var init |
 | `pkgAppender` | `MustNewSpec` | codegen funnel | sealed 白名单 funnel，pkg-level var init |
 | `pkgWebsocketHub` | `MustValidateHubConfig` | 内部 validator | `NewHub` 内部调用，不暴露为跨包 callee |
+| `runtime/auth` | `MustNewTestDevicePrincipal` | (c) test fixture（非隔离子情形） | 伪造 sealed device principal 供跨 cell handler/集成测试；依赖未导出 `mintDevicePrincipal` seal 无法迁包，production caller 由 `NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01` 守卫（#2115） |
 | ~~`runtime/audit/ledger`~~ | ~~`MustTamperEntryHash`~~ | ~~(c) test fixture method on MemStore~~ | **REMOVED (A-05 refactor)**: relocated to `ledger/mem_store_tamper_test.go` as unexported `tamperEntryHash`; negative Verify tests moved from `storetest/suite.go` to same-package `_test.go`; carve-out entry deleted from archtest `allowedMustDecls`. |
 | ~~`runtime/audit/ledger`~~ | ~~`MustTamperEntryPrevHash`~~ | ~~(c) test fixture method on MemStore~~ | **REMOVED (A-05 refactor)**: same as above; unexported `tamperEntryPrevHash` in `_test.go`. |
 

--- a/framework/kernel/projection/journal_event.go
+++ b/framework/kernel/projection/journal_event.go
@@ -31,7 +31,7 @@ import (
 // event message rather than being re-queried from the store.
 // ref: kernel/saga/sagaprojection.sagaProjectionEvent — the same carry-the-position shape.
 type JournalEvent struct {
-	entry     outbox.Entry
+	entry     ProjectionEvent
 	globalSeq int64
 }
 
@@ -39,7 +39,11 @@ type JournalEvent struct {
 // read alongside it (mem: 1-based dense index; PG: projection_events.global_seq). globalSeq
 // must be >= 1 for a real journal row; 0 is the unseeded sentinel a conforming source never
 // emits, which PositionFromCarrier rejects as a permanent error.
-func NewJournalEvent(entry outbox.Entry, globalSeq int64) *JournalEvent {
+//
+// entry is the typed cellvocab.ProjectionEvent carrier boundary (projection.ProjectionEvent
+// alias), not bare outbox.Entry, per ADR #1609 §D2: an outbox.Entry still satisfies the
+// interface, so live-bus and outbox-replay sources pass unchanged.
+func NewJournalEvent(entry ProjectionEvent, globalSeq int64) *JournalEvent {
 	return &JournalEvent{entry: entry, globalSeq: globalSeq}
 }
 

--- a/framework/kernel/projection/mem_journal_source.go
+++ b/framework/kernel/projection/mem_journal_source.go
@@ -37,7 +37,7 @@ func NewMemProjectionEventSource() *MemProjectionEventSource {
 // This is the test/demo seed surface — a production source is read-only (the sanctioned
 // same-transaction writer is the only append path; ADR §6 I2). Returning the carrier lets
 // conformance seeds hand the exact delivered carrier to Cursor.Position.
-func (m *MemProjectionEventSource) Append(entry outbox.Entry) *JournalEvent {
+func (m *MemProjectionEventSource) Append(entry ProjectionEvent) *JournalEvent {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	seq := int64(len(m.events) + 1) // 1-based dense index

--- a/framework/runtime/devtools/catalog/assembly_field_coverage_test.go
+++ b/framework/runtime/devtools/catalog/assembly_field_coverage_test.go
@@ -58,3 +58,52 @@ func TestAssemblySpec_OwnerAndMaxConsistencyLevelRoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"alpha"}, asmSpec.Cells)
 	assert.Equal(t, "k8s", asmSpec.Build.DeployTemplate)
 }
+
+// TestAssemblySpec_TopologyRoundTrip exercises the metadata.TopologyMeta →
+// AssemblySpecTopology mapping. The ASSEMBLY-META-DTO-COVERAGE-01 archtest only
+// asserts the top-level `topology` field NAME is present on AssemblySpec; this
+// test guards the actual VALUE mapping (colocated + remote cells) so a future
+// edit that adds the field but forgets the buildAssemblyEntity copy is caught —
+// the same focused round-trip guard role BuildMeta carries above.
+func TestAssemblySpec_TopologyRoundTrip(t *testing.T) {
+	t.Parallel()
+	pm := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			"alpha": {ID: "alpha", Type: "core", ConsistencyLevel: "L2"},
+			"beta":  {ID: "beta", Type: "core", ConsistencyLevel: "L2"},
+		},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"splitbundle": {
+				ID:    "splitbundle",
+				Cells: metadata.CellRefs("alpha", "beta"),
+				Owner: metadata.OwnerMeta{Team: "platform", Role: "bundle-owner"},
+				Topology: metadata.TopologyMeta{
+					Colocated: []string{"alpha"},
+					Remote: []metadata.TopologyRemoteEntry{
+						{CellID: "beta", Endpoint: "beta.svc:8080"},
+					},
+				},
+			},
+		},
+	}
+	doc, err := catalog.BuildDocument(
+		clockmock.New(time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)),
+		pm,
+		catalog.ExportOptions{},
+	)
+	require.NoError(t, err)
+
+	var asmSpec catalog.AssemblySpec
+	for _, e := range doc.Entities {
+		if e.Kind == "Assembly" && e.Metadata.Name == "splitbundle" {
+			s, ok := e.Spec.(catalog.AssemblySpec)
+			require.True(t, ok)
+			asmSpec = s
+			break
+		}
+	}
+	assert.Equal(t, []string{"alpha"}, asmSpec.Topology.Colocated)
+	require.Len(t, asmSpec.Topology.Remote, 1)
+	assert.Equal(t, "beta", asmSpec.Topology.Remote[0].CellID)
+	assert.Equal(t, "beta.svc:8080", asmSpec.Topology.Remote[0].Endpoint)
+}

--- a/framework/runtime/devtools/catalog/assembly_field_coverage_test.go
+++ b/framework/runtime/devtools/catalog/assembly_field_coverage_test.go
@@ -1,11 +1,13 @@
 package catalog_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
@@ -57,10 +59,18 @@ func TestAssemblySpec_OwnerAndMaxConsistencyLevelRoundTrip(t *testing.T) {
 	assert.Equal(t, "L2", asmSpec.MaxConsistencyLevel)
 	assert.Equal(t, []string{"alpha"}, asmSpec.Cells)
 	assert.Equal(t, "k8s", asmSpec.Build.DeployTemplate)
-	// mainbundle declares no topology → mapAssemblyTopology returns the zero
-	// AssemblySpecTopology (both slices nil), omitted on the wire via omitempty.
-	assert.Nil(t, asmSpec.Topology.Colocated)
-	assert.Nil(t, asmSpec.Topology.Remote)
+	// mainbundle declares no topology → mapAssemblyTopology returns nil so the
+	// optional topology field is omitted from the wire entirely (not `{}`).
+	assert.Nil(t, asmSpec.Topology)
+
+	// Wire shape: a topology-less assembly must NOT emit a `topology` key in
+	// either marshal format (a value struct + omitempty would emit `{}`).
+	jsonBytes, err := json.Marshal(asmSpec)
+	require.NoError(t, err)
+	assert.NotContains(t, string(jsonBytes), "topology", "empty topology must be omitted from JSON wire")
+	yamlBytes, err := yaml.Marshal(asmSpec)
+	require.NoError(t, err)
+	assert.NotContains(t, string(yamlBytes), "topology", "empty topology must be omitted from YAML wire")
 }
 
 // TestAssemblySpec_TopologyRoundTrip exercises the metadata.TopologyMeta →
@@ -106,8 +116,15 @@ func TestAssemblySpec_TopologyRoundTrip(t *testing.T) {
 			break
 		}
 	}
+	require.NotNil(t, asmSpec.Topology)
 	assert.Equal(t, []string{"alpha"}, asmSpec.Topology.Colocated)
 	require.Len(t, asmSpec.Topology.Remote, 1)
 	assert.Equal(t, "beta", asmSpec.Topology.Remote[0].CellID)
 	assert.Equal(t, "beta.svc:8080", asmSpec.Topology.Remote[0].Endpoint)
+
+	// Wire shape: a topology-bearing assembly emits the field with its values.
+	jsonBytes, err := json.Marshal(asmSpec)
+	require.NoError(t, err)
+	assert.Contains(t, string(jsonBytes), `"topology"`)
+	assert.Contains(t, string(jsonBytes), "beta.svc:8080")
 }

--- a/framework/runtime/devtools/catalog/assembly_field_coverage_test.go
+++ b/framework/runtime/devtools/catalog/assembly_field_coverage_test.go
@@ -57,6 +57,10 @@ func TestAssemblySpec_OwnerAndMaxConsistencyLevelRoundTrip(t *testing.T) {
 	assert.Equal(t, "L2", asmSpec.MaxConsistencyLevel)
 	assert.Equal(t, []string{"alpha"}, asmSpec.Cells)
 	assert.Equal(t, "k8s", asmSpec.Build.DeployTemplate)
+	// mainbundle declares no topology → mapAssemblyTopology returns the zero
+	// AssemblySpecTopology (both slices nil), omitted on the wire via omitempty.
+	assert.Nil(t, asmSpec.Topology.Colocated)
+	assert.Nil(t, asmSpec.Topology.Remote)
 }
 
 // TestAssemblySpec_TopologyRoundTrip exercises the metadata.TopologyMeta →

--- a/framework/runtime/devtools/catalog/build.go
+++ b/framework/runtime/devtools/catalog/build.go
@@ -329,6 +329,7 @@ func buildAssemblyEntity(a *metadata.AssemblyMeta, inc IncludeOptions) Entity {
 			Binary:         a.Build.Binary,
 			DeployTemplate: a.Build.DeployTemplate,
 		},
+		Topology: mapAssemblyTopology(a.Topology),
 	}
 
 	var rels []Relation
@@ -350,6 +351,20 @@ func buildAssemblyEntity(a *metadata.AssemblyMeta, inc IncludeOptions) Entity {
 		Spec:      spec,
 		Relations: rels,
 	}
+}
+
+// mapAssemblyTopology copies metadata.TopologyMeta onto the wire DTO field-by-field,
+// mirroring the AssemblyMeta.Build → AssemblySpecBuild mapping above. A zero TopologyMeta
+// yields a zero AssemblySpecTopology (omitted on the wire via omitempty).
+func mapAssemblyTopology(t metadata.TopologyMeta) AssemblySpecTopology {
+	out := AssemblySpecTopology{}
+	if len(t.Colocated) > 0 {
+		out.Colocated = append([]string(nil), t.Colocated...)
+	}
+	for _, r := range t.Remote {
+		out.Remote = append(out.Remote, AssemblySpecTopologyRemote{CellID: r.CellID, Endpoint: r.Endpoint})
+	}
+	return out
 }
 
 // buildActorEntity converts ActorMeta to an Entity.

--- a/framework/runtime/devtools/catalog/build.go
+++ b/framework/runtime/devtools/catalog/build.go
@@ -355,9 +355,14 @@ func buildAssemblyEntity(a *metadata.AssemblyMeta, inc IncludeOptions) Entity {
 
 // mapAssemblyTopology copies metadata.TopologyMeta onto the wire DTO field-by-field,
 // mirroring the AssemblyMeta.Build → AssemblySpecBuild mapping above. A zero TopologyMeta
-// yields a zero AssemblySpecTopology (omitted on the wire via omitempty).
-func mapAssemblyTopology(t metadata.TopologyMeta) AssemblySpecTopology {
-	out := AssemblySpecTopology{}
+// (no colocated and no remote cells) yields nil so the optional topology field is omitted
+// from the wire entirely (see AssemblySpecTopology godoc on why a value struct + omitempty
+// would still emit `{}`).
+func mapAssemblyTopology(t metadata.TopologyMeta) *AssemblySpecTopology {
+	if len(t.Colocated) == 0 && len(t.Remote) == 0 {
+		return nil
+	}
+	out := &AssemblySpecTopology{}
 	if len(t.Colocated) > 0 {
 		out.Colocated = append([]string(nil), t.Colocated...)
 	}

--- a/framework/runtime/devtools/catalog/wire.go
+++ b/framework/runtime/devtools/catalog/wire.go
@@ -270,11 +270,11 @@ type JourneyPassCrit struct {
 
 // AssemblySpec is Document.Entities[Kind=="Assembly"].Spec.
 type AssemblySpec struct {
-	Cells               []string             `json:"cells,omitempty"               yaml:"cells,omitempty"`
-	Owner               CellSpecOwner        `json:"owner"                         yaml:"owner"`
-	MaxConsistencyLevel string               `json:"maxConsistencyLevel,omitempty" yaml:"maxConsistencyLevel,omitempty"`
-	Build               AssemblySpecBuild    `json:"build"                         yaml:"build"`
-	Topology            AssemblySpecTopology `json:"topology,omitempty"            yaml:"topology,omitempty"`
+	Cells               []string              `json:"cells,omitempty"               yaml:"cells,omitempty"`
+	Owner               CellSpecOwner         `json:"owner"                         yaml:"owner"`
+	MaxConsistencyLevel string                `json:"maxConsistencyLevel,omitempty" yaml:"maxConsistencyLevel,omitempty"`
+	Build               AssemblySpecBuild     `json:"build"                         yaml:"build"`
+	Topology            *AssemblySpecTopology `json:"topology,omitempty"            yaml:"topology,omitempty"`
 }
 
 // AssemblySpecBuild mirrors AssemblyBuildMeta on the wire.
@@ -287,6 +287,11 @@ type AssemblySpecBuild struct {
 // AssemblySpecTopology mirrors metadata.TopologyMeta on the wire: the deployment
 // placement of the assembly's cells (colocated in-process vs reachable as remote
 // services). Empty => all cells co-located (zero-migration default).
+//
+// AssemblySpec references it as an OPTIONAL POINTER (nil => omitted): omitempty
+// on a value struct does NOT drop a struct whose fields are all zero (encoding/json
+// only treats false/0/nil-ptr/empty-len as empty), so a value field would emit
+// `"topology":{}` for every topology-less assembly. A nil pointer omits the field.
 type AssemblySpecTopology struct {
 	Colocated []string                     `json:"colocated,omitempty" yaml:"colocated,omitempty"`
 	Remote    []AssemblySpecTopologyRemote `json:"remote,omitempty"    yaml:"remote,omitempty"`

--- a/framework/runtime/devtools/catalog/wire.go
+++ b/framework/runtime/devtools/catalog/wire.go
@@ -270,10 +270,11 @@ type JourneyPassCrit struct {
 
 // AssemblySpec is Document.Entities[Kind=="Assembly"].Spec.
 type AssemblySpec struct {
-	Cells               []string          `json:"cells,omitempty"               yaml:"cells,omitempty"`
-	Owner               CellSpecOwner     `json:"owner"                         yaml:"owner"`
-	MaxConsistencyLevel string            `json:"maxConsistencyLevel,omitempty" yaml:"maxConsistencyLevel,omitempty"`
-	Build               AssemblySpecBuild `json:"build"                         yaml:"build"`
+	Cells               []string             `json:"cells,omitempty"               yaml:"cells,omitempty"`
+	Owner               CellSpecOwner        `json:"owner"                         yaml:"owner"`
+	MaxConsistencyLevel string               `json:"maxConsistencyLevel,omitempty" yaml:"maxConsistencyLevel,omitempty"`
+	Build               AssemblySpecBuild    `json:"build"                         yaml:"build"`
+	Topology            AssemblySpecTopology `json:"topology,omitempty"            yaml:"topology,omitempty"`
 }
 
 // AssemblySpecBuild mirrors AssemblyBuildMeta on the wire.
@@ -281,6 +282,20 @@ type AssemblySpecBuild struct {
 	Entrypoint     string `json:"entrypoint,omitempty"     yaml:"entrypoint,omitempty"`
 	Binary         string `json:"binary,omitempty"         yaml:"binary,omitempty"`
 	DeployTemplate string `json:"deployTemplate,omitempty" yaml:"deployTemplate,omitempty"`
+}
+
+// AssemblySpecTopology mirrors metadata.TopologyMeta on the wire: the deployment
+// placement of the assembly's cells (colocated in-process vs reachable as remote
+// services). Empty => all cells co-located (zero-migration default).
+type AssemblySpecTopology struct {
+	Colocated []string                     `json:"colocated,omitempty" yaml:"colocated,omitempty"`
+	Remote    []AssemblySpecTopologyRemote `json:"remote,omitempty"    yaml:"remote,omitempty"`
+}
+
+// AssemblySpecTopologyRemote mirrors metadata.TopologyRemoteEntry on the wire.
+type AssemblySpecTopologyRemote struct {
+	CellID   string `json:"cellID"   yaml:"cellID"`
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
 }
 
 // ActorSpec is Document.Entities[Kind=="Actor"].Spec.

--- a/tools/archtest/internal/deviceprincipalfixture/aliased.go
+++ b/tools/archtest/internal/deviceprincipalfixture/aliased.go
@@ -1,0 +1,37 @@
+//go:build archtest_fixture
+
+// Package deviceprincipalfixture is a deliberate
+// NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01 negative fixture loaded only when
+// the archtest_fixture build tag is set.
+//
+// The fixture imports framework/runtime/auth under a non-default alias (`rauth`)
+// and calls `rauth.MustNewTestDevicePrincipal(...)`. The legacy AST-only matcher
+// (`id.Name == "auth"`) silently passes this shape; the type-aware matcher
+// (ResolvePackageRef → *types.PkgName → Imported().Path()) catches it because
+// resolution is by canonical import path, not by syntactic identifier.
+//
+// The build tag excludes this package from `go build ./...` and `go test ./...`
+// so it never pollutes real-repo scans. It is loaded explicitly by
+// TestNoTestDevicePrincipal_ScannerCatchesAliasBypass via
+//
+//	archtest.Run(t, archtest.Fixture(archtest.FixtureOpts{Tests: false},
+//	    []string{"./tools/archtest/internal/deviceprincipalfixture"}), rule)
+//
+// AI co-authors who modify the fixture must keep exactly one call to
+// MustNewTestDevicePrincipal. The companion test asserts hits == 1; adding a
+// second call site or removing the call breaks the anti-vacuity contract.
+package deviceprincipalfixture
+
+import rauth "github.com/ghbvf/gocell/framework/runtime/auth"
+
+// AliasedForge intentionally invokes MustNewTestDevicePrincipal through a
+// non-default import alias. The return value is discarded; the function is never
+// called at runtime — the fixture exists only for AST/type-info analysis.
+//
+// MustNewTestDevicePrincipal's signature is
+// `func MustNewTestDevicePrincipal(subject, tenantID string) *Principal`. The call
+// below uses non-empty literal args so the fixture compiles cleanly (it is never
+// executed, so the panic-on-empty-args path is irrelevant).
+func AliasedForge() {
+	_ = rauth.MustNewTestDevicePrincipal("fixture-subject", "00000000-0000-0000-0000-000000000001")
+}

--- a/tools/archtest/kernel_mustctor_production_decl_test.go
+++ b/tools/archtest/kernel_mustctor_production_decl_test.go
@@ -22,7 +22,15 @@
 //     (`pkg/contracttest/`, `pkg/testutil/`, `runtime/internal/authtest/`,
 //     `cells/internal/testoutbox/`). Callers must be `_test.go` files —
 //     enforced indirectly by the package not being importable from
-//     production paths without raising review attention.
+//     production paths without raising review attention. SUB-CASE: a test
+//     fixture that cannot be physically isolated because it depends on
+//     package-private state of a production package (it must be exported
+//     FROM that package so cross-package `_test.go` callers can reach it) is
+//     registered as a (modulePath, funcName) carve-out instead, and its
+//     production-caller ban is carried by a dedicated companion archtest
+//     (e.g. `runtime/auth.MustNewTestDevicePrincipal` needs the unexported
+//     `mintDevicePrincipal` seal; callers are banned by
+//     `NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01`).
 //
 // Other `Must*` production declarations were removed by the B2-K-02 ship
 // (see ADR `docs/architecture/202605171800-adr-kernel-mustctor-removal.md`);
@@ -134,6 +142,14 @@ var allowedMustDecls = map[string]map[string]struct{}{
 	// (a) internal validator — NewHub calls it internally, not exposed as constructor
 	"framework/runtime/websocket": {
 		"MustValidateHubConfig": {},
+	},
+	// (c) test fixture, non-isolable sub-case — forges a sealed device principal
+	// for cross-cell handler/integration tests. Exported from the production auth
+	// package because it needs the unexported mintDevicePrincipal seal, so it
+	// cannot live in a test-fixture package; production callers are banned by the
+	// companion NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01 archtest.
+	"framework/runtime/auth": {
+		"MustNewTestDevicePrincipal": {},
 	},
 }
 

--- a/tools/archtest/no_test_device_principal_in_production_test.go
+++ b/tools/archtest/no_test_device_principal_in_production_test.go
@@ -5,8 +5,7 @@
 // # NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01
 //
 // Invariant: auth.MustNewTestDevicePrincipal(...) must only appear in _test.go
-// files or files whose name contains "_test_" (i.e. files under test helper
-// packages). It is an EXPORTED helper that delegates to the unexported
+// files. It is an EXPORTED helper that delegates to the unexported
 // mintDevicePrincipal and therefore produces a fully sealed PrincipalDevice
 // WITHOUT going through JWT verification. Calling it in production code would
 // forge a verified device identity and bypass the device-token authn boundary.
@@ -24,123 +23,128 @@
 // (TestServiceContext bypasses the service-token HMAC guard identically); the
 // helper cannot live outside package auth (it needs the unexported minter) nor
 // in _test.go (external packages must see it), so a Medium archtest is the
-// ceiling and the seal stays the Hard control.
+// ceiling and the seal stays the Hard control. This guard is also the
+// production-caller closure registered against the KERNEL-MUSTCTOR-PRODUCTION-DECL-01
+// carve-out for runtime/auth.MustNewTestDevicePrincipal (#2115).
 //
-// Detection: AST walk of all .go files under runtime/, cmd/, kernel/, adapters/,
-// examples/, tests/, and the platform-cell roots, scanning for
-// auth.MustNewTestDevicePrincipal(...) call expressions. Files ending in _test.go
-// or containing "_test_" in their base name are excluded.
+// AI-robust 评级：Medium-true (type-aware via Production(TypedOpts{Tests: false})
+// + ResolvePackageRef). Resolution is by canonical *types.PkgName import path
+// (github.com/ghbvf/gocell/framework/runtime/auth), NOT AST identifier name, so an
+// aliased import (`import rauth ".../framework/runtime/auth";
+// rauth.MustNewTestDevicePrincipal(...)`) or a dot-import cannot bypass detection.
+// The prior AST-only `id.Name == "auth"` matcher silently passed those shapes
+// (#2142 review F1); the deviceprincipalfixture alias-bypass red fixture pins the
+// anti-vacuity contract. Mirrors AUDIT-LEDGER-PROTOCOL-COMPOSITION-ROOT-01's
+// type-aware upgrade. Function-value capture (`fn := auth.MustNewTestDevicePrincipal`)
+// remains an out-of-scope theoretical blind spot, same as sibling caller-scan rules.
+//
+// Detection: Production(TypedOpts{Tests: false}) loads every non-test production
+// package across the workspace; ResolvePackageRef matches calls resolving to the
+// canonical auth.MustNewTestDevicePrincipal symbol. _test.go files are excluded
+// in-scan (test helpers call it freely).
 package archtest
 
 import (
-	"fmt"
 	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
 const ruleNoTestDevicePrincipalInProduction = "NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01"
+
+// authImportSuffix is the module-relative path of the runtime/auth package.
+// Combined with modulePath (read from go.mod) it forms the canonical import path
+// matched by ResolvePackageRef — alias-proof, since resolution is by *types.PkgName
+// import path rather than syntactic identifier.
+const authImportSuffix = "/framework/runtime/auth"
+
+type deviceForgeHit struct {
+	file string
+	line int
+}
+
+// scanDeviceForgePass walks a single Pass and records non-test calls to
+// auth.MustNewTestDevicePrincipal, resolved by canonical import path so that
+// import aliases and dot-imports cannot evade detection.
+func scanDeviceForgePass(p *Pass, modulePath string) []deviceForgeHit {
+	if p.TypesInfo == nil || p.Pkg == nil {
+		return nil
+	}
+	authImportPath := modulePath + authImportSuffix
+
+	var hits []deviceForgeHit
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		if strings.HasSuffix(rel, "_test.go") {
+			continue
+		}
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+			if !ok || pkgPath != authImportPath || name != "MustNewTestDevicePrincipal" {
+				return
+			}
+			hits = append(hits, deviceForgeHit{
+				file: rel,
+				line: p.Fset.Position(call.Pos()).Line,
+			})
+		})
+	}
+	return hits
+}
 
 // TestNO_TEST_DEVICE_PRINCIPAL_IN_PRODUCTION_01 enforces that
 // auth.MustNewTestDevicePrincipal is never called from non-test production code.
 func TestNO_TEST_DEVICE_PRINCIPAL_IN_PRODUCTION_01(t *testing.T) {
 	t.Parallel()
-
 	root := findModuleRoot(t)
+	modulePath := readModulePath(t, root)
 
-	// All production roots — non-test code anywhere in the repo must not call
-	// auth.MustNewTestDevicePrincipal. Mirrors the search scope of
-	// NO-TEST-SERVICE-CONTEXT-IN-PRODUCTION-01 (the scanner skips _test.go in-line
-	// so test helpers call it freely). Platform cells route through
-	// platformCellScanDirs (single source for the on-disk scan root).
-	searchDirs := []string{
-		filepath.Join(root, "framework", "runtime"),
-		filepath.Join(root, "cmd"),
-		filepath.Join(root, "framework", "kernel"),
-		filepath.Join(root, "adapters"),
-		filepath.Join(root, "examples"),
-		filepath.Join(root, "tests"),
-	}
-	for _, d := range platformCellScanDirs() {
-		searchDirs = append(searchDirs, filepath.Join(root, d))
-	}
+	var hits []deviceForgeHit
+	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		hits = append(hits, scanDeviceForgePass(p, modulePath)...)
+		return nil
+	})
 
-	var violations []string
-	for _, dir := range searchDirs {
-		allFiles, err := findAllGoFilesInDir(dir)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			t.Fatalf("walking %s: %v", dir, err)
-		}
-		for _, f := range allFiles {
-			base := filepath.Base(f)
-			if strings.HasSuffix(base, "_test.go") || strings.Contains(base, "_test_") {
-				continue
-			}
-
-			rel, _ := filepath.Rel(root, f)
-			rel = filepath.ToSlash(rel)
-
-			hits, scanErr := scanTestDevicePrincipalCalls(f, rel)
-			require.NoError(t, scanErr)
-			violations = append(violations, hits...)
-		}
+	for _, h := range hits {
+		t.Logf("%s: %s:%d calls auth.MustNewTestDevicePrincipal in non-test production code — move to _test.go",
+			ruleNoTestDevicePrincipalInProduction, h.file, h.line)
 	}
-
-	sort.Strings(violations)
-	for _, v := range violations {
-		t.Log(v)
-	}
-	if len(violations) > 0 {
-		t.Errorf("%s: %d auth.MustNewTestDevicePrincipal calls found in non-test production files.\n"+
-			"auth.MustNewTestDevicePrincipal is a test helper that forges a sealed device principal\n"+
-			"without JWT verification. It must only appear in _test.go files.",
-			ruleNoTestDevicePrincipalInProduction, len(violations))
-	}
+	assert.Empty(t, hits,
+		ruleNoTestDevicePrincipalInProduction+": auth.MustNewTestDevicePrincipal forges a sealed "+
+			"device principal without JWT verification; it must only be called from _test.go files")
 }
 
-// scanTestDevicePrincipalCalls parses a single .go file and returns violation
-// strings for every auth.MustNewTestDevicePrincipal(...) call expression.
-func scanTestDevicePrincipalCalls(path, rel string) ([]string, error) {
-	data, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return nil, err
-	}
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, path, data, parser.SkipObjectResolution)
-	if err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
-	}
+// TestNoTestDevicePrincipal_ScannerCatchesAliasBypass loads the build-tag-gated
+// deviceprincipalfixture package and asserts the type-aware scanner reports the
+// aliased-import call site that the prior AST-only `id.Name == "auth"` matcher
+// silently passed (#2142 review F1).
+//
+// ResolvePackageRef resolves info.Uses[sel.X] → *types.PkgName → Imported().Path(),
+// so the canonical import path matches regardless of the alias chosen at import.
+//
+// Per ai-robust.md §"Hard 范本": the fixture is a real Go package loaded via
+// packages.Load with the archtest_fixture build tag. Bypassing this test requires
+// modifying real source code.
+func TestNoTestDevicePrincipal_ScannerCatchesAliasBypass(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	modulePath := readModulePath(t, root)
 
-	var violations []string
-	scanner.EachInSubtree[ast.CallExpr](f, func(call *ast.CallExpr) {
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		if sel.Sel.Name != "MustNewTestDevicePrincipal" {
-			return
-		}
-		id, ok := sel.X.(*ast.Ident)
-		if !ok || id.Name != "auth" {
-			return
-		}
-		pos := fset.Position(call.Pos())
-		violations = append(violations, fmt.Sprintf(
-			"%s:%d: auth.MustNewTestDevicePrincipal called in non-test file — move to _test.go",
-			rel, pos.Line,
-		))
-	})
-	return violations, nil
+	var hits []deviceForgeHit
+	_ = Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/deviceprincipalfixture"}),
+		func(p *Pass) []Diagnostic {
+			hits = append(hits, scanDeviceForgePass(p, modulePath)...)
+			return nil
+		})
+
+	require.Len(t, hits, 1,
+		"fixture must yield exactly 1 violation: AliasedForge uses "+
+			"`import rauth \"<module>/framework/runtime/auth\"; rauth.MustNewTestDevicePrincipal(...)`; "+
+			"the prior AST-only id.Name == \"auth\" matcher would silently pass this")
+	assert.Contains(t, hits[0].file, "tools/archtest/internal/deviceprincipalfixture/",
+		"fixture hit must be located in the deviceprincipalfixture package directory")
 }


### PR DESCRIPTION
## Summary

收敛 2026-06-14 full archtest 暴露的 4 条 kernel/projection/assembly/auth API 漂移（#2115）：projection carrier 收窄到 typed 边界、assembly topology 映射进 catalog DTO、`MustNewTestDevicePrincipal` carve-out。

## Why / 背景

issue #2115（pri-p1 / cx-3 / area-kernel）记录的 4 条漂移。其后 `05744fd21` 把 kernel/runtime/pkg 独立成 `framework/` module，issue 路径已过时。**实跑核实**：Finding A 已自动收敛，B/C/D 仍真实失败，本 PR 修 B/C/D。

| # | Invariant | 处理 |
|---|-----------|------|
| A | `KERNEL-INTERNAL-DAG-01`（`webhook→crypto`）| ✅ 已在 `allowedKernelEdges` 收敛（#1540 source-secret），**本 PR 不动** |
| B | `PROJECTION-EVENT-CARRIER-TYPED-01` | `NewJournalEvent`/`Append` 参数 `outbox.Entry`→`ProjectionEvent`（ADR #1609 §D2）|
| C | `ASSEMBLY-META-DTO-COVERAGE-01` | `AssemblyMeta.topology` 按 `BuildMeta` 先例 MAP 进 `AssemblySpec` |
| D | `KERNEL-MUSTCTOR-PRODUCTION-DECL-01` | `MustNewTestDevicePrincipal` carve-out + 类别(c)非隔离子情形定义同改 |

**设计取舍（已与 issue owner 对齐）**：C 选 MAP（catalog 保持 assembly.yaml 完整投影，topology 同属部署形状）；D 选 carve-out（函数仅因外部 `_test.go` 够不到包私有 `mintDevicePrincipal` seal 才导出，无法物理隔离；production caller 由 `NO-TEST-DEVICE-PRINCIPAL-IN-PRODUCTION-01` 守卫）。D 的 registry 行与 archtest godoc/ADR 类别(c)定义在**同一改动**对齐，不留概念矛盾。

## Refs

Closes #2115
ref: AxonFramework TrackedEventMessage（projection carrier position-rides-with-event）
ADR `docs/architecture/202605171800-adr-kernel-mustctor-removal.md`（carve-out registry + §D1(c) 非隔离子情形）、`#1609`（projection carrier typed boundary）

## Risk / 兼容性

- **B 零调用方破坏**：`outbox.Entry` 实现 `cellvocab.ProjectionEvent`，mem + PG（`projection_event_source.go:207,248`）及全部测试调用方仍编译（已 build 核实）。
- **C wire 加字段**：`AssemblySpec` 新增 `topology`（`omitempty`），现有无 topology 的 assembly 不产生 wire/golden diff；catalog 是 devtools 导出 DTO，非跨 cell 版本化 contract。
- **D 仅 archtest + ADR**：无运行时行为变更，保留 panic-on-misuse 测试人体工学。

## Test plan

- [x] `go build ./...` 本地通过（framework + adapters/postgres）
- [x] `go test ./修改的包/...` 通过（projection / catalog 含新增 topology round-trip / auth）
- [x] 4 条目标 archtest 转绿（含 DAG 保持绿 + companion `NO-TEST-DEVICE-PRINCIPAL` 绿）
- [x] `golangci-lint run` 0 issues（framework + tools/archtest）

**全量 archtest 回归核实**：baseline(origin/develop) 24 失败 vs 本支 12 失败，本支失败 ⊊ baseline（projection/contract/testcontainer 类**均为 develop 既存、与本 diff 无关**），本 PR **引入 0 新失败**、修复其 3 个可代码收敛目标（DAG 早已绿）。

## Implementation matrix

| 变更 | schema/wire | generated | metadata | tests | docs |
|------|-------------|-----------|----------|-------|------|
| B projection carrier | n/a | n/a | n/a | projection 既有单测 + archtest | godoc inline |
| C topology MAP | `AssemblySpec.topology` DTO | n/a（手写 catalog DTO）| `TopologyMeta` 已存在 | `TestAssemblySpec_TopologyRoundTrip` + archtest | wire godoc |
| D carve-out | n/a | n/a | n/a | archtest 转绿 + companion ban 绿 | ADR registry + §D1(c) |
