### PR TITLE
test(governance): framework OBS-01 anti-vacuity + satellite duration 治理 [#2128][#2136]

### DIFF
--- a/adapters/postgres/audit_cross_tenant_store_integration_test.go
+++ b/adapters/postgres/audit_cross_tenant_store_integration_test.go
@@ -47,9 +47,14 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/framework/runtime/audit/ledger/storetest"
 )
+
+// ctDelta4s is a 4-second row timestamp delta used in cross-tenant seed data.
+// No exact mechanical alias exists in testtime for 4s.
+const ctDelta4s = 4 * time.Second
 
 // auditAdminPass is the password used when creating gocell_audit_admin in
 // these tests. Must match the value used in schema_guard_integration_test.go
@@ -210,11 +215,11 @@ func TestAuditCrossTenantStore_PG_ReadsAcrossTenants(t *testing.T) {
 		// auditcore namespace — tenant B
 		{"ct-b1-ac", ctNSAuditcore, "ev-b1-ac", "actor-b", ctTenantB, 1, time.Second},
 		// bootstrap namespace — tenant A
-		{"ct-a1-bs", ctNSBootstrap, "ev-a1-bs", "actor-a", ctTenantA, 1, 2 * time.Second},
+		{"ct-a1-bs", ctNSBootstrap, "ev-a1-bs", "actor-a", ctTenantA, 1, testtime.D2s},
 		// bootstrap namespace — tenant B
-		{"ct-b1-bs", ctNSBootstrap, "ev-b1-bs", "actor-b", ctTenantB, 1, 3 * time.Second},
+		{"ct-b1-bs", ctNSBootstrap, "ev-b1-bs", "actor-b", ctTenantB, 1, testtime.D3s},
 		// system row — tenant_id='', bootstrap namespace, no GUC needed (owner insert)
-		{"ct-sys-bs", ctNSBootstrap, "ev-sys-bs", "actor-sys", "", 1, 4 * time.Second},
+		{"ct-sys-bs", ctNSBootstrap, "ev-sys-bs", "actor-sys", "", 1, ctDelta4s},
 	}
 	for _, r := range rows {
 		insertAuditRowAsOwner(t, ownerPool, r.id, r.ns, r.eventID, r.actorID, r.tenantID, r.seqNo, base.Add(r.delta))

--- a/adapters/postgres/projection_event_source_test.go
+++ b/adapters/postgres/projection_event_source_test.go
@@ -16,6 +16,7 @@ import (
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/kernel/projection"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 )
 
 // compile-time interface checks mirror the production assertions so a signature drift
@@ -252,7 +253,7 @@ func TestPGProjectionEventSource_ResolveCarrier_BoundedLookup(t *testing.T) {
 		t.Parallel()
 		tx := &mockProjTx{row: &mockProjRow{value: 3}}
 		s, base := newEventSourceWithTx(tx)
-		callerCtx, cancel := context.WithTimeout(base, 500*time.Millisecond)
+		callerCtx, cancel := context.WithTimeout(base, testtime.D500ms)
 		defer cancel()
 		_, err := s.ResolveCarrier(callerCtx, mustEntry(t))
 		require.NoError(t, err)

--- a/adapters/postgres/projection_owner_checkpoint_integration_test.go
+++ b/adapters/postgres/projection_owner_checkpoint_integration_test.go
@@ -15,7 +15,16 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/projection"
 	"github.com/ghbvf/gocell/framework/kernel/projection/projectiontest"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 )
+
+// txHoldDuration is the max time tokenA may wait for tokenB to release the
+// SELECT FOR UPDATE row lock in the concurrent leader-handoff test.
+const txHoldDuration = testtime.D2s
+
+// blockAssertTimeout is the polling deadline used to assert that tokenA is
+// blocked on the row lock before tokenB commits.
+const blockAssertTimeout = testtime.D200ms
 
 // TestPGOwnerCheckpointStore_Conformance enrolls the concrete
 // *ProjectionCheckpointStore in the shared OwnerCheckpointStore conformance
@@ -110,11 +119,6 @@ func TestPGOwnerCheckpointStore_Concurrent_LeaderHandoff(t *testing.T) {
 
 	const cellID = "cell-concurrent-handoff"
 	const projID = "proj-concurrent-handoff"
-
-	// Warm-path timeout: max time tokenA may wait for tokenB to release the lock.
-	// Extracted per TEST-TIME-LITERAL-01.
-	const txHoldDuration = 2 * time.Second
-	const blockAssertTimeout = 200 * time.Millisecond
 
 	// Seed: tokenA claims the checkpoint at offset 10.
 	const tokenA = "leader-A-established"

--- a/examples/iotdevice/cells/devicecell/cell_test.go
+++ b/examples/iotdevice/cells/devicecell/cell_test.go
@@ -34,6 +34,14 @@ import (
 	"github.com/ghbvf/gocell/framework/runtime/outbox/outboxtest"
 )
 
+// cert duration constants for TestCertValidityExceedsThreshold.
+const (
+	certValidity90d  = 90 * 24 * time.Hour
+	certThreshold30d = 30 * 24 * time.Hour
+	certValidity10d  = 10 * 24 * time.Hour
+	certValidity20d  = 20 * 24 * time.Hour
+)
+
 func newTestCell() *DeviceCell {
 	c := NewDeviceCell(
 		clock.Real(),
@@ -83,9 +91,9 @@ func newTestRec() *cell.RegistryRecorder {
 // guard logic and that the LIVE consts satisfy it (a const change that breaks the
 // invariant turns this red rather than shipping a silent busy-loop).
 func TestCertValidityExceedsThreshold(t *testing.T) {
-	assert.True(t, certValidityExceedsThreshold(90*24*time.Hour, 30*24*time.Hour), "90d validity > 30d threshold")
-	assert.False(t, certValidityExceedsThreshold(30*24*time.Hour, 30*24*time.Hour), "equal must fail (cert would be near-expiry at issue)")
-	assert.False(t, certValidityExceedsThreshold(10*24*time.Hour, 20*24*time.Hour), "shorter validity must fail")
+	assert.True(t, certValidityExceedsThreshold(certValidity90d, certThreshold30d), "90d validity > 30d threshold")
+	assert.False(t, certValidityExceedsThreshold(certThreshold30d, certThreshold30d), "equal must fail (cert would be near-expiry at issue)")
+	assert.False(t, certValidityExceedsThreshold(certValidity10d, certValidity20d), "shorter validity must fail")
 
 	// The live consts MUST satisfy the invariant — this is the drift guard.
 	assert.True(t, certValidityExceedsThreshold(domain.CertValidity, certRenewalThreshold),

--- a/examples/iotdevice/cells/devicecell/cert_renewal_e2e_test.go
+++ b/examples/iotdevice/cells/devicecell/cert_renewal_e2e_test.go
@@ -46,6 +46,14 @@ import (
 	cmdenqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
 )
 
+// cert renewal e2e duration constants.
+const (
+	// certRenewalThreshold7d is the renewal threshold for F1 (offline device test).
+	certRenewalThreshold7d = 7 * 24 * time.Hour
+	// certNearExpiry24h is the near-expiry window seeded in test device cert fields.
+	certNearExpiry24h = 24 * time.Hour
+)
+
 // deviceSelfCtx returns ctx with a device-self principal (PrincipalUser, Subject
 // == deviceID) — the identity a device presents when acking its OWN rotate-cert.
 // The completion hook (devicecertcompletion.OnCommandResolved) emits the
@@ -104,9 +112,6 @@ func TestCertRenewal_F1_OfflineDeviceNoDuplicates(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const attemptTTL = 36 * time.Hour
-	const threshold = 7 * 24 * time.Hour
-
 	base := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
 	fc := clockmock.New(base)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -115,15 +120,15 @@ func TestCertRenewal_F1_OfflineDeviceNoDuplicates(t *testing.T) {
 	repo := mem.NewDeviceRepository()
 	require.NoError(t, repo.Create(ctx, &domain.Device{
 		ID: "dev-offline", Name: "offline-sensor", Status: "online", LastSeen: base,
-		CertEpoch: 1, CertExpiresAt: base.Add(24 * time.Hour),
+		CertEpoch: 1, CertExpiresAt: base.Add(certNearExpiry24h),
 	}))
 
 	// Producer: cert-renewal reconciler emitting into the Recorder.
 	rec := outboxtest.NewRecorder()
 	reconciler, err := devicecertrenewal.NewReconciler(fc, repo, rec.CellEmitter(),
 		devicecertrenewal.Policy{
-			Threshold:  threshold,
-			AttemptTTL: attemptTTL,
+			Threshold:  certRenewalThreshold7d,
+			AttemptTTL: certRenewalAttemptTTL,
 		}, logger)
 	require.NoError(t, err)
 
@@ -160,7 +165,7 @@ func TestCertRenewal_F1_OfflineDeviceNoDuplicates(t *testing.T) {
 	firstCmdID := active0[0].ID
 
 	// --- Phase 2: Advance clock past AttemptTTL + run Sweeper → Expired. ---
-	fc.Advance(attemptTTL + time.Second) // now > OverallDeadline of first command
+	fc.Advance(certRenewalAttemptTTL + time.Second) // now > OverallDeadline of first command
 
 	sweeper, err := kcommand.NewSweeper(queue, queue, fc)
 	require.NoError(t, err)
@@ -202,11 +207,9 @@ func TestCertRenewal_CompletionClosesLoop(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const attemptTTL = 36 * time.Hour
 	// Threshold 30d, CertValidity 90d (> threshold): a renewed cert is far from
 	// expiry, so the device drops out of the candidate set. This mirrors the
 	// cell's live co-tuning that buildCertRenewalSweeper asserts at startup.
-	const threshold = 30 * 24 * time.Hour
 
 	base := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
 	fc := clockmock.New(base)
@@ -216,13 +219,13 @@ func TestCertRenewal_CompletionClosesLoop(t *testing.T) {
 	repo := mem.NewDeviceRepository()
 	require.NoError(t, repo.Create(ctx, &domain.Device{
 		ID: "dev-online", Name: "online-sensor", Status: "online", LastSeen: base,
-		CertEpoch: 1, CertExpiresAt: base.Add(24 * time.Hour),
+		CertEpoch: 1, CertExpiresAt: base.Add(certNearExpiry24h),
 	}))
 
 	// Producer: cert-renewal reconciler emitting into rec.
 	rec := outboxtest.NewRecorder()
 	reconciler, err := devicecertrenewal.NewReconciler(fc, repo, rec.CellEmitter(),
-		devicecertrenewal.Policy{Threshold: threshold, AttemptTTL: attemptTTL}, logger)
+		devicecertrenewal.Policy{Threshold: certRenewalThreshold, AttemptTTL: certRenewalAttemptTTL}, logger)
 	require.NoError(t, err)
 
 	// Completion consumer: publishes rotation-resolved into rec2 and advances cert
@@ -309,9 +312,6 @@ func TestCertRenewal_EmitFailureSelfHeals(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	const attemptTTL = 36 * time.Hour
-	const threshold = 30 * 24 * time.Hour
-
 	base := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
 	fc := clockmock.New(base)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -320,13 +320,13 @@ func TestCertRenewal_EmitFailureSelfHeals(t *testing.T) {
 	repo := mem.NewDeviceRepository()
 	require.NoError(t, repo.Create(ctx, &domain.Device{
 		ID: "dev-failemit", Name: "fail-emit-sensor", Status: "online", LastSeen: base,
-		CertEpoch: 1, CertExpiresAt: base.Add(24 * time.Hour),
+		CertEpoch: 1, CertExpiresAt: base.Add(certNearExpiry24h),
 	}))
 
 	// Producer: cert-renewal reconciler emitting into rec.
 	rec := outboxtest.NewRecorder()
 	reconciler, err := devicecertrenewal.NewReconciler(fc, repo, rec.CellEmitter(),
-		devicecertrenewal.Policy{Threshold: threshold, AttemptTTL: attemptTTL}, logger)
+		devicecertrenewal.Policy{Threshold: certRenewalThreshold, AttemptTTL: certRenewalAttemptTTL}, logger)
 	require.NoError(t, err)
 
 	// Completion service with a FAILING emitter — Emit always errors.
@@ -370,7 +370,7 @@ func TestCertRenewal_EmitFailureSelfHeals(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), got.CertEpoch,
 		"cert state must NOT be advanced when emit fails (no resolved event delivered)")
-	assert.True(t, got.CertExpiresAt.Equal(base.Add(24*time.Hour)),
+	assert.True(t, got.CertExpiresAt.Equal(base.Add(certNearExpiry24h)),
 		"cert expiry must be unchanged when emit fails")
 
 	// --- Tick 2: device is still near-expiry → reconciler must re-emit. ---

--- a/examples/iotdevice/cells/devicecell/command_sweep_behavior_test.go
+++ b/examples/iotdevice/cells/devicecell/command_sweep_behavior_test.go
@@ -55,6 +55,9 @@ var sweepTestBase = time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
 const (
 	sweepWaitTimeout = 2 * time.Second
 	sweepWaitTick    = 5 * time.Millisecond
+	// sweepOverdueOffset is the age of the seeded overdue command relative to
+	// sweepTestBase (2h before "now"), making it past its 1h OverallDeadline.
+	sweepOverdueOffset = -2 * time.Hour
 )
 
 // newSweepTestCell builds a DeviceCell on the supplied fake clock + queue, with
@@ -109,7 +112,7 @@ func TestDeviceCell_CommandSweep_ExpiresOverdueCommand(t *testing.T) {
 		CommandType: "reboot",
 		Status:      kcommand.StatusPending,
 		// OverallDeadline = 1h, created 2h before "now" → already overdue.
-		CreatedAt: sweepTestBase.Add(-2 * time.Hour),
+		CreatedAt: sweepTestBase.Add(sweepOverdueOffset),
 		Timeouts:  kcommand.Timeouts{OverallDeadline: time.Hour},
 	}))
 

--- a/examples/iotdevice/cells/devicecell/internal/devicecmd/service_test.go
+++ b/examples/iotdevice/cells/devicecell/internal/devicecmd/service_test.go
@@ -23,6 +23,12 @@ import (
 	rtcommand "github.com/ghbvf/gocell/framework/runtime/command"
 )
 
+// Uniqueness / sweep duration constants used in enqueue tests.
+const (
+	testDeadlineTTL = 36 * time.Hour
+	testSweepFarOut = 365 * 24 * time.Hour
+)
+
 func testCodec() *query.CursorCodec {
 	codec, _ := query.NewCursorCodec(bytes.Repeat([]byte("k"), 32))
 	return codec
@@ -590,7 +596,7 @@ func TestEnqueue_WithDispatchedUniqueness_SetsIdempotencyKeyAndOverallDeadline(t
 	require.NoError(t, err)
 
 	const idemKey = "test-uniqueness-key-1"
-	deadline := base.Add(36 * time.Hour)
+	deadline := base.Add(testDeadlineTTL)
 
 	// Inject (key, deadline) as the relay would on dispatch.
 	uCtx := rtcommand.WithDispatchedUniqueness(ctx, idemKey, deadline)
@@ -614,7 +620,7 @@ func TestEnqueue_WithDispatchedUniqueness_SetsIdempotencyKeyAndOverallDeadline(t
 	// OverallDeadline: the stored entry must carry the OverallDeadline derived
 	// from deadline.Sub(now). We can verify indirectly via SweepOnce: advancing
 	// past the deadline and sweeping must expire the command.
-	fc.Advance(36*time.Hour + time.Second) // past OverallDeadline
+	fc.Advance(testDeadlineTTL + time.Second) // past OverallDeadline
 	transitions := command.SweepOnce(active, fc.Now())
 	require.Len(t, transitions, 1, "the command must be expired after advancing past OverallDeadline")
 	assert.Equal(t, command.StatusExpired, transitions[0].To)
@@ -658,6 +664,6 @@ func TestEnqueue_BareCtx_NoIdempotencyKeyNoDeadline(t *testing.T) {
 
 	// No OverallDeadline: sweeping at any time within the lease should not expire
 	// the command. (Zero deadline means the Sweeper never triggers PhaseOverall.)
-	transitions := command.SweepOnce(active, time.Now().Add(365*24*time.Hour))
+	transitions := command.SweepOnce(active, time.Now().Add(testSweepFarOut))
 	assert.Empty(t, transitions, "bare-ctx commands have no OverallDeadline — Sweeper must not expire them")
 }

--- a/examples/iotdevice/cells/devicecell/internal/domain/conformance/conformance.go
+++ b/examples/iotdevice/cells/devicecell/internal/domain/conformance/conformance.go
@@ -22,6 +22,13 @@ import (
 // fmtListErr is the t.Fatalf format string for List errors (3 sites).
 const fmtListErr = "List: %v"
 
+// Cert-lifetime constants used across conformance sub-tests.
+const (
+	conf30Days  = 30 * 24 * time.Hour
+	conf90Days  = 90 * 24 * time.Hour
+	conf365Days = 365 * 24 * time.Hour
+)
+
 // DeviceRepoFactory builds a fresh DeviceRepository and its matching TxRunner.
 // cleanup MUST be idempotent and safe to call even if no resources were
 // acquired. now returns the suite's clock — implementations using wall time
@@ -382,7 +389,7 @@ func runCertRenewalCandidatesNearExpiry(t *testing.T, factory DeviceRepoFactory,
 	defer cleanup()
 	ctx := context.Background()
 	base := now()
-	cutoff := base.Add(30 * 24 * time.Hour)
+	cutoff := base.Add(conf30Days)
 
 	mk := func(id string, epoch int64, expiresAt time.Time) *domain.Device {
 		return &domain.Device{
@@ -430,7 +437,7 @@ func runCertRenewalCandidatesReturnsAllNearExpiry(t *testing.T, factory DeviceRe
 	defer cleanup()
 	ctx := context.Background()
 	base := now()
-	cutoff := base.Add(30 * 24 * time.Hour)
+	cutoff := base.Add(conf30Days)
 
 	const totalDevices = 5
 	// Seed 5 near-expiry devices with distinct ascending expiries.
@@ -483,7 +490,7 @@ func runAdvanceCertAfterRotationSuccess(t *testing.T, factory DeviceRepoFactory,
 		CertEpoch: 2, CertExpiresAt: nearExpiry,
 	})
 
-	newExpiry := base.Add(90 * 24 * time.Hour).Truncate(time.Second)
+	newExpiry := base.Add(conf90Days).Truncate(time.Second)
 	advanced := advanceCert(t, ctx, repo, tx, features, "adv-1", 2, newExpiry)
 	if !advanced {
 		t.Fatal("AdvanceCertAfterRotation(adv-1, epoch 2): advanced=false, want true")
@@ -500,7 +507,7 @@ func runAdvanceCertAfterRotationSuccess(t *testing.T, factory DeviceRepoFactory,
 		t.Fatalf("CertExpiresAt = %v, want %v (new expiry)", got.CertExpiresAt, newExpiry)
 	}
 	// Loop-closing: a far-future expiry means the device is no longer a candidate.
-	cands, err := repo.ListCertificateRenewalCandidates(ctx, base.Add(30*24*time.Hour))
+	cands, err := repo.ListCertificateRenewalCandidates(ctx, base.Add(conf30Days))
 	if err != nil {
 		t.Fatalf("ListCertificateRenewalCandidates: %v", err)
 	}
@@ -527,13 +534,13 @@ func runAdvanceCertAfterRotationStaleEpochNoOp(t *testing.T, factory DeviceRepoF
 		CertEpoch: 2, CertExpiresAt: base.Add(time.Hour),
 	})
 
-	firstExpiry := base.Add(90 * 24 * time.Hour).Truncate(time.Second)
+	firstExpiry := base.Add(conf90Days).Truncate(time.Second)
 	if !advanceCert(t, ctx, repo, tx, features, "adv-stale", 2, firstExpiry) {
 		t.Fatal("first advance: advanced=false, want true")
 	}
 
 	// Replay the SAME resolve (rotatedEpoch=2) — device is now at epoch 3.
-	staleExpiry := base.Add(365 * 24 * time.Hour).Truncate(time.Second)
+	staleExpiry := base.Add(conf365Days).Truncate(time.Second)
 	if advanceCert(t, ctx, repo, tx, features, "adv-stale", 2, staleExpiry) {
 		t.Fatal("stale-epoch replay: advanced=true, want false (idempotent no-op)")
 	}
@@ -559,7 +566,7 @@ func runAdvanceCertAfterRotationUnknownDevice(t *testing.T, factory DeviceRepoFa
 	defer cleanup()
 	ctx := context.Background()
 
-	if advanceCert(t, ctx, repo, tx, features, "ghost", 1, now().Add(90*24*time.Hour)) {
+	if advanceCert(t, ctx, repo, tx, features, "ghost", 1, now().Add(conf90Days)) {
 		t.Fatal("unknown device: advanced=true, want false (idempotent no-op)")
 	}
 }

--- a/examples/iotdevice/cells/devicecell/slices/devicecertcompletion/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecertcompletion/service_test.go
@@ -22,6 +22,9 @@ import (
 
 var testBase = time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
 
+// certLifetime1y is the far-future cert lifetime used to seed already-advanced devices in tests.
+const certLifetime1y = 365 * 24 * time.Hour
+
 // selfCtx returns a context carrying a device-self principal (PrincipalUser with
 // Subject == deviceID) — the identity a device presents when acking its OWN
 // rotate-cert command. OnCommandResolved emits the completion event only for
@@ -263,7 +266,7 @@ func TestHandleRotationResolved_Succeeded_AdvancesCert(t *testing.T) {
 
 func TestHandleRotationResolved_StaleEpoch_AckNoOp(t *testing.T) {
 	repo := mem.NewDeviceRepository()
-	seedDevice(t, repo, "dev-1", 3, testBase.Add(365*24*time.Hour)) // already advanced
+	seedDevice(t, repo, "dev-1", 3, testBase.Add(certLifetime1y)) // already advanced
 	svc, _ := newTestService(t, repo)
 
 	// Replay a resolve for the now-stale epoch 2.

--- a/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/reconciler_loop_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/reconciler_loop_test.go
@@ -15,16 +15,20 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/framework/kernel/outbox/outboxtest"
 	"github.com/ghbvf/gocell/framework/kernel/reconcile"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/pkg/testutil/testwait"
 	rtcommand "github.com/ghbvf/gocell/framework/runtime/command"
 )
+
+// certRenewalLoopTestCertWindow is the cert expiry window seeded in loop tests.
+const certRenewalLoopTestCertWindow = 24 * time.Hour
 
 // stopLoop stops a reconcile.Loop and fails the test if it does not stop within
 // the budget. Must be called BEFORE goleak.VerifyNone so all loop goroutines are
 // joined before the leak check runs.
 func stopLoop(t *testing.T, loop *reconcile.Loop) {
 	t.Helper()
-	sc, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	sc, cancel := context.WithTimeout(context.Background(), testtime.EventuallyLong)
 	defer cancel()
 	require.NoError(t, loop.Stop(sc), "loop must stop cleanly within the budget")
 }
@@ -44,7 +48,7 @@ func TestReconciler_EmitsSystemTenantlessPrincipalViaLoop(t *testing.T) {
 	leakOpt := goleak.IgnoreCurrent()
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
-	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(24*time.Hour))
+	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(certRenewalLoopTestCertWindow))
 
 	rec := outboxtest.NewRecorder()
 	r := newTestReconciler(t, clockmock.New(certTestBase), repo, rec)
@@ -65,7 +69,7 @@ func TestReconciler_EmitsSystemTenantlessPrincipalViaLoop(t *testing.T) {
 	// so one Loop dispatch yields exactly one entry.
 	testwait.External(t, "cert-renewal-loop-emit",
 		func() bool { return len(rec.Entries()) == 1 },
-		3*time.Second, 5*time.Millisecond,
+		testtime.EventuallyDefault, testtime.FastPoll,
 		"the Loop-driven reconcile must emit exactly one rotate-cert command")
 
 	// Stop the loop before goleak runs — loop goroutines must be joined first.
@@ -135,7 +139,7 @@ func TestReconciler_OneTickEmitsAllNearExpiry(t *testing.T) {
 
 	testwait.External(t, "cert-renewal-full-sweep",
 		func() bool { return len(rec.Entries()) == totalCerts },
-		3*time.Second, 10*time.Millisecond,
+		testtime.EventuallyDefault, testtime.D10ms,
 		"all %d near-expiry certs must be emitted in a single tick (no batch boundary)", totalCerts)
 
 	// Stop the loop before goleak runs — loop goroutines must be joined first.

--- a/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/reconciler_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/reconciler_test.go
@@ -28,6 +28,14 @@ const certRenewalTestThreshold = 7 * 24 * time.Hour
 // certRenewalTestAttemptTTL is the AttemptTTL used in unit tests.
 const certRenewalTestAttemptTTL = 36 * time.Hour
 
+// Cert window constants used across reconciler unit tests.
+const (
+	certWindow12h = 12 * time.Hour
+	certWindow18h = 18 * time.Hour
+	certWindow24h = 24 * time.Hour
+	certWindow30d = 30 * 24 * time.Hour
+)
+
 // certRenewalTestPolicy is the standard test policy. The stateless producer
 // sweeps ALL near-expiry certs per tick — no BatchSize or BatchRequeue needed.
 var certRenewalTestPolicy = Policy{
@@ -68,8 +76,8 @@ func TestReconciler_EmitsRenewalForNearExpiry(t *testing.T) {
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
 	// dev-near expires within the threshold; dev-far is well outside it.
-	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(24*time.Hour))
-	seedCert(t, ctx, repo, "dev-far", certTestBase.Add(30*24*time.Hour))
+	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(certWindow24h))
+	seedCert(t, ctx, repo, "dev-far", certTestBase.Add(certWindow30d))
 
 	rec := outboxtest.NewRecorder()
 	r := newTestReconciler(t, clockmock.New(certTestBase), repo, rec)
@@ -93,7 +101,7 @@ func TestReconciler_EmitsRenewalForNearExpiry(t *testing.T) {
 	var p rotateCertPayload
 	require.NoError(t, json.Unmarshal([]byte(req.Payload), &p))
 	assert.Equal(t, int64(1), p.Epoch)
-	assert.Equal(t, certTestBase.Add(24*time.Hour).UTC().Format(time.RFC3339), p.NotAfter)
+	assert.Equal(t, certTestBase.Add(certWindow24h).UTC().Format(time.RFC3339), p.NotAfter)
 }
 
 // TestReconciler_EmitsWithActiveUniqueness verifies that each emitted rotate-cert
@@ -105,7 +113,7 @@ func TestReconciler_EmitsWithActiveUniqueness(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
-	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(24*time.Hour))
+	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(certWindow24h))
 
 	rec := outboxtest.NewRecorder()
 	fc := clockmock.New(certTestBase)
@@ -132,7 +140,7 @@ func TestReconciler_NoEmitWhenNoneNearExpiry(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
-	seedCert(t, ctx, repo, "dev-far", certTestBase.Add(30*24*time.Hour))
+	seedCert(t, ctx, repo, "dev-far", certTestBase.Add(certWindow30d))
 
 	rec := outboxtest.NewRecorder()
 	r := newTestReconciler(t, clockmock.New(certTestBase), repo, rec)
@@ -154,7 +162,7 @@ func TestReconciler_ReemitsForNewEpoch(t *testing.T) {
 	// epoch 2, near expiry.
 	require.NoError(t, repo.Create(ctx, &domain.Device{
 		ID: "dev-near", Name: "dev-near", Status: "online", LastSeen: certTestBase,
-		CertEpoch: 2, CertExpiresAt: certTestBase.Add(12 * time.Hour),
+		CertEpoch: 2, CertExpiresAt: certTestBase.Add(certWindow12h),
 	}))
 
 	rec := outboxtest.NewRecorder()
@@ -177,7 +185,7 @@ func TestReconciler_StatelessEmitsOnEachTick(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
-	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(24*time.Hour))
+	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(certWindow24h))
 
 	rec := outboxtest.NewRecorder()
 	fc := clockmock.New(certTestBase)
@@ -262,8 +270,8 @@ func TestReconciler_PartialBatchFailureRetriesOnlyFailed(t *testing.T) {
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
 
-	seedCert(t, ctx, repo, "dev-a", certTestBase.Add(12*time.Hour))
-	seedCert(t, ctx, repo, "dev-b", certTestBase.Add(18*time.Hour))
+	seedCert(t, ctx, repo, "dev-a", certTestBase.Add(certWindow12h))
+	seedCert(t, ctx, repo, "dev-b", certTestBase.Add(certWindow18h))
 
 	wantErr := errors.New("emit failed for dev-b")
 	rec := outboxtest.NewRecorder()
@@ -309,7 +317,7 @@ func TestReconciler_EmitFailureBubbles(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := mem.NewDeviceRepository()
-	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(24*time.Hour))
+	seedCert(t, ctx, repo, "dev-near", certTestBase.Add(certWindow24h))
 
 	wantErr := errors.New("emit failed")
 	r, err := NewReconciler(clockmock.New(certTestBase), repo,

--- a/examples/iotdevice/cells/devicecell/slices/devicecommand/cross_cell_dedup_e2e_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommand/cross_cell_dedup_e2e_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +32,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/idempotency"
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 	runtimecommand "github.com/ghbvf/gocell/framework/runtime/command"
 	idemhttp "github.com/ghbvf/gocell/framework/runtime/http/idempotency"
@@ -90,8 +90,8 @@ func newAsyncRelay(t *testing.T, store *outboxtest.FakeStore, reg *runtimecomman
 	t.Helper()
 	relay := outbox.NewRelay(clock.Real(), store, &kout.DiscardPublisher{},
 		outbox.RelayConfig{
-			PollInterval:   5 * time.Millisecond,
-			BaseRetryDelay: 5 * time.Millisecond,
+			PollInterval:   testtime.FastPoll,
+			BaseRetryDelay: testtime.FastPoll,
 		}.WithDefaults())
 	relay.WithCommandDispatch(reg, map[runtimecommand.CommandID]runtimecommand.AsyncDispatchFunc{
 		enqueue.DispatchID: enqueue.DispatchAsync,
@@ -130,7 +130,7 @@ func TestCrossCell_HTTPAsyncEnqueue_SameSlotDedup(t *testing.T) {
 	assert.NotEqual(t, rows[0].Entry.ID(), rows[1].Entry.ID(), "store ids must differ (two writes)")
 
 	relay := newAsyncRelay(t, store, reg)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyDefault)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 
@@ -173,7 +173,7 @@ func TestCrossCell_HTTPAsyncEnqueue_DifferentPayloadNotFolded(t *testing.T) {
 		"#1610 F1: same key + DIFFERENT payload must NOT fold to the same dedup slot")
 
 	relay := newAsyncRelay(t, store, reg)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyDefault)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 

--- a/examples/iotdevice/cells/devicecell/slices/devicecommandrpc/handler_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecommandrpc/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/command/commandtest"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/query"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 	commandv1 "github.com/ghbvf/gocell/generated/contracts/grpc/device/command/v1"
 )
@@ -184,7 +185,7 @@ func TestServer_IssueCommand_OverGRPC(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	client := commandv1.NewDeviceCommandServiceClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyLong)
 	defer cancel()
 
 	t.Run("success", func(t *testing.T) {

--- a/examples/iotdevice/command_dedup_durable_integration_test.go
+++ b/examples/iotdevice/command_dedup_durable_integration_test.go
@@ -44,6 +44,7 @@ import (
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/framework/pkg/migration"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/command"
 	outboxruntime "github.com/ghbvf/gocell/framework/runtime/outbox"
 	enqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
@@ -112,7 +113,7 @@ func TestCommandRelay_Durable_PG(t *testing.T) {
 		require.Eventually(t, func() bool {
 			pub, perr := outboxCount(context.Background(), pool, "published")
 			return perr == nil && pub == 2
-		}, 60*time.Second, 200*time.Millisecond,
+		}, testtime.D60s, testtime.D200ms,
 			"both command entries must settle to published (one dispatched, one deduped)")
 
 		// Stop the relay (wait for its goroutine to exit) before reading h.calls:
@@ -189,7 +190,7 @@ func TestCommandRelay_Durable_PG(t *testing.T) {
 		require.Eventually(t, func() bool {
 			dead, derr := outboxCount(context.Background(), pool, "dead")
 			return derr == nil && dead == 1
-		}, 30*time.Second, 200*time.Millisecond,
+		}, testtime.D30s, testtime.D200ms,
 			"identity-less command entry must be fail-closed dead-lettered on PG")
 		// Stop the relay before reading h.calls (happens-before; see ①).
 		stop()

--- a/examples/iotdevice/command_dedup_e2e_test.go
+++ b/examples/iotdevice/command_dedup_e2e_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/idempotency"
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/command"
 	"github.com/ghbvf/gocell/framework/runtime/outbox"
 	"github.com/ghbvf/gocell/framework/runtime/outbox/outboxtest"
@@ -59,8 +60,8 @@ func newDedupRelay(t *testing.T, store *outboxtest.FakeStore, reg *command.Regis
 		// command entries claimed in one batch before the first commits) re-claims
 		// quickly within the test deadline; the default 5s would exceed it.
 		outbox.RelayConfig{
-			PollInterval:   5 * time.Millisecond,
-			BaseRetryDelay: 5 * time.Millisecond,
+			PollInterval:   testtime.FastPoll,
+			BaseRetryDelay: testtime.FastPoll,
 		}.WithDefaults())
 	relay.WithCommandDispatch(reg, map[command.CommandID]command.AsyncDispatchFunc{
 		enqueue.DispatchID: enqueue.DispatchAsync,
@@ -128,7 +129,7 @@ func TestCommandRelay_DedupOnEventRedelivery(t *testing.T) {
 	assert.NotEqual(t, rows[0].Entry.ID(), rows[1].Entry.ID(), "store ids must differ")
 
 	relay := newDedupRelay(t, store, reg)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyDefault)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 
@@ -172,7 +173,7 @@ func TestCommandRelay_FailClosedOnMissingIdentity(t *testing.T) {
 	store.Seed(outbox.ClaimedEntry{Entry: bad})
 
 	relay := newDedupRelay(t, store, reg)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyDefault)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 
@@ -200,7 +201,7 @@ func TestCommandRelay_NormalCommitDispatch(t *testing.T) {
 		svc.HandleDeviceRegistered(context.Background(), sourceEvent(t, "d2", "evt-single")).Disposition)
 
 	relay := newDedupRelay(t, store, reg)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.EventuallyDefault)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 

--- a/examples/iotdevice/commandbus_roundtrip_test.go
+++ b/examples/iotdevice/commandbus_roundtrip_test.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +24,7 @@ import (
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/errcode/errcodetest"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/command"
 	"github.com/ghbvf/gocell/framework/runtime/outbox"
 	"github.com/ghbvf/gocell/framework/runtime/outbox/outboxtest"
@@ -323,12 +323,12 @@ func TestCommandBus_Enqueue_AsyncRelayEndToEnd(t *testing.T) {
 	store.Seed(outbox.ClaimedEntry{Entry: newAsyncCommandEntry(t, enqueue.Request{DeviceID: "d1", CommandType: "reboot", Payload: "now"})})
 
 	relay := outbox.NewRelay(clock.Real(), store, &kout.DiscardPublisher{},
-		outbox.RelayConfig{PollInterval: 5 * time.Millisecond}.WithDefaults())
+		outbox.RelayConfig{PollInterval: testtime.FastPoll}.WithDefaults())
 	relay.WithCommandDispatch(reg, map[command.CommandID]command.AsyncDispatchFunc{
 		enqueue.DispatchID: enqueue.DispatchAsync,
 	}, idempotency.NewInMemClaimer(clock.Real()))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 
@@ -364,12 +364,12 @@ func TestCommandBus_Enqueue_AsyncRelayValueValidationDeadLetters(t *testing.T) {
 	store.Seed(outbox.ClaimedEntry{Entry: invalidEntry})
 
 	relay := outbox.NewRelay(clock.Real(), store, &kout.DiscardPublisher{},
-		outbox.RelayConfig{PollInterval: 5 * time.Millisecond}.WithDefaults())
+		outbox.RelayConfig{PollInterval: testtime.FastPoll}.WithDefaults())
 	relay.WithCommandDispatch(reg, map[command.CommandID]command.AsyncDispatchFunc{
 		enqueue.DispatchID: enqueue.DispatchAsync,
 	}, idempotency.NewInMemClaimer(clock.Real()))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.D2s)
 	defer cancel()
 	go func() { _ = relay.Start(ctx) }()
 

--- a/examples/orderfulfillment/cells/orderfulfillmentcell/slices/placeorder/durable_replay_integration_test.go
+++ b/examples/orderfulfillment/cells/orderfulfillmentcell/slices/placeorder/durable_replay_integration_test.go
@@ -58,6 +58,12 @@ import (
 	of "github.com/ghbvf/gocell/generated/contracts/saga/orderfulfillment/v1"
 )
 
+// tailerBStabilityWindow is the sleep duration that lets Tailer B tick a few
+// times before asserting no-regression on the terminal status read model. It is
+// intentionally 3 × FastPoll so that any spurious re-process of journal events
+// has time to surface before the assertion.
+const tailerBStabilityWindow = 3 * testtime.FastPoll
+
 // applyOrderfulfillmentMigration applies the orderfulfillment example migration
 // (creates the order_saga_status table) to pool. The platform schema (obtained
 // from the pgtest template clone) is already present.
@@ -428,7 +434,7 @@ func TestDurableReplay_PGProjectionSurvivesRestart(t *testing.T) {
 	//     anything else).
 	// We give Tailer B 3 × FastPoll ticks to re-process any journal events it
 	// might replay, then verify the status is still terminal.
-	time.Sleep(3 * testtime.FastPoll) //archtest:allow:test-sleep stability window: lets Tailer B tick a few times before asserting no-regression; no completion channel to wait on
+	time.Sleep(tailerBStabilityWindow) //archtest:allow:test-sleep no completion channel to wait on
 	pgStatus3, found3, err := pgRM2.Get(ctx, orderID)
 	if err != nil {
 		t.Fatalf("durable_replay: pgRM2.Get (stability check): %v", err)

--- a/tools/archtest/prod_invariants_test.go
+++ b/tools/archtest/prod_invariants_test.go
@@ -55,7 +55,12 @@ func TestProdDurationConst(t *testing.T) {
 	}
 
 	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
+	// PatternsWithSatellites adds the cmd/adapters satellite parents the typed
+	// loader expands to real members — #2136. (examples/ production files are
+	// filtered out below by fileroles.IsProductionCode, so its production duration
+	// literals stay demo-exempt; the satellite increment is shared, the filter
+	// handles the examples/ asymmetry.)
+	patterns := prodscan.PatternsWithSatellites(root)
 
 	var violations []string
 	Run(t, Typed(TypedOpts{Tests: false, Tags: []string{"e2e", "integration", "pg"}}, patterns),

--- a/tools/archtest/test_time_literal_test.go
+++ b/tools/archtest/test_time_literal_test.go
@@ -69,7 +69,10 @@ func TestTestTimeLiteralConst(t *testing.T) {
 	// produce a false-green in CI. The full scan is ~1-2 s after caching.
 
 	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
+	// PatternsWithSatellites adds the cmd/adapters/examples satellite parents the
+	// typed loader expands to real members — #2136. The satellite-free Patterns set
+	// would silently skip them (vacuous on satellite test code).
+	patterns := prodscan.PatternsWithSatellites(root)
 
 	var violations []string
 	Run(t, Typed(TypedOpts{Tests: true, Tags: FlatNonDefaultTags()}, patterns),

--- a/tools/internal/prodscan/patterns.go
+++ b/tools/internal/prodscan/patterns.go
@@ -22,11 +22,11 @@ import (
 //     sibling go.work member); the bare kernel/runtime/pkg no longer exist at the
 //     root and are pruned; cmd/adapters/examples each hold SEVERAL go.work member
 //     modules (multi-member parents), so their "./<dir>/…" pattern is owned by no
-//     single member and is pruned by HasNestedModuleRoot — this broad production
-//     scan defers their coverage to gh #2136 (rules that need satellite coverage
-//     today hardcode the patterns + rely on the loader's workspace expansion, see
-//     the Patterns godoc). cellmodules/corecells are module roots → pruned by
-//     IsModuleRoot.
+//     single member and is pruned by HasNestedModuleRoot from THIS satellite-free
+//     scan (metricschema's OBS-01 loader cannot expand a multi-member prefix). The
+//     typeseval-backed duration gates opt INTO satellite coverage via
+//     PatternsWithSatellites; OBS-01 metric-PII coverage of satellites stays gh
+//     #2136. cellmodules/corecells are module roots → pruned by IsModuleRoot.
 //   - Single-module fixture: framework/<layer> doesn't exist (pruned); the bare
 //     cmd/pkg/kernel/runtime the fixture writes ARE part of the one module, so their
 //     "./<dir>/…" pattern matches under ModeModule and is actually scanned.
@@ -48,8 +48,7 @@ var topLevelDirs = []string{
 // governance scanners. Missing top-level directories are skipped so temp-module
 // fixtures can exercise the production entrypoints without synthetic dirs.
 //
-// Two kinds of top-level dir are skipped, both deferred to the ModeWorkspace
-// cross-module migration gh #2136:
+// Two kinds of top-level dir are pruned from this satellite-FREE scan:
 //
 //   - A go.work satellite MODULE ROOT (carries its own go.mod — e.g. cellmodules/
 //     after #1559, corecells/): a single module addressed by its own member
@@ -60,18 +59,24 @@ var topLevelDirs = []string{
 //     no single member, so post-#1565 (no root module to anchor it) it would
 //     hard-error or silently match-zero (HasNestedModuleRoot).
 //
-// Both are pruned so this PRODUCTION scan (OBS-01 + the typed governance rules that
-// consume Patterns / PatternsExtended) stays loadable and does not silently drag
-// in satellite packages whose coverage is still gh #2136. A single-module fixture
-// writes cmd/pkg/... as part of its ONE module (no nested go.mod), so neither
-// predicate fires there and the fixture's "./cmd/..." is kept and scanned.
+// Both are pruned so this PRODUCTION scan stays loadable under metricschema's OBS-01
+// loader, which loads each pattern in ModeModule/ModeWorkspace and does NOT expand a
+// multi-member parent prefix. A single-module fixture writes cmd/pkg/... as part of
+// its ONE module (no nested go.mod), so neither predicate fires there and the
+// fixture's "./cmd/..." is kept and scanned.
 //
-// Security/governance rules that DO require satellite coverage today hardcode the
-// satellite patterns ("./cmd/...", "./adapters/...") at their call sites; the typed
-// loader expands those to real members via workspace.ExpandParentPrefix (kept honest
-// by SATELLITE-PARENT-PREFIX-SCAN-01). That opt-in path is independent of this scan
-// list — Patterns deliberately does NOT emit the satellite prefixes for the broad
-// production scan.
+// Rules that DO require satellite coverage opt in through the typed (typeseval)
+// loader, which expands a satellite parent prefix to its real go.work members via
+// workspace.ExpandParentPrefix (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01):
+//
+//   - the broad duration gates (TEST-TIME-LITERAL-01, PROD-DURATION-CONST-01) take
+//     the whole satellite set via PatternsWithSatellites; and
+//   - narrow security/authz funnels (fence-token mint, …) hardcode the specific
+//     satellite patterns they need.
+//
+// Both opt-in paths are independent of THIS list — Patterns deliberately does NOT
+// emit the satellite prefixes, since OBS-01's loader cannot expand them (its own
+// metric-PII coverage of satellites remains gh #2136).
 func Patterns(root string) []string {
 	var patterns []string
 	if dirHasNonTestGoFiles(root) {
@@ -118,6 +123,44 @@ func PatternsExtended(root string) []string {
 		base = append(base, "./tools/...")
 	}
 	return base
+}
+
+// PatternsWithSatellites widens PatternsExtended(root) with the multi-member
+// satellite parent prefixes ("./cmd/...", "./adapters/...", "./examples/...") that
+// Patterns deliberately prunes. It is the production-scan source-of-record for the
+// typed (typeseval) duration gates — TEST-TIME-LITERAL-01 and PROD-DURATION-CONST-01
+// — that load via tools/archtest's typed façade, whose workspace.ExpandParentPrefix
+// expands each satellite parent prefix to its real go.work members before loading
+// (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01). Only that path can actually scan
+// the satellites, so only this constructor emits their prefixes (#2136).
+//
+// Two scan constructors exist, split by LOADER CAPABILITY — not by accident — and
+// they must NOT be merged (doing so re-breaks metricschema):
+//
+//   - Patterns / PatternsExtended (satellite-FREE): consumed by metricschema's
+//     OBS-01 loader, which does NOT expand a multi-member parent prefix; handing it
+//     "./cmd/..." (owned by no single go.work member post-#1565) hard-errors or
+//     match-zeroes, so the satellite parents are pruned there.
+//   - PatternsWithSatellites: consumed only by the typeseval-backed duration gates,
+//     which CAN expand the satellite prefixes.
+//
+// The satellite increment is DERIVED from the same HasNestedModuleRoot predicate
+// Patterns prunes on — not a hand-maintained list — so a future fourth multi-member
+// parent is picked up automatically. A single-module fixture has no nested go.mod, so
+// the increment is empty there and this equals PatternsExtended.
+//
+// Do NOT fold the satellite prefixes into PatternsExtended itself: its other
+// consumers (e.g. errcode_invariants) would then silently gain unreviewed satellite
+// scope. Widening to satellites is a per-gate opt-in by name, not a global default.
+func PatternsWithSatellites(root string) []string {
+	patterns := PatternsExtended(root)
+	for _, dir := range topLevelDirs {
+		full := filepath.Join(root, dir)
+		if dirExists(full) && !IsModuleRoot(full) && HasNestedModuleRoot(full) {
+			patterns = append(patterns, "./"+dir+"/...")
+		}
+	}
+	return patterns
 }
 
 func dirExists(path string) bool {

--- a/tools/internal/prodscan/patterns.go
+++ b/tools/internal/prodscan/patterns.go
@@ -127,12 +127,21 @@ func PatternsExtended(root string) []string {
 
 // PatternsWithSatellites widens PatternsExtended(root) with the multi-member
 // satellite parent prefixes ("./cmd/...", "./adapters/...", "./examples/...") that
-// Patterns deliberately prunes. It is the production-scan source-of-record for the
-// typed (typeseval) duration gates — TEST-TIME-LITERAL-01 and PROD-DURATION-CONST-01
-// — that load via tools/archtest's typed façade, whose workspace.ExpandParentPrefix
-// expands each satellite parent prefix to its real go.work members before loading
-// (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01). Only that path can actually scan
-// the satellites, so only this constructor emits their prefixes (#2136).
+// Patterns deliberately prunes.
+//
+// USE FOR typeseval-backed gates ONLY. The emitted satellite prefixes are owned by
+// no single go.work member and can only be loaded by a loader that expands them via
+// workspace.ExpandParentPrefix (tools/archtest's typed façade). Do NOT pass the
+// result to a ModeModule/ModeWorkspace loader that does not expand (e.g. metricschema
+// OBS-01's loadPackages) — it would hard-error or match-zero. Those callers use the
+// satellite-free Patterns / PatternsExtended instead.
+//
+// It is the production-scan source-of-record for the typed (typeseval) duration
+// gates — TEST-TIME-LITERAL-01 and PROD-DURATION-CONST-01 — whose loader's
+// workspace.ExpandParentPrefix expands each satellite parent prefix to its real
+// go.work members before loading (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01).
+// Only that path can actually scan the satellites, so only this constructor emits
+// their prefixes (#2136).
 //
 // Two scan constructors exist, split by LOADER CAPABILITY — not by accident — and
 // they must NOT be merged (doing so re-breaks metricschema):
@@ -146,8 +155,11 @@ func PatternsExtended(root string) []string {
 //
 // The satellite increment is DERIVED from the same HasNestedModuleRoot predicate
 // Patterns prunes on — not a hand-maintained list — so a future fourth multi-member
-// parent is picked up automatically. A single-module fixture has no nested go.mod, so
-// the increment is empty there and this equals PatternsExtended.
+// parent is picked up automatically. It re-includes ONLY multi-member parents:
+// plain module-root dirs (cellmodules/, corecells/) stay excluded by !IsModuleRoot,
+// since they are not expandable parent prefixes (their satellite coverage is gh
+// #2136, a separate concern). A single-module fixture has no nested go.mod, so the
+// increment is empty there and this equals PatternsExtended.
 //
 // Do NOT fold the satellite prefixes into PatternsExtended itself: its other
 // consumers (e.g. errcode_invariants) would then silently gain unreviewed satellite

--- a/tools/internal/prodscan/patterns_test.go
+++ b/tools/internal/prodscan/patterns_test.go
@@ -3,6 +3,7 @@ package prodscan
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -122,7 +123,10 @@ func TestPatternsWithSatellites(t *testing.T) {
 		})
 		ext := PatternsExtended(root)
 		full := PatternsWithSatellites(root)
-		if len(full) != len(ext) {
+		// Content equality, not just length: a regression that dropped a base
+		// pattern while adding a spurious one would keep the length equal but
+		// must still fail here.
+		if !slices.Equal(ext, full) {
 			t.Errorf("single-module fixture: PatternsWithSatellites must equal PatternsExtended "+
 				"(no nested go.mod → empty satellite increment); ext=%v full=%v", ext, full)
 		}

--- a/tools/internal/prodscan/patterns_test.go
+++ b/tools/internal/prodscan/patterns_test.go
@@ -67,6 +67,68 @@ func TestPatternsSkipsMultiMemberSatelliteParents(t *testing.T) {
 	}
 }
 
+// TestPatternsWithSatellites pins #2136: PatternsWithSatellites is the duration
+// gates' opt-in to satellite coverage — it widens PatternsExtended with EXACTLY the
+// multi-member satellite parent prefixes (cmd/adapters/examples) that Patterns
+// prunes. Anti-vacuity: in a real multi-member workspace the increment must be
+// NON-EMPTY (and those prefixes must be ABSENT from PatternsExtended, proving the
+// widening is real, not already present); in a single-module fixture the increment
+// must be EMPTY (== PatternsExtended).
+func TestPatternsWithSatellites(t *testing.T) {
+	t.Run("real workspace adds satellite parents", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"framework/kernel/k.go":    "package kernel\n",
+			"cmd/gocell/go.mod":        "module x/cmd/gocell\n",
+			"cmd/gocell/main.go":       "package main\n",
+			"cmd/corebundle/go.mod":    "module x/cmd/corebundle\n",
+			"cmd/corebundle/main.go":   "package main\n",
+			"adapters/postgres/go.mod": "module x/adapters/postgres\n",
+			"adapters/postgres/pg.go":  "package postgres\n",
+			"examples/iot/go.mod":      "module x/examples/iot\n",
+			"examples/iot/main.go":     "package main\n",
+		})
+		base := map[string]bool{}
+		for _, p := range PatternsExtended(root) {
+			base[p] = true
+		}
+		got := map[string]bool{}
+		for _, p := range PatternsWithSatellites(root) {
+			got[p] = true
+		}
+		for _, sat := range []string{"./cmd/...", "./adapters/...", "./examples/..."} {
+			if base[sat] {
+				t.Fatalf("PatternsExtended unexpectedly contains %q; the satellite increment is vacuous", sat)
+			}
+			if !got[sat] {
+				t.Errorf("PatternsWithSatellites must add %q; got %v", sat, PatternsWithSatellites(root))
+			}
+		}
+		for p := range base {
+			if !got[p] {
+				t.Errorf("PatternsWithSatellites dropped base pattern %q (must be a superset of PatternsExtended)", p)
+			}
+		}
+		if len(PatternsWithSatellites(root)) <= len(PatternsExtended(root)) {
+			t.Errorf("PatternsWithSatellites must strictly widen PatternsExtended in a multi-member workspace; "+
+				"ext=%v full=%v", PatternsExtended(root), PatternsWithSatellites(root))
+		}
+	})
+
+	t.Run("single-module fixture adds nothing", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"go.mod":      "module x\n",
+			"cmd/main.go": "package main\n",
+			"pkg/util.go": "package pkg\n",
+		})
+		ext := PatternsExtended(root)
+		full := PatternsWithSatellites(root)
+		if len(full) != len(ext) {
+			t.Errorf("single-module fixture: PatternsWithSatellites must equal PatternsExtended "+
+				"(no nested go.mod → empty satellite increment); ext=%v full=%v", ext, full)
+		}
+	})
+}
+
 // TestPatternsKeepsSingleModuleFixtureDirs proves the prune is real-workspace-only:
 // a single-module fixture writes cmd/pkg/... as part of its ONE module (no nested
 // go.mod), so those dirs stay scannable.

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -899,6 +899,11 @@ func TestOBS01CoverageRequiresFramework(t *testing.T) {
 		"OBS-01 production scan must cover the framework module (post-#1565 core: kernel/runtime/pkg)")
 
 	// (2) load-witness: framework layers load non-empty through OBS-01's loader.
+	// loadPackages is the SAME entry CheckOBS01 → checkOBS01WithPatterns uses; with
+	// >1 pattern it routes through loadPatternScopedPackages, where patternLoadMode
+	// auto-selects ModeWorkspace for the framework module root. So this exercises the
+	// real OBS-01 load path, not a weaker stand-in. (Non-project packages are dropped
+	// by packageHasProjectFile, so pkgs are framework project packages.)
 	frameworkPatterns := []string{
 		"./framework/kernel/...",
 		"./framework/runtime/...",

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -868,6 +868,73 @@ func TestOBS01ProductionPatternsCoverProjectPackages(t *testing.T) {
 	assert.Empty(t, missing, "new production Go top-level directories must be added to OBS-01 production scan SoR")
 }
 
+// TestOBS01CoverageRequiresFramework is the NON-CIRCULAR anti-vacuity witness for
+// #2128. TestOBS01ProductionPatternsCoverProjectPackages only requires the
+// top-levels productionGoTopLevels yields, and that filesystem walk SkipDir's the
+// framework module root (rel == top && prodscan.IsModuleRoot) — so post-#1565
+// "framework" silently drops out of the required set and the symmetric coverage
+// guard passes VACUOUSLY for the framework dimension. (Folding framework back into
+// productionGoTopLevels would be CIRCULAR: it would require what `covered` already
+// grants — derived from the same Patterns set — so dropping framework from Patterns
+// would also drop the requirement, and the hole reappears.)
+//
+// This guard instead asserts the independent, hardcoded fact that framework's core
+// layers MUST be OBS-01-covered, via two checks that do NOT depend on each other:
+//
+//  1. the OBS-01 production pattern set's top-levels include "framework"; and
+//  2. those framework layer patterns actually LOAD non-empty project packages
+//     through the exact loadPackages path OBS-01 uses — a load-witness, strictly
+//     stronger than string presence: it catches a pattern that is present but
+//     matches zero packages (e.g. a renamed/moved framework path).
+//
+// "framework production must be OBS-01-covered" lives here as a hardcoded fact (not
+// derived from Patterns → non-circular), the anti-tautology witness — mirroring the
+// hardcoded want-set pattern in TestBuild_CorebundleCapturesReachableTypedMetrics.
+func TestOBS01CoverageRequiresFramework(t *testing.T) {
+	root := repoRoot(t)
+
+	// (1) coverage: the OBS-01 SoR patterns map back to the "framework" top-level.
+	covered := prodscan.PatternTopLevels(obs01ProductionPatterns(root))
+	assert.True(t, covered["framework"],
+		"OBS-01 production scan must cover the framework module (post-#1565 core: kernel/runtime/pkg)")
+
+	// (2) load-witness: framework layers load non-empty through OBS-01's loader.
+	frameworkPatterns := []string{
+		"./framework/kernel/...",
+		"./framework/runtime/...",
+		"./framework/pkg/...",
+	}
+	pkgs, err := loadPackages(t.Context(), root, frameworkPatterns...)
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs,
+		"framework layer patterns loaded zero project packages — OBS-01 silently stopped scanning framework")
+	seen := map[string]bool{}
+	for _, p := range pkgs {
+		switch {
+		case strings.Contains(p.PkgPath, "/framework/kernel"):
+			seen["kernel"] = true
+		case strings.Contains(p.PkgPath, "/framework/runtime"):
+			seen["runtime"] = true
+		case strings.Contains(p.PkgPath, "/framework/pkg"):
+			seen["pkg"] = true
+		}
+	}
+	for _, layer := range []string{"kernel", "runtime", "pkg"} {
+		assert.Truef(t, seen[layer],
+			"framework/%s loaded no project package under the OBS-01 scan", layer)
+	}
+}
+
+// TestOBS01CoverageRequiresFramework_AntiVacuity proves check (1) of
+// TestOBS01CoverageRequiresFramework is not恒真: a synthetic production pattern set
+// with no framework pattern must NOT report framework as covered — otherwise the
+// real guard's coverage assertion would be vacuous.
+func TestOBS01CoverageRequiresFramework_AntiVacuity(t *testing.T) {
+	covered := prodscan.PatternTopLevels([]string{".", "./cells/...", "./adapters/..."})
+	assert.False(t, covered["framework"],
+		"PatternTopLevels must not report framework covered when no framework pattern is present")
+}
+
 func TestCheckOBS01DetectsIIFEParamTaint(t *testing.T) {
 	root := writeMetricsFixture(t)
 	writeFile(t, root, "reachable/obs.go", `package reachable


### PR DESCRIPTION
## Summary

补 framework OBS-01 coverage 的 anti-vacuity 守卫（#2128），并把 duration 字面量治理（TEST-TIME-LITERAL-01 / PROD-DURATION-CONST-01）扩到 #1565 拆 module 后被跳过的 satellite（cmd/adapters/examples，#2136），constify surfaced 的 69 处 test-time 字面量。

## Why / 背景

#1565 把 framework 拆成独立 module 后，prodscan 的两块覆盖被削弱 / 延期：

- **#2128**：`framework/` 带 go.mod 成 module root → `productionGoTopLevels`（schema_test.go）对它 `SkipDir` → `framework` 掉出 OBS-01 coverage 元守卫的「需覆盖」集，guard 对 framework 维度**空过**。`prodscan.Patterns` 实际仍发 `./framework/kernel|runtime|pkg/...`（OBS-01 真扫到 framework），缺的只是 anti-vacuity——未来 framework patterns 被误删也不报警。
- **#2136**：`prodscan.Patterns`/`PatternsExtended` 故意跳过 multi-member satellite parent（cmd/adapters/examples，`HasNestedModuleRoot`）→ TEST-TIME-LITERAL-01 不扫 satellite，~63 处裸 `time.X` 字面量未 enforce。

## What / 改动

- **新增 `prodscan.PatternsWithSatellites`**：typeseval-backed duration gate 专用的 satellite-inclusive scan SoR；satellite 前缀**派生**自 `HasNestedModuleRoot`（自动完备）。与 metricschema 的 satellite-free `Patterns` 按 **loader 能力**切分（OBS-01 loader 不做 multi-member 展开，收到 `./cmd/...` 会 hard-error）——godoc 写明二者不可合并，并删除陈旧的「deferred」表述。
- **TEST-TIME-LITERAL-01 / PROD-DURATION-CONST-01** 改调 `PatternsWithSatellites`，经既有 `workspace.ExpandParentPrefix`（SATELLITE-PARENT-PREFIX-SCAN-01 守）真扫 satellite。
- **#2128 sub-guard**（schema_test.go）：断言 `covered["framework"]` + framework 核心包**非空加载见证**（强于字符串存在）+ anti-vacuity RED case。非循环独立见证（弃 issue 方向 b，因其循环空过）。
- **constify 69 处 surfaced 违规**：cross-cutting 测试超时/poll → `testtime.*`；site-specific 域时长（cert 生命周期/续期窗口）→ 描述性 file-local package-level const；值全保留。PROD-DURATION-CONST-01 对 satellite 生产代码扫描后零违规（examples/ 生产经 `IsProductionCode` 天然豁免）。

## Refs

Closes #2128
Closes #2136
ref: 既有 typeseval `tools/workspace.ExpandParentPrefix` + `SATELLITE-PARENT-PREFIX-SCAN-01`

## Risk / 兼容性

无 wire / contract / schema 变更（纯 governance/archtest + 测试常量替换，值全保留）。无版本目录、无契约扇出。

延期覆盖面已登记 backlog（见 OOS）：
- OBS-01 metric-PII 对 satellite 生产代码的覆盖（需 metricschema loader 单独改造，不同机制）。
- errcode / clock / panic 等其余 `IsProductionCode` 消费规则对 satellite 的覆盖。
- examples/ 生产代码纳入治理（移除 `IsProductionCode` 的 examples/ 豁免会拖入多条规则，独立决策）。

## Test plan

- [x] `go build` 本地通过（adapters/postgres · examples/iotdevice · examples/orderfulfillment · tools）
- [x] `go test` 修改的包本地通过：TEST-TIME-LITERAL-01 / PROD-DURATION-CONST-01 / SATELLITE-PARENT-PREFIX-SCAN-01 / test-sleep gate 全绿；metricschema（#2128 sub-guard + coverage）+ prodscan helper 绿；examples/iotdevice 默认 tag 单测绿（值保留运行时验证）
- [x] `golangci-lint run`：本 PR 改动文件 0 issues（残留为 untouched 行的 pre-existing 问题，非本 PR 引入）
