### PR TITLE
fix(ci): tests-shard filter 回归 + 补 shard 分区不变式 [F9]

### DIFF
--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -673,6 +673,14 @@ jobs:
           # DISCOVERY-01) and avoids hardcoded `./<path>/...` globs in the
           # `go test` invocation. Empty-set fail-fast fires per shard so a
           # mis-typed filter doesn't pass silently.
+          # An empty $SHARD_FILTER makes `grep -E ""` match EVERY package, so
+          # this run_main_integration shard would run (and coverage-bill) the
+          # whole integration set, silently breaking the disjoint guarantee.
+          # This step is gated `if: matrix.run_main_integration`, so every shard
+          # reaching here MUST carry a non-empty filter (runtime half of the
+          # CI-INTEGRATION-SHARD-PARTITION-01 fail-closed pair; the nightly half
+          # is readIntegrationShardFilters in the archtest).
+          test -n "$SHARD_FILTER" || { echo "FAIL: run_main_integration shard '$SHARD_NAME' has an empty filter; an empty SHARD_FILTER matches all packages (grep -E '') and would double-run the whole integration set" >&2; exit 1; }
           mapfile -t pkgs < <(comm -13 "$tmp/bare.txt" "$tmp/tagged.txt" | awk -F'|' '{print $1}' | grep -E "$SHARD_FILTER" | sort -u)
           test "${#pkgs[@]}" -gt 0 || { echo "FAIL: no integration packages discovered for shard '$SHARD_NAME' (filter='$SHARD_FILTER'); either filter regex is wrong or the package set under that prefix vanished" >&2; exit 1; }
           printf 'Shard %s integration packages (%d):\n' "$SHARD_NAME" "${#pkgs[@]}"

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -555,7 +555,7 @@ jobs:
             run_adapters_extras: false
             run_adapters_race: false
           - shard: tests
-            filter: '^github.com/ghbvf/gocell/(tests|framework/|tools)/'
+            filter: '^github.com/ghbvf/gocell/(tests|framework|tools)/'
             run_main_integration: true
             run_adapters_extras: false
             run_adapters_race: false

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -1,6 +1,7 @@
 //go:build archtest
 
 // INVARIANT: CI-INTEGRATION-DISCOVERY-01: integration-test discovers via go list over the go.work module funnel, not hardcoded globs
+// INVARIANT: CI-INTEGRATION-SHARD-PARTITION-01: every discovered integration package routes to exactly one run_main_integration shard filter (exhaustive + disjoint)
 package archtest
 
 import (
@@ -399,6 +400,125 @@ func TestArchtest_CIIntegrationDiscovery_FixtureMetaTest(t *testing.T) {
 		e2eHit := slices.Contains(e2ePkgs, fx.name)
 		assert.Equal(t, fx.wantInt, intHit, "integration discovery for fixture %s", fx.name)
 		assert.Equal(t, fx.wantE2E, e2eHit, "e2e discovery for fixture %s", fx.name)
+	}
+}
+
+// integrationShardFilter is a parsed run_main_integration:true matrix entry of
+// the integration-test job: the (shard, filter) pairs that actually route the
+// discovered package set through an import-path regex.
+type integrationShardFilter struct {
+	shard  string
+	filter string
+}
+
+// readIntegrationShardFilters decodes the integration-test job's
+// strategy.matrix.include[] and returns the (shard, filter) pairs that carry
+// run_main_integration: true with a non-empty filter. The adapters-race leg
+// (empty filter, run_main_integration: false) is excluded by construction: it
+// re-spins curated -run race steps and routes none of the discovered set.
+//
+// The local YAML shape is decoupled from ci_pinning_test.go's workflowStep
+// (mirrors archtest_ci_shard_count_test.go's archtestWorkflowConfig rationale)
+// so adding matrix fields here cannot regress the pin / step archtests.
+func readIntegrationShardFilters(t *testing.T, root string) []integrationShardFilter {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
+	require.NoError(t, err)
+
+	var cfg struct {
+		Jobs map[string]struct {
+			Strategy struct {
+				Matrix struct {
+					Include []struct {
+						Shard              string `yaml:"shard"`
+						Filter             string `yaml:"filter"`
+						RunMainIntegration bool   `yaml:"run_main_integration"`
+					} `yaml:"include"`
+				} `yaml:"matrix"`
+			} `yaml:"strategy"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.NewDecoder(bytes.NewReader(body)).Decode(&cfg))
+
+	job, ok := cfg.Jobs["integration-test"]
+	require.True(t, ok, "integration-test job missing from _build-lint.yml")
+
+	var out []integrationShardFilter
+	for _, inc := range job.Strategy.Matrix.Include {
+		if inc.RunMainIntegration && inc.Filter != "" {
+			out = append(out, integrationShardFilter{shard: inc.Shard, filter: inc.Filter})
+		}
+	}
+	return out
+}
+
+// TestArchtest_CIIntegrationShardPartition_01 — INVARIANT: CI-INTEGRATION-SHARD-PARTITION-01
+//
+// CI-INTEGRATION-DISCOVERY-01 is the UPSTREAM half of the integration coverage
+// funnel: it proves the package set is *discovered* via the go.work module
+// funnel (no hardcoded globs, every module iterated). But discovery only
+// produces a candidate set — the integration-test job then *routes* each
+// candidate to a matrix shard via that shard's import-path `filter` regex, and
+// nothing asserted those filters actually cover the discovered set. This is the
+// DOWNSTREAM half: every discovered integration package must match EXACTLY ONE
+// run_main_integration shard filter.
+//
+//   - exhaustive (≥1): a package matched by no shard is silently dropped — no
+//     leg runs it, yet the per-shard `-gt 0` empty-guard (GuardsEmptyDiscovery)
+//     stays green because the OTHER packages under that shard's prefix still
+//     match. This is exactly the F9 / #1565 regression: the `tests` filter
+//     `(tests|framework/|tools)` carried a stray slash inside the `framework/`
+//     alternative, so with the regex's own trailing `/` it required `framework//`
+//     and matched zero `framework/...` packages — 4 framework integration
+//     packages (kernel/governance, kernel/metadata, runtime/bootstrap,
+//     runtime/webhook) went dark from the module split until this guard.
+//   - disjoint (≤1): a package matched by two shards is run (and coverage-billed)
+//     twice — wasted wall-time and double-counted profiles.
+//
+// Together with CI-INTEGRATION-DISCOVERY-01 this closes the loop:
+// discovered ⟹ routed-to-exactly-one-shard.
+//
+// AI-robust rating: Medium. The filters are YAML regex strings with no Go type
+// system to seal them; the ceiling is a string-anchored cross-check (same as
+// the sibling IteratesModuleFunnel / CI-RACE-LANE-SUBSET-01 invariants, same
+// archtest-nightly cadence). Anti-vacuity: both the parsed filter set and the
+// discovered package set are require.NotEmpty, so a YAML-shape change or a
+// broken walker fails loud instead of vacuously passing.
+func TestArchtest_CIIntegrationShardPartition_01(t *testing.T) {
+	root := findModuleRoot(t)
+
+	filters := readIntegrationShardFilters(t, root)
+	require.NotEmpty(t, filters,
+		"no run_main_integration:true shard filters parsed from the integration-test "+
+			"matrix — the strategy.matrix.include shape changed; update this archtest")
+
+	type compiledShard struct {
+		shard string
+		re    *regexp.Regexp
+	}
+	compiled := make([]compiledShard, 0, len(filters))
+	for _, f := range filters {
+		compiled = append(compiled, compiledShard{shard: f.shard, re: regexp.MustCompile(f.filter)})
+	}
+
+	pkgs, err := discoverPackagesUnderTag(root, "integration")
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs, "no integration packages discovered — walker likely broken")
+
+	const modPrefix = "github.com/ghbvf/gocell/"
+	for _, pkg := range pkgs {
+		importPath := modPrefix + filepath.ToSlash(pkg)
+		var hits []string
+		for _, sf := range compiled {
+			if sf.re.MatchString(importPath) {
+				hits = append(hits, sf.shard)
+			}
+		}
+		assert.Lenf(t, hits, 1,
+			"integration package %q must route to exactly one run_main_integration shard "+
+				"filter, got shards %v; 0 = silently dropped (no leg runs it — the F9 / #1565 "+
+				"framework double-slash regression class), >1 = double-run/double-billed across "+
+				"shards. See CI-INTEGRATION-SHARD-PARTITION-01.", importPath, hits)
 	}
 }
 

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -1,7 +1,7 @@
 //go:build archtest
 
 // INVARIANT: CI-INTEGRATION-DISCOVERY-01: integration-test discovers via go list over the go.work module funnel, not hardcoded globs
-// INVARIANT: CI-INTEGRATION-SHARD-PARTITION-01: every discovered integration package routes to exactly one run_main_integration shard filter (exhaustive + disjoint)
+// INVARIANT: CI-INTEGRATION-SHARD-PARTITION-01: every discovered integration package routes to exactly one shard filter
 package archtest
 
 import (
@@ -505,9 +505,10 @@ func TestArchtest_CIIntegrationShardPartition_01(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, pkgs, "no integration packages discovered — walker likely broken")
 
-	const modPrefix = "github.com/ghbvf/gocell/"
+	// Derive the import-path prefix from the sanctioned PlatformModulePath const
+	// (never a bare "github.com/ghbvf/gocell" literal) per ARCHTEST-MODULE-PATH-FUNNEL-01.
 	for _, pkg := range pkgs {
-		importPath := modPrefix + filepath.ToSlash(pkg)
+		importPath := PlatformModulePath + "/" + filepath.ToSlash(pkg)
 		var hits []string
 		for _, sf := range compiled {
 			if sf.re.MatchString(importPath) {

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -413,9 +413,14 @@ type integrationShardFilter struct {
 
 // readIntegrationShardFilters decodes the integration-test job's
 // strategy.matrix.include[] and returns the (shard, filter) pairs that carry
-// run_main_integration: true with a non-empty filter. The adapters-race leg
-// (empty filter, run_main_integration: false) is excluded by construction: it
-// re-spins curated -run race steps and routes none of the discovered set.
+// run_main_integration: true with a non-empty filter. A shard is excluded when
+// either condition fails, on principle: run_main_integration:false means the leg
+// runs no main integration step at all, and an empty filter means the leg does
+// not route by import-path prefix (the Test step rejects an empty SHARD_FILTER) —
+// so the exactly-one-shard partition assertion is meaningless for it. The
+// adapters-race leg (empty filter + run_main_integration:false) is the sole
+// current instance of both, but the predicate is written against the semantics,
+// not that one shard.
 //
 // The local YAML shape is decoupled from ci_pinning_test.go's workflowStep
 // (mirrors archtest_ci_shard_count_test.go's archtestWorkflowConfig rationale)
@@ -450,6 +455,37 @@ func readIntegrationShardFilters(t *testing.T, root string) []integrationShardFi
 		}
 	}
 	return out
+}
+
+// shardRouteFilter is a compiled run_main_integration shard filter.
+type shardRouteFilter struct {
+	shard string
+	re    *regexp.Regexp
+}
+
+// compileShardFilters compiles each parsed shard filter into its regex. A
+// malformed filter panics via MustCompile — a bad YAML regex should fail loud.
+func compileShardFilters(filters []integrationShardFilter) []shardRouteFilter {
+	out := make([]shardRouteFilter, 0, len(filters))
+	for _, f := range filters {
+		out = append(out, shardRouteFilter{shard: f.shard, re: regexp.MustCompile(f.filter)})
+	}
+	return out
+}
+
+// routeShards returns the name of every shard whose filter regex matches
+// importPath. The partition invariant requires exactly one. It is the pure
+// routing core shared by TestArchtest_CIIntegrationShardPartition_01 and its
+// synthetic FixtureMetaTest, so the 0-match (silent drop) and >1-match
+// (double-run) failure modes are provably caught, not just assumed.
+func routeShards(importPath string, shards []shardRouteFilter) []string {
+	var hits []string
+	for _, sf := range shards {
+		if sf.re.MatchString(importPath) {
+			hits = append(hits, sf.shard)
+		}
+	}
+	return hits
 }
 
 // TestArchtest_CIIntegrationShardPartition_01 — INVARIANT: CI-INTEGRATION-SHARD-PARTITION-01
@@ -492,14 +528,7 @@ func TestArchtest_CIIntegrationShardPartition_01(t *testing.T) {
 		"no run_main_integration:true shard filters parsed from the integration-test "+
 			"matrix — the strategy.matrix.include shape changed; update this archtest")
 
-	type compiledShard struct {
-		shard string
-		re    *regexp.Regexp
-	}
-	compiled := make([]compiledShard, 0, len(filters))
-	for _, f := range filters {
-		compiled = append(compiled, compiledShard{shard: f.shard, re: regexp.MustCompile(f.filter)})
-	}
+	shards := compileShardFilters(filters)
 
 	pkgs, err := discoverPackagesUnderTag(root, "integration")
 	require.NoError(t, err)
@@ -509,18 +538,68 @@ func TestArchtest_CIIntegrationShardPartition_01(t *testing.T) {
 	// (never a bare "github.com/ghbvf/gocell" literal) per ARCHTEST-MODULE-PATH-FUNNEL-01.
 	for _, pkg := range pkgs {
 		importPath := PlatformModulePath + "/" + filepath.ToSlash(pkg)
-		var hits []string
-		for _, sf := range compiled {
-			if sf.re.MatchString(importPath) {
-				hits = append(hits, sf.shard)
-			}
-		}
+		hits := routeShards(importPath, shards)
 		assert.Lenf(t, hits, 1,
 			"integration package %q must route to exactly one run_main_integration shard "+
 				"filter, got shards %v; 0 = silently dropped (no leg runs it — the F9 / #1565 "+
 				"framework double-slash regression class), >1 = double-run/double-billed across "+
 				"shards. See CI-INTEGRATION-SHARD-PARTITION-01.", importPath, hits)
 	}
+}
+
+// TestArchtest_CIIntegrationShardPartition_FixtureMetaTest is the synthetic
+// red/green companion to TestArchtest_CIIntegrationShardPartition_01
+// (ai-robust.md: a content-scan rule needs a synthetic red case alongside
+// anti-vacuity). It drives routeShards — the routing core of the live assertion
+// — with hand-built filters, so the partition failure modes are proven caught
+// independent of the current codebase, including the exact F9 buggy
+// double-slash form. Filter regexes are built from PlatformModulePath (never a
+// bare org/repo literal) per ARCHTEST-MODULE-PATH-FUNNEL-01.
+func TestArchtest_CIIntegrationShardPartition_FixtureMetaTest(t *testing.T) {
+	t.Parallel()
+
+	mp := regexp.QuoteMeta(PlatformModulePath)
+	good := []shardRouteFilter{
+		{shard: "tests", re: regexp.MustCompile(`^` + mp + `/(tests|framework|tools)/`)},
+		{shard: "adapters", re: regexp.MustCompile(`^` + mp + `/adapters/`)},
+	}
+
+	// GREEN: each package routes to exactly one shard. red_zero_match is the
+	// silent-drop case (no shard claims it) the exhaustive (≥1) check must catch.
+	cases := []struct {
+		name string
+		path string
+		want []string
+	}{
+		{"green_tests", PlatformModulePath + "/tests/integration", []string{"tests"}},
+		{"green_framework", PlatformModulePath + "/framework/kernel/governance", []string{"tests"}},
+		{"green_adapters", PlatformModulePath + "/adapters/postgres", []string{"adapters"}},
+		{"red_zero_match", PlatformModulePath + "/cellmodules/foo", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, routeShards(c.path, good), "routeShards(%q)", c.path)
+		})
+	}
+
+	// RED 1 — the exact F9 regression: the buggy double-slash `framework/`
+	// alternative plus the regex's trailing `/` requires `framework//`, routing
+	// framework packages to NO shard. routeShards must report zero so the live
+	// assertion's exhaustive (≥1) check fires.
+	buggy := []shardRouteFilter{
+		{shard: "tests", re: regexp.MustCompile(`^` + mp + `/(tests|framework/|tools)/`)},
+	}
+	assert.Empty(t, routeShards(PlatformModulePath+"/framework/kernel/governance", buggy),
+		"buggy double-slash filter must drop framework packages — exactly the F9 / #1565 regression")
+
+	// RED 2 — two overlapping filters route one package to two shards.
+	// routeShards must report both so the disjoint (≤1) check fires.
+	overlap := []shardRouteFilter{
+		{shard: "x", re: regexp.MustCompile(`^` + mp + `/tests/`)},
+		{shard: "y", re: regexp.MustCompile(`^` + mp + `/(tests|adapters)/`)},
+	}
+	assert.Len(t, routeShards(PlatformModulePath+"/tests/integration", overlap), 2,
+		"two matching filters must both be reported so the disjoint (≤1) assertion can fire")
 }
 
 // TestArchtest_CIRaceLaneSubset_01 — INVARIANT: CI-RACE-LANE-SUBSET-01

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -411,20 +411,54 @@ type integrationShardFilter struct {
 	filter string
 }
 
-// readIntegrationShardFilters decodes the integration-test job's
-// strategy.matrix.include[] and returns the (shard, filter) pairs that carry
-// run_main_integration: true with a non-empty filter. A shard is excluded when
-// either condition fails, on principle: run_main_integration:false means the leg
-// runs no main integration step at all, and an empty filter means the leg does
-// not route by import-path prefix (the Test step rejects an empty SHARD_FILTER) —
-// so the exactly-one-shard partition assertion is meaningless for it. The
-// adapters-race leg (empty filter + run_main_integration:false) is the sole
-// current instance of both, but the predicate is written against the semantics,
-// not that one shard.
+// matrixShardInclude is one decoded strategy.matrix.include[] entry of the
+// integration-test job. Named (not anonymous) so selectMainShardFilters can be
+// unit-tested with synthetic includes. The local YAML shape is decoupled from
+// ci_pinning_test.go's workflowStep (mirrors archtest_ci_shard_count_test.go's
+// archtestWorkflowConfig rationale) so adding matrix fields here cannot regress
+// the pin / step archtests.
+type matrixShardInclude struct {
+	Shard              string `yaml:"shard"`
+	Filter             string `yaml:"filter"`
+	RunMainIntegration bool   `yaml:"run_main_integration"`
+}
+
+// selectMainShardFilters splits the matrix includes into (a) the routing filters
+// of every run_main_integration shard and (b) the names of any
+// run_main_integration shard that declares an EMPTY filter — a fail-open
+// configuration that must be rejected, not skipped.
 //
-// The local YAML shape is decoupled from ci_pinning_test.go's workflowStep
-// (mirrors archtest_ci_shard_count_test.go's archtestWorkflowConfig rationale)
-// so adding matrix fields here cannot regress the pin / step archtests.
+// Empty-filter main shards are a violation, not an exclusion: the discovery step
+// (gated `if: matrix.run_main_integration`) routes with `grep -E "$SHARD_FILTER"`,
+// and an empty regex matches EVERY package — such a shard would run (and
+// coverage-bill) the entire integration set, silently breaking the disjoint
+// guarantee. A non-run_main_integration leg (adapters-race) never reaches that
+// step, so its empty filter is correctly excluded with no violation. Modeling
+// empty-as-excluded (the original fail-open bug) let the dangerous
+// run_main_integration+empty case pass the partition assertion vacuously.
+func selectMainShardFilters(includes []matrixShardInclude) (kept []integrationShardFilter, emptyMainShards []string) {
+	for _, inc := range includes {
+		if !inc.RunMainIntegration {
+			continue // race-only leg; never reaches the import-path discovery step
+		}
+		if inc.Filter == "" {
+			emptyMainShards = append(emptyMainShards, inc.Shard)
+			continue
+		}
+		kept = append(kept, integrationShardFilter{shard: inc.Shard, filter: inc.Filter})
+	}
+	return kept, emptyMainShards
+}
+
+// readIntegrationShardFilters decodes the integration-test job's
+// strategy.matrix.include[] and returns the (shard, filter) routing pairs of
+// every run_main_integration shard. It fails the test if any
+// run_main_integration shard declares an empty filter — `grep -E "$SHARD_FILTER"`
+// treats an empty regex as match-all, so such a shard double-runs every
+// integration package. This is the nightly-archtest half of a fail-closed pair;
+// the runtime half is the discovery step's own `test -n "$SHARD_FILTER"` guard
+// in _build-lint.yml. Only run_main_integration:false legs (adapters-race) are
+// excluded — they never run the import-path discovery.
 func readIntegrationShardFilters(t *testing.T, root string) []integrationShardFilter {
 	t.Helper()
 	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
@@ -434,11 +468,7 @@ func readIntegrationShardFilters(t *testing.T, root string) []integrationShardFi
 		Jobs map[string]struct {
 			Strategy struct {
 				Matrix struct {
-					Include []struct {
-						Shard              string `yaml:"shard"`
-						Filter             string `yaml:"filter"`
-						RunMainIntegration bool   `yaml:"run_main_integration"`
-					} `yaml:"include"`
+					Include []matrixShardInclude `yaml:"include"`
 				} `yaml:"matrix"`
 			} `yaml:"strategy"`
 		} `yaml:"jobs"`
@@ -448,13 +478,13 @@ func readIntegrationShardFilters(t *testing.T, root string) []integrationShardFi
 	job, ok := cfg.Jobs["integration-test"]
 	require.True(t, ok, "integration-test job missing from _build-lint.yml")
 
-	var out []integrationShardFilter
-	for _, inc := range job.Strategy.Matrix.Include {
-		if inc.RunMainIntegration && inc.Filter != "" {
-			out = append(out, integrationShardFilter{shard: inc.Shard, filter: inc.Filter})
-		}
-	}
-	return out
+	kept, emptyMain := selectMainShardFilters(job.Strategy.Matrix.Include)
+	require.Emptyf(t, emptyMain,
+		"run_main_integration shard(s) %v declare an empty filter; the discovery step's "+
+			"`grep -E \"$SHARD_FILTER\"` treats an empty regex as match-all, double-running every "+
+			"integration package — declare a non-empty import-path filter. "+
+			"See CI-INTEGRATION-SHARD-PARTITION-01.", emptyMain)
+	return kept
 }
 
 // shardRouteFilter is a compiled run_main_integration shard filter.
@@ -600,6 +630,33 @@ func TestArchtest_CIIntegrationShardPartition_FixtureMetaTest(t *testing.T) {
 	}
 	assert.Len(t, routeShards(PlatformModulePath+"/tests/integration", overlap), 2,
 		"two matching filters must both be reported so the disjoint (≤1) assertion can fire")
+}
+
+// TestArchtest_CIIntegrationShardPartition_SelectMainShardFiltersFixture is the
+// synthetic red/green case for selectMainShardFilters' empty-filter fail-closed
+// guard (ai-robust.md: synthetic red case + anti-vacuity). It proves a
+// run_main_integration shard with an EMPTY filter is reported as a violation
+// (the fail-open hole this guard closes — an empty `grep -E` matches all
+// packages), a non-empty one is kept, and a non-main leg's empty filter is
+// excluded without violation.
+func TestArchtest_CIIntegrationShardPartition_SelectMainShardFiltersFixture(t *testing.T) {
+	t.Parallel()
+	includes := []matrixShardInclude{
+		{Shard: "tests", Filter: "^x/(tests)/", RunMainIntegration: true},
+		{Shard: "adapters-race", Filter: "", RunMainIntegration: false},
+		{Shard: "badmain", Filter: "", RunMainIntegration: true},
+	}
+	kept, emptyMain := selectMainShardFilters(includes)
+
+	// GREEN: the non-empty main shard is kept; the race leg is silently excluded.
+	require.Len(t, kept, 1)
+	assert.Equal(t, "tests", kept[0].shard)
+
+	// RED: the run_main_integration shard with an empty filter is reported as a
+	// violation, NOT silently skipped — closing the fail-open hole where an empty
+	// SHARD_FILTER (grep match-all) would double-run every integration package.
+	assert.Equal(t, []string{"badmain"}, emptyMain,
+		"a run_main_integration shard with an empty filter must be a reported violation, not skipped")
 }
 
 // TestArchtest_CIRaceLaneSubset_01 — INVARIANT: CI-RACE-LANE-SUBSET-01


### PR DESCRIPTION
## Summary

修复 F9：integration-test `tests` shard filter 的双斜杠 bug 自 #1565 静默丢弃 4 个 framework 集成测试包；并补一条 Medium archtest（`CI-INTEGRATION-SHARD-PARTITION-01`）从机制上关闭该类 bug。核实 F12/F13 为误报，不改代码。

## Why / 背景

簇 C5 三条 review finding：

- **F9（真 bug，非「功能等价」）**：`_build-lint.yml` 的 `tests` shard filter `^.../(tests|framework/|tools)/` 中 `framework/` 分支自带尾斜杠，叠加正则尾部 `/` → 实际要求 `framework//`，匹配 **0 个** `framework/...` 包。#1565（framework module 拆分）引入，自此 `framework/kernel/{governance,metadata}`、`framework/runtime/{bootstrap,webhook}` 这 4 个集成包**从未在 CI 跑过**。line 677 的 `-gt 0` 守卫因 `tests/` 仍匹配而未报警。
- **根因（为何仅修 regex 不够）**：`CI-INTEGRATION-DISCOVERY-01` 只保证「发现走 go.work module funnel」（上游），**无任何测试断言 shard filter 完整分区发现集**（下游）。CLAUDE.md 那句「your package falls into a shard automatically」是**未强制的 Soft 声明**——F9 即其失败证据。按 AI-robust 章程（Soft 须升 Medium），补下游分区不变式。

实测（faithful 复现 workflow 发现逻辑，38 个集成包）：当前 buggy filter `unrouted=4`，修复后 `unrouted=0 double=0`。

**F12/F13 经核实为误报，不改代码**：
- **F12**（`$PKGS` 无引号）：runtime shard `pkgs: ./framework/runtime/... ./framework/pkg/...` 双路径，无引号是 go 多 package 词分割**必需**，加引号即破坏。actionlint 实测该处仅 `SC2086:info`（非阻塞，CI 仍绿）。
- **F13**（`tests/integration/go.mod:7` 占位版本）：`corecells v0.0.0-00010101000000-000000000000` 与全仓所有 go.mod **逐字相同**，line 94 有配套 `replace => ../../corecells`，是标准 workspace 占位+replace 模式。

## Refs

- Refs: 修复 review finding F9（簇 C5）；F12/F13 同簇核实为误报
- 新增不变式 `CI-INTEGRATION-SHARD-PARTITION-01`（Medium），与同文件 `CI-INTEGRATION-DISCOVERY-01` / `CI-RACE-LANE-SUBSET-01` 同构

| 变更 | 文件 | 性质 |
|------|------|------|
| 分区不变式 archtest（先 RED 后 GREEN） | `tools/archtest/ci_integration_discovery_invariants_test.go` | 根因 enforcement（Medium） |
| `tests` shard filter 去内嵌斜杠 | `.github/workflows/_build-lint.yml:558` | F9 数据订正 |

## Risk / 兼容性

- **重新纳入 4 个 framework 集成包**：F9 修复后这 4 包在 integration-test job（`run-integration=true` 时）重新执行——预期行为（修 #1565 回归）。已本地 `go -C framework test -tags=integration` 实跑，**全部通过**（轻量、无 docker），不引入红。
- 无 wire 契约 / migration / 破坏式变更。
- F12/F13 不改代码，无影响。

## Test plan

- [x] `go build ./...` 本地通过（仅改 1 个 archtest 测试文件 + 1 行 YAML）
- [x] `CI-INTEGRATION-SHARD-PARTITION-01` archtest：buggy regex 下 RED（4 包 unrouted）→ 修复后 GREEN
- [x] `go test -tags=archtest`：`CIIntegration*` / `ModulePathFunnel` / `RaceLaneSubset` 全 GREEN
- [x] 4 个 re-included framework 集成包 `-tags=integration` 全通过
- [x] `golangci-lint run --build-tags=archtest ./tools/archtest/...` 0 issues
- [x] `actionlint _build-lint.yml` 退出 0（仅 info 级预存 SC2086/SC2012）

> 注：本地全量 in-process 跑 archtest 套件时 `TestProbenameSealedFunnel_ReverseFixtures/..._red` 报 `loaded 0 packages`——已验证在 clean `origin/develop` 同样复现，是 archtest 进程隔离设计下本地 in-process 跑的预存环境问题，与本 PR 无关（CI 分片隔离跑不触发）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
