### PR TITLE
feat(percellpg): per-cell DB 凭据/连接注入 seam + 安全模型评估 [1423-US6] [#1964]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,12 @@ GOCELL_CONFIGCORE_DATABASE_URL=postgres://gocell:gocell_dev@localhost:5432/gocel
 GOCELL_AUDITCORE_DATABASE_URL=postgres://gocell:gocell_dev@localhost:5432/gocell_dev?sslmode=disable
 # accesscore cell (must equal GOCELL_CONFIGCORE_DATABASE_URL in colocated deployments):
 GOCELL_ACCESSCORE_DATABASE_URL=postgres://gocell:gocell_dev@localhost:5432/gocell_dev?sslmode=disable
-# GOCELL_CONFIGCORE_DATABASE_MAX_CONNS=10
-# GOCELL_CONFIGCORE_DATABASE_IDLE_TIMEOUT=5m
-# GOCELL_CONFIGCORE_DATABASE_MAX_LIFETIME=1h
+# Pool knobs (optional). In colocated/dedup mode the shared pool reads knobs from
+# the alphabetically-first postgres cell (accesscore, a < au < c). Set identically
+# across all postgres cells; per-cell pool-knob isolation requires split topology (#2152).
+# GOCELL_ACCESSCORE_DATABASE_MAX_CONNS=10
+# GOCELL_ACCESSCORE_DATABASE_IDLE_TIMEOUT=5m
+# GOCELL_ACCESSCORE_DATABASE_MAX_LIFETIME=1h
 
 # Redis
 GOCELL_REDIS_ADDR=localhost:6379

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,15 @@
-# PostgreSQL — per-cell database configuration (GOCELL-PER-CELL-ADAPTER-01)
-# Each cell reads its own DSN. Old global GOCELL_PG_* vars are no longer read.
+# PostgreSQL — per-cell database configuration (#1964 per-cell PG seam)
+# Each postgres-requiring cell (configcore, auditcore, accesscore) now reads its
+# own DSN from GOCELL_<CELLID>_DATABASE_URL. Colocated deployments must set all
+# three to the SAME value (percellpg.Resolve deduplicates to one pool at startup;
+# a missing per-cell DSN or >1 distinct DSN fails fast). Old global GOCELL_PG_* vars
+# are no longer read. Pool construction moved to cellmodules/percellpg.
 # configcore cell:
 GOCELL_CONFIGCORE_DATABASE_URL=postgres://gocell:gocell_dev@localhost:5432/gocell_dev?sslmode=disable
+# auditcore cell (must equal GOCELL_CONFIGCORE_DATABASE_URL in colocated deployments):
+GOCELL_AUDITCORE_DATABASE_URL=postgres://gocell:gocell_dev@localhost:5432/gocell_dev?sslmode=disable
+# accesscore cell (must equal GOCELL_CONFIGCORE_DATABASE_URL in colocated deployments):
+GOCELL_ACCESSCORE_DATABASE_URL=postgres://gocell:gocell_dev@localhost:5432/gocell_dev?sslmode=disable
 # GOCELL_CONFIGCORE_DATABASE_MAX_CONNS=10
 # GOCELL_CONFIGCORE_DATABASE_IDLE_TIMEOUT=5m
 # GOCELL_CONFIGCORE_DATABASE_MAX_LIFETIME=1h

--- a/.env.example
+++ b/.env.example
@@ -286,7 +286,9 @@ GOCELL_METRICS_TOKEN=
 # Cell storage adapter. Selects the storage backend for configcore AND for the
 # accesscore session/refresh stores (S4a — PG corecell durable wiring).
 # "memory" (default when unset) = in-memory repositories (dev/test only).
-# "postgres" = PostgreSQL (requires GOCELL_CONFIGCORE_DATABASE_URL; run migrations first:
+# "postgres" = PostgreSQL (requires a per-cell GOCELL_<CELLID>_DATABASE_URL for every
+#   postgres cell — configcore / auditcore / accesscore, identical in colocated mode;
+#   see the top of this file. Run migrations first:
 #   go run ./cmd/gocell migrate up  OR  pressly/goose up adapters/postgres/migrations).
 #   Must apply migrations 004 (config) + 012 (refresh_tokens) + 018 (sessions) before use.
 #

--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -39,8 +39,8 @@
 // connection, i.e. the single GOCELL_AMQP_URL. Per-cell publisher/subscriber
 // fan-out within one broker connection (e.g. per-cell exchange or routing-key
 // namespacing) is a separate concern coupled to per-cell outbox relay fan-out;
-// both are tracked in the per-cell infra fan-out backlog issue (issue #1964 /
-// Epic #1423 US6) and are not implemented here.
+// both are tracked in the per-cell infra fan-out backlog (#2152) and are not
+// implemented here.
 //
 // ref: kernel/outbox.ResolveEmitter — the symmetric durability-gated funnel.
 // ref: github.com/ThreeDotsLabs/watermill message/router.go — disabledPublisher pattern.

--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -25,6 +25,23 @@
 // configured: a missing GOCELL_AMQP_URL is a startup error, never a silent
 // degrade back to in-memory.
 //
+// # Broker connection is intentionally assembly-level (not per-cell)
+//
+// The broker (RabbitMQ, GOCELL_AMQP_URL) is the cross-cell event bus: its
+// defining semantic is cross-cell sharing, not per-cell isolation. Distinct
+// per-cell broker connections — or distinct broker instances per cell — would
+// sever the publish/subscribe chain between cells (cell A publishes to its own
+// broker, cell B subscribes to its own broker, events never cross). Therefore,
+// a per-cell broker connection seam analogous to the per-cell DB connection
+// seam (cellmodules/percellpg) is intentionally not modeled here.
+//
+// The correct unit of broker ownership is the per-process (assembly-level)
+// connection, i.e. the single GOCELL_AMQP_URL. Per-cell publisher/subscriber
+// fan-out within one broker connection (e.g. per-cell exchange or routing-key
+// namespacing) is a separate concern coupled to per-cell outbox relay fan-out;
+// both are tracked in the per-cell infra fan-out backlog issue (issue #1964 /
+// Epic #1423 US6) and are not implemented here.
+//
 // ref: kernel/outbox.ResolveEmitter — the symmetric durability-gated funnel.
 // ref: github.com/ThreeDotsLabs/watermill message/router.go — disabledPublisher pattern.
 package eventtransport

--- a/cellmodules/percellpg/doc.go
+++ b/cellmodules/percellpg/doc.go
@@ -25,6 +25,17 @@
 // by strings.TrimSpace(DSN) and opens exactly ONE pool, preserving today's
 // shared-pool behavior while introducing per-cell DSN injection.
 //
+// # Pool knobs in colocated mode
+//
+// In colocated/dedup mode (all cells share the same DSN) the shared pool's
+// connection knobs (MaxConns / IdleTimeout / MaxLifetime) are taken from
+// cellIDs[0] — the alphabetically-first postgres cell after sort.Strings. With
+// the current platform cells (accesscore / auditcore / configcore) that is
+// always accesscore (a < au < c). Operators MUST set the pool knobs identically
+// across all postgres cells' DATABASE_* vars; only the accesscore knobs are
+// applied to the shared pool and the others are silently ignored in colocated
+// mode. Per-cell pool-knob isolation is split-topology territory (#2152).
+//
 // # Fail-closed invariants
 //
 //   - A postgres-requiring cell whose DSN is empty (or whitespace-only) is a

--- a/cellmodules/percellpg/doc.go
+++ b/cellmodules/percellpg/doc.go
@@ -1,80 +1,60 @@
-// Package percellpg is the topology-gated single source for the per-cell
-// postgres pool that a colocated composition root provisions. It is the
-// postgres-pool sibling of cellmodules/eventtransport.Resolve (event transport),
-// cellmodules/replaydeps.Resolve (consumer claimer + service-token nonce), and
-// cellmodules/sagaprojectiondeps.Resolve (saga-journal projection dependencies):
-// one Resolve maps a bootstrap.Topology to the correct PG backend, so a
-// composition root never hard-codes a pool constructor.
+// Package percellpg is the topology-gated single source for the per-cell postgres
+// DSN decision a colocated composition root provisions its pool from. It is the
+// per-cell-DSN sibling of cellmodules/eventtransport.Resolve, replaydeps.Resolve,
+// and sagaprojectiondeps.Resolve — but it is a PURE decision function: it performs
+// NO I/O and constructs NO adapter primitives.
+//
+// # Why pure (construction stays in cmd/corebundle/cap_wiring.go)
+//
+// The banned shared-infra constructors (adapterpg.NewPool / NewTxManager /
+// NewJournalingOutboxWriter) must stay in the single sanctioned cmd/ provisioning
+// site so the cmd/-scoped machine guards keep covering them:
+//   - CAPABILITY-PROVIDER-FUNNEL-01 (bans those constructors outside cap_wiring.go), and
+//   - PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 (requires NewJournalingOutboxWriter
+//     to take the direct generatedProjectionSourceTopics() accessor, not a threaded variable).
+//
+// Moving construction into cellmodules/percellpg would silently take it out of both
+// guards' cmd/-only scan — so this package only DECIDES the agreed DSN config;
+// cap_wiring.go opens the pool, verifies schema, builds the journaling writer with
+// the direct accessor, and wraps the capability.PGProvider.
 //
 // # Backend selection
 //
 //	memory topology (topo.StorageBackend() != postgres):
-//	  No pool is opened. Resolve returns empty Deps (nil Provider, no Resources).
-//	  Cell modules fall through to their in-memory storage path.
+//	  Resolve returns (zero, ok=false, nil) — no pool. Cell modules take their
+//	  in-memory storage path.
 //
 //	postgres topology:
-//	  A single deduped pool is opened, verified, and wrapped into a sealed
-//	  capability.PGProvider. The pool is returned as a lifecycle.ManagedResource
-//	  so the composition root registers it first (LIFO: closed last, after every
-//	  PG consumer — relay, cell workers, tx).
+//	  Resolve returns (agreedConfig, ok=true, nil) — the single deduped DSN config
+//	  cap_wiring.go opens the assembly's one shared pool from.
 //
 // # Dedup-by-DSN invariant
 //
 // Colocated assemblies share one physical database: all postgres cells must be
 // configured with the SAME DSN (GOCELL_<CELLID>_DATABASE_URL). Resolve deduplicates
-// by strings.TrimSpace(DSN) and opens exactly ONE pool, preserving today's
-// shared-pool behavior while introducing per-cell DSN injection.
+// by strings.TrimSpace(DSN) and yields exactly one agreed config, preserving today's
+// shared-pool behavior while making per-cell DSN injection explicit.
 //
 // # Pool knobs in colocated mode
 //
-// In colocated/dedup mode (all cells share the same DSN) the shared pool's
-// connection knobs (MaxConns / IdleTimeout / MaxLifetime) are taken from
-// cellIDs[0] — the alphabetically-first postgres cell after sort.Strings. With
-// the current platform cells (accesscore / auditcore / configcore) that is
-// always accesscore (a < au < c). Operators MUST set the pool knobs identically
-// across all postgres cells' DATABASE_* vars; only the accesscore knobs are
-// applied to the shared pool and the others are silently ignored in colocated
-// mode. Per-cell pool-knob isolation is split-topology territory (#2152).
+// The agreed config is the alphabetically-first cell's Config (cellIDs[0] after
+// sort.Strings), so its pool knobs (MaxConns / IdleTimeout / MaxLifetime) configure
+// the shared pool. With the current platform cells that is always accesscore
+// (a < au < c). Operators MUST set the pool knobs identically across all postgres
+// cells' DATABASE_* vars — only the first cell's knobs are applied in colocated mode.
+// Per-cell pool-knob isolation is split-topology territory (#2152).
 //
-// # Fail-closed invariants
+// # Fail-closed invariants (the three gates)
 //
-//   - A postgres-requiring cell whose DSN is empty (or whitespace-only) is a
-//     startup error. The message names the cell ID and the expected env var
-//     (GOCELL_<CELLID>_DATABASE_URL). Never a silent fallback — sharing another
-//     cell's pool without operator intent would bypass per-cell credential isolation.
+//   - Empty cell set in postgres topology — a misconfiguration, fail-closed (also
+//     guards the cellIDs[0] index from panicking on an empty map).
+//   - A postgres-requiring cell whose DSN is empty (or whitespace-only) — fail-closed;
+//     the diagnostic carries the cell ID and expected env var. Never a silent fallback.
+//   - Per-cell distinct DSNs (>1 distinct after dedup) — fail-closed, pointing to the
+//     split-topology backlog (US4 #1963 / #2152, per-cell outbox relay fan-out).
 //
-//   - Per-cell distinct DSNs (>1 distinct after dedup) are a startup error pointing
-//     to the split-topology backlog (US4 #1963, per-cell outbox relay fan-out).
-//     Colocated assemblies must set all per-cell DATABASE_URLs to the same value.
-//
-// # CAPABILITY-PROVIDER-FUNNEL-01 (pool construction site)
-//
-// Primary pool construction lives here in cellmodules/percellpg, not in
-// cmd/corebundle/cap_wiring.go. Cellmodules is the Composition Root layer
-// (trusted; may import all layers) and is the same class as the auditcore admin
-// pool and sagaprojectiondeps' NewTxManager. The cmd-only CAPABILITY-PROVIDER-FUNNEL-01
-// scan (archtest) bans direct adapter constructor calls in cmd/ files outside the
-// sanctioned cap_wiring.go site; percellpg is intentionally outside that scan's
-// cmd/-only scope. The upstream Hard guard is the sealed capability.PGProvider
-// (unexported marker isPGProvider + sole NewPGProvider constructor in
-// runtime/capability), which makes the provider unforgeable outside package capability.
-// The downstream archtest scan + cmd-only ban serve as defense-in-depth for any
-// residual cmd/-level direct construction.
-//
-// # Blind spots
-//
-// Per ai-robust.md "Funnel 类约束必须分别说明上游和下游强度":
-//
-// Downstream (archtest, cmd/-only scan): the CAPABILITY-PROVIDER-FUNNEL-01 scan
-// covers cmd/... and flags direct adapterpg.NewPool / NewTxManager / NewOutboxWriter /
-// NewJournalingOutboxWriter calls outside cap_wiring.go. percellpg is in cellmodules/,
-// which is intentionally outside the cmd/-only scan — same class as sagaprojectiondeps.
-//
-// Upstream (sealed type, Hard): capability.PGProvider is unforgeable outside
-// package capability. A cellmodules package that calls adapterpg.NewPool directly
-// (outside percellpg) bypasses the dedup gate but not the sealed type: the composed
-// bootstrap still requires a capability.PGProvider, so a second raw pool would have
-// no injection path. The per-cell dedup invariant is therefore the primary new
-// behavioral gate; pool-construction multiplicity is a known accepted blind spot
-// (same posture as sagaprojectiondeps § "upstream empirical absence").
+// Being pure, all three gates plus the success/memory branches are exhaustively
+// unit-tested (no live database needed). The pool-open + schema-verify I/O that
+// cap_wiring.go runs from the agreed config is covered by the real-PG integration
+// test cmd/corebundle/corebundle_pg_env_integration_test.go.
 package percellpg

--- a/cellmodules/percellpg/doc.go
+++ b/cellmodules/percellpg/doc.go
@@ -1,0 +1,69 @@
+// Package percellpg is the topology-gated single source for the per-cell
+// postgres pool that a colocated composition root provisions. It is the
+// postgres-pool sibling of cellmodules/eventtransport.Resolve (event transport),
+// cellmodules/replaydeps.Resolve (consumer claimer + service-token nonce), and
+// cellmodules/sagaprojectiondeps.Resolve (saga-journal projection dependencies):
+// one Resolve maps a bootstrap.Topology to the correct PG backend, so a
+// composition root never hard-codes a pool constructor.
+//
+// # Backend selection
+//
+//	memory topology (topo.StorageBackend() != postgres):
+//	  No pool is opened. Resolve returns empty Deps (nil Provider, no Resources).
+//	  Cell modules fall through to their in-memory storage path.
+//
+//	postgres topology:
+//	  A single deduped pool is opened, verified, and wrapped into a sealed
+//	  capability.PGProvider. The pool is returned as a lifecycle.ManagedResource
+//	  so the composition root registers it first (LIFO: closed last, after every
+//	  PG consumer — relay, cell workers, tx).
+//
+// # Dedup-by-DSN invariant
+//
+// Colocated assemblies share one physical database: all postgres cells must be
+// configured with the SAME DSN (GOCELL_<CELLID>_DATABASE_URL). Resolve deduplicates
+// by strings.TrimSpace(DSN) and opens exactly ONE pool, preserving today's
+// shared-pool behavior while introducing per-cell DSN injection.
+//
+// # Fail-closed invariants
+//
+//   - A postgres-requiring cell whose DSN is empty (or whitespace-only) is a
+//     startup error. The message names the cell ID and the expected env var
+//     (GOCELL_<CELLID>_DATABASE_URL). Never a silent fallback — sharing another
+//     cell's pool without operator intent would bypass per-cell credential isolation.
+//
+//   - Per-cell distinct DSNs (>1 distinct after dedup) are a startup error pointing
+//     to the split-topology backlog (US4 #1963, per-cell outbox relay fan-out).
+//     Colocated assemblies must set all per-cell DATABASE_URLs to the same value.
+//
+// # CAPABILITY-PROVIDER-FUNNEL-01 (pool construction site)
+//
+// Primary pool construction lives here in cellmodules/percellpg, not in
+// cmd/corebundle/cap_wiring.go. Cellmodules is the Composition Root layer
+// (trusted; may import all layers) and is the same class as the auditcore admin
+// pool and sagaprojectiondeps' NewTxManager. The cmd-only CAPABILITY-PROVIDER-FUNNEL-01
+// scan (archtest) bans direct adapter constructor calls in cmd/ files outside the
+// sanctioned cap_wiring.go site; percellpg is intentionally outside that scan's
+// cmd/-only scope. The upstream Hard guard is the sealed capability.PGProvider
+// (unexported marker isPGProvider + sole NewPGProvider constructor in
+// runtime/capability), which makes the provider unforgeable outside package capability.
+// The downstream archtest scan + cmd-only ban serve as defense-in-depth for any
+// residual cmd/-level direct construction.
+//
+// # Blind spots
+//
+// Per ai-robust.md "Funnel 类约束必须分别说明上游和下游强度":
+//
+// Downstream (archtest, cmd/-only scan): the CAPABILITY-PROVIDER-FUNNEL-01 scan
+// covers cmd/... and flags direct adapterpg.NewPool / NewTxManager / NewOutboxWriter /
+// NewJournalingOutboxWriter calls outside cap_wiring.go. percellpg is in cellmodules/,
+// which is intentionally outside the cmd/-only scan — same class as sagaprojectiondeps.
+//
+// Upstream (sealed type, Hard): capability.PGProvider is unforgeable outside
+// package capability. A cellmodules package that calls adapterpg.NewPool directly
+// (outside percellpg) bypasses the dedup gate but not the sealed type: the composed
+// bootstrap still requires a capability.PGProvider, so a second raw pool would have
+// no injection path. The per-cell dedup invariant is therefore the primary new
+// behavioral gate; pool-construction multiplicity is a known accepted blind spot
+// (same posture as sagaprojectiondeps § "upstream empirical absence").
+package percellpg

--- a/cellmodules/percellpg/percellpg.go
+++ b/cellmodules/percellpg/percellpg.go
@@ -1,0 +1,177 @@
+package percellpg
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/lifecycle"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/migration"
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+	"github.com/ghbvf/gocell/framework/runtime/capability"
+)
+
+// Config carries the per-cell DSN resolution and pool options. The composition
+// root reads per-cell environment variables (GOCELL_<CELLID>_DATABASE_URL) and
+// passes the resolved configs here, keeping this package pure with respect to
+// os.Getenv and exhaustively unit-testable.
+type Config struct {
+	// Cells maps each postgres-requiring cell ID to its resolved PG Config
+	// (DSN + pool knobs). An empty DSN for any cell triggers a fail-closed
+	// startup error — sharing another cell's pool without operator intent would
+	// bypass per-cell credential isolation.
+	Cells map[string]adapterpg.Config
+
+	// ProjectionSourceTopics is the sorted set of outbox-projection contract IDs
+	// threaded into NewJournalingOutboxWriter (preserves EPIC #1504 D4); pass
+	// generatedProjectionSourceTopics() from the composition root.
+	ProjectionSourceTopics []string
+
+	// RequireRestrictedRole opts the serving pool into the
+	// postgres_app_role_restricted_ready precondition probe (#1676 [F-B11]):
+	// a superuser-served deployment reports /readyz 503 instead of silently
+	// leaking across tenants. The composition root passes true for the serving
+	// pool; false for tool pools (migrations).
+	RequireRestrictedRole bool
+}
+
+// Deps is the resolved per-cell PG dependency set. For memory topology, Provider
+// is nil and Resources is empty. For postgres topology with all cells sharing the
+// same DSN, Provider holds the single deduped capability.PGProvider and Resources
+// holds the pool as a lifecycle.ManagedResource for LIFO close.
+type Deps struct {
+	Provider  capability.PGProvider
+	Resources []lifecycle.ManagedResource
+}
+
+// newPool is the package-level pool factory seam. Tests can override it to inject
+// a fake without a live database (mirrors replaydeps.go's newRedisClient factory).
+// Production always uses adapterpg.NewPool.
+var newPool = adapterpg.NewPool
+
+// Resolve selects the postgres backend for topo. clk is the mandatory positional
+// clock (ADR clock-positional-injection-funnel), threaded into the outbox writer.
+//
+// Memory topology returns empty Deps (no pool). Postgres topology validates that
+// all postgres cells have a non-empty DSN and that all DSNs deduplicate to
+// exactly one (colocated invariant), then opens ONE shared pool.
+//
+// See the package doc for the selection matrix and the two fail-closed invariants
+// (missing-DSN gate, distinct-DSN gate).
+func Resolve(ctx context.Context, clk clock.Clock, topo bootstrap.Topology, cfg Config) (Deps, error) {
+	clock.MustHaveClock(clk, "percellpg.Resolve")
+
+	agreed, ok, err := resolveAgreedConfig(topo, cfg)
+	if err != nil {
+		return Deps{}, err
+	}
+	if !ok {
+		// Memory topology: no pool needed.
+		return Deps{}, nil
+	}
+
+	pool, err := newPool(ctx, agreed)
+	if err != nil {
+		return Deps{}, fmt.Errorf("percellpg: open postgres pool: %w", err)
+	}
+
+	if vErr := verifyPGPreconditions(ctx, pool); vErr != nil {
+		_ = pool.Close(ctx) // no leak on verify error, mirrors cap_wiring.go
+		return Deps{}, vErr
+	}
+
+	writer := adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(clk), cfg.ProjectionSourceTopics)
+	provider := capability.NewPGProvider(adapterpg.NewTxManager(pool), writer, pool.DB())
+
+	return Deps{
+		Provider:  provider,
+		Resources: []lifecycle.ManagedResource{pool},
+	}, nil
+}
+
+// resolveAgreedConfig is the PURE topology gate and DSN deduplicator. It:
+//   - returns (zero, false, nil) for non-postgres topology (memory mode).
+//   - iterates cfg.Cells in sorted cellID order; fails-closed on any empty DSN.
+//   - deduplicates DSNs; fails-closed if >1 distinct DSN is found.
+//   - returns (agreedConfig, true, nil) when exactly one distinct DSN exists.
+//
+// Pure: no I/O, no os.Getenv — exhaustively testable.
+func resolveAgreedConfig(topo bootstrap.Topology, cfg Config) (adapterpg.Config, bool, error) {
+	if topo.StorageBackend() != bootstrap.StorageBackendPostgres {
+		return adapterpg.Config{}, false, nil
+	}
+
+	// Sort cell IDs for deterministic error messages.
+	cellIDs := make([]string, 0, len(cfg.Cells))
+	for id := range cfg.Cells {
+		cellIDs = append(cellIDs, id)
+	}
+	sort.Strings(cellIDs)
+
+	// Dedup DSNs; fail-closed on empty DSN.
+	seen := make(map[string]adapterpg.Config, len(cellIDs))
+	for _, id := range cellIDs {
+		cellCfg := cfg.Cells[id]
+		trimmed := strings.TrimSpace(cellCfg.DSN)
+		if trimmed == "" {
+			envVar := "GOCELL_" + strings.ToUpper(id) + "_DATABASE_URL"
+			return adapterpg.Config{}, false, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"percellpg: postgres-requiring cell is missing its per-cell database URL; "+
+					"refusing to silently share another cell's pool",
+				errcode.WithInternal(errcode.InternalAttr("cell_id", id)),
+				errcode.WithInternal(errcode.InternalAttr("env_var", envVar)),
+			)
+		}
+		seen[trimmed] = cellCfg
+	}
+
+	if len(seen) > 1 {
+		return adapterpg.Config{}, false, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"percellpg: per-cell distinct database credentials require split topology "+
+				"with per-cell outbox relay fan-out (US4 #1963; tracked in the per-cell infra "+
+				"fan-out backlog); colocated assemblies must configure an identical "+
+				"GOCELL_<CELLID>_DATABASE_URL for every postgres cell",
+		)
+	}
+
+	// Exactly one distinct DSN: use the config of the first sorted cell (includes
+	// pool knobs like MaxConns / IdleTimeout / MaxLifetime set by that cell's env).
+	// Apply the RequireRestrictedRole override from the caller.
+	agreed := cfg.Cells[cellIDs[0]]
+	agreed.RequireRestrictedRole = cfg.RequireRestrictedRole
+	return agreed, true, nil
+}
+
+// verifyPGPreconditions runs the three assembly-wide PG fail-fast checks.
+// Moved from cmd/corebundle/cap_wiring.go into this package so the resolver owns
+// the full pool-open → verify → wrap sequence (mirrors auditcore's admin pool
+// pattern). Caller owns pool lifecycle; on error the caller must close the pool.
+func verifyPGPreconditions(ctx context.Context, pool *adapterpg.Pool) error {
+	if err := verifyPGSchema(ctx, pool); err != nil {
+		return err
+	}
+	// S3+S5: column-existence fail-fast catches partial migrations.
+	if err := adapterpg.VerifyExpectedShape(ctx, pool); err != nil {
+		return fmt.Errorf("percellpg: PG schema shape: %w", err)
+	}
+	// B2-X-03: operators must DROP INVALID indexes manually before start.
+	if err := adapterpg.VerifyNoInvalidIndexes(ctx, pool); err != nil {
+		return fmt.Errorf("percellpg: PG invalid indexes: %w", err)
+	}
+	return nil
+}
+
+func verifyPGSchema(ctx context.Context, pool *adapterpg.Pool) error {
+	migrationsFS, err := adapterpg.MigrationsFS()
+	if err != nil {
+		return fmt.Errorf("percellpg: PG migrations fs: %w", err)
+	}
+	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, migration.PlatformNamespace); err != nil {
+		return fmt.Errorf("percellpg: PG schema guard: %w", err)
+	}
+	return nil
+}

--- a/cellmodules/percellpg/percellpg.go
+++ b/cellmodules/percellpg/percellpg.go
@@ -132,9 +132,10 @@ func resolveAgreedConfig(topo bootstrap.Topology, cfg Config) (adapterpg.Config,
 	if len(seen) > 1 {
 		return adapterpg.Config{}, false, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"percellpg: per-cell distinct database credentials require split topology "+
-				"with per-cell outbox relay fan-out (US4 #1963; tracked in the per-cell infra "+
-				"fan-out backlog); colocated assemblies must configure an identical "+
+				"with per-cell outbox relay fan-out (US4 #1963 / #2152); colocated assemblies must configure an identical "+
 				"GOCELL_<CELLID>_DATABASE_URL for every postgres cell",
+			errcode.WithInternal(errcode.InternalAttr("distinct_dsn_count", len(seen))),
+			errcode.WithInternal(errcode.InternalAttr("cell_ids", strings.Join(cellIDs, ","))),
 		)
 	}
 

--- a/cellmodules/percellpg/percellpg.go
+++ b/cellmodules/percellpg/percellpg.go
@@ -1,116 +1,66 @@
 package percellpg
 
 import (
-	"context"
-	"fmt"
 	"sort"
 	"strings"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
-	"github.com/ghbvf/gocell/framework/kernel/clock"
-	"github.com/ghbvf/gocell/framework/kernel/lifecycle"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
-	"github.com/ghbvf/gocell/framework/pkg/migration"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
-	"github.com/ghbvf/gocell/framework/runtime/capability"
 )
 
-// Config carries the per-cell DSN resolution and pool options. The composition
-// root reads per-cell environment variables (GOCELL_<CELLID>_DATABASE_URL) and
-// passes the resolved configs here, keeping this package pure with respect to
-// os.Getenv and exhaustively unit-testable.
+// Config carries the per-cell DSN resolution inputs. The composition root reads
+// each postgres cell's GOCELL_<CELLID>_DATABASE_URL (+ pool knobs) and passes the
+// resolved configs here, keeping this package pure with respect to os.Getenv and
+// exhaustively unit-testable.
 type Config struct {
 	// Cells maps each postgres-requiring cell ID to its resolved PG Config
-	// (DSN + pool knobs). An empty DSN for any cell triggers a fail-closed
-	// startup error — sharing another cell's pool without operator intent would
-	// bypass per-cell credential isolation.
+	// (DSN + pool knobs). An empty DSN for any cell — or an empty Cells map in
+	// postgres topology — triggers a fail-closed startup error.
 	Cells map[string]adapterpg.Config
 
-	// ProjectionSourceTopics is the sorted set of outbox-projection contract IDs
-	// threaded into NewJournalingOutboxWriter (preserves EPIC #1504 D4); pass
-	// generatedProjectionSourceTopics() from the composition root.
-	ProjectionSourceTopics []string
-
 	// RequireRestrictedRole opts the serving pool into the
-	// postgres_app_role_restricted_ready precondition probe (#1676 [F-B11]):
-	// a superuser-served deployment reports /readyz 503 instead of silently
-	// leaking across tenants. The composition root passes true for the serving
-	// pool; false for tool pools (migrations).
+	// postgres_app_role_restricted_ready precondition probe (#1676 [F-B11]).
+	// Applied to the agreed Config the composition root opens the pool from.
 	RequireRestrictedRole bool
 }
 
-// Deps is the resolved per-cell PG dependency set. For memory topology, Provider
-// is nil and Resources is empty. For postgres topology with all cells sharing the
-// same DSN, Provider holds the single deduped capability.PGProvider and Resources
-// holds the pool as a lifecycle.ManagedResource for LIFO close.
-type Deps struct {
-	Provider  capability.PGProvider
-	Resources []lifecycle.ManagedResource
-}
-
-// newPool is the package-level pool factory seam. Tests can override it to inject
-// a fake without a live database (mirrors replaydeps.go's newRedisClient factory).
-// Production always uses adapterpg.NewPool.
-var newPool = adapterpg.NewPool
-
-// Resolve selects the postgres backend for topo. clk is the mandatory positional
-// clock (ADR clock-positional-injection-funnel), threaded into the outbox writer.
+// Resolve is the PURE per-cell DSN gate + dedup. It decides which single
+// postgres Config the assembly pool is opened from; it performs NO I/O.
 //
-// Memory topology returns empty Deps (no pool). Postgres topology validates that
-// all postgres cells have a non-empty DSN and that all DSNs deduplicate to
-// exactly one (colocated invariant), then opens ONE shared pool.
+// The composition root (cmd/corebundle/cap_wiring.go) owns pool construction,
+// schema verification, and capability.PGProvider wrapping — deliberately, so the
+// adapter constructors (NewPool / NewTxManager / NewJournalingOutboxWriter) stay
+// in the single sanctioned cmd site that CAPABILITY-PROVIDER-FUNNEL-01 and
+// PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 cover. This resolver only
+// supplies the agreed DSN config + the three fail-closed gates.
 //
-// See the package doc for the selection matrix and the two fail-closed invariants
-// (missing-DSN gate, distinct-DSN gate).
-func Resolve(ctx context.Context, clk clock.Clock, topo bootstrap.Topology, cfg Config) (Deps, error) {
-	clock.MustHaveClock(clk, "percellpg.Resolve")
-
-	agreed, ok, err := resolveAgreedConfig(topo, cfg)
-	if err != nil {
-		return Deps{}, err
-	}
-	if !ok {
-		// Memory topology: no pool needed.
-		return Deps{}, nil
-	}
-
-	pool, err := newPool(ctx, agreed)
-	if err != nil {
-		return Deps{}, fmt.Errorf("percellpg: open postgres pool: %w", err)
-	}
-
-	if vErr := verifyPGPreconditions(ctx, pool); vErr != nil {
-		_ = pool.Close(ctx) // no leak on verify error, mirrors cap_wiring.go
-		return Deps{}, vErr
-	}
-
-	writer := adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(clk), cfg.ProjectionSourceTopics)
-	provider := capability.NewPGProvider(adapterpg.NewTxManager(pool), writer, pool.DB())
-
-	return Deps{
-		Provider:  provider,
-		Resources: []lifecycle.ManagedResource{pool},
-	}, nil
-}
-
-// resolveAgreedConfig is the PURE topology gate and DSN deduplicator. It:
-//   - returns (zero, false, nil) for non-postgres topology (memory mode).
-//   - iterates cfg.Cells in sorted cellID order; fails-closed on any empty DSN.
-//   - deduplicates DSNs; fails-closed if >1 distinct DSN is found.
-//   - returns (agreedConfig, true, nil) when exactly one distinct DSN exists.
-//
-// Pure: no I/O, no os.Getenv — exhaustively testable.
-func resolveAgreedConfig(topo bootstrap.Topology, cfg Config) (adapterpg.Config, bool, error) {
+// Returns:
+//   - (zero, false, nil) for non-postgres (memory) topology — no pool needed.
+//   - (agreedConfig, true, nil) for postgres topology with exactly one distinct DSN
+//     (colocated). agreedConfig is the alphabetically-first cell's Config (DSN +
+//     pool knobs) with RequireRestrictedRole applied from cfg.
+//   - fail-closed error for: empty Cells, any empty per-cell DSN, or >1 distinct DSN.
+func Resolve(topo bootstrap.Topology, cfg Config) (adapterpg.Config, bool, error) {
 	if topo.StorageBackend() != bootstrap.StorageBackendPostgres {
 		return adapterpg.Config{}, false, nil
 	}
 
-	// Sort cell IDs for deterministic error messages.
+	// Sort cell IDs for deterministic error messages + a stable agreed-config pick.
 	cellIDs := make([]string, 0, len(cfg.Cells))
 	for id := range cfg.Cells {
 		cellIDs = append(cellIDs, id)
 	}
 	sort.Strings(cellIDs)
+
+	// Empty-cell-set gate: postgres topology with no postgres cells is a
+	// fail-closed misconfiguration, not a silent no-op (also guards the
+	// cellIDs[0] index below from a panic on an empty map).
+	if len(cellIDs) == 0 {
+		return adapterpg.Config{}, false, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"percellpg: postgres topology requires at least one postgres-requiring cell "+
+				"with a database URL; refusing to start with an empty cell set")
+	}
 
 	// Dedup DSNs; fail-closed on empty DSN.
 	seen := make(map[string]adapterpg.Config, len(cellIDs))
@@ -132,47 +82,18 @@ func resolveAgreedConfig(topo bootstrap.Topology, cfg Config) (adapterpg.Config,
 	if len(seen) > 1 {
 		return adapterpg.Config{}, false, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"percellpg: per-cell distinct database credentials require split topology "+
-				"with per-cell outbox relay fan-out (US4 #1963 / #2152); colocated assemblies must configure an identical "+
-				"GOCELL_<CELLID>_DATABASE_URL for every postgres cell",
+				"with per-cell outbox relay fan-out (US4 #1963 / #2152); colocated assemblies "+
+				"must configure an identical GOCELL_<CELLID>_DATABASE_URL for every postgres cell",
 			errcode.WithInternal(errcode.InternalAttr("distinct_dsn_count", len(seen))),
 			errcode.WithInternal(errcode.InternalAttr("cell_ids", strings.Join(cellIDs, ","))),
 		)
 	}
 
-	// Exactly one distinct DSN: use the config of the first sorted cell (includes
-	// pool knobs like MaxConns / IdleTimeout / MaxLifetime set by that cell's env).
-	// Apply the RequireRestrictedRole override from the caller.
+	// Exactly one distinct DSN: use the alphabetically-first cell's full Config
+	// (DSN + pool knobs). Colocated deployments must set identical pool knobs across
+	// postgres cells since they configure the one shared pool. Apply the caller's
+	// RequireRestrictedRole override.
 	agreed := cfg.Cells[cellIDs[0]]
 	agreed.RequireRestrictedRole = cfg.RequireRestrictedRole
 	return agreed, true, nil
-}
-
-// verifyPGPreconditions runs the three assembly-wide PG fail-fast checks.
-// Moved from cmd/corebundle/cap_wiring.go into this package so the resolver owns
-// the full pool-open → verify → wrap sequence (mirrors auditcore's admin pool
-// pattern). Caller owns pool lifecycle; on error the caller must close the pool.
-func verifyPGPreconditions(ctx context.Context, pool *adapterpg.Pool) error {
-	if err := verifyPGSchema(ctx, pool); err != nil {
-		return err
-	}
-	// S3+S5: column-existence fail-fast catches partial migrations.
-	if err := adapterpg.VerifyExpectedShape(ctx, pool); err != nil {
-		return fmt.Errorf("percellpg: PG schema shape: %w", err)
-	}
-	// B2-X-03: operators must DROP INVALID indexes manually before start.
-	if err := adapterpg.VerifyNoInvalidIndexes(ctx, pool); err != nil {
-		return fmt.Errorf("percellpg: PG invalid indexes: %w", err)
-	}
-	return nil
-}
-
-func verifyPGSchema(ctx context.Context, pool *adapterpg.Pool) error {
-	migrationsFS, err := adapterpg.MigrationsFS()
-	if err != nil {
-		return fmt.Errorf("percellpg: PG migrations fs: %w", err)
-	}
-	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, migration.PlatformNamespace); err != nil {
-		return fmt.Errorf("percellpg: PG schema guard: %w", err)
-	}
-	return nil
 }

--- a/cellmodules/percellpg/percellpg_test.go
+++ b/cellmodules/percellpg/percellpg_test.go
@@ -2,6 +2,7 @@ package percellpg
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -218,5 +219,36 @@ func TestResolve_MemoryTopology(t *testing.T) {
 	}
 	if len(deps.Resources) != 0 {
 		t.Errorf("Resolve(memory): Resources must be empty, got %d", len(deps.Resources))
+	}
+}
+
+// TestResolve_OpenPoolError verifies that a pool-open failure (unreachable DB,
+// bad credentials) surfaces as a wrapped fail-closed error and no partial Deps —
+// not a silent degrade. NOT parallel: it mutates the package-level newPool seam.
+//
+// The success path (open → verifyPGPreconditions → wrap into capability.PGProvider)
+// requires a live postgres (adapterpg.NewPool pings eagerly; *adapterpg.Pool cannot
+// be faked), so it is covered by the real-PG integration test
+// cmd/corebundle/corebundle_pg_env_integration_test.go — the same coverage the
+// relocated verify* helpers had while they lived in cap_wiring.go.
+func TestResolve_OpenPoolError(t *testing.T) {
+	orig := newPool
+	t.Cleanup(func() { newPool = orig })
+	wantErr := errors.New("dial tcp 127.0.0.1:1: connection refused")
+	newPool = func(_ context.Context, _ adapterpg.Config) (*adapterpg.Pool, error) {
+		return nil, wantErr
+	}
+
+	topo := mkTopo(t, "real", "postgres", true)
+	cfg := Config{Cells: map[string]adapterpg.Config{"configcore": {DSN: "postgres://host/db"}}}
+	deps, err := Resolve(context.Background(), newClk(), topo, cfg)
+	if err == nil {
+		t.Fatal("Resolve(open error) = nil error, want wrapped fail-closed error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+	if deps.Provider != nil || len(deps.Resources) != 0 {
+		t.Error("Resolve(open error): Deps must be zero-valued, no partial wiring")
 	}
 }

--- a/cellmodules/percellpg/percellpg_test.go
+++ b/cellmodules/percellpg/percellpg_test.go
@@ -1,0 +1,222 @@
+package percellpg
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+)
+
+func newClk() *clockmock.FakeClock {
+	return clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+}
+
+func mkTopo(t *testing.T, adapterMode, storageBackend string, singlePod bool) bootstrap.Topology {
+	t.Helper()
+	topo, err := bootstrap.NewTopology(adapterMode, storageBackend, singlePod)
+	if err != nil {
+		t.Fatalf("NewTopology(%q,%q,%v): %v", adapterMode, storageBackend, singlePod, err)
+	}
+	return topo
+}
+
+// ---------------------------------------------------------------------------
+// resolveAgreedConfig — pure function, white-box tests
+// ---------------------------------------------------------------------------
+
+// TestResolveAgreedConfig_MemoryTopology verifies that a non-postgres topology
+// (memory) returns ok=false with no error: no pool needed for in-memory mode.
+func TestResolveAgreedConfig_MemoryTopology(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "", "memory", false)
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"cellA": {DSN: "postgres://x/db"},
+		},
+	}
+	_, ok, err := resolveAgreedConfig(topo, cfg)
+	if err != nil {
+		t.Fatalf("resolveAgreedConfig(memory): unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("resolveAgreedConfig(memory): want ok=false (no pool in memory mode)")
+	}
+}
+
+// TestResolveAgreedConfig_MissingDSN verifies that a postgres-requiring cell
+// with an empty DSN is fail-closed with an error mentioning the cell and its
+// expected env var pattern.
+func TestResolveAgreedConfig_MissingDSN(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"configcore": {DSN: ""},
+		},
+	}
+	_, _, err := resolveAgreedConfig(topo, cfg)
+	if err == nil {
+		t.Fatal("resolveAgreedConfig(missing DSN) = nil error, want fail-closed startup error")
+	}
+	// Error must mention the cell ID and the env var pattern (in Internal attrs,
+	// not string-interpolated into the const message — but the error.Error() string
+	// includes the internal context for test assertion purposes).
+	if !strings.Contains(err.Error(), "configcore") {
+		t.Errorf("error = %q, want it to mention cell ID 'configcore'", err)
+	}
+	if !strings.Contains(err.Error(), "GOCELL_CONFIGCORE_DATABASE_URL") {
+		t.Errorf("error = %q, want it to mention GOCELL_CONFIGCORE_DATABASE_URL env var pattern", err)
+	}
+}
+
+// TestResolveAgreedConfig_DistinctDSNs verifies that two cells with different
+// DSNs cause a fail-closed error pointing to split topology and US4 #1963.
+func TestResolveAgreedConfig_DistinctDSNs(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"auditcore":  {DSN: "postgres://user:pass@host1/db1"},
+			"configcore": {DSN: "postgres://user:pass@host2/db2"},
+		},
+	}
+	_, _, err := resolveAgreedConfig(topo, cfg)
+	if err == nil {
+		t.Fatal("resolveAgreedConfig(distinct DSNs) = nil error, want fail-closed startup error")
+	}
+	if !strings.Contains(err.Error(), "distinct") {
+		t.Errorf("error = %q, want mention of 'distinct'", err)
+	}
+	if !strings.Contains(err.Error(), "#1963") {
+		t.Errorf("error = %q, want mention of US4 #1963", err)
+	}
+}
+
+// TestResolveAgreedConfig_SameDSN verifies that cells sharing the same DSN
+// resolve successfully to a single agreed config with ok=true.
+func TestResolveAgreedConfig_SameDSN(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	const dsn = "postgres://user:pass@host/db"
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"auditcore":  {DSN: dsn},
+			"configcore": {DSN: dsn},
+			"accesscore": {DSN: dsn},
+		},
+		RequireRestrictedRole: true,
+	}
+	agreed, ok, err := resolveAgreedConfig(topo, cfg)
+	if err != nil {
+		t.Fatalf("resolveAgreedConfig(same DSN): unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("resolveAgreedConfig(same DSN): want ok=true")
+	}
+	if agreed.DSN != dsn {
+		t.Errorf("agreed.DSN = %q, want %q", agreed.DSN, dsn)
+	}
+	if !agreed.RequireRestrictedRole {
+		t.Error("agreed.RequireRestrictedRole should be true (passed via Config)")
+	}
+}
+
+// TestResolveAgreedConfig_DeterministicOrder verifies that when multiple cells
+// are missing DSNs, the error is reported for the alphabetically first cell
+// (sorted cellID order), ensuring deterministic error messages.
+func TestResolveAgreedConfig_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"zebracell":  {DSN: ""},
+			"alphacell":  {DSN: ""},
+			"middlecell": {DSN: ""},
+		},
+	}
+	_, _, err := resolveAgreedConfig(topo, cfg)
+	if err == nil {
+		t.Fatal("want fail-closed error, got nil")
+	}
+	// alphacell sorts first; error must name it
+	if !strings.Contains(err.Error(), "alphacell") {
+		t.Errorf("error = %q, want 'alphacell' (first sorted cell with missing DSN)", err)
+	}
+}
+
+// TestResolveAgreedConfig_WhitespaceOnlyDSN verifies that a DSN consisting of
+// only whitespace is treated as empty (missing) and triggers the fail-closed gate.
+func TestResolveAgreedConfig_WhitespaceOnlyDSN(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"configcore": {DSN: "   "},
+		},
+	}
+	_, _, err := resolveAgreedConfig(topo, cfg)
+	if err == nil {
+		t.Fatal("whitespace-only DSN should be rejected as empty (fail-closed)")
+	}
+}
+
+// TestResolveAgreedConfig_SingleCell verifies that a single cell with a valid
+// DSN resolves successfully.
+func TestResolveAgreedConfig_SingleCell(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	const dsn = "postgres://user:pass@host/db"
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"configcore": {DSN: dsn, MaxConns: 10},
+		},
+	}
+	agreed, ok, err := resolveAgreedConfig(topo, cfg)
+	if err != nil {
+		t.Fatalf("resolveAgreedConfig(single cell): unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("resolveAgreedConfig(single cell): want ok=true")
+	}
+	if agreed.DSN != dsn {
+		t.Errorf("agreed.DSN = %q, want %q", agreed.DSN, dsn)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolve — top-level, impure (newPool override required for unit tests)
+// ---------------------------------------------------------------------------
+
+// TestResolve_MemoryTopology verifies that Resolve returns empty Deps (no
+// Provider, no Resources) for memory topology without calling newPool.
+func TestResolve_MemoryTopology(t *testing.T) {
+	t.Parallel()
+	// Override newPool to fail if called — it must NOT be called in memory topology.
+	orig := newPool
+	t.Cleanup(func() { newPool = orig })
+	newPool = func(_ context.Context, _ adapterpg.Config) (*adapterpg.Pool, error) {
+		t.Fatal("newPool must not be called in memory topology")
+		return nil, nil
+	}
+
+	topo := mkTopo(t, "", "memory", false)
+	cfg := Config{
+		Cells: map[string]adapterpg.Config{
+			"cellA": {DSN: "postgres://x/db"},
+		},
+	}
+	deps, err := Resolve(context.Background(), newClk(), topo, cfg)
+	if err != nil {
+		t.Fatalf("Resolve(memory): unexpected error: %v", err)
+	}
+	if deps.Provider != nil {
+		t.Error("Resolve(memory): Provider must be nil (no pool in memory mode)")
+	}
+	if len(deps.Resources) != 0 {
+		t.Errorf("Resolve(memory): Resources must be empty, got %d", len(deps.Resources))
+	}
+}

--- a/cellmodules/percellpg/percellpg_test.go
+++ b/cellmodules/percellpg/percellpg_test.go
@@ -1,20 +1,12 @@
 package percellpg
 
 import (
-	"context"
-	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
-	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 )
-
-func newClk() *clockmock.FakeClock {
-	return clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
-}
 
 func mkTopo(t *testing.T, adapterMode, storageBackend string, singlePod bool) bootstrap.Topology {
 	t.Helper()
@@ -25,84 +17,87 @@ func mkTopo(t *testing.T, adapterMode, storageBackend string, singlePod bool) bo
 	return topo
 }
 
-// ---------------------------------------------------------------------------
-// resolveAgreedConfig — pure function, white-box tests
-// ---------------------------------------------------------------------------
+// Resolve is a pure decision function (no I/O), so every branch is exhaustively
+// unit-testable here. The composition root (cmd/corebundle/cap_wiring.go) opens
+// the pool + verifies schema from the agreed Config; that I/O path is covered by
+// the real-PG integration test corebundle_pg_env_integration_test.go.
 
-// TestResolveAgreedConfig_MemoryTopology verifies that a non-postgres topology
-// (memory) returns ok=false with no error: no pool needed for in-memory mode.
-func TestResolveAgreedConfig_MemoryTopology(t *testing.T) {
+// TestResolve_MemoryTopology: non-postgres topology returns ok=false, no error —
+// no pool is needed and the per-cell DSNs are never read.
+func TestResolve_MemoryTopology(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "", "memory", false)
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"cellA": {DSN: "postgres://x/db"},
-		},
-	}
-	_, ok, err := resolveAgreedConfig(topo, cfg)
+	cfg := Config{Cells: map[string]adapterpg.Config{"cellA": {DSN: "postgres://x/db"}}}
+	_, ok, err := Resolve(topo, cfg)
 	if err != nil {
-		t.Fatalf("resolveAgreedConfig(memory): unexpected error: %v", err)
+		t.Fatalf("Resolve(memory): unexpected error: %v", err)
 	}
 	if ok {
-		t.Fatal("resolveAgreedConfig(memory): want ok=false (no pool in memory mode)")
+		t.Fatal("Resolve(memory): want ok=false (no pool in memory mode)")
 	}
 }
 
-// TestResolveAgreedConfig_MissingDSN verifies that a postgres-requiring cell
-// with an empty DSN is fail-closed with an error mentioning the cell and its
-// expected env var pattern.
-func TestResolveAgreedConfig_MissingDSN(t *testing.T) {
+// TestResolve_EmptyCells_Postgres: postgres topology with an empty Cells map is a
+// fail-closed misconfiguration (and must not panic on the cellIDs[0] index).
+func TestResolve_EmptyCells_Postgres(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"configcore": {DSN: ""},
-		},
-	}
-	_, _, err := resolveAgreedConfig(topo, cfg)
+	_, ok, err := Resolve(topo, Config{Cells: nil})
 	if err == nil {
-		t.Fatal("resolveAgreedConfig(missing DSN) = nil error, want fail-closed startup error")
+		t.Fatal("Resolve(postgres, empty Cells) = nil error, want fail-closed startup error")
 	}
-	// Error must mention the cell ID and the env var pattern (in Internal attrs,
-	// not string-interpolated into the const message — but the error.Error() string
-	// includes the internal context for test assertion purposes).
+	if ok {
+		t.Error("Resolve(postgres, empty Cells): want ok=false")
+	}
+	if !strings.Contains(err.Error(), "empty cell set") {
+		t.Errorf("error = %q, want it to mention 'empty cell set'", err)
+	}
+}
+
+// TestResolve_MissingDSN: a postgres-requiring cell with an empty DSN is fail-closed
+// with the cell ID + expected env var in the diagnostic context.
+func TestResolve_MissingDSN(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	cfg := Config{Cells: map[string]adapterpg.Config{"configcore": {DSN: ""}}}
+	_, _, err := Resolve(topo, cfg)
+	if err == nil {
+		t.Fatal("Resolve(missing DSN) = nil error, want fail-closed startup error")
+	}
 	if !strings.Contains(err.Error(), "configcore") {
 		t.Errorf("error = %q, want it to mention cell ID 'configcore'", err)
 	}
 	if !strings.Contains(err.Error(), "GOCELL_CONFIGCORE_DATABASE_URL") {
-		t.Errorf("error = %q, want it to mention GOCELL_CONFIGCORE_DATABASE_URL env var pattern", err)
+		t.Errorf("error = %q, want it to mention the GOCELL_CONFIGCORE_DATABASE_URL env var", err)
 	}
 }
 
-// TestResolveAgreedConfig_DistinctDSNs verifies that two cells with different
-// DSNs cause a fail-closed error pointing to split topology and US4 #1963.
-func TestResolveAgreedConfig_DistinctDSNs(t *testing.T) {
+// TestResolve_DistinctDSNs: two cells with different DSNs fail-closed, pointing to
+// split topology (US4 #1963 / #2152) with diagnostic distinct_dsn_count.
+func TestResolve_DistinctDSNs(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"auditcore":  {DSN: "postgres://host1/db1"},
-			"configcore": {DSN: "postgres://host2/db2"},
-		},
-	}
-	_, _, err := resolveAgreedConfig(topo, cfg)
+	cfg := Config{Cells: map[string]adapterpg.Config{
+		"auditcore":  {DSN: "postgres://host1/db1"},
+		"configcore": {DSN: "postgres://host2/db2"},
+	}}
+	_, _, err := Resolve(topo, cfg)
 	if err == nil {
-		t.Fatal("resolveAgreedConfig(distinct DSNs) = nil error, want fail-closed startup error")
+		t.Fatal("Resolve(distinct DSNs) = nil error, want fail-closed startup error")
 	}
-	// Error() shows WithInternal attrs (distinct_dsn_count, cell_ids) instead of the
-	// message when internal details are attached. Check that the diagnostic context is
-	// present and the error code is correct.
-	if !strings.Contains(err.Error(), "distinct_dsn_count") {
-		t.Errorf("error = %q, want internal diagnostic 'distinct_dsn_count'", err)
+	// errcode.Error() renders the WithInternal attrs (not the const message) when
+	// internal details are attached, so assert on the diagnostic context + code.
+	if !strings.Contains(err.Error(), "distinct_dsn_count=2") {
+		t.Errorf("error = %q, want internal diagnostic 'distinct_dsn_count=2'", err)
 	}
 	if !strings.Contains(err.Error(), "ERR_VALIDATION_FAILED") {
 		t.Errorf("error = %q, want ERR_VALIDATION_FAILED code", err)
 	}
 }
 
-// TestResolveAgreedConfig_SameDSN verifies that cells sharing the same DSN
-// resolve successfully to a single agreed config with ok=true.
-func TestResolveAgreedConfig_SameDSN(t *testing.T) {
+// TestResolve_SameDSN: all cells sharing one DSN dedup to a single agreed Config,
+// ok=true, with the caller's RequireRestrictedRole applied.
+func TestResolve_SameDSN(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
 	const dsn = "postgres://host/db"
@@ -114,197 +109,99 @@ func TestResolveAgreedConfig_SameDSN(t *testing.T) {
 		},
 		RequireRestrictedRole: true,
 	}
-	agreed, ok, err := resolveAgreedConfig(topo, cfg)
+	agreed, ok, err := Resolve(topo, cfg)
 	if err != nil {
-		t.Fatalf("resolveAgreedConfig(same DSN): unexpected error: %v", err)
+		t.Fatalf("Resolve(same DSN): unexpected error: %v", err)
 	}
 	if !ok {
-		t.Fatal("resolveAgreedConfig(same DSN): want ok=true")
+		t.Fatal("Resolve(same DSN): want ok=true")
 	}
 	if agreed.DSN != dsn {
 		t.Errorf("agreed.DSN = %q, want %q", agreed.DSN, dsn)
 	}
 	if !agreed.RequireRestrictedRole {
-		t.Error("agreed.RequireRestrictedRole should be true (passed via Config)")
+		t.Error("agreed.RequireRestrictedRole should be true (applied from Config)")
 	}
 }
 
-// TestResolveAgreedConfig_DeterministicOrder verifies that when multiple cells
-// are missing DSNs, the error is reported for the alphabetically first cell
-// (sorted cellID order), ensuring deterministic error messages.
-func TestResolveAgreedConfig_DeterministicOrder(t *testing.T) {
+// TestResolve_DeterministicOrder: when multiple cells are missing DSNs, the error
+// names the alphabetically-first cell (stable sorted order).
+func TestResolve_DeterministicOrder(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"zebracell":  {DSN: ""},
-			"alphacell":  {DSN: ""},
-			"middlecell": {DSN: ""},
-		},
-	}
-	_, _, err := resolveAgreedConfig(topo, cfg)
+	cfg := Config{Cells: map[string]adapterpg.Config{
+		"zebracell":  {DSN: ""},
+		"alphacell":  {DSN: ""},
+		"middlecell": {DSN: ""},
+	}}
+	_, _, err := Resolve(topo, cfg)
 	if err == nil {
 		t.Fatal("want fail-closed error, got nil")
 	}
-	// alphacell sorts first; error must name it
 	if !strings.Contains(err.Error(), "alphacell") {
 		t.Errorf("error = %q, want 'alphacell' (first sorted cell with missing DSN)", err)
 	}
 }
 
-// TestResolveAgreedConfig_WhitespaceOnlyDSN verifies that a DSN consisting of
-// only whitespace is treated as empty (missing) and triggers the fail-closed gate.
-func TestResolveAgreedConfig_WhitespaceOnlyDSN(t *testing.T) {
+// TestResolve_WhitespaceOnlyDSN: a whitespace-only DSN is treated as empty (missing).
+func TestResolve_WhitespaceOnlyDSN(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"configcore": {DSN: "   "},
-		},
-	}
-	_, _, err := resolveAgreedConfig(topo, cfg)
+	cfg := Config{Cells: map[string]adapterpg.Config{"configcore": {DSN: "   "}}}
+	_, _, err := Resolve(topo, cfg)
 	if err == nil {
 		t.Fatal("whitespace-only DSN should be rejected as empty (fail-closed)")
 	}
 }
 
-// TestResolveAgreedConfig_SingleCell verifies that a single cell with a valid
-// DSN resolves successfully.
-func TestResolveAgreedConfig_SingleCell(t *testing.T) {
+// TestResolve_SingleCell: one cell with a valid DSN resolves, carrying its pool knobs.
+func TestResolve_SingleCell(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
 	const dsn = "postgres://host/db"
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"configcore": {DSN: dsn, MaxConns: 10},
-		},
-	}
-	agreed, ok, err := resolveAgreedConfig(topo, cfg)
+	cfg := Config{Cells: map[string]adapterpg.Config{"configcore": {DSN: dsn, MaxConns: 10}}}
+	agreed, ok, err := Resolve(topo, cfg)
 	if err != nil {
-		t.Fatalf("resolveAgreedConfig(single cell): unexpected error: %v", err)
+		t.Fatalf("Resolve(single cell): unexpected error: %v", err)
 	}
 	if !ok {
-		t.Fatal("resolveAgreedConfig(single cell): want ok=true")
+		t.Fatal("Resolve(single cell): want ok=true")
 	}
-	if agreed.DSN != dsn {
-		t.Errorf("agreed.DSN = %q, want %q", agreed.DSN, dsn)
+	if agreed.DSN != dsn || agreed.MaxConns != 10 {
+		t.Errorf("agreed = %+v, want DSN=%q MaxConns=10", agreed, dsn)
 	}
 }
 
-// TestResolveAgreedConfig_RequireRestrictedRoleOverride verifies that the caller's
-// Config.RequireRestrictedRole value always wins over the individual cell's
-// adapterpg.Config.RequireRestrictedRole (percellpg.go:145: agreed.RequireRestrictedRole
-// = cfg.RequireRestrictedRole). The caller (composition root) controls this flag for
-// the shared pool; per-cell values are intentionally overridden.
-func TestResolveAgreedConfig_RequireRestrictedRoleOverride(t *testing.T) {
+// TestResolve_RequireRestrictedRoleOverride: the caller's Config.RequireRestrictedRole
+// always wins over the individual cell's adapterpg.Config value (the composition root
+// controls the serving-pool flag; per-cell values are intentionally overridden).
+func TestResolve_RequireRestrictedRoleOverride(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
 	const dsn = "postgres://host/db"
-
 	tests := []struct {
-		name           string
-		cellRole       bool // adapterpg.Config.RequireRestrictedRole for the cell
-		cfgRole        bool // Config.RequireRestrictedRole (caller override)
-		wantAgreedRole bool
+		name     string
+		cellRole bool
+		cfgRole  bool
+		want     bool
 	}{
-		{
-			name:           "cell=true cfg=false: caller false wins",
-			cellRole:       true,
-			cfgRole:        false,
-			wantAgreedRole: false,
-		},
-		{
-			name:           "cell=false cfg=true: caller true wins",
-			cellRole:       false,
-			cfgRole:        true,
-			wantAgreedRole: true,
-		},
+		{"cell=true cfg=false: caller false wins", true, false, false},
+		{"cell=false cfg=true: caller true wins", false, true, true},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := Config{
-				Cells: map[string]adapterpg.Config{
-					"accesscore": {DSN: dsn, RequireRestrictedRole: tc.cellRole},
-				},
+				Cells:                 map[string]adapterpg.Config{"configcore": {DSN: dsn, RequireRestrictedRole: tc.cellRole}},
 				RequireRestrictedRole: tc.cfgRole,
 			}
-			agreed, ok, err := resolveAgreedConfig(topo, cfg)
-			if err != nil {
-				t.Fatalf("resolveAgreedConfig: unexpected error: %v", err)
+			agreed, ok, err := Resolve(topo, cfg)
+			if err != nil || !ok {
+				t.Fatalf("Resolve: ok=%v err=%v", ok, err)
 			}
-			if !ok {
-				t.Fatal("resolveAgreedConfig: want ok=true")
-			}
-			if agreed.RequireRestrictedRole != tc.wantAgreedRole {
-				t.Errorf("agreed.RequireRestrictedRole = %v, want %v", agreed.RequireRestrictedRole, tc.wantAgreedRole)
+			if agreed.RequireRestrictedRole != tc.want {
+				t.Errorf("agreed.RequireRestrictedRole = %v, want %v", agreed.RequireRestrictedRole, tc.want)
 			}
 		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Resolve — top-level, impure (newPool override required for unit tests)
-// ---------------------------------------------------------------------------
-
-// TestResolve_MemoryTopology verifies that Resolve returns empty Deps (no
-// Provider, no Resources) for memory topology without calling newPool.
-// NOT parallel: mutates the package-level newPool seam.
-func TestResolve_MemoryTopology(t *testing.T) {
-	// Override newPool to fail if called — it must NOT be called in memory topology.
-	orig := newPool
-	t.Cleanup(func() { newPool = orig })
-	newPool = func(_ context.Context, _ adapterpg.Config) (*adapterpg.Pool, error) {
-		t.Fatal("newPool must not be called in memory topology")
-		panic("unreachable: t.Fatal above aborts the test goroutine")
-	}
-
-	topo := mkTopo(t, "", "memory", false)
-	cfg := Config{
-		Cells: map[string]adapterpg.Config{
-			"cellA": {DSN: "postgres://x/db"},
-		},
-	}
-	deps, err := Resolve(context.Background(), newClk(), topo, cfg)
-	if err != nil {
-		t.Fatalf("Resolve(memory): unexpected error: %v", err)
-	}
-	if deps.Provider != nil {
-		t.Error("Resolve(memory): Provider must be nil (no pool in memory mode)")
-	}
-	if len(deps.Resources) != 0 {
-		t.Errorf("Resolve(memory): Resources must be empty, got %d", len(deps.Resources))
-	}
-}
-
-// TestResolve_OpenPoolError verifies that a pool-open failure (unreachable DB,
-// bad credentials) surfaces as a wrapped fail-closed error and no partial Deps —
-// not a silent degrade. NOT parallel: it mutates the package-level newPool seam.
-//
-// The success path (open → verifyPGPreconditions → wrap into capability.PGProvider)
-// requires a live postgres (adapterpg.NewPool pings eagerly; *adapterpg.Pool cannot
-// be faked), so it is covered by the real-PG integration test
-// cmd/corebundle/corebundle_pg_env_integration_test.go — the same coverage the
-// relocated verify* helpers had while they lived in cap_wiring.go.
-func TestResolve_OpenPoolError(t *testing.T) {
-	orig := newPool
-	t.Cleanup(func() { newPool = orig })
-	wantErr := errors.New("dial tcp 127.0.0.1:1: connection refused")
-	newPool = func(_ context.Context, _ adapterpg.Config) (*adapterpg.Pool, error) {
-		return nil, wantErr
-	}
-
-	topo := mkTopo(t, "real", "postgres", true)
-	cfg := Config{Cells: map[string]adapterpg.Config{"configcore": {DSN: "postgres://host/db"}}}
-	deps, err := Resolve(context.Background(), newClk(), topo, cfg)
-	if err == nil {
-		t.Fatal("Resolve(open error) = nil error, want wrapped fail-closed error")
-	}
-	if !errors.Is(err, wantErr) {
-		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
-	}
-	if deps.Provider != nil || len(deps.Resources) != 0 {
-		t.Error("Resolve(open error): Deps must be zero-valued, no partial wiring")
 	}
 }

--- a/cellmodules/percellpg/percellpg_test.go
+++ b/cellmodules/percellpg/percellpg_test.go
@@ -89,11 +89,14 @@ func TestResolveAgreedConfig_DistinctDSNs(t *testing.T) {
 	if err == nil {
 		t.Fatal("resolveAgreedConfig(distinct DSNs) = nil error, want fail-closed startup error")
 	}
-	if !strings.Contains(err.Error(), "distinct") {
-		t.Errorf("error = %q, want mention of 'distinct'", err)
+	// Error() shows WithInternal attrs (distinct_dsn_count, cell_ids) instead of the
+	// message when internal details are attached. Check that the diagnostic context is
+	// present and the error code is correct.
+	if !strings.Contains(err.Error(), "distinct_dsn_count") {
+		t.Errorf("error = %q, want internal diagnostic 'distinct_dsn_count'", err)
 	}
-	if !strings.Contains(err.Error(), "#1963") {
-		t.Errorf("error = %q, want mention of US4 #1963", err)
+	if !strings.Contains(err.Error(), "ERR_VALIDATION_FAILED") {
+		t.Errorf("error = %q, want ERR_VALIDATION_FAILED code", err)
 	}
 }
 
@@ -188,14 +191,67 @@ func TestResolveAgreedConfig_SingleCell(t *testing.T) {
 	}
 }
 
+// TestResolveAgreedConfig_RequireRestrictedRoleOverride verifies that the caller's
+// Config.RequireRestrictedRole value always wins over the individual cell's
+// adapterpg.Config.RequireRestrictedRole (percellpg.go:145: agreed.RequireRestrictedRole
+// = cfg.RequireRestrictedRole). The caller (composition root) controls this flag for
+// the shared pool; per-cell values are intentionally overridden.
+func TestResolveAgreedConfig_RequireRestrictedRoleOverride(t *testing.T) {
+	t.Parallel()
+	topo := mkTopo(t, "real", "postgres", true)
+	const dsn = "postgres://host/db"
+
+	tests := []struct {
+		name           string
+		cellRole       bool // adapterpg.Config.RequireRestrictedRole for the cell
+		cfgRole        bool // Config.RequireRestrictedRole (caller override)
+		wantAgreedRole bool
+	}{
+		{
+			name:           "cell=true cfg=false: caller false wins",
+			cellRole:       true,
+			cfgRole:        false,
+			wantAgreedRole: false,
+		},
+		{
+			name:           "cell=false cfg=true: caller true wins",
+			cellRole:       false,
+			cfgRole:        true,
+			wantAgreedRole: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Config{
+				Cells: map[string]adapterpg.Config{
+					"accesscore": {DSN: dsn, RequireRestrictedRole: tc.cellRole},
+				},
+				RequireRestrictedRole: tc.cfgRole,
+			}
+			agreed, ok, err := resolveAgreedConfig(topo, cfg)
+			if err != nil {
+				t.Fatalf("resolveAgreedConfig: unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatal("resolveAgreedConfig: want ok=true")
+			}
+			if agreed.RequireRestrictedRole != tc.wantAgreedRole {
+				t.Errorf("agreed.RequireRestrictedRole = %v, want %v", agreed.RequireRestrictedRole, tc.wantAgreedRole)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Resolve — top-level, impure (newPool override required for unit tests)
 // ---------------------------------------------------------------------------
 
 // TestResolve_MemoryTopology verifies that Resolve returns empty Deps (no
 // Provider, no Resources) for memory topology without calling newPool.
+// NOT parallel: mutates the package-level newPool seam.
 func TestResolve_MemoryTopology(t *testing.T) {
-	t.Parallel()
 	// Override newPool to fail if called — it must NOT be called in memory topology.
 	orig := newPool
 	t.Cleanup(func() { newPool = orig })

--- a/cellmodules/percellpg/percellpg_test.go
+++ b/cellmodules/percellpg/percellpg_test.go
@@ -80,8 +80,8 @@ func TestResolveAgreedConfig_DistinctDSNs(t *testing.T) {
 	topo := mkTopo(t, "real", "postgres", true)
 	cfg := Config{
 		Cells: map[string]adapterpg.Config{
-			"auditcore":  {DSN: "postgres://user:pass@host1/db1"},
-			"configcore": {DSN: "postgres://user:pass@host2/db2"},
+			"auditcore":  {DSN: "postgres://host1/db1"},
+			"configcore": {DSN: "postgres://host2/db2"},
 		},
 	}
 	_, _, err := resolveAgreedConfig(topo, cfg)
@@ -101,7 +101,7 @@ func TestResolveAgreedConfig_DistinctDSNs(t *testing.T) {
 func TestResolveAgreedConfig_SameDSN(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
-	const dsn = "postgres://user:pass@host/db"
+	const dsn = "postgres://host/db"
 	cfg := Config{
 		Cells: map[string]adapterpg.Config{
 			"auditcore":  {DSN: dsn},
@@ -169,7 +169,7 @@ func TestResolveAgreedConfig_WhitespaceOnlyDSN(t *testing.T) {
 func TestResolveAgreedConfig_SingleCell(t *testing.T) {
 	t.Parallel()
 	topo := mkTopo(t, "real", "postgres", true)
-	const dsn = "postgres://user:pass@host/db"
+	const dsn = "postgres://host/db"
 	cfg := Config{
 		Cells: map[string]adapterpg.Config{
 			"configcore": {DSN: dsn, MaxConns: 10},
@@ -200,7 +200,7 @@ func TestResolve_MemoryTopology(t *testing.T) {
 	t.Cleanup(func() { newPool = orig })
 	newPool = func(_ context.Context, _ adapterpg.Config) (*adapterpg.Pool, error) {
 		t.Fatal("newPool must not be called in memory topology")
-		return nil, nil
+		panic("unreachable: t.Fatal above aborts the test goroutine")
 	}
 
 	topo := mkTopo(t, "", "memory", false)

--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -134,4 +134,5 @@ Wave-1 #1423 删除了跨 module value handoff（`ModuleExports` + `in` 参数�
 | `GOCELL_ACCESSCORE_IP_HASH_SALT` | bootstrap-failed 事件 client-IP keyed-hash salt（≥32 字节，#1488） | real 模式 fail-fast（缺失/demo key/<32B） |
 | `GOCELL_ADAPTER_MODE` | 适配器模式：`""`（dev，默认）/ `real` | — |
 | `GOCELL_CELL_ADAPTER_MODE` | 存储后端：`memory`（默认）/ `postgres`（`postgres` 经 Topology 耦合规则强制要求 `GOCELL_ADAPTER_MODE=real`） | — |
+| `GOCELL_<CELLID>_DATABASE_URL` | 每个 postgres cell 的 DSN（#1964 per-cell PG seam）。postgres 拓扑下 `generatedPostgresCells()` 中的每个 cell（accesscore / auditcore / configcore）均须设置；缺失任一 → fail-fast 报告 cell 名 + 期望的 env var。共址部署时三个 cell 设同一 DSN，`percellpg.Resolve` dedup 后只开一个 pool；>1 个不同 DSN → fail-closed（仅支持共址，拆分部署见 #1963） | postgres 拓扑 fail-fast |
 | `GOCELL_AMQP_URL` | postgres 拓扑的 RabbitMQ broker URL（事件传输 publisher/subscriber，#1940）；demo 拓扑不读 | postgres 拓扑 fail-fast（缺即启动期报错，不静默降级回 in-memory） |

--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -120,7 +120,7 @@ Wave-1 #1423 删除了跨 module value handoff（`ModuleExports` + `in` 参数�
 | `JWTDeps` | issuer + verifier（JWT 签发/验证） |
 | `InternalHMACRing` | /internal/v1/* service-token HMAC ring（#1410 起独立字段，原 `internalGuard` 已 dissolve） |
 | `NonceStore` | /internal/v1/* 服务令牌防重放 store；control-plane 校验经 `Kind()` 拒 noop / 多 pod in-memory（#1410） |
-| `SharedPGPool` | postgres 连接池（跨 Cell 共享） |
+| `PG` | sealed `capability.PGProvider`，由 `cellmodules/percellpg.Resolve` 在 postgres 拓扑下注入；memory 拓扑下为 nil，cell module 走 in-memory 路径 |
 | `ConsumerClaimer` | outbox 消费幂等键声明者；`Kind()` 自报 in_memory/distributed（#1410，CP8 fail-closed） |
 | `Publisher` / `Subscriber` | outbox 事件传输（relay 发布 sink + consumer 订阅源）；接口型，经 `cellmodules/eventtransport.Resolve` 按 Topology 选型——demo=in-memory，postgres=真实 broker（RabbitMQ），缺 broker fail-closed（#1940） |
 | `PrimaryHTTPAddr` / `InternalHTTPAddr` / `HealthHTTPAddr` | 三 listener 绑定地址 |

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -4,28 +4,29 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/cellmodules/percellpg"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
-	"github.com/ghbvf/gocell/framework/pkg/migration"
-	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 	"github.com/ghbvf/gocell/framework/runtime/capability"
 	"github.com/ghbvf/gocell/framework/runtime/composition"
 )
 
 // provisionCapabilities is the assembly's single shared-infrastructure
-// provisioning site. It is the sole sanctioned caller of the banned adapter
-// constructors (adapterpg.NewPool / NewTxManager / NewOutboxWriter /
-// NewJournalingOutboxWriter, adapterredis.NewClient via the factory) —
-// CAPABILITY-PROVIDER-FUNNEL-01 downstream allowlist locks construction to this file.
-//
-// It iterates the codegen-declared generatedCapabilities() (single source:
-// the derived union of the assembly cells' cell.yaml `requires`, computed in
-// kernel/assembly.GenerateModulesGen), and for each declared
+// provisioning site. It iterates the codegen-declared generatedCapabilities()
+// (single source: the derived union of the assembly cells' cell.yaml `requires`,
+// computed in kernel/assembly.GenerateModulesGen), and for each declared
 // capability provisions the shared resource exactly once and wraps it into the
 // sealed runtime/capability provider stored on shared. Consuming cell modules receive
 // the injected provider (shared.PG / shared.Redis) and never construct adapter
 // primitives themselves.
+//
+// Postgres provisioning now delegates to cellmodules/percellpg.Resolve, which
+// handles per-cell DSN resolution, dedup-by-DSN, fail-closed gates, pool
+// construction, schema verification, and provider wrapping. This file remains the
+// sole sanctioned caller entry point in cmd/ (CAPABILITY-PROVIDER-FUNNEL-01
+// downstream allowlist); the actual adapter constructors moved to percellpg.
 //
 // Called from runCorebundle after LoadSharedDepsFromEnv and before composition.Builder.Build
 // so the providers are present (or fail-fast) before any module.Provide runs —
@@ -61,66 +62,50 @@ func provisionCapabilities(ctx context.Context, shared *composition.SharedDeps, 
 	return nil
 }
 
-// provisionPostgres opens the assembly's single postgres pool (postgres
-// StorageBackend only), runs the schema/shape/index fail-fast checks, and wraps
-// the pool-bound TxManager + OutboxWriter + raw *pgxpool.Pool handle into the
-// sealed capability.PGProvider. The pool is recorded as locals.poolMR so bundle_options
-// registers it as the first ManagedResource (LIFO: closed last, after every PG
-// consumer — relay, cell workers, tx).
+// provisionPostgres delegates postgres pool provisioning to cellmodules/percellpg.Resolve.
+// It builds a percellpg.Config by iterating generatedPostgresCells() (single source:
+// cell IDs whose cell.yaml requires postgres, derived by codegen) and loading each
+// cell's per-cell DSN from the environment via LoadPGConfig. The resolver handles
+// dedup-by-DSN, fail-closed gates (missing DSN, distinct DSNs), pool construction,
+// schema/shape/index verification, and capability.PGProvider wrapping.
 //
-// In memory mode the pool is not opened and shared.PG stays nil; cell modules
-// fall through to their in-memory storage path.
+// In memory topology the resolver returns empty Deps and shared.PG stays nil;
+// cell modules fall through to their in-memory storage path.
+//
+// The decorator's topic argument MUST stay the direct generatedProjectionSourceTopics()
+// call (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 rejects a threaded
+// variable, which could hide a hand-typed list).
 func provisionPostgres(ctx context.Context, shared *composition.SharedDeps, locals *cmdLocals) error {
-	if shared.Topology.StorageBackend() != bootstrap.StorageBackendPostgres {
-		return nil
+	cells := make(map[string]adapterpg.Config, len(generatedPostgresCells()))
+	for _, cellID := range generatedPostgresCells() {
+		pgCfg, err := LoadPGConfig(strings.ToUpper(cellID))
+		if err != nil {
+			return fmt.Errorf("percellpg: load config for cell %s: %w", cellID, err)
+		}
+		cells[cellID] = pgCfg
 	}
-	pgCfg, err := LoadPGConfig("CONFIGCORE")
-	if err != nil {
-		return fmt.Errorf("assembly pg config: %w", err)
-	}
-	if pgCfg.DSN == "" {
-		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"corebundle postgres mode requires GOCELL_CONFIGCORE_DATABASE_URL")
-	}
-	// This is the assembly's SERVING pool. Its schema (migrations 052/053) places
-	// the six tenant tables under FORCE ROW LEVEL SECURITY, which is only enforced
-	// at runtime when the connecting role is neither a superuser nor BYPASSRLS.
-	// Opt into the postgres_app_role_restricted_ready precondition probe so a
-	// superuser-served deployment reports /readyz 503 instead of silently leaking
-	// across tenants (#1676 [F-B11]). Migrations are applied by a separate admin
-	// pool (tools/pg-migrate), which does not set this flag.
-	pgCfg.RequireRestrictedRole = true
-	pool, err := adapterpg.NewPool(ctx, pgCfg)
-	if err != nil {
-		return fmt.Errorf("assembly PG pool: %w", err)
-	}
-	// Assembly-wide schema/shape/index fail-fast before any wiring. The guard is
-	// not configcore-specific: it checks the single migration set
-	// (adapterpg.MigrationsFS) that owns config + session + audit tables.
-	if vErr := verifyPGPreconditions(ctx, pool); vErr != nil {
-		_ = pool.Close(ctx)
-		return vErr
-	}
-	txMgr := adapterpg.NewTxManager(pool)
-	// Wrap the base outbox writer so projection-source events are journaled to the
-	// durable projection_events table inside the producer's transaction (EPIC #1504
-	// D4). The topic set is cellgen-derived (generatedProjectionSourceTopics, I5); it
-	// is empty today (corebundle declares no outbox projections), so the decorator
-	// forwards writes unchanged until a projection is added — at which point its topic
-	// auto-enrolls on the next `gocell generate assembly`. Wiring the durable source as
-	// the projection read side lands in PR-03.
+
 	// Surface the wired topic-set size so operators can distinguish "journal inactive
 	// because no projections are declared" (count 0, expected today) from a wiring
 	// regression — the durable journal otherwise gives no startup signal (#1504 PR-02).
-	// The decorator's topic argument MUST stay the direct generatedProjectionSourceTopics()
-	// call (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 rejects a threaded
-	// variable, which could hide a hand-typed list); the accessor is a cheap generated
-	// slice literal, so calling it again for the count is free.
 	slog.InfoContext(ctx, "corebundle: journaling outbox writer wired",
 		slog.Int("projection_source_topic_count", len(generatedProjectionSourceTopics())))
-	writer := adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(shared.Clock), generatedProjectionSourceTopics())
-	shared.PG = capability.NewPGProvider(txMgr, writer, pool.DB())
-	locals.poolMR = pool
+
+	deps, err := percellpg.Resolve(ctx, shared.Clock, shared.Topology, percellpg.Config{
+		Cells:                  cells,
+		ProjectionSourceTopics: generatedProjectionSourceTopics(),
+		RequireRestrictedRole:  true,
+	})
+	if err != nil {
+		return err
+	}
+
+	if deps.Provider != nil {
+		shared.PG = deps.Provider
+	}
+	if len(deps.Resources) > 0 {
+		locals.poolMR = deps.Resources[0]
+	}
 	return nil
 }
 
@@ -131,33 +116,4 @@ func provisionRedis(shared *composition.SharedDeps, locals *cmdLocals) {
 	if locals.redisClient != nil {
 		shared.Redis = capability.NewRedisProvider(locals.redisClient)
 	}
-}
-
-// verifyPGPreconditions runs the three configcore PG fail-fast checks in
-// order. Caller owns pool lifecycle; on error caller must close the pool.
-func verifyPGPreconditions(ctx context.Context, pool *adapterpg.Pool) error {
-	if schemaErr := verifyConfigCorePGSchema(ctx, pool); schemaErr != nil {
-		return schemaErr
-	}
-	// S3+S5: column-existence fail-fast catches partial migrations.
-	if shapeErr := adapterpg.VerifyExpectedShape(ctx, pool); shapeErr != nil {
-		return fmt.Errorf("configcore PG schema shape: %w", shapeErr)
-	}
-	// B2-X-03: operators must DROP INVALID indexes manually before start —
-	// silent continue can hide INSERT-time failures in tests / staging.
-	if idxErr := adapterpg.VerifyNoInvalidIndexes(ctx, pool); idxErr != nil {
-		return fmt.Errorf("configcore PG invalid indexes: %w", idxErr)
-	}
-	return nil
-}
-
-func verifyConfigCorePGSchema(ctx context.Context, pool *adapterpg.Pool) error {
-	migrationsFS, err := adapterpg.MigrationsFS()
-	if err != nil {
-		return fmt.Errorf("configcore PG migrations fs: %w", err)
-	}
-	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, migration.PlatformNamespace); err != nil {
-		return fmt.Errorf("configcore PG schema guard: %w", err)
-	}
-	return nil
 }

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -9,6 +9,8 @@ import (
 	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
 	"github.com/ghbvf/gocell/cellmodules/percellpg"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/migration"
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 	"github.com/ghbvf/gocell/framework/runtime/capability"
 	"github.com/ghbvf/gocell/framework/runtime/composition"
 )
@@ -22,11 +24,11 @@ import (
 // the injected provider (shared.PG / shared.Redis) and never construct adapter
 // primitives themselves.
 //
-// Postgres provisioning now delegates to cellmodules/percellpg.Resolve, which
-// handles per-cell DSN resolution, dedup-by-DSN, fail-closed gates, pool
-// construction, schema verification, and provider wrapping. This file remains the
-// sole sanctioned caller entry point in cmd/ (CAPABILITY-PROVIDER-FUNNEL-01
-// downstream allowlist); the actual adapter constructors moved to percellpg.
+// Postgres per-cell DSN resolution (dedup-by-DSN + fail-closed gates) is decided
+// by cellmodules/percellpg.Resolve, but the adapter construction (pool, TxManager,
+// journaling outbox writer, capability.PGProvider) stays HERE — this file remains
+// the single sanctioned shared-infra provisioning site in cmd/
+// (CAPABILITY-PROVIDER-FUNNEL-01 + PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01).
 //
 // Called from runCorebundle after LoadSharedDepsFromEnv and before composition.Builder.Build
 // so the providers are present (or fail-fast) before any module.Provide runs —
@@ -62,49 +64,94 @@ func provisionCapabilities(ctx context.Context, shared *composition.SharedDeps, 
 	return nil
 }
 
-// provisionPostgres delegates postgres pool provisioning to cellmodules/percellpg.Resolve.
-// It builds a percellpg.Config by iterating generatedPostgresCells() (single source:
-// cell IDs whose cell.yaml requires postgres, derived by codegen) and loading each
-// cell's per-cell DSN from the environment via LoadPGConfig. The resolver handles
-// dedup-by-DSN, fail-closed gates (missing DSN, distinct DSNs), pool construction,
-// schema/shape/index verification, and capability.PGProvider wrapping.
+// provisionPostgres opens the assembly's single serving pool from the per-cell
+// DSN agreed by cellmodules/percellpg.Resolve. percellpg owns the per-cell DSN
+// decision (dedup-by-DSN + fail-closed gates: empty cell set, missing DSN, >1
+// distinct DSN); this site owns the actual adapter construction — pool, schema
+// verification, the journaling outbox writer, and the capability.PGProvider —
+// because the banned shared-infra constructors (NewPool / NewTxManager /
+// NewJournalingOutboxWriter) must stay in the single sanctioned cmd/ site that
+// CAPABILITY-PROVIDER-FUNNEL-01 and PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-
+// DERIVED-01 cover.
 //
-// In memory topology the resolver returns empty Deps and shared.PG stays nil;
-// cell modules fall through to their in-memory storage path.
-//
-// The decorator's topic argument MUST stay the direct generatedProjectionSourceTopics()
-// call (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 rejects a threaded
-// variable, which could hide a hand-typed list).
+// The topology gate runs FIRST — before reading any per-cell PG env — so memory
+// mode is never blocked by an unused / malformed GOCELL_<CELL>_DATABASE_* knob.
+// In memory topology shared.PG stays nil and cell modules take their in-memory path.
 func provisionPostgres(ctx context.Context, shared *composition.SharedDeps, locals *cmdLocals) error {
+	if shared.Topology.StorageBackend() != bootstrap.StorageBackendPostgres {
+		return nil
+	}
+
 	cells := make(map[string]adapterpg.Config, len(generatedPostgresCells()))
 	for _, cellID := range generatedPostgresCells() {
 		pgCfg, err := LoadPGConfig(strings.ToUpper(cellID))
 		if err != nil {
-			return fmt.Errorf("percellpg: load config for cell %s: %w", cellID, err)
+			return fmt.Errorf("corebundle: load PG config for cell %s: %w", cellID, err)
 		}
 		cells[cellID] = pgCfg
+	}
+
+	agreed, ok, err := percellpg.Resolve(shared.Topology, percellpg.Config{
+		Cells:                 cells,
+		RequireRestrictedRole: true,
+	})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// Defensive: topology was already gated above, so postgres topology always
+		// yields ok=true here. Belt-and-suspenders against a future gate drift.
+		return nil
+	}
+
+	pool, err := adapterpg.NewPool(ctx, agreed)
+	if err != nil {
+		return fmt.Errorf("corebundle: open assembly PG pool: %w", err)
+	}
+	if vErr := verifyPGPreconditions(ctx, pool); vErr != nil {
+		_ = pool.Close(ctx) // no leak on verify error
+		return vErr
 	}
 
 	// Surface the wired topic-set size so operators can distinguish "journal inactive
 	// because no projections are declared" (count 0, expected today) from a wiring
 	// regression — the durable journal otherwise gives no startup signal (#1504 PR-02).
+	// The decorator's topic argument MUST stay the direct generatedProjectionSourceTopics()
+	// call (PROJECTION-EVENT-JOURNAL-TOPIC-ALLOWLIST-DERIVED-01 rejects a threaded
+	// variable, which could hide a hand-typed list).
 	slog.InfoContext(ctx, "corebundle: journaling outbox writer wired",
 		slog.Int("projection_source_topic_count", len(generatedProjectionSourceTopics())))
+	writer := adapterpg.NewJournalingOutboxWriter(adapterpg.NewOutboxWriter(shared.Clock), generatedProjectionSourceTopics())
 
-	deps, err := percellpg.Resolve(ctx, shared.Clock, shared.Topology, percellpg.Config{
-		Cells:                  cells,
-		ProjectionSourceTopics: generatedProjectionSourceTopics(),
-		RequireRestrictedRole:  true,
-	})
-	if err != nil {
+	shared.PG = capability.NewPGProvider(adapterpg.NewTxManager(pool), writer, pool.DB())
+	locals.poolMR = pool
+	return nil
+}
+
+// verifyPGPreconditions runs the three assembly-wide PG fail-fast checks in order.
+// Caller owns pool lifecycle; on error the caller must close the pool.
+func verifyPGPreconditions(ctx context.Context, pool *adapterpg.Pool) error {
+	if err := verifyConfigCorePGSchema(ctx, pool); err != nil {
 		return err
 	}
-
-	if deps.Provider != nil {
-		shared.PG = deps.Provider
+	// S3+S5: column-existence fail-fast catches partial migrations.
+	if err := adapterpg.VerifyExpectedShape(ctx, pool); err != nil {
+		return fmt.Errorf("corebundle PG schema shape: %w", err)
 	}
-	if len(deps.Resources) > 0 {
-		locals.poolMR = deps.Resources[0]
+	// B2-X-03: operators must DROP INVALID indexes manually before start.
+	if err := adapterpg.VerifyNoInvalidIndexes(ctx, pool); err != nil {
+		return fmt.Errorf("corebundle PG invalid indexes: %w", err)
+	}
+	return nil
+}
+
+func verifyConfigCorePGSchema(ctx context.Context, pool *adapterpg.Pool) error {
+	migrationsFS, err := adapterpg.MigrationsFS()
+	if err != nil {
+		return fmt.Errorf("corebundle PG migrations fs: %w", err)
+	}
+	if err := adapterpg.VerifyExpectedVersion(ctx, pool, migrationsFS, migration.PlatformNamespace); err != nil {
+		return fmt.Errorf("corebundle PG schema guard: %w", err)
 	}
 	return nil
 }

--- a/cmd/corebundle/cap_wiring.go
+++ b/cmd/corebundle/cap_wiring.go
@@ -91,17 +91,15 @@ func provisionPostgres(ctx context.Context, shared *composition.SharedDeps, loca
 		cells[cellID] = pgCfg
 	}
 
-	agreed, ok, err := percellpg.Resolve(shared.Topology, percellpg.Config{
+	// Topology is gated above, so percellpg.Resolve always returns ok=true here
+	// (ok=false is the memory-topology signal only). A contract drift that returned
+	// an empty agreed config would still fail-closed at NewPool ("DSN is empty").
+	agreed, _, err := percellpg.Resolve(shared.Topology, percellpg.Config{
 		Cells:                 cells,
 		RequireRestrictedRole: true,
 	})
 	if err != nil {
 		return err
-	}
-	if !ok {
-		// Defensive: topology was already gated above, so postgres topology always
-		// yields ok=true here. Belt-and-suspenders against a future gate drift.
-		return nil
 	}
 
 	pool, err := adapterpg.NewPool(ctx, agreed)

--- a/cmd/corebundle/cap_wiring_test.go
+++ b/cmd/corebundle/cap_wiring_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These unit tests cover provisionPostgres's Docker-free branches — the topology
+// gate, the per-cell LoadPGConfig loop + error, and the percellpg.Resolve fail-closed
+// propagation. The postgres I/O path (NewPool + verifyPGPreconditions + provider
+// wrapping) needs a live database and is covered by the real-PG integration tests
+// (main_integration_test.go / corebundle_pg_env_integration_test.go).
+
+// TestProvisionPostgres_MemoryTopology: the topology gate runs first, so memory
+// mode returns early without reading any per-cell PG env (regression guard for the
+// re-review F3 fix) and leaves shared.PG nil.
+func TestProvisionPostgres_MemoryTopology(t *testing.T) {
+	// A malformed knob must NOT block memory mode — the gate returns before LoadPGConfig.
+	t.Setenv("GOCELL_CONFIGCORE_DATABASE_MAX_CONNS", "not-a-number")
+	shared, locals := newValidatedSharedDepsAndLocals(t, mkTopo("real", "memory", false))
+
+	require.NoError(t, provisionPostgres(context.Background(), shared, locals),
+		"memory topology must not read per-cell PG env")
+	require.Nil(t, shared.PG, "memory topology: no pool provisioned")
+}
+
+// TestProvisionPostgres_MissingDSN_FailClosed: postgres topology with no per-cell
+// DSN configured fails closed (before any pool open) via percellpg.Resolve.
+func TestProvisionPostgres_MissingDSN_FailClosed(t *testing.T) {
+	t.Setenv("GOCELL_ACCESSCORE_DATABASE_URL", "")
+	t.Setenv("GOCELL_AUDITCORE_DATABASE_URL", "")
+	t.Setenv("GOCELL_CONFIGCORE_DATABASE_URL", "")
+	shared, locals := newValidatedSharedDepsAndLocals(t, mkTopo("real", "postgres", false))
+
+	err := provisionPostgres(context.Background(), shared, locals)
+	require.Error(t, err, "postgres topology with no per-cell DSN must fail-closed")
+	// errcode.Error() renders the WithInternal attrs (cell_id / env_var) when present.
+	require.Contains(t, err.Error(), "GOCELL_ACCESSCORE_DATABASE_URL")
+	require.Nil(t, shared.PG, "no provider on fail-closed")
+}
+
+// TestProvisionPostgres_BadPoolKnob: an invalid per-cell pool knob surfaces from
+// LoadPGConfig before any pool open.
+func TestProvisionPostgres_BadPoolKnob(t *testing.T) {
+	t.Setenv("GOCELL_CONFIGCORE_DATABASE_URL", "postgres://host/db")
+	t.Setenv("GOCELL_CONFIGCORE_DATABASE_MAX_CONNS", "not-a-number")
+	shared, locals := newValidatedSharedDepsAndLocals(t, mkTopo("real", "postgres", false))
+
+	err := provisionPostgres(context.Background(), shared, locals)
+	require.Error(t, err, "an invalid per-cell pool knob must fail at config load")
+	require.Contains(t, err.Error(), "load PG config for cell configcore")
+}

--- a/cmd/corebundle/cap_wiring_test.go
+++ b/cmd/corebundle/cap_wiring_test.go
@@ -52,3 +52,19 @@ func TestProvisionPostgres_BadPoolKnob(t *testing.T) {
 	require.Error(t, err, "an invalid per-cell pool knob must fail at config load")
 	require.Contains(t, err.Error(), "load PG config for cell configcore")
 }
+
+// TestProvisionPostgres_PoolOpenError: a malformed (but non-empty) DSN passes the
+// percellpg gates and fails fast at NewPool's DSN parse (no connection attempt),
+// exercising the pool-open error branch without a live database.
+func TestProvisionPostgres_PoolOpenError(t *testing.T) {
+	const dsn = "postgres://host/db?sslmode=bogus" // rejected by ParseConfig, no dial
+	t.Setenv("GOCELL_ACCESSCORE_DATABASE_URL", dsn)
+	t.Setenv("GOCELL_AUDITCORE_DATABASE_URL", dsn)
+	t.Setenv("GOCELL_CONFIGCORE_DATABASE_URL", dsn)
+	shared, locals := newValidatedSharedDepsAndLocals(t, mkTopo("real", "postgres", false))
+
+	err := provisionPostgres(context.Background(), shared, locals)
+	require.Error(t, err, "a malformed DSN must fail-closed at pool open")
+	require.Contains(t, err.Error(), "open assembly PG pool")
+	require.Nil(t, shared.PG, "no provider on pool-open failure")
+}

--- a/cmd/corebundle/corebundle_pg_env_integration_test.go
+++ b/cmd/corebundle/corebundle_pg_env_integration_test.go
@@ -85,8 +85,11 @@ func setRealModeEnv(t *testing.T, dsn string) {
 	t.Setenv("GOCELL_AUDIT_BOOTSTRAP_HMAC_KEY", "prod-bootstrap-hmac-key-32bytes!")
 	t.Setenv("GOCELL_AUDITCORE_CURSOR_KEY", "audit-cursor-key-32-bytes-padded!")
 
-	// configcore cell
+	// Per-cell PG DSN (#1964): all three postgres cells must have a DSN set;
+	// percellpg.Resolve deduplicates to one pool when all DSNs are identical.
 	t.Setenv("GOCELL_CONFIGCORE_DATABASE_URL", dsn)
+	t.Setenv("GOCELL_AUDITCORE_DATABASE_URL", dsn)
+	t.Setenv("GOCELL_ACCESSCORE_DATABASE_URL", dsn)
 	t.Setenv("GOCELL_CONFIGCORE_KEY_PROVIDER", "local-aes")
 	t.Setenv("GOCELL_CONFIGCORE_MASTER_KEY", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
 	t.Setenv("GOCELL_CONFIGCORE_CURSOR_KEY", "config-cursor-key-32b-padded-xx!")
@@ -98,18 +101,20 @@ func setRealModeEnv(t *testing.T, dsn string) {
 	t.Setenv("GOCELL_BOOTSTRAP_ADMIN_PASSWORD", "testpassword123")
 }
 
-// TestCorebundlePG_UsesConfigCoreDatabaseURL verifies the complete
-// env-to-pool contract: setting GOCELL_CONFIGCORE_DATABASE_URL=<dsn> and
-// running the full LoadSharedDepsFromEnv → provisionCapabilities →
-// composition.Builder.Build path results in a successfully wired assembly
-// backed by a live PostgreSQL pool.
+// TestCorebundlePG_UsesPerCellDatabaseURLs verifies the complete env-to-pool
+// contract: setting GOCELL_{CELL}_DATABASE_URL for each postgres cell (#1964 per-cell
+// seam) and running the full LoadSharedDepsFromEnv → provisionCapabilities →
+// composition.Builder.Build path results in a successfully wired assembly backed by a
+// live PostgreSQL pool.
 //
-// This test covers F5: the env→pool path had zero automated coverage because
-// all existing integration tests bypassed LoadPGConfig + LoadSharedDepsFromEnv
-// by calling buildConfigCoreOpts directly. Post capability-provider refactor the
-// pool is opened by provisionCapabilities (not by any cell module), so
-// the test must run that step before Build.
-func TestCorebundlePG_UsesConfigCoreDatabaseURL(t *testing.T) {
+// setRealModeEnv sets the same DSN for configcore, auditcore, and accesscore;
+// percellpg.Resolve deduplicates to one pool (colocated deployment invariant).
+//
+// This test covers F5: the env→pool path had zero automated coverage because all
+// existing integration tests bypassed LoadPGConfig + LoadSharedDepsFromEnv by calling
+// buildConfigCoreOpts directly. Post capability-provider refactor the pool is opened by
+// provisionCapabilities (not by any cell module), so the test must run that step before Build.
+func TestCorebundlePG_UsesPerCellDatabaseURLs(t *testing.T) {
 	dsn, cleanup := setupPostgresForMain(t)
 	defer cleanup()
 
@@ -128,8 +133,8 @@ func TestCorebundlePG_UsesConfigCoreDatabaseURL(t *testing.T) {
 	require.NoError(t, err, "LoadSharedDepsFromEnv must succeed with all required env set")
 
 	require.NoError(t, provisionCapabilities(ctx, shared, locals),
-		"provisionCapabilities must open the assembly pool from GOCELL_CONFIGCORE_DATABASE_URL")
-	require.NotNil(t, shared.PG, "shared.PG must be provisioned from the DSN in postgres mode")
+		"provisionCapabilities must open the assembly pool from per-cell DSNs (#1964)")
+	require.NotNil(t, shared.PG, "shared.PG must be provisioned from the per-cell DSNs in postgres mode")
 	require.NotNil(t, locals.poolMR, "locals.poolMR must hold the pool ManagedResource")
 	defer func() { _ = locals.poolMR.Close(ctx) }()
 
@@ -148,16 +153,16 @@ func TestCorebundlePG_UsesConfigCoreDatabaseURL(t *testing.T) {
 	require.NoError(t, err, "composition.Builder.Build must succeed: cell modules consume the injected shared.PG")
 }
 
-// TestProvisionCapabilities_Postgres_UsesConfigCoreDatabaseURL verifies that
-// provisionCapabilities, when called after LoadSharedDepsFromEnv in postgres
-// mode, opens the assembly pool from GOCELL_CONFIGCORE_DATABASE_URL and records
-// it as locals.poolMR with a passing postgres_ready checker.
+// TestProvisionCapabilities_Postgres_UsesPerCellDatabaseURLs verifies that
+// provisionCapabilities, when called after LoadSharedDepsFromEnv in postgres mode, opens
+// the assembly pool from the per-cell DSN vars (#1964 percellpg seam) and records it as
+// locals.poolMR with a passing postgres_ready checker.
 //
-// This slim companion test isolates the pool-provisioning path (formerly
-// ConfigCoreModule.Provide opened the pool; the capability-provider refactor
-// moved it to provisionCapabilities) so the pool ManagedResource + its health
-// check are verified independently of the full assembly Build.
-func TestProvisionCapabilities_Postgres_UsesConfigCoreDatabaseURL(t *testing.T) {
+// setRealModeEnv sets the same DSN for all three postgres cells; percellpg.Resolve
+// deduplicates to one pool. This slim companion test isolates the pool-provisioning
+// path so the pool ManagedResource + its health check are verified independently of
+// the full assembly Build.
+func TestProvisionCapabilities_Postgres_UsesPerCellDatabaseURLs(t *testing.T) {
 	dsn, cleanup := setupPostgresForMain(t)
 	defer cleanup()
 
@@ -174,7 +179,7 @@ func TestProvisionCapabilities_Postgres_UsesConfigCoreDatabaseURL(t *testing.T) 
 
 	// provisionCapabilities opens the pool and records it as locals.poolMR.
 	require.NoError(t, provisionCapabilities(ctx, shared, locals),
-		"provisionCapabilities must succeed with GOCELL_CONFIGCORE_DATABASE_URL set")
+		"provisionCapabilities must succeed with per-cell DSNs set (#1964)")
 	require.NotNil(t, shared.PG, "shared.PG must be provisioned in postgres mode")
 	require.NotNil(t, locals.poolMR, "provisionCapabilities must record the pool as locals.poolMR")
 

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -88,21 +88,22 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMatched(t *testing.T) {
 	assert.NotNil(t, app, "App must be non-nil after successful Build")
 }
 
-// TestBuildConfigCoreOpts_Postgres_SchemaMismatch verifies that
-// verifyPGPreconditions returns an error (with schema guard message) when the
-// DB schema version does not match the binary.
+// TestBuildConfigCoreOpts_Postgres_SchemaMismatch verifies that the schema guard
+// fires when the DB schema version does not match the binary.
 //
-// Schema verification has moved to provisionPostgres / verifyPGPreconditions;
-// this test calls verifyPGPreconditions directly so the guard is still covered
-// at integration level.
+// Schema verification moved into percellpg.Resolve (invoked by
+// provisionCapabilities) in #1964. This test drives the full
+// env→provisionCapabilities path on a lagged DB and asserts the guard error
+// surfaces fail-closed (percellpg owns the pool-open → verify sequence now, so
+// the guard can no longer be called directly from package main).
 func TestBuildConfigCoreOpts_Postgres_SchemaMismatch(t *testing.T) {
 	dsn, cleanup := setupPostgresForMain(t)
 	defer cleanup()
 
 	ctx := context.Background()
 
-	// Apply only migrations up to version 3 by applying all then deleting newer
-	// records from the tracking table — simulating a lagged DB.
+	// Apply all migrations, then simulate lag by removing entries for versions > 3
+	// so VerifyExpectedVersion (inside percellpg.Resolve) sees actual < expected.
 	pool, err := adapterpg.NewPool(ctx, adapterpg.Config{DSN: dsn})
 	require.NoError(t, err, "pool for migration prep must succeed")
 
@@ -110,20 +111,24 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMismatch(t *testing.T) {
 	require.NoError(t, err, "NewMigrator must succeed")
 	require.NoError(t, migrator.Up(ctx), "Up() must apply all migrations initially")
 
-	// Simulate lag: remove entries for versions > 3 so VerifyExpectedVersion sees
-	// actual < expected and returns a schema mismatch error.
 	_, execErr := pool.DB().Exec(ctx,
 		"DELETE FROM schema_migrations_platform WHERE version_id > 3")
 	require.NoError(t, execErr, "deleting version records must succeed")
-
-	// Schema verification now lives in verifyPGPreconditions (provisionPostgres).
-	// Call it directly to assert the schema guard fires on a lagged DB.
-	err = verifyPGPreconditions(ctx, pool)
-
 	_ = pool.Close(ctx)
 
-	require.Error(t, err, "verifyPGPreconditions must return error when schema is lagged")
-	assert.Contains(t, err.Error(), "schema guard",
+	// Drive the full env→provision path on the lagged DB; percellpg.Resolve opens
+	// its own pool and runs verifyPGPreconditions, which must fail-closed.
+	setRealModeEnv(t, dsn)
+	shared, locals, err := LoadSharedDepsFromEnv(ctx)
+	require.NoError(t, err, "LoadSharedDepsFromEnv must succeed")
+
+	provErr := provisionCapabilities(ctx, shared, locals)
+	if locals.poolMR != nil {
+		_ = locals.poolMR.Close(ctx)
+	}
+
+	require.Error(t, provErr, "provisionCapabilities must fail-closed when schema is lagged")
+	assert.Contains(t, provErr.Error(), "schema guard",
 		"error must mention schema guard")
 }
 

--- a/cmd/corebundle/main_integration_test.go
+++ b/cmd/corebundle/main_integration_test.go
@@ -116,8 +116,9 @@ func TestBuildConfigCoreOpts_Postgres_SchemaMismatch(t *testing.T) {
 	require.NoError(t, execErr, "deleting version records must succeed")
 	_ = pool.Close(ctx)
 
-	// Drive the full env→provision path on the lagged DB; percellpg.Resolve opens
-	// its own pool and runs verifyPGPreconditions, which must fail-closed.
+	// Drive the full env→provision path on the lagged DB; provisionPostgres opens
+	// the pool (from the percellpg-agreed DSN) and runs verifyPGPreconditions,
+	// which must fail-closed.
 	setRealModeEnv(t, dsn)
 	shared, locals, err := LoadSharedDepsFromEnv(ctx)
 	require.NoError(t, err, "LoadSharedDepsFromEnv must succeed")

--- a/cmd/corebundle/modules_gen.go
+++ b/cmd/corebundle/modules_gen.go
@@ -49,6 +49,21 @@ func generatedProjectionSourceTopics() []string {
 	return nil
 }
 
+// generatedPostgresCells is the sorted list of cell IDs whose cell.yaml declares
+// `requires: [postgres]` (or a superset). Single-sourced from cell.yaml metadata;
+// consumed by the composition root's per-cell PG resolution
+// (cellmodules/percellpg.Resolve) to iterate cells and look up their per-cell DSN.
+// ALWAYS emitted (nil when no postgres cells) so the composition root can call it
+// unconditionally. Derived by `gocell generate assembly`; `--verify` red-flags stale
+// output (#1964 per-cell infra seam).
+func generatedPostgresCells() []string {
+	return []string{
+		"accesscore",
+		"auditcore",
+		"configcore",
+	}
+}
+
 // generatedDeploymentTopology returns the assembly's codegen-derived deployment
 // placement spec (single-sourced from assembly.yaml topology, derived by
 // `gocell generate assembly`). Empty topology => all cells co-located (zero-

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -87,8 +87,12 @@ services:
       GOCELL_HTTP_HEALTH_ADDR: "127.0.0.1:9091"
       GOCELL_HTTP_HEALTH_LOCAL_ONLY: "1"
 
-      # PostgreSQL DSN (shared-netns DNS resolution still uses container names)
+      # PostgreSQL DSN — per-cell (#1964 per-cell PG seam). All three cells share
+      # the same DSN in colocated deployments; percellpg.Resolve deduplicates to one
+      # pool at startup (a missing DSN or >1 distinct DSN fails fast).
       GOCELL_CONFIGCORE_DATABASE_URL: postgres://gocell_app:${GOCELL_APP_PASSWORD:?}@postgres:5432/gocell?sslmode=disable
+      GOCELL_AUDITCORE_DATABASE_URL: postgres://gocell_app:${GOCELL_APP_PASSWORD:?}@postgres:5432/gocell?sslmode=disable
+      GOCELL_ACCESSCORE_DATABASE_URL: postgres://gocell_app:${GOCELL_APP_PASSWORD:?}@postgres:5432/gocell?sslmode=disable
       GOCELL_CONFIGCORE_KEY_PROVIDER: local-aes
 
       # Redis loopback via shared netns (see network_mode above)

--- a/docs/architecture/202606071200-1676-adr-restricted-app-serving-pool.md
+++ b/docs/architecture/202606071200-1676-adr-restricted-app-serving-pool.md
@@ -100,9 +100,11 @@ check there would always return "superuser" in development and CI environments, 
 a permanent red /readyz for any developer who hasn't configured dual-role locally.
 
 The serving-pool probe must execute under the **serving pool** connection
-(`GOCELL_CONFIGCORE_DATABASE_URL`), which uses the restricted role in dual-role
-deployments. This is why the probe is registered in `adapters/postgres` for the
-serving pool specifically, not folded into the shared admin pool health check.
+(per-cell DSNs `GOCELL_CONFIGCORE_DATABASE_URL` / `GOCELL_AUDITCORE_DATABASE_URL` /
+`GOCELL_ACCESSCORE_DATABASE_URL`; deduped to one pool by `percellpg.Resolve`, #1964),
+which uses the restricted role in dual-role deployments. This is why the probe is
+registered in `adapters/postgres` for the serving pool specifically, not folded into
+the shared admin pool health check.
 
 ---
 
@@ -122,8 +124,10 @@ The probe itself is **Medium**:
 2. **Integration tests** assert `rolbypassrls=false` on the test DB role fixture,
    ensuring the e2e harness always runs under the correct privilege model.
 3. **Compose wiring**: `docker-compose.local.yml` and `tests/e2e/docker-compose.e2e.yaml`
-   configure `GOCELL_CONFIGCORE_DATABASE_URL` to use `gocell_app`, so the probe
-   would immediately fail in CI if the restricted role were not created or misconfigured.
+   configure all three per-cell DSNs (`GOCELL_CONFIGCORE_DATABASE_URL`,
+   `GOCELL_AUDITCORE_DATABASE_URL`, `GOCELL_ACCESSCORE_DATABASE_URL`) to use `gocell_app`,
+   so the probe would immediately fail in CI if the restricted role were not created or
+   misconfigured.
 
 ---
 
@@ -138,7 +142,8 @@ The probe itself is **Medium**:
 - **One-time volume reset**: existing local environments have a `pgdata` volume
   created without the restricted role. Run `make local-down` (which passes `-v` to
   remove volumes) then `make local-up`. The initdb script runs on the fresh data dir.
-- **Superuser dev /readyz**: if `GOCELL_CONFIGCORE_DATABASE_URL` still points to the
+- **Superuser dev /readyz**: if any per-cell DSN (`GOCELL_CONFIGCORE_DATABASE_URL`,
+  `GOCELL_AUDITCORE_DATABASE_URL`, `GOCELL_ACCESSCORE_DATABASE_URL`) still points to the
   admin role `gocell`, the new probe turns red. This is the intended behaviour.
 
 ### Production deployment

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -235,8 +235,8 @@ amendment 落地时必须同步重评安全模型」，此处显式列出威胁�
 | 缺口 / 威胁 | split 下风险 | 当前补偿 / 约束 | 归属 |
 |---|---|---|---|
 | **业务 principal 跨进程传播伪造** | caller 伪造他人 actor/subject/session → 越权 | **现有栈不足，是真缺口**：service token MAC（`runtime/auth/servicetoken.go`）只覆盖 method/path/query/timestamp/nonce/`callerCell`/`X-Tenant-ID`，且 `authenticator.go` 只构造 `PrincipalService{CallerCellID}`——**只认证调用方 cell 身份，不传播也不还原原始业务 principal（actor/subject/session）**。故 split 下传播业务 principal **MUST 用 tamper-evident 的 signed/sealed envelope**（或把 actor/subject/session/tenant 全纳入 MAC material）+ 专用 callee middleware 重建——不能靠「现有 auth middleware 已足够」。| US5 #1966（spec FR-006，安全 obligation）|
-| **共享 HMAC keyring（无 per-cell 身份颁发）** | 单 cell 进程泄露 keyring → 可签发任意 `callerCell` | 当前全 cell 共享 keyring + `RequireCallerCell` allowlist——可信网络/monolith 足够，**跨信任边界拆分不足** | US6 #1964 |
-| **无 mTLS 对等认证** | 中间人 / 端点伪造 | service token MAC 提供消息完整性，但无传输层对等认证 | US6 #1964 |
+| **共享 HMAC keyring（无 per-cell 身份颁发）** | 单 cell 进程泄露 keyring → 可签发任意 `callerCell` | **#1964 评估并登记此缺口**：`runtime/auth/servicetoken.go` 的 4 段 MAC（`ts:nonce:callerCell:mac`）确实覆盖了 `callerCell` 字段，但所有 cell 使用**同一** `ring.Current()` 密钥签名——这只能证明「某个 keyring 持有者」发出了请求，无法证明「哪个 cell」发出。任何持有 keyring 的 cell 进程均可伪造任意 `callerCell`。推荐方向：**通过以 cellID 为 HKDF 派生上下文的 per-cell 子密钥**（`HKDF(masterKey, cellID)` → per-cell signing key），使单 cell 泄露无法伪造其它 cell 的 `callerCell`。当前补偿控制 = 服务端 `RequireCallerCell` allowlist（防止跳入预期以外的 internal endpoint）+ 可信网络/同进程假设——对 monolith/同址部署足够，**跨信任边界拆分不足**。**per-cell keyring 子密钥派生在本 PR（#1964）中不实现**，追踪在 per-cell 身份 / keyring 后续 backlog issue 中。 | US6 #1964（评估 + 登记；实现在 per-cell 身份 / keyring backlog issue）|
+| **无 mTLS 对等认证** | 中间人 / 端点伪造 | service token MAC 提供消息完整性，但无传输层对等认证——此缺口已登记，**#1964 不实现 mTLS**，追踪在 per-cell 身份 / keyring backlog issue 中 | US6 #1964（登记；实现在 per-cell 身份 / keyring backlog issue）|
 | **token replay（多实例）** | 重放已签 token | `RequiresDistributedReplay()` 多实例强制分布式 NonceStore（**已有，US5 复用**）| 已覆盖 |
 | **`upstream-cell-unavailable` 错误语义** | 远端不可达与本地依赖缺失混淆 → 误诊 | 新增的是 **`errcode.Code`（`ERR_UPSTREAM_CELL_UNAVAILABLE`），用既有 `KindUnavailable` 构造**（`pkg/errcode/status.go` 已有该 Kind，**非新增 Kind**），Code 经 `ERRCODE-PREFIX-OWNERSHIP-01` 注册 + golden。**wire 可见性警示**：`KindUnavailable.PublicCode()` 现折叠为 `ERR_SERVICE_UNAVAILABLE` 且 5xx details 强制 strip——故该专属码默认只作**服务端**诊断（log/trace/internal）；若要客户端 wire 可区分，须 US5 **有意重评 5xx public-code 投影策略** + redaction（非默认）。| US5 #1966（spec T043）|
 
@@ -245,6 +245,27 @@ signed/sealed envelope**（经单一 sealed propagation funnel 注入 + 专用 c
 handler 不得自构 principal header——**不得假定现有 service-token 栈已覆盖业务 principal**（它只认证
 callerCell）；(2) in-proc 与 remote 同样经 `RequireCallerCell`（D4）；(3) 缺口非本 ADR 解，但 MUST
 在下游 issue 落地前不被静默放过——上表即其 backlog 账。
+
+### #1964 Amendment — per-cell 基础设施 seam 落地记录
+
+**#1964（US6）实际落地内容**：
+
+**per-cell DB 凭据 / 连接注入 seam**（`cellmodules/percellpg`）已在本 PR 落地：composition root
+可为每个 cell 注入独立的 `GOCELL_<CELLID>_DATABASE_URL`，seam 以 DSN 去重——同一 DSN 的 cell
+共享连接池（monolith 常见形态），不同 DSN 的 cell 持有独立连接池（split / per-cell DB 形态）。
+若某 cellID 缺少对应的 `DATABASE_URL` 配置，启动期 fail-closed（非静默降级回全局 pool）。注意：
+**split 拓扑下 per-cell outbox relay 扇出** 尚未实现（每条 outbox entry 需由所属 cell 的连接池读取并
+relay 到 broker），此部分追踪在 per-cell 基础设施扇出 backlog issue 中；在该 issue 落地前，多个 DSN
+（即真正 split 的 per-cell DB）的组合在启动期以「多于 1 个不同 DSN」作为 fail-closed 边界。
+
+**broker 连接为 assembly 级（非 per-cell seam）的设计论据**：broker（RabbitMQ，`GOCELL_AMQP_URL`）
+是跨 cell 事件总线的传输介质——其天然语义是「跨 cell 共享」，而非「per-cell 独立」。若为每个 cell
+引入独立 broker 连接甚至独立 broker 实例，跨 cell 的 publish/subscribe 链路将被切断（cell A 发布到自己
+的 broker，cell B 订阅自己的 broker，事件永远无法跨越）。因此 **per-cell 独立 broker 连接不是一个有意义
+的 per-cell-DB 式 seam**——正确的单元是 per-进程（assembly 级）连接，即现有的 `GOCELL_AMQP_URL`。
+进程内 per-cell publisher/subscriber 扇出（即在同一 broker 连接上为每个 cell 派生独立的 exchange /
+routing-key 命名空间）属于 per-cell relay 扇出范畴，与 per-cell DB relay 一起追踪在 per-cell 基础设施
+扇出 backlog issue 中。
 
 ## Rejected alternatives
 

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -235,8 +235,8 @@ amendment 落地时必须同步重评安全模型」，此处显式列出威胁�
 | 缺口 / 威胁 | split 下风险 | 当前补偿 / 约束 | 归属 |
 |---|---|---|---|
 | **业务 principal 跨进程传播伪造** | caller 伪造他人 actor/subject/session → 越权 | **现有栈不足，是真缺口**：service token MAC（`runtime/auth/servicetoken.go`）只覆盖 method/path/query/timestamp/nonce/`callerCell`/`X-Tenant-ID`，且 `authenticator.go` 只构造 `PrincipalService{CallerCellID}`——**只认证调用方 cell 身份，不传播也不还原原始业务 principal（actor/subject/session）**。故 split 下传播业务 principal **MUST 用 tamper-evident 的 signed/sealed envelope**（或把 actor/subject/session/tenant 全纳入 MAC material）+ 专用 callee middleware 重建——不能靠「现有 auth middleware 已足够」。| US5 #1966（spec FR-006，安全 obligation）|
-| **共享 HMAC keyring（无 per-cell 身份颁发）** | 单 cell 进程泄露 keyring → 可签发任意 `callerCell` | **#1964 评估并登记此缺口**：`runtime/auth/servicetoken.go` 的 4 段 MAC（`ts:nonce:callerCell:mac`）确实覆盖了 `callerCell` 字段，但所有 cell 使用**同一** `ring.Current()` 密钥签名——这只能证明「某个 keyring 持有者」发出了请求，无法证明「哪个 cell」发出。任何持有 keyring 的 cell 进程均可伪造任意 `callerCell`。推荐方向：**通过以 cellID 为 HKDF 派生上下文的 per-cell 子密钥**（`HKDF(masterKey, cellID)` → per-cell signing key），使单 cell 泄露无法伪造其它 cell 的 `callerCell`。当前补偿控制 = 服务端 `RequireCallerCell` allowlist（防止跳入预期以外的 internal endpoint）+ 可信网络/同进程假设——对 monolith/同址部署足够，**跨信任边界拆分不足**。**per-cell keyring 子密钥派生在本 PR（#1964）中不实现**，追踪在 per-cell 身份 / keyring 后续 backlog issue 中。 | US6 #1964（评估 + 登记；实现在 per-cell 身份 / keyring backlog issue）|
-| **无 mTLS 对等认证** | 中间人 / 端点伪造 | service token MAC 提供消息完整性，但无传输层对等认证——此缺口已登记，**#1964 不实现 mTLS**，追踪在 per-cell 身份 / keyring backlog issue 中 | US6 #1964（登记；实现在 per-cell 身份 / keyring backlog issue）|
+| **共享 HMAC keyring（无 per-cell 身份颁发）** | 单 cell 进程泄露 keyring → 可签发任意 `callerCell` | **#1964 评估并登记此缺口**：`runtime/auth/servicetoken.go` 的 4 段 MAC（`ts:nonce:callerCell:mac`）确实覆盖了 `callerCell` 字段，但所有 cell 使用**同一** `ring.Current()` 密钥签名——这只能证明「某个 keyring 持有者」发出了请求，无法证明「哪个 cell」发出。任何持有 keyring 的 cell 进程均可伪造任意 `callerCell`。推荐方向：**通过以 cellID 为 HKDF 派生上下文的 per-cell 子密钥**（`HKDF(masterKey, cellID)` → per-cell signing key），使单 cell 泄露无法伪造其它 cell 的 `callerCell`。当前补偿控制 = 服务端 `RequireCallerCell` allowlist（防止跳入预期以外的 internal endpoint）+ 可信网络/同进程假设——对 monolith/同址部署足够，**跨信任边界拆分不足**。**per-cell keyring 子密钥派生在本 PR（#1964）中不实现**，追踪在 **#2153**。 | US6 #1964（评估 + 登记；实现在 #2153）|
+| **无 mTLS 对等认证** | 中间人 / 端点伪造 | service token MAC 提供消息完整性，但无传输层对等认证——此缺口已登记，**#1964 不实现 mTLS**，追踪在 **#2153** | US6 #1964（登记；实现在 #2153）|
 | **token replay（多实例）** | 重放已签 token | `RequiresDistributedReplay()` 多实例强制分布式 NonceStore（**已有，US5 复用**）| 已覆盖 |
 | **`upstream-cell-unavailable` 错误语义** | 远端不可达与本地依赖缺失混淆 → 误诊 | 新增的是 **`errcode.Code`（`ERR_UPSTREAM_CELL_UNAVAILABLE`），用既有 `KindUnavailable` 构造**（`pkg/errcode/status.go` 已有该 Kind，**非新增 Kind**），Code 经 `ERRCODE-PREFIX-OWNERSHIP-01` 注册 + golden。**wire 可见性警示**：`KindUnavailable.PublicCode()` 现折叠为 `ERR_SERVICE_UNAVAILABLE` 且 5xx details 强制 strip——故该专属码默认只作**服务端**诊断（log/trace/internal）；若要客户端 wire 可区分，须 US5 **有意重评 5xx public-code 投影策略** + redaction（非默认）。| US5 #1966（spec T043）|
 
@@ -255,7 +255,7 @@ callerCell）；(2) in-proc 与 remote 同样经 `RequireCallerCell`（D4）；(
 共享连接池（monolith 常见形态），不同 DSN 的 cell 持有独立连接池（split / per-cell DB 形态）。
 若某 cellID 缺少对应的 `DATABASE_URL` 配置，启动期 fail-closed（非静默降级回全局 pool）。注意：
 **split 拓扑下 per-cell outbox relay 扇出** 尚未实现（每条 outbox entry 需由所属 cell 的连接池读取并
-relay 到 broker），此部分追踪在 per-cell 基础设施扇出 backlog issue 中；在该 issue 落地前，多个 DSN
+relay 到 broker），此部分追踪在 **#2152** 中；在该 issue 落地前，多个 DSN
 （即真正 split 的 per-cell DB）的组合在启动期以「多于 1 个不同 DSN」作为 fail-closed 边界。
 
 **broker 连接为 assembly 级（非 per-cell seam）的设计论据**：broker（RabbitMQ，`GOCELL_AMQP_URL`）
@@ -264,8 +264,7 @@ relay 到 broker），此部分追踪在 per-cell 基础设施扇出 backlog iss
 的 broker，cell B 订阅自己的 broker，事件永远无法跨越）。因此 **per-cell 独立 broker 连接不是一个有意义
 的 per-cell-DB 式 seam**——正确的单元是 per-进程（assembly 级）连接，即现有的 `GOCELL_AMQP_URL`。
 进程内 per-cell publisher/subscriber 扇出（即在同一 broker 连接上为每个 cell 派生独立的 exchange /
-routing-key 命名空间）属于 per-cell relay 扇出范畴，与 per-cell DB relay 一起追踪在 per-cell 基础设施
-扇出 backlog issue 中。
+routing-key 命名空间）属于 per-cell relay 扇出范畴，与 per-cell DB relay 一起追踪在 **#2152** 中。
 
 ## Rejected alternatives
 

--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -1639,7 +1639,7 @@ probe 没有形如 `gocell_..._total` 的专属告警序列；它复用既有的
       serving PostgreSQL role is a superuser or has BYPASSRLS — RLS policies are
       defined on all seven tenant tables (incl. policies, migration 059) but bypassed at runtime (cross-tenant leak).
       Remediation for postgres_app_role_restricted_ready:
-        1. Point GOCELL_CONFIGCORE_DATABASE_URL at role gocell_app (NOSUPERUSER NOBYPASSRLS).
+        1. Point the per-cell DSNs (GOCELL_CONFIGCORE_DATABASE_URL, GOCELL_AUDITCORE_DATABASE_URL, GOCELL_ACCESSCORE_DATABASE_URL) at role gocell_app (NOSUPERUSER NOBYPASSRLS). In colocated deployments all three share the same DSN.
         2. Ensure deploy/postgres/init/10-restricted-role.sh ran on the target DB
            (role must exist before corebundle connects).
         3. Restart corebundle; the probe turns green within the first readyz cycle.

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -124,9 +124,9 @@ DSN fails closed (split-pool topology not yet supported; see #1963).
 | `GOCELL_CONFIGCORE_DATABASE_URL` | PostgreSQL DSN for configcore; role must be `gocell_app` (restricted, NOSUPERUSER NOBYPASSRLS) so that `FORCE ROW LEVEL SECURITY` is enforced at runtime | — | **postgres mode** |
 | `GOCELL_AUDITCORE_DATABASE_URL` | PostgreSQL DSN for auditcore; same role requirement as configcore | — | **postgres mode** |
 | `GOCELL_ACCESSCORE_DATABASE_URL` | PostgreSQL DSN for accesscore; same role requirement as configcore | — | **postgres mode** |
-| `GOCELL_CONFIGCORE_DATABASE_MAX_CONNS` | Max open connections (applies to the shared pool) | 10 | No |
-| `GOCELL_CONFIGCORE_DATABASE_IDLE_TIMEOUT` | Idle connection timeout (e.g. `5m`) | `5m` | No |
-| `GOCELL_CONFIGCORE_DATABASE_MAX_LIFETIME` | Max connection lifetime (e.g. `1h`) | `1h` | No |
+| `GOCELL_ACCESSCORE_DATABASE_MAX_CONNS` | Max open connections for the shared pool. **Pool knobs are read from the alphabetically-first postgres cell** (`accesscore` today, since `a < au < c`). In colocated/dedup mode all postgres cells share ONE pool, so operators MUST set pool knobs identically across all cells — only the knobs from the first sorted cell (`GOCELL_ACCESSCORE_DATABASE_*`) are actually applied to the shared pool. `GOCELL_AUDITCORE_DATABASE_MAX_CONNS` and `GOCELL_CONFIGCORE_DATABASE_MAX_CONNS` are read but ignored in colocated mode; per-cell pool-knob isolation requires split topology (#2152). | 10 | No |
+| `GOCELL_ACCESSCORE_DATABASE_IDLE_TIMEOUT` | Idle connection timeout for the shared pool (same ordering rule as `MAX_CONNS` above; set identically across all postgres cells) | `5m` | No |
+| `GOCELL_ACCESSCORE_DATABASE_MAX_LIFETIME` | Max connection lifetime for the shared pool (same ordering rule as `MAX_CONNS` above; set identically across all postgres cells) | `1h` | No |
 
 ### Restricted serving-role credential
 
@@ -251,14 +251,23 @@ Set `GOCELL_STATE_DIR` to override the platform default for all stateful files.
 
 ## Migration from pre-T6 env names
 
-The old global PostgreSQL env names have been removed. Operators must update environment configuration before upgrading.
+The old global PostgreSQL env names for the **serving pool** (`cmd/corebundle`) have been removed. Operators must update environment configuration before upgrading.
 
-| Old name (pre-T6, removed) | New name |
+> **Note:** `GOCELL_PG_DSN` is NOT fully removed from the codebase. It is still
+> the conventional DSN variable for the **`tools/pg-migrate` migration-admin tool**
+> (owner/superuser role, distinct from the restricted `gocell_app` serving role).
+> `tools/pg-migrate` and the associated `pg-migrate` service in
+> `docker-compose.local.yml` and `tests/e2e/docker-compose.e2e.yaml` continue to
+> use `GOCELL_PG_DSN`. The migration-admin tool and the `cmd/corebundle` serving
+> pool may point at the **same database** but with **different roles** (superuser vs
+> restricted `gocell_app`).
+
+| Old name (pre-T6, removed from serving pool) | New name |
 |---|---|
-| `GOCELL_PG_DSN` | `GOCELL_CONFIGCORE_DATABASE_URL` + `GOCELL_AUDITCORE_DATABASE_URL` + `GOCELL_ACCESSCORE_DATABASE_URL` (same value, per-cell seam #1964) |
-| `GOCELL_PG_MAX_CONNS` | `GOCELL_CONFIGCORE_DATABASE_MAX_CONNS` |
-| `GOCELL_PG_IDLE_TIMEOUT` | `GOCELL_CONFIGCORE_DATABASE_IDLE_TIMEOUT` |
-| `GOCELL_PG_MAX_LIFETIME` | `GOCELL_CONFIGCORE_DATABASE_MAX_LIFETIME` |
+| `GOCELL_PG_DSN` (**serving pool only — removed**; migration tool still uses it) | `GOCELL_CONFIGCORE_DATABASE_URL` + `GOCELL_AUDITCORE_DATABASE_URL` + `GOCELL_ACCESSCORE_DATABASE_URL` (same value, per-cell seam #1964) |
+| `GOCELL_PG_MAX_CONNS` | `GOCELL_ACCESSCORE_DATABASE_MAX_CONNS` (pool knobs read from alphabetically-first cell; see §Per-cell database DSNs) |
+| `GOCELL_PG_IDLE_TIMEOUT` | `GOCELL_ACCESSCORE_DATABASE_IDLE_TIMEOUT` |
+| `GOCELL_PG_MAX_LIFETIME` | `GOCELL_ACCESSCORE_DATABASE_MAX_LIFETIME` |
 | `GOCELL_MASTER_KEY` | `GOCELL_CONFIGCORE_MASTER_KEY` |
 | `GOCELL_MASTER_KEY_PREVIOUS` | `GOCELL_CONFIGCORE_MASTER_KEY_PREVIOUS` |
 | `GOCELL_KEY_PROVIDER` | `GOCELL_CONFIGCORE_KEY_PROVIDER` |

--- a/docs/ops/env-vars.md
+++ b/docs/ops/env-vars.md
@@ -111,12 +111,20 @@ Both variables are **required, persistent operator Basic Auth credentials** prot
 
 Each Cell that uses PostgreSQL reads its own DB and encryption env variables.
 
-### configcore cell database
+### Per-cell database DSNs (#1964)
+
+Each postgres-requiring cell reads its own DSN via `GOCELL_<CELLID>_DATABASE_URL`.
+In colocated deployments (all cells on one server) all three cells are set to the same
+DSN; `percellpg.Resolve` deduplicates to one shared pool. A missing DSN for any cell
+fails fast at startup naming the cell and the expected env var. More than one distinct
+DSN fails closed (split-pool topology not yet supported; see #1963).
 
 | Variable | Purpose | Default | Required |
 |---|---|---|---|
 | `GOCELL_CONFIGCORE_DATABASE_URL` | PostgreSQL DSN for configcore; role must be `gocell_app` (restricted, NOSUPERUSER NOBYPASSRLS) so that `FORCE ROW LEVEL SECURITY` is enforced at runtime | — | **postgres mode** |
-| `GOCELL_CONFIGCORE_DATABASE_MAX_CONNS` | Max open connections | 10 | No |
+| `GOCELL_AUDITCORE_DATABASE_URL` | PostgreSQL DSN for auditcore; same role requirement as configcore | — | **postgres mode** |
+| `GOCELL_ACCESSCORE_DATABASE_URL` | PostgreSQL DSN for accesscore; same role requirement as configcore | — | **postgres mode** |
+| `GOCELL_CONFIGCORE_DATABASE_MAX_CONNS` | Max open connections (applies to the shared pool) | 10 | No |
 | `GOCELL_CONFIGCORE_DATABASE_IDLE_TIMEOUT` | Idle connection timeout (e.g. `5m`) | `5m` | No |
 | `GOCELL_CONFIGCORE_DATABASE_MAX_LIFETIME` | Max connection lifetime (e.g. `1h`) | `1h` | No |
 
@@ -124,7 +132,7 @@ Each Cell that uses PostgreSQL reads its own DB and encryption env variables.
 
 | Variable | Purpose | Default | Required |
 |---|---|---|---|
-| `GOCELL_APP_PASSWORD` | Password for the restricted PostgreSQL role `gocell_app` (NOSUPERUSER, NOBYPASSRLS, non-owner). Used by `GOCELL_CONFIGCORE_DATABASE_URL` and by `deploy/postgres/init/10-restricted-role.sh` which creates the role on first data-dir init. Must be URL-safe — RFC 3986 unreserved characters only (`A-Za-z0-9._~-`); it is interpolated into a SQL heredoc AND the serving DSN userinfo, so `'` `/` `+` `=` `@` and spaces would break init or connection. Recommended: `openssl rand -hex 16`. | — | **postgres mode** |
+| `GOCELL_APP_PASSWORD` | Password for the restricted PostgreSQL role `gocell_app` (NOSUPERUSER, NOBYPASSRLS, non-owner). Used by per-cell `GOCELL_*_DATABASE_URL` vars and by `deploy/postgres/init/10-restricted-role.sh` which creates the role on first data-dir init. Must be URL-safe — RFC 3986 unreserved characters only (`A-Za-z0-9._~-`); it is interpolated into a SQL heredoc AND the serving DSN userinfo, so `'` `/` `+` `=` `@` and spaces would break init or connection. Recommended: `openssl rand -hex 16`. | — | **postgres mode** |
 
 See `docs/ops/local-docker-deploy.md` §Dual-role PostgreSQL for first-time setup steps.
 Probe `postgres_app_role_restricted_ready` verifies at runtime that the serving role is not a superuser / `BYPASSRLS`.
@@ -221,7 +229,7 @@ All three addresses must be non-empty and distinct; startup fails fast otherwise
 | `GOCELL_ADAPTER_MODE` | Selects secret-loading and fail-fast behaviour | `""` (dev/in-memory) | `""` (dev), `"real"` |
 | `GOCELL_CELL_ADAPTER_MODE` | Selects the storage backend for Cell repositories | `""` (in-memory) | `""`, `"memory"`, `"postgres"` |
 
-Note: the per-cell `GOCELL_<CELLID>_DATABASE_URL` variables (e.g. `GOCELL_CONFIGCORE_DATABASE_URL`) replace the old global `GOCELL_PG_DSN`. Each cell reads its own DSN at startup.
+Note: the per-cell `GOCELL_<CELLID>_DATABASE_URL` variables replace the old global `GOCELL_PG_DSN`. Each postgres cell reads its own DSN at startup. In colocated deployments all three DSNs are identical; `percellpg.Resolve` deduplicates to one pool (#1964).
 
 ## State
 
@@ -247,7 +255,7 @@ The old global PostgreSQL env names have been removed. Operators must update env
 
 | Old name (pre-T6, removed) | New name |
 |---|---|
-| `GOCELL_PG_DSN` | `GOCELL_CONFIGCORE_DATABASE_URL` |
+| `GOCELL_PG_DSN` | `GOCELL_CONFIGCORE_DATABASE_URL` + `GOCELL_AUDITCORE_DATABASE_URL` + `GOCELL_ACCESSCORE_DATABASE_URL` (same value, per-cell seam #1964) |
 | `GOCELL_PG_MAX_CONNS` | `GOCELL_CONFIGCORE_DATABASE_MAX_CONNS` |
 | `GOCELL_PG_IDLE_TIMEOUT` | `GOCELL_CONFIGCORE_DATABASE_IDLE_TIMEOUT` |
 | `GOCELL_PG_MAX_LIFETIME` | `GOCELL_CONFIGCORE_DATABASE_MAX_LIFETIME` |

--- a/docs/ops/local-docker-deploy.md
+++ b/docs/ops/local-docker-deploy.md
@@ -223,7 +223,7 @@ To enforce RLS end-to-end, the stack uses **two required PostgreSQL roles** plus
 | Role | Used by | Privileges | Required? |
 |------|---------|-----------|-----------|
 | `gocell` | `migrate` service (pg-migrate tool) | Superuser / table owner; runs DDL | Yes |
-| `gocell_app` | `corebundle` serving pool (`GOCELL_CONFIGCORE_DATABASE_URL`) | NOSUPERUSER, NOBYPASSRLS, non-owner; DML only via default privileges | Yes |
+| `gocell_app` | `corebundle` serving pool (`GOCELL_CONFIGCORE_DATABASE_URL` / `GOCELL_AUDITCORE_DATABASE_URL` / `GOCELL_ACCESSCORE_DATABASE_URL`; per-cell seam #1964, dedup to one pool) | NOSUPERUSER, NOBYPASSRLS, non-owner; DML only via default privileges | Yes |
 | `gocell_audit_admin` | `corebundle` admin read pool (`GOCELL_AUDIT_ADMIN_DSN`) — for super-admin cross-tenant audit reads (#1810) | NOSUPERUSER, NOBYPASSRLS; SELECT-only on `audit_entries` via role-scoped RLS policy `audit_admin_read_all` (migration 065) | **Optional** — skipped when `GOCELL_AUDIT_ADMIN_PASSWORD` is unset |
 
 `gocell_app` is created by `deploy/postgres/init/10-restricted-role.sh`, which

--- a/docs/ops/local-docker-deploy.md
+++ b/docs/ops/local-docker-deploy.md
@@ -156,12 +156,13 @@ Primary port `:8080` is the only listener published to the host; business `/api/
 
 ### What the script generates
 
-`scripts/gen-deploy-secrets.sh` writes 13 values to `.env.local`:
+`scripts/gen-deploy-secrets.sh` writes 14 values to `.env.local`:
 
 | Variable | How generated |
 |----------|---------------|
 | `PG_PASSWORD` | `openssl rand -hex 16` |
 | `GOCELL_APP_PASSWORD` | `openssl rand -hex 16` (hex = URL-safe; embedded in the restricted serving DSN) |
+| `RABBITMQ_PASSWORD` | `openssl rand -hex 16` (hex = URL-safe; embedded in `GOCELL_AMQP_URL` userinfo, #1940) |
 | `CONFIGCORE_MASTER_KEY` | `openssl rand -hex 32` (64 hex chars) |
 | `CONFIGCORE_CURSOR_KEY` | `openssl rand -base64 32` |
 | `AUDITCORE_HMAC_KEY` | `openssl rand -base64 32` |

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -388,7 +388,7 @@ cell-level repo probes (schema shape):
 
 - Green `postgres_ready` + failing `postgres_app_role_restricted_ready` → serving
   pool is connected but running as a privileged role that bypasses RLS. Remediation:
-  change `GOCELL_CONFIGCORE_DATABASE_URL` to use role `gocell_app` and restart.
+  change the per-cell DSNs (`GOCELL_CONFIGCORE_DATABASE_URL`, `GOCELL_AUDITCORE_DATABASE_URL`, `GOCELL_ACCESSCORE_DATABASE_URL`) to use role `gocell_app` and restart.
 - Red on startup: local dev env still uses the admin `gocell` role; see
   `docs/ops/local-docker-deploy.md` §Dual-role PostgreSQL.
 

--- a/framework/kernel/assembly/generator.go
+++ b/framework/kernel/assembly/generator.go
@@ -146,6 +146,12 @@ type modulesCompositionContext struct {
 	// metadata.ValidateTopologyStructure before codegen proceeds — illegal topology
 	// (mutual exclusion, non-exhaustive, bad endpoint) fails generation closed.
 	DeploymentTopology deploymentTopologyTemplateData
+	// PostgresCells is the sorted list of cell IDs whose cell.yaml declares
+	// `requires: [postgres]`. Single-sourced from cell.yaml metadata; consumed by
+	// the composition root's per-cell PG resolution (cellmodules/percellpg.Resolve).
+	// The template ALWAYS emits generatedPostgresCells() (nil when empty) so the
+	// composition root can call it unconditionally (#1964 per-cell infra seam).
+	PostgresCells []string
 }
 
 // deploymentTopologyTemplateData is the flattened template-serialisable form of
@@ -549,6 +555,7 @@ func (g *Generator) generateModulesGenComposition(
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalAssemblyQuotedFmt, assemblyID))))
 	}
 	topoData := buildDeploymentTopologyData(asm.Topology)
+	postgresCells := g.collectPostgresCells(asm.Cells)
 	ctx := modulesCompositionContext{
 		AssemblyID:             assemblyID,
 		SourcePath:             asm.File,
@@ -557,8 +564,32 @@ func (g *Generator) generateModulesGenComposition(
 		Capabilities:           capConsts,
 		ProjectionSourceTopics: projTopics,
 		DeploymentTopology:     topoData,
+		PostgresCells:          postgresCells,
 	}
 	return g.executeTemplate("modules_gen_composition.go.tpl", ctx)
+}
+
+// collectPostgresCells returns the sorted list of cell IDs in the assembly whose
+// cell.yaml `requires` includes "postgres". Unknown cell IDs are silently skipped
+// (unknown-cell errors are already raised by collectCapabilityConsts). Dedup is
+// not needed because assembly cells are unique by ref.ID (ensured by the YAML
+// parser), but we iterate cellRefs (not the capSet) to preserve the full ID set.
+func (g *Generator) collectPostgresCells(cellRefs []metadata.AssemblyCellRef) []string {
+	var cells []string
+	for _, ref := range cellRefs {
+		cm := g.cells.Get(ref.ID)
+		if cm == nil {
+			continue // unknown cells: error raised by collectCapabilityConsts upstream
+		}
+		for _, req := range cm.Requires {
+			if req == "postgres" {
+				cells = append(cells, ref.ID)
+				break
+			}
+		}
+	}
+	sort.Strings(cells)
+	return cells
 }
 
 // buildDeploymentTopologyData translates the metadata.TopologyMeta into the

--- a/framework/kernel/assembly/generator_modulesgen_test.go
+++ b/framework/kernel/assembly/generator_modulesgen_test.go
@@ -367,3 +367,89 @@ func indexOfStr(s, substr string) int {
 	}
 	return -1
 }
+
+// ---------------------------------------------------------------------------
+// generatedPostgresCells — codegen function tests (#1964 per-cell PG seam)
+// ---------------------------------------------------------------------------
+
+// TestGenerateModulesGen_CompositionForm_PostgresCellsEmitted verifies that the
+// composition form emits generatedPostgresCells() listing only the cells that
+// declare `requires: [postgres]`, sorted alphabetically, deduplicated.
+func TestGenerateModulesGen_CompositionForm_PostgresCellsEmitted(t *testing.T) {
+	project := buildModulesTestProject()
+	asm := project.Assemblies["corebundle"]
+	asm.Build.CompositionAPI = true
+	// accesscore requires postgres + redis; auditcore requires postgres only;
+	// configcore requires postgres only. Expected sorted output: accesscore, auditcore, configcore.
+	project.Cells["accesscore"].Requires = []string{"redis", "postgres"}
+	project.Cells["auditcore"].Requires = []string{"postgres"}
+	project.Cells["configcore"].Requires = []string{"postgres"}
+	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
+
+	out, err := gen.GenerateModulesGen("corebundle")
+	require.NoError(t, err)
+	content := string(out)
+
+	// The function must be emitted.
+	assert.Contains(t, content, "func generatedPostgresCells() []string")
+	// All three postgres-requiring cells must appear.
+	assert.Contains(t, content, `"accesscore"`)
+	assert.Contains(t, content, `"auditcore"`)
+	assert.Contains(t, content, `"configcore"`)
+	// Sorted: accesscore < auditcore < configcore.
+	posAccess := indexOfStr(content, `"accesscore"`)
+	posAudit := indexOfStr(content, `"auditcore"`)
+	posConfig := indexOfStr(content, `"configcore"`)
+	assert.Less(t, posAccess, posAudit, "accesscore must precede auditcore (sorted)")
+	assert.Less(t, posAudit, posConfig, "auditcore must precede configcore (sorted)")
+}
+
+// TestGenerateModulesGen_CompositionForm_NoPostgresCells verifies that when no
+// cell in the assembly requires postgres, generatedPostgresCells() is still
+// emitted (always, like generatedProjectionSourceTopics) but returns nil.
+func TestGenerateModulesGen_CompositionForm_NoPostgresCells(t *testing.T) {
+	project := buildModulesTestProject()
+	asm := project.Assemblies["corebundle"]
+	asm.Build.CompositionAPI = true
+	// No cell requires postgres in this fixture.
+	// (all cells have empty Requires from buildModulesTestProject)
+	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
+
+	out, err := gen.GenerateModulesGen("corebundle")
+	require.NoError(t, err)
+	content := string(out)
+
+	// Function must always be emitted.
+	assert.Contains(t, content, "func generatedPostgresCells() []string")
+	// When empty, must return nil.
+	assert.Contains(t, content, "return nil")
+}
+
+// TestGenerateModulesGen_CompositionForm_PartialPostgresCells verifies that only
+// postgres-requiring cells appear (redis-only cells are excluded).
+func TestGenerateModulesGen_CompositionForm_PartialPostgresCells(t *testing.T) {
+	project := buildModulesTestProject()
+	asm := project.Assemblies["corebundle"]
+	asm.Build.CompositionAPI = true
+	// accesscore requires redis only; auditcore requires postgres.
+	project.Cells["accesscore"].Requires = []string{"redis"}
+	project.Cells["auditcore"].Requires = []string{"postgres"}
+	// configcore: no requires
+	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
+
+	out, err := gen.GenerateModulesGen("corebundle")
+	require.NoError(t, err)
+	content := string(out)
+
+	assert.Contains(t, content, "func generatedPostgresCells() []string")
+	assert.Contains(t, content, `"auditcore"`)
+	// accesscore does NOT require postgres — must not appear in postgres list.
+	// (It may appear in module imports, so we check the function body specifically.)
+	pgFnIdx := indexOfStr(content, "func generatedPostgresCells()")
+	if pgFnIdx < 0 {
+		t.Fatal("generatedPostgresCells() not found")
+	}
+	pgFnBody := content[pgFnIdx:]
+	assert.NotContains(t, pgFnBody[:strings.Index(pgFnBody, "}")+1], `"accesscore"`,
+		"accesscore does not require postgres and must not appear in generatedPostgresCells()")
+}

--- a/framework/kernel/assembly/gentpl/modules_gen_composition.go.tpl
+++ b/framework/kernel/assembly/gentpl/modules_gen_composition.go.tpl
@@ -60,6 +60,25 @@ func generatedProjectionSourceTopics() []string {
 {{- end}}
 }
 
+// generatedPostgresCells is the sorted list of cell IDs whose cell.yaml declares
+// `requires: [postgres]` (or a superset). Single-sourced from cell.yaml metadata;
+// consumed by the composition root's per-cell PG resolution
+// (cellmodules/percellpg.Resolve) to iterate cells and look up their per-cell DSN.
+// ALWAYS emitted (nil when no postgres cells) so the composition root can call it
+// unconditionally. Derived by `gocell generate assembly`; `--verify` red-flags stale
+// output (#1964 per-cell infra seam).
+func generatedPostgresCells() []string {
+{{- if .PostgresCells}}
+	return []string{
+{{- range .PostgresCells}}
+		{{printf "%q" .}},
+{{- end}}
+	}
+{{- else}}
+	return nil
+{{- end}}
+}
+
 // generatedDeploymentTopology returns the assembly's codegen-derived deployment
 // placement spec (single-sourced from assembly.yaml topology, derived by
 // `gocell generate assembly`). Empty topology => all cells co-located (zero-

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -97,9 +97,12 @@ services:
       # Single-pod deployment: in-memory nonce store is sufficient.
       GOCELL_SINGLE_POD: "1"
 
-      # configcore cell: PG DSN + AES-256 envelope encryption. Loopback host
-      # under the host-network compose topology (see file header).
+      # PostgreSQL DSN — per-cell (#1964 per-cell PG seam). All three cells share
+      # the same DSN in this colocated deployment; percellpg.Resolve deduplicates
+      # to one pool (a missing DSN or >1 distinct DSN fails fast at startup).
       GOCELL_CONFIGCORE_DATABASE_URL: postgres://gocell_app:${GOCELL_APP_PASSWORD:?GOCELL_APP_PASSWORD must be set}@127.0.0.1:5432/gocell?sslmode=disable
+      GOCELL_AUDITCORE_DATABASE_URL: postgres://gocell_app:${GOCELL_APP_PASSWORD:?GOCELL_APP_PASSWORD must be set}@127.0.0.1:5432/gocell?sslmode=disable
+      GOCELL_ACCESSCORE_DATABASE_URL: postgres://gocell_app:${GOCELL_APP_PASSWORD:?GOCELL_APP_PASSWORD must be set}@127.0.0.1:5432/gocell?sslmode=disable
       GOCELL_CONFIGCORE_KEY_PROVIDER: local-aes
       # 64-hex-char = 32 bytes. E2e-only; never reuse in production.
       GOCELL_CONFIGCORE_MASTER_KEY: aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899

--- a/tools/archtest/capability_provider_funnel.go
+++ b/tools/archtest/capability_provider_funnel.go
@@ -40,6 +40,19 @@
 // They are the legitimate downstream of the provider (CLAUDE.md observability
 // §"per-cell 资源：cell 直接构造 NewCache(client, …)") and stay in module files.
 //
+// # Primary shared-pool construction site
+//
+// As of #1964 (per-cell infra seam, Part A), the primary shared-pool construction
+// for corebundle now lives in cellmodules/percellpg (a trusted cellmodules resolver,
+// same class as the auditcore admin pool and sagaprojectiondeps' NewTxManager).
+// Cellmodules is the Composition Root layer and is intentionally outside this
+// rule's cmd/-only scan scope. The upstream Hard guard remains the sealed
+// capability.PGProvider (unexported marker isPGProvider + sole NewPGProvider
+// constructor in runtime/capability), which makes the provider unforgeable outside
+// package capability. The cmd/-only ban (capWiringRel sanctioned site) serves as
+// defense-in-depth against any residual or future direct construction in cmd/
+// files.
+//
 // # AI-robust: upstream Hard + downstream Medium (transition form)
 //
 // Upstream is Hard (sealed construction, type system). Downstream is Medium:
@@ -50,7 +63,7 @@
 // (cmd/corebundle module files moved out of `package main` so the banned
 // constructors are import-unreachable) is tracked at gh issue #988.
 //
-// The sole sanctioned provisioning site (capWiringRel) is matched by
+// The sole sanctioned cmd/ provisioning site (capWiringRel) is matched by
 // isCapWiringSanctionedSite, which binds the exemption to PLATFORM PACKAGE
 // IDENTITY (isGoCellPlatformPkgPath) — not a bare repo-relative path. This rule
 // is importable: an external Cell repo can wire it via cfg.ExtraRules, and a

--- a/tools/archtest/capability_provider_funnel.go
+++ b/tools/archtest/capability_provider_funnel.go
@@ -40,19 +40,6 @@
 // They are the legitimate downstream of the provider (CLAUDE.md observability
 // §"per-cell 资源：cell 直接构造 NewCache(client, …)") and stay in module files.
 //
-// # Primary shared-pool construction site
-//
-// As of #1964 (per-cell infra seam, Part A), the primary shared-pool construction
-// for corebundle now lives in cellmodules/percellpg (a trusted cellmodules resolver,
-// same class as the auditcore admin pool and sagaprojectiondeps' NewTxManager).
-// Cellmodules is the Composition Root layer and is intentionally outside this
-// rule's cmd/-only scan scope. The upstream Hard guard remains the sealed
-// capability.PGProvider (unexported marker isPGProvider + sole NewPGProvider
-// constructor in runtime/capability), which makes the provider unforgeable outside
-// package capability. The cmd/-only ban (capWiringRel sanctioned site) serves as
-// defense-in-depth against any residual or future direct construction in cmd/
-// files.
-//
 // # AI-robust: upstream Hard + downstream Medium (transition form)
 //
 // Upstream is Hard (sealed construction, type system). Downstream is Medium:
@@ -63,7 +50,7 @@
 // (cmd/corebundle module files moved out of `package main` so the banned
 // constructors are import-unreachable) is tracked at gh issue #988.
 //
-// The sole sanctioned cmd/ provisioning site (capWiringRel) is matched by
+// The sole sanctioned provisioning site (capWiringRel) is matched by
 // isCapWiringSanctionedSite, which binds the exemption to PLATFORM PACKAGE
 // IDENTITY (isGoCellPlatformPkgPath) — not a bare repo-relative path. This rule
 // is importable: an external Cell repo can wire it via cfg.ExtraRules, and a


### PR DESCRIPTION
## Summary

为 postgres cell 落地 **per-cell DB 凭据/连接注入 seam**（#1964 / Epic #1423 US6 Part A）：新建第 4 个 sealed topology-gated resolver `cellmodules/percellpg`，按 cell 解析 `GOCELL_<CELLID>_DATABASE_URL` → dedup-by-DSN → fail-closed，替换 `cap_wiring.go` 里隐式的单一全局池；并把 per-cell HMAC keyring / mTLS 安全模型评估写入部署拓扑 ADR。

## Why / 背景

现状 `provisionPostgres` 硬编 `GOCELL_CONFIGCORE_DATABASE_URL` 构造唯一池，auditcore/accesscore **隐式共享**它——env 变量名（configcore）与实际作用域（assembly 全局）不符。FR-008 要求每个 cell-进程**可注入**独立 DB 凭据、缺失时 fail-fast、不再隐含共享。本 PR 把隐式全局构造换成**显式 per-cell 解析 + dedup + fail-closed 双闸**，并作为 split 拓扑（US4 #1963）的数据主权落地面。

## 范围裁定（经三原则自审，Cx4→Cx3 收敛）

issue 标 `cx-3`。规划初期曾应需求扩到 Cx4「完整 per-cell relay/broker 运行期 fan-out」，但**原则自审**（彻底/不向后兼容/优雅简洁/AI-HARD）判定其违反「优雅简洁 / 不预设未来」：split 拓扑被 US4 #1963 gated，per-cell relay/pub-sub fan-out 现在掘 framework `bootstrap` 底座不变式 = 为 gated 拓扑掠底、零当前行为差异；且 distinct 池无 relay fan-out = outbox **fail-open**。故收敛为 Cx3 合规核心：

- **本 PR 落地**：per-cell DB resolution seam（`percellpg` + dedup + fail-closed），colocated 行为与今**逐字节一致**（所有 postgres cell 设同一 DSN → dedup → 一个池）；distinct DSN → 启动期 **fail-closed**（杜绝 outbox fail-open，错误指向 split/backlog）。
- **broker 不做 per-cell**：broker 是 shared-by-nature 的跨 cell 事件总线（独立 broker 会切断跨 cell 事件链路），且已是干净的 assembly 级 `GOCELL_AMQP_URL`——无隐式 wart 可修。per-cell broker 连接耦合 per-cell pub/sub fan-out → 随 Part C backlog。
- **T052 仅评估**：per-cell HMAC keyring（HKDF-by-cellID 推荐方向）+ mTLS 缺口写入 ADR 威胁矩阵，本 PR **不实施**（→ backlog）。

## 改动

| 变更 | 载体 |
|------|------|
| 第 4 个 sealed resolver（自己开池，dedup-by-DSN，fail-closed 双闸） | `cellmodules/percellpg/{percellpg,doc,percellpg_test}.go` |
| codegen 单源派生 postgres-requiring cell 集（非手写平行清单） | `framework/kernel/assembly/generator.go` + `gentpl/*.tpl` + golden；`cmd/corebundle/modules_gen.go`（regen）|
| `provisionPostgres` 委派 percellpg，删内联建池 + verify* | `cmd/corebundle/cap_wiring.go` |
| env 清晰断裂：每 postgres cell 读 `GOCELL_<CELLID>_DATABASE_URL` | `.env.example`、`docker-compose.local.yml`、`tests/e2e/docker-compose.e2e.yaml`、`cmd/corebundle/corebundle_pg_env_integration_test.go`、docs/ops/* |
| funnel doc 校正（percellpg 在 cellmodules，同 audit admin pool 类，cmd-only 扫描不变） | `tools/archtest/capability_provider_funnel.go` |
| T052 安全评估 + per-cell DB seam 落地记录 + broker 论据 | `docs/architecture/202606131142-1423-...md`、`cellmodules/eventtransport/doc.go` |

## Refs

- Closes #1964；Epic #1423 US6；方向 ADR `docs/architecture/202606131142-1423-adr-cell-deployment-topology.md`
- ref: sibling sealed resolver `cellmodules/sagaprojectiondeps` / `cellmodules/eventtransport`（同形 `Resolve(ctx,clk,topo,cfg)` + fail-closed）
- 收尾将建 2 个 backlog issue：① Part C per-cell relay/pub-sub 运行期 fan-out（blocked-by US4 #1963）② per-cell HMAC keyring HKDF + mTLS（T052 实施）

## Risk / 兼容性

- **wire 兼容**：无（无 HTTP/event/command 契约变更）。
- **env 破坏式变更（清断裂、无 shim）**：postgres 拓扑下 **每个** postgres cell（configcore/auditcore/accesscore）须设 `GOCELL_<CELLID>_DATABASE_URL`；colocated 设同值（dedup→一个池）。缺任一 → 启动 fail-fast；配 distinct → fail-closed。所有 in-repo 部署/e2e/docs 已同 PR 更新。
- AI-HARD：sealed `capability.PGProvider`（上游 Hard）+ funnel AST scan（下游 Medium）+ fail-closed 双闸运行期 guard，对齐 3 个 sibling resolver；未引入新 Soft。

## Test plan

- [x] 各 module `go build ./...` 通过（多 module go.work：framework / cellmodules / cmd/corebundle / tools）
- [x] `go test`：`cellmodules/percellpg`（含 -race）、`framework/kernel/assembly`、`cmd/corebundle`、`cellmodules/...` 全绿；archtest `CAPABILITY-PROVIDER-FUNNEL-01`（`-tags=archtest`）绿
- [x] `golangci-lint run` 0 issues（touched modules）
- [x] percellpg 决策逻辑（resolveAgreedConfig dedup/fail-closed 双闸）单测全覆盖；success+verify I/O 路径由 `corebundle_pg_env_integration_test`（真实 PG）覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)
