### PR TITLE
fix(archtest): 收敛 CI pinning / dependabot 治理漂移至 #1817/#1565 现状 [#2113]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # NOTE (#2160): since #1565/#2125 no workflow `uses:` golangci/golangci-lint-action
+      # — the real golangci-lint pin is now hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION
+      # (a `go install @version` shell literal, absent from any go.mod), so neither this
+      # github-actions group nor the gomod ecosystem auto-bumps it: golangci-lint version
+      # upgrades are MANUAL by accepted decision pending #2160. This group is retained as a
+      # placeholder (and to satisfy DEPENDABOT-COVERAGE-GOLANGCI-01) until #2160 decides
+      # whether to redirect coverage to the real pin source; it is NOT a merge condition of
+      # PR #2158 (the archtest-convergence PR), which deliberately leaves this state as-is.
       golangci-lint:
         patterns:
           - "golangci/golangci-lint-action"

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,10 @@ test:
 # module with the repo-root config.
 #
 # golangci-lint is bootstrapped from hack/lib/golangci-lint.sh at the version
-# pinned to .github/workflows/_build-lint.yml — never from $PATH — so local
-# fmt and CI lint apply identical formatter rules.
+# pinned in that file (GOLANGCI_LINT_VERSION) — never from $PATH — so local
+# fmt and CI lint resolve the same binary and apply identical formatter rules.
+# (#1565/#2125 removed the golangci-lint-action `version:` input; the shell
+# constant is now the sole CI lint pin.)
 #
 # ref: kubernetes/kubernetes hack/update-gofmt.sh + hack/verify-golangci-lint.sh.
 fmt:

--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -10,7 +10,7 @@
 | **进入运行时进程** | 否 | 是 |
 | **对标定位** | 构建 / 治理工具（类似 `kubectl` / `go generate`） | Composition Root（类似 Uber fx 的 wire-up 入口） |
 
-- **`cmd/gocell`**：治理与元数据 CLI，供 dev 与 CI 调用。执行 validate（contract / cell / slice 声明合规）、scaffold（脚手架）、generate（codegen 契约派生；含 `required-deps` 子命令 — 从 Service struct `gocell:"required"` tag 生成 `service_required_gen.go`，对应 `REQUIRED-DEP-NIL-GUARD-01` funnel；含 `shared-schema` 子命令 — 把 `contracts/shared/errors/error-response-v1.schema.json` 字节恒等派生到 3 个 mirror，对应 `SHARED-SCHEMA-MIRROR-FUNNEL-01` funnel）、check（自定义规则检查）、verify（验收规格对齐；含 `codegen-shared-schema` 子命令 — in-process 字节 diff 守护 3 个 mirror 与 canonical 同步）、graph（模块包依赖图输出）、export（项目元数据 / 目录导出为 JSON/YAML）。**不进入运行时进程**，不依赖生产外部资源。
+- **`cmd/gocell`**：治理与元数据 CLI，供 dev 与 CI 调用。执行 validate（contract / cell / slice 声明合规）、scaffold（脚手架）、generate（codegen 契约派生；含 `required-deps` 子命令 — 从 Service struct `gocell:"required"` tag 生成 `service_required_gen.go`，对应 `REQUIRED-DEP-NIL-GUARD-01` funnel；含 `shared-schema` 子命令 — 把 `contracts/shared/errors/error-response-v1.schema.json` 字节恒等派生到每个声明 mirror（目标集以 `tools/codegen/sharedschema.Mirrors` 为准），对应 `SHARED-SCHEMA-MIRROR-FUNNEL-01` funnel）、check（自定义规则检查）、verify（验收规格对齐；含 `codegen-shared-schema` 子命令 — in-process 字节 diff 守护各声明 mirror 与 canonical 同步）、graph（模块包依赖图输出）、export（项目元数据 / 目录导出为 JSON/YAML）。**不进入运行时进程**，不依赖生产外部资源。
 
 - **`cmd/corebundle`**：`assemblies/corebundle/` 的运行时组装产物。负责 bootstrap wiring：加载 SharedDeps（PG / Redis / AMQP / JWT / HMAC 等）、调用 `cellmodules/<cell>.Module()` 构造各 CellModule（平台 cell 业务 wiring 已迁移至 `cellmodules/` 层）、配置三个 HTTP listener（Primary / Internal / Health）、启动 `bootstrap.Run`。**是实际部署运行的二进制**，也是项目唯一的生产 Composition Root。`corebundle-no-cells` depguard 强制 `cmd/corebundle` 不直接 import `cells/`（cellmodules 层负责绑定 cell 与 adapter）。
 

--- a/docs/architecture/202605031600-adr-v1-schema-evolution.md
+++ b/docs/architecture/202605031600-adr-v1-schema-evolution.md
@@ -147,9 +147,9 @@ same pattern. State-carrying event payloads remain lenient (no
 > **Amendment 2026-05-25** (issue #677 / ADR `docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md`):
 > Mirror 的 strict 性现由「字节恒等 canonical」经 codegen funnel 传递继承。
 > `contracts/shared/errors/error-response-v1.schema.json` 是唯一手写源；
-> 3 个副本（`examples/iotdevice`、`examples/todoorder`、`tests/contracttest/testdata`
-> 下各一份）由 `gocell generate shared-schema` 派生并由 `gocell verify codegen-shared-schema`
-> 字节 diff 守护。`hack/verify-schema-policy.sh` 不再单列 example mirror 的 strict 行；
+> 每个消费 contractsRoot 下各一份副本（目标集以 `tools/codegen/sharedschema` 的 `Mirrors`
+> 变量为准，不在此复制数量）由 `gocell generate shared-schema` 派生并由
+> `gocell verify codegen-shared-schema` 字节 diff 守护。`hack/verify-schema-policy.sh` 不再单列 example mirror 的 strict 行；
 > strict 性由 canonical 单源传递，只需校验 canonical。
 
 `contracts/shared/errors/error-response-v1.schema.json` is the single

--- a/docs/architecture/202605061600-adr-bootstrap-admin-boundary.md
+++ b/docs/architecture/202605061600-adr-bootstrap-admin-boundary.md
@@ -28,7 +28,7 @@ codegen 对 `auth.bootstrap: true` 的 contract 生成的 `NewHandler` 必须把
 
 archtest 守卫：CELLS-NO-ROUTEMUX-WRAPPER-01 / AUTH-ROUTE-BOOTSTRAP-FLAG-REMOVED-01 / SETUP-ADMIN-CODEGEN-BOOTSTRAP-AUTH-WIRED-01。
 
-CI verify-codegen 三步（`go generate` + `git diff --quiet` + codegen drift check）从 build-test matrix 拆出为独立 job（无 `needs` 依赖），build-test 失败不再掩盖 codegen drift。`tools/archtest/TestVerifyCodegenJobIsIndependent` 静态守卫 job 拓扑不回退。
+codegen / scaffold gate 现由 `make verify` 的并行 bucket 系统唯一拥有（`governance.yml` 的 `codegen` bucket；`verify-bucket-coverage.sh` 反空洞守卫每个 `hack/verify-*.sh` 声明合法 `# verify-bucket:` 注解被 fan-out 跑到），叠加 producer 侧 `CODEGEN-*-GEN-*` Hard archtest。原 build-test matrix 内重复的独立 `verify-codegen` job 及守卫其拓扑的 `tools/archtest/TestVerifyCodegenJobIsIndependent` 已分别于 #1817 / #2113 移除（双跑去重 + 失效不变量清理）。
 
 ### D2 — Operator Basic Auth credential via env
 

--- a/docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md
+++ b/docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md
@@ -133,7 +133,7 @@ Hard 化方向（gh issue `#954` 跟踪）：
 | AI 直接编辑某 mirror 副本，绕过 canonical | 低 | A1 reverse-enum archtest 全量扫 repo，但只检测"副本存在"而非"内容对齐"——内容对齐由 `gocell verify codegen-shared-schema` verify gate 守护（CI 强制） |
 | 新增第 4 个 mirror 副本未进 `sharedschema.Mirrors` 声明 | 低 | A1 archtest：未声明副本即 CI 红（reverse-enum 无枚举漏洞） |
 | `Headerless: true` 被其他包滥用绕过 generated header 门 | 低 | A2 archtest：caller-allowlist 类型感知扫描，composite literal 包外即 CI 红 |
-| verify gate 被跳过（CI 步骤被删除） | 低 | `tools/archtest/ci_pinning_test.go` 的 `codegenStepNames` 常量集锁 verify 步骤名（blind-spot ③），步骤被删即 archtest CI 红 |
+| 镜像字节相等 gate 不再被 CI 跑到（blind-spot ③） | 低 | `tools/archtest/TestSharedSchemaMirrorByteCurrent`（`SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01`）在 archtest 进程内直跑 `sharedschema.Verify` 做 in-process 字节 diff，drift 即 CI 红——**不依赖**任何 shell 脚本或 workflow step 存在（严于 #1817 前由已删 `codegenStepNames` step-name 锁守的旧形态）。shell gate 仍经 `# verify-bucket: codegen` 路由供 `make verify` |
 | reader allowlist 升级后（Hard 化）引入 symlink 逃逸 | 低（当前不适用） | 当前 reader allowlist 结构决定必须保持物理副本；Hard 化时需同步审查 allowlist 逻辑 |
 
 ## Related

--- a/docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md
+++ b/docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md
@@ -21,11 +21,11 @@ PR #396 引入了 `TestSharedErrorSchema_CopiesInSync`（`bytes.Equal` 比对 3 
 
 ## Decision
 
-把 error envelope schema 收敛为**单一手写源 + codegen 派生 3 mirror**：
+把 error envelope schema 收敛为**单一手写源 + codegen 派生 mirror**：
 
 - **canonical 源**：`contracts/shared/errors/error-response-v1.schema.json`（唯一允许手工编辑的副本）
-- **mirror 清单**：`tools/codegen/sharedschema` 包的 `Mirrors` 变量（`map[canonicalRel][]destRoot`）声明 3 个派生目标：`examples/iotdevice`、`examples/todoorder`、`tests/contracttest/testdata`
-- **生成命令**：`gocell generate shared-schema` → 调用 `sharedschema.Generate(root, dryRun)`，把 canonical 字节恒等写到 3 个目标路径
+- **mirror 清单**：`tools/codegen/sharedschema` 包的 `Mirrors` 变量（`map[canonicalRel][]destRoot`）是**唯一**目标声明单源；本 ADR 不复制 mirror 数量（避免与 `Mirrors` 漂移）。当前声明的派生目标为 `examples/demo`、`examples/iotdevice`、`examples/orderfulfillment`、`examples/todoorder`、`tests/contracttest/testdata`（以 `sharedschema.Mirrors` 为准——新增消费 contractsRoot 时只改该变量，本 ADR 措辞不需同步）
+- **生成命令**：`gocell generate shared-schema` → 调用 `sharedschema.Generate(root, dryRun)`，把 canonical 字节恒等写到每个声明目标路径
 - **verify gate**：`gocell verify codegen-shared-schema` → 调用 `sharedschema.Verify(root)`，in-process 字节 diff，任一 mirror 漂移或缺失均返回非零退出码；该 gate 经 `# verify-bucket: codegen` 路由进 `make verify` 的 codegen bucket（#1817 删除独立 `verify-codegen` job 后单 owner），并由 nightly archtest `TestSharedSchemaMirrorByteCurrent`（`SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01`，#2113）在进程内直跑 `sharedschema.Verify` 兜底（见 §Threat Model blind-spot ③）
 - **删除旧测试**：`TestSharedErrorSchema_CopiesInSync` 删除，verify gate 取代其功能且强制物理同步
 - **reverse-enum archtest**（`SHARED-SCHEMA-MIRROR-FUNNEL-01` A1）：在 CI 全量扫描 repo，发现任何不在 `sharedschema.Mirrors` 声明集内的 `error-response-v1.schema.json` 副本即报错——新增 mirror 必须先进 `Mirrors` 清单
@@ -45,9 +45,9 @@ CAS mixin ADR（`202605241700`）和本 ADR 同在 `contracts/shared/` 命名空
 
 `contracts/shared/cas/v1/expected_version.schema.json` 的 6 个消费方（4 个 body schema + 2 个 DELETE query param）全部位于**主仓库同一 `contractsRoot`** 下，`$ref` 的相对路径解析路径完全可达。codegen DTO parse（`contractgen/jsonschema.go::fillRef`）和 runtime embed bundler（`refbundle.go`）都在主仓库树内运行，可以安全跟随 `$ref`。物理上只有 1 份定义，`$ref` 让消费方引用它——**违反在物理层不可表达**（Hard）。
 
-### Error envelope 选择「codegen 派生物理 3 份」
+### Error envelope 选择「codegen 派生物理多份（每消费 contractsRoot 一份）」
 
-Error envelope 的 3 个消费方落在 **3 个独立 `contractsRoot`**（`examples/iotdevice/contracts/`、`examples/todoorder/contracts/`、`tests/contracttest/testdata/contracts/`），无法通过 `$ref` 到主仓库根：
+Error envelope 的多个消费方落在**各自独立的 `contractsRoot`**（如 `examples/iotdevice/contracts/`、`examples/todoorder/contracts/`、`tests/contracttest/testdata/contracts/`——完整集以 `sharedschema.Mirrors` 为准），无法通过 `$ref` 到主仓库根：
 
 **物理 reader 1**（`tests/contracttest/contracttest.go` 第 385-423 行，`compileSchemaFile`）：
 
@@ -78,7 +78,7 @@ CAS ADR（`202605241700` §Out of scope）明确 `contracts/shared/` 是「mixin
 本 ADR 讨论的是**跨 contractsRoot 的副本治理**——不同 contractsRoot 下各自存在物理副本是必需的（见上两个 reader 的约束），治理方式是 codegen 字节同步而非 `$ref` 引用。两种范式处理不同层面的问题，不冲突：
 
 - CAS：同一 contractsRoot 内，`$ref` mixin → 物理单份（Hard）
-- Error envelope：跨 contractsRoot，codegen mirror → 字节恒等 3 份（Medium）
+- Error envelope：跨 contractsRoot，codegen mirror → 字节恒等多份（每消费 contractsRoot 一份，Medium）
 
 ## AI-robust 评级
 
@@ -117,7 +117,7 @@ Hard 化方向（gh issue `#954` 跟踪）：
 
 ### 正向效果
 
-- canonical 是唯一手写来源，`make generate` 后 3 个 mirror 自动对齐，AI 单独修改副本在下次 CI verify gate 时被发现。
+- canonical 是唯一手写来源，`make generate` 后所有声明 mirror 自动对齐，AI 单独修改副本在下次 CI verify gate 时被发现。
 - reverse-enum archtest 让「新增第 4 个副本」在 CI 立即可见，无需人工巡查。
 - `Headerless` 逃生口被 caller-allowlist 锁住，AI 无法在其他 codegen 路径中悄悄重用该选项。
 
@@ -133,7 +133,7 @@ Hard 化方向（gh issue `#954` 跟踪）：
 | AI 直接编辑某 mirror 副本，绕过 canonical | 低 | A1 reverse-enum archtest 全量扫 repo，但只检测"副本存在"而非"内容对齐"——内容对齐由 `gocell verify codegen-shared-schema` verify gate 守护（CI 强制） |
 | 新增第 4 个 mirror 副本未进 `sharedschema.Mirrors` 声明 | 低 | A1 archtest：未声明副本即 CI 红（reverse-enum 无枚举漏洞） |
 | `Headerless: true` 被其他包滥用绕过 generated header 门 | 低 | A2 archtest：caller-allowlist 类型感知扫描，composite literal 包外即 CI 红 |
-| 镜像字节相等 gate 不再被 CI 跑到（blind-spot ③） | 低 | `tools/archtest/TestSharedSchemaMirrorByteCurrent`（`SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01`）在 archtest 进程内直跑 `sharedschema.Verify` 做 in-process 字节 diff，drift 即 CI 红——**不依赖**任何 shell 脚本或 workflow step 存在（严于 #1817 前由已删 `codegenStepNames` step-name 锁守的旧形态）。shell gate 仍经 `# verify-bucket: codegen` 路由供 `make verify` |
+| 镜像字节相等 gate 不再被 CI 跑到（blind-spot ③） | 低 | `tools/archtest/TestSharedSchemaMirrorByteCurrent`（`SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01`，**Medium**——in-process runtime guard：stale JSON 可表达但每次 archtest 进程内 `sharedschema.Verify` 字节 diff 抓住）在 archtest 进程内直跑做 in-process 字节 diff，drift 即 CI 红——**不依赖**任何 shell 脚本或 workflow step 存在（严于 #1817 前由已删 `codegenStepNames` step-name 锁守的旧形态，但「严于 Soft step-name 锁」仍是 Medium，非 Hard）。shell gate 仍经 `# verify-bucket: codegen` 路由供 `make verify` |
 | reader allowlist 升级后（Hard 化）引入 symlink 逃逸 | 低（当前不适用） | 当前 reader allowlist 结构决定必须保持物理副本；Hard 化时需同步审查 allowlist 逻辑 |
 
 ## Related

--- a/docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md
+++ b/docs/architecture/202605250900-adr-shared-error-schema-mirror-codegen.md
@@ -26,7 +26,7 @@ PR #396 引入了 `TestSharedErrorSchema_CopiesInSync`（`bytes.Equal` 比对 3 
 - **canonical 源**：`contracts/shared/errors/error-response-v1.schema.json`（唯一允许手工编辑的副本）
 - **mirror 清单**：`tools/codegen/sharedschema` 包的 `Mirrors` 变量（`map[canonicalRel][]destRoot`）声明 3 个派生目标：`examples/iotdevice`、`examples/todoorder`、`tests/contracttest/testdata`
 - **生成命令**：`gocell generate shared-schema` → 调用 `sharedschema.Generate(root, dryRun)`，把 canonical 字节恒等写到 3 个目标路径
-- **verify gate**：`gocell verify codegen-shared-schema` → 调用 `sharedschema.Verify(root)`，in-process 字节 diff，任一 mirror 漂移或缺失均返回非零退出码，由 CI `verify-codegen` job 守护
+- **verify gate**：`gocell verify codegen-shared-schema` → 调用 `sharedschema.Verify(root)`，in-process 字节 diff，任一 mirror 漂移或缺失均返回非零退出码；该 gate 经 `# verify-bucket: codegen` 路由进 `make verify` 的 codegen bucket（#1817 删除独立 `verify-codegen` job 后单 owner），并由 nightly archtest `TestSharedSchemaMirrorByteCurrent`（`SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01`，#2113）在进程内直跑 `sharedschema.Verify` 兜底（见 §Threat Model blind-spot ③）
 - **删除旧测试**：`TestSharedErrorSchema_CopiesInSync` 删除，verify gate 取代其功能且强制物理同步
 - **reverse-enum archtest**（`SHARED-SCHEMA-MIRROR-FUNNEL-01` A1）：在 CI 全量扫描 repo，发现任何不在 `sharedschema.Mirrors` 声明集内的 `error-response-v1.schema.json` 副本即报错——新增 mirror 必须先进 `Mirrors` 清单
 - **caller-allowlist archtest**（`SHARED-SCHEMA-MIRROR-FUNNEL-01` A2）：`codegen.WriteOptions{Headerless: true}` 复合字面量只允许出现在 `tools/codegen/sharedschema` 包，其他包使用即 CI 红

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -47,8 +47,9 @@
 #     `bash hack/verify-archtest.sh` or `make verify` explicitly.
 #   - golangci-lint runs CI-faithfully —
 #     `golangci-lint run --new-from-merge-base=origin/develop` with the
-#     version pinned by hack/lib/golangci-lint.sh (the project's single
-#     source of truth, reviewer-synced with _build-lint.yml; NOT go.mod
+#     version pinned by hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION (the
+#     project's single source of truth, which CI's lint step sources via the
+#     same gocell::golangci_lint::ensure; NOT go.mod
 #     like gofumpt — golangci-lint is not a go.mod tool dependency).
 #     Three honest caveats: (a) MEASURED cost is ~7s warm but ~295s
 #     (~5min) COLD — i.e. after `go clean -cache`, a dependency bump, or

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -233,8 +233,9 @@ gofumpt_gate() {
 # measured cost (warm ~7s / cold ~5min), the base-ref pin rationale, and
 # why mirroring PR-mode (not push-mode) CI cannot produce "hook red / CI
 # green". The binary version is resolved through the project's single
-# source of truth — hack/lib/golangci-lint.sh, reviewer-synced with
-# _build-lint.yml — NOT go.mod (golangci-lint is not a go.mod tool dep,
+# source of truth — hack/lib/golangci-lint.sh (GOLANGCI_LINT_VERSION), which
+# CI's lint step sources via the same gocell::golangci_lint::ensure — NOT
+# go.mod (golangci-lint is not a go.mod tool dep,
 # unlike gofumpt; this is the one place the no-PATH-ambient rule routes
 # through the lib instead of `go run`). Fail-closed: any sourcing /
 # resolver / install error returns non-zero so run_bg blocks the push
@@ -260,12 +261,14 @@ lint_gate() {
         printf 'golangci-lint gate: %s not found locally (run: git fetch origin develop)\n' "${BASE_BRANCH}"
         return 1
     fi
-    # --timeout overrides golangci-lint's 60s default; PR-mode on a
-    # multi-commit merge-base..HEAD range (especially after a develop sync)
-    # routinely exceeds 60s on cold-cache. CI's golangci-lint-action carries
-    # its own action-level timeout, so this command-line flag aligns the
-    # local hook with CI behaviour. 10m matches the value used in
-    # _build-lint.yml's runner job.
+    # --timeout overrides golangci-lint's default; PR-mode on a multi-commit
+    # merge-base..HEAD range (especially after a develop sync) routinely needs
+    # more than the default on cold-cache. CI invokes the same pinned binary via
+    # hack/lib/golangci-lint.sh (gocell::golangci_lint::ensure) without an
+    # explicit --timeout, so this generous 10m local cap only keeps the hook from
+    # aborting a slow cold-cache range — it does not change which findings the
+    # hook vs. CI report (verdict parity comes from the shared binary + config,
+    # not the timeout).
     "${bin}" run "--new-from-merge-base=${BASE_BRANCH}" --timeout=10m
 }
 

--- a/hack/lib/golangci-lint.sh
+++ b/hack/lib/golangci-lint.sh
@@ -9,14 +9,15 @@
 # locally vs CI — exactly the failure mode the gofumpt rollout was meant
 # to prevent on the producer side.
 #
-# Sync requirements (manual, not statically enforced):
+# Since #1565/#2125 GOLANGCI_LINT_VERSION below is the SOLE source of the CI
+# lint pin: the golangci-lint-action step (which replicated the version literal
+# in _build-lint.yml) was removed and CI resolves the binary via
+# gocell::golangci_lint::ensure. Patch-pinning of this constant is archtest-
+# guarded by CI-PINNING-WORKFLOW-DIGEST-01 (tools/archtest/ci_pinning_test.go).
 #
-#   1. .github/workflows/_build-lint.yml's golangci-lint-action `version:`
-#      MUST equal GOLANGCI_LINT_VERSION below. The lint-action is kept for
-#      its build cache and `config verify`; the version literal is the
-#      source of truth replicated there.
+# Sync requirement (manual, not statically enforced):
 #
-#   2. The repo's go.mod `mvdan.cc/gofumpt` version MUST equal the version
+#   1. The repo's go.mod `mvdan.cc/gofumpt` version MUST equal the version
 #      vendored by the pinned golangci-lint release (v2.11.4 vendors
 #      mvdan.cc/gofumpt v0.9.2). Producer-side round-trip tests in
 #      tools/codegen call gofumpt.Source via the project lib, while the CI
@@ -27,8 +28,10 @@
 #      mvdan.cc/gofumpt v0.9.2 — invariant satisfied (PR #534 restored it
 #      from a stray v0.10.0).
 #
-# Reviewer-enforced sync — no archtest because both upstreams are yaml /
-# go.mod literals shellcheck/Go can't cross-reference cleanly.
+# The remaining gofumpt↔golangci-lint cross-version sync (#1 above) is
+# reviewer-enforced — no archtest, because it cross-references a go.mod literal
+# against the gofumpt version vendored inside the golangci-lint release —
+# static analysis (Go / shellcheck) can't resolve cleanly.
 #
 # ref: kubernetes/kubernetes hack/verify-golangci-lint.sh — same
 # go-install-from-pinned-version pattern; we omit the docker fallback

--- a/tools/archtest/ci_integration_discovery_invariants_test.go
+++ b/tools/archtest/ci_integration_discovery_invariants_test.go
@@ -96,6 +96,25 @@ func fileHasExclusivelyTag(path, tag string) (bool, error) {
 	return withTagCtx && !withoutTagCtx, nil
 }
 
+// workflowConfig / workflowJob / workflowStep model the subset of GitHub Actions
+// workflow YAML these archtests parse (jobs → steps → name/if/uses/run). Shared
+// by readWorkflowStep below.
+type workflowConfig struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Uses  string         `yaml:"uses"`
+	Steps []workflowStep `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name string `yaml:"name"`
+	If   string `yaml:"if"`
+	Uses string `yaml:"uses"`
+	Run  string `yaml:"run"`
+}
+
 // readWorkflowStep reads <workflowFile> under .github/workflows/ and returns
 // the named step from the named job. Step + job + workflow names are coupled
 // to the YAML by string; renaming any of them is a coordinated change with

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestGolangCILintVersionPinnedToPatch(t *testing.T) {
 	root := findModuleRoot(t)
-	// Since #1565/#2125 golangci-lint runs via the shared funnel — the
+	// Since #1565 (PR #2125) golangci-lint runs via the shared funnel — the
 	// golangci-lint-action `version:` input in _build-lint.yml was removed and
 	// the pin now lives solely in hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION
 	// (resolved by gocell::golangci_lint::ensure). That constant is the single

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -9,6 +9,16 @@
 //	golangci/golangci-lint-action and a root gomod block is present; the decode is
 //	tolerant of unmodeled orchestration fields (a typo in an asserted field
 //	collapses to its zero value and still reds the guard)
+//
+// Known limitation (#2160): since #1565/#2125 no workflow `uses:`
+// golangci/golangci-lint-action anymore — the real lint pin moved to
+// hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION (a `go install @version`
+// shell literal, absent from any go.mod). So the dependabot golangci-lint group
+// this guard requires currently covers a ghost action and does NOT make the real
+// pin auto-updatable. The guard is kept as-is pending the supply-chain
+// auto-upgrade decision (redirect to the real pin source vs. go.mod tool dep vs.
+// accept manual bump) tracked in #2160; this note keeps the guard honest rather
+// than implying live dependabot coverage of the real golangci-lint pin.
 package archtest
 
 import (
@@ -20,7 +30,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -34,15 +43,73 @@ func TestGolangCILintVersionPinnedToPatch(t *testing.T) {
 	// the pin now lives solely in hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION
 	// (resolved by gocell::golangci_lint::ensure). That constant is the single
 	// source of the CI lint pin; CI-PINNING-WORKFLOW-DIGEST-01 guards it stays
-	// patch-pinned (not bare major.minor).
+	// patch-pinned (not bare major.minor) AND is declared exactly once.
 	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, "hack", "lib", "golangci-lint.sh")))
 	require.NoError(t, err)
+	require.NoError(t, validateGolangCILintPatchPinned(body))
+}
 
-	re := regexp.MustCompile(`(?m)^GOLANGCI_LINT_VERSION="(v[0-9]+\.[0-9]+(?:\.[0-9]+)?)"\s*$`)
-	matches := re.FindStringSubmatch(string(body))
-	require.Len(t, matches, 2, "hack/lib/golangci-lint.sh must declare GOLANGCI_LINT_VERSION")
-	assert.Regexp(t, regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`), matches[1],
-		"golangci-lint must be pinned to patch version, not only major.minor")
+// validateGolangCILintPatchPinned checks that the golangci-lint pin source
+// declares GOLANGCI_LINT_VERSION exactly once and pins it to a full patch
+// version (vMAJOR.MINOR.PATCH), not a bare vMAJOR.MINOR.
+//
+// Exactly-once is load-bearing: hack/lib/golangci-lint.sh is `source`d by every
+// consumer (CI lint step, make fmt, pre-push hook), and shell keeps the LAST
+// assignment of a variable. A first-match-only check (the pre-#2158 form used
+// regexp.FindStringSubmatch) read only the topmost line, so appending a second
+// `GOLANGCI_LINT_VERSION="v2.12"` below the patch-pinned one would make the
+// unpinned major.minor value win at runtime while the guard stayed green
+// (#2158 F2). The guard therefore rejects duplicate declarations outright; the
+// assignment regex captures ANY quoted value so a laundered second assignment
+// is still counted, not silently skipped.
+func validateGolangCILintPatchPinned(body []byte) error {
+	assign := regexp.MustCompile(`(?m)^GOLANGCI_LINT_VERSION="([^"]*)"\s*$`)
+	all := assign.FindAllStringSubmatch(string(body), -1)
+	if len(all) != 1 {
+		return fmt.Errorf("hack/lib/golangci-lint.sh must declare GOLANGCI_LINT_VERSION "+
+			"exactly once (shell `source` keeps the last assignment); found %d", len(all))
+	}
+	if !regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`).MatchString(all[0][1]) {
+		return fmt.Errorf("golangci-lint must be pinned to patch version "+
+			"(vMAJOR.MINOR.PATCH), not only major.minor; got %q", all[0][1])
+	}
+	return nil
+}
+
+// TestValidateGolangCILintPatchPinned is the synthetic red/green table for the
+// patch-pin guard. The real hack/lib/golangci-lint.sh declares the version
+// exactly once, so the duplicate-assignment regression (#2158 F2) can only be
+// exercised against fixtures here.
+//
+// INVARIANT: CI-PINNING-WORKFLOW-DIGEST-01 — exactly-once patch pin.
+func TestValidateGolangCILintPatchPinned(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"single patch pin", "GOLANGCI_LINT_VERSION=\"v2.11.4\"\n", false},
+		{"bare major.minor", "GOLANGCI_LINT_VERSION=\"v2.11\"\n", true},
+		{"no declaration", "echo hi\n", true},
+		// shell `source` keeps the LAST assignment: a second bare major.minor
+		// below the pinned line wins at runtime, so the guard must red on the
+		// duplicate rather than read only the first (the #2158 F2 hole).
+		{"duplicate, second unpinned", "GOLANGCI_LINT_VERSION=\"v2.11.4\"\nGOLANGCI_LINT_VERSION=\"v2.12\"\n", true},
+		// even two patch-pinned assignments are an ambiguous single-source — reject.
+		{"duplicate, both patch-pinned", "GOLANGCI_LINT_VERSION=\"v2.11.4\"\nGOLANGCI_LINT_VERSION=\"v2.11.5\"\n", true},
+		// a non-version garbage value is still a (rejected) declaration, not skipped.
+		{"single garbage value", "GOLANGCI_LINT_VERSION=\"latest\"\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGolangCILintPatchPinned([]byte(tt.body))
+			if tt.wantErr {
+				require.Error(t, err, "expected validation error for %q", tt.body)
+			} else {
+				require.NoError(t, err, "expected validation pass for %q", tt.body)
+			}
+		})
+	}
 }
 
 func TestWorkflowExternalUsesPinnedToSHA(t *testing.T) {

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -361,6 +361,66 @@ updates:
 		"a typo in the asserted `groups` field must red the guard, not pass silently")
 }
 
+// TestDependabotCoversCIAndGolangCILintAcceptsDirectoriesList locks the guard's
+// support for dependabot's plural `directories:` list form. dependabot natively
+// supports both singular `directory:` (one dir) and plural `directories:` (a
+// list / glob); the real .github/dependabot.yml uses the plural form for its
+// gomod block to cover the workspace's many sub-modules. The guard must detect
+// root ("/") coverage in EITHER form — modeling only `directory:` made the
+// gomod root check silently fail (#2113). Anti-vacuity companion below proves
+// the plural path is not a tautology.
+//
+// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01 — plural directories list form.
+func TestDependabotCoversCIAndGolangCILintAcceptsDirectoriesList(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci/golangci-lint-action"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/tools"
+    schedule:
+      interval: "weekly"
+`)
+	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body),
+		"plural `directories:` list containing / must satisfy the root gomod coverage check")
+}
+
+// TestDependabotCoversCIAndGolangCILintRejectsDirectoriesListWithoutRoot is the
+// anti-vacuity red case for the plural form: a `directories:` list that omits
+// "/" must NOT satisfy the root gomod coverage check, proving the plural-path
+// check tests membership of "/" rather than mere presence of the field.
+//
+// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01 — plural directories without root.
+func TestDependabotCoversCIAndGolangCILintRejectsDirectoriesListWithoutRoot(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci/golangci-lint-action"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/tools"
+      - "/cmd/gocell"
+    schedule:
+      interval: "weekly"
+`)
+	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
+		"a plural `directories:` list without / must not satisfy the root gomod coverage check")
+}
+
 // dependabotConfig models only the fields validateDependabotCoversCIAndGolangCILint
 // asserts on. The decode is intentionally tolerant (no KnownFields(true)):
 // dependabot.yml legitimately grows orchestration fields (ignore /

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -12,7 +12,6 @@
 package archtest
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,12 +29,18 @@ import (
 
 func TestGolangCILintVersionPinnedToPatch(t *testing.T) {
 	root := findModuleRoot(t)
-	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
+	// Since #1565/#2125 golangci-lint runs via the shared funnel — the
+	// golangci-lint-action `version:` input in _build-lint.yml was removed and
+	// the pin now lives solely in hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION
+	// (resolved by gocell::golangci_lint::ensure). That constant is the single
+	// source of the CI lint pin; CI-PINNING-WORKFLOW-DIGEST-01 guards it stays
+	// patch-pinned (not bare major.minor).
+	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, "hack", "lib", "golangci-lint.sh")))
 	require.NoError(t, err)
 
-	re := regexp.MustCompile(`(?m)^\s*version:\s*(v[0-9]+\.[0-9]+(?:\.[0-9]+)?)\s*$`)
+	re := regexp.MustCompile(`(?m)^GOLANGCI_LINT_VERSION="(v[0-9]+\.[0-9]+(?:\.[0-9]+)?)"\s*$`)
 	matches := re.FindStringSubmatch(string(body))
-	require.Len(t, matches, 2, "golangci-lint action version input must be present")
+	require.Len(t, matches, 2, "hack/lib/golangci-lint.sh must declare GOLANGCI_LINT_VERSION")
 	assert.Regexp(t, regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`), matches[1],
 		"golangci-lint must be pinned to patch version, not only major.minor")
 }
@@ -145,56 +150,6 @@ func TestValidateLocalUsesResolveAcceptsExistingTarget(t *testing.T) {
 	require.NoError(t, validateLocalUsesResolve(root, "fixture.yml", body))
 }
 
-func TestGeneratedArtifactGatesAreStructured(t *testing.T) {
-	root := findModuleRoot(t)
-	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
-	require.NoError(t, err)
-
-	require.NoError(t, validateGeneratedArtifactGates(body))
-}
-
-func TestGeneratedArtifactGateRejectsProducerDefinedScope(t *testing.T) {
-	// Fixture: verify-codegen job exists but step uses forbidden producer-defined
-	// scope pattern (git diff, generated_entrypoints, etc.).
-	body := []byte(`jobs:
-  verify-codegen:
-    steps:
-      - name: Verify generated artifacts are up-to-date
-        run: |
-          go run ./cmd/gocell verify generated
-          entrypoints_file="$(mktemp)"
-          go run ./cmd/gocell generate assembly --id "$(basename "$d")"
-          echo "Generated: cmd/corebundle/main.go"
-          generated_entrypoints=()
-          while IFS= read -r entrypoint; do
-            [ -n "$entrypoint" ] || continue
-            generated_entrypoints+=("$entrypoint")
-          done < "$entrypoints_file"
-          diff_paths=(assemblies/)
-          diff_paths+=("${generated_entrypoints[@]}")
-          git diff --exit-code -- "${diff_paths[@]}"
-          git ls-files --others --exclude-standard -- "${generated_entrypoints[@]}"
-          git ls-files --others --exclude-standard assemblies/*/generated/boundary.yaml
-`)
-	require.Error(t, validateGeneratedArtifactGates(body))
-}
-
-func TestGeneratedArtifactGateRejectsLegacyEntrypointGlob(t *testing.T) {
-	// Fixture: verify-codegen job exists but step uses legacy cmd/*/main.go glob.
-	body := []byte(`jobs:
-  verify-codegen:
-    steps:
-      - name: Verify generated artifacts are up-to-date
-        run: |
-          go run ./cmd/gocell verify generated
-          go run ./cmd/gocell generate assembly --id "$(basename "$d")"
-          git diff --exit-code assemblies/ cmd/*/main.go
-          git ls-files --others --exclude-standard cmd/*/main.go
-          git ls-files --others --exclude-standard assemblies/*/generated/boundary.yaml
-`)
-	require.Error(t, validateGeneratedArtifactGates(body))
-}
-
 func TestDependabotCoversCIAndGolangCILint(t *testing.T) {
 	root := findModuleRoot(t)
 	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "dependabot.yml")))
@@ -287,9 +242,8 @@ updates:
 // orchestration fields the guard does not assert on — ignore (with full
 // dependency-name/versions/update-types), open-pull-requests-limit, labels.
 // The validator must check only the coverage invariant (root github-actions
-// covers golangci + root gomod) and stay tolerant of schema growth, matching
-// the other validators in this file (validateGeneratedArtifactGates /
-// validateCodegenJobStructure). A strict KnownFields(true) decode here would
+// covers golangci + root gomod) and stay tolerant of schema growth. A strict
+// KnownFields(true) decode here would
 // red on every new dependabot field while adding nothing to the assertion —
 // that fragility caused #925 (trigger: #911 added `ignore:`). This test
 // prevents a "helpful" reintroduction of strict decode: with strict decode
@@ -428,8 +382,8 @@ updates:
 // does not care about, and strict decode would red on each one while adding
 // nothing to the assertion (a typo in a field the guard *does* read collapses
 // it to its zero value, so the pattern match fails and the guard reds anyway).
-// Matches the tolerant decode in validateGeneratedArtifactGates /
-// validateCodegenJobStructure. See #925.
+// The tolerant-decode contract is locked by the fixtures above
+// (ToleratesUnmodeledFields + RejectsGroupsFieldTypo). See #925.
 type dependabotConfig struct {
 	Updates []dependabotUpdate `yaml:"updates"`
 }
@@ -437,7 +391,20 @@ type dependabotConfig struct {
 type dependabotUpdate struct {
 	PackageEcosystem string                     `yaml:"package-ecosystem"`
 	Directory        string                     `yaml:"directory"`
+	Directories      []string                   `yaml:"directories"`
 	Groups           map[string]dependabotGroup `yaml:"groups"`
+}
+
+// coversRoot reports whether the update targets the repo root ("/"). dependabot
+// natively supports BOTH the singular `directory:` field (one dir — used by the
+// github-actions / docker blocks) and the plural `directories:` list (a list /
+// glob — used by the gomod block to cover the workspace's many sub-modules), so
+// the guard must accept either form. Modeling only `directory:` made the gomod
+// root check silently fail once dependabot.yml moved gomod to the list form
+// (#2113). Both branches are load-bearing — they model dependabot's real schema
+// union, not a legacy/new compat shim.
+func (u dependabotUpdate) coversRoot() bool {
+	return u.Directory == "/" || slices.Contains(u.Directories, "/")
 }
 
 // dependabotGroup deliberately models only Patterns. The guard asks whether a
@@ -459,14 +426,14 @@ func validateDependabotCoversCIAndGolangCILint(body []byte) error {
 	for _, update := range cfg.Updates {
 		switch update.PackageEcosystem {
 		case "github-actions":
-			if update.Directory == "/" {
+			if update.coversRoot() {
 				hasGitHubActions = true
 				if rootGitHubActionsUpdateCoversGolangCI(update) {
 					return validateDependabotHasGoModRoot(cfg)
 				}
 			}
 		case "gomod":
-			if update.Directory == "/" {
+			if update.coversRoot() {
 				hasGoMod = true
 			}
 		}
@@ -491,27 +458,11 @@ func rootGitHubActionsUpdateCoversGolangCI(update dependabotUpdate) bool {
 
 func validateDependabotHasGoModRoot(cfg dependabotConfig) error {
 	for _, update := range cfg.Updates {
-		if update.PackageEcosystem == "gomod" && update.Directory == "/" {
+		if update.PackageEcosystem == "gomod" && update.coversRoot() {
 			return nil
 		}
 	}
 	return fmt.Errorf("dependabot must update Go module pins from directory /")
-}
-
-type workflowConfig struct {
-	Jobs map[string]workflowJob `yaml:"jobs"`
-}
-
-type workflowJob struct {
-	Uses  string         `yaml:"uses"`
-	Steps []workflowStep `yaml:"steps"`
-}
-
-type workflowStep struct {
-	Name string `yaml:"name"`
-	If   string `yaml:"if"`
-	Uses string `yaml:"uses"`
-	Run  string `yaml:"run"`
 }
 
 func validateWorkflowUsesPinned(path string, body []byte) error {
@@ -678,184 +629,4 @@ func dockerDigestPinned(uses string) bool {
 	}
 	digest := rest[at+1:]
 	return regexp.MustCompile(`^sha256:[a-f0-9]{64}$`).MatchString(digest)
-}
-
-func validateGeneratedArtifactGates(body []byte) error {
-	var cfg workflowConfig
-	dec := yaml.NewDecoder(bytes.NewReader(body))
-	if err := dec.Decode(&cfg); err != nil {
-		return fmt.Errorf("parse _build-lint.yml: %w", err)
-	}
-	// After SEC-SETUP-CLOSURE F2, the generated-artifact gate lives in the
-	// independent verify-codegen job, not in build-test.
-	job, ok := cfg.Jobs["verify-codegen"]
-	if !ok {
-		return fmt.Errorf("verify-codegen job missing")
-	}
-	assemblyStep, ok := findWorkflowStep(job.Steps, "Verify generated artifacts are up-to-date")
-	if !ok {
-		return fmt.Errorf("generated artifact gate missing from verify-codegen")
-	}
-	if strings.TrimSpace(assemblyStep.Run) == "" {
-		return fmt.Errorf("generated artifact gate: run block missing")
-	}
-	if !strings.Contains(assemblyStep.Run, "go run ./cmd/gocell verify generated") {
-		return fmt.Errorf("generated artifact gate must call gocell verify generated")
-	}
-	for _, forbidden := range []string{
-		"Generated:",
-		"entrypoints_file",
-		"generated_entrypoints",
-		"go run ./cmd/gocell generate assembly",
-		"go run ./cmd/gocell generate metrics-schema",
-		"git diff",
-		"git ls-files",
-		"cmd/*/main.go",
-		"--boundary-only",
-	} {
-		if strings.Contains(assemblyStep.Run, forbidden) {
-			return fmt.Errorf("generated artifact gate must not contain %q", forbidden)
-		}
-	}
-	return nil
-}
-
-func findWorkflowStep(steps []workflowStep, name string) (workflowStep, bool) {
-	for _, step := range steps {
-		if step.Name == name {
-			return step, true
-		}
-	}
-	return workflowStep{}, false
-}
-
-// --- SEC-SETUP-CLOSURE RED tests (Batch 0, tests 17-18) ---
-// These tests verify that the three codegen verify steps move from build-test
-// into a new independent verify-codegen job (no needs: build-test).
-// They are RED because the workflow currently has all three steps inside
-// build-test, and no verify-codegen job exists yet.
-// After the workflow migration (Batch 1 / Agent-C), they will turn GREEN.
-
-// codegenStepNames are the codegen verify step names that must live in
-// verify-codegen, not in build-test, after the SEC-SETUP-CLOSURE workflow
-// refactor. Adding a new codegen subsystem (K#04 cell, K#06 contract,
-// K#10 assembly, …) means adding the step here so the SEC-SETUP-CLOSURE
-// archtest covers it.
-var codegenStepNames = []string{
-	"Verify generated artifacts are up-to-date",
-	"Verify cell codegen (K#04)",
-	"Verify contract codegen (K#06)",
-	"Verify assembly codegen (K#10)",
-	"Verify shared-schema codegen",
-}
-
-// TestVerifyCodegenJobIsIndependent asserts:
-//  1. jobs.verify-codegen exists in _build-lint.yml
-//  2. jobs.verify-codegen.needs does NOT contain "build-test" (runs in parallel)
-//  3. jobs.build-test does NOT contain any of the three codegen verify steps
-//  4. jobs.verify-codegen contains all three codegen verify steps
-//
-// RED: verify-codegen job does not exist yet; all three steps are in build-test.
-func TestVerifyCodegenJobIsIndependent(t *testing.T) {
-	root := findModuleRoot(t)
-	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "workflows", "_build-lint.yml")))
-	require.NoError(t, err)
-
-	require.NoError(t, validateCodegenJobStructure(body))
-}
-
-// TestVerifyCodegenGateRejectsStepsInBuildTest is a negative-fixture unit test
-// for validateCodegenJobStructure. It verifies the checker correctly flags a
-// workflow where the three steps remain in build-test.
-// This test itself is GREEN (it validates checker logic); the real-workflow
-// assertion above (TestVerifyCodegenJobIsIndependent) is RED.
-func TestVerifyCodegenGateRejectsStepsInBuildTest(t *testing.T) {
-	// Fixture: three codegen steps are still in build-test, no verify-codegen job.
-	body := []byte(`jobs:
-  build-test:
-    steps:
-      - name: Verify generated artifacts are up-to-date
-        if: matrix.static_checks
-        run: go run ./cmd/gocell verify generated
-      - name: Verify cell codegen (K#04)
-        if: matrix.static_checks
-        run: ./hack/verify-codegen-cell.sh
-      - name: Verify contract codegen (K#06)
-        if: matrix.static_checks
-        run: ./hack/verify-codegen-contract.sh
-      - name: Verify assembly codegen (K#10)
-        if: matrix.static_checks
-        run: ./hack/verify-codegen-assembly.sh
-`)
-	require.Error(t, validateCodegenJobStructure(body),
-		"checker must reject when codegen steps are still in build-test")
-}
-
-// workflowJobWithNeeds extends workflowJob with a Needs field for the
-// verify-codegen independence check.
-type workflowJobWithNeeds struct {
-	Needs interface{}    `yaml:"needs"`
-	Steps []workflowStep `yaml:"steps"`
-}
-
-type workflowConfigWithNeeds struct {
-	Jobs map[string]workflowJobWithNeeds `yaml:"jobs"`
-}
-
-// validateCodegenJobStructure enforces the SEC-SETUP-CLOSURE CI split:
-//   - verify-codegen job must exist
-//   - verify-codegen must not depend on build-test (parallel execution)
-//   - build-test must not contain any of the three codegen verify steps
-//   - verify-codegen must contain all three codegen verify steps
-func validateCodegenJobStructure(body []byte) error {
-	var cfg workflowConfigWithNeeds
-	dec := yaml.NewDecoder(bytes.NewReader(body))
-	if err := dec.Decode(&cfg); err != nil {
-		return fmt.Errorf("parse _build-lint.yml: %w", err)
-	}
-
-	// 1. verify-codegen job must exist.
-	vcJob, ok := cfg.Jobs["verify-codegen"]
-	if !ok {
-		return fmt.Errorf("verify-codegen job missing from _build-lint.yml")
-	}
-
-	// 2. verify-codegen must not depend on build-test.
-	if jobNeeds(vcJob.Needs, "build-test") {
-		return fmt.Errorf("verify-codegen must not have needs: build-test (must run in parallel)")
-	}
-
-	// 3. build-test must not contain the three codegen steps.
-	if btJob, hasBT := cfg.Jobs["build-test"]; hasBT {
-		for _, stepName := range codegenStepNames {
-			if _, found := findWorkflowStep(btJob.Steps, stepName); found {
-				return fmt.Errorf("build-test must not contain step %q (must move to verify-codegen)", stepName)
-			}
-		}
-	}
-
-	// 4. verify-codegen must contain all three codegen steps.
-	for _, stepName := range codegenStepNames {
-		if _, found := findWorkflowStep(vcJob.Steps, stepName); !found {
-			return fmt.Errorf("verify-codegen must contain step %q", stepName)
-		}
-	}
-
-	return nil
-}
-
-// jobNeeds reports whether the given needs value (string, []interface{}, or nil)
-// contains the target job name.
-func jobNeeds(needs interface{}, target string) bool {
-	switch v := needs.(type) {
-	case string:
-		return v == target
-	case []interface{}:
-		for _, item := range v {
-			if s, ok := item.(string); ok && s == target {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/tools/archtest/shared_schema_mirror_test.go
+++ b/tools/archtest/shared_schema_mirror_test.go
@@ -52,9 +52,14 @@
 //     allowlist. Validated by TestSHARED_SCHEMA_MIRROR_FUNNEL_01_A2 (production)
 //     and TestSharedSchemaMirror_HeaderlessMatcher_CatchesNonLiteral (matcher).
 //
-//   - ③ CI step "Verify shared-schema codegen" omitted from the verify-codegen
-//     workflow job: covered by ci_pinning_test.go codegenStepNames (the step
-//     name was added there as part of this PR's TDD RED wave).
+//   - ③ Mirror byte-equality gate stops running in CI: covered in-process by
+//     TestSharedSchemaMirrorByteCurrent (SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01),
+//     which runs sharedschema.Verify directly in the archtest process — drift
+//     reds regardless of whether any shell script (hack/verify-codegen-shared-
+//     schema.sh) or workflow step exists. (#1817 deleted the verify-codegen
+//     workflow job that the old ci_pinning_test.go codegenStepNames step-name
+//     lock guarded; #2113 re-anchored this invariant here, strictly stronger.
+//     The shell gate still routes via `# verify-bucket: codegen` for `make verify`.)
 //
 //   - ④ Headerless set via field assignment (var o codegen.WriteOptions;
 //     o.Headerless = true) rather than a composite literal: NOT caught by A2
@@ -169,7 +174,7 @@ func TestSHARED_SCHEMA_MIRROR_FUNNEL_01_A1(t *testing.T) {
 // a stale checked-in JSON file unrepresentable, but the diff is computed in-process
 // every archtest run, so drift cannot pass silently.
 //
-// INVARIANT: SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01
+// INVARIANT: SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01 — in-process byte diff.
 func TestSharedSchemaMirrorByteCurrent(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)

--- a/tools/archtest/shared_schema_mirror_test.go
+++ b/tools/archtest/shared_schema_mirror_test.go
@@ -178,7 +178,10 @@ func TestSHARED_SCHEMA_MIRROR_FUNNEL_01_A1(t *testing.T) {
 func TestSharedSchemaMirrorByteCurrent(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
-	// Anti-vacuity: an empty mirror set would make Verify vacuously pass.
+	// Anti-vacuity: an empty mirror set would make Verify vacuously pass; the
+	// drift-DETECTION logic of sharedschema.Verify (a tampered/missing mirror
+	// reds) is unit-tested in the sharedschema package's TestVerify, so this
+	// archtest is a thin real-repo assertion over that proven behavior.
 	require.NotEmpty(t, sharedschema.Mirrors,
 		"sharedschema.Mirrors must declare at least one mirror, else this guard is vacuous")
 

--- a/tools/archtest/shared_schema_mirror_test.go
+++ b/tools/archtest/shared_schema_mirror_test.go
@@ -154,6 +154,35 @@ func TestSHARED_SCHEMA_MIRROR_FUNNEL_01_A1(t *testing.T) {
 	}
 }
 
+// TestSharedSchemaMirrorByteCurrent asserts every declared shared-schema mirror
+// is byte-identical to its canonical source, by running the in-process verify
+// (sharedschema.Verify) directly inside the archtest process. This closes
+// blind-spot ③ (see package doc): pre-#1817 the only guard that the mirror
+// byte-equality gate "still runs in CI" was the codegenStepNames step-name lock
+// in ci_pinning_test.go; #1817 removed the verify-codegen workflow job, voiding
+// that lock. Re-anchoring byte-equality here makes drift fail in-process —
+// independent of any shell script (hack/verify-codegen-shared-schema.sh) or
+// workflow step existing. Strictly stronger than the old step-name lock.
+//
+// Tool choice: in-process byte diff (Hard) — sharedschema.Verify re-derives each
+// mirror from its canonical source and reports drift; the type system cannot make
+// a stale checked-in JSON file unrepresentable, but the diff is computed in-process
+// every archtest run, so drift cannot pass silently.
+//
+// INVARIANT: SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01
+func TestSharedSchemaMirrorByteCurrent(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	// Anti-vacuity: an empty mirror set would make Verify vacuously pass.
+	require.NotEmpty(t, sharedschema.Mirrors,
+		"sharedschema.Mirrors must declare at least one mirror, else this guard is vacuous")
+
+	drifted, err := sharedschema.Verify(root)
+	require.NoError(t, err, "sharedschema.Verify must run without error")
+	require.Empty(t, drifted,
+		"shared-schema mirrors drifted from canonical source; regenerate via shared-schema codegen")
+}
+
 // TestSHARED_SCHEMA_MIRROR_FUNNEL_01_A2 (caller-allowlist) asserts that every
 // production composite literal that sets the codegen.WriteOptions Headerless
 // field (any value) lives in package tools/codegen/sharedschema and nowhere

--- a/tools/archtest/shared_schema_mirror_test.go
+++ b/tools/archtest/shared_schema_mirror_test.go
@@ -169,12 +169,17 @@ func TestSHARED_SCHEMA_MIRROR_FUNNEL_01_A1(t *testing.T) {
 // independent of any shell script (hack/verify-codegen-shared-schema.sh) or
 // workflow step existing. Strictly stronger than the old step-name lock.
 //
-// Tool choice: in-process byte diff (Hard) — sharedschema.Verify re-derives each
-// mirror from its canonical source and reports drift; the type system cannot make
-// a stale checked-in JSON file unrepresentable, but the diff is computed in-process
-// every archtest run, so drift cannot pass silently.
+// Tool choice: in-process byte diff (Medium) — sharedschema.Verify re-derives
+// each mirror from its canonical source and reports drift. Grade is Medium, not
+// Hard: a stale checked-in JSON file IS representable; the drift is caught by a
+// CI/runtime guard, which is the ai-robust.md Medium tier ("违反可表达，但 CI 中
+// 由 type-aware scan 或 runtime guard 抓住"). It is strictly stronger than the
+// deleted codegenStepNames step-name lock — the diff runs in-process every
+// archtest run, independent of any workflow step existing — but "stronger than a
+// Soft step-name lock" is still Medium. This is consistent with the funnel's
+// composite Medium (package doc line 83-84) and the ADR §"为何不能评 Hard".
 //
-// INVARIANT: SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01 — in-process byte diff.
+// INVARIANT: SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01 — in-process byte diff (Medium).
 func TestSharedSchemaMirrorByteCurrent(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)


### PR DESCRIPTION
## Summary

收敛 full archtest 暴露的 4 处 CI-pinning / dependabot 治理漂移：让过时的 archtest 不变量服从 #1817/#1565 后的 workflow/dependabot/funnel 现状（archtest 错、现状对），并把 shared-schema 镜像字节守卫从已删 step-name 锁迁为 in-process Medium backstop（runtime guard）。

## Why / 背景

2026-06-14 full archtest 暴露 archtest 不变量与现状冲突。两类根因都是 **archtest 过时、被测文件正确**，故采用 issue 的 "Thorough" 方向（对齐单源），**否决** "Minimal"（回改正确的现状文件会重新引入 #1817 刻意删除的 dual-path、并把 dependabot 退回笨重的逐块单数写法）。

| 失败/漂移 | 根因 | 处置 |
|---|---|---|
| `TestDependabotCoversCIAndGolangCILint` | 解析器只认单数 `directory:`，但真实 gomod 块用复数 `directories:`（覆盖 `/`+14 子模块） | 解析器认两种形式（`coversRoot()`） |
| `TestGeneratedArtifactGatesAreStructured` / `TestVerifyCodegenJobIsIndependent` | 期望 `_build-lint.yml` 有 `verify-codegen` job——#1817 已**有意删除**，codegen gate 改由 `make verify` bucket 唯一拥有 | 删两失效不变量 + 全部孤立 helper/类型 |
| `TestGolangCILintVersionPinnedToPatch`（**实施中发现的第 4 处**，同 `CI-PINNING-WORKFLOW-DIGEST-01` 不变量） | #1565/#2125 移除了 `golangci-lint-action` 的 `version:` 输入，pin 迁至 `hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION` | 测试重指向真实单源（patch 锁守卫语义保留并真正生效） |

> **第 4 处为实施中发现的范围扩展**：issue 仅列前 3 处，但第 4 处是**同一文件、同一 `CI-PINNING-WORKFLOW-DIGEST-01` 不变量、同一根因类**（archtest 滞后于 workflow 重构），且 issue 的验收命令 `gocell verify archtest` 要求 ci_pinning 区域全绿。按"彻底"原则纳入并在此显式说明，非静默扩张。

**blind-spot ③ 闭合（Medium backstop，非 Hard 升档 — 见 PR #2158 F5 修正）**：纯删除会留 blind-spot ③ 二阶盲区。改为**闭合**——新增 in-process Medium `TestSharedSchemaMirrorByteCurrent`（`SHARED-SCHEMA-MIRROR-BYTE-CURRENT-01`）直跑 `sharedschema.Verify` 做字节 diff，drift 不依赖任何 shell/workflow step 存在，**严于**已删的 `codegenStepNames` step-name 锁——但 in-process runtime guard（stale JSON 可表达、CI 内抓住）按 ai-robust rubric 仍是 **Medium**，非 Hard。`DEPENDABOT-COVERAGE-GOLANGCI-01` 保持 Medium 并补复数 `directories:` 正/负反空洞 fixture。

**L3 概念同步**（ADR amendment 须同改冲突段）：2 个 ADR 威胁矩阵行（`202605061600` / `202605250900`）+ `hack/lib/golangci-lint.sh` sync-comment #1 重指向 bucket 机制 / 新 Hard 守卫。

预期结果：`gocell verify archtest` 的 CI-pinning / DEPENDABOT / SHARED-SCHEMA 不变量全绿；codegen gate 覆盖与 Go module pin 覆盖各由唯一机制守卫。

## Refs

- Closes #2113
- 关联：#1817（删 verify-codegen job + bucket 并行）、#1565/#2125（framework module 拆分 + golangci-lint funnel 化）
- ADR：`docs/architecture/202606111200-1817-...`、`202605061600-...`、`202605250900-...`
- ref: kubernetes `hack/verify-*.sh` glob-discovery 单源模型（#1817 即依此重构）

## Risk / 兼容性

无生产代码改动——仅 archtest 测试（behind `//go:build archtest`，nightly bucket，无 PR-time CI 影响）+ 1 个 shell 注释 + 2 个 ADR 段。golangci-lint 的 patch 锁语义**完整保留**（仅守卫位置从已删的 workflow 输入迁到真实单源 `GOLANGCI_LINT_VERSION`）。`_build-lint.yml` 现状正确不改；`.github/dependabot.yml` 仅加一段注释（F1/#2160：讲死 golangci-lint group 守的是幽灵 action、真实 pin 是 manual bump、非本 PR 合并门槛），不动 group/pattern 本体。

## Test plan

- [x] `go build ./...`（root go.work 上下文，无生产代码变更）
- [x] `go test -tags=archtest ...`：4 处修复 + 2 个新守卫 + 三个被改文件全部 test 函数 GREEN（含 ci_integration / shared-schema funnel A1/A2）
- [x] `golangci-lint run --build-tags=archtest ./tools/archtest/...` 0 issues
- [x] `shellcheck hack/lib/golangci-lint.sh` clean
- [x] RED→GREEN 两阶段提交（先红后绿）


