### PR TITLE
refactor(loader): 合并 satellite-aware loader 到 packagesload + OBS-01 覆盖 satellite [#2147]

### DIFF
--- a/tools/archtest/internal/typeseval/typeseval.go
+++ b/tools/archtest/internal/typeseval/typeseval.go
@@ -30,8 +30,6 @@ import (
 	"go/ast"
 	"go/constant"
 	"go/types"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -39,7 +37,6 @@ import (
 	"golang.org/x/tools/go/packages"
 
 	"github.com/ghbvf/gocell/tools/packagesload"
-	"github.com/ghbvf/gocell/tools/workspace"
 )
 
 // EvaluateConstString returns the compile-time string constant value of expr,
@@ -123,38 +120,27 @@ func LoadPackages(modRoot string, tests bool, tags []string, patterns ...string)
 }
 
 // loadPackagesMode is the shared body of LoadPackages; mode selects the GOWORK
-// semantics (see tools/packagesload). ModeWorkspace is used only by the
-// cross-module workspace production scan.
+// semantics (see tools/packagesload). The ModeModule path routes through the shared
+// satellite-aware loader packagesload.LoadWorkspace, which expands multi-member
+// satellite parent-prefixes ("./cmd/...", "./adapters/...", "./examples/...") to
+// their go.work members so they are actually scanned (the grouping logic this used
+// to carry inline, consolidated into the single sanctioned loader — #2147).
+// ModeWorkspace is the cross-module production scan, loaded flat from the root
+// without parent-prefix expansion.
 func loadPackagesMode(
 	mode packagesload.Mode, dir string, tests bool, tags []string, patterns ...string,
 ) ([]*packages.Package, []packages.Error, error) {
-	if mode == packagesload.ModeModule {
-		if groups, rootPatterns, ok := workspacePatternGroups(dir, patterns); ok {
-			// A span across multiple member modules, OR a single group that IS the
-			// workspace root (parent-of-member / root-level patterns), must load
-			// from the root in ModeWorkspace using rootPatterns — where unanchored
-			// "./parent/..." patterns have been translated to import-path form
-			// (post-#1565 the root has no module to anchor a relative dir pattern).
-			if len(groups) > 1 || (len(groups) == 1 && groups[0].dir == dir) {
-				return loadPackageGroups(
-					packagesload.ModeWorkspace,
-					tests,
-					tags,
-					[]patternGroup{{dir: dir, patterns: rootPatterns}},
-				)
-			}
-			return loadPackageGroups(mode, tests, tags, groups)
-		}
-	}
-	cfg := &packages.Config{
-		Mode:  loadMode,
-		Dir:   dir,
-		Tests: tests,
-	}
+	cfg := packages.Config{Mode: loadMode, Tests: tests}
 	if len(tags) > 0 {
 		cfg.BuildFlags = []string{"-tags=" + strings.Join(tags, ",")}
 	}
-	pkgs, err := packagesload.Load(mode, cfg, patterns...)
+	if mode == packagesload.ModeModule {
+		return packagesload.LoadWorkspace(dir, cfg, patterns...)
+	}
+	// Explicit ModeWorkspace: the cross-module workspace production scan loads flat
+	// from the root (no satellite parent-prefix expansion).
+	cfg.Dir = dir
+	pkgs, err := packagesload.Load(mode, &cfg, patterns...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("packages.Load: %w", err)
 	}
@@ -166,187 +152,6 @@ func loadPackagesMode(
 		errs = append(errs, p.Errors...)
 	})
 	return pkgs, errs, nil
-}
-
-type patternGroup struct {
-	dir      string
-	patterns []string
-}
-
-func loadPackageGroups(
-	mode packagesload.Mode, tests bool, tags []string, groups []patternGroup,
-) ([]*packages.Package, []packages.Error, error) {
-	var all []*packages.Package
-	var allErrs []packages.Error
-	for _, g := range groups {
-		cfg := &packages.Config{
-			Mode:  loadMode,
-			Dir:   g.dir,
-			Tests: tests,
-		}
-		if len(tags) > 0 {
-			cfg.BuildFlags = []string{"-tags=" + strings.Join(tags, ",")}
-		}
-		pkgs, err := packagesload.Load(mode, cfg, g.patterns...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("packages.Load: %w", err)
-		}
-		packages.Visit(pkgs, nil, func(p *packages.Package) {
-			for i := range p.Errors {
-				p.Errors[i].Msg = g.dir + ": " + p.Errors[i].Msg
-			}
-			allErrs = append(allErrs, p.Errors...)
-		})
-		all = append(all, pkgs...)
-	}
-	return all, allErrs, nil
-}
-
-// workspacePatternGroups returns, for a go.work workspace at root: (1) the
-// per-member pattern groups (each loaded in module mode), and (2) rootPatterns —
-// the equivalent flat pattern list for a single ModeWorkspace load FROM the root,
-// in which any "./parent/..." pattern that spans multiple members (no single
-// member owns it) is rewritten to its import-path form so workspace mode resolves
-// it without a root module to anchor the relative dir.
-func workspacePatternGroups(root string, patterns []string) ([]patternGroup, []string, bool) {
-	if _, err := os.Stat(filepath.Join(root, "go.work")); err != nil {
-		return nil, nil, false
-	}
-	mods, err := workspace.Modules(root)
-	if err != nil {
-		return nil, nil, false
-	}
-	// Expand satellite parent-prefixes ("./cmd/...", "./adapters/...",
-	// "./examples/...") that span multiple members into their per-member patterns
-	// so the satellite packages are ACTUALLY scanned. Without this a pattern no
-	// single member owns hits splitWorkspacePattern's skip and match-zeroes —
-	// silently dropping the ./cmd/… ./adapters/… ./examples/… coverage that
-	// security/governance archtest rules declare over those satellites (#1565
-	// fidelity, F5). A prefix with zero members under it still falls through to
-	// the skip (genuine match-zero).
-	expanded := make([]string, 0, len(patterns))
-	for _, p := range patterns {
-		if parts, ok := workspace.ExpandParentPrefix(mods, p); ok {
-			expanded = append(expanded, parts...)
-		} else {
-			expanded = append(expanded, p)
-		}
-	}
-	patterns = expanded
-	groups := make([]patternGroup, 0, len(mods))
-	groupByDir := map[string]int{}
-	add := func(dir, pattern string) {
-		if i, ok := groupByDir[dir]; ok {
-			groups[i].patterns = append(groups[i].patterns, pattern)
-			return
-		}
-		groupByDir[dir] = len(groups)
-		groups = append(groups, patternGroup{dir: dir, patterns: []string{pattern}})
-	}
-	rootPatterns := make([]string, 0, len(patterns))
-	for _, pattern := range patterns {
-		moduleDir, modulePattern := splitWorkspacePattern(mods, pattern)
-		if moduleDir == skipPatternDir {
-			// Unmatched satellite parent-prefix ("./cmd/...", "./adapters/...") —
-			// drop it so it match-zeroes (see splitWorkspacePattern).
-			continue
-		}
-		add(filepath.Join(root, moduleDir), modulePattern)
-		if moduleDir == "." {
-			// No member owns the pattern: use the member-relative form for the
-			// root-anchored ModeWorkspace load.
-			rootPatterns = append(rootPatterns, modulePattern)
-		} else {
-			// Into-member relative pattern resolves from the root in workspace mode.
-			rootPatterns = append(rootPatterns, pattern)
-		}
-	}
-	return groups, rootPatterns, true
-}
-
-// frameworkModuleDir is the workspace-relative dir of the core framework module
-// (kernel/runtime/pkg) since the #1565 split — the successor to the pre-split root
-// module that "." / "./..." referred to.
-const frameworkModuleDir = "framework"
-
-// skipPatternDir is the sentinel member-dir splitWorkspacePattern returns for a
-// root-relative parent prefix that no workspace member owns AND that has no member
-// living under it — a genuine empty match (e.g. a typo "./nonexistent/..."). Real
-// multi-member satellite prefixes ("./cmd/...", "./adapters/...", "./examples/...")
-// are expanded to their members by workspacePatternGroups BEFORE split is called
-// (workspace.ExpandParentPrefix), so they are actually scanned, never silently
-// skipped (F5, SATELLITE-PARENT-PREFIX-SCAN-01). workspacePatternGroups drops a
-// skipPatternDir pattern so it match-zeroes. The NUL byte cannot occur in a real
-// dir, so it is unambiguous.
-const skipPatternDir = "\x00skip-no-member"
-
-func splitWorkspacePattern(mods []workspace.Module, pattern string) (string, string) {
-	// "." / "./..." referred to the pre-#1565 ROOT module — the platform CORE
-	// (kernel/runtime/pkg at the repo root). The core moved to ./framework, so map
-	// the bare-root patterns onto the framework member, preserving "scan the
-	// platform core" semantics.
-	if (pattern == "." || pattern == "./...") && hasFrameworkMember(mods) {
-		return frameworkModuleDir, pattern
-	}
-	if dir, modulePattern, ok := matchWorkspaceMember(mods, pattern); ok {
-		return dir, modulePattern
-	}
-	// No member matched a root-relative parent prefix. Multi-member satellite
-	// prefixes ("./cmd/...", "./adapters/...", "./examples/...") are already expanded
-	// to their owning members upstream in workspacePatternGroups
-	// (workspace.ExpandParentPrefix), so they are scanned, not skipped (F5). Reaching
-	// here means the prefix has NO member under it at all — a genuine empty match
-	// (e.g. a typo "./nonexistent/..."). Signal SKIP: workspacePatternGroups drops the
-	// pattern entirely (→ match-zero). A member that matched but whose subdir is
-	// missing (e.g. "./tools/.../nonexistent/...") took the matched branch above and is
-	// NOT skipped — it loads and surfaces a packages.Error, preserving typo
-	// diagnostics. Only skip when a framework core member exists (the real post-#1565
-	// workspace); a synthetic single-module set falls through to the root-anchored
-	// (".") form so its in-module subtrees still load.
-	if strings.HasPrefix(pattern, "./") && hasFrameworkMember(mods) {
-		return skipPatternDir, ""
-	}
-	return ".", pattern
-}
-
-// hasFrameworkMember reports whether the workspace contains the core framework
-// module (the post-#1565 successor to the root "." module).
-func hasFrameworkMember(mods []workspace.Module) bool {
-	for _, m := range mods {
-		if filepath.ToSlash(filepath.Clean(m.Dir)) == frameworkModuleDir {
-			return true
-		}
-	}
-	return false
-}
-
-// matchWorkspaceMember finds the workspace member that owns pattern (longest dir /
-// import-path prefix wins), returning (member-dir, member-relative pattern, true).
-// ok is false when no member owns the pattern.
-func matchWorkspaceMember(mods []workspace.Module, pattern string) (string, string, bool) {
-	bestDir, bestPattern, bestScore := "", "", -1
-	consider := func(score int, dir, modulePattern string) {
-		if score > bestScore {
-			bestScore, bestDir, bestPattern = score, dir, modulePattern
-		}
-	}
-	for _, m := range mods {
-		dir := filepath.ToSlash(filepath.Clean(m.Dir))
-		if dir == "." || dir == "" {
-			continue
-		}
-		prefix := "./" + dir
-		switch {
-		case pattern == prefix:
-			consider(len(dir), dir, ".")
-		case strings.HasPrefix(pattern, prefix+"/"):
-			consider(len(dir), dir, "."+strings.TrimPrefix(pattern, prefix))
-		}
-		if pattern == m.ImportPath || strings.HasPrefix(pattern, m.ImportPath+"/") {
-			consider(len(m.ImportPath), dir, pattern)
-		}
-	}
-	return bestDir, bestPattern, bestScore >= 0
 }
 
 var (

--- a/tools/archtest/internal/typeseval/typeseval.go
+++ b/tools/archtest/internal/typeseval/typeseval.go
@@ -111,10 +111,14 @@ const loadMode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
 // the second value so callers can fail fast on type-check errors without
 // re-walking.
 //
-// The cross-module workspace scan ([LoadProductionPackages]) uses the
-// ModeWorkspace variant ([loadPackagesMode]); this single-module form is the one
-// the Typed / Fixture / StandaloneModule scopes route through, and its signature
-// is held stable so the pass / production funnel meta-archtests keep matching it.
+// The cross-module workspace scan ([LoadProductionPackages]) uses the ModeWorkspace
+// variant ([loadPackagesMode]); this ModeModule form is the one the Typed / Fixture /
+// StandaloneModule scopes route through. Its ModeModule path delegates to the shared
+// packagesload.LoadWorkspace, so a satellite parent prefix ("./cmd/...", "./adapters/...",
+// "./examples/...") is expanded to its go.work members and loaded in workspace mode —
+// the single-module name refers to the GOWORK mode requested, not a guarantee that
+// only one module loads. The signature is held stable so the pass / production funnel
+// meta-archtests keep matching it.
 func LoadPackages(modRoot string, tests bool, tags []string, patterns ...string) ([]*packages.Package, []packages.Error, error) {
 	return loadPackagesMode(packagesload.ModeModule, modRoot, tests, tags, patterns...)
 }

--- a/tools/archtest/internal/typeseval/typeseval_test.go
+++ b/tools/archtest/internal/typeseval/typeseval_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/go/packages"
-
-	"github.com/ghbvf/gocell/tools/workspace"
 )
 
 // TestLoadMode_NoNeedDeps guards the #1499 RSS optimization: the shared
@@ -189,41 +187,6 @@ func cacheKey(root string, tests bool, patterns ...string) string {
 		out += p
 	}
 	return out
-}
-
-func TestSplitWorkspacePattern_RoutesKnownSatellite(t *testing.T) {
-	mods := []workspace.Module{
-		{Dir: ".", ImportPath: "github.com/ghbvf/gocell"},
-		{Dir: "tools", ImportPath: "github.com/ghbvf/gocell/tools"},
-	}
-
-	dir, pattern := splitWorkspacePattern(mods, "./tools/archtest/internal/typeseval/...")
-	assert.Equal(t, "tools", dir)
-	assert.Equal(t, "./archtest/internal/typeseval/...", pattern)
-
-	dir, pattern = splitWorkspacePattern(mods, "./framework/pkg/...")
-	assert.Equal(t, ".", dir)
-	assert.Equal(t, "./framework/pkg/...", pattern)
-
-	dir, pattern = splitWorkspacePattern(mods, "github.com/ghbvf/gocell/tools/archtest/internal/scanner")
-	assert.Equal(t, "tools", dir)
-	assert.Equal(t, "github.com/ghbvf/gocell/tools/archtest/internal/scanner", pattern)
-}
-
-func TestSplitWorkspacePattern_PrefersLongestSatellitePrefix(t *testing.T) {
-	mods := []workspace.Module{
-		{Dir: ".", ImportPath: "github.com/ghbvf/gocell"},
-		{Dir: "tools", ImportPath: "github.com/ghbvf/gocell/tools"},
-		{Dir: "tools/nested", ImportPath: "github.com/ghbvf/gocell/tools/nested"},
-	}
-
-	dir, pattern := splitWorkspacePattern(mods, "./tools/nested/pkg/...")
-	assert.Equal(t, "tools/nested", dir)
-	assert.Equal(t, "./pkg/...", pattern)
-
-	dir, pattern = splitWorkspacePattern(mods, "github.com/ghbvf/gocell/tools/nested/pkg")
-	assert.Equal(t, "tools/nested", dir)
-	assert.Equal(t, "github.com/ghbvf/gocell/tools/nested/pkg", pattern)
 }
 
 func TestLoadPackages_HappyPath(t *testing.T) {

--- a/tools/archtest/outbox_subscriber_settlement_notify_test.go
+++ b/tools/archtest/outbox_subscriber_settlement_notify_test.go
@@ -74,7 +74,7 @@ func scanOutboxSubscriberSettlement(t *testing.T) (implPkgSet, notifyPkgSet map[
 	// adapters/rabbitmq + adapters/mqtt would be invisible to this scan — leaving
 	// the rule vacuous for everything but the in-process eventbus. Hardcode the
 	// satellite parent prefix (the sanctioned opt-in: the typed loader expands it
-	// via workspace.ExpandParentPrefix, kept honest by SATELLITE-PARENT-PREFIX-SCAN-01;
+	// via packagesload.LoadWorkspace, kept honest by SATELLITE-PARENT-PREFIX-SCAN-01;
 	// mirrors health_aggregation_test.go) so all three terminal packages are scanned.
 	ifacePatterns := append([]string{"./framework/kernel/outbox/...", "./adapters/..."}, prodPatterns...)
 

--- a/tools/archtest/satellite_scan_coverage_test.go
+++ b/tools/archtest/satellite_scan_coverage_test.go
@@ -14,8 +14,9 @@
 // Many security/authz funnels — fence-token mint, no-deleted-auth-symbols,
 // credential-invalidate, capability-provider, … — declare coverage over exactly
 // these satellite dirs; with the silent skip they passed VACUOUSLY (scanned
-// nothing in cmd/adapters/examples). tools/workspace.ExpandParentPrefix now
-// expands each prefix to its real members so they are actually loaded.
+// nothing in cmd/adapters/examples). The shared satellite-aware loader
+// packagesload.LoadWorkspace now expands each prefix to its real members so they are
+// actually loaded.
 //
 // This guard loads the prefixes through the SAME typed path the funnels use
 // (Run + Typed) and asserts each prefix yields packages from its member modules.

--- a/tools/internal/prodscan/patterns.go
+++ b/tools/internal/prodscan/patterns.go
@@ -127,10 +127,14 @@ func PatternsExtended(root string) []string {
 //
 // The emitted prefixes are owned by no single go.work member and are loadable ONLY
 // through the shared satellite-aware loader packagesload.LoadWorkspace, which expands
-// each to its real members (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01). Both
-// the OBS-01 metric-PII scan (#2147) and the typeseval duration gates compose this
-// increment onto their respective base scope; do NOT hand the prefixes to a loader
-// that does not go through LoadWorkspace.
+// each to its real members. Both the OBS-01 metric-PII scan (#2147) and the typeseval
+// duration gates compose this increment onto their respective base scope; do NOT hand
+// the prefixes to a loader that does not go through LoadWorkspace — a raw ModeModule
+// load hard-errors and a non-expanding workspace load match-zeroes (silent coverage
+// loss). This "must go through LoadWorkspace" is a Soft (godoc) convention: it is not
+// type-enforced, but the loader's expansion is kept honest by the Medium archtest
+// SATELLITE-PARENT-PREFIX-SCAN-01, which fails if a satellite prefix stops expanding
+// to real members.
 func SatelliteParentPatterns(root string) []string {
 	var patterns []string
 	for _, dir := range topLevelDirs {

--- a/tools/internal/prodscan/patterns.go
+++ b/tools/internal/prodscan/patterns.go
@@ -13,20 +13,20 @@ import (
 //   - a single-module consumer/fixture project (the metricschema OBS-01 fixtures,
 //     a downstream module that vendors gocell).
 //
-// dirExists + IsModuleRoot prune entries that don't apply, and patternLoadMode
-// (in tools/metricschema) routes each surviving pattern to the right load mode, so
-// the EFFECTIVE scan differs per context without a per-context list:
+// dirExists + IsModuleRoot prune entries that don't apply, and the shared
+// satellite-aware loader (packagesload.LoadWorkspace) routes each surviving pattern
+// to the right load mode — expanding a multi-member parent prefix to its members —
+// so the EFFECTIVE scan differs per context without a per-context list:
 //
 //   - Real repo post-#1565: the core lives in the `framework` submodule, so
 //     framework/{kernel,runtime,pkg} match (loaded ModeWorkspace — framework is a
 //     sibling go.work member); the bare kernel/runtime/pkg no longer exist at the
 //     root and are pruned; cmd/adapters/examples each hold SEVERAL go.work member
 //     modules (multi-member parents), so their "./<dir>/…" pattern is owned by no
-//     single member and is pruned by HasNestedModuleRoot from THIS satellite-free
-//     scan (metricschema's OBS-01 loader cannot expand a multi-member prefix). The
-//     typeseval-backed duration gates opt INTO satellite coverage via
-//     PatternsWithSatellites; OBS-01 metric-PII coverage of satellites stays gh
-//     #2136. cellmodules/corecells are module roots → pruned by IsModuleRoot.
+//     single member and is pruned by HasNestedModuleRoot from THIS base scan — it is
+//     re-emitted ONLY by SatelliteParentPatterns, which callers compose in when they
+//     want satellite coverage (the shared loader expands it to the members).
+//     cellmodules/corecells are module roots → pruned by IsModuleRoot.
 //   - Single-module fixture: framework/<layer> doesn't exist (pruned); the bare
 //     cmd/pkg/kernel/runtime the fixture writes ARE part of the one module, so their
 //     "./<dir>/…" pattern matches under ModeModule and is actually scanned.
@@ -48,7 +48,7 @@ var topLevelDirs = []string{
 // governance scanners. Missing top-level directories are skipped so temp-module
 // fixtures can exercise the production entrypoints without synthetic dirs.
 //
-// Two kinds of top-level dir are pruned from this satellite-FREE scan:
+// Two kinds of top-level dir are pruned from this satellite-FREE base scan:
 //
 //   - A go.work satellite MODULE ROOT (carries its own go.mod — e.g. cellmodules/
 //     after #1559, corecells/): a single module addressed by its own member
@@ -56,27 +56,17 @@ var topLevelDirs = []string{
 //   - A MULTI-MEMBER PARENT (cmd/, adapters/, examples/): not a module root itself,
 //     but holding several go.work member modules one level deeper (cmd/gocell +
 //     cmd/corebundle; adapters/postgres …; examples/<id> …). "./cmd/..." is owned by
-//     no single member, so post-#1565 (no root module to anchor it) it would
-//     hard-error or silently match-zero (HasNestedModuleRoot).
+//     no single member (HasNestedModuleRoot).
 //
-// Both are pruned so this PRODUCTION scan stays loadable under metricschema's OBS-01
-// loader, which loads each pattern in ModeModule/ModeWorkspace and does NOT expand a
-// multi-member parent prefix. A single-module fixture writes cmd/pkg/... as part of
-// its ONE module (no nested go.mod), so neither predicate fires there and the
-// fixture's "./cmd/..." is kept and scanned.
-//
-// Rules that DO require satellite coverage opt in through the typed (typeseval)
-// loader, which expands a satellite parent prefix to its real go.work members via
-// workspace.ExpandParentPrefix (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01):
-//
-//   - the broad duration gates (TEST-TIME-LITERAL-01, PROD-DURATION-CONST-01) take
-//     the whole satellite set via PatternsWithSatellites; and
-//   - narrow security/authz funnels (fence-token mint, …) hardcode the specific
-//     satellite patterns they need.
-//
-// Both opt-in paths are independent of THIS list — Patterns deliberately does NOT
-// emit the satellite prefixes, since OBS-01's loader cannot expand them (its own
-// metric-PII coverage of satellites remains gh #2136).
+// Patterns is the conservative BASE: it omits the satellite prefixes so consumers
+// that do not want satellite scope (the bulk of the production scanners) are not
+// silently widened. Widening to satellites is a per-gate opt-in: a caller composes
+// SatelliteParentPatterns onto Patterns (OBS-01) or PatternsExtended
+// (PatternsWithSatellites), and the shared satellite-aware loader
+// (packagesload.LoadWorkspace) expands each parent prefix to its real go.work
+// members before loading. A single-module fixture writes cmd/pkg/... as part of its
+// ONE module (no nested go.mod), so neither predicate fires there, the increment is
+// empty, and the fixture's "./cmd/..." stays in Patterns and is scanned directly.
 func Patterns(root string) []string {
 	var patterns []string
 	if dirHasNonTestGoFiles(root) {
@@ -125,47 +115,24 @@ func PatternsExtended(root string) []string {
 	return base
 }
 
-// PatternsWithSatellites widens PatternsExtended(root) with the multi-member
-// satellite parent prefixes ("./cmd/...", "./adapters/...", "./examples/...") that
-// Patterns deliberately prunes.
+// SatelliteParentPatterns returns the multi-member satellite parent prefixes
+// ("./cmd/...", "./adapters/...", "./examples/...") that Patterns prunes — the
+// single-sourced satellite increment. It is DERIVED from the same
+// HasNestedModuleRoot predicate Patterns prunes on (not a hand-maintained list), so
+// a future fourth multi-member parent is picked up automatically; it re-includes
+// ONLY multi-member parents (plain module-root dirs cellmodules/, corecells/ stay
+// excluded by !IsModuleRoot — they are addressed by their own member pattern, not an
+// expandable parent prefix). A single-module fixture has no nested go.mod, so the
+// increment is EMPTY there.
 //
-// USE FOR typeseval-backed gates ONLY. The emitted satellite prefixes are owned by
-// no single go.work member and can only be loaded by a loader that expands them via
-// workspace.ExpandParentPrefix (tools/archtest's typed façade). Do NOT pass the
-// result to a ModeModule/ModeWorkspace loader that does not expand (e.g. metricschema
-// OBS-01's loadPackages) — it would hard-error or match-zero. Those callers use the
-// satellite-free Patterns / PatternsExtended instead.
-//
-// It is the production-scan source-of-record for the typed (typeseval) duration
-// gates — TEST-TIME-LITERAL-01 and PROD-DURATION-CONST-01 — whose loader's
-// workspace.ExpandParentPrefix expands each satellite parent prefix to its real
-// go.work members before loading (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01).
-// Only that path can actually scan the satellites, so only this constructor emits
-// their prefixes (#2136).
-//
-// Two scan constructors exist, split by LOADER CAPABILITY — not by accident — and
-// they must NOT be merged (doing so re-breaks metricschema):
-//
-//   - Patterns / PatternsExtended (satellite-FREE): consumed by metricschema's
-//     OBS-01 loader, which does NOT expand a multi-member parent prefix; handing it
-//     "./cmd/..." (owned by no single go.work member post-#1565) hard-errors or
-//     match-zeroes, so the satellite parents are pruned there.
-//   - PatternsWithSatellites: consumed only by the typeseval-backed duration gates,
-//     which CAN expand the satellite prefixes.
-//
-// The satellite increment is DERIVED from the same HasNestedModuleRoot predicate
-// Patterns prunes on — not a hand-maintained list — so a future fourth multi-member
-// parent is picked up automatically. It re-includes ONLY multi-member parents:
-// plain module-root dirs (cellmodules/, corecells/) stay excluded by !IsModuleRoot,
-// since they are not expandable parent prefixes (their satellite coverage is gh
-// #2136, a separate concern). A single-module fixture has no nested go.mod, so the
-// increment is empty there and this equals PatternsExtended.
-//
-// Do NOT fold the satellite prefixes into PatternsExtended itself: its other
-// consumers (e.g. errcode_invariants) would then silently gain unreviewed satellite
-// scope. Widening to satellites is a per-gate opt-in by name, not a global default.
-func PatternsWithSatellites(root string) []string {
-	patterns := PatternsExtended(root)
+// The emitted prefixes are owned by no single go.work member and are loadable ONLY
+// through the shared satellite-aware loader packagesload.LoadWorkspace, which expands
+// each to its real members (kept honest by SATELLITE-PARENT-PREFIX-SCAN-01). Both
+// the OBS-01 metric-PII scan (#2147) and the typeseval duration gates compose this
+// increment onto their respective base scope; do NOT hand the prefixes to a loader
+// that does not go through LoadWorkspace.
+func SatelliteParentPatterns(root string) []string {
+	var patterns []string
 	for _, dir := range topLevelDirs {
 		full := filepath.Join(root, dir)
 		if dirExists(full) && !IsModuleRoot(full) && HasNestedModuleRoot(full) {
@@ -175,6 +142,27 @@ func PatternsWithSatellites(root string) []string {
 	return patterns
 }
 
+// PatternsWithSatellites widens PatternsExtended(root) — Patterns plus tests/ and
+// tools/ — with the multi-member satellite parent prefixes (SatelliteParentPatterns).
+// It is the production-scan source-of-record for the typeseval-backed duration gates
+// (TEST-TIME-LITERAL-01, PROD-DURATION-CONST-01), whose broad invariant covers
+// production + test/tool support packages + satellites.
+//
+// Two satellite-bearing scopes exist, split by BASE (not loader capability — since
+// #2147 both load through the same packagesload.LoadWorkspace expander):
+//
+//   - PatternsWithSatellites = PatternsExtended + satellites — the broad duration
+//     gates (production + tests/ + tools/ + satellites).
+//   - OBS-01 = Patterns + satellites — production + satellites, WITHOUT tests/+tools/
+//     (composed in tools/metricschema; OBS-01 never scanned tests/ or tools/).
+//
+// Do NOT fold the satellite prefixes into PatternsExtended itself: its other
+// consumers (e.g. errcode_invariants) would then silently gain unreviewed satellite
+// scope. Widening to satellites is a per-gate opt-in by name, not a global default.
+func PatternsWithSatellites(root string) []string {
+	return append(PatternsExtended(root), SatelliteParentPatterns(root)...)
+}
+
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
@@ -182,10 +170,10 @@ func dirExists(path string) bool {
 
 // IsModuleRoot reports whether dir carries its own go.mod (a go.work satellite
 // module root). Such dirs are unaddressable by root-relative patterns under
-// ModeModule (GOWORK=off) and are skipped by Patterns / PatternsExtended — see
-// the Patterns godoc + gh #2136. Exported so coverage guards that must stay
-// symmetric with the scan set (e.g. metricschema's productionGoTopLevels) share
-// this single source of truth rather than re-deriving the go.mod check.
+// ModeModule (GOWORK=off) and are skipped by Patterns / PatternsExtended — see the
+// Patterns godoc. Exported so coverage guards that must stay symmetric with the scan
+// set (e.g. metricschema's productionGoTopLevels) share this single source of truth
+// rather than re-deriving the go.mod check.
 func IsModuleRoot(dir string) bool {
 	info, err := os.Stat(filepath.Join(dir, "go.mod"))
 	return err == nil && !info.IsDir()
@@ -195,13 +183,15 @@ func IsModuleRoot(dir string) bool {
 // itself a module root, but at least one immediate subdirectory carries a go.mod
 // (a go.work member). cmd/ (over cmd/gocell, cmd/corebundle), adapters/ (over
 // adapters/postgres …), and examples/ (over examples/<id> …) are the post-#1565
-// instances. A root-relative "./<dir>/..." pattern over such a parent is owned by
-// no single member and cannot be loaded as a ModeModule pattern (no root module to
-// anchor it); its production-scan coverage is deferred to gh #2136. Patterns skips
-// these dirs and the OBS-01 coverage guard (metricschema's productionGoTopLevels)
-// must skip them symmetrically — exported so both share this single source rather
-// than re-deriving the nested-go.mod check. A single-module fixture has no nested
-// go.mod under cmd/pkg/…, so this is false there and the fixture dir is kept.
+// instances. A root-relative "./<dir>/..." pattern over such a parent is owned by no
+// single member and cannot be loaded as a plain ModeModule pattern; Patterns prunes
+// it from the base scope, and SatelliteParentPatterns re-emits it for callers that
+// opt into satellite coverage, where packagesload.LoadWorkspace expands it to the
+// members (#2147). Exported so the satellite increment and the OBS-01 coverage guard
+// (metricschema's productionGoTopLevels, which now REQUIRES these parents) share this
+// single source rather than re-deriving the nested-go.mod check. A single-module
+// fixture has no nested go.mod under cmd/pkg/…, so this is false there and the fixture
+// dir is kept in Patterns directly.
 func HasNestedModuleRoot(dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/tools/internal/prodscan/patterns_test.go
+++ b/tools/internal/prodscan/patterns_test.go
@@ -133,6 +133,64 @@ func TestPatternsWithSatellites(t *testing.T) {
 	})
 }
 
+// TestSatelliteParentPatterns covers the single-sourced satellite increment (#2147)
+// that both PatternsWithSatellites and the OBS-01 scan compose onto their base.
+func TestSatelliteParentPatterns(t *testing.T) {
+	t.Run("real workspace yields exactly the multi-member parents", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"framework/kernel/k.go":    "package kernel\n",
+			"cmd/gocell/go.mod":        "module x/cmd/gocell\n",
+			"cmd/gocell/main.go":       "package main\n",
+			"adapters/postgres/go.mod": "module x/adapters/postgres\n",
+			"adapters/postgres/pg.go":  "package postgres\n",
+			"examples/iot/go.mod":      "module x/examples/iot\n",
+			"examples/iot/main.go":     "package main\n",
+			// cellmodules is a plain module root (own go.mod, no nested member) — it
+			// is NOT a satellite parent and must be excluded by !IsModuleRoot.
+			"cellmodules/go.mod": "module x/cellmodules\n",
+			"cellmodules/m.go":   "package cellmodules\n",
+			// tests/ + tools/ are PatternsExtended-only scope, never satellites.
+			"tests/e2e/e.go": "package e2e\n",
+			"tools/t/t.go":   "package t\n",
+		})
+		got := SatelliteParentPatterns(root)
+		gotSet := map[string]bool{}
+		for _, p := range got {
+			gotSet[p] = true
+		}
+		for _, want := range []string{"./cmd/...", "./adapters/...", "./examples/..."} {
+			if !gotSet[want] {
+				t.Errorf("SatelliteParentPatterns missing %q; got %v", want, got)
+			}
+		}
+		if len(got) != 3 {
+			t.Errorf("SatelliteParentPatterns = %v, want exactly the 3 multi-member parents "+
+				"(no framework/cellmodules/tests/tools)", got)
+		}
+		// OBS-01 composition = Patterns + increment, and must NOT pull in tests/ or
+		// tools/ (PatternsExtended scope) — the split is by base, not loader capability.
+		obs01 := map[string]bool{}
+		for _, p := range append(Patterns(root), SatelliteParentPatterns(root)...) {
+			obs01[p] = true
+		}
+		for _, forbidden := range []string{"./tests/...", "./tools/..."} {
+			if obs01[forbidden] {
+				t.Errorf("OBS-01 composition (Patterns + satellites) must exclude %q", forbidden)
+			}
+		}
+	})
+
+	t.Run("single-module fixture yields nothing", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"go.mod":      "module x\n",
+			"cmd/main.go": "package main\n",
+		})
+		if got := SatelliteParentPatterns(root); len(got) != 0 {
+			t.Errorf("SatelliteParentPatterns on single-module fixture = %v, want empty", got)
+		}
+	})
+}
+
 // TestPatternsKeepsSingleModuleFixtureDirs proves the prune is real-workspace-only:
 // a single-module fixture writes cmd/pkg/... as part of its ONE module (no nested
 // go.mod), so those dirs stay scannable.

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -234,23 +234,52 @@ func Marshal(schema *Schema) ([]byte, error) {
 	return append([]byte(header), body...), nil
 }
 
+// loadPackages loads the OBS-01 production scan patterns through the shared
+// satellite-aware loader packagesload.LoadWorkspace, which expands the multi-member
+// satellite parent-prefixes obs01ProductionPatterns now emits ("./cmd/...",
+// "./adapters/...", "./examples/...") to their go.work members so OBS-01 scans
+// satellite production code (#2147). It keeps only this project's packages
+// (packageHasProjectFile), deduped by import path (preferring the syntax-rich copy),
+// and fails closed on any load error.
 func loadPackages(ctx context.Context, root string, patterns ...string) ([]*packages.Package, error) {
-	return loadPackagesWithMode(ctx, root, false, packagesload.ModeModule, patterns...)
-}
-
-func loadReachablePackages(ctx context.Context, root string, mode packagesload.Mode, patterns ...string) ([]*packages.Package, error) {
-	return loadPackagesWithMode(ctx, root, true, mode, patterns...)
-}
-
-func loadPackagesWithMode(
-	ctx context.Context, root string, includeDeps bool, mode packagesload.Mode, patterns ...string,
-) ([]*packages.Package, error) {
-	if !includeDeps && len(patterns) > 1 {
-		return loadPatternScopedPackages(ctx, root, patterns...)
+	cfg := packages.Config{Context: ctx, Mode: packageLoadMode(false)}
+	pkgs, loadErrs, err := packagesload.LoadWorkspace(root, cfg, patterns...)
+	if err != nil {
+		return nil, err
 	}
+	if len(loadErrs) > 0 {
+		return nil, fmt.Errorf("packages.Load: %d error(s): first=%w", len(loadErrs), loadErrs[0])
+	}
+	byPath := map[string]*packages.Package{}
+	var paths []string
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		if !packageHasProjectFile(root, p) {
+			return
+		}
+		if _, ok := byPath[p.PkgPath]; !ok {
+			paths = append(paths, p.PkgPath)
+		}
+		if existing := byPath[p.PkgPath]; existing == nil || len(existing.Syntax) == 0 {
+			byPath[p.PkgPath] = p
+		}
+	})
+	sort.Strings(paths)
+	out := make([]*packages.Package, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, byPath[path])
+	}
+	return out, nil
+}
+
+// loadReachablePackages loads the reachable closure of a single assembly entrypoint
+// for Build's metric-schema generation. This is the cross-module REACHABILITY path
+// (NeedDeps, whole-graph ModeWorkspace when the entrypoint lives in a satellite
+// module — see Build/containingModuleDir), distinct from loadPackages' per-member
+// satellite SCAN grouping; it deliberately does NOT route through LoadWorkspace.
+func loadReachablePackages(ctx context.Context, root string, mode packagesload.Mode, patterns ...string) ([]*packages.Package, error) {
 	cfg := &packages.Config{
 		Context: ctx,
-		Mode:    packageLoadMode(includeDeps),
+		Mode:    packageLoadMode(true),
 		Dir:     root,
 	}
 	// mode is ModeModule (GOWORK=off, go.work-agnostic) for root-module assemblies
@@ -271,65 +300,6 @@ func loadPackagesWithMode(
 		return nil, fmt.Errorf("packages.Load: %d error(s): first=%w", len(loadErrs), loadErrs[0])
 	}
 	return out, nil
-}
-
-// patternLoadMode returns the Mode to use for a single go-packages pattern
-// rooted at root. Post-#1565 the repo root has no go.mod; patterns that address
-// a sub-module with its own go.mod (e.g. "./framework/kernel/...") must use
-// ModeWorkspace so the framework workspace member is visible. Patterns that do
-// NOT live under a sub-module root (e.g. "./cmd/...", "./adapters/...") still
-// use ModeModule: under ModeWorkspace they would fail because "cmd" is not a
-// workspace member, whereas ModeModule silently skips them (match-zero).
-func patternLoadMode(root, pattern string) packagesload.Mode {
-	// Strip the leading "./" and trailing "/..." to get the directory segment.
-	rel := strings.TrimPrefix(pattern, "./")
-	rel = strings.TrimSuffix(rel, "/...")
-	// Use only the top-level directory component to find the module root.
-	if idx := strings.IndexByte(rel, '/'); idx >= 0 {
-		rel = rel[:idx]
-	}
-	if rel == "" || rel == "." {
-		return packagesload.ModeModule
-	}
-	if prodscan.IsModuleRoot(filepath.Join(root, rel)) {
-		return packagesload.ModeWorkspace
-	}
-	return packagesload.ModeModule
-}
-
-func loadPatternScopedPackages(ctx context.Context, root string, patterns ...string) ([]*packages.Package, error) {
-	byPath := map[string]*packages.Package{}
-	var paths []string
-	for _, pattern := range patterns {
-		mode := patternLoadMode(root, pattern)
-		pkgs, err := loadPackagesWithMode(ctx, root, false, mode, pattern)
-		if err != nil {
-			return nil, err
-		}
-		paths = mergeLoadedPackages(byPath, paths, pkgs)
-	}
-	sort.Strings(paths)
-	out := make([]*packages.Package, 0, len(paths))
-	for _, path := range paths {
-		out = append(out, byPath[path])
-	}
-	return out, nil
-}
-
-func mergeLoadedPackages(
-	byPath map[string]*packages.Package,
-	paths []string,
-	pkgs []*packages.Package,
-) []string {
-	for _, p := range pkgs {
-		if _, ok := byPath[p.PkgPath]; !ok {
-			paths = append(paths, p.PkgPath)
-		}
-		if existing := byPath[p.PkgPath]; existing == nil || len(existing.Syntax) == 0 {
-			byPath[p.PkgPath] = p
-		}
-	}
-	return paths
 }
 
 func packageLoadMode(includeDeps bool) packages.LoadMode {
@@ -2000,8 +1970,14 @@ func checkOBS01WithPatterns(ctx context.Context, projectRoot string, patterns ..
 	return diagnostics, nil
 }
 
+// obs01ProductionPatterns is the OBS-01 production-scan source-of-record: the
+// satellite-free base (prodscan.Patterns) plus the multi-member satellite parent
+// prefixes (cmd/adapters/examples), which the shared satellite-aware loader
+// (loadPackages → packagesload.LoadWorkspace) expands to their go.work members so
+// satellite production code is scanned for metric-PII leaks (#2147). It does NOT use
+// PatternsExtended — OBS-01 never scanned tests/ or tools/.
 func obs01ProductionPatterns(projectRoot string) []string {
-	return prodscan.Patterns(projectRoot)
+	return append(prodscan.Patterns(projectRoot), prodscan.SatelliteParentPatterns(projectRoot)...)
 }
 
 func dedupeDiagnostics(in []Diagnostic) []Diagnostic {

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -940,6 +940,86 @@ func TestOBS01CoverageRequiresFramework_AntiVacuity(t *testing.T) {
 		"PatternTopLevels must not report framework covered when no framework pattern is present")
 }
 
+// TestOBS01CoverageRequiresSatellites is the #2147 satellite analogue of
+// TestOBS01CoverageRequiresFramework: it asserts the independent, hardcoded fact
+// that the multi-member satellite parents (cmd/adapters/examples, each holding
+// several go.work member modules) MUST be OBS-01-covered, via two checks that do
+// NOT depend on each other:
+//
+//  1. the OBS-01 production pattern set's top-levels include cmd/adapters/examples;
+//     and
+//  2. those satellite parent patterns actually LOAD non-empty project packages
+//     through the EXACT loadPackages path OBS-01 uses (expand "./<parent>/..." to
+//     its members, then per-member load) — a load-witness strictly stronger than
+//     string presence: it catches a parent that is present in the SoR but expands
+//     to zero members (the pre-#2147 silent match-zero).
+func TestOBS01CoverageRequiresSatellites(t *testing.T) {
+	root := repoRoot(t)
+
+	// (1) coverage: the OBS-01 SoR patterns map back to the satellite top-levels.
+	covered := prodscan.PatternTopLevels(obs01ProductionPatterns(root))
+	for _, sat := range []string{"cmd", "adapters", "examples"} {
+		assert.Truef(t, covered[sat],
+			"OBS-01 production scan must cover satellite parent %q (cmd/adapters/examples hold go.work member modules — #2147)", sat)
+	}
+
+	// (2) load-witness: the satellite parents load non-empty through OBS-01's loader.
+	// loadPackages is the SAME entry CheckOBS01 → checkOBS01WithPatterns uses; the
+	// merged satellite-aware loader expands each "./<parent>/..." to its members and
+	// loads them. A regression to silent match-zero loads nothing and fails here.
+	pkgs, err := loadPackages(t.Context(), root, "./cmd/...", "./adapters/...", "./examples/...")
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs,
+		"satellite parent patterns loaded zero project packages — OBS-01 silently stopped scanning satellites")
+	seen := map[string]bool{}
+	for _, p := range pkgs {
+		switch {
+		case strings.Contains(p.PkgPath, "/cmd/"):
+			seen["cmd"] = true
+		case strings.Contains(p.PkgPath, "/adapters/"):
+			seen["adapters"] = true
+		case strings.Contains(p.PkgPath, "/examples/"):
+			seen["examples"] = true
+		}
+	}
+	for _, sat := range []string{"cmd", "adapters", "examples"} {
+		assert.Truef(t, seen[sat], "satellite %q loaded no project package under the OBS-01 scan", sat)
+	}
+}
+
+// TestOBS01CoverageRequiresSatellites_AntiVacuity proves check (1) of
+// TestOBS01CoverageRequiresSatellites is not恒真: a synthetic production pattern
+// set with no satellite parent must NOT report cmd/adapters/examples as covered.
+func TestOBS01CoverageRequiresSatellites_AntiVacuity(t *testing.T) {
+	covered := prodscan.PatternTopLevels([]string{".", "./framework/kernel/..."})
+	for _, sat := range []string{"cmd", "adapters", "examples"} {
+		assert.Falsef(t, covered[sat],
+			"PatternTopLevels must not report satellite %q covered when no satellite pattern is present", sat)
+	}
+}
+
+// TestCheckOBS01DetectsSatelliteMemberLeak is the #2147 anti-vacuity witness that
+// OBS-01 actually SCANS satellite (cmd/adapters/examples) production code. It builds
+// a multi-member go.work workspace whose sole satellite member (examples/leakydemo)
+// leaks an errcode classifier (errcode.IsInfraError) into a metric label.
+//
+// On the pre-#2147 loader the satellite parent prefix "./examples/..." is pruned by
+// HasNestedModuleRoot and never re-emitted, so the member is never loaded and the
+// leak goes uncaught (CheckOBS01 errors / yields 0 diagnostics → this test RED). The
+// merged satellite-aware loader expands "./examples/..." to examples/leakydemo and
+// scans it, catching the leak (GREEN). The member is a self-complete module (the
+// canonical tidied fixture go.mod/go.sum, module path renamed), so the per-member
+// GOWORK=off load resolves it under -mod=readonly without a go.work.sum.
+func TestCheckOBS01DetectsSatelliteMemberLeak(t *testing.T) {
+	root := writeSatelliteMetricsFixture(t)
+	diagnostics, err := CheckOBS01(t.Context(), root)
+	require.NoError(t, err)
+	require.Len(t, diagnostics, 1)
+	assert.Equal(t, "reason", diagnostics[0].Label)
+	assert.Contains(t, filepath.ToSlash(diagnostics[0].File), "examples/leakydemo",
+		"diagnostic must point at the satellite member file — proves satellite code is scanned")
+}
+
 func TestCheckOBS01DetectsIIFEParamTaint(t *testing.T) {
 	root := writeMetricsFixture(t)
 	writeFile(t, root, "reachable/obs.go", `package reachable
@@ -2242,6 +2322,48 @@ func writeMetricsFixture(t *testing.T) string {
 	return root
 }
 
+// writeSatelliteMetricsFixture builds a multi-member go.work workspace with one
+// satellite member (examples/leakydemo) that leaks an errcode classifier into a
+// metric label — the #2147 RED witness that OBS-01 scans satellite production code.
+//
+// The member reuses the canonical tidied fixture go.mod/go.sum (module path renamed)
+// so it is a self-complete module: the satellite-aware loader expands "./examples/..."
+// to examples/leakydemo and loads it GOWORK=off via its own go.mod under -mod=readonly,
+// needing no go.work.sum. go.work exists solely so workspace.Modules enumerates the
+// member (driving the parent-prefix expansion); HasNestedModuleRoot(root/examples) is
+// true because examples/leakydemo carries a go.mod.
+func writeSatelliteMetricsFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mod, sum := canonicalMetricsFixtureMod(t)
+	mod = strings.Replace(mod, "module example.com/metricsfixture", "module example.com/leakydemo", 1)
+	writeFile(t, root, "go.work", "go 1.25.11\n\nuse ./examples/leakydemo\n")
+	writeFile(t, root, "examples/leakydemo/go.mod", mod)
+	writeFile(t, root, "examples/leakydemo/go.sum", sum)
+	writeFile(t, root, "docs/observability/metrics-migration-acks.yaml", "acknowledgements: []\n")
+	writeFile(t, root, "examples/leakydemo/leak.go", `package leakydemo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ghbvf/gocell/framework/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+var leakProvider = metrics.NopProvider{}
+var leakCounter, _ = leakProvider.CounterVec(metrics.CounterOpts{
+	Name:       "satellite_leak_total",
+	LabelNames: []string{"reason"},
+})
+
+func Record(err error) {
+	leakCounter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
+}
+`)
+	return root
+}
+
 // writeMetricsFixtureFiles lays down the throwaway metrics-fixture module tree:
 // a clone of the slimmed post-#1558 root go.mod plus the prometheus-adapter
 // require/replace, a cmd/app entrypoint, and reachable/unreachable packages.
@@ -2414,15 +2536,23 @@ func productionGoTopLevels(t *testing.T, root string) map[string]bool {
 				return nil
 			}
 			top := strings.Split(rel, "/")[0]
-			// A top-level dir that prodscan.Patterns prunes is not required by this
-			// coverage guard either — symmetric with the scan, sharing the same
-			// prodscan single source. Two cases, both deferred to the ModeWorkspace
-			// migration gh #2136: a go.work satellite MODULE ROOT (own go.mod, e.g.
-			// cellmodules/ #1559 — IsModuleRoot), and a MULTI-MEMBER PARENT
-			// (cmd/adapters/examples holding member modules one level deeper —
-			// HasNestedModuleRoot), unaddressable by a root-relative ModeModule
-			// "./<dir>/..." post-#1565.
-			if rel == top && (prodscan.IsModuleRoot(path) || prodscan.HasNestedModuleRoot(path)) {
+			// A pure go.work satellite MODULE ROOT (own go.mod — cellmodules/ #1559,
+			// corecells/) stays excluded from this root-relative coverage guard: OBS-01
+			// addresses such a module only by its own member pattern, not a
+			// root-relative "./<dir>/..." prefix (its satellite coverage is a separate
+			// concern). framework/ is also a module root and is handled independently by
+			// TestOBS01CoverageRequiresFramework.
+			if rel == top && prodscan.IsModuleRoot(path) {
+				return filepath.SkipDir
+			}
+			// A MULTI-MEMBER PARENT (cmd/adapters/examples, holding go.work member
+			// modules one level deeper — HasNestedModuleRoot) IS required since #2147:
+			// the merged satellite-aware loader (packagesload.LoadWorkspace) expands
+			// "./<parent>/..." to its members and OBS-01 scans them. Register the parent
+			// top-level as required, then skip the descent — the members' production
+			// files live in nested modules the satellite-aware loader reaches on its own.
+			if rel == top && prodscan.HasNestedModuleRoot(path) {
+				out[top] = true
 				return filepath.SkipDir
 			}
 			if strings.HasPrefix(d.Name(), ".") || obs01CoverageExcludedTop(top) || d.Name() == "testdata" {

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/tools/internal/prodscan"
-	"github.com/ghbvf/gocell/tools/packagesload"
 )
 
 func TestBuild_CorebundleCapturesReachableTypedMetrics(t *testing.T) {
@@ -143,10 +142,11 @@ func TestBuild_CorebundleGeneratedSchemaIsCurrent(t *testing.T) {
 // promwrap export set for the funnel-enforcement side.
 func TestPrometheusConstructor_RecognizesPromwrapFunnel(t *testing.T) {
 	root := repoRoot(t)
-	// promwrap now lives in the adapters/prometheus go.work satellite module
-	// (#1558), invisible to a GOWORK=off ModeModule load from the repo root;
-	// ModeWorkspace resolves it as a workspace member.
-	pkgs, err := loadPackagesWithMode(t.Context(), root, false, packagesload.ModeWorkspace, promwrapPkg)
+	// promwrap lives in the adapters/prometheus go.work satellite module (#1558),
+	// invisible to a GOWORK=off ModeModule load from the repo root. The shared
+	// satellite-aware loadPackages resolves the import path to its owning member and
+	// loads it (#2147).
+	pkgs, err := loadPackages(t.Context(), root, promwrapPkg)
 	require.NoError(t, err)
 
 	var exported []string
@@ -940,7 +940,7 @@ func TestOBS01CoverageRequiresFramework_AntiVacuity(t *testing.T) {
 		"PatternTopLevels must not report framework covered when no framework pattern is present")
 }
 
-// TestOBS01CoverageRequiresSatellites is the #2147 satellite analogue of
+// TestOBS01CoverageRequiresSatellites is the #2147 satellite counterpart of
 // TestOBS01CoverageRequiresFramework: it asserts the independent, hardcoded fact
 // that the multi-member satellite parents (cmd/adapters/examples, each holding
 // several go.work member modules) MUST be OBS-01-covered, via two checks that do

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -1016,8 +1016,8 @@ func TestCheckOBS01DetectsSatelliteMemberLeak(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, diagnostics, 1)
 	assert.Equal(t, "reason", diagnostics[0].Label)
-	assert.Contains(t, filepath.ToSlash(diagnostics[0].File), "examples/leakydemo",
-		"diagnostic must point at the satellite member file — proves satellite code is scanned")
+	assert.Equal(t, "examples/leakydemo/leak.go", filepath.ToSlash(diagnostics[0].File),
+		"diagnostic must point exactly at the satellite member leak file — proves satellite code is scanned")
 }
 
 func TestCheckOBS01DetectsIIFEParamTaint(t *testing.T) {
@@ -2336,8 +2336,12 @@ func writeSatelliteMetricsFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	mod, sum := canonicalMetricsFixtureMod(t)
-	mod = strings.Replace(mod, "module example.com/metricsfixture", "module example.com/leakydemo", 1)
-	writeFile(t, root, "go.work", "go 1.25.11\n\nuse ./examples/leakydemo\n")
+	const newModulePath = "module example.com/leakydemo"
+	mod = strings.Replace(mod, "module example.com/metricsfixture", newModulePath, 1)
+	require.Contains(t, mod, newModulePath,
+		"fixture go.mod module-path replacement failed — canonicalMetricsFixtureMod format changed?")
+	// Pin the same toolchain version as the real repo go.work (no hardcoded drift).
+	writeFile(t, root, "go.work", repoGoWorkGoDirective(t)+"\n\nuse ./examples/leakydemo\n")
 	writeFile(t, root, "examples/leakydemo/go.mod", mod)
 	writeFile(t, root, "examples/leakydemo/go.sum", sum)
 	writeFile(t, root, "docs/observability/metrics-migration-acks.yaml", "acknowledgements: []\n")
@@ -2362,6 +2366,22 @@ func Record(err error) {
 }
 `)
 	return root
+}
+
+// repoGoWorkGoDirective returns the real repo go.work's `go X.Y.Z` line so a fixture
+// workspace pins the same toolchain version the test binary runs under — no hardcoded
+// version that drifts when the repo bumps Go.
+func repoGoWorkGoDirective(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), "go.work"))
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(data), "\n") {
+		if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, "go ") {
+			return trimmed
+		}
+	}
+	t.Fatal("repo go.work has no `go` directive")
+	return ""
 }
 
 // writeMetricsFixtureFiles lays down the throwaway metrics-fixture module tree:

--- a/tools/packagesload/workspace.go
+++ b/tools/packagesload/workspace.go
@@ -26,18 +26,39 @@ import (
 //   - a tree with no go.work loads as a single ModeModule module at root.
 //
 // cfgTemplate supplies Mode (the go/packages Need* bits), Tests, BuildFlags, and
-// Context; Dir/Env are owned per group (Env via [Load]'s mode handling). The returned
-// []packages.Error is the flat, dir-prefixed set collected from every loaded package
-// so callers can fail fast on type-check errors without re-walking. This is the ONLY
-// satellite-aware package loader in the repo; both the OBS-01 metric-PII scan
-// (tools/metricschema) and the archtest typed façade (tools/archtest) route through
-// it, so "spawn a second satellite loader" cannot be expressed without reaching
-// packages.Load — itself funneled here by PACKAGES-LOAD-FUNNEL-01.
+// Context; Dir/Env are owned per group (Env via [Load]'s mode handling). Do NOT set
+// packages.NeedDeps in cfgTemplate.Mode: it keeps full Syntax+TypesInfo resident for
+// every transitive dependency (~1GB RSS, the #1499 regression); the scan callers
+// deliberately omit it.
+//
+// The returned []packages.Error is the flat, dir-prefixed set collected from every
+// loaded package. Callers MUST treat any non-empty []packages.Error as a scan failure
+// and fail closed — the returned packages may be incomplete; do not scan them and
+// report "clean".
+//
+// This is the ONLY satellite-aware package loader in the repo; both the OBS-01
+// metric-PII scan (tools/metricschema) and the archtest typed façade (tools/archtest)
+// route through it. Carrier strength (per ai-robust.md, upstream vs downstream): a
+// satellite loader OUTSIDE packagesload cannot be expressed — the expansion atom
+// expandParentPrefix is package-private (unreachable) AND any reimplementation must
+// reach packages.Load, itself funneled here by PACKAGES-LOAD-FUNNEL-01 (Hard upstream).
+// WITHIN packagesload a parallel loader is only convention-guarded (Medium); this is
+// the sanctioned single home, and tightening it to a private sub-package is a tracked
+// Hard-ization follow-up.
 func LoadWorkspace(root string, cfgTemplate packages.Config, patterns ...string) ([]*packages.Package, []packages.Error, error) {
-	if groups, rootPatterns, ok := workspacePatternGroups(root, patterns); ok {
+	groups, rootPatterns, ok, err := workspacePatternGroups(root, patterns)
+	if err != nil {
+		// go.work exists but its members could not be resolved — fail closed (do NOT
+		// silently degrade to a single-module scan that drops satellite coverage).
+		return nil, nil, err
+	}
+	if ok {
 		// A span across multiple member modules, OR a single group that IS the
 		// workspace root, must load from the root in ModeWorkspace using rootPatterns
 		// (where unanchored "./parent/..." patterns are translated to import-path form).
+		// NOTE: this is the documented ModeModule→ModeWorkspace upgrade — a ModeModule
+		// caller asking for a satellite parent prefix gets a workspace-mode load of the
+		// expanded members, which is the only way those members resolve post-#1565.
 		if len(groups) > 1 || (len(groups) == 1 && groups[0].dir == root) {
 			return loadPackageGroups(ModeWorkspace, cfgTemplate, []patternGroup{{dir: root, patterns: rootPatterns}})
 		}
@@ -52,6 +73,12 @@ type patternGroup struct {
 	patterns []string
 }
 
+// loadPackageGroups loads each group's patterns with a per-group clone of cfgTemplate
+// (Dir set to the group dir) and concatenates the results. It does NOT dedup packages
+// across groups: LoadWorkspace only ever passes either ONE root-anchored ModeWorkspace
+// group or N disjoint per-member ModeModule groups, so no package is loaded twice.
+// Consumers that mix patterns hitting the same package (e.g. metricschema's
+// loadPackages) dedup by import path downstream.
 func loadPackageGroups(
 	mode Mode, cfgTemplate packages.Config, groups []patternGroup,
 ) ([]*packages.Package, []packages.Error, error) {
@@ -62,7 +89,7 @@ func loadPackageGroups(
 		cfg.Dir = g.dir
 		pkgs, err := Load(mode, &cfg, g.patterns...)
 		if err != nil {
-			return nil, nil, fmt.Errorf("packages.Load: %w", err)
+			return nil, nil, fmt.Errorf("packages.Load %s: %w", g.dir, err)
 		}
 		packages.Visit(pkgs, nil, func(p *packages.Package) {
 			for i := range p.Errors {
@@ -92,13 +119,19 @@ const skipPatternDir = "\x00skip-no-member"
 // in which any "./parent/..." pattern that spans multiple members (no single
 // member owns it) is rewritten to its import-path form so workspace mode resolves
 // it without a root module to anchor the relative dir.
-func workspacePatternGroups(root string, patterns []string) ([]patternGroup, []string, bool) {
+//
+// The bool is true when root is a go.work workspace and the patterns were grouped;
+// false (with nil error) signals "no go.work — caller should do a single-module
+// load". A non-nil error means root IS a workspace but its members could not be
+// resolved: the caller MUST fail closed rather than fall back to a single-module
+// scan (that would silently drop the satellite coverage governance rules declare).
+func workspacePatternGroups(root string, patterns []string) ([]patternGroup, []string, bool, error) {
 	if !workspace.HasGoWork(root) {
-		return nil, nil, false
+		return nil, nil, false, nil
 	}
 	mods, err := workspace.Modules(root)
 	if err != nil {
-		return nil, nil, false
+		return nil, nil, false, fmt.Errorf("packagesload: resolve workspace members at %s: %w", root, err)
 	}
 	// Expand satellite parent-prefixes ("./cmd/...", "./adapters/...",
 	// "./examples/...") that span multiple members into their per-member patterns
@@ -145,7 +178,7 @@ func workspacePatternGroups(root string, patterns []string) ([]patternGroup, []s
 			rootPatterns = append(rootPatterns, pattern)
 		}
 	}
-	return groups, rootPatterns, true
+	return groups, rootPatterns, true, nil
 }
 
 // splitWorkspacePattern maps a root-relative pattern to (owning member dir,

--- a/tools/packagesload/workspace.go
+++ b/tools/packagesload/workspace.go
@@ -1,0 +1,267 @@
+package packagesload
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/ghbvf/gocell/tools/workspace"
+)
+
+// LoadWorkspace is the single sanctioned satellite-aware loader: it loads patterns
+// against the go.work workspace at root, EXPANDING multi-member satellite
+// parent-prefixes ("./cmd/...", "./adapters/...", "./examples/...") into their owning
+// members so they are actually scanned, never silently skipped.
+//
+// Routing (faithful to the pre-#2147 typeseval loader it consolidates):
+//   - a span across multiple members, OR a single group that IS the workspace root
+//     (parent-of-member / root-level patterns), loads FROM the root in ModeWorkspace
+//     using the rewritten rootPatterns (post-#1565 the root has no module to anchor a
+//     relative "./parent/..." pattern, so it is rewritten to import-path form);
+//   - a single member's patterns load per-member in ModeModule (GOWORK=off, via the
+//     member's own go.mod);
+//   - a tree with no go.work loads as a single ModeModule module at root.
+//
+// cfgTemplate supplies Mode (the go/packages Need* bits), Tests, BuildFlags, and
+// Context; Dir/Env are owned per group (Env via [Load]'s mode handling). The returned
+// []packages.Error is the flat, dir-prefixed set collected from every loaded package
+// so callers can fail fast on type-check errors without re-walking. This is the ONLY
+// satellite-aware package loader in the repo; both the OBS-01 metric-PII scan
+// (tools/metricschema) and the archtest typed façade (tools/archtest) route through
+// it, so "spawn a second satellite loader" cannot be expressed without reaching
+// packages.Load — itself funneled here by PACKAGES-LOAD-FUNNEL-01.
+func LoadWorkspace(root string, cfgTemplate packages.Config, patterns ...string) ([]*packages.Package, []packages.Error, error) {
+	if groups, rootPatterns, ok := workspacePatternGroups(root, patterns); ok {
+		// A span across multiple member modules, OR a single group that IS the
+		// workspace root, must load from the root in ModeWorkspace using rootPatterns
+		// (where unanchored "./parent/..." patterns are translated to import-path form).
+		if len(groups) > 1 || (len(groups) == 1 && groups[0].dir == root) {
+			return loadPackageGroups(ModeWorkspace, cfgTemplate, []patternGroup{{dir: root, patterns: rootPatterns}})
+		}
+		return loadPackageGroups(ModeModule, cfgTemplate, groups)
+	}
+	// No go.work workspace at root: a single ModeModule (GOWORK=off) load.
+	return loadPackageGroups(ModeModule, cfgTemplate, []patternGroup{{dir: root, patterns: patterns}})
+}
+
+type patternGroup struct {
+	dir      string
+	patterns []string
+}
+
+func loadPackageGroups(
+	mode Mode, cfgTemplate packages.Config, groups []patternGroup,
+) ([]*packages.Package, []packages.Error, error) {
+	var all []*packages.Package
+	var allErrs []packages.Error
+	for _, g := range groups {
+		cfg := cfgTemplate // value copy; Dir/Env owned per group
+		cfg.Dir = g.dir
+		pkgs, err := Load(mode, &cfg, g.patterns...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("packages.Load: %w", err)
+		}
+		packages.Visit(pkgs, nil, func(p *packages.Package) {
+			for i := range p.Errors {
+				p.Errors[i].Msg = g.dir + ": " + p.Errors[i].Msg
+			}
+			allErrs = append(allErrs, p.Errors...)
+		})
+		all = append(all, pkgs...)
+	}
+	return all, allErrs, nil
+}
+
+// frameworkModuleDir is the workspace-relative dir of the core framework module
+// (kernel/runtime/pkg) since the #1565 split — the successor to the pre-split root
+// module that "." / "./..." referred to.
+const frameworkModuleDir = "framework"
+
+// skipPatternDir is the sentinel member-dir splitWorkspacePattern returns for a
+// root-relative parent prefix that no workspace member owns AND that has no member
+// living under it — a genuine empty match (e.g. a typo "./nonexistent/..."). The NUL
+// byte cannot occur in a real dir, so it is unambiguous.
+const skipPatternDir = "\x00skip-no-member"
+
+// workspacePatternGroups returns, for a go.work workspace at root: (1) the
+// per-member pattern groups (each loaded in module mode), and (2) rootPatterns —
+// the equivalent flat pattern list for a single ModeWorkspace load FROM the root,
+// in which any "./parent/..." pattern that spans multiple members (no single
+// member owns it) is rewritten to its import-path form so workspace mode resolves
+// it without a root module to anchor the relative dir.
+func workspacePatternGroups(root string, patterns []string) ([]patternGroup, []string, bool) {
+	if !workspace.HasGoWork(root) {
+		return nil, nil, false
+	}
+	mods, err := workspace.Modules(root)
+	if err != nil {
+		return nil, nil, false
+	}
+	// Expand satellite parent-prefixes ("./cmd/...", "./adapters/...",
+	// "./examples/...") that span multiple members into their per-member patterns
+	// so the satellite packages are ACTUALLY scanned. Without this a pattern no
+	// single member owns hits splitWorkspacePattern's skip and match-zeroes —
+	// silently dropping the ./cmd/… ./adapters/… ./examples/… coverage that
+	// security/governance archtest rules declare over those satellites (#1565
+	// fidelity, F5). A prefix with zero members under it still falls through to
+	// the skip (genuine match-zero).
+	expanded := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		if parts, ok := expandParentPrefix(mods, p); ok {
+			expanded = append(expanded, parts...)
+		} else {
+			expanded = append(expanded, p)
+		}
+	}
+	patterns = expanded
+	groups := make([]patternGroup, 0, len(mods))
+	groupByDir := map[string]int{}
+	add := func(dir, pattern string) {
+		if i, ok := groupByDir[dir]; ok {
+			groups[i].patterns = append(groups[i].patterns, pattern)
+			return
+		}
+		groupByDir[dir] = len(groups)
+		groups = append(groups, patternGroup{dir: dir, patterns: []string{pattern}})
+	}
+	rootPatterns := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		moduleDir, modulePattern := splitWorkspacePattern(mods, pattern)
+		if moduleDir == skipPatternDir {
+			// Unmatched satellite parent-prefix ("./cmd/...", "./adapters/...") —
+			// drop it so it match-zeroes (see splitWorkspacePattern).
+			continue
+		}
+		add(filepath.Join(root, moduleDir), modulePattern)
+		if moduleDir == "." {
+			// No member owns the pattern: use the member-relative form for the
+			// root-anchored ModeWorkspace load.
+			rootPatterns = append(rootPatterns, modulePattern)
+		} else {
+			// Into-member relative pattern resolves from the root in workspace mode.
+			rootPatterns = append(rootPatterns, pattern)
+		}
+	}
+	return groups, rootPatterns, true
+}
+
+// splitWorkspacePattern maps a root-relative pattern to (owning member dir,
+// member-relative pattern). Multi-member satellite prefixes ("./cmd/...",
+// "./adapters/...", "./examples/...") are expanded to their members by
+// workspacePatternGroups BEFORE split is called (expandParentPrefix), so they are
+// actually scanned, never silently skipped (F5, SATELLITE-PARENT-PREFIX-SCAN-01).
+func splitWorkspacePattern(mods []workspace.Module, pattern string) (string, string) {
+	// "." / "./..." referred to the pre-#1565 ROOT module — the platform CORE
+	// (kernel/runtime/pkg at the repo root). The core moved to ./framework, so map
+	// the bare-root patterns onto the framework member, preserving "scan the
+	// platform core" semantics.
+	if (pattern == "." || pattern == "./...") && hasFrameworkMember(mods) {
+		return frameworkModuleDir, pattern
+	}
+	if dir, modulePattern, ok := matchWorkspaceMember(mods, pattern); ok {
+		return dir, modulePattern
+	}
+	// No member matched a root-relative parent prefix. Reaching here means the prefix
+	// has NO member under it at all — a genuine empty match (e.g. a typo
+	// "./nonexistent/..."). Signal SKIP: workspacePatternGroups drops the pattern
+	// entirely (→ match-zero). A member that matched but whose subdir is missing took
+	// the matched branch above and is NOT skipped — it loads and surfaces a
+	// packages.Error, preserving typo diagnostics. Only skip when a framework core
+	// member exists (the real post-#1565 workspace); a synthetic single-module set
+	// falls through to the root-anchored (".") form so its in-module subtrees load.
+	if strings.HasPrefix(pattern, "./") && hasFrameworkMember(mods) {
+		return skipPatternDir, ""
+	}
+	return ".", pattern
+}
+
+// hasFrameworkMember reports whether the workspace contains the core framework
+// module (the post-#1565 successor to the root "." module).
+func hasFrameworkMember(mods []workspace.Module) bool {
+	for _, m := range mods {
+		if filepath.ToSlash(filepath.Clean(m.Dir)) == frameworkModuleDir {
+			return true
+		}
+	}
+	return false
+}
+
+// matchWorkspaceMember finds the workspace member that owns pattern (longest dir /
+// import-path prefix wins), returning (member-dir, member-relative pattern, true).
+// ok is false when no member owns the pattern.
+func matchWorkspaceMember(mods []workspace.Module, pattern string) (string, string, bool) {
+	bestDir, bestPattern, bestScore := "", "", -1
+	consider := func(score int, dir, modulePattern string) {
+		if score > bestScore {
+			bestScore, bestDir, bestPattern = score, dir, modulePattern
+		}
+	}
+	for _, m := range mods {
+		dir := filepath.ToSlash(filepath.Clean(m.Dir))
+		if dir == "." || dir == "" {
+			continue
+		}
+		prefix := "./" + dir
+		switch {
+		case pattern == prefix:
+			consider(len(dir), dir, ".")
+		case strings.HasPrefix(pattern, prefix+"/"):
+			consider(len(dir), dir, "."+strings.TrimPrefix(pattern, prefix))
+		}
+		if pattern == m.ImportPath || strings.HasPrefix(pattern, m.ImportPath+"/") {
+			consider(len(m.ImportPath), dir, pattern)
+		}
+	}
+	return bestDir, bestPattern, bestScore >= 0
+}
+
+// expandParentPrefix expands a root-relative parent-prefix package pattern that
+// spans MULTIPLE workspace members — e.g. "./cmd/...", "./adapters/...",
+// "./examples/..." — into one "./<member-dir>/..." pattern per member living
+// strictly under that prefix dir (cmd/ holds cmd/gocell + cmd/corebundle;
+// adapters/ holds adapters/postgres, adapters/redis, …).
+//
+// Such a prefix has no single owning module, so post-#1565 (no root module to
+// anchor "./cmd/...") it cannot be loaded as written: a ModeModule load errors
+// ("directory prefix cmd does not contain main module") and a workspace loader
+// that merely match-zeroes it SILENTLY DROPS the satellite coverage that
+// governance / security archtest rules declare over ./cmd/… ./adapters/… and
+// ./examples/…. Expanding to the real members restores that coverage — each
+// "./<member>/..." resolves as a normal workspace member in ModeWorkspace.
+//
+// Returns (expansions, true) iff pattern is "./<dir>/..." and ≥1 member lives
+// strictly under <dir>. Returns (nil, false) for everything else and the caller
+// keeps the pattern verbatim: a member owning <dir> exactly (normal single-member
+// resolution handles it), no member under <dir> (a genuine match-zero), a
+// single-module fixture (its sole "." member owns nothing under a subdir), or a
+// non-recursive pattern. Expansions are sorted for deterministic load order.
+func expandParentPrefix(mods []workspace.Module, pattern string) ([]string, bool) {
+	if !strings.HasPrefix(pattern, "./") || !strings.HasSuffix(pattern, "/...") {
+		return nil, false
+	}
+	dir := strings.TrimSuffix(strings.TrimPrefix(pattern, "./"), "/...")
+	if dir == "" || dir == "." {
+		return nil, false
+	}
+	prefix := dir + "/"
+	var out []string
+	for _, m := range mods {
+		md := filepath.ToSlash(filepath.Clean(m.Dir))
+		if md == dir {
+			// A single member owns the prefix exactly → not a multi-member parent
+			// prefix; the caller's normal single-member resolution handles it.
+			return nil, false
+		}
+		if strings.HasPrefix(md, prefix) {
+			out = append(out, "./"+md+"/...")
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	sort.Strings(out)
+	return out, true
+}

--- a/tools/packagesload/workspace_test.go
+++ b/tools/packagesload/workspace_test.go
@@ -1,0 +1,233 @@
+package packagesload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/ghbvf/gocell/tools/workspace"
+)
+
+// representativeMods is a post-#1565 member set: cmd/ and adapters/ each span
+// multiple members; framework is a single top-level member.
+var representativeMods = []workspace.Module{
+	{Dir: "framework", ImportPath: "github.com/ghbvf/gocell/framework"},
+	{Dir: "cmd/gocell", ImportPath: "github.com/ghbvf/gocell/cmd/gocell"},
+	{Dir: "cmd/corebundle", ImportPath: "github.com/ghbvf/gocell/cmd/corebundle"},
+	{Dir: "adapters/postgres", ImportPath: "github.com/ghbvf/gocell/adapters/postgres"},
+	{Dir: "adapters/redis", ImportPath: "github.com/ghbvf/gocell/adapters/redis"},
+}
+
+func TestExpandParentPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		mods    []workspace.Module
+		pattern string
+		want    []string
+		wantOK  bool
+	}{
+		{
+			name:    "multi-member cmd prefix expands to each member",
+			mods:    representativeMods,
+			pattern: "./cmd/...",
+			want:    []string{"./cmd/corebundle/...", "./cmd/gocell/..."},
+			wantOK:  true,
+		},
+		{
+			name:    "multi-member adapters prefix expands and sorts",
+			mods:    representativeMods,
+			pattern: "./adapters/...",
+			want:    []string{"./adapters/postgres/...", "./adapters/redis/..."},
+			wantOK:  true,
+		},
+		{
+			// framework is a single member that OWNS the dir exactly — the
+			// caller's normal single-member resolution must handle it, not us.
+			name:    "single owning member is not expanded",
+			mods:    representativeMods,
+			pattern: "./framework/...",
+			wantOK:  false,
+		},
+		{
+			name:    "subpath under a single member is not expanded",
+			mods:    representativeMods,
+			pattern: "./framework/kernel/...",
+			wantOK:  false,
+		},
+		{
+			name:    "prefix with no member under it match-zeroes (not expanded)",
+			mods:    representativeMods,
+			pattern: "./examples/...",
+			wantOK:  false,
+		},
+		{
+			name:    "single-module fixture leaves pattern verbatim",
+			mods:    []workspace.Module{{Dir: ".", ImportPath: "github.com/acme/app"}},
+			pattern: "./cmd/...",
+			wantOK:  false,
+		},
+		{
+			name:    "non-recursive pattern is not expanded",
+			mods:    representativeMods,
+			pattern: "./cmd/gocell",
+			wantOK:  false,
+		},
+		{
+			name:    "bare-root recursive pattern is not expanded",
+			mods:    representativeMods,
+			pattern: "./...",
+			wantOK:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := expandParentPrefix(tc.mods, tc.pattern)
+			if ok != tc.wantOK {
+				t.Fatalf("expandParentPrefix(%q) ok = %v, want %v (got %v)", tc.pattern, ok, tc.wantOK, got)
+			}
+			if tc.wantOK && !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("expandParentPrefix(%q) = %v, want %v", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitWorkspacePattern(t *testing.T) {
+	tests := []struct {
+		name        string
+		pattern     string
+		wantDir     string
+		wantPattern string
+	}{
+		{"bare root maps to framework member", "./...", frameworkModuleDir, "./..."},
+		{"member subpath", "./cmd/gocell/...", "cmd/gocell", "./..."},
+		{"member by import path", "github.com/ghbvf/gocell/adapters/redis/x", "adapters/redis", "github.com/ghbvf/gocell/adapters/redis/x"},
+		{"unowned parent prefix skips", "./examples/...", skipPatternDir, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, pattern := splitWorkspacePattern(representativeMods, tc.pattern)
+			if dir != tc.wantDir || pattern != tc.wantPattern {
+				t.Fatalf("splitWorkspacePattern(%q) = (%q, %q), want (%q, %q)",
+					tc.pattern, dir, pattern, tc.wantDir, tc.wantPattern)
+			}
+		})
+	}
+}
+
+func TestSplitWorkspacePattern_RoutesKnownSatellite(t *testing.T) {
+	mods := []workspace.Module{
+		{Dir: ".", ImportPath: "github.com/ghbvf/gocell"},
+		{Dir: "tools", ImportPath: "github.com/ghbvf/gocell/tools"},
+	}
+
+	dir, pattern := splitWorkspacePattern(mods, "./tools/archtest/internal/typeseval/...")
+	if dir != "tools" || pattern != "./archtest/internal/typeseval/..." {
+		t.Fatalf("split = (%q, %q), want (tools, ./archtest/internal/typeseval/...)", dir, pattern)
+	}
+
+	// No framework member here, so a root-relative non-member prefix falls back to the
+	// root (".") form rather than the skip sentinel.
+	dir, pattern = splitWorkspacePattern(mods, "./framework/pkg/...")
+	if dir != "." || pattern != "./framework/pkg/..." {
+		t.Fatalf("split = (%q, %q), want (., ./framework/pkg/...)", dir, pattern)
+	}
+
+	dir, pattern = splitWorkspacePattern(mods, "github.com/ghbvf/gocell/tools/archtest/internal/scanner")
+	if dir != "tools" || pattern != "github.com/ghbvf/gocell/tools/archtest/internal/scanner" {
+		t.Fatalf("split = (%q, %q), want (tools, <importpath>)", dir, pattern)
+	}
+}
+
+func TestSplitWorkspacePattern_PrefersLongestSatellitePrefix(t *testing.T) {
+	mods := []workspace.Module{
+		{Dir: ".", ImportPath: "github.com/ghbvf/gocell"},
+		{Dir: "tools", ImportPath: "github.com/ghbvf/gocell/tools"},
+		{Dir: "tools/nested", ImportPath: "github.com/ghbvf/gocell/tools/nested"},
+	}
+
+	dir, pattern := splitWorkspacePattern(mods, "./tools/nested/pkg/...")
+	if dir != "tools/nested" || pattern != "./pkg/..." {
+		t.Fatalf("split = (%q, %q), want (tools/nested, ./pkg/...)", dir, pattern)
+	}
+
+	dir, pattern = splitWorkspacePattern(mods, "github.com/ghbvf/gocell/tools/nested/pkg")
+	if dir != "tools/nested" || pattern != "github.com/ghbvf/gocell/tools/nested/pkg" {
+		t.Fatalf("split = (%q, %q), want (tools/nested, <importpath>)", dir, pattern)
+	}
+}
+
+// TestLoadWorkspace_ExpandsSatelliteMember exercises the full expand → group → load
+// path against a real (dependency-free) go.work workspace: "./examples/..." is owned
+// by no single member, so LoadWorkspace must expand it to examples/foo and load that
+// member — the satellite coverage the pre-#2147 loader silently dropped.
+func TestLoadWorkspace_ExpandsSatelliteMember(t *testing.T) {
+	root := t.TempDir()
+	writeWS(t, root, "go.work", "go 1.25\n\nuse ./examples/foo\n")
+	writeWS(t, root, "examples/foo/go.mod", "module example.com/foo\n\ngo 1.25\n")
+	writeWS(t, root, "examples/foo/foo.go", "package foo\n\n// F is a satellite-member symbol.\nfunc F() int { return 1 }\n")
+
+	cfg := packages.Config{Context: context.Background(), Mode: packages.NeedName | packages.NeedFiles}
+	pkgs, loadErrs, err := LoadWorkspace(root, cfg, "./examples/...")
+	if err != nil {
+		t.Fatalf("LoadWorkspace: %v", err)
+	}
+	if len(loadErrs) > 0 {
+		t.Fatalf("LoadWorkspace load errors: %v", loadErrs)
+	}
+	if !containsPkgPath(pkgs, "example.com/foo") {
+		t.Fatalf("LoadWorkspace did not load the satellite member example.com/foo; got %v", pkgPaths(pkgs))
+	}
+}
+
+// TestLoadWorkspace_SingleModuleFallback verifies a tree with no go.work loads as one
+// ModeModule module at root (the no-workspace fallback path).
+func TestLoadWorkspace_SingleModuleFallback(t *testing.T) {
+	root := t.TempDir()
+	writeWS(t, root, "go.mod", "module example.com/solo\n\ngo 1.25\n")
+	writeWS(t, root, "pkg/util/util.go", "package util\n\nfunc V() int { return 2 }\n")
+
+	cfg := packages.Config{Context: context.Background(), Mode: packages.NeedName | packages.NeedFiles}
+	pkgs, loadErrs, err := LoadWorkspace(root, cfg, "./pkg/...")
+	if err != nil {
+		t.Fatalf("LoadWorkspace: %v", err)
+	}
+	if len(loadErrs) > 0 {
+		t.Fatalf("LoadWorkspace load errors: %v", loadErrs)
+	}
+	if !containsPkgPath(pkgs, "example.com/solo/pkg/util") {
+		t.Fatalf("single-module fallback did not load example.com/solo/pkg/util; got %v", pkgPaths(pkgs))
+	}
+}
+
+func writeWS(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func pkgPaths(pkgs []*packages.Package) []string {
+	out := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		out = append(out, p.PkgPath)
+	}
+	return out
+}
+
+func containsPkgPath(pkgs []*packages.Package, path string) bool {
+	for _, p := range pkgs {
+		if p.PkgPath == path {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/packagesload/workspace_test.go
+++ b/tools/packagesload/workspace_test.go
@@ -65,6 +65,19 @@ func TestExpandParentPrefix(t *testing.T) {
 			wantOK:  false,
 		},
 		{
+			// Positive examples/ case (symmetry with cmd/adapters): when examples/
+			// holds members, the parent prefix expands to each — the OBS-01 #2147 path.
+			name: "multi-member examples prefix expands",
+			mods: []workspace.Module{
+				{Dir: "framework", ImportPath: "github.com/ghbvf/gocell/framework"},
+				{Dir: "examples/iotdevice", ImportPath: "github.com/ghbvf/gocell/examples/iotdevice"},
+				{Dir: "examples/ssobff", ImportPath: "github.com/ghbvf/gocell/examples/ssobff"},
+			},
+			pattern: "./examples/...",
+			want:    []string{"./examples/iotdevice/...", "./examples/ssobff/..."},
+			wantOK:  true,
+		},
+		{
 			name:    "single-module fixture leaves pattern verbatim",
 			mods:    []workspace.Module{{Dir: ".", ImportPath: "github.com/acme/app"}},
 			pattern: "./cmd/...",

--- a/tools/slowgate/allowlist.txt
+++ b/tools/slowgate/allowlist.txt
@@ -270,3 +270,13 @@ github.com/ghbvf/gocell/tools/archtest	TestFixtureCellIDTypedBuilder
 # SCOPE-01 have per-test Elapsed under 1s after R3 scope-narrowing (A2 single
 # package, A5 single package, A4 file I/O only, A3 single fixture pkg, import
 # scope AST-only Run); they do not need slowgate allowlist entries.
+
+# type-graph-load: OBS-01 #2147 satellite coverage load-witness — loadPackages
+# over ./cmd/... ./adapters/... ./examples/... which the satellite-aware loader
+# expands to ~22 go.work member modules (the per-satellite anti-vacuity witness
+# that the SoR satellite prefixes load non-empty, not a silent match-zero).
+# Cold-cache packages.Load of ~22 member modules with type info is inherently
+# >20s on ubuntu-latest 2-CPU runners (21.03s on PR #2163); the per-run cost is
+# removed once OBS-01 loader caching lands (#2165). Same type-graph-load class
+# as the entries above. First tools/metricschema entry (others are tools/archtest).
+github.com/ghbvf/gocell/tools/metricschema	TestOBS01CoverageRequiresSatellites

--- a/tools/workspace/workspace.go
+++ b/tools/workspace/workspace.go
@@ -161,53 +161,14 @@ func Modules(root string) ([]Module, error) {
 	return mods, nil
 }
 
-// ExpandParentPrefix expands a root-relative parent-prefix package pattern that
-// spans MULTIPLE workspace members — e.g. "./cmd/...", "./adapters/...",
-// "./examples/..." — into one "./<member-dir>/..." pattern per member living
-// strictly under that prefix dir (cmd/ holds cmd/gocell + cmd/corebundle;
-// adapters/ holds adapters/postgres, adapters/redis, …).
-//
-// Such a prefix has no single owning module, so post-#1565 (no root module to
-// anchor "./cmd/...") it cannot be loaded as written: a ModeModule load errors
-// ("directory prefix cmd does not contain main module") and a workspace loader
-// that merely match-zeroes it SILENTLY DROPS the satellite coverage that
-// governance / security archtest rules declare over ./cmd/… ./adapters/… and
-// ./examples/…. Expanding to the real members restores that coverage — each
-// "./<member>/..." resolves as a normal workspace member in ModeWorkspace.
-//
-// Returns (expansions, true) iff pattern is "./<dir>/..." and ≥1 member lives
-// strictly under <dir>. Returns (nil, false) for everything else and the caller
-// keeps the pattern verbatim: a member owning <dir> exactly (normal
-// single-member resolution handles it), no member under <dir> (a genuine
-// match-zero), a single-module fixture (its sole "." member owns nothing under a
-// subdir), or a non-recursive pattern. Expansions are sorted for deterministic
-// load order.
-func ExpandParentPrefix(mods []Module, pattern string) ([]string, bool) {
-	if !strings.HasPrefix(pattern, "./") || !strings.HasSuffix(pattern, "/...") {
-		return nil, false
-	}
-	dir := strings.TrimSuffix(strings.TrimPrefix(pattern, "./"), "/...")
-	if dir == "" || dir == "." {
-		return nil, false
-	}
-	prefix := dir + "/"
-	var out []string
-	for _, m := range mods {
-		md := filepath.ToSlash(filepath.Clean(m.Dir))
-		if md == dir {
-			// A single member owns the prefix exactly → not a multi-member parent
-			// prefix; the caller's normal single-member resolution handles it.
-			return nil, false
-		}
-		if strings.HasPrefix(md, prefix) {
-			out = append(out, "./"+md+"/...")
-		}
-	}
-	if len(out) == 0 {
-		return nil, false
-	}
-	sort.Strings(out)
-	return out, true
+// HasGoWork reports whether root contains a go.work file — i.e. root is a workspace
+// root rather than a single module. It is the marker check [Modules] uses internally
+// to choose between workspace and single-module resolution, exposed so loaders can
+// gate workspace-only logic (the satellite parent-prefix expansion in
+// tools/packagesload) on the same single source rather than re-stat'ing go.work.
+func HasGoWork(root string) bool {
+	_, err := os.Stat(filepath.Join(root, goWorkFile))
+	return err == nil
 }
 
 // CorePrefix returns the GoCell org/repo PREFIX (e.g. "github.com/ghbvf/gocell")

--- a/tools/workspace/workspace_test.go
+++ b/tools/workspace/workspace_test.go
@@ -285,89 +285,15 @@ func TestModules_ManifestSymlinkEscape(t *testing.T) {
 	}
 }
 
-func TestExpandParentPrefix(t *testing.T) {
-	// A representative post-#1565 member set: cmd/ and adapters/ each span
-	// multiple members; framework is a single top-level member.
-	mods := []workspace.Module{
-		{Dir: "framework", ImportPath: "github.com/ghbvf/gocell/framework"},
-		{Dir: "cmd/gocell", ImportPath: "github.com/ghbvf/gocell/cmd/gocell"},
-		{Dir: "cmd/corebundle", ImportPath: "github.com/ghbvf/gocell/cmd/corebundle"},
-		{Dir: "adapters/postgres", ImportPath: "github.com/ghbvf/gocell/adapters/postgres"},
-		{Dir: "adapters/redis", ImportPath: "github.com/ghbvf/gocell/adapters/redis"},
+func TestHasGoWork(t *testing.T) {
+	root := t.TempDir()
+	if workspace.HasGoWork(root) {
+		t.Fatalf("HasGoWork on a dir without go.work = true, want false")
 	}
-	tests := []struct {
-		name    string
-		mods    []workspace.Module
-		pattern string
-		want    []string
-		wantOK  bool
-	}{
-		{
-			name:    "multi-member cmd prefix expands to each member",
-			mods:    mods,
-			pattern: "./cmd/...",
-			want:    []string{"./cmd/corebundle/...", "./cmd/gocell/..."},
-			wantOK:  true,
-		},
-		{
-			name:    "multi-member adapters prefix expands and sorts",
-			mods:    mods,
-			pattern: "./adapters/...",
-			want:    []string{"./adapters/postgres/...", "./adapters/redis/..."},
-			wantOK:  true,
-		},
-		{
-			// framework is a single member that OWNS the dir exactly — the
-			// caller's normal single-member resolution must handle it, not us.
-			name:    "single owning member is not expanded",
-			mods:    mods,
-			pattern: "./framework/...",
-			wantOK:  false,
-		},
-		{
-			// A subpath UNDER a single member (framework/kernel) is owned by that
-			// member; no member lives strictly under "framework/kernel".
-			name:    "subpath under a single member is not expanded",
-			mods:    mods,
-			pattern: "./framework/kernel/...",
-			wantOK:  false,
-		},
-		{
-			name:    "prefix with no member under it match-zeroes (not expanded)",
-			mods:    mods,
-			pattern: "./examples/...",
-			wantOK:  false,
-		},
-		{
-			// Single-module fixture: the sole "." member owns nothing under a
-			// subdir, so "./cmd/..." stays verbatim (loads in the one module).
-			name:    "single-module fixture leaves pattern verbatim",
-			mods:    []workspace.Module{{Dir: ".", ImportPath: "github.com/acme/app"}},
-			pattern: "./cmd/...",
-			wantOK:  false,
-		},
-		{
-			name:    "non-recursive pattern is not expanded",
-			mods:    mods,
-			pattern: "./cmd/gocell",
-			wantOK:  false,
-		},
-		{
-			name:    "bare-root recursive pattern is not expanded",
-			mods:    mods,
-			pattern: "./...",
-			wantOK:  false,
-		},
+	if err := os.WriteFile(filepath.Join(root, "go.work"), []byte("go 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := workspace.ExpandParentPrefix(tc.mods, tc.pattern)
-			if ok != tc.wantOK {
-				t.Fatalf("ExpandParentPrefix(%q) ok = %v, want %v (got %v)", tc.pattern, ok, tc.wantOK, got)
-			}
-			if tc.wantOK && !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("ExpandParentPrefix(%q) = %v, want %v", tc.pattern, got, tc.want)
-			}
-		})
+	if !workspace.HasGoWork(root) {
+		t.Fatalf("HasGoWork after writing go.work = false, want true")
 	}
 }


### PR DESCRIPTION
## Summary

把 typeseval 与 metricschema 两套 package loader 的 satellite 前缀展开 + member 分组合并到唯一共享入口 `packagesload.LoadWorkspace`，让 OBS-01 metric-PII scan 覆盖 cmd/adapters/examples satellite 生产代码。

## Why / 背景

#1565 拆出独立 `framework` module 后，仓库根从 go.mod 变成 go.work 多成员工作区。OBS-01 metric-PII 扫描（`tools/metricschema` 的 `CheckOBS01`，检测把 `errcode.IsInfraError` 派生值塞进 prometheus metric label 的泄露）走 `obs01ProductionPatterns` → `prodscan.Patterns`，后者经 `HasNestedModuleRoot` 剪掉 multi-member satellite parent（cmd/adapters/examples），且 metricschema 自己的 loader 不做 satellite 前缀展开（`./cmd/...` → silently match-zero）。结果：**satellite 生产代码的 metric-PII 泄露守卫从未生效**（纵深防御盲区）。

架构根因是**两套 loader**：typeseval（有 satellite 展开，PR #2143 为 duration gate 加的）、metricschema（无）。本 PR 把 satellite-aware 加载下沉到共享 funnel `tools/packagesload`（已是 PACKAGES-LOAD-FUNNEL-01 唯一 `packages.Load` 入口，两套 loader 都 import 它），新增 `LoadWorkspace`，typeseval 与 metricschema 双双 delegate，**消除架构根因（真单 loader）**，同时保持 `CheckOBS01` taint 分析与公开签名不动。

预期结果：satellite 生产代码纳入 OBS-01 扫描；典型/边界/错误路径有 load-witness + 多成员 go.work RED fixture 守卫。真实仓库 cmd/adapters/examples 当前**无** errcode-classifier→metric-label 泄露 sink，故 gate 仍绿——纯补覆盖盲区。

**AI-HARD**：satellite 展开原子 `ExpandParentPrefix` 从 `tools/workspace` 迁入 `packagesload` 设为私有 `expandParentPrefix`（包外不可表达），配合既有 PACKAGES-LOAD-FUNNEL-01（任何重造 loader 必经 `packages.Load`，被收口逼回 packagesload）——「别处重造 satellite loader」不可表达，单 loader 不变式从 Soft（靠人记得用）升为 **Hard**。

## Refs

- Closes #2147
- 关联：PR #2143（duration gate satellite 展开，本 PR 复用其 `ExpandParentPrefix` 原子并下沉合并）

## Risk / 兼容性

- 无 wire / 契约影响（纯 tooling / archtest loader + scan 覆盖，无 schema/generated/slice 扇出）。
- **R1（首要）**：`LoadWorkspace` 是 typeseval `loadPackagesMode` 的行为搬迁，typeseval 是全 archtest 加载地基。已验证：全量 archtest 套件失败集 vs `origin/develop` **逐一相同**（17 个均 pre-existing 环境敏感规则，零回归）。
- 不向后兼容：typeseval 5 + metricschema 3 函数 outright 删除，`workspace.ExpandParentPrefix` 导出符号删除；无 shim / 别名 / 双路径。

## Test plan

- [x] `go build ./tools/...` 本地通过
- [x] `go test ./tools/{packagesload,internal/prodscan,workspace,archtest/internal/typeseval,metricschema}/...` 全绿（含新 satellite RED→GREEN fixture + load-witness）
- [x] 全量 `go test -tags=archtest ./tools/archtest/...` vs base 失败集逐一相同（零回归）；`SATELLITE-PARENT-PREFIX-SCAN-01`、`TestMetricLabelErrcodeClassifiersRequireAck`（真实仓库 OBS-01）绿
- [x] `golangci-lint run`（改动包）0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
