### PR TITLE
docs(skills): ship/fix 收尾改为延迟 ~30min 单次启动 pr-monitor（auto 模式自动修）

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -276,7 +276,7 @@ Priority：review finding 用原 `[P0-P3]`；`/fix` 派生默认 `pri-p2`；`pri
 
 按 `issues` B5 ② 等 CI 收敛 + 失败回阶段 1-4 修复循环再推再等（时限 / 3 轮熔断单源在 B5 ②）；CI 收敛后**贴独立 pm:ci 评论**（用 `<!-- pm:ci -->` 模板）：全绿 → `verdict=ci-green`；B5 ② 熔断仍红 → `verdict=ci-failed`（含失败 check 摘要 + run 链接）。**追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=ci --pr=<PR#> --ci='{"failedChecks":[…],"passedChecks":<n>,"totalChecks":<m>}'`，输出追加到 pm:ci body 末尾，再走 `issues` B4 贴。
 
-**步骤 5: 自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#>`（check-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 `--check` 进展，约 2 次无进展即转人工，human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
+**步骤 5: 自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（check-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 `--check` 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后最多巡检 2 轮，第 2 轮无进展即转人工，human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
 
 完成后 **TaskUpdate → completed**。
 

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -276,7 +276,7 @@ Priority：review finding 用原 `[P0-P3]`；`/fix` 派生默认 `pri-p2`；`pri
 
 按 `issues` B5 ② 等 CI 收敛 + 失败回阶段 1-4 修复循环再推再等（时限 / 3 轮熔断单源在 B5 ②）；CI 收敛后**贴独立 pm:ci 评论**（用 `<!-- pm:ci -->` 模板）：全绿 → `verdict=ci-green`；B5 ② 熔断仍红 → `verdict=ci-failed`（含失败 check 摘要 + run 链接）。**追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=ci --pr=<PR#> --ci='{"failedChecks":[…],"passedChecks":<n>,"totalChecks":<m>}'`，输出追加到 pm:ci body 末尾，再走 `issues` B4 贴。
 
-**步骤 5: 自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（check-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 `--check` 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后连续 2 轮无进展即转人工（有进展则重置；仅交互会话内生效），human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
+**步骤 5: 延迟单次启动监控**：所有评论 + label 操作完成后，**延迟约 30 分钟后单次启动** `/pr-monitor <PR#> --mode=auto`（check-side；给 `/pr-review --check` 时间响应后**单次**检查——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；单次跑完即止、之后交人工，非 /loop 循环）。交互会话用一次延迟唤醒实现；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
 
 完成后 **TaskUpdate → completed**。
 

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -276,7 +276,7 @@ Priority：review finding 用原 `[P0-P3]`；`/fix` 派生默认 `pri-p2`；`pri
 
 按 `issues` B5 ② 等 CI 收敛 + 失败回阶段 1-4 修复循环再推再等（时限 / 3 轮熔断单源在 B5 ②）；CI 收敛后**贴独立 pm:ci 评论**（用 `<!-- pm:ci -->` 模板）：全绿 → `verdict=ci-green`；B5 ② 熔断仍红 → `verdict=ci-failed`（含失败 check 摘要 + run 链接）。**追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=ci --pr=<PR#> --ci='{"failedChecks":[…],"passedChecks":<n>,"totalChecks":<m>}'`，输出追加到 pm:ci body 末尾，再走 `issues` B4 贴。
 
-**步骤 5: 自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（check-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 `--check` 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后最多巡检 2 轮，第 2 轮无进展即转人工，human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
+**步骤 5: 自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（check-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 `--check` 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后连续 2 轮无进展即转人工（有进展则重置；仅交互会话内生效），human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
 
 完成后 **TaskUpdate → completed**。
 

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -1,22 +1,17 @@
 ---
 name: pr-monitor
-description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。由 `/loop <interval> /pr-monitor <PR#>` 简单 loop 驱动（ship/fix 收尾自动启动 auto 模式，手动单次默认 report；每 tick 无状态，只读 label + 机器块；每次启动后连续 2 轮无进展即终止）；human-in-loop 可随时中断。pr-status/ready、PR 关闭、熔断或连续 2 轮无进展时报告终止。"
+description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。无状态单 tick（每次调用只查一次，只读 label + 机器块）；ship/fix 收尾延迟约 30min 单次启动 auto 模式（跑完即止，非循环），手动单次默认 report，也可由 `/loop` 持续观察；human-in-loop 可随时中断。pr-status/ready、PR 关闭或熔断时报告终止。"
 argument-hint: "<PR#> [--mode report|auto] [--role fix|review]"
 allowed-tools: [Bash, Read, Skill, Agent]
 ---
 
 # pr-monitor — PR 状态单 tick 检查器（fix 侧）
 
-> **适用场景**：ship/fix 推完 PR 后，持续观察 review/check 侧进展，在满足条件时自动（或提示人工）调用 `/fix`。
+> **适用场景**：ship/fix 推完 PR 后，单次观察 review/check 侧进展，在满足条件时自动（或提示人工）调用 `/fix`。
 >
-> **loop 模型（简单）**：本技能是**无状态单 tick**——每次调用只做一次检查就返回。循环交给内建 `/loop` 原语：
-> `/loop 20m /pr-monitor <PR#>` 每 20min 重放同一行命令再调用一次（flag 随命令行原样保留，无需跨 tick 携带状态）。
-> **不自己调 ScheduleWakeup、不携带 tick payload、不写文件**——每 tick 的状态全部从 PR 实时读取（label + 最新机器块）。
-> human-in-loop 全程在场，可随时 Ctrl-C 停 `/loop`；**每次启动后连续 2 轮无进展即终止转人工**（轮巡上限）。「无进展」= 本 tick 未 dispatch `/fix` 且 PR label 较上一 tick 未变；有进展（dispatch 或 label 变）则重置计数。计数取本次启动会话顺序 tick（来自会话上下文、非 PR API，不持久化、不跨会话）。
+> **单 tick 模型（简单）**：本技能是**无状态单 tick**——每次调用只做一次检查就返回，**不自己调 ScheduleWakeup、不携带 tick payload、不写文件**，状态全部从 PR 实时读取（label + 最新机器块）。
 >
-> **如何启动**：ship/fix 收尾**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管）。手动单次 `/pr-monitor <PR#>` 也合法（默认 report 模式）——只做一次检查就返回。
->
-> **轮巡上限作用域**：连续 2 轮无进展终止是**交互 /loop 会话**内的软约束（模型据会话顺序 tick 计数）；headless 一次性会话每次独立、无法跨会话计数，不受此软上限约束，由 daemon 调度 + 3 轮熔断（Hard 机器读）兜底。
+> **如何启动**：ship/fix 收尾**延迟约 30 分钟后单次启动** `/pr-monitor <PR#> --mode=auto`——给 review/check 时间响应后单次检查，**跑完即止、之后交人工**（非 /loop 循环、无轮巡上限）。交互会话用一次延迟唤醒（ScheduleWakeup，跑完不再调度）实现；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。手动单次 `/pr-monitor <PR#>` 也合法（默认 report 模式）；需持续观察可自行 `/loop <interval> /pr-monitor <PR#>`（用户 Esc 停）。
 
 ---
 
@@ -51,7 +46,7 @@ esac; shift; done
 
 ## §2 每 tick 逻辑（顶层控制流）
 
-每次 `/pr-monitor` 调用（= 一个 `/loop` tick）按序执行，做完即返回：
+每次 `/pr-monitor` 调用（一次检查；若由 `/loop` 驱动则为一个 tick）按序执行，做完即返回：
 
 1. **读 PR 状态（一次 gh，兼存在性校验）**：
    ```bash
@@ -60,7 +55,7 @@ esac; shift; done
    ```
 2. **§3.1 终止检查**（优先；命中即打印结束语并返回，提示用户停 `/loop`）。
 3. 按 `$ROLE` 分支：`--role=review` → §4；否则按 `$MODE` → report（§3.2）或 auto（§3.3-3.6）。
-4. 返回（**不调 ScheduleWakeup**）；下一 tick 由 `/loop` 调度。
+4. 返回（pr-monitor 本身**不调 ScheduleWakeup**）；单次调用到此结束，之后交人工（若由 `/loop` 驱动则下一 tick 由 `/loop` 调度）。
 
 > **无 cursor / 无时间戳追增量**：「有无待修 findings」由 **label + 最新机器块**判定（§3.2/§3.3）——`pr-status/needs-fix` 在即「review 给了结论待修」，幂等可重报，不怕 `/loop` 重放。
 
@@ -75,9 +70,8 @@ esac; shift; done
 | `pr-status/ready` ∈ labels | label 含 | "✅ PR #N 已 ready，监控可结束——请停止 /loop" |
 | PR state != OPEN | `state != "OPEN"` | "PR #N 已关闭（state=$STATE），请停止 /loop" |
 | §3.3 熔断触发 | block `cycle.exhausted` / round≥3 | 见 §3.3 |
-| 本次启动连续 2 轮无进展 | 模型据会话顺序 tick 判定（无进展 = 未 dispatch 且 label 未变；会话本地软计数，非 label/非持久，交互会话内生效） | "PR #N 连续 2 轮无进展，转人工（停 /loop）" |
 
-> 无持久 tickCount、不跨会话——ready/closed/熔断是机器读出口；另加**连续 2 轮无进展轮巡上限**（模型据会话顺序 tick 软计数，有进展即重置；仅交互会话内生效，headless 见顶部「轮巡上限作用域」），嫌久也可直接停 `/loop`。轮巡上限（软，每次启动重置）与 §3.3 的 3 轮 review↔fix 熔断（Hard 机器读）正交、互不替代。
+> ready/closed/熔断 是终止出口。ship/fix 经延迟单次调用本技能、跑完即止（无 loop、无轮巡计数）；手动 `/loop` 持续观察时可随时 Esc 停。
 
 ### §3.2 report 模式（默认）
 
@@ -128,9 +122,9 @@ pr-monitor 只凭**机器可判定**的事实（label + 最新机器块）决定
 Skill("fix", args="<N>")
 ```
 
-> auto 模式的 `Skill("fix")` 是 **loop 内**的自动操作（`--mode=auto`）；经 dispatch 门（needs-fix / 未熔断 / Cx1/Cx2 window）+ fix 侧文件级 instruction-level 自限双重收窄 + 3 轮 review↔fix 熔断（Hard 机器读）+ 连续 2 轮无进展轮巡上限（软，会话计数）转人工。
+> auto 模式的 `Skill("fix")` 是 pr-monitor 单次调用内的自动操作（`--mode=auto`）；经 dispatch 门（needs-fix / 未熔断 / Cx1/Cx2 window）+ fix 侧文件级 instruction-level 自限双重收窄 + 3 轮 review↔fix 熔断（Hard 机器读）兜底。
 
-fix 会贴 pm:fix + 切 `pr-status/needs-check-fix`；下个 `/loop` tick 继续等 `/pr-review --check` 结论（非终止）。
+fix 会贴 pm:fix + 切 `pr-status/needs-check-fix`；pr-monitor 本次单次调用到此结束——后续 `/pr-review --check` 进展由 fix 收尾自己再调度的延迟单次检查接力（baton 交接），不在本次调用内等待。
 
 ### §3.5 不自动修的情况（报告 + 建议人工，不 AskUserQuestion）
 

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-monitor
-description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。由 `/loop <interval> /pr-monitor <PR#>` 简单 loop 驱动（ship/fix 收尾自动启动；每 tick 无状态，只读 label + 机器块）；human-in-loop 可随时中断。pr-status/ready 或 PR 关闭时报告终止。"
+description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。由 `/loop <interval> /pr-monitor <PR#>` 简单 loop 驱动（ship/fix 收尾自动启动 auto 模式；每 tick 无状态，只读 label + 机器块；每次启动后轮巡上限 2 轮）；human-in-loop 可随时中断。pr-status/ready 或 PR 关闭或达轮巡上限时报告终止。"
 argument-hint: "<PR#> [--mode report|auto] [--role fix|review]"
 allowed-tools: [Bash, Read, Skill, Agent]
 ---
@@ -12,9 +12,9 @@ allowed-tools: [Bash, Read, Skill, Agent]
 > **loop 模型（简单）**：本技能是**无状态单 tick**——每次调用只做一次检查就返回。循环交给内建 `/loop` 原语：
 > `/loop 20m /pr-monitor <PR#>` 每 20min 重放同一行命令再调用一次（flag 随命令行原样保留，无需跨 tick 携带状态）。
 > **不自己调 ScheduleWakeup、不携带 tick payload、不写文件**——每 tick 的状态全部从 PR 实时读取（label + 最新机器块）。
-> human-in-loop 全程在场，可随时 Ctrl-C 停 `/loop`；约 2 次无进展即转人工（轻提示，不加跨 tick 计数）。
+> human-in-loop 全程在场，可随时 Ctrl-C 停 `/loop`；**每次启动后最多巡检 2 轮（轮巡上限）**——模型据本次启动以来的会话顺序 tick 计数（会话本地软信号，不持久化、不跨会话、非 PR 读取），第 2 轮仍无进展即终止转人工。
 >
-> **如何启动**：ship/fix 收尾**自动启动** `/loop 20m /pr-monitor <PR#>`（交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管）。手动单次 `/pr-monitor <PR#>` 也合法——只做一次检查就返回。
+> **如何启动**：ship/fix 收尾**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管）。手动单次 `/pr-monitor <PR#>` 也合法（默认 report 模式）——只做一次检查就返回。
 
 ---
 
@@ -73,8 +73,9 @@ esac; shift; done
 | `pr-status/ready` ∈ labels | label 含 | "✅ PR #N 已 ready，监控可结束——请停止 /loop" |
 | PR state != OPEN | `state != "OPEN"` | "PR #N 已关闭（state=$STATE），请停止 /loop" |
 | §3.3 熔断触发 | block `cycle.exhausted` / round≥3 | 见 §3.3 |
+| 本次启动已巡检 2 轮无进展 | 模型据本次启动会话顺序 tick 判定（会话本地软计数，非 label/非持久） | "PR #N 本次启动已达 2 轮轮巡上限，转人工（停 /loop）" |
 
-> 无 tickCount 跨 tick 状态——ready/closed 是唯一正常出口；约 2 次无进展即转人工（轻提示，不加计数），嫌久直接停 `/loop`。
+> 无持久 tickCount、不跨会话——ready/closed/熔断是机器读出口；另加**每次启动 2 轮轮巡上限**（模型据本次启动会话顺序 tick 软计数，第 2 轮无进展即终止转人工），嫌久也可直接停 `/loop`。轮巡上限（软，每次启动重置）与 §3.3 的 3 轮 review↔fix 熔断（Hard 机器读）正交、互不替代。
 
 ### §3.2 report 模式（默认）
 
@@ -125,7 +126,7 @@ pr-monitor 只凭**机器可判定**的事实（label + 最新机器块）决定
 Skill("fix", args="<N>")
 ```
 
-> auto 模式的 `Skill("fix")` 是 **loop 内**的自动操作（`--mode=auto`）；经 dispatch 门（needs-fix / 未熔断 / Cx1/Cx2 window）+ fix 侧文件级 instruction-level 自限双重收窄 + 3 轮熔断 + 约 2 次无进展转人工。
+> auto 模式的 `Skill("fix")` 是 **loop 内**的自动操作（`--mode=auto`）；经 dispatch 门（needs-fix / 未熔断 / Cx1/Cx2 window）+ fix 侧文件级 instruction-level 自限双重收窄 + 3 轮 review↔fix 熔断（Hard 机器读）+ 每次启动 2 轮轮巡上限（软，会话计数）转人工。
 
 fix 会贴 pm:fix + 切 `pr-status/needs-check-fix`；下个 `/loop` tick 继续等 `/pr-review --check` 结论（非终止）。
 

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-monitor
-description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。由 `/loop <interval> /pr-monitor <PR#>` 简单 loop 驱动（ship/fix 收尾自动启动 auto 模式；每 tick 无状态，只读 label + 机器块；每次启动后轮巡上限 2 轮）；human-in-loop 可随时中断。pr-status/ready 或 PR 关闭或达轮巡上限时报告终止。"
+description: "PR 状态单 tick 检查器：观察一个 PR 的 review/check 进展并按 label 路由。默认 report 模式（#1657，仅观察+窗口提示）；auto 模式（#1663）在机器可判定的 Cx1/Cx2 + needs-fix + 未熔断 时 dispatch /fix，文件级/禁止域安全裁决交由 /fix 自己的 [AUTO-FIX] 门把关。由 `/loop <interval> /pr-monitor <PR#>` 简单 loop 驱动（ship/fix 收尾自动启动 auto 模式，手动单次默认 report；每 tick 无状态，只读 label + 机器块；每次启动后连续 2 轮无进展即终止）；human-in-loop 可随时中断。pr-status/ready、PR 关闭、熔断或连续 2 轮无进展时报告终止。"
 argument-hint: "<PR#> [--mode report|auto] [--role fix|review]"
 allowed-tools: [Bash, Read, Skill, Agent]
 ---
@@ -12,9 +12,11 @@ allowed-tools: [Bash, Read, Skill, Agent]
 > **loop 模型（简单）**：本技能是**无状态单 tick**——每次调用只做一次检查就返回。循环交给内建 `/loop` 原语：
 > `/loop 20m /pr-monitor <PR#>` 每 20min 重放同一行命令再调用一次（flag 随命令行原样保留，无需跨 tick 携带状态）。
 > **不自己调 ScheduleWakeup、不携带 tick payload、不写文件**——每 tick 的状态全部从 PR 实时读取（label + 最新机器块）。
-> human-in-loop 全程在场，可随时 Ctrl-C 停 `/loop`；**每次启动后最多巡检 2 轮（轮巡上限）**——模型据本次启动以来的会话顺序 tick 计数（会话本地软信号，不持久化、不跨会话、非 PR 读取），第 2 轮仍无进展即终止转人工。
+> human-in-loop 全程在场，可随时 Ctrl-C 停 `/loop`；**每次启动后连续 2 轮无进展即终止转人工**（轮巡上限）。「无进展」= 本 tick 未 dispatch `/fix` 且 PR label 较上一 tick 未变；有进展（dispatch 或 label 变）则重置计数。计数取本次启动会话顺序 tick（来自会话上下文、非 PR API，不持久化、不跨会话）。
 >
 > **如何启动**：ship/fix 收尾**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管）。手动单次 `/pr-monitor <PR#>` 也合法（默认 report 模式）——只做一次检查就返回。
+>
+> **轮巡上限作用域**：连续 2 轮无进展终止是**交互 /loop 会话**内的软约束（模型据会话顺序 tick 计数）；headless 一次性会话每次独立、无法跨会话计数，不受此软上限约束，由 daemon 调度 + 3 轮熔断（Hard 机器读）兜底。
 
 ---
 
@@ -73,9 +75,9 @@ esac; shift; done
 | `pr-status/ready` ∈ labels | label 含 | "✅ PR #N 已 ready，监控可结束——请停止 /loop" |
 | PR state != OPEN | `state != "OPEN"` | "PR #N 已关闭（state=$STATE），请停止 /loop" |
 | §3.3 熔断触发 | block `cycle.exhausted` / round≥3 | 见 §3.3 |
-| 本次启动已巡检 2 轮无进展 | 模型据本次启动会话顺序 tick 判定（会话本地软计数，非 label/非持久） | "PR #N 本次启动已达 2 轮轮巡上限，转人工（停 /loop）" |
+| 本次启动连续 2 轮无进展 | 模型据会话顺序 tick 判定（无进展 = 未 dispatch 且 label 未变；会话本地软计数，非 label/非持久，交互会话内生效） | "PR #N 连续 2 轮无进展，转人工（停 /loop）" |
 
-> 无持久 tickCount、不跨会话——ready/closed/熔断是机器读出口；另加**每次启动 2 轮轮巡上限**（模型据本次启动会话顺序 tick 软计数，第 2 轮无进展即终止转人工），嫌久也可直接停 `/loop`。轮巡上限（软，每次启动重置）与 §3.3 的 3 轮 review↔fix 熔断（Hard 机器读）正交、互不替代。
+> 无持久 tickCount、不跨会话——ready/closed/熔断是机器读出口；另加**连续 2 轮无进展轮巡上限**（模型据会话顺序 tick 软计数，有进展即重置；仅交互会话内生效，headless 见顶部「轮巡上限作用域」），嫌久也可直接停 `/loop`。轮巡上限（软，每次启动重置）与 §3.3 的 3 轮 review↔fix 熔断（Hard 机器读）正交、互不替代。
 
 ### §3.2 report 模式（默认）
 
@@ -126,7 +128,7 @@ pr-monitor 只凭**机器可判定**的事实（label + 最新机器块）决定
 Skill("fix", args="<N>")
 ```
 
-> auto 模式的 `Skill("fix")` 是 **loop 内**的自动操作（`--mode=auto`）；经 dispatch 门（needs-fix / 未熔断 / Cx1/Cx2 window）+ fix 侧文件级 instruction-level 自限双重收窄 + 3 轮 review↔fix 熔断（Hard 机器读）+ 每次启动 2 轮轮巡上限（软，会话计数）转人工。
+> auto 模式的 `Skill("fix")` 是 **loop 内**的自动操作（`--mode=auto`）；经 dispatch 门（needs-fix / 未熔断 / Cx1/Cx2 window）+ fix 侧文件级 instruction-level 自限双重收窄 + 3 轮 review↔fix 熔断（Hard 机器读）+ 连续 2 轮无进展轮巡上限（软，会话计数）转人工。
 
 fix 会贴 pm:fix + 切 `pr-status/needs-check-fix`；下个 `/loop` tick 继续等 `/pr-review --check` 结论（非终止）。
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -161,7 +161,7 @@ GoCell 六维度 = 架构合规 / 安全 / 测试 / 运维可观测 / DX / 产�
 7. **CI 异步收敛（非阻塞收尾，切 label 后执行）**：按 `issues` B5 ② 等 CI 收敛 + 失败回 `fix` 修复循环再推再等（时限 / 3 轮熔断单源在 B5 ②）；CI 收敛后**贴独立 pm:ci 评论**（用 `.github/project-template/pr-comment.md` 的 `<!-- pm:ci -->` 模板）：
    - 全绿 → `verdict=ci-green`；B5 ② 熔断仍红 → `verdict=ci-failed`（含失败 check 摘要 + run 链接）。
    - **追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=ci --pr=<PR#> --ci='{"failedChecks":[{"name":"…","url":"…"},…],"passedChecks":<n>,"totalChecks":<m>}'`（verdict 由 failedChecks 派生、round carry），输出追加到 pm:ci body 末尾，再走 `issues` B4 贴评论。
-8. **自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（review-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 review 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后连续 2 轮无进展即转人工（有进展则重置；仅交互会话内生效），human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
+8. **延迟单次启动监控**：所有评论 + label 操作完成后，**延迟约 30 分钟后单次启动** `/pr-monitor <PR#> --mode=auto`（review-side；给 review 时间响应后**单次**检查——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；单次跑完即止、之后交人工，非 /loop 循环）。交互会话用一次延迟唤醒实现；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
 
 > **收尾不变式（artifact-before-trigger）**：OOS 留痕（建 issue + 贴 pm:oos）必须在切 `needs-review-again`（步骤 6）**之前**完成——切 label 即触发 review-side 执行器，pm:ship 的 `🚦 OUT_OF_SCOPE` 指针在那一刻必须已指向真实的 pm:oos/issue，不得悬空；CI（步骤 7）异步在后，不阻塞 backlog 落地。`/fix` 4.6 step 3 同序（pm:fix → OOS 留痕 → 切 `needs-check-fix` → CI）。
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -161,7 +161,7 @@ GoCell 六维度 = 架构合规 / 安全 / 测试 / 运维可观测 / DX / 产�
 7. **CI 异步收敛（非阻塞收尾，切 label 后执行）**：按 `issues` B5 ② 等 CI 收敛 + 失败回 `fix` 修复循环再推再等（时限 / 3 轮熔断单源在 B5 ②）；CI 收敛后**贴独立 pm:ci 评论**（用 `.github/project-template/pr-comment.md` 的 `<!-- pm:ci -->` 模板）：
    - 全绿 → `verdict=ci-green`；B5 ② 熔断仍红 → `verdict=ci-failed`（含失败 check 摘要 + run 链接）。
    - **追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=ci --pr=<PR#> --ci='{"failedChecks":[{"name":"…","url":"…"},…],"passedChecks":<n>,"totalChecks":<m>}'`（verdict 由 failedChecks 派生、round carry），输出追加到 pm:ci body 末尾，再走 `issues` B4 贴评论。
-8. **自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#>`（review-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 review 进展，约 2 次无进展即转人工，human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
+8. **自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（review-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 review 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后最多巡检 2 轮，第 2 轮无进展即转人工，human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
 
 > **收尾不变式（artifact-before-trigger）**：OOS 留痕（建 issue + 贴 pm:oos）必须在切 `needs-review-again`（步骤 6）**之前**完成——切 label 即触发 review-side 执行器，pm:ship 的 `🚦 OUT_OF_SCOPE` 指针在那一刻必须已指向真实的 pm:oos/issue，不得悬空；CI（步骤 7）异步在后，不阻塞 backlog 落地。`/fix` 4.6 step 3 同序（pm:fix → OOS 留痕 → 切 `needs-check-fix` → CI）。
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -161,7 +161,7 @@ GoCell 六维度 = 架构合规 / 安全 / 测试 / 运维可观测 / DX / 产�
 7. **CI 异步收敛（非阻塞收尾，切 label 后执行）**：按 `issues` B5 ② 等 CI 收敛 + 失败回 `fix` 修复循环再推再等（时限 / 3 轮熔断单源在 B5 ②）；CI 收敛后**贴独立 pm:ci 评论**（用 `.github/project-template/pr-comment.md` 的 `<!-- pm:ci -->` 模板）：
    - 全绿 → `verdict=ci-green`；B5 ② 熔断仍红 → `verdict=ci-failed`（含失败 check 摘要 + run 链接）。
    - **追加机器块**（贴评论前）：`bash hack/automation/pr-meta.sh emit-block --kind=ci --pr=<PR#> --ci='{"failedChecks":[{"name":"…","url":"…"},…],"passedChecks":<n>,"totalChecks":<m>}'`（verdict 由 failedChecks 派生、round carry），输出追加到 pm:ci body 末尾，再走 `issues` B4 贴评论。
-8. **自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（review-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 review 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后最多巡检 2 轮，第 2 轮无进展即转人工，human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
+8. **自动启动监控**：所有评论 + label 操作完成后，**自动启动** `/loop 20m /pr-monitor <PR#> --mode=auto`（review-side；每 20min 调一次**无状态**的 `/pr-monitor` 跟 review 进展——auto 模式在 needs-fix + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`（不再 report+等人确认），Cx3+ 仍转人工；每次启动后连续 2 轮无进展即转人工（有进展则重置；仅交互会话内生效），human-in-loop 可随时停）。交互会话内常驻；headless 一次性会话由 codex-pr-app-dispatcher daemon 接管。
 
 > **收尾不变式（artifact-before-trigger）**：OOS 留痕（建 issue + 贴 pm:oos）必须在切 `needs-review-again`（步骤 6）**之前**完成——切 label 即触发 review-side 执行器，pm:ship 的 `🚦 OUT_OF_SCOPE` 指针在那一刻必须已指向真实的 pm:oos/issue，不得悬空；CI（步骤 7）异步在后，不阻塞 backlog 落地。`/fix` 4.6 step 3 同序（pm:fix → OOS 留痕 → 切 `needs-check-fix` → CI）。
 

--- a/.github/project-template/PROJECT.md
+++ b/.github/project-template/PROJECT.md
@@ -129,7 +129,7 @@
 /ship <issue>
   实施 → PR 创建 → 贴 pr-status/in-progress
   → ship：内置 6 维 reviewer + /fix Cx1/Cx2 → 贴 pm:ship → 冲突预检 + CI 绿
-  → 切 pr-status/needs-review-again → 自动启动 pr-monitor 监听交接（首审唯一使用点）
+  → 切 pr-status/needs-review-again → 自动启动 pr-monitor --mode=auto 监听交接（needs-fix 自动 /fix；每次启动轮巡上限 2 轮；首审唯一使用点）
 
 [review 轮] codex review 或 /pr-review <PR#>
   → 贴 findings 评论（codex / pm:pr-review）

--- a/.github/project-template/PROJECT.md
+++ b/.github/project-template/PROJECT.md
@@ -129,7 +129,7 @@
 /ship <issue>
   实施 → PR 创建 → 贴 pr-status/in-progress
   → ship：内置 6 维 reviewer + /fix Cx1/Cx2 → 贴 pm:ship → 冲突预检 + CI 绿
-  → 切 pr-status/needs-review-again（首审唯一使用点）→ 自动启动 pr-monitor --mode=auto 监听交接（needs-fix 自动 /fix；连续 2 轮无进展转人工）
+  → 切 pr-status/needs-review-again（首审唯一使用点）→ 延迟 ~30min 单次启动 pr-monitor --mode=auto 监听交接（needs-fix 自动 /fix；单次跑完即止）
 
 [review 轮] codex review 或 /pr-review <PR#>
   → 贴 findings 评论（codex / pm:pr-review）

--- a/.github/project-template/PROJECT.md
+++ b/.github/project-template/PROJECT.md
@@ -129,7 +129,7 @@
 /ship <issue>
   实施 → PR 创建 → 贴 pr-status/in-progress
   → ship：内置 6 维 reviewer + /fix Cx1/Cx2 → 贴 pm:ship → 冲突预检 + CI 绿
-  → 切 pr-status/needs-review-again → 自动启动 pr-monitor --mode=auto 监听交接（needs-fix 自动 /fix；每次启动轮巡上限 2 轮；首审唯一使用点）
+  → 切 pr-status/needs-review-again（首审唯一使用点）→ 自动启动 pr-monitor --mode=auto 监听交接（needs-fix 自动 /fix；连续 2 轮无进展转人工）
 
 [review 轮] codex review 或 /pr-review <PR#>
   → 贴 findings 评论（codex / pm:pr-review）


### PR DESCRIPTION
## Summary

ship/fix 收尾改为**延迟约 30 分钟后单次启动** `/pr-monitor <PR#> --mode=auto`（auto 模式 needs-fix 自动 /fix）；pr-monitor 从「`/loop` 持续巡检」简化为单次延迟检查，**不再循环、无轮巡上限**。

## Why / 背景

原行为：ship/fix 收尾自动 `/loop 20m /pr-monitor`（默认 report，只观察+提示人工），监控无明确上限。

经与需求方多轮澄清，最终方案是**两点**：

1. **needs-fix 自动修，不等人确认**：启动命令带 `--mode=auto`，监控在 `needs-fix` + 机器可判定 Cx1/Cx2 + 未熔断 时自动 dispatch `/fix`；Cx3+ 仍 report + 转人工（安全边界保留）。
2. **改为延迟单次、不循环**：ship/fix 收尾后**延迟约 30 分钟**（给 review/check 时间响应）**单次**跑 `/pr-monitor --mode=auto`，跑完即止、之后交人工。

> **设计演进说明**：本 PR 早期版本曾实现「`/loop` 持续巡检 + 每次启动连续 2 轮无进展上限（软会话计数）」。经查官方文档（[scheduled-tasks](https://code.claude.com/docs/en/scheduled-tasks.md)）确认 `/loop` **无原生次数参数**、自驱模式**不能携带改写过的 prompt**，故「硬计数 2 次」不可达；需求方据此改为**最简单的延迟单次检查**，整套轮巡计数机制随之移除。提交历史保留了这一演进（2 轮版 → 单次版）。

pr-monitor 仍是无状态单 tick 检查器，核心不变；`/loop` 降为可选的手动持续观察方式。dispatch /fix 后的续接由 fix 收尾自己再调度的延迟单次检查接力（baton 交接）。

## Refs

无关联 issue / ADR。AI 操作 skill 指令文档调整。扇出：ship 阶段8 step8 / fix 步骤5 / pr-monitor description+intro+§2+§3.1+§3.4 / PROJECT.md §5 流程图。

## Risk / 兼容性

无 wire / migration / Go API 影响——纯 AI 操作 skill 指令文档。行为变更：ship/fix 启动的 pr-monitor 改为延迟单次 auto（原为间隔循环 report）；监控覆盖面收窄为单次（取舍：review 若 >30min 才出结论，该次可能空跑、之后交人工）。`--mode=auto` 的 §3.4 dispatch 门 + fix [AUTO-FIX] 文件级自限 + 3 轮熔断 + Cx3+ 转人工 安全边界均保留。

## Test plan

- 无 Go 改动，`go build` / `go test` / `golangci-lint` N/A。
- [x] `grep` 验证：旧措辞「轮巡/连续 2 轮/约 2 次/loop 20m /pr-monitor/自动启动监控」零残留。
- [x] 「延迟 + 单次 + 跑完即止」四文件口径一致；安全边界（§3.4 门 / Cx3+ / 熔断）保留。
- [x] pr-monitor §2/§3.1/§3.4 措辞校准到「单次调用 + 可选 loop」，无自相矛盾。
