### PR TITLE
fix(archtest): LISTENER-DX-A52 guard 路径随 framework module 拆分更新 [#2173]

### DIFF
--- a/tools/archtest/listener_dx_test.go
+++ b/tools/archtest/listener_dx_test.go
@@ -253,7 +253,7 @@ func forbiddenProductionSurfaceViolationsPass(p *Pass, file *ast.File) []Diagnos
 func routeGroupRegisterSignatureViolations(t *testing.T, root string) []string {
 	t.Helper()
 	// RouteGroup struct is defined in registry.go (merged in batch 1/4).
-	const rel = "kernel/cell/registry.go"
+	const rel = "framework/kernel/cell/registry.go"
 	path := filepath.Join(root, filepath.FromSlash(rel))
 
 	var result []string
@@ -312,7 +312,7 @@ func routeGroupRegisterSignatureViolations(t *testing.T, root string) []string {
 
 func authMountSignatureViolations(t *testing.T, root string) []string {
 	t.Helper()
-	const rel = "runtime/auth/route.go"
+	const rel = "framework/runtime/auth/route.go"
 	path := filepath.Join(root, filepath.FromSlash(rel))
 
 	var result []string


### PR DESCRIPTION
## Summary

修复 `LISTENER-DX-A52` archtest guard 的两处硬编码拆分前路径，使其重新命中 framework module 下的
owner-API 源文件，`TestListenerDXA52Guard` 恢复全绿。

## Why / 背景

framework module 拆分（#1565 / PR #2125，commit `05744fd21`）把 `kernel/` `runtime/` 移到独立
module `framework/`。guard 的两处 `const rel` 仍指拆分前路径，`filepath.Join(workspace-root, rel)`
找不到文件 → 误报 `RouteGroup type missing` / `auth.Mount function missing`（假阴性式 owner-API
漂移），子测试 `owner_surface_signatures_stay_current` FAIL。

这**不是**真 API 漂移：`RouteGroup` type、`auth.Mount` function 都仍在 framework 新位置
（`framework/kernel/cell/registry.go:400`、`framework/runtime/auth/route.go:106`）。两处 `rel` 加
`framework/` 前缀后 guard 全绿，对齐仓库既有 framework-path 惯用法。该 guard 是 Medium 且
fail-closed（路径错走红而非漏放），本 bug 是 false-red、非危险漏放；修复只恢复其命中能力，grade 不变。

| 行 | 当前值 | 改为 |
|----|--------|------|
| listener_dx_test.go:256 | `kernel/cell/registry.go` | `framework/kernel/cell/registry.go` |
| listener_dx_test.go:315 | `runtime/auth/route.go` | `framework/runtime/auth/route.go` |

## Refs

- Closes #2173
- Refs #2179（systemic 加固：path-based archtest guard 应有单一 module-root path funnel，杜绝模块重构
  集体 desync；本 PR scope 外，已另开 backlog）
- ref 对标（仓库既有 framework-path 惯用法）：`tools/archtest/assembly_invariants_test.go:1389/1438`、
  `tools/archtest/audit_hash_input_frozen_test.go:119`

## Risk / 兼容性

无。仅改 archtest 测试文件内两处路径字面量，无生产代码、无 wire 契约、无 migration、无消费方影响。

## Test plan

- [x] `go build -tags archtest ./tools/archtest/` 本地通过
- [x] `go test -tags archtest ./tools/archtest/ -run TestListenerDXA52Guard` 本地全绿（修复前 RED：
  `owner_surface_signatures_stay_current` 报 `RouteGroup type missing` / `auth.Mount function missing`）
- [x] `golangci-lint run`（canonical PR 模式 `--new-from-merge-base=origin/develop --build-tags=archtest,releasesmoke`）0 issues
