### PR TITLE
fix(archtest): SEC-FAIL-CLOSED-05 改用 yaml.v3 结构化解析消除 compose sequence-item 误报 [#2176]

### DIFF
--- a/tools/archtest/security_defaults.go
+++ b/tools/archtest/security_defaults.go
@@ -609,28 +609,33 @@ func findExampleComposeCredentialViolations(t *testing.T, root string) []Diagnos
 // through scanner.EachContentFile can pass bytes directly.
 //
 // It parses the document with yaml.v3 and walks the node tree structurally
-// rather than string-cutting each line. Two structural shapes carry credentials:
+// rather than string-cutting each line. Three structural shapes carry a
+// credential, all governed by the same policy — the value must be a required
+// ${VAR:?message} interpolation:
 //
 //   - mapping entry — a scalar key matching isComposeCredentialKey
-//     ("POSTGRES_PASSWORD: ...") governs its scalar value.
-//   - sequence item — a scalar ${NAME...} whose NAME matches isComposeCredentialKey
-//     (e.g. redis `--requirepass "${REDIS_PASSWORD:?msg}"`). There is no key, so
-//     the env-var name is the credential signal.
+//     ("POSTGRES_PASSWORD: ...") governs its value.
+//   - array-env sequence item — Compose `environment:` written as a list of
+//     "KEY=VALUE" strings; a credential KEY governs VALUE
+//     ("- POSTGRES_PASSWORD=...").
+//   - command env-ref sequence item — a scalar that is itself a ${NAME...}
+//     interpolation (e.g. redis `--requirepass "${REDIS_PASSWORD:?msg}"`); the
+//     env-var name is the credential signal.
 //
-// Each governed value must be a required ${VAR:?message} interpolation.
 // Comments, quoting and the ":?" default-message colon are handled by the YAML
 // decoder, so the #2176 first-colon mis-cut (which false-positived a redis
 // command sequence item that was already the secure required form) is
-// structurally impossible. An unparseable compose file fails closed: the
-// scanner cannot vouch for its credentials, so it reports rather than passes.
+// structurally impossible. Two fail-closed edges: an unparseable compose file
+// is reported file-anchored (the scanner cannot vouch for its credentials), and
+// a credential key whose value is not a scalar cannot be a required
+// interpolation, so it is reported rather than skipped (#2184 F2/F3).
 func scanComposeCredentialViolations(rel string, data []byte) []Diagnostic {
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return []Diagnostic{{
-			Rel:     rel,
-			Line:    0,
-			Message: "compose file is not valid YAML; credential scan cannot verify it",
-		}}
+		// Fail closed: a compose file the scanner cannot parse may hide a
+		// committed credential, so report it (file-anchored, parser error
+		// preserved) instead of passing.
+		return []Diagnostic{diagFile(rel, "compose file is not valid YAML, credential scan cannot verify it: "+err.Error())}
 	}
 	var diags []Diagnostic
 	walkComposeCredentialNodes(rel, &root, &diags)
@@ -641,49 +646,84 @@ func scanComposeCredentialViolations(rel string, data []byte) []Diagnostic {
 // appends one Diagnostic per credential that is not a required ${VAR:?message}
 // interpolation. A credential is emitted at most once: mapping pairs are checked
 // at the MappingNode level (key-based) and sequence credentials at the
-// SequenceNode level (env-var-name based); recursing into a scalar is a no-op
-// (no children), so mapping value scalars are never re-tested under the
-// env-ref rule — preserving the "value is a credential but key is not" pass
+// SequenceNode level (composeSequenceCredential); recursing into a scalar is a
+// no-op (no children), so mapping value scalars are never re-tested as sequence
+// items — preserving the "value is a credential ref but key is not" pass
 // (e.g. "REDISCLI_AUTH: ${...PASSWORD...}").
 func walkComposeCredentialNodes(rel string, node *yaml.Node, diags *[]Diagnostic) {
 	switch node.Kind {
 	case yaml.MappingNode:
-		for i := 0; i+1 < len(node.Content); i += 2 {
-			key, val := node.Content[i], node.Content[i+1]
-			if key.Kind == yaml.ScalarNode && val.Kind == yaml.ScalarNode &&
-				isComposeCredentialKey(key.Value) && !isRequiredComposeEnvInterpolation(val.Value) {
-				*diags = append(*diags, Diagnostic{
-					Rel:     rel,
-					Line:    val.Line,
-					Message: key.Value + " must use required environment interpolation ${VAR:?message}",
-				})
-			}
-		}
+		appendMappingCredentialDiags(rel, node, diags)
 	case yaml.SequenceNode:
-		for _, item := range node.Content {
-			name, ok := composeEnvVarName(item)
-			if ok && isComposeCredentialKey(name) && !isRequiredComposeEnvInterpolation(item.Value) {
-				*diags = append(*diags, Diagnostic{
-					Rel:     rel,
-					Line:    item.Line,
-					Message: name + " must use required environment interpolation ${VAR:?message}",
-				})
-			}
-		}
+		appendSequenceCredentialDiags(rel, node, diags)
 	}
 	for _, child := range node.Content {
 		walkComposeCredentialNodes(rel, child, diags)
 	}
 }
 
-// composeEnvVarName returns the variable name of a scalar ${NAME...} interpolation
-// (NAME runs up to the first ':' or '}'), reporting ok=false when the node is not
-// such a scalar.
-func composeEnvVarName(node *yaml.Node) (string, bool) {
-	if node.Kind != yaml.ScalarNode {
-		return "", false
+// appendMappingCredentialDiags flags each "KEY: VALUE" entry whose KEY is a
+// credential and whose VALUE is not a required ${VAR:?message} interpolation. A
+// non-scalar value cannot be such an interpolation, so it fails closed rather
+// than being skipped (#2184 F2).
+func appendMappingCredentialDiags(rel string, node *yaml.Node, diags *[]Diagnostic) {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key, val := node.Content[i], node.Content[i+1]
+		if key.Kind != yaml.ScalarNode || !isComposeCredentialKey(key.Value) {
+			continue
+		}
+		if val.Kind != yaml.ScalarNode || !isRequiredComposeEnvInterpolation(val.Value) {
+			*diags = append(*diags, composeCredentialDiag(rel, key.Value, val.Line))
+		}
 	}
-	value := strings.TrimSpace(node.Value)
+}
+
+// appendSequenceCredentialDiags flags each sequence item that carries a
+// credential (composeSequenceCredential) whose value is not a required
+// interpolation.
+func appendSequenceCredentialDiags(rel string, node *yaml.Node, diags *[]Diagnostic) {
+	for _, item := range node.Content {
+		if name, value, ok := composeSequenceCredential(item); ok &&
+			!isRequiredComposeEnvInterpolation(value) {
+			*diags = append(*diags, composeCredentialDiag(rel, name, item.Line))
+		}
+	}
+}
+
+// composeSequenceCredential reports whether a sequence-item scalar carries a
+// credential and, if so, returns (name, valueToValidate). Two Compose shapes put
+// a credential in a sequence:
+//
+//   - command env-ref — the whole item is a ${NAME...} interpolation, e.g. redis
+//     `--requirepass "${REDIS_PASSWORD:?msg}"`; the value to validate is the item.
+//   - array-env "KEY=VALUE" — Compose `environment:` written as a sequence, e.g.
+//     `- "POSTGRES_PASSWORD=${VAR:-weak}"`; the value to validate is VALUE.
+//
+// A leading "${" is always the env-ref form (never a KEY=VALUE pair), so it is
+// checked first — otherwise an "=" inside a ${VAR:?message with =} default
+// message would be mis-split as KEY=VALUE.
+func composeSequenceCredential(node *yaml.Node) (name, value string, ok bool) {
+	if node.Kind != yaml.ScalarNode {
+		return "", "", false
+	}
+	scalar := strings.TrimSpace(node.Value)
+	if envName, isEnvRef := composeEnvVarName(scalar); isEnvRef {
+		if isComposeCredentialKey(envName) {
+			return envName, scalar, true
+		}
+		return "", "", false
+	}
+	if key, val, isPair := strings.Cut(scalar, "="); isPair && isComposeCredentialKey(key) {
+		return key, val, true
+	}
+	return "", "", false
+}
+
+// composeEnvVarName returns the variable name of a ${NAME...} interpolation
+// (NAME runs up to the first ':' or '}'), reporting ok=false when value is not
+// such an interpolation.
+func composeEnvVarName(value string) (string, bool) {
+	value = strings.TrimSpace(value)
 	if !strings.HasPrefix(value, "${") {
 		return "", false
 	}
@@ -693,6 +733,12 @@ func composeEnvVarName(node *yaml.Node) (string, bool) {
 		return "", false
 	}
 	return inner[:end], true
+}
+
+// composeCredentialDiag builds the SEC-05 "must use required env interpolation"
+// diagnostic for credential label, anchored at rel:line.
+func composeCredentialDiag(rel, label string, line int) Diagnostic {
+	return diagAt(rel, line, label+" must use required environment interpolation ${VAR:?message}")
 }
 
 func isComposeCredentialKey(key string) bool {

--- a/tools/archtest/security_defaults.go
+++ b/tools/archtest/security_defaults.go
@@ -52,6 +52,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
 )
 
@@ -601,28 +603,96 @@ func findExampleComposeCredentialViolations(t *testing.T, root string) []Diagnos
 }
 
 // scanComposeCredentialViolations inspects compose YAML bytes for committed
-// credential literals (any line whose key matches isComposeCredentialKey must
-// use ${VAR:?required} env interpolation) and returns one structured Diagnostic
-// per offending line (Rel = rel, Line = line number, Message = key explanation —
-// no rel/line/id baked into the message). Decoupled from file reading so callers
-// funneled through scanner.EachContentFile can pass bytes directly.
+// credential literals and returns one structured Diagnostic per offending node
+// (Rel = rel, Line = node line, Message = credential explanation — no rel/line/id
+// baked into the message). Decoupled from file reading so callers funneled
+// through scanner.EachContentFile can pass bytes directly.
+//
+// It parses the document with yaml.v3 and walks the node tree structurally
+// rather than string-cutting each line. Two structural shapes carry credentials:
+//
+//   - mapping entry — a scalar key matching isComposeCredentialKey
+//     ("POSTGRES_PASSWORD: ...") governs its scalar value.
+//   - sequence item — a scalar ${NAME...} whose NAME matches isComposeCredentialKey
+//     (e.g. redis `--requirepass "${REDIS_PASSWORD:?msg}"`). There is no key, so
+//     the env-var name is the credential signal.
+//
+// Each governed value must be a required ${VAR:?message} interpolation.
+// Comments, quoting and the ":?" default-message colon are handled by the YAML
+// decoder, so the #2176 first-colon mis-cut (which false-positived a redis
+// command sequence item that was already the secure required form) is
+// structurally impossible. An unparseable compose file fails closed: the
+// scanner cannot vouch for its credentials, so it reports rather than passes.
 func scanComposeCredentialViolations(rel string, data []byte) []Diagnostic {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return []Diagnostic{{
+			Rel:     rel,
+			Line:    0,
+			Message: "compose file is not valid YAML; credential scan cannot verify it",
+		}}
+	}
 	var diags []Diagnostic
-	for i, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		key, value, ok := strings.Cut(trimmed, ":")
-		if !ok || !isComposeCredentialKey(key) {
-			continue
+	walkComposeCredentialNodes(rel, &root, &diags)
+	return diags
+}
+
+// walkComposeCredentialNodes recursively visits a decoded compose YAML tree and
+// appends one Diagnostic per credential that is not a required ${VAR:?message}
+// interpolation. A credential is emitted at most once: mapping pairs are checked
+// at the MappingNode level (key-based) and sequence credentials at the
+// SequenceNode level (env-var-name based); recursing into a scalar is a no-op
+// (no children), so mapping value scalars are never re-tested under the
+// env-ref rule — preserving the "value is a credential but key is not" pass
+// (e.g. "REDISCLI_AUTH: ${...PASSWORD...}").
+func walkComposeCredentialNodes(rel string, node *yaml.Node, diags *[]Diagnostic) {
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, val := node.Content[i], node.Content[i+1]
+			if key.Kind == yaml.ScalarNode && val.Kind == yaml.ScalarNode &&
+				isComposeCredentialKey(key.Value) && !isRequiredComposeEnvInterpolation(val.Value) {
+				*diags = append(*diags, Diagnostic{
+					Rel:     rel,
+					Line:    val.Line,
+					Message: key.Value + " must use required environment interpolation ${VAR:?message}",
+				})
+			}
 		}
-		if !isRequiredComposeEnvInterpolation(value) {
-			diags = append(diags, Diagnostic{
-				Rel:     rel,
-				Line:    i + 1,
-				Message: key + " must use required environment interpolation ${VAR:?message}",
-			})
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			name, ok := composeEnvVarName(item)
+			if ok && isComposeCredentialKey(name) && !isRequiredComposeEnvInterpolation(item.Value) {
+				*diags = append(*diags, Diagnostic{
+					Rel:     rel,
+					Line:    item.Line,
+					Message: name + " must use required environment interpolation ${VAR:?message}",
+				})
+			}
 		}
 	}
-	return diags
+	for _, child := range node.Content {
+		walkComposeCredentialNodes(rel, child, diags)
+	}
+}
+
+// composeEnvVarName returns the variable name of a scalar ${NAME...} interpolation
+// (NAME runs up to the first ':' or '}'), reporting ok=false when the node is not
+// such a scalar.
+func composeEnvVarName(node *yaml.Node) (string, bool) {
+	if node.Kind != yaml.ScalarNode {
+		return "", false
+	}
+	value := strings.TrimSpace(node.Value)
+	if !strings.HasPrefix(value, "${") {
+		return "", false
+	}
+	inner := value[len("${"):]
+	end := strings.IndexAny(inner, ":}")
+	if end < 0 {
+		return "", false
+	}
+	return inner[:end], true
 }
 
 func isComposeCredentialKey(key string) bool {

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -282,6 +282,25 @@ func TestScanComposeCredentialViolations_Structural(t *testing.T) {
 			wantContains: nil,
 		},
 		{
+			name: "non-scalar command item is skipped (env-var name only applies to scalars)",
+			yaml: `services:
+  redis:
+    command:
+      - "redis-server"
+      - ["nested", "list"]
+`,
+			wantContains: nil,
+		},
+		{
+			name: "malformed interpolation without terminator is not flagged",
+			yaml: `services:
+  redis:
+    command:
+      - "${REDIS_PASSWORD"
+`,
+			wantContains: nil,
+		},
+		{
 			name:         "unparseable YAML fails closed",
 			yaml:         "services:\n  db:\n    command: [unterminated\n",
 			wantContains: []string{"not valid YAML"},

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -282,6 +282,16 @@ func TestScanComposeCredentialViolations_Structural(t *testing.T) {
 			wantContains: nil,
 		},
 		{
+			name: "non-credential env-ref command item is ignored",
+			yaml: `services:
+  app:
+    command:
+      - "--redis-url"
+      - "${REDIS_HOST:?set host}"
+`,
+			wantContains: nil,
+		},
+		{
 			name: "non-scalar command item is skipped (env-var name only applies to scalars)",
 			yaml: `services:
   redis:
@@ -305,6 +315,49 @@ func TestScanComposeCredentialViolations_Structural(t *testing.T) {
 			yaml:         "services:\n  db:\n    command: [unterminated\n",
 			wantContains: []string{"not valid YAML"},
 		},
+		{
+			// #2184 F1: Compose `environment` written as a sequence uses KEY=VALUE
+			// array form; a credential KEY with a fallback default leaks just like
+			// the mapping form and must be flagged.
+			name: "array-env KEY=VALUE fallback is flagged (#2184 F1)",
+			yaml: `services:
+  db:
+    environment:
+      - "POSTGRES_PASSWORD=${VAR:-weak}"
+`,
+			wantContains: []string{"POSTGRES_PASSWORD"},
+		},
+		{
+			name: "array-env KEY=VALUE required interpolation is not flagged (#2184 F1)",
+			yaml: `services:
+  db:
+    environment:
+      - "POSTGRES_PASSWORD=${VAR:?set it}"
+`,
+			wantContains: nil,
+		},
+		{
+			name: "array-env KEY=VALUE plaintext credential is flagged (#2184 F1)",
+			yaml: `services:
+  db:
+    environment:
+      - "POSTGRES_PASSWORD=plaintext"
+`,
+			wantContains: []string{"POSTGRES_PASSWORD"},
+		},
+		{
+			// #2184 F2: a credential key whose value is not a scalar cannot be a
+			// required ${VAR:?message} interpolation, so it fails closed rather
+			// than being silently skipped.
+			name: "credential key with non-scalar value fails closed (#2184 F2)",
+			yaml: `services:
+  db:
+    environment:
+      POSTGRES_PASSWORD:
+        - nested
+`,
+			wantContains: []string{"POSTGRES_PASSWORD"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -316,6 +369,19 @@ func TestScanComposeCredentialViolations_Structural(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestScanComposeCredentialViolations_ParseFailureFailsClosed pins the #2184 F3
+// fix: a YAML parse failure must produce a file-anchored diagnostic (Line 1, the
+// diagFile convention — not the unclickable :0:) and must preserve the parser
+// error detail rather than discarding it.
+func TestScanComposeCredentialViolations_ParseFailureFailsClosed(t *testing.T) {
+	t.Parallel()
+	diags := scanComposeCredentialViolations("docker-compose.yml", []byte("services:\n  db:\n    command: [unterminated\n"))
+	require.Len(t, diags, 1)
+	assert.Equal(t, 1, diags[0].Line, "parse-failure diagnostic must anchor to file head (Line 1), not :0:")
+	assert.Contains(t, diags[0].Message, "not valid YAML")
+	assert.Contains(t, diags[0].Message, "yaml:", "parser error detail must be preserved")
 }
 
 func TestFindUpgradeConfigWithoutAuthenticator_DetectsLiteralWithMissingField(t *testing.T) {

--- a/tools/archtest/security_defaults_test.go
+++ b/tools/archtest/security_defaults_test.go
@@ -211,6 +211,94 @@ services:
 	assert.Equal(t, "examples/futuredevice/docker-compose.yml", rels[1])
 }
 
+// TestScanComposeCredentialViolations_Structural drives the #2176 fix: the
+// SEC-05 compose scanner must classify credentials by YAML STRUCTURE (mapping
+// key vs. sequence item), not by string-cutting on the first ":". The legacy
+// strings.Cut(line, ":") mis-cut a redis `--requirepass "${VAR:?msg}"` command
+// sequence item (first ":" landed inside ":?") and FALSE-POSITIVED a line that
+// was already the secure required-interpolation form.
+//
+// RED→GREEN drivers (FAIL on the legacy string scanner, PASS once the scanner
+// parses with yaml.v3): "required interpolation in command array" and "comment
+// with credential keyword". Anti-vacuity guards (flag both before and after, so
+// the sequence/mapping paths are provably non-vacuous): "fallback in command
+// array", "mapping fallback still governed". fail-closed: unparseable YAML must
+// surface a diagnostic rather than silently pass.
+func TestScanComposeCredentialViolations_Structural(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		yaml string
+		// one expected message substring per diagnostic, in order; empty = no violation.
+		wantContains []string
+	}{
+		{
+			name: "required interpolation in command array is not flagged (#2176)",
+			yaml: `services:
+  redis:
+    command:
+      - "redis-server"
+      - "--requirepass"
+      - "${GOCELL_EXAMPLE_REDIS_PASSWORD:?set it for local demo}"
+`,
+			wantContains: nil,
+		},
+		{
+			name: "credential keyword inside a comment is not flagged",
+			yaml: `services:
+  db:
+    image: postgres:16
+    # POSTGRES_PASSWORD: example-do-not-flag
+`,
+			wantContains: nil,
+		},
+		{
+			name: "fallback default in command array is still flagged",
+			yaml: `services:
+  redis:
+    command:
+      - "--requirepass"
+      - "${REDIS_PASSWORD:-weakdefault}"
+`,
+			wantContains: []string{"REDIS_PASSWORD"},
+		},
+		{
+			name: "mapping fallback is still flagged",
+			yaml: `services:
+  db:
+    environment:
+      POSTGRES_PASSWORD: ${VAR:-gocell}
+`,
+			wantContains: []string{"POSTGRES_PASSWORD"},
+		},
+		{
+			name: "non-credential command items are ignored",
+			yaml: `services:
+  redis:
+    command:
+      - "redis-server"
+      - "--appendonly"
+`,
+			wantContains: nil,
+		},
+		{
+			name:         "unparseable YAML fails closed",
+			yaml:         "services:\n  db:\n    command: [unterminated\n",
+			wantContains: []string{"not valid YAML"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			diags := scanComposeCredentialViolations("docker-compose.yml", []byte(tt.yaml))
+			require.Len(t, diags, len(tt.wantContains), "diags: %+v", diags)
+			for i, want := range tt.wantContains {
+				assert.Contains(t, diags[i].Message, want)
+			}
+		})
+	}
+}
+
 func TestFindUpgradeConfigWithoutAuthenticator_DetectsLiteralWithMissingField(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

修 `SEC-FAIL-CLOSED-05` 误报：compose 扫描器改用 `yaml.v3` 结构化解析，不再按首个 `:` 字符串切 `KEY:VALUE`。

## Why / 背景

旧 `scanComposeCredentialViolations` 用 `strings.Cut(line, ":")` 切行。对 YAML sequence item（如 redis `--requirepass "${VAR:?msg}"`），首个 `:` 落在 `:?` 上 → key 片段含 `PASSWORD` 误判为凭据键、value 片段已不像 `${...}` 误判非 required → 把一行**本就 fail-closed 的 required 插值**报成违规（`examples/ssobff/docker-compose.yml:33`）。

误报本身不是漏洞，真正缺陷是 **parser 不可靠且带 fail-open 维度**：对一个真正坏的 command 凭据（如 `--requirepass ${VAR:-weak}`）判定同样是垃圾、可能漏判。改用结构化解析后，mapping/sequence/注释/引号/`:?` 冒号全由 YAML 解码器处理，**整类**首个 `:` 误切构造性不可能。

- mapping entry：凭据键治理其标量值（key-based，语义不变）。
- sequence item：标量 `${NAME...}` 的 `NAME` 命中凭据名时治理（env-ref，反转误报）。
- 不可解析的 compose 文件 **fail-closed**（报而非静默放行）。
- 检测口径不变；不加 `--requirepass` 跨行 flag 追踪（无状态）。

AI-robust：同 Medium 载体（YAML content-scan）内，由字符串启发式升级为结构化解析（构造即正确）。补表驱动 `TestScanComposeCredentialViolations_Structural`（3 个 RED→GREEN 驱动 + 2 个 anti-vacuity 守卫 + fail-closed）。`SEC-FAIL-CLOSED-05` dogfood 红转绿。

## Refs

Closes #2176

## Risk / 兼容性

无 wire / migration / 契约影响——仅 archtest 内部扫描器实现，无外部消费方。`go.mod`/`go.sum` 无变更（`yaml.v3` 已是 `tools` 模块直接依赖）。

> 验证时全量 archtest 另有 **1 个与本 PR 无关的预存红**：`PROJECTION-CONSUMERBASE-WIRING-01`（`examples/orderfulfillment/run.go` 缺 `WithConsumerBase`）。已确认该 gap 存在于 `origin/develop`、本分支未触及 `examples/orderfulfillment`，由既有 issue **#2174** 跟踪，不在本 PR 范围。

## Test plan

- [x] `go -C tools build -tags archtest ./...` 本地通过
- [x] `go -C tools test -tags archtest ./archtest/ -run 'TestScanComposeCredentialViolations_Structural|TestSEC05|TestSecurityDefaults'` 全绿（含 SEC-05 dogfood 红转绿）
- [x] `golangci-lint run --build-tags archtest --new-from-merge-base=origin/develop ./archtest/` 0 issues
