### PR TITLE
fix(archtest): GOSEC-G101-ROWSCOPE-CARVEOUT gosec G101 误报 → path-scoped 豁免 archtest 目录 [#2185]

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -949,7 +949,10 @@ linters:
       # false positive across this whole directory (test carve-out maps AND
       # non-test scanner sources). Same justification as the errcode.go G101
       # waiver below: the matched strings are documentation/identifiers, not
-      # secrets. Path-scoped to tools/archtest/ (not a global G101 disable).
+      # secrets. Path-scoped to tools/archtest/ (not a global G101 disable). This
+      # rests on archtest's zero-secrets contract: a real credential literal in
+      # this tree would itself be a bug to fix at the source, not something to
+      # hide behind this waiver.
       - path: ^tools/archtest/
         linters:
           - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -939,6 +939,21 @@ linters:
         linters:
           - gosec
         text: "G122"
+      # archtest governance scanners are static analyzers that assert about
+      # OTHER code's structure — they never hold real credentials. Their files
+      # naturally contain the auth vocabulary they police (method names like
+      # UpdatePassword, carve-out rationale strings such as "CAS write
+      # (password); not a row read", scan patterns referencing token/secret/
+      # bcrypt). gosec G101's pattern (passwd|pass|password|pwd|secret|token|
+      # apikey) matches those human-readable strings, so G101 is a categorical
+      # false positive across this whole directory (test carve-out maps AND
+      # non-test scanner sources). Same justification as the errcode.go G101
+      # waiver below: the matched strings are documentation/identifiers, not
+      # secrets. Path-scoped to tools/archtest/ (not a global G101 disable).
+      - path: ^tools/archtest/
+        linters:
+          - gosec
+        text: "G101"
       - path: ^tools/metricschema/
         linters:
           - gosec

--- a/tools/archtest/http_idempotency_assembly_scope_test.go
+++ b/tools/archtest/http_idempotency_assembly_scope_test.go
@@ -944,7 +944,7 @@ func DeriveKey(tenantID, subject, method, path, idemKey string) IdempotencyKey {
 // deriveKeyBad: each fixture drops one isolation dimension (caught by the taint
 // walk) or adds a node-id param (caught by the signature freeze). The dummy-read
 // fixture references every input but flows only subject into the key.
-var deriveKeyBad = map[string]string{ //nolint:gosec,gochecknoglobals // G101 false positive: values are Go source fixtures, not credentials
+var deriveKeyBad = map[string]string{ //nolint:gochecknoglobals // intentional package-level RED-case fixture map
 	"node-id-param": `package p
 func DeriveKey(tenantID, subject, method, path, idemKey, podID string) IdempotencyKey {
 	return IdempotencyKey{ns: tenantID + podID, key: subject + method + path + idemKey}
@@ -1008,7 +1008,7 @@ func DeriveCommandKey(tenantID, subject, commandID string) IdempotencyKey {
 // deriveCommandKeyBad: each fixture drops one isolation dimension (caught by the
 // taint walk) or adds a node-id param (caught by the signature freeze). The
 // dummy-read fixture references commandID but flows only subject into the key.
-var deriveCommandKeyBad = map[string]string{ //nolint:gosec,gochecknoglobals // G101: Go source fixtures, not credentials
+var deriveCommandKeyBad = map[string]string{ //nolint:gochecknoglobals // intentional package-level RED-case fixture map
 	"node-id-param": `package p
 func DeriveCommandKey(tenantID, subject, commandID, podID string) IdempotencyKey {
 	return IdempotencyKey{ns: tenantID + podID, key: subject + commandID}

--- a/tools/archtest/svctoken_caller_cell.go
+++ b/tools/archtest/svctoken_caller_cell.go
@@ -44,8 +44,6 @@ import (
 )
 
 // ruleSvctokenCallerCellRequired01 is the archtest rule identifier; not a credential.
-//
-//nolint:gosec // G101 false positive: archtest rule identifier, not a credential
 const ruleSvctokenCallerCellRequired01 = "SVCTOKEN-CALLER-CELL-REQUIRED-01"
 
 // authRuntimeImportPath is the canonical import path for runtime/auth.


### PR DESCRIPTION
## Summary

`.golangci.yml` 给 `tools/archtest/` 加 path-scoped gosec **G101** 豁免，消除治理 scanner 文件里人类可读字符串触发的「hardcoded credentials」范畴性误报；同 PR 清理因此变冗余的逐点 `//nolint:gosec`。

## Why / 背景

`golangci-lint` **full 模式**（`ci.yml` push:develop 的 build-test kernel shard）报 1 issue：

```
tools/archtest/rowscope_repo_param_funnel_test.go:168:29: G101: Potential hardcoded credentials (gosec)
```

gosec G101 pattern `(?i)passwd|pass|password|pwd|secret|token|apikey` 匹配到 archtest 治理 scanner 文件里**人类可读的方法名 / 理由说明串**——例如 carve-out map 的 `"CAS write (password); not a row read"`、`SVCTOKEN-CALLER-CELL-REQUIRED-01` 规则标识。archtest 是断言「其他代码结构」的静态分析器，**天然引用所巡查的 auth 词汇**（`password` / `token` / `secret` / `bcrypt`），却从不持有真凭据 → 纯误报。

误报是**整目录范畴性**的：不止 issue 那一行，多个**非 test** scanner 源（`bcrypt_cost_funnel.go` / `auth_*` / `audit_hash_input_frozen.go` …）同样命中。PR CI 经 `--new-from-merge-base` 把它作 baseline 抑制故 PR 绿，**仅 push:develop full-lint 暴露**。

本地 RED 复现（go1.26.1 / golangci-lint v2.11.4，与 CI pin 同版本）：

```
cd tools && GOWORK=off golangci-lint run --config "$PWD/../.golangci.yml" \
  --build-tags=archtest,releasesmoke --enable-only gosec ./archtest/...
# → rowscope_repo_param_funnel_test.go:168:29: G101 ...
```

> 关键：archtest leaf 受 `//go:build archtest` gate，CI 对 tools module 用 `--build-tags=archtest,releasesmoke`；不带 tag 跑会跳过这些文件、复现不出。

## 方案

`.golangci.yml` `linters.exclusions.rules` 加一条 path-scoped 豁免，**复刻同文件内两处现成先例**：`^framework/pkg/errcode/errcode.go` 的 G101 豁免（const 是 wire 标识符非凭据）+ `^tools/archtest/` 的 G122 豁免（trusted scanner context）。

```yaml
- path: ^tools/archtest/
  linters: [gosec]
  text: "G101"
```

- **彻底**：whole-dir 覆盖整类误报（test carve-out map + 非 test scanner 源），非只贴当前一行。
- **优雅简洁**：一条声明式豁免；该豁免使既有逐点 inline `//nolint:gosec`(G101) 冗余（`nolintlint allow-unused:false` 即报）→ 同 PR 清理 3 处：`svctoken_caller_cell.go` 整行删；`http_idempotency_assembly_scope_test.go` 两处 `gosec,gochecknoglobals` 组合指令仅删冗余 `gosec` token、保留 disabled 的 `gochecknoglobals`。
- **开源对标**：golangci-lint 官方对范畴性误报建议优先集中 `exclusions.rules` 而非 per-site nolint；Grafana 用全局豁免 G101（过宽），本仓 path-scoped（非全局禁用）更优。

## Refs

Closes #2185

ref: golangci-lint `linters.exclusions.rules`（范畴性误报优先集中 config 豁免而非 per-site `//nolint`）

## Risk / 兼容性

无。纯 lint config + 注释清理，无 Go 语义 / wire 契约 / migration 影响。豁免 **path-scoped 到 `^tools/archtest/`**（非全局 G101 disable），不影响其他路径的真实 G101 检出；archtest 是静态治理 scanner、不连接外部系统、不持真凭据，故 G101 在此目录零真阳性。

## Test plan

- [x] `go build -tags=archtest,releasesmoke ./archtest/...` 本地通过
- [x] `go test -tags=archtest`（touched archtest 规则：Svctoken / HTTPIdempotency / RowScopeRepoParam）本地通过
- [x] `golangci-lint run`（tools module 全量，`--build-tags=archtest,releasesmoke`，CI-faithful）→ **0 issues**（修前 1 = 该 G101）
- [x] `golangci-lint config verify` 通过（v2 schema 合法）
