### PR TITLE
feat(topology): broker-mandatory 双闸 fail-fast——split 拓扑 ∧ in-memory EventBus 静态+启动期拒绝 [1423-US3]

### DIFF
--- a/docs/guides/deployment-topology.md
+++ b/docs/guides/deployment-topology.md
@@ -57,16 +57,20 @@ accepted (useful for dev/compose multi-process topologies).
 
 ## Static enforcement by `gocell validate`
 
-Three governance rules enforce deployment topology:
+Four governance rules enforce deployment topology:
 
 | Rule | What it checks |
 |------|---------------|
 | **TOPO-10** | Structural validity: mutual exclusion, exhaustive partition, valid endpoints |
 | **TOPO-11** | Provider reachability: every contract consumed by a cell in the assembly must have its provider cell reachable (colocated or remote) within that assembly |
 | **TOPO-12** | INTERIM: topology.remote fail-closed until US4 #1963 wires transport |
+| **TOPO-13** | Broker-mandatory static gate (US3 #1965): in a split topology, an event contract whose publisher and subscriber fall on opposite sides of the process boundary requires a real broker — the in-memory EventBus cannot deliver events across processes |
 
-Run `gocell validate` to check all three. TOPO-12 fires if any assembly declares
-`topology.remote`; remove it until US4 lands.
+Run `gocell validate` to check all four. TOPO-12 fires if any assembly declares
+`topology.remote`; remove it until US4 lands. TOPO-13 is forward-looking: it is
+production-shadowed by the interim TOPO-12 (which blanket-rejects `remote`) and
+proven by synthetic unit tests until TOPO-12 is removed, after which it becomes
+the event-specific broker guard.
 
 ## Example YAML
 
@@ -92,9 +96,16 @@ topology:
 
 When cells are split across processes, the following infrastructure is required:
 
-- **Event transport broker** (US3 #1965): remote cells need a real message
-  broker (e.g. RabbitMQ) to exchange events across process boundaries. In
-  postgres topology this is provisioned via `GOCELL_AMQP_URL`.
+- **Event transport broker** (US3 #1965, enforced): remote cells need a real
+  message broker (e.g. RabbitMQ) to exchange events across process boundaries.
+  In postgres topology this is provisioned via `GOCELL_AMQP_URL`. A split
+  topology combined with an in-memory EventBus is rejected by a **double gate**:
+  the static `gocell validate` rule TOPO-13 and a bootstrap **phase0 runtime
+  gate** (`validateSplitTopologyBroker`) that fail-fasts when the deployment has
+  remote cells while `StorageBackend() != postgres` (the in-memory bus is
+  reachable only in non-postgres topology — #1940 funnel). The runtime gate is a
+  coarse proxy: it fires on any remote cell, even one with only sync (no
+  cross-process events); a precise codegen-derived signal is a follow-up.
 - **Remote sync transport** (US4 #1963 / US5 #1966): a remote dispatch
   transport layer for synchronous cross-cell calls (planned, not yet
   implemented). US4 also removes the TOPO-12 fail-close gate.

--- a/docs/guides/deployment-topology.md
+++ b/docs/guides/deployment-topology.md
@@ -122,11 +122,12 @@ split topology in production. `topology.remote` is fail-closed until US4 lands.
 
 **Diagnosing broker status via `/readyz?verbose`**: the framework-level
 `Topology.AdapterInfo()` method returns `"in-memory"` by default. In a postgres
-topology, the composition root (`cmd/corebundle`) overrides this value with the
-actual broker descriptor (e.g. `"rabbitmq:<amqp-url>"`). When interpreting the
-`event_bus` field in verbose readyz output, use the value reported by the
-composition root override — the framework default is not meaningful in a
-postgres deployment.
+topology, the composition root (`cmd/corebundle`) overrides the `event_bus`
+value with the broker kind — currently the literal `"rabbitmq"` (the broker
+*kind*, never the connection URL, which would leak the AMQP credentials). When
+interpreting the `event_bus` field in verbose readyz output, use the value
+reported by the composition root override — the framework default is not
+meaningful in a postgres deployment.
 
 ## ADR reference
 

--- a/docs/guides/deployment-topology.md
+++ b/docs/guides/deployment-topology.md
@@ -67,10 +67,14 @@ Four governance rules enforce deployment topology:
 | **TOPO-13** | Broker-mandatory static gate (US3 #1965): in a split topology, an event contract whose publisher and subscriber fall on opposite sides of the process boundary requires a real broker — the in-memory EventBus cannot deliver events across processes |
 
 Run `gocell validate` to check all four. TOPO-12 fires if any assembly declares
-`topology.remote`; remove it until US4 lands. TOPO-13 is forward-looking: it is
-production-shadowed by the interim TOPO-12 (which blanket-rejects `remote`) and
-proven by synthetic unit tests until TOPO-12 is removed, after which it becomes
-the event-specific broker guard.
+`topology.remote`; remove it until US4 lands. TOPO-13 runs normally in
+`gocell validate` and would fire on cross-process event pub/sub, but its trigger
+condition (split topology with cross-process event pub/sub) is currently
+**unreachable** because TOPO-12 issues a blanket rejection of all
+`topology.remote` declarations first — TOPO-13 is not disabled, it simply has
+no valid input to check until TOPO-12 is removed. Correctness is proven by
+synthetic RED/GREEN unit tests. When TOPO-12 is removed (US5 #1966), TOPO-13
+becomes the event-specific broker guard for split topologies.
 
 ## Example YAML
 
@@ -115,6 +119,14 @@ When cells are split across processes, the following infrastructure is required:
 
 Currently, `cmd/corebundle` is an all-colocated assembly and does not use
 split topology in production. `topology.remote` is fail-closed until US4 lands.
+
+**Diagnosing broker status via `/readyz?verbose`**: the framework-level
+`Topology.AdapterInfo()` method returns `"in-memory"` by default. In a postgres
+topology, the composition root (`cmd/corebundle`) overrides this value with the
+actual broker descriptor (e.g. `"rabbitmq:<amqp-url>"`). When interpreting the
+`event_bus` field in verbose readyz output, use the value reported by the
+composition root override — the framework default is not meaningful in a
+postgres deployment.
 
 ## ADR reference
 

--- a/framework/kernel/governance/rule_inventory_test.go
+++ b/framework/kernel/governance/rule_inventory_test.go
@@ -185,7 +185,8 @@ func goldenRuleIDs() []string {
 		// exhaustiveness, endpoint syntax).
 		// TOPO-11: per-assembly contract-provider reachability gate.
 		// TOPO-12: INTERIM topology.remote fail-close gate until US4 #1963.
-		"TOPO-10", "TOPO-11", "TOPO-12",
+		// TOPO-13: broker-mandatory static gate (Epic #1423 US3, permanent).
+		"TOPO-10", "TOPO-11", "TOPO-12", "TOPO-13",
 
 		// VERIFY — verification closure (rules_verify.go)
 		"VERIFY-01", "VERIFY-02", "VERIFY-03",

--- a/framework/kernel/governance/rulecodes.go
+++ b/framework/kernel/governance/rulecodes.go
@@ -77,6 +77,19 @@ const (
 	// The runtime DeploymentTopology API and ValidateTopologyStructure intentionally
 	// still accept remote (US4-ready shape preserved in schema).
 	codeTOPO12 RuleCode = "TOPO-12"
+	// TOPO-13: broker-mandatory static gate (Epic #1423 US3). For an assembly
+	// with a split topology, an event contract whose publisher cell and a
+	// subscriber cell fall on opposite sides of the process boundary (one Local,
+	// one Remote) requires a real broker — the in-memory EventBus cannot deliver
+	// across processes. Medium, permanent ceiling (Hard unreachable: bus is a
+	// runtime-injected instance, not statically expressible — ADR 1423 §214-219).
+	// Blind-spots: (1) production-shadowed by the interim TOPO-12 (blanket remote
+	// ban) until US5 #1966 removes it; proven via synthetic unit test until then.
+	// (2) Structural-only — asserts cross-process pub/sub, cannot verify a broker
+	// is wired (runtime concern, enforced by the bootstrap runtime gate); thus
+	// fail-closed and over-constrains future broker-backed split (US7 #1967
+	// reconciliation tracked separately).
+	codeTOPO13 RuleCode = "TOPO-13"
 
 	// VERIFY — verify closure (rules_verify.go; VERIFY-06 strict-only).
 	codeVERIFY01 RuleCode = "VERIFY-01"

--- a/framework/kernel/governance/rules_registry.go
+++ b/framework/kernel/governance/rules_registry.go
@@ -54,6 +54,8 @@ var allRules = []Rule{
 	{Code: codeTOPO11, Phase: PhaseBase, Detect: (*Validator).validateTOPO11},
 	// TOPO-12: INTERIM remote placement fail-close gate. Remove when US4 #1963 lands.
 	{Code: codeTOPO12, Phase: PhaseBase, Detect: (*Validator).validateTOPO12},
+	// TOPO-13: broker-mandatory static gate (Epic #1423 US3, permanent).
+	{Code: codeTOPO13, Phase: PhaseBase, Detect: (*Validator).validateTOPO13},
 
 	// VERIFY — verify closure (VERIFY-06 is PhaseStrict below)
 	{Code: codeVERIFY01, Phase: PhaseBase, Detect: (*Validator).validateVERIFY01},

--- a/framework/kernel/governance/rules_topo.go
+++ b/framework/kernel/governance/rules_topo.go
@@ -689,16 +689,19 @@ func (v *Validator) validateTOPO06() []ValidationResult {
 //     broker is actually wired (runtime concern, enforced by the bootstrap
 //     runtime gate). This causes TOPO-13 to over-constrain future broker-backed
 //     split topologies (US7 #1967 reconciliation tracked separately).
-//  3. When pub and sub are BOTH Remote from this assembly's perspective,
-//     pubLoc.IsLocal() != subLoc.IsLocal() evaluates to false != false == false
-//     and TOPO-13 does NOT fire. This is correct per-assembly behavior: if this
-//     assembly is not the host of either party, the cross-process concern belongs
-//     to the assembly that IS the publisher's local host — TOPO-13 will fire
-//     there. Intentional non-firing confirmed by TestTOPO13_BothRemote_NotFired.
+//
+// Cross-process detection is per-assembly and self-contained: a pub/sub pair is
+// cross-process unless both cells share a process within THIS assembly — i.e.
+// both colocated, or both remote at the SAME endpoint (deployed together). Two
+// remote cells at DIFFERENT endpoints are different processes and DO fire (see
+// isCrossProcessEventPair); each assembly fail-closes its own cross-process
+// events rather than relying on another assembly to catch them.
 //
 // Skip conditions (delegated to other rules or out-of-scope):
 //   - assembly has no topology.remote (all-colocated → no cross-process boundary)
 //   - contract kind != event (HTTP/command/etc. are out of scope for broker rule)
+//   - contract lifecycle != active (draft/deprecated events are not served, so
+//     they carry no live broker requirement — same active-only scope as ADV-05)
 //   - framework-owned contract (provider-agnostic; c.Owner().IsFramework())
 //   - publisher cell not found in project.Cells (external actor — topology governs cells only)
 //   - ClassifyCell(asm, publisher).IsMissing() (not in this assembly — TOPO-11 covers reachability)
@@ -746,6 +749,11 @@ func (v *Validator) checkTOPO13Contract(asm *metadata.AssemblyMeta, c *metadata.
 	if cellvocab.ContractKind(c.Kind) != cellvocab.ContractEvent {
 		return nil
 	}
+	// Only active contracts are served — draft/deprecated events carry no live
+	// broker requirement (same active-only scope as ADV-05's dead-event check).
+	if c.Lifecycle != lifecycleActive {
+		return nil
+	}
 	// Framework-owned contracts are provider-agnostic — skip.
 	if c.Owner().IsFramework() {
 		return nil
@@ -772,16 +780,15 @@ func (v *Validator) checkTOPO13Contract(asm *metadata.AssemblyMeta, c *metadata.
 		if subLoc.IsMissing() {
 			continue // subscriber not in this assembly — TOPO-11 covers reachability
 		}
-		if pubLoc.IsLocal() != subLoc.IsLocal() {
-			// One side is Local, the other is Remote — cross-process boundary.
+		if isCrossProcessEventPair(pubLoc, subLoc) {
 			results = append(results, v.newError(
 				codeTOPO13, IssueForbidden,
 				assemblyFile(asm),
 				"topology",
 				fmt.Sprintf(
 					"assembly %q splits event contract %q across processes:"+
-						" publisher cell %q and subscriber cell %q are on opposite sides"+
-						" of the process boundary;"+
+						" publisher cell %q and subscriber cell %q are not co-located"+
+						" in the same process;"+
 						" the in-memory EventBus cannot deliver events across processes"+
 						" — a real broker is required",
 					asm.ID, c.ID, pub, sub,
@@ -795,6 +802,30 @@ func (v *Validator) checkTOPO13Contract(asm *metadata.AssemblyMeta, c *metadata.
 		}
 	}
 	return results
+}
+
+// isCrossProcessEventPair reports whether an event published by a cell at pubLoc
+// and consumed by a cell at subLoc crosses a process boundary within the
+// assembly being checked — in which case the in-memory EventBus cannot deliver
+// it and a real broker is required. Two cells share a process iff they are both
+// colocated (this assembly's process) OR both remote at the SAME endpoint
+// (deployed together). Any other combination (one local + one remote, or two
+// remotes at DIFFERENT endpoints) is cross-process.
+//
+// Callers pre-filter Missing locations (TOPO-11 covers reachability), so only
+// Local/Remote pairs reach here. Endpoint comparison is raw string equality:
+// non-normalized but equivalent endpoint forms compare unequal and therefore
+// fail-closed (over-flag rather than under-flag), the safe direction.
+func isCrossProcessEventPair(pubLoc, subLoc metadata.CellLocation) bool {
+	if pubLoc.IsLocal() && subLoc.IsLocal() {
+		return false // both in this assembly's process
+	}
+	if pubLoc.IsRemote() && subLoc.IsRemote() {
+		pubEP, _ := pubLoc.RemoteEndpoint()
+		subEP, _ := subLoc.RemoteEndpoint()
+		return pubEP != subEP // same remote endpoint = same process
+	}
+	return true // one local + one remote → cross-process
 }
 
 // validateTOPO12 is the INTERIM fail-close gate for topology.remote.

--- a/framework/kernel/governance/rules_topo.go
+++ b/framework/kernel/governance/rules_topo.go
@@ -689,6 +689,12 @@ func (v *Validator) validateTOPO06() []ValidationResult {
 //     broker is actually wired (runtime concern, enforced by the bootstrap
 //     runtime gate). This causes TOPO-13 to over-constrain future broker-backed
 //     split topologies (US7 #1967 reconciliation tracked separately).
+//  3. When pub and sub are BOTH Remote from this assembly's perspective,
+//     pubLoc.IsLocal() != subLoc.IsLocal() evaluates to false != false == false
+//     and TOPO-13 does NOT fire. This is correct per-assembly behavior: if this
+//     assembly is not the host of either party, the cross-process concern belongs
+//     to the assembly that IS the publisher's local host — TOPO-13 will fire
+//     there. Intentional non-firing confirmed by TestTOPO13_BothRemote_NotFired.
 //
 // Skip conditions (delegated to other rules or out-of-scope):
 //   - assembly has no topology.remote (all-colocated → no cross-process boundary)
@@ -782,7 +788,9 @@ func (v *Validator) checkTOPO13Contract(asm *metadata.AssemblyMeta, c *metadata.
 				),
 				"co-locate publisher and subscriber (topology.colocated),"+
 					" or deploy with a real event broker"+
-					" (GOCELL_CELL_ADAPTER_MODE=postgres + GOCELL_AMQP_URL)",
+					" (GOCELL_CELL_ADAPTER_MODE=postgres + GOCELL_ADAPTER_MODE=real + GOCELL_AMQP_URL);"+
+					" if a broker is already configured but this still fires,"+
+					" the broker-backed split path lands in US7 #1967",
 			))
 		}
 	}

--- a/framework/kernel/governance/rules_topo.go
+++ b/framework/kernel/governance/rules_topo.go
@@ -671,6 +671,124 @@ func (v *Validator) validateTOPO06() []ValidationResult {
 	return results
 }
 
+// validateTOPO13 is the broker-mandatory static gate (Epic #1423 US3, Medium,
+// permanent ceiling). For every assembly that declares a split topology
+// (len(topology.remote) > 0), it checks whether any active event contract
+// has a publisher cell and a subscriber cell on opposite sides of the process
+// boundary. The in-memory EventBus cannot deliver events across processes; a
+// real broker is required.
+//
+// Rating: Medium — permanent ceiling. Hard is unreachable: the EventBus is a
+// runtime-injected instance, not statically expressible (ADR 1423 §214-219).
+//
+// Blind-spots:
+//  1. Production-shadowed by the interim TOPO-12 (blanket topology.remote ban)
+//     until US5 #1966 removes TOPO-12. Proven effective via synthetic unit tests
+//     until then.
+//  2. Structural-only gate: asserts cross-process pub/sub but cannot verify a
+//     broker is actually wired (runtime concern, enforced by the bootstrap
+//     runtime gate). This causes TOPO-13 to over-constrain future broker-backed
+//     split topologies (US7 #1967 reconciliation tracked separately).
+//
+// Skip conditions (delegated to other rules or out-of-scope):
+//   - assembly has no topology.remote (all-colocated → no cross-process boundary)
+//   - contract kind != event (HTTP/command/etc. are out of scope for broker rule)
+//   - framework-owned contract (provider-agnostic; c.Owner().IsFramework())
+//   - publisher cell not found in project.Cells (external actor — topology governs cells only)
+//   - ClassifyCell(asm, publisher).IsMissing() (not in this assembly — TOPO-11 covers reachability)
+//   - subscriber not found in project.Cells (external actor — same as publisher skip)
+//   - ClassifyCell(asm, subscriber).IsMissing() (not in this assembly)
+func (v *Validator) validateTOPO13() []ValidationResult {
+	var results []ValidationResult
+
+	keys := make([]string, 0, len(v.project.Assemblies))
+	for k := range v.project.Assemblies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, asmID := range keys {
+		asm := v.project.Assemblies[asmID]
+		if asm == nil || len(asm.Topology.Remote) == 0 {
+			continue // only split assemblies need a broker
+		}
+		results = append(results, v.checkTOPO13Assembly(asm)...)
+	}
+	return results
+}
+
+// checkTOPO13Assembly checks every event contract for cross-process pub/sub in one assembly.
+func (v *Validator) checkTOPO13Assembly(asm *metadata.AssemblyMeta) []ValidationResult {
+	var results []ValidationResult
+
+	contractKeys := make([]string, 0, len(v.project.Contracts))
+	for k := range v.project.Contracts {
+		contractKeys = append(contractKeys, k)
+	}
+	sort.Strings(contractKeys)
+
+	for _, cid := range contractKeys {
+		c := v.project.Contracts[cid]
+		results = append(results, v.checkTOPO13Contract(asm, c)...)
+	}
+	return results
+}
+
+// checkTOPO13Contract checks a single contract for cross-process event pub/sub in the assembly.
+func (v *Validator) checkTOPO13Contract(asm *metadata.AssemblyMeta, c *metadata.ContractMeta) []ValidationResult {
+	// Only event contracts require a broker for cross-process delivery.
+	if cellvocab.ContractKind(c.Kind) != cellvocab.ContractEvent {
+		return nil
+	}
+	// Framework-owned contracts are provider-agnostic — skip.
+	if c.Owner().IsFramework() {
+		return nil
+	}
+	pub := contractProvider(c) // publisher cell (endpoints.publisher)
+	if pub == "" {
+		return nil
+	}
+	// External actor publisher — topology only governs cells.
+	if _, knownCell := v.project.Cells[pub]; !knownCell {
+		return nil
+	}
+	pubLoc := metadata.ClassifyCell(asm, pub)
+	if pubLoc.IsMissing() {
+		return nil // publisher not in this assembly — TOPO-11 covers reachability
+	}
+
+	var results []ValidationResult
+	for _, sub := range contractConsumers(c) {
+		if _, knownCell := v.project.Cells[sub]; !knownCell {
+			continue // external actor subscriber — not governed by topology
+		}
+		subLoc := metadata.ClassifyCell(asm, sub)
+		if subLoc.IsMissing() {
+			continue // subscriber not in this assembly — TOPO-11 covers reachability
+		}
+		if pubLoc.IsLocal() != subLoc.IsLocal() {
+			// One side is Local, the other is Remote — cross-process boundary.
+			results = append(results, v.newError(
+				codeTOPO13, IssueForbidden,
+				assemblyFile(asm),
+				"topology",
+				fmt.Sprintf(
+					"assembly %q splits event contract %q across processes:"+
+						" publisher cell %q and subscriber cell %q are on opposite sides"+
+						" of the process boundary;"+
+						" the in-memory EventBus cannot deliver events across processes"+
+						" — a real broker is required",
+					asm.ID, c.ID, pub, sub,
+				),
+				"co-locate publisher and subscriber (topology.colocated),"+
+					" or deploy with a real event broker"+
+					" (GOCELL_CELL_ADAPTER_MODE=postgres + GOCELL_AMQP_URL)",
+			))
+		}
+	}
+	return results
+}
+
 // validateTOPO12 is the INTERIM fail-close gate for topology.remote.
 // Until US4 #1963 wires cross-process transport, a non-empty topology.remote
 // declaration cannot be honored — the cell would still be composed locally

--- a/framework/kernel/governance/rules_topo13_test.go
+++ b/framework/kernel/governance/rules_topo13_test.go
@@ -285,25 +285,14 @@ func TestTOPO13_PublisherRemote_SubscriberLocal(t *testing.T) {
 	assert.Equal(t, SeverityError, got[0].Severity)
 }
 
-// TestTOPO13_BothRemote_NotFired documents and locks the intentional per-assembly
-// skip when BOTH publisher and subscriber are in topology.remote from THIS
-// assembly's perspective.
-//
-// Per-assembly semantics: when this assembly is not the local host of either the
-// pub or the sub, pubLoc.IsLocal() == false and subLoc.IsLocal() == false, so
-// the cross-process condition (IsLocal() != IsLocal()) evaluates false — TOPO-13
-// does NOT fire here. The violation is detected by whichever assembly IS the
-// publisher's local host. This is correct non-missing behavior, not a detector
-// defect. See validateTOPO13 godoc Blind-spots §3.
-func TestTOPO13_BothRemote_NotFired(t *testing.T) {
+// topo13BothRemoteProject builds a split assembly where pub and sub are BOTH in
+// topology.remote (at the given endpoints) plus a colocated bystander so the
+// assembly counts as split.
+func topo13BothRemoteProject(pubEndpoint, subEndpoint string) *metadata.ProjectMeta {
 	pub := metadatatest.CellIDCellA
 	sub := metadatatest.CellIDCellB
-	// A third bystander cell is colocated so the assembly counts as split
-	// (has topology.remote), but both pub and sub are in remote from this
-	// assembly's perspective.
 	bystander := "cellC"
-
-	pm := &metadata.ProjectMeta{
+	return &metadata.ProjectMeta{
 		Cells: map[string]*metadata.CellMeta{
 			pub:       topoTestCell(pub),
 			sub:       topoTestCell(sub),
@@ -320,22 +309,67 @@ func TestTOPO13_BothRemote_NotFired(t *testing.T) {
 		Journeys: map[string]*metadata.JourneyMeta{},
 		Assemblies: map[string]*metadata.AssemblyMeta{
 			"testasm": topoTestAssembly([]string{pub, sub, bystander}, metadata.TopologyMeta{
-				Colocated: []string{bystander}, // only bystander is local
+				Colocated: []string{bystander},
 				Remote: []metadata.TopologyRemoteEntry{
-					{CellID: pub, Endpoint: "pub.svc:9090"},
-					{CellID: sub, Endpoint: "sub.svc:9090"},
+					{CellID: pub, Endpoint: pubEndpoint},
+					{CellID: sub, Endpoint: subEndpoint},
 				},
 			}),
 		},
 	}
-	val := NewValidator(pm, ".", clock.Real())
-	got := findByCode(val.validateTOPO13(), codeTOPO13)
-	// INTENTIONAL zero findings: both pub and sub are Remote → IsLocal()==false for
-	// both → IsLocal()!=IsLocal() is false → no cross-process split detected from
-	// THIS assembly's viewpoint (per-assembly semantics; see godoc Blind-spots §3).
+}
+
+// TestTOPO13_BothRemote_DifferentEndpoint_Fired locks the fix for the both-remote
+// blind-spot: two remote cells at DIFFERENT endpoints are different processes, so
+// their cross-process event pub/sub DOES require a broker (each assembly
+// fail-closes its own cross-process events; #2188 review F1).
+func TestTOPO13_BothRemote_DifferentEndpoint_Fired(t *testing.T) {
+	pm := topo13BothRemoteProject("pub.svc:9090", "sub.svc:9090")
+	got := findByCode(NewValidator(pm, ".", clock.Real()).validateTOPO13(), codeTOPO13)
+	assert.NotEmpty(t, got,
+		"both-remote pub/sub at different endpoints are different processes → TOPO-13 must fire")
+}
+
+// TestTOPO13_BothRemote_SameEndpoint_NotFired: two remote cells at the SAME
+// endpoint are deployed together (same process), so in-memory delivery between
+// them is fine — no broker required, no finding.
+func TestTOPO13_BothRemote_SameEndpoint_NotFired(t *testing.T) {
+	pm := topo13BothRemoteProject("colo.svc:9090", "colo.svc:9090")
+	got := findByCode(NewValidator(pm, ".", clock.Real()).validateTOPO13(), codeTOPO13)
 	assert.Empty(t, got,
-		"both-remote pub/sub should produce 0 TOPO-13 findings from this assembly's perspective "+
-			"(per-assembly semantics: cross-process concern belongs to the publisher's host assembly)")
+		"both-remote pub/sub at the SAME endpoint share a process → TOPO-13 must NOT fire")
+}
+
+// TestTOPO13_DraftEvent_Skipped: a cross-process event whose contract is not
+// active (draft/deprecated) is not served, so it carries no live broker
+// requirement — TOPO-13 skips it (active-only scope, #2188 review F4).
+func TestTOPO13_DraftEvent_Skipped(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+	pm := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			pub: topoTestCell(pub),
+			sub: topoTestCell(sub),
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.data.v1": func() *metadata.ContractMeta {
+				c := topoTestContract("event.data.v1", "event", pub)
+				c.Lifecycle = "draft" // not active → not served
+				c.Endpoints.Subscribers = []string{sub}
+				return c
+			}(),
+		},
+		Journeys: map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"testasm": topoTestAssembly([]string{pub, sub}, metadata.TopologyMeta{
+				Colocated: []string{pub}, // pub local, sub remote → cross-process
+				Remote:    []metadata.TopologyRemoteEntry{{CellID: sub, Endpoint: "sub.svc:9090"}},
+			}),
+		},
+	}
+	got := findByCode(NewValidator(pm, ".", clock.Real()).validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got, "draft (non-active) cross-process event must be skipped by TOPO-13")
 }
 
 // TestTOPO13_AntiVacuity: explicit RED/GREEN fixture pair confirming the

--- a/framework/kernel/governance/rules_topo13_test.go
+++ b/framework/kernel/governance/rules_topo13_test.go
@@ -285,6 +285,59 @@ func TestTOPO13_PublisherRemote_SubscriberLocal(t *testing.T) {
 	assert.Equal(t, SeverityError, got[0].Severity)
 }
 
+// TestTOPO13_BothRemote_NotFired documents and locks the intentional per-assembly
+// skip when BOTH publisher and subscriber are in topology.remote from THIS
+// assembly's perspective.
+//
+// Per-assembly semantics: when this assembly is not the local host of either the
+// pub or the sub, pubLoc.IsLocal() == false and subLoc.IsLocal() == false, so
+// the cross-process condition (IsLocal() != IsLocal()) evaluates false — TOPO-13
+// does NOT fire here. The violation is detected by whichever assembly IS the
+// publisher's local host. This is correct non-missing behavior, not a detector
+// defect. See validateTOPO13 godoc Blind-spots §3.
+func TestTOPO13_BothRemote_NotFired(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+	// A third bystander cell is colocated so the assembly counts as split
+	// (has topology.remote), but both pub and sub are in remote from this
+	// assembly's perspective.
+	bystander := "cellC"
+
+	pm := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			pub:       topoTestCell(pub),
+			sub:       topoTestCell(sub),
+			bystander: topoTestCell(bystander),
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.data.v1": func() *metadata.ContractMeta {
+				c := topoTestContract("event.data.v1", "event", pub)
+				c.Endpoints.Subscribers = []string{sub}
+				return c
+			}(),
+		},
+		Journeys: map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"testasm": topoTestAssembly([]string{pub, sub, bystander}, metadata.TopologyMeta{
+				Colocated: []string{bystander}, // only bystander is local
+				Remote: []metadata.TopologyRemoteEntry{
+					{CellID: pub, Endpoint: "pub.svc:9090"},
+					{CellID: sub, Endpoint: "sub.svc:9090"},
+				},
+			}),
+		},
+	}
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	// INTENTIONAL zero findings: both pub and sub are Remote → IsLocal()==false for
+	// both → IsLocal()!=IsLocal() is false → no cross-process split detected from
+	// THIS assembly's viewpoint (per-assembly semantics; see godoc Blind-spots §3).
+	assert.Empty(t, got,
+		"both-remote pub/sub should produce 0 TOPO-13 findings from this assembly's perspective "+
+			"(per-assembly semantics: cross-process concern belongs to the publisher's host assembly)")
+}
+
 // TestTOPO13_AntiVacuity: explicit RED/GREEN fixture pair confirming the
 // detector is not vacuously passing.
 // RED: cross-process split → ≥1 TOPO-13 finding.

--- a/framework/kernel/governance/rules_topo13_test.go
+++ b/framework/kernel/governance/rules_topo13_test.go
@@ -1,0 +1,318 @@
+// INVARIANT: TOPO-13 broker-mandatory static gate (Epic #1423 US3)
+// Medium, permanent ceiling. Blind-spots: (1) production-shadowed by TOPO-12
+// (interim blanket remote ban) until US5 #1966; proven via synthetic unit tests
+// until then. (2) Cannot verify a broker is wired (runtime concern). See
+// validateTOPO13 godoc and ADR 202606131142-1423.
+
+package governance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/metadata"
+	"github.com/ghbvf/gocell/framework/kernel/metadata/metadatatest"
+)
+
+// buildTOPO13Project builds a ProjectMeta for TOPO-13 tests.
+// pubCellID is the publisher cell; subCellID is the subscriber cell.
+// Both are in the assembly with the given topology. The contract is always
+// kind=event because TOPO-13 only checks event contracts.
+func buildTOPO13Project(
+	pubCellID, subCellID string,
+	asmCellIDs []string,
+	topo metadata.TopologyMeta,
+) *metadata.ProjectMeta {
+	cells := map[string]*metadata.CellMeta{}
+	cells[pubCellID] = topoTestCell(pubCellID)
+	if subCellID != pubCellID {
+		cells[subCellID] = topoTestCell(subCellID)
+	}
+
+	contract := topoTestContract("event.data.v1", "event", pubCellID)
+	contract.Endpoints.Subscribers = []string{subCellID}
+
+	return &metadata.ProjectMeta{
+		Cells:  cells,
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.data.v1": contract,
+		},
+		Journeys: map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"testasm": topoTestAssembly(asmCellIDs, topo),
+		},
+	}
+}
+
+// =============================================================================
+// TOPO-13: broker-mandatory static gate
+// =============================================================================
+
+// TestTOPO13_CrossProcessEvent_Split is the primary RED test.
+// Publisher cell is in colocated; subscriber cell is in remote → cross-process
+// event pub/sub → TOPO-13 must fire.
+//
+// Anti-vacuity note: if this test returns 0 findings, the detector is broken.
+// TestTOPO13_ColocatedEvent_NoError must also pass (0 findings) to confirm the
+// detector is not a false-positive machine.
+func TestTOPO13_CrossProcessEvent_Split(t *testing.T) {
+	pub := metadatatest.CellIDCellA // colocated side
+	sub := metadatatest.CellIDCellB // remote side
+
+	pm := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{pub},
+			Remote:    []metadata.TopologyRemoteEntry{{CellID: sub, Endpoint: "remote.svc:9090"}},
+		},
+	)
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	require.GreaterOrEqual(t, len(got), 1,
+		"split topology with cross-process event pub/sub must produce ≥1 TOPO-13 finding")
+	assert.Equal(t, SeverityError, got[0].Severity)
+	assert.Equal(t, IssueForbidden, got[0].IssueType)
+	assert.NotEmpty(t, got[0].Fix)
+	assert.NotEmpty(t, got[0].Message)
+}
+
+// TestTOPO13_ColocatedEvent_NoError is the anti-vacuity GREEN test.
+// Publisher and subscriber are both in colocated (same process) → no cross-process
+// boundary → TOPO-13 must NOT fire.
+//
+// If TestTOPO13_CrossProcessEvent_Split (RED) also returned 0, the detector
+// would be vacuously non-firing — this test separates "detector works but no
+// violation" from "detector is dead".
+func TestTOPO13_ColocatedEvent_NoError(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+
+	pm := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{pub, sub},
+		},
+	)
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got,
+		"colocated pub/sub should produce 0 TOPO-13 findings (anti-vacuity: if RED test "+
+			"also returns 0, the detector is broken)")
+}
+
+// TestTOPO13_EmptyTopology_NoError: empty topology → all cells are Local (same process)
+// → no cross-process boundary → TOPO-13 must NOT fire.
+func TestTOPO13_EmptyTopology_NoError(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+
+	pm := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{},
+	)
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got, "empty topology (all cells local) should produce 0 TOPO-13 findings")
+}
+
+// TestTOPO13_NonSplitAssembly_Skipped: assembly with no topology.remote →
+// TOPO-13 skips it entirely (only split assemblies are checked).
+func TestTOPO13_NonSplitAssembly_Skipped(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+
+	// No remote entries → not a split assembly → TOPO-13 must skip.
+	pm := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{pub, sub},
+		},
+	)
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got, "non-split assembly (no topology.remote) should produce 0 TOPO-13 findings")
+}
+
+// TestTOPO13_NonEventContract_Skipped: HTTP contract with cross-process endpoints
+// is NOT a TOPO-13 violation (only event contracts are checked).
+func TestTOPO13_NonEventContract_Skipped(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+
+	// HTTP contract — not event kind → TOPO-13 must skip.
+	pm := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			metadatatest.CellIDCellA: topoTestCell(pub),
+			metadatatest.CellIDCellB: topoTestCell(sub),
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"http.data.v1": func() *metadata.ContractMeta {
+				c := topoTestContract("http.data.v1", "http", pub)
+				c.Endpoints.Clients = []string{sub}
+				return c
+			}(),
+		},
+		Journeys: map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"testasm": topoTestAssembly([]string{pub, sub}, metadata.TopologyMeta{
+				Colocated: []string{pub},
+				Remote:    []metadata.TopologyRemoteEntry{{CellID: sub, Endpoint: "remote.svc:9090"}},
+			}),
+		},
+	}
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got, "non-event contract (http) should be skipped by TOPO-13")
+}
+
+// TestTOPO13_ExternalActorSubscriber_Skipped: event contract with an external
+// actor as subscriber — actors are not cells, TOPO-13 only governs cell placements.
+func TestTOPO13_ExternalActorSubscriber_Skipped(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	actorID := "externalconsumer" // not a cell — a registered actor
+
+	pm := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			metadatatest.CellIDCellA: topoTestCell(pub),
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.data.v1": func() *metadata.ContractMeta {
+				c := topoTestContract("event.data.v1", "event", pub)
+				c.Endpoints.Subscribers = []string{actorID}
+				return c
+			}(),
+		},
+		Journeys: map[string]*metadata.JourneyMeta{},
+		Actors: []metadata.ActorMeta{
+			{ID: actorID},
+		},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"testasm": topoTestAssembly([]string{pub}, metadata.TopologyMeta{
+				Colocated: []string{pub},
+			}),
+		},
+	}
+	// Give the assembly a remote entry so it counts as split, but actor is not a cell.
+	// We need a second cell to have a valid split topology.
+	bystander := metadatatest.CellIDCellB
+	pm.Cells[metadatatest.CellIDCellB] = topoTestCell(bystander)
+	pm.Assemblies["testasm"] = topoTestAssembly([]string{pub, bystander}, metadata.TopologyMeta{
+		Colocated: []string{pub},
+		Remote:    []metadata.TopologyRemoteEntry{{CellID: bystander, Endpoint: "remote.svc:9090"}},
+	})
+
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got, "external actor subscriber should be skipped by TOPO-13 (not a cell)")
+}
+
+// TestTOPO13_FrameworkOwnedContract_Skipped: framework-owned event contract is
+// provider-agnostic → skipped by TOPO-13 (mirrors TOPO-11 skip condition).
+func TestTOPO13_FrameworkOwnedContract_Skipped(t *testing.T) {
+	sub := metadatatest.CellIDCellA
+	bystander := metadatatest.CellIDCellB
+
+	pm := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			metadatatest.CellIDCellA: topoTestCell(sub),
+			metadatatest.CellIDCellB: topoTestCell(bystander),
+		},
+		Slices: map[string]*metadata.SliceMeta{},
+		Contracts: map[string]*metadata.ContractMeta{
+			"event.framework.v1": {
+				ID:               "event.framework.v1",
+				Kind:             "event",
+				Lifecycle:        "draft",
+				ConsistencyLevel: "L1",
+				OwnerCell:        metadata.FrameworkOwnerSentinel,
+				File:             "contracts/event/framework/v1/contract.yaml",
+				Endpoints: metadata.EndpointsMeta{
+					Subscribers: []string{sub},
+				},
+			},
+		},
+		Journeys: map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"testasm": topoTestAssembly([]string{sub, bystander}, metadata.TopologyMeta{
+				Colocated: []string{sub},
+				Remote:    []metadata.TopologyRemoteEntry{{CellID: bystander, Endpoint: "remote.svc:9090"}},
+			}),
+		},
+	}
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, got, "framework-owned event contract should be skipped by TOPO-13")
+}
+
+// TestTOPO13_SubscriberRemote_PublisherLocal: the reverse cross-process case —
+// publisher in colocated, subscriber in remote → same violation → TOPO-13 must fire.
+// (Verifies the IsLocal() != IsLocal() condition is symmetric.)
+func TestTOPO13_SubscriberRemote_PublisherLocal(t *testing.T) {
+	pub := metadatatest.CellIDCellA // colocated
+	sub := metadatatest.CellIDCellB // remote
+
+	pm := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{pub},
+			Remote:    []metadata.TopologyRemoteEntry{{CellID: sub, Endpoint: "remote.svc:9090"}},
+		},
+	)
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	require.GreaterOrEqual(t, len(got), 1,
+		"publisher local, subscriber remote must produce ≥1 TOPO-13 finding")
+	assert.Equal(t, SeverityError, got[0].Severity)
+}
+
+// TestTOPO13_PublisherRemote_SubscriberLocal: publisher in remote, subscriber
+// in colocated → also cross-process → TOPO-13 must fire.
+func TestTOPO13_PublisherRemote_SubscriberLocal(t *testing.T) {
+	pub := metadatatest.CellIDCellA // remote
+	sub := metadatatest.CellIDCellB // colocated
+
+	pm := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{sub},
+			Remote:    []metadata.TopologyRemoteEntry{{CellID: pub, Endpoint: "remote.svc:9090"}},
+		},
+	)
+	val := NewValidator(pm, ".", clock.Real())
+	got := findByCode(val.validateTOPO13(), codeTOPO13)
+	require.GreaterOrEqual(t, len(got), 1,
+		"publisher remote, subscriber local must produce ≥1 TOPO-13 finding")
+	assert.Equal(t, SeverityError, got[0].Severity)
+}
+
+// TestTOPO13_AntiVacuity: explicit RED/GREEN fixture pair confirming the
+// detector is not vacuously passing.
+// RED: cross-process split → ≥1 TOPO-13 finding.
+// GREEN: same cells, but both colocated → 0 TOPO-13 findings.
+func TestTOPO13_AntiVacuity(t *testing.T) {
+	pub := metadatatest.CellIDCellA
+	sub := metadatatest.CellIDCellB
+
+	// RED: publisher colocated, subscriber remote.
+	pmRed := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{pub},
+			Remote:    []metadata.TopologyRemoteEntry{{CellID: sub, Endpoint: "remote.svc:9090"}},
+		},
+	)
+	valRed := NewValidator(pmRed, ".", clock.Real())
+	redGot := findByCode(valRed.validateTOPO13(), codeTOPO13)
+	require.NotEmpty(t, redGot,
+		"anti-vacuity RED: cross-process event pub/sub must produce ≥1 TOPO-13 finding")
+
+	// GREEN: both in colocated.
+	pmGreen := buildTOPO13Project(pub, sub, []string{pub, sub},
+		metadata.TopologyMeta{
+			Colocated: []string{pub, sub},
+		},
+	)
+	valGreen := NewValidator(pmGreen, ".", clock.Real())
+	greenGot := findByCode(valGreen.validateTOPO13(), codeTOPO13)
+	assert.Empty(t, greenGot,
+		"anti-vacuity GREEN: co-located pub/sub must produce 0 TOPO-13 findings")
+}

--- a/framework/runtime/bootstrap/deployment_topology.go
+++ b/framework/runtime/bootstrap/deployment_topology.go
@@ -177,6 +177,21 @@ func validateDeployEndpoint(ep, cellID string) error {
 		errcode.WithDetails(errcode.PublicString("cellID", cellID)))
 }
 
+// HasRemoteCells reports whether the deployment topology declares at least one
+// remote cell (i.e. a split topology with a process boundary). Zero value
+// (no explicit topology, all-colocated) returns false. Used by the bootstrap
+// phase0 broker-mandatory gate: a split topology + in-memory EventBus is
+// rejected because the in-memory bus cannot deliver events across processes.
+//
+// Coarse proxy (Medium, blind-spot): true for ANY remote cell, even one with
+// only sync (CellTransport) contracts and no cross-process events; the precise
+// "has cross-process event pub/sub" signal would require codegen derivation
+// (tracked as follow-up). Currently unreachable in production because the
+// interim TOPO-12 rule blanket-rejects topology.remote at gocell validate.
+func (t DeploymentTopology) HasRemoteCells() bool {
+	return len(t.remote) > 0
+}
+
 // IsColocated reports whether cellID is co-located in the same process.
 // For a zero-value (no explicit topology), always returns true — all cells
 // are treated as colocated (single-process default).

--- a/framework/runtime/bootstrap/deployment_topology.go
+++ b/framework/runtime/bootstrap/deployment_topology.go
@@ -186,7 +186,7 @@ func validateDeployEndpoint(ep, cellID string) error {
 // Coarse proxy (Medium, blind-spot): true for ANY remote cell, even one with
 // only sync (CellTransport) contracts and no cross-process events; the precise
 // "has cross-process event pub/sub" signal would require codegen derivation
-// (tracked as follow-up). Currently unreachable in production because the
+// (tracked as #1967). Currently unreachable in production because the
 // interim TOPO-12 rule blanket-rejects topology.remote at gocell validate.
 func (t DeploymentTopology) HasRemoteCells() bool {
 	return len(t.remote) > 0

--- a/framework/runtime/bootstrap/deployment_topology_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_test.go
@@ -622,6 +622,11 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 	// nonNilBus is used for the GREEN cases that require non-nil publisher/subscriber.
 	nonNilBus := eventbus.New(clock.Real())
 
+	// typedNilPub is a typed-nil interface value (non-nil interface header, nil
+	// concrete pointer). A bare == nil check would MISS it; the gate uses
+	// validation.IsNilInterface so it is correctly rejected (#2188 review F3).
+	var typedNilPub outbox.Publisher = (*eventbus.InMemoryEventBus)(nil)
+
 	cases := []struct {
 		name               string
 		deploymentTopology DeploymentTopology
@@ -688,6 +693,18 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 			name:               "RED: split topology + zero Topology{} (StorageBackend==\"\") → rejected (fail-closed)",
 			deploymentTopology: splitDT,
 			controlPlaneTopo:   Topology{}, // true zero value — StorageBackend()==""
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
+			// F3: typed-nil publisher (non-nil interface, nil concrete pointer)
+			// must be rejected — a bare == nil check would let it pass and phase2
+			// would degrade to the in-memory bus. validation.IsNilInterface closes it.
+			name:               "RED: split topology + postgres + typed-nil publisher → rejected (F3 typed-nil)",
+			deploymentTopology: splitDT,
+			controlPlaneTopo:   postgresTopo,
+			publisher:          typedNilPub,
+			subscriber:         nonNilBus,
 			wantErr:            true,
 			wantErrCode:        errcode.ErrValidationFailed,
 		},

--- a/framework/runtime/bootstrap/deployment_topology_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_test.go
@@ -403,19 +403,26 @@ func TestPhase0_RejectsInvalidDeploymentTopology(t *testing.T) {
 
 // TestPhase0_AcceptsValidDeploymentTopology verifies the happy path: a valid
 // DeploymentTopologySpec does not cause phase0 to fail.
+// A split topology requires postgres storage (broker-mandatory gate); inject
+// WithControlPlaneTopology(postgres) so the gate accepts it.
 func TestPhase0_AcceptsValidDeploymentTopology(t *testing.T) {
 	spec := DeploymentTopologySpec{
 		Colocated: []string{"cellA"},
 		Remote:    []RemoteCellEndpoint{{CellID: "cellB", Endpoint: "cell-b:9090"}},
 	}
+	postgresTopo, err := NewTopology("real", "postgres", false)
+	if err != nil {
+		t.Fatalf("NewTopology: %v", err)
+	}
 	b := New(
 		clock.Real(),
 		WithDeploymentTopology(spec),
+		WithControlPlaneTopology(postgresTopo),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
 
-	err := b.phase0ValidateOptions()
+	err = b.phase0ValidateOptions()
 	if err != nil {
 		t.Fatalf("phase0ValidateOptions: unexpected error for valid DeploymentTopologySpec: %v", err)
 	}
@@ -436,13 +443,20 @@ func TestPhase0_AcceptsValidDeploymentTopology(t *testing.T) {
 // TestBootstrap_DeploymentTopologyGetter_BeforePhase0 verifies that the
 // Bootstrap.DeploymentTopology() getter returns the zero value (all-colocated)
 // before phase0 runs, and the sealed value after (F4).
+// A split topology requires postgres storage (broker-mandatory gate); inject
+// WithControlPlaneTopology(postgres) so the gate accepts the split spec.
 func TestBootstrap_DeploymentTopologyGetter_BeforePhase0(t *testing.T) {
+	postgresTopo, err := NewTopology("real", "postgres", false)
+	if err != nil {
+		t.Fatalf("NewTopology: %v", err)
+	}
 	b := New(
 		clock.Real(),
 		WithDeploymentTopology(DeploymentTopologySpec{
 			Colocated: []string{"cellA"},
 			Remote:    []RemoteCellEndpoint{{CellID: "cellB", Endpoint: "cell-b:9090"}},
 		}),
+		WithControlPlaneTopology(postgresTopo),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
@@ -496,5 +510,226 @@ func TestPhase0_OmittedDeploymentTopology_AllColocated(t *testing.T) {
 	_, ok := b.deploymentTopology.RemoteEndpoint("anyCellID")
 	if ok {
 		t.Error("zero DeploymentTopology.RemoteEndpoint(any) = hit, want miss")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HasRemoteCells predicate
+// ---------------------------------------------------------------------------
+
+// TestDeploymentTopologyHasRemoteCells verifies the HasRemoteCells predicate
+// used by the phase0 broker-mandatory gate (validateSplitTopologyBroker).
+func TestDeploymentTopologyHasRemoteCells(t *testing.T) {
+	cases := []struct {
+		name string
+		spec DeploymentTopologySpec
+		want bool
+	}{
+		{
+			name: "zero value (no topology declared) → false",
+			spec: DeploymentTopologySpec{},
+			want: false,
+		},
+		{
+			name: "only colocated cells → false",
+			spec: DeploymentTopologySpec{
+				Colocated: []string{"cellA", "cellB"},
+			},
+			want: false,
+		},
+		{
+			name: "at least one remote cell → true",
+			spec: DeploymentTopologySpec{
+				Remote: []RemoteCellEndpoint{
+					{CellID: "cellRemote", Endpoint: "cell-remote:8080"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mixed colocated + remote → true",
+			spec: DeploymentTopologySpec{
+				Colocated: []string{"cellA"},
+				Remote: []RemoteCellEndpoint{
+					{CellID: "cellB", Endpoint: "cell-b:9090"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dt, err := newDeploymentTopology(tc.spec)
+			if err != nil {
+				t.Fatalf("newDeploymentTopology: unexpected error: %v", err)
+			}
+			if got := dt.HasRemoteCells(); got != tc.want {
+				t.Errorf("HasRemoteCells() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateSplitTopologyBroker — phase0 broker-mandatory gate
+// ---------------------------------------------------------------------------
+
+// TestValidateSplitTopologyBroker exercises the phase0 broker-mandatory gate
+// (validateSplitTopologyBroker) directly, without starting a full Bootstrap.
+// The gate must:
+//   - reject split topology (≥1 remote) + in-memory bus (storage != postgres)
+//   - accept split topology + postgres storage
+//   - accept colocated topology + in-memory bus (no remote cells, no broker needed)
+func TestValidateSplitTopologyBroker(t *testing.T) {
+	splitSpec := DeploymentTopologySpec{
+		Colocated: []string{"cellA"},
+		Remote: []RemoteCellEndpoint{
+			{CellID: "cellB", Endpoint: "cell-b:9090"},
+		},
+	}
+	colocatedSpec := DeploymentTopologySpec{
+		Colocated: []string{"cellA", "cellB"},
+	}
+
+	splitDT, err := newDeploymentTopology(splitSpec)
+	if err != nil {
+		t.Fatalf("newDeploymentTopology(split): %v", err)
+	}
+	colocatedDT, err := newDeploymentTopology(colocatedSpec)
+	if err != nil {
+		t.Fatalf("newDeploymentTopology(colocated): %v", err)
+	}
+	memoryTopo, err := NewTopology("", "memory", false)
+	if err != nil {
+		t.Fatalf("NewTopology(memory): %v", err)
+	}
+	postgresTopo, err := NewTopology("real", "postgres", false)
+	if err != nil {
+		t.Fatalf("NewTopology(postgres): %v", err)
+	}
+
+	cases := []struct {
+		name               string
+		deploymentTopology DeploymentTopology
+		controlPlaneTopo   Topology
+		wantErr            bool
+		wantErrCode        errcode.Code
+	}{
+		{
+			name:               "RED: split topology + in-memory bus → rejected",
+			deploymentTopology: splitDT,
+			controlPlaneTopo:   memoryTopo,
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
+			name:               "GREEN: split topology + postgres storage → accepted",
+			deploymentTopology: splitDT,
+			controlPlaneTopo:   postgresTopo,
+			wantErr:            false,
+		},
+		{
+			name:               "GREEN: colocated topology + in-memory bus → accepted (no remote cells)",
+			deploymentTopology: colocatedDT,
+			controlPlaneTopo:   memoryTopo,
+			wantErr:            false,
+		},
+		{
+			name:               "GREEN: zero deployment topology + in-memory bus → accepted (all-colocated default)",
+			deploymentTopology: DeploymentTopology{},
+			controlPlaneTopo:   memoryTopo,
+			wantErr:            false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &Bootstrap{
+				deploymentTopology:   tc.deploymentTopology,
+				controlPlaneTopology: tc.controlPlaneTopo,
+			}
+			err := b.validateSplitTopologyBroker()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("validateSplitTopologyBroker: expected error, got nil")
+				}
+				var ec *errcode.Error
+				if !errors.As(err, &ec) {
+					t.Fatalf("error is not *errcode.Error: %T %v", err, err)
+				}
+				if ec.Code != tc.wantErrCode {
+					t.Errorf("error code = %s, want %s", ec.Code, tc.wantErrCode)
+				}
+			} else if err != nil {
+				t.Errorf("validateSplitTopologyBroker: unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestPhase0_RejectsSplitTopologyWithInMemoryBus verifies that phase0 end-to-end
+// rejects a split topology combined with in-memory bus (no postgres storage).
+func TestPhase0_RejectsSplitTopologyWithInMemoryBus(t *testing.T) {
+	splitSpec := DeploymentTopologySpec{
+		Colocated: []string{"cellA"},
+		Remote: []RemoteCellEndpoint{
+			{CellID: "cellB", Endpoint: "cell-b:9090"},
+		},
+	}
+	memoryTopo, err := NewTopology("", "memory", false)
+	if err != nil {
+		t.Fatalf("NewTopology: %v", err)
+	}
+
+	b := New(
+		clock.Real(),
+		WithDeploymentTopology(splitSpec),
+		WithControlPlaneTopology(memoryTopo),
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+	)
+
+	err = b.phase0ValidateOptions()
+	if err == nil {
+		t.Fatal("phase0ValidateOptions: expected error for split topology + in-memory bus, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("error is not *errcode.Error: %T %v", err, err)
+	}
+	if ec.Code != errcode.ErrValidationFailed {
+		t.Errorf("error code = %s, want %s", ec.Code, errcode.ErrValidationFailed)
+	}
+	if !strings.Contains(ec.Message, "in-memory") {
+		t.Errorf("error message %q should mention in-memory bus", ec.Message)
+	}
+}
+
+// TestPhase0_AcceptsSplitTopologyWithPostgres verifies that phase0 accepts a
+// split topology when postgres storage is declared (real broker available).
+func TestPhase0_AcceptsSplitTopologyWithPostgres(t *testing.T) {
+	splitSpec := DeploymentTopologySpec{
+		Colocated: []string{"cellA"},
+		Remote: []RemoteCellEndpoint{
+			{CellID: "cellB", Endpoint: "cell-b:9090"},
+		},
+	}
+	postgresTopo, err := NewTopology("real", "postgres", false)
+	if err != nil {
+		t.Fatalf("NewTopology: %v", err)
+	}
+
+	b := New(
+		clock.Real(),
+		WithDeploymentTopology(splitSpec),
+		WithControlPlaneTopology(postgresTopo),
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+	)
+
+	err = b.phase0ValidateOptions()
+	if err != nil {
+		t.Fatalf("phase0ValidateOptions: unexpected error for split topology + postgres: %v", err)
 	}
 }

--- a/framework/runtime/bootstrap/deployment_topology_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/auth"
 	"github.com/ghbvf/gocell/framework/kernel/cell"
 	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/runtime/eventbus"
 )
 
 // ---------------------------------------------------------------------------
@@ -403,8 +405,8 @@ func TestPhase0_RejectsInvalidDeploymentTopology(t *testing.T) {
 
 // TestPhase0_AcceptsValidDeploymentTopology verifies the happy path: a valid
 // DeploymentTopologySpec does not cause phase0 to fail.
-// A split topology requires postgres storage (broker-mandatory gate); inject
-// WithControlPlaneTopology(postgres) so the gate accepts it.
+// A split topology requires postgres storage + non-nil publisher/subscriber
+// (broker-mandatory gate, F1); inject both so the gate accepts it.
 func TestPhase0_AcceptsValidDeploymentTopology(t *testing.T) {
 	spec := DeploymentTopologySpec{
 		Colocated: []string{"cellA"},
@@ -414,10 +416,13 @@ func TestPhase0_AcceptsValidDeploymentTopology(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewTopology: %v", err)
 	}
+	brokerBus := eventbus.New(clock.Real())
 	b := New(
 		clock.Real(),
 		WithDeploymentTopology(spec),
 		WithControlPlaneTopology(postgresTopo),
+		WithPublisher(brokerBus),
+		WithSubscriber(brokerBus),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
@@ -443,13 +448,14 @@ func TestPhase0_AcceptsValidDeploymentTopology(t *testing.T) {
 // TestBootstrap_DeploymentTopologyGetter_BeforePhase0 verifies that the
 // Bootstrap.DeploymentTopology() getter returns the zero value (all-colocated)
 // before phase0 runs, and the sealed value after (F4).
-// A split topology requires postgres storage (broker-mandatory gate); inject
-// WithControlPlaneTopology(postgres) so the gate accepts the split spec.
+// A split topology requires postgres storage + non-nil publisher/subscriber
+// (broker-mandatory gate, F1); inject both so the gate accepts the split spec.
 func TestBootstrap_DeploymentTopologyGetter_BeforePhase0(t *testing.T) {
 	postgresTopo, err := NewTopology("real", "postgres", false)
 	if err != nil {
 		t.Fatalf("NewTopology: %v", err)
 	}
+	brokerBus := eventbus.New(clock.Real())
 	b := New(
 		clock.Real(),
 		WithDeploymentTopology(DeploymentTopologySpec{
@@ -457,6 +463,8 @@ func TestBootstrap_DeploymentTopologyGetter_BeforePhase0(t *testing.T) {
 			Remote:    []RemoteCellEndpoint{{CellID: "cellB", Endpoint: "cell-b:9090"}},
 		}),
 		WithControlPlaneTopology(postgresTopo),
+		WithPublisher(brokerBus),
+		WithSubscriber(brokerBus),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
@@ -579,7 +587,9 @@ func TestDeploymentTopologyHasRemoteCells(t *testing.T) {
 // (validateSplitTopologyBroker) directly, without starting a full Bootstrap.
 // The gate must:
 //   - reject split topology (≥1 remote) + in-memory bus (storage != postgres)
-//   - accept split topology + postgres storage
+//   - reject split topology + postgres storage but nil publisher or subscriber
+//     (F1: phase2 would degrade to in-memory bus — same security gap)
+//   - accept split topology + postgres storage + non-nil publisher + non-nil subscriber
 //   - accept colocated topology + in-memory bus (no remote cells, no broker needed)
 func TestValidateSplitTopologyBroker(t *testing.T) {
 	splitSpec := DeploymentTopologySpec{
@@ -609,10 +619,15 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 		t.Fatalf("NewTopology(postgres): %v", err)
 	}
 
+	// nonNilBus is used for the GREEN cases that require non-nil publisher/subscriber.
+	nonNilBus := eventbus.New(clock.Real())
+
 	cases := []struct {
 		name               string
 		deploymentTopology DeploymentTopology
 		controlPlaneTopo   Topology
+		publisher          outbox.Publisher
+		subscriber         outbox.Subscriber
 		wantErr            bool
 		wantErrCode        errcode.Code
 	}{
@@ -624,9 +639,33 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 			wantErrCode:        errcode.ErrValidationFailed,
 		},
 		{
-			name:               "GREEN: split topology + postgres storage → accepted",
+			// F1: split topology + postgres storage but nil publisher → rejected.
+			// phase2InitPubSub falls back to in-memory bus when publisher==nil,
+			// so this combination must be fail-closed even though StorageBackend==postgres.
+			name:               "RED: split topology + postgres + nil publisher → rejected (F1 nil guard)",
 			deploymentTopology: splitDT,
 			controlPlaneTopo:   postgresTopo,
+			publisher:          nil,
+			subscriber:         nonNilBus,
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
+			// F1: split topology + postgres storage but nil subscriber → rejected.
+			name:               "RED: split topology + postgres + nil subscriber → rejected (F1 nil guard)",
+			deploymentTopology: splitDT,
+			controlPlaneTopo:   postgresTopo,
+			publisher:          nonNilBus,
+			subscriber:         nil,
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
+			name:               "GREEN: split topology + postgres storage + non-nil pub/sub → accepted",
+			deploymentTopology: splitDT,
+			controlPlaneTopo:   postgresTopo,
+			publisher:          nonNilBus,
+			subscriber:         nonNilBus,
 			wantErr:            false,
 		},
 		{
@@ -641,6 +680,17 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 			controlPlaneTopo:   memoryTopo,
 			wantErr:            false,
 		},
+		{
+			// F6: zero-value Topology{} (StorageBackend()=="") combined with a split
+			// deployment topology must be fail-closed rejected. This locks the
+			// invariant that a zero Topology does not accidentally read as postgres
+			// and let an un-configured split deployment pass the broker gate.
+			name:               "RED: split topology + zero Topology{} (StorageBackend==\"\") → rejected (fail-closed)",
+			deploymentTopology: splitDT,
+			controlPlaneTopo:   Topology{}, // true zero value — StorageBackend()==""
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
 	}
 
 	for _, tc := range cases {
@@ -648,6 +698,8 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 			b := &Bootstrap{
 				deploymentTopology:   tc.deploymentTopology,
 				controlPlaneTopology: tc.controlPlaneTopo,
+				publisher:            tc.publisher,
+				subscriber:           tc.subscriber,
 			}
 			err := b.validateSplitTopologyBroker()
 			if tc.wantErr {
@@ -707,7 +759,8 @@ func TestPhase0_RejectsSplitTopologyWithInMemoryBus(t *testing.T) {
 }
 
 // TestPhase0_AcceptsSplitTopologyWithPostgres verifies that phase0 accepts a
-// split topology when postgres storage is declared (real broker available).
+// split topology when postgres storage is declared and non-nil publisher/subscriber
+// are injected (broker-mandatory gate, F1).
 func TestPhase0_AcceptsSplitTopologyWithPostgres(t *testing.T) {
 	splitSpec := DeploymentTopologySpec{
 		Colocated: []string{"cellA"},
@@ -719,17 +772,20 @@ func TestPhase0_AcceptsSplitTopologyWithPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewTopology: %v", err)
 	}
+	brokerBus := eventbus.New(clock.Real())
 
 	b := New(
 		clock.Real(),
 		WithDeploymentTopology(splitSpec),
 		WithControlPlaneTopology(postgresTopo),
+		WithPublisher(brokerBus),
+		WithSubscriber(brokerBus),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
 
 	err = b.phase0ValidateOptions()
 	if err != nil {
-		t.Fatalf("phase0ValidateOptions: unexpected error for split topology + postgres: %v", err)
+		t.Fatalf("phase0ValidateOptions: unexpected error for split topology + postgres + non-nil pub/sub: %v", err)
 	}
 }

--- a/framework/runtime/bootstrap/options_assembly.go
+++ b/framework/runtime/bootstrap/options_assembly.go
@@ -67,6 +67,12 @@ func WithDeploymentTopology(spec DeploymentTopologySpec) Option {
 // skips the topology-dependent replay check — identical to prior behavior for
 // hand-written bootstraps. The always-on nil/noop/ring service-token checks
 // (validateAuthServiceTokenPlan) run regardless.
+//
+// Note: the broker-mandatory split gate (validateSplitTopologyBroker) still
+// applies — a zero Topology reads as non-postgres (StorageBackend()==""), so a
+// split deployment topology is fail-closed rejected (not skipped). To pass the
+// gate with a split topology, supply a postgres Topology AND inject non-nil
+// publisher/subscriber via WithPublisher/WithSubscriber.
 func WithControlPlaneTopology(topo Topology) Option {
 	return func(b *Bootstrap) {
 		b.controlPlaneTopology = topo

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -132,14 +132,29 @@ func (b *Bootstrap) validateDeploymentTopology() error {
 // as topology.go's "postgres requires real adapter" coupling check. Called at
 // phase0 after validateDeploymentTopology seals b.deploymentTopology.
 //
-// Medium gate (Hard unreachable: compares two runtime values). Coarse: fires on
-// any remote cell (see DeploymentTopology.HasRemoteCells blind-spot). Fail-closed:
-// an un-injected controlPlaneTopology reads as memory, so a split topology that
-// forgot to declare postgres storage is correctly rejected.
+// Split topology additionally requires explicit broker publisher/subscriber
+// injection; a nil publisher or subscriber causes phase2InitPubSub to fall back
+// to the in-memory EventBus regardless of StorageBackend, so this gate also
+// rejects that combination. Residual blind-spot: StorageBackend==postgres with
+// a hand-injected in-memory publisher/subscriber instance is not caught here;
+// that is prevented by the #1940 eventtransport funnel + depguard at the
+// composition root layer.
+//
+// Medium gate (Hard unreachable: compares two runtime values). Coarse proxy:
+// fires on ANY remote cell — even one with only sync (HTTP/CellTransport)
+// contracts and no cross-process events — because HasRemoteCells is a
+// per-assembly signal, not a per-contract signal (US7 #1967 refines this).
+// Fail-closed: an un-injected controlPlaneTopology reads as memory, so a split
+// topology that forgot to declare postgres storage is correctly rejected; a nil
+// publisher or subscriber is also rejected (phase2 would degrade to in-memory
+// bus). See also DeploymentTopology.HasRemoteCells for the blind-spot note.
 func (b *Bootstrap) validateSplitTopologyBroker() error {
-	if b.deploymentTopology.HasRemoteCells() && b.controlPlaneTopology.StorageBackend() != StorageBackendPostgres {
+	if b.deploymentTopology.HasRemoteCells() &&
+		(b.controlPlaneTopology.StorageBackend() != StorageBackendPostgres ||
+			b.publisher == nil || b.subscriber == nil) {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			errMsgSplitTopologyRequiresBroker)
+			errMsgSplitTopologyRequiresBroker,
+			errcode.WithInternal(errcode.InternalAttr("storageBackend", b.controlPlaneTopology.StorageBackend())))
 	}
 	return nil
 }
@@ -218,7 +233,9 @@ const terminationGraceSafetyMargin = 10 * time.Second
 // errMsgSplitTopologyRequiresBroker — MESSAGE-CONST-LITERAL-01.
 const errMsgSplitTopologyRequiresBroker = "split deployment topology (remote cells) requires a real event broker; " +
 	"the in-memory EventBus cannot deliver events across process boundaries — " +
-	"set GOCELL_CELL_ADAPTER_MODE=postgres (+ GOCELL_ADAPTER_MODE=real) and GOCELL_AMQP_URL"
+	"set GOCELL_CELL_ADAPTER_MODE=postgres (+ GOCELL_ADAPTER_MODE=real) and GOCELL_AMQP_URL, " +
+	"and inject a real broker publisher/subscriber via WithPublisher/WithSubscriber" +
+	" — or remove topology.remote to keep all cells co-located (no broker needed)"
 
 // phase10ShutdownBudgetBuckets is the number of independent timeout buckets
 // allocated by phase10OrchestrateShutdown — drainCtx (stage 1+2) and tearCtx

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -51,6 +51,9 @@ func (b *Bootstrap) phase0ValidateOptions() error {
 	if err := b.validateDeploymentTopology(); err != nil {
 		return err
 	}
+	if err := b.validateSplitTopologyBroker(); err != nil {
+		return err
+	}
 	if err := b.validateGRPCListenerConfigs(); err != nil {
 		return err
 	}
@@ -118,6 +121,26 @@ func (b *Bootstrap) validateDeploymentTopology() error {
 		return err
 	}
 	b.deploymentTopology = dt
+	return nil
+}
+
+// validateSplitTopologyBroker rejects the illegal combination of a split
+// deployment topology (≥1 remote cell) with an in-memory EventBus. The bus is
+// in-memory iff the storage backend is not postgres (#1940 eventtransport
+// funnel: in-memory is reachable only in demo/non-postgres topology), so this
+// gate is expressed via controlPlaneTopology.StorageBackend() — the same shape
+// as topology.go's "postgres requires real adapter" coupling check. Called at
+// phase0 after validateDeploymentTopology seals b.deploymentTopology.
+//
+// Medium gate (Hard unreachable: compares two runtime values). Coarse: fires on
+// any remote cell (see DeploymentTopology.HasRemoteCells blind-spot). Fail-closed:
+// an un-injected controlPlaneTopology reads as memory, so a split topology that
+// forgot to declare postgres storage is correctly rejected.
+func (b *Bootstrap) validateSplitTopologyBroker() error {
+	if b.deploymentTopology.HasRemoteCells() && b.controlPlaneTopology.StorageBackend() != StorageBackendPostgres {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			errMsgSplitTopologyRequiresBroker)
+	}
 	return nil
 }
 
@@ -191,6 +214,11 @@ func (b *Bootstrap) resolveHealthAggregator() error {
 // must remain on top of shutdownTimeout before kubelet escalates to SIGKILL.
 // 10s is the empirical floor — see docs/ops/graceful-shutdown-k8s.md.
 const terminationGraceSafetyMargin = 10 * time.Second
+
+// errMsgSplitTopologyRequiresBroker — MESSAGE-CONST-LITERAL-01.
+const errMsgSplitTopologyRequiresBroker = "split deployment topology (remote cells) requires a real event broker; " +
+	"the in-memory EventBus cannot deliver events across process boundaries — " +
+	"set GOCELL_CELL_ADAPTER_MODE=postgres (+ GOCELL_ADAPTER_MODE=real) and GOCELL_AMQP_URL"
 
 // phase10ShutdownBudgetBuckets is the number of independent timeout buckets
 // allocated by phase10OrchestrateShutdown — drainCtx (stage 1+2) and tearCtx

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/healthz"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/validation"
 	"github.com/ghbvf/gocell/framework/runtime/config"
 	"github.com/ghbvf/gocell/framework/runtime/eventbus"
 	obshealthz "github.com/ghbvf/gocell/framework/runtime/observability/healthz"
@@ -135,10 +136,16 @@ func (b *Bootstrap) validateDeploymentTopology() error {
 // Split topology additionally requires explicit broker publisher/subscriber
 // injection; a nil publisher or subscriber causes phase2InitPubSub to fall back
 // to the in-memory EventBus regardless of StorageBackend, so this gate also
-// rejects that combination. Residual blind-spot: StorageBackend==postgres with
-// a hand-injected in-memory publisher/subscriber instance is not caught here;
-// that is prevented by the #1940 eventtransport funnel + depguard at the
-// composition root layer.
+// rejects that combination. The nil check uses validation.IsNilInterface so a
+// typed-nil interface value (e.g. WithPublisher((*T)(nil))) cannot slip past a
+// bare == nil comparison — the same defense SharedDeps applies to its
+// Publisher/Subscriber. Residual blind-spot: StorageBackend==postgres with a
+// hand-injected non-nil in-memory publisher/subscriber instance is not caught
+// here (non-nil ≠ real broker); that hole is closed by the
+// COREBUNDLE-EVENTBUS-FUNNEL-01 depguard (in-memory bus is import-banned in the
+// production composition roots, reachable only via eventtransport.Resolve's
+// non-postgres branch). Promoting this gate to a sealed broker-kind check is
+// tracked as a follow-up (#1965 review F2).
 //
 // Medium gate (Hard unreachable: compares two runtime values). Coarse proxy:
 // fires on ANY remote cell — even one with only sync (HTTP/CellTransport)
@@ -146,12 +153,12 @@ func (b *Bootstrap) validateDeploymentTopology() error {
 // per-assembly signal, not a per-contract signal (US7 #1967 refines this).
 // Fail-closed: an un-injected controlPlaneTopology reads as memory, so a split
 // topology that forgot to declare postgres storage is correctly rejected; a nil
-// publisher or subscriber is also rejected (phase2 would degrade to in-memory
-// bus). See also DeploymentTopology.HasRemoteCells for the blind-spot note.
+// (or typed-nil) publisher or subscriber is also rejected (phase2 would degrade
+// to in-memory bus). See also DeploymentTopology.HasRemoteCells for the blind-spot.
 func (b *Bootstrap) validateSplitTopologyBroker() error {
 	if b.deploymentTopology.HasRemoteCells() &&
 		(b.controlPlaneTopology.StorageBackend() != StorageBackendPostgres ||
-			b.publisher == nil || b.subscriber == nil) {
+			validation.IsNilInterface(b.publisher) || validation.IsNilInterface(b.subscriber)) {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			errMsgSplitTopologyRequiresBroker,
 			errcode.WithInternal(errcode.InternalAttr("storageBackend", b.controlPlaneTopology.StorageBackend())))


### PR DESCRIPTION
## Summary

为「split 部署拓扑 ∧ in-memory EventBus」加 broker-mandatory **双闸 fail-fast**：静态闸（`gocell validate` 新规则 TOPO-13）+ 运行时闸（bootstrap phase0 `validateSplitTopologyBroker`），堵死跨进程事件被进程内总线静默丢弃的组合。

## Why / 背景

Epic #1423（Cell 部署拓扑 / 可重定位）US3。当 assembly 声明 split 拓扑（cell 拆到不同进程）却仍用 in-memory EventBus 时，跨进程事件会**静默丢失**——validate 与 bootstrap 都不报错。本 PR 用双闸把这个非法组合在静态校验期与启动期分别 fail-fast。

> 注：issue body 提到的「`runtime/composition/shared_deps.go:92` 硬编码 `*eventbus.InMemoryEventBus`」已在前置 #1940 接口化为 `outbox.Publisher`/`Subscriber`，本 PR 不动该处（issue 描述 stale）。

**设计要点**：
- 两条正交轴——存储/总线轴 `Topology.StorageBackend()`（in-memory bus ⟺ `!= postgres`，#1940 funnel 保证）与部署轴 `DeploymentTopology`（colocated/remote）。运行时闸经 `StorageBackend()` 等价判定 in-memory（不 type-assert Publisher——phase0 时其可能为 nil），同形于既有 `topology.go` postgres-requires-real 耦合规则。
- 静态闸 TOPO-13 镜像 TOPO-11 结构：split assembly 的 event 契约，publisher 与 subscriber 跨进程（一 Local 一 Remote）→ 报错。
- **AI-robust 评级 = Medium，永久档位**：拓扑×bus 组合 type system 不可表达（bus 是运行时注入实例），Hard 不可达；评级/盲区写入 rule godoc + guard godoc。
- **已知 blind-spot（已在 godoc + docs 标注）**：① TOPO-13 当前被 interim TOPO-12（blanket 禁 remote）production-shadow，靠 synthetic 单测证明，TOPO-12 移除（US5）后接管；② 运行时闸 `HasRemoteCells()` 是粗代理，对「remote cell 仅 sync 契约」误报（当前 TOPO-12 全禁 remote ⇒ 不可达）。

## Refs

Closes #1965

- Epic #1423（US3）；前置 #1962（US2 拓扑声明）、#1940（broker publisher funnel）均已 CLOSED
- ADR `docs/architecture/202606131142-1423-adr-cell-deployment-topology.md`（§214-219 双闸评级）
- speckit `specs/069-cell-deploy-topology/tasks.md` T030/T031/T032
- `ref: kubernetes/kubernetes cmd/kube-apiserver/app/server.go`（Complete→Validate→Run 启动期聚合校验）
- 同仓同形模板：`runtime/bootstrap/topology.go` postgres-requires-real、`kernel/governance/rules_topo.go` TOPO-11

## Risk / 兼容性

- 无 wire contract / schema / generated / 版本目录变更（纯 governance rule + bootstrap guard）。
- **行为变更**：bootstrap phase0 现会拒绝「split DeploymentTopology + 非 postgres storage」。两个既有 bootstrap 测试（`TestPhase0_AcceptsValidDeploymentTopology`、`TestBootstrap_DeploymentTopologyGetter_BeforePhase0`）此前用 split spec 但未注入 postgres topology，被新闸正确拒绝——已补 `WithControlPlaneTopology(postgresTopo)` 恢复语义（未改测试意图）。生产 composition root（corebundle）为全 colocated，不触发新闸。

## Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| TOPO-13 静态闸 | 无 | 无 | 无 | rules_topo13_test.go (RED/GREEN/anti-vacuity/skip) + rule_inventory golden | deployment-topology.md |
| phase0 运行时闸 | 无 | 无 | 无 | deployment_topology_test.go (HasRemoteCells + validateSplitTopologyBroker + phase0 e2e) | deployment-topology.md |

## Test plan

- [x] `go build ./...` 本地通过（framework 模块 + cmd/gocell + cmd/corebundle + cellmodules + 全 examples 模块）
- [x] `go test ./framework/kernel/governance/... ./framework/runtime/bootstrap/...` 本地通过（含 TDD RED→GREEN + `TestAllRulesMatchGolden`）
- [x] 全 workspace 模块回归测试通过（cmd/gocell、cmd/corebundle、cellmodules、examples/*）
- [x] `golangci-lint run` 0 issues（governance + bootstrap 两包，含 gomodguard）
