### PR TITLE
chore(cleanup): cx-1 bundle — 11 个 #2000 后 cx-1 issues 收口 [#2028 #2061 #2081 #2090 #2107 #2130 #2167 #2169 #2170 #2182 #2183]

### DIFF
--- a/adapters/postgres/outbox_store.go
+++ b/adapters/postgres/outbox_store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/metautil"
@@ -144,11 +145,11 @@ const markDeadQuery = `UPDATE outbox_entries SET status = $1, attempts = $2,
 // ref: graphile/worker resetLockedAt.ts — outer UPDATE re-asserts locked_by
 // ref: river_job.sql / pgxjob — CTE + SKIP LOCKED batched reclaim
 //
-// $1 claimTTL interval text, $2 maxAttempts, $3 kout.StateDead.String(), $4 kout.StatePending.String(),
+// $1 claimTTL interval (pgtype.Interval), $2 maxAttempts, $3 kout.StateDead.String(), $4 kout.StatePending.String(),
 // $5 baseDelayMicros, $6 kout.StateClaiming.String(), $7 maxDelayMicros, $8 batchSize.
 const reclaimStaleQuery = `WITH picked AS (
 		SELECT id, lease_id, attempts FROM outbox_entries
-		WHERE status = $6 AND claimed_at < now() - $1::interval
+		WHERE status = $6 AND claimed_at < now() - $1
 		ORDER BY claimed_at
 		FOR UPDATE SKIP LOCKED
 		LIMIT $8
@@ -251,14 +252,13 @@ func (s *PGOutboxStore) MarkRetry(
 	ctx context.Context, id, leaseID string,
 	attempts int, nextRetryAt time.Time, lastError string,
 ) (bool, error) {
-	// Convert time.Time to a PG interval offset from now().
-	// We use an absolute timestamp approach: compute delay from now, then
-	// express as "N microseconds" interval added to now() in SQL.
-	// This matches the writeBack approach: pass a duration interval string
-	// (pgx serializes time.Duration as int64 nanoseconds which PG cannot cast
-	// to interval directly — SQLSTATE 42846).
+	// Compute the backoff delay from now and pass it as a typed pgtype.Interval
+	// (Microseconds) so `now() + $3` casts cleanly. A raw time.Duration is int64
+	// nanoseconds which PG cannot cast to interval (SQLSTATE 42846); pgtype.Interval
+	// is the pgx/v5 idiomatic typed entry. Aligns with the saga journal typed-interval
+	// path (#2058).
 	delay := max(s.clock.Until(nextRetryAt), 0)
-	delayInterval := fmt.Sprintf("%d microseconds", delay.Microseconds())
+	delayInterval := pgtype.Interval{Microseconds: delay.Microseconds(), Valid: true}
 
 	errMsg := sanitizeError(lastError, 1000)
 
@@ -295,10 +295,11 @@ func (s *PGOutboxStore) ReclaimStale(
 	baseDelay, maxDelay time.Duration,
 	batchSize int,
 ) (int, error) {
-	// pgx serializes time.Duration as int64 nanoseconds which PostgreSQL cannot
-	// cast to interval (SQLSTATE 42846). Pass claimTTL as "N microseconds" text;
-	// baseDelay and maxDelay as int64 microseconds multiplied by interval '1 microsecond'.
-	claimTTLInterval := fmt.Sprintf("%d microseconds", claimTTL.Microseconds())
+	// A raw time.Duration is int64 nanoseconds which PostgreSQL cannot cast to
+	// interval (SQLSTATE 42846). Pass claimTTL as a typed pgtype.Interval (pgx/v5
+	// idiomatic, aligns with saga #2058); baseDelay and maxDelay stay int64
+	// microseconds multiplied by interval '1 microsecond' in SQL.
+	claimTTLInterval := pgtype.Interval{Microseconds: claimTTL.Microseconds(), Valid: true}
 
 	ct, err := s.db.Exec(ctx, reclaimStaleQuery,
 		claimTTLInterval, maxAttempts,
@@ -383,7 +384,7 @@ func scanClaimedEntry(rows RowScanner) (outbox.ClaimedEntry, error) {
 // observability, principal) into scan, applying the per-column oversize guards.
 // It is the single source of the scan-side decode/cap logic shared by the relay
 // claim path (scanClaimedEntry) and the projection journal replay path
-// (projection_replay_source.go) — both reconstruct a kout.Entry from
+// (projection_event_source.go) — both reconstruct a kout.Entry from
 // outbox_entries rows and must defend identically against unbounded allocation
 // from a corrupted or maliciously-crafted row (the three columns face the same
 // DoS vector). Each caller owns its own rows.Scan (the column sets differ: the

--- a/adapters/postgres/outbox_store.go
+++ b/adapters/postgres/outbox_store.go
@@ -384,8 +384,9 @@ func scanClaimedEntry(rows RowScanner) (outbox.ClaimedEntry, error) {
 // observability, principal) into scan, applying the per-column oversize guards.
 // It is the single source of the scan-side decode/cap logic shared by the relay
 // claim path (scanClaimedEntry) and the projection journal replay path
-// (projection_event_source.go) — both reconstruct a kout.Entry from
-// outbox_entries rows and must defend identically against unbounded allocation
+// (projection_event_source.go) — both reconstruct a kout.Entry from DB rows
+// (the claim query from outbox_entries, the replay path from projection_events)
+// and must defend identically against unbounded allocation
 // from a corrupted or maliciously-crafted row (the three columns face the same
 // DoS vector). Each caller owns its own rows.Scan (the column sets differ: the
 // claim query interleaves relay state, the replay query carries the seq

--- a/adapters/postgres/outbox_store.go
+++ b/adapters/postgres/outbox_store.go
@@ -149,7 +149,7 @@ const markDeadQuery = `UPDATE outbox_entries SET status = $1, attempts = $2,
 // $5 baseDelayMicros, $6 kout.StateClaiming.String(), $7 maxDelayMicros, $8 batchSize.
 const reclaimStaleQuery = `WITH picked AS (
 		SELECT id, lease_id, attempts FROM outbox_entries
-		WHERE status = $6 AND claimed_at < now() - $1
+		WHERE status = $6 AND claimed_at < now() - $1::interval
 		ORDER BY claimed_at
 		FOR UPDATE SKIP LOCKED
 		LIMIT $8
@@ -299,6 +299,13 @@ func (s *PGOutboxStore) ReclaimStale(
 	// interval (SQLSTATE 42846). Pass claimTTL as a typed pgtype.Interval (pgx/v5
 	// idiomatic, aligns with saga #2058); baseDelay and maxDelay stay int64
 	// microseconds multiplied by interval '1 microsecond' in SQL.
+	//
+	// The SQL keeps `$1::interval` even though the value is already interval-typed:
+	// `now() - $1` is ambiguous (timestamptz - interval = timestamptz OR
+	// timestamptz - timestamptz = interval), so PG would otherwise infer $1 as
+	// timestamptz and `claimed_at < (interval)` fails (42883). The cast pins the
+	// overload at parse time. (MarkRetry's `now() + $3` needs no cast — `+` only
+	// has the timestamptz+interval overload, so it is unambiguous.)
 	claimTTLInterval := pgtype.Interval{Microseconds: claimTTL.Microseconds(), Valid: true}
 
 	ct, err := s.db.Exec(ctx, reclaimStaleQuery,

--- a/adapters/postgres/outbox_store_test.go
+++ b/adapters/postgres/outbox_store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -106,10 +107,12 @@ func TestPGOutboxStore_MarkRetry_Updated(t *testing.T) {
 	assert.Equal(t, kout.StateClaiming.String(), ec.args[5])
 	assert.Equal(t, testLease, ec.args[6])
 
-	// Interval arg ($3) should be a non-empty string with microseconds
-	intervalArg, ok := ec.args[2].(string)
-	require.True(t, ok, "interval arg should be a string")
-	assert.Contains(t, intervalArg, "microseconds")
+	// Interval arg ($3) is a typed pgtype.Interval; ~10s future delay → positive microseconds.
+	intervalArg, ok := ec.args[2].(pgtype.Interval)
+	require.True(t, ok, "delay must be a typed pgtype.Interval")
+	assert.True(t, intervalArg.Valid, "interval must be valid")
+	assert.Greater(t, intervalArg.Microseconds, int64(0), "future nextRetryAt yields positive interval")
+	assert.LessOrEqual(t, intervalArg.Microseconds, testtime.D10s.Microseconds(), "delay capped by the requested offset")
 }
 
 func TestPGOutboxStore_MarkRetry_NotUpdated(t *testing.T) {
@@ -163,9 +166,10 @@ func TestPGOutboxStore_MarkRetry_PastNextRetry_UsesZeroDelay(t *testing.T) {
 	require.NoError(t, err)
 
 	ec := db.execCalls[0]
-	intervalArg, ok := ec.args[2].(string)
-	require.True(t, ok)
-	assert.Equal(t, "0 microseconds", intervalArg, "past nextRetryAt should yield 0 interval")
+	intervalArg, ok := ec.args[2].(pgtype.Interval)
+	require.True(t, ok, "delay must be a typed pgtype.Interval")
+	assert.Equal(t, pgtype.Interval{Microseconds: 0, Valid: true}, intervalArg,
+		"past nextRetryAt should yield 0 interval")
 }
 
 // ---------------------------------------------------------------------------
@@ -271,10 +275,11 @@ func TestPGOutboxStore_ReclaimStale_ReturnsCount(t *testing.T) {
 	assert.Equal(t, kout.StateClaiming.String(), ec.args[5], "claiming status for WHERE clause")
 	assert.Equal(t, callerBatch, ec.args[7], "ReclaimStale must pass through the caller's batchSize")
 
-	// claimTTL interval text
-	ttlArg, ok := ec.args[0].(string)
-	require.True(t, ok)
-	assert.Contains(t, ttlArg, "microseconds")
+	// claimTTL is passed as a typed pgtype.Interval (Microseconds), not text.
+	ttlArg, ok := ec.args[0].(pgtype.Interval)
+	require.True(t, ok, "claimTTL must be a typed pgtype.Interval")
+	assert.Equal(t, pgtype.Interval{Microseconds: testtime.D60s.Microseconds(), Valid: true}, ttlArg,
+		"claimTTL must encode the duration as microseconds")
 }
 
 func TestPGOutboxStore_ReclaimStale_ExecError(t *testing.T) {

--- a/adapters/postgres/outbox_store_test.go
+++ b/adapters/postgres/outbox_store_test.go
@@ -280,6 +280,17 @@ func TestPGOutboxStore_ReclaimStale_ReturnsCount(t *testing.T) {
 	require.True(t, ok, "claimTTL must be a typed pgtype.Interval")
 	assert.Equal(t, pgtype.Interval{Microseconds: testtime.D60s.Microseconds(), Valid: true}, ttlArg,
 		"claimTTL must encode the duration as microseconds")
+
+	// baseDelay ($5) / maxDelay ($7) stay int64 microseconds — the SQL multiplies
+	// them by interval '1 microsecond' (NOT the pgtype.Interval path). Assert the
+	// type so accidentally typing the backoff args as pgtype.Interval (which would
+	// make `$5 * power(...)` an invalid interval*interval expression) is caught.
+	baseDelayArg, ok := ec.args[4].(int64)
+	require.True(t, ok, "baseDelay must be int64 microseconds, not pgtype.Interval")
+	assert.Equal(t, testtime.D5s.Microseconds(), baseDelayArg, "baseDelay microseconds")
+	maxDelayArg, ok := ec.args[6].(int64)
+	require.True(t, ok, "maxDelay must be int64 microseconds, not pgtype.Interval")
+	assert.Equal(t, testtime.D5min.Microseconds(), maxDelayArg, "maxDelay microseconds")
 }
 
 func TestPGOutboxStore_ReclaimStale_ExecError(t *testing.T) {

--- a/cellmodules/cellsecrets/secrets.go
+++ b/cellmodules/cellsecrets/secrets.go
@@ -119,6 +119,7 @@ func ResolveAndRejectDemoKey(adapterMode, envLabel, primary, devDefault string) 
 		return nil, fmt.Errorf("%s must be set in adapter mode \"real\"", envLabel)
 	default:
 		slog.Warn("using dev-only default; set env var for production",
+			slog.String("adapter_mode", adapterMode),
 			slog.String("var", envLabel),
 			slog.String("mode", "dev-fallback"),
 			slog.String("action_required", "set env var before real mode"))
@@ -163,6 +164,7 @@ func BuildCursorCodec(cfg CursorCodecConfig) (*query.CursorCodec, error) {
 	}
 	if len(prevKey) > 0 {
 		slog.Info("cursor key rotation active",
+			slog.String("adapter_mode", cfg.AdapterMode),
 			slog.String("label", cfg.Label),
 			slog.String("current_env", cfg.EnvName),
 			slog.String("previous_env", cfg.PrevEnvName))
@@ -188,7 +190,8 @@ func BuildHMACKey(cfg HMACKeyConfig) ([]byte, error) {
 func LoadKeySet(adapterMode string, clk clock.Clock) (*auth.KeySet, error) {
 	ks, err := auth.LoadKeySetFromEnv(clk)
 	if err == nil {
-		slog.Info("JWT key set loaded from environment variables")
+		slog.Info("JWT key set loaded from environment variables",
+			slog.String("adapter_mode", adapterMode))
 		return ks, nil
 	}
 	if IsRealMode(adapterMode) {
@@ -198,7 +201,8 @@ func LoadKeySet(adapterMode string, clk clock.Clock) (*auth.KeySet, error) {
 	if genErr != nil {
 		return nil, fmt.Errorf("dev mode ephemeral key pair: %w", genErr)
 	}
-	slog.Warn("dev mode: using ephemeral RSA key pair; tokens will be invalidated on restart")
+	slog.Warn("dev mode: using ephemeral RSA key pair; tokens will be invalidated on restart",
+		slog.String("adapter_mode", adapterMode))
 	return auth.NewKeySet(privKey, pubKey, clk)
 }
 

--- a/contracts/http/deviceidentity/enroll/v1/contract.yaml
+++ b/contracts/http/deviceidentity/enroll/v1/contract.yaml
@@ -26,13 +26,13 @@ endpoints:
         description: "Forbidden — authenticated but lacks required permission"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       409:
-        description: "Conflict — device already has an active certificate; use the renew endpoint to rotate."
+        description: "Conflict — device already has an active certificate; use the renew endpoint to rotate. NOTE: 409 is also the idempotency framework status (ClaimBusy, ADR 202606021000-1043); this entry describes the orthogonal business-level meaning."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       413:
         description: "Payload Too Large — request body exceeds the size limit"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       422:
-        description: "Unprocessable Entity — request body is structurally valid JSON but contains semantic validation errors"
+        description: "Unprocessable Entity — request body is structurally valid JSON but contains semantic validation errors. NOTE: 422 is also the idempotency framework status (key-reused, ADR 202606021000-1043); this entry describes the orthogonal business-level meaning."
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       503:
         description: "Service Unavailable — CA backend is not reachable"

--- a/corecells/accesscore/internal/adapters/postgres/policy_codec.go
+++ b/corecells/accesscore/internal/adapters/postgres/policy_codec.go
@@ -177,9 +177,20 @@ func decodeSource(c string) (abac.AttributeSource, error) {
 
 // encodeRowScope maps the zero value (no obligation) to "" and every other valid
 // scope to its frozen code via String(); an out-of-range value is an error (fail-closed).
+//
+// RowScopeAll is rejected on both encode and decode: a policy rule must never
+// authorize the cross-tenant "all" scope. That scope is reserved for the audited
+// super-admin derivation (sealed tenant.NewCrossTenantVisibility), not policy
+// obligations. The converter rejects rowScope=all on write; rejecting it here too
+// makes the codec layer itself fail-closed (defense-in-depth, #2028).
 func encodeRowScope(rs tenant.RowScope) (string, error) {
 	if rs == 0 {
 		return "", nil
+	}
+	if rs == tenant.RowScopeAll {
+		return "", fmt.Errorf(
+			"policy_codec: rowScope %q is not a valid policy obligation; cross-tenant 'all' is audited-only (#2028)",
+			rs.String())
 	}
 	if _, ok := rowScopeToCode[rs]; !ok {
 		return "", fmt.Errorf("policy_codec: cannot encode unknown rowScope %d", uint8(rs))
@@ -189,11 +200,15 @@ func encodeRowScope(rs tenant.RowScope) (string, error) {
 
 // decodeRowScope delegates to tenant.ParseRowScope which already implements the
 // empty-string → zero value (no obligation) semantics. An unknown non-empty code
-// is an error (fail-closed).
+// is an error (fail-closed). RowScopeAll is additionally rejected: see
+// encodeRowScope — policy obligations never carry the audited cross-tenant scope (#2028).
 func decodeRowScope(c string) (tenant.RowScope, error) {
 	rs, err := tenant.ParseRowScope(c)
 	if err != nil {
 		return 0, fmt.Errorf("policy_codec: unknown rowScope code %q", c)
+	}
+	if rs == tenant.RowScopeAll {
+		return 0, fmt.Errorf("policy_codec: rowScope %q is not a valid policy obligation; cross-tenant 'all' is audited-only (#2028)", c)
 	}
 	return rs, nil
 }

--- a/corecells/accesscore/internal/adapters/postgres/policy_codec.go
+++ b/corecells/accesscore/internal/adapters/postgres/policy_codec.go
@@ -79,6 +79,11 @@ var (
 	// rowScopeToCode maps only the NON-zero RowScope values. The zero value is a
 	// valid obligation meaning "no row-scope constraint" (authz.Obligations); it
 	// encodes to "" and is handled explicitly in encode/decodeRowScope, not here.
+	// RowScopeAll IS listed (it is a valid tenant code) but encode/decodeRowScope
+	// reject it at the policy layer (#2028) — a policy rule never authorizes the
+	// audited cross-tenant scope. The entry stays so the codec golden test can
+	// assert the full tenant rowScope code table; the runtime rejection is a
+	// separate, independent guard (not a hole in this map).
 	rowScopeToCode = map[tenant.RowScope]string{
 		tenant.RowScopeSelf:   "self",
 		tenant.RowScopeDevice: "device",
@@ -189,7 +194,7 @@ func encodeRowScope(rs tenant.RowScope) (string, error) {
 	}
 	if rs == tenant.RowScopeAll {
 		return "", fmt.Errorf(
-			"policy_codec: rowScope %q is not a valid policy obligation; cross-tenant 'all' is audited-only (#2028)",
+			"policy_codec: rowScope %q is not a valid policy obligation; cross-tenant 'all' is audited-only",
 			rs.String())
 	}
 	if _, ok := rowScopeToCode[rs]; !ok {
@@ -208,7 +213,7 @@ func decodeRowScope(c string) (tenant.RowScope, error) {
 		return 0, fmt.Errorf("policy_codec: unknown rowScope code %q", c)
 	}
 	if rs == tenant.RowScopeAll {
-		return 0, fmt.Errorf("policy_codec: rowScope %q is not a valid policy obligation; cross-tenant 'all' is audited-only (#2028)", c)
+		return 0, fmt.Errorf("policy_codec: rowScope %q is not a valid policy obligation; cross-tenant 'all' is audited-only", c)
 	}
 	return rs, nil
 }

--- a/corecells/accesscore/internal/adapters/postgres/policy_codec_test.go
+++ b/corecells/accesscore/internal/adapters/postgres/policy_codec_test.go
@@ -121,6 +121,11 @@ func TestPolicyCodec_RowScopeExhaustiveRoundTrip(t *testing.T) {
 
 	n := 0
 	for s := tenant.RowScope(1); s.Valid(); s++ {
+		if s == tenant.RowScopeAll {
+			// Policy rules never authorize the cross-tenant "all" scope; the codec
+			// rejects it on both directions (asserted in RowScopeAllRejected, #2028).
+			continue
+		}
 		n++
 		c, err := encodeRowScope(s)
 		require.NoErrorf(t, err, "rowScope %d must encode", s)
@@ -129,7 +134,19 @@ func TestPolicyCodec_RowScopeExhaustiveRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		require.Equalf(t, s, got, "rowScope %d must round-trip", s)
 	}
-	require.GreaterOrEqual(t, n, 4, "anti-vacuity: every valid RowScope must be exercised")
+	require.GreaterOrEqual(t, n, 3, "anti-vacuity: every policy-authorable RowScope (self/device/tenant) must be exercised")
+}
+
+// TestPolicyCodec_RowScopeAllRejected proves the policy codec fail-closes on the
+// cross-tenant "all" scope in BOTH directions. A policy rule must never authorize
+// RowScopeAll — it is reserved for the audited super-admin derivation (sealed
+// tenant.NewCrossTenantVisibility). The converter rejects it on write; the codec
+// rejects it too so the data layer itself is fail-closed (defense-in-depth, #2028).
+func TestPolicyCodec_RowScopeAllRejected(t *testing.T) {
+	_, err := encodeRowScope(tenant.RowScopeAll)
+	require.Error(t, err, "encodeRowScope must reject RowScopeAll (not a policy obligation)")
+	_, err = decodeRowScope("all")
+	require.Error(t, err, "decodeRowScope must reject the 'all' code (not a policy obligation)")
 }
 
 // ─── fail-closed ───────────────────────────────────────────────────────────

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -315,6 +315,44 @@ func (c *MyCell) Init(ctx context.Context, reg cell.Registrar) error {
 - Nesting `/internal/v1/*` routes inside a `Route` / `Group` / `With` sub-scope is forbidden — it triggers `chiRouterAdapter.guardNestedInternalRegistration` panic (the top-level Router is the sole entry point for internal/external mux splitting).
 - `/healthz` / `/readyz` / `/metrics` are only available on the health listener (`cell.HealthListener`); if no health listener is declared, bootstrap phase0 fails fast (since there is no fallback to primary and no opt-in escape hatch).
 
+### 6b. gRPC Per-Method Public Auth (Optional)
+
+A gRPC service is JWT-authed on every method by default (fail-closed). To expose a
+specific RPC without a token (e.g. a health probe), declare it in the gRPC contract —
+**not** by installing an auth option yourself. The `.proto` remains the single source
+of the method set; the contract overlay only **annotates** an existing method.
+
+```yaml
+# contract.yaml (kind: grpc)
+endpoints:
+  grpc:
+    codegen: true          # required whenever methods[] is present
+    methods:               # SPARSE: list only RPCs that need a non-default flag
+      - name: Check        # must match a proto method name (referential integrity is enforced)
+        public: true       # the only allowed value (const:true); an absent method stays authed
+```
+
+Declaration path (all derived, single-sourced — you write only the contract):
+
+1. contract `endpoints.grpc.methods[].public:true`
+2. → cellgen derives `GRPCServiceSpec.PublicMethods []string` (full `/{Service}/{Method}` names, byte-locked by the cellgen golden)
+3. → the runtime `ServiceRegistrar` aggregates them (`IsPublicMethod`)
+4. → the auth interceptor installs `WithPublicMethod(reg.IsPublicMethod)` for both the unary and stream chains (`authOptionsWithPublicMethods` in `chain.go` — the sole sanctioned installer)
+
+**Compared to HTTP `auth.public`**: an HTTP route declares public access per-route via
+the route field (`auth.Route{Public: true}`, §6). gRPC declares it per-method via the
+contract overlay because the proto — not the contract — owns the method set, so the
+overlay annotates rather than declares. Both are fail-closed: a method/route is authed
+unless explicitly marked public.
+
+**Do not** call `WithPublicMethod` or inject a public-method predicate through
+`Deps.AuthOptions` in your cell — production `WithPublicMethod` references are funnel-locked
+to `chain.go` (`GRPC-PUBLIC-METHOD-WIRING-FUNNEL-01`); the contract overlay is the only
+authoring path, and a name absent from the proto fails the codegen referential-integrity
+funnel. ABAC `permission`/`resource`/`action` and `internalOnly` are **not** part of this
+overlay yet — only `public` is live (the rest are deferred to #2008). See ADR
+`docs/architecture/202605260000-adr-grpc-transport-adapter.md` §"Amendment #1675".
+
 ### 7. Register Event Subscriptions (Optional)
 
 The sole authoritative source for subscriptions is **`slice.yaml` `contractUsages[role=subscribe]`** — cellgen generates the `reg.Subscribe(...)` call into `cell_gen.go` from this declaration. Manually starting goroutines or calling `Subscriber.Subscribe` directly is forbidden; goroutine lifecycle, error convergence, and Setup/Ready phases are all managed by EventRouter.

--- a/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
+++ b/docs/plans/specs/202605262200-047-kernel-webhook-implementation-plan.md
@@ -491,7 +491,7 @@ make verify
 | 项 | 状态 | 载体 |
 |----|------|------|
 | 4 个 OTel metrics | ✅ | `kernel/webhook/metrics.go`：`webhook_deliveries_total{result,source}` / `webhook_delivery_duration_seconds{source}` / `webhook_signature_failures_total{source,reason}` / `webhook_idempotency_hits_total{source}`。收集器在 kernel（镜像 `kernel/reconcile`），`Dispatcher.Handle`（发端，status-aware）+ runtime `Receiver.ServeHTTP`（收端）记录；bootstrap `autoWireWebhookMetricsCollector` 经 `autoWireCachedCollector` funnel 单源接线 phase5+phase6 |
-| `WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01` archtest | ✅ Medium | 双 sealed 枚举（`webhookDeliveryResult` 5 值 + `SignatureFailureReason` 5 值）按 TYPE 冻结 + `recordDelivery` callsite guard；Hard 路径并入 metricschema golden #1416 |
+| `WEBHOOK-METRIC-LABEL-VALUES-FROZEN-01` archtest | ✅ Medium | 双 sealed 枚举（`webhookDeliveryResult` 6 值（含 `circuit_open`，#1541 熔断器 fast-fail）+ `SignatureFailureReason` 5 值）按 TYPE 冻结 + `recordDelivery` callsite guard；Hard 路径并入 metricschema golden #1416 |
 | `WEBHOOK-IDEMPOTENCY-CLAIMER-01` archtest | ✅ Medium | type-keyed data-flow：`claimed.rcpt` 必须溯源自 `idempotency.Claimer.Claim`（object identity + method resolution，rename-proof）。**与计划假设的 `gocell:"required"` tag 形态不同**——receiver 用构造器 nil-guard；本规则锁 substance（claim 做真实幂等工作），与 PIPELINE-01 锁 ordering 正交 |
 | backlog `KERNEL-WEBHOOK-01` | PR-6 交付完成；EPIC #831 关闭**待人工裁定** | 6 个 PR 全合入 + follow-up issues #1539–#1544 全开；但 follow-up #1544（webhook receiver 在 JWT-gated PrimaryListener 上功能阻断）是 capability 级未竟项，EPIC 是否就此关闭由维护者决定。`docs/backlog/20260520/cap-x-cross.md` 是冻结快照，不编辑 |
 

--- a/hack/automation/codex-pr-app-dispatcher/selftest.sh
+++ b/hack/automation/codex-pr-app-dispatcher/selftest.sh
@@ -11,9 +11,16 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
 
 PASS_COUNT=0
 FAIL_COUNT=0
+CHECK_COUNT=0
+# EXPECTED_CHECKS is the anti-vacuity anchor: the exact number of assert_* calls
+# across all scenarios below. If a scenario returns early or is silently skipped
+# (e.g. a handshake abort under load) CHECK_COUNT drifts from this and the run
+# hard-fails instead of false-greening on a 0-fail partial run. Update this when
+# adding/removing a check. (Same pattern as hack/automation/bucket-coverage-selftest.sh.)
+EXPECTED_CHECKS=18
 
-pass() { echo "PASS [$1]"; PASS_COUNT=$((PASS_COUNT + 1)); }
-fail() { echo "FAIL [$1]: $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "PASS [$1]"; PASS_COUNT=$((PASS_COUNT + 1)); CHECK_COUNT=$((CHECK_COUNT + 1)); }
+fail() { echo "FAIL [$1]: $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); CHECK_COUNT=$((CHECK_COUNT + 1)); }
 
 assert_contains() {
     local name="$1" file="$2" needle="$3"
@@ -156,6 +163,11 @@ CODEXSTUB
 chmod +x "${STUB_BIN}/codex"
 
 run_router() {
+    # APP_SERVER_REQUEST_TIMEOUT is generous (30s) so a stub JSON-RPC handshake that
+    # is slow under heavy parallel CI load does not abort Scenario 1 (the ~8% flake
+    # at 5s, #2130). The stub always responds in milliseconds on the happy path, so
+    # this never adds wall-clock; no scenario waits for the timeout to fire (S4 returns
+    # a forced error; S5 skips dispatch). It only raises the previously-flaky ceiling.
     env \
         PATH="${STUB_BIN}:${PATH}" \
         GOCELL_APP_ROUTER_HOME="${ROUTER_HOME}" \
@@ -164,7 +176,7 @@ run_router() {
         GOCELL_APP_ROUTER_AUTHORS="alice bot" \
         GOCELL_APP_ROUTER_PR_COOLDOWN_SECONDS="${ROUTER_COOLDOWN:-1800}" \
         GOCELL_APP_ROUTER_GH_TIMEOUT=5 \
-        GOCELL_APP_ROUTER_APP_SERVER_REQUEST_TIMEOUT=5 \
+        GOCELL_APP_ROUTER_APP_SERVER_REQUEST_TIMEOUT=30 \
         CODEX_BIN="${STUB_BIN}/codex" \
         GH_BIN="${STUB_BIN}/gh" \
         GH_REVIEW_LIST_FILE="${REVIEW_LIST}" \
@@ -249,5 +261,9 @@ assert_not_contains "S5-no-ledger-conflict" "${ROUTER_HOME}/state/dispatched" "4
 assert_not_contains "S5-no-ledger-conflict-check" "${ROUTER_HOME}/state/dispatched" "4@${OID4}:check"
 
 echo ""
-echo "codex-pr-app-dispatcher selftest: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+echo "codex-pr-app-dispatcher selftest: ${PASS_COUNT} passed, ${FAIL_COUNT} failed (${CHECK_COUNT}/${EXPECTED_CHECKS} checks ran)"
+if [[ "${CHECK_COUNT}" -ne "${EXPECTED_CHECKS}" ]]; then
+    echo "ANTI-VACUITY FAIL: ran ${CHECK_COUNT} checks, expected ${EXPECTED_CHECKS} — a scenario was skipped (false-green risk)" >&2
+    exit 1
+fi
 [[ "${FAIL_COUNT}" -eq 0 ]]

--- a/hack/verify-archtest-invariants.sh
+++ b/hack/verify-archtest-invariants.sh
@@ -88,6 +88,17 @@ source hack/lib/archtest.sh
 # close-out). #2024 pr-review F4. The sub-cases are the synthetic red/green
 # fixtures that prove the validator is non-vacuous at PR-merge.
 #
+# REPLAYDEPS-INMEM-FUNNEL-01 and SAGA-PROJECTION-DEPS-INMEM-FUNNEL-01 (each: the
+# rule + RedFixture + ScanCore/Nonce + NoDotImportBlindSpot) are BOTH in this set:
+# they are sibling sealed single-pod-primitive funnels (claimer/nonce vs saga-
+# projection locker) and must be PR-time gated symmetrically — a funnel regression
+# is cheap to detect here (pure AST, no packages.Load) and should fail at PR-merge,
+# not only next-day nightly. #2182 (asymmetry close-out); funnels #1391/#2060.
+#
+# NOTE: fast-lane membership is still a manual test-name allowlist (Soft); deriving
+# it from the rule declarations is the #1279 consolidation-guard generalization,
+# tracked separately — not done here.
+#
 # -tags=archtest: the archtest leaf is gated behind `//go:build archtest` so a
 # bare `go test ./...` keeps it off the make verify / PR critical path (build-tag
 # funnel; same convention as integration / e2e). This gate is a sanctioned
@@ -95,7 +106,7 @@ source hack/lib/archtest.sh
 # renamed tag (which yields "[no test files]" → 0 tests → false green) into a
 # hard failure — `-run` over an empty test set exits 0 otherwise.
 if ! output="$(go test -tags="$ARCHTEST_BUILD_TAGS" ./tools/archtest \
-  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestArchtestModulePathFunnel|TestModulePathFunnel_TypedReconstruction|TestFenceTokenMintFunnel_AllowlistEnforced|TestMetadatatestImportScope|TestFixtureCellIDTypedBuilder_NewCellIDBodyShape|TestFixtureCellIDTypedBuilder_VarInitializerShape|TestRootModuleNoReplace01|TestRootModuleNoReplace01_NegativeControl|TestPlatformCellScanCoverage01|TestPlatformCellScanCoverage01_AntiVacuity|TestArchtest_AllLeafTestFiles_HaveArchtestBuildTag|TestArchtest_InvariantsScriptContainsFunnelGuard|TestPermissionBasedAuthzAllowlist_FrozenEmpty|TestPermissionBasedAuthz_ReverseFixture|TestContractOwnerCellFunnel_NoBypass|TestContractOwnerCellFunnel_DetectorIsNotVacuous|TestArchtestCIGoworkActive|TestArchtestCIGoworkActive_RejectsGoworkOff|TestArchtestCIGoworkActive_AcceptsGoworkActive|TestArchtestCIGoworkActive_IgnoresNonArchtestWorkflow|TestREPLAYDEPS_INMEM_FUNNEL_01|TestREPLAYDEPS_INMEM_FUNNEL_01_ClaimerRedFixture|TestREPLAYDEPS_INMEM_FUNNEL_01_NonceRedFixture|TestREPLAYDEPS_INMEM_FUNNEL_01_NoDotImportBlindSpot)$' \
+  -run '^(TestProdClockInjection|TestKernelClockLeafFallback|TestKernelClockLeafFallbackFixtures|TestProdClockInjectionFixtures|TestProdDurationConst|TestProdDurationConstFixtures|TestTestTimeLiteralConst|TestTestSleepDiscipline|TestTestTimeLiteralFixtures|TestPanicRegistered|TestPanicRegisteredScannerFixtures|TestArchtestModulePathFunnel|TestModulePathFunnel_TypedReconstruction|TestFenceTokenMintFunnel_AllowlistEnforced|TestMetadatatestImportScope|TestFixtureCellIDTypedBuilder_NewCellIDBodyShape|TestFixtureCellIDTypedBuilder_VarInitializerShape|TestRootModuleNoReplace01|TestRootModuleNoReplace01_NegativeControl|TestPlatformCellScanCoverage01|TestPlatformCellScanCoverage01_AntiVacuity|TestArchtest_AllLeafTestFiles_HaveArchtestBuildTag|TestArchtest_InvariantsScriptContainsFunnelGuard|TestPermissionBasedAuthzAllowlist_FrozenEmpty|TestPermissionBasedAuthz_ReverseFixture|TestContractOwnerCellFunnel_NoBypass|TestContractOwnerCellFunnel_DetectorIsNotVacuous|TestArchtestCIGoworkActive|TestArchtestCIGoworkActive_RejectsGoworkOff|TestArchtestCIGoworkActive_AcceptsGoworkActive|TestArchtestCIGoworkActive_IgnoresNonArchtestWorkflow|TestREPLAYDEPS_INMEM_FUNNEL_01|TestREPLAYDEPS_INMEM_FUNNEL_01_ClaimerRedFixture|TestREPLAYDEPS_INMEM_FUNNEL_01_NonceRedFixture|TestREPLAYDEPS_INMEM_FUNNEL_01_NoDotImportBlindSpot|TestSAGA_PROJECTION_DEPS_INMEM_FUNNEL_01|TestSAGA_PROJECTION_DEPS_INMEM_FUNNEL_01_RedFixture|TestSAGA_PROJECTION_DEPS_INMEM_FUNNEL_01_ScanCore_SyntheticTree|TestSAGA_PROJECTION_DEPS_INMEM_FUNNEL_01_NoDotImportBlindSpot)$' \
   -count=1 -timeout 5m 2>&1)"; then
   printf '%s\n' "$output"
   exit 1

--- a/tools/archtest/saga_invariants_test.go
+++ b/tools/archtest/saga_invariants_test.go
@@ -3987,9 +3987,8 @@ func TestSAGA_PROJECTION_DEPS_INMEM_FUNNEL_01_RedFixture(t *testing.T) {
 	line, ok, err := firstQualifiedSelectorLine(path, distlockModule, "distlock", "NewInProcessDriver")
 	require.NoError(t, err, "parse RED fixture")
 	if !ok {
-		t.Error("SAGA-PROJECTION-DEPS-INMEM-FUNNEL-01 RED fixture: detector found no " +
+		t.Fatal("SAGA-PROJECTION-DEPS-INMEM-FUNNEL-01 RED fixture: detector found no " +
 			"distlock.NewInProcessDriver; firstQualifiedSelectorLine may be broken")
-		return
 	}
 	t.Logf("RED fixture hit at line %d", line)
 }

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/tools/internal/prodscan"
 	"github.com/ghbvf/gocell/tools/packagesload"
+	"github.com/ghbvf/gocell/tools/workspace"
 )
 
 const (
@@ -209,20 +210,38 @@ func Build(ctx context.Context, projectRoot string, project *metadata.ProjectMet
 	return schema, nil
 }
 
-// containingModuleDir returns the deepest directory at or above dir (a
-// projectRoot-relative path) that holds a go.mod — i.e. the go.work satellite
-// module that owns dir — or "" when dir belongs to the repo root module. Build
-// uses a non-empty result to recognize a satellite example entrypoint and switch
-// the package load to ModeWorkspace (NOT GOWORK=off): ModeWorkspace resolves the
-// satellite AND core as workspace members in one graph, whereas a repo-root
-// ModeModule load cannot see a nested module's packages at all (#1556).
+// containingModuleDir returns the go.work satellite member that owns dir (a
+// projectRoot-relative path) — the member whose directory is the longest prefix
+// of dir — or "" when dir belongs to the repo root module. Build uses a non-empty
+// result to recognize a satellite example entrypoint and switch the package load
+// to ModeWorkspace (NOT GOWORK=off): ModeWorkspace resolves the satellite AND core
+// as workspace members in one graph, whereas a repo-root ModeModule load cannot
+// see a nested module's packages at all (#1556).
+//
+// Owner-resolution is single-sourced through workspace.Modules — the same member
+// set packagesload uses (#2167) — rather than a bespoke go.mod filesystem walk:
+// the decision is precisely "is dir inside a go.work member", which only the
+// registered member set answers (a nested go.mod absent from go.work is not a
+// member and ModeWorkspace would not resolve it either). A Modules error degrades
+// to root ownership ("") → ModeModule; any real satellite resolution failure then
+// surfaces from the subsequent package load with a clear "package not found".
 func containingModuleDir(projectRoot, dir string) string {
-	for d := filepath.Clean(dir); d != "." && d != ""; d = filepath.Dir(d) {
-		if _, err := os.Stat(filepath.Join(projectRoot, d, "go.mod")); err == nil {
-			return d
+	mods, err := workspace.Modules(projectRoot)
+	if err != nil {
+		return ""
+	}
+	target := filepath.ToSlash(filepath.Clean(dir))
+	best := ""
+	for _, m := range mods {
+		md := filepath.ToSlash(filepath.Clean(m.Dir))
+		if md == "." || md == "" {
+			continue // root module is represented by "" (not a satellite)
+		}
+		if (target == md || strings.HasPrefix(target, md+"/")) && len(md) > len(best) {
+			best = md
 		}
 	}
-	return ""
+	return best
 }
 
 // Marshal serializes schema with the generated-file header.

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -14,6 +14,7 @@ import (
 	"go/format"
 	"go/token"
 	"go/types"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -228,6 +229,10 @@ func Build(ctx context.Context, projectRoot string, project *metadata.ProjectMet
 func containingModuleDir(projectRoot, dir string) string {
 	mods, err := workspace.Modules(projectRoot)
 	if err != nil {
+		// Degrade to root ownership (ModeModule). Surface the cause so a malformed
+		// go.work isn't diagnosed only via a downstream "package not found" (#2167 review).
+		slog.Warn("metricschema: workspace.Modules failed; treating entrypoint as root-module-owned",
+			slog.String("project_root", projectRoot), slog.Any("error", err))
 		return ""
 	}
 	target := filepath.ToSlash(filepath.Clean(dir))


### PR DESCRIPTION
## Summary

cx-1 清理 bundle：合并 11 个 #2000 之后的 `cx-1` issues（docs / 注释 / 小重构 / archtest / automation），均经 read-only 核实为真。

## Why / 背景

批量收口一批低风险 cx-1 治理/文档/重构遗留，单 PR 减少逐条流程开销。每条修复见下方 commit（按关注点分组，可独立 review/revert）。

## Refs

Closes #2028 Closes #2061 Closes #2081 Closes #2090 Closes #2107 Closes #2130 Closes #2167 Closes #2169 Closes #2170 Closes #2182 Closes #2183

- #2061 ref: 对齐 saga journal #2058 的 typed `pgtype.Interval` 路径
- #2081 ref: ADR `202605260000-adr-grpc-transport-adapter.md` §Amendment #1675

## Risk / 兼容性

无破坏式 wire 变更。

- #2028 收紧 policy codec（encode/decode 拒绝 RowScopeAll，纵深防御；当前无逃逸路径变化，converter 写入层已拒）。
- #2061 PG interval 改 typed `pgtype.Interval`（行为等价，去冗余 `::interval` cast）。
- #2167 metricschema owner-resolution 改用 `workspace.Modules`（行为等价，member 集单源）。
- docs / 注释 / archtest / automation 零运行时影响。
- #2182 fast-lane 仍为手工 test-name allowlist（Soft），Hard 化是 #1279 同族 epic（注释指向，不在本 PR 范围）。

## Test plan

- [x] `go build` 本地通过（adapters/postgres、corecells/accesscore、cellmodules/cellsecrets、tools/metricschema 各模块）
- [x] `go test` 本地通过（含新 `TestPolicyCodec_RowScopeAllRejected`、outbox typed-interval 断言更新）
- [x] `golangci-lint run` 0 issues（4 个改动模块）
- [x] `bash hack/verify-archtest-invariants.sh` 含 SAGA-PROJECTION，exit 0
- [x] `bash hack/automation/codex-pr-app-dispatcher/selftest.sh` 18/18 checks，exit 0
- [x] `go run ./cmd/gocell validate` 0 errors（2 warnings 为 pre-existing journey-status）
