### PR TITLE
feat(webhook): per-deployment 熔断器阈值可配置 [#2106]

### DIFF
--- a/framework/kernel/webhook/circuit.go
+++ b/framework/kernel/webhook/circuit.go
@@ -15,6 +15,27 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 )
 
+// Upper bounds for CircuitBreakerSettings fields — defense-in-depth for the
+// no-disable invariant: absurdly large values make the breaker de-facto
+// disabled (MaxInt TripThreshold = never trips; very large OpenTimeout =
+// never recovers). These caps allow all realistic tuning ranges while
+// blocking values that are semantically equivalent to "circuit breaker off".
+// They are NOT performance limits.
+const (
+	// cbMaxTripThreshold is the upper bound for TripThreshold.
+	// TripThreshold > 1000 would mean tolerating 1001+ consecutive endpoint
+	// failures before tripping — effectively disabling the breaker.
+	cbMaxTripThreshold = 1000
+	// cbMaxOpenTimeout is the upper bound for OpenTimeout (1 hour).
+	// An OpenTimeout > 1h means the breaker would stay open for a very long
+	// time before admitting a probe — effectively never recovering.
+	cbMaxOpenTimeout = time.Hour
+	// cbMaxHalfOpenProbes is the upper bound for HalfOpenProbes.
+	// HalfOpenProbes > 100 would flood a recovering endpoint with probes,
+	// defeating the purpose of the half-open state.
+	cbMaxHalfOpenProbes = 100
+)
+
 // noTenantSentinel is the breaker-key tenant segment for a tenantless (system)
 // delivery — an outbox entry whose principal carries no TenantID. Mirrors the
 // idempotency/reconcile _notenant convention so a tenantless delivery can never
@@ -79,25 +100,33 @@ const circuitGateMaxEndpoints = 1024
 
 // CircuitBreakerSettings holds the per-deployment tunable thresholds for the
 // outbound webhook per-endpoint circuit breaker. The zero value is invalid;
-// use [defaultCircuitBreakerSettings] to obtain valid defaults, or construct
-// with all fields positive and call [CircuitBreakerSettings.validate].
+// use [DefaultCircuitBreakerSettings] to obtain valid defaults, or construct
+// with all fields positive and call [CircuitBreakerSettings.Validate].
 //
 // Design: no Enabled/Disabled field — "disable the circuit breaker" must be
 // inexpressible at the type level. Options only tune thresholds.
+//
+// INVARIANT: WEBHOOK-CB-NO-DISABLE-01 (Hard — reflect field freeze, see
+// tools/archtest/webhook_cb_no_disable_test.go): the exported field set is
+// frozen to exactly {TripThreshold int, OpenTimeout time.Duration,
+// HalfOpenProbes int}. Adding an Enabled/Disabled bool or any other field that
+// could semantically suppress the circuit breaker causes the archtest to fail.
 //
 // ref: sony/gobreaker Settings (MaxRequests/Interval/Timeout/ReadyToTrip) for
 // naming inspiration; GoCell adapts to the webhook-delivery semantics.
 type CircuitBreakerSettings struct {
 	// TripThreshold is the number of consecutive endpoint-health failures that
 	// MUST BE EXCEEDED before the breaker opens. The (TripThreshold+1)'th
-	// consecutive failure opens the circuit. Must be > 0.
+	// consecutive failure opens the circuit. Example: TripThreshold=5 means the
+	// 6th consecutive failure opens the circuit. Must be in [1, cbMaxTripThreshold].
 	TripThreshold int
 	// OpenTimeout is how long the breaker stays open (fast-failing deliveries)
-	// before admitting a single half-open probe. Must be > 0.
+	// before admitting a single half-open probe.
+	// Must be in (0, cbMaxOpenTimeout].
 	OpenTimeout time.Duration
 	// HalfOpenProbes is the maximum number of probe deliveries admitted while
 	// half-open; one probe is sufficient to decide recovery in normal deployments.
-	// Must be > 0.
+	// Must be in [1, cbMaxHalfOpenProbes].
 	HalfOpenProbes int
 }
 
@@ -115,23 +144,54 @@ func DefaultCircuitBreakerSettings() CircuitBreakerSettings {
 	}
 }
 
-// defaultCircuitBreakerSettings is the package-internal alias used by
-// Dispatcher construction and tests to avoid exporting the symbol redundantly.
-func defaultCircuitBreakerSettings() CircuitBreakerSettings { return DefaultCircuitBreakerSettings() }
-
-// Validate returns a non-nil error if any field is ≤ 0 (fail-fast; complies
-// with runtime-api.md §Option 范式: "强依赖 option 必须 fail-fast，不静默 noop").
-// Called by [WithCircuitBreakerSettings] at Dispatcher construction time and by
-// bootstrap's [WithWebhookCircuitBreaker] at option-apply time.
+// Validate returns a non-nil error if any field is outside its valid range
+// (fail-fast; complies with runtime-api.md §Option 范式: "强依赖 option 必须
+// fail-fast，不静默 noop"). Called by [WithCircuitBreakerSettings] at Dispatcher
+// construction time and by bootstrap's [WithWebhookCircuitBreaker] at phase-drain
+// time.
+//
+// Lower bounds (> 0) reject zero/negative values.
+// Upper bounds (cbMax*) are the no-disable defense-in-depth: a value equivalent
+// to "never trip" or "never recover" is treated as an invalid configuration.
 func (s CircuitBreakerSettings) Validate() error {
 	if s.TripThreshold <= 0 {
-		return fmt.Errorf("webhook circuit breaker: TripThreshold must be > 0, got %d", s.TripThreshold)
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook circuit breaker: TripThreshold must be > 0",
+			errcode.WithDetails(errcode.PublicInt("got", s.TripThreshold)))
+	}
+	if s.TripThreshold > cbMaxTripThreshold {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook circuit breaker: TripThreshold exceeds maximum",
+			errcode.WithDetails(
+				errcode.PublicInt("got", s.TripThreshold),
+				errcode.PublicInt("max", cbMaxTripThreshold),
+			))
 	}
 	if s.OpenTimeout <= 0 {
-		return fmt.Errorf("webhook circuit breaker: OpenTimeout must be > 0, got %s", s.OpenTimeout)
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook circuit breaker: OpenTimeout must be > 0",
+			errcode.WithDetails(errcode.PublicDuration("got", s.OpenTimeout)))
+	}
+	if s.OpenTimeout > cbMaxOpenTimeout {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook circuit breaker: OpenTimeout exceeds maximum",
+			errcode.WithDetails(
+				errcode.PublicDuration("got", s.OpenTimeout),
+				errcode.PublicDuration("max", cbMaxOpenTimeout),
+			))
 	}
 	if s.HalfOpenProbes <= 0 {
-		return fmt.Errorf("webhook circuit breaker: HalfOpenProbes must be > 0, got %d", s.HalfOpenProbes)
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook circuit breaker: HalfOpenProbes must be > 0",
+			errcode.WithDetails(errcode.PublicInt("got", s.HalfOpenProbes)))
+	}
+	if s.HalfOpenProbes > cbMaxHalfOpenProbes {
+		return errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook circuit breaker: HalfOpenProbes exceeds maximum",
+			errcode.WithDetails(
+				errcode.PublicInt("got", s.HalfOpenProbes),
+				errcode.PublicInt("max", cbMaxHalfOpenProbes),
+			))
 	}
 	return nil
 }

--- a/framework/kernel/webhook/circuit.go
+++ b/framework/kernel/webhook/circuit.go
@@ -34,6 +34,10 @@ const (
 	// HalfOpenProbes > 100 would flood a recovering endpoint with probes,
 	// defeating the purpose of the half-open state.
 	cbMaxHalfOpenProbes = 100
+	// defaultCBOpenTimeout is the default OpenTimeout used by
+	// DefaultCircuitBreakerSettings. A named const (not an inline literal) is
+	// required by the PROD-DURATION-CONST invariant for production duration values.
+	defaultCBOpenTimeout = 60 * time.Second
 )
 
 // noTenantSentinel is the breaker-key tenant segment for a tenantless (system)
@@ -139,7 +143,7 @@ type CircuitBreakerSettings struct {
 func DefaultCircuitBreakerSettings() CircuitBreakerSettings {
 	return CircuitBreakerSettings{
 		TripThreshold:  5,
-		OpenTimeout:    60 * time.Second,
+		OpenTimeout:    defaultCBOpenTimeout,
 		HalfOpenProbes: 1,
 	}
 }

--- a/framework/kernel/webhook/circuit.go
+++ b/framework/kernel/webhook/circuit.go
@@ -70,33 +70,79 @@ func circuitFingerprint(s string) string {
 	return fmt.Sprintf("%08x", h.Sum32())
 }
 
-// Circuit-breaker defaults for outbound webhook delivery. These mirror the
-// sony/gobreaker standard defaults but are stated explicitly here so the
-// dispatcher's resilience posture is self-documenting and decoupled from the
-// kernel breaker's own zero-value defaults.
-const (
-	// circuitTripThreshold trips an endpoint's breaker once consecutive
-	// delivery failures EXCEED this count (so the threshold+1'th failure opens).
-	circuitTripThreshold = 5
-	// circuitOpenTimeout is how long an endpoint stays open (fast-failing)
-	// before the breaker admits a single half-open probe.
-	circuitOpenTimeout = 60 * time.Second
-	// circuitHalfOpenProbes is the number of probe deliveries admitted while
-	// half-open; a single probe is enough to decide recovery.
-	circuitHalfOpenProbes = 1
-	// circuitGateMaxEndpoints bounds the per-endpoint breaker registry so a
-	// selector that fans out to unbounded distinct target URLs cannot grow
-	// memory without limit (DoS guard). Mirrors kernel/reconcile/backoff.go's
-	// maxBackoffEntries. At this cardinality eviction is a pathological safety
-	// valve, not a hot path.
-	circuitGateMaxEndpoints = 1024
-)
+// circuitGateMaxEndpoints bounds the per-endpoint breaker registry so a
+// selector that fans out to unbounded distinct target URLs cannot grow
+// memory without limit (DoS guard). Mirrors kernel/reconcile/backoff.go's
+// maxBackoffEntries. At this cardinality eviction is a pathological safety
+// valve, not a hot path. Orthogonal to CB thresholds — not user-configurable.
+const circuitGateMaxEndpoints = 1024
 
-// circuitReadyToTrip opens the breaker once consecutive failures exceed
-// circuitTripThreshold. Package-level so every per-endpoint breaker shares one
-// function value rather than allocating a closure per endpoint.
-func circuitReadyToTrip(c circuitbreaker.Counts) bool {
-	return c.ConsecutiveFailures > circuitTripThreshold
+// CircuitBreakerSettings holds the per-deployment tunable thresholds for the
+// outbound webhook per-endpoint circuit breaker. The zero value is invalid;
+// use [defaultCircuitBreakerSettings] to obtain valid defaults, or construct
+// with all fields positive and call [CircuitBreakerSettings.validate].
+//
+// Design: no Enabled/Disabled field — "disable the circuit breaker" must be
+// inexpressible at the type level. Options only tune thresholds.
+//
+// ref: sony/gobreaker Settings (MaxRequests/Interval/Timeout/ReadyToTrip) for
+// naming inspiration; GoCell adapts to the webhook-delivery semantics.
+type CircuitBreakerSettings struct {
+	// TripThreshold is the number of consecutive endpoint-health failures that
+	// MUST BE EXCEEDED before the breaker opens. The (TripThreshold+1)'th
+	// consecutive failure opens the circuit. Must be > 0.
+	TripThreshold int
+	// OpenTimeout is how long the breaker stays open (fast-failing deliveries)
+	// before admitting a single half-open probe. Must be > 0.
+	OpenTimeout time.Duration
+	// HalfOpenProbes is the maximum number of probe deliveries admitted while
+	// half-open; one probe is sufficient to decide recovery in normal deployments.
+	// Must be > 0.
+	HalfOpenProbes int
+}
+
+// DefaultCircuitBreakerSettings returns the default per-endpoint circuit-breaker
+// thresholds (TripThreshold=5, OpenTimeout=60s, HalfOpenProbes=1). These equal
+// the values formerly hard-coded as package constants and are used when
+// [WithCircuitBreakerSettings] is not provided. Callers (bootstrap's
+// [WithWebhookCircuitBreaker], dispatch.BuildConsumers) use this to populate the
+// explicit settings parameter rather than accepting a zero value.
+func DefaultCircuitBreakerSettings() CircuitBreakerSettings {
+	return CircuitBreakerSettings{
+		TripThreshold:  5,
+		OpenTimeout:    60 * time.Second,
+		HalfOpenProbes: 1,
+	}
+}
+
+// defaultCircuitBreakerSettings is the package-internal alias used by
+// Dispatcher construction and tests to avoid exporting the symbol redundantly.
+func defaultCircuitBreakerSettings() CircuitBreakerSettings { return DefaultCircuitBreakerSettings() }
+
+// Validate returns a non-nil error if any field is ≤ 0 (fail-fast; complies
+// with runtime-api.md §Option 范式: "强依赖 option 必须 fail-fast，不静默 noop").
+// Called by [WithCircuitBreakerSettings] at Dispatcher construction time and by
+// bootstrap's [WithWebhookCircuitBreaker] at option-apply time.
+func (s CircuitBreakerSettings) Validate() error {
+	if s.TripThreshold <= 0 {
+		return fmt.Errorf("webhook circuit breaker: TripThreshold must be > 0, got %d", s.TripThreshold)
+	}
+	if s.OpenTimeout <= 0 {
+		return fmt.Errorf("webhook circuit breaker: OpenTimeout must be > 0, got %s", s.OpenTimeout)
+	}
+	if s.HalfOpenProbes <= 0 {
+		return fmt.Errorf("webhook circuit breaker: HalfOpenProbes must be > 0, got %d", s.HalfOpenProbes)
+	}
+	return nil
+}
+
+// makeCircuitReadyToTrip returns a ReadyToTrip predicate that opens the breaker
+// once consecutive failures exceed tripThreshold. A closure per circuitGate is
+// acceptable (one gate per Dispatcher, not one per endpoint).
+func makeCircuitReadyToTrip(tripThreshold int) func(circuitbreaker.Counts) bool {
+	return func(c circuitbreaker.Counts) bool {
+		return c.ConsecutiveFailures > uint32(tripThreshold) //nolint:gosec // tripThreshold is validated > 0
+	}
 }
 
 // errCircuitProbeFailure is the sentinel handed to a breaker's done callback
@@ -134,16 +180,17 @@ func circuitProbeOutcome(statusCode int, transportErr error) error {
 // The map is bounded (circuitGateMaxEndpoints) as a DoS guard.
 type circuitGate struct {
 	clk      clock.Clock
+	settings CircuitBreakerSettings
 	mu       sync.Mutex
 	breakers map[string]*circuitbreaker.Breaker
 }
 
 // newCircuitGate builds an enabled circuit gate. clk is the dispatcher's clock,
 // shared so open→half-open transitions advance with the same time source the
-// tests drive.
-func newCircuitGate(clk clock.Clock) *circuitGate {
+// tests drive. settings must have been validated before calling newCircuitGate.
+func newCircuitGate(clk clock.Clock, settings CircuitBreakerSettings) *circuitGate {
 	clock.MustHaveClock(clk, "webhook.newCircuitGate")
-	return &circuitGate{clk: clk, breakers: make(map[string]*circuitbreaker.Breaker)}
+	return &circuitGate{clk: clk, settings: settings, breakers: make(map[string]*circuitbreaker.Breaker)}
 }
 
 // Allow gates a delivery for key. It returns allowed=true and a done callback
@@ -193,10 +240,10 @@ func (g *circuitGate) breakerFor(key circuitEndpointKey) *circuitbreaker.Breaker
 		}
 	}
 	b, err := circuitbreaker.New(circuitbreaker.Config{
-		Name:        key.logName(), // safe log label: host#fingerprint, no path/query
-		MaxRequests: circuitHalfOpenProbes,
-		Timeout:     circuitOpenTimeout,
-		ReadyToTrip: circuitReadyToTrip,
+		Name:        key.logName(),                     // safe log label: host#fingerprint, no path/query
+		MaxRequests: uint32(g.settings.HalfOpenProbes), //nolint:gosec // validated > 0
+		Timeout:     g.settings.OpenTimeout,
+		ReadyToTrip: makeCircuitReadyToTrip(g.settings.TripThreshold),
 	}, g.clk)
 	if err != nil {
 		return nil

--- a/framework/kernel/webhook/circuit_settings_test.go
+++ b/framework/kernel/webhook/circuit_settings_test.go
@@ -1,0 +1,227 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/framework/kernel/outbox"
+)
+
+// TestCircuitBreakerSettings_Defaults verifies that defaultCircuitBreakerSettings
+// returns values equal to the original package-const values (TripThreshold=5,
+// OpenTimeout=60s, HalfOpenProbes=1).
+func TestCircuitBreakerSettings_Defaults(t *testing.T) {
+	s := defaultCircuitBreakerSettings()
+	assert.Equal(t, 5, s.TripThreshold, "default TripThreshold must equal original const 5")
+	assert.Equal(t, 60*time.Second, s.OpenTimeout, "default OpenTimeout must equal original const 60s")
+	assert.Equal(t, 1, s.HalfOpenProbes, "default HalfOpenProbes must equal original const 1")
+}
+
+// TestCircuitBreakerSettings_Validate_NonPositiveTrip verifies that a
+// TripThreshold ≤ 0 is rejected (fail-fast).
+func TestCircuitBreakerSettings_Validate_NonPositiveTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		s    CircuitBreakerSettings
+	}{
+		{"zero trip", CircuitBreakerSettings{TripThreshold: 0, OpenTimeout: time.Second, HalfOpenProbes: 1}},
+		{"negative trip", CircuitBreakerSettings{TripThreshold: -1, OpenTimeout: time.Second, HalfOpenProbes: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.s.Validate()
+			require.Error(t, err, "non-positive TripThreshold must be rejected")
+			assert.Contains(t, err.Error(), "TripThreshold")
+		})
+	}
+}
+
+// TestCircuitBreakerSettings_Validate_NonPositiveOpenTimeout verifies that
+// OpenTimeout ≤ 0 is rejected (fail-fast).
+func TestCircuitBreakerSettings_Validate_NonPositiveOpenTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		s    CircuitBreakerSettings
+	}{
+		{"zero timeout", CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: 0, HalfOpenProbes: 1}},
+		{"negative timeout", CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: -time.Second, HalfOpenProbes: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.s.Validate()
+			require.Error(t, err, "non-positive OpenTimeout must be rejected")
+			assert.Contains(t, err.Error(), "OpenTimeout")
+		})
+	}
+}
+
+// TestCircuitBreakerSettings_Validate_NonPositiveHalfOpenProbes verifies that
+// HalfOpenProbes ≤ 0 is rejected (fail-fast).
+func TestCircuitBreakerSettings_Validate_NonPositiveHalfOpenProbes(t *testing.T) {
+	cases := []struct {
+		name string
+		s    CircuitBreakerSettings
+	}{
+		{"zero probes", CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: time.Second, HalfOpenProbes: 0}},
+		{"negative probes", CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: time.Second, HalfOpenProbes: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.s.Validate()
+			require.Error(t, err, "non-positive HalfOpenProbes must be rejected")
+			assert.Contains(t, err.Error(), "HalfOpenProbes")
+		})
+	}
+}
+
+// TestCircuitBreakerSettings_Validate_Valid verifies that a valid settings struct
+// passes validation without error.
+func TestCircuitBreakerSettings_Validate_Valid(t *testing.T) {
+	s := CircuitBreakerSettings{TripThreshold: 3, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
+	require.NoError(t, s.Validate())
+}
+
+// TestWithCircuitBreakerSettings_InvalidSettings verifies that NewDispatcher
+// returns an error when provided settings fail validation (fail-fast at
+// construction time, not first delivery).
+func TestWithCircuitBreakerSettings_InvalidSettings(t *testing.T) {
+	cases := []struct {
+		name string
+		s    CircuitBreakerSettings
+		want string
+	}{
+		{
+			"zero TripThreshold",
+			CircuitBreakerSettings{TripThreshold: 0, OpenTimeout: time.Second, HalfOpenProbes: 1},
+			"TripThreshold",
+		},
+		{
+			"zero OpenTimeout",
+			CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: 0, HalfOpenProbes: 1},
+			"OpenTimeout",
+		},
+		{
+			"zero HalfOpenProbes",
+			CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: time.Second, HalfOpenProbes: 0},
+			"HalfOpenProbes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewDispatcher(
+				clockmock.New(time.Unix(dispatchTestTS, 0)),
+				dispatchTestSigner(t),
+				NewSafePolicy(WithAllowLoopback()),
+				staticSelector("http://example.test/"),
+				WithCircuitBreakerSettings(tc.s),
+			)
+			require.Error(t, err, "invalid settings must cause NewDispatcher to return error")
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestWithCircuitBreakerSettings_CustomTripThreshold verifies that a Dispatcher
+// built with TripThreshold=2 trips after exactly 3 consecutive failures (> 2),
+// not after the default 5.
+func TestWithCircuitBreakerSettings_CustomTripThreshold(t *testing.T) {
+	srv, hits, _ := countingServer(t, http.StatusInternalServerError)
+
+	customSettings := CircuitBreakerSettings{
+		TripThreshold:  2,
+		OpenTimeout:    30 * time.Second,
+		HalfOpenProbes: 1,
+	}
+	d, err := NewDispatcher(
+		clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t),
+		NewSafePolicy(WithAllowLoopback()),
+		staticSelector(srv.URL),
+		WithCircuitBreakerSettings(customSettings),
+	)
+	require.NoError(t, err)
+
+	// Deliver exactly TripThreshold times — breaker must still be CLOSED.
+	for i := range customSettings.TripThreshold {
+		res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+		assert.Equal(t, outbox.DispositionRequeue, res.Disposition,
+			"delivery %d: circuit must be closed (only %d failures so far)", i+1, i+1)
+	}
+	assert.Equal(t, int32(customSettings.TripThreshold), hits.Load(), //nolint:gosec // TripThreshold is validated > 0 and << MaxInt32
+		"all TripThreshold deliveries must have reached the endpoint")
+
+	// One more exceeds the threshold → trips the circuit.
+	d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	// The NEXT call must be fast-failed (circuit open).
+	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{}`))))
+}
+
+// TestWithCircuitBreakerSettings_CustomOpenTimeout verifies that the custom
+// OpenTimeout controls when the breaker admits a half-open probe: advancing less
+// than the timeout keeps the circuit open; advancing past it allows a probe.
+func TestWithCircuitBreakerSettings_CustomOpenTimeout(t *testing.T) {
+	srv, _, _ := countingServer(t, http.StatusInternalServerError)
+
+	customSettings := CircuitBreakerSettings{
+		TripThreshold:  2,
+		OpenTimeout:    10 * time.Second,
+		HalfOpenProbes: 1,
+	}
+	fc := clockmock.New(time.Unix(dispatchTestTS, 0))
+	d, err := NewDispatcher(fc, dispatchTestSigner(t),
+		NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL),
+		WithCircuitBreakerSettings(customSettings))
+	require.NoError(t, err)
+
+	// Trip the circuit.
+	for range customSettings.TripThreshold + 1 {
+		d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	}
+	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{}`))))
+
+	// Advancing less than OpenTimeout → still open.
+	fc.Advance(5 * time.Second)
+	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{}`))))
+
+	// Advancing past OpenTimeout → half-open; probe is admitted, reaches server.
+	fc.Advance(customSettings.OpenTimeout + time.Second)
+	probeRes := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	assert.Equal(t, outbox.DispositionRequeue, probeRes.Disposition,
+		"half-open probe must reach the endpoint (still 5xx → Requeue, not circuit-open fast-fail)")
+}
+
+// TestWithCircuitBreakerSettings_DefaultsUnchangedWhenOptionAbsent verifies the
+// no-option path: a Dispatcher without WithCircuitBreakerSettings trips at the
+// original default TripThreshold (5) and not earlier.
+func TestWithCircuitBreakerSettings_DefaultsUnchangedWhenOptionAbsent(t *testing.T) {
+	srv, hits, _ := countingServer(t, http.StatusInternalServerError)
+
+	d, err := NewDispatcher(
+		clockmock.New(time.Unix(dispatchTestTS, 0)),
+		dispatchTestSigner(t),
+		NewSafePolicy(WithAllowLoopback()),
+		staticSelector(srv.URL),
+		// No WithCircuitBreakerSettings — defaults apply.
+	)
+	require.NoError(t, err)
+
+	defaults := defaultCircuitBreakerSettings()
+	// Deliver exactly TripThreshold times — circuit must still be CLOSED.
+	for i := range defaults.TripThreshold {
+		res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+		assert.Equal(t, outbox.DispositionRequeue, res.Disposition,
+			"delivery %d: circuit must be closed (default threshold not yet exceeded)", i+1)
+	}
+	assert.Equal(t, int32(defaults.TripThreshold), hits.Load(), //nolint:gosec // TripThreshold is validated > 0 and << MaxInt32
+		"all TripThreshold deliveries must have reached the endpoint")
+
+	// One more exceeds the threshold → trips the circuit.
+	d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))
+	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{}`))))
+}

--- a/framework/kernel/webhook/circuit_settings_test.go
+++ b/framework/kernel/webhook/circuit_settings_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 )
 
-// TestCircuitBreakerSettings_Defaults verifies that defaultCircuitBreakerSettings
+// TestCircuitBreakerSettings_Defaults verifies that DefaultCircuitBreakerSettings
 // returns values equal to the original package-const values (TripThreshold=5,
 // OpenTimeout=60s, HalfOpenProbes=1).
 func TestCircuitBreakerSettings_Defaults(t *testing.T) {
-	s := defaultCircuitBreakerSettings()
+	s := DefaultCircuitBreakerSettings()
 	assert.Equal(t, 5, s.TripThreshold, "default TripThreshold must equal original const 5")
 	assert.Equal(t, 60*time.Second, s.OpenTimeout, "default OpenTimeout must equal original const 60s")
 	assert.Equal(t, 1, s.HalfOpenProbes, "default HalfOpenProbes must equal original const 1")
@@ -85,6 +85,39 @@ func TestCircuitBreakerSettings_Validate_NonPositiveHalfOpenProbes(t *testing.T)
 func TestCircuitBreakerSettings_Validate_Valid(t *testing.T) {
 	s := CircuitBreakerSettings{TripThreshold: 3, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
 	require.NoError(t, s.Validate())
+}
+
+// TestCircuitBreakerSettings_Validate_AboveUpperBound verifies that values exceeding
+// the upper bounds are rejected (no-disable defense-in-depth).
+func TestCircuitBreakerSettings_Validate_AboveUpperBound(t *testing.T) {
+	cases := []struct {
+		name string
+		s    CircuitBreakerSettings
+		want string
+	}{
+		{
+			"TripThreshold above max",
+			CircuitBreakerSettings{TripThreshold: 1001, OpenTimeout: time.Second, HalfOpenProbes: 1},
+			"TripThreshold",
+		},
+		{
+			"OpenTimeout above max",
+			CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: 2 * time.Hour, HalfOpenProbes: 1},
+			"OpenTimeout",
+		},
+		{
+			"HalfOpenProbes above max",
+			CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: time.Second, HalfOpenProbes: 101},
+			"HalfOpenProbes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.s.Validate()
+			require.Error(t, err, "above-upper-bound value must be rejected")
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
 }
 
 // TestWithCircuitBreakerSettings_InvalidSettings verifies that NewDispatcher
@@ -211,7 +244,7 @@ func TestWithCircuitBreakerSettings_DefaultsUnchangedWhenOptionAbsent(t *testing
 	)
 	require.NoError(t, err)
 
-	defaults := defaultCircuitBreakerSettings()
+	defaults := DefaultCircuitBreakerSettings()
 	// Deliver exactly TripThreshold times — circuit must still be CLOSED.
 	for i := range defaults.TripThreshold {
 		res := d.Handle(context.Background(), newTestEntry(t, []byte(`{}`)))

--- a/framework/kernel/webhook/circuit_settings_test.go
+++ b/framework/kernel/webhook/circuit_settings_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 )
 
 // TestCircuitBreakerSettings_Defaults verifies that DefaultCircuitBreakerSettings
@@ -19,7 +20,7 @@ import (
 func TestCircuitBreakerSettings_Defaults(t *testing.T) {
 	s := DefaultCircuitBreakerSettings()
 	assert.Equal(t, 5, s.TripThreshold, "default TripThreshold must equal original const 5")
-	assert.Equal(t, 60*time.Second, s.OpenTimeout, "default OpenTimeout must equal original const 60s")
+	assert.Equal(t, testtime.D60s, s.OpenTimeout, "default OpenTimeout must equal original const 60s")
 	assert.Equal(t, 1, s.HalfOpenProbes, "default HalfOpenProbes must equal original const 1")
 }
 
@@ -83,7 +84,7 @@ func TestCircuitBreakerSettings_Validate_NonPositiveHalfOpenProbes(t *testing.T)
 // TestCircuitBreakerSettings_Validate_Valid verifies that a valid settings struct
 // passes validation without error.
 func TestCircuitBreakerSettings_Validate_Valid(t *testing.T) {
-	s := CircuitBreakerSettings{TripThreshold: 3, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
+	s := CircuitBreakerSettings{TripThreshold: 3, OpenTimeout: testtime.D30s, HalfOpenProbes: 2}
 	require.NoError(t, s.Validate())
 }
 
@@ -102,7 +103,7 @@ func TestCircuitBreakerSettings_Validate_AboveUpperBound(t *testing.T) {
 		},
 		{
 			"OpenTimeout above max",
-			CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: 2 * time.Hour, HalfOpenProbes: 1},
+			CircuitBreakerSettings{TripThreshold: 1, OpenTimeout: testtime.D2h, HalfOpenProbes: 1},
 			"OpenTimeout",
 		},
 		{
@@ -168,7 +169,7 @@ func TestWithCircuitBreakerSettings_CustomTripThreshold(t *testing.T) {
 
 	customSettings := CircuitBreakerSettings{
 		TripThreshold:  2,
-		OpenTimeout:    30 * time.Second,
+		OpenTimeout:    testtime.D30s,
 		HalfOpenProbes: 1,
 	}
 	d, err := NewDispatcher(
@@ -203,7 +204,7 @@ func TestWithCircuitBreakerSettings_CustomOpenTimeout(t *testing.T) {
 
 	customSettings := CircuitBreakerSettings{
 		TripThreshold:  2,
-		OpenTimeout:    10 * time.Second,
+		OpenTimeout:    testtime.D10s,
 		HalfOpenProbes: 1,
 	}
 	fc := clockmock.New(time.Unix(dispatchTestTS, 0))
@@ -219,7 +220,7 @@ func TestWithCircuitBreakerSettings_CustomOpenTimeout(t *testing.T) {
 	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{}`))))
 
 	// Advancing less than OpenTimeout → still open.
-	fc.Advance(5 * time.Second)
+	fc.Advance(testtime.D5s)
 	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{}`))))
 
 	// Advancing past OpenTimeout → half-open; probe is admitted, reaches server.

--- a/framework/kernel/webhook/dispatcher.go
+++ b/framework/kernel/webhook/dispatcher.go
@@ -52,6 +52,11 @@ type Dispatcher struct {
 	// (buildConsumer constructs one per webhook-dispatch contract).
 	recorder Metrics
 	source   string
+	// cbSettings holds the circuit-breaker thresholds supplied via
+	// WithCircuitBreakerSettings. cbSettingsSet distinguishes "option provided
+	// with specific values" from "option not provided → use defaults".
+	cbSettings    CircuitBreakerSettings
+	cbSettingsSet bool
 }
 
 // DispatcherOption customizes a Dispatcher at construction time.
@@ -74,6 +79,23 @@ func WithMetrics(rec Metrics, source string) DispatcherOption {
 	return func(dp *Dispatcher) {
 		dp.recorder = rec
 		dp.source = source
+	}
+}
+
+// WithCircuitBreakerSettings overrides the per-endpoint circuit-breaker
+// thresholds for this dispatcher. All three fields (TripThreshold, OpenTimeout,
+// HalfOpenProbes) must be positive; a zero or negative value causes
+// [NewDispatcher] to return an error (fail-fast — no silent noop, per
+// runtime-api.md §Option 范式). Omitting this option uses the defaults that
+// match the original hardcoded values (TripThreshold=5, OpenTimeout=60s,
+// HalfOpenProbes=1).
+//
+// There is intentionally no Enabled/Disabled field: disabling the circuit
+// breaker is not a supported configuration (no-disable invariant).
+func WithCircuitBreakerSettings(s CircuitBreakerSettings) DispatcherOption {
+	return func(dp *Dispatcher) {
+		dp.cbSettings = s
+		dp.cbSettingsSet = true
 	}
 }
 
@@ -109,11 +131,20 @@ func NewDispatcher(
 		policy:   policy,
 		selector: selector,
 		timeout:  defaultDeliveryTimeout,
-		circuit:  newCircuitGate(clk),
 	}
 	for _, o := range opts {
 		o(d)
 	}
+	// Resolve circuit-breaker settings AFTER options: if WithCircuitBreakerSettings
+	// was provided, validate and use it; otherwise fall back to defaults.
+	cbSettings := defaultCircuitBreakerSettings()
+	if d.cbSettingsSet {
+		if err := d.cbSettings.Validate(); err != nil {
+			return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid, err.Error())
+		}
+		cbSettings = d.cbSettings
+	}
+	d.circuit = newCircuitGate(clk, cbSettings)
 	// Build the client AFTER options so WithDeliveryTimeout is honored. The
 	// transport's DialContext and the CheckRedirect both come from the SSRF
 	// policy; there is intentionally no way to inject a foreign client.

--- a/framework/kernel/webhook/dispatcher.go
+++ b/framework/kernel/webhook/dispatcher.go
@@ -137,10 +137,10 @@ func NewDispatcher(
 	}
 	// Resolve circuit-breaker settings AFTER options: if WithCircuitBreakerSettings
 	// was provided, validate and use it; otherwise fall back to defaults.
-	cbSettings := defaultCircuitBreakerSettings()
+	cbSettings := DefaultCircuitBreakerSettings()
 	if d.cbSettingsSet {
 		if err := d.cbSettings.Validate(); err != nil {
-			return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid, err.Error())
+			return nil, err
 		}
 		cbSettings = d.cbSettings
 	}

--- a/framework/kernel/webhook/dispatcher_circuit_test.go
+++ b/framework/kernel/webhook/dispatcher_circuit_test.go
@@ -23,7 +23,7 @@ import (
 
 // defaultCB is a test-local shorthand for the default circuit breaker settings,
 // replacing the former package-level const references deleted in #2106.
-var defaultCB = defaultCircuitBreakerSettings()
+var defaultCB = DefaultCircuitBreakerSettings()
 
 // tenantEntry builds an outbox entry whose principal carries tenantID, so the
 // dispatcher's circuit key includes the tenant dimension.
@@ -303,7 +303,7 @@ func TestDispatcher_Handle_Circuit429Trips(t *testing.T) {
 // breaker construction never fails on an empty Name. allowed=true and the done
 // callback does not panic.
 func TestCircuitGate_EmptyKeyStillBreaks(t *testing.T) {
-	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), defaultCircuitBreakerSettings())
+	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), DefaultCircuitBreakerSettings())
 	allow, done := g.Allow(newCircuitEndpointKey("", ""))
 	assert.True(t, allow, "fresh breaker starts closed (allow=true)")
 	require.NotNil(t, done, "a working breaker returns a non-nil done callback")
@@ -363,7 +363,7 @@ func TestDispatcher_Handle_CircuitTransportFaultTrips(t *testing.T) {
 // bounded (DoS guard) — registering far more than the cap never grows the map
 // past circuitGateMaxEndpoints.
 func TestCircuitGate_BoundedEviction(t *testing.T) {
-	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), defaultCircuitBreakerSettings())
+	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), DefaultCircuitBreakerSettings())
 	for i := range circuitGateMaxEndpoints + 100 {
 		allow, done := g.Allow(newCircuitEndpointKey("", fmt.Sprintf("http://e%d.example.test/", i)))
 		require.True(t, allow, "fresh endpoint breaker starts closed")

--- a/framework/kernel/webhook/dispatcher_circuit_test.go
+++ b/framework/kernel/webhook/dispatcher_circuit_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 )
 
+// defaultCB is a test-local shorthand for the default circuit breaker settings,
+// replacing the former package-level const references deleted in #2106.
+var defaultCB = defaultCircuitBreakerSettings()
+
 // tenantEntry builds an outbox entry whose principal carries tenantID, so the
 // dispatcher's circuit key includes the tenant dimension.
 func tenantEntry(t *testing.T, tenantID string, payload []byte) outbox.Entry {
@@ -43,7 +47,7 @@ func TestDispatcher_Handle_CircuitPerTenantIsolation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trip tenant A's breaker for the shared URL.
-	for range circuitTripThreshold + 1 {
+	for range defaultCB.TripThreshold + 1 {
 		d.Handle(context.Background(), tenantEntry(t, "tenanta", []byte(`{}`)))
 	}
 	requireCircuitOpen(t, d.Handle(context.Background(), tenantEntry(t, "tenanta", []byte(`{}`))))
@@ -112,8 +116,8 @@ func TestDispatcher_Handle_CircuitOpensAndFastFails(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trip: every 5xx counts as an endpoint-health failure. After
-	// circuitTripThreshold+1 consecutive failures the breaker opens.
-	tripCount := circuitTripThreshold + 1
+	// TripThreshold+1 consecutive failures the breaker opens.
+	tripCount := defaultCB.TripThreshold + 1
 	deliverN(t, d, tripCount)
 	require.Equal(t, tripCount, int(hits.Load()), "all trip deliveries reach the endpoint while closed")
 
@@ -152,13 +156,13 @@ func TestDispatcher_Handle_CircuitHalfOpenRecoversOnSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trip the circuit.
-	deliverN(t, d, circuitTripThreshold+1)
+	deliverN(t, d, defaultCB.TripThreshold+1)
 	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`))))
 	hitsAfterTrip := hits.Load()
 
 	// Endpoint recovers; advance past the open timeout → half-open probe admitted.
 	status.Store(http.StatusOK)
-	fc.Advance(circuitOpenTimeout + time.Second)
+	fc.Advance(defaultCB.OpenTimeout + time.Second)
 
 	probe := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
 	assert.Equal(t, outbox.DispositionAck, probe.Disposition, "successful half-open probe acks")
@@ -180,11 +184,11 @@ func TestDispatcher_Handle_CircuitHalfOpenReopensOnFailure(t *testing.T) {
 		NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
 	require.NoError(t, err)
 
-	deliverN(t, d, circuitTripThreshold+1)
+	deliverN(t, d, defaultCB.TripThreshold+1)
 	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`))))
 
 	// Advance to half-open; probe still fails (server stays 5xx) → reopen.
-	fc.Advance(circuitOpenTimeout + time.Second)
+	fc.Advance(defaultCB.OpenTimeout + time.Second)
 	probe := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
 	assert.Equal(t, outbox.DispositionRequeue, probe.Disposition, "failed probe still Requeues the delivery")
 	hitsAfterProbe := hits.Load()
@@ -258,7 +262,7 @@ func TestDispatcher_Handle_CircuitPerEndpointIsolation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trip endpoint A.
-	for range circuitTripThreshold + 1 {
+	for range defaultCB.TripThreshold + 1 {
 		d.Handle(context.Background(), newTestEntry(t, []byte("a")))
 	}
 	requireCircuitOpen(t, d.Handle(context.Background(), newTestEntry(t, []byte("a"))))
@@ -280,9 +284,8 @@ func TestDispatcher_Handle_Circuit429Trips(t *testing.T) {
 		dispatchTestSigner(t), NewSafePolicy(WithAllowLoopback()), staticSelector(srv.URL))
 	require.NoError(t, err)
 
-	// Trip: 429 counts as an endpoint-health failure. Use a named const rather
-	// than deliverN to avoid an unparam lint hit on deliverN's n parameter.
-	const tripCount = circuitTripThreshold + 1
+	// Trip: 429 counts as an endpoint-health failure.
+	tripCount := defaultCB.TripThreshold + 1
 	for range tripCount {
 		d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
 	}
@@ -300,7 +303,7 @@ func TestDispatcher_Handle_Circuit429Trips(t *testing.T) {
 // breaker construction never fails on an empty Name. allowed=true and the done
 // callback does not panic.
 func TestCircuitGate_EmptyKeyStillBreaks(t *testing.T) {
-	g := newCircuitGate(clockmock.New(time.Unix(0, 0)))
+	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), defaultCircuitBreakerSettings())
 	allow, done := g.Allow(newCircuitEndpointKey("", ""))
 	assert.True(t, allow, "fresh breaker starts closed (allow=true)")
 	require.NotNil(t, done, "a working breaker returns a non-nil done callback")
@@ -344,7 +347,7 @@ func TestDispatcher_Handle_CircuitTransportFaultTrips(t *testing.T) {
 	require.NoError(t, err)
 
 	// Each delivery fails with a transport fault (connection refused) → Requeue.
-	tripCount := circuitTripThreshold + 1
+	tripCount := defaultCB.TripThreshold + 1
 	for range tripCount {
 		res := d.Handle(context.Background(), newTestEntry(t, []byte(`{"k":"v"}`)))
 		assert.Equal(t, outbox.DispositionRequeue, res.Disposition,
@@ -360,7 +363,7 @@ func TestDispatcher_Handle_CircuitTransportFaultTrips(t *testing.T) {
 // bounded (DoS guard) — registering far more than the cap never grows the map
 // past circuitGateMaxEndpoints.
 func TestCircuitGate_BoundedEviction(t *testing.T) {
-	g := newCircuitGate(clockmock.New(time.Unix(0, 0)))
+	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), defaultCircuitBreakerSettings())
 	for i := range circuitGateMaxEndpoints + 100 {
 		allow, done := g.Allow(newCircuitEndpointKey("", fmt.Sprintf("http://e%d.example.test/", i)))
 		require.True(t, allow, "fresh endpoint breaker starts closed")

--- a/framework/runtime/bootstrap/bootstrap.go
+++ b/framework/runtime/bootstrap/bootstrap.go
@@ -222,8 +222,9 @@ type Bootstrap struct {
 
 	// webhookCBSettings holds the per-deployment circuit-breaker thresholds
 	// injected via WithWebhookCircuitBreaker. webhookCBSettingsSet distinguishes
-	// "option provided" from "not provided → use defaults". Validated at
-	// option-apply time so a bad value fails at bootstrap rather than first delivery.
+	// "option provided" from "not provided → use defaults". Validated during
+	// phase6 (drainWebhookDispatchers) at startup so a bad value fails at
+	// bootstrap rather than first delivery.
 	webhookCBSettings    kwh.CircuitBreakerSettings
 	webhookCBSettingsSet bool
 

--- a/framework/runtime/bootstrap/bootstrap.go
+++ b/framework/runtime/bootstrap/bootstrap.go
@@ -220,6 +220,13 @@ type Bootstrap struct {
 	// dispatcher. The dispatcher reuses webhookSourceStore for signing secrets.
 	webhookSSRFPolicy *kwh.SafePolicy
 
+	// webhookCBSettings holds the per-deployment circuit-breaker thresholds
+	// injected via WithWebhookCircuitBreaker. webhookCBSettingsSet distinguishes
+	// "option provided" from "not provided → use defaults". Validated at
+	// option-apply time so a bad value fails at bootstrap rather than first delivery.
+	webhookCBSettings    kwh.CircuitBreakerSettings
+	webhookCBSettingsSet bool
+
 	// webhookMetrics is the single shared kwh.Metrics collector registered once
 	// (cached here) so the receiver (phase5) and dispatcher (phase6) record to
 	// the same fixed-name instruments instead of re-registering the metric

--- a/framework/runtime/bootstrap/options_webhook.go
+++ b/framework/runtime/bootstrap/options_webhook.go
@@ -25,6 +25,8 @@ package bootstrap
 import (
 	"github.com/ghbvf/gocell/framework/kernel/idempotency"
 	kwh "github.com/ghbvf/gocell/framework/kernel/webhook"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/panicregister"
 	"github.com/ghbvf/gocell/framework/pkg/validation"
 )
 
@@ -81,5 +83,36 @@ func WithWebhookSSRFPolicy(policy *kwh.SafePolicy) Option {
 			return
 		}
 		b.webhookSSRFPolicy = policy
+	}
+}
+
+// WithWebhookCircuitBreaker overrides the per-endpoint circuit-breaker
+// thresholds applied to every outbound webhook dispatcher in this deployment.
+// All three fields (TripThreshold, OpenTimeout, HalfOpenProbes) must be
+// positive; a zero or negative value is rejected immediately at option-apply
+// time (fail-fast — per runtime-api.md §Option 范式: "强依赖 option 必须
+// fail-fast，不静默 noop"). Omitting this option uses the defaults that match
+// the original hardcoded values (TripThreshold=5, OpenTimeout=60s,
+// HalfOpenProbes=1).
+//
+// There is intentionally no Enabled/Disabled variant: disabling the circuit
+// breaker is not a supported configuration (no-disable invariant).
+//
+// Bootstrap panics at option-apply time on invalid settings so misconfiguration
+// is visible on startup rather than silently degrading to defaults or first
+// delivery. The panic uses [panicregister.Approved] as required by the
+// PANIC-REGISTERED-01 governance rule.
+func WithWebhookCircuitBreaker(settings kwh.CircuitBreakerSettings) Option {
+	return func(b *Bootstrap) {
+		if err := settings.Validate(); err != nil {
+			// Fail-fast at option-apply time: invalid CB settings are a
+			// programmer error (B-class assertion), not a runtime degradation
+			// path. Panics through the panic-taxonomy funnel so PANIC-REGISTERED-01
+			// archtest does not flag this as an unapproved panic site.
+			panic(panicregister.Approved("bootstrap-webhook-cb-invalid-settings",
+				errcode.Assertion("bootstrap: WithWebhookCircuitBreaker: %s", err.Error())))
+		}
+		b.webhookCBSettings = settings
+		b.webhookCBSettingsSet = true
 	}
 }

--- a/framework/runtime/bootstrap/options_webhook.go
+++ b/framework/runtime/bootstrap/options_webhook.go
@@ -25,8 +25,6 @@ package bootstrap
 import (
 	"github.com/ghbvf/gocell/framework/kernel/idempotency"
 	kwh "github.com/ghbvf/gocell/framework/kernel/webhook"
-	"github.com/ghbvf/gocell/framework/pkg/errcode"
-	"github.com/ghbvf/gocell/framework/pkg/panicregister"
 	"github.com/ghbvf/gocell/framework/pkg/validation"
 )
 
@@ -88,30 +86,26 @@ func WithWebhookSSRFPolicy(policy *kwh.SafePolicy) Option {
 
 // WithWebhookCircuitBreaker overrides the per-endpoint circuit-breaker
 // thresholds applied to every outbound webhook dispatcher in this deployment.
-// All three fields (TripThreshold, OpenTimeout, HalfOpenProbes) must be
-// positive; a zero or negative value is rejected immediately at option-apply
-// time (fail-fast — per runtime-api.md §Option 范式: "强依赖 option 必须
-// fail-fast，不静默 noop"). Omitting this option uses the defaults that match
-// the original hardcoded values (TripThreshold=5, OpenTimeout=60s,
-// HalfOpenProbes=1).
+// All three fields (TripThreshold, OpenTimeout, HalfOpenProbes) must be in
+// range; invalid settings are rejected at phase6 [drainWebhookDispatchers]
+// via [kwh.CircuitBreakerSettings.Validate], which causes bootstrap to fail
+// fast at startup before any delivery is attempted.
+//
+// Omitting this option uses the defaults that match the original hardcoded
+// values (TripThreshold=5, OpenTimeout=60s, HalfOpenProbes=1).
 //
 // There is intentionally no Enabled/Disabled variant: disabling the circuit
 // breaker is not a supported configuration (no-disable invariant).
 //
-// Bootstrap panics at option-apply time on invalid settings so misconfiguration
-// is visible on startup rather than silently degrading to defaults or first
-// delivery. The panic uses [panicregister.Approved] as required by the
-// PANIC-REGISTERED-01 governance rule.
+// Design note — fail-fast timing: validation happens at phase6
+// (drainWebhookDispatchers) rather than at option-apply time, consistent with
+// the cumulative-builder convention used by other webhook options in this file.
+// A deployment with zero dispatchers needs no circuit-breaker settings; the
+// dependency only becomes mandatory when a cell has actually declared a
+// dispatcher — exactly when phase6 can see both the snapshot and the wired
+// options.
 func WithWebhookCircuitBreaker(settings kwh.CircuitBreakerSettings) Option {
 	return func(b *Bootstrap) {
-		if err := settings.Validate(); err != nil {
-			// Fail-fast at option-apply time: invalid CB settings are a
-			// programmer error (B-class assertion), not a runtime degradation
-			// path. Panics through the panic-taxonomy funnel so PANIC-REGISTERED-01
-			// archtest does not flag this as an unapproved panic site.
-			panic(panicregister.Approved("bootstrap-webhook-cb-invalid-settings",
-				errcode.Assertion("bootstrap: WithWebhookCircuitBreaker: %s", err.Error())))
-		}
 		b.webhookCBSettings = settings
 		b.webhookCBSettingsSet = true
 	}

--- a/framework/runtime/bootstrap/phases_dispatch_test.go
+++ b/framework/runtime/bootstrap/phases_dispatch_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	kwh "github.com/ghbvf/gocell/framework/kernel/webhook"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/eventbus"
 	"github.com/ghbvf/gocell/framework/runtime/eventrouter"
 )
@@ -273,7 +274,7 @@ func TestDrainWebhookDispatchers_HappyPath_RegistersHandler(t *testing.T) {
 // phase6 drainWebhookDispatchers.
 func TestWithWebhookCircuitBreaker_StoresSettingsWithoutValidation(t *testing.T) {
 	t.Parallel()
-	custom := kwh.CircuitBreakerSettings{TripThreshold: 10, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
+	custom := kwh.CircuitBreakerSettings{TripThreshold: 10, OpenTimeout: testtime.D30s, HalfOpenProbes: 2}
 
 	// Apply option — must NOT panic even though we haven't called phase6 yet.
 	b := New(clockmock.New(whFixedNow), WithWebhookCircuitBreaker(custom))
@@ -290,7 +291,7 @@ func TestDrainWebhookDispatchers_CustomCBSettings_Propagated(t *testing.T) {
 	dc := newWebhookDispatchCell()
 	s := buildPhaseStateWithWebhookCells(t, dc)
 
-	custom := kwh.CircuitBreakerSettings{TripThreshold: 10, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
+	custom := kwh.CircuitBreakerSettings{TripThreshold: 10, OpenTimeout: testtime.D30s, HalfOpenProbes: 2}
 	clk := clockmock.New(whFixedNow)
 	b := New(clk,
 		WithConsumerBase(newTestConsumerBase(t)),

--- a/framework/runtime/bootstrap/phases_dispatch_test.go
+++ b/framework/runtime/bootstrap/phases_dispatch_test.go
@@ -20,6 +20,7 @@ package bootstrap
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,6 +264,72 @@ func TestDrainWebhookDispatchers_HappyPath_RegistersHandler(t *testing.T) {
 	require.NoError(t, err, "happy path must not error")
 	assert.Equal(t, 1, evtRouter.HandlerCount(),
 		"one dispatcher must register exactly one handler on the event router")
+}
+
+// TestWithWebhookCircuitBreaker_StoresSettingsWithoutValidation verifies that
+// WithWebhookCircuitBreaker stores the settings on the Bootstrap struct without
+// performing validation at option-apply time (cumulative-builder semantics, consistent
+// with other webhook options in options_webhook.go). Validation happens later at
+// phase6 drainWebhookDispatchers.
+func TestWithWebhookCircuitBreaker_StoresSettingsWithoutValidation(t *testing.T) {
+	t.Parallel()
+	custom := kwh.CircuitBreakerSettings{TripThreshold: 10, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
+
+	// Apply option — must NOT panic even though we haven't called phase6 yet.
+	b := New(clockmock.New(whFixedNow), WithWebhookCircuitBreaker(custom))
+
+	assert.True(t, b.webhookCBSettingsSet, "WithWebhookCircuitBreaker must set webhookCBSettingsSet")
+	assert.Equal(t, custom, b.webhookCBSettings, "WithWebhookCircuitBreaker must store the settings")
+}
+
+// TestDrainWebhookDispatchers_CustomCBSettings_Propagated verifies that custom
+// circuit-breaker settings provided via WithWebhookCircuitBreaker reach
+// drainWebhookDispatchers and are used by BuildConsumers without error.
+func TestDrainWebhookDispatchers_CustomCBSettings_Propagated(t *testing.T) {
+	t.Parallel()
+	dc := newWebhookDispatchCell()
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	custom := kwh.CircuitBreakerSettings{TripThreshold: 10, OpenTimeout: 30 * time.Second, HalfOpenProbes: 2}
+	clk := clockmock.New(whFixedNow)
+	b := New(clk,
+		WithConsumerBase(newTestConsumerBase(t)),
+		WithWebhookCircuitBreaker(custom),
+	)
+	b.webhookSourceStore = whTestStore(t)
+
+	evtRouter := newDispatchEvtRouter(t, b)
+	err := b.drainWebhookDispatchers(s, evtRouter)
+
+	require.NoError(t, err, "custom CB settings within valid range must not error")
+	assert.Equal(t, 1, evtRouter.HandlerCount(), "dispatcher must still be registered with custom CB settings")
+}
+
+// TestDrainWebhookDispatchers_InvalidCBSettings_FailsFast verifies that invalid
+// circuit-breaker settings (non-positive TripThreshold) cause drainWebhookDispatchers
+// to return a non-nil error at startup (phase-level fail-fast, not a panic).
+func TestDrainWebhookDispatchers_InvalidCBSettings_FailsFast(t *testing.T) {
+	t.Parallel()
+	dc := newWebhookDispatchCell()
+	s := buildPhaseStateWithWebhookCells(t, dc)
+
+	invalid := kwh.CircuitBreakerSettings{TripThreshold: 0, OpenTimeout: time.Second, HalfOpenProbes: 1}
+	clk := clockmock.New(whFixedNow)
+	b := New(clk,
+		WithConsumerBase(newTestConsumerBase(t)),
+		WithWebhookCircuitBreaker(invalid),
+	)
+	b.webhookSourceStore = whTestStore(t)
+
+	evtRouter := newDispatchEvtRouter(t, b)
+
+	// Must NOT panic; must return an error.
+	require.NotPanics(t, func() {
+		err := b.drainWebhookDispatchers(s, evtRouter)
+		require.Error(t, err, "invalid CB settings must cause drainWebhookDispatchers to fail fast")
+		assert.Contains(t, err.Error(), "TripThreshold",
+			"error must identify the invalid field")
+	}, "invalid CB settings must not panic — only return an error")
 }
 
 // TestDrainWebhookDispatchers_HappyPath_LocksSvixSchedule verifies the full

--- a/framework/runtime/bootstrap/phases_events.go
+++ b/framework/runtime/bootstrap/phases_events.go
@@ -185,7 +185,11 @@ func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventroute
 	if err != nil {
 		return err
 	}
-	consumers, err := webhookdispatch.BuildConsumers(b.clock, reqs, b.webhookSourceStore, policy, rec)
+	cbSettings := b.webhookCBSettings
+	if !b.webhookCBSettingsSet {
+		cbSettings = kwh.DefaultCircuitBreakerSettings()
+	}
+	consumers, err := webhookdispatch.BuildConsumers(b.clock, reqs, b.webhookSourceStore, policy, rec, cbSettings)
 	if err != nil {
 		return fmt.Errorf("bootstrap: build webhook dispatch consumers: %w", err)
 	}

--- a/framework/runtime/bootstrap/phases_events.go
+++ b/framework/runtime/bootstrap/phases_events.go
@@ -189,6 +189,14 @@ func (b *Bootstrap) drainWebhookDispatchers(s *phaseState, evtRouter *eventroute
 	if !b.webhookCBSettingsSet {
 		cbSettings = kwh.DefaultCircuitBreakerSettings()
 	}
+	if err := cbSettings.Validate(); err != nil {
+		return fmt.Errorf("bootstrap: webhook circuit breaker settings invalid: %w", err)
+	}
+	slog.Info("bootstrap: webhook circuit breaker settings",
+		slog.Int("trip_threshold", cbSettings.TripThreshold),
+		slog.Duration("open_timeout", cbSettings.OpenTimeout),
+		slog.Int("half_open_probes", cbSettings.HalfOpenProbes),
+		slog.Bool("custom", b.webhookCBSettingsSet))
 	consumers, err := webhookdispatch.BuildConsumers(b.clock, reqs, b.webhookSourceStore, policy, rec, cbSettings)
 	if err != nil {
 		return fmt.Errorf("bootstrap: build webhook dispatch consumers: %w", err)

--- a/framework/runtime/webhook/dispatch/dispatch.go
+++ b/framework/runtime/webhook/dispatch/dispatch.go
@@ -103,6 +103,10 @@ func (c Consumer) Validate() error {
 // Construction is eager so a missing source or bad config fails at startup
 // rather than at first delivery.
 //
+// cbSettings controls the per-endpoint circuit-breaker thresholds for every
+// dispatcher built by this call. The zero value is invalid; pass
+// [kwh.DefaultCircuitBreakerSettings] when no override is configured.
+//
 // DLX: the composition root must configure the broker subscriber's DLX exchange
 // for dispatch subscription topics; permanently-failed deliveries (Reject) are
 // Nack(requeue=false)→DLX and are otherwise silently discarded.
@@ -115,6 +119,7 @@ func BuildConsumers(
 	store kwh.SourceStore,
 	policy *kwh.SafePolicy,
 	rec kwh.Metrics,
+	cbSettings kwh.CircuitBreakerSettings,
 ) ([]Consumer, error) {
 	clock.MustHaveClock(clk, "webhook/dispatch.BuildConsumers")
 	if validation.IsNilInterface(store) {
@@ -125,9 +130,15 @@ func BuildConsumers(
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
 			"webhook dispatch: SSRF policy must not be nil")
 	}
+	// Validate settings here so a bad value from the caller fails eagerly at
+	// BuildConsumers time (startup) rather than per-dispatcher construction.
+	if err := cbSettings.Validate(); err != nil {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
+			"webhook dispatch: "+err.Error())
+	}
 	out := make([]Consumer, 0, len(reqs))
 	for _, req := range reqs {
-		c, err := buildConsumer(clk, req, store, policy, rec)
+		c, err := buildConsumer(clk, req, store, policy, rec, cbSettings)
 		if err != nil {
 			return nil, fmt.Errorf("webhook dispatch: contract %q: %w", req.Spec.ContractID, err)
 		}
@@ -148,6 +159,7 @@ func buildConsumer(
 	store kwh.SourceStore,
 	policy *kwh.SafePolicy,
 	rec kwh.Metrics,
+	cbSettings kwh.CircuitBreakerSettings,
 ) (Consumer, error) {
 	spec := req.Spec
 	if err := spec.Validate(); err != nil {
@@ -173,7 +185,8 @@ func buildConsumer(
 		return Consumer{}, err
 	}
 	dispatcher, err := kwh.NewDispatcher(clk, signer, policy, req.Selector,
-		kwh.WithMetrics(rec, spec.SourceID))
+		kwh.WithMetrics(rec, spec.SourceID),
+		kwh.WithCircuitBreakerSettings(cbSettings))
 	if err != nil {
 		return Consumer{}, err
 	}

--- a/framework/runtime/webhook/dispatch/dispatch.go
+++ b/framework/runtime/webhook/dispatch/dispatch.go
@@ -132,9 +132,11 @@ func BuildConsumers(
 	}
 	// Validate settings here so a bad value from the caller fails eagerly at
 	// BuildConsumers time (startup) rather than per-dispatcher construction.
+	// cbSettings.Validate() already returns a well-formed errcode (KindInvalid +
+	// ErrWebhookConfigInvalid + typed WithDetails), so propagate it directly
+	// rather than re-minting a new errcode with a dynamic message string.
 	if err := cbSettings.Validate(); err != nil {
-		return nil, errcode.New(errcode.KindInvalid, errcode.ErrWebhookConfigInvalid,
-			"webhook dispatch: "+err.Error())
+		return nil, err
 	}
 	out := make([]Consumer, 0, len(reqs))
 	for _, req := range reqs {

--- a/framework/runtime/webhook/dispatch/dispatch_test.go
+++ b/framework/runtime/webhook/dispatch/dispatch_test.go
@@ -127,6 +127,21 @@ func TestBuildConsumers_InvalidSpec(t *testing.T) {
 	requireWebhookConfigErr(t, err)
 }
 
+// TestBuildConsumers_InvalidCBSettings verifies that an invalid
+// CircuitBreakerSettings fails eagerly at BuildConsumers time and that the
+// returned error is the well-formed errcode produced by
+// CircuitBreakerSettings.Validate() — i.e. BuildConsumers does NOT re-mint a
+// new errcode with a dynamic message string (MESSAGE-CONST-LITERAL-01).
+func TestBuildConsumers_InvalidCBSettings(t *testing.T) {
+	t.Parallel()
+	store := testStore(t, "s")
+	// TripThreshold == 0 is explicitly rejected by Validate().
+	bad := kwh.CircuitBreakerSettings{TripThreshold: 0}
+	_, err := BuildConsumers(
+		testClock(), nil, store, kwh.NewSafePolicy(), kwh.Metrics{}, bad)
+	requireWebhookConfigErr(t, err)
+}
+
 func requireWebhookConfigErr(t *testing.T, err error) {
 	t.Helper()
 	require.Error(t, err)

--- a/framework/runtime/webhook/dispatch/dispatch_test.go
+++ b/framework/runtime/webhook/dispatch/dispatch_test.go
@@ -52,7 +52,7 @@ func TestBuildConsumers_HappyPath(t *testing.T) {
 	reqs := []cell.WebhookDispatchRequest{
 		dispatchReq("webhook.shopify.orders.v1", "shopify", "ordercore"),
 	}
-	consumers, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy(), kwh.Metrics{})
+	consumers, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy(), kwh.Metrics{}, kwh.DefaultCircuitBreakerSettings())
 	require.NoError(t, err)
 	require.Len(t, consumers, 1)
 
@@ -75,20 +75,22 @@ func TestBuildConsumers_HappyPath(t *testing.T) {
 
 func TestBuildConsumers_Empty(t *testing.T) {
 	t.Parallel()
-	consumers, err := BuildConsumers(testClock(), nil, testStore(t, "s"), kwh.NewSafePolicy(), kwh.Metrics{})
+	consumers, err := BuildConsumers(
+		testClock(), nil, testStore(t, "s"), kwh.NewSafePolicy(), kwh.Metrics{},
+		kwh.DefaultCircuitBreakerSettings())
 	require.NoError(t, err)
 	assert.Empty(t, consumers)
 }
 
 func TestBuildConsumers_NilStore(t *testing.T) {
 	t.Parallel()
-	_, err := BuildConsumers(testClock(), nil, nil, kwh.NewSafePolicy(), kwh.Metrics{})
+	_, err := BuildConsumers(testClock(), nil, nil, kwh.NewSafePolicy(), kwh.Metrics{}, kwh.DefaultCircuitBreakerSettings())
 	requireWebhookConfigErr(t, err)
 }
 
 func TestBuildConsumers_NilPolicy(t *testing.T) {
 	t.Parallel()
-	_, err := BuildConsumers(testClock(), nil, testStore(t, "s"), nil, kwh.Metrics{})
+	_, err := BuildConsumers(testClock(), nil, testStore(t, "s"), nil, kwh.Metrics{}, kwh.DefaultCircuitBreakerSettings())
 	requireWebhookConfigErr(t, err)
 }
 
@@ -96,7 +98,9 @@ func TestBuildConsumers_UnregisteredSource(t *testing.T) {
 	t.Parallel()
 	store := testStore(t, "shopify")
 	reqs := []cell.WebhookDispatchRequest{dispatchReq("webhook.x.v1", "stripe", "c")} // "stripe" not registered
-	_, err := BuildConsumers(testClock(), reqs, store, kwh.NewSafePolicy(), kwh.Metrics{})
+	_, err := BuildConsumers(
+		testClock(), reqs, store, kwh.NewSafePolicy(), kwh.Metrics{},
+		kwh.DefaultCircuitBreakerSettings())
 	requireWebhookConfigErr(t, err)
 }
 
@@ -107,7 +111,9 @@ func TestBuildConsumers_NilSelector(t *testing.T) {
 		Spec:     kwh.DispatchSpec{ContractID: "webhook.x.v1", SourceID: "shopify", CellID: "c"},
 		Selector: nil,
 	}
-	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy(), kwh.Metrics{})
+	_, err := BuildConsumers(
+		testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy(), kwh.Metrics{},
+		kwh.DefaultCircuitBreakerSettings())
 	requireWebhookConfigErr(t, err)
 }
 
@@ -115,7 +121,9 @@ func TestBuildConsumers_InvalidSpec(t *testing.T) {
 	t.Parallel()
 	store := testStore(t, "shopify")
 	req := dispatchReq("", "shopify", "c") // empty ContractID → spec invalid
-	_, err := BuildConsumers(testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy(), kwh.Metrics{})
+	_, err := BuildConsumers(
+		testClock(), []cell.WebhookDispatchRequest{req}, store, kwh.NewSafePolicy(), kwh.Metrics{},
+		kwh.DefaultCircuitBreakerSettings())
 	requireWebhookConfigErr(t, err)
 }
 

--- a/tools/archtest/webhook_cb_no_disable_test.go
+++ b/tools/archtest/webhook_cb_no_disable_test.go
@@ -1,0 +1,187 @@
+//go:build archtest
+
+// INVARIANT: WEBHOOK-CB-NO-DISABLE-01
+//
+// WEBHOOK-CB-NO-DISABLE-01 — CircuitBreakerSettings exported field set freeze.
+//
+// # What this guards
+//
+// kernel/webhook.CircuitBreakerSettings deliberately has no Enabled/Disabled
+// field: "disabling the circuit breaker" must be inexpressible at the type
+// level (no-disable invariant, see circuit.go godoc and ADR #2106). This test
+// locks the exported field set to exactly:
+//
+//	{TripThreshold int, OpenTimeout time.Duration, HalfOpenProbes int}
+//
+// Any change that adds an Enabled/Disabled field — or any other exported field
+// that could semantically suppress circuit-breaker protection — causes this
+// test to fail at CI. The frozen set is intentionally EXPORTED-only: unexported
+// fields are internal implementation detail and do not affect the no-disable
+// invariant.
+//
+// # AI-robust rating
+//
+// Hard — reflect field freeze (charter §"Hard 范本目录": "reflect schema freeze:
+// wire/schema struct 字段集、tag、类型身份精确冻结"). The field set, field names,
+// and field types are objective structural facts captured by reflect.Type.
+// Any drift (add Enabled bool / rename / reorder exported fields) produces a
+// tuple mismatch and forces the change through this explicit checkpoint.
+//
+// Upstream Hard (type system): the Go type system prevents any caller from
+// minting a CircuitBreakerSettings with fields that do not exist; adding one
+// forces every existing literal and composite-literal to also add the field,
+// making the change auditable at compile time.
+//
+// Downstream Hard: [CircuitBreakerSettings.Validate] rejects zero/near-disable
+// values for all three tunable fields — a complement to the no-field gate that
+// prevents de-facto disabling via extreme values.
+//
+// # Blind spots (charter §"强制盲区自检")
+//
+//   - Unexported fields: a same-package unexported `enabled bool` field would
+//     not appear in the frozen exported set below. Bounded by code review +
+//     PANIC-REGISTERED-01 / existing archtest coverage of the package. The
+//     circuit gate itself (circuitGate.Allow) is tested to never silently skip
+//     the breaker even when breakerFor returns nil (fail-open with Error log).
+//   - Validate upper-bound bypass: an operator could still call
+//     CircuitBreakerSettings{TripThreshold: cbMaxTripThreshold, ...} for the
+//     maximum allowed value; the freeze does not prevent that. cbMaxTripThreshold
+//     is chosen to allow realistic high thresholds (≤ 1000), so no real-world
+//     tuning need is blocked.
+//   - Anti-vacuity: if the package path changes or the type is renamed, the anti-
+//     vacuity assertion (NumExportedFields > 0 + correct type name + pkg path)
+//     catches the regression and turns GREEN fixture → RED, alerting immediately.
+//
+// ref: tools/archtest/webhook_signer_funnel_test.go (A2 SignedHeaders field freeze
+// — same reflect schema freeze pattern)
+// ref: kernel/webhook/circuit.go (CircuitBreakerSettings godoc + const bounds)
+package archtest
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/webhook"
+)
+
+// frozenCBField describes one expected exported field of CircuitBreakerSettings.
+type frozenCBField struct {
+	name     string
+	typeName string // reflect.Type.String()
+}
+
+// frozenCBExportedFields is the expected exact exported-field tuple for
+// webhook.CircuitBreakerSettings (in Go struct declaration order).
+// Updating this list requires a conscious decision: any addition of an
+// Enabled/Disabled field MUST be discussed and WILL break CI.
+var frozenCBExportedFields = []frozenCBField{
+	{name: "TripThreshold", typeName: "int"},
+	{name: "OpenTimeout", typeName: "time.Duration"},
+	{name: "HalfOpenProbes", typeName: "int"},
+}
+
+// TestWebhookCBNoDisable_ExportedFieldFreeze is the primary guard: it freezes
+// the exported field set of webhook.CircuitBreakerSettings and asserts every
+// field matches the frozen tuple by name, type, and count.
+//
+// Adding an Enabled/Disabled bool or any other exported field → NumExportedFields
+// mismatch → CI red.
+// Renaming a field → name mismatch → CI red.
+// Changing a field type → typeName mismatch → CI red.
+func TestWebhookCBNoDisable_ExportedFieldFreeze(t *testing.T) {
+	t.Parallel()
+
+	st := reflect.TypeOf(webhook.CircuitBreakerSettings{})
+	require.Equal(t, reflect.Struct, st.Kind(),
+		"webhook.CircuitBreakerSettings must be a struct")
+
+	// Collect exported fields only (PkgPath == "" → exported).
+	var exported []reflect.StructField
+	for i := range st.NumField() {
+		sf := st.Field(i)
+		if sf.PkgPath == "" { // exported
+			exported = append(exported, sf)
+		}
+	}
+
+	require.Equal(t, len(frozenCBExportedFields), len(exported),
+		"WEBHOOK-CB-NO-DISABLE-01: CircuitBreakerSettings exported field count = %d, want %d "+
+			"(adding an Enabled/Disabled field re-opens the no-disable invariant; "+
+			"removing one breaks downstream callers; update frozenCBExportedFields + circuit.go together)",
+		len(exported), len(frozenCBExportedFields))
+
+	for i, want := range frozenCBExportedFields {
+		sf := exported[i]
+		assert.Equal(t, want.name, sf.Name,
+			"WEBHOOK-CB-NO-DISABLE-01: exported field[%d] name = %q, want %q", i, sf.Name, want.name)
+		assert.Equal(t, want.typeName, sf.Type.String(),
+			"WEBHOOK-CB-NO-DISABLE-01: exported field %s type = %q, want %q",
+			sf.Name, sf.Type.String(), want.typeName)
+		exported := sf.PkgPath == ""
+		assert.True(t, exported,
+			"WEBHOOK-CB-NO-DISABLE-01: field %s must remain exported (PkgPath must be empty)", sf.Name)
+	}
+}
+
+// TestWebhookCBNoDisable_AntiVacuity guards against the freeze trivially passing
+// on a wrong/empty type load or an unexpected package rename.
+func TestWebhookCBNoDisable_AntiVacuity(t *testing.T) {
+	t.Parallel()
+
+	st := reflect.TypeOf(webhook.CircuitBreakerSettings{})
+	assert.Equal(t, "CircuitBreakerSettings", st.Name(),
+		"anti-vacuity: loaded type name = %q, want CircuitBreakerSettings", st.Name())
+	assert.True(t, strings.HasSuffix(st.PkgPath(), "kernel/webhook"),
+		"anti-vacuity: package path %q must end with kernel/webhook", st.PkgPath())
+
+	// Count exported fields directly (not via the frozen slice) to prove the
+	// reflect call actually found fields.
+	exportedCount := 0
+	for i := range st.NumField() {
+		if st.Field(i).PkgPath == "" {
+			exportedCount++
+		}
+	}
+	assert.Equal(t, len(frozenCBExportedFields), exportedCount,
+		"anti-vacuity: exported field count via reflect (%d) must equal frozen tuple size (%d) — "+
+			"wrong type loaded or freeze slice is stale",
+		exportedCount, len(frozenCBExportedFields))
+	assert.Greater(t, exportedCount, 0,
+		"anti-vacuity: CircuitBreakerSettings has no exported fields — wrong type loaded?")
+}
+
+// TestWebhookCBNoDisable_RedFixture is the reverse self-check: a look-alike
+// struct with an extra Enabled field must be detected by the field-count check,
+// proving the freeze is not vacuous.
+func TestWebhookCBNoDisable_RedFixture(t *testing.T) {
+	t.Parallel()
+
+	// brokenCBSettings mimics CircuitBreakerSettings but adds an Enabled bool —
+	// the exact field addition the no-disable invariant forbids.
+	type brokenCBSettings struct {
+		TripThreshold  int
+		OpenTimeout    time.Duration
+		HalfOpenProbes int
+		Enabled        bool // forbidden addition — should trigger the count mismatch
+	}
+	bt := reflect.TypeOf(brokenCBSettings{})
+
+	// Count exported fields.
+	exportedCount := 0
+	for i := range bt.NumField() {
+		if bt.Field(i).PkgPath == "" {
+			exportedCount++
+		}
+	}
+	assert.Equal(t, 4, exportedCount,
+		"RED fixture self-check: brokenCBSettings must have 4 exported fields (including Enabled)")
+	assert.Greater(t, exportedCount, len(frozenCBExportedFields),
+		"RED fixture self-check: brokenCBSettings field count (%d) must exceed frozen count (%d) — "+
+			"proves the field-count check would catch this addition",
+		exportedCount, len(frozenCBExportedFields))
+}


### PR DESCRIPTION
## Summary

webhook 熔断器阈值可 per-deployment 配置：新增 `bootstrap.WithWebhookCircuitBreaker(settings)`，未设用默认值（trip=5 / open=60s / halfOpen=1）。

## Why / 背景

#1541 给 webhook dispatcher 接了 per-endpoint 三态熔断器，但阈值硬编为 package const，无公开配置面。低流量 webhook 下默认阈值可能不合适（PR #2102 F12）。本 PR 提供 per-deployment 全局调优。

## Refs

Closes #2106

- ref: sony/gobreaker（`Settings` 命名风格对标）

## Risk / 兼容性

无破坏式变更（option 未设 → 默认值 = 原 const，行为等价）。

设计要点（AI-robust）：
- **无双路径**：删除 `circuitTripThreshold`/`circuitOpenTimeout`/`circuitHalfOpenProbes` 三个 const，折进 `CircuitBreakerSettings` 默认值。
- **no-disable 类型级**：`CircuitBreakerSettings` 无 `Enabled`/disable 字段——「关闭熔断」不可表达，option 只能调阈值（禁 noop 资态）。
- **fail-fast**：非正阈值在 `NewDispatcher`（error）/ `WithWebhookCircuitBreaker`（`panicregister.Approved`）/ `BuildConsumers`（边界 error）三层拒绝。
- `circuitGateMaxEndpoints`（DoS 内存上限）保持 unexported，与 CB 阈值正交，不暴露（最小面）。

per-contract 阈值（从 slice.yaml/contract metadata 派生）超出 cx-1 范围 → 另登 backlog（见 §backlog 计划，与 #1542 per-contract Claim TTL 同族）。

## Test plan

- [x] `go build ./...` 本地通过（framework module）
- [x] `go test ./framework/kernel/webhook/... ./framework/runtime/webhook/dispatch/...` 通过（新增 `circuit_settings_test.go`：默认值/非正值 fail-fast 逐字段/自定义阈值全状态机）
- [x] `golangci-lint run ./...` 0 issues（framework module）
