### PR TITLE
refactor(command): producer 侧命令 emit 收口为生成式 typed wrapper（对称 DispatchAsync）[#2059]

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -103,6 +103,17 @@ webhook、grpc serve、event subscribe 遵循同一范式：声明在 metadata�
 命令 dispatch 通过 generated typed API 和 Claimer 两阶段去重。producer 侧 key、
 consumer 侧 claim、composition-root wiring 必须同源；不得新增裸字符串 dispatch。
 
+producer 与 consumer **双侧**都收口到 codegen typed API：cell 经生成式
+`<cmd>.EmitAsync` / `<cmd>.EmitAsyncFromIdempotencyKey`（per-command wrapper，bake
+DispatchID + 锁 payload 为 `*Request`）发命令，**不**直调 runtime `command.EmitAsync`
+（裸 DispatchID）。三层嵌套 funnel：业务 → 生成 wrapper（`COMMAND-ASYNC-EMIT-CALLER-01`
+锁两个 runtime emit 出口的调用方为 generated/runtime） → runtime `command.EmitAsync`
+（`COMMAND-ASYNC-EMIT-FUNNEL-01` 锁裸 `outbox.Emit`/`NewEntry` 命令 topic 构造）→
+`outbox.NewEntry`。consumer 侧对称由 `COMMAND-ASYNC-DISPATCH-CALLER-01` +
+`COMMAND-DISPATCH-REGISTER-CALLER-01` 锁。wrapper 存在性 codegen+golden Hard、caller
+funnel type-aware scan Medium（Go 天花板，#2059）。符号/盲区见对应 archtest godoc 与 ADR
+`202606040550-1044`。
+
 ## Projection
 
 projection consumer 必须 wire `bootstrap.WithConsumerBase`。投影事件载体使用

--- a/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
+++ b/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
@@ -51,6 +51,7 @@ issue 立项门要「上游 Hard + 下游 Hard」。**闭环 funnel 由两条 in
 | `COMMAND-DISPATCH-REGISTER-CALLER-01` | `(*command.Registry).RegisterHandler`/`LookupHandler` 调用方 ⊆ `generated/contracts/command/**` + `runtime/command` 自测 | Medium（Go 无 friend-package：「仅生成码可调」不可编译期表达；archtest caller-allowlist 兜底） | **Hard**（`ResolveMethodCall` 按 pkg path + receiver type 绑定 callee，alias/同名异型不匹配） |
 | `COMMAND-ASYNC-DISPATCH-CALLER-01`（#1667 / #1673 / #1698 3-arg） | `(*outbox.Relay).WithCommandDispatch(reg, dispatch, claimer)`（#1698 起 **3-arg**，claimer 必填位置参）必须是直接 method-call，其 dispatch-map 把生成 `DispatchID` const 映射到**同包**生成 `DispatchAsync`（`generated/contracts/command/**`），异步路径下游半边 | Medium（Go 无 friend-package：「relay 只接生成 DispatchAsync」不可编译期表达；archtest value-allowlist 兜底。forwarded func-var = #1508-family data-flow 残留。与同步 `…REGISTER-CALLER-01` 共用 gh #1575） | **Hard**（go/types 绑 value 的 `*types.Func` + key 的 `DispatchID *types.Const` 身份 = pkg path + name，alias-proof；**form-complete**：扫全部 WithCommandDispatch selector，method-value capture / method-expression 即违例（#1673 F2 闭 call-only 盲区）；key↔value 同源校验（#1673 F1，今日单包 vacuous，第 2 个 codegen command 自动 bites）） |
 | `COMMAND-ASYNC-EMIT-FUNNEL-01`（#1698） | 任何 `command.*`-topic 的 `kout.Emit` / `kout.NewEntry` 必须在 `runtime/command` 包内（即异步命令只能经 sanctioned `command.EmitAsync` 出口构造 + 发射）；producer 侧上游半边 | **Medium**（Go 无 friend-package：「业务只能经 EmitAsync emit 异步命令」不可编译期表达；producer↔relay 经 async outbox store 解耦，「每条异步命令必带身份」无法端到端编译期 Hard——同 ConsumerBase 运行期 key 构造 / #1282·#851·#893 族结构天花板。archtest caller-allowlist 兜底；**won't-do ceiling**，per-command codegen extractor 不抬升该天花板，**不开伪 Hard-升级 issue**） | **Hard**（`EmitAsync` 的 subject/commandID 为 required 位置参 → happy-path「emit 异步命令但无身份槽」编译不可表达） |
+| `COMMAND-ASYNC-EMIT-CALLER-01`（#2059） | runtime 两个异步命令 emit 出口 `command.EmitAsync` / `command.EmitAsyncFromIdempotencyKey`（均带裸 `dispatchID CommandID` 参）的调用方 ⊆ `generated/contracts/command/**`（生成 typed wrapper）+ `runtime/command` 自身；业务 cell 经生成 `<cmd>.EmitAsync` 发命令、不直调裸 DispatchID；producer 侧**第二层**下游半边（对称 consumer `COMMAND-ASYNC-DISPATCH-CALLER-01`） | **Medium**（Go 无 friend-package：「仅生成 wrapper 可调 `command.EmitAsync`」不可编译期表达；archtest caller-allowlist 兜底，同 EMIT-FUNNEL / #851 / #893 / #1282 族永久天花板；**won't-do ceiling，不开伪 Hard-升级 issue**） | **Hard**（生成 `<cmd>.EmitAsync` / `EmitAsyncFromIdempotencyKey` wrapper 由 `command.tmpl` 派生 + golden 字节锁；wrapper bake DispatchID + 锁 payload 为 `*Request` → 裸字符串 dispatch 经生成路径不可表达，对称上游 Hard 半边 `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`） |
 
 **闭环论证**：codegen-Hard 上游（typed funnel 不可手写，D1/D2）+ caller-allowlist-Hard 下游（raw `RegisterHandler` 在生成码外被调即 CI 红，D3）= 业务**既不能手写 typed funnel、也不能在 funnel 外用 raw registry** → 达成立项门「Hard 双向锁」。
 
@@ -90,6 +91,7 @@ amend 时须回到 §4 矩阵逐行重评（ai-robust.md ADR amendment 必查）
 |------|---------|------|
 | archtest | `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01` / `COMMAND-DISPATCH-REGISTER-CALLER-01` / `COMMAND-ASYNC-DISPATCH-CALLER-01`（#1698 3-arg） | `tools/archtest/command_dispatch_funnel_test.go` |
 | archtest | `COMMAND-ASYNC-EMIT-FUNNEL-01`（#1698 producer 上游半边） | `tools/archtest/command_async_emit_caller_test.go` |
+| archtest | `COMMAND-ASYNC-EMIT-CALLER-01`（#2059 producer 下游半边：生成 wrapper caller-allowlist） | `tools/archtest/command_async_emit_wrapper_caller_test.go` |
 | governance | `COMMAND-CONTRACT-SCHEMA-REF-01` / `COMMAND-CONTRACT-CONSISTENCY-LEVEL-01` | `kernel/governance/rules_command.go` |
 | codegen | `kind:command` 生成器 + golden；`COMMAND-CONTRACT-CONSISTENCY-LEVEL-01` 编译期 const-guard | `tools/codegen/contractgen/{builder,generator}.go`（`validateCommandLevel`）+ `templates/{command,types}.tmpl` |
 | runtime | sealed `Registry` | `runtime/command/registry.go` |
@@ -366,3 +368,34 @@ enforcement 索引（§7）**无新增 dispatch-funnel invariant**——active-u
 - 完成回执闭环 E2E —— **Medium**（`TestCertRenewal_CompletionClosesLoop`：ack success → cert 状态推进 → 下一 tick 不再 emit；emit/hook/consumer/wiring 任一断即红）。
 
 enforcement 索引（§7）**无新增 dispatch-funnel invariant**。威胁矩阵的收敛环闭合细节见 ADR-1822 §7 amendment。**无 ✅→⚠️/❌ 降格，无补偿措施**。
+
+## Amendment 2026-06-15(#2059) — producer 侧命令 emit 收口为生成式 typed wrapper（对称 DispatchAsync）
+
+**触发**：#2059（承接 #1674 body §重构档 + #1698 reconcile 决议）。按 ai-robust.md「ADR amendment 必查」逐行重评 §4 + 新增第 5 行矩阵 + 同步 §7 索引。
+
+**flag-cond 触发条件未满足，用户显式 override（诚实记录）**：#2059 的 `flag-cond` 触发条件是「≥2 个产异步命令的 **cell**」。当前仍只有 **1 个** producer cell（`examples/iotdevice/cells/devicecell`，`devicebootstrap` + `devicecertrenewal` + `devicecmd` 三个 slice 共用同一 `command.devicecommand.enqueue.v1` 契约）。触发条件**未满足**——本 amendment 是用户在知悉「单 producer cell 投机抽象/YAGNI」后**显式裁定提前实施**「彻底」档，非自动触发。记录于此以备后续审计：若未来始终只有单 producer cell，本机制是否过度抽象由后续 review 复核。
+
+**根本动机（producer↔consumer 对称缺口）**：#1698/#1757 落地后，consumer 侧已是生成式 typed `DispatchAsync` + 双 caller-funnel（REGISTER-CALLER + ASYNC-DISPATCH-CALLER），但 producer 侧 cell 仍手调 runtime `command.EmitAsync(ctx, clk, emitter, cmdenqueue.DispatchID, …)`——裸 DispatchID + 手填 `subject/commandID`（runtime `EmitAsync` godoc 自述的 transpose footgun 面）。#2059「彻底」档补齐 producer 侧生成式收口，使两侧对称。
+
+**交付**：
+1. **codegen（command.tmpl，golden + 真实 generated 重生成）**：每个 `kind=command` 契约的生成包新增两个 producer typed free function——
+   - `EmitAsync(ctx, clk, emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error` → 委托 runtime `command.EmitAsync(…, DispatchID, …)`；
+   - `EmitAsyncFromIdempotencyKey(ctx, clk, emitter, subject string, req *Request, opts ...command.EmitOption) error` → 委托 runtime 同名 HTTP 桥（commandID 由 ctx 的 Idempotency-Key 派生）。
+   两者 **bake DispatchID**（cell 不再命名 routing topic）+ **锁 payload 为 `*Request`**。无新增 IR 字段（复用 `CommandSpec.DispatchID` / `RequestGoType`）。
+2. **archtest `COMMAND-ASYNC-EMIT-CALLER-01`**（`tools/archtest/command_async_emit_wrapper_caller_test.go`）：锁 runtime **两个** emit 出口（`command.EmitAsync` + `command.EmitAsyncFromIdempotencyKey`）的生产调用方 ⊆ `generated/contracts/command/**` + `runtime/command`。**必须锁两个出口**——只锁 `EmitAsync` 会留下 `EmitAsyncFromIdempotencyKey(…, DispatchID, …)` 裸-DispatchID 旁路，闭环不彻底。含 anti-vacuity（generated `EmitAsync` wrapper 存在性）+ RED fixture（两出口各一 violation 负控）。
+3. **三处生产调用点迁移**到生成式 wrapper：`devicebootstrap/service.go`（`EmitAsync`，移除 runtime command import）、`devicecertrenewal/reconciler.go`（`EmitAsync` + `WithActiveUniqueness`）、`devicecmd/service.go`（`EmitAsyncFromIdempotencyKey`，HTTP #1610 桥）。
+
+**实施中经 archtest 校正的范围（诚实记录）**：原计划假设 `EmitAsyncFromIdempotencyKey` 无生产调用方、其 typed wrapper 推迟生成（避免死代码）。Wave 1 archtest RED **暴露第 3 个调用点** `devicecmd/service.go` 直调 `EmitAsyncFromIdempotencyKey`（早期 `EmitAsync(` grep 漏匹配该名）。故 HTTP→command 桥**已接线**、其 wrapper **非死代码**——两 wrapper 均生成、均有真实调用方。这比原计划更彻底，YAGNI 顾虑消失。
+
+**§4 评级矩阵逐行重评（无降格，新增 1 行）**：
+- `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`：✅ **不变**（上游 Hard / 下游 Medium）。新 producer wrapper 经同一 `command.tmpl` 派生 + golden 字节锁，sole-emitter 半边覆盖**净增**（wrapper 亦不可手写 look-alike）。
+- `COMMAND-DISPATCH-REGISTER-CALLER-01`：✅ **不变**（上游 Medium / 下游 Hard）。Register/Lookup caller-allowlist 不动。
+- `COMMAND-ASYNC-DISPATCH-CALLER-01`：✅ **不变**（上游 Medium / 下游 Hard）。consumer 侧 dispatch funnel 不动；本 amendment 是其 producer 侧孪生。
+- `COMMAND-ASYNC-EMIT-FUNNEL-01`：✅ **不变**（上游 Medium / 下游 Hard）。生成 wrapper 经 sanctioned runtime `command.EmitAsync` 构造 entry（by-construction 合规）；该上游守卫的 `runtime/command` 唯一构造方约束不动。
+- **新增第 5 行 `COMMAND-ASYNC-EMIT-CALLER-01`**（producer 第二层下游半边）：**上游 Medium**（caller-allowlist，Go 无 friend-package 永久天花板，同族不开伪 Hard-升级 issue）/ **下游 Hard**（生成 wrapper codegen + golden bake DispatchID）。与上游 Hard 半边 `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01` 合成 producer 侧第二层闭环双向锁，与 consumer 侧 `COMMAND-ASYNC-DISPATCH-CALLER-01` 对称。
+
+**威胁矩阵重评（ai-robust ADR amendment 必查）**：本 amendment **收紧** producer 攻击面——业务 cell 不能再手填裸 DispatchID / 手填 commandID 经 runtime emit 出口构造命令（runtime `EmitAsync` godoc 自述的 subject/commandID transpose footgun 在生成 wrapper 路径上不再暴露给业务）。新威胁面 = 0：wrapper 是 runtime 出口的 thin typed 委托，未改 sealed `Entry`、未引入 metadata 约定、未改 Claimer 身份语义。**Medium 结构天花板诚实记录**：「仅生成 wrapper 可调 runtime `command.EmitAsync`」与 EMIT-FUNNEL/REGISTER-CALLER 同族 Go 天花板（无 friend-package），archtest caller-allowlist 兜底；**不开伪 Hard-升级 issue**。
+
+**无 ✅→⚠️/❌ 降格，无补偿措施缺口；contract-fanout 处置（正向陈述）**：未改 `command.devicecommand.enqueue.v1` 的 contract.yaml / request·response schema / wire / version——生成 wrapper 是**同一命令契约的派生产物**（消费方，非 wire 契约本身）。`command_gen.go` 的 generated diff 是一等审查材料（PR body Implementation matrix 标注）。未触发 contract-fanout 5 载体（schema / generated-conformance / cell-slice metadata / journey-fixture / governance）的任一跨 cell wire 面：generated diff 限于 producer wrapper 增量，slice `contractUsages`（devicecertrenewal `role: invoke` + waiver 等）不变，无新 errcode/Kind/migration。
+
+**enforcement 索引（§7）新增**：archtest `COMMAND-ASYNC-EMIT-CALLER-01`（`tools/archtest/command_async_emit_wrapper_caller_test.go`）。**无 ✅→⚠️/❌ 降格，无补偿措施**。

--- a/examples/iotdevice/README.md
+++ b/examples/iotdevice/README.md
@@ -273,8 +273,9 @@ bus. This is producer **archetype ②** (reconcile → command, #1757), the
 counterpart to the event-reactive bootstrap producer above.
 
 Flow: each interval the loop scans the `devices` table for certificates whose
-`NotAfter` is within the renewal threshold → for each, `command.EmitAsync` emits a
-`command.devicecommand.enqueue.v1` entry with `commandType: rotate-cert` →
+`NotAfter` is within the renewal threshold → for each, the generated
+`cmdenqueue.EmitAsync` wrapper emits a `command.devicecommand.enqueue.v1` entry
+with `commandType: rotate-cert` →
 the outbox relay dispatches it in-process → a `rotate-cert` command lands in the
 device's queue, dequeued like any other command.
 

--- a/examples/iotdevice/cells/devicecell/cell.go
+++ b/examples/iotdevice/cells/devicecell/cell.go
@@ -126,7 +126,7 @@ func WithBootstrapEmitter(e outbox.CellEmitter) Option {
 }
 
 // WithBootstrapTxManager sets the CellTxManager injected into the devicebootstrap
-// reactive slice. That slice wraps command.EmitAsync in txRunner.RunInTx so
+// reactive slice. That slice wraps cmdenqueue.EmitAsync in txRunner.RunInTx so
 // durable mode (PG outbox writer) gets a real transaction in ctx. The cell
 // defaults the field to outbox.DemoCellTxManager() (no-op) in NewDeviceCell, so
 // demo mode and tests work without wiring it.

--- a/examples/iotdevice/cells/devicecell/internal/devicecmd/service.go
+++ b/examples/iotdevice/cells/devicecell/internal/devicecmd/service.go
@@ -299,8 +299,10 @@ func (s *Service) Enqueue(ctx context.Context, deviceID, commandType, payload st
 // consumer). It is the async sibling of Enqueue (which writes Pending directly).
 //
 // The commandID is sourced from the request's validated Idempotency-Key in ctx by
-// the bridge commandruntime.EmitAsyncFromIdempotencyKey — NOT a parameter here —
-// so the subject/commandID transpose footgun is structurally inexpressible. The
+// the generated cmdenqueue.EmitAsyncFromIdempotencyKey wrapper (which bakes in
+// DispatchID and delegates to runtime commandruntime.EmitAsyncFromIdempotencyKey)
+// — NOT a parameter here — so the subject/commandID transpose footgun is
+// structurally inexpressible. The
 // emit is wrapped in txRunner.RunInTx so the durable PG outbox writer gets a tx
 // (no-op in demo mode). A nil emitter (async path not wired) fail-fasts.
 func (s *Service) EnqueueAsync(ctx context.Context, deviceID, commandType, payload string) error {
@@ -323,8 +325,8 @@ func (s *Service) EnqueueAsync(ctx context.Context, deviceID, commandType, paylo
 	}
 	req := cmdenqueue.Request{DeviceID: deviceID, CommandType: commandType, Payload: payload}
 	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
-		return commandruntime.EmitAsyncFromIdempotencyKey(
-			txCtx, s.clock, s.emitter, cmdenqueue.DispatchID, deviceID, req)
+		return cmdenqueue.EmitAsyncFromIdempotencyKey(
+			txCtx, s.clock, s.emitter, deviceID, &req)
 	}); err != nil {
 		return err
 	}

--- a/examples/iotdevice/cells/devicecell/slices/devicebootstrap/doc.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicebootstrap/doc.go
@@ -2,7 +2,7 @@
 // event-reactive producer that subscribes to event.device-registered.v1 and,
 // for every newly registered device, reactively emits a
 // command.devicecommand.enqueue.v1 async command outbox entry (a "bootstrap"
-// command) via runtime/command.EmitAsync.
+// command) via the generated cmdenqueue.EmitAsync wrapper.
 //
 // The slice owns no domain state: it decodes the source event payload, builds a
 // typed enqueue Request, and emits the command. The command_id carried in the

--- a/examples/iotdevice/cells/devicecell/slices/devicebootstrap/service.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicebootstrap/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/kernel/persistence"
-	"github.com/ghbvf/gocell/framework/runtime/command"
 	cmdenqueue "github.com/ghbvf/gocell/generated/contracts/command/devicecommand/enqueue/v1"
 )
 
@@ -35,12 +34,12 @@ type deviceRegisteredEvent struct {
 // Service is the event-reactive bootstrap producer.
 //
 // emitter is the sealed CellEmitter marker (composition root wraps a raw
-// Emitter); it embeds outbox.Emitter, so it is passed directly to
-// command.EmitAsync's kout.Emitter parameter. It is an optional dependency
-// (defaults to outbox.DemoCellEmitter), matching the deviceregister slice — no
-// gocell:"required" tag.
+// Emitter); it embeds outbox.Emitter, so it is passed directly to the generated
+// cmdenqueue.EmitAsync wrapper's kout.Emitter parameter. It is an optional
+// dependency (defaults to outbox.DemoCellEmitter), matching the deviceregister
+// slice — no gocell:"required" tag.
 //
-// txRunner wraps command.EmitAsync in a real transaction when the durable
+// txRunner wraps the cmdenqueue.EmitAsync emit in a real transaction when the durable
 // outbox writer requires one (adapters/postgres.OutboxWriter.Write calls
 // persistence.TxFromContext[pgx.Tx] and returns ErrAdapterPGNoTx when no tx
 // is present in ctx). Defaults to outbox.DemoCellTxManager() — a no-op that
@@ -68,8 +67,8 @@ func WithEmitter(e outbox.CellEmitter) Option {
 	}
 }
 
-// WithTxManager sets the CellTxManager used to wrap command.EmitAsync in a
-// transaction. Required for durable mode: the PG outbox writer calls
+// WithTxManager sets the CellTxManager used to wrap the cmdenqueue.EmitAsync
+// emit in a transaction. Required for durable mode: the PG outbox writer calls
 // persistence.TxFromContext[pgx.Tx] and returns ErrAdapterPGNoTx when no tx
 // is in ctx. Demo mode and tests use the default outbox.DemoCellTxManager()
 // no-op. Accumulative: a nil txRunner leaves the previously-set value in place.
@@ -142,8 +141,7 @@ func (s *Service) HandleDeviceRegistered(ctx context.Context, entry outbox.Entry
 	// Demo mode uses outbox.DemoCellTxManager() (no-op), which just calls the
 	// closure directly, so behavior is unchanged for tests and demo assemblies.
 	if err := s.txRunner.RunInTx(ctx, func(txCtx context.Context) error {
-		return command.EmitAsync(txCtx, s.clk, s.emitter, cmdenqueue.DispatchID,
-			ev.ID, entry.ID(), req)
+		return cmdenqueue.EmitAsync(txCtx, s.clk, s.emitter, ev.ID, entry.ID(), &req)
 	}); err != nil {
 		s.logger.Error("device-bootstrap: failed to emit enqueue command",
 			slog.String("device_id", ev.ID), slog.String("entry_id", entry.ID()),

--- a/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/doc.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/doc.go
@@ -1,8 +1,8 @@
 // Package devicecertrenewal is the cert-renewal producer slice: a STATELESS
 // reconcile.Reconciler that, on each tick, scans the device repository for
 // near-expiry certificates (cert_expires_at on the devices row, #1819) and
-// enqueues a rotate-cert async command per device via runtime/command.EmitAsync
-// with active-uniqueness (#1820).
+// enqueues a rotate-cert async command per device via the generated
+// cmdenqueue.EmitAsync wrapper with active-uniqueness (#1820).
 //
 // It is the iotdevice archetype-② reference (reconcile → command, issue #1757),
 // the counterpart to the event-reactive devicebootstrap producer. The slice owns

--- a/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/reconciler.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecertrenewal/reconciler.go
@@ -53,7 +53,8 @@ func (p Policy) validate() error {
 
 // Reconciler is a STATELESS cert-renewal producer: a reconcile.Reconciler that,
 // on each tick, scans ALL near-expiry certificates and enqueues a rotate-cert
-// async command per device via runtime/command.EmitAsync with active-uniqueness.
+// async command per device via the generated cmdenqueue.EmitAsync wrapper
+// (→ runtime command.EmitAsync) with active-uniqueness.
 //
 // It is the iotdevice archetype-② reference (reconcile → command, issue #1757):
 // it reuses the already-activated async-dispatch path (#1698 WithCommandDispatch
@@ -196,7 +197,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 }
 
 // enqueueRenewal emits one rotate-cert async outbox entry for a near-expiry cert
-// via command.EmitAsync(..., command.WithActiveUniqueness(deadline)).
+// via the generated cmdenqueue.EmitAsync(..., command.WithActiveUniqueness(deadline))
+// wrapper (DispatchID baked in; delegates to runtime command.EmitAsync).
 // WithActiveUniqueness stamps CommandDeadlineMetadataKey on the entry; the relay
 // reads that key and injects (claimKey, deadline) into the dispatch ctx via
 // rtcommand.WithDispatchedUniqueness before calling the enqueue handler. The
@@ -219,8 +221,7 @@ func (r *Reconciler) enqueueRenewal(ctx context.Context, cand domain.Certificate
 	}
 	commandID := rotateCommandID(cand.DeviceID, cand.CertEpoch)
 	deadline := now.Add(r.policy.AttemptTTL)
-	if err := command.EmitAsync(ctx, r.clk, r.emitter, cmdenqueue.DispatchID,
-		cand.DeviceID, commandID, req,
+	if err := cmdenqueue.EmitAsync(ctx, r.clk, r.emitter, cand.DeviceID, commandID, &req,
 		command.WithActiveUniqueness(deadline)); err != nil {
 		return fmt.Errorf("devicecertrenewal: enqueue cert-renewal command: %w", err)
 	}

--- a/examples/iotdevice/command_dedup_durable_integration_test.go
+++ b/examples/iotdevice/command_dedup_durable_integration_test.go
@@ -142,8 +142,8 @@ func TestCommandRelay_Durable_PG(t *testing.T) {
 		// Rollback: the PG outbox writer writes inside the device-bootstrap tx, so
 		// a tx that emits then fails must leave NO command entry.
 		rbErr := crs.bootstrapTxManager.RunInTx(ctx, func(txCtx context.Context) error {
-			if e := command.EmitAsync(txCtx, clk, crs.bootstrapEmitter,
-				enqueue.DispatchID, "d2", "evt-rollback", req); e != nil {
+			if e := enqueue.EmitAsync(txCtx, clk, crs.bootstrapEmitter,
+				"d2", "evt-rollback", &req); e != nil {
 				return e
 			}
 			return errBoom
@@ -155,8 +155,8 @@ func TestCommandRelay_Durable_PG(t *testing.T) {
 
 		// Commit: the same emit with a tx that succeeds → exactly one entry persists.
 		require.NoError(t, crs.bootstrapTxManager.RunInTx(ctx, func(txCtx context.Context) error {
-			return command.EmitAsync(txCtx, clk, crs.bootstrapEmitter,
-				enqueue.DispatchID, "d2", "evt-commit", req)
+			return enqueue.EmitAsync(txCtx, clk, crs.bootstrapEmitter,
+				"d2", "evt-commit", &req)
 		}))
 		n, err = outboxCount(ctx, pool, "")
 		require.NoError(t, err)

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -274,7 +274,7 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 // into, the ConsumerBase that idempotency-guards the device-registered
 // subscriber, the relay that polls the outbox store and dispatches command
 // entries in-process, and the CellTxManager the bootstrap slice uses to wrap
-// command.EmitAsync in a real transaction in durable mode (#1698).
+// cmdenqueue.EmitAsync in a real transaction in durable mode (#1698).
 type commandRelaySubsystem struct {
 	bootstrapEmitter   outbox.CellEmitter
 	bootstrapTxManager persistence.CellTxManager
@@ -318,7 +318,7 @@ func buildCommandRelaySubsystem(
 	} else {
 		store = adapterpg.NewOutboxStore(pool.DB(), clk)
 		writer = adapterpg.NewOutboxWriter(clk)
-		// Durable mode: wrap PG TxManager so command.EmitAsync gets a real tx in
+		// Durable mode: wrap PG TxManager so cmdenqueue.EmitAsync gets a real tx in
 		// ctx — adapterpg.OutboxWriter.Write calls persistence.TxFromContext[pgx.Tx]
 		// and returns ErrAdapterPGNoTx without one.
 		bootstrapTxManager = persistence.WrapForCell(adapterpg.NewTxManager(pool))

--- a/generated/contracts/command/devicecommand/enqueue/v1/command_gen.go
+++ b/generated/contracts/command/devicecommand/enqueue/v1/command_gen.go
@@ -217,7 +217,16 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 // to opt into queue active-uniqueness. The funnel is locked by archtest
 // COMMAND-ASYNC-EMIT-CALLER-01 (symmetric to the consumer-side
 // COMMAND-ASYNC-DISPATCH-CALLER-01).
+//
+// Returns KindInvalid / ErrValidationFailed when req is nil (mirrors Dispatch):
+// a nil *Request would otherwise marshal to a `null` payload
+// and enter the outbox as a poison entry that only fails at the relay
+// (DispatchAsync schema-validate → MarkDead). Fail fast at the producer instead.
 func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error {
+	if req == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"command.devicecommand.enqueue.v1 emit async: request must not be nil")
+	}
 	return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)
 }
 
@@ -228,6 +237,14 @@ func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subje
 // because commandID is derived from the sealed ctx identity, the subject/commandID
 // transpose footgun is structurally inexpressible on this HTTP-sourced path.
 // Callers are locked by archtest COMMAND-ASYNC-EMIT-CALLER-01.
+//
+// Returns KindInvalid / ErrValidationFailed when req is nil (mirrors Dispatch and
+// EmitAsync): a nil request must fail fast at the producer, not become a `null`
+// outbox poison entry.
 func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *Request, opts ...command.EmitOption) error {
+	if req == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"command.devicecommand.enqueue.v1 emit async (idempotency-key): request must not be nil")
+	}
 	return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)
 }

--- a/generated/contracts/command/devicecommand/enqueue/v1/command_gen.go
+++ b/generated/contracts/command/devicecommand/enqueue/v1/command_gen.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/ghbvf/gocell/framework/kernel/clock"
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/idutil"
@@ -202,4 +203,31 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 	}
 	_, err := h.HandleEnqueue(ctx, &req)
 	return err
+}
+
+// EmitAsync enqueues a command.devicecommand.enqueue.v1 async command through the sanctioned
+// runtime command emit funnel. It is the producer-side counterpart of
+// DispatchAsync: it bakes in DispatchID (the cell never names the raw routing
+// topic) and locks the payload to the typed *Request, so a
+// bare-DispatchID dispatch is unexpressible at the call site.
+//
+// subject and commandID are the idempotency identity slot the relay's Claimer
+// wrap reads (subject = the dedup aggregate, e.g. deviceID; commandID = the
+// per-instance identity). opts is additive — pass command.WithActiveUniqueness
+// to opt into queue active-uniqueness. The funnel is locked by archtest
+// COMMAND-ASYNC-EMIT-CALLER-01 (symmetric to the consumer-side
+// COMMAND-ASYNC-DISPATCH-CALLER-01).
+func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error {
+	return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)
+}
+
+// EmitAsyncFromIdempotencyKey enqueues a command.devicecommand.enqueue.v1 async command sourcing
+// the per-instance commandID from the validated HTTP Idempotency-Key in ctx
+// (the #1610 bridge), instead of taking commandID as a parameter. Like EmitAsync
+// it bakes in DispatchID and locks the payload to *Request;
+// because commandID is derived from the sealed ctx identity, the subject/commandID
+// transpose footgun is structurally inexpressible on this HTTP-sourced path.
+// Callers are locked by archtest COMMAND-ASYNC-EMIT-CALLER-01.
+func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *Request, opts ...command.EmitOption) error {
+	return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)
 }

--- a/tools/archtest/command_async_emit_wrapper_caller_test.go
+++ b/tools/archtest/command_async_emit_wrapper_caller_test.go
@@ -91,12 +91,12 @@ func commandEmitExitCallee(p *Pass, call *ast.CallExpr) (name string, ok bool) {
 //     excluded by Production() scope regardless — so the Production scan never
 //     observes a sanctioned caller; the anti-vacuity anchor scans generated/
 //     separately for the wrapper's existence.
-//  2. EmitAsyncFromIdempotencyKey currently has zero production callers
-//     (HTTP→command is not wired). Its arm of the lock is therefore vacuous-green
-//     today, anchored structurally by the EmitAsync wrapper anti-vacuity — the
-//     same posture as COMMAND-ASYNC-EMIT-FUNNEL-01's vacuous-green const-topic
-//     arm. A typed HTTP wrapper is generated on demand when HTTP→command is wired
-//     (no dead code emitted now).
+//  2. Both exits have live production callers post-migration (#2059): EmitAsync
+//     (device bootstrap + cert-renewal reconcile producers) and
+//     EmitAsyncFromIdempotencyKey (the devicecmd HTTP EnqueueAsync bridge, #1610).
+//     Both arms are therefore non-vacuous and both typed wrappers are generated —
+//     neither is dead code. The anti-vacuity anchor below checks the EmitAsync
+//     wrapper's existence, which is sufficient to prove the codegen funnel is wired.
 //  3. Build-tag-gated production files under a non-default tag are not scanned by
 //     the default-tags Production scan (same posture as the sibling funnels).
 func TestCommandAsyncEmitCaller01(t *testing.T) {

--- a/tools/archtest/command_async_emit_wrapper_caller_test.go
+++ b/tools/archtest/command_async_emit_wrapper_caller_test.go
@@ -25,6 +25,7 @@ package archtest
 import (
 	"fmt"
 	"go/ast"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,30 +75,42 @@ func commandEmitExitCallee(p *Pass, call *ast.CallExpr) (name string, ok bool) {
 //
 // # AI-robust rating (charter §"Funnel 双向锁评级")
 //
-//   - Upstream (wrapper existence): HARD — the generated EmitAsync wrapper is
-//     codegen + golden-locked (command.tmpl render golden + `gocell generate
-//     contract --all --verify` in CI). A wrapper that fails to bake DispatchID /
-//     the typed *Request cannot be expressed through the generated path.
-//   - Downstream (this archtest): MEDIUM — caller-allowlist type-aware scan, a
+// Label convention matches the ADR §4 matrix row (上游 Medium / 下游 Hard) and the
+// sibling CALLER-family godocs (EMIT-FUNNEL / DISPATCH-CALLER): Upstream = this
+// caller-allowlist archtest; Downstream = the structural backstop.
+//
+//   - Upstream (caller-allowlist, this archtest): MEDIUM — type-aware scan, a
 //     GO-LANGUAGE CEILING, not a deferred TODO. Go cannot express "only
 //     generated/contracts/command/** may call this exported func". Same permanent
 //     ceiling documented for COMMAND-ASYNC-EMIT-FUNNEL-01 /
 //     COMMAND-ASYNC-DISPATCH-CALLER-01 / #851 / #893 / #1282. No fake Hard-upgrade
 //     issue is opened.
+//   - Downstream (wrapper existence, codegen + golden): HARD — the generated
+//     EmitAsync / EmitAsyncFromIdempotencyKey wrappers are codegen + golden-locked
+//     (command.tmpl render golden + `gocell generate contract --all --verify` in
+//     CI). A wrapper that fails to bake DispatchID / the typed *Request cannot be
+//     expressed through the generated path (symmetric to the Hard half of
+//     COMMAND-GEN-FUNNEL-SOLE-EMITTER-01).
 //
 // # Tool blind spots (charter §"强制盲区自检")
 //
 //  1. generated/contracts/command/** packages ARE sanctioned callers but are
 //     excluded by Production() scope regardless — so the Production scan never
 //     observes a sanctioned caller; the anti-vacuity anchor scans generated/
-//     separately for the wrapper's existence.
+//     separately for both wrappers' existence.
 //  2. Both exits have live production callers post-migration (#2059): EmitAsync
 //     (device bootstrap + cert-renewal reconcile producers) and
 //     EmitAsyncFromIdempotencyKey (the devicecmd HTTP EnqueueAsync bridge, #1610).
 //     Both arms are therefore non-vacuous and both typed wrappers are generated —
-//     neither is dead code. The anti-vacuity anchor below checks the EmitAsync
-//     wrapper's existence, which is sufficient to prove the codegen funnel is wired.
-//  3. Build-tag-gated production files under a non-default tag are not scanned by
+//     neither is dead code. The anti-vacuity anchor below checks BOTH wrappers'
+//     existence so a template regression dropping either arm fails closed.
+//  3. _test.go files — including build-tag-gated tests such as `integration` — are
+//     EXCLUDED from the Production() scan (TypedOpts.Tests defaults false). A direct
+//     command.EmitAsync / EmitAsyncFromIdempotencyKey call in a test helper or
+//     integration test is therefore NOT caught; such calls should still be migrated
+//     to the generated wrapper for production↔test funnel consistency (the #2059
+//     migration covers the iotdevice durable integration test for this reason).
+//  4. Build-tag-gated production files under a non-default tag are not scanned by
 //     the default-tags Production scan (same posture as the sibling funnels).
 func TestCommandAsyncEmitCaller01(t *testing.T) {
 	t.Parallel()
@@ -143,48 +156,64 @@ func TestCommandAsyncEmitCaller01(t *testing.T) {
 		return d
 	})
 
-	// Anti-vacuity: at least one generated command package must declare an
-	// EmitAsync wrapper that calls runtime command.EmitAsync, else the funnel
-	// guards nothing — the Production scan above can never observe a sanctioned
-	// caller because generated/ is excluded from Production() scope.
-	if !observedGeneratedEmitWrapperPresent(t) {
+	// Anti-vacuity: a generated command package must declare BOTH wrappers
+	// (EmitAsync + EmitAsyncFromIdempotencyKey), each calling its runtime exit,
+	// else the funnel guards nothing — the Production scan above can never observe
+	// a sanctioned caller because generated/ is excluded from Production() scope.
+	// Both arms are checked so a template regression dropping either wrapper (whose
+	// exit this rule also locks) fails closed, not just the EmitAsync arm.
+	if missing := missingGeneratedEmitWrappers(t); len(missing) > 0 {
 		diags = append(diags, Diagnostic{
 			Message: "COMMAND-ASYNC-EMIT-CALLER-01 anti-vacuity: no generated command package " +
-				"declares an EmitAsync wrapper calling runtime command.EmitAsync. Either the " +
-				"producer codegen (command.tmpl) was removed/renamed or the scanner regressed — " +
-				"the wrapper funnel guards nothing without it.",
+				"declares a wrapper calling runtime command." + strings.Join(missing, " / command.") +
+				". Either the producer codegen (command.tmpl) was removed/renamed or the scanner " +
+				"regressed — the wrapper funnel guards nothing without it.",
 		})
 	}
 
 	Report(t, "COMMAND-ASYNC-EMIT-CALLER-01", diags)
 }
 
-// observedGeneratedEmitWrapperPresent verifies a generated command package
-// declares an EmitAsync free function whose body calls runtime command.EmitAsync
-// — the structural anti-vacuity anchor (the Production scan cannot see generated
-// packages because they are excluded from Production() scope).
-func observedGeneratedEmitWrapperPresent(t *testing.T) bool {
+// missingGeneratedEmitWrappers returns the runtime emit-exit names for which NO
+// generated command package declares a same-named wrapper free function whose
+// body calls that runtime exit — the structural anti-vacuity anchor (the
+// Production scan cannot see generated packages because they are excluded from
+// Production() scope). Both exits are checked so a template regression dropping
+// either wrapper is caught; an empty result means both wrappers are wired.
+func missingGeneratedEmitWrappers(t *testing.T) []string {
 	t.Helper()
-	var found bool
+	expected := []string{"EmitAsync", "EmitAsyncFromIdempotencyKey"}
+	found := map[string]bool{}
 	_ = Run(t, Typed(TypedOpts{}, []string{"./generated/contracts/command/..."}), func(p *Pass) []Diagnostic {
 		if !p.Typed() {
 			return nil
 		}
 		for _, file := range p.Files {
 			EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
-				if fd.Recv != nil || fd.Name == nil || fd.Name.Name != "EmitAsync" {
+				if fd.Recv != nil || fd.Name == nil {
 					return
 				}
+				wrapperName := fd.Name.Name
+				if wrapperName != "EmitAsync" && wrapperName != "EmitAsyncFromIdempotencyKey" {
+					return
+				}
+				// The wrapper must delegate to the SAME-named runtime exit.
 				EachInSubtree[ast.CallExpr](fd, func(call *ast.CallExpr) {
-					if name, ok := commandEmitExitCallee(p, call); ok && name == "EmitAsync" {
-						found = true
+					if name, ok := commandEmitExitCallee(p, call); ok && name == wrapperName {
+						found[wrapperName] = true
 					}
 				})
 			})
 		}
 		return nil
 	})
-	return found
+	var missing []string
+	for _, name := range expected {
+		if !found[name] {
+			missing = append(missing, name)
+		}
+	}
+	return missing
 }
 
 // TestCommandAsyncEmitCaller01_RedFixture verifies the scanner fires against a

--- a/tools/archtest/command_async_emit_wrapper_caller_test.go
+++ b/tools/archtest/command_async_emit_wrapper_caller_test.go
@@ -94,10 +94,13 @@ func commandEmitExitCallee(p *Pass, call *ast.CallExpr) (name string, ok bool) {
 //
 // # Tool blind spots (charter §"强制盲区自检")
 //
-//  1. generated/contracts/command/** packages ARE sanctioned callers but are
-//     excluded by Production() scope regardless — so the Production scan never
-//     observes a sanctioned caller; the anti-vacuity anchor scans generated/
-//     separately for both wrappers' existence.
+//  1. generated/ is excluded from Production() scope, so the Production scan never
+//     observes a generated caller. Generated packages are handled by two separate
+//     typed scans over generated/: (a) the anti-vacuity anchor verifies the
+//     command wrappers exist (both arms); (b) nonCommandGeneratedEmitCallers flags
+//     any NON-command generated package calling a runtime emit exit (#2059 F2) —
+//     so the stated allowlist {generated/contracts/command/**, runtime/command} is
+//     actually enforced, not assumed. (b) is vacuous-green today (no such caller).
 //  2. Both exits have live production callers post-migration (#2059): EmitAsync
 //     (device bootstrap + cert-renewal reconcile producers) and
 //     EmitAsyncFromIdempotencyKey (the devicecmd HTTP EnqueueAsync bridge, #1610).
@@ -171,6 +174,14 @@ func TestCommandAsyncEmitCaller01(t *testing.T) {
 		})
 	}
 
+	// Generated-scope enforcement (#2059 F2): the stated allowlist is
+	// {generated/contracts/command/**, runtime/command}. The Production scan above
+	// excludes ALL generated/, so a NON-command generated package directly calling a
+	// runtime emit exit would slip through. Scan generated/contracts/** and flag any
+	// emit-exit caller whose package is not under generated/contracts/command/, so the
+	// enforcement matches the allowlist the rule claims (not just command anti-vacuity).
+	diags = append(diags, nonCommandGeneratedEmitCallers(t)...)
+
 	Report(t, "COMMAND-ASYNC-EMIT-CALLER-01", diags)
 }
 
@@ -214,6 +225,55 @@ func missingGeneratedEmitWrappers(t *testing.T) []string {
 		}
 	}
 	return missing
+}
+
+// generatedCommandPkgInfix is the import-path infix marking the SOLE sanctioned
+// generated caller of the runtime emit exits — the per-command generated wrappers
+// under generated/contracts/command/**. Any OTHER generated/contracts/** package
+// calling a runtime emit exit is a funnel bypass (#2059 F2).
+const generatedCommandPkgInfix = "/generated/contracts/command/"
+
+// nonCommandGeneratedEmitCallers scans generated/contracts/** and returns a
+// diagnostic for every direct runtime emit-exit call (command.EmitAsync /
+// command.EmitAsyncFromIdempotencyKey) made from a generated package NOT under
+// generated/contracts/command/. The Production scan in the main test excludes all
+// of generated/ by scope; this closes that hole so the rule actually enforces its
+// stated allowlist for generated packages, not only the command anti-vacuity.
+// Reuses the production-proven commandEmitExitCallee detector (RED-fixture covered),
+// so only the package-prefix gate is new; today this is vacuous-green (no
+// non-command generated package calls the exits).
+func nonCommandGeneratedEmitCallers(t *testing.T) []Diagnostic {
+	t.Helper()
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{}, []string{"./generated/contracts/..."}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		if strings.Contains(p.Pkg.Path(), generatedCommandPkgInfix) {
+			return nil // sanctioned generated caller
+		}
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				name, ok := commandEmitExitCallee(p, call)
+				if !ok {
+					return
+				}
+				pos := p.Fset.Position(call.Pos())
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: pos.Line,
+					Message: fmt.Sprintf(
+						"COMMAND-ASYNC-EMIT-CALLER-01: %s is a NON-command generated package "+
+							"calling runtime command.%s directly. Only generated/contracts/command/** "+
+							"per-command wrappers may call the runtime emit exits (#2059 F2).",
+						rel, name),
+				})
+			})
+		}
+		return nil
+	})
+	return diags
 }
 
 // TestCommandAsyncEmitCaller01_RedFixture verifies the scanner fires against a

--- a/tools/archtest/command_async_emit_wrapper_caller_test.go
+++ b/tools/archtest/command_async_emit_wrapper_caller_test.go
@@ -1,0 +1,227 @@
+//go:build archtest
+
+// command_async_emit_wrapper_caller_test.go — locks the DOWNSTREAM (cell-side)
+// caller-allowlist of the async command emit funnel: every call to a runtime
+// command emit exit (command.EmitAsync / command.EmitAsyncFromIdempotencyKey)
+// must originate from a generated per-command package (generated/contracts/
+// command/**) or from runtime/command itself — never hand-written in a cell.
+//
+//   - INVARIANT: COMMAND-ASYNC-EMIT-CALLER-01
+//
+// This is the producer-side mirror of COMMAND-ASYNC-DISPATCH-CALLER-01 (which
+// locks the consumer-side WithCommandDispatch map values to generated
+// DispatchAsync symbols). Together with the upstream COMMAND-ASYNC-EMIT-FUNNEL-01
+// (which locks bare kout.Emit/NewEntry command-topic construction to
+// runtime/command) they form the producer funnel's nested double-lock:
+//
+//	cell business code
+//	  → generated enqueue.EmitAsync (this rule: only generated may call ↓)
+//	    → runtime command.EmitAsync (EMIT-FUNNEL-01: only it may call ↓)
+//	      → kout.NewEntry
+//
+// ADR ref: docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// commandEmitWrapperCallerFixturePkg is the RED fixture package path (loaded
+// under the archtest_fixture tag for the negative-control self-check).
+const commandEmitWrapperCallerFixturePkg = "./tools/archtest/internal/commandasyncemitcallerfixture"
+
+// commandEmitExitCallee reports the runtime command emit-exit a call targets —
+// EmitAsync or EmitAsyncFromIdempotencyKey in runtime/command — or ok=false for
+// any other callee. Both exits are generic ([T any]); call.Fun is unwrapped from
+// IndexExpr / IndexListExpr before resolution, mirroring
+// commandTopicOfEmitOrNewEntry. Resolution is via ResolvePackageRef (go/types),
+// so it is alias- and dot-import-proof and resolves same-package unqualified
+// calls too.
+//
+// BOTH exits are locked deliberately: each takes a bare `dispatchID CommandID`,
+// so leaving EmitAsyncFromIdempotencyKey open would let a cell emit with a bare
+// DispatchID via the HTTP bridge — exactly the bare-string dispatch the generated
+// per-command wrapper eliminates (#2059).
+func commandEmitExitCallee(p *Pass, call *ast.CallExpr) (name string, ok bool) {
+	fun := call.Fun
+	if idx, isIdx := fun.(*ast.IndexExpr); isIdx {
+		fun = idx.X
+	} else if idxl, isIdxl := fun.(*ast.IndexListExpr); isIdxl {
+		fun = idxl.X
+	}
+	pkgPath, n, resolved := ResolvePackageRef(p.TypesInfo, fun)
+	if !resolved || pkgPath != commandEmitFunnelPkgPath {
+		return "", false
+	}
+	if n == "EmitAsync" || n == "EmitAsyncFromIdempotencyKey" {
+		return n, true
+	}
+	return "", false
+}
+
+// TestCommandAsyncEmitCaller01 asserts that every production call to a runtime
+// command emit exit (command.EmitAsync / command.EmitAsyncFromIdempotencyKey)
+// lives in a sanctioned package: a generated per-command package
+// (generated/contracts/command/**, the typed EmitAsync wrapper #2059) or
+// runtime/command itself (EmitAsyncFromIdempotencyKey delegates to EmitAsync).
+// Any other caller hand-rolls async-command dispatch with a bare DispatchID,
+// defeating the single-source key/payload guarantee the generated wrapper
+// provides.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Upstream (wrapper existence): HARD — the generated EmitAsync wrapper is
+//     codegen + golden-locked (command.tmpl render golden + `gocell generate
+//     contract --all --verify` in CI). A wrapper that fails to bake DispatchID /
+//     the typed *Request cannot be expressed through the generated path.
+//   - Downstream (this archtest): MEDIUM — caller-allowlist type-aware scan, a
+//     GO-LANGUAGE CEILING, not a deferred TODO. Go cannot express "only
+//     generated/contracts/command/** may call this exported func". Same permanent
+//     ceiling documented for COMMAND-ASYNC-EMIT-FUNNEL-01 /
+//     COMMAND-ASYNC-DISPATCH-CALLER-01 / #851 / #893 / #1282. No fake Hard-upgrade
+//     issue is opened.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//  1. generated/contracts/command/** packages ARE sanctioned callers but are
+//     excluded by Production() scope regardless — so the Production scan never
+//     observes a sanctioned caller; the anti-vacuity anchor scans generated/
+//     separately for the wrapper's existence.
+//  2. EmitAsyncFromIdempotencyKey currently has zero production callers
+//     (HTTP→command is not wired). Its arm of the lock is therefore vacuous-green
+//     today, anchored structurally by the EmitAsync wrapper anti-vacuity — the
+//     same posture as COMMAND-ASYNC-EMIT-FUNNEL-01's vacuous-green const-topic
+//     arm. A typed HTTP wrapper is generated on demand when HTTP→command is wired
+//     (no dead code emitted now).
+//  3. Build-tag-gated production files under a non-default tag are not scanned by
+//     the default-tags Production scan (same posture as the sibling funnels).
+func TestCommandAsyncEmitCaller01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		// runtime/command OWNS the exits; its internal
+		// EmitAsyncFromIdempotencyKey→EmitAsync delegation is sanctioned. Generated
+		// per-command packages are the other sanctioned callers but are excluded
+		// from Production() scope, so they never reach here.
+		if p.Pkg.Path() == commandEmitFunnelPkgPath {
+			return nil
+		}
+		var d []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				name, ok := commandEmitExitCallee(p, call)
+				if !ok {
+					return
+				}
+				pos := p.Fset.Position(call.Pos())
+				d = append(d, Diagnostic{
+					Rel:  rel,
+					Line: pos.Line,
+					Message: fmt.Sprintf(
+						"COMMAND-ASYNC-EMIT-CALLER-01: %s calls runtime command.%s directly. "+
+							"Async commands MUST be emitted through the generated per-command "+
+							"EmitAsync wrapper (generated/contracts/command/**), which bakes in "+
+							"DispatchID and locks the payload to the typed *Request — a cell never "+
+							"names the raw routing topic. A direct command.%s call re-admits the "+
+							"bare-DispatchID dispatch the generated wrapper eliminates (#2059; "+
+							"symmetric to consumer COMMAND-ASYNC-DISPATCH-CALLER-01).",
+						rel, name, name),
+				})
+			})
+		}
+		return d
+	})
+
+	// Anti-vacuity: at least one generated command package must declare an
+	// EmitAsync wrapper that calls runtime command.EmitAsync, else the funnel
+	// guards nothing — the Production scan above can never observe a sanctioned
+	// caller because generated/ is excluded from Production() scope.
+	if !observedGeneratedEmitWrapperPresent(t) {
+		diags = append(diags, Diagnostic{
+			Message: "COMMAND-ASYNC-EMIT-CALLER-01 anti-vacuity: no generated command package " +
+				"declares an EmitAsync wrapper calling runtime command.EmitAsync. Either the " +
+				"producer codegen (command.tmpl) was removed/renamed or the scanner regressed — " +
+				"the wrapper funnel guards nothing without it.",
+		})
+	}
+
+	Report(t, "COMMAND-ASYNC-EMIT-CALLER-01", diags)
+}
+
+// observedGeneratedEmitWrapperPresent verifies a generated command package
+// declares an EmitAsync free function whose body calls runtime command.EmitAsync
+// — the structural anti-vacuity anchor (the Production scan cannot see generated
+// packages because they are excluded from Production() scope).
+func observedGeneratedEmitWrapperPresent(t *testing.T) bool {
+	t.Helper()
+	var found bool
+	_ = Run(t, Typed(TypedOpts{}, []string{"./generated/contracts/command/..."}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		for _, file := range p.Files {
+			EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+				if fd.Recv != nil || fd.Name == nil || fd.Name.Name != "EmitAsync" {
+					return
+				}
+				EachInSubtree[ast.CallExpr](fd, func(call *ast.CallExpr) {
+					if name, ok := commandEmitExitCallee(p, call); ok && name == "EmitAsync" {
+						found = true
+					}
+				})
+			})
+		}
+		return nil
+	})
+	return found
+}
+
+// TestCommandAsyncEmitCaller01_RedFixture verifies the scanner fires against a
+// hand-written package that calls command.EmitAsync AND
+// command.EmitAsyncFromIdempotencyKey directly (bypassing the generated wrapper).
+//
+// The fixture must produce ≥ 2 diagnostics (one per exit). total==0 means the
+// scanner is fail-open.
+func TestCommandAsyncEmitCaller01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{commandEmitWrapperCallerFixturePkg}),
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			// The fixture package path is neither runtime/command nor generated, so
+			// every command-exit call there is a violation.
+			for _, file := range p.Files {
+				EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+					if _, ok := commandEmitExitCallee(p, call); ok {
+						found++
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, found, 2,
+		"COMMAND-ASYNC-EMIT-CALLER-01 RED fixture self-check FAILED: expected ≥ 2 "+
+			"violations from commandasyncemitcallerfixture (direct command.EmitAsync + "+
+			"command.EmitAsyncFromIdempotencyKey); got %d. found==0 means the scanner is "+
+			"fail-open — check ResolvePackageRef resolves under the archtest_fixture tag.",
+		found)
+}

--- a/tools/archtest/internal/commandasyncemitcallerfixture/fixture.go
+++ b/tools/archtest/internal/commandasyncemitcallerfixture/fixture.go
@@ -1,0 +1,44 @@
+//go:build archtest_fixture
+
+// Package commandasyncemitcallerfixture is the RED fixture for
+// COMMAND-ASYNC-EMIT-CALLER-01.
+//
+// It calls the runtime async-command emit exits — command.EmitAsync and
+// command.EmitAsyncFromIdempotencyKey — DIRECTLY with a bare DispatchID,
+// bypassing the generated per-command EmitAsync wrapper that bakes in DispatchID
+// and locks the payload to the typed *Request (#2059). Both are violations the
+// scanner must flag: leaving either exit open re-admits the bare-DispatchID
+// dispatch the wrapper funnel exists to eliminate.
+//
+// DO NOT use this package in production code.
+package commandasyncemitcallerfixture
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/runtime/command"
+)
+
+// dispatchID is a bare command DispatchID a cell should never name directly —
+// the generated wrapper bakes it in.
+const dispatchID command.CommandID = "command.devicecommand.enqueue.v1"
+
+type payload struct {
+	Foo string `json:"foo"`
+}
+
+// BadEmitAsync calls runtime command.EmitAsync directly with a bare DispatchID,
+// bypassing the generated per-command EmitAsync wrapper — the primary bypass.
+func BadEmitAsync(ctx context.Context, emitter kout.Emitter) error {
+	return command.EmitAsync(ctx, clock.Real(), emitter, dispatchID,
+		"subject", "cmd-1", payload{Foo: "bar"})
+}
+
+// BadEmitAsyncFromIdempotencyKey calls the HTTP-bridge exit directly with a bare
+// DispatchID — the second bypass the funnel must close.
+func BadEmitAsyncFromIdempotencyKey(ctx context.Context, emitter kout.Emitter) error {
+	return command.EmitAsyncFromIdempotencyKey(ctx, clock.Real(), emitter, dispatchID,
+		"subject", payload{Foo: "bar"})
+}

--- a/tools/codegen/contractgen/command_render_test.go
+++ b/tools/codegen/contractgen/command_render_test.go
@@ -127,11 +127,12 @@ func TestRender_Command_ContainsKeySymbols(t *testing.T) {
 		// #2059 producer wrappers: per-command typed EmitAsync +
 		// EmitAsyncFromIdempotencyKey that bake DispatchID + lock the payload to
 		// *Request (symmetric to consumer DispatchAsync; callers locked by archtest
-		// COMMAND-ASYNC-EMIT-CALLER-01).
-		{"EmitAsync producer wrapper", "func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error"},
-		{"EmitAsync delegates to runtime", "return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)"},
-		{"EmitAsyncFromIdempotencyKey producer wrapper", "func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *Request, opts ...command.EmitOption) error"},
-		{"EmitAsyncFromIdempotencyKey delegates to runtime", "return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)"},
+		// COMMAND-ASYNC-EMIT-CALLER-01). Fragments kept short for lll; the full
+		// signatures are byte-locked by the golden test above.
+		{"EmitAsync wrapper", "func EmitAsync(ctx context.Context, clk clock.Clock,"},
+		{"EmitAsync bakes DispatchID", "command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)"},
+		{"EmitFromIdemKey wrapper", "func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock,"},
+		{"EmitFromIdemKey bakes DispatchID", "command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)"},
 		{"clock import", `"github.com/ghbvf/gocell/framework/kernel/clock"`},
 		// #1588 value funnel: unconditional request-schema embed + validator +
 		// the DispatchAsync Validate call (the async command-entry value check).

--- a/tools/codegen/contractgen/command_render_test.go
+++ b/tools/codegen/contractgen/command_render_test.go
@@ -124,6 +124,15 @@ func TestRender_Command_ContainsKeySymbols(t *testing.T) {
 		{"Dispatch func", "func Dispatch(ctx context.Context, reg *command.Registry, req *Request) (*Response, error)"},
 		{"AsyncDispatchFunc assert", "var _ command.AsyncDispatchFunc = DispatchAsync"},
 		{"DispatchAsync func", "func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry) error"},
+		// #2059 producer wrappers: per-command typed EmitAsync +
+		// EmitAsyncFromIdempotencyKey that bake DispatchID + lock the payload to
+		// *Request (symmetric to consumer DispatchAsync; callers locked by archtest
+		// COMMAND-ASYNC-EMIT-CALLER-01).
+		{"EmitAsync producer wrapper", "func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error"},
+		{"EmitAsync delegates to runtime", "return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)"},
+		{"EmitAsyncFromIdempotencyKey producer wrapper", "func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *Request, opts ...command.EmitOption) error"},
+		{"EmitAsyncFromIdempotencyKey delegates to runtime", "return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)"},
+		{"clock import", `"github.com/ghbvf/gocell/framework/kernel/clock"`},
 		// #1588 value funnel: unconditional request-schema embed + validator +
 		// the DispatchAsync Validate call (the async command-entry value check).
 		{"requestSchemaJSON embed", "var requestSchemaJSON = []byte("},

--- a/tools/codegen/contractgen/command_render_test.go
+++ b/tools/codegen/contractgen/command_render_test.go
@@ -133,6 +133,10 @@ func TestRender_Command_ContainsKeySymbols(t *testing.T) {
 		{"EmitAsync bakes DispatchID", "command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)"},
 		{"EmitFromIdemKey wrapper", "func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock,"},
 		{"EmitFromIdemKey bakes DispatchID", "command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)"},
+		// #2059 F1: both producer wrappers fail-fast on nil request (mirror Dispatch)
+		// so a nil *Request never becomes a `null` outbox poison entry.
+		{"EmitAsync nil-req guard", `"command.synth.do.v1 emit async: request must not be nil"`},
+		{"EmitFromIdemKey nil-req guard", `"command.synth.do.v1 emit async (idempotency-key): request must not be nil"`},
 		{"clock import", `"github.com/ghbvf/gocell/framework/kernel/clock"`},
 		// #1588 value funnel: unconditional request-schema embed + validator +
 		// the DispatchAsync Validate call (the async command-entry value check).

--- a/tools/codegen/contractgen/templates/command.tmpl
+++ b/tools/codegen/contractgen/templates/command.tmpl
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/ghbvf/gocell/framework/kernel/clock"
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/idutil"
@@ -201,4 +202,31 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 	}
 	_, err := h.{{.Command.HandlerMethod}}(ctx, &req)
 	return err
+}
+
+// EmitAsync enqueues a {{.ContractID}} async command through the sanctioned
+// runtime command emit funnel. It is the producer-side counterpart of
+// DispatchAsync: it bakes in DispatchID (the cell never names the raw routing
+// topic) and locks the payload to the typed *{{.Command.RequestGoType}}, so a
+// bare-DispatchID dispatch is unexpressible at the call site.
+//
+// subject and commandID are the idempotency identity slot the relay's Claimer
+// wrap reads (subject = the dedup aggregate, e.g. deviceID; commandID = the
+// per-instance identity). opts is additive — pass command.WithActiveUniqueness
+// to opt into queue active-uniqueness. The funnel is locked by archtest
+// COMMAND-ASYNC-EMIT-CALLER-01 (symmetric to the consumer-side
+// COMMAND-ASYNC-DISPATCH-CALLER-01).
+func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *{{.Command.RequestGoType}}, opts ...command.EmitOption) error {
+	return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)
+}
+
+// EmitAsyncFromIdempotencyKey enqueues a {{.ContractID}} async command sourcing
+// the per-instance commandID from the validated HTTP Idempotency-Key in ctx
+// (the #1610 bridge), instead of taking commandID as a parameter. Like EmitAsync
+// it bakes in DispatchID and locks the payload to *{{.Command.RequestGoType}};
+// because commandID is derived from the sealed ctx identity, the subject/commandID
+// transpose footgun is structurally inexpressible on this HTTP-sourced path.
+// Callers are locked by archtest COMMAND-ASYNC-EMIT-CALLER-01.
+func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *{{.Command.RequestGoType}}, opts ...command.EmitOption) error {
+	return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)
 }

--- a/tools/codegen/contractgen/templates/command.tmpl
+++ b/tools/codegen/contractgen/templates/command.tmpl
@@ -216,7 +216,16 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 // to opt into queue active-uniqueness. The funnel is locked by archtest
 // COMMAND-ASYNC-EMIT-CALLER-01 (symmetric to the consumer-side
 // COMMAND-ASYNC-DISPATCH-CALLER-01).
+//
+// Returns KindInvalid / ErrValidationFailed when req is nil (mirrors Dispatch):
+// a nil *{{.Command.RequestGoType}} would otherwise marshal to a `null` payload
+// and enter the outbox as a poison entry that only fails at the relay
+// (DispatchAsync schema-validate → MarkDead). Fail fast at the producer instead.
 func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *{{.Command.RequestGoType}}, opts ...command.EmitOption) error {
+	if req == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"{{.Command.DispatchID}} emit async: request must not be nil")
+	}
 	return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)
 }
 
@@ -227,6 +236,14 @@ func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subje
 // because commandID is derived from the sealed ctx identity, the subject/commandID
 // transpose footgun is structurally inexpressible on this HTTP-sourced path.
 // Callers are locked by archtest COMMAND-ASYNC-EMIT-CALLER-01.
+//
+// Returns KindInvalid / ErrValidationFailed when req is nil (mirrors Dispatch and
+// EmitAsync): a nil request must fail fast at the producer, not become a `null`
+// outbox poison entry.
 func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *{{.Command.RequestGoType}}, opts ...command.EmitOption) error {
+	if req == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"{{.Command.DispatchID}} emit async (idempotency-key): request must not be nil")
+	}
 	return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)
 }

--- a/tools/codegen/contractgen/testdata/golden/synth_command_command_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_command_command_gen_go.golden
@@ -217,7 +217,16 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 // to opt into queue active-uniqueness. The funnel is locked by archtest
 // COMMAND-ASYNC-EMIT-CALLER-01 (symmetric to the consumer-side
 // COMMAND-ASYNC-DISPATCH-CALLER-01).
+//
+// Returns KindInvalid / ErrValidationFailed when req is nil (mirrors Dispatch):
+// a nil *Request would otherwise marshal to a `null` payload
+// and enter the outbox as a poison entry that only fails at the relay
+// (DispatchAsync schema-validate → MarkDead). Fail fast at the producer instead.
 func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error {
+	if req == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"command.synth.do.v1 emit async: request must not be nil")
+	}
 	return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)
 }
 
@@ -228,6 +237,14 @@ func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subje
 // because commandID is derived from the sealed ctx identity, the subject/commandID
 // transpose footgun is structurally inexpressible on this HTTP-sourced path.
 // Callers are locked by archtest COMMAND-ASYNC-EMIT-CALLER-01.
+//
+// Returns KindInvalid / ErrValidationFailed when req is nil (mirrors Dispatch and
+// EmitAsync): a nil request must fail fast at the producer, not become a `null`
+// outbox poison entry.
 func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *Request, opts ...command.EmitOption) error {
+	if req == nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"command.synth.do.v1 emit async (idempotency-key): request must not be nil")
+	}
 	return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)
 }

--- a/tools/codegen/contractgen/testdata/golden/synth_command_command_gen_go.golden
+++ b/tools/codegen/contractgen/testdata/golden/synth_command_command_gen_go.golden
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/ghbvf/gocell/framework/kernel/clock"
 	kout "github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/idutil"
@@ -202,4 +203,31 @@ func DispatchAsync(ctx context.Context, reg *command.Registry, entry kout.Entry)
 	}
 	_, err := h.HandleDo(ctx, &req)
 	return err
+}
+
+// EmitAsync enqueues a command.synth.do.v1 async command through the sanctioned
+// runtime command emit funnel. It is the producer-side counterpart of
+// DispatchAsync: it bakes in DispatchID (the cell never names the raw routing
+// topic) and locks the payload to the typed *Request, so a
+// bare-DispatchID dispatch is unexpressible at the call site.
+//
+// subject and commandID are the idempotency identity slot the relay's Claimer
+// wrap reads (subject = the dedup aggregate, e.g. deviceID; commandID = the
+// per-instance identity). opts is additive — pass command.WithActiveUniqueness
+// to opt into queue active-uniqueness. The funnel is locked by archtest
+// COMMAND-ASYNC-EMIT-CALLER-01 (symmetric to the consumer-side
+// COMMAND-ASYNC-DISPATCH-CALLER-01).
+func EmitAsync(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject, commandID string, req *Request, opts ...command.EmitOption) error {
+	return command.EmitAsync(ctx, clk, emitter, DispatchID, subject, commandID, req, opts...)
+}
+
+// EmitAsyncFromIdempotencyKey enqueues a command.synth.do.v1 async command sourcing
+// the per-instance commandID from the validated HTTP Idempotency-Key in ctx
+// (the #1610 bridge), instead of taking commandID as a parameter. Like EmitAsync
+// it bakes in DispatchID and locks the payload to *Request;
+// because commandID is derived from the sealed ctx identity, the subject/commandID
+// transpose footgun is structurally inexpressible on this HTTP-sourced path.
+// Callers are locked by archtest COMMAND-ASYNC-EMIT-CALLER-01.
+func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock, emitter kout.Emitter, subject string, req *Request, opts ...command.EmitOption) error {
+	return command.EmitAsyncFromIdempotencyKey(ctx, clk, emitter, DispatchID, subject, req, opts...)
 }


### PR DESCRIPTION
## Summary

为每个 `kind=command` 契约 codegen 生成 producer 侧 typed wrapper（`EmitAsync` + `EmitAsyncFromIdempotencyKey`），cell 不再直调 runtime `command.EmitAsync` / 裸 `DispatchID`；新增对称 archtest `COMMAND-ASYNC-EMIT-CALLER-01` 锁两个 runtime emit 出口的调用方为 generated/runtime。

## Why / 背景

- 承接 #2059（#1674 body §重构档 + #1698 reconcile 决议）。consumer 侧已是生成式 `DispatchAsync` + 双 caller-funnel（REGISTER-CALLER + ASYNC-DISPATCH-CALLER），producer 侧仍手调 runtime `command.EmitAsync(…, cmdenqueue.DispatchID, …)`（裸 DispatchID + 手填 subject/commandID — runtime godoc 自述的 transpose footgun 面）。本 PR 补齐 producer 侧生成式收口，使两侧对称。
- **flag-cond 触发条件未满足，用户显式 override（诚实记录）**：#2059 触发条件是「≥2 个产异步命令的 cell」，当前仍只有 1 个（devicecell，三 slice 共用同一契约）。用户在知悉「单 producer cell 投机抽象/YAGNI」后**显式裁定提前实施**「彻底」档。详见 ADR `§Amendment 2026-06-15(#2059)`。
- 预期结果：`业务 → 生成 <cmd>.EmitAsync wrapper → runtime command.EmitAsync → outbox.NewEntry` 三层嵌套 funnel，裸字符串 dispatch 经生成路径不可表达。

## Refs

- Closes #2059
- 同批核实关闭 #1787（`[IOTDEVICE-CODEGEN-TRUE]`，前提已失效——目标 contract.yaml 在 origin/develop 上已无 `codegen` 键、guard `CONTRACT-YAML-NO-CODEGEN-TRUE-LITERAL-01` 已生效；无残留可删，非本 PR 代码改动）
- ADR amendment：`docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md` §Amendment 2026-06-15(#2059)（§4 矩阵新增第 5 行 + §7 索引 + 威胁矩阵逐行重评）
- ref: `COMMAND-ASYNC-DISPATCH-CALLER-01`（consumer 孪生 funnel）

## Risk / 兼容性

- **无 wire 契约变更**：未改 `command.devicecommand.enqueue.v1` 的 contract.yaml / request·response schema / version。生成 wrapper 是**同一命令契约的派生产物**（消费方，非 wire 契约本身）。
- 无 migration / 无 errcode / 无 sealed `Entry` 变更；未触发 contract-fanout 跨 cell wire 5 载体。
- 三处生产调用点（devicecell 三 slice）随本 PR **原子迁移**到生成 wrapper；无外部消费方。
- AI-robust：wrapper 存在性 = **Hard**（codegen + golden 字节锁）；caller funnel = **Medium**（Go 无 friend-package 永久天花板，同 EMIT-FUNNEL / #851 / #893 / #1282 族；**不开伪 Hard-升级 issue**）。

### Implementation matrix（contract-fanout）

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| producer wrapper codegen | 不动 schema/wire | `command_gen.go` +`EmitAsync`/`EmitAsyncFromIdempotencyKey`；synth golden 重生成（一等审查材料） | devicebootstrap / devicecertrenewal / devicecmd 三调用点迁移 | 新 archtest `COMMAND-ASYNC-EMIT-CALLER-01` + RED fixture（两出口各一 violation）+ render 符号检查 | `eventbus.md` §Command dispatch + ADR amendment |

## Test plan

- [x] `go build ./...` 本地通过（generated / tools / examples/iotdevice / cmd/gocell / cellmodules）
- [x] `go test ./修改的包/...` 本地通过（contractgen golden + 全 devicecell 包 + 新 archtest `COMMAND-ASYNC-EMIT-CALLER-01` GREEN，sibling funnel 无回归）
- [x] `golangci-lint run ./...` 0 issues（iotdevice / tools 触发包）+ gofumpt clean
- [x] `gocell generate contract --all` 无 stale（generated diff 仅 `command_gen.go` +28 行）
- [x] 回归：`grep` 零直调 runtime emit 出口（三调用点全走生成 wrapper）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
