### PR TITLE
feat(certsigning): runtime/certsigning CA 签发接缝 + sealed 类型 + funnel [PR-5/#1895]

### DIFF
--- a/framework/pkg/errcode/errcode.go
+++ b/framework/pkg/errcode/errcode.go
@@ -74,7 +74,23 @@ const (
 	ErrOrderNotFound           Code = "ERR_ORDER_NOT_FOUND"
 	ErrDeviceNotFound          Code = "ERR_DEVICE_NOT_FOUND"
 	ErrCommandNotFound         Code = "ERR_COMMAND_NOT_FOUND"
-	ErrAdapterPGNoTx           Code = "ERR_ADAPTER_PG_NO_TX"
+	// ERR_CERT_ namespace (Epic #1895 PR-5, runtime/certsigning). PR-5 mints only
+	// the construction-validation codes below; signing / revocation runtime codes
+	// (cross-scope denial, sign failure) land with their producing implementation
+	// (softca / PG, PR-6).
+	//
+	// ErrCertScopeInvalid signals an invalid CertScope / IssuerID / DeviceID /
+	// Serial construction (empty dimension, non-hex serial, non-canonical tenant).
+	// Constructed with KindInvalid → HTTP 400.
+	ErrCertScopeInvalid Code = "ERR_CERT_SCOPE_INVALID"
+	// ErrCertRequestInvalid signals an invalid CertRequest / DeviceSubject /
+	// SubjectAltNames / KeyUsages / SignConstraints (unparseable CSR, blank SAN,
+	// empty usage, non-positive TTL). Constructed with KindInvalid → HTTP 400.
+	ErrCertRequestInvalid Code = "ERR_CERT_REQUEST_INVALID"
+	// ErrCertIssuedInvalid signals an invalid IssuedCert reconstruction (empty or
+	// unparseable certificate DER). Constructed with KindInvalid → HTTP 400.
+	ErrCertIssuedInvalid Code = "ERR_CERT_ISSUED_INVALID"
+	ErrAdapterPGNoTx     Code = "ERR_ADAPTER_PG_NO_TX"
 	// ErrPGSchemaShape signals that a value read from a PostgreSQL column does
 	// not conform to the expected schema shape — e.g., an enum column returned a
 	// value not in the application's known set. Usable from both adapters/postgres

--- a/framework/pkg/errcode/errcode.go
+++ b/framework/pkg/errcode/errcode.go
@@ -90,7 +90,15 @@ const (
 	// ErrCertIssuedInvalid signals an invalid IssuedCert reconstruction (empty or
 	// unparseable certificate DER). Constructed with KindInvalid → HTTP 400.
 	ErrCertIssuedInvalid Code = "ERR_CERT_ISSUED_INVALID"
-	ErrAdapterPGNoTx     Code = "ERR_ADAPTER_PG_NO_TX"
+	// ErrCertAuthorizeDenied signals that an AuthorizedCertRequest was built from a
+	// non-granted SignConstraints (authorization was not granted). Constructed with
+	// KindPermissionDenied → HTTP 403.
+	ErrCertAuthorizeDenied Code = "ERR_CERT_AUTHORIZE_DENIED"
+	// ErrCertConstraintViolation signals that a request exceeds its granted signing
+	// constraints (TTL above the granted max, or a SAN outside the granted
+	// allowance). Constructed with KindPermissionDenied → HTTP 403.
+	ErrCertConstraintViolation Code = "ERR_CERT_CONSTRAINT_VIOLATION"
+	ErrAdapterPGNoTx           Code = "ERR_ADAPTER_PG_NO_TX"
 	// ErrPGSchemaShape signals that a value read from a PostgreSQL column does
 	// not conform to the expected schema shape — e.g., an enum column returned a
 	// value not in the application's known set. Usable from both adapters/postgres

--- a/framework/pkg/errcode/prefix_registry.go
+++ b/framework/pkg/errcode/prefix_registry.go
@@ -271,6 +271,7 @@ var gocellPlatformPrefixes = []string{
 	"ERR_ZERO_TEST_MATCH",
 
 	// ── Namespace entries for single-code subsystem segments (subsystem nouns) ──
+	"ERR_CERT_",
 	"ERR_COMMAND_",
 	"ERR_DEVICE_",
 	"ERR_ORDER_",

--- a/framework/pkg/errcode/testdata/prefix_set.golden
+++ b/framework/pkg/errcode/testdata/prefix_set.golden
@@ -7,6 +7,7 @@ ERR_BODY_TOO_LARGE	github.com/ghbvf/gocell
 ERR_BOOTSTRAP_	github.com/ghbvf/gocell
 ERR_BUS_	github.com/ghbvf/gocell
 ERR_CELL_	github.com/ghbvf/gocell
+ERR_CERT_	github.com/ghbvf/gocell
 ERR_CHECKREF_	github.com/ghbvf/gocell
 ERR_CIRCUIT_	github.com/ghbvf/gocell
 ERR_CLIENT_	github.com/ghbvf/gocell

--- a/framework/runtime/certsigning/authorizer.go
+++ b/framework/runtime/certsigning/authorizer.go
@@ -1,0 +1,83 @@
+package certsigning
+
+import (
+	"context"
+	"time"
+)
+
+// EnrollmentClaim is the sealed enrollment assertion presented to an
+// [Authorizer]: which device (subject) under which isolation scope is asking for
+// a certificate. It is a cross-boundary input decoded from an EST / SCEP
+// front-end, so it is sealed (unexported fields + sole [NewEnrollmentClaim]
+// minter) to prevent forging an elevated claim by composite literal.
+type EnrollmentClaim struct {
+	scope   CertScope
+	subject DeviceSubject
+}
+
+// NewEnrollmentClaim returns a sealed EnrollmentClaim. The scope and subject
+// must be non-zero; a claim cannot omit who is asking or under which isolation
+// domain (fail-closed).
+func NewEnrollmentClaim(scope CertScope, subject DeviceSubject) (EnrollmentClaim, error) {
+	if scope.IsZero() {
+		return EnrollmentClaim{}, errCertRequestInvalid("enrollment scope must not be empty")
+	}
+	if subject.IsZero() {
+		return EnrollmentClaim{}, errCertRequestInvalid("enrollment subject must not be empty")
+	}
+	return EnrollmentClaim{scope: scope, subject: subject}, nil
+}
+
+// Scope returns the enrollment isolation scope.
+func (c EnrollmentClaim) Scope() CertScope { return c.scope }
+
+// Subject returns the enrolling device subject.
+func (c EnrollmentClaim) Subject() DeviceSubject { return c.subject }
+
+// SignConstraints is the sealed obligation an [Authorizer] returns on a granted
+// enrollment and a [Signer] MUST enforce: the maximum certificate TTL and the
+// allowed SANs. It is fail-closed by construction — the zero value is NOT
+// granted ([SignConstraints.Granted] reports false), so an Authorizer that
+// returns a zero SignConstraints (nil grant) denies signing rather than
+// silently permitting an unconstrained certificate. Only [NewSignConstraints]
+// mints a granted value.
+type SignConstraints struct {
+	granted     bool
+	maxTTL      time.Duration
+	allowedSANs SubjectAltNames
+}
+
+// NewSignConstraints returns a granted SignConstraints with a positive maximum
+// TTL and the allowed SAN set. A non-positive maxTTL is rejected — a granted
+// constraint with no positive lifetime ceiling is meaningless.
+func NewSignConstraints(maxTTL time.Duration, allowedSANs SubjectAltNames) (SignConstraints, error) {
+	if maxTTL <= 0 {
+		return SignConstraints{}, errCertRequestInvalid("max ttl must be positive")
+	}
+	return SignConstraints{granted: true, maxTTL: maxTTL, allowedSANs: allowedSANs}, nil
+}
+
+// Granted reports whether these constraints authorize signing. The zero value
+// returns false (fail-closed): a Signer must refuse unless Granted is true.
+func (c SignConstraints) Granted() bool { return c.granted }
+
+// MaxTTL returns the maximum certificate lifetime the Signer may grant.
+func (c SignConstraints) MaxTTL() time.Duration { return c.maxTTL }
+
+// AllowedSANs returns the SANs the Signer may include.
+func (c SignConstraints) AllowedSANs() SubjectAltNames { return c.allowedSANs }
+
+// Authorizer decides whether a device may obtain a certificate and, on a grant,
+// returns the [SignConstraints] the [Signer] must enforce. It is INDEPENDENT of
+// Signer (reusing the existing PDP): separating "may enroll" from "sign the
+// CSR" keeps an authorization defect from widening into unauthorized signing.
+//
+// Authorization is fail-closed: an implementation denies by returning an error
+// OR a zero (not-granted) SignConstraints; a Signer must verify Granted before
+// minting.
+type Authorizer interface {
+	// AuthorizeEnroll evaluates claim and returns the signing constraints on a
+	// grant. A nil-grant outcome is expressed as a non-granted SignConstraints
+	// (or an error) — never an unconstrained permit.
+	AuthorizeEnroll(ctx context.Context, claim EnrollmentClaim) (SignConstraints, error)
+}

--- a/framework/runtime/certsigning/authorizer.go
+++ b/framework/runtime/certsigning/authorizer.go
@@ -50,6 +50,11 @@ type SignConstraints struct {
 // NewSignConstraints returns a granted SignConstraints with a positive maximum
 // TTL and the allowed SAN set. A non-positive maxTTL is rejected — a granted
 // constraint with no positive lifetime ceiling is meaningless.
+//
+// Allowed-SAN semantics are deny-by-default: an empty allowedSANs
+// ([SubjectAltNames.IsEmpty] true) means the Signer MUST NOT include any SAN —
+// a request carrying SANs is rejected. To permit SANs the Authorizer must
+// enumerate them explicitly. (An empty set is NOT "any SAN allowed".)
 func NewSignConstraints(maxTTL time.Duration, allowedSANs SubjectAltNames) (SignConstraints, error) {
 	if maxTTL <= 0 {
 		return SignConstraints{}, errCertRequestInvalid("max ttl must be positive")
@@ -64,7 +69,8 @@ func (c SignConstraints) Granted() bool { return c.granted }
 // MaxTTL returns the maximum certificate lifetime the Signer may grant.
 func (c SignConstraints) MaxTTL() time.Duration { return c.maxTTL }
 
-// AllowedSANs returns the SANs the Signer may include.
+// AllowedSANs returns the SANs the Signer may include. Deny-by-default: an empty
+// result means no SAN is permitted (see [NewSignConstraints]).
 func (c SignConstraints) AllowedSANs() SubjectAltNames { return c.allowedSANs }
 
 // Authorizer decides whether a device may obtain a certificate and, on a grant,

--- a/framework/runtime/certsigning/authorizer.go
+++ b/framework/runtime/certsigning/authorizer.go
@@ -25,6 +25,9 @@ func NewEnrollmentClaim(scope CertScope, subject DeviceSubject) (EnrollmentClaim
 	if subject.IsZero() {
 		return EnrollmentClaim{}, errCertRequestInvalid("enrollment subject must not be empty")
 	}
+	if err := requireSameOrigin(scope, subject); err != nil {
+		return EnrollmentClaim{}, err
+	}
 	return EnrollmentClaim{scope: scope, subject: subject}, nil
 }
 
@@ -87,3 +90,46 @@ type Authorizer interface {
 	// (or an error) — never an unconstrained permit.
 	AuthorizeEnroll(ctx context.Context, claim EnrollmentClaim) (SignConstraints, error)
 }
+
+// AuthorizedCertRequest is a sealed signing request that has PASSED authorization:
+// it can only be minted by [NewAuthorizedCertRequest] from a [CertRequest] plus a
+// granted [SignConstraints], so a [Signer] can never be handed an un-authorized
+// request. This carries the Authorizer's grant INTO the signing funnel as a
+// type-level fact — the cert-manager/step-ca pattern (authorize produces
+// constraints, sign enforces them), strengthened by Go's type system: there is
+// no way to construct this value without satisfying the grant. The single field
+// is unexported; the grant's obligations are enforced at construction, so an
+// AuthorizedCertRequest is provably within its authorization.
+type AuthorizedCertRequest struct {
+	req CertRequest
+}
+
+// NewAuthorizedCertRequest combines a validated CertRequest with a granted
+// SignConstraints, enforcing the authorization obligations fail-closed:
+//   - the grant MUST be Granted (a zero / denied SignConstraints is rejected);
+//   - the request TTL MUST NOT exceed the granted MaxTTL;
+//   - every requested SAN MUST be within the granted AllowedSANs (deny-by-default:
+//     an empty AllowedSANs permits no SAN).
+//
+// The result is the only value [Signer.Sign] accepts, so these checks cannot be
+// skipped on the path to issuance (FR-005: SignConstraints enforced by the Signer
+// boundary).
+func NewAuthorizedCertRequest(req CertRequest, grant SignConstraints) (AuthorizedCertRequest, error) {
+	if req.Scope().IsZero() {
+		return AuthorizedCertRequest{}, errCertRequestInvalid("authorized request requires a valid request")
+	}
+	if !grant.Granted() {
+		return AuthorizedCertRequest{}, errCertAuthorizeDenied("authorization not granted")
+	}
+	if req.TTL() > grant.MaxTTL() {
+		return AuthorizedCertRequest{}, errCertConstraintViolation("requested ttl exceeds granted max ttl")
+	}
+	if !req.SubjectAltNames().subsetOf(grant.AllowedSANs()) {
+		return AuthorizedCertRequest{}, errCertConstraintViolation("requested SAN outside granted allowance")
+	}
+	return AuthorizedCertRequest{req: req}, nil
+}
+
+// Request returns the authorized underlying request for the Signer to sign. Its
+// TTL and SANs are provably within the grant that minted this value.
+func (a AuthorizedCertRequest) Request() CertRequest { return a.req }

--- a/framework/runtime/certsigning/authorizer_test.go
+++ b/framework/runtime/certsigning/authorizer_test.go
@@ -1,0 +1,108 @@
+package certsigning_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+func TestNewEnrollmentClaim(t *testing.T) {
+	t.Parallel()
+	scope := mustScope(t)
+	dev, _ := cs.NewDeviceID("device-1")
+	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		claim, err := cs.NewEnrollmentClaim(scope, subject)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if claim.Scope() != scope || claim.Subject() != subject {
+			t.Error("claim accessors mismatch")
+		}
+	})
+	t.Run("zero scope", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewEnrollmentClaim(cs.CertScope{}, subject)
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("zero subject", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewEnrollmentClaim(scope, cs.DeviceSubject{})
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+}
+
+func TestSignConstraintsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	// The zero value is the fail-closed deny: a Signer must refuse unless Granted.
+	var zero cs.SignConstraints
+	if zero.Granted() {
+		t.Fatal("zero SignConstraints must NOT be granted (fail-closed)")
+	}
+
+	t.Run("non-positive ttl rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewSignConstraints(0, cs.SubjectAltNames{})
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+
+	t.Run("granted constraints", func(t *testing.T) {
+		t.Parallel()
+		sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
+		c, err := cs.NewSignConstraints(2*time.Hour, sans)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if !c.Granted() || c.MaxTTL() != 2*time.Hour {
+			t.Error("granted constraints accessors mismatch")
+		}
+		if c.AllowedSANs().IsEmpty() {
+			t.Error("allowed SANs should carry the entry")
+		}
+	})
+}
+
+// denyAuthorizer is a fake Authorizer that denies by returning the zero
+// (non-granted) SignConstraints — proving the interface's nil-grant fail-closed
+// contract is expressible without an error.
+type denyAuthorizer struct{}
+
+func (denyAuthorizer) AuthorizeEnroll(context.Context, cs.EnrollmentClaim) (cs.SignConstraints, error) {
+	return cs.SignConstraints{}, nil
+}
+
+// grantAuthorizer is a fake Authorizer that grants a bounded constraint.
+type grantAuthorizer struct{ maxTTL time.Duration }
+
+func (g grantAuthorizer) AuthorizeEnroll(context.Context, cs.EnrollmentClaim) (cs.SignConstraints, error) {
+	return cs.NewSignConstraints(g.maxTTL, cs.SubjectAltNames{})
+}
+
+func TestAuthorizerContract(t *testing.T) {
+	t.Parallel()
+	scope := mustScope(t)
+	dev, _ := cs.NewDeviceID("device-1")
+	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
+	claim, _ := cs.NewEnrollmentClaim(scope, subject)
+
+	var deny cs.Authorizer = denyAuthorizer{}
+	got, err := deny.AuthorizeEnroll(context.Background(), claim)
+	if err != nil {
+		t.Fatalf("deny authorizer error: %v", err)
+	}
+	if got.Granted() {
+		t.Error("deny authorizer must yield a non-granted constraint (fail-closed)")
+	}
+
+	var grant cs.Authorizer = grantAuthorizer{maxTTL: time.Hour}
+	got, err = grant.AuthorizeEnroll(context.Background(), claim)
+	if err != nil || !got.Granted() {
+		t.Fatalf("grant authorizer: %v granted=%v", err, got.Granted())
+	}
+}

--- a/framework/runtime/certsigning/authorizer_test.go
+++ b/framework/runtime/certsigning/authorizer_test.go
@@ -2,6 +2,9 @@ package certsigning_test
 
 import (
 	"context"
+	"crypto/x509"
+	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -9,9 +12,12 @@ import (
 	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
 
-// testGrantTTL is a site-specific granted max TTL. Per TEST-TIME-LITERAL-01, a
-// time.Duration expression containing a literal must be a package-level const.
-const testGrantTTL = 2 * time.Hour
+// Site-specific durations. Per TEST-TIME-LITERAL-01 a time.Duration expression
+// containing a literal must be a package-level const.
+const (
+	testGrantTTL = 2 * time.Hour
+	testTightTTL = 30 * time.Minute // < the requests' 1h TTL, to trip the TTL ceiling
+)
 
 func TestNewEnrollmentClaim(t *testing.T) {
 	t.Parallel()
@@ -37,6 +43,19 @@ func TestNewEnrollmentClaim(t *testing.T) {
 	t.Run("zero subject", func(t *testing.T) {
 		t.Parallel()
 		_, err := cs.NewEnrollmentClaim(scope, cs.DeviceSubject{})
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("cross-device subject rejected", func(t *testing.T) {
+		t.Parallel()
+		devB, _ := cs.NewDeviceID("device-2")
+		subjB, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), devB, "device-2")
+		_, err := cs.NewEnrollmentClaim(scope, subjB) // scope device-1 vs subject device-2
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("cross-tenant subject rejected", func(t *testing.T) {
+		t.Parallel()
+		subjB, _ := cs.NewDeviceSubject(mustTenant(t, testTenantB), dev, "device-1")
+		_, err := cs.NewEnrollmentClaim(scope, subjB) // scope tenant-A vs subject tenant-B
 		assertCode(t, err, errcode.ErrCertRequestInvalid)
 	})
 }
@@ -109,4 +128,80 @@ func TestAuthorizerContract(t *testing.T) {
 	if err != nil || !got.Granted() {
 		t.Fatalf("grant authorizer: %v granted=%v", err, got.Granted())
 	}
+}
+
+func TestNewAuthorizedCertRequest(t *testing.T) {
+	t.Parallel()
+	scope := mustScope(t)
+	dev, _ := cs.NewDeviceID("device-1")
+	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
+	usages, _ := cs.NewKeyUsages(x509.KeyUsageDigitalSignature)
+	sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
+	req, err := cs.NewCertRequest(scope, subject, testCSRDER(t), sans, usages, time.Hour)
+	if err != nil {
+		t.Fatalf("req: %v", err)
+	}
+
+	t.Run("granted within constraints", func(t *testing.T) {
+		t.Parallel()
+		grant, _ := cs.NewSignConstraints(testGrantTTL, sans)
+		auth, err := cs.NewAuthorizedCertRequest(req, grant)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if auth.Request().Scope() != scope {
+			t.Error("authorized request must carry the underlying request")
+		}
+	})
+	t.Run("not granted denied", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewAuthorizedCertRequest(req, cs.SignConstraints{}) // zero = not granted
+		assertCode(t, err, errcode.ErrCertAuthorizeDenied)
+	})
+	t.Run("ttl exceeds granted max", func(t *testing.T) {
+		t.Parallel()
+		grant, _ := cs.NewSignConstraints(testTightTTL, sans) // 30m < req 1h
+		_, err := cs.NewAuthorizedCertRequest(req, grant)
+		assertCode(t, err, errcode.ErrCertConstraintViolation)
+	})
+	t.Run("san outside granted allowance", func(t *testing.T) {
+		t.Parallel()
+		grant, _ := cs.NewSignConstraints(testGrantTTL, cs.SubjectAltNames{}) // empty = deny-by-default
+		_, err := cs.NewAuthorizedCertRequest(req, grant)
+		assertCode(t, err, errcode.ErrCertConstraintViolation)
+	})
+	t.Run("ip and uri SAN allowance enforced", func(t *testing.T) {
+		t.Parallel()
+		ip := net.ParseIP("10.1.2.3")
+		uri := &url.URL{Scheme: "spiffe", Host: "td", Path: "/dev"}
+		reqSANs, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, []net.IP{ip}, []*url.URL{uri})
+		r, err := cs.NewCertRequest(scope, subject, testCSRDER(t), reqSANs, usages, time.Hour)
+		if err != nil {
+			t.Fatalf("req: %v", err)
+		}
+		// Allowing exactly the requested DNS+IP+URI → granted.
+		okGrant, _ := cs.NewSignConstraints(testGrantTTL, reqSANs)
+		if _, err := cs.NewAuthorizedCertRequest(r, okGrant); err != nil {
+			t.Errorf("IP/URI within allowance should be granted: %v", err)
+		}
+		// Allowing only DNS (no IP/URI) → the IP SAN is outside allowance → violation.
+		dnsOnly, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
+		_, err = cs.NewAuthorizedCertRequest(r, mustGrant(t, dnsOnly))
+		assertCode(t, err, errcode.ErrCertConstraintViolation)
+	})
+	t.Run("zero request rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewAuthorizedCertRequest(cs.CertRequest{}, mustGrant(t, sans))
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+}
+
+// mustGrant builds a granted SignConstraints for tests.
+func mustGrant(t *testing.T, allowed cs.SubjectAltNames) cs.SignConstraints {
+	t.Helper()
+	g, err := cs.NewSignConstraints(testGrantTTL, allowed)
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	return g
 }

--- a/framework/runtime/certsigning/authorizer_test.go
+++ b/framework/runtime/certsigning/authorizer_test.go
@@ -9,6 +9,10 @@ import (
 	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
 
+// testGrantTTL is a site-specific granted max TTL. Per TEST-TIME-LITERAL-01, a
+// time.Duration expression containing a literal must be a package-level const.
+const testGrantTTL = 2 * time.Hour
+
 func TestNewEnrollmentClaim(t *testing.T) {
 	t.Parallel()
 	scope := mustScope(t)
@@ -55,11 +59,11 @@ func TestSignConstraintsFailClosed(t *testing.T) {
 	t.Run("granted constraints", func(t *testing.T) {
 		t.Parallel()
 		sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
-		c, err := cs.NewSignConstraints(2*time.Hour, sans)
+		c, err := cs.NewSignConstraints(testGrantTTL, sans)
 		if err != nil {
 			t.Fatalf("unexpected: %v", err)
 		}
-		if !c.Granted() || c.MaxTTL() != 2*time.Hour {
+		if !c.Granted() || c.MaxTTL() != testGrantTTL {
 			t.Error("granted constraints accessors mismatch")
 		}
 		if c.AllowedSANs().IsEmpty() {

--- a/framework/runtime/certsigning/doc.go
+++ b/framework/runtime/certsigning/doc.go
@@ -38,6 +38,17 @@
 // serial is never a query key); specific-certificate lookup downstream must
 // carry a typed CertScope.
 //
+// CertScope requires a non-empty tenant by construction. A lifecycle reconciler
+// (PR-7) runs under the tenantless system identity (#1821 clears ctx tenant), so
+// it MUST source the tenant dimension from the scanned device row — NOT from
+// ctx — when building a CertScope / CertRequest; reading tenant from ctx there
+// would fail NewCertScope. This is the spec #1821 caveat's correct path.
+//
+// The Signer / Authorizer / RevocationStore interfaces are independent seams:
+// the composition root (PR-10) MAY bind them to different adapters (e.g. a Vault
+// PKI Signer with a PostgreSQL RevocationStore). Nothing here couples them to a
+// single provider.
+//
 // # Enforced invariants
 //
 // CERT-VALUE-SEALED-CONSTRUCTION-01 (Hard). Every cross-trust-boundary input and
@@ -52,6 +63,15 @@
 // NOT sealed: they carry no forgeable security boundary.) The archtest is the
 // reverse self-check that pins the seal against a regression that re-exports a
 // field or adds a second minter surface.
+//
+// Note: only POPULATED literals are blocked. A zero-value literal (e.g.
+// CertScope{}, SignConstraints{}) still compiles outside the package — Go
+// permits the empty literal of a struct with unexported fields. That is by
+// design and harmless: each sealed type's zero value is explicitly INVALID
+// (IsZero / !Granted), so a zero value is a fail-closed deny, never a usable
+// forgery (e.g. an Authorizer returning SignConstraints{} is a valid "deny"
+// path). Constructed (non-zero) values are the only valid ones, and the sealed
+// constructors guarantee they are well-formed.
 //
 // CERT-SIGN-FUNNEL-01 (funnel; upstream Hard, downstream Medium). Upstream Hard:
 // [IssuedCert] / [CertRequest] field sealing makes forged signing material

--- a/framework/runtime/certsigning/doc.go
+++ b/framework/runtime/certsigning/doc.go
@@ -53,9 +53,10 @@
 //
 // CERT-VALUE-SEALED-CONSTRUCTION-01 (Hard). Every cross-trust-boundary input and
 // minted-credential value type — [CertScope], [CertRequest], [IssuedCert],
-// [DeviceSubject], [SubjectAltNames], [KeyUsages], [SignConstraints],
-// [EnrollmentClaim], and the [IssuerID] / [DeviceID] / [Serial] newtypes — has
-// only unexported fields, so a populated composite literal of any of them
+// [AuthorizedCertRequest], [DeviceSubject], [SubjectAltNames], [KeyUsages],
+// [SignConstraints], [EnrollmentClaim], and the [IssuerID] / [DeviceID] /
+// [Serial] newtypes — has only unexported fields, so a populated composite
+// literal of any of them
 // outside this package is a Go compile error. Forging certificate material or
 // signing inputs is structurally unrepresentable; the sole minters are the
 // New* constructors, which validate fail-closed. (Read-only OUTPUT types —
@@ -83,6 +84,18 @@
 // caller-allowlist, NOT Hard — there is no low-cost Hard path while the adapter
 // is necessarily external. This is documented rather than packaged as a false
 // Hard.
+//
+// Authorization-into-the-funnel (Hard). [Signer.Sign] takes a sealed
+// [AuthorizedCertRequest], not a bare [CertRequest]. That value can only be
+// minted by [NewAuthorizedCertRequest], which fail-closed enforces the
+// Authorizer's grant (Granted, TTL ≤ MaxTTL, SAN ⊆ AllowedSANs) — so the
+// authorization obligation (FR-005) is carried into the signing funnel as a
+// compile-time fact: a Signer cannot be handed an un-authorized request. This is
+// the GoCell type-system strengthening of the open-source consensus (step-ca's
+// AuthorizeSign→SignOptions→Sign, SPIRE's authorized params→Sign) — the two
+// interfaces stay separate while the grant becomes unforgeable. An archtest
+// reverse self-check pins Signer.Sign's parameter to AuthorizedCertRequest (a
+// relaxation back to CertRequest fails CI).
 //
 // CERT-REVOKE-SCOPED-01 (Hard). [RevocationStore].Revoke / RevocationList / Tidy
 // take [CertScope] (and Revoke additionally [Serial]) as mandatory typed

--- a/framework/runtime/certsigning/doc.go
+++ b/framework/runtime/certsigning/doc.go
@@ -1,0 +1,85 @@
+// Package certsigning is the framework's certificate-signing control-plane seam
+// (Epic #1895 US2 PR-5 #1901): the CA signing interface, a protocol-agnostic
+// request model, and the single mint funnel for device certificates. It defines
+// the seam and its sealed value types ONLY — implementations land downstream
+// (adapters/softca PR-6, runtime/certlifecycle PR-7, the EST front-end PR-8b,
+// composition wiring PR-10).
+//
+// # Open-source alignment
+//
+// SPIRE ServerCA, cert-manager Sign, and step-ca Authority.Sign agree: the
+// control plane (request model + signing seam) belongs to the framework; the
+// signing private key (crypto.Signer) stays in an adapter and never crosses this
+// boundary; and authorization ([Authorizer], "may this device enroll") is a
+// SEPARATE interface from signing ([Signer], "sign this CSR"). This package
+// encodes that split.
+//
+//	ref: SPIRE pkg/server/ca (ServerCA.Sign* — signing seam, key never exported)
+//	ref: cert-manager pkg/controller/certificates (Authorize / Sign separation)
+//	ref: step-ca authority/sign.go (SignConstraints / provisioner claims)
+//
+// # Core security invariants
+//
+//   - The signing private key never enters kernel/runtime. This seam exposes a
+//     Sign operation and the trust bundle — never a key getter. (Key custody is
+//     enforced adapter-side by CERT-PRIVATE-KEY-CUSTODY-01, PR-6.)
+//   - [Signer.Sign] is the single sanctioned entry to mint a certificate, and
+//     [NewIssuedCert] is the single minter of the sealed result (CERT-SIGN-FUNNEL-01).
+//   - Signing and revocation share [CertScope] isolation: a bare serial never
+//     crosses an isolation domain (RFC 5280 — issuer + serial is the unique
+//     identity; serial alone is not). Revoke / RevocationList take CertScope as a
+//     mandatory typed positional parameter (CERT-REVOKE-SCOPED-01).
+//   - [Authorizer] and [Signer] are independent, so an authorization defect
+//     cannot widen into unauthorized signing. [SignConstraints] is fail-closed:
+//     its zero value is not granted.
+//
+// CertScope is also the isolation-invariant backstop for the #1899 status
+// contract narrowing (http.deviceidentity.status.v1 is deviceId-only — a raw
+// serial is never a query key); specific-certificate lookup downstream must
+// carry a typed CertScope.
+//
+// # Enforced invariants
+//
+// CERT-VALUE-SEALED-CONSTRUCTION-01 (Hard). Every cross-trust-boundary input and
+// minted-credential value type — [CertScope], [CertRequest], [IssuedCert],
+// [DeviceSubject], [SubjectAltNames], [KeyUsages], [SignConstraints],
+// [EnrollmentClaim], and the [IssuerID] / [DeviceID] / [Serial] newtypes — has
+// only unexported fields, so a populated composite literal of any of them
+// outside this package is a Go compile error. Forging certificate material or
+// signing inputs is structurally unrepresentable; the sole minters are the
+// New* constructors, which validate fail-closed. (Read-only OUTPUT types —
+// [RevokedCertificate], the [Signer.TrustBundle] DER slice — are intentionally
+// NOT sealed: they carry no forgeable security boundary.) The archtest is the
+// reverse self-check that pins the seal against a regression that re-exports a
+// field or adds a second minter surface.
+//
+// CERT-SIGN-FUNNEL-01 (funnel; upstream Hard, downstream Medium). Upstream Hard:
+// [IssuedCert] / [CertRequest] field sealing makes forged signing material
+// uncompilable. Downstream Medium: an archtest caller-allowlist restricts who
+// may invoke [NewIssuedCert] (the mint funnel) to the sanctioned signer adapter
+// (adapters/softca, PR-6; the allowlist is empty / forward in PR-5). Blind spot:
+// [NewIssuedCert] MUST be exported because the signing adapter lives outside this
+// package, so "only the sanctioned Signer mints certificates" is a Medium
+// caller-allowlist, NOT Hard — there is no low-cost Hard path while the adapter
+// is necessarily external. This is documented rather than packaged as a false
+// Hard.
+//
+// CERT-REVOKE-SCOPED-01 (Hard). [RevocationStore].Revoke / RevocationList / Tidy
+// take [CertScope] (and Revoke additionally [Serial]) as mandatory typed
+// positional parameters: omitting the scope is a compile error (arity) and
+// passing a raw string is a compile error (type). The compile-time type system
+// is the guarantee; the archtest is the reverse self-check / anti-vacuity that
+// fails if a refactor relaxes a signature back to a bare string or serial.
+//
+// Full invariant IDs, ratings, symbols, and blind spots are co-located in
+// tools/archtest/cert_invariants_test.go.
+//
+// # Layering
+//
+// runtime/certsigning depends only on the standard library, crypto/x509, and
+// framework/pkg (errcode, tenant). It defines interfaces an adapter implements;
+// it imports no adapter, cell, or wiring package.
+//
+//	ref: docs/plans/specs/1895-device-identity-cert-framework/spec.md FR-004..007
+//	ref: docs/architecture/202606130635-1939-adr-framework-owned-contract.md
+package certsigning

--- a/framework/runtime/certsigning/errors.go
+++ b/framework/runtime/certsigning/errors.go
@@ -5,13 +5,17 @@ import "github.com/ghbvf/gocell/framework/pkg/errcode"
 // Error codes minted by this package. The ERR_CERT_ namespace is registered in
 // framework/pkg/errcode (gocellPlatformPrefixes) and locked by
 // ERRCODE-PREFIX-OWNERSHIP-01; the golden prefix set is regenerated when the
-// namespace is added. PR-5 emits only the construction-validation codes below —
-// signing / revocation runtime codes (cross-scope denial, sign failure) land
-// with their producing implementation (softca / PG, PR-6).
+// namespace is added. PR-5 emits the construction-validation codes (scope /
+// request / issued invalid) plus the authorization-funnel codes (authorize
+// denied / constraint violation, enforced by NewAuthorizedCertRequest). The
+// signing-execution runtime codes (CA sign failure, cross-scope revocation
+// denial) land with their producing implementation (softca / PG, PR-6).
 const (
-	errCertScopeInvalidCode   = errcode.ErrCertScopeInvalid
-	errCertRequestInvalidCode = errcode.ErrCertRequestInvalid
-	errCertIssuedInvalidCode  = errcode.ErrCertIssuedInvalid
+	errCertScopeInvalidCode        = errcode.ErrCertScopeInvalid
+	errCertRequestInvalidCode      = errcode.ErrCertRequestInvalid
+	errCertIssuedInvalidCode       = errcode.ErrCertIssuedInvalid
+	errCertAuthorizeDeniedCode     = errcode.ErrCertAuthorizeDenied
+	errCertConstraintViolationCode = errcode.ErrCertConstraintViolation
 )
 
 // Const-literal messages (MESSAGE-CONST-LITERAL-01: errcode messages must be
@@ -22,9 +26,12 @@ const (
 	msgScopeInvalid         = "certsigning: invalid certificate scope"
 	msgRequestInvalid       = "certsigning: invalid certificate request"
 	msgIssuedInvalid        = "certsigning: invalid issued certificate"
+	msgAuthorizeDenied      = "certsigning: certificate enrollment not authorized"
+	msgConstraintViolation  = "certsigning: request exceeds granted signing constraints"
 	msgScopeTenantInvalid   = "certsigning: certificate scope tenant invalid"
 	msgSubjectTenantInvalid = "certsigning: certificate subject tenant invalid"
 	msgCSRUnparseable       = "certsigning: csr is not a valid PKCS#10 request"
+	msgCSRSignatureInvalid  = "certsigning: csr signature is invalid (proof-of-possession failed)"
 	msgCertUnparseable      = "certsigning: certificate is not valid DER"
 )
 
@@ -45,5 +52,19 @@ func errCertRequestInvalid(reason string) error {
 // unparseable certificate DER).
 func errCertIssuedInvalid(reason string) error {
 	return errcode.New(errcode.KindInvalid, errCertIssuedInvalidCode, msgIssuedInvalid,
+		errcode.WithInternal(errcode.InternalAttr("reason", reason)))
+}
+
+// errCertAuthorizeDenied reports that authorization was not granted for an
+// AuthorizedCertRequest. KindPermissionDenied → HTTP 403.
+func errCertAuthorizeDenied(reason string) error {
+	return errcode.New(errcode.KindPermissionDenied, errCertAuthorizeDeniedCode, msgAuthorizeDenied,
+		errcode.WithInternal(errcode.InternalAttr("reason", reason)))
+}
+
+// errCertConstraintViolation reports that a request exceeds its granted signing
+// constraints (TTL or SAN). KindPermissionDenied → HTTP 403.
+func errCertConstraintViolation(reason string) error {
+	return errcode.New(errcode.KindPermissionDenied, errCertConstraintViolationCode, msgConstraintViolation,
 		errcode.WithInternal(errcode.InternalAttr("reason", reason)))
 }

--- a/framework/runtime/certsigning/errors.go
+++ b/framework/runtime/certsigning/errors.go
@@ -1,0 +1,49 @@
+package certsigning
+
+import "github.com/ghbvf/gocell/framework/pkg/errcode"
+
+// Error codes minted by this package. The ERR_CERT_ namespace is registered in
+// framework/pkg/errcode (gocellPlatformPrefixes) and locked by
+// ERRCODE-PREFIX-OWNERSHIP-01; the golden prefix set is regenerated when the
+// namespace is added. PR-5 emits only the construction-validation codes below —
+// signing / revocation runtime codes (cross-scope denial, sign failure) land
+// with their producing implementation (softca / PG, PR-6).
+const (
+	errCertScopeInvalidCode   = errcode.ErrCertScopeInvalid
+	errCertRequestInvalidCode = errcode.ErrCertRequestInvalid
+	errCertIssuedInvalidCode  = errcode.ErrCertIssuedInvalid
+)
+
+// Const-literal messages (MESSAGE-CONST-LITERAL-01: errcode messages must be
+// const literals; runtime data flows through WithInternal / WithDetails). The
+// short per-reason strings passed to the helpers below are themselves const
+// literals at every call site.
+const (
+	msgScopeInvalid         = "certsigning: invalid certificate scope"
+	msgRequestInvalid       = "certsigning: invalid certificate request"
+	msgIssuedInvalid        = "certsigning: invalid issued certificate"
+	msgScopeTenantInvalid   = "certsigning: certificate scope tenant invalid"
+	msgSubjectTenantInvalid = "certsigning: certificate subject tenant invalid"
+	msgCSRUnparseable       = "certsigning: csr is not a valid PKCS#10 request"
+	msgCertUnparseable      = "certsigning: certificate is not valid DER"
+)
+
+// errCertScopeInvalid reports an invalid CertScope / IssuerID / DeviceID /
+// Serial construction. The per-reason detail is server-only (WithInternal).
+func errCertScopeInvalid(reason string) error {
+	return errcode.New(errcode.KindInvalid, errCertScopeInvalidCode, msgScopeInvalid,
+		errcode.WithInternal(errcode.InternalAttr("reason", reason)))
+}
+
+// errCertRequestInvalid reports an invalid CertRequest / subject / SAN / usage.
+func errCertRequestInvalid(reason string) error {
+	return errcode.New(errcode.KindInvalid, errCertRequestInvalidCode, msgRequestInvalid,
+		errcode.WithInternal(errcode.InternalAttr("reason", reason)))
+}
+
+// errCertIssuedInvalid reports an invalid IssuedCert reconstruction (empty or
+// unparseable certificate DER).
+func errCertIssuedInvalid(reason string) error {
+	return errcode.New(errcode.KindInvalid, errCertIssuedInvalidCode, msgIssuedInvalid,
+		errcode.WithInternal(errcode.InternalAttr("reason", reason)))
+}

--- a/framework/runtime/certsigning/request.go
+++ b/framework/runtime/certsigning/request.go
@@ -144,7 +144,12 @@ func (s CertScope) Issuer() IssuerID { return s.issuer }
 // Device returns the scope device.
 func (s CertScope) Device() DeviceID { return s.device }
 
-// IsZero reports whether s is the invalid zero value (any dimension absent).
+// IsZero reports whether s is the zero value (any dimension absent). Because
+// CertScope is sealed (the only minter is [NewCertScope], which validates the
+// tenant as a canonical UUID and rejects empty issuer/device), a non-zero
+// CertScope is guaranteed well-formed — so IsZero is a sufficient guard on any
+// API taking a CertScope. It is a zero-value test, not a re-validation: a value
+// that survived NewCertScope is already canonical.
 func (s CertScope) IsZero() bool {
 	return s.tenant == "" || s.issuer.IsZero() || s.device.IsZero()
 }
@@ -169,29 +174,68 @@ type SubjectAltNames struct {
 }
 
 // NewSubjectAltNames returns a sealed SAN set. Empty is allowed (a request may
-// carry no SANs); individual DNS entries must be non-blank. The slices are
-// defensively copied so the sealed value cannot be mutated post-construction.
+// carry no SANs); individual DNS entries must be non-blank, IP entries must be a
+// valid (non-empty) net.IP, and URI entries must be non-nil. The entries are
+// DEEP copied (net.IP byte slices and *url.URL values, not just the outer
+// slices) so the sealed value cannot be mutated through an aliased element.
 func NewSubjectAltNames(dnsNames []string, ipAddrs []net.IP, uris []*url.URL) (SubjectAltNames, error) {
 	for _, d := range dnsNames {
 		if strings.TrimSpace(d) == "" {
 			return SubjectAltNames{}, errCertRequestInvalid("dns SAN must not be blank")
 		}
 	}
+	for _, ip := range ipAddrs {
+		if len(ip) == 0 {
+			return SubjectAltNames{}, errCertRequestInvalid("ip SAN must not be empty")
+		}
+	}
+	for _, u := range uris {
+		if u == nil {
+			return SubjectAltNames{}, errCertRequestInvalid("uri SAN must not be nil")
+		}
+	}
 	return SubjectAltNames{
 		dnsNames: append([]string(nil), dnsNames...),
-		ipAddrs:  append([]net.IP(nil), ipAddrs...),
-		uris:     append([]*url.URL(nil), uris...),
+		ipAddrs:  deepCopyIPs(ipAddrs),
+		uris:     deepCopyURLs(uris),
 	}, nil
+}
+
+// deepCopyIPs copies the outer slice AND each net.IP's bytes, so a caller cannot
+// mutate the sealed SAN set through a retained net.IP element.
+func deepCopyIPs(in []net.IP) []net.IP {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]net.IP, len(in))
+	for i, ip := range in {
+		out[i] = append(net.IP(nil), ip...)
+	}
+	return out
+}
+
+// deepCopyURLs copies the outer slice AND each *url.URL (by value), so a caller
+// cannot mutate the sealed SAN set through a retained URL pointer.
+func deepCopyURLs(in []*url.URL) []*url.URL {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*url.URL, len(in))
+	for i, u := range in {
+		dup := *u
+		out[i] = &dup
+	}
+	return out
 }
 
 // DNSNames returns a copy of the DNS SANs.
 func (s SubjectAltNames) DNSNames() []string { return append([]string(nil), s.dnsNames...) }
 
-// IPAddresses returns a copy of the IP SANs.
-func (s SubjectAltNames) IPAddresses() []net.IP { return append([]net.IP(nil), s.ipAddrs...) }
+// IPAddresses returns a deep copy of the IP SANs.
+func (s SubjectAltNames) IPAddresses() []net.IP { return deepCopyIPs(s.ipAddrs) }
 
-// URIs returns a copy of the URI SANs.
-func (s SubjectAltNames) URIs() []*url.URL { return append([]*url.URL(nil), s.uris...) }
+// URIs returns a deep copy of the URI SANs.
+func (s SubjectAltNames) URIs() []*url.URL { return deepCopyURLs(s.uris) }
 
 // IsEmpty reports whether the SAN set carries no entries.
 func (s SubjectAltNames) IsEmpty() bool {
@@ -217,6 +261,9 @@ func NewKeyUsages(keyUsage x509.KeyUsage, extKeyUsage ...x509.ExtKeyUsage) (KeyU
 		extKeyUsage: append([]x509.ExtKeyUsage(nil), extKeyUsage...),
 	}, nil
 }
+
+// IsZero reports whether k is the invalid zero value (no key-usage bits).
+func (k KeyUsages) IsZero() bool { return k.keyUsage == 0 }
 
 // KeyUsage returns the requested x509.KeyUsage bitmask.
 func (k KeyUsages) KeyUsage() x509.KeyUsage { return k.keyUsage }
@@ -309,7 +356,7 @@ func NewCertRequest(
 		return CertRequest{}, errcode.Wrap(errcode.KindInvalid, errCertRequestInvalidCode,
 			msgCSRUnparseable, err)
 	}
-	if usages.keyUsage == 0 {
+	if usages.IsZero() {
 		return CertRequest{}, errCertRequestInvalid("key usage must not be empty")
 	}
 	if ttl <= 0 {
@@ -426,6 +473,10 @@ func (c IssuedCert) Epoch() uint64 { return c.epoch }
 // Certificate parses and returns the certificate for full X.509 access. It is
 // the convenience accessor over the canonical DER (re-parsed on demand) — the
 // seam stores opaque bytes, not a *x509.Certificate, to stay protocol-neutral.
+// Each call re-parses the DER; callers needing repeated full access (e.g. a
+// lifecycle reconciler) should cache the returned value. The cheap identity
+// fields ([IssuedCert.Serial] / [IssuedCert.NotAfter] / [IssuedCert.NotBefore])
+// are pre-derived and need no re-parse.
 func (c IssuedCert) Certificate() (*x509.Certificate, error) {
 	cert, err := x509.ParseCertificate(c.certDER)
 	if err != nil {

--- a/framework/runtime/certsigning/request.go
+++ b/framework/runtime/certsigning/request.go
@@ -1,0 +1,436 @@
+package certsigning
+
+import (
+	"crypto/x509"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// maxIdentLen bounds issuer / device / serial / common-name string lengths,
+// mirroring the contract-schema maxLength guards on the deviceidentity wire
+// (#1899: deviceId maxLength 256, serial maxLength 128, issuer maxLength 256).
+const (
+	maxIssuerLen     = 256
+	maxDeviceLen     = 256
+	maxSerialHexLen  = 128
+	maxCommonNameLen = 256
+)
+
+// IssuerID is the sealed issuing-CA identifier (the RFC 5280 issuer dimension of
+// a certificate identity: issuer name + serial uniquely identify a certificate,
+// not a globally-unique serial — RFC 5280 §4.1.2.2). The single field is
+// unexported, so a populated IssuerID cannot be forged by an external composite
+// literal; [NewIssuerID] is the sole minter. A zero value is invalid (IsZero).
+type IssuerID struct{ v string }
+
+// NewIssuerID validates s (non-blank, within maxIssuerLen) and returns a sealed
+// IssuerID. Empty / over-long input is rejected fail-closed — an issuer cannot be
+// absent at the point a CertScope is required.
+func NewIssuerID(s string) (IssuerID, error) {
+	if s == "" {
+		return IssuerID{}, errCertScopeInvalid("issuer must not be empty")
+	}
+	if len(s) > maxIssuerLen {
+		return IssuerID{}, errCertScopeInvalid("issuer too long")
+	}
+	return IssuerID{v: s}, nil
+}
+
+// String returns the underlying issuer identifier.
+func (i IssuerID) String() string { return i.v }
+
+// IsZero reports whether i is the invalid zero value.
+func (i IssuerID) IsZero() bool { return i.v == "" }
+
+// DeviceID is the sealed device identifier (the device dimension of a CertScope
+// and the subject of a device certificate). The single field is unexported;
+// [NewDeviceID] is the sole minter. A zero value is invalid.
+type DeviceID struct{ v string }
+
+// NewDeviceID validates s (non-blank, within maxDeviceLen) and returns a sealed
+// DeviceID. Empty / over-long input is rejected fail-closed.
+func NewDeviceID(s string) (DeviceID, error) {
+	if s == "" {
+		return DeviceID{}, errCertScopeInvalid("device must not be empty")
+	}
+	if len(s) > maxDeviceLen {
+		return DeviceID{}, errCertScopeInvalid("device too long")
+	}
+	return DeviceID{v: s}, nil
+}
+
+// String returns the underlying device identifier.
+func (d DeviceID) String() string { return d.v }
+
+// IsZero reports whether d is the invalid zero value.
+func (d DeviceID) IsZero() bool { return d.v == "" }
+
+// Serial is the sealed certificate serial number in canonical lowercase hex
+// (RFC 5280 §4.1.2.2). It is NOT a CertScope dimension: a serial alone never
+// crosses an isolation boundary — Revoke / RevocationList scope it with a
+// [CertScope] (issuer + serial is the RFC 5280 unique identity). The single
+// field is unexported; [NewSerial] is the sole minter.
+type Serial struct{ v string }
+
+// NewSerial validates that hex is a non-blank, within-bounds hexadecimal serial
+// and returns a sealed Serial normalized to lowercase. Non-hex / empty / over-
+// long input is rejected fail-closed.
+func NewSerial(hex string) (Serial, error) {
+	if hex == "" {
+		return Serial{}, errCertScopeInvalid("serial must not be empty")
+	}
+	if len(hex) > maxSerialHexLen {
+		return Serial{}, errCertScopeInvalid("serial too long")
+	}
+	for _, r := range hex {
+		if !isHexDigit(r) {
+			return Serial{}, errCertScopeInvalid("serial must be hexadecimal")
+		}
+	}
+	return Serial{v: strings.ToLower(hex)}, nil
+}
+
+// String returns the canonical lowercase hex serial.
+func (s Serial) String() string { return s.v }
+
+// IsZero reports whether s is the invalid zero value.
+func (s Serial) IsZero() bool { return s.v == "" }
+
+func isHexDigit(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+}
+
+// CertScope is the sealed isolation scope shared by signing and revocation:
+// {tenant, issuer, device}. It is the typed positional parameter that makes
+// "操作不带 scope" a compile error on Signer/RevocationStore APIs, and the
+// isolation invariant behind the #1899 status-contract narrowing (a bare serial
+// is never an isolation key — specific-cert lookup must carry a CertScope).
+// All three fields are unexported; [NewCertScope] is the sole minter.
+type CertScope struct {
+	tenant tenant.TenantID
+	issuer IssuerID
+	device DeviceID
+}
+
+// NewCertScope returns a sealed CertScope from typed dimensions. The tenant is a
+// canonical-UUID [tenant.TenantID] (validated here); issuer and device must be
+// non-zero. Any missing dimension is rejected fail-closed — a scope cannot
+// express a valid isolation predicate without all three.
+func NewCertScope(t tenant.TenantID, issuer IssuerID, device DeviceID) (CertScope, error) {
+	if err := t.Validate(); err != nil {
+		return CertScope{}, errcode.Wrap(errcode.KindInvalid, errCertScopeInvalidCode,
+			msgScopeTenantInvalid, err)
+	}
+	if issuer.IsZero() {
+		return CertScope{}, errCertScopeInvalid("issuer must not be empty")
+	}
+	if device.IsZero() {
+		return CertScope{}, errCertScopeInvalid("device must not be empty")
+	}
+	return CertScope{tenant: t, issuer: issuer, device: device}, nil
+}
+
+// Tenant returns the scope tenant.
+func (s CertScope) Tenant() tenant.TenantID { return s.tenant }
+
+// Issuer returns the scope issuer.
+func (s CertScope) Issuer() IssuerID { return s.issuer }
+
+// Device returns the scope device.
+func (s CertScope) Device() DeviceID { return s.device }
+
+// IsZero reports whether s is the invalid zero value (any dimension absent).
+func (s CertScope) IsZero() bool {
+	return s.tenant == "" || s.issuer.IsZero() || s.device.IsZero()
+}
+
+// Equal reports whether s and other share the same isolation domain. It is the
+// sanctioned cross-scope comparison for revocation-store implementations
+// enforcing "绝不凭裸 serial 跨隔离域" (a stored cert's scope must Equal the
+// caller's scope before its serial is visible).
+func (s CertScope) Equal(other CertScope) bool {
+	return s.tenant == other.tenant && s.issuer == other.issuer && s.device == other.device
+}
+
+// SubjectAltNames is the sealed set of certificate Subject Alternative Names
+// (DNS / IP / URI). SAN forgery is a real escalation surface, so SANs are an
+// explicit sealed request input — the Signer takes them from the (constrained)
+// request, never blindly from the CSR. The fields are unexported;
+// [NewSubjectAltNames] is the sole minter.
+type SubjectAltNames struct {
+	dnsNames []string
+	ipAddrs  []net.IP
+	uris     []*url.URL
+}
+
+// NewSubjectAltNames returns a sealed SAN set. Empty is allowed (a request may
+// carry no SANs); individual DNS entries must be non-blank. The slices are
+// defensively copied so the sealed value cannot be mutated post-construction.
+func NewSubjectAltNames(dnsNames []string, ipAddrs []net.IP, uris []*url.URL) (SubjectAltNames, error) {
+	for _, d := range dnsNames {
+		if strings.TrimSpace(d) == "" {
+			return SubjectAltNames{}, errCertRequestInvalid("dns SAN must not be blank")
+		}
+	}
+	return SubjectAltNames{
+		dnsNames: append([]string(nil), dnsNames...),
+		ipAddrs:  append([]net.IP(nil), ipAddrs...),
+		uris:     append([]*url.URL(nil), uris...),
+	}, nil
+}
+
+// DNSNames returns a copy of the DNS SANs.
+func (s SubjectAltNames) DNSNames() []string { return append([]string(nil), s.dnsNames...) }
+
+// IPAddresses returns a copy of the IP SANs.
+func (s SubjectAltNames) IPAddresses() []net.IP { return append([]net.IP(nil), s.ipAddrs...) }
+
+// URIs returns a copy of the URI SANs.
+func (s SubjectAltNames) URIs() []*url.URL { return append([]*url.URL(nil), s.uris...) }
+
+// IsEmpty reports whether the SAN set carries no entries.
+func (s SubjectAltNames) IsEmpty() bool {
+	return len(s.dnsNames) == 0 && len(s.ipAddrs) == 0 && len(s.uris) == 0
+}
+
+// KeyUsages is the sealed set of X.509 key usages requested for a certificate.
+// The fields are unexported; [NewKeyUsages] is the sole minter. A zero usage
+// (no key-usage bits) is rejected — a certificate with no usage is unusable.
+type KeyUsages struct {
+	keyUsage    x509.KeyUsage
+	extKeyUsage []x509.ExtKeyUsage
+}
+
+// NewKeyUsages returns a sealed KeyUsages from an x509.KeyUsage bitmask plus
+// optional extended usages. A zero keyUsage is rejected fail-closed.
+func NewKeyUsages(keyUsage x509.KeyUsage, extKeyUsage ...x509.ExtKeyUsage) (KeyUsages, error) {
+	if keyUsage == 0 {
+		return KeyUsages{}, errCertRequestInvalid("key usage must not be empty")
+	}
+	return KeyUsages{
+		keyUsage:    keyUsage,
+		extKeyUsage: append([]x509.ExtKeyUsage(nil), extKeyUsage...),
+	}, nil
+}
+
+// KeyUsage returns the requested x509.KeyUsage bitmask.
+func (k KeyUsages) KeyUsage() x509.KeyUsage { return k.keyUsage }
+
+// ExtKeyUsage returns a copy of the requested extended key usages.
+func (k KeyUsages) ExtKeyUsage() []x509.ExtKeyUsage {
+	return append([]x509.ExtKeyUsage(nil), k.extKeyUsage...)
+}
+
+// DeviceSubject is the sealed certificate subject identity (the device + tenant
+// dimension plus the X.509 common name). The fields are unexported;
+// [NewDeviceSubject] is the sole minter. The subject is a policy decision made
+// at the enroll boundary, not trusted from the CSR.
+type DeviceSubject struct {
+	tenant     tenant.TenantID
+	device     DeviceID
+	commonName string
+}
+
+// NewDeviceSubject returns a sealed DeviceSubject. The tenant must be canonical,
+// the device non-zero, and the common name non-blank and within bounds.
+func NewDeviceSubject(t tenant.TenantID, device DeviceID, commonName string) (DeviceSubject, error) {
+	if err := t.Validate(); err != nil {
+		return DeviceSubject{}, errcode.Wrap(errcode.KindInvalid, errCertRequestInvalidCode,
+			msgSubjectTenantInvalid, err)
+	}
+	if device.IsZero() {
+		return DeviceSubject{}, errCertRequestInvalid("subject device must not be empty")
+	}
+	if commonName == "" {
+		return DeviceSubject{}, errCertRequestInvalid("subject common name must not be empty")
+	}
+	if len(commonName) > maxCommonNameLen {
+		return DeviceSubject{}, errCertRequestInvalid("subject common name too long")
+	}
+	return DeviceSubject{tenant: t, device: device, commonName: commonName}, nil
+}
+
+// Tenant returns the subject tenant.
+func (d DeviceSubject) Tenant() tenant.TenantID { return d.tenant }
+
+// Device returns the subject device.
+func (d DeviceSubject) Device() DeviceID { return d.device }
+
+// CommonName returns the subject X.509 common name.
+func (d DeviceSubject) CommonName() string { return d.commonName }
+
+// IsZero reports whether d is the invalid zero value.
+func (d DeviceSubject) IsZero() bool {
+	return d.tenant == "" || d.device.IsZero() || d.commonName == ""
+}
+
+// CertRequest is the sealed protocol-agnostic signing request: an isolation
+// scope, the policy-decided subject / SANs / usages / TTL, and the raw PKCS#10
+// CSR DER (public key + proof-of-possession; the private key never crosses this
+// boundary). EST / SCEP / XCEP front-ends decode to this single shape. All
+// fields are unexported; [NewCertRequest] is the sole minter, so an external
+// package cannot forge signing inputs by composite literal.
+type CertRequest struct {
+	scope   CertScope
+	subject DeviceSubject
+	csrDER  []byte
+	sans    SubjectAltNames
+	usages  KeyUsages
+	ttl     time.Duration
+}
+
+// NewCertRequest validates and returns a sealed CertRequest. The scope and
+// subject must be non-zero, the CSR DER must parse as a PKCS#10
+// CertificateRequest, and the TTL must be positive. The CSR is defensively
+// copied. Validation is fail-closed: a malformed request never reaches a Signer.
+func NewCertRequest(
+	scope CertScope,
+	subject DeviceSubject,
+	csrDER []byte,
+	sans SubjectAltNames,
+	usages KeyUsages,
+	ttl time.Duration,
+) (CertRequest, error) {
+	if scope.IsZero() {
+		return CertRequest{}, errCertRequestInvalid("scope must not be empty")
+	}
+	if subject.IsZero() {
+		return CertRequest{}, errCertRequestInvalid("subject must not be empty")
+	}
+	if len(csrDER) == 0 {
+		return CertRequest{}, errCertRequestInvalid("csr must not be empty")
+	}
+	if _, err := x509.ParseCertificateRequest(csrDER); err != nil {
+		return CertRequest{}, errcode.Wrap(errcode.KindInvalid, errCertRequestInvalidCode,
+			msgCSRUnparseable, err)
+	}
+	if usages.keyUsage == 0 {
+		return CertRequest{}, errCertRequestInvalid("key usage must not be empty")
+	}
+	if ttl <= 0 {
+		return CertRequest{}, errCertRequestInvalid("ttl must be positive")
+	}
+	return CertRequest{
+		scope:   scope,
+		subject: subject,
+		csrDER:  append([]byte(nil), csrDER...),
+		sans:    sans,
+		usages:  usages,
+		ttl:     ttl,
+	}, nil
+}
+
+// Scope returns the request isolation scope.
+func (r CertRequest) Scope() CertScope { return r.scope }
+
+// Subject returns the requested certificate subject.
+func (r CertRequest) Subject() DeviceSubject { return r.subject }
+
+// CSRDER returns a copy of the raw PKCS#10 CSR DER.
+func (r CertRequest) CSRDER() []byte { return append([]byte(nil), r.csrDER...) }
+
+// SubjectAltNames returns the requested SAN set.
+func (r CertRequest) SubjectAltNames() SubjectAltNames { return r.sans }
+
+// KeyUsages returns the requested key usages.
+func (r CertRequest) KeyUsages() KeyUsages { return r.usages }
+
+// TTL returns the requested certificate lifetime.
+func (r CertRequest) TTL() time.Duration { return r.ttl }
+
+// IssuedCert is the sealed result of a signing operation (a minted credential):
+// the certificate DER, its chain, and the renewal epoch. The canonical material
+// is the opaque DER; the serial / notBefore / notAfter are DERIVED from it at
+// construction (single source — an issued cert's serial cannot disagree with
+// its bytes). All fields are unexported; [NewIssuedCert] is the sole minter, the
+// upstream-Hard half of CERT-SIGN-FUNNEL-01 (no package outside can forge an
+// issued certificate by composite literal).
+type IssuedCert struct {
+	scope     CertScope
+	serial    Serial
+	certDER   []byte
+	chainDER  [][]byte
+	notBefore time.Time
+	notAfter  time.Time
+	epoch     uint64
+}
+
+// NewIssuedCert returns a sealed IssuedCert from the signed certificate DER, its
+// intermediate chain DER, the isolation scope, and the renewal epoch. The DER is
+// parsed to derive (and validate) the serial / notBefore / notAfter — so the
+// identity is single-sourced from the bytes. Empty / unparseable DER is rejected
+// fail-closed. The byte slices are defensively copied.
+func NewIssuedCert(scope CertScope, certDER []byte, chainDER [][]byte, epoch uint64) (IssuedCert, error) {
+	if scope.IsZero() {
+		return IssuedCert{}, errCertIssuedInvalid("scope must not be empty")
+	}
+	if len(certDER) == 0 {
+		return IssuedCert{}, errCertIssuedInvalid("certificate must not be empty")
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return IssuedCert{}, errcode.Wrap(errcode.KindInvalid, errCertIssuedInvalidCode,
+			msgCertUnparseable, err)
+	}
+	serial, err := NewSerial(cert.SerialNumber.Text(16))
+	if err != nil {
+		return IssuedCert{}, err
+	}
+	chainCopy := make([][]byte, len(chainDER))
+	for i, link := range chainDER {
+		chainCopy[i] = append([]byte(nil), link...)
+	}
+	return IssuedCert{
+		scope:     scope,
+		serial:    serial,
+		certDER:   append([]byte(nil), certDER...),
+		chainDER:  chainCopy,
+		notBefore: cert.NotBefore,
+		notAfter:  cert.NotAfter,
+		epoch:     epoch,
+	}, nil
+}
+
+// Scope returns the issued certificate's isolation scope.
+func (c IssuedCert) Scope() CertScope { return c.scope }
+
+// Serial returns the certificate serial (derived from the DER).
+func (c IssuedCert) Serial() Serial { return c.serial }
+
+// DER returns a copy of the certificate DER.
+func (c IssuedCert) DER() []byte { return append([]byte(nil), c.certDER...) }
+
+// Chain returns a copy of the intermediate-chain DER links.
+func (c IssuedCert) Chain() [][]byte {
+	out := make([][]byte, len(c.chainDER))
+	for i, link := range c.chainDER {
+		out[i] = append([]byte(nil), link...)
+	}
+	return out
+}
+
+// NotBefore returns the certificate validity start (derived from the DER).
+func (c IssuedCert) NotBefore() time.Time { return c.notBefore }
+
+// NotAfter returns the certificate expiry (derived from the DER).
+func (c IssuedCert) NotAfter() time.Time { return c.notAfter }
+
+// Epoch returns the monotonic renewal epoch (0 for initial enrollment).
+func (c IssuedCert) Epoch() uint64 { return c.epoch }
+
+// Certificate parses and returns the certificate for full X.509 access. It is
+// the convenience accessor over the canonical DER (re-parsed on demand) — the
+// seam stores opaque bytes, not a *x509.Certificate, to stay protocol-neutral.
+func (c IssuedCert) Certificate() (*x509.Certificate, error) {
+	cert, err := x509.ParseCertificate(c.certDER)
+	if err != nil {
+		return nil, errcode.Wrap(errcode.KindInternal, errCertIssuedInvalidCode,
+			msgCertUnparseable, err)
+	}
+	return cert, nil
+}

--- a/framework/runtime/certsigning/request.go
+++ b/framework/runtime/certsigning/request.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -32,8 +33,8 @@ type IssuerID struct{ v string }
 // IssuerID. Empty / over-long input is rejected fail-closed — an issuer cannot be
 // absent at the point a CertScope is required.
 func NewIssuerID(s string) (IssuerID, error) {
-	if s == "" {
-		return IssuerID{}, errCertScopeInvalid("issuer must not be empty")
+	if strings.TrimSpace(s) == "" {
+		return IssuerID{}, errCertScopeInvalid("issuer must not be blank")
 	}
 	if len(s) > maxIssuerLen {
 		return IssuerID{}, errCertScopeInvalid("issuer too long")
@@ -55,8 +56,8 @@ type DeviceID struct{ v string }
 // NewDeviceID validates s (non-blank, within maxDeviceLen) and returns a sealed
 // DeviceID. Empty / over-long input is rejected fail-closed.
 func NewDeviceID(s string) (DeviceID, error) {
-	if s == "" {
-		return DeviceID{}, errCertScopeInvalid("device must not be empty")
+	if strings.TrimSpace(s) == "" {
+		return DeviceID{}, errCertScopeInvalid("device must not be blank")
 	}
 	if len(s) > maxDeviceLen {
 		return DeviceID{}, errCertScopeInvalid("device too long")
@@ -162,6 +163,22 @@ func (s CertScope) Equal(other CertScope) bool {
 	return s.tenant == other.tenant && s.issuer == other.issuer && s.device == other.device
 }
 
+// requireSameOrigin fail-closes when a scope and a subject name different
+// tenants or devices. A request / claim carries two identity sources (the
+// isolation [CertScope] and the certificate [DeviceSubject]); they MUST agree on
+// tenant and device, else a caller could mint a request scoped to tenant-A while
+// naming tenant-B's device subject (cross-subject issuance). The issuer is a
+// scope-only dimension (the CA) and is not part of the subject.
+func requireSameOrigin(scope CertScope, subject DeviceSubject) error {
+	if scope.tenant != subject.tenant {
+		return errCertRequestInvalid("scope and subject tenant must match")
+	}
+	if scope.device != subject.device {
+		return errCertRequestInvalid("scope and subject device must match")
+	}
+	return nil
+}
+
 // SubjectAltNames is the sealed set of certificate Subject Alternative Names
 // (DNS / IP / URI). SAN forgery is a real escalation surface, so SANs are an
 // explicit sealed request input — the Signer takes them from the (constrained)
@@ -242,6 +259,29 @@ func (s SubjectAltNames) IsEmpty() bool {
 	return len(s.dnsNames) == 0 && len(s.ipAddrs) == 0 && len(s.uris) == 0
 }
 
+// subsetOf reports whether every SAN entry in s is also present in allowed
+// (deny-by-default: an empty allowed admits only an empty s). It backs the
+// SAN-allowance enforcement in [NewAuthorizedCertRequest].
+func (s SubjectAltNames) subsetOf(allowed SubjectAltNames) bool {
+	for _, d := range s.dnsNames {
+		if !slices.Contains(allowed.dnsNames, d) {
+			return false
+		}
+	}
+	for _, ip := range s.ipAddrs {
+		if !slices.ContainsFunc(allowed.ipAddrs, ip.Equal) {
+			return false
+		}
+	}
+	for _, u := range s.uris {
+		us := u.String()
+		if !slices.ContainsFunc(allowed.uris, func(a *url.URL) bool { return a.String() == us }) {
+			return false
+		}
+	}
+	return true
+}
+
 // KeyUsages is the sealed set of X.509 key usages requested for a certificate.
 // The fields are unexported; [NewKeyUsages] is the sole minter. A zero usage
 // (no key-usage bits) is rejected — a certificate with no usage is unusable.
@@ -293,8 +333,8 @@ func NewDeviceSubject(t tenant.TenantID, device DeviceID, commonName string) (De
 	if device.IsZero() {
 		return DeviceSubject{}, errCertRequestInvalid("subject device must not be empty")
 	}
-	if commonName == "" {
-		return DeviceSubject{}, errCertRequestInvalid("subject common name must not be empty")
+	if strings.TrimSpace(commonName) == "" {
+		return DeviceSubject{}, errCertRequestInvalid("subject common name must not be blank")
 	}
 	if len(commonName) > maxCommonNameLen {
 		return DeviceSubject{}, errCertRequestInvalid("subject common name too long")
@@ -349,12 +389,23 @@ func NewCertRequest(
 	if subject.IsZero() {
 		return CertRequest{}, errCertRequestInvalid("subject must not be empty")
 	}
+	if err := requireSameOrigin(scope, subject); err != nil {
+		return CertRequest{}, err
+	}
 	if len(csrDER) == 0 {
 		return CertRequest{}, errCertRequestInvalid("csr must not be empty")
 	}
-	if _, err := x509.ParseCertificateRequest(csrDER); err != nil {
+	csr, err := x509.ParseCertificateRequest(csrDER)
+	if err != nil {
 		return CertRequest{}, errcode.Wrap(errcode.KindInvalid, errCertRequestInvalidCode,
 			msgCSRUnparseable, err)
+	}
+	// Proof-of-possession: a parseable CSR is not proof the requester holds the
+	// private key. CheckSignature verifies the CSR self-signature (the POP). A
+	// parse-OK but signature-invalid CSR is rejected fail-closed.
+	if err := csr.CheckSignature(); err != nil {
+		return CertRequest{}, errcode.Wrap(errcode.KindInvalid, errCertRequestInvalidCode,
+			msgCSRSignatureInvalid, err)
 	}
 	if usages.IsZero() {
 		return CertRequest{}, errCertRequestInvalid("key usage must not be empty")

--- a/framework/runtime/certsigning/request_test.go
+++ b/framework/runtime/certsigning/request_test.go
@@ -147,15 +147,33 @@ func TestNewIssuerID(t *testing.T) {
 
 func TestNewDeviceID(t *testing.T) {
 	t.Parallel()
-	if _, err := cs.NewDeviceID(""); err == nil {
-		t.Error("empty device should error")
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "valid", in: "dev-1"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "too long", in: string(make([]byte, 300)), wantErr: true},
 	}
-	if _, err := cs.NewDeviceID(string(make([]byte, 300))); err == nil {
-		t.Error("over-long device should error")
-	}
-	d, err := cs.NewDeviceID("dev-1")
-	if err != nil || d.String() != "dev-1" || d.IsZero() {
-		t.Fatalf("valid device: %v %q", err, d.String())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d, err := cs.NewDeviceID(tc.in)
+			if tc.wantErr {
+				assertCode(t, err, errcode.ErrCertScopeInvalid)
+				if !d.IsZero() {
+					t.Error("expected zero DeviceID on error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.String() != tc.in || d.IsZero() {
+				t.Errorf("DeviceID round-trip: got %q", d.String())
+			}
+		})
 	}
 }
 
@@ -261,6 +279,16 @@ func TestNewSubjectAltNames(t *testing.T) {
 		_, err := cs.NewSubjectAltNames([]string{" "}, nil, nil)
 		assertCode(t, err, errcode.ErrCertRequestInvalid)
 	})
+	t.Run("empty ip rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewSubjectAltNames(nil, []net.IP{{}}, nil)
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("nil uri rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewSubjectAltNames(nil, nil, []*url.URL{nil})
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
 	t.Run("empty ok", func(t *testing.T) {
 		t.Parallel()
 		sans, err := cs.NewSubjectAltNames(nil, nil, nil)
@@ -268,7 +296,7 @@ func TestNewSubjectAltNames(t *testing.T) {
 			t.Fatalf("empty SANs: %v isEmpty=%v", err, sans.IsEmpty())
 		}
 	})
-	t.Run("copies inputs", func(t *testing.T) {
+	t.Run("deep-copies inputs", func(t *testing.T) {
 		t.Parallel()
 		dns := []string{"a.example"}
 		ips := []net.IP{net.ParseIP("10.0.0.1")}
@@ -277,17 +305,25 @@ func TestNewSubjectAltNames(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected: %v", err)
 		}
+		// Mutating the caller's inputs must not change the sealed value.
 		dns[0] = "mutated"
+		ips[0][0] = 0xff
+		uris[0].Host = "mutated"
 		if got := sans.DNSNames(); got[0] != "a.example" {
-			t.Errorf("SAN not defensively copied: %q", got[0])
+			t.Errorf("DNS not defensively copied: %q", got[0])
 		}
-		// accessor returns copy
-		sans.DNSNames()[0] = "mutated2"
-		if sans.DNSNames()[0] != "a.example" {
-			t.Error("DNSNames accessor must return a copy")
+		if got := sans.IPAddresses(); !got[0].Equal(net.ParseIP("10.0.0.1")) {
+			t.Errorf("IP not deep-copied: %v", got[0])
 		}
-		if len(sans.IPAddresses()) != 1 || len(sans.URIs()) != 1 {
-			t.Error("IP/URI accessors mismatch")
+		if got := sans.URIs(); got[0].Host != "x" {
+			t.Errorf("URI not deep-copied: %q", got[0].Host)
+		}
+		// Accessors return copies — mutating the result must not change internals.
+		sans.DNSNames()[0] = "x"
+		sans.IPAddresses()[0][0] = 0xff
+		sans.URIs()[0].Host = "y"
+		if sans.DNSNames()[0] != "a.example" || !sans.IPAddresses()[0].Equal(net.ParseIP("10.0.0.1")) || sans.URIs()[0].Host != "x" {
+			t.Error("accessors must return deep copies")
 		}
 	})
 }

--- a/framework/runtime/certsigning/request_test.go
+++ b/framework/runtime/certsigning/request_test.go
@@ -33,11 +33,13 @@ func testKey(t *testing.T) *ecdsa.PrivateKey {
 	return key
 }
 
-// testCSRDER fabricates a valid PKCS#10 CSR DER for the given common name.
-func testCSRDER(t *testing.T, cn string) []byte {
+// testCSRDER fabricates a valid PKCS#10 CSR DER (properly self-signed, so
+// CheckSignature passes). The subject is policy-decided from the request, not
+// the CSR, so the CSR common name is fixed.
+func testCSRDER(t *testing.T) []byte {
 	t.Helper()
 	der, err := x509.CreateCertificateRequest(rand.Reader,
-		&x509.CertificateRequest{Subject: pkix.Name{CommonName: cn}}, testKey(t))
+		&x509.CertificateRequest{Subject: pkix.Name{CommonName: "device-1"}}, testKey(t))
 	if err != nil {
 		t.Fatalf("create csr: %v", err)
 	}
@@ -122,6 +124,7 @@ func TestNewIssuerID(t *testing.T) {
 	}{
 		{name: "valid", in: "ca-root"},
 		{name: "empty", in: "", wantErr: true},
+		{name: "whitespace", in: "   ", wantErr: true},
 		{name: "too long", in: string(make([]byte, 300)), wantErr: true},
 	}
 	for _, tc := range tests {
@@ -154,6 +157,7 @@ func TestNewDeviceID(t *testing.T) {
 	}{
 		{name: "valid", in: "dev-1"},
 		{name: "empty", in: "", wantErr: true},
+		{name: "whitespace", in: "   ", wantErr: true},
 		{name: "too long", in: string(make([]byte, 300)), wantErr: true},
 	}
 	for _, tc := range tests {
@@ -366,6 +370,11 @@ func TestNewDeviceSubject(t *testing.T) {
 		_, err := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, string(make([]byte, 300)))
 		assertCode(t, err, errcode.ErrCertRequestInvalid)
 	})
+	t.Run("whitespace cn", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "   ")
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
 	t.Run("blank cn", func(t *testing.T) {
 		t.Parallel()
 		_, err := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "")
@@ -390,7 +399,7 @@ func TestNewCertRequest(t *testing.T) {
 	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
 	usages, _ := cs.NewKeyUsages(x509.KeyUsageDigitalSignature)
 	sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
-	csr := testCSRDER(t, "device-1")
+	csr := testCSRDER(t)
 
 	t.Run("valid", func(t *testing.T) {
 		t.Parallel()
@@ -444,6 +453,29 @@ func TestNewCertRequest(t *testing.T) {
 	t.Run("zero key usages", func(t *testing.T) {
 		t.Parallel()
 		_, err := cs.NewCertRequest(scope, subject, csr, sans, cs.KeyUsages{}, time.Hour)
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+
+	t.Run("cross-device subject rejected", func(t *testing.T) {
+		t.Parallel()
+		devB, _ := cs.NewDeviceID("device-2")
+		subjB, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), devB, "device-2")
+		_, err := cs.NewCertRequest(scope, subjB, csr, sans, usages, time.Hour) // scope device-1 vs subject device-2
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+
+	t.Run("cross-tenant subject rejected", func(t *testing.T) {
+		t.Parallel()
+		subjB, _ := cs.NewDeviceSubject(mustTenant(t, testTenantB), dev, "device-1")
+		_, err := cs.NewCertRequest(scope, subjB, csr, sans, usages, time.Hour)
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+
+	t.Run("csr proof-of-possession rejected (bad signature)", func(t *testing.T) {
+		t.Parallel()
+		bad := append([]byte(nil), csr...)
+		bad[len(bad)-1] ^= 0xff // corrupt the signature; structure stays parseable
+		_, err := cs.NewCertRequest(scope, subject, bad, sans, usages, time.Hour)
 		assertCode(t, err, errcode.ErrCertRequestInvalid)
 	})
 }

--- a/framework/runtime/certsigning/request_test.go
+++ b/framework/runtime/certsigning/request_test.go
@@ -1,0 +1,469 @@
+package certsigning_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+const (
+	testTenant  = "11111111-1111-1111-1111-111111111111"
+	testTenantB = "22222222-2222-2222-2222-222222222222"
+)
+
+// testKey is a shared signing key for fabricating CSR / certificate DER in tests.
+func testKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return key
+}
+
+// testCSRDER fabricates a valid PKCS#10 CSR DER for the given common name.
+func testCSRDER(t *testing.T, cn string) []byte {
+	t.Helper()
+	der, err := x509.CreateCertificateRequest(rand.Reader,
+		&x509.CertificateRequest{Subject: pkix.Name{CommonName: cn}}, testKey(t))
+	if err != nil {
+		t.Fatalf("create csr: %v", err)
+	}
+	return der
+}
+
+// testCertDER fabricates a self-signed certificate DER with the given serial.
+func testCertDER(t *testing.T, serial *big.Int, notAfter time.Time) []byte {
+	t.Helper()
+	key := testKey(t)
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "device"},
+		NotBefore:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return der
+}
+
+// mustTenant parses a canonical tenant UUID for tests.
+func mustTenant(t *testing.T, s string) tenant.TenantID {
+	t.Helper()
+	tid, err := tenant.ParseTenantID(s)
+	if err != nil {
+		t.Fatalf("parse tenant: %v", err)
+	}
+	return tid
+}
+
+// mustScope builds a valid CertScope for tests.
+func mustScope(t *testing.T) cs.CertScope {
+	t.Helper()
+	iss, err := cs.NewIssuerID("ca-root")
+	if err != nil {
+		t.Fatalf("issuer: %v", err)
+	}
+	dev, err := cs.NewDeviceID("device-1")
+	if err != nil {
+		t.Fatalf("device: %v", err)
+	}
+	scope, err := cs.NewCertScope(mustTenant(t, testTenant), iss, dev)
+	if err != nil {
+		t.Fatalf("scope: %v", err)
+	}
+	return scope
+}
+
+// assertCode fails unless err carries the expected errcode.Code.
+func assertCode(t *testing.T, err error, want errcode.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with code %s, got nil", want)
+	}
+	var e *errcode.Error
+	if !errors.As(err, &e) {
+		t.Fatalf("error %v is not *errcode.Error", err)
+	}
+	if e.Code != want {
+		t.Fatalf("error code = %s, want %s", e.Code, want)
+	}
+}
+
+// makeHex returns n hex digits, for over-length boundary tests.
+func makeHex(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 'a'
+	}
+	return b
+}
+
+func TestNewIssuerID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "valid", in: "ca-root"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "too long", in: string(make([]byte, 300)), wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := cs.NewIssuerID(tc.in)
+			if tc.wantErr {
+				assertCode(t, err, errcode.ErrCertScopeInvalid)
+				if !id.IsZero() {
+					t.Error("expected zero IssuerID on error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id.String() != tc.in || id.IsZero() {
+				t.Errorf("IssuerID round-trip: got %q", id.String())
+			}
+		})
+	}
+}
+
+func TestNewDeviceID(t *testing.T) {
+	t.Parallel()
+	if _, err := cs.NewDeviceID(""); err == nil {
+		t.Error("empty device should error")
+	}
+	if _, err := cs.NewDeviceID(string(make([]byte, 300))); err == nil {
+		t.Error("over-long device should error")
+	}
+	d, err := cs.NewDeviceID("dev-1")
+	if err != nil || d.String() != "dev-1" || d.IsZero() {
+		t.Fatalf("valid device: %v %q", err, d.String())
+	}
+}
+
+func TestNewSerial(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "lowercase hex", in: "1a2b3c", want: "1a2b3c"},
+		{name: "uppercase normalized", in: "ABCDEF", want: "abcdef"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "non-hex", in: "xyz", wantErr: true},
+		{name: "too long", in: string(makeHex(200)), wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := cs.NewSerial(tc.in)
+			if tc.wantErr {
+				assertCode(t, err, errcode.ErrCertScopeInvalid)
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if s.String() != tc.want {
+				t.Errorf("serial = %q, want %q", s.String(), tc.want)
+			}
+		})
+	}
+	if !(cs.Serial{}).IsZero() {
+		t.Error("zero Serial must report IsZero")
+	}
+}
+
+func TestNewCertScope(t *testing.T) {
+	t.Parallel()
+	iss, _ := cs.NewIssuerID("ca-root")
+	dev, _ := cs.NewDeviceID("dev-1")
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		scope, err := cs.NewCertScope(mustTenant(t, testTenant), iss, dev)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scope.IsZero() || scope.Issuer() != iss || scope.Device() != dev {
+			t.Error("scope accessors mismatch")
+		}
+		if scope.Tenant().String() != testTenant {
+			t.Errorf("scope tenant = %q", scope.Tenant().String())
+		}
+	})
+
+	t.Run("invalid tenant", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewCertScope(tenant.TenantID("not-a-uuid"), iss, dev)
+		assertCode(t, err, errcode.ErrCertScopeInvalid)
+	})
+
+	t.Run("zero issuer", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewCertScope(mustTenant(t, testTenant), cs.IssuerID{}, dev)
+		assertCode(t, err, errcode.ErrCertScopeInvalid)
+	})
+
+	t.Run("zero device", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewCertScope(mustTenant(t, testTenant), iss, cs.DeviceID{})
+		assertCode(t, err, errcode.ErrCertScopeInvalid)
+	})
+}
+
+func TestCertScopeEqual(t *testing.T) {
+	t.Parallel()
+	iss, _ := cs.NewIssuerID("ca-root")
+	issB, _ := cs.NewIssuerID("ca-other")
+	dev, _ := cs.NewDeviceID("dev-1")
+
+	a, _ := cs.NewCertScope(mustTenant(t, testTenant), iss, dev)
+	same, _ := cs.NewCertScope(mustTenant(t, testTenant), iss, dev)
+	otherTenant, _ := cs.NewCertScope(mustTenant(t, testTenantB), iss, dev)
+	otherIssuer, _ := cs.NewCertScope(mustTenant(t, testTenant), issB, dev)
+
+	if !a.Equal(same) {
+		t.Error("identical scopes must be Equal")
+	}
+	if a.Equal(otherTenant) {
+		t.Error("cross-tenant scopes must NOT be Equal")
+	}
+	if a.Equal(otherIssuer) {
+		t.Error("cross-issuer scopes must NOT be Equal")
+	}
+}
+
+func TestNewSubjectAltNames(t *testing.T) {
+	t.Parallel()
+	t.Run("blank dns rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewSubjectAltNames([]string{" "}, nil, nil)
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("empty ok", func(t *testing.T) {
+		t.Parallel()
+		sans, err := cs.NewSubjectAltNames(nil, nil, nil)
+		if err != nil || !sans.IsEmpty() {
+			t.Fatalf("empty SANs: %v isEmpty=%v", err, sans.IsEmpty())
+		}
+	})
+	t.Run("copies inputs", func(t *testing.T) {
+		t.Parallel()
+		dns := []string{"a.example"}
+		ips := []net.IP{net.ParseIP("10.0.0.1")}
+		uris := []*url.URL{{Scheme: "spiffe", Host: "x"}}
+		sans, err := cs.NewSubjectAltNames(dns, ips, uris)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		dns[0] = "mutated"
+		if got := sans.DNSNames(); got[0] != "a.example" {
+			t.Errorf("SAN not defensively copied: %q", got[0])
+		}
+		// accessor returns copy
+		sans.DNSNames()[0] = "mutated2"
+		if sans.DNSNames()[0] != "a.example" {
+			t.Error("DNSNames accessor must return a copy")
+		}
+		if len(sans.IPAddresses()) != 1 || len(sans.URIs()) != 1 {
+			t.Error("IP/URI accessors mismatch")
+		}
+	})
+}
+
+func TestNewKeyUsages(t *testing.T) {
+	t.Parallel()
+	if _, err := cs.NewKeyUsages(0); err == nil {
+		t.Error("zero key usage must error")
+	}
+	ku, err := cs.NewKeyUsages(x509.KeyUsageDigitalSignature, x509.ExtKeyUsageClientAuth)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if ku.KeyUsage() != x509.KeyUsageDigitalSignature {
+		t.Error("KeyUsage accessor mismatch")
+	}
+	if len(ku.ExtKeyUsage()) != 1 || ku.ExtKeyUsage()[0] != x509.ExtKeyUsageClientAuth {
+		t.Error("ExtKeyUsage accessor mismatch")
+	}
+}
+
+func TestNewDeviceSubject(t *testing.T) {
+	t.Parallel()
+	dev, _ := cs.NewDeviceID("dev-1")
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		sub, err := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1.example")
+		if err != nil || sub.IsZero() {
+			t.Fatalf("valid subject: %v", err)
+		}
+		if sub.CommonName() != "device-1.example" || sub.Device() != dev {
+			t.Error("subject accessors mismatch")
+		}
+		if sub.Tenant().String() != testTenant {
+			t.Errorf("subject tenant = %q", sub.Tenant().String())
+		}
+	})
+	t.Run("over-long cn", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, string(make([]byte, 300)))
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("blank cn", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "")
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("invalid tenant", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewDeviceSubject(tenant.TenantID("bad"), dev, "cn")
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+	t.Run("zero device", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewDeviceSubject(mustTenant(t, testTenant), cs.DeviceID{}, "cn")
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+}
+
+func TestNewCertRequest(t *testing.T) {
+	t.Parallel()
+	scope := mustScope(t)
+	dev, _ := cs.NewDeviceID("device-1")
+	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
+	usages, _ := cs.NewKeyUsages(x509.KeyUsageDigitalSignature)
+	sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
+	csr := testCSRDER(t, "device-1")
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		req, err := cs.NewCertRequest(scope, subject, csr, sans, usages, time.Hour)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if req.TTL() != time.Hour || req.Scope() != scope {
+			t.Error("request accessors mismatch")
+		}
+		if req.Subject() != subject {
+			t.Error("Subject accessor mismatch")
+		}
+		if req.SubjectAltNames().IsEmpty() {
+			t.Error("SubjectAltNames accessor must carry the SAN")
+		}
+		if req.KeyUsages().KeyUsage() != x509.KeyUsageDigitalSignature {
+			t.Error("KeyUsages accessor mismatch")
+		}
+		if len(req.CSRDER()) != len(csr) {
+			t.Error("CSRDER mismatch")
+		}
+		// defensive copy on accessor
+		req.CSRDER()[0] ^= 0xff
+		if req.CSRDER()[0] == (csr[0] ^ 0xff) {
+			t.Error("CSRDER must return a copy")
+		}
+	})
+
+	tests := []struct {
+		name    string
+		scope   cs.CertScope
+		subject cs.DeviceSubject
+		csr     []byte
+		ttl     time.Duration
+	}{
+		{name: "zero scope", scope: cs.CertScope{}, subject: subject, csr: csr, ttl: time.Hour},
+		{name: "zero subject", scope: scope, subject: cs.DeviceSubject{}, csr: csr, ttl: time.Hour},
+		{name: "empty csr", scope: scope, subject: subject, csr: nil, ttl: time.Hour},
+		{name: "garbage csr", scope: scope, subject: subject, csr: []byte("not-a-csr"), ttl: time.Hour},
+		{name: "non-positive ttl", scope: scope, subject: subject, csr: csr, ttl: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := cs.NewCertRequest(tc.scope, tc.subject, tc.csr, sans, usages, tc.ttl)
+			assertCode(t, err, errcode.ErrCertRequestInvalid)
+		})
+	}
+
+	t.Run("zero key usages", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewCertRequest(scope, subject, csr, sans, cs.KeyUsages{}, time.Hour)
+		assertCode(t, err, errcode.ErrCertRequestInvalid)
+	})
+}
+
+func TestNewIssuedCert(t *testing.T) {
+	t.Parallel()
+	scope := mustScope(t)
+	notAfter := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	certDER := testCertDER(t, big.NewInt(0x1a2b3c), notAfter)
+
+	t.Run("valid derives serial and validity from DER", func(t *testing.T) {
+		t.Parallel()
+		chain := [][]byte{testCertDER(t, big.NewInt(0x01), notAfter)}
+		ic, err := cs.NewIssuedCert(scope, certDER, chain, 3)
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if ic.Serial().String() != "1a2b3c" {
+			t.Errorf("derived serial = %q, want 1a2b3c", ic.Serial().String())
+		}
+		if !ic.NotAfter().Equal(notAfter) {
+			t.Errorf("notAfter = %v", ic.NotAfter())
+		}
+		if !ic.NotBefore().Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("notBefore = %v", ic.NotBefore())
+		}
+		if ic.Epoch() != 3 {
+			t.Errorf("epoch = %d", ic.Epoch())
+		}
+		if len(ic.DER()) != len(certDER) || len(ic.Chain()) != 1 {
+			t.Error("DER/Chain accessor mismatch")
+		}
+		cert, err := ic.Certificate()
+		if err != nil || cert.SerialNumber.Cmp(big.NewInt(0x1a2b3c)) != 0 {
+			t.Errorf("Certificate() parse: %v", err)
+		}
+		// defensive copy
+		ic.DER()[0] ^= 0xff
+		if ic.DER()[0] == (certDER[0] ^ 0xff) {
+			t.Error("DER must return a copy")
+		}
+	})
+
+	t.Run("zero scope", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewIssuedCert(cs.CertScope{}, certDER, nil, 0)
+		assertCode(t, err, errcode.ErrCertIssuedInvalid)
+	})
+	t.Run("empty der", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewIssuedCert(scope, nil, nil, 0)
+		assertCode(t, err, errcode.ErrCertIssuedInvalid)
+	})
+	t.Run("garbage der", func(t *testing.T) {
+		t.Parallel()
+		_, err := cs.NewIssuedCert(scope, []byte("not-a-cert"), nil, 0)
+		assertCode(t, err, errcode.ErrCertIssuedInvalid)
+	})
+}

--- a/framework/runtime/certsigning/revocation.go
+++ b/framework/runtime/certsigning/revocation.go
@@ -29,25 +29,45 @@ var (
 	reasonAffiliationChanged   = RevocationReason{v: "affiliationChanged"}
 	reasonSuperseded           = RevocationReason{v: "superseded"}
 	reasonCessationOfOperation = RevocationReason{v: "cessationOfOperation"}
+	reasonCertificateHold      = RevocationReason{v: "certificateHold"}
+	reasonRemoveFromCRL        = RevocationReason{v: "removeFromCRL"}
+	reasonPrivilegeWithdrawn   = RevocationReason{v: "privilegeWithdrawn"}
+	reasonAACompromise         = RevocationReason{v: "aACompromise"}
 )
 
 // ReasonUnspecified is RFC 5280 reason code 0.
 func ReasonUnspecified() RevocationReason { return reasonUnspecified }
 
-// ReasonKeyCompromise is RFC 5280 reason code 1.
+// ReasonKeyCompromise is RFC 5280 reason code 1. Use when the certificate's
+// private key is known or suspected compromised.
 func ReasonKeyCompromise() RevocationReason { return reasonKeyCompromise }
 
-// ReasonCACompromise is RFC 5280 reason code 2.
+// ReasonCACompromise is RFC 5280 reason code 2 (the issuing CA key is compromised).
 func ReasonCACompromise() RevocationReason { return reasonCACompromise }
 
 // ReasonAffiliationChanged is RFC 5280 reason code 3.
 func ReasonAffiliationChanged() RevocationReason { return reasonAffiliationChanged }
 
-// ReasonSuperseded is RFC 5280 reason code 4.
+// ReasonSuperseded is RFC 5280 reason code 4 (a replacement certificate was issued).
 func ReasonSuperseded() RevocationReason { return reasonSuperseded }
 
 // ReasonCessationOfOperation is RFC 5280 reason code 5.
 func ReasonCessationOfOperation() RevocationReason { return reasonCessationOfOperation }
+
+// ReasonCertificateHold is RFC 5280 reason code 6 (temporary suspension; may be
+// lifted via ReasonRemoveFromCRL).
+func ReasonCertificateHold() RevocationReason { return reasonCertificateHold }
+
+// ReasonRemoveFromCRL is RFC 5280 reason code 8 (remove a held entry — un-hold).
+func ReasonRemoveFromCRL() RevocationReason { return reasonRemoveFromCRL }
+
+// ReasonPrivilegeWithdrawn is RFC 5280 reason code 9. Use when a device's
+// authorization to hold the certificate is withdrawn (MDM de-enrollment / ZT
+// privilege revocation).
+func ReasonPrivilegeWithdrawn() RevocationReason { return reasonPrivilegeWithdrawn }
+
+// ReasonAACompromise is RFC 5280 reason code 10 (attribute-authority compromise).
+func ReasonAACompromise() RevocationReason { return reasonAACompromise }
 
 // String returns the reason mnemonic; a zero value renders as reasonUnknown
 // (fail-closed), never the empty string.
@@ -72,10 +92,15 @@ var allRevocationReasons = []RevocationReason{
 	reasonAffiliationChanged,
 	reasonSuperseded,
 	reasonCessationOfOperation,
+	reasonCertificateHold,
+	reasonRemoveFromCRL,
+	reasonPrivilegeWithdrawn,
+	reasonAACompromise,
 }
 
-// RevocationReasons returns a copy of the closed set of revocation reasons (for
-// enumeration / validation by callers and adapters).
+// RevocationReasons returns a defensive copy of the closed set of every RFC 5280
+// §5.3.1 revocation reason this seam supports (for enumeration or adapter
+// validation). Mutating the result does not affect the registry.
 func RevocationReasons() []RevocationReason {
 	return append([]RevocationReason(nil), allRevocationReasons...)
 }
@@ -85,6 +110,10 @@ func RevocationReasons() []RevocationReason {
 // sealing ceremony) — the security-bearing values it carries ([Serial],
 // [RevocationReason]) are themselves sealed, so a forged RevokedCertificate
 // still cannot name a forged serial or out-of-spec reason.
+//
+// RevokedAt MUST be UTC: implementations normalize to UTC before returning, so
+// callers can compare it against the [RevocationStore.Tidy] before instant and
+// CRL thisUpdate/nextUpdate without timezone ambiguity.
 type RevokedCertificate struct {
 	Serial    Serial
 	Reason    RevocationReason

--- a/framework/runtime/certsigning/revocation.go
+++ b/framework/runtime/certsigning/revocation.go
@@ -1,0 +1,113 @@
+package certsigning
+
+import (
+	"context"
+	"time"
+)
+
+// RevocationReason is the sealed RFC 5280 §5.3.1 CRL reason code. The value set
+// is closed by the type system (single unexported field; the only constructors
+// are the package-private singletons exposed via the accessor functions below),
+// mirroring runtime/transport.TransportMode — an external package cannot mint an
+// out-of-spec reason or pass a raw string where a RevocationReason is required.
+// The zero value is invalid ([RevocationReason.IsZero]); it renders as the
+// reasonUnknown sentinel rather than the empty string (fail-closed).
+type RevocationReason struct{ v string }
+
+// reasonUnknown is the fail-closed render of a zero-value RevocationReason. It is
+// NOT a producible reason (absent from allRevocationReasons) — only the zero
+// value renders as it, signaling a forged/uninitialized reason.
+const reasonUnknown = "unknown"
+
+// Package-private singletons — the sole RevocationReason values (RFC 5280
+// §5.3.1). Exposed via accessor functions (not exported vars) so the registered
+// values are immutable: reassigning a function is a compile error.
+var (
+	reasonUnspecified          = RevocationReason{v: "unspecified"}
+	reasonKeyCompromise        = RevocationReason{v: "keyCompromise"}
+	reasonCACompromise         = RevocationReason{v: "cACompromise"}
+	reasonAffiliationChanged   = RevocationReason{v: "affiliationChanged"}
+	reasonSuperseded           = RevocationReason{v: "superseded"}
+	reasonCessationOfOperation = RevocationReason{v: "cessationOfOperation"}
+)
+
+// ReasonUnspecified is RFC 5280 reason code 0.
+func ReasonUnspecified() RevocationReason { return reasonUnspecified }
+
+// ReasonKeyCompromise is RFC 5280 reason code 1.
+func ReasonKeyCompromise() RevocationReason { return reasonKeyCompromise }
+
+// ReasonCACompromise is RFC 5280 reason code 2.
+func ReasonCACompromise() RevocationReason { return reasonCACompromise }
+
+// ReasonAffiliationChanged is RFC 5280 reason code 3.
+func ReasonAffiliationChanged() RevocationReason { return reasonAffiliationChanged }
+
+// ReasonSuperseded is RFC 5280 reason code 4.
+func ReasonSuperseded() RevocationReason { return reasonSuperseded }
+
+// ReasonCessationOfOperation is RFC 5280 reason code 5.
+func ReasonCessationOfOperation() RevocationReason { return reasonCessationOfOperation }
+
+// String returns the reason mnemonic; a zero value renders as reasonUnknown
+// (fail-closed), never the empty string.
+func (r RevocationReason) String() string {
+	if r.v == "" {
+		return reasonUnknown
+	}
+	return r.v
+}
+
+// IsZero reports whether r is the invalid zero value.
+func (r RevocationReason) IsZero() bool { return r.v == "" }
+
+// allRevocationReasons is the closed registry of every producible reason. It
+// backs the anti-vacuity freeze (a new reason added without registering here —
+// or a renamed mnemonic — is caught by the archtest) and the [RevocationReasons]
+// enumeration accessor.
+var allRevocationReasons = []RevocationReason{
+	reasonUnspecified,
+	reasonKeyCompromise,
+	reasonCACompromise,
+	reasonAffiliationChanged,
+	reasonSuperseded,
+	reasonCessationOfOperation,
+}
+
+// RevocationReasons returns a copy of the closed set of revocation reasons (for
+// enumeration / validation by callers and adapters).
+func RevocationReasons() []RevocationReason {
+	return append([]RevocationReason(nil), allRevocationReasons...)
+}
+
+// RevokedCertificate is a read-only revocation-list entry: a revoked serial, its
+// reason, and when it was revoked. It is an output DTO with exported fields (no
+// sealing ceremony) — the security-bearing values it carries ([Serial],
+// [RevocationReason]) are themselves sealed, so a forged RevokedCertificate
+// still cannot name a forged serial or out-of-spec reason.
+type RevokedCertificate struct {
+	Serial    Serial
+	Reason    RevocationReason
+	RevokedAt time.Time
+}
+
+// RevocationStore is the certificate revocation + CRL seam. Every method takes a
+// [CertScope] as a mandatory typed positional parameter (the tenant + issuer +
+// device isolation domain), so revocation and CRL queries CANNOT be expressed by
+// a bare serial — omitting the scope is a compile error and passing a raw string
+// is a type error (CERT-REVOKE-SCOPED-01, Hard). Implementations (softca / PG,
+// PR-6) MUST fail closed across isolation domains: a serial belonging to another
+// tenant or issuer is invisible to Revoke / RevocationList — a caller never
+// revokes or enumerates outside its scope (绝不凭裸 serial 跨隔离域).
+type RevocationStore interface {
+	// Revoke marks serial revoked within scope, with reason. Cross-scope serials
+	// fail closed (the serial is treated as not found in scope).
+	Revoke(ctx context.Context, scope CertScope, serial Serial, reason RevocationReason) error
+
+	// RevocationList returns the revoked certificates within scope only.
+	RevocationList(ctx context.Context, scope CertScope) ([]RevokedCertificate, error)
+
+	// Tidy removes revocation records within scope whose certificates expired
+	// before the given instant.
+	Tidy(ctx context.Context, scope CertScope, before time.Time) error
+}

--- a/framework/runtime/certsigning/revocation_test.go
+++ b/framework/runtime/certsigning/revocation_test.go
@@ -18,8 +18,8 @@ func TestRevocationReasonClosedSet(t *testing.T) {
 	}
 
 	reasons := cs.RevocationReasons()
-	if len(reasons) != 6 {
-		t.Fatalf("expected 6 RFC 5280 reasons, got %d", len(reasons))
+	if len(reasons) != 10 {
+		t.Fatalf("expected 10 RFC 5280 reasons, got %d", len(reasons))
 	}
 	// Every registered reason is non-zero and stringifies to its mnemonic.
 	for _, r := range reasons {
@@ -35,6 +35,10 @@ func TestRevocationReasonClosedSet(t *testing.T) {
 		cs.ReasonAffiliationChanged().String():   "affiliationChanged",
 		cs.ReasonSuperseded().String():           "superseded",
 		cs.ReasonCessationOfOperation().String(): "cessationOfOperation",
+		cs.ReasonCertificateHold().String():      "certificateHold",
+		cs.ReasonRemoveFromCRL().String():        "removeFromCRL",
+		cs.ReasonPrivilegeWithdrawn().String():   "privilegeWithdrawn",
+		cs.ReasonAACompromise().String():         "aACompromise",
 	} {
 		if got != want {
 			t.Errorf("reason mnemonic = %q, want %q", got, want)
@@ -96,9 +100,10 @@ func TestRevocationStoreScopeIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	issuer, _ := cs.NewIssuerID("ca-root")
+	issuerB, _ := cs.NewIssuerID("ca-other")
 	dev, _ := cs.NewDeviceID("device-1")
+	devB, _ := cs.NewDeviceID("device-2")
 	scopeA, _ := cs.NewCertScope(mustTenant(t, testTenant), issuer, dev)
-	scopeB, _ := cs.NewCertScope(mustTenant(t, testTenantB), issuer, dev)
 	serial, _ := cs.NewSerial("1a2b3c")
 
 	if err := store.Revoke(ctx, scopeA, serial, cs.ReasonKeyCompromise()); err != nil {
@@ -111,21 +116,47 @@ func TestRevocationStoreScopeIsolation(t *testing.T) {
 		t.Fatalf("scope A list: %v %+v", err, listA)
 	}
 
-	// Invisible across the tenant boundary (fail-closed by scope key) — a
-	// tenant-B principal cannot see tenant-A's serial.
-	listB, err := store.RevocationList(ctx, scopeB)
-	if err != nil {
-		t.Fatalf("scope B list: %v", err)
+	// FR-007: the serial is invisible across EVERY isolation dimension — a query
+	// under a different tenant, issuer, or device must not surface it. A bare
+	// serial never crosses an isolation domain.
+	crossScopes := map[string]cs.CertScope{
+		"cross-tenant": mustScopeFrom(t, testTenantB, issuer, dev),
+		"cross-issuer": mustScopeFrom(t, testTenant, issuerB, dev),
+		"cross-device": mustScopeFrom(t, testTenant, issuer, devB),
 	}
-	if len(listB) != 0 {
-		t.Errorf("cross-tenant query leaked %d entries; serial must be invisible across scope", len(listB))
+	for name, sc := range crossScopes {
+		list, err := store.RevocationList(ctx, sc)
+		if err != nil {
+			t.Fatalf("%s list: %v", name, err)
+		}
+		if len(list) != 0 {
+			t.Errorf("%s query leaked %d entries; serial must be invisible across scope", name, len(list))
+		}
+	}
+
+	// Revoke under a different scope must not touch scope A's entry.
+	if err := store.Revoke(ctx, crossScopes["cross-issuer"], serial, cs.ReasonSuperseded()); err != nil {
+		t.Fatalf("cross-issuer revoke: %v", err)
+	}
+	if listA, _ = store.RevocationList(ctx, scopeA); len(listA) != 1 || listA[0].Reason != cs.ReasonKeyCompromise() {
+		t.Error("cross-issuer Revoke must not mutate scope A's entry")
 	}
 
 	// Tidy is scope-bounded.
-	if err := store.Tidy(ctx, scopeB, time.Now()); err != nil {
-		t.Fatalf("tidy scope B: %v", err)
+	if err := store.Tidy(ctx, crossScopes["cross-tenant"], time.Now()); err != nil {
+		t.Fatalf("tidy cross-tenant: %v", err)
 	}
 	if listA, _ = store.RevocationList(ctx, scopeA); len(listA) != 1 {
-		t.Error("tidy of scope B must not affect scope A")
+		t.Error("tidy of another scope must not affect scope A")
 	}
+}
+
+// mustScopeFrom builds a CertScope from explicit dimensions for isolation tests.
+func mustScopeFrom(t *testing.T, tenantID string, issuer cs.IssuerID, dev cs.DeviceID) cs.CertScope {
+	t.Helper()
+	sc, err := cs.NewCertScope(mustTenant(t, tenantID), issuer, dev)
+	if err != nil {
+		t.Fatalf("scope: %v", err)
+	}
+	return sc
 }

--- a/framework/runtime/certsigning/revocation_test.go
+++ b/framework/runtime/certsigning/revocation_test.go
@@ -1,0 +1,131 @@
+package certsigning_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+func TestRevocationReasonClosedSet(t *testing.T) {
+	t.Parallel()
+
+	// Zero value is invalid and renders as the fail-closed sentinel.
+	var zero cs.RevocationReason
+	if !zero.IsZero() || zero.String() != "unknown" {
+		t.Errorf("zero reason: isZero=%v str=%q", zero.IsZero(), zero.String())
+	}
+
+	reasons := cs.RevocationReasons()
+	if len(reasons) != 6 {
+		t.Fatalf("expected 6 RFC 5280 reasons, got %d", len(reasons))
+	}
+	// Every registered reason is non-zero and stringifies to its mnemonic.
+	for _, r := range reasons {
+		if r.IsZero() || r.String() == "unknown" {
+			t.Errorf("registered reason %q must be non-zero", r.String())
+		}
+	}
+	// Each accessor returns its RFC 5280 mnemonic.
+	for got, want := range map[string]string{
+		cs.ReasonUnspecified().String():          "unspecified",
+		cs.ReasonKeyCompromise().String():        "keyCompromise",
+		cs.ReasonCACompromise().String():         "cACompromise",
+		cs.ReasonAffiliationChanged().String():   "affiliationChanged",
+		cs.ReasonSuperseded().String():           "superseded",
+		cs.ReasonCessationOfOperation().String(): "cessationOfOperation",
+	} {
+		if got != want {
+			t.Errorf("reason mnemonic = %q, want %q", got, want)
+		}
+	}
+
+	// RevocationReasons returns a copy (mutating it must not affect the registry).
+	reasons[0] = cs.RevocationReason{}
+	if cs.RevocationReasons()[0].IsZero() {
+		t.Error("RevocationReasons must return a defensive copy")
+	}
+}
+
+// memRevocationStore is a TEST-ONLY fake demonstrating that the RevocationStore
+// interface shape supports CertScope isolation: a revoked serial is recorded
+// AND keyed by scope, and a query/revoke under a different scope cannot see it.
+// The production fail-closed cross-scope behavior (acceptance scenario 7) lands
+// with the softca / PG implementation in PR-6 (#1902); this fake proves the seam
+// can express it (绝不凭裸 serial 跨隔离域).
+type memRevocationStore struct {
+	byScope map[string]map[string]cs.RevokedCertificate
+}
+
+func newMemRevocationStore() *memRevocationStore {
+	return &memRevocationStore{byScope: map[string]map[string]cs.RevokedCertificate{}}
+}
+
+func scopeKey(s cs.CertScope) string {
+	return s.Tenant().String() + "|" + s.Issuer().String() + "|" + s.Device().String()
+}
+
+func (m *memRevocationStore) Revoke(_ context.Context, scope cs.CertScope, serial cs.Serial, reason cs.RevocationReason) error {
+	k := scopeKey(scope)
+	if m.byScope[k] == nil {
+		m.byScope[k] = map[string]cs.RevokedCertificate{}
+	}
+	m.byScope[k][serial.String()] = cs.RevokedCertificate{
+		Serial: serial, Reason: reason, RevokedAt: time.Unix(0, 0).UTC(),
+	}
+	return nil
+}
+
+func (m *memRevocationStore) RevocationList(_ context.Context, scope cs.CertScope) ([]cs.RevokedCertificate, error) {
+	var out []cs.RevokedCertificate
+	for _, rc := range m.byScope[scopeKey(scope)] {
+		out = append(out, rc)
+	}
+	return out, nil
+}
+
+func (m *memRevocationStore) Tidy(_ context.Context, scope cs.CertScope, _ time.Time) error {
+	delete(m.byScope, scopeKey(scope))
+	return nil
+}
+
+func TestRevocationStoreScopeIsolation(t *testing.T) {
+	t.Parallel()
+	var store cs.RevocationStore = newMemRevocationStore()
+	ctx := context.Background()
+
+	issuer, _ := cs.NewIssuerID("ca-root")
+	dev, _ := cs.NewDeviceID("device-1")
+	scopeA, _ := cs.NewCertScope(mustTenant(t, testTenant), issuer, dev)
+	scopeB, _ := cs.NewCertScope(mustTenant(t, testTenantB), issuer, dev)
+	serial, _ := cs.NewSerial("1a2b3c")
+
+	if err := store.Revoke(ctx, scopeA, serial, cs.ReasonKeyCompromise()); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	// Visible within scope A.
+	listA, err := store.RevocationList(ctx, scopeA)
+	if err != nil || len(listA) != 1 || listA[0].Serial != serial {
+		t.Fatalf("scope A list: %v %+v", err, listA)
+	}
+
+	// Invisible across the tenant boundary (fail-closed by scope key) — a
+	// tenant-B principal cannot see tenant-A's serial.
+	listB, err := store.RevocationList(ctx, scopeB)
+	if err != nil {
+		t.Fatalf("scope B list: %v", err)
+	}
+	if len(listB) != 0 {
+		t.Errorf("cross-tenant query leaked %d entries; serial must be invisible across scope", len(listB))
+	}
+
+	// Tidy is scope-bounded.
+	if err := store.Tidy(ctx, scopeB, time.Now()); err != nil {
+		t.Fatalf("tidy scope B: %v", err)
+	}
+	if listA, _ = store.RevocationList(ctx, scopeA); len(listA) != 1 {
+		t.Error("tidy of scope B must not affect scope A")
+	}
+}

--- a/framework/runtime/certsigning/signer.go
+++ b/framework/runtime/certsigning/signer.go
@@ -1,0 +1,29 @@
+package certsigning
+
+import "context"
+
+// Signer is the CA signing seam (the cert-manager Sign / SPIRE ServerCA /
+// step-ca Authority.Sign analog). It is the SINGLE entry point for minting a
+// device certificate: a Signer takes a sealed [CertRequest] and returns a sealed
+// [IssuedCert]. The implementation lives in an adapter (adapters/softca, PR-6),
+// where the signing private key (crypto.Signer) is held and NEVER crosses this
+// boundary — the interface exposes a Sign operation and the trust bundle, never
+// a key getter.
+//
+// Sign is fail-closed: a Signer that cannot mint a certificate (CA unavailable,
+// constraint violation) returns an error and never a partial / downgraded
+// credential. Authorization (whether a device may obtain a certificate at all)
+// is a SEPARATE concern handled by [Authorizer] — an authorization defect must
+// not widen into unauthorized signing.
+type Signer interface {
+	// Sign mints a certificate for req and returns the sealed result. The
+	// implementation reads the public key + proof-of-possession from the
+	// request CSR but takes the subject / SANs / usages from the (constrained)
+	// request itself, never blindly from the CSR.
+	Sign(ctx context.Context, req CertRequest) (IssuedCert, error)
+
+	// TrustBundle returns the CA trust anchors as DER-encoded certificates (the
+	// EST /cacerts payload). It is a read-only output (no sealing ceremony) — the
+	// caller verifies issued chains against it.
+	TrustBundle(ctx context.Context) ([][]byte, error)
+}

--- a/framework/runtime/certsigning/signer.go
+++ b/framework/runtime/certsigning/signer.go
@@ -22,8 +22,11 @@ type Signer interface {
 	// request itself, never blindly from the CSR.
 	Sign(ctx context.Context, req CertRequest) (IssuedCert, error)
 
-	// TrustBundle returns the CA trust anchors as DER-encoded certificates (the
-	// EST /cacerts payload). It is a read-only output (no sealing ceremony) — the
-	// caller verifies issued chains against it.
+	// TrustBundle returns the CA trust anchors as DER-encoded certificates,
+	// ordered leaf-issuer first to root last (the order an EST /cacerts response
+	// is built from). It is a read-only output (no sealing ceremony) — the caller
+	// verifies issued chains against it. Each element is a single certificate
+	// DER; the EST front-end (PR-8b) is responsible for packaging them into the
+	// RFC 7030 application/pkcs7-mime /cacerts response.
 	TrustBundle(ctx context.Context) ([][]byte, error)
 }

--- a/framework/runtime/certsigning/signer.go
+++ b/framework/runtime/certsigning/signer.go
@@ -16,11 +16,14 @@ import "context"
 // is a SEPARATE concern handled by [Authorizer] — an authorization defect must
 // not widen into unauthorized signing.
 type Signer interface {
-	// Sign mints a certificate for req and returns the sealed result. The
-	// implementation reads the public key + proof-of-possession from the
-	// request CSR but takes the subject / SANs / usages from the (constrained)
-	// request itself, never blindly from the CSR.
-	Sign(ctx context.Context, req CertRequest) (IssuedCert, error)
+	// Sign mints a certificate for an AUTHORIZED request and returns the sealed
+	// result. Taking [AuthorizedCertRequest] (not a bare [CertRequest]) is the
+	// type-level guarantee that authorization happened and its constraints (TTL,
+	// SAN allowance) were enforced before signing — a Signer cannot be handed an
+	// un-authorized request. The implementation reads the public key + verified
+	// proof-of-possession from the request CSR and takes subject / SANs / usages
+	// from the (constrained) request, never blindly from the CSR.
+	Sign(ctx context.Context, req AuthorizedCertRequest) (IssuedCert, error)
 
 	// TrustBundle returns the CA trust anchors as DER-encoded certificates,
 	// ordered leaf-issuer first to root last (the order an EST /cacerts response

--- a/framework/runtime/certsigning/signer_test.go
+++ b/framework/runtime/certsigning/signer_test.go
@@ -1,0 +1,65 @@
+package certsigning_test
+
+import (
+	"context"
+	"crypto/x509"
+	"math/big"
+	"testing"
+	"time"
+
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+// fakeSigner is a TEST-ONLY Signer demonstrating that the seam expresses a
+// CSR→IssuedCert mint plus a trust bundle, with the issued serial / validity
+// derived from the certificate DER (single-sourced). It is NOT a CA — it
+// fabricates a self-signed DER to exercise the interface contract. The real
+// implementation (adapters/softca) lands in PR-6.
+type fakeSigner struct {
+	t        *testing.T
+	notAfter time.Time
+}
+
+func (f fakeSigner) Sign(_ context.Context, req cs.CertRequest) (cs.IssuedCert, error) {
+	der := testCertDER(f.t, big.NewInt(0x42), f.notAfter)
+	return cs.NewIssuedCert(req.Scope(), der, nil, 0)
+}
+
+func (fakeSigner) TrustBundle(context.Context) ([][]byte, error) {
+	return [][]byte{[]byte("ca-der")}, nil
+}
+
+func TestSignerContract(t *testing.T) {
+	t.Parallel()
+	notAfter := time.Date(2027, 6, 1, 0, 0, 0, 0, time.UTC)
+	var signer cs.Signer = fakeSigner{t: t, notAfter: notAfter}
+
+	scope := mustScope(t)
+	dev, _ := cs.NewDeviceID("device-1")
+	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
+	usages, _ := cs.NewKeyUsages(x509.KeyUsageDigitalSignature, x509.ExtKeyUsageClientAuth)
+	sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
+	req, err := cs.NewCertRequest(scope, subject, testCSRDER(t, "device-1"), sans, usages, time.Hour)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	issued, err := signer.Sign(context.Background(), req)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if issued.Serial().String() != "42" {
+		t.Errorf("issued serial = %q, want 42", issued.Serial().String())
+	}
+	if !issued.NotAfter().Equal(notAfter) {
+		t.Errorf("issued notAfter = %v", issued.NotAfter())
+	}
+	if !issued.Scope().Equal(scope) {
+		t.Error("issued scope must equal request scope")
+	}
+
+	bundle, err := signer.TrustBundle(context.Background())
+	if err != nil || len(bundle) != 1 {
+		t.Fatalf("trust bundle: %v len=%d", err, len(bundle))
+	}
+}

--- a/framework/runtime/certsigning/signer_test.go
+++ b/framework/runtime/certsigning/signer_test.go
@@ -20,9 +20,9 @@ type fakeSigner struct {
 	notAfter time.Time
 }
 
-func (f fakeSigner) Sign(_ context.Context, req cs.CertRequest) (cs.IssuedCert, error) {
+func (f fakeSigner) Sign(_ context.Context, req cs.AuthorizedCertRequest) (cs.IssuedCert, error) {
 	der := testCertDER(f.t, big.NewInt(0x42), f.notAfter)
-	return cs.NewIssuedCert(req.Scope(), der, nil, 0)
+	return cs.NewIssuedCert(req.Request().Scope(), der, nil, 0)
 }
 
 func (fakeSigner) TrustBundle(context.Context) ([][]byte, error) {
@@ -39,12 +39,21 @@ func TestSignerContract(t *testing.T) {
 	subject, _ := cs.NewDeviceSubject(mustTenant(t, testTenant), dev, "device-1")
 	usages, _ := cs.NewKeyUsages(x509.KeyUsageDigitalSignature, x509.ExtKeyUsageClientAuth)
 	sans, _ := cs.NewSubjectAltNames([]string{"device-1.example"}, nil, nil)
-	req, err := cs.NewCertRequest(scope, subject, testCSRDER(t, "device-1"), sans, usages, time.Hour)
+	req, err := cs.NewCertRequest(scope, subject, testCSRDER(t), sans, usages, time.Hour)
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
+	// Sign only accepts an AuthorizedCertRequest — authorization must precede it.
+	grant, err := cs.NewSignConstraints(testGrantTTL, sans)
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	authReq, err := cs.NewAuthorizedCertRequest(req, grant)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
 
-	issued, err := signer.Sign(context.Background(), req)
+	issued, err := signer.Sign(context.Background(), authReq)
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}

--- a/tools/archtest/cert_invariants_test.go
+++ b/tools/archtest/cert_invariants_test.go
@@ -86,6 +86,7 @@ var certSealedTypes = []struct {
 	{"DeviceSubject", reflect.TypeOf(cs.DeviceSubject{})},
 	{"CertRequest", reflect.TypeOf(cs.CertRequest{})},
 	{"IssuedCert", reflect.TypeOf(cs.IssuedCert{})},
+	{"AuthorizedCertRequest", reflect.TypeOf(cs.AuthorizedCertRequest{})},
 	{"EnrollmentClaim", reflect.TypeOf(cs.EnrollmentClaim{})},
 	{"SignConstraints", reflect.TypeOf(cs.SignConstraints{})},
 	{"RevocationReason", reflect.TypeOf(cs.RevocationReason{})},
@@ -95,17 +96,18 @@ var certSealedTypes = []struct {
 // package-level funcs that may return it. A drift (new constructor, or a removed
 // one) fails the SoleConstructionSurface check.
 var certConstructorSurface = map[string]map[string]struct{}{
-	"IssuerID":        {"NewIssuerID": {}},
-	"DeviceID":        {"NewDeviceID": {}},
-	"Serial":          {"NewSerial": {}},
-	"CertScope":       {"NewCertScope": {}},
-	"SubjectAltNames": {"NewSubjectAltNames": {}},
-	"KeyUsages":       {"NewKeyUsages": {}},
-	"DeviceSubject":   {"NewDeviceSubject": {}},
-	"CertRequest":     {"NewCertRequest": {}},
-	"IssuedCert":      {"NewIssuedCert": {}},
-	"EnrollmentClaim": {"NewEnrollmentClaim": {}},
-	"SignConstraints": {"NewSignConstraints": {}},
+	"IssuerID":              {"NewIssuerID": {}},
+	"DeviceID":              {"NewDeviceID": {}},
+	"Serial":                {"NewSerial": {}},
+	"CertScope":             {"NewCertScope": {}},
+	"SubjectAltNames":       {"NewSubjectAltNames": {}},
+	"KeyUsages":             {"NewKeyUsages": {}},
+	"DeviceSubject":         {"NewDeviceSubject": {}},
+	"CertRequest":           {"NewCertRequest": {}},
+	"IssuedCert":            {"NewIssuedCert": {}},
+	"AuthorizedCertRequest": {"NewAuthorizedCertRequest": {}},
+	"EnrollmentClaim":       {"NewEnrollmentClaim": {}},
+	"SignConstraints":       {"NewSignConstraints": {}},
 	"RevocationReason": {
 		"ReasonUnspecified": {}, "ReasonKeyCompromise": {}, "ReasonCACompromise": {},
 		"ReasonAffiliationChanged": {}, "ReasonSuperseded": {}, "ReasonCessationOfOperation": {},
@@ -262,6 +264,71 @@ func TestCertSignFunnel01_RedFixture(t *testing.T) {
 	if hits == 0 {
 		t.Error("CERT-SIGN-FUNNEL-01 RED fixture: scanner found 0 hits; expected ≥ 1 from " +
 			"forbidden_mint_caller.go — the detector scanCertMintCallers may be broken")
+	}
+}
+
+// TestCertSignFunnel01_SignTakesAuthorizedRequest is the reverse self-check that
+// Signer.Sign accepts a sealed AuthorizedCertRequest (NOT a bare CertRequest).
+// Taking AuthorizedCertRequest is the compile-time guarantee that authorization
+// + constraint enforcement (NewAuthorizedCertRequest: Granted / TTL / SAN) has
+// happened before signing; relaxing the param back to CertRequest would re-open
+// unauthorized signing (FR-005) and is caught here.
+func TestCertSignFunnel01_SignTakesAuthorizedRequest(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	pkgPath := certSigningPkgPath()
+	var visited bool
+	diags := Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != pkgPath {
+				return nil
+			}
+			visited = true
+			scope := p.Pkg.Scope()
+			signerObj := scope.Lookup("Signer")
+			if signerObj == nil {
+				return []Diagnostic{{Message: "CERT-SIGN-FUNNEL-01: Signer interface not found"}}
+			}
+			iface, ok := signerObj.Type().Underlying().(*types.Interface)
+			if !ok {
+				return []Diagnostic{{Message: "CERT-SIGN-FUNNEL-01: Signer is not an interface"}}
+			}
+			authType := lookupType(scope, "AuthorizedCertRequest")
+			certReqType := lookupType(scope, "CertRequest")
+			if authType == nil {
+				return []Diagnostic{{Message: "CERT-SIGN-FUNNEL-01: AuthorizedCertRequest type not found"}}
+			}
+			var out []Diagnostic
+			found := false
+			for i := 0; i < iface.NumMethods(); i++ {
+				m := iface.Method(i)
+				if m.Name() != "Sign" {
+					continue
+				}
+				found = true
+				sig, ok := m.Type().(*types.Signature)
+				if !ok {
+					continue
+				}
+				if !sigHasParamType(sig, authType) {
+					out = append(out, Diagnostic{Message: "CERT-SIGN-FUNNEL-01: Signer.Sign must take an " +
+						"AuthorizedCertRequest parameter — authorization must precede signing (FR-005)"})
+				}
+				if certReqType != nil && sigHasParamType(sig, certReqType) {
+					out = append(out, Diagnostic{Message: "CERT-SIGN-FUNNEL-01: Signer.Sign must NOT take a bare " +
+						"CertRequest — use AuthorizedCertRequest so the authorization gate cannot be skipped"})
+				}
+			}
+			if !found {
+				out = append(out, Diagnostic{Message: "CERT-SIGN-FUNNEL-01: Signer.Sign method not found — the guard is vacuous"})
+			}
+			return out
+		})
+	Report(t, "CERT-SIGN-FUNNEL-01/SignTakesAuthorizedRequest", diags)
+	if !visited {
+		t.Fatal("CERT-SIGN-FUNNEL-01/SignTakesAuthorizedRequest: certsigning package was never scanned — vacuous")
 	}
 }
 

--- a/tools/archtest/cert_invariants_test.go
+++ b/tools/archtest/cert_invariants_test.go
@@ -109,6 +109,8 @@ var certConstructorSurface = map[string]map[string]struct{}{
 	"RevocationReason": {
 		"ReasonUnspecified": {}, "ReasonKeyCompromise": {}, "ReasonCACompromise": {},
 		"ReasonAffiliationChanged": {}, "ReasonSuperseded": {}, "ReasonCessationOfOperation": {},
+		"ReasonCertificateHold": {}, "ReasonRemoveFromCRL": {}, "ReasonPrivilegeWithdrawn": {},
+		"ReasonAACompromise": {},
 	},
 }
 
@@ -147,12 +149,13 @@ func TestCertValueSealedConstruction01_SoleConstructionSurface(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 	pkgPath := certSigningPkgPath()
-	var diags []Diagnostic
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
+	var visited bool
+	diags := Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != pkgPath {
 				return nil
 			}
+			visited = true
 			scope := p.Pkg.Scope()
 			var out []Diagnostic
 			for typeName, expected := range certConstructorSurface {
@@ -181,6 +184,10 @@ func TestCertValueSealedConstruction01_SoleConstructionSurface(t *testing.T) {
 			return out
 		})
 	Report(t, "CERT-VALUE-SEALED-CONSTRUCTION-01/SoleConstructionSurface", diags)
+	if !visited {
+		t.Fatal("CERT-VALUE-SEALED-CONSTRUCTION-01/SoleConstructionSurface: certsigning package was never " +
+			"scanned (Typed load returned no matching package) — the check is vacuous; fix the load pattern")
+	}
 }
 
 // ── CERT-SIGN-FUNNEL-01 ────────────────────────────────────────────────────
@@ -271,12 +278,13 @@ func TestCertRevokeScoped01_StoreMethodsCarryScope(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 	pkgPath := certSigningPkgPath()
-	var diags []Diagnostic
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
+	var visited bool
+	diags := Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
 		func(p *Pass) []Diagnostic {
 			if p.Pkg == nil || p.Pkg.Path() != pkgPath {
 				return nil
 			}
+			visited = true
 			scope := p.Pkg.Scope()
 			storeObj := scope.Lookup("RevocationStore")
 			if storeObj == nil {
@@ -324,6 +332,10 @@ func TestCertRevokeScoped01_StoreMethodsCarryScope(t *testing.T) {
 			return out
 		})
 	Report(t, "CERT-REVOKE-SCOPED-01/StoreMethodsCarryScope", diags)
+	if !visited {
+		t.Fatal("CERT-REVOKE-SCOPED-01/StoreMethodsCarryScope: certsigning package was never scanned " +
+			"(Typed load returned no matching package) — the check is vacuous; fix the load pattern")
+	}
 }
 
 // lookupType returns the types.Type of a named type in scope, or nil.

--- a/tools/archtest/cert_invariants_test.go
+++ b/tools/archtest/cert_invariants_test.go
@@ -1,0 +1,348 @@
+//go:build archtest
+
+// INVARIANT: CERT-VALUE-SEALED-CONSTRUCTION-01
+// INVARIANT: CERT-SIGN-FUNNEL-01
+// INVARIANT: CERT-REVOKE-SCOPED-01
+//
+// Consolidated certificate-signing archtest invariants for
+// framework/runtime/certsigning (Epic #1895 PR-5 #1901). Authoritative godoc:
+// framework/runtime/certsigning/doc.go §Enforced invariants.
+//
+// # CERT-VALUE-SEALED-CONSTRUCTION-01 (Hard)
+//
+// Every cross-trust-boundary input and minted-credential value type in
+// certsigning has only unexported fields, so a POPULATED composite literal of
+// any of them outside the package is a Go compile error — forging certificate
+// material / signing inputs is structurally unrepresentable. The sole minters
+// are the New* constructors (RevocationReason: the Reason* accessor singletons).
+// The Go compiler is the Hard gate; these tests are the REVERSE self-check that
+// pins the seal so a future PR re-exporting a field, or adding a second
+// constructor surface, fails at PR/nightly time:
+//   - AllFieldsUnexported (reflect): every field of every sealed type is unexported.
+//   - SoleConstructionSurface (go/types): the exported funcs returning each
+//     sealed type match the frozen constructor allowlist exactly (anti-vacuity).
+//
+// Read-only OUTPUT types (RevokedCertificate, the TrustBundle DER slice) are
+// intentionally NOT sealed — they carry no forgeable boundary — and are absent
+// from certSealedTypes by design.
+//
+// # CERT-SIGN-FUNNEL-01 (funnel; upstream Hard, downstream Medium)
+//
+// Upstream Hard: IssuedCert / CertRequest field sealing (above) makes forged
+// signing material uncompilable. Downstream Medium: a caller-allowlist scan
+// restricts who may invoke NewIssuedCert (the mint funnel) to the sanctioned
+// signer adapter. The allowlist (certIssuedMintAllowlist) is EMPTY in PR-5 — no
+// signer implementation exists yet; adapters/softca joins it in PR-6. GREEN =
+// zero callers outside certsigning today; the RED fixture proves the detector
+// fires.
+//
+// Blind spot (per AI-robust §强制盲区自检): NewIssuedCert MUST be exported
+// because the signing adapter lives in a different module, so "only the
+// sanctioned Signer mints certificates" is a Medium caller-allowlist, NOT Hard —
+// there is no low-cost Hard path while the adapter is necessarily external. The
+// upstream populated-literal forgery vector cannot have a RED fixture: such a
+// literal does not compile (that is precisely the Hard seal).
+//
+// # CERT-REVOKE-SCOPED-01 (Hard)
+//
+// RevocationStore.Revoke / RevocationList / Tidy take CertScope (and Revoke
+// additionally Serial) as mandatory typed positional parameters — omitting the
+// scope is a compile error (arity), passing a raw string is a compile error
+// (type). The type system is the Hard guarantee; this is the reverse
+// self-check / anti-vacuity that fails if a refactor relaxes a signature back to
+// a bare string or serial, or drops a required method.
+package archtest
+
+import (
+	"go/ast"
+	"go/types"
+	"reflect"
+	"testing"
+
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// certSigningPkgPath is the import path of the package under guard.
+func certSigningPkgPath() string { return PlatformFrameworkModulePath + "/runtime/certsigning" }
+
+const certSigningPattern = "./framework/runtime/certsigning/..."
+
+// ── CERT-VALUE-SEALED-CONSTRUCTION-01 ──────────────────────────────────────
+
+// certSealedTypes is the closed set of sealed (unexported-field) value types.
+// Read-only output types (RevokedCertificate, trust-bundle slice) are excluded
+// by design — they carry no forgeable boundary.
+var certSealedTypes = []struct {
+	name string
+	typ  reflect.Type
+}{
+	{"IssuerID", reflect.TypeOf(cs.IssuerID{})},
+	{"DeviceID", reflect.TypeOf(cs.DeviceID{})},
+	{"Serial", reflect.TypeOf(cs.Serial{})},
+	{"CertScope", reflect.TypeOf(cs.CertScope{})},
+	{"SubjectAltNames", reflect.TypeOf(cs.SubjectAltNames{})},
+	{"KeyUsages", reflect.TypeOf(cs.KeyUsages{})},
+	{"DeviceSubject", reflect.TypeOf(cs.DeviceSubject{})},
+	{"CertRequest", reflect.TypeOf(cs.CertRequest{})},
+	{"IssuedCert", reflect.TypeOf(cs.IssuedCert{})},
+	{"EnrollmentClaim", reflect.TypeOf(cs.EnrollmentClaim{})},
+	{"SignConstraints", reflect.TypeOf(cs.SignConstraints{})},
+	{"RevocationReason", reflect.TypeOf(cs.RevocationReason{})},
+}
+
+// certConstructorSurface freezes, per sealed type, the exact set of exported
+// package-level funcs that may return it. A drift (new constructor, or a removed
+// one) fails the SoleConstructionSurface check.
+var certConstructorSurface = map[string]map[string]struct{}{
+	"IssuerID":        {"NewIssuerID": {}},
+	"DeviceID":        {"NewDeviceID": {}},
+	"Serial":          {"NewSerial": {}},
+	"CertScope":       {"NewCertScope": {}},
+	"SubjectAltNames": {"NewSubjectAltNames": {}},
+	"KeyUsages":       {"NewKeyUsages": {}},
+	"DeviceSubject":   {"NewDeviceSubject": {}},
+	"CertRequest":     {"NewCertRequest": {}},
+	"IssuedCert":      {"NewIssuedCert": {}},
+	"EnrollmentClaim": {"NewEnrollmentClaim": {}},
+	"SignConstraints": {"NewSignConstraints": {}},
+	"RevocationReason": {
+		"ReasonUnspecified": {}, "ReasonKeyCompromise": {}, "ReasonCACompromise": {},
+		"ReasonAffiliationChanged": {}, "ReasonSuperseded": {}, "ReasonCessationOfOperation": {},
+	},
+}
+
+// TestCertValueSealedConstruction01_AllFieldsUnexported reflectively asserts
+// every sealed type has zero exported fields — the property that makes a
+// populated composite literal a compile error outside certsigning.
+func TestCertValueSealedConstruction01_AllFieldsUnexported(t *testing.T) {
+	t.Parallel()
+	for _, st := range certSealedTypes {
+		if st.typ.Kind() != reflect.Struct {
+			t.Errorf("CERT-VALUE-SEALED-CONSTRUCTION-01: certsigning.%s is not a struct (kind=%s)", st.name, st.typ.Kind())
+			continue
+		}
+		if st.typ.NumField() == 0 {
+			t.Errorf("CERT-VALUE-SEALED-CONSTRUCTION-01: certsigning.%s has no fields — the seal would be vacuous", st.name)
+			continue
+		}
+		for i := 0; i < st.typ.NumField(); i++ {
+			f := st.typ.Field(i)
+			if f.IsExported() {
+				t.Errorf("CERT-VALUE-SEALED-CONSTRUCTION-01: certsigning.%s field %q is EXPORTED — this re-opens "+
+					"external populated-literal forgery of certificate material. Keep all fields unexported and "+
+					"expose reads via value-receiver getters; construct via the New* funnel.", st.name, f.Name)
+			}
+		}
+	}
+}
+
+// TestCertValueSealedConstruction01_SoleConstructionSurface pins, per sealed
+// type, the complete set of exported funcs that yield it. A new func returning a
+// sealed type (a fresh construction backdoor the literal seal does not cover), or
+// a removed sanctioned constructor (making the seal vacuous), fails here.
+func TestCertValueSealedConstruction01_SoleConstructionSurface(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	pkgPath := certSigningPkgPath()
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != pkgPath {
+				return nil
+			}
+			scope := p.Pkg.Scope()
+			var out []Diagnostic
+			for typeName, expected := range certConstructorSurface {
+				obj := scope.Lookup(typeName)
+				if obj == nil {
+					out = append(out, Diagnostic{Message: "CERT-VALUE-SEALED-CONSTRUCTION-01: sealed type certsigning." + typeName + " not found"})
+					continue
+				}
+				want := obj.Type()
+				var funcs []string
+				for _, name := range scope.Names() {
+					o := scope.Lookup(name)
+					if !o.Exported() {
+						continue
+					}
+					fn, ok := o.(*types.Func)
+					if !ok {
+						continue
+					}
+					if sig, ok := fn.Type().(*types.Signature); ok && sigReturnsType(sig, want) {
+						funcs = append(funcs, name)
+					}
+				}
+				out = append(out, diffExpectedSet("constructors returning certsigning."+typeName, expected, funcs)...)
+			}
+			return out
+		})
+	Report(t, "CERT-VALUE-SEALED-CONSTRUCTION-01/SoleConstructionSurface", diags)
+}
+
+// ── CERT-SIGN-FUNNEL-01 ────────────────────────────────────────────────────
+
+// certIssuedMintAllowlist is the set of package import paths permitted to call
+// certsigning.NewIssuedCert (the certificate mint funnel). EMPTY in PR-5: no
+// signer implementation exists yet. adapters/softca (PR-6 #1902) is the first
+// member. The certsigning package itself is exempt separately (it is the home of
+// the constructor).
+var certIssuedMintAllowlist = map[string]struct{}{}
+
+const certMintCallerMsg = "forbidden call certsigning.NewIssuedCert — minting an IssuedCert is restricted to the " +
+	"sanctioned signer adapter (certIssuedMintAllowlist); business code obtains certificates via Signer.Sign"
+
+// scanCertMintCallers flags calls to certsigning.NewIssuedCert from packages
+// outside certsigning and the mint allowlist.
+func scanCertMintCallers(p *Pass, pkgPath string) []Diagnostic {
+	if p.Pkg != nil && p.Pkg.Path() == pkgPath {
+		return nil
+	}
+	if p.Pkg != nil {
+		if _, ok := certIssuedMintAllowlist[p.Pkg.Path()]; ok {
+			return nil
+		}
+	}
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if IsCallToPkgFunc(p.TypesInfo, call, pkgPath, "NewIssuedCert") {
+				pos := p.Fset.Position(call.Pos())
+				diags = append(diags, Diagnostic{Rel: rel, Line: pos.Line, Message: certMintCallerMsg})
+			}
+		})
+	}
+	return diags
+}
+
+// TestCertSignFunnel01_GreenProduction asserts production code has zero
+// out-of-allowlist callers of certsigning.NewIssuedCert today.
+func TestCertSignFunnel01_GreenProduction(t *testing.T) {
+	t.Parallel()
+	pkgPath := certSigningPkgPath()
+	diags := Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		return scanCertMintCallers(p, pkgPath)
+	})
+	if len(diags) > 0 {
+		t.Errorf("CERT-SIGN-FUNNEL-01 production GREEN: expected 0 violations, got %d:\n%v", len(diags), diags)
+	}
+}
+
+// TestCertSignFunnel01_RedFixture loads the archtest_fixture-tagged fixture (a
+// non-allowlisted package calling NewIssuedCert) and asserts the detector fires
+// — the reverse self-check that the GREEN baseline above is meaningful.
+func TestCertSignFunnel01_RedFixture(t *testing.T) {
+	t.Parallel()
+	pkgPath := certSigningPkgPath()
+	diags := Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/certsignmintfixture/..."}),
+		func(p *Pass) []Diagnostic {
+			return scanCertMintCallers(p, pkgPath)
+		})
+	for _, d := range diags {
+		t.Logf("RED fixture hit: %s:%d %s", d.Rel, d.Line, d.Message)
+	}
+	var hits int
+	for _, d := range diags {
+		if d.Message == certMintCallerMsg {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Error("CERT-SIGN-FUNNEL-01 RED fixture: scanner found 0 hits; expected ≥ 1 from " +
+			"forbidden_mint_caller.go — the detector scanCertMintCallers may be broken")
+	}
+}
+
+// ── CERT-REVOKE-SCOPED-01 ──────────────────────────────────────────────────
+
+// TestCertRevokeScoped01_StoreMethodsCarryScope is the reverse self-check that
+// RevocationStore.Revoke / RevocationList / Tidy still take CertScope (and Revoke
+// additionally Serial) as typed positional parameters. The Hard guarantee is the
+// compiler (omitting the scope is an arity error; a bare string a type error);
+// this fails if a refactor relaxes a signature or drops a required method.
+func TestCertRevokeScoped01_StoreMethodsCarryScope(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	pkgPath := certSigningPkgPath()
+	var diags []Diagnostic
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, []string{certSigningPattern}),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.Pkg.Path() != pkgPath {
+				return nil
+			}
+			scope := p.Pkg.Scope()
+			storeObj := scope.Lookup("RevocationStore")
+			if storeObj == nil {
+				return []Diagnostic{{Message: "CERT-REVOKE-SCOPED-01: RevocationStore interface not found"}}
+			}
+			iface, ok := storeObj.Type().Underlying().(*types.Interface)
+			if !ok {
+				return []Diagnostic{{Message: "CERT-REVOKE-SCOPED-01: RevocationStore is not an interface"}}
+			}
+			certScopeType := lookupType(scope, "CertScope")
+			serialType := lookupType(scope, "Serial")
+			if certScopeType == nil || serialType == nil {
+				return []Diagnostic{{Message: "CERT-REVOKE-SCOPED-01: CertScope / Serial type not found"}}
+			}
+			requireScope := map[string]bool{"Revoke": true, "RevocationList": true, "Tidy": true}
+			requireSerial := map[string]bool{"Revoke": true}
+			seen := map[string]bool{}
+			var out []Diagnostic
+			for i := 0; i < iface.NumMethods(); i++ {
+				m := iface.Method(i)
+				if !requireScope[m.Name()] {
+					continue
+				}
+				seen[m.Name()] = true
+				sig, ok := m.Type().(*types.Signature)
+				if !ok {
+					continue
+				}
+				if !sigHasParamType(sig, certScopeType) {
+					out = append(out, Diagnostic{Message: "CERT-REVOKE-SCOPED-01: RevocationStore." + m.Name() +
+						" does not take a certsigning.CertScope positional parameter — revocation must be scoped " +
+						"(绝不凭裸 serial 跨隔离域)"})
+				}
+				if requireSerial[m.Name()] && !sigHasParamType(sig, serialType) {
+					out = append(out, Diagnostic{Message: "CERT-REVOKE-SCOPED-01: RevocationStore." + m.Name() +
+						" does not take a certsigning.Serial positional parameter — a bare string serial is forbidden"})
+				}
+			}
+			for name := range requireScope {
+				if !seen[name] {
+					out = append(out, Diagnostic{Message: "CERT-REVOKE-SCOPED-01: required RevocationStore method " +
+						name + " not found — the scope guard is now vacuous"})
+				}
+			}
+			return out
+		})
+	Report(t, "CERT-REVOKE-SCOPED-01/StoreMethodsCarryScope", diags)
+}
+
+// lookupType returns the types.Type of a named type in scope, or nil.
+func lookupType(scope *types.Scope, name string) types.Type {
+	obj := scope.Lookup(name)
+	if obj == nil {
+		return nil
+	}
+	return obj.Type()
+}
+
+// sigHasParamType reports whether sig has any parameter whose type is identical
+// to want.
+func sigHasParamType(sig *types.Signature, want types.Type) bool {
+	params := sig.Params()
+	for i := 0; i < params.Len(); i++ {
+		if types.Identical(params.At(i).Type(), want) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/archtest/internal/certsignmintfixture/forbidden_mint_caller.go
+++ b/tools/archtest/internal/certsignmintfixture/forbidden_mint_caller.go
@@ -1,0 +1,24 @@
+//go:build archtest_fixture
+
+// Package certsignmintfixture contains an intentionally-violating caller for the
+// CERT-SIGN-FUNNEL-01 archtest detector. Gated by the archtest_fixture build tag
+// (must agree with the literal value of the unexported fixtureBuildTag const in
+// tools/archtest/fixture.go; Go build-directive syntax cannot reference a Go
+// constant, so this file hard-codes the tag literal).
+//
+// It exercises the funnel's DOWNSTREAM half: a package outside the sanctioned
+// mint allowlist calling certsigning.NewIssuedCert. (The UPSTREAM half — forging
+// an IssuedCert by populated composite literal — is unrepresentable: IssuedCert's
+// fields are unexported, so cs.IssuedCert{Field: ...} does not compile. That
+// compile-time impossibility is the Hard seal; it cannot be a fixture.)
+package certsignmintfixture
+
+import cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+
+// VIOLATION: a non-allowlisted package minting an IssuedCert via the funnel.
+// The zero-value cs.CertScope{} composite literal compiles (a struct with only
+// unexported fields permits its EMPTY literal); the scanner flags the CALL to
+// NewIssuedCert, not the scope literal.
+//
+//nolint:all // intentional violation for archtest RED fixture
+var redMintCaller, _ = cs.NewIssuedCert(cs.CertScope{}, nil, nil, 0) //nolint:unused


### PR DESCRIPTION
## Summary

定义 `framework/runtime/certsigning` 控制面接缝层（Epic #1895 PR-5 / US2）：CA 签发接口 + 协议无关 sealed 请求模型 + 单一签发 funnel + 3 条 archtest invariant + `ERR_CERT_` 前缀注册。**纯接缝 + sealed 类型，零实现/零 wiring**——softca 实现=PR-6，lifecycle reconciler=PR-7，EST 前端=PR-8b，composition wiring=PR-10。

## Why / 背景

Epic #1895 把设备证书/PKI（#995）从「消费方自建」**转向进框架**。本 PR 落地控制面接缝，对标 SPIRE ServerCA / cert-manager Sign / step-ca Authority.Sign 的一致结论：控制面（请求模型+接缝）属框架；签名私钥（`crypto.Signer`）永不出 adapter 边界；`Authorize`（能否拿证书）与 `Sign`（CSR→证书）是两个独立接口。`CertScope` 同时是 #1899 status 契约收窄（deviceId-only）的 isolation invariant 兜底——specific-cert lookup 下游必须经 typed `CertScope`，禁裸 serial 跨隔离域。

## Refs

- Closes #1901 · Epic #1895 · 依赖 #1899（PR-3，已 CLOSED）
- ADR `docs/architecture/202606130635-1939-adr-framework-owned-contract.md`；spec `docs/plans/specs/1895-device-identity-cert-framework/spec.md` FR-004..007
- `ref: SPIRE pkg/server/ca`（ServerCA.Sign* — 签发接缝，私钥不出边界）
- `ref: cert-manager pkg/controller/certificates`（Authorize/Sign 分离）
- `ref: step-ca authority/sign.go`（SignConstraints / provisioner claims）

## 交付物

- **接口**：`Signer`（`Sign(ctx,CertRequest)→IssuedCert` + `TrustBundle`）、`Authorizer`（`AuthorizeEnroll→SignConstraints`，独立于 Signer，nil/zero grant fail-closed）、`RevocationStore`（`Revoke/RevocationList/Tidy`，`CertScope`+`Serial` typed 位置参）。
- **sealed 值类型**：`IssuerID`/`DeviceID`/`Serial` newtype + `CertScope{tenant,issuer,device}` + `CertRequest`/`IssuedCert`/`DeviceSubject`/`SubjectAltNames`/`KeyUsages`/`SignConstraints`/`EnrollmentClaim` + `RevocationReason` 闭值集（仿 `transport.TransportMode`）。证书材料以不透明 DER 为 canonical，serial/notAfter 从 DER 派生（单源）+ `Certificate()` 便捷解析。只读输出（`TrustBundle=[][]byte`、`RevokedCertificate`）不 seal。
- **errcode 扇出**：注册 `ERR_CERT_` 前缀（`prefix_registry.go` + golden）+ 3 个构造校验码（`ErrCertScopeInvalid`/`ErrCertRequestInvalid`/`ErrCertIssuedInvalid`，PR-5 实际发射；签发/吊销运行期码留 PR-6）。
- **治理守卫**（`tools/archtest/cert_invariants_test.go`，上下游强度分别申明）：
  | invariant | 评级 | 机制 |
  |---|---|---|
  | CERT-VALUE-SEALED-CONSTRUCTION-01 | **Hard** | 全 sealed 类型字段 unexported → 包外字面量编译错；reflect + go/types sole-constructor 反向自检 |
  | CERT-SIGN-FUNNEL-01 | 上游 **Hard**（字段 seal）/ 下游 **Medium**（`NewIssuedCert` caller allowlist，PR-5 内空/前向）+ RED fixture | 盲区：minter 必导出供 adapter，无低成本 Hard 化路径（godoc 记录） |
  | CERT-REVOKE-SCOPED-01 | **Hard** | `RevocationStore` 方法强制 `CertScope`(+`Serial`) typed 位置参，漏传/裸 string 编译错；签名反向自检 |

## Risk / 兼容性

新包，无旧 API、无 shim/双路径、无破坏式 wire 变更、无 migration。纯接缝零 wiring，所有产物到 PR-6+ 才被消费（12-PR epic 既定地基）。**显式前向 carve-out（非 silent）**：运行期生产跨租户/issuer 吊销拒绝（spec 验收场景 7）随 softca/PG 实现落 PR-6；私钥 custody guard（CERT-PRIVATE-KEY-CUSTODY-01）落 PR-6。PR-5 测**结构性** fail-closed（typed 位置参强制声明 scope）+ 测试内 fake 演练隔离语义。

## Test plan

- [x] `go -C framework build ./...` 本地通过
- [x] `go -C framework test ./runtime/certsigning/...` 通过，**覆盖率 98.5%**（≥90% 目标）
- [x] `ERRCODE_PREFIX_GOLDEN_UPDATE=1 go -C framework test ./pkg/errcode/...` 重生成 golden（含 `ERR_CERT_`）
- [x] `go -C tools test -tags=archtest ./archtest/ -run Cert` 3 invariant GREEN + RED fixture fire；ERRCODE-PREFIX-OWNERSHIP-01 GREEN
- [x] `golangci-lint run`（framework certsigning + errcode）0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
