### PR TITLE
docs(ops): saga tick-error 告警 GoCellSagaTickErrors + observer 测试 flaky 记录 [#1464][#1527]

### DIFF
--- a/docs/ops/alerting-rules.md
+++ b/docs/ops/alerting-rules.md
@@ -1322,6 +1322,33 @@ cannot confirm leadership and skips every instance fail-closed.
     description: "Cell {{ $labels.cell }} leader-elect is failing on distlock backend I/O (>0.05/sec over 5min). Check the distlock backend (Redis) health. Runbook: docs/ops/saga-runbook.md"
 ```
 
+### GoCellSagaTickErrors
+
+The Coordinator's ClaimPending cycle itself fails every tick — the loop goroutine
+is alive (tick rate is non-zero) but cannot claim work. A distinct failure domain
+from leader-elect skips (4a/4b): journal/DB unreachable, migration drift, or
+transaction-pool exhaustion.
+
+```yaml
+# rate() = events/sec; `> 0.05` fires at >0.05 errored ClaimPending cycles/sec
+# (≈ 3/min) over the 5m window — matched to GoCellSagaLockAcquireFailures since
+# both are backend-fault rates. result="error" means ClaimPending returned an
+# error (journal/backend fault); a sustained rate is the loop alive-but-wedged,
+# not idle. No `unless` liveness term needed: unlike a flat tick rate (loop
+# stalled — the series simply stops updating, which is the absent-series case),
+# an errored tick is a present, positive series, so a direct threshold fires
+# correctly. The #1454 absent-series pitfall only bites when ANDing a liveness
+# term; this alert deliberately does not combine one.
+- alert: GoCellSagaTickErrors
+  expr: sum(rate(gocell_saga_tick_total{result="error"}[5m])) by (cell) > 0.05
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Saga coordinator tick errors (loop alive, cannot claim work)"
+    description: "Cell {{ $labels.cell }} Coordinator ClaimPending is failing (>0.05/sec over 5min) — journal/DB unreachable or migration drift. Runbook: docs/ops/saga-runbook.md"
+```
+
 **StatusCompensationFailed terminal state**: when a saga instance reaches
 `status=compensation_failed` (status=8 in PG), the compensation phase itself failed.
 This is distinct from `status=failed` (forward failure, no rollback attempted).

--- a/docs/ops/saga-runbook.md
+++ b/docs/ops/saga-runbook.md
@@ -124,9 +124,9 @@ GROUP BY definition_id ORDER BY events DESC;
 
 ---
 
-## 场景 4：实例停在 leader-elect skip 不推进 / distlock 后端故障（#1109 指标）
+## 场景 4：coordinator 推进受阻 / loop 故障（#1109 coordinator 指标）
 
-对应告警 `GoCellSagaInstanceStuckSkipping` 与 `GoCellSagaLockAcquireFailures`（`docs/ops/alerting-rules.md`）。仅在 leader-elect 模式（`WithLeaderElect`）且接入真实 metrics Provider 后才会触发——saga 接入生产 cell（PR-09 / #978）前这两条告警沉默。
+对应告警 `GoCellSagaInstanceStuckSkipping`、`GoCellSagaLockAcquireFailures`（4a/4b，leader-elect 故障）与 `GoCellSagaTickErrors`（4c，coordinator loop ClaimPending 故障）（`docs/ops/alerting-rules.md`）。4a/4b 仅在 leader-elect 模式（`WithLeaderElect`）下有意义；三条均需接入真实 metrics Provider 后才触发——saga 接入生产 cell（PR-09 / #978）前沉默。
 
 ### 4a：stuck skipping（`GoCellSagaInstanceStuckSkipping`）
 
@@ -160,6 +160,16 @@ ORDER BY updated_at ASC LIMIT 20;
 **根因**：distlock 后端（Redis）不可达 / 认证失败 / 命令被拒。
 
 **处置**：按 Redis 连接故障处置（网络、ACL、连接池、TLS）。恢复后 skip 自动回落、drive 恢复。该路径下 backend error 文本经 `redaction.RedactAny` 脱敏后入 slog（`reason=backend_error`），用 `instance_id` / `lock_key` 关联具体实例。
+
+### 4c：tick 持续 error（`GoCellSagaTickErrors`）
+
+**症状**：`saga_tick_total{result="error"}` 持续 >0——coordinator loop 仍在 tick（goroutine 存活），但每次 `ClaimPending` 返回错误、抢不到工作。区别于 4a/4b（leader-elect skip，loop 健康只是不持锁）与场景 1（tick 平坦 = loop 停滞）：这里 tick 在涨、但全落 error 分支。不依赖 leader-elect 模式——无论单进程还是 leader-elect，ClaimPending 故障都会触发。
+
+**根因**：`ClaimPending` 失败——journal/DB 不可达、migration drift、连接池耗尽、查询超时等 journal 后端故障。错误经 `slog.Warn("saga: tick failed")` 落日志（`runtime/saga/coordinator.go::tickLoop`）。
+
+**诊断**：查 PG/journal 可用性（连接、迁移状态、连接池水位）；对照 server log 的 "saga: tick failed" WARN 行取脱敏后 last_error；`saga_tick_total{result="claimed"|"empty"}` 应同时停止增长（所有 tick 落 error 分支）。
+
+**处置**：恢复 journal 后端连通性 / 修复 migration drift。loop 是 level-triggered，journal 恢复后下一个 tick 自动回到 claimed/empty，无需人工重启 coordinator。
 
 ---
 

--- a/framework/runtime/saga/executor/observer_test.go
+++ b/framework/runtime/saga/executor/observer_test.go
@@ -701,8 +701,9 @@ func TestObserverCall_Timeout_LogsCorrelation(t *testing.T) {
 	// errCh is the tightest available sync point: it fires exactly when
 	// RunWithHeartbeat returns, just after the bounded-observer timer logged the
 	// WARN asserted below. The window between fc.Advance and this send is real
-	// goroutine scheduling (timer-fire goroutine → log → return) that the fake
-	// clock cannot collapse — there is no closer signal to wait on. Under
+	// goroutine scheduling — the run goroutine must wake on the fired timer's
+	// channel inside callObserverBounded's select, log, then return — that the
+	// fake clock cannot collapse; there is no closer signal to wait on. Under
 	// pathological local load (`go test -race -count=5 ./runtime/saga/...`, where
 	// the saga package and this executor package stress-run concurrently and
 	// saturate the CPU) that real progress can occasionally exceed testwait's 30s

--- a/framework/runtime/saga/executor/observer_test.go
+++ b/framework/runtime/saga/executor/observer_test.go
@@ -698,6 +698,21 @@ func TestObserverCall_Timeout_LogsCorrelation(t *testing.T) {
 	// advance past its deadline to fire the timeout branch.
 	testwait.Deterministic(t, obs.hbEntered, "observer-call-entered")
 	fc.Advance(testtime.D50ms)
+	// errCh is the tightest available sync point: it fires exactly when
+	// RunWithHeartbeat returns, just after the bounded-observer timer logged the
+	// WARN asserted below. The window between fc.Advance and this send is real
+	// goroutine scheduling (timer-fire goroutine → log → return) that the fake
+	// clock cannot collapse — there is no closer signal to wait on. Under
+	// pathological local load (`go test -race -count=5 ./runtime/saga/...`, where
+	// the saga package and this executor package stress-run concurrently and
+	// saturate the CPU) that real progress can occasionally exceed testwait's 30s
+	// safety-net and trip a false Fatalf. CI (`-count=1`) is unaffected and stays
+	// green. This is a test-infra artifact under CPU starvation, not an executor
+	// bug (#1527): the 30s constant is intentionally fixed (see signalSafetyNet
+	// godoc) and testwait.Deterministic forbids a per-call timeout
+	// (TEST-DETERMINISTIC-NO-TIMEOUT-PARAM-01). To stress-test saga locally
+	// without self-starvation, serialize the packages with `-p 1`
+	// (`go test -race -count=5 -p 1 ./runtime/saga/...`).
 	_ = testwait.Deterministic(t, errCh, "RunWithHeartbeat must return")
 
 	entry := sloghelper.FindLogEntry(buf.String(), "observer call exceeded deadline")


### PR DESCRIPTION
## Summary

补 saga coordinator tick-error 指标告警 `GoCellSagaTickErrors` + runbook 场景 4c（#1464），并把 observer 超时测试的极端 -race 压测 flaky 根因钉死在测试注释里（#1527）。纯 docs + 测试注释，无生产代码行为变更。

## Why / 背景

- **#1464**：`gocell_saga_tick_total{result="error"}`（「coordinator loop 存活但 ClaimPending 持续失败」=journal/DB 不可达、migration drift）计数器已在 #1109 落地，但这条失败域此前只有 `slog.Warn`、没有指标阈值告警。本 PR 补齐告警 + runbook 诊断/处置闭环。激活门同 #1109：saga 接入真实 metrics Provider（PR-09 / #978）前沉默。
- **#1527**：`TestObserverCall_Timeout_LogsCorrelation` 在病态本地压测（`go test -race -count=5 ./runtime/saga/...`，saga 与 executor 包并发饱和 CPU）下偶发命中 testwait 的 30s 安全网。根因是 `fc.Advance`→`errCh` send 之间 fake clock 无法折叠的真实 goroutine 调度在 CPU 饥饿下偶尔 >30s；**CI（count=1）不受影响、恒绿**。`errCh` 已是最紧 sync point、30s 常量 godoc 明令不许调高、`Deterministic` 禁 timeout 参——无 Hard 修法，按「记录为压测产物」在测试注释钉死根因 + 正确压测姿势（`-p 1`）。

## Refs

- Closes #1464
- Closes #1527
- ref: docs/ops/alerting-rules.md (Saga section), runtime/saga/coordinator.go::tickLoop

## Risk / 兼容性

无。纯 docs（alerting-rules.md / saga-runbook.md）+ 一处测试注释；无 wire 契约 / 签名 / 行为变更，无 migration，无消费方需同步。新告警在 saga 接入真实 Provider 前沉默（与既有 #1109 两条告警同激活门）。

## Test plan

- [x] `go build ./...` 本地通过（framework module）
- [x] `go test ./runtime/saga/... -count=1` 全绿（含 executor flaky 测试）
- [x] saga golden archtest 不漂：`go test -tags archtest ./archtest/ -run 'SagaCoverageGolden|SagaStatusFanoutCoverage'` 通过（告警插入点在生成区 kind-legend 之前）
- [x] `golangci-lint run ./runtime/saga/executor/...` 0 issues、gofumpt 干净
