### PR TITLE
fix(prodscan): OBS-01 + duration gates 补齐 corecells/cellmodules 单模块根覆盖 [#2164]

### DIFF
--- a/corecells/accesscore/slices/identitymanage/handler_rowscope_test.go
+++ b/corecells/accesscore/slices/identitymanage/handler_rowscope_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/persistence"
 	"github.com/ghbvf/gocell/framework/pkg/ctxkeys"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 	"github.com/ghbvf/gocell/framework/runtime/auth/refresh"
 	refreshmem "github.com/ghbvf/gocell/framework/runtime/auth/refresh/memstore"
@@ -52,7 +53,7 @@ func setupRowScopeHandler(t *testing.T) (http.Handler, *mem.UserRepository) {
 	repo := mem.NewStore(clock.Real()).UserRepository()
 	clk := storetest.NewFakeClock(time.Now())
 	rs, err := refreshmem.New(refresh.Policy{
-		ReuseInterval:  2 * time.Second,
+		ReuseInterval:  testtime.D2s,
 		MaxAge:         time.Hour,
 		MaxIdle:        refresh.DefaultMaxIdle,
 		GraceMaxReuses: refresh.DefaultGraceMaxReuses,

--- a/corecells/auditcore/slices/auditquery/service_test.go
+++ b/corecells/auditcore/slices/auditquery/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
 	"github.com/ghbvf/gocell/framework/runtime/audit/ledger"
 )
 
@@ -775,12 +776,12 @@ func TestService_QueryCrossTenant_WithStore_ReturnsPaged(t *testing.T) {
 		{
 			ID: "ct-3", EventID: "evt-ct-3", EventType: "vis.v1",
 			ActorID: "sa", TenantID: auditQueryTestTenant,
-			Timestamp: base.Add(2 * time.Second), Payload: []byte("{}"),
+			Timestamp: base.Add(testtime.D2s), Payload: []byte("{}"),
 		},
 		{
 			ID: "ct-4", EventID: "evt-ct-4", EventType: "vis.v1",
 			ActorID: "sa", TenantID: auditQueryTestTenantB,
-			Timestamp: base.Add(3 * time.Second), Payload: []byte("{}"),
+			Timestamp: base.Add(testtime.D3s), Payload: []byte("{}"),
 		},
 	}
 	fake := &fakeCtStore{entries: entries}

--- a/tools/internal/prodscan/patterns.go
+++ b/tools/internal/prodscan/patterns.go
@@ -173,11 +173,18 @@ func SatelliteParentPatterns(root string) []string {
 // Like SatelliteParentPatterns the prefixes are loadable ONLY through the shared
 // satellite-aware loader packagesload.LoadWorkspace; a single-module fixture has no
 // module-root subdir (those dirs are part of the ONE module, no own go.mod), so the
-// increment is EMPTY there. The increment's coverage of every go.work production
-// single-module root is kept honest by the Medium anti-drift guard
-// TestModuleRootMembersCoverGoWorkProductionRoots (tools/metricschema), which fails when
-// a top-level single-module root in go.work is missing from topLevelDirs (#2164's
-// recurrence guard).
+// increment is EMPTY there. Two Medium tests in tools/metricschema keep this honest,
+// the module-root analog of SatelliteParentPatterns' SATELLITE-PARENT-PREFIX-SCAN-01:
+//
+//   - TestModuleRootMembersCoverGoWorkProductionRoots (anti-drift): fails when a
+//     top-level single-module root in go.work is missing from topLevelDirs (#2164's
+//     recurrence guard — coverage completeness).
+//   - TestOBS01CoverageRequiresModuleRootMembers (load-witness) +
+//     TestCheckOBS01DetectsModuleRootMemberLeak (scan-witness): fail if "./corecells/..."
+//     / "./cellmodules/..." stop resolving to non-empty packages through LoadWorkspace —
+//     the "must go through LoadWorkspace" property, machine-checked, not Soft. (Both gates
+//     that compose this increment, OBS-01 and the duration gates, use the SAME prefixes
+//     through the SAME loader, so the OBS-01 witness covers the duration-gate path too.)
 func ModuleRootMemberPatterns(root string) []string {
 	var patterns []string
 	for _, dir := range topLevelDirs {

--- a/tools/internal/prodscan/patterns.go
+++ b/tools/internal/prodscan/patterns.go
@@ -26,7 +26,9 @@ import (
 //     single member and is pruned by HasNestedModuleRoot from THIS base scan — it is
 //     re-emitted ONLY by SatelliteParentPatterns, which callers compose in when they
 //     want satellite coverage (the shared loader expands it to the members).
-//     cellmodules/corecells are module roots → pruned by IsModuleRoot.
+//     cellmodules/corecells are TOP-LEVEL single-module roots → pruned from the base by
+//     IsModuleRoot, and re-emitted by ModuleRootMemberPatterns (the sibling increment)
+//     for callers that opt into module-root coverage (OBS-01, the duration gates).
 //   - Single-module fixture: framework/<layer> doesn't exist (pruned); the bare
 //     cmd/pkg/kernel/runtime the fixture writes ARE part of the one module, so their
 //     "./<dir>/…" pattern matches under ModeModule and is actually scanned.
@@ -41,6 +43,7 @@ var topLevelDirs = []string{
 	"adapters",
 	"cells",
 	"cellmodules",
+	"corecells",
 	"examples",
 }
 
@@ -51,8 +54,9 @@ var topLevelDirs = []string{
 // Two kinds of top-level dir are pruned from this satellite-FREE base scan:
 //
 //   - A go.work satellite MODULE ROOT (carries its own go.mod — e.g. cellmodules/
-//     after #1559, corecells/): a single module addressed by its own member
+//     after #1559, corecells/ after #1560): a single module addressed by its own member
 //     pattern, unaddressable by a root-relative ModeModule "./<dir>/..." (IsModuleRoot).
+//     Re-emitted by ModuleRootMemberPatterns for callers opting into module-root scope.
 //   - A MULTI-MEMBER PARENT (cmd/, adapters/, examples/): not a module root itself,
 //     but holding several go.work member modules one level deeper (cmd/gocell +
 //     cmd/corebundle; adapters/postgres …; examples/<id> …). "./cmd/..." is owned by
@@ -146,25 +150,67 @@ func SatelliteParentPatterns(root string) []string {
 	return patterns
 }
 
+// ModuleRootMemberPatterns returns the TOP-LEVEL single-module-root prefixes
+// ("./corecells/...", "./cellmodules/...") that Patterns prunes — the SIBLING of
+// SatelliteParentPatterns and the second class of satellite increment (#2164). It is
+// DERIVED from the same predicates Patterns prunes on (not a hand-maintained list): it
+// re-includes ONLY dirs that ARE module roots themselves but hold NO nested member
+// (IsModuleRoot && !HasNestedModuleRoot), the complement of SatelliteParentPatterns'
+// multi-member parents (!IsModuleRoot && HasNestedModuleRoot). A future fifth top-level
+// single-module root listed in topLevelDirs is picked up automatically.
+//
+// The two increments cover the two distinct go.work shapes a top-level dir can take:
+//
+//   - SatelliteParentPatterns: a MULTI-MEMBER PARENT (cmd/, adapters/, examples/) —
+//     "./<dir>/..." owned by no single member, expanded to its members by the loader.
+//   - ModuleRootMemberPatterns: a TOP-LEVEL SINGLE-MODULE ROOT (corecells/, cellmodules/)
+//     — "./<dir>/..." owned by exactly that member; the satellite-aware loader resolves
+//     it as a normal workspace member (expandParentPrefix bails on an exact-member dir,
+//     so matchWorkspaceMember handles it). The platform core lives in the framework
+//     module but is scanned via its framework/{kernel,runtime,pkg} sub-layers in the
+//     base Patterns, so bare "framework" is not in topLevelDirs and is never re-emitted here.
+//
+// Like SatelliteParentPatterns the prefixes are loadable ONLY through the shared
+// satellite-aware loader packagesload.LoadWorkspace; a single-module fixture has no
+// module-root subdir (those dirs are part of the ONE module, no own go.mod), so the
+// increment is EMPTY there. The increment's coverage of every go.work production
+// single-module root is kept honest by the Medium anti-drift guard
+// TestModuleRootMembersCoverGoWorkProductionRoots (tools/metricschema), which fails when
+// a top-level single-module root in go.work is missing from topLevelDirs (#2164's
+// recurrence guard).
+func ModuleRootMemberPatterns(root string) []string {
+	var patterns []string
+	for _, dir := range topLevelDirs {
+		full := filepath.Join(root, dir)
+		if dirExists(full) && IsModuleRoot(full) && !HasNestedModuleRoot(full) {
+			patterns = append(patterns, "./"+dir+"/...")
+		}
+	}
+	return patterns
+}
+
 // PatternsWithSatellites widens PatternsExtended(root) — Patterns plus tests/ and
-// tools/ — with the multi-member satellite parent prefixes (SatelliteParentPatterns).
-// It is the production-scan source-of-record for the typeseval-backed duration gates
-// (TEST-TIME-LITERAL-01, PROD-DURATION-CONST-01), whose broad invariant covers
-// production + test/tool support packages + satellites.
+// tools/ — with BOTH satellite increments: the multi-member satellite parent prefixes
+// (SatelliteParentPatterns) and the top-level single-module roots
+// (ModuleRootMemberPatterns, #2164). It is the production-scan source-of-record for the
+// typeseval-backed duration gates (TEST-TIME-LITERAL-01, PROD-DURATION-CONST-01), whose
+// broad invariant covers production + test/tool support packages + satellites.
 //
 // Two satellite-bearing scopes exist, split by BASE (not loader capability — since
 // #2147 both load through the same packagesload.LoadWorkspace expander):
 //
-//   - PatternsWithSatellites = PatternsExtended + satellites — the broad duration
-//     gates (production + tests/ + tools/ + satellites).
-//   - OBS-01 = Patterns + satellites — production + satellites, WITHOUT tests/+tools/
-//     (composed in tools/metricschema; OBS-01 never scanned tests/ or tools/).
+//   - PatternsWithSatellites = PatternsExtended + both increments — the broad duration
+//     gates (production + tests/ + tools/ + satellites + module roots).
+//   - OBS-01 = Patterns + both increments — production + satellites + module roots,
+//     WITHOUT tests/+tools/ (composed in tools/metricschema; OBS-01 never scanned
+//     tests/ or tools/).
 //
 // Do NOT fold the satellite prefixes into PatternsExtended itself: its other
 // consumers (e.g. errcode_invariants) would then silently gain unreviewed satellite
 // scope. Widening to satellites is a per-gate opt-in by name, not a global default.
 func PatternsWithSatellites(root string) []string {
-	return append(PatternsExtended(root), SatelliteParentPatterns(root)...)
+	out := append(PatternsExtended(root), SatelliteParentPatterns(root)...)
+	return append(out, ModuleRootMemberPatterns(root)...)
 }
 
 func dirExists(path string) bool {

--- a/tools/internal/prodscan/patterns_test.go
+++ b/tools/internal/prodscan/patterns_test.go
@@ -131,6 +131,35 @@ func TestPatternsWithSatellites(t *testing.T) {
 				"(no nested go.mod → empty satellite increment); ext=%v full=%v", ext, full)
 		}
 	})
+
+	t.Run("real workspace adds top-level single-module roots", func(t *testing.T) {
+		// #2164: PatternsWithSatellites must compose the module-root increment too,
+		// so the duration gates (PROD-DURATION-CONST-01 / TEST-TIME-LITERAL-01) cover
+		// corecells/cellmodules — the symmetric counterpart of the satellite increment.
+		root := writeTree(t, map[string]string{
+			"framework/kernel/k.go": "package kernel\n",
+			"corecells/go.mod":      "module x/corecells\n",
+			"corecells/c.go":        "package corecells\n",
+			"cellmodules/go.mod":    "module x/cellmodules\n",
+			"cellmodules/m.go":      "package cellmodules\n",
+		})
+		ext := map[string]bool{}
+		for _, p := range PatternsExtended(root) {
+			ext[p] = true
+		}
+		got := map[string]bool{}
+		for _, p := range PatternsWithSatellites(root) {
+			got[p] = true
+		}
+		for _, mod := range []string{"./corecells/...", "./cellmodules/..."} {
+			if ext[mod] {
+				t.Fatalf("PatternsExtended unexpectedly contains %q; the module-root increment is vacuous", mod)
+			}
+			if !got[mod] {
+				t.Errorf("PatternsWithSatellites must add %q; got %v", mod, PatternsWithSatellites(root))
+			}
+		}
+	})
 }
 
 // TestSatelliteParentPatterns covers the single-sourced satellite increment (#2147)
@@ -187,6 +216,64 @@ func TestSatelliteParentPatterns(t *testing.T) {
 		})
 		if got := SatelliteParentPatterns(root); len(got) != 0 {
 			t.Errorf("SatelliteParentPatterns on single-module fixture = %v, want empty", got)
+		}
+	})
+}
+
+// TestModuleRootMemberPatterns covers the single-sourced module-root increment
+// (#2164) — the sibling of SatelliteParentPatterns. SatelliteParentPatterns re-emits
+// the MULTI-MEMBER parents (cmd/adapters/examples, !IsModuleRoot && HasNestedModuleRoot);
+// ModuleRootMemberPatterns re-emits the TOP-LEVEL SINGLE-MODULE ROOTS (corecells/
+// cellmodules, IsModuleRoot && !HasNestedModuleRoot) that Patterns prunes via IsModuleRoot.
+// Both OBS-01 and the duration gates compose this increment onto their base.
+func TestModuleRootMemberPatterns(t *testing.T) {
+	t.Run("real workspace yields exactly the top-level single-module roots", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"framework/kernel/k.go": "package kernel\n", // plain production layer, not a module root
+			// multi-member parent — owned by SatelliteParentPatterns, NOT this increment.
+			"cmd/gocell/go.mod":  "module x/cmd/gocell\n",
+			"cmd/gocell/main.go": "package main\n",
+			// top-level single-module roots — own go.mod, no nested member → THIS increment.
+			"cellmodules/go.mod": "module x/cellmodules\n",
+			"cellmodules/m.go":   "package cellmodules\n",
+			"corecells/go.mod":   "module x/corecells\n",
+			"corecells/c.go":     "package corecells\n",
+		})
+		got := ModuleRootMemberPatterns(root)
+		gotSet := map[string]bool{}
+		for _, p := range got {
+			gotSet[p] = true
+		}
+		for _, want := range []string{"./cellmodules/...", "./corecells/..."} {
+			if !gotSet[want] {
+				t.Errorf("ModuleRootMemberPatterns missing %q; got %v", want, got)
+			}
+		}
+		if len(got) != 2 {
+			t.Errorf("ModuleRootMemberPatterns = %v, want exactly the 2 top-level single-module roots "+
+				"(no framework layers, no multi-member parents)", got)
+		}
+		// The increment is genuinely NEW: its members appear in neither the base scan
+		// nor the multi-member-parent increment (else composing it would be vacuous).
+		base := map[string]bool{}
+		for _, p := range append(Patterns(root), SatelliteParentPatterns(root)...) {
+			base[p] = true
+		}
+		for _, p := range got {
+			if base[p] {
+				t.Errorf("ModuleRootMemberPatterns member %q already present in Patterns+SatelliteParentPatterns "+
+					"— the increment is not additive", p)
+			}
+		}
+	})
+
+	t.Run("single-module fixture yields nothing", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"go.mod":            "module x\n",
+			"corecells/repo.go": "package corecells\n", // part of the ONE module, no own go.mod
+		})
+		if got := ModuleRootMemberPatterns(root); len(got) != 0 {
+			t.Errorf("ModuleRootMemberPatterns on single-module fixture = %v, want empty", got)
 		}
 	})
 }

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -239,7 +239,8 @@ func Marshal(schema *Schema) ([]byte, error) {
 // prefixes obs01ProductionPatterns emits — the multi-member parents ("./cmd/...",
 // "./adapters/...", "./examples/...", #2147) expanded to their members, and the
 // top-level single-module roots ("./corecells/...", "./cellmodules/...", #2164)
-// resolved as workspace members — so OBS-01 scans that production code. It keeps only this project's packages
+// resolved as workspace members — so OBS-01 scans that production code. It keeps only
+// this project's packages
 // (packageHasProjectFile), deduped by import path (preferring the syntax-rich copy),
 // and fails closed on any load error.
 func loadPackages(ctx context.Context, root string, patterns ...string) ([]*packages.Package, error) {

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -235,10 +235,11 @@ func Marshal(schema *Schema) ([]byte, error) {
 }
 
 // loadPackages loads the OBS-01 production scan patterns through the shared
-// satellite-aware loader packagesload.LoadWorkspace, which expands the multi-member
-// satellite parent-prefixes obs01ProductionPatterns now emits ("./cmd/...",
-// "./adapters/...", "./examples/...") to their go.work members so OBS-01 scans
-// satellite production code (#2147). It keeps only this project's packages
+// satellite-aware loader packagesload.LoadWorkspace, which resolves the satellite
+// prefixes obs01ProductionPatterns emits — the multi-member parents ("./cmd/...",
+// "./adapters/...", "./examples/...", #2147) expanded to their members, and the
+// top-level single-module roots ("./corecells/...", "./cellmodules/...", #2164)
+// resolved as workspace members — so OBS-01 scans that production code. It keeps only this project's packages
 // (packageHasProjectFile), deduped by import path (preferring the syntax-rich copy),
 // and fails closed on any load error.
 func loadPackages(ctx context.Context, root string, patterns ...string) ([]*packages.Package, error) {
@@ -1971,13 +1972,15 @@ func checkOBS01WithPatterns(ctx context.Context, projectRoot string, patterns ..
 }
 
 // obs01ProductionPatterns is the OBS-01 production-scan source-of-record: the
-// satellite-free base (prodscan.Patterns) plus the multi-member satellite parent
-// prefixes (cmd/adapters/examples), which the shared satellite-aware loader
-// (loadPackages → packagesload.LoadWorkspace) expands to their go.work members so
-// satellite production code is scanned for metric-PII leaks (#2147). It does NOT use
-// PatternsExtended — OBS-01 never scanned tests/ or tools/.
+// satellite-free base (prodscan.Patterns) plus BOTH satellite increments — the
+// multi-member satellite parent prefixes (cmd/adapters/examples, #2147) and the
+// top-level single-module roots (corecells/cellmodules, #2164). The shared
+// satellite-aware loader (loadPackages → packagesload.LoadWorkspace) resolves each to
+// its go.work member(s) so that production code is scanned for metric-PII leaks. It
+// does NOT use PatternsExtended — OBS-01 never scanned tests/ or tools/.
 func obs01ProductionPatterns(projectRoot string) []string {
-	return append(prodscan.Patterns(projectRoot), prodscan.SatelliteParentPatterns(projectRoot)...)
+	patterns := append(prodscan.Patterns(projectRoot), prodscan.SatelliteParentPatterns(projectRoot)...)
+	return append(patterns, prodscan.ModuleRootMemberPatterns(projectRoot)...)
 }
 
 func dedupeDiagnostics(in []Diagnostic) []Diagnostic {

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/tools/internal/prodscan"
+	"github.com/ghbvf/gocell/tools/workspace"
 )
 
 func TestBuild_CorebundleCapturesReachableTypedMetrics(t *testing.T) {
@@ -998,6 +999,167 @@ func TestOBS01CoverageRequiresSatellites_AntiVacuity(t *testing.T) {
 	}
 }
 
+// moduleRootCoverageExcluded lists the depth-1 go.work module roots that are
+// legitimately NOT covered by ModuleRootMemberPatterns, each with its reason:
+//   - framework: the platform core, covered by base Patterns via its
+//     framework/{kernel,runtime,pkg} sub-layer patterns (NOT as a whole module).
+//   - generated: codegen output, excluded from every production scan.
+//   - tools: build/governance tooling, PatternsExtended-only scope (never OBS-01
+//     production / never a production-shippable layer).
+//
+// The set is fail-closed in BOTH directions (see
+// TestModuleRootMembersCoverGoWorkProductionRoots): a new PRODUCTION single-module
+// root missing from topLevelDirs surfaces as uncovered → CI red; a new NON-production
+// module root missing from this set surfaces as "required but uncovered" → CI red →
+// a human adds it here with a reason. `tests` is auto-excluded (it is a MULTI-MEMBER
+// parent — tests/integration carries its own go.mod — so HasNestedModuleRoot prunes it).
+var moduleRootCoverageExcluded = map[string]bool{
+	"framework": true,
+	"generated": true,
+	"tools":     true,
+}
+
+// goWorkProductionModuleRoots derives, from the AUTHORITATIVE go.work member list
+// (NOT from prodscan.topLevelDirs — that would be circular), the depth-1 members that
+// are top-level single-module PRODUCTION roots: own go.mod (IsModuleRoot), no nested
+// member (!HasNestedModuleRoot → not a multi-member parent), one path segment, and not
+// in moduleRootCoverageExcluded. corecells/cellmodules are the post-#1559/#1560 members.
+func goWorkProductionModuleRoots(t *testing.T, root string) []string {
+	t.Helper()
+	mods, err := workspace.Modules(root)
+	require.NoError(t, err)
+	var out []string
+	for _, m := range mods {
+		dir := filepath.ToSlash(filepath.Clean(m.Dir))
+		if dir == "." || dir == "" || strings.Contains(dir, "/") {
+			continue // root or nested (multi-member child) — not a depth-1 single-module root
+		}
+		abs := filepath.Join(root, dir)
+		if !prodscan.IsModuleRoot(abs) || prodscan.HasNestedModuleRoot(abs) {
+			continue
+		}
+		if moduleRootCoverageExcluded[dir] {
+			continue
+		}
+		out = append(out, dir)
+	}
+	return out
+}
+
+// uncoveredModuleRoots is the pure set-difference at the heart of the anti-drift
+// guard: the required roots not present in the covered top-level set. Extracted so the
+// guard's core decision is unit-testable with synthetic input (see
+// TestUncoveredModuleRootsDetectsGap) independent of the real go.work / filesystem.
+func uncoveredModuleRoots(required []string, covered map[string]bool) []string {
+	var missing []string
+	for _, r := range required {
+		if !covered[r] {
+			missing = append(missing, r)
+		}
+	}
+	return missing
+}
+
+// TestModuleRootMembersCoverGoWorkProductionRoots is the #2164 AI-robust (Medium)
+// anti-drift guard: it closes the recurrence vector that produced #2164 — corecells
+// was simply forgotten in the hand-maintained prodscan.topLevelDirs, and nothing
+// caught the omission (TestOBS01ProductionPatternsCoverProjectPackages SkipDir's
+// module roots, so it passes vacuously for them).
+//
+// It cross-checks the two INDEPENDENT sources fail-closed: every depth-1 production
+// single-module root the AUTHORITATIVE go.work declares MUST be covered by
+// ModuleRootMemberPatterns (derived from topLevelDirs). A future top-level
+// single-module module added to go.work but not topLevelDirs is uncovered → CI red.
+// The check is non-circular: `required` comes from go.work, `covered` from
+// topLevelDirs — drift between them is machine-detectable.
+func TestModuleRootMembersCoverGoWorkProductionRoots(t *testing.T) {
+	root := repoRoot(t)
+	required := goWorkProductionModuleRoots(t, root)
+
+	// Anti-vacuity: the guard is meaningless if `required` is empty. Pin the two
+	// real members so a refactor that stops yielding them (e.g. go.work parse change)
+	// fails here rather than passing trivially.
+	require.GreaterOrEqual(t, len(required), 2,
+		"go.work must yield ≥2 production single-module roots (corecells, cellmodules) — guard would be vacuous otherwise")
+	for _, want := range []string{"corecells", "cellmodules"} {
+		assert.Containsf(t, required, want,
+			"go.work production single-module roots must include %q (anti-vacuity)", want)
+	}
+
+	covered := prodscan.PatternTopLevels(prodscan.ModuleRootMemberPatterns(root))
+	missing := uncoveredModuleRoots(required, covered)
+	slices.Sort(missing)
+	assert.Emptyf(t, missing,
+		"go.work declares production single-module root(s) %v not covered by "+
+			"prodscan.ModuleRootMemberPatterns — add them to prodscan.topLevelDirs "+
+			"(or, if non-production, to moduleRootCoverageExcluded with a reason). This is #2164's recurrence guard.",
+		missing)
+}
+
+// TestUncoveredModuleRootsDetectsGap is the synthetic RED witness proving the
+// anti-drift guard's core decision is not恒真: a required root absent from the covered
+// set must be reported missing.
+func TestUncoveredModuleRootsDetectsGap(t *testing.T) {
+	missing := uncoveredModuleRoots(
+		[]string{"corecells", "cellmodules"},
+		map[string]bool{"cellmodules": true}, // corecells forgotten in scan scope
+	)
+	assert.Equal(t, []string{"corecells"}, missing,
+		"uncoveredModuleRoots must report a required root absent from the covered set")
+	assert.Empty(t,
+		uncoveredModuleRoots([]string{"corecells"}, map[string]bool{"corecells": true}),
+		"uncoveredModuleRoots must report nothing when every required root is covered")
+}
+
+// TestOBS01CoverageRequiresModuleRootMembers is the #2164 module-root counterpart of
+// TestOBS01CoverageRequiresSatellites: it asserts the independent, hardcoded fact that
+// the top-level single-module roots (corecells/cellmodules) MUST be OBS-01-covered, via
+// two checks that do NOT depend on each other:
+//
+//  1. the OBS-01 production pattern set's top-levels include corecells/cellmodules; and
+//  2. those module-root patterns actually LOAD non-empty project packages through the
+//     EXACT loadPackages path OBS-01 uses — a load-witness strictly stronger than string
+//     presence: it catches a pattern present in the SoR but matching zero packages.
+func TestOBS01CoverageRequiresModuleRootMembers(t *testing.T) {
+	root := repoRoot(t)
+
+	// (1) coverage: the OBS-01 SoR patterns map back to the module-root top-levels.
+	covered := prodscan.PatternTopLevels(obs01ProductionPatterns(root))
+	for _, mod := range []string{"corecells", "cellmodules"} {
+		assert.Truef(t, covered[mod],
+			"OBS-01 production scan must cover top-level single-module root %q (#2164)", mod)
+	}
+
+	// (2) load-witness: the module-root patterns load non-empty through OBS-01's loader.
+	pkgs, err := loadPackages(t.Context(), root, "./corecells/...", "./cellmodules/...")
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs,
+		"module-root patterns loaded zero project packages — OBS-01 silently stopped scanning corecells/cellmodules")
+	seen := map[string]bool{}
+	for _, p := range pkgs {
+		switch {
+		case strings.Contains(p.PkgPath, "/corecells"):
+			seen["corecells"] = true
+		case strings.Contains(p.PkgPath, "/cellmodules"):
+			seen["cellmodules"] = true
+		}
+	}
+	for _, mod := range []string{"corecells", "cellmodules"} {
+		assert.Truef(t, seen[mod], "module root %q loaded no project package under the OBS-01 scan", mod)
+	}
+}
+
+// TestOBS01CoverageRequiresModuleRootMembers_AntiVacuity proves check (1) is not恒真:
+// a synthetic production pattern set with no module-root pattern must NOT report
+// corecells/cellmodules as covered.
+func TestOBS01CoverageRequiresModuleRootMembers_AntiVacuity(t *testing.T) {
+	covered := prodscan.PatternTopLevels([]string{".", "./framework/kernel/...", "./cmd/..."})
+	for _, mod := range []string{"corecells", "cellmodules"} {
+		assert.Falsef(t, covered[mod],
+			"PatternTopLevels must not report module root %q covered when no module-root pattern is present", mod)
+	}
+}
+
 // TestCheckOBS01DetectsSatelliteMemberLeak is the #2147 anti-vacuity witness that
 // OBS-01 actually SCANS satellite (cmd/adapters/examples) production code. It builds
 // a multi-member go.work workspace whose sole satellite member (examples/leakydemo)
@@ -1018,6 +1180,27 @@ func TestCheckOBS01DetectsSatelliteMemberLeak(t *testing.T) {
 	assert.Equal(t, "reason", diagnostics[0].Label)
 	assert.Equal(t, "examples/leakydemo/leak.go", filepath.ToSlash(diagnostics[0].File),
 		"diagnostic must point exactly at the satellite member leak file — proves satellite code is scanned")
+}
+
+// TestCheckOBS01DetectsModuleRootMemberLeak is the #2164 anti-vacuity witness that
+// OBS-01 actually SCANS top-level single-module root (corecells/cellmodules)
+// production code. It builds a go.work workspace whose sole member is a top-level
+// single-module root (corecells/) that leaks an errcode classifier
+// (errcode.IsInfraError) into a metric label.
+//
+// Before #2164 the module root is pruned by Patterns' IsModuleRoot and re-emitted by
+// neither SatelliteParentPatterns (it is !IsModuleRoot-gated) nor anything else, so the
+// member is never loaded and the leak goes uncaught (CheckOBS01 yields 0 diagnostics →
+// this test RED). With ModuleRootMemberPatterns the member is emitted ("./corecells/...")
+// and the satellite-aware loader resolves it as a workspace member and scans it (GREEN).
+func TestCheckOBS01DetectsModuleRootMemberLeak(t *testing.T) {
+	root := writeModuleRootMemberMetricsFixture(t)
+	diagnostics, err := CheckOBS01(t.Context(), root)
+	require.NoError(t, err)
+	require.Len(t, diagnostics, 1)
+	assert.Equal(t, "reason", diagnostics[0].Label)
+	assert.Equal(t, "corecells/leak.go", filepath.ToSlash(diagnostics[0].File),
+		"diagnostic must point exactly at the module-root member leak file — proves module-root code is scanned")
 }
 
 func TestCheckOBS01DetectsIIFEParamTaint(t *testing.T) {
@@ -2358,6 +2541,47 @@ import (
 var leakProvider = metrics.NopProvider{}
 var leakCounter, _ = leakProvider.CounterVec(metrics.CounterOpts{
 	Name:       "satellite_leak_total",
+	LabelNames: []string{"reason"},
+})
+
+func Record(err error) {
+	leakCounter.With(metrics.Labels{"reason": fmt.Sprint(errcode.IsInfraError(err))}).Inc(context.Background())
+}
+`)
+	return root
+}
+
+// writeModuleRootMemberMetricsFixture mirrors writeSatelliteMetricsFixture but places
+// the leaky member at a TOP-LEVEL SINGLE-MODULE ROOT (corecells/ — own go.mod, no
+// nested member, in prodscan.topLevelDirs) rather than under a multi-member parent.
+// OBS-01 reaches it only via prodscan.ModuleRootMemberPatterns ("./corecells/..."),
+// which the satellite-aware loader resolves as a workspace member (#2164).
+func writeModuleRootMemberMetricsFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mod, sum := canonicalMetricsFixtureMod(t)
+	const newModulePath = "module example.com/corecellsleak"
+	mod = strings.Replace(mod, "module example.com/metricsfixture", newModulePath, 1)
+	require.Contains(t, mod, newModulePath,
+		"fixture go.mod module-path replacement failed — canonicalMetricsFixtureMod format changed?")
+	// Pin the same toolchain version as the real repo go.work (no hardcoded drift).
+	writeFile(t, root, "go.work", repoGoWorkGoDirective(t)+"\n\nuse ./corecells\n")
+	writeFile(t, root, "corecells/go.mod", mod)
+	writeFile(t, root, "corecells/go.sum", sum)
+	writeFile(t, root, "docs/observability/metrics-migration-acks.yaml", "acknowledgements: []\n")
+	writeFile(t, root, "corecells/leak.go", `package corecells
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ghbvf/gocell/framework/kernel/observability/metrics"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+var leakProvider = metrics.NopProvider{}
+var leakCounter, _ = leakProvider.CounterVec(metrics.CounterOpts{
+	Name:       "modroot_leak_total",
 	LabelNames: []string{"reason"},
 })
 

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -1010,9 +1010,12 @@ func TestOBS01CoverageRequiresSatellites_AntiVacuity(t *testing.T) {
 // The set is fail-closed in BOTH directions (see
 // TestModuleRootMembersCoverGoWorkProductionRoots): a new PRODUCTION single-module
 // root missing from topLevelDirs surfaces as uncovered → CI red; a new NON-production
-// module root missing from this set surfaces as "required but uncovered" → CI red →
-// a human adds it here with a reason. `tests` is auto-excluded (it is a MULTI-MEMBER
-// parent — tests/integration carries its own go.mod — so HasNestedModuleRoot prunes it).
+// module root missing from this set is NOT pruned by goWorkProductionModuleRoots, so it
+// enters `required` while topLevelDirs lacks it → "required but uncovered" → CI red →
+// a human adds it here with a reason. `tests` needs no entry: it IS a module root
+// (tests/go.mod), but it is ALSO a MULTI-MEMBER parent (tests/integration carries its
+// own go.mod), and goWorkProductionModuleRoots' !HasNestedModuleRoot filter prunes it
+// before this set is consulted (a multi-member parent is never a single-module root).
 var moduleRootCoverageExcluded = map[string]bool{
 	"framework": true,
 	"generated": true,
@@ -2556,6 +2559,11 @@ func Record(err error) {
 // nested member, in prodscan.topLevelDirs) rather than under a multi-member parent.
 // OBS-01 reaches it only via prodscan.ModuleRootMemberPatterns ("./corecells/..."),
 // which the satellite-aware loader resolves as a workspace member (#2164).
+//
+// Like writeSatelliteMetricsFixture it reuses the canonical tidied go.mod/go.sum with
+// only the module PATH renamed: go.sum pins the dependency-module hashes (framework,
+// prometheus, …), which are independent of the fixture's own module path, so the rename
+// stays valid under -mod=readonly without re-tidying.
 func writeModuleRootMemberMetricsFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

为 `corecells/`、`cellmodules/` 这类**顶层单模块根** go.work 成员补齐生产治理扫描覆盖：新增 `prodscan.ModuleRootMemberPatterns`（`SatelliteParentPatterns` 的姐妹增量），接入 OBS-01 metric-PII 扫描与 duration gates 两侧，并加一条派生反漂移守卫防 `topLevelDirs` 漂移复发。

## Why / 背景

`tools/internal/prodscan` 经 pattern 派生治理扫描范围。`SatelliteParentPatterns` 处理**多成员父目录**（`!IsModuleRoot && HasNestedModuleRoot` → cmd/adapters/examples），但**顶层单模块根**（`IsModuleRoot && !HasNestedModuleRoot` → corecells/cellmodules）此前**无对应增量**：corecells 根本不在 `topLevelDirs`，cellmodules 在表里却被 `Patterns()` 的 `IsModuleRoot` 剪掉、又被 `!IsModuleRoot` 挡在 satellite 增量外。两个 module 的生产/测试代码因此不受 OBS-01 / PROD-DURATION-CONST-01 / TEST-TIME-LITERAL-01 守护（纵深防御缺口）。#1559/#1560 拆 module 时只补了 multi-member（#2147），单模块根遗留。

根因不止于「漏了 corecells」——`topLevelDirs` 是**手维护清单**，corecells 当初就是漏进它才有 #2164。故本 PR 除补增量外，加一条派生守卫让该 bug 类机器可判定、不复发。

## Refs

Closes #2164

ref: kubernetes（k8s controller-runtime 的 scheme/scope 派生范式——扫描范围从权威成员集派生而非手维护）

## Risk / 兼容性

- **无 wire / contract / 版本影响**：纯治理扫描工具改动 + 内部 test-time duration 字面量提取。
- duration gates 扩面到 corecells/cellmodules 后实跑暴露：PROD-DURATION-CONST-01 **0 处**（候选均在包级 const，豁免），TEST-TIME-LITERAL-01 **3 处**（已按 gate 规定改用同包既有 `testtime.*`）。OBS-01 **0 处**新增。
- 分支已 merge 最新 origin/develop（#2187），无文件冲突。

### AI-robust 评级

| 机制 | 档位 | 说明 |
|------|------|------|
| `ModuleRootMemberPatterns` 增量 | Medium | 从 `topLevelDirs`+谓词派生，非硬编清单，与 `SatelliteParentPatterns` 同档 |
| go.work↔扫描范围 派生反漂移守卫 | Medium | `TestModuleRootMembersCoverGoWorkProductionRoots`，fail-closed 双向 + synthetic red + anti-vacuity；#2164 复发即 CI 红 |
| OBS-01 单模块根 scan-witness | Medium | `TestCheckOBS01DetectsModuleRootMemberLeak`，仿 #2147，证非 vacuous |

Hard 化路径（从 go.work 一次性派生扫描范围、消除 `topLevelDirs`）blast radius 大，登记 follow-up，本 PR 不做。

### Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| `ModuleRootMemberPatterns` 增量 + topLevelDirs += corecells | — | — | — | `prodscan/patterns_test.go` | patterns.go godoc |
| 接入 OBS-01 + duration gates | — | — | — | metricschema 守卫/load-witness/scan-witness | schema.go godoc |
| TEST-TIME-LITERAL-01 扩面 3 处修复 | — | — | corecells 2 test 文件 | gate GREEN | — |

## Test plan

- [x] `go build ./...` 本地通过（tools + corecells 模块）
- [x] `go test ./tools/internal/prodscan/... ./tools/metricschema/...` 本地通过（含新增 TDD：增量/反漂移守卫/scan-witness）
- [x] 三 gate 全绿：`TestMetricLabelErrcodeClassifiersRequireAck` / `TestProdDurationConst` / `TestTestTimeLiteralConst`（`-tags archtest`）
- [x] 受影响 corecells 包单测通过
- [x] `golangci-lint run` 0 issues（prodscan / metricschema / 改动的 corecells 包）
